### PR TITLE
fix: #964 レビュー必須化 — pr-size-check + 運用ルール追加

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -16,6 +16,24 @@
 - Draft PR はマージできない（GitHub ルールセットで保護）
 - Dependabot PR は自動的に non-draft で作成されるため、従来通りレビュー → auto-merge
 
+## レビュー必須化（#964 / Postmortem #962）
+
+PR は **APPROVED レビュー 1 件以上なしではマージ禁止**。GitHub Branch Ruleset の
+`required_approving_review_count=1` で強制。
+
+- Copilot の自動レビュー (`COMMENTED`) は APPROVED にならない → 別途明示的な APPROVE が必要
+- PO 1 人体制のため、Claude Code Quality Manager / 他 AI レビュアの APPROVED を APPROVED として運用
+- 緊急修正 (`priority:critical`) は admin bypass (`RepositoryRole=Admin`) で許容、ただし PR 本文に bypass 理由を必ず記載
+- 500 行超えの PR は `pr-size-check.yml` が自動警告コメントを投稿する (分割・スコープ明記を検討)
+
+### Ruleset 変更コマンド (管理者のみ)
+```bash
+# required_approving_review_count を 1 に設定
+gh api --method PUT repos/:owner/:repo/rulesets/<ruleset-id> \
+  --input <patch.json>
+```
+詳細: Issue #964, Postmortem #962
+
 ### コマンド例
 ```bash
 gh issue create --title "feat: 機能名" --label "type:feat,priority:medium"

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -1,0 +1,79 @@
+name: PR Size Check
+
+# #964: PR サイズ警告 (500行超えの変更に警告コメントを自動投稿)。
+# Postmortem #962: 37ファイル/+1273行の巨大 PR が APPROVED なくマージされて本番障害化。
+# 大きすぎる PR は review 品質が落ちるため、500行を閾値として警告する。
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  size-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute diff size (excluding generated / lockfile)
+        id: size
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          # lockfile / generated asset は除外
+          CHANGED=$(git diff --numstat "$BASE_SHA..$HEAD_SHA" \
+            -- . \
+            ':(exclude)package-lock.json' \
+            ':(exclude)**/*.lock' \
+            ':(exclude)**/*.min.*' \
+            ':(exclude)**/generated/**' \
+            | awk '{ add += $1; del += $2 } END { print add + del }')
+          CHANGED=${CHANGED:-0}
+          FILES=$(git diff --name-only "$BASE_SHA..$HEAD_SHA" \
+            -- . \
+            ':(exclude)package-lock.json' \
+            ':(exclude)**/*.lock' \
+            | wc -l | tr -d ' ')
+          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "PR 変更行数: $CHANGED / 変更ファイル数: $FILES"
+
+      - name: Post size warning comment when over threshold
+        if: steps.size.outputs.changed != '' && fromJSON(steps.size.outputs.changed) > 500
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const changed = Number('${{ steps.size.outputs.changed }}');
+            const files = Number('${{ steps.size.outputs.files }}');
+            const marker = '<!-- pr-size-check -->';
+            const body = [
+              marker,
+              '## ⚠️ PR サイズ警告 (#964 / ADR-0020)',
+              '',
+              `- 変更行数: **${changed}** 行 (閾値 500 行)`,
+              `- 変更ファイル数: **${files}**`,
+              '',
+              'レビュー品質を保つため、以下のいずれかを検討してください:',
+              '- スコープを縮小して分割 PR 化',
+              '- レビュー観点を PR 本文で絞り込む (「ここは生成物」等)',
+              '- やむを得ない場合は理由を PR 本文に明記',
+              '',
+              '参考: Postmortem #962 (APPROVED なしマージによる本番障害)',
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: pull_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pull_number, body });
+            }


### PR DESCRIPTION
## Summary

Postmortem #962 (PR #941 が APPROVED なしでマージされ本番障害) の再発防止。
GitHub Ruleset での強制は本番設定即時反映なので別途実行（下記手順）、本 PR では CI と docs のみ先行導入。

Closes #964 (部分 — Ruleset 変更は後続)

## 変更内容

### 1. `.github/workflows/pr-size-check.yml` 新規
- PR の変更行数が 500 行を超えると警告コメントを自動投稿
- `package-lock.json` / `*.lock` / `*.min.*` / `**/generated/**` は除外 (実質的な review 対象のみ計測)
- マーカーコメントで重複投稿を防ぎ、push のたびに最新数値で上書き

### 2. `.github/CLAUDE.md` に「レビュー必須化」セクション追加
- APPROVED 1 件以上なしではマージ禁止の方針を明記
- Copilot の `COMMENTED` は APPROVED に**ならない**ことを明示
- PO 1 人体制の運用: Claude Code Quality Manager の APPROVED を APPROVED として採用
- `priority:critical` の緊急修正は admin bypass を許容、ただし PR 本文に bypass 理由必須

## 管理者側で残す作業（この PR マージ後）

GitHub Ruleset `14673945` (PR_Mearge) の `required_approving_review_count` を **0 → 1** に変更:

\`\`\`bash
# 現状確認
gh api repos/Takenori-Kusaka/ganbari-quest/rulesets/14673945 | jq '.rules[] | select(.type=="pull_request")'

# 1 に設定（JSON patch ファイル経由）
cat > /tmp/ruleset-patch.json <<'JSON'
{
  "rules": [
    {"type":"deletion"},
    {"type":"non_fast_forward"},
    {"type":"pull_request","parameters":{
      "required_approving_review_count":1,
      "dismiss_stale_reviews_on_push":false,
      "required_reviewers":[],
      "require_code_owner_review":false,
      "require_last_push_approval":false,
      "required_review_thread_resolution":false,
      "allowed_merge_methods":["merge","squash","rebase"]
    }},
    {"type":"required_status_checks","parameters":{
      "strict_required_status_checks_policy":false,
      "do_not_enforce_on_create":false,
      "required_status_checks":[{"context":"ci-gate","integration_id":15368}]
    }},
    {"type":"copilot_code_review","parameters":{
      "review_on_push":false,
      "review_draft_pull_requests":false
    }}
  ]
}
JSON
gh api --method PUT repos/Takenori-Kusaka/ganbari-quest/rulesets/14673945 --input /tmp/ruleset-patch.json
\`\`\`

Admin bypass (`RepositoryRole=5`) は既に設定済みなので、critical 緊急修正は引き続き通せる。

## Test plan

- [x] YAML 構文確認 (`python3 -c "import yaml; yaml.safe_load(...)"` 通過)
- [ ] マージ後、本 PR 自身 (97 行) は閾値以下なので警告コメント無しを確認
- [ ] 次回 500 行超えの PR で警告コメントが自動投稿されることを確認
- [ ] Ruleset 変更後、APPROVED なしの PR がマージブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)