### PR TITLE
test(e2e): #776 プラン別ゲート E2E を cognito-dev モードで実装

### DIFF
--- a/playwright.cognito-dev.config.ts
+++ b/playwright.cognito-dev.config.ts
@@ -6,7 +6,9 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
 	testDir: 'tests/e2e',
-	testMatch: 'cognito-auth.spec.ts',
+	// #776: plan-gated-features spec も cognito-dev モードでのみ実行可能
+	// （local モードでは resolvePlanTier が常に 'family' を返すため）
+	testMatch: /(cognito-auth|plan-gated-features)\.spec\.ts$/,
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 1,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
 	testDir: 'tests/e2e',
 	testIgnore: [
 		'**/cognito-auth.spec.ts',
+		// #776, #779: プラン別ゲート E2E は cognito-dev モード専用
+		// （playwright.cognito-dev.config.ts でのみ実行する）
+		'**/plan-gated-features.spec.ts',
 		'**/production-smoke.spec.ts',
 		// ビジュアル回帰テストはプラットフォーム固有のスナップショットを使うため
 		// CI（Linux）ではスキップし、ローカル開発でのUI崩壊検知にのみ使用する

--- a/src/lib/server/auth/providers/cognito-dev.ts
+++ b/src/lib/server/auth/providers/cognito-dev.ts
@@ -14,6 +14,11 @@ import { verifyDevIdentityToken } from './cognito-dev-jwt';
 /**
  * 開発用ダミーユーザー（E2E テストでも使用）
  * ログインフォームでこれらの email/password でログイン可能
+ *
+ * #776: プラン別ゲート E2E 用に、プラン指定付きの owner ユーザーを追加できるように
+ * `licenseStatus` / `plan` を optional フィールドとして持てるようにした。
+ * 未指定（従来の owner/parent/child）は `licenseStatus='active'` / `plan=undefined`
+ * → `resolvePlanTier` では `standard` と解決される。
  */
 export interface DevUser {
 	userId: string;
@@ -21,6 +26,10 @@ export interface DevUser {
 	password: string;
 	tenantId: string;
 	role: Role;
+	/** ライセンス状態（未指定は 'active'） */
+	licenseStatus?: AuthContext['licenseStatus'];
+	/** Stripe price id 相当（例: 'standard_monthly', 'family_monthly'） */
+	plan?: string;
 }
 
 export const DEV_USERS: DevUser[] = [
@@ -44,6 +53,35 @@ export const DEV_USERS: DevUser[] = [
 		password: 'Gq!Dev#Child2026x',
 		tenantId: 'dev-tenant-001',
 		role: 'child',
+	},
+	// ---------- #776: プラン別ゲート E2E 用ユーザー ----------
+	// 各ユーザーは tenant を分けておき、データ干渉を防ぐ。
+	{
+		userId: 'dev-free-owner-001',
+		email: 'free@example.com',
+		password: 'Gq!Dev#Free2026xy',
+		tenantId: 'dev-tenant-free',
+		role: 'owner',
+		licenseStatus: 'none',
+		plan: undefined,
+	},
+	{
+		userId: 'dev-standard-owner-001',
+		email: 'standard@example.com',
+		password: 'Gq!Dev#Std2026xyz',
+		tenantId: 'dev-tenant-standard',
+		role: 'owner',
+		licenseStatus: 'active',
+		plan: 'standard_monthly',
+	},
+	{
+		userId: 'dev-family-owner-001',
+		email: 'family@example.com',
+		password: 'Gq!Dev#Fam2026xyz',
+		tenantId: 'dev-tenant-family',
+		role: 'owner',
+		licenseStatus: 'active',
+		plan: 'family_monthly',
 	},
 ];
 
@@ -108,11 +146,13 @@ export class DevCognitoAuthProvider implements AuthProvider {
 		const devUser = findDevUser(identity.email);
 		if (!devUser) return null;
 
+		// #776: dev user のプラン情報を反映する。未指定時は従来通り active/standard 扱い。
 		const context: AuthContext = {
 			tenantId: devUser.tenantId,
 			role: devUser.role,
-			licenseStatus: 'active',
+			licenseStatus: devUser.licenseStatus ?? 'active',
 			tenantStatus: 'active',
+			plan: devUser.plan,
 		};
 
 		const token = signContext(context);

--- a/tests/e2e/plan-gated-features.spec.ts
+++ b/tests/e2e/plan-gated-features.spec.ts
@@ -1,0 +1,115 @@
+// tests/e2e/plan-gated-features.spec.ts
+// #776: プラン別ゲート UI の E2E 検証
+//
+// ローカル auth モードでは plan-limit-service の resolvePlanTier が
+// 早期 return で常に 'family' を返すため、プランゲートを E2E で検証できない。
+// この spec は AUTH_MODE=cognito + COGNITO_DEV_MODE=true 前提で実行し、
+// DevCognitoAuthProvider のプラン別ダミーユーザー（free/standard/family）で
+// ログイン → 実際のプランゲート UI を検証する。
+//
+// 実行: npx playwright test --config playwright.cognito-dev.config.ts plan-gated-features
+//
+// 対応ゲート:
+//  - /admin/rewards: rewards-upgrade-banner（free のみ表示）
+//  - /admin/messages: ひとことメッセージボタン（free/standard は disabled、family は enabled）
+
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+const PLAN_USERS = {
+	free: { email: 'free@example.com', password: 'Gq!Dev#Free2026xy' },
+	standard: { email: 'standard@example.com', password: 'Gq!Dev#Std2026xyz' },
+	family: { email: 'family@example.com', password: 'Gq!Dev#Fam2026xyz' },
+} as const;
+
+async function loginAs(page: Page, plan: keyof typeof PLAN_USERS) {
+	const { email, password } = PLAN_USERS[plan];
+	// Vite dev のコールドコンパイルでは load/domcontentloaded が長時間完了しないため、
+	// commit イベントで navigation を解除し、フォーム表示は waitFor で待つ。
+	await page.goto('/auth/login', { waitUntil: 'commit', timeout: 180_000 });
+	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 180_000 });
+	await page.getByLabel('メールアドレス').fill(email);
+	await page.getByLabel('パスワード', { exact: true }).fill(password);
+	await page.getByRole('button', { name: 'ログイン' }).click();
+	await page.waitForURL(/\/admin/, { timeout: 120_000 });
+}
+
+// Vite dev のコールドコンパイルで /auth/login と /admin 配下の初回ビルドが
+// 数分かかることがあるため、テスト前に warmup でプリコンパイルを走らせる。
+test.beforeAll(async ({ browser }) => {
+	test.setTimeout(360_000);
+	const ctx = await browser.newContext();
+	const page = await ctx.newPage();
+	try {
+		await page.goto('/auth/login', { waitUntil: 'commit', timeout: 180_000 });
+		await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 180_000 });
+		// rewards/messages ページもプリコンパイルしておく（login 後にリダイレクトで /admin に飛ぶ）
+		await page.goto('/admin/rewards', { waitUntil: 'commit', timeout: 180_000 }).catch(() => {});
+		await page.goto('/admin/messages', { waitUntil: 'commit', timeout: 180_000 }).catch(() => {});
+	} finally {
+		await ctx.close();
+	}
+});
+
+// ============================================================
+// /admin/rewards — #728 カスタムごほうびプランゲート
+// ============================================================
+test.describe('#776 /admin/rewards プランゲート', () => {
+	test.beforeEach(() => {
+		test.slow(); // Vite dev のコールドコンパイルでタイムアウトを 3x 延長
+	});
+
+	test('free プランではアップグレードバナーが表示される', async ({ page }) => {
+		await loginAs(page, 'free');
+		await page.goto('/admin/rewards');
+		await expect(page.getByTestId('rewards-upgrade-banner')).toBeVisible();
+		await expect(page.getByTestId('rewards-upgrade-cta')).toBeVisible();
+	});
+
+	test('standard プランではアップグレードバナーが表示されない', async ({ page }) => {
+		await loginAs(page, 'standard');
+		await page.goto('/admin/rewards');
+		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
+	});
+
+	test('family プランではアップグレードバナーが表示されない', async ({ page }) => {
+		await loginAs(page, 'family');
+		await page.goto('/admin/rewards');
+		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
+	});
+});
+
+// ============================================================
+// /admin/messages — #0270 自由テキストメッセージプランゲート
+// ============================================================
+test.describe('#776 /admin/messages プランゲート', () => {
+	test.beforeEach(() => {
+		test.slow();
+	});
+
+	test('free プランではひとことメッセージボタンが disabled', async ({ page }) => {
+		await loginAs(page, 'free');
+		await page.goto('/admin/messages');
+		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
+		await expect(textBtn).toBeVisible();
+		await expect(textBtn).toBeDisabled();
+	});
+
+	test('standard プランでもひとことメッセージボタンは disabled（family 限定）', async ({
+		page,
+	}) => {
+		await loginAs(page, 'standard');
+		await page.goto('/admin/messages');
+		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
+		await expect(textBtn).toBeVisible();
+		await expect(textBtn).toBeDisabled();
+	});
+
+	test('family プランではひとことメッセージボタンが有効', async ({ page }) => {
+		await loginAs(page, 'family');
+		await page.goto('/admin/messages');
+		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
+		await expect(textBtn).toBeVisible();
+		await expect(textBtn).toBeEnabled();
+	});
+});


### PR DESCRIPTION
## Summary

- プラン別ゲート UI を E2E で検証する `tests/e2e/plan-gated-features.spec.ts` を新規追加
- `AUTH_MODE=cognito` + `COGNITO_DEV_MODE=true` 前提で、free/standard/family プランのダミーユーザー 3 名を `DEV_USERS` に追加
- `DevUser` インターフェースに `licenseStatus` / `plan` を optional で追加し、`issueContextFromDevUsers` で AuthContext に反映
- `playwright.cognito-dev.config.ts` の testMatch を regex 化して新スペックも実行対象に

## なぜ cognito-dev モードなのか

`plan-limit-service.ts#resolvePlanTier` は `getAuthMode() === 'local'` の場合に早期 return で常に `'family'` を返す。
ローカル auth モードの E2E ではプラン別ゲートの 403 を発火できないため、cognito-dev モードで専用ユーザーを用意した。

## 検証内容

| ルート | free | standard | family |
| --- | --- | --- | --- |
| `/admin/rewards` | `rewards-upgrade-banner` visible | banner 非表示 | banner 非表示 |
| `/admin/messages` | ひとことメッセージボタン disabled | ひとことメッセージボタン disabled | ひとことメッセージボタン enabled |

POST 側の 403 検証は既に unit テスト (`tests/unit/routes/*`) でカバー済み。本 PR は UI レイヤのゲート表示の E2E 保証に徹する。

## Acceptance Criteria

#776 の AC を確認:

- [x] POST /admin/rewards?/grant (free): 403 → `tests/unit/routes/admin-rewards-actions.test.ts` 既存カバー
- [x] POST /admin/rewards?/addPreset (free): 403 → 同上
- [x] POST /api/v1/activities/suggest (free): 403 → `tests/unit/routes/activities-suggest-api.test.ts` 既存カバー
- [x] POST /admin/messages (free, free text): 403 → `tests/unit/routes/admin-messages-send.test.ts` 既存カバー
- [x] POST /admin/messages (standard, free text): 403 → 同上
- [N/A] GET /admin/reports/weekly (free): 現行実装にプランゲートは存在しない（全プラン閲覧可）
- [x] E2E で UI レイヤのプランゲート表示を検証 ← 本 PR で追加

## Test plan

- [x] `npx playwright test --config playwright.cognito-dev.config.ts plan-gated-features` で 6/6 pass
- [x] `npx biome check` クリーン
- [x] `npx svelte-check` エラーなし
- [ ] CI (deploy.yml の cognito-dev ジョブ) で pass

closes #776