### PR TITLE
feat: #804 license_events 監査ログ + ライフサイクルイベント記録

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1082,6 +1082,32 @@ Web Push 通知の購読情報。1ブラウザ1レコード。
 
 **インデックス:** idx_viewer_tokens_tenant(tenant_id)
 
+### license_events
+
+ライセンスキーのライフサイクル監査ログ（#804）。発行 / 検証 / 消費 / 失効の各イベントを記録する。
+不正利用検知（IP ベースの失敗集計 / ブルートフォース検知）と ops 画面でのキー別履歴表示に用いる。
+
+| カラム | 型 | NULL | デフォルト | 説明 |
+|--------|------|------|-----------|------|
+| id | INTEGER | NO | autoincrement | 主キー |
+| event_type | TEXT | NO | - | `issued` / `validated` / `validation_failed` / `consumed` / `consume_failed` / `revoked` |
+| license_key | TEXT | NO | - | 対象キー。`validation_failed` で未知キーの場合は先頭 7 文字 + `...` のプレフィックスのみ（DB 膨張と偽造試行値漏洩の抑制） |
+| tenant_id | TEXT | YES | - | キーに紐づくテナントID（未割当時は NULL） |
+| actor_id | TEXT | YES | - | 操作主体。`stripe:<session>` / `ops:<uid>` / `tenant:<id>` / `system` |
+| ip | TEXT | YES | - | 発生元 IP（Cloudflare / ALB ヘッダ由来） |
+| ua | TEXT | YES | - | User-Agent |
+| metadata | TEXT | YES | - | イベント固有情報の JSON（plan, kind, expiresAt, reason 等） |
+| created_at | TEXT | NO | CURRENT_TIMESTAMP | 発生時刻（UTC） |
+
+**インデックス:**
+- idx_license_events_key(license_key, created_at) — キー別履歴
+- idx_license_events_type_created(event_type, created_at) — 最新イベント一覧
+- idx_license_events_tenant(tenant_id) — テナント別検索
+- idx_license_events_ip_created(ip, created_at) — IP 別失敗集計（ブルートフォース検知）
+
+**記録失敗時のポリシー:** license-event-service は repo の例外を内部で catch し、
+issue / validate / consume / revoke の主業務を阻害しない（監査ログ欠損 > 機能停止）。
+
 ---
 
 ## 4. Drizzle ORM スキーマ定義（TypeScript）

--- a/src/lib/server/db/create-tables.ts
+++ b/src/lib/server/db/create-tables.ts
@@ -721,4 +721,24 @@ export const SQL_CREATE_TABLES = `
 		ON ops_audit_log(created_at);
 	CREATE INDEX IF NOT EXISTS idx_ops_audit_log_action
 		ON ops_audit_log(action);
+
+	CREATE TABLE IF NOT EXISTS license_events (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		event_type TEXT NOT NULL,
+		license_key TEXT NOT NULL,
+		tenant_id TEXT,
+		actor_id TEXT,
+		ip TEXT,
+		ua TEXT,
+		metadata TEXT,
+		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	CREATE INDEX IF NOT EXISTS idx_license_events_key
+		ON license_events(license_key, created_at);
+	CREATE INDEX IF NOT EXISTS idx_license_events_type_created
+		ON license_events(event_type, created_at);
+	CREATE INDEX IF NOT EXISTS idx_license_events_tenant
+		ON license_events(tenant_id);
+	CREATE INDEX IF NOT EXISTS idx_license_events_ip_created
+		ON license_events(ip, created_at);
 `;

--- a/src/lib/server/db/dynamodb/license-event-repo.ts
+++ b/src/lib/server/db/dynamodb/license-event-repo.ts
@@ -1,36 +1,152 @@
 // src/lib/server/db/dynamodb/license-event-repo.ts
-// DynamoDB stub for ILicenseEventRepo (#804)
-// 実装は DynamoDB テーブル追加 PR で差し替える。
-// 現時点では no-op でインタフェース契約のみ満たす。
+// DynamoDB implementation of ILicenseEventRepo (#804, #1012 stub 解消)
 //
-// 予定スキーマ:
-//   PK = `LICENSE_EVENT#${licenseKey}` / SK = `EVENT#${createdAt}#${id}`
-//   GSI1 (直近イベント一覧)    : PK = 'LICENSE_EVENT_ALL' / SK = createdAt
-//   GSI2 (IP 別 fail 集計用)   : PK = `LICENSE_FAIL_IP#${ip}` / SK = createdAt
+// スキーマ:
+//   PK = `LICENSE_EVENT#${licenseKey}`
+//   SK = `EVENT#${createdAt}#${uuid}`
+//   GSI2PK = 'LICENSE_EVENT_ALL' （全イベントを単一パーティションに集約）
+//   GSI2SK = `${createdAt}#${uuid}`
+//
+// アクセスパターン:
+// - insert: PutItem
+// - findByLicenseKey(key, limit): Query PK=`LICENSE_EVENT#${key}`, SIF=false, Limit=limit
+// - findRecent(limit): Query GSI2 PK='LICENSE_EVENT_ALL', SIF=false, Limit=limit
+// - countRecentFailuresByIp(windowMin, limit): Query GSI2 PK='LICENSE_EVENT_ALL' +
+//   FilterExpression (eventType='validation_failed' + ip exists + GSI2SK>=since) を
+//   時間窓内でページング集計。小規模運用想定 (時間窓内イベント数が safetyCap=5000 以下) で許容。
 
+import { randomUUID } from 'node:crypto';
+import { PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import type {
 	InsertLicenseEventInput,
 	LicenseEventRow,
+	LicenseEventType,
 } from '../interfaces/license-event-repo.interface';
+import { GSI, getDocClient, TABLE_NAME } from './client';
 
-export async function insert(_input: InsertLicenseEventInput): Promise<void> {
-	// TODO(#804 follow-up): DynamoDB 実装。
+const LICENSE_EVENT_PK_PREFIX = 'LICENSE_EVENT#';
+const ALL_EVENTS_GSI_PK = 'LICENSE_EVENT_ALL';
+
+const doc = () => getDocClient();
+
+let _idCounter = 0;
+function nextId(): number {
+	_idCounter = (_idCounter + 1) % 100;
+	return Date.now() * 100 + _idCounter;
+}
+
+function itemToRow(item: Record<string, unknown>): LicenseEventRow {
+	return {
+		id: (item.id as number) ?? 0,
+		eventType: item.eventType as LicenseEventType,
+		licenseKey: item.licenseKey as string,
+		tenantId: (item.tenantId as string | null) ?? null,
+		actorId: (item.actorId as string | null) ?? null,
+		ip: (item.ip as string | null) ?? null,
+		ua: (item.ua as string | null) ?? null,
+		metadata: (item.metadata as string | null) ?? null,
+		createdAt: item.createdAt as string,
+	};
+}
+
+export async function insert(input: InsertLicenseEventInput): Promise<void> {
+	const createdAt = new Date().toISOString();
+	const sortToken = `${createdAt}#${randomUUID()}`;
+	const id = nextId();
+	const metadataJson =
+		input.metadata === undefined || input.metadata === null ? null : JSON.stringify(input.metadata);
+
+	await doc().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				PK: `${LICENSE_EVENT_PK_PREFIX}${input.licenseKey}`,
+				SK: `EVENT#${sortToken}`,
+				GSI2PK: ALL_EVENTS_GSI_PK,
+				GSI2SK: sortToken,
+				id,
+				eventType: input.eventType,
+				licenseKey: input.licenseKey,
+				tenantId: input.tenantId ?? null,
+				actorId: input.actorId ?? null,
+				ip: input.ip ?? null,
+				ua: input.ua ?? null,
+				metadata: metadataJson,
+				createdAt,
+			},
+		}),
+	);
 }
 
 export async function findByLicenseKey(
-	_licenseKey: string,
-	_limit: number,
+	licenseKey: string,
+	limit: number,
 ): Promise<LicenseEventRow[]> {
-	return [];
+	const resp = await doc().send(
+		new QueryCommand({
+			TableName: TABLE_NAME,
+			KeyConditionExpression: 'PK = :pk',
+			ExpressionAttributeValues: { ':pk': `${LICENSE_EVENT_PK_PREFIX}${licenseKey}` },
+			ScanIndexForward: false,
+			Limit: limit,
+		}),
+	);
+	return (resp.Items ?? []).map((it) => itemToRow(it as Record<string, unknown>));
 }
 
-export async function findRecent(_limit: number): Promise<LicenseEventRow[]> {
-	return [];
+export async function findRecent(limit: number): Promise<LicenseEventRow[]> {
+	const resp = await doc().send(
+		new QueryCommand({
+			TableName: TABLE_NAME,
+			IndexName: GSI.GSI2,
+			KeyConditionExpression: 'GSI2PK = :pk',
+			ExpressionAttributeValues: { ':pk': ALL_EVENTS_GSI_PK },
+			ScanIndexForward: false,
+			Limit: limit,
+		}),
+	);
+	return (resp.Items ?? []).map((it) => itemToRow(it as Record<string, unknown>));
 }
 
 export async function countRecentFailuresByIp(
-	_windowMinutes: number,
-	_limit: number,
+	windowMinutes: number,
+	limit: number,
 ): Promise<Array<{ ip: string; count: number }>> {
-	return [];
+	const since = new Date(Date.now() - windowMinutes * 60 * 1000).toISOString();
+	const sinceToken = `${since}#`;
+
+	const counts = new Map<string, number>();
+	let lastKey: Record<string, unknown> | undefined;
+	const safetyCap = 5000;
+	let scanned = 0;
+
+	do {
+		const resp = await doc().send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				IndexName: GSI.GSI2,
+				KeyConditionExpression: 'GSI2PK = :pk AND GSI2SK >= :since',
+				FilterExpression: 'eventType = :ft AND attribute_exists(ip)',
+				ExpressionAttributeValues: {
+					':pk': ALL_EVENTS_GSI_PK,
+					':since': sinceToken,
+					':ft': 'validation_failed',
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of resp.Items ?? []) {
+			const ip = (item as Record<string, unknown>).ip as string | null;
+			if (!ip) continue;
+			counts.set(ip, (counts.get(ip) ?? 0) + 1);
+		}
+		scanned += resp.ScannedCount ?? 0;
+		lastKey = resp.LastEvaluatedKey;
+		if (scanned >= safetyCap) break;
+	} while (lastKey);
+
+	return [...counts.entries()]
+		.map(([ip, count]) => ({ ip, count }))
+		.sort((a, b) => b.count - a.count)
+		.slice(0, limit);
 }

--- a/src/lib/server/db/dynamodb/license-event-repo.ts
+++ b/src/lib/server/db/dynamodb/license-event-repo.ts
@@ -1,0 +1,36 @@
+// src/lib/server/db/dynamodb/license-event-repo.ts
+// DynamoDB stub for ILicenseEventRepo (#804)
+// 実装は DynamoDB テーブル追加 PR で差し替える。
+// 現時点では no-op でインタフェース契約のみ満たす。
+//
+// 予定スキーマ:
+//   PK = `LICENSE_EVENT#${licenseKey}` / SK = `EVENT#${createdAt}#${id}`
+//   GSI1 (直近イベント一覧)    : PK = 'LICENSE_EVENT_ALL' / SK = createdAt
+//   GSI2 (IP 別 fail 集計用)   : PK = `LICENSE_FAIL_IP#${ip}` / SK = createdAt
+
+import type {
+	InsertLicenseEventInput,
+	LicenseEventRow,
+} from '../interfaces/license-event-repo.interface';
+
+export async function insert(_input: InsertLicenseEventInput): Promise<void> {
+	// TODO(#804 follow-up): DynamoDB 実装。
+}
+
+export async function findByLicenseKey(
+	_licenseKey: string,
+	_limit: number,
+): Promise<LicenseEventRow[]> {
+	return [];
+}
+
+export async function findRecent(_limit: number): Promise<LicenseEventRow[]> {
+	return [];
+}
+
+export async function countRecentFailuresByIp(
+	_windowMinutes: number,
+	_limit: number,
+): Promise<Array<{ ip: string; count: number }>> {
+	return [];
+}

--- a/src/lib/server/db/factory.ts
+++ b/src/lib/server/db/factory.ts
@@ -15,6 +15,7 @@ import * as dynamoDailyMissionRepo from './dynamodb/daily-mission-repo';
 import * as dynamoEvaluationRepo from './dynamodb/evaluation-repo';
 import * as dynamoImageRepo from './dynamodb/image-repo';
 import * as dynamoInquiryRepo from './dynamodb/inquiry-repo';
+import * as dynamoLicenseEventRepo from './dynamodb/license-event-repo';
 import * as dynamoLoginBonusRepo from './dynamodb/login-bonus-repo';
 import * as dynamoMessageRepo from './dynamodb/message-repo';
 import * as dynamoOpsAuditLogRepo from './dynamodb/ops-audit-log-repo';
@@ -47,6 +48,7 @@ import type { IDailyMissionRepo } from './interfaces/daily-mission-repo.interfac
 import type { IEvaluationRepo } from './interfaces/evaluation-repo.interface';
 import type { IImageRepo } from './interfaces/image-repo.interface';
 import type { IInquiryRepo } from './interfaces/inquiry-repo.interface';
+import type { ILicenseEventRepo } from './interfaces/license-event-repo.interface';
 import type { ILoginBonusRepo } from './interfaces/login-bonus-repo.interface';
 import type { IMessageRepo } from './interfaces/message-repo.interface';
 import type { IOpsAuditLogRepo } from './interfaces/ops-audit-log-repo.interface';
@@ -79,6 +81,7 @@ import * as sqliteDailyMissionRepo from './sqlite/daily-mission-repo';
 import * as sqliteEvaluationRepo from './sqlite/evaluation-repo';
 import * as sqliteImageRepo from './sqlite/image-repo';
 import * as sqliteInquiryRepo from './sqlite/inquiry-repo';
+import * as sqliteLicenseEventRepo from './sqlite/license-event-repo';
 import * as sqliteLoginBonusRepo from './sqlite/login-bonus-repo';
 import * as sqliteMessageRepo from './sqlite/message-repo';
 import * as sqliteOpsAuditLogRepo from './sqlite/ops-audit-log-repo';
@@ -113,6 +116,7 @@ export interface Repositories {
 	evaluation: IEvaluationRepo;
 	image: IImageRepo;
 	inquiry: IInquiryRepo;
+	licenseEvent: ILicenseEventRepo;
 	loginBonus: ILoginBonusRepo;
 	message: IMessageRepo;
 	opsAuditLog: IOpsAuditLogRepo;
@@ -155,6 +159,7 @@ export function getRepos(): Repositories {
 			evaluation: dynamoEvaluationRepo,
 			image: dynamoImageRepo,
 			inquiry: dynamoInquiryRepo,
+			licenseEvent: dynamoLicenseEventRepo,
 			loginBonus: dynamoLoginBonusRepo,
 			message: dynamoMessageRepo,
 			opsAuditLog: dynamoOpsAuditLogRepo,
@@ -193,6 +198,7 @@ export function getRepos(): Repositories {
 		evaluation: sqliteEvaluationRepo,
 		image: sqliteImageRepo,
 		inquiry: sqliteInquiryRepo,
+		licenseEvent: sqliteLicenseEventRepo,
 		loginBonus: sqliteLoginBonusRepo,
 		message: sqliteMessageRepo,
 		opsAuditLog: sqliteOpsAuditLogRepo,

--- a/src/lib/server/db/interfaces/license-event-repo.interface.ts
+++ b/src/lib/server/db/interfaces/license-event-repo.interface.ts
@@ -1,0 +1,51 @@
+// src/lib/server/db/interfaces/license-event-repo.interface.ts
+// #804: ライセンスキーライフサイクル監査ログ
+
+export type LicenseEventType =
+	| 'issued'
+	| 'validated'
+	| 'validation_failed'
+	| 'consumed'
+	| 'consume_failed'
+	| 'revoked';
+
+export interface LicenseEventRow {
+	id: number;
+	eventType: LicenseEventType;
+	licenseKey: string;
+	tenantId: string | null;
+	actorId: string | null;
+	ip: string | null;
+	ua: string | null;
+	/** JSON 文字列。呼び出し側でパース */
+	metadata: string | null;
+	createdAt: string;
+}
+
+export interface InsertLicenseEventInput {
+	eventType: LicenseEventType;
+	/** 完全なキー or 未知キーの先頭 7 文字 + '...' */
+	licenseKey: string;
+	tenantId?: string | null;
+	actorId?: string | null;
+	ip?: string | null;
+	ua?: string | null;
+	/** 任意の構造化メタ。repo 層で JSON 文字列化する */
+	metadata?: Record<string, unknown> | null;
+}
+
+export interface ILicenseEventRepo {
+	insert(input: InsertLicenseEventInput): Promise<void>;
+	/** 特定キーのイベント履歴を時系列降順で取得 (ops ダッシュボード用) */
+	findByLicenseKey(licenseKey: string, limit: number): Promise<LicenseEventRow[]>;
+	/** 直近 N 件 (ops 一覧用) */
+	findRecent(limit: number): Promise<LicenseEventRow[]>;
+	/**
+	 * 指定時間窓内の validation_failed の件数を ip ごとに集計する（ブルートフォース検知）。
+	 * 返却: `[{ ip, count }]` (ip が null のものは集計対象外)
+	 */
+	countRecentFailuresByIp(
+		windowMinutes: number,
+		limit: number,
+	): Promise<Array<{ ip: string; count: number }>>;
+}

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1010,6 +1010,47 @@ export const enemyCollection = sqliteTable(
 );
 
 // ============================================================
+// license_events - ライセンスキーライフサイクル監査ログ (#804)
+// ============================================================
+//
+// `issueLicenseKey` / `validateLicenseKey` / `consumeLicenseKey` / `revokeLicenseKey`
+// の各操作をキー別に永続化し、CS 対応・不正利用検知 (validate 失敗の多発 = ブルートフォース)
+// ・返金時の証跡・法的開示請求に備える。
+// DynamoDB 側は PK='LICENSE_EVENT#<licenseKey>', SK='EVENT#<createdAt>' を想定。
+//
+// 設計判断:
+// - `licenseKey` は validation_failed でも検索性のため保存するが、存在しないキーは
+//   先頭 7 文字 + '...' を入れて DB 膨張抑制 + 偽造試行値の漏洩抑制を両立する。
+// - `actorId` は 'stripe:<session>' / 'ops:<uid>' / 'tenant:<id>' / 'system' / null
+//   のいずれか。呼び出し側のコンテキストで決まる。
+// - `metadata` は JSON 文字列。reason / plan / kind / expiresAt / revokedBy 等を格納。
+export const licenseEvents = sqliteTable(
+	'license_events',
+	{
+		id: integer('id').primaryKey({ autoIncrement: true }),
+		/** 'issued' | 'validated' | 'validation_failed' | 'consumed' | 'consume_failed' | 'revoked' */
+		eventType: text('event_type').notNull(),
+		/** 対象ライセンスキー。validation_failed の未知キーは先頭 7 文字 + '...' */
+		licenseKey: text('license_key').notNull(),
+		/** 関連テナント。発行先 or 消費者。nullable */
+		tenantId: text('tenant_id'),
+		/** 操作主体。'stripe:<s>' / 'ops:<uid>' / 'tenant:<id>' / 'system' / null */
+		actorId: text('actor_id'),
+		ip: text('ip'),
+		ua: text('ua'),
+		/** 追加メタ情報 (JSON 文字列)。reason / plan / kind / revokedBy 等 */
+		metadata: text('metadata'),
+		createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
+	},
+	(table) => [
+		index('idx_license_events_key').on(table.licenseKey, table.createdAt),
+		index('idx_license_events_type_created').on(table.eventType, table.createdAt),
+		index('idx_license_events_tenant').on(table.tenantId, table.createdAt),
+		index('idx_license_events_ip_created').on(table.ip, table.createdAt),
+	],
+);
+
+// ============================================================
 // ops_audit_log - /ops 運営ダッシュボード操作監査 (#820)
 // ============================================================
 //

--- a/src/lib/server/db/sqlite/license-event-repo.ts
+++ b/src/lib/server/db/sqlite/license-event-repo.ts
@@ -1,0 +1,84 @@
+// src/lib/server/db/sqlite/license-event-repo.ts
+// SQLite implementation of ILicenseEventRepo (#804)
+
+import { and, desc, eq, gte, isNotNull, sql } from 'drizzle-orm';
+import { db } from '../client';
+import type {
+	InsertLicenseEventInput,
+	LicenseEventRow,
+	LicenseEventType,
+} from '../interfaces/license-event-repo.interface';
+import { licenseEvents } from '../schema';
+
+function rowFromRecord(r: typeof licenseEvents.$inferSelect): LicenseEventRow {
+	return {
+		id: r.id,
+		eventType: r.eventType as LicenseEventType,
+		licenseKey: r.licenseKey,
+		tenantId: r.tenantId,
+		actorId: r.actorId,
+		ip: r.ip,
+		ua: r.ua,
+		metadata: r.metadata,
+		createdAt: r.createdAt,
+	};
+}
+
+export async function insert(input: InsertLicenseEventInput): Promise<void> {
+	await db.insert(licenseEvents).values({
+		eventType: input.eventType,
+		licenseKey: input.licenseKey,
+		tenantId: input.tenantId ?? null,
+		actorId: input.actorId ?? null,
+		ip: input.ip ?? null,
+		ua: input.ua ?? null,
+		metadata:
+			input.metadata === undefined || input.metadata === null
+				? null
+				: JSON.stringify(input.metadata),
+	});
+}
+
+export async function findByLicenseKey(
+	licenseKey: string,
+	limit: number,
+): Promise<LicenseEventRow[]> {
+	const rows = await db
+		.select()
+		.from(licenseEvents)
+		.where(eq(licenseEvents.licenseKey, licenseKey))
+		.orderBy(desc(licenseEvents.id))
+		.limit(limit);
+	return rows.map(rowFromRecord);
+}
+
+export async function findRecent(limit: number): Promise<LicenseEventRow[]> {
+	const rows = await db.select().from(licenseEvents).orderBy(desc(licenseEvents.id)).limit(limit);
+	return rows.map(rowFromRecord);
+}
+
+export async function countRecentFailuresByIp(
+	windowMinutes: number,
+	limit: number,
+): Promise<Array<{ ip: string; count: number }>> {
+	const since = new Date(Date.now() - windowMinutes * 60 * 1000).toISOString();
+	const rows = await db
+		.select({
+			ip: licenseEvents.ip,
+			count: sql<number>`count(*)`.as('count'),
+		})
+		.from(licenseEvents)
+		.where(
+			and(
+				eq(licenseEvents.eventType, 'validation_failed'),
+				gte(licenseEvents.createdAt, since),
+				isNotNull(licenseEvents.ip),
+			),
+		)
+		.groupBy(licenseEvents.ip)
+		.orderBy(desc(sql`count`))
+		.limit(limit);
+	return rows
+		.filter((r): r is { ip: string; count: number } => r.ip !== null)
+		.map((r) => ({ ip: r.ip, count: Number(r.count) }));
+}

--- a/src/lib/server/services/license-event-service.ts
+++ b/src/lib/server/services/license-event-service.ts
@@ -1,0 +1,119 @@
+// src/lib/server/services/license-event-service.ts
+// #804: ライセンスキー監査ログサービス
+//
+// license-key-service の各ライフサイクル操作から呼ばれる。記録失敗は呼び出し元の
+// ビジネスロジックを阻害してはならない（監査ログが落ちても本処理は完走させる）。
+// ops 側の一覧 / キー別履歴 / IP 別失敗集計 もここから提供する。
+
+import { getRepos } from '$lib/server/db/factory';
+import type {
+	LicenseEventRow,
+	LicenseEventType,
+} from '$lib/server/db/interfaces/license-event-repo.interface';
+import { logger } from '$lib/server/logger';
+
+/**
+ * ライセンスキーの先頭プレフィックスのみ取り出す。
+ * validation_failed で未知キーが入力された場合に、
+ * DB 膨張と偽造試行値の漏洩を抑えるために使う。
+ */
+export function licenseKeyPrefix(key: string, len = 7): string {
+	const normalized = (key ?? '').toString().toUpperCase().trim();
+	if (normalized.length <= len) return normalized;
+	return `${normalized.slice(0, len)}...`;
+}
+
+export interface LicenseEventContext {
+	/** 'stripe:<session>' / 'ops:<uid>' / 'tenant:<id>' / 'system' / null */
+	actorId?: string | null;
+	tenantId?: string | null;
+	ip?: string | null;
+	ua?: string | null;
+}
+
+export interface RecordLicenseEventInput extends LicenseEventContext {
+	eventType: LicenseEventType;
+	licenseKey: string;
+	metadata?: Record<string, unknown> | null;
+}
+
+export async function recordLicenseEvent(input: RecordLicenseEventInput): Promise<void> {
+	try {
+		await getRepos().licenseEvent.insert({
+			eventType: input.eventType,
+			licenseKey: input.licenseKey,
+			tenantId: input.tenantId ?? null,
+			actorId: input.actorId ?? null,
+			ip: input.ip ?? null,
+			ua: input.ua ?? null,
+			metadata: input.metadata ?? null,
+		});
+	} catch (e) {
+		logger.error('[LICENSE_EVENT] Failed to record event', {
+			context: {
+				eventType: input.eventType,
+				keyPrefix: licenseKeyPrefix(input.licenseKey),
+				error: e instanceof Error ? e.message : String(e),
+			},
+		});
+	}
+}
+
+export interface LicenseEventEntry {
+	id: number;
+	eventType: LicenseEventType;
+	licenseKey: string;
+	tenantId: string | null;
+	actorId: string | null;
+	ip: string | null;
+	ua: string | null;
+	metadata: Record<string, unknown> | null;
+	createdAt: string;
+}
+
+function parseMetadata(raw: string | null): Record<string, unknown> | null {
+	if (!raw) return null;
+	try {
+		const parsed = JSON.parse(raw);
+		return typeof parsed === 'object' && parsed !== null
+			? (parsed as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function toEntry(row: LicenseEventRow): LicenseEventEntry {
+	return {
+		id: row.id,
+		eventType: row.eventType,
+		licenseKey: row.licenseKey,
+		tenantId: row.tenantId,
+		actorId: row.actorId,
+		ip: row.ip,
+		ua: row.ua,
+		metadata: parseMetadata(row.metadata),
+		createdAt: row.createdAt,
+	};
+}
+
+export async function listEventsByLicenseKey(
+	licenseKey: string,
+	limit = 100,
+): Promise<LicenseEventEntry[]> {
+	const normalized = licenseKey.toUpperCase().trim();
+	const rows = await getRepos().licenseEvent.findByLicenseKey(normalized, limit);
+	return rows.map(toEntry);
+}
+
+export async function listRecentEvents(limit = 100): Promise<LicenseEventEntry[]> {
+	const rows = await getRepos().licenseEvent.findRecent(limit);
+	return rows.map(toEntry);
+}
+
+export async function countRecentFailuresByIp(
+	windowMinutes = 10,
+	limit = 20,
+): Promise<Array<{ ip: string; count: number }>> {
+	return getRepos().licenseEvent.countRecentFailuresByIp(windowMinutes, limit);
+}

--- a/src/lib/server/services/license-key-service.ts
+++ b/src/lib/server/services/license-key-service.ts
@@ -10,6 +10,11 @@ import { type LicensePlan, planDurationDays } from '$lib/domain/constants/licens
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
+import {
+	type LicenseEventContext,
+	licenseKeyPrefix,
+	recordLicenseEvent,
+} from '$lib/server/services/license-event-service';
 
 // ============================================================
 // 定数
@@ -217,6 +222,8 @@ export async function issueLicenseKey(params: {
 	 * 明示的に `null` を渡すと期限なし（lifetime 的扱い）。ops 発行で使用。
 	 */
 	expiresAt?: string | null;
+	/** #804: 監査ログ用コンテキスト (ip/ua)。actorId は issuedBy / stripeSessionId から自動解決。 */
+	context?: Pick<LicenseEventContext, 'ip' | 'ua'>;
 }): Promise<LicenseRecord> {
 	const kind = params.kind ?? 'purchase';
 
@@ -265,12 +272,33 @@ export async function issueLicenseKey(params: {
 	logger.info(
 		`[LICENSE] Key issued: ${key.slice(0, 7)}... for tenant=${params.tenantId} plan=${params.plan} kind=${kind} expiresAt=${expiresAt ?? 'never'}`,
 	);
+
+	// #804: 監査ログに issued イベント記録
+	const issuedActor =
+		params.issuedBy ?? (params.stripeSessionId ? `stripe:${params.stripeSessionId}` : 'system');
+	await recordLicenseEvent({
+		eventType: 'issued',
+		licenseKey: key,
+		tenantId: params.tenantId,
+		actorId: issuedActor,
+		ip: params.context?.ip ?? null,
+		ua: params.context?.ua ?? null,
+		metadata: {
+			plan: params.plan,
+			kind,
+			expiresAt: expiresAt ?? null,
+			stripeSessionId: params.stripeSessionId ?? null,
+		},
+	});
+
 	return record;
 }
 
 /** ライセンスキーを検証 (署名チェック + DB 存在チェック + active 状態チェック) */
 export async function validateLicenseKey(
 	key: string,
+	/** #804: 監査ログ用コンテキスト (ip/ua/actor/tenant)。省略時は null で記録。 */
+	context?: LicenseEventContext,
 ): Promise<{ valid: true; record: LicenseRecord } | { valid: false; reason: string }> {
 	const normalized = key.toUpperCase().trim();
 
@@ -278,7 +306,26 @@ export async function validateLicenseKey(
 	const isLegacy = LEGACY_FORMAT.test(normalized);
 	const isSigned = SIGNED_FORMAT.test(normalized);
 
+	// #804: validation_failed の共通記録ヘルパ。
+	// 未知キー (DB に無い形式不正 or 署名不一致) は prefix のみ保存して DB 膨張 + 偽造試行値
+	// の漏洩を抑える。findLicenseKey まで進んだ場合はレコード側と紐付けたいので full key。
+	const recordFailure = async (
+		reason: string,
+		options?: { useFullKey?: boolean; extra?: Record<string, unknown> },
+	) => {
+		await recordLicenseEvent({
+			eventType: 'validation_failed',
+			licenseKey: options?.useFullKey ? normalized : licenseKeyPrefix(normalized),
+			tenantId: context?.tenantId ?? null,
+			actorId: context?.actorId ?? null,
+			ip: context?.ip ?? null,
+			ua: context?.ua ?? null,
+			metadata: { reason, ...(options?.extra ?? {}) },
+		});
+	};
+
 	if (!isLegacy && !isSigned) {
+		await recordFailure('format_invalid');
 		return { valid: false, reason: 'ライセンスキーの形式が不正です' };
 	}
 
@@ -290,6 +337,7 @@ export async function validateLicenseKey(
 			`[LICENSE] Legacy format rejected in production: ${normalized.slice(0, 7)}... ` +
 				`Set ALLOW_LEGACY_LICENSE_KEYS=true to temporarily permit (migration window only).`,
 		);
+		await recordFailure('legacy_format_rejected');
 		return { valid: false, reason: 'ライセンスキーが不正です' };
 	}
 
@@ -298,6 +346,7 @@ export async function validateLicenseKey(
 		const secret = getLicenseSecret();
 		if (secret && !verifyKeySignature(normalized, secret)) {
 			logger.warn(`[LICENSE] Signature verification failed: ${normalized.slice(0, 7)}...`);
+			await recordFailure('signature_mismatch');
 			return { valid: false, reason: 'ライセンスキーが不正です' };
 		}
 	}
@@ -311,14 +360,23 @@ export async function validateLicenseKey(
 	const record = await repos.auth.findLicenseKey(normalized);
 
 	if (!record) {
+		await recordFailure('not_found');
 		return { valid: false, reason: 'ライセンスキーが見つかりません' };
 	}
 
 	if (record.status === LICENSE_KEY_STATUS.CONSUMED) {
+		await recordFailure('already_consumed', {
+			useFullKey: true,
+			extra: { issuedFor: record.tenantId },
+		});
 		return { valid: false, reason: 'このライセンスキーは既に使用されています' };
 	}
 
 	if (record.status === LICENSE_KEY_STATUS.REVOKED) {
+		await recordFailure('revoked', {
+			useFullKey: true,
+			extra: { revokedReason: record.revokedReason ?? null },
+		});
 		return { valid: false, reason: 'このライセンスキーは無効化されています' };
 	}
 
@@ -328,8 +386,23 @@ export async function validateLicenseKey(
 		logger.info(
 			`[LICENSE] Expired key rejected: ${normalized.slice(0, 7)}... expiresAt=${record.expiresAt}`,
 		);
+		await recordFailure('expired', {
+			useFullKey: true,
+			extra: { expiresAt: record.expiresAt ?? null },
+		});
 		return { valid: false, reason: 'このライセンスキーは有効期限が切れています' };
 	}
+
+	// #804: 検証成功を記録 (ブルートフォース検知の母数にもなる)
+	await recordLicenseEvent({
+		eventType: 'validated',
+		licenseKey: normalized,
+		tenantId: context?.tenantId ?? record.tenantId,
+		actorId: context?.actorId ?? null,
+		ip: context?.ip ?? null,
+		ua: context?.ua ?? null,
+		metadata: { plan: record.plan, kind: getRecordKind(record) },
+	});
 
 	return { valid: true, record };
 }
@@ -391,21 +464,49 @@ function computePlanExpiresAt(
 export async function consumeLicenseKey(
 	key: string,
 	consumedByTenantId: string,
+	/** #804: 監査ログ用コンテキスト (ip/ua)。actorId は 'tenant:<id>' を自動付与。 */
+	context?: Pick<LicenseEventContext, 'ip' | 'ua'>,
 ): Promise<ConsumeLicenseKeyResult> {
 	const normalized = key.toUpperCase().trim();
 	const repos = getRepos();
 
+	const ip = context?.ip ?? null;
+	const ua = context?.ua ?? null;
+	const actorId = `tenant:${consumedByTenantId}`;
+	const recordFailure = async (reason: string, extra?: Record<string, unknown>) =>
+		recordLicenseEvent({
+			eventType: 'consume_failed',
+			licenseKey: normalized,
+			tenantId: consumedByTenantId,
+			actorId,
+			ip,
+			ua,
+			metadata: { reason, ...(extra ?? {}) },
+		});
+
 	const record = await repos.auth.findLicenseKey(normalized);
 	if (!record) {
+		await recordLicenseEvent({
+			eventType: 'consume_failed',
+			licenseKey: licenseKeyPrefix(normalized),
+			tenantId: consumedByTenantId,
+			actorId,
+			ip,
+			ua,
+			metadata: { reason: 'not_found' },
+		});
 		return { ok: false, reason: 'ライセンスキーが見つかりません' };
 	}
 	if (record.status === LICENSE_KEY_STATUS.CONSUMED) {
+		await recordFailure('already_consumed', { issuedFor: record.tenantId });
 		return { ok: false, reason: 'このライセンスキーは既に使用されています' };
 	}
 	if (record.status === LICENSE_KEY_STATUS.REVOKED) {
+		await recordFailure('revoked', { revokedReason: record.revokedReason ?? null });
 		return { ok: false, reason: 'このライセンスキーは無効化されています' };
 	}
 	if (record.status !== LICENSE_KEY_STATUS.ACTIVE) {
+		await recordFailure('not_active', { status: record.status });
 		return { ok: false, reason: 'ライセンスキーが使用できません' };
 	}
 
@@ -414,6 +515,7 @@ export async function consumeLicenseKey(
 		logger.info(
 			`[LICENSE] Expired key consume rejected: ${normalized.slice(0, 7)}... expiresAt=${record.expiresAt}`,
 		);
+		await recordFailure('expired', { expiresAt: record.expiresAt ?? null });
 		return { ok: false, reason: 'このライセンスキーは有効期限が切れています' };
 	}
 
@@ -427,6 +529,10 @@ export async function consumeLicenseKey(
 		logger.warn(
 			`[LICENSE] Cross-tenant purchase consume rejected: key=${normalized.slice(0, 7)}... issued_for=${record.tenantId} attempted_by=${consumedByTenantId}`,
 		);
+		await recordFailure('cross_tenant_purchase', {
+			issuedFor: record.tenantId,
+			kind,
+		});
 		return {
 			ok: false,
 			reason: 'このライセンスキーは購入したアカウントでのみ使用できます',
@@ -453,6 +559,23 @@ export async function consumeLicenseKey(
 	logger.info(
 		`[LICENSE] Key consumed: ${normalized.slice(0, 7)}... by tenant=${consumedByTenantId} (issued for=${record.tenantId}, kind=${kind}) plan=${record.plan} expiresAt=${planExpiresAt ?? 'never'}`,
 	);
+
+	// #804: 監査ログに consumed イベント記録
+	await recordLicenseEvent({
+		eventType: 'consumed',
+		licenseKey: normalized,
+		tenantId: consumedByTenantId,
+		actorId,
+		ip,
+		ua,
+		metadata: {
+			plan: record.plan,
+			kind,
+			issuedFor: record.tenantId,
+			planExpiresAt: planExpiresAt ?? null,
+		},
+	});
+
 	return { ok: true, plan: record.plan, planExpiresAt };
 }
 
@@ -481,6 +604,8 @@ export async function revokeLicenseKey(params: {
 	licenseKey: string;
 	reason: LicenseRevokeReason;
 	revokedBy: string;
+	/** #804: 監査ログ用コンテキスト (ip/ua)。actorId は revokedBy を使う。 */
+	context?: Pick<LicenseEventContext, 'ip' | 'ua'>;
 }): Promise<RevokeLicenseKeyResult> {
 	const normalized = params.licenseKey.toUpperCase().trim();
 	const repos = getRepos();
@@ -513,6 +638,21 @@ export async function revokeLicenseKey(params: {
 	logger.warn(
 		`[LICENSE] Key revoked: ${normalized.slice(0, 7)}... reason=${params.reason} by=${params.revokedBy}`,
 	);
+
+	// #804: 監査ログに revoked イベント記録
+	await recordLicenseEvent({
+		eventType: 'revoked',
+		licenseKey: normalized,
+		tenantId: record.tenantId,
+		actorId: params.revokedBy,
+		ip: params.context?.ip ?? null,
+		ua: params.context?.ua ?? null,
+		metadata: {
+			reason: params.reason,
+			plan: record.plan,
+			kind: getRecordKind(record),
+		},
+	});
 
 	return { ok: true, licenseKey: normalized, revokedReason: params.reason, revokedAt };
 }

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -554,6 +554,26 @@ export default async function globalSetup() {
 			CREATE INDEX IF NOT EXISTS idx_ops_audit_log_action
 				ON ops_audit_log(action);
 
+			CREATE TABLE IF NOT EXISTS license_events (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				event_type TEXT NOT NULL,
+				license_key TEXT NOT NULL,
+				tenant_id TEXT,
+				actor_id TEXT,
+				ip TEXT,
+				ua TEXT,
+				metadata TEXT,
+				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+			);
+			CREATE INDEX IF NOT EXISTS idx_license_events_key
+				ON license_events(license_key, created_at);
+			CREATE INDEX IF NOT EXISTS idx_license_events_type_created
+				ON license_events(event_type, created_at);
+			CREATE INDEX IF NOT EXISTS idx_license_events_tenant
+				ON license_events(tenant_id);
+			CREATE INDEX IF NOT EXISTS idx_license_events_ip_created
+				ON license_events(ip, created_at);
+
 		`);
 
 		// リアルな過去の活動ログを追加（ステータス画面・レーダーチャートの表示用）

--- a/tests/unit/helpers/test-db.ts
+++ b/tests/unit/helpers/test-db.ts
@@ -760,6 +760,25 @@ export const SQL_TABLES = `
 	CREATE INDEX idx_ops_audit_log_actor ON ops_audit_log(actor_id);
 	CREATE INDEX idx_ops_audit_log_created ON ops_audit_log(created_at);
 	CREATE INDEX idx_ops_audit_log_action ON ops_audit_log(action);
+
+	-- ============================================================
+	-- license_events (#804)
+	-- ============================================================
+	CREATE TABLE license_events (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		event_type TEXT NOT NULL,
+		license_key TEXT NOT NULL,
+		tenant_id TEXT,
+		actor_id TEXT,
+		ip TEXT,
+		ua TEXT,
+		metadata TEXT,
+		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	CREATE INDEX idx_license_events_key ON license_events(license_key, created_at);
+	CREATE INDEX idx_license_events_type_created ON license_events(event_type, created_at);
+	CREATE INDEX idx_license_events_tenant ON license_events(tenant_id, created_at);
+	CREATE INDEX idx_license_events_ip_created ON license_events(ip, created_at);
 `;
 
 // ============================================================
@@ -767,6 +786,7 @@ export const SQL_TABLES = `
 // ============================================================
 
 const ALL_TABLES = [
+	'license_events',
 	'ops_audit_log',
 	'enemy_collection',
 	'daily_battles',

--- a/tests/unit/services/license-key-service.test.ts
+++ b/tests/unit/services/license-key-service.test.ts
@@ -9,6 +9,10 @@ const mockFindLicenseKey = vi.fn();
 const mockUpdateLicenseKeyStatus = vi.fn();
 const mockUpdateTenantStripe = vi.fn();
 const mockRevokeLicenseKey = vi.fn();
+const mockLicenseEventInsert = vi.fn();
+const mockLicenseEventFindByKey = vi.fn();
+const mockLicenseEventFindRecent = vi.fn();
+const mockLicenseEventCountFailures = vi.fn();
 
 vi.mock('$lib/server/db/factory', () => ({
 	getRepos: () => ({
@@ -18,6 +22,12 @@ vi.mock('$lib/server/db/factory', () => ({
 			updateLicenseKeyStatus: (...args: unknown[]) => mockUpdateLicenseKeyStatus(...args),
 			updateTenantStripe: (...args: unknown[]) => mockUpdateTenantStripe(...args),
 			revokeLicenseKey: (...args: unknown[]) => mockRevokeLicenseKey(...args),
+		},
+		licenseEvent: {
+			insert: (...args: unknown[]) => mockLicenseEventInsert(...args),
+			findByLicenseKey: (...args: unknown[]) => mockLicenseEventFindByKey(...args),
+			findRecent: (...args: unknown[]) => mockLicenseEventFindRecent(...args),
+			countRecentFailuresByIp: (...args: unknown[]) => mockLicenseEventCountFailures(...args),
 		},
 	}),
 }));
@@ -1467,5 +1477,288 @@ describe('revokeLicenseKey (#797)', () => {
 		if (!validateResult.valid) {
 			expect(validateResult.reason).toContain('無効');
 		}
+	});
+});
+
+// ============================================================
+// #804: ライセンスキー監査ログ (license_events) の記録
+// ============================================================
+
+describe('ライセンスキー監査ログ記録 (#804)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockSaveLicenseKey.mockResolvedValue(undefined);
+		mockUpdateLicenseKeyStatus.mockResolvedValue(undefined);
+		mockUpdateTenantStripe.mockResolvedValue(undefined);
+		mockRevokeLicenseKey.mockResolvedValue(undefined);
+		mockLicenseEventInsert.mockResolvedValue(undefined);
+		process.env.AWS_LICENSE_SECRET = '';
+	});
+
+	afterEach(() => {
+		process.env.AWS_LICENSE_SECRET = '';
+	});
+
+	describe('issueLicenseKey', () => {
+		it('Stripe webhook 経由の発行で issued イベントを記録する', async () => {
+			const result = await issueLicenseKey({
+				tenantId: 'tenant-issue-1',
+				plan: 'monthly',
+				stripeSessionId: 'cs_test_evt',
+			});
+
+			expect(mockLicenseEventInsert).toHaveBeenCalledTimes(1);
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('issued');
+			expect(call.licenseKey).toBe(result.licenseKey);
+			expect(call.tenantId).toBe('tenant-issue-1');
+			expect(call.actorId).toBe('stripe:cs_test_evt');
+			expect(call.metadata.plan).toBe('monthly');
+			expect(call.metadata.kind).toBe('purchase');
+			expect(call.metadata.stripeSessionId).toBe('cs_test_evt');
+		});
+
+		it('gift キーの発行で actorId に issuedBy を記録する', async () => {
+			await issueLicenseKey({
+				tenantId: 'tenant-gift',
+				plan: 'lifetime',
+				kind: 'gift',
+				issuedBy: 'ops:admin-1',
+				expiresAt: null,
+			});
+
+			expect(mockLicenseEventInsert).toHaveBeenCalledTimes(1);
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('issued');
+			expect(call.actorId).toBe('ops:admin-1');
+			expect(call.metadata.kind).toBe('gift');
+			expect(call.metadata.expiresAt).toBeNull();
+		});
+
+		it('context (ip/ua) を渡すと監査ログに保存される', async () => {
+			await issueLicenseKey({
+				tenantId: 'tenant-ctx',
+				plan: 'yearly',
+				kind: 'campaign',
+				issuedBy: 'ops:admin-2',
+				context: { ip: '203.0.113.5', ua: 'ops-cli/1.0' },
+			});
+
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.ip).toBe('203.0.113.5');
+			expect(call.ua).toBe('ops-cli/1.0');
+		});
+	});
+
+	describe('validateLicenseKey', () => {
+		it('形式不正 → validation_failed (prefix のみ、reason=format_invalid)', async () => {
+			const result = await validateLicenseKey('INVALID-KEY');
+			expect(result.valid).toBe(false);
+
+			expect(mockLicenseEventInsert).toHaveBeenCalledTimes(1);
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('validation_failed');
+			expect(call.licenseKey.length).toBeLessThanOrEqual(11); // prefix + '...'
+			expect(call.metadata.reason).toBe('format_invalid');
+		});
+
+		it('存在しないキー → validation_failed (prefix, reason=not_found)', async () => {
+			mockFindLicenseKey.mockResolvedValueOnce(null);
+			await validateLicenseKey('GQ-AAAA-BBBB-CCCC');
+
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('validation_failed');
+			expect(call.licenseKey).toContain('...'); // prefix + '...'
+			expect(call.metadata.reason).toBe('not_found');
+		});
+
+		it('consumed キー → validation_failed (full key, reason=already_consumed)', async () => {
+			mockFindLicenseKey.mockResolvedValueOnce({
+				licenseKey: 'GQ-AAAA-BBBB-CCCC',
+				tenantId: 'tenant-x',
+				plan: 'monthly',
+				status: 'consumed',
+				createdAt: '2026-01-01T00:00:00Z',
+			} satisfies LicenseRecord);
+
+			await validateLicenseKey('GQ-AAAA-BBBB-CCCC');
+
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('validation_failed');
+			expect(call.licenseKey).toBe('GQ-AAAA-BBBB-CCCC'); // full key
+			expect(call.metadata.reason).toBe('already_consumed');
+			expect(call.metadata.issuedFor).toBe('tenant-x');
+		});
+
+		it('署名不一致 → validation_failed (reason=signature_mismatch)', async () => {
+			process.env.AWS_LICENSE_SECRET = TEST_SECRET;
+			// 署名なし payload に適当な 5 文字を付与 → 署名不一致になる
+			await validateLicenseKey('GQ-ABCD-EFGH-JKLM-ZZZZZ');
+
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('validation_failed');
+			expect(call.metadata.reason).toBe('signature_mismatch');
+		});
+
+		it('成功時 → validated イベントを記録', async () => {
+			mockFindLicenseKey.mockResolvedValueOnce({
+				licenseKey: 'GQ-AAAA-BBBB-CCCC',
+				tenantId: 'tenant-ok',
+				plan: 'yearly',
+				status: 'active',
+				createdAt: '2026-01-01T00:00:00Z',
+			} satisfies LicenseRecord);
+
+			const result = await validateLicenseKey('GQ-AAAA-BBBB-CCCC', {
+				ip: '198.51.100.1',
+				ua: 'ua-test',
+			});
+			expect(result.valid).toBe(true);
+
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('validated');
+			expect(call.licenseKey).toBe('GQ-AAAA-BBBB-CCCC');
+			expect(call.tenantId).toBe('tenant-ok');
+			expect(call.ip).toBe('198.51.100.1');
+			expect(call.ua).toBe('ua-test');
+			expect(call.metadata.plan).toBe('yearly');
+			expect(call.metadata.kind).toBe('purchase');
+		});
+
+		it('期限切れ → validation_failed (reason=expired, expiresAt が metadata に入る)', async () => {
+			mockFindLicenseKey.mockResolvedValueOnce({
+				licenseKey: 'GQ-AAAA-BBBB-CCCC',
+				tenantId: 'tenant-exp',
+				plan: 'monthly',
+				status: 'active',
+				createdAt: '2024-01-01T00:00:00Z',
+				expiresAt: '2024-02-01T00:00:00Z',
+			} satisfies LicenseRecord);
+
+			await validateLicenseKey('GQ-AAAA-BBBB-CCCC');
+
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('validation_failed');
+			expect(call.metadata.reason).toBe('expired');
+			expect(call.metadata.expiresAt).toBe('2024-02-01T00:00:00Z');
+		});
+	});
+
+	describe('consumeLicenseKey', () => {
+		it('成功時 → consumed イベント (actorId=tenant:<id>, plan/kind/planExpiresAt を metadata)', async () => {
+			mockFindLicenseKey.mockResolvedValueOnce({
+				licenseKey: 'GQ-AAAA-BBBB-CCCC',
+				tenantId: 'tenant-buyer',
+				plan: 'monthly',
+				status: 'active',
+				createdAt: '2026-01-01T00:00:00Z',
+			} satisfies LicenseRecord);
+
+			const result = await consumeLicenseKey('GQ-AAAA-BBBB-CCCC', 'tenant-buyer', {
+				ip: '203.0.113.9',
+				ua: 'browser',
+			});
+			expect(result.ok).toBe(true);
+
+			expect(mockLicenseEventInsert).toHaveBeenCalledTimes(1);
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('consumed');
+			expect(call.actorId).toBe('tenant:tenant-buyer');
+			expect(call.ip).toBe('203.0.113.9');
+			expect(call.metadata.plan).toBe('monthly');
+			expect(call.metadata.kind).toBe('purchase');
+			expect(call.metadata.planExpiresAt).toBeTruthy();
+		});
+
+		it('cross-tenant 試行 → consume_failed (reason=cross_tenant_purchase, issuedFor 記録)', async () => {
+			mockFindLicenseKey.mockResolvedValueOnce({
+				licenseKey: 'GQ-AAAA-BBBB-CCCC',
+				tenantId: 'tenant-buyer',
+				plan: 'monthly',
+				status: 'active',
+				createdAt: '2026-01-01T00:00:00Z',
+			} satisfies LicenseRecord);
+
+			const result = await consumeLicenseKey('GQ-AAAA-BBBB-CCCC', 'tenant-attacker');
+			expect(result.ok).toBe(false);
+
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('consume_failed');
+			expect(call.actorId).toBe('tenant:tenant-attacker');
+			expect(call.metadata.reason).toBe('cross_tenant_purchase');
+			expect(call.metadata.issuedFor).toBe('tenant-buyer');
+		});
+
+		it('存在しないキー → consume_failed (prefix のみ)', async () => {
+			mockFindLicenseKey.mockResolvedValueOnce(null);
+
+			await consumeLicenseKey('GQ-ZZZZ-YYYY-XXXX', 'tenant-x');
+
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('consume_failed');
+			expect(call.licenseKey).toContain('...');
+			expect(call.metadata.reason).toBe('not_found');
+		});
+	});
+
+	describe('revokeLicenseKey', () => {
+		it('成功時 → revoked イベント (actorId=revokedBy, reason/plan/kind を metadata)', async () => {
+			mockFindLicenseKey.mockResolvedValueOnce({
+				licenseKey: 'GQ-AAAA-BBBB-CCCC',
+				tenantId: 'tenant-rev',
+				plan: 'yearly',
+				status: 'active',
+				createdAt: '2026-01-01T00:00:00Z',
+			} satisfies LicenseRecord);
+
+			await revokeLicenseKey({
+				licenseKey: 'GQ-AAAA-BBBB-CCCC',
+				reason: 'leaked',
+				revokedBy: 'ops:admin-9',
+				context: { ip: '198.51.100.9', ua: 'ops' },
+			});
+
+			expect(mockLicenseEventInsert).toHaveBeenCalledTimes(1);
+			const call = mockLicenseEventInsert.mock.calls[0]![0]!;
+			expect(call.eventType).toBe('revoked');
+			expect(call.actorId).toBe('ops:admin-9');
+			expect(call.tenantId).toBe('tenant-rev');
+			expect(call.ip).toBe('198.51.100.9');
+			expect(call.metadata.reason).toBe('leaked');
+			expect(call.metadata.plan).toBe('yearly');
+			expect(call.metadata.kind).toBe('purchase');
+		});
+
+		it('既に revoked 済みのキーは revoked イベントを記録しない', async () => {
+			mockFindLicenseKey.mockResolvedValueOnce({
+				licenseKey: 'GQ-AAAA-BBBB-CCCC',
+				tenantId: 'tenant-rev',
+				plan: 'yearly',
+				status: 'revoked',
+				createdAt: '2026-01-01T00:00:00Z',
+				revokedAt: '2026-02-01T00:00:00Z',
+				revokedReason: 'ops-manual',
+				revokedBy: 'ops:admin-1',
+			} satisfies LicenseRecord);
+
+			const result = await revokeLicenseKey({
+				licenseKey: 'GQ-AAAA-BBBB-CCCC',
+				reason: 'leaked',
+				revokedBy: 'ops:admin-2',
+			});
+
+			expect(result.ok).toBe(false);
+			expect(mockLicenseEventInsert).not.toHaveBeenCalled();
+		});
+	});
+
+	it('監査ログ insert が throw しても本体処理は完走する (エラー分離)', async () => {
+		mockLicenseEventInsert.mockRejectedValueOnce(new Error('db down'));
+		const result = await issueLicenseKey({
+			tenantId: 'tenant-err',
+			plan: 'monthly',
+		});
+		expect(result.status).toBe('active');
+		expect(mockSaveLicenseKey).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary

ライセンスキーのライフサイクル（発行 / 検証 / 消費 / 失効）を永続的な監査ログとして DB に記録する。
`logger.info` 任せでは CS 対応 / 不正検知 / 返金対応 / 開示請求に応えられないため、`ops_audit_log` (#820) と同じ repository パターンで `license_events` テーブルを追加。

- 新テーブル `license_events` (9 col + 4 index) と `ILicenseEventRepo` / SQLite / DynamoDB 実装（**#1012 対応で DynamoDB も本実装化**）
- `license-key-service` の issue / validate / consume / revoke に optional context 引数を追加し、成功 / 失敗経路で event を write
- ADR-0026 準拠: validation_failed の未知キーは先頭 7 文字 prefix + `...` で記録（DB 膨張・偽造試行値漏洩の抑制）。records が存在する already_consumed / revoked / expired は full key で記録（監査連結用）
- `recordLicenseEvent` は内部で catch し主業務を阻害しない（監査ログ欠損 > 機能停止）
- countRecentFailuresByIp でブルートフォース検知の土台を提供
- 08-DB設計書 に `license_events` 仕様追加、create-tables / test-db / e2e global-setup も追随

Closes #804
Refs #1012 (段階的対応禁止に従って本 PR で DynamoDB を本実装化)

## DynamoDB 実装 (#1012 対応)

既存 GSI2 (GSI2PK/GSI2SK) を流用し、CDK 変更なしで実装:

- PK = `LICENSE_EVENT#${licenseKey}` / SK = `EVENT#${createdAt}#${uuid}`
- GSI2PK = 'LICENSE_EVENT_ALL' (全イベント集約) / GSI2SK = sortToken
- findByLicenseKey: Query main table (ScanIndexForward=false)
- findRecent: Query GSI2 (全イベント逆順)
- countRecentFailuresByIp: Query GSI2 + FilterExpression で時間窓内 validation_failed をページング集計 (safetyCap=5000)

## 受け入れ基準の対応

- [x] `license_events` テーブル（SQLite + DynamoDB **両本実装**）
- [x] フィールド: eventType / licenseKey / tenantId / actorId / ip / ua / metadata / createdAt
- [x] `issueLicenseKey` / `validateLicenseKey` / `consumeLicenseKey` / `revokeLicenseKey` で write
- [ ] Ops 画面（キー別履歴タブ）は本 PR スコープ外（#別 issue を follow-up に残す）
- [x] Unit tests: license-key-service.test.ts に 15 ケース追加（全 104 pass）
- [x] 設計書 `08-データベース設計書.md` 反映

## Test plan

- [x] `npx biome check .` — クリーン
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run` — 176 files / 3297 tests all pass
- [ ] Ops 画面側の E2E は Ops UI 実装 PR で対応（本 PR は永続化レイヤのみ）

### DynamoDB 実装完成度 (#1012)

- [x] SQLite + DynamoDB 両実装を同 PR で完成
- [x] `scripts/check-dynamodb-stub.mjs` (PR #1017) がローカル PASS
- [x] CDK 変更不要 (既存 GSI2 流用)
- [ ] `DATA_SOURCE=dynamodb` staging 実機確認 → マージ後 deploy.yml 成功を経て実施

## 設計決定の要点

| 項目 | 決定 | 理由 |
|---|---|---|
| 失敗時のキー記録 | 未知キーは prefix のみ / 既知キーは full | ADR-0026 準拠 + DB 膨張抑制 |
| context 引数 | optional | 既存呼び出し箇所を破壊しない |
| 記録失敗ハンドリング | service 内で catch | 監査ログ落ちで主業務停止を避ける |
| DynamoDB 実装 | **同 PR で本実装** (#1012 対応) | PO 方針: main merge = 即本番。段階的対応禁止 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)