### PR TITLE
fix: #953 サインアップの利用規約チェックボックスをリンク閲覧前でも有効化

### DIFF
--- a/src/routes/auth/signup/+page.svelte
+++ b/src/routes/auth/signup/+page.svelte
@@ -46,12 +46,6 @@ let showLicenseHelp = $state(false); // 折りたたみヘルプの開閉
 let showLicenseConfirmDialog = $state(false); // 確認ダイアログ
 let signupFormEl: HTMLFormElement | null = $state(null); // dialog から submit を呼ぶため
 
-// #588: 規約リンク閲覧追跡（一度クリックして開くまでチェック不可）
-let termsViewed = $state(false);
-let privacyViewed = $state(false);
-let termsHintShown = $state(false);
-let privacyHintShown = $state(false);
-
 // #588: フォーム送信試行追跡（未入力フィールドのエラー表示用）
 let submitAttempted = $state(false);
 
@@ -390,50 +384,30 @@ $effect(() => {
 				<div class="-mt-1">
 					<FormField label="" error={submitAttempted && !agreedTerms ? '利用規約への同意が必要です' : undefined}>
 						{#snippet children()}
-							<label class="flex items-start gap-2 {termsViewed ? 'cursor-pointer' : 'cursor-default'}">
+							<label class="flex items-start gap-2 cursor-pointer">
 								<input
 									type="checkbox"
 									name="agreedTerms"
 									bind:checked={agreedTerms}
-									disabled={!termsViewed}
-									class="mt-0.5 w-4 h-4 shrink-0 accent-[var(--theme-primary)] disabled:opacity-40"
-									onclick={(e) => {
-										if (!termsViewed) {
-											e.preventDefault();
-											termsHintShown = true;
-										}
-									}}
+									class="mt-0.5 w-4 h-4 shrink-0 accent-[var(--theme-primary)]"
 								/>
 								<span class="text-[0.8rem] text-[var(--color-text-muted)] leading-relaxed">
-									<a href="https://www.ganbari-quest.com/terms.html" target="_blank" rel="noopener noreferrer" class="text-[var(--color-text-link)] underline" onclick={() => { termsViewed = true; termsHintShown = false; }}>利用規約</a>に同意します
-									{#if termsHintShown && !termsViewed}
-										<span class="block text-xs text-[var(--color-warning)] mt-0.5">先に利用規約をお読みください</span>
-									{/if}
+									<a href="https://www.ganbari-quest.com/terms.html" target="_blank" rel="noopener noreferrer" class="text-[var(--color-text-link)] underline">利用規約</a>に同意します
 								</span>
 							</label>
 						{/snippet}
 					</FormField>
 					<FormField label="" error={submitAttempted && !agreedPrivacy ? 'プライバシーポリシーへの同意が必要です' : undefined}>
 						{#snippet children()}
-							<label class="flex items-start gap-2 {privacyViewed ? 'cursor-pointer' : 'cursor-default'}">
+							<label class="flex items-start gap-2 cursor-pointer">
 								<input
 									type="checkbox"
 									name="agreedPrivacy"
 									bind:checked={agreedPrivacy}
-									disabled={!privacyViewed}
-									class="mt-0.5 w-4 h-4 shrink-0 accent-[var(--theme-primary)] disabled:opacity-40"
-									onclick={(e) => {
-										if (!privacyViewed) {
-											e.preventDefault();
-											privacyHintShown = true;
-										}
-									}}
+									class="mt-0.5 w-4 h-4 shrink-0 accent-[var(--theme-primary)]"
 								/>
 								<span class="text-[0.8rem] text-[var(--color-text-muted)] leading-relaxed">
-									<a href="https://www.ganbari-quest.com/privacy.html" target="_blank" rel="noopener noreferrer" class="text-[var(--color-text-link)] underline" onclick={() => { privacyViewed = true; privacyHintShown = false; }}>プライバシーポリシー</a>に同意します
-									{#if privacyHintShown && !privacyViewed}
-										<span class="block text-xs text-[var(--color-warning)] mt-0.5">先にプライバシーポリシーをお読みください</span>
-									{/if}
+									<a href="https://www.ganbari-quest.com/privacy.html" target="_blank" rel="noopener noreferrer" class="text-[var(--color-text-link)] underline">プライバシーポリシー</a>に同意します
 								</span>
 							</label>
 						{/snippet}

--- a/src/routes/consent/+page.svelte
+++ b/src/routes/consent/+page.svelte
@@ -11,13 +11,7 @@ let agreedTerms = $state(false);
 let agreedPrivacy = $state(false);
 let loading = $state(false);
 
-// #708: 規約リンク閲覧追跡（signup画面 #588 と同等パターン）
-let termsViewed = $state(false);
-let privacyViewed = $state(false);
-let termsHintShown = $state(false);
-let privacyHintShown = $state(false);
-
-// #708: 送信可能かの判定（ユーザーに明確なフィードバックを出すため derived で算出）
+// 送信可能かの判定（ユーザーに明確なフィードバックを出すため derived で算出）
 const needsTerms = $derived(!data.termsAccepted);
 const needsPrivacy = $derived(!data.privacyAccepted);
 const canSubmit = $derived(
@@ -25,8 +19,6 @@ const canSubmit = $derived(
 );
 const submitBlockReason = $derived.by(() => {
 	if (loading) return '';
-	if (needsTerms && !termsViewed) return '利用規約をお読みください';
-	if (needsPrivacy && !privacyViewed) return 'プライバシーポリシーをお読みください';
 	if (needsTerms && !agreedTerms) return '利用規約への同意が必要です';
 	if (needsPrivacy && !agreedPrivacy) return 'プライバシーポリシーへの同意が必要です';
 	return '';
@@ -93,29 +85,19 @@ const submitBlockReason = $derived.by(() => {
 							target="_blank"
 							rel="noopener"
 							class="text-sm text-[var(--color-text-link)] inline-block mb-3"
-							onclick={() => { termsViewed = true; termsHintShown = false; }}
 						>利用規約を確認する ↗</a>
 						<FormField label="">
 							{#snippet children()}
-								<label class="flex items-start gap-2 {termsViewed ? 'cursor-pointer' : 'cursor-default'} text-sm text-[var(--color-text-primary)]">
+								<label class="flex items-start gap-2 cursor-pointer text-sm text-[var(--color-text-primary)]">
 									<input
 										type="checkbox"
 										name="agreedTerms"
 										bind:checked={agreedTerms}
 										data-testid="consent-terms-checkbox"
-										class="mt-0.5 w-[18px] h-[18px] shrink-0 accent-[var(--color-action-primary)] {!termsViewed ? 'opacity-40' : ''}"
-										onclick={(e) => {
-											if (!termsViewed) {
-												e.preventDefault();
-												termsHintShown = true;
-											}
-										}}
+										class="mt-0.5 w-[18px] h-[18px] shrink-0 accent-[var(--color-action-primary)]"
 									/>
 									<span>
 										利用規約に同意します
-										{#if termsHintShown && !termsViewed}
-											<span class="block text-xs text-[var(--color-feedback-warning-text)] mt-0.5">先に利用規約をお読みください</span>
-										{/if}
 									</span>
 								</label>
 							{/snippet}
@@ -134,29 +116,19 @@ const submitBlockReason = $derived.by(() => {
 							target="_blank"
 							rel="noopener"
 							class="text-sm text-[var(--color-text-link)] inline-block mb-3"
-							onclick={() => { privacyViewed = true; privacyHintShown = false; }}
 						>プライバシーポリシーを確認する ↗</a>
 						<FormField label="">
 							{#snippet children()}
-								<label class="flex items-start gap-2 {privacyViewed ? 'cursor-pointer' : 'cursor-default'} text-sm text-[var(--color-text-primary)]">
+								<label class="flex items-start gap-2 cursor-pointer text-sm text-[var(--color-text-primary)]">
 									<input
 										type="checkbox"
 										name="agreedPrivacy"
 										bind:checked={agreedPrivacy}
 										data-testid="consent-privacy-checkbox"
-										class="mt-0.5 w-[18px] h-[18px] shrink-0 accent-[var(--color-action-primary)] {!privacyViewed ? 'opacity-40' : ''}"
-										onclick={(e) => {
-											if (!privacyViewed) {
-												e.preventDefault();
-												privacyHintShown = true;
-											}
-										}}
+										class="mt-0.5 w-[18px] h-[18px] shrink-0 accent-[var(--color-action-primary)]"
 									/>
 									<span>
 										プライバシーポリシーに同意します
-										{#if privacyHintShown && !privacyViewed}
-											<span class="block text-xs text-[var(--color-feedback-warning-text)] mt-0.5">先にプライバシーポリシーをお読みください</span>
-										{/if}
 									</span>
 								</label>
 							{/snippet}


### PR DESCRIPTION
## Summary
- 利用規約・プライバシーポリシーのリンクを先にクリックしないとチェックボックスが操作できない制約（#588 由来）を撤廃
- チェックボックスは常に有効（`disabled` / `onclick` ゲート / ヒントテキスト / `termsViewed` / `privacyViewed` 状態を完全除去）
- `canSubmit` / `submitBlockReason` は `agreedTerms` / `agreedPrivacy` のみで判定するため変更不要
- `-32 行 / +6 行`の純削減

## Why
UX 監査（#840）で指摘された Quick Win 改善。リンクを開かないとチェックできない仕様は、
ユーザーが規約を既読の場合や画面をリロードした場合に無駄な摩擦を生む。
一般的な Web サービスでは規約チェックボックスはリンク閲覧を前提条件としない。

## Test plan
- [x] `npx biome check .` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし（0 errors）
- [x] `npx vitest run` — 3121 passed（1件の既存タイムアウトは無関係）
- [ ] CI 全パス確認

closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

> **Note**: /auth/signup および /consent は認証保護ルートのためスクリーンショット取得不可。デモ画面のチェックボックス UI を参考として添付。

![demo-checkbox-ui](https://github.com/Takenori-Kusaka/ganbari-quest/releases/download/untagged-c2c35375f1a99aa4c726/959-demo-checkbox-ui.png)

**変更内容**: チェックボックスは常時有効（`disabled` / `onclick` ゲート / ヒントテキスト / `termsViewed` / `privacyViewed` 状態を完全除去）。signup + consent 両ページに適用。