### PR TITLE
refactor: #983 DynamoDB repo 層のコード重複をリポジトリ基底で解消

### DIFF
--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -80,6 +80,7 @@ export class ComputeStack extends cdk.Stack {
 			// CDK 側で明示的に失敗させる（addError は deploy を阻止する）。
 			cdk.Annotations.of(this).addError(
 				'[ComputeStack] awsLicenseSecret context is empty. ' +
+t				// biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions template syntax, not JS template literal
 					'Pass -c awsLicenseSecret=${{ secrets.AWS_LICENSE_SECRET }} in the deploy workflow. ' +
 					'See docs/decisions/0026-license-key-architecture.md and infra/CLAUDE.md.',
 			);

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -80,7 +80,7 @@ export class ComputeStack extends cdk.Stack {
 			// CDK 側で明示的に失敗させる（addError は deploy を阻止する）。
 			cdk.Annotations.of(this).addError(
 				'[ComputeStack] awsLicenseSecret context is empty. ' +
-t				// biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions template syntax, not JS template literal
+					// biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions template syntax, not JS template literal
 					'Pass -c awsLicenseSecret=${{ secrets.AWS_LICENSE_SECRET }} in the deploy workflow. ' +
 					'See docs/decisions/0026-license-key-architecture.md and infra/CLAUDE.md.',
 			);

--- a/scripts/add-avatar-tables.cjs
+++ b/scripts/add-avatar-tables.cjs
@@ -6,7 +6,7 @@
 //   デフォルト: ./data/ganbari-quest.db
 
 const Database = require('better-sqlite3');
-const path = require('path');
+const path = require('node:path');
 
 const dbPath = process.argv[2] || path.join(__dirname, '..', 'data', 'ganbari-quest.db');
 console.log(`DB: ${dbPath}`);

--- a/src/lib/server/db/dynamodb/checklist-repo.ts
+++ b/src/lib/server/db/dynamodb/checklist-repo.ts
@@ -37,13 +37,7 @@ import {
 	ENTITY_NAMES,
 	tenantPK,
 } from './keys';
-
-function stripKeys<T extends Record<string, unknown>>(
-	item: T,
-): Omit<T, 'PK' | 'SK' | 'GSI2PK' | 'GSI2SK'> {
-	const { PK, SK, GSI2PK, GSI2SK, ...rest } = item;
-	return rest;
-}
+import { stripKeys } from './repo-helpers';
 
 // ============================================================
 // Templates

--- a/src/lib/server/db/dynamodb/child-repo.ts
+++ b/src/lib/server/db/dynamodb/child-repo.ts
@@ -2,7 +2,6 @@
 // DynamoDB implementation of IChildRepo
 
 import {
-	BatchWriteCommand,
 	GetCommand,
 	PutCommand,
 	QueryCommand,
@@ -15,14 +14,7 @@ import type { Child, InsertChildInput, UpdateChildInput } from '../types';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import { childKey, childPK, ENTITY_NAMES, tenantPK } from './keys';
-
-/** Strip PK/SK/GSI keys from a DynamoDB item */
-function stripKeys<T extends Record<string, unknown>>(
-	item: T,
-): Omit<T, 'PK' | 'SK' | 'GSI2PK' | 'GSI2SK'> {
-	const { PK, SK, GSI2PK, GSI2SK, ...rest } = item;
-	return rest;
-}
+import { batchDeleteItems, stripKeys } from './repo-helpers';
 
 /** DynamoDB アイテムをマイグレーション（必要なら Write-Back） */
 async function hydrateChild(
@@ -242,20 +234,7 @@ export async function deleteChild(id: number, tenantId: string): Promise<void> {
 		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
 	} while (lastKey);
 
-	// Batch delete in chunks of 25 (DynamoDB limit)
-	const BATCH_SIZE = 25;
-	for (let i = 0; i < allKeys.length; i += BATCH_SIZE) {
-		const batch = allKeys.slice(i, i + BATCH_SIZE);
-		await getDocClient().send(
-			new BatchWriteCommand({
-				RequestItems: {
-					[TABLE_NAME]: batch.map((key) => ({
-						DeleteRequest: { Key: key },
-					})),
-				},
-			}),
-		);
-	}
+	await batchDeleteItems(allKeys);
 }
 
 // #783: archive / restore

--- a/src/lib/server/db/dynamodb/daily-mission-repo.ts
+++ b/src/lib/server/db/dynamodb/daily-mission-repo.ts
@@ -8,14 +8,13 @@ import {
 	ScanCommand,
 	UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
-import type { Activity, Child, DailyMissionWithActivity } from '../types';
+import type { Activity, DailyMissionWithActivity } from '../types';
 import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
 	activityKey,
 	activityLogPrefix,
-	childKey,
 	childPK,
 	dailyMissionDatePrefix,
 	dailyMissionKey,
@@ -24,13 +23,9 @@ import {
 	pointLedgerPrefix,
 	tenantPK,
 } from './keys';
+import { findChildByIdRaw, stripKeys } from './repo-helpers';
 
-function stripKeys<T extends Record<string, unknown>>(
-	item: T,
-): Omit<T, 'PK' | 'SK' | 'GSI2PK' | 'GSI2SK'> {
-	const { PK, SK, GSI2PK, GSI2SK, ...rest } = item;
-	return rest;
-}
+export { findChildByIdRaw as findChildForMission } from './repo-helpers';
 
 /** 今日のミッション一覧（活動情報付き） */
 export async function findTodayMissions(
@@ -178,22 +173,6 @@ export async function findAllMissionStatuses(
 	return (result.Items ?? []).map((item) => ({
 		completed: item.completed as number,
 	}));
-}
-
-/** ミッション用の子供情報取得 */
-export async function findChildForMission(
-	childId: number,
-	tenantId: string,
-): Promise<Child | undefined> {
-	const result = await getDocClient().send(
-		new GetCommand({
-			TableName: TABLE_NAME,
-			Key: childKey(childId, tenantId),
-		}),
-	);
-
-	if (!result.Item) return undefined;
-	return stripKeys(result.Item) as unknown as Child;
 }
 
 /** 表示可能な全活動を取得 */

--- a/src/lib/server/db/dynamodb/evaluation-repo.ts
+++ b/src/lib/server/db/dynamodb/evaluation-repo.ts
@@ -22,14 +22,7 @@ import {
 	statusHistoryPrefix,
 	tenantPK,
 } from './keys';
-
-/** Strip PK/SK/GSI keys from a DynamoDB item */
-function stripKeys<T extends Record<string, unknown>>(
-	item: T,
-): Omit<T, 'PK' | 'SK' | 'GSI2PK' | 'GSI2SK'> {
-	const { PK, SK, GSI2PK, GSI2SK, ...rest } = item;
-	return rest;
-}
+import { queryAllItems, stripKeys } from './repo-helpers';
 
 /** 指定期間のカテゴリ別活動回数を集計 */
 export async function countActivitiesByCategory(
@@ -41,38 +34,20 @@ export async function countActivitiesByCategory(
 	const pk = childPK(childId, tenantId);
 	const prefix = activityLogPrefix();
 
-	// Query all activity logs for this child, filter by date range
-	const items: Record<string, unknown>[] = [];
-	let lastKey: Record<string, unknown> | undefined;
-
-	do {
-		const result = await getDocClient().send(
-			new QueryCommand({
-				TableName: TABLE_NAME,
-				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
-				FilterExpression:
-					'#cancelled = :zero AND #recordedDate >= :weekStart AND #recordedDate <= :weekEnd',
-				ExpressionAttributeNames: {
-					'#cancelled': 'cancelled',
-					'#recordedDate': 'recordedDate',
-				},
-				ExpressionAttributeValues: {
-					':pk': pk,
-					':prefix': prefix,
-					':zero': 0,
-					':weekStart': weekStart,
-					':weekEnd': weekEnd,
-				},
-				ProjectionExpression: 'activityId, categoryId, points',
-				ExclusiveStartKey: lastKey,
-			}),
-		);
-
-		for (const item of result.Items ?? []) {
-			items.push(item);
-		}
-		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
-	} while (lastKey);
+	const items = await queryAllItems(pk, prefix, {
+		filterExpression:
+			'#cancelled = :zero AND #recordedDate >= :weekStart AND #recordedDate <= :weekEnd',
+		expressionAttributeNames: {
+			'#cancelled': 'cancelled',
+			'#recordedDate': 'recordedDate',
+		},
+		expressionAttributeValues: {
+			':zero': 0,
+			':weekStart': weekStart,
+			':weekEnd': weekEnd,
+		},
+		projectionExpression: 'activityId, categoryId, points',
+	});
 
 	// Group by categoryId and count + sum points
 	const catMap = new Map<number, { count: number; totalPoints: number }>();
@@ -138,7 +113,9 @@ export async function findAllChildren(tenantId: string): Promise<Child[]> {
 		}),
 	);
 
-	return (result.Items ?? []).map((item) => stripKeys(item) as unknown as Child);
+	return (result.Items ?? []).map(
+		(item) => stripKeys(item as Record<string, unknown>) as unknown as Child,
+	);
 }
 
 /** 子供の評価履歴を取得 */
@@ -224,32 +201,12 @@ export async function findLastActivityDateByCategory(
 	const pk = childPK(childId, tenantId);
 	const prefix = activityLogPrefix();
 
-	// Query all activity logs for this child
-	const items: Record<string, unknown>[] = [];
-	let lastKey: Record<string, unknown> | undefined;
-
-	do {
-		const result = await getDocClient().send(
-			new QueryCommand({
-				TableName: TABLE_NAME,
-				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
-				FilterExpression: '#cancelled = :zero',
-				ExpressionAttributeNames: { '#cancelled': 'cancelled' },
-				ExpressionAttributeValues: {
-					':pk': pk,
-					':prefix': prefix,
-					':zero': 0,
-				},
-				ProjectionExpression: 'categoryId, recordedDate',
-				ExclusiveStartKey: lastKey,
-			}),
-		);
-
-		for (const item of result.Items ?? []) {
-			items.push(item);
-		}
-		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
-	} while (lastKey);
+	const items = await queryAllItems(pk, prefix, {
+		filterExpression: '#cancelled = :zero',
+		expressionAttributeNames: { '#cancelled': 'cancelled' },
+		expressionAttributeValues: { ':zero': 0 },
+		projectionExpression: 'categoryId, recordedDate',
+	});
 
 	// Group by categoryId and find max date
 	const catMaxDate = new Map<number, string>();

--- a/src/lib/server/db/dynamodb/image-repo.ts
+++ b/src/lib/server/db/dynamodb/image-repo.ts
@@ -2,19 +2,14 @@
 // DynamoDB implementation of IImageRepo
 
 import { GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
-import type { CharacterImage, Child, InsertCharacterImageInput } from '../types';
+import type { CharacterImage, InsertCharacterImageInput } from '../types';
 import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import { characterImageKey, characterImagePrefix, childKey, ENTITY_NAMES, tenantPK } from './keys';
+import { findChildByIdRaw, stripKeys } from './repo-helpers';
 
-/** Strip PK/SK/GSI keys from a DynamoDB item */
-function stripKeys<T extends Record<string, unknown>>(
-	item: T,
-): Omit<T, 'PK' | 'SK' | 'GSI2PK' | 'GSI2SK'> {
-	const { PK, SK, GSI2PK, GSI2SK, ...rest } = item;
-	return rest;
-}
+export { findChildByIdRaw as findChildForImage } from './repo-helpers';
 
 /** キャッシュされた画像を取得 */
 export async function findCachedImage(
@@ -89,22 +84,6 @@ export async function updateChildAvatarUrl(
 			},
 		}),
 	);
-}
-
-/** 子供情報を取得 */
-export async function findChildForImage(
-	childId: number,
-	tenantId: string,
-): Promise<Child | undefined> {
-	const result = await getDocClient().send(
-		new GetCommand({
-			TableName: TABLE_NAME,
-			Key: childKey(childId, tenantId),
-		}),
-	);
-
-	if (!result.Item) return undefined;
-	return stripKeys(result.Item) as unknown as Child;
 }
 
 /** テナントの全キャラクター画像レコードを削除（CHILD#* 配下の IMG# アイテム） */

--- a/src/lib/server/db/dynamodb/login-bonus-repo.ts
+++ b/src/lib/server/db/dynamodb/login-bonus-repo.ts
@@ -146,7 +146,5 @@ export async function deleteLoginBonusesBeforeDate(
 		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
 	} while (lastKey);
 
-	return batchDeleteItems(
-		items.map((it) => ({ PK: it.PK as string, SK: it.SK as string })),
-	);
+	return batchDeleteItems(items.map((it) => ({ PK: it.PK as string, SK: it.SK as string })));
 }

--- a/src/lib/server/db/dynamodb/login-bonus-repo.ts
+++ b/src/lib/server/db/dynamodb/login-bonus-repo.ts
@@ -2,19 +2,14 @@
 // DynamoDB implementation of ILoginBonusRepo
 
 import { BatchWriteCommand, GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
-import type { Child, InsertLoginBonusInput, LoginBonus } from '../types';
+import type { InsertLoginBonusInput, LoginBonus } from '../types';
 import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
-import { childKey, childPK, ENTITY_NAMES, loginBonusKey, loginBonusPrefix, tenantPK } from './keys';
+import { childPK, ENTITY_NAMES, loginBonusKey, loginBonusPrefix, tenantPK } from './keys';
+import { batchDeleteItems, findChildByIdRaw, stripKeys } from './repo-helpers';
 
-/** Strip PK/SK/GSI keys from a DynamoDB item */
-function stripKeys<T extends Record<string, unknown>>(
-	item: T,
-): Omit<T, 'PK' | 'SK' | 'GSI2PK' | 'GSI2SK'> {
-	const { PK, SK, GSI2PK, GSI2SK, ...rest } = item;
-	return rest;
-}
+export { findChildByIdRaw as findChildById } from './repo-helpers';
 
 /** 今日のログインボーナスを取得 */
 export async function findTodayBonus(
@@ -93,19 +88,6 @@ export async function insertLoginBonus(
 	return bonus;
 }
 
-/** 子供の存在確認 */
-export async function findChildById(id: number, tenantId: string): Promise<Child | undefined> {
-	const result = await getDocClient().send(
-		new GetCommand({
-			TableName: TABLE_NAME,
-			Key: childKey(id, tenantId),
-		}),
-	);
-
-	if (!result.Item) return undefined;
-	return stripKeys(result.Item) as unknown as Child;
-}
-
 /** テナントの全ログインボーナスを削除（CHILD#* 配下の LOGIN# アイテム） */
 export async function deleteByTenantId(tenantId: string): Promise<void> {
 	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), loginBonusPrefix());
@@ -164,19 +146,7 @@ export async function deleteLoginBonusesBeforeDate(
 		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
 	} while (lastKey);
 
-	// BatchWrite in chunks of 25
-	for (let i = 0; i < items.length; i += 25) {
-		const chunk = items.slice(i, i + 25);
-		await getDocClient().send(
-			new BatchWriteCommand({
-				RequestItems: {
-					[TABLE_NAME]: chunk.map((it) => ({
-						DeleteRequest: { Key: { PK: it.PK as string, SK: it.SK as string } },
-					})),
-				},
-			}),
-		);
-	}
-
-	return items.length;
+	return batchDeleteItems(
+		items.map((it) => ({ PK: it.PK as string, SK: it.SK as string })),
+	);
 }

--- a/src/lib/server/db/dynamodb/point-repo.ts
+++ b/src/lib/server/db/dynamodb/point-repo.ts
@@ -8,12 +8,11 @@ import {
 	QueryCommand,
 	UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
-import type { Child, InsertPointLedgerInput, PointLedgerEntry } from '../types';
+import type { InsertPointLedgerInput, PointLedgerEntry } from '../types';
 import { deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
-	childKey,
 	childPK,
 	ENTITY_NAMES,
 	pointBalanceKey,
@@ -21,14 +20,9 @@ import {
 	pointLedgerPrefix,
 	tenantPK,
 } from './keys';
+import { batchDeleteItems, findChildByIdRaw, stripKeys } from './repo-helpers';
 
-/** Strip PK/SK/GSI keys from a DynamoDB item */
-function stripKeys<T extends Record<string, unknown>>(
-	item: T,
-): Omit<T, 'PK' | 'SK' | 'GSI2PK' | 'GSI2SK'> {
-	const { PK, SK, GSI2PK, GSI2SK, ...rest } = item;
-	return rest;
-}
+export { findChildByIdRaw as findChildById } from './repo-helpers';
 
 /** ポイント残高を取得 */
 export async function getBalance(childId: number, tenantId: string): Promise<number> {
@@ -127,19 +121,6 @@ export async function insertPointEntry(
 	return entry;
 }
 
-/** 子供の存在確認 */
-export async function findChildById(id: number, tenantId: string): Promise<Child | undefined> {
-	const result = await getDocClient().send(
-		new GetCommand({
-			TableName: TABLE_NAME,
-			Key: childKey(id, tenantId),
-		}),
-	);
-
-	if (!result.Item) return undefined;
-	return stripKeys(result.Item) as unknown as Child;
-}
-
 /** テナントの全ポイント台帳・残高を削除（CHILD#* 配下の POINT# + BALANCE アイテム） */
 export async function deleteByTenantId(tenantId: string): Promise<void> {
 	// Delete point ledger entries (POINT#...)
@@ -191,19 +172,7 @@ export async function deletePointLedgerBeforeDate(
 		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
 	} while (lastKey);
 
-	// BatchWrite in chunks of 25
-	for (let i = 0; i < items.length; i += 25) {
-		const chunk = items.slice(i, i + 25);
-		await getDocClient().send(
-			new BatchWriteCommand({
-				RequestItems: {
-					[TABLE_NAME]: chunk.map((it) => ({
-						DeleteRequest: { Key: { PK: it.PK as string, SK: it.SK as string } },
-					})),
-				},
-			}),
-		);
-	}
-
-	return items.length;
+	return batchDeleteItems(
+		items.map((it) => ({ PK: it.PK as string, SK: it.SK as string })),
+	);
 }

--- a/src/lib/server/db/dynamodb/point-repo.ts
+++ b/src/lib/server/db/dynamodb/point-repo.ts
@@ -172,7 +172,5 @@ export async function deletePointLedgerBeforeDate(
 		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
 	} while (lastKey);
 
-	return batchDeleteItems(
-		items.map((it) => ({ PK: it.PK as string, SK: it.SK as string })),
-	);
+	return batchDeleteItems(items.map((it) => ({ PK: it.PK as string, SK: it.SK as string })));
 }

--- a/src/lib/server/db/dynamodb/repo-helpers.ts
+++ b/src/lib/server/db/dynamodb/repo-helpers.ts
@@ -71,9 +71,7 @@ export async function queryAllItems(
  * PK/SK キーの配列を 25 件ずつ BatchWriteCommand で削除する。
  * login-bonus-repo / point-repo / child-repo で重複していた BatchWrite ループを共通化。
  */
-export async function batchDeleteItems(
-	keys: Array<{ PK: string; SK: string }>,
-): Promise<number> {
+export async function batchDeleteItems(keys: Array<{ PK: string; SK: string }>): Promise<number> {
 	const doc = getDocClient();
 
 	for (let i = 0; i < keys.length; i += BATCH_SIZE) {
@@ -100,10 +98,7 @@ export async function batchDeleteItems(
  * Note: child-repo.ts の findChildById は hydration + write-back を含むため別物。
  * この関数は簡易的な存在確認用途。
  */
-export async function findChildByIdRaw(
-	id: number,
-	tenantId: string,
-): Promise<Child | undefined> {
+export async function findChildByIdRaw(id: number, tenantId: string): Promise<Child | undefined> {
 	const result = await getDocClient().send(
 		new GetCommand({
 			TableName: TABLE_NAME,

--- a/src/lib/server/db/dynamodb/repo-helpers.ts
+++ b/src/lib/server/db/dynamodb/repo-helpers.ts
@@ -1,0 +1,116 @@
+// src/lib/server/db/dynamodb/repo-helpers.ts
+// DynamoDB repo 層の共通ヘルパ (#983)
+// - stripKeys: PK/SK/GSI キーの除去
+// - queryAllItems: ページネーション付きクエリ
+// - batchDeleteItems: 25 件ずつの BatchWrite 削除
+// - findChildByIdRaw: 子供プロフィールの直接取得(hydration なし)
+
+import { BatchWriteCommand, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import type { Child } from '../types';
+import { getDocClient, TABLE_NAME } from './client';
+import { childKey } from './keys';
+
+const BATCH_SIZE = 25;
+
+/**
+ * DynamoDB アイテムから PK/SK/GSI キーを除去して純粋なエンティティデータを返す。
+ * 全 repo で同一の実装が重複していたものを共通化。
+ */
+export function stripKeys<T extends Record<string, unknown>>(
+	item: T,
+): Omit<T, 'PK' | 'SK' | 'GSI2PK' | 'GSI2SK'> {
+	const { PK, SK, GSI2PK, GSI2SK, ...rest } = item;
+	return rest;
+}
+
+/**
+ * PK + SK prefix でクエリし、ページネーションを自動処理して全アイテムを返す。
+ * evaluation-repo / status-repo / login-bonus-repo 等で重複していたパターンを共通化。
+ */
+export async function queryAllItems(
+	pk: string,
+	skPrefix: string,
+	opts?: {
+		filterExpression?: string;
+		expressionAttributeNames?: Record<string, string>;
+		expressionAttributeValues?: Record<string, unknown>;
+		projectionExpression?: string;
+	},
+): Promise<Record<string, unknown>[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				FilterExpression: opts?.filterExpression,
+				ExpressionAttributeNames: opts?.expressionAttributeNames,
+				ExpressionAttributeValues: {
+					':pk': pk,
+					':prefix': skPrefix,
+					...opts?.expressionAttributeValues,
+				},
+				ProjectionExpression: opts?.projectionExpression,
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+
+		for (const item of result.Items ?? []) {
+			items.push(item);
+		}
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+
+	return items;
+}
+
+/**
+ * PK/SK キーの配列を 25 件ずつ BatchWriteCommand で削除する。
+ * login-bonus-repo / point-repo / child-repo で重複していた BatchWrite ループを共通化。
+ */
+export async function batchDeleteItems(
+	keys: Array<{ PK: string; SK: string }>,
+): Promise<number> {
+	const doc = getDocClient();
+
+	for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+		const chunk = keys.slice(i, i + BATCH_SIZE);
+		await doc.send(
+			new BatchWriteCommand({
+				RequestItems: {
+					[TABLE_NAME]: chunk.map((key) => ({
+						DeleteRequest: { Key: key },
+					})),
+				},
+			}),
+		);
+	}
+
+	return keys.length;
+}
+
+/**
+ * 子供プロフィールを直接取得する（hydration なし）。
+ * evaluation-repo / login-bonus-repo / point-repo / daily-mission-repo / image-repo で
+ * 各 repo が独自に findChildById を定義していた重複を解消。
+ *
+ * Note: child-repo.ts の findChildById は hydration + write-back を含むため別物。
+ * この関数は簡易的な存在確認用途。
+ */
+export async function findChildByIdRaw(
+	id: number,
+	tenantId: string,
+): Promise<Child | undefined> {
+	const result = await getDocClient().send(
+		new GetCommand({
+			TableName: TABLE_NAME,
+			Key: childKey(id, tenantId),
+		}),
+	);
+
+	if (!result.Item) return undefined;
+	return stripKeys(result.Item) as unknown as Child;
+}

--- a/src/lib/server/db/dynamodb/status-repo.ts
+++ b/src/lib/server/db/dynamodb/status-repo.ts
@@ -34,14 +34,7 @@ import {
 	statusPrefix,
 	tenantPK,
 } from './keys';
-
-/** Strip PK/SK/GSI keys from a DynamoDB item */
-function stripKeys<T extends Record<string, unknown>>(
-	item: T,
-): Omit<T, 'PK' | 'SK' | 'GSI2PK' | 'GSI2SK'> {
-	const { PK, SK, GSI2PK, GSI2SK, ...rest } = item;
-	return rest;
-}
+import { queryAllItems, stripKeys } from './repo-helpers';
 
 /** DynamoDB アイテムをマイグレーション（必要なら Write-Back） */
 async function hydrateStatus(
@@ -372,32 +365,12 @@ export async function findLastActivityDates(
 	const pk = childPK(childId, tenantId);
 	const prefix = activityLogPrefix();
 
-	// Query all activity logs for this child
-	const items: Record<string, unknown>[] = [];
-	let lastKey: Record<string, unknown> | undefined;
-
-	do {
-		const result = await getDocClient().send(
-			new QueryCommand({
-				TableName: TABLE_NAME,
-				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
-				FilterExpression: '#cancelled = :zero',
-				ExpressionAttributeNames: { '#cancelled': 'cancelled' },
-				ExpressionAttributeValues: {
-					':pk': pk,
-					':prefix': prefix,
-					':zero': 0,
-				},
-				ProjectionExpression: 'activityId, recordedDate',
-				ExclusiveStartKey: lastKey,
-			}),
-		);
-
-		for (const item of result.Items ?? []) {
-			items.push(item);
-		}
-		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
-	} while (lastKey);
+	const items = await queryAllItems(pk, prefix, {
+		filterExpression: '#cancelled = :zero',
+		expressionAttributeNames: { '#cancelled': 'cancelled' },
+		expressionAttributeValues: { ':zero': 0 },
+		projectionExpression: 'activityId, recordedDate',
+	});
 
 	// Group by activityId and find max date
 	const activityMaxDate = new Map<number, string>();

--- a/tests/unit/db/repo-helpers.test.ts
+++ b/tests/unit/db/repo-helpers.test.ts
@@ -26,6 +26,14 @@ import {
 	stripKeys,
 } from '../../../src/lib/server/db/dynamodb/repo-helpers';
 
+/** mockSend.mock.calls[n][0] を型安全に取得するヘルパー */
+// biome-ignore lint/suspicious/noExplicitAny: テストヘルパー — mock の戻り値型が不定
+function getSentCommand(callIndex: number): any {
+	const call = mockSend.mock.calls[callIndex];
+	if (!call) throw new Error(`mock call[${callIndex}] is undefined`);
+	return call[0];
+}
+
 beforeEach(() => {
 	mockSend.mockReset();
 });
@@ -90,7 +98,7 @@ describe('queryAllItems', () => {
 		expect(result[0]).toEqual({ PK: 'T#t1#CHILD#1', SK: 'LOG#2026-01-01', id: 1 });
 		expect(mockSend).toHaveBeenCalledTimes(1);
 
-		const command = mockSend.mock.calls[0][0];
+		const command = getSentCommand(0);
 		expect(command).toBeInstanceOf(QueryCommand);
 	});
 
@@ -149,7 +157,7 @@ describe('queryAllItems', () => {
 			projectionExpression: 'id, #s',
 		});
 
-		const command = mockSend.mock.calls[0][0] as QueryCommand;
+		const command = getSentCommand(0) as QueryCommand;
 		const input = command.input;
 		expect(input.FilterExpression).toBe('#s = :status');
 		expect(input.ExpressionAttributeNames).toEqual({ '#s': 'status' });
@@ -179,7 +187,7 @@ describe('batchDeleteItems', () => {
 		expect(count).toBe(2);
 		expect(mockSend).toHaveBeenCalledTimes(1);
 
-		const command = mockSend.mock.calls[0][0];
+		const command = getSentCommand(0);
 		expect(command).toBeInstanceOf(BatchWriteCommand);
 		const requestItems = command.input.RequestItems?.['test-table'];
 		expect(requestItems).toHaveLength(2);
@@ -199,8 +207,8 @@ describe('batchDeleteItems', () => {
 		// 25 + 5 = 2 batches
 		expect(mockSend).toHaveBeenCalledTimes(2);
 
-		const firstBatch = mockSend.mock.calls[0][0].input.RequestItems?.['test-table'];
-		const secondBatch = mockSend.mock.calls[1][0].input.RequestItems?.['test-table'];
+		const firstBatch = getSentCommand(0).input.RequestItems?.['test-table'];
+		const secondBatch = getSentCommand(1).input.RequestItems?.['test-table'];
 		expect(firstBatch).toHaveLength(25);
 		expect(secondBatch).toHaveLength(5);
 	});
@@ -251,7 +259,7 @@ describe('findChildByIdRaw', () => {
 		expect(child).not.toHaveProperty('PK');
 		expect(child).not.toHaveProperty('SK');
 
-		const command = mockSend.mock.calls[0][0];
+		const command = getSentCommand(0);
 		expect(command).toBeInstanceOf(GetCommand);
 		expect(command.input.Key).toEqual({
 			PK: 'T#tenant1#CHILD#1',

--- a/tests/unit/db/repo-helpers.test.ts
+++ b/tests/unit/db/repo-helpers.test.ts
@@ -1,0 +1,269 @@
+// tests/unit/db/repo-helpers.test.ts
+// repo-helpers.ts のユニットテスト (#1041)
+
+import { BatchWriteCommand, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- mock: DynamoDB client ---
+const mockSend = vi.fn();
+vi.mock('../../../src/lib/server/db/dynamodb/client', () => ({
+	getDocClient: () => ({ send: mockSend }),
+	TABLE_NAME: 'test-table',
+}));
+
+// --- mock: keys (childKey) ---
+vi.mock('../../../src/lib/server/db/dynamodb/keys', () => ({
+	childKey: (id: number, tenantId: string) => ({
+		PK: `T#${tenantId}#CHILD#${id}`,
+		SK: 'PROFILE',
+	}),
+}));
+
+import {
+	batchDeleteItems,
+	findChildByIdRaw,
+	queryAllItems,
+	stripKeys,
+} from '../../../src/lib/server/db/dynamodb/repo-helpers';
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+// ============================================================
+// stripKeys
+// ============================================================
+
+describe('stripKeys', () => {
+	it('PK, SK, GSI2PK, GSI2SK を除去する', () => {
+		const input = {
+			PK: 'T#1',
+			SK: 'CHILD#1',
+			GSI2PK: 'g2',
+			GSI2SK: 'g2s',
+			id: 1,
+			name: 'test',
+		};
+		const result = stripKeys(input);
+		expect(result).toEqual({ id: 1, name: 'test' });
+		expect(result).not.toHaveProperty('PK');
+		expect(result).not.toHaveProperty('SK');
+		expect(result).not.toHaveProperty('GSI2PK');
+		expect(result).not.toHaveProperty('GSI2SK');
+	});
+
+	it('PK/SK のみ存在する場合でも正常に動作する', () => {
+		const input = { PK: 'T#1', SK: 'PROFILE', nickname: 'たろう', age: 5 };
+		const result = stripKeys(input);
+		expect(result).toEqual({ nickname: 'たろう', age: 5 });
+	});
+
+	it('除去対象キーが無い場合はそのまま返す', () => {
+		const input = { id: 42, name: 'hello' };
+		const result = stripKeys(input);
+		expect(result).toEqual({ id: 42, name: 'hello' });
+	});
+
+	it('空オブジェクトを渡すと空オブジェクトを返す', () => {
+		const result = stripKeys({});
+		expect(result).toEqual({});
+	});
+});
+
+// ============================================================
+// queryAllItems
+// ============================================================
+
+describe('queryAllItems', () => {
+	it('単一ページの結果を返す（LastEvaluatedKey なし）', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				{ PK: 'T#t1#CHILD#1', SK: 'LOG#2026-01-01', id: 1 },
+				{ PK: 'T#t1#CHILD#1', SK: 'LOG#2026-01-02', id: 2 },
+			],
+			LastEvaluatedKey: undefined,
+		});
+
+		const result = await queryAllItems('T#t1#CHILD#1', 'LOG#');
+
+		expect(result).toHaveLength(2);
+		expect(result[0]).toEqual({ PK: 'T#t1#CHILD#1', SK: 'LOG#2026-01-01', id: 1 });
+		expect(mockSend).toHaveBeenCalledTimes(1);
+
+		const command = mockSend.mock.calls[0][0];
+		expect(command).toBeInstanceOf(QueryCommand);
+	});
+
+	it('複数ページをページネーションで全件取得する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ PK: 'pk', SK: 'sk1', val: 'a' }],
+				LastEvaluatedKey: { PK: 'pk', SK: 'sk1' },
+			})
+			.mockResolvedValueOnce({
+				Items: [{ PK: 'pk', SK: 'sk2', val: 'b' }],
+				LastEvaluatedKey: { PK: 'pk', SK: 'sk2' },
+			})
+			.mockResolvedValueOnce({
+				Items: [{ PK: 'pk', SK: 'sk3', val: 'c' }],
+				LastEvaluatedKey: undefined,
+			});
+
+		const result = await queryAllItems('pk', 'sk');
+
+		expect(result).toHaveLength(3);
+		expect(result.map((r) => r.val)).toEqual(['a', 'b', 'c']);
+		expect(mockSend).toHaveBeenCalledTimes(3);
+	});
+
+	it('結果が空の場合は空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [],
+			LastEvaluatedKey: undefined,
+		});
+
+		const result = await queryAllItems('pk', 'prefix');
+
+		expect(result).toEqual([]);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+
+	it('Items が undefined の場合も空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: undefined,
+			LastEvaluatedKey: undefined,
+		});
+
+		const result = await queryAllItems('pk', 'prefix');
+
+		expect(result).toEqual([]);
+	});
+
+	it('オプション（filterExpression 等）を QueryCommand に渡す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+
+		await queryAllItems('pk', 'prefix', {
+			filterExpression: '#s = :status',
+			expressionAttributeNames: { '#s': 'status' },
+			expressionAttributeValues: { ':status': 'active' },
+			projectionExpression: 'id, #s',
+		});
+
+		const command = mockSend.mock.calls[0][0] as QueryCommand;
+		const input = command.input;
+		expect(input.FilterExpression).toBe('#s = :status');
+		expect(input.ExpressionAttributeNames).toEqual({ '#s': 'status' });
+		expect(input.ExpressionAttributeValues).toEqual({
+			':pk': 'pk',
+			':prefix': 'prefix',
+			':status': 'active',
+		});
+		expect(input.ProjectionExpression).toBe('id, #s');
+	});
+});
+
+// ============================================================
+// batchDeleteItems
+// ============================================================
+
+describe('batchDeleteItems', () => {
+	it('キーの配列を BatchWriteCommand で削除し件数を返す', async () => {
+		mockSend.mockResolvedValue({});
+
+		const keys = [
+			{ PK: 'pk1', SK: 'sk1' },
+			{ PK: 'pk2', SK: 'sk2' },
+		];
+		const count = await batchDeleteItems(keys);
+
+		expect(count).toBe(2);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+
+		const command = mockSend.mock.calls[0][0];
+		expect(command).toBeInstanceOf(BatchWriteCommand);
+		const requestItems = command.input.RequestItems?.['test-table'];
+		expect(requestItems).toHaveLength(2);
+		expect(requestItems?.[0]).toEqual({ DeleteRequest: { Key: { PK: 'pk1', SK: 'sk1' } } });
+	});
+
+	it('25 件を超えるキーを複数バッチに分割して削除する', async () => {
+		mockSend.mockResolvedValue({});
+
+		const keys = Array.from({ length: 30 }, (_, i) => ({
+			PK: `pk${i}`,
+			SK: `sk${i}`,
+		}));
+		const count = await batchDeleteItems(keys);
+
+		expect(count).toBe(30);
+		// 25 + 5 = 2 batches
+		expect(mockSend).toHaveBeenCalledTimes(2);
+
+		const firstBatch = mockSend.mock.calls[0][0].input.RequestItems?.['test-table'];
+		const secondBatch = mockSend.mock.calls[1][0].input.RequestItems?.['test-table'];
+		expect(firstBatch).toHaveLength(25);
+		expect(secondBatch).toHaveLength(5);
+	});
+
+	it('空配列の場合は 0 を返し send を呼ばない', async () => {
+		const count = await batchDeleteItems([]);
+
+		expect(count).toBe(0);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it('ちょうど 25 件の場合は 1 バッチで処理する', async () => {
+		mockSend.mockResolvedValue({});
+
+		const keys = Array.from({ length: 25 }, (_, i) => ({
+			PK: `pk${i}`,
+			SK: `sk${i}`,
+		}));
+		const count = await batchDeleteItems(keys);
+
+		expect(count).toBe(25);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ============================================================
+// findChildByIdRaw
+// ============================================================
+
+describe('findChildByIdRaw', () => {
+	it('子供プロフィールを取得して PK/SK を除去して返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Item: {
+				PK: 'T#tenant1#CHILD#1',
+				SK: 'PROFILE',
+				id: 1,
+				nickname: 'たろう',
+				age: 5,
+				theme: 'blue',
+			},
+		});
+
+		const child = await findChildByIdRaw(1, 'tenant1');
+
+		expect(child).toBeDefined();
+		expect(child?.id).toBe(1);
+		expect(child?.nickname).toBe('たろう');
+		expect(child).not.toHaveProperty('PK');
+		expect(child).not.toHaveProperty('SK');
+
+		const command = mockSend.mock.calls[0][0];
+		expect(command).toBeInstanceOf(GetCommand);
+		expect(command.input.Key).toEqual({
+			PK: 'T#tenant1#CHILD#1',
+			SK: 'PROFILE',
+		});
+	});
+
+	it('存在しない子供の場合は undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Item: undefined });
+
+		const child = await findChildByIdRaw(999, 'tenant1');
+
+		expect(child).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- `src/lib/server/db/dynamodb/repo-helpers.ts` を新設し、全 repo で重複していた以下の共通パターンを抽出
  - `stripKeys`: PK/SK/GSI キーの除去（8 repo で重複 → 1 箇所に統一）
  - `queryAllItems`: ページネーション付きクエリラッパ（evaluation-repo / status-repo の 21 行重複を解消）
  - `batchDeleteItems`: 25 件ずつの BatchWrite 削除ループ（login-bonus-repo / point-repo / child-repo の重複を解消）
  - `findChildByIdRaw`: 簡易的な子供プロフィール取得（login-bonus / point / daily-mission / image の 4 repo で重複していた findChildById を統一）
- 対象 repo: evaluation / status / login-bonus / point / checklist / child / daily-mission / image

## Test plan
- [x] `npx vitest run` — 3180 テスト全通過
- [ ] DynamoDB 関連テストの動作確認

closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)