### PR TITLE
feat: #820 PR-A Identity に Cognito groups を surface + ops-authz 土台

### DIFF
--- a/src/lib/server/auth/ops-authz.ts
+++ b/src/lib/server/auth/ops-authz.ts
@@ -1,0 +1,33 @@
+// src/lib/server/auth/ops-authz.ts
+// #820: /ops 認可のための Cognito group 定義と判定ヘルパ。
+//
+// 現状（PR-A）: 定数と判定ヘルパを追加するのみ。実際の /ops 認可切替は PR-C で行う。
+// 将来の階層化（`ops-cs` / `ops-eng` など）に備え、名前は enum 化して 1 箇所で管理する。
+
+import type { Identity } from './types';
+
+/**
+ * 運営ダッシュボード `/ops` 全体を操作できる group 名。
+ * Cognito User Pool の group 名と一致させる（CDK 側で同じ文字列で作成する）。
+ */
+export const OPS_GROUP = 'ops';
+
+/**
+ * すべての ops 系 group を列挙。
+ * 将来 `ops-cs` / `ops-eng` のように分割しても、1 箇所の変更で判定が追従する。
+ */
+export const OPS_GROUPS = [OPS_GROUP] as const;
+
+export type OpsGroup = (typeof OPS_GROUPS)[number];
+
+/**
+ * identity が ops group に所属しているか判定する。
+ * - local identity は常に false（`/ops` は Cognito 配信のみ想定）
+ * - groups が未提供（旧トークン等）の場合も false
+ */
+export function isOpsMember(identity: Identity | null): boolean {
+	if (!identity || identity.type !== 'cognito') return false;
+	const groups = identity.groups;
+	if (!groups || groups.length === 0) return false;
+	return OPS_GROUPS.some((g) => groups.includes(g));
+}

--- a/src/lib/server/auth/providers/cognito-dev-jwt.ts
+++ b/src/lib/server/auth/providers/cognito-dev-jwt.ts
@@ -21,17 +21,23 @@ export interface DevUserProfile {
 	userId: string;
 	email: string;
 	username?: string;
+	/** #820: ダミー JWT の `cognito:groups` claim に載せる group 一覧 */
+	groups?: string[];
 }
 
 /** ダミー Cognito ID Token を生成 */
 export async function signDevIdentityToken(user: DevUserProfile): Promise<string> {
-	return new SignJWT({
+	const payload: Record<string, unknown> = {
 		sub: user.userId,
 		email: user.email,
 		email_verified: true,
 		'cognito:username': user.username ?? user.email,
 		token_use: 'id',
-	})
+	};
+	if (user.groups && user.groups.length > 0) {
+		payload['cognito:groups'] = user.groups;
+	}
+	return new SignJWT(payload)
 		.setProtectedHeader({ alg: 'HS256' })
 		.setIssuer(DEV_ISSUER)
 		.setAudience(DEV_AUDIENCE)
@@ -50,11 +56,17 @@ export async function verifyDevIdentityToken(token: string): Promise<CognitoClai
 
 		if (payload.token_use !== 'id') return null;
 
+		const rawGroups = payload['cognito:groups'];
+		const groups = Array.isArray(rawGroups)
+			? rawGroups.filter((g): g is string => typeof g === 'string')
+			: undefined;
+
 		return {
 			sub: payload.sub as string,
 			email: payload.email as string,
 			email_verified: payload.email_verified as boolean | undefined,
 			'cognito:username': payload['cognito:username'] as string | undefined,
+			'cognito:groups': groups,
 			iss: payload.iss as string,
 			aud: payload.aud as string,
 		};

--- a/src/lib/server/auth/providers/cognito-dev.ts
+++ b/src/lib/server/auth/providers/cognito-dev.ts
@@ -30,6 +30,8 @@ export interface DevUser {
 	licenseStatus?: AuthContext['licenseStatus'];
 	/** Stripe price id 相当（例: 'standard_monthly', 'family_monthly'） */
 	plan?: string;
+	/** #820: Cognito group 疑似所属。未指定は空扱い */
+	groups?: string[];
 }
 
 export const DEV_USERS: DevUser[] = [
@@ -119,6 +121,7 @@ export class DevCognitoAuthProvider implements AuthProvider {
 					type: 'cognito',
 					userId: claims.sub,
 					email: claims.email,
+					groups: claims['cognito:groups'],
 				};
 			}
 		} catch (e) {

--- a/src/lib/server/auth/providers/cognito-jwt.ts
+++ b/src/lib/server/auth/providers/cognito-jwt.ts
@@ -9,6 +9,8 @@ export interface CognitoClaims {
 	email: string;
 	email_verified?: boolean;
 	'cognito:username'?: string;
+	/** #820: ユーザーが所属する Cognito group の一覧（例: ['ops']） */
+	'cognito:groups'?: string[];
 	iss: string;
 	aud: string;
 }
@@ -64,11 +66,17 @@ export async function verifyIdentityToken(token: string): Promise<CognitoClaims 
 			return null;
 		}
 
+		const rawGroups = payload['cognito:groups'];
+		const groups = Array.isArray(rawGroups)
+			? rawGroups.filter((g): g is string => typeof g === 'string')
+			: undefined;
+
 		return {
 			sub: payload.sub as string,
 			email: payload.email as string,
 			email_verified: payload.email_verified as boolean | undefined,
 			'cognito:username': payload['cognito:username'] as string | undefined,
+			'cognito:groups': groups,
 			iss: payload.iss as string,
 			aud: payload.aud as string,
 		};

--- a/src/lib/server/auth/providers/cognito.ts
+++ b/src/lib/server/auth/providers/cognito.ts
@@ -31,6 +31,7 @@ export class CognitoAuthProvider implements AuthProvider {
 					type: 'cognito',
 					userId: claims.sub,
 					email: claims.email,
+					groups: claims['cognito:groups'],
 				};
 			}
 		} catch (e) {

--- a/src/lib/server/auth/types.ts
+++ b/src/lib/server/auth/types.ts
@@ -12,8 +12,14 @@ export type Role = 'owner' | 'parent' | 'child';
 /** Layer 1: Identity（誰であるか）
  * - local: LAN内認証なし（NUC/Docker）
  * - cognito: Cognito Email/Password + MFA（AWS SaaS）
+ *
+ * #820: Cognito `cognito:groups` claim を surfaces する `groups` フィールドを追加。
+ * /ops のような group ベース認可は `groups.includes('ops')` で判定する。
+ * PR-A 時点ではフィールドを追加するのみで、既存の認可ロジックは未変更。
  */
-export type Identity = { type: 'local' } | { type: 'cognito'; userId: string; email: string };
+export type Identity =
+	| { type: 'local' }
+	| { type: 'cognito'; userId: string; email: string; groups?: string[] };
 
 /** Layer 2: Context（何として操作しているか） */
 export interface AuthContext {

--- a/src/routes/auth/login/+page.server.ts
+++ b/src/routes/auth/login/+page.server.ts
@@ -176,6 +176,7 @@ async function handleDevLogin(
 	const idToken = await signDevIdentityToken({
 		userId: user.userId,
 		email: user.email,
+		groups: user.groups,
 	});
 
 	cookies.set(IDENTITY_COOKIE_NAME, idToken, {

--- a/tests/unit/services/cognito-dev-jwt.test.ts
+++ b/tests/unit/services/cognito-dev-jwt.test.ts
@@ -1,0 +1,54 @@
+// tests/unit/services/cognito-dev-jwt.test.ts
+// #820: 開発用ダミー JWT の cognito:groups claim ラウンドトリップ
+//
+// @vitest-environment node
+// jsdom だと jose の Uint8Array instanceof チェックが realm 越しで失敗するため Node 環境で実行
+
+import { describe, expect, it } from 'vitest';
+import {
+	signDevIdentityToken,
+	verifyDevIdentityToken,
+} from '$lib/server/auth/providers/cognito-dev-jwt';
+
+describe('#820 dev JWT with cognito:groups', () => {
+	it('groups なしで sign → verify すると cognito:groups は undefined', async () => {
+		const token = await signDevIdentityToken({
+			userId: 'u-1',
+			email: 'a@b.com',
+		});
+		const claims = await verifyDevIdentityToken(token);
+		expect(claims).not.toBeNull();
+		expect(claims?.sub).toBe('u-1');
+		expect(claims?.['cognito:groups']).toBeUndefined();
+	});
+
+	it('groups=["ops"] で sign → verify すると cognito:groups に ["ops"] が復元される', async () => {
+		const token = await signDevIdentityToken({
+			userId: 'u-ops-1',
+			email: 'ops@example.com',
+			groups: ['ops'],
+		});
+		const claims = await verifyDevIdentityToken(token);
+		expect(claims?.['cognito:groups']).toEqual(['ops']);
+	});
+
+	it('groups=[] で sign すると cognito:groups は payload に含まれず undefined になる', async () => {
+		const token = await signDevIdentityToken({
+			userId: 'u-empty-1',
+			email: 'empty@example.com',
+			groups: [],
+		});
+		const claims = await verifyDevIdentityToken(token);
+		expect(claims?.['cognito:groups']).toBeUndefined();
+	});
+
+	it('groups=["ops", "admin"] で sign → verify すると両方の group が復元される', async () => {
+		const token = await signDevIdentityToken({
+			userId: 'u-multi-1',
+			email: 'multi@example.com',
+			groups: ['ops', 'admin'],
+		});
+		const claims = await verifyDevIdentityToken(token);
+		expect(claims?.['cognito:groups']).toEqual(['ops', 'admin']);
+	});
+});

--- a/tests/unit/services/cognito-jwt.test.ts
+++ b/tests/unit/services/cognito-jwt.test.ts
@@ -139,6 +139,74 @@ describe('verifyIdentityToken', () => {
 		expect(claims).toBeNull();
 	});
 
+	it('#820: cognito:groups claim を配列として抽出する', async () => {
+		mockJwtVerify.mockResolvedValue({
+			payload: {
+				sub: 'u-ops-1',
+				email: 'ops@example.com',
+				token_use: 'id',
+				'cognito:groups': ['ops', 'admin'],
+				iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TestPool',
+				aud: 'test-client-id',
+			},
+			protectedHeader: { alg: 'RS256' },
+			// biome-ignore lint/suspicious/noExplicitAny: jose mock type
+		} as any);
+
+		vi.resetModules();
+		const { verifyIdentityToken } = await import(
+			'../../../src/lib/server/auth/providers/cognito-jwt'
+		);
+		const claims = await verifyIdentityToken('ops-token');
+
+		expect(claims?.['cognito:groups']).toEqual(['ops', 'admin']);
+	});
+
+	it('#820: cognito:groups が未定義の場合は undefined を返す', async () => {
+		mockJwtVerify.mockResolvedValue({
+			payload: {
+				sub: 'u-plain-1',
+				email: 'plain@example.com',
+				token_use: 'id',
+				iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TestPool',
+				aud: 'test-client-id',
+			},
+			protectedHeader: { alg: 'RS256' },
+			// biome-ignore lint/suspicious/noExplicitAny: jose mock type
+		} as any);
+
+		vi.resetModules();
+		const { verifyIdentityToken } = await import(
+			'../../../src/lib/server/auth/providers/cognito-jwt'
+		);
+		const claims = await verifyIdentityToken('plain-token');
+
+		expect(claims?.['cognito:groups']).toBeUndefined();
+	});
+
+	it('#820: cognito:groups に非文字列が混在していたら除外する', async () => {
+		mockJwtVerify.mockResolvedValue({
+			payload: {
+				sub: 'u-dirty-1',
+				email: 'dirty@example.com',
+				token_use: 'id',
+				'cognito:groups': ['ops', 42, null, 'admin'],
+				iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TestPool',
+				aud: 'test-client-id',
+			},
+			protectedHeader: { alg: 'RS256' },
+			// biome-ignore lint/suspicious/noExplicitAny: jose mock type
+		} as any);
+
+		vi.resetModules();
+		const { verifyIdentityToken } = await import(
+			'../../../src/lib/server/auth/providers/cognito-jwt'
+		);
+		const claims = await verifyIdentityToken('dirty-token');
+
+		expect(claims?.['cognito:groups']).toEqual(['ops', 'admin']);
+	});
+
 	it('email_verified が false の場合もクレームを返す（ポリシーは呼び出し側で判断）', async () => {
 		mockJwtVerify.mockResolvedValue({
 			payload: {

--- a/tests/unit/services/ops-authz.test.ts
+++ b/tests/unit/services/ops-authz.test.ts
@@ -1,0 +1,81 @@
+// tests/unit/services/ops-authz.test.ts
+// #820: /ops 認可ヘルパのユニットテスト
+
+import { describe, expect, it } from 'vitest';
+import { isOpsMember, OPS_GROUP, OPS_GROUPS } from '$lib/server/auth/ops-authz';
+
+describe('#820 ops-authz', () => {
+	describe('OPS_GROUP 定数', () => {
+		it('Cognito group 名と一致する "ops"', () => {
+			expect(OPS_GROUP).toBe('ops');
+		});
+
+		it('OPS_GROUPS に OPS_GROUP が含まれる', () => {
+			expect(OPS_GROUPS).toContain(OPS_GROUP);
+		});
+	});
+
+	describe('isOpsMember', () => {
+		it('identity=null は false', () => {
+			expect(isOpsMember(null)).toBe(false);
+		});
+
+		it('local identity は false', () => {
+			expect(isOpsMember({ type: 'local' })).toBe(false);
+		});
+
+		it('cognito identity で groups 未提供は false', () => {
+			expect(
+				isOpsMember({
+					type: 'cognito',
+					userId: 'u-1',
+					email: 'a@b.com',
+				}),
+			).toBe(false);
+		});
+
+		it('cognito identity で groups=[] は false', () => {
+			expect(
+				isOpsMember({
+					type: 'cognito',
+					userId: 'u-1',
+					email: 'a@b.com',
+					groups: [],
+				}),
+			).toBe(false);
+		});
+
+		it('cognito identity で groups=["ops"] は true', () => {
+			expect(
+				isOpsMember({
+					type: 'cognito',
+					userId: 'u-ops-1',
+					email: 'ops@example.com',
+					groups: ['ops'],
+				}),
+			).toBe(true);
+		});
+
+		it('cognito identity で groups=["ops", "other"] は true', () => {
+			expect(
+				isOpsMember({
+					type: 'cognito',
+					userId: 'u-ops-2',
+					email: 'ops@example.com',
+					groups: ['ops', 'other'],
+				}),
+			).toBe(true);
+		});
+
+		it('cognito identity で ops 以外の group のみは false', () => {
+			expect(
+				isOpsMember({
+					type: 'cognito',
+					userId: 'u-1',
+					email: 'a@b.com',
+					groups: ['random', 'admin'],
+				}),
+			).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

\`/ops\` 認可を \`OPS_SECRET_KEY\` 共有シークレットから Cognito group ベースへ刷新する (#820) ための **非破壊的な土台 PR**。本 PR では動作変更はなく、型と判定ヘルパを追加するのみで、既存ユーザー・既存 /ops の挙動に影響しない。

Refs #820（段階 PR の 1/4）

## 段階 PR 計画

| PR | スコープ | 状態 |
|---|---|---|
| **PR-A（本 PR）** | Identity.groups 型拡張 + cognito:groups claim 抽出 + OPS_GROUP/isOpsMember 土台 | 🟢 本 PR |
| PR-B | ops_audit_log テーブル + OpsAuditLogService | ⏳ 後続 |
| PR-C | CDK ops group 追加 + /ops auth を isOpsMember() ベースに切替 + E2E | ⏳ 後続 |
| PR-D | OPS_SECRET_KEY 廃止 + deploy.yml / compute-stack 削除 + 設計書 (07, 24) / ADR 更新 | ⏳ 後続 |

## 変更内容

### 型
- \`Identity\`（type='cognito'）に \`groups?: string[]\` フィールド追加
- \`CognitoClaims\` に \`'cognito:groups'?: string[]\` 追加

### JWT 検証
- \`verifyIdentityToken\` / \`verifyDevIdentityToken\` で \`cognito:groups\` claim を抽出
- 非文字列要素が混在していた場合は除外（防御的フィルタ）
- claim 未提供時は \`undefined\` を返す（空配列ではない）

### 開発用 JWT
- \`signDevIdentityToken\` に \`groups?: string[]\` を受け取れる拡張
- 空配列・未指定時は payload に含めない（本番 Cognito の挙動に合わせる）
- \`DevUser\` に \`groups?: string[]\` 追加、dev login で JWT に伝播

### 新規ファイル
- \`src/lib/server/auth/ops-authz.ts\`
  - \`OPS_GROUP = 'ops'\` 定数（Cognito group 名と 1:1 対応）
  - \`OPS_GROUPS\` 配列（将来 \`ops-cs\` / \`ops-eng\` 分割時の 1 箇所変更ポイント）
  - \`isOpsMember(identity)\`: null / local / groups 未提供 / 空配列 いずれも false、ops を含めば true

## テスト

- \`tests/unit/services/cognito-jwt.test.ts\`: +3 テスト
  - cognito:groups claim 抽出、未定義時 undefined、非文字列混在時の除外
- \`tests/unit/services/cognito-dev-jwt.test.ts\`: +4 テスト（新規ファイル）
  - sign → verify ラウンドトリップ、空配列時の除外、複数 group
  - \`@vitest-environment node\` で jose の Uint8Array realm 問題を回避
- \`tests/unit/services/ops-authz.test.ts\`: +8 テスト（新規ファイル）
  - null / local / groups 未提供 / 空配列 / ops 単独 / ops + other / ops 以外のみ

全 69 テスト green（既存 54 + 新規 15）。

## 非破壊性の確認

- \`Identity.groups\` は optional → 既存コンシューマ（15 ファイル）は全て \`.type\` / \`.userId\` / \`.email\` のみ参照しており影響なし
- \`signDevIdentityToken\` の \`groups\` も optional → 既存呼び出し元（login +page.server.ts）は変更不要だが、透過的に dev user の groups を伝播するよう更新
- \`/ops/+layout.server.ts\` は未変更 → 現行の OPS_SECRET_KEY 認証はそのまま動作

## Test plan

- [x] \`npx vitest run tests/unit/services/cognito-*.test.ts tests/unit/services/ops-authz.test.ts\` — 69 passed
- [x] \`npx biome check\` — no errors
- [x] \`npx svelte-check\` — 0 errors (warnings pre-existing)
- [ ] CI: 既存 E2E が全て通過（破壊的変更なしの確認）
- [ ] コードレビュー: 型拡張の妥当性 / ops-authz helper の命名

## 関連

- #820（親 issue）
- \`docs/security/security-code-review-2026-03.md\`（/ops 認可の既知課題、PR-C/D で解消予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)