### PR TITLE
fix: #547 TutorialOverlay タイマー未クリア + bottomNav可視判定 + E2E文字化け修正

### DIFF
--- a/src/lib/ui/components/TutorialBubble.svelte
+++ b/src/lib/ui/components/TutorialBubble.svelte
@@ -42,8 +42,12 @@ const bubbleStyle = $derived.by(() => {
 	const stickyHeader = document.querySelector('.admin-header, [class*="sticky"][class*="top-"]');
 	const bottomNav = document.querySelector('[data-tutorial="nav-primary"]');
 
-	const headerH = stickyHeader ? stickyHeader.getBoundingClientRect().bottom : 0;
-	const navTop = bottomNav ? bottomNav.getBoundingClientRect().top : window.innerHeight;
+	const headerRect = stickyHeader?.getBoundingClientRect();
+	const navRect = bottomNav?.getBoundingClientRect();
+	const headerH =
+		headerRect && headerRect.width > 0 && headerRect.height > 0 ? headerRect.bottom : 0;
+	const navTop =
+		navRect && navRect.width > 0 && navRect.height > 0 ? navRect.top : window.innerHeight;
 
 	// セーフゾーン: ヘッダー下端 ～ ボトムナビ上端
 	const safeTop = Math.max(headerH + edgePad, edgePad);

--- a/src/lib/ui/components/TutorialOverlay.svelte
+++ b/src/lib/ui/components/TutorialOverlay.svelte
@@ -56,10 +56,13 @@ function waitForElement(
 		return;
 	}
 
+	let timer: ReturnType<typeof setTimeout>;
+
 	const observer = new MutationObserver(() => {
 		const el = findVisibleElement(selector);
 		if (el) {
 			observer.disconnect();
+			clearTimeout(timer);
 			requestAnimationFrame(() => {
 				if (!signal.aborted) callback(el);
 			});
@@ -68,7 +71,7 @@ function waitForElement(
 
 	observer.observe(document.body, { childList: true, subtree: true, attributes: true });
 
-	const timer = setTimeout(() => {
+	timer = setTimeout(() => {
 		observer.disconnect();
 		if (!signal.aborted) {
 			// 最終チェック

--- a/tests/e2e/tutorial-verification.spec.ts
+++ b/tests/e2e/tutorial-verification.spec.ts
@@ -220,7 +220,7 @@ test.describe('チュートリアル全ステップ検証', () => {
 						bubbleBox.y + bubbleBox.height > navBox.y && bubbleBox.y < navBox.y + navBox.height;
 					expect(
 						navOverlap,
-						`Mobile Step ${stepNum} "${title}": バブルがボトムナビに被っていな��`,
+						`Mobile Step ${stepNum} "${title}": バブルがボトムナビに被っていない`,
 					).toBe(false);
 				}
 			}


### PR DESCRIPTION
## Summary
- TutorialOverlay の `waitForElement` 内 MutationObserver がタイマーをクリアしていなかったバグを修正
- TutorialBubble の bottomNav/stickyHeader 可視判定に `rect.width > 0 && rect.height > 0` を追加
- E2E テスト `tutorial-verification.spec.ts` L223 の文字化け修正

closes #547

## Test plan
- [x] `npx biome check src/ tests/` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし（0 ERRORS）
- [x] `npx vitest run` — 2235 テスト全通過
- [x] `npx playwright test` — 106 E2E テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>