### PR TITLE
fix: #500 活動一覧ページのUI改善 — ポイント・カテゴリの視認性向上

### DIFF
--- a/src/lib/features/admin/components/ActivityListItem.svelte
+++ b/src/lib/features/admin/components/ActivityListItem.svelte
@@ -20,6 +20,8 @@ interface Props {
 
 let { activity, categoryDefs, logCount, isEditing, onedit, oncanceledit }: Props = $props();
 
+const category = $derived(getCategoryById(activity.categoryId));
+
 function dailyLimitLabel(val: number | null): string {
 	if (val === null) return '1回/日';
 	if (val === 0) return '無制限';
@@ -27,20 +29,27 @@ function dailyLimitLabel(val: number | null): string {
 }
 </script>
 
-<div class="bg-white rounded-lg shadow-sm {activity.isVisible ? '' : 'opacity-50'}">
+<div class="activity-list-item {activity.isVisible ? '' : 'opacity-50'}">
 	<div class="px-3 py-2 flex items-center gap-3">
 		<CompoundIcon icon={activity.icon} size="md" />
 		<div class="flex-1 min-w-0">
-			<p class="text-sm font-bold text-gray-700 truncate">{getActivityDisplayNameForAdult(activity)}</p>
-			<p class="text-xs text-gray-400">
-				{getCategoryById(activity.categoryId)?.name ?? ''} / {activity.basePoints}P
+			<div class="flex items-center gap-2 flex-wrap">
+				<p class="text-sm font-bold truncate" style:color="var(--color-text)">{getActivityDisplayNameForAdult(activity)}</p>
+				<span class="activity-points">{activity.basePoints}P</span>
+			</div>
+			<div class="activity-meta">
+				{#if category}
+					<span class="category-badge" style:background-color="{category.color}20" style:color={category.accent}>
+						{category.icon} {category.name}
+					</span>
+				{/if}
 				{#if activity.dailyLimit !== null}
-					/ {dailyLimitLabel(activity.dailyLimit)}
+					<span class="meta-item">{dailyLimitLabel(activity.dailyLimit)}</span>
 				{/if}
 				{#if activity.ageMin != null || activity.ageMax != null}
-					/ {activity.ageMin ?? 0}-{activity.ageMax ?? 18}歳
+					<span class="meta-item">{activity.ageMin ?? 0}-{activity.ageMax ?? 18}歳</span>
 				{/if}
-			</p>
+			</div>
 		</div>
 		<div class="flex gap-1">
 			<button
@@ -74,3 +83,47 @@ function dailyLimitLabel(val: number | null): string {
 		/>
 	{/if}
 </div>
+
+<style>
+	.activity-list-item {
+		background: var(--color-surface-card);
+		border-radius: var(--radius-md, 0.5rem);
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+	}
+
+	.activity-points {
+		display: inline-flex;
+		align-items: center;
+		font-size: 0.75rem;
+		font-weight: 700;
+		color: var(--color-point);
+		background: linear-gradient(135deg, rgba(255, 215, 0, 0.15), rgba(255, 215, 0, 0.08));
+		padding: 0.125rem 0.5rem;
+		border-radius: var(--radius-full, 9999px);
+		white-space: nowrap;
+	}
+
+	.activity-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		margin-top: 0.25rem;
+		flex-wrap: wrap;
+	}
+
+	.category-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.125rem;
+		font-size: 0.625rem;
+		font-weight: 600;
+		padding: 0.0625rem 0.375rem;
+		border-radius: var(--radius-full, 9999px);
+		white-space: nowrap;
+	}
+
+	.meta-item {
+		font-size: 0.625rem;
+		color: var(--color-text-muted);
+	}
+</style>

--- a/src/lib/ui/tutorial/tutorial-chapters.ts
+++ b/src/lib/ui/tutorial/tutorial-chapters.ts
@@ -85,20 +85,20 @@ export const TUTORIAL_CHAPTERS: TutorialChapter[] = [
 			{
 				id: 'activities-1',
 				chapterId: 3,
-				selector: '[data-tutorial="category-filter"]',
-				title: 'カテゴリで絞り込み',
+				selector: '[data-tutorial="activity-list"]',
+				title: '活動一覧',
 				description:
-					'活動は「うんどう」「べんきょう」「せいかつ」などのカテゴリに分かれています。「うんどう系の活動を見直したい」など、目的に合わせて絞り込めます。',
+					'こどもが記録できる活動の一覧です。各活動の獲得ポイントや1日の上限回数を確認・編集できます。「このポイント多すぎるかな？」と思ったらここで調整しましょう。',
 				position: 'bottom',
 				page: '/admin/activities',
 			},
 			{
 				id: 'activities-2',
 				chapterId: 3,
-				selector: '[data-tutorial="activity-list"]',
-				title: '活動一覧',
+				selector: '[data-tutorial="category-filter"]',
+				title: 'カテゴリで絞り込み',
 				description:
-					'こどもが記録できる活動の一覧です。各活動の獲得ポイントや1日の上限回数を確認・編集できます。「このポイント多すぎるかな？」と思ったらここで調整しましょう。',
+					'活動は「うんどう」「べんきょう」「せいかつ」などのカテゴリに分かれています。「うんどう系の活動を見直したい」など、目的に合わせて絞り込めます。',
 				position: 'bottom',
 				page: '/admin/activities',
 			},

--- a/src/routes/demo/(parent)/admin/activities/+page.svelte
+++ b/src/routes/demo/(parent)/admin/activities/+page.svelte
@@ -104,23 +104,28 @@ function dailyLimitLabel(val: number | null): string {
 	<!-- Activity List (matches production card style) -->
 	<div class="space-y-1">
 		{#each filteredActivities as activity (activity.id)}
+			{@const cat = getCategoryById(activity.categoryId)}
 			<Card padding="none">
 				<div class="px-3 py-2 flex items-center gap-3">
 					<CompoundIcon icon={activity.icon} size="md" />
 					<div class="flex-1 min-w-0">
-						<p class="text-sm font-bold text-gray-700 truncate">{getActivityDisplayNameForAdult(activity)}</p>
-						<p class="text-xs text-gray-400">
-							{getCategoryById(activity.categoryId)?.name ?? ''} / {activity.basePoints}P
+						<div class="flex items-center gap-2 flex-wrap">
+							<p class="text-sm font-bold truncate" style:color="var(--color-text)">{getActivityDisplayNameForAdult(activity)}</p>
+							<span class="activity-points">{fmtPts(activity.basePoints)}</span>
+						</div>
+						<div class="activity-meta">
+							{#if cat}
+								<span class="category-badge" style:background-color="{cat.color}20" style:color={cat.accent}>
+									{cat.icon} {cat.name}
+								</span>
+							{/if}
 							{#if activity.dailyLimit !== null && activity.dailyLimit !== undefined}
-								/ {dailyLimitLabel(activity.dailyLimit)}
+								<span class="meta-item">{dailyLimitLabel(activity.dailyLimit)}</span>
 							{/if}
 							{#if activity.ageMin != null || activity.ageMax != null}
-								/ {activity.ageMin ?? 0}-{activity.ageMax ?? 18}歳
+								<span class="meta-item">{activity.ageMin ?? 0}-{activity.ageMax ?? 18}歳</span>
 							{/if}
-						</p>
-					</div>
-					<div class="text-right">
-						<span class="text-sm font-bold text-amber-500">{fmtPts(activity.basePoints)}</span>
+						</div>
 					</div>
 				</div>
 			</Card>
@@ -138,3 +143,41 @@ function dailyLimitLabel(val: number | null): string {
 		description="登録すると、お子さまに合わせた活動を自由に追加・編集できます。"
 	/>
 </div>
+
+<style>
+	.activity-points {
+		display: inline-flex;
+		align-items: center;
+		font-size: 0.75rem;
+		font-weight: 700;
+		color: var(--color-point);
+		background: linear-gradient(135deg, rgba(255, 215, 0, 0.15), rgba(255, 215, 0, 0.08));
+		padding: 0.125rem 0.5rem;
+		border-radius: var(--radius-full, 9999px);
+		white-space: nowrap;
+	}
+
+	.activity-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.375rem;
+		margin-top: 0.25rem;
+		flex-wrap: wrap;
+	}
+
+	.category-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.125rem;
+		font-size: 0.625rem;
+		font-weight: 600;
+		padding: 0.0625rem 0.375rem;
+		border-radius: var(--radius-full, 9999px);
+		white-space: nowrap;
+	}
+
+	.meta-item {
+		font-size: 0.625rem;
+		color: var(--color-text-muted);
+	}
+</style>


### PR DESCRIPTION
## Summary
- 活動カードのポイント表示をゴールド色のピルバッジに変更（`text-gray-400` → `var(--color-point)`）で視認性を大幅に向上
- カテゴリをアイコン付き色分けバッジで表示し、スラッシュ区切りの薄いテキストから視覚的に区別しやすいバッジに改善
- ガイドツアーのステップ順序を「活動一覧の説明 → カテゴリフィルタの説明」に変更し、初回ユーザーの理解しやすさを向上
- デモ版（`/demo/admin/activities`）にも同じUI改善を適用

closes #500

## Test plan
- [ ] 活動カードのポイントがゴールド色のピルバッジで見やすく表示される
- [ ] カテゴリバッジがアイコン付きで色分けされている
- [ ] 日次上限・年齢制限がメタ情報として正しく表示される
- [ ] 編集・表示/非表示ボタンが正常に動作する
- [ ] デモ版の活動一覧でも同じ改善が適用されている
- [ ] ガイドツアーが活動一覧→カテゴリフィルタの順で案内される

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>