### PR TITLE
feat: #945 Cognito E2E test-user-factory (ADR-0030 D-3/D-5)

### DIFF
--- a/tests/e2e/fixtures/cognito-lifecycle.ts
+++ b/tests/e2e/fixtures/cognito-lifecycle.ts
@@ -1,0 +1,87 @@
+/**
+ * Playwright fixtures for Cognito E2E test-user lifecycle (ADR-0030 D-5).
+ *
+ * 使い方:
+ *   import { test, expect } from './fixtures/cognito-lifecycle';
+ *
+ *   test('ops signin with group-based auth', async ({ page, opsUser }) => {
+ *     await page.goto('/ops');
+ *     // opsUser is auto-created with ops group, cleaned up after test.
+ *   });
+ *
+ * 要求 env (staging only — ADR-0030 D-2 により prod User Pool は IAM で禁止):
+ *   - AWS_REGION
+ *   - COGNITO_E2E_USER_POOL_ID   (staging pool の ID — prod は throw される)
+ *   - AWS credentials: OIDC 経由で自動注入 (GitHub Actions の `aws-actions/configure-aws-credentials`)
+ */
+
+import { test as base } from '@playwright/test';
+import { CognitoAdminClient } from '../helpers/cognito-admin-client';
+import {
+	type CreateTestUserOptions,
+	createTestUser,
+	type TestUser,
+} from '../helpers/test-user-factory';
+
+type TestFixtures = {
+	/** 標準テスト用ユーザー (グループなし) */
+	testUser: TestUser;
+	/** ops グループ所属ユーザー (ADR-0030 + #820) */
+	opsUser: TestUser;
+	/** 任意グループ構成のユーザーを作る factory */
+	makeTestUser: (opts?: Partial<CreateTestUserOptions>) => Promise<TestUser>;
+};
+
+type WorkerFixtures = {
+	cognitoAdminClient: CognitoAdminClient;
+};
+
+export const test = base.extend<TestFixtures, WorkerFixtures>({
+	cognitoAdminClient: [
+		// biome-ignore lint/correctness/noEmptyPattern: Playwright fixtures require ({ deps }, use) signature
+		async ({}, use) => {
+			const region = process.env.AWS_REGION;
+			const userPoolId = process.env.COGNITO_E2E_USER_POOL_ID;
+			if (!region || !userPoolId) {
+				throw new Error(
+					'[cognito-lifecycle] AWS_REGION and COGNITO_E2E_USER_POOL_ID must be set for AWS E2E fixtures (ADR-0030 D-2). ' +
+						'Run non-AWS tests via cognito-dev mode instead.',
+				);
+			}
+			const client = new CognitoAdminClient({ region, userPoolId });
+			await use(client);
+		},
+		{ scope: 'worker' },
+	],
+
+	makeTestUser: async ({ cognitoAdminClient }, use) => {
+		const created: TestUser[] = [];
+		const factory = async (opts: Partial<CreateTestUserOptions> = {}) => {
+			const user = await createTestUser({
+				adminClient: cognitoAdminClient,
+				...opts,
+			});
+			created.push(user);
+			return user;
+		};
+		await use(factory);
+		for (const user of created) {
+			await user.cleanup().catch((err: unknown) => {
+				// D-4 3段構え: spec-local cleanup が失敗しても global-teardown + nightly janitor で補完
+				console.warn(`[cognito-lifecycle] cleanup failed for ${user.email}:`, err);
+			});
+		}
+	},
+
+	testUser: async ({ makeTestUser }, use) => {
+		const user = await makeTestUser();
+		await use(user);
+	},
+
+	opsUser: async ({ makeTestUser }, use) => {
+		const user = await makeTestUser({ groups: ['ops'] });
+		await use(user);
+	},
+});
+
+export { expect } from '@playwright/test';

--- a/tests/e2e/helpers/cognito-admin-client.ts
+++ b/tests/e2e/helpers/cognito-admin-client.ts
@@ -1,0 +1,197 @@
+/**
+ * Cognito Admin API client wrapper for E2E tests (ADR-0030 D-2 / D-5).
+ *
+ * Production User Pool への誤操作を「物理」と「ランタイム」の二重で防ぐ:
+ *   - IAM: CDK の E2EAdminRole は staging User Pool ARN のみ Allow (ADR-0030 D-2)
+ *   - Runtime: このクラスの production guard が pool ID を検査し throw
+ *
+ * 禁止 (ADR-0030):
+ *   - production User Pool Id を渡すこと (即 throw)
+ *   - @ganbari-quest.com ドメインの email を作成すること (呼び出し側で防ぐ)
+ *   - 静的 Access Key を使うこと (OIDC 経由で credentials を取得)
+ */
+
+import {
+	AdminAddUserToGroupCommand,
+	AdminCreateUserCommand,
+	AdminDeleteUserCommand,
+	AdminGetUserCommand,
+	AdminRemoveUserFromGroupCommand,
+	AdminSetUserPasswordCommand,
+	CognitoIdentityProviderClient,
+	ListUsersCommand,
+	type UserType,
+} from '@aws-sdk/client-cognito-identity-provider';
+
+export type CognitoAdminClientOptions = {
+	region: string;
+	userPoolId: string;
+};
+
+export type AdminCreateUserOptions = {
+	email: string;
+	password: string;
+	groups?: string[];
+	attributes?: Record<string, string>;
+};
+
+export type AdminCreateUserResult = {
+	userId: string;
+	email: string;
+	enabled: boolean;
+};
+
+/**
+ * Runtime guard: production User Pool Id を弾く。
+ * IAM 側で既に防がれているが、開発者が誤って prod pool id を config に書いても
+ * AWS へ到達する前にここで例外を投げる (ADR-0030 D-5)。
+ */
+export function assertNotProductionUserPool(userPoolId: string): void {
+	const lowered = userPoolId.toLowerCase();
+	if (
+		lowered.includes('-prod') ||
+		lowered.includes('_prod') ||
+		lowered.endsWith('prod') ||
+		lowered.includes('production')
+	) {
+		throw new Error(
+			`[CognitoAdminClient] refused to operate on production-looking User Pool: ${userPoolId}. ` +
+				'E2E helpers may only target staging / e2e User Pools (ADR-0030 D-2 / D-5).',
+		);
+	}
+}
+
+export class CognitoAdminClient {
+	readonly region: string;
+	readonly userPoolId: string;
+	private readonly client: CognitoIdentityProviderClient;
+
+	constructor(options: CognitoAdminClientOptions) {
+		assertNotProductionUserPool(options.userPoolId);
+		this.region = options.region;
+		this.userPoolId = options.userPoolId;
+		this.client = new CognitoIdentityProviderClient({ region: options.region });
+	}
+
+	async createUser(options: AdminCreateUserOptions): Promise<AdminCreateUserResult> {
+		const { email, password, groups = [], attributes = {} } = options;
+
+		const userAttrs = [
+			{ Name: 'email', Value: email },
+			{ Name: 'email_verified', Value: 'true' },
+			...Object.entries(attributes).map(([Name, Value]) => ({ Name, Value })),
+		];
+
+		const created = await this.client.send(
+			new AdminCreateUserCommand({
+				UserPoolId: this.userPoolId,
+				Username: email,
+				UserAttributes: userAttrs,
+				MessageAction: 'SUPPRESS',
+				DesiredDeliveryMediums: [],
+			}),
+		);
+
+		await this.client.send(
+			new AdminSetUserPasswordCommand({
+				UserPoolId: this.userPoolId,
+				Username: email,
+				Password: password,
+				Permanent: true,
+			}),
+		);
+
+		for (const group of groups) {
+			await this.client.send(
+				new AdminAddUserToGroupCommand({
+					UserPoolId: this.userPoolId,
+					Username: email,
+					GroupName: group,
+				}),
+			);
+		}
+
+		const sub =
+			created.User?.Attributes?.find((attr) => attr.Name === 'sub')?.Value ??
+			created.User?.Username;
+		if (!sub) {
+			throw new Error(`[CognitoAdminClient] AdminCreateUser returned no sub for ${email}`);
+		}
+
+		return {
+			userId: sub,
+			email,
+			enabled: created.User?.Enabled ?? true,
+		};
+	}
+
+	async deleteUser(email: string): Promise<void> {
+		await this.client.send(
+			new AdminDeleteUserCommand({
+				UserPoolId: this.userPoolId,
+				Username: email,
+			}),
+		);
+	}
+
+	async getUser(email: string): Promise<UserType | null> {
+		try {
+			const res = await this.client.send(
+				new AdminGetUserCommand({
+					UserPoolId: this.userPoolId,
+					Username: email,
+				}),
+			);
+			return {
+				Username: res.Username,
+				Attributes: res.UserAttributes,
+				Enabled: res.Enabled,
+				UserStatus: res.UserStatus,
+			} satisfies UserType;
+		} catch (err) {
+			if (isUserNotFoundError(err)) return null;
+			throw err;
+		}
+	}
+
+	async addUserToGroup(email: string, group: string): Promise<void> {
+		await this.client.send(
+			new AdminAddUserToGroupCommand({
+				UserPoolId: this.userPoolId,
+				Username: email,
+				GroupName: group,
+			}),
+		);
+	}
+
+	async removeUserFromGroup(email: string, group: string): Promise<void> {
+		await this.client.send(
+			new AdminRemoveUserFromGroupCommand({
+				UserPoolId: this.userPoolId,
+				Username: email,
+				GroupName: group,
+			}),
+		);
+	}
+
+	/**
+	 * email prefix で User Pool を scan する。global-teardown と nightly janitor が
+	 * orphan を掃除するのに使う (ADR-0030 D-4)。
+	 */
+	async listUsersByEmailPrefix(prefix: string, limit = 60): Promise<UserType[]> {
+		const res = await this.client.send(
+			new ListUsersCommand({
+				UserPoolId: this.userPoolId,
+				Filter: `email ^= "${prefix}"`,
+				Limit: limit,
+			}),
+		);
+		return res.Users ?? [];
+	}
+}
+
+function isUserNotFoundError(err: unknown): boolean {
+	if (!err || typeof err !== 'object') return false;
+	const name = (err as { name?: string }).name;
+	return name === 'UserNotFoundException';
+}

--- a/tests/e2e/helpers/test-user-factory.ts
+++ b/tests/e2e/helpers/test-user-factory.ts
@@ -1,0 +1,109 @@
+/**
+ * E2E test user factory (ADR-0030 D-3 / D-5).
+ *
+ * - email 命名規則 (ADR-0030 D-3): `e2e-{ISO date}-{sha7}-{run_attempt}-{worker}-{uuid8}@ganbari-quest.test`
+ * - `.test` TLD で誤送信リスクなし
+ * - sha 入りで「どのコミットが作ったユーザか」が残骸から追跡可能
+ * - UUID で同一 run 内の並列衝突を完全排除
+ *
+ * 使い方:
+ *   const user = await createTestUser({ adminClient, groups: ['ops'] });
+ *   // ... test ...
+ *   await user.cleanup();
+ *
+ *   // または fixture:
+ *   await withTestUser({ adminClient }, async (user) => { ... });
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { CognitoAdminClient } from './cognito-admin-client';
+
+export type CreateTestUserOptions = {
+	adminClient: CognitoAdminClient;
+	groups?: string[];
+	attributes?: Record<string, string>;
+	/** テスト名 / 目的のヒント。email には入らず、metadata として保持される */
+	purpose?: string;
+};
+
+export type TestUser = {
+	email: string;
+	password: string;
+	userId: string;
+	cleanup: () => Promise<void>;
+};
+
+/**
+ * email 命名規則 (ADR-0030 D-3) のパーツを組み立てる。
+ * 環境変数が無い場合は現実的な fallback を使う (ローカル実行でも壊れない)。
+ */
+export function buildTestUserEmail(
+	opts: { workerIndex?: number; runAttempt?: number } = {},
+): string {
+	const iso = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+	const sha = (process.env.GITHUB_SHA ?? 'localdev').slice(0, 7);
+	const runAttempt = opts.runAttempt ?? Number(process.env.GITHUB_RUN_ATTEMPT ?? '0');
+	const worker = opts.workerIndex ?? Number(process.env.TEST_WORKER_INDEX ?? '0');
+	const uuid = randomUUID().replace(/-/g, '').slice(0, 8);
+	return `e2e-${iso}-${sha}-${runAttempt}-w${worker}-${uuid}@ganbari-quest.test`;
+}
+
+/**
+ * テストユーザー用 password を生成する。
+ * Cognito policy (大文字/小文字/数字/記号/16+ 文字) を満たす。
+ */
+export function generateTestPassword(): string {
+	const uuid = randomUUID().replace(/-/g, '');
+	// 固定プレフィックスで policy 要件を確実に満たす
+	return `E2e!${uuid.slice(0, 20)}Ax9`;
+}
+
+export async function createTestUser(options: CreateTestUserOptions): Promise<TestUser> {
+	const { adminClient, groups, attributes } = options;
+	const email = buildTestUserEmail();
+
+	if (email.endsWith('@ganbari-quest.com')) {
+		throw new Error(
+			'[test-user-factory] refused to create user under production domain @ganbari-quest.com (ADR-0030)',
+		);
+	}
+
+	const password = generateTestPassword();
+	const created = await adminClient.createUser({ email, password, groups, attributes });
+
+	return {
+		email,
+		password,
+		userId: created.userId,
+		cleanup: async () => {
+			try {
+				await adminClient.deleteUser(email);
+			} catch (err) {
+				if (!isUserAlreadyDeleted(err)) {
+					throw err;
+				}
+			}
+		},
+	};
+}
+
+/**
+ * fixture-style helper — fn 内で例外が起きても必ず cleanup を走らせる。
+ */
+export async function withTestUser<T>(
+	options: CreateTestUserOptions,
+	fn: (user: TestUser) => Promise<T>,
+): Promise<T> {
+	const user = await createTestUser(options);
+	try {
+		return await fn(user);
+	} finally {
+		await user.cleanup();
+	}
+}
+
+function isUserAlreadyDeleted(err: unknown): boolean {
+	if (!err || typeof err !== 'object') return false;
+	const name = (err as { name?: string }).name;
+	return name === 'UserNotFoundException';
+}

--- a/tests/unit/e2e-helpers/cognito-admin-client.test.ts
+++ b/tests/unit/e2e-helpers/cognito-admin-client.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for CognitoAdminClient (ADR-0030 D-5).
+ *
+ * Production guard が真っ先に効くことを証明する。AWS への実際の SDK 呼び出しは
+ * `@aws-sdk/client-cognito-identity-provider` 全体を vi.mock で差し替え。
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sendMock = vi.fn();
+
+vi.mock('@aws-sdk/client-cognito-identity-provider', () => {
+	class FakeClient {
+		send = sendMock;
+	}
+	class Cmd {
+		_kind: string;
+		input: unknown;
+		constructor(kind: string, input: unknown) {
+			this._kind = kind;
+			this.input = input;
+		}
+	}
+	return {
+		CognitoIdentityProviderClient: FakeClient,
+		AdminCreateUserCommand: class extends Cmd {
+			constructor(input: unknown) {
+				super('AdminCreateUser', input);
+			}
+		},
+		AdminSetUserPasswordCommand: class extends Cmd {
+			constructor(input: unknown) {
+				super('AdminSetUserPassword', input);
+			}
+		},
+		AdminDeleteUserCommand: class extends Cmd {
+			constructor(input: unknown) {
+				super('AdminDeleteUser', input);
+			}
+		},
+		AdminGetUserCommand: class extends Cmd {
+			constructor(input: unknown) {
+				super('AdminGetUser', input);
+			}
+		},
+		AdminAddUserToGroupCommand: class extends Cmd {
+			constructor(input: unknown) {
+				super('AdminAddUserToGroup', input);
+			}
+		},
+		AdminRemoveUserFromGroupCommand: class extends Cmd {
+			constructor(input: unknown) {
+				super('AdminRemoveUserFromGroup', input);
+			}
+		},
+		ListUsersCommand: class extends Cmd {
+			constructor(input: unknown) {
+				super('ListUsers', input);
+			}
+		},
+	};
+});
+
+import {
+	assertNotProductionUserPool,
+	CognitoAdminClient,
+} from '../../../tests/e2e/helpers/cognito-admin-client';
+
+describe('assertNotProductionUserPool', () => {
+	it('accepts staging / e2e pool ids', () => {
+		expect(() => assertNotProductionUserPool('ap-northeast-1_stagingPool')).not.toThrow();
+		expect(() => assertNotProductionUserPool('ap-northeast-1_e2epool1')).not.toThrow();
+		expect(() => assertNotProductionUserPool('ap-northeast-1_devPool')).not.toThrow();
+	});
+
+	it('throws on production-looking pool ids', () => {
+		expect(() => assertNotProductionUserPool('ap-northeast-1_ganbari-prod')).toThrow(/production/i);
+		expect(() => assertNotProductionUserPool('ap-northeast-1_myPoolProd')).toThrow(/production/i);
+		expect(() => assertNotProductionUserPool('ap-northeast-1_productionPool')).toThrow(
+			/production/i,
+		);
+		expect(() => assertNotProductionUserPool('ap-northeast-1_prod_pool')).toThrow(/production/i);
+	});
+
+	it('is case-insensitive', () => {
+		expect(() => assertNotProductionUserPool('AP-NORTHEAST-1_POOL-PROD')).toThrow(/production/i);
+		expect(() => assertNotProductionUserPool('ap-northeast-1_PRODUCTIONpool')).toThrow(
+			/production/i,
+		);
+	});
+});
+
+describe('CognitoAdminClient constructor', () => {
+	beforeEach(() => {
+		sendMock.mockReset();
+	});
+
+	it('rejects production User Pool in constructor', () => {
+		expect(
+			() =>
+				new CognitoAdminClient({
+					region: 'ap-northeast-1',
+					userPoolId: 'ap-northeast-1_ganbari-prod',
+				}),
+		).toThrow(/production/i);
+	});
+
+	it('accepts staging User Pool', () => {
+		expect(
+			() =>
+				new CognitoAdminClient({
+					region: 'ap-northeast-1',
+					userPoolId: 'ap-northeast-1_stagingPool',
+				}),
+		).not.toThrow();
+	});
+});
+
+describe('CognitoAdminClient.createUser', () => {
+	const region = 'ap-northeast-1';
+	const userPoolId = 'ap-northeast-1_stagingPool';
+
+	beforeEach(() => {
+		sendMock.mockReset();
+	});
+
+	it('calls AdminCreateUser with SUPPRESS + AdminSetUserPassword Permanent', async () => {
+		sendMock
+			.mockResolvedValueOnce({
+				User: {
+					Username: 'user-abc',
+					Attributes: [{ Name: 'sub', Value: 'sub-123' }],
+					Enabled: true,
+				},
+			})
+			.mockResolvedValueOnce({});
+
+		const client = new CognitoAdminClient({ region, userPoolId });
+		const result = await client.createUser({
+			email: 'e2e-2026-04-16-abc1234-0-w0-deadbeef@ganbari-quest.test',
+			password: 'E2e!secretValueXxxxAx9',
+		});
+
+		expect(result.userId).toBe('sub-123');
+		expect(sendMock).toHaveBeenCalledTimes(2);
+
+		const createCommand = sendMock.mock.calls[0]![0]!;
+		expect(createCommand._kind).toBe('AdminCreateUser');
+		expect(createCommand.input.UserPoolId).toBe(userPoolId);
+		expect(createCommand.input.MessageAction).toBe('SUPPRESS');
+		expect(createCommand.input.DesiredDeliveryMediums).toEqual([]);
+		expect(createCommand.input.UserAttributes).toEqual(
+			expect.arrayContaining([
+				{ Name: 'email', Value: 'e2e-2026-04-16-abc1234-0-w0-deadbeef@ganbari-quest.test' },
+				{ Name: 'email_verified', Value: 'true' },
+			]),
+		);
+
+		const setPwCommand = sendMock.mock.calls[1]![0]!;
+		expect(setPwCommand._kind).toBe('AdminSetUserPassword');
+		expect(setPwCommand.input.Permanent).toBe(true);
+	});
+
+	it('adds user to groups when requested', async () => {
+		sendMock
+			.mockResolvedValueOnce({
+				User: { Username: 'u', Attributes: [{ Name: 'sub', Value: 'sub-1' }], Enabled: true },
+			})
+			.mockResolvedValueOnce({})
+			.mockResolvedValueOnce({})
+			.mockResolvedValueOnce({});
+
+		const client = new CognitoAdminClient({ region, userPoolId });
+		await client.createUser({
+			email: 'e2e-foo@ganbari-quest.test',
+			password: 'E2e!xxxxxxxxxxxxxxxxAx9',
+			groups: ['ops', 'admin'],
+		});
+
+		expect(sendMock).toHaveBeenCalledTimes(4);
+		const group1 = sendMock.mock.calls[2]![0]!;
+		const group2 = sendMock.mock.calls[3]![0]!;
+		expect(group1._kind).toBe('AdminAddUserToGroup');
+		expect(group1.input.GroupName).toBe('ops');
+		expect(group2.input.GroupName).toBe('admin');
+	});
+
+	it('throws when AdminCreateUser returns no sub', async () => {
+		sendMock
+			.mockResolvedValueOnce({ User: { Username: undefined, Attributes: [] } })
+			.mockResolvedValueOnce({});
+
+		const client = new CognitoAdminClient({ region, userPoolId });
+		await expect(
+			client.createUser({
+				email: 'e2e-no-sub@ganbari-quest.test',
+				password: 'E2e!xxxxxxxxxxxxxxxxAx9',
+			}),
+		).rejects.toThrow(/no sub/);
+	});
+});
+
+describe('CognitoAdminClient.getUser', () => {
+	beforeEach(() => {
+		sendMock.mockReset();
+	});
+
+	it('returns null when UserNotFoundException is thrown', async () => {
+		const notFound = Object.assign(new Error('not found'), { name: 'UserNotFoundException' });
+		sendMock.mockRejectedValueOnce(notFound);
+
+		const client = new CognitoAdminClient({
+			region: 'ap-northeast-1',
+			userPoolId: 'ap-northeast-1_stagingPool',
+		});
+		const result = await client.getUser('missing@ganbari-quest.test');
+		expect(result).toBeNull();
+	});
+
+	it('rethrows other errors', async () => {
+		sendMock.mockRejectedValueOnce(new Error('boom'));
+
+		const client = new CognitoAdminClient({
+			region: 'ap-northeast-1',
+			userPoolId: 'ap-northeast-1_stagingPool',
+		});
+		await expect(client.getUser('x@ganbari-quest.test')).rejects.toThrow(/boom/);
+	});
+});
+
+describe('CognitoAdminClient.listUsersByEmailPrefix', () => {
+	beforeEach(() => {
+		sendMock.mockReset();
+	});
+
+	it('passes email prefix filter to ListUsersCommand', async () => {
+		sendMock.mockResolvedValueOnce({ Users: [{ Username: 'user-1' }, { Username: 'user-2' }] });
+
+		const client = new CognitoAdminClient({
+			region: 'ap-northeast-1',
+			userPoolId: 'ap-northeast-1_stagingPool',
+		});
+		const users = await client.listUsersByEmailPrefix('e2e-', 30);
+
+		expect(users).toHaveLength(2);
+		const cmd = sendMock.mock.calls[0]![0]!;
+		expect(cmd._kind).toBe('ListUsers');
+		expect(cmd.input.Filter).toBe('email ^= "e2e-"');
+		expect(cmd.input.Limit).toBe(30);
+	});
+});

--- a/tests/unit/e2e-helpers/test-user-factory.test.ts
+++ b/tests/unit/e2e-helpers/test-user-factory.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for test-user-factory (ADR-0030 D-3).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CognitoAdminClient } from '../../../tests/e2e/helpers/cognito-admin-client';
+import {
+	buildTestUserEmail,
+	createTestUser,
+	generateTestPassword,
+	withTestUser,
+} from '../../../tests/e2e/helpers/test-user-factory';
+
+function fakeAdminClient(): CognitoAdminClient & {
+	createUser: ReturnType<typeof vi.fn>;
+	deleteUser: ReturnType<typeof vi.fn>;
+} {
+	return {
+		createUser: vi.fn().mockResolvedValue({ userId: 'sub-abc', email: 'ignored', enabled: true }),
+		deleteUser: vi.fn().mockResolvedValue(undefined),
+	} as unknown as CognitoAdminClient & {
+		createUser: ReturnType<typeof vi.fn>;
+		deleteUser: ReturnType<typeof vi.fn>;
+	};
+}
+
+describe('buildTestUserEmail', () => {
+	const origEnv = { ...process.env };
+
+	afterEach(() => {
+		process.env = { ...origEnv };
+	});
+
+	it('uses ganbari-quest.test TLD per ADR-0030 D-3', () => {
+		const email = buildTestUserEmail();
+		expect(email.endsWith('@ganbari-quest.test')).toBe(true);
+	});
+
+	it('never uses production @ganbari-quest.com domain', () => {
+		for (let i = 0; i < 20; i++) {
+			expect(buildTestUserEmail().endsWith('@ganbari-quest.com')).toBe(false);
+		}
+	});
+
+	it('includes date / sha / run / worker / uuid segments', () => {
+		process.env.GITHUB_SHA = 'abc1234567890';
+		process.env.GITHUB_RUN_ATTEMPT = '3';
+		const email = buildTestUserEmail({ workerIndex: 5 });
+		expect(email).toMatch(/^e2e-\d{4}-\d{2}-\d{2}-abc1234-3-w5-[0-9a-f]{8}@ganbari-quest\.test$/);
+	});
+
+	it('generates unique emails across calls (UUID collision resistance)', () => {
+		const seen = new Set<string>();
+		for (let i = 0; i < 100; i++) {
+			seen.add(buildTestUserEmail());
+		}
+		expect(seen.size).toBe(100);
+	});
+
+	it('falls back to localdev / 0 when GITHUB env is absent', () => {
+		delete process.env.GITHUB_SHA;
+		delete process.env.GITHUB_RUN_ATTEMPT;
+		delete process.env.TEST_WORKER_INDEX;
+		const email = buildTestUserEmail();
+		// 'localdev' sliced to 7 chars = 'localde'
+		expect(email).toMatch(/-localde-0-w0-[0-9a-f]{8}@ganbari-quest\.test$/);
+	});
+});
+
+describe('generateTestPassword', () => {
+	it('meets Cognito default password policy (upper/lower/digit/symbol, 8+)', () => {
+		for (let i = 0; i < 10; i++) {
+			const pw = generateTestPassword();
+			expect(pw.length).toBeGreaterThanOrEqual(8);
+			expect(pw).toMatch(/[A-Z]/);
+			expect(pw).toMatch(/[a-z]/);
+			expect(pw).toMatch(/\d/);
+			expect(pw).toMatch(/[!@#$%^&*()_+=\-/]/);
+		}
+	});
+
+	it('generates different passwords each call', () => {
+		const pw1 = generateTestPassword();
+		const pw2 = generateTestPassword();
+		expect(pw1).not.toBe(pw2);
+	});
+});
+
+describe('createTestUser', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns TestUser with email/password/userId and cleanup function', async () => {
+		const client = fakeAdminClient();
+		const user = await createTestUser({ adminClient: client });
+
+		expect(user.email).toMatch(/@ganbari-quest\.test$/);
+		expect(user.password.length).toBeGreaterThanOrEqual(16);
+		expect(user.userId).toBe('sub-abc');
+		expect(typeof user.cleanup).toBe('function');
+
+		expect(client.createUser).toHaveBeenCalledWith(
+			expect.objectContaining({
+				email: user.email,
+				password: user.password,
+			}),
+		);
+	});
+
+	it('passes groups through to adminClient', async () => {
+		const client = fakeAdminClient();
+		await createTestUser({ adminClient: client, groups: ['ops'] });
+		expect(client.createUser).toHaveBeenCalledWith(expect.objectContaining({ groups: ['ops'] }));
+	});
+
+	it('cleanup() deletes the user and is idempotent when user already gone', async () => {
+		const client = fakeAdminClient();
+		const notFound = Object.assign(new Error('not found'), { name: 'UserNotFoundException' });
+		client.deleteUser.mockRejectedValueOnce(notFound);
+
+		const user = await createTestUser({ adminClient: client });
+		await expect(user.cleanup()).resolves.not.toThrow();
+		expect(client.deleteUser).toHaveBeenCalledWith(user.email);
+	});
+
+	it('cleanup() rethrows non-UserNotFound errors', async () => {
+		const client = fakeAdminClient();
+		client.deleteUser.mockRejectedValueOnce(new Error('network boom'));
+
+		const user = await createTestUser({ adminClient: client });
+		await expect(user.cleanup()).rejects.toThrow(/network boom/);
+	});
+});
+
+describe('withTestUser', () => {
+	it('runs fn then cleans up on success', async () => {
+		const client = fakeAdminClient();
+		const result = await withTestUser({ adminClient: client }, async (user) => {
+			expect(user.email).toMatch(/@ganbari-quest\.test$/);
+			return 42;
+		});
+		expect(result).toBe(42);
+		expect(client.deleteUser).toHaveBeenCalledTimes(1);
+	});
+
+	it('cleans up even when fn throws', async () => {
+		const client = fakeAdminClient();
+		await expect(
+			withTestUser({ adminClient: client }, async () => {
+				throw new Error('test body failure');
+			}),
+		).rejects.toThrow(/test body failure/);
+		expect(client.deleteUser).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
closes #945
related ADR: #994 (ADR-0030 Cognito E2E lifecycle)

## Summary

ADR-0030 D-3 / D-5 に基づき、E2E テスト用 Cognito ユーザーを動的に作成・削除するヘルパを実装。

- `tests/e2e/helpers/cognito-admin-client.ts` — AWS SDK ラッパ
  - Runtime production guard: pool id が `-prod` / `_prod` / `production` / `prod` 末尾にマッチすると throw (ADR-0030 D-5)
  - IAM allowlist (staging ARN のみ) との二重防御
  - `AdminCreateUser(SUPPRESS)` + `AdminSetUserPassword(Permanent: true)` → CONFIRMED 状態の user を即作る
  - `listUsersByEmailPrefix`: global-teardown / nightly janitor の orphan 掃除用
- `tests/e2e/helpers/test-user-factory.ts`
  - email 命名 (ADR-0030 D-3): `e2e-{ISO date}-{sha7}-{run_attempt}-{worker}-{uuid8}@ganbari-quest.test`
  - `createTestUser` / `withTestUser` (fixture-style auto cleanup)
  - cleanup は冪等 (UserNotFoundException 許容 → D-4 3 段構えで補完)
- `tests/e2e/fixtures/cognito-lifecycle.ts` — Playwright fixtures
  - worker-scoped `cognitoAdminClient` + test-scoped `testUser` / `opsUser` / `makeTestUser`
  - `AWS_REGION` / `COGNITO_E2E_USER_POOL_ID` 未設定なら throw
- `tests/unit/e2e-helpers/` — unit tests 24 件
  - production guard (大文字小文字 / 位置違い / 部分一致) の網羅
  - email 命名規則 (100 件 uniqueness / `.com` 誤爆ゼロ) の検証
  - AdminCreateUser の引数 (SUPPRESS / DesiredDeliveryMediums=[] / email_verified=true) を検証
  - cleanup 冪等性 (UserNotFoundException 許容 / 他 error は rethrow)

## Test plan

- [x] `npx vitest run tests/unit/e2e-helpers/` — 24 tests passed
- [x] `npx svelte-check` — 0 errors
- [x] `npx biome check` — 警告のみ (既存 `mock.calls[0]!` パターン踏襲)
- [ ] 実 AWS staging pool での smoke test は本 PR では行わない (CDK 側で staging User Pool 整備は別 PR: ADR-0030 フォローアップ)

## Non-goals (フォローアップ)

- `infra/lib/auth-stack.ts` を `AuthStack-prod` / `AuthStack-e2e` に分離 (別 PR)
- `tests/e2e/global-teardown-aws.ts` を D-4 3 段構えに合わせて書き直し (別 PR)
- nightly janitor Lambda (別 PR)
- 実際の account-deletion / license-lifecycle spec 移植 (#755 / #810)

## ADR-0029 チェック

- production guard を warn に落とす変更: なし
- `NODE_ENV === 'test'` skip 分岐: なし
- `ALLOW_*` / `SKIP_*` 既定値 true 化: なし
- retry / timeout の根拠なき追加: なし
- `.skip` / `.todo` / `@ts-expect-error` / `eslint-disable` の追加: なし
- 新規必須 env / secret の追加: なし (`AWS_REGION` / `COGNITO_E2E_USER_POOL_ID` は fixture 内限定で assertion を持つが、本体コードではない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)