### PR TITLE
fix: #1124 upgrade-flow E2E の strict mode violation を修正

### DIFF
--- a/src/routes/(parent)/admin/license/+page.svelte
+++ b/src/routes/(parent)/admin/license/+page.svelte
@@ -661,6 +661,7 @@ async function openPortal() {
 					class:selected={selectedTier === 'standard'}
 					role="button"
 					tabindex="0"
+					data-testid="standard-plan-card"
 					onclick={() => (selectedTier = 'standard')}
 					onkeydown={(e) => e.key === 'Enter' && (selectedTier = 'standard')}
 				>
@@ -689,6 +690,7 @@ async function openPortal() {
 					class:recommended={true}
 					role="button"
 					tabindex="0"
+					data-testid="family-plan-card"
 					onclick={() => (selectedTier = 'family')}
 					onkeydown={(e) => e.key === 'Enter' && (selectedTier = 'family')}
 				>

--- a/tests/e2e/upgrade-flow.spec.ts
+++ b/tests/e2e/upgrade-flow.spec.ts
@@ -228,8 +228,8 @@ test.describe('#753 /admin/license プラン選択 UI', () => {
 		// Stripe 有効環境ではプラン選択カードが表示される。
 		// どちらかが必ず表示されることを検証する。
 		const preparingText = page.getByText('決済機能は現在準備中です');
-		const standardText = page.getByText('スタンダード');
-		const preparingOrPlanCard = preparingText.or(standardText);
+		const standardPlanCard = page.getByTestId('standard-plan-card');
+		const preparingOrPlanCard = preparingText.or(standardPlanCard);
 		await expect(preparingOrPlanCard).toBeVisible({ timeout: 30_000 });
 
 		const preparingCount = await preparingText.count();
@@ -242,8 +242,8 @@ test.describe('#753 /admin/license プラン選択 UI', () => {
 		}
 
 		// Stripe 有効環境: スタンダード / ファミリーの選択カードが表示される
-		await expect(standardText).toBeVisible();
-		await expect(page.getByText('ファミリー')).toBeVisible();
+		await expect(standardPlanCard).toBeVisible();
+		await expect(page.getByTestId('family-plan-card')).toBeVisible();
 
 		// 月額 / 年額の切り替えがある
 		await expect(page.getByText('月額')).toBeVisible();


### PR DESCRIPTION
## Summary
- `getByText('スタンダード')` が `/admin/license` 画面で複数要素にマッチし Playwright strict mode violation を起こしていた問題を修正
- プランカードに `data-testid="standard-plan-card"` / `"family-plan-card"` を追加
- E2E テストを `getByTestId` に変更し一意にマッチさせる

## Root Cause
free ユーザーが `/admin/license` にアクセスすると「スタンダード」を含むテキストが4箇所に表示される:
1. プランカード見出し `<p>スタンダード</p>`
2. PlanStatusCard CTA `⭐ スタンダードにアップグレード`
3. チェックアウトボタン `スタンダードプランで始める`
4. その他のプラン説明テキスト

`getByText('スタンダード')` は部分一致のため全てにマッチし strict mode violation。

## Test plan
- [x] `npx biome check` — lint エラーなし（既存 warn のみ）
- [x] `npx svelte-check` — 0 ERRORS
- [x] `npx vitest run` — 3479 テスト全通過
- [ ] CI E2E（upgrade-flow.spec.ts）で strict mode violation が解消されること

Closes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)