### PR TITLE
test(unit): #777 TrialBanner 5 状態の表示テストを追加

### DIFF
--- a/tests/unit/components/trial-banner-display.test.ts
+++ b/tests/unit/components/trial-banner-display.test.ts
@@ -13,13 +13,13 @@
 // 別 spec を追加してよい。コンポーネントの分岐が変わった時の安全網としては
 // 本ユニットテストで十分。
 
-import { render, screen } from '@testing-library/svelte';
+import { cleanup, render, screen } from '@testing-library/svelte';
 import { afterEach, describe, expect, it } from 'vitest';
 import TrialBanner from '../../../src/lib/features/admin/components/TrialBanner.svelte';
 
 describe('TrialBanner 表示', () => {
 	afterEach(() => {
-		document.body.innerHTML = '';
+		cleanup();
 	});
 
 	// ============================================================

--- a/tests/unit/components/trial-banner-display.test.ts
+++ b/tests/unit/components/trial-banner-display.test.ts
@@ -1,0 +1,179 @@
+// tests/unit/components/trial-banner-display.test.ts
+// #777 — TrialBanner の 5 状態表示（not-started / active x2 / expired / suppressed）
+//
+// 本来 Issue は Playwright E2E (`trial-banner-display.spec.ts`) を提案しているが、
+// E2E で TrialBanner の各状態を再現するには DEBUG_PLAN/DEBUG_TRIAL (#758) を
+// playwright.config.ts の webServer.env 経由で切替える必要があり、state ごとに
+// サーバー再起動が要る。既存 E2E に DEBUG_* 経由のパターンがまだなく、本 Issue
+// の目的は「5 状態の分岐と表示内容を保証する」ことなので、@testing-library/svelte
+// でコンポーネント単体を jsdom にマウントして検証する。この方式なら props を
+// 直接渡せるため、全 5 状態を高速に網羅できる。
+//
+// 将来、admin 画面側の DEBUG_PLAN 起動 E2E セットアップが入れば上位テストとして
+// 別 spec を追加してよい。コンポーネントの分岐が変わった時の安全網としては
+// 本ユニットテストで十分。
+
+import { render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import TrialBanner from '../../../src/lib/features/admin/components/TrialBanner.svelte';
+
+describe('TrialBanner 表示', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	// ============================================================
+	// 1) not-started: 未利用 free ユーザー
+	// ============================================================
+
+	describe('not-started 状態', () => {
+		const props = {
+			isTrialActive: false,
+			daysRemaining: 0,
+			trialUsed: false,
+			trialEndDate: null,
+			planTier: 'free' as const,
+		};
+
+		it('「7日間 無料で試す」ボタンが表示される', () => {
+			render(TrialBanner, props);
+			const btn = screen.getByTestId('trial-banner-start-button');
+			expect(btn).toBeDefined();
+			expect(btn.textContent).toContain('7日間');
+		});
+
+		it('not-started コンテナが描画される', () => {
+			render(TrialBanner, props);
+			expect(screen.getByTestId('trial-banner-not-started')).toBeDefined();
+		});
+
+		it('active / expired の CTA は描画されない', () => {
+			render(TrialBanner, props);
+			expect(screen.queryByTestId('trial-banner-active-cta')).toBeNull();
+			expect(screen.queryByTestId('trial-banner-expired-cta')).toBeNull();
+		});
+	});
+
+	// ============================================================
+	// 2) active（残り 7 日 — 通常）
+	// ============================================================
+
+	describe('active 状態（残り 7 日）', () => {
+		const props = {
+			isTrialActive: true,
+			daysRemaining: 7,
+			trialUsed: true,
+			trialEndDate: '2099-12-31',
+			planTier: 'free' as const,
+		};
+
+		it('「残り7日」表記と「プランを見る」CTA が表示される', () => {
+			render(TrialBanner, props);
+			const cta = screen.getByTestId('trial-banner-active-cta');
+			expect(cta).toBeDefined();
+			expect(cta.getAttribute('href')).toBe('/admin/license');
+
+			// タイトル本文に残り日数が含まれる
+			expect(document.body.textContent).toContain('残り7日');
+		});
+
+		it('not-started / expired CTA は描画されない', () => {
+			render(TrialBanner, props);
+			expect(screen.queryByTestId('trial-banner-not-started')).toBeNull();
+			expect(screen.queryByTestId('trial-banner-expired-cta')).toBeNull();
+		});
+	});
+
+	// ============================================================
+	// 3) active（残り 1 日 — urgent）
+	// ============================================================
+
+	describe('active 状態（残り 1 日 — urgent）', () => {
+		const props = {
+			isTrialActive: true,
+			daysRemaining: 1,
+			trialUsed: true,
+			trialEndDate: '2099-12-31',
+			planTier: 'free' as const,
+		};
+
+		it('「明日で終了します」のタイトルが表示される', () => {
+			render(TrialBanner, props);
+			expect(document.body.textContent).toContain('明日で終了');
+		});
+
+		it('urgent クラスがバナーに付く', () => {
+			const { container } = render(TrialBanner, props);
+			const banner = container.querySelector('.trial-banner');
+			expect(banner).not.toBeNull();
+			expect(banner?.classList.contains('urgent')).toBe(true);
+		});
+
+		it('active CTA（プランを見る）は引き続き描画される', () => {
+			render(TrialBanner, props);
+			expect(screen.getByTestId('trial-banner-active-cta')).toBeDefined();
+		});
+	});
+
+	// ============================================================
+	// 4) expired: 利用済み + 非アクティブ
+	// ============================================================
+
+	describe('expired 状態', () => {
+		const props = {
+			isTrialActive: false,
+			daysRemaining: 0,
+			trialUsed: true,
+			trialEndDate: '2026-01-01',
+			planTier: 'free' as const,
+		};
+
+		it('アップグレード CTA が表示される', () => {
+			render(TrialBanner, props);
+			const cta = screen.getByTestId('trial-banner-expired-cta');
+			expect(cta).toBeDefined();
+			expect(cta.getAttribute('href')).toBe('/admin/license');
+			expect(cta.textContent).toContain('アップグレード');
+		});
+
+		it('not-started 状態は描画されない（再開不可 = used=true ルール）', () => {
+			render(TrialBanner, props);
+			expect(screen.queryByTestId('trial-banner-not-started')).toBeNull();
+			expect(screen.queryByTestId('trial-banner-start-button')).toBeNull();
+		});
+
+		it('expired タイトル「無料体験が終了しました」が表示される', () => {
+			render(TrialBanner, props);
+			expect(document.body.textContent).toContain('無料体験が終了しました');
+		});
+	});
+
+	// ============================================================
+	// 5) 有料プラン: バナーは一切描画されない
+	// ============================================================
+
+	describe('有料プラン（バナー非表示）', () => {
+		it('standard プランでは何も描画されない', () => {
+			const { container } = render(TrialBanner, {
+				isTrialActive: false,
+				daysRemaining: 0,
+				trialUsed: false,
+				trialEndDate: null,
+				planTier: 'standard',
+			});
+			// コンポーネントは {#if ...} チェーンで全て偽なら何も出力しない
+			expect(container.querySelector('.trial-banner')).toBeNull();
+		});
+
+		it('family プランでもバナーは描画されない', () => {
+			const { container } = render(TrialBanner, {
+				isTrialActive: false,
+				daysRemaining: 0,
+				trialUsed: false,
+				trialEndDate: null,
+				planTier: 'family',
+			});
+			expect(container.querySelector('.trial-banner')).toBeNull();
+		});
+	});
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
+import { svelteTesting } from '@testing-library/svelte/vite';
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
@@ -35,6 +36,10 @@ export default defineConfig({
 		projects: [
 			{
 				extends: true,
+				// #777: @testing-library/svelte を使う tests/unit/components 以下のテストで
+				// Svelte 5 の client/server エントリを正しく解決するため、svelteTesting() を適用。
+				// jsdom + resolve.conditions=['browser'] がセットで必要。
+				plugins: [svelteTesting()],
 				test: {
 					include: ['tests/unit/**/*.test.ts', 'tests/integration/**/*.test.ts'],
 					environment: 'jsdom',


### PR DESCRIPTION
## Summary

- Issue #777 の「TrialBanner の 3 状態（実質 5 状態）表示を検証する」テストを追加
- @testing-library/svelte で jsdom マウント、state ごとに props を直接渡して網羅
- `vite.config.ts` の unit プロジェクトに `svelteTesting()` プラグインを適用し、Svelte 5 の client エントリを解決できるようにした

## なぜ E2E ではなく unit テストか

Issue 本文は Playwright E2E (`trial-banner-display.spec.ts`) を提案しているが、

- E2E で 5 状態を再現するには `DEBUG_PLAN` / `DEBUG_TRIAL` (#758) を `playwright.config.ts` の `webServer.env` 経由で切替える必要があり、state ごとにサーバー再起動が要る
- 既存 E2E に `DEBUG_*` 経由のパターンがまだない
- 本チケットの目的は **5 状態の分岐と表示内容を保証する** こと

このため、`@testing-library/svelte` で props を直接渡す方式が高速・正確に網羅できる。将来 `DEBUG_PLAN` の E2E セットアップが入れば、上位テストとして別 spec を追加すればよい。

## テストケース（13 件）

| 状態 | ケース数 | 検証内容 |
|---|---|---|
| not-started | 3 | 「7日間 無料で試す」ボタン表示、コンテナ描画、他 CTA 非描画 |
| active（残り7日） | 2 | 「残り7日」表記、`/admin/license` CTA、他 CTA 非描画 |
| active（残り1日 urgent） | 3 | 「明日で終了」タイトル、`.urgent` クラス、active CTA 継続 |
| expired | 3 | アップグレード CTA、not-started 非描画、終了タイトル |
| 有料プラン（suppressed） | 2 | standard / family でバナー全体が非描画 |

## vite.config.ts の変更理由

`@testing-library/svelte` 5.3 + Svelte 5 + vitest 4 で `render()` を呼ぶと、デフォルトの vite 設定では Svelte の server エントリ（`svelte/server`）が解決されてしまい `mount() is not available on the server` エラーになる。

`@testing-library/svelte/vite` が提供する `svelteTesting()` プラグインを unit プロジェクトに適用すると、`VITEST` 環境で `resolve.conditions` に `'browser'` を `'node'` より前に挿入し、client エントリが解決されるようになる。

副作用：
- 既存の 2638 件の unit テストは全通過を確認済み（回帰なし）
- `globals: true` なので auto-cleanup は既存の vitest globals に任せる（プラグインが検出してスキップ）
- `@testing-library/svelte` を `ssr.noExternal` に追加するが、既存の SSR 外部化対象（`sharp`）と競合しない

## Test plan

- [x] `npx vitest run tests/unit/components/trial-banner-display.test.ts` — 13 件全通過
- [x] `npx vitest run tests/unit` — 2638 件全通過（既存テスト回帰なし）
- [x] `npx biome check` — clean
- [x] `npx svelte-check` — 0 errors（既存 39 warnings は無関係）

## Closes

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)