### PR TITLE
fix: #545 管理画面・demo版のダイアログ排他制御を追加

### DIFF
--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -58,7 +58,11 @@ const DIRECTION_OPTIONS = [
 
 const COMMON_ICONS = ['🏫', '👕', '👟', '🎨', '🎵', '📚', '🧹', '🍱', '💧', '📦', '🎒', '✏️'];
 
+// Dialog exclusion: only one dialog open at a time
+const anyDialogOpen = $derived(addItemOpen || addTemplateOpen || overrideOpen);
+
 function openAddItem(templateId: number) {
+	if (anyDialogOpen) return;
 	addItemTemplateId = templateId;
 	itemName = '';
 	itemIcon = '🏫';
@@ -68,12 +72,14 @@ function openAddItem(templateId: number) {
 }
 
 function openAddTemplate() {
+	if (anyDialogOpen) return;
 	templateName = '';
 	templateIcon = '📋';
 	addTemplateOpen = true;
 }
 
 function openOverride() {
+	if (anyDialogOpen) return;
 	overrideDate = data?.today ?? '';
 	overrideAction = 'add';
 	overrideName = '';

--- a/src/routes/(parent)/admin/points/+page.svelte
+++ b/src/routes/(parent)/admin/points/+page.svelte
@@ -74,6 +74,9 @@ const thisMonthTotal = $derived.by(() => {
 });
 const allTimeTotal = $derived(convertHistory.reduce((sum, h) => sum + Math.abs(h.amount), 0));
 
+// Operation exclusion: prevent concurrent form/scan operations
+const anyOperationBusy = $derived(submitting || receiptScanning);
+
 const manualAmount = $derived(Math.floor(Number(manualInput) || 0));
 const manualValid = $derived(manualAmount >= 1 && manualAmount <= currentBalance);
 const receiptValid = $derived(
@@ -106,6 +109,7 @@ function resetReceipt() {
 }
 
 async function handleReceiptFile(event: Event) {
+	if (anyOperationBusy) return;
 	const input = event.target as HTMLInputElement;
 	const file = input.files?.[0];
 	if (!file) return;
@@ -212,7 +216,8 @@ async function handleReceiptFile(event: Event) {
 		<Card padding="lg"><form
 			method="POST"
 			action="?/convert"
-			use:enhance={() => {
+			use:enhance={({ cancel }) => {
+				if (anyOperationBusy) { cancel(); return; }
 				submitting = true;
 				return async ({ result, update }) => {
 					submitting = false;

--- a/src/routes/(parent)/admin/settings/+page.svelte
+++ b/src/routes/(parent)/admin/settings/+page.svelte
@@ -38,6 +38,7 @@ let importResult = $state<{
 let importStep = $state<'select' | 'preview' | 'done'>('select');
 
 async function handleImportFileChange(e: Event) {
+	if (anyFormBusy) return;
 	const input = e.target as HTMLInputElement;
 	importFile = input.files?.[0] ?? null;
 	importError = '';
@@ -81,7 +82,7 @@ async function handleImportFileChange(e: Event) {
 }
 
 async function handleImportExecute() {
-	if (!importFile) return;
+	if (anyFormBusy || !importFile) return;
 	importLoading = true;
 	importError = '';
 	try {
@@ -115,6 +116,7 @@ function resetImport() {
 }
 
 async function handleExport() {
+	if (anyFormBusy) return;
 	exportLoading = true;
 	exportError = '';
 	try {
@@ -185,6 +187,7 @@ async function loadCloudExports() {
 }
 
 async function handleCloudExport() {
+	if (anyFormBusy) return;
 	cloudLoading = true;
 	cloudError = '';
 	cloudSuccess = '';
@@ -221,7 +224,7 @@ async function handleDeleteCloudExport(id: number) {
 }
 
 async function handleCloudImportPreview() {
-	if (!cloudImportPin.trim()) return;
+	if (anyFormBusy || !cloudImportPin.trim()) return;
 	cloudImportLoading = true;
 	cloudImportError = '';
 	try {
@@ -244,6 +247,7 @@ async function handleCloudImportPreview() {
 }
 
 async function handleCloudImportExecute() {
+	if (anyFormBusy) return;
 	cloudImportLoading = true;
 	cloudImportError = '';
 	try {
@@ -297,6 +301,7 @@ const DECAY_OPTIONS = [
 ] as const;
 
 async function saveDecayIntensity() {
+	if (anyFormBusy) return;
 	decaySaving = true;
 	decaySuccess = false;
 	try {
@@ -370,6 +375,7 @@ let deletionInfoLoading = $state(false);
 
 /** Owner 削除時: 他メンバー情報を取得 */
 async function fetchDeletionInfo() {
+	if (anyFormBusy) return;
 	deletionInfoLoading = true;
 	try {
 		const res = await fetch('/api/v1/admin/account/deletion-info');
@@ -385,7 +391,7 @@ async function fetchDeletionInfo() {
 
 /** ロールに応じたアカウント削除 */
 async function handleDeleteAccount() {
-	if (deleteConfirmText !== 'アカウントを削除します') return;
+	if (anyFormBusy || deleteConfirmText !== 'アカウントを削除します') return;
 	deleteSubmitting = true;
 	deleteError = '';
 
@@ -425,7 +431,7 @@ async function handleDeleteAccount() {
 
 /** Owner: 権限移譲して退会 */
 async function handleTransferAndDelete() {
-	if (!transferTargetId) return;
+	if (anyFormBusy || !transferTargetId) return;
 	deleteSubmitting = true;
 	deleteError = '';
 
@@ -450,6 +456,7 @@ async function handleTransferAndDelete() {
 
 /** Owner: 移譲なしで全削除 */
 async function handleFullDelete() {
+	if (anyFormBusy) return;
 	deleteSubmitting = true;
 	deleteError = '';
 
@@ -470,7 +477,7 @@ async function handleFullDelete() {
 }
 
 async function handleCancelAccount() {
-	if (cancelConfirmText !== 'アカウントを削除します') return;
+	if (anyFormBusy || cancelConfirmText !== 'アカウントを削除します') return;
 	cancelSubmitting = true;
 	cancelError = '';
 	try {
@@ -486,6 +493,7 @@ async function handleCancelAccount() {
 }
 
 async function handleReactivate() {
+	if (anyFormBusy) return;
 	reactivateSubmitting = true;
 	try {
 		const res = await fetch('/api/v1/admin/tenant/reactivate', { method: 'POST' });
@@ -502,6 +510,23 @@ async function handleReactivate() {
 const previewPoints = 100;
 const previewFormatted = $derived(
 	formatPointValue(previewPoints, pointMode, pointCurrency, Number.parseFloat(pointRate) || 1),
+);
+
+// Form exclusion: prevent concurrent form operations
+const anyFormBusy = $derived(
+	submitting ||
+		exportLoading ||
+		importLoading ||
+		cloudLoading ||
+		cloudImportLoading ||
+		decaySaving ||
+		pointSubmitting ||
+		feedbackSubmitting ||
+		clearSubmitting ||
+		cancelSubmitting ||
+		reactivateSubmitting ||
+		deleteSubmitting ||
+		deletionInfoLoading,
 );
 </script>
 
@@ -548,7 +573,8 @@ const previewFormatted = $derived(
 		<form
 			method="POST"
 			action="?/changePin"
-			use:enhance={() => {
+			use:enhance={({ cancel }) => {
+				if (anyFormBusy) { cancel(); return; }
 				submitting = true;
 				success = false;
 				return async ({ result, update }) => {
@@ -854,7 +880,8 @@ const previewFormatted = $derived(
 		<form
 			method="POST"
 			action="?/updatePointSettings"
-			use:enhance={() => {
+			use:enhance={({ cancel }) => {
+				if (anyFormBusy) { cancel(); return; }
 				pointSubmitting = true;
 				pointSuccess = false;
 				return async ({ result, update }) => {
@@ -1380,7 +1407,8 @@ const previewFormatted = $derived(
 		<form
 			method="POST"
 			action="?/clearData"
-			use:enhance={() => {
+			use:enhance={({ cancel }) => {
+				if (anyFormBusy) { cancel(); return; }
 				clearSubmitting = true;
 				clearSuccess = false;
 				clearError = '';
@@ -1433,7 +1461,8 @@ const previewFormatted = $derived(
 		<form
 			method="POST"
 			action="?/sendFeedback"
-			use:enhance={() => {
+			use:enhance={({ cancel }) => {
+				if (anyFormBusy) { cancel(); return; }
 				feedbackSubmitting = true;
 				feedbackSuccess = false;
 				feedbackInquiryId = '';

--- a/src/routes/demo/(child)/[mode]/home/+page.svelte
+++ b/src/routes/demo/(child)/[mode]/home/+page.svelte
@@ -55,12 +55,16 @@ let resultData = $state<{ activityName: string; totalPoints: number; streakDays:
 	null,
 );
 
+// Dialog exclusion: prevent opening confirm while result or another dialog is shown
+const anyDialogOpen = $derived(confirmOpen || resultOpen);
+
 function handleActivityTap(activity: {
 	id: number;
 	name: string;
 	displayName?: string;
 	icon: string;
 }) {
+	if (anyDialogOpen || submitting) return;
 	selectedActivity = activity;
 	confirmOpen = true;
 }


### PR DESCRIPTION
## Summary
- `admin/checklists`: 3つのダイアログ（addItem/addTemplate/override）に `anyDialogOpen` ガードを追加し、同時に1つだけ開くよう制御
- `admin/settings`: `anyFormBusy` derived flag を追加し、全フォーム操作（エクスポート/インポート/PIN変更/ポイント設定等 13種）の同時実行を防止
- `admin/points`: `anyOperationBusy` derived flag でフォーム送信とレシートOCRスキャンの競合を防止
- `demo/(child)/[mode]/home`: `confirmOpen` と `resultOpen` の排他制御を追加（#543 の子ども画面と同パターン）

closes #545

## Test plan
- [ ] 管理画面 > チェックリスト: アイテム追加ダイアログ表示中にテンプレート追加ボタンを押してもブロックされる
- [ ] 管理画面 > 設定: エクスポート中に他のフォーム送信がブロックされる
- [ ] 管理画面 > ポイント: 変換送信中にレシート撮影がブロックされる
- [ ] デモ版: 結果ダイアログ表示中に活動カードタップがブロックされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)