### PR TITLE
fix: #405 LP上のDiscord公開リンクを方針に合わせて修正

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -672,6 +672,11 @@
         <a href="https://ganbari-quest.com/demo" class="btn btn-outline" style="margin-top:12px">デモを試す</a>
       </div>
     </div>
+    <p style="text-align:center;margin-top:32px;font-size:.85rem;color:var(--gray-500);">
+      &#x1F4AC; あなたの体験談もお待ちしています &#8212;
+      <a href="https://ganbari-quest.com/demo">まずはデモで試してみる</a> /
+      <a href="mailto:ganbari.quest.support@gmail.com">メールで声を聞かせてください</a>
+    </p>
   </div>
 </section>
 
@@ -839,7 +844,6 @@
       <h4>リンク</h4>
       <a href="pricing.html">料金プラン</a>
       <a href="https://github.com/Takenori-Kusaka/ganbari-quest">GitHub</a>
-      <a href="https://discord.gg/5pWkf4Z5">Discordコミュニティ</a>
       <a href="https://github.com/sponsors/Takenori-Kusaka">Sponsor</a>
       <a href="https://ganbari-quest.com/auth/login">ログイン</a>
     </div>

--- a/site/pamphlet.html
+++ b/site/pamphlet.html
@@ -736,7 +736,6 @@ body{font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN','Noto Sans JP',syst
         <h4>お問い合わせ・コミュニティ</h4>
         <a href="mailto:ganbari.quest.support@gmail.com">&#x2709;&#xFE0F; メール: ganbari.quest.support@gmail.com</a>
         <a href="https://github.com/Takenori-Kusaka/ganbari-quest">&#x1F4E6; GitHub: Takenori-Kusaka/ganbari-quest</a>
-        <span>&#x2709;&#xFE0F; support@ganbari-quest.com</span>
       </div>
     </div>
     <hr class="footer-divider">

--- a/site/pamphlet.html
+++ b/site/pamphlet.html
@@ -648,7 +648,7 @@ body{font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN','Noto Sans JP',syst
           <li><span class="check">&#x2713;</span>高度な成長分析</li>
           <li><span class="check">&#x2713;</span>カスタムチャレンジ作成</li>
           <li><span class="check">&#x2713;</span>月次レポート</li>
-          <li><span class="check">&#x2713;</span>Discordサポート</li>
+          <li><span class="check">&#x2713;</span>Discordコミュニティ参加</li>
           <li><span class="cross">&#x2013;</span>複数保護者</li>
         </ul>
       </div>
@@ -734,7 +734,7 @@ body{font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN','Noto Sans JP',syst
       </div>
       <div class="footer-contact">
         <h4>お問い合わせ・コミュニティ</h4>
-        <a href="https://discord.gg/5pWkf4Z5">&#x1F4AC; Discord: discord.gg/5pWkf4Z5</a>
+        <a href="mailto:ganbari.quest.support@gmail.com">&#x2709;&#xFE0F; メール: ganbari.quest.support@gmail.com</a>
         <a href="https://github.com/Takenori-Kusaka/ganbari-quest">&#x1F4E6; GitHub: Takenori-Kusaka/ganbari-quest</a>
         <span>&#x2709;&#xFE0F; support@ganbari-quest.com</span>
       </div>

--- a/site/pricing.html
+++ b/site/pricing.html
@@ -155,7 +155,7 @@
           <li>活動バランスの見える化</li>
           <li>データエクスポート（JSON）</li>
           <li>1年間の履歴保持</li>
-          <li>Discordサポート</li>
+          <li>Discordコミュニティ参加</li>
         </ul>
       </div>
 
@@ -234,8 +234,8 @@
         <tr><td>データインポート</td><td class="dash">&#8212;</td><td class="check">&#10003;</td><td class="check">&#10003;</td></tr>
 
         <tr class="cat-row"><td colspan="4">サポート</td></tr>
-        <tr><td>Discordコミュニティ</td><td class="check">&#10003;</td><td class="check">&#10003;</td><td class="check">&#10003;</td></tr>
-        <tr><td>Discordサポート</td><td class="dash">&#8212;</td><td class="check">&#10003;</td><td class="check">&#10003;</td></tr>
+        <tr><td>メール・GitHub Issuesサポート</td><td class="check">&#10003;</td><td class="check">&#10003;</td><td class="check">&#10003;</td></tr>
+        <tr><td>Discordコミュニティ</td><td class="dash">&#8212;</td><td class="check">&#10003;</td><td class="check">&#10003;</td></tr>
         <tr><td>Discordサポート（優先対応）</td><td class="dash">&#8212;</td><td class="dash">&#8212;</td><td class="check">&#10003;</td></tr>
       </tbody>
     </table>
@@ -336,7 +336,6 @@
       <h4>リンク</h4>
       <a href="index.html">ホーム</a>
       <a href="https://github.com/Takenori-Kusaka/ganbari-quest">GitHub</a>
-      <a href="https://discord.gg/5pWkf4Z5">Discordコミュニティ</a>
       <a href="https://ganbari-quest.com/auth/login">ログイン</a>
     </div>
     <div class="footer-links">

--- a/site/pricing.html
+++ b/site/pricing.html
@@ -173,7 +173,7 @@
           <li>きょうだいランキング</li>
           <li>月次比較レポート</li>
           <li>無制限の履歴保持</li>
-          <li>Discordサポート（優先対応）</li>
+          <li>Discordコミュニティ（優先対応）</li>
         </ul>
       </div>
 
@@ -236,7 +236,7 @@
         <tr class="cat-row"><td colspan="4">サポート</td></tr>
         <tr><td>メール・GitHub Issuesサポート</td><td class="check">&#10003;</td><td class="check">&#10003;</td><td class="check">&#10003;</td></tr>
         <tr><td>Discordコミュニティ</td><td class="dash">&#8212;</td><td class="check">&#10003;</td><td class="check">&#10003;</td></tr>
-        <tr><td>Discordサポート（優先対応）</td><td class="dash">&#8212;</td><td class="dash">&#8212;</td><td class="check">&#10003;</td></tr>
+        <tr><td>Discordコミュニティ（優先対応）</td><td class="dash">&#8212;</td><td class="dash">&#8212;</td><td class="check">&#10003;</td></tr>
       </tbody>
     </table>
     </div>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -165,7 +165,7 @@ body{line-height:1.8;background:var(--gray-50)}
     <p>個人情報の取扱いに関するお問い合わせは、以下までご連絡ください。</p>
     <div class="contact">
       <p>がんばりクエスト運営者</p>
-      <p>お問い合わせ: <a href="https://github.com/Takenori-Kusaka/ganbari-quest/issues">GitHub Issues</a> / <a href="https://discord.gg/5pWkf4Z5">Discordコミュニティ</a></p>
+      <p>お問い合わせ: <a href="https://github.com/Takenori-Kusaka/ganbari-quest/issues">GitHub Issues</a> / <a href="mailto:ganbari.quest.support@gmail.com">メール</a></p>
     </div>
   </section>
 

--- a/site/sla.html
+++ b/site/sla.html
@@ -104,7 +104,7 @@ body{line-height:1.8;background:var(--gray-50)}
 
   <section>
     <h2>第6条（サポート対応）</h2>
-    <p>お問い合わせは<a href="https://github.com/Takenori-Kusaka/ganbari-quest/issues">GitHub Issues</a>または<a href="https://discord.gg/5pWkf4Z5">Discordコミュニティ</a>にて24時間受け付けています。初回応答は48時間以内（営業日ベース）を目標としています。対応言語は日本語です。</p>
+    <p>お問い合わせは<a href="https://github.com/Takenori-Kusaka/ganbari-quest/issues">GitHub Issues</a>または<a href="mailto:ganbari.quest.support@gmail.com">メール</a>にて24時間受け付けています。初回応答は48時間以内（営業日ベース）を目標としています。対応言語は日本語です。</p>
     <p>個人運営のため、応答が遅れる場合があります。ご理解をお願いいたします。</p>
   </section>
 

--- a/site/terms.html
+++ b/site/terms.html
@@ -182,7 +182,7 @@ body{line-height:1.8;background:var(--gray-50)}
 
   <section>
     <h2>第15条（お問い合わせ）</h2>
-    <p>本規約に関するお問い合わせは、<a href="https://github.com/Takenori-Kusaka/ganbari-quest/issues">GitHubのIssuesページ</a>または<a href="https://discord.gg/5pWkf4Z5">Discordコミュニティ</a>よりご連絡ください。</p>
+    <p>本規約に関するお問い合わせは、<a href="https://github.com/Takenori-Kusaka/ganbari-quest/issues">GitHubのIssuesページ</a>または<a href="mailto:ganbari.quest.support@gmail.com">メール</a>よりご連絡ください。</p>
   </section>
 
   <div class="effective">


### PR DESCRIPTION
## Summary
- LP全体（index.html, pricing.html, pamphlet.html, privacy.html, sla.html, terms.html）からDiscord招待リンク（`discord.gg/5pWkf4Z5`）を削除
- お問い合わせ先をメール（ganbari.quest.support@gmail.com）およびGitHub Issuesに統一
- pricing比較表でDiscordコミュニティをフリープランから除外し、有料プラン（スタンダード以上）限定に修正
- プラン機能説明のテキストは「Discordコミュニティ参加」として残し（リンクなし）、契約後にアプリ内からアクセスする方針を反映

## 変更ファイル（6ファイル）
| ファイル | 変更内容 |
|---------|---------|
| `site/index.html` | Social proofセクションのDiscordリンク→メール、フッターからDiscordリンク削除 |
| `site/pricing.html` | フッターからDiscordリンク削除、比較表修正（フリープランDiscord除外）、メールサポート行追加 |
| `site/pamphlet.html` | フッター連絡先をメールに変更、プラン機能表記を「Discordコミュニティ参加」に統一 |
| `site/privacy.html` | お問い合わせDiscordリンク→メール |
| `site/sla.html` | お問い合わせDiscordリンク→メール |
| `site/terms.html` | お問い合わせDiscordリンク→メール |

## Test plan
- [ ] LP全ページで `discord.gg` の招待リンクが残っていないことを確認
- [ ] フッター・お問い合わせセクションのメールリンクが正しく機能すること
- [ ] pricing比較表でDiscordコミュニティがフリープランに含まれていないこと

closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)