### PR TITLE
test(e2e): #779 plan-standard / plan-family 機能疎通 E2E

### DIFF
--- a/playwright.cognito-dev.config.ts
+++ b/playwright.cognito-dev.config.ts
@@ -6,9 +6,10 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
 	testDir: 'tests/e2e',
-	// #776: plan-gated-features spec も cognito-dev モードでのみ実行可能
-	// （local モードでは resolvePlanTier が常に 'family' を返すため）
-	testMatch: /(cognito-auth|plan-gated-features)\.spec\.ts$/,
+	// #776, #779: plan-gated-features / plan-standard / plan-family spec も
+	// cognito-dev モードでのみ実行可能（local モードでは resolvePlanTier が常に
+	// 'family' を返すため）
+	testMatch: /(cognito-auth|plan-gated-features|plan-standard|plan-family)\.spec\.ts$/,
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 1,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
 		// #776, #779: プラン別ゲート E2E は cognito-dev モード専用
 		// （playwright.cognito-dev.config.ts でのみ実行する）
 		'**/plan-gated-features.spec.ts',
+		'**/plan-standard.spec.ts',
+		'**/plan-family.spec.ts',
 		'**/production-smoke.spec.ts',
 		// ビジュアル回帰テストはプラットフォーム固有のスナップショットを使うため
 		// CI（Linux）ではスキップし、ローカル開発でのUI崩壊検知にのみ使用する

--- a/tests/e2e/cognito-dev-helpers.ts
+++ b/tests/e2e/cognito-dev-helpers.ts
@@ -1,0 +1,46 @@
+// tests/e2e/cognito-dev-helpers.ts
+// cognito-dev モード（AUTH_MODE=cognito + COGNITO_DEV_MODE=true）の E2E 共通ヘルパー。
+//
+// - プラン別 dev ユーザー定義（DevCognitoAuthProvider.DEV_USERS と同期）
+// - loginAs: Vite dev のコールドコンパイル（load/domcontentloaded が長時間完了しない）を
+//            避けるため `waitUntil: 'commit'` で navigation を解除し、フォーム表示は waitFor で待つ。
+// - warmupCognitoDev: describe/spec の beforeAll で呼び出し、/auth/login と主要な admin
+//                     配下ページをプリコンパイルして 1 本目のテストの timeout を防ぐ。
+
+import type { Browser, Page } from '@playwright/test';
+
+export const PLAN_USERS = {
+	free: { email: 'free@example.com', password: 'Gq!Dev#Free2026xy' },
+	standard: { email: 'standard@example.com', password: 'Gq!Dev#Std2026xyz' },
+	family: { email: 'family@example.com', password: 'Gq!Dev#Fam2026xyz' },
+} as const;
+
+export type PlanKey = keyof typeof PLAN_USERS;
+
+export async function loginAs(page: Page, plan: PlanKey): Promise<void> {
+	const { email, password } = PLAN_USERS[plan];
+	await page.goto('/auth/login', { waitUntil: 'commit', timeout: 180_000 });
+	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 180_000 });
+	await page.getByLabel('メールアドレス').fill(email);
+	await page.getByLabel('パスワード', { exact: true }).fill(password);
+	await page.getByRole('button', { name: 'ログイン' }).click();
+	await page.waitForURL(/\/admin/, { timeout: 120_000 });
+}
+
+/**
+ * Vite dev のコールドコンパイルを先に済ませて、1 本目のテストが timeout するのを防ぐ。
+ * 呼び出し側で `test.setTimeout(360_000)` を設定してから呼ぶこと。
+ */
+export async function warmupCognitoDev(browser: Browser, paths: string[]): Promise<void> {
+	const ctx = await browser.newContext();
+	const page = await ctx.newPage();
+	try {
+		await page.goto('/auth/login', { waitUntil: 'commit', timeout: 180_000 });
+		await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 180_000 });
+		for (const path of paths) {
+			await page.goto(path, { waitUntil: 'commit', timeout: 180_000 }).catch(() => {});
+		}
+	} finally {
+		await ctx.close();
+	}
+}

--- a/tests/e2e/plan-family.spec.ts
+++ b/tests/e2e/plan-family.spec.ts
@@ -1,0 +1,72 @@
+// tests/e2e/plan-family.spec.ts
+// #779: family プランで standard の全機能に加え、family 限定機能が enable されている
+// ことの疎通 E2E。
+//
+// cognito-dev モード（AUTH_MODE=cognito + COGNITO_DEV_MODE=true）で family@example.com
+// としてログインし、プランゲートが外れていることを UI 状態から検証する。
+//
+// family 限定機能で UI で判定できるもの:
+//  - /admin/messages のひとことメッセージ（自由テキスト）ボタンが enabled
+//    （#776 の plan-gated-features.spec.ts でも検証済みだが、family プラン疎通として
+//     独立に保持する）
+//  - /admin/license の PlanStatusCard が "ファミリー プラン"
+//
+// 月次比較レポート / きょうだいランキング / 無制限履歴保持 は子データ前提の機能のため
+// この spec では扱わない（専用のデータ投入 E2E を別途用意する想定）。
+//
+// 実行: npx playwright test --config playwright.cognito-dev.config.ts plan-family
+
+import { expect, test } from '@playwright/test';
+import { loginAs, warmupCognitoDev } from './cognito-dev-helpers';
+
+test.beforeAll(async ({ browser }) => {
+	test.setTimeout(360_000);
+	await warmupCognitoDev(browser, [
+		'/admin',
+		'/admin/license',
+		'/admin/settings',
+		'/admin/messages',
+	]);
+});
+
+test.describe('#779 family プランの機能疎通', () => {
+	test.beforeEach(() => {
+		test.slow();
+	});
+
+	test('/admin ダッシュボードで free 向けアップグレードリンクが表示されない', async ({ page }) => {
+		await loginAs(page, 'family');
+		await page.goto('/admin');
+		await expect(page.locator('.plan-quick-link--free')).toHaveCount(0);
+	});
+
+	test('/admin/license の PlanStatusCard が "ファミリー プラン" を示す', async ({ page }) => {
+		await loginAs(page, 'family');
+		await page.goto('/admin/license');
+		const card = page.locator('.plan-status-card--family');
+		await expect(card).toBeVisible();
+		await expect(card).toContainText('ファミリー プラン');
+		// free 向けバッジ/CTA は出ていないはず
+		await expect(page.getByTestId('plan-status-free-cta')).toHaveCount(0);
+	});
+
+	test('/admin/settings のデータエクスポートが有効化されている', async ({ page }) => {
+		await loginAs(page, 'family');
+		await page.goto('/admin/settings');
+		const section = page.getByTestId('data-export-section');
+		await section.scrollIntoViewIfNeeded();
+		await expect(section).toBeVisible();
+		await expect(page.getByTestId('export-upsell')).toHaveCount(0);
+		const exportBtn = page.getByTestId('data-export-button');
+		await expect(exportBtn).toBeVisible();
+		await expect(exportBtn).toBeEnabled();
+	});
+
+	test('/admin/messages のひとことメッセージ（family 限定）が enabled', async ({ page }) => {
+		await loginAs(page, 'family');
+		await page.goto('/admin/messages');
+		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
+		await expect(textBtn).toBeVisible();
+		await expect(textBtn).toBeEnabled();
+	});
+});

--- a/tests/e2e/plan-standard.spec.ts
+++ b/tests/e2e/plan-standard.spec.ts
@@ -1,0 +1,53 @@
+// tests/e2e/plan-standard.spec.ts
+// #779: standard プランで各機能が想定通り enable されていることの疎通 E2E。
+//
+// cognito-dev モード（AUTH_MODE=cognito + COGNITO_DEV_MODE=true）で standard@example.com
+// としてログインし、無料プランゲートが外れていることを UI 状態から検証する。
+//
+// 実行: npx playwright test --config playwright.cognito-dev.config.ts plan-standard
+
+import { expect, test } from '@playwright/test';
+import { loginAs, warmupCognitoDev } from './cognito-dev-helpers';
+
+test.beforeAll(async ({ browser }) => {
+	test.setTimeout(360_000);
+	await warmupCognitoDev(browser, ['/admin', '/admin/license', '/admin/settings']);
+});
+
+test.describe('#779 standard プランの機能疎通', () => {
+	test.beforeEach(() => {
+		test.slow(); // Vite dev cold compile 対策
+	});
+
+	test('/admin ダッシュボードで free 向けアップグレードリンクが表示されない', async ({ page }) => {
+		await loginAs(page, 'standard');
+		await page.goto('/admin');
+		// free プランだけに表示される `.plan-quick-link--free` が存在しないことを確認
+		await expect(page.locator('.plan-quick-link--free')).toHaveCount(0);
+	});
+
+	test('/admin/license の PlanStatusCard が "スタンダード プラン" を示す', async ({ page }) => {
+		await loginAs(page, 'standard');
+		await page.goto('/admin/license');
+		const card = page.locator('.plan-status-card--standard');
+		await expect(card).toBeVisible();
+		await expect(card).toContainText('スタンダード プラン');
+		// free 向けバッジ/CTA は出ていないはず
+		await expect(page.getByTestId('plan-status-free-cta')).toHaveCount(0);
+	});
+
+	test('/admin/settings のデータエクスポートが有効化されている', async ({ page }) => {
+		await loginAs(page, 'standard');
+		await page.goto('/admin/settings');
+		// データエクスポートセクションまでスクロール
+		const section = page.getByTestId('data-export-section');
+		await section.scrollIntoViewIfNeeded();
+		await expect(section).toBeVisible();
+		// free プラン向けアップセルは DOM に存在しない
+		await expect(page.getByTestId('export-upsell')).toHaveCount(0);
+		// エクスポートボタンは enabled
+		const exportBtn = page.getByTestId('data-export-button');
+		await expect(exportBtn).toBeVisible();
+		await expect(exportBtn).toBeEnabled();
+	});
+});


### PR DESCRIPTION
## Summary

#779 対応。standard / family プランで各機能が想定通り enable されていることを
cognito-dev モード（#776 の dev ユーザー基盤）で検証する疎通 E2E を追加。

## 依存

- **ベース: #896 (test/776-plan-gated-features-e2e)**
- #776 がマージされ次第、本 PR は自動的に main に reparent される
- #776 の \`DEV_USERS\` 拡張（free/standard/family ユーザー）を前提とする

## 変更内容

### 新規ファイル
- \`tests/e2e/cognito-dev-helpers.ts\`: PLAN_USERS / loginAs / warmupCognitoDev の共通ヘルパー
- \`tests/e2e/plan-standard.spec.ts\`: 3 テスト
  - /admin: \`plan-quick-link--free\` が非表示
  - /admin/license: PlanStatusCard が "スタンダード プラン"
  - /admin/settings: export-upsell なし + data-export-button enabled
- \`tests/e2e/plan-family.spec.ts\`: 4 テスト
  - /admin, /admin/license, /admin/settings（standard と同様）
  - /admin/messages: ひとことメッセージ（family 限定）が enabled

### 変更
- \`playwright.cognito-dev.config.ts\`: testMatch を plan-standard / plan-family に拡張

## ローカル実行結果

\`\`\`
7 passed (3.2m)
\`\`\`

\`\`\`bash
npx playwright test --config playwright.cognito-dev.config.ts plan-standard plan-family
\`\`\`

## AC カバレッジ

#779 の受け入れ基準項目ごとの対応状況:

### plan-standard.spec.ts
- [x] /admin/license: PlanStatusCard が standard
- [x] /admin/settings: データエクスポート利用可能
- [ ] /admin/children 無制限 → PlanLimits 単体テストで担保（E2E 観測困難）
- [ ] /admin/activities 無制限 → 同上
- [x] /admin/rewards 特別報酬付与 → #776 の rewards-upgrade-banner 非表示で担保
- [ ] AI 提案機能 → 外部 API 呼び出しのため E2E 範囲外
- [ ] 週次メールレポート → バッチ送信のため E2E 範囲外
- [x] /admin/messages 自由テキスト family 限定 disabled → #776 で担保

### plan-family.spec.ts
- [x] standard の全機能（同じ UI 検証）
- [ ] 月次比較レポート → 子データ前提、別 spec 予定
- [ ] きょうだいランキング → 複数子データ前提、別 spec 予定
- [ ] 無制限の履歴保持 → PlanLimits 単体テストで担保
- [x] 自由テキストメッセージ → /admin/messages ボタン enabled

## Test plan

- [ ] CI: lint-and-test 通過
- [ ] CI: e2e-test 通過（local auth モードなので plan-standard/plan-family は CI では実行されない）
- [x] ローカルで \`playwright.cognito-dev.config.ts\` を使って 7 tests 通過

closes #779