### PR TITLE
fix: #438 #440 #441 デモ画面の軽微な不整合3件を修正

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -13,8 +13,8 @@
 		<meta property="og:type" content="website" />
 		<meta property="og:image" content="/icons/icon-512.png" />
 		<meta property="og:locale" content="ja_JP" />
-		<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+		<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=2" />
+		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=2" />
 		<link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
 		<link rel="manifest" href="/manifest.webmanifest" />
 		%sveltekit.head%

--- a/src/routes/demo/(parent)/admin/events/+page.server.ts
+++ b/src/routes/demo/(parent)/admin/events/+page.server.ts
@@ -11,7 +11,7 @@ export const load: PageServerLoad = async () => {
 			startDate: '2026-04-01',
 			endDate: '2026-04-30',
 			bannerIcon: '🌸',
-			bannerColor: 'linear-gradient(135deg, #fef3c7, #fde68a)',
+			bannerColor: null,
 			rewardConfig: '{"points":50,"title":"スタートダッシュ達成！"}',
 			isActive: 1,
 		},

--- a/src/routes/demo/(parent)/admin/messages/+page.server.ts
+++ b/src/routes/demo/(parent)/admin/messages/+page.server.ts
@@ -4,15 +4,14 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async () => {
 	const adminData = getDemoAdminData();
 
+	// sibling-cheer-service.ts の CHEER_STAMPS と一致させる（6種）
 	const stamps = [
-		{ code: 'great', icon: '👏', label: 'すごい！' },
-		{ code: 'love', icon: '❤️', label: 'だいすき' },
-		{ code: 'cheer', icon: '📣', label: 'がんばれ！' },
-		{ code: 'star', icon: '⭐', label: 'きらきら' },
-		{ code: 'muscle', icon: '💪', label: 'つよい！' },
-		{ code: 'smile', icon: '😊', label: 'にこにこ' },
-		{ code: 'rainbow', icon: '🌈', label: 'すてき！' },
-		{ code: 'crown', icon: '👑', label: 'チャンピオン' },
+		{ code: 'ganbare', icon: '💪', label: 'がんばって！' },
+		{ code: 'sugoi', icon: '⭐', label: 'すごいね！' },
+		{ code: 'issho', icon: '🤝', label: 'いっしょにがんばろう！' },
+		{ code: 'omedeto', icon: '🎉', label: 'おめでとう！' },
+		{ code: 'nice', icon: '👍', label: 'ナイス！' },
+		{ code: 'fight', icon: '🔥', label: 'ファイト！' },
 	];
 
 	const children = adminData.children.map((child) => ({
@@ -20,9 +19,9 @@ export const load: PageServerLoad = async () => {
 		nickname: child.nickname,
 		recentMessages: [
 			{
-				icon: '👏',
+				icon: '⭐',
 				messageType: 'stamp' as const,
-				stampCode: 'great',
+				stampCode: 'sugoi',
 				body: null,
 				sentAt: '2026-03-27T08:30:00.000Z',
 				shownAt: '2026-03-27T09:00:00.000Z',


### PR DESCRIPTION
## Summary
- **#438**: デモおうえんスタンプ8種 → `sibling-cheer-service.ts` の実装に合わせて6種に修正。recentMessages のスタンプコードも有効な値に更新
- **#440**: デモイベントページの `bannerColor` から hex カラー直書き (`linear-gradient(135deg, #fef3c7, #fde68a)`) を除去。`null` にしてコンポーネントの CSS デフォルトグラデーションにフォールバック
- **#441**: favicon の `<link>` タグにキャッシュバスティング用クエリパラメータ `?v=2` を付与。ブラウザキャッシュで古い favicon が表示される問題に対応

closes #438, closes #440, closes #441

## Test plan
- [ ] デモおうえんメッセージ画面でスタンプが6種表示されることを確認
- [ ] デモイベント画面のバナーがデフォルトグラデーションで表示されることを確認
- [ ] ブラウザのハードリロード後に正しい favicon が表示されることを確認
- [ ] `npx vitest run` で全ユニットテスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)