### PR TITLE
feat: #820 PR-B ops_audit_log テーブル + 監査ログサービス

### DIFF
--- a/src/lib/server/db/create-tables.ts
+++ b/src/lib/server/db/create-tables.ts
@@ -703,4 +703,22 @@ export const SQL_CREATE_TABLES = `
 		ON enemy_collection(child_id, enemy_id);
 	CREATE INDEX IF NOT EXISTS idx_enemy_collection_child
 		ON enemy_collection(child_id);
+
+	CREATE TABLE IF NOT EXISTS ops_audit_log (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		actor_id TEXT NOT NULL,
+		actor_email TEXT NOT NULL,
+		ip TEXT,
+		ua TEXT,
+		action TEXT NOT NULL,
+		target TEXT,
+		metadata TEXT,
+		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	CREATE INDEX IF NOT EXISTS idx_ops_audit_log_actor
+		ON ops_audit_log(actor_id);
+	CREATE INDEX IF NOT EXISTS idx_ops_audit_log_created
+		ON ops_audit_log(created_at);
+	CREATE INDEX IF NOT EXISTS idx_ops_audit_log_action
+		ON ops_audit_log(action);
 `;

--- a/src/lib/server/db/dynamodb/ops-audit-log-repo.ts
+++ b/src/lib/server/db/dynamodb/ops-audit-log-repo.ts
@@ -1,0 +1,24 @@
+// src/lib/server/db/dynamodb/ops-audit-log-repo.ts
+// DynamoDB stub for IOpsAuditLogRepo (#820)
+// 実装は PR-C で CDK に DynamoDB テーブルを追加するタイミングで差し替える。
+// 現時点では no-op でインタフェース契約のみ満たす。
+
+import type {
+	InsertOpsAuditLogInput,
+	OpsAuditLogRow,
+} from '../interfaces/ops-audit-log-repo.interface';
+
+export async function insert(_input: InsertOpsAuditLogInput): Promise<void> {
+	// TODO(#820 PR-C): DynamoDB 実装。
+	// PK = 'OPS_AUDIT' / SK = `${createdAt}#${actorId}` を予定。
+}
+
+export async function findRecent(_limit: number): Promise<OpsAuditLogRow[]> {
+	// TODO(#820 PR-C): DynamoDB 実装
+	return [];
+}
+
+export async function findByActor(_actorId: string, _limit: number): Promise<OpsAuditLogRow[]> {
+	// TODO(#820 PR-C): DynamoDB 実装
+	return [];
+}

--- a/src/lib/server/db/factory.ts
+++ b/src/lib/server/db/factory.ts
@@ -17,6 +17,7 @@ import * as dynamoImageRepo from './dynamodb/image-repo';
 import * as dynamoInquiryRepo from './dynamodb/inquiry-repo';
 import * as dynamoLoginBonusRepo from './dynamodb/login-bonus-repo';
 import * as dynamoMessageRepo from './dynamodb/message-repo';
+import * as dynamoOpsAuditLogRepo from './dynamodb/ops-audit-log-repo';
 import * as dynamoPointRepo from './dynamodb/point-repo';
 import * as dynamoPushSubscriptionRepo from './dynamodb/push-subscription-repo';
 import * as dynamoReportDailySummaryRepo from './dynamodb/report-daily-summary-repo';
@@ -48,6 +49,7 @@ import type { IImageRepo } from './interfaces/image-repo.interface';
 import type { IInquiryRepo } from './interfaces/inquiry-repo.interface';
 import type { ILoginBonusRepo } from './interfaces/login-bonus-repo.interface';
 import type { IMessageRepo } from './interfaces/message-repo.interface';
+import type { IOpsAuditLogRepo } from './interfaces/ops-audit-log-repo.interface';
 import type { IPointRepo } from './interfaces/point-repo.interface';
 import type { IPushSubscriptionRepo } from './interfaces/push-subscription-repo.interface';
 import type { IReportDailySummaryRepo } from './interfaces/report-daily-summary-repo.interface';
@@ -79,6 +81,7 @@ import * as sqliteImageRepo from './sqlite/image-repo';
 import * as sqliteInquiryRepo from './sqlite/inquiry-repo';
 import * as sqliteLoginBonusRepo from './sqlite/login-bonus-repo';
 import * as sqliteMessageRepo from './sqlite/message-repo';
+import * as sqliteOpsAuditLogRepo from './sqlite/ops-audit-log-repo';
 import * as sqlitePointRepo from './sqlite/point-repo';
 import * as sqlitePushSubscriptionRepo from './sqlite/push-subscription-repo';
 import * as sqliteReportDailySummaryRepo from './sqlite/report-daily-summary-repo';
@@ -112,6 +115,7 @@ export interface Repositories {
 	inquiry: IInquiryRepo;
 	loginBonus: ILoginBonusRepo;
 	message: IMessageRepo;
+	opsAuditLog: IOpsAuditLogRepo;
 	point: IPointRepo;
 	pushSubscription: IPushSubscriptionRepo;
 	reportDailySummary: IReportDailySummaryRepo;
@@ -153,6 +157,7 @@ export function getRepos(): Repositories {
 			inquiry: dynamoInquiryRepo,
 			loginBonus: dynamoLoginBonusRepo,
 			message: dynamoMessageRepo,
+			opsAuditLog: dynamoOpsAuditLogRepo,
 			point: dynamoPointRepo,
 			pushSubscription: dynamoPushSubscriptionRepo,
 			reportDailySummary: dynamoReportDailySummaryRepo,
@@ -190,6 +195,7 @@ export function getRepos(): Repositories {
 		inquiry: sqliteInquiryRepo,
 		loginBonus: sqliteLoginBonusRepo,
 		message: sqliteMessageRepo,
+		opsAuditLog: sqliteOpsAuditLogRepo,
 		point: sqlitePointRepo,
 		pushSubscription: sqlitePushSubscriptionRepo,
 		reportDailySummary: sqliteReportDailySummaryRepo,

--- a/src/lib/server/db/interfaces/ops-audit-log-repo.interface.ts
+++ b/src/lib/server/db/interfaces/ops-audit-log-repo.interface.ts
@@ -1,0 +1,32 @@
+// src/lib/server/db/interfaces/ops-audit-log-repo.interface.ts
+// #820: /ops 運営操作の監査ログ
+
+export interface OpsAuditLogRow {
+	id: number;
+	actorId: string;
+	actorEmail: string;
+	ip: string | null;
+	ua: string | null;
+	action: string;
+	target: string | null;
+	/** JSON 文字列。呼び出し側でパース */
+	metadata: string | null;
+	createdAt: string;
+}
+
+export interface InsertOpsAuditLogInput {
+	actorId: string;
+	actorEmail: string;
+	ip?: string | null;
+	ua?: string | null;
+	action: string;
+	target?: string | null;
+	/** 任意の構造化メタ。repo 層で JSON 文字列化する */
+	metadata?: Record<string, unknown> | null;
+}
+
+export interface IOpsAuditLogRepo {
+	insert(input: InsertOpsAuditLogInput): Promise<void>;
+	findRecent(limit: number): Promise<OpsAuditLogRow[]>;
+	findByActor(actorId: string, limit: number): Promise<OpsAuditLogRow[]>;
+}

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1008,3 +1008,36 @@ export const enemyCollection = sqliteTable(
 		index('idx_enemy_collection_child').on(table.childId),
 	],
 );
+
+// ============================================================
+// ops_audit_log - /ops 運営ダッシュボード操作監査 (#820)
+// ============================================================
+//
+// `/ops` 配下の mutation アクション（ライセンス発行・テナント停止・データ削除等）を
+// 誰がいつ何にどの IP から行ったかを追跡するため、tenant 非依存の監査ログ。
+// PR-B: テーブル定義 + 書き込みサービス
+// PR-C: /ops の実 mutation endpoint から呼び出し
+export const opsAuditLog = sqliteTable(
+	'ops_audit_log',
+	{
+		id: integer('id').primaryKey({ autoIncrement: true }),
+		/** Cognito sub (= identity.userId) */
+		actorId: text('actor_id').notNull(),
+		/** 事後追跡用に email も非正規化して保持 */
+		actorEmail: text('actor_email').notNull(),
+		ip: text('ip'),
+		ua: text('ua'),
+		/** ドット区切りの action 名。例: 'license.issue', 'tenant.suspend' */
+		action: text('action').notNull(),
+		/** 操作対象の識別子（例: 'LICENSE#GQ-XXXX-...', 'TENANT#t-abc'）。nullable */
+		target: text('target'),
+		/** 追加メタ情報（JSON 文字列）。nullable */
+		metadata: text('metadata'),
+		createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
+	},
+	(table) => [
+		index('idx_ops_audit_log_actor').on(table.actorId),
+		index('idx_ops_audit_log_created').on(table.createdAt),
+		index('idx_ops_audit_log_action').on(table.action),
+	],
+);

--- a/src/lib/server/db/sqlite/ops-audit-log-repo.ts
+++ b/src/lib/server/db/sqlite/ops-audit-log-repo.ts
@@ -1,0 +1,54 @@
+// src/lib/server/db/sqlite/ops-audit-log-repo.ts
+// SQLite implementation of IOpsAuditLogRepo (#820)
+
+import { desc, eq } from 'drizzle-orm';
+import { db } from '../client';
+import type {
+	InsertOpsAuditLogInput,
+	OpsAuditLogRow,
+} from '../interfaces/ops-audit-log-repo.interface';
+import { opsAuditLog } from '../schema';
+
+function rowFromRecord(r: typeof opsAuditLog.$inferSelect): OpsAuditLogRow {
+	return {
+		id: r.id,
+		actorId: r.actorId,
+		actorEmail: r.actorEmail,
+		ip: r.ip,
+		ua: r.ua,
+		action: r.action,
+		target: r.target,
+		metadata: r.metadata,
+		createdAt: r.createdAt,
+	};
+}
+
+export async function insert(input: InsertOpsAuditLogInput): Promise<void> {
+	await db.insert(opsAuditLog).values({
+		actorId: input.actorId,
+		actorEmail: input.actorEmail,
+		ip: input.ip ?? null,
+		ua: input.ua ?? null,
+		action: input.action,
+		target: input.target ?? null,
+		metadata:
+			input.metadata === undefined || input.metadata === null
+				? null
+				: JSON.stringify(input.metadata),
+	});
+}
+
+export async function findRecent(limit: number): Promise<OpsAuditLogRow[]> {
+	const rows = await db.select().from(opsAuditLog).orderBy(desc(opsAuditLog.id)).limit(limit);
+	return rows.map(rowFromRecord);
+}
+
+export async function findByActor(actorId: string, limit: number): Promise<OpsAuditLogRow[]> {
+	const rows = await db
+		.select()
+		.from(opsAuditLog)
+		.where(eq(opsAuditLog.actorId, actorId))
+		.orderBy(desc(opsAuditLog.id))
+		.limit(limit);
+	return rows.map(rowFromRecord);
+}

--- a/src/lib/server/services/ops-audit-log-service.ts
+++ b/src/lib/server/services/ops-audit-log-service.ts
@@ -1,0 +1,107 @@
+// src/lib/server/services/ops-audit-log-service.ts
+// #820: /ops 運営操作の監査ログサービス
+
+import type { RequestEvent } from '@sveltejs/kit';
+import type { Identity } from '$lib/server/auth/types';
+import { getRepos } from '$lib/server/db/factory';
+import type { OpsAuditLogRow } from '$lib/server/db/interfaces/ops-audit-log-repo.interface';
+import { logger } from '$lib/server/logger';
+
+export interface RecordOpsAuditInput {
+	identity: Identity;
+	event: RequestEvent;
+	action: string;
+	target?: string | null;
+	metadata?: Record<string, unknown> | null;
+}
+
+export interface OpsAuditLogEntry {
+	id: number;
+	actorId: string;
+	actorEmail: string;
+	ip: string | null;
+	ua: string | null;
+	action: string;
+	target: string | null;
+	metadata: Record<string, unknown> | null;
+	createdAt: string;
+}
+
+function extractActor(identity: Identity): { actorId: string; actorEmail: string } {
+	if (identity.type === 'cognito') {
+		return { actorId: identity.userId, actorEmail: identity.email };
+	}
+	return { actorId: 'local', actorEmail: 'local@localhost' };
+}
+
+function extractIpUa(event: RequestEvent): { ip: string | null; ua: string | null } {
+	const ua = event.request.headers.get('user-agent');
+	let ip: string | null = null;
+	try {
+		ip = event.getClientAddress();
+	} catch {
+		ip = event.request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
+	}
+	return { ip, ua };
+}
+
+function parseMetadata(raw: string | null): Record<string, unknown> | null {
+	if (!raw) return null;
+	try {
+		const parsed = JSON.parse(raw);
+		return typeof parsed === 'object' && parsed !== null
+			? (parsed as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function toEntry(row: OpsAuditLogRow): OpsAuditLogEntry {
+	return {
+		id: row.id,
+		actorId: row.actorId,
+		actorEmail: row.actorEmail,
+		ip: row.ip,
+		ua: row.ua,
+		action: row.action,
+		target: row.target,
+		metadata: parseMetadata(row.metadata),
+		createdAt: row.createdAt,
+	};
+}
+
+export async function recordOpsAudit(input: RecordOpsAuditInput): Promise<void> {
+	const { actorId, actorEmail } = extractActor(input.identity);
+	const { ip, ua } = extractIpUa(input.event);
+
+	try {
+		await getRepos().opsAuditLog.insert({
+			actorId,
+			actorEmail,
+			ip,
+			ua,
+			action: input.action,
+			target: input.target ?? null,
+			metadata: input.metadata ?? null,
+		});
+	} catch (e) {
+		logger.error('[OPS_AUDIT] Failed to record audit log', {
+			context: {
+				action: input.action,
+				actorId,
+				error: e instanceof Error ? e.message : String(e),
+			},
+		});
+	}
+}
+
+export async function listRecentAudits(limit = 100): Promise<OpsAuditLogEntry[]> {
+	const rows = await getRepos().opsAuditLog.findRecent(limit);
+	return rows.map(toEntry);
+}
+
+export async function listAuditsByActor(actorId: string, limit = 100): Promise<OpsAuditLogEntry[]> {
+	const rows = await getRepos().opsAuditLog.findByActor(actorId, limit);
+	return rows.map(toEntry);
+}

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -536,6 +536,24 @@ export default async function globalSetup() {
 			CREATE INDEX IF NOT EXISTS idx_enemy_collection_child
 				ON enemy_collection(child_id);
 
+			CREATE TABLE IF NOT EXISTS ops_audit_log (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				actor_id TEXT NOT NULL,
+				actor_email TEXT NOT NULL,
+				ip TEXT,
+				ua TEXT,
+				action TEXT NOT NULL,
+				target TEXT,
+				metadata TEXT,
+				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+			);
+			CREATE INDEX IF NOT EXISTS idx_ops_audit_log_actor
+				ON ops_audit_log(actor_id);
+			CREATE INDEX IF NOT EXISTS idx_ops_audit_log_created
+				ON ops_audit_log(created_at);
+			CREATE INDEX IF NOT EXISTS idx_ops_audit_log_action
+				ON ops_audit_log(action);
+
 		`);
 
 		// リアルな過去の活動ログを追加（ステータス画面・レーダーチャートの表示用）

--- a/tests/unit/helpers/test-db.ts
+++ b/tests/unit/helpers/test-db.ts
@@ -742,6 +742,24 @@ export const SQL_TABLES = `
 	);
 	CREATE UNIQUE INDEX idx_enemy_collection_child_enemy ON enemy_collection(child_id, enemy_id);
 	CREATE INDEX idx_enemy_collection_child ON enemy_collection(child_id);
+
+	-- ============================================================
+	-- ops_audit_log (#820)
+	-- ============================================================
+	CREATE TABLE ops_audit_log (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		actor_id TEXT NOT NULL,
+		actor_email TEXT NOT NULL,
+		ip TEXT,
+		ua TEXT,
+		action TEXT NOT NULL,
+		target TEXT,
+		metadata TEXT,
+		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	CREATE INDEX idx_ops_audit_log_actor ON ops_audit_log(actor_id);
+	CREATE INDEX idx_ops_audit_log_created ON ops_audit_log(created_at);
+	CREATE INDEX idx_ops_audit_log_action ON ops_audit_log(action);
 `;
 
 // ============================================================
@@ -749,6 +767,7 @@ export const SQL_TABLES = `
 // ============================================================
 
 const ALL_TABLES = [
+	'ops_audit_log',
 	'enemy_collection',
 	'daily_battles',
 	'trial_history',

--- a/tests/unit/services/ops-audit-log-service.test.ts
+++ b/tests/unit/services/ops-audit-log-service.test.ts
@@ -1,0 +1,217 @@
+// tests/unit/services/ops-audit-log-service.test.ts
+// #820 監査ログサービスのユニットテスト
+
+import type { RequestEvent } from '@sveltejs/kit';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Identity } from '../../../src/lib/server/auth/types';
+import type {
+	InsertOpsAuditLogInput,
+	OpsAuditLogRow,
+} from '../../../src/lib/server/db/interfaces/ops-audit-log-repo.interface';
+
+const mockInsert = vi.fn<(input: InsertOpsAuditLogInput) => Promise<void>>();
+const mockFindRecent = vi.fn<(limit: number) => Promise<OpsAuditLogRow[]>>();
+const mockFindByActor = vi.fn<(actorId: string, limit: number) => Promise<OpsAuditLogRow[]>>();
+const mockLoggerError = vi.fn();
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		opsAuditLog: {
+			insert: (i: InsertOpsAuditLogInput) => mockInsert(i),
+			findRecent: (n: number) => mockFindRecent(n),
+			findByActor: (a: string, n: number) => mockFindByActor(a, n),
+		},
+	}),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: (...args: unknown[]) => mockLoggerError(...args), info: vi.fn(), warn: vi.fn() },
+}));
+
+import {
+	listAuditsByActor,
+	listRecentAudits,
+	recordOpsAudit,
+} from '../../../src/lib/server/services/ops-audit-log-service';
+
+function makeCognitoIdentity(overrides: Partial<{ userId: string; email: string }> = {}): Identity {
+	return {
+		type: 'cognito',
+		userId: overrides.userId ?? 'cog-user-1',
+		email: overrides.email ?? 'ops@example.com',
+	};
+}
+
+function makeLocalIdentity(): Identity {
+	return { type: 'local' };
+}
+
+function makeEvent(opts: { ip?: string | null; ua?: string | null; xff?: string | null } = {}) {
+	const headers = new Headers();
+	if (opts.ua !== null && opts.ua !== undefined) headers.set('user-agent', opts.ua);
+	if (opts.xff !== null && opts.xff !== undefined) headers.set('x-forwarded-for', opts.xff);
+	return {
+		request: { headers },
+		getClientAddress: () => {
+			if (opts.ip === null) throw new Error('no ip');
+			return opts.ip ?? '127.0.0.1';
+		},
+	} as unknown as RequestEvent;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockInsert.mockResolvedValue(undefined);
+});
+
+describe('recordOpsAudit', () => {
+	it('cognito identity から actorId/actorEmail を抽出して insert する', async () => {
+		await recordOpsAudit({
+			identity: makeCognitoIdentity({ userId: 'u-42', email: 'admin@example.com' }),
+			event: makeEvent({ ip: '203.0.113.10', ua: 'Mozilla/5.0 test' }),
+			action: 'tenant.suspend',
+			target: 'tenant-xyz',
+			metadata: { reason: 'payment-failed' },
+		});
+
+		expect(mockInsert).toHaveBeenCalledTimes(1);
+		const arg = mockInsert.mock.calls[0]![0]!;
+		expect(arg.actorId).toBe('u-42');
+		expect(arg.actorEmail).toBe('admin@example.com');
+		expect(arg.ip).toBe('203.0.113.10');
+		expect(arg.ua).toBe('Mozilla/5.0 test');
+		expect(arg.action).toBe('tenant.suspend');
+		expect(arg.target).toBe('tenant-xyz');
+		expect(arg.metadata).toEqual({ reason: 'payment-failed' });
+	});
+
+	it('local identity は actorId=local / actorEmail=local@localhost で記録される', async () => {
+		await recordOpsAudit({
+			identity: makeLocalIdentity(),
+			event: makeEvent({ ip: '192.168.1.2', ua: 'curl/8.0' }),
+			action: 'ping',
+		});
+
+		const arg = mockInsert.mock.calls[0]![0]!;
+		expect(arg.actorId).toBe('local');
+		expect(arg.actorEmail).toBe('local@localhost');
+	});
+
+	it('target/metadata 未指定の場合は null が渡される', async () => {
+		await recordOpsAudit({
+			identity: makeCognitoIdentity(),
+			event: makeEvent(),
+			action: 'kpi.view',
+		});
+
+		const arg = mockInsert.mock.calls[0]![0]!;
+		expect(arg.target).toBeNull();
+		expect(arg.metadata).toBeNull();
+	});
+
+	it('getClientAddress が throw した場合は x-forwarded-for の先頭 IP をフォールバックに使う', async () => {
+		await recordOpsAudit({
+			identity: makeCognitoIdentity(),
+			event: makeEvent({ ip: null, xff: '198.51.100.7, 10.0.0.1', ua: 'ua-x' }),
+			action: 'login',
+		});
+
+		const arg = mockInsert.mock.calls[0]![0]!;
+		expect(arg.ip).toBe('198.51.100.7');
+	});
+
+	it('IP/UA が取得できない場合は null で記録される', async () => {
+		await recordOpsAudit({
+			identity: makeCognitoIdentity(),
+			event: makeEvent({ ip: null }),
+			action: 'login',
+		});
+
+		const arg = mockInsert.mock.calls[0]![0]!;
+		expect(arg.ip).toBeNull();
+		expect(arg.ua).toBeNull();
+	});
+
+	it('insert が throw しても呼び出し元には例外を伝播させず logger.error に記録する', async () => {
+		mockInsert.mockRejectedValueOnce(new Error('db down'));
+
+		await expect(
+			recordOpsAudit({
+				identity: makeCognitoIdentity(),
+				event: makeEvent(),
+				action: 'tenant.suspend',
+			}),
+		).resolves.toBeUndefined();
+
+		expect(mockLoggerError).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('listRecentAudits', () => {
+	it('findRecent の結果を OpsAuditLogEntry 形式で返し metadata JSON をパースする', async () => {
+		mockFindRecent.mockResolvedValueOnce([
+			{
+				id: 2,
+				actorId: 'u-1',
+				actorEmail: 'a@example.com',
+				ip: '127.0.0.1',
+				ua: 'ua',
+				action: 'tenant.suspend',
+				target: 't-1',
+				metadata: JSON.stringify({ reason: 'x' }),
+				createdAt: '2026-04-15T00:00:00Z',
+			},
+			{
+				id: 1,
+				actorId: 'u-2',
+				actorEmail: 'b@example.com',
+				ip: null,
+				ua: null,
+				action: 'login',
+				target: null,
+				metadata: null,
+				createdAt: '2026-04-14T00:00:00Z',
+			},
+		]);
+
+		const result = await listRecentAudits(50);
+
+		expect(mockFindRecent).toHaveBeenCalledWith(50);
+		expect(result).toHaveLength(2);
+		expect(result[0]!.metadata).toEqual({ reason: 'x' });
+		expect(result[1]!.metadata).toBeNull();
+	});
+
+	it('不正な JSON metadata は null に変換される', async () => {
+		mockFindRecent.mockResolvedValueOnce([
+			{
+				id: 1,
+				actorId: 'u-1',
+				actorEmail: 'a@example.com',
+				ip: null,
+				ua: null,
+				action: 'x',
+				target: null,
+				metadata: '{broken',
+				createdAt: '2026-04-15T00:00:00Z',
+			},
+		]);
+
+		const result = await listRecentAudits(10);
+		expect(result[0]!.metadata).toBeNull();
+	});
+
+	it('limit 省略時は 100 を渡す', async () => {
+		mockFindRecent.mockResolvedValueOnce([]);
+		await listRecentAudits();
+		expect(mockFindRecent).toHaveBeenCalledWith(100);
+	});
+});
+
+describe('listAuditsByActor', () => {
+	it('findByActor に actorId と limit を委譲する', async () => {
+		mockFindByActor.mockResolvedValueOnce([]);
+		await listAuditsByActor('u-99', 20);
+		expect(mockFindByActor).toHaveBeenCalledWith('u-99', 20);
+	});
+});


### PR DESCRIPTION
## Summary

#820 を 4 フェーズに分割したうちの **PR-B**。/ops 運営操作の監査証跡を記録する基盤を追加する。

- `ops_audit_log` テーブル（actor_id / actor_email / ip / ua / action / target / metadata / created_at）
- `IOpsAuditLogRepo` 契約 + SQLite 実装 + DynamoDB スタブ（PR-C で差し替え）
- `ops-audit-log-service.ts`: `recordOpsAudit` / `listRecentAudits` / `listAuditsByActor`
  - Identity + RequestEvent から actor / IP / UA を抽出
  - insert 失敗は logger.error に吸収（呼び出し元の /ops ハンドラが監査失敗でユーザ操作まで失敗するのを防ぐ）
- 並行実装チェックリスト準拠: `schema.ts` / `create-tables.ts` / `tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` の 4 箇所で DDL を同期

## 分割の意図

| PR | 内容 | 状態 |
|----|------|------|
| PR-A | Identity.groups 拡張 + ops-authz 定数 | #992 |
| **PR-B** | **ops_audit_log テーブル + 監査サービス（本 PR）** | **本 PR** |
| PR-C | /ops auth Cognito group 切替 + CDK group + recordOpsAudit 埋め込み | 次 |
| PR-D | OPS_SECRET_KEY 廃止 + 設計書/ADR | 最後 |

PR-B は PR-A / PR-C とは独立にマージ可能（監査ログ配線は PR-C で行う）。

## 使い方（PR-C でのコール例）

```ts
import { recordOpsAudit } from '$lib/server/services/ops-audit-log-service';

// /ops/tenants/[id]/suspend など重要操作の直後
await recordOpsAudit({
  identity: locals.identity,
  event,
  action: 'tenant.suspend',
  target: tenantId,
  metadata: { reason: 'payment-failed' },
});
```

## Test plan

- [x] `npx vitest run tests/unit/services/ops-audit-log-service.test.ts` — 10/10 passing
  - actor 抽出（cognito/local）
  - IP/UA 抽出（getClientAddress / x-forwarded-for フォールバック / null）
  - metadata の JSON パース（正常 / 不正 JSON → null）
  - insert throw 時の伝播抑止 + logger.error 記録
  - limit 省略時のデフォルト 100
- [x] `npx biome check .` — OK
- [x] `npx svelte-check` — エラー 0
- [ ] PR-C で /ops ハンドラから recordOpsAudit を呼び、実テーブルに記録されることを E2E で検証

## 関連

- Parent: #820
- 前段: #992 (PR-A)
- 後続: PR-C (/ops auth 切替) / PR-D (OPS_SECRET_KEY 廃止 + ADR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)