### PR TITLE
feat: #450 パスワードリセット機能の実装

### DIFF
--- a/src/lib/server/auth/providers/cognito-direct-auth.ts
+++ b/src/lib/server/auth/providers/cognito-direct-auth.ts
@@ -271,6 +271,129 @@ export async function signUpWithCognito(
 }
 
 /**
+ * パスワードリセットリクエスト（確認コード送信）
+ */
+export async function forgotPassword(email: string): Promise<{ success: true } | CognitoAuthError> {
+	const config = getConfig();
+	const client = new CognitoIdentityProviderClient({ region: config.region });
+
+	try {
+		const { ForgotPasswordCommand } = await import('@aws-sdk/client-cognito-identity-provider');
+
+		const command = new ForgotPasswordCommand({
+			ClientId: config.clientId,
+			Username: email,
+		});
+
+		await client.send(command);
+		return { success: true };
+	} catch (e: unknown) {
+		const errorName = (e as { name?: string })?.name ?? '';
+		logger.warn('[AUTH] Cognito ForgotPassword failed', {
+			context: { errorName, error: e instanceof Error ? e.message : String(e) },
+		});
+
+		if (errorName === 'UserNotFoundException') {
+			// セキュリティ上、ユーザーが存在しない場合も成功扱いにする
+			return { success: true };
+		}
+
+		if (errorName === 'LimitExceededException') {
+			return {
+				success: false,
+				error: 'UNKNOWN',
+				message: 'リクエスト回数の上限に達しました。しばらくしてからお試しください',
+			};
+		}
+
+		if (errorName === 'InvalidParameterException') {
+			return {
+				success: false,
+				error: 'UNKNOWN',
+				message: 'メールアドレスの形式が正しくありません',
+			};
+		}
+
+		return {
+			success: false,
+			error: 'UNKNOWN',
+			message: 'パスワードリセットに失敗しました。しばらくしてからお試しください',
+		};
+	}
+}
+
+/**
+ * パスワードリセット確認（新パスワード設定）
+ */
+export async function confirmForgotPassword(
+	email: string,
+	code: string,
+	newPassword: string,
+): Promise<{ success: true } | CognitoAuthError> {
+	const config = getConfig();
+	const client = new CognitoIdentityProviderClient({ region: config.region });
+
+	try {
+		const { ConfirmForgotPasswordCommand } = await import(
+			'@aws-sdk/client-cognito-identity-provider'
+		);
+
+		const command = new ConfirmForgotPasswordCommand({
+			ClientId: config.clientId,
+			Username: email,
+			ConfirmationCode: code,
+			Password: newPassword,
+		});
+
+		await client.send(command);
+		return { success: true };
+	} catch (e: unknown) {
+		const errorName = (e as { name?: string })?.name ?? '';
+		logger.warn('[AUTH] Cognito ConfirmForgotPassword failed', {
+			context: { errorName, error: e instanceof Error ? e.message : String(e) },
+		});
+
+		if (errorName === 'CodeMismatchException') {
+			return {
+				success: false,
+				error: 'UNKNOWN',
+				message: '確認コードが正しくありません',
+			};
+		}
+
+		if (errorName === 'ExpiredCodeException') {
+			return {
+				success: false,
+				error: 'UNKNOWN',
+				message: '確認コードの有効期限が切れています。もう一度リクエストしてください',
+			};
+		}
+
+		if (errorName === 'InvalidPasswordException') {
+			return {
+				success: false,
+				error: 'UNKNOWN',
+				message: 'パスワードが要件を満たしていません（8文字以上、大小英字・数字を含む）',
+			};
+		}
+
+		if (errorName === 'LimitExceededException') {
+			return {
+				success: false,
+				error: 'UNKNOWN',
+				message: 'リクエスト回数の上限に達しました。しばらくしてからお試しください',
+			};
+		}
+
+		return {
+			success: false,
+			error: 'UNKNOWN',
+			message: 'パスワードのリセットに失敗しました',
+		};
+	}
+}
+
+/**
  * メール認証コード確認
  */
 export async function confirmSignUp(

--- a/src/lib/server/auth/providers/cognito-direct-auth.ts
+++ b/src/lib/server/auth/providers/cognito-direct-auth.ts
@@ -44,7 +44,7 @@ export interface CognitoMfaChallenge {
 
 export interface CognitoAuthError {
 	success: false;
-	error: 'INVALID_CREDENTIALS' | 'USER_NOT_FOUND' | 'NOT_CONFIRMED' | 'UNKNOWN';
+	error: 'INVALID_CREDENTIALS' | 'USER_NOT_FOUND' | 'NOT_CONFIRMED' | 'INVALID_CODE' | 'UNKNOWN';
 	message: string;
 }
 
@@ -289,14 +289,16 @@ export async function forgotPassword(email: string): Promise<{ success: true } |
 		return { success: true };
 	} catch (e: unknown) {
 		const errorName = (e as { name?: string })?.name ?? '';
-		logger.warn('[AUTH] Cognito ForgotPassword failed', {
-			context: { errorName, error: e instanceof Error ? e.message : String(e) },
-		});
 
 		if (errorName === 'UserNotFoundException') {
 			// セキュリティ上、ユーザーが存在しない場合も成功扱いにする
+			logger.info('[AUTH] ForgotPassword for non-existent user (treated as success)');
 			return { success: true };
 		}
+
+		logger.warn('[AUTH] Cognito ForgotPassword failed', {
+			context: { errorName, error: e instanceof Error ? e.message : String(e) },
+		});
 
 		if (errorName === 'LimitExceededException') {
 			return {
@@ -353,10 +355,16 @@ export async function confirmForgotPassword(
 			context: { errorName, error: e instanceof Error ? e.message : String(e) },
 		});
 
-		if (errorName === 'CodeMismatchException') {
+		// セキュリティ: UserNotFoundException / InvalidParameterException も CodeMismatchException と
+		// 同じエラーメッセージを返し、メールアドレスの存在有無を推測させない
+		if (
+			errorName === 'CodeMismatchException' ||
+			errorName === 'UserNotFoundException' ||
+			errorName === 'InvalidParameterException'
+		) {
 			return {
 				success: false,
-				error: 'UNKNOWN',
+				error: 'INVALID_CODE',
 				message: '確認コードが正しくありません',
 			};
 		}

--- a/src/routes/auth/forgot-password/+page.server.ts
+++ b/src/routes/auth/forgot-password/+page.server.ts
@@ -1,0 +1,92 @@
+// /auth/forgot-password — パスワードリセット
+// Step 1: メールアドレス入力 → Cognito ForgotPassword API で確認コード送信
+// Step 2: 確認コード + 新パスワード入力 → Cognito ConfirmForgotPassword API でリセット
+
+import { fail, redirect } from '@sveltejs/kit';
+import { getAuthMode, isCognitoDevMode } from '$lib/server/auth/factory';
+import {
+	confirmForgotPassword,
+	forgotPassword,
+} from '$lib/server/auth/providers/cognito-direct-auth';
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	const authMode = getAuthMode();
+
+	// local モードやdevモードではパスワードリセット不要
+	if (authMode === 'local' || isCognitoDevMode()) {
+		redirect(302, '/auth/login');
+	}
+
+	// 既にログイン済み
+	if (locals.identity) {
+		redirect(302, '/admin');
+	}
+
+	return {};
+};
+
+export const actions: Actions = {
+	requestReset: async ({ request }) => {
+		const formData = await request.formData();
+		const email = (formData.get('email') as string)?.trim();
+
+		if (!email) {
+			return fail(400, { error: 'メールアドレスを入力してください' });
+		}
+
+		const result = await forgotPassword(email);
+
+		if (!result.success) {
+			return fail(400, { error: result.message, email });
+		}
+
+		// 成功 → 確認コード入力ステップへ
+		return { confirmStep: true, email };
+	},
+
+	confirmReset: async ({ request }) => {
+		const formData = await request.formData();
+		const email = (formData.get('email') as string)?.trim();
+		const code = (formData.get('code') as string)?.replace(/\s/g, '');
+		const newPassword = formData.get('newPassword') as string;
+		const newPasswordConfirm = formData.get('newPasswordConfirm') as string;
+
+		if (!email || !code || !newPassword) {
+			return fail(400, {
+				error: '全ての項目を入力してください',
+				email,
+				confirmStep: true,
+			});
+		}
+
+		if (newPassword !== newPasswordConfirm) {
+			return fail(400, {
+				error: 'パスワードが一致しません',
+				email,
+				confirmStep: true,
+			});
+		}
+
+		if (newPassword.length < 8) {
+			return fail(400, {
+				error: 'パスワードは8文字以上で入力してください',
+				email,
+				confirmStep: true,
+			});
+		}
+
+		const result = await confirmForgotPassword(email, code, newPassword);
+
+		if (!result.success) {
+			return fail(400, {
+				error: result.message,
+				email,
+				confirmStep: true,
+			});
+		}
+
+		// 成功 → ログインページへリダイレクト
+		redirect(302, '/auth/login?passwordReset=true');
+	},
+};

--- a/src/routes/auth/forgot-password/+page.svelte
+++ b/src/routes/auth/forgot-password/+page.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+import { enhance } from '$app/forms';
+import Logo from '$lib/ui/components/Logo.svelte';
+import Button from '$lib/ui/primitives/Button.svelte';
+import Card from '$lib/ui/primitives/Card.svelte';
+import FormField from '$lib/ui/primitives/FormField.svelte';
+
+let { form } = $props();
+
+let email = $state('');
+let codeRaw = $state('');
+const code = $derived(codeRaw.replace(/\s/g, ''));
+let newPassword = $state('');
+let newPasswordConfirm = $state('');
+let loading = $state(false);
+
+let confirmStep = $derived(form?.confirmStep ?? false);
+
+// Restore email from server response
+$effect(() => {
+	if (typeof form?.email === 'string') email = form.email;
+});
+</script>
+
+<svelte:head>
+	<title>パスワードリセット - がんばりクエスト</title>
+</svelte:head>
+
+<div class="min-h-dvh flex items-center justify-center bg-[var(--gradient-brand)] p-4">
+	<Card padding="none" class="w-full max-w-[400px] px-8 py-10 shadow-[0_20px_60px_rgba(0,0,0,0.15)]">
+		{#snippet children()}
+		<div class="text-center mb-8">
+			<Logo variant="full" size={320} />
+			<p class="text-sm text-[var(--color-text-muted)] mt-2 font-semibold">パスワードリセット</p>
+		</div>
+
+		{#if form?.error}
+			<div class="mb-4 p-3 bg-red-50 text-red-600 border border-red-200 rounded-[var(--radius-sm)] text-sm" role="alert">
+				{form.error}
+			</div>
+		{/if}
+
+		{#if confirmStep}
+			<!-- Step 2: Verification code + new password -->
+			<form
+				method="POST"
+				action="?/confirmReset"
+				use:enhance={() => {
+					loading = true;
+					return async ({ update }) => {
+						loading = false;
+						await update();
+					};
+				}}
+				class="flex flex-col gap-5"
+			>
+				<input type="hidden" name="email" value={email} />
+
+				<p class="text-sm text-[var(--color-text-muted)] text-center leading-relaxed">
+					<strong>{email}</strong> に確認コードを送信しました。<br />
+					メールに記載されたコードと新しいパスワードを入力してください。
+				</p>
+
+				<FormField label="確認コード" id="code">
+					{#snippet children()}
+						<input
+							id="code"
+							name="code"
+							type="text"
+							bind:value={codeRaw}
+							placeholder="123456"
+							required
+							inputmode="numeric"
+							autocomplete="one-time-code"
+							class="px-4 py-3 border border-[var(--input-border)] rounded-[var(--input-radius)] text-2xl text-center tracking-[0.5em] font-mono
+								focus:border-[var(--input-border-focus)] focus:ring-2 focus:ring-[var(--color-brand-300)] focus:ring-opacity-50 outline-none transition-colors"
+						/>
+					{/snippet}
+				</FormField>
+
+				<FormField
+					label="新しいパスワード"
+					type="password"
+					id="newPassword"
+					name="newPassword"
+					bind:value={newPassword}
+					placeholder="8文字以上（大小英字・数字を含む）"
+					required
+					minlength={8}
+					autocomplete="new-password"
+					hint="8文字以上、大文字・小文字・数字を含む"
+				/>
+
+				<FormField
+					label="新しいパスワード（確認）"
+					type="password"
+					id="newPasswordConfirm"
+					name="newPasswordConfirm"
+					bind:value={newPasswordConfirm}
+					placeholder="パスワードを再入力"
+					required
+					minlength={8}
+					autocomplete="new-password"
+				/>
+
+				<Button type="submit" disabled={loading || code.length < 1 || !newPassword || !newPasswordConfirm} size="md" class="w-full">
+					{#if loading}
+						<span class="inline-block w-4 h-4 border-2 border-current border-r-transparent rounded-full animate-spin" aria-hidden="true"></span>
+						リセット中...
+					{:else}
+						パスワードをリセット
+					{/if}
+				</Button>
+			</form>
+		{:else}
+			<!-- Step 1: Email input -->
+			<form
+				method="POST"
+				action="?/requestReset"
+				use:enhance={() => {
+					loading = true;
+					return async ({ update }) => {
+						loading = false;
+						await update();
+					};
+				}}
+				class="flex flex-col gap-5"
+			>
+				<p class="text-sm text-[var(--color-text-muted)] text-center leading-relaxed">
+					登録済みのメールアドレスを入力してください。<br />
+					パスワードリセット用の確認コードを送信します。
+				</p>
+
+				<FormField
+					label="メールアドレス"
+					type="email"
+					id="email"
+					name="email"
+					bind:value={email}
+					placeholder="example@email.com"
+					required
+					autocomplete="email"
+				/>
+
+				<Button type="submit" disabled={loading || !email} size="md" class="w-full">
+					{#if loading}
+						<span class="inline-block w-4 h-4 border-2 border-current border-r-transparent rounded-full animate-spin" aria-hidden="true"></span>
+						送信中...
+					{:else}
+						確認コードを送信
+					{/if}
+				</Button>
+			</form>
+		{/if}
+
+		<div class="mt-5 text-center">
+			<a href="/auth/login" class="text-sm text-[var(--color-text-link)] hover:underline">
+				ログインに戻る
+			</a>
+		</div>
+		{/snippet}
+	</Card>
+</div>

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { page } from '$app/stores';
 import GoogleSignInButton from '$lib/ui/components/GoogleSignInButton.svelte';
 import Logo from '$lib/ui/components/Logo.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
@@ -28,6 +29,8 @@ let loading = $state(false);
 let mfaStep = $derived((f()?.mfaStep as boolean) ?? false);
 let mfaSession = $derived((f()?.session as string) ?? '');
 let mfaChallengeName = $derived((f()?.challengeName as string) ?? '');
+
+const passwordReset = $derived($page.url.searchParams.get('passwordReset') === 'true');
 </script>
 
 <svelte:head>
@@ -43,6 +46,12 @@ let mfaChallengeName = $derived((f()?.challengeName as string) ?? '');
 				<p class="text-sm text-[var(--color-text-muted)] mt-2 font-semibold">MFA認証</p>
 			{/if}
 		</div>
+
+		{#if passwordReset}
+			<div class="mb-4 p-3 bg-green-50 text-green-700 border border-green-200 rounded-[var(--radius-sm)] text-sm" role="status">
+				パスワードがリセットされました。新しいパスワードでログインしてください。
+			</div>
+		{/if}
 
 		{#if form?.error}
 			<div class="mb-4 p-3 bg-red-50 text-red-600 border border-red-200 rounded-[var(--radius-sm)] text-sm" role="alert">
@@ -143,6 +152,12 @@ let mfaChallengeName = $derived((f()?.challengeName as string) ?? '');
 					minlength={8}
 					autocomplete="current-password"
 				/>
+
+				<div class="-mt-2 text-right">
+					<a href="/auth/forgot-password" class="text-xs text-[var(--color-text-link)] hover:underline">
+						パスワードを忘れた方はこちら
+					</a>
+				</div>
 
 				<Button type="submit" disabled={loading || !email || !password} size="md" class="w-full">
 					{#if loading}

--- a/tests/unit/services/cognito-direct-auth.test.ts
+++ b/tests/unit/services/cognito-direct-auth.test.ts
@@ -1,5 +1,5 @@
 // tests/unit/services/cognito-direct-auth.test.ts
-// Cognito Direct Auth (SignUp, ConfirmSignUp, Authenticate, MFA) のユニットテスト
+// Cognito Direct Auth (SignUp, ConfirmSignUp, Authenticate, MFA, ForgotPassword) のユニットテスト
 // AWS SDK をモックして各関数のエラーハンドリングを検証する
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -30,12 +30,24 @@ vi.mock('@aws-sdk/client-cognito-identity-provider', () => {
 			Object.assign(this, params, { _type: 'RespondToAuthChallenge' });
 		}
 	}
+	class MockForgotPasswordCommand {
+		constructor(params: Record<string, unknown>) {
+			Object.assign(this, params, { _type: 'ForgotPassword' });
+		}
+	}
+	class MockConfirmForgotPasswordCommand {
+		constructor(params: Record<string, unknown>) {
+			Object.assign(this, params, { _type: 'ConfirmForgotPassword' });
+		}
+	}
 	return {
 		CognitoIdentityProviderClient: MockClient,
 		InitiateAuthCommand: MockInitiateAuthCommand,
 		SignUpCommand: MockSignUpCommand,
 		ConfirmSignUpCommand: MockConfirmSignUpCommand,
 		RespondToAuthChallengeCommand: MockRespondToAuthChallengeCommand,
+		ForgotPasswordCommand: MockForgotPasswordCommand,
+		ConfirmForgotPasswordCommand: MockConfirmForgotPasswordCommand,
 	};
 });
 
@@ -47,7 +59,9 @@ vi.mock('$lib/server/logger', () => ({
 // 各関数は呼び出し時に process.env を読むため、beforeEach での env 設定が有効
 import {
 	authenticateWithCognito,
+	confirmForgotPassword,
 	confirmSignUp,
+	forgotPassword,
 	respondToMfaChallenge,
 	signUpWithCognito,
 } from '../../../src/lib/server/auth/providers/cognito-direct-auth';
@@ -289,6 +303,135 @@ describe('respondToMfaChallenge', () => {
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(result.message).toContain('期限切れ');
+		}
+	});
+});
+
+// ============================================================
+// forgotPassword
+// ============================================================
+describe('forgotPassword', () => {
+	it('正常にパスワードリセットリクエストを送信する', async () => {
+		mockSend.mockResolvedValue({});
+
+		const result = await forgotPassword('test@example.com');
+
+		expect(result).toEqual({ success: true });
+	});
+
+	it('UserNotFoundException でも成功扱いにする（ユーザー列挙防止）', async () => {
+		mockSend.mockRejectedValue(
+			Object.assign(new Error('user not found'), { name: 'UserNotFoundException' }),
+		);
+
+		const result = await forgotPassword('nonexistent@example.com');
+
+		// セキュリティ: ユーザーが存在しないことを漏らさない
+		expect(result).toEqual({ success: true });
+	});
+
+	it('LimitExceededException で適切なエラーメッセージ', async () => {
+		mockSend.mockRejectedValue(
+			Object.assign(new Error('too many requests'), { name: 'LimitExceededException' }),
+		);
+
+		const result = await forgotPassword('test@example.com');
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.message).toContain('上限に達しました');
+		}
+	});
+
+	it('不明なエラーで汎用メッセージ', async () => {
+		mockSend.mockRejectedValue(new Error('network error'));
+
+		const result = await forgotPassword('test@example.com');
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.message).toContain('パスワードリセットに失敗しました');
+		}
+	});
+});
+
+// ============================================================
+// confirmForgotPassword
+// ============================================================
+describe('confirmForgotPassword', () => {
+	it('正常にパスワードをリセットする', async () => {
+		mockSend.mockResolvedValue({});
+
+		const result = await confirmForgotPassword('test@example.com', '123456', 'NewPassword1');
+
+		expect(result).toEqual({ success: true });
+	});
+
+	it('CodeMismatchException で INVALID_CODE エラー', async () => {
+		mockSend.mockRejectedValue(
+			Object.assign(new Error('code mismatch'), { name: 'CodeMismatchException' }),
+		);
+
+		const result = await confirmForgotPassword('test@example.com', '000000', 'NewPassword1');
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toBe('INVALID_CODE');
+			expect(result.message).toContain('確認コードが正しくありません');
+		}
+	});
+
+	it('UserNotFoundException で CodeMismatchException と同じエラーを返す（ユーザー列挙防止）', async () => {
+		mockSend.mockRejectedValue(
+			Object.assign(new Error('user not found'), { name: 'UserNotFoundException' }),
+		);
+
+		const result = await confirmForgotPassword('nonexistent@example.com', '123456', 'NewPassword1');
+
+		// セキュリティ: CodeMismatchException と区別できないこと
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toBe('INVALID_CODE');
+			expect(result.message).toContain('確認コードが正しくありません');
+		}
+	});
+
+	it('InvalidParameterException で CodeMismatchException と同じエラーを返す（ユーザー列挙防止）', async () => {
+		mockSend.mockRejectedValue(
+			Object.assign(new Error('invalid parameter'), { name: 'InvalidParameterException' }),
+		);
+
+		const result = await confirmForgotPassword('test@example.com', '123456', 'NewPassword1');
+
+		// セキュリティ: CodeMismatchException と区別できないこと
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toBe('INVALID_CODE');
+			expect(result.message).toContain('確認コードが正しくありません');
+		}
+	});
+
+	it('ExpiredCodeException で適切なエラーメッセージ', async () => {
+		mockSend.mockRejectedValue(
+			Object.assign(new Error('expired'), { name: 'ExpiredCodeException' }),
+		);
+
+		const result = await confirmForgotPassword('test@example.com', '123456', 'NewPassword1');
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.message).toContain('有効期限が切れています');
+		}
+	});
+
+	it('不明なエラーで汎用メッセージ', async () => {
+		mockSend.mockRejectedValue(new Error('network error'));
+
+		const result = await confirmForgotPassword('test@example.com', '123456', 'NewPassword1');
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.message).toContain('パスワードのリセットに失敗しました');
 		}
 	});
 });


### PR DESCRIPTION
## Summary
- Cognito `ForgotPassword` / `ConfirmForgotPassword` API ラッパーを `cognito-direct-auth.ts` に追加
- `/auth/forgot-password` ルート（2ステップフォーム）を新規作成
- ログインページに「パスワードを忘れた方はこちら」リンクとリセット成功メッセージを追加

## Test plan
- [ ] `npx biome check` (変更ファイル) -- pass
- [ ] `npx svelte-check` -- 0 errors
- [ ] `npx vitest run` -- 2171 tests pass
- [ ] `/auth/forgot-password` にアクセスし、Step 1 (メール入力) フォームが表示される
- [ ] メール送信後、Step 2 (確認コード + 新パスワード) に遷移する
- [ ] パスワードリセット成功後、`/auth/login?passwordReset=true` にリダイレクトされ成功メッセージが表示される
- [ ] ログインページに「パスワードを忘れた方はこちら」リンクが表示される

closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)