### PR TITLE
refactor: #972 plan/license/subscription status の値リテラルを定数化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Parallel implementation sync check (#565)
         run: npm run lint:parallel
 
+      - name: No plan/status literal direct write check (#972)
+        run: node scripts/check-no-plan-literals.mjs
+
       - name: Stylelint (CSS hex check)
         run: npx stylelint "src/**/*.css"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ vitest --coverage（カバレッジ閾値）, playwright（E2E）, ESLint（svel
 - E2E テストで `clearDialogGhosts` を新規使用しない → アプリ側のダイアログバグを隠蔽するため
 - `assert*Configured()` / `throw new Error('XXX is required')` / `process.env.X || (() => { throw ... })()` を新規追加するときに、PR 本文へ「配布済み: ENV」証跡を書かない → CI の `new-env-distribution-check` が red になる（ADR-0029、`scripts/check-new-required-env.mjs`）
 - ADR-0029 禁止 5 項目（warn 化 / NODE_ENV skip / `ALLOW_*=true` / retry 延長 / `.skip` 追加）を行わない → 例外手続きは別 ADR で当該 ADR を supersede すること
+- ライセンスプラン / 購読ステータス / ライセンスキー状態の値を文字列リテラルで直書きしない（#972）→ `$lib/domain/constants/{license-plan,subscription-status,license-key-status,auth-license-status}.ts` の定数経由で参照すること。`'family-monthly'` / `'family-yearly'` / `'grace_period'` は CI (`scripts/check-no-plan-literals.mjs`) が自動拒否
 
 ## Critical バグ修正の必須要件（ADR-0005）
 

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1602,6 +1602,18 @@ T#<tenantId>#COUNTER           // テナント内 ID カウンタ
 
 **実装リファレンス**: `src/lib/server/services/license-key-service.ts`
 
+**値定数の SSOT (#972)**:
+`plan` / `status` / `subscription.status` / `licenseStatus` の値リテラルは以下を Single Source of Truth とし、TypeScript 側の比較・分岐では必ず定数参照で書く（DB 値そのものは変更しない）:
+
+| 値カテゴリ | 定数 | ファイル |
+|----------|------|---------|
+| ライセンスキープラン (`monthly` / `yearly` / `family-monthly` / `family-yearly` / `lifetime`) | `LICENSE_PLAN` | `src/lib/domain/constants/license-plan.ts` |
+| ライセンスキー状態 (`active` / `consumed` / `revoked`) | `LICENSE_KEY_STATUS` | `src/lib/domain/constants/license-key-status.ts` |
+| テナント購読状態 (`active` / `grace_period` / `suspended` / `terminated`) | `SUBSCRIPTION_STATUS` | `src/lib/domain/constants/subscription-status.ts` |
+| AuthContext.licenseStatus (`active` / `suspended` / `expired` / `none`) | `AUTH_LICENSE_STATUS` | `src/lib/domain/constants/auth-license-status.ts` |
+
+派生集合 (`MONTHLY_PLANS` / `YEARLY_PLANS` / `FAMILY_PLANS` / `ENTITLED_SUBSCRIPTION_STATUSES`) とヘルパ (`planDurationDays` / `isEntitledStatus` 等) を利用して条件分岐を書く。個別リテラル比較は `scripts/check-no-plan-literals.mjs` が CI で自動検出する。
+
 ### 7.5 GSI2 の利用パターン
 
 | GSI2PK | GSI2SK | 用途 |
@@ -1718,3 +1730,4 @@ src/lib/server/db/migration/
 | 2026-04-11 | 4.7 | #739 §6.5.6 データ削除スコープマトリクス追加。`tenant-cleanup-service.ts` へ共通ヘルパ（`deleteAllChildrenData` / `deleteTenantScopedData`）を集約し、`clearAllFamilyData` / `fullTenantDeletion` / `deleteOwnerFullDelete` から同じ下位関数を呼ぶ構造に統一 |
 | 2026-04-11 | 4.8 | #717, #729 §6.5 保持期間ポリシーを二層構造（表示フィルタ + 物理削除バッチ）に全面改訂。`retention-cleanup-service` を新設し activity_logs / point_ledger / login_bonuses を日次物理削除。ポイント残高は維持（明細のみ削除）。[ADR-0028](../decisions/0028-retention-physical-delete.md) 参照。ADR-0027 は supersede |
 | 2026-04-12 | 4.9 | #769 trial_history に `stripe_subscription_id` / `upgrade_reason` / `trial_start_source` カラム追加（コンバージョン分析用）。既存レコードは NULL 許容 |
+| 2026-04-16 | 5.0 | #972 plan / license / subscription status の値定数を `src/lib/domain/constants/` に集約（`license-plan.ts` / `license-key-status.ts` / `subscription-status.ts` / `auth-license-status.ts`）。DB カラム値は変更せず、比較・分岐ロジックだけを定数経由に統一。`family-monthly` / `family-yearly` / `grace_period` の文字列リテラル直書きは `scripts/check-no-plan-literals.mjs` で CI 自動拒否 |

--- a/scripts/check-no-plan-literals.mjs
+++ b/scripts/check-no-plan-literals.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-no-plan-literals.mjs (#972)
+ *
+ * プラン / ステータス値の文字列リテラル直書きを検出する。
+ * 新規コードは `$lib/domain/constants/*` の定数経由で参照すること。
+ *
+ * 検出対象:
+ *  - LicensePlan 値 ('monthly' | 'yearly' | 'family-monthly' | 'family-yearly' | 'lifetime')
+ *  - SubscriptionStatus の非自明な値 ('grace_period' | 'terminated')
+ *  - LicenseKeyStatus の非自明な値 ('consumed' | 'revoked')
+ *  - AuthLicenseStatus の文脈識別できる値
+ *
+ * ※ 'active' / 'suspended' / 'none' / 'expired' のような汎用短語は他ドメインでも頻用されるため
+ *    本スクリプトでは対象外。レビューと型で担保する。
+ *
+ * 使用法: node scripts/check-no-plan-literals.mjs
+ * CI: エラー検出時は exit 1。
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+/**
+ * 検出ルール (曖昧性のない = 他ドメインで流用されない値のみ)
+ *  - 'monthly' / 'yearly' / 'terminated' / 'consumed' / 'revoked' / 'lifetime' は
+ *    チャレンジ周期・sitemap changefreq・汎用ステータス等で正当に使われるため対象外
+ *  - kebab-case の `family-*` と snake_case の `grace_period` はライセンス文脈固有
+ */
+const RULES = [
+	{ pattern: 'family-monthly', constant: 'LICENSE_PLAN.FAMILY_MONTHLY' },
+	{ pattern: 'family-yearly', constant: 'LICENSE_PLAN.FAMILY_YEARLY' },
+	{ pattern: 'grace_period', constant: 'SUBSCRIPTION_STATUS.GRACE_PERIOD' },
+];
+
+/** 検査対象ディレクトリと拡張子 */
+const SEARCH_ROOTS = ['src/lib/server', 'src/hooks.server.ts', 'src/routes'];
+const EXTENSIONS = ['.ts', '.svelte'];
+
+/**
+ * 検査除外パス (定数定義・マイグレーション・外部 API 互換レイヤ・テスト)
+ *  - 定数ファイル本体: ここでリテラルを定義しているので当然除外
+ *  - Stripe webhook layer: Stripe SDK の生の subscription.status 値を扱うため除外
+ *  - drizzle schema: DB カラム名ではなく SQL default 値として出現する場合がある
+ */
+const EXCLUDE_PATTERNS = [
+	/src[\\/]lib[\\/]domain[\\/]constants[\\/]/,
+	/src[\\/]lib[\\/]server[\\/]services[\\/]stripe-service\.ts$/,
+	/src[\\/]lib[\\/]server[\\/]db[\\/].*[\\/]schema\.ts$/,
+	/src[\\/]lib[\\/]server[\\/]db[\\/]migrations[\\/]/,
+	/\.test\.ts$/,
+	/\.spec\.ts$/,
+];
+
+function shouldExclude(filePath) {
+	const rel = path.relative(REPO_ROOT, filePath);
+	return EXCLUDE_PATTERNS.some((p) => p.test(rel));
+}
+
+function walk(dir, out = []) {
+	if (!fs.existsSync(dir)) return out;
+	const stat = fs.statSync(dir);
+	if (stat.isFile()) {
+		if (EXTENSIONS.some((ext) => dir.endsWith(ext)) && !shouldExclude(dir)) {
+			out.push(dir);
+		}
+		return out;
+	}
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) walk(full, out);
+		else if (entry.isFile() && EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+			if (!shouldExclude(full)) out.push(full);
+		}
+	}
+	return out;
+}
+
+function makeMatchers(pattern) {
+	const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	return [
+		new RegExp(`['"\`]${escaped}['"\`]`),
+	];
+}
+
+function checkFile(filePath) {
+	const text = fs.readFileSync(filePath, 'utf8');
+	const lines = text.split(/\r?\n/);
+	const findings = [];
+	for (const rule of RULES) {
+		const matchers = makeMatchers(rule.pattern);
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i];
+			// コメント行はスキップ (行頭//, /* ... */ 内は完全検出しないが誤検知抑止優先)
+			if (/^\s*\/\//.test(line) || /^\s*\*/.test(line)) continue;
+			for (const m of matchers) {
+				if (m.test(line)) {
+					findings.push({
+						file: path.relative(REPO_ROOT, filePath),
+						line: i + 1,
+						pattern: rule.pattern,
+						constant: rule.constant,
+						snippet: line.trim().slice(0, 120),
+					});
+					break;
+				}
+			}
+		}
+	}
+	return findings;
+}
+
+function main() {
+	const files = [];
+	for (const root of SEARCH_ROOTS) {
+		walk(path.join(REPO_ROOT, root), files);
+	}
+	const allFindings = [];
+	for (const f of files) {
+		allFindings.push(...checkFile(f));
+	}
+	if (allFindings.length === 0) {
+		console.log('[check-no-plan-literals] OK — リテラル直書きなし');
+		process.exit(0);
+	}
+	console.error(
+		`[check-no-plan-literals] NG — ${allFindings.length} 件のリテラル直書きを検出しました:\n`,
+	);
+	for (const f of allFindings) {
+		console.error(`  ${f.file}:${f.line}`);
+		console.error(`    ${f.snippet}`);
+		console.error(`    → ${f.constant} を使用してください (pattern: '${f.pattern}')\n`);
+	}
+	console.error(
+		'定数の場所: src/lib/domain/constants/{license-plan,subscription-status,license-key-status,auth-license-status}.ts',
+	);
+	process.exit(1);
+}
+
+main();

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'node:crypto';
 import { type Handle, type HandleServerError, redirect } from '@sveltejs/kit';
 import { building } from '$app/environment';
 import { analytics } from '$lib/analytics';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { getAuthMode, getAuthProvider } from '$lib/server/auth/factory';
 import { applyDebugPlanOverride } from '$lib/server/debug-plan';
 import {
@@ -254,7 +256,7 @@ export const handle: Handle = ({ event, resolve }) =>
 				{
 					tenantId: 'demo',
 					role: 'owner',
-					licenseStatus: 'active',
+					licenseStatus: AUTH_LICENSE_STATUS.ACTIVE,
 				},
 				demoPlan,
 			);
@@ -318,7 +320,7 @@ export const handle: Handle = ({ event, resolve }) =>
 		}
 
 		// grace_period 読み取り専用制御（#0193）
-		if (context?.tenantStatus === 'grace_period') {
+		if (context?.tenantStatus === SUBSCRIPTION_STATUS.GRACE_PERIOD) {
 			const method = event.request.method;
 			const isWrite = method !== 'GET' && method !== 'HEAD';
 			const isAllowedWritePath = [
@@ -341,7 +343,7 @@ export const handle: Handle = ({ event, resolve }) =>
 		}
 
 		// terminated テナントは完全ブロック（#0193）
-		if (context?.tenantStatus === 'terminated') {
+		if (context?.tenantStatus === SUBSCRIPTION_STATUS.TERMINATED) {
 			if (path.startsWith('/api/')) {
 				return new Response(JSON.stringify({ error: 'アカウントは削除済みです。' }), {
 					status: 403,

--- a/src/lib/domain/constants/auth-license-status.ts
+++ b/src/lib/domain/constants/auth-license-status.ts
@@ -1,0 +1,36 @@
+// src/lib/domain/constants/auth-license-status.ts
+// #972: AuthContext.licenseStatus (認証コンテキスト上のライセンス状態) の SSOT。
+//
+// SubscriptionStatus との関係:
+//   Tenant.status             → AuthContext.licenseStatus
+//   ----------------------------------------------------
+//   'active'                  → 'active'
+//   'grace_period'            → 'active' (猶予中も機能利用可)
+//   'suspended'               → 'suspended'
+//   'terminated' / undefined  → 'none'
+//
+// この正規化は src/lib/server/auth/providers/cognito.ts で実装されている。
+
+export const AUTH_LICENSE_STATUS = {
+	/** 有効 (active / grace_period の正規化結果) */
+	ACTIVE: 'active',
+	/** 機能停止 (支払い失敗等) */
+	SUSPENDED: 'suspended',
+	/** 期限切れ (planExpiresAt 経過) */
+	EXPIRED: 'expired',
+	/** ライセンス無し (free / terminated) */
+	NONE: 'none',
+} as const;
+
+export type AuthLicenseStatus = (typeof AUTH_LICENSE_STATUS)[keyof typeof AUTH_LICENSE_STATUS];
+
+export const ALL_AUTH_LICENSE_STATUSES: readonly AuthLicenseStatus[] = [
+	AUTH_LICENSE_STATUS.ACTIVE,
+	AUTH_LICENSE_STATUS.SUSPENDED,
+	AUTH_LICENSE_STATUS.EXPIRED,
+	AUTH_LICENSE_STATUS.NONE,
+] as const;
+
+export function isAuthLicenseActive(status: AuthLicenseStatus): boolean {
+	return status === AUTH_LICENSE_STATUS.ACTIVE;
+}

--- a/src/lib/domain/constants/license-key-status.ts
+++ b/src/lib/domain/constants/license-key-status.ts
@@ -1,0 +1,36 @@
+// src/lib/domain/constants/license-key-status.ts
+// #972: LicenseRecord.status (発行したライセンスキー自体の状態) の SSOT。
+//
+// 意味的に以下の 3 種類の status と区別すること:
+//  - SubscriptionStatus (Tenant.status): テナント購読の状態
+//  - AuthLicenseStatus (AuthContext.licenseStatus): 認証コンテキストへの正規化後の状態
+//  - StampCardStatus: スタンプカードの状態 (本 issue 範囲外)
+
+export const LICENSE_KEY_STATUS = {
+	/** 発行済み / 未使用 */
+	ACTIVE: 'active',
+	/** consumeLicenseKey で tenant に紐付いた (使用済み) */
+	CONSUMED: 'consumed',
+	/** revokeLicenseKey で失効された (返金 / 漏洩 / 期限切れ等) */
+	REVOKED: 'revoked',
+} as const;
+
+export type LicenseKeyStatus = (typeof LICENSE_KEY_STATUS)[keyof typeof LICENSE_KEY_STATUS];
+
+export const ALL_LICENSE_KEY_STATUSES: readonly LicenseKeyStatus[] = [
+	LICENSE_KEY_STATUS.ACTIVE,
+	LICENSE_KEY_STATUS.CONSUMED,
+	LICENSE_KEY_STATUS.REVOKED,
+] as const;
+
+export function isLicenseKeyActive(status: LicenseKeyStatus): boolean {
+	return status === LICENSE_KEY_STATUS.ACTIVE;
+}
+
+export function isLicenseKeyConsumed(status: LicenseKeyStatus): boolean {
+	return status === LICENSE_KEY_STATUS.CONSUMED;
+}
+
+export function isLicenseKeyRevoked(status: LicenseKeyStatus): boolean {
+	return status === LICENSE_KEY_STATUS.REVOKED;
+}

--- a/src/lib/domain/constants/license-plan.ts
+++ b/src/lib/domain/constants/license-plan.ts
@@ -1,0 +1,87 @@
+// src/lib/domain/constants/license-plan.ts
+// #972: ライセンスプラン値の SSOT。
+// 値リテラルの直書き比較を排除し、新プラン追加時の変更点を 1 箇所に集約する。
+//
+// 設計原則:
+//  - 値は既存 DB / Stripe との後方互換性のため kebab-case を維持
+//  - 定数名は UPPER_SNAKE
+//  - 派生集合 (MONTHLY_PLANS 等) を使って条件分岐を書く。個別リテラル比較は禁止
+//  - UI 表示ラベルは $lib/domain/labels.ts の getPlanLabel() を使う。本ファイルは値のみ
+
+export const LICENSE_PLAN = {
+	MONTHLY: 'monthly',
+	YEARLY: 'yearly',
+	FAMILY_MONTHLY: 'family-monthly',
+	FAMILY_YEARLY: 'family-yearly',
+	LIFETIME: 'lifetime',
+} as const;
+
+export type LicensePlan = (typeof LICENSE_PLAN)[keyof typeof LICENSE_PLAN];
+
+/** 全プラン値の配列 (zod schema / 網羅性テスト用) */
+export const ALL_LICENSE_PLANS: readonly LicensePlan[] = [
+	LICENSE_PLAN.MONTHLY,
+	LICENSE_PLAN.YEARLY,
+	LICENSE_PLAN.FAMILY_MONTHLY,
+	LICENSE_PLAN.FAMILY_YEARLY,
+	LICENSE_PLAN.LIFETIME,
+] as const;
+
+/** 月次課金プラン (30 日周期) */
+export const MONTHLY_PLANS: readonly LicensePlan[] = [
+	LICENSE_PLAN.MONTHLY,
+	LICENSE_PLAN.FAMILY_MONTHLY,
+] as const;
+
+/** 年次課金プラン (365 日周期) */
+export const YEARLY_PLANS: readonly LicensePlan[] = [
+	LICENSE_PLAN.YEARLY,
+	LICENSE_PLAN.FAMILY_YEARLY,
+] as const;
+
+/** family ティア (monthly + yearly) */
+export const FAMILY_PLANS: readonly LicensePlan[] = [
+	LICENSE_PLAN.FAMILY_MONTHLY,
+	LICENSE_PLAN.FAMILY_YEARLY,
+] as const;
+
+/** standard ティア (monthly + yearly、family 以外の有料) */
+export const STANDARD_PLANS: readonly LicensePlan[] = [
+	LICENSE_PLAN.MONTHLY,
+	LICENSE_PLAN.YEARLY,
+] as const;
+
+export function isMonthlyPlan(plan: LicensePlan): boolean {
+	return MONTHLY_PLANS.includes(plan);
+}
+
+export function isYearlyPlan(plan: LicensePlan): boolean {
+	return YEARLY_PLANS.includes(plan);
+}
+
+export function isFamilyPlan(plan: LicensePlan): boolean {
+	return FAMILY_PLANS.includes(plan);
+}
+
+export function isLifetimePlan(plan: LicensePlan): boolean {
+	return plan === LICENSE_PLAN.LIFETIME;
+}
+
+/** #972: plan → 有効期間日数。lifetime は undefined (期限なし) */
+export function planDurationDays(plan: LicensePlan): number | undefined {
+	switch (plan) {
+		case LICENSE_PLAN.LIFETIME:
+			return undefined;
+		case LICENSE_PLAN.MONTHLY:
+		case LICENSE_PLAN.FAMILY_MONTHLY:
+			return 30;
+		case LICENSE_PLAN.YEARLY:
+		case LICENSE_PLAN.FAMILY_YEARLY:
+			return 365;
+		default: {
+			// 型で網羅済みだが将来プラン追加時のガード
+			const _exhaustive: never = plan;
+			throw new Error(`[license-plan] unknown plan: ${String(_exhaustive)}`);
+		}
+	}
+}

--- a/src/lib/domain/constants/subscription-status.ts
+++ b/src/lib/domain/constants/subscription-status.ts
@@ -1,0 +1,51 @@
+// src/lib/domain/constants/subscription-status.ts
+// #972: Tenant.status (Stripe 連動のテナント購読状態) の SSOT。
+// Stripe subscription の状態をアプリ内の状態機械に落とし込んだもの。
+//
+// 遷移 (ADR-0022):
+//   active → grace_period (支払い失敗の猶予期間)
+//          → suspended (猶予期間経過で機能停止)
+//          → terminated (解約確定)
+//   cancel_at_period_end で suspended に移行する経路もある
+
+export const SUBSCRIPTION_STATUS = {
+	/** 購読中 (Stripe subscription active) */
+	ACTIVE: 'active',
+	/** 支払い失敗の猶予期間 (past_due 相当) */
+	GRACE_PERIOD: 'grace_period',
+	/** 機能停止 (猶予経過後 / cancel_at_period_end 通過後) */
+	SUSPENDED: 'suspended',
+	/** 完全解約 */
+	TERMINATED: 'terminated',
+} as const;
+
+export type SubscriptionStatus = (typeof SUBSCRIPTION_STATUS)[keyof typeof SUBSCRIPTION_STATUS];
+
+export const ALL_SUBSCRIPTION_STATUSES: readonly SubscriptionStatus[] = [
+	SUBSCRIPTION_STATUS.ACTIVE,
+	SUBSCRIPTION_STATUS.GRACE_PERIOD,
+	SUBSCRIPTION_STATUS.SUSPENDED,
+	SUBSCRIPTION_STATUS.TERMINATED,
+] as const;
+
+/** 機能が利用可能な status (active + 猶予期間中) */
+export const ENTITLED_SUBSCRIPTION_STATUSES: readonly SubscriptionStatus[] = [
+	SUBSCRIPTION_STATUS.ACTIVE,
+	SUBSCRIPTION_STATUS.GRACE_PERIOD,
+] as const;
+
+export function isEntitledStatus(status: SubscriptionStatus): boolean {
+	return ENTITLED_SUBSCRIPTION_STATUSES.includes(status);
+}
+
+export function isSubscriptionActive(status: SubscriptionStatus): boolean {
+	return status === SUBSCRIPTION_STATUS.ACTIVE;
+}
+
+export function isSubscriptionSuspended(status: SubscriptionStatus): boolean {
+	return status === SUBSCRIPTION_STATUS.SUSPENDED;
+}
+
+export function isSubscriptionTerminated(status: SubscriptionStatus): boolean {
+	return status === SUBSCRIPTION_STATUS.TERMINATED;
+}

--- a/src/lib/server/auth/authorization.ts
+++ b/src/lib/server/auth/authorization.ts
@@ -1,6 +1,7 @@
 // src/lib/server/auth/authorization.ts
 // ロール × ルート 認可マトリクス (#0123: viewer廃止, device廃止)
 
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import type { AuthContext, AuthResult, Identity, Role } from './types';
 
 interface RouteRule {
@@ -136,11 +137,11 @@ function isPublicRoute(path: string): boolean {
 function checkLicenseAccess(path: string, context: AuthContext): AuthResult {
 	const { licenseStatus } = context;
 
-	if (licenseStatus === 'active' || licenseStatus === 'none') {
+	if (licenseStatus === AUTH_LICENSE_STATUS.ACTIVE || licenseStatus === AUTH_LICENSE_STATUS.NONE) {
 		return { allowed: true };
 	}
 
-	if (licenseStatus === 'expired') {
+	if (licenseStatus === AUTH_LICENSE_STATUS.EXPIRED) {
 		// ライセンス管理・決済ページは期限切れでもアクセス可能（更新促進）
 		if (
 			path.startsWith('/admin/license') ||
@@ -153,7 +154,7 @@ function checkLicenseAccess(path: string, context: AuthContext): AuthResult {
 		return { allowed: false, redirect: '/admin/license?reason=expired' };
 	}
 
-	if (licenseStatus === 'suspended') {
+	if (licenseStatus === AUTH_LICENSE_STATUS.SUSPENDED) {
 		// suspended = 読み取り専用。GET は許可、POST/PUT/DELETE は API レイヤで制御
 		return { allowed: true };
 	}

--- a/src/lib/server/auth/entities.ts
+++ b/src/lib/server/auth/entities.ts
@@ -1,6 +1,8 @@
 // src/lib/server/auth/entities.ts
 // マルチテナント認証エンティティの型定義 (#0123)
 
+import type { LicensePlan } from '$lib/domain/constants/license-plan';
+import type { SubscriptionStatus } from '$lib/domain/constants/subscription-status';
 import type { Role } from './types';
 
 /** Cognito ユーザー（Email/Password 認証） */
@@ -24,9 +26,9 @@ export interface Tenant {
 	tenantId: string;
 	name: string;
 	ownerId: string;
-	status: 'active' | 'suspended' | 'grace_period' | 'terminated';
+	status: SubscriptionStatus;
 	licenseKey?: string;
-	plan?: 'monthly' | 'yearly' | 'family-monthly' | 'family-yearly' | 'lifetime';
+	plan?: LicensePlan;
 	stripeCustomerId?: string;
 	stripeSubscriptionId?: string;
 	planExpiresAt?: string;

--- a/src/lib/server/auth/providers/cognito-dev.ts
+++ b/src/lib/server/auth/providers/cognito-dev.ts
@@ -3,6 +3,8 @@
 // 実際の AWS Cognito なしでログイン/認可フローをテスト可能にする
 
 import type { RequestEvent } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { CONTEXT_COOKIE_NAME, IDENTITY_COOKIE_NAME } from '$lib/domain/validation/auth';
 import { COOKIE_SECURE } from '$lib/server/cookie-config';
 import { logger } from '$lib/server/logger';
@@ -62,7 +64,7 @@ export const DEV_USERS: DevUser[] = [
 		password: 'Gq!Dev#Free2026xy',
 		tenantId: 'dev-tenant-free',
 		role: 'owner',
-		licenseStatus: 'none',
+		licenseStatus: AUTH_LICENSE_STATUS.NONE,
 		plan: undefined,
 	},
 	{
@@ -71,7 +73,7 @@ export const DEV_USERS: DevUser[] = [
 		password: 'Gq!Dev#Std2026xyz',
 		tenantId: 'dev-tenant-standard',
 		role: 'owner',
-		licenseStatus: 'active',
+		licenseStatus: AUTH_LICENSE_STATUS.ACTIVE,
 		plan: 'standard_monthly',
 	},
 	{
@@ -80,7 +82,7 @@ export const DEV_USERS: DevUser[] = [
 		password: 'Gq!Dev#Fam2026xyz',
 		tenantId: 'dev-tenant-family',
 		role: 'owner',
-		licenseStatus: 'active',
+		licenseStatus: AUTH_LICENSE_STATUS.ACTIVE,
 		plan: 'family_monthly',
 	},
 	// ---------- #752: トライアル E2E 用ユーザー ----------
@@ -91,7 +93,7 @@ export const DEV_USERS: DevUser[] = [
 		password: 'Gq!Dev#TrialExp26',
 		tenantId: 'dev-tenant-trial-expired',
 		role: 'owner',
-		licenseStatus: 'none',
+		licenseStatus: AUTH_LICENSE_STATUS.NONE,
 		plan: undefined,
 	},
 ];
@@ -161,8 +163,8 @@ export class DevCognitoAuthProvider implements AuthProvider {
 		const context: AuthContext = {
 			tenantId: devUser.tenantId,
 			role: devUser.role,
-			licenseStatus: devUser.licenseStatus ?? 'active',
-			tenantStatus: 'active',
+			licenseStatus: devUser.licenseStatus ?? AUTH_LICENSE_STATUS.ACTIVE,
+			tenantStatus: SUBSCRIPTION_STATUS.ACTIVE,
 			plan: devUser.plan,
 		};
 

--- a/src/lib/server/auth/providers/cognito.ts
+++ b/src/lib/server/auth/providers/cognito.ts
@@ -2,6 +2,8 @@
 // CognitoAuthProvider — Email/Password + MFA + マルチテナント (#0123)
 
 import type { RequestEvent } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import {
 	CONTEXT_COOKIE_NAME,
 	IDENTITY_COOKIE_NAME,
@@ -118,17 +120,18 @@ export class CognitoAuthProvider implements AuthProvider {
 			const tenant = await repos.auth.findTenantById(membership.tenantId);
 
 			// Stripe サブスクリプション状態からライセンスステータスを判定
-			const licenseStatus = tenant?.stripeSubscriptionId
-				? ((tenant.status === 'active' || tenant.status === 'grace_period'
-						? 'active'
-						: 'suspended') as AuthContext['licenseStatus'])
-				: ('none' as AuthContext['licenseStatus']);
+			const licenseStatus: AuthContext['licenseStatus'] = tenant?.stripeSubscriptionId
+				? tenant.status === SUBSCRIPTION_STATUS.ACTIVE ||
+					tenant.status === SUBSCRIPTION_STATUS.GRACE_PERIOD
+					? AUTH_LICENSE_STATUS.ACTIVE
+					: AUTH_LICENSE_STATUS.SUSPENDED
+				: AUTH_LICENSE_STATUS.NONE;
 
 			const context: AuthContext = {
 				tenantId: membership.tenantId,
 				role: membership.role,
 				licenseStatus,
-				tenantStatus: tenant?.status ?? 'active',
+				tenantStatus: tenant?.status ?? SUBSCRIPTION_STATUS.ACTIVE,
 				plan: tenant?.plan,
 			};
 

--- a/src/lib/server/auth/providers/local.ts
+++ b/src/lib/server/auth/providers/local.ts
@@ -2,6 +2,7 @@
 // LocalAuthProvider — 認証なし（LAN内限定、#0123 要件: PIN廃止）
 
 import type { RequestEvent } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import type { AuthContext, AuthProvider, AuthResult, Identity } from '../types';
 
 export class LocalAuthProvider implements AuthProvider {
@@ -15,7 +16,7 @@ export class LocalAuthProvider implements AuthProvider {
 		return {
 			tenantId: 'local',
 			role: 'owner',
-			licenseStatus: 'none',
+			licenseStatus: AUTH_LICENSE_STATUS.NONE,
 		};
 	}
 

--- a/src/lib/server/auth/types.ts
+++ b/src/lib/server/auth/types.ts
@@ -2,6 +2,8 @@
 // 二層セッションモデルの型定義
 
 import type { RequestEvent } from '@sveltejs/kit';
+import type { AuthLicenseStatus } from '$lib/domain/constants/auth-license-status';
+import type { SubscriptionStatus } from '$lib/domain/constants/subscription-status';
 
 /** 認証モードの切り替え（DATA_SOURCE パターンと同様） */
 export type AuthMode = 'local' | 'cognito';
@@ -15,13 +17,19 @@ export type Role = 'owner' | 'parent' | 'child';
  */
 export type Identity = { type: 'local' } | { type: 'cognito'; userId: string; email: string };
 
-/** Layer 2: Context（何として操作しているか） */
+/** Layer 2: Context（何として操作しているか）
+ *
+ * plan は Stripe price ID 相当（例: 'standard_monthly', 'family_monthly'）
+ * または DB Tenant.plan（'monthly' | 'family-monthly' 等）のいずれか。
+ * 呼び出し側は `startsWith('family')` 等でゆるく判定しているため、ここでは
+ * string のまま保持する（#972 も含め今後整理予定）。
+ */
 export interface AuthContext {
 	tenantId: string;
 	role: Role;
 	childId?: number;
-	licenseStatus: 'active' | 'suspended' | 'expired' | 'none';
-	tenantStatus?: 'active' | 'suspended' | 'grace_period' | 'terminated';
+	licenseStatus: AuthLicenseStatus;
+	tenantStatus?: SubscriptionStatus;
 	plan?: string;
 }
 

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -10,6 +10,7 @@ import {
 	ScanCommand,
 	UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { INVITE_EXPIRY_DAYS } from '$lib/domain/validation/auth';
 import type {
 	AuthUser,
@@ -140,7 +141,7 @@ export const createTenant: IAuthRepo['createTenant'] = async (input) => {
 		tenantId,
 		name: input.name,
 		ownerId: input.ownerId,
-		status: 'active',
+		status: SUBSCRIPTION_STATUS.ACTIVE,
 		licenseKey: input.licenseKey,
 		createdAt: now,
 		updatedAt: now,

--- a/src/lib/server/db/sqlite/auth-repo.ts
+++ b/src/lib/server/db/sqlite/auth-repo.ts
@@ -2,6 +2,7 @@
 // SQLite stub for IAuthRepo — local mode does not use auth entities.
 // All methods throw to catch accidental usage in local mode.
 
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import type { IAuthRepo } from '../interfaces/auth-repo.interface';
 
 const NOT_SUPPORTED = 'Auth repo is not supported in local (SQLite) mode. Set AUTH_MODE=cognito.';
@@ -24,7 +25,7 @@ export const findTenantById: IAuthRepo['findTenantById'] = async () => {
 		tenantId: 'local',
 		name: 'ローカル家族',
 		ownerId: 'local',
-		status: 'active' as const,
+		status: SUBSCRIPTION_STATUS.ACTIVE,
 		createdAt: new Date().toISOString(),
 		updatedAt: new Date().toISOString(),
 	};
@@ -36,7 +37,7 @@ export const listAllTenants: IAuthRepo['listAllTenants'] = async () => {
 			tenantId: 'local',
 			name: 'ローカル家族',
 			ownerId: 'local',
-			status: 'active' as const,
+			status: SUBSCRIPTION_STATUS.ACTIVE,
 			createdAt: new Date().toISOString(),
 			updatedAt: new Date().toISOString(),
 		},

--- a/src/lib/server/debug-plan.ts
+++ b/src/lib/server/debug-plan.ts
@@ -6,6 +6,8 @@
 // 場合にのみ有効。本番 (`dev === false`) では常に無効。
 
 import { dev } from '$app/environment';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { LICENSE_PLAN } from '$lib/domain/constants/license-plan';
 import { toJSTDateString } from '$lib/domain/date-utils';
 import type { AuthContext } from '$lib/server/auth/types';
 import type { TrialTier } from '$lib/server/services/trial-service';
@@ -47,11 +49,11 @@ export function getDebugPlanOverride(): DebugPlanOverride | null {
 	}
 	switch (raw as DebugPlan) {
 		case 'free':
-			return { licenseStatus: 'none', plan: undefined };
+			return { licenseStatus: AUTH_LICENSE_STATUS.NONE, plan: undefined };
 		case 'standard':
-			return { licenseStatus: 'active', plan: 'monthly' };
+			return { licenseStatus: AUTH_LICENSE_STATUS.ACTIVE, plan: LICENSE_PLAN.MONTHLY };
 		case 'family':
-			return { licenseStatus: 'active', plan: 'family-monthly' };
+			return { licenseStatus: AUTH_LICENSE_STATUS.ACTIVE, plan: LICENSE_PLAN.FAMILY_MONTHLY };
 	}
 }
 

--- a/src/lib/server/demo/demo-plan.ts
+++ b/src/lib/server/demo/demo-plan.ts
@@ -9,6 +9,8 @@
 //
 // デフォルトは free（サインアップ後の体験との乖離を防ぐ — #956）。
 
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { LICENSE_PLAN } from '$lib/domain/constants/license-plan';
 import type { AuthContext } from '$lib/server/auth/types';
 
 export type DemoPlan = 'free' | 'standard' | 'family';
@@ -43,10 +45,18 @@ export function resolveDemoPlan(query: string | null, cookie: string | undefined
 export function applyDemoPlanToContext(base: AuthContext, demoPlan: DemoPlan): AuthContext {
 	switch (demoPlan) {
 		case 'free':
-			return { ...base, licenseStatus: 'none', plan: undefined };
+			return { ...base, licenseStatus: AUTH_LICENSE_STATUS.NONE, plan: undefined };
 		case 'standard':
-			return { ...base, licenseStatus: 'active', plan: 'monthly' };
+			return {
+				...base,
+				licenseStatus: AUTH_LICENSE_STATUS.ACTIVE,
+				plan: LICENSE_PLAN.MONTHLY,
+			};
 		case 'family':
-			return { ...base, licenseStatus: 'active', plan: 'family-monthly' };
+			return {
+				...base,
+				licenseStatus: AUTH_LICENSE_STATUS.ACTIVE,
+				plan: LICENSE_PLAN.FAMILY_MONTHLY,
+			};
 	}
 }

--- a/src/lib/server/services/email-service.ts
+++ b/src/lib/server/services/email-service.ts
@@ -4,6 +4,7 @@
 
 import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses';
 import { env } from '$env/dynamic/private';
+import { LICENSE_PLAN } from '$lib/domain/constants/license-plan';
 import { logger } from '$lib/server/logger';
 
 // ============================================================
@@ -234,11 +235,11 @@ export async function sendLicenseKeyEmail(
 	plan: string,
 ): Promise<boolean> {
 	const planLabels: Record<string, string> = {
-		monthly: 'スタンダード月額プラン',
-		yearly: 'スタンダード年額プラン',
-		'family-monthly': 'ファミリー月額プラン',
-		'family-yearly': 'ファミリー年額プラン',
-		lifetime: '永久ライセンス',
+		[LICENSE_PLAN.MONTHLY]: 'スタンダード月額プラン',
+		[LICENSE_PLAN.YEARLY]: 'スタンダード年額プラン',
+		[LICENSE_PLAN.FAMILY_MONTHLY]: 'ファミリー月額プラン',
+		[LICENSE_PLAN.FAMILY_YEARLY]: 'ファミリー年額プラン',
+		[LICENSE_PLAN.LIFETIME]: '永久ライセンス',
 	};
 	const planLabel = planLabels[plan] ?? '月額プラン';
 	return sendEmail({

--- a/src/lib/server/services/invite-service.ts
+++ b/src/lib/server/services/invite-service.ts
@@ -1,6 +1,7 @@
 // src/lib/server/services/invite-service.ts
 // 招待リンクサービス (#0129)
 
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import type { Invite, Membership } from '$lib/server/auth/entities';
 import type { Role } from '$lib/server/auth/types';
 import { getRepos } from '$lib/server/db/factory';
@@ -69,7 +70,7 @@ export async function acceptInvite(
 
 	// テナントの存在確認
 	const tenant = await repos().auth.findTenantById(invite.tenantId);
-	if (!tenant || tenant.status !== 'active') {
+	if (!tenant || tenant.status !== SUBSCRIPTION_STATUS.ACTIVE) {
 		return { error: 'TENANT_NOT_FOUND' };
 	}
 

--- a/src/lib/server/services/license-key-service.ts
+++ b/src/lib/server/services/license-key-service.ts
@@ -2,6 +2,12 @@
 // ライセンスキー生成・検証・消費サービス (#0247, #319 HMAC署名対応)
 
 import { createHmac, randomBytes } from 'node:crypto';
+import {
+	LICENSE_KEY_STATUS,
+	type LicenseKeyStatus,
+} from '$lib/domain/constants/license-key-status';
+import { type LicensePlan, planDurationDays } from '$lib/domain/constants/license-plan';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 
@@ -169,9 +175,9 @@ export const DEFAULT_LICENSE_VALIDITY_DAYS = 90;
 export interface LicenseRecord {
 	licenseKey: string;
 	tenantId: string;
-	plan: 'monthly' | 'yearly' | 'family-monthly' | 'family-yearly' | 'lifetime';
+	plan: LicensePlan;
 	stripeSessionId?: string;
-	status: 'active' | 'consumed' | 'revoked';
+	status: LicenseKeyStatus;
 	consumedBy?: string;
 	consumedAt?: string;
 	createdAt: string;
@@ -200,7 +206,7 @@ export function getRecordKind(record: Pick<LicenseRecord, 'kind'>): LicenseKeyKi
 /** ライセンスキーを発行して DynamoDB に保存 */
 export async function issueLicenseKey(params: {
 	tenantId: string;
-	plan: 'monthly' | 'yearly' | 'family-monthly' | 'family-yearly' | 'lifetime';
+	plan: LicensePlan;
 	stripeSessionId?: string;
 	/** #801: キー種別。省略時は 'purchase'（既存呼び出しは Stripe webhook 経由のため） */
 	kind?: LicenseKeyKind;
@@ -245,7 +251,7 @@ export async function issueLicenseKey(params: {
 		tenantId: params.tenantId,
 		plan: params.plan,
 		stripeSessionId: params.stripeSessionId,
-		status: 'active',
+		status: LICENSE_KEY_STATUS.ACTIVE,
 		createdAt: now,
 		kind,
 		issuedBy: params.issuedBy,
@@ -308,11 +314,11 @@ export async function validateLicenseKey(
 		return { valid: false, reason: 'ライセンスキーが見つかりません' };
 	}
 
-	if (record.status === 'consumed') {
+	if (record.status === LICENSE_KEY_STATUS.CONSUMED) {
 		return { valid: false, reason: 'このライセンスキーは既に使用されています' };
 	}
 
-	if (record.status === 'revoked') {
+	if (record.status === LICENSE_KEY_STATUS.REVOKED) {
 		return { valid: false, reason: 'このライセンスキーは無効化されています' };
 	}
 
@@ -360,9 +366,9 @@ function computePlanExpiresAt(
 	plan: LicenseRecord['plan'],
 	now: Date = new Date(),
 ): string | undefined {
-	if (plan === 'lifetime') return undefined;
+	const days = planDurationDays(plan);
+	if (days === undefined) return undefined;
 	const MS_PER_DAY = 24 * 60 * 60 * 1000;
-	const days = plan === 'monthly' || plan === 'family-monthly' ? 30 : 365;
 	return new Date(now.getTime() + days * MS_PER_DAY).toISOString();
 }
 
@@ -393,13 +399,13 @@ export async function consumeLicenseKey(
 	if (!record) {
 		return { ok: false, reason: 'ライセンスキーが見つかりません' };
 	}
-	if (record.status === 'consumed') {
+	if (record.status === LICENSE_KEY_STATUS.CONSUMED) {
 		return { ok: false, reason: 'このライセンスキーは既に使用されています' };
 	}
-	if (record.status === 'revoked') {
+	if (record.status === LICENSE_KEY_STATUS.REVOKED) {
 		return { ok: false, reason: 'このライセンスキーは無効化されています' };
 	}
-	if (record.status !== 'active') {
+	if (record.status !== LICENSE_KEY_STATUS.ACTIVE) {
 		return { ok: false, reason: 'ライセンスキーが使用できません' };
 	}
 
@@ -432,13 +438,17 @@ export async function consumeLicenseKey(
 	// 先に tenant の plan を昇格（失敗したら license は consumed にしない）
 	await repos.auth.updateTenantStripe(consumedByTenantId, {
 		plan: record.plan,
-		status: 'active',
+		status: SUBSCRIPTION_STATUS.ACTIVE,
 		planExpiresAt,
 		licenseKey: normalized,
 	});
 
 	// 成功したので license を consumed としてマーク
-	await repos.auth.updateLicenseKeyStatus(normalized, 'consumed', consumedByTenantId);
+	await repos.auth.updateLicenseKeyStatus(
+		normalized,
+		LICENSE_KEY_STATUS.CONSUMED,
+		consumedByTenantId,
+	);
 
 	logger.info(
 		`[LICENSE] Key consumed: ${normalized.slice(0, 7)}... by tenant=${consumedByTenantId} (issued for=${record.tenantId}, kind=${kind}) plan=${record.plan} expiresAt=${planExpiresAt ?? 'never'}`,
@@ -480,14 +490,14 @@ export async function revokeLicenseKey(params: {
 		return { ok: false, reason: 'ライセンスキーが見つかりません' };
 	}
 
-	if (record.status === 'revoked') {
+	if (record.status === LICENSE_KEY_STATUS.REVOKED) {
 		logger.info(
 			`[LICENSE] revokeLicenseKey: already revoked: ${normalized.slice(0, 7)}... (reason=${record.revokedReason ?? 'unknown'})`,
 		);
 		return { ok: false, reason: 'このライセンスキーは既に無効化されています' };
 	}
 
-	if (record.status === 'consumed') {
+	if (record.status === LICENSE_KEY_STATUS.CONSUMED) {
 		// consumed キーも監査目的で revoke 可能だが、現状ユースケースがないため拒否
 		return { ok: false, reason: 'このライセンスキーは既に使用されています' };
 	}

--- a/src/lib/server/services/ops-service.ts
+++ b/src/lib/server/services/ops-service.ts
@@ -1,6 +1,8 @@
 // src/lib/server/services/ops-service.ts
 // 運営管理ダッシュボード: テナントKPI集計サービス (#0176)
 
+import { LICENSE_PLAN } from '$lib/domain/constants/license-plan';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import type { Tenant } from '$lib/server/auth/entities';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
@@ -63,21 +65,21 @@ async function getTenantStats(): Promise<TenantStats> {
 
 	return {
 		total: tenants.length,
-		active: tenants.filter((t) => t.status === 'active').length,
-		gracePeriod: tenants.filter((t) => t.status === 'grace_period').length,
-		suspended: tenants.filter((t) => t.status === 'suspended').length,
-		terminated: tenants.filter((t) => t.status === 'terminated').length,
+		active: tenants.filter((t) => t.status === SUBSCRIPTION_STATUS.ACTIVE).length,
+		gracePeriod: tenants.filter((t) => t.status === SUBSCRIPTION_STATUS.GRACE_PERIOD).length,
+		suspended: tenants.filter((t) => t.status === SUBSCRIPTION_STATUS.SUSPENDED).length,
+		terminated: tenants.filter((t) => t.status === SUBSCRIPTION_STATUS.TERMINATED).length,
 		planBreakdown: countPlans(tenants),
 		newThisMonth: tenants.filter((t) => new Date(t.createdAt) >= monthStart).length,
 	};
 }
 
 function countPlans(tenants: Tenant[]) {
-	const activeTenants = tenants.filter((t) => t.status === 'active');
+	const activeTenants = tenants.filter((t) => t.status === SUBSCRIPTION_STATUS.ACTIVE);
 	return {
-		monthly: activeTenants.filter((t) => t.plan === 'monthly').length,
-		yearly: activeTenants.filter((t) => t.plan === 'yearly').length,
-		lifetime: activeTenants.filter((t) => t.plan === 'lifetime').length,
+		monthly: activeTenants.filter((t) => t.plan === LICENSE_PLAN.MONTHLY).length,
+		yearly: activeTenants.filter((t) => t.plan === LICENSE_PLAN.YEARLY).length,
+		lifetime: activeTenants.filter((t) => t.plan === LICENSE_PLAN.LIFETIME).length,
 		noPlan: activeTenants.filter((t) => !t.plan).length,
 	};
 }

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -1,6 +1,7 @@
 // src/lib/server/services/plan-limit-service.ts
 // プラン別機能制限サービス (#0196, #0269, #0270)
 
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { getAuthMode } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { buildPlanTierCacheKey, getRequestContext } from '$lib/server/request-context';
@@ -80,7 +81,7 @@ export function resolvePlanTier(
 	// ローカル版（セルフホスト）は常に全機能解放
 	if (getAuthMode() === 'local') return 'family';
 	// アクティブな有料プラン
-	if (licenseStatus === 'active') {
+	if (licenseStatus === AUTH_LICENSE_STATUS.ACTIVE) {
 		return planId?.startsWith('family') ? 'family' : 'standard';
 	}
 	// トライアル期間中 → トライアルのティアを適用（デフォルト: standard）

--- a/src/lib/server/services/retention-cleanup-service.ts
+++ b/src/lib/server/services/retention-cleanup-service.ts
@@ -14,6 +14,11 @@
 // - `/api/cron/retention-cleanup/+server.ts` (EventBridge スケジュール経由)
 // - 手動実行（OPS_SECRET_KEY 認証）
 
+import {
+	AUTH_LICENSE_STATUS,
+	type AuthLicenseStatus,
+} from '$lib/domain/constants/auth-license-status';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import {
@@ -48,10 +53,15 @@ export interface RetentionCleanupOptions {
 function deriveLicenseStatus(tenant: {
 	stripeSubscriptionId?: string;
 	status: string;
-}): 'active' | 'suspended' | 'none' {
-	if (!tenant.stripeSubscriptionId) return 'none';
-	if (tenant.status === 'active' || tenant.status === 'grace_period') return 'active';
-	return 'suspended';
+}): AuthLicenseStatus {
+	if (!tenant.stripeSubscriptionId) return AUTH_LICENSE_STATUS.NONE;
+	if (
+		tenant.status === SUBSCRIPTION_STATUS.ACTIVE ||
+		tenant.status === SUBSCRIPTION_STATUS.GRACE_PERIOD
+	) {
+		return AUTH_LICENSE_STATUS.ACTIVE;
+	}
+	return AUTH_LICENSE_STATUS.SUSPENDED;
 }
 
 /**

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -2,6 +2,8 @@
 // Stripe 決済サービス (#0131)
 
 import type Stripe from 'stripe';
+import { LICENSE_PLAN, type LicensePlan } from '$lib/domain/constants/license-plan';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { PLAN_LABELS } from '$lib/domain/labels';
 import type { Tenant } from '$lib/server/auth/entities';
 import { getRepos } from '$lib/server/db/factory';
@@ -24,7 +26,8 @@ import {
 
 export interface CreateCheckoutInput {
 	tenantId: string;
-	planId: 'monthly' | 'yearly' | 'family-monthly' | 'family-yearly';
+	/** lifetime は Checkout 対象外。Stripe サブスク対象のみ。 */
+	planId: Exclude<LicensePlan, typeof LICENSE_PLAN.LIFETIME>;
 	successUrl: string;
 	cancelUrl: string;
 }
@@ -247,13 +250,13 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promis
 	const subscriptionId =
 		typeof session.subscription === 'string' ? session.subscription : session.subscription?.id;
 
-	const plan = (planId as Tenant['plan']) ?? 'monthly';
+	const plan = (planId as Tenant['plan']) ?? LICENSE_PLAN.MONTHLY;
 	const repos = getRepos();
 	await repos.auth.updateTenantStripe(tenantId, {
 		stripeCustomerId: customerId ?? undefined,
 		stripeSubscriptionId: subscriptionId ?? undefined,
 		plan,
-		status: 'active',
+		status: SUBSCRIPTION_STATUS.ACTIVE,
 		trialUsedAt: new Date().toISOString(),
 	});
 
@@ -263,7 +266,7 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promis
 	try {
 		const licenseRecord = await issueLicenseKey({
 			tenantId,
-			plan: plan ?? 'monthly',
+			plan: plan ?? LICENSE_PLAN.MONTHLY,
 			stripeSessionId: session.id,
 			kind: 'purchase',
 			issuedBy: `stripe:${session.id}`,
@@ -275,11 +278,13 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promis
 		// Stripe Customer のメールアドレスにキーを送信
 		const customerEmail = session.customer_details?.email ?? session.customer_email;
 		if (customerEmail) {
-			sendLicenseKeyEmail(customerEmail, licenseRecord.licenseKey, plan ?? 'monthly').catch(
-				(err) => {
-					logger.warn('[STRIPE] License key email failed', { error: String(err) });
-				},
-			);
+			sendLicenseKeyEmail(
+				customerEmail,
+				licenseRecord.licenseKey,
+				plan ?? LICENSE_PLAN.MONTHLY,
+			).catch((err) => {
+				logger.warn('[STRIPE] License key email failed', { error: String(err) });
+			});
 		}
 	} catch (err) {
 		logger.error('[STRIPE] License key issuance failed', { error: String(err) });
@@ -312,8 +317,8 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
 
 	const repos = getRepos();
 	await repos.auth.updateTenantStripe(tenant.tenantId, {
-		status: 'active',
-		plan: plan ?? tenant.plan ?? 'monthly',
+		status: SUBSCRIPTION_STATUS.ACTIVE,
+		plan: plan ?? tenant.plan ?? LICENSE_PLAN.MONTHLY,
 	});
 
 	logger.info(`[STRIPE] Invoice paid: tenant=${tenant.tenantId}`);
@@ -336,7 +341,7 @@ async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
 	const repos = getRepos();
 	const graceExpires = new Date(Date.now() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000).toISOString();
 	await repos.auth.updateTenantStripe(tenant.tenantId, {
-		status: 'grace_period',
+		status: SUBSCRIPTION_STATUS.GRACE_PERIOD,
 		planExpiresAt: graceExpires,
 	});
 
@@ -359,16 +364,18 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription): Pro
 	const plan = priceId ? planIdFromPriceId(priceId) : null;
 
 	const repos = getRepos();
-	const status =
+	// Stripe SDK 側の subscription.status ('active'|'trialing'|'past_due'|…) を
+	// アプリ内部の SUBSCRIPTION_STATUS に正規化する。
+	const status: Tenant['status'] =
 		subscription.status === 'active' || subscription.status === 'trialing'
-			? 'active'
+			? SUBSCRIPTION_STATUS.ACTIVE
 			: subscription.status === 'past_due'
-				? 'grace_period'
-				: 'suspended';
+				? SUBSCRIPTION_STATUS.GRACE_PERIOD
+				: SUBSCRIPTION_STATUS.SUSPENDED;
 
 	await repos.auth.updateTenantStripe(tenant.tenantId, {
-		plan: plan ?? tenant.plan ?? 'monthly',
-		status: status as Tenant['status'],
+		plan: plan ?? tenant.plan ?? LICENSE_PLAN.MONTHLY,
+		status,
 	});
 
 	logger.info(`[STRIPE] Subscription updated: tenant=${tenant.tenantId} status=${status}`);
@@ -391,7 +398,7 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription): Pro
 	await repos.auth.updateTenantStripe(tenant.tenantId, {
 		stripeSubscriptionId: undefined,
 		plan: undefined,
-		status: 'suspended',
+		status: SUBSCRIPTION_STATUS.SUSPENDED,
 	});
 
 	logger.info(`[STRIPE] Subscription deleted: tenant=${tenant.tenantId}`);

--- a/src/lib/server/stripe/config.ts
+++ b/src/lib/server/stripe/config.ts
@@ -1,7 +1,10 @@
 // src/lib/server/stripe/config.ts
 // Stripe 決済設定・プラン定義 (#0131, #0271)
 
-export type PlanId = 'monthly' | 'yearly' | 'family-monthly' | 'family-yearly';
+import { LICENSE_PLAN, type LicensePlan } from '$lib/domain/constants/license-plan';
+
+/** Stripe で購入可能なプラン (lifetime は Stripe サブスク対象外) */
+export type PlanId = Exclude<LicensePlan, typeof LICENSE_PLAN.LIFETIME>;
 
 export interface PlanConfig {
 	priceId: string;
@@ -14,28 +17,28 @@ export interface PlanConfig {
 /** 環境変数から Price ID を取得し、プラン設定を構築 */
 function buildPlanConfigs(): Record<PlanId, PlanConfig> {
 	return {
-		monthly: {
+		[LICENSE_PLAN.MONTHLY]: {
 			priceId: process.env.STRIPE_PRICE_MONTHLY ?? '',
 			amount: 500,
 			interval: 'month',
 			tier: 'standard',
 			label: 'スタンダード月額（¥500/月）',
 		},
-		yearly: {
+		[LICENSE_PLAN.YEARLY]: {
 			priceId: process.env.STRIPE_PRICE_YEARLY ?? '',
 			amount: 5000,
 			interval: 'year',
 			tier: 'standard',
 			label: 'スタンダード年額（¥5,000/年）',
 		},
-		'family-monthly': {
+		[LICENSE_PLAN.FAMILY_MONTHLY]: {
 			priceId: process.env.STRIPE_PRICE_FAMILY_MONTHLY ?? '',
 			amount: 780,
 			interval: 'month',
 			tier: 'family',
 			label: 'ファミリー月額（¥780/月）',
 		},
-		'family-yearly': {
+		[LICENSE_PLAN.FAMILY_YEARLY]: {
 			priceId: process.env.STRIPE_PRICE_FAMILY_YEARLY ?? '',
 			amount: 7800,
 			interval: 'year',

--- a/src/routes/(child)/+layout.server.ts
+++ b/src/routes/(child)/+layout.server.ts
@@ -1,4 +1,5 @@
 import { redirect } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import type { CurrencyCode, PointSettings, PointUnitMode } from '$lib/domain/point-display';
 import { DEFAULT_POINT_SETTINGS } from '$lib/domain/point-display';
 import { UI_MODES } from '$lib/domain/validation/age-tier';
@@ -89,7 +90,7 @@ export const load: LayoutServerLoad = async ({ cookies, url, locals }) => {
 	// 本 layout で 1 回だけ解決し、planTier / planLimits / isPremium を配布する。
 	const planTier = await resolveFullPlanTier(
 		tenantId,
-		locals.context?.licenseStatus ?? 'none',
+		locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 		locals.context?.plan,
 	);
 	const planLimits = getPlanLimits(planTier);

--- a/src/routes/(child)/[uiMode=uiMode]/(character)/history/+page.server.ts
+++ b/src/routes/(child)/[uiMode=uiMode]/(character)/history/+page.server.ts
@@ -1,3 +1,4 @@
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { todayDateJST, toJSTDateString } from '$lib/domain/date-utils';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getActivityLogs } from '$lib/server/services/activity-log-service';
@@ -33,7 +34,7 @@ export const load: PageServerLoad = async ({ parent, url, locals }) => {
 	const dateRange = getDateRange(period);
 	const planTier = await resolveFullPlanTier(
 		tenantId,
-		locals.context?.licenseStatus ?? 'none',
+		locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 		locals.context?.plan,
 	);
 	const filtered = applyRetentionFilter(planTier, dateRange);

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { getActivityDisplayName } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
@@ -555,7 +556,7 @@ export const actions: Actions = {
 			const isPremium = isPaidTier(
 				await resolveFullPlanTier(
 					tenantId,
-					locals.context?.licenseStatus ?? 'none',
+					locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 					locals.context?.plan,
 				),
 			);

--- a/src/routes/(parent)/admin/+layout.server.ts
+++ b/src/routes/(parent)/admin/+layout.server.ts
@@ -1,3 +1,5 @@
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import type { CurrencyCode, PointSettings, PointUnitMode } from '$lib/domain/point-display';
 import { DEFAULT_POINT_SETTINGS } from '$lib/domain/point-display';
 import { getAuthMode, requireTenantId } from '$lib/server/auth/factory';
@@ -38,12 +40,12 @@ export const load: LayoutServerLoad = async ({ locals, cookies }) => {
 		rate: Number.parseFloat(pointSettingsRaw.point_rate ?? '') || DEFAULT_POINT_SETTINGS.rate,
 	};
 
-	const tenantStatus = locals.context?.tenantStatus ?? 'active';
+	const tenantStatus = locals.context?.tenantStatus ?? SUBSCRIPTION_STATUS.ACTIVE;
 	// #732: server load 全体で resolveFullPlanTier に統一。
 	// trial 期限・tier は resolveFullPlanTier が内部で取得する（#725 の両引数漏れも自動解消）。
 	const planTier = await resolveFullPlanTier(
 		tenantId,
-		locals.context?.licenseStatus ?? 'none',
+		locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 		locals.context?.plan,
 	);
 	const isPremium = isPaidTier(planTier);

--- a/src/routes/(parent)/admin/achievements/+page.server.ts
+++ b/src/routes/(parent)/admin/achievements/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { requireTenantId } from '$lib/server/auth/factory';
 import type { CustomAchievementConditionType } from '$lib/server/db/types';
 import { getAllChildren } from '$lib/server/services/child-service';
@@ -14,7 +15,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const tenantId = requireTenantId(locals);
 	const children = await getAllChildren(tenantId);
 
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const planTier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 	const isPremium = isPaidTier(planTier);
 
@@ -53,7 +54,7 @@ export const actions = {
 			return fail(400, { error: '必須項目を入力してください' });
 		}
 
-		const licenseStatus = locals.context?.licenseStatus ?? 'none';
+		const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 		const planTier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 
 		const result = await createCustomAchievement(

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail } from '@sveltejs/kit';
 import { activityPackIndex, getActivityPack } from '$lib/data/activity-packs';
 import type { ActivityPackItem } from '$lib/domain/activity-pack';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { CATEGORY_CODES, CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
@@ -35,7 +36,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const mainQuestCount = await getMainQuestCount(tenantId);
 
 	// プラン制限情報
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const activityLimit = await checkActivityLimit(tenantId, licenseStatus);
 
 	// プリセットパック一覧
@@ -100,7 +101,7 @@ export const actions: Actions = {
 		}
 
 		// プラン制限チェック（カスタム活動数）
-		const licenseStatus = locals.context?.licenseStatus ?? 'none';
+		const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 		const activityLimitCheck = await checkActivityLimit(tenantId, licenseStatus);
 		if (!activityLimitCheck.allowed) {
 			// #787: PlanLimitError 形式に統一。tier は memoize 済み (#788) なので 2 回目の呼び出しは安い

--- a/src/routes/(parent)/admin/certificates/+page.server.ts
+++ b/src/routes/(parent)/admin/certificates/+page.server.ts
@@ -1,3 +1,4 @@
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getCertificatesForChild } from '$lib/server/services/certificate-service';
 import { getAllChildren } from '$lib/server/services/child-service';
@@ -21,7 +22,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 		),
 		resolveFullPlanTier(
 			tenantId,
-			locals.context?.licenseStatus ?? 'none',
+			locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 			locals.context?.plan,
 		).then(isPaidTier),
 	]);

--- a/src/routes/(parent)/admin/certificates/[id]/+page.server.ts
+++ b/src/routes/(parent)/admin/certificates/[id]/+page.server.ts
@@ -1,4 +1,5 @@
 import { error } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { buildRenderData, getCertificateDetail } from '$lib/server/services/certificate-service';
 import { getChildById } from '$lib/server/services/child-service';
@@ -18,7 +19,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 
 	const renderData = buildRenderData(cert, child.nickname);
 
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const isPremium = isPaidTier(
 		await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan),
 	);

--- a/src/routes/(parent)/admin/challenges/+page.server.ts
+++ b/src/routes/(parent)/admin/challenges/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getAllChildren } from '$lib/server/services/child-service';
 import { getFamilyStreak, getNextMilestone } from '$lib/server/services/family-streak-service';
@@ -12,7 +13,7 @@ import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	const tenantId = requireTenantId(locals);
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const planTier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 
 	const [challenges, children, familyStreakData] = await Promise.all([

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { todayDateJST } from '$lib/domain/date-utils';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { requireTenantId } from '$lib/server/auth/factory';
@@ -50,7 +51,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 	const tier = await resolveFullPlanTier(
 		tenantId,
-		locals.context?.licenseStatus ?? 'none',
+		locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 		locals.context?.plan,
 	);
 	const isPremium = isPaidTier(tier);
@@ -81,7 +82,7 @@ export const actions: Actions = {
 			return fail(400, { error: '時間帯が不正です' });
 
 		// #723: Free プランの上限チェック（UI ゲートをバイパスした直接 POST を防ぐ）
-		const licenseStatus = locals.context?.licenseStatus ?? 'none';
+		const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 		const limit = await checkChecklistTemplateLimit(tenantId, licenseStatus, childId);
 		if (!limit.allowed) {
 			// #787: PlanLimitError 形式に統一。tier は memoize 済み (#788) なので 2 回目の呼び出しは安い
@@ -196,7 +197,7 @@ export const actions: Actions = {
 	createFromAi: async ({ request, locals }) => {
 		const tenantId = requireTenantId(locals);
 
-		const licenseStatus = locals.context?.licenseStatus ?? 'none';
+		const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 		const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 		if (tier !== 'family') {
 			return fail(403, {

--- a/src/routes/(parent)/admin/children/+page.server.ts
+++ b/src/routes/(parent)/admin/children/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
@@ -41,7 +42,7 @@ function calculateAge(birthDate: string): number {
 
 export const load: PageServerLoad = async ({ url, locals }) => {
 	const tenantId = requireTenantId(locals);
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const children = await getAllChildren(tenantId);
 	const selectedId = url.searchParams.get('id');
 
@@ -169,7 +170,7 @@ export const actions: Actions = {
 		}
 
 		// プラン制限チェック
-		const licenseStatus = locals.context?.licenseStatus ?? 'none';
+		const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 		const childLimitCheck = await checkChildLimit(tenantId, licenseStatus);
 		if (!childLimitCheck.allowed) {
 			// #787: PlanLimitError 形式に統一。tier は memoize 済み (#788) なので 2 回目の呼び出しは安い

--- a/src/routes/(parent)/admin/growth-book/+page.server.ts
+++ b/src/routes/(parent)/admin/growth-book/+page.server.ts
@@ -1,3 +1,4 @@
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getAllChildren } from '$lib/server/services/child-service';
 import { buildGrowthBook } from '$lib/server/services/growth-book-service';
@@ -26,7 +27,7 @@ export const load: PageServerLoad = async ({ url, locals }) => {
 		buildGrowthBook(selectedChildId, fiscalYear, tenantId),
 		resolveFullPlanTier(
 			tenantId,
-			locals.context?.licenseStatus ?? 'none',
+			locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 			locals.context?.plan,
 		).then(isPaidTier),
 	]);

--- a/src/routes/(parent)/admin/license/+page.server.ts
+++ b/src/routes/(parent)/admin/license/+page.server.ts
@@ -1,6 +1,8 @@
 // /admin/license — ライセンス管理画面 (#0130, #0131, #314, #796)
 
 import { fail } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { requireRole } from '$lib/server/auth/guards';
 import { logger } from '$lib/server/logger';
@@ -30,7 +32,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	// プラン利用状況 (#732: resolveFullPlanTier に統一)
 	const tier = await resolveFullPlanTier(
 		tenantId,
-		locals.context?.licenseStatus ?? 'none',
+		locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 		locals.context?.plan,
 	);
 	const planLimits = getPlanLimits(tier);
@@ -56,7 +58,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	return {
 		license: license ?? {
 			plan: 'free' as const,
-			status: 'active' as const,
+			status: SUBSCRIPTION_STATUS.ACTIVE,
 			tenantName: '',
 			createdAt: new Date().toISOString(),
 			updatedAt: new Date().toISOString(),

--- a/src/routes/(parent)/admin/license/+page.svelte
+++ b/src/routes/(parent)/admin/license/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { LICENSE_PLAN } from '$lib/domain/constants/license-plan';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { getLicenseHighlights } from '$lib/domain/plan-features';
 import PlanStatusCard from '$lib/features/admin/components/PlanStatusCard.svelte';
 import ChurnPreventionModal from '$lib/features/loyalty/ChurnPreventionModal.svelte';
@@ -60,15 +62,15 @@ const applySuccess = $derived(applyResult?.success === true);
 
 const planLabel = (plan: string) => {
 	switch (plan) {
-		case 'monthly':
+		case LICENSE_PLAN.MONTHLY:
 			return 'スタンダード月額（¥500/月）';
-		case 'yearly':
+		case LICENSE_PLAN.YEARLY:
 			return 'スタンダード年額（¥5,000/年）';
-		case 'family-monthly':
+		case LICENSE_PLAN.FAMILY_MONTHLY:
 			return 'ファミリー月額（¥780/月）';
-		case 'family-yearly':
+		case LICENSE_PLAN.FAMILY_YEARLY:
 			return 'ファミリー年額（¥7,800/年）';
-		case 'lifetime':
+		case LICENSE_PLAN.LIFETIME:
 			return '永久ライセンス';
 		case 'free':
 			return '無料プラン';
@@ -79,28 +81,28 @@ const planLabel = (plan: string) => {
 
 const statusLabel = (status: string) => {
 	switch (status) {
-		case 'active':
+		case SUBSCRIPTION_STATUS.ACTIVE:
 			return {
 				text: '有効',
 				color:
 					'bg-[var(--color-feedback-success-bg-strong)] text-[var(--color-feedback-success-text)]',
 				icon: '✅',
 			};
-		case 'grace_period':
+		case SUBSCRIPTION_STATUS.GRACE_PERIOD:
 			return {
 				text: '猶予期間',
 				color:
 					'bg-[var(--color-feedback-warning-bg-strong)] text-[var(--color-feedback-warning-text)]',
 				icon: '⚠️',
 			};
-		case 'suspended':
+		case SUBSCRIPTION_STATUS.SUSPENDED:
 			return {
 				text: '停止中',
 				color:
 					'bg-[var(--color-feedback-warning-bg-strong)] text-[var(--color-feedback-warning-text)]',
 				icon: '⏸️',
 			};
-		case 'terminated':
+		case SUBSCRIPTION_STATUS.TERMINATED:
 			return {
 				text: '解約済み',
 				color: 'bg-[var(--color-feedback-error-bg-strong)] text-[var(--color-feedback-error-text)]',
@@ -505,7 +507,7 @@ async function openPortal() {
 	{/if}
 
 	<!-- ステータス別メッセージ -->
-	{#if license.status === 'grace_period'}
+	{#if license.status === SUBSCRIPTION_STATUS.GRACE_PERIOD}
 		<section class="bg-[var(--color-feedback-warning-bg)] rounded-xl p-4 border border-[var(--color-feedback-warning-border)]">
 			<h3 class="text-sm font-semibold text-[var(--color-feedback-warning-text)] mb-1">⚠️ 猶予期間中</h3>
 			<p class="text-sm text-[var(--color-feedback-warning-text)]">
@@ -513,7 +515,7 @@ async function openPortal() {
 				期間を過ぎるとサービスが停止されます。
 			</p>
 		</section>
-	{:else if license.status === 'suspended'}
+	{:else if license.status === SUBSCRIPTION_STATUS.SUSPENDED}
 		<section class="bg-[var(--color-feedback-warning-bg)] rounded-xl p-4 border border-[var(--color-feedback-warning-border)]">
 			<h3 class="text-sm font-semibold text-[var(--color-feedback-warning-text)] mb-1">⏸️ サービス停止中</h3>
 			<p class="text-sm text-[var(--color-feedback-warning-text)]">
@@ -521,7 +523,7 @@ async function openPortal() {
 				新しい活動の記録やポイントの付与はできません。
 			</p>
 		</section>
-	{:else if license.status === 'terminated'}
+	{:else if license.status === SUBSCRIPTION_STATUS.TERMINATED}
 		<section class="bg-[var(--color-feedback-error-bg)] rounded-xl p-4 border border-[var(--color-feedback-error-border)]">
 			<h3 class="text-sm font-semibold text-[var(--color-feedback-error-text)] mb-1">❌ 解約済み</h3>
 			<p class="text-sm text-[var(--color-feedback-error-text)]">

--- a/src/routes/(parent)/admin/messages/+page.server.ts
+++ b/src/routes/(parent)/admin/messages/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import {
 	MESSAGE_TEXT_MAX_LENGTH,
@@ -59,7 +60,7 @@ export const actions: Actions = {
 		}
 		if (validType === 'text') {
 			// ファミリープラン限定チェック（トライアル状態も考慮）
-			const licenseStatus = locals.context?.licenseStatus ?? 'none';
+			const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 			const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 			const limits = getPlanLimits(tier);
 			if (!limits.canFreeTextMessage) {

--- a/src/routes/(parent)/admin/reports/+page.server.ts
+++ b/src/routes/(parent)/admin/reports/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getSettings, setSetting } from '$lib/server/db/settings-repo';
@@ -129,7 +130,7 @@ export const actions: Actions = {
 		// サーバ側でも必ずプランを解決して拒否する。
 		const planTier = await resolveFullPlanTier(
 			tenantId,
-			locals.context?.licenseStatus ?? 'none',
+			locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 			locals.context?.plan,
 		);
 		if (planTier === 'free') {

--- a/src/routes/(parent)/admin/rewards/+page.server.ts
+++ b/src/routes/(parent)/admin/rewards/+page.server.ts
@@ -2,6 +2,7 @@
 
 import { fail } from '@sveltejs/kit';
 import { PRESET_REWARD_GROUPS } from '$lib/data/preset-rewards';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getAllChildren } from '$lib/server/services/child-service';
@@ -23,7 +24,7 @@ const UPGRADE_MESSAGE = '特別なごほうび設定はスタンダードプラ�
 
 export const load: PageServerLoad = async ({ locals }) => {
 	const tenantId = requireTenantId(locals);
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 	const isPremium = isPaidTier(tier);
 
@@ -52,7 +53,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 /** 現在のプラン tier を解決して返すヘルパー (#787) */
 async function resolveTier(locals: App.Locals, tenantId: string): Promise<PlanTier> {
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	return resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 }
 

--- a/src/routes/(parent)/admin/settings/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import type { CurrencyCode, PointUnitMode } from '$lib/domain/point-display';
 import { CURRENCY_CODES } from '$lib/domain/point-display';
@@ -48,7 +49,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	// #773: エクスポート / クラウドエクスポートも同じ planLimits から UI ゲート情報を配布する。
 	const planTier = await resolveFullPlanTier(
 		tenantId,
-		locals.context?.licenseStatus ?? 'none',
+		locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 		locals.context?.plan,
 	);
 	const planLimits = getPlanLimits(planTier);
@@ -262,7 +263,7 @@ export const actions = {
 		// #782: きょうだいランキングは family プラン限定
 		const planTier = await resolveFullPlanTier(
 			tenantId,
-			locals.context?.licenseStatus ?? 'none',
+			locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 			locals.context?.plan,
 		);
 		const planLimits = getPlanLimits(planTier);

--- a/src/routes/(parent)/admin/settings/+page.svelte
+++ b/src/routes/(parent)/admin/settings/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { page } from '$app/stores';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { getErrorMessage } from '$lib/domain/errors';
 import type { CurrencyCode, PointUnitMode } from '$lib/domain/point-display';
 import { CURRENCY_CODES, CURRENCY_DEFS, formatPointValue } from '$lib/domain/point-display';
@@ -548,7 +549,7 @@ const anyFormBusy = $derived(
 
 <div class="space-y-6">
 	<!-- grace_period バナー -->
-	{#if $page.data.tenantStatus === 'grace_period'}
+	{#if $page.data.tenantStatus === SUBSCRIPTION_STATUS.GRACE_PERIOD}
 		<div class="bg-[var(--color-feedback-error-bg)] border-2 border-[var(--color-feedback-error-border)] rounded-xl p-6">
 			<h3 class="text-lg font-bold text-[var(--color-feedback-error-text)] mb-2">解約手続き中です</h3>
 			<p class="text-sm text-[var(--color-feedback-error-text)] mb-4">
@@ -1726,7 +1727,7 @@ const anyFormBusy = $derived(
 	</Card>
 
 	<!-- アカウント削除（cognito モードの全ロール） -->
-	{#if $page.data.authMode === 'cognito' && $page.data.tenantStatus !== 'grace_period'}
+	{#if $page.data.authMode === 'cognito' && $page.data.tenantStatus !== SUBSCRIPTION_STATUS.GRACE_PERIOD}
 		<Card padding="lg" class="border-2 border-[var(--color-feedback-error-border)]">
 			<h3 class="text-lg font-bold text-[var(--color-feedback-error-text)] mb-2">アカウント削除</h3>
 			{#if $page.data.userRole === 'owner'}

--- a/src/routes/api/stripe/checkout/+server.ts
+++ b/src/routes/api/stripe/checkout/+server.ts
@@ -2,6 +2,7 @@
 // セキュリティ: 認証必須 + owner/parent ロールのみ + tenantId はサーバー側から取得（改ざん不可）
 
 import { error, json } from '@sveltejs/kit';
+import { LICENSE_PLAN } from '$lib/domain/constants/license-plan';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { createCheckoutSession } from '$lib/server/services/stripe-service';
 import type { RequestHandler } from './$types';
@@ -18,7 +19,12 @@ export const POST: RequestHandler = async ({ request, locals, url }) => {
 
 	const body = await request.json();
 	const planId = body.planId;
-	const validPlanIds = ['monthly', 'yearly', 'family-monthly', 'family-yearly'];
+	const validPlanIds: string[] = [
+		LICENSE_PLAN.MONTHLY,
+		LICENSE_PLAN.YEARLY,
+		LICENSE_PLAN.FAMILY_MONTHLY,
+		LICENSE_PLAN.FAMILY_YEARLY,
+	];
 	if (!validPlanIds.includes(planId)) {
 		error(400, 'プランが正しくありません');
 	}

--- a/src/routes/api/v1/activities/suggest/+server.ts
+++ b/src/routes/api/v1/activities/suggest/+server.ts
@@ -2,6 +2,7 @@
 // AI 活動提案 API — プランゲート必須 (#727)
 
 import { error, json } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { apiError } from '$lib/server/errors';
 import { suggestActivity } from '$lib/server/services/activity-suggest-service';
 import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
@@ -15,7 +16,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const tenantId = locals.context.tenantId;
 
 	// #727: プランゲート — 無料プランは AI 提案を利用不可（コスト流出防止）
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 	if (tier !== 'family') {
 		return apiError('PLAN_LIMIT_EXCEEDED', 'AI 活動提案はファミリープランでご利用いただけます');

--- a/src/routes/api/v1/admin/cleanup-orphans/+server.ts
+++ b/src/routes/api/v1/admin/cleanup-orphans/+server.ts
@@ -3,6 +3,7 @@
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { deleteFile, listFiles } from '$lib/server/storage';
@@ -60,7 +61,7 @@ async function detectAndCleanOrphans(dryRun: boolean): Promise<CleanupResult> {
 		// テナント存在チェック
 		if (!tenantCache.has(tenantId)) {
 			const tenant = await repos.auth.findTenantById(tenantId);
-			const exists = !!tenant && tenant.status !== 'terminated';
+			const exists = !!tenant && tenant.status !== SUBSCRIPTION_STATUS.TERMINATED;
 			tenantCache.set(tenantId, exists);
 		}
 		if (!tenantCache.get(tenantId)) {

--- a/src/routes/api/v1/admin/tenant-cleanup/+server.ts
+++ b/src/routes/api/v1/admin/tenant-cleanup/+server.ts
@@ -3,6 +3,7 @@
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { notifyDeletionComplete } from '$lib/server/services/discord-notify-service';
@@ -133,7 +134,7 @@ async function findGracePeriodTenants(): Promise<TenantInfo[]> {
 					ExpressionAttributeValues: {
 						':prefix': 'TENANT#',
 						':sk': 'META',
-						':status': 'grace_period',
+						':status': SUBSCRIPTION_STATUS.GRACE_PERIOD,
 					},
 					ExclusiveStartKey: lastKey,
 				}),

--- a/src/routes/api/v1/admin/tenant/cancel/+server.ts
+++ b/src/routes/api/v1/admin/tenant/cancel/+server.ts
@@ -17,6 +17,7 @@
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { error, json } from '@sveltejs/kit';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
@@ -40,10 +41,10 @@ export const POST: RequestHandler = async ({ locals }) => {
 		return json({ error: 'テナントが見つかりません' }, { status: 404 });
 	}
 
-	if (tenant.status === 'grace_period') {
+	if (tenant.status === SUBSCRIPTION_STATUS.GRACE_PERIOD) {
 		return json({ error: '既に解約手続き中です' }, { status: 409 });
 	}
-	if (tenant.status === 'terminated') {
+	if (tenant.status === SUBSCRIPTION_STATUS.TERMINATED) {
 		return json({ error: 'アカウントは既に削除済みです' }, { status: 409 });
 	}
 
@@ -67,7 +68,7 @@ export const POST: RequestHandler = async ({ locals }) => {
 	const graceEndAt = graceEnd.toISOString();
 
 	await repos.auth.updateTenantStripe(tenantId, {
-		status: 'grace_period',
+		status: SUBSCRIPTION_STATUS.GRACE_PERIOD,
 		planExpiresAt: graceEndAt,
 	});
 

--- a/src/routes/api/v1/admin/tenant/reactivate/+server.ts
+++ b/src/routes/api/v1/admin/tenant/reactivate/+server.ts
@@ -9,6 +9,7 @@
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
@@ -28,7 +29,7 @@ export const POST: RequestHandler = async ({ locals }) => {
 		return json({ error: 'テナントが見つかりません' }, { status: 404 });
 	}
 
-	if (tenant.status !== 'grace_period') {
+	if (tenant.status !== SUBSCRIPTION_STATUS.GRACE_PERIOD) {
 		return json({ error: '解約手続き中ではありません' }, { status: 409 });
 	}
 
@@ -51,7 +52,7 @@ export const POST: RequestHandler = async ({ locals }) => {
 	// 防御的: 万一 Subscription がまだ残っている場合（本来到達しない）、
 	// その場合のみ DB 上で active に戻す。
 	await repos.auth.updateTenantStripe(tenantId, {
-		status: 'active',
+		status: SUBSCRIPTION_STATUS.ACTIVE,
 		planExpiresAt: undefined,
 	});
 

--- a/src/routes/api/v1/admin/viewer-tokens/+server.ts
+++ b/src/routes/api/v1/admin/viewer-tokens/+server.ts
@@ -3,6 +3,7 @@
 // (#371)
 
 import { error, json } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import { createViewerToken, listViewerTokens } from '$lib/server/services/viewer-token-service';
@@ -12,7 +13,7 @@ async function requireFamily(locals: App.Locals): Promise<string> {
 	const tenantId = requireTenantId(locals);
 	const tier = await resolveFullPlanTier(
 		tenantId,
-		locals.context?.licenseStatus ?? 'none',
+		locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
 		locals.context?.plan,
 	);
 	if (tier !== 'family') {

--- a/src/routes/api/v1/checklists/suggest/+server.ts
+++ b/src/routes/api/v1/checklists/suggest/+server.ts
@@ -2,6 +2,7 @@
 // AI チェックリスト提案 API — プランゲート必須 (#720)
 
 import { error, json } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { apiError } from '$lib/server/errors';
 import { suggestChecklist } from '$lib/server/services/checklist-suggest-service';
 import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
@@ -13,7 +14,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 	const tenantId = locals.context.tenantId;
 
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 	if (tier !== 'family') {
 		return apiError(

--- a/src/routes/api/v1/export/+server.ts
+++ b/src/routes/api/v1/export/+server.ts
@@ -1,6 +1,7 @@
 // src/routes/api/v1/export/+server.ts
 // 家族データエクスポートAPI（JSON / ZIP対応）
 
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { requireRole, requireTenantId } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
@@ -15,7 +16,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	requireRole(locals, ['owner', 'parent']);
 
 	// プラン制限チェック（エクスポート機能）
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const limits = getPlanLimits(
 		await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan),
 	);

--- a/src/routes/api/v1/export/cloud/+server.ts
+++ b/src/routes/api/v1/export/cloud/+server.ts
@@ -2,6 +2,7 @@
 // クラウドエクスポートAPI（一覧取得 + 新規作成）
 
 import { json } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { requireRole, requireTenantId } from '$lib/server/auth/factory';
 import type { CloudExportType } from '$lib/server/db/types';
 import { apiError, validationError } from '$lib/server/errors';
@@ -40,7 +41,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		return validationError('exportType は template または full を指定してください');
 	}
 
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const planId = locals.context?.plan;
 
 	try {

--- a/src/routes/api/v1/special-rewards/suggest/+server.ts
+++ b/src/routes/api/v1/special-rewards/suggest/+server.ts
@@ -2,6 +2,7 @@
 // AI ごほうび提案 API — プランゲート必須 (#719)
 
 import { error, json } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { apiError } from '$lib/server/errors';
 import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import { suggestReward } from '$lib/server/services/reward-suggest-service';
@@ -13,7 +14,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 	const tenantId = locals.context.tenantId;
 
-	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 	if (tier !== 'family') {
 		return apiError('PLAN_LIMIT_EXCEEDED', 'AI ごほうび提案はファミリープランでご利用いただけます');

--- a/src/routes/demo/(parent)/admin/license/+page.server.ts
+++ b/src/routes/demo/(parent)/admin/license/+page.server.ts
@@ -2,6 +2,7 @@
 // 本番 /admin/license の UI をミラーしつつ、Stripe/ライセンスサービスは全てモック化する。
 // デモは認証レスなので tenant 情報は固定値。クリックしても Stripe には到達しない。
 
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
@@ -10,7 +11,7 @@ export const load: PageServerLoad = async () => {
 	return {
 		license: {
 			plan: 'free' as const,
-			status: 'active' as const,
+			status: SUBSCRIPTION_STATUS.ACTIVE,
 			tenantName: 'デモファミリー',
 			createdAt: '2026-01-01T00:00:00Z',
 			updatedAt: '2026-01-01T00:00:00Z',

--- a/tests/unit/domain/auth-license-status-constants.test.ts
+++ b/tests/unit/domain/auth-license-status-constants.test.ts
@@ -1,0 +1,42 @@
+// tests/unit/domain/auth-license-status-constants.test.ts
+// #972: AUTH_LICENSE_STATUS 定数 / ヘルパの網羅性テスト
+//
+// 注: SubscriptionStatus → AuthLicenseStatus の正規化ロジック自体は
+// src/lib/server/auth/providers/cognito.ts の本体で実装されており、
+// そちらの単体テストで担保する。本ファイルは定数値と集合の整合のみ検証。
+
+import { describe, expect, it } from 'vitest';
+import {
+	ALL_AUTH_LICENSE_STATUSES,
+	AUTH_LICENSE_STATUS,
+	isAuthLicenseActive,
+} from '../../../src/lib/domain/constants/auth-license-status';
+
+describe('AUTH_LICENSE_STATUS 定数', () => {
+	it('値は既存 cookie / API レスポンス互換のため小文字', () => {
+		expect(AUTH_LICENSE_STATUS.ACTIVE).toBe('active');
+		expect(AUTH_LICENSE_STATUS.SUSPENDED).toBe('suspended');
+		expect(AUTH_LICENSE_STATUS.EXPIRED).toBe('expired');
+		expect(AUTH_LICENSE_STATUS.NONE).toBe('none');
+	});
+
+	it('ALL_AUTH_LICENSE_STATUSES は全 status を含む (重複なし)', () => {
+		expect(ALL_AUTH_LICENSE_STATUSES).toHaveLength(4);
+		expect(new Set(ALL_AUTH_LICENSE_STATUSES).size).toBe(ALL_AUTH_LICENSE_STATUSES.length);
+	});
+
+	it('ALL_AUTH_LICENSE_STATUSES は AUTH_LICENSE_STATUS の全 value と一致', () => {
+		const values = Object.values(AUTH_LICENSE_STATUS).sort();
+		const all = [...ALL_AUTH_LICENSE_STATUSES].sort();
+		expect(all).toEqual(values);
+	});
+});
+
+describe('ヘルパ関数', () => {
+	it('isAuthLicenseActive は ACTIVE のみ true', () => {
+		expect(isAuthLicenseActive(AUTH_LICENSE_STATUS.ACTIVE)).toBe(true);
+		expect(isAuthLicenseActive(AUTH_LICENSE_STATUS.SUSPENDED)).toBe(false);
+		expect(isAuthLicenseActive(AUTH_LICENSE_STATUS.EXPIRED)).toBe(false);
+		expect(isAuthLicenseActive(AUTH_LICENSE_STATUS.NONE)).toBe(false);
+	});
+});

--- a/tests/unit/domain/license-key-status-constants.test.ts
+++ b/tests/unit/domain/license-key-status-constants.test.ts
@@ -1,0 +1,61 @@
+// tests/unit/domain/license-key-status-constants.test.ts
+// #972: LICENSE_KEY_STATUS 定数 / ヘルパの網羅性テスト
+
+import { describe, expect, it } from 'vitest';
+import {
+	ALL_LICENSE_KEY_STATUSES,
+	isLicenseKeyActive,
+	isLicenseKeyConsumed,
+	isLicenseKeyRevoked,
+	LICENSE_KEY_STATUS,
+} from '../../../src/lib/domain/constants/license-key-status';
+
+describe('LICENSE_KEY_STATUS 定数', () => {
+	it('値は既存 DB との後方互換性のため kebab-case', () => {
+		expect(LICENSE_KEY_STATUS.ACTIVE).toBe('active');
+		expect(LICENSE_KEY_STATUS.CONSUMED).toBe('consumed');
+		expect(LICENSE_KEY_STATUS.REVOKED).toBe('revoked');
+	});
+
+	it('ALL_LICENSE_KEY_STATUSES は全 status を含む (重複なし)', () => {
+		expect(ALL_LICENSE_KEY_STATUSES).toHaveLength(3);
+		expect(new Set(ALL_LICENSE_KEY_STATUSES).size).toBe(ALL_LICENSE_KEY_STATUSES.length);
+	});
+
+	it('ALL_LICENSE_KEY_STATUSES は LICENSE_KEY_STATUS の全 value と一致', () => {
+		const values = Object.values(LICENSE_KEY_STATUS).sort();
+		const all = [...ALL_LICENSE_KEY_STATUSES].sort();
+		expect(all).toEqual(values);
+	});
+});
+
+describe('ヘルパ関数 (相互排他)', () => {
+	it('ACTIVE のみ isLicenseKeyActive === true', () => {
+		expect(isLicenseKeyActive(LICENSE_KEY_STATUS.ACTIVE)).toBe(true);
+		expect(isLicenseKeyActive(LICENSE_KEY_STATUS.CONSUMED)).toBe(false);
+		expect(isLicenseKeyActive(LICENSE_KEY_STATUS.REVOKED)).toBe(false);
+	});
+
+	it('CONSUMED のみ isLicenseKeyConsumed === true', () => {
+		expect(isLicenseKeyConsumed(LICENSE_KEY_STATUS.CONSUMED)).toBe(true);
+		expect(isLicenseKeyConsumed(LICENSE_KEY_STATUS.ACTIVE)).toBe(false);
+		expect(isLicenseKeyConsumed(LICENSE_KEY_STATUS.REVOKED)).toBe(false);
+	});
+
+	it('REVOKED のみ isLicenseKeyRevoked === true', () => {
+		expect(isLicenseKeyRevoked(LICENSE_KEY_STATUS.REVOKED)).toBe(true);
+		expect(isLicenseKeyRevoked(LICENSE_KEY_STATUS.ACTIVE)).toBe(false);
+		expect(isLicenseKeyRevoked(LICENSE_KEY_STATUS.CONSUMED)).toBe(false);
+	});
+
+	it('各 status はちょうど 1 つのヘルパで true になる (partition)', () => {
+		for (const s of ALL_LICENSE_KEY_STATUSES) {
+			const trueCount = [
+				isLicenseKeyActive(s),
+				isLicenseKeyConsumed(s),
+				isLicenseKeyRevoked(s),
+			].filter(Boolean).length;
+			expect(trueCount).toBe(1);
+		}
+	});
+});

--- a/tests/unit/domain/license-plan-constants.test.ts
+++ b/tests/unit/domain/license-plan-constants.test.ts
@@ -1,0 +1,134 @@
+// tests/unit/domain/license-plan-constants.test.ts
+// #972: LICENSE_PLAN 定数 / 派生集合 / ヘルパの網羅性テスト
+//
+// 目的: 新プラン追加時に必要な派生配列の更新漏れを検出する。
+// LICENSE_PLAN に値を追加したら planDurationDays に case を足さない限り
+// 型エラーになる設計だが、派生配列 (MONTHLY_PLANS 等) は型では検出できないため
+// ここで集合関係を明示的に assert する。
+
+import { describe, expect, it } from 'vitest';
+import {
+	ALL_LICENSE_PLANS,
+	FAMILY_PLANS,
+	isFamilyPlan,
+	isLifetimePlan,
+	isMonthlyPlan,
+	isYearlyPlan,
+	LICENSE_PLAN,
+	type LicensePlan,
+	MONTHLY_PLANS,
+	planDurationDays,
+	STANDARD_PLANS,
+	YEARLY_PLANS,
+} from '../../../src/lib/domain/constants/license-plan';
+
+describe('LICENSE_PLAN 定数', () => {
+	it('値は既存 DB / Stripe との後方互換性のため kebab-case を維持', () => {
+		expect(LICENSE_PLAN.MONTHLY).toBe('monthly');
+		expect(LICENSE_PLAN.YEARLY).toBe('yearly');
+		expect(LICENSE_PLAN.FAMILY_MONTHLY).toBe('family-monthly');
+		expect(LICENSE_PLAN.FAMILY_YEARLY).toBe('family-yearly');
+		expect(LICENSE_PLAN.LIFETIME).toBe('lifetime');
+	});
+
+	it('ALL_LICENSE_PLANS は全プランを含む (重複なし)', () => {
+		expect(ALL_LICENSE_PLANS).toHaveLength(5);
+		expect(new Set(ALL_LICENSE_PLANS).size).toBe(ALL_LICENSE_PLANS.length);
+	});
+
+	it('ALL_LICENSE_PLANS は LICENSE_PLAN の全 value と一致する', () => {
+		const values = Object.values(LICENSE_PLAN).sort();
+		const all = [...ALL_LICENSE_PLANS].sort();
+		expect(all).toEqual(values);
+	});
+});
+
+describe('派生集合', () => {
+	it('MONTHLY_PLANS は monthly + family-monthly', () => {
+		expect(MONTHLY_PLANS).toEqual([LICENSE_PLAN.MONTHLY, LICENSE_PLAN.FAMILY_MONTHLY]);
+	});
+
+	it('YEARLY_PLANS は yearly + family-yearly', () => {
+		expect(YEARLY_PLANS).toEqual([LICENSE_PLAN.YEARLY, LICENSE_PLAN.FAMILY_YEARLY]);
+	});
+
+	it('FAMILY_PLANS は family-monthly + family-yearly', () => {
+		expect(FAMILY_PLANS).toEqual([LICENSE_PLAN.FAMILY_MONTHLY, LICENSE_PLAN.FAMILY_YEARLY]);
+	});
+
+	it('STANDARD_PLANS は monthly + yearly', () => {
+		expect(STANDARD_PLANS).toEqual([LICENSE_PLAN.MONTHLY, LICENSE_PLAN.YEARLY]);
+	});
+
+	it('MONTHLY_PLANS と YEARLY_PLANS は素 (交差なし)', () => {
+		const intersection = MONTHLY_PLANS.filter((p) => YEARLY_PLANS.includes(p));
+		expect(intersection).toEqual([]);
+	});
+
+	it('STANDARD_PLANS と FAMILY_PLANS は素 (交差なし)', () => {
+		const intersection = STANDARD_PLANS.filter((p) => FAMILY_PLANS.includes(p));
+		expect(intersection).toEqual([]);
+	});
+
+	it('全有料プラン (STANDARD + FAMILY) + LIFETIME = ALL_LICENSE_PLANS', () => {
+		const paidAndLifetime = [...STANDARD_PLANS, ...FAMILY_PLANS, LICENSE_PLAN.LIFETIME].sort();
+		const all = [...ALL_LICENSE_PLANS].sort();
+		expect(paidAndLifetime).toEqual(all);
+	});
+});
+
+describe('ヘルパ関数', () => {
+	it('isMonthlyPlan', () => {
+		expect(isMonthlyPlan(LICENSE_PLAN.MONTHLY)).toBe(true);
+		expect(isMonthlyPlan(LICENSE_PLAN.FAMILY_MONTHLY)).toBe(true);
+		expect(isMonthlyPlan(LICENSE_PLAN.YEARLY)).toBe(false);
+		expect(isMonthlyPlan(LICENSE_PLAN.FAMILY_YEARLY)).toBe(false);
+		expect(isMonthlyPlan(LICENSE_PLAN.LIFETIME)).toBe(false);
+	});
+
+	it('isYearlyPlan', () => {
+		expect(isYearlyPlan(LICENSE_PLAN.YEARLY)).toBe(true);
+		expect(isYearlyPlan(LICENSE_PLAN.FAMILY_YEARLY)).toBe(true);
+		expect(isYearlyPlan(LICENSE_PLAN.MONTHLY)).toBe(false);
+	});
+
+	it('isFamilyPlan', () => {
+		expect(isFamilyPlan(LICENSE_PLAN.FAMILY_MONTHLY)).toBe(true);
+		expect(isFamilyPlan(LICENSE_PLAN.FAMILY_YEARLY)).toBe(true);
+		expect(isFamilyPlan(LICENSE_PLAN.MONTHLY)).toBe(false);
+		expect(isFamilyPlan(LICENSE_PLAN.YEARLY)).toBe(false);
+	});
+
+	it('isLifetimePlan', () => {
+		expect(isLifetimePlan(LICENSE_PLAN.LIFETIME)).toBe(true);
+		expect(isLifetimePlan(LICENSE_PLAN.MONTHLY)).toBe(false);
+	});
+});
+
+describe('planDurationDays', () => {
+	it('monthly 系は 30 日', () => {
+		expect(planDurationDays(LICENSE_PLAN.MONTHLY)).toBe(30);
+		expect(planDurationDays(LICENSE_PLAN.FAMILY_MONTHLY)).toBe(30);
+	});
+
+	it('yearly 系は 365 日', () => {
+		expect(planDurationDays(LICENSE_PLAN.YEARLY)).toBe(365);
+		expect(planDurationDays(LICENSE_PLAN.FAMILY_YEARLY)).toBe(365);
+	});
+
+	it('lifetime は期限なし (undefined)', () => {
+		expect(planDurationDays(LICENSE_PLAN.LIFETIME)).toBeUndefined();
+	});
+
+	it('全プランについて例外を投げずに結果を返す (網羅性)', () => {
+		for (const plan of ALL_LICENSE_PLANS) {
+			expect(() => planDurationDays(plan)).not.toThrow();
+		}
+	});
+
+	it('未知のプラン値は例外を投げる (ランタイムガード)', () => {
+		// 型システムを意図的にバイパスして網羅性ガードの動作を確認
+		const unknownPlan = 'unknown-plan' as unknown as LicensePlan;
+		expect(() => planDurationDays(unknownPlan)).toThrow(/unknown plan/);
+	});
+});

--- a/tests/unit/domain/subscription-status-constants.test.ts
+++ b/tests/unit/domain/subscription-status-constants.test.ts
@@ -1,0 +1,68 @@
+// tests/unit/domain/subscription-status-constants.test.ts
+// #972: SUBSCRIPTION_STATUS 定数 / 派生集合 / ヘルパの網羅性テスト
+
+import { describe, expect, it } from 'vitest';
+import {
+	ALL_SUBSCRIPTION_STATUSES,
+	ENTITLED_SUBSCRIPTION_STATUSES,
+	isEntitledStatus,
+	isSubscriptionActive,
+	isSubscriptionSuspended,
+	isSubscriptionTerminated,
+	SUBSCRIPTION_STATUS,
+} from '../../../src/lib/domain/constants/subscription-status';
+
+describe('SUBSCRIPTION_STATUS 定数', () => {
+	it('値は snake_case (既存 DB 互換)', () => {
+		expect(SUBSCRIPTION_STATUS.ACTIVE).toBe('active');
+		expect(SUBSCRIPTION_STATUS.GRACE_PERIOD).toBe('grace_period');
+		expect(SUBSCRIPTION_STATUS.SUSPENDED).toBe('suspended');
+		expect(SUBSCRIPTION_STATUS.TERMINATED).toBe('terminated');
+	});
+
+	it('ALL_SUBSCRIPTION_STATUSES は全 status を含む', () => {
+		expect(ALL_SUBSCRIPTION_STATUSES).toHaveLength(4);
+		expect(new Set(ALL_SUBSCRIPTION_STATUSES).size).toBe(ALL_SUBSCRIPTION_STATUSES.length);
+	});
+
+	it('ALL_SUBSCRIPTION_STATUSES は SUBSCRIPTION_STATUS の全 value と一致', () => {
+		const values = Object.values(SUBSCRIPTION_STATUS).sort();
+		const all = [...ALL_SUBSCRIPTION_STATUSES].sort();
+		expect(all).toEqual(values);
+	});
+});
+
+describe('ENTITLED_SUBSCRIPTION_STATUSES (機能利用可能集合)', () => {
+	it('active + grace_period のみ entitled', () => {
+		expect(ENTITLED_SUBSCRIPTION_STATUSES).toEqual([
+			SUBSCRIPTION_STATUS.ACTIVE,
+			SUBSCRIPTION_STATUS.GRACE_PERIOD,
+		]);
+	});
+
+	it('isEntitledStatus は entitled 集合と一致', () => {
+		expect(isEntitledStatus(SUBSCRIPTION_STATUS.ACTIVE)).toBe(true);
+		expect(isEntitledStatus(SUBSCRIPTION_STATUS.GRACE_PERIOD)).toBe(true);
+		expect(isEntitledStatus(SUBSCRIPTION_STATUS.SUSPENDED)).toBe(false);
+		expect(isEntitledStatus(SUBSCRIPTION_STATUS.TERMINATED)).toBe(false);
+	});
+});
+
+describe('ヘルパ関数 (単一 status)', () => {
+	it('isSubscriptionActive', () => {
+		expect(isSubscriptionActive(SUBSCRIPTION_STATUS.ACTIVE)).toBe(true);
+		expect(isSubscriptionActive(SUBSCRIPTION_STATUS.GRACE_PERIOD)).toBe(false);
+		expect(isSubscriptionActive(SUBSCRIPTION_STATUS.SUSPENDED)).toBe(false);
+		expect(isSubscriptionActive(SUBSCRIPTION_STATUS.TERMINATED)).toBe(false);
+	});
+
+	it('isSubscriptionSuspended', () => {
+		expect(isSubscriptionSuspended(SUBSCRIPTION_STATUS.SUSPENDED)).toBe(true);
+		expect(isSubscriptionSuspended(SUBSCRIPTION_STATUS.ACTIVE)).toBe(false);
+	});
+
+	it('isSubscriptionTerminated', () => {
+		expect(isSubscriptionTerminated(SUBSCRIPTION_STATUS.TERMINATED)).toBe(true);
+		expect(isSubscriptionTerminated(SUBSCRIPTION_STATUS.ACTIVE)).toBe(false);
+	});
+});


### PR DESCRIPTION
closes #972

## Summary

プラン / ライセンスキー状態 / テナント購読状態の値リテラルを `src/lib/domain/constants/` の SSOT に集約し、全箇所を定数参照に置換。

## 変更内容

### 1. 定数モジュールの新設（SSOT）

| ファイル | 責務 | 主な export |
|---------|------|-----------|
| `src/lib/domain/constants/license-plan.ts` | LicenseRecord.plan 値 | `LICENSE_PLAN`, `MONTHLY_PLANS`, `YEARLY_PLANS`, `FAMILY_PLANS`, `STANDARD_PLANS`, `planDurationDays()` |
| `src/lib/domain/constants/license-key-status.ts` | LicenseRecord.status 値 | `LICENSE_KEY_STATUS`, ヘルパ (isLicenseKeyActive 等) |
| `src/lib/domain/constants/subscription-status.ts` | Tenant.status 値 | `SUBSCRIPTION_STATUS`, `ENTITLED_SUBSCRIPTION_STATUSES`, `isEntitledStatus()` 等 |
| `src/lib/domain/constants/auth-license-status.ts` | AuthContext.licenseStatus 値 | `AUTH_LICENSE_STATUS`, `isAuthLicenseActive()` |

### 2. 値リテラル比較の全置換

Issue #972 で列挙された 11 ファイルを含む **52 ファイル** でリテラル直書きを定数参照に置換。

主要変更点:
- `license-key-service.ts:365` の 30/365 日計算を `planDurationDays()` ヘルパに統一（新プラン追加時に case 追加漏れが型エラーで検出される）
- `stripe/config.ts` の `PlanId` を `Exclude<LicensePlan, typeof LICENSE_PLAN.LIFETIME>` に統一
- `AuthContext.licenseStatus` / `Tenant.status` の型を TS union string から定数由来の型へ置換
- `retention-cleanup-service.ts` の `deriveLicenseStatus` 戻り値を `AuthLicenseStatus` に
- Cognito / dev-cognito / local の 3 プロバイダ全てで定数参照に統一

### 3. 単体テスト追加

`tests/unit/domain/` に 4 ファイル・38 テストケース追加:
- 定数値の後方互換性（kebab-case / snake_case / 小文字）の検証
- `ALL_*` 配列と定数 object の網羅性検証
- 派生集合の相互排他性（MONTHLY ∩ YEARLY = ∅ など）
- ヘルパ関数の partition（各 status はちょうど 1 つのヘルパで true）
- `planDurationDays` の例外パス（未知プランはランタイムガード発動）

### 4. 静的チェックスクリプト

`scripts/check-no-plan-literals.mjs` を新設し、CI で自動実行:
- 検出対象: `'family-monthly'` / `'family-yearly'` / `'grace_period'`（ライセンス文脈固有の値のみ）
- `'monthly'` / `'yearly'` / `'active'` / `'terminated'` 等の汎用語は他ドメイン（チャレンジ周期・sitemap changefreq・DecayIntensity 等）で正当に使われるため対象外
- 除外: `src/lib/domain/constants/` 本体、`stripe-service.ts`（Stripe SDK の生値を扱う）、`db/*/schema.ts`、テスト

### 5. ドキュメント更新

- `CLAUDE.md` 「Things Not To Do」に #972 ルールを追記
- `docs/design/08-データベース設計書.md` §ライセンスキー関連エンティティに SSOT 表を追記 (version 5.0)
- `.github/workflows/ci.yml` の lint-and-test ジョブに check-no-plan-literals を追加

## Acceptance Criteria チェック

- [x] 4 定数モジュールを新規作成し現行の全値を const object として export
- [x] 11 ファイル + 付随箇所で文字列リテラル比較を定数参照に置換
- [x] 派生集合（`MONTHLY_PLANS` / `YEARLY_PLANS` / `FAMILY_PLANS`）を用意し、30/365 日計算を派生集合ベースに書き換え
- [x] 既存のユニットテストがすべて green（3182 件通過）
- [x] 新規 domain/constants の単体テストを追加（4 ファイル・38 ケース）
- [x] 設計書 08 に SSOT 記述を追加（ADR-0003 準拠）
- [x] 静的検証スクリプト `scripts/check-no-plan-literals.mjs` を追加・CI 組み込み
- [~] zod スキーマの enum 置換 — リポジトリに該当する zod enum は存在せず（grep で 0 件）。TypeScript union 型経由で管理されている

## Test plan

- [x] `npx biome check .` — 既存の 2 warning のみ（checklist-repo.ts の未使用引数、本件と無関係）
- [x] `npx svelte-check` — 0 errors, 40 pre-existing warnings
- [x] `npx vitest run` — 3182 tests passed
- [x] `node scripts/check-no-plan-literals.mjs` — OK (0 件)
- [ ] `npx playwright test` — CI で実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)