### PR TITLE
fix(license): /admin/license のハードコード orange Tailwind を Semantic トークンに (#763)

### DIFF
--- a/src/routes/(parent)/admin/license/+page.svelte
+++ b/src/routes/(parent)/admin/license/+page.svelte
@@ -72,7 +72,12 @@ const statusLabel = (status: string) => {
 				icon: '⚠️',
 			};
 		case 'suspended':
-			return { text: '停止中', color: 'bg-orange-100 text-orange-700', icon: '⏸️' };
+			return {
+				text: '停止中',
+				color:
+					'bg-[var(--color-feedback-warning-bg-strong)] text-[var(--color-feedback-warning-text)]',
+				icon: '⏸️',
+			};
 		case 'terminated':
 			return {
 				text: '解約済み',
@@ -376,9 +381,9 @@ async function openPortal() {
 			</p>
 		</section>
 	{:else if license.status === 'suspended'}
-		<section class="bg-orange-50 rounded-xl p-4 border border-orange-200">
-			<h3 class="text-sm font-semibold text-orange-800 mb-1">⏸️ サービス停止中</h3>
-			<p class="text-sm text-orange-700">
+		<section class="bg-[var(--color-feedback-warning-bg)] rounded-xl p-4 border border-[var(--color-feedback-warning-border)]">
+			<h3 class="text-sm font-semibold text-[var(--color-feedback-warning-text)] mb-1">⏸️ サービス停止中</h3>
+			<p class="text-sm text-[var(--color-feedback-warning-text)]">
 				ライセンスが停止されています。データは保持されていますが、
 				新しい活動の記録やポイントの付与はできません。
 			</p>


### PR DESCRIPTION
Closes #763 (部分対応)

## Summary

\`src/routes/(parent)/admin/license/+page.svelte\` にあったハードコード \`bg-orange-*\` / \`text-orange-*\` / \`border-orange-*\` クラスを Semantic feedback-warning トークンに置き換え。DESIGN.md §9 の「Tailwind default 色直書き禁止」に準拠。

## 変更

- \`statusLabel('suspended')\` の \`color\`: \`bg-orange-100 text-orange-700\` → \`bg-[var(--color-feedback-warning-bg-strong)] text-[var(--color-feedback-warning-text)]\`
- サービス停止中セクション (\`.status === 'suspended'\` 分岐):
  - \`bg-orange-50\` → \`bg-[var(--color-feedback-warning-bg)]\`
  - \`border-orange-200\` → \`border-[var(--color-feedback-warning-border)]\`
  - \`text-orange-800/700\` → \`text-[var(--color-feedback-warning-text)]\`

## Acceptance Criteria 対応状況 (#763)

- [x] bg-orange-*, text-orange-* などのハードコードを排除
- [x] Semantic トークンのみ使用
- [ ] features リストを plan-features.ts から取得 → **後続で対応** (#762 依存、plan-features.ts 未作成)
- [ ] Button/Card/Badge プリミティブに置き換え → **後続で対応** (#762 連動)

## Test plan

- [x] \`npx biome check\` — green
- [x] \`npx svelte-check\` — 0 errors
- [x] 他の hex/tailwind 色直書きが残っていないか grep 確認

## Notes

- #762 (plan-features SSOT 化) は別 PR で対応が適切
- 本 PR はトークン違反の最優先除去に集中

🤖 Generated with [Claude Code](https://claude.com/claude-code)