### PR TITLE
fix: #524 #525 CSS変数 --color-text-disabled 定義 + opacity パターン移行

### DIFF
--- a/src/lib/features/admin/components/ActivityEditForm.svelte
+++ b/src/lib/features/admin/components/ActivityEditForm.svelte
@@ -150,7 +150,7 @@ let actionMessage = $state('');
 
 	<!-- Delete confirmation -->
 	{#if deleteConfirmId === activity.id}
-		<div class="bg-[var(--color-feedback-error-bg,#fef2f2)] border border-[var(--color-action-danger,#f44336)]/20 rounded-lg p-3 space-y-2">
+		<div class="bg-[var(--color-feedback-error-bg,#fef2f2)] border border-[var(--color-border-danger)] rounded-lg p-3 space-y-2">
 			{#if logCount > 0}
 				<p class="text-sm text-[var(--color-gold-700)] font-bold">この活動には {logCount} 件の記録があります</p>
 				<p class="text-xs text-[var(--color-warning)]">記録を保護するため、完全削除ではなく「非表示」にします。非表示の活動は子供の画面に表示されなくなりますが、過去の記録はそのまま残ります。</p>

--- a/src/lib/features/admin/components/ActivityImportPanel.svelte
+++ b/src/lib/features/admin/components/ActivityImportPanel.svelte
@@ -14,7 +14,7 @@ let importLoading = $state(false);
 let fileImportLoading = $state(false);
 </script>
 
-<div class="bg-[var(--color-rarity-common-bg)] rounded-xl p-4 shadow-sm space-y-3 border border-[var(--color-action-success)]/20">
+<div class="bg-[var(--color-rarity-common-bg)] rounded-xl p-4 shadow-sm space-y-3 border border-[var(--color-border-success)]">
 	<div class="flex items-center justify-between">
 		<h3 class="font-bold text-[var(--color-action-success)]">📥 活動パックからインポート</h3>
 		<a href="/admin/packs" class="text-xs text-[var(--color-action-success)] hover:opacity-80 underline">すべてのパック →</a>
@@ -45,7 +45,7 @@ let fileImportLoading = $state(false);
 					<button
 						type="submit"
 						disabled={importLoading}
-						class="w-full flex items-center gap-3 p-3 bg-[var(--color-surface-card)] rounded-lg border border-[var(--color-action-success)]/20 hover:border-[var(--color-action-success)]/40 hover:bg-[var(--color-rarity-common-bg)] transition-colors text-left"
+						class="w-full flex items-center gap-3 p-3 bg-[var(--color-surface-card)] rounded-lg border border-[var(--color-border-success)] hover:border-[var(--color-border-success-strong)] hover:bg-[var(--color-rarity-common-bg)] transition-colors text-left"
 					>
 						<span class="text-2xl">{pack.icon}</span>
 						<div class="flex-1 min-w-0">
@@ -62,7 +62,7 @@ let fileImportLoading = $state(false);
 	{/if}
 
 	<!-- ファイルからインポート -->
-	<div class="border-t border-[var(--color-action-success)]/20 pt-3 mt-3">
+	<div class="border-t border-[var(--color-border-success)] pt-3 mt-3">
 		<h4 class="font-bold text-[var(--color-action-success)] text-sm mb-2">📁 ファイルからインポート</h4>
 		<p class="text-xs text-[var(--color-action-success)] mb-2">JSON または CSV ファイルから活動を一括追加（重複はスキップ）</p>
 		<form

--- a/src/lib/features/admin/components/AiSuggestPanel.svelte
+++ b/src/lib/features/admin/components/AiSuggestPanel.svelte
@@ -47,7 +47,7 @@ function acceptPreview() {
 }
 </script>
 
-<div class="bg-[var(--color-premium-bg)] rounded-xl p-4 shadow-sm space-y-3 border border-[var(--color-premium)]/20">
+<div class="bg-[var(--color-premium-bg)] rounded-xl p-4 shadow-sm space-y-3 border border-[var(--color-border-premium)]">
 	<h3 class="font-bold text-[var(--color-premium)]">✨ やりたいことを教えてください</h3>
 	<p class="text-xs text-[var(--color-premium-light)]">
 		やりたい活動を自由に入力すると、カテゴリ・ポイント・アイコンを自動で提案します
@@ -85,7 +85,7 @@ function acceptPreview() {
 	{/if}
 
 	{#if aiPreview}
-		<div class="bg-[var(--color-surface-card)] rounded-lg p-3 space-y-2 border border-[var(--color-premium)]/20">
+		<div class="bg-[var(--color-surface-card)] rounded-lg p-3 space-y-2 border border-[var(--color-border-premium)]">
 			{#if aiPreview.source === 'fallback'}
 				<p class="text-xs text-[var(--color-warning)] bg-[var(--color-gold-100)] px-2 py-1 rounded">AIが利用できなかったため、入力内容から推定しました</p>
 			{/if}

--- a/src/lib/ui/styles/app.css
+++ b/src/lib/ui/styles/app.css
@@ -69,6 +69,7 @@
 	--color-gold-300: #ffed80;
 	--color-gold-200: #fff4b3;
 	--color-gold-100: #fffbe6;
+	--color-gold-50: #fffef5;
 
 	/* ---- Neutral (テキスト・背景のグレースケール) ---- */
 	--color-neutral-900: #1e293b;
@@ -99,6 +100,9 @@
 	--color-violet-700: #6d28d9;
 	--color-violet-600: #7c3aed;
 	--color-violet-500: #8b5cf6;
+	--color-violet-300: #c4b5fd;
+	--color-violet-200: #ddd6fe;
+	--color-violet-50: #f5f3ff;
 
 	/* ---- Rarity Colors (実績・シールのレアリティ) ---- */
 	--color-rarity-common: #86efac;
@@ -226,6 +230,7 @@
 
 	/* ---- Action: インタラクティブ要素 ---- */
 	--color-action-primary: var(--theme-primary);
+	--color-action-primary-hover: var(--color-brand-700);
 	--color-action-secondary: var(--theme-secondary);
 	--color-action-accent: var(--theme-accent);
 	--color-action-danger: var(--color-danger);
@@ -233,19 +238,34 @@
 	--color-action-ghost: transparent;
 
 	/* ---- Surface: 背景・コンテナ ---- */
+	--color-surface: white;
 	--color-surface-base: var(--color-bg);
 	--color-surface-card: white;
 	--color-surface-overlay: rgba(0, 0, 0, 0.5);
 	--color-surface-elevated: white;
 	--color-surface-muted: var(--color-neutral-50);
+	--color-surface-secondary: var(--color-neutral-100);
+	--color-surface-accent: var(--color-feedback-info-bg);
+	--color-surface-info: var(--color-feedback-info-bg);
+	--color-surface-success: var(--color-feedback-success-bg);
+	--color-surface-warning: var(--color-feedback-warning-bg);
+	--color-surface-warm: #fef3c7;
 	--color-surface-themed: var(--theme-bg);
 	--color-surface-nav: var(--theme-nav);
 
 	/* ---- Border ---- */
+	--color-border: var(--color-neutral-200);
 	--color-border-default: var(--color-neutral-200);
+	--color-border-light: var(--color-neutral-100);
 	--color-border-strong: var(--color-neutral-300);
 	--color-border-focus: var(--theme-primary);
 	--color-border-accent: var(--theme-accent);
+	--color-border-warm: rgba(251, 191, 36, 0.3);
+	--color-border-warning: var(--color-feedback-warning-border);
+	--color-border-premium: color-mix(in srgb, var(--color-premium) 20%, transparent);
+	--color-border-danger: color-mix(in srgb, var(--color-danger) 20%, transparent);
+	--color-border-success: color-mix(in srgb, var(--color-success) 20%, transparent);
+	--color-border-success-strong: color-mix(in srgb, var(--color-success) 40%, transparent);
 
 	/* ---- Text (Base層の補完) ---- */
 	--color-text-inverse: white;
@@ -254,6 +274,9 @@
 	--color-text-primary: var(--color-neutral-700);
 	--color-text-secondary: var(--color-neutral-600);
 	--color-text-tertiary: var(--color-neutral-400);
+	--color-text-disabled: #9ca3af;
+	--color-text-warm: #92400e;
+	--color-text-warm-muted: #a16207;
 
 	/* ---- Status Colors (Danger/Success/Warning スケール) ---- */
 	--color-danger-50: #fef2f2;
@@ -270,6 +293,9 @@
 	--color-warning-50: #fff7ed;
 	--color-warning-100: #ffedd5;
 	--color-warning-200: #fed7aa;
+	--color-warning-text: #92400e;
+	--color-warning-hover: #d97706;
+	--color-info-50: #eff6ff;
 
 	/* ---- Premium (スケール拡充) ---- */
 	--color-premium-50: #f5f3ff;


### PR DESCRIPTION
## Summary
- `--color-text-disabled` (#9ca3af) を app.css の `:root` に定義し、21箇所の参照を正式にサポート
- 他の未定義CSS変数23個も一括定義（`--color-border`, `--color-surface-secondary`, `--color-text-warm` 等）
- Tailwind `/20` opacity パターン6箇所を `color-mix()` ベースのセマンティックトークンに移行
  - `--color-border-premium`, `--color-border-danger`, `--color-border-success` を追加
- `@theme` ブロックに `--color-violet-50/200/300`, `--color-gold-50` を追加
- 突合後に残る未定義変数は `--color-pricing-accent` のみ（pricing ページでローカル定義済み）

closes #524, closes #525

## Test plan
- [x] `--color-text-disabled` が app.css に定義されていること
- [x] disabled 要素の色が統一されていること（21箇所すべて同一トークン参照）
- [x] Tailwind の opacity 記法 (`/20` 等) が残っていないこと
- [x] `svelte-check` でCSS変更起因のエラーなし
- [x] `vitest run` でCSS変更起因のテスト失敗なし
- [x] 未定義CSS変数の突合完了（pricing ページのローカル定義を除き解消済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>