### PR TITLE
ci: screenshot-check のパスフィルタを可視ファイルに絞る

### DIFF
--- a/.github/workflows/pr-ui-check.yml
+++ b/.github/workflows/pr-ui-check.yml
@@ -4,9 +4,26 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]
     paths:
-      - "src/routes/**"
-      - "src/lib/ui/**"
-      - "src/lib/features/**"
+      # ビジュアル変更を含むファイル種別のみに絞る（バックエンド .ts / API endpoint は除外）。
+      # 過去の `src/routes/**` 全体マッチは `+page.server.ts` や `api/.../+server.ts` でも
+      # 発火してしまい、backend-only PR で false-positive を出す不具合があった。
+      - "src/routes/**/*.svelte"
+      - "src/routes/**/*.svelte.ts"
+      - "src/routes/**/*.svelte.js"
+      - "src/routes/**/*.css"
+      - "src/routes/**/*.scss"
+      - "src/lib/ui/**/*.svelte"
+      - "src/lib/ui/**/*.svelte.ts"
+      - "src/lib/ui/**/*.svelte.js"
+      - "src/lib/ui/**/*.css"
+      - "src/lib/ui/**/*.scss"
+      - "src/lib/features/**/*.svelte"
+      - "src/lib/features/**/*.svelte.ts"
+      - "src/lib/features/**/*.svelte.js"
+      - "src/lib/features/**/*.css"
+      - "src/lib/features/**/*.scss"
+      - "src/app.css"
+      - "src/app.html"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- `pr-ui-check.yml` の `screenshot-check` ジョブのパスフィルタを可視ファイル限定に変更
- `src/routes/**` の全体マッチは `+page.server.ts` や `api/.../+server.ts` などの backend-only 変更でも発火してしまい、false-positive を出していた
- 拡張子を `.svelte` / `.svelte.ts` / `.svelte.js` / `.css` / `.scss` に限定

## Background

#787 の PR #891 を Ready に昇格したところ、`screenshot-check` ジョブが失敗:

```
❌ UI変更PRにはスクリーンショットの添付が必須です。
```

しかし #787 は `src/routes/**/+page.server.ts` / `src/routes/api/**/+server.ts` のみを触る backend-only のエラーフォーマット統一 PR で、UI には一切影響しない。原因は `paths: - "src/routes/**"` のワイルドカードが `.ts` backend ファイルも拾ってしまうこと。

## Fix

```yaml
paths:
  - "src/routes/**/*.svelte"
  - "src/routes/**/*.svelte.ts"
  - "src/routes/**/*.svelte.js"
  - "src/routes/**/*.css"
  - "src/routes/**/*.scss"
  - "src/lib/ui/**/*.svelte"
  # ... 同様に拡張子で限定
  - "src/app.css"
  - "src/app.html"
```

## Impact

- PR #891 (#787 plan-limit error unification): この fix がマージされれば screenshot-check は trigger されず、Ready 昇格可能
- PR #894 (#729 retention cleanup cron): 同じく backend-only (`api/cron/retention-cleanup/+server.ts`) なので恩恵を受ける
- UI を触る PR では従来通り screenshot-check が必須のまま動作

## Test plan

- [x] `.github/workflows/pr-ui-check.yml` の YAML 構文確認
- [ ] マージ後、#891 を Ready 昇格して screenshot-check が trigger されないこと
- [ ] 新規の UI 変更 PR (`.svelte` 変更) では screenshot-check が従来通り trigger されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)