### PR TITLE
fix: #1084 deploy.yml CI 全修正 — biome format + API 認証順序 + E2E セレクタ

### DIFF
--- a/src/lib/features/admin/components/AiSuggestPanel.svelte
+++ b/src/lib/features/admin/components/AiSuggestPanel.svelte
@@ -79,7 +79,7 @@ function acceptPreview() {
 				AI 活動提案はファミリープランで解放されます。
 			</p>
 			<a
-				href="/pricing"
+				href="/admin/license"
 				class="inline-block px-3 py-1.5 bg-[var(--color-premium)] text-[var(--color-text-inverse)] rounded-lg font-bold hover:opacity-90 transition-colors"
 				data-testid="ai-suggest-upgrade-cta"
 			>

--- a/src/routes/api/stripe/checkout/+server.ts
+++ b/src/routes/api/stripe/checkout/+server.ts
@@ -3,7 +3,6 @@
 
 import { error, json } from '@sveltejs/kit';
 import { LICENSE_PLAN } from '$lib/domain/constants/license-plan';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { createCheckoutSession } from '$lib/server/services/stripe-service';
 import type { RequestHandler } from './$types';
 
@@ -17,14 +16,17 @@ function validateReturnPath(path: string | undefined): string {
 }
 
 export const POST: RequestHandler = async ({ request, locals, url }) => {
-	// 認証 + テナント検証（サーバー側の署名付きContextから取得 — 偽造不可）
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		error(401, '認証が必要です');
+	}
 
 	// ロールチェック: owner/parent のみ決済操作を許可
-	const role = locals.context?.role;
-	if (role !== 'owner' && role !== 'parent') {
+	if (context.role !== 'owner' && context.role !== 'parent') {
 		error(403, 'サブスクリプションの管理は保護者のみ可能です');
 	}
+
+	const tenantId = context.tenantId;
 
 	const body = await request.json();
 	const planId = body.planId;

--- a/src/routes/api/v1/admin/account/delete/+server.ts
+++ b/src/routes/api/v1/admin/account/delete/+server.ts
@@ -4,7 +4,6 @@
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
 import {
 	deleteChildAccount,
@@ -21,13 +20,14 @@ interface DeleteRequestBody {
 }
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	const tenantId = requireTenantId(locals);
 	const context = locals.context;
 	const identity = locals.identity;
 
 	if (!context || !identity || identity.type !== 'cognito') {
 		return json({ error: '認証が必要です' }, { status: 401 });
 	}
+
+	const tenantId = context.tenantId;
 
 	let body: DeleteRequestBody;
 	try {

--- a/src/routes/api/v1/admin/account/deletion-info/+server.ts
+++ b/src/routes/api/v1/admin/account/deletion-info/+server.ts
@@ -3,17 +3,17 @@
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { getOwnerDeletionInfo } from '$lib/server/services/account-deletion-service';
 
 export const GET: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
 	const context = locals.context;
 	const identity = locals.identity;
 
 	if (!context || !identity || identity.type !== 'cognito') {
 		return json({ error: '認証が必要です' }, { status: 401 });
 	}
+
+	const tenantId = context.tenantId;
 
 	if (context.role !== 'owner') {
 		return json({ error: 'owner のみ取得できます' }, { status: 403 });

--- a/src/routes/api/v1/admin/members/leave/+server.ts
+++ b/src/routes/api/v1/admin/members/leave/+server.ts
@@ -3,18 +3,18 @@
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 
 export const POST: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
 	const context = locals.context;
 	const identity = locals.identity;
 
 	if (!context || !identity || identity.type !== 'cognito') {
 		return json({ error: '認証が必要です' }, { status: 401 });
 	}
+
+	const tenantId = context.tenantId;
 
 	// owner は離脱不可（権限を移譲してから）
 	if (context.role === 'owner') {

--- a/src/routes/api/v1/admin/tenant/cancel/+server.ts
+++ b/src/routes/api/v1/admin/tenant/cancel/+server.ts
@@ -18,7 +18,6 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { error, json } from '@sveltejs/kit';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { notifyCancellation } from '$lib/server/services/discord-notify-service';
@@ -28,12 +27,17 @@ import { cancelSubscription } from '$lib/server/services/stripe-service';
 const GRACE_PERIOD_DAYS = 30;
 
 export const POST: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
 	const context = locals.context;
 
-	if (!context || context.role !== 'owner') {
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+
+	if (context.role !== 'owner') {
 		return json({ error: 'owner のみ解約申請できます' }, { status: 403 });
 	}
+
+	const tenantId = context.tenantId;
 
 	const repos = getRepos();
 	const tenant = await repos.auth.findTenantById(tenantId);

--- a/src/routes/api/v1/admin/tenant/reactivate/+server.ts
+++ b/src/routes/api/v1/admin/tenant/reactivate/+server.ts
@@ -10,18 +10,22 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { notifyCancellationReverted } from '$lib/server/services/discord-notify-service';
 
 export const POST: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
 	const context = locals.context;
 
-	if (!context || context.role !== 'owner') {
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+
+	if (context.role !== 'owner') {
 		return json({ error: 'owner のみ解約キャンセルできます' }, { status: 403 });
 	}
+
+	const tenantId = context.tenantId;
 
 	const repos = getRepos();
 	const tenant = await repos.auth.findTenantById(tenantId);

--- a/tests/e2e/plan-family.spec.ts
+++ b/tests/e2e/plan-family.spec.ts
@@ -43,10 +43,15 @@ test.describe('#779 family プラン — 全機能解放確認', () => {
 		await expect(page.getByTestId('plan-status-trial-badge')).toHaveCount(0);
 	});
 
-	test('/admin にホームを開いても free 用 quick-link が出ない', async ({ page }) => {
+	test('/admin にホームを開いても free 用アップグレード CTA が出ない', async ({ page }) => {
 		await loginAsPlan(page, 'family');
 		await page.goto('/admin');
-		await expect(page.locator('.plan-quick-link--free')).toHaveCount(0);
+		// family のときは PlanStatusCard が data-plan-tier="family" で表示される
+		const card = page.getByTestId('plan-status-card');
+		await expect(card).toBeVisible({ timeout: 30_000 });
+		await expect(card).toHaveAttribute('data-plan-tier', 'family');
+		// free 専用の CTA は表示されない
+		await expect(page.getByTestId('plan-status-free-cta')).toHaveCount(0);
 	});
 
 	test('/admin/reports — weekly-report-upsell バナーが出ない', async ({ page }) => {

--- a/tests/e2e/plan-free.spec.ts
+++ b/tests/e2e/plan-free.spec.ts
@@ -48,11 +48,15 @@ test.describe('#751 free プラン — 機能ゲート', () => {
 		await expect(page.getByTestId('plan-status-trial-badge')).toHaveCount(0);
 	});
 
-	test('/admin ホームに無料プラン用 quick-link が表示される', async ({ page }) => {
+	test('/admin ホームに無料プラン用 PlanStatusCard が表示される', async ({ page }) => {
 		await loginAsPlan(page, 'free');
 		await page.goto('/admin');
-		// free のときだけ表示される「無料プラン もっと便利に使いませんか？」リンク
-		await expect(page.locator('.plan-quick-link--free')).toBeVisible();
+		// free のときは PlanStatusCard が data-plan-tier="free" で表示される
+		const card = page.getByTestId('plan-status-card');
+		await expect(card).toBeVisible({ timeout: 30_000 });
+		await expect(card).toHaveAttribute('data-plan-tier', 'free');
+		// free 専用のアップグレード CTA が表示される
+		await expect(page.getByTestId('plan-status-free-cta')).toBeVisible();
 	});
 
 	test('/admin/reports — weekly-report-upsell バナーが表示される', async ({ page }) => {

--- a/tests/e2e/plan-standard.spec.ts
+++ b/tests/e2e/plan-standard.spec.ts
@@ -6,7 +6,7 @@
 // 「standard だからこそ表示される / されない」UI を一通り確認する。
 //
 // 設計意図:
-//  - free 専用のアップセル UI（weekly-report-upsell / export-upsell / plan-quick-link--free）が
+//  - free 専用のアップセル UI（weekly-report-upsell / export-upsell / plan-status-free-cta）が
 //    出ないことを negative assertion で押さえる
 //  - 同時に「ある機能はまだ family 限定で disabled のままか」も確認し、
 //    standard ↔ family のプラン境界を回帰検知できるようにする
@@ -44,11 +44,15 @@ test.describe('#779 standard プラン — 機能疎通', () => {
 		await expect(page.getByTestId('plan-status-trial-badge')).toHaveCount(0);
 	});
 
-	test('/admin にホームを開いても free 用 quick-link が出ない', async ({ page }) => {
+	test('/admin にホームを開いても free 用アップグレード CTA が出ない', async ({ page }) => {
 		await loginAsPlan(page, 'standard');
 		await page.goto('/admin');
-		// free のときだけ表示される「無料プラン もっと便利に使いませんか？」リンク
-		await expect(page.locator('.plan-quick-link--free')).toHaveCount(0);
+		// standard のときは PlanStatusCard が data-plan-tier="standard" で表示される
+		const card = page.getByTestId('plan-status-card');
+		await expect(card).toBeVisible({ timeout: 30_000 });
+		await expect(card).toHaveAttribute('data-plan-tier', 'standard');
+		// free 専用の CTA は表示されない
+		await expect(page.getByTestId('plan-status-free-cta')).toHaveCount(0);
 	});
 
 	test('/admin/reports — weekly-report-upsell バナーが出ない', async ({ page }) => {

--- a/tests/e2e/upgrade-flow.spec.ts
+++ b/tests/e2e/upgrade-flow.spec.ts
@@ -230,7 +230,7 @@ test.describe('#753 /admin/license プラン選択 UI', () => {
 		const preparingText = page.getByText('決済機能は現在準備中です');
 		const standardText = page.getByText('スタンダード');
 		const preparingOrPlanCard = preparingText.or(standardText);
-		await expect(preparingOrPlanCard).toBeVisible({ timeout: 10_000 });
+		await expect(preparingOrPlanCard).toBeVisible({ timeout: 30_000 });
 
 		const preparingCount = await preparingText.count();
 		if (preparingCount > 0 && (await preparingText.isVisible())) {

--- a/tests/unit/components/ai-suggest-panel-plan-gate.test.ts
+++ b/tests/unit/components/ai-suggest-panel-plan-gate.test.ts
@@ -4,7 +4,7 @@
 // テスト観点:
 // - isFamily=false: ロックバッジ・アップセル CTA が表示され、input/button が disabled
 // - isFamily=true: ロック UI が出ない、input/button が enabled
-// - CTA リンク先は /pricing（#722 でファミリー限定に変更）
+// - CTA リンク先は /admin/license（ライセンス管理ページへ導線）
 //
 // 本来 E2E を推すが、AiSuggestPanel の可視状態を検証するだけなら jsdom で十分。
 // props を直接渡せるので free/standard/family 相当を高速に切替確認できる。
@@ -44,11 +44,11 @@ describe('AiSuggestPanel プランゲート (#722)', () => {
 			expect(screen.getByTestId('ai-suggest-upgrade-card')).toBeDefined();
 		});
 
-		it('「ファミリープランにアップグレード」CTA が /pricing へ導線する', () => {
+		it('「ファミリープランにアップグレード」CTA が /admin/license へ導線する', () => {
 			render(AiSuggestPanel, props);
 			const cta = screen.getByTestId('ai-suggest-upgrade-cta');
 			expect(cta).toBeDefined();
-			expect(cta.getAttribute('href')).toBe('/pricing');
+			expect(cta.getAttribute('href')).toBe('/admin/license');
 			expect(cta.textContent).toContain('ファミリープラン');
 		});
 


### PR DESCRIPTION
## Summary
- `tests/e2e/retention-filter.spec.ts` の biome format エラー修正（deploy.yml test-lint 失敗の直接原因）
- 6つの API エンドポイントで `requireTenantId(locals)` を認証チェックの後に移動し、未認証リクエストが 500 ではなく 401 を返すように修正（deploy.yml test-cognito 失敗の原因）
  - `api/v1/admin/account/delete`
  - `api/v1/admin/account/deletion-info`
  - `api/v1/admin/members/leave`
  - `api/v1/admin/tenant/cancel`
  - `api/v1/admin/tenant/reactivate`
  - `api/stripe/checkout`
- E2E テストのセレクタを `.plan-quick-link--free` CSS クラスから `PlanStatusCard` の `data-testid` に更新
- `AiSuggestPanel` のアップグレードリンクを `/pricing` → `/admin/license` に修正

## Test plan
- [ ] `npx biome check . --diagnostic-level=error` でエラーゼロ確認
- [ ] CI の `lint-and-test` ジョブが通過
- [ ] CI の cognito-dev E2E テストが通過（account-deletion, plan-free, plan-standard, plan-family, upgrade-flow）
- [ ] deploy.yml の test-lint, test-cognito, test-gate が全通過

closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)