### PR TITLE
docs: #746 アカウント削除フロー設計書 + drawio 図新設

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,7 @@ Design documents are the Single Source of Truth. A PR that changes the following
 | DB table/column add/change | `docs/design/08-データベース設計書.md` |
 | UI screen/component add/major change | `docs/design/06-UI設計書.md` |
 | AWS infrastructure change | `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` |
+| Account deletion flow add/change | `docs/design/account-deletion-flow.md` |
 | Auth/security change | Security design doc |
 | Brand/visual change | `docs/design/15-ブランドガイドライン.md` |
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -13,6 +13,7 @@
 | DB テーブル・カラムの追加・変更 | `08-データベース設計書.md` |
 | UI 機能・画面・オーバーレイの追加・変更 | `06-UI設計書.md` |
 | **UI プラン仕様の追加・変更**（FeatureGate / TrialBanner / PlanStatusCard / PremiumWelcome / disabled パターン） | `06-UI設計書.md §10` (#743) |
+| **アカウント削除フローの追加・変更**（5 パターン分岐 / fullTenantDeletion 順序 / Stripe 連動） | `account-deletion-flow.md` (#746) |
 | AWS インフラ構成の変更 | `13-AWSサーバレスアーキテクチャ設計書.md` |
 | 認証・セキュリティ関連の変更 | `14-セキュリティ設計書.md` |
 | デザイン・ビジュアル変更 | `15-ブランドガイドライン.md` |

--- a/docs/design/account-deletion-flow.md
+++ b/docs/design/account-deletion-flow.md
@@ -58,19 +58,39 @@ else                              pattern = 'member';
 
 ADR-0022 の原則に従い、**全データ削除を伴うパターン（1 / 2b）では DB 削除よりも先に Stripe Subscription をキャンセルする**。
 
+**Pattern 1 (`deleteOwnerOnlyAccount` → `fullTenantDeletion`):**
+
 ```
-[fullTenantDeletion]
+fullTenantDeletion(tenantId, ownerId)
   └─ 0. cancelSubscription(tenantId)   ← 失敗したら throw → 以降の処理は走らない
-  └─ 1. S3 削除
-  └─ 2. tenant scoped data 削除
-  └─ 3. children データ削除
-  └─ 4. members の Cognito ユーザー削除 + DB ユーザー削除
-  └─ 5. memberships 削除
-  └─ 6. invites 削除
-  └─ 7. tenant 削除
+  └─ 1. S3 削除 (deleteByPrefix)
+  └─ 2. tenant scoped data 削除 (deleteTenantScopedData)
+  └─ 3. children データ削除 (deleteAllChildrenData)
+  └─ 4. 全メンバーの Cognito + DB ユーザー削除 (findTenantMembers → deleteCognitoUser + deleteUser)
+  └─ 5. 全メンバーシップ削除 (deleteAllMemberships)
+  └─ 6. 招待リンク無効化 + 物理削除 (revokeAndDeleteAllInvites)
+  └─ 7. テナント削除 (deleteTenant)
   └─ 8. notifyDeletionComplete (失敗は無視)
-  └─ 9. (2b のみ) sendMemberRemovedEmail (失敗は無視)
 ```
+
+**Pattern 2b (`deleteOwnerFullDelete` — `fullTenantDeletion` は呼ばない):**
+
+```
+deleteOwnerFullDelete(tenantId, ownerId)
+  └─ 0. 他メンバー一覧 + メール情報を事前収集（削除後は取得不能）
+  └─ 1. cancelSubscription(tenantId)   ← 失敗したら throw
+  └─ 2. S3 削除 (deleteByPrefix)
+  └─ 3. tenant scoped data 削除 (deleteTenantScopedData)
+  └─ 4. children データ削除 (deleteAllChildrenData)
+  └─ 5. 招待リンク無効化 + 物理削除 (revokeAndDeleteAllInvites)
+  └─ 6. 全メンバーシップ削除 (deleteAllMemberships)
+  └─ 7. Owner のみ Cognito + DB ユーザー削除（他メンバーの Cognito は削除しない）
+  └─ 8. テナント削除 (deleteTenant)
+  └─ 9. notifyDeletionComplete (失敗は無視)
+  └─ 10. 他メンバーへ sendMemberRemovedEmail (失敗は無視)
+```
+
+> **Pattern 1 vs 2b の重要な違い**: Pattern 1 の `fullTenantDeletion` は全メンバーの Cognito ユーザーを削除する（テナントに owner しかいないため）。Pattern 2b の `deleteOwnerFullDelete` は **Owner の Cognito のみ削除**し、他メンバーの Cognito は残す（所属解除＋メール通知で対応）。
 
 **理由**: Stripe キャンセルが失敗したまま DB を削除すると、課金は継続しているのにテナントが消滅して問い合わせ窓口を失う。逆順なら、DB は残ったまま再試行できる。
 
@@ -80,11 +100,12 @@ ADR-0022 の原則に従い、**全データ削除を伴うパターン（1 / 2b
 
 **現状**: グレースピリオドは未実装。`fullTenantDeletion` は即時に物理削除する。
 
-**#742 で導入予定**:
+**#742 で導入予定（仕様は #742 で最終確定、以下は提案値）**:
 
-- standard プラン: グレースピリオドなし（即時削除）
-- family プラン: 30 日間の復元期間
-- 削除直後はテナントを `status=pending-delete` に遷移させ、`deletedAt+30d` の cron で実体削除
+- free プラン: グレースピリオドなし（即時削除）
+- standard プラン: 7 日間の復元期間
+- family プラン: 30 日間の復元期間 + 削除前エクスポートメール送信
+- グレースピリオドがあるプランは、削除直後にテナントを `status=pending-delete` に遷移させ、`deletedAt+planRetentionDays` の cron で実体削除
 - 復元 API（`/api/v1/admin/account/restore`）を用意し、メールリンクから 1 クリック復元できるようにする
 
 実装時に本ドキュメントの §2 のマトリクスに「pending-delete 中の状態」列を追加すること。
@@ -147,8 +168,8 @@ ADR-0022 の原則に従い、**全データ削除を伴うパターン（1 / 2b
   - #742 — グレースピリオド
   - #738 / #754 — ダウングレード前確認 / 超過リソース処理
 - ADR
-  - [ADR-0022](decisions/0022-billing-data-lifecycle-consistency.md) — 課金サイクルとデータライフサイクルの整合性
-  - [ADR-0003](decisions/0003-design-doc-as-source-of-truth.md) — 設計書 SSOT
+  - [ADR-0022](../decisions/0022-billing-data-lifecycle-consistency.md) — 課金サイクルとデータライフサイクルの整合性
+  - [ADR-0003](../decisions/0003-design-doc-as-source-of-truth.md) — 設計書 SSOT
 - 実装
   - `src/lib/server/services/account-deletion-service.ts`
   - `src/routes/api/v1/admin/account/delete/+server.ts`

--- a/docs/design/account-deletion-flow.md
+++ b/docs/design/account-deletion-flow.md
@@ -1,0 +1,164 @@
+# account-deletion-flow.md — アカウント削除フロー仕様 (#746)
+
+> アカウント削除は **5 つのパターン** に分岐する。本ドキュメントは各パターンの判定条件・UI フロー・サーバ側挙動・削除範囲・関連 Issue を 1 か所にまとめる SSOT である。実装は `src/lib/server/services/account-deletion-service.ts` および `src/routes/api/v1/admin/account/delete/+server.ts` を参照。
+
+---
+
+## 1. パターン一覧
+
+| # | DeletionPattern | 実行条件 | 主な操作 | 関連 Issue |
+|---|---|---|---|---|
+| 1 | `owner-only` | role=owner かつ 他メンバーなし | テナント全削除 + Owner Cognito 削除 | #458, #739, #741 |
+| 2a | `owner-with-transfer` | role=owner かつ 他メンバーあり | 権限を別メンバーに移譲 + Owner だけ離脱 | #458 |
+| 2b | `owner-full-delete` | role=owner かつ 他メンバーあり（移譲しない） | 全データ削除 + 他メンバーは所属解除 + メール通知 | #458, #739, #741 |
+| 3 | `child` | role=child 本人 | 子供アカウント切り離し + Cognito 削除 | #458 |
+| 4 | `member` | role=parent（非 owner） | メンバーシップ削除 + Cognito 削除 | #458 |
+
+> **注**: パターン 2 は内部的に 2a と 2b に分岐するが、API としては別々の DeletionPattern として渡す。UI では owner かつ他メンバーがいるとき、まず移譲ダイアログを表示し、ユーザーが「移譲」か「全削除」を選ぶ。
+
+判定の擬似コード（`src/routes/(parent)/admin/settings/+page.svelte` の `handleDeleteAccount`）:
+
+```ts
+const role = $page.data.userRole;
+if (role === 'owner') {
+  if (deletionInfo.isOnlyMember) pattern = 'owner-only';
+  else                            showTransferDialog = true; // → 2a または 2b を選択
+} else if (role === 'child')      pattern = 'child';
+else                              pattern = 'member';
+```
+
+---
+
+## 2. データクリア範囲マトリクス（#739 連動）
+
+各パターンで何が消えるかを下表で固定する。チェックなしは **削除されない**。
+
+| 対象 | 1. owner-only | 2a. transfer | 2b. full-delete | 3. child | 4. member |
+|------|---|---|---|---|---|
+| Stripe Subscription（#741 必須） | ✔ | ✘ | ✔ | ✘ | ✘ |
+| S3 / ストレージ（`tenants/{tenantId}/`） | ✔ | ✘ | ✔ | ✘ | ✘ |
+| `deleteTenantScopedData` (activities, viewerTokens, cloudExports, pushSubscriptions, voice) | ✔ | ✘ | ✔ | ✘ | ✘ |
+| 子供データ全件 (`deleteAllChildrenData`) | ✔ | ✘ | ✔ | ✘ | ✘ |
+| 全メンバーシップ (`deleteAllMemberships`) | ✔ | ✘ | ✔ | ✘ | ✘ |
+| 招待リンク (`revokeAndDeleteAllInvites`) | ✔ | ✘ | ✔ | ✘ | ✘ |
+| テナント本体 (`deleteTenant`) | ✔ | ✘ | ✔ | ✘ | ✘ |
+| 自分の Cognito ユーザー | ✔ | ✔ | ✔ | ✔ | ✔ |
+| 自分の DB ユーザー (`auth.deleteUser`) | ✔ | ✔ | ✔ | ✔ | ✔ |
+| 自分のメンバーシップ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| **新オーナー昇格** (テナント `ownerId` 付け替え) | — | ✔ | — | — | — |
+| 子供レコードと user の link 解除（`child.userId = null`） | — | — | — | ✔ | — |
+| 他メンバーへのメール通知（`sendMemberRemovedEmail`） | — | — | ✔ | — | — |
+| Discord 通知（`notifyDeletionComplete`） | ✔ | — | ✔ | — | — |
+
+> **重要**: パターン 3 (`deleteChildAccount`) は子供レコード自体を削除しない（活動履歴・実績は残す）。代わりに `child.userId` を `null` にしてアカウントだけ切り離す。これは「子供がスマホを返した」「再ログインのため UID を作り直したい」等のケースを想定したもの。
+
+---
+
+## 3. Stripe キャンセル連動（#741 / ADR-0022）
+
+ADR-0022 の原則に従い、**全データ削除を伴うパターン（1 / 2b）では DB 削除よりも先に Stripe Subscription をキャンセルする**。
+
+```
+[fullTenantDeletion]
+  └─ 0. cancelSubscription(tenantId)   ← 失敗したら throw → 以降の処理は走らない
+  └─ 1. S3 削除
+  └─ 2. tenant scoped data 削除
+  └─ 3. children データ削除
+  └─ 4. members の Cognito ユーザー削除 + DB ユーザー削除
+  └─ 5. memberships 削除
+  └─ 6. invites 削除
+  └─ 7. tenant 削除
+  └─ 8. notifyDeletionComplete (失敗は無視)
+  └─ 9. (2b のみ) sendMemberRemovedEmail (失敗は無視)
+```
+
+**理由**: Stripe キャンセルが失敗したまま DB を削除すると、課金は継続しているのにテナントが消滅して問い合わせ窓口を失う。逆順なら、DB は残ったまま再試行できる。
+
+---
+
+## 4. グレースピリオド（#742 連動）
+
+**現状**: グレースピリオドは未実装。`fullTenantDeletion` は即時に物理削除する。
+
+**#742 で導入予定**:
+
+- standard プラン: グレースピリオドなし（即時削除）
+- family プラン: 30 日間の復元期間
+- 削除直後はテナントを `status=pending-delete` に遷移させ、`deletedAt+30d` の cron で実体削除
+- 復元 API（`/api/v1/admin/account/restore`）を用意し、メールリンクから 1 クリック復元できるようにする
+
+実装時に本ドキュメントの §2 のマトリクスに「pending-delete 中の状態」列を追加すること。
+
+---
+
+## 5. 確認 UX
+
+### 5.1 共通の入力チェック
+
+- 削除実行ボタンの直前に **入力フィールド**を置き、ユーザーに `アカウントを削除します` と正確に入力させる（コピー禁止のため `<input>` を使う）
+- 入力値が一致しない限り削除実行ボタンは disabled
+- 実装: `src/routes/(parent)/admin/settings/+page.svelte` の `deleteConfirmText !== 'アカウントを削除します'` ガード
+
+### 5.2 パターンごとの追加 UX
+
+| パターン | 追加表示 | 注記 |
+|---------|---------|------|
+| 1. owner-only | 「家族グループ全体が削除されます」の警告 | `getOwnerDeletionInfo().isOnlyMember=true` で判定 |
+| 2. owner（他メンバーあり） | 移譲ダイアログ（`showTransferDialog`）→ 移譲先選択 or 「全削除」ボタン | `getOwnerDeletionInfo()` で他メンバー一覧を取得 |
+| 2a. transfer | 移譲先メンバー（child 不可）を select | `child` ロールは select に出さない |
+| 2b. full-delete | 「他のメンバーも所属を失います」「Stripe を停止します」 | 削除完了後に他メンバーへメール通知 |
+| 3. child | 子供レコードは残る旨を明示 | parent からの操作ではなく **child 本人セッション** から実行 |
+| 4. member | 「テナントは残ります」「自分のログイン情報のみ削除」 | parent ロールのみ |
+
+### 5.3 削除完了後
+
+- 全パターンで `window.location.href = '/auth/signout'` → サインアウト経由で `/` に戻す
+- セッションが切れているため admin 画面の再読込は不要
+
+---
+
+## 6. 画面遷移図
+
+詳細な画面遷移は [`diagrams/account-deletion-flow.drawio`](diagrams/account-deletion-flow.drawio) を参照。
+
+---
+
+## 7. テスト戦略
+
+### 7.1 ユニットテスト（vitest）
+
+- パターンごとに `getOwnerDeletionInfo` のモックを切り替え、`/api/v1/admin/account/delete` の dispatch が正しいか検証
+- Stripe キャンセル失敗時に DB 削除が走らないことを `cancelSubscription` mock の throw で検証（#741 回帰テスト）
+- ロール判定エラー: owner が `child` パターンを送ると 403、parent が `owner-only` を送ると 403
+
+### 7.2 E2E（Playwright）
+
+- #755 で 4 パターンの E2E を整備予定
+- ローカル認証モードでは Cognito 削除がスキップされるため、E2E は **DB 削除 + サインアウト** までを確認する
+
+---
+
+## 8. 関連
+
+- 設計
+  - #743 — プラン/トライアル UI パターン（PlanStatusCard 等）
+  - #739 — データクリア範囲の見直し
+  - #741 — Stripe キャンセル先行（ADR-0022）
+  - #742 — グレースピリオド
+  - #738 / #754 — ダウングレード前確認 / 超過リソース処理
+- ADR
+  - [ADR-0022](decisions/0022-billing-data-lifecycle-consistency.md) — 課金サイクルとデータライフサイクルの整合性
+  - [ADR-0003](decisions/0003-design-doc-as-source-of-truth.md) — 設計書 SSOT
+- 実装
+  - `src/lib/server/services/account-deletion-service.ts`
+  - `src/routes/api/v1/admin/account/delete/+server.ts`
+  - `src/routes/api/v1/admin/account/deletion-info/+server.ts`
+  - `src/routes/(parent)/admin/settings/+page.svelte`
+
+---
+
+## 更新履歴
+
+| 日付 | 版数 | 内容 |
+|------|------|------|
+| 2026-04-11 | 1.0 | #746 初版作成（実装状態を反映） |

--- a/docs/design/diagrams/account-deletion-flow.drawio
+++ b/docs/design/diagrams/account-deletion-flow.drawio
@@ -1,0 +1,188 @@
+<mxfile host="app.diagrams.net" modified="2026-04-11" agent="Claude" version="24.0.0" type="device">
+  <diagram id="patterns" name="1. Deletion Patterns">
+    <mxGraphModel dx="1422" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <mxCell id="title" value="アカウント削除フロー — 5 パターン分岐 (#746)" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=18;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="450" y="10" width="700" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- Entry: settings page -->
+        <mxCell id="entry" value="admin/settings&#xa;削除ボタン押下" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="80" width="160" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="confirm" value="入力確認&#xa;&quot;アカウントを削除します&quot;&#xa;一致チェック" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="240" y="80" width="180" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="role" value="role 判定" style="shape=rhombus;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#F57F17;" vertex="1" parent="1">
+          <mxGeometry x="470" y="75" width="160" height="70" as="geometry" />
+        </mxCell>
+
+        <mxCell id="entry-e1" style="strokeColor=#333;strokeWidth=2;" edge="1" source="entry" target="confirm" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+        <mxCell id="entry-e2" style="strokeColor=#333;strokeWidth=2;" edge="1" source="confirm" target="role" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Owner branch -->
+        <mxCell id="owner-only-check" value="他メンバー&#xa;いる？" style="shape=rhombus;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#F57F17;" vertex="1" parent="1">
+          <mxGeometry x="700" y="20" width="140" height="80" as="geometry" />
+        </mxCell>
+
+        <mxCell id="role-owner" value="owner" style="strokeColor=#333;strokeWidth=2;" edge="1" source="role" target="owner-only-check" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Pattern 1: owner-only -->
+        <mxCell id="p1" value="Pattern 1: owner-only&#xa;deleteOwnerOnlyAccount()&#xa;→ fullTenantDeletion()" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#B71C1C;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="900" y="20" width="220" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="p1-edge" value="No" style="strokeColor=#333;strokeWidth=2;" edge="1" source="owner-only-check" target="p1" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Pattern 2: transfer dialog -->
+        <mxCell id="dialog" value="移譲ダイアログ&#xa;showTransferDialog" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E1F5FE;strokeColor=#0277BD;" vertex="1" parent="1">
+          <mxGeometry x="900" y="100" width="220" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="dialog-edge" value="Yes" style="strokeColor=#333;strokeWidth=2;" edge="1" source="owner-only-check" target="dialog" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="choice" value="ユーザー選択" style="shape=rhombus;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#F57F17;" vertex="1" parent="1">
+          <mxGeometry x="1170" y="95" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="choice-edge" style="strokeColor=#333;strokeWidth=2;" edge="1" source="dialog" target="choice" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Pattern 2a: transfer -->
+        <mxCell id="p2a" value="Pattern 2a: owner-with-transfer&#xa;transferOwnershipAndLeave()&#xa;→ tenant.ownerId 付替&#xa;+ 自分のみ離脱" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF3E0;strokeColor=#E65100;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="1360" y="40" width="220" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="p2a-edge" value="移譲" style="strokeColor=#333;strokeWidth=2;" edge="1" source="choice" target="p2a" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Pattern 2b: full delete -->
+        <mxCell id="p2b" value="Pattern 2b: owner-full-delete&#xa;deleteOwnerFullDelete()&#xa;→ fullTenantDeletion()&#xa;+ sendMemberRemovedEmail" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#B71C1C;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="1360" y="140" width="220" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="p2b-edge" value="全削除" style="strokeColor=#333;strokeWidth=2;" edge="1" source="choice" target="p2b" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Pattern 3: child -->
+        <mxCell id="p3" value="Pattern 3: child&#xa;deleteChildAccount()&#xa;→ child.userId = null&#xa;+ Cognito 削除&#xa;(子供レコードは残す)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#2E7D32;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="700" y="170" width="220" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="p3-edge" value="child" style="strokeColor=#333;strokeWidth=2;" edge="1" source="role" target="p3" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Pattern 4: member -->
+        <mxCell id="p4" value="Pattern 4: member&#xa;deleteMemberAccount()&#xa;→ membership 削除&#xa;+ Cognito 削除&#xa;(テナントは残す)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8EAF6;strokeColor=#283593;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="700" y="290" width="220" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="p4-edge" value="parent (非 owner)" style="strokeColor=#333;strokeWidth=2;" edge="1" source="role" target="p4" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Common end -->
+        <mxCell id="signout" value="window.location.href&#xa;= /auth/signout" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3E5F5;strokeColor=#6A1B9A;" vertex="1" parent="1">
+          <mxGeometry x="40" y="450" width="200" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="end1" style="strokeColor=#666;strokeWidth=1;dashed=1;" edge="1" source="p1" target="signout" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+        <mxCell id="end2a" style="strokeColor=#666;strokeWidth=1;dashed=1;" edge="1" source="p2a" target="signout" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+        <mxCell id="end2b" style="strokeColor=#666;strokeWidth=1;dashed=1;" edge="1" source="p2b" target="signout" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+        <mxCell id="end3" style="strokeColor=#666;strokeWidth=1;dashed=1;" edge="1" source="p3" target="signout" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+        <mxCell id="end4" style="strokeColor=#666;strokeWidth=1;dashed=1;" edge="1" source="p4" target="signout" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Legend -->
+        <mxCell id="legend-title" value="凡例" style="text;html=1;align=left;verticalAlign=middle;strokeColor=none;fillColor=none;fontSize=14;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="40" y="560" width="100" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="leg1" value="赤系: 全データ削除を伴う" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#B71C1C;" vertex="1" parent="1">
+          <mxGeometry x="40" y="595" width="200" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="leg2" value="橙: 部分削除 (移譲)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF3E0;strokeColor=#E65100;" vertex="1" parent="1">
+          <mxGeometry x="260" y="595" width="200" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="leg3" value="緑: 子供切り離し" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#2E7D32;" vertex="1" parent="1">
+          <mxGeometry x="480" y="595" width="200" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="leg4" value="紺: メンバー単体削除" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8EAF6;strokeColor=#283593;" vertex="1" parent="1">
+          <mxGeometry x="700" y="595" width="200" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="leg5" value="点線: サインアウト遷移" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3E5F5;strokeColor=#6A1B9A;" vertex="1" parent="1">
+          <mxGeometry x="920" y="595" width="200" height="40" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+
+  <diagram id="full-tenant-deletion" name="2. fullTenantDeletion Order">
+    <mxGraphModel dx="1422" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <mxCell id="title2" value="fullTenantDeletion 実行順序 (ADR-0022 / #741)" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=18;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="280" y="10" width="600" height="40" as="geometry" />
+        </mxCell>
+
+        <mxCell id="note" value="重要: Stripe キャンセルが先。失敗したら throw して以降のステップは走らない。&#xa;逆順だと「課金は継続しているのにテナントが消滅して問い合わせ窓口を失う」事故になる。" style="text;html=1;align=left;verticalAlign=middle;strokeColor=#B71C1C;fillColor=#FFEBEE;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="40" y="60" width="1080" height="50" as="geometry" />
+        </mxCell>
+
+        <mxCell id="s0" value="0. cancelSubscription(tenantId)&#xa;Stripe Subscription キャンセル" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#B71C1C;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="40" y="140" width="240" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="s0-fail" value="失敗 → throw&#xa;DB は無傷" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#F57F17;" vertex="1" parent="1">
+          <mxGeometry x="320" y="145" width="160" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="s0-fail-edge" value="error" style="strokeColor=#B71C1C;strokeWidth=2;dashed=1;" edge="1" source="s0" target="s0-fail" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="s1" value="1. S3 削除&#xa;tenants/{tenantId}/" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="230" width="240" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="s1-edge" style="strokeColor=#333;strokeWidth=2;" edge="1" source="s0" target="s1" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="s2" value="2. deleteTenantScopedData&#xa;activities / viewerTokens / cloudExports&#xa;/ pushSubscriptions / voice" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="300" width="240" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="s2-edge" style="strokeColor=#333;strokeWidth=2;" edge="1" source="s1" target="s2" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="s3" value="3. deleteAllChildrenData" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="400" width="240" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="s3-edge" style="strokeColor=#333;strokeWidth=2;" edge="1" source="s2" target="s3" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="s4" value="4. members の Cognito 削除&#xa;+ DB ユーザー削除 (auth.deleteUser)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF3E0;strokeColor=#E65100;" vertex="1" parent="1">
+          <mxGeometry x="40" y="470" width="240" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="s4-edge" style="strokeColor=#333;strokeWidth=2;" edge="1" source="s3" target="s4" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="s5" value="5. deleteAllMemberships" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="550" width="240" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="s5-edge" style="strokeColor=#333;strokeWidth=2;" edge="1" source="s4" target="s5" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="s6" value="6. revokeAndDeleteAllInvites" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="620" width="240" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="s6-edge" style="strokeColor=#333;strokeWidth=2;" edge="1" source="s5" target="s6" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="s7" value="7. deleteTenant" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="690" width="240" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="s7-edge" style="strokeColor=#333;strokeWidth=2;" edge="1" source="s6" target="s7" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="s8" value="8. notifyDeletionComplete (Discord)&#xa;失敗は無視" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#2E7D32;" vertex="1" parent="1">
+          <mxGeometry x="320" y="690" width="240" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="s8-edge" style="strokeColor=#333;strokeWidth=2;dashed=1;" edge="1" source="s7" target="s8" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="s9" value="9. (Pattern 2b のみ)&#xa;sendMemberRemovedEmail&#xa;事前収集したメール宛 / 失敗は無視" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#2E7D32;" vertex="1" parent="1">
+          <mxGeometry x="600" y="685" width="280" height="65" as="geometry" />
+        </mxCell>
+        <mxCell id="s9-edge" style="strokeColor=#333;strokeWidth=2;dashed=1;" edge="1" source="s8" target="s9" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Side note about deleteAllChildrenData differences -->
+        <mxCell id="note2" value="補足: Pattern 3 (deleteChildAccount) は本フローを通らない。&#xa;child.userId = null + 自分の Cognito + 自分の DB ユーザーのみ削除し、&#xa;子供レコード本体・活動履歴・実績は保持する (再ログイン用に切り離すだけ)。" style="text;html=1;align=left;verticalAlign=middle;strokeColor=#2E7D32;fillColor=#E8F5E9;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="320" y="140" width="800" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="note3" value="補足: Pattern 4 (deleteMemberAccount) も本フローを通らない。&#xa;自分の membership + 自分の Cognito + 自分の DB ユーザーのみ削除し、&#xa;テナント本体は無傷 (Stripe 課金もそのまま継続)。" style="text;html=1;align=left;verticalAlign=middle;strokeColor=#283593;fillColor=#E8EAF6;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="320" y="220" width="800" height="60" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/design/diagrams/account-deletion-flow.drawio
+++ b/docs/design/diagrams/account-deletion-flow.drawio
@@ -56,7 +56,7 @@
         <mxCell id="p2a-edge" value="移譲" style="strokeColor=#333;strokeWidth=2;" edge="1" source="choice" target="p2a" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
 
         <!-- Pattern 2b: full delete -->
-        <mxCell id="p2b" value="Pattern 2b: owner-full-delete&#xa;deleteOwnerFullDelete()&#xa;→ fullTenantDeletion()&#xa;+ sendMemberRemovedEmail" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#B71C1C;fontStyle=1;" vertex="1" parent="1">
+        <mxCell id="p2b" value="Pattern 2b: owner-full-delete&#xa;deleteOwnerFullDelete()&#xa;(独自実装: Owner のみ Cognito 削除)&#xa;+ sendMemberRemovedEmail" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#B71C1C;fontStyle=1;" vertex="1" parent="1">
           <mxGeometry x="1360" y="140" width="220" height="80" as="geometry" />
         </mxCell>
         <mxCell id="p2b-edge" value="全削除" style="strokeColor=#333;strokeWidth=2;" edge="1" source="choice" target="p2b" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
@@ -113,7 +113,7 @@
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
 
-        <mxCell id="title2" value="fullTenantDeletion 実行順序 (ADR-0022 / #741)" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=18;fontStyle=1;" vertex="1" parent="1">
+        <mxCell id="title2" value="fullTenantDeletion 実行順序 — Pattern 1 のみ (ADR-0022 / #741)" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=18;fontStyle=1;" vertex="1" parent="1">
           <mxGeometry x="280" y="10" width="600" height="40" as="geometry" />
         </mxCell>
 
@@ -169,10 +169,9 @@
         </mxCell>
         <mxCell id="s8-edge" style="strokeColor=#333;strokeWidth=2;dashed=1;" edge="1" source="s7" target="s8" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
 
-        <mxCell id="s9" value="9. (Pattern 2b のみ)&#xa;sendMemberRemovedEmail&#xa;事前収集したメール宛 / 失敗は無視" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#2E7D32;" vertex="1" parent="1">
-          <mxGeometry x="600" y="685" width="280" height="65" as="geometry" />
+        <mxCell id="note4" value="補足: Pattern 2b (deleteOwnerFullDelete) は fullTenantDeletion を呼ばず独自実装。&#xa;主な違い: (a) Owner の Cognito のみ削除（他メンバーの Cognito は残す）&#xa;(b) 全削除成功後に sendMemberRemovedEmail を事前収集アドレス宛に送信（失敗は無視）。" style="text;html=1;align=left;verticalAlign=middle;strokeColor=#B71C1C;fillColor=#FFEBEE;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="600" y="680" width="500" height="70" as="geometry" />
         </mxCell>
-        <mxCell id="s9-edge" style="strokeColor=#333;strokeWidth=2;dashed=1;" edge="1" source="s8" target="s9" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
 
         <!-- Side note about deleteAllChildrenData differences -->
         <mxCell id="note2" value="補足: Pattern 3 (deleteChildAccount) は本フローを通らない。&#xa;child.userId = null + 自分の Cognito + 自分の DB ユーザーのみ削除し、&#xa;子供レコード本体・活動履歴・実績は保持する (再ログイン用に切り離すだけ)。" style="text;html=1;align=left;verticalAlign=middle;strokeColor=#2E7D32;fillColor=#E8F5E9;fontSize=11;" vertex="1" parent="1">


### PR DESCRIPTION
## Summary

- `docs/design/account-deletion-flow.md` を新設し、5 パターン (owner-only / owner-with-transfer / owner-full-delete / child / member) の判定条件・データクリア範囲マトリクス・Stripe キャンセル連動順序 (ADR-0022 / #741)・グレースピリオド (#742) 連動・確認 UX を SSOT 化
- `docs/design/diagrams/account-deletion-flow.drawio` に 2 ページ図を追加
  - **Page 1**: 5 パターン分岐フローチャート（settings ボタン → role 判定 → owner-only/transfer/full-delete/child/member）
  - **Page 2**: `fullTenantDeletion` 実行順序（Stripe キャンセル → S3 → tenantScopedData → children → members Cognito+DB → memberships → invites → tenant → notify、ADR-0022 の「Stripe を先に」原則を可視化）
- `docs/CLAUDE.md` の設計書更新ルール表に 1 行追加（「アカウント削除フローの追加・変更」→ `design/account-deletion-flow.md`）

## Acceptance Criteria

- [x] 新規設計書作成 (`docs/design/account-deletion-flow.md`, 165 行)
- [x] drawio 図追加 (`docs/design/diagrams/account-deletion-flow.drawio`, 2 ページ)
- [x] CLAUDE.md の設計書一覧に追加

## 関連

- #746 (このIssue)
- #739 — データクリア範囲の見直し（マトリクス §2 で参照）
- #741 / ADR-0022 — Stripe キャンセル先行（フロー §3 + drawio Page 2 で可視化）
- #742 — グレースピリオド（§4 で「未実装、#742 で導入予定」と明記）
- #755 — 4 パターン E2E（§7.2 で参照）

## Test plan

- [ ] drawio が draw.io デスクトップ / app.diagrams.net で開けることを確認
- [ ] biome check (`.md` は ignore 対象) — 影響なし
- [ ] svelte-check / vitest / playwright — ドキュメント変更のため影響なし

closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)