### PR TITLE
fix: #460 特商法表記の氏名誤記を修正

### DIFF
--- a/site/tokushoho.html
+++ b/site/tokushoho.html
@@ -50,11 +50,11 @@ table td{color:var(--gray-700)}
   <table>
     <tr>
       <th>販売業者</th>
-      <td>日下武則</td>
+      <td>日下武紀</td>
     </tr>
     <tr>
       <th>運営責任者</th>
-      <td>日下武則</td>
+      <td>日下武紀</td>
     </tr>
     <tr>
       <th>所在地</th>


### PR DESCRIPTION
## Summary
- `site/tokushoho.html` の販売業者・運営責任者の氏名を `日下武則` → `日下武紀` に修正（2箇所）

closes #460

## Test plan
- [ ] `site/tokushoho.html` をブラウザで開き、販売業者・運営責任者が「日下武紀」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)