### PR TITLE
fix(child-ui): プラン情報を (child)/+layout で集約 (#789)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -831,6 +831,52 @@
 | チェックリスト | `/(child)/checklist` | 持ち物チェックリスト |
 | バトル | `/(child)/[uiMode]/(character)/battle` | 日次バトルアドベンチャー |
 
+### 9.x プラン情報の parent ↔ child データフロー (#789)
+
+child UI にもプラン依存機能（きょうだいランキング、家族向け特別報酬表示、自由記述メッセージ等）が存在するため、`planTier` / `planLimits` / `isPremium` を child UI 配下で参照可能にする。
+
+**解決の所在（単一責任）**:
+
+- `src/routes/(child)/+layout.server.ts` の `load` で以下を **1 回だけ** 解決する:
+  - `planTier` ← `resolveFullPlanTier(tenantId, licenseStatus, plan)`
+  - `planLimits` ← `getPlanLimits(planTier)`
+  - `isPremium` ← `isPaidTier(planTier)`
+- 各 `+page.server.ts` / `+page.svelte` は SvelteKit の `parent()` / `$props().data` を通じて上記 3 値を参照する
+- **子ページで `resolveFullPlanTier` / `getPlanLimits` を再度呼ぶのは禁止**（重複 DB 参照 + 契約のドリフト源）
+  - 例外: フォーム送信 action（`+page.server.ts` の `actions`）は `parent()` にアクセスできないため、action 内で再度解決する
+
+**データフロー**:
+
+```
+hooks.server.ts
+  └─ event.locals.context { tenantId, licenseStatus, plan }
+       │
+       ↓
+(child)/+layout.server.ts  ← プラン解決の単一責任
+  │  resolveFullPlanTier → planTier
+  │  getPlanLimits(planTier) → planLimits
+  │  isPaidTier(planTier)   → isPremium
+  │
+  └─ return { child, balance, planTier, planLimits, isPremium, ... }
+       │
+       ↓ parent() / $props().data
+(child)/[uiMode]/home/+page.server.ts
+  │  const parentData = await parent();
+  │  if (parentData.planLimits.canSiblingRanking) { ... }
+  │
+  └─ return { siblingRanking, ... }
+       │
+       ↓ $props().data
+(child)/[uiMode]/home/+page.svelte  ← data.planLimits で表示制御
+```
+
+**child UI 側でのプラン依存機能の表示制御**:
+
+- きょうだいランキング: `data.planLimits.canSiblingRanking` が `false` の場合は非表示
+- 自由記述おうえんメッセージ: `data.planLimits.canFreeTextMessage` が `false` の場合は非表示
+- カスタム特別報酬: `data.planLimits.canCustomReward` が `false` の場合は非表示
+- プレミアムテーマ等: `data.isPremium` で分岐
+
 ---
 
 ## 10. 全ページ一覧
@@ -925,6 +971,5 @@
 | 2026-03-31 | 1.2 | #0257 廃止機能削除に伴い関連記述を除去（ショップ・おもいで・みらいのゆめ・スキルツリー画面は本書に未記載のため変更なし。履歴のみ記録） |
 | 2026-04-04 | 1.3 | #344 実装とのUI同期: 5つのUIモード定義（baby/kinder/lower/upper/teen）追加、全ページ一覧（公開/認証/セットアップ/管理/デモ/OPS）追加 |
 | 2026-04-10 | 1.4 | #605 バトルアドベンチャーページ追加（子供用追加ページ） |
-=======
 | 2026-04-09 | 1.5 | #609 設計書同期: 未記載13機能の画面仕様を追記（おみくじ演出、ロイヤルティ、おうえんメッセージ、誕生日、チュートリアル、証明書、きょうだいおうえん、特別ごほうび、レベルアップ、イベントバナー、シーズンパス、離脱防止、キャラクタータブ） |
->>>>>>> b58a82d6 (infra: #609 Phase 1 — UI/API/DB設計書の実装同期)
+| 2026-04-11 | 1.6 | #789 child UI にプラン情報配布フロー追加（§9.x）— `(child)/+layout.server.ts` で planTier/planLimits/isPremium を解決し parent() 経由で配布 |

--- a/src/routes/(child)/+layout.server.ts
+++ b/src/routes/(child)/+layout.server.ts
@@ -6,7 +6,11 @@ import { requireTenantId } from '$lib/server/auth/factory';
 import { getSettings } from '$lib/server/db/settings-repo';
 import { getAllChildren, getChildById } from '$lib/server/services/child-service';
 import { markChildScreenVisited } from '$lib/server/services/onboarding-service';
-import { isPaidTier, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
+import {
+	getPlanLimits,
+	isPaidTier,
+	resolveFullPlanTier,
+} from '$lib/server/services/plan-limit-service';
 import { getPointBalance } from '$lib/server/services/point-service';
 import { getStampCardStatus } from '$lib/server/services/stamp-card-service';
 import { getChildStatus } from '$lib/server/services/status-service';
@@ -79,13 +83,17 @@ export const load: LayoutServerLoad = async ({ cookies, url, locals }) => {
 	// オンボーディング「子供の画面を確認する」を自動マーク（fire-and-forget）
 	markChildScreenVisited(tenantId).catch(() => {});
 
-	const isPremium = isPaidTier(
-		await resolveFullPlanTier(
-			tenantId,
-			locals.context?.licenseStatus ?? 'none',
-			locals.context?.plan,
-		),
+	// #789: プラン情報を child UI 配下で一元的に参照できるよう layout に集約する。
+	// 従来は各 +page.server.ts が個別に resolveFullPlanTier を呼び直しており、
+	// 「child 側で planTier を取得する手段が無い」状態だった。
+	// 本 layout で 1 回だけ解決し、planTier / planLimits / isPremium を配布する。
+	const planTier = await resolveFullPlanTier(
+		tenantId,
+		locals.context?.licenseStatus ?? 'none',
+		locals.context?.plan,
 	);
+	const planLimits = getPlanLimits(planTier);
+	const isPremium = isPaidTier(planTier);
 
 	return {
 		child,
@@ -98,5 +106,7 @@ export const load: LayoutServerLoad = async ({ cookies, url, locals }) => {
 		stampProgress,
 		stampCard: !stampCardResult || 'error' in stampCardResult ? null : stampCardResult,
 		isPremium,
+		planTier,
+		planLimits,
 	};
 };

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
@@ -22,7 +22,6 @@ import { getTodayMissions } from '$lib/server/services/daily-mission-service';
 import { getFamilyStreak, getNextMilestone } from '$lib/server/services/family-streak-service';
 import { claimLoginBonus, getLoginBonusStatus } from '$lib/server/services/login-bonus-service';
 import { getUnshownMessage } from '$lib/server/services/message-service';
-import { getPlanLimits, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import { selectRecommendations } from '$lib/server/services/recommendation-service';
 import {
 	claimEventReward,
@@ -160,15 +159,10 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 				: null;
 
 	// きょうだいランキング（#782: family プラン + 設定有効時のみ）
+	// #789: planLimits は parent layout が解決済み。重複 DB アクセスを避けるため parentData を参照する。
 	let siblingRanking: Awaited<ReturnType<typeof getWeeklyRanking>> | null = null;
 	try {
-		const planTier = await resolveFullPlanTier(
-			tenantId,
-			locals.context?.licenseStatus ?? 'none',
-			locals.context?.plan,
-		);
-		const planLimits = getPlanLimits(planTier);
-		if (planLimits.canSiblingRanking) {
+		if (parentData.planLimits.canSiblingRanking) {
 			const rankingOn = await isRankingEnabled(tenantId);
 			if (rankingOn) {
 				siblingRanking = await getWeeklyRanking(tenantId);

--- a/tests/unit/routes/child-layout-plan-info.test.ts
+++ b/tests/unit/routes/child-layout-plan-info.test.ts
@@ -1,0 +1,159 @@
+// tests/unit/routes/child-layout-plan-info.test.ts
+// #789: (child)/+layout.server.ts がプラン情報を正しく配布するかを検証する。
+//
+// テスト観点:
+// - 無料プランで load した場合、planTier=free / planLimits.canSiblingRanking=false
+// - standard プランの場合、planTier=standard / isPremium=true
+// - family プランの場合、planTier=family / planLimits.canSiblingRanking=true
+// - layout の戻り値に planTier / planLimits / isPremium が全て含まれる
+//
+// 本テストは child UI 側で planTier を参照できるようにした #789 の
+// 回帰防止として作成した（Acceptance Criteria の「child UI が planTier
+// を参照できる」「プラン依存機能の表示制御」をカバーする）。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------- service mocks ----------
+
+const mockResolveFullPlanTier = vi.fn();
+vi.mock('$lib/server/services/plan-limit-service', async () => {
+	// 実体の getPlanLimits / isPaidTier をそのまま使いたいので動的 import で取得する。
+	// resolveFullPlanTier のみ差し替える。
+	const actual = await vi.importActual<typeof import('$lib/server/services/plan-limit-service')>(
+		'$lib/server/services/plan-limit-service',
+	);
+	return {
+		...actual,
+		resolveFullPlanTier: (...args: unknown[]) => mockResolveFullPlanTier(...args),
+	};
+});
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: (locals: { context?: { tenantId?: string } }) => {
+		if (!locals.context?.tenantId) throw new Error('Unauthorized');
+		return locals.context.tenantId;
+	},
+}));
+
+vi.mock('$lib/server/services/child-service', () => ({
+	getChildById: vi.fn().mockResolvedValue({
+		id: 1,
+		nickname: 'たろうくん',
+		uiMode: 'elementary',
+		age: 7,
+		avatarUrl: null,
+	}),
+	getAllChildren: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('$lib/server/db/settings-repo', () => ({
+	getSettings: vi.fn().mockResolvedValue({
+		point_unit_mode: 'point',
+		point_currency: 'JPY',
+		point_rate: '1',
+	}),
+}));
+
+vi.mock('$lib/server/services/point-service', () => ({
+	getPointBalance: vi.fn().mockResolvedValue({ balance: 100 }),
+}));
+
+vi.mock('$lib/server/services/status-service', () => ({
+	getChildStatus: vi.fn().mockResolvedValue({ level: 3, levelTitle: 'かけだし' }),
+}));
+
+vi.mock('$lib/server/services/stamp-card-service', () => ({
+	getStampCardStatus: vi.fn().mockResolvedValue({
+		filledSlots: 2,
+		totalSlots: 10,
+	}),
+}));
+
+vi.mock('$lib/server/services/onboarding-service', () => ({
+	markChildScreenVisited: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { load } = await import('../../../src/routes/(child)/+layout.server');
+
+// ---------- helpers ----------
+
+type PlanTier = 'free' | 'standard' | 'family';
+
+/**
+ * load() は redirect() を投げるパスがあるため型上は `void | Data` になる。
+ * 正常系テストでは redirect されない前提なので、戻り値が undefined でないことを
+ * 明示的に assert し、以降の assertion のために型を narrow する。
+ */
+async function loadResolved(tier: PlanTier) {
+	const result = await load(createLoadEvent(tier));
+	if (!result) throw new Error(`load() returned void for tier=${tier}`);
+	return result;
+}
+
+function createLoadEvent(tier: PlanTier) {
+	return {
+		cookies: {
+			get: vi.fn((key: string) => (key === 'selectedChildId' ? '1' : undefined)),
+			set: vi.fn(),
+			delete: vi.fn(),
+		},
+		url: new URL('http://localhost/home'),
+		locals: {
+			context: {
+				tenantId: 't-test',
+				licenseStatus: tier === 'free' ? 'none' : 'active',
+				plan: tier,
+			},
+		},
+	} as unknown as Parameters<typeof load>[0];
+}
+
+// ---------- tests ----------
+
+describe('(child)/+layout.server.ts プラン情報配布 (#789)', () => {
+	beforeEach(() => {
+		mockResolveFullPlanTier.mockReset();
+	});
+
+	it('free プランの場合 planTier=free / planLimits.canSiblingRanking=false / isPremium=false', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('free');
+		const result = await loadResolved('free');
+		expect(result.planTier).toBe('free');
+		expect(result.planLimits.canSiblingRanking).toBe(false);
+		expect(result.planLimits.canFreeTextMessage).toBe(false);
+		expect(result.planLimits.canCustomReward).toBe(false);
+		expect(result.isPremium).toBe(false);
+	});
+
+	it('standard プランの場合 planTier=standard / isPremium=true / canSiblingRanking=false', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('standard');
+		const result = await loadResolved('standard');
+		expect(result.planTier).toBe('standard');
+		expect(result.planLimits.canCustomReward).toBe(true);
+		expect(result.planLimits.canSiblingRanking).toBe(false);
+		expect(result.planLimits.canFreeTextMessage).toBe(false);
+		expect(result.isPremium).toBe(true);
+	});
+
+	it('family プランの場合 planTier=family / canSiblingRanking=true / canFreeTextMessage=true', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('family');
+		const result = await loadResolved('family');
+		expect(result.planTier).toBe('family');
+		expect(result.planLimits.canSiblingRanking).toBe(true);
+		expect(result.planLimits.canFreeTextMessage).toBe(true);
+		expect(result.planLimits.canCustomReward).toBe(true);
+		expect(result.isPremium).toBe(true);
+	});
+
+	it('layout 戻り値に child / balance / level など既存フィールドも含まれる（後方互換）', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('family');
+		const result = await loadResolved('family');
+		expect(result.child).toBeDefined();
+		expect(result.balance).toBe(100);
+		expect(result.level).toBe(3);
+		expect(result.isPremium).toBe(true);
+		// #789 で追加したフィールド
+		expect(result.planTier).toBeDefined();
+		expect(result.planLimits).toBeDefined();
+	});
+});

--- a/tests/unit/routes/child-layout-plan-info.test.ts
+++ b/tests/unit/routes/child-layout-plan-info.test.ts
@@ -33,6 +33,7 @@ vi.mock('$lib/server/auth/factory', () => ({
 		if (!locals.context?.tenantId) throw new Error('Unauthorized');
 		return locals.context.tenantId;
 	},
+	getAuthMode: vi.fn(() => 'cognito'),
 }));
 
 vi.mock('$lib/server/services/child-service', () => ({


### PR DESCRIPTION
## Summary

#789 対応。child UI 配下から `planTier` / `planLimits` / `isPremium` を参照できるよう、`(child)/+layout.server.ts` で一元解決するパターンに揃えた。

## 背景

これまで `(child)` 配下のページは、プラン依存機能が必要になるたびに個別の `+page.server.ts` で `resolveFullPlanTier` を呼び直していた。結果として:

- **child UI が planTier を取得する手段が設計書に無い** — 本 Issue の主題
- 同一リクエストで `resolveFullPlanTier` が複数回実行されていた（home は parent layout と重複）
- プラン解決ロジックが複数箇所に散在 → ADR-0024 の責務分離に反する

## 変更内容

### `src/routes/(child)/+layout.server.ts`
- `resolveFullPlanTier` → `planTier` を一度だけ解決
- `getPlanLimits(planTier)` → `planLimits` を同時に算出して返却
- `isPaidTier(planTier)` → `isPremium` を返却（従来どおり）
- 戻り値に `planTier` / `planLimits` / `isPremium` の 3 つを含める

### `src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts`
- 重複していた `resolveFullPlanTier` / `getPlanLimits` 呼び出しを削除
- `await parent()` から `parentData.planLimits.canSiblingRanking` を参照するように変更
- きょうだいランキングのゲート動作は変更なし（=このリファクタは挙動非変更）

### `docs/design/06-UI設計書.md`
- §9.x「プラン情報の parent ↔ child データフロー」を新設
  - どの層で何を解決するか
  - `parent()` / `$props().data` 経由で伝播するパターン
  - child UI で使える表示制御フラグ一覧
- 末尾に残っていた merge conflict マーカー（1.5 行のエントリ）も合わせて解消
- 更新履歴 1.6 行を追加

### `tests/unit/routes/child-layout-plan-info.test.ts` (NEW)
- 4 ケースの unit test を追加
  1. free: `planTier=free` / `canSiblingRanking=false` / `isPremium=false`
  2. standard: `planTier=standard` / `canCustomReward=true` / `isPremium=true`
  3. family: `planTier=family` / `canSiblingRanking=true` / `canFreeTextMessage=true`
  4. 後方互換: `child` / `balance` / `level` / `isPremium` も戻り値に含まれる
- `vi.importActual` で `getPlanLimits` / `isPaidTier` の実装をそのまま使い、`resolveFullPlanTier` のみ差し替え

## Acceptance Criteria

- [x] child UI が planTier を参照できる — layout 戻り値に `planTier` を追加
- [x] プラン依存機能の表示制御 — `planLimits` を戻り値に追加し、home ページでランキング表示制御に使用
- [ ] E2E テスト — 本 PR では **挙動非変更のリファクタ** のため unit test で代替。プラン別表示差の E2E は既存のプランゲート E2E でカバー済み
- [x] 設計書反映 — `06-UI設計書.md` §9.x 追加

## Test plan

- [x] `npx vitest run tests/unit/routes/child-layout-plan-info.test.ts` — 4/4 passed
- [x] `npx vitest run tests/unit/routes` — 76/76 passed (child/admin/home 全通過)
- [x] `npx biome check` (対象 3 ファイル) — エラーなし
- [x] `npx svelte-check` — 0 errors / 39 warnings（事前状態と同一）
- [ ] CI（GitHub Actions）— このドラフト PR で走行

## 備考

- `home/+page.server.ts` の action ハンドラ内の動的 import による `resolveFullPlanTier` は残している（action は `parent()` にアクセスできないため）
- 他の child ページは `canSiblingRanking` 以外のプランフラグを使う場面が無かったため、今回の PR では touch していない。必要になった段階で `parent()` からの参照に移行すればよい

🤖 Generated with [Claude Code](https://claude.com/claude-code)