### PR TITLE
refactor: #984 API handler / 内部ロジックのコード重複を解消

### DIFF
--- a/src/lib/server/api/suggest-plan-gate.ts
+++ b/src/lib/server/api/suggest-plan-gate.ts
@@ -1,0 +1,63 @@
+// src/lib/server/api/suggest-plan-gate.ts
+// AI 提案エンドポイント共通プランゲート (#727)
+
+import { error } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { apiError } from '$lib/server/errors';
+import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
+
+interface PlanGateSuccess {
+	ok: true;
+	tenantId: string;
+	text: string;
+}
+
+interface PlanGateFailure {
+	ok: false;
+	response: Response;
+}
+
+/**
+ * AI 提案エンドポイント共通のプランゲートとバリデーションを実行する。
+ *
+ * 1. 認証チェック（未認証 → 401）
+ * 2. プランチェック（family 以外 → PLAN_LIMIT_EXCEEDED）
+ * 3. テキストバリデーション（空 → 400, 200文字超 → 400）
+ *
+ * @returns 成功時は { ok: true, tenantId, text }, 失敗時は { ok: false, response }
+ */
+export async function validateSuggestRequest(
+	locals: App.Locals,
+	request: Request,
+	featureLabel: string,
+): Promise<PlanGateSuccess | PlanGateFailure> {
+	if (!locals.context) {
+		throw error(401, { message: 'Unauthorized' });
+	}
+	const tenantId = locals.context.tenantId;
+
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
+	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
+	if (tier !== 'family') {
+		return {
+			ok: false,
+			response: apiError(
+				'PLAN_LIMIT_EXCEEDED',
+				`${featureLabel}はファミリープランでご利用いただけます`,
+			),
+		};
+	}
+
+	const body = await request.json();
+	const text = String(body.text ?? '').trim();
+
+	if (!text) {
+		throw error(400, { message: 'テキストを入力してください' });
+	}
+
+	if (text.length > 200) {
+		throw error(400, { message: 'テキストは200文字以内にしてください' });
+	}
+
+	return { ok: true, tenantId, text };
+}

--- a/src/lib/server/auth/cron-auth.ts
+++ b/src/lib/server/auth/cron-auth.ts
@@ -1,0 +1,26 @@
+// src/lib/server/auth/cron-auth.ts
+// 共通 cron 認証ヘルパー — EventBridge / 手動トリガー用の内部エンドポイント認証
+
+import { json } from '@sveltejs/kit';
+
+/**
+ * CRON_SECRET ヘッダによる内部 cron 認証を検証する。
+ *
+ * - CRON_SECRET が設定されている場合: x-cron-secret ヘッダと照合
+ * - CRON_SECRET が未設定 かつ AUTH_MODE=local: 認証スキップ（ローカル開発用）
+ * - CRON_SECRET が未設定 かつ AUTH_MODE≠local: 500 エラー
+ *
+ * @returns 認証失敗時は Response を返す。成功時は null。
+ */
+export function verifyCronAuth(request: Request): Response | null {
+	const cronSecret = process.env.CRON_SECRET;
+	if (cronSecret) {
+		const authHeader = request.headers.get('x-cron-secret');
+		if (authHeader !== cronSecret) {
+			return json({ error: 'Unauthorized' }, { status: 401 }) as unknown as Response;
+		}
+	} else if (process.env.AUTH_MODE !== 'local') {
+		return json({ error: 'CRON_SECRET not configured' }, { status: 500 }) as unknown as Response;
+	}
+	return null;
+}

--- a/src/lib/server/services/sibling-ranking-service.ts
+++ b/src/lib/server/services/sibling-ranking-service.ts
@@ -53,110 +53,28 @@ export async function isRankingEnabled(tenantId: string): Promise<boolean> {
 
 /** 今週のきょうだいランキングを算出 */
 export async function getWeeklyRanking(tenantId: string): Promise<WeeklyRankingResult> {
-	const children = await findAllChildren(tenantId);
-
-	if (children.length <= 1) {
-		// 1人家庭の場合: gracefulに自分がチャンピオン
-		const child = children[0];
-		if (child) {
-			const logs = await findActivityLogs(child.id, tenantId, {
-				from: getWeekStart(),
-				to: getWeekEnd(),
-			});
-			const categoryCounts: Record<number, number> = {};
-			for (const log of logs) {
-				categoryCounts[log.categoryId] = (categoryCounts[log.categoryId] ?? 0) + 1;
-			}
-			const ranking: SiblingRanking = {
-				childId: child.id,
-				childName: child.nickname,
-				totalCount: logs.length,
-				categoryCounts,
-			};
-			return {
-				mostActive:
-					logs.length > 0
-						? { childId: child.id, childName: child.nickname, count: logs.length }
-						: null,
-				categoryChampions: {},
-				rankings: [ranking],
-				encouragement: logs.length > 0 ? 'がんばってるね！' : 'きょうもがんばろう！',
-			};
-		}
-		return {
-			mostActive: null,
-			categoryChampions: {},
-			rankings: [],
-			encouragement: 'きょうもがんばろう！',
-		};
-	}
-
 	const weekStart = getWeekStart();
 	const weekEnd = getWeekEnd();
 
-	// 全きょうだいの今週の活動ログを取得
-	const rankings: SiblingRanking[] = await Promise.all(
-		children.map(async (child) => {
-			const logs = await findActivityLogs(child.id, tenantId, {
-				from: weekStart,
-				to: weekEnd,
-			});
-			const categoryCounts: Record<number, number> = {};
-			for (const log of logs) {
-				categoryCounts[log.categoryId] = (categoryCounts[log.categoryId] ?? 0) + 1;
-			}
-			return {
-				childId: child.id,
-				childName: child.nickname,
-				totalCount: logs.length,
-				categoryCounts,
-			};
-		}),
-	);
+	const result = await getRankingForPeriod(tenantId, weekStart, weekEnd);
 
-	// 総活動数ランキング（降順）
-	rankings.sort((a, b) => b.totalCount - a.totalCount);
-
-	// 最もアクティブな子供
-	const mostActive =
-		rankings[0] && rankings[0].totalCount > 0
-			? {
-					childId: rankings[0].childId,
-					childName: rankings[0].childName,
-					count: rankings[0].totalCount,
-				}
-			: null;
-
-	// カテゴリ別チャンピオン
-	const categoryChampions: Record<number, CategoryChampion> = {};
-	const allCategories = new Set(rankings.flatMap((r) => Object.keys(r.categoryCounts).map(Number)));
-	for (const catId of allCategories) {
-		let best: CategoryChampion | null = null;
-		for (const r of rankings) {
-			const val = r.categoryCounts[catId] ?? 0;
-			if (val > 0 && (!best || val > best.value)) {
-				best = { childId: r.childId, childName: r.childName, value: val };
-			}
+	// 週次 × 複数きょうだいの場合のみ、専用の励ましメッセージ（閾値が月次と異なる）
+	if (result.rankings.length > 1) {
+		const totalAll = result.rankings.reduce((sum, r) => sum + r.totalCount, 0);
+		let encouragement: string;
+		if (totalAll === 0) {
+			encouragement = 'きょうもがんばろう！';
+		} else if (totalAll >= 20) {
+			encouragement = 'みんなすごい！かぞくのチカラだね！';
+		} else if (totalAll >= 10) {
+			encouragement = 'いいかんじ！みんなでがんばってるね！';
+		} else {
+			encouragement = 'がんばってるね！もっとできるよ！';
 		}
-		if (best) {
-			categoryChampions[catId] = best;
-		}
+		return { ...result, encouragement };
 	}
 
-	// 励ましメッセージ
-	const totalAll = rankings.reduce((sum, r) => sum + r.totalCount, 0);
-	let encouragement: string;
-	if (totalAll === 0) {
-		encouragement = 'きょうもがんばろう！';
-	} else if (totalAll >= 20) {
-		encouragement = 'みんなすごい！かぞくのチカラだね！';
-	} else if (totalAll >= 10) {
-		encouragement = 'いいかんじ！みんなでがんばってるね！';
-	} else {
-		encouragement = 'がんばってるね！もっとできるよ！';
-	}
-
-	return { mostActive, categoryChampions, rankings, encouragement };
+	return result;
 }
 
 // ============================================================

--- a/src/lib/server/services/special-reward-service.ts
+++ b/src/lib/server/services/special-reward-service.ts
@@ -63,6 +63,31 @@ interface GrantInput {
 
 const TEMPLATES_KEY = 'reward_templates';
 
+// --- DB行 → SpecialRewardResult マッピング ---
+
+/** DB の報酬レコードを SpecialRewardResult にマッピング */
+function toRewardResult(row: {
+	id: number;
+	childId: number;
+	title: string;
+	description: string | null;
+	points: number;
+	icon: string | null;
+	category: string;
+	grantedAt: string;
+}): SpecialRewardResult {
+	return {
+		id: row.id,
+		childId: row.childId,
+		title: row.title,
+		description: row.description,
+		points: row.points,
+		icon: row.icon,
+		category: row.category,
+		grantedAt: row.grantedAt,
+	};
+}
+
 // --- 特別報酬付与 ---
 
 export async function grantSpecialReward(
@@ -96,16 +121,7 @@ export async function grantSpecialReward(
 		tenantId,
 	);
 
-	return {
-		id: reward.id,
-		childId: reward.childId,
-		title: reward.title,
-		description: reward.description,
-		points: reward.points,
-		icon: reward.icon,
-		category: reward.category,
-		grantedAt: reward.grantedAt,
-	};
+	return toRewardResult(reward);
 }
 
 // --- 履歴取得 ---
@@ -122,16 +138,7 @@ export async function getChildSpecialRewards(
 	let totalPoints = 0;
 	const rewards: SpecialRewardResult[] = rows.map((r) => {
 		totalPoints += r.points;
-		return {
-			id: r.id,
-			childId: r.childId,
-			title: r.title,
-			description: r.description,
-			points: r.points,
-			icon: r.icon,
-			category: r.category,
-			grantedAt: r.grantedAt,
-		};
+		return toRewardResult(r);
 	});
 
 	return { rewards, totalPoints };
@@ -145,16 +152,7 @@ export async function getUnshownReward(
 ): Promise<SpecialRewardResult | null> {
 	const row = await findUnshownReward(childId, tenantId);
 	if (!row) return null;
-	return {
-		id: row.id,
-		childId: row.childId,
-		title: row.title,
-		description: row.description,
-		points: row.points,
-		icon: row.icon,
-		category: row.category,
-		grantedAt: row.grantedAt,
-	};
+	return toRewardResult(row);
 }
 
 // --- 報酬表示済みマーク ---
@@ -229,16 +227,7 @@ export async function checkAndGrantFixedIntervalReward(
 		tenantId,
 	);
 
-	return {
-		id: reward.id,
-		childId: reward.childId,
-		title: reward.title,
-		description: reward.description,
-		points: reward.points,
-		icon: reward.icon,
-		category: reward.category,
-		grantedAt: reward.grantedAt,
-	};
+	return toRewardResult(reward);
 }
 
 /**

--- a/src/lib/ui/tutorial/tutorial-store.svelte.ts
+++ b/src/lib/ui/tutorial/tutorial-store.svelte.ts
@@ -142,6 +142,25 @@ export function getChapters() {
 	return activeChapters;
 }
 
+/**
+ * 共通のチュートリアル開始処理: state をリセットして最初のステップのページへ遷移する。
+ * startTutorial / startFromBeginning / startTutorialForPage で共通利用。
+ */
+async function activateChapter(chapterId: number, quickMode: boolean) {
+	state.showResumePrompt = false;
+	state.showQuickComplete = false;
+	state.quickMode = quickMode;
+	state.isActive = true;
+	state.currentChapter = chapterId;
+	state.currentStepIndex = 0;
+	saveProgress(chapterId, 0);
+
+	const step = getCurrentStep();
+	if (step?.page) {
+		await goto(step.page);
+	}
+}
+
 export async function startTutorial(chapter?: number) {
 	// If no explicit chapter is given, check for saved progress
 	if (chapter == null) {
@@ -159,18 +178,7 @@ export async function startTutorial(chapter?: number) {
 	// #955: 明示的なチャプター指定なし（初回開始）の場合はクイックモード
 	// #961 QA: ただし親チャプター中のみ有効。子チャプター等では全ステップ通常表示
 	const isQuickStart = chapter == null && state.isParentChapters;
-	state.showResumePrompt = false;
-	state.showQuickComplete = false;
-	state.quickMode = isQuickStart;
-	state.isActive = true;
-	state.currentChapter = chapterId;
-	state.currentStepIndex = 0;
-	saveProgress(chapterId, 0);
-
-	const step = getCurrentStep();
-	if (step?.page) {
-		await goto(step.page);
-	}
+	await activateChapter(chapterId, isQuickStart);
 }
 
 /** #955: クイック完了画面が表示中か */
@@ -224,20 +232,9 @@ export async function resumeTutorial() {
 /** Start from the beginning, discarding saved progress */
 export async function startFromBeginning(chapter?: number) {
 	clearSavedProgress();
-	state.showResumePrompt = false;
-	state.showQuickComplete = false;
 	// #955: 明示的なチャプター指定なし（最初から）の場合はクイックモード
 	// #961 QA: ただし親チャプター中のみ有効
-	state.quickMode = chapter == null && state.isParentChapters;
-	state.isActive = true;
-	state.currentChapter = chapter ?? 1;
-	state.currentStepIndex = 0;
-	saveProgress(state.currentChapter, 0);
-
-	const step = getCurrentStep();
-	if (step?.page) {
-		await goto(step.page);
-	}
+	await activateChapter(chapter ?? 1, chapter == null && state.isParentChapters);
 }
 
 /** Dismiss the resume prompt without starting */
@@ -254,16 +251,7 @@ export async function startTutorialForPage(pathname: string) {
 
 	// If a matching chapter is found (not chapter 1), skip directly there
 	if (chapterId > 1) {
-		state.showResumePrompt = false;
-		state.isActive = true;
-		state.currentChapter = chapterId;
-		state.currentStepIndex = 0;
-		saveProgress(chapterId, 0);
-
-		const step = getCurrentStep();
-		if (step?.page) {
-			await goto(step.page);
-		}
+		await activateChapter(chapterId, false);
 		return;
 	}
 

--- a/src/routes/api/v1/activities/suggest/+server.ts
+++ b/src/routes/api/v1/activities/suggest/+server.ts
@@ -1,38 +1,15 @@
 // src/routes/api/v1/activities/suggest/+server.ts
 // AI 活動提案 API — プランゲート必須 (#727)
 
-import { error, json } from '@sveltejs/kit';
-import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
-import { apiError } from '$lib/server/errors';
+import { json } from '@sveltejs/kit';
+import { validateSuggestRequest } from '$lib/server/api/suggest-plan-gate';
 import { suggestActivity } from '$lib/server/services/activity-suggest-service';
-import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	// #727: 認証必須 — unauthenticated 呼び出しを 401 で即座に拒否
-	if (!locals.context) {
-		throw error(401, { message: 'Unauthorized' });
-	}
-	const tenantId = locals.context.tenantId;
+	const result = await validateSuggestRequest(locals, request, 'AI 活動提案');
+	if (!result.ok) return result.response;
 
-	// #727: プランゲート — 無料プランは AI 提案を利用不可（コスト流出防止）
-	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
-	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
-	if (tier !== 'family') {
-		return apiError('PLAN_LIMIT_EXCEEDED', 'AI 活動提案はファミリープランでご利用いただけます');
-	}
-
-	const body = await request.json();
-	const text = String(body.text ?? '').trim();
-
-	if (!text) {
-		throw error(400, { message: 'テキストを入力してください' });
-	}
-
-	if (text.length > 200) {
-		throw error(400, { message: 'テキストは200文字以内にしてください' });
-	}
-
-	const suggestion = await suggestActivity(text);
+	const suggestion = await suggestActivity(result.text);
 	return json(suggestion);
 };

--- a/src/routes/api/v1/admin/cleanup-orphans/+server.ts
+++ b/src/routes/api/v1/admin/cleanup-orphans/+server.ts
@@ -4,21 +4,14 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { verifyCronAuth } from '$lib/server/auth/cron-auth';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { deleteFile, listFiles } from '$lib/server/storage';
 
 export const POST: RequestHandler = async ({ request }) => {
-	// 内部 cron 認証
-	const cronSecret = process.env.CRON_SECRET;
-	if (cronSecret) {
-		const authHeader = request.headers.get('x-cron-secret');
-		if (authHeader !== cronSecret) {
-			return json({ error: 'Unauthorized' }, { status: 401 });
-		}
-	} else if (process.env.AUTH_MODE !== 'local') {
-		return json({ error: 'CRON_SECRET not configured' }, { status: 500 });
-	}
+	const authError = verifyCronAuth(request);
+	if (authError) return authError;
 
 	const body = (await request.json().catch(() => ({}))) as { dryRun?: boolean };
 	const dryRun = body.dryRun ?? true;

--- a/src/routes/api/v1/admin/migration/+server.ts
+++ b/src/routes/api/v1/admin/migration/+server.ts
@@ -3,21 +3,9 @@
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
+import { verifyCronAuth } from '$lib/server/auth/cron-auth';
 import { getMigrationStats, runAllBatchMigrations } from '$lib/server/db/migration/batch';
 import { logger } from '$lib/server/logger';
-
-function verifyCronAuth(request: Request): Response | null {
-	const cronSecret = process.env.CRON_SECRET;
-	if (cronSecret) {
-		const authHeader = request.headers.get('x-cron-secret');
-		if (authHeader !== cronSecret) {
-			return json({ error: 'Unauthorized' }, { status: 401 }) as unknown as Response;
-		}
-	} else if (process.env.AUTH_MODE !== 'local') {
-		return json({ error: 'CRON_SECRET not configured' }, { status: 500 }) as unknown as Response;
-	}
-	return null;
-}
 
 /** GET: マイグレーション統計を返す */
 export const GET: RequestHandler = async ({ request }) => {

--- a/src/routes/api/v1/admin/notifications/reminder/+server.ts
+++ b/src/routes/api/v1/admin/notifications/reminder/+server.ts
@@ -3,6 +3,7 @@
 
 import { json } from '@sveltejs/kit';
 import { formatChildNames } from '$lib/domain/child-display';
+import { verifyCronAuth } from '$lib/server/auth/cron-auth';
 import { logger } from '$lib/server/logger';
 import {
 	getNotificationSettings,
@@ -11,16 +12,8 @@ import {
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request }) => {
-	// 内部 cron 認証
-	const cronSecret = process.env.CRON_SECRET;
-	if (cronSecret) {
-		const authHeader = request.headers.get('x-cron-secret');
-		if (authHeader !== cronSecret) {
-			return json({ error: 'Unauthorized' }, { status: 401 });
-		}
-	} else if (process.env.AUTH_MODE !== 'local') {
-		return json({ error: 'CRON_SECRET not configured' }, { status: 500 });
-	}
+	const authError = verifyCronAuth(request);
+	if (authError) return authError;
 
 	try {
 		const body = (await request.json()) as {

--- a/src/routes/api/v1/admin/notifications/streak-warning/+server.ts
+++ b/src/routes/api/v1/admin/notifications/streak-warning/+server.ts
@@ -3,6 +3,7 @@
 
 import { json } from '@sveltejs/kit';
 import { formatChildName } from '$lib/domain/child-display';
+import { verifyCronAuth } from '$lib/server/auth/cron-auth';
 import { logger } from '$lib/server/logger';
 import {
 	getNotificationSettings,
@@ -11,16 +12,8 @@ import {
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request }) => {
-	// 内部 cron 認証
-	const cronSecret = process.env.CRON_SECRET;
-	if (cronSecret) {
-		const authHeader = request.headers.get('x-cron-secret');
-		if (authHeader !== cronSecret) {
-			return json({ error: 'Unauthorized' }, { status: 401 });
-		}
-	} else if (process.env.AUTH_MODE !== 'local') {
-		return json({ error: 'CRON_SECRET not configured' }, { status: 500 });
-	}
+	const authError = verifyCronAuth(request);
+	if (authError) return authError;
 
 	try {
 		const body = (await request.json()) as {

--- a/src/routes/api/v1/admin/tenant-cleanup/+server.ts
+++ b/src/routes/api/v1/admin/tenant-cleanup/+server.ts
@@ -4,6 +4,7 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { verifyCronAuth } from '$lib/server/auth/cron-auth';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { notifyDeletionComplete } from '$lib/server/services/discord-notify-service';
@@ -11,16 +12,8 @@ import { sendDeletionCompleteEmail } from '$lib/server/services/email-service';
 import { deleteByPrefix } from '$lib/server/storage';
 
 export const POST: RequestHandler = async ({ request }) => {
-	// 内部 cron 認証
-	const cronSecret = process.env.CRON_SECRET;
-	if (cronSecret) {
-		const authHeader = request.headers.get('x-cron-secret');
-		if (authHeader !== cronSecret) {
-			return json({ error: 'Unauthorized' }, { status: 401 });
-		}
-	} else if (process.env.AUTH_MODE !== 'local') {
-		return json({ error: 'CRON_SECRET not configured' }, { status: 500 });
-	}
+	const authError = verifyCronAuth(request);
+	if (authError) return authError;
 
 	const body = (await request.json().catch(() => ({}))) as { dryRun?: boolean };
 	const dryRun = body.dryRun ?? true;

--- a/src/routes/api/v1/admin/weekly-report/+server.ts
+++ b/src/routes/api/v1/admin/weekly-report/+server.ts
@@ -10,6 +10,7 @@
 // という三重の問題があった。本エンドポイントでプラン解決→free は早期 return する。
 
 import { json } from '@sveltejs/kit';
+import { verifyCronAuth } from '$lib/server/auth/cron-auth';
 import { logger } from '$lib/server/logger';
 import type { WeeklyReportData } from '$lib/server/services/email-service';
 import { sendWeeklyReportEmail } from '$lib/server/services/email-service';
@@ -18,16 +19,8 @@ import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request }) => {
-	// 内部 cron 認証（CRON_SECRET ヘッダ）
-	const cronSecret = process.env.CRON_SECRET;
-	if (cronSecret) {
-		const authHeader = request.headers.get('x-cron-secret');
-		if (authHeader !== cronSecret) {
-			return json({ error: 'Unauthorized' }, { status: 401 });
-		}
-	} else if (process.env.AUTH_MODE !== 'local') {
-		return json({ error: 'CRON_SECRET not configured' }, { status: 500 });
-	}
+	const authError = verifyCronAuth(request);
+	if (authError) return authError;
 
 	try {
 		const body = (await request.json()) as {

--- a/src/routes/api/v1/battle/[childId]/+server.ts
+++ b/src/routes/api/v1/battle/[childId]/+server.ts
@@ -6,8 +6,18 @@ import { getChildById } from '$lib/server/services/child-service';
 import { getChildStatus } from '$lib/server/services/status-service';
 import type { RequestHandler } from './$types';
 
-/** GET: 今日のバトル情報を取得 */
-export const GET: RequestHandler = async ({ params, locals }) => {
+interface BattleContext {
+	tenantId: string;
+	childId: number;
+	uiMode: string;
+	categoryXp: Record<number, number>;
+}
+
+/** childId パース → 子供取得 → ステータス取得 → カテゴリXP算出 の共通処理 */
+async function resolveChildBattleContext(
+	params: { childId: string },
+	locals: App.Locals,
+): Promise<BattleContext | Response> {
 	const tenantId = requireTenantId(locals);
 	const childId = Number(params.childId);
 	if (Number.isNaN(childId)) return validationError('IDが不正です');
@@ -26,33 +36,25 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 	}
 
 	const uiMode = child.uiMode ?? 'preschool';
-	const battle = await getTodayBattle(childId, uiMode, categoryXp, tenantId);
+	return { tenantId, childId, uiMode, categoryXp };
+}
+
+/** GET: 今日のバトル情報を取得 */
+export const GET: RequestHandler = async ({ params, locals }) => {
+	const ctx = await resolveChildBattleContext(params, locals);
+	if (ctx instanceof Response) return ctx;
+
+	const battle = await getTodayBattle(ctx.childId, ctx.uiMode, ctx.categoryXp, ctx.tenantId);
 	return json(battle);
 };
 
 /** POST: バトルを実行（サーバ側で今日のバトルを再取得して検証） */
 export const POST: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
-	const childId = Number(params.childId);
-	if (Number.isNaN(childId)) return validationError('IDが不正です');
-
-	const child = await getChildById(childId, tenantId);
-	if (!child) return validationError('子供が見つかりません');
-
-	const statusResult = await getChildStatus(childId, tenantId);
-	if ('error' in statusResult) {
-		return validationError('ステータスが見つかりません');
-	}
-
-	const categoryXp: Record<number, number> = {};
-	for (const [catId, detail] of Object.entries(statusResult.statuses)) {
-		categoryXp[Number(catId)] = detail.value;
-	}
-
-	const uiMode = child.uiMode ?? 'preschool';
+	const ctx = await resolveChildBattleContext(params, locals);
+	if (ctx instanceof Response) return ctx;
 
 	try {
-		const result = await executeDailyBattle(childId, uiMode, categoryXp, tenantId);
+		const result = await executeDailyBattle(ctx.childId, ctx.uiMode, ctx.categoryXp, ctx.tenantId);
 		return json(result);
 	} catch (e) {
 		return validationError(e instanceof Error ? e.message : 'バトル実行に失敗しました');

--- a/src/routes/api/v1/checklists/suggest/+server.ts
+++ b/src/routes/api/v1/checklists/suggest/+server.ts
@@ -1,39 +1,15 @@
 // src/routes/api/v1/checklists/suggest/+server.ts
 // AI チェックリスト提案 API — プランゲート必須 (#720)
 
-import { error, json } from '@sveltejs/kit';
-import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
-import { apiError } from '$lib/server/errors';
+import { json } from '@sveltejs/kit';
+import { validateSuggestRequest } from '$lib/server/api/suggest-plan-gate';
 import { suggestChecklist } from '$lib/server/services/checklist-suggest-service';
-import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	if (!locals.context) {
-		throw error(401, { message: 'Unauthorized' });
-	}
-	const tenantId = locals.context.tenantId;
+	const result = await validateSuggestRequest(locals, request, 'AI チェックリスト提案');
+	if (!result.ok) return result.response;
 
-	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
-	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
-	if (tier !== 'family') {
-		return apiError(
-			'PLAN_LIMIT_EXCEEDED',
-			'AI チェックリスト提案はファミリープランでご利用いただけます',
-		);
-	}
-
-	const body = await request.json();
-	const text = String(body.text ?? '').trim();
-
-	if (!text) {
-		throw error(400, { message: 'テキストを入力してください' });
-	}
-
-	if (text.length > 200) {
-		throw error(400, { message: 'テキストは200文字以内にしてください' });
-	}
-
-	const suggestion = await suggestChecklist(text);
+	const suggestion = await suggestChecklist(result.text);
 	return json(suggestion);
 };

--- a/src/routes/api/v1/special-rewards/suggest/+server.ts
+++ b/src/routes/api/v1/special-rewards/suggest/+server.ts
@@ -1,36 +1,15 @@
 // src/routes/api/v1/special-rewards/suggest/+server.ts
 // AI ごほうび提案 API — プランゲート必須 (#719)
 
-import { error, json } from '@sveltejs/kit';
-import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
-import { apiError } from '$lib/server/errors';
-import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
+import { json } from '@sveltejs/kit';
+import { validateSuggestRequest } from '$lib/server/api/suggest-plan-gate';
 import { suggestReward } from '$lib/server/services/reward-suggest-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	if (!locals.context) {
-		throw error(401, { message: 'Unauthorized' });
-	}
-	const tenantId = locals.context.tenantId;
+	const result = await validateSuggestRequest(locals, request, 'AI ごほうび提案');
+	if (!result.ok) return result.response;
 
-	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
-	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
-	if (tier !== 'family') {
-		return apiError('PLAN_LIMIT_EXCEEDED', 'AI ごほうび提案はファミリープランでご利用いただけます');
-	}
-
-	const body = await request.json();
-	const text = String(body.text ?? '').trim();
-
-	if (!text) {
-		throw error(400, { message: 'テキストを入力してください' });
-	}
-
-	if (text.length > 200) {
-		throw error(400, { message: 'テキストは200文字以内にしてください' });
-	}
-
-	const suggestion = await suggestReward(text);
+	const suggestion = await suggestReward(result.text);
 	return json(suggestion);
 };


### PR DESCRIPTION
## Summary
- cron 認証パターン（`CRON_SECRET` ヘッダチェック）を `verifyCronAuth()` に抽出し、6つの admin エンドポイントで共通化
- AI suggest エンドポイント（活動/チェックリスト/ごほうび提案）のプランゲート + バリデーションを `validateSuggestRequest()` に抽出
- `bedrock-client.ts` の `converseWithTool` / `converseWithImageAndTool` 内部重複を `buildTools()` + `extractToolUse()` + `sendConverseCommand()` に分解
- `special-reward-service.ts` の `SpecialRewardResult` マッピング（4箇所で重複）を `toRewardResult()` に統合
- `tutorial-store.svelte.ts` の `startTutorial` / `startFromBeginning` / `startTutorialForPage` の state リセット + `goto` パターンを `activateChapter()` に統合
- `sibling-ranking-service.ts` の `getWeeklyRanking` を `getRankingForPeriod` に委譲（重複90行を削除）
- `battle/[childId]/+server.ts` の GET/POST 共通の childId→child→status→categoryXp 取得を `resolveChildBattleContext()` に抽出

**変更量**: 16 files changed, 286 insertions, 427 deletions（**net -141 lines**）

## 新規ファイル
| ファイル | 役割 |
|---------|------|
| `src/lib/server/auth/cron-auth.ts` | 共通 cron 認証ヘルパー |
| `src/lib/server/api/suggest-plan-gate.ts` | AI 提案エンドポイント共通プランゲート |

## Test plan
- [x] `npx vitest run` — 3179/3180 passed（1件は既知の Cognito timeout flaky test）
- [x] `npx biome check` — 0 errors
- [x] `npx svelte-check` — 0 errors

Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots
> This PR does not include UI changes requiring visual verification.
![no-ui-change](https://img.shields.io/badge/UI_change-none-lightgrey)