### PR TITLE
refactor: getLevelEvaluationText をテーブル駆動に置換 (#974)

### DIFF
--- a/src/lib/domain/validation/status.ts
+++ b/src/lib/domain/validation/status.ts
@@ -189,17 +189,32 @@ export function calcActivitiesToNextLevel(totalXp: number, avgPointsPerActivity 
 // Level-based Evaluation Text (replaces deviation-based for child UI)
 // ================================================================
 
+export type LevelEvaluationTier = {
+	readonly minLevel: number;
+	readonly text: string;
+	readonly emoji: string;
+};
+
+/** minLevel 降順。配列要素の追加は他要素に影響しない（データ駆動） */
+export const LEVEL_EVALUATION_TIERS: readonly LevelEvaluationTier[] = [
+	{ minLevel: 50, text: 'でんせつのぼうけんしゃ！', emoji: '👑' },
+	{ minLevel: 30, text: 'もはやたつじん！', emoji: '🏆' },
+	{ minLevel: 20, text: 'すばらしいせいちょう！', emoji: '🌟' },
+	{ minLevel: 10, text: 'めちゃくちゃがんばってる！', emoji: '🔥' },
+	{ minLevel: 7, text: 'たつじんレベル！', emoji: '⭐' },
+	{ minLevel: 5, text: 'すごいぞ！', emoji: '✨' },
+	{ minLevel: 3, text: 'いいかんじ！', emoji: '😊' },
+	{ minLevel: 2, text: 'そのちょうしだ！', emoji: '💪' },
+	{ minLevel: 0, text: 'はじめのいっぽ！', emoji: '🌱' },
+] as const;
+
 /** レベルに連動した評価文（子供画面用） */
 export function getLevelEvaluationText(level: number): { text: string; emoji: string } {
-	if (level >= 50) return { text: 'でんせつのぼうけんしゃ！', emoji: '👑' };
-	if (level >= 30) return { text: 'もはやたつじん！', emoji: '🏆' };
-	if (level >= 20) return { text: 'すばらしいせいちょう！', emoji: '🌟' };
-	if (level >= 10) return { text: 'めちゃくちゃがんばってる！', emoji: '🔥' };
-	if (level >= 7) return { text: 'たつじんレベル！', emoji: '⭐' };
-	if (level >= 5) return { text: 'すごいぞ！', emoji: '✨' };
-	if (level >= 3) return { text: 'いいかんじ！', emoji: '😊' };
-	if (level >= 2) return { text: 'そのちょうしだ！', emoji: '💪' };
-	return { text: 'はじめのいっぽ！', emoji: '🌱' };
+	const tier =
+		LEVEL_EVALUATION_TIERS.find((t) => level >= t.minLevel) ??
+		LEVEL_EVALUATION_TIERS[LEVEL_EVALUATION_TIERS.length - 1];
+	if (!tier) throw new Error('LEVEL_EVALUATION_TIERS must include minLevel: 0 terminator');
+	return { text: tier.text, emoji: tier.emoji };
 }
 
 // ================================================================

--- a/tests/unit/domain/status-validation.test.ts
+++ b/tests/unit/domain/status-validation.test.ts
@@ -16,6 +16,7 @@ import {
 	getAgeCoefficient,
 	getComparisonLabel,
 	getLevelEvaluationText,
+	LEVEL_EVALUATION_TIERS,
 	LEVEL_TABLE,
 } from '../../../src/lib/domain/validation/status';
 
@@ -197,6 +198,28 @@ describe('calcActivitiesToNextLevel', () => {
 // getLevelEvaluationText
 // ================================================================
 
+describe('LEVEL_EVALUATION_TIERS', () => {
+	it('終端（minLevel: 0）が存在する', () => {
+		const terminator = LEVEL_EVALUATION_TIERS.find((t) => t.minLevel === 0);
+		expect(terminator).toBeDefined();
+	});
+
+	it('minLevel が降順にソートされている', () => {
+		for (let i = 1; i < LEVEL_EVALUATION_TIERS.length; i++) {
+			const prev = LEVEL_EVALUATION_TIERS[i - 1];
+			const curr = LEVEL_EVALUATION_TIERS[i];
+			expect(prev?.minLevel).toBeGreaterThan(curr?.minLevel ?? 0);
+		}
+	});
+
+	it('全エントリに text と emoji がある', () => {
+		for (const tier of LEVEL_EVALUATION_TIERS) {
+			expect(tier.text.length).toBeGreaterThan(0);
+			expect(tier.emoji.length).toBeGreaterThan(0);
+		}
+	});
+});
+
 describe('getLevelEvaluationText', () => {
 	it('Lv.1は「はじめのいっぽ」', () => {
 		const result = getLevelEvaluationText(1);
@@ -218,6 +241,28 @@ describe('getLevelEvaluationText', () => {
 
 	it('Lv.50は「でんせつのぼうけんしゃ」', () => {
 		expect(getLevelEvaluationText(50).text).toBe('でんせつのぼうけんしゃ！');
+	});
+
+	// 境界値テスト（AC 要件: level -1, 0, 1, 2, 3, 4, 5, 6, 7, 10, 20, 30, 50, 100）
+	it.each([
+		{ level: -1, expectedText: 'はじめのいっぽ！', expectedEmoji: '🌱' },
+		{ level: 0, expectedText: 'はじめのいっぽ！', expectedEmoji: '🌱' },
+		{ level: 1, expectedText: 'はじめのいっぽ！', expectedEmoji: '🌱' },
+		{ level: 2, expectedText: 'そのちょうしだ！', expectedEmoji: '💪' },
+		{ level: 3, expectedText: 'いいかんじ！', expectedEmoji: '😊' },
+		{ level: 4, expectedText: 'いいかんじ！', expectedEmoji: '😊' },
+		{ level: 5, expectedText: 'すごいぞ！', expectedEmoji: '✨' },
+		{ level: 6, expectedText: 'すごいぞ！', expectedEmoji: '✨' },
+		{ level: 7, expectedText: 'たつじんレベル！', expectedEmoji: '⭐' },
+		{ level: 10, expectedText: 'めちゃくちゃがんばってる！', expectedEmoji: '🔥' },
+		{ level: 20, expectedText: 'すばらしいせいちょう！', expectedEmoji: '🌟' },
+		{ level: 30, expectedText: 'もはやたつじん！', expectedEmoji: '🏆' },
+		{ level: 50, expectedText: 'でんせつのぼうけんしゃ！', expectedEmoji: '👑' },
+		{ level: 100, expectedText: 'でんせつのぼうけんしゃ！', expectedEmoji: '👑' },
+	])('level=$level → "$expectedText"', ({ level, expectedText, expectedEmoji }) => {
+		const result = getLevelEvaluationText(level);
+		expect(result.text).toBe(expectedText);
+		expect(result.emoji).toBe(expectedEmoji);
 	});
 });
 


### PR DESCRIPTION
## Summary
- `LEVEL_EVALUATION_TIERS` 配列を export し、`getLevelEvaluationText` を `Array.find` ベースに書き換え
- 9 段の if-else 分岐を minLevel 降順の配列走査に置換（データ駆動）
- `LevelEvaluationTier` 型を export（テスト・ドキュメント生成で参照可能）
- 負の level 値にも旧実装と同じ結果を返すフォールバックを追加

## Test plan
- [x] `LEVEL_EVALUATION_TIERS` の構造検証（終端 minLevel:0 の存在、降順ソート、全エントリに text/emoji）
- [x] 境界値テスト（level: -1, 0, 1, 2, 3, 4, 5, 6, 7, 10, 20, 30, 50, 100）で新旧一致を確認
- [x] `npx biome check` pass
- [x] `npx vitest run` -- 全 3197 テスト pass（Storybook 関連の既存 failure を除く）

Closes #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)