### PR TITLE
fix: #1130 LP 年齢モード/活動パックのアイコン統一・性別表示

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -710,7 +710,7 @@
     <p class="section-desc">年齢に合わせた活動セットをワンタップでインポート。<br>何を登録すればいいか迷いません。</p>
     <div class="pack-grid">
       <div class="pack-card">
-        <div class="pack-icon">&#x1F37C;</div>
+        <div class="pack-icon">&#x1F476;</div>
         <h3>はじめてのぼうけん</h3>
         <div class="pack-age">0&#x301C;2歳向け &#x30FB; 15件の活動</div>
         <p>赤ちゃんの生活習慣と基本的な運動を中心に、毎日の小さな成長を記録できます。</p>
@@ -745,7 +745,7 @@
         </details>
       </div>
       <div class="pack-card">
-        <div class="pack-icon">&#x1F3A8;</div>
+        <div class="pack-icon">&#x1F9D2;</div>
         <h3>ようじキッズ</h3>
         <div class="pack-age">3&#x301C;5歳向け &#x30FB; 20件の活動</div>
         <p>保育園・幼稚園の日常活動をバランスよくカバーし、自立心を育てます。</p>
@@ -753,6 +753,7 @@
           <span class="pack-tag">初心者向け</span>
           <span class="pack-tag">幼児</span>
           <span class="pack-tag">バランス型</span>
+          <span class="pack-tag">&#x1F466;&#x1F467; 性別バリエーション</span>
         </div>
         <div class="pack-activities">
           <span class="pack-activity">&#x1FAA5; はみがきした</span>
@@ -785,7 +786,7 @@
         </details>
       </div>
       <div class="pack-card">
-        <div class="pack-icon">&#x1F4DA;</div>
+        <div class="pack-icon">&#x1F466;</div>
         <h3>しょうがくせいチャレンジ</h3>
         <div class="pack-age">6&#x301C;9歳向け &#x30FB; 16件の活動</div>
         <p>学習習慣・運動・お手伝いをバランスよく組み合わせ、自主性を育てます。</p>
@@ -793,6 +794,7 @@
           <span class="pack-tag">小学生</span>
           <span class="pack-tag">学習</span>
           <span class="pack-tag">自立</span>
+          <span class="pack-tag">&#x1F466;&#x1F467; 性別バリエーション</span>
         </div>
         <div class="pack-activities">
           <span class="pack-activity">&#x1F4DD; しゅくだいをした</span>
@@ -856,7 +858,7 @@
         </details>
       </div>
       <div class="pack-card">
-        <div class="pack-icon">&#x1F3AF;</div>
+        <div class="pack-icon">&#x1F9D1;&#x200D;&#x1F393;</div>
         <h3>中学生チャレンジ</h3>
         <div class="pack-age">10&#x301C;14歳向け &#x30FB; 16件の活動</div>
         <p>学習・自己管理・社会性をバランスよく組み合わせ、自律心を育てます。</p>
@@ -864,6 +866,7 @@
           <span class="pack-tag">中学生</span>
           <span class="pack-tag">自律</span>
           <span class="pack-tag">学習習慣</span>
+          <span class="pack-tag">&#x1F466;&#x1F467; 性別バリエーション</span>
         </div>
         <div class="pack-activities">
           <span class="pack-activity">&#x1F4DD; 予習・復習した</span>
@@ -892,7 +895,7 @@
         </details>
       </div>
       <div class="pack-card">
-        <div class="pack-icon">&#x1F393;</div>
+        <div class="pack-icon">&#x1F9D1;&#x200D;&#x1F4BB;</div>
         <h3>高校生チャレンジ</h3>
         <div class="pack-age">15&#x301C;18歳向け &#x30FB; 16件の活動</div>
         <p>進路準備・自立スキル・キャリアを意識した活動で、社会に出る準備を支援します。</p>
@@ -900,6 +903,7 @@
           <span class="pack-tag">高校生</span>
           <span class="pack-tag">進路</span>
           <span class="pack-tag">自立</span>
+          <span class="pack-tag">&#x1F466;&#x1F467; 性別バリエーション</span>
         </div>
         <div class="pack-activities">
           <span class="pack-activity">&#x1F4DD; 受験勉強・自主学習した</span>


### PR DESCRIPTION
## Summary
- 活動パックカードのアイコンを年齢モードセクションと統一（5パックの1:1対応）
- 年齢別パックカードに「👦👧 性別バリエーション」タグを視覚的に追加（4パック）
- クロスエイジの「おてつだいマスター」(4-10歳)は💪アイコンを維持（テーマ別のため）

### アイコン対応表
| 年齢帯 | 年齢モード | 活動パック（修正前→後） |
|--------|----------|----------------------|
| 0-2歳 | 👶 | 🍼→👶 |
| 3-5歳 | 🧒 | 🎨→🧒 |
| 6-12歳 | 👦 | 📚→👦 |
| 13-15歳 | 🧑‍🎓 | 🎯→🧑‍🎓 |
| 16-18歳 | 🧑‍💻 | 🎓→🧑‍💻 |

## AC 突合
- [x] 年齢モードセクションと活動パックセクションの間で、同じ年齢帯を示すアイコンに一貫性がある
- [x] 活動パックカードに性別バリエーションの存在が視覚的に示される（文言だけでなくタグで表示）
- [x] 年齢モード→活動パックへの視覚的な対応関係が明確

## Test plan
- [ ] `node scripts/check-site-html.mjs` 通過確認済み
- [ ] 年齢モードセクションと活動パックセクションのアイコンが一致していることを目視確認
- [ ] 性別バリエーションタグが4パック（ようじ/しょうがくせい/中学生/高校生）に表示
- [ ] おてつだいマスターは💪のまま（テーマ別パックの識別）

Closes #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)