### PR TITLE
fix: #447 #451 エラーページの表示改善

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -8,6 +8,46 @@ import { checkConsent } from '$lib/server/services/consent-service';
 import { notifyIncident } from '$lib/server/services/discord-notify-service';
 import { isSetupRequired } from '$lib/server/services/setup-service';
 
+/**
+ * Accept ヘッダーを検査し、ブラウザ（HTML）リクエストかどうかを判定する
+ */
+function acceptsHtml(request: Request): boolean {
+	const accept = request.headers.get('Accept') ?? '';
+	return accept.includes('text/html');
+}
+
+/**
+ * ミニマルなスタイル付き HTML エラーページを生成する
+ * (hooks 内で SvelteKit のレンダリングパイプラインを通らない場面用)
+ */
+function renderErrorHtml(status: number, title: string, message: string): string {
+	return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>${title} - がんばりクエスト</title>
+<style>
+body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f2f9ff;color:#2d2d2d}
+.container{text-align:center;padding:2rem;max-width:480px}
+.status{font-size:4rem;font-weight:700;color:#4a90d9;margin-bottom:0.5rem}
+h1{font-size:1.25rem;margin:0 0 1rem}
+p{color:#8b8b8b;line-height:1.6}
+a{color:#4a90d9;text-decoration:none;font-weight:500}
+a:hover{text-decoration:underline}
+</style>
+</head>
+<body>
+<div class="container">
+<div class="status">${status}</div>
+<h1>${title}</h1>
+<p>${message}</p>
+<p style="margin-top:2rem"><a href="/">トップページへ戻る</a></p>
+</div>
+</body>
+</html>`;
+}
+
 const provider = getAuthProvider();
 const authMode = getAuthMode();
 
@@ -23,6 +63,19 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	// 0-a) メンテナンスモード（Lambda環境変数で切替）
 	if (MAINTENANCE_MODE && path !== '/api/health') {
+		if (acceptsHtml(event.request)) {
+			return new Response(
+				renderErrorHtml(
+					503,
+					'メンテナンス中',
+					'ただいまメンテナンス中です。しばらくしてから再度お試しください。',
+				),
+				{
+					status: 503,
+					headers: { 'Content-Type': 'text/html; charset=utf-8', 'Retry-After': '600' },
+				},
+			);
+		}
 		return new Response(JSON.stringify({ status: 'maintenance', message: 'メンテナンス中です' }), {
 			status: 503,
 			headers: { 'Content-Type': 'application/json', 'Retry-After': '600' },
@@ -45,6 +98,22 @@ export const handle: Handle = async ({ event, resolve }) => {
 		if (!allowed) {
 			logger.warn(`Rate limit exceeded: ${ip} on ${path}`);
 			const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
+			if (acceptsHtml(event.request)) {
+				return new Response(
+					renderErrorHtml(
+						429,
+						'アクセスが集中しています',
+						'アクセスが集中しています。しばらくしてから再度お試しください。',
+					),
+					{
+						status: 429,
+						headers: {
+							'Content-Type': 'text/html; charset=utf-8',
+							'Retry-After': String(retryAfter),
+						},
+					},
+				);
+			}
 			return new Response(JSON.stringify({ error: 'Too Many Requests' }), {
 				status: 429,
 				headers: {
@@ -241,5 +310,15 @@ export const handleError: HandleServerError = ({ error, event, status, message }
 		}).catch(() => {});
 	}
 
-	return { message: 'Internal Server Error' };
+	// ステータスコードに応じた日本語メッセージを返す
+	if (status === 404) {
+		return { message: 'ページが見つかりません' };
+	}
+	if (status === 429) {
+		return { message: 'アクセスが集中しています' };
+	}
+	if (status === 403) {
+		return { message: 'アクセスが拒否されました' };
+	}
+	return { message: 'サーバーエラーが発生しました' };
 };

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -310,7 +310,7 @@ export const handleError: HandleServerError = ({ error, event, status, message }
 		}).catch(() => {});
 	}
 
-	// ステータスコードに応じた日本語メッセージを返す
+	// ステータスコードに応じたメッセージを返す
 	if (status === 404) {
 		return { message: 'ページが見つかりません' };
 	}
@@ -319,6 +319,10 @@ export const handleError: HandleServerError = ({ error, event, status, message }
 	}
 	if (status === 403) {
 		return { message: 'アクセスが拒否されました' };
+	}
+	// その他の 4xx はSvelteKitが設定した元のメッセージをそのまま返す
+	if (status < 500) {
+		return { message };
 	}
 	return { message: 'サーバーエラーが発生しました' };
 };

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -27,7 +27,7 @@ import { page } from '$app/state';
 		align-items: center;
 		justify-content: center;
 		min-height: 100vh;
-		background: var(--color-brand-50);
+		background: var(--color-surface-base);
 		padding: 1rem;
 	}
 
@@ -39,7 +39,7 @@ import { page } from '$app/state';
 	.error-status {
 		font-size: 4rem;
 		font-weight: 700;
-		color: var(--color-brand-600);
+		color: var(--color-action-primary);
 		margin: 0 0 0.5rem;
 		line-height: 1;
 	}
@@ -57,7 +57,7 @@ import { page } from '$app/state';
 	}
 
 	.home-link {
-		color: var(--color-brand-600);
+		color: var(--color-text-link);
 		text-decoration: none;
 		font-weight: 500;
 	}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+import { page } from '$app/state';
+</script>
+
+<div class="error-page">
+	<div class="error-container">
+		<p class="error-status">{page.status}</p>
+		<h1 class="error-title">{page.error?.message ?? 'エラーが発生しました'}</h1>
+		<p class="error-description">
+			{#if page.status === 404}
+				お探しのページは存在しないか、移動した可能性があります。
+			{:else if page.status === 429}
+				しばらくしてから再度お試しください。
+			{:else if page.status === 403}
+				このページにアクセスする権限がありません。
+			{:else}
+				予期しないエラーが発生しました。時間をおいて再度お試しください。
+			{/if}
+		</p>
+		<a href="/" class="home-link">トップページへ戻る</a>
+	</div>
+</div>
+
+<style>
+	.error-page {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 100vh;
+		background: var(--color-brand-50);
+		padding: 1rem;
+	}
+
+	.error-container {
+		text-align: center;
+		max-width: 480px;
+	}
+
+	.error-status {
+		font-size: 4rem;
+		font-weight: 700;
+		color: var(--color-brand-600);
+		margin: 0 0 0.5rem;
+		line-height: 1;
+	}
+
+	.error-title {
+		font-size: 1.25rem;
+		margin: 0 0 1rem;
+		color: var(--color-text);
+	}
+
+	.error-description {
+		color: var(--color-text-muted);
+		line-height: 1.6;
+		margin: 0 0 2rem;
+	}
+
+	.home-link {
+		color: var(--color-brand-600);
+		text-decoration: none;
+		font-weight: 500;
+	}
+
+	.home-link:hover {
+		text-decoration: underline;
+	}
+</style>


### PR DESCRIPTION
## Summary
- **#447**: hooks.server.tsのレートリミット(429)とメンテナンスモード(503)レスポンスで`Accept`ヘッダーを検査し、ブラウザリクエスト(`text/html`)にはスタイル付きHTMLエラーページ、APIリクエストには従来のJSONレスポンスを返すよう修正
- **#451**: `handleError`が全エラーに対して`Internal Server Error`を返していた問題を修正。ステータスコード別の日本語メッセージに変更(404/429/403/500+)
- `src/routes/+error.svelte`を新規作成し、SvelteKitが処理するエラー(404等)でユーザーフレンドリーなエラーページを表示

## Test plan
- [x] `npx biome check` — lint/format エラーなし
- [x] `npx svelte-check` — 型エラーなし
- [x] `npx vitest run` — 全2171テスト通過
- [ ] E2E: 存在しないURLにアクセスして404ページが「ページが見つかりません」と表示されることを確認
- [ ] ブラウザで429/503レスポンスがHTMLで返されることを確認

closes #447, closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)