### PR TITLE
docs: improve README for OSS/selfhost users

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -3,44 +3,54 @@
 </h1>
 
 <p align="center">
-  <strong>Turn your child's efforts into an RPG adventure — A family gamification web app</strong>
+  <strong>Turn your child's efforts into an RPG adventure -- A family gamification web app</strong>
 </p>
 
 <p align="center">
+  <a href="https://github.com/sponsors/Takenori-Kusaka"><img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?logo=github" alt="Sponsor"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License: AGPL-3.0"></a>
   <img src="https://img.shields.io/badge/SvelteKit-2-FF3E00?logo=svelte&logoColor=white" alt="SvelteKit 2">
   <img src="https://img.shields.io/badge/Svelte-5_(Runes)-FF3E00?logo=svelte&logoColor=white" alt="Svelte 5">
   <img src="https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white" alt="TypeScript strict">
   <img src="https://img.shields.io/badge/SQLite-WAL-003B57?logo=sqlite&logoColor=white" alt="SQLite">
-  <img src="https://img.shields.io/badge/tests-606_passing-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" alt="Docker">
 </p>
 
 <p align="center">
-  English | <a href="./README.md">日本語</a>
+  English | <a href="./README.md">Japanese (日本語)</a>
 </p>
 
 ---
 
 ## What is Ganbari Quest?
 
-Ganbari Quest is an open-source web app that motivates children through RPG-style gamification. Kids earn points, level up, and collect titles by completing daily activities — from homework and chores to sports and creative work.
+Ganbari Quest is an open-source web app that motivates children (ages 0--18) through RPG-style gamification. Kids earn points, level up, collect titles, and customize avatars by completing daily activities -- from homework and chores to sports and creative work.
 
-Designed for **Japanese families** but adaptable to any culture. Runs entirely on your home network with zero cloud dependency.
+Designed for **Japanese families** but adaptable to any culture. Runs entirely on your home network with **zero cloud dependency** -- your children's data stays in your home.
 
 ## Features
 
-- **RPG Gamification** — Levels, 5 status categories, title collection, combo bonuses
-- **Age-Adaptive UI** — Automatically adjusts from baby (0-3) to kinder (4-9) to teen (10+)
-- **2-Tap Recording** — Simple activity logging with daily missions and checklists
-- **Benchmark Comparison** — Developmental psychology-based percentile rankings
-- **Privacy First** — Runs on your LAN, no external data transmission
-- **Avatar Customization** — Spend points on backgrounds, frames, and effects
-- **Career Planning** — Mandala chart goal-setting (inspired by Shohei Ohtani)
-- **Self-Hostable** — One-command Docker deploy. Fully open source
+- **RPG Gamification** -- Levels, 5 status categories, title collection, combo bonuses, and daily missions
+- **Age-Adaptive UI** -- 5 modes (baby / preschool / elementary / junior / senior) that automatically adjust font size, tap targets, and information density
+- **2-Tap Recording** -- Simple activity logging with daily missions and checklists
+- **Benchmark Comparison** -- Developmental psychology-based percentile rankings to visualize your child's strengths
+- **Privacy First** -- Runs on your LAN, no external data transmission required
+- **Avatar Customization** -- Spend earned points on backgrounds, frames, and effects
+- **Career Planning** -- Mandala chart goal-setting (inspired by Shohei Ohtani's method)
+- **Self-Hostable** -- One-command Docker deployment, fully open source
 
 ## Quick Start
 
-### Docker (Recommended)
+### Prerequisites
+
+| Requirement | Version |
+|-------------|---------|
+| Docker & Docker Compose | 20.10+ / v2+ |
+| **-- OR --** | |
+| Node.js | 22+ |
+| npm | 10+ |
+
+### Option 1: Docker (Recommended for self-hosting)
 
 ```bash
 git clone https://github.com/Takenori-Kusaka/ganbari-quest.git
@@ -50,7 +60,13 @@ docker compose up -d
 
 Open `http://localhost:3000`. The setup wizard will guide you through initial configuration.
 
-### Local Development
+**What happens on first boot:**
+1. The Docker image is built (multi-stage, Node.js 22 Alpine-based)
+2. SQLite database is automatically created in `./data/`
+3. Schema is applied and seed data is loaded
+4. The app starts on port 3000
+
+### Option 2: Local Development
 
 ```bash
 git clone https://github.com/Takenori-Kusaka/ganbari-quest.git
@@ -60,6 +76,126 @@ cp .env.example .env
 npm run dev
 ```
 
+Open `http://localhost:5173` for the development server with hot reload.
+
+## Configuration
+
+Copy `.env.example` to `.env` and configure as needed. All variables have sensible defaults -- the app works out of the box with zero configuration.
+
+### Core Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DATABASE_URL` | `./data/ganbari-quest.db` | Path to SQLite database file |
+| `HOST` | `0.0.0.0` | Bind address |
+| `PORT` | `3000` | HTTP port |
+| `ORIGIN` | Auto-detected | Full app URL (set explicitly when behind a reverse proxy) |
+
+### Optional Integrations
+
+| Variable | Description |
+|----------|-------------|
+| `AI_PROVIDER` | AI provider: `gemini` or `bedrock` (for AI-generated avatar images) |
+| `GEMINI_API_KEY` | [Google AI Studio](https://aistudio.google.com/) API key (when `AI_PROVIDER=gemini`) |
+| `GDRIVE_CLIENT_ID` | Google Drive backup -- OAuth client ID |
+| `GDRIVE_CLIENT_SECRET` | Google Drive backup -- OAuth client secret |
+| `GDRIVE_REFRESH_TOKEN` | Google Drive backup -- OAuth refresh token |
+| `GDRIVE_FOLDER_ID` | Google Drive backup -- target folder ID |
+| `DISCORD_ALERT_WEBHOOK_URL` | Discord webhook for 500 error notifications |
+| `LOG_LEVEL` | Logging level (default: `info`) |
+
+### Backup Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BACKUP_DIR` | `./data/backups` | Local backup directory |
+| `BACKUP_RETENTION` | `10` | Number of backup files to keep |
+| `BACKUP_POST_HOOK` | -- | Post-backup script (e.g., `node scripts/hooks/gdrive-upload.cjs`) |
+
+> **Note:** Production SaaS settings (`AWS_LICENSE_SECRET`, `STRIPE_*`, `CRON_SECRET`, etc.) are not needed for self-hosting. Self-hosted instances run with all core features available. See `.env.example` for the full list.
+
+## Self-Hosting Guide
+
+### Minimum System Requirements
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| CPU | 1 core | 2 cores |
+| RAM | 512 MB | 1 GB |
+| Storage | 500 MB | 2 GB (with backups) |
+| OS | Any Docker-compatible OS | Linux |
+
+### Basic Deployment
+
+```bash
+# Clone and start
+git clone https://github.com/Takenori-Kusaka/ganbari-quest.git
+cd ganbari-quest
+docker compose up -d
+
+# View logs
+docker compose logs -f app
+
+# Stop
+docker compose down
+
+# Update to latest version
+git pull
+docker compose up -d --build
+```
+
+### Data Persistence
+
+The following directories are mounted as Docker volumes and persist across container restarts:
+
+| Directory | Contents |
+|-----------|----------|
+| `./data/` | SQLite database and backups |
+| `./uploads/` | User-uploaded files (avatars, etc.) |
+| `./generated/` | AI-generated images |
+| `./tenants/` | Tenant-specific data |
+
+### Automated Backups
+
+Enable the backup sidecar to run daily backups at 3:00 AM (JST):
+
+```bash
+docker compose --profile backup up -d
+```
+
+To enable Google Drive cloud backup, set the `GDRIVE_*` variables in your `.env` file. See `.env.example` for details.
+
+### HTTPS with Reverse Proxy
+
+For production deployments with HTTPS, uncomment the Caddy section in `docker-compose.yml` and create a `Caddyfile`:
+
+```
+your-domain.example.com {
+    reverse_proxy app:3000
+}
+```
+
+Then update your `.env`:
+
+```bash
+ORIGIN=https://your-domain.example.com
+```
+
+Alternatively, use any reverse proxy (nginx, Traefik, etc.) that terminates TLS and forwards to port 3000.
+
+### Accessing from Other Devices on LAN
+
+To access from phones and tablets on your home network:
+
+1. Find your server's local IP (e.g., `192.168.1.100`)
+2. Set `ORIGIN=http://192.168.1.100:3000` in `.env`
+3. Restart: `docker compose up -d`
+4. Access from any device at `http://192.168.1.100:3000`
+
+### Health Check
+
+The app exposes a health endpoint at `GET /api/health`, used by Docker's built-in `HEALTHCHECK`.
+
 ## Tech Stack
 
 | Category | Technology |
@@ -67,17 +203,72 @@ npm run dev
 | Framework | SvelteKit 2 + Svelte 5 (Runes) |
 | UI | Ark UI Svelte (Headless) + Custom Design System |
 | Database | SQLite (WAL mode) + Drizzle ORM |
-| Testing | Vitest (606 tests) + Playwright |
-| Lint/Format | Biome |
+| Testing | Vitest + Playwright |
+| Lint/Format | Biome + ESLint + Stylelint |
 | Language | TypeScript (strict) |
 | Infrastructure | Docker + Node.js 22 |
 
+## Development
+
+### Commands
+
+```bash
+npm run dev              # Dev server (http://localhost:5173)
+npm run build            # Production build
+npx vitest run           # Unit tests
+npx playwright test      # E2E tests
+npx biome check .        # Lint & format
+npx svelte-check         # Type checking
+npx drizzle-kit push     # Apply DB migrations
+```
+
+### Project Structure
+
+```
+ganbari-quest/
+├── src/
+│   ├── routes/              # SvelteKit file-based routing
+│   │   ├── (child)/         # Child-facing pages (age-adaptive)
+│   │   ├── (parent)/        # Parent admin panel (PIN-protected)
+│   │   └── api/             # REST API endpoints
+│   └── lib/
+│       ├── ui/              # Ark UI wrappers + shared components
+│       ├── features/        # Feature modules (career, avatar, etc.)
+│       ├── domain/          # Domain models & validation
+│       └── server/          # DB & service layer (server-only)
+├── docs/design/             # Design documents
+├── tests/                   # Unit & E2E tests
+├── scripts/                 # Migration, backup, CI scripts
+├── infra/                   # AWS CDK infrastructure (SaaS)
+├── docker-compose.yml       # Docker deployment config
+└── Dockerfile               # Multi-stage production build
+```
+
+## SaaS vs Self-Hosted
+
+| | Self-Hosted (this repo) | SaaS |
+|---|---|---|
+| **Cost** | Free (your hardware) | Free tier + paid plans |
+| **Data location** | Your server | Cloud (AWS) |
+| **Setup** | `docker compose up -d` | Sign up at website |
+| **Updates** | `git pull && docker compose up -d --build` | Automatic |
+| **Auth** | Local PIN-based | AWS Cognito (Google SSO) |
+| **AI features** | Bring your own API key | Included |
+| **Backups** | Manual or cron | Automatic |
+| **Support** | Community (GitHub Issues) | Email support |
+
 ## Contributing
 
-Bug reports, feature requests, and PRs are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
+Bug reports, feature requests, and PRs are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 
-> Note: The UI is currently in Japanese only. Internationalization (i18n) is planned for future releases.
+> **Note:** The UI is currently in Japanese only. Internationalization (i18n) contributions are especially welcome.
+
+## Community & Support
+
+- **Issues & Discussions**: [GitHub Issues](https://github.com/Takenori-Kusaka/ganbari-quest/issues)
+- **Email**: [ganbari.quest.support@gmail.com](mailto:ganbari.quest.support@gmail.com)
+- **Sponsor**: [GitHub Sponsors](https://github.com/sponsors/Takenori-Kusaka)
 
 ## License
 
-[AGPL-3.0](./LICENSE) — Free to use, self-host, and modify.
+[AGPL-3.0](./LICENSE) -- Free to use, self-host, and modify. If you distribute a modified version as a network service, you must share your source code under the same license.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </h1>
 
 <p align="center">
-  <strong>子供の「がんばり」をRPGに変える — 家庭内ゲーミフィケーションWebアプリ</strong>
+  <strong>子供の「がんばり」をRPGに変える -- 家庭内ゲーミフィケーションWebアプリ</strong>
 </p>
 
 <p align="center">
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Svelte-5_(Runes)-FF3E00?logo=svelte&logoColor=white" alt="Svelte 5">
   <img src="https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white" alt="TypeScript strict">
   <img src="https://img.shields.io/badge/SQLite-WAL-003B57?logo=sqlite&logoColor=white" alt="SQLite">
-  <img src="https://img.shields.io/badge/tests-606_passing-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" alt="Docker">
 </p>
 
 <p align="center">
@@ -24,30 +24,27 @@
 
 ## 特徴
 
-- **RPG風ゲーミフィケーション** — レベルアップ、ステータス5種、称号コレクション、コンボボーナスで日々の活動を冒険に
-- **年齢対応UI** — 0歳（baby）〜15歳（teen）まで、成長に合わせてUIモードが自動変化
-- **簡単操作** — 最大2タップで活動記録。デイリーミッション、チェックリストで習慣化
-- **偏差値比較** — 発達心理学に基づく市場ベンチマークで「うちの子の強み」を可視化
-- **家庭内完結** — LAN内で動作、外部通信なし。子供のデータは家族だけのもの
-- **きせかえアバター** — ポイントで背景・フレーム・エフェクトを購入してカスタマイズ
-- **キャリアプランニング** — マンダラチャートで将来の夢を構造化（大谷翔平方式）
-- **セルフホスト可能** — Docker一発で自宅サーバーに展開。OSSだからコードも完全透明
-
-## 技術スタック
-
-| カテゴリ | 技術 |
-|---------|------|
-| フレームワーク | SvelteKit 2 + Svelte 5 (Runes) |
-| UI | Ark UI Svelte (Headless) + 独自デザインシステム |
-| データベース | SQLite (WAL) + Drizzle ORM |
-| テスト | Vitest (606件) + Playwright |
-| Lint/Format | Biome |
-| 言語 | TypeScript (strict) |
-| インフラ | Docker + Node.js 22 |
+- **RPG風ゲーミフィケーション** -- レベルアップ、ステータス5種、称号コレクション、コンボボーナスで日々の活動を冒険に
+- **年齢対応UI** -- 5モード（baby / preschool / elementary / junior / senior）で、フォントサイズ・タップ領域・情報密度が自動変化
+- **簡単操作** -- 最大2タップで活動記録。デイリーミッション、チェックリストで習慣化
+- **偏差値比較** -- 発達心理学に基づく市場ベンチマークで「うちの子の強み」を可視化
+- **家庭内完結** -- LAN内で動作、外部通信不要。子供のデータは家族だけのもの
+- **きせかえアバター** -- ポイントで背景・フレーム・エフェクトを購入してカスタマイズ
+- **キャリアプランニング** -- マンダラチャートで将来の夢を構造化（大谷翔平方式）
+- **セルフホスト可能** -- Docker一発で自宅サーバーに展開。OSSだからコードも完全透明
 
 ## クイックスタート
 
-### Docker（推奨）
+### 前提条件
+
+| 要件 | バージョン |
+|------|-----------|
+| Docker & Docker Compose | 20.10+ / v2+ |
+| **-- または --** | |
+| Node.js | 22+ |
+| npm | 10+ |
+
+### Docker（推奨・セルフホスト向け）
 
 ```bash
 git clone https://github.com/Takenori-Kusaka/ganbari-quest.git
@@ -56,6 +53,12 @@ docker compose up -d
 ```
 
 `http://localhost:3000` にアクセス。初回はセットアップウィザードが表示されます。
+
+**初回起動時の動作:**
+1. Docker イメージをビルド（マルチステージ、Node.js 22 Alpine ベース）
+2. SQLite データベースが `./data/` に自動作成
+3. スキーマ適用 & シードデータ投入
+4. ポート 3000 でアプリ起動
 
 ### ローカル開発
 
@@ -67,69 +70,197 @@ cp .env.example .env
 npm run dev
 ```
 
-`http://localhost:5173` で開発サーバーが起動します。
+`http://localhost:5173` で開発サーバーが起動します（ホットリロード対応）。
 
-## ディレクトリ構成
+## 設定
+
+`.env.example` を `.env` にコピーして設定してください。すべての変数にデフォルト値があるため、設定なしでも動作します。
+
+### 基本設定
+
+| 変数 | デフォルト | 説明 |
+|------|-----------|------|
+| `DATABASE_URL` | `./data/ganbari-quest.db` | SQLite データベースのパス |
+| `HOST` | `0.0.0.0` | バインドアドレス |
+| `PORT` | `3000` | HTTP ポート |
+| `ORIGIN` | 自動検出 | アプリの完全URL（リバースプロキシ使用時は明示的に設定） |
+
+### オプション連携
+
+| 変数 | 説明 |
+|------|------|
+| `AI_PROVIDER` | AI プロバイダー: `gemini` or `bedrock`（アバター画像のAI生成用） |
+| `GEMINI_API_KEY` | [Google AI Studio](https://aistudio.google.com/) API キー（`AI_PROVIDER=gemini` 時） |
+| `GDRIVE_CLIENT_ID` | Google Drive バックアップ -- OAuth クライアントID |
+| `GDRIVE_CLIENT_SECRET` | Google Drive バックアップ -- OAuth クライアントシークレット |
+| `GDRIVE_REFRESH_TOKEN` | Google Drive バックアップ -- OAuth リフレッシュトークン |
+| `GDRIVE_FOLDER_ID` | Google Drive バックアップ -- ターゲットフォルダID |
+| `DISCORD_ALERT_WEBHOOK_URL` | 500 エラー通知用 Discord Webhook |
+| `LOG_LEVEL` | ログレベル（デフォルト: `info`） |
+
+### バックアップ設定
+
+| 変数 | デフォルト | 説明 |
+|------|-----------|------|
+| `BACKUP_DIR` | `./data/backups` | ローカルバックアップディレクトリ |
+| `BACKUP_RETENTION` | `10` | 保持するバックアップファイル数 |
+| `BACKUP_POST_HOOK` | -- | バックアップ後スクリプト（例: `node scripts/hooks/gdrive-upload.cjs`） |
+
+> **注:** 本番SaaS設定（`AWS_LICENSE_SECRET`, `STRIPE_*`, `CRON_SECRET` 等）はセルフホストでは不要です。セルフホスト環境ではすべてのコア機能が利用可能です。全変数の一覧は `.env.example` を参照してください。
+
+## セルフホスティングガイド
+
+### 最小システム要件
+
+| リソース | 最小 | 推奨 |
+|---------|------|------|
+| CPU | 1コア | 2コア |
+| RAM | 512 MB | 1 GB |
+| ストレージ | 500 MB | 2 GB（バックアップ含む） |
+| OS | Docker 対応 OS | Linux |
+
+### 基本デプロイ
+
+```bash
+# クローン & 起動
+git clone https://github.com/Takenori-Kusaka/ganbari-quest.git
+cd ganbari-quest
+docker compose up -d
+
+# ログ確認
+docker compose logs -f app
+
+# 停止
+docker compose down
+
+# 最新版にアップデート
+git pull
+docker compose up -d --build
+```
+
+### データ永続化
+
+以下のディレクトリが Docker ボリュームとしてマウントされ、コンテナ再起動後も保持されます。
+
+| ディレクトリ | 内容 |
+|-------------|------|
+| `./data/` | SQLite データベースとバックアップ |
+| `./uploads/` | ユーザーアップロードファイル（アバター等） |
+| `./generated/` | AI 生成画像 |
+| `./tenants/` | テナント固有データ |
+
+### 自動バックアップ
+
+バックアップサイドカーを有効にして、毎日 3:00 AM（JST）に自動バックアップを実行できます。
+
+```bash
+docker compose --profile backup up -d
+```
+
+Google Drive へのクラウドバックアップを有効にするには、`.env` ファイルに `GDRIVE_*` 変数を設定してください。詳細は `.env.example` を参照。
+
+### HTTPS（リバースプロキシ）
+
+HTTPS を使う本番デプロイでは、`docker-compose.yml` の Caddy セクションのコメントを外し、`Caddyfile` を作成します。
+
+```
+your-domain.example.com {
+    reverse_proxy app:3000
+}
+```
+
+`.env` を更新します。
+
+```bash
+ORIGIN=https://your-domain.example.com
+```
+
+nginx や Traefik 等、TLS を終端してポート 3000 に転送するリバースプロキシも利用可能です。
+
+### LAN 内の他デバイスからアクセス
+
+スマートフォンやタブレットからアクセスするには:
+
+1. サーバーのローカル IP を確認（例: `192.168.1.100`）
+2. `.env` に `ORIGIN=http://192.168.1.100:3000` を設定
+3. 再起動: `docker compose up -d`
+4. `http://192.168.1.100:3000` でアクセス
+
+### ヘルスチェック
+
+`GET /api/health` でヘルスエンドポイントが利用可能です（Docker の `HEALTHCHECK` で使用）。
+
+## 技術スタック
+
+| カテゴリ | 技術 |
+|---------|------|
+| フレームワーク | SvelteKit 2 + Svelte 5 (Runes) |
+| UI | Ark UI Svelte (Headless) + 独自デザインシステム |
+| データベース | SQLite (WAL) + Drizzle ORM |
+| テスト | Vitest + Playwright |
+| Lint/Format | Biome + ESLint + Stylelint |
+| 言語 | TypeScript (strict) |
+| インフラ | Docker + Node.js 22 |
+
+## 開発
+
+### コマンド
+
+```bash
+npm run dev              # 開発サーバー (http://localhost:5173)
+npm run build            # プロダクションビルド
+npx vitest run           # ユニットテスト
+npx playwright test      # E2E テスト
+npx biome check .        # Lint & フォーマット
+npx svelte-check         # 型チェック
+npx drizzle-kit push     # DB マイグレーション
+```
+
+### ディレクトリ構成
 
 ```
 ganbari-quest/
 ├── src/
-│   ├── routes/             # SvelteKit ファイルベースルーティング
-│   │   ├── (child)/        # 子供向けページ (baby/kinder/teen)
-│   │   ├── (parent)/       # 親の管理画面 (PIN認証付き)
-│   │   └── api/            # REST API エンドポイント
+│   ├── routes/              # SvelteKit ファイルベースルーティング
+│   │   ├── (child)/         # 子供向けページ（年齢適応UI）
+│   │   ├── (parent)/        # 親の管理画面（PIN認証付き）
+│   │   └── api/             # REST API エンドポイント
 │   └── lib/
-│       ├── ui/             # Ark UI ラッパ + 共通コンポーネント
-│       ├── features/       # 機能単位 (career, avatar 等)
-│       ├── domain/         # ドメインモデル・バリデーション
-│       └── server/         # DB・サービス層 (server only)
-├── docs/
-│   ├── design/             # 設計ドキュメント (12本)
-│   └── tickets/            # 開発チケット (100+)
-├── scripts/                # マイグレーション・バックアップ
-├── tests/                  # ユニットテスト (32ファイル)
-└── docker-compose.yml
+│       ├── ui/              # Ark UI ラッパ + 共通コンポーネント
+│       ├── features/        # 機能モジュール (career, avatar 等)
+│       ├── domain/          # ドメインモデル・バリデーション
+│       └── server/          # DB・サービス層 (server only)
+├── docs/design/             # 設計ドキュメント
+├── tests/                   # ユニット & E2E テスト
+├── scripts/                 # マイグレーション・バックアップ・CI スクリプト
+├── infra/                   # AWS CDK インフラ（SaaS）
+├── docker-compose.yml       # Docker デプロイ設定
+└── Dockerfile               # マルチステージプロダクションビルド
 ```
 
-## 環境変数
+## SaaS vs セルフホスト
 
-`.env.example` を `.env` にコピーして設定してください。
-
-| 変数 | 必須 | 説明 |
-|------|------|------|
-| `DATABASE_URL` | Yes | SQLiteデータベースのパス |
-| `HOST` | No | バインドホスト（デフォルト: `0.0.0.0`） |
-| `PORT` | No | ポート番号（デフォルト: `3000`） |
-| `ORIGIN` | No | アプリのURL |
-| `GEMINI_API_KEY` | No | アバター画像AI生成用 |
-| `GDRIVE_*` | No | Google Driveバックアップ用 |
-| `DEBUG_PLAN` | No | **dev only** — `free`/`standard`/`family` でプランを上書き (#758) |
-| `DEBUG_TRIAL` | No | **dev only** — `active`/`expired`/`not-started` でトライアル状態を上書き |
-| `DEBUG_TRIAL_TIER` | No | **dev only** — `standard`/`family` でトライアルティア指定 |
-
-## 開発コマンド
-
-```bash
-npm run dev          # 開発サーバー
-npm run build        # プロダクションビルド
-npx vitest run       # ユニットテスト (606件)
-npx playwright test  # E2Eテスト
-npx biome check .    # Lint
-npx drizzle-kit push # DBマイグレーション
-```
-
-## コミュニティ
-
-質問・要望・体験談の共有は [GitHub Issues](https://github.com/Takenori-Kusaka/ganbari-quest/issues) または [メール](mailto:ganbari.quest.support@gmail.com) で受け付けています。お気軽にご連絡ください。
+| | セルフホスト（このリポジトリ） | SaaS |
+|---|---|---|
+| **コスト** | 無料（自前ハードウェア） | 無料枠 + 有料プラン |
+| **データ保存先** | 自分のサーバー | クラウド（AWS） |
+| **セットアップ** | `docker compose up -d` | Web サイトで登録 |
+| **アップデート** | `git pull && docker compose up -d --build` | 自動 |
+| **認証** | ローカル PIN 認証 | AWS Cognito (Google SSO) |
+| **AI 機能** | 自前 API キー設定 | 標準搭載 |
+| **バックアップ** | 手動 or cron | 自動 |
+| **サポート** | コミュニティ (GitHub Issues) | メールサポート |
 
 ## コントリビュート
 
 バグ報告・機能提案・PRを歓迎します。詳細は [CONTRIBUTING.md](./CONTRIBUTING.md) を参照してください。
 
-## サポート
+## コミュニティ & サポート
 
-がんばりクエストの開発を応援していただける方は [GitHub Sponsors](https://github.com/sponsors/Takenori-Kusaka) からご支援ください。
+- **Issue & ディスカッション**: [GitHub Issues](https://github.com/Takenori-Kusaka/ganbari-quest/issues)
+- **メール**: [ganbari.quest.support@gmail.com](mailto:ganbari.quest.support@gmail.com)
+- **スポンサー**: [GitHub Sponsors](https://github.com/sponsors/Takenori-Kusaka) -- 開発を応援していただける方はぜひ
 
 ## ライセンス
 
-[AGPL-3.0](./LICENSE) — 個人利用・セルフホスト・改造は自由です。
+[AGPL-3.0](./LICENSE) -- 個人利用・セルフホスト・改造は自由です。改変版をネットワークサービスとして配布する場合は、同じライセンスでソースコードを公開する必要があります。


### PR DESCRIPTION
## Summary

Closes #1101

- Add comprehensive **Self-Hosting Guide** section: system requirements, Docker deployment, data persistence, automated backups, HTTPS with reverse proxy, LAN access instructions, health check endpoint
- Add **Configuration** section: core settings, optional integrations, backup settings with clear table format (replaces minimal env var list)
- Add **SaaS vs Self-Hosted** comparison table
- Add **Prerequisites** section with Docker/Node.js version requirements
- Add **first boot behavior** explanation for Docker deployments
- Improve **Features** section with 5 age modes detail
- Add Docker badge to header
- Add AGPL-3.0 license explanation (network service source code requirement)
- Add **Community & Support** section with links
- Update both `README.md` (Japanese) and `README.en.md` (English) in sync

## Test plan

- [ ] Verify all links in README.en.md resolve correctly (LICENSE, CONTRIBUTING.md, .env.example, GitHub Issues, sponsors)
- [ ] Verify all links in README.md resolve correctly
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm Docker instructions match actual `docker-compose.yml` configuration
- [ ] Confirm environment variable documentation matches `.env.example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)