### PR TITLE
perf(plan): trial_history を request-scoped memoize (#788)

### DIFF
--- a/docs/decisions/0024-plan-tier-resolution-pattern.md
+++ b/docs/decisions/0024-plan-tier-resolution-pattern.md
@@ -5,7 +5,7 @@
 | ステータス | accepted |
 | 日付 | 2026-04-11 |
 | 起票者 | Takenori-Kusaka |
-| 関連 Issue | #748, #725, #726, #727, #728, #732 |
+| 関連 Issue | #748, #725, #726, #727, #728, #732, #788 |
 | 関連 ADR | ADR-0003（設計書 SSOT）, ADR-0015（Repository パターン） |
 
 ## コンテキスト
@@ -110,6 +110,39 @@ type PlanLimitError = {
 
 - 既存コード（`admin/+layout.server.ts`, `admin/license/+page.server.ts`）は依然として `resolvePlanTier` を直接呼んでいる。ESLint ルール導入までは規約依存で対処する
 - `resolveFullPlanTier` は DB 2 往復（trial_end / trial_tier の fetch）が必須なため、パフォーマンス観点では低レベル API の方が軽い。ただし Pre-PMF 段階ではユーザー数が少なく、可読性・安全性を優先する
+- 同一リクエスト内で複数の load/service から `resolveFullPlanTier` が呼ばれるため、本番 DynamoDB では N+1 になる懸念があった → **#788 で request-scoped memoize を導入し解決（下記追記参照）**
+
+### 6. 同一リクエスト内の memoize パターン (#788)
+
+**背景**: admin 配下では `(child)/+layout.server.ts` / `admin/+layout.server.ts` / `admin/**/+page.server.ts` / 内部サービスが独立に `resolveFullPlanTier` を呼ぶため、素朴に実装すると 1 リクエストで `trial_history` に 3〜6 回 SELECT が飛ぶ。本番 DynamoDB では RCU コスト・レイテンシの温床になる。
+
+**採用した解決策**: `src/lib/server/request-context.ts` に `AsyncLocalStorage` ベースのリクエスト単位キャッシュを実装し、`hooks.server.ts` の `handle` 全体を `runWithRequestContext(...)` で包む。`resolveFullPlanTier` と `getTrialStatus` は呼ばれるたびに現在のコンテキストからキャッシュを引き、ヒットすれば DB を叩かない。
+
+```text
+handle
+└─ runWithRequestContext(async () => {
+       await resolveFullPlanTier(...)   ← 1回目: DB hit → cache set
+       await resolveFullPlanTier(...)   ← 2回目以降: cache hit
+       // layout / page.server / service のどこから呼ばれても同じ
+   })
+```
+
+**キャッシュキー**:
+- `getTrialStatus`: `tenantId`
+- `resolveFullPlanTier`: `${tenantId}::${licenseStatus}::${planId ?? ''}`
+
+**なぜ ALS なのか**:
+- `event.locals` に planTier を先置きする案は、`resolveFullPlanTier` 呼び出し元 55 箇所すべてを「locals 経由に書き換える」必要があり、広大なリファクタになる。ALS は呼び出し元を一切変更せず透過的に最適化できる。
+- action ハンドラは `parent()` アクセス手段がないので、どうしても `resolveFullPlanTier` を直接呼ばざるを得ない。ALS ならこのケースも同じリクエスト内ならキャッシュが効く。
+
+**無効化**:
+- `startTrial` で trial_history を insert した直後は `invalidateRequestCaches(tenantId)` でキャッシュを破棄。同一リクエスト内で startTrial → getTrialStatus の順で呼ばれても stale な値を返さない。
+- `account-deletion-service` の trial_history 削除時も同様に invalidate（防衛的）。
+
+**規約**:
+- `resolveFullPlanTier` / `getTrialStatus` に新しい引数を追加する時は、`request-context.ts` のキャッシュキーにも反映すること。反映漏れは異なる引数で同じキャッシュを返す事故になる。
+- trial_history に insert/update/delete を追加した場合、直後に `invalidateRequestCaches(tenantId)` を呼ぶ。
+- バックグラウンドジョブ（cron、queue worker 等）からは ALS コンテキスト外で呼ばれるため、キャッシュは効かない（`getRequestContext()` が undefined を返し、キャッシュをスキップする）。これは意図した挙動。
 
 ### 既存呼び出しの段階的移行
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -6,6 +6,7 @@ import { getAuthMode, getAuthProvider } from '$lib/server/auth/factory';
 import { applyDebugPlanOverride } from '$lib/server/debug-plan';
 import { sendDiscordAlert } from '$lib/server/discord-alert';
 import { logger } from '$lib/server/logger';
+import { runWithRequestContext } from '$lib/server/request-context';
 import { findLegacyRedirect, rewriteLegacyPath } from '$lib/server/routing/legacy-url-map';
 import { checkApiRateLimit, checkAuthRateLimit } from '$lib/server/security/rate-limiter';
 import { trackServerError } from '$lib/server/services/analytics-service';
@@ -122,279 +123,285 @@ function buildCspHeader(): string {
 /** Cached CSP header (built once at startup) */
 const CSP_HEADER = buildCspHeader();
 
-export const handle: Handle = async ({ event, resolve }) => {
-	const start = Date.now();
-	const path = event.url.pathname;
+export const handle: Handle = ({ event, resolve }) =>
+	// #788: リクエスト境界でコンテキストを張る。resolveFullPlanTier / getTrialStatus が
+	// このリクエスト内で初回呼び出し時に DB を叩き、以降は memoize された値を返す。
+	runWithRequestContext(async () => {
+		const start = Date.now();
+		const path = event.url.pathname;
 
-	// リクエストID 生成（相関ID）
-	event.locals.requestId = randomUUID();
+		// リクエストID 生成（相関ID）
+		event.locals.requestId = randomUUID();
 
-	// 0-a) メンテナンスモード（Lambda環境変数で切替）
-	if (MAINTENANCE_MODE && path !== '/api/health') {
-		if (acceptsHtml(event.request)) {
-			return new Response(
-				renderErrorHtml(
-					503,
-					'メンテナンス中',
-					'ただいまメンテナンス中です。しばらくしてから再度お試しください。',
-				),
-				{
-					status: 503,
-					headers: { 'Content-Type': 'text/html; charset=utf-8', 'Retry-After': '600' },
-				},
-			);
-		}
-		return new Response(JSON.stringify({ status: 'maintenance', message: 'メンテナンス中です' }), {
-			status: 503,
-			headers: { 'Content-Type': 'application/json', 'Retry-After': '600' },
-		});
-	}
-
-	// 0-b) レートリミット（cognito 本番モードのみ、dev モードは除外）
-	if (
-		authMode === 'cognito' &&
-		!COGNITO_DEV_MODE &&
-		!path.startsWith('/_app/') &&
-		!path.startsWith('/favicon')
-	) {
-		const ip = event.getClientAddress();
-		const isAuthRoute = path.startsWith('/auth/');
-		const { allowed, remaining, resetAt } = isAuthRoute
-			? checkAuthRateLimit(ip, event.request.method)
-			: checkApiRateLimit(ip);
-
-		if (!allowed) {
-			logger.warn(`Rate limit exceeded: ${ip} on ${path}`);
-			const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
+		// 0-a) メンテナンスモード（Lambda環境変数で切替）
+		if (MAINTENANCE_MODE && path !== '/api/health') {
 			if (acceptsHtml(event.request)) {
 				return new Response(
 					renderErrorHtml(
-						429,
-						'アクセスが集中しています',
-						'アクセスが集中しています。しばらくしてから再度お試しください。',
+						503,
+						'メンテナンス中',
+						'ただいまメンテナンス中です。しばらくしてから再度お試しください。',
 					),
 					{
-						status: 429,
-						headers: {
-							'Content-Type': 'text/html; charset=utf-8',
-							'Retry-After': String(retryAfter),
-						},
+						status: 503,
+						headers: { 'Content-Type': 'text/html; charset=utf-8', 'Retry-After': '600' },
 					},
 				);
 			}
-			return new Response(JSON.stringify({ error: 'Too Many Requests' }), {
-				status: 429,
-				headers: {
-					'Content-Type': 'application/json',
-					'Retry-After': String(retryAfter),
+			return new Response(
+				JSON.stringify({ status: 'maintenance', message: 'メンテナンス中です' }),
+				{
+					status: 503,
+					headers: { 'Content-Type': 'application/json', 'Retry-After': '600' },
+				},
+			);
+		}
+
+		// 0-b) レートリミット（cognito 本番モードのみ、dev モードは除外）
+		if (
+			authMode === 'cognito' &&
+			!COGNITO_DEV_MODE &&
+			!path.startsWith('/_app/') &&
+			!path.startsWith('/favicon')
+		) {
+			const ip = event.getClientAddress();
+			const isAuthRoute = path.startsWith('/auth/');
+			const { allowed, remaining, resetAt } = isAuthRoute
+				? checkAuthRateLimit(ip, event.request.method)
+				: checkApiRateLimit(ip);
+
+			if (!allowed) {
+				logger.warn(`Rate limit exceeded: ${ip} on ${path}`);
+				const retryAfter = Math.ceil((resetAt - Date.now()) / 1000);
+				if (acceptsHtml(event.request)) {
+					return new Response(
+						renderErrorHtml(
+							429,
+							'アクセスが集中しています',
+							'アクセスが集中しています。しばらくしてから再度お試しください。',
+						),
+						{
+							status: 429,
+							headers: {
+								'Content-Type': 'text/html; charset=utf-8',
+								'Retry-After': String(retryAfter),
+							},
+						},
+					);
+				}
+				return new Response(JSON.stringify({ error: 'Too Many Requests' }), {
+					status: 429,
+					headers: {
+						'Content-Type': 'application/json',
+						'Retry-After': String(retryAfter),
+					},
+				});
+			}
+			event.request.headers.set('X-RateLimit-Remaining', String(remaining));
+		}
+
+		// 0-c) 旧 URL の中央リダイレクト（#578）
+		//
+		// 年齢区分リネーム等で廃止された URL は `legacy-url-map.ts` に集約されている。
+		// ここで一括処理することで、個別ルートに散在していた 404 救済ロジックを
+		// 不要にする。クエリ文字列・ハッシュは保持される。
+		//
+		// 認証・セッション解決より前に実行するため、ログイン状態に関係なく
+		// 全ユーザーに対してリダイレクトが効く。
+		const legacyEntry = findLegacyRedirect(path);
+		if (legacyEntry) {
+			const newPath = rewriteLegacyPath(path, legacyEntry);
+			const newUrl = newPath + event.url.search + event.url.hash;
+			logger.info(`Legacy URL redirect: ${path} → ${newPath} (${legacyEntry.issue})`, {
+				requestId: event.locals.requestId,
+				path,
+				context: {
+					from: path,
+					to: newPath,
+					issue: legacyEntry.issue,
 				},
 			});
+			redirect(legacyEntry.status ?? 308, newUrl);
 		}
-		event.request.headers.set('X-RateLimit-Remaining', String(remaining));
-	}
 
-	// 0-c) 旧 URL の中央リダイレクト（#578）
-	//
-	// 年齢区分リネーム等で廃止された URL は `legacy-url-map.ts` に集約されている。
-	// ここで一括処理することで、個別ルートに散在していた 404 救済ロジックを
-	// 不要にする。クエリ文字列・ハッシュは保持される。
-	//
-	// 認証・セッション解決より前に実行するため、ログイン状態に関係なく
-	// 全ユーザーに対してリダイレクトが効く。
-	const legacyEntry = findLegacyRedirect(path);
-	if (legacyEntry) {
-		const newPath = rewriteLegacyPath(path, legacyEntry);
-		const newUrl = newPath + event.url.search + event.url.hash;
-		logger.info(`Legacy URL redirect: ${path} → ${newPath} (${legacyEntry.issue})`, {
-			requestId: event.locals.requestId,
-			path,
-			context: {
-				from: path,
-				to: newPath,
-				issue: legacyEntry.issue,
-			},
-		});
-		redirect(legacyEntry.status ?? 308, newUrl);
-	}
+		// 1) 二層セッション解決
+		// デモモード: /demo 以下は認証不要、ダミーコンテキストをセット
+		if (path.startsWith('/demo')) {
+			event.locals.authenticated = false;
+			event.locals.identity = null;
+			event.locals.context = applyDebugPlanOverride({
+				tenantId: 'demo',
+				role: 'owner',
+				licenseStatus: 'active',
+			});
+			const response = await resolve(event);
+			if (!path.startsWith('/_app/') && !path.startsWith('/favicon')) {
+				logger.request(event.request.method, path, response.status, Date.now() - start, {
+					requestId: event.locals.requestId,
+					tenantId: 'demo',
+				});
+			}
+			return response;
+		}
 
-	// 1) 二層セッション解決
-	// デモモード: /demo 以下は認証不要、ダミーコンテキストをセット
-	if (path.startsWith('/demo')) {
-		event.locals.authenticated = false;
-		event.locals.identity = null;
-		event.locals.context = applyDebugPlanOverride({
-			tenantId: 'demo',
-			role: 'owner',
-			licenseStatus: 'active',
-		});
+		const identity = await provider.resolveIdentity(event);
+		const resolvedContext = await provider.resolveContext(event, identity);
+		// DEBUG_PLAN / DEBUG_TRIAL による上書きは、以降の認可・tenantStatus チェックにも
+		// 一貫して適用する必要があるため、ローカル変数 context 自体を上書き後の値で統一する。
+		const context = applyDebugPlanOverride(resolvedContext);
+
+		event.locals.authenticated = identity !== null;
+		event.locals.identity = identity;
+		event.locals.context = context;
+
+		// 2) ルート保護
+
+		// セットアップチェック（local モードのみ — 子供が未登録ならセットアップへ）
+		if (authMode === 'local') {
+			const tenantId = context?.tenantId ?? 'local';
+			if (
+				!path.startsWith('/setup') &&
+				!path.startsWith('/_app') &&
+				!path.startsWith('/favicon') &&
+				!path.startsWith('/api/health') &&
+				// #832: 公開 SEO エンドポイントはセットアップ前でもクロール可能にする。
+				// プリレンダも hooks.server を通るため、除外しないと /setup へ 302 され
+				// sitemap.xml がビルド時に生成できずビルド失敗する。
+				path !== '/sitemap.xml' &&
+				path !== '/robots.txt'
+			) {
+				if (await isSetupRequired(tenantId)) {
+					redirect(302, '/setup');
+				}
+			}
+
+			// セットアップ完了済みなら /setup へのアクセスをブロック
+			if (path.startsWith('/setup') && !(await isSetupRequired(tenantId))) {
+				redirect(302, '/');
+			}
+		}
+
+		// cognito モードで旧 /login（PIN画面）にアクセスした場合 → /auth/login へ
+		if (authMode === 'cognito' && path === '/login') {
+			redirect(302, '/auth/login');
+		}
+
+		// 認可チェック（Provider 固有のルート保護）
+		const authResult = provider.authorize(path, identity, context);
+		if (!authResult.allowed) {
+			redirect(302, authResult.redirect);
+		}
+
+		// grace_period 読み取り専用制御（#0193）
+		if (context?.tenantStatus === 'grace_period') {
+			const method = event.request.method;
+			const isWrite = method !== 'GET' && method !== 'HEAD';
+			const isAllowedWritePath = [
+				'/api/v1/admin/tenant/reactivate',
+				'/api/v1/export',
+				'/api/v1/auth/logout',
+				'/auth/logout',
+			].some((p) => path.startsWith(p));
+
+			if (isWrite && !isAllowedWritePath) {
+				if (path.startsWith('/api/')) {
+					return new Response(
+						JSON.stringify({ error: 'テナントは解約手続き中です。読み取り専用モードです。' }),
+						{ status: 403, headers: { 'Content-Type': 'application/json' } },
+					);
+				}
+				// フォーム送信等は設定画面にリダイレクト
+				redirect(302, '/admin/settings?reason=grace_period');
+			}
+		}
+
+		// terminated テナントは完全ブロック（#0193）
+		if (context?.tenantStatus === 'terminated') {
+			if (path.startsWith('/api/')) {
+				return new Response(JSON.stringify({ error: 'アカウントは削除済みです。' }), {
+					status: 403,
+					headers: { 'Content-Type': 'application/json' },
+				});
+			}
+			redirect(302, '/auth/login?reason=deleted');
+		}
+
+		// 同意バージョンチェック（cognito 本番モードのみ、dev モードは除外）
+		if (
+			authMode === 'cognito' &&
+			!COGNITO_DEV_MODE &&
+			identity &&
+			context?.tenantId &&
+			!path.startsWith('/consent') &&
+			!path.startsWith('/legal/') &&
+			!path.startsWith('/auth/') &&
+			!path.startsWith('/api/') &&
+			!path.startsWith('/_app/') &&
+			!path.startsWith('/favicon')
+		) {
+			const consent = await checkConsent(context.tenantId);
+			if (consent.needsReconsent) {
+				redirect(302, '/consent');
+			}
+		}
+
 		const response = await resolve(event);
+
+		// 3) セキュリティヘッダ付与
+		response.headers.set('X-Frame-Options', 'DENY');
+		response.headers.set('X-Content-Type-Options', 'nosniff');
+		response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+		response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+		response.headers.set('Content-Security-Policy', CSP_HEADER);
+		if (authMode === 'cognito') {
+			response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+		}
+
+		// 認証必要ページはブラウザキャッシュ禁止（ログアウト後の戻るボタン対策）
+		if (path.startsWith('/admin') || path === '/login' || path.startsWith('/auth/')) {
+			response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+			response.headers.set('Pragma', 'no-cache');
+			response.headers.set('Expires', '0');
+		}
+
+		// 4) リクエストログ + アナリティクス（静的ファイルは除外）
 		if (!path.startsWith('/_app/') && !path.startsWith('/favicon')) {
 			logger.request(event.request.method, path, response.status, Date.now() - start, {
 				requestId: event.locals.requestId,
-				tenantId: 'demo',
-			});
-		}
-		return response;
-	}
-
-	const identity = await provider.resolveIdentity(event);
-	const resolvedContext = await provider.resolveContext(event, identity);
-	// DEBUG_PLAN / DEBUG_TRIAL による上書きは、以降の認可・tenantStatus チェックにも
-	// 一貫して適用する必要があるため、ローカル変数 context 自体を上書き後の値で統一する。
-	const context = applyDebugPlanOverride(resolvedContext);
-
-	event.locals.authenticated = identity !== null;
-	event.locals.identity = identity;
-	event.locals.context = context;
-
-	// 2) ルート保護
-
-	// セットアップチェック（local モードのみ — 子供が未登録ならセットアップへ）
-	if (authMode === 'local') {
-		const tenantId = context?.tenantId ?? 'local';
-		if (
-			!path.startsWith('/setup') &&
-			!path.startsWith('/_app') &&
-			!path.startsWith('/favicon') &&
-			!path.startsWith('/api/health') &&
-			// #832: 公開 SEO エンドポイントはセットアップ前でもクロール可能にする。
-			// プリレンダも hooks.server を通るため、除外しないと /setup へ 302 され
-			// sitemap.xml がビルド時に生成できずビルド失敗する。
-			path !== '/sitemap.xml' &&
-			path !== '/robots.txt'
-		) {
-			if (await isSetupRequired(tenantId)) {
-				redirect(302, '/setup');
-			}
-		}
-
-		// セットアップ完了済みなら /setup へのアクセスをブロック
-		if (path.startsWith('/setup') && !(await isSetupRequired(tenantId))) {
-			redirect(302, '/');
-		}
-	}
-
-	// cognito モードで旧 /login（PIN画面）にアクセスした場合 → /auth/login へ
-	if (authMode === 'cognito' && path === '/login') {
-		redirect(302, '/auth/login');
-	}
-
-	// 認可チェック（Provider 固有のルート保護）
-	const authResult = provider.authorize(path, identity, context);
-	if (!authResult.allowed) {
-		redirect(302, authResult.redirect);
-	}
-
-	// grace_period 読み取り専用制御（#0193）
-	if (context?.tenantStatus === 'grace_period') {
-		const method = event.request.method;
-		const isWrite = method !== 'GET' && method !== 'HEAD';
-		const isAllowedWritePath = [
-			'/api/v1/admin/tenant/reactivate',
-			'/api/v1/export',
-			'/api/v1/auth/logout',
-			'/auth/logout',
-		].some((p) => path.startsWith(p));
-
-		if (isWrite && !isAllowedWritePath) {
-			if (path.startsWith('/api/')) {
-				return new Response(
-					JSON.stringify({ error: 'テナントは解約手続き中です。読み取り専用モードです。' }),
-					{ status: 403, headers: { 'Content-Type': 'application/json' } },
-				);
-			}
-			// フォーム送信等は設定画面にリダイレクト
-			redirect(302, '/admin/settings?reason=grace_period');
-		}
-	}
-
-	// terminated テナントは完全ブロック（#0193）
-	if (context?.tenantStatus === 'terminated') {
-		if (path.startsWith('/api/')) {
-			return new Response(JSON.stringify({ error: 'アカウントは削除済みです。' }), {
-				status: 403,
-				headers: { 'Content-Type': 'application/json' },
-			});
-		}
-		redirect(302, '/auth/login?reason=deleted');
-	}
-
-	// 同意バージョンチェック（cognito 本番モードのみ、dev モードは除外）
-	if (
-		authMode === 'cognito' &&
-		!COGNITO_DEV_MODE &&
-		identity &&
-		context?.tenantId &&
-		!path.startsWith('/consent') &&
-		!path.startsWith('/legal/') &&
-		!path.startsWith('/auth/') &&
-		!path.startsWith('/api/') &&
-		!path.startsWith('/_app/') &&
-		!path.startsWith('/favicon')
-	) {
-		const consent = await checkConsent(context.tenantId);
-		if (consent.needsReconsent) {
-			redirect(302, '/consent');
-		}
-	}
-
-	const response = await resolve(event);
-
-	// 3) セキュリティヘッダ付与
-	response.headers.set('X-Frame-Options', 'DENY');
-	response.headers.set('X-Content-Type-Options', 'nosniff');
-	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-	response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-	response.headers.set('Content-Security-Policy', CSP_HEADER);
-	if (authMode === 'cognito') {
-		response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
-	}
-
-	// 認証必要ページはブラウザキャッシュ禁止（ログアウト後の戻るボタン対策）
-	if (path.startsWith('/admin') || path === '/login' || path.startsWith('/auth/')) {
-		response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate');
-		response.headers.set('Pragma', 'no-cache');
-		response.headers.set('Expires', '0');
-	}
-
-	// 4) リクエストログ + アナリティクス（静的ファイルは除外）
-	if (!path.startsWith('/_app/') && !path.startsWith('/favicon')) {
-		logger.request(event.request.method, path, response.status, Date.now() - start, {
-			requestId: event.locals.requestId,
-			tenantId: context?.tenantId,
-		});
-
-		// 4-a) 404 構造化ログ（#577）
-		//
-		// HTML リクエストの 404 のみを拾い、集計・棚卸しできるようにする。
-		// LEGACY_URL_MAP にヒットしたパスはこの時点で既にリダイレクト済みなので、
-		// ここに来る 404 は「マップ未登録の旧 URL」「タイポ」「外部リンク切れ」の
-		// いずれか。referer / userAgent / role を出力することで原因を分類する。
-		if (response.status === 404 && event.request.method === 'GET' && acceptsHtml(event.request)) {
-			logger.warn(`404 Not Found: ${path}`, {
-				requestId: event.locals.requestId,
 				tenantId: context?.tenantId,
-				path,
-				status: 404,
-				context: {
-					referer: event.request.headers.get('Referer') ?? null,
-					userAgent: event.request.headers.get('User-Agent') ?? null,
-					role: context?.role ?? 'anonymous',
-				},
 			});
+
+			// 4-a) 404 構造化ログ（#577）
+			//
+			// HTML リクエストの 404 のみを拾い、集計・棚卸しできるようにする。
+			// LEGACY_URL_MAP にヒットしたパスはこの時点で既にリダイレクト済みなので、
+			// ここに来る 404 は「マップ未登録の旧 URL」「タイポ」「外部リンク切れ」の
+			// いずれか。referer / userAgent / role を出力することで原因を分類する。
+			if (response.status === 404 && event.request.method === 'GET' && acceptsHtml(event.request)) {
+				logger.warn(`404 Not Found: ${path}`, {
+					requestId: event.locals.requestId,
+					tenantId: context?.tenantId,
+					path,
+					status: 404,
+					context: {
+						referer: event.request.headers.get('Referer') ?? null,
+						userAgent: event.request.headers.get('User-Agent') ?? null,
+						role: context?.role ?? 'anonymous',
+					},
+				});
+			}
+
+			// Analytics: identify tenant and track page views for HTML requests
+			if (context?.tenantId) {
+				analytics.identify(context.tenantId);
+			}
+			if (event.request.method === 'GET' && acceptsHtml(event.request)) {
+				analytics.trackPageView(path, event.request.headers.get('Referer') ?? undefined);
+			}
 		}
 
-		// Analytics: identify tenant and track page views for HTML requests
-		if (context?.tenantId) {
-			analytics.identify(context.tenantId);
-		}
-		if (event.request.method === 'GET' && acceptsHtml(event.request)) {
-			analytics.trackPageView(path, event.request.headers.get('Referer') ?? undefined);
-		}
-	}
-
-	return response;
-};
+		return response;
+	});
 
 // サーバーエラーハンドラ: 500エラーの詳細をログに記録 + Discord 障害通知
 export const handleError: HandleServerError = ({ error, event, status, message }) => {

--- a/src/lib/server/request-context.ts
+++ b/src/lib/server/request-context.ts
@@ -1,0 +1,79 @@
+// src/lib/server/request-context.ts
+// リクエスト単位の memoize ストア (#788)
+//
+// 背景: `resolveFullPlanTier` は admin 配下の全ページで呼ばれるが、内部で
+// `getTrialStatus` → `trial_history` SELECT を実行する。layout + 各 page.server +
+// 個別サービスが独立に呼ぶと、同一リクエストで同じテナントに対し DB を複数回叩き、
+// 本番 DynamoDB ではコスト・レイテンシの温床になる。
+//
+// 対応: AsyncLocalStorage でリクエストごとにキャッシュを持ち、
+// `resolveFullPlanTier` / `getTrialStatus` が同じ引数で 2 回目以降呼ばれた時は
+// DB をスキップする。hooks.server.ts の handle をこのストアでラップする。
+//
+// 透過的な最適化のため、55 箇所以上ある呼び出し元を一切変更しない。
+// 無効化は `invalidateRequestCaches(tenantId)` — トライアル開始/終了など
+// 同一リクエスト内で状態が変わる操作の直後に呼ぶ。
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { PlanTier } from '$lib/server/services/plan-limit-service';
+import type { TrialStatus } from '$lib/server/services/trial-service';
+
+interface RequestContext {
+	/** key: `${tenantId}::${licenseStatus}::${planId ?? ''}` */
+	planTierCache: Map<string, PlanTier>;
+	/** key: tenantId */
+	trialStatusCache: Map<string, TrialStatus>;
+}
+
+const store = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * リクエスト境界でコンテキストを張る。hooks.server.ts の handle 全体を包む想定。
+ * 外側のリクエストコンテキストが既に存在する場合（ネストしたテストなど）は
+ * 新しいコンテキストを上書きせず既存を再利用する。
+ */
+export function runWithRequestContext<T>(fn: () => Promise<T>): Promise<T> {
+	if (store.getStore()) {
+		// 既にコンテキスト内なら二重に張らない
+		return fn();
+	}
+	return store.run<Promise<T>>(
+		{
+			planTierCache: new Map(),
+			trialStatusCache: new Map(),
+		},
+		fn,
+	);
+}
+
+/**
+ * 現在のリクエストコンテキストを取得。コンテキスト外（バックグラウンドジョブ等）なら undefined。
+ * 呼び出し側は `undefined` の場合にキャッシュを使わず素通しでよい。
+ */
+export function getRequestContext(): RequestContext | undefined {
+	return store.getStore();
+}
+
+/**
+ * 指定テナントに紐づくキャッシュを破棄する。
+ * トライアル開始/終了・プラン変更など、リクエスト内で状態が変わる操作後に呼ぶこと。
+ */
+export function invalidateRequestCaches(tenantId: string): void {
+	const ctx = store.getStore();
+	if (!ctx) return;
+	ctx.trialStatusCache.delete(tenantId);
+	// planTier は key に tenantId prefix を含むため前方一致で削除
+	const prefix = `${tenantId}::`;
+	for (const key of ctx.planTierCache.keys()) {
+		if (key.startsWith(prefix)) ctx.planTierCache.delete(key);
+	}
+}
+
+/** planTier キャッシュのキーを構築 */
+export function buildPlanTierCacheKey(
+	tenantId: string,
+	licenseStatus: string,
+	planId: string | undefined,
+): string {
+	return `${tenantId}::${licenseStatus}::${planId ?? ''}`;
+}

--- a/src/lib/server/services/account-deletion-service.ts
+++ b/src/lib/server/services/account-deletion-service.ts
@@ -13,6 +13,7 @@ import {
 import type { Membership } from '$lib/server/auth/entities';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
+import { invalidateRequestCaches } from '$lib/server/request-context';
 import { deleteByPrefix } from '$lib/server/storage';
 import { deleteChildFiles } from './child-service';
 import { notifyDeletionComplete } from './discord-notify-service';
@@ -343,6 +344,8 @@ async function deleteTenantScopedData(tenantId: string): Promise<number> {
 	// Trial history
 	try {
 		await r.trialHistory.deleteByTenantId(tenantId);
+		// #788: 同一リクエスト内のキャッシュも破棄（後続処理が stale 値を見ないよう防衛）
+		invalidateRequestCaches(tenantId);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[account-deletion] trialHistory 削除失敗: ${String(err)}`);

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -3,6 +3,7 @@
 
 import { getAuthMode } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
+import { buildPlanTierCacheKey, getRequestContext } from '$lib/server/request-context';
 import type { TrialTier } from '$lib/server/services/trial-service';
 import { getTrialStatus } from '$lib/server/services/trial-service';
 
@@ -99,6 +100,12 @@ export function resolvePlanTier(
  * #732: 全ての server load / services の呼び出し口をこの関数に統一する。
  * 内部で `getTrialStatus` を 1 回だけ呼び出し、expired 判定を含めて解決する。
  *
+ * #788: 同一リクエスト内の2回目以降は request-context のキャッシュから返す。
+ * これにより `(child)/+layout.server.ts` + 各 `page.server.ts` + 内部サービスが
+ * 独立に呼び出しても、実際に `trial_history` を叩くのは最初の1回だけになる。
+ * `getTrialStatus` 側にもキャッシュがあるため二重防護だが、key にライセンス状態を
+ * 含めるぶんプランティア単位でキャッシュできる利点がある。
+ *
  * @param tenantId - テナントID
  * @param licenseStatus - `locals.context?.licenseStatus` （未設定なら 'none' 扱い）
  * @param planId - `locals.context?.plan`
@@ -108,12 +115,21 @@ export async function resolveFullPlanTier(
 	licenseStatus: string,
 	planId?: string,
 ): Promise<PlanTier> {
+	// #788: リクエストスコープのキャッシュを優先
+	const ctx = getRequestContext();
+	const cacheKey = buildPlanTierCacheKey(tenantId, licenseStatus, planId);
+	const cached = ctx?.planTierCache.get(cacheKey);
+	if (cached) return cached;
+
 	// getTrialStatus を 1 回だけ呼ぶ。過去実装は getTrialEndDate + getTrialTier を
 	// 別々に呼び、それぞれ内部で getTrialStatus を実行していたため DB 2 回叩いていた。
 	const status = await getTrialStatus(tenantId);
 	const trialEnd = status.isTrialActive ? status.trialEndDate : null;
 	const trialTierValue = status.isTrialActive ? status.trialTier : null;
-	return resolvePlanTier(licenseStatus, planId, trialEnd, trialTierValue);
+	const tier = resolvePlanTier(licenseStatus, planId, trialEnd, trialTierValue);
+
+	ctx?.planTierCache.set(cacheKey, tier);
+	return tier;
 }
 
 /** 有料プランかどうか */

--- a/src/lib/server/services/trial-service.ts
+++ b/src/lib/server/services/trial-service.ts
@@ -6,6 +6,7 @@ import { toJSTDateString } from '$lib/domain/date-utils';
 import { getRepos } from '$lib/server/db/factory';
 import { getDebugTrialOverride } from '$lib/server/debug-plan';
 import { logger } from '$lib/server/logger';
+import { getRequestContext, invalidateRequestCaches } from '$lib/server/request-context';
 
 const DEFAULT_TRIAL_DAYS = 7;
 const DEFAULT_TRIAL_TIER = 'standard' as const;
@@ -33,8 +34,28 @@ export interface StartTrialInput {
 
 /**
  * トライアル状態を取得（trial_history テーブルから最新レコードを参照）
+ *
+ * #788: 同一リクエスト内の2回目以降は request-context のキャッシュから返す。
+ * layout + 各 page.server + 内部サービスがそれぞれ独立に呼んでも DB は1回で済む。
+ * トライアル開始/終了など状態が変わる操作の直後は `invalidateRequestCaches` が
+ * キャッシュを破棄するため、リクエスト内で stale な値を返すことはない。
  */
 export async function getTrialStatus(tenantId: string): Promise<TrialStatus> {
+	// #788: リクエストスコープのキャッシュを優先
+	const ctx = getRequestContext();
+	const cached = ctx?.trialStatusCache.get(tenantId);
+	if (cached) return cached;
+
+	const status = await computeTrialStatus(tenantId);
+	ctx?.trialStatusCache.set(tenantId, status);
+	return status;
+}
+
+/**
+ * #788: 実際の DB 参照を担うヘルパ。キャッシュなしで常に DB を叩く。
+ * `getTrialStatus` 経由で呼ばれるため、通常は直接呼び出さない。
+ */
+async function computeTrialStatus(tenantId: string): Promise<TrialStatus> {
 	// dev: DEBUG_TRIAL env があればDB参照をスキップして擬似ステータスを返す (#758)
 	const debugOverride = getDebugTrialOverride();
 	if (debugOverride) {
@@ -142,6 +163,10 @@ export async function startTrial(input: StartTrialInput): Promise<boolean> {
 		source,
 		campaignId: campaignId ?? null,
 	});
+
+	// #788: 同一リクエスト内で startTrial 後に getTrialStatus / resolveFullPlanTier が
+	// 呼ばれた時に stale な値を返さないよう、キャッシュを破棄する。
+	invalidateRequestCaches(tenantId);
 
 	logger.info('Trial started', { context: { tenantId, startStr, endStr, tier, source } });
 	return true;

--- a/tests/unit/services/request-context-memoize.test.ts
+++ b/tests/unit/services/request-context-memoize.test.ts
@@ -1,0 +1,211 @@
+// tests/unit/services/request-context-memoize.test.ts
+// #788: request-context によるリクエスト単位 memoize 動作テスト
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// In-memory trial_history store
+let trialRows: Array<{
+	id: number;
+	tenantId: string;
+	startDate: string;
+	endDate: string;
+	tier: string;
+	source: string;
+	campaignId: string | null;
+	createdAt: string;
+}> = [];
+let nextId = 1;
+
+const findLatestByTenant = vi.fn(async (tenantId: string) => {
+	const rows = trialRows.filter((r) => r.tenantId === tenantId).sort((a, b) => b.id - a.id);
+	return rows[0];
+});
+const insert = vi.fn(
+	async (input: {
+		tenantId: string;
+		startDate: string;
+		endDate: string;
+		tier: string;
+		source: string;
+		campaignId?: string | null;
+	}) => {
+		trialRows.push({
+			id: nextId++,
+			tenantId: input.tenantId,
+			startDate: input.startDate,
+			endDate: input.endDate,
+			tier: input.tier,
+			source: input.source,
+			campaignId: input.campaignId ?? null,
+			createdAt: new Date().toISOString(),
+		});
+	},
+);
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		trialHistory: { findLatestByTenant, insert },
+	}),
+}));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	getAuthMode: () => 'cognito',
+	getAuthProvider: () => ({}),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { runWithRequestContext } from '$lib/server/request-context';
+import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
+import { getTrialStatus, startTrial } from '$lib/server/services/trial-service';
+
+function seedActiveFamilyTrial(tenantId: string) {
+	const today = new Date();
+	const end = new Date(today);
+	end.setDate(end.getDate() + 7);
+	const fmt = (d: Date) => d.toISOString().slice(0, 10);
+	trialRows.push({
+		id: nextId++,
+		tenantId,
+		startDate: fmt(today),
+		endDate: fmt(end),
+		tier: 'family',
+		source: 'user_initiated',
+		campaignId: null,
+		createdAt: new Date().toISOString(),
+	});
+}
+
+describe('request-context memoize (#788)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		trialRows = [];
+		nextId = 1;
+	});
+
+	describe('getTrialStatus', () => {
+		it('同一リクエスト内で複数回呼んでも DB アクセスは1回だけ', async () => {
+			seedActiveFamilyTrial('tenant-a');
+
+			await runWithRequestContext(async () => {
+				await getTrialStatus('tenant-a');
+				await getTrialStatus('tenant-a');
+				await getTrialStatus('tenant-a');
+			});
+
+			expect(findLatestByTenant).toHaveBeenCalledTimes(1);
+		});
+
+		it('リクエストコンテキスト外では毎回 DB を叩く（後方互換）', async () => {
+			seedActiveFamilyTrial('tenant-b');
+
+			// コンテキスト外: キャッシュなし、毎回 DB
+			await getTrialStatus('tenant-b');
+			await getTrialStatus('tenant-b');
+
+			expect(findLatestByTenant).toHaveBeenCalledTimes(2);
+		});
+
+		it('異なるテナントはそれぞれキャッシュされる', async () => {
+			seedActiveFamilyTrial('tenant-c');
+			seedActiveFamilyTrial('tenant-d');
+
+			await runWithRequestContext(async () => {
+				await getTrialStatus('tenant-c');
+				await getTrialStatus('tenant-d');
+				await getTrialStatus('tenant-c'); // cached
+				await getTrialStatus('tenant-d'); // cached
+			});
+
+			expect(findLatestByTenant).toHaveBeenCalledTimes(2);
+		});
+
+		it('別リクエスト間ではキャッシュが独立している', async () => {
+			seedActiveFamilyTrial('tenant-e');
+
+			await runWithRequestContext(async () => {
+				await getTrialStatus('tenant-e');
+			});
+			await runWithRequestContext(async () => {
+				await getTrialStatus('tenant-e');
+			});
+
+			// 各リクエストで1回ずつ = 合計2回
+			expect(findLatestByTenant).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('resolveFullPlanTier', () => {
+		it('同一リクエスト内で複数回呼んでも DB アクセスは1回だけ', async () => {
+			seedActiveFamilyTrial('tenant-f');
+
+			await runWithRequestContext(async () => {
+				// layout が呼ぶ
+				const t1 = await resolveFullPlanTier('tenant-f', 'none', undefined);
+				// child page.server.ts が呼ぶ
+				const t2 = await resolveFullPlanTier('tenant-f', 'none', undefined);
+				// 内部サービスが呼ぶ
+				const t3 = await resolveFullPlanTier('tenant-f', 'none', undefined);
+				expect(t1).toBe('family');
+				expect(t2).toBe('family');
+				expect(t3).toBe('family');
+			});
+
+			expect(findLatestByTenant).toHaveBeenCalledTimes(1);
+		});
+
+		it('ライセンス状態が異なればキャッシュキーが別になる', async () => {
+			seedActiveFamilyTrial('tenant-g');
+
+			await runWithRequestContext(async () => {
+				await resolveFullPlanTier('tenant-g', 'none', undefined);
+				await resolveFullPlanTier('tenant-g', 'active', 'standard-monthly');
+			});
+
+			// それぞれ resolveFullPlanTier の planTier キャッシュは別だが、
+			// getTrialStatus は同じ tenantId で1回だけ呼ばれる
+			expect(findLatestByTenant).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('invalidation', () => {
+		it('startTrial 後は同一リクエスト内でも再度 DB が叩かれる', async () => {
+			// 事前データなし（isTrialActive=false）の状態からスタート
+			await runWithRequestContext(async () => {
+				await getTrialStatus('tenant-h'); // 1回目: DB hit (結果: 未使用)
+
+				await startTrial({
+					tenantId: 'tenant-h',
+					source: 'user_initiated',
+					tier: 'standard',
+				});
+
+				// startTrial は内部で getTrialStatus を1回呼ぶ。ただしキャッシュから返る。
+				// insert 後に invalidate しているので、下の getTrialStatus は DB を再度叩く。
+				const status = await getTrialStatus('tenant-h');
+				expect(status.isTrialActive).toBe(true);
+			});
+
+			// 1回目 + invalidate 後の再読み込み1回 = 2回
+			expect(findLatestByTenant).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('ネストされた runWithRequestContext', () => {
+		it('内側の runWithRequestContext は新しいストアを作らず外側を共有する', async () => {
+			seedActiveFamilyTrial('tenant-i');
+
+			await runWithRequestContext(async () => {
+				await getTrialStatus('tenant-i'); // 1回目: DB hit
+				await runWithRequestContext(async () => {
+					await getTrialStatus('tenant-i'); // キャッシュヒット（外側のストアを使う）
+				});
+				await getTrialStatus('tenant-i'); // キャッシュヒット
+			});
+
+			expect(findLatestByTenant).toHaveBeenCalledTimes(1);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- `resolveFullPlanTier` / `getTrialStatus` が admin 配下の layout + 各 page.server + 内部サービスから独立に呼ばれるため、1 リクエストで `trial_history` に 3〜6 回 SELECT が飛んでいた（本番 DynamoDB では RCU/レイテンシの温床）。
- `AsyncLocalStorage` ベースの request-scoped キャッシュ (`src/lib/server/request-context.ts`) を導入し、`hooks.server.ts` の `handle` 全体を `runWithRequestContext` で包む。
- 同一リクエスト内の 2 回目以降の呼び出しでキャッシュから返すため、**55 箇所ある呼び出し元を一切書き換えずに透過的に最適化**できる。
- `startTrial` / `account-deletion` の trial_history 書き込み直後は `invalidateRequestCaches` でキャッシュを破棄（stale 防止）。

## Cache keys

- `getTrialStatus`: `tenantId`
- `resolveFullPlanTier`: `${tenantId}::${licenseStatus}::${planId ?? ''}`

## Design decisions

**Why ALS over `event.locals.planTier` 先置き**:
- `locals` 経由案は 55 箇所の呼び出し元すべての書き換えが必要で広大なリファクタになる。
- action ハンドラは `parent()` アクセス手段がないので、どうしても `resolveFullPlanTier` を直接呼ばざるを得ない。ALS ならこのケースも同じリクエスト内ならキャッシュが効く。
- バックグラウンドジョブ（cron 等）からは ALS コンテキスト外で呼ばれるため、キャッシュは自動的にスキップ（`getRequestContext()` が undefined を返す）。

## Changes

| ファイル | 変更 |
|---------|------|
| `src/lib/server/request-context.ts` | **新規** — AsyncLocalStorage ベースのキャッシュストア |
| `src/hooks.server.ts` | `handle` を `runWithRequestContext` で包む |
| `src/lib/server/services/trial-service.ts` | `getTrialStatus` にキャッシュ層 + `startTrial` 後に invalidate |
| `src/lib/server/services/plan-limit-service.ts` | `resolveFullPlanTier` にキャッシュ層 |
| `src/lib/server/services/account-deletion-service.ts` | trial_history 削除直後に invalidate |
| `tests/unit/services/request-context-memoize.test.ts` | **新規** — 8 件の memoize/invalidation テスト |
| `docs/decisions/0024-plan-tier-resolution-pattern.md` | §6 memoize パターン追記 |

## Acceptance Criteria (#788)

- [x] リクエスト単位の memoize 実装
- [x] N+1 除去（同一リクエスト内の重複 `trial_history` SELECT を 1 回に集約）
- [x] ユニットテストで検証（8 ケース: 基本キャッシュ・異テナント独立・別リクエスト独立・ライセンス状態別キャッシュ・invalidation・ネスト `runWithRequestContext`）
- [x] ADR-0024 に記載

## Test plan

- [x] `npx biome check` — pass (6 files)
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run tests/unit/services/request-context-memoize.test.ts` — 8/8 pass
- [x] `npx vitest run tests/unit/services/trial-service.test.ts tests/unit/services/plan-limit-service.test.ts` — 72/72 既存テスト全 pass（後方互換確認）
- [ ] Full unit suite（pre-existing flakiness あり、本 PR とは無関係）
- [ ] E2E smoke — CI で検証

## Related

- Issue: #788
- ADR: [0024-plan-tier-resolution-pattern.md](../blob/fix/788-plan-tier-memoize/docs/decisions/0024-plan-tier-resolution-pattern.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)