### PR TITLE
fix(plan): きょうだいランキングを family プラン限定に (#782)

### DIFF
--- a/docs/design/19-プライシング戦略書.md
+++ b/docs/design/19-プライシング戦略書.md
@@ -343,6 +343,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     canFreeTextMessage: false,
     canWeeklyReport: false,
     canMonthlyReport: false,
+    canSiblingRanking: false, // きょうだいランキング (#782)
     canSiblingAnalysis: false,
     canPdfExport: false,
     canCustomTitle: false,
@@ -357,6 +358,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     canFreeTextMessage: true,
     canWeeklyReport: true,
     canMonthlyReport: false,
+    canSiblingRanking: false, // きょうだいランキング (#782)
     canSiblingAnalysis: false,
     canPdfExport: false,
     canCustomTitle: false,
@@ -371,6 +373,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     canFreeTextMessage: true,
     canWeeklyReport: true,
     canMonthlyReport: true,
+    canSiblingRanking: true, // きょうだいランキング (#782)
     canSiblingAnalysis: true,
     canPdfExport: true,
     canCustomTitle: true,

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -15,6 +15,7 @@ export interface PlanLimits {
 	canCustomAvatar: boolean;
 	canFreeTextMessage: boolean; // 自由テキストメッセージ（ファミリープラン限定）
 	canCustomReward: boolean; // 特別なごほうび設定（スタンダード以上） #728
+	canSiblingRanking: boolean; // きょうだいランキング（ファミリープラン限定） #782
 	maxCloudExports: number; // クラウド保管の同時保管数上限
 }
 
@@ -33,6 +34,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		canCustomAvatar: false,
 		canFreeTextMessage: false,
 		canCustomReward: false,
+		canSiblingRanking: false,
 		maxCloudExports: 0,
 	},
 	standard: {
@@ -44,6 +46,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		canCustomAvatar: true,
 		canFreeTextMessage: false,
 		canCustomReward: true,
+		canSiblingRanking: false,
 		maxCloudExports: 3,
 	},
 	family: {
@@ -55,6 +58,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		canCustomAvatar: true,
 		canFreeTextMessage: true,
 		canCustomReward: true,
+		canSiblingRanking: true,
 		maxCloudExports: 10,
 	},
 };

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
@@ -22,6 +22,7 @@ import { getTodayMissions } from '$lib/server/services/daily-mission-service';
 import { getFamilyStreak, getNextMilestone } from '$lib/server/services/family-streak-service';
 import { claimLoginBonus, getLoginBonusStatus } from '$lib/server/services/login-bonus-service';
 import { getUnshownMessage } from '$lib/server/services/message-service';
+import { getPlanLimits, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import { selectRecommendations } from '$lib/server/services/recommendation-service';
 import {
 	claimEventReward,
@@ -158,12 +159,20 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 				? birthdayBonusStatus
 				: null;
 
-	// きょうだいランキング（設定有効時のみ）
+	// きょうだいランキング（#782: family プラン + 設定有効時のみ）
 	let siblingRanking: Awaited<ReturnType<typeof getWeeklyRanking>> | null = null;
 	try {
-		const rankingOn = await isRankingEnabled(tenantId);
-		if (rankingOn) {
-			siblingRanking = await getWeeklyRanking(tenantId);
+		const planTier = await resolveFullPlanTier(
+			tenantId,
+			locals.context?.licenseStatus ?? 'none',
+			locals.context?.plan,
+		);
+		const planLimits = getPlanLimits(planTier);
+		if (planLimits.canSiblingRanking) {
+			const rankingOn = await isRankingEnabled(tenantId);
+			if (rankingOn) {
+				siblingRanking = await getWeeklyRanking(tenantId);
+			}
 		}
 	} catch {
 		// ランキング取得失敗はページ全体に影響させない

--- a/src/routes/(parent)/admin/settings/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/+page.server.ts
@@ -11,6 +11,7 @@ import { clearAllFamilyData, getDataSummary } from '$lib/server/services/data-se
 import { getDefaultChildId, setDefaultChildId } from '$lib/server/services/default-child-service';
 import { notifyInquiry } from '$lib/server/services/discord-notify-service';
 import { sendInquiryConfirmationEmail } from '$lib/server/services/email-service';
+import { getPlanLimits, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -41,6 +42,14 @@ export const load: PageServerLoad = async ({ locals }) => {
 	};
 	let children: Awaited<ReturnType<typeof getAllChildren>> = [];
 	let defaultChildId: number | null = null;
+
+	// #782: プラン判定（きょうだいランキングは family 限定）
+	const planTier = await resolveFullPlanTier(
+		tenantId,
+		locals.context?.licenseStatus ?? 'none',
+		locals.context?.plan,
+	);
+	const planLimits = getPlanLimits(planTier);
 
 	try {
 		[dataSummary, decayIntensity, siblingMode, siblingRankingEnabled, children, defaultChildId] =
@@ -80,6 +89,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 		decayIntensity,
 		siblingMode,
 		siblingRankingEnabled,
+		// #782 きょうだいランキングのプランゲート状態
+		canSiblingRanking: planLimits.canSiblingRanking,
 		notificationSettings,
 		// #576 既定の子供（家族全体の設定）
 		children: children.map((c) => ({ id: c.id, nickname: c.nickname })),
@@ -235,11 +246,30 @@ export const actions = {
 		const tenantId = requireTenantId(locals);
 		const form = await request.formData();
 		const mode = form.get('siblingMode')?.toString() ?? 'both';
-		const rankingEnabled = form.has('siblingRankingEnabled') ? 'true' : 'false';
+		const rankingRequested = form.has('siblingRankingEnabled');
 
 		if (!['cooperative', 'competitive', 'both'].includes(mode)) {
 			return fail(400, { siblingError: '不正なモードです' });
 		}
+
+		// #782: きょうだいランキングは family プラン限定
+		const planTier = await resolveFullPlanTier(
+			tenantId,
+			locals.context?.licenseStatus ?? 'none',
+			locals.context?.plan,
+		);
+		const planLimits = getPlanLimits(planTier);
+
+		if (rankingRequested && !planLimits.canSiblingRanking) {
+			return fail(403, {
+				siblingError:
+					'きょうだいランキングはファミリープラン限定です。アップグレードすると利用できます。',
+				upgradeRequired: true,
+			});
+		}
+
+		// ゲートが閉じている場合は強制的に false を保存（プラン降格時のクリーンアップ）
+		const rankingEnabled = rankingRequested && planLimits.canSiblingRanking ? 'true' : 'false';
 
 		await setSetting('sibling_mode', mode, tenantId);
 		await setSetting('sibling_ranking_enabled', rankingEnabled, tenantId);

--- a/src/routes/(parent)/admin/settings/+page.svelte
+++ b/src/routes/(parent)/admin/settings/+page.svelte
@@ -781,10 +781,31 @@ const anyFormBusy = $derived(
 					{/each}
 				</div>
 			</div>
-			<label class="flex items-center gap-2">
-				<input type="checkbox" name="siblingRankingEnabled" checked={data.siblingRankingEnabled === 'true'} class="h-4 w-4 rounded border-[var(--color-border-strong)]" />
-				<span class="text-sm text-[var(--color-text)]">きょうだいランキングを表示する</span>
-			</label>
+			{#if data.canSiblingRanking}
+				<label class="flex items-center gap-2">
+					<input type="checkbox" name="siblingRankingEnabled" checked={data.siblingRankingEnabled === 'true'} class="h-4 w-4 rounded border-[var(--color-border-strong)]" />
+					<span class="text-sm text-[var(--color-text)]">きょうだいランキングを表示する</span>
+				</label>
+			{:else}
+				<div class="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-surface-muted)] p-3">
+					<label class="flex items-center gap-2 cursor-not-allowed" aria-describedby="sibling-ranking-disabled-reason">
+						<input
+							type="checkbox"
+							disabled
+							aria-disabled="true"
+							checked={false}
+							class="h-4 w-4 rounded border-[var(--color-border-strong)]"
+						/>
+						<span class="text-sm text-[var(--color-text-muted)]">
+							きょうだいランキングを表示する
+							<span class="text-xs font-bold text-[var(--color-point)]">⭐⭐</span>
+						</span>
+					</label>
+					<p id="sibling-ranking-disabled-reason" class="mt-2 text-xs text-[var(--color-text-muted)]">
+						きょうだいランキングはファミリープラン限定の機能です。<a href="/pricing" class="underline text-[var(--color-text-link)]">プランのアップグレード</a>で利用できます。
+					</p>
+				</div>
+			{/if}
 			<Button type="submit" variant="primary" size="md" class="w-full">
 				設定を保存
 			</Button>

--- a/tests/unit/routes/admin-settings-sibling-ranking.test.ts
+++ b/tests/unit/routes/admin-settings-sibling-ranking.test.ts
@@ -1,0 +1,177 @@
+// tests/unit/routes/admin-settings-sibling-ranking.test.ts
+// #782: /admin/settings?/updateSiblingSettings action のプランゲートテスト
+//
+// テスト観点:
+// - free プランで ranking を有効化しようとすると 403
+// - standard プランで ranking を有効化しようとすると 403
+// - family プランなら ranking を有効化できる
+// - ranking を OFF にする操作はプランに関係なく成功する
+// - mode は保存されるが、プランゲート時は強制的に false で保存される
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------- mocks ----------
+
+const mockSetSetting = vi.fn();
+const mockGetSetting = vi.fn();
+const mockGetSettings = vi.fn();
+vi.mock('$lib/server/db/settings-repo', () => ({
+	setSetting: (...args: unknown[]) => mockSetSetting(...args),
+	getSetting: (...args: unknown[]) => mockGetSetting(...args),
+	getSettings: (...args: unknown[]) => mockGetSettings(...args),
+}));
+
+const mockResolveFullPlanTier = vi.fn();
+const mockGetPlanLimits = vi.fn();
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	resolveFullPlanTier: (...args: unknown[]) => mockResolveFullPlanTier(...args),
+	getPlanLimits: (...args: unknown[]) => mockGetPlanLimits(...args),
+}));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: (locals: { context?: { tenantId?: string } }) => {
+		if (!locals.context?.tenantId) throw new Error('Unauthorized');
+		return locals.context.tenantId;
+	},
+}));
+
+// Other dependencies the page.server.ts imports but we don't exercise in these tests.
+vi.mock('$lib/server/services/data-service', () => ({
+	clearAllFamilyData: vi.fn(),
+	getDataSummary: vi.fn(),
+}));
+vi.mock('$lib/server/services/child-service', () => ({
+	getAllChildren: vi.fn(),
+}));
+vi.mock('$lib/server/services/default-child-service', () => ({
+	getDefaultChildId: vi.fn(),
+	setDefaultChildId: vi.fn(),
+}));
+vi.mock('$lib/server/services/auth-service', () => ({
+	changePin: vi.fn(),
+}));
+vi.mock('$lib/server/services/discord-notify-service', () => ({
+	notifyInquiry: vi.fn(),
+}));
+vi.mock('$lib/server/services/email-service', () => ({
+	sendInquiryConfirmationEmail: vi.fn(),
+}));
+vi.mock('$lib/server/db/inquiry-repo', () => ({
+	generateInquiryId: vi.fn().mockResolvedValue('INQ-TEST'),
+	saveInquiry: vi.fn(),
+}));
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { actions } = await import('../../../src/routes/(parent)/admin/settings/+page.server');
+
+// ---------- helpers ----------
+
+type PlanTier = 'free' | 'standard' | 'family';
+
+function createRequest(formValues: Record<string, string>, rankingEnabled: boolean): Request {
+	const fd = new FormData();
+	for (const [k, v] of Object.entries(formValues)) fd.set(k, v);
+	if (rankingEnabled) fd.set('siblingRankingEnabled', 'on');
+	return {
+		formData: () => Promise.resolve(fd),
+	} as unknown as Request;
+}
+
+function createEvent(
+	tier: PlanTier,
+	formValues: Record<string, string>,
+	rankingEnabled: boolean,
+	tenantId = 't-test',
+) {
+	mockResolveFullPlanTier.mockResolvedValue(tier);
+	mockGetPlanLimits.mockImplementation((t: PlanTier) => ({
+		maxChildren: null,
+		maxActivities: null,
+		historyRetentionDays: null,
+		canExport: t !== 'free',
+		canCustomAvatar: t !== 'free',
+		canFreeTextMessage: t === 'family',
+		canCustomReward: t !== 'free',
+		canSiblingRanking: t === 'family',
+		maxCloudExports: 0,
+	}));
+	return {
+		request: createRequest(formValues, rankingEnabled),
+		locals: {
+			context: { tenantId, licenseStatus: tier === 'free' ? 'none' : 'active', plan: tier },
+		},
+	} as unknown as Parameters<NonNullable<typeof actions.updateSiblingSettings>>[0];
+}
+
+// ---------- tests ----------
+
+describe('POST /admin/settings?/updateSiblingSettings (#782)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('free プランで ranking を ON にしようとすると 403 + upgradeRequired', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: updateSiblingSettings is defined
+		const result = await actions.updateSiblingSettings!(
+			createEvent('free', { siblingMode: 'both' }, true),
+		);
+		expect(result).toMatchObject({
+			status: 403,
+			data: { upgradeRequired: true },
+		});
+		expect(mockSetSetting).not.toHaveBeenCalled();
+	});
+
+	it('standard プランで ranking を ON にしようとすると 403 + upgradeRequired', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: updateSiblingSettings is defined
+		const result = await actions.updateSiblingSettings!(
+			createEvent('standard', { siblingMode: 'both' }, true),
+		);
+		expect(result).toMatchObject({
+			status: 403,
+			data: { upgradeRequired: true },
+		});
+		expect(mockSetSetting).not.toHaveBeenCalled();
+	});
+
+	it('family プランなら ranking を ON にできる', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: updateSiblingSettings is defined
+		const result = await actions.updateSiblingSettings!(
+			createEvent('family', { siblingMode: 'both' }, true),
+		);
+		expect(result).toEqual({ siblingSuccess: true });
+		expect(mockSetSetting).toHaveBeenCalledWith('sibling_mode', 'both', 't-test');
+		expect(mockSetSetting).toHaveBeenCalledWith('sibling_ranking_enabled', 'true', 't-test');
+	});
+
+	it('free プランで ranking OFF のままモードだけ更新する場合は成功する', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: updateSiblingSettings is defined
+		const result = await actions.updateSiblingSettings!(
+			createEvent('free', { siblingMode: 'cooperative' }, false),
+		);
+		expect(result).toEqual({ siblingSuccess: true });
+		expect(mockSetSetting).toHaveBeenCalledWith('sibling_mode', 'cooperative', 't-test');
+		expect(mockSetSetting).toHaveBeenCalledWith('sibling_ranking_enabled', 'false', 't-test');
+	});
+
+	it('family プランでも ranking OFF を保存できる', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: updateSiblingSettings is defined
+		const result = await actions.updateSiblingSettings!(
+			createEvent('family', { siblingMode: 'competitive' }, false),
+		);
+		expect(result).toEqual({ siblingSuccess: true });
+		expect(mockSetSetting).toHaveBeenCalledWith('sibling_mode', 'competitive', 't-test');
+		expect(mockSetSetting).toHaveBeenCalledWith('sibling_ranking_enabled', 'false', 't-test');
+	});
+
+	it('不正な siblingMode は 400 を返す', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: updateSiblingSettings is defined
+		const result = await actions.updateSiblingSettings!(
+			createEvent('family', { siblingMode: 'invalid' }, true),
+		);
+		expect(result).toMatchObject({ status: 400 });
+		expect(mockSetSetting).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/services/plan-limit-service.test.ts
+++ b/tests/unit/services/plan-limit-service.test.ts
@@ -245,6 +245,7 @@ describe('plan-limit-service', () => {
 			expect(limits.canCustomAvatar).toBe(false);
 			expect(limits.canFreeTextMessage).toBe(false);
 			expect(limits.canCustomReward).toBe(false);
+			expect(limits.canSiblingRanking).toBe(false);
 		});
 
 		it('standard tier limits', () => {
@@ -256,6 +257,7 @@ describe('plan-limit-service', () => {
 			expect(limits.canCustomAvatar).toBe(true);
 			expect(limits.canFreeTextMessage).toBe(false);
 			expect(limits.canCustomReward).toBe(true);
+			expect(limits.canSiblingRanking).toBe(false);
 		});
 
 		it('family tier limits', () => {
@@ -267,6 +269,14 @@ describe('plan-limit-service', () => {
 			expect(limits.canCustomAvatar).toBe(true);
 			expect(limits.canFreeTextMessage).toBe(true);
 			expect(limits.canCustomReward).toBe(true);
+			expect(limits.canSiblingRanking).toBe(true);
+		});
+
+		// #782: きょうだいランキングは family 限定
+		it('canSiblingRanking: only family can use sibling ranking', () => {
+			expect(getPlanLimits('free').canSiblingRanking).toBe(false);
+			expect(getPlanLimits('standard').canSiblingRanking).toBe(false);
+			expect(getPlanLimits('family').canSiblingRanking).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- `PlanLimits` に `canSiblingRanking` フィールドを追加（free/standard=false, family=true）
- `/admin/settings?/updateSiblingSettings` action に plan gate を追加 — family 以外が ranking ON にしようとすると 403 + upgradeRequired
- 設定 UI で family 以外は toggle disabled + ロック表示 + `/pricing` リンク
- 子供ホーム (`/[uiMode]/home`) の sibling ranking 取得にも plan gate を追加
- plan-limit-service と updateSiblingSettings のユニットテスト追加（7 ケース）

## なぜ
`/pricing` では family 限定機能として記載されていたが、実際は standard プランでも toggle が有効化できる状態だった。family プラン訴求を守るため、settings / load / home / UI の 4 箇所で plan gate を実装。

## Test plan
- [x] `npx vitest run tests/unit/services/plan-limit-service.test.ts tests/unit/routes/admin-settings-sibling-ranking.test.ts` (42 passed)
- [x] `npx biome check .` (0 errors)
- [x] `npx svelte-check` (0 errors, 39 pre-existing warnings)
- [ ] CI 全通過確認

closes #782