### PR TITLE
fix: #1096 requireTenantId アンチパターン横展開修正 (47 endpoints)

### DIFF
--- a/src/routes/api/stripe/portal/+server.ts
+++ b/src/routes/api/stripe/portal/+server.ts
@@ -5,7 +5,6 @@
 //       PIN 未設定テナントは確認フレーズ (`プランを変更します`) でフォールバックする。
 
 import { error, json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { isPinConfigured, verifyPin } from '$lib/server/services/auth-service';
 import { createPortalSession } from '$lib/server/services/stripe-service';
 import type { RequestHandler } from './$types';
@@ -13,7 +12,11 @@ import type { RequestHandler } from './$types';
 const DOWNGRADE_CONFIRM_PHRASE = 'プランを変更します';
 
 export const POST: RequestHandler = async ({ locals, url, request }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		error(401, '認証が必要です');
+	}
+	const tenantId = context.tenantId;
 
 	const role = locals.context?.role;
 	if (role !== 'owner' && role !== 'parent') {

--- a/src/routes/api/v1/activities/+server.ts
+++ b/src/routes/api/v1/activities/+server.ts
@@ -1,13 +1,16 @@
 import { json } from '@sveltejs/kit';
 import { activitiesQuerySchema, createActivitySchema } from '$lib/domain/validation/activity';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { findChildById } from '$lib/server/db/activity-repo';
 import { validationError } from '$lib/server/errors';
 import { createActivity, getActivities } from '$lib/server/services/activity-service';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const parsed = activitiesQuerySchema.safeParse(Object.fromEntries(url.searchParams));
 	if (!parsed.success) {
 		return validationError(parsed.error.issues[0]?.message ?? 'パラメータが不正です');
@@ -29,7 +32,11 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 };
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const body = await request.json();
 	const parsed = createActivitySchema.safeParse(body);
 	if (!parsed.success) {

--- a/src/routes/api/v1/activities/[id]/+server.ts
+++ b/src/routes/api/v1/activities/[id]/+server.ts
@@ -1,6 +1,5 @@
 import { json } from '@sveltejs/kit';
 import { updateActivitySchema } from '$lib/domain/validation/activity';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { notFound, validationError } from '$lib/server/errors';
 import {
 	getActivityById,
@@ -10,7 +9,11 @@ import {
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const id = Number(params.id);
 	if (Number.isNaN(id)) return validationError('IDが不正です');
 
@@ -21,7 +24,11 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 };
 
 export const PATCH: RequestHandler = async ({ params, request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const id = Number(params.id);
 	if (Number.isNaN(id)) return validationError('IDが不正です');
 
@@ -39,7 +46,11 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 };
 
 export const DELETE: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const id = Number(params.id);
 	if (Number.isNaN(id)) return validationError('IDが不正です');
 

--- a/src/routes/api/v1/activities/[id]/visibility/+server.ts
+++ b/src/routes/api/v1/activities/[id]/visibility/+server.ts
@@ -1,11 +1,14 @@
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { notFound, validationError } from '$lib/server/errors';
 import { getActivityById, setActivityVisibility } from '$lib/server/services/activity-service';
 import type { RequestHandler } from './$types';
 
 export const PATCH: RequestHandler = async ({ params, request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const id = Number(params.id);
 	if (Number.isNaN(id)) return validationError('IDが不正です');
 

--- a/src/routes/api/v1/activities/export/+server.ts
+++ b/src/routes/api/v1/activities/export/+server.ts
@@ -1,6 +1,5 @@
 import { json } from '@sveltejs/kit';
 import { CATEGORY_CODES } from '$lib/domain/validation/activity';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { getActivities } from '$lib/server/services/activity-service';
 import type { RequestHandler } from './$types';
 
@@ -10,7 +9,11 @@ for (const [i, code] of CATEGORY_CODES.entries()) {
 }
 
 export const GET: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const activities = await getActivities(tenantId, { includeHidden: false });
 
 	const exportData = {

--- a/src/routes/api/v1/activities/import/+server.ts
+++ b/src/routes/api/v1/activities/import/+server.ts
@@ -1,7 +1,6 @@
 import { error, json } from '@sveltejs/kit';
 import type { ActivityPackItem } from '$lib/domain/activity-pack';
 import { CATEGORY_CODES } from '$lib/domain/validation/activity';
-import { requireTenantId } from '$lib/server/auth/factory';
 import {
 	importActivities,
 	previewActivityImport,
@@ -45,7 +44,11 @@ function validateActivities(data: unknown): ActivityPackItem[] {
 }
 
 export const POST: RequestHandler = async ({ request, url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const mode = url.searchParams.get('mode') ?? 'preview';
 
 	let body: unknown;

--- a/src/routes/api/v1/activity-logs/+server.ts
+++ b/src/routes/api/v1/activity-logs/+server.ts
@@ -1,12 +1,15 @@
 import { json } from '@sveltejs/kit';
 import { activityLogsQuerySchema, recordActivitySchema } from '$lib/domain/validation/activity';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { apiError, validationError } from '$lib/server/errors';
 import { getActivityLogs, recordActivity } from '$lib/server/services/activity-log-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const body = await request.json();
 	const parsed = recordActivitySchema.safeParse(body);
 	if (!parsed.success) {
@@ -31,7 +34,11 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 };
 
 export const GET: RequestHandler = async ({ url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const parsed = activityLogsQuerySchema.safeParse(Object.fromEntries(url.searchParams));
 	if (!parsed.success) {
 		return validationError(parsed.error.issues[0]?.message ?? 'パラメータが不正です');

--- a/src/routes/api/v1/activity-logs/[id]/+server.ts
+++ b/src/routes/api/v1/activity-logs/[id]/+server.ts
@@ -1,11 +1,14 @@
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { apiError, validationError } from '$lib/server/errors';
 import { cancelActivityLog } from '$lib/server/services/activity-log-service';
 import type { RequestHandler } from './$types';
 
 export const DELETE: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const id = Number(params.id);
 	if (Number.isNaN(id)) return validationError('IDが不正です');
 

--- a/src/routes/api/v1/admin/invites/+server.ts
+++ b/src/routes/api/v1/admin/invites/+server.ts
@@ -4,19 +4,26 @@
 
 import { error, json } from '@sveltejs/kit';
 import { createInviteSchema } from '$lib/domain/validation/auth';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { validationError } from '$lib/server/errors';
 import { createInvite, listInvites } from '$lib/server/services/invite-service';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const invites = await listInvites(tenantId);
 	return json({ invites });
 };
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const identity = locals.identity;
 	if (!identity || identity.type !== 'cognito') {
 		error(401, 'Unauthorized');

--- a/src/routes/api/v1/admin/invites/[code]/+server.ts
+++ b/src/routes/api/v1/admin/invites/[code]/+server.ts
@@ -1,12 +1,15 @@
 // DELETE /api/v1/admin/invites/[code] — 招待取消し (#0129)
 
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { revokeInvite } from '$lib/server/services/invite-service';
 import type { RequestHandler } from './$types';
 
 export const DELETE: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	await revokeInvite(params.code, tenantId);
 	return json({ ok: true });
 };

--- a/src/routes/api/v1/admin/license/+server.ts
+++ b/src/routes/api/v1/admin/license/+server.ts
@@ -1,12 +1,15 @@
 // GET /api/v1/admin/license — ライセンス情報取得 (#0130)
 
 import { error, json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { getLicenseInfo } from '$lib/server/services/license-service';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const info = await getLicenseInfo(tenantId);
 	if (!info) {
 		error(404, 'テナント情報が見つかりません');

--- a/src/routes/api/v1/admin/members/[userId]/+server.ts
+++ b/src/routes/api/v1/admin/members/[userId]/+server.ts
@@ -3,17 +3,19 @@
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { sendMemberRemovedEmail } from '$lib/server/services/email-service';
 
 export const DELETE: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
 	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const targetUserId = (params as Record<string, string>).userId ?? '';
 
-	if (!context || context.role !== 'owner') {
+	if (context.role !== 'owner') {
 		return json({ error: 'owner のみメンバーを削除できます' }, { status: 403 });
 	}
 

--- a/src/routes/api/v1/admin/members/[userId]/transfer-ownership/+server.ts
+++ b/src/routes/api/v1/admin/members/[userId]/transfer-ownership/+server.ts
@@ -3,18 +3,20 @@
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { sendMemberJoinedEmail } from '$lib/server/services/email-service';
 
 export const POST: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
 	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const identity = locals.identity;
 	const targetUserId = (params as Record<string, string>).userId ?? '';
 
-	if (!context || context.role !== 'owner') {
+	if (context.role !== 'owner') {
 		return json({ error: 'owner のみ権限を移譲できます' }, { status: 403 });
 	}
 

--- a/src/routes/api/v1/admin/tenant/status/+server.ts
+++ b/src/routes/api/v1/admin/tenant/status/+server.ts
@@ -3,11 +3,14 @@
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 
 export const GET: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 
 	const repos = getRepos();
 	const tenant = await repos.auth.findTenantById(tenantId);

--- a/src/routes/api/v1/admin/viewer-tokens/+server.ts
+++ b/src/routes/api/v1/admin/viewer-tokens/+server.ts
@@ -4,13 +4,16 @@
 
 import { error, json } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import { createViewerToken, listViewerTokens } from '$lib/server/services/viewer-token-service';
 import type { RequestHandler } from './$types';
 
 async function requireFamily(locals: App.Locals): Promise<string> {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		throw error(401, '認証が必要です');
+	}
+	const tenantId = context.tenantId;
 	const tier = await resolveFullPlanTier(
 		tenantId,
 		locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,

--- a/src/routes/api/v1/admin/viewer-tokens/[id]/+server.ts
+++ b/src/routes/api/v1/admin/viewer-tokens/[id]/+server.ts
@@ -2,12 +2,15 @@
 // (#371)
 
 import { error, json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { deleteViewerToken, revokeViewerToken } from '$lib/server/services/viewer-token-service';
 import type { RequestHandler } from './$types';
 
 export const DELETE: RequestHandler = async ({ params, locals, url }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const id = Number(params.id);
 	if (!Number.isFinite(id)) {
 		error(400, '不正なID');

--- a/src/routes/api/v1/auth/login/+server.ts
+++ b/src/routes/api/v1/auth/login/+server.ts
@@ -4,14 +4,17 @@ import {
 	SESSION_COOKIE_NAME,
 	SESSION_MAX_AGE_SECONDS,
 } from '$lib/domain/validation/auth';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { COOKIE_SECURE } from '$lib/server/cookie-config';
 import { apiError, validationError } from '$lib/server/errors';
 import { login } from '$lib/server/services/auth-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request, cookies, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const body = await request.json();
 	const parsed = loginSchema.safeParse(body);
 	if (!parsed.success) {

--- a/src/routes/api/v1/auth/logout/+server.ts
+++ b/src/routes/api/v1/auth/logout/+server.ts
@@ -1,11 +1,14 @@
-import { redirect } from '@sveltejs/kit';
+import { json, redirect } from '@sveltejs/kit';
 import { SESSION_COOKIE_NAME } from '$lib/domain/validation/auth';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { logout } from '$lib/server/services/auth-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ cookies, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	await logout(tenantId);
 	cookies.delete(SESSION_COOKIE_NAME, { path: '/' });
 	redirect(302, '/');

--- a/src/routes/api/v1/battle/[childId]/+server.ts
+++ b/src/routes/api/v1/battle/[childId]/+server.ts
@@ -1,5 +1,4 @@
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { validationError } from '$lib/server/errors';
 import { executeDailyBattle, getTodayBattle } from '$lib/server/services/battle-service';
 import { getChildById } from '$lib/server/services/child-service';
@@ -18,7 +17,11 @@ async function resolveChildBattleContext(
 	params: { childId: string },
 	locals: App.Locals,
 ): Promise<BattleContext | Response> {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.childId);
 	if (Number.isNaN(childId)) return validationError('IDが不正です');
 

--- a/src/routes/api/v1/children/[id]/activities/[activityId]/pin/+server.ts
+++ b/src/routes/api/v1/children/[id]/activities/[activityId]/pin/+server.ts
@@ -2,13 +2,16 @@
 // 活動ピン留めトグルAPI
 
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { toggleActivityPin } from '$lib/server/services/activity-pin-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ params, request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.id);
 	const activityId = Number(params.activityId);
 
@@ -34,7 +37,11 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 };
 
 export const DELETE: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.id);
 	const activityId = Number(params.activityId);
 

--- a/src/routes/api/v1/children/[id]/avatar/+server.ts
+++ b/src/routes/api/v1/children/[id]/avatar/+server.ts
@@ -1,5 +1,4 @@
 import { error, json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { findChildById } from '$lib/server/db/activity-repo';
 import { updateChildAvatarUrl } from '$lib/server/db/image-repo';
 import { logger } from '$lib/server/logger';
@@ -13,7 +12,11 @@ const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 export const POST: RequestHandler = async ({ params, request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.id);
 	if (!childId || Number.isNaN(childId)) {
 		throw error(400, { message: '不正なIDです' });

--- a/src/routes/api/v1/children/[id]/voices/+server.ts
+++ b/src/routes/api/v1/children/[id]/voices/+server.ts
@@ -1,11 +1,14 @@
 import { error, json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { listVoices, uploadVoice } from '$lib/server/services/voice-service';
 import type { RequestHandler } from './$types';
 
 /** GET /api/v1/children/:id/voices?scene=complete */
 export const GET: RequestHandler = async ({ params, url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.id);
 	if (!childId || Number.isNaN(childId)) throw error(400, { message: '不正なIDです' });
 
@@ -16,7 +19,11 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 
 /** POST /api/v1/children/:id/voices */
 export const POST: RequestHandler = async ({ params, request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.id);
 	if (!childId || Number.isNaN(childId)) throw error(400, { message: '不正なIDです' });
 

--- a/src/routes/api/v1/children/[id]/voices/[voiceId]/+server.ts
+++ b/src/routes/api/v1/children/[id]/voices/[voiceId]/+server.ts
@@ -1,11 +1,14 @@
 import { error, json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { activateVoice, deleteVoice } from '$lib/server/services/voice-service';
 import type { RequestHandler } from './$types';
 
 /** PATCH /api/v1/children/:id/voices/:voiceId — アクティブ切替 */
 export const PATCH: RequestHandler = async ({ params, request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.id);
 	const voiceId = Number(params.voiceId);
 	if (!childId || !voiceId) throw error(400, { message: '不正なIDです' });
@@ -21,7 +24,11 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 
 /** DELETE /api/v1/children/:id/voices/:voiceId — ボイス削除 */
 export const DELETE: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const voiceId = Number(params.voiceId);
 	if (!voiceId) throw error(400, { message: '不正なIDです' });
 

--- a/src/routes/api/v1/data/clear/+server.ts
+++ b/src/routes/api/v1/data/clear/+server.ts
@@ -2,7 +2,7 @@
 // テナントデータクリア API (#0205)
 
 import { json } from '@sveltejs/kit';
-import { requireRole, requireTenantId } from '$lib/server/auth/factory';
+import { requireRole } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
 import { clearAllFamilyData } from '$lib/server/services/data-service';
@@ -10,7 +10,11 @@ import type { RequestHandler } from './$types';
 
 /** POST /api/v1/data/clear */
 export const POST: RequestHandler = async ({ request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	requireRole(locals, ['owner']);
 
 	let body: { confirm?: string };

--- a/src/routes/api/v1/data/summary/+server.ts
+++ b/src/routes/api/v1/data/summary/+server.ts
@@ -2,13 +2,17 @@
 // テナントデータサマリー API (#0205)
 
 import { json } from '@sveltejs/kit';
-import { requireRole, requireTenantId } from '$lib/server/auth/factory';
+import { requireRole } from '$lib/server/auth/factory';
 import { getDataSummary } from '$lib/server/services/data-service';
 import type { RequestHandler } from './$types';
 
 /** GET /api/v1/data/summary */
 export const GET: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	requireRole(locals, ['owner', 'parent']);
 
 	const summary = await getDataSummary(tenantId);

--- a/src/routes/api/v1/evaluations/[childId]/+server.ts
+++ b/src/routes/api/v1/evaluations/[childId]/+server.ts
@@ -1,12 +1,15 @@
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { notFound, validationError } from '$lib/server/errors';
 import { getAllChildren } from '$lib/server/services/child-service';
 import { getChildEvaluations } from '$lib/server/services/evaluation-service';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params, url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.childId);
 	if (Number.isNaN(childId)) return validationError('IDが不正です');
 

--- a/src/routes/api/v1/export/+server.ts
+++ b/src/routes/api/v1/export/+server.ts
@@ -1,9 +1,10 @@
 // src/routes/api/v1/export/+server.ts
 // 家族データエクスポートAPI（JSON / ZIP対応）
+import { json } from '@sveltejs/kit';
 
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { todayDateJST } from '$lib/domain/date-utils';
-import { requireRole, requireTenantId } from '$lib/server/auth/factory';
+import { requireRole } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
 import { exportFamilyData } from '$lib/server/services/export-service';
@@ -13,7 +14,11 @@ import { tenantPrefix } from '$lib/server/storage-keys';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	requireRole(locals, ['owner', 'parent']);
 
 	// プラン制限チェック（エクスポート機能）

--- a/src/routes/api/v1/export/cloud/+server.ts
+++ b/src/routes/api/v1/export/cloud/+server.ts
@@ -3,7 +3,7 @@
 
 import { json } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
-import { requireRole, requireTenantId } from '$lib/server/auth/factory';
+import { requireRole } from '$lib/server/auth/factory';
 import type { CloudExportType } from '$lib/server/db/types';
 import { apiError, validationError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
@@ -12,7 +12,11 @@ import type { RequestHandler } from './$types';
 
 /** GET /api/v1/export/cloud — 自テナントのクラウドエクスポート一覧 */
 export const GET: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	requireRole(locals, ['owner', 'parent']);
 
 	try {
@@ -26,7 +30,11 @@ export const GET: RequestHandler = async ({ locals }) => {
 
 /** POST /api/v1/export/cloud — クラウドエクスポート作成 */
 export const POST: RequestHandler = async ({ request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	requireRole(locals, ['owner', 'parent']);
 
 	let body: { exportType?: string; label?: string };

--- a/src/routes/api/v1/export/cloud/[id]/+server.ts
+++ b/src/routes/api/v1/export/cloud/[id]/+server.ts
@@ -2,7 +2,7 @@
 // クラウドエクスポート個別操作API（削除）
 
 import { json } from '@sveltejs/kit';
-import { requireRole, requireTenantId } from '$lib/server/auth/factory';
+import { requireRole } from '$lib/server/auth/factory';
 import { apiError, validationError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
 import { deleteCloudExport } from '$lib/server/services/cloud-export-service';
@@ -10,7 +10,11 @@ import type { RequestHandler } from './$types';
 
 /** DELETE /api/v1/export/cloud/:id — クラウドエクスポート削除 */
 export const DELETE: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	requireRole(locals, ['owner', 'parent']);
 
 	const id = Number(params.id);

--- a/src/routes/api/v1/images/+server.ts
+++ b/src/routes/api/v1/images/+server.ts
@@ -1,5 +1,3 @@
-import { requireTenantId } from '$lib/server/auth/factory';
-
 // POST /api/v1/images - Generate avatar or favicon
 // GET /api/v1/images?type=favicon - Get favicon path
 
@@ -14,7 +12,11 @@ import { getChildStatus } from '$lib/server/services/status-service';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const type = url.searchParams.get('type');
 
 	if (type === 'favicon') {
@@ -26,7 +28,11 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 };
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const body = await request.json().catch(() => null);
 	if (!body || typeof body !== 'object') {
 		return validationError('リクエストボディが不正です');

--- a/src/routes/api/v1/import/+server.ts
+++ b/src/routes/api/v1/import/+server.ts
@@ -2,7 +2,7 @@
 // 家族データインポートAPI
 
 import { json } from '@sveltejs/kit';
-import { requireRole, requireTenantId } from '$lib/server/auth/factory';
+import { requireRole } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
 import { clearAllFamilyData } from '$lib/server/services/data-service';
@@ -15,7 +15,11 @@ import type { RequestHandler } from './$types';
 
 /** POST /api/v1/import?mode=preview|execute|replace */
 export const POST: RequestHandler = async ({ request, url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	requireRole(locals, ['owner', 'parent']);
 
 	const mode = url.searchParams.get('mode') ?? 'preview';

--- a/src/routes/api/v1/import/cloud/+server.ts
+++ b/src/routes/api/v1/import/cloud/+server.ts
@@ -2,7 +2,7 @@
 // PINコードによるクラウドインポートAPI
 
 import { json } from '@sveltejs/kit';
-import { requireRole, requireTenantId } from '$lib/server/auth/factory';
+import { requireRole } from '$lib/server/auth/factory';
 import { apiError, validationError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
 import { fetchCloudExportByPin } from '$lib/server/services/cloud-export-service';
@@ -22,7 +22,11 @@ import type { RequestHandler } from './$types';
  * フルインポート: 既存import-serviceのフローを利用
  */
 export const POST: RequestHandler = async ({ request, url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	requireRole(locals, ['owner', 'parent']);
 
 	const mode = url.searchParams.get('mode') ?? 'preview';

--- a/src/routes/api/v1/login-bonus/[childId]/+server.ts
+++ b/src/routes/api/v1/login-bonus/[childId]/+server.ts
@@ -1,11 +1,14 @@
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { notFound, validationError } from '$lib/server/errors';
 import { getLoginBonusStatus } from '$lib/server/services/login-bonus-service';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.childId);
 	if (Number.isNaN(childId)) return validationError('IDが不正です');
 

--- a/src/routes/api/v1/login-bonus/[childId]/claim/+server.ts
+++ b/src/routes/api/v1/login-bonus/[childId]/claim/+server.ts
@@ -1,11 +1,14 @@
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { apiError, validationError } from '$lib/server/errors';
 import { claimLoginBonus } from '$lib/server/services/login-bonus-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.childId);
 	if (Number.isNaN(childId)) return validationError('IDが不正です');
 

--- a/src/routes/api/v1/messages/[childId]/+server.ts
+++ b/src/routes/api/v1/messages/[childId]/+server.ts
@@ -1,6 +1,5 @@
 import { json } from '@sveltejs/kit';
 import { messageQuerySchema, sendMessageSchema } from '$lib/domain/validation/message';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { validationError } from '$lib/server/errors';
 import {
 	getMessageHistory,
@@ -11,7 +10,11 @@ import {
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params, url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const parsed = messageQuerySchema.safeParse({ childId: params.childId });
 	if (!parsed.success) {
 		return validationError(parsed.error.issues[0]?.message ?? 'パラメータが不正です');
@@ -31,7 +34,11 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 };
 
 export const POST: RequestHandler = async ({ request, params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const body = await request.json();
 
 	const parsed = sendMessageSchema.safeParse({

--- a/src/routes/api/v1/messages/[messageId]/shown/+server.ts
+++ b/src/routes/api/v1/messages/[messageId]/shown/+server.ts
@@ -1,11 +1,14 @@
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { notFound } from '$lib/server/errors';
 import { markAsShown } from '$lib/server/services/message-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const messageId = Number(params.messageId);
 	if (!messageId || Number.isNaN(messageId)) {
 		return notFound('メッセージが見つかりません');

--- a/src/routes/api/v1/points/[childId]/+server.ts
+++ b/src/routes/api/v1/points/[childId]/+server.ts
@@ -1,11 +1,14 @@
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { notFound, validationError } from '$lib/server/errors';
 import { getPointBalance } from '$lib/server/services/point-service';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.childId);
 	if (Number.isNaN(childId)) return validationError('IDが不正です');
 

--- a/src/routes/api/v1/points/[childId]/history/+server.ts
+++ b/src/routes/api/v1/points/[childId]/history/+server.ts
@@ -1,12 +1,15 @@
 import { json } from '@sveltejs/kit';
 import { pointHistoryQuerySchema } from '$lib/domain/validation/point';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { notFound, validationError } from '$lib/server/errors';
 import { getPointHistory } from '$lib/server/services/point-service';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params, url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.childId);
 	if (Number.isNaN(childId)) return validationError('IDが不正です');
 

--- a/src/routes/api/v1/points/convert/+server.ts
+++ b/src/routes/api/v1/points/convert/+server.ts
@@ -1,12 +1,15 @@
 import { json } from '@sveltejs/kit';
 import { ConvertMode, convertPointsSchema } from '$lib/domain/validation/point';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { apiError, validationError } from '$lib/server/errors';
 import { convertPoints } from '$lib/server/services/point-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const body = await request.json();
 	// mode が未指定の場合はプリセットとして扱う（後方互換）
 	const input = { mode: ConvertMode.PRESET, ...body };

--- a/src/routes/api/v1/points/ocr-receipt/+server.ts
+++ b/src/routes/api/v1/points/ocr-receipt/+server.ts
@@ -1,5 +1,4 @@
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { validationError } from '$lib/server/errors';
 import { validateBase64ImageMagicBytes } from '$lib/server/security/magic-bytes';
 import { ocrReceipt } from '$lib/server/services/receipt-ocr-service';
@@ -9,7 +8,10 @@ const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
 	const body = await request.json();
 	const { image, mimeType } = body as { image?: string; mimeType?: string };
 

--- a/src/routes/api/v1/rest-days/[childId]/+server.ts
+++ b/src/routes/api/v1/rest-days/[childId]/+server.ts
@@ -1,5 +1,4 @@
 import { error, json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import {
 	countRestDaysInMonth,
 	deleteRestDay,
@@ -13,7 +12,11 @@ const VALID_REASONS = ['sick', 'trip', 'rest'] as const;
 
 /** おやすみ日一覧取得 (GET /api/v1/rest-days/:childId?month=2026-03) */
 export const GET: RequestHandler = async ({ params, url, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.childId);
 	if (!childId) throw error(400, 'Invalid childId');
 
@@ -26,7 +29,11 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 
 /** おやすみ日登録 (POST /api/v1/rest-days/:childId) */
 export const POST: RequestHandler = async ({ params, request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.childId);
 	if (!childId) throw error(400, 'Invalid childId');
 
@@ -53,7 +60,11 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 
 /** おやすみ日削除 (DELETE /api/v1/rest-days/:childId) */
 export const DELETE: RequestHandler = async ({ params, request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.childId);
 	if (!childId) throw error(400, 'Invalid childId');
 

--- a/src/routes/api/v1/settings/decay/+server.ts
+++ b/src/routes/api/v1/settings/decay/+server.ts
@@ -1,5 +1,4 @@
 import { error, json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { getSetting, setSetting } from '$lib/server/db/settings-repo';
 import type { RequestHandler } from './$types';
 
@@ -7,14 +6,22 @@ const VALID_INTENSITIES = ['none', 'gentle', 'normal', 'strict'] as const;
 
 /** 減少強度設定を取得 */
 export const GET: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const value = await getSetting('decay_intensity', tenantId);
 	return json({ intensity: value ?? 'normal' });
 };
 
 /** 減少強度設定を更新 */
 export const PUT: RequestHandler = async ({ request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const body = await request.json();
 	const intensity = body.intensity as string;
 

--- a/src/routes/api/v1/settings/tutorial/+server.ts
+++ b/src/routes/api/v1/settings/tutorial/+server.ts
@@ -1,10 +1,13 @@
 import { error, json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { setSetting } from '$lib/server/db/settings-repo';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const body = await request.json();
 	const action = body.action as string;
 

--- a/src/routes/api/v1/special-rewards/[childId]/+server.ts
+++ b/src/routes/api/v1/special-rewards/[childId]/+server.ts
@@ -3,7 +3,6 @@ import {
 	grantSpecialRewardSchema,
 	specialRewardQuerySchema,
 } from '$lib/domain/validation/special-reward';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { notFound, validationError } from '$lib/server/errors';
 import {
 	getChildSpecialRewards,
@@ -12,7 +11,11 @@ import {
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const parsed = specialRewardQuerySchema.safeParse({ childId: params.childId });
 	if (!parsed.success) {
 		return validationError(parsed.error.issues[0]?.message ?? 'パラメータが不正です');
@@ -23,7 +26,11 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 };
 
 export const POST: RequestHandler = async ({ request, params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const body = await request.json();
 
 	const parsed = grantSpecialRewardSchema.safeParse({

--- a/src/routes/api/v1/special-rewards/[rewardId]/shown/+server.ts
+++ b/src/routes/api/v1/special-rewards/[rewardId]/shown/+server.ts
@@ -1,10 +1,13 @@
 import { error, json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { markRewardShown } from '$lib/server/services/special-reward-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const rewardId = Number(params.rewardId);
 	if (Number.isNaN(rewardId)) {
 		error(400, 'Invalid reward ID');

--- a/src/routes/api/v1/special-rewards/templates/+server.ts
+++ b/src/routes/api/v1/special-rewards/templates/+server.ts
@@ -1,6 +1,5 @@
 import { json } from '@sveltejs/kit';
 import { rewardTemplatesArraySchema } from '$lib/domain/validation/special-reward';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { validationError } from '$lib/server/errors';
 import {
 	getRewardTemplates,
@@ -9,13 +8,21 @@ import {
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const templates = await getRewardTemplates(tenantId);
 	return json({ templates });
 };
 
 export const PUT: RequestHandler = async ({ request, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const body = await request.json();
 
 	const parsed = rewardTemplatesArraySchema.safeParse(body.templates ?? body);

--- a/src/routes/api/v1/status/[childId]/+server.ts
+++ b/src/routes/api/v1/status/[childId]/+server.ts
@@ -1,11 +1,14 @@
 import { json } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
 import { notFound, validationError } from '$lib/server/errors';
 import { getChildStatus } from '$lib/server/services/status-service';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params, locals }) => {
-	const tenantId = requireTenantId(locals);
+	const context = locals.context;
+	if (!context) {
+		return json({ error: '認証が必要です' }, { status: 401 });
+	}
+	const tenantId = context.tenantId;
 	const childId = Number(params.childId);
 	if (Number.isNaN(childId)) return validationError('IDが不正です');
 


### PR DESCRIPTION
## Summary

- `requireTenantId(locals)` が `locals.context === null` のとき plain `Error('Unauthorized: missing auth context')` を throw し HTTP 500 を返していたアンチパターンを、47 API エンドポイントで修正
- 各ハンドラで `locals.context` の null チェックをインラインで行い、適切な **401** レスポンスを返すように変更
- `requireTenantId` の import を全対象ファイルから除去（`requireRole` 等の他 import は維持）

### 修正パターン

**api/v1/ 配下 (46 files)**: `return json({ error: '認証が必要です' }, { status: 401 })`
**api/stripe/ 配下 (1 file)**: `error(401, '認証が必要です')` (SvelteKit error())

### 検証

- `npx biome check src/routes/api/` — エラーなし（pre-existing warnings 3 件のみ）
- `npx svelte-check` — 0 errors
- `npx vitest run` — 3479 tests passed

## Test plan

- [ ] `npx biome check .` — lint エラーなし
- [ ] `npx svelte-check` — 型エラーなし
- [ ] `npx vitest run` — ユニットテスト全通過
- [ ] 未認証状態で API エンドポイントにアクセスし、500 ではなく 401 が返ることを確認

Closes #1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)