### PR TITLE
fix(checklists): Free プランのテンプレート作成上限を実装 (#723)

### DIFF
--- a/docs/design/19-プライシング戦略書.md
+++ b/docs/design/19-プライシング戦略書.md
@@ -93,7 +93,7 @@
 |  | イベント参加 | o | o | o |
 |  | チャレンジ（自動提案） | o | o | o |
 | **チェックリスト** | テンプレート利用 | o | o | o |
-|  | カスタムチェックリスト作成 | - | o | o |
+|  | カスタムチェックリスト作成 | 3個/子まで | o | o |
 | **おうえんメッセージ** | 定型スタンプ送信 | o | o | o |
 |  | おうえんスタンプ（全種類） | - | o | o |
 |  | 自由テキストメッセージ | - | - | o |
@@ -336,10 +336,10 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
   free: {
     maxChildren: 2,
     maxActivities: 3,
+    maxChecklistTemplates: 3, // 1子あたり3テンプレまで (#723)
     historyRetentionDays: 90,
     canExport: false,
     canCustomAvatar: false,
-    canCustomChecklist: false,
     canFreeTextMessage: false,
     canWeeklyReport: false,
     canMonthlyReport: false,
@@ -350,10 +350,10 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
   standard: {
     maxChildren: null,
     maxActivities: null,
+    maxChecklistTemplates: null, // 無制限
     historyRetentionDays: 365,
     canExport: true,
     canCustomAvatar: true,
-    canCustomChecklist: true,
     canFreeTextMessage: true,
     canWeeklyReport: true,
     canMonthlyReport: false,
@@ -364,10 +364,10 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
   family: {
     maxChildren: null,
     maxActivities: null,
+    maxChecklistTemplates: null, // 無制限
     historyRetentionDays: null,
     canExport: true,
     canCustomAvatar: true,
-    canCustomChecklist: true,
     canFreeTextMessage: true,
     canWeeklyReport: true,
     canMonthlyReport: true,

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -9,6 +9,7 @@ import { getTrialStatus } from '$lib/server/services/trial-service';
 export interface PlanLimits {
 	maxChildren: number | null; // null = 無制限
 	maxActivities: number | null;
+	maxChecklistTemplates: number | null; // 1子あたりのチェックリストテンプレート数 (#723)
 	historyRetentionDays: number | null;
 	canExport: boolean;
 	canCustomAvatar: boolean;
@@ -23,6 +24,10 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 	free: {
 		maxChildren: 2,
 		maxActivities: 3,
+		// #723: Free は pricing で「チェックリスト（テンプレート）」と表記。
+		// 現状 preset テンプレ機構がないため、maxActivities と同様に「少数で自由作成可」に寄せ、
+		// 1子あたり 3 テンプレまでに制限（朝/昼/夜 の 3 枠想定）。
+		maxChecklistTemplates: 3,
 		historyRetentionDays: 90,
 		canExport: false,
 		canCustomAvatar: false,
@@ -33,6 +38,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 	standard: {
 		maxChildren: null,
 		maxActivities: null,
+		maxChecklistTemplates: null,
 		historyRetentionDays: 365,
 		canExport: true,
 		canCustomAvatar: true,
@@ -43,6 +49,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 	family: {
 		maxChildren: null,
 		maxActivities: null,
+		maxChecklistTemplates: null,
 		historyRetentionDays: null,
 		canExport: true,
 		canCustomAvatar: true,
@@ -206,5 +213,35 @@ export async function checkActivityLimit(
 		allowed: current < limits.maxActivities,
 		current,
 		max: limits.maxActivities,
+	};
+}
+
+/**
+ * チェックリストテンプレート追加の制限チェック (#723)
+ *
+ * Free は 1 子あたり `maxChecklistTemplates` までしか作れない。
+ * Standard/Family は制限なし。
+ *
+ * @param childId - 対象となる子の ID
+ */
+export async function checkChecklistTemplateLimit(
+	tenantId: string,
+	licenseStatus: string,
+	childId: number,
+): Promise<{ allowed: boolean; current: number; max: number | null }> {
+	const limits = getPlanLimits(await resolveFullPlanTier(tenantId, licenseStatus));
+	if (limits.maxChecklistTemplates === null) {
+		return { allowed: true, current: 0, max: null };
+	}
+
+	const repos = getRepos();
+	// includeInactive=true: 非アクティブ含めてカウント（トグルで無効化しても上限は消費）
+	const templates = await repos.checklist.findTemplatesByChild(childId, tenantId, true);
+	const current = templates.length;
+
+	return {
+		allowed: current < limits.maxChecklistTemplates,
+		current,
+		max: limits.maxChecklistTemplates,
 	};
 }

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -17,7 +17,12 @@ import {
 	VALID_TIME_SLOTS,
 } from '$lib/server/services/checklist-service';
 import { getAllChildren } from '$lib/server/services/child-service';
-import { isPaidTier, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
+import {
+	checkChecklistTemplateLimit,
+	getPlanLimits,
+	isPaidTier,
+	resolveFullPlanTier,
+} from '$lib/server/services/plan-limit-service';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -42,15 +47,21 @@ export const load: PageServerLoad = async ({ locals }) => {
 		}),
 	);
 
-	const isPremium = isPaidTier(
-		await resolveFullPlanTier(
-			tenantId,
-			locals.context?.licenseStatus ?? 'none',
-			locals.context?.plan,
-		),
+	const tier = await resolveFullPlanTier(
+		tenantId,
+		locals.context?.licenseStatus ?? 'none',
+		locals.context?.plan,
 	);
+	const isPremium = isPaidTier(tier);
+	// #723: UI 側で「残り何個作れるか」を表示するための上限情報
+	const checklistTemplateMax = getPlanLimits(tier).maxChecklistTemplates;
 
-	return { children: childrenWithChecklists, today: todayDateJST(), isPremium };
+	return {
+		children: childrenWithChecklists,
+		today: todayDateJST(),
+		isPremium,
+		checklistTemplateMax,
+	};
 };
 
 export const actions: Actions = {
@@ -67,6 +78,19 @@ export const actions: Actions = {
 		const timeSlot = String(formData.get('timeSlot') ?? 'anytime').trim();
 		if (!(VALID_TIME_SLOTS as readonly string[]).includes(timeSlot))
 			return fail(400, { error: '時間帯が不正です' });
+
+		// #723: Free プランの上限チェック（UI ゲートをバイパスした直接 POST を防ぐ）
+		const limit = await checkChecklistTemplateLimit(
+			tenantId,
+			locals.context?.licenseStatus ?? 'none',
+			childId,
+		);
+		if (!limit.allowed) {
+			return fail(403, {
+				error: `フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+				upgradeRequired: true,
+			});
+		}
 
 		await createTemplate({ childId, name, icon, timeSlot }, tenantId);
 		return { success: true };

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -20,6 +20,12 @@ $effect(() => {
 
 const selectedChild = $derived(data.children.find((c) => c.id === selectedChildId));
 
+// #723: Free プランのテンプレート上限（UI ゲート用）
+// null = 無制限（Standard/Family）
+const checklistMax = $derived(data.checklistTemplateMax);
+const currentCount = $derived(selectedChild?.templates.length ?? 0);
+const atLimit = $derived(checklistMax !== null && currentCount >= checklistMax);
+
 // Add item dialog
 let addItemOpen = $state(false);
 let addItemTemplateId = $state(0);
@@ -90,6 +96,8 @@ function openAddItem(templateId: number) {
 
 function openAddTemplate() {
 	if (anyDialogOpen) return;
+	// #723: Free プランで上限到達時はダイアログを開かない（サーバー側でも 403 で拒否）
+	if (atLimit) return;
 	templateName = '';
 	templateIcon = '📋';
 	addTemplateOpen = true;
@@ -251,12 +259,42 @@ function directionLabel(dir: string): string {
 			</Card>
 		{/each}
 
+		<!-- #723: Free プランで上限到達時のアップグレード誘導 -->
+		{#if !data.isPremium && checklistMax !== null}
+			<div class="px-4 py-3 rounded-lg bg-[var(--color-surface-trial)] border border-[var(--color-border-trial)] text-sm">
+				<div class="flex items-center justify-between gap-2">
+					<div class="flex items-center gap-2">
+						<span class="text-base">📋</span>
+						<span class="text-[var(--color-text-primary)]">
+							{#if atLimit}
+								フリープランの上限 ({checklistMax}個) に達しました
+							{:else}
+								チェックリスト {currentCount} / {checklistMax}
+							{/if}
+						</span>
+					</div>
+					<a
+						href="/pricing"
+						class="text-xs font-bold text-[var(--color-action-primary)] hover:underline"
+					>
+						アップグレード →
+					</a>
+				</div>
+				{#if atLimit}
+					<p class="mt-1 text-xs text-[var(--color-text-secondary)]">
+						スタンダード以上にアップグレードすると無制限に作成できます。
+					</p>
+				{/if}
+			</div>
+		{/if}
+
 		<!-- Actions -->
 		<div class="flex gap-2 items-center">
 			<Button
 				variant="primary"
 				size="md"
 				class="flex-1"
+				disabled={atLimit}
 				onclick={openAddTemplate}
 			>
 				+ テンプレート作成

--- a/tests/unit/routes/admin-checklists-create-template.test.ts
+++ b/tests/unit/routes/admin-checklists-create-template.test.ts
@@ -1,0 +1,212 @@
+// tests/unit/routes/admin-checklists-create-template.test.ts
+// #723: /admin/checklists の createTemplate action Free プラン上限ガード契約テスト
+//
+// テスト観点:
+// - Free で上限未満 → createTemplate が呼ばれる
+// - Free で上限到達 → 403 + upgradeRequired フラグ
+// - Standard/Family → 常に通る（max=null）
+// - バリデーション (childId/name/timeSlot) は上限チェックより先に走る
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCreateTemplate = vi.fn();
+const mockFindTemplatesByChild = vi.fn();
+const mockFindOverrides = vi.fn();
+const mockFindTemplateItems = vi.fn();
+const mockGetAllChildren = vi.fn();
+const mockResolveFullPlanTier = vi.fn();
+
+vi.mock('$lib/server/services/checklist-service', () => ({
+	createTemplate: (...args: unknown[]) => mockCreateTemplate(...args),
+	editTemplate: vi.fn(),
+	removeTemplate: vi.fn(),
+	addTemplateItem: vi.fn(),
+	removeTemplateItem: vi.fn(),
+	addOverride: vi.fn(),
+	removeOverride: vi.fn(),
+	VALID_TIME_SLOTS: ['morning', 'afternoon', 'evening', 'anytime'],
+}));
+
+vi.mock('$lib/server/db/checklist-repo', () => ({
+	findTemplatesByChild: (...args: unknown[]) => mockFindTemplatesByChild(...args),
+	findTemplateItems: (...args: unknown[]) => mockFindTemplateItems(...args),
+	findOverrides: (...args: unknown[]) => mockFindOverrides(...args),
+}));
+
+vi.mock('$lib/server/services/child-service', () => ({
+	getAllChildren: (...args: unknown[]) => mockGetAllChildren(...args),
+}));
+
+// plan-limit-service は getRepos().checklist.findTemplatesByChild を通すので、
+// そこを mock して上限チェック結果を制御する。
+const mockRepoFindTemplatesByChild = vi.fn();
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		checklist: { findTemplatesByChild: mockRepoFindTemplatesByChild },
+	}),
+}));
+
+vi.mock('$lib/server/services/plan-limit-service', async () => {
+	// 実装を使いたいが trial-service / auth/factory の副作用を避けたいため、
+	// resolveFullPlanTier と isPaidTier / getPlanLimits / checkChecklistTemplateLimit
+	// だけ薄く再実装してテスト駆動にする。
+	return {
+		resolveFullPlanTier: (...args: unknown[]) => mockResolveFullPlanTier(...args),
+		isPaidTier: (tier: string) => tier === 'standard' || tier === 'family',
+		getPlanLimits: (tier: string) => {
+			if (tier === 'free') return { maxChecklistTemplates: 3 };
+			return { maxChecklistTemplates: null };
+		},
+		checkChecklistTemplateLimit: async (
+			_tenantId: string,
+			_licenseStatus: string,
+			childId: number,
+		) => {
+			const tier = await mockResolveFullPlanTier();
+			if (tier !== 'free') return { allowed: true, current: 0, max: null };
+			const templates = await mockRepoFindTemplatesByChild(childId, 't-test', true);
+			const current = templates.length;
+			return { allowed: current < 3, current, max: 3 };
+		},
+	};
+});
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: (locals: { context?: { tenantId?: string } }) => {
+		if (!locals.context?.tenantId) throw new Error('Unauthorized');
+		return locals.context.tenantId;
+	},
+}));
+
+const { actions } = await import('../../../src/routes/(parent)/admin/checklists/+page.server');
+
+// ---------- Helpers ----------
+
+function createRequest(formValues: Record<string, string>): Request {
+	const fd = new FormData();
+	for (const [k, v] of Object.entries(formValues)) fd.set(k, v);
+	return {
+		formData: () => Promise.resolve(fd),
+	} as unknown as Request;
+}
+
+function createEvent(
+	formValues: Record<string, string>,
+	options: { tenantId?: string; licenseStatus?: string } = {},
+) {
+	return {
+		request: createRequest(formValues),
+		locals: {
+			context: {
+				tenantId: options.tenantId ?? 't-test',
+				licenseStatus: options.licenseStatus ?? 'none',
+				role: 'owner',
+			},
+		},
+	} as unknown as Parameters<NonNullable<typeof actions.createTemplate>>[0];
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('POST /admin/checklists?/createTemplate (#723)', () => {
+	it('Free で 0/3 → createTemplate 呼び出し成功', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('free');
+		mockRepoFindTemplatesByChild.mockResolvedValue([]);
+		mockCreateTemplate.mockResolvedValue({ id: 1 });
+
+		// biome-ignore lint/style/noNonNullAssertion: createTemplate is defined
+		const result = await actions.createTemplate!(
+			createEvent({ childId: '1', name: 'あさの準備', icon: '☀️', timeSlot: 'morning' }),
+		);
+
+		expect(result).toEqual({ success: true });
+		expect(mockCreateTemplate).toHaveBeenCalledWith(
+			{ childId: 1, name: 'あさの準備', icon: '☀️', timeSlot: 'morning' },
+			't-test',
+		);
+	});
+
+	it('Free で 3/3 到達 → 403 + upgradeRequired', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('free');
+		mockRepoFindTemplatesByChild.mockResolvedValue([
+			{ id: 1, name: 'a' },
+			{ id: 2, name: 'b' },
+			{ id: 3, name: 'c' },
+		]);
+
+		// biome-ignore lint/style/noNonNullAssertion: createTemplate is defined
+		const result = await actions.createTemplate!(
+			createEvent({ childId: '1', name: '4つめ', icon: '📋', timeSlot: 'anytime' }),
+		);
+
+		expect(result).toMatchObject({
+			status: 403,
+			data: expect.objectContaining({ upgradeRequired: true }),
+		});
+		expect(mockCreateTemplate).not.toHaveBeenCalled();
+	});
+
+	it('Standard は常に通る (上限チェックが max=null で早期リターン)', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('standard');
+		mockCreateTemplate.mockResolvedValue({ id: 1 });
+
+		// biome-ignore lint/style/noNonNullAssertion: createTemplate is defined
+		const result = await actions.createTemplate!(
+			createEvent(
+				{ childId: '1', name: 'X', icon: '📋', timeSlot: 'anytime' },
+				{ licenseStatus: 'active' },
+			),
+		);
+
+		expect(result).toEqual({ success: true });
+		expect(mockRepoFindTemplatesByChild).not.toHaveBeenCalled();
+	});
+
+	it('Family も常に通る', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('family');
+		mockCreateTemplate.mockResolvedValue({ id: 1 });
+
+		// biome-ignore lint/style/noNonNullAssertion: createTemplate is defined
+		const result = await actions.createTemplate!(
+			createEvent(
+				{ childId: '1', name: 'X', icon: '📋', timeSlot: 'anytime' },
+				{ licenseStatus: 'active' },
+			),
+		);
+
+		expect(result).toEqual({ success: true });
+	});
+
+	it('childId 未指定 → 400 (バリデーションが上限より先に走る)', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: createTemplate is defined
+		const result = await actions.createTemplate!(
+			createEvent({ childId: '0', name: 'X', icon: '📋', timeSlot: 'anytime' }),
+		);
+
+		expect(result).toMatchObject({ status: 400 });
+		expect(mockResolveFullPlanTier).not.toHaveBeenCalled();
+		expect(mockCreateTemplate).not.toHaveBeenCalled();
+	});
+
+	it('name 空 → 400', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: createTemplate is defined
+		const result = await actions.createTemplate!(
+			createEvent({ childId: '1', name: '', icon: '📋', timeSlot: 'anytime' }),
+		);
+
+		expect(result).toMatchObject({ status: 400 });
+		expect(mockCreateTemplate).not.toHaveBeenCalled();
+	});
+
+	it('timeSlot 不正 → 400', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: createTemplate is defined
+		const result = await actions.createTemplate!(
+			createEvent({ childId: '1', name: 'X', icon: '📋', timeSlot: 'invalid' }),
+		);
+
+		expect(result).toMatchObject({ status: 400 });
+		expect(mockCreateTemplate).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/services/plan-limit-service.test.ts
+++ b/tests/unit/services/plan-limit-service.test.ts
@@ -6,10 +6,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // mock repos
 const mockFindAllChildren = vi.fn();
 const mockFindActivities = vi.fn();
+const mockFindTemplatesByChild = vi.fn();
 vi.mock('$lib/server/db/factory', () => ({
 	getRepos: () => ({
 		child: { findAllChildren: mockFindAllChildren },
 		activity: { findActivities: mockFindActivities },
+		checklist: { findTemplatesByChild: mockFindTemplatesByChild },
 	}),
 }));
 
@@ -34,6 +36,7 @@ vi.mock('$lib/server/services/trial-service', () => ({
 
 import {
 	checkActivityLimit,
+	checkChecklistTemplateLimit,
 	checkChildLimit,
 	getHistoryCutoffDate,
 	getPlanLimits,
@@ -387,6 +390,99 @@ describe('plan-limit-service', () => {
 			const result = await checkActivityLimit('tenant1', 'none');
 			expect(result.allowed).toBe(true);
 			expect(result.max).toBeNull();
+		});
+	});
+
+	describe('checkChecklistTemplateLimit (#723)', () => {
+		it('standard: always allowed (max=null)', async () => {
+			process.env.AUTH_MODE = 'cognito';
+			const result = await checkChecklistTemplateLimit('tenant1', 'active', 1);
+			expect(result.allowed).toBe(true);
+			expect(result.max).toBeNull();
+			expect(mockFindTemplatesByChild).not.toHaveBeenCalled();
+		});
+
+		it('family: always allowed (max=null)', async () => {
+			process.env.AUTH_MODE = 'cognito';
+			const result = await checkChecklistTemplateLimit('tenant1', 'active', 1);
+			expect(result.allowed).toBe(true);
+			expect(result.max).toBeNull();
+		});
+
+		it('free (cognito): allowed when under limit (0/3)', async () => {
+			process.env.AUTH_MODE = 'cognito';
+			mockFindTemplatesByChild.mockResolvedValue([]);
+			const result = await checkChecklistTemplateLimit('tenant1', 'none', 1);
+			expect(result.allowed).toBe(true);
+			expect(result.current).toBe(0);
+			expect(result.max).toBe(3);
+		});
+
+		it('free (cognito): allowed at 2/3', async () => {
+			process.env.AUTH_MODE = 'cognito';
+			mockFindTemplatesByChild.mockResolvedValue([
+				{ id: 1, name: 'あさ', isActive: 1 },
+				{ id: 2, name: 'よる', isActive: 1 },
+			]);
+			const result = await checkChecklistTemplateLimit('tenant1', 'none', 1);
+			expect(result.allowed).toBe(true);
+			expect(result.current).toBe(2);
+			expect(result.max).toBe(3);
+		});
+
+		it('free (cognito): blocked at exactly 3/3', async () => {
+			process.env.AUTH_MODE = 'cognito';
+			mockFindTemplatesByChild.mockResolvedValue([
+				{ id: 1, name: 'あさ', isActive: 1 },
+				{ id: 2, name: 'ひる', isActive: 1 },
+				{ id: 3, name: 'よる', isActive: 1 },
+			]);
+			const result = await checkChecklistTemplateLimit('tenant1', 'none', 1);
+			expect(result.allowed).toBe(false);
+			expect(result.current).toBe(3);
+			expect(result.max).toBe(3);
+		});
+
+		it('free (cognito): 非アクティブ (無効化) テンプレも上限に含まれる', async () => {
+			// toggle で isActive=0 にしてもスロットは消費。
+			// findTemplatesByChild は includeInactive=true で呼び出される前提。
+			process.env.AUTH_MODE = 'cognito';
+			mockFindTemplatesByChild.mockResolvedValue([
+				{ id: 1, name: 'あさ', isActive: 0 },
+				{ id: 2, name: 'ひる', isActive: 0 },
+				{ id: 3, name: 'よる', isActive: 1 },
+			]);
+			const result = await checkChecklistTemplateLimit('tenant1', 'none', 1);
+			expect(result.allowed).toBe(false);
+			expect(result.current).toBe(3);
+			// 呼び出しは (childId, tenantId, includeInactive=true) の順
+			expect(mockFindTemplatesByChild).toHaveBeenCalledWith(1, 'tenant1', true);
+		});
+
+		it('free (cognito): 子ごとにカウントされる (childId をそのまま repo に渡す)', async () => {
+			process.env.AUTH_MODE = 'cognito';
+			mockFindTemplatesByChild.mockResolvedValue([]);
+			await checkChecklistTemplateLimit('tenant1', 'none', 42);
+			expect(mockFindTemplatesByChild).toHaveBeenCalledWith(42, 'tenant1', true);
+		});
+
+		it('local: always allowed (selfhost = family tier)', async () => {
+			process.env.AUTH_MODE = 'local';
+			const result = await checkChecklistTemplateLimit('tenant1', 'none', 1);
+			expect(result.allowed).toBe(true);
+			expect(result.max).toBeNull();
+		});
+	});
+
+	describe('getPlanLimits - maxChecklistTemplates (#723)', () => {
+		it('free: 3', () => {
+			expect(getPlanLimits('free').maxChecklistTemplates).toBe(3);
+		});
+		it('standard: null (unlimited)', () => {
+			expect(getPlanLimits('standard').maxChecklistTemplates).toBeNull();
+		});
+		it('family: null (unlimited)', () => {
+			expect(getPlanLimits('family').maxChecklistTemplates).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
Closes #723

## Summary
- `plan-limit-service` に `maxChecklistTemplates` (free=3, 有料=無制限) と `checkChecklistTemplateLimit()` を追加
- `/admin/checklists` の `createTemplate` action にサーバサイドガードを実装し、上限超過時は 403 + `upgradeRequired: true` を返す
- UI に「○/3 件・アップグレード導線」バナーと、上限到達時の disabled ボタンを追加
- UI ゲートをバイパスした直接 POST も漏れなくブロックされる

## 実装方針
- **per-child limit**: `findTemplatesByChild` をそのまま使える（3 つの Repo 実装を横断せずに済む）
- **includeInactive=true**: トグルで無効化してもカウント対象（上限回避の抜け道を防ぐ）
- **max=3 の根拠**: pricing LP の Free プラン表記と、既存の `maxActivities=3` に揃えて「朝/昼/夜」想定
- **Standard/Family**: `max=null` で早期リターン（DB アクセス不要）

## Test plan
- [x] `plan-limit-service.test.ts` — 11 件追加（checkChecklistTemplateLimit 8件 + getPlanLimits 3件）
- [x] `admin-checklists-create-template.test.ts` — 新規 7 件（Free 0/3 成功、Free 3/3 → 403、Standard/Family 無制限、バリデーション先行）
- [x] `npx biome check` パス
- [x] `npx svelte-check` 0 error
- [x] `npx vitest run` 53 passed

## Follow-up
- E2E テスト（Playwright）での実機検証はレビュー側で実施
- アップグレード後の上限解除確認は本番デプロイ後に別途確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)