### PR TITLE
feat: #839 アプリ内フィードバック送信フォーム

### DIFF
--- a/src/lib/domain/validation/feedback.ts
+++ b/src/lib/domain/validation/feedback.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const FEEDBACK_CATEGORIES = ['opinion', 'bug', 'feature', 'other'] as const;
+export type FeedbackCategory = (typeof FEEDBACK_CATEGORIES)[number];
+
+export const FEEDBACK_CATEGORY_LABELS: Record<FeedbackCategory, string> = {
+	opinion: 'ご意見',
+	bug: '不具合報告',
+	feature: '機能要望',
+	other: 'その他',
+};
+
+export const feedbackSchema = z.object({
+	category: z.enum(FEEDBACK_CATEGORIES),
+	text: z
+		.string()
+		.min(1, 'フィードバック内容を入力してください')
+		.max(1000, 'フィードバックは1000文字以内で入力してください'),
+	currentUrl: z.string().max(500).optional(),
+});
+
+export type FeedbackInput = z.infer<typeof feedbackSchema>;

--- a/src/lib/features/admin/components/AdminLayout.svelte
+++ b/src/lib/features/admin/components/AdminLayout.svelte
@@ -2,6 +2,7 @@
 import type { Snippet } from 'svelte';
 import { navigating, page } from '$app/stores';
 import { NAV_CATEGORIES, NAV_ITEM_LABELS, PLAN_LABELS } from '$lib/domain/labels';
+import FeedbackDialog from '$lib/features/admin/components/FeedbackDialog.svelte';
 import Logo from '$lib/ui/components/Logo.svelte';
 import PageGuideOverlay from '$lib/ui/components/PageGuideOverlay.svelte';
 import TutorialOverlay from '$lib/ui/components/TutorialOverlay.svelte';
@@ -180,6 +181,9 @@ function handleDesktopCategoryLeave() {
 function isItemActive(itemHref: string): boolean {
 	return $page.url.pathname.startsWith(itemHref);
 }
+
+// #839: Feedback dialog
+let feedbackOpen = $state(false);
 </script>
 
 <div data-theme="admin" data-plan={planTier} class="admin-shell">
@@ -358,7 +362,20 @@ function isItemActive(itemHref: string): boolean {
 		<TutorialOverlay />
 		<PageGuideOverlay />
 	{/if}
+
+	<!-- #839: Feedback floating button -->
+	<button
+		type="button"
+		class="feedback-fab"
+		onclick={() => { feedbackOpen = true; }}
+		aria-label="ご意見・不具合報告"
+		data-testid="feedback-fab"
+	>
+		<span aria-hidden="true">💬</span>
+	</button>
 </div>
+
+<FeedbackDialog bind:open={feedbackOpen} demo={isDemo} />
 
 <style>
 	.admin-shell {
@@ -604,5 +621,35 @@ function isItemActive(itemHref: string): boolean {
 		border-radius: 9999px;
 		background: var(--color-danger, #ef4444);
 		border: 2px solid white;
+	}
+	/* #839: Feedback floating action button */
+	.feedback-fab {
+		position: fixed;
+		bottom: 5rem;
+		right: 1rem;
+		width: 3rem;
+		height: 3rem;
+		border-radius: 9999px;
+		background: var(--color-action-primary);
+		color: var(--color-text-inverse);
+		border: none;
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 1.25rem;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+		transition: transform 0.15s, box-shadow 0.15s;
+		z-index: 20;
+	}
+	.feedback-fab:hover {
+		transform: scale(1.1);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+	}
+	@media (min-width: 768px) {
+		.feedback-fab {
+			bottom: 1.5rem;
+			right: 1.5rem;
+		}
 	}
 </style>

--- a/src/lib/features/admin/components/FeedbackDialog.svelte
+++ b/src/lib/features/admin/components/FeedbackDialog.svelte
@@ -1,0 +1,226 @@
+<script lang="ts">
+import { page } from '$app/stores';
+import {
+	FEEDBACK_CATEGORIES,
+	FEEDBACK_CATEGORY_LABELS,
+	type FeedbackCategory,
+} from '$lib/domain/validation/feedback';
+import Button from '$lib/ui/primitives/Button.svelte';
+import Dialog from '$lib/ui/primitives/Dialog.svelte';
+import FormField from '$lib/ui/primitives/FormField.svelte';
+import Select from '$lib/ui/primitives/Select.svelte';
+
+interface Props {
+	open: boolean;
+	/** demo mode: show mock success instead of calling API */
+	demo?: boolean;
+}
+
+let { open = $bindable(), demo = false }: Props = $props();
+
+const MAX_TEXT_LENGTH = 1000;
+
+let categoryValue = $state<string[]>([]);
+let text = $state('');
+let submitting = $state(false);
+let error = $state('');
+let successMessage = $state('');
+
+const category = $derived((categoryValue[0] ?? '') as FeedbackCategory | '');
+const currentUrl = $derived($page.url.pathname);
+const textLength = $derived(text.length);
+const isOverLimit = $derived(textLength > MAX_TEXT_LENGTH);
+const canSubmit = $derived(
+	category !== '' && text.trim().length > 0 && !isOverLimit && !submitting,
+);
+
+const categoryItems = FEEDBACK_CATEGORIES.map((c) => ({
+	value: c,
+	label: FEEDBACK_CATEGORY_LABELS[c],
+}));
+
+function resetForm() {
+	categoryValue = [];
+	text = '';
+	error = '';
+	successMessage = '';
+	submitting = false;
+}
+
+function handleOpenChange(details: { open: boolean }) {
+	if (!details.open) {
+		resetForm();
+	}
+}
+
+async function handleSubmit() {
+	if (!canSubmit) return;
+
+	submitting = true;
+	error = '';
+
+	if (demo) {
+		// Demo mode: simulate success after short delay
+		await new Promise((r) => setTimeout(r, 500));
+		successMessage = `${FEEDBACK_CATEGORY_LABELS[category as FeedbackCategory]}を送信しました。ありがとうございます！（デモのため実際には送信されていません）`;
+		submitting = false;
+		return;
+	}
+
+	try {
+		const res = await fetch('/api/v1/feedback', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				category,
+				text: text.trim(),
+				currentUrl,
+			}),
+		});
+
+		const data = await res.json();
+
+		if (!res.ok) {
+			error = data.error ?? 'フィードバックの送信に失敗しました';
+			submitting = false;
+			return;
+		}
+
+		successMessage = data.message;
+		submitting = false;
+	} catch {
+		error = 'ネットワークエラーが発生しました。時間をおいて再度お試しください。';
+		submitting = false;
+	}
+}
+</script>
+
+<Dialog
+	bind:open
+	title="ご意見・不具合報告"
+	testid="feedback-dialog"
+	size="md"
+	onOpenChange={handleOpenChange}
+>
+	{#if successMessage}
+		<div class="feedback-success" data-testid="feedback-success">
+			<div class="feedback-success-icon">✅</div>
+			<p class="feedback-success-text">{successMessage}</p>
+			<Button
+				variant="primary"
+				size="sm"
+				onclick={() => { open = false; }}
+				data-testid="feedback-close-button"
+			>
+				とじる
+			</Button>
+		</div>
+	{:else}
+		<form
+			onsubmit={(e) => { e.preventDefault(); handleSubmit(); }}
+			class="flex flex-col gap-4"
+			data-testid="feedback-form"
+		>
+			<Select
+				label="種別"
+				items={categoryItems}
+				bind:value={categoryValue}
+				placeholder="選択してください"
+				error={undefined}
+			/>
+
+			<FormField label="内容" error={isOverLimit ? `${MAX_TEXT_LENGTH}文字以内で入力してください` : undefined}>
+				{#snippet children()}
+					<textarea
+						bind:value={text}
+						rows={5}
+						class="feedback-textarea"
+						class:feedback-textarea--error={isOverLimit}
+						placeholder="ご意見・不具合の内容を入力してください"
+						data-testid="feedback-text"
+					></textarea>
+				{/snippet}
+			</FormField>
+
+			<div class="flex items-center justify-between text-xs text-[var(--color-text-muted)]">
+				<span>送信元: {currentUrl}</span>
+				<span class:text-\[var\(--color-danger\)\]={isOverLimit}>
+					{textLength} / {MAX_TEXT_LENGTH}
+				</span>
+			</div>
+
+			{#if error}
+				<p class="text-sm text-[var(--color-danger)]" role="alert" data-testid="feedback-error">
+					{error}
+				</p>
+			{/if}
+
+			<div class="flex gap-2 justify-end">
+				<Button
+					variant="ghost"
+					size="sm"
+					onclick={() => { open = false; }}
+					type="button"
+				>
+					キャンセル
+				</Button>
+				<Button
+					variant="primary"
+					size="sm"
+					type="submit"
+					disabled={!canSubmit}
+					data-testid="feedback-submit"
+				>
+					{#if submitting}
+						送信中...
+					{:else}
+						送信する
+					{/if}
+				</Button>
+			</div>
+		</form>
+	{/if}
+</Dialog>
+
+<style>
+	.feedback-textarea {
+		width: 100%;
+		padding: 0.5rem 0.75rem;
+		border: 1px solid var(--input-border);
+		border-radius: var(--input-radius);
+		background: var(--input-bg);
+		font-size: 0.875rem;
+		resize: vertical;
+		min-height: 100px;
+		transition: border-color 0.15s;
+	}
+
+	.feedback-textarea:focus {
+		outline: none;
+		border-color: var(--input-border-focus);
+		box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+	}
+
+	.feedback-textarea--error {
+		border-color: var(--color-danger);
+	}
+
+	.feedback-success {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1rem;
+		padding: 1rem 0;
+		text-align: center;
+	}
+
+	.feedback-success-icon {
+		font-size: 2rem;
+	}
+
+	.feedback-success-text {
+		font-size: 0.875rem;
+		color: var(--color-text);
+		line-height: 1.5;
+	}
+</style>

--- a/src/routes/api/v1/feedback/+server.ts
+++ b/src/routes/api/v1/feedback/+server.ts
@@ -1,0 +1,96 @@
+// src/routes/api/v1/feedback/+server.ts
+// #839: アプリ内フィードバック送信 API
+// ログイン済みユーザーからのフィードバックを Discord webhook で運営に通知する。
+// レート制限: 1テナント/5分1件
+
+import type { RequestHandler } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
+import { FEEDBACK_CATEGORY_LABELS, feedbackSchema } from '$lib/domain/validation/feedback';
+import { requireTenantId } from '$lib/server/auth/factory';
+import { logger } from '$lib/server/logger';
+import { notifyInquiry } from '$lib/server/services/discord-notify-service';
+
+// In-memory rate limit map: tenantId -> last submission timestamp
+const rateLimitMap = new Map<string, number>();
+const RATE_LIMIT_MS = 5 * 60 * 1000; // 5 minutes
+
+function checkRateLimit(tenantId: string): boolean {
+	const lastSubmission = rateLimitMap.get(tenantId);
+	if (lastSubmission && Date.now() - lastSubmission < RATE_LIMIT_MS) {
+		return false;
+	}
+	return true;
+}
+
+function recordSubmission(tenantId: string): void {
+	rateLimitMap.set(tenantId, Date.now());
+	// Cleanup old entries (>30min) to prevent memory leak
+	if (rateLimitMap.size > 1000) {
+		const cutoff = Date.now() - 30 * 60 * 1000;
+		for (const [key, time] of rateLimitMap) {
+			if (time < cutoff) rateLimitMap.delete(key);
+		}
+	}
+}
+
+export const POST: RequestHandler = async ({ locals, request }) => {
+	const tenantId = requireTenantId(locals);
+	const identity = locals.identity;
+	const email = identity && identity.type === 'cognito' ? identity.email : 'unknown';
+
+	// Rate limit check
+	if (!checkRateLimit(tenantId)) {
+		return json(
+			{ error: 'フィードバックの送信は5分に1回までです。しばらくお待ちください。' },
+			{ status: 429 },
+		);
+	}
+
+	let body: unknown;
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'リクエストの形式が正しくありません' }, { status: 400 });
+	}
+
+	const parsed = feedbackSchema.safeParse(body);
+	if (!parsed.success) {
+		const firstError = parsed.error.issues[0]?.message ?? 'Validation error';
+		return json({ error: firstError }, { status: 400 });
+	}
+
+	const { category, text, currentUrl } = parsed.data;
+
+	try {
+		await notifyInquiry(
+			tenantId,
+			category,
+			`${text}${currentUrl ? `\n\n📍 送信元: ${currentUrl}` : ''}`,
+			email,
+			undefined,
+			undefined,
+		);
+		recordSubmission(tenantId);
+
+		logger.info('[feedback] Feedback submitted', {
+			context: {
+				tenantId,
+				category,
+				textLength: text.length,
+			},
+		});
+
+		return json({
+			success: true,
+			message: `${FEEDBACK_CATEGORY_LABELS[category]}を送信しました。ありがとうございます！`,
+		});
+	} catch (err) {
+		logger.error('[feedback] Failed to send feedback', {
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return json(
+			{ error: 'フィードバックの送信に失敗しました。時間をおいて再度お試しください。' },
+			{ status: 500 },
+		);
+	}
+};

--- a/tests/e2e/feedback-form.spec.ts
+++ b/tests/e2e/feedback-form.spec.ts
@@ -1,0 +1,97 @@
+// tests/e2e/feedback-form.spec.ts
+// #839: アプリ内フィードバック送信フォームの E2E テスト
+// デモモードでの UI 検証（Discord 送信なしでモック挙動を確認）
+
+import { expect, test } from '@playwright/test';
+
+test.describe('#839 フィードバック送信フォーム (デモ)', () => {
+	test.describe.configure({ mode: 'serial' });
+
+	test('フィードバックFABボタンが表示される', async ({ page }) => {
+		test.slow();
+		await page.goto('/demo/admin', { waitUntil: 'domcontentloaded' });
+		await expect(page.getByTestId('feedback-fab')).toBeVisible();
+	});
+
+	test('FABクリックでフィードバックダイアログが開く', async ({ page }) => {
+		test.slow();
+		await page.goto('/demo/admin', { waitUntil: 'domcontentloaded' });
+		await page.getByTestId('feedback-fab').click();
+		await expect(page.getByTestId('feedback-dialog')).toBeVisible();
+		await expect(page.getByTestId('feedback-form')).toBeVisible();
+	});
+
+	test('種別未選択・本文未入力では送信ボタンが無効', async ({ page }) => {
+		test.slow();
+		await page.goto('/demo/admin', { waitUntil: 'domcontentloaded' });
+		await page.getByTestId('feedback-fab').click();
+		await expect(page.getByTestId('feedback-dialog')).toBeVisible();
+		await expect(page.getByTestId('feedback-submit')).toBeDisabled();
+	});
+
+	test('種別選択＋本文入力で送信でき、成功メッセージが表示される', async ({ page }) => {
+		test.slow();
+		await page.goto('/demo/admin', { waitUntil: 'domcontentloaded' });
+		await page.getByTestId('feedback-fab').click();
+		await expect(page.getByTestId('feedback-dialog')).toBeVisible();
+
+		// Select category - click the trigger, then the item
+		const selectTrigger = page.getByTestId('feedback-dialog').locator('button[role="combobox"]');
+		await selectTrigger.click();
+		// Wait for dropdown and select "ご意見"
+		await page.getByRole('option', { name: 'ご意見' }).click();
+
+		// Enter feedback text
+		await page.getByTestId('feedback-text').fill('テスト用のフィードバックです');
+
+		// Submit should now be enabled
+		await expect(page.getByTestId('feedback-submit')).toBeEnabled();
+		await page.getByTestId('feedback-submit').click();
+
+		// Wait for success message (demo mode has 500ms delay)
+		await expect(page.getByTestId('feedback-success')).toBeVisible({ timeout: 5000 });
+		await expect(page.getByTestId('feedback-success')).toContainText('ありがとうございます');
+		await expect(page.getByTestId('feedback-success')).toContainText('デモ');
+	});
+
+	test('1000文字超過でエラー表示＆送信不可', async ({ page }) => {
+		test.slow();
+		await page.goto('/demo/admin', { waitUntil: 'domcontentloaded' });
+		await page.getByTestId('feedback-fab').click();
+		await expect(page.getByTestId('feedback-dialog')).toBeVisible();
+
+		// Select category
+		const selectTrigger = page.getByTestId('feedback-dialog').locator('button[role="combobox"]');
+		await selectTrigger.click();
+		await page.getByRole('option', { name: '不具合報告' }).click();
+
+		// Enter text over 1000 characters
+		const longText = 'あ'.repeat(1001);
+		await page.getByTestId('feedback-text').fill(longText);
+
+		// Submit should be disabled due to over-limit
+		await expect(page.getByTestId('feedback-submit')).toBeDisabled();
+
+		// Error message about character limit should appear
+		await expect(page.getByTestId('feedback-dialog').getByText('1000文字以内')).toBeVisible();
+	});
+
+	test('ダイアログを閉じるとフォームがリセットされる', async ({ page }) => {
+		test.slow();
+		await page.goto('/demo/admin', { waitUntil: 'domcontentloaded' });
+		await page.getByTestId('feedback-fab').click();
+		await expect(page.getByTestId('feedback-dialog')).toBeVisible();
+
+		// Enter some text
+		await page.getByTestId('feedback-text').fill('some text');
+
+		// Close dialog via close button
+		await page.getByTestId('feedback-dialog').getByLabel('とじる').click();
+		await expect(page.getByTestId('feedback-dialog')).toBeHidden();
+
+		// Re-open — form should be reset
+		await page.getByTestId('feedback-fab').click();
+		await expect(page.getByTestId('feedback-dialog')).toBeVisible();
+		await expect(page.getByTestId('feedback-text')).toHaveValue('');
+	});
+});

--- a/tests/e2e/feedback-form.spec.ts
+++ b/tests/e2e/feedback-form.spec.ts
@@ -35,11 +35,13 @@ test.describe('#839 フィードバック送信フォーム (デモ)', () => {
 		await page.getByTestId('feedback-fab').click();
 		await expect(page.getByTestId('feedback-dialog')).toBeVisible();
 
-		// Select category - click the trigger, then the item
+		// Select category - click the trigger, wait for dropdown, then select
 		const selectTrigger = page.getByTestId('feedback-dialog').locator('button[role="combobox"]');
 		await selectTrigger.click();
-		// Wait for dropdown and select "ご意見"
-		await page.getByRole('option', { name: 'ご意見' }).click();
+		// Ark UI renders Select options in a Portal — wait for content to mount
+		const selectContent = page.locator('[data-scope="select"][data-part="content"]');
+		await selectContent.waitFor({ state: 'visible', timeout: 10000 });
+		await selectContent.locator('[data-part="item"]', { hasText: 'ご意見' }).click();
 
 		// Enter feedback text
 		await page.getByTestId('feedback-text').fill('テスト用のフィードバックです');
@@ -63,7 +65,9 @@ test.describe('#839 フィードバック送信フォーム (デモ)', () => {
 		// Select category
 		const selectTrigger = page.getByTestId('feedback-dialog').locator('button[role="combobox"]');
 		await selectTrigger.click();
-		await page.getByRole('option', { name: '不具合報告' }).click();
+		const selectContent = page.locator('[data-scope="select"][data-part="content"]');
+		await selectContent.waitFor({ state: 'visible', timeout: 10000 });
+		await selectContent.locator('[data-part="item"]', { hasText: '不具合報告' }).click();
 
 		// Enter text over 1000 characters
 		const longText = 'あ'.repeat(1001);

--- a/tests/unit/validation/feedback.test.ts
+++ b/tests/unit/validation/feedback.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+	FEEDBACK_CATEGORIES,
+	FEEDBACK_CATEGORY_LABELS,
+	feedbackSchema,
+} from '$lib/domain/validation/feedback';
+
+describe('feedback validation', () => {
+	describe('feedbackSchema', () => {
+		it('valid feedback passes', () => {
+			const result = feedbackSchema.safeParse({
+				category: 'opinion',
+				text: 'This is feedback',
+				currentUrl: '/admin/settings',
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it('all categories are accepted', () => {
+			for (const category of FEEDBACK_CATEGORIES) {
+				const result = feedbackSchema.safeParse({
+					category,
+					text: 'Test feedback',
+				});
+				expect(result.success).toBe(true);
+			}
+		});
+
+		it('rejects invalid category', () => {
+			const result = feedbackSchema.safeParse({
+				category: 'invalid',
+				text: 'Test',
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects empty text', () => {
+			const result = feedbackSchema.safeParse({
+				category: 'bug',
+				text: '',
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0]?.message).toContain('入力してください');
+			}
+		});
+
+		it('rejects text over 1000 characters', () => {
+			const result = feedbackSchema.safeParse({
+				category: 'bug',
+				text: 'a'.repeat(1001),
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues[0]?.message).toContain('1000文字以内');
+			}
+		});
+
+		it('accepts text exactly 1000 characters', () => {
+			const result = feedbackSchema.safeParse({
+				category: 'feature',
+				text: 'a'.repeat(1000),
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it('currentUrl is optional', () => {
+			const result = feedbackSchema.safeParse({
+				category: 'other',
+				text: 'Test feedback',
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('FEEDBACK_CATEGORY_LABELS', () => {
+		it('all categories have labels', () => {
+			for (const category of FEEDBACK_CATEGORIES) {
+				expect(FEEDBACK_CATEGORY_LABELS[category]).toBeTruthy();
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- /admin + /demo/admin にフローティングFABボタンを追加し、フィードバック（ご意見・不具合報告・機能要望・その他）を Discord webhook で通知する機能を実装
- POST /api/v1/feedback: Zod バリデーション + in-memory レート制限（5分/1件/テナント）
- デモモードではモック挙動（送信なし、成功メッセージのみ表示）

## Changes
- `src/lib/domain/validation/feedback.ts` — フィードバックスキーマ + カテゴリ定義
- `src/routes/api/v1/feedback/+server.ts` — API エンドポイント（Discord webhook 通知）
- `src/lib/features/admin/components/FeedbackDialog.svelte` — Dialog + Select + textarea フォーム
- `src/lib/features/admin/components/AdminLayout.svelte` — FAB ボタン追加
- `tests/unit/validation/feedback.test.ts` — バリデーション 8 テスト
- `tests/e2e/feedback-form.spec.ts` — E2E 6 テスト（FAB表示・送信成功・文字数超過等）

## Test plan
- [x] `npx biome check .` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし
- [x] `npx vitest run` — 3122 テスト全通過
- [x] `npx playwright test tests/e2e/feedback-form.spec.ts` — 6 テスト通過（デモモード）
- [ ] CI E2E 全通過

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)