### PR TITLE
fix: #411 プラン説明の「ゲーム体験」表現を具体化

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -721,7 +721,7 @@
 <section class="section bg-white" id="pricing">
   <div class="section-inner">
     <h2 class="section-title">料金プラン</h2>
-    <p class="section-desc">基本無料ではじめられます。ゲーム体験はすべてのプランで制限なし。</p>
+    <p class="section-desc">基本無料ではじめられます。ポイント・レベルアップ・シールガチャなどの冒険体験はすべてのプランで制限なし。</p>
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:24px;max-width:900px;margin:0 auto 32px">
 
       <div style="background:#fff;border:1px solid var(--gray-300);border-radius:var(--radius);padding:28px 24px;text-align:center">

--- a/site/pricing.html
+++ b/site/pricing.html
@@ -6,7 +6,7 @@
 <title>料金プラン - がんばりクエスト</title>
 <meta name="description" content="がんばりクエストの料金プラン。基本無料で始められます。スタンダード月額500円、ファミリー月額780円。すべてのプランに7日間の無料トライアル付き。">
 <meta property="og:title" content="料金プラン - がんばりクエスト">
-<meta property="og:description" content="基本無料で始められます。お子さまのゲーム体験は無料プランでも一切制限ありません。">
+<meta property="og:description" content="基本無料で始められます。お子さまのポイント・レベルアップ・シールガチャなどの冒険体験は無料プランでも一切制限ありません。">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.ganbari-quest.com/pricing.html">
 <meta property="og:image" content="https://www.ganbari-quest.com/ogp.png">


### PR DESCRIPTION
## Summary
- LP料金プランセクション(`site/index.html`)の「ゲーム体験」を「ポイント・レベルアップ・シールガチャなどの冒険体験」に具体化
- 料金ページ(`site/pricing.html`)のog:descriptionメタタグも同様に修正
- 無料プランで制限なく利用できる機能が曖昧だった問題を解消

closes #411

## Test plan
- [ ] `site/index.html` の料金プランセクションで修正後のテキストが表示されることを確認
- [ ] `site/pricing.html` のog:descriptionが更新されていることを確認
- [ ] 既存の pricing.html 内の他のテキスト（FAQ等）は「冒険体験」表現で統一されていることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)