### PR TITLE
fix: #448 認証レートリミット緩和 — GET/POST分離

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -39,7 +39,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 		const ip = event.getClientAddress();
 		const isAuthRoute = path.startsWith('/auth/');
 		const { allowed, remaining, resetAt } = isAuthRoute
-			? checkAuthRateLimit(ip)
+			? checkAuthRateLimit(ip, event.request.method)
 			: checkApiRateLimit(ip);
 
 		if (!allowed) {

--- a/src/lib/server/security/rate-limiter.ts
+++ b/src/lib/server/security/rate-limiter.ts
@@ -57,7 +57,14 @@ export function checkApiRateLimit(ip: string) {
 	return checkRateLimit(`api:${ip}`, 100, 60 * 1000);
 }
 
-/** ログイン試行用レートリミット: 10 req/min per IP */
-export function checkAuthRateLimit(ip: string) {
-	return checkRateLimit(`auth:${ip}`, 10, 60 * 1000);
+/**
+ * 認証ルートのレートリミット（メソッド別）
+ * - POST（ログイン試行）: 30 req/min — ブルートフォース保護は account-lockout.ts が担当
+ * - GET（ページ表示・リダイレクト）: 60 req/min — 複数タブ同時オープン等を許容
+ */
+export function checkAuthRateLimit(ip: string, method: string) {
+	if (method === 'POST') {
+		return checkRateLimit(`auth:post:${ip}`, 30, 60 * 1000);
+	}
+	return checkRateLimit(`auth:get:${ip}`, 60, 60 * 1000);
 }

--- a/src/lib/server/security/rate-limiter.ts
+++ b/src/lib/server/security/rate-limiter.ts
@@ -63,8 +63,8 @@ export function checkApiRateLimit(ip: string) {
  * - GET（ページ表示・リダイレクト）: 60 req/min — 複数タブ同時オープン等を許容
  */
 export function checkAuthRateLimit(ip: string, method: string) {
-	if (method === 'POST') {
-		return checkRateLimit(`auth:post:${ip}`, 30, 60 * 1000);
+	if (method === 'GET' || method === 'HEAD') {
+		return checkRateLimit(`auth:get:${ip}`, 60, 60 * 1000);
 	}
-	return checkRateLimit(`auth:get:${ip}`, 60, 60 * 1000);
+	return checkRateLimit(`auth:post:${ip}`, 30, 60 * 1000);
 }

--- a/tests/unit/services/hooks-integration.test.ts
+++ b/tests/unit/services/hooks-integration.test.ts
@@ -22,7 +22,10 @@ vi.mock('$lib/server/logger', () => ({
 
 vi.mock('$lib/server/security/rate-limiter', () => ({
 	checkApiRateLimit: () => ({ allowed: true, remaining: 99, resetAt: Date.now() + 60000 }),
-	checkAuthRateLimit: () => ({ allowed: true, remaining: 29, resetAt: Date.now() + 60000 }),
+	checkAuthRateLimit: (method?: string) => {
+		const isGet = method?.toUpperCase() === 'GET' || method?.toUpperCase() === 'HEAD';
+		return { allowed: true, remaining: isGet ? 59 : 29, resetAt: Date.now() + 60000 };
+	},
 }));
 
 const mockCheckConsent = vi.fn();

--- a/tests/unit/services/hooks-integration.test.ts
+++ b/tests/unit/services/hooks-integration.test.ts
@@ -22,7 +22,7 @@ vi.mock('$lib/server/logger', () => ({
 
 vi.mock('$lib/server/security/rate-limiter', () => ({
 	checkApiRateLimit: () => ({ allowed: true, remaining: 99, resetAt: Date.now() + 60000 }),
-	checkAuthRateLimit: () => ({ allowed: true, remaining: 9, resetAt: Date.now() + 60000 }),
+	checkAuthRateLimit: () => ({ allowed: true, remaining: 29, resetAt: Date.now() + 60000 }),
 }));
 
 const mockCheckConsent = vi.fn();


### PR DESCRIPTION
## Summary
- 認証ルート (`/auth/*`) のレートリミットをHTTPメソッド別に分離
- **POST** (ログイン試行): 10 → 30 req/min — ブルートフォース保護は `account-lockout.ts` が担当（10回失敗で30分ロック）
- **GET** (ページ表示・リダイレクト): 60 req/min — 複数admin画面の同時オープンでログインページにリダイレクトされても制限に引っかからない

## Changes
- `src/lib/server/security/rate-limiter.ts`: `checkAuthRateLimit` に `method` パラメータ追加、GET/POST別のキーと制限値で管理
- `src/hooks.server.ts`: `event.request.method` を `checkAuthRateLimit` に渡すよう変更
- `tests/unit/services/hooks-integration.test.ts`: モックの `remaining` 値を更新

## Test plan
- [x] `npx vitest run` — 2074テスト全通過（Storybook関連の15件は既存の問題）
- [ ] CI全通過確認

closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)