### PR TITLE
fix: #481 E2Eテスト終了時のテナント・ユーザーデータクリーンアップ

### DIFF
--- a/playwright.aws.config.ts
+++ b/playwright.aws.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 	timeout: 60_000,
 	reporter: [['list'], ['json', { outputFile: 'test-results/aws.json' }]],
 	globalSetup: './tests/e2e/global-setup-aws.ts',
+	globalTeardown: './tests/e2e/global-teardown-aws.ts',
 	use: {
 		baseURL: process.env.E2E_BASE_URL || 'https://ganbari-quest.com',
 		actionTimeout: 15_000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 	timeout: 30_000,
 	reporter: [['list'], ['html', { open: 'never' }], ['json', { outputFile: 'test-results.json' }]],
 	globalSetup: './tests/e2e/global-setup.ts',
+	globalTeardown: './tests/e2e/global-teardown.ts',
 	use: {
 		baseURL: 'http://localhost:5173',
 		trace: 'on-first-retry',

--- a/tests/e2e/global-teardown-aws.ts
+++ b/tests/e2e/global-teardown-aws.ts
@@ -44,9 +44,7 @@ export default async function globalTeardown() {
 	console.log(
 		'[AWS E2E Teardown] WARNING: Cleanup failed. Orphaned test data may remain in DynamoDB/Cognito.',
 	);
-	console.log(
-		`[AWS E2E Teardown] Manual cleanup may be needed for test user: ${TEST_EMAIL}`,
-	);
+	console.log(`[AWS E2E Teardown] Manual cleanup may be needed for test user: ${TEST_EMAIL}`);
 }
 
 // ============================================================
@@ -59,7 +57,7 @@ async function tryApiDeletion(): Promise<boolean> {
 		return false;
 	}
 
-	let browser;
+	let browser: import('@playwright/test').Browser | undefined;
 	try {
 		browser = await chromium.launch();
 		const context = await browser.newContext({
@@ -87,12 +85,9 @@ async function tryApiDeletion(): Promise<boolean> {
 		// 403 → owner でない可能性（テスト用ユーザーが owner ではない場合）
 		// owner-full-delete を試す
 		if (status === 403) {
-			const fullDeleteRes = await apiContext.post(
-				`${BASE_URL}/api/v1/admin/account/delete`,
-				{
-					data: { pattern: 'owner-full-delete' },
-				},
-			);
+			const fullDeleteRes = await apiContext.post(`${BASE_URL}/api/v1/admin/account/delete`, {
+				data: { pattern: 'owner-full-delete' },
+			});
 			if (fullDeleteRes.status() === 200) {
 				console.log('[AWS E2E Teardown] Account deleted via API (full-delete pattern).');
 				return true;
@@ -100,9 +95,7 @@ async function tryApiDeletion(): Promise<boolean> {
 		}
 
 		const errorBody = await response.text().catch(() => '');
-		console.log(
-			`[AWS E2E Teardown] API deletion returned status ${status}: ${errorBody}`,
-		);
+		console.log(`[AWS E2E Teardown] API deletion returned status ${status}: ${errorBody}`);
 		return false;
 	} catch (err) {
 		console.log(`[AWS E2E Teardown] API deletion error: ${String(err)}`);
@@ -126,9 +119,7 @@ async function trySdkDeletion(): Promise<boolean> {
 		if (userPoolId) {
 			await deleteCognitoTestUser(userPoolId, region, TEST_EMAIL);
 		} else {
-			console.log(
-				'[AWS E2E Teardown] COGNITO_USER_POOL_ID not set, skipping Cognito cleanup.',
-			);
+			console.log('[AWS E2E Teardown] COGNITO_USER_POOL_ID not set, skipping Cognito cleanup.');
 		}
 
 		// DynamoDB からテストユーザーのデータを削除
@@ -148,10 +139,9 @@ async function deleteCognitoTestUser(
 	email: string,
 ): Promise<void> {
 	try {
-		const {
-			AdminDeleteUserCommand,
-			CognitoIdentityProviderClient,
-		} = await import('@aws-sdk/client-cognito-identity-provider');
+		const { AdminDeleteUserCommand, CognitoIdentityProviderClient } = await import(
+			'@aws-sdk/client-cognito-identity-provider'
+		);
 
 		const client = new CognitoIdentityProviderClient({ region });
 		await client.send(
@@ -171,6 +161,92 @@ async function deleteCognitoTestUser(
 	}
 }
 
+// ============================================================
+// DynamoDB ヘルパー: ページング付き Query → 全件削除
+// ============================================================
+
+type DocClient = import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+/** Query でパーティション内のアイテムを全件取得（ページング対応） */
+async function queryAllItems(
+	doc: DocClient,
+	tableName: string,
+	keyConditionExpression: string,
+	expressionAttributeValues: Record<string, unknown>,
+): Promise<Record<string, unknown>[]> {
+	const { QueryCommand } = await import('@aws-sdk/lib-dynamodb');
+	const items: Record<string, unknown>[] = [];
+	let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: tableName,
+				KeyConditionExpression: keyConditionExpression,
+				ExpressionAttributeValues: expressionAttributeValues,
+				ExclusiveStartKey: lastEvaluatedKey,
+			}),
+		);
+		items.push(...((result.Items ?? []) as Record<string, unknown>[]));
+		lastEvaluatedKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastEvaluatedKey);
+
+	return items;
+}
+
+/** 指定されたアイテムを全件削除 */
+async function deleteItems(
+	doc: DocClient,
+	tableName: string,
+	items: Record<string, unknown>[],
+): Promise<number> {
+	const { DeleteCommand } = await import('@aws-sdk/lib-dynamodb');
+	let deleted = 0;
+	for (const item of items) {
+		await doc.send(
+			new DeleteCommand({
+				TableName: tableName,
+				Key: { PK: item.PK, SK: item.SK },
+			}),
+		);
+		deleted++;
+	}
+	return deleted;
+}
+
+/** GSI を使った Query（ページング対応） */
+async function queryAllItemsGSI(
+	doc: DocClient,
+	tableName: string,
+	indexName: string,
+	keyConditionExpression: string,
+	expressionAttributeValues: Record<string, unknown>,
+): Promise<Record<string, unknown>[]> {
+	const { QueryCommand } = await import('@aws-sdk/lib-dynamodb');
+	const items: Record<string, unknown>[] = [];
+	let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: tableName,
+				IndexName: indexName,
+				KeyConditionExpression: keyConditionExpression,
+				ExpressionAttributeValues: expressionAttributeValues,
+				ExclusiveStartKey: lastEvaluatedKey,
+			}),
+		);
+		items.push(...((result.Items ?? []) as Record<string, unknown>[]));
+		lastEvaluatedKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastEvaluatedKey);
+
+	return items;
+}
+
+// ============================================================
+// DynamoDB テストデータ削除
+// ============================================================
+
 /** DynamoDB から E2E テストユーザーのデータを検索・削除 */
 async function deleteDynamoDbTestData(
 	tableName: string,
@@ -178,11 +254,7 @@ async function deleteDynamoDbTestData(
 	email: string,
 ): Promise<void> {
 	const { DynamoDBClient } = await import('@aws-sdk/client-dynamodb');
-	const {
-		DynamoDBDocumentClient,
-		QueryCommand,
-		DeleteCommand,
-	} = await import('@aws-sdk/lib-dynamodb');
+	const { DynamoDBDocumentClient } = await import('@aws-sdk/lib-dynamodb');
 
 	const baseClient = new DynamoDBClient({ region });
 	const doc = DynamoDBDocumentClient.from(baseClient, {
@@ -190,17 +262,11 @@ async function deleteDynamoDbTestData(
 		unmarshallOptions: { wrapNumbers: false },
 	});
 
-	// GSI1 (inverted index: PK=SK) でメールからユーザーを検索
-	const userResult = await doc.send(
-		new QueryCommand({
-			TableName: tableName,
-			IndexName: 'GSI1',
-			KeyConditionExpression: 'SK = :sk',
-			ExpressionAttributeValues: { ':sk': `EMAIL#${email}` },
-		}),
-	);
+	// GSI1 (inverted index: PK=SK) でメールからユーザーを検索（ページング対応）
+	const userItems = await queryAllItemsGSI(doc, tableName, 'GSI1', 'SK = :sk', {
+		':sk': `EMAIL#${email}`,
+	});
 
-	const userItems = userResult.Items ?? [];
 	if (userItems.length === 0) {
 		console.log(`[AWS E2E Teardown] No DynamoDB user found for: ${email}`);
 		return;
@@ -210,54 +276,31 @@ async function deleteDynamoDbTestData(
 		const userId = userItem.userId as string;
 		const userPK = `USER#${userId}`;
 
-		// ユーザーのテナントメンバーシップを検索
-		const membershipResult = await doc.send(
-			new QueryCommand({
-				TableName: tableName,
-				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
-				ExpressionAttributeValues: {
-					':pk': userPK,
-					':prefix': 'TENANT#',
-				},
-			}),
+		// ユーザーのテナントメンバーシップを検索（ページング対応）
+		const membershipItems = await queryAllItems(
+			doc,
+			tableName,
+			'PK = :pk AND begins_with(SK, :prefix)',
+			{ ':pk': userPK, ':prefix': 'TENANT#' },
 		);
 
 		const tenantIds: string[] = [];
-		for (const item of membershipResult.Items ?? []) {
+		for (const item of membershipItems) {
 			const tenantId = item.tenantId as string;
 			if (tenantId) tenantIds.push(tenantId);
-
-			// User-tenant membership を削除
-			await doc.send(
-				new DeleteCommand({
-					TableName: tableName,
-					Key: { PK: userPK, SK: item.SK },
-				}),
-			);
 		}
+
+		// User-tenant membership を削除
+		await deleteItems(doc, tableName, membershipItems);
 
 		// 各テナントのクリーンアップ
 		for (const tenantId of tenantIds) {
-			await cleanupTenantData(doc, tableName, tenantId, userId);
+			await cleanupTenantData(doc, tableName, tenantId);
 		}
 
-		// ユーザー関連の全アイテムを削除
-		const userAllItems = await doc.send(
-			new QueryCommand({
-				TableName: tableName,
-				KeyConditionExpression: 'PK = :pk',
-				ExpressionAttributeValues: { ':pk': userPK },
-			}),
-		);
-
-		for (const item of userAllItems.Items ?? []) {
-			await doc.send(
-				new DeleteCommand({
-					TableName: tableName,
-					Key: { PK: item.PK, SK: item.SK },
-				}),
-			);
-		}
+		// ユーザー関連の全アイテムを削除（ページング対応）
+		const userAllItems = await queryAllItems(doc, tableName, 'PK = :pk', { ':pk': userPK });
+		await deleteItems(doc, tableName, userAllItems);
 
 		console.log(
 			`[AWS E2E Teardown] DynamoDB user cleaned: ${userId} (${tenantIds.length} tenant(s))`,
@@ -267,73 +310,107 @@ async function deleteDynamoDbTestData(
 	baseClient.destroy();
 }
 
-/** テナント配下の全データを削除 */
+/** テナント配下の全データを削除（INVITE#/LICENSE# 含む） */
 async function cleanupTenantData(
-	doc: import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient,
+	doc: DocClient,
 	tableName: string,
 	tenantId: string,
-	_userId: string,
 ): Promise<void> {
-	const { QueryCommand, DeleteCommand, ScanCommand } = await import('@aws-sdk/lib-dynamodb');
-	const tenantAuthPK = `TENANT#${tenantId}`;
+	const { DeleteCommand } = await import('@aws-sdk/lib-dynamodb');
 	let totalDeleted = 0;
 
-	// 1. Auth パーティション (PK=TENANT#<tenantId>) — メンバー、招待、同意等
-	let lastKey: Record<string, unknown> | undefined;
-	do {
-		const result = await doc.send(
-			new QueryCommand({
-				TableName: tableName,
-				KeyConditionExpression: 'PK = :pk',
-				ExpressionAttributeValues: { ':pk': tenantAuthPK },
-				ExclusiveStartKey: lastKey,
-			}),
-		);
+	// 1. Auth パーティション (PK=TENANT#<tenantId>) — メンバー、招待、同意等（ページング対応）
+	const tenantAuthPK = `TENANT#${tenantId}`;
+	const authItems = await queryAllItems(doc, tableName, 'PK = :pk', { ':pk': tenantAuthPK });
 
-		for (const item of result.Items ?? []) {
+	// 招待コードとライセンスキーを収集（グローバルPK アイテム削除用）
+	const inviteCodes: string[] = [];
+	const licenseKeys: string[] = [];
+	for (const item of authItems) {
+		const sk = item.SK as string;
+		if (sk?.startsWith('INVITE#')) {
+			const code = sk.replace('INVITE#', '');
+			if (code) inviteCodes.push(code);
+		}
+		if (sk === 'LICENSE') {
+			// tenantLicenseKey の SK は 'LICENSE'（ライセンスキー値は item.licenseKey に格納）
+			const key = item.licenseKey as string | undefined;
+			if (key) licenseKeys.push(key);
+		}
+		// META アイテムの licenseKey フィールドも確認
+		if (sk === 'META') {
+			const key = item.licenseKey as string | undefined;
+			if (key) licenseKeys.push(key);
+		}
+	}
+
+	totalDeleted += await deleteItems(doc, tableName, authItems);
+
+	// 2. INVITE#<code> グローバルアイテムの削除（招待コードの primary item）
+	for (const code of inviteCodes) {
+		try {
 			await doc.send(
 				new DeleteCommand({
 					TableName: tableName,
-					Key: { PK: item.PK, SK: item.SK },
+					Key: { PK: `INVITE#${code}`, SK: 'META' },
 				}),
 			);
 			totalDeleted++;
+		} catch {
+			// アイテムが既に削除済みの場合は無視
 		}
+	}
 
-		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
-	} while (lastKey);
-
-	// 2. データパーティション (PK begins_with T#<tenantId>#) — 子供、活動、設定等
-	// DynamoDB の Query は正確な PK 一致のみ対応するため、Scan + FilterExpression を使用
-	const dataPrefix = `T#${tenantId}#`;
-	lastKey = undefined;
-
-	do {
-		const result = await doc.send(
-			new ScanCommand({
-				TableName: tableName,
-				FilterExpression: 'begins_with(PK, :prefix)',
-				ExpressionAttributeValues: { ':prefix': dataPrefix },
-				ExclusiveStartKey: lastKey,
-			}),
-		);
-
-		for (const item of result.Items ?? []) {
+	// 3. LICENSE#<key> グローバルアイテムの削除（ライセンスキーの primary item）
+	for (const key of licenseKeys) {
+		try {
 			await doc.send(
 				new DeleteCommand({
 					TableName: tableName,
-					Key: { PK: item.PK, SK: item.SK },
+					Key: { PK: `LICENSE#${key}`, SK: 'META' },
 				}),
 			);
 			totalDeleted++;
+		} catch {
+			// アイテムが既に削除済みの場合は無視
 		}
+	}
 
-		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
-	} while (lastKey);
+	// 4. データパーティション (PK=T#<tenantId>#*) — 子供、活動、設定等
+	//    DynamoDB の Query は正確な PK 一致のみ対応。テナント配下の既知のパーティションを列挙して削除。
+	//    既知のサブパーティション: CHILDREN, ACTIVITIES, SETTINGS, LOGS, STATUSES, STAMPS, CHECKLISTS 等
+	const knownSubPartitions = [
+		'CHILDREN',
+		'ACTIVITIES',
+		'SETTINGS',
+		'LOGS',
+		'STATUSES',
+		'STAMPS',
+		'CHECKLISTS',
+		'ACHIEVEMENTS',
+		'SIBLING_CHALLENGES',
+		'PUSH_SUBSCRIPTIONS',
+		'NOTIFICATION_LOGS',
+		'CERTIFICATES',
+		'CUSTOM_ACHIEVEMENTS',
+		'TRIAL_HISTORY',
+		'VIEWER_TOKENS',
+		'CUSTOM_VOICES',
+		'MASTERY',
+	];
+
+	for (const sub of knownSubPartitions) {
+		const subPK = `T#${tenantId}#${sub}`;
+		const subItems = await queryAllItems(doc, tableName, 'PK = :pk', { ':pk': subPK });
+		totalDeleted += await deleteItems(doc, tableName, subItems);
+	}
+
+	// 5. T#<tenantId> 直接パーティション（テナントレベルのデータ）
+	const directPK = `T#${tenantId}`;
+	const directItems = await queryAllItems(doc, tableName, 'PK = :pk', { ':pk': directPK });
+	totalDeleted += await deleteItems(doc, tableName, directItems);
 
 	if (totalDeleted > 0) {
-		console.log(
-			`[AWS E2E Teardown] Cleaned ${totalDeleted} item(s) from tenant: ${tenantId}`,
-		);
+		console.log(`[AWS E2E Teardown] Cleaned ${totalDeleted} item(s) from tenant: ${tenantId}`);
 	}
 }

--- a/tests/e2e/global-teardown-aws.ts
+++ b/tests/e2e/global-teardown-aws.ts
@@ -1,0 +1,339 @@
+// tests/e2e/global-teardown-aws.ts
+// AWS 本番環境 E2E テスト後のクリーンアップ
+// DynamoDB テナント・ユーザーデータ + Cognito ユーザーを削除
+//
+// 2段階のクリーンアップ戦略:
+// 1. 認証済み storageState を使って API 経由でアカウント削除（推奨）
+// 2. フォールバック: AWS SDK で直接 DynamoDB + Cognito を操作
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { chromium } from '@playwright/test';
+
+const BASE_URL = process.env.E2E_BASE_URL || 'https://ganbari-quest.com';
+const TEST_EMAIL = process.env.E2E_TEST_EMAIL || 'e2e-test@ganbari-quest.com';
+const STORAGE_STATE_PATH = path.resolve('tests/e2e/.auth/aws-storage-state.json');
+
+/** E2E テスト用データのクリーンアップを無効にする環境変数 */
+const SKIP_TEARDOWN = process.env.E2E_SKIP_TEARDOWN === 'true';
+
+export default async function globalTeardown() {
+	if (SKIP_TEARDOWN) {
+		console.log('[AWS E2E Teardown] E2E_SKIP_TEARDOWN=true, skipping cleanup.');
+		return;
+	}
+
+	console.log('[AWS E2E Teardown] Starting cleanup...');
+
+	// 戦略1: API 経由でアカウント削除
+	const apiSuccess = await tryApiDeletion();
+	if (apiSuccess) {
+		console.log('[AWS E2E Teardown] API-based cleanup succeeded.');
+		return;
+	}
+
+	// 戦略2: AWS SDK 直接操作（フォールバック）
+	console.log('[AWS E2E Teardown] API cleanup failed, trying direct SDK cleanup...');
+	const sdkSuccess = await trySdkDeletion();
+	if (sdkSuccess) {
+		console.log('[AWS E2E Teardown] SDK-based cleanup succeeded.');
+		return;
+	}
+
+	// 両方失敗しても、teardown の失敗でテストスイートを落とさない
+	console.log(
+		'[AWS E2E Teardown] WARNING: Cleanup failed. Orphaned test data may remain in DynamoDB/Cognito.',
+	);
+	console.log(
+		`[AWS E2E Teardown] Manual cleanup may be needed for test user: ${TEST_EMAIL}`,
+	);
+}
+
+// ============================================================
+// 戦略1: API 経由でアカウント削除
+// ============================================================
+
+async function tryApiDeletion(): Promise<boolean> {
+	if (!fs.existsSync(STORAGE_STATE_PATH)) {
+		console.log('[AWS E2E Teardown] storageState not found, cannot use API deletion.');
+		return false;
+	}
+
+	let browser;
+	try {
+		browser = await chromium.launch();
+		const context = await browser.newContext({
+			baseURL: BASE_URL,
+			storageState: STORAGE_STATE_PATH,
+			ignoreHTTPSErrors: true,
+		});
+
+		const apiContext = context.request;
+
+		// アカウント削除 API を呼び出す (Pattern 1: owner-only)
+		const response = await apiContext.post(`${BASE_URL}/api/v1/admin/account/delete`, {
+			data: { pattern: 'owner-only' },
+		});
+
+		const status = response.status();
+		if (status === 200) {
+			const body = await response.json();
+			console.log(
+				`[AWS E2E Teardown] Account deleted via API: ${body.itemsDeleted ?? 0} items, ${body.filesDeleted ?? 0} files`,
+			);
+			return true;
+		}
+
+		// 403 → owner でない可能性（テスト用ユーザーが owner ではない場合）
+		// owner-full-delete を試す
+		if (status === 403) {
+			const fullDeleteRes = await apiContext.post(
+				`${BASE_URL}/api/v1/admin/account/delete`,
+				{
+					data: { pattern: 'owner-full-delete' },
+				},
+			);
+			if (fullDeleteRes.status() === 200) {
+				console.log('[AWS E2E Teardown] Account deleted via API (full-delete pattern).');
+				return true;
+			}
+		}
+
+		const errorBody = await response.text().catch(() => '');
+		console.log(
+			`[AWS E2E Teardown] API deletion returned status ${status}: ${errorBody}`,
+		);
+		return false;
+	} catch (err) {
+		console.log(`[AWS E2E Teardown] API deletion error: ${String(err)}`);
+		return false;
+	} finally {
+		await browser?.close();
+	}
+}
+
+// ============================================================
+// 戦略2: AWS SDK 直接操作
+// ============================================================
+
+async function trySdkDeletion(): Promise<boolean> {
+	const userPoolId = process.env.COGNITO_USER_POOL_ID;
+	const region = process.env.AWS_REGION ?? 'us-east-1';
+	const tableName = process.env.DYNAMODB_TABLE ?? process.env.TABLE_NAME ?? 'ganbari-quest';
+
+	try {
+		// Cognito ユーザーを削除
+		if (userPoolId) {
+			await deleteCognitoTestUser(userPoolId, region, TEST_EMAIL);
+		} else {
+			console.log(
+				'[AWS E2E Teardown] COGNITO_USER_POOL_ID not set, skipping Cognito cleanup.',
+			);
+		}
+
+		// DynamoDB からテストユーザーのデータを削除
+		await deleteDynamoDbTestData(tableName, region, TEST_EMAIL);
+
+		return true;
+	} catch (err) {
+		console.log(`[AWS E2E Teardown] SDK cleanup error: ${String(err)}`);
+		return false;
+	}
+}
+
+/** Cognito から E2E テストユーザーを削除 */
+async function deleteCognitoTestUser(
+	userPoolId: string,
+	region: string,
+	email: string,
+): Promise<void> {
+	try {
+		const {
+			AdminDeleteUserCommand,
+			CognitoIdentityProviderClient,
+		} = await import('@aws-sdk/client-cognito-identity-provider');
+
+		const client = new CognitoIdentityProviderClient({ region });
+		await client.send(
+			new AdminDeleteUserCommand({
+				UserPoolId: userPoolId,
+				Username: email,
+			}),
+		);
+		console.log(`[AWS E2E Teardown] Cognito user deleted: ${email}`);
+	} catch (err) {
+		const errorName = (err as { name?: string })?.name ?? '';
+		if (errorName === 'UserNotFoundException') {
+			console.log(`[AWS E2E Teardown] Cognito user already gone: ${email}`);
+			return;
+		}
+		throw err;
+	}
+}
+
+/** DynamoDB から E2E テストユーザーのデータを検索・削除 */
+async function deleteDynamoDbTestData(
+	tableName: string,
+	region: string,
+	email: string,
+): Promise<void> {
+	const { DynamoDBClient } = await import('@aws-sdk/client-dynamodb');
+	const {
+		DynamoDBDocumentClient,
+		QueryCommand,
+		DeleteCommand,
+	} = await import('@aws-sdk/lib-dynamodb');
+
+	const baseClient = new DynamoDBClient({ region });
+	const doc = DynamoDBDocumentClient.from(baseClient, {
+		marshallOptions: { removeUndefinedValues: true },
+		unmarshallOptions: { wrapNumbers: false },
+	});
+
+	// GSI1 (inverted index: PK=SK) でメールからユーザーを検索
+	const userResult = await doc.send(
+		new QueryCommand({
+			TableName: tableName,
+			IndexName: 'GSI1',
+			KeyConditionExpression: 'SK = :sk',
+			ExpressionAttributeValues: { ':sk': `EMAIL#${email}` },
+		}),
+	);
+
+	const userItems = userResult.Items ?? [];
+	if (userItems.length === 0) {
+		console.log(`[AWS E2E Teardown] No DynamoDB user found for: ${email}`);
+		return;
+	}
+
+	for (const userItem of userItems) {
+		const userId = userItem.userId as string;
+		const userPK = `USER#${userId}`;
+
+		// ユーザーのテナントメンバーシップを検索
+		const membershipResult = await doc.send(
+			new QueryCommand({
+				TableName: tableName,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				ExpressionAttributeValues: {
+					':pk': userPK,
+					':prefix': 'TENANT#',
+				},
+			}),
+		);
+
+		const tenantIds: string[] = [];
+		for (const item of membershipResult.Items ?? []) {
+			const tenantId = item.tenantId as string;
+			if (tenantId) tenantIds.push(tenantId);
+
+			// User-tenant membership を削除
+			await doc.send(
+				new DeleteCommand({
+					TableName: tableName,
+					Key: { PK: userPK, SK: item.SK },
+				}),
+			);
+		}
+
+		// 各テナントのクリーンアップ
+		for (const tenantId of tenantIds) {
+			await cleanupTenantData(doc, tableName, tenantId, userId);
+		}
+
+		// ユーザー関連の全アイテムを削除
+		const userAllItems = await doc.send(
+			new QueryCommand({
+				TableName: tableName,
+				KeyConditionExpression: 'PK = :pk',
+				ExpressionAttributeValues: { ':pk': userPK },
+			}),
+		);
+
+		for (const item of userAllItems.Items ?? []) {
+			await doc.send(
+				new DeleteCommand({
+					TableName: tableName,
+					Key: { PK: item.PK, SK: item.SK },
+				}),
+			);
+		}
+
+		console.log(
+			`[AWS E2E Teardown] DynamoDB user cleaned: ${userId} (${tenantIds.length} tenant(s))`,
+		);
+	}
+
+	baseClient.destroy();
+}
+
+/** テナント配下の全データを削除 */
+async function cleanupTenantData(
+	doc: import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient,
+	tableName: string,
+	tenantId: string,
+	_userId: string,
+): Promise<void> {
+	const { QueryCommand, DeleteCommand, ScanCommand } = await import('@aws-sdk/lib-dynamodb');
+	const tenantAuthPK = `TENANT#${tenantId}`;
+	let totalDeleted = 0;
+
+	// 1. Auth パーティション (PK=TENANT#<tenantId>) — メンバー、招待、同意等
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: tableName,
+				KeyConditionExpression: 'PK = :pk',
+				ExpressionAttributeValues: { ':pk': tenantAuthPK },
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+
+		for (const item of result.Items ?? []) {
+			await doc.send(
+				new DeleteCommand({
+					TableName: tableName,
+					Key: { PK: item.PK, SK: item.SK },
+				}),
+			);
+			totalDeleted++;
+		}
+
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+
+	// 2. データパーティション (PK begins_with T#<tenantId>#) — 子供、活動、設定等
+	// DynamoDB の Query は正確な PK 一致のみ対応するため、Scan + FilterExpression を使用
+	const dataPrefix = `T#${tenantId}#`;
+	lastKey = undefined;
+
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: tableName,
+				FilterExpression: 'begins_with(PK, :prefix)',
+				ExpressionAttributeValues: { ':prefix': dataPrefix },
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+
+		for (const item of result.Items ?? []) {
+			await doc.send(
+				new DeleteCommand({
+					TableName: tableName,
+					Key: { PK: item.PK, SK: item.SK },
+				}),
+			);
+			totalDeleted++;
+		}
+
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+
+	if (totalDeleted > 0) {
+		console.log(
+			`[AWS E2E Teardown] Cleaned ${totalDeleted} item(s) from tenant: ${tenantId}`,
+		);
+	}
+}

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,0 +1,71 @@
+// tests/e2e/global-teardown.ts
+// E2E テスト後のローカル DB クリーンアップスクリプト
+// playwright.config.ts の globalTeardown から呼ばれる
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DB_PATH = path.resolve('data/ganbari-quest.db');
+
+export default async function globalTeardown() {
+	console.log('[E2E Teardown] Cleaning up test data...');
+
+	if (!fs.existsSync(DB_PATH)) {
+		console.log('[E2E Teardown] DB file not found, skipping cleanup.');
+		return;
+	}
+
+	try {
+		const Database = (await import('better-sqlite3')).default;
+		const db = new Database(DB_PATH);
+
+		// 今日の活動ログを削除（テスト実行で作成されたもの）
+		const deletedLogs = db
+			.prepare("DELETE FROM activity_logs WHERE recorded_date = date('now', 'localtime')")
+			.run();
+		if (deletedLogs.changes > 0) {
+			console.log(`[E2E Teardown]   Cleaned ${deletedLogs.changes} activity log(s) from today.`);
+		}
+
+		// 今日のログインボーナスを削除
+		const deletedBonus = db
+			.prepare("DELETE FROM login_bonuses WHERE login_date = date('now', 'localtime')")
+			.run();
+		if (deletedBonus.changes > 0) {
+			console.log(`[E2E Teardown]   Cleaned ${deletedBonus.changes} login bonus(es) from today.`);
+		}
+
+		// ピン留め設定を削除
+		const deletedPins = db.prepare('DELETE FROM child_activity_preferences').run();
+		if (deletedPins.changes > 0) {
+			console.log(`[E2E Teardown]   Cleaned ${deletedPins.changes} pin preference(s).`);
+		}
+
+		// 今日のスタンプエントリを削除
+		try {
+			const deletedStamps = db
+				.prepare("DELETE FROM stamp_entries WHERE login_date = date('now', 'localtime')")
+				.run();
+			if (deletedStamps.changes > 0) {
+				console.log(
+					`[E2E Teardown]   Cleaned ${deletedStamps.changes} stamp entry(ies) from today.`,
+				);
+			}
+		} catch {
+			// stamp_entries テーブルが存在しない場合は無視
+		}
+
+		// セッション情報をクリア（テスト中に作成されたセッション）
+		try {
+			db.prepare("UPDATE settings SET value = '' WHERE key IN ('session_token', 'session_expires_at')").run();
+		} catch {
+			// settings テーブルに該当行がない場合は無視
+		}
+
+		db.close();
+		console.log('[E2E Teardown] Cleanup complete.');
+	} catch (e) {
+		// Teardown の失敗はテスト結果に影響させない
+		console.log('[E2E Teardown] Cleanup error (non-fatal):', e);
+	}
+}

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -5,9 +5,22 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const DB_PATH = path.resolve('data/ganbari-quest.db');
+const databaseUrl = process.env.DATABASE_URL ?? './data/ganbari-quest.db';
+const DB_PATH = path.resolve(databaseUrl);
+
+/**
+ * E2E テスト用の子供 ID（global-setup.ts で作成されるテストデータ）
+ * セットアップで INSERT される子供の ID は 1, 2 （たろうくん, はなこちゃん）。
+ * 削除対象をこれらに限定することで、共用 DB 上の本物のユーザーデータを守る。
+ */
+const E2E_CHILD_IDS = [1, 2];
 
 export default async function globalTeardown() {
+	if (process.env.E2E_SKIP_TEARDOWN === 'true') {
+		console.log('[E2E Teardown] E2E_SKIP_TEARDOWN=true — skipping local cleanup.');
+		return;
+	}
+
 	console.log('[E2E Teardown] Cleaning up test data...');
 
 	if (!fs.existsSync(DB_PATH)) {
@@ -19,37 +32,43 @@ export default async function globalTeardown() {
 		const Database = (await import('better-sqlite3')).default;
 		const db = new Database(DB_PATH);
 
-		// 今日の活動ログを削除（テスト実行で作成されたもの）
+		const childIdPlaceholders = E2E_CHILD_IDS.map(() => '?').join(', ');
+
+		// E2E テスト子供の活動ログを削除（日付条件なし — 子供IDでスコープ限定）
 		const deletedLogs = db
-			.prepare("DELETE FROM activity_logs WHERE recorded_date = date('now', 'localtime')")
-			.run();
+			.prepare(`DELETE FROM activity_logs WHERE child_id IN (${childIdPlaceholders})`)
+			.run(...E2E_CHILD_IDS);
 		if (deletedLogs.changes > 0) {
-			console.log(`[E2E Teardown]   Cleaned ${deletedLogs.changes} activity log(s) from today.`);
+			console.log(`[E2E Teardown]   Cleaned ${deletedLogs.changes} activity log(s).`);
 		}
 
-		// 今日のログインボーナスを削除
+		// E2E テスト子供のログインボーナスを削除
 		const deletedBonus = db
-			.prepare("DELETE FROM login_bonuses WHERE login_date = date('now', 'localtime')")
-			.run();
+			.prepare(`DELETE FROM login_bonuses WHERE child_id IN (${childIdPlaceholders})`)
+			.run(...E2E_CHILD_IDS);
 		if (deletedBonus.changes > 0) {
-			console.log(`[E2E Teardown]   Cleaned ${deletedBonus.changes} login bonus(es) from today.`);
+			console.log(`[E2E Teardown]   Cleaned ${deletedBonus.changes} login bonus(es).`);
 		}
 
-		// ピン留め設定を削除
-		const deletedPins = db.prepare('DELETE FROM child_activity_preferences').run();
+		// E2E テスト子供のピン留め設定を削除
+		const deletedPins = db
+			.prepare(`DELETE FROM child_activity_preferences WHERE child_id IN (${childIdPlaceholders})`)
+			.run(...E2E_CHILD_IDS);
 		if (deletedPins.changes > 0) {
 			console.log(`[E2E Teardown]   Cleaned ${deletedPins.changes} pin preference(s).`);
 		}
 
-		// 今日のスタンプエントリを削除
+		// E2E テスト子供のスタンプエントリを削除
 		try {
 			const deletedStamps = db
-				.prepare("DELETE FROM stamp_entries WHERE login_date = date('now', 'localtime')")
-				.run();
+				.prepare(
+					`DELETE FROM stamp_entries WHERE card_id IN (
+						SELECT id FROM stamp_cards WHERE child_id IN (${childIdPlaceholders})
+					)`,
+				)
+				.run(...E2E_CHILD_IDS);
 			if (deletedStamps.changes > 0) {
-				console.log(
-					`[E2E Teardown]   Cleaned ${deletedStamps.changes} stamp entry(ies) from today.`,
-				);
+				console.log(`[E2E Teardown]   Cleaned ${deletedStamps.changes} stamp entry(ies).`);
 			}
 		} catch {
 			// stamp_entries テーブルが存在しない場合は無視
@@ -57,7 +76,9 @@ export default async function globalTeardown() {
 
 		// セッション情報をクリア（テスト中に作成されたセッション）
 		try {
-			db.prepare("UPDATE settings SET value = '' WHERE key IN ('session_token', 'session_expires_at')").run();
+			db.prepare(
+				"UPDATE settings SET value = '' WHERE key IN ('session_token', 'session_expires_at')",
+			).run();
 		} catch {
 			// settings テーブルに該当行がない場合は無視
 		}


### PR DESCRIPTION
## Summary
- `tests/e2e/global-teardown.ts` を追加し、ローカルE2Eテスト終了時にSQLiteのテストデータ（今日の活動ログ・ログインボーナス・ピン設定・スタンプ）を自動削除
- `tests/e2e/global-teardown-aws.ts` を追加し、AWS E2Eテスト終了時にDynamoDBテナントデータ + Cognitoユーザーを自動削除（API経由 + SDK直接操作のフォールバック戦略）
- `playwright.config.ts` と `playwright.aws.config.ts` に `globalTeardown` を登録

closes #481

## Test plan
- [ ] ローカルE2Eテスト実行後にテストデータが削除されていることを確認
- [ ] AWS E2Eテスト実行後にDynamoDB/Cognitoのテストデータが削除されていることを確認
- [ ] teardownでエラーが発生してもテスト結果に影響しないことを確認
- [ ] `E2E_SKIP_TEARDOWN=true` でクリーンアップが無効化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>