### PR TITLE
infra: #971 jscpd 導入でコードクローン週次検出

### DIFF
--- a/.github/workflows/code-quality-weekly.yml
+++ b/.github/workflows/code-quality-weekly.yml
@@ -1,0 +1,35 @@
+name: Code Quality Weekly (jscpd)
+
+on:
+  schedule:
+    # Every Monday 00:00 UTC = 09:00 JST
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  jscpd:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run jscpd (code clone detection)
+        run: npm run jscpd
+
+      - name: Upload jscpd report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: jscpd-report
+          path: reports/jscpd/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -71,8 +71,8 @@ screenshots/
 !site/screenshots/
 !docs/screenshots/
 
-# Security scan reports (may contain sensitive info)
-reports/security/
+# Reports (jscpd, type-coverage, security scan, etc.)
+reports/
 
 # Storybook
 storybook-static/

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,23 +1,23 @@
 {
-  "$schema": "https://jscpd.dev/schema/jscpd.json",
-  "threshold": 1,
-  "minTokens": 50,
-  "minLines": 5,
-  "reporters": ["html", "json", "console"],
-  "output": "./reports/jscpd/",
-  "format": ["typescript", "svelte", "javascript"],
-  "ignore": [
-    ".svelte-kit/**",
-    "drizzle/**",
-    "tests/e2e/fixtures/**",
-    "**/*.test.ts",
-    "**/*.spec.ts",
-    "site/**",
-    "personal/**",
-    "node_modules/**",
-    "build/**",
-    "storybook-static/**",
-    "reports/**",
-    "coverage/**"
-  ]
+	"$schema": "https://jscpd.dev/schema/jscpd.json",
+	"threshold": 1,
+	"minTokens": 50,
+	"minLines": 5,
+	"reporters": ["html", "json", "console"],
+	"output": "./reports/jscpd/",
+	"format": ["typescript", "svelte", "javascript"],
+	"ignore": [
+		".svelte-kit/**",
+		"drizzle/**",
+		"tests/e2e/fixtures/**",
+		"**/*.test.ts",
+		"**/*.spec.ts",
+		"site/**",
+		"personal/**",
+		"node_modules/**",
+		"build/**",
+		"storybook-static/**",
+		"reports/**",
+		"coverage/**"
+	]
 }

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://jscpd.dev/schema/jscpd.json",
+  "threshold": 1,
+  "minTokens": 50,
+  "minLines": 5,
+  "reporters": ["html", "json", "console"],
+  "output": "./reports/jscpd/",
+  "format": ["typescript", "svelte", "javascript"],
+  "ignore": [
+    ".svelte-kit/**",
+    "drizzle/**",
+    "tests/e2e/fixtures/**",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "site/**",
+    "personal/**",
+    "node_modules/**",
+    "build/**",
+    "storybook-static/**",
+    "reports/**",
+    "coverage/**"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ vitest --coverage（カバレッジ閾値）, playwright（E2E）, ESLint（svel
 - Pre-PMF で過剰防衛設計（汎用監査ログ DynamoDB テーブル / S3+Athena / AWS WAF / IP 単位ブルートフォース検知 等）を新規追加しない（ADR-0034）→ HMAC 鍵強度 + API Gateway スロットリング + AWS Budgets + 既存 state カラムで Pre-PMF 段階は十分。採用するには ADR-0034 を supersede する新 ADR を先に起票すること
 - **認証が絡む UI 画面** (login / signup / 管理画面 / ops / プラン別 UI) を `npm run dev` の自動認証モードだけで検証した状態で PR を Ready にしない（#1026）→ `npm run dev` は `/auth/login` を 302 redirect するためログインフォームが描画されず UI 検証ができない。必ず `npm run dev:cognito` で Cognito モックモード (port 5174) を起動し、`DEV_USERS` の該当アカウントでログインした上で `docs/DESIGN.md` §9 禁忌事項のセルフチェックを行うこと
 - **スクリーンショットは CI を通すためではなく UI/UX デザイナー視点の自己判定証跡**として貼る（#1026）→ PR 本文に `![...](...)` さえあれば screenshot-check は通るが、それは目的ではない。撮った画像を自分で見て違和感があれば修正すること。PR template の「スクリーンショット / ビジュアルデモ」セクション冒頭の目的説明に従うこと
+- jscpd を PR の hard-fail に昇格させない（別 ADR なしには）（#971）→ jscpd は週次レポートとして T3 階層で運用。PR ゲートに含めると開発体験が悪化する
 
 ## Critical バグ修正の必須要件（ADR-0005）
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
 				"eslint-plugin-storybook": "^10.3.5",
 				"eslint-plugin-svelte": "^3.17.0",
 				"googleapis": "^171.4.0",
+				"jscpd": "^4.0.9",
 				"jsdom": "^29.0.2",
 				"knip": "^6.4.1",
 				"playwright": "^1.59.1",
@@ -1861,6 +1862,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@colors/colors": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.1.90"
 			}
 		},
 		"node_modules/@cspell/cspell-bundled-dicts": {
@@ -4383,6 +4395,71 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@jscpd/badge-reporter": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@jscpd/badge-reporter/-/badge-reporter-4.0.5.tgz",
+			"integrity": "sha512-SLVhP00R9lkQ//Ivaanfm7k0L9sewpBven670kk1uGec2SWUOa7MVQcuad/TV59KEZ73UIC1lXvi6O9hAnbpUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"badgen": "^3.2.3",
+				"colors": "^1.4.0",
+				"fs-extra": "^11.2.0"
+			}
+		},
+		"node_modules/@jscpd/core": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@jscpd/core/-/core-4.0.5.tgz",
+			"integrity": "sha512-Udvym21nWzxjYRVXwwpYNBqZ6b50QV2zHN3fFNzOPPg4cfQVYOZerILB7xNDUsXHC1PCr/N52Tq3q7AElvjWWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eventemitter3": "^5.0.1"
+			}
+		},
+		"node_modules/@jscpd/finder": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@jscpd/finder/-/finder-4.0.5.tgz",
+			"integrity": "sha512-/2VkRoVrrfya+51sitZo5I9MdwsRaPKB8X3L3khAYoHFXk4L/mUuG81RmGazDHjUIGg22ItlkQtwzorNZ2+aPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jscpd/core": "4.0.5",
+				"@jscpd/tokenizer": "4.0.5",
+				"blamer": "^1.0.6",
+				"bytes": "^3.1.2",
+				"cli-table3": "^0.6.5",
+				"colors": "^1.4.0",
+				"fast-glob": "^3.3.2",
+				"fs-extra": "^11.2.0",
+				"markdown-table": "^2.0.0",
+				"pug": "^3.0.3"
+			}
+		},
+		"node_modules/@jscpd/html-reporter": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@jscpd/html-reporter/-/html-reporter-4.0.5.tgz",
+			"integrity": "sha512-drK2J8KyPIW9wvaElSIobZFp4dBO9GA++JW4gx3oihvLdDSp8qSo/CNqH47Dw0XkjQTxND3j/+Wz5JWvYRBgFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"colors": "1.4.0",
+				"fs-extra": "^11.2.0",
+				"pug": "^3.0.3"
+			}
+		},
+		"node_modules/@jscpd/tokenizer": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@jscpd/tokenizer/-/tokenizer-4.0.5.tgz",
+			"integrity": "sha512-WzRujQtN5WedxZVDKuoanxmKAFrxcLrHpcA6kaM4z8AhGtWXZ325yseqgL5TZ8OK7Auwu7kQLlqhfk05fGYG7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jscpd/core": "4.0.5",
+				"reprism": "^0.0.11",
+				"spark-md5": "^3.0.2"
 			}
 		},
 		"node_modules/@keyv/serialize": {
@@ -7568,6 +7645,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/sarif": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+			"integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -9118,6 +9202,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/asap": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/asn1.js": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
@@ -9129,6 +9220,13 @@
 				"minimalistic-assert": "^1.0.0",
 				"safer-buffer": "^2.1.0"
 			}
+		},
+		"node_modules/assert-never": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.4.0.tgz",
+			"integrity": "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
@@ -9210,6 +9308,26 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/babel-walk": {
+			"version": "3.0.0-canary-5",
+			"resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
+			"integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.9.6"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/badgen": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/badgen/-/badgen-3.2.3.tgz",
+			"integrity": "sha512-svDuwkc63E/z0ky3drpUppB83s/nlgDciH9m+STwwQoWyq7yCgew1qEfJ+9axkKdNq7MskByptWUN9j1PGMwFA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/balanced-match": {
 			"version": "4.0.4",
@@ -9307,6 +9425,20 @@
 				"buffer": "^5.5.0",
 				"inherits": "^2.0.4",
 				"readable-stream": "^3.4.0"
+			}
+		},
+		"node_modules/blamer": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/blamer/-/blamer-1.0.7.tgz",
+			"integrity": "sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^4.0.0",
+				"which": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=8.9"
 			}
 		},
 		"node_modules/bn.js": {
@@ -9569,6 +9701,16 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/character-parser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
+			"integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-regex": "^1.0.3"
+			}
+		},
 		"node_modules/check-error": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -9617,6 +9759,22 @@
 				"@chromatic-com/playwright": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/cli-table3": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+			"integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^4.2.0"
+			},
+			"engines": {
+				"node": "10.* || >= 12.*"
+			},
+			"optionalDependencies": {
+				"@colors/colors": "1.5.0"
 			}
 		},
 		"node_modules/cliui": {
@@ -9693,14 +9851,24 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/commander": {
-			"version": "14.0.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+		"node_modules/colors": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=20"
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/commander": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/comment-json": {
@@ -9723,6 +9891,17 @@
 			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/constantinople": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
+			"integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.6.0",
+				"@babel/types": "^7.6.1"
+			}
 		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
@@ -9807,29 +9986,6 @@
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/cross-spawn/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/cross-spawn/node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
 			},
 			"engines": {
 				"node": ">= 8"
@@ -10066,6 +10222,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cspell/node_modules/commander": {
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/css-functions-list": {
@@ -10320,6 +10486,13 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
 			"integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+			"license": "MIT"
+		},
+		"node_modules/doctypes": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
+			"integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/dom-accessibility-api": {
@@ -11491,6 +11664,44 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/execa": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"get-stream": "^5.0.0",
+				"human-signals": "^1.1.1",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.0",
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/execa/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/expand-template": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -11819,6 +12030,21 @@
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
 			"license": "MIT"
 		},
+		"node_modules/fs-extra": {
+			"version": "11.3.4",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+			"integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -11971,6 +12197,22 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/get-tsconfig": {
 			"version": "4.13.7",
 			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
@@ -12056,13 +12298,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/global-prefix/node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/global-prefix/node_modules/which": {
 			"version": "1.3.1",
@@ -12230,6 +12465,22 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/hashery": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
@@ -12316,6 +12567,16 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/human-signals": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.12.0"
 			}
 		},
 		"node_modules/ieee754": {
@@ -12447,6 +12708,30 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-expression": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
+			"integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^7.1.1",
+				"object-assign": "^4.1.1"
+			}
+		},
+		"node_modules/is-expression/node_modules/acorn": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -12545,6 +12830,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/is-promise": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-reference": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -12555,6 +12847,25 @@
 				"@types/estree": "*"
 			}
 		},
+		"node_modules/is-regex": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-safe-filename": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-safe-filename/-/is-safe-filename-0.1.1.tgz",
@@ -12563,6 +12874,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -12583,6 +12907,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -12658,6 +12989,13 @@
 				"url": "https://github.com/sponsors/panva"
 			}
 		},
+		"node_modules/js-stringify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
+			"integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12676,6 +13014,39 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jscpd": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/jscpd/-/jscpd-4.0.9.tgz",
+			"integrity": "sha512-fp6Sh42W3mIPoQgZmgYmKDLQzEDnnX2vaGlTN4haILkB2vsi+ewcCHEtWR/2CR/QbsBvAvsNo8U5Sa+p9aHiGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jscpd/badge-reporter": "4.0.5",
+				"@jscpd/core": "4.0.5",
+				"@jscpd/finder": "4.0.5",
+				"@jscpd/html-reporter": "4.0.5",
+				"@jscpd/tokenizer": "4.0.5",
+				"colors": "^1.4.0",
+				"commander": "^5.0.0",
+				"fs-extra": "^11.2.0",
+				"jscpd-sarif-reporter": "4.0.7"
+			},
+			"bin": {
+				"jscpd": "bin/jscpd"
+			}
+		},
+		"node_modules/jscpd-sarif-reporter": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/jscpd-sarif-reporter/-/jscpd-sarif-reporter-4.0.7.tgz",
+			"integrity": "sha512-Q/VlfTI/Nbjc8dZ/2pDVIf1aRi2bM2CTYujcAoeYr7brRnS4o5ZeW86W8q7MM7cQu40gezlNckl+E9wKFSMFiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"colors": "^1.4.0",
+				"fs-extra": "^11.2.0",
+				"node-sarif-builder": "^3.4.0"
 			}
 		},
 		"node_modules/jsdom": {
@@ -12768,6 +13139,17 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jstransformer": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
+			"integrity": "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-promise": "^2.0.0",
+				"promise": "^7.0.1"
 			}
 		},
 		"node_modules/jsx-ast-utils-x": {
@@ -13271,6 +13653,20 @@
 				"source-map-js": "^1.2.1"
 			}
 		},
+		"node_modules/markdown-table": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+			"integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"repeat-string": "^1.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -13312,6 +13708,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -13347,6 +13750,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/mimic-response": {
@@ -13528,10 +13941,47 @@
 				"node-gyp-build-test": "build-test.js"
 			}
 		},
+		"node_modules/node-sarif-builder": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+			"integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/sarif": "^2.1.7",
+				"fs-extra": "^11.1.1"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13575,6 +14025,22 @@
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/open": {
@@ -14110,6 +14576,16 @@
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
+		"node_modules/promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"asap": "~2.0.3"
+			}
+		},
 		"node_modules/protobufjs": {
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
@@ -14149,6 +14625,142 @@
 			"dependencies": {
 				"proxy-compare": "^3.0.0"
 			}
+		},
+		"node_modules/pug": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pug/-/pug-3.0.4.tgz",
+			"integrity": "sha512-kFfq5mMzrS7+wrl5pLJzZEzemx34OQ0w4SARfhy/3yxTlhbstsudDwJzhf1hP02yHzbjoVMSXUj/Sz6RNfMyXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pug-code-gen": "^3.0.4",
+				"pug-filters": "^4.0.0",
+				"pug-lexer": "^5.0.1",
+				"pug-linker": "^4.0.0",
+				"pug-load": "^3.0.0",
+				"pug-parser": "^6.0.0",
+				"pug-runtime": "^3.0.1",
+				"pug-strip-comments": "^2.0.0"
+			}
+		},
+		"node_modules/pug-attrs": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
+			"integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"constantinople": "^4.0.1",
+				"js-stringify": "^1.0.2",
+				"pug-runtime": "^3.0.0"
+			}
+		},
+		"node_modules/pug-code-gen": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.4.tgz",
+			"integrity": "sha512-6okWYIKdasTyXICyEtvobmTZAVX57JkzgzIi4iRJlin8kmhG+Xry2dsus+Mun/nGCn6F2U49haHI5mkELXB14g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"constantinople": "^4.0.1",
+				"doctypes": "^1.1.0",
+				"js-stringify": "^1.0.2",
+				"pug-attrs": "^3.0.0",
+				"pug-error": "^2.1.0",
+				"pug-runtime": "^3.0.1",
+				"void-elements": "^3.1.0",
+				"with": "^7.0.0"
+			}
+		},
+		"node_modules/pug-error": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
+			"integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pug-filters": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
+			"integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"constantinople": "^4.0.1",
+				"jstransformer": "1.0.0",
+				"pug-error": "^2.0.0",
+				"pug-walk": "^2.0.0",
+				"resolve": "^1.15.1"
+			}
+		},
+		"node_modules/pug-lexer": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
+			"integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"character-parser": "^2.2.0",
+				"is-expression": "^4.0.0",
+				"pug-error": "^2.0.0"
+			}
+		},
+		"node_modules/pug-linker": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
+			"integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pug-error": "^2.0.0",
+				"pug-walk": "^2.0.0"
+			}
+		},
+		"node_modules/pug-load": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
+			"integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4.1.1",
+				"pug-walk": "^2.0.0"
+			}
+		},
+		"node_modules/pug-parser": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
+			"integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pug-error": "^2.0.0",
+				"token-stream": "1.0.0"
+			}
+		},
+		"node_modules/pug-runtime": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
+			"integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pug-strip-comments": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
+			"integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pug-error": "^2.0.0"
+			}
+		},
+		"node_modules/pug-walk": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
+			"integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pump": {
 			"version": "3.0.3",
@@ -14374,6 +14986,23 @@
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
+		},
+		"node_modules/repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/reprism": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/reprism/-/reprism-0.0.11.tgz",
+			"integrity": "sha512-VsxDR5QxZo08M/3nRypNlScw5r3rKeSOPdU/QhDmu3Ai3BJxHn/qgfXGWQp/tAxUtzwYNo9W6997JZR0tPLZsA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -14999,6 +15628,13 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/spark-md5": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+			"integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+			"dev": true,
+			"license": "(WTFPL OR MIT)"
+		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -15168,6 +15804,16 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/strip-indent": {
@@ -15898,6 +16544,13 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/token-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
+			"integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -16428,6 +17081,16 @@
 				}
 			}
 		},
+		"node_modules/void-elements": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+			"integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/vscode-languageserver-textdocument": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
@@ -16536,6 +17199,22 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/which-module": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
@@ -16557,6 +17236,22 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/with": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
+			"integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.9.6",
+				"@babel/types": "^7.9.6",
+				"assert-never": "^1.2.1",
+				"babel-walk": "3.0.0-canary-5"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build",
 		"type-coverage": "type-coverage -p . --at-least 97 --strict --ignore-catch --detail",
-		"knip": "knip"
+		"knip": "knip",
+		"jscpd": "jscpd ."
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.10",
@@ -82,6 +83,7 @@
 		"eslint-plugin-storybook": "^10.3.5",
 		"eslint-plugin-svelte": "^3.17.0",
 		"googleapis": "^171.4.0",
+		"jscpd": "^4.0.9",
 		"jsdom": "^29.0.2",
 		"knip": "^6.4.1",
 		"playwright": "^1.59.1",


### PR DESCRIPTION
## Summary

- `jscpd` を devDependency に追加し、コードクローン検出を週次 CI で自動実行する基盤を整備
- `.jscpd.json` (minTokens: 50 / minLines: 5 / format: TS+Svelte+JS) を作成
- `npm run jscpd` が `./reports/jscpd/` に html/json レポートを出力
- `.github/workflows/code-quality-weekly.yml` を新設 (毎週月曜 00:00 UTC = 09:00 JST cron + workflow_dispatch)
- 初回は `continue-on-error: true` で warn-only 運用
- `reports/` を `.gitignore` に追加
- CLAUDE.md の Things Not To Do に「jscpd を PR の hard-fail に昇格させない（別 ADR なしには）」を追記

## ADR-0032 階層

T3 (週次 cron) — PR ゲートには含めない

## Acceptance Criteria 対応

- [x] `jscpd` を devDependency に追加
- [x] `.jscpd.json` を `minTokens: 50 / minLines: 5 / format: [typescript, svelte, javascript] / ignore: [.svelte-kit, drizzle, tests/e2e/fixtures, *.test.ts, site/, personal/, node_modules]` で作成
- [x] `npm run jscpd` が `./reports/jscpd/` に html / json を出力すること
- [x] `.github/workflows/code-quality-weekly.yml` を追加（cron: 毎週月曜 0:00 UTC = 09:00 JST）
- [x] 初回実行結果の html レポートを zip で artifact 保存（retention 30 日）
- [x] `reports/` を `.gitignore` に追加
- [x] **本 Issue では jscpd が検出した違反の修正は行わない**
- [x] CLAUDE.md の「Things Not To Do」に追記

closes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)