### PR TITLE
fix: #1084 API認可失敗時にリダイレクトではなくJSON 401/403を返す

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -316,6 +316,15 @@ export const handle: Handle = ({ event, resolve }) =>
 		// 認可チェック（Provider 固有のルート保護）
 		const authResult = provider.authorize(path, identity, context);
 		if (!authResult.allowed) {
+			if (path.startsWith('/api/')) {
+				const status = authResult.status ?? 401;
+				return new Response(
+					JSON.stringify({
+						error: status === 403 ? 'アクセスが拒否されました' : '認証が必要です',
+					}),
+					{ status, headers: { 'Content-Type': 'application/json' } },
+				);
+			}
 			redirect(302, authResult.redirect);
 		}
 


### PR DESCRIPTION
## Summary

- `hooks.server.ts` の `authorize()` 失敗時、全パスに対して `redirect(302, '/auth/login')` を実行していたのが根本原因
- `/api/*` パスへの未認証リクエストがログインページへリダイレクト → Playwright の `request` がフォロー → 200 (HTML) が返る
- テストは 400/401 を期待 → deploy.yml の test-cognito で account-deletion.spec.ts 11テストが失敗
- API パスには `grace_period` / `terminated` と同じパターンで JSON エラーレスポンス (401/403) を返すように修正

### 根本原因の詳細

1. `authorizeCognito()` は未認証リクエストに `{ allowed: false, redirect: '/auth/login', status: 401 }` を正しく返す
2. `hooks.server.ts:319` が `status` フィールドを無視し、常に `redirect(302, authResult.redirect)` を実行
3. Playwright の `request` fixture はデフォルトで 302 をフォロー
4. 最終的にログインページの 200 OK が返り、テストの `expect(status === 400 || status === 401).toBe(true)` が失敗

## ローカル検証結果

| テスト | 結果 |
|-------|------|
| `npx biome check src/hooks.server.ts` | OK (warn 1: 既存の cognitive complexity) |
| `npx svelte-check --threshold error` | 0 errors |
| cognito-dev E2E (account-deletion) | **17/17 passed** |
| cognito-dev E2E (全テスト) | **117/117 passed** |
| 通常 E2E | **241/241 passed** (7 skipped) |

## Test plan

- [x] `CI=true AWS_LICENSE_SECRET=... npx playwright test --config playwright.cognito-dev.config.ts account-deletion` → 17/17 passed
- [x] `CI=true AWS_LICENSE_SECRET=... npx playwright test --config playwright.cognito-dev.config.ts` → 117/117 passed
- [x] `npx playwright test` → 241/241 passed
- [ ] CI (ci.yml) 全ジョブ green
- [ ] deploy.yml の test-cognito ジョブ green

closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)