### PR TITLE
design: #327 子供ホーム画面リストラクチャ — 活動カードファースト

### DIFF
--- a/src/routes/(child)/kinder/home/+page.svelte
+++ b/src/routes/(child)/kinder/home/+page.svelte
@@ -442,14 +442,6 @@ $effect(() => {
 		/>
 	{/if}
 
-<!-- Sibling ranking (1-line summary) -->
-	{#if data.siblingRanking && data.siblingRanking.rankings.length > 1}
-		<SiblingRanking
-			rankings={data.siblingRanking.rankings}
-			childId={data.child?.id ?? 0}
-		/>
-	{/if}
-
 	<!-- Error toast -->
 	{#if errorMessage}
 		<div class="fixed top-16 left-1/2 -translate-x-1/2 z-50 bg-red-500 text-white px-4 py-2 rounded-lg shadow-lg text-sm font-bold animate-bounce-in">
@@ -587,6 +579,14 @@ $effect(() => {
 		</CategorySection>
 	{/each}
 
+	<!-- Sibling ranking (1-line summary, below activities) -->
+	{#if data.siblingRanking && data.siblingRanking.rankings.length > 1}
+		<SiblingRanking
+			rankings={data.siblingRanking.rankings}
+			childId={data.child?.id ?? 0}
+		/>
+	{/if}
+
 	<!-- おうえんメッセージ（Kinder固有） -->
 	{#if kinderTodayCount > 0}
 		<div class="mt-[var(--sp-md)] p-4 rounded-2xl bg-[var(--theme-bg)] border border-[var(--theme-secondary)] text-center">
@@ -673,24 +673,6 @@ $effect(() => {
 		/>
 	{/if}
 
-	<!-- Sibling ranking (collapsible) -->
-	{#if data.siblingRanking && data.siblingRanking.rankings.length > 1}
-		<details class="mt-[var(--sp-sm)]">
-			<summary class="flex items-center justify-between px-[var(--sp-md)] py-[var(--sp-sm)] rounded-[var(--radius-lg)] bg-white shadow-sm border border-[var(--color-border)] cursor-pointer tap-target list-none">
-				<div class="flex items-center gap-[var(--sp-sm)]">
-					<span class="text-xl">🏆</span>
-					<span class="font-bold text-sm">こんしゅうの ランキング</span>
-				</div>
-				<span class="text-[var(--color-text-muted)] transition-transform duration-200 ranking-arrow">▼</span>
-			</summary>
-			<div class="mt-1">
-				<SiblingRanking
-					rankings={data.siblingRanking.rankings}
-					childId={data.child?.id ?? 0}
-				/>
-			</div>
-		</details>
-	{/if}
 </div>
 
 <!-- Pin context menu -->


### PR DESCRIPTION
## Summary
- きょうだいランキング1行サマリーを活動カード上部→下部に移動し、活動入力カードがファーストビューに収まるよう改善
- 下部の重複した折りたたみランキングセクションを削除（サマリー1つに統合）
- レイアウト優先度: クエスト進捗 → 活動カード → ランキング → イベント/チャレンジ

## 補足
#323（ランキング縮小）、#324（シーズンパス移動）、#326（特別ごほうび変更）、#334（イベント・チャレンジ改修）により、ホーム画面の情報量は既に大幅に削減済み。本PRではレイアウト順序の最適化を実施。

通知バッジ・イベントモーダル等の追加UIは後続チケットで対応。

## Test plan
- [ ] kinder モードでファーストビュー（375px幅）に活動カードが収まること
- [ ] ランキングサマリーが活動カードの下に表示されること
- [ ] E2Eテストが全通過すること

closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)