### PR TITLE
fix: #548 calculateAge の UTC パース修正

### DIFF
--- a/src/lib/server/db/migration/transformers/child.ts
+++ b/src/lib/server/db/migration/transformers/child.ts
@@ -35,12 +35,12 @@ export const childV1toV2: SchemaTransformer = {
  */
 function calculateAge(birthDate: string | null | undefined): number | null {
 	if (!birthDate || typeof birthDate !== 'string') return null;
-	const birth = new Date(birthDate);
+	const birth = new Date(`${birthDate}T00:00:00Z`);
 	if (Number.isNaN(birth.getTime())) return null;
 	const now = new Date();
-	let age = now.getFullYear() - birth.getFullYear();
-	const monthDiff = now.getMonth() - birth.getMonth();
-	if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < birth.getDate())) {
+	let age = now.getUTCFullYear() - birth.getUTCFullYear();
+	const monthDiff = now.getUTCMonth() - birth.getUTCMonth();
+	if (monthDiff < 0 || (monthDiff === 0 && now.getUTCDate() < birth.getUTCDate())) {
 		age--;
 	}
 	return age;

--- a/tests/unit/migration/child-transformers.test.ts
+++ b/tests/unit/migration/child-transformers.test.ts
@@ -1,8 +1,8 @@
 // tests/unit/migration/child-transformers.test.ts
 // Child エンティティの Transformer テスト
 
-import { describe, expect, it } from 'vitest';
-import { childV1toV2 } from '../../../src/lib/server/db/migration/transformers/child';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { childV1toV2, childV2toV3 } from '../../../src/lib/server/db/migration/transformers/child';
 import { SCHEMA_VERSION_FIELD } from '../../../src/lib/server/db/migration/types';
 
 describe('Child Transformer: V1→V2', () => {
@@ -58,5 +58,90 @@ describe('Child Transformer: V1→V2', () => {
 		const original = { nickname: '太郎', age: 5 };
 		childV1toV2.transform(original);
 		expect(original).toEqual({ nickname: '太郎', age: 5 });
+	});
+});
+
+describe('Child Transformer: V2→V3', () => {
+	beforeEach(() => {
+		// 2026-04-06T12:00:00Z に固定
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-04-06T12:00:00Z'));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('_sv を 3 に設定する', () => {
+		const result = childV2toV3.transform({
+			[SCHEMA_VERSION_FIELD]: 2,
+			uiMode: 'preschool',
+		});
+		expect(result[SCHEMA_VERSION_FIELD]).toBe(3);
+	});
+
+	it('既に新コード名の場合はそのまま保持する', () => {
+		for (const mode of ['baby', 'preschool', 'elementary', 'junior', 'senior']) {
+			const result = childV2toV3.transform({
+				[SCHEMA_VERSION_FIELD]: 2,
+				uiMode: mode,
+			});
+			expect(result.uiMode).toBe(mode);
+		}
+	});
+
+	it('旧コード名を年齢ベースで再割り当てする', () => {
+		const result = childV2toV3.transform({
+			[SCHEMA_VERSION_FIELD]: 2,
+			uiMode: 'kinder',
+			birthDate: '2021-01-01', // 5歳 → preschool
+		});
+		expect(result.uiMode).toBe('preschool');
+	});
+
+	it('年齢不明の場合は機械的マッピングで変換する', () => {
+		const cases: [string, string][] = [
+			['kinder', 'preschool'],
+			['lower', 'elementary'],
+			['upper', 'junior'],
+			['teen', 'senior'],
+		];
+		for (const [oldMode, expected] of cases) {
+			const result = childV2toV3.transform({
+				[SCHEMA_VERSION_FIELD]: 2,
+				uiMode: oldMode,
+				birthDate: null,
+			});
+			expect(result.uiMode).toBe(expected);
+		}
+	});
+
+	it('calculateAge が UTC ベースで正しく算出される（TZ境界テスト）', () => {
+		// 2026-04-06 に 2020-04-06 生まれ → ちょうど6歳 → elementary
+		const result = childV2toV3.transform({
+			[SCHEMA_VERSION_FIELD]: 2,
+			uiMode: 'kinder',
+			birthDate: '2020-04-06',
+		});
+		expect(result.uiMode).toBe('elementary');
+	});
+
+	it('誕生日前日の場合はまだ加齢しない', () => {
+		// 2026-04-06 に 2020-04-07 生まれ → まだ5歳 → preschool
+		const result = childV2toV3.transform({
+			[SCHEMA_VERSION_FIELD]: 2,
+			uiMode: 'kinder',
+			birthDate: '2020-04-07',
+		});
+		expect(result.uiMode).toBe('preschool');
+	});
+
+	it('不正な birthDate は null 扱い（機械的マッピングフォールバック）', () => {
+		const result = childV2toV3.transform({
+			[SCHEMA_VERSION_FIELD]: 2,
+			uiMode: 'lower',
+			birthDate: 'invalid-date',
+		});
+		expect(result.uiMode).toBe('elementary');
 	});
 });


### PR DESCRIPTION
## Summary
- `calculateAge` 関数が `new Date(birthDate)` でローカル TZ に依存したパースを行っていた問題を修正
- UTC 固定パース (`T00:00:00Z` suffix) + `getUTCFullYear/getUTCMonth/getUTCDate` に変更
- V2→V3 Transformer のユニットテスト7件追加（TZ境界、旧→新コード変換、不正日付フォールバック）

closes #548

## Test plan
- [x] `npx biome check` — lint エラーなし
- [x] `npx vitest run` — 2242 テスト全通過（+7 新規テスト）
- [x] 誕生日当日・前日の境界テスト追加済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>