### PR TITLE
fix(lint): #1083 infra/ と scripts/ の Biome lint overrides 追加

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -75,6 +75,39 @@
 					}
 				}
 			}
+		},
+		{
+			"includes": ["infra/lambda/**"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noConsole": "off"
+					}
+				}
+			}
+		},
+		{
+			"includes": ["infra/lib/**"],
+			"linter": {
+				"rules": {
+					"style": {
+						"noNonNullAssertion": "off"
+					},
+					"complexity": {
+						"noExcessiveCognitiveComplexity": "off"
+					}
+				}
+			}
+		},
+		{
+			"includes": ["scripts/**/*.cjs"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noConsole": "off"
+					}
+				}
+			}
 		}
 	],
 	"files": {


### PR DESCRIPTION
## Summary
- `infra/lambda/**` に `noConsole: off` を追加（Lambda 関数の CloudWatch ログ出力は正当な用途）
- `infra/lib/**` に `noNonNullAssertion: off` と `noExcessiveCognitiveComplexity: off` を追加（CDK props パターン）
- `scripts/**/*.cjs` に `noConsole: off` を追加（マイグレーションスクリプトのログ出力）
- `src/` のルールは一切変更なし

## Test plan
- [x] `npx biome check infra/lambda/ infra/lib/ scripts/add-avatar-tables.cjs` が 0 violations
- [x] `npx biome check src/` の既存 warn 数が変化しないことを確認

Closes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)