### PR TITLE
fix: #1116 LP フッターを全 6 ページで統一

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1058,8 +1058,8 @@
       <h4>リンク</h4>
       <a href="pricing.html">料金プラン</a>
       <a href="https://github.com/Takenori-Kusaka/ganbari-quest">GitHub</a>
+      <a href="mailto:ganbari.quest.support@gmail.com" data-contact-context="トップページ">お問い合わせ</a>
       <a href="https://github.com/sponsors/Takenori-Kusaka">Sponsor</a>
-      <a href="https://ganbari-quest.com/auth/login">ログイン</a>
     </div>
     <div class="footer-links">
       <h4>法的情報</h4>

--- a/site/pricing.html
+++ b/site/pricing.html
@@ -402,9 +402,8 @@
       <h4>リンク</h4>
       <a href="pricing.html">料金プラン</a>
       <a href="https://github.com/Takenori-Kusaka/ganbari-quest">GitHub</a>
-      <a href="mailto:ganbari.quest.support@gmail.com">お問い合わせ</a>
+      <a href="mailto:ganbari.quest.support@gmail.com" data-contact-context="料金プラン">お問い合わせ</a>
       <a href="https://github.com/sponsors/Takenori-Kusaka">Sponsor</a>
-      <a href="https://ganbari-quest.com/auth/login">ログイン</a>
     </div>
     <div class="footer-links">
       <h4>法的情報</h4>
@@ -419,5 +418,6 @@
   </div>
 </footer>
 
+<script src="js/contact.js"></script>
 </body>
 </html>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -216,9 +216,8 @@ body{line-height:1.8;background:var(--gray-50)}
       <h4>リンク</h4>
       <a href="pricing.html">料金プラン</a>
       <a href="https://github.com/Takenori-Kusaka/ganbari-quest">GitHub</a>
-      <a href="mailto:ganbari.quest.support@gmail.com">お問い合わせ</a>
+      <a href="mailto:ganbari.quest.support@gmail.com" data-contact-context="プライバシーポリシー">お問い合わせ</a>
       <a href="https://github.com/sponsors/Takenori-Kusaka">Sponsor</a>
-      <a href="https://ganbari-quest.com/auth/login">ログイン</a>
     </div>
     <div class="footer-links">
       <h4>法的情報</h4>

--- a/site/sla.html
+++ b/site/sla.html
@@ -145,9 +145,8 @@ body{line-height:1.8;background:var(--gray-50)}
       <h4>リンク</h4>
       <a href="pricing.html">料金プラン</a>
       <a href="https://github.com/Takenori-Kusaka/ganbari-quest">GitHub</a>
-      <a href="mailto:ganbari.quest.support@gmail.com">お問い合わせ</a>
+      <a href="mailto:ganbari.quest.support@gmail.com" data-contact-context="SLA">お問い合わせ</a>
       <a href="https://github.com/sponsors/Takenori-Kusaka">Sponsor</a>
-      <a href="https://ganbari-quest.com/auth/login">ログイン</a>
     </div>
     <div class="footer-links">
       <h4>法的情報</h4>

--- a/site/terms.html
+++ b/site/terms.html
@@ -249,9 +249,8 @@ body{line-height:1.8;background:var(--gray-50)}
       <h4>リンク</h4>
       <a href="pricing.html">料金プラン</a>
       <a href="https://github.com/Takenori-Kusaka/ganbari-quest">GitHub</a>
-      <a href="mailto:ganbari.quest.support@gmail.com">お問い合わせ</a>
+      <a href="mailto:ganbari.quest.support@gmail.com" data-contact-context="利用規約">お問い合わせ</a>
       <a href="https://github.com/sponsors/Takenori-Kusaka">Sponsor</a>
-      <a href="https://ganbari-quest.com/auth/login">ログイン</a>
     </div>
     <div class="footer-links">
       <h4>法的情報</h4>

--- a/site/tokushoho.html
+++ b/site/tokushoho.html
@@ -128,9 +128,8 @@ table td{color:var(--gray-700)}
       <h4>リンク</h4>
       <a href="pricing.html">料金プラン</a>
       <a href="https://github.com/Takenori-Kusaka/ganbari-quest">GitHub</a>
-      <a href="mailto:ganbari.quest.support@gmail.com">お問い合わせ</a>
+      <a href="mailto:ganbari.quest.support@gmail.com" data-contact-context="特定商取引法">お問い合わせ</a>
       <a href="https://github.com/sponsors/Takenori-Kusaka">Sponsor</a>
-      <a href="https://ganbari-quest.com/auth/login">ログイン</a>
     </div>
     <div class="footer-links">
       <h4>法的情報</h4>


### PR DESCRIPTION
## Summary

- index.html にお問い合わせ mailto リンクを追加（欠落していた）
- pricing.html に `contact.js` スクリプトの読み込みを追加（欠落していた）
- 全 6 ページのフッター mailto リンクに `data-contact-context` 属性を付与（ページ名でメール件名テンプレートが自動設定される）
- 全ページのフッターから「ログイン」リンクを削除し、signup CTA に集約
- フッター「リンク」列のリンク構成を統一: 料金プラン / GitHub / お問い合わせ / Sponsor

### 変更対象ファイル

| ファイル | data-contact-context | contact.js | ログイン削除 |
|---------|---------------------|-----------|------------|
| `site/index.html` | `トップページ` (新規追加) | 既存 | 削除 |
| `site/pricing.html` | `料金プラン` (新規追加) | **新規追加** | 削除 |
| `site/privacy.html` | `プライバシーポリシー` (新規追加) | 既存 | 削除 |
| `site/sla.html` | `SLA` (新規追加) | 既存 | 削除 |
| `site/terms.html` | `利用規約` (新規追加) | 既存 | 削除 |
| `site/tokushoho.html` | `特定商取引法` (新規追加) | 既存 | 削除 |

Closes #1116

## Test plan

- [ ] 全 6 ページのフッターが同一のリンク構成になっていることを目視確認
- [ ] 各ページのお問い合わせリンクをクリックし、メールテンプレートに正しいページ名が入ることを確認
- [ ] pricing.html でお問い合わせリンクのメールテンプレートが動作することを確認（contact.js 読み込み追加）
- [ ] フッターに「ログイン」リンクが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)