### PR TITLE
fix: #787 プラン制限エラー形式を PlanLimitError に統一

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1525,28 +1525,31 @@ export interface PlanLimitError {
 #### プラン制限が適用される主要エンドポイント
 
 現時点でプラン制限（`PLAN_LIMIT_EXCEEDED` 403 を返し得る）が実装済みのエンドポイントを整理する。
-既存実装の body 形式は段階的に `PlanLimitError` 形式へ移行する（別 issue で追跡）。
+#787 で全 form action が `createPlanLimitError()` 形式に統一済み。
 
-| エンドポイント / フォームアクション | 必要プラン | 根拠 |
-|----------|---------|------|
-| `POST /api/v1/activities/suggest` | standard | AI 活動提案 (`isPaidTier`) |
-| `GET /api/v1/export` | standard | `canExport` フラグ |
-| `POST /api/v1/export/cloud` | standard | `canExport` + `maxCloudExports` |
-| `POST /api/v1/children` | 上限付き | `free` は `maxChildren=2` まで |
-| `POST /api/v1/activities` (custom) | 上限付き | `free` は `maxActivities=3` まで |
-| `POST /admin/checklists/+page.server.ts ?/createTemplate` | 上限付き | `free` は `maxChecklistTemplates=3` まで (#723) |
-| `POST /admin/rewards ?/create` | standard | 特別なごほうび (`canCustomReward`, #728) |
-| `POST /admin/rewards ?/importPresets` | standard | 特別なごほうび取り込み (#728) |
-| `POST /admin/messages ?/send` (text モード) | family | 自由テキストメッセージ (`canFreeTextMessage`, #772) |
-| `POST /admin/settings ?/updateSiblingSettings` (ranking ON) | family | きょうだいランキング (`canSiblingRanking`, #782) |
+| エンドポイント / フォームアクション | 必要プラン | 根拠 | 実装状況 |
+|----------|---------|------|---------|
+| `POST /api/v1/activities/suggest` | standard | AI 活動提案 (`isPaidTier`) | `planLimitError()` 済 |
+| `GET /api/v1/export` | standard | `canExport` フラグ | `planLimitError()` 済 |
+| `POST /api/v1/export/cloud` | standard | `canExport` + `maxCloudExports` | `planLimitError()` 済 |
+| `POST /admin/children ?/addChild` | 上限付き | `free` は `maxChildren=2` まで | `createPlanLimitError()` 済 (#787) |
+| `POST /admin/activities ?/create` | 上限付き | `free` は `maxActivities=3` まで | `createPlanLimitError()` 済 (#787) |
+| `POST /admin/checklists ?/createTemplate` | 上限付き | `free` は `maxChecklistTemplates=3` まで (#723) | `createPlanLimitError()` 済 (#787) |
+| `POST /admin/rewards ?/grant` | standard | 特別なごほうび (`canCustomReward`, #728) | `createPlanLimitError()` 済 (#787) |
+| `POST /admin/rewards ?/addPreset` | standard | 特別なごほうび取り込み (#728) | `createPlanLimitError()` 済 (#787) |
+| `POST /admin/messages ?/send` (text モード) | family | 自由テキストメッセージ (`canFreeTextMessage`, #772) | `createPlanLimitError()` 済 (#787) |
+| `POST /admin/settings ?/updateSiblingSettings` (ranking ON) | family | きょうだいランキング (`canSiblingRanking`, #782) | `createPlanLimitError()` 済 (#787) |
 
 **注意**: 上記以外のエンドポイント（GET 系・基本的な CRUD 等）は**全プラン利用可**。
 新規にプラン制限を追加する際は、本表へ追記し `PlanLimitError` 形式で 403 を返すこと。
 
+クライアント側では `getErrorMessage(form?.error)` ヘルパー（`src/lib/domain/errors.ts`）を使うと
+`string | PlanLimitError | null` を一貫して表示用文字列へ正規化できる。
+
 #### 移行計画
 
-1. **Phase 1**（本 PR #744）: 仕様定義・型定義・ヘルパー追加。既存実装は変更しない。
-2. **Phase 2** (#787): 全プラン制限箇所を `planLimitError()` / `createPlanLimitError()` に統一。
+1. **Phase 1**（#744, 完了）: 仕様定義・型定義・ヘルパー追加。既存実装は変更しない。
+2. **Phase 2** (#787, 完了): 全プラン制限箇所を `planLimitError()` / `createPlanLimitError()` に統一。`getErrorMessage()` ヘルパー追加によりクライアント側の表示を共通化。
 3. **Phase 3**: フロント共通エラーハンドラで `isPlanLimitError` を使ったアップセルトーストを実装。
 
 ---
@@ -1626,3 +1629,4 @@ export interface PlanLimitError {
 | 2026-04-10 | 2.7 | #605 バトルアドベンチャーAPI追加: GET/POST /api/v1/battle/[childId]（日次バトル取得・実行） |
 | 2026-04-09 | 2.8 | #609 設計書同期: アカウント削除(2)・閲覧専用トークン(3)エンドポイントを一覧追加。未記載だった9カテゴリのエンドポイント詳細仕様（3.17-3.25）を追記 |
 | 2026-04-12 | 2.9 | #744 プラン制限エラー仕様 (§4.2) 追加。`PLAN_LIMIT_EXCEEDED` の body フォーマット (`currentTier` / `requiredTier` / `upgradeUrl`) を正仕様化。型定義を `src/lib/domain/errors.ts` として新設し client/server で共有。既存実装の移行は #787 で追跡 |
+| 2026-04-11 | 2.10 | #787 プラン制限エラー形式統一。全 form action (`/admin/children`, `/admin/activities`, `/admin/checklists`, `/admin/rewards`, `/admin/messages`, `/admin/settings`) が `createPlanLimitError()` 形式の `PlanLimitError` body を返すように統一。クライアント側表示を共通化する `getErrorMessage()` ヘルパーを `src/lib/domain/errors.ts` に追加 |

--- a/src/lib/domain/errors.ts
+++ b/src/lib/domain/errors.ts
@@ -97,3 +97,25 @@ export function isPlanLimitError(value: unknown): value is PlanLimitError {
 		v.upgradeUrl === '/admin/license'
 	);
 }
+
+/**
+ * `form.error` / `result.data?.error` の値を表示用の文字列に正規化する (#787)。
+ *
+ * サーバ側のフォームアクションが返すエラーは、
+ * - 従来: `{ error: string }` （バリデーションエラー等）
+ * - 新規: `{ error: PlanLimitError }` （プラン制限エラー）
+ *
+ * の 2 形態が混在するため、Svelte 側で `getErrorMessage(form?.error)` を使って
+ * 一貫した文字列を得る。値が空/未定義なら空文字を返す。
+ */
+export function getErrorMessage(value: unknown): string {
+	if (value == null) return '';
+	if (typeof value === 'string') return value;
+	if (isPlanLimitError(value)) return value.message;
+	// 想定外のオブジェクトでも `.message` があれば取り出す（Error 互換）
+	if (typeof value === 'object' && 'message' in value) {
+		const msg = (value as { message: unknown }).message;
+		if (typeof msg === 'string') return msg;
+	}
+	return '';
+}

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail } from '@sveltejs/kit';
 import { activityPackIndex, getActivityPack } from '$lib/data/activity-packs';
 import type { ActivityPackItem } from '$lib/domain/activity-pack';
+import { createPlanLimitError } from '$lib/domain/errors';
 import { CATEGORY_CODES, CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
@@ -102,8 +103,14 @@ export const actions: Actions = {
 		const licenseStatus = locals.context?.licenseStatus ?? 'none';
 		const activityLimitCheck = await checkActivityLimit(tenantId, licenseStatus);
 		if (!activityLimitCheck.allowed) {
+			// #787: PlanLimitError 形式に統一。tier は memoize 済み (#788) なので 2 回目の呼び出しは安い
+			const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 			return fail(403, {
-				error: `カスタム活動は最大${activityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+				error: createPlanLimitError(
+					tier,
+					'standard',
+					`カスタム活動は最大${activityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+				),
 			});
 		}
 

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import { todayDateJST } from '$lib/domain/date-utils';
+import { createPlanLimitError } from '$lib/domain/errors';
 import { requireTenantId } from '$lib/server/auth/factory';
 import {
 	findOverrides,
@@ -80,14 +81,17 @@ export const actions: Actions = {
 			return fail(400, { error: '時間帯が不正です' });
 
 		// #723: Free プランの上限チェック（UI ゲートをバイパスした直接 POST を防ぐ）
-		const limit = await checkChecklistTemplateLimit(
-			tenantId,
-			locals.context?.licenseStatus ?? 'none',
-			childId,
-		);
+		const licenseStatus = locals.context?.licenseStatus ?? 'none';
+		const limit = await checkChecklistTemplateLimit(tenantId, licenseStatus, childId);
 		if (!limit.allowed) {
+			// #787: PlanLimitError 形式に統一。tier は memoize 済み (#788) なので 2 回目の呼び出しは安い
+			const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 			return fail(403, {
-				error: `フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+				error: createPlanLimitError(
+					tier,
+					'standard',
+					`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+				),
 				upgradeRequired: true,
 			});
 		}

--- a/src/routes/(parent)/admin/children/+page.server.ts
+++ b/src/routes/(parent)/admin/children/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { createPlanLimitError } from '$lib/domain/errors';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
@@ -170,8 +171,14 @@ export const actions: Actions = {
 		const licenseStatus = locals.context?.licenseStatus ?? 'none';
 		const childLimitCheck = await checkChildLimit(tenantId, licenseStatus);
 		if (!childLimitCheck.allowed) {
+			// #787: PlanLimitError 形式に統一。tier は memoize 済み (#788) なので 2 回目の呼び出しは安い
+			const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 			return fail(403, {
-				error: `子供は最大${childLimitCheck.max}人まで登録できます。プランをアップグレードしてください。`,
+				error: createPlanLimitError(
+					tier,
+					'standard',
+					`子供は最大${childLimitCheck.max}人まで登録できます。プランをアップグレードしてください。`,
+				),
 			});
 		}
 

--- a/src/routes/(parent)/admin/children/+page.svelte
+++ b/src/routes/(parent)/admin/children/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { getErrorMessage } from '$lib/domain/errors';
 import { formatPointValue } from '$lib/domain/point-display';
 import ChildListCard from '$lib/features/admin/components/ChildListCard.svelte';
 import ChildProfileCard from '$lib/features/admin/components/ChildProfileCard.svelte';
@@ -14,6 +15,8 @@ const childLimit = $derived(
 		| { allowed: boolean; current: number; max: number | null }
 		| undefined,
 );
+// #787: form.error が string | PlanLimitError どちらでも表示できるよう正規化
+const errorMessage = $derived(getErrorMessage(form?.error));
 
 const ps = $derived(data.pointSettings);
 const fmtBal = (pts: number) => formatPointValue(pts, ps.mode, ps.currency, ps.rate);
@@ -128,8 +131,8 @@ let showAddForm = $state(false);
 	{/if}
 
 	<!-- Error display -->
-	{#if form?.error}
-		<div class="children-page__error">{form.error}</div>
+	{#if errorMessage}
+		<div class="children-page__error">{errorMessage}</div>
 	{/if}
 
 	<!-- Children list -->

--- a/src/routes/(parent)/admin/messages/+page.server.ts
+++ b/src/routes/(parent)/admin/messages/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { createPlanLimitError } from '$lib/domain/errors';
 import {
 	MESSAGE_TEXT_MAX_LENGTH,
 	SENDABLE_MESSAGE_TYPES,
@@ -62,7 +63,14 @@ export const actions: Actions = {
 			const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 			const limits = getPlanLimits(tier);
 			if (!limits.canFreeTextMessage) {
-				return fail(403, { error: '自由テキストメッセージはファミリープラン限定です' });
+				// #787: PlanLimitError 形式に統一
+				return fail(403, {
+					error: createPlanLimitError(
+						tier,
+						'family',
+						'自由テキストメッセージはファミリープラン限定です',
+					),
+				});
 			}
 			if (!body) {
 				return fail(400, { error: 'メッセージを入力してください' });

--- a/src/routes/(parent)/admin/rewards/+page.server.ts
+++ b/src/routes/(parent)/admin/rewards/+page.server.ts
@@ -1,10 +1,15 @@
-// /admin/rewards — 特別報酬の付与（#336, #501, #581 プリセット追加, #728 プランゲート）
+// /admin/rewards — 特別報酬の付与（#336, #501, #581 プリセット追加, #728 プランゲート, #787 PlanLimitError 統一）
 
 import { fail } from '@sveltejs/kit';
 import { PRESET_REWARD_GROUPS } from '$lib/data/preset-rewards';
+import { createPlanLimitError } from '$lib/domain/errors';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getAllChildren } from '$lib/server/services/child-service';
-import { isPaidTier, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
+import {
+	isPaidTier,
+	type PlanTier,
+	resolveFullPlanTier,
+} from '$lib/server/services/plan-limit-service';
 import {
 	getChildSpecialRewards,
 	getRewardTemplates,
@@ -45,10 +50,10 @@ export const load: PageServerLoad = async ({ locals }) => {
 	};
 };
 
-async function ensurePremium(locals: App.Locals, tenantId: string): Promise<boolean> {
+/** 現在のプラン tier を解決して返すヘルパー (#787) */
+async function resolveTier(locals: App.Locals, tenantId: string): Promise<PlanTier> {
 	const licenseStatus = locals.context?.licenseStatus ?? 'none';
-	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
-	return isPaidTier(tier);
+	return resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 }
 
 export const actions: Actions = {
@@ -56,8 +61,12 @@ export const actions: Actions = {
 		const tenantId = requireTenantId(locals);
 
 		// #728: プランゲート — 無料プランはカスタム報酬付与不可
-		if (!(await ensurePremium(locals, tenantId))) {
-			return fail(403, { error: UPGRADE_MESSAGE, code: 'PLAN_LIMIT_EXCEEDED' });
+		// #787: PlanLimitError 形式に統一
+		const tier = await resolveTier(locals, tenantId);
+		if (!isPaidTier(tier)) {
+			return fail(403, {
+				error: createPlanLimitError(tier, 'standard', UPGRADE_MESSAGE),
+			});
 		}
 
 		const formData = await request.formData();
@@ -83,8 +92,12 @@ export const actions: Actions = {
 		const tenantId = requireTenantId(locals);
 
 		// #728: プランゲート — 無料プランはプリセットの取り込みも不可
-		if (!(await ensurePremium(locals, tenantId))) {
-			return fail(403, { error: UPGRADE_MESSAGE, code: 'PLAN_LIMIT_EXCEEDED' });
+		// #787: PlanLimitError 形式に統一
+		const tier = await resolveTier(locals, tenantId);
+		if (!isPaidTier(tier)) {
+			return fail(403, {
+				error: createPlanLimitError(tier, 'standard', UPGRADE_MESSAGE),
+			});
 		}
 
 		const formData = await request.formData();

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { getErrorMessage } from '$lib/domain/errors';
 import PageHelpButton from '$lib/ui/components/PageHelpButton.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
 
 let { data, form } = $props();
+// #787: form.error が string | PlanLimitError どちらでも表示できるよう正規化
+const errorMessage = $derived(getErrorMessage(form?.error));
 
 let selectedChildId = $state(0);
 
@@ -115,9 +118,9 @@ const categoryLabels: Record<string, string> = {
 	</section>
 
 	<!-- Error Display -->
-	{#if form?.error}
+	{#if errorMessage}
 		<div class="bg-[color-mix(in_srgb,var(--color-action-danger)_10%,transparent)] rounded-xl p-3 border border-[color-mix(in_srgb,var(--color-action-danger)_30%,transparent)] text-[var(--color-action-danger)] text-sm">
-			{form.error}
+			{errorMessage}
 		</div>
 	{/if}
 

--- a/src/routes/(parent)/admin/settings/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { createPlanLimitError } from '$lib/domain/errors';
 import type { CurrencyCode, PointUnitMode } from '$lib/domain/point-display';
 import { CURRENCY_CODES } from '$lib/domain/point-display';
 import { requireTenantId } from '$lib/server/auth/factory';
@@ -267,9 +268,13 @@ export const actions = {
 		const planLimits = getPlanLimits(planTier);
 
 		if (rankingRequested && !planLimits.canSiblingRanking) {
+			// #787: PlanLimitError 形式に統一（siblingError キーは保持、値を PlanLimitError に）
 			return fail(403, {
-				siblingError:
+				siblingError: createPlanLimitError(
+					planTier,
+					'family',
 					'きょうだいランキングはファミリープラン限定です。アップグレードすると利用できます。',
+				),
 				upgradeRequired: true,
 			});
 		}

--- a/src/routes/(parent)/admin/settings/+page.svelte
+++ b/src/routes/(parent)/admin/settings/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { page } from '$app/stores';
+import { getErrorMessage } from '$lib/domain/errors';
 import type { CurrencyCode, PointUnitMode } from '$lib/domain/point-display';
 import { CURRENCY_CODES, CURRENCY_DEFS, formatPointValue } from '$lib/domain/point-display';
 import { ErrorAlert, SuccessAlert } from '$lib/ui/components';
@@ -11,6 +12,9 @@ import FormField from '$lib/ui/primitives/FormField.svelte';
 import { APP_VERSION } from '$lib/version';
 
 let { data, form } = $props();
+// #787: form.error / form.siblingError が string | PlanLimitError どちらでも表示できるよう正規化
+const errorMessage = $derived(getErrorMessage(form?.error));
+const siblingErrorMessage = $derived(getErrorMessage(form?.siblingError));
 
 let success = $state(false);
 let submitting = $state(false);
@@ -574,8 +578,8 @@ const anyFormBusy = $derived(
 			<SuccessAlert message="PINコードを変更しました" />
 		{/if}
 
-		{#if form?.error}
-			<ErrorAlert message={form.error} severity="warning" action="fix_input" />
+		{#if errorMessage}
+			<ErrorAlert message={errorMessage} severity="warning" action="fix_input" />
 		{/if}
 
 		<form
@@ -759,8 +763,8 @@ const anyFormBusy = $derived(
 		{#if form?.siblingSuccess}
 			<div class="rounded-lg bg-[var(--color-feedback-success-bg)] p-3 text-sm text-[var(--color-feedback-success-text)] mb-4">きょうだい設定を保存しました</div>
 		{/if}
-		{#if form?.siblingError}
-			<div class="rounded-lg bg-[var(--color-feedback-error-bg)] p-3 text-sm text-[var(--color-feedback-error-text)] mb-4">{form.siblingError}</div>
+		{#if siblingErrorMessage}
+			<div class="rounded-lg bg-[var(--color-feedback-error-bg)] p-3 text-sm text-[var(--color-feedback-error-text)] mb-4">{siblingErrorMessage}</div>
 		{/if}
 
 		<form method="POST" action="?/updateSiblingSettings" use:enhance class="space-y-4">

--- a/tests/unit/domain/errors.test.ts
+++ b/tests/unit/domain/errors.test.ts
@@ -1,9 +1,11 @@
 // tests/unit/domain/errors.test.ts
 // #744: PlanLimitError 共有型の単体テスト
+// #787: getErrorMessage ヘルパーの追加
 
 import { describe, expect, it } from 'vitest';
 import {
 	createPlanLimitError,
+	getErrorMessage,
 	isPlanLimitError,
 	type PlanLimitError,
 } from '../../../src/lib/domain/errors';
@@ -108,5 +110,51 @@ describe('#744 PlanLimitError', () => {
 			expect(isPlanLimitError('PLAN_LIMIT_EXCEEDED')).toBe(false);
 			expect(isPlanLimitError(403)).toBe(false);
 		});
+	});
+});
+
+describe('#787 getErrorMessage', () => {
+	it('string をそのまま返す', () => {
+		expect(getErrorMessage('エラーメッセージ')).toBe('エラーメッセージ');
+	});
+
+	it('空文字はそのまま空文字', () => {
+		expect(getErrorMessage('')).toBe('');
+	});
+
+	it('PlanLimitError から message を抽出する', () => {
+		const err = createPlanLimitError(
+			'free',
+			'standard',
+			'スタンダードプラン以上でご利用いただけます',
+		);
+		expect(getErrorMessage(err)).toBe('スタンダードプラン以上でご利用いただけます');
+	});
+
+	it('null は空文字', () => {
+		expect(getErrorMessage(null)).toBe('');
+	});
+
+	it('undefined は空文字', () => {
+		expect(getErrorMessage(undefined)).toBe('');
+	});
+
+	it('message プロパティを持つ任意オブジェクトから文字列を抽出', () => {
+		expect(getErrorMessage({ message: 'バリデーションエラー' })).toBe('バリデーションエラー');
+	});
+
+	it('message プロパティが文字列でない場合は空文字', () => {
+		expect(getErrorMessage({ message: 123 })).toBe('');
+		expect(getErrorMessage({ message: null })).toBe('');
+	});
+
+	it('message プロパティを持たないオブジェクトは空文字', () => {
+		expect(getErrorMessage({})).toBe('');
+		expect(getErrorMessage({ code: 'X' })).toBe('');
+	});
+
+	it('プリミティブ（数値 / boolean）は空文字', () => {
+		expect(getErrorMessage(403)).toBe('');
+		expect(getErrorMessage(true)).toBe('');
 	});
 });

--- a/tests/unit/routes/admin-checklists-create-template.test.ts
+++ b/tests/unit/routes/admin-checklists-create-template.test.ts
@@ -128,7 +128,7 @@ describe('POST /admin/checklists?/createTemplate (#723)', () => {
 		);
 	});
 
-	it('Free で 3/3 到達 → 403 + upgradeRequired', async () => {
+	it('Free で 3/3 到達 → 403 + upgradeRequired（PlanLimitError 形式 #787）', async () => {
 		mockResolveFullPlanTier.mockResolvedValue('free');
 		mockRepoFindTemplatesByChild.mockResolvedValue([
 			{ id: 1, name: 'a' },
@@ -137,13 +137,21 @@ describe('POST /admin/checklists?/createTemplate (#723)', () => {
 		]);
 
 		// biome-ignore lint/style/noNonNullAssertion: createTemplate is defined
-		const result = await actions.createTemplate!(
+		const result = (await actions.createTemplate!(
 			createEvent({ childId: '1', name: '4つめ', icon: '📋', timeSlot: 'anytime' }),
-		);
+		)) as {
+			status: number;
+			data: { error: { code: string; requiredTier: string }; upgradeRequired: boolean };
+		};
 
-		expect(result).toMatchObject({
-			status: 403,
-			data: expect.objectContaining({ upgradeRequired: true }),
+		expect(result.status).toBe(403);
+		expect(result.data.upgradeRequired).toBe(true);
+		// #787: PlanLimitError 形式で返る
+		expect(result.data.error).toMatchObject({
+			code: 'PLAN_LIMIT_EXCEEDED',
+			currentTier: 'free',
+			requiredTier: 'standard',
+			upgradeUrl: '/admin/license',
 		});
 		expect(mockCreateTemplate).not.toHaveBeenCalled();
 	});

--- a/tests/unit/routes/admin-messages-send.test.ts
+++ b/tests/unit/routes/admin-messages-send.test.ts
@@ -84,7 +84,8 @@ describe('POST /admin/messages?/send (#772)', () => {
 		mockSendMessage.mockResolvedValue({ id: 1, childId: 1, messageType: 'text', body: 'ok' });
 	});
 
-	it('free プランで text メッセージを送ると 403（ファミリー限定）', async () => {
+	it('free プランで text メッセージを送ると 403（ファミリー限定、PlanLimitError 形式）', async () => {
+		// #787: エラー形式は PlanLimitError オブジェクト
 		// biome-ignore lint/style/noNonNullAssertion: send is defined
 		const result = await actions.send!(
 			createEvent('free', {
@@ -95,12 +96,21 @@ describe('POST /admin/messages?/send (#772)', () => {
 		);
 		expect(result).toMatchObject({
 			status: 403,
-			data: { error: '自由テキストメッセージはファミリープラン限定です' },
+			data: {
+				error: {
+					code: 'PLAN_LIMIT_EXCEEDED',
+					message: '自由テキストメッセージはファミリープラン限定です',
+					currentTier: 'free',
+					requiredTier: 'family',
+					upgradeUrl: '/admin/license',
+				},
+			},
 		});
 		expect(mockSendMessage).not.toHaveBeenCalled();
 	});
 
-	it('standard プランで text メッセージを送ると 403（ファミリー限定）', async () => {
+	it('standard プランで text メッセージを送ると 403（ファミリー限定、PlanLimitError 形式）', async () => {
+		// #787: currentTier は standard、requiredTier は family
 		// biome-ignore lint/style/noNonNullAssertion: send is defined
 		const result = await actions.send!(
 			createEvent('standard', {
@@ -111,7 +121,14 @@ describe('POST /admin/messages?/send (#772)', () => {
 		);
 		expect(result).toMatchObject({
 			status: 403,
-			data: { error: '自由テキストメッセージはファミリープラン限定です' },
+			data: {
+				error: {
+					code: 'PLAN_LIMIT_EXCEEDED',
+					currentTier: 'standard',
+					requiredTier: 'family',
+					upgradeUrl: '/admin/license',
+				},
+			},
 		});
 		expect(mockSendMessage).not.toHaveBeenCalled();
 	});

--- a/tests/unit/routes/admin-rewards-actions.test.ts
+++ b/tests/unit/routes/admin-rewards-actions.test.ts
@@ -47,14 +47,29 @@ const mod = await import('../../../src/routes/(parent)/admin/rewards/+page.serve
 const load = mod.load as unknown as (event: {
 	locals: App.Locals;
 }) => Promise<{ isPremium: boolean; planTier: string; children: unknown[]; templates: unknown[] }>;
+type PlanLimitErrorShape = {
+	code: 'PLAN_LIMIT_EXCEEDED';
+	message: string;
+	currentTier: 'free' | 'standard' | 'family';
+	requiredTier: 'standard' | 'family';
+	upgradeUrl: '/admin/license';
+};
 const grantAction = mod.actions.grant as unknown as (event: {
 	request: Request;
 	locals: App.Locals;
-}) => Promise<{ status?: number; data?: { error: string; code?: string }; granted?: boolean }>;
+}) => Promise<{
+	status?: number;
+	data?: { error: PlanLimitErrorShape | string };
+	granted?: boolean;
+}>;
 const addPresetAction = mod.actions.addPreset as unknown as (event: {
 	request: Request;
 	locals: App.Locals;
-}) => Promise<{ status?: number; data?: { error: string; code?: string }; presetAdded?: boolean }>;
+}) => Promise<{
+	status?: number;
+	data?: { error: PlanLimitErrorShape | string };
+	presetAdded?: boolean;
+}>;
 
 function makeLocals(opts: { licenseStatus?: string; plan?: string; tenantId?: string } = {}) {
 	return {
@@ -111,7 +126,7 @@ describe('/admin/rewards page.server', () => {
 	});
 
 	describe('grant action', () => {
-		it('無料プランでは 403 を返し grantSpecialReward を呼ばない', async () => {
+		it('無料プランでは 403 を返し grantSpecialReward を呼ばない（PlanLimitError 形式 #787）', async () => {
 			mockResolveFullPlanTier.mockResolvedValue('free');
 			const result = await grantAction({
 				request: makeFormRequest({ childId: 1, title: 'ごほうび', points: 100, icon: '🎁' }),
@@ -119,7 +134,13 @@ describe('/admin/rewards page.server', () => {
 			});
 
 			expect(result.status).toBe(403);
-			expect(result.data?.code).toBe('PLAN_LIMIT_EXCEEDED');
+			const err = result.data?.error as PlanLimitErrorShape;
+			expect(err).toMatchObject({
+				code: 'PLAN_LIMIT_EXCEEDED',
+				currentTier: 'free',
+				requiredTier: 'standard',
+				upgradeUrl: '/admin/license',
+			});
 			expect(mockGrantSpecialReward).not.toHaveBeenCalled();
 		});
 
@@ -151,7 +172,7 @@ describe('/admin/rewards page.server', () => {
 	});
 
 	describe('addPreset action', () => {
-		it('無料プランでは 403 を返し saveRewardTemplates を呼ばない', async () => {
+		it('無料プランでは 403 を返し saveRewardTemplates を呼ばない（PlanLimitError 形式 #787）', async () => {
 			mockResolveFullPlanTier.mockResolvedValue('free');
 
 			const result = await addPresetAction({
@@ -165,7 +186,12 @@ describe('/admin/rewards page.server', () => {
 			});
 
 			expect(result.status).toBe(403);
-			expect(result.data?.code).toBe('PLAN_LIMIT_EXCEEDED');
+			const err = result.data?.error as PlanLimitErrorShape;
+			expect(err).toMatchObject({
+				code: 'PLAN_LIMIT_EXCEEDED',
+				currentTier: 'free',
+				requiredTier: 'standard',
+			});
 			expect(mockSaveRewardTemplates).not.toHaveBeenCalled();
 		});
 

--- a/tests/unit/routes/admin-settings-sibling-ranking.test.ts
+++ b/tests/unit/routes/admin-settings-sibling-ranking.test.ts
@@ -111,26 +111,47 @@ describe('POST /admin/settings?/updateSiblingSettings (#782)', () => {
 		vi.clearAllMocks();
 	});
 
-	it('free プランで ranking を ON にしようとすると 403 + upgradeRequired', async () => {
+	it('free プランで ranking を ON にしようとすると 403 + upgradeRequired（PlanLimitError 形式 #787）', async () => {
 		// biome-ignore lint/style/noNonNullAssertion: updateSiblingSettings is defined
-		const result = await actions.updateSiblingSettings!(
+		const result = (await actions.updateSiblingSettings!(
 			createEvent('free', { siblingMode: 'both' }, true),
-		);
-		expect(result).toMatchObject({
-			status: 403,
-			data: { upgradeRequired: true },
+		)) as {
+			status: number;
+			data: {
+				siblingError: { code: string; currentTier: string; requiredTier: string };
+				upgradeRequired: boolean;
+			};
+		};
+		expect(result.status).toBe(403);
+		expect(result.data.upgradeRequired).toBe(true);
+		// #787: siblingError は PlanLimitError 形式
+		expect(result.data.siblingError).toMatchObject({
+			code: 'PLAN_LIMIT_EXCEEDED',
+			currentTier: 'free',
+			requiredTier: 'family',
+			upgradeUrl: '/admin/license',
 		});
 		expect(mockSetSetting).not.toHaveBeenCalled();
 	});
 
-	it('standard プランで ranking を ON にしようとすると 403 + upgradeRequired', async () => {
+	it('standard プランで ranking を ON にしようとすると 403 + upgradeRequired（PlanLimitError 形式 #787）', async () => {
 		// biome-ignore lint/style/noNonNullAssertion: updateSiblingSettings is defined
-		const result = await actions.updateSiblingSettings!(
+		const result = (await actions.updateSiblingSettings!(
 			createEvent('standard', { siblingMode: 'both' }, true),
-		);
-		expect(result).toMatchObject({
-			status: 403,
-			data: { upgradeRequired: true },
+		)) as {
+			status: number;
+			data: {
+				siblingError: { code: string; currentTier: string; requiredTier: string };
+				upgradeRequired: boolean;
+			};
+		};
+		expect(result.status).toBe(403);
+		expect(result.data.upgradeRequired).toBe(true);
+		// #787: currentTier は standard、requiredTier は family
+		expect(result.data.siblingError).toMatchObject({
+			code: 'PLAN_LIMIT_EXCEEDED',
+			currentTier: 'standard',
+			requiredTier: 'family',
 		});
 		expect(mockSetSetting).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
## Summary

Issue #787 Phase 2 完了。全 form action のプラン制限エラーを `PlanLimitError` 形式に統一し、クライアント側で `requiredTier` からアップセル先プランを決定できるようにした。

- `src/lib/domain/errors.ts` に `getErrorMessage()` ヘルパーを追加（`string | PlanLimitError | null` → 表示文字列）
- 6 画面の form action を `createPlanLimitError()` 呼び出しに置換
- 3 画面のクライアントテンプレートで `$derived(getErrorMessage(form?.error))` による表示
- 既存 4 テストファイルを追随、`getErrorMessage()` 単体テスト 9 ケース追加
- 設計書 07-API設計書.md §4.2 移行計画を Phase 2 完了に更新

## 変更対象の form action

| 画面 | action | アップセル先 | 備考 |
|------|--------|------------|------|
| `/admin/children` | `addChild` | free→standard | `maxChildren` 上限 |
| `/admin/activities` | `create` | free→standard | `maxActivities` 上限 |
| `/admin/checklists` | `createTemplate` | free→standard | `upgradeRequired` フラグ維持 (#723) |
| `/admin/rewards` | `grant` / `addPreset` | non-paid→standard | `ensurePremium` → `resolveTier` 置換 (#728) |
| `/admin/messages` | `send` (text) | non-family→family | `canFreeTextMessage` (#772) |
| `/admin/settings` | `updateSiblingSettings` (ranking ON) | non-family→family | `siblingError` キー維持 (#782) |

## Acceptance Criteria 状況

- [x] `PlanLimitError` 型を server / client で共有 (#744 で完了)
- [x] 全プラン制限箇所がこの型を返す（本 PR で完了）
- [ ] フロント共通エラーハンドラ → Phase 3 (後続 Issue)
- [ ] E2E テスト → Phase 3 (後続 Issue)

## Test plan

- [x] `npx vitest run tests/unit/domain tests/unit/routes/admin-*` — 47 tests passed
- [x] `npx svelte-check` — 0 errors
- [x] `npx biome check .` — 0 errors (pre-existing warnings only)
- [ ] CI 確認

pre-existing failing tests (analytics/file-sanitizer/hooks-integration/signup-actions) は main と同一で本 PR 起因ではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)