### PR TITLE
fix: #706 デプロイブロッカー — E2Eパスワードラベル exact match

### DIFF
--- a/tests/e2e/cognito-auth.spec.ts
+++ b/tests/e2e/cognito-auth.spec.ts
@@ -16,7 +16,7 @@ async function gotoLogin(page: Page) {
 async function loginAs(page: Page, email: string, password: string, expectedUrl: RegExp) {
 	await gotoLogin(page);
 	await page.getByLabel('メールアドレス').fill(email);
-	await page.getByLabel('パスワード').fill(password);
+	await page.getByLabel('パスワード', { exact: true }).fill(password);
 	await page.getByRole('button', { name: 'ログイン' }).click();
 	await page.waitForURL(expectedUrl, { timeout: 30_000 });
 }
@@ -29,7 +29,7 @@ test.describe('ログインページ', () => {
 		await gotoLogin(page);
 		await expect(page.getByAltText('がんばりクエスト')).toBeVisible();
 		await expect(page.getByLabel('メールアドレス')).toBeVisible();
-		await expect(page.getByLabel('パスワード')).toBeVisible();
+		await expect(page.getByLabel('パスワード', { exact: true })).toBeVisible();
 		await expect(page.getByRole('button', { name: 'ログイン' })).toBeVisible();
 	});
 
@@ -64,7 +64,7 @@ test.describe('ログイン失敗', () => {
 	test('不正なパスワードでエラーが表示される', async ({ page }) => {
 		await gotoLogin(page);
 		await page.getByLabel('メールアドレス').fill('owner@example.com');
-		await page.getByLabel('パスワード').fill('wrongpassword');
+		await page.getByLabel('パスワード', { exact: true }).fill('wrongpassword');
 		await page.getByRole('button', { name: 'ログイン' }).click();
 		await expect(page.getByText('メールアドレスまたはパスワードが正しくありません')).toBeVisible();
 	});
@@ -72,7 +72,7 @@ test.describe('ログイン失敗', () => {
 	test('存在しないメールアドレスでエラーが表示される', async ({ page }) => {
 		await gotoLogin(page);
 		await page.getByLabel('メールアドレス').fill('nobody@example.com');
-		await page.getByLabel('パスワード').fill('Gq!Dev#Owner2026x');
+		await page.getByLabel('パスワード', { exact: true }).fill('Gq!Dev#Owner2026x');
 		await page.getByRole('button', { name: 'ログイン' }).click();
 		await expect(page.getByText('メールアドレスまたはパスワードが正しくありません')).toBeVisible();
 	});

--- a/tests/e2e/global-setup-aws.ts
+++ b/tests/e2e/global-setup-aws.ts
@@ -47,7 +47,7 @@ export default async function globalSetup() {
 			const emailInput = page.getByLabel('メールアドレス');
 			await emailInput.waitFor({ timeout: 15000 });
 			await emailInput.fill(TEST_EMAIL);
-			await page.getByLabel('パスワード').fill(TEST_PASSWORD);
+			await page.getByLabel('パスワード', { exact: true }).fill(TEST_PASSWORD);
 
 			const loginBtn = page.getByRole('button', { name: 'ログイン' });
 			await loginBtn.click();

--- a/tests/e2e/production-smoke.spec.ts
+++ b/tests/e2e/production-smoke.spec.ts
@@ -40,7 +40,7 @@ async function loginAsOwner(page: Page): Promise<boolean> {
 	await emailInput.click();
 	await emailInput.fill('');
 	await emailInput.type(TEST_EMAIL, { delay: 10 });
-	const passwordInput = page.getByLabel('パスワード');
+	const passwordInput = page.getByLabel('パスワード', { exact: true });
 	await passwordInput.click();
 	await passwordInput.type(TEST_PASSWORD, { delay: 10 });
 
@@ -76,7 +76,7 @@ test.describe('本番環境 - 基本動作', () => {
 			timeout: 10000,
 		});
 		await expect(page.getByLabel('メールアドレス')).toBeVisible();
-		await expect(page.getByLabel('パスワード')).toBeVisible();
+		await expect(page.getByLabel('パスワード', { exact: true })).toBeVisible();
 	});
 
 	test('404ページが適切に表示される', async ({ page }) => {


### PR DESCRIPTION
## Summary
- `getByLabel('パスワード')` が FormField の `showToggle` ボタン（`aria-label="パスワードを表示"`）にも部分一致し、strict mode違反で全E2Eが失敗
- これにより **全てのdeploy workflowが失敗** し、mainへのマージ後も本番環境に反映されない状態が続いていた
- `{ exact: true }` オプションで完全一致に修正

## 変更対象（3ファイル）
- `tests/e2e/cognito-auth.spec.ts` — loginAs関数 + 個別テスト4箇所
- `tests/e2e/global-setup-aws.ts` — AWS環境セットアップ1箇所
- `tests/e2e/production-smoke.spec.ts` — 本番スモークテスト2箇所

## 根本原因
FormField コンポーネントに `showToggle` prop を追加した際（#587 パスワード表示トグル）、
トグルボタンの `aria-label="パスワードを表示"` が `getByLabel('パスワード')` の部分一致に
該当するようになった。E2Eテストが更新されず、deployが全てブロックされていた。

## Test plan
- [ ] CI全通過確認（特にcognito-dev E2Eテスト）
- [ ] deploy workflow成功確認

#706

🤖 Generated with [Claude Code](https://claude.com/claude-code)