### PR TITLE
test(e2e): #778 premium-welcome.spec.ts — 初回アップグレード時の歓迎モーダル

### DIFF
--- a/playwright.cognito-dev.config.ts
+++ b/playwright.cognito-dev.config.ts
@@ -9,7 +9,9 @@ export default defineConfig({
 	// #776: plan-gated-features spec も cognito-dev モードでのみ実行可能
 	// （local モードでは resolvePlanTier が常に 'family' を返すため）
 	// #779: plan-standard / plan-family の機能疎通 spec を追加
-	testMatch: /(cognito-auth|plan-gated-features|plan-standard|plan-family)\.spec\.ts$/,
+	// #778: premium-welcome モーダルの初回表示・dismiss spec を追加
+	testMatch:
+		/(cognito-auth|plan-gated-features|plan-standard|plan-family|premium-welcome)\.spec\.ts$/,
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 1,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,13 +4,14 @@ export default defineConfig({
 	testDir: 'tests/e2e',
 	testIgnore: [
 		'**/cognito-auth.spec.ts',
-		// #776, #779: プラン別ゲート E2E は cognito-dev モード専用
+		// #776, #779, #778: プラン別ゲート E2E は cognito-dev モード専用
 		// （playwright.cognito-dev.config.ts でのみ実行する）
 		// local モードでは email/password ログインフォームが存在せず、
 		// loginAsPlan() が 180s 待ちで CI を hang させるため必ず除外する
 		'**/plan-gated-features.spec.ts',
 		'**/plan-standard.spec.ts',
 		'**/plan-family.spec.ts',
+		'**/premium-welcome.spec.ts',
 		'**/production-smoke.spec.ts',
 		// ビジュアル回帰テストはプラットフォーム固有のスナップショットを使うため
 		// CI（Linux）ではスキップし、ローカル開発でのUI崩壊検知にのみ使用する

--- a/tests/e2e/premium-welcome.spec.ts
+++ b/tests/e2e/premium-welcome.spec.ts
@@ -1,0 +1,105 @@
+// tests/e2e/premium-welcome.spec.ts
+// #778: 初回アップグレード時の歓迎モーダル E2E
+//
+// PremiumWelcome モーダル（src/lib/features/admin/components/PremiumWelcome.svelte）の
+// トリガ条件と永続化動作を検証する。
+//
+// 表示条件:
+//  - planTier が standard / family
+//  - settings.premium_welcome_shown !== 'true'
+// 非表示化:
+//  - 「さっそく始める →」ボタン押下 → POST ?/dismissPremiumWelcome
+//    → settings.premium_welcome_shown = 'true' で永続化
+//
+// 設計メモ:
+//  - SQLite settings は tenantId 引数を無視するシングルテナント実装
+//    （src/lib/server/db/sqlite/settings-repo.ts）。よって全プランユーザー
+//    が同じ premium_welcome_shown を共有する。
+//    ローカル E2E では beforeEach で settings 行を削除して初回表示状態を再現し、
+//    afterEach で `'true'` に戻すことで他 spec への副作用を防ぐ。
+//
+// 実行: npx playwright test --config playwright.cognito-dev.config.ts premium-welcome
+
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import Database from 'better-sqlite3';
+import { loginAsPlan, warmupAdminPages } from './plan-login-helpers';
+
+const DB_PATH = path.resolve('data/ganbari-quest.db');
+
+function resetWelcomeFlag(): void {
+	const db = new Database(DB_PATH);
+	try {
+		db.prepare("DELETE FROM settings WHERE key = 'premium_welcome_shown'").run();
+	} finally {
+		db.close();
+	}
+}
+
+function markWelcomeDismissed(): void {
+	const db = new Database(DB_PATH);
+	try {
+		db.prepare(
+			"INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('premium_welcome_shown', 'true', datetime('now'))",
+		).run();
+	} finally {
+		db.close();
+	}
+}
+
+test.beforeAll(async ({ browser }) => {
+	test.setTimeout(360_000);
+	await warmupAdminPages(browser, ['/admin']);
+});
+
+test.afterEach(() => {
+	// 他 spec の /admin 訪問にモーダルがかぶらないよう必ず dismissed 状態に戻す
+	markWelcomeDismissed();
+});
+
+test.describe('#778 PremiumWelcome モーダル', () => {
+	test.beforeEach(() => {
+		test.slow(); // Vite dev のコールドコンパイルでタイムアウトを 3x 延長
+		resetWelcomeFlag();
+	});
+
+	test('standard プラン初回 /admin で歓迎モーダルが表示される', async ({ page }) => {
+		await loginAsPlan(page, 'standard');
+		await page.goto('/admin');
+		const dialog = page.getByRole('dialog', { name: /スタンダード.*ようこそ/ });
+		await expect(dialog).toBeVisible();
+		// 「解放された機能」セクションが含まれる
+		await expect(dialog.getByText('解放された機能')).toBeVisible();
+		// standard 固有の項目（PREMIUM_UNLOCKED_FEATURES.standard より）
+		await expect(dialog.getByText('AI による活動提案')).toBeVisible();
+	});
+
+	test('family プラン初回 /admin で歓迎モーダルが表示される', async ({ page }) => {
+		await loginAsPlan(page, 'family');
+		await page.goto('/admin');
+		const dialog = page.getByRole('dialog', { name: /ファミリー.*ようこそ/ });
+		await expect(dialog).toBeVisible();
+		// family 固有の項目（PREMIUM_UNLOCKED_FEATURES.family より）
+		await expect(dialog.getByText('きょうだいランキング')).toBeVisible();
+		await expect(dialog.getByText('ひとことメッセージ（自由テキスト）')).toBeVisible();
+	});
+
+	test('「さっそく始める」で閉じた後はリロードしても表示されない', async ({ page }) => {
+		await loginAsPlan(page, 'standard');
+		await page.goto('/admin');
+		const dialog = page.getByRole('dialog', { name: /スタンダード.*ようこそ/ });
+		await expect(dialog).toBeVisible();
+		await page.getByRole('button', { name: /さっそく始める/ }).click();
+		await expect(dialog).toHaveCount(0);
+		// リロード後も再表示されない（永続化されている）
+		await page.reload();
+		await expect(page.getByRole('dialog', { name: /ようこそ/ })).toHaveCount(0);
+	});
+
+	test('free プランでは歓迎モーダルは出ない（プラン条件ガード）', async ({ page }) => {
+		await loginAsPlan(page, 'free');
+		await page.goto('/admin');
+		// AdminHome の {#if welcomeVisible && (planTier === 'standard' || 'family')} ガード
+		await expect(page.getByRole('dialog', { name: /ようこそ/ })).toHaveCount(0);
+	});
+});


### PR DESCRIPTION
## Summary

#778 の `premium-welcome.spec.ts` を追加。`PremiumWelcome.svelte` の表示条件と dismiss 後の永続化動作を E2E で検証する。

## 検証ケース

- [x] standard プラン初回 `/admin` で歓迎モーダル表示 + 「AI による活動提案」項目
- [x] family プラン初回 `/admin` で歓迎モーダル表示 + 「きょうだいランキング」「ひとことメッセージ（自由テキスト）」など family 固有項目
- [x] 「さっそく始める →」ボタンで dismiss 後、リロードしても再表示されない（永続化）
- [x] free プランでは `{#if welcomeVisible && (planTier === 'standard' || 'family')}` ガードにより表示されない

## 設計メモ

- SQLite `settings` は `tenantId` 引数を無視するシングルテナント実装（`src/lib/server/db/sqlite/settings-repo.ts`）。
- よって全プランユーザーが同じ `premium_welcome_shown` を共有する → `beforeEach` で行削除して初回表示状態を再現
- `afterEach` で `'true'` に戻すことで他 spec の `/admin` 訪問にモーダルがかぶらないよう副作用を防ぐ
- `tests/e2e/plan-login-helpers.ts` の `loginAsPlan` / `warmupAdminPages` を流用（#779 で追加済み）

## 依存

- このブランチは #779 (`test/779-plan-standard-family-e2e`) を base にスタックしている。`#920` がマージされたら main にリベースする。
- DB 直接操作のため `better-sqlite3` を import するが、既に devDependencies に存在（vitest helpers と共有）。

## Test plan

- [ ] CI green（lint-and-test, e2e-test, ci-gate）
- [ ] cognito-dev 環境で実際にログインし、各アサーションが意図通り通ることを確認

## スクリーンショット

UI 変更を伴わないテスト追加 PR のため、参考スクショは省略。PremiumWelcome 自体の見た目は別 UI 改善 PR の責務。

🤖 Generated with [Claude Code](https://claude.com/claude-code)