### PR TITLE
design(lp): #583 7日間無料体験 CTA 導線改善 — セクション間CTAバー追加

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -143,6 +143,12 @@
 .faq-item[open] summary{margin-bottom:12px}
 .faq-answer{font-size:.9rem;color:var(--gray-500);padding-left:28px;line-height:1.7}
 
+/* Inline CTA bar (#583) */
+.cta-bar{background:linear-gradient(90deg,var(--brand-50) 0%,#fef9e7 50%,var(--brand-50) 100%);padding:24px 16px;text-align:center;border-top:1px solid var(--brand-200);border-bottom:1px solid var(--brand-200)}
+.cta-bar-inner{max-width:640px;margin:0 auto;display:flex;align-items:center;justify-content:center;gap:16px;flex-wrap:wrap}
+.cta-bar-text{font-size:.95rem;color:var(--gray-700);font-weight:500}
+.cta-bar-text strong{color:var(--brand-800)}
+
 /* CTA bottom */
 .cta-bottom{background:linear-gradient(135deg,var(--brand-100) 0%,#fef9e7 100%);padding:64px 16px;text-align:center}
 .cta-bottom h2{font-size:1.8rem;font-weight:700;color:var(--gray-900);margin-bottom:12px}
@@ -456,6 +462,14 @@
   </div>
 </section>
 
+<!-- Inline CTA 1: After features -->
+<div class="cta-bar">
+  <div class="cta-bar-inner">
+    <p class="cta-bar-text"><strong>7日間、全機能を無料で体験</strong> &#8212; クレジットカード不要ですぐ始められます</p>
+    <a href="https://ganbari-quest.com/auth/signup" class="btn btn-primary">無料で始める</a>
+  </div>
+</div>
+
 <!-- What makes it different -->
 <section class="section bg-white" id="difference">
   <div class="section-inner">
@@ -565,6 +579,15 @@
     </div>
   </div>
 </section>
+
+<!-- Inline CTA 2: After age-modes -->
+<div class="cta-bar">
+  <div class="cta-bar-inner">
+    <p class="cta-bar-text">お子さまの年齢に最適化された画面を<strong>今すぐ体験</strong></p>
+    <a href="https://ganbari-quest.com/demo" class="btn btn-demo">デモを試す</a>
+    <a href="https://ganbari-quest.com/auth/signup" class="btn btn-primary">無料ではじめる</a>
+  </div>
+</div>
 
 <!-- Template Packs -->
 <section class="section bg-gray" id="templates">


### PR DESCRIPTION
## Summary

#583 の CTA 配置改善部分を対応。スクリーンショット再撮影は別途対応。

### 変更内容

LP のセクション間にインラインCTAバーを2箇所追加し、任意のタイミングで無料体験に誘導できる導線を確立。

1. **Features 直後** — 「7日間、全機能を無料で体験 — クレジットカード不要ですぐ始められます」
2. **Age-modes 直後** — 「お子さまの年齢に最適化された画面を今すぐ体験」（デモ + サインアップの2パス）

### CSS
- `.cta-bar` — ブランドカラーのグラデーション背景、ボーダー区切り
- `.cta-bar-inner` — Flex レイアウト、レスポンシブ対応（flex-wrap）
- `.cta-bar-text` — テキストスタイル

### 未対応（別途）
- [ ] 中学生/高校生モードのスクリーンショット再撮影（デモサーバー+データ投入が必要）

## Test plan
- [ ] LP の Features セクション後に CTA バーが表示される
- [ ] LP の Age-modes セクション後に CTA バーが表示される
- [ ] モバイル・デスクトップ両方で確認
- [ ] ボタンリンク先が正しい

🤖 Generated with [Claude Code](https://claude.com/claude-code)