### PR TITLE
fix: #654 年齢モード間のUIテキスト表記不統一を修正

### DIFF
--- a/src/routes/(child)/junior/home/+page.svelte
+++ b/src/routes/(child)/junior/home/+page.svelte
@@ -725,7 +725,7 @@ $effect(() => {
 								size="sm"
 								class="w-full bg-gray-200 text-[var(--color-text-muted)]"
 							>
-								取消 ({cancelCountdown}s)
+								とりけし ({cancelCountdown}s)
 							</Button>
 						</form>
 					{/if}

--- a/src/routes/(child)/senior/home/+page.svelte
+++ b/src/routes/(child)/senior/home/+page.svelte
@@ -513,9 +513,9 @@ $effect(() => {
 				{#if pinSubmitting}
 					<span class="inline-block w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" aria-hidden="true"></span>
 				{:else if pinMenuActivity.isPinned}
-					📌 ピン留め解除
+					📌 ピン留めを解除
 				{:else}
-					📌 ピン留め
+					📌 ピン留めする
 				{/if}
 			</Button>
 			<Button


### PR DESCRIPTION
## Summary

closes #654

年齢モード間のUIテキスト表記揺れを修正。

- **upper**: 取消ボタン「取消」→「とりけし」（lower と統一）
- **teen**: ピン留めボタンの助詞統一（「ピン留め解除」→「ピン留めを解除」、「ピン留め」→「ピン留めする」）

### 表記ガイドライン
| モード | スタイル | 「！」 |
|--------|---------|-------|
| baby/kinder | ひらがな主体 | あり |
| lower/upper | 漢字混じり・カジュアル | あり |
| teen | 漢字主体・落ち着いたトーン | なし |

## Test plan
- [ ] upper: 取消ボタンが「とりけし (Ns)」と表示されること
- [ ] teen: ピン留めボタンが「📌 ピン留めを解除」「📌 ピン留めする」と表示されること
- [ ] 全5モードで意図通りの表記になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)