### PR TITLE
test: #1094 cron E2E ヘルパー追加・retention-filter リファクタ

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -112,3 +112,78 @@ DEBUG_PLAN=standard DEBUG_TRIAL=active DEBUG_TRIAL_TIER=family npx playwright te
 ```
 
 詳細: `src/lib/server/debug-plan.ts` / `.env.example`
+
+## cron E2E テストの書き方
+
+`/api/cron/*` エンドポイントの E2E テストでは、`tests/e2e/helpers.ts` の cron ヘルパーを使う。
+
+### ヘルパー
+
+| 関数 | 用途 |
+|------|------|
+| `getCronHeaders()` | cron 認証用ヘッダーを返す（`CRON_SECRET` 設定時のみ `x-cron-secret` を含む） |
+| `isCronAuthSkipped()` | cron 認証がスキップされる環境か判定（`CRON_SECRET` 未設定 + `AUTH_MODE=local`） |
+
+### 認証の 3 パターン
+
+`verifyCronAuth`（`src/lib/server/auth/cron-auth.ts`）は環境変数に応じて 3 通りの動作をする。
+テストでは `getCronHeaders()` と `isCronAuthSkipped()` でこの分岐を吸収する。
+
+| 条件 | 動作 | テストでの期待値 |
+|------|------|----------------|
+| `CRON_SECRET` 設定済み + ヘッダー一致 | 認証成功 | `200` |
+| `CRON_SECRET` 設定済み + ヘッダー不一致/なし | 認証失敗 | `401` |
+| `CRON_SECRET` 未設定 + `AUTH_MODE=local` | 認証スキップ | `[200, 500]`（DB 未初期化で 500 の場合あり） |
+| `CRON_SECRET` 未設定 + `AUTH_MODE≠local` | 設定ミス | `500` |
+
+### 使用例
+
+```ts
+import { expect, test } from '@playwright/test';
+import { getCronHeaders, isCronAuthSkipped } from './helpers';
+
+const cronSecret = process.env.CRON_SECRET;
+const authSkipped = isCronAuthSkipped();
+
+test('正常リクエスト', async ({ request }) => {
+  // 認証不可能な環境では早期リターン
+  if (!cronSecret && !authSkipped) {
+    const res = await request.post('/api/cron/my-endpoint');
+    expect(res.status()).toBe(500);
+    return;
+  }
+
+  // getCronHeaders() が環境に応じた認証ヘッダーを返す
+  const res = await request.post('/api/cron/my-endpoint', {
+    headers: getCronHeaders(),
+    data: { dryRun: true },
+  });
+
+  if (!cronSecret && authSkipped) {
+    expect([200, 500]).toContain(res.status());
+    if (res.status() !== 200) return;
+  } else {
+    expect(res.status()).toBe(200);
+  }
+
+  const body = await res.json();
+  expect(body.ok).toBe(true);
+});
+
+test('認証エラー', async ({ request }) => {
+  const res = await request.post('/api/cron/my-endpoint');
+  if (cronSecret) {
+    expect(res.status()).toBe(401);
+  } else if (authSkipped) {
+    expect([200, 500]).toContain(res.status());
+  } else {
+    expect(res.status()).toBe(500);
+  }
+});
+```
+
+### 注意事項
+
+- インラインで `process.env.CRON_SECRET` / `AUTH_MODE` を直接参照してヘッダーを組み立てない。必ずヘルパーを使う
+- `isCronAuthSkipped()` の判定ロジックは `verifyCronAuth` と同期している。cron-auth.ts のロジック変更時はヘルパーも更新すること
+- ローカル開発環境（`AUTH_MODE=local`）では DB が未初期化で 500 を返す場合があるため、`[200, 500]` を許容する

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -21,6 +21,21 @@ export function isLocalEnv(): boolean {
 }
 
 // ============================================================
+// cron エンドポイント
+// ============================================================
+
+/** cron エンドポイント用ヘッダーを返す（CRON_SECRET 設定時のみ x-cron-secret を含む） */
+export function getCronHeaders(): Record<string, string> {
+	const cronSecret = process.env.CRON_SECRET;
+	return cronSecret ? { 'x-cron-secret': cronSecret } : {};
+}
+
+/** cron 認証がスキップされる環境か判定（CRON_SECRET 未設定 + AUTH_MODE=local） */
+export function isCronAuthSkipped(): boolean {
+	return !process.env.CRON_SECRET && (process.env.AUTH_MODE === 'local' || !process.env.AUTH_MODE);
+}
+
+// ============================================================
 // 子供選択
 // ============================================================
 

--- a/tests/e2e/retention-filter.spec.ts
+++ b/tests/e2e/retention-filter.spec.ts
@@ -12,10 +12,10 @@
 // 実行: npx playwright test retention-filter
 
 import { expect, test } from '@playwright/test';
+import { getCronHeaders, isCronAuthSkipped } from './helpers';
 
 const cronSecret = process.env.CRON_SECRET;
-const isLocalAuth =
-	process.env.AUTH_MODE === 'local' || !process.env.AUTH_MODE;
+const authSkipped = isCronAuthSkipped();
 
 // ============================================================
 // 認証ガード
@@ -27,22 +27,20 @@ test.describe('#750 retention-cleanup — 認証ガード', () => {
 		const res = await request.post('/api/cron/retention-cleanup');
 		if (cronSecret) {
 			expect(res.status()).toBe(401);
-		} else if (isLocalAuth) {
+		} else if (authSkipped) {
 			expect([200, 500]).toContain(res.status());
 		} else {
 			expect(res.status()).toBe(500);
 		}
 	});
 
-	test('不正な x-cron-secret で POST すると認証エラー', async ({
-		request,
-	}) => {
+	test('不正な x-cron-secret で POST すると認証エラー', async ({ request }) => {
 		const res = await request.post('/api/cron/retention-cleanup', {
 			headers: { 'x-cron-secret': 'invalid-token-12345' },
 		});
 		if (cronSecret) {
 			expect(res.status()).toBe(401);
-		} else if (isLocalAuth) {
+		} else if (authSkipped) {
 			expect([200, 500]).toContain(res.status());
 		} else {
 			expect(res.status()).toBe(500);
@@ -55,7 +53,7 @@ test.describe('#750 retention-cleanup — 認証ガード', () => {
 		const res = await request.get('/api/cron/retention-cleanup');
 		if (cronSecret) {
 			expect(res.status()).toBe(401);
-		} else if (isLocalAuth) {
+		} else if (authSkipped) {
 			expect([200, 500]).toContain(res.status());
 		} else {
 			expect(res.status()).toBe(500);
@@ -68,7 +66,7 @@ test.describe('#750 retention-cleanup — 認証ガード', () => {
 // ============================================================
 test.describe('#750 retention-cleanup — dryRun', () => {
 	test('dryRun POST', async ({ request }) => {
-		if (!cronSecret && !isLocalAuth) {
+		if (!cronSecret && !authSkipped) {
 			const res = await request.post('/api/cron/retention-cleanup', {
 				data: { dryRun: true },
 			});
@@ -76,17 +74,14 @@ test.describe('#750 retention-cleanup — dryRun', () => {
 			return;
 		}
 
-		const headers: Record<string, string> = {};
-		if (cronSecret) {
-			headers['x-cron-secret'] = cronSecret;
-		}
+		const headers = getCronHeaders();
 
 		const res = await request.post('/api/cron/retention-cleanup', {
 			headers,
 			data: { dryRun: true },
 		});
 
-		if (!cronSecret && isLocalAuth) {
+		if (!cronSecret && authSkipped) {
 			expect([200, 500]).toContain(res.status());
 			if (res.status() !== 200) return;
 		} else {
@@ -103,22 +98,19 @@ test.describe('#750 retention-cleanup — dryRun', () => {
 	});
 
 	test('GET ヘルスチェック', async ({ request }) => {
-		if (!cronSecret && !isLocalAuth) {
+		if (!cronSecret && !authSkipped) {
 			const res = await request.get('/api/cron/retention-cleanup');
 			expect(res.status()).toBe(500);
 			return;
 		}
 
-		const headers: Record<string, string> = {};
-		if (cronSecret) {
-			headers['x-cron-secret'] = cronSecret;
-		}
+		const headers = getCronHeaders();
 
 		const res = await request.get('/api/cron/retention-cleanup', {
 			headers,
 		});
 
-		if (!cronSecret && isLocalAuth) {
+		if (!cronSecret && authSkipped) {
 			expect([200, 500]).toContain(res.status());
 			if (res.status() !== 200) return;
 		} else {


### PR DESCRIPTION
## Summary

- `getCronHeaders()` / `isCronAuthSkipped()` ヘルパーを `tests/e2e/helpers.ts` に追加
- `retention-filter.spec.ts` のインライン cron 認証ロジックをヘルパー呼び出しにリファクタ（テストアサーションは変更なし）
- `tests/CLAUDE.md` に「cron E2E テストの書き方」セクションを追加（認証 3 パターンの解説 + 使用例）

## Test plan

- [ ] `npx biome check tests/e2e/helpers.ts tests/e2e/retention-filter.spec.ts` でフォーマット・lint エラーなし
- [ ] `npx playwright test retention-filter` で既存テストが通ること
- [ ] ヘルパーのロジックが `src/lib/server/auth/cron-auth.ts` の `verifyCronAuth` と一致していること

Closes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)