### PR TITLE
fix: #494 #495 チュートリアルUX改善 + カバレッジ拡充

### DIFF
--- a/src/lib/features/admin/components/AdminLayout.svelte
+++ b/src/lib/features/admin/components/AdminLayout.svelte
@@ -4,7 +4,7 @@ import { navigating, page } from '$app/stores';
 import Logo from '$lib/ui/components/Logo.svelte';
 import TutorialOverlay from '$lib/ui/components/TutorialOverlay.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
-import { markTutorialStarted, startTutorial } from '$lib/ui/tutorial/tutorial-store.svelte';
+import { markTutorialStarted, startTutorialForPage } from '$lib/ui/tutorial/tutorial-store.svelte';
 
 interface NavItem {
 	href: string;
@@ -33,7 +33,8 @@ const isDemo = $derived(mode === 'demo');
 
 async function handleStartTutorial() {
 	await markTutorialStarted();
-	await startTutorial();
+	const currentPath = $page.url.pathname;
+	await startTutorialForPage(currentPath);
 }
 
 // bfcache recovery (production only)

--- a/src/lib/ui/components/TutorialOverlay.svelte
+++ b/src/lib/ui/components/TutorialOverlay.svelte
@@ -1,16 +1,22 @@
 <script lang="ts">
 import {
+	dismissResumePrompt,
 	endTutorial,
 	getCurrentStep,
+	isResumePromptShown,
 	isTutorialActive,
+	resumeTutorial,
+	startFromBeginning,
 } from '$lib/ui/tutorial/tutorial-store.svelte';
 import TutorialBubble from './TutorialBubble.svelte';
 
 let targetRect = $state<DOMRect | null>(null);
 let animKey = $state(0);
+let showExitConfirm = $state(false);
 
 const active = $derived(isTutorialActive());
 const step = $derived(getCurrentStep());
+const showResume = $derived(isResumePromptShown());
 
 /** Find the first visible element matching a selector (handles responsive layouts) */
 function findVisibleElement(selector: string): Element | null {
@@ -49,12 +55,98 @@ $effect(() => {
 });
 
 function handleOverlayClick(e: MouseEvent) {
-	// Only close if clicking the dark overlay itself, not the bubble
+	// Show exit confirmation instead of closing immediately
 	if ((e.target as HTMLElement).classList.contains('tutorial-overlay-bg')) {
-		endTutorial();
+		showExitConfirm = true;
 	}
 }
+
+function confirmExit() {
+	showExitConfirm = false;
+	endTutorial();
+}
+
+function cancelExit() {
+	showExitConfirm = false;
+}
 </script>
+
+<!-- Resume prompt dialog -->
+{#if showResume}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="tutorial-overlay">
+		<div class="tutorial-overlay-backdrop"></div>
+		<div class="tutorial-dialog" role="dialog" aria-label="チュートリアル再開" tabindex="-1">
+			<div class="tutorial-dialog-header">
+				<span aria-hidden="true">📖</span>
+				<span>チュートリアルの続き</span>
+			</div>
+			<div class="tutorial-dialog-body">
+				<p>前回の途中から続けますか？</p>
+			</div>
+			<div class="tutorial-dialog-actions">
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--secondary"
+					onclick={dismissResumePrompt}
+				>
+					キャンセル
+				</button>
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--secondary"
+					onclick={() => startFromBeginning()}
+				>
+					最初から
+				</button>
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--primary"
+					onclick={() => resumeTutorial()}
+				>
+					続きから
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Exit confirmation dialog -->
+{#if showExitConfirm && active}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="tutorial-confirm-overlay" onclick={cancelExit}>
+		<div
+			class="tutorial-dialog"
+			role="dialog"
+			aria-label="チュートリアル終了確認"
+			tabindex="-1"
+			onclick={(e) => e.stopPropagation()}
+		>
+			<div class="tutorial-dialog-body">
+				<p>チュートリアルを終了しますか？</p>
+				<p class="tutorial-dialog-hint">進捗は保存されるので、後から続きを再開できます。</p>
+			</div>
+			<div class="tutorial-dialog-actions">
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--secondary"
+					onclick={cancelExit}
+				>
+					続ける
+				</button>
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--danger"
+					onclick={confirmExit}
+				>
+					終了する
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
 
 {#if active && step && targetRect}
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -107,6 +199,12 @@ function handleOverlayClick(e: MouseEvent) {
 		z-index: 100;
 	}
 
+	.tutorial-overlay-backdrop {
+		position: absolute;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+	}
+
 	.tutorial-overlay-svg {
 		position: absolute;
 		inset: 0;
@@ -117,7 +215,7 @@ function handleOverlayClick(e: MouseEvent) {
 
 	.tutorial-overlay-bg {
 		pointer-events: auto;
-		cursor: pointer;
+		cursor: default;
 	}
 
 	.tutorial-spotlight-ring {
@@ -136,5 +234,140 @@ function handleOverlayClick(e: MouseEvent) {
 		50% {
 			box-shadow: 0 0 24px rgba(59, 130, 246, 0.5);
 		}
+	}
+
+	/* Confirm overlay — sits above the tutorial overlay */
+	.tutorial-confirm-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 120;
+		background: rgba(0, 0, 0, 0.4);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	/* Dialog shared styles */
+	.tutorial-dialog {
+		position: relative;
+		z-index: 110;
+		background: white;
+		border-radius: 16px;
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+		width: 320px;
+		max-width: 90vw;
+		margin: auto;
+		overflow: hidden;
+		animation: dialog-appear 0.2s ease-out;
+		/* Center in overlay */
+		position: fixed;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+	}
+
+	.tutorial-confirm-overlay .tutorial-dialog {
+		position: relative;
+		top: auto;
+		left: auto;
+		transform: none;
+	}
+
+	@keyframes dialog-appear {
+		from {
+			opacity: 0;
+			transform: translate(-50%, -50%) scale(0.95);
+		}
+		to {
+			opacity: 1;
+			transform: translate(-50%, -50%) scale(1);
+		}
+	}
+
+	.tutorial-confirm-overlay .tutorial-dialog {
+		animation-name: dialog-appear-centered;
+	}
+
+	@keyframes dialog-appear-centered {
+		from {
+			opacity: 0;
+			transform: scale(0.95);
+		}
+		to {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
+
+	.tutorial-dialog-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 14px 16px;
+		background: linear-gradient(135deg, #3b82f6, #2563eb);
+		color: white;
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+
+	.tutorial-dialog-body {
+		padding: 20px 16px 12px;
+	}
+
+	.tutorial-dialog-body p {
+		margin: 0;
+		font-size: 0.9rem;
+		color: #334155;
+		line-height: 1.5;
+	}
+
+	.tutorial-dialog-hint {
+		margin-top: 8px !important;
+		font-size: 0.8rem !important;
+		color: #64748b !important;
+	}
+
+	.tutorial-dialog-actions {
+		display: flex;
+		gap: 8px;
+		padding: 12px 16px 16px;
+		justify-content: flex-end;
+	}
+
+	.tutorial-dialog-btn {
+		padding: 8px 16px;
+		border-radius: 8px;
+		font-size: 0.8rem;
+		font-weight: 600;
+		border: none;
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.tutorial-dialog-btn--primary {
+		background: linear-gradient(135deg, #3b82f6, #2563eb);
+		color: white;
+	}
+
+	.tutorial-dialog-btn--primary:hover {
+		background: linear-gradient(135deg, #2563eb, #1d4ed8);
+	}
+
+	.tutorial-dialog-btn--secondary {
+		background: #f1f5f9;
+		color: #475569;
+	}
+
+	.tutorial-dialog-btn--secondary:hover {
+		background: #e2e8f0;
+	}
+
+	.tutorial-dialog-btn--danger {
+		background: #fef2f2;
+		color: #dc2626;
+	}
+
+	.tutorial-dialog-btn--danger:hover {
+		background: #fee2e2;
 	}
 </style>

--- a/src/lib/ui/tutorial/tutorial-chapters.ts
+++ b/src/lib/ui/tutorial/tutorial-chapters.ts
@@ -144,49 +144,84 @@ export const TUTORIAL_CHAPTERS: TutorialChapter[] = [
 	},
 	{
 		id: 5,
-		title: 'アップグレード',
-		icon: '⭐',
+		title: 'みまもり（レポート）',
+		icon: '📊',
 		steps: [
 			{
-				id: 'premium-1',
+				id: 'reports-1',
 				chapterId: 5,
-				selector: '[data-tutorial="summary-cards"]',
-				title: '無料でできること',
+				selector: '[data-tutorial="report-tabs"]',
+				title: 'レポート画面',
 				description:
-					'初期登録されている活動の記録、こども1人の登録、ポイント・レベル機能は無料でお使いいただけます。まずは無料で試してみてください！',
+					'こどもの活動を月次・週次で振り返れるレポート画面です。上部のタブで「月次レポート」と「週次レポート」を切り替えられます。「今月はどんな活動が多かったかな？」を確認しましょう。',
 				position: 'bottom',
-				page: '/admin',
+				page: '/admin/reports',
 			},
 			{
-				id: 'premium-2',
+				id: 'reports-2',
 				chapterId: 5,
-				selector: '[data-tutorial="children-overview"]',
-				title: 'スタンダード / ファミリーでできること',
+				selector: '[data-tutorial="growth-book-link"]',
+				title: 'グロースブック',
 				description:
-					'オリジナル活動の追加・編集、チェックリストの自由作成、ごほうびの設定、こどもの登録無制限、データのエクスポートが可能になります。お子さまに合わせた設定で、もっと楽しく！',
+					'こどもの1年間の成長をまとめた「成長記録ブック」も用意しています。レポート画面右上の「📖 記録ブック」リンクからアクセスできます。印刷してお子さまの記念にもなります。',
 				position: 'bottom',
-				page: '/admin',
-			},
-			{
-				id: 'premium-3',
-				chapterId: 5,
-				selector: '[data-tutorial="upgrade-btn"]',
-				title: 'アップグレード',
-				description:
-					'管理画面右上の「⭐ アップグレード」ボタンから、いつでも有料プランに切り替えられます。7日間の無料トライアル付きなので、まずはお試しください。',
-				position: 'bottom',
-				page: '/admin',
+				page: '/admin/reports',
 			},
 		],
 	},
 	{
 		id: 6,
+		title: 'はげまし（メッセージ）',
+		icon: '💬',
+		steps: [
+			{
+				id: 'messages-1',
+				chapterId: 6,
+				selector: '[data-tutorial="message-child-select"]',
+				title: 'メッセージ送信',
+				description:
+					'こどもにおうえんメッセージを送れる画面です。まず送りたいこどもを選んで、スタンプまたはテキストメッセージを選びましょう。こどもの画面にメッセージが届きます。',
+				position: 'bottom',
+				page: '/admin/messages',
+			},
+			{
+				id: 'messages-2',
+				chapterId: 6,
+				selector: '[data-tutorial="message-stamp-grid"]',
+				title: 'スタンプの送り方',
+				description:
+					'スタンプを選択して「送信」ボタンを押すだけで、こどもにおうえんの気持ちを伝えられます。「がんばったね！」「すごい！」など、お子さまが喜ぶスタンプが揃っています。',
+				position: 'bottom',
+				page: '/admin/messages',
+			},
+		],
+	},
+	{
+		id: 7,
+		title: 'カスタマイズ（データ管理）',
+		icon: '🎮',
+		steps: [
+			{
+				id: 'customize-1',
+				chapterId: 7,
+				selector: '[data-tutorial="data-management"]',
+				title: 'データ管理',
+				description:
+					'家族のデータをJSONファイルとしてエクスポート（バックアップ）したり、別の環境からインポート（復元）できます。機種変更やデータの引っ越しに便利です。',
+				position: 'bottom',
+				page: '/admin/settings',
+				requiredTier: 'standard',
+			},
+		],
+	},
+	{
+		id: 8,
 		title: '設定と日常の使い方',
 		icon: '⚙️',
 		steps: [
 			{
 				id: 'settings-1',
-				chapterId: 6,
+				chapterId: 8,
 				selector: '[data-tutorial="switch-to-child"]',
 				title: 'こども画面へ切替',
 				description:
@@ -196,7 +231,7 @@ export const TUTORIAL_CHAPTERS: TutorialChapter[] = [
 			},
 			{
 				id: 'settings-2',
-				chapterId: 6,
+				chapterId: 8,
 				selector: '[data-tutorial="pin-settings"]',
 				title: 'PINコード設定',
 				description:
@@ -206,7 +241,7 @@ export const TUTORIAL_CHAPTERS: TutorialChapter[] = [
 			},
 			{
 				id: 'settings-3',
-				chapterId: 6,
+				chapterId: 8,
 				selector: '[data-tutorial="feedback-section"]',
 				title: 'フィードバック',
 				description:
@@ -216,13 +251,50 @@ export const TUTORIAL_CHAPTERS: TutorialChapter[] = [
 			},
 			{
 				id: 'settings-4',
-				chapterId: 6,
+				chapterId: 8,
 				selector: '[data-tutorial="tutorial-restart"]',
 				title: 'チュートリアルの再開',
 				description:
 					'このチュートリアルは、ヘッダーの「？」ボタンからいつでも見直せます。使い方に迷った時はお気軽にどうぞ。お疲れさまでした！',
 				position: 'bottom',
 				page: '/admin/settings',
+			},
+		],
+	},
+	{
+		id: 9,
+		title: 'アップグレード',
+		icon: '⭐',
+		steps: [
+			{
+				id: 'premium-1',
+				chapterId: 9,
+				selector: '[data-tutorial="summary-cards"]',
+				title: '無料でできること',
+				description:
+					'初期登録されている活動の記録、こども2人の登録、ポイント・レベル機能は無料でお使いいただけます。まずは無料で試してみてください！',
+				position: 'bottom',
+				page: '/admin',
+			},
+			{
+				id: 'premium-2',
+				chapterId: 9,
+				selector: '[data-tutorial="children-overview"]',
+				title: 'スタンダード / ファミリーでもっと便利に',
+				description:
+					'オリジナル活動の追加・編集、チェックリストの自由作成、ごほうびの設定、こどもの登録無制限、データのエクスポートが可能になります。お子さまに合わせた設定で、もっと楽しく！',
+				position: 'bottom',
+				page: '/admin',
+			},
+			{
+				id: 'premium-3',
+				chapterId: 9,
+				selector: '[data-tutorial="upgrade-btn"]',
+				title: 'アップグレード',
+				description:
+					'管理画面右上の「⭐ アップグレード」ボタンから、いつでも有料プランに切り替えられます。7日間の無料トライアル付きなので、まずはお試しください。',
+				position: 'bottom',
+				page: '/admin',
 			},
 		],
 	},

--- a/src/lib/ui/tutorial/tutorial-store.svelte.ts
+++ b/src/lib/ui/tutorial/tutorial-store.svelte.ts
@@ -2,16 +2,29 @@ import { goto } from '$app/navigation';
 import { TUTORIAL_CHAPTERS } from './tutorial-chapters';
 import type { TutorialChapter, TutorialStep } from './tutorial-types';
 
+// ── localStorage persistence keys ──
+const STORAGE_KEY_CHAPTER = 'tutorial-progress-chapter';
+const STORAGE_KEY_STEP = 'tutorial-progress-step';
+
 interface TutorialState {
 	isActive: boolean;
 	currentChapter: number;
 	currentStepIndex: number;
+	/** Whether a resume prompt is being shown */
+	showResumePrompt: boolean;
+	/** Saved chapter id from previous session */
+	savedChapter: number;
+	/** Saved step index from previous session */
+	savedStepIndex: number;
 }
 
 const state = $state<TutorialState>({
 	isActive: false,
 	currentChapter: 1,
 	currentStepIndex: 0,
+	showResumePrompt: false,
+	savedChapter: 1,
+	savedStepIndex: 0,
 });
 
 // Configurable chapter source (default: parent admin chapters)
@@ -25,6 +38,48 @@ export function setChapters(chapters: TutorialChapter[]) {
 /** Reset to default parent admin chapters */
 export function resetChapters() {
 	activeChapters = TUTORIAL_CHAPTERS;
+}
+
+// ── localStorage helpers (SSR-safe) ──
+function saveProgress(chapterId: number, stepIndex: number) {
+	try {
+		if (typeof window !== 'undefined') {
+			localStorage.setItem(STORAGE_KEY_CHAPTER, String(chapterId));
+			localStorage.setItem(STORAGE_KEY_STEP, String(stepIndex));
+		}
+	} catch {
+		// localStorage unavailable — silently ignore
+	}
+}
+
+function loadSavedProgress(): { chapter: number; stepIndex: number } | null {
+	try {
+		if (typeof window === 'undefined') return null;
+		const ch = localStorage.getItem(STORAGE_KEY_CHAPTER);
+		const st = localStorage.getItem(STORAGE_KEY_STEP);
+		if (ch == null || st == null) return null;
+		const chapter = Number.parseInt(ch, 10);
+		const stepIndex = Number.parseInt(st, 10);
+		if (Number.isNaN(chapter) || Number.isNaN(stepIndex)) return null;
+		// Validate that the saved chapter and step still exist
+		const chapterData = activeChapters.find((c) => c.id === chapter);
+		if (!chapterData) return null;
+		if (stepIndex < 0 || stepIndex >= chapterData.steps.length) return null;
+		return { chapter, stepIndex };
+	} catch {
+		return null;
+	}
+}
+
+function clearSavedProgress() {
+	try {
+		if (typeof window !== 'undefined') {
+			localStorage.removeItem(STORAGE_KEY_CHAPTER);
+			localStorage.removeItem(STORAGE_KEY_STEP);
+		}
+	} catch {
+		// silently ignore
+	}
 }
 
 function flatSteps(): TutorialStep[] {
@@ -60,20 +115,119 @@ export function isTutorialActive(): boolean {
 	return state.isActive;
 }
 
+export function isResumePromptShown(): boolean {
+	return state.showResumePrompt;
+}
+
+export function getSavedProgress(): { chapter: number; stepIndex: number } {
+	return { chapter: state.savedChapter, stepIndex: state.savedStepIndex };
+}
+
 export function getChapters() {
 	return activeChapters;
 }
 
 export async function startTutorial(chapter?: number) {
+	// If no explicit chapter is given, check for saved progress
+	if (chapter == null) {
+		const saved = loadSavedProgress();
+		if (saved && (saved.chapter > 1 || saved.stepIndex > 0)) {
+			// Show resume prompt
+			state.savedChapter = saved.chapter;
+			state.savedStepIndex = saved.stepIndex;
+			state.showResumePrompt = true;
+			return;
+		}
+	}
+
 	const chapterId = chapter ?? 1;
+	state.showResumePrompt = false;
 	state.isActive = true;
 	state.currentChapter = chapterId;
 	state.currentStepIndex = 0;
+	saveProgress(chapterId, 0);
 
 	const step = getCurrentStep();
 	if (step?.page) {
 		await goto(step.page);
 	}
+}
+
+/** Resume from saved progress */
+export async function resumeTutorial() {
+	state.showResumePrompt = false;
+	state.isActive = true;
+	state.currentChapter = state.savedChapter;
+	state.currentStepIndex = state.savedStepIndex;
+
+	const step = getCurrentStep();
+	if (step?.page) {
+		await goto(step.page);
+	}
+}
+
+/** Start from the beginning, discarding saved progress */
+export async function startFromBeginning(chapter?: number) {
+	clearSavedProgress();
+	state.showResumePrompt = false;
+	state.isActive = true;
+	state.currentChapter = chapter ?? 1;
+	state.currentStepIndex = 0;
+	saveProgress(state.currentChapter, 0);
+
+	const step = getCurrentStep();
+	if (step?.page) {
+		await goto(step.page);
+	}
+}
+
+/** Dismiss the resume prompt without starting */
+export function dismissResumePrompt() {
+	state.showResumePrompt = false;
+}
+
+/**
+ * Start tutorial from the chapter most relevant to the current URL path.
+ * Falls back to chapter 1 if no matching chapter is found.
+ */
+export async function startTutorialForPage(pathname: string) {
+	const chapterId = resolveChapterForPath(pathname);
+
+	// If a matching chapter is found (not chapter 1), skip directly there
+	if (chapterId > 1) {
+		state.showResumePrompt = false;
+		state.isActive = true;
+		state.currentChapter = chapterId;
+		state.currentStepIndex = 0;
+		saveProgress(chapterId, 0);
+
+		const step = getCurrentStep();
+		if (step?.page) {
+			await goto(step.page);
+		}
+		return;
+	}
+
+	// Otherwise, fall back to normal start (which may show resume prompt)
+	await startTutorial();
+}
+
+/**
+ * Map a URL pathname to the best-matching tutorial chapter ID.
+ * Returns the chapter id, or 1 (intro) as fallback.
+ */
+function resolveChapterForPath(pathname: string): number {
+	// Build a mapping from page paths to chapter IDs
+	// Check the most specific paths first
+	for (const chapter of activeChapters) {
+		for (const step of chapter.steps) {
+			if (step.page && pathname.startsWith(step.page) && step.page !== '/admin') {
+				return chapter.id;
+			}
+		}
+	}
+	// Default to intro
+	return 1;
 }
 
 export async function nextStep() {
@@ -94,6 +248,8 @@ export async function nextStep() {
 			return;
 		}
 	}
+
+	saveProgress(state.currentChapter, state.currentStepIndex);
 
 	const step = getCurrentStep();
 	if (step?.page && typeof window !== 'undefined') {
@@ -116,6 +272,8 @@ export async function prevStep() {
 		}
 	}
 
+	saveProgress(state.currentChapter, state.currentStepIndex);
+
 	const step = getCurrentStep();
 	if (step?.page && typeof window !== 'undefined') {
 		const currentPath = window.location.pathname;
@@ -131,6 +289,7 @@ export async function skipToChapter(chapterId: number) {
 
 	state.currentChapter = chapterId;
 	state.currentStepIndex = 0;
+	saveProgress(chapterId, 0);
 
 	const step = getCurrentStep();
 	if (step?.page) {
@@ -139,6 +298,10 @@ export async function skipToChapter(chapterId: number) {
 }
 
 export function endTutorial() {
+	// Save current progress before ending so it can be resumed later
+	if (state.isActive) {
+		saveProgress(state.currentChapter, state.currentStepIndex);
+	}
 	state.isActive = false;
 	state.currentChapter = 1;
 	state.currentStepIndex = 0;
@@ -146,6 +309,7 @@ export function endTutorial() {
 
 async function completeTutorial() {
 	state.isActive = false;
+	clearSavedProgress();
 
 	// Persist completion to server
 	try {

--- a/src/routes/(parent)/admin/messages/+page.svelte
+++ b/src/routes/(parent)/admin/messages/+page.svelte
@@ -51,7 +51,7 @@ function selectStamp(code: string) {
 	</div>
 
 	<!-- Step 1: Select child -->
-	<section>
+	<section data-tutorial="message-child-select">
 		<h3 class="text-sm font-bold text-[var(--color-text-muted)] mb-2">1. こどもを選択</h3>
 		<div class="flex gap-2 flex-wrap">
 			{#each data.children as child}
@@ -108,7 +108,7 @@ function selectStamp(code: string) {
 		</div>
 
 		{#if messageType === 'stamp'}
-			<div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
+			<div class="grid grid-cols-2 sm:grid-cols-4 gap-2" data-tutorial="message-stamp-grid">
 				{#each data.stamps as stamp}
 					<Button
 						variant="ghost"

--- a/src/routes/(parent)/admin/reports/+page.svelte
+++ b/src/routes/(parent)/admin/reports/+page.svelte
@@ -108,6 +108,7 @@ function maxCategoryCount(breakdown: Record<string, number>): number {
 			<a
 				href="/admin/growth-book"
 				class="text-sm font-medium px-3 py-1.5 rounded-lg bg-purple-50 text-purple-600 hover:bg-purple-100 transition-colors inline-flex items-center gap-1"
+				data-tutorial="growth-book-link"
 			>
 				📖 記録ブック
 			</a>
@@ -119,7 +120,7 @@ function maxCategoryCount(breakdown: Record<string, number>): number {
 	{/if}
 
 	<!-- Tab navigation -->
-	<div class="flex gap-1 rounded-lg bg-gray-100 p-1">
+	<div class="flex gap-1 rounded-lg bg-gray-100 p-1" data-tutorial="report-tabs">
 		<button
 			class="tab-btn"
 			class:active={activeTab === 'monthly'}

--- a/src/routes/(parent)/admin/settings/+page.svelte
+++ b/src/routes/(parent)/admin/settings/+page.svelte
@@ -947,7 +947,7 @@ const previewFormatted = $derived(
 	</Card>
 
 	<!-- データ管理 -->
-	<Card padding="lg">
+	<Card padding="lg" data-tutorial="data-management">
 		<h3 class="text-lg font-bold text-[var(--color-text)] mb-4">💾 データ管理</h3>
 
 		{#if exportError}


### PR DESCRIPTION
## Summary
- チュートリアル進捗のlocalStorage永続化（中断→再開で前回位置から再開可能）
- ページ別起動（現在のURLに応じたチャプター開始 — /admin/reports→みまもり、/admin/messages→はげまし等）
- 外部クリックで即終了ではなく確認ダイアログ表示に変更
- みまもり（レポート・グロースブック）・はげまし（メッセージ・スタンプ）・カスタマイズ（データ管理）のチュートリアルステップ追加
- チャプター数: 6→9、ステップ数: 18→23

closes #494, closes #495

## Test plan
- [ ] チュートリアル中断→再開で前回位置から再開可能
- [ ] 各ページで「?」ボタン押下時に適切なチャプターから開始
- [ ] 外部クリック時に確認ダイアログが表示される
- [ ] 新規追加ステップ（レポート・メッ��ージ・データ管理）が正しくフォーカス・表示される
- [ ] チュートリアル完了時にlocalStorage進捗がクリアされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>