### PR TITLE
feat(dx): #758 DEBUG_PLAN env で開発中のプラン/トライアル状態を切替

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,26 @@ PORT=3000
 # DynamoDB business events (app-specific event logging)
 # ANALYTICS_ENABLED=true
 # ANALYTICS_TABLE_NAME=ganbari-analytics
+
+# ===================================================
+# DEBUG: Plan / Trial Override (#758, dev only)
+# ===================================================
+# Dev モード (`npm run dev`) かつ下記 env が設定されている時のみ
+# locals.context.plan / licenseStatus / trial 状態を上書きする。
+# 本番ビルド (dev=false) では一切無効。E2E / 手動検証で free/standard/family
+# の画面を切り替えるために使用する。
+#
+# DEBUG_PLAN: free | standard | family
+#   - free     → licenseStatus=none,   plan=undefined
+#   - standard → licenseStatus=active, plan=monthly
+#   - family   → licenseStatus=active, plan=family-monthly
+# DEBUG_PLAN=standard
+#
+# DEBUG_TRIAL: active | expired | not-started
+#   - active      → getTrialEndDate は 7 日後を返す (DEBUG_TRIAL_TIER 適用)
+#   - expired     → getTrialEndDate は null
+#   - not-started → getTrialEndDate は null
+# DEBUG_TRIAL=active
+#
+# DEBUG_TRIAL_TIER: standard | family （DEBUG_TRIAL=active のとき使用）
+# DEBUG_TRIAL_TIER=standard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,19 @@ SvelteKit 2 + Svelte 5 (Runes) + Ark UI Svelte + SQLite + Drizzle ORM。TypeScri
 - Lint: `npx biome check .`
 - DB マイグレーション: `npx drizzle-kit push`
 
+### 開発中のプラン切替（#758、dev only）
+
+`npm run dev` 実行時に `.env.local`（またはシェル env）で以下を設定すると、
+`locals.context.plan` / `licenseStatus` / トライアル状態を上書きできる。
+**本番ビルドでは無効**（`dev === false` でガード）。
+
+- `DEBUG_PLAN=free|standard|family` — プランを直接指定
+- `DEBUG_TRIAL=active|expired|not-started` — トライアル状態を上書き
+- `DEBUG_TRIAL_TIER=standard|family` — `DEBUG_TRIAL=active` 時のティア
+
+admin 画面右下に「DEBUG: plan=family」等のインジケータが表示される。
+詳細は `.env.example` および `src/lib/server/debug-plan.ts` を参照。
+
 ### コミット前チェック（必須）
 
 1. `npx biome check .` — lint エラーなし

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ ganbari-quest/
 | `ORIGIN` | No | アプリのURL |
 | `GEMINI_API_KEY` | No | アバター画像AI生成用 |
 | `GDRIVE_*` | No | Google Driveバックアップ用 |
+| `DEBUG_PLAN` | No | **dev only** — `free`/`standard`/`family` でプランを上書き (#758) |
+| `DEBUG_TRIAL` | No | **dev only** — `active`/`expired`/`not-started` でトライアル状態を上書き |
+| `DEBUG_TRIAL_TIER` | No | **dev only** — `standard`/`family` でトライアルティア指定 |
 
 ## 開発コマンド
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -229,11 +229,14 @@ export const handle: Handle = async ({ event, resolve }) => {
 	}
 
 	const identity = await provider.resolveIdentity(event);
-	const context = await provider.resolveContext(event, identity);
+	const resolvedContext = await provider.resolveContext(event, identity);
+	// DEBUG_PLAN / DEBUG_TRIAL による上書きは、以降の認可・tenantStatus チェックにも
+	// 一貫して適用する必要があるため、ローカル変数 context 自体を上書き後の値で統一する。
+	const context = applyDebugPlanOverride(resolvedContext);
 
 	event.locals.authenticated = identity !== null;
 	event.locals.identity = identity;
-	event.locals.context = applyDebugPlanOverride(context);
+	event.locals.context = context;
 
 	// 2) ルート保護
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { type Handle, type HandleServerError, redirect } from '@sveltejs/kit';
 import { analytics } from '$lib/analytics';
 import { getAuthMode, getAuthProvider } from '$lib/server/auth/factory';
+import { applyDebugPlanOverride } from '$lib/server/debug-plan';
 import { sendDiscordAlert } from '$lib/server/discord-alert';
 import { logger } from '$lib/server/logger';
 import { findLegacyRedirect, rewriteLegacyPath } from '$lib/server/routing/legacy-url-map';
@@ -212,11 +213,11 @@ export const handle: Handle = async ({ event, resolve }) => {
 	if (path.startsWith('/demo')) {
 		event.locals.authenticated = false;
 		event.locals.identity = null;
-		event.locals.context = {
+		event.locals.context = applyDebugPlanOverride({
 			tenantId: 'demo',
 			role: 'owner',
 			licenseStatus: 'active',
-		};
+		});
 		const response = await resolve(event);
 		if (!path.startsWith('/_app/') && !path.startsWith('/favicon')) {
 			logger.request(event.request.method, path, response.status, Date.now() - start, {
@@ -232,7 +233,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	event.locals.authenticated = identity !== null;
 	event.locals.identity = identity;
-	event.locals.context = context;
+	event.locals.context = applyDebugPlanOverride(context);
 
 	// 2) ルート保護
 

--- a/src/lib/server/debug-plan.ts
+++ b/src/lib/server/debug-plan.ts
@@ -1,0 +1,139 @@
+// src/lib/server/debug-plan.ts
+// 開発モード専用 — プラン / トライアル状態を環境変数で上書きするデバッグ機構 (#758)
+//
+// ローカル開発・Playwright E2E で「free / standard / family」「trial 各状態」を
+// 切り替えて動作確認するために使う。`dev === true` かつ env が設定されている
+// 場合にのみ有効。本番 (`dev === false`) では常に無効。
+
+import { dev } from '$app/environment';
+import type { AuthContext } from '$lib/server/auth/types';
+import type { TrialTier } from '$lib/server/services/trial-service';
+
+/** 許容される DEBUG_PLAN 値 */
+export type DebugPlan = 'free' | 'standard' | 'family';
+
+/** 許容される DEBUG_TRIAL 値 */
+export type DebugTrial = 'active' | 'expired' | 'not-started';
+
+export interface DebugPlanOverride {
+	licenseStatus: AuthContext['licenseStatus'];
+	plan?: string;
+}
+
+export interface DebugTrialOverride {
+	endDate: string | null;
+	tier: TrialTier | null;
+}
+
+const VALID_PLANS: ReadonlySet<string> = new Set(['free', 'standard', 'family']);
+const VALID_TRIALS: ReadonlySet<string> = new Set(['active', 'expired', 'not-started']);
+const VALID_TRIAL_TIERS: ReadonlySet<string> = new Set(['standard', 'family']);
+
+/**
+ * DEBUG_PLAN env に基づくプラン上書きを返す。
+ * dev モードでない、または env 未設定の場合は null。
+ */
+export function getDebugPlanOverride(): DebugPlanOverride | null {
+	if (!dev) return null;
+	const raw = process.env.DEBUG_PLAN?.trim().toLowerCase();
+	if (!raw) return null;
+	if (!VALID_PLANS.has(raw)) {
+		console.warn(
+			`[debug-plan] DEBUG_PLAN="${raw}" is invalid. Expected one of: free, standard, family`,
+		);
+		return null;
+	}
+	switch (raw as DebugPlan) {
+		case 'free':
+			return { licenseStatus: 'none', plan: undefined };
+		case 'standard':
+			return { licenseStatus: 'active', plan: 'monthly' };
+		case 'family':
+			return { licenseStatus: 'active', plan: 'family-monthly' };
+	}
+}
+
+/**
+ * DEBUG_TRIAL env に基づくトライアル上書きを返す。
+ * dev モードでない、または env 未設定の場合は null。
+ */
+export function getDebugTrialOverride(): DebugTrialOverride | null {
+	if (!dev) return null;
+	const rawTrial = process.env.DEBUG_TRIAL?.trim().toLowerCase();
+	if (!rawTrial) return null;
+	if (!VALID_TRIALS.has(rawTrial)) {
+		console.warn(
+			`[debug-plan] DEBUG_TRIAL="${rawTrial}" is invalid. Expected one of: active, expired, not-started`,
+		);
+		return null;
+	}
+
+	const rawTier = process.env.DEBUG_TRIAL_TIER?.trim().toLowerCase();
+	let tier: TrialTier = 'standard';
+	if (rawTier) {
+		if (!VALID_TRIAL_TIERS.has(rawTier)) {
+			console.warn(
+				`[debug-plan] DEBUG_TRIAL_TIER="${rawTier}" is invalid. Expected one of: standard, family`,
+			);
+		} else {
+			tier = rawTier as TrialTier;
+		}
+	}
+
+	switch (rawTrial as DebugTrial) {
+		case 'active': {
+			// 7 日後を終了日とする
+			const d = new Date();
+			d.setDate(d.getDate() + 7);
+			const y = d.getFullYear();
+			const m = String(d.getMonth() + 1).padStart(2, '0');
+			const day = String(d.getDate()).padStart(2, '0');
+			return { endDate: `${y}-${m}-${day}`, tier };
+		}
+		case 'expired':
+		case 'not-started':
+			return { endDate: null, tier: null };
+	}
+}
+
+/**
+ * デバッグ上書きが有効かどうか（インジケータ表示用）
+ */
+export function isDebugPlanActive(): boolean {
+	return getDebugPlanOverride() !== null || getDebugTrialOverride() !== null;
+}
+
+/**
+ * 現在のデバッグ状態を短い表示文字列として返す
+ * 例: "plan=family", "trial=active(family)", "plan=standard trial=expired"
+ */
+export function getDebugPlanSummary(): string | null {
+	if (!dev) return null;
+	const parts: string[] = [];
+	const rawPlan = process.env.DEBUG_PLAN?.trim().toLowerCase();
+	if (rawPlan && VALID_PLANS.has(rawPlan)) {
+		parts.push(`plan=${rawPlan}`);
+	}
+	const rawTrial = process.env.DEBUG_TRIAL?.trim().toLowerCase();
+	if (rawTrial && VALID_TRIALS.has(rawTrial)) {
+		const rawTier = process.env.DEBUG_TRIAL_TIER?.trim().toLowerCase();
+		const tierStr = rawTier && VALID_TRIAL_TIERS.has(rawTier) ? `(${rawTier})` : '';
+		parts.push(`trial=${rawTrial}${tierStr}`);
+	}
+	return parts.length > 0 ? parts.join(' ') : null;
+}
+
+/**
+ * AuthContext に DEBUG_PLAN 上書きを適用した新しい context を返す。
+ * 上書きが無い場合は元の context をそのまま返す。
+ */
+export function applyDebugPlanOverride(context: AuthContext | null): AuthContext | null {
+	if (!context) return context;
+	const override = getDebugPlanOverride();
+	if (!override) return context;
+	return {
+		...context,
+		licenseStatus: override.licenseStatus,
+		plan: override.plan,
+	};
+}

--- a/src/lib/server/debug-plan.ts
+++ b/src/lib/server/debug-plan.ts
@@ -6,6 +6,7 @@
 // 場合にのみ有効。本番 (`dev === false`) では常に無効。
 
 import { dev } from '$app/environment';
+import { toJSTDateString } from '$lib/domain/date-utils';
 import type { AuthContext } from '$lib/server/auth/types';
 import type { TrialTier } from '$lib/server/services/trial-service';
 
@@ -82,13 +83,10 @@ export function getDebugTrialOverride(): DebugTrialOverride | null {
 
 	switch (rawTrial as DebugTrial) {
 		case 'active': {
-			// 7 日後を終了日とする
+			// 7 日後を終了日とする（JST固定）
 			const d = new Date();
 			d.setDate(d.getDate() + 7);
-			const y = d.getFullYear();
-			const m = String(d.getMonth() + 1).padStart(2, '0');
-			const day = String(d.getDate()).padStart(2, '0');
-			return { endDate: `${y}-${m}-${day}`, tier };
+			return { endDate: toJSTDateString(d), tier };
 		}
 		case 'expired':
 		case 'not-started':
@@ -116,8 +114,10 @@ export function getDebugPlanSummary(): string | null {
 	}
 	const rawTrial = process.env.DEBUG_TRIAL?.trim().toLowerCase();
 	if (rawTrial && VALID_TRIALS.has(rawTrial)) {
+		// tier はアクティブ時のみ表示（expired/not-started では tier 無関係）
 		const rawTier = process.env.DEBUG_TRIAL_TIER?.trim().toLowerCase();
-		const tierStr = rawTier && VALID_TRIAL_TIERS.has(rawTier) ? `(${rawTier})` : '';
+		const tierStr =
+			rawTrial === 'active' && rawTier && VALID_TRIAL_TIERS.has(rawTier) ? `(${rawTier})` : '';
 		parts.push(`trial=${rawTrial}${tierStr}`);
 	}
 	return parts.length > 0 ? parts.join(' ') : null;

--- a/src/lib/server/services/trial-service.ts
+++ b/src/lib/server/services/trial-service.ts
@@ -35,6 +35,37 @@ export interface StartTrialInput {
  * トライアル状態を取得（trial_history テーブルから最新レコードを参照）
  */
 export async function getTrialStatus(tenantId: string): Promise<TrialStatus> {
+	// dev: DEBUG_TRIAL env があればDB参照をスキップして擬似ステータスを返す (#758)
+	const debugOverride = getDebugTrialOverride();
+	if (debugOverride) {
+		if (debugOverride.endDate) {
+			const todayStr = toJSTDateString(new Date());
+			const todayDate = new Date(`${todayStr}T00:00:00Z`);
+			const endDate = new Date(`${debugOverride.endDate}T00:00:00Z`);
+			const daysRemaining = Math.round(
+				(endDate.getTime() - todayDate.getTime()) / (1000 * 60 * 60 * 24),
+			);
+			return {
+				isTrialActive: true,
+				trialUsed: true,
+				trialStartDate: todayStr,
+				trialEndDate: debugOverride.endDate,
+				trialTier: debugOverride.tier,
+				daysRemaining,
+				source: 'admin_grant',
+			};
+		}
+		return {
+			isTrialActive: false,
+			trialUsed: false,
+			trialStartDate: null,
+			trialEndDate: null,
+			trialTier: null,
+			daysRemaining: 0,
+			source: null,
+		};
+	}
+
 	const latest = await getRepos().trialHistory.findLatestByTenant(tenantId);
 
 	if (!latest) {

--- a/src/lib/server/services/trial-service.ts
+++ b/src/lib/server/services/trial-service.ts
@@ -4,6 +4,7 @@
 
 import { toJSTDateString } from '$lib/domain/date-utils';
 import { getRepos } from '$lib/server/db/factory';
+import { getDebugTrialOverride } from '$lib/server/debug-plan';
 import { logger } from '$lib/server/logger';
 
 const DEFAULT_TRIAL_DAYS = 7;
@@ -127,6 +128,10 @@ export async function isTrialActive(tenantId: string): Promise<boolean> {
  * トライアル終了日を取得（null = トライアルなし or 終了済み）
  */
 export async function getTrialEndDate(tenantId: string): Promise<string | null> {
+	// dev: DEBUG_TRIAL env があれば上書き (#758)
+	const debugOverride = getDebugTrialOverride();
+	if (debugOverride) return debugOverride.endDate;
+
 	const status = await getTrialStatus(tenantId);
 	return status.isTrialActive ? status.trialEndDate : null;
 }
@@ -135,6 +140,10 @@ export async function getTrialEndDate(tenantId: string): Promise<string | null> 
  * アクティブなトライアルのティアを取得
  */
 export async function getTrialTier(tenantId: string): Promise<TrialTier | null> {
+	// dev: DEBUG_TRIAL env があれば上書き (#758)
+	const debugOverride = getDebugTrialOverride();
+	if (debugOverride) return debugOverride.tier;
+
 	const status = await getTrialStatus(tenantId);
 	return status.isTrialActive ? status.trialTier : null;
 }

--- a/src/lib/ui/components/DebugPlanIndicator.svelte
+++ b/src/lib/ui/components/DebugPlanIndicator.svelte
@@ -29,7 +29,7 @@ let { summary }: { summary: string | null } = $props();
 		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 		font-size: 0.6875rem;
 		font-weight: 600;
-		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+		box-shadow: 0 2px 8px color-mix(in srgb, var(--color-surface-overlay) 30%, transparent);
 		pointer-events: none;
 	}
 	.debug-plan-indicator__label {

--- a/src/lib/ui/components/DebugPlanIndicator.svelte
+++ b/src/lib/ui/components/DebugPlanIndicator.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+// 開発モード専用 — DEBUG_PLAN / DEBUG_TRIAL の現在状態を可視化 (#758)
+// summary が null の場合は何も描画しない（prod では常に null が渡る想定）。
+
+let { summary }: { summary: string | null } = $props();
+</script>
+
+{#if summary}
+	<div class="debug-plan-indicator" role="status" aria-label="Debug plan override" data-testid="debug-plan-indicator">
+		<span class="debug-plan-indicator__label">DEBUG</span>
+		<span class="debug-plan-indicator__value">{summary}</span>
+	</div>
+{/if}
+
+<style>
+	.debug-plan-indicator {
+		position: fixed;
+		bottom: 0.75rem;
+		right: 0.75rem;
+		z-index: 9999;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
+		padding: 0.375rem 0.625rem;
+		background: var(--color-feedback-warning-bg-strong);
+		color: var(--color-feedback-warning-text);
+		border: 1px solid var(--color-feedback-warning-border);
+		border-radius: 0.5rem;
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		font-size: 0.6875rem;
+		font-weight: 600;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+		pointer-events: none;
+	}
+	.debug-plan-indicator__label {
+		padding: 0.0625rem 0.25rem;
+		background: var(--color-feedback-warning-text);
+		color: var(--color-feedback-warning-bg);
+		border-radius: 0.25rem;
+		letter-spacing: 0.05em;
+	}
+</style>

--- a/src/routes/(parent)/admin/+layout.server.ts
+++ b/src/routes/(parent)/admin/+layout.server.ts
@@ -2,6 +2,7 @@ import type { CurrencyCode, PointSettings, PointUnitMode } from '$lib/domain/poi
 import { DEFAULT_POINT_SETTINGS } from '$lib/domain/point-display';
 import { getAuthMode, requireTenantId } from '$lib/server/auth/factory';
 import { getSettings } from '$lib/server/db/settings-repo';
+import { getDebugPlanSummary } from '$lib/server/debug-plan';
 import { isPaidTier, resolvePlanTier } from '$lib/server/services/plan-limit-service';
 import { getTrialStatus } from '$lib/server/services/trial-service';
 import type { LayoutServerLoad } from './$types';
@@ -59,5 +60,6 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 			trialUsed: trialStatus.trialUsed,
 			trialEndDate: trialStatus.trialEndDate,
 		},
+		debugPlanSummary: getDebugPlanSummary(),
 	};
 };

--- a/src/routes/(parent)/admin/+layout.svelte
+++ b/src/routes/(parent)/admin/+layout.svelte
@@ -2,12 +2,14 @@
 import type { Snippet } from 'svelte';
 import AdminLayout from '$lib/features/admin/components/AdminLayout.svelte';
 import TrialBanner from '$lib/features/admin/components/TrialBanner.svelte';
+import DebugPlanIndicator from '$lib/ui/components/DebugPlanIndicator.svelte';
 
 interface Props {
 	data: {
 		isPremium?: boolean;
 		planTier?: 'free' | 'standard' | 'family';
 		authMode?: string;
+		debugPlanSummary?: string | null;
 		trialStatus?: {
 			isTrialActive: boolean;
 			daysRemaining: number;
@@ -42,3 +44,4 @@ const showTrialBanner = $derived(
 	{/if}
 	{@render children()}
 </AdminLayout>
+<DebugPlanIndicator summary={data.debugPlanSummary ?? null} />

--- a/tests/unit/server/debug-plan.test.ts
+++ b/tests/unit/server/debug-plan.test.ts
@@ -1,0 +1,195 @@
+// tests/unit/server/debug-plan.test.ts
+// debug-plan ユニットテスト (#758)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// $app/environment.dev をモックで切り替えられるようにする
+const devState = { dev: true };
+vi.mock('$app/environment', () => ({
+	get dev() {
+		return devState.dev;
+	},
+}));
+
+import type { AuthContext } from '$lib/server/auth/types';
+import {
+	applyDebugPlanOverride,
+	getDebugPlanOverride,
+	getDebugPlanSummary,
+	getDebugTrialOverride,
+	isDebugPlanActive,
+} from '$lib/server/debug-plan';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('debug-plan', () => {
+	beforeEach(() => {
+		devState.dev = true;
+		process.env = { ...ORIGINAL_ENV };
+		delete process.env.DEBUG_PLAN;
+		delete process.env.DEBUG_TRIAL;
+		delete process.env.DEBUG_TRIAL_TIER;
+	});
+
+	afterEach(() => {
+		process.env = ORIGINAL_ENV;
+	});
+
+	describe('getDebugPlanOverride', () => {
+		it('dev=false なら常に null（本番セーフガード）', () => {
+			devState.dev = false;
+			process.env.DEBUG_PLAN = 'family';
+			expect(getDebugPlanOverride()).toBeNull();
+		});
+
+		it('env 未設定なら null', () => {
+			expect(getDebugPlanOverride()).toBeNull();
+		});
+
+		it('DEBUG_PLAN=free → licenseStatus=none', () => {
+			process.env.DEBUG_PLAN = 'free';
+			expect(getDebugPlanOverride()).toEqual({ licenseStatus: 'none', plan: undefined });
+		});
+
+		it('DEBUG_PLAN=standard → licenseStatus=active, plan=monthly', () => {
+			process.env.DEBUG_PLAN = 'standard';
+			expect(getDebugPlanOverride()).toEqual({ licenseStatus: 'active', plan: 'monthly' });
+		});
+
+		it('DEBUG_PLAN=family → licenseStatus=active, plan=family-monthly', () => {
+			process.env.DEBUG_PLAN = 'family';
+			expect(getDebugPlanOverride()).toEqual({ licenseStatus: 'active', plan: 'family-monthly' });
+		});
+
+		it('大文字小文字混在も許容', () => {
+			process.env.DEBUG_PLAN = ' FAMILY ';
+			expect(getDebugPlanOverride()).toEqual({ licenseStatus: 'active', plan: 'family-monthly' });
+		});
+
+		it('無効値は null を返して警告', () => {
+			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			process.env.DEBUG_PLAN = 'enterprise';
+			expect(getDebugPlanOverride()).toBeNull();
+			expect(warn).toHaveBeenCalled();
+			warn.mockRestore();
+		});
+	});
+
+	describe('getDebugTrialOverride', () => {
+		it('dev=false なら常に null', () => {
+			devState.dev = false;
+			process.env.DEBUG_TRIAL = 'active';
+			expect(getDebugTrialOverride()).toBeNull();
+		});
+
+		it('env 未設定なら null', () => {
+			expect(getDebugTrialOverride()).toBeNull();
+		});
+
+		it('DEBUG_TRIAL=active → 7 日後 + standard tier', () => {
+			process.env.DEBUG_TRIAL = 'active';
+			const override = getDebugTrialOverride();
+			expect(override).not.toBeNull();
+			expect(override?.tier).toBe('standard');
+			expect(override?.endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+			// 未来日付（今日より後）であること
+			expect(new Date(override?.endDate ?? '').getTime()).toBeGreaterThan(Date.now());
+		});
+
+		it('DEBUG_TRIAL=active + DEBUG_TRIAL_TIER=family → family tier', () => {
+			process.env.DEBUG_TRIAL = 'active';
+			process.env.DEBUG_TRIAL_TIER = 'family';
+			expect(getDebugTrialOverride()?.tier).toBe('family');
+		});
+
+		it('DEBUG_TRIAL=expired → endDate=null, tier=null', () => {
+			process.env.DEBUG_TRIAL = 'expired';
+			expect(getDebugTrialOverride()).toEqual({ endDate: null, tier: null });
+		});
+
+		it('DEBUG_TRIAL=not-started → endDate=null, tier=null', () => {
+			process.env.DEBUG_TRIAL = 'not-started';
+			expect(getDebugTrialOverride()).toEqual({ endDate: null, tier: null });
+		});
+
+		it('無効値は null', () => {
+			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			process.env.DEBUG_TRIAL = 'forever';
+			expect(getDebugTrialOverride()).toBeNull();
+			warn.mockRestore();
+		});
+
+		it('無効な DEBUG_TRIAL_TIER は standard フォールバック', () => {
+			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			process.env.DEBUG_TRIAL = 'active';
+			process.env.DEBUG_TRIAL_TIER = 'enterprise';
+			expect(getDebugTrialOverride()?.tier).toBe('standard');
+			warn.mockRestore();
+		});
+	});
+
+	describe('applyDebugPlanOverride', () => {
+		const baseContext: AuthContext = {
+			tenantId: 't1',
+			role: 'owner',
+			licenseStatus: 'none',
+			plan: undefined,
+		};
+
+		it('context=null はそのまま null', () => {
+			expect(applyDebugPlanOverride(null)).toBeNull();
+		});
+
+		it('env 未設定なら context をそのまま返す', () => {
+			expect(applyDebugPlanOverride(baseContext)).toEqual(baseContext);
+		});
+
+		it('DEBUG_PLAN=family を適用', () => {
+			process.env.DEBUG_PLAN = 'family';
+			const result = applyDebugPlanOverride(baseContext);
+			expect(result?.licenseStatus).toBe('active');
+			expect(result?.plan).toBe('family-monthly');
+			// tenantId / role は保持
+			expect(result?.tenantId).toBe('t1');
+			expect(result?.role).toBe('owner');
+		});
+
+		it('dev=false なら override を無視', () => {
+			devState.dev = false;
+			process.env.DEBUG_PLAN = 'family';
+			expect(applyDebugPlanOverride(baseContext)).toEqual(baseContext);
+		});
+	});
+
+	describe('isDebugPlanActive / getDebugPlanSummary', () => {
+		it('env 未設定 → false / null', () => {
+			expect(isDebugPlanActive()).toBe(false);
+			expect(getDebugPlanSummary()).toBeNull();
+		});
+
+		it('DEBUG_PLAN=family のみ', () => {
+			process.env.DEBUG_PLAN = 'family';
+			expect(isDebugPlanActive()).toBe(true);
+			expect(getDebugPlanSummary()).toBe('plan=family');
+		});
+
+		it('DEBUG_TRIAL=active + tier=family', () => {
+			process.env.DEBUG_TRIAL = 'active';
+			process.env.DEBUG_TRIAL_TIER = 'family';
+			expect(isDebugPlanActive()).toBe(true);
+			expect(getDebugPlanSummary()).toBe('trial=active(family)');
+		});
+
+		it('plan + trial 両方', () => {
+			process.env.DEBUG_PLAN = 'standard';
+			process.env.DEBUG_TRIAL = 'expired';
+			expect(getDebugPlanSummary()).toBe('plan=standard trial=expired');
+		});
+
+		it('dev=false では summary も null', () => {
+			devState.dev = false;
+			process.env.DEBUG_PLAN = 'family';
+			expect(getDebugPlanSummary()).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者・QA・レビューチーム（システム全体）

**解決する課題**:
ローカル開発・Playwright E2E で「プラン状態（free/standard/family）」と「トライアル状態（active/expired/not-started）」を切り替える手段が一切存在しなかった。結果として開発者が自分の変更を手元で検証できず、#725-#735 で発覚したプランゲート欠落バグ群がローカルで検出できなかった（#758 critical）。

**期待される効果**:
- `.env.local` に DEBUG_PLAN 等を設定するだけで、画面リロードごとに free/standard/family の挙動を確認できる
- E2E fixture として使える（#750 の前提）
- admin 画面右下のインジケータで「今どの状態を見ているか」が一目で分かる
- 本番ビルドでは絶対に有効化しない（`dev === false` ガード）

## 関連 Issue

closes #758

関連: #750 (E2E 親 issue の前提), #725-#735 (プランゲート欠落群)

## スクリーンショット / ビジュアルデモ

![DebugPlanIndicator プレビュー](docs/images/debug-plan-indicator-preview.png)

<sub>`scripts/capture-debug-plan-indicator.mjs` を使い、プロジェクトの feedback-warning セマンティックトークンで 3 パターンをレンダリングしたもの。実際には `(parent)/admin/+layout.svelte` の右下に `position: fixed` で表示され、本番ビルド（`dev === false`）では `getDebugPlanSummary()` が常に null を返すため `{#if summary}` で非表示。</sub>

## 変更タイプ

- [x] feat: 新機能（開発者向け DX）

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/debug-plan.ts` 新規, `trial-service.ts` 修正)
- [x] ページ / レイアウト (`src/hooks.server.ts`, `admin/+layout.server.ts`, `admin/+layout.svelte`)
- [x] UI コンポーネント (`$lib/ui/components/DebugPlanIndicator.svelte` 新規)
- [x] 設定・CI (`.env.example`, `README.md`, `CLAUDE.md`)

**影響を受ける画面・機能**:
- 開発モードのみ: `(parent)/admin/*` 配下全体と `/demo/*` の context override、トライアル関連判定
- **本番ビルドでは `dev === false` により完全に無効**

## 設計方針・将来性

**採用した設計方針**:
- `$app/environment` の `dev` 定数でガード → 本番バンドルでは tree-shaking
- env バリデーション（無効値は warn + null）で安全に失敗
- プラン override と trial override を独立させ、DEBUG_PLAN と DEBUG_TRIAL を自由に組み合わせ可能
- インジケータはプリミティブではなく dev 専用コンポーネントとして隔離

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加: `tests/unit/server/debug-plan.test.ts` (24 ケース)
- 既存テストへの影響なし: trial-service.test.ts (23 件)、plan-limit-service.test.ts (34 件) すべて従来通り通過

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check src tests` | PASS | 0 errors (pre-existing warn のみ) |
| 型チェック | `npx svelte-check` | PASS | 0 errors (pre-existing warn のみ) |
| 単体テスト | `npx vitest run tests/unit/server/debug-plan.test.ts tests/unit/services/trial-service.test.ts tests/unit/services/plan-limit-service.test.ts` | PASS | 81/81 |

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | `dev === false` で prod バンドルから実質的に消える（tree-shaking）。環境変数の値は enum validation | 本番リスクなし |
| パフォーマンス | hooks.server.ts での override は process.env 参照のみ | 本番では null 早期 return |
| アクセシビリティ | インジケータに role="status" + aria-label | 対象外（dev only） |
| ロギング | 無効値検出時に `console.warn` | dev 表示のみ |
| ドキュメント | README.md / CLAUDE.md / .env.example に使用法記載 | すべて同 PR 内 |

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

新規追加のみ。既存の `locals.context` は env 未設定時に従来通り。

## 横展開・影響波及チェック

- [x] **本番アプリ** — `(parent)/admin/+layout.svelte` に指示器追加、hooks.server.ts で全 context に override 適用
- [x] **デモ版** — hooks.server.ts の /demo 分岐にも `applyDebugPlanOverride` を適用
- [x] **カラー・スタイル**: セマンティックトークンのみ使用（`--color-feedback-warning-*`）
- [x] **プリミティブ**: DebugPlanIndicator は dev 専用隔離コンポーネント

## Ready for Review チェックリスト

- [x] CI が全て通過している
- [x] セルフレビュー済み
- [x] スクリーンショット添付済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
