### PR TITLE
chore: #377 TypeScript v5→v6 メジャーアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
 				"svelte-eslint-parser": "^1.6.0",
 				"tailwindcss": "^4.2.2",
 				"tsx": "^4.19.0",
-				"typescript": "^5.9.3",
+				"typescript": "^6.0.2",
 				"vite": "^8.0.3",
 				"vitest": "^4.1.2"
 			}
@@ -5494,6 +5494,35 @@
 				"storybook": "^10.3.4",
 				"svelte": "^5.0.0",
 				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@storybook/svelte-vite/node_modules/svelte2tsx": {
+			"version": "0.7.53",
+			"resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.53.tgz",
+			"integrity": "sha512-ljVSwmnYRDHRm8+7ICP6QoAN7U7vgOFfPBLN6T745YWNYqRRSzHxlrzUVqMjYls2Un8MzJissfziy/38e6Deeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dedent-js": "^1.0.1",
+				"scule": "^1.3.0"
+			},
+			"peerDependencies": {
+				"svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0",
+				"typescript": "^4.9.4 || ^5.0.0"
+			}
+		},
+		"node_modules/@storybook/svelte-vite/node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/@storybook/sveltekit": {
@@ -13369,21 +13398,6 @@
 				"@types/estree": "^1.0.6"
 			}
 		},
-		"node_modules/svelte2tsx": {
-			"version": "0.7.53",
-			"resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.53.tgz",
-			"integrity": "sha512-ljVSwmnYRDHRm8+7ICP6QoAN7U7vgOFfPBLN6T745YWNYqRRSzHxlrzUVqMjYls2Un8MzJissfziy/38e6Deeg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"dedent-js": "^1.0.1",
-				"scule": "^1.3.0"
-			},
-			"peerDependencies": {
-				"svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0",
-				"typescript": "^4.9.4 || ^5.0.0"
-			}
-		},
 		"node_modules/svg-tags": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
@@ -13726,9 +13740,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+			"integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"svelte-eslint-parser": "^1.6.0",
 		"tailwindcss": "^4.2.2",
 		"tsx": "^4.19.0",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.2",
 		"vite": "^8.0.3",
 		"vitest": "^4.1.2"
 	},


### PR DESCRIPTION
## Summary
- TypeScript 5.9.3 → 6.0.2 へメジャーアップデート
- 全ビルド・型チェック（svelte-check）・ユニットテスト（2163件）通過確認済み
- 破壊的変更の影響なし（ESM import、strict mode は既に準拠）
- Dependabot PR #362 の手動対応版

## Test plan
- [x] `npx tsc --version` → 6.0.2
- [x] `npx svelte-check` → 0 errors
- [x] `npx biome check .` → clean
- [x] `npx vitest run` → 2163 tests passed
- [ ] CI (lint-and-test, e2e-test, docker-build) 全通過

closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)