### PR TITLE
fix: #590 ライセンスキー入力フロー改善

### DIFF
--- a/src/lib/domain/validation/auth.ts
+++ b/src/lib/domain/validation/auth.ts
@@ -30,12 +30,20 @@ export const emailLoginSchema = z.object({
 	password: z.string().min(8, 'パスワードは8文字以上です'),
 });
 
+/** 旧形式: GQ-XXXX-XXXX-XXXX */
+export const LICENSE_KEY_LEGACY_FORMAT = /^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/;
+/** 新形式: GQ-XXXX-XXXX-XXXX-YYYYY (HMAC署名付き) */
+export const LICENSE_KEY_SIGNED_FORMAT = /^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{5}$/;
+
 export const signupSchema = z.object({
 	email: z.string().email('有効なメールアドレスを入力してください'),
 	password: z.string().min(8, 'パスワードは8文字以上です'),
 	licenseKey: z
 		.string()
-		.regex(/^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/, 'ライセンスキーの形式が不正です'),
+		.refine(
+			(v) => v === '' || LICENSE_KEY_LEGACY_FORMAT.test(v) || LICENSE_KEY_SIGNED_FORMAT.test(v),
+			'ライセンスキーの形式が不正です（GQ-XXXX-XXXX-XXXX または GQ-XXXX-XXXX-XXXX-XXXXX）',
+		),
 });
 
 // --- 確認コード有効期限（UI 表示用 — #591: 2026-04-09 セキュリティ改善） ---

--- a/src/routes/auth/signup/+page.svelte
+++ b/src/routes/auth/signup/+page.svelte
@@ -2,7 +2,11 @@
 import { onDestroy } from 'svelte';
 import { enhance } from '$app/forms';
 import { page } from '$app/stores';
-import { SIGNUP_CODE_EXPIRY_MINUTES } from '$lib/domain/validation/auth';
+import {
+	LICENSE_KEY_LEGACY_FORMAT,
+	LICENSE_KEY_SIGNED_FORMAT,
+	SIGNUP_CODE_EXPIRY_MINUTES,
+} from '$lib/domain/validation/auth';
 import GoogleSignInButton from '$lib/ui/components/GoogleSignInButton.svelte';
 import Logo from '$lib/ui/components/Logo.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
@@ -15,7 +19,18 @@ let { form } = $props();
 let email = $state('');
 let password = $state('');
 let passwordConfirm = $state('');
-let licenseKey = $state('');
+let licenseKeyRaw = $state('');
+const licenseKey = $derived(licenseKeyRaw.toUpperCase().trim());
+const licenseKeyValid = $derived(
+	licenseKey === '' ||
+		LICENSE_KEY_LEGACY_FORMAT.test(licenseKey) ||
+		LICENSE_KEY_SIGNED_FORMAT.test(licenseKey),
+);
+const licenseKeyError = $derived(
+	licenseKeyRaw && !licenseKeyValid
+		? 'GQ-XXXX-XXXX-XXXX または GQ-XXXX-XXXX-XXXX-XXXXX 形式で入力してください'
+		: undefined,
+);
 let codeRaw = $state('');
 const code = $derived(codeRaw.replace(/\s/g, ''));
 let loading = $state(false);
@@ -60,7 +75,7 @@ let confirmStep = $derived(form?.confirmStep ?? false);
 $effect(() => {
 	if (typeof form?.email === 'string') email = form.email;
 	if (typeof form?.licenseKey === 'string') {
-		licenseKey = form.licenseKey;
+		licenseKeyRaw = form.licenseKey;
 		if (form.licenseKey) showLicenseKey = true;
 	}
 });
@@ -245,20 +260,33 @@ $effect(() => {
 				/>
 
 				{#if showLicenseKey}
-					<FormField label="ライセンスキー" id="licenseKey" hint="購入済みのライセンスキーを入力してください">
+					<FormField
+						label="ライセンスキー"
+						id="licenseKey"
+						hint="購入済みのライセンスキーを入力してください"
+						error={licenseKeyError}
+					>
 						{#snippet children()}
 							<input
 								id="licenseKey"
 								name="licenseKey"
 								type="text"
-								bind:value={licenseKey}
+								bind:value={licenseKeyRaw}
 								placeholder="GQ-XXXX-XXXX-XXXX-XXXXX"
+								required
 								autocomplete="off"
 								class="w-full px-3 py-2 border border-[var(--input-border)] rounded-[var(--input-radius)] text-sm uppercase font-mono tracking-wider
 									focus:border-[var(--input-border-focus)] focus:outline-none focus:ring-2 focus:ring-opacity-30 transition-colors"
 							/>
 						{/snippet}
 					</FormField>
+					<button
+						type="button"
+						class="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-link)] underline cursor-pointer bg-transparent border-none p-0 -mt-3"
+						onclick={() => { showLicenseKey = false; licenseKeyRaw = ''; }}
+					>
+						ライセンスキーなしで続ける
+					</button>
 				{:else}
 					<input type="hidden" name="licenseKey" value="" />
 				{/if}
@@ -301,13 +329,15 @@ $effect(() => {
 
 				<Button
 					type="submit"
-					disabled={loading || !email || !password || !passwordConfirm || !agreedTerms || !agreedPrivacy}
+					disabled={loading || !email || !password || !passwordConfirm || !agreedTerms || !agreedPrivacy || (showLicenseKey && (!licenseKey || !licenseKeyValid))}
 					size="md"
 					class="w-full"
 				>
 					{#if loading}
 						<span class="inline-block w-4 h-4 border-2 border-current border-r-transparent rounded-full animate-spin" aria-hidden="true"></span>
 						登録中...
+					{:else if showLicenseKey}
+						ライセンスキーで登録
 					{:else if planParam}
 						7日間 無料体験をはじめる
 					{:else}

--- a/src/routes/auth/signup/+page.svelte
+++ b/src/routes/auth/signup/+page.svelte
@@ -280,13 +280,15 @@ $effect(() => {
 							/>
 						{/snippet}
 					</FormField>
-					<button
+					<Button
 						type="button"
-						class="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-link)] underline cursor-pointer bg-transparent border-none p-0 -mt-3"
+						variant="ghost"
+						size="sm"
+						class="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-link)] underline -mt-3 !p-0"
 						onclick={() => { showLicenseKey = false; licenseKeyRaw = ''; }}
 					>
 						ライセンスキーなしで続ける
-					</button>
+					</Button>
 				{:else}
 					<input type="hidden" name="licenseKey" value="" />
 				{/if}
@@ -355,13 +357,15 @@ $effect(() => {
 			<!-- ライセンスキー / プランの切り替えリンク -->
 			<div class="mt-3 text-center">
 				{#if !showLicenseKey}
-					<button
+					<Button
 						type="button"
-						class="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-link)] underline cursor-pointer bg-transparent border-none p-0"
+						variant="ghost"
+						size="sm"
+						class="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-link)] underline !p-0"
 						onclick={() => { showLicenseKey = true; }}
 					>
 						ライセンスキーをお持ちの方
-					</button>
+					</Button>
 				{/if}
 			</div>
 		{/if}

--- a/tests/unit/domain/auth-validation.test.ts
+++ b/tests/unit/domain/auth-validation.test.ts
@@ -7,6 +7,7 @@ import {
 	pinSchema,
 	SESSION_COOKIE_NAME,
 	SESSION_MAX_AGE_SECONDS,
+	signupSchema,
 } from '../../../src/lib/domain/validation/auth';
 
 describe('pinSchema', () => {
@@ -67,6 +68,45 @@ describe('loginSchema', () => {
 
 	it('不正なpin値のオブジェクトを拒否する', () => {
 		const result = loginSchema.safeParse({ pin: '12' });
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('signupSchema — licenseKey', () => {
+	const base = { email: 'test@example.com', password: 'Password1' };
+
+	it('空文字のライセンスキーを受け入れる', () => {
+		const result = signupSchema.safeParse({ ...base, licenseKey: '' });
+		expect(result.success).toBe(true);
+	});
+
+	it('旧形式（3グループ）のライセンスキーを受け入れる', () => {
+		const result = signupSchema.safeParse({ ...base, licenseKey: 'GQ-ABCD-EFGH-JKLM' });
+		expect(result.success).toBe(true);
+	});
+
+	it('署名付き形式（4グループ）のライセンスキーを受け入れる', () => {
+		const result = signupSchema.safeParse({ ...base, licenseKey: 'GQ-ABCD-EFGH-JKLM-NPRST' });
+		expect(result.success).toBe(true);
+	});
+
+	it('不正なプレフィックスを拒否する', () => {
+		const result = signupSchema.safeParse({ ...base, licenseKey: 'XX-ABCD-EFGH-JKLM' });
+		expect(result.success).toBe(false);
+	});
+
+	it('セグメント不足を拒否する', () => {
+		const result = signupSchema.safeParse({ ...base, licenseKey: 'GQ-ABCD-EFGH' });
+		expect(result.success).toBe(false);
+	});
+
+	it('チェックサム長が不正な場合を拒否する', () => {
+		const result = signupSchema.safeParse({ ...base, licenseKey: 'GQ-ABCD-EFGH-JKLM-NP' });
+		expect(result.success).toBe(false);
+	});
+
+	it('特殊文字を含むキーを拒否する', () => {
+		const result = signupSchema.safeParse({ ...base, licenseKey: 'GQ-AB!D-EFGH-JKLM' });
 		expect(result.success).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary
closes #590

- `signupSchema` を旧形式(`GQ-XXXX-XXXX-XXXX`)と署名付き形式(`GQ-XXXX-XXXX-XXXX-YYYYY`)の両方に対応
- ライセンスキー表示時はフィールド必須化＋リアルタイムフォーマットバリデーション
- ボタンラベルを「ライセンスキーで登録」に変更（`showLicenseKey` 時）
- 「ライセンスキーなしで続ける」キャンセルリンク追加
- 入力値の自動大文字変換（`$derived` で `toUpperCase`）
- `signupSchema` のライセンスキーバリデーションテスト7件追加

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `src/lib/domain/validation/auth.ts` | `LICENSE_KEY_LEGACY_FORMAT` / `LICENSE_KEY_SIGNED_FORMAT` 定数追加、`signupSchema.licenseKey` を `refine` に変更（空文字・旧形式・署名付き形式を受理） |
| `src/routes/auth/signup/+page.svelte` | `licenseKeyRaw` → `licenseKey`（derived uppercase）、フォーマットバリデーション、ボタンラベル分岐、キャンセルリンク、disabled条件更新 |
| `tests/unit/domain/auth-validation.test.ts` | `signupSchema` ライセンスキーバリデーション7テスト追加 |

## Test plan
- [x] `npx biome check .` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし（0 errors）
- [x] `npx vitest run` — 全2371テスト通過（新規7件含む）
- [x] `npx playwright test` — 315/316通過（1件は既存のvisual regressionスナップショット差分で本PR無関係）
- [ ] 通常サインアップでボタンラベルが「無料ではじめる」
- [ ] ライセンスキー欄表示時にボタンラベルが「ライセンスキーで登録」
- [ ] ライセンスキー未入力で送信ボタンが無効化
- [ ] 不正形式入力時にエラーメッセージ表示
- [ ] 「ライセンスキーなしで続ける」クリックで通常フォームに復帰
- [ ] 小文字入力が自動大文字変換される
- [ ] planParam付きで「7日間 無料体験をはじめる」表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)