### PR TITLE
design: #584 リンク色コントラスト強化 + text-wrap balance

### DIFF
--- a/site/shared.css
+++ b/site/shared.css
@@ -65,6 +65,9 @@ a {
 a:hover {
 	text-decoration: underline;
 }
+h1, h2, h3, h4 {
+	text-wrap: balance;
+}
 img {
 	max-width: 100%;
 	height: auto;

--- a/src/lib/ui/styles/app.css
+++ b/src/lib/ui/styles/app.css
@@ -270,7 +270,7 @@
 	/* ---- Text (Base層の補完) ---- */
 	--color-text-inverse: white;
 	--color-text-accent: var(--theme-accent);
-	--color-text-link: var(--color-brand-600);
+	--color-text-link: var(--color-brand-700);
 	--color-text-primary: var(--color-neutral-700);
 	--color-text-secondary: var(--color-neutral-600);
 	--color-text-tertiary: var(--color-neutral-400);
@@ -616,6 +616,11 @@ html {
 body {
 	margin: 0;
 	min-height: 100dvh;
+}
+
+/* Heading text-wrap: balance for natural Japanese line breaks (#584) */
+h1, h2, h3, h4 {
+	text-wrap: balance;
 }
 
 /* ============================================================


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供 / 親（管理者）

**解決する課題**: リンク色と本文色のコントラストが弱く、リンク発見性・アクセシビリティが不十分

**期待される効果**: WCAG AA準拠のリンク色コントラスト + 見出しの自然な改行で読みやすさ向上

## 関連 Issue

closes #584

## 変更タイプ

- [x] design: デザイン・UI改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] LP サイト (`site/`)

**影響を受ける画面・機能**: アプリ全体のリンク色、全画面の見出し改行

## 変更内容

### リンク色コントラスト強化
| 指標 | Before (brand-600) | After (brand-700) |
|------|---------------------|---------------------|
| Hex | #4a90d9 | #3878b8 |
| vs 背景 (#fffdf7) | 3.29:1 | **4.54:1** |
| WCAG AA (4.5:1) | 不合格 | **合格** |

### text-wrap: balance
- アプリ: `src/lib/ui/styles/app.css` の h1-h4 に追加
- LP: `site/shared.css` の h1-h4 に追加
- BudouX は導入せず、CSS ネイティブの `text-wrap: balance` で対応

## テスト戦略

- [x] `npx svelte-check` — 型エラーなし
- CSSトークン変更のみ、ロジック変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

🤖 Generated with [Claude Code](https://claude.com/claude-code)