### PR TITLE
fix: #498 #506 ChildListCard uiMode日本語化 + OnboardingChecklist CSS変数化

### DIFF
--- a/src/lib/features/admin/components/ChildListCard.svelte
+++ b/src/lib/features/admin/components/ChildListCard.svelte
@@ -29,6 +29,14 @@ const themeEmojis: Record<string, string> = {
 	purple: '💜',
 };
 
+const uiModeLabels: Record<string, string> = {
+	baby: 'あかちゃん',
+	kinder: 'ようちえん',
+	lower: 'しょうがく低学年',
+	upper: 'しょうがく高学年',
+	teen: 'ティーン',
+};
+
 function formatBirthday(dateStr: string): string {
 	const d = new Date(dateStr);
 	return `${d.getMonth() + 1}月${d.getDate()}日`;
@@ -48,7 +56,7 @@ function formatBirthday(dateStr: string): string {
 			<div class="child-list-card__info">
 				<p class="child-list-card__name">{child.nickname}</p>
 				<p class="child-list-card__meta">
-					{child.age}歳 / {child.uiMode} / {themeEmojis[child.theme] ?? '🩷'}
+					{child.age}歳 / {uiModeLabels[child.uiMode] ?? child.uiMode} / {themeEmojis[child.theme] ?? '🩷'}
 				</p>
 				{#if child.birthDate}
 					<p class="child-list-card__birthday">🎂 {formatBirthday(child.birthDate)}</p>

--- a/src/lib/features/admin/components/OnboardingChecklist.svelte
+++ b/src/lib/features/admin/components/OnboardingChecklist.svelte
@@ -60,8 +60,8 @@ const progressPct = $derived(
 
 <style>
 	.onboarding-card {
-		background: linear-gradient(135deg, #eff6ff, #f0fdf4);
-		border: 1px solid #bfdbfe;
+		background: linear-gradient(135deg, var(--color-brand-50), var(--color-rarity-common-bg));
+		border: 1px solid var(--color-brand-200);
 		border-radius: 12px;
 		padding: 16px;
 	}
@@ -80,12 +80,12 @@ const progressPct = $derived(
 	.onboarding-title {
 		font-weight: 700;
 		font-size: 0.9375rem;
-		color: #1e40af;
+		color: var(--color-brand-800);
 	}
 
 	.progress-bar-container {
 		height: 8px;
-		background: #e2e8f0;
+		background: var(--color-neutral-200);
 		border-radius: 4px;
 		overflow: hidden;
 		margin-bottom: 4px;
@@ -93,14 +93,14 @@ const progressPct = $derived(
 
 	.progress-bar {
 		height: 100%;
-		background: linear-gradient(90deg, #3b82f6, #10b981);
+		background: linear-gradient(90deg, var(--color-action-primary), var(--color-success));
 		border-radius: 4px;
 		transition: width 0.3s ease;
 	}
 
 	.progress-text {
 		font-size: 0.6875rem;
-		color: #64748b;
+		color: var(--color-neutral-500);
 		margin: 0 0 12px 0;
 	}
 
@@ -118,11 +118,11 @@ const progressPct = $derived(
 		align-items: center;
 		gap: 8px;
 		font-size: 0.8125rem;
-		color: #374151;
+		color: var(--color-text);
 	}
 
 	.checklist-item.completed {
-		color: #9ca3af;
+		color: var(--color-text-muted);
 	}
 
 	.checklist-item.completed .item-label {
@@ -144,7 +144,7 @@ const progressPct = $derived(
 		justify-content: center;
 		width: 28px;
 		height: 28px;
-		background: #3b82f6;
+		background: var(--color-action-primary);
 		color: white;
 		border-radius: 8px;
 		text-decoration: none;
@@ -155,7 +155,7 @@ const progressPct = $derived(
 	}
 
 	.item-link:hover {
-		background: #2563eb;
+		background: var(--color-brand-700);
 	}
 
 	.next-recommendation {
@@ -163,9 +163,9 @@ const progressPct = $derived(
 		align-items: center;
 		gap: 6px;
 		font-size: 0.75rem;
-		color: #1e40af;
+		color: var(--color-brand-800);
 		padding: 8px 12px;
-		background: rgba(59, 130, 246, 0.08);
+		background: color-mix(in srgb, var(--color-action-primary) 8%, transparent);
 		border-radius: 8px;
 	}
 
@@ -175,7 +175,7 @@ const progressPct = $derived(
 
 	.recommendation-link {
 		font-weight: 700;
-		color: #1e40af;
+		color: var(--color-brand-800);
 		text-decoration: underline;
 	}
 
@@ -187,13 +187,13 @@ const progressPct = $derived(
 	.dismiss-btn {
 		background: none;
 		border: none;
-		color: #9ca3af;
+		color: var(--color-text-muted);
 		font-size: 0.6875rem;
 		cursor: pointer;
 		text-decoration: underline;
 	}
 
 	.dismiss-btn:hover {
-		color: #6b7280;
+		color: var(--color-neutral-500);
 	}
 </style>


### PR DESCRIPTION
## Summary
- ChildListCard の uiMode 内部コード(kinder/baby等)を日本語ラベルにマッピング（あかちゃん/ようちえん等）
- OnboardingChecklist の hex カラー14箇所を CSS 変数に置換（デザイントークン準拠）

closes #498, closes #506

## Test plan
- [ ] こども一覧で「ようちえん」「あかちゃん」等の日本語表示を確認
- [ ] OnboardingChecklist に hex カラーが残っていないこと
- [ ] svelte-check で変更ファイルにエラーなし
- [ ] vitest 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>