### PR TITLE
feat: #1121 external health check monitoring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -284,6 +284,7 @@ jobs:
           -c cronSecret=${{ secrets.CRON_SECRET }}
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
           -c awsLicenseSecret=${{ secrets.AWS_LICENSE_SECRET }}
+          -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }}
 

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -67,6 +67,7 @@ new SesStack(app, `${appName}Ses`, {
 
 // OpsStack: 監視・アラート + コスト防衛 (deploy with -c opsEmail=you@example.com)
 const opsEmail = app.node.tryGetContext('opsEmail') as string | undefined;
+const discordWebhookHealth = app.node.tryGetContext('discordWebhookHealth') as string | undefined;
 new OpsStack(app, `${appName}Ops`, {
 	env,
 	description: 'Monitoring, Alerts, Budgets, Cost Management for Ganbari Quest',
@@ -74,6 +75,7 @@ new OpsStack(app, `${appName}Ops`, {
 	table: storage.table,
 	distribution: network.distribution,
 	opsEmail,
+	discordWebhookHealth,
 });
 
 app.synth();

--- a/infra/lambda/health-check/index.ts
+++ b/infra/lambda/health-check/index.ts
@@ -1,0 +1,253 @@
+/**
+ * External Health Check Prober Lambda
+ *
+ * Runs independently from the app (via EventBridge Scheduler, every 1 hour).
+ * Checks /api/health and reports failures/degradation to Discord webhook.
+ *
+ * Design:
+ * - Uses Node.js built-in https module (no dependencies)
+ * - Notifies Discord only on failure/degraded (v1: no state tracking)
+ * - Timeout: 10s per check, 30s total Lambda timeout
+ */
+
+import * as https from 'node:https';
+import * as http from 'node:http';
+
+// ----------------------------------------------------------------
+// Types
+// ----------------------------------------------------------------
+
+interface HealthCheckResult {
+	endpoint: string;
+	status: 'ok' | 'degraded' | 'down';
+	responseTimeMs: number;
+	statusCode?: number;
+	error?: string;
+}
+
+interface OverallStatus {
+	status: 'normal' | 'degraded' | 'down';
+	checks: HealthCheckResult[];
+	timestamp: string;
+}
+
+// ----------------------------------------------------------------
+// Configuration
+// ----------------------------------------------------------------
+
+const HEALTH_CHECK_URL = process.env.HEALTH_CHECK_URL ?? 'https://ganbari-quest.com';
+const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_HEALTH ?? '';
+const REQUEST_TIMEOUT_MS = 10_000;
+const DEGRADED_THRESHOLD_MS = 3_000;
+
+// ----------------------------------------------------------------
+// Handler
+// ----------------------------------------------------------------
+
+export async function handler(): Promise<OverallStatus> {
+	const timestamp = new Date().toISOString();
+
+	const healthCheck = await checkEndpoint(`${HEALTH_CHECK_URL}/api/health`);
+
+	const checks = [healthCheck];
+
+	// Determine overall status
+	const hasDown = checks.some((c) => c.status === 'down');
+	const hasDegraded = checks.some((c) => c.status === 'degraded');
+
+	let overallStatus: OverallStatus['status'];
+	if (hasDown) {
+		overallStatus = 'down';
+	} else if (hasDegraded) {
+		overallStatus = 'degraded';
+	} else {
+		overallStatus = 'normal';
+	}
+
+	const result: OverallStatus = {
+		status: overallStatus,
+		checks,
+		timestamp,
+	};
+
+	// v1: Only notify Discord on failure/degraded (skip success to avoid noise)
+	if (overallStatus !== 'normal') {
+		await notifyDiscord(result);
+	}
+
+	// Always log result for CloudWatch
+	console.log(JSON.stringify(result));
+
+	return result;
+}
+
+// ----------------------------------------------------------------
+// Health Check
+// ----------------------------------------------------------------
+
+async function checkEndpoint(url: string): Promise<HealthCheckResult> {
+	const start = Date.now();
+
+	try {
+		const { statusCode } = await httpGet(url, REQUEST_TIMEOUT_MS);
+		const responseTimeMs = Date.now() - start;
+
+		if (statusCode !== 200) {
+			return {
+				endpoint: url,
+				status: 'down',
+				responseTimeMs,
+				statusCode,
+				error: `Unexpected status code: ${statusCode}`,
+			};
+		}
+
+		if (responseTimeMs > DEGRADED_THRESHOLD_MS) {
+			return {
+				endpoint: url,
+				status: 'degraded',
+				responseTimeMs,
+				statusCode,
+			};
+		}
+
+		return {
+			endpoint: url,
+			status: 'ok',
+			responseTimeMs,
+			statusCode,
+		};
+	} catch (err) {
+		const responseTimeMs = Date.now() - start;
+		const errorMessage = err instanceof Error ? err.message : String(err);
+
+		return {
+			endpoint: url,
+			status: 'down',
+			responseTimeMs,
+			error: errorMessage,
+		};
+	}
+}
+
+// ----------------------------------------------------------------
+// HTTP client (built-in, no dependencies)
+// ----------------------------------------------------------------
+
+function httpGet(
+	url: string,
+	timeoutMs: number,
+): Promise<{ statusCode: number; body: string }> {
+	return new Promise((resolve, reject) => {
+		const client = url.startsWith('https') ? https : http;
+
+		const req = client.get(url, { timeout: timeoutMs }, (res) => {
+			let body = '';
+			res.on('data', (chunk: Buffer) => {
+				body += chunk.toString();
+			});
+			res.on('end', () => {
+				resolve({ statusCode: res.statusCode ?? 0, body });
+			});
+		});
+
+		req.on('timeout', () => {
+			req.destroy();
+			reject(new Error(`Request timed out after ${timeoutMs}ms`));
+		});
+
+		req.on('error', (err) => {
+			reject(err);
+		});
+	});
+}
+
+// ----------------------------------------------------------------
+// Discord Notification
+// ----------------------------------------------------------------
+
+async function notifyDiscord(result: OverallStatus): Promise<void> {
+	if (!DISCORD_WEBHOOK_URL) {
+		console.log('DISCORD_WEBHOOK_HEALTH not set, skipping notification');
+		return;
+	}
+
+	const statusEmoji = result.status === 'down' ? '\u{1F534}' : '\u{1F7E1}'; // Red or Yellow circle
+	const statusLabel = result.status === 'down' ? 'down' : 'degraded';
+
+	const checkDetails = result.checks
+		.map((c) => {
+			if (c.status === 'ok') {
+				return `\u{1F7E2} ${c.endpoint} | ${c.responseTimeMs}ms`;
+			}
+			if (c.status === 'degraded') {
+				return `\u{1F7E1} ${c.endpoint} | ${c.responseTimeMs}ms (slow)`;
+			}
+			return `\u{1F534} ${c.endpoint} | ${c.error ?? `HTTP ${c.statusCode}`}`;
+		})
+		.join('\n');
+
+	const embed = {
+		title: `${statusEmoji} Health Check: ${statusLabel}`,
+		description: checkDetails,
+		color: result.status === 'down' ? 0xff0000 : 0xffcc00,
+		fields: [
+			{
+				name: 'Timestamp',
+				value: result.timestamp,
+				inline: true,
+			},
+		],
+		timestamp: result.timestamp,
+	};
+
+	try {
+		const payload = JSON.stringify({ embeds: [embed] });
+
+		await new Promise<void>((resolve, reject) => {
+			const url = new URL(DISCORD_WEBHOOK_URL);
+			const options: https.RequestOptions = {
+				hostname: url.hostname,
+				port: 443,
+				path: url.pathname + url.search,
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Content-Length': Buffer.byteLength(payload),
+				},
+				timeout: 5_000,
+			};
+
+			const req = https.request(options, (res) => {
+				let body = '';
+				res.on('data', (chunk: Buffer) => {
+					body += chunk.toString();
+				});
+				res.on('end', () => {
+					if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+						resolve();
+					} else {
+						console.error('Discord webhook failed:', res.statusCode, body);
+						resolve(); // Don't fail the Lambda on notification failure
+					}
+				});
+			});
+
+			req.on('timeout', () => {
+				req.destroy();
+				console.error('Discord webhook timed out');
+				resolve();
+			});
+
+			req.on('error', (err) => {
+				console.error('Discord webhook error:', err);
+				resolve(); // Don't fail the Lambda on notification failure
+			});
+
+			req.write(payload);
+			req.end();
+		});
+	} catch (e) {
+		console.error('Discord notification error:', e);
+	}
+}

--- a/infra/lambda/health-check/index.ts
+++ b/infra/lambda/health-check/index.ts
@@ -10,8 +10,8 @@
  * - Timeout: 10s per check, 30s total Lambda timeout
  */
 
-import * as https from 'node:https';
 import * as http from 'node:http';
+import * as https from 'node:https';
 
 // ----------------------------------------------------------------
 // Types
@@ -134,10 +134,7 @@ async function checkEndpoint(url: string): Promise<HealthCheckResult> {
 // HTTP client (built-in, no dependencies)
 // ----------------------------------------------------------------
 
-function httpGet(
-	url: string,
-	timeoutMs: number,
-): Promise<{ statusCode: number; body: string }> {
+function httpGet(url: string, timeoutMs: number): Promise<{ statusCode: number; body: string }> {
 	return new Promise((resolve, reject) => {
 		const client = url.startsWith('https') ? https : http;
 

--- a/infra/lib/ops-stack.ts
+++ b/infra/lib/ops-stack.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import * as cdk from 'aws-cdk-lib';
 import * as budgets from 'aws-cdk-lib/aws-budgets';
 import type * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
@@ -6,7 +7,9 @@ import * as cw_actions from 'aws-cdk-lib/aws-cloudwatch-actions';
 import type * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as events from 'aws-cdk-lib/aws-events';
 import * as events_targets from 'aws-cdk-lib/aws-events-targets';
-import type * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as lambdaNode from 'aws-cdk-lib/aws-lambda-nodejs';
+import * as logs from 'aws-cdk-lib/aws-logs';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
 import type { Construct } from 'constructs';
@@ -16,6 +19,7 @@ export interface OpsStackProps extends cdk.StackProps {
 	table: dynamodb.TableV2;
 	distribution: cloudfront.Distribution;
 	opsEmail?: string;
+	discordWebhookHealth?: string;
 }
 
 export class OpsStack extends cdk.Stack {
@@ -359,11 +363,57 @@ export class OpsStack extends cdk.Stack {
 		});
 
 		// ================================================================
+		// 7. External Health Check Prober (#1121)
+		// Separate Lambda that pings /api/health every 1 hour.
+		// Reports failures/degradation to Discord webhook.
+		// ================================================================
+		const discordWebhookHealth =
+			props.discordWebhookHealth ??
+			(this.node.tryGetContext('discordWebhookHealth') as string | undefined) ??
+			'';
+
+		const healthCheckLogGroup = new logs.LogGroup(this, 'HealthCheckLogGroup', {
+			logGroupName: '/aws/lambda/ganbari-quest-health-check',
+			retention: logs.RetentionDays.THREE_DAYS,
+			removalPolicy: cdk.RemovalPolicy.DESTROY,
+		});
+
+		const healthCheckFn = new lambdaNode.NodejsFunction(this, 'HealthCheckFn', {
+			functionName: 'ganbari-quest-health-check',
+			entry: path.join(__dirname, '..', 'lambda', 'health-check', 'index.ts'),
+			handler: 'handler',
+			runtime: lambda.Runtime.NODEJS_20_X,
+			architecture: lambda.Architecture.ARM_64,
+			memorySize: 128,
+			timeout: cdk.Duration.seconds(30),
+			environment: {
+				HEALTH_CHECK_URL: 'https://ganbari-quest.com',
+				...(discordWebhookHealth ? { DISCORD_WEBHOOK_HEALTH: discordWebhookHealth } : {}),
+			},
+			bundling: {
+				minify: true,
+				sourceMap: false,
+			},
+		});
+		healthCheckFn.node.addDependency(healthCheckLogGroup);
+
+		// EventBridge Rule: trigger every 1 hour
+		new events.Rule(this, 'HealthCheckSchedule', {
+			ruleName: 'ganbari-quest-health-check',
+			description: 'External health check prober: 1時間ごとに /api/health を確認',
+			schedule: events.Schedule.rate(cdk.Duration.hours(1)),
+			targets: [new events_targets.LambdaFunction(healthCheckFn)],
+		});
+
+		// ================================================================
 		// Outputs
 		// ================================================================
 		new cdk.CfnOutput(this, 'OpsTopicArn', { value: opsTopic.topicArn });
 		new cdk.CfnOutput(this, 'DashboardUrl', {
 			value: `https://${this.region}.console.aws.amazon.com/cloudwatch/home?region=${this.region}#dashboards:name=ganbari-quest-ops`,
+		});
+		new cdk.CfnOutput(this, 'HealthCheckFunctionArn', {
+			value: healthCheckFn.functionArn,
 		});
 	}
 }

--- a/scripts/add-benchmarks.cjs
+++ b/scripts/add-benchmarks.cjs
@@ -9,7 +9,7 @@
 // 3〜12歳のベンチマークデータを投入する。
 
 const Database = require('better-sqlite3');
-const path = require('path');
+const path = require('node:path');
 
 const dbPath = process.argv[2] || path.join(__dirname, '..', 'data', 'ganbari-quest.db');
 console.log(`DB: ${dbPath}`);


### PR DESCRIPTION
## Summary
- Add external health check prober Lambda that monitors `/api/health` every 1 hour
- Separate from the app Lambda so it can detect when the app itself is down
- Reports failures/degradation to Discord webhook (success is silent to avoid noise)

## Architecture
- **Lambda**: `ganbari-quest-health-check` (Node.js 20.x, ARM64, 128MB, 30s timeout)
- **EventBridge Rule**: triggers every 1 hour
- **Discord Webhook**: notifies on `degraded` (response > 3000ms) or `down` (non-200 / timeout)
- **Log Group**: 3-day retention, same pattern as app Lambda

## Changes
| File | Description |
|------|-------------|
| `infra/lambda/health-check/index.ts` | Health check prober Lambda (no external dependencies, uses built-in `https` module) |
| `infra/lib/ops-stack.ts` | CDK resources: Lambda, EventBridge schedule, CloudWatch log group |
| `infra/bin/app.ts` | Pass `discordWebhookHealth` context to OpsStack |
| `.github/workflows/deploy.yml` | Pass `DISCORD_WEBHOOK_HEALTH` secret to CDK deploy |

## PO action required
```bash
gh secret set DISCORD_WEBHOOK_HEALTH --body "<webhook-url>" --repo Takenori-Kusaka/ganbari-quest
```

## Test plan
- [ ] CDK synth produces valid CloudFormation template
- [ ] Lambda function deploys successfully
- [ ] EventBridge rule triggers Lambda every hour
- [ ] Discord notification fires when app is down/degraded
- [ ] No notification when app is healthy (confirmed via CloudWatch logs)

Closes #1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)