### PR TITLE
fix(license): AWS_LICENSE_SECRET を production で必須化 (#806)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,24 @@ PORT=3000
 # Cognito (production only)
 # COGNITO_LOGOUT_URL=https://ganbari-quest.com/
 
+# ===================================================
+# License Key HMAC secret (#319, #806) — REQUIRED in production
+# ===================================================
+# ライセンスキー (GQ-XXXX-XXXX-XXXX-YYYYY) の HMAC-SHA256 署名に使用する秘密鍵。
+# production では必須。未設定のまま起動するとアプリは起動時にエラー終了する。
+#
+# 生成コマンド:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+#
+# production では AWS SSM Parameter Store (SecureString) / Secrets Manager に保存し、
+# Lambda / ECS の実行ロール経由で環境変数に注入する。平文コミット厳禁。
+#
+# AWS_LICENSE_SECRET=your_32_byte_hex_secret_here
+#
+# 移行期のみ: legacy 形式 (GQ-XXXX-XXXX-XXXX, 署名なし) を production で受け入れる。
+# 既存キーを再発行するまでの一時フラグ。移行完了後は必ず false に戻す。
+# ALLOW_LEGACY_LICENSE_KEYS=false
+
 # Logging
 # LOG_LEVEL=info
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,11 @@ jobs:
         run: npm run build
 
       - name: Run E2E tests
+        # #806: vite preview は NODE_ENV=production で起動するため、
+        # hooks.server.ts の assertLicenseKeyConfigured() が AWS_LICENSE_SECRET を要求する。
+        # E2E はダミーの固定値で良い（本番シークレットとは別物）。
+        env:
+          AWS_LICENSE_SECRET: e2e-test-secret-do-not-use-in-production
         run: npx playwright test
 
       - name: Upload E2E test results

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,7 +10,12 @@ import { checkApiRateLimit, checkAuthRateLimit } from '$lib/server/security/rate
 import { trackServerError } from '$lib/server/services/analytics-service';
 import { checkConsent } from '$lib/server/services/consent-service';
 import { notifyIncident } from '$lib/server/services/discord-notify-service';
+import { assertLicenseKeyConfigured } from '$lib/server/services/license-key-service';
 import { isSetupRequired } from '$lib/server/services/setup-service';
+
+// #806: production で AWS_LICENSE_SECRET が未設定だと署名付きキーの偽造が可能になる。
+// モジュールロード時に明示的に失敗させることで、誤デプロイを早期検知する。
+assertLicenseKeyConfigured();
 
 /**
  * Accept ヘッダーを検査し、ブラウザ（HTML）リクエストかどうかを判定する

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { type Handle, type HandleServerError, redirect } from '@sveltejs/kit';
+import { building } from '$app/environment';
 import { analytics } from '$lib/analytics';
 import { getAuthMode, getAuthProvider } from '$lib/server/auth/factory';
 import { applyDebugPlanOverride } from '$lib/server/debug-plan';
@@ -15,7 +16,10 @@ import { isSetupRequired } from '$lib/server/services/setup-service';
 
 // #806: production で AWS_LICENSE_SECRET が未設定だと署名付きキーの偽造が可能になる。
 // モジュールロード時に明示的に失敗させることで、誤デプロイを早期検知する。
-assertLicenseKeyConfigured();
+// `building` は vite build / prerender 中のみ true。ビルド時は env が無くても通す。
+if (!building) {
+	assertLicenseKeyConfigured();
+}
 
 /**
  * Accept ヘッダーを検査し、ブラウザ（HTML）リクエストかどうかを判定する

--- a/src/lib/server/services/license-key-service.ts
+++ b/src/lib/server/services/license-key-service.ts
@@ -18,12 +18,66 @@ const LEGACY_FORMAT = /^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/;
 const SIGNED_FORMAT = /^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{5}$/;
 
 // ============================================================
-// HMAC署名 (#319)
+// HMAC署名 (#319, #806)
 // ============================================================
 
 /** LICENSE_SECRET 環境変数を取得（未設定なら undefined） */
 function getLicenseSecret(): string | undefined {
 	return process.env.AWS_LICENSE_SECRET || undefined;
+}
+
+/** production 環境かどうか判定 */
+function isProduction(): boolean {
+	return process.env.NODE_ENV === 'production';
+}
+
+/**
+ * Legacy 形式（署名なし）のライセンスキーを受け入れるかどうか判定する (#806)
+ *
+ * - production + secret 未設定: 受け入れない（偽造リスク）
+ * - production + secret 設定済み + `ALLOW_LEGACY_LICENSE_KEYS=true`: 受け入れる（移行期のみ）
+ * - production + secret 設定済み + フラグなし: 受け入れない（新形式に移行済み）
+ * - dev / test: 常に受け入れる（既存キーでの開発/テストを壊さない）
+ */
+function isLegacyFormatAllowed(): boolean {
+	if (!isProduction()) return true;
+	return process.env.ALLOW_LEGACY_LICENSE_KEYS === 'true';
+}
+
+/**
+ * ライセンスキーサービスの起動時設定チェック (#806)
+ *
+ * production で `AWS_LICENSE_SECRET` が未設定だと、署名付きキーの偽造が可能になり、
+ * legacy 形式のキーを総当たりできる状態でサービスが動いてしまう。これは致命的な
+ * セキュリティバグなので、production 起動時に明示的に失敗させる。
+ *
+ * - production: secret 未設定なら throw（起動失敗）
+ * - dev: secret 未設定なら WARN ログ（既存開発フローを壊さない）
+ * - test: サイレント（ユニットテストで env を切り替える都合）
+ *
+ * hooks.server.ts 等の SvelteKit 起動パスから1度だけ呼ぶ想定。
+ */
+export function assertLicenseKeyConfigured(): void {
+	const hasSecret = Boolean(getLicenseSecret());
+	if (hasSecret) return;
+
+	if (isProduction()) {
+		throw new Error(
+			'[LICENSE] AWS_LICENSE_SECRET is required in production. ' +
+				"Generate one with: `node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"` " +
+				'and set it in your environment (e.g. AWS SSM Parameter Store). ' +
+				'See .env.example and docs/decisions/0026-license-key-architecture.md.',
+		);
+	}
+
+	// Avoid noise during `vitest` runs — tests drive env manually.
+	if (process.env.NODE_ENV === 'test') return;
+
+	logger.warn(
+		'[LICENSE] AWS_LICENSE_SECRET is not set. ' +
+			'HMAC-signed license keys will fall back to legacy format. ' +
+			'This is OK for local dev but MUST be set in production.',
+	);
 }
 
 /** ペイロードから HMAC-SHA256 チェックサムを生成 (KEY_CHARS エンコード, 5文字) */
@@ -131,6 +185,17 @@ export async function validateLicenseKey(
 
 	if (!isLegacy && !isSigned) {
 		return { valid: false, reason: 'ライセンスキーの形式が不正です' };
+	}
+
+	// 旧形式キーは production では原則拒否（#806）
+	// 移行期に限り `ALLOW_LEGACY_LICENSE_KEYS=true` で明示的に許可可能。
+	// dev/test では常に受け入れる（既存テスト互換性のため）。
+	if (isLegacy && !isLegacyFormatAllowed()) {
+		logger.warn(
+			`[LICENSE] Legacy format rejected in production: ${normalized.slice(0, 7)}... ` +
+				`Set ALLOW_LEGACY_LICENSE_KEYS=true to temporarily permit (migration window only).`,
+		);
+		return { valid: false, reason: 'ライセンスキーが不正です' };
 	}
 
 	// 署名付きキーの場合: HMAC 署名を検証（DB問い合わせ前に拒否可能）

--- a/tests/unit/services/license-key-service.test.ts
+++ b/tests/unit/services/license-key-service.test.ts
@@ -30,6 +30,7 @@ vi.mock('$lib/server/logger', () => ({
 }));
 
 import {
+	assertLicenseKeyConfigured,
 	consumeLicenseKey,
 	createHmacChecksum,
 	generateLicenseKey,
@@ -809,5 +810,142 @@ describe('consumeLicenseKey', () => {
 		);
 		// tenant 更新は既に成功している（順序どおり）
 		expect(mockUpdateTenantStripe).toHaveBeenCalled();
+	});
+});
+
+// ============================================================
+// #806: assertLicenseKeyConfigured / production legacy 拒否
+// ============================================================
+
+describe('assertLicenseKeyConfigured (#806)', () => {
+	const originalNodeEnv = process.env.NODE_ENV;
+	const originalSecret = process.env.AWS_LICENSE_SECRET;
+
+	afterEach(() => {
+		process.env.NODE_ENV = originalNodeEnv;
+		process.env.AWS_LICENSE_SECRET = originalSecret;
+	});
+
+	it('production + secret 未設定で throw する（誤デプロイ検知）', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.AWS_LICENSE_SECRET = '';
+
+		expect(() => assertLicenseKeyConfigured()).toThrow(/AWS_LICENSE_SECRET is required/);
+	});
+
+	it('production + secret 設定済みで throw しない', () => {
+		process.env.NODE_ENV = 'production';
+		process.env.AWS_LICENSE_SECRET = TEST_SECRET;
+
+		expect(() => assertLicenseKeyConfigured()).not.toThrow();
+	});
+
+	it('development + secret 未設定で throw しない（ローカル開発を壊さない）', () => {
+		process.env.NODE_ENV = 'development';
+		process.env.AWS_LICENSE_SECRET = '';
+
+		expect(() => assertLicenseKeyConfigured()).not.toThrow();
+	});
+
+	it('test 環境 + secret 未設定で throw しない', () => {
+		process.env.NODE_ENV = 'test';
+		process.env.AWS_LICENSE_SECRET = '';
+
+		expect(() => assertLicenseKeyConfigured()).not.toThrow();
+	});
+});
+
+describe('validateLicenseKey legacy 形式の production 拒否 (#806)', () => {
+	const originalNodeEnv = process.env.NODE_ENV;
+	const originalAllowLegacy = process.env.ALLOW_LEGACY_LICENSE_KEYS;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		process.env.NODE_ENV = originalNodeEnv;
+		if (originalAllowLegacy === undefined) {
+			delete process.env.ALLOW_LEGACY_LICENSE_KEYS;
+		} else {
+			process.env.ALLOW_LEGACY_LICENSE_KEYS = originalAllowLegacy;
+		}
+		process.env.AWS_LICENSE_SECRET = '';
+	});
+
+	it('production では legacy 形式キーを DB 問い合わせなしで拒否する', async () => {
+		process.env.NODE_ENV = 'production';
+		process.env.AWS_LICENSE_SECRET = TEST_SECRET;
+		delete process.env.ALLOW_LEGACY_LICENSE_KEYS;
+
+		const result = await validateLicenseKey('GQ-ABCD-EFGH-JKLM');
+
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.reason).toBe('ライセンスキーが不正です');
+		}
+		expect(mockFindLicenseKey).not.toHaveBeenCalled();
+	});
+
+	it('production + ALLOW_LEGACY_LICENSE_KEYS=true では legacy 形式を受け入れる (移行期)', async () => {
+		process.env.NODE_ENV = 'production';
+		process.env.AWS_LICENSE_SECRET = TEST_SECRET;
+		process.env.ALLOW_LEGACY_LICENSE_KEYS = 'true';
+
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-ABCD-EFGH-JKLM',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: '2026-01-01T00:00:00Z',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await validateLicenseKey('GQ-ABCD-EFGH-JKLM');
+
+		expect(result.valid).toBe(true);
+		expect(mockFindLicenseKey).toHaveBeenCalledWith('GQ-ABCD-EFGH-JKLM');
+	});
+
+	it('development では legacy 形式を引き続き受け入れる（既存開発フローを壊さない）', async () => {
+		process.env.NODE_ENV = 'development';
+		process.env.AWS_LICENSE_SECRET = '';
+		delete process.env.ALLOW_LEGACY_LICENSE_KEYS;
+
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-ABCD-EFGH-JKLM',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: '2026-01-01T00:00:00Z',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await validateLicenseKey('GQ-ABCD-EFGH-JKLM');
+
+		expect(result.valid).toBe(true);
+	});
+
+	it('production でも署名付きキーは従来どおり受け入れる', async () => {
+		process.env.NODE_ENV = 'production';
+		process.env.AWS_LICENSE_SECRET = TEST_SECRET;
+		delete process.env.ALLOW_LEGACY_LICENSE_KEYS;
+
+		const payload = 'GQ-ABCD-EFGH-JKLM';
+		const checksum = createHmacChecksum(payload, TEST_SECRET);
+		const signedKey = `${payload}-${checksum}`;
+
+		const record: LicenseRecord = {
+			licenseKey: signedKey,
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: '2026-01-01T00:00:00Z',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await validateLicenseKey(signedKey);
+
+		expect(result.valid).toBe(true);
 	});
 });


### PR DESCRIPTION
## Summary

Closes #806

production で `AWS_LICENSE_SECRET` が未設定だと、署名付きキー (GQ-XXXX-XXXX-XXXX-YYYYY) の偽造が可能になり、旧形式 (GQ-XXXX-XXXX-XXXX) を総当たりできる状態でサービスが動いてしまう致命的なセキュリティバグを修正。

## 変更点

- **起動時チェック** (`hooks.server.ts` + `assertLicenseKeyConfigured`)
  - production で `AWS_LICENSE_SECRET` 未設定なら throw → 誤デプロイを早期検知
  - dev では WARN ログ（既存ローカル開発を壊さない）
  - test ではサイレント（vitest が env を切替える都合）
- **legacy 形式の拒否** (`validateLicenseKey`)
  - production では旧形式 `GQ-XXXX-XXXX-XXXX` を DB 問い合わせ前に拒否
  - 移行期のみ `ALLOW_LEGACY_LICENSE_KEYS=true` で明示的に許可可能
  - dev/test は既存フロー互換のため常に受け入れ
- **ドキュメント** (`.env.example`)
  - `AWS_LICENSE_SECRET` の必須化、生成コマンド、SSM 運用の注意書き
  - 移行期フラグ `ALLOW_LEGACY_LICENSE_KEYS` の説明
- **Unit tests** (`license-key-service.test.ts`)
  - `assertLicenseKeyConfigured` 4 件（production/dev/test × secret 有無）
  - `validateLicenseKey` legacy 拒否 4 件（production 拒否 / 移行フラグ / dev 受入 / 署名付きは引き続き受入）

## 受け入れ基準

- [x] 起動時に `AWS_LICENSE_SECRET` が無ければ `Error` で起動失敗（production 限定）
- [x] dev mode でも警告ログを WARN レベルで出す
- [x] legacy format 受け入れは dev + env flag でのみ許可
- [ ] 既存の legacy キーを migrate するスクリプト（再発行） ← **Follow-up issue で対応**
- [x] ドキュメント: `.env.example` に `AWS_LICENSE_SECRET` 必須化と生成コマンド例
- [x] Unit tests

### Follow-up

既存 legacy キーの再発行スクリプトは別 Issue として切り出し予定。本 PR マージ後は `ALLOW_LEGACY_LICENSE_KEYS=true` を一時的に production に設定することで移行期間を確保できる。

## Test plan

- [x] `npx vitest run tests/unit/services/license-key-service.test.ts` → 63 passed (55 existing + 8 new)
- [x] `npx biome check` → clean
- [x] `npx svelte-check` → 0 errors
- [ ] CI 通過確認
- [ ] 本番デプロイ前に SSM Parameter Store に `AWS_LICENSE_SECRET` を投入（別作業）

🤖 Generated with [Claude Code](https://claude.com/claude-code)