### PR TITLE
feat: #831 Activation Funnel 計測基盤 — 4ステップのイベント発火

### DIFF
--- a/docs/design/27-監視オブザーバビリティ設計書.md
+++ b/docs/design/27-監視オブザーバビリティ設計書.md
@@ -91,6 +91,21 @@
 | MRR (月次経常収益) | `/ops/api/analytics` | 収益 |
 | チャーン率 | `/ops/api/analytics` | リテンション |
 
+### 3.4 Activation Funnel イベント (#831)
+
+サインアップから初回報酬体験までの 4 ステップを計測するイベント。
+`analytics-service.ts` の `trackActivation*` ヘルパーで発火する。
+
+| Step | イベント名 | 発火タイミング | 初回判定方式 |
+|------|-----------|-------------|------------|
+| 1 | `activation_signup_completed` | サインアップ + consent 記録成功時 | サインアップは本質的に 1 回のみ |
+| 2 | `activation_first_child_added` | 子供登録成功時（テナント子供数 = 1） | アプリ層で `allChildren.length === 1` をガード |
+| 3 | `activation_first_activity_completed` | 活動記録成功時（子供のログ数 = 1） | アプリ層で `activeCount === 1` をガード（子供単位）。テナント単位は集計層で dedup |
+| 4 | `activation_first_reward_seen` | スタンプ獲得またはレベルアップ時 | 毎回発火。テナント初回判定は集計層（DynamoDB / BI）で dedup |
+
+> **設計判断**: Step 4 はアプリ層での初回判定に追加 DB クエリが必要であり、
+> イベント頻度（スタンプ・レベルアップ）が低いため集計層 dedup で十分と判断した。
+
 ---
 
 ## 4. アラート設定

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -17,7 +17,11 @@ export type BusinessEventName =
 	| 'special_reward_granted'
 	| 'login_bonus_claimed'
 	| 'daily_mission_completed'
-	| 'page_view';
+	| 'page_view'
+	| 'activation_signup_completed'
+	| 'activation_first_child_added'
+	| 'activation_first_activity_completed'
+	| 'activation_first_reward_seen';
 
 /**
  * Properties that can be attached to a tracking event.

--- a/src/lib/server/services/activity-log-service.ts
+++ b/src/lib/server/services/activity-log-service.ts
@@ -26,6 +26,7 @@ import {
 	insertPointLedger,
 	markActivityLogCancelled,
 } from '$lib/server/db/activity-repo';
+import { trackActivationFirstActivityCompleted } from '$lib/server/services/analytics-service';
 import { type ComboResult, checkAndGrantCombo } from '$lib/server/services/combo-service';
 import { checkMissionCompletion } from '$lib/server/services/daily-mission-service';
 import { type LevelUpInfo, updateStatus } from '$lib/server/services/status-service';
@@ -167,6 +168,14 @@ export async function recordActivity(
 		},
 		tenantId,
 	);
+
+	// #831: Activation Funnel Step 3 — テナント初の活動記録
+	// この子供のアクティブログが 1 件（今挿入した分のみ）なら初回候補としてトラック。
+	// テナント全体の初回判定は集計層で行う。
+	const activeCount = await countActiveActivityLogs(childId, tenantId);
+	if (activeCount === 1) {
+		trackActivationFirstActivityCompleted(tenantId, childId, activityId);
+	}
 
 	// 習熟度更新（count+1 → レベル再計算）
 	const newCount = (mastery?.totalCount ?? 0) + 1;

--- a/src/lib/server/services/analytics-service.ts
+++ b/src/lib/server/services/analytics-service.ts
@@ -130,6 +130,9 @@ export function trackActivationFirstChildAdded(tenantId: string, childId: number
 /**
  * Track: テナント初の活動記録完了 (Step 3)
  * 呼び出し側で「初回かどうか」を判定すること。
+ *
+ * 子供単位の初回判定（activeCount === 1）。
+ * テナント単位の初回判定は集計層で dedup する設計。
  */
 export function trackActivationFirstActivityCompleted(
 	tenantId: string,
@@ -146,6 +149,10 @@ export function trackActivationFirstActivityCompleted(
 /**
  * Track: テナント初の報酬演出表示 (Step 4)
  * シール獲得またはレベルアップモーダル表示時。
+ *
+ * NOTE: Step 2/3 とは異なり、このイベントは報酬発生のたびに毎回発火する。
+ * アプリ層での「初回判定」には追加 DB クエリが必要で、イベント頻度（スタンプ・レベルアップ）が
+ * 低いため、テナント初回の判定は集計層（DynamoDB / BI）で dedup する設計とする。
  */
 export function trackActivationFirstRewardSeen(
 	tenantId: string,

--- a/src/lib/server/services/analytics-service.ts
+++ b/src/lib/server/services/analytics-service.ts
@@ -110,6 +110,50 @@ export function trackServerError(
 	analytics.trackError(error, context);
 }
 
+// ── Activation Funnel (#831) ──────────────────────────────────
+
+/**
+ * Track: サインアップ + consent 完了 (Step 1)
+ */
+export function trackActivationSignupCompleted(tenantId: string): void {
+	trackBusinessEvent('activation_signup_completed', { step: 1 }, tenantId);
+}
+
+/**
+ * Track: テナント初の子供登録 (Step 2)
+ * 呼び出し側で「初回かどうか」を判定すること。
+ */
+export function trackActivationFirstChildAdded(tenantId: string, childId: number): void {
+	trackBusinessEvent('activation_first_child_added', { step: 2, childId }, tenantId);
+}
+
+/**
+ * Track: テナント初の活動記録完了 (Step 3)
+ * 呼び出し側で「初回かどうか」を判定すること。
+ */
+export function trackActivationFirstActivityCompleted(
+	tenantId: string,
+	childId: number,
+	activityId: number,
+): void {
+	trackBusinessEvent(
+		'activation_first_activity_completed',
+		{ step: 3, childId, activityId },
+		tenantId,
+	);
+}
+
+/**
+ * Track: テナント初の報酬演出表示 (Step 4)
+ * シール獲得またはレベルアップモーダル表示時。
+ */
+export function trackActivationFirstRewardSeen(
+	tenantId: string,
+	rewardType: 'stamp' | 'level_up',
+): void {
+	trackBusinessEvent('activation_first_reward_seen', { step: 4, rewardType }, tenantId);
+}
+
 /**
  * Get analytics system status (for admin/ops dashboard).
  */

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
@@ -230,7 +230,8 @@ export const actions: Actions = {
 			return fail(404, { error: 'みつかりません' });
 		}
 
-		// #831: Activation Funnel Step 4 — 初回報酬演出（レベルアップ時）
+		// #831: Activation Funnel Step 4 — 報酬演出（レベルアップ時）
+		// NOTE: 初回判定は集計層で dedup（Step 2/3 とは異なるアプローチ）
 		if (result.levelUp) {
 			trackActivationFirstRewardSeen(tenantId, 'level_up');
 		}
@@ -333,7 +334,8 @@ export const actions: Actions = {
 			weeklyRedeem = null;
 		}
 
-		// #831: Activation Funnel Step 4 — 初回報酬演出（スタンプ押印成功時）
+		// #831: Activation Funnel Step 4 — 報酬演出（スタンプ押印成功時）
+		// NOTE: 初回判定は集計層で dedup（Step 2/3 とは異なるアプローチ）
 		if (stamp) {
 			trackActivationFirstRewardSeen(tenantId, 'stamp');
 		}
@@ -384,7 +386,8 @@ export const actions: Actions = {
 			return fail(400, { error: 'スタンプをおせませんでした' });
 		}
 
-		// #831: Activation Funnel Step 4 — 初回報酬演出（スタンプ押印成功時）
+		// #831: Activation Funnel Step 4 — 報酬演出（スタンプ押印成功時）
+		// NOTE: 初回判定は集計層で dedup（Step 2/3 とは異なるアプローチ）
 		trackActivationFirstRewardSeen(tenantId, 'stamp');
 
 		return {

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
@@ -13,6 +13,7 @@ import {
 	toggleActivityPin,
 } from '$lib/server/services/activity-pin-service';
 import { getActivities } from '$lib/server/services/activity-service';
+import { trackActivationFirstRewardSeen } from '$lib/server/services/analytics-service';
 import {
 	claimBirthdayBonus,
 	getBirthdayBonusStatus,
@@ -229,6 +230,11 @@ export const actions: Actions = {
 			return fail(404, { error: 'みつかりません' });
 		}
 
+		// #831: Activation Funnel Step 4 — 初回報酬演出（レベルアップ時）
+		if (result.levelUp) {
+			trackActivationFirstRewardSeen(tenantId, 'level_up');
+		}
+
 		return {
 			success: true,
 			logId: result.id,
@@ -327,6 +333,11 @@ export const actions: Actions = {
 			weeklyRedeem = null;
 		}
 
+		// #831: Activation Funnel Step 4 — 初回報酬演出（スタンプ押印成功時）
+		if (stamp) {
+			trackActivationFirstRewardSeen(tenantId, 'stamp');
+		}
+
 		return {
 			success: true,
 			loginStamp: true,
@@ -372,6 +383,9 @@ export const actions: Actions = {
 			if (result.error === 'CARD_FULL') return fail(409, { error: 'カードがいっぱいだよ' });
 			return fail(400, { error: 'スタンプをおせませんでした' });
 		}
+
+		// #831: Activation Funnel Step 4 — 初回報酬演出（スタンプ押印成功時）
+		trackActivationFirstRewardSeen(tenantId, 'stamp');
 
 		return {
 			success: true,

--- a/src/routes/(parent)/admin/children/+page.server.ts
+++ b/src/routes/(parent)/admin/children/+page.server.ts
@@ -4,6 +4,7 @@ import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
 import { getActivityLogs } from '$lib/server/services/activity-log-service';
+import { trackActivationFirstChildAdded } from '$lib/server/services/analytics-service';
 import {
 	addChild,
 	editChild,
@@ -186,6 +187,13 @@ export const actions: Actions = {
 			{ nickname, age, theme, birthDate: birthDate ?? undefined },
 			tenantId,
 		);
+
+		// #831: Activation Funnel Step 2 — テナント初の子供登録
+		const allChildren = await getAllChildren(tenantId);
+		if (allChildren.length === 1) {
+			trackActivationFirstChildAdded(tenantId, child.id);
+		}
+
 		return { success: true, addedChild: child };
 	},
 

--- a/src/routes/auth/signup/+page.server.ts
+++ b/src/routes/auth/signup/+page.server.ts
@@ -13,6 +13,7 @@ import { verifyIdentityToken } from '$lib/server/auth/providers/cognito-jwt';
 import { setIdentityCookie } from '$lib/server/auth/providers/cognito-oauth';
 import type { Identity } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logger';
+import { trackActivationSignupCompleted } from '$lib/server/services/analytics-service';
 import { recordConsent } from '$lib/server/services/consent-service';
 import { notifyNewSignup } from '$lib/server/services/discord-notify-service';
 import { consumeLicenseKey, validateLicenseKey } from '$lib/server/services/license-key-service';
@@ -337,6 +338,9 @@ export const actions: Actions = {
 			// Consent 記録失敗 → /consent 画面で再取得
 			redirect(302, '/consent');
 		}
+
+		// #831: Activation Funnel Step 1 — サインアップ完了
+		trackActivationSignupCompleted(tenantId);
 
 		// #766: /auth/signup?plan=X からの遷移ならトライアルを自動開始する
 		//

--- a/tests/unit/services/analytics-service.test.ts
+++ b/tests/unit/services/analytics-service.test.ts
@@ -177,6 +177,107 @@ describe('Analytics providers', () => {
 	});
 });
 
+describe('Activation Funnel helpers (#831)', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		process.env = { ...originalEnv };
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	it('trackActivationSignupCompleted emits activation_signup_completed', async () => {
+		const { analytics } = await import('../../../src/lib/analytics');
+		analytics.reset();
+		analytics.init();
+		const spy = vi.spyOn(analytics, 'trackEvent');
+
+		const { trackActivationSignupCompleted } = await import(
+			'../../../src/lib/server/services/analytics-service'
+		);
+		trackActivationSignupCompleted('t-1');
+
+		expect(spy).toHaveBeenCalledWith('activation_signup_completed', {
+			step: 1,
+			tenantId: 't-1',
+		});
+	});
+
+	it('trackActivationFirstChildAdded emits activation_first_child_added with childId', async () => {
+		const { analytics } = await import('../../../src/lib/analytics');
+		analytics.reset();
+		analytics.init();
+		const spy = vi.spyOn(analytics, 'trackEvent');
+
+		const { trackActivationFirstChildAdded } = await import(
+			'../../../src/lib/server/services/analytics-service'
+		);
+		trackActivationFirstChildAdded('t-2', 42);
+
+		expect(spy).toHaveBeenCalledWith('activation_first_child_added', {
+			step: 2,
+			childId: 42,
+			tenantId: 't-2',
+		});
+	});
+
+	it('trackActivationFirstActivityCompleted emits with childId and activityId', async () => {
+		const { analytics } = await import('../../../src/lib/analytics');
+		analytics.reset();
+		analytics.init();
+		const spy = vi.spyOn(analytics, 'trackEvent');
+
+		const { trackActivationFirstActivityCompleted } = await import(
+			'../../../src/lib/server/services/analytics-service'
+		);
+		trackActivationFirstActivityCompleted('t-3', 10, 5);
+
+		expect(spy).toHaveBeenCalledWith('activation_first_activity_completed', {
+			step: 3,
+			childId: 10,
+			activityId: 5,
+			tenantId: 't-3',
+		});
+	});
+
+	it('trackActivationFirstRewardSeen emits with rewardType=stamp', async () => {
+		const { analytics } = await import('../../../src/lib/analytics');
+		analytics.reset();
+		analytics.init();
+		const spy = vi.spyOn(analytics, 'trackEvent');
+
+		const { trackActivationFirstRewardSeen } = await import(
+			'../../../src/lib/server/services/analytics-service'
+		);
+		trackActivationFirstRewardSeen('t-4', 'stamp');
+
+		expect(spy).toHaveBeenCalledWith('activation_first_reward_seen', {
+			step: 4,
+			rewardType: 'stamp',
+			tenantId: 't-4',
+		});
+	});
+
+	it('trackActivationFirstRewardSeen emits with rewardType=level_up', async () => {
+		const { analytics } = await import('../../../src/lib/analytics');
+		analytics.reset();
+		analytics.init();
+		const spy = vi.spyOn(analytics, 'trackEvent');
+
+		const { trackActivationFirstRewardSeen } = await import(
+			'../../../src/lib/server/services/analytics-service'
+		);
+		trackActivationFirstRewardSeen('t-5', 'level_up');
+
+		expect(spy).toHaveBeenCalledWith('activation_first_reward_seen', {
+			step: 4,
+			rewardType: 'level_up',
+			tenantId: 't-5',
+		});
+	});
+});
+
 describe('AnalyticsManager', () => {
 	beforeEach(() => {
 		vi.resetModules();

--- a/tests/unit/services/signup-actions.test.ts
+++ b/tests/unit/services/signup-actions.test.ts
@@ -77,6 +77,11 @@ vi.mock('$lib/server/services/trial-service', () => ({
 	startTrial: (...args: unknown[]) => mockStartTrial(...args),
 }));
 
+// --- Analytics Service モック (#831) ---
+vi.mock('$lib/server/services/analytics-service', () => ({
+	trackActivationSignupCompleted: vi.fn(),
+}));
+
 beforeEach(() => {
 	mockSignUp.mockReset();
 	mockConfirmSignUp.mockReset();


### PR DESCRIPTION
## Summary

- サインアップからシール獲得までの **Activation Funnel 4ステップ** を `analytics-service` 経由で発火するインストルメンテーションを追加
- `BusinessEventName` に `activation_*` イベント 4種を追加
- 各発火箇所: signup confirm, 子供登録, 活動記録, スタンプ/レベルアップ時
- テナント初回判定: 子供数=1、アクティブログ数=1 で判定（集計層で per-tenant dedup 可能）

### 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `src/lib/analytics/types.ts` | `activation_*` イベント名 4種追加 |
| `src/lib/server/services/analytics-service.ts` | `trackActivation*` ヘルパー関数 4つ追加 |
| `src/routes/auth/signup/+page.server.ts` | consent 記録成功後に `signup_completed` 発火 |
| `src/routes/(parent)/admin/children/+page.server.ts` | addChild 成功時に `first_child_added` 発火（テナント子供数=1 のみ）|
| `src/lib/server/services/activity-log-service.ts` | recordActivity 成功時に `first_activity_completed` 発火（子供のログ数=1 のみ）|
| `src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts` | loginStamp/stampCard/recordActivity 成功時に `first_reward_seen` 発火 |
| `tests/unit/services/analytics-service.test.ts` | activation ヘルパーのテスト 5件追加 |
| `tests/unit/services/signup-actions.test.ts` | analytics-service モック追加（タイムアウト修正）|

### スコープ
本 PR は **Step 1（インストルメンテーション）のみ**。以下は後続チケット:
- Step 2: DynamoDB プロバイダー本番有効化
- Step 3: `/ops/activation` タブ新設（Funnel 可視化）
- Step 4: LP → デモ → サインアップ経路計測

Refs #831

## Test plan
- [x] `npx biome check .` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし
- [x] `npx vitest run` — 3119 テスト全パス（新規 5件含む）
- [ ] CI 全パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)