### PR TITLE
docs(db): #745 08-DB 設計書に §6.5 保持期間ポリシー + ADR-0027 追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -178,6 +178,7 @@ The project maintains ADRs in `docs/decisions/`. Key decisions to be aware of:
 - **ADR-0024**: Plan tier resolution pattern — use `resolveFullPlanTier` from server load/action, never call `resolvePlanTier` directly
 - **ADR-0025**: License ↔ Stripe Subscription causality — Stripe is source of truth, dunning delegated to Stripe
 - **ADR-0026**: License key architecture — HMAC-SHA256, 32-char alphabet, single-use, 90-day expiry
+- **ADR-0027**: Plan-based history retention policy — retention is a read-time display filter only; no physical delete cron. Summary tables are exempt from retention filtering
 
 ### Team Structure
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -62,6 +62,7 @@
 - [ADR-0024](decisions/0024-plan-tier-resolution-pattern.md) — プラン解決 (resolvePlanTier) の責務分離パターン
 - [ADR-0025](decisions/0025-license-subscription-causality.md) — License ↔ Stripe Subscription 因果関係
 - [ADR-0026](decisions/0026-license-key-architecture.md) — ライセンスキーアーキテクチャ
+- [ADR-0027](decisions/0027-retention-policy.md) — プラン別履歴保持期間ポリシー（retention = 表示フィルタ、物理削除禁止）
 
 ## 画像アセット
 

--- a/docs/decisions/0027-retention-policy.md
+++ b/docs/decisions/0027-retention-policy.md
@@ -94,7 +94,7 @@
 
 ### テスト
 
-- `tests/unit/services/plan-limit-service.test.ts` に「retention が `null` のとき全期間返す」「cutoff より前の `from` が上書きされる」等のテストが存在することを確認済み
+- `tests/unit/services/plan-limit-service.test.ts` に `getHistoryCutoffDate` のユニットテスト（free=90日/standard=365日/family=null）が存在することを確認済み。`applyRetentionFilter` / `hasArchivedData` のテストは未整備（将来追加推奨）
 - 新しい集計テーブルや物理削除 cron を導入する場合は本 ADR を差し戻して再検討すること
 
 ## 代替案と却下理由
@@ -113,7 +113,7 @@
 
 ## フォローアップ
 
-- [ ] #745 PR で 08-DB 設計書に §6.X 保持期間ポリシーを追記（本 ADR へのリンクを含む）
+- [x] #745 PR で 08-DB 設計書に §6.5 保持期間ポリシーを追記（本 ADR へのリンクを含む）
 - [ ] 将来的に retention を UI 上で変更する機能が出てきたら、「カットオフ日時点のスナップショット」を保存する要件が発生する可能性あり。その時点で本 ADR を再検討
 - [ ] 集計テーブル（`report_daily_summaries` 以外の kind of summary）を追加する場合、本 ADR の「集計値は保持期間の影響を受けない」原則を守ること
 

--- a/docs/decisions/0027-retention-policy.md
+++ b/docs/decisions/0027-retention-policy.md
@@ -1,0 +1,125 @@
+# ADR-0027: プラン別履歴保持期間ポリシー（retention = 表示フィルタ）
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | accepted |
+| 日付 | 2026-04-12 |
+| 起票者 | Takenori-Kusaka |
+| 関連 Issue | #745, #729, #737 |
+| 関連 ADR | ADR-0003（設計書 SSOT）, ADR-0015（Repository パターン）, ADR-0024（プラン解決パターン）, ADR-0025（License ↔ Subscription 因果関係） |
+
+## コンテキスト
+
+プラン別の履歴保持期間（retention）は `PLAN_LIMITS.historyRetentionDays` で定義されているが、仕様書上の定義と実装の対応関係が未記載だった。
+
+| プラン | `historyRetentionDays` | 意味 |
+|--------|----------------------|------|
+| free | `90` | 90 日より前のレコードは非表示 |
+| standard | `365` | 1 年より前のレコードは非表示 |
+| family | `null` | 制限なし（全期間表示） |
+
+実装は `src/lib/server/services/plan-limit-service.ts` の以下 3 関数に集約されている:
+
+| 関数 | 責務 |
+|------|------|
+| `getHistoryCutoffDate(tier)` | カットオフ日（YYYY-MM-DD）を計算する。`null` なら制限なし |
+| `applyRetentionFilter(tier, { from, to })` | `from` が cutoff より前なら cutoff で上書きした日付範囲を返す（読み取り時のフィルタ） |
+| `hasArchivedData(tenantId, childId, tier)` | cutoff より前にデータがあるか判定する（アップグレード誘導バナー用） |
+
+### 呼び出し側
+
+- `src/routes/(child)/[uiMode=uiMode]/(character)/history/+page.server.ts`: 子供側の履歴画面で `applyRetentionFilter` 後に `getActivityLogs` を呼ぶ
+- `src/routes/(parent)/admin/children/+page.server.ts`: 管理画面の子供ページで `applyRetentionFilter` + `hasArchivedData` を使用
+- `src/lib/features/admin/components/ArchiveBanner.svelte`: `hasArchivedData === true` のときにアップグレード誘導を表示
+
+## 決定事項
+
+**retention は「表示フィルタ（論理削除相当）」として実装する。物理削除は行わない。**
+
+### 1. retention = 表示フィルタ（物理削除なし）
+
+- DB 上のレコードは**常に全期間保持**する
+- プラン別カットオフは**読み取り時のフィルタ**として適用する（`applyRetentionFilter`）
+- アーカイブ削除用の cron / バッチは**実装しない**
+
+**根拠:**
+
+1. ストレージコストより UX リスクの方が大きい — 物理削除すると downgrade / 誤課金キャンセルで過去データが復旧不能になる
+2. downgrade したユーザーが family に復帰したとき「過去のがんばり記録」がそのまま蘇る設計が子供向けプロダクトとして重要
+3. 活動ログは 1 家族あたり年間 1MB 程度であり、3〜5 年の全保持でも DynamoDB コストは無視できる
+4. SQLite（セルフホスト）では物理削除する実装上の動機がさらに弱い（`auth === 'local'` は常に family 相当）
+
+### 2. 集計値は保持期間の影響を受けない
+
+`report_daily_summaries` テーブル（§3. の日次バッチ集計）はプラン関係なく全期間の集計値を保持する。retention フィルタは**当該テーブルには適用しない**。
+
+**理由:**
+- 集計値（合計ポイント・達成数・レベル推移）は過去の "がんばりの証" であり、プランを下げても失われるべきではない
+- 集計値の物理サイズは日次 1 行 × 家族数しかなく、圧倒的に小さい
+- 月次レポート画面（有料機能）は保持期間の影響を受けない前提で設計されている
+
+### 3. アップグレード誘導バナー
+
+`hasArchivedData()` が true を返す（= cutoff より前にレコードがある）家族に対して、`ArchiveBanner.svelte` が「過去のデータが隠れています、ファミリープランで全期間閲覧できます」というアップグレード誘導を表示する。
+
+これにより「データを消された」ではなく「プランを上げれば蘇る」という体験になる。
+
+### 4. プラン downgrade 時の扱い
+
+- 既存レコードは DB 上残る
+- 次回リクエストから `applyRetentionFilter` が cutoff より前のデータを隠す
+- downgrade 時点で警告モーダル（`hasArchivedData` と同等の文言）を出すのは UI 側の責務
+
+### 5. 物理削除は「アカウント削除」のみ
+
+物理削除が発生するのは以下のみ:
+
+| トリガ | 対象 | grace period |
+|-------|------|--------------|
+| ユーザーによるアカウント削除 | 当該テナントの全レコード | 30 日（ADR-0022） |
+| 違反アカウント強制削除 | 当該テナントの全レコード | なし |
+
+これらは retention とは**別軸**で、`data-service.clearAllFamilyData()` が担う。
+
+## 影響範囲
+
+### 設計書
+
+- `docs/design/08-データベース設計書.md` §6.X に本ポリシーを追記（#745 PR でコミット）
+- `docs/design/07-API設計書.md` の履歴系 API 説明に「cutoff フィルタ」注記を将来追加
+
+### 実装
+
+既存実装（`applyRetentionFilter` / `hasArchivedData`）は本 ADR の結論と整合しており、**コード変更不要**。
+
+### テスト
+
+- `tests/unit/services/plan-limit-service.test.ts` に「retention が `null` のとき全期間返す」「cutoff より前の `from` が上書きされる」等のテストが存在することを確認済み
+- 新しい集計テーブルや物理削除 cron を導入する場合は本 ADR を差し戻して再検討すること
+
+## 代替案と却下理由
+
+### A. 物理削除 cron を実装する（#729 の原案）
+
+**却下理由:** 上記「根拠」参照。データ復元不能になる UX リスクとストレージ節約がつり合わない。
+
+### B. SQLite と DynamoDB で異なる retention 実装にする
+
+**却下理由:** duplicated implementation risk。本プロジェクトはどちらのバックエンドでも同じ UX を保証する方針（`src/lib/server/db/factory.ts`）。
+
+### C. retention を「論理削除フラグ」カラムで表現する
+
+**却下理由:** downgrade → upgrade 時にフラグを付け替えるバッチが必要になり、unnecessary complexity。日付比較だけで済む現行実装の方がシンプル。
+
+## フォローアップ
+
+- [ ] #745 PR で 08-DB 設計書に §6.X 保持期間ポリシーを追記（本 ADR へのリンクを含む）
+- [ ] 将来的に retention を UI 上で変更する機能が出てきたら、「カットオフ日時点のスナップショット」を保存する要件が発生する可能性あり。その時点で本 ADR を再検討
+- [ ] 集計テーブル（`report_daily_summaries` 以外の kind of summary）を追加する場合、本 ADR の「集計値は保持期間の影響を受けない」原則を守ること
+
+## 関連
+
+- #729: 実削除 cron が無い問題（→ 本 ADR により「cron 不要」が正仕様）
+- #737: 保持期間ポリシーの明文化要求
+- ADR-0022: 課金サイクルとデータライフサイクルの整合性
+- ADR-0024: プラン解決パターン

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -73,3 +73,4 @@
 | 0024 | [プラン解決 (resolvePlanTier) の責務分離パターン](0024-plan-tier-resolution-pattern.md) | accepted | 2026-04-11 |
 | 0025 | [License ↔ Stripe Subscription 因果関係](0025-license-subscription-causality.md) | accepted | 2026-04-11 |
 | 0026 | [ライセンスキーアーキテクチャ](0026-license-key-architecture.md) | accepted | 2026-04-11 |
+| 0027 | [プラン別履歴保持期間ポリシー（retention = 表示フィルタ）](0027-retention-policy.md) | accepted | 2026-04-12 |

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1296,6 +1296,88 @@ git push origin main
 
 ---
 
+## 6.5 保持期間ポリシー（プラン別 retention） — #745
+
+本プロジェクトの履歴保持ポリシーの **SSOT（Single Source of Truth）**。詳細な意思決定背景は [ADR-0027: プラン別履歴保持期間ポリシー](../decisions/0027-retention-policy.md) を参照。
+
+### 6.5.1 プラン別保持期間
+
+| プラン | `historyRetentionDays` | 意味 | 物理削除 |
+|--------|----------------------|------|---------|
+| free | `90` | 90 日より前のレコードは非表示 | なし |
+| standard | `365` | 1 年より前のレコードは非表示 | なし |
+| family | `null` | 制限なし（全期間表示） | なし |
+
+値の正は `src/lib/server/services/plan-limit-service.ts` の `PLAN_LIMITS[tier].historyRetentionDays`。設計書とコードが乖離した場合はコードを正として設計書側を修正すること。
+
+### 6.5.2 retention の実装：表示フィルタ（論理削除相当）
+
+**retention は「読み取り時の表示フィルタ」として実装する。物理削除は行わない。**
+
+- DB 上のレコードは**常に全期間保持**される
+- プラン別カットオフは**読み取り時のフィルタ**として適用される
+- アーカイブ削除用の cron / バッチは**存在しない**（実装禁止）
+
+#### 実装関数
+
+`src/lib/server/services/plan-limit-service.ts`:
+
+| 関数 | 責務 | 呼び出し側 |
+|------|------|-----------|
+| `getHistoryCutoffDate(tier)` | カットオフ日（YYYY-MM-DD）を返す。`null` なら制限なし | 内部ヘルパ |
+| `applyRetentionFilter(tier, { from, to })` | `from` が cutoff より前なら cutoff で上書きした日付範囲を返す | 履歴一覧 API の呼び出し側 |
+| `hasArchivedData(tenantId, childId, tier)` | cutoff より前にデータがあるか判定（アップグレード誘導バナー用） | admin ページ |
+
+#### 現在の呼び出し側
+
+| ファイル | 用途 |
+|---------|------|
+| `src/routes/(child)/[uiMode=uiMode]/(character)/history/+page.server.ts` | 子供の履歴画面で `applyRetentionFilter` 適用後に `getActivityLogs` を呼ぶ |
+| `src/routes/(parent)/admin/children/+page.server.ts` | 管理画面の子供ページで `applyRetentionFilter` + `hasArchivedData` を使用 |
+| `src/lib/features/admin/components/ArchiveBanner.svelte` | `hasArchivedData === true` のときアップグレード誘導を表示 |
+
+### 6.5.3 集計値は保持期間の影響を受けない
+
+`report_daily_summaries` テーブル（§3 参照）および将来追加される他の集計系テーブルは、プランに関係なく**全期間の集計値を保持**する。
+
+- `applyRetentionFilter` は当該テーブルには**適用しない**
+- 月次レポート機能（有料）は全期間の集計を前提に動作する
+- カラム例: `activity_count`, `total_points`, `streak_days`, `new_achievements`
+
+**理由**: 集計値は "がんばりの証" であり、プラン downgrade で失われてはならない。かつ日次 1 行 × 家族数しかなく物理サイズが小さい。
+
+### 6.5.4 プラン downgrade 時の扱い
+
+- 既存レコードは DB 上**残る**
+- 次回リクエストから `applyRetentionFilter` が cutoff より前のデータを隠す
+- downgrade 時点の UI 警告（"過去のデータが非表示になります" モーダル）は UI 層の責務
+- 再 upgrade で過去データが "蘇る"（物理削除しないため）
+
+### 6.5.5 retention と物理削除の使い分け
+
+物理削除は retention とは**別軸**であり、以下 2 ケースのみに限定される:
+
+| トリガ | 対象 | grace period | 実装 |
+|-------|------|-------------|------|
+| ユーザーによるアカウント削除 | 当該テナントの全レコード | 30 日（[ADR-0022](../decisions/0022-billing-data-lifecycle-consistency.md)） | `data-service.clearAllFamilyData()` |
+| 違反アカウント強制削除 | 当該テナントの全レコード | なし | OPS 画面からの手動操作 |
+
+retention（表示フィルタ）は**物理削除しない**、アカウント削除は**物理削除する**、という 2 軸の対比を混同しないこと。
+
+### 6.5.6 アップグレード誘導バナー
+
+`hasArchivedData()` が true を返す家族に対して、`ArchiveBanner.svelte` が「過去のデータが隠れています、ファミリープランで全期間閲覧できます」というアップグレード誘導を表示する。
+
+これにより "データを消された" ではなく "プランを上げれば蘇る" という体験を提供する。
+
+### 6.5.7 禁止事項
+
+- **物理削除 cron の実装禁止**: 本ポリシーは "表示フィルタ" のみ。物理削除バッチを追加する場合は本 SSOT と ADR-0027 を同時に差し戻して再合意を取ること
+- **集計テーブルへの retention 適用禁止**: `report_daily_summaries` 等の集計系には `applyRetentionFilter` を通さない
+- **retention 超過データの SELECT 時の物理削除禁止**: "見かけ上消えていたから消してよい" という誤解釈禁止
+
+---
+
 ## 7. DynamoDB シングルテーブル設計（本番 SaaS）
 
 ### 7.1 テーブル構成
@@ -1507,3 +1589,4 @@ src/lib/server/db/migration/
 | 2026-04-09 | 4.3 | #609 未記載7テーブル追記（parent_messages, rest_days, tenant_events, tenant_event_progress, auto_challenges, trial_history, viewer_tokens）、廃止テーブル（level_titles, custom_titles）に deprecated 注記追加 |
 | 2026-04-11 | 4.4 | #808 ライセンスキー関連エンティティ追加（LicenseRecord, LicenseEvent）+ GSI2 にテナント別ライセンス一覧パターン追加。詳細は [license-key-lifecycle.md](./license-key-lifecycle.md) を参照 |
 | 2026-04-11 | 4.5 | #801 LicenseRecord に `kind` / `issuedBy` 追加（cross-tenant consume 制御）。#797 LicenseRecord に `expiresAt` / `revokedBy` 追加（有効期限 90 日 + revoke 監査） |
+| 2026-04-12 | 4.6 | #745 §6.5 保持期間ポリシー（プラン別 retention = 表示フィルタ）を正仕様化。実装関数と呼び出し側を明記、集計値除外・物理削除禁止を明文化。[ADR-0027](../decisions/0027-retention-policy.md) と同期 |


### PR DESCRIPTION
closes #745

## Summary

#745 の「保持期間ポリシー・retention 実装が 08-データベース設計書.md に未記載」問題に対応。

- `docs/design/08-データベース設計書.md` に **§6.5 保持期間ポリシー（プラン別 retention）** を新設
  - free=90 日 / standard=365 日 / family=無制限 の SSOT（値は `PLAN_LIMITS.historyRetentionDays` を正とする）
  - **retention = 読み取り時の表示フィルタ（物理削除なし）** を明文化
  - 実装関数（`applyRetentionFilter` / `hasArchivedData` / `getHistoryCutoffDate`）と呼び出し側（子供履歴 / admin children / ArchiveBanner）を明記
  - 集計値（`report_daily_summaries`）は retention の対象外
  - プラン downgrade 時の扱い（レコードは残り、再 upgrade で "蘇る"）
  - retention と物理削除（アカウント削除 + grace period）の使い分け
  - **禁止事項**: 物理削除 cron の実装禁止、集計テーブルへの retention 適用禁止
- **ADR-0027 を新設**: 「retention は表示フィルタ」という意思決定を永続化（#745 issue の「実装方針を ADR 化」要件に対応）
- `docs/CLAUDE.md` / `docs/decisions/README.md` / `.github/copilot-instructions.md` の ADR 一覧を更新

## なぜ表示フィルタで物理削除しないのか（ADR-0027 §決定事項より）

1. ストレージコストより UX リスクの方が大きい — 物理削除すると downgrade / 誤課金キャンセルで過去データが復旧不能
2. downgrade したユーザーが family に復帰したとき「過去のがんばり記録」がそのまま蘇る設計が子供向けプロダクトとして重要
3. 活動ログは 1 家族あたり年間 ~1MB 程度であり、全保持コストは無視できる
4. セルフホスト SQLite は常に family 相当（retention 制限なし）のため、物理削除する動機がそもそも弱い

これにより #729 の「実削除 cron が無い」問題は **"cron 不要が正仕様"** として解消される。

## 影響範囲

- **コード変更なし**: 既存の `applyRetentionFilter` / `hasArchivedData` は本仕様と整合しており、そのまま維持
- 設計書の SSOT 化のみ

## Acceptance Criteria

- [x] 08-DB 設計書に §6.5 保持期間ポリシーを追記
- [x] 実装方針を ADR 化（ADR-0027）
- [x] docs/CLAUDE.md と copilot-instructions.md の ADR 一覧を更新

## Test plan

- [ ] biome check / svelte-check が通ること（ドキュメント変更のみなので影響なし見込み）
- [ ] CI lint-and-test / site-check / e2e が通ること
- [ ] リンクの到達性: 08-DB 設計書の §6.5 からの `../decisions/0027-retention-policy.md` リンクが正しいこと

## 関連

- #729, #737 （retention 関連の先行 issue）
- ADR-0022 (課金サイクルとデータライフサイクル)
- ADR-0024 (プラン解決パターン)