### PR TITLE
fix: #485 確認コード入力画面に有効期限ガイダンス表示

### DIFF
--- a/src/lib/domain/validation/auth.ts
+++ b/src/lib/domain/validation/auth.ts
@@ -38,6 +38,12 @@ export const signupSchema = z.object({
 		.regex(/^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/, 'ライセンスキーの形式が不正です'),
 });
 
+// 確認コード有効期限（Cognito設定と同期）
+/** サインアップ確認コードの有効期限（時間） */
+export const SIGNUP_CODE_EXPIRY_HOURS = 24;
+/** パスワードリセット確認コードの有効期限（分） */
+export const PASSWORD_RESET_CODE_EXPIRY_MINUTES = 60;
+
 // 招待リンク関連
 export const INVITE_COOKIE_NAME = 'invite_code';
 export const INVITE_EXPIRY_DAYS = 7;

--- a/src/lib/server/auth/providers/cognito-direct-auth.ts
+++ b/src/lib/server/auth/providers/cognito-direct-auth.ts
@@ -7,6 +7,7 @@ import {
 	InitiateAuthCommand,
 	type InitiateAuthCommandOutput,
 } from '@aws-sdk/client-cognito-identity-provider';
+import { SIGNUP_CODE_EXPIRY_HOURS } from '$lib/domain/validation/auth';
 import { logger } from '$lib/server/logger';
 
 interface CognitoDirectAuthConfig {
@@ -129,7 +130,7 @@ export async function authenticateWithCognito(
 			return {
 				success: false,
 				error: 'NOT_CONFIRMED',
-				message: 'メールアドレスの確認が完了していません',
+				message: `メールアドレスの確認が完了していません。登録時に送信された確認コード（${SIGNUP_CODE_EXPIRY_HOURS}時間有効）を入力してください`,
 			};
 		}
 

--- a/src/routes/auth/forgot-password/+page.svelte
+++ b/src/routes/auth/forgot-password/+page.svelte
@@ -4,6 +4,7 @@ import Logo from '$lib/ui/components/Logo.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
+import { PASSWORD_RESET_CODE_EXPIRY_MINUTES } from '$lib/domain/validation/auth';
 
 let { form } = $props();
 
@@ -59,6 +60,10 @@ $effect(() => {
 				<p class="text-sm text-[var(--color-text-muted)] text-center leading-relaxed">
 					<strong>{email}</strong> に確認コードを送信しました。<br />
 					メールに記載されたコードと新しいパスワードを入力してください。
+				</p>
+
+				<p class="text-xs text-[var(--color-text-muted)] text-center">
+					確認コードは{PASSWORD_RESET_CODE_EXPIRY_MINUTES}分間有効です。届かない場合は再送してください
 				</p>
 
 				<FormField label="確認コード" id="code">

--- a/src/routes/auth/signup/+page.svelte
+++ b/src/routes/auth/signup/+page.svelte
@@ -7,6 +7,7 @@ import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import Divider from '$lib/ui/primitives/Divider.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
+import { SIGNUP_CODE_EXPIRY_HOURS } from '$lib/domain/validation/auth';
 
 let { form } = $props();
 
@@ -74,6 +75,10 @@ $effect(() => {
 				<p class="text-sm text-[var(--color-text-muted)] text-center leading-relaxed">
 					<strong>{email}</strong> に確認コードを送信しました。<br />
 					メールに記載された6桁のコードを入力してください。
+				</p>
+
+				<p class="text-xs text-[var(--color-text-muted)] text-center">
+					確認コードは{SIGNUP_CODE_EXPIRY_HOURS}時間有効です
 				</p>
 
 				<FormField label="確認コード" id="code">


### PR DESCRIPTION
## Summary
- サインアップ確認画面に「確認コードは24時間有効です」ガイダンス追加
- パスワードリセット画面に「確認コードは60分間有効です。届かない場合は再送してください」ガイダンス追加
- ログインUNCONFIRMEDエラーメッセージに有効期限情報を追記
- 有効期限の値を共有定数化（`SIGNUP_CODE_EXPIRY_HOURS`, `PASSWORD_RESET_CODE_EXPIRY_MINUTES`）

closes #485

## Test plan
- [ ] サインアップ確認画面に有効期限テキストが表示される
- [ ] パスワードリセット画面に有効期限テキストが表示される
- [ ] ログインで未確認アカウントエラー時に有効期限情報が含まれる
- [ ] テキストが控えめなスタイル（muted, text-xs）で表示される
- [ ] CSSカスタムプロパティのみ使用（ハードコード色なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>