### PR TITLE
fix(plan): canCustomAvatar デッドコンフィグを PlanLimits から削除 (#866)

### DIFF
--- a/docs/design/19-プライシング戦略書.md
+++ b/docs/design/19-プライシング戦略書.md
@@ -339,7 +339,6 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     maxChecklistTemplates: 3, // 1子あたり3テンプレまで (#723)
     historyRetentionDays: 90,
     canExport: false,
-    canCustomAvatar: false,
     canFreeTextMessage: false,
     canWeeklyReport: false,
     canMonthlyReport: false,
@@ -354,7 +353,6 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     maxChecklistTemplates: null, // 無制限
     historyRetentionDays: 365,
     canExport: true,
-    canCustomAvatar: true,
     canFreeTextMessage: true,
     canWeeklyReport: true,
     canMonthlyReport: false,
@@ -369,7 +367,6 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     maxChecklistTemplates: null, // 無制限
     historyRetentionDays: null,
     canExport: true,
-    canCustomAvatar: true,
     canFreeTextMessage: true,
     canWeeklyReport: true,
     canMonthlyReport: true,

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -12,7 +12,6 @@ export interface PlanLimits {
 	maxChecklistTemplates: number | null; // 1子あたりのチェックリストテンプレート数 (#723)
 	historyRetentionDays: number | null;
 	canExport: boolean;
-	canCustomAvatar: boolean;
 	canFreeTextMessage: boolean; // 自由テキストメッセージ（ファミリープラン限定）
 	canCustomReward: boolean; // 特別なごほうび設定（スタンダード以上） #728
 	canSiblingRanking: boolean; // きょうだいランキング（ファミリープラン限定） #782
@@ -31,7 +30,6 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		maxChecklistTemplates: 3,
 		historyRetentionDays: 90,
 		canExport: false,
-		canCustomAvatar: false,
 		canFreeTextMessage: false,
 		canCustomReward: false,
 		canSiblingRanking: false,
@@ -43,7 +41,6 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		maxChecklistTemplates: null,
 		historyRetentionDays: 365,
 		canExport: true,
-		canCustomAvatar: true,
 		canFreeTextMessage: false,
 		canCustomReward: true,
 		canSiblingRanking: false,
@@ -55,7 +52,6 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		maxChecklistTemplates: null,
 		historyRetentionDays: null,
 		canExport: true,
-		canCustomAvatar: true,
 		canFreeTextMessage: true,
 		canCustomReward: true,
 		canSiblingRanking: true,

--- a/tests/unit/routes/admin-settings-sibling-ranking.test.ts
+++ b/tests/unit/routes/admin-settings-sibling-ranking.test.ts
@@ -91,7 +91,6 @@ function createEvent(
 		maxActivities: null,
 		historyRetentionDays: null,
 		canExport: t !== 'free',
-		canCustomAvatar: t !== 'free',
 		canFreeTextMessage: t === 'family',
 		canCustomReward: t !== 'free',
 		canSiblingRanking: t === 'family',

--- a/tests/unit/services/plan-limit-service.test.ts
+++ b/tests/unit/services/plan-limit-service.test.ts
@@ -242,7 +242,6 @@ describe('plan-limit-service', () => {
 			expect(limits.maxActivities).toBe(3);
 			expect(limits.historyRetentionDays).toBe(90);
 			expect(limits.canExport).toBe(false);
-			expect(limits.canCustomAvatar).toBe(false);
 			expect(limits.canFreeTextMessage).toBe(false);
 			expect(limits.canCustomReward).toBe(false);
 			expect(limits.canSiblingRanking).toBe(false);
@@ -254,7 +253,6 @@ describe('plan-limit-service', () => {
 			expect(limits.maxActivities).toBeNull();
 			expect(limits.historyRetentionDays).toBe(365);
 			expect(limits.canExport).toBe(true);
-			expect(limits.canCustomAvatar).toBe(true);
 			expect(limits.canFreeTextMessage).toBe(false);
 			expect(limits.canCustomReward).toBe(true);
 			expect(limits.canSiblingRanking).toBe(false);
@@ -266,7 +264,6 @@ describe('plan-limit-service', () => {
 			expect(limits.maxActivities).toBeNull();
 			expect(limits.historyRetentionDays).toBeNull();
 			expect(limits.canExport).toBe(true);
-			expect(limits.canCustomAvatar).toBe(true);
 			expect(limits.canFreeTextMessage).toBe(true);
 			expect(limits.canCustomReward).toBe(true);
 			expect(limits.canSiblingRanking).toBe(true);


### PR DESCRIPTION
## Summary

- `canCustomAvatar` は PlanLimits に定義されているが、アバターアップロード API から参照されておらず、無料プランでも実質使える状態のデッドコンフィグだった
- Issue #866 の選択肢A（削除）を採用。無料ユーザーが既に使っている機能を取り上げるのは UX 悪化するため
- `PlanLimits` interface / `PLAN_LIMITS` / テスト / 設計書 から全て削除

## 背景

PR #877 (#792 棚卸し) で `/pricing` features を plan-gate 実装と一致させる過程で、`canCustomAvatar` がデッドコンフィグであることを再確認した。

\`\`\`
grep canCustomAvatar src/
# → plan-limit-service.ts の定義のみ（実装側の参照ゼロ）
\`\`\`

アバターアップロード API (\`src/routes/api/v1/children/[id]/avatar/+server.ts\`) には一切のプラン gate がない。MIME type / magic bytes / ファイルサイズ検証のみ。

## 判断理由

Issue 本文の選択肢A推奨ロジックに従う:

1. \`/pricing\` に「アバター機能」の記載がない → 謳っていない制限を後から課すのは不誠実
2. 無料ユーザーが既に使っている機能を取り上げる = 反発を招く
3. 有料プランとの差別化は既に十分（maxChildren / maxActivities / 履歴日数 / AI 提案 等）

## 変更内容

| ファイル | 変更 |
|---------|------|
| \`src/lib/server/services/plan-limit-service.ts\` | \`PlanLimits\` interface から \`canCustomAvatar\` を削除、\`PLAN_LIMITS\` の 3 エントリからも削除 |
| \`tests/unit/services/plan-limit-service.test.ts\` | \`canCustomAvatar\` の期待値 assertion 3 つを削除 |
| \`tests/unit/routes/admin-settings-sibling-ranking.test.ts\` | mock factory から \`canCustomAvatar: t !== 'free'\` を削除 |
| \`docs/design/19-プライシング戦略書.md\` | plan-limit-service 変更イメージ（設計提案）から削除 |

## Acceptance Criteria

- [x] 選択肢A/B のどちらかを決定（PO 確認） → **A（削除）**
- [x] \`PlanLimits\` から \`canCustomAvatar\` を削除
- [x] テスト更新

## Test plan

- [x] \`npx biome check .\` — エラーなし
- [x] \`npx svelte-check\` — 0 errors
- [x] \`npx vitest run tests/unit/services/plan-limit-service.test.ts\` — 56/56 pass
- [x] \`npx vitest run tests/unit/routes/admin-settings-sibling-ranking.test.ts\` — pass
- [ ] CI の E2E フル実行（e2e-test）

## 関連

- Closes #866
- 棚卸しの契機: PR #877 (#792 /pricing features plan-gate 棚卸し)

🤖 Generated with [Claude Code](https://claude.com/claude-code)