### PR TITLE
fix: #462 #463 SLA Discord記述修正 + 法務ページnoindex見直し

### DIFF
--- a/site/privacy.html
+++ b/site/privacy.html
@@ -4,7 +4,6 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>プライバシーポリシー - がんばりクエスト</title>
-<meta name="robots" content="noindex">
 <meta property="og:title" content="プライバシーポリシー - がんばりクエスト">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.ganbari-quest.com/privacy.html">

--- a/site/sla.html
+++ b/site/sla.html
@@ -104,7 +104,7 @@ body{line-height:1.8;background:var(--gray-50)}
 
   <section>
     <h2>第6条（サポート対応）</h2>
-    <p>お問い合わせは<a href="https://github.com/Takenori-Kusaka/ganbari-quest/issues">GitHub Issues</a>または<a href="mailto:ganbari.quest.support@gmail.com">メール</a>にて24時間受け付けています。初回応答は48時間以内（営業日ベース）を目標としています。対応言語は日本語です。</p>
+    <p>お問い合わせは<a href="https://github.com/Takenori-Kusaka/ganbari-quest/issues">GitHub Issues</a>または<a href="mailto:ganbari.quest.support@gmail.com">メール</a>にて24時間受け付けています。有料プランご利用者は<a href="https://discord.gg/5pWkf4Z5">Discord</a>でもお問い合わせいただけます。初回応答は48時間以内（営業日ベース）を目標としています。対応言語は日本語です。</p>
     <p>個人運営のため、応答が遅れる場合があります。ご理解をお願いいたします。</p>
   </section>
 

--- a/site/terms.html
+++ b/site/terms.html
@@ -4,7 +4,6 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>利用規約 - がんばりクエスト</title>
-<meta name="robots" content="noindex">
 <meta property="og:title" content="利用規約 - がんばりクエスト">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://www.ganbari-quest.com/terms.html">


### PR DESCRIPTION
## Summary
- **#462**: sla.html の Discord サポートリンクを有料プラン利用者向けの条件付き記述に変更（Discord は有料プラン限定のため）
- **#463**: terms.html と privacy.html から `noindex` メタタグを削除し、SEO 信頼シグナルとしてインデックスを許可。sla.html と tokushoho.html は `noindex` を維持

closes #462, closes #463

## Test plan
- [ ] `site/sla.html` を開いて第6条の文言が「有料プランご利用者はDiscordでもお問い合わせいただけます」になっていること
- [ ] `site/terms.html` のソースに `noindex` が含まれないこと
- [ ] `site/privacy.html` のソースに `noindex` が含まれないこと
- [ ] `site/sla.html` と `site/tokushoho.html` に `noindex` が維持されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)