### PR TITLE
fix: #735 週次メールレポートを standard+ プランに限定

### DIFF
--- a/src/routes/(parent)/admin/reports/+page.server.ts
+++ b/src/routes/(parent)/admin/reports/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { createPlanLimitError } from '$lib/domain/errors';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getSettings, setSetting } from '$lib/server/db/settings-repo';
 import { logger } from '$lib/server/logger';
@@ -133,7 +134,11 @@ export const actions: Actions = {
 		);
 		if (planTier === 'free') {
 			return fail(403, {
-				error: '週次メールレポートはスタンダードプラン以上でご利用いただけます',
+				error: createPlanLimitError(
+					planTier,
+					'standard',
+					'週次メールレポートはスタンダードプラン以上でご利用いただけます',
+				),
 			});
 		}
 

--- a/src/routes/(parent)/admin/reports/+page.server.ts
+++ b/src/routes/(parent)/admin/reports/+page.server.ts
@@ -3,6 +3,7 @@ import { requireTenantId } from '$lib/server/auth/factory';
 import { getSettings, setSetting } from '$lib/server/db/settings-repo';
 import { logger } from '$lib/server/logger';
 import { getAllChildren } from '$lib/server/services/child-service';
+import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import { computeAllChildrenDetailedReport } from '$lib/server/services/report-service';
 import {
 	getMonthlyRanking,
@@ -31,6 +32,9 @@ export const load: PageServerLoad = async ({ locals, url, parent }) => {
 	// ランキングデータ取得（ファミリープラン用、#373）
 	const parentData = await parent();
 	const isFamily = parentData.planTier === 'family';
+	// #735: 週次メールレポートは standard+ 特典。free はプレビューのみ、設定不可
+	const planTier = parentData.planTier;
+	const canReceiveWeeklyEmail = planTier !== 'free';
 
 	let rankingData: Awaited<ReturnType<typeof getWeeklyRanking>> | null = null;
 	let monthlyRankingData: Awaited<ReturnType<typeof getMonthlyRanking>> | null = null;
@@ -82,6 +86,8 @@ export const load: PageServerLoad = async ({ locals, url, parent }) => {
 			monthlyRankingData,
 			trendData,
 			isFamily,
+			planTier,
+			canReceiveWeeklyEmail,
 		};
 	} catch (e) {
 		logger.error('月次レポート取得エラー', { context: { error: String(e) } });
@@ -99,6 +105,8 @@ export const load: PageServerLoad = async ({ locals, url, parent }) => {
 			monthlyRankingData: null,
 			trendData: null,
 			isFamily,
+			planTier,
+			canReceiveWeeklyEmail,
 		};
 	}
 };
@@ -114,6 +122,21 @@ function getPrevMonth(yearMonth: string): [number, number] {
 export const actions: Actions = {
 	updateSettings: async ({ request, locals }) => {
 		const tenantId = requireTenantId(locals);
+
+		// #735: 無料プランは週次メールレポート設定を変更できない（サーバ側ゲート）。
+		// クライアント側で disabled 表示するが、フォーム改竄による回避を防ぐため
+		// サーバ側でも必ずプランを解決して拒否する。
+		const planTier = await resolveFullPlanTier(
+			tenantId,
+			locals.context?.licenseStatus ?? 'none',
+			locals.context?.plan,
+		);
+		if (planTier === 'free') {
+			return fail(403, {
+				error: '週次メールレポートはスタンダードプラン以上でご利用いただけます',
+			});
+		}
+
 		const fd = await request.formData();
 		const enabled = fd.get('enabled') === 'on' ? '1' : '0';
 		const day = String(fd.get('day') ?? 'monday');

--- a/src/routes/(parent)/admin/reports/+page.svelte
+++ b/src/routes/(parent)/admin/reports/+page.svelte
@@ -264,9 +264,41 @@ function maxCategoryCount(breakdown: Record<string, number>): number {
 		</div>
 	{:else}
 		<!-- Weekly Report Section (existing) -->
+
+		<!-- #735: 無料プラン向けアップセルバナー —
+			週次メールレポートは standard+ 特典のため free プランでは配信されない。
+			プレビューは引き続き表示するが、メール配信設定はロックしてアップグレード導線を示す。 -->
+		{#if !data.canReceiveWeeklyEmail}
+			<div
+				data-testid="weekly-report-upsell"
+				class="rounded-xl border border-[var(--color-border-premium)] bg-[var(--color-surface-trial)] p-4"
+			>
+				<p class="text-sm font-bold text-[var(--color-text-primary)]">
+					✉️ 週次メールレポートはスタンダードプラン以上の特典です
+				</p>
+				<p class="mt-1 text-xs text-[var(--color-text-secondary)]">
+					毎週設定した曜日に、お子さまのがんばりをまとめたレポートがメールで届きます。
+					下のプレビューはいつでもご覧いただけます。
+				</p>
+				<div class="mt-3">
+					<a
+						href="/pricing"
+						class="inline-flex items-center gap-1 rounded-lg bg-[var(--color-action-trial-upgrade)] px-3 py-1.5 text-xs font-semibold text-[var(--color-text-inverse)] hover:bg-[var(--color-action-trial-upgrade-hover)]"
+					>
+						プランを見る →
+					</a>
+				</div>
+			</div>
+		{/if}
+
 		<!-- 設定セクション -->
 		<form method="POST" action="?/updateSettings" use:enhance class="rounded-xl border bg-white p-4">
 			<h3 class="mb-3 text-sm font-bold text-[var(--color-text-primary)]">⚙️ レポート設定</h3>
+			{#if !data.canReceiveWeeklyEmail}
+				<p class="mb-3 text-xs text-[var(--color-text-muted)]">
+					スタンダードプラン以上でメール配信設定を変更できます
+				</p>
+			{/if}
 			<div class="flex flex-wrap items-center gap-4">
 				<FormField label="週次レポートを有効にする">
 					{#snippet children()}
@@ -274,20 +306,25 @@ function maxCategoryCount(breakdown: Record<string, number>): number {
 							type="checkbox"
 							name="enabled"
 							checked={data.settings.enabled}
-							class="h-4 w-4 rounded border-[var(--color-border-strong)]"
+							disabled={!data.canReceiveWeeklyEmail}
+							class="h-4 w-4 rounded border-[var(--color-border-strong)] disabled:opacity-50"
 						/>
 					{/snippet}
 				</FormField>
 				<FormField label="配信曜日">
 					{#snippet children()}
-						<select name="day" class="rounded-[var(--input-radius)] border bg-[var(--input-bg)] px-2 py-1 text-sm">
+						<select
+							name="day"
+							disabled={!data.canReceiveWeeklyEmail}
+							class="rounded-[var(--input-radius)] border bg-[var(--input-bg)] px-2 py-1 text-sm disabled:opacity-50"
+						>
 							{#each Object.entries(dayLabels) as [value, label]}
 								<option {value} selected={data.settings.day === value}>{label}</option>
 							{/each}
 						</select>
 					{/snippet}
 				</FormField>
-				<Button type="submit" variant="primary" size="sm">
+				<Button type="submit" variant="primary" size="sm" disabled={!data.canReceiveWeeklyEmail}>
 					保存
 				</Button>
 			</div>

--- a/src/routes/api/v1/admin/weekly-report/+server.ts
+++ b/src/routes/api/v1/admin/weekly-report/+server.ts
@@ -1,10 +1,20 @@
 // src/routes/api/v1/admin/weekly-report/+server.ts
 // 週次活動レポートメール送信（EventBridge / 手動トリガー用）
+//
+// #735: 週次メールレポートはスタンダードプラン以上の特典。
+// /pricing の features で「週次メールレポート」と明示しているにもかかわらず、
+// 旧実装は全テナント（無料プラン含む）に配信しており、
+//   - 課金動機を削ぐ（有料プラン特典の価値毀損）
+//   - SES 送信コストが想定比率を超過する
+//   - HP と実装の乖離で課金ユーザーが不公平感を持つ
+// という三重の問題があった。本エンドポイントでプラン解決→free は早期 return する。
 
 import { json } from '@sveltejs/kit';
 import { logger } from '$lib/server/logger';
 import type { WeeklyReportData } from '$lib/server/services/email-service';
 import { sendWeeklyReportEmail } from '$lib/server/services/email-service';
+import { getLicenseInfo } from '$lib/server/services/license-service';
+import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request }) => {
@@ -26,6 +36,30 @@ export const POST: RequestHandler = async ({ request }) => {
 			children: WeeklyReportData[];
 		};
 
+		// #735: プランゲート — 無料プランは送信スキップ
+		// licenseInfo が取得できない場合は安全側に倒してスキップ（未知のテナントには送らない）
+		const licenseInfo = await getLicenseInfo(body.tenantId);
+		if (!licenseInfo) {
+			logger.warn('[weekly-report] テナント情報が見つからないため送信スキップ', {
+				context: { tenantId: body.tenantId },
+			});
+			return json({
+				success: true,
+				sent: 0,
+				total: body.children.length,
+				skipped: 'tenant_not_found',
+			});
+		}
+
+		const planTier = await resolveFullPlanTier(body.tenantId, licenseInfo.status, licenseInfo.plan);
+
+		if (planTier === 'free') {
+			logger.info('[weekly-report] 無料プランのため送信スキップ', {
+				context: { tenantId: body.tenantId, total: body.children.length },
+			});
+			return json({ success: true, sent: 0, total: body.children.length, skipped: 'free_plan' });
+		}
+
 		let sent = 0;
 		for (const child of body.children) {
 			const ok = await sendWeeklyReportEmail(body.ownerEmail, child);
@@ -33,10 +67,10 @@ export const POST: RequestHandler = async ({ request }) => {
 		}
 
 		logger.info('[weekly-report] レポート送信完了', {
-			context: { tenantId: body.tenantId, sent, total: body.children.length },
+			context: { tenantId: body.tenantId, planTier, sent, total: body.children.length },
 		});
 
-		return json({ success: true, sent, total: body.children.length });
+		return json({ success: true, sent, total: body.children.length, planTier });
 	} catch (err) {
 		logger.error('[weekly-report] レポート送信失敗', { error: String(err) });
 		return json({ error: 'Internal error' }, { status: 500 });

--- a/tests/unit/routes/admin-reports-plan-gate.test.ts
+++ b/tests/unit/routes/admin-reports-plan-gate.test.ts
@@ -1,0 +1,212 @@
+// tests/unit/routes/admin-reports-plan-gate.test.ts
+// #735: /admin/reports load で canReceiveWeeklyEmail が plan tier に応じて正しく
+// 計算されて UI 側に配布されること、および updateSettings action が free プランの
+// フォーム POST を 403 で拒否することを検証する。
+//
+// 観点:
+// - free → canReceiveWeeklyEmail=false
+// - standard / family → canReceiveWeeklyEmail=true
+// - free で updateSettings を POST → 403（フォーム改竄による回避を防ぐ）
+// - standard で updateSettings を POST → setSetting が呼ばれる
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- モック ---
+
+const mockGetSettings = vi.fn();
+const mockSetSetting = vi.fn();
+vi.mock('$lib/server/db/settings-repo', () => ({
+	getSettings: (...args: unknown[]) => mockGetSettings(...args),
+	setSetting: (...args: unknown[]) => mockSetSetting(...args),
+}));
+
+const mockResolveFullPlanTier = vi.fn();
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	resolveFullPlanTier: (...args: unknown[]) => mockResolveFullPlanTier(...args),
+}));
+
+const mockGetAllChildren = vi.fn();
+vi.mock('$lib/server/services/child-service', () => ({
+	getAllChildren: (...args: unknown[]) => mockGetAllChildren(...args),
+}));
+
+const mockGenerateReportsForChildren = vi.fn();
+vi.mock('$lib/server/services/weekly-report-service', () => ({
+	generateReportsForChildren: (...args: unknown[]) => mockGenerateReportsForChildren(...args),
+}));
+
+const mockComputeAllChildrenDetailedReport = vi.fn();
+vi.mock('$lib/server/services/report-service', () => ({
+	computeAllChildrenDetailedReport: (...args: unknown[]) =>
+		mockComputeAllChildrenDetailedReport(...args),
+}));
+
+vi.mock('$lib/server/services/sibling-ranking-service', () => ({
+	getMonthlyRanking: vi.fn().mockResolvedValue(null),
+	getRankingTrend: vi.fn().mockResolvedValue(null),
+	getWeeklyRanking: vi.fn().mockResolvedValue(null),
+	isRankingEnabled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: (locals: { context?: { tenantId?: string } }) => {
+		if (!locals.context?.tenantId) throw new Error('Unauthorized');
+		return locals.context.tenantId;
+	},
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { load, actions } = await import('../../../src/routes/(parent)/admin/reports/+page.server');
+
+// --- ヘルパ ---
+
+type PlanTier = 'free' | 'standard' | 'family';
+
+function primeCommonMocks(tier: PlanTier) {
+	mockResolveFullPlanTier.mockResolvedValue(tier);
+	mockGetSettings.mockResolvedValue({});
+	mockGetAllChildren.mockResolvedValue([{ id: 1, nickname: 'たろう' }]);
+	mockGenerateReportsForChildren.mockResolvedValue([]);
+	mockComputeAllChildrenDetailedReport.mockResolvedValue([]);
+}
+
+function makeLoadEvent(tier: PlanTier) {
+	return {
+		locals: {
+			context: {
+				tenantId: 't-test',
+				licenseStatus: tier === 'free' ? 'none' : 'active',
+				plan:
+					tier === 'family'
+						? 'family_monthly'
+						: tier === 'standard'
+							? 'standard_monthly'
+							: undefined,
+			},
+		},
+		url: new URL('http://localhost/admin/reports'),
+		parent: async () => ({ planTier: tier }),
+	} as unknown as Parameters<NonNullable<typeof load>>[0];
+}
+
+function makeFormEvent(tier: PlanTier, formEntries: Record<string, string> = {}) {
+	const fd = new FormData();
+	for (const [k, v] of Object.entries(formEntries)) fd.set(k, v);
+	return {
+		request: {
+			formData: async () => fd,
+		},
+		locals: {
+			context: {
+				tenantId: 't-test',
+				licenseStatus: tier === 'free' ? 'none' : 'active',
+				plan:
+					tier === 'family'
+						? 'family_monthly'
+						: tier === 'standard'
+							? 'standard_monthly'
+							: undefined,
+			},
+		},
+	} as unknown as Parameters<NonNullable<typeof actions.updateSettings>>[0];
+}
+
+// --- tests ---
+
+describe('GET /admin/reports load — weekly mail plan gate (#735)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('free プランでは canReceiveWeeklyEmail=false を返す', async () => {
+		primeCommonMocks('free');
+		// biome-ignore lint/style/noNonNullAssertion: load is defined
+		const result = (await load!(makeLoadEvent('free'))) as {
+			canReceiveWeeklyEmail: boolean;
+			planTier: PlanTier;
+		};
+		expect(result.canReceiveWeeklyEmail).toBe(false);
+		expect(result.planTier).toBe('free');
+	});
+
+	it('standard プランでは canReceiveWeeklyEmail=true を返す', async () => {
+		primeCommonMocks('standard');
+		// biome-ignore lint/style/noNonNullAssertion: load is defined
+		const result = (await load!(makeLoadEvent('standard'))) as {
+			canReceiveWeeklyEmail: boolean;
+			planTier: PlanTier;
+		};
+		expect(result.canReceiveWeeklyEmail).toBe(true);
+		expect(result.planTier).toBe('standard');
+	});
+
+	it('family プランでは canReceiveWeeklyEmail=true を返す', async () => {
+		primeCommonMocks('family');
+		// biome-ignore lint/style/noNonNullAssertion: load is defined
+		const result = (await load!(makeLoadEvent('family'))) as {
+			canReceiveWeeklyEmail: boolean;
+			planTier: PlanTier;
+		};
+		expect(result.canReceiveWeeklyEmail).toBe(true);
+		expect(result.planTier).toBe('family');
+	});
+});
+
+describe('POST /admin/reports?/updateSettings — server side plan gate (#735)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('free プランの POST は 403 で拒否し setSetting は呼ばれない', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('free');
+
+		// biome-ignore lint/style/noNonNullAssertion: action defined
+		const result = await actions.updateSettings!(
+			makeFormEvent('free', { enabled: 'on', day: 'monday' }),
+		);
+
+		// ActionFailure はオブジェクトで返る（throw しない）
+		expect((result as { status?: number }).status).toBe(403);
+		expect(mockSetSetting).not.toHaveBeenCalled();
+	});
+
+	it('standard プランの POST は setSetting を呼ぶ', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('standard');
+
+		// biome-ignore lint/style/noNonNullAssertion: action defined
+		const result = await actions.updateSettings!(
+			makeFormEvent('standard', { enabled: 'on', day: 'friday' }),
+		);
+
+		expect((result as { settingsUpdated?: boolean }).settingsUpdated).toBe(true);
+		expect(mockSetSetting).toHaveBeenCalledWith('weekly_report_enabled', '1', 't-test');
+		expect(mockSetSetting).toHaveBeenCalledWith('weekly_report_day', 'friday', 't-test');
+	});
+
+	it('family プランの POST も setSetting を呼ぶ', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('family');
+
+		// biome-ignore lint/style/noNonNullAssertion: action defined
+		const result = await actions.updateSettings!(
+			makeFormEvent('family', { enabled: '', day: 'sunday' }),
+		);
+
+		expect((result as { settingsUpdated?: boolean }).settingsUpdated).toBe(true);
+		expect(mockSetSetting).toHaveBeenCalledWith('weekly_report_enabled', '0', 't-test');
+	});
+
+	it('standard プランでも無効な曜日は 400', async () => {
+		mockResolveFullPlanTier.mockResolvedValue('standard');
+
+		// biome-ignore lint/style/noNonNullAssertion: action defined
+		const result = await actions.updateSettings!(
+			makeFormEvent('standard', { enabled: 'on', day: 'invalid-day' }),
+		);
+
+		expect((result as { status?: number }).status).toBe(400);
+		expect(mockSetSetting).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/routes/admin-reports-plan-gate.test.ts
+++ b/tests/unit/routes/admin-reports-plan-gate.test.ts
@@ -160,16 +160,26 @@ describe('POST /admin/reports?/updateSettings — server side plan gate (#735)',
 		vi.clearAllMocks();
 	});
 
-	it('free プランの POST は 403 で拒否し setSetting は呼ばれない', async () => {
+	it('free プランの POST は 403 + PlanLimitError 形式で拒否し setSetting は呼ばれない (#787)', async () => {
 		mockResolveFullPlanTier.mockResolvedValue('free');
 
 		// biome-ignore lint/style/noNonNullAssertion: action defined
-		const result = await actions.updateSettings!(
+		const result = (await actions.updateSettings!(
 			makeFormEvent('free', { enabled: 'on', day: 'monday' }),
-		);
+		)) as {
+			status: number;
+			data: { error: { code: string; currentTier: string; requiredTier: string } };
+		};
 
 		// ActionFailure はオブジェクトで返る（throw しない）
-		expect((result as { status?: number }).status).toBe(403);
+		expect(result.status).toBe(403);
+		// #787: PlanLimitError 形式で返る
+		expect(result.data.error).toMatchObject({
+			code: 'PLAN_LIMIT_EXCEEDED',
+			currentTier: 'free',
+			requiredTier: 'standard',
+			upgradeUrl: '/admin/license',
+		});
 		expect(mockSetSetting).not.toHaveBeenCalled();
 	});
 

--- a/tests/unit/routes/weekly-report-api.test.ts
+++ b/tests/unit/routes/weekly-report-api.test.ts
@@ -1,0 +1,241 @@
+// tests/unit/routes/weekly-report-api.test.ts
+// #735: /api/v1/admin/weekly-report のプランゲート検証
+//
+// HP の /pricing で「週次メールレポート」は standard+ 特典として明示されているのに、
+// 旧実装は全テナント（無料プラン含む）に配信していた。本テストは
+//  - free プランでは sendWeeklyReportEmail が 1 度も呼ばれない
+//  - standard / family プランでは各子供分 sendWeeklyReportEmail が呼ばれる
+//  - テナント情報が取れない場合は安全側に倒して送信しない
+//  - CRON_SECRET が不一致なら 401（プランゲートより前に弾く）
+// の 4 点を保証する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- モック ---
+
+const mockSendWeeklyReportEmail = vi.fn();
+vi.mock('$lib/server/services/email-service', () => ({
+	sendWeeklyReportEmail: (...args: unknown[]) => mockSendWeeklyReportEmail(...args),
+}));
+
+const mockGetLicenseInfo = vi.fn();
+vi.mock('$lib/server/services/license-service', () => ({
+	getLicenseInfo: (...args: unknown[]) => mockGetLicenseInfo(...args),
+}));
+
+const mockResolveFullPlanTier = vi.fn();
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	resolveFullPlanTier: (...args: unknown[]) => mockResolveFullPlanTier(...args),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { POST } = await import('../../../src/routes/api/v1/admin/weekly-report/+server');
+
+// --- ヘルパ ---
+
+type ChildReport = {
+	childName: string;
+	weekStart: string;
+	weekEnd: string;
+	totalActivities: number;
+	totalPoints: number;
+	categories: { name: string; count: number; points: number }[];
+};
+
+function makeChildren(count: number): ChildReport[] {
+	return Array.from({ length: count }, (_, i) => ({
+		childName: `子供${i + 1}`,
+		weekStart: '2026-04-01',
+		weekEnd: '2026-04-07',
+		totalActivities: 5,
+		totalPoints: 50,
+		categories: [{ name: 'うんどう', count: 5, points: 50 }],
+	}));
+}
+
+function makeEvent(
+	opts: {
+		tenantId?: string;
+		ownerEmail?: string;
+		childCount?: number;
+		cronSecret?: string | null;
+	} = {},
+) {
+	const body = JSON.stringify({
+		tenantId: opts.tenantId ?? 'tenant-test',
+		ownerEmail: opts.ownerEmail ?? 'parent@example.com',
+		children: makeChildren(opts.childCount ?? 2),
+	});
+	const headers = new Headers({ 'Content-Type': 'application/json' });
+	if (opts.cronSecret !== null && opts.cronSecret !== undefined) {
+		headers.set('x-cron-secret', opts.cronSecret);
+	}
+	const request = new Request('http://localhost/api/v1/admin/weekly-report', {
+		method: 'POST',
+		headers,
+		body,
+	});
+	return { request } as unknown as Parameters<typeof POST>[0];
+}
+
+function primeLicense(tier: 'free' | 'standard' | 'family' | null) {
+	if (tier === null) {
+		mockGetLicenseInfo.mockResolvedValue(null);
+		return;
+	}
+	mockGetLicenseInfo.mockResolvedValue({
+		plan: tier === 'free' ? 'free' : `${tier}_monthly`,
+		status: tier === 'free' ? 'none' : 'active',
+		tenantName: 'Test Tenant',
+		createdAt: '2026-01-01',
+		updatedAt: '2026-01-01',
+	});
+	mockResolveFullPlanTier.mockResolvedValue(tier);
+}
+
+// --- テスト ---
+
+describe('POST /api/v1/admin/weekly-report (#735 プランゲート)', () => {
+	const ORIGINAL_ENV = { ...process.env };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// CRON_SECRET / AUTH_MODE は各テストで明示的に設定
+		process.env = { ...ORIGINAL_ENV };
+		delete process.env.CRON_SECRET;
+		delete process.env.AUTH_MODE;
+		process.env.AUTH_MODE = 'local'; // default: 認証をバイパス（CRON_SECRET 未設定でも通す）
+		mockSendWeeklyReportEmail.mockResolvedValue(true);
+	});
+
+	it('無料プランは送信スキップし skipped:"free_plan" を返す（SES コスト流出防止）', async () => {
+		primeLicense('free');
+
+		const response = await POST(makeEvent({ childCount: 3 }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.success).toBe(true);
+		expect(body.sent).toBe(0);
+		expect(body.total).toBe(3);
+		expect(body.skipped).toBe('free_plan');
+		// ガード条件: send が 1 度も呼ばれていないこと（無料ユーザーに 1 通でも届けば NG）
+		expect(mockSendWeeklyReportEmail).not.toHaveBeenCalled();
+	});
+
+	it('standard プランでは全子供分 sendWeeklyReportEmail が呼ばれる', async () => {
+		primeLicense('standard');
+
+		const response = await POST(makeEvent({ childCount: 2, ownerEmail: 'pro@example.com' }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.sent).toBe(2);
+		expect(body.total).toBe(2);
+		expect(body.skipped).toBeUndefined();
+		expect(mockSendWeeklyReportEmail).toHaveBeenCalledTimes(2);
+		// 宛先は全て ownerEmail
+		for (const call of mockSendWeeklyReportEmail.mock.calls) {
+			expect(call[0]).toBe('pro@example.com');
+		}
+	});
+
+	it('family プランでは全子供分 sendWeeklyReportEmail が呼ばれる', async () => {
+		primeLicense('family');
+
+		const response = await POST(makeEvent({ childCount: 4 }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.sent).toBe(4);
+		expect(body.total).toBe(4);
+		expect(mockSendWeeklyReportEmail).toHaveBeenCalledTimes(4);
+	});
+
+	it('トライアル中（tier=standard）は free ではないので送信される', async () => {
+		// resolveFullPlanTier がトライアル解決済みで standard を返すケース
+		mockGetLicenseInfo.mockResolvedValue({
+			plan: 'free',
+			status: 'none',
+			tenantName: 'Trial Tenant',
+			createdAt: '2026-01-01',
+			updatedAt: '2026-01-01',
+		});
+		mockResolveFullPlanTier.mockResolvedValue('standard');
+
+		const response = await POST(makeEvent({ childCount: 1 }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.sent).toBe(1);
+		expect(mockSendWeeklyReportEmail).toHaveBeenCalledTimes(1);
+	});
+
+	it('テナント情報が見つからない場合は送信スキップ（安全側）', async () => {
+		primeLicense(null);
+
+		const response = await POST(makeEvent({ childCount: 2 }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.sent).toBe(0);
+		expect(body.skipped).toBe('tenant_not_found');
+		expect(mockSendWeeklyReportEmail).not.toHaveBeenCalled();
+		// プラン解決すら呼ばれない（先に弾く）
+		expect(mockResolveFullPlanTier).not.toHaveBeenCalled();
+	});
+
+	it('CRON_SECRET が設定されていて x-cron-secret ヘッダが不一致なら 401（プラン解決前に拒否）', async () => {
+		process.env.AUTH_MODE = 'saas';
+		process.env.CRON_SECRET = 'correct-secret';
+
+		const response = await POST(makeEvent({ cronSecret: 'wrong-secret' }));
+
+		expect(response.status).toBe(401);
+		expect(mockGetLicenseInfo).not.toHaveBeenCalled();
+		expect(mockSendWeeklyReportEmail).not.toHaveBeenCalled();
+	});
+
+	it('CRON_SECRET が一致しプランが standard なら正常に送信される', async () => {
+		process.env.AUTH_MODE = 'saas';
+		process.env.CRON_SECRET = 'correct-secret';
+		primeLicense('standard');
+
+		const response = await POST(makeEvent({ cronSecret: 'correct-secret', childCount: 1 }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.sent).toBe(1);
+	});
+
+	it('SaaS モード + CRON_SECRET 未設定は 500（運用ミスの早期検知）', async () => {
+		process.env.AUTH_MODE = 'saas';
+		delete process.env.CRON_SECRET;
+
+		const response = await POST(makeEvent({}));
+
+		expect(response.status).toBe(500);
+		expect(mockGetLicenseInfo).not.toHaveBeenCalled();
+		expect(mockSendWeeklyReportEmail).not.toHaveBeenCalled();
+	});
+
+	it('一部の送信が失敗しても全件試行し sent は成功数のみカウント', async () => {
+		primeLicense('family');
+		// 1 件目成功、2 件目失敗、3 件目成功
+		mockSendWeeklyReportEmail
+			.mockResolvedValueOnce(true)
+			.mockResolvedValueOnce(false)
+			.mockResolvedValueOnce(true);
+
+		const response = await POST(makeEvent({ childCount: 3 }));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.sent).toBe(2);
+		expect(body.total).toBe(3);
+		expect(mockSendWeeklyReportEmail).toHaveBeenCalledTimes(3);
+	});
+});


### PR DESCRIPTION
## Summary

#735 — 無料プランのテナントに週次メールレポートが配信されていた不具合を修正。/pricing で「週次メールレポート」は standard+ 特典として明示されているにもかかわらず、旧実装は全テナントに配信しており、課金動機の毀損・SES 送信コスト超過・HP と実装の乖離による不公平感という三重の問題を招いていた。

### 変更点

- **API エンドポイント (`/api/v1/admin/weekly-report`)**
  - `getLicenseInfo` + `resolveFullPlanTier` で tenant のプランを解決
  - `free` プランは `skipped: 'free_plan'` で送信スキップ（0 通）
  - tenant 情報が取得できない場合も安全側に倒してスキップ（`skipped: 'tenant_not_found'`）
  - トライアル中（resolveFullPlanTier が standard/family を返す）は送信対象

- **/admin/reports ページ**
  - load で `canReceiveWeeklyEmail = planTier !== 'free'` を配布
  - free プランはページ上部に upsell バナーを表示し、`/pricing` への導線を提示
  - 設定フォーム（曜日選択・enabled チェック・保存ボタン）は `disabled`
  - **`updateSettings` action もサーバ側でプラン解決し、free は 403 で拒否**（disabled を JS で外すようなフォーム改竄を防止）

### 追加テスト

- `tests/unit/routes/weekly-report-api.test.ts` (9 tests)
  - free / standard / family / tenant_not_found / CRON_SECRET mismatch / SaaS + no secret / 部分失敗カウント 等
- `tests/unit/routes/admin-reports-plan-gate.test.ts` (7 tests)
  - load: free → false, standard/family → true
  - action: free → 403, standard/family → setSetting 呼び出し, invalid day → 400

## Test plan

- [x] `npx vitest run tests/unit/routes/weekly-report-api.test.ts tests/unit/routes/admin-reports-plan-gate.test.ts` — 16/16 passing
- [x] `npx biome check` — changed files clean
- [x] `npx svelte-check` — 0 errors
- [ ] CI green（GitHub Actions）
- [ ] 実機 free プランで `/admin/reports` を開き upsell バナー表示と disabled UI を確認
- [ ] 実機 standard プランで設定保存 → 成功
- [ ] EventBridge cron で free プランへの配信が 0 件であることをログで確認（デプロイ後）

closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)