### PR TITLE
docs: #808 設計書にライセンスキーライフサイクル全仕様を追加

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1353,6 +1353,22 @@ Push 通知の購読解除。
 
 ---
 
+### 3.X ライセンスキー API (#808)
+
+> **SSOT**: [license-key-lifecycle.md §4](./license-key-lifecycle.md#4-api-エンドポイント一覧) を参照。本セクションは要約。
+
+| メソッド | パス | 説明 | 権限 |
+|---------|------|------|------|
+| POST | `/api/v1/license/verify` | キー検証（署名 + DB 照合） | 認証済みユーザー |
+| POST | `/api/v1/license/consume` | キー消費 → 有料プラン昇格 | 認証済みユーザー |
+| GET | `/api/v1/ops/license-keys` | Ops 一覧（フィルタ対応） | Ops ロール |
+| POST | `/api/v1/ops/license-keys` | Ops 手動発行 | Ops ロール |
+| POST | `/api/v1/ops/license-keys/:key/revoke` | Ops 失効 | Ops ロール |
+
+関連エラーコード: `LICENSE_FORMAT_INVALID` / `LICENSE_SIGNATURE_INVALID` / `LICENSE_NOT_FOUND` / `LICENSE_ALREADY_CONSUMED` / `LICENSE_REVOKED` — §4 参照。
+
+---
+
 ## 4. エラーレスポンス仕様
 
 ### 共通エラー形式
@@ -1380,6 +1396,11 @@ Push 通知の購読解除。
 | LOCKED_OUT | 429 | ロックアウト中 |
 | NOT_FOUND | 404 | リソースが見つからない |
 | INTERNAL_ERROR | 500 | サーバー内部エラー |
+| LICENSE_FORMAT_INVALID | 400 | ライセンスキー形式が不正 |
+| LICENSE_SIGNATURE_INVALID | 400 | ライセンスキー HMAC 署名不一致 |
+| LICENSE_NOT_FOUND | 404 | ライセンスキーが存在しない |
+| LICENSE_ALREADY_CONSUMED | 409 | ライセンスキー消費済み |
+| LICENSE_REVOKED | 410 | ライセンスキー失効済み |
 
 ---
 

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1313,7 +1313,7 @@ git push origin main
 | インデックス名 | PK | SK | 用途 |
 |--------------|-----|-----|------|
 | GSI1 | `SK` | `PK` | 逆引きクエリ（全テナントの特定 SK を検索） |
-| GSI2 | `GSI2PK` | `GSI2SK` | カテゴリ別活動クエリ、時系列クエリ |
+| GSI2 | `GSI2PK` | `GSI2SK` | カテゴリ別活動クエリ、時系列クエリ、ライセンスキーのテナント別一覧 |
 
 ### 7.3 テナント分離
 
@@ -1366,11 +1366,38 @@ T#<tenantId>#COUNTER           // テナント内 ID カウンタ
 | 称号マスタ | `TITLE#<titleId>` | `MASTER` | 称号定義 |
 | 市場ベンチマーク | `BENCH#<age>` | `CAT#<catId>` | 年齢×カテゴリ別平均値 |
 
+#### ライセンスキー関連エンティティ（キーグローバル一意）
+
+ライセンスキー (`GQ-XXXX-XXXX-XXXX-YYYYY`) は全テナントをまたいで一意。そのため PK にテナントプレフィックスは付与せず、キー値そのものをパーティションキーに利用する。詳細は [license-key-lifecycle.md](./license-key-lifecycle.md) を参照。
+
+| エンティティ | PK | SK | 説明 |
+|------------|-----|-----|------|
+| ライセンスキー本体 | `LICENSE#<licenseKey>` | `LICENSE#<licenseKey>` | status (`active`/`consumed`/`revoked`), plan, tenantId, stripeSessionId, consumedBy, consumedAt, revokedReason, revokedAt, createdAt |
+| ライセンス監査ログ | `LICENSE_EVENT#<licenseKey>` | `EVENT#<ts>#<ulid>` | eventType (`issued`/`consumed`/`revoked`/`rotated`/`verify_failed`/`ops_manual`), actor, metadata。TTL 7 年（会計書類保存期間） |
+
+**主要属性（LicenseRecord）**:
+
+| 属性 | 型 | 必須 | 説明 |
+|------|---|------|------|
+| `licenseKey` | string | ○ | キー本体（`GQ-` プレフィックス + 署名付き 22 文字） |
+| `tenantId` | string | ○ | 発行先テナント |
+| `plan` | enum | ○ | `'monthly' \| 'yearly' \| 'family-monthly' \| 'family-yearly' \| 'lifetime'` |
+| `stripeSessionId` | string | — | Stripe Checkout Session ID（発行元トレース用） |
+| `status` | enum | ○ | `'active' \| 'consumed' \| 'revoked'` |
+| `consumedBy` | string | — | 消費したユーザー ID |
+| `consumedAt` | string (ISO8601) | — | 消費日時 |
+| `revokedReason` | enum | — | `'expired' \| 'leaked' \| 'ops-manual' \| 'refund'` |
+| `revokedAt` | string (ISO8601) | — | 失効日時 |
+| `createdAt` | string (ISO8601) | ○ | 発行日時（90日期限の起点） |
+
+**実装リファレンス**: `src/lib/server/services/license-key-service.ts`
+
 ### 7.5 GSI2 の利用パターン
 
 | GSI2PK | GSI2SK | 用途 |
 |--------|--------|------|
 | `T#<tid>#CAT#<catId>` | `ACT#<sort>#<actId>` | カテゴリ別活動一覧（ソート済み） |
+| `TENANT#<tenantId>` | `LICENSE#<createdAt>` | テナント別ライセンスキー一覧（Ops 画面、直近発行順） |
 
 ### 7.6 ID 自動採番
 
@@ -1474,3 +1501,4 @@ src/lib/server/db/migration/
 | 2026-04-06 | 4.1 | #549 activities テーブルに is_main_quest カラム追加（メインクエスト機能） |
 | 2026-04-10 | 4.2 | #605 daily_battles・enemy_collection テーブル追加（バトルアドベンチャー機能） |
 | 2026-04-09 | 4.3 | #609 未記載7テーブル追記（parent_messages, rest_days, tenant_events, tenant_event_progress, auto_challenges, trial_history, viewer_tokens）、廃止テーブル（level_titles, custom_titles）に deprecated 注記追加 |
+| 2026-04-11 | 4.4 | #808 ライセンスキー関連エンティティ追加（LicenseRecord, LicenseEvent）+ GSI2 にテナント別ライセンス一覧パターン追加。詳細は [license-key-lifecycle.md](./license-key-lifecycle.md) を参照 |

--- a/docs/design/19-プライシング戦略書.md
+++ b/docs/design/19-プライシング戦略書.md
@@ -288,7 +288,7 @@ Day 98+   : 90日超の履歴をアーカイブ（削除ではない）
 |--------------|------|------|
 | Stripe Checkout/Portal | 実装済み | 月額/年額の2プラン |
 | Webhook処理 | 実装済み | 5イベント型対応 |
-| ライセンスキー発行 | 実装済み | GQ-XXXX-XXXX-XXXX形式 |
+| ライセンスキー発行 | 実装済み | `GQ-XXXX-XXXX-XXXX-YYYYY` 形式（HMAC-SHA256 署名付き 5 文字チェックサム）。仕様の正は [license-key-lifecycle.md](./license-key-lifecycle.md) |
 | プラン制限チェック | 実装済み | free/paid 2ティア |
 | 料金ページ | 実装済み | /pricing |
 | ライセンス管理画面 | 実装済み | /admin/license |
@@ -369,6 +369,41 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 
 ---
 
+## 7A. ライセンスキー運用
+
+> **SSOT**: ライセンスキーのフォーマット・ライフサイクル・API・DB スキーマ・状態遷移は **[license-key-lifecycle.md](./license-key-lifecycle.md)** を参照。本章ではプライシング戦略との接続点のみ記載する。
+
+### 7A.1 プライシングとの接続
+
+- **発行トリガ**: Stripe Checkout 完了 (`checkout.session.completed` webhook) で自動発行
+- **配布方法**: 決済完了メールに記載 + `/admin/license` から再取得可能
+- **消費タイミング**: ユーザーが `/admin/license` 画面から consume API を叩くことで有料プラン昇格
+- **プラン紐付け**: `LicenseRecord.plan` に `standard-monthly` / `standard-yearly` / `family-monthly` / `family-yearly` のいずれかを保存（Stripe Price ID から解決）
+- **有効期限**: 発行から 90 日で自動失効 (`status='revoked'`, `revokedReason='expired'`)。期限前 7 日で通知メール送信
+- **返金対応**: Stripe 返金時に `revokedReason='refund'` で失効 + テナントを `expired_free` に降格
+
+### 7A.2 決済との因果関係
+
+| プライシングイベント | License Key 状態 | 関連 |
+|-------------------|----------------|------|
+| 初回 Checkout 完了 | 新規発行 (`active`) | [license-subscription-causality.md](./license-subscription-causality.md) |
+| ユーザー consume 操作 | `consumed` + テナント `paid` 昇格 | #824 |
+| `invoice.paid` (継続課金) | — (License Key 自体は発行時に一度だけ使用) | — |
+| `customer.subscription.deleted` | — (License Key は独立して consumed 状態維持) | — |
+| 返金処理 | `revoked` (`reason='refund'`) | #824 |
+
+> **重要**: ライセンスキーは「初回有料化のきっかけ」として設計されており、継続課金は Stripe subscription 自体で管理される。ライセンスキーが consume された後、テナントは Stripe subscription のライフサイクルに従って `active` → `grace_period` → `expired_retention` → `expired_free` と遷移する。
+
+### 7A.3 競合との差別化
+
+競合分析の詳細は [license-key-competitor-analysis.md](./license-key-competitor-analysis.md) (#811) 参照。本プロダクトの差別化ポイント:
+
+- **HMAC-SHA256 署名付きキー**: 総当たり攻撃を 32^20 ≒ 10^30 まで困難化（Keygen.sh/JetBrains と同等）
+- **90 日有効期限**: Gumroad/Lemon Squeezy の無期限キーに対し、漏洩リスクを時間軸で制限
+- **完全監査ログ**: 全状態遷移を `LicenseEvent` に 7 年保持（会計書類保存期間対応）
+
+---
+
 ## 8. KPI と見直し基準
 
 ### 8.1 追跡KPI
@@ -436,3 +471,4 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 | 版数 | 日付 | 変更内容 |
 |------|------|---------|
 | 1.0 | 2026-04-01 | 初版作成。3ティアプラン確定、機能制限マトリクス、損益分岐点分析 |
+| 1.1 | 2026-04-11 | #808 §7A ライセンスキー運用 章追加。license-key-lifecycle.md への SSOT ポインタ設置 |

--- a/docs/design/24-ソフトウェアアーキテクチャ設計書.md
+++ b/docs/design/24-ソフトウェアアーキテクチャ設計書.md
@@ -169,7 +169,7 @@ Layer C: Component Usage (var(--color-action-primary))
 | | stripe-service | Stripe API ラッパー |
 | | plan-limit-service | プラン別機能制限チェック |
 | | trial-service | トライアル期間管理 |
-| | license-service | ライセンスキー管理 |
+| | license-key-service | ライセンスキー発行/検証/消費/失効。`GQ-XXXX-XXXX-XXXX-YYYYY` (HMAC-SHA256 署名付き 22文字)。詳細: [license-key-lifecycle.md](./license-key-lifecycle.md) |
 | **ゲーミフィケーション** | stamp-card-service | スタンプカード管理 |
 | | combo-service | コンボ倍率計算 |
 | | login-bonus-service | ログインボーナス |
@@ -298,6 +298,7 @@ try {
 | UI ラベル・用語 | `src/lib/domain/labels.ts` |
 | DB スキーマ | `src/lib/server/db/schema.ts` |
 | 旧 URL マッピング | `src/lib/server/routing/legacy-url-map.ts` |
+| ライセンスキー仕様 | [`docs/design/license-key-lifecycle.md`](./license-key-lifecycle.md) |
 | 設計書 | `docs/design/` |
 
 ---

--- a/docs/design/license-key-lifecycle.md
+++ b/docs/design/license-key-lifecycle.md
@@ -1,0 +1,353 @@
+# ライセンスキー ライフサイクル設計書
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | accepted |
+| 最終更新 | 2026-04-11 |
+| 関連 Issue | #808 |
+| 上位 ADR | ADR-0026 (#809) |
+| 上位要件 | [license-key-requirements.md](./license-key-requirements.md) (#812) |
+| 因果関係マップ | [license-subscription-causality.md](./license-subscription-causality.md) (#824) |
+| 競合分析 | [license-key-competitor-analysis.md](./license-key-competitor-analysis.md) (#811) |
+| 運用手順 | [../operations/license-key-secrets.md](../operations/license-key-secrets.md) (#807) |
+
+---
+
+## 0. 本書の位置づけ
+
+ライセンスキーの**全ライフサイクル（発行→配布→検証→消費→失効→監査）**を網羅する設計書。他の設計書 (07/08/19/24) からの参照先として機能する SSOT。
+
+> **本書は「ライフサイクル」のみを扱う。上位要件は #812、決済との因果関係は #824、競合比較は #811、シークレット運用は #807 を参照。**
+
+---
+
+## 1. 全体ライフサイクル図
+
+```mermaid
+stateDiagram-v2
+    [*] --> active: 発行 (Stripe webhook)
+    active --> consumed: consume (ユーザー)
+    active --> revoked: 失効 (Ops/漏洩/期限切れ)
+    active --> expired: 90日経過 (バッチ)
+    consumed --> [*]
+    revoked --> [*]
+    expired --> revoked: バッチで自動 revoke
+```
+
+| 状態 | 説明 | DB `status` 値 |
+|------|------|--------------|
+| **active** | 発行済み・未消費 | `'active'` |
+| **consumed** | ユーザーが consume 済み | `'consumed'` |
+| **revoked** | Ops 手動 / 漏洩 / 期限切れで失効 | `'revoked'` |
+| **expired** (論理状態) | 90 日経過だがバッチ未実行 | `'active'` + `createdAt + 90d < now()` |
+
+---
+
+## 2. キー形式
+
+### 2.1 フォーマット
+
+```
+GQ-XXXX-XXXX-XXXX-YYYYY
+│  │    │    │    └── HMAC-SHA256 署名 (5文字)
+│  └────┴────┴─────── ランダムペイロード (4文字×3 = 12文字)
+└──────────────────── プレフィックス (固定)
+```
+
+- **全長**: 22 文字 (`GQ-` + 4 + `-` + 4 + `-` + 4 + `-` + 5)
+- **文字セット**: `KEY_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'` (32 文字、0/O/1/I 除外)
+- **ペイロード**: `randomBytes(12)` を `KEY_CHARS[b % 32]` で変換
+- **署名**: `HMAC-SHA256(payload, AWS_LICENSE_SECRET)` の先頭 5 バイトを `KEY_CHARS` で変換
+
+### 2.2 LEGACY vs SIGNED
+
+| 形式 | 正規表現 | 説明 | 廃止時期 |
+|------|---------|------|---------|
+| LEGACY | `^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$` | HMAC 署名なし (旧実装) | #806 対応後に廃止 |
+| SIGNED | `^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{5}$` | HMAC-SHA256 付き (現行) | — |
+
+> 現状 `AWS_LICENSE_SECRET` が **optional** (#806 bug) のため、dev 環境では LEGACY で発行される場合がある。#806 解消後は SIGNED 必須。
+
+### 2.3 実装リファレンス
+
+- `src/lib/server/services/license-key-service.ts`:
+  - `KEY_CHARS`, `CHECKSUM_LENGTH`, `LEGACY_FORMAT`, `SIGNED_FORMAT`
+  - `createHmacChecksum(payload, secret)` — 署名生成
+  - `verifyKeySignature(key, secret)` — 署名検証
+  - `generateLicenseKey()` — 発行
+  - `issueLicenseKey(params)` — DB 保存
+  - `consumeLicenseKey(key, tenantId)` — 消費
+
+---
+
+## 3. DB スキーマ
+
+### 3.1 LicenseRecord (DynamoDB 単一テーブル)
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|---|------|------|
+| `PK` | string | ○ | `LICENSE#<licenseKey>` |
+| `SK` | string | ○ | `LICENSE#<licenseKey>` (同一値) |
+| `licenseKey` | string | ○ | `GQ-XXXX-XXXX-XXXX-YYYYY` |
+| `tenantId` | string | ○ | 発行先テナント ID |
+| `plan` | enum | ○ | `'monthly' \| 'yearly' \| 'family-monthly' \| 'family-yearly' \| 'lifetime'` |
+| `stripeSessionId` | string | — | Stripe Checkout Session ID (発行元) |
+| `status` | enum | ○ | `'active' \| 'consumed' \| 'revoked'` |
+| `consumedBy` | string | — | 消費したユーザー ID (consume 後) |
+| `consumedAt` | string (ISO8601) | — | 消費日時 |
+| `revokedReason` | string | — | 失効理由 (`expired` / `leaked` / `ops-manual` / `refund`) |
+| `revokedAt` | string (ISO8601) | — | 失効日時 |
+| `createdAt` | string (ISO8601) | ○ | 発行日時 |
+
+### 3.2 GSI (tenant 検索用)
+
+| GSI | PK | SK | 用途 |
+|-----|-----|-----|------|
+| `GSI1` | `TENANT#<tenantId>` | `LICENSE#<createdAt>` | テナント別キー一覧 (Ops 画面) |
+
+### 3.3 LicenseEvent (監査ログ)
+
+ライセンスキーの全状態変更を記録する append-only ログ。
+
+| フィールド | 型 | 説明 |
+|-----------|---|------|
+| `PK` | string | `LICENSE_EVENT#<licenseKey>` |
+| `SK` | string | `EVENT#<timestamp>#<ulid>` |
+| `eventType` | enum | `'issued' \| 'consumed' \| 'revoked' \| 'rotated' \| 'verify_failed' \| 'ops_manual'` |
+| `licenseKey` | string | 対象キー |
+| `tenantId` | string | 対象テナント |
+| `actor` | string | 実行者 (`system` / `user:<uid>` / `ops:<uid>` / `stripe:<eventId>`) |
+| `metadata` | map | イベント固有の追加情報 |
+| `timestamp` | string | ISO8601 |
+| `ttl` | number | Unix timestamp (発行から 7 年後、会計法対応) |
+
+**保持期間**: 7 年 (日本の会計書類保存期間。DynamoDB TTL で自動削除)
+
+---
+
+## 4. API エンドポイント一覧
+
+| メソッド | パス | 説明 | 権限 | 関連 Issue |
+|---------|------|------|------|-----------|
+| POST | `/api/v1/license/verify` | キー検証 (署名 + DB 照合) | 認証済みユーザー | #812 US-02 |
+| POST | `/api/v1/license/consume` | キー消費 → 有料プラン昇格 | 認証済みユーザー | #812 US-02 |
+| GET | `/api/v1/ops/license-keys` | Ops 用一覧 (フィルタ対応) | Ops ロール | #812 US-04, #816 |
+| POST | `/api/v1/ops/license-keys` | Ops 手動発行 | Ops ロール | #812 US-05, #816 |
+| POST | `/api/v1/ops/license-keys/:key/revoke` | Ops 失効 | Ops ロール | #812 US-06, #816 |
+| POST | `/api/stripe/webhook` | Stripe webhook 受信 → 発行 | Stripe 署名検証 | #824 |
+
+### 4.1 レスポンス例
+
+#### POST /api/v1/license/verify
+
+```json
+// 200 OK
+{
+  "valid": true,
+  "plan": "family-monthly",
+  "status": "active",
+  "expiresAt": "2026-07-10T00:00:00Z"
+}
+
+// 400 Bad Request (形式不正)
+{ "error": { "code": "LICENSE_FORMAT_INVALID", "message": "キー形式が不正です" } }
+
+// 404 Not Found (DB 未登録)
+{ "error": { "code": "LICENSE_NOT_FOUND", "message": "キーが存在しません" } }
+
+// 410 Gone (失効)
+{ "error": { "code": "LICENSE_REVOKED", "message": "キーは失効しています" } }
+```
+
+#### POST /api/v1/license/consume
+
+```json
+// 200 OK
+{
+  "tenant": {
+    "tenantId": "tenant_123",
+    "plan": "family-monthly",
+    "status": "active",
+    "currentPeriodEnd": "2026-05-11T00:00:00Z"
+  }
+}
+
+// 409 Conflict (既に消費済み)
+{ "error": { "code": "LICENSE_ALREADY_CONSUMED", "message": "既に使用されたキーです" } }
+```
+
+> エラーコード一覧は [07-API設計書.md §4](./07-API設計書.md#4-エラーレスポンス仕様) に追記。
+
+---
+
+## 5. 状態遷移詳細
+
+### 5.1 発行 (issue)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as Stripe
+    participant W as /api/stripe/webhook
+    participant L as license-key-service
+    participant D as DynamoDB
+
+    U->>S: Checkout 決済
+    S->>W: checkout.session.completed
+    W->>L: issueLicenseKey({tenantId, plan, stripeSessionId})
+    L->>L: generateLicenseKey() (HMAC 署名付き)
+    L->>D: PutItem (status=active)
+    L->>D: PutItem LicenseEvent (issued)
+    L-->>W: {licenseKey}
+    W->>U: メール送信 (支援キー記載)
+```
+
+**ポイント**:
+- 発行は **Stripe webhook からのみ** (手動発行は Ops 経由の例外)
+- `stripe_webhook_events` テーブルで冪等性を担保 (#824)
+- 発行時にはまだテナントはキーを消費していない (`active` 状態)
+
+### 5.2 配布 (deliver)
+
+- **通常ルート**: 決済完了メールに本文で記載 (`GQ-XXXX-XXXX-XXXX-YYYYY`)
+- **再送**: `/admin/plan` からユーザーが自分で再取得可能
+- **Ops 対応**: `/ops/license-keys` からサポート担当者が特定ユーザーに再送信
+- **贈答/キャンペーン**: Stripe のクーポン (100% OFF) 経由で通常発行フローを流用 (独自の贈答発行 API は作らない)
+
+### 5.3 検証 (verify)
+
+```mermaid
+flowchart TD
+    A[キー入力] --> B{形式 OK?}
+    B -- No --> E1[LICENSE_FORMAT_INVALID]
+    B -- Yes --> C{署名 OK?}
+    C -- No --> E2[LICENSE_SIGNATURE_INVALID]
+    C -- Yes --> D{DB 存在?}
+    D -- No --> E3[LICENSE_NOT_FOUND]
+    D -- Yes --> E{status?}
+    E -- active --> OK[検証成功]
+    E -- consumed --> E4[LICENSE_ALREADY_CONSUMED]
+    E -- revoked --> E5[LICENSE_REVOKED]
+```
+
+**レート制限**: 同一 IP から 1 分 5 回失敗で 15 分ブロック (#813)
+
+### 5.4 消費 (consume)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant A as /api/v1/license/consume
+    participant L as license-key-service
+    participant D as DynamoDB (Transaction)
+
+    U->>A: POST {licenseKey}
+    A->>L: verify signature + format
+    L->>D: GetItem (status check)
+    alt status != active
+        L-->>A: 409 / 410 / 404
+    else status == active
+        L->>D: TransactWrite:
+        Note over D: 1. Update LICENSE status → consumed<br>2. Update TENANT plan → paid<br>3. Put LicenseEvent (consumed)
+        L-->>A: 200 {tenant}
+    end
+    A-->>U: 200 OK
+```
+
+**ポイント**:
+- **TransactWrite で原子性担保**: ライセンス消費とテナント昇格は同一トランザクション
+- consumed 状態は**不可逆** (再利用不可)
+- consume 後 `current_period_end` は Stripe subscription の値を参照 (#824)
+
+### 5.5 失効 (revoke)
+
+| トリガ | `revokedReason` | 実施者 |
+|-------|---------------|-------|
+| 90 日経過バッチ | `'expired'` | `system` |
+| HMAC シークレット漏洩 | `'leaked'` | `ops:<uid>` |
+| Ops 手動失効 | `'ops-manual'` | `ops:<uid>` |
+| Stripe 返金 | `'refund'` | `system` (webhook) |
+
+### 5.6 期限切れバッチ
+
+- **実行頻度**: 1 日 1 回 (EventBridge cron)
+- **対象**: `status='active'` かつ `createdAt + 90日 < now()`
+- **処理**: `status='revoked'`, `revokedReason='expired'` に更新 + LicenseEvent 記録
+- **通知**: 期限切れ 7 日前にメール通知 (#818)
+
+---
+
+## 6. 権限ロール
+
+| ロール | 実行可能操作 |
+|--------|------------|
+| **user (テナント管理者)** | 自テナントのキー consume / 再送要求 |
+| **user (一般メンバー)** | キー consume (招待されたテナント内で) |
+| **ops (サポート)** | 全キー閲覧・手動発行・手動失効・CSV export |
+| **ops (admin)** | + シークレットローテーション |
+| **system** | 発行 / 期限切れバッチ / 監査ログ記録 |
+
+---
+
+## 7. Stripe Webhook との関係
+
+詳細は [license-subscription-causality.md](./license-subscription-causality.md) 参照。要点のみ:
+
+| Stripe イベント | License への影響 | Tenant への影響 |
+|----------------|----------------|----------------|
+| `checkout.session.completed` | `issued` (新規発行) | — (この時点ではまだ free) |
+| ユーザーによる consume API 呼び出し | `consumed` | `plan='paid'`, `status='active'` |
+| `invoice.paid` | — | `currentPeriodEnd` 更新 |
+| `invoice.payment_failed` | — | `status='grace_period'` |
+| `customer.subscription.deleted` | — | `status='expired_retention'` |
+| 返金処理 | `revoked` (`reason='refund'`) | `status='expired_free'` |
+
+---
+
+## 8. セキュリティ考慮
+
+| 項目 | 対策 | 関連 |
+|------|-----|------|
+| 偽造防止 | HMAC-SHA256 署名 (5 文字チェックサム) | ADR-0026 §A |
+| 総当たり攻撃 | レート制限 (IP 単位 + テナント単位) | #813 |
+| シークレット漏洩 | `AWS_LICENSE_SECRET_PREVIOUS` で grace period 検証 | #807, #810 |
+| 監査トレイル | LicenseEvent に 7 年保持 | §3.3 |
+| CS なりすまし | Ops 操作は 2FA 必須 | #820 |
+
+---
+
+## 9. 設計書間の参照マップ
+
+本書は他の設計書から参照される SSOT として位置付ける。
+
+| 参照元 | 参照セクション | 内容 |
+|-------|-------------|------|
+| `07-API設計書.md` | §2.9 ライセンスキー | §4 API エンドポイント一覧 |
+| `08-データベース設計書.md` | §3.X LicenseRecord / LicenseEvent | §3 DB スキーマ |
+| `19-プライシング戦略書.md` | §X ライセンスキー運用 | §5 状態遷移 |
+| `24-ソフトウェアアーキテクチャ設計書.md` | license-service | §1-2 形式・状態 |
+| `14-セキュリティ設計書.md` | ライセンスキーセキュリティ | §8 セキュリティ考慮 |
+
+---
+
+## 10. 未解決項目 (Gap)
+
+以下は現状の実装と本書の乖離ポイント。各 Issue で対応中:
+
+| # | 項目 | 現状 | 目標 | Issue |
+|---|------|------|------|-------|
+| 1 | `AWS_LICENSE_SECRET` optional | optional で LEGACY 形式が発行される場合あり | required 化 | #806 |
+| 2 | HMAC 鍵 grace period | 未実装 | `AWS_LICENSE_SECRET_PREVIOUS` フォールバック | #810 |
+| 3 | LicenseEvent テーブル | 未作成 | DynamoDB に追加 | #815 |
+| 4 | `/ops/license-keys` | 未実装 | Ops 画面作成 | #816 |
+| 5 | レート制限 | 未実装 | consume エンドポイントに導入 | #813 |
+| 6 | 期限切れバッチ | 未実装 | EventBridge cron | #817 |
+| 7 | 期限切れ通知メール | 未実装 | 7 日前通知 | #818 |
+
+---
+
+## 11. 更新履歴
+
+| 日付 | 更新内容 | 更新者 |
+|------|---------|--------|
+| 2026-04-11 | 初版作成 (#808) | Claude Code |


### PR DESCRIPTION
## Summary

Issue #808 対応。ライセンスキーの全ライフサイクル仕様を設計書に反映。
`license-key-lifecycle.md` を SSOT として新設し、既存 4 設計書から参照する構造に整理。

## 変更ファイル

### 新規作成

- `docs/design/license-key-lifecycle.md` — ライフサイクル全仕様 SSOT
  - §1 状態遷移図 (mermaid stateDiagram-v2)
  - §2 キー形式 (LEGACY vs SIGNED)
  - §3 DB スキーマ (LicenseRecord + LicenseEvent)
  - §4 API エンドポイント一覧 + レスポンス例
  - §5 状態遷移詳細 (発行/配布/検証/消費/失効/期限切れ、mermaid sequence/flowchart)
  - §6 権限ロール
  - §7 Stripe Webhook との関係
  - §8 セキュリティ考慮
  - §9 設計書間参照マップ
  - §10 未解決項目 (Gap) を Issue にマッピング

### 修正

- `docs/design/07-API設計書.md`
  - §3.X ライセンスキー API セクション追加 (SSOT ポインタ付き)
  - エラーコード表に `LICENSE_FORMAT_INVALID` / `LICENSE_SIGNATURE_INVALID` / `LICENSE_NOT_FOUND` / `LICENSE_ALREADY_CONSUMED` / `LICENSE_REVOKED` 追加

- `docs/design/08-データベース設計書.md`
  - §7.2 GSI 説明に license 用途追記
  - §7.4 ライセンスキー関連エンティティ追加 (LicenseRecord, LicenseEvent + 主要属性表)
  - §7.5 GSI2 パターンに `TENANT#<tenantId>` / `LICENSE#<createdAt>` 追加
  - 更新履歴 4.4

- `docs/design/19-プライシング戦略書.md`
  - §7.1 ライセンスキー形式を正確な `GQ-XXXX-XXXX-XXXX-YYYYY` (HMAC 署名付き) に修正
  - §7A ライセンスキー運用 章を新設 (プライシングとの接続、決済因果関係、競合差別化)
  - 改訂履歴 1.1

- `docs/design/24-ソフトウェアアーキテクチャ設計書.md`
  - §2.5 license-service → license-key-service に正確化 (HMAC 署名付き 22 文字)
  - §4.5 SSoT 表にライセンスキー仕様 (lifecycle.md) を追加

## 関連

- Upstream ADR: #809 (ADR-0026)
- 要件定義: #812 → `license-key-requirements.md`
- 因果関係マップ: #824 → `license-subscription-causality.md`
- 競合分析: #811 → `license-key-competitor-analysis.md`
- 運用手順: #807 → `license-key-secrets.md`

## Test plan

- [ ] markdown リンク切れ確認 (lifecycle.md ↔ 07/08/19/24 の相互参照)
- [ ] mermaid 図が GitHub でレンダリングされることを確認
- [ ] 他の設計書 (14 セキュリティ等) からも参照可能であることを確認
- [ ] Draft のまま、CI 通過後に Ready に変更

closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)