### PR TITLE
fix: #928 stripe-service.ts の svelte-check 型エラー2件を解消

### DIFF
--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -56,11 +56,10 @@ export async function createCheckoutSession(
 	// #314: Stripe 側 trial_period_days を廃止（アプリ側一元管理に移行）
 	const tierLabel = PLAN_LABELS[plan.tier as keyof typeof PLAN_LABELS] ?? plan.tier;
 
-	// #570: Stripe SDK v22 では `create(params?: ...)` と params が optional のため
-	// `Parameters<>[0]` が `SessionCreateParams | undefined` になる。
-	// `NonNullable<>` で undefined を除外して正しい型注釈を得る。
-	// 実行時の挙動は変わらない（型のみの修正）。
-	const sessionParams: NonNullable<Parameters<typeof stripe.checkout.sessions.create>[0]> = {
+	// #928: Stripe SDK v22 の `create(params?, requestOptions?)` オーバーロードにより
+	// `Parameters<>[0]` が `SessionCreateParams | RequestOptions | undefined` になる。
+	// Stripe.Checkout.SessionCreateParams を直接指定して型安全性を確保する。
+	const sessionParams: Stripe.Checkout.SessionCreateParams = {
 		mode: 'subscription',
 		payment_method_types: ['card'],
 		line_items: [{ price: plan.priceId, quantity: 1 }],


### PR DESCRIPTION
## Summary

closes #928

`stripe-service.ts` の svelte-check TypeScript エラー 2 件を修正。

### 原因

Stripe SDK v22 の `checkout.sessions.create(params?, requestOptions?)` オーバーロードにより、`Parameters<typeof stripe.checkout.sessions.create>[0]` が `SessionCreateParams | RequestOptions | undefined` を返す。`NonNullable<>` で `undefined` を除外しても union が残り:

- L64: `mode` は `SessionCreateParams` にのみ存在 → `RequestOptions` に存在しないエラー
- L98: `customer` も同様

### 修正

```diff
- const sessionParams: NonNullable<Parameters<typeof stripe.checkout.sessions.create>[0]> = {
+ const sessionParams: Stripe.Checkout.SessionCreateParams = {
```

`Stripe` 型は既に `import type Stripe from 'stripe'` で利用可能。

### 検証

```
npx svelte-check --tsconfig ./tsconfig.json
→ 0 ERRORS  40 WARNINGS  (修正前: 2 ERRORS)
```

## Test plan

- [x] `npx svelte-check` — エラー 0 件確認
- [ ] CI lint-and-test 通過
- [ ] CI e2e-test 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)