### PR TITLE
fix: #614 auth/setup CSS ハードコード色をトークンに置換

### DIFF
--- a/src/routes/auth/forgot-password/+page.svelte
+++ b/src/routes/auth/forgot-password/+page.svelte
@@ -36,7 +36,7 @@ $effect(() => {
 		</div>
 
 		{#if form?.error}
-			<div class="mb-4 p-3 bg-red-50 text-red-600 border border-red-200 rounded-[var(--radius-sm)] text-sm" role="alert">
+			<div class="mb-4 p-3 bg-[var(--color-danger-50)] text-[var(--color-danger-600)] border border-[var(--color-danger-200)] rounded-[var(--radius-sm)] text-sm" role="alert">
 				{form.error}
 			</div>
 		{/if}

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -107,7 +107,7 @@ $effect(() => {
 		{/if}
 
 		{#if form?.error}
-			<div class="mb-4 p-3 bg-red-50 text-red-600 border border-red-200 rounded-[var(--radius-sm)] text-sm" role="alert">
+			<div class="mb-4 p-3 bg-[var(--color-danger-50)] text-[var(--color-danger-600)] border border-[var(--color-danger-200)] rounded-[var(--radius-sm)] text-sm" role="alert">
 				{form.error}
 			</div>
 		{/if}

--- a/src/routes/auth/signup/+page.svelte
+++ b/src/routes/auth/signup/+page.svelte
@@ -91,7 +91,7 @@ $effect(() => {
 		</div>
 
 		{#if form?.error}
-			<div class="mb-4 p-3 bg-red-50 text-red-600 border border-red-200 rounded-[var(--radius-sm)] text-sm" role="alert">
+			<div class="mb-4 p-3 bg-[var(--color-danger-50)] text-[var(--color-danger-600)] border border-[var(--color-danger-200)] rounded-[var(--radius-sm)] text-sm" role="alert">
 				{form.error}
 			</div>
 		{/if}

--- a/src/routes/setup/children/+page.svelte
+++ b/src/routes/setup/children/+page.svelte
@@ -19,8 +19,8 @@ const autoUiLabel = $derived(autoUiMode ? AGE_TIER_CONFIG[autoUiMode].label : ''
 	<title>子供登録 - がんばりクエスト セットアップ</title>
 </svelte:head>
 
-<h2 class="text-lg font-bold text-gray-700 mb-2">子供を登録しよう</h2>
-<p class="text-sm text-gray-500 mb-4">
+<h2 class="text-lg font-bold text-[var(--color-text)] mb-2">子供を登録しよう</h2>
+<p class="text-sm text-[var(--color-text-muted)] mb-4">
 	がんばりクエストを使う子供を登録してください（1人以上）。
 </p>
 
@@ -35,7 +35,7 @@ const autoUiLabel = $derived(autoUiMode ? AGE_TIER_CONFIG[autoUiMode].label : ''
 <!-- Registered children list -->
 {#if data.children.length > 0}
 	<div class="mb-4">
-		<h3 class="text-sm font-bold text-gray-600 mb-2">登録済み（{data.children.length}人）</h3>
+		<h3 class="text-sm font-bold text-[var(--color-text-secondary)] mb-2">登録済み（{data.children.length}人）</h3>
 		<div class="flex flex-col gap-2">
 			{#each data.children as child (child.id)}
 				<div class="flex items-center gap-3 p-3 bg-green-50 border border-green-200 rounded-lg">
@@ -47,8 +47,8 @@ const autoUiLabel = $derived(autoUiMode ? AGE_TIER_CONFIG[autoUiMode].label : ''
 						{/if}
 					</span>
 					<div>
-						<p class="font-bold text-sm text-gray-700">{child.nickname}</p>
-						<p class="text-xs text-gray-500">
+						<p class="font-bold text-sm text-[var(--color-text)]">{child.nickname}</p>
+						<p class="text-xs text-[var(--color-text-muted)]">
 							{child.age}歳 / {getAgeTierLabel(child.uiMode)}モード
 						</p>
 					</div>
@@ -76,7 +76,7 @@ const autoUiLabel = $derived(autoUiMode ? AGE_TIER_CONFIG[autoUiMode].label : ''
 	}}
 	class="flex flex-col gap-3 mb-4 p-4 bg-gray-50 rounded-lg border border-gray-200"
 >
-	<h3 class="text-sm font-bold text-gray-600">子供を追加</h3>
+	<h3 class="text-sm font-bold text-[var(--color-text-secondary)]">子供を追加</h3>
 
 	<FormField
 		label="ニックネーム"
@@ -97,20 +97,20 @@ const autoUiLabel = $derived(autoUiMode ? AGE_TIER_CONFIG[autoUiMode].label : ''
 	/>
 
 	<div>
-		<label for="theme" class="block text-sm font-medium text-gray-600 mb-1">テーマカラー</label>
+		<label for="theme" class="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">テーマカラー</label>
 		<div class="grid grid-cols-2 gap-2">
 			<label class="theme-option">
 				<input type="radio" name="theme" value="pink" checked class="sr-only peer" />
 				<div class="theme-card peer-checked:border-pink-400 peer-checked:bg-pink-50">
 					<span class="text-2xl">👧</span>
-					<span class="text-sm font-medium text-gray-700">ピンク</span>
+					<span class="text-sm font-medium text-[var(--color-text)]">ピンク</span>
 				</div>
 			</label>
 			<label class="theme-option">
 				<input type="radio" name="theme" value="blue" class="sr-only peer" />
 				<div class="theme-card peer-checked:border-blue-400 peer-checked:bg-blue-50">
 					<span class="text-2xl">👦</span>
-					<span class="text-sm font-medium text-gray-700">ブルー</span>
+					<span class="text-sm font-medium text-[var(--color-text)]">ブルー</span>
 				</div>
 			</label>
 		</div>

--- a/src/routes/setup/complete/+page.svelte
+++ b/src/routes/setup/complete/+page.svelte
@@ -14,8 +14,8 @@ const childHomeUrl = $derived(firstChild ? `/${firstChild.uiMode}/home` : '/swit
 
 <div class="text-center complete-screen">
 	<div class="text-4xl mb-2">⚔️</div>
-	<h2 class="text-xl font-bold text-gray-700 mb-1">ぼうけんのはじまり！</h2>
-	<p class="text-sm text-gray-500 mb-4">
+	<h2 class="text-xl font-bold text-[var(--color-text)] mb-1">ぼうけんのはじまり！</h2>
+	<p class="text-sm text-[var(--color-text-muted)] mb-4">
 		{formatChildName(firstChild?.nickname, 'possessive')}ぼうけんじゅんびが<br />かんりょうしたよ！
 	</p>
 

--- a/src/routes/setup/first-adventure/+page.svelte
+++ b/src/routes/setup/first-adventure/+page.svelte
@@ -51,11 +51,11 @@ function goToComplete() {
 			<span class="celebration-emoji text-[4rem] inline-block">🎉</span>
 		</div>
 
-		<h2 class="text-xl font-bold text-gray-700 mt-4 mb-2">
+		<h2 class="text-xl font-bold text-[var(--color-text)] mt-4 mb-2">
 			{formatChildName(child?.nickname, 'vocative')}すごい！
 		</h2>
 
-		<p class="text-sm text-gray-500 mb-4">
+		<p class="text-sm text-[var(--color-text-muted)] mb-4">
 			「{resultName}」をきろくしたよ！
 		</p>
 
@@ -83,8 +83,8 @@ function goToComplete() {
 	<!-- 活動選択画面 -->
 	<div class="text-center mb-4">
 		<div class="text-3xl mb-2">⚔️</div>
-		<h2 class="text-lg font-bold text-gray-700">はじめてのぼうけん！</h2>
-		<p class="text-sm text-gray-500 mt-1">
+		<h2 class="text-lg font-bold text-[var(--color-text)]">はじめてのぼうけん！</h2>
+		<p class="text-sm text-[var(--color-text-muted)] mt-1">
 			{formatChildName(child?.nickname, 'vocative')}さいしょのがんばりを<br />いっしょにきろくしよう！
 		</p>
 	</div>
@@ -92,7 +92,7 @@ function goToComplete() {
 	{#if data.activities.length === 0}
 		<!-- 活動未登録の場合はスキップ -->
 		<div class="text-center">
-			<p class="text-sm text-gray-400 mb-4">
+			<p class="text-sm text-[var(--color-neutral-400)] mb-4">
 				まだ活動が登録されていません。あとから管理画面で追加できます。
 			</p>
 			<form method="POST" action="?/skip">
@@ -145,7 +145,7 @@ function goToComplete() {
 					{/if}
 				</Button>
 			{:else}
-				<p class="text-xs text-gray-400 text-center mt-4">
+				<p class="text-xs text-[var(--color-neutral-400)] text-center mt-4">
 					がんばりをえらんでね！
 				</p>
 			{/if}


### PR DESCRIPTION
## Summary

- auth/login, signup, forgot-password: `bg-red-50 text-red-600 border-red-200` → `var(--color-danger-*)` トークン
- setup/children, complete, first-adventure: `text-gray-*` → `var(--color-text/text-muted/text-secondary/neutral-400)` トークン
- 計6ファイル・20箇所を修正

## Test plan

- [ ] CI全通過
- [ ] login/signup/forgot-password/setup各画面の表示が視覚的に同等

closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)