### PR TITLE
refactor: #820 PR-C /ops 認可を Cognito ops group ベースに刷新

### DIFF
--- a/infra/lib/auth-stack.ts
+++ b/infra/lib/auth-stack.ts
@@ -72,6 +72,19 @@ export class AuthStack extends cdk.Stack {
 			removalPolicy: cdk.RemovalPolicy.RETAIN,
 		});
 
+		// --- #820 PR-C: /ops ダッシュボード用 Cognito group ---
+		// 所属ユーザーのみが /ops/* にアクセスできる（+layout.server.ts で isOpsMember チェック）。
+		// group 名は src/lib/server/auth/ops-authz.ts の OPS_GROUP 定数と一致させること。
+		// 運用メモ（#820）:
+		//   - ユーザーを追加: AWS Console or `aws cognito-idp admin-add-user-to-group --group-name ops`
+		//   - 権限剥奪: `aws cognito-idp admin-remove-user-from-group --group-name ops`
+		new cognito.CfnUserPoolGroup(this, 'OpsGroup', {
+			userPoolId: this.userPool.userPoolId,
+			groupName: 'ops',
+			description: 'Ganbari Quest operations dashboard (/ops) access',
+			precedence: 0,
+		});
+
 		// --- CustomMessage Lambda Trigger (日本語HTML メールテンプレート) ---
 		const customMessageFn = new lambda.Function(this, 'CustomMessageFn', {
 			functionName: 'ganbari-quest-cognito-custom-message',

--- a/src/lib/server/auth/providers/cognito-dev.ts
+++ b/src/lib/server/auth/providers/cognito-dev.ts
@@ -98,6 +98,17 @@ export const DEV_USERS: DevUser[] = [
 		licenseStatus: AUTH_LICENSE_STATUS.NONE,
 		plan: undefined,
 	},
+	// ---------- #820 PR-C: /ops 認可 E2E 用ユーザー ----------
+	// groups: ['ops'] を付与し、Cognito の ops group 所属として扱う。
+	// ops ダッシュボードは単独テナントで閲覧・操作するため、専用 tenant を割り当てる。
+	{
+		userId: 'dev-ops-001',
+		email: 'ops@example.com',
+		password: 'Gq!Dev#Ops2026xyz',
+		tenantId: 'dev-tenant-ops',
+		role: 'owner',
+		groups: ['ops'],
+	},
 ];
 
 /** Email でダミーユーザーを検索 */

--- a/src/routes/ops/+layout.server.ts
+++ b/src/routes/ops/+layout.server.ts
@@ -1,38 +1,27 @@
 // src/routes/ops/+layout.server.ts
-// OPS ダッシュボード認証: Bearer token (#0176)
+// #820 PR-C: /ops 認可を Cognito ops group ベースに刷新
+//
+// 旧実装（#0176）: `OPS_SECRET_KEY` による Bearer token / cookie / URL パラメータ認証。
+// 問題点:
+//   - actor 識別不能（共有シークレット）→ 監査ログに「誰が操作したか」残らない
+//   - シークレット漏洩時の影響範囲が無限大
+//   - cookie 平文保存の既知課題（docs/security/security-code-review-2026-03.md:189）
+//
+// 新実装（PR-C）: Cognito `ops` group 所属チェック。
+//   - actor 識別 = Cognito sub（PR-B の ops_audit_log で利用）
+//   - 非所属は 403（以前は 401）
+//   - hooks.server.ts で resolveIdentity 済みの `locals.identity` を使用
+//   - cognito-dev mode（ローカル / CI）では DEV_USERS の `groups: ['ops']` 指定で通過
+//
+// OPS_SECRET_KEY env の完全除去・設計書更新は PR-D で対応（Issue #820）。
 
 import { error } from '@sveltejs/kit';
+import { isOpsMember } from '$lib/server/auth/ops-authz';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ request, cookies }) => {
-	const secret = process.env.OPS_SECRET_KEY;
-
-	if (!secret) {
-		// OPS_SECRET_KEY 未設定時は ops ダッシュボード無効
-		error(404, 'Not Found');
+export const load: LayoutServerLoad = async ({ locals }) => {
+	if (!isOpsMember(locals.identity)) {
+		error(403, 'Forbidden');
 	}
-
-	// Bearer token (API / curl) または cookie (ブラウザセッション) で認証
-	const authHeader = request.headers.get('Authorization');
-	const cookieToken = cookies.get('ops_token');
-
-	if (authHeader === `Bearer ${secret}` || cookieToken === secret) {
-		return {};
-	}
-
-	// URL パラメータでのトークン渡し（初回アクセス用） → cookie にセット
-	const url = new URL(request.url);
-	const tokenParam = url.searchParams.get('token');
-	if (tokenParam === secret) {
-		cookies.set('ops_token', secret, {
-			path: '/ops',
-			httpOnly: true,
-			secure: process.env.AUTH_MODE === 'cognito',
-			sameSite: 'strict',
-			maxAge: 60 * 60 * 24, // 24 hours
-		});
-		return {};
-	}
-
-	error(401, 'Unauthorized');
+	return {};
 };

--- a/tests/unit/routes/ops-layout-server.test.ts
+++ b/tests/unit/routes/ops-layout-server.test.ts
@@ -1,0 +1,103 @@
+// tests/unit/routes/ops-layout-server.test.ts
+// #820 PR-C: /ops 認可を Cognito ops group ベースに切替えたことの回帰テスト。
+//
+// 旧実装（OPS_SECRET_KEY Bearer）では Bearer token が一致すれば通過していた。
+// 新実装では locals.identity に ops group 所属の Cognito identity が居ることを要求する。
+
+import { describe, expect, it } from 'vitest';
+import type { Identity } from '$lib/server/auth/types';
+import { load } from '../../../src/routes/ops/+layout.server';
+
+function makeEvent(identity: Identity | null) {
+	return {
+		locals: { identity },
+	} as unknown as Parameters<typeof load>[0];
+}
+
+function isHttpError(e: unknown): e is { status: number; body: { message: string } } {
+	return (
+		typeof e === 'object' &&
+		e !== null &&
+		'status' in e &&
+		typeof (e as { status: unknown }).status === 'number'
+	);
+}
+
+describe('#820 /ops/+layout.server.ts', () => {
+	it('identity=null は 403', async () => {
+		try {
+			await load(makeEvent(null));
+			expect.fail('403 がスローされるはず');
+		} catch (e) {
+			if (!isHttpError(e)) throw e;
+			expect(e.status).toBe(403);
+		}
+	});
+
+	it('local identity は 403', async () => {
+		try {
+			await load(makeEvent({ type: 'local' }));
+			expect.fail('403 がスローされるはず');
+		} catch (e) {
+			if (!isHttpError(e)) throw e;
+			expect(e.status).toBe(403);
+		}
+	});
+
+	it('cognito identity で groups 未指定は 403', async () => {
+		try {
+			await load(
+				makeEvent({
+					type: 'cognito',
+					userId: 'u-1',
+					email: 'a@b.com',
+				}),
+			);
+			expect.fail('403 がスローされるはず');
+		} catch (e) {
+			if (!isHttpError(e)) throw e;
+			expect(e.status).toBe(403);
+		}
+	});
+
+	it('cognito identity で groups=["random"] は 403', async () => {
+		try {
+			await load(
+				makeEvent({
+					type: 'cognito',
+					userId: 'u-1',
+					email: 'a@b.com',
+					groups: ['random'],
+				}),
+			);
+			expect.fail('403 がスローされるはず');
+		} catch (e) {
+			if (!isHttpError(e)) throw e;
+			expect(e.status).toBe(403);
+		}
+	});
+
+	it('cognito identity で groups=["ops"] は通過', async () => {
+		const result = await load(
+			makeEvent({
+				type: 'cognito',
+				userId: 'u-ops',
+				email: 'ops@example.com',
+				groups: ['ops'],
+			}),
+		);
+		expect(result).toEqual({});
+	});
+
+	it('cognito identity で groups=["ops", "other"] は通過', async () => {
+		const result = await load(
+			makeEvent({
+				type: 'cognito',
+				userId: 'u-ops',
+				email: 'ops@example.com',
+				groups: ['ops', 'other'],
+			}),
+		);
+		expect(result).toEqual({});
+	});
+});


### PR DESCRIPTION
## 概要 (refs #820)

#820 PR-C として `/ops` ダッシュボードの認可を `OPS_SECRET_KEY` 共有シークレットから
Cognito `ops` group ベースに刷新する。PR-A (#992) で Identity.groups と isOpsMember、
PR-B (#993) で ops_audit_log を整備済み。

## 変更内容

| ファイル | 変更 |
|----|----|
| `src/routes/ops/+layout.server.ts` | Bearer 認証を撤廃し `isOpsMember(locals.identity)` を必須化。非所属は 403（以前 401） |
| `infra/lib/auth-stack.ts` | `CfnUserPoolGroup('ops')` を追加（`OPS_GROUP` 定数と一致） |
| `src/lib/server/auth/providers/cognito-dev.ts` | `groups: ['ops']` 付きの dev user を追加（ops@example.com） |
| `tests/unit/routes/ops-layout-server.test.ts` | 403 / 通過の回帰テスト 6 本 |

## 受け入れ基準（PR-C 分）

- [x] Cognito ops group の CDK 定義追加
- [x] `src/routes/ops/+layout.server.ts` を Cognito ベースに書き換え
- [x] 非所属ユーザーで 403（locals.identity=null / local / groups=[] / groups=['random']）
- [x] 所属ユーザーで通過（groups=['ops'] / groups=['ops','other']）
- [x] cognito-dev mode の dev user 経由で E2E 実行可能

## PR-D への持ち越し

- `OPS_SECRET_KEY` env 完全廃止（`.env.example` / `deploy.yml` / `compute-stack.ts` の
  grep ヒット 0）
- 設計書更新（`docs/design/07-API設計書.md`, `docs/design/24-ソフトウェアアーキテクチャ設計書.md`）
- ADR 追加: /ops 認可モデル決定

## 運用メモ

本 PR がマージされると、CDK デプロイ後に AWS Cognito `ops` group が作成される。
**本番デプロイ後、次のどちらかで ops 担当者を group に追加すること:**

```bash
aws cognito-idp admin-add-user-to-group \
  --user-pool-id <pool-id> \
  --username <email> \
  --group-name ops
```

追加するまでは本番の `/ops` へアクセス可能なユーザーは存在しない（全員 403）。
**PR-D マージ前に必ず ops group にメンバーを追加しておくこと**（PR-D で
`OPS_SECRET_KEY` による代替アクセス経路が消えるため）。

## テスト

- [x] `npx biome check .` エラーなし（15 warnings は既存）
- [x] `npx svelte-check` 0 errors
- [x] `npx vitest run` 3246 tests all pass
- [ ] `npx playwright test` — CI で検証

closes part of #820