### PR TITLE
fix: #1151 screenshot-check CI を site/** 対応に拡張

### DIFF
--- a/.github/workflows/pr-ui-check.yml
+++ b/.github/workflows/pr-ui-check.yml
@@ -24,6 +24,15 @@ on:
       - "src/lib/features/**/*.scss"
       - "src/app.css"
       - "src/app.html"
+      # LP (site/**) — 静的 HTML/CSS/JS/画像のビジュアル変更
+      - "site/**/*.html"
+      - "site/**/*.css"
+      - "site/**/*.js"
+      - "site/**/*.svg"
+      - "site/**/*.png"
+      - "site/**/*.jpg"
+      - "site/**/*.jpeg"
+      - "site/**/*.webp"
 
 permissions:
   contents: read
@@ -54,7 +63,7 @@ jobs:
                   '1. PR本文の「スクリーンショット / ビジュアルデモ」セクションに画像を貼り付け',
                   '2. Playwrightで取得したスクリーンショットを添付',
                   '',
-                  '対象ファイル: src/routes/**, src/lib/ui/**, src/lib/features/**',
+                  '対象ファイル: src/routes/**, src/lib/ui/**, src/lib/features/**, site/**',
                   '',
                   'このチェックはUI関連ファイルを変更したPRでのみ実行されます。',
                   'Draft PRではスキップされます。Ready for Review に変更する前に添付してください。',


### PR DESCRIPTION
## Summary
- `.github/workflows/pr-ui-check.yml` の `paths` に `site/**` 系 (html/css/js/svg/png/jpg/jpeg/webp) を追加
- 失敗時メッセージの対象ファイル一覧にも `site/**` を追記

## 背景・根本原因
2026-04-18 に以下 5 つの LP 変更 PR が **スクリーンショット証跡なしでマージ** された:
- #1138 / #1140 / #1141 / #1142 / #1143 / #1144

全て `site/**` の変更を含むが、`screenshot-check` ジョブの paths が
`src/routes/**` 系と `src/lib/**` 系にしか反応せず、LP 変更 PR では
ジョブが発火しないため素通りしていた。

## AC 突合 (#1151)
- [x] paths に `site/**` 系 (html/css/js/画像) が追加されている
- [x] 失敗メッセージにも `site/**` が入り、次回の開発者がスコープを認識できる
- [ ] 新規 PR で `site/index.html` のみを変更した場合、screenshot-check ジョブが発火することを CI で確認（本 PR 自体は `.github/workflows/**` のみの変更なので発火しない。次の LP 変更 PR (#1147 Phase 1) で実地確認する）

## Test plan
- [x] YAML 構文破壊なし（paths 追記のみ）
- [ ] 本 PR マージ後、次の LP 変更 PR で screenshot-check が発火することを確認

## スクリーンショット / ビジュアルデモ
CI workflow 設定変更のみ、ビジュアル変更なし。screenshot-check ジョブ自体も本 PR では発火しない（paths 不一致）。

Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)