### PR TITLE
fix: #433 #435 #436 #439 デモ画面の4件修正

### DIFF
--- a/src/routes/demo/(child)/[mode]/achievements/+page.server.ts
+++ b/src/routes/demo/(child)/[mode]/achievements/+page.server.ts
@@ -1,8 +1,9 @@
+import { todayDateJST, toJSTDateString } from '$lib/domain/date-utils';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	const today = new Date().toISOString().slice(0, 10);
-	const weekAgo = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
+	const today = todayDateJST();
+	const weekAgo = toJSTDateString(new Date(Date.now() - 7 * 86400000));
 
 	const challenges = [
 		{

--- a/src/routes/demo/(child)/[mode]/achievements/+page.server.ts
+++ b/src/routes/demo/(child)/[mode]/achievements/+page.server.ts
@@ -1,5 +1,26 @@
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	return { challenges: [] };
+	const today = new Date().toISOString().slice(0, 10);
+	const weekAgo = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
+
+	const challenges = [
+		{
+			id: 101,
+			title: 'みんなで今週5かいうんどう！',
+			description: '家族みんなでうんどう週間チャレンジ',
+			challengeType: 'cooperative',
+			periodType: 'weekly',
+			startDate: weekAgo,
+			endDate: today,
+			status: 'completed',
+			targetValue: 5,
+			currentValue: 5,
+			completed: true,
+			rewardPoints: 150,
+			rewardMessage: 'チームワークばっちり！',
+		},
+	];
+
+	return { challenges };
 };

--- a/src/routes/demo/(child)/[mode]/achievements/+page.svelte
+++ b/src/routes/demo/(child)/[mode]/achievements/+page.svelte
@@ -1,9 +1,50 @@
+<script lang="ts">
+let { data } = $props();
+</script>
+
 <svelte:head>
 	<title>チャレンジきろく - がんばりクエスト デモ</title>
 </svelte:head>
 
-<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
-	<span class="text-5xl mb-4">📋</span>
-	<p class="text-lg font-bold mb-2">まだチャレンジきろくがないよ</p>
-	<p class="text-sm">チャレンジがはじまったら ここにきろくされるよ</p>
-</div>
+{#if data.challenges.length === 0}
+	<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
+		<span class="text-5xl mb-4">📋</span>
+		<p class="text-lg font-bold mb-2">まだチャレンジきろくがないよ</p>
+		<p class="text-sm">チャレンジがはじまったら ここにきろくされるよ</p>
+	</div>
+{:else}
+	<div class="px-[var(--sp-md)] space-y-4">
+		<h2 class="text-lg font-bold">🏅 チャレンジきろく</h2>
+
+		{#each data.challenges as challenge (challenge.id)}
+			<div class="rounded-xl border bg-white p-4 {challenge.completed ? 'border-green-200' : 'border-blue-200'}">
+				<h3 class="font-bold text-sm">
+					{challenge.title}
+					{#if challenge.completed}
+						<span class="ml-1 rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-bold text-green-700">クリア！</span>
+					{:else}
+						<span class="ml-1 rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-bold text-blue-700">ちょうせん中</span>
+					{/if}
+				</h3>
+				{#if challenge.description}
+					<p class="text-xs text-gray-600 mt-1">{challenge.description}</p>
+				{/if}
+				<div class="mt-2 flex items-center gap-2">
+					<div class="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+						<div
+							class="h-full rounded-full transition-all {challenge.completed ? 'bg-green-400' : 'bg-blue-400'}"
+							style:width="{Math.min(100, Math.round((challenge.currentValue / challenge.targetValue) * 100))}%"
+						></div>
+					</div>
+					<span class="text-[10px] text-gray-500">
+						{challenge.currentValue}/{challenge.targetValue}
+						{#if challenge.completed}✅{/if}
+					</span>
+				</div>
+				{#if challenge.completed && challenge.rewardMessage}
+					<p class="mt-2 text-xs text-green-600 font-medium">🎉 {challenge.rewardMessage} (+{challenge.rewardPoints}P)</p>
+				{/if}
+			</div>
+		{/each}
+	</div>
+{/if}

--- a/src/routes/demo/(parent)/admin/achievements/+page.server.ts
+++ b/src/routes/demo/(parent)/admin/achievements/+page.server.ts
@@ -1,9 +1,16 @@
+import { todayDateJST, toJSTDateString } from '$lib/domain/date-utils';
+import { DEMO_CHILDREN } from '$lib/server/demo/demo-data';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	const today = new Date().toISOString().slice(0, 10);
-	const weekAgo = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
-	const twoWeeksAgo = new Date(Date.now() - 14 * 86400000).toISOString().slice(0, 10);
+	const today = todayDateJST();
+	const weekAgo = toJSTDateString(new Date(Date.now() - 7 * 86400000));
+	const twoWeeksAgo = toJSTDateString(new Date(Date.now() - 14 * 86400000));
+
+	// biome-ignore lint/style/noNonNullAssertion: demo data — indices are guaranteed
+	const child1 = DEMO_CHILDREN[1]!; // たろう (5歳)
+	// biome-ignore lint/style/noNonNullAssertion: demo data — indices are guaranteed
+	const child2 = DEMO_CHILDREN[2]!; // さくら (8歳)
 
 	const challenges = [
 		{
@@ -24,7 +31,7 @@ export const load: PageServerLoad = async () => {
 				{
 					id: 101,
 					challengeId: 101,
-					childId: 1,
+					childId: child1.id,
 					currentValue: 5,
 					targetValue: 5,
 					completed: 1,
@@ -37,7 +44,7 @@ export const load: PageServerLoad = async () => {
 				{
 					id: 102,
 					challengeId: 101,
-					childId: 2,
+					childId: child2.id,
 					currentValue: 5,
 					targetValue: 5,
 					completed: 1,
@@ -52,8 +59,8 @@ export const load: PageServerLoad = async () => {
 		},
 		{
 			id: 102,
-			title: 'べんきょう10かいチャレンジ',
-			description: 'みんなの合計が10回になったらクリア',
+			title: 'べんきょう5かいチャレンジ',
+			description: 'みんなでべんきょう5回をめざそう',
 			challengeType: 'cooperative',
 			periodType: 'monthly',
 			startDate: twoWeeksAgo,
@@ -68,7 +75,7 @@ export const load: PageServerLoad = async () => {
 				{
 					id: 103,
 					challengeId: 102,
-					childId: 1,
+					childId: child1.id,
 					currentValue: 5,
 					targetValue: 5,
 					completed: 1,
@@ -81,7 +88,7 @@ export const load: PageServerLoad = async () => {
 				{
 					id: 104,
 					challengeId: 102,
-					childId: 2,
+					childId: child2.id,
 					currentValue: 5,
 					targetValue: 5,
 					completed: 1,
@@ -97,8 +104,8 @@ export const load: PageServerLoad = async () => {
 	];
 
 	const children = [
-		{ id: 1, nickname: 'ゆいちゃん', age: 5 },
-		{ id: 2, nickname: 'けんくん', age: 8 },
+		{ id: child1.id, nickname: child1.nickname, age: child1.age },
+		{ id: child2.id, nickname: child2.nickname, age: child2.age },
 	];
 
 	return { challenges, children };

--- a/src/routes/demo/(parent)/admin/achievements/+page.server.ts
+++ b/src/routes/demo/(parent)/admin/achievements/+page.server.ts
@@ -1,5 +1,105 @@
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	return { challenges: [] };
+	const today = new Date().toISOString().slice(0, 10);
+	const weekAgo = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
+	const twoWeeksAgo = new Date(Date.now() - 14 * 86400000).toISOString().slice(0, 10);
+
+	const challenges = [
+		{
+			id: 101,
+			title: 'みんなで今週5かいうんどう！',
+			description: '家族みんなでうんどう週間チャレンジ',
+			challengeType: 'cooperative',
+			periodType: 'weekly',
+			startDate: weekAgo,
+			endDate: today,
+			targetConfig: '{"metric":"count","baseTarget":5,"categoryId":1}',
+			rewardConfig: '{"points":150,"message":"チームワークばっちり！"}',
+			status: 'completed',
+			isActive: 0,
+			createdAt: weekAgo,
+			updatedAt: today,
+			progress: [
+				{
+					id: 101,
+					challengeId: 101,
+					childId: 1,
+					currentValue: 5,
+					targetValue: 5,
+					completed: 1,
+					completedAt: today,
+					rewardClaimed: 1,
+					rewardClaimedAt: today,
+					progressJson: null,
+					updatedAt: today,
+				},
+				{
+					id: 102,
+					challengeId: 101,
+					childId: 2,
+					currentValue: 5,
+					targetValue: 5,
+					completed: 1,
+					completedAt: today,
+					rewardClaimed: 1,
+					rewardClaimedAt: today,
+					progressJson: null,
+					updatedAt: today,
+				},
+			],
+			allCompleted: true,
+		},
+		{
+			id: 102,
+			title: 'べんきょう10かいチャレンジ',
+			description: 'みんなの合計が10回になったらクリア',
+			challengeType: 'cooperative',
+			periodType: 'monthly',
+			startDate: twoWeeksAgo,
+			endDate: weekAgo,
+			targetConfig: '{"metric":"count","baseTarget":5,"categoryId":2}',
+			rewardConfig: '{"points":200,"message":"がんばったね！"}',
+			status: 'completed',
+			isActive: 0,
+			createdAt: twoWeeksAgo,
+			updatedAt: weekAgo,
+			progress: [
+				{
+					id: 103,
+					challengeId: 102,
+					childId: 1,
+					currentValue: 5,
+					targetValue: 5,
+					completed: 1,
+					completedAt: weekAgo,
+					rewardClaimed: 1,
+					rewardClaimedAt: weekAgo,
+					progressJson: null,
+					updatedAt: weekAgo,
+				},
+				{
+					id: 104,
+					challengeId: 102,
+					childId: 2,
+					currentValue: 5,
+					targetValue: 5,
+					completed: 1,
+					completedAt: weekAgo,
+					rewardClaimed: 0,
+					rewardClaimedAt: null,
+					progressJson: null,
+					updatedAt: weekAgo,
+				},
+			],
+			allCompleted: true,
+		},
+	];
+
+	const children = [
+		{ id: 1, nickname: 'ゆいちゃん', age: 5 },
+		{ id: 2, nickname: 'けんくん', age: 8 },
+	];
+
+	return { challenges, children };
 };

--- a/src/routes/demo/(parent)/admin/achievements/+page.svelte
+++ b/src/routes/demo/(parent)/admin/achievements/+page.svelte
@@ -1,23 +1,115 @@
 <script lang="ts">
 import DemoBanner from '$lib/features/admin/components/DemoBanner.svelte';
 import DemoCta from '$lib/features/admin/components/DemoCta.svelte';
+import ProgressFill from '$lib/ui/components/ProgressFill.svelte';
+
+let { data } = $props();
+
+interface TargetConfig {
+	metric: string;
+	baseTarget: number;
+	categoryId?: number;
+}
+interface RewardConfig {
+	points: number;
+	message?: string;
+}
+
+function parseJSON<T>(json: string, fallback: T): T {
+	try {
+		return JSON.parse(json);
+	} catch {
+		return fallback;
+	}
+}
+
+function formatDate(d: string): string {
+	return d.replace(/-/g, '/');
+}
+
+const typeLabel = (t: string) => (t === 'cooperative' ? '協力' : '競争');
+const periodLabel = (t: string) => {
+	switch (t) {
+		case 'weekly':
+			return '週間';
+		case 'monthly':
+			return '月間';
+		default:
+			return 'カスタム';
+	}
+};
+
+const categories: Record<number, string> = {
+	1: 'うんどう',
+	2: 'べんきょう',
+	3: 'せいかつ',
+	4: 'こうりゅう',
+	5: 'そうぞう',
+};
 </script>
 
 <svelte:head>
-	<title>チャレンジ管理 - がんばりクエスト デモ</title>
+	<title>チャレンジ履歴（デモ） - がんばりクエスト</title>
 </svelte:head>
 
-<div class="space-y-6">
-	<DemoBanner />
+<DemoBanner />
 
-	<div class="text-center py-12 text-[var(--color-text-muted)]">
-		<span class="text-5xl mb-4 block">📋</span>
-		<p class="text-lg font-bold mb-2">チャレンジ管理</p>
-		<p class="text-sm">チャレンジ機能は今後リリース予定です</p>
-	</div>
+<div class="space-y-4">
+	<h2 class="text-lg font-bold">🏅 チャレンジ履歴</h2>
+	<p class="text-sm text-gray-500">過去に完了したチャレンジの記録です。</p>
+
+	{#each data.challenges as challenge (challenge.id)}
+		{@const target = parseJSON<TargetConfig>(challenge.targetConfig, { metric: 'count', baseTarget: 0 })}
+		{@const reward = parseJSON<RewardConfig>(challenge.rewardConfig, { points: 0 })}
+		<div class="rounded-xl border bg-white p-4 border-green-200">
+			<div class="flex-1">
+				<h3 class="font-bold text-sm">
+					{challenge.title}
+					{#if challenge.allCompleted}
+						<span class="ml-1 rounded bg-green-100 px-1.5 py-0.5 text-[10px] font-bold text-green-700">全員クリア！</span>
+					{/if}
+					<span class="ml-1 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-bold text-gray-500">完了</span>
+				</h3>
+				<p class="text-xs text-gray-500 mt-0.5">
+					{typeLabel(challenge.challengeType)} · {periodLabel(challenge.periodType)}
+					· {formatDate(challenge.startDate)} 〜 {formatDate(challenge.endDate)}
+					· 目標{target.baseTarget}回 · 報酬{reward.points}P
+					{#if target.categoryId}
+						· {categories[target.categoryId] ?? ''}
+					{/if}
+				</p>
+				{#if challenge.description}
+					<p class="text-xs text-gray-600 mt-1">{challenge.description}</p>
+				{/if}
+
+				{#if challenge.progress.length > 0}
+					<div class="mt-2 space-y-1">
+						{#each challenge.progress as prog}
+							{@const child = data.children.find((c: { id: number }) => c.id === prog.childId)}
+							<div class="flex items-center gap-2">
+								<span class="text-xs font-medium text-gray-700 w-16 truncate">
+									{child?.nickname ?? `#${prog.childId}`}
+								</span>
+								<div class="flex-1 h-2 bg-gray-100 rounded-full overflow-hidden">
+									<ProgressFill
+										pct={Math.min(100, Math.round((prog.currentValue / prog.targetValue) * 100))}
+										class="h-full rounded-full transition-all {prog.completed === 1 ? 'bg-green-400' : 'bg-blue-400'}"
+									/>
+								</div>
+								<span class="text-[10px] text-gray-500 w-12 text-right">
+									{prog.currentValue}/{prog.targetValue}
+									{#if prog.completed === 1}✅{/if}
+								</span>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		</div>
+	{/each}
 
 	<DemoCta
-		title="お子さまの成長をサポートしませんか？"
-		description="登録すると、チャレンジやカスタム実績の管理ができます。"
+		title="チャレンジ履歴を管理しませんか？"
+		description="登録すると、きょうだいチャレンジの作成・管理・履歴の確認ができます。"
 	/>
 </div>

--- a/src/routes/demo/(parent)/admin/challenges/+page.server.ts
+++ b/src/routes/demo/(parent)/admin/challenges/+page.server.ts
@@ -1,13 +1,14 @@
-import { DEMO_CHILDREN } from '$lib/server/demo/demo-data.js';
+import { todayDateJST, toJSTDateString } from '$lib/domain/date-utils';
+import { DEMO_CHILDREN } from '$lib/server/demo/demo-data';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	const today = new Date().toISOString().slice(0, 10);
-	const weekEnd = new Date(Date.now() + 6 * 86400000).toISOString().slice(0, 10);
+	const today = todayDateJST();
+	const weekEnd = toJSTDateString(new Date(Date.now() + 6 * 86400000));
 
-	// biome-ignore lint: DEMO_CHILDREN indices are always defined (static demo data)
+	// biome-ignore lint/style/noNonNullAssertion: demo data — indices are guaranteed
 	const child1 = DEMO_CHILDREN[1]!; // たろう (5歳)
-	// biome-ignore lint: DEMO_CHILDREN indices are always defined (static demo data)
+	// biome-ignore lint/style/noNonNullAssertion: demo data — indices are guaranteed
 	const child2 = DEMO_CHILDREN[2]!; // さくら (8歳)
 
 	const challenges = [
@@ -101,11 +102,10 @@ export const load: PageServerLoad = async () => {
 		},
 	];
 
-	const children = DEMO_CHILDREN.slice(1, 3).map((c) => ({
-		id: c.id,
-		nickname: c.nickname,
-		age: c.age,
-	}));
+	const children = [
+		{ id: child1.id, nickname: child1.nickname, age: child1.age },
+		{ id: child2.id, nickname: child2.nickname, age: child2.age },
+	];
 
 	return { challenges, children };
 };

--- a/src/routes/demo/(parent)/admin/settings/+page.svelte
+++ b/src/routes/demo/(parent)/admin/settings/+page.svelte
@@ -9,14 +9,6 @@ let { data } = $props();
 
 const ps = $derived(data.pointSettings);
 
-const themeOptions = [
-	{ value: 'pink', label: 'ピンク', icon: '&#x1F49B;' },
-	{ value: 'blue', label: 'ブルー', icon: '&#x1F499;' },
-	{ value: 'green', label: 'みどり', icon: '&#x1F49A;' },
-	{ value: 'orange', label: 'オレンジ', icon: '&#x1F9E1;' },
-	{ value: 'purple', label: 'むらさき', icon: '&#x1F49C;' },
-];
-
 const decayOptions = [
 	{ value: 'off', label: 'なし', desc: 'ステータスは下がりません' },
 	{ value: 'gentle', label: 'やさしい', desc: '2週間放置で少し下がる' },
@@ -98,23 +90,6 @@ const decayOptions = [
 							{opt.label}
 						</p>
 						<p class="text-xs text-gray-400 mt-0.5">{opt.desc}</p>
-					</div>
-				{/each}
-			</div>
-		</div>
-	</Card>
-
-	<!-- Theme Colors -->
-	<Card>
-		<div class="space-y-3">
-			<h2 class="text-sm font-bold text-gray-700">&#x1F3A8; テーマカラー</h2>
-			<p class="text-xs text-gray-500">
-				こどもごとにテーマカラーを設定できます。こども管理画面から変更してください。
-			</p>
-			<div class="flex gap-2">
-				{#each themeOptions as theme}
-					<div class="w-10 h-10 rounded-full border-2 border-gray-200 flex items-center justify-center text-lg" title={theme.label}>
-						{@html theme.icon}
 					</div>
 				{/each}
 			</div>

--- a/src/routes/demo/+layout.svelte
+++ b/src/routes/demo/+layout.svelte
@@ -71,7 +71,7 @@ $effect(() => {
 			&times;
 		</Button>
 		<p class="text-sm font-bold text-gray-700 mb-1">お子さまの ぼうけん、はじめよう！</p>
-		<p class="text-xs text-gray-500 mb-3">初月無料・いつでもキャンセルOK</p>
+		<p class="text-xs text-gray-500 mb-3">7日間無料・いつでもキャンセルOK</p>
 		<a
 			href="/demo/signup"
 			class="block w-full py-2.5 bg-gradient-to-r from-amber-500 to-orange-500 text-white font-bold rounded-xl text-center text-sm"

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -154,10 +154,10 @@ const modeColors: Record<string, string> = {
 					</div>
 				</li>
 				<li class="flex gap-2">
-					<span class="text-lg">🏆</span>
+					<span class="text-lg">👥</span>
 					<div>
-						<span class="font-medium text-gray-700">実績・称号</span>
-						— がんばりに応じて実績を解除、称号を獲得
+						<span class="font-medium text-gray-700">きょうだいチャレンジ</span>
+						— きょうだいで協力・競争する目標を設定
 					</div>
 				</li>
 				<li class="flex gap-2">


### PR DESCRIPTION
## Summary
- **#433**: 親管理画面「設定」からテーマカラーセクション削除（子ども管理画面で設定する機能のため不要）
- **#435**: デモトップ「体験できる機能」から廃止済み「実績・称号」を削除し「きょうだいチャレンジ」に差し替え
- **#436**: デモ内フローティングCTAの「初月無料」を「7日間無料」に統一（他CTAと表記一致）
- **#439**: チャレンジ管理ページ（親admin/achievements, 子achievements）のスタブを実データ表示に修正

closes #433, closes #435, closes #436, closes #439

## Test plan
- [x] `npx svelte-check` — 変更ファイルに型エラーなし（既存stripe-service.tsの3件は既知）
- [x] `npx vitest run` — ユニットテスト全2074件パス
- [ ] デモトップページ `/demo` で「きょうだいチャレンジ」が表示されること
- [ ] デモ設定ページ `/demo/admin/settings` にテーマカラーセクションがないこと
- [ ] フローティングCTA（5分後表示）に「7日間無料」と表示されること
- [ ] `/demo/admin/achievements` にチャレンジ履歴が表示されること
- [ ] 子ども画面 `/demo/kinder/achievements` にチャレンジ記録が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)