### PR TITLE
feat: #816 IAuthRepo にライセンスキー検索メソッド追加

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1604,7 +1604,7 @@ T#<tenantId>#COUNTER           // テナント内 ID カウンタ
 
 | エンティティ | PK | SK | 説明 |
 |------------|-----|-----|------|
-| ライセンスキー本体 | `LICENSE#<licenseKey>` | `LICENSE#<licenseKey>` | status (`active`/`consumed`/`revoked`), plan, tenantId, kind (#801), issuedBy (#801), stripeSessionId, consumedBy, consumedAt, expiresAt (#797), revokedReason, revokedAt, revokedBy (#797), createdAt |
+| ライセンスキー本体 | `LICENSE#<licenseKey>` | `LICENSE#<licenseKey>` | status (`active`/`consumed`/`revoked`), plan, tenantId, kind (#801), issuedBy (#801), stripeSessionId, consumedBy, consumedAt, expiresAt (#797), revokedReason, revokedAt, revokedBy (#797), createdAt。**GSI2**: `GSI2PK=TENANT#<tenantId>`, `GSI2SK=LICENSE#<createdAt>` でテナント別一覧検索 (#816) |
 | ライセンス監査ログ | `LICENSE_EVENT#<licenseKey>` | `EVENT#<ts>#<ulid>` | eventType (`issued`/`consumed`/`revoked`/`rotated`/`verify_failed`/`ops_manual`), actor, metadata。TTL 7 年（会計書類保存期間） |
 
 **主要属性（LicenseRecord）**:
@@ -1625,6 +1625,15 @@ T#<tenantId>#COUNTER           // テナント内 ID カウンタ
 | `revokedAt` | string (ISO8601) | — | 失効日時 |
 | `revokedBy` | string | — | **#797**: 失効実行者（`ops:<uid>` / `system` / `stripe:<eventId>`） |
 | `createdAt` | string (ISO8601) | ○ | 発行日時（90 日期限の起点） |
+
+**検索メソッド (#816)**:
+
+| メソッド | 実装方式 | 用途 |
+|---------|---------|------|
+| `listLicenseKeysByTenant(tenantId, limit?, cursor?)` | GSI2 Query | テナント別キー一覧（Ops 画面） |
+| `listLicenseKeysByStatus(status, limit?, cursor?)` | Scan + Filter | ステータス別一覧（Ops 監視） |
+| `listExpiringSoon(days)` | Scan + Filter | N 日以内期限切れ（通知バッチ） |
+| `countLicenseKeys(filter?)` | GSI2 Query / Scan (COUNT) | 集計（ダッシュボード） |
 
 **実装リファレンス**: `src/lib/server/services/license-key-service.ts`
 
@@ -1757,3 +1766,4 @@ src/lib/server/db/migration/
 | 2026-04-11 | 4.8 | #717, #729 §6.5 保持期間ポリシーを二層構造（表示フィルタ + 物理削除バッチ）に全面改訂。`retention-cleanup-service` を新設し activity_logs / point_ledger / login_bonuses を日次物理削除。ポイント残高は維持（明細のみ削除）。[ADR-0028](../decisions/0028-retention-physical-delete.md) 参照。ADR-0027 は supersede |
 | 2026-04-12 | 4.9 | #769 trial_history に `stripe_subscription_id` / `upgrade_reason` / `trial_start_source` カラム追加（コンバージョン分析用）。既存レコードは NULL 許容 |
 | 2026-04-16 | 5.0 | #972 plan / license / subscription status の値定数を `src/lib/domain/constants/` に集約（`license-plan.ts` / `license-key-status.ts` / `subscription-status.ts` / `auth-license-status.ts`）。DB カラム値は変更せず、比較・分岐ロジックだけを定数経由に統一。`family-monthly` / `family-yearly` / `grace_period` の文字列リテラル直書きは `scripts/check-no-plan-literals.mjs` で CI 自動拒否 |
+| 2026-04-17 | 5.1 | #816 IAuthRepo にライセンスキー検索メソッド追加（`listLicenseKeysByTenant` / `listLicenseKeysByStatus` / `listExpiringSoon` / `countLicenseKeys`）。ライセンスキー本体に GSI2PK/GSI2SK を付与してテナント別 Query を実現 |

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -10,6 +10,7 @@ import {
 	ScanCommand,
 	UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
+import { LICENSE_KEY_STATUS } from '$lib/domain/constants/license-key-status';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { INVITE_EXPIRY_DAYS } from '$lib/domain/validation/auth';
 import type {
@@ -735,7 +736,15 @@ const DEFAULT_PAGE_SIZE = 50;
 
 /** カーソルを Base64 エンコードされた DynamoDB ExclusiveStartKey として扱う */
 function decodeCursor(cursor: string): Record<string, unknown> {
-	return JSON.parse(Buffer.from(cursor, 'base64url').toString('utf-8'));
+	try {
+		const parsed: unknown = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf-8'));
+		if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+			throw new TypeError('Cursor must decode to a non-null object');
+		}
+		return parsed as Record<string, unknown>;
+	} catch {
+		throw new Error('Invalid pagination cursor');
+	}
 }
 
 function encodeCursor(lastKey: Record<string, unknown>): string {
@@ -856,7 +865,7 @@ export const listExpiringSoon: IAuthRepo['listExpiringSoon'] = async (days) => {
 				ExpressionAttributeNames: { '#status': 'status' },
 				ExpressionAttributeValues: {
 					':prefix': 'LICENSE#',
-					':active': 'active',
+					':active': LICENSE_KEY_STATUS.ACTIVE,
 					':now': nowIso,
 					':threshold': thresholdIso,
 				},

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -636,6 +636,9 @@ export const saveLicenseKey: IAuthRepo['saveLicenseKey'] = async (record) => {
 			TableName: TABLE_NAME,
 			Item: {
 				...keys,
+				// #816: GSI2 でテナント別一覧を引けるようにする
+				GSI2PK: `TENANT#${record.tenantId}`,
+				GSI2SK: `LICENSE#${record.createdAt}`,
 				tenantId: record.tenantId,
 				plan: record.plan,
 				stripeSessionId: record.stripeSessionId,
@@ -722,4 +725,211 @@ export const revokeLicenseKey: IAuthRepo['revokeLicenseKey'] = async (params) =>
 			},
 		}),
 	);
+};
+
+// ============================================================
+// License Key Search (#816)
+// ============================================================
+
+const DEFAULT_PAGE_SIZE = 50;
+
+/** カーソルを Base64 エンコードされた DynamoDB ExclusiveStartKey として扱う */
+function decodeCursor(cursor: string): Record<string, unknown> {
+	return JSON.parse(Buffer.from(cursor, 'base64url').toString('utf-8'));
+}
+
+function encodeCursor(lastKey: Record<string, unknown>): string {
+	return Buffer.from(JSON.stringify(lastKey), 'utf-8').toString('base64url');
+}
+
+function itemToLicenseRecord(item: Record<string, unknown>): LicenseRecord {
+	return {
+		licenseKey: (item.PK as string).replace('LICENSE#', ''),
+		tenantId: item.tenantId as string,
+		plan: item.plan as LicenseRecord['plan'],
+		stripeSessionId: item.stripeSessionId as string | undefined,
+		status: item.status as LicenseRecord['status'],
+		consumedBy: item.consumedBy as string | undefined,
+		consumedAt: item.consumedAt as string | undefined,
+		createdAt: item.createdAt as string,
+		kind: item.kind as LicenseRecord['kind'],
+		issuedBy: item.issuedBy as string | undefined,
+		expiresAt: item.expiresAt as string | undefined,
+		revokedAt: item.revokedAt as string | undefined,
+		revokedReason: item.revokedReason as LicenseRecord['revokedReason'],
+		revokedBy: item.revokedBy as string | undefined,
+	};
+}
+
+export const listLicenseKeysByTenant: IAuthRepo['listLicenseKeysByTenant'] = async (
+	tenantId,
+	limit = DEFAULT_PAGE_SIZE,
+	cursor,
+) => {
+	const result = await doc().send(
+		new QueryCommand({
+			TableName: TABLE_NAME,
+			IndexName: GSI.GSI2,
+			KeyConditionExpression: 'GSI2PK = :pk AND begins_with(GSI2SK, :prefix)',
+			ExpressionAttributeValues: {
+				':pk': `TENANT#${tenantId}`,
+				':prefix': 'LICENSE#',
+			},
+			ScanIndexForward: false, // 直近発行順
+			Limit: limit,
+			...(cursor ? { ExclusiveStartKey: decodeCursor(cursor) } : {}),
+		}),
+	);
+
+	const items = (result.Items ?? []).map((item) =>
+		itemToLicenseRecord(item as Record<string, unknown>),
+	);
+
+	return {
+		items,
+		cursor: result.LastEvaluatedKey ? encodeCursor(result.LastEvaluatedKey) : null,
+	};
+};
+
+export const listLicenseKeysByStatus: IAuthRepo['listLicenseKeysByStatus'] = async (
+	status,
+	limit = DEFAULT_PAGE_SIZE,
+	cursor,
+) => {
+	// DynamoDB の LICENSE# パーティションは status でインデックスされていないため、
+	// Scan + FilterExpression を使用。Pre-PMF 段階ではキー数が限定的。
+	// 本番スケール時は GSI 追加を検討（ADR-0034 準拠で過剰設計を避ける）。
+	const items: LicenseRecord[] = [];
+	let lastKey = cursor ? decodeCursor(cursor) : undefined;
+	let scannedCount = 0;
+
+	// Scan は FilterExpression 適用前の Limit なので、十分な件数が集まるまでループする
+	while (items.length < limit) {
+		const result = await doc().send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: 'begins_with(PK, :prefix) AND #status = :status',
+				ExpressionAttributeNames: { '#status': 'status' },
+				ExpressionAttributeValues: {
+					':prefix': 'LICENSE#',
+					':status': status,
+				},
+				ExclusiveStartKey: lastKey,
+				// 多めにスキャンしてフィルタで絞る
+				Limit: Math.max(limit * 3, 100),
+			}),
+		);
+
+		for (const item of result.Items ?? []) {
+			if (items.length >= limit) break;
+			items.push(itemToLicenseRecord(item as Record<string, unknown>));
+		}
+
+		lastKey = result.LastEvaluatedKey;
+		scannedCount++;
+
+		// テーブル末尾到達 or 安全弁（最大 10 ラウンド）
+		if (!lastKey || scannedCount >= 10) break;
+	}
+
+	return {
+		items,
+		cursor: lastKey ? encodeCursor(lastKey) : null,
+	};
+};
+
+export const listExpiringSoon: IAuthRepo['listExpiringSoon'] = async (days) => {
+	const now = new Date();
+	const threshold = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+	const nowIso = now.toISOString();
+	const thresholdIso = threshold.toISOString();
+
+	const items: LicenseRecord[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+
+	do {
+		const result = await doc().send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression:
+					'begins_with(PK, :prefix) AND #status = :active AND expiresAt BETWEEN :now AND :threshold',
+				ExpressionAttributeNames: { '#status': 'status' },
+				ExpressionAttributeValues: {
+					':prefix': 'LICENSE#',
+					':active': 'active',
+					':now': nowIso,
+					':threshold': thresholdIso,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+
+		for (const item of result.Items ?? []) {
+			items.push(itemToLicenseRecord(item as Record<string, unknown>));
+		}
+
+		lastKey = result.LastEvaluatedKey;
+	} while (lastKey);
+
+	return items;
+};
+
+export const countLicenseKeys: IAuthRepo['countLicenseKeys'] = async (filter) => {
+	let count = 0;
+	let lastKey: Record<string, unknown> | undefined;
+
+	// テナント指定がある場合は GSI2 Query を使用
+	if (filter?.tenantId) {
+		do {
+			const result = await doc().send(
+				new QueryCommand({
+					TableName: TABLE_NAME,
+					IndexName: GSI.GSI2,
+					KeyConditionExpression: 'GSI2PK = :pk AND begins_with(GSI2SK, :prefix)',
+					ExpressionAttributeValues: {
+						':pk': `TENANT#${filter.tenantId}`,
+						':prefix': 'LICENSE#',
+						...(filter.status ? { ':status': filter.status } : {}),
+					},
+					...(filter.status
+						? {
+								FilterExpression: '#status = :status',
+								ExpressionAttributeNames: { '#status': 'status' },
+							}
+						: {}),
+					Select: 'COUNT',
+					ExclusiveStartKey: lastKey,
+				}),
+			);
+			count += result.Count ?? 0;
+			lastKey = result.LastEvaluatedKey;
+		} while (lastKey);
+
+		return count;
+	}
+
+	// テナント指定なし: Scan
+	do {
+		const hasStatusFilter = !!filter?.status;
+
+		const result = await doc().send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: hasStatusFilter
+					? 'begins_with(PK, :prefix) AND #status = :status'
+					: 'begins_with(PK, :prefix)',
+				...(hasStatusFilter ? { ExpressionAttributeNames: { '#status': 'status' } } : {}),
+				ExpressionAttributeValues: {
+					':prefix': 'LICENSE#',
+					...(hasStatusFilter ? { ':status': filter.status } : {}),
+				},
+				Select: 'COUNT',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		count += result.Count ?? 0;
+		lastKey = result.LastEvaluatedKey;
+	} while (lastKey);
+
+	return count;
 };

--- a/src/lib/server/db/interfaces/auth-repo.interface.ts
+++ b/src/lib/server/db/interfaces/auth-repo.interface.ts
@@ -1,6 +1,7 @@
 // src/lib/server/db/interfaces/auth-repo.interface.ts
 // マルチテナント認証リポジトリインターフェース (#0123)
 
+import type { LicenseKeyStatus } from '$lib/domain/constants/license-key-status';
 import type {
 	AuthUser,
 	ConsentRecord,
@@ -14,6 +15,19 @@ import type {
 	Tenant,
 } from '$lib/server/auth/entities';
 import type { LicenseRecord, LicenseRevokeReason } from '$lib/server/services/license-key-service';
+
+/** ページネーション用カーソル (#816) */
+export interface LicenseKeyPage {
+	items: LicenseRecord[];
+	/** 次ページのカーソル。null なら最終ページ */
+	cursor: string | null;
+}
+
+/** ライセンスキー検索フィルタ (#816) */
+export interface LicenseKeyCountFilter {
+	tenantId?: string;
+	status?: LicenseKeyStatus;
+}
 
 export interface IAuthRepo {
 	// --- User ---
@@ -87,4 +101,26 @@ export interface IAuthRepo {
 		revokedBy: string;
 		revokedAt: string;
 	}): Promise<void>;
+
+	// --- License Key Search (#816) ---
+
+	/** テナントに紐付く全ライセンスキーを取得（ページネーション対応） */
+	listLicenseKeysByTenant(
+		tenantId: string,
+		limit?: number,
+		cursor?: string,
+	): Promise<LicenseKeyPage>;
+
+	/** ステータス別のライセンスキー一覧（ページネーション対応） */
+	listLicenseKeysByStatus(
+		status: LicenseKeyStatus,
+		limit?: number,
+		cursor?: string,
+	): Promise<LicenseKeyPage>;
+
+	/** N 日以内に有効期限が切れるアクティブなキー一覧 */
+	listExpiringSoon(days: number): Promise<LicenseRecord[]>;
+
+	/** ライセンスキーの集計 */
+	countLicenseKeys(filter?: LicenseKeyCountFilter): Promise<number>;
 }

--- a/src/lib/server/db/interfaces/index.ts
+++ b/src/lib/server/db/interfaces/index.ts
@@ -2,7 +2,7 @@
 // All repository interfaces re-exported for factory pattern
 
 export type { IActivityRepo } from './activity-repo.interface';
-export type { IAuthRepo } from './auth-repo.interface';
+export type { IAuthRepo, LicenseKeyCountFilter, LicenseKeyPage } from './auth-repo.interface';
 export type { IAutoChallengeRepo } from './auto-challenge-repo.interface';
 export type { IBattleRepo } from './battle-repo.interface';
 export type { IChecklistRepo } from './checklist-repo.interface';

--- a/src/lib/server/db/sqlite/auth-repo.ts
+++ b/src/lib/server/db/sqlite/auth-repo.ts
@@ -112,3 +112,15 @@ export const updateLicenseKeyStatus: IAuthRepo['updateLicenseKeyStatus'] = async
 export const revokeLicenseKey: IAuthRepo['revokeLicenseKey'] = async () => {
 	// no-op in local mode (#797)
 };
+export const listLicenseKeysByTenant: IAuthRepo['listLicenseKeysByTenant'] = async () => {
+	return { items: [], cursor: null }; // no-op in local mode (#816)
+};
+export const listLicenseKeysByStatus: IAuthRepo['listLicenseKeysByStatus'] = async () => {
+	return { items: [], cursor: null }; // no-op in local mode (#816)
+};
+export const listExpiringSoon: IAuthRepo['listExpiringSoon'] = async () => {
+	return []; // no-op in local mode (#816)
+};
+export const countLicenseKeys: IAuthRepo['countLicenseKeys'] = async () => {
+	return 0; // no-op in local mode (#816)
+};

--- a/tests/unit/services/license-key-search.test.ts
+++ b/tests/unit/services/license-key-search.test.ts
@@ -307,3 +307,36 @@ describe('DynamoDB auth-repo — license key search (#816)', () => {
 		});
 	});
 });
+
+// ============================================================
+// decodeCursor security (#816 QA review)
+// ============================================================
+
+describe('DynamoDB auth-repo — decodeCursor security (#816)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('不正な Base64 カーソル文字列でエラーをスローする', async () => {
+		const mod = await import('$lib/server/db/dynamodb/auth-repo');
+		await expect(mod.listLicenseKeysByTenant('t-1', 10, 'not-valid-base64!!!')).rejects.toThrow(
+			'Invalid pagination cursor',
+		);
+	});
+
+	it('配列をデコードした場合もエラーをスローする', async () => {
+		const arrayCursor = Buffer.from(JSON.stringify([1, 2, 3]), 'utf-8').toString('base64url');
+		const mod = await import('$lib/server/db/dynamodb/auth-repo');
+		await expect(mod.listLicenseKeysByTenant('t-1', 10, arrayCursor)).rejects.toThrow(
+			'Invalid pagination cursor',
+		);
+	});
+
+	it('null をデコードした場合もエラーをスローする', async () => {
+		const nullCursor = Buffer.from('null', 'utf-8').toString('base64url');
+		const mod = await import('$lib/server/db/dynamodb/auth-repo');
+		await expect(mod.listLicenseKeysByTenant('t-1', 10, nullCursor)).rejects.toThrow(
+			'Invalid pagination cursor',
+		);
+	});
+});

--- a/tests/unit/services/license-key-search.test.ts
+++ b/tests/unit/services/license-key-search.test.ts
@@ -1,0 +1,309 @@
+// tests/unit/services/license-key-search.test.ts
+// IAuthRepo の検索メソッド (#816) のユニットテスト
+// DynamoDB 実装のモック + SQLite (local) 実装のスタブの両方をテスト
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LICENSE_KEY_STATUS } from '$lib/domain/constants/license-key-status';
+import { LICENSE_PLAN } from '$lib/domain/constants/license-plan';
+import type { LicenseRecord } from '$lib/server/services/license-key-service';
+
+// ============================================================
+// Mock: SQLite local mode (no-op stubs)
+// ============================================================
+
+describe('SQLite auth-repo (local mode) — license key search (#816)', () => {
+	// SQLite モジュールを直接テスト
+	// vi.mock は不要: SQLite 実装は DynamoDB に依存しないスタブ
+
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	it('listLicenseKeysByTenant は空ページを返す', async () => {
+		const mod = await import('$lib/server/db/sqlite/auth-repo');
+		const result = await mod.listLicenseKeysByTenant('t-123');
+		expect(result).toEqual({ items: [], cursor: null });
+	});
+
+	it('listLicenseKeysByStatus は空ページを返す', async () => {
+		const mod = await import('$lib/server/db/sqlite/auth-repo');
+		const result = await mod.listLicenseKeysByStatus(LICENSE_KEY_STATUS.ACTIVE);
+		expect(result).toEqual({ items: [], cursor: null });
+	});
+
+	it('listExpiringSoon は空配列を返す', async () => {
+		const mod = await import('$lib/server/db/sqlite/auth-repo');
+		const result = await mod.listExpiringSoon(30);
+		expect(result).toEqual([]);
+	});
+
+	it('countLicenseKeys は 0 を返す', async () => {
+		const mod = await import('$lib/server/db/sqlite/auth-repo');
+		const result = await mod.countLicenseKeys();
+		expect(result).toBe(0);
+	});
+});
+
+// ============================================================
+// Mock: DynamoDB implementation
+// ============================================================
+
+// DynamoDB SDK をモックして auth-repo の検索メソッドをテスト
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/lib-dynamodb', () => {
+	class MockQueryCommand {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	class MockScanCommand {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	class MockGetCommand {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	class MockPutCommand {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	class MockDeleteCommand {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	class MockUpdateCommand {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	return {
+		DynamoDBDocumentClient: {
+			from: () => ({ send: mockSend }),
+		},
+		QueryCommand: MockQueryCommand,
+		ScanCommand: MockScanCommand,
+		GetCommand: MockGetCommand,
+		PutCommand: MockPutCommand,
+		DeleteCommand: MockDeleteCommand,
+		UpdateCommand: MockUpdateCommand,
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {
+		destroy() {
+			/* noop */
+		}
+	},
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+
+function makeLicenseItem(
+	overrides: Partial<LicenseRecord> & { licenseKey: string },
+): Record<string, unknown> {
+	return {
+		PK: `LICENSE#${overrides.licenseKey}`,
+		SK: `LICENSE#${overrides.licenseKey}`,
+		GSI2PK: `TENANT#${overrides.tenantId ?? 't-1'}`,
+		GSI2SK: `LICENSE#${overrides.createdAt ?? '2026-04-01T00:00:00.000Z'}`,
+		tenantId: overrides.tenantId ?? 't-1',
+		plan: overrides.plan ?? LICENSE_PLAN.MONTHLY,
+		status: overrides.status ?? LICENSE_KEY_STATUS.ACTIVE,
+		createdAt: overrides.createdAt ?? '2026-04-01T00:00:00.000Z',
+		...(overrides.expiresAt ? { expiresAt: overrides.expiresAt } : {}),
+		...(overrides.kind ? { kind: overrides.kind } : {}),
+		...(overrides.issuedBy ? { issuedBy: overrides.issuedBy } : {}),
+		...(overrides.consumedBy ? { consumedBy: overrides.consumedBy } : {}),
+		...(overrides.consumedAt ? { consumedAt: overrides.consumedAt } : {}),
+		...(overrides.revokedAt ? { revokedAt: overrides.revokedAt } : {}),
+		...(overrides.revokedReason ? { revokedReason: overrides.revokedReason } : {}),
+		...(overrides.revokedBy ? { revokedBy: overrides.revokedBy } : {}),
+	};
+}
+
+describe('DynamoDB auth-repo — license key search (#816)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('listLicenseKeysByTenant', () => {
+		it('テナントのライセンスキー一覧を返す', async () => {
+			const items = [
+				makeLicenseItem({
+					licenseKey: 'GQ-AAAA-BBBB-CCCC',
+					tenantId: 't-1',
+					createdAt: '2026-04-02T00:00:00.000Z',
+				}),
+				makeLicenseItem({
+					licenseKey: 'GQ-DDDD-EEEE-FFFF',
+					tenantId: 't-1',
+					createdAt: '2026-04-01T00:00:00.000Z',
+				}),
+			];
+			mockSend.mockResolvedValueOnce({ Items: items, LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			const result = await mod.listLicenseKeysByTenant('t-1');
+
+			expect(result.items).toHaveLength(2);
+			expect(result.items[0]?.licenseKey).toBe('GQ-AAAA-BBBB-CCCC');
+			expect(result.items[1]?.licenseKey).toBe('GQ-DDDD-EEEE-FFFF');
+			expect(result.cursor).toBeNull();
+		});
+
+		it('ページネーションカーソルを返す', async () => {
+			const lastKey = {
+				PK: 'LICENSE#GQ-XXXX',
+				SK: 'META',
+				GSI2PK: 'TENANT#t-1',
+				GSI2SK: 'LICENSE#2026-04-01',
+			};
+			mockSend.mockResolvedValueOnce({
+				Items: [makeLicenseItem({ licenseKey: 'GQ-AAAA-BBBB-CCCC' })],
+				LastEvaluatedKey: lastKey,
+			});
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			const result = await mod.listLicenseKeysByTenant('t-1', 1);
+
+			expect(result.items).toHaveLength(1);
+			expect(result.cursor).toBeTruthy();
+			expect(typeof result.cursor).toBe('string');
+		});
+
+		it('空のテナントには空配列を返す', async () => {
+			mockSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			const result = await mod.listLicenseKeysByTenant('t-empty');
+
+			expect(result.items).toHaveLength(0);
+			expect(result.cursor).toBeNull();
+		});
+	});
+
+	describe('listLicenseKeysByStatus', () => {
+		it('指定ステータスのキー一覧を返す', async () => {
+			const items = [
+				makeLicenseItem({ licenseKey: 'GQ-AAAA-BBBB-CCCC', status: LICENSE_KEY_STATUS.ACTIVE }),
+			];
+			mockSend.mockResolvedValueOnce({ Items: items, LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			const result = await mod.listLicenseKeysByStatus(LICENSE_KEY_STATUS.ACTIVE);
+
+			expect(result.items).toHaveLength(1);
+			expect(result.items[0]?.status).toBe(LICENSE_KEY_STATUS.ACTIVE);
+			expect(result.cursor).toBeNull();
+		});
+
+		it('revoked ステータスでフィルタリングできる', async () => {
+			const items = [
+				makeLicenseItem({
+					licenseKey: 'GQ-RRRR-RRRR-RRRR',
+					status: LICENSE_KEY_STATUS.REVOKED,
+					revokedAt: '2026-04-10T00:00:00.000Z',
+					revokedReason: 'ops-manual',
+					revokedBy: 'ops:admin',
+				}),
+			];
+			mockSend.mockResolvedValueOnce({ Items: items, LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			const result = await mod.listLicenseKeysByStatus(LICENSE_KEY_STATUS.REVOKED);
+
+			expect(result.items).toHaveLength(1);
+			expect(result.items[0]?.revokedReason).toBe('ops-manual');
+		});
+	});
+
+	describe('listExpiringSoon', () => {
+		it('期限切れ間近のキーを返す', async () => {
+			const soon = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString();
+			const items = [
+				makeLicenseItem({
+					licenseKey: 'GQ-EEEE-EEEE-EEEE',
+					status: LICENSE_KEY_STATUS.ACTIVE,
+					expiresAt: soon,
+				}),
+			];
+			mockSend.mockResolvedValueOnce({ Items: items, LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			const result = await mod.listExpiringSoon(7);
+
+			expect(result).toHaveLength(1);
+			expect(result[0]?.licenseKey).toBe('GQ-EEEE-EEEE-EEEE');
+		});
+
+		it('期限切れキーがない場合は空配列を返す', async () => {
+			mockSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			const result = await mod.listExpiringSoon(7);
+
+			expect(result).toHaveLength(0);
+		});
+	});
+
+	describe('countLicenseKeys', () => {
+		it('全キーの数を返す', async () => {
+			mockSend.mockResolvedValueOnce({ Count: 42, LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			const result = await mod.countLicenseKeys();
+
+			expect(result).toBe(42);
+		});
+
+		it('テナントフィルタ付きで数を返す', async () => {
+			mockSend.mockResolvedValueOnce({ Count: 5, LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			const result = await mod.countLicenseKeys({ tenantId: 't-1' });
+
+			expect(result).toBe(5);
+		});
+
+		it('ステータスフィルタ付きで数を返す', async () => {
+			mockSend.mockResolvedValueOnce({ Count: 10, LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			const result = await mod.countLicenseKeys({ status: LICENSE_KEY_STATUS.ACTIVE });
+
+			expect(result).toBe(10);
+		});
+
+		it('テナント + ステータスフィルタの組み合わせ', async () => {
+			mockSend.mockResolvedValueOnce({ Count: 3, LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			const result = await mod.countLicenseKeys({
+				tenantId: 't-1',
+				status: LICENSE_KEY_STATUS.CONSUMED,
+			});
+
+			expect(result).toBe(3);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- `IAuthRepo` に `listLicenseKeysByTenant` / `listLicenseKeysByStatus` / `listExpiringSoon` / `countLicenseKeys` の4メソッドを追加
- DynamoDB 実装: `listLicenseKeysByTenant` は GSI2 Query、他は Scan + Filter（Pre-PMF 段階で ADR-0034 準拠）
- SQLite (local mode) 実装: no-op stub（空結果を返す）
- ページネーション対応（Base64url カーソル）
- 設計書 `08-データベース設計書.md` に検索メソッドと GSI2 利用パターンを反映

## Test plan
- [x] `tests/unit/services/license-key-search.test.ts` に 15 テストケース追加（SQLite 4件 + DynamoDB 11件）
- [x] 既存 `license-key-service.test.ts` (89テスト) が全通過
- [x] `biome check` / `svelte-check` クリーン

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)