### PR TITLE
feat(license): LicenseRecord に expiresAt / revoke metadata を追加 (#797)

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1372,7 +1372,7 @@ T#<tenantId>#COUNTER           // テナント内 ID カウンタ
 
 | エンティティ | PK | SK | 説明 |
 |------------|-----|-----|------|
-| ライセンスキー本体 | `LICENSE#<licenseKey>` | `LICENSE#<licenseKey>` | status (`active`/`consumed`/`revoked`), plan, tenantId, stripeSessionId, consumedBy, consumedAt, revokedReason, revokedAt, createdAt |
+| ライセンスキー本体 | `LICENSE#<licenseKey>` | `LICENSE#<licenseKey>` | status (`active`/`consumed`/`revoked`), plan, tenantId, kind (#801), issuedBy (#801), stripeSessionId, consumedBy, consumedAt, expiresAt (#797), revokedReason, revokedAt, revokedBy (#797), createdAt |
 | ライセンス監査ログ | `LICENSE_EVENT#<licenseKey>` | `EVENT#<ts>#<ulid>` | eventType (`issued`/`consumed`/`revoked`/`rotated`/`verify_failed`/`ops_manual`), actor, metadata。TTL 7 年（会計書類保存期間） |
 
 **主要属性（LicenseRecord）**:
@@ -1382,13 +1382,17 @@ T#<tenantId>#COUNTER           // テナント内 ID カウンタ
 | `licenseKey` | string | ○ | キー本体（`GQ-` プレフィックス + 署名付き 22 文字） |
 | `tenantId` | string | ○ | 発行先テナント |
 | `plan` | enum | ○ | `'monthly' \| 'yearly' \| 'family-monthly' \| 'family-yearly' \| 'lifetime'` |
+| `kind` | enum | △ | **#801**: `'purchase' \| 'gift' \| 'campaign'`。未設定は `purchase` 扱い |
+| `issuedBy` | string | △ | **#801**: 発行 actor。`gift`/`campaign` では必須 |
 | `stripeSessionId` | string | — | Stripe Checkout Session ID（発行元トレース用） |
 | `status` | enum | ○ | `'active' \| 'consumed' \| 'revoked'` |
 | `consumedBy` | string | — | 消費したユーザー ID |
 | `consumedAt` | string (ISO8601) | — | 消費日時 |
+| `expiresAt` | string (ISO8601) | △ | **#797**: キーの有効期限（発行から 90 日をデフォルト）。legacy レコードは未設定＝期限なし扱い |
 | `revokedReason` | enum | — | `'expired' \| 'leaked' \| 'ops-manual' \| 'refund'` |
 | `revokedAt` | string (ISO8601) | — | 失効日時 |
-| `createdAt` | string (ISO8601) | ○ | 発行日時（90日期限の起点） |
+| `revokedBy` | string | — | **#797**: 失効実行者（`ops:<uid>` / `system` / `stripe:<eventId>`） |
+| `createdAt` | string (ISO8601) | ○ | 発行日時（90 日期限の起点） |
 
 **実装リファレンス**: `src/lib/server/services/license-key-service.ts`
 
@@ -1502,3 +1506,4 @@ src/lib/server/db/migration/
 | 2026-04-10 | 4.2 | #605 daily_battles・enemy_collection テーブル追加（バトルアドベンチャー機能） |
 | 2026-04-09 | 4.3 | #609 未記載7テーブル追記（parent_messages, rest_days, tenant_events, tenant_event_progress, auto_challenges, trial_history, viewer_tokens）、廃止テーブル（level_titles, custom_titles）に deprecated 注記追加 |
 | 2026-04-11 | 4.4 | #808 ライセンスキー関連エンティティ追加（LicenseRecord, LicenseEvent）+ GSI2 にテナント別ライセンス一覧パターン追加。詳細は [license-key-lifecycle.md](./license-key-lifecycle.md) を参照 |
+| 2026-04-11 | 4.5 | #801 LicenseRecord に `kind` / `issuedBy` 追加（cross-tenant consume 制御）。#797 LicenseRecord に `expiresAt` / `revokedBy` 追加（有効期限 90 日 + revoke 監査） |

--- a/docs/design/license-key-lifecycle.md
+++ b/docs/design/license-key-lifecycle.md
@@ -99,6 +99,8 @@ GQ-XXXX-XXXX-XXXX-YYYYY
 | `consumedAt` | string (ISO8601) | — | 消費日時 |
 | `revokedReason` | string | — | 失効理由 (`expired` / `leaked` / `ops-manual` / `refund`) |
 | `revokedAt` | string (ISO8601) | — | 失効日時 |
+| `revokedBy` | string | — | **#797**: 失効実行者 (`ops:<uid>` / `system` / `stripe:<eventId>`)。監査要件 |
+| `expiresAt` | string (ISO8601) | △ | **#797**: 有効期限。未設定 (legacy) は期限なし扱い。新規発行は `createdAt + 90 日` をデフォルト |
 | `createdAt` | string (ISO8601) | ○ | 発行日時 |
 
 #### 3.1.1 キー種別 (`kind`) と consume 権限 — #801
@@ -283,12 +285,18 @@ sequenceDiagram
 
 ### 5.5 失効 (revoke)
 
-| トリガ | `revokedReason` | 実施者 |
+| トリガ | `revokedReason` | 実施者 (`revokedBy`) |
 |-------|---------------|-------|
 | 90 日経過バッチ | `'expired'` | `system` |
 | HMAC シークレット漏洩 | `'leaked'` | `ops:<uid>` |
 | Ops 手動失効 | `'ops-manual'` | `ops:<uid>` |
-| Stripe 返金 | `'refund'` | `system` (webhook) |
+| Stripe 返金 | `'refund'` | `stripe:<eventId>` (webhook) |
+
+**#797 実装ポイント**:
+- `revokeLicenseKey(params)` サービスが `IAuthRepo.revokeLicenseKey()` を呼ぶ。`status='revoked'` + `revokedAt` + `revokedReason` + `revokedBy` を**一括更新**する（部分更新で `reason` が欠落するのを防ぐ）
+- `active` 以外のキー (consumed / revoked) は revoke 不可。**冪等**なので既に revoked なキーへの呼び出しはエラー応答のみで副作用なし
+- revoke 後の `validateLicenseKey` / `consumeLicenseKey` は `reason: 'このライセンスキーは無効化されています'` を返す
+- 期限切れ (`expiresAt < now`) は `status='active'` でも `validate` / `consume` で拒否される（バッチ未実行でも安全）
 
 ### 5.6 期限切れバッチ
 
@@ -374,3 +382,4 @@ sequenceDiagram
 |------|---------|--------|
 | 2026-04-11 | 初版作成 (#808) | Claude Code |
 | 2026-04-11 | §3.1 に `kind` / `issuedBy` フィールド追加、§5.4 に cross-tenant 拒否フロー追記 (#801) | Claude Code |
+| 2026-04-11 | §3.1 に `expiresAt` / `revokedBy` フィールド追加、§5.5 に revokeLicenseKey 実装ポイント追記 (#797) | Claude Code |

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -643,6 +643,11 @@ export const saveLicenseKey: IAuthRepo['saveLicenseKey'] = async (record) => {
 				// #801: kind / issuedBy を永続化。undefined のフィールドは DynamoDB に保存しない
 				...(record.kind ? { kind: record.kind } : {}),
 				...(record.issuedBy ? { issuedBy: record.issuedBy } : {}),
+				// #797: expiresAt / revokedAt / revokedReason / revokedBy を永続化
+				...(record.expiresAt ? { expiresAt: record.expiresAt } : {}),
+				...(record.revokedAt ? { revokedAt: record.revokedAt } : {}),
+				...(record.revokedReason ? { revokedReason: record.revokedReason } : {}),
+				...(record.revokedBy ? { revokedBy: record.revokedBy } : {}),
 			},
 		}),
 	);
@@ -666,6 +671,11 @@ export const findLicenseKey: IAuthRepo['findLicenseKey'] = async (key) => {
 		// サービス層の getRecordKind() で 'purchase' デフォルトに解決する。
 		kind: item.kind as LicenseRecord['kind'],
 		issuedBy: item.issuedBy as string | undefined,
+		// #797: 旧レコードには expiresAt/revokedAt 等が存在しない。undefined で返す。
+		expiresAt: item.expiresAt as string | undefined,
+		revokedAt: item.revokedAt as string | undefined,
+		revokedReason: item.revokedReason as LicenseRecord['revokedReason'],
+		revokedBy: item.revokedBy as string | undefined,
 	};
 };
 
@@ -687,6 +697,27 @@ export const updateLicenseKeyStatus: IAuthRepo['updateLicenseKeyStatus'] = async
 			ExpressionAttributeValues: {
 				':status': status,
 				...(consumedBy ? { ':consumedBy': consumedBy, ':consumedAt': now } : {}),
+			},
+		}),
+	);
+};
+
+// #797: revoke 専用のアトミック更新。status + revokedAt + revokedReason + revokedBy を
+// 1 UpdateItem で書き込むことで、status だけ更新されて理由が欠落する事故を防ぐ。
+export const revokeLicenseKey: IAuthRepo['revokeLicenseKey'] = async (params) => {
+	const keys = licenseKeyFn(params.licenseKey);
+	await doc().send(
+		new UpdateCommand({
+			TableName: TABLE_NAME,
+			Key: keys,
+			UpdateExpression:
+				'SET #status = :status, revokedAt = :revokedAt, revokedReason = :revokedReason, revokedBy = :revokedBy',
+			ExpressionAttributeNames: { '#status': 'status' },
+			ExpressionAttributeValues: {
+				':status': 'revoked',
+				':revokedAt': params.revokedAt,
+				':revokedReason': params.reason,
+				':revokedBy': params.revokedBy,
 			},
 		}),
 	);

--- a/src/lib/server/db/interfaces/auth-repo.interface.ts
+++ b/src/lib/server/db/interfaces/auth-repo.interface.ts
@@ -13,7 +13,7 @@ import type {
 	RecordConsentInput,
 	Tenant,
 } from '$lib/server/auth/entities';
-import type { LicenseRecord } from '$lib/server/services/license-key-service';
+import type { LicenseRecord, LicenseRevokeReason } from '$lib/server/services/license-key-service';
 
 export interface IAuthRepo {
 	// --- User ---
@@ -77,4 +77,14 @@ export interface IAuthRepo {
 		status: LicenseRecord['status'],
 		consumedBy?: string,
 	): Promise<void>;
+	/**
+	 * #797: ライセンスキーを失効させる。
+	 * status='revoked' + revokedAt + revokedReason + revokedBy を一括更新。
+	 */
+	revokeLicenseKey(params: {
+		licenseKey: string;
+		reason: LicenseRevokeReason;
+		revokedBy: string;
+		revokedAt: string;
+	}): Promise<void>;
 }

--- a/src/lib/server/db/sqlite/auth-repo.ts
+++ b/src/lib/server/db/sqlite/auth-repo.ts
@@ -108,3 +108,6 @@ export const findLicenseKey: IAuthRepo['findLicenseKey'] = async () => {
 export const updateLicenseKeyStatus: IAuthRepo['updateLicenseKeyStatus'] = async () => {
 	// no-op in local mode
 };
+export const revokeLicenseKey: IAuthRepo['revokeLicenseKey'] = async () => {
+	// no-op in local mode (#797)
+};

--- a/src/lib/server/services/license-key-service.ts
+++ b/src/lib/server/services/license-key-service.ts
@@ -153,6 +153,19 @@ export function generateLicenseKey(): string {
  */
 export type LicenseKeyKind = 'purchase' | 'gift' | 'campaign';
 
+/**
+ * ライセンスキーの失効理由 (#797)
+ *
+ * - `expired`: 有効期限経過バッチによる自動失効 (#818 の期限切れバッチ)
+ * - `leaked`: HMAC シークレット漏洩等で先行的に revoke (#810)
+ * - `ops-manual`: サポートによる手動失効 (#805)
+ * - `refund`: Stripe 返金 webhook による自動失効 (#824)
+ */
+export type LicenseRevokeReason = 'expired' | 'leaked' | 'ops-manual' | 'refund';
+
+/** #797: デフォルト有効期限（発行から 90 日）。競合他社標準 (Keygen 等) に合わせた値。 */
+export const DEFAULT_LICENSE_VALIDITY_DAYS = 90;
+
 export interface LicenseRecord {
 	licenseKey: string;
 	tenantId: string;
@@ -166,6 +179,14 @@ export interface LicenseRecord {
 	kind?: LicenseKeyKind;
 	/** #801: 発行 actor。gift/campaign では必須。purchase では stripe webhook 由来 */
 	issuedBy?: string;
+	/** #797: キーの有効期限 (発行から N 日で失効)。未設定は「永久有効」ではなく legacy 扱い */
+	expiresAt?: string;
+	/** #797: revoke された日時 (status='revoked' と対になる) */
+	revokedAt?: string;
+	/** #797: revoke 理由。監査ログ・CS 対応のために記録 */
+	revokedReason?: LicenseRevokeReason;
+	/** #797: revoke を実行した actor (`ops:<uid>` / `system` / `stripe:<eventId>`) */
+	revokedBy?: string;
 }
 
 /**
@@ -185,6 +206,11 @@ export async function issueLicenseKey(params: {
 	kind?: LicenseKeyKind;
 	/** #801: 発行 actor (ops user id / 'stripe:<sessionId>' 等)。gift/campaign では必須 */
 	issuedBy?: string;
+	/**
+	 * #797: 有効期限 (ISO8601)。省略時は発行日時 + DEFAULT_LICENSE_VALIDITY_DAYS 日。
+	 * 明示的に `null` を渡すと期限なし（lifetime 的扱い）。ops 発行で使用。
+	 */
+	expiresAt?: string | null;
 }): Promise<LicenseRecord> {
 	const kind = params.kind ?? 'purchase';
 
@@ -196,7 +222,23 @@ export async function issueLicenseKey(params: {
 	}
 
 	const key = generateLicenseKey();
-	const now = new Date().toISOString();
+	const nowDate = new Date();
+	const now = nowDate.toISOString();
+
+	// #797: expiresAt の解決
+	// - undefined: デフォルト 90 日後
+	// - null: 期限なし（ops が明示的に渡した場合）
+	// - string: 指定値をそのまま使う
+	let expiresAt: string | undefined;
+	if (params.expiresAt === null) {
+		expiresAt = undefined;
+	} else if (params.expiresAt === undefined) {
+		expiresAt = new Date(
+			nowDate.getTime() + DEFAULT_LICENSE_VALIDITY_DAYS * 24 * 60 * 60 * 1000,
+		).toISOString();
+	} else {
+		expiresAt = params.expiresAt;
+	}
 
 	const record: LicenseRecord = {
 		licenseKey: key,
@@ -207,13 +249,14 @@ export async function issueLicenseKey(params: {
 		createdAt: now,
 		kind,
 		issuedBy: params.issuedBy,
+		expiresAt,
 	};
 
 	const repos = getRepos();
 	await repos.auth.saveLicenseKey(record);
 
 	logger.info(
-		`[LICENSE] Key issued: ${key} for tenant=${params.tenantId} plan=${params.plan} kind=${kind}`,
+		`[LICENSE] Key issued: ${key} for tenant=${params.tenantId} plan=${params.plan} kind=${kind} expiresAt=${expiresAt ?? 'never'}`,
 	);
 	return record;
 }
@@ -272,7 +315,29 @@ export async function validateLicenseKey(
 		return { valid: false, reason: 'このライセンスキーは無効化されています' };
 	}
 
+	// #797: 有効期限チェック。active でも expiresAt を過ぎていたら reject する。
+	// expiresAt が未設定の legacy レコードは期限チェックをスキップ（後方互換）。
+	if (isLicenseExpired(record)) {
+		logger.info(
+			`[LICENSE] Expired key rejected: ${normalized.slice(0, 7)}... expiresAt=${record.expiresAt}`,
+		);
+		return { valid: false, reason: 'このライセンスキーは有効期限が切れています' };
+	}
+
 	return { valid: true, record };
+}
+
+/**
+ * #797: ライセンスレコードが有効期限切れかどうか判定。
+ * - expiresAt が未設定の legacy レコード → false（期限チェックなし）
+ * - expiresAt が現在時刻より前 → true
+ */
+export function isLicenseExpired(
+	record: Pick<LicenseRecord, 'expiresAt'>,
+	now: Date = new Date(),
+): boolean {
+	if (!record.expiresAt) return false;
+	return new Date(record.expiresAt).getTime() < now.getTime();
 }
 
 /** consumeLicenseKey の結果 */
@@ -337,6 +402,14 @@ export async function consumeLicenseKey(
 		return { ok: false, reason: 'ライセンスキーが使用できません' };
 	}
 
+	// #797: 期限切れは active でも consume 拒否。validateLicenseKey と同じルール。
+	if (isLicenseExpired(record)) {
+		logger.info(
+			`[LICENSE] Expired key consume rejected: ${normalized.slice(0, 7)}... expiresAt=${record.expiresAt}`,
+		);
+		return { ok: false, reason: 'このライセンスキーは有効期限が切れています' };
+	}
+
 	// #801: キー種別に応じた consume 権限チェック。
 	// - purchase: buyer tenant にロック (record.tenantId === consumedByTenantId)
 	// - gift / campaign: 任意 tenant が consume 可能
@@ -370,4 +443,65 @@ export async function consumeLicenseKey(
 		`[LICENSE] Key consumed: ${normalized.slice(0, 7)}... by tenant=${consumedByTenantId} (issued for=${record.tenantId}, kind=${kind}) plan=${record.plan} expiresAt=${planExpiresAt ?? 'never'}`,
 	);
 	return { ok: true, plan: record.plan, planExpiresAt };
+}
+
+// ============================================================
+// Revoke (#797, #805)
+// ============================================================
+
+export type RevokeLicenseKeyResult =
+	| { ok: true; licenseKey: string; revokedReason: LicenseRevokeReason; revokedAt: string }
+	| { ok: false; reason: string };
+
+/**
+ * ライセンスキーを失効させる (#797)
+ *
+ * - active → revoked に状態遷移
+ * - revokedAt / revokedReason / revokedBy を記録して監査証跡を残す
+ * - 既に consumed / revoked のキーは再度 revoke できない（冪等性のため同じ理由なら許容）
+ *
+ * 利用想定:
+ * - Ops 手動失効 (#805): `revokedReason='ops-manual'`, `revokedBy='ops:<uid>'`
+ * - 期限切れバッチ (#818): `revokedReason='expired'`, `revokedBy='system'`
+ * - Stripe 返金 (#824): `revokedReason='refund'`, `revokedBy='stripe:<eventId>'`
+ * - シークレット漏洩 (#810): `revokedReason='leaked'`, `revokedBy='ops:<uid>'`
+ */
+export async function revokeLicenseKey(params: {
+	licenseKey: string;
+	reason: LicenseRevokeReason;
+	revokedBy: string;
+}): Promise<RevokeLicenseKeyResult> {
+	const normalized = params.licenseKey.toUpperCase().trim();
+	const repos = getRepos();
+
+	const record = await repos.auth.findLicenseKey(normalized);
+	if (!record) {
+		return { ok: false, reason: 'ライセンスキーが見つかりません' };
+	}
+
+	if (record.status === 'revoked') {
+		logger.info(
+			`[LICENSE] revokeLicenseKey: already revoked: ${normalized.slice(0, 7)}... (reason=${record.revokedReason ?? 'unknown'})`,
+		);
+		return { ok: false, reason: 'このライセンスキーは既に無効化されています' };
+	}
+
+	if (record.status === 'consumed') {
+		// consumed キーも監査目的で revoke 可能だが、現状ユースケースがないため拒否
+		return { ok: false, reason: 'このライセンスキーは既に使用されています' };
+	}
+
+	const revokedAt = new Date().toISOString();
+	await repos.auth.revokeLicenseKey({
+		licenseKey: normalized,
+		reason: params.reason,
+		revokedBy: params.revokedBy,
+		revokedAt,
+	});
+
+	logger.warn(
+		`[LICENSE] Key revoked: ${normalized.slice(0, 7)}... reason=${params.reason} by=${params.revokedBy}`,
+	);
+
+	return { ok: true, licenseKey: normalized, revokedReason: params.reason, revokedAt };
 }

--- a/tests/unit/services/license-key-service.test.ts
+++ b/tests/unit/services/license-key-service.test.ts
@@ -8,6 +8,7 @@ const mockSaveLicenseKey = vi.fn();
 const mockFindLicenseKey = vi.fn();
 const mockUpdateLicenseKeyStatus = vi.fn();
 const mockUpdateTenantStripe = vi.fn();
+const mockRevokeLicenseKey = vi.fn();
 
 vi.mock('$lib/server/db/factory', () => ({
 	getRepos: () => ({
@@ -16,6 +17,7 @@ vi.mock('$lib/server/db/factory', () => ({
 			findLicenseKey: (...args: unknown[]) => mockFindLicenseKey(...args),
 			updateLicenseKeyStatus: (...args: unknown[]) => mockUpdateLicenseKeyStatus(...args),
 			updateTenantStripe: (...args: unknown[]) => mockUpdateTenantStripe(...args),
+			revokeLicenseKey: (...args: unknown[]) => mockRevokeLicenseKey(...args),
 		},
 	}),
 }));
@@ -37,6 +39,7 @@ import {
 	isSignedKeyFormat,
 	issueLicenseKey,
 	type LicenseRecord,
+	revokeLicenseKey,
 	validateLicenseKey,
 	verifyKeySignature,
 } from '$lib/server/services/license-key-service';
@@ -367,6 +370,50 @@ describe('issueLicenseKey', () => {
 		expect(result.kind).toBe('campaign');
 		expect(result.issuedBy).toBe('ops:campaign-2026-spring');
 	});
+
+	// --- #797: expiresAt ---
+
+	it('expiresAt を省略した場合はデフォルト90日後が設定される', async () => {
+		const before = Date.now();
+		const result = await issueLicenseKey({
+			tenantId: 'tenant-default-expiry',
+			plan: 'monthly',
+		});
+		const after = Date.now();
+
+		expect(result.expiresAt).toBeDefined();
+		const expiresMs = new Date(result.expiresAt as string).getTime();
+		const MS_PER_DAY = 24 * 60 * 60 * 1000;
+		// 90 日後 ± 数秒 (テスト実行時間分の誤差)
+		expect(expiresMs).toBeGreaterThanOrEqual(before + 90 * MS_PER_DAY);
+		expect(expiresMs).toBeLessThanOrEqual(after + 90 * MS_PER_DAY);
+	});
+
+	it('expiresAt を明示的に指定した場合はその値が使われる', async () => {
+		const customExpiry = '2027-01-01T00:00:00.000Z';
+		const result = await issueLicenseKey({
+			tenantId: 'tenant-custom-expiry',
+			plan: 'yearly',
+			expiresAt: customExpiry,
+		});
+
+		expect(result.expiresAt).toBe(customExpiry);
+		expect(mockSaveLicenseKey).toHaveBeenCalledWith(
+			expect.objectContaining({ expiresAt: customExpiry }),
+		);
+	});
+
+	it('expiresAt=null を渡すと期限なし (lifetime 扱い)', async () => {
+		const result = await issueLicenseKey({
+			tenantId: 'tenant-lifetime',
+			plan: 'lifetime',
+			expiresAt: null,
+			kind: 'gift',
+			issuedBy: 'ops:admin-1',
+		});
+
+		expect(result.expiresAt).toBeUndefined();
+	});
 });
 
 // ============================================================
@@ -591,6 +638,60 @@ describe('validateLicenseKey', () => {
 			expect(result.record).toEqual(record);
 			expect(result.record.plan).toBe('yearly');
 		}
+	});
+
+	// --- #797: expiresAt ---
+
+	it('期限切れのキーは invalid を返す (active でも expiresAt < now)', async () => {
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-ABCD-EFGH-JKLM',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: '2026-01-01T00:00:00Z',
+			expiresAt: '2026-02-01T00:00:00Z', // 過去
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await validateLicenseKey('GQ-ABCD-EFGH-JKLM');
+
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.reason).toBe('このライセンスキーは有効期限が切れています');
+		}
+	});
+
+	it('未来の expiresAt を持つキーは valid を返す', async () => {
+		const oneYearLater = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-ABCD-EFGH-JKLM',
+			tenantId: 'tenant-1',
+			plan: 'yearly',
+			status: 'active',
+			createdAt: new Date().toISOString(),
+			expiresAt: oneYearLater,
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await validateLicenseKey('GQ-ABCD-EFGH-JKLM');
+
+		expect(result.valid).toBe(true);
+	});
+
+	it('expiresAt 未設定の legacy レコードは期限チェックをスキップして valid', async () => {
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-ABCD-EFGH-JKLM',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: '2020-01-01T00:00:00Z',
+			// expiresAt なし (legacy)
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await validateLicenseKey('GQ-ABCD-EFGH-JKLM');
+
+		expect(result.valid).toBe(true);
 	});
 });
 
@@ -1015,6 +1116,46 @@ describe('consumeLicenseKey', () => {
 			expect.objectContaining({ plan: 'monthly' }),
 		);
 	});
+
+	// --- #797: expiresAt ---
+
+	it('期限切れキーは consume を拒否する (#797)', async () => {
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-EXPR-EXPR-EXPR',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: '2026-01-01T00:00:00Z',
+			expiresAt: '2026-02-01T00:00:00Z', // 過去
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await consumeLicenseKey('GQ-EXPR-EXPR-EXPR', 'tenant-1');
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toContain('有効期限');
+		}
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+		expect(mockUpdateLicenseKeyStatus).not.toHaveBeenCalled();
+	});
+
+	it('未来の expiresAt を持つキーは consume 成功する (#797)', async () => {
+		const oneYearLater = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-FUTR-FUTR-FUTR',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: new Date().toISOString(),
+			expiresAt: oneYearLater,
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await consumeLicenseKey('GQ-FUTR-FUTR-FUTR', 'tenant-1');
+
+		expect(result.ok).toBe(true);
+	});
 });
 
 // ============================================================
@@ -1151,5 +1292,180 @@ describe('validateLicenseKey legacy 形式の production 拒否 (#806)', () => {
 		const result = await validateLicenseKey(signedKey);
 
 		expect(result.valid).toBe(true);
+	});
+});
+
+// ============================================================
+// #797: revokeLicenseKey
+// ============================================================
+
+describe('revokeLicenseKey (#797)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('active なキーを revoke して repo を呼び出す', async () => {
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-ACTV-ACTV-ACTV',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: '2026-01-01T00:00:00Z',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+		mockRevokeLicenseKey.mockResolvedValue(undefined);
+
+		const result = await revokeLicenseKey({
+			licenseKey: 'GQ-ACTV-ACTV-ACTV',
+			reason: 'ops-manual',
+			revokedBy: 'ops:admin-1',
+		});
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.licenseKey).toBe('GQ-ACTV-ACTV-ACTV');
+			expect(result.revokedReason).toBe('ops-manual');
+			expect(result.revokedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+		}
+		expect(mockRevokeLicenseKey).toHaveBeenCalledTimes(1);
+		expect(mockRevokeLicenseKey).toHaveBeenCalledWith(
+			expect.objectContaining({
+				licenseKey: 'GQ-ACTV-ACTV-ACTV',
+				reason: 'ops-manual',
+				revokedBy: 'ops:admin-1',
+				revokedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+			}),
+		);
+	});
+
+	it('小文字入力を正規化して revoke する', async () => {
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-LOWR-LOWR-LOWR',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: '2026-01-01T00:00:00Z',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+		mockRevokeLicenseKey.mockResolvedValue(undefined);
+
+		const result = await revokeLicenseKey({
+			licenseKey: '  gq-lowr-lowr-lowr  ',
+			reason: 'leaked',
+			revokedBy: 'system',
+		});
+
+		expect(result.ok).toBe(true);
+		expect(mockFindLicenseKey).toHaveBeenCalledWith('GQ-LOWR-LOWR-LOWR');
+		expect(mockRevokeLicenseKey).toHaveBeenCalledWith(
+			expect.objectContaining({
+				licenseKey: 'GQ-LOWR-LOWR-LOWR',
+				reason: 'leaked',
+			}),
+		);
+	});
+
+	it('存在しないキーはエラーを返す', async () => {
+		mockFindLicenseKey.mockResolvedValue(undefined);
+
+		const result = await revokeLicenseKey({
+			licenseKey: 'GQ-NONE-NONE-NONE',
+			reason: 'ops-manual',
+			revokedBy: 'ops:admin-1',
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toContain('見つかりません');
+		}
+		expect(mockRevokeLicenseKey).not.toHaveBeenCalled();
+	});
+
+	it('既に revoked なキーは冪等にエラーを返し repo を呼ばない', async () => {
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-REVD-REVD-REVD',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'revoked',
+			createdAt: '2026-01-01T00:00:00Z',
+			revokedAt: '2026-02-01T00:00:00Z',
+			revokedReason: 'leaked',
+			revokedBy: 'system',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await revokeLicenseKey({
+			licenseKey: 'GQ-REVD-REVD-REVD',
+			reason: 'ops-manual',
+			revokedBy: 'ops:admin-1',
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toContain('無効化');
+		}
+		expect(mockRevokeLicenseKey).not.toHaveBeenCalled();
+	});
+
+	it('consumed 済みのキーは revoke できない', async () => {
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-CONS-CONS-CONS',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'consumed',
+			createdAt: '2026-01-01T00:00:00Z',
+			consumedAt: '2026-02-01T00:00:00Z',
+			consumedBy: 'tenant-1',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await revokeLicenseKey({
+			licenseKey: 'GQ-CONS-CONS-CONS',
+			reason: 'ops-manual',
+			revokedBy: 'ops:admin-1',
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toContain('使用');
+		}
+		expect(mockRevokeLicenseKey).not.toHaveBeenCalled();
+	});
+
+	it('revoke 後の validateLicenseKey は invalid を返す', async () => {
+		// revoke 実行
+		const activeRecord: LicenseRecord = {
+			licenseKey: 'GQ-FLOW-FLOW-FLOW',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: '2026-01-01T00:00:00Z',
+		};
+		mockFindLicenseKey.mockResolvedValueOnce(activeRecord);
+		mockRevokeLicenseKey.mockResolvedValue(undefined);
+
+		const revokeResult = await revokeLicenseKey({
+			licenseKey: 'GQ-FLOW-FLOW-FLOW',
+			reason: 'leaked',
+			revokedBy: 'ops:admin-1',
+		});
+		expect(revokeResult.ok).toBe(true);
+
+		// 次に validate 呼び出し時には revoked 状態で返す
+		const revokedRecord: LicenseRecord = {
+			...activeRecord,
+			status: 'revoked',
+			revokedAt: new Date().toISOString(),
+			revokedReason: 'leaked',
+			revokedBy: 'ops:admin-1',
+		};
+		mockFindLicenseKey.mockResolvedValueOnce(revokedRecord);
+
+		const validateResult = await validateLicenseKey('GQ-FLOW-FLOW-FLOW');
+
+		expect(validateResult.valid).toBe(false);
+		if (!validateResult.valid) {
+			expect(validateResult.reason).toContain('無効');
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- \`LicenseRecord\` に \`expiresAt\` / \`revokedAt\` / \`revokedReason\` / \`revokedBy\` を追加 (#797)
- 有効期限 90 日をデフォルトとし、\`issueLicenseKey\` で \`null\` 指定で期限なし (ops gift/lifetime 用)
- \`revokeLicenseKey(params)\` サービスを新設し、status + revokedAt + revokedReason + revokedBy を **atomic** 一括更新
- \`validateLicenseKey\` / \`consumeLicenseKey\` で期限切れを拒否（active ステータスでも \`expiresAt < now\` なら reject）
- 設計書更新（\`license-key-lifecycle.md\`, \`08-データベース設計書.md\`）

Closes #797

## 後方互換

- \`expiresAt\` 未設定の legacy レコードは「期限なし」扱い (\`isLicenseExpired\` が false を返す)
- 既存 issueLicenseKey コードは引数なしでも 90 日デフォルトで動作

## 再オープン経緯

元 PR #873 は \`fix/801-license-kind-field\` を base にしていたが、#872 が main に squash-merge された際に自動で閉じられた。
本 PR は main に直接向けて rebase 済み。

## Test Results

- \`npx svelte-check\` — 0 errors
- \`npx vitest run tests/unit/services/license-key-service.test.ts\` — 89/89 passed（revokeLicenseKey (#797) の 6 テスト含む）

## Test Plan

- [ ] license-key-service の全テスト通過
- [ ] 期限切れキーが consume で拒否される
- [ ] legacy レコード (expiresAt なし) が引き続き consume できる
- [ ] revoke 後に validate / consume が invalid になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)