### PR TITLE
fix(messages): ひとことメッセージの family 限定仕様を設計書・LP と同期 (#772)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -484,6 +484,18 @@
 
 **コンポーネント:** `src/lib/ui/components/ParentMessageOverlay.svelte`
 
+**プラン別の送信可否 (#772):**
+
+| 種別 | free | standard | family |
+|-----|------|----------|--------|
+| スタンプ送信 | o | o | o |
+| ひとことメッセージ（自由テキスト） | - | - | o |
+
+- 自由テキスト送信は `PlanLimits.canFreeTextMessage` でゲートされ、**family プラン限定**。
+- 管理画面 `/admin/messages` の「ひとことメッセージ」ボタンは standard / free では disabled 表示にし、`aria-describedby` で「ファミリープラン限定」理由を提示する。
+- サーバ側は `send` アクション内で `resolveFullPlanTier()` → `getPlanLimits(tier).canFreeTextMessage` を再判定し、false なら `fail(403)` を返す（クライアント制御の二重チェック）。
+- 仕様の根拠は ADR-0024（プラン解決責務分離）＋ `docs/design/19-プライシング戦略書.md §4` の差別化ポイント。
+
 ### 4.12 誕生日バナー・モーダル（BirthdayBanner / BirthdayModal）
 
 子供の誕生日に表示されるボーナス受取フロー。

--- a/docs/design/19-プライシング戦略書.md
+++ b/docs/design/19-プライシング戦略書.md
@@ -353,7 +353,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     maxChecklistTemplates: null, // 無制限
     historyRetentionDays: 365,
     canExport: true,
-    canFreeTextMessage: true,
+    canFreeTextMessage: false, // #772: family 限定（差別化ポイント）
     canWeeklyReport: true,
     canMonthlyReport: false,
     canSiblingRanking: false, // きょうだいランキング (#782)

--- a/tests/unit/routes/admin-messages-send.test.ts
+++ b/tests/unit/routes/admin-messages-send.test.ts
@@ -1,0 +1,223 @@
+// tests/unit/routes/admin-messages-send.test.ts
+// #772: /admin/messages?/send action の自由テキストプランゲートテスト
+//
+// テスト観点:
+// - free プランで text メッセージを送ると 403（ファミリー限定エラー）
+// - standard プランで text メッセージを送ると 403（ファミリー限定エラー）
+// - family プランなら text メッセージを送信できる
+// - stamp メッセージはプランに関係なく送信できる（ゲートされない）
+// - messageType バリデーション / body 必須 / 文字数上限などの基本バリデーション
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------- mocks ----------
+
+const mockResolveFullPlanTier = vi.fn();
+const mockGetPlanLimits = vi.fn();
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	resolveFullPlanTier: (...args: unknown[]) => mockResolveFullPlanTier(...args),
+	getPlanLimits: (...args: unknown[]) => mockGetPlanLimits(...args),
+}));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: (locals: { context?: { tenantId?: string } }) => {
+		if (!locals.context?.tenantId) throw new Error('Unauthorized');
+		return locals.context.tenantId;
+	},
+}));
+
+const mockSendMessage = vi.fn();
+const mockGetMessageHistory = vi.fn();
+vi.mock('$lib/server/services/message-service', () => ({
+	sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+	getMessageHistory: (...args: unknown[]) => mockGetMessageHistory(...args),
+	STAMP_PRESETS: [],
+}));
+
+vi.mock('$lib/server/services/child-service', () => ({
+	getAllChildren: vi.fn(),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { actions } = await import('../../../src/routes/(parent)/admin/messages/+page.server');
+
+// ---------- helpers ----------
+
+type PlanTier = 'free' | 'standard' | 'family';
+
+function createRequest(formValues: Record<string, string>): Request {
+	const fd = new FormData();
+	for (const [k, v] of Object.entries(formValues)) fd.set(k, v);
+	return {
+		formData: () => Promise.resolve(fd),
+	} as unknown as Request;
+}
+
+function createEvent(tier: PlanTier, formValues: Record<string, string>, tenantId = 't-test') {
+	mockResolveFullPlanTier.mockResolvedValue(tier);
+	mockGetPlanLimits.mockImplementation((t: PlanTier) => ({
+		maxChildren: null,
+		maxActivities: null,
+		historyRetentionDays: null,
+		canExport: t !== 'free',
+		canCustomAvatar: t !== 'free',
+		canFreeTextMessage: t === 'family',
+		canCustomReward: t !== 'free',
+		canSiblingRanking: t === 'family',
+		maxCloudExports: 0,
+	}));
+	return {
+		request: createRequest(formValues),
+		locals: {
+			context: { tenantId, licenseStatus: tier === 'free' ? 'none' : 'active', plan: tier },
+		},
+	} as unknown as Parameters<NonNullable<typeof actions.send>>[0];
+}
+
+// ---------- tests ----------
+
+describe('POST /admin/messages?/send (#772)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockSendMessage.mockResolvedValue({ id: 1, childId: 1, messageType: 'text', body: 'ok' });
+	});
+
+	it('free プランで text メッセージを送ると 403（ファミリー限定）', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: send is defined
+		const result = await actions.send!(
+			createEvent('free', {
+				childId: '1',
+				messageType: 'text',
+				body: 'がんばったね',
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 403,
+			data: { error: '自由テキストメッセージはファミリープラン限定です' },
+		});
+		expect(mockSendMessage).not.toHaveBeenCalled();
+	});
+
+	it('standard プランで text メッセージを送ると 403（ファミリー限定）', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: send is defined
+		const result = await actions.send!(
+			createEvent('standard', {
+				childId: '1',
+				messageType: 'text',
+				body: 'がんばったね',
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 403,
+			data: { error: '自由テキストメッセージはファミリープラン限定です' },
+		});
+		expect(mockSendMessage).not.toHaveBeenCalled();
+	});
+
+	it('family プランなら text メッセージを送信できる', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: send is defined
+		const result = await actions.send!(
+			createEvent('family', {
+				childId: '1',
+				messageType: 'text',
+				body: 'がんばったね',
+			}),
+		);
+		expect(result).toMatchObject({ sent: true });
+		expect(mockSendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				childId: 1,
+				messageType: 'text',
+				body: 'がんばったね',
+				stampCode: null,
+			}),
+			't-test',
+		);
+	});
+
+	it('free プランでも stamp メッセージは送信できる（ゲートされない）', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: send is defined
+		const result = await actions.send!(
+			createEvent('free', {
+				childId: '1',
+				messageType: 'stamp',
+				stampCode: 'good_job',
+			}),
+		);
+		expect(result).toMatchObject({ sent: true });
+		expect(mockSendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				childId: 1,
+				messageType: 'stamp',
+				stampCode: 'good_job',
+				body: null,
+			}),
+			't-test',
+		);
+		// stamp はプランゲートを通らないので resolveFullPlanTier は呼ばれない
+		expect(mockResolveFullPlanTier).not.toHaveBeenCalled();
+	});
+
+	it('standard プランでも stamp メッセージは送信できる', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: send is defined
+		const result = await actions.send!(
+			createEvent('standard', {
+				childId: '1',
+				messageType: 'stamp',
+				stampCode: 'good_job',
+			}),
+		);
+		expect(result).toMatchObject({ sent: true });
+		expect(mockSendMessage).toHaveBeenCalled();
+	});
+
+	it('family プランで空本文の text は 400', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: send is defined
+		const result = await actions.send!(
+			createEvent('family', {
+				childId: '1',
+				messageType: 'text',
+				body: '   ',
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'メッセージを入力してください' },
+		});
+		expect(mockSendMessage).not.toHaveBeenCalled();
+	});
+
+	it('childId 未指定は 400', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: send is defined
+		const result = await actions.send!(
+			createEvent('family', {
+				messageType: 'text',
+				body: 'hi',
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'こどもを選択してください' },
+		});
+		expect(mockSendMessage).not.toHaveBeenCalled();
+	});
+
+	it('不正な messageType は 400', async () => {
+		// biome-ignore lint/style/noNonNullAssertion: send is defined
+		const result = await actions.send!(
+			createEvent('family', {
+				childId: '1',
+				messageType: 'voice',
+				body: 'hi',
+			}),
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'メッセージ種別が不正です' },
+		});
+		expect(mockSendMessage).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/routes/admin-messages-send.test.ts
+++ b/tests/unit/routes/admin-messages-send.test.ts
@@ -6,7 +6,7 @@
 // - standard プランで text メッセージを送ると 403（ファミリー限定エラー）
 // - family プランなら text メッセージを送信できる
 // - stamp メッセージはプランに関係なく送信できる（ゲートされない）
-// - messageType バリデーション / body 必須 / 文字数上限などの基本バリデーション
+// - messageType バリデーション / body 必須などの基本バリデーション
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -63,7 +63,6 @@ function createEvent(tier: PlanTier, formValues: Record<string, string>, tenantI
 		maxActivities: null,
 		historyRetentionDays: null,
 		canExport: t !== 'free',
-		canCustomAvatar: t !== 'free',
 		canFreeTextMessage: t === 'family',
 		canCustomReward: t !== 'free',
 		canSiblingRanking: t === 'family',


### PR DESCRIPTION
## Summary
- ひとことメッセージ（自由テキスト）は ADR-0024 / `plan-features.ts` SSOT で family プラン限定と定義されているが、設計書・LP・比較表で仕様が散在していた
- コード側（`plan-limit-service.ts` / `messages/+page.server.ts` / `+page.svelte`）は既に正しく family 限定で実装済み
- ドキュメント・LP を SSOT に同期させ、回帰テストを追加

## Changes
### Docs
- `docs/design/19-プライシング戦略書.md` §7.4 コード例: `standard.canFreeTextMessage` を `false` に修正（`family 限定（差別化ポイント）` コメント付き）
- `docs/design/06-UI設計書.md` §4.11 おうえんメッセージ: プラン別の送信可否テーブル、`PlanLimits.canFreeTextMessage` ゲートの説明、`aria-describedby` による不活性化時の案内、`fail(403)` による再検証、ADR-0024 への相互参照を追記

### LP (`site/pricing.html`)
- family プラン特典リストに `ひとことメッセージ（自由テキスト）` を追加
- プラン比較表に `おうえん・メッセージ` カテゴリを追加
  - スタンプでおうえん: free / standard / family すべて ✓
  - ひとことメッセージ（自由テキスト）: family のみ ✓

### Tests
- `tests/unit/routes/admin-messages-send.test.ts` を新規追加
  - `resolveFullPlanTier` + `getPlanLimits` をモックして send action を直接呼び出し
  - free + text → 403 `自由テキストメッセージはファミリープラン限定です`
  - standard + text → 403 同エラー
  - family + text → 成功、`sendMessage` が呼ばれる
  - free / standard + stamp → 成功（プランゲートを通らない）
  - family + 空本文 text → 400
  - childId 未指定 → 400
  - 不正 messageType → 400

## Test plan
- [x] `npx vitest run tests/unit/routes/admin-messages-send.test.ts` → 8 passed
- [x] `npx biome check tests/unit/routes/admin-messages-send.test.ts` → clean
- [x] `npx svelte-check` → 0 errors
- [ ] CI green (e2e, docker-build, unit)

Closes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)