### PR TITLE
feat: #956 デモのデフォルトプランを family → free に変更

### DIFF
--- a/src/lib/server/demo/demo-plan.ts
+++ b/src/lib/server/demo/demo-plan.ts
@@ -7,7 +7,7 @@
 //   - standard → licenseStatus='active', plan='monthly'
 //   - family   → licenseStatus='active', plan='family-monthly'
 //
-// デフォルトは family（最も価値が伝わるプランを最初に showcase する）。
+// デフォルトは free（サインアップ後の体験との乖離を防ぐ — #956）。
 
 import type { AuthContext } from '$lib/server/auth/types';
 
@@ -17,7 +17,7 @@ export type DemoPlan = 'free' | 'standard' | 'family';
 export const DEMO_PLAN_COOKIE = 'demo_plan';
 
 /** デフォルトのデモプラン（最初の訪問で showcase される） */
-export const DEFAULT_DEMO_PLAN: DemoPlan = 'family';
+export const DEFAULT_DEMO_PLAN: DemoPlan = 'free';
 
 const VALID_PLANS: ReadonlySet<string> = new Set(['free', 'standard', 'family']);
 

--- a/src/routes/demo/(parent)/admin/+page.server.ts
+++ b/src/routes/demo/(parent)/admin/+page.server.ts
@@ -15,7 +15,7 @@ export const load: PageServerLoad = async ({ parent }) => {
 
 	// #760: プランはルート layout の demoPlan から取得（cookie/query の一元管理）
 	const parentData = await parent();
-	const planTier = parentData.demoPlan ?? 'family';
+	const planTier = parentData.demoPlan ?? 'free';
 	const limits = getPlanLimits(planTier);
 
 	// デモ用のプラン統計（固定値）。本番 /admin/license の planStats と同じ shape。

--- a/tests/unit/demo/demo-plan.test.ts
+++ b/tests/unit/demo/demo-plan.test.ts
@@ -30,9 +30,9 @@ describe('demo-plan helpers (#760)', () => {
 	});
 
 	describe('resolveDemoPlan', () => {
-		it('クエリ・cookie 共に未指定 → デフォルト (family)', () => {
+		it('クエリ・cookie 共に未指定 → デフォルト (free)', () => {
 			expect(resolveDemoPlan(null, undefined)).toBe(DEFAULT_DEMO_PLAN);
-			expect(resolveDemoPlan(null, undefined)).toBe('family');
+			expect(resolveDemoPlan(null, undefined)).toBe('free');
 		});
 
 		it('クエリが優先される', () => {

--- a/tests/unit/services/hooks-integration.test.ts
+++ b/tests/unit/services/hooks-integration.test.ts
@@ -75,7 +75,7 @@ vi.mock('$lib/server/demo/demo-plan', () => ({
 	applyDemoPlanToContext: (ctx: unknown) => ctx,
 	DEMO_PLAN_COOKIE: 'demo_plan',
 	isDemoPlan: () => false,
-	resolveDemoPlan: () => 'family',
+	resolveDemoPlan: () => 'free',
 }));
 
 vi.mock('$lib/server/discord-alert', () => ({


### PR DESCRIPTION
## Summary
- デモ画面の初回訪問時デフォルトプランを `family` → `free` に変更
- `DEFAULT_DEMO_PLAN` 定数、`+page.server.ts` のフォールバック値、関連テスト・モックを一括更新
- プラン切替タブは維持されるため、ユーザーは Standard/Family の機能も任意に確認可能

## Why
UX 監査（#840 QW-4）で指摘。デモが Family プラン全機能で表示されると、
サインアップ後の Free プランとの乖離で「あれ？デモと違う」の失望が生じる。
Free をデフォルトにすることでサインアップ後の体験と一致させ、
上位プランの機能は「切り替えて確認」する動線に変更。

## Test plan
- [x] `npx biome check` — lint エラーなし
- [x] `npx vitest run tests/unit/demo/demo-plan.test.ts tests/unit/services/hooks-integration.test.ts` — 25 passed
- [ ] CI 全パス確認

closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)