### PR TITLE
test(e2e): #779 plan-standard / plan-family の機能疎通 E2E を追加

### DIFF
--- a/playwright.cognito-dev.config.ts
+++ b/playwright.cognito-dev.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
 	testDir: 'tests/e2e',
 	// #776: plan-gated-features spec も cognito-dev モードでのみ実行可能
 	// （local モードでは resolvePlanTier が常に 'family' を返すため）
-	testMatch: /(cognito-auth|plan-gated-features)\.spec\.ts$/,
+	// #779: plan-standard / plan-family の機能疎通 spec を追加
+	testMatch: /(cognito-auth|plan-gated-features|plan-standard|plan-family)\.spec\.ts$/,
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 1,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,11 @@ export default defineConfig({
 		'**/cognito-auth.spec.ts',
 		// #776, #779: プラン別ゲート E2E は cognito-dev モード専用
 		// （playwright.cognito-dev.config.ts でのみ実行する）
+		// local モードでは email/password ログインフォームが存在せず、
+		// loginAsPlan() が 180s 待ちで CI を hang させるため必ず除外する
 		'**/plan-gated-features.spec.ts',
+		'**/plan-standard.spec.ts',
+		'**/plan-family.spec.ts',
 		'**/production-smoke.spec.ts',
 		// ビジュアル回帰テストはプラットフォーム固有のスナップショットを使うため
 		// CI（Linux）ではスキップし、ローカル開発でのUI崩壊検知にのみ使用する

--- a/src/lib/features/admin/components/PlanStatusCard.svelte
+++ b/src/lib/features/admin/components/PlanStatusCard.svelte
@@ -55,7 +55,7 @@ const trialTierLabel = $derived(
 </script>
 
 <Card class="plan-status-card plan-status-card--{planTier}">
-	<div class="plan-status">
+	<div class="plan-status" data-testid="plan-status-card" data-plan-tier={planTier}>
 		<h3 class="plan-status__title">
 			{#if label.icon}<span class="plan-status__icon">{label.icon}</span>{/if}
 			{label.name}

--- a/tests/e2e/plan-family.spec.ts
+++ b/tests/e2e/plan-family.spec.ts
@@ -1,0 +1,75 @@
+// tests/e2e/plan-family.spec.ts
+// #779: ファミリープランの機能疎通 E2E
+//
+// AUTH_MODE=cognito + COGNITO_DEV_MODE=true で DevCognitoAuthProvider の
+// dev-tenant-family（plan=family_monthly）でログインし、
+// 「family だからこそ全機能が解放されている」状態を一通り確認する。
+//
+// 設計意図:
+//  - free / standard で出ていたアップセル UI が一切出ないこと
+//  - family 限定機能（ひとことメッセージ等）が enabled で操作可能なこと
+//  - PlanStatusCard が family を示すこと
+//
+// 実行: npx playwright test --config playwright.cognito-dev.config.ts plan-family
+
+import { expect, test } from '@playwright/test';
+import { loginAsPlan, warmupAdminPages } from './plan-login-helpers';
+
+test.beforeAll(async ({ browser }) => {
+	test.setTimeout(360_000);
+	await warmupAdminPages(browser, [
+		'/admin',
+		'/admin/license',
+		'/admin/reports',
+		'/admin/settings',
+		'/admin/messages',
+	]);
+});
+
+test.describe('#779 family プラン — 全機能解放確認', () => {
+	test.beforeEach(() => {
+		test.slow();
+	});
+
+	test('/admin/license の PlanStatusCard が family を示す', async ({ page }) => {
+		await loginAsPlan(page, 'family');
+		await page.goto('/admin/license');
+		const card = page.getByTestId('plan-status-card');
+		await expect(card).toBeVisible();
+		await expect(card).toHaveAttribute('data-plan-tier', 'family');
+		// free 用アップセル CTA は出ない
+		await expect(page.getByTestId('plan-status-free-cta')).toHaveCount(0);
+		// 本契約済みなのでトライアルバッジは出ない
+		await expect(page.getByTestId('plan-status-trial-badge')).toHaveCount(0);
+	});
+
+	test('/admin にホームを開いても free 用 quick-link が出ない', async ({ page }) => {
+		await loginAsPlan(page, 'family');
+		await page.goto('/admin');
+		await expect(page.locator('.plan-quick-link--free')).toHaveCount(0);
+	});
+
+	test('/admin/reports — weekly-report-upsell バナーが出ない', async ({ page }) => {
+		await loginAsPlan(page, 'family');
+		await page.goto('/admin/reports');
+		await expect(page.getByTestId('weekly-report-upsell')).toHaveCount(0);
+	});
+
+	test('/admin/settings — エクスポートボタンが有効化されている', async ({ page }) => {
+		await loginAsPlan(page, 'family');
+		await page.goto('/admin/settings');
+		await expect(page.getByTestId('data-export-section')).toBeVisible();
+		await expect(page.getByTestId('export-upsell')).toHaveCount(0);
+		const exportBtn = page.getByTestId('data-export-button');
+		await expect(exportBtn).toBeVisible();
+		await expect(exportBtn).toBeEnabled();
+	});
+
+	test('/admin/messages — ひとことメッセージは family 限定機能として有効', async ({ page }) => {
+		await loginAsPlan(page, 'family');
+		await page.goto('/admin/messages');
+		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
+		await expect(textBtn).toBeVisible();
+		await expect(textBtn).toBeEnabled();
+	});
+});

--- a/tests/e2e/plan-gated-features.spec.ts
+++ b/tests/e2e/plan-gated-features.spec.ts
@@ -13,42 +13,14 @@
 //  - /admin/rewards: rewards-upgrade-banner（free のみ表示）
 //  - /admin/messages: ひとことメッセージボタン（free/standard は disabled、family は enabled）
 
-import type { Page } from '@playwright/test';
 import { expect, test } from '@playwright/test';
-
-const PLAN_USERS = {
-	free: { email: 'free@example.com', password: 'Gq!Dev#Free2026xy' },
-	standard: { email: 'standard@example.com', password: 'Gq!Dev#Std2026xyz' },
-	family: { email: 'family@example.com', password: 'Gq!Dev#Fam2026xyz' },
-} as const;
-
-async function loginAs(page: Page, plan: keyof typeof PLAN_USERS) {
-	const { email, password } = PLAN_USERS[plan];
-	// Vite dev のコールドコンパイルでは load/domcontentloaded が長時間完了しないため、
-	// commit イベントで navigation を解除し、フォーム表示は waitFor で待つ。
-	await page.goto('/auth/login', { waitUntil: 'commit', timeout: 180_000 });
-	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 180_000 });
-	await page.getByLabel('メールアドレス').fill(email);
-	await page.getByLabel('パスワード', { exact: true }).fill(password);
-	await page.getByRole('button', { name: 'ログイン' }).click();
-	await page.waitForURL(/\/admin/, { timeout: 120_000 });
-}
+import { loginAsPlan as loginAs, warmupAdminPages } from './plan-login-helpers';
 
 // Vite dev のコールドコンパイルで /auth/login と /admin 配下の初回ビルドが
 // 数分かかることがあるため、テスト前に warmup でプリコンパイルを走らせる。
 test.beforeAll(async ({ browser }) => {
 	test.setTimeout(360_000);
-	const ctx = await browser.newContext();
-	const page = await ctx.newPage();
-	try {
-		await page.goto('/auth/login', { waitUntil: 'commit', timeout: 180_000 });
-		await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 180_000 });
-		// rewards/messages ページもプリコンパイルしておく（login 後にリダイレクトで /admin に飛ぶ）
-		await page.goto('/admin/rewards', { waitUntil: 'commit', timeout: 180_000 }).catch(() => {});
-		await page.goto('/admin/messages', { waitUntil: 'commit', timeout: 180_000 }).catch(() => {});
-	} finally {
-		await ctx.close();
-	}
+	await warmupAdminPages(browser, ['/admin/rewards', '/admin/messages']);
 });
 
 // ============================================================

--- a/tests/e2e/plan-login-helpers.ts
+++ b/tests/e2e/plan-login-helpers.ts
@@ -1,0 +1,58 @@
+// tests/e2e/plan-login-helpers.ts
+// #779: plan-standard.spec.ts / plan-family.spec.ts と
+// 既存 plan-gated-features.spec.ts で共有するログインヘルパー
+//
+// AUTH_MODE=cognito + COGNITO_DEV_MODE=true の dev cognito provider が
+// 用意しているプラン別ダミーユーザー（free / standard / family）を使う。
+// 詳しくは src/lib/server/auth/providers/cognito-dev.ts の DEV_USERS。
+
+import type { Page } from '@playwright/test';
+
+export const PLAN_USERS = {
+	free: { email: 'free@example.com', password: 'Gq!Dev#Free2026xy' },
+	standard: { email: 'standard@example.com', password: 'Gq!Dev#Std2026xyz' },
+	family: { email: 'family@example.com', password: 'Gq!Dev#Fam2026xyz' },
+} as const;
+
+export type PlanUserKey = keyof typeof PLAN_USERS;
+
+/**
+ * dev cognito provider の指定プランユーザーでログインし /admin に到達する。
+ *
+ * Vite dev のコールドコンパイルでは load/domcontentloaded の到達に
+ * 数十秒〜数分かかることがあるため、navigation は commit イベントで打ち切り、
+ * 画面要素は waitFor で待つ。
+ */
+export async function loginAsPlan(page: Page, plan: PlanUserKey): Promise<void> {
+	const { email, password } = PLAN_USERS[plan];
+	await page.goto('/auth/login', { waitUntil: 'commit', timeout: 180_000 });
+	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 180_000 });
+	await page.getByLabel('メールアドレス').fill(email);
+	await page.getByLabel('パスワード', { exact: true }).fill(password);
+	await page.getByRole('button', { name: 'ログイン' }).click();
+	await page.waitForURL(/\/admin/, { timeout: 120_000 });
+}
+
+/**
+ * Vite dev のコールドコンパイルで初回ビルドが数分かかる画面を warmup する。
+ * 各 spec の `test.beforeAll` から呼んで beforeEach のタイムアウトを抑える。
+ */
+export async function warmupAdminPages(
+	browser: import('@playwright/test').Browser,
+	paths: readonly string[],
+): Promise<void> {
+	const ctx = await browser.newContext();
+	const page = await ctx.newPage();
+	try {
+		await page.goto('/auth/login', { waitUntil: 'commit', timeout: 180_000 });
+		await page
+			.getByLabel('メールアドレス')
+			.waitFor({ state: 'visible', timeout: 180_000 })
+			.catch(() => {});
+		for (const path of paths) {
+			await page.goto(path, { waitUntil: 'commit', timeout: 180_000 }).catch(() => {});
+		}
+	} finally {
+		await ctx.close();
+	}
+}

--- a/tests/e2e/plan-standard.spec.ts
+++ b/tests/e2e/plan-standard.spec.ts
@@ -1,0 +1,80 @@
+// tests/e2e/plan-standard.spec.ts
+// #779: スタンダードプランの機能疎通 E2E
+//
+// AUTH_MODE=cognito + COGNITO_DEV_MODE=true で DevCognitoAuthProvider の
+// dev-tenant-standard（plan=standard_monthly）でログインし、
+// 「standard だからこそ表示される / されない」UI を一通り確認する。
+//
+// 設計意図:
+//  - free 専用のアップセル UI（weekly-report-upsell / export-upsell / plan-quick-link--free）が
+//    出ないことを negative assertion で押さえる
+//  - 同時に「ある機能はまだ family 限定で disabled のままか」も確認し、
+//    standard ↔ family のプラン境界を回帰検知できるようにする
+//
+// 実行: npx playwright test --config playwright.cognito-dev.config.ts plan-standard
+
+import { expect, test } from '@playwright/test';
+import { loginAsPlan, warmupAdminPages } from './plan-login-helpers';
+
+test.beforeAll(async ({ browser }) => {
+	test.setTimeout(360_000);
+	await warmupAdminPages(browser, [
+		'/admin',
+		'/admin/license',
+		'/admin/reports',
+		'/admin/settings',
+		'/admin/messages',
+	]);
+});
+
+test.describe('#779 standard プラン — 機能疎通', () => {
+	test.beforeEach(() => {
+		test.slow(); // Vite dev のコールドコンパイルでタイムアウトを 3x 延長
+	});
+
+	test('/admin/license の PlanStatusCard が standard を示す', async ({ page }) => {
+		await loginAsPlan(page, 'standard');
+		await page.goto('/admin/license');
+		const card = page.getByTestId('plan-status-card');
+		await expect(card).toBeVisible();
+		await expect(card).toHaveAttribute('data-plan-tier', 'standard');
+		// free 用アップセル CTA は出ない
+		await expect(page.getByTestId('plan-status-free-cta')).toHaveCount(0);
+		// standard はまだトライアル文言を出さない（本契約済み）
+		await expect(page.getByTestId('plan-status-trial-badge')).toHaveCount(0);
+	});
+
+	test('/admin にホームを開いても free 用 quick-link が出ない', async ({ page }) => {
+		await loginAsPlan(page, 'standard');
+		await page.goto('/admin');
+		// free のときだけ表示される「無料プラン もっと便利に使いませんか？」リンク
+		await expect(page.locator('.plan-quick-link--free')).toHaveCount(0);
+	});
+
+	test('/admin/reports — weekly-report-upsell バナーが出ない', async ({ page }) => {
+		await loginAsPlan(page, 'standard');
+		await page.goto('/admin/reports');
+		await expect(page.getByTestId('weekly-report-upsell')).toHaveCount(0);
+	});
+
+	test('/admin/settings — エクスポートボタンが有効化されている', async ({ page }) => {
+		await loginAsPlan(page, 'standard');
+		await page.goto('/admin/settings');
+		await expect(page.getByTestId('data-export-section')).toBeVisible();
+		// free 用アップセルは出ない
+		await expect(page.getByTestId('export-upsell')).toHaveCount(0);
+		// data-export-button は活性化（free のときは disabled）
+		const exportBtn = page.getByTestId('data-export-button');
+		await expect(exportBtn).toBeVisible();
+		await expect(exportBtn).toBeEnabled();
+	});
+
+	test('/admin/messages — ひとことメッセージは family 限定で disabled のまま', async ({ page }) => {
+		// プラン境界の回帰検知: standard はまだ family 限定機能にアクセスできない
+		await loginAsPlan(page, 'standard');
+		await page.goto('/admin/messages');
+		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
+		await expect(textBtn).toBeVisible();
+		await expect(textBtn).toBeDisabled();
+	});
+});


### PR DESCRIPTION
## Summary
- #776 で plan-gated-features spec により free / family のゲート UI をピンポイント検証していたが、standard / family の **「全機能が正しく解放されているか」の疎通テスト** がなかった
- プラン解決ロジックの回帰や Premium 機能のリグレッションを早期検知するため、プラン別の機能疎通 spec を追加
- ログインヘルパを `plan-login-helpers.ts` に共通化し、既存 `plan-gated-features.spec.ts` も DRY 化

## 追加した spec

### `tests/e2e/plan-standard.spec.ts`
- `/admin/license` → `PlanStatusCard` の `data-plan-tier="standard"`、free 用 CTA / トライアルバッジが出ない
- `/admin` → free 用 `plan-quick-link--free` が出ない
- `/admin/reports` → `weekly-report-upsell` バナーが出ない
- `/admin/settings` → `data-export-button` 有効、`export-upsell` 非表示
- `/admin/messages` → ひとことメッセージは family 限定で **disabled のまま** (境界回帰検知)

### `tests/e2e/plan-family.spec.ts`
- `/admin/license` → `data-plan-tier="family"`、free 用 CTA / トライアルバッジ非表示
- `/admin` → `plan-quick-link--free` 非表示
- `/admin/reports` → `weekly-report-upsell` 非表示
- `/admin/settings` → `data-export-button` 有効、`export-upsell` 非表示
- `/admin/messages` → ひとことメッセージ **enabled** (family 限定機能)

## 周辺変更
- `tests/e2e/plan-login-helpers.ts` (NEW): `PLAN_USERS` / `loginAsPlan` / `warmupAdminPages` を抽出
- `tests/e2e/plan-gated-features.spec.ts`: 共有ヘルパに移行して 32 行削減
- `playwright.cognito-dev.config.ts`: testMatch に `plan-standard` / `plan-family` を追加
- `src/lib/features/admin/components/PlanStatusCard.svelte`: `data-testid="plan-status-card"` + `data-plan-tier={planTier}` を追加 (プラン解決結果を安定して E2E から確認するため)

## 設計メモ
- `PremiumWelcome` は初回ログイン時にしか出ないので negative assertion の対象から除外
- きょうだいランキングは `data.rankingData.rankings.length > 1` 依存で dev cognito の seed では出ないため除外
- 既存 `plan-gated-features.spec.ts` の方法 (`AUTH_MODE=cognito + COGNITO_DEV_MODE=true`) に揃える ── ローカル auth モードでは `resolvePlanTier` が常に `family` を返してプラン分岐を検証できないため

## Test plan
- [ ] CI: `lint-and-test` 緑 (biome / svelte-check / vitest)
- [ ] CI: `e2e-test` 緑 (本 spec は cognito-dev config 専用なので main の e2e ジョブとは別経路)
- [ ] ローカル疎通: `npx playwright test --config playwright.cognito-dev.config.ts plan-standard plan-family`

closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)