### PR TITLE
docs: #747 プラン変更フロー設計書 + drawio 図新設

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -14,6 +14,7 @@
 | UI 機能・画面・オーバーレイの追加・変更 | `06-UI設計書.md` |
 | **UI プラン仕様の追加・変更**（FeatureGate / TrialBanner / PlanStatusCard / PremiumWelcome / disabled パターン） | `06-UI設計書.md §10` (#743) |
 | **アカウント削除フローの追加・変更**（5 パターン分岐 / fullTenantDeletion 順序 / Stripe 連動） | `account-deletion-flow.md` (#746) |
+| **プラン変更フロー（アップグレード/ダウングレード/解約/月年額切替）** | `plan-change-flow.md` (#747) |
 | AWS インフラ構成の変更 | `13-AWSサーバレスアーキテクチャ設計書.md` |
 | 認証・セキュリティ関連の変更 | `14-セキュリティ設計書.md` |
 | デザイン・ビジュアル変更 | `15-ブランドガイドライン.md` |

--- a/docs/design/diagrams/plan-change-flow.drawio
+++ b/docs/design/diagrams/plan-change-flow.drawio
@@ -1,0 +1,248 @@
+<mxfile host="app.diagrams.net" modified="2026-04-11" agent="Claude" version="24.0.0" type="device">
+  <diagram id="upgrade-new" name="1. Upgrade (new purchase)">
+    <mxGraphModel dx="1422" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <mxCell id="title" value="アップグレード — 新規購入フロー (free → standard / family)" style="text;html=1;align=center;verticalAlign=middle;strokeColor=none;fillColor=none;fontSize=18;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="350" y="10" width="800" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- Step 1: license page -->
+        <mxCell id="lic" value="/admin/license&#xa;月額/年額タブ + プランカード 2 枚" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="80" width="220" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="select" value="プラン選択&#xa;billingInterval × tier&#xa;= planId" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="300" y="80" width="180" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="lic-e1" style="strokeColor=#333;strokeWidth=2;" edge="1" source="lic" target="select" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="checkoutapi" value="POST /api/stripe/checkout&#xa;{ planId }" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF3E0;strokeColor=#E65100;" vertex="1" parent="1">
+          <mxGeometry x="520" y="80" width="200" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="select-e" style="strokeColor=#333;strokeWidth=2;" edge="1" source="select" target="checkoutapi" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="auth" value="認可&#xa;role ∈ {owner, parent}&#xa;child → 403" style="shape=rhombus;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#F57F17;" vertex="1" parent="1">
+          <mxGeometry x="760" y="65" width="160" height="90" as="geometry" />
+        </mxCell>
+        <mxCell id="auth-e" style="strokeColor=#333;strokeWidth=2;" edge="1" source="checkoutapi" target="auth" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="ccs" value="createCheckoutSession()&#xa;Stripe Price ID マップ&#xa;success_url / cancel_url 設定" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF3E0;strokeColor=#E65100;" vertex="1" parent="1">
+          <mxGeometry x="960" y="65" width="220" height="90" as="geometry" />
+        </mxCell>
+        <mxCell id="ccs-e" value="OK" style="strokeColor=#333;strokeWidth=2;" edge="1" source="auth" target="ccs" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="redirect" value="window.location.href&#xa;= checkout.stripe.com/..." style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="1220" y="80" width="220" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="redirect-e" style="strokeColor=#333;strokeWidth=2;" edge="1" source="ccs" target="redirect" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Step 2: Stripe Checkout external -->
+        <mxCell id="stripeext" value="Stripe Checkout&#xa;(外部画面)&#xa;カード情報入力" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3E5F5;strokeColor=#6A1B9A;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="1220" y="200" width="220" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="stripe-e" style="strokeColor=#333;strokeWidth=2;" edge="1" source="redirect" target="stripeext" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="stripechoice" value="完了？" style="shape=rhombus;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#F57F17;" vertex="1" parent="1">
+          <mxGeometry x="1260" y="320" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="stripechoice-e" style="strokeColor=#333;strokeWidth=2;" edge="1" source="stripeext" target="stripechoice" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="cancel" value="cancel_url&#xa;/pricing&#xa;DB 変更なし" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#B71C1C;" vertex="1" parent="1">
+          <mxGeometry x="1460" y="320" width="120" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="cancel-e" value="No" style="strokeColor=#333;strokeWidth=2;dashed=1;" edge="1" source="stripechoice" target="cancel" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Webhook path -->
+        <mxCell id="webhook" value="Webhook&#xa;checkout.session.completed" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E1F5FE;strokeColor=#0277BD;" vertex="1" parent="1">
+          <mxGeometry x="800" y="320" width="220" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="webhook-e" value="Yes" style="strokeColor=#333;strokeWidth=2;" edge="1" source="stripechoice" target="webhook" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="handler" value="handleCheckoutCompleted&#xa;1. tenantId from metadata&#xa;2. updateTenantStripe(plan, status=active,&#xa;     customerId, subscriptionId, trialUsedAt)&#xa;3. issueLicenseKey (purchase)&#xa;4. sendLicenseKeyEmail&#xa;5. notifyBillingEvent (Discord)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#2E7D32;align=left;" vertex="1" parent="1">
+          <mxGeometry x="800" y="410" width="320" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="handler-e" style="strokeColor=#333;strokeWidth=2;" edge="1" source="webhook" target="handler" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="success" value="success_url&#xa;/admin/license?session_id=..." style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="400" y="320" width="220" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="success-e" style="strokeColor=#333;strokeWidth=2;" edge="1" source="stripechoice" target="success" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="welcome" value="次回 admin ロード&#xa;PremiumWelcome モーダル&#xa;(setting flag で 1 回のみ)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF3E0;strokeColor=#E65100;" vertex="1" parent="1">
+          <mxGeometry x="400" y="430" width="240" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="welcome-e" style="strokeColor=#333;strokeWidth=2;dashed=1;" edge="1" source="success" target="welcome" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Legend -->
+        <mxCell id="leg" value="凡例 — 青: クライアント / 橙: サーバー API / 紫: Stripe 外部 / 水色: Webhook 受信 / 緑: Webhook ハンドラ" style="text;html=1;align=left;verticalAlign=middle;strokeColor=#666;fillColor=#FAFAFA;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="40" y="700" width="1100" height="30" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+
+  <diagram id="portal" name="2. Portal (upgrade/downgrade/cancel)">
+    <mxGraphModel dx="1422" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <mxCell id="title2" value="Customer Portal 経由 — プラン変更 / ダウングレード / 解約 / 月年額切替 (#771)" style="text;html=1;align=center;verticalAlign=middle;strokeColor=none;fillColor=none;fontSize=18;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="200" y="10" width="1100" height="40" as="geometry" />
+        </mxCell>
+
+        <mxCell id="p2-lic" value="/admin/license&#xa;hasSubscription === true 時&#xa;「プラン変更・支払い管理」ボタン" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="80" width="240" height="70" as="geometry" />
+        </mxCell>
+
+        <mxCell id="p2-dialog" value="Dialog 開く&#xa;showPortalConfirm = true" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E1F5FE;strokeColor=#0277BD;" vertex="1" parent="1">
+          <mxGeometry x="320" y="85" width="200" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e1" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-lic" target="p2-dialog" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="p2-pinq" value="pinConfigured?" style="shape=rhombus;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#F57F17;" vertex="1" parent="1">
+          <mxGeometry x="560" y="80" width="160" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e2" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-dialog" target="p2-pinq" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="p2-pin" value="親 PIN 入力&#xa;(4〜6桁数字)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="780" y="40" width="180" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e3a" value="Yes" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-pinq" target="p2-pin" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="p2-phrase" value="確認フレーズ入力&#xa;「プランを変更します」" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="780" y="130" width="200" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e3b" value="No" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-pinq" target="p2-phrase" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="p2-portalapi" value="POST /api/stripe/portal&#xa;{ pin } or { confirmPhrase }" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF3E0;strokeColor=#E65100;" vertex="1" parent="1">
+          <mxGeometry x="1020" y="85" width="220" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e4a" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-pin" target="p2-portalapi" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+        <mxCell id="p2-e4b" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-phrase" target="p2-portalapi" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="p2-verify" value="verifyPin / phrase 検証&#xa;失敗 → 401/423&#xa;成功 → 続行" style="shape=rhombus;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#F57F17;" vertex="1" parent="1">
+          <mxGeometry x="1290" y="65" width="180" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e5" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-portalapi" target="p2-verify" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="p2-cps" value="createPortalSession&#xa;return_url=/admin/license" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFF3E0;strokeColor=#E65100;" vertex="1" parent="1">
+          <mxGeometry x="1290" y="200" width="200" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e6" value="OK" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-verify" target="p2-cps" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="p2-portal" value="Stripe Customer Portal&#xa;(外部画面)&#xa;- プラン変更&#xa;- 月/年額切替&#xa;- 支払方法更新&#xa;- 解約&#xa;- 請求書履歴" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3E5F5;strokeColor=#6A1B9A;fontStyle=1;align=left;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="290" width="240" height="160" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e7" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-cps" target="p2-portal" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Webhook branches -->
+        <mxCell id="p2-action" value="Portal で操作確定" style="shape=rhombus;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#F57F17;" vertex="1" parent="1">
+          <mxGeometry x="1310" y="490" width="180" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e8" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-portal" target="p2-action" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="p2-wh-update" value="Webhook&#xa;customer.subscription.updated" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E1F5FE;strokeColor=#0277BD;" vertex="1" parent="1">
+          <mxGeometry x="900" y="490" width="240" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e9a" value="プラン/期間変更" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-action" target="p2-wh-update" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="p2-wh-delete" value="Webhook&#xa;customer.subscription.deleted" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E1F5FE;strokeColor=#0277BD;" vertex="1" parent="1">
+          <mxGeometry x="900" y="600" width="240" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e9b" value="解約" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-action" target="p2-wh-delete" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="p2-h-update" value="handleSubscriptionUpdated&#xa;1. tenant 特定&#xa;2. priceId → plan 解決&#xa;3. status: active/grace/suspended&#xa;4. updateTenantStripe(plan, status)&#xa;5. notifyBillingEvent" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#2E7D32;align=left;" vertex="1" parent="1">
+          <mxGeometry x="500" y="470" width="320" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e10a" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-wh-update" target="p2-h-update" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="p2-h-delete" value="handleSubscriptionDeleted&#xa;1. tenant 特定&#xa;2. updateTenantStripe&#xa;   stripeSubscriptionId=undef&#xa;   plan=undef, status=suspended&#xa;3. notifyBillingEvent&#xa;※ テナント本体は残す" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#B71C1C;align=left;" vertex="1" parent="1">
+          <mxGeometry x="500" y="610" width="320" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e10b" style="strokeColor=#333;strokeWidth=2;" edge="1" source="p2-wh-delete" target="p2-h-delete" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Return -->
+        <mxCell id="p2-return" value="ユーザー戻る&#xa;/admin/license&#xa;新プラン状態を反映" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="540" width="200" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="p2-e11" style="strokeColor=#333;strokeWidth=2;dashed=1;" edge="1" source="p2-h-update" target="p2-return" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+
+  <diagram id="failure" name="3. Payment failure / grace period">
+    <mxGraphModel dx="1422" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <mxCell id="title3" value="支払い失敗 → 猶予期間 → リトライ / suspended (GRACE_PERIOD_DAYS = 7)" style="text;html=1;align=center;verticalAlign=middle;strokeColor=none;fillColor=none;fontSize=18;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="10" width="1000" height="40" as="geometry" />
+        </mxCell>
+
+        <mxCell id="f-active" value="status: active&#xa;通常運用" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#2E7D32;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="40" y="100" width="180" height="60" as="geometry" />
+        </mxCell>
+
+        <mxCell id="f-fail" value="Stripe 課金失敗&#xa;invoice.payment_failed" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#B71C1C;" vertex="1" parent="1">
+          <mxGeometry x="280" y="100" width="200" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="f-e1" style="strokeColor=#B71C1C;strokeWidth=2;" edge="1" source="f-active" target="f-fail" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="f-handler" value="handlePaymentFailed&#xa;status = grace_period&#xa;planExpiresAt = now + 7d" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#2E7D32;" vertex="1" parent="1">
+          <mxGeometry x="540" y="100" width="220" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="f-e2" style="strokeColor=#333;strokeWidth=2;" edge="1" source="f-fail" target="f-handler" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <mxCell id="f-grace" value="status: grace_period&#xa;機能維持 (元プランの上限)&#xa;/admin/license に警告セクション" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFDE7;strokeColor=#F57F17;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="820" y="90" width="280" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="f-e3" style="strokeColor=#333;strokeWidth=2;" edge="1" source="f-handler" target="f-grace" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Recovery branch -->
+        <mxCell id="f-update" value="ユーザー支払方法更新&#xa;(Customer Portal)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E3F2FD;strokeColor=#1565C0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="240" width="220" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="f-retry" value="Stripe Smart Retry&#xa;リトライ成功" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3E5F5;strokeColor=#6A1B9A;" vertex="1" parent="1">
+          <mxGeometry x="320" y="240" width="200" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="f-paid" value="invoice.paid Webhook&#xa;handleInvoicePaid&#xa;status = active 復帰" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E8F5E9;strokeColor=#2E7D32;" vertex="1" parent="1">
+          <mxGeometry x="580" y="240" width="220" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="f-e4" style="strokeColor=#333;strokeWidth=2;" edge="1" source="f-update" target="f-retry" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+        <mxCell id="f-e5" style="strokeColor=#333;strokeWidth=2;" edge="1" source="f-retry" target="f-paid" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+        <mxCell id="f-e6" style="strokeColor=#333;strokeWidth=2;dashed=1;" edge="1" source="f-paid" target="f-active" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Failure branch -->
+        <mxCell id="f-7d" value="7 日経過＆未払いのまま" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#B71C1C;" vertex="1" parent="1">
+          <mxGeometry x="40" y="380" width="220" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="f-stripeexp" value="Stripe&#xa;subscription.status&#xa;= past_due → unpaid" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#F3E5F5;strokeColor=#6A1B9A;" vertex="1" parent="1">
+          <mxGeometry x="320" y="370" width="200" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="f-update2" value="Webhook&#xa;customer.subscription.updated&#xa;handleSubscriptionUpdated&#xa;status → suspended" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#E1F5FE;strokeColor=#0277BD;" vertex="1" parent="1">
+          <mxGeometry x="580" y="370" width="240" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="f-suspended" value="status: suspended&#xa;サービス停止表示&#xa;機能ロック (free 相当)&#xa;データは保持" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFEBEE;strokeColor=#B71C1C;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="880" y="370" width="220" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="f-e7" style="strokeColor=#B71C1C;strokeWidth=2;" edge="1" source="f-7d" target="f-stripeexp" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+        <mxCell id="f-e8" style="strokeColor=#333;strokeWidth=2;" edge="1" source="f-stripeexp" target="f-update2" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+        <mxCell id="f-e9" style="strokeColor=#333;strokeWidth=2;" edge="1" source="f-update2" target="f-suspended" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Connectors from grace -->
+        <mxCell id="f-e10" value="復帰経路" style="strokeColor=#2E7D32;strokeWidth=2;dashed=1;" edge="1" source="f-grace" target="f-update" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+        <mxCell id="f-e11" value="放置経路" style="strokeColor=#B71C1C;strokeWidth=2;dashed=1;" edge="1" source="f-grace" target="f-7d" parent="1"><mxGeometry relative="1" as="geometry" /></mxCell>
+
+        <!-- Note -->
+        <mxCell id="f-note" value="補足: suspended からの復活は支払方法更新 → Stripe で手動再開 → checkout.session.completed か invoice.paid 経由で active に戻す。&#xa;DB 上のデータは削除されない（解約とは別概念）。アカウント削除は /admin/settings 経由で別フロー (account-deletion-flow.md)。" style="text;html=1;align=left;verticalAlign=middle;strokeColor=#666;fillColor=#FAFAFA;fontSize=11;" vertex="1" parent="1">
+          <mxGeometry x="40" y="500" width="1080" height="60" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/design/plan-change-flow.md
+++ b/docs/design/plan-change-flow.md
@@ -16,7 +16,7 @@
 | **支払い失敗** | Stripe (自動) | `invoice.payment_failed` Webhook | DB: `status=grace_period, planExpiresAt=now+7d` → 猶予期間中は機能維持 |
 | **ライセンスキー適用** | `/admin/license` フォーム | `applyLicenseKey` action → `consumeLicenseKey` (Stripe を経由しない) | テナント plan を直接昇格、Stripe 課金は発生しない |
 
-> **重要**: 本プロジェクトでは「アプリ内独自のプラン変更 API」は持たず、ダウングレード・解約・月年額切替は **すべて Stripe Customer Portal に委譲** している (#771)。これは「Stripe = 正、DB = 反映」の原則 (#823 / ADR-0022) を守るため。
+> **重要**: プラン昇降格と月年額切替は **Stripe Customer Portal に委譲** している (#771)。ただし解約については `/admin/settings` から `POST /api/v1/admin/tenant/cancel` を呼ぶアプリ内フローも存在する（#784: Stripe 即時キャンセル → `status=grace_period` + `planExpiresAt` 更新、30日間のデータ保持）。本ドキュメント §3 のスコープは `/admin/license` 経由の Customer Portal 操作に限定し、`/admin/settings` 経由の解約フローは [`account-deletion-flow.md`](account-deletion-flow.md) に記載する。
 
 ---
 
@@ -388,7 +388,7 @@ Customer Portal 経由のみ。Portal 内の「プラン変更」UI から切り
 
 ### 11.2 E2E（Playwright）
 
-- 既存: `tests/e2e/license-management.spec.ts`（PIN 確認ダイアログ表示）
+- 既存: `tests/e2e/portal-pin-gate.spec.ts`（PIN 確認ダイアログ表示）
 - **未整備**: アップグレード/ダウングレードの実際の Stripe 統合は test mode key が必要なため CI で動かない
 - ローカル認証モードでは Stripe API 呼び出しはスタブ化されており、Webhook イベントを直接モック注入してハンドラをテストする想定
 
@@ -398,12 +398,12 @@ Customer Portal 経由のみ。Portal 内の「プラン変更」UI から切り
 
 - 設計
   - [06-UI設計書.md §10](06-UI設計書.md) — プラン UI パターン全体（#743）
-  - [account-deletion-flow.md](account-deletion-flow.md) — 削除フロー（#746）
+  - [account-deletion-flow.md](account-deletion-flow.md) — 削除フロー（#746、PR #908 でマージ予定）
   - #738 — ダウングレード前警告フロー（超過リソース処理）
   - #786 — 月額↔年額切替の UI 導線改善 / proration 仕様
   - #823 — Tenant plan 状態マシン統一 EPIC
 - ADR
-  - [ADR-0022](decisions/0022-billing-data-lifecycle-consistency.md) — 課金サイクルとデータライフサイクルの整合性
+  - [ADR-0022](../decisions/0022-billing-data-lifecycle-consistency.md) — 課金サイクルとデータライフサイクルの整合性
 - 実装
   - `src/routes/(parent)/admin/license/+page.svelte`
   - `src/routes/(parent)/admin/license/+page.server.ts`

--- a/docs/design/plan-change-flow.md
+++ b/docs/design/plan-change-flow.md
@@ -1,0 +1,422 @@
+# plan-change-flow.md — プラン変更フロー仕様 (#747)
+
+> アップグレード（free→standard→family）とダウングレード（family→standard→free）、月額↔年額切替、および解約時の挙動を 1 か所にまとめた SSOT。実装は `/admin/license` ページと `/api/stripe/{checkout,portal,webhook}` に集約されている。
+
+---
+
+## 1. 全体像
+
+| フロー | エントリ | 経路 | 終端 |
+|--------|---------|------|------|
+| **アップグレード (新規購入)** | `/admin/license` プラン選択カード | `POST /api/stripe/checkout` → Stripe Checkout (外部) → `checkout.session.completed` Webhook | success URL = `/admin/license?session_id=...` → PremiumWelcome 表示 |
+| **アップグレード (プラン昇格)** | `/admin/license` 「プラン変更・支払い管理」 | PIN 確認 → `POST /api/stripe/portal` → Stripe Customer Portal → `customer.subscription.updated` Webhook | Portal の return URL = `/admin/license` → 新プラン反映 |
+| **ダウングレード** | 同上（Customer Portal） | 同上 → Portal で下位プランに変更 → `customer.subscription.updated` Webhook | 同上 → 新プラン反映＋PlanStatusCard で超過リソースを警告 |
+| **月額↔年額切替** | 同上（Customer Portal） | 同上（Stripe 標準 UI） | 同上 |
+| **解約 (cancel)** | 同上（Customer Portal） | 同上 → Portal で「解約」 → `customer.subscription.deleted` Webhook | DB: `plan=undefined, status=suspended`（テナントは残る） |
+| **支払い失敗** | Stripe (自動) | `invoice.payment_failed` Webhook | DB: `status=grace_period, planExpiresAt=now+7d` → 猶予期間中は機能維持 |
+| **ライセンスキー適用** | `/admin/license` フォーム | `applyLicenseKey` action → `consumeLicenseKey` (Stripe を経由しない) | テナント plan を直接昇格、Stripe 課金は発生しない |
+
+> **重要**: 本プロジェクトでは「アプリ内独自のプラン変更 API」は持たず、ダウングレード・解約・月年額切替は **すべて Stripe Customer Portal に委譲** している (#771)。これは「Stripe = 正、DB = 反映」の原則 (#823 / ADR-0022) を守るため。
+
+---
+
+## 2. アップグレード — 新規購入（free → standard / family）
+
+### 2.1 画面遷移
+
+```
+[/admin/license]
+  ├─ 月額/年額タブ（billingInterval state）
+  ├─ プランカード × 2（standard / family、ファミリーが「おすすめ」バッジ）
+  └─ 「{プラン名}プランで始める」ボタン
+        │
+        ▼
+  POST /api/stripe/checkout
+   body: { planId: 'monthly' | 'yearly' | 'family-monthly' | 'family-yearly' }
+        │
+        ├─ 認可: role ∈ {owner, parent}（child は 403）
+        ├─ tenantId: locals.context.tenantId（改ざん不可、サーバー署名付き）
+        ├─ planId バリデーション: validPlanIds に含まれるか
+        ▼
+  createCheckoutSession()
+        │
+        ├─ Stripe Price ID を planId からマッピング (planId → price)
+        ├─ success_url = ${origin}/admin/license?session_id={CHECKOUT_SESSION_ID}
+        ├─ cancel_url  = ${origin}/pricing
+        ▼
+  { url: 'https://checkout.stripe.com/c/pay/...' }
+        │
+        ▼
+  window.location.href = url   ← ブラウザを Stripe にリダイレクト
+        │
+        ▼
+[Stripe Checkout（外部画面）]
+        │
+        ├─ 支払い方法入力 → 完了
+        │   └─ 成功 → success_url にリダイレクト
+        │       └─ 同時に Webhook: checkout.session.completed
+        │
+        └─ キャンセル → cancel_url (/pricing) にリダイレクト
+            └─ Webhook 発火なし、DB は free のまま
+```
+
+### 2.2 Webhook 処理 — `checkout.session.completed`
+
+`stripe-service.ts:handleCheckoutCompleted()`
+
+1. `session.metadata.tenantId` を取得（Checkout 作成時に埋め込み済み）
+2. `session.metadata.planId` を取得し `Tenant['plan']` にキャスト
+3. `repos.auth.updateTenantStripe()` で以下を更新:
+   - `stripeCustomerId`
+   - `stripeSubscriptionId`
+   - `plan` = 新プラン
+   - `status` = `'active'`
+   - `trialUsedAt` = now（トライアル消化済みフラグ）
+4. **ライセンスキー発行 (#0247 / #801)**:
+   - `issueLicenseKey({ kind: 'purchase', tenantId, plan, stripeSessionId, issuedBy })`
+   - 発行されたキーをテナントに紐付け
+   - Stripe Customer のメールアドレスへ `sendLicenseKeyEmail` で送信
+   - キー発行失敗時も決済自体は成功扱い（手動補完可）
+5. Discord 通知: `notifyBillingEvent(tenantId, 'checkout_completed', 'plan=...')`
+
+### 2.3 PremiumWelcome モーダル表示
+
+- success URL `/admin/license?session_id=...` への帰還時、admin の `+page.server.ts` (#743 §10.5) で次回ロード時に判定:
+  - `isPaidTier(tier) && setting('premium_welcome_shown') !== 'true'` → モーダル表示
+  - dismiss 時に setting を `'true'` に更新（テナントスコープ）
+
+---
+
+## 3. プラン変更 / ダウングレード / 解約 — Customer Portal 経由
+
+### 3.1 PIN 確認ゲート (#771)
+
+子供が親端末で誤操作するのを防ぐため、Portal 遷移前に二段階確認を必須化。
+
+```
+[/admin/license]
+  └─ 「プラン変更・支払い管理」ボタン
+        │
+        ▼
+  Dialog: showPortalConfirm = true
+        │
+        ├─ pinConfigured === true   → 親 PIN コード（4〜6桁数字）入力
+        └─ pinConfigured === false  → 確認フレーズ「プランを変更します」入力
+        │
+        ▼
+  「Stripe の管理画面を開く」確認ボタン
+        │
+        ▼
+  POST /api/stripe/portal
+   body: { pin: '1234' } または { confirmPhrase: 'プランを変更します' }
+        │
+        ├─ 認可: role ∈ {owner, parent}
+        ├─ pinConfigured 分岐:
+        │    pin あり → verifyPin()
+        │      ├─ INVALID_PIN  → 401 INVALID_PIN
+        │      ├─ LOCKED_OUT   → 423 LOCKED_OUT:{lockedUntil}
+        │      └─ ok           → 続行
+        │    pin なし → confirmPhrase === 'プランを変更します' でなければ 401
+        ▼
+  createPortalSession(tenantId, return_url=`${origin}/admin/license`)
+        │
+        ▼
+  { url: 'https://billing.stripe.com/p/session/...' }
+        │
+        ▼
+  window.location.href = url
+```
+
+### 3.2 Stripe Customer Portal で行える操作
+
+| 操作 | Webhook | DB 反映 |
+|------|---------|---------|
+| プラン変更（standard ↔ family、月 ↔ 年） | `customer.subscription.updated` | `plan` を `planIdFromPriceId(item.price.id)` で更新、`status='active'` |
+| サブスク解約（即時 or 期末） | `customer.subscription.deleted` | `stripeSubscriptionId=undefined, plan=undefined, status='suspended'` |
+| 支払い方法更新 | （Stripe 側のみ） | DB 変更なし |
+| 請求書履歴閲覧 | （Stripe 側のみ） | DB 変更なし |
+
+### 3.3 Webhook 処理 — `customer.subscription.updated`
+
+`stripe-service.ts:handleSubscriptionUpdated()`
+
+1. `subscription.metadata.tenantId` か `findTenantBySubscription(subscription.id)` でテナント特定
+2. `subscription.items[0].price.id` から `planIdFromPriceId()` で `Tenant['plan']` を解決
+3. `subscription.status` を DB 用に正規化:
+   | Stripe status | DB status |
+   |---------------|-----------|
+   | `active` / `trialing` | `'active'` |
+   | `past_due` | `'grace_period'` |
+   | その他 (`canceled` / `unpaid` / `incomplete_expired`) | `'suspended'` |
+4. `repos.auth.updateTenantStripe()` で `plan, status` を保存
+5. Discord 通知: `notifyBillingEvent(tenantId, 'subscription_updated', 'status=..., plan=...')`
+
+### 3.4 Webhook 処理 — `customer.subscription.deleted`
+
+`stripe-service.ts:handleSubscriptionDeleted()`
+
+1. テナント特定（同上）
+2. `repos.auth.updateTenantStripe()` で:
+   - `stripeSubscriptionId` = undefined
+   - `plan` = undefined
+   - `status` = `'suspended'`
+3. **重要**: テナント・子供データ・活動履歴は削除しない（解約と削除は別概念。アカウント削除は `/admin/settings` 経由 → `account-deletion-flow.md` 参照）
+4. Discord 通知: `notifyBillingEvent(tenantId, 'subscription_deleted')`
+
+---
+
+## 4. 支払い失敗フロー（猶予期間）
+
+### 4.1 Webhook 処理 — `invoice.payment_failed`
+
+`stripe-service.ts:handlePaymentFailed()`
+
+1. テナント特定
+2. **猶予期間設定**: `GRACE_PERIOD_DAYS = 7` (`src/lib/server/stripe/config.ts`)
+   ```ts
+   const graceExpires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+   ```
+3. `repos.auth.updateTenantStripe()` で:
+   - `status` = `'grace_period'`
+   - `planExpiresAt` = `graceExpires`
+4. Discord 通知: `notifyBillingEvent(tenantId, 'payment_failed', '猶予期間: ...')`
+
+### 4.2 ユーザー視点の挙動
+
+- `/admin/license` の現在プラン表示で「⚠️ 猶予期間中」セクションが表示される
+- プラン機能は維持される（=猶予期間中は引き続き standard/family の制限が適用）
+- 7 日以内に支払い方法を更新 → Stripe が自動リトライ → `invoice.paid` Webhook で `status='active'` に復帰
+- 7 日経過しても未払い → Stripe 側で `subscription.status='past_due' → 'unpaid'` 等に遷移 → `customer.subscription.updated` で `status='suspended'` に遷移
+- `suspended` 状態では `/admin/license` に「⏸️ サービス停止中」セクションが表示される
+
+### 4.3 リトライ・復帰
+
+- Stripe Smart Retries に委譲（Stripe Dashboard 設定）
+- 復帰経路: 支払い更新 → `invoice.paid` Webhook → `handleInvoicePaid()` で `status='active', plan=請求書から再解決` に戻す
+
+---
+
+## 5. ダウングレード時の超過リソース処理（#738 連動）
+
+### 5.1 現状
+
+**未実装**。`checkChildLimit` は新規作成のみブロックし、既存リソースのアーカイブ機構はない。
+
+### 5.2 #738 で実装予定の挙動
+
+ダウングレード前確認画面で:
+
+| 項目 | 仕様 |
+|------|------|
+| 現在リソース表示 | 子供 N 人 / 活動 M 個 / 履歴保持 X 日 |
+| ダウングレード先制限 | 子供 2 人 / 活動 3 個 / 履歴 90 日 (free) |
+| 超過分 | 「N - 2 人分」「M - 3 個分」を明示 |
+| 残すリソース選択 | チェックボックスで「残す」「アーカイブ」を選択 |
+| アーカイブ動作 | `is_archived = true` フラグ。物理削除しない |
+| アップグレード時の復元 | `is_archived = false` に戻すだけで完全復元可能 |
+| 履歴保持の警告 | 現在の保持日数 > 新プランの保持日数なら「古い履歴は閲覧不可になります」警告 |
+
+### 5.3 ダウングレード経路への組み込み案
+
+現状は Customer Portal を直叩きしているため、超過リソース処理を **Portal 遷移前** に実施する必要がある。実装方針:
+
+1. `/admin/license` で「ダウングレード」を選んだ時点で、まず先に超過リソースチェック画面を表示
+2. ユーザーが残すリソースを選択 → サーバーで `is_archived` を更新
+3. 確認完了後に Customer Portal セッションを発行
+4. Portal でユーザーが実際にダウングレード → Webhook で `plan` を更新
+5. Webhook 受信時、新プランの上限に対して `is_archived = false` のリソース数をアサート（不整合なら追加でアーカイブ）
+
+> 詳細仕様は #738 で定義。
+
+---
+
+## 6. 月額 ↔ 年額切替
+
+### 6.1 新規購入時
+
+`/admin/license` のプランカード上部にあるトグル (`billingInterval` state) で `monthly` ↔ `yearly` を切り替えてから購入ボタンを押す。`planId` は以下にマッピング:
+
+| プラン × 期間 | planId | Stripe Price ID 取得元 |
+|--------------|--------|----------------------|
+| standard × monthly | `monthly` | `STRIPE_PRICE_STANDARD_MONTHLY` |
+| standard × yearly | `yearly` | `STRIPE_PRICE_STANDARD_YEARLY` |
+| family × monthly | `family-monthly` | `STRIPE_PRICE_FAMILY_MONTHLY` |
+| family × yearly | `family-yearly` | `STRIPE_PRICE_FAMILY_YEARLY` |
+
+年額は約 17% OFF（`¥500/月 → ¥5,000/年`、`¥780/月 → ¥7,800/年`）。
+
+### 6.2 既存ユーザーの切替
+
+Customer Portal 経由のみ。Portal 内の「プラン変更」UI から切り替える。Stripe が proration（日割り計算）を自動で実施する。
+
+> **注意 (#786 連動)**: 「月額↔年額切替がどの画面から可能か不明」「proration の扱い未定義」と #786 で指摘されている。本ドキュメントの本セクションで「Customer Portal で実施・proration は Stripe 自動」を仕様として確定させた。UI 側の導線案内も #786 で改善予定。
+
+---
+
+## 7. ライセンスキー適用フロー（Stripe を経由しない昇格）
+
+### 7.1 経路
+
+`/admin/license` の「ライセンスキー適用」フォーム → `?/applyLicenseKey` action → `consumeLicenseKey` サービス。
+
+```
+[/admin/license]
+  └─ 「ライセンスキーを適用」入力欄
+        │
+        ▼
+  確認ダイアログ
+        │
+        ▼
+  POST ?/applyLicenseKey  (form action)
+        │
+        ├─ 認可: requireRole(['owner'])  ← parent/child は 403
+        ├─ validateLicenseKey(rawKey)
+        │    └─ 形式・存在・状態（unused / not expired / not revoked）
+        ▼
+  consumeLicenseKey(rawKey, tenantId)
+        │
+        ├─ ライセンスを consumed にマーク
+        ├─ tenant.plan を昇格
+        ├─ tenant.planExpiresAt を設定（あれば）
+        ▼
+  { apply: { success: true, plan, planExpiresAt } }
+        │
+        ▼
+  data リロード → PlanStatusCard / 現在のプラン表示が更新
+```
+
+### 7.2 Stripe との関係
+
+- ライセンスキーは **Stripe を経由せず** プランを昇格させる
+- 用途: キャンペーン配布 / サポート対応 / 法人顧客の請求書払い等
+- consumed 後は同じキーを再利用不可（buyer_tenant にロック / #801）
+- Stripe Subscription は発生しないため、`stripeSubscriptionId = undefined` のまま
+- このため Customer Portal は使用不可（「サブスクリプション無し → プラン選択 UI」が表示される）
+- 期限切れ時は `/api/cron/license-key-revoke` 等で自動失効（#821 で実装予定）
+
+---
+
+## 8. 状態マシン（簡略版）
+
+```
+                   ┌──────────────┐
+                   │     free     │
+                   └──────┬───────┘
+                          │ checkout (購入)
+                          │ or applyLicenseKey
+                          ▼
+                   ┌──────────────┐
+        ┌─────────►│   standard   │◄─────────┐
+        │          └──────┬───────┘          │
+        │                 │ Portal でアップ  │
+        │                 │ (webhook updated)│
+        │                 ▼                  │
+        │          ┌──────────────┐          │
+        │          │    family    │          │
+        │          └──────┬───────┘          │
+        │                 │ Portal でダウン  │
+        │                 │ (webhook updated)│
+        │                 └──────────────────┘
+        │
+        │ 解約 (subscription.deleted)
+        │ → status=suspended, plan=undefined
+        ▼
+   ┌──────────────┐
+   │  suspended   │  ※ free 機能に縮退
+   └──────────────┘
+
+[並行] payment_failed → status=grace_period, planExpiresAt=now+7d
+        │
+        ├─ invoice.paid 受信 → status=active に戻る
+        └─ 7d 経過＆未払い → suspended に遷移
+```
+
+詳細な画面遷移は [`diagrams/plan-change-flow.drawio`](diagrams/plan-change-flow.drawio) を参照。
+
+---
+
+## 9. 確認 UX サマリ
+
+| アクション | 確認 UX | 理由 |
+|-----------|---------|------|
+| 新規購入 | プラン選択 → 「{プラン}プランで始める」→ Stripe Checkout でカード入力 | Stripe Checkout 自体が確認画面 |
+| プラン変更（昇格・降格） | PIN 入力 or 確認フレーズ → Customer Portal に遷移 | #771: 子供誤操作防止 |
+| 解約 | 同上 → Customer Portal で「Cancel Plan」 | Stripe Portal の標準 UI |
+| 支払い方法更新 | 同上 → Customer Portal で更新 | 同上 |
+| 月額 ↔ 年額切替 | 同上 → Customer Portal で変更 | 同上 |
+| ライセンスキー適用 | キー入力 → 確認ダイアログ → 適用 | owner ロールのみ実行可 |
+
+---
+
+## 10. 途中離脱時の状態管理
+
+### 10.1 Checkout 中断
+
+- ユーザーが Stripe Checkout を完了せず戻った場合: cancel_url (`/pricing`) にリダイレクト
+- Webhook は発火しないため DB は free のまま
+- 副作用なし（Stripe 側で incomplete な session が残るのみ、24h で自動失効）
+
+### 10.2 Customer Portal 中断
+
+- ユーザーが Portal を完了せず閉じた場合: 何も起こらない
+- Portal で実際に変更操作を完了しない限り Webhook は発火しない
+- DB は変更前の状態を維持
+
+### 10.3 Webhook 受信失敗
+
+- Stripe は自動でリトライ（最大 3 日、指数バックオフ）
+- アプリ側で 500 を返した場合 → Stripe が再送
+- 200 を返した場合 → 完了扱い
+- リコンサイル: Stripe Dashboard の Webhook ログで失敗イベントを目視確認可能。将来的に #821 で自動リトライ・調整 cron を予定
+
+### 10.4 ロールバック
+
+現状、明示的なロールバックは未実装。Webhook が成功した時点で DB は新状態に更新される。
+
+**将来検討 (#823)**: Stripe 側を正として DB を eventually consistent に保つため、定期的に `stripe.subscriptions.list` で全 active subscription をスキャンし、DB と乖離があれば修正する reconcile job を追加する想定。
+
+---
+
+## 11. テスト戦略
+
+### 11.1 ユニットテスト（vitest）
+
+- `handleCheckoutCompleted` / `handleSubscriptionUpdated` / `handleSubscriptionDeleted` / `handlePaymentFailed` のモックイベントテスト（既存）
+- `planIdFromPriceId` のマッピングテスト
+- `createCheckoutSession` の planId バリデーション（INVALID_PLAN 系）
+- Portal セッション作成の認可テスト（child=403、owner/parent=200）
+
+### 11.2 E2E（Playwright）
+
+- 既存: `tests/e2e/license-management.spec.ts`（PIN 確認ダイアログ表示）
+- **未整備**: アップグレード/ダウングレードの実際の Stripe 統合は test mode key が必要なため CI で動かない
+- ローカル認証モードでは Stripe API 呼び出しはスタブ化されており、Webhook イベントを直接モック注入してハンドラをテストする想定
+
+---
+
+## 12. 関連
+
+- 設計
+  - [06-UI設計書.md §10](06-UI設計書.md) — プラン UI パターン全体（#743）
+  - [account-deletion-flow.md](account-deletion-flow.md) — 削除フロー（#746）
+  - #738 — ダウングレード前警告フロー（超過リソース処理）
+  - #786 — 月額↔年額切替の UI 導線改善 / proration 仕様
+  - #823 — Tenant plan 状態マシン統一 EPIC
+- ADR
+  - [ADR-0022](decisions/0022-billing-data-lifecycle-consistency.md) — 課金サイクルとデータライフサイクルの整合性
+- 実装
+  - `src/routes/(parent)/admin/license/+page.svelte`
+  - `src/routes/(parent)/admin/license/+page.server.ts`
+  - `src/routes/api/stripe/checkout/+server.ts`
+  - `src/routes/api/stripe/portal/+server.ts`
+  - `src/routes/api/stripe/webhook/+server.ts`
+  - `src/lib/server/services/stripe-service.ts`
+  - `src/lib/server/stripe/config.ts`
+
+---
+
+## 更新履歴
+
+| 日付 | 版数 | 内容 |
+|------|------|------|
+| 2026-04-11 | 1.0 | #747 初版作成（実装状態を反映） |


### PR DESCRIPTION
## Summary

- `docs/design/plan-change-flow.md` を新設し、以下を SSOT 化:
  - **アップグレード (新規購入)**: `/admin/license` プラン選択 → `POST /api/stripe/checkout` → Stripe Checkout → `checkout.session.completed` Webhook → `handleCheckoutCompleted` (ライセンスキー発行 + Discord 通知)
  - **アップグレード/ダウングレード/解約 (既存ユーザー)**: `/admin/license` ボタン → PIN/フレーズ確認 (#771) → `POST /api/stripe/portal` → Customer Portal → Webhook (`customer.subscription.updated` / `deleted`)
  - **支払い失敗 → 猶予期間**: `invoice.payment_failed` → `status='grace_period'`, `planExpiresAt = now + 7d` (`GRACE_PERIOD_DAYS = 7`) → リトライ成功で `active` 復帰 / 7d 経過で `suspended`
  - **月額↔年額切替**: 新規=トグル / 既存=Customer Portal 経由 (#786 連動の仕様確定)
  - **ライセンスキー適用**: `applyLicenseKey` action → `consumeLicenseKey` (Stripe を経由しない昇格)
  - **ダウングレード時の超過リソース処理**: 現状未実装、#738 で実装予定の仕様を §5 に明記
- `docs/design/diagrams/plan-change-flow.drawio` に **3 ページ図** を追加
  - **Page 1**: 新規購入フロー (`/admin/license` → checkout API → Stripe Checkout → success_url + Webhook)
  - **Page 2**: Customer Portal 経由 (PIN ゲート + 2 種 Webhook 分岐 + 「テナント本体は残す」明示)
  - **Page 3**: 支払い失敗 → 猶予期間 → リトライ復帰経路 / 7d 放置 → suspended 経路
- `docs/CLAUDE.md` の設計書更新ルール表に 1 行追加

## Acceptance Criteria

- [x] 新規設計書作成 (`docs/design/plan-change-flow.md`, 約 320 行)
- [x] drawio 図追加 (`docs/design/diagrams/plan-change-flow.drawio`, 3 ページ)
- [x] CLAUDE.md 設計書一覧に追加

## 関連

- #747 (このIssue)
- #738 — ダウングレード前警告フロー（§5 で連動仕様を明記）
- #741 / ADR-0022 — Stripe キャンセル先行（解約フロー §3 で参照）
- #771 — Customer Portal 前の PIN ゲート（§3.1 で実装一致を明文化）
- #786 — 月額↔年額切替の UI 導線（§6.2 で proration を Stripe 自動と確定）
- #823 — Tenant plan 状態マシン統一 EPIC（§10.4 ロールバック方針で参照）
- ADR-0003

## Test plan

- [ ] drawio が draw.io デスクトップ / app.diagrams.net で開けることを確認
- [ ] biome check (`.md` は ignore 対象) — 影響なし
- [ ] svelte-check / vitest / playwright — ドキュメント変更のため影響なし

closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)