### PR TITLE
fix: #430 デモガイドツアーのUX不備修正

### DIFF
--- a/src/lib/features/demo/DemoGuideBar.svelte
+++ b/src/lib/features/demo/DemoGuideBar.svelte
@@ -5,6 +5,7 @@ import {
 	advanceStep,
 	checkAutoAdvance,
 	dismissGuide,
+	goBack,
 	GUIDE_STEPS,
 	getGuideState,
 } from './demo-guide-state.svelte.js';
@@ -17,8 +18,14 @@ $effect(() => {
 });
 
 function handleAdvance() {
+	const prevStep = guide.currentStep;
 	advanceStep();
-	trackDemoEvent('demo_guide_step', { step: guide.currentStep + 1 });
+	trackDemoEvent('demo_guide_step', { step: prevStep + 1 });
+}
+
+function handleBack() {
+	goBack();
+	trackDemoEvent('demo_guide_step', { step: guide.currentStep, direction: 'back' });
 }
 
 function handleDismiss() {
@@ -39,6 +46,21 @@ function handleDismiss() {
 			</div>
 
 			<div class="p-3 flex items-center gap-3">
+				<!-- Back button -->
+				{#if !guide.isFirstStep}
+					{@const prevStep = GUIDE_STEPS[guide.currentStep - 1]}
+					{#if prevStep}
+						<a
+							href={prevStep.href}
+							class="flex-shrink-0 w-8 h-8 rounded-full bg-gray-100 text-gray-500 flex items-center justify-center text-sm hover:bg-gray-200 transition-colors"
+							onclick={handleBack}
+							aria-label="もどる"
+						>
+							&#8249;
+						</a>
+					{/if}
+				{/if}
+
 				<!-- Step indicator -->
 				<div class="flex-shrink-0 w-8 h-8 rounded-full bg-blue-500 text-white flex items-center justify-center text-sm font-bold">
 					{guide.currentStep + 1}
@@ -59,6 +81,11 @@ function handleDismiss() {
 						>
 							はじめる
 						</a>
+					{:else if guide.step?.requiresAction}
+						<!-- Action-required step: show hint instead of navigation button -->
+						<span class="px-2 py-1 text-xs text-blue-500 font-medium">
+							👆 やってみよう
+						</span>
 					{:else}
 						{@const nextStep = GUIDE_STEPS[guide.currentStep + 1]}
 						{#if nextStep}

--- a/src/lib/features/demo/DemoGuideBar.svelte
+++ b/src/lib/features/demo/DemoGuideBar.svelte
@@ -5,9 +5,9 @@ import {
 	advanceStep,
 	checkAutoAdvance,
 	dismissGuide,
-	goBack,
 	GUIDE_STEPS,
 	getGuideState,
+	goBack,
 } from './demo-guide-state.svelte.js';
 
 const guide = getGuideState();
@@ -18,14 +18,22 @@ $effect(() => {
 });
 
 function handleAdvance() {
-	const prevStep = guide.currentStep;
+	const fromStep = guide.currentStep;
 	advanceStep();
-	trackDemoEvent('demo_guide_step', { step: prevStep + 1 });
+	trackDemoEvent('demo_guide_step', {
+		fromStep: fromStep + 1,
+		toStep: guide.currentStep + 1,
+	});
 }
 
 function handleBack() {
+	const fromStep = guide.currentStep;
 	goBack();
-	trackDemoEvent('demo_guide_step', { step: guide.currentStep, direction: 'back' });
+	trackDemoEvent('demo_guide_step', {
+		fromStep: fromStep + 1,
+		toStep: guide.currentStep + 1,
+		direction: 'back',
+	});
 }
 
 function handleDismiss() {
@@ -84,7 +92,7 @@ function handleDismiss() {
 					{:else if guide.step?.requiresAction}
 						<!-- Action-required step: show hint instead of navigation button -->
 						<span class="px-2 py-1 text-xs text-blue-500 font-medium">
-							👆 やってみよう
+							<span aria-hidden="true">👆</span> やってみよう
 						</span>
 					{:else}
 						{@const nextStep = GUIDE_STEPS[guide.currentStep + 1]}

--- a/src/lib/features/demo/demo-guide-state.svelte.ts
+++ b/src/lib/features/demo/demo-guide-state.svelte.ts
@@ -155,7 +155,11 @@ export function checkAutoAdvance(pathname: string) {
 	const nextStep = GUIDE_STEPS[nextStepIndex];
 	if (!nextStep || !pathname.startsWith(nextStep.matchPath)) return;
 
-	// requiresAction ステップは明示的な advanceStep() を待つ
+	// 現在のステップが requiresAction なら、パス遷移だけではスキップさせない
+	const currentStepDef = GUIDE_STEPS[currentStep];
+	if (currentStepDef?.requiresAction) return;
+
+	// 次のステップが requiresAction の場合も明示的な advanceStep() を待つ
 	if (nextStep.requiresAction) return;
 
 	// 現在のステップと次のステップが同一パスならスキップ（手動遷移を待つ）

--- a/src/lib/features/demo/demo-guide-state.svelte.ts
+++ b/src/lib/features/demo/demo-guide-state.svelte.ts
@@ -11,6 +11,12 @@ export interface GuideStep {
 	matchPath: string;
 	/** URL to navigate to for this step */
 	href: string;
+	/**
+	 * If true, this step requires an explicit action (e.g. recording an activity)
+	 * and should NOT show the "つぎへ" navigation button.
+	 * Advance via advanceStep() from the action handler.
+	 */
+	requiresAction?: boolean;
 }
 
 export const GUIDE_STEPS: GuideStep[] = [
@@ -27,6 +33,7 @@ export const GUIDE_STEPS: GuideStep[] = [
 		description: 'かつどうカードをタップして きろくしてみましょう',
 		matchPath: '/demo/kinder/home',
 		href: '/demo/kinder/home?childId=902',
+		requiresAction: true,
 	},
 	{
 		id: 3,
@@ -62,7 +69,27 @@ export function startGuide() {
 }
 
 export function dismissGuide() {
+	guideActive = false;
 	guideDismissed = true;
+}
+
+/**
+ * Restart a previously dismissed guide from the beginning.
+ */
+export function restartGuide() {
+	guideActive = true;
+	currentStep = 0;
+	guideDismissed = false;
+}
+
+/**
+ * Reset guide state when navigating back to /demo top.
+ * Deactivates the guide without marking it as dismissed,
+ * so the "ガイドを再開" button can offer to restart.
+ */
+export function resetGuide() {
+	guideActive = false;
+	currentStep = 0;
 }
 
 export function advanceStep() {
@@ -71,10 +98,25 @@ export function advanceStep() {
 	}
 }
 
+/**
+ * Go back one step.
+ */
+export function goBack() {
+	if (currentStep > 0) {
+		currentStep--;
+	}
+}
+
 export function getGuideState() {
 	return {
 		get active() {
 			return guideActive && !guideDismissed;
+		},
+		get dismissed() {
+			return guideDismissed;
+		},
+		get wasStarted() {
+			return guideActive || guideDismissed;
 		},
 		get currentStep() {
 			return currentStep;
@@ -84,6 +126,9 @@ export function getGuideState() {
 		},
 		get totalSteps() {
 			return GUIDE_STEPS.length;
+		},
+		get isFirstStep() {
+			return currentStep === 0;
 		},
 		get isLastStep() {
 			return currentStep >= GUIDE_STEPS.length - 1;
@@ -98,6 +143,8 @@ export function getGuideState() {
  * 同一 matchPath が連続するステップ（例: ステップ1→2は共に /demo/kinder/home）では
  * URL遷移だけでは区別できないため auto-advance をスキップする。
  * そのようなステップは advanceStep() で明示的に進める。
+ *
+ * requiresAction ステップも auto-advance をスキップする。
  */
 export function checkAutoAdvance(pathname: string) {
 	if (!guideActive || guideDismissed) return;
@@ -107,6 +154,9 @@ export function checkAutoAdvance(pathname: string) {
 
 	const nextStep = GUIDE_STEPS[nextStepIndex];
 	if (!nextStep || !pathname.startsWith(nextStep.matchPath)) return;
+
+	// requiresAction ステップは明示的な advanceStep() を待つ
+	if (nextStep.requiresAction) return;
 
 	// 現在のステップと次のステップが同一パスならスキップ（手動遷移を待つ）
 	const currentMatchPath = GUIDE_STEPS[currentStep]?.matchPath;

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -1,14 +1,32 @@
 <script lang="ts">
 import { trackDemoEvent } from '$lib/features/demo/demo-analytics.js';
-import { startGuide } from '$lib/features/demo/demo-guide-state.svelte.js';
+import {
+	getGuideState,
+	resetGuide,
+	restartGuide,
+	startGuide,
+} from '$lib/features/demo/demo-guide-state.svelte.js';
 import Logo from '$lib/ui/components/Logo.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 
 let { data } = $props();
 
+const guide = getGuideState();
+
+// Reset guide state when navigating back to /demo top
+// This clears the overlay so it doesn't persist on the top page
+$effect(() => {
+	resetGuide();
+});
+
 function handleGuideStart() {
 	startGuide();
 	trackDemoEvent('demo_guide_start');
+}
+
+function handleGuideRestart() {
+	restartGuide();
+	trackDemoEvent('demo_guide_start', { restart: true });
 }
 
 const modeLabels: Record<string, string> = {
@@ -43,15 +61,27 @@ const modeColors: Record<string, string> = {
 
 		<!-- Guided demo option -->
 		<div class="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-2xl border border-blue-200 p-5 mb-6 text-center">
-			<p class="text-sm font-bold text-gray-700 mb-1">はじめてですか？</p>
-			<p class="text-xs text-gray-500 mb-3">5ステップで主な機能をご案内します</p>
-			<a
-				href="/demo/kinder/home?childId=902"
-				class="block w-full py-2.5 bg-blue-500 text-white font-bold rounded-xl text-sm hover:bg-blue-600 transition-colors"
-				onclick={handleGuideStart}
-			>
-				ガイド付きデモを はじめる
-			</a>
+			{#if guide.dismissed}
+				<p class="text-sm font-bold text-gray-700 mb-1">ガイドをとじました</p>
+				<p class="text-xs text-gray-500 mb-3">もう一度はじめから体験できます</p>
+				<a
+					href="/demo/kinder/home?childId=902"
+					class="block w-full py-2.5 bg-blue-500 text-white font-bold rounded-xl text-sm hover:bg-blue-600 transition-colors"
+					onclick={handleGuideRestart}
+				>
+					ガイドを再開する
+				</a>
+			{:else}
+				<p class="text-sm font-bold text-gray-700 mb-1">はじめてですか？</p>
+				<p class="text-xs text-gray-500 mb-3">5ステップで主な機能をご案内します</p>
+				<a
+					href="/demo/kinder/home?childId=902"
+					class="block w-full py-2.5 bg-blue-500 text-white font-bold rounded-xl text-sm hover:bg-blue-600 transition-colors"
+					onclick={handleGuideStart}
+				>
+					ガイド付きデモを はじめる
+				</a>
+			{/if}
 		</div>
 
 		<!-- Family Introduction -->


### PR DESCRIPTION
## Summary
- デモガイドツアーの5つのUX不備を修正
  - **ステップスキップ防止**: ステップ2（活動記録）に `requiresAction` フラグを追加。「つぎへ」ボタンの代わりに「やってみよう」ヒントを表示し、実際に活動記録を行うまで進めないように
  - **戻るボタン追加**: `goBack()` 関数と DemoGuideBar の「もどる」ボタンを実装。前のステップのページへ遷移
  - **ガイド再開機能**: ガイドを閉じた後、デモトップページに「ガイドを再開する」ボタンを表示
  - **オーバーレイクリア**: `/demo` トップに戻った際に `resetGuide()` でガイドバーを非表示に
  - **遷移安定化**: `checkAutoAdvance` で `requiresAction` ステップの自動進行を抑止

## Changed Files
- `src/lib/features/demo/demo-guide-state.svelte.ts` — `goBack()`, `resetGuide()`, `restartGuide()` 追加、`requiresAction` フラグ対応
- `src/lib/features/demo/DemoGuideBar.svelte` — 戻るボタン、requiresAction ヒント表示
- `src/routes/demo/+page.svelte` — ガイド再開ボタン、トップ遷移時のリセット

## Test plan
- [ ] ガイド開始後、ステップ1→2→3→4→5 が順番通りに進むことを確認
- [ ] ステップ2で「つぎへ」ではなく「やってみよう」が表示されることを確認
- [ ] 活動記録後にステップ3へ自動進行することを確認
- [ ] 各ステップで「もどる」ボタンが機能することを確認（ステップ1では非表示）
- [ ] ガイドを×で閉じた後、/demo トップに「ガイドを再開する」ボタンが表示されることを確認
- [ ] /demo トップに戻った際にガイドバーが消えることを確認

closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)