### PR TITLE
design: #630 今日のがんばり・連続日数の表示位置見直し

### DIFF
--- a/src/routes/(child)/baby/home/+page.svelte
+++ b/src/routes/(child)/baby/home/+page.svelte
@@ -15,7 +15,6 @@ import type { CelebrationType } from '$lib/ui/components/CelebrationEffect.svelt
 import CelebrationEffect from '$lib/ui/components/CelebrationEffect.svelte';
 import ChallengeBanner from '$lib/ui/components/ChallengeBanner.svelte';
 import CompoundIcon from '$lib/ui/components/CompoundIcon.svelte';
-import FamilyStreakBanner from '$lib/ui/components/FamilyStreakBanner.svelte';
 
 import MonthlyRewardModal from '$lib/ui/components/MonthlyRewardModal.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
@@ -444,18 +443,6 @@ $effect(() => {
 		<ActivityEmptyState uiMode={data.uiMode} />
 	{/if}
 
-	<!-- Family streak banner (below activities) -->
-	{#if data.familyStreak && data.familyStreak.currentStreak > 0}
-		<FamilyStreakBanner
-			currentStreak={data.familyStreak.currentStreak}
-			hasRecordedToday={data.familyStreak.hasRecordedToday}
-			todayRecorders={data.familyStreak.todayRecorders}
-			childId={data.child?.id ?? 0}
-			siblings={data.allChildren ?? []}
-			nextMilestone={data.familyStreak.nextMilestone}
-			compact
-		/>
-	{/if}
 
 
 	<!-- Sibling challenge banners -->
@@ -537,6 +524,8 @@ $effect(() => {
 					{/if}
 				</div>
 			{/if}
+
+			<p class="text-xs text-[var(--color-text-muted)]">きょう {data.todayRecorded.reduce((sum, r) => sum + r.count, 0) + 1}かいめ！</p>
 
 			<div class="flex gap-2 w-full">
 				{#if cancelCountdown > 0}

--- a/src/routes/(child)/elementary/home/+page.svelte
+++ b/src/routes/(child)/elementary/home/+page.svelte
@@ -15,10 +15,9 @@ import type { CelebrationType } from '$lib/ui/components/CelebrationEffect.svelt
 import CelebrationEffect from '$lib/ui/components/CelebrationEffect.svelte';
 import ChallengeBanner from '$lib/ui/components/ChallengeBanner.svelte';
 import CompoundIcon from '$lib/ui/components/CompoundIcon.svelte';
-import FamilyStreakBanner from '$lib/ui/components/FamilyStreakBanner.svelte';
 import MonthlyRewardModal from '$lib/ui/components/MonthlyRewardModal.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
-import Card from '$lib/ui/primitives/Card.svelte';
+
 import Dialog from '$lib/ui/primitives/Dialog.svelte';
 import { soundService } from '$lib/ui/sound';
 
@@ -418,35 +417,12 @@ $effect(() => {
 			</CategorySection>
 		{/each}
 
-	<!-- 今日のきろくサマリー（lower以上で表示） -->
-	{#if data.todayRecorded.length > 0}
-		<Card padding="md" class="mt-[var(--sp-md)]">
-			{#snippet children()}
-			<h3 class="text-sm font-bold text-[var(--color-text-muted)] mb-[var(--sp-sm)]">📝 今日の記録</h3>
-			<div class="flex justify-between items-center">
-				<span class="text-sm text-[var(--color-text-muted)]">記録した活動</span>
-				<span class="font-bold">{data.todayRecorded.reduce((sum, r) => sum + r.count, 0)}回</span>
-			</div>
-			{/snippet}
-		</Card>
-	{/if}
 
 	{#if data.activities.length === 0}
 		<ActivityEmptyState uiMode={data.uiMode} />
 	{/if}
 
-	<!-- Family streak banner (below activities) -->
-	{#if data.familyStreak && data.familyStreak.currentStreak > 0}
-		<FamilyStreakBanner
-			currentStreak={data.familyStreak.currentStreak}
-			hasRecordedToday={data.familyStreak.hasRecordedToday}
-			todayRecorders={data.familyStreak.todayRecorders}
-			childId={data.child?.id ?? 0}
-			siblings={data.allChildren ?? []}
-			nextMilestone={data.familyStreak.nextMilestone}
-			compact
-		/>
-	{/if}
+
 
 
 	<!-- Sibling challenge banners -->
@@ -679,6 +655,8 @@ $effect(() => {
 						{/if}
 					</div>
 				{/if}
+
+				<p class="text-xs text-[var(--color-text-muted)]">今日 {data.todayRecorded.reduce((sum, r) => sum + r.count, 0) + 1}回目！</p>
 
 				<div class="flex gap-[var(--sp-sm)] w-full mt-[var(--sp-sm)]">
 					<!-- Cancel button with countdown -->

--- a/src/routes/(child)/junior/home/+page.svelte
+++ b/src/routes/(child)/junior/home/+page.svelte
@@ -15,7 +15,6 @@ import type { CelebrationType } from '$lib/ui/components/CelebrationEffect.svelt
 import CelebrationEffect from '$lib/ui/components/CelebrationEffect.svelte';
 import ChallengeBanner from '$lib/ui/components/ChallengeBanner.svelte';
 import CompoundIcon from '$lib/ui/components/CompoundIcon.svelte';
-import FamilyStreakBanner from '$lib/ui/components/FamilyStreakBanner.svelte';
 import MonthlyRewardModal from '$lib/ui/components/MonthlyRewardModal.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
@@ -421,7 +420,6 @@ $effect(() => {
 	<!-- 週間アクティビティサマリー（Upper固有） -->
 	{#if data.weeklySummary}
 		{@const ws = data.weeklySummary}
-		{@const todayCount = data.todayRecorded.reduce((sum, r) => sum + r.count, 0)}
 		{@const maxDayCount = Math.max(...ws.days.map((d) => d.count), 1)}
 		<Card padding="md" class="mt-[var(--sp-md)]">
 			{#snippet children()}
@@ -459,12 +457,6 @@ $effect(() => {
 					{/each}
 				</div>
 			{/if}
-			{#if todayCount > 0}
-				<div class="flex justify-between items-center mt-2 pt-2 border-t border-gray-100">
-					<span class="text-xs text-[var(--color-text-muted)]">📝 今日の記録</span>
-					<span class="text-sm font-bold">{todayCount}回</span>
-				</div>
-			{/if}
 			{/snippet}
 		</Card>
 	{/if}
@@ -473,18 +465,7 @@ $effect(() => {
 		<ActivityEmptyState uiMode={data.uiMode} />
 	{/if}
 
-	<!-- Family streak banner (below activities) -->
-	{#if data.familyStreak && data.familyStreak.currentStreak > 0}
-		<FamilyStreakBanner
-			currentStreak={data.familyStreak.currentStreak}
-			hasRecordedToday={data.familyStreak.hasRecordedToday}
-			todayRecorders={data.familyStreak.todayRecorders}
-			childId={data.child?.id ?? 0}
-			siblings={data.allChildren ?? []}
-			nextMilestone={data.familyStreak.nextMilestone}
-			compact
-		/>
-	{/if}
+
 
 
 	<!-- Sibling challenge banners -->
@@ -717,6 +698,8 @@ $effect(() => {
 						{/if}
 					</div>
 				{/if}
+
+				<p class="text-xs text-[var(--color-text-muted)]">今日{data.todayRecorded.reduce((sum, r) => sum + r.count, 0) + 1}回目！</p>
 
 				<div class="flex gap-[var(--sp-sm)] w-full mt-[var(--sp-sm)]">
 					<!-- Cancel button with countdown -->

--- a/src/routes/(child)/preschool/home/+page.svelte
+++ b/src/routes/(child)/preschool/home/+page.svelte
@@ -18,7 +18,6 @@ import CelebrationEffect from '$lib/ui/components/CelebrationEffect.svelte';
 import ChallengeBanner from '$lib/ui/components/ChallengeBanner.svelte';
 import CompoundIcon from '$lib/ui/components/CompoundIcon.svelte';
 import EventBanner from '$lib/ui/components/EventBanner.svelte';
-import FamilyStreakBanner from '$lib/ui/components/FamilyStreakBanner.svelte';
 import MonthlyRewardModal from '$lib/ui/components/MonthlyRewardModal.svelte';
 import ParentMessageOverlay from '$lib/ui/components/ParentMessageOverlay.svelte';
 import SiblingCheerOverlay from '$lib/ui/components/SiblingCheerOverlay.svelte';
@@ -544,52 +543,12 @@ $effect(() => {
 		/>
 	{/if}
 
-	<!-- おうえんメッセージ（Kinder固有） -->
-	{#if kinderTodayCount > 0}
-		<div class="mt-[var(--sp-md)] p-4 rounded-2xl bg-[var(--theme-bg)] border border-[var(--theme-secondary)] text-center">
-			<div class="text-3xl mb-1">
-				{#if kinderTodayCount >= 5}
-					🌟
-				{:else if kinderTodayCount >= 3}
-					⭐
-				{:else}
-					😊
-				{/if}
-			</div>
-			<p class="text-sm font-bold" style="color: var(--theme-accent);">
-				{#if kinderTodayCount >= 5}
-					すっごーい！ きょう {kinderTodayCount}かい がんばったね！
-				{:else if kinderTodayCount >= 3}
-					いいかんじ！ {kinderTodayCount}かい できたよ！
-				{:else}
-					がんばってるね！ {kinderTodayCount}かい きろくしたよ！
-				{/if}
-			</p>
-			<div class="flex justify-center gap-1 mt-2">
-				{#each Array(Math.min(kinderTodayCount, 10)) as _}
-					<span class="text-lg">⭐</span>
-				{/each}
-			</div>
-		</div>
-	{/if}
 
 	{#if data.activities.length === 0}
 		<ActivityEmptyState uiMode={data.uiMode} />
 	{/if}
 
 
-	<!-- Family streak banner (below activities) -->
-	{#if data.familyStreak && data.familyStreak.currentStreak > 0}
-		<FamilyStreakBanner
-			currentStreak={data.familyStreak.currentStreak}
-			hasRecordedToday={data.familyStreak.hasRecordedToday}
-			todayRecorders={data.familyStreak.todayRecorders}
-			childId={data.child?.id ?? 0}
-			siblings={data.allChildren?.map((c: { id: number; nickname: string }) => ({ id: c.id, nickname: c.nickname })) ?? []}
-			nextMilestone={data.familyStreak.nextMilestone}
-			compact
-		/>
-	{/if}
 
 	<!-- Season event banners -->
 	{#if data.activeEvents && data.activeEvents.length > 0}
@@ -833,6 +792,8 @@ $effect(() => {
 						{/if}
 					</div>
 				{/if}
+
+				<p class="text-xs text-[var(--color-text-muted)]">きょう {kinderTodayCount + 1}かいめ！</p>
 
 				<div class="flex gap-[var(--sp-sm)] w-full mt-[var(--sp-sm)]">
 					<!-- Cancel button with countdown -->

--- a/src/routes/(child)/senior/home/+page.svelte
+++ b/src/routes/(child)/senior/home/+page.svelte
@@ -15,7 +15,6 @@ import type { CelebrationType } from '$lib/ui/components/CelebrationEffect.svelt
 import CelebrationEffect from '$lib/ui/components/CelebrationEffect.svelte';
 import ChallengeBanner from '$lib/ui/components/ChallengeBanner.svelte';
 import CompoundIcon from '$lib/ui/components/CompoundIcon.svelte';
-import FamilyStreakBanner from '$lib/ui/components/FamilyStreakBanner.svelte';
 import MonthlyRewardModal from '$lib/ui/components/MonthlyRewardModal.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
@@ -420,7 +419,6 @@ $effect(() => {
 	<!-- 週間ダッシュボード（Teen固有） -->
 	{#if data.weeklySummary}
 		{@const ws = data.weeklySummary}
-		{@const todayCount = data.todayRecorded.reduce((sum, r) => sum + r.count, 0)}
 		{@const maxDayCount = Math.max(...ws.days.map((d) => d.count), 1)}
 		<Card padding="md" class="mt-[var(--sp-md)]">
 			{#snippet children()}
@@ -479,12 +477,6 @@ $effect(() => {
 					</div>
 				</div>
 			{/if}
-			{#if todayCount > 0}
-				<div class="flex justify-between items-center mt-2 pt-2 border-t border-gray-100">
-					<span class="text-xs text-[var(--color-text-muted)]">📝 今日の記録</span>
-					<span class="text-sm font-bold">{todayCount}回</span>
-				</div>
-			{/if}
 			{/snippet}
 		</Card>
 	{/if}
@@ -493,18 +485,7 @@ $effect(() => {
 		<ActivityEmptyState uiMode={data.uiMode} />
 	{/if}
 
-	<!-- Family streak banner (below activities) -->
-	{#if data.familyStreak && data.familyStreak.currentStreak > 0}
-		<FamilyStreakBanner
-			currentStreak={data.familyStreak.currentStreak}
-			hasRecordedToday={data.familyStreak.hasRecordedToday}
-			todayRecorders={data.familyStreak.todayRecorders}
-			childId={data.child?.id ?? 0}
-			siblings={data.allChildren ?? []}
-			nextMilestone={data.familyStreak.nextMilestone}
-			compact
-		/>
-	{/if}
+
 
 
 	<!-- Sibling challenge banners -->
@@ -737,6 +718,8 @@ $effect(() => {
 						{/if}
 					</div>
 				{/if}
+
+				<p class="text-xs text-[var(--color-text-muted)]">今日{data.todayRecorded.reduce((sum, r) => sum + r.count, 0) + 1}回目</p>
 
 				<div class="flex gap-[var(--sp-sm)] w-full mt-[var(--sp-sm)]">
 					<!-- Cancel button with countdown -->

--- a/src/routes/demo/(child)/[mode]/home/+page.svelte
+++ b/src/routes/demo/(child)/[mode]/home/+page.svelte
@@ -209,6 +209,7 @@ function handleResultClose() {
 			<p class="text-sm text-[var(--color-text-muted)]">
 				{resultData.streakDays}日れんぞく！
 			</p>
+			<p class="text-xs text-[var(--color-text-muted)] mt-1">きょう {data.todayRecorded.reduce((sum: number, r: { activityId: number; count: number }) => sum + r.count, 0) + 1}かいめ！</p>
 			<p class="text-xs text-amber-500 mt-3">
 				（デモモード：データは保存されません）
 			</p>


### PR DESCRIPTION
## Summary
- ホーム画面のスクロール下部にあった「おうえんメッセージ」セクション・FamilyStreakBanner・「今日の記録」カードを削除
- 活動記録直後の結果ダイアログに「きょう Nかいめ！」テキストを追加（全5年齢モード + demo）
- 連続日数は既に結果ダイアログに表示済みのため、FamilyStreakBannerの重複を排除

## Changes
| ファイル | 変更内容 |
|---------|---------|
| preschool/home | おうえんメッセージ削除 + FamilyStreakBanner削除 + 結果ダイアログに回数追加 |
| elementary/home | 「今日の記録」Card削除 + FamilyStreakBanner削除 + 結果ダイアログに回数追加 |
| junior/home | 週間サマリー内「今日の記録」削除 + FamilyStreakBanner削除 + 結果ダイアログに回数追加 |
| senior/home | 週間ダッシュボード内「今日の記録」削除 + FamilyStreakBanner削除 + 結果ダイアログに回数追加 |
| baby/home | FamilyStreakBanner削除 + 結果ダイアログに回数追加 |
| demo/home | 結果ダイアログに回数追加 |

## Test plan
- [x] `npx biome check .` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし (0 errors)
- [x] `npx vitest run` — ユニットテスト全通過 (2364 tests)
- [x] `npx playwright test` — E2Eテスト全通過 (315 passed)
- [x] Visual regression スナップショット更新済み

closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)