### PR TITLE
fix: #781 Discord サポート文言の排除を回帰テストで保証

### DIFF
--- a/tests/unit/domain/plan-features.test.ts
+++ b/tests/unit/domain/plan-features.test.ts
@@ -147,6 +147,47 @@ describe('plan-features.ts SSOT', () => {
 		});
 	});
 
+	describe('Discord サポート文言の排除 (#781)', () => {
+		it('全プランの pricing features に Discord の文言が含まれないこと', () => {
+			const allFeatures = [
+				...PRICING_PAGE_FEATURES.free,
+				...PRICING_PAGE_FEATURES.standard,
+				...PRICING_PAGE_FEATURES.family,
+			];
+			for (const feature of allFeatures) {
+				expect(feature.toLowerCase()).not.toContain('discord');
+			}
+		});
+
+		it('全プランの license highlights に Discord の文言が含まれないこと', () => {
+			const allHighlights = [
+				...LICENSE_PAGE_HIGHLIGHTS.standard,
+				...LICENSE_PAGE_HIGHLIGHTS.family,
+			];
+			for (const highlight of allHighlights) {
+				expect(highlight.toLowerCase()).not.toContain('discord');
+			}
+		});
+
+		it('全プランの unlocked features に Discord の文言が含まれないこと', () => {
+			const allTexts = [
+				...PREMIUM_UNLOCKED_FEATURES.standard.map((f) => f.text),
+				...PREMIUM_UNLOCKED_FEATURES.family.map((f) => f.text),
+			];
+			for (const text of allTexts) {
+				expect(text.toLowerCase()).not.toContain('discord');
+			}
+		});
+
+		it('サポート表記がメール優先サポートに統一されていること', () => {
+			const standardFeatures = PRICING_PAGE_FEATURES.standard;
+			const familyFeatures = PRICING_PAGE_FEATURES.family;
+
+			expect(standardFeatures).toContain('メール優先サポート');
+			expect(familyFeatures).toContain('メール優先サポート（24時間以内応答）');
+		});
+	});
+
 	describe('PRICING_PAGE_META (#765)', () => {
 		it('3 プラン全てが定義されている', () => {
 			expect(PRICING_PAGE_META.free).toBeDefined();


### PR DESCRIPTION
## Summary

- Issue #781 で指摘された「Discord サポート」のプラン差別化は既に解消済みであることを確認
- Discord サポート文言が再混入しないことを保証する回帰テストを追加
- サポート表記がメール優先サポートに統一されていることのアサーションを追加

## 背景

Issue #781 は「/pricing に Discord サポート / Discord サポート（優先対応）と記載されているが、実装がない」という指摘でした。

調査の結果、過去の LP 改訂時に Discord サポートの記載は既に削除されており、現在は以下のように統一されています:

| プラン | サポート表記 |
|-------|------------|
| free | メール・GitHub Issues サポート |
| standard | メール優先サポート |
| family | メール優先サポート（24時間以内応答） |

コードベース内の Discord 関連コードは全て運用者向け内部通知（discord-notify-service, discord-alert）であり、ユーザー向けサポート機能ではありません。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `tests/unit/domain/plan-features.test.ts` | Discord 文言排除の回帰テスト 4 件追加 |

## Test plan

- [x] `npx vitest run tests/unit/domain/plan-features.test.ts` — 39 テスト全通過
- [x] `npx biome check` — エラーなし

closes #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)