### PR TITLE
feat: #760 デモモードでプラン切替トグル追加 (free/standard/family)

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,6 +4,11 @@ import { building } from '$app/environment';
 import { analytics } from '$lib/analytics';
 import { getAuthMode, getAuthProvider } from '$lib/server/auth/factory';
 import { applyDebugPlanOverride } from '$lib/server/debug-plan';
+import {
+	applyDemoPlanToContext,
+	DEMO_PLAN_COOKIE,
+	resolveDemoPlan,
+} from '$lib/server/demo/demo-plan';
 import { sendDiscordAlert } from '$lib/server/discord-alert';
 import { logger } from '$lib/server/logger';
 import { runWithRequestContext } from '$lib/server/request-context';
@@ -229,11 +234,30 @@ export const handle: Handle = ({ event, resolve }) =>
 		if (path.startsWith('/demo')) {
 			event.locals.authenticated = false;
 			event.locals.identity = null;
-			event.locals.context = applyDebugPlanOverride({
-				tenantId: 'demo',
-				role: 'owner',
-				licenseStatus: 'active',
-			});
+
+			// #760: ?plan= クエリ → cookie の優先順でデモプランを決定し、cookie に永続化する。
+			// デフォルトは family（最も価値が伝わるプランを最初に showcase）。
+			const planQuery = event.url.searchParams.get('plan');
+			const planCookie = event.cookies.get(DEMO_PLAN_COOKIE);
+			const demoPlan = resolveDemoPlan(planQuery, planCookie);
+			if (planQuery && planQuery !== planCookie) {
+				event.cookies.set(DEMO_PLAN_COOKIE, demoPlan, {
+					path: '/demo',
+					sameSite: 'lax',
+					httpOnly: false,
+					maxAge: 60 * 60 * 24 * 30, // 30 日
+				});
+			}
+
+			const baseDemoContext = applyDemoPlanToContext(
+				{
+					tenantId: 'demo',
+					role: 'owner',
+					licenseStatus: 'active',
+				},
+				demoPlan,
+			);
+			event.locals.context = applyDebugPlanOverride(baseDemoContext);
 			const response = await resolve(event);
 			if (!path.startsWith('/_app/') && !path.startsWith('/favicon')) {
 				logger.request(event.request.method, path, response.status, Date.now() - start, {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -7,6 +7,7 @@ import { applyDebugPlanOverride } from '$lib/server/debug-plan';
 import {
 	applyDemoPlanToContext,
 	DEMO_PLAN_COOKIE,
+	isDemoPlan,
 	resolveDemoPlan,
 } from '$lib/server/demo/demo-plan';
 import { sendDiscordAlert } from '$lib/server/discord-alert';
@@ -240,11 +241,11 @@ export const handle: Handle = ({ event, resolve }) =>
 			const planQuery = event.url.searchParams.get('plan');
 			const planCookie = event.cookies.get(DEMO_PLAN_COOKIE);
 			const demoPlan = resolveDemoPlan(planQuery, planCookie);
-			if (planQuery && planQuery !== planCookie) {
+			if (isDemoPlan(planQuery) && planQuery !== planCookie) {
 				event.cookies.set(DEMO_PLAN_COOKIE, demoPlan, {
 					path: '/demo',
 					sameSite: 'lax',
-					httpOnly: false,
+					httpOnly: true,
 					maxAge: 60 * 60 * 24 * 30, // 30 日
 				});
 			}

--- a/src/lib/features/demo/demo-analytics.ts
+++ b/src/lib/features/demo/demo-analytics.ts
@@ -13,7 +13,8 @@ type DemoEvent =
 	| 'demo_cta_click'
 	| 'demo_signup_page'
 	| 'demo_back_to_lp'
-	| 'demo_guide_see_pricing';
+	| 'demo_guide_see_pricing'
+	| 'demo_plan_switch';
 
 export function trackDemoEvent(event: DemoEvent, metadata?: Record<string, unknown>): void {
 	try {

--- a/src/lib/server/demo/demo-plan.ts
+++ b/src/lib/server/demo/demo-plan.ts
@@ -1,0 +1,52 @@
+// src/lib/server/demo/demo-plan.ts
+// #760: デモ画面で free / standard / family の各プランを切り替えて体験できる
+// 仕組みを提供する。`?plan=` クエリで切替、cookie で永続化する。
+//
+// `plan-limit-service.ts` の `resolvePlanTier` と整合する組み合わせ:
+//   - free     → licenseStatus='none',   plan=undefined
+//   - standard → licenseStatus='active', plan='monthly'
+//   - family   → licenseStatus='active', plan='family-monthly'
+//
+// デフォルトは family（最も価値が伝わるプランを最初に showcase する）。
+
+import type { AuthContext } from '$lib/server/auth/types';
+
+export type DemoPlan = 'free' | 'standard' | 'family';
+
+/** デモプラン保存用 Cookie 名 */
+export const DEMO_PLAN_COOKIE = 'demo_plan';
+
+/** デフォルトのデモプラン（最初の訪問で showcase される） */
+export const DEFAULT_DEMO_PLAN: DemoPlan = 'family';
+
+const VALID_PLANS: ReadonlySet<string> = new Set(['free', 'standard', 'family']);
+
+/** 文字列が DemoPlan として有効かどうか */
+export function isDemoPlan(value: unknown): value is DemoPlan {
+	return typeof value === 'string' && VALID_PLANS.has(value);
+}
+
+/**
+ * `?plan=` クエリ → cookie の優先順で現在のデモプランを解決する。
+ * クエリも cookie も無ければ DEFAULT_DEMO_PLAN を返す。
+ */
+export function resolveDemoPlan(query: string | null, cookie: string | undefined): DemoPlan {
+	if (query && isDemoPlan(query)) return query;
+	if (cookie && isDemoPlan(cookie)) return cookie;
+	return DEFAULT_DEMO_PLAN;
+}
+
+/**
+ * デモプランに対応する licenseStatus / plan を AuthContext に適用した
+ * 新しい context を返す。
+ */
+export function applyDemoPlanToContext(base: AuthContext, demoPlan: DemoPlan): AuthContext {
+	switch (demoPlan) {
+		case 'free':
+			return { ...base, licenseStatus: 'none', plan: undefined };
+		case 'standard':
+			return { ...base, licenseStatus: 'active', plan: 'monthly' };
+		case 'family':
+			return { ...base, licenseStatus: 'active', plan: 'family-monthly' };
+	}
+}

--- a/src/routes/demo/(parent)/admin/+page.server.ts
+++ b/src/routes/demo/(parent)/admin/+page.server.ts
@@ -4,21 +4,7 @@ import { getDemoAdminData } from '$lib/server/demo/demo-service.js';
 import { getPlanLimits, type PlanTier } from '$lib/server/services/plan-limit-service';
 import type { PageServerLoad } from './$types';
 
-/**
- * デモ用プランティアを URL クエリから解決する (#791, #760 連動)。
- *
- * `?plan=free|standard|family` で切り替え可能。未指定時は `standard`（最も典型的なユースケース）。
- * これにより「プラン訴求」「有料機能」「無料制限」いずれもデモで体験できる。
- */
-function resolveDemoPlanTier(url: URL): PlanTier {
-	const param = url.searchParams.get('plan');
-	if (param === 'free' || param === 'standard' || param === 'family') {
-		return param;
-	}
-	return 'standard';
-}
-
-export const load: PageServerLoad = async ({ url }) => {
+export const load: PageServerLoad = async ({ parent }) => {
 	const adminData = getDemoAdminData();
 	const children = adminData.children.map((child) => ({
 		...child,
@@ -27,7 +13,9 @@ export const load: PageServerLoad = async ({ url }) => {
 		levelTitle: '',
 	}));
 
-	const planTier = resolveDemoPlanTier(url);
+	// #760: プランはルート layout の demoPlan から取得（cookie/query の一元管理）
+	const parentData = await parent();
+	const planTier = parentData.demoPlan ?? 'family';
 	const limits = getPlanLimits(planTier);
 
 	// デモ用のプラン統計（固定値）。本番 /admin/license の planStats と同じ shape。

--- a/src/routes/demo/+layout.server.ts
+++ b/src/routes/demo/+layout.server.ts
@@ -1,0 +1,12 @@
+// src/routes/demo/+layout.server.ts
+// #760: デモプランを layout に渡して、プラン切替トグル UI が現在の選択を表示できるようにする。
+
+import { DEMO_PLAN_COOKIE, resolveDemoPlan } from '$lib/server/demo/demo-plan';
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = ({ url, cookies }) => {
+	const planQuery = url.searchParams.get('plan');
+	const planCookie = cookies.get(DEMO_PLAN_COOKIE);
+	const demoPlan = resolveDemoPlan(planQuery, planCookie);
+	return { demoPlan };
+};

--- a/src/routes/demo/+layout.svelte
+++ b/src/routes/demo/+layout.svelte
@@ -8,9 +8,16 @@ import NavigationProgress from '$lib/ui/components/NavigationProgress.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 
-let { children } = $props();
+let { data, children } = $props();
 
 const guide = getGuideState();
+
+// #760: デモプラン切替 — `?plan=family|standard|free` で切り替え、cookie で永続化される。
+const PLAN_OPTIONS = [
+	{ key: 'free', label: 'フリー' },
+	{ key: 'standard', label: 'スタンダード' },
+	{ key: 'family', label: 'ファミリー' },
+] as const;
 
 // Track demo page views on navigation
 $effect(() => {
@@ -60,7 +67,28 @@ $effect(() => {
 	</a>
 </div>
 
-<div class="pt-10">
+<!-- #760: デモプラン切替トグル — どのプランで体験中かを明示し、ワンクリックで切替できる -->
+<div
+	class="fixed top-10 left-0 right-0 z-40 bg-white/95 border-b border-[var(--color-border-light)] py-1 px-4 flex items-center justify-center gap-2 text-xs shadow-sm"
+	data-testid="demo-plan-switcher"
+>
+	<span class="text-[var(--color-text-muted)]">プラン体験:</span>
+	{#each PLAN_OPTIONS as opt (opt.key)}
+		<a
+			href="?plan={opt.key}"
+			class="px-2 py-0.5 rounded-full font-bold transition-colors {data.demoPlan === opt.key
+				? 'bg-[var(--color-action-primary)] text-white'
+				: 'bg-[var(--color-surface-muted)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-secondary)]'}"
+			data-testid="demo-plan-switch-{opt.key}"
+			data-active={data.demoPlan === opt.key}
+			onclick={() => trackDemoEvent('demo_plan_switch', { from: data.demoPlan, to: opt.key })}
+		>
+			{opt.label}
+		</a>
+	{/each}
+</div>
+
+<div class="pt-16">
 	{@render children()}
 </div>
 

--- a/src/routes/demo/+layout.svelte
+++ b/src/routes/demo/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import '$lib/ui/styles/app.css';
 import { page } from '$app/stores';
+import { PLAN_SHORT_LABELS, type PlanKey } from '$lib/domain/labels';
 import DemoGuideBar from '$lib/features/demo/DemoGuideBar.svelte';
 import { trackDemoEvent } from '$lib/features/demo/demo-analytics.js';
 import { getGuideState } from '$lib/features/demo/demo-guide-state.svelte.js';
@@ -13,11 +14,14 @@ let { data, children } = $props();
 const guide = getGuideState();
 
 // #760: デモプラン切替 — `?plan=family|standard|free` で切り替え、cookie で永続化される。
-const PLAN_OPTIONS = [
-	{ key: 'free', label: 'フリー' },
-	{ key: 'standard', label: 'スタンダード' },
-	{ key: 'family', label: 'ファミリー' },
-] as const;
+const PLAN_KEYS: PlanKey[] = ['free', 'standard', 'family'];
+
+/** 現在の URL の searchParams に plan だけ差し替えた URL 文字列を生成 */
+function planSwitchHref(key: string): string {
+	const url = new URL($page.url);
+	url.searchParams.set('plan', key);
+	return `${url.pathname}${url.search}`;
+}
 
 // Track demo page views on navigation
 $effect(() => {
@@ -73,17 +77,21 @@ $effect(() => {
 	data-testid="demo-plan-switcher"
 >
 	<span class="text-[var(--color-text-muted)]">プラン体験:</span>
-	{#each PLAN_OPTIONS as opt (opt.key)}
+	{#each PLAN_KEYS as key (key)}
 		<a
-			href="?plan={opt.key}"
-			class="px-2 py-0.5 rounded-full font-bold transition-colors {data.demoPlan === opt.key
+			href={planSwitchHref(key)}
+			class="px-2 py-0.5 rounded-full font-bold transition-colors {data.demoPlan === key
 				? 'bg-[var(--color-action-primary)] text-white'
 				: 'bg-[var(--color-surface-muted)] text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-secondary)]'}"
-			data-testid="demo-plan-switch-{opt.key}"
-			data-active={data.demoPlan === opt.key}
-			onclick={() => trackDemoEvent('demo_plan_switch', { from: data.demoPlan, to: opt.key })}
+			data-testid="demo-plan-switch-{key}"
+			data-active={data.demoPlan === key}
+			onclick={() => {
+				if (key !== data.demoPlan) {
+					trackDemoEvent('demo_plan_switch', { from: data.demoPlan, to: key });
+				}
+			}}
 		>
-			{opt.label}
+			{PLAN_SHORT_LABELS[key]}
 		</a>
 	{/each}
 </div>

--- a/tests/unit/demo/demo-plan.test.ts
+++ b/tests/unit/demo/demo-plan.test.ts
@@ -1,0 +1,123 @@
+// tests/unit/demo/demo-plan.test.ts
+// #760: デモ画面のプラン切替ヘルパーの単体テスト
+
+import { describe, expect, it } from 'vitest';
+import type { AuthContext } from '../../../src/lib/server/auth/types';
+import {
+	applyDemoPlanToContext,
+	DEFAULT_DEMO_PLAN,
+	DEMO_PLAN_COOKIE,
+	isDemoPlan,
+	resolveDemoPlan,
+} from '../../../src/lib/server/demo/demo-plan';
+
+describe('demo-plan helpers (#760)', () => {
+	describe('isDemoPlan', () => {
+		it('受け付ける値: free / standard / family', () => {
+			expect(isDemoPlan('free')).toBe(true);
+			expect(isDemoPlan('standard')).toBe(true);
+			expect(isDemoPlan('family')).toBe(true);
+		});
+
+		it('それ以外は false', () => {
+			expect(isDemoPlan('premium')).toBe(false);
+			expect(isDemoPlan('')).toBe(false);
+			expect(isDemoPlan(undefined)).toBe(false);
+			expect(isDemoPlan(null)).toBe(false);
+			expect(isDemoPlan(123)).toBe(false);
+			expect(isDemoPlan('FAMILY')).toBe(false); // case sensitive
+		});
+	});
+
+	describe('resolveDemoPlan', () => {
+		it('クエリ・cookie 共に未指定 → デフォルト (family)', () => {
+			expect(resolveDemoPlan(null, undefined)).toBe(DEFAULT_DEMO_PLAN);
+			expect(resolveDemoPlan(null, undefined)).toBe('family');
+		});
+
+		it('クエリが優先される', () => {
+			expect(resolveDemoPlan('standard', 'family')).toBe('standard');
+			expect(resolveDemoPlan('free', 'family')).toBe('free');
+		});
+
+		it('クエリが無効値 → cookie にフォールバック', () => {
+			expect(resolveDemoPlan('premium', 'standard')).toBe('standard');
+			expect(resolveDemoPlan('', 'family')).toBe('family');
+		});
+
+		it('クエリ無効・cookie 無効 → デフォルト', () => {
+			expect(resolveDemoPlan('xxx', 'yyy')).toBe(DEFAULT_DEMO_PLAN);
+		});
+
+		it('クエリ無し・cookie 有効 → cookie の値', () => {
+			expect(resolveDemoPlan(null, 'free')).toBe('free');
+			expect(resolveDemoPlan(null, 'standard')).toBe('standard');
+			expect(resolveDemoPlan(null, 'family')).toBe('family');
+		});
+	});
+
+	describe('applyDemoPlanToContext', () => {
+		const baseContext: AuthContext = {
+			tenantId: 'demo',
+			role: 'owner',
+			licenseStatus: 'active',
+		};
+
+		it('free → licenseStatus=none, plan=undefined', () => {
+			const ctx = applyDemoPlanToContext(baseContext, 'free');
+			expect(ctx.licenseStatus).toBe('none');
+			expect(ctx.plan).toBeUndefined();
+			expect(ctx.tenantId).toBe('demo'); // 他のフィールドは保持
+			expect(ctx.role).toBe('owner');
+		});
+
+		it('standard → licenseStatus=active, plan=monthly', () => {
+			const ctx = applyDemoPlanToContext(baseContext, 'standard');
+			expect(ctx.licenseStatus).toBe('active');
+			expect(ctx.plan).toBe('monthly');
+		});
+
+		it('family → licenseStatus=active, plan=family-monthly', () => {
+			const ctx = applyDemoPlanToContext(baseContext, 'family');
+			expect(ctx.licenseStatus).toBe('active');
+			expect(ctx.plan).toBe('family-monthly');
+		});
+
+		it('元のオブジェクトを破壊しない（イミュータブル）', () => {
+			const original: AuthContext = {
+				tenantId: 'demo',
+				role: 'owner',
+				licenseStatus: 'active',
+			};
+			applyDemoPlanToContext(original, 'free');
+			expect(original.licenseStatus).toBe('active'); // 変更されていない
+			expect(original.plan).toBeUndefined();
+		});
+	});
+
+	describe('DEMO_PLAN_COOKIE', () => {
+		it('cookie 名は demo_plan で固定', () => {
+			expect(DEMO_PLAN_COOKIE).toBe('demo_plan');
+		});
+	});
+
+	describe('plan-limit-service.resolvePlanTier との整合性', () => {
+		// resolvePlanTier の判定ロジックと一致させていることを保証する
+		// （plan?.startsWith('family') ? 'family' : 'standard'）
+		it('standard の plan は family で始まらない', () => {
+			const ctx = applyDemoPlanToContext(
+				{ tenantId: 'demo', role: 'owner', licenseStatus: 'active' },
+				'standard',
+			);
+			expect(ctx.plan?.startsWith('family')).toBe(false);
+		});
+
+		it('family の plan は family で始まる', () => {
+			const ctx = applyDemoPlanToContext(
+				{ tenantId: 'demo', role: 'owner', licenseStatus: 'active' },
+				'family',
+			);
+			expect(ctx.plan?.startsWith('family')).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Closes #760
- `/demo` 配下で `?plan=family|standard|free` クエリと `demo_plan` cookie によるプラン切替機構を追加
- 訪問者がワンクリックで free/standard/family の各プランの gated feature 体験を切替できる
- デフォルトは **family**（最も価値が伝わるプランを最初に showcase、CV 観点）

## 実装詳細

### 1. ヘルパー (`src/lib/server/demo/demo-plan.ts`)
- `DemoPlan` 型: `'free' | 'standard' | 'family'`
- `resolveDemoPlan(query, cookie)`: 優先順 `query → cookie → DEFAULT_DEMO_PLAN(family)`
- `applyDemoPlanToContext(base, plan)`: AuthContext に licenseStatus / plan を設定
  - `plan-limit-service.ts:resolvePlanTier` の判定ロジックと整合
- `DEMO_PLAN_COOKIE = 'demo_plan'` (path=/demo, sameSite=lax, 30日)

### 2. hooks.server.ts デモブランチ
- `event.url.searchParams.get('plan')` をチェック
- 明示変更時のみ cookie を上書き（毎リクエストの不要書込みを避ける）
- `applyDebugPlanOverride` で `DEBUG_PLAN` env が引き続き最優先

### 3. UI トグル (`src/routes/demo/+layout.svelte`)
- 既存デモバナー直下に固定配置（z-40, top-10）
- 3 ボタン: フリー / スタンダード / ファミリー
- 現在選択は `--color-action-primary` 背景でハイライト
- `data-testid="demo-plan-switch-{key}"` でテスト可
- `demo_plan_switch` イベントを analytics 送信（既存ファネル計測と統合）

### 4. layout server (`src/routes/demo/+layout.server.ts`)
- 既存 `(child)/+layout.server.ts` とは別に **demo root** 用の layout server を新設
- `data.demoPlan` を全デモページで参照可能に

## 検証

### Acceptance Criteria
- [x] /demo でファミリープランの機能が確認できる（デフォルト）
- [x] /demo でスタンダードプランも確認できる（`?plan=standard`）
- [x] /demo で無料プランの disabled 表示も確認できる（`?plan=free`）
- [x] 単体テスト追加（resolveDemoPlan / applyDemoPlanToContext / isDemoPlan）
- [ ] E2E テスト追加 → 別 Issue (#751 plan-free, #779 plan-standard/family) と統合方針

### 実行結果
- `npx svelte-check` — 0 errors
- `npx biome check` — clean
- `npx vitest run tests/unit/demo/ tests/unit/services/plan-limit-service.test.ts tests/unit/services/hooks-integration.test.ts tests/unit/routes/` — 170+ tests pass
- 新規追加 14 ケース全通過

## 並行実装チェック
- [x] hooks.server.ts デモブランチ（本番ハンドラは触らない）
- [x] `src/lib/server/demo/demo-plan.ts` 新規（既存 `demo-data.ts` / `demo-service.ts` の隣）
- [x] cookie 名は 1 箇所定数化（`DEMO_PLAN_COOKIE`）
- [x] DEBUG_PLAN env 上書きは引き続き最優先（dev workflow 互換）

## Test plan
- [ ] CI 通過確認
- [ ] /demo に普通にアクセス → デフォルトで family ハイライト
- [ ] トグルで standard/free に切替 → 該当プランの gated feature 表示が変わることを目視確認
- [ ] 別タブで /demo を開いた時に cookie で前回選択が引き継がれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)