### PR TITLE
infra(ci): #1007 e2e-production に Playwright browser cache 共有

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -388,8 +388,22 @@ jobs:
 
       - run: npm ci
 
+      # #1007: test job と同一の cache key で Playwright browsers を共有
+      # 同一 workflow run 内では test job が保存した cache を即時利用可能
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright deps (cached browsers)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       # CloudFront Geo Restriction (JP only) のため、Lambda Function URL 直接でテスト
       - name: Configure AWS credentials (OIDC)


### PR DESCRIPTION
## Summary
closes #1007

deploy.yml の `e2e-production` job で Playwright ブラウザが毎回フルインストール (24s) されていた問題を修正。`test` job と同一の `actions/cache` key を使用し、cache hit 時は `install-deps` のみ (~5s) に短縮。

### 変更内容

`e2e-production` job に以下の 3 step を追加:
1. `Cache Playwright browsers` - `actions/cache@v5` で `playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}` key を使用
2. `Install Playwright browsers` - cache miss 時のみフルインストール
3. `Install Playwright deps (cached browsers)` - cache hit 時は OS deps のみ

### 波及チェック
- `ci.yml` の `e2e-test` job: 既にキャッシュ対応済み
- `deploy-nuc.yml`: Playwright 未使用
- 他の workflow: Playwright 未使用

### 計測
- **変更前**: `Install Playwright browsers` = 24s (無条件フルインストール)
- **変更後目標**: ~5s (cache hit 時は `install-deps` のみ)

## Test plan
- [ ] deploy.yml の e2e-production で Playwright install が cache hit で 10s 以下になること
- [ ] Production smoke test の成功率が変更前後で同等であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)