### PR TITLE
fix: #632 チャレンジ自動生成の接続 — achievements ページ実装

### DIFF
--- a/src/routes/(child)/baby/(character)/achievements/+page.server.ts
+++ b/src/routes/(child)/baby/(character)/achievements/+page.server.ts
@@ -1,5 +1,19 @@
+import { requireTenantId } from '$lib/server/auth/factory';
+import {
+	getChallengeHistory,
+	getOrCreateWeeklyChallenge,
+} from '$lib/server/services/auto-challenge-service';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
-	return { challenges: [] };
+export const load: PageServerLoad = async ({ locals, parent }) => {
+	const tenantId = requireTenantId(locals);
+	const { child } = await parent();
+	if (!child) return { activeChallenge: null, history: [] };
+
+	const [activeChallenge, history] = await Promise.all([
+		getOrCreateWeeklyChallenge(child.id, tenantId),
+		getChallengeHistory(child.id, tenantId, 10),
+	]);
+
+	return { activeChallenge, history };
 };

--- a/src/routes/(child)/baby/(character)/achievements/+page.svelte
+++ b/src/routes/(child)/baby/(character)/achievements/+page.svelte
@@ -1,9 +1,74 @@
+<script lang="ts">
+import Card from '$lib/ui/primitives/Card.svelte';
+
+let { data } = $props();
+
+const active = $derived(data.activeChallenge);
+const history = $derived(data.history ?? []);
+</script>
+
 <svelte:head>
 	<title>チャレンジきろく - がんばりクエスト</title>
 </svelte:head>
 
-<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
-	<span class="text-5xl mb-4">📋</span>
-	<p class="text-lg font-bold mb-2">まだチャレンジきろくがないよ</p>
-	<p class="text-sm">チャレンジがはじまったら ここにきろくされるよ</p>
+<div class="px-[var(--sp-sm)] py-[var(--sp-md)]">
+	{#if active}
+		<Card padding="md" class="mb-[var(--sp-md)]">
+			{#snippet children()}
+			<div class="flex items-center gap-2 mb-[var(--sp-sm)]">
+				<span class="text-2xl">⚔️</span>
+				<h2 class="text-base font-bold text-[var(--color-text)]">こんしゅうの チャレンジ</h2>
+			</div>
+			<p class="text-sm text-[var(--color-text-secondary)] mb-[var(--sp-sm)]">{active.description}</p>
+			<div class="flex items-center gap-2">
+				<div class="flex-1 h-3 bg-[var(--color-neutral-200)] rounded-full overflow-hidden">
+					<div
+						class="h-full rounded-full transition-all duration-500"
+						class:bg-[var(--color-brand-500)]={active.status !== 'completed'}
+						class:bg-[var(--color-success-500)]={active.status === 'completed'}
+						style:width="{active.progressPercent}%"
+					></div>
+				</div>
+				<span class="text-sm font-bold text-[var(--color-text)]">{active.currentCount}/{active.targetCount}</span>
+			</div>
+			{#if active.status === 'completed'}
+				<p class="text-sm font-bold text-[var(--color-success-600)] mt-[var(--sp-sm)] text-center">クリア！ おめでとう！</p>
+			{/if}
+			{/snippet}
+		</Card>
+	{/if}
+
+	{#if history.length > 0}
+		<h3 class="text-sm font-bold text-[var(--color-text-muted)] mb-[var(--sp-sm)]">いままでの チャレンジ</h3>
+		<div class="flex flex-col gap-[var(--sp-xs)]">
+			{#each history as challenge (challenge.id)}
+				<Card padding="sm">
+					{#snippet children()}
+					<div class="flex items-center justify-between">
+						<div>
+							<p class="text-sm font-bold text-[var(--color-text)]">{challenge.categoryName}</p>
+							<p class="text-xs text-[var(--color-text-muted)]">{challenge.weekStart}〜</p>
+						</div>
+						<div class="text-right">
+							<span class="text-sm font-bold">{challenge.currentCount}/{challenge.targetCount}</span>
+							{#if challenge.status === 'completed'}
+								<p class="text-xs font-bold text-[var(--color-success-600)]">クリア！</p>
+							{:else if challenge.status === 'expired'}
+								<p class="text-xs text-[var(--color-text-muted)]">おわり</p>
+							{:else}
+								<p class="text-xs text-[var(--color-brand-500)]">チャレンジちゅう</p>
+							{/if}
+						</div>
+					</div>
+					{/snippet}
+				</Card>
+			{/each}
+		</div>
+	{:else if !active}
+		<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
+			<span class="text-5xl mb-4">📋</span>
+			<p class="text-lg font-bold mb-2">まだ チャレンジきろくが ないよ</p>
+			<p class="text-sm">チャレンジが はじまったら ここに きろくされるよ</p>
+		</div>
+	{/if}
 </div>

--- a/src/routes/(child)/elementary/(character)/achievements/+page.server.ts
+++ b/src/routes/(child)/elementary/(character)/achievements/+page.server.ts
@@ -1,5 +1,19 @@
+import { requireTenantId } from '$lib/server/auth/factory';
+import {
+	getChallengeHistory,
+	getOrCreateWeeklyChallenge,
+} from '$lib/server/services/auto-challenge-service';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
-	return { challenges: [] };
+export const load: PageServerLoad = async ({ locals, parent }) => {
+	const tenantId = requireTenantId(locals);
+	const { child } = await parent();
+	if (!child) return { activeChallenge: null, history: [] };
+
+	const [activeChallenge, history] = await Promise.all([
+		getOrCreateWeeklyChallenge(child.id, tenantId),
+		getChallengeHistory(child.id, tenantId, 10),
+	]);
+
+	return { activeChallenge, history };
 };

--- a/src/routes/(child)/elementary/(character)/achievements/+page.svelte
+++ b/src/routes/(child)/elementary/(character)/achievements/+page.svelte
@@ -1,9 +1,74 @@
+<script lang="ts">
+import Card from '$lib/ui/primitives/Card.svelte';
+
+let { data } = $props();
+
+const active = $derived(data.activeChallenge);
+const history = $derived(data.history ?? []);
+</script>
+
 <svelte:head>
 	<title>チャレンジきろく - がんばりクエスト</title>
 </svelte:head>
 
-<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
-	<span class="text-5xl mb-4">📋</span>
-	<p class="text-lg font-bold mb-2">まだチャレンジきろくがないよ</p>
-	<p class="text-sm">チャレンジが始まったらここに記録されるよ</p>
+<div class="px-[var(--sp-sm)] py-[var(--sp-md)]">
+	{#if active}
+		<Card padding="md" class="mb-[var(--sp-md)]">
+			{#snippet children()}
+			<div class="flex items-center gap-2 mb-[var(--sp-sm)]">
+				<span class="text-2xl">⚔️</span>
+				<h2 class="text-base font-bold text-[var(--color-text)]">今週のチャレンジ</h2>
+			</div>
+			<p class="text-sm text-[var(--color-text-secondary)] mb-[var(--sp-sm)]">{active.description}</p>
+			<div class="flex items-center gap-2">
+				<div class="flex-1 h-3 bg-[var(--color-neutral-200)] rounded-full overflow-hidden">
+					<div
+						class="h-full rounded-full transition-all duration-500"
+						class:bg-[var(--color-brand-500)]={active.status !== 'completed'}
+						class:bg-[var(--color-success-500)]={active.status === 'completed'}
+						style:width="{active.progressPercent}%"
+					></div>
+				</div>
+				<span class="text-sm font-bold text-[var(--color-text)]">{active.currentCount}/{active.targetCount}</span>
+			</div>
+			{#if active.status === 'completed'}
+				<p class="text-sm font-bold text-[var(--color-success-600)] mt-[var(--sp-sm)] text-center">クリア！おめでとう！</p>
+			{/if}
+			{/snippet}
+		</Card>
+	{/if}
+
+	{#if history.length > 0}
+		<h3 class="text-sm font-bold text-[var(--color-text-muted)] mb-[var(--sp-sm)]">これまでのチャレンジ</h3>
+		<div class="flex flex-col gap-[var(--sp-xs)]">
+			{#each history as challenge (challenge.id)}
+				<Card padding="sm">
+					{#snippet children()}
+					<div class="flex items-center justify-between">
+						<div>
+							<p class="text-sm font-bold text-[var(--color-text)]">{challenge.categoryName}</p>
+							<p class="text-xs text-[var(--color-text-muted)]">{challenge.weekStart}〜</p>
+						</div>
+						<div class="text-right">
+							<span class="text-sm font-bold">{challenge.currentCount}/{challenge.targetCount}</span>
+							{#if challenge.status === 'completed'}
+								<p class="text-xs font-bold text-[var(--color-success-600)]">クリア！</p>
+							{:else if challenge.status === 'expired'}
+								<p class="text-xs text-[var(--color-text-muted)]">しゅうりょう</p>
+							{:else}
+								<p class="text-xs text-[var(--color-brand-500)]">ちゃれんじ中</p>
+							{/if}
+						</div>
+					</div>
+					{/snippet}
+				</Card>
+			{/each}
+		</div>
+	{:else if !active}
+		<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
+			<span class="text-5xl mb-4">📋</span>
+			<p class="text-lg font-bold mb-2">まだチャレンジきろくがないよ</p>
+			<p class="text-sm">チャレンジが始まったらここに記録されるよ</p>
+		</div>
+	{/if}
 </div>

--- a/src/routes/(child)/junior/(character)/achievements/+page.server.ts
+++ b/src/routes/(child)/junior/(character)/achievements/+page.server.ts
@@ -1,5 +1,19 @@
+import { requireTenantId } from '$lib/server/auth/factory';
+import {
+	getChallengeHistory,
+	getOrCreateWeeklyChallenge,
+} from '$lib/server/services/auto-challenge-service';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
-	return { challenges: [] };
+export const load: PageServerLoad = async ({ locals, parent }) => {
+	const tenantId = requireTenantId(locals);
+	const { child } = await parent();
+	if (!child) return { activeChallenge: null, history: [] };
+
+	const [activeChallenge, history] = await Promise.all([
+		getOrCreateWeeklyChallenge(child.id, tenantId),
+		getChallengeHistory(child.id, tenantId, 10),
+	]);
+
+	return { activeChallenge, history };
 };

--- a/src/routes/(child)/junior/(character)/achievements/+page.svelte
+++ b/src/routes/(child)/junior/(character)/achievements/+page.svelte
@@ -1,9 +1,74 @@
+<script lang="ts">
+import Card from '$lib/ui/primitives/Card.svelte';
+
+let { data } = $props();
+
+const active = $derived(data.activeChallenge);
+const history = $derived(data.history ?? []);
+</script>
+
 <svelte:head>
-	<title>チャレンジきろく - がんばりクエスト</title>
+	<title>チャレンジ記録 - がんばりクエスト</title>
 </svelte:head>
 
-<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
-	<span class="text-5xl mb-4">📋</span>
-	<p class="text-lg font-bold mb-2">まだチャレンジ記録がありません</p>
-	<p class="text-sm">チャレンジが始まったらここに記録されます</p>
+<div class="px-[var(--sp-sm)] py-[var(--sp-md)]">
+	{#if active}
+		<Card padding="md" class="mb-[var(--sp-md)]">
+			{#snippet children()}
+			<div class="flex items-center gap-2 mb-[var(--sp-sm)]">
+				<span class="text-2xl">⚔️</span>
+				<h2 class="text-base font-bold text-[var(--color-text)]">今週のチャレンジ</h2>
+			</div>
+			<p class="text-sm text-[var(--color-text-secondary)] mb-[var(--sp-sm)]">{active.description}</p>
+			<div class="flex items-center gap-2">
+				<div class="flex-1 h-3 bg-[var(--color-neutral-200)] rounded-full overflow-hidden">
+					<div
+						class="h-full rounded-full transition-all duration-500"
+						class:bg-[var(--color-brand-500)]={active.status !== 'completed'}
+						class:bg-[var(--color-success-500)]={active.status === 'completed'}
+						style:width="{active.progressPercent}%"
+					></div>
+				</div>
+				<span class="text-sm font-bold text-[var(--color-text)]">{active.currentCount}/{active.targetCount}</span>
+			</div>
+			{#if active.status === 'completed'}
+				<p class="text-sm font-bold text-[var(--color-success-600)] mt-[var(--sp-sm)] text-center">クリア！おめでとう！</p>
+			{/if}
+			{/snippet}
+		</Card>
+	{/if}
+
+	{#if history.length > 0}
+		<h3 class="text-sm font-bold text-[var(--color-text-muted)] mb-[var(--sp-sm)]">これまでのチャレンジ</h3>
+		<div class="flex flex-col gap-[var(--sp-xs)]">
+			{#each history as challenge (challenge.id)}
+				<Card padding="sm">
+					{#snippet children()}
+					<div class="flex items-center justify-between">
+						<div>
+							<p class="text-sm font-bold text-[var(--color-text)]">{challenge.categoryName}</p>
+							<p class="text-xs text-[var(--color-text-muted)]">{challenge.weekStart}〜</p>
+						</div>
+						<div class="text-right">
+							<span class="text-sm font-bold">{challenge.currentCount}/{challenge.targetCount}</span>
+							{#if challenge.status === 'completed'}
+								<p class="text-xs font-bold text-[var(--color-success-600)]">クリア！</p>
+							{:else if challenge.status === 'expired'}
+								<p class="text-xs text-[var(--color-text-muted)]">終了</p>
+							{:else}
+								<p class="text-xs text-[var(--color-brand-500)]">チャレンジ中</p>
+							{/if}
+						</div>
+					</div>
+					{/snippet}
+				</Card>
+			{/each}
+		</div>
+	{:else if !active}
+		<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
+			<span class="text-5xl mb-4">📋</span>
+			<p class="text-lg font-bold mb-2">まだチャレンジ記録がありません</p>
+			<p class="text-sm">チャレンジが始まったらここに記録されます</p>
+		</div>
+	{/if}
 </div>

--- a/src/routes/(child)/preschool/(character)/achievements/+page.server.ts
+++ b/src/routes/(child)/preschool/(character)/achievements/+page.server.ts
@@ -1,5 +1,19 @@
+import { requireTenantId } from '$lib/server/auth/factory';
+import {
+	getChallengeHistory,
+	getOrCreateWeeklyChallenge,
+} from '$lib/server/services/auto-challenge-service';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
-	return { challenges: [] };
+export const load: PageServerLoad = async ({ locals, parent }) => {
+	const tenantId = requireTenantId(locals);
+	const { child } = await parent();
+	if (!child) return { activeChallenge: null, history: [] };
+
+	const [activeChallenge, history] = await Promise.all([
+		getOrCreateWeeklyChallenge(child.id, tenantId),
+		getChallengeHistory(child.id, tenantId, 10),
+	]);
+
+	return { activeChallenge, history };
 };

--- a/src/routes/(child)/preschool/(character)/achievements/+page.svelte
+++ b/src/routes/(child)/preschool/(character)/achievements/+page.svelte
@@ -1,9 +1,74 @@
+<script lang="ts">
+import Card from '$lib/ui/primitives/Card.svelte';
+
+let { data } = $props();
+
+const active = $derived(data.activeChallenge);
+const history = $derived(data.history ?? []);
+</script>
+
 <svelte:head>
 	<title>チャレンジきろく - がんばりクエスト</title>
 </svelte:head>
 
-<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
-	<span class="text-5xl mb-4">📋</span>
-	<p class="text-lg font-bold mb-2">まだチャレンジきろくがないよ</p>
-	<p class="text-sm">チャレンジがはじまったら ここにきろくされるよ</p>
+<div class="px-[var(--sp-sm)] py-[var(--sp-md)]">
+	{#if active}
+		<Card padding="md" class="mb-[var(--sp-md)]">
+			{#snippet children()}
+			<div class="flex items-center gap-2 mb-[var(--sp-sm)]">
+				<span class="text-2xl">⚔️</span>
+				<h2 class="text-base font-bold text-[var(--color-text)]">こんしゅうの チャレンジ</h2>
+			</div>
+			<p class="text-sm text-[var(--color-text-secondary)] mb-[var(--sp-sm)]">{active.description}</p>
+			<div class="flex items-center gap-2">
+				<div class="flex-1 h-3 bg-[var(--color-neutral-200)] rounded-full overflow-hidden">
+					<div
+						class="h-full rounded-full transition-all duration-500"
+						class:bg-[var(--color-brand-500)]={active.status !== 'completed'}
+						class:bg-[var(--color-success-500)]={active.status === 'completed'}
+						style:width="{active.progressPercent}%"
+					></div>
+				</div>
+				<span class="text-sm font-bold text-[var(--color-text)]">{active.currentCount}/{active.targetCount}</span>
+			</div>
+			{#if active.status === 'completed'}
+				<p class="text-sm font-bold text-[var(--color-success-600)] mt-[var(--sp-sm)] text-center">クリア！ おめでとう！</p>
+			{/if}
+			{/snippet}
+		</Card>
+	{/if}
+
+	{#if history.length > 0}
+		<h3 class="text-sm font-bold text-[var(--color-text-muted)] mb-[var(--sp-sm)]">いままでの チャレンジ</h3>
+		<div class="flex flex-col gap-[var(--sp-xs)]">
+			{#each history as challenge (challenge.id)}
+				<Card padding="sm">
+					{#snippet children()}
+					<div class="flex items-center justify-between">
+						<div>
+							<p class="text-sm font-bold text-[var(--color-text)]">{challenge.categoryName}</p>
+							<p class="text-xs text-[var(--color-text-muted)]">{challenge.weekStart}〜</p>
+						</div>
+						<div class="text-right">
+							<span class="text-sm font-bold">{challenge.currentCount}/{challenge.targetCount}</span>
+							{#if challenge.status === 'completed'}
+								<p class="text-xs font-bold text-[var(--color-success-600)]">クリア！</p>
+							{:else if challenge.status === 'expired'}
+								<p class="text-xs text-[var(--color-text-muted)]">おわり</p>
+							{:else}
+								<p class="text-xs text-[var(--color-brand-500)]">チャレンジちゅう</p>
+							{/if}
+						</div>
+					</div>
+					{/snippet}
+				</Card>
+			{/each}
+		</div>
+	{:else if !active}
+		<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
+			<span class="text-5xl mb-4">📋</span>
+			<p class="text-lg font-bold mb-2">まだ チャレンジきろくが ないよ</p>
+			<p class="text-sm">チャレンジが はじまったら ここに きろくされるよ</p>
+		</div>
+	{/if}
 </div>

--- a/src/routes/(child)/senior/(character)/achievements/+page.server.ts
+++ b/src/routes/(child)/senior/(character)/achievements/+page.server.ts
@@ -1,5 +1,19 @@
+import { requireTenantId } from '$lib/server/auth/factory';
+import {
+	getChallengeHistory,
+	getOrCreateWeeklyChallenge,
+} from '$lib/server/services/auto-challenge-service';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
-	return { challenges: [] };
+export const load: PageServerLoad = async ({ locals, parent }) => {
+	const tenantId = requireTenantId(locals);
+	const { child } = await parent();
+	if (!child) return { activeChallenge: null, history: [] };
+
+	const [activeChallenge, history] = await Promise.all([
+		getOrCreateWeeklyChallenge(child.id, tenantId),
+		getChallengeHistory(child.id, tenantId, 10),
+	]);
+
+	return { activeChallenge, history };
 };

--- a/src/routes/(child)/senior/(character)/achievements/+page.svelte
+++ b/src/routes/(child)/senior/(character)/achievements/+page.svelte
@@ -1,9 +1,74 @@
+<script lang="ts">
+import Card from '$lib/ui/primitives/Card.svelte';
+
+let { data } = $props();
+
+const active = $derived(data.activeChallenge);
+const history = $derived(data.history ?? []);
+</script>
+
 <svelte:head>
 	<title>チャレンジ記録 - がんばりクエスト</title>
 </svelte:head>
 
-<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
-	<span class="text-5xl mb-4">📋</span>
-	<p class="text-lg font-bold mb-2">チャレンジ記録はまだありません</p>
-	<p class="text-sm">チャレンジが始まるとここに記録されます</p>
+<div class="px-[var(--sp-sm)] py-[var(--sp-md)]">
+	{#if active}
+		<Card padding="md" class="mb-[var(--sp-md)]">
+			{#snippet children()}
+			<div class="flex items-center gap-2 mb-[var(--sp-sm)]">
+				<span class="text-2xl">⚔️</span>
+				<h2 class="text-base font-bold text-[var(--color-text)]">今週のチャレンジ</h2>
+			</div>
+			<p class="text-sm text-[var(--color-text-secondary)] mb-[var(--sp-sm)]">{active.description}</p>
+			<div class="flex items-center gap-2">
+				<div class="flex-1 h-3 bg-[var(--color-neutral-200)] rounded-full overflow-hidden">
+					<div
+						class="h-full rounded-full transition-all duration-500"
+						class:bg-[var(--color-brand-500)]={active.status !== 'completed'}
+						class:bg-[var(--color-success-500)]={active.status === 'completed'}
+						style:width="{active.progressPercent}%"
+					></div>
+				</div>
+				<span class="text-sm font-bold text-[var(--color-text)]">{active.currentCount}/{active.targetCount}</span>
+			</div>
+			{#if active.status === 'completed'}
+				<p class="text-sm font-bold text-[var(--color-success-600)] mt-[var(--sp-sm)] text-center">クリア！おめでとう！</p>
+			{/if}
+			{/snippet}
+		</Card>
+	{/if}
+
+	{#if history.length > 0}
+		<h3 class="text-sm font-bold text-[var(--color-text-muted)] mb-[var(--sp-sm)]">これまでのチャレンジ</h3>
+		<div class="flex flex-col gap-[var(--sp-xs)]">
+			{#each history as challenge (challenge.id)}
+				<Card padding="sm">
+					{#snippet children()}
+					<div class="flex items-center justify-between">
+						<div>
+							<p class="text-sm font-bold text-[var(--color-text)]">{challenge.categoryName}</p>
+							<p class="text-xs text-[var(--color-text-muted)]">{challenge.weekStart}〜</p>
+						</div>
+						<div class="text-right">
+							<span class="text-sm font-bold">{challenge.currentCount}/{challenge.targetCount}</span>
+							{#if challenge.status === 'completed'}
+								<p class="text-xs font-bold text-[var(--color-success-600)]">クリア！</p>
+							{:else if challenge.status === 'expired'}
+								<p class="text-xs text-[var(--color-text-muted)]">終了</p>
+							{:else}
+								<p class="text-xs text-[var(--color-brand-500)]">チャレンジ中</p>
+							{/if}
+						</div>
+					</div>
+					{/snippet}
+				</Card>
+			{/each}
+		</div>
+	{:else if !active}
+		<div class="flex flex-col items-center justify-center py-16 text-[var(--color-text-muted)]">
+			<span class="text-5xl mb-4">📋</span>
+			<p class="text-lg font-bold mb-2">チャレンジ記録はまだありません</p>
+			<p class="text-sm">チャレンジが始まるとここに記録されます</p>
+		</div>
+	{/if}
 </div>


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供

**解決する課題**: チャレンジ機能が実装されているがUIから一度も呼び出されておらず、チャレンジタブが常に空の状態

**期待される効果**: 毎週自動で苦手カテゴリのチャレンジが生成され、子供の活動バランス改善を促進

## 関連 Issue

closes #632

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`)
- [x] ページ / レイアウト (`src/routes/`)

**影響を受ける画面・機能**: チャレンジきろくページ（全5年齢モード）

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| page.server.ts | `{ challenges: [] }` ハードコード | `getOrCreateWeeklyChallenge` + `getChallengeHistory` 呼び出し |
| page.svelte | 空状態メッセージのみ | アクティブチャレンジ（進捗バー）+ 履歴リスト表示 |

## テスト戦略

**単体テスト**: 既存 auto-challenge-service.test.ts が全通過（2364テスト全通過）
**E2Eテスト**: 既存テスト全通過

**網羅性の判断根拠**: auto-challenge-service のロジック自体は既にテスト済み。今回はUI接続のみ。

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

## 横展開・影響波及チェック

- [x] **全年齢モード** — 5モード全てに横展開済み（baby/preschool=ひらがな、elementary/junior/senior=漢字）

## 完了チェックリスト

- [x] `npx biome check .` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし
- [x] `npx vitest run` — ユニットテスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)