### PR TITLE
infra: #930 CE API使用制限をCLAUDE.mdに追記 + ECRドリフト修復確認

### DIFF
--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -34,6 +34,24 @@ production に新しい env を追加した場合は以下 **4 経路すべて**
 - [ ] 本ファイル（`infra/CLAUDE.md`）の env 一覧表に追記
 - [ ] PR 本文の "PO action required" セクションで `gh secret set XXX --body <value> --repo Takenori-Kusaka/ganbari-quest` を明記（GitHub Secrets 1 回登録するだけで Lambda + NUC 両方に配布される）
 
+## AWS Cost Explorer API 使用制限
+
+Cost Explorer API (`ce:GetCostAndUsage` 等) には以下の制約がある。
+自動化スクリプトや /ops ダッシュボードから呼び出す際は注意すること。
+
+| 制約 | 値 | 補足 |
+|------|---|------|
+| リクエスト数上限 | 25 回/秒（アカウント単位） | スロットリング (`ThrottlingException`) |
+| API コスト | **$0.01 / リクエスト** | 無料枠なし。月 100 回で $1、1000 回で $10 |
+| データ反映遅延 | 12〜24 時間 | 当日分は翌日まで取得不可 |
+
+### 運用ガイドライン
+
+- **定期取得は 1 日 1 回を上限** とし、結果をキャッシュ/DB に保存して再利用する
+- `/ops` ダッシュボードからのリアルタイムクエリは避け、バッチ取得済みデータを表示する
+- CI/CD パイプラインからの CE API 呼び出しは原則禁止（コスト肥大化リスク）
+- コスト監視は **AWS Budgets アラート** (無料) を優先し、CE API は月次レポート等に限定する
+
 ## AWS Lambda 本番（ganbari-quest.com）
 
 - **自動デプロイ**: main ブランチへの push で GitHub Actions が自動実行


### PR DESCRIPTION
## Summary
- `infra/CLAUDE.md` に「AWS Cost Explorer API 使用制限」セクションを追記（PO が CLI 直接追記した内容を PR 経由で正式コミット）
- CE API のリクエスト単価 ($0.01/回)、スロットリング制約、運用ガイドライン (1日1回上限、バッチ取得、CI/CD禁止) を明文化
- ECR ライフサイクルポリシー: CDK 定義 `maxImageCount: 10` が正。CLI ドリフト (5) は次回 `cdk deploy` で自動修復

## PO action required
- ECR ポリシードリフトは次回の `cdk deploy` (main push) で自動修復されます
- 修復後に `aws ecr get-lifecycle-policy --repository-name ganbari-quest` で 10 に戻ったことを確認してください

## Test plan
- [x] `infra/CLAUDE.md` の内容レビュー — CE API 制約が正確に記載されている
- [x] `storage-stack.ts:93` — `maxImageCount: 10` が維持されていることを確認
- [ ] CI 全ジョブ通過

Closes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)