### PR TITLE
infra: #487 テナントスコープデータ完全削除の実装

### DIFF
--- a/src/lib/server/db/dynamodb/activity-mastery-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-mastery-repo.ts
@@ -3,8 +3,9 @@
 
 import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import type { ActivityMastery } from '../types';
+import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
-import { activityMasteryKey, activityMasteryPrefix, childPK } from './keys';
+import { activityMasteryKey, activityMasteryPrefix, childPK, tenantPK } from './keys';
 
 function stripKeys<T extends Record<string, unknown>>(
 	item: T,
@@ -69,6 +70,7 @@ export async function upsert(
 	return stripKeys(item) as unknown as ActivityMastery;
 }
 
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for activity-mastery-repo not implemented');
+/** テナントの全活動習熟度を削除（CHILD#* パーティション配下の MAST# アイテム） */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), activityMasteryPrefix());
 }

--- a/src/lib/server/db/dynamodb/activity-mastery-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-mastery-repo.ts
@@ -68,3 +68,7 @@ export async function upsert(
 	await getDocClient().send(new PutCommand({ TableName: TABLE_NAME, Item: item }));
 	return stripKeys(item) as unknown as ActivityMastery;
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for activity-mastery-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/activity-pref-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-pref-repo.ts
@@ -3,6 +3,7 @@
 
 import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import type { ActivityUsageCount, ChildActivityPreference } from '../types';
+import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { activityLogPrefix, activityPrefKey, activityPrefPrefix, childPK, tenantPK } from './keys';
 
@@ -132,6 +133,7 @@ export async function getUsageCounts(
 	}));
 }
 
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for activity-pref-repo not implemented');
+/** テナントの全活動ピン留め設定を削除（CHILD#* 配下の ACTPREF# アイテム） */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), activityPrefPrefix());
 }

--- a/src/lib/server/db/dynamodb/activity-pref-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-pref-repo.ts
@@ -131,3 +131,7 @@ export async function getUsageCounts(
 		usageCount,
 	}));
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for activity-pref-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -484,6 +484,17 @@ export const findTenantInvites: IAuthRepo['findTenantInvites'] = async (tenantId
 	return (result.Items ?? []).map(itemToInvite);
 };
 
+export const deleteInvite: IAuthRepo['deleteInvite'] = async (inviteCode, tenantId) => {
+	// Delete primary invite item (INVITE#<code>)
+	await doc().send(
+		new DeleteCommand({ TableName: TABLE_NAME, Key: inviteKey(inviteCode) }),
+	);
+	// Delete tenant adjacency item (TENANT#<tenantId>, INVITE#<code>)
+	await doc().send(
+		new DeleteCommand({ TableName: TABLE_NAME, Key: tenantInviteKey(tenantId, inviteCode) }),
+	);
+};
+
 // ============================================================
 // Item → Entity mappers
 // ============================================================

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -486,9 +486,7 @@ export const findTenantInvites: IAuthRepo['findTenantInvites'] = async (tenantId
 
 export const deleteInvite: IAuthRepo['deleteInvite'] = async (inviteCode, tenantId) => {
 	// Delete primary invite item (INVITE#<code>)
-	await doc().send(
-		new DeleteCommand({ TableName: TABLE_NAME, Key: inviteKey(inviteCode) }),
-	);
+	await doc().send(new DeleteCommand({ TableName: TABLE_NAME, Key: inviteKey(inviteCode) }));
 	// Delete tenant adjacency item (TENANT#<tenantId>, INVITE#<code>)
 	await doc().send(
 		new DeleteCommand({ TableName: TABLE_NAME, Key: tenantInviteKey(tenantId, inviteCode) }),

--- a/src/lib/server/db/dynamodb/auto-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/auto-challenge-repo.ts
@@ -45,3 +45,7 @@ export async function update(
 export async function expireOldChallenges(_beforeDate: string, _tenantId: string): Promise<number> {
 	throw new Error(NOT_IMPL);
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error(NOT_IMPL);
+}

--- a/src/lib/server/db/dynamodb/auto-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/auto-challenge-repo.ts
@@ -46,6 +46,7 @@ export async function expireOldChallenges(_beforeDate: string, _tenantId: string
 	throw new Error(NOT_IMPL);
 }
 
+/** テナントの全自動チャレンジを削除（DynamoDB未実装: 書き込みがないため no-op） */
 export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error(NOT_IMPL);
+	// DynamoDB auto-challenge repo は未実装のため書き込みデータなし — no-op
 }

--- a/src/lib/server/db/dynamodb/bulk-delete.ts
+++ b/src/lib/server/db/dynamodb/bulk-delete.ts
@@ -1,0 +1,108 @@
+// src/lib/server/db/dynamodb/bulk-delete.ts
+// Shared utility for bulk-deleting DynamoDB items by PK prefix (tenant data cleanup).
+
+import { BatchWriteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
+import { getDocClient, TABLE_NAME } from './client';
+
+const BATCH_SIZE = 25;
+
+/**
+ * Scan for all items whose PK begins with `pkPrefix` and batch-delete them.
+ * Handles pagination (LastEvaluatedKey) and batching (25 items per BatchWrite).
+ *
+ * @param pkPrefix - The PK prefix to match, e.g. `T#<tenantId>#CHILD#`
+ * @param skPrefix - Optional SK prefix to further narrow the scan
+ * @returns The number of items deleted
+ */
+export async function deleteItemsByPkPrefix(pkPrefix: string, skPrefix?: string): Promise<number> {
+	const doc = getDocClient();
+	const allKeys: Array<{ PK: string; SK: string }> = [];
+	let lastKey: Record<string, unknown> | undefined;
+
+	const filterParts = ['begins_with(PK, :pkPrefix)'];
+	const exprValues: Record<string, unknown> = { ':pkPrefix': pkPrefix };
+
+	if (skPrefix) {
+		filterParts.push('begins_with(SK, :skPrefix)');
+		exprValues[':skPrefix'] = skPrefix;
+	}
+
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: filterParts.join(' AND '),
+				ExpressionAttributeValues: exprValues,
+				ProjectionExpression: 'PK, SK',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+
+		for (const item of result.Items ?? []) {
+			allKeys.push({ PK: item.PK as string, SK: item.SK as string });
+		}
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+
+	// Batch delete in chunks of 25
+	for (let i = 0; i < allKeys.length; i += BATCH_SIZE) {
+		const batch = allKeys.slice(i, i + BATCH_SIZE);
+		await doc.send(
+			new BatchWriteCommand({
+				RequestItems: {
+					[TABLE_NAME]: batch.map((key) => ({
+						DeleteRequest: { Key: key },
+					})),
+				},
+			}),
+		);
+	}
+
+	return allKeys.length;
+}
+
+/**
+ * Delete all items whose PK exactly matches a single value.
+ * Uses Query (more efficient than Scan) when we know the full PK.
+ *
+ * @param pk - The exact PK value
+ * @returns The number of items deleted
+ */
+export async function deleteItemsByExactPk(pk: string): Promise<number> {
+	const { QueryCommand } = await import('@aws-sdk/lib-dynamodb');
+	const doc = getDocClient();
+	const allKeys: Array<{ PK: string; SK: string }> = [];
+	let lastKey: Record<string, unknown> | undefined;
+
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk',
+				ExpressionAttributeValues: { ':pk': pk },
+				ProjectionExpression: 'PK, SK',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+
+		for (const item of result.Items ?? []) {
+			allKeys.push({ PK: item.PK as string, SK: item.SK as string });
+		}
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+
+	for (let i = 0; i < allKeys.length; i += BATCH_SIZE) {
+		const batch = allKeys.slice(i, i + BATCH_SIZE);
+		await doc.send(
+			new BatchWriteCommand({
+				RequestItems: {
+					[TABLE_NAME]: batch.map((key) => ({
+						DeleteRequest: { Key: key },
+					})),
+				},
+			}),
+		);
+	}
+
+	return allKeys.length;
+}

--- a/src/lib/server/db/dynamodb/checklist-repo.ts
+++ b/src/lib/server/db/dynamodb/checklist-repo.ts
@@ -417,3 +417,7 @@ export async function deleteOverride(id: number): Promise<void> {
 		lastKey = result.LastEvaluatedKey;
 	} while (lastKey);
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for checklists not implemented');
+}

--- a/src/lib/server/db/dynamodb/checklist-repo.ts
+++ b/src/lib/server/db/dynamodb/checklist-repo.ts
@@ -20,14 +20,17 @@ import type {
 	UpdateChecklistTemplateInput,
 	UpsertChecklistLogInput,
 } from '../types';
+import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
 	checklistItemKey,
 	checklistItemPrefix,
 	checklistLogKey,
+	checklistLogPrefix,
 	checklistOverrideDatePrefix,
 	checklistOverrideKey,
+	checklistOverridePrefix,
 	checklistTemplateKey,
 	checklistTemplatePrefix,
 	childPK,
@@ -418,6 +421,18 @@ export async function deleteOverride(id: number): Promise<void> {
 	} while (lastKey);
 }
 
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for checklists not implemented');
+/**
+ * テナントの全チェックリストデータを削除。
+ * - CHILD#* 配下: CKTPL# (テンプレート), CKLOG# (ログ), CKOVER# (オーバーライド)
+ * - CKTPL#* 配下: ITEM# (テンプレートアイテム)
+ */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	// Delete checklist template items (PK=T#<tenantId>#CKTPL#*, SK=ITEM#*)
+	await deleteItemsByPkPrefix(tenantPK('CKTPL#', tenantId));
+	// Delete templates (CHILD#* 配下の CKTPL# アイテム)
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), checklistTemplatePrefix());
+	// Delete logs (CHILD#* 配下の CKLOG# アイテム)
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), checklistLogPrefix());
+	// Delete overrides (CHILD#* 配下の CKOVER# アイテム)
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), checklistOverridePrefix());
 }

--- a/src/lib/server/db/dynamodb/daily-mission-repo.ts
+++ b/src/lib/server/db/dynamodb/daily-mission-repo.ts
@@ -9,6 +9,7 @@ import {
 	UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
 import type { Activity, Child, DailyMissionWithActivity } from '../types';
+import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -332,6 +333,7 @@ export async function insertDailyMission(
 	);
 }
 
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for daily-mission-repo not implemented');
+/** テナントの全デイリーミッションを削除（CHILD#* 配下の MISSION# アイテム） */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), dailyMissionPrefix());
 }

--- a/src/lib/server/db/dynamodb/daily-mission-repo.ts
+++ b/src/lib/server/db/dynamodb/daily-mission-repo.ts
@@ -331,3 +331,7 @@ export async function insertDailyMission(
 		}),
 	);
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for daily-mission-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/evaluation-repo.ts
+++ b/src/lib/server/db/dynamodb/evaluation-repo.ts
@@ -310,3 +310,7 @@ export async function findRestDays(
 ): Promise<RestDay[]> {
 	return [];
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for evaluation-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/evaluation-repo.ts
+++ b/src/lib/server/db/dynamodb/evaluation-repo.ts
@@ -10,6 +10,7 @@ import type {
 	InsertEvaluationInput,
 	RestDay,
 } from '../types';
+import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -311,6 +312,7 @@ export async function findRestDays(
 	return [];
 }
 
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for evaluation-repo not implemented');
+/** テナントの全評価データを削除（CHILD#* 配下の EVAL# アイテム） */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), evaluationPrefix());
 }

--- a/src/lib/server/db/dynamodb/image-repo.ts
+++ b/src/lib/server/db/dynamodb/image-repo.ts
@@ -3,9 +3,10 @@
 
 import { GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type { CharacterImage, Child, InsertCharacterImageInput } from '../types';
+import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
-import { characterImageKey, childKey, ENTITY_NAMES } from './keys';
+import { characterImageKey, characterImagePrefix, childKey, ENTITY_NAMES, tenantPK } from './keys';
 
 /** Strip PK/SK/GSI keys from a DynamoDB item */
 function stripKeys<T extends Record<string, unknown>>(
@@ -106,6 +107,7 @@ export async function findChildForImage(
 	return stripKeys(result.Item) as unknown as Child;
 }
 
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for image-repo not implemented');
+/** テナントの全キャラクター画像レコードを削除（CHILD#* 配下の IMG# アイテム） */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), characterImagePrefix());
 }

--- a/src/lib/server/db/dynamodb/image-repo.ts
+++ b/src/lib/server/db/dynamodb/image-repo.ts
@@ -105,3 +105,7 @@ export async function findChildForImage(
 	if (!result.Item) return undefined;
 	return stripKeys(result.Item) as unknown as Child;
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for image-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/login-bonus-repo.ts
+++ b/src/lib/server/db/dynamodb/login-bonus-repo.ts
@@ -3,9 +3,10 @@
 
 import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import type { Child, InsertLoginBonusInput, LoginBonus } from '../types';
+import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
-import { childKey, childPK, ENTITY_NAMES, loginBonusKey, loginBonusPrefix } from './keys';
+import { childKey, childPK, ENTITY_NAMES, loginBonusKey, loginBonusPrefix, tenantPK } from './keys';
 
 /** Strip PK/SK/GSI keys from a DynamoDB item */
 function stripKeys<T extends Record<string, unknown>>(
@@ -105,6 +106,7 @@ export async function findChildById(id: number, tenantId: string): Promise<Child
 	return stripKeys(result.Item) as unknown as Child;
 }
 
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for login-bonus-repo not implemented');
+/** テナントの全ログインボーナスを削除（CHILD#* 配下の LOGIN# アイテム） */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), loginBonusPrefix());
 }

--- a/src/lib/server/db/dynamodb/login-bonus-repo.ts
+++ b/src/lib/server/db/dynamodb/login-bonus-repo.ts
@@ -104,3 +104,7 @@ export async function findChildById(id: number, tenantId: string): Promise<Child
 	if (!result.Item) return undefined;
 	return stripKeys(result.Item) as unknown as Child;
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for login-bonus-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/message-repo.ts
+++ b/src/lib/server/db/dynamodb/message-repo.ts
@@ -36,6 +36,7 @@ export async function markMessageShown(
 	return undefined;
 }
 
+/** テナントの全メッセージを削除（DynamoDB未実装: 書き込みがないため no-op） */
 export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for message-repo not implemented');
+	// DynamoDB message repo は未実装のため書き込みデータなし — no-op
 }

--- a/src/lib/server/db/dynamodb/message-repo.ts
+++ b/src/lib/server/db/dynamodb/message-repo.ts
@@ -35,3 +35,7 @@ export async function markMessageShown(
 ): Promise<ParentMessage | undefined> {
 	return undefined;
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for message-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/point-repo.ts
+++ b/src/lib/server/db/dynamodb/point-repo.ts
@@ -3,6 +3,7 @@
 
 import { GetCommand, PutCommand, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type { Child, InsertPointLedgerInput, PointLedgerEntry } from '../types';
+import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -12,6 +13,7 @@ import {
 	pointBalanceKey,
 	pointLedgerKey,
 	pointLedgerPrefix,
+	tenantPK,
 } from './keys';
 
 /** Strip PK/SK/GSI keys from a DynamoDB item */
@@ -132,6 +134,10 @@ export async function findChildById(id: number, tenantId: string): Promise<Child
 	return stripKeys(result.Item) as unknown as Child;
 }
 
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for point-repo not implemented');
+/** テナントの全ポイント台帳・残高を削除（CHILD#* 配下の POINT# + BALANCE アイテム） */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	// Delete point ledger entries (POINT#...)
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), pointLedgerPrefix());
+	// Delete balance records (BALANCE)
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), 'BALANCE');
 }

--- a/src/lib/server/db/dynamodb/point-repo.ts
+++ b/src/lib/server/db/dynamodb/point-repo.ts
@@ -131,3 +131,7 @@ export async function findChildById(id: number, tenantId: string): Promise<Child
 	if (!result.Item) return undefined;
 	return stripKeys(result.Item) as unknown as Child;
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for point-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/report-daily-summary-repo.ts
+++ b/src/lib/server/db/dynamodb/report-daily-summary-repo.ts
@@ -26,3 +26,7 @@ export async function upsert(_input: InsertReportDailySummaryInput): Promise<voi
 export async function deleteOlderThan(_tenantId: string, _cutoffDate: string): Promise<number> {
 	throw new Error(NOT_IMPL);
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error(NOT_IMPL);
+}

--- a/src/lib/server/db/dynamodb/report-daily-summary-repo.ts
+++ b/src/lib/server/db/dynamodb/report-daily-summary-repo.ts
@@ -27,6 +27,7 @@ export async function deleteOlderThan(_tenantId: string, _cutoffDate: string): P
 	throw new Error(NOT_IMPL);
 }
 
+/** テナントの全日次サマリーを削除（DynamoDB未実装: 書き込みがないため no-op） */
 export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error(NOT_IMPL);
+	// DynamoDB report-daily-summary repo は未実装のため書き込みデータなし — no-op
 }

--- a/src/lib/server/db/dynamodb/season-event-repo.ts
+++ b/src/lib/server/db/dynamodb/season-event-repo.ts
@@ -83,3 +83,7 @@ export async function claimReward(
 ): Promise<void> {
 	throw new Error(NOT_IMPL);
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error(NOT_IMPL);
+}

--- a/src/lib/server/db/dynamodb/season-event-repo.ts
+++ b/src/lib/server/db/dynamodb/season-event-repo.ts
@@ -84,6 +84,7 @@ export async function claimReward(
 	throw new Error(NOT_IMPL);
 }
 
+/** テナントの全シーズンイベントを削除（DynamoDB未実装: 書き込みがないため no-op） */
 export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error(NOT_IMPL);
+	// DynamoDB season-event repo は未実装のため書き込みデータなし — no-op
 }

--- a/src/lib/server/db/dynamodb/settings-repo.ts
+++ b/src/lib/server/db/dynamodb/settings-repo.ts
@@ -59,3 +59,8 @@ export async function getSettings(
 	}
 	return map;
 }
+
+/** テナントの全設定を削除 */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for settings not implemented');
+}

--- a/src/lib/server/db/dynamodb/settings-repo.ts
+++ b/src/lib/server/db/dynamodb/settings-repo.ts
@@ -2,8 +2,9 @@
 // DynamoDB implementation of ISettingsRepo
 
 import { BatchGetCommand, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { deleteItemsByExactPk } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
-import { settingKey } from './keys';
+import { settingKey, tenantPK } from './keys';
 
 /** 設定値を取得 */
 export async function getSetting(key: string, tenantId: string): Promise<string | undefined> {
@@ -60,7 +61,7 @@ export async function getSettings(
 	return map;
 }
 
-/** テナントの全設定を削除 */
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for settings not implemented');
+/** テナントの全設定を削除（PK=T#<tenantId>#SETTING のアイテムをすべて削除） */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	await deleteItemsByExactPk(tenantPK('SETTING', tenantId));
 }

--- a/src/lib/server/db/dynamodb/sibling-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/sibling-challenge-repo.ts
@@ -89,3 +89,7 @@ export async function enrollChildren(
 ): Promise<void> {
 	throw new Error(NOT_IMPL);
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error(NOT_IMPL);
+}

--- a/src/lib/server/db/dynamodb/sibling-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/sibling-challenge-repo.ts
@@ -90,6 +90,7 @@ export async function enrollChildren(
 	throw new Error(NOT_IMPL);
 }
 
+/** テナントの全きょうだいチャレンジを削除（DynamoDB未実装: 書き込みがないため no-op） */
 export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error(NOT_IMPL);
+	// DynamoDB sibling-challenge repo は未実装のため書き込みデータなし — no-op
 }

--- a/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
+++ b/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
@@ -27,6 +27,7 @@ export async function countTodayCheersFrom(
 	throw new Error(NOT_IMPL);
 }
 
+/** テナントの全おうえんスタンプを削除（DynamoDB未実装: 書き込みがないため no-op） */
 export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error(NOT_IMPL);
+	// DynamoDB sibling-cheer repo は未実装のため書き込みデータなし — no-op
 }

--- a/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
+++ b/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
@@ -26,3 +26,7 @@ export async function countTodayCheersFrom(
 ): Promise<number> {
 	throw new Error(NOT_IMPL);
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error(NOT_IMPL);
+}

--- a/src/lib/server/db/dynamodb/special-reward-repo.ts
+++ b/src/lib/server/db/dynamodb/special-reward-repo.ts
@@ -154,3 +154,7 @@ export async function markRewardShown(
 	if (!updateResult.Attributes) return undefined;
 	return stripKeys(updateResult.Attributes) as unknown as SpecialReward;
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for special-reward-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/special-reward-repo.ts
+++ b/src/lib/server/db/dynamodb/special-reward-repo.ts
@@ -3,9 +3,10 @@
 
 import { PutCommand, QueryCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type { InsertSpecialRewardInput, SpecialReward } from '../types';
+import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
-import { childPK, ENTITY_NAMES, specialRewardKey, specialRewardPrefix } from './keys';
+import { childPK, ENTITY_NAMES, specialRewardKey, specialRewardPrefix, tenantPK } from './keys';
 
 /** Strip PK/SK/GSI keys from a DynamoDB item */
 function stripKeys<T extends Record<string, unknown>>(
@@ -155,6 +156,7 @@ export async function markRewardShown(
 	return stripKeys(updateResult.Attributes) as unknown as SpecialReward;
 }
 
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for special-reward-repo not implemented');
+/** テナントの全特別報酬を削除（CHILD#* 配下の REWARD# アイテム） */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), specialRewardPrefix());
 }

--- a/src/lib/server/db/dynamodb/stamp-card-repo.ts
+++ b/src/lib/server/db/dynamodb/stamp-card-repo.ts
@@ -55,3 +55,7 @@ export async function updateCardStatusIfCollecting(
 ): Promise<number> {
 	throw new Error('stamp-card-repo: DynamoDB not implemented');
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for stamp-card-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/stamp-card-repo.ts
+++ b/src/lib/server/db/dynamodb/stamp-card-repo.ts
@@ -56,6 +56,7 @@ export async function updateCardStatusIfCollecting(
 	throw new Error('stamp-card-repo: DynamoDB not implemented');
 }
 
+/** テナントの全スタンプカード・エントリを削除（DynamoDB未実装: 書き込みがないため no-op） */
 export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for stamp-card-repo not implemented');
+	// DynamoDB stamp-card repo は未実装のため書き込みデータなし — no-op
 }

--- a/src/lib/server/db/dynamodb/status-repo.ts
+++ b/src/lib/server/db/dynamodb/status-repo.ts
@@ -412,3 +412,7 @@ export async function findLastActivityDates(
 		lastDate,
 	}));
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for status-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/status-repo.ts
+++ b/src/lib/server/db/dynamodb/status-repo.ts
@@ -17,6 +17,7 @@ import type {
 	Status,
 	StatusHistoryEntry,
 } from '../types';
+import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -28,8 +29,10 @@ import {
 	marketBenchmarkPrefix,
 	statusHistoryByCategoryPrefix,
 	statusHistoryKey,
+	statusHistoryPrefix,
 	statusKey,
 	statusPrefix,
+	tenantPK,
 } from './keys';
 
 /** Strip PK/SK/GSI keys from a DynamoDB item */
@@ -413,6 +416,13 @@ export async function findLastActivityDates(
 	}));
 }
 
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for status-repo not implemented');
+/**
+ * テナントの全ステータスデータを削除（CHILD#* 配下の STATUS# + STATHIST# アイテム）。
+ * market_benchmarks はグローバルなマスターデータのため削除しない。
+ */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	// Delete status records (STATUS#...)
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), statusPrefix());
+	// Delete status history records (STATHIST#...)
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), statusHistoryPrefix());
 }

--- a/src/lib/server/db/dynamodb/tenant-event-repo.ts
+++ b/src/lib/server/db/dynamodb/tenant-event-repo.ts
@@ -63,3 +63,7 @@ export async function upsertProgress(
 ): Promise<void> {
 	throw new Error(NOT_IMPL);
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error(NOT_IMPL);
+}

--- a/src/lib/server/db/dynamodb/tenant-event-repo.ts
+++ b/src/lib/server/db/dynamodb/tenant-event-repo.ts
@@ -64,6 +64,7 @@ export async function upsertProgress(
 	throw new Error(NOT_IMPL);
 }
 
+/** テナントの全イベントデータを削除（DynamoDB未実装: 書き込みがないため no-op） */
 export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error(NOT_IMPL);
+	// DynamoDB tenant-event repo は未実装のため書き込みデータなし — no-op
 }

--- a/src/lib/server/db/dynamodb/trial-history-repo.ts
+++ b/src/lib/server/db/dynamodb/trial-history-repo.ts
@@ -14,3 +14,7 @@ export async function findLatestByTenant(_tenantId: string): Promise<TrialHistor
 export async function insert(_input: InsertTrialHistoryInput): Promise<void> {
 	// TODO: DynamoDB implementation
 }
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	throw new Error('DynamoDB deleteByTenantId for trial-history-repo not implemented');
+}

--- a/src/lib/server/db/dynamodb/trial-history-repo.ts
+++ b/src/lib/server/db/dynamodb/trial-history-repo.ts
@@ -15,6 +15,7 @@ export async function insert(_input: InsertTrialHistoryInput): Promise<void> {
 	// TODO: DynamoDB implementation
 }
 
+/** テナントの全トライアル履歴を削除（DynamoDB未実装: 書き込みがないため no-op） */
 export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	throw new Error('DynamoDB deleteByTenantId for trial-history-repo not implemented');
+	// DynamoDB trial-history repo は未実装のため書き込みデータなし — no-op
 }

--- a/src/lib/server/db/interfaces/activity-mastery-repo.interface.ts
+++ b/src/lib/server/db/interfaces/activity-mastery-repo.interface.ts
@@ -14,4 +14,5 @@ export interface IActivityMasteryRepo {
 		level: number,
 		tenantId: string,
 	): Promise<ActivityMastery>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/activity-pref-repo.interface.ts
+++ b/src/lib/server/db/interfaces/activity-pref-repo.interface.ts
@@ -14,4 +14,5 @@ export interface IActivityPrefRepo {
 		sinceDate: string,
 		tenantId: string,
 	): Promise<ActivityUsageCount[]>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/auth-repo.interface.ts
+++ b/src/lib/server/db/interfaces/auth-repo.interface.ts
@@ -59,6 +59,7 @@ export interface IAuthRepo {
 		acceptedBy?: string,
 	): Promise<void>;
 	findTenantInvites(tenantId: string): Promise<Invite[]>;
+	deleteInvite(inviteCode: string, tenantId: string): Promise<void>;
 
 	// --- Consent (#0192) ---
 	recordConsent(input: RecordConsentInput): Promise<ConsentRecord>;

--- a/src/lib/server/db/interfaces/auto-challenge-repo.interface.ts
+++ b/src/lib/server/db/interfaces/auto-challenge-repo.interface.ts
@@ -16,4 +16,5 @@ export interface IAutoChallengeRepo {
 	update(id: number, input: UpdateAutoChallengeInput, tenantId: string): Promise<void>;
 
 	expireOldChallenges(beforeDate: string, tenantId: string): Promise<number>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/checklist-repo.interface.ts
+++ b/src/lib/server/db/interfaces/checklist-repo.interface.ts
@@ -47,4 +47,7 @@ export interface IChecklistRepo {
 	findOverrides(childId: number, date: string, tenantId: string): Promise<ChecklistOverride[]>;
 	insertOverride(input: InsertChecklistOverrideInput, tenantId: string): Promise<ChecklistOverride>;
 	deleteOverride(id: number, tenantId: string): Promise<void>;
+
+	// Tenant bulk deletion
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/daily-mission-repo.interface.ts
+++ b/src/lib/server/db/interfaces/daily-mission-repo.interface.ts
@@ -34,4 +34,5 @@ export interface IDailyMissionRepo {
 		activityId: number,
 		tenantId: string,
 	): Promise<void>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/evaluation-repo.interface.ts
+++ b/src/lib/server/db/interfaces/evaluation-repo.interface.ts
@@ -34,4 +34,5 @@ export interface IEvaluationRepo {
 	isRestDay(childId: number, date: string, tenantId: string): Promise<boolean>;
 	countRestDaysInMonth(childId: number, yearMonth: string, tenantId: string): Promise<number>;
 	findRestDays(childId: number, yearMonth: string, tenantId: string): Promise<RestDay[]>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/image-repo.interface.ts
+++ b/src/lib/server/db/interfaces/image-repo.interface.ts
@@ -10,4 +10,5 @@ export interface IImageRepo {
 	insertCharacterImage(input: InsertCharacterImageInput, tenantId: string): Promise<void>;
 	updateChildAvatarUrl(childId: number, avatarUrl: string, tenantId: string): Promise<void>;
 	findChildForImage(childId: number, tenantId: string): Promise<Child | undefined>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/login-bonus-repo.interface.ts
+++ b/src/lib/server/db/interfaces/login-bonus-repo.interface.ts
@@ -5,4 +5,5 @@ export interface ILoginBonusRepo {
 	findRecentBonuses(childId: number, tenantId: string, limit?: number): Promise<LoginBonus[]>;
 	insertLoginBonus(input: InsertLoginBonusInput, tenantId: string): Promise<LoginBonus>;
 	findChildById(id: number, tenantId: string): Promise<Child | undefined>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/message-repo.interface.ts
+++ b/src/lib/server/db/interfaces/message-repo.interface.ts
@@ -6,4 +6,5 @@ export interface IMessageRepo {
 	findUnshownMessage(childId: number, tenantId: string): Promise<ParentMessage | undefined>;
 	countUnshownMessages(childId: number, tenantId: string): Promise<number>;
 	markMessageShown(messageId: number, tenantId: string): Promise<ParentMessage | undefined>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/point-repo.interface.ts
+++ b/src/lib/server/db/interfaces/point-repo.interface.ts
@@ -9,4 +9,5 @@ export interface IPointRepo {
 	): Promise<PointLedgerEntry[]>;
 	insertPointEntry(input: InsertPointLedgerInput, tenantId: string): Promise<PointLedgerEntry>;
 	findChildById(id: number, tenantId: string): Promise<Child | undefined>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/report-daily-summary-repo.interface.ts
+++ b/src/lib/server/db/interfaces/report-daily-summary-repo.interface.ts
@@ -17,4 +17,5 @@ export interface IReportDailySummaryRepo {
 	upsert(input: InsertReportDailySummaryInput): Promise<void>;
 
 	deleteOlderThan(tenantId: string, cutoffDate: string): Promise<number>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/season-event-repo.interface.ts
+++ b/src/lib/server/db/interfaces/season-event-repo.interface.ts
@@ -32,4 +32,5 @@ export interface ISeasonEventRepo {
 		tenantId: string,
 	): Promise<void>;
 	claimReward(childId: number, eventId: number, tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/settings-repo.interface.ts
+++ b/src/lib/server/db/interfaces/settings-repo.interface.ts
@@ -2,4 +2,5 @@ export interface ISettingsRepo {
 	getSetting(key: string, tenantId: string): Promise<string | undefined>;
 	setSetting(key: string, value: string, tenantId: string): Promise<void>;
 	getSettings(keys: string[], tenantId: string): Promise<Record<string, string>>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/sibling-challenge-repo.interface.ts
+++ b/src/lib/server/db/interfaces/sibling-challenge-repo.interface.ts
@@ -37,4 +37,5 @@ export interface ISiblingChallengeRepo {
 		children: { childId: number; targetValue: number }[],
 		tenantId: string,
 	): Promise<void>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/sibling-cheer-repo.interface.ts
+++ b/src/lib/server/db/interfaces/sibling-cheer-repo.interface.ts
@@ -5,4 +5,5 @@ export interface ISiblingCheerRepo {
 	findUnshownCheers(toChildId: number, tenantId: string): Promise<SiblingCheer[]>;
 	markShown(cheerIds: number[], tenantId: string): Promise<void>;
 	countTodayCheersFrom(fromChildId: number, tenantId: string): Promise<number>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/special-reward-repo.interface.ts
+++ b/src/lib/server/db/interfaces/special-reward-repo.interface.ts
@@ -5,4 +5,5 @@ export interface ISpecialRewardRepo {
 	findSpecialRewards(childId: number, tenantId: string): Promise<SpecialReward[]>;
 	findUnshownReward(childId: number, tenantId: string): Promise<SpecialReward | undefined>;
 	markRewardShown(rewardId: number, tenantId: string): Promise<SpecialReward | undefined>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/stamp-card-repo.interface.ts
+++ b/src/lib/server/db/interfaces/stamp-card-repo.interface.ts
@@ -27,4 +27,5 @@ export interface IStampCardRepo {
 		input: UpdateStampCardStatusInput,
 		tenantId: string,
 	): Promise<number>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/status-repo.interface.ts
+++ b/src/lib/server/db/interfaces/status-repo.interface.ts
@@ -52,4 +52,5 @@ export interface IStatusRepo {
 		childId: number,
 		tenantId: string,
 	): Promise<{ category: number; lastDate: string | null }[]>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/tenant-event-repo.interface.ts
+++ b/src/lib/server/db/interfaces/tenant-event-repo.interface.ts
@@ -33,4 +33,5 @@ export interface ITenantEventRepo {
 	): Promise<TenantEventProgress[]>;
 
 	upsertProgress(input: UpsertTenantEventProgressInput, tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/trial-history-repo.interface.ts
+++ b/src/lib/server/db/interfaces/trial-history-repo.interface.ts
@@ -21,4 +21,5 @@ export interface InsertTrialHistoryInput {
 export interface ITrialHistoryRepo {
 	findLatestByTenant(tenantId: string): Promise<TrialHistoryRow | undefined>;
 	insert(input: InsertTrialHistoryInput): Promise<void>;
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/sqlite/activity-mastery-repo.ts
+++ b/src/lib/server/db/sqlite/activity-mastery-repo.ts
@@ -49,3 +49,8 @@ export async function upsert(
 		.returning()
 		.get();
 }
+
+/** テナントの全活動習熟度を削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(activityMastery).run();
+}

--- a/src/lib/server/db/sqlite/activity-pref-repo.ts
+++ b/src/lib/server/db/sqlite/activity-pref-repo.ts
@@ -145,3 +145,8 @@ export async function getUsageCounts(
 		.groupBy(activityLogs.activityId)
 		.all();
 }
+
+/** テナントの全活動ピン留め設定を削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(childActivityPreferences).run();
+}

--- a/src/lib/server/db/sqlite/auth-repo.ts
+++ b/src/lib/server/db/sqlite/auth-repo.ts
@@ -87,6 +87,9 @@ export const updateInviteStatus: IAuthRepo['updateInviteStatus'] = async () => {
 export const findTenantInvites: IAuthRepo['findTenantInvites'] = async () => {
 	return [];
 };
+export const deleteInvite: IAuthRepo['deleteInvite'] = async () => {
+	// no-op in local mode (invites not supported)
+};
 export const recordConsent: IAuthRepo['recordConsent'] = async (input) => {
 	return { ...input, consentedAt: new Date().toISOString() };
 };

--- a/src/lib/server/db/sqlite/auto-challenge-repo.ts
+++ b/src/lib/server/db/sqlite/auto-challenge-repo.ts
@@ -86,3 +86,8 @@ export async function expireOldChallenges(beforeDate: string, _tenantId: string)
 		.run();
 	return result.changes;
 }
+
+/** テナントの全自動チャレンジを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(autoChallenges).run();
+}

--- a/src/lib/server/db/sqlite/checklist-repo.ts
+++ b/src/lib/server/db/sqlite/checklist-repo.ts
@@ -184,3 +184,11 @@ export async function insertOverride(
 export async function deleteOverride(id: number, _tenantId: string) {
 	db.delete(checklistOverrides).where(eq(checklistOverrides.id, id)).run();
 }
+
+/** テナントの全チェックリストデータを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(checklistOverrides).run();
+	db.delete(checklistLogs).run();
+	db.delete(checklistTemplateItems).run();
+	db.delete(checklistTemplates).run();
+}

--- a/src/lib/server/db/sqlite/daily-mission-repo.ts
+++ b/src/lib/server/db/sqlite/daily-mission-repo.ts
@@ -133,3 +133,8 @@ export async function insertDailyMission(
 ) {
 	db.insert(dailyMissions).values({ childId, missionDate: date, activityId }).run();
 }
+
+/** テナントの全デイリーミッションを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(dailyMissions).run();
+}

--- a/src/lib/server/db/sqlite/evaluation-repo.ts
+++ b/src/lib/server/db/sqlite/evaluation-repo.ts
@@ -179,3 +179,9 @@ export async function findRestDays(childId: number, yearMonth: string, _tenantId
 		.orderBy(restDays.date)
 		.all();
 }
+
+/** テナントの全評価データを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(restDays).run();
+	db.delete(evaluations).run();
+}

--- a/src/lib/server/db/sqlite/image-repo.ts
+++ b/src/lib/server/db/sqlite/image-repo.ts
@@ -50,3 +50,8 @@ export async function updateChildAvatarUrl(childId: number, avatarUrl: string, _
 export async function findChildForImage(childId: number, _tenantId: string) {
 	return db.select().from(children).where(eq(children.id, childId)).get();
 }
+
+/** テナントの全キャラクター画像レコードを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(characterImages).run();
+}

--- a/src/lib/server/db/sqlite/login-bonus-repo.ts
+++ b/src/lib/server/db/sqlite/login-bonus-repo.ts
@@ -45,3 +45,8 @@ export async function insertLoginBonus(
 export async function findChildById(id: number, _tenantId: string) {
 	return db.select().from(children).where(eq(children.id, id)).get();
 }
+
+/** テナントの全ログインボーナスを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(loginBonuses).run();
+}

--- a/src/lib/server/db/sqlite/message-repo.ts
+++ b/src/lib/server/db/sqlite/message-repo.ts
@@ -57,3 +57,8 @@ export async function markMessageShown(messageId: number, _tenantId: string) {
 		.returning()
 		.get();
 }
+
+/** テナントの全メッセージを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(parentMessages).run();
+}

--- a/src/lib/server/db/sqlite/point-repo.ts
+++ b/src/lib/server/db/sqlite/point-repo.ts
@@ -50,3 +50,8 @@ export async function insertPointEntry(
 export async function findChildById(id: number, _tenantId: string) {
 	return db.select().from(children).where(eq(children.id, id)).get();
 }
+
+/** テナントの全ポイント台帳を削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(pointLedger).run();
+}

--- a/src/lib/server/db/sqlite/report-daily-summary-repo.ts
+++ b/src/lib/server/db/sqlite/report-daily-summary-repo.ts
@@ -74,3 +74,8 @@ export async function deleteOlderThan(tenantId: string, cutoffDate: string): Pro
 		.run();
 	return result.changes;
 }
+
+/** テナントの全日次サマリーを削除 */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	db.delete(reportDailySummaries).where(eq(reportDailySummaries.tenantId, tenantId)).run();
+}

--- a/src/lib/server/db/sqlite/season-event-repo.ts
+++ b/src/lib/server/db/sqlite/season-event-repo.ts
@@ -150,3 +150,9 @@ export async function claimReward(
 		.where(and(eq(childEventProgress.childId, childId), eq(childEventProgress.eventId, eventId)))
 		.run();
 }
+
+/** テナントの全シーズンイベントデータを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(childEventProgress).run();
+	db.delete(seasonEvents).run();
+}

--- a/src/lib/server/db/sqlite/settings-repo.ts
+++ b/src/lib/server/db/sqlite/settings-repo.ts
@@ -32,3 +32,8 @@ export async function getSettings(
 	}
 	return map;
 }
+
+/** テナントの全設定を削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(settings).run();
+}

--- a/src/lib/server/db/sqlite/sibling-challenge-repo.ts
+++ b/src/lib/server/db/sqlite/sibling-challenge-repo.ts
@@ -193,3 +193,9 @@ export async function enrollChildren(
 			.run();
 	}
 }
+
+/** テナントの全きょうだいチャレンジを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(siblingChallengeProgress).run();
+	db.delete(siblingChallenges).run();
+}

--- a/src/lib/server/db/sqlite/sibling-cheer-repo.ts
+++ b/src/lib/server/db/sqlite/sibling-cheer-repo.ts
@@ -58,3 +58,8 @@ export async function countTodayCheersFrom(
 		.get();
 	return result?.value ?? 0;
 }
+
+/** テナントの全おうえんスタンプを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(siblingCheers).run();
+}

--- a/src/lib/server/db/sqlite/special-reward-repo.ts
+++ b/src/lib/server/db/sqlite/special-reward-repo.ts
@@ -48,3 +48,8 @@ export async function markRewardShown(rewardId: number, _tenantId: string) {
 		.returning()
 		.get();
 }
+
+/** テナントの全特別報酬を削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(specialRewards).run();
+}

--- a/src/lib/server/db/sqlite/stamp-card-repo.ts
+++ b/src/lib/server/db/sqlite/stamp-card-repo.ts
@@ -131,3 +131,9 @@ export async function updateCardStatusIfCollecting(
 		.run();
 	return result.changes;
 }
+
+/** テナントの全スタンプカード・エントリを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(schema.stampEntries).run();
+	db.delete(schema.stampCards).run();
+}

--- a/src/lib/server/db/sqlite/status-repo.ts
+++ b/src/lib/server/db/sqlite/status-repo.ts
@@ -207,9 +207,11 @@ export async function findLastActivityDates(childId: number, _tenantId: string) 
 		.all();
 }
 
-/** テナントの全ステータスデータを削除（SQLite: シングルテナントのため全行削除） */
+/**
+ * テナントの全ステータスデータを削除（SQLite: シングルテナントのため全行削除）。
+ * market_benchmarks はグローバルなマスター/シードデータのため削除しない。
+ */
 export async function deleteByTenantId(_tenantId: string): Promise<void> {
 	db.delete(statusHistory).run();
 	db.delete(statuses).run();
-	db.delete(marketBenchmarks).run();
 }

--- a/src/lib/server/db/sqlite/status-repo.ts
+++ b/src/lib/server/db/sqlite/status-repo.ts
@@ -206,3 +206,10 @@ export async function findLastActivityDates(childId: number, _tenantId: string) 
 		.groupBy(activityLogs.activityId)
 		.all();
 }
+
+/** テナントの全ステータスデータを削除（SQLite: シングルテナントのため全行削除） */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(statusHistory).run();
+	db.delete(statuses).run();
+	db.delete(marketBenchmarks).run();
+}

--- a/src/lib/server/db/sqlite/tenant-event-repo.ts
+++ b/src/lib/server/db/sqlite/tenant-event-repo.ts
@@ -148,3 +148,9 @@ export async function upsertProgress(
 		})
 		.run();
 }
+
+/** テナントの全イベントデータを削除 */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	db.delete(tenantEventProgress).where(eq(tenantEventProgress.tenantId, tenantId)).run();
+	db.delete(tenantEvents).where(eq(tenantEvents.tenantId, tenantId)).run();
+}

--- a/src/lib/server/db/sqlite/trial-history-repo.ts
+++ b/src/lib/server/db/sqlite/trial-history-repo.ts
@@ -29,3 +29,8 @@ export async function insert(input: InsertTrialHistoryInput): Promise<void> {
 		campaignId: input.campaignId ?? null,
 	});
 }
+
+/** テナントの全トライアル履歴を削除 */
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	db.delete(trialHistory).where(eq(trialHistory.tenantId, tenantId)).run();
+}

--- a/src/lib/server/services/account-deletion-service.ts
+++ b/src/lib/server/services/account-deletion-service.ts
@@ -159,10 +159,7 @@ async function revokeAndDeleteAllInvites(tenantId: string): Promise<number> {
 				}
 			}
 			// 物理削除: 招待レコード自体を削除（テナント側・招待コード側の両方）
-			// NOTE: auth-repo に deleteInvite がないため、テナント削除時に
-			// deleteTenant で TENANT#<id> パーティション配下は一括クリーンアップされる。
-			// 招待コード側（INVITE#<code>）は残留するが、テナント削除後はアクセス不能。
-			// TODO: auth-repo に deleteInvite(inviteCode) を追加し、INVITE#<code> も物理削除する
+			await repos().auth.deleteInvite(invite.inviteCode, tenantId);
 			deleted++;
 		} catch (err) {
 			logger.warn(
@@ -176,37 +173,8 @@ async function revokeAndDeleteAllInvites(tenantId: string): Promise<number> {
 
 /**
  * テナントスコープの全データを削除する（子供・認証以外）。
- * 各リポジトリの既存 delete/find メソッドを使用して可能な限りクリーンアップする。
- *
- * 現在削除可能:
- * - activities（findActivities + deleteActivity）
- * - viewerTokens（findByTenant + deleteById）
- * - cloudExports（findByTenant + deleteById）
- * - pushSubscriptions（findByTenant + deleteByEndpoint）
- *
- * TODO (#458): 以下のテナントスコープデータに deleteByTenant メソッドが未実装。
- * 各リポジトリインターフェースに追加する必要がある:
- * - settings: PK=T#<tenantId>#SETTING — deleteByTenant 未実装
- * - checklists: 子供ごと（findTemplatesByChild）— テナント一括削除なし
- * - dailyMissions: 子供ごと — テナント一括削除なし
- * - evaluations: 子供ごと — テナント一括削除なし
- * - points: 子供ごと — テナント一括削除なし
- * - stamps/stampCards: 子供ごと — テナント一括削除なし
- * - status: 子供ごと — テナント一括削除なし
- * - loginBonus: 子供ごと — テナント一括削除なし
- * - specialReward: 子供ごと — テナント一括削除なし
- * - activityPref: 子供ごと — テナント一括削除なし
- * - activityMastery: 子供ごと — テナント一括削除なし
- * - voice: deleteByChild 利用可能
- * - message: テナント一括削除なし
- * - tenantEvent: findByTenantAndYear — deleteEvent 未実装
- * - trialHistory: findLatestByTenant — delete 未実装
- * - siblingChallenge: deleteChallenge あり — findByTenant なし
- * - siblingCheer: テナント一括削除なし
- * - autoChallenge: テナント一括削除なし
- * - reportDailySummary: deleteOlderThan あり — テナント全件削除なし
- * - seasonEvent: deleteEvent あり — findByTenant なし
- * - image: テナント一括削除なし
+ * 各リポジトリの deleteByTenantId メソッドを使用してテナント全データをクリーンアップする。
+ * 各リポジトリの削除は独立しており、個別の失敗が他の削除をブロックしない。
  */
 async function deleteTenantScopedData(tenantId: string): Promise<number> {
 	let deleted = 0;
@@ -265,6 +233,166 @@ async function deleteTenantScopedData(tenantId: string): Promise<number> {
 		}
 	} catch (err) {
 		logger.warn(`[account-deletion] voice 削除失敗: ${String(err)}`);
+	}
+
+	// Settings
+	try {
+		await r.settings.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] settings 削除失敗: ${String(err)}`);
+	}
+
+	// Checklists（templates, items, logs, overrides）
+	try {
+		await r.checklist.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] checklists 削除失敗: ${String(err)}`);
+	}
+
+	// Daily missions
+	try {
+		await r.dailyMission.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] dailyMissions 削除失敗: ${String(err)}`);
+	}
+
+	// Evaluations（evaluations + rest_days）
+	try {
+		await r.evaluation.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] evaluations 削除失敗: ${String(err)}`);
+	}
+
+	// Points（point_ledger）
+	try {
+		await r.point.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] points 削除失敗: ${String(err)}`);
+	}
+
+	// Stamp cards + entries
+	try {
+		await r.stampCard.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] stampCards 削除失敗: ${String(err)}`);
+	}
+
+	// Status（statuses + status_history + market_benchmarks）
+	try {
+		await r.status.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] status 削除失敗: ${String(err)}`);
+	}
+
+	// Login bonuses
+	try {
+		await r.loginBonus.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] loginBonus 削除失敗: ${String(err)}`);
+	}
+
+	// Special rewards
+	try {
+		await r.specialReward.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] specialReward 削除失敗: ${String(err)}`);
+	}
+
+	// Activity preferences（pin settings）
+	try {
+		await r.activityPref.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] activityPref 削除失敗: ${String(err)}`);
+	}
+
+	// Activity mastery
+	try {
+		await r.activityMastery.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] activityMastery 削除失敗: ${String(err)}`);
+	}
+
+	// Parent messages
+	try {
+		await r.message.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] message 削除失敗: ${String(err)}`);
+	}
+
+	// Tenant events + progress
+	try {
+		await r.tenantEvent.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] tenantEvent 削除失敗: ${String(err)}`);
+	}
+
+	// Trial history
+	try {
+		await r.trialHistory.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] trialHistory 削除失敗: ${String(err)}`);
+	}
+
+	// Sibling challenges + progress
+	try {
+		await r.siblingChallenge.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] siblingChallenge 削除失敗: ${String(err)}`);
+	}
+
+	// Sibling cheers
+	try {
+		await r.siblingCheer.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] siblingCheer 削除失敗: ${String(err)}`);
+	}
+
+	// Auto challenges
+	try {
+		await r.autoChallenge.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] autoChallenge 削除失敗: ${String(err)}`);
+	}
+
+	// Report daily summaries
+	try {
+		await r.reportDailySummary.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] reportDailySummary 削除失敗: ${String(err)}`);
+	}
+
+	// Season events + child_event_progress
+	try {
+		await r.seasonEvent.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] seasonEvent 削除失敗: ${String(err)}`);
+	}
+
+	// Character images
+	try {
+		await r.image.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[account-deletion] image 削除失敗: ${String(err)}`);
 	}
 
 	return deleted;


### PR DESCRIPTION
## Summary
- 21個のリポジトリインターフェースに `deleteByTenantId` メソッドを追加（settings, checklists, dailyMissions, evaluations, points, stampCards, status, loginBonus, specialReward, activityPref, activityMastery, message, tenantEvent, trialHistory, siblingChallenge, siblingCheer, autoChallenge, reportDailySummary, seasonEvent, image）
- auth-repo に `deleteInvite(inviteCode, tenantId)` を追加し、`INVITE#<code>` アイテムの物理削除を実現
- `account-deletion-service.ts` の `deleteTenantScopedData()` を更新し、全リポジトリの削除メソッドを呼び出すように修正（TODO 解消）

closes #487

## Test plan
- [x] 既存ユニットテスト全通過（2119テスト合格）
- [x] svelte-check 型エラーなし（既存のstripe-service.ts以外）
- [ ] アカウント削除時に全テナントデータが削除される（手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>