### PR TITLE
fix: #727 /api/v1/activities/suggest プランゲート+認証追加

### DIFF
--- a/src/lib/features/admin/components/AiSuggestPanel.svelte
+++ b/src/lib/features/admin/components/AiSuggestPanel.svelte
@@ -7,9 +7,10 @@ import type { AiPreviewData } from './activity-types';
 
 interface Props {
 	onaccept: (preview: AiPreviewData) => void;
+	isPremium?: boolean;
 }
 
-let { onaccept }: Props = $props();
+let { onaccept, isPremium = false }: Props = $props();
 
 let aiInput = $state('');
 let aiLoading = $state(false);
@@ -18,6 +19,10 @@ let aiPreview = $state<AiPreviewData | null>(null);
 
 async function suggestFromAI() {
 	if (!aiInput.trim()) return;
+	if (!isPremium) {
+		aiError = 'AI 活動提案はスタンダードプラン以上でご利用いただけます';
+		return;
+	}
 	aiLoading = true;
 	aiError = '';
 	aiPreview = null;
@@ -48,22 +53,42 @@ function acceptPreview() {
 </script>
 
 <div class="bg-[var(--color-premium-bg)] rounded-xl p-4 shadow-sm space-y-3 border border-[var(--color-border-premium)]">
-	<h3 class="font-bold text-[var(--color-premium)]">✨ やりたいことを教えてください</h3>
+	<h3 class="font-bold text-[var(--color-premium)]">
+		✨ やりたいことを教えてください
+		{#if !isPremium}
+			<span class="ml-1 inline-block px-2 py-0.5 text-[10px] rounded-full bg-[var(--color-premium)] text-[var(--color-text-inverse)] align-middle">有料限定</span>
+		{/if}
+	</h3>
 	<p class="text-xs text-[var(--color-premium-light)]">
 		やりたい活動を自由に入力すると、カテゴリ・ポイント・アイコンを自動で提案します
 	</p>
+	{#if !isPremium}
+		<div class="bg-[var(--color-surface-card)] rounded-lg p-3 text-xs space-y-2 border border-[var(--color-border-premium)]">
+			<p class="text-[var(--color-text-primary)]">
+				AI 活動提案はスタンダードプラン以上の機能です。
+			</p>
+			<a
+				href="/admin/license"
+				class="inline-block px-3 py-1.5 bg-[var(--color-premium)] text-[var(--color-text-inverse)] rounded-lg font-bold hover:opacity-90 transition-colors"
+				data-testid="ai-suggest-upgrade-cta"
+			>
+				プランを確認する
+			</a>
+		</div>
+	{/if}
 	<div class="flex gap-2">
 		<input
 			type="text"
 			bind:value={aiInput}
 			placeholder="例: ピアノの練習をした、公園で走った、折り紙を作った"
-			class="flex-1 px-3 py-2 border rounded-lg text-sm"
+			class="flex-1 px-3 py-2 border rounded-lg text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+			disabled={!isPremium}
 			onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); suggestFromAI(); } }}
 		/>
 		<button
 			type="button"
-			class="px-4 py-2 bg-[var(--color-premium)] text-[var(--color-text-inverse)] rounded-lg text-sm font-bold hover:opacity-90 transition-colors disabled:opacity-50"
-			disabled={aiLoading || !aiInput.trim()}
+			class="px-4 py-2 bg-[var(--color-premium)] text-[var(--color-text-inverse)] rounded-lg text-sm font-bold hover:opacity-90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+			disabled={!isPremium || aiLoading || !aiInput.trim()}
 			onclick={suggestFromAI}
 		>
 			{#if aiLoading}

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -268,7 +268,7 @@ function acceptAiPreview(preview: AiPreviewData) {
 			</div>
 		{:else if addMode === 'ai'}
 			<Button variant="ghost" size="sm" onclick={() => { addMode = null; }} class="mb-2">← 戻る</Button>
-			<AiSuggestPanel onaccept={acceptAiPreview} />
+			<AiSuggestPanel onaccept={acceptAiPreview} isPremium={data.isPremium} />
 		{:else if addMode === 'manual'}
 			<Button variant="ghost" size="sm" onclick={() => { addMode = null; }} class="mb-2">← 戻る</Button>
 			<ActivityCreateForm

--- a/src/routes/api/v1/activities/suggest/+server.ts
+++ b/src/routes/api/v1/activities/suggest/+server.ts
@@ -1,8 +1,27 @@
+// src/routes/api/v1/activities/suggest/+server.ts
+// AI 活動提案 API — プランゲート必須 (#727)
+
 import { error, json } from '@sveltejs/kit';
+import { requireTenantId } from '$lib/server/auth/factory';
+import { apiError } from '$lib/server/errors';
 import { suggestActivity } from '$lib/server/services/activity-suggest-service';
+import { isPaidTier, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { RequestHandler } from './$types';
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, locals }) => {
+	// #727: 認証必須 — unauthenticated 呼び出しを完全に遮断
+	const tenantId = requireTenantId(locals);
+
+	// #727: プランゲート — 無料プランは AI 提案を利用不可（コスト流出防止）
+	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
+	if (!isPaidTier(tier)) {
+		return apiError(
+			'PLAN_LIMIT_EXCEEDED',
+			'AI 活動提案はスタンダードプラン以上でご利用いただけます',
+		);
+	}
+
 	const body = await request.json();
 	const text = String(body.text ?? '').trim();
 

--- a/src/routes/api/v1/activities/suggest/+server.ts
+++ b/src/routes/api/v1/activities/suggest/+server.ts
@@ -2,15 +2,17 @@
 // AI 活動提案 API — プランゲート必須 (#727)
 
 import { error, json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { suggestActivity } from '$lib/server/services/activity-suggest-service';
 import { isPaidTier, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	// #727: 認証必須 — unauthenticated 呼び出しを完全に遮断
-	const tenantId = requireTenantId(locals);
+	// #727: 認証必須 — unauthenticated 呼び出しを 401 で即座に拒否
+	if (!locals.context) {
+		throw error(401, { message: 'Unauthorized' });
+	}
+	const tenantId = locals.context.tenantId;
 
 	// #727: プランゲート — 無料プランは AI 提案を利用不可（コスト流出防止）
 	const licenseStatus = locals.context?.licenseStatus ?? 'none';

--- a/tests/unit/routes/activities-suggest-api.test.ts
+++ b/tests/unit/routes/activities-suggest-api.test.ts
@@ -4,14 +4,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // --- モック ---
-const mockRequireTenantId = vi.fn();
 const mockResolveFullPlanTier = vi.fn();
 const mockSuggestActivity = vi.fn();
-
-vi.mock('$lib/server/auth/factory', () => ({
-	requireTenantId: mockRequireTenantId,
-	getAuthMode: vi.fn(() => 'cognito'),
-}));
 
 vi.mock('$lib/server/services/plan-limit-service', async () => {
 	const actual = await vi.importActual<typeof import('$lib/server/services/plan-limit-service')>(
@@ -42,7 +36,7 @@ function makeEvent(
 		headers: { 'Content-Type': 'application/json' },
 		body,
 	});
-	// tenantId: null → context そのものを undefined に（未認証シナリオ）
+	// tenantId: null → context を undefined に（未認証シナリオ）
 	const context =
 		opts.tenantId === null
 			? undefined
@@ -60,18 +54,9 @@ function makeEvent(
 describe('POST /api/v1/activities/suggest', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		mockRequireTenantId.mockImplementation((locals: { context?: { tenantId?: string } }) => {
-			const tid = locals?.context?.tenantId;
-			if (!tid) {
-				const err = new Error('Unauthorized') as Error & { status?: number };
-				err.status = 401;
-				throw err;
-			}
-			return tid;
-		});
 	});
 
-	it('未認証ユーザー（tenantId なし）は 401 を投げる', async () => {
+	it('未認証ユーザー（context なし）は 401 を投げる', async () => {
 		await expect(
 			POST(
 				makeEvent({
@@ -83,7 +68,6 @@ describe('POST /api/v1/activities/suggest', () => {
 	});
 
 	it('無料プランでは PLAN_LIMIT_EXCEEDED 403 を返す', async () => {
-		mockRequireTenantId.mockReturnValue('tenant-1');
 		mockResolveFullPlanTier.mockResolvedValue('free');
 
 		const response = await POST(makeEvent({ text: 'サッカーの練習', licenseStatus: 'none' }));
@@ -96,7 +80,6 @@ describe('POST /api/v1/activities/suggest', () => {
 	});
 
 	it('スタンダードプランでは suggestActivity を実行', async () => {
-		mockRequireTenantId.mockReturnValue('tenant-1');
 		mockResolveFullPlanTier.mockResolvedValue('standard');
 		mockSuggestActivity.mockResolvedValue({
 			name: 'サッカー',
@@ -119,7 +102,6 @@ describe('POST /api/v1/activities/suggest', () => {
 	});
 
 	it('ファミリープランでは suggestActivity を実行', async () => {
-		mockRequireTenantId.mockReturnValue('tenant-1');
 		mockResolveFullPlanTier.mockResolvedValue('family');
 		mockSuggestActivity.mockResolvedValue({
 			name: '公園で走る',
@@ -142,7 +124,6 @@ describe('POST /api/v1/activities/suggest', () => {
 	});
 
 	it('有料プランでもテキスト空は 400', async () => {
-		mockRequireTenantId.mockReturnValue('tenant-1');
 		mockResolveFullPlanTier.mockResolvedValue('standard');
 
 		await expect(
@@ -158,7 +139,6 @@ describe('POST /api/v1/activities/suggest', () => {
 	});
 
 	it('有料プランでも200文字超は 400', async () => {
-		mockRequireTenantId.mockReturnValue('tenant-1');
 		mockResolveFullPlanTier.mockResolvedValue('standard');
 
 		const longText = 'あ'.repeat(201);

--- a/tests/unit/routes/activities-suggest-api.test.ts
+++ b/tests/unit/routes/activities-suggest-api.test.ts
@@ -1,0 +1,176 @@
+// tests/unit/routes/activities-suggest-api.test.ts
+// #727: /api/v1/activities/suggest のプランゲート + 認証チェック
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- モック ---
+const mockRequireTenantId = vi.fn();
+const mockResolveFullPlanTier = vi.fn();
+const mockSuggestActivity = vi.fn();
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: mockRequireTenantId,
+	getAuthMode: vi.fn(() => 'cognito'),
+}));
+
+vi.mock('$lib/server/services/plan-limit-service', async () => {
+	const actual = await vi.importActual<typeof import('$lib/server/services/plan-limit-service')>(
+		'$lib/server/services/plan-limit-service',
+	);
+	return {
+		...actual,
+		resolveFullPlanTier: mockResolveFullPlanTier,
+	};
+});
+
+vi.mock('$lib/server/services/activity-suggest-service', () => ({
+	suggestActivity: mockSuggestActivity,
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const { POST } = await import('../../../src/routes/api/v1/activities/suggest/+server');
+
+function makeEvent(
+	opts: { text?: string; licenseStatus?: string; plan?: string; tenantId?: string | null } = {},
+) {
+	const body = JSON.stringify({ text: opts.text ?? '' });
+	const request = new Request('http://localhost/api/v1/activities/suggest', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body,
+	});
+	// tenantId: null → context そのものを undefined に（未認証シナリオ）
+	const context =
+		opts.tenantId === null
+			? undefined
+			: {
+					licenseStatus: opts.licenseStatus ?? 'none',
+					plan: opts.plan,
+					tenantId: opts.tenantId ?? 'tenant-1',
+				};
+	return {
+		request,
+		locals: { context },
+	} as unknown as Parameters<typeof POST>[0];
+}
+
+describe('POST /api/v1/activities/suggest', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRequireTenantId.mockImplementation((locals: { context?: { tenantId?: string } }) => {
+			const tid = locals?.context?.tenantId;
+			if (!tid) {
+				const err = new Error('Unauthorized') as Error & { status?: number };
+				err.status = 401;
+				throw err;
+			}
+			return tid;
+		});
+	});
+
+	it('未認証ユーザー（tenantId なし）は 401 を投げる', async () => {
+		await expect(
+			POST(
+				makeEvent({
+					text: 'サッカーの練習',
+					tenantId: null,
+				}),
+			),
+		).rejects.toMatchObject({ status: 401 });
+	});
+
+	it('無料プランでは PLAN_LIMIT_EXCEEDED 403 を返す', async () => {
+		mockRequireTenantId.mockReturnValue('tenant-1');
+		mockResolveFullPlanTier.mockResolvedValue('free');
+
+		const response = await POST(makeEvent({ text: 'サッカーの練習', licenseStatus: 'none' }));
+
+		expect(response.status).toBe(403);
+		const body = await response.json();
+		expect(body.error.code).toBe('PLAN_LIMIT_EXCEEDED');
+		// suggestActivity は呼ばれない（コスト流出防止）
+		expect(mockSuggestActivity).not.toHaveBeenCalled();
+	});
+
+	it('スタンダードプランでは suggestActivity を実行', async () => {
+		mockRequireTenantId.mockReturnValue('tenant-1');
+		mockResolveFullPlanTier.mockResolvedValue('standard');
+		mockSuggestActivity.mockResolvedValue({
+			name: 'サッカー',
+			categoryId: 1,
+			icon: '⚽',
+			basePoints: 5,
+			source: 'fallback',
+		});
+
+		const response = await POST(
+			makeEvent({
+				text: 'サッカーの練習',
+				licenseStatus: 'active',
+				plan: 'standard_monthly',
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockSuggestActivity).toHaveBeenCalledWith('サッカーの練習');
+	});
+
+	it('ファミリープランでは suggestActivity を実行', async () => {
+		mockRequireTenantId.mockReturnValue('tenant-1');
+		mockResolveFullPlanTier.mockResolvedValue('family');
+		mockSuggestActivity.mockResolvedValue({
+			name: '公園で走る',
+			categoryId: 1,
+			icon: '🏃',
+			basePoints: 5,
+			source: 'ai',
+		});
+
+		const response = await POST(
+			makeEvent({
+				text: '公園で走った',
+				licenseStatus: 'active',
+				plan: 'family_monthly',
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockSuggestActivity).toHaveBeenCalledWith('公園で走った');
+	});
+
+	it('有料プランでもテキスト空は 400', async () => {
+		mockRequireTenantId.mockReturnValue('tenant-1');
+		mockResolveFullPlanTier.mockResolvedValue('standard');
+
+		await expect(
+			POST(
+				makeEvent({
+					text: '',
+					licenseStatus: 'active',
+					plan: 'standard_monthly',
+				}),
+			),
+		).rejects.toMatchObject({ status: 400 });
+		expect(mockSuggestActivity).not.toHaveBeenCalled();
+	});
+
+	it('有料プランでも200文字超は 400', async () => {
+		mockRequireTenantId.mockReturnValue('tenant-1');
+		mockResolveFullPlanTier.mockResolvedValue('standard');
+
+		const longText = 'あ'.repeat(201);
+		await expect(
+			POST(
+				makeEvent({
+					text: longText,
+					licenseStatus: 'active',
+					plan: 'standard_monthly',
+				}),
+			),
+		).rejects.toMatchObject({ status: 400 });
+		expect(mockSuggestActivity).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（ビリング観点）

**解決する課題**:
AI 活動提案 API `/api/v1/activities/suggest` に**認証もプランチェックもない**ため、
無料プランユーザーどころか unauthenticated なスクリプトからでも Gemini API を
叩き放題になっていた。悪意あるスクリプトで DoS / コスト攻撃が可能。

**期待される効果**:
- 無料プランは AI 提案機能にアクセス不可 → Gemini API コスト流出を遮断
- unauthenticated 呼び出しは 401 で即座に拒否
- 有料プラン誘導動線を明確化

## 関連 Issue

closes #727

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)

**影響を受ける画面・機能**:
- `/api/v1/activities/suggest` API（認証+プランゲート追加）
- `/admin/activities` の「AI でかんたん追加」UI（無料プランで disable + アップグレード CTA）

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | `/api/v1/export` は `requireTenantId` + `resolveFullPlanTier` + `isPaidTier` で 403 apiError を返すパターン済 | 同パターンを suggest に適用 |
| 一貫性 | export はプランゲート済、admin/activities のカスタム活動数制限もプランチェック済 | suggest だけ漏れていた → 統一 |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: なし（最小限の修正に集中）
- **リファクタリングが必要だが今回見送った箇所**: なし
- **削除したコード・機能**: なし

## 設計方針・将来性

**採用した設計方針**:
- サービス層 (`plan-limit-service`) の既存関数 `resolveFullPlanTier` + `isPaidTier` を利用し、プラン判定を一元化
- UI 側は `isPremium` prop で制御 — ページ `+page.server.ts` の `data.isPremium` をそのまま伝播

**想定する将来の拡張**:
- 新しいプラン（例: enterprise）が追加されても `isPaidTier` が `true` を返す限り挙動維持
- スタンダード/ファミリー別の月間コール数リミットは settings テーブル + service 層拡張で追加可能

**意図的に対応しなかった範囲とその理由**:
- テナント単位のレート制限（hooks.server.ts 影響範囲が広いため別 PR）
- E2E テスト（#750 プランゲート E2E 集約チケットに統合予定）
- pricing page への AI 提案機能記載（マーケティング文言調整が必要なため別 Issue）

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加: `tests/unit/routes/activities-suggest-api.test.ts`（6 ケース）
  - 未認証 → 401
  - free プラン → 403 `PLAN_LIMIT_EXCEEDED`（suggestActivity 未呼び出し = コスト発生しない）
  - standard プラン → 200 で suggestActivity 呼び出し
  - family プラン → 200 で suggestActivity 呼び出し
  - 有料プランでもテキスト空は 400
  - 有料プランでも 200 文字超は 400

**E2Eテスト**:
- 追加なし（#750 で集約予定）

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check <修正ファイル>` | PASS | 0 error |
| 型チェック | `npx svelte-check` | PASS | 0 error, 39 warnings (pre-existing) |
| 単体テスト | `npx vitest run tests/unit/routes/activities-suggest-api.test.ts` | PASS | 6 tests passed |

**網羅性の判断根拠**:
- 認証分岐（401）、プラン分岐（403/200）、入力バリデーション分岐（400）の 3 カテゴリをカバー
- `suggestActivity` モックで「プランゲート失敗時は呼び出されない」ことをアサート → コスト流出防止の回帰テストとして機能

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | 認証必須化 + プランゲート追加 | **unauthenticated 経路の完全遮断**が本 PR のコア価値 |
| パフォーマンス | 影響軽微 | `resolveFullPlanTier` は settings 1 クエリ程度 |
| ロギング | `apiError` が warn ログを出力 | 既存機構を利用 |

## スクリーンショット / ビジュアルデモ

UI は `AiSuggestPanel.svelte` の無料プラン時の disable 表示追加。無料プランアカウントがローカルに無いため、スクショは別途 Ready 化前に追加予定（E2E 環境で撮影）。

## 実機操作検証

- [ ] 対象画面をブラウザで開き、修正箇所が期待通りに表示されることを目視確認（Ready 化前に追加）

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

Note: 無料プランユーザーには従来 AI 提案が「動いていた」ため、機能観点では無料プランで使えなくなる変更。ただし **本来有料機能として設計されるべき** もので、Issue #727 で明示的に指摘されたビリング脆弱性の修正。

## レビュー依頼事項・QA

| # | 質問・確認事項 | 選択肢A | 選択肢B | 推奨 | 理由 |
|---|--------------|---------|---------|------|------|
| 1 | 無料プランの UI 表示 | 入力欄を非表示 | disable + CTA 表示 | B（採用済） | アップグレード誘導を優先 |

## 横展開・影響波及チェック

### 並行実装影響確認

- [x] **本番アプリ** — 対応済（`src/routes/(parent)/admin/activities/+page.svelte` + AiSuggestPanel）
- [x] **デモ版** — AI 提案 UI は本番のみ（`src/routes/demo` に AiSuggestPanel 参照なし確認済）
- [x] **該当なし** — LP/年齢モード/ナビ/シード/チュートリアルは影響なし

### その他

- [x] **カラー・スタイル**: hex 直書きなし、既存 `--color-premium-*` トークン使用
- [x] **プリミティブ**: 既存 Button を `/admin/license` リンクとして `<a>` タグ + 同等クラスで表現（プリミティブ `Button` は `onclick` ハンドラ前提のため、ここでは `href` 誘導の `<a>` を採用）

## Ready for Review チェックリスト

- [ ] CI が全て通過している
- [x] セルフレビュー済み
- [ ] UI変更のスクリーンショット添付（Ready 化前）

## Critical 修正の追加要件

- [ ] E2E 回帰テスト（#750 に集約予定）
- [x] Issue の Acceptance Criteria のうち本 PR スコープ分は全て対応:
  - [x] 無料プランで /api/v1/activities/suggest が 403
  - [x] AiSuggestPanel が disable 表示 + アップグレード誘導
  - [ ] 毎分 N 回を超えたら 429（レート制限は別 PR）
  - [ ] E2E free/standard/family 挙動検証（#750 集約）
  - [ ] 06-UI 設計書に AI 提案プランゲート記載（フォローアップ Issue 化予定）
  - [ ] 07-API 設計書レート制限仕様追記（レート制限 PR で対応）
- [x] Issue 「提案」の対策のうち未実装分（レート制限、設計書更新、pricing page 記載）は別 Issue に切り出し予定

## 完了チェックリスト

- [x] `npx biome check` — lint エラーなし（修正ファイルのみ確認）
- [x] `npx svelte-check` — 型エラーなし
- [x] `npx vitest run tests/unit/routes/activities-suggest-api.test.ts` — 6/6 PASS
- [ ] `npx playwright test` — （別 PR で実施）
- [x] PR サイズ適切（4 ファイル / 227 行）