### PR TITLE
infra: #985 OSS 脆弱性診断ツール導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ screenshots/
 !site/screenshots/
 !docs/screenshots/
 
+# Security scan reports (may contain sensitive info)
+reports/security/
+
 # Storybook
 storybook-static/
 

--- a/docs/security/scan.md
+++ b/docs/security/scan.md
@@ -1,0 +1,197 @@
+# OSS 脆弱性診断ガイド
+
+> Issue #985 / ADR-0032 T4（四半期 / 手動実行）
+
+## 概要
+
+3 つの OSS ツールでプロジェクトの脆弱性を検査する。
+
+| ツール | 対象 | インストール | 必須 |
+|--------|------|-------------|------|
+| **npm audit** | npm 依存パッケージ | npm 組み込み（追加不要） | YES |
+| **osv-scanner** | lockfile → OSV.dev DB | brew / go install | NO（推奨） |
+| **semgrep** | ソースコード脆弱パターン | pip / brew | NO（推奨） |
+
+## クイックスタート
+
+```bash
+# 最小構成（npm audit のみ）
+npm run security:scan
+
+# 全ツール使用（osv-scanner + semgrep をインストール済みの場合）
+npm run security:scan
+```
+
+結果は `reports/security/YYYY-MM-DD/` に出力される。
+
+## ツール別インストール手順
+
+### npm audit（インストール不要）
+
+npm 組み込み。追加作業なし。
+
+### osv-scanner
+
+Google 製の OSS 脆弱性スキャナ。OSV.dev の広範な脆弱性データベースを使用。
+
+```bash
+# macOS
+brew install osv-scanner
+
+# Go (any OS)
+go install github.com/google/osv-scanner/cmd/osv-scanner@latest
+
+# Linux (binary)
+curl -L https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64 -o /usr/local/bin/osv-scanner
+chmod +x /usr/local/bin/osv-scanner
+
+# Windows (scoop)
+scoop install osv-scanner
+```
+
+検証: `osv-scanner --version`
+
+### semgrep
+
+軽量な静的解析ツール。SQLi、XSS、path traversal 等のコードパターンを検出。
+
+```bash
+# Python (any OS)
+pip install semgrep
+
+# macOS
+brew install semgrep
+
+# Docker
+docker run --rm -v "${PWD}:/src" returntocorp/semgrep semgrep scan --config auto /src
+```
+
+検証: `semgrep --version`
+
+## 実行
+
+### 定期実行（推奨: 四半期ごと）
+
+```bash
+npm run security:scan
+```
+
+### カスタム出力先
+
+```bash
+node scripts/security-scan.mjs --output-dir reports/security/custom-name
+```
+
+### 個別ツール実行
+
+```bash
+# npm audit のみ
+npm audit
+npm audit --json > reports/security/npm-audit.json
+
+# osv-scanner のみ
+osv-scanner --lockfile=package-lock.json
+
+# semgrep のみ
+semgrep scan --config auto src/
+```
+
+## 出力ファイル
+
+```
+reports/security/YYYY-MM-DD/
+  npm-audit.json        # npm audit の JSON 出力
+  npm-audit.txt         # npm audit の人間可読出力
+  osv-scanner.json      # osv-scanner 結果（未インストール時は skipped フラグ）
+  semgrep.json          # semgrep 結果（未インストール時は skipped フラグ）
+  summary.txt           # 全ツールのサマリ
+```
+
+> `reports/security/` は `.gitignore` に含まれる（機密情報を含む可能性があるため）。
+
+## finding の対処フロー
+
+### 1. 重要度の判定
+
+| Severity | 対応 |
+|----------|------|
+| **critical / high** | 即座に個別 Issue を起票。修正 PR を優先 |
+| **moderate** | 個別 Issue を起票。次スプリントで対応 |
+| **low / info** | 本 Issue (#985) のコメントに集約。次回スキャンまでに対応 |
+
+### 2. Issue 起票テンプレート
+
+```markdown
+## 脆弱性報告
+
+- **ツール**: npm audit / osv-scanner / semgrep
+- **パッケージ**: package-name@version
+- **CVE**: CVE-YYYY-XXXXX
+- **Severity**: high
+- **概要**: [脆弱性の概要]
+- **影響**: [本プロジェクトでの影響範囲]
+- **修正方法**: [パッケージ更新 / コード修正 / ワークアラウンド]
+- **検出日**: YYYY-MM-DD
+```
+
+### 3. 修正方法
+
+#### npm 依存パッケージの脆弱性
+
+```bash
+# 自動修正（breaking change なし）
+npm audit fix
+
+# 強制修正（breaking change あり — テスト必須）
+npm audit fix --force
+
+# 特定パッケージの更新
+npm update <package-name>
+```
+
+#### コードパターンの脆弱性（semgrep 検出）
+
+semgrep の出力に修正提案が含まれる。手動でコードを修正し、テストで回帰を確認。
+
+## 例外登録
+
+### npm audit
+
+`package.json` に `overrides` を追加して脆弱性を受容する場合:
+
+```json
+{
+  "overrides": {
+    "vulnerable-package": ">=fixed-version"
+  }
+}
+```
+
+### osv-scanner
+
+`.osv-scanner.toml` で特定 CVE を無視:
+
+```toml
+[[IgnoredVulns]]
+id = "CVE-YYYY-XXXXX"
+reason = "Not exploitable in our usage (see #IssueNumber)"
+```
+
+### semgrep
+
+`.semgrepignore` で特定パスを除外:
+
+```
+# セキュリティ上問題のないパターン
+tests/
+```
+
+> **重要**: 例外登録は PR レビューで正当性を必ず確認すること。「面倒だから ignore」は禁止。
+
+## 関連
+
+- ADR-0032: 静的解析ツール実行頻度ポリシー（T4 = 四半期/手動）
+- ADR-0029: Safety Assertion Erosion Ban
+- ADR-0034: Pre-PMF セキュリティ最小化方針
+- `.github/workflows/codeql.yml`: CodeQL（JS/TS コードパターン検出）
+- `.github/workflows/dependency-review.yml`: PR 時の依存差分レビュー

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"db:seed": "tsx src/lib/server/db/seed.ts",
 		"deploy": "bash scripts/deploy.sh",
 		"start": "node build/index.js",
+		"security:scan": "node scripts/security-scan.mjs",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build"
 	},

--- a/scripts/security-scan.mjs
+++ b/scripts/security-scan.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+/**
+ * OSS 脆弱性診断スクリプト (#985 / ADR-0032 T4)
+ *
+ * 3 つのツールを順次実行し、結果を reports/security/YYYY-MM-DD/ に集約する。
+ *
+ * 1. npm audit (built-in) — npm の依存脆弱性チェック
+ * 2. osv-scanner (optional) — OSV.dev の広範な脆弱性 DB にクエリ
+ * 3. semgrep (optional) — コードパターン脆弱性検出
+ *
+ * Usage:
+ *   npm run security:scan
+ *   node scripts/security-scan.mjs [--output-dir <dir>]
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// ===== Configuration =====
+
+const today = new Date().toISOString().split('T')[0];
+const outputDirArg = process.argv.find((_, i, arr) => arr[i - 1] === '--output-dir');
+const outputDir = outputDirArg || join('reports', 'security', today);
+
+// ===== Helpers =====
+
+function ensureDir(dir) {
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+}
+
+function commandExists(cmd) {
+	try {
+		execSync(`${cmd} --version`, { stdio: 'pipe', timeout: 10_000 });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function runTool(name, command, outputFile) {
+	console.log(`\n${'='.repeat(60)}`);
+	console.log(`[${name}] Running...`);
+	console.log(`${'='.repeat(60)}`);
+
+	try {
+		const result = execSync(command, {
+			encoding: 'utf-8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+			timeout: 300_000, // 5 min timeout
+			maxBuffer: 10 * 1024 * 1024, // 10MB
+		});
+		writeFileSync(outputFile, result);
+		console.log(`[${name}] Completed. Output: ${outputFile}`);
+		return { success: true, findings: false };
+	} catch (err) {
+		// npm audit exits non-zero when vulnerabilities found — that's expected
+		if (err.stdout) {
+			writeFileSync(outputFile, err.stdout);
+			console.log(`[${name}] Completed with findings. Output: ${outputFile}`);
+			return { success: true, findings: true };
+		}
+		if (err.stderr) {
+			writeFileSync(outputFile, `STDERR:\n${err.stderr}\n\nSTDOUT:\n${err.stdout || '(empty)'}`);
+		}
+		console.error(`[${name}] Failed: ${err.message}`);
+		return { success: false, findings: false };
+	}
+}
+
+// ===== Main =====
+
+console.log('OSS Security Scan (#985 / ADR-0032 T4)');
+console.log(`Output directory: ${outputDir}`);
+console.log(`Date: ${today}`);
+
+ensureDir(outputDir);
+
+const results = [];
+
+// ----- 1. npm audit -----
+{
+	const outputFile = join(outputDir, 'npm-audit.json');
+	const result = runTool(
+		'npm audit',
+		'npm audit --json',
+		outputFile,
+	);
+	results.push({ tool: 'npm audit', ...result });
+
+	// Also generate human-readable output
+	const readableFile = join(outputDir, 'npm-audit.txt');
+	runTool('npm audit (readable)', 'npm audit', readableFile);
+}
+
+// ----- 2. osv-scanner (optional) -----
+{
+	const outputFile = join(outputDir, 'osv-scanner.json');
+	if (commandExists('osv-scanner')) {
+		const result = runTool(
+			'osv-scanner',
+			'osv-scanner --lockfile=package-lock.json --format json',
+			outputFile,
+		);
+		results.push({ tool: 'osv-scanner', ...result });
+	} else {
+		console.log('\n[osv-scanner] Not installed. Skipping.');
+		console.log('  Install: brew install osv-scanner');
+		console.log('  Or: go install github.com/google/osv-scanner/cmd/osv-scanner@latest');
+		console.log('  See: docs/security/scan.md');
+		writeFileSync(outputFile, JSON.stringify({ skipped: true, reason: 'osv-scanner not installed' }, null, 2));
+		results.push({ tool: 'osv-scanner', success: false, findings: false, skipped: true });
+	}
+}
+
+// ----- 3. semgrep (optional) -----
+{
+	const outputFile = join(outputDir, 'semgrep.json');
+	if (commandExists('semgrep')) {
+		const result = runTool(
+			'semgrep',
+			'semgrep scan --config auto --json --timeout 300 src/',
+			outputFile,
+		);
+		results.push({ tool: 'semgrep', ...result });
+	} else {
+		console.log('\n[semgrep] Not installed. Skipping.');
+		console.log('  Install: pip install semgrep');
+		console.log('  Or: brew install semgrep');
+		console.log('  See: docs/security/scan.md');
+		writeFileSync(outputFile, JSON.stringify({ skipped: true, reason: 'semgrep not installed' }, null, 2));
+		results.push({ tool: 'semgrep', success: false, findings: false, skipped: true });
+	}
+}
+
+// ----- Summary -----
+console.log(`\n${'='.repeat(60)}`);
+console.log('Summary');
+console.log(`${'='.repeat(60)}`);
+
+const summaryLines = [];
+for (const r of results) {
+	const status = r.skipped
+		? 'SKIPPED (not installed)'
+		: r.success
+			? r.findings
+				? 'FINDINGS DETECTED'
+				: 'CLEAN'
+			: 'ERROR';
+	const line = `${r.tool}: ${status}`;
+	console.log(`  ${line}`);
+	summaryLines.push(line);
+}
+
+const summaryFile = join(outputDir, 'summary.txt');
+writeFileSync(summaryFile, [
+	`Security Scan Summary — ${today}`,
+	'',
+	...summaryLines,
+	'',
+	`Full results: ${outputDir}/`,
+	'',
+	'Next steps:',
+	'- severity high 以上の finding は個別 Issue として起票する',
+	'- low/info は本 Issue のコメントに集約可',
+	'- 詳細手順: docs/security/scan.md',
+].join('\n'));
+
+console.log(`\nSummary written to: ${summaryFile}`);
+
+// Exit with non-zero if any tool found vulnerabilities
+const hasFindings = results.some((r) => r.findings);
+if (hasFindings) {
+	console.log('\n⚠ Vulnerabilities found. Review reports and file Issues as needed.');
+	process.exit(1);
+}
+
+console.log('\n✓ No vulnerabilities found.');


### PR DESCRIPTION
## Summary

closes #985

- `scripts/security-scan.mjs` を新設し、3 ツールを順次実行
  - **npm audit** (組み込み / 必須) — npm 依存パッケージの脆弱性チェック
  - **osv-scanner** (オプション) — OSV.dev の広範な脆弱性 DB にクエリ
  - **semgrep** (オプション) — コードパターン脆弱性検出（SQLi, XSS, path traversal 等）
- `npm run security:scan` コマンドを追加
- `reports/security/` を `.gitignore` に追加（機密情報の混入防止）
- `docs/security/scan.md` に手順・対処ガイド・例外登録方法を記載

### 初回ベースライン実行結果

| ツール | ステータス | 検出数 | 重要度 |
|--------|-----------|--------|--------|
| npm audit | FINDINGS | 8 件 | 4 low, 4 moderate |
| osv-scanner | SKIPPED | - | 未インストール |
| semgrep | SKIPPED | - | 未インストール |

npm audit の検出内容:
- `cookie` < 0.7.0: OOB characters in name/path/domain (low) — @sveltejs/kit の transitive dep
- `esbuild` <= 0.24.2: dev server request hijacking (moderate) — drizzle-kit の transitive dep

**severity high 以上の finding なし** → 個別 Issue 起票は不要。本 Issue コメントに集約。

### ADR-0032 ティア

T4（四半期 / 手動実行）— CI には追加しない。ローカルで手動実行。

### osv-scanner / semgrep の導入手順

未インストールの場合、スクリプトは SKIPPED として処理し、エラーにはならない。
導入手順は `docs/security/scan.md` を参照:

```bash
# osv-scanner
brew install osv-scanner  # or: scoop install osv-scanner (Windows)

# semgrep
pip install semgrep       # or: brew install semgrep
```

## Test plan

- [x] `npm run security:scan` でスクリプトが正常実行される
- [x] npm audit の結果が `reports/security/` に出力される
- [x] osv-scanner / semgrep 未インストール時は SKIPPED で正常終了
- [x] `reports/security/` が `.gitignore` で除外されている
- [x] `docs/security/scan.md` の手順が正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)