### PR TITLE
feat: #740 アカウント削除前のプラン別データエクスポート

### DIFF
--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -80,6 +80,7 @@ export class ComputeStack extends cdk.Stack {
 			// CDK 側で明示的に失敗させる（addError は deploy を阻止する）。
 			cdk.Annotations.of(this).addError(
 				'[ComputeStack] awsLicenseSecret context is empty. ' +
+t				// biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions template syntax, not JS template literal
 					'Pass -c awsLicenseSecret=${{ secrets.AWS_LICENSE_SECRET }} in the deploy workflow. ' +
 					'See docs/decisions/0026-license-key-architecture.md and infra/CLAUDE.md.',
 			);

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -80,7 +80,7 @@ export class ComputeStack extends cdk.Stack {
 			// CDK 側で明示的に失敗させる（addError は deploy を阻止する）。
 			cdk.Annotations.of(this).addError(
 				'[ComputeStack] awsLicenseSecret context is empty. ' +
-t				// biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions template syntax, not JS template literal
+					// biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions template syntax, not JS template literal
 					'Pass -c awsLicenseSecret=${{ secrets.AWS_LICENSE_SECRET }} in the deploy workflow. ' +
 					'See docs/decisions/0026-license-key-architecture.md and infra/CLAUDE.md.',
 			);

--- a/scripts/add-avatar-tables.cjs
+++ b/scripts/add-avatar-tables.cjs
@@ -6,7 +6,7 @@
 //   デフォルト: ./data/ganbari-quest.db
 
 const Database = require('better-sqlite3');
-const path = require('path');
+const path = require('node:path');
 
 const dbPath = process.argv[2] || path.join(__dirname, '..', 'data', 'ganbari-quest.db');
 console.log(`DB: ${dbPath}`);

--- a/scripts/security-scan.mjs
+++ b/scripts/security-scan.mjs
@@ -84,11 +84,7 @@ const results = [];
 // ----- 1. npm audit -----
 {
 	const outputFile = join(outputDir, 'npm-audit.json');
-	const result = runTool(
-		'npm audit',
-		'npm audit --json',
-		outputFile,
-	);
+	const result = runTool('npm audit', 'npm audit --json', outputFile);
 	results.push({ tool: 'npm audit', ...result });
 
 	// Also generate human-readable output
@@ -111,7 +107,10 @@ const results = [];
 		console.log('  Install: brew install osv-scanner');
 		console.log('  Or: go install github.com/google/osv-scanner/cmd/osv-scanner@latest');
 		console.log('  See: docs/security/scan.md');
-		writeFileSync(outputFile, JSON.stringify({ skipped: true, reason: 'osv-scanner not installed' }, null, 2));
+		writeFileSync(
+			outputFile,
+			JSON.stringify({ skipped: true, reason: 'osv-scanner not installed' }, null, 2),
+		);
 		results.push({ tool: 'osv-scanner', success: false, findings: false, skipped: true });
 	}
 }
@@ -131,7 +130,10 @@ const results = [];
 		console.log('  Install: pip install semgrep');
 		console.log('  Or: brew install semgrep');
 		console.log('  See: docs/security/scan.md');
-		writeFileSync(outputFile, JSON.stringify({ skipped: true, reason: 'semgrep not installed' }, null, 2));
+		writeFileSync(
+			outputFile,
+			JSON.stringify({ skipped: true, reason: 'semgrep not installed' }, null, 2),
+		);
 		results.push({ tool: 'semgrep', success: false, findings: false, skipped: true });
 	}
 }
@@ -156,18 +158,21 @@ for (const r of results) {
 }
 
 const summaryFile = join(outputDir, 'summary.txt');
-writeFileSync(summaryFile, [
-	`Security Scan Summary — ${today}`,
-	'',
-	...summaryLines,
-	'',
-	`Full results: ${outputDir}/`,
-	'',
-	'Next steps:',
-	'- severity high 以上の finding は個別 Issue として起票する',
-	'- low/info は本 Issue のコメントに集約可',
-	'- 詳細手順: docs/security/scan.md',
-].join('\n'));
+writeFileSync(
+	summaryFile,
+	[
+		`Security Scan Summary — ${today}`,
+		'',
+		...summaryLines,
+		'',
+		`Full results: ${outputDir}/`,
+		'',
+		'Next steps:',
+		'- severity high 以上の finding は個別 Issue として起票する',
+		'- low/info は本 Issue のコメントに集約可',
+		'- 詳細手順: docs/security/scan.md',
+	].join('\n'),
+);
 
 console.log(`\nSummary written to: ${summaryFile}`);
 

--- a/src/lib/server/services/deletion-export-service.ts
+++ b/src/lib/server/services/deletion-export-service.ts
@@ -1,0 +1,281 @@
+// src/lib/server/services/deletion-export-service.ts
+// #740: アカウント削除前のプラン別データエクスポート
+//
+// プラン別エクスポート範囲:
+// - free:     子供名・活動履歴サマリ（最小限の JSON）
+// - standard: フルエクスポート（活動ログ全件、スタンプカード、特別報酬、メッセージ）
+// - family:   上記 + きょうだい比較データ
+
+import type { ExportData, ExportOptions } from '$lib/domain/export-format';
+import { getRepos } from '$lib/server/db/factory';
+import { logger } from '$lib/server/logger';
+import type { PlanTier } from './plan-limit-service';
+import { resolveFullPlanTier } from './plan-limit-service';
+
+// ============================================================
+// Types
+// ============================================================
+
+export type ExportScope = 'minimal' | 'full' | 'family';
+
+export interface DeletionExportOptions {
+	tenantId: string;
+	planTier: PlanTier;
+}
+
+export interface DeletionExportResult {
+	scope: ExportScope;
+	data: MinimalExportData | ExportData;
+	generatedAt: string;
+}
+
+/** free プラン向けの最小限エクスポート */
+export interface MinimalExportData {
+	format: 'ganbari-quest-deletion-export';
+	version: '1.0.0';
+	exportedAt: string;
+	scope: 'minimal';
+	children: MinimalChildExport[];
+	activitySummary: ActivitySummaryExport[];
+}
+
+export interface MinimalChildExport {
+	nickname: string;
+	age: number;
+	uiMode: string;
+	createdAt: string;
+}
+
+export interface ActivitySummaryExport {
+	childNickname: string;
+	totalActivities: number;
+	totalPoints: number;
+	categories: { name: string; count: number }[];
+	firstRecordDate: string | null;
+	lastRecordDate: string | null;
+}
+
+/** family プラン向けのきょうだい比較データ */
+export interface SiblingComparisonExport {
+	children: Array<{
+		nickname: string;
+		totalPoints: number;
+		level: number;
+		streakRecord: number;
+		categorySummary: { categoryCode: string; totalXp: number; level: number }[];
+	}>;
+}
+
+// ============================================================
+// Scope resolution
+// ============================================================
+
+/**
+ * プランティアからエクスポートスコープを判定する。
+ */
+export function resolveExportScope(planTier: PlanTier): ExportScope {
+	switch (planTier) {
+		case 'family':
+			return 'family';
+		case 'standard':
+			return 'full';
+		case 'free':
+		default:
+			return 'minimal';
+	}
+}
+
+// ============================================================
+// Minimal export (free plan)
+// ============================================================
+
+/**
+ * free プラン向けの最小限エクスポートを生成する。
+ *
+ * 子供名と活動サマリのみ含む。法的要件（個人情報保護法のデータポータビリティ権）に
+ * 最低限対応するためのもの。
+ */
+export async function generateMinimalExport(
+	tenantId: string,
+): Promise<MinimalExportData> {
+	const repos = getRepos();
+	const allChildren = await repos.child.findAllChildren(tenantId);
+	const allActivities = await repos.activity.findActivities(tenantId);
+
+	const children: MinimalChildExport[] = allChildren.map((c) => ({
+		nickname: c.nickname,
+		age: c.age,
+		uiMode: c.uiMode,
+		createdAt: c.createdAt,
+	}));
+
+	const activitySummary: ActivitySummaryExport[] = [];
+
+	for (const child of allChildren) {
+		const statuses = await repos.status.findStatuses(child.id, tenantId);
+
+		// カテゴリ別集計
+		const categories = statuses.map((s) => ({
+			name: getCategoryName(s.categoryId),
+			count: s.totalXp,
+		}));
+
+		const totalPoints = statuses.reduce((sum, s) => sum + s.totalXp, 0);
+
+		activitySummary.push({
+			childNickname: child.nickname,
+			totalActivities: allActivities.length,
+			totalPoints,
+			categories,
+			firstRecordDate: child.createdAt.split('T')[0] ?? null,
+			lastRecordDate: null, // サマリレベルでは最終記録日は省略
+		});
+	}
+
+	return {
+		format: 'ganbari-quest-deletion-export',
+		version: '1.0.0',
+		exportedAt: new Date().toISOString(),
+		scope: 'minimal',
+		children,
+		activitySummary,
+	};
+}
+
+// ============================================================
+// Full export (standard+)
+// ============================================================
+
+/**
+ * standard 以上向けのフルエクスポートを生成する。
+ * 既存の export-service.ts の exportFamilyData をそのまま利用する。
+ */
+export async function generateFullExport(
+	tenantId: string,
+): Promise<ExportData> {
+	// dynamic import で循環参照を回避
+	const { exportFamilyData } = await import('./export-service');
+	return exportFamilyData({ tenantId });
+}
+
+// ============================================================
+// Family export (family plan additional data)
+// ============================================================
+
+/**
+ * family プラン向けのきょうだい比較データを生成する。
+ */
+export async function generateSiblingComparison(
+	tenantId: string,
+): Promise<SiblingComparisonExport> {
+	const repos = getRepos();
+	const allChildren = await repos.child.findAllChildren(tenantId);
+
+	const children: SiblingComparisonExport['children'] = [];
+
+	for (const child of allChildren) {
+		const statuses = await repos.status.findStatuses(child.id, tenantId);
+
+		const categorySummary = statuses.map((s) => ({
+			categoryCode: getCategoryCode(s.categoryId),
+			totalXp: s.totalXp,
+			level: s.level,
+		}));
+
+		const totalPoints = statuses.reduce((sum, s) => sum + s.totalXp, 0);
+		const maxLevel = statuses.reduce((max, s) => Math.max(max, s.level), 0);
+
+		children.push({
+			nickname: child.nickname,
+			totalPoints,
+			level: maxLevel,
+			streakRecord: 0, // 最大連続記録は別途取得が必要（将来拡張）
+			categorySummary,
+		});
+	}
+
+	return { children };
+}
+
+// ============================================================
+// Unified deletion export
+// ============================================================
+
+/**
+ * 削除前エクスポートを生成する（プラン別スコープ適用）。
+ *
+ * アカウント削除確認画面から呼び出される。
+ */
+export async function generateDeletionExport(
+	options: DeletionExportOptions,
+): Promise<DeletionExportResult> {
+	const { tenantId, planTier } = options;
+	const scope = resolveExportScope(planTier);
+
+	logger.info('[deletion-export] Generating export', {
+		context: { tenantId, planTier, scope },
+	});
+
+	const generatedAt = new Date().toISOString();
+
+	switch (scope) {
+		case 'minimal': {
+			const data = await generateMinimalExport(tenantId);
+			return { scope, data, generatedAt };
+		}
+		case 'full': {
+			const data = await generateFullExport(tenantId);
+			return { scope, data, generatedAt };
+		}
+		case 'family': {
+			const data = await generateFullExport(tenantId);
+			const siblingData = await generateSiblingComparison(tenantId);
+			// family エクスポートでは sibling comparison を data に追加
+			const familyData = {
+				...data,
+				siblingComparison: siblingData,
+			};
+			return { scope, data: familyData as ExportData, generatedAt };
+		}
+	}
+}
+
+/**
+ * テナントのプランを解決してからエクスポートを生成する便利関数。
+ */
+export async function generateDeletionExportForTenant(
+	tenantId: string,
+	licenseStatus: string,
+	planId?: string,
+): Promise<DeletionExportResult> {
+	const planTier = await resolveFullPlanTier(tenantId, licenseStatus, planId);
+	return generateDeletionExport({ tenantId, planTier });
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+const CATEGORY_NAMES: Record<number, string> = {
+	1: 'うんどう',
+	2: 'べんきょう',
+	3: 'せいかつ',
+	4: 'こうりゅう',
+	5: 'そうぞう',
+};
+
+const CATEGORY_CODES: Record<number, string> = {
+	1: 'undou',
+	2: 'benkyou',
+	3: 'seikatsu',
+	4: 'kouryuu',
+	5: 'souzou',
+};
+
+function getCategoryName(categoryId: number): string {
+	return CATEGORY_NAMES[categoryId] ?? 'その他';
+}
+
+function getCategoryCode(categoryId: number): string {
+	return CATEGORY_CODES[categoryId] ?? 'unknown';
+}

--- a/src/lib/server/services/deletion-export-service.ts
+++ b/src/lib/server/services/deletion-export-service.ts
@@ -95,9 +95,7 @@ export function resolveExportScope(planTier: PlanTier): ExportScope {
  * 子供名と活動サマリのみ含む。法的要件（個人情報保護法のデータポータビリティ権）に
  * 最低限対応するためのもの。
  */
-export async function generateMinimalExport(
-	tenantId: string,
-): Promise<MinimalExportData> {
+export async function generateMinimalExport(tenantId: string): Promise<MinimalExportData> {
 	const repos = getRepos();
 	const allChildren = await repos.child.findAllChildren(tenantId);
 	const allActivities = await repos.activity.findActivities(tenantId);
@@ -150,9 +148,7 @@ export async function generateMinimalExport(
  * standard 以上向けのフルエクスポートを生成する。
  * 既存の export-service.ts の exportFamilyData をそのまま利用する。
  */
-export async function generateFullExport(
-	tenantId: string,
-): Promise<ExportData> {
+export async function generateFullExport(tenantId: string): Promise<ExportData> {
 	// dynamic import で循環参照を回避
 	const { exportFamilyData } = await import('./export-service');
 	return exportFamilyData({ tenantId });

--- a/src/lib/server/services/deletion-export-service.ts
+++ b/src/lib/server/services/deletion-export-service.ts
@@ -6,7 +6,8 @@
 // - standard: フルエクスポート（活動ログ全件、スタンプカード、特別報酬、メッセージ）
 // - family:   上記 + きょうだい比較データ
 
-import type { ExportData, ExportOptions } from '$lib/domain/export-format';
+import type { ExportData } from '$lib/domain/export-format';
+import { getCategoryById } from '$lib/domain/validation/activity';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import type { PlanTier } from './plan-limit-service';
@@ -25,7 +26,7 @@ export interface DeletionExportOptions {
 
 export interface DeletionExportResult {
 	scope: ExportScope;
-	data: MinimalExportData | ExportData;
+	data: MinimalExportData | ExportData | FamilyExportData;
 	generatedAt: string;
 }
 
@@ -66,6 +67,11 @@ export interface SiblingComparisonExport {
 	}>;
 }
 
+/** family プラン向けエクスポート（フルエクスポート + きょうだい比較） */
+export interface FamilyExportData extends ExportData {
+	siblingComparison: SiblingComparisonExport;
+}
+
 // ============================================================
 // Scope resolution
 // ============================================================
@@ -98,7 +104,6 @@ export function resolveExportScope(planTier: PlanTier): ExportScope {
 export async function generateMinimalExport(tenantId: string): Promise<MinimalExportData> {
 	const repos = getRepos();
 	const allChildren = await repos.child.findAllChildren(tenantId);
-	const allActivities = await repos.activity.findActivities(tenantId);
 
 	const children: MinimalChildExport[] = allChildren.map((c) => ({
 		nickname: c.nickname,
@@ -111,18 +116,22 @@ export async function generateMinimalExport(tenantId: string): Promise<MinimalEx
 
 	for (const child of allChildren) {
 		const statuses = await repos.status.findStatuses(child.id, tenantId);
+		const childLogs = await repos.activity.findActivityLogs(child.id, tenantId);
 
 		// カテゴリ別集計
-		const categories = statuses.map((s) => ({
-			name: getCategoryName(s.categoryId),
-			count: s.totalXp,
-		}));
+		const categories = statuses.map((s) => {
+			const catDef = getCategoryById(s.categoryId);
+			return {
+				name: catDef?.name ?? 'その他',
+				count: s.totalXp,
+			};
+		});
 
 		const totalPoints = statuses.reduce((sum, s) => sum + s.totalXp, 0);
 
 		activitySummary.push({
 			childNickname: child.nickname,
-			totalActivities: allActivities.length,
+			totalActivities: childLogs.length,
 			totalPoints,
 			categories,
 			firstRecordDate: child.createdAt.split('T')[0] ?? null,
@@ -172,11 +181,14 @@ export async function generateSiblingComparison(
 	for (const child of allChildren) {
 		const statuses = await repos.status.findStatuses(child.id, tenantId);
 
-		const categorySummary = statuses.map((s) => ({
-			categoryCode: getCategoryCode(s.categoryId),
-			totalXp: s.totalXp,
-			level: s.level,
-		}));
+		const categorySummary = statuses.map((s) => {
+			const catDef = getCategoryById(s.categoryId);
+			return {
+				categoryCode: catDef?.code ?? 'unknown',
+				totalXp: s.totalXp,
+				level: s.level,
+			};
+		});
 
 		const totalPoints = statuses.reduce((sum, s) => sum + s.totalXp, 0);
 		const maxLevel = statuses.reduce((max, s) => Math.max(max, s.level), 0);
@@ -227,11 +239,11 @@ export async function generateDeletionExport(
 			const data = await generateFullExport(tenantId);
 			const siblingData = await generateSiblingComparison(tenantId);
 			// family エクスポートでは sibling comparison を data に追加
-			const familyData = {
+			const familyData: FamilyExportData = {
 				...data,
 				siblingComparison: siblingData,
 			};
-			return { scope, data: familyData as ExportData, generatedAt };
+			return { scope, data: familyData, generatedAt };
 		}
 	}
 }
@@ -246,32 +258,4 @@ export async function generateDeletionExportForTenant(
 ): Promise<DeletionExportResult> {
 	const planTier = await resolveFullPlanTier(tenantId, licenseStatus, planId);
 	return generateDeletionExport({ tenantId, planTier });
-}
-
-// ============================================================
-// Helpers
-// ============================================================
-
-const CATEGORY_NAMES: Record<number, string> = {
-	1: 'うんどう',
-	2: 'べんきょう',
-	3: 'せいかつ',
-	4: 'こうりゅう',
-	5: 'そうぞう',
-};
-
-const CATEGORY_CODES: Record<number, string> = {
-	1: 'undou',
-	2: 'benkyou',
-	3: 'seikatsu',
-	4: 'kouryuu',
-	5: 'souzou',
-};
-
-function getCategoryName(categoryId: number): string {
-	return CATEGORY_NAMES[categoryId] ?? 'その他';
-}
-
-function getCategoryCode(categoryId: number): string {
-	return CATEGORY_CODES[categoryId] ?? 'unknown';
 }

--- a/src/routes/api/v1/admin/account/export/+server.ts
+++ b/src/routes/api/v1/admin/account/export/+server.ts
@@ -1,0 +1,28 @@
+// GET /api/v1/admin/account/export — 削除前データエクスポート (#740)
+//
+// アカウント削除確認画面からダウンロードリンクを提供する。
+// プラン別にエクスポート範囲が異なる:
+//   free:     子供名・活動サマリ（最小限）
+//   standard: フルエクスポート
+//   family:   フル + きょうだい比較
+
+import { json } from '@sveltejs/kit';
+import { requireTenantId } from '$lib/server/auth/factory';
+import { requireRole } from '$lib/server/auth/guards';
+import { generateDeletionExportForTenant } from '$lib/server/services/deletion-export-service';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ locals }) => {
+	requireRole(locals, ['owner']);
+	const tenantId = requireTenantId(locals);
+	const licenseStatus = locals.context?.licenseStatus ?? 'none';
+	const planId = locals.context?.plan;
+
+	const result = await generateDeletionExportForTenant(
+		tenantId,
+		licenseStatus,
+		planId,
+	);
+
+	return json(result);
+};

--- a/src/routes/api/v1/admin/account/export/+server.ts
+++ b/src/routes/api/v1/admin/account/export/+server.ts
@@ -18,11 +18,7 @@ export const GET: RequestHandler = async ({ locals }) => {
 	const licenseStatus = locals.context?.licenseStatus ?? 'none';
 	const planId = locals.context?.plan;
 
-	const result = await generateDeletionExportForTenant(
-		tenantId,
-		licenseStatus,
-		planId,
-	);
+	const result = await generateDeletionExportForTenant(tenantId, licenseStatus, planId);
 
 	return json(result);
 };

--- a/tests/unit/services/deletion-export-service.test.ts
+++ b/tests/unit/services/deletion-export-service.test.ts
@@ -1,0 +1,221 @@
+// tests/unit/services/deletion-export-service.test.ts
+// #740: 削除前エクスポートサービスのユニットテスト
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- mocks ---
+
+const mockFindAllChildren = vi.fn();
+const mockFindActivities = vi.fn();
+const mockFindStatuses = vi.fn();
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		child: { findAllChildren: mockFindAllChildren },
+		activity: { findActivities: mockFindActivities },
+		status: { findStatuses: mockFindStatuses },
+	}),
+}));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	getAuthMode: () => 'cognito',
+}));
+
+vi.mock('$lib/server/services/trial-service', () => ({
+	getTrialStatus: vi.fn().mockResolvedValue({
+		isTrialActive: false,
+		trialUsed: false,
+		trialStartDate: null,
+		trialEndDate: null,
+		trialTier: null,
+		daysRemaining: 0,
+		source: null,
+	}),
+}));
+
+vi.mock('$lib/server/request-context', () => ({
+	getRequestContext: () => null,
+	buildPlanTierCacheKey: (...args: unknown[]) => args.join(':'),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+// export-service のモック（full export 用）
+const mockExportFamilyData = vi.fn().mockResolvedValue({
+	format: 'ganbari-quest-backup',
+	version: '1.1.0',
+	exportedAt: '2026-04-17T00:00:00.000Z',
+	checksum: 'sha256:abc123',
+	master: { categories: [], activities: [], titles: [], achievements: [], avatarItems: [] },
+	family: { children: [] },
+	data: {
+		activityLogs: [],
+		pointLedger: [],
+		statuses: [],
+		statusHistory: [],
+		childAchievements: [],
+		childTitles: [],
+		loginBonuses: [],
+		evaluations: [],
+		specialRewards: [],
+		checklistTemplates: [],
+		checklistLogs: [],
+		childAvatarItems: [],
+		dailyMissions: [],
+	},
+});
+
+vi.mock('$lib/server/services/export-service', () => ({
+	exportFamilyData: (...args: unknown[]) => mockExportFamilyData(...args),
+}));
+
+import {
+	generateDeletionExport,
+	generateMinimalExport,
+	generateSiblingComparison,
+	resolveExportScope,
+} from '$lib/server/services/deletion-export-service';
+
+describe('deletion-export-service', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// ============================================================
+	// resolveExportScope
+	// ============================================================
+
+	describe('resolveExportScope', () => {
+		it('free プランは minimal スコープ', () => {
+			expect(resolveExportScope('free')).toBe('minimal');
+		});
+
+		it('standard プランは full スコープ', () => {
+			expect(resolveExportScope('standard')).toBe('full');
+		});
+
+		it('family プランは family スコープ', () => {
+			expect(resolveExportScope('family')).toBe('family');
+		});
+	});
+
+	// ============================================================
+	// generateMinimalExport
+	// ============================================================
+
+	describe('generateMinimalExport', () => {
+		it('子供名とサマリを含む最小限のエクスポートを生成する', async () => {
+			mockFindAllChildren.mockResolvedValue([
+				{ id: 1, nickname: 'たろう', age: 6, uiMode: 'elementary', createdAt: '2026-01-01T00:00:00.000Z' },
+				{ id: 2, nickname: 'はなこ', age: 4, uiMode: 'preschool', createdAt: '2026-02-01T00:00:00.000Z' },
+			]);
+			mockFindActivities.mockResolvedValue([
+				{ id: 1, name: 'うんどう', source: 'seed' },
+			]);
+			mockFindStatuses.mockResolvedValue([
+				{ categoryId: 1, totalXp: 100, level: 3, peakXp: 100, updatedAt: '2026-04-17' },
+				{ categoryId: 2, totalXp: 50, level: 2, peakXp: 50, updatedAt: '2026-04-17' },
+			]);
+
+			const result = await generateMinimalExport('tenant-1');
+
+			expect(result.format).toBe('ganbari-quest-deletion-export');
+			expect(result.scope).toBe('minimal');
+			expect(result.children).toHaveLength(2);
+			expect(result.children[0].nickname).toBe('たろう');
+			expect(result.activitySummary).toHaveLength(2);
+			expect(result.activitySummary[0].totalPoints).toBe(150);
+		});
+
+		it('子供がいない場合も空の結果を返す', async () => {
+			mockFindAllChildren.mockResolvedValue([]);
+			mockFindActivities.mockResolvedValue([]);
+
+			const result = await generateMinimalExport('tenant-1');
+
+			expect(result.children).toHaveLength(0);
+			expect(result.activitySummary).toHaveLength(0);
+		});
+	});
+
+	// ============================================================
+	// generateSiblingComparison
+	// ============================================================
+
+	describe('generateSiblingComparison', () => {
+		it('きょうだい比較データを生成する', async () => {
+			mockFindAllChildren.mockResolvedValue([
+				{ id: 1, nickname: 'たろう', age: 6 },
+				{ id: 2, nickname: 'はなこ', age: 4 },
+			]);
+			mockFindStatuses
+				.mockResolvedValueOnce([
+					{ categoryId: 1, totalXp: 200, level: 5, peakXp: 200, updatedAt: '2026-04-17' },
+				])
+				.mockResolvedValueOnce([
+					{ categoryId: 1, totalXp: 100, level: 3, peakXp: 100, updatedAt: '2026-04-17' },
+				]);
+
+			const result = await generateSiblingComparison('tenant-1');
+
+			expect(result.children).toHaveLength(2);
+			expect(result.children[0].nickname).toBe('たろう');
+			expect(result.children[0].totalPoints).toBe(200);
+			expect(result.children[1].nickname).toBe('はなこ');
+			expect(result.children[1].totalPoints).toBe(100);
+		});
+	});
+
+	// ============================================================
+	// generateDeletionExport
+	// ============================================================
+
+	describe('generateDeletionExport', () => {
+		it('free プランで minimal エクスポートを生成する', async () => {
+			mockFindAllChildren.mockResolvedValue([]);
+			mockFindActivities.mockResolvedValue([]);
+
+			const result = await generateDeletionExport({
+				tenantId: 'tenant-1',
+				planTier: 'free',
+			});
+
+			expect(result.scope).toBe('minimal');
+		});
+
+		it('standard プランで full エクスポートを生成する', async () => {
+			const result = await generateDeletionExport({
+				tenantId: 'tenant-1',
+				planTier: 'standard',
+			});
+
+			expect(result.scope).toBe('full');
+			expect(mockExportFamilyData).toHaveBeenCalledWith({ tenantId: 'tenant-1' });
+		});
+
+		it('family プランで family エクスポート（full + sibling）を生成する', async () => {
+			mockFindAllChildren.mockResolvedValue([
+				{ id: 1, nickname: 'たろう', age: 6 },
+			]);
+			mockFindStatuses.mockResolvedValue([]);
+
+			const result = await generateDeletionExport({
+				tenantId: 'tenant-1',
+				planTier: 'family',
+			});
+
+			expect(result.scope).toBe('family');
+			expect(mockExportFamilyData).toHaveBeenCalled();
+		});
+	});
+});

--- a/tests/unit/services/deletion-export-service.test.ts
+++ b/tests/unit/services/deletion-export-service.test.ts
@@ -116,12 +116,22 @@ describe('deletion-export-service', () => {
 	describe('generateMinimalExport', () => {
 		it('子供名とサマリを含む最小限のエクスポートを生成する', async () => {
 			mockFindAllChildren.mockResolvedValue([
-				{ id: 1, nickname: 'たろう', age: 6, uiMode: 'elementary', createdAt: '2026-01-01T00:00:00.000Z' },
-				{ id: 2, nickname: 'はなこ', age: 4, uiMode: 'preschool', createdAt: '2026-02-01T00:00:00.000Z' },
+				{
+					id: 1,
+					nickname: 'たろう',
+					age: 6,
+					uiMode: 'elementary',
+					createdAt: '2026-01-01T00:00:00.000Z',
+				},
+				{
+					id: 2,
+					nickname: 'はなこ',
+					age: 4,
+					uiMode: 'preschool',
+					createdAt: '2026-02-01T00:00:00.000Z',
+				},
 			]);
-			mockFindActivities.mockResolvedValue([
-				{ id: 1, name: 'うんどう', source: 'seed' },
-			]);
+			mockFindActivities.mockResolvedValue([{ id: 1, name: 'うんどう', source: 'seed' }]);
 			mockFindStatuses.mockResolvedValue([
 				{ categoryId: 1, totalXp: 100, level: 3, peakXp: 100, updatedAt: '2026-04-17' },
 				{ categoryId: 2, totalXp: 50, level: 2, peakXp: 50, updatedAt: '2026-04-17' },
@@ -204,9 +214,7 @@ describe('deletion-export-service', () => {
 		});
 
 		it('family プランで family エクスポート（full + sibling）を生成する', async () => {
-			mockFindAllChildren.mockResolvedValue([
-				{ id: 1, nickname: 'たろう', age: 6 },
-			]);
+			mockFindAllChildren.mockResolvedValue([{ id: 1, nickname: 'たろう', age: 6 }]);
 			mockFindStatuses.mockResolvedValue([]);
 
 			const result = await generateDeletionExport({

--- a/tests/unit/services/deletion-export-service.test.ts
+++ b/tests/unit/services/deletion-export-service.test.ts
@@ -142,9 +142,9 @@ describe('deletion-export-service', () => {
 			expect(result.format).toBe('ganbari-quest-deletion-export');
 			expect(result.scope).toBe('minimal');
 			expect(result.children).toHaveLength(2);
-			expect(result.children[0].nickname).toBe('たろう');
+			expect(result.children[0]!.nickname).toBe('たろう');
 			expect(result.activitySummary).toHaveLength(2);
-			expect(result.activitySummary[0].totalPoints).toBe(150);
+			expect(result.activitySummary[0]!.totalPoints).toBe(150);
 		});
 
 		it('子供がいない場合も空の結果を返す', async () => {
@@ -179,10 +179,10 @@ describe('deletion-export-service', () => {
 			const result = await generateSiblingComparison('tenant-1');
 
 			expect(result.children).toHaveLength(2);
-			expect(result.children[0].nickname).toBe('たろう');
-			expect(result.children[0].totalPoints).toBe(200);
-			expect(result.children[1].nickname).toBe('はなこ');
-			expect(result.children[1].totalPoints).toBe(100);
+			expect(result.children[0]!.nickname).toBe('たろう');
+			expect(result.children[0]!.totalPoints).toBe(200);
+			expect(result.children[1]!.nickname).toBe('はなこ');
+			expect(result.children[1]!.totalPoints).toBe(100);
 		});
 	});
 

--- a/tests/unit/services/deletion-export-service.test.ts
+++ b/tests/unit/services/deletion-export-service.test.ts
@@ -7,12 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockFindAllChildren = vi.fn();
 const mockFindActivities = vi.fn();
+const mockFindActivityLogs = vi.fn();
 const mockFindStatuses = vi.fn();
 
 vi.mock('$lib/server/db/factory', () => ({
 	getRepos: () => ({
 		child: { findAllChildren: mockFindAllChildren },
-		activity: { findActivities: mockFindActivities },
+		activity: { findActivities: mockFindActivities, findActivityLogs: mockFindActivityLogs },
 		status: { findStatuses: mockFindStatuses },
 	}),
 }));
@@ -131,11 +132,14 @@ describe('deletion-export-service', () => {
 					createdAt: '2026-02-01T00:00:00.000Z',
 				},
 			]);
-			mockFindActivities.mockResolvedValue([{ id: 1, name: 'うんどう', source: 'seed' }]);
 			mockFindStatuses.mockResolvedValue([
 				{ categoryId: 1, totalXp: 100, level: 3, peakXp: 100, updatedAt: '2026-04-17' },
 				{ categoryId: 2, totalXp: 50, level: 2, peakXp: 50, updatedAt: '2026-04-17' },
 			]);
+			// たろう: 5件、はなこ: 3件の活動ログ
+			mockFindActivityLogs
+				.mockResolvedValueOnce([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }])
+				.mockResolvedValueOnce([{ id: 6 }, { id: 7 }, { id: 8 }]);
 
 			const result = await generateMinimalExport('tenant-1');
 
@@ -145,11 +149,16 @@ describe('deletion-export-service', () => {
 			expect(result.children[0]!.nickname).toBe('たろう');
 			expect(result.activitySummary).toHaveLength(2);
 			expect(result.activitySummary[0]!.totalPoints).toBe(150);
+			// 子供ごとの活動数が正しくカウントされること
+			expect(result.activitySummary[0]!.totalActivities).toBe(5);
+			expect(result.activitySummary[1]!.totalActivities).toBe(3);
+			// カテゴリ名がSSOTから取得されること
+			expect(result.activitySummary[0]!.categories[0]!.name).toBe('うんどう');
+			expect(result.activitySummary[0]!.categories[1]!.name).toBe('べんきょう');
 		});
 
 		it('子供がいない場合も空の結果を返す', async () => {
 			mockFindAllChildren.mockResolvedValue([]);
-			mockFindActivities.mockResolvedValue([]);
 
 			const result = await generateMinimalExport('tenant-1');
 
@@ -193,7 +202,6 @@ describe('deletion-export-service', () => {
 	describe('generateDeletionExport', () => {
 		it('free プランで minimal エクスポートを生成する', async () => {
 			mockFindAllChildren.mockResolvedValue([]);
-			mockFindActivities.mockResolvedValue([]);
 
 			const result = await generateDeletionExport({
 				tenantId: 'tenant-1',


### PR DESCRIPTION
## Summary
- プラン別エクスポートスコープの実装（free: minimal / standard: full / family: full+sibling）
- free プランでも最小限のデータエクスポート（子供名・活動サマリ）を提供し、データポータビリティ権に対応
- family プランではきょうだい比較データを追加エクスポート
- 削除前エクスポート API エンドポイント（`GET /api/v1/admin/account/export`）

## 変更ファイル
- `src/lib/server/services/deletion-export-service.ts` - プラン別エクスポートサービス（新規）
- `src/routes/api/v1/admin/account/export/+server.ts` - API エンドポイント（新規）
- `tests/unit/services/deletion-export-service.test.ts` - ユニットテスト（新規）

## Test plan
- [x] ユニットテスト 9 件全通過
- [ ] E2E テスト（削除フロー内エクスポート）は UI 実装後に追加

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)