### PR TITLE
feat: #373 きょうだいランキング強化（トレンドグラフ・カテゴリ比較）

### DIFF
--- a/src/lib/server/services/sibling-ranking-service.ts
+++ b/src/lib/server/services/sibling-ranking-service.ts
@@ -285,7 +285,12 @@ async function getRankingForPeriod(
 				encouragement: logs.length > 0 ? 'がんばってるね！' : 'きょうもがんばろう！',
 			};
 		}
-		return { mostActive: null, categoryChampions: {}, rankings: [], encouragement: 'きょうもがんばろう！' };
+		return {
+			mostActive: null,
+			categoryChampions: {},
+			rankings: [],
+			encouragement: 'きょうもがんばろう！',
+		};
 	}
 
 	const rankings: SiblingRanking[] = await Promise.all(
@@ -295,7 +300,12 @@ async function getRankingForPeriod(
 			for (const log of logs) {
 				categoryCounts[log.categoryId] = (categoryCounts[log.categoryId] ?? 0) + 1;
 			}
-			return { childId: child.id, childName: child.nickname, totalCount: logs.length, categoryCounts };
+			return {
+				childId: child.id,
+				childName: child.nickname,
+				totalCount: logs.length,
+				categoryCounts,
+			};
 		}),
 	);
 
@@ -303,7 +313,11 @@ async function getRankingForPeriod(
 
 	const mostActive =
 		rankings[0] && rankings[0].totalCount > 0
-			? { childId: rankings[0].childId, childName: rankings[0].childName, count: rankings[0].totalCount }
+			? {
+					childId: rankings[0].childId,
+					childName: rankings[0].childName,
+					count: rankings[0].totalCount,
+				}
 			: null;
 
 	const categoryChampions: Record<number, CategoryChampion> = {};
@@ -321,9 +335,11 @@ async function getRankingForPeriod(
 
 	const totalAll = rankings.reduce((sum, r) => sum + r.totalCount, 0);
 	const encouragement =
-		totalAll === 0 ? 'きょうもがんばろう！' :
-		totalAll < 10 ? 'がんばりはじめたね！' :
-		'がんばってるね！もっとできるよ！';
+		totalAll === 0
+			? 'きょうもがんばろう！'
+			: totalAll < 10
+				? 'がんばりはじめたね！'
+				: 'がんばってるね！もっとできるよ！';
 
 	return { mostActive, categoryChampions, rankings, encouragement };
 }

--- a/src/lib/server/services/sibling-ranking-service.ts
+++ b/src/lib/server/services/sibling-ranking-service.ts
@@ -242,3 +242,88 @@ export async function getRankingTrend(tenantId: string, numWeeks = 4): Promise<R
 		children: children.map((c) => ({ childId: c.id, childName: c.nickname })),
 	};
 }
+
+// ============================================================
+// Monthly Ranking (#373)
+// ============================================================
+
+/** 今月のきょうだいランキングを算出 */
+export async function getMonthlyRanking(tenantId: string): Promise<WeeklyRankingResult> {
+	const now = new Date();
+	const monthStart = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
+	const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+	const monthEnd = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
+
+	return getRankingForPeriod(tenantId, monthStart, monthEnd);
+}
+
+/** 期間指定のきょうだいランキング（週次・月次共通ロジック） */
+async function getRankingForPeriod(
+	tenantId: string,
+	from: string,
+	to: string,
+): Promise<WeeklyRankingResult> {
+	const children = await findAllChildren(tenantId);
+
+	if (children.length <= 1) {
+		const child = children[0];
+		if (child) {
+			const logs = await findActivityLogs(child.id, tenantId, { from, to });
+			const categoryCounts: Record<number, number> = {};
+			for (const log of logs) {
+				categoryCounts[log.categoryId] = (categoryCounts[log.categoryId] ?? 0) + 1;
+			}
+			return {
+				mostActive:
+					logs.length > 0
+						? { childId: child.id, childName: child.nickname, count: logs.length }
+						: null,
+				categoryChampions: {},
+				rankings: [
+					{ childId: child.id, childName: child.nickname, totalCount: logs.length, categoryCounts },
+				],
+				encouragement: logs.length > 0 ? 'がんばってるね！' : 'きょうもがんばろう！',
+			};
+		}
+		return { mostActive: null, categoryChampions: {}, rankings: [], encouragement: 'きょうもがんばろう！' };
+	}
+
+	const rankings: SiblingRanking[] = await Promise.all(
+		children.map(async (child) => {
+			const logs = await findActivityLogs(child.id, tenantId, { from, to });
+			const categoryCounts: Record<number, number> = {};
+			for (const log of logs) {
+				categoryCounts[log.categoryId] = (categoryCounts[log.categoryId] ?? 0) + 1;
+			}
+			return { childId: child.id, childName: child.nickname, totalCount: logs.length, categoryCounts };
+		}),
+	);
+
+	rankings.sort((a, b) => b.totalCount - a.totalCount);
+
+	const mostActive =
+		rankings[0] && rankings[0].totalCount > 0
+			? { childId: rankings[0].childId, childName: rankings[0].childName, count: rankings[0].totalCount }
+			: null;
+
+	const categoryChampions: Record<number, CategoryChampion> = {};
+	const allCategories = new Set(rankings.flatMap((r) => Object.keys(r.categoryCounts).map(Number)));
+	for (const catId of allCategories) {
+		let best: CategoryChampion | null = null;
+		for (const r of rankings) {
+			const val = r.categoryCounts[catId] ?? 0;
+			if (val > 0 && (!best || val > best.value)) {
+				best = { childId: r.childId, childName: r.childName, value: val };
+			}
+		}
+		if (best) categoryChampions[catId] = best;
+	}
+
+	const totalAll = rankings.reduce((sum, r) => sum + r.totalCount, 0);
+	const encouragement =
+		totalAll === 0 ? 'きょうもがんばろう！' :
+		totalAll < 10 ? 'がんばりはじめたね！' :
+		'がんばってるね！もっとできるよ！';
+
+	return { mostActive, categoryChampions, rankings, encouragement };
+}

--- a/src/lib/server/services/sibling-ranking-service.ts
+++ b/src/lib/server/services/sibling-ranking-service.ts
@@ -180,8 +180,15 @@ export async function getRankingTrend(tenantId: string, numWeeks = 4): Promise<R
 	if (children.length === 0) return { weeks: [], children: [] };
 
 	const now = new Date();
-	const weeks: WeeklyTrendEntry[] = [];
 
+	// Build week boundaries first
+	interface WeekBoundary {
+		weekStart: string;
+		weekEnd: string;
+		weekLabel: string;
+		monday: Date;
+	}
+	const weekBoundaries: WeekBoundary[] = [];
 	for (let w = numWeeks - 1; w >= 0; w--) {
 		const refDate = new Date(now);
 		refDate.setDate(refDate.getDate() - w * 7);
@@ -193,22 +200,42 @@ export async function getRankingTrend(tenantId: string, numWeeks = 4): Promise<R
 		const sunday = new Date(monday);
 		sunday.setDate(monday.getDate() + 6);
 
-		const weekStart = monday.toISOString().slice(0, 10);
-		const weekEnd = sunday.toISOString().slice(0, 10);
-		const weekLabel = `${monday.getMonth() + 1}/${monday.getDate()}〜`;
-
-		const childCounts = await Promise.all(
-			children.map(async (child) => {
-				const logs = await findActivityLogs(child.id, tenantId, {
-					from: weekStart,
-					to: weekEnd,
-				});
-				return { childId: child.id, childName: child.nickname, count: logs.length };
-			}),
-		);
-
-		weeks.push({ weekLabel, weekStart, children: childCounts });
+		weekBoundaries.push({
+			weekStart: monday.toISOString().slice(0, 10),
+			weekEnd: sunday.toISOString().slice(0, 10),
+			weekLabel: `${monday.getMonth() + 1}/${monday.getDate()}〜`,
+			monday,
+		});
 	}
+
+	// Fetch all logs for the entire date range once per child (instead of per week × per child)
+	const firstWeek = weekBoundaries[0];
+	const lastWeek = weekBoundaries[weekBoundaries.length - 1];
+	if (!firstWeek || !lastWeek) return { weeks: [], children: [] };
+	const overallFrom = firstWeek.weekStart;
+	const overallTo = lastWeek.weekEnd;
+
+	const allChildLogs = await Promise.all(
+		children.map(async (child) => {
+			const logs = await findActivityLogs(child.id, tenantId, {
+				from: overallFrom,
+				to: overallTo,
+			});
+			return { child, logs };
+		}),
+	);
+
+	// Bucket logs by week in memory
+	const weeks: WeeklyTrendEntry[] = weekBoundaries.map((wb) => {
+		const childCounts = allChildLogs.map(({ child, logs }) => {
+			const count = logs.filter((log) => {
+				const d = typeof log.recordedAt === 'string' ? log.recordedAt.slice(0, 10) : '';
+				return d >= wb.weekStart && d <= wb.weekEnd;
+			}).length;
+			return { childId: child.id, childName: child.nickname, count };
+		});
+		return { weekLabel: wb.weekLabel, weekStart: wb.weekStart, children: childCounts };
+	});
 
 	return {
 		weeks,

--- a/src/lib/server/services/sibling-ranking-service.ts
+++ b/src/lib/server/services/sibling-ranking-service.ts
@@ -158,3 +158,60 @@ export async function getWeeklyRanking(tenantId: string): Promise<WeeklyRankingR
 
 	return { mostActive, categoryChampions, rankings, encouragement };
 }
+
+// ============================================================
+// Ranking Trend (#373)
+// ============================================================
+
+export interface WeeklyTrendEntry {
+	weekLabel: string;
+	weekStart: string;
+	children: { childId: number; childName: string; count: number }[];
+}
+
+export interface RankingTrendResult {
+	weeks: WeeklyTrendEntry[];
+	children: { childId: number; childName: string }[];
+}
+
+/** 過去N週のきょうだい活動数推移を取得 */
+export async function getRankingTrend(tenantId: string, numWeeks = 4): Promise<RankingTrendResult> {
+	const children = await findAllChildren(tenantId);
+	if (children.length === 0) return { weeks: [], children: [] };
+
+	const now = new Date();
+	const weeks: WeeklyTrendEntry[] = [];
+
+	for (let w = numWeeks - 1; w >= 0; w--) {
+		const refDate = new Date(now);
+		refDate.setDate(refDate.getDate() - w * 7);
+
+		const day = refDate.getDay();
+		const mondayOffset = day === 0 ? 6 : day - 1;
+		const monday = new Date(refDate);
+		monday.setDate(refDate.getDate() - mondayOffset);
+		const sunday = new Date(monday);
+		sunday.setDate(monday.getDate() + 6);
+
+		const weekStart = monday.toISOString().slice(0, 10);
+		const weekEnd = sunday.toISOString().slice(0, 10);
+		const weekLabel = `${monday.getMonth() + 1}/${monday.getDate()}〜`;
+
+		const childCounts = await Promise.all(
+			children.map(async (child) => {
+				const logs = await findActivityLogs(child.id, tenantId, {
+					from: weekStart,
+					to: weekEnd,
+				});
+				return { childId: child.id, childName: child.nickname, count: logs.length };
+			}),
+		);
+
+		weeks.push({ weekLabel, weekStart, children: childCounts });
+	}
+
+	return {
+		weeks,
+		children: children.map((c) => ({ childId: c.id, childName: c.nickname })),
+	};
+}

--- a/src/lib/ui/components/SiblingCategoryChart.svelte
+++ b/src/lib/ui/components/SiblingCategoryChart.svelte
@@ -16,7 +16,13 @@ interface Props {
 
 let { rankings, width = 360, height = 180 }: Props = $props();
 
-const CHILD_COLORS = ['#3b82f6', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6'];
+const CHILD_COLORS = [
+	'var(--color-chart-1)',
+	'var(--color-chart-2)',
+	'var(--color-chart-3)',
+	'var(--color-chart-4)',
+	'var(--color-chart-5)',
+];
 
 const CATEGORIES = CATEGORY_DEFS.map((c) => ({ id: c.id, label: c.name, icon: c.icon }));
 

--- a/src/lib/ui/components/SiblingCategoryChart.svelte
+++ b/src/lib/ui/components/SiblingCategoryChart.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+interface RankingData {
+	childId: number;
+	childName: string;
+	totalCount: number;
+	categoryCounts: Record<number, number>;
+}
+
+interface Props {
+	rankings: RankingData[];
+	width?: number;
+	height?: number;
+}
+
+let { rankings, width = 360, height = 180 }: Props = $props();
+
+const CHILD_COLORS = ['#3b82f6', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6'];
+
+const CATEGORIES = [
+	{ id: 1, label: 'うんどう', icon: '🏃' },
+	{ id: 2, label: 'べんきょう', icon: '📚' },
+	{ id: 3, label: 'せいかつ', icon: '🏠' },
+	{ id: 4, label: 'こうりゅう', icon: '🤝' },
+	{ id: 5, label: 'そうぞう', icon: '🎨' },
+];
+
+const PADDING = { top: 12, right: 12, bottom: 40, left: 32 };
+const chartW = $derived(width - PADDING.left - PADDING.right);
+const chartH = $derived(height - PADDING.top - PADDING.bottom);
+
+const maxCount = $derived(
+	Math.max(1, ...rankings.flatMap((r) => CATEGORIES.map((cat) => r.categoryCounts[cat.id] ?? 0))),
+);
+
+const groupWidth = $derived(chartW / CATEGORIES.length);
+const barWidth = $derived(Math.min(16, (groupWidth - 8) / Math.max(1, rankings.length)));
+</script>
+
+{#if rankings.length > 1}
+	<div class="cat-chart">
+		<svg viewBox="0 0 {width} {height}" {width} {height} class="cat-svg">
+			<!-- Y axis grid -->
+			{#each [0, Math.ceil(maxCount / 2), maxCount] as tick}
+				{@const py = PADDING.top + chartH - (tick / maxCount) * chartH}
+				<line
+					x1={PADDING.left}
+					y1={py}
+					x2={PADDING.left + chartW}
+					y2={py}
+					stroke="var(--color-border-default, #e2e8f0)"
+					stroke-width="0.5"
+				/>
+				<text x={PADDING.left - 4} y={py + 3} text-anchor="end" class="tick-label">
+					{tick}
+				</text>
+			{/each}
+
+			<!-- Category groups -->
+			{#each CATEGORIES as cat, catIdx}
+				{@const groupX = PADDING.left + catIdx * groupWidth + groupWidth / 2}
+
+				<!-- Category label -->
+				<text
+					x={groupX}
+					y={height - 4}
+					text-anchor="middle"
+					class="cat-label"
+				>{cat.icon}</text>
+				<text
+					x={groupX}
+					y={height - 16}
+					text-anchor="middle"
+					class="tick-label"
+				>{cat.label}</text>
+
+				<!-- Bars per child -->
+				{#each rankings as ranking, childIdx}
+					{@const count = ranking.categoryCounts[cat.id] ?? 0}
+					{@const barH = (count / maxCount) * chartH}
+					{@const bx = groupX - (rankings.length * barWidth) / 2 + childIdx * barWidth}
+					<rect
+						x={bx}
+						y={PADDING.top + chartH - barH}
+						width={barWidth - 1}
+						height={barH}
+						fill={CHILD_COLORS[childIdx % CHILD_COLORS.length]}
+						rx="2"
+					/>
+				{/each}
+			{/each}
+		</svg>
+
+		<!-- Legend -->
+		<div class="cat-legend">
+			{#each rankings as ranking, ci}
+				<span class="cat-legend__item">
+					<span
+						class="cat-legend__dot"
+						style:background={CHILD_COLORS[ci % CHILD_COLORS.length]}
+					></span>
+					{ranking.childName}
+				</span>
+			{/each}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.cat-chart {
+		width: 100%;
+	}
+
+	.cat-svg {
+		width: 100%;
+		height: auto;
+		display: block;
+	}
+
+	.tick-label {
+		font-size: 10px;
+		fill: var(--color-text-tertiary, #94a3b8);
+	}
+
+	.cat-label {
+		font-size: 14px;
+	}
+
+	.cat-legend {
+		display: flex;
+		justify-content: center;
+		gap: 1rem;
+		margin-top: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.cat-legend__item {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		font-size: 0.75rem;
+		color: var(--color-text-secondary, #64748b);
+	}
+
+	.cat-legend__dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+</style>

--- a/src/lib/ui/components/SiblingCategoryChart.svelte
+++ b/src/lib/ui/components/SiblingCategoryChart.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
+
 interface RankingData {
 	childId: number;
 	childName: string;
@@ -16,13 +18,7 @@ let { rankings, width = 360, height = 180 }: Props = $props();
 
 const CHILD_COLORS = ['#3b82f6', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6'];
 
-const CATEGORIES = [
-	{ id: 1, label: 'うんどう', icon: '🏃' },
-	{ id: 2, label: 'べんきょう', icon: '📚' },
-	{ id: 3, label: 'せいかつ', icon: '🏠' },
-	{ id: 4, label: 'こうりゅう', icon: '🤝' },
-	{ id: 5, label: 'そうぞう', icon: '🎨' },
-];
+const CATEGORIES = CATEGORY_DEFS.map((c) => ({ id: c.id, label: c.name, icon: c.icon }));
 
 const PADDING = { top: 12, right: 12, bottom: 40, left: 32 };
 const chartW = $derived(width - PADDING.left - PADDING.right);
@@ -34,11 +30,16 @@ const maxCount = $derived(
 
 const groupWidth = $derived(chartW / CATEGORIES.length);
 const barWidth = $derived(Math.min(16, (groupWidth - 8) / Math.max(1, rankings.length)));
+
+const ariaLabel = $derived(
+	`きょうだいカテゴリ比較グラフ。${rankings.map((r) => r.childName).join('、')}の5カテゴリ別の件数を比較しています。`,
+);
 </script>
 
 {#if rankings.length > 1}
 	<div class="cat-chart">
-		<svg viewBox="0 0 {width} {height}" {width} {height} class="cat-svg">
+		<svg viewBox="0 0 {width} {height}" {width} {height} class="cat-svg" role="img" aria-label={ariaLabel}>
+			<title>{ariaLabel}</title>
 			<!-- Y axis grid -->
 			{#each [0, Math.ceil(maxCount / 2), maxCount] as tick}
 				{@const py = PADDING.top + chartH - (tick / maxCount) * chartH}
@@ -78,10 +79,11 @@ const barWidth = $derived(Math.min(16, (groupWidth - 8) / Math.max(1, rankings.l
 					{@const count = ranking.categoryCounts[cat.id] ?? 0}
 					{@const barH = (count / maxCount) * chartH}
 					{@const bx = groupX - (rankings.length * barWidth) / 2 + childIdx * barWidth}
+					{@const rectWidth = Math.max(barWidth - 1, 1)}
 					<rect
 						x={bx}
 						y={PADDING.top + chartH - barH}
-						width={barWidth - 1}
+						width={rectWidth}
 						height={barH}
 						fill={CHILD_COLORS[childIdx % CHILD_COLORS.length]}
 						rx="2"

--- a/src/lib/ui/components/SiblingTrendChart.svelte
+++ b/src/lib/ui/components/SiblingTrendChart.svelte
@@ -12,7 +12,13 @@ interface Props {
 
 let { weeks, width = 360, height = 200 }: Props = $props();
 
-const COLORS = ['#3b82f6', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6'];
+const COLORS = [
+	'var(--color-chart-1)',
+	'var(--color-chart-2)',
+	'var(--color-chart-3)',
+	'var(--color-chart-4)',
+	'var(--color-chart-5)',
+];
 const PADDING = { top: 20, right: 16, bottom: 32, left: 36 };
 
 const chartW = $derived(width - PADDING.left - PADDING.right);

--- a/src/lib/ui/components/SiblingTrendChart.svelte
+++ b/src/lib/ui/components/SiblingTrendChart.svelte
@@ -53,7 +53,8 @@ const yTicks = $derived.by(() => {
 
 {#if weeks.length > 0 && childNames.length > 1}
 	<div class="trend-chart">
-		<svg viewBox="0 0 {width} {height}" {width} {height} class="trend-svg">
+		<svg viewBox="0 0 {width} {height}" {width} {height} class="trend-svg" role="img" aria-label="きょうだい週次トレンドグラフ">
+			<title>きょうだい週次トレンドグラフ</title>
 			<!-- Y axis grid -->
 			{#each yTicks as tick}
 				<line

--- a/src/lib/ui/components/SiblingTrendChart.svelte
+++ b/src/lib/ui/components/SiblingTrendChart.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+interface WeekData {
+	weekLabel: string;
+	children: { childId: number; childName: string; count: number }[];
+}
+
+interface Props {
+	weeks: WeekData[];
+	width?: number;
+	height?: number;
+}
+
+let { weeks, width = 360, height = 200 }: Props = $props();
+
+const COLORS = ['#3b82f6', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6'];
+const PADDING = { top: 20, right: 16, bottom: 32, left: 36 };
+
+const chartW = $derived(width - PADDING.left - PADDING.right);
+const chartH = $derived(height - PADDING.top - PADDING.bottom);
+
+const childNames = $derived(weeks[0]?.children.map((c) => c.childName) ?? []);
+
+const maxCount = $derived(Math.max(1, ...weeks.flatMap((w) => w.children.map((c) => c.count))));
+
+function x(i: number): number {
+	if (weeks.length <= 1) return PADDING.left + chartW / 2;
+	return PADDING.left + (i / (weeks.length - 1)) * chartW;
+}
+
+function y(count: number): number {
+	return PADDING.top + chartH - (count / maxCount) * chartH;
+}
+
+function linePath(childIdx: number): string {
+	return weeks
+		.map((w, i) => {
+			const c = w.children[childIdx];
+			const px = x(i);
+			const py = y(c?.count ?? 0);
+			return `${i === 0 ? 'M' : 'L'}${px},${py}`;
+		})
+		.join(' ');
+}
+
+// Y axis ticks
+const yTicks = $derived.by(() => {
+	const step = maxCount <= 5 ? 1 : Math.ceil(maxCount / 4);
+	const ticks: number[] = [];
+	for (let v = 0; v <= maxCount; v += step) ticks.push(v);
+	return ticks;
+});
+</script>
+
+{#if weeks.length > 0 && childNames.length > 1}
+	<div class="trend-chart">
+		<svg viewBox="0 0 {width} {height}" {width} {height} class="trend-svg">
+			<!-- Y axis grid -->
+			{#each yTicks as tick}
+				<line
+					x1={PADDING.left}
+					y1={y(tick)}
+					x2={PADDING.left + chartW}
+					y2={y(tick)}
+					stroke="var(--color-border-default, #e2e8f0)"
+					stroke-width="0.5"
+				/>
+				<text
+					x={PADDING.left - 4}
+					y={y(tick) + 3}
+					text-anchor="end"
+					class="tick-label"
+				>{tick}</text>
+			{/each}
+
+			<!-- X axis labels -->
+			{#each weeks as week, i}
+				<text
+					x={x(i)}
+					y={height - 4}
+					text-anchor="middle"
+					class="tick-label"
+				>{week.weekLabel}</text>
+			{/each}
+
+			<!-- Lines -->
+			{#each childNames as _name, ci}
+				<path
+					d={linePath(ci)}
+					fill="none"
+					stroke={COLORS[ci % COLORS.length]}
+					stroke-width="2.5"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+				<!-- Data points -->
+				{#each weeks as w, wi}
+					{@const c = w.children[ci]}
+					<circle
+						cx={x(wi)}
+						cy={y(c?.count ?? 0)}
+						r="3.5"
+						fill={COLORS[ci % COLORS.length]}
+					/>
+				{/each}
+			{/each}
+		</svg>
+
+		<!-- Legend -->
+		<div class="trend-legend">
+			{#each childNames as name, ci}
+				<span class="trend-legend__item">
+					<span
+						class="trend-legend__dot"
+						style:background={COLORS[ci % COLORS.length]}
+					></span>
+					{name}
+				</span>
+			{/each}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.trend-chart {
+		width: 100%;
+	}
+
+	.trend-svg {
+		width: 100%;
+		height: auto;
+		display: block;
+	}
+
+	.tick-label {
+		font-size: 10px;
+		fill: var(--color-text-tertiary, #94a3b8);
+	}
+
+	.trend-legend {
+		display: flex;
+		justify-content: center;
+		gap: 1rem;
+		margin-top: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.trend-legend__item {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		font-size: 0.75rem;
+		color: var(--color-text-secondary, #64748b);
+	}
+
+	.trend-legend__dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+</style>

--- a/src/lib/ui/styles/app.css
+++ b/src/lib/ui/styles/app.css
@@ -173,6 +173,13 @@
 	--color-premium-bg: #f5f3ff;
 	--gradient-premium: linear-gradient(135deg, var(--color-violet-600), var(--color-violet-500));
 
+	/* ---- Chart (きょうだい比較グラフ等のシリーズカラー) ---- */
+	--color-chart-1: #3b82f6;
+	--color-chart-2: #f59e0b;
+	--color-chart-3: #10b981;
+	--color-chart-4: #ef4444;
+	--color-chart-5: #8b5cf6;
+
 	/* ---- Gradient ---- */
 	--gradient-brand: linear-gradient(135deg, var(--color-brand-600), var(--color-brand-400));
 	--gradient-gold: linear-gradient(135deg, var(--color-gold-600), var(--color-gold-400));

--- a/src/routes/(parent)/admin/reports/+page.server.ts
+++ b/src/routes/(parent)/admin/reports/+page.server.ts
@@ -5,6 +5,7 @@ import { logger } from '$lib/server/logger';
 import { getAllChildren } from '$lib/server/services/child-service';
 import { computeAllChildrenDetailedReport } from '$lib/server/services/report-service';
 import {
+	getMonthlyRanking,
 	getRankingTrend,
 	getWeeklyRanking,
 	isRankingEnabled,
@@ -32,18 +33,20 @@ export const load: PageServerLoad = async ({ locals, url, parent }) => {
 	const isFamily = parentData.planTier === 'family';
 
 	let rankingData: Awaited<ReturnType<typeof getWeeklyRanking>> | null = null;
+	let monthlyRankingData: Awaited<ReturnType<typeof getMonthlyRanking>> | null = null;
 	let trendData: Awaited<ReturnType<typeof getRankingTrend>> | null = null;
 	if (isFamily) {
 		try {
 			const rankingOn = await isRankingEnabled(tenantId);
 			if (rankingOn && children.length > 1) {
-				[rankingData, trendData] = await Promise.all([
+				[rankingData, monthlyRankingData, trendData] = await Promise.all([
 					getWeeklyRanking(tenantId),
+					getMonthlyRanking(tenantId),
 					getRankingTrend(tenantId, 4),
 				]);
 			}
-		} catch {
-			// ランキング取得失敗は無視
+		} catch (err) {
+			logger.error('[reports] ランキング取得失敗', { error: String(err) });
 		}
 	}
 
@@ -62,8 +65,8 @@ export const load: PageServerLoad = async ({ locals, url, parent }) => {
 		let prevMonthlyReports: typeof monthlyReports = [];
 		try {
 			prevMonthlyReports = await computeAllChildrenDetailedReport(tenantId, prevMonthStr);
-		} catch {
-			// 先月データなしでも継続
+		} catch (err) {
+			logger.error('[reports] 先月レポート取得失敗', { error: String(err) });
 		}
 
 		return {
@@ -76,6 +79,7 @@ export const load: PageServerLoad = async ({ locals, url, parent }) => {
 				day: reportSettings.weekly_report_day ?? 'monday',
 			},
 			rankingData,
+			monthlyRankingData,
 			trendData,
 			isFamily,
 		};
@@ -92,6 +96,7 @@ export const load: PageServerLoad = async ({ locals, url, parent }) => {
 				day: reportSettings.weekly_report_day ?? 'monday',
 			},
 			rankingData: null,
+			monthlyRankingData: null,
 			trendData: null,
 			isFamily,
 		};

--- a/src/routes/(parent)/admin/reports/+page.server.ts
+++ b/src/routes/(parent)/admin/reports/+page.server.ts
@@ -4,10 +4,15 @@ import { getSettings, setSetting } from '$lib/server/db/settings-repo';
 import { logger } from '$lib/server/logger';
 import { getAllChildren } from '$lib/server/services/child-service';
 import { computeAllChildrenDetailedReport } from '$lib/server/services/report-service';
+import {
+	getRankingTrend,
+	getWeeklyRanking,
+	isRankingEnabled,
+} from '$lib/server/services/sibling-ranking-service';
 import { generateReportsForChildren } from '$lib/server/services/weekly-report-service';
 import type { Actions, PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals, url }) => {
+export const load: PageServerLoad = async ({ locals, url, parent }) => {
 	const tenantId = requireTenantId(locals);
 
 	// 月パラメータ（デフォルト: 今月）
@@ -21,6 +26,26 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	]);
 
 	const childList = children.map((c) => ({ id: c.id, nickname: c.nickname }));
+
+	// ランキングデータ取得（ファミリープラン用、#373）
+	const parentData = await parent();
+	const isFamily = parentData.planTier === 'family';
+
+	let rankingData: Awaited<ReturnType<typeof getWeeklyRanking>> | null = null;
+	let trendData: Awaited<ReturnType<typeof getRankingTrend>> | null = null;
+	if (isFamily) {
+		try {
+			const rankingOn = await isRankingEnabled(tenantId);
+			if (rankingOn && children.length > 1) {
+				[rankingData, trendData] = await Promise.all([
+					getWeeklyRanking(tenantId),
+					getRankingTrend(tenantId, 4),
+				]);
+			}
+		} catch {
+			// ランキング取得失敗は無視
+		}
+	}
 
 	// 週次 + 月次レポートを並行取得
 	let monthlyReports: Awaited<ReturnType<typeof computeAllChildrenDetailedReport>> = [];
@@ -50,6 +75,9 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 				enabled: reportSettings.weekly_report_enabled !== '0',
 				day: reportSettings.weekly_report_day ?? 'monday',
 			},
+			rankingData,
+			trendData,
+			isFamily,
 		};
 	} catch (e) {
 		logger.error('月次レポート取得エラー', { context: { error: String(e) } });
@@ -63,6 +91,9 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 				enabled: reportSettings.weekly_report_enabled !== '0',
 				day: reportSettings.weekly_report_day ?? 'monday',
 			},
+			rankingData: null,
+			trendData: null,
+			isFamily,
 		};
 	}
 };

--- a/src/routes/(parent)/admin/reports/+page.svelte
+++ b/src/routes/(parent)/admin/reports/+page.svelte
@@ -2,6 +2,8 @@
 import { enhance } from '$app/forms';
 import { goto } from '$app/navigation';
 import ProgressFill from '$lib/ui/components/ProgressFill.svelte';
+import SiblingCategoryChart from '$lib/ui/components/SiblingCategoryChart.svelte';
+import SiblingTrendChart from '$lib/ui/components/SiblingTrendChart.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
 
@@ -387,6 +389,38 @@ function maxCategoryCount(breakdown: Record<string, number>): number {
 				</div>
 			{/each}
 		{/if}
+	{/if}
+
+	<!-- きょうだいランキング強化セクション (#373) -->
+	{#if data.isFamily && data.rankingData && data.rankingData.rankings.length > 1}
+		<section class="space-y-4">
+			<h3 class="text-base font-bold text-gray-700">👫 きょうだいランキング</h3>
+
+			<!-- 今週の概要 -->
+			<div class="bg-white rounded-xl p-4 shadow-sm">
+				<p class="text-sm font-bold text-gray-600 mb-2">📊 今週のまとめ</p>
+				{#if data.rankingData.mostActive}
+					<p class="text-sm text-gray-700">
+						🏆 もっとも活発: <strong>{data.rankingData.mostActive.childName}</strong>（{data.rankingData.mostActive.count}回）
+					</p>
+				{/if}
+				<p class="text-sm text-gray-500 mt-1">{data.rankingData.encouragement}</p>
+			</div>
+
+			<!-- 活動数推移グラフ -->
+			{#if data.trendData && data.trendData.weeks.length > 1}
+				<div class="bg-white rounded-xl p-4 shadow-sm">
+					<p class="text-sm font-bold text-gray-600 mb-3">📈 週別 活動数のうつりかわり</p>
+					<SiblingTrendChart weeks={data.trendData.weeks} />
+				</div>
+			{/if}
+
+			<!-- カテゴリ別比較 -->
+			<div class="bg-white rounded-xl p-4 shadow-sm">
+				<p class="text-sm font-bold text-gray-600 mb-3">📊 今週のカテゴリ別くらべっこ</p>
+				<SiblingCategoryChart rankings={data.rankingData.rankings} />
+			</div>
+		</section>
 	{/if}
 </div>
 

--- a/src/routes/(parent)/admin/reports/+page.svelte
+++ b/src/routes/(parent)/admin/reports/+page.svelte
@@ -415,11 +415,24 @@ function maxCategoryCount(breakdown: Record<string, number>): number {
 				</div>
 			{/if}
 
-			<!-- カテゴリ別比較 -->
+			<!-- カテゴリ別比較（週次） -->
 			<div class="bg-white rounded-xl p-4 shadow-sm">
 				<p class="text-sm font-bold text-gray-600 mb-3">📊 今週のカテゴリ別くらべっこ</p>
 				<SiblingCategoryChart rankings={data.rankingData.rankings} />
 			</div>
+
+			<!-- カテゴリ別比較（月次） -->
+			{#if data.monthlyRankingData && data.monthlyRankingData.rankings.length > 1}
+				<div class="bg-white rounded-xl p-4 shadow-sm">
+					<p class="text-sm font-bold text-gray-600 mb-3">📊 今月のカテゴリ別くらべっこ</p>
+					<SiblingCategoryChart rankings={data.monthlyRankingData.rankings} />
+					{#if data.monthlyRankingData.mostActive}
+						<p class="text-xs text-gray-500 mt-2">
+							🏆 今月もっとも活発: <strong>{data.monthlyRankingData.mostActive.childName}</strong>（{data.monthlyRankingData.mostActive.count}回）
+						</p>
+					{/if}
+				</div>
+			{/if}
 		</section>
 	{/if}
 </div>


### PR DESCRIPTION
## Summary
- ファミリープラン限定で「きょうだいランキング」を強化
- **週別活動数推移グラフ**: 過去4週分の折れ線チャート（SVG, ライブラリ不使用）
- **カテゴリ別比較チャート**: 5カテゴリのバーチャート（きょうだい横並び比較）
- レポートページ下部に統合（ランキング有効 + 2人以上の家庭のみ表示）
- `getRankingTrend()` サービス関数で過去N週のデータ取得

## Test plan
- [x] `npx vitest run` → 2163 tests passed
- [x] `npx svelte-check` → 0 errors (stripe除く)
- [ ] CI 全通過
- [ ] ファミリープランでグラフ表示、フリー/スタンダードでは非表示

closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)