### PR TITLE
refactor: #980 labels.ts / age-tier.ts の循環依存を解消

### DIFF
--- a/docs/design/parallel-implementations.md
+++ b/docs/design/parallel-implementations.md
@@ -31,6 +31,7 @@
 | 場所 | 内容 | 技術 |
 |------|------|------|
 | `src/lib/domain/labels.ts` | アプリの用語辞書（Single Source of Truth） | TypeScript |
+| `src/lib/domain/validation/age-tier-types.ts` | UiMode 型・LEGACY_UI_MODE_MAP・normalizeUiMode（#980: labels.ts / age-tier.ts 共通基盤） | TypeScript |
 | `site/index.html` | LP トップページの用語直書き | 静的 HTML |
 | `site/pamphlet.html` | パンフレットページの用語直書き | 静的 HTML |
 | `site/shared-labels.js` | LP 共通用語ラッパ（2026-04-07 新設、#561） | JavaScript |

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2,35 +2,9 @@
 // 用語辞書 — UI表示ラベルの Single Source of Truth
 // 全てのUIラベルはこのファイルからインポートすること。ハードコード禁止。
 
-import type { UiMode } from './validation/age-tier';
-
-// ============================================================
-// UiMode 正規化（#573: 循環依存を避けるため labels.ts 内に定義）
-// ============================================================
-// NOTE: validation/age-tier.ts の LEGACY_UI_MODE_MAP / normalizeUiMode と
-// 同じ内容を意図的に複製している。age-tier.ts が labels.ts から
-// AGE_TIER_LABELS を import しているため、逆方向の import は循環依存になる。
-// 変更時は両方を同期させること。
-
-const VALID_UI_MODES: ReadonlySet<UiMode> = new Set([
-	'baby',
-	'preschool',
-	'elementary',
-	'junior',
-	'senior',
-]);
-
-const LEGACY_UI_MODE_MAP_LOCAL: Record<string, UiMode> = {
-	kinder: 'preschool',
-	lower: 'elementary',
-	upper: 'junior',
-	teen: 'senior',
-};
-
-function normalizeUiModeForLabel(value: string): UiMode {
-	if (VALID_UI_MODES.has(value as UiMode)) return value as UiMode;
-	return LEGACY_UI_MODE_MAP_LOCAL[value] ?? 'preschool';
-}
+import type { UiMode } from './validation/age-tier-types';
+// #980: age-tier-types.ts に型・正規化関数を集約し循環依存を解消
+import { normalizeUiMode } from './validation/age-tier-types';
 
 // ============================================================
 // ナビゲーションカテゴリ
@@ -98,14 +72,14 @@ export const AGE_TIER_SHORT_LABELS: Record<UiMode, string> = {
  */
 export function getAgeTierLabel(mode: string | null | undefined): string {
 	if (!mode) return AGE_TIER_LABELS.preschool;
-	const normalized = normalizeUiModeForLabel(mode);
+	const normalized = normalizeUiMode(mode);
 	return AGE_TIER_LABELS[normalized];
 }
 
 /** 年齢区分の短縮ラベルを取得（#573: defensive normalization） */
 export function getAgeTierShortLabel(mode: string | null | undefined): string {
 	if (!mode) return AGE_TIER_SHORT_LABELS.preschool;
-	const normalized = normalizeUiModeForLabel(mode);
+	const normalized = normalizeUiMode(mode);
 	return AGE_TIER_SHORT_LABELS[normalized];
 }
 

--- a/src/lib/domain/validation/age-tier-types.ts
+++ b/src/lib/domain/validation/age-tier-types.ts
@@ -1,0 +1,24 @@
+// src/lib/domain/validation/age-tier-types.ts
+// 型定義専用モジュール — labels.ts / age-tier.ts の循環依存を解消するために新設 (#980)
+// UiMode 型・UI_MODES 定数・LEGACY_UI_MODE_MAP・normalizeUiMode をここに集約し、
+// labels.ts と age-tier.ts は共にこのモジュールに依存する形にする。
+
+/** 有効な UI モード一覧（#537: 日本の学校制度に合わせたコード名） */
+export const UI_MODES = ['baby', 'preschool', 'elementary', 'junior', 'senior'] as const;
+
+/** UI モードの型 */
+export type UiMode = (typeof UI_MODES)[number];
+
+/** 旧コード -> 新コード マッピング（遅延マイグレーション・互換チェック用） */
+export const LEGACY_UI_MODE_MAP: Record<string, UiMode> = {
+	kinder: 'preschool',
+	lower: 'elementary',
+	upper: 'junior',
+	teen: 'senior',
+};
+
+/** 旧コードを含む値を新コードに変換する */
+export function normalizeUiMode(value: string): UiMode {
+	if (UI_MODES.includes(value as UiMode)) return value as UiMode;
+	return LEGACY_UI_MODE_MAP[value] ?? 'preschool';
+}

--- a/src/lib/domain/validation/age-tier.ts
+++ b/src/lib/domain/validation/age-tier.ts
@@ -1,26 +1,15 @@
 import { z } from 'zod';
 import { AGE_TIER_LABELS } from '../labels';
+import type { UiMode } from './age-tier-types';
+import { LEGACY_UI_MODE_MAP, UI_MODES } from './age-tier-types';
 
-// 年齢帯モード定義（#537: 日本の学校制度に合わせたコード名に改修）
-export const UI_MODES = ['baby', 'preschool', 'elementary', 'junior', 'senior'] as const;
-export type UiMode = (typeof UI_MODES)[number];
+export type { UiMode } from './age-tier-types';
+// 型・定数・正規化関数は age-tier-types.ts に集約（#980: 循環依存解消）
+// 既存の import path を維持するため re-export する
+export { LEGACY_UI_MODE_MAP, normalizeUiMode, UI_MODES } from './age-tier-types';
 
 // Zod スキーマ
 export const uiModeSchema = z.enum(UI_MODES);
-
-// 旧コード → 新コード マッピング（遅延マイグレーション・互換チェック用）
-export const LEGACY_UI_MODE_MAP: Record<string, UiMode> = {
-	kinder: 'preschool',
-	lower: 'elementary',
-	upper: 'junior',
-	teen: 'senior',
-};
-
-/** 旧コードを含む値を新コードに変換する */
-export function normalizeUiMode(value: string): UiMode {
-	if (UI_MODES.includes(value as UiMode)) return value as UiMode;
-	return LEGACY_UI_MODE_MAP[value] ?? 'preschool';
-}
 
 // 年齢帯設定
 export const AGE_TIER_CONFIG: Record<


### PR DESCRIPTION
## Summary
- `labels.ts` と `age-tier.ts` の循環依存を、型定義専用モジュール `age-tier-types.ts` を新設して解消
- `labels.ts` 内の「意図的に複製」コメント（#573 対症療法）と `normalizeUiModeForLabel` / `LEGACY_UI_MODE_MAP_LOCAL` / `VALID_UI_MODES` の複製コードを削除
- `age-tier.ts` は既存の import path を維持するため re-export を提供
- `parallel-implementations.md` に新設モジュールの配置場所を追記

## Acceptance Criteria
- [x] `npx madge src/ --circular` が 0 circular を返す
- [x] `labels.ts` 行 8-11 の「意図的に複製」コメントと `normalizeUiMode` の複製を削除
- [x] `npx svelte-check` / `npx vitest run` 既存テスト全通過
- [x] 新設モジュールの配置場所を `docs/design/parallel-implementations.md` の該当節に追記

## Test plan
- [x] `npx madge src/ --circular` -> No circular dependency found
- [x] `npx svelte-check` -> 0 errors
- [x] `npx vitest run` -> 3180 tests passed
- [x] `npx biome check` -> no errors on changed files

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)