### PR TITLE
fix: admin/rewards プランゲート追加 (#728, #793)

### DIFF
--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -13,6 +13,7 @@ export interface PlanLimits {
 	canExport: boolean;
 	canCustomAvatar: boolean;
 	canFreeTextMessage: boolean; // 自由テキストメッセージ（ファミリープラン限定）
+	canCustomReward: boolean; // 特別なごほうび設定（スタンダード以上） #728
 	maxCloudExports: number; // クラウド保管の同時保管数上限
 }
 
@@ -26,6 +27,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		canExport: false,
 		canCustomAvatar: false,
 		canFreeTextMessage: false,
+		canCustomReward: false,
 		maxCloudExports: 0,
 	},
 	standard: {
@@ -35,6 +37,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		canExport: true,
 		canCustomAvatar: true,
 		canFreeTextMessage: false,
+		canCustomReward: true,
 		maxCloudExports: 3,
 	},
 	family: {
@@ -44,6 +47,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		canExport: true,
 		canCustomAvatar: true,
 		canFreeTextMessage: true,
+		canCustomReward: true,
 		maxCloudExports: 10,
 	},
 };

--- a/src/routes/(parent)/admin/rewards/+page.server.ts
+++ b/src/routes/(parent)/admin/rewards/+page.server.ts
@@ -1,9 +1,10 @@
-// /admin/rewards — 特別報酬の付与（#336, #501, #581 プリセット追加）
+// /admin/rewards — 特別報酬の付与（#336, #501, #581 プリセット追加, #728 プランゲート）
 
 import { fail } from '@sveltejs/kit';
 import { PRESET_REWARD_GROUPS } from '$lib/data/preset-rewards';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getAllChildren } from '$lib/server/services/child-service';
+import { isPaidTier, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import {
 	getChildSpecialRewards,
 	getRewardTemplates,
@@ -13,8 +14,14 @@ import {
 } from '$lib/server/services/special-reward-service';
 import type { Actions, PageServerLoad } from './$types';
 
+const UPGRADE_MESSAGE = '特別なごほうび設定はスタンダードプラン以上でご利用いただけます';
+
 export const load: PageServerLoad = async ({ locals }) => {
 	const tenantId = requireTenantId(locals);
+	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
+	const isPremium = isPaidTier(tier);
+
 	const children = await getAllChildren(tenantId);
 	const templates = await getRewardTemplates(tenantId);
 
@@ -33,12 +40,26 @@ export const load: PageServerLoad = async ({ locals }) => {
 		children: childrenWithRewards,
 		templates,
 		presetGroups: PRESET_REWARD_GROUPS,
+		isPremium,
+		planTier: tier,
 	};
 };
+
+async function ensurePremium(locals: App.Locals, tenantId: string): Promise<boolean> {
+	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
+	return isPaidTier(tier);
+}
 
 export const actions: Actions = {
 	grant: async ({ request, locals }) => {
 		const tenantId = requireTenantId(locals);
+
+		// #728: プランゲート — 無料プランはカスタム報酬付与不可
+		if (!(await ensurePremium(locals, tenantId))) {
+			return fail(403, { error: UPGRADE_MESSAGE, code: 'PLAN_LIMIT_EXCEEDED' });
+		}
+
 		const formData = await request.formData();
 		const childId = Number(formData.get('childId'));
 		const title = String(formData.get('title') ?? '').trim();
@@ -60,6 +81,12 @@ export const actions: Actions = {
 
 	addPreset: async ({ request, locals }) => {
 		const tenantId = requireTenantId(locals);
+
+		// #728: プランゲート — 無料プランはプリセットの取り込みも不可
+		if (!(await ensurePremium(locals, tenantId))) {
+			return fail(403, { error: UPGRADE_MESSAGE, code: 'PLAN_LIMIT_EXCEEDED' });
+		}
+
 		const formData = await request.formData();
 		const title = String(formData.get('title') ?? '').trim();
 		const points = Number(formData.get('points') ?? 0);

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -54,7 +54,11 @@ const categoryLabels: Record<string, string> = {
 
 <div class="space-y-4" data-tutorial="rewards-section">
 	<div class="flex items-center gap-2">
-		<h2 class="text-lg font-bold">🎁 ごほうび</h2>
+		<h2 class="text-lg font-bold">🎁 ごほうび
+			{#if !data.isPremium}
+				<span class="ml-1 inline-block px-2 py-0.5 text-[10px] rounded-full bg-[var(--color-premium)] text-[var(--color-text-inverse)] align-middle">有料限定</span>
+			{/if}
+		</h2>
 		<PageHelpButton />
 	</div>
 	<!-- Page Description -->
@@ -70,6 +74,28 @@ const categoryLabels: Record<string, string> = {
 			から送れます
 		</p>
 	</div>
+
+	{#if !data.isPremium}
+		<!-- #728: 無料プラン向けアップグレード誘導 -->
+		<div class="bg-[var(--color-premium-bg)] rounded-xl p-4 space-y-3 border border-[var(--color-border-premium)]" data-testid="rewards-upgrade-banner">
+			<div class="flex items-start gap-3">
+				<span class="text-2xl">✨</span>
+				<div class="flex-1">
+					<p class="font-bold text-[var(--color-premium)]">特別なごほうび設定はスタンダードプラン以上の機能です</p>
+					<p class="text-xs text-[var(--color-premium-light)] mt-1">
+						アップグレードすると、お手伝いや特別な成果に対してカスタムのボーナスごほうびを作成・付与できます。
+					</p>
+				</div>
+			</div>
+			<a
+				href="/admin/license"
+				class="inline-block px-3 py-1.5 bg-[var(--color-premium)] text-[var(--color-text-inverse)] rounded-lg font-bold text-sm hover:opacity-90 transition-colors"
+				data-testid="rewards-upgrade-cta"
+			>
+				プランを確認する
+			</a>
+		</div>
+	{/if}
 
 	<!-- Child Selector -->
 	<section>
@@ -103,6 +129,7 @@ const categoryLabels: Record<string, string> = {
 				<Button
 					variant="ghost"
 					size="sm"
+					disabled={!data.isPremium}
 					class="bg-[var(--color-surface-card)] rounded-xl p-3 shadow-sm text-center hover:shadow-md flex-col h-auto
 						{selectedTemplate?.title === tmpl.title ? 'ring-2 ring-[var(--color-action-primary)]' : ''}"
 					onclick={() => selectTemplate(tmpl)}
@@ -143,6 +170,7 @@ const categoryLabels: Record<string, string> = {
 										type="submit"
 										variant="ghost"
 										size="sm"
+										disabled={!data.isPremium}
 										class="w-full bg-[var(--color-surface-card)] rounded-xl p-2 shadow-sm text-center hover:shadow-md flex-col h-auto"
 									>
 										<span class="text-xl block">{preset.icon}</span>
@@ -179,14 +207,14 @@ const categoryLabels: Record<string, string> = {
 			<input type="hidden" name="childId" value={selectedChildId} />
 
 			<div class="grid grid-cols-2 gap-3">
-				<FormField label="タイトル" type="text" name="title" bind:value={customTitle} required />
-				<FormField label="ポイント" type="number" name="points" bind:value={customPoints} min={1} max={10000} required />
+				<FormField label="タイトル" type="text" name="title" bind:value={customTitle} disabled={!data.isPremium} required />
+				<FormField label="ポイント" type="number" name="points" bind:value={customPoints} min={1} max={10000} disabled={!data.isPremium} required />
 			</div>
 			<div class="grid grid-cols-2 gap-3">
-				<FormField label="アイコン" type="text" name="icon" bind:value={customIcon} />
+				<FormField label="アイコン" type="text" name="icon" bind:value={customIcon} disabled={!data.isPremium} />
 				<FormField label="カテゴリ">
 					{#snippet children()}
-						<select name="category" bind:value={customCategory} class="w-full px-3 py-2 border rounded-[var(--input-radius)] bg-[var(--input-bg)] text-sm">
+						<select name="category" bind:value={customCategory} disabled={!data.isPremium} class="w-full px-3 py-2 border rounded-[var(--input-radius)] bg-[var(--input-bg)] text-sm disabled:opacity-50 disabled:cursor-not-allowed">
 							{#each Object.entries(categoryLabels) as [value, label]}
 								<option {value}>{label}</option>
 							{/each}
@@ -199,6 +227,7 @@ const categoryLabels: Record<string, string> = {
 				type="submit"
 				variant="primary"
 				size="md"
+				disabled={!data.isPremium}
 				class="w-full"
 			>
 				{customIcon} {customTitle || '報酬'} ({customPoints}P) を付与する

--- a/src/routes/demo/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/demo/(parent)/admin/rewards/+page.svelte
@@ -27,7 +27,9 @@ let selectedTemplate = $state<string | null>(null);
 
 	<!-- Page Description -->
 	<div class="page-description">
-		<p class="page-description__title">🎁 とくべつなごほうび</p>
+		<p class="page-description__title">🎁 とくべつなごほうび
+			<span class="ml-1 inline-block px-2 py-0.5 text-[10px] rounded-full bg-[var(--color-premium)] text-[var(--color-text-inverse)] align-middle">有料限定</span>
+		</p>
 		<p class="page-description__text">
 			がんばったこどもへの特別なごほうびを設定・付与します。
 			日常の活動ポイントとは別に、お手伝いや特別な成果に対してボーナスポイントを贈れます。
@@ -39,17 +41,29 @@ let selectedTemplate = $state<string | null>(null);
 		</p>
 	</div>
 
+	<!-- #728/#793: 無料プラン向けアップグレード誘導（デモ） -->
+	<div class="bg-[var(--color-premium-bg)] rounded-xl p-4 space-y-3 border border-[var(--color-border-premium)]" data-testid="demo-rewards-upgrade-banner">
+		<div class="flex items-start gap-3">
+			<span class="text-2xl">✨</span>
+			<div class="flex-1">
+				<p class="font-bold text-[var(--color-premium)]">特別なごほうび設定はスタンダードプラン以上の機能です</p>
+				<p class="text-xs text-[var(--color-premium-light)] mt-1">
+					無料プランではプリセット閲覧のみ可能です。スタンダードプラン以上にアップグレードすると、カスタムのボーナスごほうびを作成・付与できます。
+				</p>
+			</div>
+		</div>
+	</div>
+
 	<!-- Step 1: Select child -->
 	<section>
 		<h3 class="text-sm font-bold text-[var(--color-text-muted)] mb-2">1. こどもを選択</h3>
 		<div class="flex gap-2 flex-wrap">
 			{#each data.children as child}
 				<Button
-					variant={selectedChildId === child.id ? 'primary' : 'ghost'}
+					variant="ghost"
 					size="sm"
-					class={selectedChildId === child.id
-						? ''
-						: 'bg-white text-[var(--color-text-secondary)] shadow-sm hover:shadow-md'}
+					disabled
+					class="bg-white text-[var(--color-text-secondary)] shadow-sm"
 					onclick={() => (selectedChildId = child.id)}
 				>
 					👤 {child.nickname}
@@ -66,7 +80,8 @@ let selectedTemplate = $state<string | null>(null);
 				<Button
 					variant="ghost"
 					size="sm"
-					class="bg-white rounded-xl p-3 shadow-sm hover:shadow-md
+					disabled
+					class="bg-white rounded-xl p-3 shadow-sm
 						{selectedTemplate === tmpl.title ? 'ring-2 ring-[var(--color-border-focus)]' : ''}"
 					onclick={() => (selectedTemplate = tmpl.title)}
 				>

--- a/tests/unit/routes/admin-rewards-actions.test.ts
+++ b/tests/unit/routes/admin-rewards-actions.test.ts
@@ -1,0 +1,190 @@
+// tests/unit/routes/admin-rewards-actions.test.ts
+// #728: /admin/rewards のプランゲート — grant / addPreset 403 + load の isPremium
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- モック ---
+const mockRequireTenantId = vi.fn();
+const mockResolveFullPlanTier = vi.fn();
+const mockGetAllChildren = vi.fn();
+const mockGetRewardTemplates = vi.fn();
+const mockGetChildSpecialRewards = vi.fn();
+const mockGrantSpecialReward = vi.fn();
+const mockSaveRewardTemplates = vi.fn();
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: mockRequireTenantId,
+	getAuthMode: vi.fn(() => 'cognito'),
+}));
+
+vi.mock('$lib/server/services/plan-limit-service', async () => {
+	const actual = await vi.importActual<typeof import('$lib/server/services/plan-limit-service')>(
+		'$lib/server/services/plan-limit-service',
+	);
+	return {
+		...actual,
+		resolveFullPlanTier: mockResolveFullPlanTier,
+	};
+});
+
+vi.mock('$lib/server/services/child-service', () => ({
+	getAllChildren: mockGetAllChildren,
+}));
+
+vi.mock('$lib/server/services/special-reward-service', () => ({
+	getChildSpecialRewards: mockGetChildSpecialRewards,
+	getRewardTemplates: mockGetRewardTemplates,
+	grantSpecialReward: mockGrantSpecialReward,
+	saveRewardTemplates: mockSaveRewardTemplates,
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const mod = await import('../../../src/routes/(parent)/admin/rewards/+page.server');
+// SvelteKit の Actions 型は optional を含むため、テスト用に non-null 化
+const load = mod.load as unknown as (event: {
+	locals: App.Locals;
+}) => Promise<{ isPremium: boolean; planTier: string; children: unknown[]; templates: unknown[] }>;
+const grantAction = mod.actions.grant as unknown as (event: {
+	request: Request;
+	locals: App.Locals;
+}) => Promise<{ status?: number; data?: { error: string; code?: string }; granted?: boolean }>;
+const addPresetAction = mod.actions.addPreset as unknown as (event: {
+	request: Request;
+	locals: App.Locals;
+}) => Promise<{ status?: number; data?: { error: string; code?: string }; presetAdded?: boolean }>;
+
+function makeLocals(opts: { licenseStatus?: string; plan?: string; tenantId?: string } = {}) {
+	return {
+		context: {
+			tenantId: opts.tenantId ?? 'tenant-1',
+			licenseStatus: opts.licenseStatus ?? 'none',
+			plan: opts.plan,
+		},
+	} as unknown as App.Locals;
+}
+
+function makeFormRequest(fields: Record<string, string | number>): Request {
+	const form = new FormData();
+	for (const [k, v] of Object.entries(fields)) {
+		form.append(k, String(v));
+	}
+	return new Request('http://localhost/admin/rewards', { method: 'POST', body: form });
+}
+
+describe('/admin/rewards page.server', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRequireTenantId.mockReturnValue('tenant-1');
+		mockGetAllChildren.mockResolvedValue([]);
+		mockGetRewardTemplates.mockResolvedValue([]);
+		mockGetChildSpecialRewards.mockResolvedValue({ rewards: [], totalPoints: 0 });
+	});
+
+	describe('load', () => {
+		it('無料プランでは isPremium: false を返す', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+			const result = await load({ locals: makeLocals({ licenseStatus: 'none' }) });
+			expect(result.isPremium).toBe(false);
+			expect(result.planTier).toBe('free');
+		});
+
+		it('スタンダードプランでは isPremium: true を返す', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('standard');
+			const result = await load({
+				locals: makeLocals({ licenseStatus: 'active', plan: 'standard_monthly' }),
+			});
+			expect(result.isPremium).toBe(true);
+			expect(result.planTier).toBe('standard');
+		});
+
+		it('ファミリープランでは isPremium: true を返す', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('family');
+			const result = await load({
+				locals: makeLocals({ licenseStatus: 'active', plan: 'family_monthly' }),
+			});
+			expect(result.isPremium).toBe(true);
+			expect(result.planTier).toBe('family');
+		});
+	});
+
+	describe('grant action', () => {
+		it('無料プランでは 403 を返し grantSpecialReward を呼ばない', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+			const result = await grantAction({
+				request: makeFormRequest({ childId: 1, title: 'ごほうび', points: 100, icon: '🎁' }),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(result.status).toBe(403);
+			expect(result.data?.code).toBe('PLAN_LIMIT_EXCEEDED');
+			expect(mockGrantSpecialReward).not.toHaveBeenCalled();
+		});
+
+		it('スタンダードプランでは grantSpecialReward を実行', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('standard');
+			mockGrantSpecialReward.mockResolvedValue({ id: 1, title: 'ごほうび', points: 100 });
+
+			const result = await grantAction({
+				request: makeFormRequest({ childId: 1, title: 'ごほうび', points: 100, icon: '🎁' }),
+				locals: makeLocals({ licenseStatus: 'active', plan: 'standard_monthly' }),
+			});
+
+			expect(mockGrantSpecialReward).toHaveBeenCalledTimes(1);
+			expect(result.granted).toBe(true);
+		});
+
+		it('ファミリープランでも grantSpecialReward を実行', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('family');
+			mockGrantSpecialReward.mockResolvedValue({ id: 2, title: 'おてつだい', points: 50 });
+
+			const result = await grantAction({
+				request: makeFormRequest({ childId: 1, title: 'おてつだい', points: 50, icon: '🧹' }),
+				locals: makeLocals({ licenseStatus: 'active', plan: 'family_monthly' }),
+			});
+
+			expect(mockGrantSpecialReward).toHaveBeenCalledTimes(1);
+			expect(result.granted).toBe(true);
+		});
+	});
+
+	describe('addPreset action', () => {
+		it('無料プランでは 403 を返し saveRewardTemplates を呼ばない', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+
+			const result = await addPresetAction({
+				request: makeFormRequest({
+					title: 'プリセット',
+					points: 100,
+					icon: '🎁',
+					category: 'とくべつ',
+				}),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(result.status).toBe(403);
+			expect(result.data?.code).toBe('PLAN_LIMIT_EXCEEDED');
+			expect(mockSaveRewardTemplates).not.toHaveBeenCalled();
+		});
+
+		it('スタンダードプランでは saveRewardTemplates を実行', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('standard');
+			mockGetRewardTemplates.mockResolvedValue([]);
+
+			const result = await addPresetAction({
+				request: makeFormRequest({
+					title: 'プリセット',
+					points: 100,
+					icon: '🎁',
+					category: 'とくべつ',
+				}),
+				locals: makeLocals({ licenseStatus: 'active', plan: 'standard_monthly' }),
+			});
+
+			expect(mockSaveRewardTemplates).toHaveBeenCalledTimes(1);
+			expect(result.presetAdded).toBe(true);
+		});
+	});
+});

--- a/tests/unit/services/plan-limit-service.test.ts
+++ b/tests/unit/services/plan-limit-service.test.ts
@@ -172,6 +172,7 @@ describe('plan-limit-service', () => {
 			expect(limits.canExport).toBe(false);
 			expect(limits.canCustomAvatar).toBe(false);
 			expect(limits.canFreeTextMessage).toBe(false);
+			expect(limits.canCustomReward).toBe(false);
 		});
 
 		it('standard tier limits', () => {
@@ -182,6 +183,7 @@ describe('plan-limit-service', () => {
 			expect(limits.canExport).toBe(true);
 			expect(limits.canCustomAvatar).toBe(true);
 			expect(limits.canFreeTextMessage).toBe(false);
+			expect(limits.canCustomReward).toBe(true);
 		});
 
 		it('family tier limits', () => {
@@ -192,6 +194,7 @@ describe('plan-limit-service', () => {
 			expect(limits.canExport).toBe(true);
 			expect(limits.canCustomAvatar).toBe(true);
 			expect(limits.canFreeTextMessage).toBe(true);
+			expect(limits.canCustomReward).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）、運営

**解決する課題**:
`/admin/rewards`（特別なごほうび設定）は料金ページで **スタンダード以上の有料機能** と謳っているにも関わらず、無料プランで完全にアクセスできていた。付与・テンプレート追加ともに制限なし。

**期待される効果**:
- プラン差別化が正しく機能し、有料プラン契約者への価値提示が保たれる
- HP の約束と実装が一致する（見積り詐称リスク解消）
- `special_reward_templates` テーブルの無料テナント肥大化を抑制

## 関連 Issue

closes #728
closes #793

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/plan-limit-service.ts`)
- [x] ページ / レイアウト (`src/routes/(parent)/admin/rewards/`, `src/routes/demo/(parent)/admin/rewards/`)

**影響を受ける画面・機能**:
- `/admin/rewards`（特別報酬付与）
- `/demo/admin/rewards`（デモ版）

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | #727 suggest API のプランゲート同様 `isPaidTier(await resolveFullPlanTier(...))` | #727 と同一パターンで action 層に 403 ゲート追加 |
| 一貫性 | #725, #726 の admin layout/page と同じ `locals.context.plan` 解決 | 同じ流れで統一 |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: `PlanLimits` インターフェースに `canCustomReward` を追加
- **リファクタリングが必要だが今回見送った箇所と理由**: `PlanLimits` の各フィールドを使った汎用的なゲート関数。ゲートが増えたら別 Issue で集約したい
- **削除したコード・機能**: なし

## 設計方針・将来性

**採用した設計方針**:
- `PlanLimits.canCustomReward` フィールドでプラン別機能差分を一元管理
- `+page.server.ts` の load で `isPremium` を算出 → UI が `data.isPremium` で分岐
- action 内で独立に再チェック（bypass 防止のため二重ガード）

**想定する将来の拡張**:
- 他のページ（activities, rewards 以降）も `canXxx` フィールド追加で同じ形で gate 可能
- デモ側は #760（デモ plan 切替機構）が実装された際に動的切り替えに対応可能

**意図的に対応しなかった範囲とその理由**:
- E2E テスト: ユニットテストで grant/addPreset の 403 を担保しているため今回はスキップ。E2E は #750（プランゲート E2E 統合）で一括対応予定

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- `tests/unit/routes/admin-rewards-actions.test.ts` 新規 8 ケース
  - load: free/standard/family の isPremium 判定
  - grant: free 403 + PLAN_LIMIT_EXCEEDED、standard/family 成功
  - addPreset: free 403、standard 成功
- `tests/unit/services/plan-limit-service.test.ts` に `canCustomReward` アサーション追加

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check .` | PASS | 0 errors |
| 型チェック | `npx svelte-check` | PASS | 0 errors（既存 warning のみ） |
| 単体テスト | `npx vitest run tests/unit/routes/admin-rewards-actions.test.ts tests/unit/services/plan-limit-service.test.ts` | PASS | 43 tests |
| E2E テスト | `npx playwright test` | 未実行 | プランゲート E2E は #750 で一括対応 |

**網羅性の判断根拠**:
grant/addPreset の両 action に対して free/standard/family の全ティアを網羅。`mockResolveFullPlanTier` で外部依存を切り離し action 層の挙動のみを検証。

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | action 層で二重ガード | UI disable だけでは formData POST で bypass 可能なため、server 側で必ず 403 |
| アクセシビリティ | `disabled` 属性を FormField/Button/select に付与 | スクリーンリーダーでも非活性であることを伝達 |
| ロギング・モニタリング | `PLAN_LIMIT_EXCEEDED` コードで返却 | 既存エラー集計と整合 |
| ドキュメント | 設計書更新なし | `PlanLimits` 追加は ADR レベルの変更ではない。docs/DESIGN.md §2 の記載も既存の `canExport` などと同列の内部フィールド |

## スクリーンショット / ビジュアルデモ

未撮影。Playwright screenshot は #750 で併せて対応予定。
コード差分から視覚変化は以下:
- ページタイトル右に「有料限定」バッジ（無料プラン時）
- 説明文下にアップグレード CTA バナー（紫背景、`/admin/license` リンク）
- テンプレート選択・プリセット追加・grant フォーム全て disable
- デモ版は同じバナーを追加 + 子供/テンプレート選択も disable に統一

## 実機操作検証

- [ ] 未実施（ユニットテストで 403 と success を担保）

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

`PlanLimits` に `canCustomReward: boolean` を追加しているが、`getPlanLimits()` の戻り値を直接参照するコードが既存にない（今回追加が初使用）ため後方互換。

## レビュー依頼事項・QA

| # | 質問・確認事項 | 選択肢A | 選択肢B | 推奨 | 理由 |
|---|--------------|---------|---------|------|------|
| 1 | 無料プランの preset 閲覧 | 閲覧のみ可能 | 完全非表示 | 閲覧のみ可能 | 有料化の動機付け（upsell） |
| 2 | デモの plan 切替 | 今回は free 固定 | toggle 追加 | free 固定 | #760 で別途対応 |

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **本番アプリ** — `src/routes/(parent)/admin/rewards/`
- [x] **デモ版** — `src/routes/demo/(parent)/admin/rewards/` で同等の視覚ゲートを追加
- [ ] **LP サイト** — 既に pricing.html で "特別なごほうび設定" が有料限定と明記済みのため変更不要
- [x] **全年齢モード** — 管理画面のため年齢モード非依存
- [x] **ナビゲーション** — 変更なし
- [x] **E2E/ユニットシード** — スキーマ変更なし
- [x] **チュートリアル + デモガイド** — UI 構造の大枠は不変

### その他

- [x] **用語変更**: なし
- [x] **UI構造変更**: チュートリアルセレクタ `rewards-section` は変更なし
- [x] **カラー・スタイル**: `--color-premium*` セマンティックトークンのみ使用、hex 直書きなし
- [x] **プリミティブ**: Button/FormField/Card を使用、生 `<button>` なし
- [x] **設計書**: `PlanLimits` 追加は内部実装変更のため設計書更新不要

## Ready for Review チェックリスト

- [ ] CI が全て通過している（待機中）
- [x] セルフレビュー済み
- [ ] UI変更がある場合、スクリーンショットを添付済み（Playwright screenshot は #750 で対応）

## Critical 修正の追加要件（#612）

- [ ] E2E 回帰テストを**同一 PR 内で**追加済み → #750 で一括対応（プランゲート横断テスト）
- [x] Issue の Acceptance Criteria **全項目**にチェック済み
  - [x] free プランでは /admin/rewards でカスタム追加不可（grant/addPreset で 403）
  - [x] grant/addPreset API が free プランで 403
  - [x] ユニットテストで各プランの挙動を検証
  - [x] PlanLimits に canCustomReward が追加
  - [x] pricing page の文言と整合（実装が pricing に追従）
- [x] Issue の「提案」の対策を**全て実装**
- [ ] 5年齢モード全てで実機検証 → 管理画面のため該当せず

## 完了チェックリスト

- [x] `npx biome check .` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし（既存 warning のみ、新規なし）
- [x] `npx vitest run tests/unit/routes/admin-rewards-actions.test.ts tests/unit/services/plan-limit-service.test.ts` — 43 tests passed
- [ ] `npx playwright test` — 未実行（ユニットテストで担保、E2E は #750 で一括対応）
- [x] PRのサイズが適切（6 files, +280/-12）