### PR TITLE
fix: #967 cognito-dev E2E 4テスト破綻を修正 (deploy unblocker)

### DIFF
--- a/tests/e2e/plan-free.spec.ts
+++ b/tests/e2e/plan-free.spec.ts
@@ -58,7 +58,16 @@ test.describe('#751 free プラン — 機能ゲート', () => {
 	test('/admin/reports — weekly-report-upsell バナーが表示される', async ({ page }) => {
 		await loginAsPlan(page, 'free');
 		await page.goto('/admin/reports');
-		await expect(page.getByTestId('weekly-report-upsell')).toBeVisible();
+		// 週次メールレポート機能は weekly タブに閉じ込められている。
+		// 既定は monthly タブなので、upsell バナーを見るにはタブ切替が必要。
+		// Vite dev のコールドコンパイル中は click が hydration 前に着弾して state が
+		// 切り替わらないことがあるため、toPass でリトライする。
+		const weeklyTab = page.getByRole('button', { name: '週次レポート', exact: true });
+		await weeklyTab.waitFor({ state: 'visible', timeout: 30_000 });
+		await expect(async () => {
+			await weeklyTab.click();
+			await expect(page.getByTestId('weekly-report-upsell')).toBeVisible({ timeout: 3_000 });
+		}).toPass({ timeout: 30_000 });
 	});
 
 	test('/admin/settings — エクスポートはアップセル表示で disabled', async ({ page }) => {
@@ -77,6 +86,18 @@ test.describe('#751 free プラン — 機能ゲート', () => {
 	}) => {
 		await loginAsPlan(page, 'free');
 		await page.goto('/admin/activities');
+		// AiSuggestPanel は 追加ダイアログの "AIで追加" モード内にのみ描画される。
+		// FAB → 追加ダイアログ → "AIで追加" カードを辿って到達する。
+		// Vite dev のコールドコンパイル中は click が hydration 前に着弾して
+		// ダイアログが開かないことがあるため、toPass でリトライする。
+		const fab = page.getByRole('button', { name: '活動を追加' });
+		await fab.waitFor({ state: 'visible', timeout: 30_000 });
+		const addDialog = page.getByTestId('add-activity-dialog');
+		await expect(async () => {
+			await fab.click();
+			await expect(addDialog).toBeVisible({ timeout: 3_000 });
+		}).toPass({ timeout: 30_000 });
+		await page.getByRole('button', { name: /AIで追加/ }).click();
 		const panel = page.getByTestId('ai-suggest-panel');
 		await expect(panel).toBeVisible();
 		await expect(panel).toHaveAttribute('data-plan-locked', 'true');

--- a/tests/e2e/premium-welcome.spec.ts
+++ b/tests/e2e/premium-welcome.spec.ts
@@ -70,8 +70,10 @@ test.describe('#778 PremiumWelcome モーダル', () => {
 		await expect(dialog).toBeVisible();
 		// 「解放された機能」セクションが含まれる
 		await expect(dialog.getByText('解放された機能')).toBeVisible();
-		// standard 固有の項目（PREMIUM_UNLOCKED_FEATURES.standard より）
-		await expect(dialog.getByText('AI による活動提案')).toBeVisible();
+		// standard 固有の項目（PREMIUM_UNLOCKED_FEATURES.standard より）。
+		// AI 提案は #722 で family 限定になったため、standard の代表項目は
+		// 「1年間のデータ保持」を使う。
+		await expect(dialog.getByText('1年間のデータ保持')).toBeVisible();
 	});
 
 	test('family プラン初回 /admin で歓迎モーダルが表示される', async ({ page }) => {

--- a/tests/e2e/trial-flow.spec.ts
+++ b/tests/e2e/trial-flow.spec.ts
@@ -93,8 +93,12 @@ test.describe('#752 トライアルフロー', () => {
 		await loginAsPlan(page, 'free');
 		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 180_000 });
 
-		// トライアルセクションが表示される（active 状態）
-		await expect(page.getByText(/残り.*日/)).toBeVisible({ timeout: 30_000 });
+		// トライアルセクションが表示される（active 状態）。
+		// /admin/license では TrialBanner（+layout.svelte 由来）と
+		// PlanStatusCard の両方が「残り○日」を表示するため、
+		// getByText(/残り.*日/) は strict mode 違反になる。
+		// PlanStatusCard 側の testid でピンポイントに検証する。
+		await expect(page.getByTestId('plan-status-trial-badge')).toBeVisible({ timeout: 30_000 });
 	});
 
 	// ========================================================


### PR DESCRIPTION
## Summary

`deploy.yml` をブロックしていた cognito-dev E2E 4件の破綻を修正し、デプロイパイプラインを復旧させる。本番コードのバグではなく、UI リファクタに E2E テスト側の locator が追従できていなかったことが原因。

Closes #967

## 修正内容

| # | テスト | 原因 | 修正方針 |
|---|--------|------|---------|
| 1 | `plan-free` › weekly-report-upsell | weekly タブに閉じ込められた upsell へ到達する遷移が欠落。加えて Vite dev の hydration 遅延で click が空振りするフレーク。 | 「週次レポート」タブクリック追加 + `toPass` でリトライ化 |
| 2 | `plan-free` › ai-suggest-panel | AiSuggestPanel は FAB → 追加ダイアログ → 「AIで追加」経路でのみ描画されるが、テストは直接 testid を探していた。 | 到達ナビ追加 + `toPass` で hydration 遅延をハンドル |
| 3 | `premium-welcome` › standard 初回モーダル | #722 で「AI による活動提案」が family 限定に移ったため standard 用アサーションが stale。 | 「1年間のデータ保持」に差し替え |
| 4 | `trial-flow` › /admin/license active | TrialBanner (+layout) と PlanStatusCard の両方が「残り○日」を描画し `getByText(/残り.*日/)` が strict mode 違反。 | `plan-status-trial-badge` testid で特定 |

## Verification

- `npx biome check .` — 新規エラーなし（事前からの警告2件は本PR対象外）
- `npx svelte-check` — 0 errors (40 warnings は既存)
- `npx vitest run` — 3144/3144 pass
- `npx playwright test --config playwright.cognito-dev.config.ts` — 61 pass (1 flaky は cognito-auth の hydration 遅延で retry1 で自動回復、CI 側も 2 retries 許容)

## 経緯メモ（根本原因分析）

4件とも共通して「UI 側の構造変更 (#664 パスルート統合 / #722 プラン移動 / #735 upsell 導入など) に E2E テストの到達ナビが追従していない」問題で、プロダクトコードの不具合ではない。
今後は PR レビュー時に「UI 構造変更 → 該当 E2E テストの到達パスも更新されているか」をチェックリストに追加するとよい（CLAUDE.md の PR review checklist 項目に候補として記録済み）。

## Test plan

- [x] cognito-dev E2E 62 tests 全通過確認
- [x] biome / svelte-check / vitest 通過確認
- [ ] CI 上で `deploy.yml` が green になることを確認
- [ ] マージ後、AWS Lambda へ #962 の JST 修正を含む変更が自動デプロイされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)