### PR TITLE
fix: #766 /auth/signup?plan=X のトライアル自動開始を実装

### DIFF
--- a/src/routes/auth/signup/+page.server.ts
+++ b/src/routes/auth/signup/+page.server.ts
@@ -16,7 +16,19 @@ import { logger } from '$lib/server/logger';
 import { recordConsent } from '$lib/server/services/consent-service';
 import { notifyNewSignup } from '$lib/server/services/discord-notify-service';
 import { consumeLicenseKey, validateLicenseKey } from '$lib/server/services/license-key-service';
+import { startTrial, type TrialTier } from '$lib/server/services/trial-service';
 import type { Actions, PageServerLoad } from './$types';
+
+/**
+ * #766: /auth/signup?plan=X からのサインアップ時にトライアル自動開始用のティアを決定する。
+ * 既知のティア以外（無効値・空文字）は null を返し、呼び出し側でトライアル開始をスキップする。
+ */
+function parsePlanForTrial(planInput: string | null | undefined): TrialTier | null {
+	if (!planInput) return null;
+	const normalized = planInput.trim().toLowerCase();
+	if (normalized === 'standard' || normalized === 'family') return normalized;
+	return null;
+}
 
 export const load: PageServerLoad = async ({ locals }) => {
 	const _tenantId = locals.context?.tenantId;
@@ -43,6 +55,8 @@ export const actions: Actions = {
 		const password = formData.get('password') as string;
 		const passwordConfirm = formData.get('passwordConfirm') as string;
 		const licenseKeyInput = (formData.get('licenseKey') as string)?.trim() || '';
+		// #766: /pricing からの遷移で plan パラメータ（standard|family）を引き継ぐ
+		const planInput = (formData.get('plan') as string | null) ?? '';
 		const agreedTerms = formData.get('agreedTerms') === 'on';
 		const agreedPrivacy = formData.get('agreedPrivacy') === 'on';
 
@@ -51,6 +65,7 @@ export const actions: Actions = {
 				error: '利用規約とプライバシーポリシーへの同意が必要です',
 				email,
 				licenseKey: licenseKeyInput,
+				plan: planInput,
 			});
 		}
 
@@ -59,11 +74,17 @@ export const actions: Actions = {
 				error: '全ての項目を入力してください',
 				email,
 				licenseKey: licenseKeyInput,
+				plan: planInput,
 			});
 		}
 
 		if (password !== passwordConfirm) {
-			return fail(400, { error: 'パスワードが一致しません', email, licenseKey: licenseKeyInput });
+			return fail(400, {
+				error: 'パスワードが一致しません',
+				email,
+				licenseKey: licenseKeyInput,
+				plan: planInput,
+			});
 		}
 
 		if (password.length < 8) {
@@ -71,6 +92,7 @@ export const actions: Actions = {
 				error: 'パスワードは8文字以上で入力してください',
 				email,
 				licenseKey: licenseKeyInput,
+				plan: planInput,
 			});
 		}
 
@@ -78,19 +100,29 @@ export const actions: Actions = {
 		if (licenseKeyInput) {
 			const keyCheck = await validateLicenseKey(licenseKeyInput);
 			if (!keyCheck.valid) {
-				return fail(400, { error: keyCheck.reason, email, licenseKey: licenseKeyInput });
+				return fail(400, {
+					error: keyCheck.reason,
+					email,
+					licenseKey: licenseKeyInput,
+					plan: planInput,
+				});
 			}
 		}
 
 		const result = await signUpWithCognito(email, password);
 
 		if (!result.success) {
-			return fail(400, { error: result.message, email, licenseKey: licenseKeyInput });
+			return fail(400, {
+				error: result.message,
+				email,
+				licenseKey: licenseKeyInput,
+				plan: planInput,
+			});
 		}
 
 		// メール認証が必要（通常のケース）
 		if (!result.userConfirmed) {
-			return { confirmStep: true, email, licenseKey: licenseKeyInput };
+			return { confirmStep: true, email, licenseKey: licenseKeyInput, plan: planInput };
 		}
 
 		// 即時確認（auto-verify が有効な場合）
@@ -101,6 +133,8 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const email = formData.get('email') as string;
 		const licenseKeyInput = (formData.get('licenseKey') as string)?.trim() || '';
+		// #766: plan パラメータを再送後も保持
+		const planInput = (formData.get('plan') as string | null) ?? '';
 
 		if (!email) {
 			return fail(400, {
@@ -108,6 +142,7 @@ export const actions: Actions = {
 				confirmStep: true,
 				email: '',
 				licenseKey: licenseKeyInput,
+				plan: planInput,
 			});
 		}
 
@@ -119,6 +154,7 @@ export const actions: Actions = {
 				confirmStep: true,
 				email,
 				licenseKey: licenseKeyInput,
+				plan: planInput,
 			});
 		}
 
@@ -126,6 +162,7 @@ export const actions: Actions = {
 			confirmStep: true,
 			email,
 			licenseKey: licenseKeyInput,
+			plan: planInput,
 			resent: true,
 		};
 	},
@@ -158,6 +195,8 @@ export const actions: Actions = {
 		const code = (formData.get('code') as string)?.replace(/\s/g, '');
 		const password = formData.get('password') as string;
 		const licenseKeyInput = (formData.get('licenseKey') as string)?.trim() || '';
+		// #766: /pricing からの遷移時の plan パラメータ。トライアル自動開始用
+		const planInput = (formData.get('plan') as string | null) ?? '';
 
 		if (!email || !code) {
 			return fail(400, {
@@ -165,6 +204,7 @@ export const actions: Actions = {
 				email,
 				confirmStep: true,
 				licenseKey: licenseKeyInput,
+				plan: planInput,
 			});
 		}
 
@@ -176,6 +216,7 @@ export const actions: Actions = {
 				email,
 				confirmStep: true,
 				licenseKey: licenseKeyInput,
+				plan: planInput,
 			});
 		}
 
@@ -295,6 +336,44 @@ export const actions: Actions = {
 			});
 			// Consent 記録失敗 → /consent 画面で再取得
 			redirect(302, '/consent');
+		}
+
+		// #766: /auth/signup?plan=X からの遷移ならトライアルを自動開始する
+		//
+		// 条件:
+		//  - plan パラメータが 'standard' または 'family' の有効値
+		//  - ライセンスキー未指定（指定されている場合はライセンスキーが優先。consume 失敗時も
+		//    ユーザー意図として「ライセンスキーで登録」が明確なので、トライアルは開始しない）
+		//
+		// 失敗（既に使用済み等）は best-effort でログのみ記録し /admin に進む。
+		// /pricing の CTA からは新規テナントでのみ遷移する想定だが、万一 trialUsed=true でも
+		// startTrial() 側で拒否されて false が返るだけで致命的影響はない。
+		const trialTier = parsePlanForTrial(planInput);
+		if (trialTier && !licenseKeyInput) {
+			try {
+				const started = await startTrial({
+					tenantId,
+					source: 'user_initiated',
+					tier: trialTier,
+				});
+				if (started) {
+					logger.info('[SIGNUP] Trial auto-started from pricing flow', {
+						context: { tenantId, tier: trialTier },
+					});
+				} else {
+					logger.info('[SIGNUP] Trial auto-start rejected (already used/active)', {
+						context: { tenantId, tier: trialTier },
+					});
+				}
+			} catch (err) {
+				logger.error('[SIGNUP] Trial auto-start threw', {
+					context: {
+						error: err instanceof Error ? err.message : String(err),
+						tenantId,
+						tier: trialTier,
+					},
+				});
+			}
 		}
 
 		// 正常完了

--- a/src/routes/auth/signup/+page.svelte
+++ b/src/routes/auth/signup/+page.svelte
@@ -172,6 +172,7 @@ $effect(() => {
 				<input type="hidden" name="email" value={email} />
 				<input type="hidden" name="password" value={password} />
 				<input type="hidden" name="licenseKey" value={licenseKey} />
+				<input type="hidden" name="plan" value={planParam ?? ''} />
 
 				<p class="text-sm text-[var(--color-text-muted)] text-center leading-relaxed">
 					<strong>{email}</strong> に確認コードを送信しました。<br />
@@ -229,6 +230,7 @@ $effect(() => {
 			>
 				<input type="hidden" name="email" value={email} />
 				<input type="hidden" name="licenseKey" value={licenseKey} />
+				<input type="hidden" name="plan" value={planParam ?? ''} />
 				<Button
 					type="submit"
 					variant="ghost"
@@ -264,6 +266,9 @@ $effect(() => {
 				}}
 				class="flex flex-col gap-5"
 			>
+				<!-- #766: /pricing からの遷移で plan パラメータを確認アクションまで引き継ぐ -->
+				<input type="hidden" name="plan" value={planParam ?? ''} />
+
 				<FormField
 					label="メールアドレス"
 					type="email"

--- a/tests/unit/services/signup-actions.test.ts
+++ b/tests/unit/services/signup-actions.test.ts
@@ -68,6 +68,12 @@ vi.mock('$lib/server/services/license-key-service', () => ({
 	consumeLicenseKey: (...args: unknown[]) => mockConsumeLicenseKey(...args),
 }));
 
+// --- Trial Service モック (#766) ---
+const mockStartTrial = vi.fn();
+vi.mock('$lib/server/services/trial-service', () => ({
+	startTrial: (...args: unknown[]) => mockStartTrial(...args),
+}));
+
 beforeEach(() => {
 	mockSignUp.mockReset();
 	mockConfirmSignUp.mockReset();
@@ -83,6 +89,9 @@ beforeEach(() => {
 	mockValidateLicenseKey.mockResolvedValue({ valid: true, key: null });
 	mockConsumeLicenseKey.mockReset();
 	mockConsumeLicenseKey.mockResolvedValue({ ok: true, plan: 'monthly' });
+	// #766: startTrial モックのデフォルトは成功
+	mockStartTrial.mockReset();
+	mockStartTrial.mockResolvedValue(true);
 });
 
 /** FormData モック */
@@ -570,6 +579,220 @@ describe('confirm action', () => {
 		}
 
 		expect(mockConsumeLicenseKey).not.toHaveBeenCalled();
+	});
+
+	// ========================================================
+	// #766: /auth/signup?plan=X トライアル自動開始
+	// ========================================================
+	it('#766: plan=standard 指定時は startTrial が tier=standard で呼ばれる', async () => {
+		setupSuccessfulAutoLogin();
+
+		const { actions } = await import('../../../src/routes/auth/signup/+page.server');
+		const event = createConfirmEvent({
+			email: 'test@example.com',
+			code: '123456',
+			password: 'Password1',
+			plan: 'standard',
+		});
+
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			await (actions.confirm as any)(event);
+			expect.unreachable('should have thrown redirect');
+		} catch (e) {
+			expect((e as { status: number }).status).toBe(302);
+			expect((e as { location: string }).location).toBe('/admin');
+		}
+
+		expect(mockStartTrial).toHaveBeenCalledWith({
+			tenantId: 'tenant-abc',
+			source: 'user_initiated',
+			tier: 'standard',
+		});
+	});
+
+	it('#766: plan=family 指定時は startTrial が tier=family で呼ばれる', async () => {
+		setupSuccessfulAutoLogin();
+
+		const { actions } = await import('../../../src/routes/auth/signup/+page.server');
+		const event = createConfirmEvent({
+			email: 'test@example.com',
+			code: '123456',
+			password: 'Password1',
+			plan: 'family',
+		});
+
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			await (actions.confirm as any)(event);
+			expect.unreachable('should have thrown redirect');
+		} catch (e) {
+			expect((e as { status: number }).status).toBe(302);
+			expect((e as { location: string }).location).toBe('/admin');
+		}
+
+		expect(mockStartTrial).toHaveBeenCalledWith({
+			tenantId: 'tenant-abc',
+			source: 'user_initiated',
+			tier: 'family',
+		});
+	});
+
+	it('#766: plan 未指定時は startTrial が呼ばれない', async () => {
+		setupSuccessfulAutoLogin();
+
+		const { actions } = await import('../../../src/routes/auth/signup/+page.server');
+		const event = createConfirmEvent({
+			email: 'test@example.com',
+			code: '123456',
+			password: 'Password1',
+		});
+
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			await (actions.confirm as any)(event);
+			expect.unreachable('should have thrown redirect');
+		} catch (e) {
+			expect((e as { status: number }).status).toBe(302);
+			expect((e as { location: string }).location).toBe('/admin');
+		}
+
+		expect(mockStartTrial).not.toHaveBeenCalled();
+	});
+
+	it('#766: 不正な plan パラメータ（free / 無効値 / 大文字小文字ずれ）は無視される', async () => {
+		setupSuccessfulAutoLogin();
+
+		const { actions } = await import('../../../src/routes/auth/signup/+page.server');
+		// 'free' は有料プランではないのでトライアル対象外
+		const event1 = createConfirmEvent({
+			email: 'test@example.com',
+			code: '123456',
+			password: 'Password1',
+			plan: 'free',
+		});
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			await (actions.confirm as any)(event1);
+			expect.unreachable();
+		} catch (e) {
+			expect((e as { status: number }).status).toBe(302);
+		}
+		expect(mockStartTrial).not.toHaveBeenCalled();
+
+		mockStartTrial.mockClear();
+
+		// 任意の未知値
+		setupSuccessfulAutoLogin();
+		const event2 = createConfirmEvent({
+			email: 'test@example.com',
+			code: '123456',
+			password: 'Password1',
+			plan: 'enterprise',
+		});
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			await (actions.confirm as any)(event2);
+			expect.unreachable();
+		} catch (e) {
+			expect((e as { status: number }).status).toBe(302);
+		}
+		expect(mockStartTrial).not.toHaveBeenCalled();
+	});
+
+	it('#766: plan=STANDARD（大文字）でも小文字に正規化してトライアル開始する', async () => {
+		setupSuccessfulAutoLogin();
+
+		const { actions } = await import('../../../src/routes/auth/signup/+page.server');
+		const event = createConfirmEvent({
+			email: 'test@example.com',
+			code: '123456',
+			password: 'Password1',
+			plan: 'STANDARD',
+		});
+
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			await (actions.confirm as any)(event);
+			expect.unreachable();
+		} catch (e) {
+			expect((e as { status: number }).status).toBe(302);
+		}
+
+		expect(mockStartTrial).toHaveBeenCalledWith({
+			tenantId: 'tenant-abc',
+			source: 'user_initiated',
+			tier: 'standard',
+		});
+	});
+
+	it('#766: ライセンスキー指定時は plan=standard でも startTrial は呼ばれない（ライセンス優先）', async () => {
+		setupSuccessfulAutoLogin();
+
+		const { actions } = await import('../../../src/routes/auth/signup/+page.server');
+		const event = createConfirmEvent({
+			email: 'test@example.com',
+			code: '123456',
+			password: 'Password1',
+			plan: 'standard',
+			licenseKey: 'GQ-ABCD-EFGH-JKLM',
+		});
+
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			await (actions.confirm as any)(event);
+			expect.unreachable();
+		} catch (e) {
+			expect((e as { status: number }).status).toBe(302);
+		}
+
+		// ライセンスキー消費は呼ばれているが、トライアル開始はスキップ
+		expect(mockConsumeLicenseKey).toHaveBeenCalled();
+		expect(mockStartTrial).not.toHaveBeenCalled();
+	});
+
+	it('#766: startTrial が false を返しても（既に使用済み等） /admin に進む', async () => {
+		setupSuccessfulAutoLogin();
+		mockStartTrial.mockResolvedValue(false);
+
+		const { actions } = await import('../../../src/routes/auth/signup/+page.server');
+		const event = createConfirmEvent({
+			email: 'test@example.com',
+			code: '123456',
+			password: 'Password1',
+			plan: 'standard',
+		});
+
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			await (actions.confirm as any)(event);
+			expect.unreachable();
+		} catch (e) {
+			expect((e as { status: number }).status).toBe(302);
+			expect((e as { location: string }).location).toBe('/admin');
+		}
+	});
+
+	it('#766: startTrial が例外を投げても /admin に進む（ログのみで続行）', async () => {
+		setupSuccessfulAutoLogin();
+		mockStartTrial.mockRejectedValue(new Error('Trial DB unavailable'));
+
+		const { actions } = await import('../../../src/routes/auth/signup/+page.server');
+		const event = createConfirmEvent({
+			email: 'test@example.com',
+			code: '123456',
+			password: 'Password1',
+			plan: 'family',
+		});
+
+		try {
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			await (actions.confirm as any)(event);
+			expect.unreachable();
+		} catch (e) {
+			expect((e as { status: number }).status).toBe(302);
+			expect((e as { location: string }).location).toBe('/admin');
+		}
 	});
 
 	it('#589: recordConsent 失敗時 → /consent に誘導して再同意を促す', async () => {


### PR DESCRIPTION
## Summary

- `/pricing` の「7日間 無料体験」CTA → `/auth/signup?plan=standard|family` 遷移後、サインアップ完了時にトライアルが自動で開始されるようにした
- 以前は `planParam` は signup ページで表示されるだけで confirm アクションまで届かず、ユーザーは free プランのまま `/admin` に入っていた
- 不正な plan パラメータ（`free` / `enterprise` / 空文字）は無視。ライセンスキー指定時はライセンスキー優先でトライアル自動開始をスキップ

## 変更点

### UI (`+page.svelte`)

- signup / confirm / resend フォームに `<input type="hidden" name="plan" value={planParam ?? ''} />` を追加し、URL の `?plan=` を confirm action まで引き継ぐ

### Server Action (`+page.server.ts`)

- `parsePlanForTrial(planInput)` ヘルパを追加（`'standard' | 'family'` のみ許容、不正値・空文字は `null`）
- signup / resend / confirm の全 action で plan をフォームから読み取り、fail / confirmStep レスポンスに含めて引き継ぐ
- confirm action の最後（consent 記録成功後 / `/admin` リダイレクト前）で、plan が有効かつライセンスキー未指定なら `startTrial({ source: 'user_initiated', tier })` を呼ぶ
- 失敗（既に使用済み・例外）は best-effort でログのみ残し `/admin` へ進む

## テスト

`signup-actions.test.ts` に #766 ブロックとして 8 件追加:

- [x] plan=standard → `startTrial(tier='standard')` で呼ばれる
- [x] plan=family → `startTrial(tier='family')` で呼ばれる
- [x] plan 未指定 → `startTrial` 呼ばれない
- [x] plan='free' / 'enterprise' → 無効値として無視
- [x] plan='STANDARD'（大文字）→ 小文字正規化してトライアル開始
- [x] licenseKey 指定時 → ライセンス優先でトライアル自動開始スキップ
- [x] `startTrial` が false を返しても `/admin` へ進む
- [x] `startTrial` が例外を投げても `/admin` へ進む（ログのみ）

全 30 件パス（既存 22 件 + 新規 8 件）。

## Acceptance Criteria

- [x] /pricing → signup → 自動トライアル開始が動作（unit テストで検証）
- [x] 不正な plan パラメータ（無効値）は無視
- [x] 回帰防止のユニットテストを追加

## 備考 — E2E について

cognito-dev モードでは `/auth/signup` が `/auth/login` にリダイレクトされるため、サインアップフロー全体の E2E テストは現状の dev 環境では不可能。本 PR では unit テスト（action ロジックを完全モック）で検証する方針をとった。本番 Cognito を使う E2E は別 issue（#757）でカバー予定。

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)