### PR TITLE
fix: #543 活動記録時のダイアログ重複・画面フリーズを防止

### DIFF
--- a/src/lib/ui/sound/sound-service.ts
+++ b/src/lib/ui/sound/sound-service.ts
@@ -12,6 +12,8 @@ export class SoundService {
 	private _muted = false;
 	private _enabledSounds: Set<SoundId> = new Set();
 	private _preloading = false;
+	private _lastPlayTime: Map<SoundId, number> = new Map();
+	private static readonly DEBOUNCE_MS = 300;
 
 	/** AudioContext を遅延初期化（ユーザー操作後に呼出） */
 	ensureContext(): void {
@@ -62,7 +64,7 @@ export class SoundService {
 		this._preloading = false;
 	}
 
-	/** サウンドを再生 */
+	/** サウンドを再生（同一サウンドの300ms以内の連続再生を抑制） */
 	play(soundId: SoundId): void {
 		if (this._muted) return;
 		if (!this.context || !this.gainNode) {
@@ -70,6 +72,12 @@ export class SoundService {
 			if (!this.context || !this.gainNode) return;
 		}
 		if (this._enabledSounds.size > 0 && !this._enabledSounds.has(soundId)) return;
+
+		// Debounce: skip if the same sound was played within DEBOUNCE_MS
+		const now = Date.now();
+		const lastPlay = this._lastPlayTime.get(soundId) ?? 0;
+		if (now - lastPlay < SoundService.DEBOUNCE_MS) return;
+		this._lastPlayTime.set(soundId, now);
 
 		const buffer = this.buffers.get(soundId);
 		if (!buffer) return;

--- a/src/routes/(child)/baby/home/+page.svelte
+++ b/src/routes/(child)/baby/home/+page.svelte
@@ -175,7 +175,7 @@ const focusAllCompleted = $derived(
 let focusRecordActivityId = $state<number | null>(null);
 
 function handleActivityTap(activity: { id: number; name: string; icon: string }) {
-	if (submitting) return;
+	if (submitting || resultOpen || levelUpOpen || rewardOpen || stampPressOpen) return;
 	focusRecordActivityId = activity.id;
 	soundService.ensureContext();
 	soundService.play('tap');
@@ -432,7 +432,7 @@ $effect(() => {
 							action="?/record"
 							data-tutorial={groupIdx === 0 && actIdx === 0 ? 'activity-card' : undefined}
 							use:enhance={() => {
-								if (submitting) return ({ update }) => update();
+								if (submitting || resultOpen || levelUpOpen || rewardOpen || stampPressOpen) return ({ update }) => update();
 								submitting = true;
 								pendingActivityId = activity.id;
 								soundService.ensureContext();

--- a/src/routes/(child)/elementary/home/+page.svelte
+++ b/src/routes/(child)/elementary/home/+page.svelte
@@ -190,6 +190,8 @@ const focusAllCompleted = $derived(
 	recommendedActivities.length > 0 && focusCompletedCount === recommendedActivities.length,
 );
 function handleActivityTap(activity: { id: number; name: string; icon: string }) {
+	if (submitting || confirmOpen || resultOpen || levelUpOpen || rewardOpen || stampPressOpen)
+		return;
 	soundService.play('tap');
 	selectedActivity = activity;
 	confirmOpen = true;

--- a/src/routes/(child)/junior/home/+page.svelte
+++ b/src/routes/(child)/junior/home/+page.svelte
@@ -190,6 +190,8 @@ const focusAllCompleted = $derived(
 	recommendedActivities.length > 0 && focusCompletedCount === recommendedActivities.length,
 );
 function handleActivityTap(activity: { id: number; name: string; icon: string }) {
+	if (submitting || confirmOpen || resultOpen || levelUpOpen || rewardOpen || stampPressOpen)
+		return;
 	soundService.play('tap');
 	selectedActivity = activity;
 	confirmOpen = true;

--- a/src/routes/(child)/preschool/home/+page.svelte
+++ b/src/routes/(child)/preschool/home/+page.svelte
@@ -253,6 +253,8 @@ function getCategoryCompletedMissionCount(categoryId: number) {
 }
 
 function handleActivityTap(activity: { id: number; name: string; icon: string }) {
+	if (submitting || confirmOpen || resultOpen || levelUpOpen || rewardOpen || stampPressOpen)
+		return;
 	soundService.play('tap');
 	selectedActivity = activity;
 	confirmOpen = true;

--- a/src/routes/(child)/senior/home/+page.svelte
+++ b/src/routes/(child)/senior/home/+page.svelte
@@ -190,6 +190,8 @@ const focusAllCompleted = $derived(
 	recommendedActivities.length > 0 && focusCompletedCount === recommendedActivities.length,
 );
 function handleActivityTap(activity: { id: number; name: string; icon: string }) {
+	if (submitting || confirmOpen || resultOpen || levelUpOpen || rewardOpen || stampPressOpen)
+		return;
 	soundService.play('tap');
 	selectedActivity = activity;
 	confirmOpen = true;


### PR DESCRIPTION
## Summary
- 送信中やオーバーレイ（結果表示・レベルアップ・報酬・スタンプ）表示中に、新しい活動記録のconfirmダイアログが開かないようガードを追加（全5つの子供ホームページ）
- サウンド再生に300msデバウンスを追加し、同一サウンドの連続再生を抑制
- baby ページのインラインフォーム送信にもオーバーレイ状態のガードを追加

## Test plan
- [x] `npx biome check` lint エラーなし
- [x] `npx svelte-check` 型エラーなし
- [x] `npx vitest run` 全2235テスト通過
- [ ] `npx playwright test` E2E テスト通過
- [ ] 手動テスト: 連続タップ時にダイアログが重複しないことを確認

closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)