### PR TITLE
fix: #402 ライトボックスでcurrentSrcを使用しPC版画像を正しく表示

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -428,7 +428,7 @@
       </div>
       <div class="feature-card">
         <div class="feature-screenshot">
-          <picture><source srcset="screenshots/feature-radar-chart-desktop.webp" media="(min-width:1024px)" type="image/webp"><source srcset="screenshots/feature-radar-chart.webp" type="image/webp"><img src="screenshots/feature-radar-chart.webp" alt="5軸の成長レーダーチャート" width="390" height="844" loading="lazy" data-lightbox></picture>
+          <picture><source srcset="screenshots/feature-radar-chart-desktop.webp" media="(min-width:1024px)" type="image/webp"><source srcset="screenshots/feature-radar-chart.webp" type="image/webp"><img src="screenshots/feature-radar-chart.webp" alt="5つのチカラチャート" width="390" height="844" loading="lazy" data-lightbox></picture>
         </div>
         <div class="feature-icon">&#x1F4CA;</div>
         <h3>5つのチカラチャート</h3>
@@ -918,7 +918,7 @@
   }
 
   document.querySelectorAll('img[data-lightbox]').forEach((img)=> {
-    img.addEventListener('click',function(){open(this.src,this.alt)});
+    img.addEventListener('click',function(){open(this.currentSrc||this.src,this.alt)});
   });
   overlay.addEventListener('click',(e)=> {if(e.target===overlay)close()});
   closeBtn.addEventListener('click',close);


### PR DESCRIPTION
## Summary
- LPライトボックスのクリックハンドラで `this.src` を `this.currentSrc || this.src` に変更
- `<picture>` 要素内で `<source>` によるデスクトップ版画像が表示されている場合、`currentSrc` が実際に表示中のURLを返すため、PC版で正しい画像が拡大表示される
- `currentSrc` 未対応ブラウザへのフォールバック（`|| this.src`）も維持

closes #402

## Test plan
- [ ] PC版ブラウザでLPスクリーンショットをクリックし、デスクトップ版画像が拡大表示されることを確認
- [ ] モバイル版ブラウザでクリック拡大が従来通り動作することを確認
- [ ] `<picture>` 要素を持たない通常の `<img>` でもライトボックスが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)