### PR TITLE
fix: #593 規約バージョン不整合を修正

### DIFF
--- a/site/privacy.html
+++ b/site/privacy.html
@@ -43,7 +43,7 @@ body{line-height:1.8;background:var(--gray-50)}
 <main class="main">
 <article class="doc">
   <h1>プライバシーポリシー</h1>
-  <p class="meta">最終更新日: 2026年4月4日</p>
+  <p class="meta">最終更新日: 2026年4月9日</p>
 
   <p class="intro">
     がんばりクエスト運営者（以下「運営者」）は、Webアプリケーション「がんばりクエスト」（以下「本サービス」）における利用者の個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下「本ポリシー」）を定めます。本サービスは家庭内でお子さまが利用することを想定しており、お子さまの個人情報の保護には特に配慮しています。
@@ -181,6 +181,7 @@ body{line-height:1.8;background:var(--gray-50)}
   <div class="effective">
     <p>以上</p>
     <p>制定日: 2026年3月27日</p>
+    <p>最終改定日: 2026年4月9日</p>
   </div>
 </article>
 </main>

--- a/site/terms.html
+++ b/site/terms.html
@@ -37,7 +37,7 @@ body{line-height:1.8;background:var(--gray-50)}
 <main class="main">
 <article class="doc">
   <h1>利用規約</h1>
-  <p class="meta">最終更新日: 2026年3月27日</p>
+  <p class="meta">最終更新日: 2026年3月29日</p>
 
   <p class="intro">
     本利用規約（以下「本規約」）は、がんばりクエスト運営者（以下「運営者」）が提供するWebアプリケーション「がんばりクエスト」（以下「本サービス」）の利用条件を定めるものです。本サービスをご利用いただくにあたり、本規約に同意いただく必要があります。
@@ -188,6 +188,7 @@ body{line-height:1.8;background:var(--gray-50)}
   <div class="effective">
     <p>以上</p>
     <p>制定日: 2026年3月27日</p>
+    <p>最終改定日: 2026年3月29日</p>
   </div>
 </article>
 </main>

--- a/src/lib/server/services/consent-service.ts
+++ b/src/lib/server/services/consent-service.ts
@@ -7,7 +7,7 @@ import { logger } from '$lib/server/logger';
 
 /** 規約バージョン（改訂日ベース） */
 export const CURRENT_TERMS_VERSION = '2026-03-29';
-export const CURRENT_PRIVACY_VERSION = '2026-03-29';
+export const CURRENT_PRIVACY_VERSION = '2026-04-09';
 
 export interface ConsentCheck {
 	termsAccepted: boolean;

--- a/tests/unit/services/signup-actions.test.ts
+++ b/tests/unit/services/signup-actions.test.ts
@@ -51,7 +51,7 @@ vi.mock('$lib/server/services/consent-service', () => ({
 	recordConsent: (...args: unknown[]) => mockRecordConsent(...args),
 	checkConsent: vi.fn().mockResolvedValue({ needsReconsent: false }),
 	CURRENT_TERMS_VERSION: '2026-03-29',
-	CURRENT_PRIVACY_VERSION: '2026-03-29',
+	CURRENT_PRIVACY_VERSION: '2026-04-09',
 }));
 
 // --- Discord Notify Service モック ---


### PR DESCRIPTION
## Summary
- terms.html・privacy.htmlの最終更新日とconsent-service.tsのバージョン定数が不整合だった問題を修正
- 利用規約: 最終更新日を2026年3月29日に統一（`CURRENT_TERMS_VERSION`と一致）
- プライバシーポリシー: 最終更新日を2026年4月9日に更新、`CURRENT_PRIVACY_VERSION`も同期

## Test plan
- [x] `npx biome check .` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし（0 errors）
- [x] `npx vitest run` — 2364テスト全通過（signup-actions.test.tsのモック値も更新済み）
- [x] `npx playwright test` — 315 passed（1 snapshot差分は既存の別PR由来）

closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)