### PR TITLE
fix: #1134 LP料金プランセクション重複解消

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -308,6 +308,18 @@
 .testimonial-form .form-actions{text-align:center}
 .testimonial-form .btn[disabled]{opacity:.5;cursor:not-allowed;pointer-events:none}
 
+/* Pricing summary */
+.pricing-summary{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:24px;max-width:900px;margin:0 auto 32px}
+.pricing-summary-card{background:#fff;border:1px solid var(--gray-300);border-radius:var(--radius);padding:28px 24px;text-align:center;position:relative}
+.pricing-summary-card.recommended{border:2px solid #8b5cf6;box-shadow:0 4px 20px rgba(139,92,246,.12)}
+.pricing-summary-badge{position:absolute;top:-12px;left:50%;transform:translateX(-50%);background:#8b5cf6;color:#fff;font-size:.72rem;font-weight:700;padding:3px 14px;border-radius:2rem}
+.pricing-summary-name{font-size:1rem;font-weight:700;color:var(--gray-900);margin-bottom:8px}
+.pricing-summary-price{font-size:2rem;font-weight:800;color:var(--gray-900);margin-bottom:12px}
+.pricing-summary-unit{font-size:.85rem;font-weight:400;color:var(--gray-500)}
+.pricing-summary-desc{font-size:.85rem;color:var(--gray-500);line-height:1.6;margin:0}
+.pricing-summary-cta{text-align:center;margin-top:0}
+.pricing-summary-cta a{font-size:.9rem;color:var(--brand-700)}
+
 @media(max-width:640px){
   .hero h1{font-size:1.8rem}
   .hero-cta{flex-direction:column;align-items:center}
@@ -1156,55 +1168,30 @@
   </div>
 </section>
 
-<!-- Pricing -->
+<!-- Pricing (summary — details at pricing.html) -->
 <section class="section bg-white" id="pricing">
   <div class="section-inner">
     <h2 class="section-title">料金プラン</h2>
     <p class="section-desc">基本無料ではじめられます。ポイント・レベルアップ・シールガチャなどの冒険体験はすべてのプランで制限なし。</p>
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:24px;max-width:900px;margin:0 auto 32px">
-
-      <div style="background:#fff;border:1px solid var(--gray-300);border-radius:var(--radius);padding:28px 24px;text-align:center">
-        <div style="font-size:1rem;font-weight:700;color:var(--gray-900);margin-bottom:8px">フリー</div>
-        <div style="font-size:2rem;font-weight:800;color:var(--gray-900)">&#165;0</div>
-        <div style="font-size:.82rem;color:var(--gray-500);margin-bottom:16px">&nbsp;</div>
-        <ul style="list-style:none;padding:0;text-align:left;font-size:.85rem;color:var(--gray-700);margin-bottom:20px">
-          <li style="padding:4px 0">&#10003; 子供2人まで</li>
-          <li style="padding:4px 0">&#10003; プリセット活動の利用</li>
-          <li style="padding:4px 0">&#10003; レベル・ポイント・シールくじ</li>
-          <li style="padding:4px 0">&#10003; 90日間の履歴</li>
-        </ul>
-        <a href="https://ganbari-quest.com/auth/signup" class="btn btn-outline" style="width:100%;text-align:center">無料ではじめる</a>
+    <div class="pricing-summary">
+      <div class="pricing-summary-card">
+        <div class="pricing-summary-name">無料プラン</div>
+        <div class="pricing-summary-price">&#165;0</div>
+        <p class="pricing-summary-desc">お子さま2人まで。プリセット活動・90日間の履歴。</p>
       </div>
-
-      <div style="background:#fff;border:2px solid #8b5cf6;border-radius:var(--radius);padding:28px 24px;text-align:center;position:relative;box-shadow:0 4px 20px rgba(139,92,246,.12)">
-        <span style="position:absolute;top:-12px;left:50%;transform:translateX(-50%);background:#8b5cf6;color:#fff;font-size:.72rem;font-weight:700;padding:3px 14px;border-radius:2rem">おすすめ</span>
-        <div style="font-size:1rem;font-weight:700;color:var(--gray-900);margin-bottom:8px">スタンダード</div>
-        <div style="font-size:2rem;font-weight:800;color:var(--gray-900)">&#165;500<span style="font-size:.85rem;font-weight:400;color:var(--gray-500)">/月〜</span></div>
-        <div style="font-size:.82rem;color:var(--gray-500);margin-bottom:16px">年額 &#165;5,000（2ヶ月分お得）</div>
-        <ul style="list-style:none;padding:0;text-align:left;font-size:.85rem;color:var(--gray-700);margin-bottom:20px">
-          <li style="padding:4px 0">&#10003; お子さまの登録人数：無制限</li>
-          <li style="padding:4px 0">&#10003; オリジナル活動の作成：無制限</li>
-          <li style="padding:4px 0">&#10003; チェックリスト自由作成（無制限）</li>
-          <li style="padding:4px 0">&#10003; データのダウンロード</li>
-        </ul>
-        <a href="https://ganbari-quest.com/auth/signup?plan=standard" class="btn btn-primary" style="width:100%;text-align:center;background:linear-gradient(135deg,#7c3aed,#8b5cf6);box-shadow:0 2px 8px rgba(139,92,246,.3)">7日間 無料体験</a>
+      <div class="pricing-summary-card recommended">
+        <span class="pricing-summary-badge">おすすめ</span>
+        <div class="pricing-summary-name">スタンダード</div>
+        <div class="pricing-summary-price">&#165;500<span class="pricing-summary-unit">/月〜</span></div>
+        <p class="pricing-summary-desc">お子さま無制限。オリジナル活動・1年間の履歴。</p>
       </div>
-
-      <div style="background:#fff;border:1px solid var(--gray-300);border-radius:var(--radius);padding:28px 24px;text-align:center">
-        <div style="font-size:1rem;font-weight:700;color:var(--gray-900);margin-bottom:8px">ファミリー</div>
-        <div style="font-size:2rem;font-weight:800;color:var(--gray-900)">&#165;780<span style="font-size:.85rem;font-weight:400;color:var(--gray-500)">/月〜</span></div>
-        <div style="font-size:.82rem;color:var(--gray-500);margin-bottom:16px">年額 &#165;7,800（2ヶ月分お得）</div>
-        <ul style="list-style:none;padding:0;text-align:left;font-size:.85rem;color:var(--gray-700);margin-bottom:20px">
-          <li style="padding:4px 0">&#10003; スタンダードの全機能</li>
-          <li style="padding:4px 0">&#10003; ✨ AI 自動提案（活動・ごほうび・チェックリスト）</li>
-          <li style="padding:4px 0">&#10003; きょうだいランキング</li>
-          <li style="padding:4px 0">&#10003; 無制限の履歴保持</li>
-        </ul>
-        <a href="https://ganbari-quest.com/auth/signup?plan=family" class="btn btn-primary" style="width:100%;text-align:center;background:linear-gradient(135deg,#7c3aed,#8b5cf6);box-shadow:0 2px 8px rgba(139,92,246,.3)">7日間 無料体験</a>
+      <div class="pricing-summary-card">
+        <div class="pricing-summary-name">ファミリー</div>
+        <div class="pricing-summary-price">&#165;780<span class="pricing-summary-unit">/月〜</span></div>
+        <p class="pricing-summary-desc">スタンダードの全機能 + AI 自動提案・無制限の履歴。</p>
       </div>
-
     </div>
-    <p style="text-align:center"><a href="pricing.html" style="font-size:.9rem;color:var(--brand-700)">詳しい機能比較を見る &#8594;</a></p>
+    <p class="pricing-summary-cta"><a href="pricing.html">全プランの機能比較・無料体験の詳細を見る &#8594;</a></p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- LP `index.html` の料金プランセクション（50行超のインラインスタイル付きカード3枚）をCSSクラスベースのサマリーカードに統合
- 各プランの詳細機能リスト・個別CTAを削除し、`pricing.html` への導線に一本化
- インラインスタイルをすべて `.pricing-summary*` CSSクラスに移行（ESLint `svelte/no-inline-styles` 方針準拠）

## 変更内容
- 旧: 3プラン×詳細リスト（各プラン5-6行の機能一覧＋個別CTA）= ~50行のインラインスタイル付きHTML
- 新: 3プラン×サマリーカード（プラン名・価格・1行説明）+ pricing.html リンク = ~20行のクリーンなHTML

## Test plan
- [ ] `node scripts/check-site-html.mjs` 通過確認済み
- [ ] LP pricing セクションの表示確認（3カード横並び、おすすめバッジ表示）
- [ ] モバイル表示確認（カードの縦積み）
- [ ] 「全プランの機能比較・無料体験の詳細を見る →」リンクが pricing.html に遷移

Closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)