### PR TITLE
refactor(plan-limit): resolvePlanTier を resolveFullPlanTier に統一 (#732)

### DIFF
--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -4,7 +4,7 @@
 import { getAuthMode } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import type { TrialTier } from '$lib/server/services/trial-service';
-import { getTrialEndDate, getTrialTier } from '$lib/server/services/trial-service';
+import { getTrialStatus } from '$lib/server/services/trial-service';
 
 export interface PlanLimits {
 	maxChildren: number | null; // null = 無制限
@@ -52,7 +52,17 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 	},
 };
 
-/** テナントのプランティアを判定 */
+/**
+ * テナントのプランティアを判定する同期版（低レベル・internal 用途）。
+ *
+ * 呼び出し元は自前で trialEndDate / trialTier を取得する必要がある。
+ * アプリケーションコード（routes/load, services）は基本的に
+ * {@link resolveFullPlanTier} を使うこと。テストと同ファイル内の
+ * ラッパからのみ呼び出すことを想定している。
+ *
+ * @internal
+ * @see resolveFullPlanTier - 推奨される非同期ラッパ（trial 取得込み）
+ */
 export function resolvePlanTier(
 	licenseStatus: string,
 	planId?: string,
@@ -72,14 +82,26 @@ export function resolvePlanTier(
 	return 'free';
 }
 
-/** テナントのプランティアを非同期で判定（トライアル状態を自動チェック） */
+/**
+ * テナントのプランティアを非同期で判定する（トライアル状態を自動チェック）。
+ *
+ * #732: 全ての server load / services の呼び出し口をこの関数に統一する。
+ * 内部で `getTrialStatus` を 1 回だけ呼び出し、expired 判定を含めて解決する。
+ *
+ * @param tenantId - テナントID
+ * @param licenseStatus - `locals.context?.licenseStatus` （未設定なら 'none' 扱い）
+ * @param planId - `locals.context?.plan`
+ */
 export async function resolveFullPlanTier(
 	tenantId: string,
 	licenseStatus: string,
 	planId?: string,
 ): Promise<PlanTier> {
-	const trialEnd = await getTrialEndDate(tenantId);
-	const trialTierValue = await getTrialTier(tenantId);
+	// getTrialStatus を 1 回だけ呼ぶ。過去実装は getTrialEndDate + getTrialTier を
+	// 別々に呼び、それぞれ内部で getTrialStatus を実行していたため DB 2 回叩いていた。
+	const status = await getTrialStatus(tenantId);
+	const trialEnd = status.isTrialActive ? status.trialEndDate : null;
+	const trialTierValue = status.isTrialActive ? status.trialTier : null;
 	return resolvePlanTier(licenseStatus, planId, trialEnd, trialTierValue);
 }
 

--- a/src/routes/(parent)/admin/+layout.server.ts
+++ b/src/routes/(parent)/admin/+layout.server.ts
@@ -3,7 +3,7 @@ import { DEFAULT_POINT_SETTINGS } from '$lib/domain/point-display';
 import { getAuthMode, requireTenantId } from '$lib/server/auth/factory';
 import { getSettings } from '$lib/server/db/settings-repo';
 import { getDebugPlanSummary } from '$lib/server/debug-plan';
-import { isPaidTier, resolvePlanTier } from '$lib/server/services/plan-limit-service';
+import { isPaidTier, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import { getTrialStatus } from '$lib/server/services/trial-service';
 import type { LayoutServerLoad } from './$types';
 
@@ -31,13 +31,12 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 	};
 
 	const tenantStatus = locals.context?.tenantStatus ?? 'active';
-	// #725: トライアル中にファミリー体験ユーザーが standard 扱いになるバグ修正
-	// trialTier 引数を必ず渡す（トライアル非アクティブ時は null で OK）
-	const planTier = resolvePlanTier(
+	// #732: server load 全体で resolveFullPlanTier に統一。
+	// trial 期限・tier は resolveFullPlanTier が内部で取得する（#725 の両引数漏れも自動解消）。
+	const planTier = await resolveFullPlanTier(
+		tenantId,
 		locals.context?.licenseStatus ?? 'none',
 		locals.context?.plan,
-		trialStatus.isTrialActive ? trialStatus.trialEndDate : null,
-		trialStatus.isTrialActive ? trialStatus.trialTier : null,
 	);
 	const isPremium = isPaidTier(planTier);
 	const tutorialStarted = !!(

--- a/src/routes/(parent)/admin/license/+page.server.ts
+++ b/src/routes/(parent)/admin/license/+page.server.ts
@@ -9,7 +9,7 @@ import { getAllChildren } from '$lib/server/services/child-service';
 import { consumeLicenseKey, validateLicenseKey } from '$lib/server/services/license-key-service';
 import { getLicenseInfo } from '$lib/server/services/license-service';
 import { getLoyaltyInfo } from '$lib/server/services/loyalty-service';
-import { getPlanLimits, resolvePlanTier } from '$lib/server/services/plan-limit-service';
+import { getPlanLimits, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import { getTrialStatus, startTrial } from '$lib/server/services/trial-service';
 import { isStripeEnabled } from '$lib/server/stripe/client';
 import type { Actions, PageServerLoad } from './$types';
@@ -23,12 +23,11 @@ export const load: PageServerLoad = async ({ locals }) => {
 		getTrialStatus(tenantId),
 	]);
 
-	// プラン利用状況
-	const tier = resolvePlanTier(
+	// プラン利用状況 (#732: resolveFullPlanTier に統一)
+	const tier = await resolveFullPlanTier(
+		tenantId,
 		locals.context?.licenseStatus ?? 'none',
 		locals.context?.plan,
-		trialStatus.isTrialActive ? trialStatus.trialEndDate : null,
-		trialStatus.isTrialActive ? trialStatus.trialTier : null,
 	);
 	const planLimits = getPlanLimits(tier);
 	let activityCount = 0;

--- a/tests/unit/routes/admin-license-apply.test.ts
+++ b/tests/unit/routes/admin-license-apply.test.ts
@@ -48,7 +48,8 @@ vi.mock('$lib/server/services/activity-service', () => ({
 
 vi.mock('$lib/server/services/plan-limit-service', () => ({
 	getPlanLimits: () => ({ maxActivities: 10, maxChildren: 3, historyRetentionDays: 90 }),
-	resolvePlanTier: () => 'free',
+	// #732: admin/license/+page.server.ts は resolveFullPlanTier に移行済み
+	resolveFullPlanTier: async () => 'free',
 }));
 
 vi.mock('$lib/server/stripe/client', () => ({

--- a/tests/unit/services/plan-limit-service.test.ts
+++ b/tests/unit/services/plan-limit-service.test.ts
@@ -18,11 +18,18 @@ vi.mock('$lib/server/auth/factory', () => ({
 }));
 
 // mock trial-service (resolveFullPlanTier depends on it)
-const mockGetTrialEndDate = vi.fn().mockResolvedValue(null);
-const mockGetTrialTier = vi.fn().mockResolvedValue(null);
+// #732: resolveFullPlanTier は getTrialStatus を 1 回だけ呼ぶ形に変更
+const mockGetTrialStatus = vi.fn().mockResolvedValue({
+	isTrialActive: false,
+	trialUsed: false,
+	trialStartDate: null,
+	trialEndDate: null,
+	trialTier: null,
+	daysRemaining: 0,
+	source: null,
+});
 vi.mock('$lib/server/services/trial-service', () => ({
-	getTrialEndDate: (...args: unknown[]) => mockGetTrialEndDate(...args),
-	getTrialTier: (...args: unknown[]) => mockGetTrialTier(...args),
+	getTrialStatus: (...args: unknown[]) => mockGetTrialStatus(...args),
 }));
 
 import {
@@ -132,18 +139,80 @@ describe('plan-limit-service', () => {
 			process.env.AUTH_MODE = 'cognito';
 			const futureDate = new Date();
 			futureDate.setDate(futureDate.getDate() + 3);
-			mockGetTrialEndDate.mockResolvedValue(futureDate.toISOString().slice(0, 10));
-			mockGetTrialTier.mockResolvedValue('standard');
+			mockGetTrialStatus.mockResolvedValue({
+				isTrialActive: true,
+				trialUsed: true,
+				trialStartDate: '2026-04-01',
+				trialEndDate: futureDate.toISOString().slice(0, 10),
+				trialTier: 'standard',
+				daysRemaining: 3,
+				source: 'user_initiated',
+			});
 			const tier = await resolveFullPlanTier('tenant1', 'none');
 			expect(tier).toBe('standard');
-			expect(mockGetTrialEndDate).toHaveBeenCalledWith('tenant1');
-			expect(mockGetTrialTier).toHaveBeenCalledWith('tenant1');
+			expect(mockGetTrialStatus).toHaveBeenCalledWith('tenant1');
+		});
+
+		it('resolves to family when trial is family-tier', async () => {
+			process.env.AUTH_MODE = 'cognito';
+			const futureDate = new Date();
+			futureDate.setDate(futureDate.getDate() + 3);
+			mockGetTrialStatus.mockResolvedValue({
+				isTrialActive: true,
+				trialUsed: true,
+				trialStartDate: '2026-04-01',
+				trialEndDate: futureDate.toISOString().slice(0, 10),
+				trialTier: 'family',
+				daysRemaining: 3,
+				source: 'user_initiated',
+			});
+			const tier = await resolveFullPlanTier('tenant1', 'none');
+			expect(tier).toBe('family');
 		});
 
 		it('resolves to free when no trial', async () => {
 			process.env.AUTH_MODE = 'cognito';
-			mockGetTrialEndDate.mockResolvedValue(null);
-			mockGetTrialTier.mockResolvedValue(null);
+			mockGetTrialStatus.mockResolvedValue({
+				isTrialActive: false,
+				trialUsed: false,
+				trialStartDate: null,
+				trialEndDate: null,
+				trialTier: null,
+				daysRemaining: 0,
+				source: null,
+			});
+			const tier = await resolveFullPlanTier('tenant1', 'none');
+			expect(tier).toBe('free');
+		});
+
+		it('#732: calls getTrialStatus only once per resolution (no duplicate DB query)', async () => {
+			process.env.AUTH_MODE = 'cognito';
+			mockGetTrialStatus.mockResolvedValue({
+				isTrialActive: false,
+				trialUsed: false,
+				trialStartDate: null,
+				trialEndDate: null,
+				trialTier: null,
+				daysRemaining: 0,
+				source: null,
+			});
+			await resolveFullPlanTier('tenant1', 'none');
+			expect(mockGetTrialStatus).toHaveBeenCalledTimes(1);
+		});
+
+		it('#725/#732: trial が非アクティブなら trialTier は無視される', async () => {
+			process.env.AUTH_MODE = 'cognito';
+			const pastDate = new Date();
+			pastDate.setDate(pastDate.getDate() - 5);
+			mockGetTrialStatus.mockResolvedValue({
+				isTrialActive: false,
+				trialUsed: true,
+				trialStartDate: '2026-03-01',
+				trialEndDate: pastDate.toISOString().slice(0, 10),
+				trialTier: 'family',
+				daysRemaining: 0,
+				source: 'user_initiated',
+			});
 			const tier = await resolveFullPlanTier('tenant1', 'none');
 			expect(tier).toBe('free');
 		});


### PR DESCRIPTION
## Summary

Closes #732

`admin/+layout.server.ts` と `admin/license/+page.server.ts` が sync 版の `resolvePlanTier` を直接呼び、`trialStatus.isTrialActive ? ... : null` という冗長な三項演算子で trial 状態を手渡ししていた。`resolvePlanTier` 自身が expired 判定を行うためこの三項演算子は不要。呼び出し規約がファイルごとに異なるため、`resolveFullPlanTier` に統一する。

## 変更点

### 1. `resolveFullPlanTier` の内部最適化

過去実装は `getTrialEndDate` + `getTrialTier` を別々に呼び出しており、それぞれ内部で `getTrialStatus` を実行していたため **1 resolution あたり DB クエリ 2 回**発生していた。`getTrialStatus` を直接 1 回だけ呼ぶ形に変更。

**影響範囲**: この関数を呼ぶ全ての server load / services（約 15 箇所）が自動的に +1 query ぶん高速化。

### 2. admin 配下 2 ファイルの移行

- `src/routes/(parent)/admin/+layout.server.ts`
- `src/routes/(parent)/admin/license/+page.server.ts`

どちらも `resolveFullPlanTier(tenantId, licenseStatus, plan)` に差し替え。trial 引数の手渡しを廃止。#725 の trialTier 渡し漏れバグも構造的に再発しない形になった。

### 3. `resolvePlanTier` に `@internal` JSDoc

アプリケーションコードは `resolveFullPlanTier` を使うべきことを明記。テストと同ファイル内のラッパ（`resolveFullPlanTier`）からのみ呼ばれる。

### 4. ユニットテスト更新

- `getTrialEndDate`/`getTrialTier` の個別モック → `getTrialStatus` 単一モックに統一
- 1 resolution = 1 DB query を保証する回帰テスト追加
- trial family-tier の解決、trial expired 時の tier 無視挙動のテスト追加
- `admin-license-apply.test.ts` のモックも `resolveFullPlanTier` に修正

## Acceptance Criteria

- [x] admin 配下すべての server load で `resolveFullPlanTier` 経由に統一
- [x] grep で `resolvePlanTier(` を呼ぶ箇所がテスト以外に存在しない（定義と同ファイル内ラッパのみ）
- [x] 単体テスト追加（trial active/inactive/expired、1-query 保証）

## Test plan

- [x] `npx vitest run tests/unit/services/` → 1389 passed
- [x] `npx vitest run tests/unit/routes/` → 59 passed
- [x] `npx biome check` → clean
- [x] `npx svelte-check` → 0 errors
- [ ] CI 通過確認

## 関連

- #725 (trial family bug) の根本対策
- #726 と同テーマ

🤖 Generated with [Claude Code](https://claude.com/claude-code)