### PR TITLE
fix: biome useNodejsImportProtocol — main CI ブロッカー修正

### DIFF
--- a/scripts/add-avatar-tables.cjs
+++ b/scripts/add-avatar-tables.cjs
@@ -6,7 +6,7 @@
 //   デフォルト: ./data/ganbari-quest.db
 
 const Database = require('better-sqlite3');
-const path = require('path');
+const path = require('node:path');
 
 const dbPath = process.argv[2] || path.join(__dirname, '..', 'data', 'ganbari-quest.db');
 console.log(`DB: ${dbPath}`);


### PR DESCRIPTION
## Summary
- `scripts/add-avatar-tables.cjs` の `require('path')` → `require('node:path')` に修正
- PR #1069 で scripts/ が biome lint 対象に拡張されたことで `useNodejsImportProtocol` エラーが発生
- **main の CI が failure になっており、全 PR の lint-and-test がブロックされていた**

## Test plan
- [ ] `npx biome check scripts/add-avatar-tables.cjs` がエラー 0 件であること
- [ ] main にマージ後、他 PR の CI が通過すること

![ci](https://img.shields.io/badge/ci-blocker_fix-red)

🤖 Generated with [Claude Code](https://claude.com/claude-code)