### PR TITLE
fix: #725 #726 admin 配下の resolvePlanTier トライアル情報欠落

### DIFF
--- a/src/routes/(parent)/admin/+layout.server.ts
+++ b/src/routes/(parent)/admin/+layout.server.ts
@@ -30,10 +30,13 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 	};
 
 	const tenantStatus = locals.context?.tenantStatus ?? 'active';
+	// #725: トライアル中にファミリー体験ユーザーが standard 扱いになるバグ修正
+	// trialTier 引数を必ず渡す（トライアル非アクティブ時は null で OK）
 	const planTier = resolvePlanTier(
 		locals.context?.licenseStatus ?? 'none',
 		locals.context?.plan,
-		trialStatus.trialEndDate,
+		trialStatus.isTrialActive ? trialStatus.trialEndDate : null,
+		trialStatus.isTrialActive ? trialStatus.trialTier : null,
 	);
 	const isPremium = isPaidTier(planTier);
 	const tutorialStarted = !!(

--- a/src/routes/(parent)/admin/+page.server.ts
+++ b/src/routes/(parent)/admin/+page.server.ts
@@ -5,15 +5,21 @@ import { getSettings, setSetting } from '$lib/server/db/settings-repo';
 import { logger } from '$lib/server/logger';
 import { getAllChildren } from '$lib/server/services/child-service';
 import { dismissOnboarding, getOnboardingProgress } from '$lib/server/services/onboarding-service';
-import { resolvePlanTier } from '$lib/server/services/plan-limit-service';
+import { isPaidTier } from '$lib/server/services/plan-limit-service';
 import { getPointBalance } from '$lib/server/services/point-service';
 import { getAllChildrenSimpleSummary } from '$lib/server/services/report-service';
 import { getMemoryTicketStatus } from '$lib/server/services/seasonal-content-service';
 import { getChildStatus } from '$lib/server/services/status-service';
 import type { Actions, PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, parent }) => {
 	const tenantId = requireTenantId(locals);
+
+	// #726: 親 layout で解決済みの planTier をそのまま継承する。
+	// ここで独自に resolvePlanTier を呼ぶとトライアル情報を渡し忘れ、
+	// トライアル中でも free と判定される（歓迎画面が出ない）バグにつながる。
+	const parentData = await parent();
+	const tier = parentData.planTier;
 
 	const [children, onboarding] = await Promise.all([
 		getAllChildren(tenantId),
@@ -57,10 +63,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 		logger.warn('[admin] 月次サマリー取得フォールバック', { context: { error: String(e) } });
 	}
 
-	const tier = resolvePlanTier(locals.context?.licenseStatus ?? 'none', locals.context?.plan);
-
-	// 有料プラン歓迎画面フラグ
-	const isPaid = tier !== 'free';
+	// 有料プラン歓迎画面フラグ（トライアル中も有料扱い）
+	const isPaid = isPaidTier(tier);
 	let showPremiumWelcome = false;
 	if (isPaid) {
 		const welcomeSettings = await getSettings(['premium_welcome_shown'], tenantId);


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: ファミリートライアル中のユーザー / 全トライアルユーザー

**解決する課題**:
admin 画面の 2 箇所で `resolvePlanTier` にトライアル情報が正しく渡されておらず、
- ファミリー体験中でも standard 扱い → ファミリー限定機能が触れない (#725)
- トライアル中でも free 扱い → 歓迎画面が表示されない (#726)

**期待される効果**:
- ファミリー体験トライアル中のユーザーが正しくファミリー機能を利用できる
- トライアル開始直後に歓迎画面が表示される
- Memory Ticket 取得ロジックが正しく起動する

## 関連 Issue

closes #725
closes #726

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/(parent)/admin/+layout.server.ts`, `+page.server.ts`)

**影響を受ける画面・機能**:
- `/admin` ダッシュボード（歓迎画面、Memory Ticket）
- `/admin/reports` 以下全ページ（layout の planTier を参照）
- `/admin/messages`, `/admin/challenges`, `/admin/achievements` 等（ファミリー機能ゲート）

## 既存実装との比較

| 観点 | 既存 | 今回 |
|------|------|------|
| `admin/+layout.server.ts` | 3 引数呼び出し（trialTier 欠落） | 4 引数で trialStatus から正しく供給 |
| `admin/+page.server.ts` | 独自に 2 引数で再解決（free 固定） | 親 layout の planTier を parent() で継承 |
| `admin/license/+page.server.ts` | 4 引数で正しい（参照実装） | 変更なし |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**:
  - `admin/+page.server.ts` が独自に `resolvePlanTier` を呼んでいた重複を削除し、親 layout の `planTier` を継承する形に変更
  - 独自判定 `tier !== 'free'` を `isPaidTier(tier)` ヘルパーに統一
- **削除したコード**: `admin/+page.server.ts` の `resolvePlanTier` import + 呼び出し

## 設計方針

**採用した設計方針**:
- SvelteKit の `parent()` を使って子 page で layout の解決結果を再利用
- 同じバグの再発を構造的に防ぐ（子ページが独自解決しないように強制）

**意図的に対応しなかった範囲**:
- `resolvePlanTier` の型レベルでの必須引数化: 既存の多数の呼び出し箇所との互換性確保のため、別 Issue で検討

## テスト戦略

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check` (modified files) | PASS | |
| 型チェック | `npx svelte-check` | PASS (0 errors, 39 warnings pre-existing) | |
| 単体テスト | `npx vitest run tests/unit/services/plan-limit-service.test.ts` | 35/35 PASS | `resolvePlanTier` の既存テストが全ケース網羅 |

**網羅性の判断根拠**:
`resolvePlanTier` のロジック自体は `plan-limit-service.test.ts` で全分岐網羅済み（35 テスト）。
本 PR は呼び出し側の引数欠落を修正するもので、同サービスの境界契約は変更していない。

## 品質観点チェック

| 観点 | 対応内容 |
|------|---------|
| セキュリティ | プラン判定ミスによるファミリー機能の誤制限を修正。free 判定での UI 非表示は変わらず |
| パフォーマンス | `parent()` 呼び出しは SvelteKit の load シーケンスで自然にキャッシュされる |

## スクリーンショット

UI ロジック層の修正のみで UI そのものは変わらないため、スクリーンショットは不要。

## 横展開・影響波及チェック

- [x] **本番アプリ** — `src/routes/(parent)/admin/` 対応済み
- [x] **デモ版** — `/demo/admin/` は別実装で影響範囲外
- [x] **該当なし** — 並行実装対象外

### その他
- [x] `src/` 配下全 `resolvePlanTier` 呼び出し箇所を監査し、残り全てが正しい呼び出しであることを確認

## Critical 修正の追加要件

- [ ] E2E 回帰テスト: 本 PR では追加せず。理由: トライアル状態の E2E seed 整備は #752 / #758 / #759 で計画されており、本 PR のスコープ外
- [ ] 5年齢モード実機検証: 該当なし（admin 層の修正）

## 完了チェックリスト

- [x] `npx biome check` (対象ファイル) — 0 errors
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run tests/unit/services/plan-limit-service.test.ts` — 35/35 passed
- [ ] `npx playwright test` — 本 PR スコープ外（上記理由）
- [x] PR サイズ適切（2 files, 14/7 insertions/deletions）

🤖 Generated with [Claude Code](https://claude.com/claude-code)