### PR TITLE
refactor: #996 TutorialOverlay.svelte の責務分離

### DIFF
--- a/src/lib/ui/components/TutorialOverlay.svelte
+++ b/src/lib/ui/components/TutorialOverlay.svelte
@@ -1,282 +1,44 @@
 <script lang="ts">
-import { TUTORIAL_LABELS } from '$lib/domain/labels';
 import {
-	continueFullTutorial,
-	dismissResumePrompt,
-	endTutorial,
-	finishQuickTutorial,
-	getCurrentStep,
-	isQuickCompleteShown,
-	isResumePromptShown,
-	isTutorialActive,
-	resumeTutorial,
-	startFromBeginning,
-} from '$lib/ui/tutorial/tutorial-store.svelte';
+	cancelExit,
+	confirmExit,
+	getAnimKey,
+	getShowExitConfirm,
+	getShowQuickComplete,
+	getShowResume,
+	getStep,
+	getTargetRect,
+	handleOverlayClick,
+	isActive,
+	setupResizeScrollTracking,
+	setupStepTracking,
+	setupTutorialActiveFlag,
+} from '$lib/ui/tutorial/tutorial-step-controller.svelte';
 import TutorialBubble from './TutorialBubble.svelte';
+import TutorialQuickCompleteDialog from './TutorialQuickCompleteDialog.svelte';
 
-let targetRect = $state<DOMRect | null>(null);
-let animKey = $state(0);
-let showExitConfirm = $state(false);
+const active = $derived(isActive());
+const step = $derived(getStep());
+const targetRect = $derived(getTargetRect());
+const animKey = $derived(getAnimKey());
+const showResume = $derived(getShowResume());
+const showQuickComplete = $derived(getShowQuickComplete());
+const showExitConfirm = $derived(getShowExitConfirm() && active);
 
-const active = $derived(isTutorialActive());
-const step = $derived(getCurrentStep());
-const showResume = $derived(isResumePromptShown());
-const showQuickComplete = $derived(isQuickCompleteShown());
-
-// A. チュートリアル中はナビのz-indexを抑制するためhtml要素にフラグを付与
-$effect(() => {
-	if (active) {
-		document.documentElement.setAttribute('data-tutorial-active', '');
-		return () => document.documentElement.removeAttribute('data-tutorial-active');
-	}
-	document.documentElement.removeAttribute('data-tutorial-active');
-});
-
-/** Find the first visible element matching a selector (handles responsive layouts) */
-function findVisibleElement(selector: string): Element | null {
-	const candidates = document.querySelectorAll(selector);
-	for (const el of candidates) {
-		const rect = el.getBoundingClientRect();
-		if (rect.width > 0 && rect.height > 0) return el;
-	}
-	return candidates[0] ?? null;
-}
-
-/**
- * B. MutationObserver で対象要素の出現を待機し、位置安定後にフォーカスを設定する。
- * タイムアウト付き（最大3秒）で、要素が見つからなければ中央表示にフォールバック。
- */
-function waitForElement(
-	selector: string,
-	callback: (el: Element) => void,
-	signal: AbortSignal,
-	timeoutMs = 3000,
-) {
-	// 即座に見つかる場合
-	const existing = findVisibleElement(selector);
-	if (existing) {
-		requestAnimationFrame(() => {
-			if (!signal.aborted) callback(existing);
-		});
-		return;
-	}
-
-	let timer: ReturnType<typeof setTimeout>;
-
-	const observer = new MutationObserver(() => {
-		const el = findVisibleElement(selector);
-		if (el) {
-			observer.disconnect();
-			clearTimeout(timer);
-			requestAnimationFrame(() => {
-				if (!signal.aborted) callback(el);
-			});
-		}
-	});
-
-	observer.observe(document.body, { childList: true, subtree: true, attributes: true });
-
-	timer = setTimeout(() => {
-		observer.disconnect();
-		if (!signal.aborted) {
-			// 最終チェック
-			const el = findVisibleElement(selector);
-			if (el) {
-				callback(el);
-			} else {
-				// 要素未発見 — 中央表示フォールバック
-				showCenteredBubble();
-			}
-		}
-	}, timeoutMs);
-
-	signal.addEventListener('abort', () => {
-		observer.disconnect();
-		clearTimeout(timer);
-	});
-}
-
-function showCenteredBubble() {
-	targetRect = new DOMRect(window.innerWidth / 2 - 100, window.innerHeight / 3, 200, 40);
-	animKey++;
-}
-
-function focusElement(el: Element) {
-	el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-	// スクロール完了を待って位置を取得
-	requestAnimationFrame(() => {
-		setTimeout(() => {
-			targetRect = el.getBoundingClientRect();
-			animKey++;
-		}, 300);
-	});
-}
-
-$effect(() => {
-	if (active && step) {
-		const controller = new AbortController();
-
-		if (step.selector) {
-			// セレクタ指定あり — MutationObserverで要素出現を待機
-			waitForElement(step.selector, focusElement, controller.signal);
-		} else {
-			// セレクタなし — 中央表示
-			requestAnimationFrame(() => {
-				if (!controller.signal.aborted) showCenteredBubble();
-			});
-		}
-
-		return () => controller.abort();
-	}
-	targetRect = null;
-});
-
-// リサイズ・スクロール時にtargetRectを再計算（バブル位置を動的に追従）
-$effect(() => {
-	if (!active || !step?.selector) return;
-
-	function recalc() {
-		const el = step?.selector ? findVisibleElement(step.selector) : null;
-		if (el) {
-			targetRect = el.getBoundingClientRect();
-		}
-	}
-
-	window.addEventListener('resize', recalc, { passive: true });
-	window.addEventListener('scroll', recalc, { passive: true, capture: true });
-
-	return () => {
-		window.removeEventListener('resize', recalc);
-		window.removeEventListener('scroll', recalc, { capture: true });
-	};
-});
-
-function handleOverlayClick(e: MouseEvent) {
-	// Show exit confirmation instead of closing immediately
-	if ((e.target as HTMLElement).classList.contains('tutorial-overlay-bg')) {
-		showExitConfirm = true;
-	}
-}
-
-function confirmExit() {
-	showExitConfirm = false;
-	endTutorial();
-}
-
-function cancelExit() {
-	showExitConfirm = false;
-}
+// Setup effects (must be called within component context)
+setupTutorialActiveFlag();
+setupStepTracking();
+setupResizeScrollTracking();
 </script>
 
-<!-- Resume prompt dialog -->
-{#if showResume}
-	<!-- svelte-ignore a11y_click_events_have_key_events -->
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div class="tutorial-overlay">
-		<div class="tutorial-overlay-backdrop"></div>
-		<div class="tutorial-dialog" role="dialog" aria-label="チュートリアル再開" tabindex="-1">
-			<div class="tutorial-dialog-header">
-				<span aria-hidden="true">📖</span>
-				<span>チュートリアルの続き</span>
-			</div>
-			<div class="tutorial-dialog-body">
-				<p>前回の途中から続けますか？</p>
-			</div>
-			<div class="tutorial-dialog-actions">
-				<button
-					type="button"
-					class="tutorial-dialog-btn tutorial-dialog-btn--secondary"
-					onclick={dismissResumePrompt}
-				>
-					キャンセル
-				</button>
-				<button
-					type="button"
-					class="tutorial-dialog-btn tutorial-dialog-btn--secondary"
-					onclick={() => startFromBeginning()}
-				>
-					最初から
-				</button>
-				<button
-					type="button"
-					class="tutorial-dialog-btn tutorial-dialog-btn--primary"
-					onclick={() => resumeTutorial()}
-				>
-					続きから
-				</button>
-			</div>
-		</div>
-	</div>
-{/if}
-
-<!-- #955: Quick complete dialog — チャプター1終了後の選択画面 -->
-{#if showQuickComplete}
-	<div class="tutorial-overlay">
-		<div class="tutorial-overlay-backdrop"></div>
-		<div class="tutorial-dialog" role="dialog" aria-label="チュートリアル完了" tabindex="-1">
-			<div class="tutorial-dialog-header">
-				<span aria-hidden="true">🎉</span>
-				<span>基本の使い方を確認しました！</span>
-			</div>
-			<div class="tutorial-dialog-body">
-				<p>ここからは実際にお子さまを登録して使い始めましょう。</p>
-				<p class="tutorial-dialog-hint">残りのガイド（活動管理・報酬・レポートなど）は、いつでもヘッダーの「❓」ボタンから確認できます。</p>
-			</div>
-			<div class="tutorial-dialog-actions">
-				<button
-					type="button"
-					class="tutorial-dialog-btn tutorial-dialog-btn--secondary"
-					onclick={() => continueFullTutorial()}
-				>
-					{TUTORIAL_LABELS.quickContinue}
-				</button>
-				<button
-					type="button"
-					class="tutorial-dialog-btn tutorial-dialog-btn--primary"
-					onclick={() => finishQuickTutorial()}
-				>
-					{TUTORIAL_LABELS.quickFinish}
-				</button>
-			</div>
-		</div>
-	</div>
-{/if}
-
-<!-- Exit confirmation dialog -->
-{#if showExitConfirm && active}
-	<!-- svelte-ignore a11y_click_events_have_key_events -->
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div class="tutorial-confirm-overlay" onclick={cancelExit}>
-		<div
-			class="tutorial-dialog"
-			role="dialog"
-			aria-label="チュートリアル終了確認"
-			tabindex="-1"
-			onclick={(e) => e.stopPropagation()}
-		>
-			<div class="tutorial-dialog-body">
-				<p>チュートリアルを終了しますか？</p>
-				<p class="tutorial-dialog-hint">進捗は保存されるので、後から続きを再開できます。</p>
-			</div>
-			<div class="tutorial-dialog-actions">
-				<button
-					type="button"
-					class="tutorial-dialog-btn tutorial-dialog-btn--secondary"
-					onclick={cancelExit}
-				>
-					続ける
-				</button>
-				<button
-					type="button"
-					class="tutorial-dialog-btn tutorial-dialog-btn--danger"
-					onclick={confirmExit}
-				>
-					終了する
-				</button>
-			</div>
-		</div>
-	</div>
-{/if}
+<!-- Dialogs: resume, quickComplete, exitConfirm -->
+<TutorialQuickCompleteDialog
+	{showResume}
+	{showQuickComplete}
+	{showExitConfirm}
+	onConfirmExit={confirmExit}
+	onCancelExit={cancelExit}
+/>
 
 {#if active && step && targetRect && !showQuickComplete}
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -329,12 +91,6 @@ function cancelExit() {
 		z-index: 100;
 	}
 
-	.tutorial-overlay-backdrop {
-		position: absolute;
-		inset: 0;
-		background: rgba(0, 0, 0, 0.5);
-	}
-
 	.tutorial-overlay-svg {
 		position: absolute;
 		inset: 0;
@@ -364,141 +120,6 @@ function cancelExit() {
 		50% {
 			box-shadow: 0 0 24px rgba(59, 130, 246, 0.5);
 		}
-	}
-
-	/* Confirm overlay — sits above the tutorial overlay */
-	.tutorial-confirm-overlay {
-		position: fixed;
-		inset: 0;
-		z-index: 120;
-		background: rgba(0, 0, 0, 0.4);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	/* Dialog shared styles */
-	.tutorial-dialog {
-		position: relative;
-		z-index: 110;
-		background: white;
-		border-radius: 16px;
-		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
-		width: 320px;
-		max-width: 90vw;
-		margin: auto;
-		overflow: hidden;
-		animation: dialog-appear 0.2s ease-out;
-		/* Center in overlay */
-		position: fixed;
-		top: 50%;
-		left: 50%;
-		transform: translate(-50%, -50%);
-	}
-
-	.tutorial-confirm-overlay .tutorial-dialog {
-		position: relative;
-		top: auto;
-		left: auto;
-		transform: none;
-	}
-
-	@keyframes dialog-appear {
-		from {
-			opacity: 0;
-			transform: translate(-50%, -50%) scale(0.95);
-		}
-		to {
-			opacity: 1;
-			transform: translate(-50%, -50%) scale(1);
-		}
-	}
-
-	.tutorial-confirm-overlay .tutorial-dialog {
-		animation-name: dialog-appear-centered;
-	}
-
-	@keyframes dialog-appear-centered {
-		from {
-			opacity: 0;
-			transform: scale(0.95);
-		}
-		to {
-			opacity: 1;
-			transform: scale(1);
-		}
-	}
-
-	.tutorial-dialog-header {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		padding: 14px 16px;
-		background: linear-gradient(135deg, #3b82f6, #2563eb);
-		color: white;
-		font-weight: 600;
-		font-size: 0.9rem;
-	}
-
-	.tutorial-dialog-body {
-		padding: 20px 16px 12px;
-	}
-
-	.tutorial-dialog-body p {
-		margin: 0;
-		font-size: 0.9rem;
-		color: #334155;
-		line-height: 1.5;
-	}
-
-	.tutorial-dialog-hint {
-		margin-top: 8px !important;
-		font-size: 0.8rem !important;
-		color: #64748b !important;
-	}
-
-	.tutorial-dialog-actions {
-		display: flex;
-		gap: 8px;
-		padding: 12px 16px 16px;
-		justify-content: flex-end;
-	}
-
-	.tutorial-dialog-btn {
-		padding: 8px 16px;
-		border-radius: 8px;
-		font-size: 0.8rem;
-		font-weight: 600;
-		border: none;
-		cursor: pointer;
-		transition: all 0.15s;
-	}
-
-	.tutorial-dialog-btn--primary {
-		background: linear-gradient(135deg, #3b82f6, #2563eb);
-		color: white;
-	}
-
-	.tutorial-dialog-btn--primary:hover {
-		background: linear-gradient(135deg, #2563eb, #1d4ed8);
-	}
-
-	.tutorial-dialog-btn--secondary {
-		background: #f1f5f9;
-		color: #475569;
-	}
-
-	.tutorial-dialog-btn--secondary:hover {
-		background: #e2e8f0;
-	}
-
-	.tutorial-dialog-btn--danger {
-		background: #fef2f2;
-		color: #dc2626;
-	}
-
-	.tutorial-dialog-btn--danger:hover {
-		background: #fee2e2;
 	}
 
 	/* A. チュートリアル中はナビ・ヘッダーのz-indexをオーバーレイ以下に抑制 */

--- a/src/lib/ui/components/TutorialQuickCompleteDialog.svelte
+++ b/src/lib/ui/components/TutorialQuickCompleteDialog.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+import { TUTORIAL_LABELS } from '$lib/domain/labels';
+import {
+	continueFullTutorial,
+	dismissResumePrompt,
+	finishQuickTutorial,
+	resumeTutorial,
+	startFromBeginning,
+} from '$lib/ui/tutorial/tutorial-store.svelte';
+
+interface Props {
+	showResume: boolean;
+	showQuickComplete: boolean;
+	showExitConfirm: boolean;
+	onConfirmExit: () => void;
+	onCancelExit: () => void;
+}
+
+let { showResume, showQuickComplete, showExitConfirm, onConfirmExit, onCancelExit }: Props =
+	$props();
+</script>
+
+<!-- Resume prompt dialog -->
+{#if showResume}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="tutorial-overlay">
+		<div class="tutorial-overlay-backdrop"></div>
+		<div class="tutorial-dialog" role="dialog" aria-label="チュートリアル再開" tabindex="-1">
+			<div class="tutorial-dialog-header">
+				<span aria-hidden="true">📖</span>
+				<span>チュートリアルの続き</span>
+			</div>
+			<div class="tutorial-dialog-body">
+				<p>前回の途中から続けますか？</p>
+			</div>
+			<div class="tutorial-dialog-actions">
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--secondary"
+					onclick={dismissResumePrompt}
+				>
+					キャンセル
+				</button>
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--secondary"
+					onclick={() => startFromBeginning()}
+				>
+					最初から
+				</button>
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--primary"
+					onclick={() => resumeTutorial()}
+				>
+					続きから
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- #955: Quick complete dialog — チャプター1終了後の選択画面 -->
+{#if showQuickComplete}
+	<div class="tutorial-overlay">
+		<div class="tutorial-overlay-backdrop"></div>
+		<div class="tutorial-dialog" role="dialog" aria-label="チュートリアル完了" tabindex="-1">
+			<div class="tutorial-dialog-header">
+				<span aria-hidden="true">🎉</span>
+				<span>基本の使い方を確認しました！</span>
+			</div>
+			<div class="tutorial-dialog-body">
+				<p>ここからは実際にお子さまを登録して使い始めましょう。</p>
+				<p class="tutorial-dialog-hint">残りのガイド（活動管理・報酬・レポートなど）は、いつでもヘッダーの「❓」ボタンから確認できます。</p>
+			</div>
+			<div class="tutorial-dialog-actions">
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--secondary"
+					onclick={() => continueFullTutorial()}
+				>
+					{TUTORIAL_LABELS.quickContinue}
+				</button>
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--primary"
+					onclick={() => finishQuickTutorial()}
+				>
+					{TUTORIAL_LABELS.quickFinish}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Exit confirmation dialog -->
+{#if showExitConfirm}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="tutorial-confirm-overlay" onclick={onCancelExit}>
+		<div
+			class="tutorial-dialog"
+			role="dialog"
+			aria-label="チュートリアル終了確認"
+			tabindex="-1"
+			onclick={(e) => e.stopPropagation()}
+		>
+			<div class="tutorial-dialog-body">
+				<p>チュートリアルを終了しますか？</p>
+				<p class="tutorial-dialog-hint">進捗は保存されるので、後から続きを再開できます。</p>
+			</div>
+			<div class="tutorial-dialog-actions">
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--secondary"
+					onclick={onCancelExit}
+				>
+					続ける
+				</button>
+				<button
+					type="button"
+					class="tutorial-dialog-btn tutorial-dialog-btn--danger"
+					onclick={onConfirmExit}
+				>
+					終了する
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.tutorial-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 100;
+	}
+
+	.tutorial-overlay-backdrop {
+		position: absolute;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+	}
+
+	/* Confirm overlay — sits above the tutorial overlay */
+	.tutorial-confirm-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 120;
+		background: rgba(0, 0, 0, 0.4);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	/* Dialog shared styles */
+	.tutorial-dialog {
+		position: fixed;
+		z-index: 110;
+		background: white;
+		border-radius: 16px;
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+		width: 320px;
+		max-width: 90vw;
+		overflow: hidden;
+		animation: dialog-appear 0.2s ease-out;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+	}
+
+	.tutorial-confirm-overlay .tutorial-dialog {
+		position: relative;
+		top: auto;
+		left: auto;
+		transform: none;
+	}
+
+	@keyframes dialog-appear {
+		from {
+			opacity: 0;
+			transform: translate(-50%, -50%) scale(0.95);
+		}
+		to {
+			opacity: 1;
+			transform: translate(-50%, -50%) scale(1);
+		}
+	}
+
+	.tutorial-confirm-overlay .tutorial-dialog {
+		animation-name: dialog-appear-centered;
+	}
+
+	@keyframes dialog-appear-centered {
+		from {
+			opacity: 0;
+			transform: scale(0.95);
+		}
+		to {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
+
+	.tutorial-dialog-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 14px 16px;
+		background: linear-gradient(135deg, #3b82f6, #2563eb);
+		color: white;
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+
+	.tutorial-dialog-body {
+		padding: 20px 16px 12px;
+	}
+
+	.tutorial-dialog-body p {
+		margin: 0;
+		font-size: 0.9rem;
+		color: #334155;
+		line-height: 1.5;
+	}
+
+	.tutorial-dialog-hint {
+		margin-top: 8px !important;
+		font-size: 0.8rem !important;
+		color: #64748b !important;
+	}
+
+	.tutorial-dialog-actions {
+		display: flex;
+		gap: 8px;
+		padding: 12px 16px 16px;
+		justify-content: flex-end;
+	}
+
+	.tutorial-dialog-btn {
+		padding: 8px 16px;
+		border-radius: 8px;
+		font-size: 0.8rem;
+		font-weight: 600;
+		border: none;
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.tutorial-dialog-btn--primary {
+		background: linear-gradient(135deg, #3b82f6, #2563eb);
+		color: white;
+	}
+
+	.tutorial-dialog-btn--primary:hover {
+		background: linear-gradient(135deg, #2563eb, #1d4ed8);
+	}
+
+	.tutorial-dialog-btn--secondary {
+		background: #f1f5f9;
+		color: #475569;
+	}
+
+	.tutorial-dialog-btn--secondary:hover {
+		background: #e2e8f0;
+	}
+
+	.tutorial-dialog-btn--danger {
+		background: #fef2f2;
+		color: #dc2626;
+	}
+
+	.tutorial-dialog-btn--danger:hover {
+		background: #fee2e2;
+	}
+</style>

--- a/src/lib/ui/tutorial/tutorial-step-controller.svelte.ts
+++ b/src/lib/ui/tutorial/tutorial-step-controller.svelte.ts
@@ -1,0 +1,155 @@
+/**
+ * tutorial-step-controller.svelte.ts
+ *
+ * チュートリアルオーバーレイの状態管理を担う runes ベースのコントローラー。
+ * targetRect / animKey / showExitConfirm の管理、および各 $effect を提供する。
+ * TutorialOverlay から分離 (#996)。
+ */
+import {
+	endTutorial,
+	getCurrentStep,
+	isQuickCompleteShown,
+	isResumePromptShown,
+	isTutorialActive,
+} from './tutorial-store.svelte';
+import {
+	createCenteredRect,
+	findVisibleElement,
+	focusElement,
+	waitForElement,
+} from './useStepHighlight.svelte';
+
+// ── Reactive state ──
+let targetRect = $state<DOMRect | null>(null);
+let animKey = $state(0);
+let showExitConfirm = $state(false);
+
+// ── Derived state ──
+const active = $derived(isTutorialActive());
+const step = $derived(getCurrentStep());
+const showResume = $derived(isResumePromptShown());
+const showQuickComplete = $derived(isQuickCompleteShown());
+
+// ── Getters (for external consumers) ──
+export function getTargetRect(): DOMRect | null {
+	return targetRect;
+}
+
+export function getAnimKey(): number {
+	return animKey;
+}
+
+export function getShowExitConfirm(): boolean {
+	return showExitConfirm;
+}
+
+export function isActive(): boolean {
+	return active;
+}
+
+export function getStep() {
+	return step;
+}
+
+export function getShowResume(): boolean {
+	return showResume;
+}
+
+export function getShowQuickComplete(): boolean {
+	return showQuickComplete;
+}
+
+// ── Actions ──
+export function handleOverlayClick(e: MouseEvent) {
+	// Show exit confirmation instead of closing immediately
+	if ((e.target as HTMLElement).classList.contains('tutorial-overlay-bg')) {
+		showExitConfirm = true;
+	}
+}
+
+export function confirmExit() {
+	showExitConfirm = false;
+	endTutorial();
+}
+
+export function cancelExit() {
+	showExitConfirm = false;
+}
+
+// ── Effects ──
+
+/**
+ * チュートリアル中はナビの z-index を抑制するため html 要素にフラグを付与。
+ * コンポーネントの $effect 内で呼び出す。
+ */
+export function setupTutorialActiveFlag() {
+	$effect(() => {
+		if (active) {
+			document.documentElement.setAttribute('data-tutorial-active', '');
+			return () => document.documentElement.removeAttribute('data-tutorial-active');
+		}
+		document.documentElement.removeAttribute('data-tutorial-active');
+	});
+}
+
+/**
+ * ステップ変更時にターゲット要素を検索し targetRect を更新する。
+ * コンポーネントの $effect 内で呼び出す。
+ */
+export function setupStepTracking() {
+	$effect(() => {
+		if (active && step) {
+			const controller = new AbortController();
+
+			const showCentered = () => {
+				targetRect = createCenteredRect();
+				animKey++;
+			};
+
+			const onFocus = (el: Element) => {
+				focusElement(el, (rect) => {
+					targetRect = rect;
+					animKey++;
+				});
+			};
+
+			if (step.selector) {
+				// セレクタ指定あり — MutationObserver で要素出現を待機
+				waitForElement(step.selector, onFocus, controller.signal, showCentered);
+			} else {
+				// セレクタなし — 中央表示
+				requestAnimationFrame(() => {
+					if (!controller.signal.aborted) showCentered();
+				});
+			}
+
+			return () => controller.abort();
+		}
+		targetRect = null;
+	});
+}
+
+/**
+ * リサイズ・スクロール時に targetRect を再計算（バブル位置を動的に追従）。
+ * コンポーネントの $effect 内で呼び出す。
+ */
+export function setupResizeScrollTracking() {
+	$effect(() => {
+		if (!active || !step?.selector) return;
+
+		function recalc() {
+			const el = step?.selector ? findVisibleElement(step.selector) : null;
+			if (el) {
+				targetRect = el.getBoundingClientRect();
+			}
+		}
+
+		window.addEventListener('resize', recalc, { passive: true });
+		window.addEventListener('scroll', recalc, { passive: true, capture: true });
+
+		return () => {
+			window.removeEventListener('resize', recalc);
+			window.removeEventListener('scroll', recalc, { capture: true });
+		};
+	});
+}

--- a/src/lib/ui/tutorial/useStepHighlight.svelte.ts
+++ b/src/lib/ui/tutorial/useStepHighlight.svelte.ts
@@ -1,0 +1,87 @@
+/**
+ * useStepHighlight.svelte.ts
+ *
+ * チュートリアルステップ対象要素の DOMRect 計算・スクロール制御・リサイズ追従を担う runes ベースのフック。
+ * TutorialOverlay から分離 (#996)。
+ */
+
+/** Find the first visible element matching a selector (handles responsive layouts) */
+export function findVisibleElement(selector: string): Element | null {
+	const candidates = document.querySelectorAll(selector);
+	for (const el of candidates) {
+		const rect = el.getBoundingClientRect();
+		if (rect.width > 0 && rect.height > 0) return el;
+	}
+	return candidates[0] ?? null;
+}
+
+/**
+ * MutationObserver で対象要素の出現を待機し、位置安定後にコールバックを実行する。
+ * タイムアウト付き（最大3秒）で、要素が見つからなければ onFallback にフォールバック。
+ */
+export function waitForElement(
+	selector: string,
+	callback: (el: Element) => void,
+	signal: AbortSignal,
+	onFallback: () => void,
+	timeoutMs = 3000,
+) {
+	// 即座に見つかる場合
+	const existing = findVisibleElement(selector);
+	if (existing) {
+		requestAnimationFrame(() => {
+			if (!signal.aborted) callback(existing);
+		});
+		return;
+	}
+
+	let timer: ReturnType<typeof setTimeout>;
+
+	const observer = new MutationObserver(() => {
+		const el = findVisibleElement(selector);
+		if (el) {
+			observer.disconnect();
+			clearTimeout(timer);
+			requestAnimationFrame(() => {
+				if (!signal.aborted) callback(el);
+			});
+		}
+	});
+
+	observer.observe(document.body, { childList: true, subtree: true, attributes: true });
+
+	timer = setTimeout(() => {
+		observer.disconnect();
+		if (!signal.aborted) {
+			// 最終チェック
+			const el = findVisibleElement(selector);
+			if (el) {
+				callback(el);
+			} else {
+				// 要素未発見 — フォールバック
+				onFallback();
+			}
+		}
+	}, timeoutMs);
+
+	signal.addEventListener('abort', () => {
+		observer.disconnect();
+		clearTimeout(timer);
+	});
+}
+
+/** 画面中央にバブルを表示するためのフォールバック DOMRect を生成する */
+export function createCenteredRect(): DOMRect {
+	return new DOMRect(window.innerWidth / 2 - 100, window.innerHeight / 3, 200, 40);
+}
+
+/** 対象要素をスクロールして DOMRect を返すコールバックを生成する */
+export function focusElement(el: Element, onComplete: (rect: DOMRect) => void) {
+	el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+	// スクロール完了を待って位置を取得
+	requestAnimationFrame(() => {
+		setTimeout(() => {
+			onComplete(el.getBoundingClientRect());
+		}, 300);
+	});
+}


### PR DESCRIPTION
## Summary

closes #996

`TutorialOverlay.svelte` (511行) を以下の 4 モジュールに責務分離:

- **`useStepHighlight.svelte.ts`** (87行): DOM要素検索 (`findVisibleElement`)、MutationObserver待機 (`waitForElement`)、スクロール制御 (`focusElement`)、中央表示フォールバック (`createCenteredRect`)
- **`tutorial-step-controller.svelte.ts`** (155行): `targetRect` / `animKey` / `showExitConfirm` のリアクティブstate管理、ステップ追従・リサイズ/スクロール追従・data-tutorial-active フラグの `$effect` 群、オーバーレイクリック/終了操作
- **`TutorialQuickCompleteDialog.svelte`** (277行): resume / quickComplete / exitConfirm の 3 ダイアログ UI + CSS
- **`TutorialOverlay.svelte`** (132行): 上記モジュールのオーケストレーション + SVG スポットライト描画 + グローバル z-index 制御

機能変更なし。リファクタのみ。

## Test plan

- [x] `npx biome check .` -- lint エラーなし
- [x] `npx svelte-check --threshold error` -- 型エラーなし (0 errors)
- [x] `npx vitest run tests/unit/tutorial/` -- tutorial-store.test.ts 全 10 テスト通過
- [x] `npx vitest run` -- 全 3180 テスト通過 (Storybook 15件の既存失敗のみ, 変更とは無関係)
- [ ] E2E: `npx playwright test tests/e2e/tutorial-verification.spec.ts` -- CI で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots
> This PR does not include UI changes requiring visual verification.
![no-ui-change](https://img.shields.io/badge/UI_change-none-lightgrey)