### PR TITLE
fix: LP マーケットプレイス表記修正 + オンボーディングステップ簡素化

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -859,7 +859,7 @@
     <p class="pack-note">
       &#x1F4A1; 特別なごほうびは、保護者がタイミングを見て即時付与できる「がんばりの価値化」装置です。<br>
       お子さまにとって本当に大事な達成を、家庭ごとの基準で評価しましょう。<br>
-      <a href="https://ganbari-quest.com/marketplace">マーケットプレイス</a>で他の家庭が作ったテンプレートも参照できます。
+      <a href="https://ganbari-quest.com/marketplace">マーケットプレイス</a>でテンプレートを探して、すぐに使い始められます。
     </p>
   </div>
 </section>
@@ -985,7 +985,7 @@
     <a href="https://ganbari-quest.com/auth/signup" class="btn btn-primary btn-lg">無料ではじめる</a>
   </div>
   <p style="margin-top:16px;font-size:.85rem;color:var(--gray-500);">
-    &#x1F4E6; <a href="https://ganbari-quest.com/marketplace">マーケットプレイス</a>で50種類以上の活動パック・ごほうび・チェックリストを探す
+    &#x1F4E6; <a href="https://ganbari-quest.com/marketplace">マーケットプレイス</a>で約50種類の活動パック・ごほうび・チェックリストを探す
   </p>
 </section>
 
@@ -998,15 +998,15 @@
       <div class="step">
         <div class="step-num">1</div>
         <div class="step-body">
-          <h3>アカウント登録</h3>
+          <h3>アカウント登録（無料）</h3>
           <p>メールアドレスまたはGoogleアカウントで登録完了。お子さまのニックネームと年齢を登録します。</p>
         </div>
       </div>
       <div class="step">
         <div class="step-num">2</div>
         <div class="step-body">
-          <h3>活動を設定</h3>
-          <p>「宿題」「お手伝い」「読書」など、がんばってほしい活動を登録。テンプレートから選ぶこともできます。</p>
+          <h3>お子さまの年齢と性別を設定</h3>
+          <p>年齢と性別に合わせた活動・チェックリストが自動でセットアップされます。</p>
         </div>
       </div>
       <div class="step">

--- a/site/pamphlet.html
+++ b/site/pamphlet.html
@@ -676,15 +676,15 @@ body{font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN','Noto Sans JP',syst
       <div class="step-card">
         <div class="sc-num">1</div>
         <div class="sc-icon">&#x1F4DD;</div>
-        <h3>アカウント登録</h3>
+        <h3>アカウント登録（無料）</h3>
         <p>メールまたはGoogleアカウントで。<br>1分で完了します。</p>
       </div>
       <div class="step-arrow">&#x25B6;</div>
       <div class="step-card">
         <div class="sc-num">2</div>
         <div class="sc-icon">&#x2699;&#xFE0F;</div>
-        <h3>活動を設定</h3>
-        <p>「宿題」「お手伝い」など<br>がんばる活動を登録。</p>
+        <h3>お子さまの年齢と性別を設定</h3>
+        <p>年齢に合わせた活動が<br>自動でセットアップ。</p>
       </div>
       <div class="step-arrow">&#x25B6;</div>
       <div class="step-card">


### PR DESCRIPTION
## Summary

- **#1099**: LP のマーケットプレイス関連テキストを修正
  - 「50種類以上」→「約50種類」(実数: 活動パック14 + チェックリスト15 + ごほうびセット10 + ルールプリセット10 = 49種類)
  - 「他の家庭が作ったテンプレート」→ 実態はキュレーション済みデータのためUGC表現を削除
- **#1100**: LP の「かんたん3ステップ」を簡素化
  - Step 1: 「アカウント登録」→「アカウント登録（無料）」
  - Step 2: 「活動を設定」→「お子さまの年齢と性別を設定」+ 自動セットアップ訴求
  - `pamphlet.html` も並行同期済み

## #1099 マーケットプレイス認証設計の調査結果

### 現状
- `/marketplace` は `isPublicRoute()` に含まれていない（`src/lib/server/auth/authorization.ts`）
- Cognito モードでは認証必須（未認証は `/auth/login` にリダイレクト）
- `ROUTE_RULES` にも明示エントリなし → 認証済みユーザーは全ロールでアクセス可能
- Local モードではセットアップ完了後は認証不要でアクセス可能

### 推奨: Option C（閲覧は公開、インポートは認証必須）
- マーケットプレイスの閲覧はSEO・コンバージョン上公開が望ましい
- `isPublicRoute()` に `/marketplace` を追加し、閲覧を公開化
- インポート API (`/api/v1/marketplace/import` 等) は既存の認証ガードで保護
- **PO 判断が必要なため、本 PR ではアプリ側の変更は行わない**

## #1100 アプリ側自動セットアップの現状

セットアップフロー（`/setup/packs`）には既にプリセット自動適用ロジックが実装済み:
- ユーザーがパック選択をスキップした場合、年齢に合致する全パックを自動インポート
- `/setup/questionnaire` でチェックリストプリセットも自動適用

**LP の「自動セットアップ」表記はアプリの実態と一致している。追加のアプリ改修は不要。**

## 変更ファイル
- `site/index.html` — マーケットプレイス数量修正 + 3ステップ簡素化
- `site/pamphlet.html` — 3ステップの並行同期

## Test plan
- [ ] `site/index.html` をブラウザで開き、マーケットプレイス表記が「約50種類」であることを確認
- [ ] 「かんたん3ステップ」のStep 2が「お子さまの年齢と性別を設定」であることを確認
- [ ] `site/pamphlet.html` も同じ変更が反映されていることを確認
- [ ] リンク先 `/marketplace` が正しいことを確認

Ref #1099, Closes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)