### PR TITLE
fix: #488 レポートの子供名suffix重複を修正

### DIFF
--- a/src/routes/(parent)/admin/reports/+page.svelte
+++ b/src/routes/(parent)/admin/reports/+page.svelte
@@ -160,7 +160,7 @@ function maxCategoryCount(breakdown: Record<string, number>): number {
 					<div class="rounded-xl border bg-white shadow-sm">
 						<!-- Header -->
 						<div class="monthly-report-header">
-							<h3 class="text-base font-bold">{report.childName}ちゃんの がんばりレポート</h3>
+							<h3 class="text-base font-bold">{report.childName}の がんばりレポート</h3>
 							<p class="text-xs opacity-80">{formatMonth(report.month)}</p>
 						</div>
 
@@ -299,7 +299,7 @@ function maxCategoryCount(breakdown: Record<string, number>): number {
 				<div class="rounded-xl border bg-white shadow-sm">
 					<!-- Header -->
 					<div class="rounded-t-xl bg-gradient-to-r from-blue-500 to-blue-600 px-4 py-3 text-white">
-						<h3 class="text-base font-bold">{report.childName}ちゃんの 週間レポート</h3>
+						<h3 class="text-base font-bold">{report.childName}の 週間レポート</h3>
 						<p class="text-xs opacity-80">{formatWeek(report.weekStart, report.weekEnd)}</p>
 					</div>
 


### PR DESCRIPTION
## Summary
- レポート画面（月次・週次）で「ちゃん」がハードコードされていたのを削除
- 登録名をそのまま表示するように変更し、「ゆうきちゃんちゃん」等のsuffix重複を解消

closes #488

## Test plan
- [ ] レポート画面で子供名にsuffixが重複しないこと
- [ ] 月次レポートヘッダーの表示確認
- [ ] 週次レポートヘッダーの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>