### PR TITLE
fix(test): フルスイート並列実行時のテストタイムアウトを解消

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -69,7 +69,6 @@ a:hover{text-decoration:underline}
 }
 
 const provider = getAuthProvider();
-const authMode = getAuthMode();
 
 const MAINTENANCE_MODE = process.env.MAINTENANCE_MODE === 'true';
 const COGNITO_DEV_MODE = process.env.COGNITO_DEV_MODE === 'true';
@@ -135,6 +134,7 @@ export const handle: Handle = ({ event, resolve }) =>
 	runWithRequestContext(async () => {
 		const start = Date.now();
 		const path = event.url.pathname;
+		const authMode = getAuthMode();
 
 		// リクエストID 生成（相関ID）
 		event.locals.requestId = randomUUID();

--- a/tests/unit/services/analytics-service.test.ts
+++ b/tests/unit/services/analytics-service.test.ts
@@ -1,7 +1,11 @@
 // tests/unit/services/analytics-service.test.ts
 // Analytics service unit tests
+// vi.resetModules() + dynamic import パターンのため、フルスイートではモジュール解決に時間がかかる
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// フルスイート並列実行時の dynamic import タイムアウト対策
+vi.setConfig({ testTimeout: 30_000 });
 
 // Mock the logger to avoid file I/O in tests
 vi.mock('$lib/server/logger', () => ({

--- a/tests/unit/services/consent-service.test.ts
+++ b/tests/unit/services/consent-service.test.ts
@@ -2,6 +2,10 @@
 // 同意サービスのユニットテスト (#0192)
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// フルスイート並列実行時の dynamic import タイムアウト対策
+vi.setConfig({ testTimeout: 15_000 });
+
 import type { ConsentRecord } from '../../../src/lib/server/auth/entities';
 
 const mockFindLatestConsent = vi.fn();

--- a/tests/unit/services/file-sanitizer.test.ts
+++ b/tests/unit/services/file-sanitizer.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// フルスイート並列実行時の sharp dynamic import タイムアウト対策
+vi.setConfig({ testTimeout: 30_000 });
+
 import {
 	safeContentType,
 	sanitizeAudio,

--- a/tests/unit/services/hooks-integration.test.ts
+++ b/tests/unit/services/hooks-integration.test.ts
@@ -1,10 +1,16 @@
 // tests/unit/services/hooks-integration.test.ts
 // hooks.server.ts の結合テスト (#0123: Identity型変更、PIN廃止)
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// フルスイート並列実行時の dynamic import タイムアウト対策
+// hooks.server.ts は依存が深く、並列実行時のモジュール解決に時間がかかる
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 60_000 });
+
 import type { AuthContext, Identity } from '../../../src/lib/server/auth/types';
 
 // --- モック定義 ---
+// hooks.server.ts の全依存をモック化し、並列実行時の深いモジュール解決を回避する
 
 const mockIsSetupRequired = vi.fn();
 vi.mock('$lib/server/services/setup-service', () => ({
@@ -44,6 +50,57 @@ vi.mock('$lib/server/auth/factory', () => ({
 		authorize: mockAuthorize,
 	}),
 	getAuthMode: () => currentAuthMode,
+}));
+
+// hooks.server.ts の残り依存モジュールをモック化（並列実行時のモジュール解決高速化）
+vi.mock('$app/environment', () => ({ building: false }));
+
+vi.mock('$lib/analytics', () => ({
+	analytics: {
+		init: vi.fn(),
+		isProviderActive: vi.fn(() => false),
+		getUmamiConfig: vi.fn(() => null),
+		identify: vi.fn(),
+		trackPageView: vi.fn(),
+		trackEvent: vi.fn(),
+		flush: vi.fn(),
+	},
+}));
+
+vi.mock('$lib/server/debug-plan', () => ({
+	applyDebugPlanOverride: (ctx: unknown) => ctx,
+}));
+
+vi.mock('$lib/server/demo/demo-plan', () => ({
+	applyDemoPlanToContext: (ctx: unknown) => ctx,
+	DEMO_PLAN_COOKIE: 'demo_plan',
+	isDemoPlan: () => false,
+	resolveDemoPlan: () => 'family',
+}));
+
+vi.mock('$lib/server/discord-alert', () => ({
+	sendDiscordAlert: vi.fn(async () => {}),
+}));
+
+vi.mock('$lib/server/request-context', () => ({
+	runWithRequestContext: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('$lib/server/routing/legacy-url-map', () => ({
+	findLegacyRedirect: () => null,
+	rewriteLegacyPath: () => '/',
+}));
+
+vi.mock('$lib/server/services/analytics-service', () => ({
+	trackServerError: vi.fn(),
+}));
+
+vi.mock('$lib/server/services/discord-notify-service', () => ({
+	notifyIncident: vi.fn(async () => {}),
+}));
+
+vi.mock('$lib/server/services/license-key-service', () => ({
+	assertLicenseKeyConfigured: vi.fn(),
 }));
 
 let currentAuthMode: 'local' | 'cognito' = 'local';
@@ -103,14 +160,16 @@ afterEach(() => {
 
 // vi.resetModules() + dynamic import は並列テスト実行時にモジュール解決が遅延するため
 // デフォルト 5s では不足することがある
-describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () => {
-	async function loadHandle() {
-		vi.resetModules();
-		// vi.mock はトップレベルで定義済み — ここでは再宣言不要
-		// vi.resetModules() 後でもトップレベルのモック定義が有効
+describe('hooks.server.ts handle（結合テスト）', { timeout: 30_000 }, () => {
+	// handle 関数は authMode をリクエストごとに getAuthMode() で取得するため、
+	// 1回だけ import してキャッシュ可能（currentAuthMode の変更が即座に反映される）
+	// biome-ignore lint/suspicious/noExplicitAny: dynamic import の型を静的に参照できないため
+	let handle: any;
+
+	beforeAll(async () => {
 		const mod = await import('../../../src/hooks.server');
-		return mod.handle;
-	}
+		handle = mod.handle;
+	});
 
 	describe('Local モード（認証なし）', () => {
 		it('local Identity で /admin アクセス → 正常レスポンス', async () => {
@@ -121,7 +180,6 @@ describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () 
 			mockResolveContext.mockResolvedValue(context);
 			mockAuthorize.mockReturnValue({ allowed: true });
 
-			const handle = await loadHandle();
 			const event = createMockEvent('/admin');
 			const resolve = createMockResolve();
 
@@ -138,7 +196,6 @@ describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () 
 			currentAuthMode = 'local';
 			mockIsSetupRequired.mockResolvedValue(true);
 
-			const handle = await loadHandle();
 			const event = createMockEvent('/admin');
 			const resolve = createMockResolve();
 
@@ -157,7 +214,6 @@ describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () 
 			mockIsSetupRequired.mockResolvedValue(false);
 			mockAuthorize.mockReturnValue({ allowed: true });
 
-			const handle = await loadHandle();
 			const event = createMockEvent('/setup');
 			const resolve = createMockResolve();
 
@@ -177,7 +233,6 @@ describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () 
 			mockResolveContext.mockResolvedValue(null);
 			mockAuthorize.mockReturnValue({ allowed: true });
 
-			const handle = await loadHandle();
 			const event = createMockEvent('/');
 			const resolve = createMockResolve();
 
@@ -196,7 +251,6 @@ describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () 
 			mockIsSetupRequired.mockResolvedValue(true);
 			mockAuthorize.mockReturnValue({ allowed: true });
 
-			const handle = await loadHandle();
 			const event = createMockEvent('/admin');
 			const resolve = createMockResolve();
 
@@ -214,7 +268,6 @@ describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () 
 			mockResolveContext.mockResolvedValue(context);
 			mockAuthorize.mockReturnValue({ allowed: true });
 
-			const handle = await loadHandle();
 			const event = createMockEvent('/admin');
 			const resolve = createMockResolve();
 
@@ -231,7 +284,6 @@ describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () 
 			currentAuthMode = 'cognito';
 			mockAuthorize.mockReturnValue({ allowed: false, redirect: '/auth/login', status: 401 });
 
-			const handle = await loadHandle();
 			const event = createMockEvent('/admin');
 			const resolve = createMockResolve();
 
@@ -252,7 +304,6 @@ describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () 
 			mockResolveContext.mockResolvedValue(null);
 			mockAuthorize.mockReturnValue({ allowed: false, redirect: '/auth/login' });
 
-			const handle = await loadHandle();
 			const event = createMockEvent('/admin');
 			const resolve = createMockResolve();
 
@@ -277,7 +328,6 @@ describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () 
 				redirect: '/admin/license?reason=expired',
 			});
 
-			const handle = await loadHandle();
 			const event = createMockEvent('/admin');
 			const resolve = createMockResolve();
 
@@ -297,7 +347,6 @@ describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () 
 			currentAuthMode = 'local';
 			mockAuthorize.mockReturnValue({ allowed: true });
 
-			const handle = await loadHandle();
 			const event = createMockEvent('/_app/immutable/chunks/app.js');
 			const resolve = createMockResolve();
 
@@ -312,7 +361,6 @@ describe('hooks.server.ts handle（結合テスト）', { timeout: 15_000 }, () 
 			currentAuthMode = 'local';
 			mockAuthorize.mockReturnValue({ allowed: true });
 
-			const handle = await loadHandle();
 			const event = createMockEvent('/api/health');
 			const resolve = createMockResolve();
 

--- a/tests/unit/services/signup-actions.test.ts
+++ b/tests/unit/services/signup-actions.test.ts
@@ -6,6 +6,9 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// フルスイート並列実行時の dynamic import タイムアウト対策
+vi.setConfig({ testTimeout: 30_000 });
+
 // --- Cognito Direct Auth モック ---
 const mockSignUp = vi.fn();
 const mockConfirmSignUp = vi.fn();

--- a/tests/unit/ui/sound-service.test.ts
+++ b/tests/unit/ui/sound-service.test.ts
@@ -2,6 +2,9 @@
 // サウンドサービスのユニットテスト
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 15_000 });
+
 import { SOUND_DEFS, SOUND_IDS, SOUND_TIER_CONFIG } from '../../../src/lib/ui/sound/sounds';
 
 // --- 定数テスト ---


### PR DESCRIPTION
## Summary
- フルスイート (3071テスト) 並列実行時に `hooks-integration`, `analytics-service`, `consent-service`, `signup-actions`, `file-sanitizer` テストがモジュール解決の競合でタイムアウトしていた問題を修正
- `hooks-integration.test.ts`: `hooks.server.ts` の全依存モジュールをモック化し、`beforeAll` の dynamic import を軽量化
- `src/hooks.server.ts`: `getAuthMode()` をモジュールスコープからリクエストハンドラ内に移動（テスト時の authMode 切替対応 + 正確性向上）

## Test plan
- [x] `npx vitest run` — 全 3071 テスト通過（0 失敗、0 スキップ）
- [x] `npx biome check .` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし
- [ ] CI 全ジョブ通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)