### PR TITLE
infra(ci): #926 ci-gate を toJSON(needs) ベースに置換

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,13 +216,17 @@ jobs:
     needs: [changes, lint-and-test, e2e-test, docker-build, site-check, new-env-distribution-check]
     runs-on: ubuntu-latest
     steps:
+      # #926: needs を toJSON で一括チェックし、新規 job 追加時に results 配列の更新忘れで
+      # ゲートが素通りする事故を防ぐ。`needs:` リストへの追加だけで自動的にゲート対象になる。
       - name: Check CI results
+        env:
+          NEEDS: ${{ toJSON(needs) }}
         run: |
-          results=("${{ needs.changes.result }}" "${{ needs.lint-and-test.result }}" "${{ needs.e2e-test.result }}" "${{ needs.docker-build.result }}" "${{ needs.site-check.result }}" "${{ needs.new-env-distribution-check.result }}")
-          for r in "${results[@]}"; do
-            if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
-              echo "CI failed: $r"
-              exit 1
-            fi
-          done
-          echo "CI passed (jobs: ${results[*]})"
+          echo "Job results:"
+          echo "$NEEDS" | jq -r 'to_entries[] | "  \(.key): \(.value.result)"'
+          failed=$(echo "$NEEDS" | jq -r '[to_entries[] | select(.value.result == "failure" or .value.result == "cancelled")] | length')
+          if [ "$failed" -gt 0 ]; then
+            echo "CI failed: $failed job(s) failed or cancelled"
+            exit 1
+          fi
+          echo "CI passed"


### PR DESCRIPTION
## Summary

closes #926

`ci-gate` job の結果集計を、手動列挙の `results=(...)` 配列から `toJSON(needs)` + jq の一括チェックに置換しました。これにより、新規 job 追加時に `needs:` リストを更新するだけで自動的にゲート対象になります。

## 背景

PR #925 (#923 Phase 1) のレビュー時に発覚した構造的リスク:

```yaml
# Before
results=("${{ needs.changes.result }}" "${{ needs.lint-and-test.result }}" "${{ needs.e2e-test.result }}" "${{ needs.docker-build.result }}" "${{ needs.site-check.result }}")
```

`needs:` リスト と `results=(...)` の **2 か所** を同期しないと事故る構造でした。`results` 側の更新を忘れた場合、新規 job が `failure` になっても `ci-gate` が `pass` してブランチ保護をすり抜けます。

## 変更内容

```yaml
# After
env:
  NEEDS: ${{ toJSON(needs) }}
run: |
  echo "Job results:"
  echo "$NEEDS" | jq -r 'to_entries[] | "  \(.key): \(.value.result)"'
  failed=$(echo "$NEEDS" | jq -r '[to_entries[] | select(.value.result == "failure" or .value.result == "cancelled")] | length')
  if [ "$failed" -gt 0 ]; then
    echo "CI failed: $failed job(s) failed or cancelled"
    exit 1
  fi
  echo "CI passed"
```

- `toJSON(needs)` で全 job の状態を環境変数に渡す
- `jq` で `failure` / `cancelled` の件数を集計
- 1 件以上で `exit 1` （既存挙動と完全互換）
- 全 job の結果を逐次ログ出力するため可視性が上がる

## Acceptance Criteria

- [x] `ci-gate` の結果集計が手動列挙ではなく `toJSON(needs)` ベースになっている
- [x] 既存 job (changes/lint-and-test/e2e-test/docker-build/site-check) で従来通り failure 検知できる
- [x] `needs:` リストへの job 追加だけで自動的にゲート対象になる

## ADR-0029 整合性

「Safety Assertion Erosion Ban」の精神 ── ガード抜け穴を計画的に塞ぐ ── と整合します。手動列挙という抜け穴を、jq の一括チェックで構造的に閉じました。

## Test plan

- [ ] CI lint-and-test 通過（YAML 構文エラーなし）
- [ ] CI e2e-test 通過
- [ ] ci-gate 自身が SUCCESS になる（既存 job に対する互換性確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)