### PR TITLE
fix: #325 イベントバナーからカウントダウン表示を削除

### DIFF
--- a/src/lib/ui/components/ActivityCard.svelte
+++ b/src/lib/ui/components/ActivityCard.svelte
@@ -22,6 +22,7 @@ interface Props {
 	isPinned?: boolean;
 	frozen?: boolean;
 	triggerHint?: string | null;
+	eventBadge?: string | null;
 	onclick?: () => void;
 	onlongpress?: () => void;
 }
@@ -39,6 +40,7 @@ let {
 	isPinned = false,
 	frozen = false,
 	triggerHint,
+	eventBadge = null,
 	onclick,
 	onlongpress,
 }: Props = $props();
@@ -126,6 +128,12 @@ function handleClick(e: Event) {
 		</div>
 	{/if}
 
+	{#if eventBadge && !completed}
+		<div class="event-badge" aria-label="イベントちゅう">
+			<span class="event-badge__icon">{eventBadge}</span>
+		</div>
+	{/if}
+
 	<CompoundIcon {icon} size={iconSize} faded={completed} />
 	<span class="font-bold leading-tight text-center line-clamp-2 {completed ? 'opacity-40' : ''}" style:font-size={textSize}>{name}</span>
 	{#if triggerHint && !completed}
@@ -210,6 +218,28 @@ function handleClick(e: Event) {
 	}
 	.card-mission__sparkle::before { top: -4px; left: -4px; animation-delay: 0s; }
 	.card-mission__sparkle::after  { top: -4px; right: -4px; animation-delay: 0.5s; }
+
+	/* Event badge */
+	.event-badge {
+		position: absolute;
+		bottom: -2px;
+		right: -2px;
+		z-index: 10;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 18px;
+		height: 18px;
+		border-radius: var(--radius-full, 9999px);
+		background: var(--color-surface-warm, #fef3c7);
+		border: 1.5px solid var(--color-border-warm, rgba(251, 191, 36, 0.4));
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+	}
+
+	.event-badge__icon {
+		font-size: 0.6rem;
+		line-height: 1;
+	}
 
 	/* Frozen card (#0266) */
 	:global(.card-frozen) {

--- a/src/lib/ui/components/ActivityCard.svelte
+++ b/src/lib/ui/components/ActivityCard.svelte
@@ -129,7 +129,7 @@ function handleClick(e: Event) {
 	{/if}
 
 	{#if eventBadge && !completed}
-		<div class="event-badge" aria-label="イベントちゅう">
+		<div class="event-badge" aria-hidden="true">
 			<span class="event-badge__icon">{eventBadge}</span>
 		</div>
 	{/if}

--- a/src/lib/ui/components/EventBanner.svelte
+++ b/src/lib/ui/components/EventBanner.svelte
@@ -20,12 +20,6 @@ interface Props {
 
 let { events }: Props = $props();
 
-function remainingDays(endDate: string): number {
-	const end = new Date(`${endDate}T23:59:59`);
-	const now = new Date();
-	return Math.max(0, Math.ceil((end.getTime() - now.getTime()) / 86400000));
-}
-
 function getMissionProgress(event: EventData): { current: number; target: number } | null {
 	if (!event.missionConfig) return null;
 	try {
@@ -81,13 +75,6 @@ function getMissionProgress(event: EventData): { current: number; target: number
 								</span>
 							</div>
 						{/if}
-						{#if remainingDays(event.endDate) <= 3}
-							<span class="event-banner__countdown event-banner__countdown--urgent">
-								あと{remainingDays(event.endDate)}にち！
-							</span>
-						{:else}
-							<span class="event-banner__countdown">あと{remainingDays(event.endDate)}にち</span>
-						{/if}
 					{/if}
 				</div>
 			</div>
@@ -109,8 +96,8 @@ function getMissionProgress(event: EventData): { current: number; target: number
 		gap: 8px;
 		padding: 8px 12px;
 		border-radius: var(--radius-md, 12px);
-		background: linear-gradient(135deg, #fef3c7, #fde68a);
-		border: 1px solid #fbbf2433;
+		background: var(--color-surface-warm, linear-gradient(135deg, #fef3c7, #fde68a));
+		border: 1px solid var(--color-border-warm, rgba(251, 191, 36, 0.2));
 	}
 
 	.event-banner__icon {
@@ -126,13 +113,13 @@ function getMissionProgress(event: EventData): { current: number; target: number
 	.event-banner__name {
 		font-size: 0.75rem;
 		font-weight: 700;
-		color: #92400e;
+		color: var(--color-text-warm, #92400e);
 		display: block;
 	}
 
 	.event-banner__desc {
 		font-size: 0.625rem;
-		color: #a16207;
+		color: var(--color-text-warm-muted, #a16207);
 		display: block;
 		white-space: nowrap;
 		overflow: hidden;
@@ -141,13 +128,6 @@ function getMissionProgress(event: EventData): { current: number; target: number
 
 	.event-banner__meta {
 		flex-shrink: 0;
-	}
-
-	.event-banner__countdown {
-		font-size: 0.625rem;
-		font-weight: 600;
-		color: #92400e;
-		white-space: nowrap;
 	}
 
 	.event-banner__mission {
@@ -167,26 +147,26 @@ function getMissionProgress(event: EventData): { current: number; target: number
 
 	.event-banner__progress-fill {
 		height: 100%;
-		background: #f59e0b;
+		background: var(--color-warning, #f59e0b);
 		border-radius: 3px;
 		transition: width 0.3s ease;
 	}
 
 	.event-banner__progress-fill--complete {
-		background: #22c55e;
+		background: var(--color-success, #22c55e);
 	}
 
 	.event-banner__progress-text {
 		font-size: 0.5625rem;
 		font-weight: 700;
-		color: #92400e;
+		color: var(--color-text-warm, #92400e);
 		white-space: nowrap;
 	}
 
 	.event-banner__claim-btn {
 		padding: 2px 8px;
 		border-radius: 6px;
-		background: #f59e0b;
+		background: var(--color-warning, #f59e0b);
 		color: white;
 		font-size: 0.625rem;
 		font-weight: 700;
@@ -197,28 +177,18 @@ function getMissionProgress(event: EventData): { current: number; target: number
 	}
 
 	.event-banner__claim-btn:hover {
-		background: #d97706;
+		background: var(--color-warning-hover, #d97706);
 	}
 
 	.event-banner__claimed {
 		font-size: 0.5625rem;
 		font-weight: 600;
-		color: #16a34a;
+		color: var(--color-success, #16a34a);
 		white-space: nowrap;
 	}
 
 	@keyframes pulse-claim {
 		0%, 100% { transform: scale(1); }
 		50% { transform: scale(1.05); }
-	}
-
-	.event-banner__countdown--urgent {
-		color: #dc2626;
-		animation: pulse-urgent 1.5s ease-in-out infinite;
-	}
-
-	@keyframes pulse-urgent {
-		0%, 100% { opacity: 1; }
-		50% { opacity: 0.6; }
 	}
 </style>

--- a/src/routes/(child)/kinder/home/+page.svelte
+++ b/src/routes/(child)/kinder/home/+page.svelte
@@ -201,7 +201,9 @@ function isCompleted(activity: { id: number; dailyLimit: number | null }): boole
 
 // Event badge: show first active event's icon on activity cards (#325)
 const activeEventBadge = $derived(
-	data.activeEvents && data.activeEvents.length > 0 ? (data.activeEvents[0]?.bannerIcon ?? null) : null,
+	data.activeEvents && data.activeEvents.length > 0
+		? (data.activeEvents[0]?.bannerIcon ?? null)
+		: null,
 );
 
 // Group activities by category

--- a/src/routes/(child)/kinder/home/+page.svelte
+++ b/src/routes/(child)/kinder/home/+page.svelte
@@ -199,6 +199,11 @@ function isCompleted(activity: { id: number; dailyLimit: number | null }): boole
 	return getCount(activity.id) >= limit;
 }
 
+// Event badge: show first active event's icon on activity cards (#325)
+const activeEventBadge = $derived(
+	data.activeEvents && data.activeEvents.length > 0 ? (data.activeEvents[0]?.bannerIcon ?? null) : null,
+);
+
 // Group activities by category
 const activitiesByCategory = $derived(
 	CATEGORY_DEFS.map((catDef) => ({
@@ -534,6 +539,7 @@ $effect(() => {
 					isPinned={activity.isPinned}
 					frozen={!data.isPremium && activity.source === 'custom'}
 					triggerHint={activity.triggerHint}
+					eventBadge={activeEventBadge}
 					onclick={() => handleActivityTap(activity)}
 					onlongpress={() => handleActivityLongPress(activity)}
 				/>
@@ -551,6 +557,7 @@ $effect(() => {
 					isPinned={activity.isPinned}
 					frozen={!data.isPremium && activity.source === 'custom'}
 					triggerHint={activity.triggerHint}
+					eventBadge={activeEventBadge}
 					onclick={() => handleActivityTap(activity)}
 					onlongpress={() => handleActivityLongPress(activity)}
 				/>


### PR DESCRIPTION
## Summary
- イベントバナーからカウントダウン（残りX日）表示を完全削除（子供へのプレッシャー排除）
- イベント期間中は活動カード右下に小さなイベントバッジ（イベントアイコン）を表示
- イベント情報は親管理画面（季節コンテンツセクション）で引き続き確認可能

## Changes
- `EventBanner.svelte`: `remainingDays()`関数・カウントダウンUI・関連CSSを削除。hex直書きをCSS変数に置換
- `ActivityCard.svelte`: `eventBadge` prop追加。イベント期間中にカード右下に小さなバッジを表示
- `kinder/home/+page.svelte`: activeEventsからバッジアイコンを取得しActivityCardに渡す

## Test plan
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run` — 2171 tests passed
- [ ] `npx playwright test` — E2E全通過確認
- [ ] イベント期間中にカウントダウンが表示されないこと
- [ ] 活動カードにイベントバッジが表示されること
- [ ] イベント期間外にはバッジが表示されないこと

closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)