### PR TITLE
fix: #699 LP に中学生/高校生チャレンジ + ごほうびパック説明追加

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -761,8 +761,8 @@
           <span class="pack-activity">&#x1F4DD; 受験勉強・自主学習した</span>
           <span class="pack-activity">&#x1F30F; 英語学習した</span>
           <span class="pack-activity">&#x1F4BB; プログラミング・IT学習した</span>
-          <span class="pack-activity">&#x1F4BC; アルバイト・社会経験</span>
-          <span class="pack-activity">&#x1F3AF; 進路について考えた</span>
+          <span class="pack-activity">&#x1F91D; ボランティアに参加した</span>
+          <span class="pack-activity">&#x1F50D; 進路について調べた</span>
         </div>
       </div>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -696,7 +696,7 @@
       <div class="pack-card">
         <div class="pack-icon">&#x1F4DA;</div>
         <h3>しょうがくせいチャレンジ</h3>
-        <div class="pack-age">6&#x301C;12歳向け &#x30FB; 16件の活動</div>
+        <div class="pack-age">6&#x301C;9歳向け &#x30FB; 16件の活動</div>
         <p>学習習慣・運動・お手伝いをバランスよく組み合わせ、自主性を育てます。</p>
         <div class="pack-tags">
           <span class="pack-tag">小学生</span>
@@ -729,10 +729,137 @@
           <span class="pack-activity">&#x1F331; みずやりした</span>
         </div>
       </div>
+      <div class="pack-card">
+        <div class="pack-icon">&#x1F3AF;</div>
+        <h3>中学生チャレンジ</h3>
+        <div class="pack-age">10&#x301C;14歳向け &#x30FB; 16件の活動</div>
+        <p>学習・自己管理・社会性をバランスよく組み合わせ、自律心を育てます。</p>
+        <div class="pack-tags">
+          <span class="pack-tag">中学生</span>
+          <span class="pack-tag">自律</span>
+          <span class="pack-tag">学習習慣</span>
+        </div>
+        <div class="pack-activities">
+          <span class="pack-activity">&#x1F4DD; 予習・復習した</span>
+          <span class="pack-activity">&#x1F30F; 英語の勉強をした</span>
+          <span class="pack-activity">&#x1F4BB; プログラミングをした</span>
+          <span class="pack-activity">&#x1F4AA; 筋トレ・ストレッチした</span>
+          <span class="pack-activity">&#x26BD; 部活・習い事に行った</span>
+        </div>
+      </div>
+      <div class="pack-card">
+        <div class="pack-icon">&#x1F393;</div>
+        <h3>高校生チャレンジ</h3>
+        <div class="pack-age">15&#x301C;18歳向け &#x30FB; 16件の活動</div>
+        <p>進路準備・自立スキル・キャリアを意識した活動で、社会に出る準備を支援します。</p>
+        <div class="pack-tags">
+          <span class="pack-tag">高校生</span>
+          <span class="pack-tag">進路</span>
+          <span class="pack-tag">自立</span>
+        </div>
+        <div class="pack-activities">
+          <span class="pack-activity">&#x1F4DD; 受験勉強・自主学習した</span>
+          <span class="pack-activity">&#x1F30F; 英語学習した</span>
+          <span class="pack-activity">&#x1F4BB; プログラミング・IT学習した</span>
+          <span class="pack-activity">&#x1F4BC; アルバイト・社会経験</span>
+          <span class="pack-activity">&#x1F3AF; 進路について考えた</span>
+        </div>
+      </div>
     </div>
     <p class="pack-note">
+      0&#x301C;18歳まで、6つの活動パックで全年齢をカバー。<br>
       セットアップ時にお子さまの年齢にぴったりのパックを自動でおすすめ。<br>
       もちろん、活動パックはあとからいつでも追加・カスタマイズできます。
+    </p>
+  </div>
+</section>
+
+<!-- Reward Packs (#699) -->
+<section class="section bg-white" id="reward-packs">
+  <div class="section-inner">
+    <h2 class="section-title">特別なごほうび &#8212; がんばりを「価値」に変える</h2>
+    <p class="section-desc">毎日のシール・ポイントとは別に、「特別なごほうび」で大きな達成を称えられます。<br>年齢に応じた推奨ごほうびテンプレートを用意しています。</p>
+    <div class="pack-grid">
+      <div class="pack-card">
+        <div class="pack-icon">&#x1F4DA;</div>
+        <h3>がくしゅう系ごほうび</h3>
+        <div class="pack-age">全年齢 &#x30FB; academic カテゴリ</div>
+        <p>テスト100点・漢字検定合格・自由研究完成など、学習成果を特別に称えます。</p>
+        <div class="pack-tags">
+          <span class="pack-tag">学習</span>
+          <span class="pack-tag">高ポイント</span>
+        </div>
+        <div class="pack-activities">
+          <span class="pack-activity">&#x1F4AF; テスト100点</span>
+          <span class="pack-activity">&#x1F396;&#xFE0F; 検定合格</span>
+          <span class="pack-activity">&#x1F4DD; 自由研究完成</span>
+        </div>
+      </div>
+      <div class="pack-card">
+        <div class="pack-icon">&#x1F3C6;</div>
+        <h3>うんどう系ごほうび</h3>
+        <div class="pack-age">全年齢 &#x30FB; sports カテゴリ</div>
+        <p>大会出場・記録更新・継続達成など、運動・スポーツの頑張りを評価します。</p>
+        <div class="pack-tags">
+          <span class="pack-tag">運動</span>
+          <span class="pack-tag">継続</span>
+        </div>
+        <div class="pack-activities">
+          <span class="pack-activity">&#x1F3C5; 大会出場</span>
+          <span class="pack-activity">&#x1F3C3; 記録更新</span>
+          <span class="pack-activity">&#x26BD; 1ヶ月皆勤</span>
+        </div>
+      </div>
+      <div class="pack-card">
+        <div class="pack-icon">&#x1F91D;</div>
+        <h3>しゃかい系ごほうび</h3>
+        <div class="pack-age">全年齢 &#x30FB; social カテゴリ</div>
+        <p>お友達とのトラブル解決・ボランティア参加・年下のお世話など、社会性を育む達成を讃えます。</p>
+        <div class="pack-tags">
+          <span class="pack-tag">社会性</span>
+          <span class="pack-tag">思いやり</span>
+        </div>
+        <div class="pack-activities">
+          <span class="pack-activity">&#x1F4AC; なかなおりできた</span>
+          <span class="pack-activity">&#x1F49D; ボランティア参加</span>
+          <span class="pack-activity">&#x1F476; 年下のお世話</span>
+        </div>
+      </div>
+      <div class="pack-card">
+        <div class="pack-icon">&#x1F3A8;</div>
+        <h3>そうぞう系ごほうび</h3>
+        <div class="pack-age">全年齢 &#x30FB; creative カテゴリ</div>
+        <p>絵画コンクール入選・楽器発表会・作品完成など、表現活動の成果を称えます。</p>
+        <div class="pack-tags">
+          <span class="pack-tag">創造</span>
+          <span class="pack-tag">表現</span>
+        </div>
+        <div class="pack-activities">
+          <span class="pack-activity">&#x1F3A8; 作品完成</span>
+          <span class="pack-activity">&#x1F3B5; 発表会出演</span>
+          <span class="pack-activity">&#x1F4F8; 撮影・編集</span>
+        </div>
+      </div>
+      <div class="pack-card">
+        <div class="pack-icon">&#x1F33F;</div>
+        <h3>せいかつ系ごほうび</h3>
+        <div class="pack-age">全年齢 &#x30FB; life カテゴリ</div>
+        <p>長期の生活習慣達成・自立行動・特別なお手伝いなど、生活面の頑張りを讃えます。</p>
+        <div class="pack-tags">
+          <span class="pack-tag">生活習慣</span>
+          <span class="pack-tag">自立</span>
+        </div>
+        <div class="pack-activities">
+          <span class="pack-activity">&#x1F305; 早起き1ヶ月</span>
+          <span class="pack-activity">&#x1F37D;&#xFE0F; 1人で食事の準備</span>
+          <span class="pack-activity">&#x1F4B0; お小遣い管理</span>
+        </div>
+      </div>
+    </div>
+    <p class="pack-note">
+      &#x1F4A1; 特別なごほうびは、保護者がタイミングを見て即時付与できる「がんばりの価値化」装置です。<br>
+      お子さまにとって本当に大事な達成を、家庭ごとの基準で評価しましょう。<br>
+      <a href="https://ganbari-quest.com/marketplace">マーケットプレイス</a>で他の家庭が作ったテンプレートも参照できます。
     </p>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Closes #699
- LP (`site/index.html`) に **中学生チャレンジ (10〜14歳)** と **高校生チャレンジ (15〜18歳)** のパックカードを追加し、`src/lib/data/activity-packs/index.json` に登録済みの 6 種すべてが LP で紹介されるようにした
- 既存「しょうがくせいチャレンジ」の年齢表記を `6〜12歳向け` から `6〜9歳向け` に修正（実装と整合）
- 新セクション `#reward-packs` を新設し、特別なごほうびの 5 カテゴリ（がくしゅう / うんどう / しゃかい / そうぞう / せいかつ系）を説明
- マーケットプレイスへの導線をごほうびセクションにも追加

## Why
- Issue #699 で「HP に中学生/高校生チャレンジが載っておらず、保護者がプロダクトの全年齢対応性を認識できない」との指摘
- ごほうびパックの存在が LP で説明されておらず、課金プランの価値が伝わらない

## 並行実装チェック
- [x] `site/index.html` 更新（LP）
- [x] `src/lib/data/activity-packs/*.json` は既存通り（実装側は変更不要）
- [x] 用語: 既存活動名と整合（予習・復習した、進路について考えた 等）

## 検証
- [x] `node scripts/check-site-html.mjs` 通過（7 ファイル, エラーなし）
- [x] `node scripts/generate-lp-labels.mjs --check` 通過（site/shared-labels.js は最新）
- [x] `node scripts/check-forbidden-terms.mjs` 通過（禁止語なし）

## Test plan
- [ ] CI 通過確認
- [ ] LP デプロイ後、トップページから新セクションが視認できることを確認
- [ ] レビュアーによる文言確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)