### PR TITLE
infra(ci): #1006 E2E shard matrix + vitest shard で CI/deploy を高速化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,83 @@ jobs:
       - name: Type coverage ratchet check (#978)
         run: npm run type-coverage
 
-      - name: Unit tests with coverage enforcement
-        run: npx vitest run --coverage
+      - name: Build
+        run: npm run build
+
+      - name: Storybook build check
+        # #923 Phase 1: stories / .storybook 配下が変更された PR でのみ実行 (-13s)
+        if: needs.changes.outputs.stories == 'true'
+        run: npm run build-storybook -- --quiet
+
+  # #1006 Phase 2: vitest を 2 shard に分割して並列化 (1m 23s → ~40s 目標)
+  # 各 shard は coverage を出力し、unit-test-merge で合算してラチェットチェック。
+  # shard 実行時は threshold 未達でも fail しない (部分カバレッジのため不正確)。
+  # threshold enforcement は merge 後に行う。
+  unit-test:
+    needs: changes
+    if: needs.changes.outputs.app == 'true' || needs.changes.outputs.deps == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Unit tests with coverage (shard ${{ matrix.shard }}/2)
+        run: npx vitest run --reporter=blob --coverage.enabled --coverage.reporter=json --shard=${{ matrix.shard }}/2
+
+      - name: Upload vitest blob report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: vitest-blob-${{ matrix.shard }}
+          path: .vitest-reports/
+          retention-days: 3
+
+      - name: Upload coverage JSON
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: vitest-coverage-${{ matrix.shard }}
+          path: coverage/coverage-final.json
+          retention-days: 3
+
+  # #1006: shard 分割された vitest 結果を merge してラチェット検証
+  unit-test-merge:
+    needs: [unit-test]
+    if: always() && (needs.unit-test.result == 'success' || needs.unit-test.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Download vitest blob reports
+        uses: actions/download-artifact@v7
+        with:
+          pattern: vitest-blob-*
+          path: .vitest-reports
+          merge-multiple: true
+
+      - name: Merge vitest reports and validate coverage
+        run: npx vitest --merge-reports --coverage
 
       - name: Coverage threshold ratchet check
         if: github.event_name == 'pull_request'
@@ -110,20 +185,17 @@ jobs:
         if: github.event_name == 'pull_request'
         run: node scripts/check-test-antipatterns.js
 
-      - name: Build
-        run: npm run build
-
-      - name: Storybook build check
-        # #923 Phase 1: stories / .storybook 配下が変更された PR でのみ実行 (-13s)
-        if: needs.changes.outputs.stories == 'true'
-        run: npm run build-storybook -- --quiet
-
   e2e-test:
     runs-on: ubuntu-latest
     # #923 Phase 1: lint-and-test 依存を外して並列化 (-2m 44s)。
     # lint 失敗時も e2e は走るが、ci-gate が両方の結果を集約するので問題なし。
+    # #1006 Phase 2: --shard matrix で 3 並列化 (7m 37s → ~3m 目標)
     needs: [changes]
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.deps == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v6
 
@@ -152,20 +224,60 @@ jobs:
       - name: Build for E2E (preview mode)
         run: npm run build
 
-      - name: Run E2E tests
+      - name: Run E2E tests (shard ${{ matrix.shard }}/3)
         # #806: vite preview は NODE_ENV=production で起動するため、
         # hooks.server.ts の assertLicenseKeyConfigured() が AWS_LICENSE_SECRET を要求する。
         # E2E はダミーの固定値で良い（本番シークレットとは別物）。
         env:
           AWS_LICENSE_SECRET: e2e-test-secret-do-not-use-in-production
-        run: npx playwright test
+        run: npx playwright test --shard=${{ matrix.shard }}/3
+
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-blob-report-${{ matrix.shard }}
+          path: blob-report/
+          retention-days: 7
 
       - name: Upload E2E test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: e2e-test-results
+          name: e2e-test-results-${{ matrix.shard }}
           path: test-results/
+          retention-days: 7
+
+  # #1006: shard 分割された E2E blob レポートを集約し、HTML レポートを生成
+  e2e-merge-reports:
+    runs-on: ubuntu-latest
+    needs: [e2e-test]
+    if: always() && (needs.e2e-test.result == 'success' || needs.e2e-test.result == 'failure')
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Download all blob reports
+        uses: actions/download-artifact@v7
+        with:
+          pattern: e2e-blob-report-*
+          path: all-blob-reports
+          merge-multiple: true
+
+      - name: Merge reports
+        run: npx playwright merge-reports --reporter=html ./all-blob-reports
+
+      - name: Upload merged HTML report
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-html-report
+          path: playwright-report/
           retention-days: 7
 
   docker-build:
@@ -259,7 +371,10 @@ jobs:
       [
         changes,
         lint-and-test,
+        unit-test,
+        unit-test-merge,
         e2e-test,
+        e2e-merge-reports,
         docker-build,
         site-check,
         new-env-distribution-check,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,18 @@ jobs:
       - run: npm ci
 
       - name: Unit tests with coverage (shard ${{ matrix.shard }}/2)
-        run: npx vitest run --reporter=blob --coverage.enabled --coverage.reporter=json --shard=${{ matrix.shard }}/2
+        # shard 単体では全テストの一部しか走らないため coverage threshold は必ず未達になる。
+        # threshold は unit-test-merge の --merge-reports 時に vite.config.ts の値で検証する。
+        run: >-
+          npx vitest run
+          --reporter=blob
+          --coverage.enabled
+          --coverage.reporter=json
+          --coverage.thresholds.lines=0
+          --coverage.thresholds.functions=0
+          --coverage.thresholds.branches=0
+          --coverage.thresholds.statements=0
+          --shard=${{ matrix.shard }}/2
 
       - name: Upload vitest blob report
         if: always()
@@ -140,14 +151,7 @@ jobs:
         with:
           name: vitest-blob-${{ matrix.shard }}
           path: .vitest-reports/
-          retention-days: 3
-
-      - name: Upload coverage JSON
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: vitest-coverage-${{ matrix.shard }}
-          path: coverage/coverage-final.json
+          include-hidden-files: true
           retention-days: 3
 
   # #1006: shard 分割された vitest 結果を merge してラチェット検証

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,8 @@ env:
   APP_MAJOR_VERSION: "1"
 
 jobs:
-  test:
+  # #1006: deploy.yml の test を lint / E2E shard / cognito に分離して並列化
+  test-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -56,10 +57,26 @@ jobs:
       - run: npx vitest run --coverage
         name: Unit tests with coverage enforcement
 
+  # #1006: E2E local tests を 3 shard に分割
+  test-e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
       # Build before E2E (preview mode eliminates Vite JIT compilation overhead)
       - run: npm run build
 
-      # E2E tests (local mode)
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v5
@@ -79,19 +96,66 @@ jobs:
       # hooks.server.ts の assertLicenseKeyConfigured() が AWS_LICENSE_SECRET を要求する。
       # 未設定だと webServer が起動失敗 → "Process from config.webServer was not able to start" で
       # 全 E2E が落ちる。CI 用の固定ダミー値を注入して assertion を通す（本番値とは別物）。
-      - name: E2E tests (local mode)
+      - name: E2E tests (local mode, shard ${{ matrix.shard }}/3)
         env:
           AWS_LICENSE_SECRET: ci-deploy-test-secret-do-not-use-in-production
-        run: npx playwright test
+        run: npx playwright test --shard=${{ matrix.shard }}/3
 
-      # E2E tests (cognito-dev mode)
+  # #1006: cognito-dev E2E は spec が少ないため shard 不要
+  test-cognito:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright deps (cached browsers)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
       - name: E2E tests (cognito-dev mode)
         env:
           AWS_LICENSE_SECRET: ci-deploy-test-secret-do-not-use-in-production
         run: npx playwright test --config playwright.cognito-dev.config.ts
 
+  # #1006: 全 test job の結果を集約する gate job (deploy の依存先)
+  test-gate:
+    if: always()
+    needs: [test-lint, test-e2e, test-cognito]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "Test job results:"
+          echo "$NEEDS" | jq -r 'to_entries[] | "  \(.key): \(.value.result)"'
+          failed=$(echo "$NEEDS" | jq -r '[to_entries[] | select(.value.result == "failure" or .value.result == "cancelled")] | length')
+          if [ "$failed" -gt 0 ]; then
+            echo "Tests failed: $failed job(s) failed or cancelled"
+            exit 1
+          fi
+          echo "All tests passed"
+
   deploy:
-    needs: test
+    needs: test-gate
     runs-on: ubuntu-24.04-arm
     environment: production
     outputs:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,7 +35,11 @@ export default defineConfig({
 	// CI / ローカルとも同値のため三項演算子は不要（意図せず差を入れる事故防止）。
 	workers: 2,
 	timeout: 30_000,
-	reporter: [['list'], ['html', { open: 'never' }], ['json', { outputFile: 'test-results.json' }]],
+	// CI shard 時は blob reporter で結果を個別出力し、merge-reports で集約する。
+	// ローカル / 非 shard CI では従来の list + html + json を維持。
+	reporter: process.env.CI
+		? [['blob', { outputDir: 'blob-report' }], ['list']]
+		: [['list'], ['html', { open: 'never' }], ['json', { outputFile: 'test-results.json' }]],
 	globalSetup: './tests/e2e/global-setup.ts',
 	globalTeardown: './tests/e2e/global-teardown.ts',
 	use: {


### PR DESCRIPTION
## Summary
closes #1006

#923 Phase 2 follow-up として、E2E テストと vitest を shard 分割して CI / deploy を高速化。

### 変更内容

#### E2E shard 化 (ci.yml / deploy.yml)
- `e2e-test` job を `strategy.matrix.shard: [1, 2, 3]` で 3 並列化
- `--shard=${{ matrix.shard }}/3` で Playwright テストを分割
- CI 時は `blob` reporter で結果を出力し、`e2e-merge-reports` job で HTML レポートに集約
- `workers: 2` は Phase 1 の flake 回避判断を踏襲して維持

#### vitest shard 化 (ci.yml)
- `unit-test` job を `strategy.matrix.shard: [1, 2]` で 2 並列化
- `--reporter=blob --coverage.enabled --coverage.reporter=json --shard=X/2` で分割実行
- `unit-test-merge` job で `vitest --merge-reports --coverage` により coverage 統合 + threshold 検証
- `check-coverage-threshold.js` / `check-test-antipatterns.js` は merge 後に実行

#### deploy.yml の test job 分離
- 単一 `test` job を `test-lint` / `test-e2e` (3 shard) / `test-cognito` に分離
- `test-gate` job で全結果を集約し、`deploy` job の依存先とする

#### playwright.config.ts
- CI 時は `[['blob', { outputDir: 'blob-report' }], ['list']]` reporter を使用
- ローカルは従来の `list + html + json` を維持

### 計測
- **変更前**: E2E local 7m 37s / vitest 1m 23s / deploy run 合計 24 分
- **変更後目標**: E2E local ~2:30 (3 shard) / vitest ~40s (2 shard) / deploy run 合計 18 分以下
- 実測は PR マージ後 5 run で確認

## Test plan
- [ ] CI (ci.yml) で e2e-test matrix 3 shard が全て成功すること
- [ ] e2e-merge-reports で HTML レポート artifact が生成されること
- [ ] unit-test matrix 2 shard が成功し、unit-test-merge の coverage 検証が通ること
- [ ] ci-gate が全 job 結果を正しく集約すること
- [ ] deploy.yml の test-gate → deploy 依存チェーンが動作すること
- [ ] flake が変更前後で同等以下であること（マージ後 5 run を手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)