### PR TITLE
fix: #526 #527 #528 AdminHome — dead prop削除・uiMode日本語化確認・見出し階層修正

### DIFF
--- a/src/lib/features/admin/components/AdminHome.svelte
+++ b/src/lib/features/admin/components/AdminHome.svelte
@@ -59,13 +59,6 @@ interface Props {
 	monthlySummaries?: Record<number, MonthSummaryData>;
 	currentMonth?: string;
 	planTier?: 'free' | 'standard' | 'family';
-	planStats?: {
-		activityCount: number;
-		activityMax: number | null;
-		childCount: number;
-		childMax: number | null;
-		retentionDays: number | null;
-	};
 	showPremiumWelcome?: boolean;
 	seasonalInfo?: {
 		activeEvents: SeasonEventInfo[];
@@ -83,7 +76,6 @@ let {
 	monthlySummaries = {},
 	currentMonth = '',
 	planTier = 'free',
-	planStats,
 	showPremiumWelcome = false,
 	seasonalInfo = null,
 }: Props = $props();
@@ -139,6 +131,9 @@ function childLink(child: ChildSummary): string {
 {/if}
 
 <div class="space-y-6">
+	<!-- Page heading (visually compact, semantically correct) -->
+	<h1 class="dashboard-heading">管理ダッシュボード{isDemo ? '（デモ）' : ''}</h1>
+
 	<!-- Onboarding Checklist (replaces tutorial banner for new users) -->
 	{#if showOnboarding && onboarding}
 		<OnboardingChecklist {onboarding} />
@@ -217,9 +212,6 @@ function childLink(child: ChildSummary): string {
 			{/if}
 		</section>
 	{/if}
-
-	<!-- Page heading (visually compact, semantically correct) -->
-	<h1 class="dashboard-heading">管理ダッシュボード{isDemo ? '（デモ）' : ''}</h1>
 
 	<!-- Summary Cards -->
 	<div class="grid grid-cols-2 gap-3" data-tutorial="summary-cards">


### PR DESCRIPTION
## Summary
- **#526**: `planStats` dead prop をProps定義とdestructureから完全削除（親コンポーネント・サーバー側は既に未使用）
- **#527**: `child.uiMode` はChildListCard内の`uiModeLabels`マッピングで既に日本語化済み。AdminHomeはChildListCardに委譲しているため追加変更不要
- **#528**: `<h1>`をページ最上部（`div.space-y-6`の先頭）に移動し、セマンティクス上正しい位置に配置。セクション見出しは`<h2>`で適切な階層構造を維持

closes #526, closes #527, closes #528

## Test plan
- [ ] planStatsがAdminHome.svelteのコード内に残っていないこと
- [ ] こども一覧でuiModeが日本語表示されること（ChildListCard経由）
- [ ] ページに`<h1>`が1つだけ存在し、コンテンツの先頭にあること
- [ ] セクション見出しが`<h2>`であること
- [ ] svelte-check で AdminHome 関連の新規エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>