### PR TITLE
fix: #389 OGP URLをwww統一 + canonicalタグ追加

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -8,7 +8,7 @@
 <meta property="og:title" content="がんばりクエスト — 「やりなさい」を「やりたい！」に変える">
 <meta property="og:description" content="お子さまの毎日のがんばりをRPG風の冒険に変える家庭向けWebアプリ。ポイント、レベルアップ、称号で「自分から動く力」を育てます。">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://ganbari-quest.com">
+<meta property="og:url" content="https://www.ganbari-quest.com/">
 <meta property="og:image" content="https://www.ganbari-quest.com/ogp.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -17,6 +17,7 @@
 <meta name="twitter:title" content="がんばりクエスト — 「やりなさい」を「やりたい！」に変える">
 <meta name="twitter:description" content="お子さまの毎日のがんばりをRPG風の冒険に変える家庭向けWebアプリ。ポイント、レベルアップ、称号で「自分から動く力」を育てます。">
 <meta name="twitter:image" content="https://www.ganbari-quest.com/ogp.png">
+<link rel="canonical" href="https://www.ganbari-quest.com/">
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
 <link rel="stylesheet" href="shared.css">

--- a/site/pamphlet.html
+++ b/site/pamphlet.html
@@ -4,6 +4,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>がんばりクエスト パンフレット</title>
+<meta property="og:title" content="がんばりクエスト パンフレット">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.ganbari-quest.com/pamphlet.html">
+<meta property="og:image" content="https://www.ganbari-quest.com/ogp.png">
+<link rel="canonical" href="https://www.ganbari-quest.com/pamphlet.html">
 <style>
 /* === Reset & Variables === */
 *{margin:0;padding:0;box-sizing:border-box}

--- a/site/pricing.html
+++ b/site/pricing.html
@@ -10,6 +10,7 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.ganbari-quest.com/pricing.html">
 <meta property="og:image" content="https://www.ganbari-quest.com/ogp.png">
+<link rel="canonical" href="https://www.ganbari-quest.com/pricing.html">
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
 <style>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -5,6 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>プライバシーポリシー - がんばりクエスト</title>
 <meta name="robots" content="noindex">
+<meta property="og:title" content="プライバシーポリシー - がんばりクエスト">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.ganbari-quest.com/privacy.html">
+<meta property="og:image" content="https://www.ganbari-quest.com/ogp.png">
+<link rel="canonical" href="https://www.ganbari-quest.com/privacy.html">
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
 <link rel="stylesheet" href="shared.css">

--- a/site/sla.html
+++ b/site/sla.html
@@ -5,6 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>サービスレベル合意（SLA） - がんばりクエスト</title>
 <meta name="robots" content="noindex">
+<meta property="og:title" content="サービスレベル合意（SLA） - がんばりクエスト">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.ganbari-quest.com/sla.html">
+<meta property="og:image" content="https://www.ganbari-quest.com/ogp.png">
+<link rel="canonical" href="https://www.ganbari-quest.com/sla.html">
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
 <link rel="stylesheet" href="shared.css">

--- a/site/terms.html
+++ b/site/terms.html
@@ -5,6 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>利用規約 - がんばりクエスト</title>
 <meta name="robots" content="noindex">
+<meta property="og:title" content="利用規約 - がんばりクエスト">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.ganbari-quest.com/terms.html">
+<meta property="og:image" content="https://www.ganbari-quest.com/ogp.png">
+<link rel="canonical" href="https://www.ganbari-quest.com/terms.html">
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
 <link rel="stylesheet" href="shared.css">

--- a/site/tokushoho.html
+++ b/site/tokushoho.html
@@ -5,6 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>特定商取引法に基づく表記 - がんばりクエスト</title>
 <meta name="robots" content="noindex">
+<meta property="og:title" content="特定商取引法に基づく表記 - がんばりクエスト">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://www.ganbari-quest.com/tokushoho.html">
+<meta property="og:image" content="https://www.ganbari-quest.com/ogp.png">
+<link rel="canonical" href="https://www.ganbari-quest.com/tokushoho.html">
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
 <link rel="stylesheet" href="shared.css">


### PR DESCRIPTION
closes #389

## Summary
- `site/index.html` の `og:url` を `https://www.ganbari-quest.com/` に統一（www なし → www あり）
- 全7ページ（index, pricing, terms, privacy, sla, tokushoho, pamphlet）に `<link rel="canonical">` を追加
- OGPタグ未設定だった5ページ（terms, privacy, sla, tokushoho, pamphlet）に `og:title` / `og:type` / `og:url` / `og:image` を追加

## Test plan
- [ ] 各ページのHTMLソースで `og:url` が `https://www.ganbari-quest.com/` で統一されていることを確認
- [ ] 各ページに `<link rel="canonical">` が正しいURLで設定されていることを確認
- [ ] OGPバリデーター等でメタタグが正しく読み取れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)