### PR TITLE
fix(license): ChurnPreventionModal の '90日' を PLAN_LIMITS 由来の動的値に (#736)

### DIFF
--- a/src/routes/(parent)/admin/license/+page.server.ts
+++ b/src/routes/(parent)/admin/license/+page.server.ts
@@ -46,10 +46,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 		retentionDays: planLimits.historyRetentionDays,
 	};
 
-	// #736: 解約時のダウングレード先（常に free プラン）の保持期間を PLAN_LIMITS から取得し、
-	// ChurnPreventionModal のメッセージを動的にする。ハードコードの "90日" はバグ防止の観点でも
-	// PLAN_LIMITS 由来の値に置き換えるべき（ADR-0024 参照）。
-	const downgradeRetentionDays = getPlanLimits('free').historyRetentionDays ?? 90;
+	// #736: 解約時のダウングレード先（常に free プラン）の保持期間を PLAN_LIMITS から取得。
+	// null = 無制限（現状 free は 90 だが、将来変更されても自動追従する）。
+	const downgradeRetentionDays = getPlanLimits('free').historyRetentionDays;
 
 	return {
 		license: license ?? {

--- a/src/routes/(parent)/admin/license/+page.server.ts
+++ b/src/routes/(parent)/admin/license/+page.server.ts
@@ -46,6 +46,11 @@ export const load: PageServerLoad = async ({ locals }) => {
 		retentionDays: planLimits.historyRetentionDays,
 	};
 
+	// #736: 解約時のダウングレード先（常に free プラン）の保持期間を PLAN_LIMITS から取得し、
+	// ChurnPreventionModal のメッセージを動的にする。ハードコードの "90日" はバグ防止の観点でも
+	// PLAN_LIMITS 由来の値に置き換えるべき（ADR-0024 参照）。
+	const downgradeRetentionDays = getPlanLimits('free').historyRetentionDays ?? 90;
+
 	return {
 		license: license ?? {
 			plan: 'free' as const,
@@ -58,6 +63,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 		loyaltyInfo,
 		planTier: tier,
 		planStats,
+		downgradeRetentionDays,
 		trialStatus: {
 			isTrialActive: trialStatus.isTrialActive,
 			trialUsed: trialStatus.trialUsed,

--- a/src/routes/(parent)/admin/license/+page.svelte
+++ b/src/routes/(parent)/admin/license/+page.svelte
@@ -17,9 +17,13 @@ const planStats = $derived(data.planStats);
 const trialStatus = $derived(data.trialStatus);
 const isOwner = $derived(data.role === 'owner');
 // #736: 解約時のダウングレード先 (free) の保持期間。PLAN_LIMITS 由来の動的値。
-const downgradeRetentionDays = $derived(data.downgradeRetentionDays ?? 90);
-// 解約して失うデータアクセスの表示文言（ハードコード "90日" を排除）
-const churnLostRetentionLabel = $derived(`${downgradeRetentionDays}日以前のデータへのアクセス`);
+// null = 無制限（保持期間制限なし → lostItems から除外すべきだが安全のためラベルで対応）。
+const downgradeRetentionDays = $derived(data.downgradeRetentionDays);
+const churnLostRetentionLabel = $derived(
+	downgradeRetentionDays === null || downgradeRetentionDays === undefined
+		? null
+		: `${downgradeRetentionDays}日以前のデータへのアクセス`,
+);
 
 let checkoutLoading = $state(false);
 let portalLoading = $state(false);
@@ -607,7 +611,7 @@ async function openPortal() {
 			...(data.loyaltyInfo.memoryTickets > 0 ? [`思い出チケット ${data.loyaltyInfo.memoryTickets}枚`] : []),
 			...(data.loyaltyInfo.loginBonusMultiplier > 1 ? [`ログインボーナス ×${data.loyaltyInfo.loginBonusMultiplier}倍`] : []),
 			...(data.loyaltyInfo.currentTier.titleUnlock ? [`「${data.loyaltyInfo.currentTier.titleUnlock}」称号`] : []),
-			churnLostRetentionLabel,
+			...(churnLostRetentionLabel ? [churnLostRetentionLabel] : []),
 		]}
 		onKeep={() => { showChurnModal = false; }}
 		onCancel={() => { showChurnModal = false; openPortal(); }}

--- a/src/routes/(parent)/admin/license/+page.svelte
+++ b/src/routes/(parent)/admin/license/+page.svelte
@@ -16,6 +16,10 @@ const planTier = $derived(data.planTier ?? 'free');
 const planStats = $derived(data.planStats);
 const trialStatus = $derived(data.trialStatus);
 const isOwner = $derived(data.role === 'owner');
+// #736: 解約時のダウングレード先 (free) の保持期間。PLAN_LIMITS 由来の動的値。
+const downgradeRetentionDays = $derived(data.downgradeRetentionDays ?? 90);
+// 解約して失うデータアクセスの表示文言（ハードコード "90日" を排除）
+const churnLostRetentionLabel = $derived(`${downgradeRetentionDays}日以前のデータへのアクセス`);
 
 let checkoutLoading = $state(false);
 let portalLoading = $state(false);
@@ -603,7 +607,7 @@ async function openPortal() {
 			...(data.loyaltyInfo.memoryTickets > 0 ? [`思い出チケット ${data.loyaltyInfo.memoryTickets}枚`] : []),
 			...(data.loyaltyInfo.loginBonusMultiplier > 1 ? [`ログインボーナス ×${data.loyaltyInfo.loginBonusMultiplier}倍`] : []),
 			...(data.loyaltyInfo.currentTier.titleUnlock ? [`「${data.loyaltyInfo.currentTier.titleUnlock}」称号`] : []),
-			'90日以前のデータへのアクセス',
+			churnLostRetentionLabel,
 		]}
 		onKeep={() => { showChurnModal = false; }}
 		onCancel={() => { showChurnModal = false; openPortal(); }}


### PR DESCRIPTION
Closes #736 (部分対応: AC 1-2)

## Summary

解約時の ChurnPreventionModal に「90日以前のデータへのアクセス」とハードコードされていた保持期間表記を `PLAN_LIMITS` から動的取得するように修正。

- \`+page.server.ts\` で \`getPlanLimits('free').historyRetentionDays\` を \`downgradeRetentionDays\` として load から返す
- \`+page.svelte\` で \`\$derived\` を使って \`churnLostRetentionLabel\` を生成し ChurnPreventionModal の \`lostItems\` に渡す
- 将来 free プランの保持期間が変わっても自動追従

## Acceptance Criteria 対応状況 (#736)

- [x] ハードコードされた \"90日\" が PLAN_LIMITS 由来の値になる
- [x] ダウングレード先に応じて文言が変わる (現状 \"解約\" 経路は free 固定なので同じ文言になるが、仕組みとしては ready)
- [ ] 非表示になる件数が表示される → **後続で対応**。件数算出には \`findActivityLogs\` ベースの新しい count メソッドを activity-repo インタフェースに追加し、SQLite/DynamoDB 両方の adapter で実装する必要がある。スコープを明確化するため別 PR で対応予定
- [ ] E2E テスト追加 → **後続で対応**。churn modal 自体がトリガーされるのは有料プラン契約中ユーザーの解約フローのため、E2E 環境でのセットアップが必要

## Test plan

- [x] \`npx biome check .\` — green
- [x] \`npx svelte-check\` — 0 errors
- [x] \`npx vitest run tests/unit/services/plan-limit-service.test.ts\` — 35 passed
- [ ] 本番デプロイ後に解約フロー実機確認

## Notes

- 本 PR は #736 の AC 1-2 のみカバーする部分対応
- AC 3 (件数表示) は repository インタフェース拡張が必要なため別タスク化
- AC 4 (E2E) は AC 3 と合わせて対応が効率的

🤖 Generated with [Claude Code](https://claude.com/claude-code)