### PR TITLE
refactor: 時間計算マジックナンバーを MS_PER_DAY 定数に集約 (#973)

### DIFF
--- a/src/lib/domain/constants/time.ts
+++ b/src/lib/domain/constants/time.ts
@@ -1,0 +1,9 @@
+// 時間単位変換定数（外部ライブラリ不要のプロジェクト共通モジュール）
+// 命名規則: MS_PER_* (ミリ秒), SECONDS_PER_* (秒)
+
+export const MS_PER_SECOND = 1000;
+export const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+export const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+export const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+export const SECONDS_PER_DAY = 24 * 60 * 60;

--- a/src/lib/domain/validation/auth.ts
+++ b/src/lib/domain/validation/auth.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MS_PER_DAY, MS_PER_MINUTE, SECONDS_PER_DAY } from '$lib/domain/constants/time';
 
 // Cookie名
 export const IDENTITY_COOKIE_NAME = 'identity_token';
@@ -8,9 +9,9 @@ export const CONTEXT_COOKIE_NAME = 'context_token';
 export const PIN_MIN_LENGTH = 4;
 export const PIN_MAX_LENGTH = 6;
 export const MAX_FAILED_ATTEMPTS = 5;
-export const LOCKOUT_DURATION_MS = 15 * 60 * 1000; // 15分
-export const SESSION_MAX_AGE_SECONDS = 365 * 24 * 60 * 60; // 1年
-export const SESSION_REFRESH_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000; // 残り30日未満でリフレッシュ
+export const LOCKOUT_DURATION_MS = 15 * MS_PER_MINUTE;
+export const SESSION_MAX_AGE_SECONDS = 365 * SECONDS_PER_DAY;
+export const SESSION_REFRESH_THRESHOLD_MS = 30 * MS_PER_DAY;
 export const SESSION_COOKIE_NAME = 'sessionToken';
 
 // Zodスキーマ（PIN認証用 — 後方互換）

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -11,6 +11,7 @@ import {
 	UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { MS_PER_DAY } from '$lib/domain/constants/time';
 import { INVITE_EXPIRY_DAYS } from '$lib/domain/validation/auth';
 import type {
 	AuthUser,
@@ -386,7 +387,7 @@ export const deleteMembership: IAuthRepo['deleteMembership'] = async (userId, te
 export const createInvite: IAuthRepo['createInvite'] = async (input) => {
 	const inviteCode = `inv-${randomUUID()}`;
 	const now = new Date();
-	const expiresAt = new Date(now.getTime() + INVITE_EXPIRY_DAYS * 24 * 60 * 60 * 1000);
+	const expiresAt = new Date(now.getTime() + INVITE_EXPIRY_DAYS * MS_PER_DAY);
 	const invite: Invite = {
 		inviteCode,
 		tenantId: input.tenantId,

--- a/src/lib/server/services/license-key-service.ts
+++ b/src/lib/server/services/license-key-service.ts
@@ -8,6 +8,7 @@ import {
 } from '$lib/domain/constants/license-key-status';
 import { type LicensePlan, planDurationDays } from '$lib/domain/constants/license-plan';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { MS_PER_DAY } from '$lib/domain/constants/time';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 
@@ -240,7 +241,7 @@ export async function issueLicenseKey(params: {
 		expiresAt = undefined;
 	} else if (params.expiresAt === undefined) {
 		expiresAt = new Date(
-			nowDate.getTime() + DEFAULT_LICENSE_VALIDITY_DAYS * 24 * 60 * 60 * 1000,
+			nowDate.getTime() + DEFAULT_LICENSE_VALIDITY_DAYS * MS_PER_DAY,
 		).toISOString();
 	} else {
 		expiresAt = params.expiresAt;
@@ -368,7 +369,6 @@ function computePlanExpiresAt(
 ): string | undefined {
 	const days = planDurationDays(plan);
 	if (days === undefined) return undefined;
-	const MS_PER_DAY = 24 * 60 * 60 * 1000;
 	return new Date(now.getTime() + days * MS_PER_DAY).toISOString();
 }
 

--- a/src/lib/server/services/ops-service.ts
+++ b/src/lib/server/services/ops-service.ts
@@ -3,6 +3,7 @@
 
 import { LICENSE_PLAN } from '$lib/domain/constants/license-plan';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { MS_PER_DAY } from '$lib/domain/constants/time';
 import type { Tenant } from '$lib/server/auth/entities';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
@@ -212,7 +213,7 @@ export interface AWSCostData {
 
 // メモリキャッシュ（Lambda warm instance 内で1日保持）
 let _costCache: { key: string; data: AWSCostData; fetchedAt: number } | null = null;
-const COST_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24時間
+const COST_CACHE_TTL_MS = MS_PER_DAY;
 
 /**
  * AWS Cost Explorer から当月の費用データを取得（1日キャッシュ）

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -4,6 +4,7 @@
 import type Stripe from 'stripe';
 import { LICENSE_PLAN, type LicensePlan } from '$lib/domain/constants/license-plan';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { MS_PER_DAY } from '$lib/domain/constants/time';
 import { PLAN_LABELS } from '$lib/domain/labels';
 import type { Tenant } from '$lib/server/auth/entities';
 import { getRepos } from '$lib/server/db/factory';
@@ -339,7 +340,7 @@ async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
 	}
 
 	const repos = getRepos();
-	const graceExpires = new Date(Date.now() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000).toISOString();
+	const graceExpires = new Date(Date.now() + GRACE_PERIOD_DAYS * MS_PER_DAY).toISOString();
 	await repos.auth.updateTenantStripe(tenant.tenantId, {
 		status: SUBSCRIPTION_STATUS.GRACE_PERIOD,
 		planExpiresAt: graceExpires,

--- a/tests/unit/domain/time-constants.test.ts
+++ b/tests/unit/domain/time-constants.test.ts
@@ -1,0 +1,45 @@
+// tests/unit/domain/time-constants.test.ts
+// 時間単位変換定数の正しさを検証 (#973)
+
+import { describe, expect, it } from 'vitest';
+import {
+	MS_PER_DAY,
+	MS_PER_HOUR,
+	MS_PER_MINUTE,
+	MS_PER_SECOND,
+	SECONDS_PER_DAY,
+} from '../../../src/lib/domain/constants/time';
+
+describe('time constants', () => {
+	it('MS_PER_SECOND は 1000', () => {
+		expect(MS_PER_SECOND).toBe(1000);
+	});
+
+	it('MS_PER_MINUTE は 60,000', () => {
+		expect(MS_PER_MINUTE).toBe(60_000);
+	});
+
+	it('MS_PER_HOUR は 3,600,000', () => {
+		expect(MS_PER_HOUR).toBe(3_600_000);
+	});
+
+	it('MS_PER_DAY は 86,400,000', () => {
+		expect(MS_PER_DAY).toBe(86_400_000);
+	});
+
+	it('SECONDS_PER_DAY は 86,400', () => {
+		expect(SECONDS_PER_DAY).toBe(86_400);
+	});
+
+	it('MS_PER_DAY === 24 * 60 * 60 * 1000', () => {
+		expect(MS_PER_DAY).toBe(24 * 60 * 60 * 1000);
+	});
+
+	it('SECONDS_PER_DAY === 24 * 60 * 60', () => {
+		expect(SECONDS_PER_DAY).toBe(24 * 60 * 60);
+	});
+
+	it('定数間の整合性: MS_PER_DAY === SECONDS_PER_DAY * MS_PER_SECOND', () => {
+		expect(MS_PER_DAY).toBe(SECONDS_PER_DAY * MS_PER_SECOND);
+	});
+});


### PR DESCRIPTION
## Summary
- `src/lib/domain/constants/time.ts` を新設し、`MS_PER_SECOND` / `MS_PER_MINUTE` / `MS_PER_HOUR` / `MS_PER_DAY` / `SECONDS_PER_DAY` を export
- 6 箇所の `24 * 60 * 60 * 1000` リテラルを定数参照に置換（auth.ts, license-key-service.ts x2, ops-service.ts, stripe-service.ts, auth-repo.ts）
- `auth.ts` の `LOCKOUT_DURATION_MS`（15分）と `SESSION_MAX_AGE_SECONDS`（1年）も定数参照化
- `license-key-service.ts` のローカル `const MS_PER_DAY` 定義を削除し import へ
- `constants/time.ts` のユニットテストを追加

## Test plan
- [x] `grep '24 \* 60 \* 60 \* 1000' src/` が 0 件（constants/time.ts を除く）
- [x] `npx biome check` pass
- [x] `npx vitest run` — 全 3188 テスト pass（Storybook 関連の既存 failure を除く）
- [x] 新規テスト `tests/unit/domain/time-constants.test.ts` — 定数値の正しさと整合性を検証

Closes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)