### PR TITLE
refactor: #568 デモルートをアダプタパターンで本番ルートに統合（Phase 1）

### DIFF
--- a/src/lib/server/data-source/demo-source.ts
+++ b/src/lib/server/data-source/demo-source.ts
@@ -32,7 +32,7 @@ export class DemoChildDataSource implements ChildDataSource {
 			activities: demo.activities.map((a) => ({
 				...a,
 				isPinned: false,
-				isMainQuest: false,
+				isMainQuest: 0,
 			})),
 			todayRecorded: demo.todayRecorded,
 			loginBonusStatus: demo.loginBonusStatus,

--- a/src/lib/server/data-source/demo-source.ts
+++ b/src/lib/server/data-source/demo-source.ts
@@ -5,12 +5,11 @@
  * demo-service.ts のラッパーで、ChildDataSource インターフェースに準拠する。
  */
 
-import { DEMO_ACTIVITIES } from '$lib/server/demo/demo-data.js';
+import { DEMO_ACTIVITIES, getDemoLogsForChild } from '$lib/server/demo/demo-data.js';
 import {
 	demoCancelRecord,
 	demoRecordActivity,
 	demoTogglePin,
-	getDemoHistoryData,
 	getDemoHomeData,
 	getDemoStatusData,
 } from '$lib/server/demo/demo-service.js';
@@ -112,29 +111,33 @@ export class DemoChildDataSource implements ChildDataSource {
 		childId: number,
 		_dateRange: { from: string; to: string },
 	): Promise<HistoryPageData> {
-		const demo = getDemoHistoryData(childId);
+		const logs = getDemoLogsForChild(childId);
+		const actMap = new Map(DEMO_ACTIVITIES.map((a) => [a.id, a]));
 		const byCategory: Record<string, { count: number; points: number }> = {};
-		for (const log of demo.logs) {
-			const act = DEMO_ACTIVITIES.find((a) => a.id === log.id);
+		for (const log of logs) {
+			const act = actMap.get(log.activityId);
 			const catId = String(act?.categoryId ?? 0);
 			if (!byCategory[catId]) byCategory[catId] = { count: 0, points: 0 };
 			byCategory[catId].count++;
 			byCategory[catId].points += log.points;
 		}
 		return {
-			logs: demo.logs.map((l) => ({
-				id: l.id,
-				activityName: l.activityName,
-				activityIcon: l.activityIcon,
-				categoryId: 0,
-				points: l.points,
-				streakDays: l.streakDays,
-				streakBonus: 0,
-				recordedAt: l.recordedAt,
-			})),
+			logs: logs.map((l) => {
+				const act = actMap.get(l.activityId);
+				return {
+					id: l.id,
+					activityName: act?.name ?? '不明',
+					activityIcon: act?.icon ?? '❓',
+					categoryId: act?.categoryId ?? 0,
+					points: l.points,
+					streakDays: l.streakDays,
+					streakBonus: l.streakBonus,
+					recordedAt: l.recordedAt,
+				};
+			}),
 			summary: {
-				totalCount: demo.logs.length,
-				totalPoints: demo.logs.reduce((sum, l) => sum + l.points, 0),
+				totalCount: logs.length,
+				totalPoints: logs.reduce((sum, l) => sum + l.points, 0),
 				byCategory,
 			},
 			period: 'week',

--- a/src/lib/server/data-source/demo-source.ts
+++ b/src/lib/server/data-source/demo-source.ts
@@ -1,0 +1,143 @@
+/**
+ * デモ用データソース実装
+ *
+ * インメモリの静的データを返す。書き込み操作は no-op でデモ用成功レスポンスを返す。
+ * demo-service.ts のラッパーで、ChildDataSource インターフェースに準拠する。
+ */
+
+import { DEMO_ACTIVITIES } from '$lib/server/demo/demo-data.js';
+import {
+	demoCancelRecord,
+	demoRecordActivity,
+	demoTogglePin,
+	getDemoHistoryData,
+	getDemoHomeData,
+	getDemoStatusData,
+} from '$lib/server/demo/demo-service.js';
+import type {
+	AchievementsPageData,
+	CancelResult,
+	ChildDataSource,
+	HistoryPageData,
+	HomePageData,
+	LoginStampResult,
+	RecordResult,
+	StatusPageData,
+} from './types.js';
+
+export class DemoChildDataSource implements ChildDataSource {
+	async getHomeData(childId: number): Promise<HomePageData> {
+		const demo = getDemoHomeData(childId);
+		return {
+			activities: demo.activities.map((a) => ({
+				...a,
+				isPinned: false,
+				isMainQuest: false,
+			})),
+			todayRecorded: demo.todayRecorded,
+			loginBonusStatus: demo.loginBonusStatus,
+			latestReward: null,
+			latestMessage: null,
+			hasChecklists: demo.hasChecklists,
+			checklistProgress: demo.checklistProgress,
+			dailyMissions: demo.dailyMissions,
+			stampCard: null,
+			categoryXp: null,
+			isFirstTime: false,
+			recommendedActivityIds: [],
+			birthdayBonus: null,
+			activeEvents: [],
+			activeChallenges: [],
+			siblingRanking: null,
+			unshownCheers: [],
+			monthlyPremiumReward: null,
+			specialRewardProgress: null,
+		};
+	}
+
+	async recordActivity(_childId: number, activityId: number): Promise<RecordResult> {
+		const result = demoRecordActivity(activityId);
+		return {
+			...result,
+			masteryBonus: 0,
+			masteryLevel: 1,
+			masteryLeveledUp: null,
+		};
+	}
+
+	async cancelRecord(_logId: number, _childId: number): Promise<CancelResult> {
+		return demoCancelRecord();
+	}
+
+	async claimLoginStamp(_childId: number): Promise<LoginStampResult> {
+		return {
+			loginStamp: true,
+			stampEmoji: '⭐',
+			stampRarity: 'N',
+			stampName: 'デモスタンプ',
+			omikujiRank: 'kichi',
+			instantPoints: 5,
+			consecutiveLoginDays: 3,
+			multiplier: 1,
+			cardData: null,
+			weeklyRedeem: null,
+		};
+	}
+
+	async togglePin(
+		_childId: number,
+		_activityId: number,
+		pinned: boolean,
+	): Promise<{ isPinned: boolean }> {
+		const result = demoTogglePin(pinned);
+		return { isPinned: result.isPinned };
+	}
+
+	async getStatusData(childId: number): Promise<StatusPageData> {
+		const status = getDemoStatusData(childId);
+		return {
+			status,
+			monthlyComparison: null,
+		};
+	}
+
+	async getAchievementsData(_childId: number): Promise<AchievementsPageData> {
+		return {
+			activeChallenge: null,
+			history: [],
+		};
+	}
+
+	async getHistoryData(
+		childId: number,
+		_dateRange: { from: string; to: string },
+	): Promise<HistoryPageData> {
+		const demo = getDemoHistoryData(childId);
+		const byCategory: Record<string, { count: number; points: number }> = {};
+		for (const log of demo.logs) {
+			const act = DEMO_ACTIVITIES.find((a) => a.id === log.id);
+			const catId = String(act?.categoryId ?? 0);
+			if (!byCategory[catId]) byCategory[catId] = { count: 0, points: 0 };
+			byCategory[catId].count++;
+			byCategory[catId].points += log.points;
+		}
+		return {
+			logs: demo.logs.map((l) => ({
+				id: l.id,
+				activityName: l.activityName,
+				activityIcon: l.activityIcon,
+				categoryId: 0,
+				points: l.points,
+				streakDays: l.streakDays,
+				streakBonus: 0,
+				recordedAt: l.recordedAt,
+			})),
+			summary: {
+				totalCount: demo.logs.length,
+				totalPoints: demo.logs.reduce((sum, l) => sum + l.points, 0),
+				byCategory,
+			},
+			period: 'week',
+		};
+	}
+}

--- a/src/lib/server/data-source/index.ts
+++ b/src/lib/server/data-source/index.ts
@@ -1,12 +1,7 @@
 /**
  * データソースファクトリ
  *
- * リクエストからデモモードを判定し、適切なデータソースを返す。
- *
- * デモ判定ロジック:
- * 1. URL が /demo/ で始まる場合
- * 2. locals.isDemo が true の場合（hooks で設定済み）
- * 3. クエリパラメータ ?demo=true の場合
+ * `locals.isDemo` からデモモードを判定し、適切なデータソースを返す。
  */
 
 import type { ChildDataSource } from './types.js';
@@ -14,8 +9,7 @@ import type { ChildDataSource } from './types.js';
 /**
  * リクエストがデモモードかどうかを判定する。
  *
- * hooks.server.ts の handle 内で URL prefix `/demo/` を検出して
- * locals.isDemo = true を設定しておくことを前提とする。
+ * hooks.server.ts で locals.isDemo = true が設定されていることを前提とする。
  */
 export function isDemoMode(locals: App.Locals): boolean {
 	return (locals as unknown as Record<string, unknown>).isDemo === true;

--- a/src/lib/server/data-source/index.ts
+++ b/src/lib/server/data-source/index.ts
@@ -1,0 +1,38 @@
+/**
+ * データソースファクトリ
+ *
+ * リクエストからデモモードを判定し、適切なデータソースを返す。
+ *
+ * デモ判定ロジック:
+ * 1. URL が /demo/ で始まる場合
+ * 2. locals.isDemo が true の場合（hooks で設定済み）
+ * 3. クエリパラメータ ?demo=true の場合
+ */
+
+import type { ChildDataSource } from './types.js';
+
+/**
+ * リクエストがデモモードかどうかを判定する。
+ *
+ * hooks.server.ts の handle 内で URL prefix `/demo/` を検出して
+ * locals.isDemo = true を設定しておくことを前提とする。
+ */
+export function isDemoMode(locals: App.Locals): boolean {
+	return (locals as Record<string, unknown>).isDemo === true;
+}
+
+/**
+ * デモモードかどうかに応じてデータソースを生成する。
+ *
+ * DB ソースは各 +page.server.ts で直接サービス関数を呼ぶ既存パターンを維持するため、
+ * 現時点ではデモソースのみファクトリで生成する。
+ * 本番はアダプタ移行完了後に DbChildDataSource として実装する。
+ */
+export async function createChildDataSource(locals: App.Locals): Promise<ChildDataSource | null> {
+	if (!isDemoMode(locals)) return null;
+
+	const { DemoChildDataSource } = await import('./demo-source.js');
+	return new DemoChildDataSource();
+}
+
+export type { ChildDataSource } from './types.js';

--- a/src/lib/server/data-source/index.ts
+++ b/src/lib/server/data-source/index.ts
@@ -18,7 +18,7 @@ import type { ChildDataSource } from './types.js';
  * locals.isDemo = true を設定しておくことを前提とする。
  */
 export function isDemoMode(locals: App.Locals): boolean {
-	return (locals as Record<string, unknown>).isDemo === true;
+	return (locals as unknown as Record<string, unknown>).isDemo === true;
 }
 
 /**

--- a/src/lib/server/data-source/types.ts
+++ b/src/lib/server/data-source/types.ts
@@ -35,7 +35,6 @@ export interface ActivityWithDisplay extends Activity {
 	displayName: string;
 	isMission: boolean;
 	isPinned?: boolean;
-	isMainQuest?: boolean;
 }
 
 export interface HomePageData {

--- a/src/lib/server/data-source/types.ts
+++ b/src/lib/server/data-source/types.ts
@@ -1,0 +1,176 @@
+/**
+ * データソース抽象レイヤ — 型定義
+ *
+ * 本番 (DB) とデモ (インメモリ) のデータソースを統一するインターフェース。
+ * #568: デモルートをアダプタパターンで本番ルートに統合するための基盤。
+ */
+
+import type { PointSettings } from '$lib/domain/point-display';
+import type { Activity, Child } from '$lib/server/db/types/index.js';
+import type { DailyMissionStatus } from '$lib/server/services/daily-mission-service';
+import type { LoginBonusStatus } from '$lib/server/services/login-bonus-service';
+import type { ChildStatus } from '$lib/server/services/status-service';
+
+// ============================================================
+// Layout data
+// ============================================================
+
+export interface ChildLayoutData {
+	child: Child | null;
+	balance: number;
+	level: number;
+	levelTitle: string;
+	avatarConfig: unknown;
+	allChildren: Child[];
+	uiMode: string;
+	pointSettings: PointSettings;
+	isPremium: boolean;
+}
+
+// ============================================================
+// Home page
+// ============================================================
+
+export interface ActivityWithDisplay extends Activity {
+	displayName: string;
+	isMission: boolean;
+	isPinned?: boolean;
+	isMainQuest?: boolean;
+}
+
+export interface HomePageData {
+	activities: ActivityWithDisplay[];
+	todayRecorded: { activityId: number; count: number }[];
+	loginBonusStatus: LoginBonusStatus | null;
+	latestReward: unknown;
+	latestMessage: unknown;
+	hasChecklists: boolean;
+	checklistProgress: { checkedCount: number; totalCount: number; allDone: boolean } | null;
+	dailyMissions: DailyMissionStatus | null;
+	stampCard: unknown;
+	categoryXp: Record<number, unknown> | null;
+	isFirstTime: boolean;
+	recommendedActivityIds: number[];
+	birthdayBonus: unknown;
+	activeEvents: unknown[];
+	activeChallenges: unknown[];
+	siblingRanking: unknown;
+	unshownCheers: unknown[];
+	monthlyPremiumReward: unknown;
+	specialRewardProgress: unknown;
+}
+
+export interface RecordResult {
+	success: boolean;
+	logId: number;
+	activityName: string;
+	totalPoints: number;
+	streakDays: number;
+	streakBonus: number;
+	masteryBonus: number;
+	masteryLevel: number;
+	masteryLeveledUp: { oldLevel: number; newLevel: number; isMilestone: boolean } | null;
+	cancelableUntil: string;
+	comboBonus: unknown;
+	missionComplete: unknown;
+	levelUp: unknown;
+}
+
+export interface CancelResult {
+	success: boolean;
+	cancelled: boolean;
+	refundedPoints: number;
+}
+
+export interface LoginStampResult {
+	loginStamp: boolean;
+	stampEmoji: string;
+	stampRarity: string;
+	stampName: string;
+	omikujiRank: string | null;
+	instantPoints: number;
+	consecutiveLoginDays: number;
+	multiplier: number;
+	cardData: unknown;
+	weeklyRedeem: unknown;
+}
+
+// ============================================================
+// Status page
+// ============================================================
+
+export interface StatusPageData {
+	status: ChildStatus | null;
+	monthlyComparison: unknown;
+}
+
+// ============================================================
+// History page
+// ============================================================
+
+export interface HistoryLog {
+	id: number;
+	activityName: string;
+	activityIcon: string;
+	categoryId: number;
+	points: number;
+	streakDays: number;
+	streakBonus: number;
+	recordedAt: string;
+}
+
+export interface HistoryPageData {
+	logs: HistoryLog[];
+	summary: {
+		totalCount: number;
+		totalPoints: number;
+		byCategory: Record<string, { count: number; points: number }>;
+	};
+	period: string;
+}
+
+// ============================================================
+// Achievements page
+// ============================================================
+
+export interface AchievementsPageData {
+	activeChallenge: unknown;
+	history: unknown[];
+}
+
+// ============================================================
+// DataSource interface
+// ============================================================
+
+/**
+ * Child ページ群のデータソース。
+ * 本番 (DbChildDataSource) とデモ (DemoChildDataSource) で実装を切り替える。
+ */
+export interface ChildDataSource {
+	/** ホームページデータ取得 */
+	getHomeData(childId: number): Promise<HomePageData>;
+
+	/** 活動記録 */
+	recordActivity(childId: number, activityId: number): Promise<RecordResult>;
+
+	/** 記録取り消し */
+	cancelRecord(logId: number, childId: number): Promise<CancelResult>;
+
+	/** ログインスタンプ（ボーナス + スタンプカード） */
+	claimLoginStamp(childId: number): Promise<LoginStampResult>;
+
+	/** アクティビティピン切替 */
+	togglePin(childId: number, activityId: number, pinned: boolean): Promise<{ isPinned: boolean }>;
+
+	/** ステータスページデータ取得 */
+	getStatusData(childId: number): Promise<StatusPageData>;
+
+	/** 実績ページデータ取得 */
+	getAchievementsData(childId: number): Promise<AchievementsPageData>;
+
+	/** 履歴ページデータ取得 */
+	getHistoryData(
+		childId: number,
+		dateRange: { from: string; to: string },
+	): Promise<HistoryPageData>;
+}


### PR DESCRIPTION
## Summary
- Phase 1: データソース抽象レイヤ（`src/lib/server/data-source/`）を新設
  - `types.ts` — `ChildDataSource` インターフェース + 各ページデータ型定義
  - `demo-source.ts` — `DemoChildDataSource`（既存 demo-service.ts のラッパー）
  - `index.ts` — `isDemoMode()` 判定 + `createChildDataSource()` ファクトリ

## TODO（Phase 2-3）
- [ ] Phase 2: `hooks.server.ts` のデモ判定 + `reroute` フック + layout/page のデータソース切替
- [ ] Phase 3: `src/routes/demo/` 削除 + レガシーURLリダイレクト

> **Note**: Phase 2-3 は #567（PR #664）マージ後に実装予定

ref #568 (Phase 1 のみ — Phase 2-3 は別PRで実装)

## Test plan
- [x] `npx biome check .` — lint エラーなし
- [ ] Phase 2-3 実装後に E2E テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)