### PR TITLE
refactor: #966 サービス層の日付計算を todayDateJST() に統一

### DIFF
--- a/src/lib/domain/date-utils.ts
+++ b/src/lib/domain/date-utils.ts
@@ -1,5 +1,23 @@
 // src/lib/domain/date-utils.ts
 // 日付ユーティリティ（JST固定）
+//
+// ## 日時管理方針（#966）
+//
+// 本プロジェクトでは recorded_date カラムが YYYY-MM-DD テキスト型のため、
+// 日付計算は **JST 基準で統一** する。
+//
+// | レイヤー       | 方針                             |
+// |---------------|--------------------------------|
+// | DB 保存       | JST 基準の YYYY-MM-DD (recorded_date) |
+// | サービス層     | todayDateJST() を使用（UTC 混在禁止） |
+// | 表示層         | toJSTDateString / formatJSTDateTime を使用 |
+//
+// `new Date().toISOString().slice(0, 10)` は UTC 日付を返すため、
+// 0:00〜9:00 JST の間に当日判定がずれる。サービス層では必ず
+// todayDateJST() を使用すること。
+//
+// 将来 UTC 保存に移行する場合は recorded_at (timestamp) カラムの
+// 新設が必要（#966 コメント 案A 参照）。
 
 const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
@@ -19,4 +37,21 @@ export function prevDateJST(dateStr: string): string {
 	const d = new Date(`${dateStr}T00:00:00Z`);
 	d.setUTCDate(d.getUTCDate() - 1);
 	return d.toISOString().slice(0, 10);
+}
+
+/**
+ * YYYY-MM-DD 日付文字列を JST の表示用文字列に変換する。
+ * 例: '2026-04-13' → '2026年4月13日'
+ */
+export function formatJSTDate(dateStr: string): string {
+	const [y, m, d] = dateStr.split('-').map(Number);
+	return `${y}年${m}月${d}日`;
+}
+
+/**
+ * Date オブジェクトを JST の日時表示用文字列に変換する。
+ * 例: new Date('2026-04-13T01:00:00Z') → '2026/04/13 10:00'
+ */
+export function formatJSTDateTime(date: Date): string {
+	return date.toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' });
 }

--- a/src/lib/server/db/sqlite/sibling-cheer-repo.ts
+++ b/src/lib/server/db/sqlite/sibling-cheer-repo.ts
@@ -1,4 +1,5 @@
 import { and, count, eq, gte, isNull } from 'drizzle-orm';
+import { todayDateJST } from '$lib/domain/date-utils';
 import { db } from '../client';
 import { siblingCheers } from '../schema';
 import type { InsertSiblingCheerInput, SiblingCheer } from '../types';
@@ -45,7 +46,7 @@ export async function countTodayCheersFrom(
 	fromChildId: number,
 	_tenantId: string,
 ): Promise<number> {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	const result = db
 		.select({ value: count() })
 		.from(siblingCheers)

--- a/src/lib/server/services/battle-service.ts
+++ b/src/lib/server/services/battle-service.ts
@@ -5,6 +5,7 @@ import { getEnemyById, selectDailyEnemy } from '$lib/domain/battle-enemies';
 import { executeBattle, scaleEnemyStats } from '$lib/domain/battle-engine';
 import { convertToBattleStats, getAgeScaling } from '$lib/domain/battle-stat-calculator';
 import type { BattleResult, BattleStats, Enemy } from '$lib/domain/battle-types';
+import { todayDateJST } from '$lib/domain/date-utils';
 import {
 	completeBattle,
 	countConsecutiveLosses,
@@ -68,7 +69,7 @@ export async function getTodayBattle(
 	categoryXp: Record<number, number>,
 	tenantId: string,
 ): Promise<TodayBattleInfo> {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	let battle = await findTodayBattle(childId, today, tenantId);
 
 	if (!battle) {
@@ -136,7 +137,7 @@ export async function executeDailyBattle(
 	categoryXp: Record<number, number>,
 	tenantId: string,
 ): Promise<BattleExecutionResult> {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	const battle = await findTodayBattle(childId, today, tenantId);
 
 	if (!battle) {

--- a/src/lib/server/services/family-streak-service.ts
+++ b/src/lib/server/services/family-streak-service.ts
@@ -1,15 +1,9 @@
 // src/lib/server/services/family-streak-service.ts
 // 家族ストリーク — 家族の誰かが毎日記録していれば維持されるストリーク
 
+import { todayDateJST } from '$lib/domain/date-utils';
 import { findDistinctRecordedDates } from '$lib/server/db/activity-repo';
 import { findAllChildren } from '$lib/server/db/child-repo';
-
-/** 今日の日付を JST で取得 */
-function todayDateJST(): string {
-	const now = new Date();
-	const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
-	return jst.toISOString().slice(0, 10);
-}
 
 export interface FamilyStreakInfo {
 	currentStreak: number;

--- a/src/lib/server/services/notification-service.ts
+++ b/src/lib/server/services/notification-service.ts
@@ -4,6 +4,7 @@
 
 import webpush from 'web-push';
 import { formatChildName } from '$lib/domain/child-display';
+import { todayDateJST } from '$lib/domain/date-utils';
 import {
 	countTodayLogs,
 	deleteByEndpoint,
@@ -125,7 +126,7 @@ export async function canSendNotification(tenantId: string): Promise<boolean> {
 	}
 
 	// 日次上限チェック
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	const count = await countTodayLogs(tenantId, today);
 	return count < MAX_DAILY_NOTIFICATIONS;
 }

--- a/src/lib/server/services/season-event-service.ts
+++ b/src/lib/server/services/season-event-service.ts
@@ -1,6 +1,7 @@
 // src/lib/server/services/season-event-service.ts
 // シーズンイベント管理サービス
 
+import { todayDateJST } from '$lib/domain/date-utils';
 import {
 	findActiveEvents,
 	findAllEvents,
@@ -27,7 +28,7 @@ export async function getAllEvents(tenantId: string): Promise<SeasonEvent[]> {
 
 /** 現在開催中のイベント一覧 */
 export async function getActiveEvents(tenantId: string): Promise<SeasonEvent[]> {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	return findActiveEvents(today, tenantId);
 }
 
@@ -36,7 +37,7 @@ export async function getActiveEventsForChild(
 	childId: number,
 	tenantId: string,
 ): Promise<SeasonEventWithProgress[]> {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	const events = await findActiveEvents(today, tenantId);
 
 	const result: SeasonEventWithProgress[] = [];
@@ -90,7 +91,7 @@ export async function checkEventMissionProgress(
 	childId: number,
 	tenantId: string,
 ): Promise<{ eventId: number; missionComplete: boolean; eventName: string }[]> {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	const events = await findActiveEvents(today, tenantId);
 	const results: { eventId: number; missionComplete: boolean; eventName: string }[] = [];
 

--- a/src/lib/server/services/seasonal-content-service.ts
+++ b/src/lib/server/services/seasonal-content-service.ts
@@ -1,6 +1,7 @@
 // src/lib/server/services/seasonal-content-service.ts
 // 季節コンテンツ管理サービス — シーズンパス + 月替わり有料プラン報酬
 
+import { todayDateJST } from '$lib/domain/date-utils';
 import {
 	findActiveEvents,
 	findChildProgress,
@@ -145,7 +146,7 @@ export async function getSeasonPassForChild(
 	tenantId: string,
 	isPremium: boolean,
 ): Promise<SeasonPassData | null> {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	const events = await findActiveEvents(today, tenantId);
 	const passEvent = events.find((e) => e.eventType === 'season_pass');
 	if (!passEvent) return null;
@@ -189,7 +190,7 @@ export async function claimSeasonPassMilestone(
 	if (progress.count < target) return null;
 
 	// Find the milestone reward
-	const events = await findActiveEvents(new Date().toISOString().slice(0, 10), tenantId);
+	const events = await findActiveEvents(todayDateJST(), tenantId);
 	const passEvent = events.find((e) => e.id === eventId);
 	if (!passEvent) return null;
 
@@ -221,7 +222,7 @@ export async function incrementSeasonPassProgress(
 	childId: number,
 	tenantId: string,
 ): Promise<{ eventId: number; newCount: number; newMilestones: SeasonPassMilestone[] } | null> {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	const events = await findActiveEvents(today, tenantId);
 	const passEvent = events.find((e) => e.eventType === 'season_pass');
 	if (!passEvent) return null;
@@ -274,7 +275,7 @@ export async function getMonthlyPremiumReward(
 ): Promise<MonthlyRewardData | null> {
 	if (!isPremium) return null;
 
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	const events = await findActiveEvents(today, tenantId);
 	const rewardEvent = events.find((e) => e.eventType === 'monthly_premium_reward');
 	if (!rewardEvent) return null;
@@ -303,7 +304,7 @@ export async function claimMonthlyPremiumReward(
 	if (progressRow?.status === 'reward_claimed') return null;
 
 	// Find the event
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	const events = await findActiveEvents(today, tenantId);
 	const rewardEvent = events.find((e) => e.id === eventId);
 	if (!rewardEvent) return null;

--- a/src/lib/server/services/sibling-challenge-service.ts
+++ b/src/lib/server/services/sibling-challenge-service.ts
@@ -1,6 +1,7 @@
 // src/lib/server/services/sibling-challenge-service.ts
 // きょうだいチャレンジ — 協力＆ライバル機能のサービス層
 
+import { todayDateJST } from '$lib/domain/date-utils';
 import { insertPointLedger } from '$lib/server/db/activity-repo';
 import { findAllChildren } from '$lib/server/db/child-repo';
 import {
@@ -105,7 +106,7 @@ export async function getActiveChallengesForChild(
 	childId: number,
 	tenantId: string,
 ): Promise<SiblingChallengeWithProgress[]> {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	const challenges = await findActiveChallenges(today, tenantId);
 	const result: SiblingChallengeWithProgress[] = [];
 
@@ -152,7 +153,7 @@ export async function checkChallengeProgress(
 	categoryId: number,
 	tenantId: string,
 ): Promise<{ challengeId: number; allSiblingsComplete: boolean; challengeTitle: string }[]> {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	const challenges = await findActiveChallenges(today, tenantId);
 	const results: { challengeId: number; allSiblingsComplete: boolean; challengeTitle: string }[] =
 		[];

--- a/src/routes/(parent)/admin/challenges/+page.svelte
+++ b/src/routes/(parent)/admin/challenges/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { todayDateJST } from '$lib/domain/date-utils';
 import ProgressFill from '$lib/ui/components/ProgressFill.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
@@ -37,7 +38,7 @@ function isCurrentlyActive(challenge: {
 	startDate: string;
 	endDate: string;
 }): boolean {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	return (
 		challenge.isActive === 1 &&
 		challenge.status === 'active' &&

--- a/src/routes/(parent)/admin/events/+page.svelte
+++ b/src/routes/(parent)/admin/events/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { todayDateJST } from '$lib/domain/date-utils';
 import Button from '$lib/ui/primitives/Button.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
 
@@ -22,7 +23,7 @@ interface SeasonEvent {
 }
 
 function isCurrentlyActive(event: SeasonEvent): boolean {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	return event.isActive === 1 && event.startDate <= today && event.endDate >= today;
 }
 

--- a/src/routes/api/v1/export/+server.ts
+++ b/src/routes/api/v1/export/+server.ts
@@ -2,6 +2,7 @@
 // 家族データエクスポートAPI（JSON / ZIP対応）
 
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { todayDateJST } from '$lib/domain/date-utils';
 import { requireRole, requireTenantId } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
@@ -39,7 +40,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 
 	try {
 		const exportData = await exportFamilyData({ tenantId, childIds, compact });
-		const now = new Date().toISOString().slice(0, 10);
+		const now = todayDateJST();
 
 		if (format === 'zip') {
 			return await buildZipResponse(exportData, tenantId, now, compact);

--- a/src/routes/demo/(parent)/admin/events/+page.svelte
+++ b/src/routes/demo/(parent)/admin/events/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { todayDateJST } from '$lib/domain/date-utils';
 import DemoBanner from '$lib/features/admin/components/DemoBanner.svelte';
 import DemoCta from '$lib/features/admin/components/DemoCta.svelte';
 
@@ -19,7 +20,7 @@ interface SeasonEvent {
 }
 
 function isCurrentlyActive(event: SeasonEvent): boolean {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	return event.isActive === 1 && event.startDate <= today && event.endDate >= today;
 }
 

--- a/tests/unit/domain/date-utils.test.ts
+++ b/tests/unit/domain/date-utils.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { prevDateJST, todayDateJST, toJSTDateString } from '$lib/domain/date-utils';
+import {
+	formatJSTDate,
+	formatJSTDateTime,
+	prevDateJST,
+	todayDateJST,
+	toJSTDateString,
+} from '$lib/domain/date-utils';
 
 describe('date-utils', () => {
 	afterEach(() => {
@@ -55,6 +61,54 @@ describe('date-utils', () => {
 
 		it('年をまたぐ', () => {
 			expect(prevDateJST('2026-01-01')).toBe('2025-12-31');
+		});
+	});
+
+	describe('formatJSTDate', () => {
+		it('YYYY-MM-DD を年月日形式に変換', () => {
+			expect(formatJSTDate('2026-04-13')).toBe('2026年4月13日');
+		});
+
+		it('1月1日のゼロ埋めなし', () => {
+			expect(formatJSTDate('2026-01-01')).toBe('2026年1月1日');
+		});
+	});
+
+	describe('formatJSTDateTime', () => {
+		it('Date を JST 日時文字列に変換', () => {
+			// UTC 2026-04-13 01:00 → JST 2026-04-13 10:00
+			const date = new Date('2026-04-13T01:00:00Z');
+			const result = formatJSTDateTime(date);
+			// toLocaleString のフォーマットは実行環境依存だが、日本語で年月日時分が含まれること
+			expect(result).toContain('2026');
+			expect(result).toContain('4');
+			expect(result).toContain('13');
+		});
+	});
+
+	describe('todayDateJST vs UTC の差異（#966 回帰防止）', () => {
+		it('0:00〜9:00 JST (= 前日15:00〜当日0:00 UTC) で todayDateJST は JST の今日を返す', () => {
+			vi.useFakeTimers();
+			// JST 2026-04-14 03:00 = UTC 2026-04-13 18:00
+			vi.setSystemTime(new Date('2026-04-13T18:00:00Z'));
+			const jstToday = todayDateJST();
+			const utcToday = new Date().toISOString().slice(0, 10);
+
+			// JST は 4/14 だが UTC は 4/13 → 不一致が発生する時間帯
+			expect(jstToday).toBe('2026-04-14');
+			expect(utcToday).toBe('2026-04-13');
+			expect(jstToday).not.toBe(utcToday);
+		});
+
+		it('9:00 JST 以降 (= 当日0:00 UTC 以降) では JST と UTC の日付は一致する', () => {
+			vi.useFakeTimers();
+			// JST 2026-04-14 12:00 = UTC 2026-04-14 03:00
+			vi.setSystemTime(new Date('2026-04-14T03:00:00Z'));
+			const jstToday = todayDateJST();
+			const utcToday = new Date().toISOString().slice(0, 10);
+
+			expect(jstToday).toBe('2026-04-14');
+			expect(utcToday).toBe('2026-04-14');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- サービス層に散在していた `new Date().toISOString().slice(0, 10)` (UTC) を `todayDateJST()` に統一
- `date-utils.ts` に日時管理方針のドキュメントと表示用ヘルパー関数を追加
- `family-streak-service.ts` のローカル `todayDateJST` 定義を共通ユーティリティに統合
- JST/UTC 差異の回帰テストを追加

## 背景

#962 の本番障害（0:00〜9:00 JST に当日記録が表示されない）の根本原因は、サービス層で `new Date().toISOString().slice(0, 10)` が UTC 日付を返していたこと。#962 では history/status/admin の 3 箇所を対症療法で修正したが、残り 18 箇所のサービス層に同パターンが残存していた。

## 設計判断

Issue #966 のコメントで議論された通り、`recorded_date` は時刻情報を持たない YYYY-MM-DD テキスト型のため、JST → UTC マイグレーションは非可逆（0:00〜9:00 JST の記録が前日にずれるリスク）。本 PR では以下の方針を採用:

- **保存**: JST 基準の YYYY-MM-DD を維持（現状維持・案C）
- **サービス層**: `todayDateJST()` に統一（`new Date().toISOString().slice(0,10)` パターンの排除）
- **表示層**: `toJSTDateString` / `formatJSTDateTime` を使用

将来 UTC 保存に移行する場合は `recorded_at` (timestamp) カラムの新設が必要（案A）。

## 変更箇所（13 ファイル）

| ファイル | 変更内容 |
|---------|---------|
| `src/lib/domain/date-utils.ts` | 方針ドキュメント追加、`formatJSTDate`/`formatJSTDateTime` 追加 |
| `src/lib/server/services/battle-service.ts` | 2箇所を `todayDateJST()` に置換 |
| `src/lib/server/services/season-event-service.ts` | 3箇所を `todayDateJST()` に置換 |
| `src/lib/server/services/seasonal-content-service.ts` | 5箇所を `todayDateJST()` に置換 |
| `src/lib/server/services/sibling-challenge-service.ts` | 2箇所を `todayDateJST()` に置換 |
| `src/lib/server/db/sqlite/sibling-cheer-repo.ts` | 1箇所を `todayDateJST()` に置換 |
| `src/lib/server/services/notification-service.ts` | 1箇所を `todayDateJST()` に置換 |
| `src/routes/api/v1/export/+server.ts` | ファイル名用の日付を JST に統一 |
| `src/lib/server/services/family-streak-service.ts` | ローカル定義を共通ユーティリティに統合 |
| `src/routes/(parent)/admin/events/+page.svelte` | クライアント側の日付計算を JST に統一 |
| `src/routes/demo/(parent)/admin/events/+page.svelte` | 同上（デモ側並行実装） |
| `src/routes/(parent)/admin/challenges/+page.svelte` | 同上 |
| `tests/unit/domain/date-utils.test.ts` | 回帰テスト追加（JST/UTC 差異検証） |

## 対象外（意図的）

- `src/lib/server/logger.ts` — ログファイル名用（Issue でも「低優先」と記載）
- `tests/` 内の `new Date().toISOString().slice(0, 10)` — テストコード内のためスコープ外

## Test plan

- [x] `npx vitest run` — 3185 テスト全通過
- [x] `npx svelte-check` — 0 errors
- [x] `npx biome check .` — 変更ファイル全通過
- [x] JST/UTC 差異の回帰テスト追加（`date-utils.test.ts`）

closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots
> This PR does not include UI changes requiring visual verification.
![no-ui-change](https://img.shields.io/badge/UI_change-none-lightgrey)