### PR TITLE
docs(api): PlanLimitError 仕様を §4.2 に正仕様化 (#744)

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -2,9 +2,9 @@
 
 | 項目 | 内容 |
 |------|------|
-| 版数 | 2.7 |
+| 版数 | 2.9 |
 | 作成日 | 2026-02-19 |
-| 更新日 | 2026-04-09 |
+| 更新日 | 2026-04-12 |
 | 作成者 | 日下武紀 |
 
 ---
@@ -1423,18 +1423,101 @@ Push 通知の購読解除。
 | VALIDATION_ERROR | 400 | リクエストバリデーション失敗 |
 | CANCEL_EXPIRED | 400 | キャンセル期限超過 |
 | ALREADY_RECORDED | 409 | 同日同活動の重複記録 |
+| DAILY_LIMIT_REACHED | 409 | 1日あたりの記録上限到達 |
 | ALREADY_CLAIMED | 409 | ログインボーナス受取済み |
 | INSUFFICIENT_POINTS | 400 | ポイント残高不足 |
 | INVALID_PIN | 401 | PIN不一致 |
 | UNAUTHORIZED | 401 | 認証が必要 |
 | LOCKED_OUT | 429 | ロックアウト中 |
 | NOT_FOUND | 404 | リソースが見つからない |
+| PLAN_LIMIT_EXCEEDED | 403 | プラン制限により拒否（§4.2 参照） |
 | INTERNAL_ERROR | 500 | サーバー内部エラー |
 | LICENSE_FORMAT_INVALID | 400 | ライセンスキー形式が不正 |
 | LICENSE_SIGNATURE_INVALID | 400 | ライセンスキー HMAC 署名不一致 |
 | LICENSE_NOT_FOUND | 404 | ライセンスキーが存在しない |
 | LICENSE_ALREADY_CONSUMED | 409 | ライセンスキー消費済み |
 | LICENSE_REVOKED | 410 | ライセンスキー失効済み |
+
+### 4.2 プラン制限エラー (`PLAN_LIMIT_EXCEEDED`) — #744
+
+プラン制限（`PLAN_LIMITS` の boolean フラグまたは数値上限）によって拒否されたリクエストは、
+**必ず HTTP 403** と以下の body で応答する。フロントエンドが「どのプランにすれば使えるか」を
+一貫した UI で提示できるよう、`currentTier` / `requiredTier` / `upgradeUrl` を含める。
+
+#### レスポンス body（正仕様）
+
+```ts
+// src/lib/domain/errors.ts
+export interface PlanLimitError {
+  code: 'PLAN_LIMIT_EXCEEDED';
+  message: string;                              // 人間可読（日本語）
+  currentTier: 'free' | 'standard' | 'family';  // リクエスト時点のテナントプラン
+  requiredTier: 'standard' | 'family';          // 許可される最小プラン
+  upgradeUrl: '/admin/license';                 // アップグレード導線。固定
+}
+```
+
+レスポンス例:
+
+```json
+{
+  "error": {
+    "code": "PLAN_LIMIT_EXCEEDED",
+    "message": "AI 活動提案はスタンダードプラン以上でご利用いただけます",
+    "currentTier": "free",
+    "requiredTier": "standard",
+    "upgradeUrl": "/admin/license"
+  }
+}
+```
+
+#### 使い分け（ステータスコード規約）
+
+| コード | 用途 |
+|-------|------|
+| `400 VALIDATION_ERROR` | リクエストボディのバリデーション失敗（プラン制限以外） |
+| `403 PLAN_LIMIT_EXCEEDED` | **プラン制限による拒否のみ**（boolean フラグ / 数値上限いずれも） |
+| `403` （UNAUTHORIZED 系） | ロール不足 / 未認証などの認可エラー。`PLAN_LIMIT_EXCEEDED` とは別コード |
+| `429 LOCKED_OUT` | レートリミット超過 |
+
+#### トライアル中の扱い
+
+- `currentTier` にはトライアル中のティア（`standard` / `family`）が入る。
+- トライアル終了後にもう一度叩かれた場合は `currentTier: 'free'` で 403 が返る。
+- クライアント側でトライアル残日数を表示するには `GET /api/v1/admin/plan-status`（別）を併用する。
+
+#### 実装ヘルパー
+
+- **API エンドポイント (`+server.ts`)**: `src/lib/server/errors.ts` の `planLimitError({ currentTier, requiredTier, message })` を使う。
+- **フォームアクション (`+page.server.ts`)**: `fail(403, { error: createPlanLimitError(currentTier, requiredTier, message) })` を返す。`createPlanLimitError` は `src/lib/domain/errors.ts` から import する。
+- **クライアント**: `isPlanLimitError(result.data?.error)` の型ガードで判定し、`requiredTier` からアップセル先プランのラベルを決定する。
+
+#### プラン制限が適用される主要エンドポイント
+
+現時点でプラン制限（`PLAN_LIMIT_EXCEEDED` 403 を返し得る）が実装済みのエンドポイントを整理する。
+既存実装の body 形式は段階的に `PlanLimitError` 形式へ移行する（別 issue で追跡）。
+
+| エンドポイント / フォームアクション | 必要プラン | 根拠 |
+|----------|---------|------|
+| `POST /api/v1/activities/suggest` | standard | AI 活動提案 (`isPaidTier`) |
+| `POST /api/v1/export` (activity pack export) | standard | `canExport` フラグ |
+| `POST /api/v1/export/cloud` | standard | `canExport` + `maxCloudExports` |
+| `POST /api/v1/children` | 上限付き | `free` は `maxChildren=2` まで |
+| `POST /api/v1/activities` (custom) | 上限付き | `free` は `maxActivities=3` まで |
+| `POST /admin/checklists/+page.server.ts ?/createTemplate` | 上限付き | `free` は `maxChecklistTemplates=3` まで (#723) |
+| `POST /admin/rewards ?/create` | standard | 特別なごほうび (`canCustomReward`, #728) |
+| `POST /admin/rewards ?/importPresets` | standard | 特別なごほうび取り込み (#728) |
+| `POST /admin/messages ?/send` (text モード) | family | 自由テキストメッセージ (`canFreeTextMessage`, #772) |
+| `POST /admin/settings ?/updateSiblingSettings` (ranking ON) | family | きょうだいランキング (`canSiblingRanking`, #782) |
+
+**注意**: 上記以外のエンドポイント（GET 系・基本的な CRUD 等）は**全プラン利用可**。
+新規にプラン制限を追加する際は、本表へ追記し `PlanLimitError` 形式で 403 を返すこと。
+
+#### 移行計画
+
+1. **Phase 1**（本 PR #744）: 仕様定義・型定義・ヘルパー追加。既存実装は変更しない。
+2. **Phase 2** (#787): 全プラン制限箇所を `planLimitError()` / `createPlanLimitError()` に統一。
+3. **Phase 3**: フロント共通エラーハンドラで `isPlanLimitError` を使ったアップセルトーストを実装。
 
 ---
 
@@ -1512,3 +1595,4 @@ Push 通知の購読解除。
 | 2026-04-06 | 2.6 | #550 アナリティクス基盤: POST /api/v1/analytics（イベント記録）、GET /api/v1/analytics/status（設定確認）追加。3層プロバイダー（Sentry/Umami/DynamoDB）アーキテクチャ |
 | 2026-04-10 | 2.7 | #605 バトルアドベンチャーAPI追加: GET/POST /api/v1/battle/[childId]（日次バトル取得・実行） |
 | 2026-04-09 | 2.8 | #609 設計書同期: アカウント削除(2)・閲覧専用トークン(3)エンドポイントを一覧追加。未記載だった9カテゴリのエンドポイント詳細仕様（3.17-3.25）を追記 |
+| 2026-04-12 | 2.9 | #744 プラン制限エラー仕様 (§4.2) 追加。`PLAN_LIMIT_EXCEEDED` の body フォーマット (`currentTier` / `requiredTier` / `upgradeUrl`) を正仕様化。型定義を `src/lib/domain/errors.ts` として新設し client/server で共有。既存実装の移行は #787 で追跡 |

--- a/src/lib/domain/errors.ts
+++ b/src/lib/domain/errors.ts
@@ -1,0 +1,99 @@
+// src/lib/domain/errors.ts
+// #744: プラン制限エラーの共有型定義
+//
+// server (`apiError` / `fail(403, ...)`) とクライアント（フォームアクション結果ハンドラ等）で
+// 同じ型を参照できるよう、ドメイン層に型を置く。実装の移行は別チケットで段階的に行う。
+
+// PlanTier はドメインの概念だが、現状は plan-limit-service.ts に定義されているため
+// type-only import で利用する（実行時に server コードを読み込まない）。
+import type { PlanTier } from '$lib/server/services/plan-limit-service';
+
+/**
+ * プラン制限で API / フォームアクションが拒否された際のエラー body。
+ *
+ * HTTP ステータス: **403 Forbidden**
+ *
+ * ## レスポンス例
+ *
+ * ```json
+ * {
+ *   "error": {
+ *     "code": "PLAN_LIMIT_EXCEEDED",
+ *     "message": "AI 活動提案はスタンダードプラン以上でご利用いただけます",
+ *     "currentTier": "free",
+ *     "requiredTier": "standard",
+ *     "upgradeUrl": "/admin/license"
+ *   }
+ * }
+ * ```
+ *
+ * ## 使い方（server）
+ *
+ * - API エンドポイント: `src/lib/server/errors.ts` の `planLimitError()` を使う
+ * - フォームアクション: `fail(403, { error: planLimitError({ ... }) })` を返す
+ *
+ * ## 使い方（client）
+ *
+ * - `result.data?.error?.code === 'PLAN_LIMIT_EXCEEDED'` で判定
+ * - `requiredTier` を使ってアップグレード先のプラン表記を動的に切り替え
+ *
+ * @see docs/design/07-API設計書.md §4.2 プラン制限エラー
+ * @see ADR-0024 plan-tier-resolution-pattern
+ */
+export interface PlanLimitError {
+	/** 常に 'PLAN_LIMIT_EXCEEDED' */
+	code: 'PLAN_LIMIT_EXCEEDED';
+	/** 人間可読なエラーメッセージ（日本語） */
+	message: string;
+	/** リクエスト時点でのテナントのプラン。トライアルの場合はトライアルティアが入る */
+	currentTier: PlanTier;
+	/** この操作を許可する最小プラン */
+	requiredTier: Exclude<PlanTier, 'free'>;
+	/** アップグレード導線 URL。常に '/admin/license' */
+	upgradeUrl: '/admin/license';
+}
+
+/** レスポンス body のエラー部分（`{ error: ... }` の値） */
+export type PlanLimitErrorBody = PlanLimitError;
+
+/**
+ * PlanLimitError を組み立てるヘルパー。
+ *
+ * @example
+ * ```ts
+ * return json(
+ *   { error: createPlanLimitError('free', 'standard', 'AI 活動提案はスタンダードプラン以上でご利用いただけます') },
+ *   { status: 403 },
+ * );
+ * ```
+ */
+export function createPlanLimitError(
+	currentTier: PlanTier,
+	requiredTier: Exclude<PlanTier, 'free'>,
+	message: string,
+): PlanLimitError {
+	return {
+		code: 'PLAN_LIMIT_EXCEEDED',
+		message,
+		currentTier,
+		requiredTier,
+		upgradeUrl: '/admin/license',
+	};
+}
+
+/**
+ * レスポンスが PlanLimitError 形式かを型ガードで判定する。
+ *
+ * クライアント側で `result.data?.error` を受け取った際に使う。
+ */
+export function isPlanLimitError(value: unknown): value is PlanLimitError {
+	if (!value || typeof value !== 'object') return false;
+	const v = value as Record<string, unknown>;
+	return (
+		v.code === 'PLAN_LIMIT_EXCEEDED' &&
+		typeof v.message === 'string' &&
+		(v.currentTier === 'free' || v.currentTier === 'standard' || v.currentTier === 'family') &&
+		(v.requiredTier === 'standard' || v.requiredTier === 'family') &&
+		v.upgradeUrl === '/admin/license'
+	);
+}

--- a/src/lib/domain/errors.ts
+++ b/src/lib/domain/errors.ts
@@ -30,7 +30,7 @@ import type { PlanTier } from '$lib/server/services/plan-limit-service';
  * ## 使い方（server）
  *
  * - API エンドポイント: `src/lib/server/errors.ts` の `planLimitError()` を使う
- * - フォームアクション: `fail(403, { error: planLimitError({ ... }) })` を返す
+ * - フォームアクション: `fail(403, { error: createPlanLimitError(...) })` を返す
  *
  * ## 使い方（client）
  *

--- a/src/lib/server/errors.ts
+++ b/src/lib/server/errors.ts
@@ -1,5 +1,7 @@
 import { json } from '@sveltejs/kit';
+import { createPlanLimitError, type PlanLimitError } from '$lib/domain/errors';
 import { logger } from '$lib/server/logger';
+import type { PlanTier } from '$lib/server/services/plan-limit-service';
 
 export type ErrorCode =
 	| 'VALIDATION_ERROR'
@@ -133,6 +135,43 @@ export function validationError(message: string) {
 /** エラーコードからユーザー向けメッセージを取得（page.server.ts の fail() で利用） */
 export function getUserMessage(code: ErrorCode): string {
 	return ERROR_DEFINITIONS[code].userMessage;
+}
+
+/**
+ * プラン制限エラーを 403 レスポンスとして返す (#744)。
+ *
+ * 既存の {@link apiError} が返す `{ error: { code, message, userMessage, ... } }` に加えて
+ * `currentTier` / `requiredTier` / `upgradeUrl` を含む {@link PlanLimitError} 形式で body を返す。
+ *
+ * クライアントは `error.code === 'PLAN_LIMIT_EXCEEDED'` と `error.requiredTier` を使って
+ * アップセル UI を出し分ける。
+ *
+ * @example
+ * ```ts
+ * return planLimitError({
+ *   currentTier: 'free',
+ *   requiredTier: 'standard',
+ *   message: 'AI 活動提案はスタンダードプラン以上でご利用いただけます',
+ * });
+ * ```
+ *
+ * @see docs/design/07-API設計書.md §4.2 プラン制限エラー
+ */
+export function planLimitError(opts: {
+	currentTier: PlanTier;
+	requiredTier: Exclude<PlanTier, 'free'>;
+	message: string;
+	context?: Record<string, unknown>;
+}) {
+	const body: PlanLimitError = createPlanLimitError(
+		opts.currentTier,
+		opts.requiredTier,
+		opts.message,
+	);
+	logger.warn(`[API] PLAN_LIMIT_EXCEEDED: ${opts.message}`, {
+		context: { ...opts.context, currentTier: opts.currentTier, requiredTier: opts.requiredTier },
+	});
+	return json({ error: body }, { status: 403 });
 }
 
 /** エラーコードから定義全体を取得 */

--- a/src/lib/server/errors.ts
+++ b/src/lib/server/errors.ts
@@ -140,8 +140,8 @@ export function getUserMessage(code: ErrorCode): string {
 /**
  * プラン制限エラーを 403 レスポンスとして返す (#744)。
  *
- * 既存の {@link apiError} が返す `{ error: { code, message, userMessage, ... } }` に加えて
- * `currentTier` / `requiredTier` / `upgradeUrl` を含む {@link PlanLimitError} 形式で body を返す。
+ * {@link apiError} とは別の error shape で `{ error: PlanLimitError }` の形式で body を返す。
+ * `error` には `code` / `message` / `currentTier` / `requiredTier` / `upgradeUrl` が含まれる。
  *
  * クライアントは `error.code === 'PLAN_LIMIT_EXCEEDED'` と `error.requiredTier` を使って
  * アップセル UI を出し分ける。

--- a/tests/unit/domain/errors.test.ts
+++ b/tests/unit/domain/errors.test.ts
@@ -1,0 +1,112 @@
+// tests/unit/domain/errors.test.ts
+// #744: PlanLimitError 共有型の単体テスト
+
+import { describe, expect, it } from 'vitest';
+import {
+	createPlanLimitError,
+	isPlanLimitError,
+	type PlanLimitError,
+} from '../../../src/lib/domain/errors';
+
+describe('#744 PlanLimitError', () => {
+	describe('createPlanLimitError', () => {
+		it('free → standard のアップセルエラーを構築する', () => {
+			const err = createPlanLimitError(
+				'free',
+				'standard',
+				'AI 活動提案はスタンダードプラン以上でご利用いただけます',
+			);
+			expect(err).toEqual({
+				code: 'PLAN_LIMIT_EXCEEDED',
+				message: 'AI 活動提案はスタンダードプラン以上でご利用いただけます',
+				currentTier: 'free',
+				requiredTier: 'standard',
+				upgradeUrl: '/admin/license',
+			});
+		});
+
+		it('standard → family のアップセルエラーを構築する', () => {
+			const err = createPlanLimitError(
+				'standard',
+				'family',
+				'きょうだいランキングはファミリープラン限定です',
+			);
+			expect(err.currentTier).toBe('standard');
+			expect(err.requiredTier).toBe('family');
+			expect(err.upgradeUrl).toBe('/admin/license');
+		});
+
+		it('upgradeUrl は常に /admin/license で固定', () => {
+			const err = createPlanLimitError('free', 'family', 'msg');
+			expect(err.upgradeUrl).toBe('/admin/license');
+		});
+	});
+
+	describe('isPlanLimitError', () => {
+		it('正しい形式を true 判定する', () => {
+			const err: PlanLimitError = {
+				code: 'PLAN_LIMIT_EXCEEDED',
+				message: 'test',
+				currentTier: 'free',
+				requiredTier: 'standard',
+				upgradeUrl: '/admin/license',
+			};
+			expect(isPlanLimitError(err)).toBe(true);
+		});
+
+		it('code が違えば false', () => {
+			expect(
+				isPlanLimitError({
+					code: 'VALIDATION_ERROR',
+					message: 'test',
+					currentTier: 'free',
+					requiredTier: 'standard',
+					upgradeUrl: '/admin/license',
+				}),
+			).toBe(false);
+		});
+
+		it('currentTier が不正値なら false', () => {
+			expect(
+				isPlanLimitError({
+					code: 'PLAN_LIMIT_EXCEEDED',
+					message: 'test',
+					currentTier: 'premium',
+					requiredTier: 'standard',
+					upgradeUrl: '/admin/license',
+				}),
+			).toBe(false);
+		});
+
+		it('requiredTier が free なら false（free へのアップセルはあり得ない）', () => {
+			expect(
+				isPlanLimitError({
+					code: 'PLAN_LIMIT_EXCEEDED',
+					message: 'test',
+					currentTier: 'free',
+					requiredTier: 'free',
+					upgradeUrl: '/admin/license',
+				}),
+			).toBe(false);
+		});
+
+		it('upgradeUrl が違う path なら false', () => {
+			expect(
+				isPlanLimitError({
+					code: 'PLAN_LIMIT_EXCEEDED',
+					message: 'test',
+					currentTier: 'free',
+					requiredTier: 'standard',
+					upgradeUrl: '/pricing',
+				}),
+			).toBe(false);
+		});
+
+		it('null / undefined / プリミティブは false', () => {
+			expect(isPlanLimitError(null)).toBe(false);
+			expect(isPlanLimitError(undefined)).toBe(false);
+			expect(isPlanLimitError('PLAN_LIMIT_EXCEEDED')).toBe(false);
+			expect(isPlanLimitError(403)).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Closes #744 (Phase 1: 仕様定義)

プラン制限によるエラーが実装箇所ごとに異なる形式 (`fail(400)` / `fail(403)` / `throw error` 混在) で返されていたため、フロントエンド側で「どのプランにすれば使えるか」を統一的に表示できなかった。

## Changes

- **`docs/design/07-API設計書.md` §4.2 プラン制限エラー** を新設
  - `PLAN_LIMIT_EXCEEDED` レスポンス body の正仕様化（`currentTier` / `requiredTier` / `upgradeUrl` を必須化）
  - ステータスコード規約の明示（400 validation / 403 plan-limit / 429 rate-limit）
  - プラン制限が適用される主要エンドポイント一覧の棚卸し（現状実装 10 箇所）
  - 移行計画: Phase 1=仕様定義 (本 PR) / Phase 2=既存実装移行 (#787) / Phase 3=フロント共通ハンドラ
- **`src/lib/domain/errors.ts` 新設**
  - `PlanLimitError` 型定義（client/server 共有）
  - `createPlanLimitError(currentTier, requiredTier, message)` ヘルパー
  - `isPlanLimitError(value)` 型ガード
- **`src/lib/server/errors.ts`**
  - `planLimitError({ currentTier, requiredTier, message })` ヘルパー追加
  - 既存 `apiError` と並列の互換 API（既存実装を壊さない）
- **`tests/unit/domain/errors.test.ts` 新設** — 9 ケース

## Acceptance Criteria (#744)

- [x] 07-API設計書 にプラン別エラー仕様セクション追加
- [x] 型定義を `src/lib/domain/errors.ts` として export し、client/server で共有
- [x] 主要プラン制限エンドポイントの棚卸し表
- [ ] 既存の API を段階的に移行 → **#787 で追跡（本 PR スコープ外）**

## Test plan

- [x] `npx biome check .` — エラーなし
- [x] `npx svelte-check` — エラー 0
- [x] `npx vitest run tests/unit/domain/errors.test.ts` — 9/9 通過
- [x] `npx vitest run tests/unit/domain tests/unit/services/errors` — 501/501 通過

## Notes

- 本 PR は **Phase 1 (仕様定義のみ)**。既存実装（`apiError('PLAN_LIMIT_EXCEEDED', msg)` / `fail(403, { error, code })`）は変更していないため、互換性の破壊なし。
- Phase 2 (#787) で全箇所を `planLimitError()` / `createPlanLimitError()` に統一する。
- 既存 `src/lib/server/errors.ts` の `PLAN_LIMIT_EXCEEDED` 定義は Phase 2 で body 拡張時に整理予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)