### PR TITLE
feat(tests): #759 プラン別 seed fixture（AuthContext + trial_history）

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -32,7 +32,7 @@
 ### unit テスト（vitest）での使い方
 
 ```ts
-import { createTestDb, closeDb } from './test-db';
+import { createTestDb, closeDb } from '../helpers/test-db';
 import {
   makeFreeContext,
   makeStandardContext,
@@ -40,7 +40,7 @@ import {
   seedTrialActive,
   seedTrialExpired,
   seedTrialActiveContext,
-} from '../../helpers/plan-fixtures';
+} from '../helpers/plan-fixtures';
 
 const { sqlite, db } = createTestDb();
 
@@ -70,7 +70,8 @@ E2E のローカル認証モードは常に `plan=family` を返すため、本 
 **`DEBUG_PLAN` / `DEBUG_TRIAL` 環境変数（#758）**を使うこと。
 
 ```bash
-DEBUG_PLAN=free npx playwright test tests/e2e/free-plan-spec.ts
+# 例: free プランで任意の E2E テストを実行
+DEBUG_PLAN=free npx playwright test tests/e2e/some-spec.ts
 DEBUG_PLAN=standard DEBUG_TRIAL=active DEBUG_TRIAL_TIER=family npx playwright test ...
 ```
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -21,3 +21,57 @@
 - DB スキーマ変更時は `tests/e2e/global-setup.ts` のテストデータ投入も更新すること
 - 全 5 年齢モード（baby/kinder/lower/upper/teen）のテストデータが必要
 - 活動記録の完全フロー（確認→記録→コンボ→スタンプ→レベルアップ→ホーム復帰）を検証すること
+
+## プラン別 seed fixture（#759）
+
+プランティア（free / standard / family）やトライアル状態を持ったテストを書く場合、
+`tests/helpers/plan-fixtures.ts` のヘルパを使う。ローカル SQLite には `licenses`
+テーブルが存在しないため、プラン状態は `AuthContext` + `trial_history` テーブルの
+組み合わせで表現する（詳しい経緯はファイル冒頭の設計メモを参照）。
+
+### unit テスト（vitest）での使い方
+
+```ts
+import { createTestDb, closeDb } from './test-db';
+import {
+  makeFreeContext,
+  makeStandardContext,
+  makeFamilyContext,
+  seedTrialActive,
+  seedTrialExpired,
+  seedTrialActiveContext,
+} from '../../helpers/plan-fixtures';
+
+const { sqlite, db } = createTestDb();
+
+// 1. 純粋な AuthContext を組み立てる（DB I/O なし）
+const freeCtx     = makeFreeContext({ tenantId: 't-1' });
+const standardCtx = makeStandardContext({ tenantId: 't-2' });
+const familyCtx   = makeFamilyContext({ tenantId: 't-3', role: 'parent', childId: 10 });
+
+// 2. トライアル中のテナントを用意（licenseStatus=none のまま、trial_history で解決）
+const { context, trial } = seedTrialActiveContext(sqlite, {
+  tenantId: 't-trial',
+  tier: 'family',
+  daysOffset: 5,
+});
+// → resolveFullPlanTier('t-trial', 'none') が 'family' を返す
+
+// 3. トライアル終了済み（再開始不可）
+seedTrialExpired(sqlite, { tenantId: 't-used' });
+
+closeDb(sqlite);
+```
+
+### E2E テスト（Playwright）での使い方
+
+E2E のローカル認証モードは常に `plan=family` を返すため、本 seeder を呼んでも
+プラン切替にはならない。E2E からプラン状態を切り替えたいときは
+**`DEBUG_PLAN` / `DEBUG_TRIAL` 環境変数（#758）**を使うこと。
+
+```bash
+DEBUG_PLAN=free npx playwright test tests/e2e/free-plan-spec.ts
+DEBUG_PLAN=standard DEBUG_TRIAL=active DEBUG_TRIAL_TIER=family npx playwright test ...
+```
+
+詳細: `src/lib/server/debug-plan.ts` / `.env.example`

--- a/tests/helpers/plan-fixtures.ts
+++ b/tests/helpers/plan-fixtures.ts
@@ -55,6 +55,9 @@ const DEFAULT_TENANT_ID = 'test-tenant-1';
  *
  * `resolveFullPlanTier(tenantId, ctx.licenseStatus, ctx.plan)` は、
  * 同 tenantId に対してアクティブな trial_history が無ければ `'free'` を返す。
+ *
+ * **注意**: 本番環境（AUTH_MODE=cognito）では `licenseStatus` は Cognito
+ * カスタム属性から取得されるため、テストでの `'none'` 固定値と異なる場合がある。
  */
 export function makeFreeContext(overrides: ContextOverrides = {}): AuthContext {
 	return {

--- a/tests/helpers/plan-fixtures.ts
+++ b/tests/helpers/plan-fixtures.ts
@@ -1,0 +1,248 @@
+// tests/helpers/plan-fixtures.ts
+// Plan seed fixtures for vitest / Playwright (#759)
+//
+// ## 設計メモ（オリジナル Issue からのスコープ調整）
+//
+// Issue 本文は「licenses / trial_history / tenants テーブルを populate する」
+// と書かれているが、ローカル SQLite には `licenses` / `tenants` テーブルは存在
+// しない。これらは Cognito モード専用で DynamoDB の LICENSE# / TENANT# エンティ
+// ティ側にしかない。
+//
+// ローカルテスト環境での「プラン」は次の 2 つだけで決まる:
+//   1. `AuthContext.licenseStatus` / `AuthContext.plan`（メモリ上の値）
+//   2. `trial_history` テーブル（実 DB レコード）
+//
+// そのため本ヘルパは以下を提供する:
+//   - AuthContext コンストラクタ（`makeFreeContext` / `makeStandardContext` /
+//     `makeFamilyContext`）— DB I/O なし、純粋な値ファクトリ
+//   - `trial_history` seeder（`seedTrialActive` / `seedTrialExpired`）—
+//     better-sqlite3 インスタンスを受け取り行を挿入
+//   - 両者を組み合わせた便宜ヘルパ（`seedTrialActiveContext`）
+//
+// ## E2E (Playwright) での使い方
+//
+// E2E のローカル認証モードは常に `plan='family'` を返すため、この seeder を
+// 直接呼び出しても意味がない場面がある。E2E からプラン状態を切り替えたい場合は
+// DEBUG_PLAN / DEBUG_TRIAL の env 変数（#758）を使うこと。
+//
+//   DEBUG_PLAN=free    → licenseStatus=none, plan=undefined
+//   DEBUG_PLAN=standard→ licenseStatus=active, plan=monthly
+//   DEBUG_PLAN=family  → licenseStatus=active, plan=family-monthly
+//   DEBUG_TRIAL=active → trial_history 相当の擬似ステータスを注入
+//
+// 詳細: `src/lib/server/debug-plan.ts` / `.env.example`
+
+import type Database from 'better-sqlite3';
+import type { AuthContext, Role } from '../../src/lib/server/auth/types';
+import type { TrialSource, TrialTier } from '../../src/lib/server/services/trial-service';
+
+export type TestSqlite = InstanceType<typeof Database>;
+
+export interface ContextOverrides {
+	tenantId?: string;
+	role?: Role;
+	childId?: number;
+}
+
+const DEFAULT_TENANT_ID = 'test-tenant-1';
+
+// ============================================================
+// AuthContext コンストラクタ（DB I/O なし）
+// ============================================================
+
+/**
+ * Free プラン相当の `AuthContext` を返す。
+ *
+ * `resolveFullPlanTier(tenantId, ctx.licenseStatus, ctx.plan)` は、
+ * 同 tenantId に対してアクティブな trial_history が無ければ `'free'` を返す。
+ */
+export function makeFreeContext(overrides: ContextOverrides = {}): AuthContext {
+	return {
+		tenantId: overrides.tenantId ?? DEFAULT_TENANT_ID,
+		role: overrides.role ?? 'owner',
+		childId: overrides.childId,
+		licenseStatus: 'none',
+		plan: undefined,
+	};
+}
+
+/**
+ * Standard プラン相当の `AuthContext` を返す。
+ *
+ * plan は `'monthly'` — `resolvePlanTier` は `family` 接頭辞でない plan を
+ * 全て standard として扱うため、実際の Stripe plan ID と 1:1 対応する必要はない。
+ */
+export function makeStandardContext(overrides: ContextOverrides = {}): AuthContext {
+	return {
+		tenantId: overrides.tenantId ?? DEFAULT_TENANT_ID,
+		role: overrides.role ?? 'owner',
+		childId: overrides.childId,
+		licenseStatus: 'active',
+		plan: 'monthly',
+	};
+}
+
+/**
+ * Family プラン相当の `AuthContext` を返す。
+ *
+ * plan は `'family-monthly'` — `resolvePlanTier` は `family` 接頭辞で family tier と判定する。
+ */
+export function makeFamilyContext(overrides: ContextOverrides = {}): AuthContext {
+	return {
+		tenantId: overrides.tenantId ?? DEFAULT_TENANT_ID,
+		role: overrides.role ?? 'owner',
+		childId: overrides.childId,
+		licenseStatus: 'active',
+		plan: 'family-monthly',
+	};
+}
+
+// ============================================================
+// trial_history seeders
+// ============================================================
+
+export interface SeedTrialOptions {
+	tenantId?: string;
+	tier?: TrialTier;
+	/**
+	 * active 時: 終了日が今日から何日後か（default: 7）
+	 * expired 時: 終了日が今日から何日前か（default: 1）
+	 */
+	daysOffset?: number;
+	source?: TrialSource;
+	campaignId?: string | null;
+}
+
+export interface SeededTrial {
+	tenantId: string;
+	startDate: string;
+	endDate: string;
+	tier: TrialTier;
+}
+
+function formatDate(d: Date): string {
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const day = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${day}`;
+}
+
+function insertTrialRow(
+	sqlite: TestSqlite,
+	row: {
+		tenantId: string;
+		startDate: string;
+		endDate: string;
+		tier: TrialTier;
+		source: TrialSource;
+		campaignId: string | null;
+	},
+): void {
+	sqlite
+		.prepare(
+			`INSERT INTO trial_history (tenant_id, start_date, end_date, tier, source, campaign_id)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(row.tenantId, row.startDate, row.endDate, row.tier, row.source, row.campaignId);
+}
+
+/**
+ * アクティブなトライアル履歴を seed する。
+ *
+ * 挿入後は `getTrialStatus(tenantId)` が `isTrialActive=true` を返し、
+ * `resolveFullPlanTier(tenantId, 'none')` は指定した tier を返すようになる。
+ *
+ * @param sqlite   test-db の `createTestDb()` が返す `sqlite` インスタンス
+ * @param options  tenantId / tier / 日数オフセット等
+ * @returns 挿入したレコードの要約
+ */
+export function seedTrialActive(sqlite: TestSqlite, options: SeedTrialOptions = {}): SeededTrial {
+	const tenantId = options.tenantId ?? DEFAULT_TENANT_ID;
+	const tier = options.tier ?? 'standard';
+	const daysOffset = options.daysOffset ?? 7;
+
+	const today = new Date();
+	const start = new Date(today);
+	const end = new Date(today);
+	end.setDate(end.getDate() + daysOffset);
+
+	const startDate = formatDate(start);
+	const endDate = formatDate(end);
+
+	insertTrialRow(sqlite, {
+		tenantId,
+		startDate,
+		endDate,
+		tier,
+		source: options.source ?? 'user_initiated',
+		campaignId: options.campaignId ?? null,
+	});
+
+	return { tenantId, startDate, endDate, tier };
+}
+
+/**
+ * 終了済みのトライアル履歴を seed する。
+ *
+ * 挿入後は `getTrialStatus(tenantId)` が `isTrialActive=false, trialUsed=true` を
+ * 返し、`resolveFullPlanTier(tenantId, 'none')` は `'free'` を返す。
+ * トライアル再利用制限（`user_initiated` の再開始拒否）のテストに使う。
+ */
+export function seedTrialExpired(sqlite: TestSqlite, options: SeedTrialOptions = {}): SeededTrial {
+	const tenantId = options.tenantId ?? DEFAULT_TENANT_ID;
+	const tier = options.tier ?? 'standard';
+	const daysOffset = options.daysOffset ?? 1;
+
+	const end = new Date();
+	end.setDate(end.getDate() - daysOffset);
+	const start = new Date(end);
+	start.setDate(start.getDate() - 7);
+
+	const startDate = formatDate(start);
+	const endDate = formatDate(end);
+
+	insertTrialRow(sqlite, {
+		tenantId,
+		startDate,
+		endDate,
+		tier,
+		source: options.source ?? 'user_initiated',
+		campaignId: options.campaignId ?? null,
+	});
+
+	return { tenantId, startDate, endDate, tier };
+}
+
+// ============================================================
+// 組み合わせヘルパ
+// ============================================================
+
+export interface SeedTrialContextResult {
+	context: AuthContext;
+	trial: SeededTrial;
+}
+
+/**
+ * アクティブなトライアルを seed した上で、対応する `AuthContext` を返す。
+ *
+ * `licenseStatus` は `'none'` のままなので、プラン解決は trial_history 経由で
+ * 行われる（ライセンスが切れた直後にトライアルに入るシナリオの再現用）。
+ */
+export function seedTrialActiveContext(
+	sqlite: TestSqlite,
+	options: SeedTrialOptions & ContextOverrides = {},
+): SeedTrialContextResult {
+	const trial = seedTrialActive(sqlite, {
+		tenantId: options.tenantId,
+		tier: options.tier,
+		daysOffset: options.daysOffset,
+		source: options.source,
+		campaignId: options.campaignId,
+	});
+	const context = makeFreeContext({
+		tenantId: trial.tenantId,
+		role: options.role,
+		childId: options.childId,
+	});
+	return { context, trial };
+}

--- a/tests/unit/helpers/plan-fixtures.test.ts
+++ b/tests/unit/helpers/plan-fixtures.test.ts
@@ -1,0 +1,175 @@
+// tests/unit/helpers/plan-fixtures.test.ts
+// #759 — plan-fixtures ヘルパ自体のユニットテスト
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	makeFamilyContext,
+	makeFreeContext,
+	makeStandardContext,
+	seedTrialActive,
+	seedTrialActiveContext,
+	seedTrialExpired,
+	type TestSqlite,
+} from '../../helpers/plan-fixtures';
+import { closeDb, createTestDb } from './test-db';
+
+/** ローカル時刻ベースで "YYYY-MM-DD" を返す（helper 側と同じ formatDate） */
+function todayLocalStr(): string {
+	const d = new Date();
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const day = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${day}`;
+}
+
+describe('plan-fixtures', () => {
+	let sqlite: TestSqlite;
+
+	beforeEach(() => {
+		const { sqlite: s } = createTestDb();
+		sqlite = s;
+	});
+
+	afterEach(() => {
+		closeDb(sqlite);
+	});
+
+	// ============================================================
+	// AuthContext コンストラクタ
+	// ============================================================
+
+	describe('makeFreeContext', () => {
+		it('licenseStatus=none / plan=undefined を返す', () => {
+			const ctx = makeFreeContext();
+			expect(ctx.licenseStatus).toBe('none');
+			expect(ctx.plan).toBeUndefined();
+			expect(ctx.role).toBe('owner');
+			expect(ctx.tenantId).toBe('test-tenant-1');
+		});
+
+		it('overrides が反映される', () => {
+			const ctx = makeFreeContext({ tenantId: 't-42', role: 'parent', childId: 7 });
+			expect(ctx.tenantId).toBe('t-42');
+			expect(ctx.role).toBe('parent');
+			expect(ctx.childId).toBe(7);
+		});
+	});
+
+	describe('makeStandardContext', () => {
+		it('licenseStatus=active / plan=monthly を返す', () => {
+			const ctx = makeStandardContext();
+			expect(ctx.licenseStatus).toBe('active');
+			expect(ctx.plan).toBe('monthly');
+		});
+	});
+
+	describe('makeFamilyContext', () => {
+		it('licenseStatus=active / plan=family-monthly を返す', () => {
+			const ctx = makeFamilyContext();
+			expect(ctx.licenseStatus).toBe('active');
+			expect(ctx.plan).toBe('family-monthly');
+		});
+	});
+
+	// ============================================================
+	// seedTrialActive
+	// ============================================================
+
+	describe('seedTrialActive', () => {
+		it('trial_history に行を 1 件挿入する', () => {
+			seedTrialActive(sqlite, { tenantId: 't-trial' });
+			const rows = sqlite
+				.prepare('SELECT COUNT(*) as c FROM trial_history WHERE tenant_id = ?')
+				.get('t-trial') as { c: number };
+			expect(rows.c).toBe(1);
+		});
+
+		it('end_date が今日より未来になる', () => {
+			seedTrialActive(sqlite, { tenantId: 't-trial', daysOffset: 5 });
+			const row = sqlite
+				.prepare('SELECT end_date FROM trial_history WHERE tenant_id = ?')
+				.get('t-trial') as { end_date: string };
+			expect(row.end_date > todayLocalStr()).toBe(true);
+		});
+
+		it('tier=family を指定できる', () => {
+			seedTrialActive(sqlite, { tenantId: 't-trial', tier: 'family' });
+			const row = sqlite
+				.prepare('SELECT tier FROM trial_history WHERE tenant_id = ?')
+				.get('t-trial') as { tier: string };
+			expect(row.tier).toBe('family');
+		});
+
+		it('source / campaignId を指定できる', () => {
+			seedTrialActive(sqlite, {
+				tenantId: 't-trial',
+				source: 'campaign',
+				campaignId: 'spring-2026',
+			});
+			const row = sqlite
+				.prepare('SELECT source, campaign_id FROM trial_history WHERE tenant_id = ?')
+				.get('t-trial') as { source: string; campaign_id: string };
+			expect(row.source).toBe('campaign');
+			expect(row.campaign_id).toBe('spring-2026');
+		});
+
+		it('返り値に tenantId / 日付 / tier が含まれる', () => {
+			const result = seedTrialActive(sqlite, { tenantId: 't-trial' });
+			expect(result.tenantId).toBe('t-trial');
+			expect(result.tier).toBe('standard');
+			expect(result.startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+			expect(result.endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		});
+	});
+
+	// ============================================================
+	// seedTrialExpired
+	// ============================================================
+
+	describe('seedTrialExpired', () => {
+		it('end_date が今日より過去になる', () => {
+			seedTrialExpired(sqlite, { tenantId: 't-expired' });
+			const row = sqlite
+				.prepare('SELECT end_date FROM trial_history WHERE tenant_id = ?')
+				.get('t-expired') as { end_date: string };
+			expect(row.end_date < todayLocalStr()).toBe(true);
+		});
+
+		it('start_date < end_date', () => {
+			seedTrialExpired(sqlite, { tenantId: 't-expired' });
+			const row = sqlite
+				.prepare('SELECT start_date, end_date FROM trial_history WHERE tenant_id = ?')
+				.get('t-expired') as { start_date: string; end_date: string };
+			expect(row.start_date < row.end_date).toBe(true);
+		});
+	});
+
+	// ============================================================
+	// seedTrialActiveContext（組み合わせ）
+	// ============================================================
+
+	describe('seedTrialActiveContext', () => {
+		it('AuthContext と seed されたレコードを同時に返す', () => {
+			const { context, trial } = seedTrialActiveContext(sqlite, {
+				tenantId: 't-combo',
+				tier: 'family',
+				daysOffset: 3,
+			});
+
+			// context: licenseStatus=none のまま（trial で resolve される）
+			expect(context.tenantId).toBe('t-combo');
+			expect(context.licenseStatus).toBe('none');
+			expect(context.plan).toBeUndefined();
+
+			// trial: family tier で挿入されている
+			expect(trial.tier).toBe('family');
+			expect(trial.tenantId).toBe('t-combo');
+
+			// DB にも行がある
+			const count = sqlite
+				.prepare('SELECT COUNT(*) as c FROM trial_history WHERE tenant_id = ?')
+				.get('t-combo') as { c: number };
+			expect(count.c).toBe(1);
+		});
+	});
+});


### PR DESCRIPTION
closes #759

## 追加した成果物

- `tests/helpers/plan-fixtures.ts` — プランティア / トライアル seed ヘルパ
- `tests/unit/helpers/plan-fixtures.test.ts` — 12 ケースのユニットテスト（全通過）
- `tests/CLAUDE.md` §「プラン別 seed fixture（#759）」に使い方を追記

## 提供するヘルパ

| カテゴリ | 関数 | DB I/O |
|----------|------|--------|
| AuthContext コンストラクタ | `makeFreeContext` / `makeStandardContext` / `makeFamilyContext` | なし |
| trial_history seeder | `seedTrialActive` / `seedTrialExpired` | あり |
| 組み合わせ | `seedTrialActiveContext` | あり |

## 元 Issue からのスコープ調整（重要）

Issue 本文は「\`licenses\` / \`trial_history\` / \`tenants\` テーブルを populate する」と書かれているが、**ローカル SQLite には \`licenses\` / \`tenants\` テーブルが存在しない**。これらは Cognito モード用に DynamoDB の LICENSE# / TENANT# エンティティ側にしかない。

ローカルテスト環境でのプランは次の 2 つだけで決まる:

1. \`AuthContext.licenseStatus\` / \`AuthContext.plan\`（メモリ上の値、\`locals.context\` として routes に渡される）
2. \`trial_history\` テーブル（実 DB レコード）

そのため本ヘルパもこの 2 つを対象としている。ファイル冒頭の設計メモに経緯を明記。

## vitest での使い方

\`\`\`ts
import { createTestDb, closeDb } from './test-db';
import {
  makeFreeContext,
  makeStandardContext,
  makeFamilyContext,
  seedTrialActive,
  seedTrialExpired,
  seedTrialActiveContext,
} from '../../helpers/plan-fixtures';

const { sqlite, db } = createTestDb();

// 1. 純粋な AuthContext（DB I/O なし）
const freeCtx     = makeFreeContext({ tenantId: 't-1' });
const standardCtx = makeStandardContext({ tenantId: 't-2' });
const familyCtx   = makeFamilyContext({ tenantId: 't-3', role: 'parent', childId: 10 });

// 2. トライアル中のテナント（licenseStatus=none のまま、trial_history で解決）
const { context, trial } = seedTrialActiveContext(sqlite, {
  tenantId: 't-trial',
  tier: 'family',
  daysOffset: 5,
});
// → resolveFullPlanTier('t-trial', 'none') が 'family' を返す

// 3. トライアル終了済み（再開始不可シナリオ）
seedTrialExpired(sqlite, { tenantId: 't-used' });
\`\`\`

## Playwright での注意

E2E のローカル認証モードは常に \`plan=family\` を返すため、本 seeder を呼んでもプラン切替にはならない。E2E からプラン状態を切り替えたいときは **\`DEBUG_PLAN\` / \`DEBUG_TRIAL\` 環境変数（#758）** を使う。tests/CLAUDE.md にその旨を明記済み。

## Acceptance Criteria

- [x] ヘルパ実装
- [x] 既存の fixture と整合性が取れている（\`AuthContext\` 型 / \`trial_history\` スキーマ準拠）
- [x] unit テストで 12 ケース全通過
- [x] 使用例を test ドキュメント（\`tests/CLAUDE.md\`）に記載
- [x] スコープ調整（licenses テーブル非存在）の根拠をコメントに明記

## 検証

- \`npx vitest run tests/unit/helpers/plan-fixtures.test.ts\` → 12 passed
- \`npx biome check tests/helpers/plan-fixtures.ts tests/unit/helpers/plan-fixtures.test.ts\` → Clean
- \`npx svelte-check\` → 0 errors（既存 warning のみ）

## 関連

- #758 DEBUG_PLAN env 切替（E2E 側の補完手段）
- #750 プラン別機能制限

🤖 Generated with [Claude Code](https://claude.com/claude-code)