### PR TITLE
fix: #911 [CRITICAL] AWS_LICENSE_SECRET を deploy.yml / deploy-nuc.yml / CDK に配布

### DIFF
--- a/.github/workflows/deploy-nuc.yml
+++ b/.github/workflows/deploy-nuc.yml
@@ -40,6 +40,32 @@ jobs:
       - name: Pull latest code
         run: git pull origin main
 
+      # Step 2.5: Inject AWS_LICENSE_SECRET into .env (#806, #911)
+      # production NODE_ENV では assertLicenseKeyConfigured() が起動時に必須化しており、
+      # .env から AWS_LICENSE_SECRET が読めないとコンテナが health check に失敗する。
+      # secret は GitHub repo secrets で1度だけ設定すれば、以降の deploy は自動で反映される。
+      - name: Inject AWS_LICENSE_SECRET into .env
+        env:
+          AWS_LICENSE_SECRET: ${{ secrets.AWS_LICENSE_SECRET }}
+        run: |
+          if ([string]::IsNullOrEmpty($env:AWS_LICENSE_SECRET)) {
+            throw "AWS_LICENSE_SECRET is not configured in GitHub repo secrets. See #911 / ADR-0026."
+          }
+          $envFile = ".env"
+          $newLine = "AWS_LICENSE_SECRET=$env:AWS_LICENSE_SECRET"
+          if (Test-Path $envFile) {
+            $content = Get-Content $envFile
+            if ($content -match "^AWS_LICENSE_SECRET=") {
+              $content = $content -replace "^AWS_LICENSE_SECRET=.*", $newLine
+            } else {
+              $content += $newLine
+            }
+            $content | Set-Content $envFile
+          } else {
+            Set-Content -Path $envFile -Value $newLine
+          }
+          Write-Host "AWS_LICENSE_SECRET injected into .env"
+
       # Step 3: Rebuild and start containers (stop -> build -> up order is critical for WAL safety)
       # Dockerfile regenerates APP_VERSION at build time (#711), so no host-side tsx required.
       # BUILD_TIMESTAMP busts the build-stage cache (#711 / PR #826 review) — without this,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,10 +75,16 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
+      # AWS_LICENSE_SECRET is required by hooks.server.ts in NODE_ENV=production (#806, #911)
+      # without it, `vite preview` fails before Playwright can even reach the test step.
       - run: npx playwright test
+        env:
+          AWS_LICENSE_SECRET: ${{ secrets.AWS_LICENSE_SECRET }}
 
       # E2E tests (cognito-dev mode)
       - run: npx playwright test --config playwright.cognito-dev.config.ts
+        env:
+          AWS_LICENSE_SECRET: ${{ secrets.AWS_LICENSE_SECRET }}
 
   deploy:
     needs: test
@@ -208,6 +214,7 @@ jobs:
           -c stripePriceFamilyYearly=${{ vars.STRIPE_PRICE_FAMILY_YEARLY }}
           -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }}
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
+          -c awsLicenseSecret=${{ secrets.AWS_LICENSE_SECRET }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }}
 

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -1,5 +1,37 @@
 # infra/ — デプロイ手順
 
+## production 環境変数チェックリスト（必須 — #911 / ADR-0026）
+
+新しい環境必須シークレットを追加した場合は、**必ず以下の 4 経路すべてに配布する**こと。
+1 経路でも欠けると本番デプロイが完全停止する（#911 で 25 連続失敗の前例あり）。
+
+| 経路 | 配布先 | 配布方法 | 担当 |
+|---|---|---|---|
+| ① test 用（GitHub Actions） | `deploy.yml` test job の `npx playwright test` env | `${{ secrets.NAME }}` を `env:` で渡す | dev |
+| ② AWS Lambda（GitHub Actions 経由） | `compute-stack.ts` の Lambda environment | `deploy.yml` で `-c name=${{ secrets.NAME }}` → CDK context → environment | dev |
+| ③ NUC 自宅サーバー（self-hosted runner） | `C:\Docker\ganbari-quest\.env` | `deploy-nuc.yml` の `Inject ... into .env` step で書き込み | dev |
+| ④ 開発者ローカル | `.env.local` | `.env.example` に追記し、各開発者が個別配置 | dev |
+
+### 必須シークレット一覧
+
+| 環境変数名 | 用途 | 生成方法 | GitHub Secret 名 |
+|---|---|---|---|
+| `AWS_LICENSE_SECRET` | ライセンスキー HMAC 署名（#806, ADR-0026） | `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"` | `AWS_LICENSE_SECRET` |
+| `STRIPE_SECRET_KEY` | Stripe 決済 | Stripe ダッシュボード | `STRIPE_SECRET_KEY` |
+| `STRIPE_WEBHOOK_SECRET` | Stripe Webhook 検証 | Stripe ダッシュボード | `STRIPE_WEBHOOK_SECRET` |
+| `OPS_SECRET_KEY` | /ops ダッシュボード認証 | 任意のランダム値 | `OPS_SECRET_KEY` |
+| `GEMINI_API_KEY` | Gemini API（リリースノート生成等） | Google AI Studio | `GEMINI_API_KEY` |
+
+新しいシークレットを追加するときの手順:
+1. **GitHub Secrets** に登録 (`gh secret set NAME`)
+2. **`.env.example`** に追記してチームに周知
+3. **`deploy.yml`** の test job env に追加 + `deploy.yml` の CDK deploy step に `-c` で渡す
+4. **`infra/lib/compute-stack.ts`** で `tryGetContext` から読み Lambda environment に追加
+5. **`deploy-nuc.yml`** の `Inject ... into .env` step に追加（NUC 用）
+6. **本表に追記** し、PR description でチェック
+
+> **PR マージ前チェック**: 「上記 5 ステップが揃っているか」を `.github/CLAUDE.md` の Done 基準に含めること（#911 再発防止）。
+
 ## AWS Lambda 本番（ganbari-quest.com）
 
 - **自動デプロイ**: main ブランチへの push で GitHub Actions が自動実行

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -62,6 +62,12 @@ export class ComputeStack extends cdk.Stack {
 		// --- OPS Dashboard（CDK context 経由で GitHub Actions Secrets から取得） ---
 		const opsSecretKey = this.node.tryGetContext('opsSecretKey') ?? '';
 
+		// --- License HMAC Secret (#806, #911) ---
+		// production では `assertLicenseKeyConfigured()` が起動時に必須化しており、
+		// 未設定だと Lambda が cold start で例外死する。GitHub Secrets の
+		// `AWS_LICENSE_SECRET` を必ず設定すること（ADR-0026）。
+		const awsLicenseSecret = this.node.tryGetContext('awsLicenseSecret') ?? '';
+
 		// --- Discord Webhook URLs（CDK context 経由で GitHub Actions Secrets から取得） ---
 		const feedbackDiscordWebhookUrl = this.node.tryGetContext('feedbackDiscordWebhookUrl') ?? '';
 		const discordWebhookSignup = this.node.tryGetContext('discordWebhookSignup') ?? '';
@@ -110,6 +116,7 @@ export class ComputeStack extends cdk.Stack {
 					? { DISCORD_WEBHOOK_INCIDENT: discordWebhookIncident }
 					: {}),
 				...(opsSecretKey ? { OPS_SECRET_KEY: opsSecretKey } : {}),
+				...(awsLicenseSecret ? { AWS_LICENSE_SECRET: awsLicenseSecret } : {}),
 				...(geminiApiKey ? { GEMINI_API_KEY: geminiApiKey } : {}),
 				...(stripeSecretKey ? { STRIPE_SECRET_KEY: stripeSecretKey } : {}),
 				...(stripeWebhookSecret ? { STRIPE_WEBHOOK_SECRET: stripeWebhookSecret } : {}),


### PR DESCRIPTION
## サマリ

PR #863 (#806) で license-key-service.ts に production 起動時 assertion を入れた一方、
deploy.yml と deploy-nuc.yml の secret 配線が同 PR に含まれず、本番デプロイが
**25 連続失敗 (~10 時間)** で完全停止した。

ADR-0026 を後退させずに、`AWS_LICENSE_SECRET` を 4 経路すべてに配線する。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `.github/workflows/deploy.yml` | test job の playwright 2 step に `env: AWS_LICENSE_SECRET`、deploy job の cdk deploy に `-c awsLicenseSecret` |
| `.github/workflows/deploy-nuc.yml` | pull 後・docker build 前に `Inject AWS_LICENSE_SECRET into .env` step を追加 |
| `infra/lib/compute-stack.ts` | `tryGetContext('awsLicenseSecret')` → Lambda environment 配線 |
| `infra/CLAUDE.md` | 「production 環境変数チェックリスト」を新設 (4 経路 × 必須シークレット表 + 6 ステップ追加手順) |

## ⚠️ ユーザー作業必須 (マージ前)

このコードは GitHub Secrets `AWS_LICENSE_SECRET` を**参照する**だけ。
secret 値そのものは Auto Mode の安全境界 (CLAUDE.md「.env や認証情報に関わるファイルの変更」)
を超えるためエージェント側では設定していない。**マージ前に手動設定が必要**。

\`\`\`bash
# 1. 32 byte hex を生成
node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"

# 2. GitHub Secrets に登録
gh secret set AWS_LICENSE_SECRET

# 3. (推奨) 同値を AWS SSM Parameter Store にバックアップ
aws ssm put-parameter --name /ganbari-quest/license-secret \
  --type SecureString --value <hex>
\`\`\`

NUC は self-hosted runner なので追加作業不要 (deploy-nuc.yml が secret から
.env を自動生成する)。

## ローカル検証

- [x] CDK tsc 型チェック green (`infra && npx tsc --noEmit`)
- [x] YAML 構文 valid (js-yaml で deploy.yml + deploy-nuc.yml をパース確認)
- [x] biome は対象外 (workflow / md / infra ファイル)

## マージ後検証 (本 PR の Done 基準)

- [ ] **GitHub Secrets `AWS_LICENSE_SECRET` を登録済み** (上記)
- [ ] deploy.yml が green で完走
- [ ] deploy-nuc.yml が green で完走
- [ ] Lambda Function URL `/api/health` が 200
- [ ] NUC `http://localhost:3000/api/health` が 200

## 影響範囲

- 25 連続失敗中の deploy.yml / deploy-nuc.yml が解消
- マージされた #864-#900 (約 25 件) の修正が初めて本番に届く
- e2e-production / release-notes / Discord 通知も連鎖復旧

## 関連

- 原因 PR: #863 (#806 close)
- ADR: #809 / PR #844 (ADR-0026)
- ADR-0026 追記 issue: #869

closes #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)