### PR TITLE
fix: #318 子供画面UX改善 — ナビラベル直感化・初回ガイダンス追加

### DIFF
--- a/src/lib/domain/icons.ts
+++ b/src/lib/domain/icons.ts
@@ -14,8 +14,8 @@ export const ICON_STATUS = '⭐';
 export const ICON_HISTORY = '📋';
 /** じっせき / 実績 */
 export const ICON_ACHIEVEMENTS = '🏆';
-/** きりかえ / 切替 */
-export const ICON_SWITCH = '🔄';
+/** かぞく / メンバー（子供選択） */
+export const ICON_SWITCH = '👨‍👩‍👧‍👦';
 
 // ============================================================
 // セクション・機能アイコン
@@ -45,7 +45,7 @@ export interface ModeLabels {
 export const MODE_LABELS: Record<string, ModeLabels> = {
 	baby: {
 		status: 'つよさ',
-		switch: 'きりかえ',
+		switch: 'かぞく',
 		history: 'きろく',
 		achievements: 'じっせき',
 		recordSummary: 'きょうの きろく',
@@ -53,7 +53,7 @@ export const MODE_LABELS: Record<string, ModeLabels> = {
 	},
 	kinder: {
 		status: 'つよさ',
-		switch: 'きりかえ',
+		switch: 'かぞく',
 		history: 'きろく',
 		achievements: 'じっせき',
 		recordSummary: 'きょうの きろく',
@@ -61,7 +61,7 @@ export const MODE_LABELS: Record<string, ModeLabels> = {
 	},
 	lower: {
 		status: 'つよさ',
-		switch: 'きりかえ',
+		switch: 'かぞく',
 		history: '記録',
 		achievements: '実績',
 		recordSummary: '今日の記録',
@@ -69,7 +69,7 @@ export const MODE_LABELS: Record<string, ModeLabels> = {
 	},
 	upper: {
 		status: 'ステータス',
-		switch: '切り替え',
+		switch: 'メンバー',
 		history: '記録',
 		achievements: '実績',
 		recordSummary: '今日の記録',
@@ -77,7 +77,7 @@ export const MODE_LABELS: Record<string, ModeLabels> = {
 	},
 	teen: {
 		status: 'ステータス',
-		switch: '切り替え',
+		switch: 'メンバー',
 		history: '記録',
 		achievements: '実績',
 		recordSummary: '今日の記録',

--- a/src/lib/ui/components/ActivityEmptyState.svelte
+++ b/src/lib/ui/components/ActivityEmptyState.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { ICON_ACHIEVEMENTS, ICON_STATUS, getModeLabels } from '$lib/domain/icons';
+import { ICON_STATUS, getModeLabels } from '$lib/domain/icons';
 
 interface Props {
 	uiMode: string;
@@ -21,10 +21,6 @@ const labels = $derived(getModeLabels(uiMode));
 			<a href="/{uiMode}/status" class="empty-link">
 				<span>{ICON_STATUS}</span>
 				<span>{labels.status}をみる</span>
-			</a>
-			<a href="/{uiMode}/achievements" class="empty-link">
-				<span>{ICON_ACHIEVEMENTS}</span>
-				<span>{labels.achievements}をみる</span>
 			</a>
 		</div>
 	</div>

--- a/src/lib/ui/components/BottomNav.svelte
+++ b/src/lib/ui/components/BottomNav.svelte
@@ -17,7 +17,7 @@ interface Props {
 const defaultItems: NavItem[] = [
 	{ href: '/home', icon: ICON_HOME, label: 'ホーム' },
 	{ href: '/status', icon: ICON_STATUS, label: 'つよさ' },
-	{ href: '/switch', icon: ICON_SWITCH, label: 'きりかえ' },
+	{ href: '/switch', icon: ICON_SWITCH, label: 'かぞく' },
 ];
 
 let { items = defaultItems, iconOnly = false }: Props = $props();

--- a/src/routes/(child)/kinder/home/+page.svelte
+++ b/src/routes/(child)/kinder/home/+page.svelte
@@ -495,6 +495,9 @@ $effect(() => {
 					{/each}
 					<span class="text-xs font-bold text-orange-600 ml-1">{questProgress.completed}/{questProgress.total}</span>
 				</div>
+				{#if questProgress.completed === 0}
+					<p class="text-[10px] text-orange-400 mt-0.5">⬇ したの カードを タップして きろくしよう！</p>
+				{/if}
 			</div>
 			{#if questProgress.completed >= questProgress.total}
 				<span class="text-sm font-bold text-orange-600">コンプリート！</span>

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -73,7 +73,7 @@ test.describe('UC-01: Kinder ホーム画面', () => {
 	test('ボトムナビゲーションが表示される', async ({ page }) => {
 		const nav = page.locator('[data-testid="bottom-nav"]');
 		await expect(nav).toBeVisible();
-		// ナビリンクが3つ表示される（ホーム、つよさ、きりかえ）
+		// ナビリンクが3つ表示される（ホーム、つよさ、かぞく）
 		const links = nav.locator('a');
 		expect(await links.count()).toBe(3);
 	});
@@ -241,11 +241,11 @@ test.describe('ナビゲーション', () => {
 		await expect(page).toHaveURL(/\/kinder\/home/);
 	});
 
-	test('きりかえリンクで /switch に戻れる', async ({ page }) => {
+	test('かぞくリンクで /switch に戻れる', async ({ page }) => {
 		const nav = page.locator('[data-testid="bottom-nav"]');
 		await page.evaluate(() => window.scrollTo(0, 0));
 		await nav.waitFor({ state: 'visible' });
-		await nav.locator('a').filter({ hasText: 'きりかえ' }).click({ force: true });
+		await nav.locator('a').filter({ hasText: 'かぞく' }).click({ force: true });
 		await expect(page).toHaveURL(/\/switch/);
 	});
 });


### PR DESCRIPTION
## Summary
- BottomNav「きりかえ」→「かぞく」(幼児)・「メンバー」(高学年)に変更し、子供選択であることを直感的に伝達
- アイコンも🔄→👨‍👩‍👧‍👦に変更
- クエスト進捗が0の初回表示時に「カードをタップしよう！」のガイダンスヒントを追加
- ActivityEmptyStateから廃止予定の実績ページリンクを除去

## 空カード問題について
NUCが106コミット遅れていたことが原因の可能性が高い。最新版(main)では ActivityCard に `icon`/`displayName` が正しく渡されており、空表示は再現しない。NUCを最新版にデプロイ後の動作確認が必要。

## Test plan
- [ ] E2Eテスト「かぞくリンクで /switch に戻れる」が通過すること
- [ ] kinder/baby/lower モードでナビラベルが「かぞく」と表示されること
- [ ] upper/teen モードでナビラベルが「メンバー」と表示されること
- [ ] クエスト進捗が0のときにヒントテキストが表示されること
- [ ] NUCデプロイ後に活動カードが正しく表示されること

closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)