### PR TITLE
fix: #403 LP文言をペルソナに合わせて平易化

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -286,7 +286,7 @@
 <section class="section bg-white" id="pain">
   <div class="section-inner">
     <h2 class="section-title">こんな経験、ありませんか？</h2>
-    <p class="section-desc">毎日がんばっているのは、お子さまだけじゃない。あなたもです。</p>
+    <p class="section-desc">毎日の声かけ、本当に大変ですよね。</p>
     <div class="pain-grid">
       <div class="pain-card">
         <div class="pain-icon">&#x23F0;</div>
@@ -429,7 +429,7 @@
           <picture><source srcset="screenshots/feature-radar-chart-desktop.webp" media="(min-width:1024px)" type="image/webp"><source srcset="screenshots/feature-radar-chart.webp" type="image/webp"><img src="screenshots/feature-radar-chart.webp" alt="5軸の成長レーダーチャート" width="390" height="844" loading="lazy" data-lightbox></picture>
         </div>
         <div class="feature-icon">&#x1F4CA;</div>
-        <h3>成長レーダーチャート</h3>
+        <h3>5つのチカラチャート</h3>
         <div class="feature-benefit">&#x2192; 「すごいね」に根拠が生まれる</div>
         <p>5軸のレーダーチャートでお子さまの強みが一目瞭然。同年齢の目安と比較でき、親として自信を持って「がんばってるね」と褒められます。</p>
       </div>
@@ -481,7 +481,7 @@
         <div class="diff-solve">&#x2705; ポイントはお小遣いにも使えるが、レベルや称号など金銭以外の動機づけが中心。</div>
       </div>
       <div class="diff-card">
-        <h3>&#x1F4F1; 他のゲーミフィケーションアプリ</h3>
+        <h3>&#x1F4F1; 他の子育てアプリ</h3>
         <div class="diff-issue">&#x274C; 幼児には難しい。中高生には子供っぽい。1つの年齢層だけ。</div>
         <div class="diff-solve">&#x2705; 0歳から18歳まで、年齢に応じてUIが自動で変わる。きょうだいでずっと使える。</div>
       </div>
@@ -493,7 +493,7 @@
 <section class="section bg-gray" id="evolution">
   <div class="section-inner">
     <h2 class="section-title">シール帳の「いいところ」は、そのまま</h2>
-    <p class="section-desc">足りなかったところを、テクノロジーで補いました</p>
+    <p class="section-desc">足りなかったところを、がんばりクエストが補います</p>
     <div class="evo-grid">
       <div class="evo-card evo-sticker">
         <h3>&#x2B50; シール帳</h3>


### PR DESCRIPTION
## Summary
- LP（`site/index.html`）の4箇所で、ターゲットペルソナ（30-40代の子育て中の保護者）に伝わりにくい用語・表現を平易化
- 「レーダーチャート」「ゲーミフィケーション」「テクノロジー」等の専門用語を排除

## Changes
| 箇所 | Before | After |
|------|--------|-------|
| Pain scenes (L289) | 毎日がんばっているのは、お子さまだけじゃない。あなたもです。 | 毎日の声かけ、本当に大変ですよね。 |
| Feature card (L432) | 成長レーダーチャート | 5つのチカラチャート |
| Diff section (L484) | 他のゲーミフィケーションアプリ | 他の子育てアプリ |
| Evolution section (L496) | 足りなかったところを、テクノロジーで補いました | 足りなかったところを、がんばりクエストが補います |

closes #403

## Test plan
- [ ] LPをブラウザで開き、4箇所の文言が正しく表示されることを確認
- [ ] 文脈として自然に読めることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)