### PR TITLE
feat: #1202 P1 Typed Config Object (ADR-0040)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       - name: No plan/status literal direct write check (#972)
         run: node scripts/check-no-plan-literals.mjs
 
+      - name: No direct process.env access check (#1202 / ADR-0040 P1)
+        run: node scripts/check-no-direct-env-access.mjs
+
       - name: DynamoDB stub/no-op implementation check (#1021 / ADR-0034)
         run: node scripts/check-dynamodb-stub.mjs
 

--- a/scripts/check-no-direct-env-access.mjs
+++ b/scripts/check-no-direct-env-access.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-no-direct-env-access.mjs (ADR-0040 P1)
+ *
+ * `process.env.X` の直接参照を検出する。唯一の読込点は
+ * `src/lib/runtime/env.ts` のみ。新規ファイル / grandfather 外のファイルに
+ * 直接参照が入ったら CI を fail させる。
+ *
+ * 設計:
+ *  - grandfather list = ADR-0040 採択時点 (2026-04-19) に既に process.env を
+ *    直接参照していた 35 ファイル。P2-P4 で段階的に `$lib/runtime/env` 経由へ
+ *    移行する
+ *  - 新規ファイル追加時は即時 fail
+ *  - grandfather ファイルの「新しい env 追加」は静的に検出しづらいため、
+ *    レビュアー責任 + `check-new-required-env.mjs` (ADR-0029) で補完
+ *
+ * 使用法: node scripts/check-no-direct-env-access.mjs
+ * CI: エラー検出時は exit 1
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+/** 唯一の読込点 (ADR-0040 P1) */
+const SSOT = 'src/lib/runtime/env.ts';
+
+/**
+ * Grandfather list: ADR-0040 採択時 (2026-04-19) に既に process.env を直接参照
+ * していたファイル。P2-P4 で `$lib/runtime/env` 経由へ段階的に移行する。
+ *
+ * このリストは P4 完了時にゼロになる予定。新規追加は禁止（レビュアーが reject）。
+ */
+const GRANDFATHER = new Set(
+	[
+		'src/hooks.server.ts',
+		'src/lib/analytics/providers/dynamo.ts',
+		'src/lib/analytics/providers/sentry.ts',
+		'src/lib/analytics/providers/umami.ts',
+		'src/lib/server/ai/bedrock-claude-provider.ts',
+		'src/lib/server/ai/factory.ts',
+		'src/lib/server/ai/gemini-provider.ts',
+		'src/lib/server/auth/cron-auth.ts',
+		'src/lib/server/auth/context-token.ts',
+		'src/lib/server/auth/factory.ts',
+		'src/lib/server/auth/providers/cognito-direct-auth.ts',
+		'src/lib/server/auth/providers/cognito-jwt.ts',
+		'src/lib/server/auth/providers/cognito-oauth.ts',
+		'src/lib/server/cookie-config.ts',
+		'src/lib/server/db/client.ts',
+		'src/lib/server/db/dynamodb/client.ts',
+		'src/lib/server/db/dynamodb/storage-repo.ts',
+		'src/lib/server/db/factory.ts',
+		'src/lib/server/db/seed.ts',
+		'src/lib/server/debug-plan.ts',
+		'src/lib/server/logger.ts',
+		'src/lib/server/services/account-deletion-service.ts',
+		'src/lib/server/services/breakeven-service.ts',
+		'src/lib/server/services/email-service.ts',
+		'src/lib/server/services/image-service.ts',
+		'src/lib/server/services/license-key-service.ts',
+		'src/lib/server/services/notification-service.ts',
+		'src/lib/server/services/stripe-metrics-service.ts',
+		'src/lib/server/services/umami-service.ts',
+		'src/lib/server/stripe/client.ts',
+		'src/lib/server/stripe/config.ts',
+		'src/routes/api/cron/license-expire/+server.ts',
+		'src/routes/api/health/+server.ts',
+		'src/routes/api/v1/admin/tenant-cleanup/+server.ts',
+		'src/routes/api/v1/settings/vapid-key/+server.ts',
+	].map((p) => p.replace(/\//g, path.sep)),
+);
+
+/** 検査対象ディレクトリ / 拡張子 */
+const SEARCH_ROOTS = ['src'];
+const EXTENSIONS = new Set(['.ts', '.svelte']);
+
+/** 除外 (定義上 process.env を参照しても問題ないもの) */
+const EXCLUDE_PATTERNS = [/\.test\.ts$/, /\.spec\.ts$/];
+
+/** 検出パターン */
+const ENV_REGEX = /\bprocess\.env\.[A-Z][A-Z0-9_]*/;
+
+function shouldExclude(absFile) {
+	const rel = path.relative(REPO_ROOT, absFile);
+	if (rel.replace(/\\/g, '/') === SSOT) return true;
+	return EXCLUDE_PATTERNS.some((p) => p.test(rel));
+}
+
+function walk(dir, out = []) {
+	if (!fs.existsSync(dir)) return out;
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) walk(full, out);
+		else if (entry.isFile() && EXTENSIONS.has(path.extname(entry.name))) {
+			if (!shouldExclude(full)) out.push(full);
+		}
+	}
+	return out;
+}
+
+function checkFile(absFile) {
+	const rel = path.relative(REPO_ROOT, absFile);
+	if (GRANDFATHER.has(rel)) return null; // allowed for now
+	const text = fs.readFileSync(absFile, 'utf8');
+	const lines = text.split(/\r?\n/);
+	const hits = [];
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		// block comments / line comments で import 例示などは許す
+		if (/^\s*\/\//.test(line) || /^\s*\*/.test(line)) continue;
+		const m = line.match(ENV_REGEX);
+		if (m) {
+			hits.push({ line: i + 1, match: m[0], snippet: line.trim().slice(0, 120) });
+		}
+	}
+	if (hits.length === 0) return null;
+	return { file: rel.replace(/\\/g, '/'), hits };
+}
+
+function main() {
+	const files = [];
+	for (const root of SEARCH_ROOTS) {
+		walk(path.join(REPO_ROOT, root), files);
+	}
+	const violations = [];
+	for (const f of files) {
+		const r = checkFile(f);
+		if (r) violations.push(r);
+	}
+	if (violations.length === 0) {
+		console.log(
+			'[check-no-direct-env-access] OK — grandfather 外のファイルに process.env 直接参照なし',
+		);
+		process.exit(0);
+	}
+	console.error(
+		`[check-no-direct-env-access] NG — ${violations.length} ファイルに新規の process.env 直接参照があります (ADR-0040):\n`,
+	);
+	for (const v of violations) {
+		console.error(`  ${v.file}`);
+		for (const h of v.hits) {
+			console.error(`    line ${h.line}: ${h.match}`);
+			console.error(`      ${h.snippet}`);
+		}
+	}
+	console.error(
+		"\n→ src/lib/runtime/env.ts 経由で参照してください:\n    import { env } from '$lib/runtime/env';\n",
+	);
+	console.error(
+		'→ 既存ファイルの grandfather 扱いは scripts/check-no-direct-env-access.mjs の GRANDFATHER を参照。',
+	);
+	console.error(
+		'→ 新しい env を schema に追加する場合は src/lib/runtime/env.ts の envSchema に追記し、必須値なら',
+	);
+	console.error('  ADR-0029 に従い PR 本文に「配布済み: <ENV>」証跡を記載してください。');
+	process.exit(1);
+}
+
+main();

--- a/src/lib/runtime/env.ts
+++ b/src/lib/runtime/env.ts
@@ -1,0 +1,161 @@
+/**
+ * Typed Config Object (ADR-0040 Phase 1)
+ *
+ * 環境変数の唯一の読込点。本ファイル以外で `process.env.X` を直接参照することは
+ * `scripts/check-no-direct-env-access.mjs` で CI 禁止される（grandfather された
+ * 既存ファイルを除く）。
+ *
+ * 設計:
+ * - Zod で型 + バリデーション。起動時に一度だけ parse し、壊れた env は即 throw
+ * - `z.string().optional()` を既定にし、必須値は `.min(N)` / `.nonempty()` で明示
+ * - `dev` 限定 env (DEBUG_*) は dev 以外で設定されていても無視される設計
+ *   （ランタイム側で `dev === true` チェックを継続）
+ * - PUBLIC_* は SvelteKit の `$env/static/public` と命名規約一致。ただし
+ *   `import.meta.env` ではなく `process.env` 経由で統一する（SSR / Lambda / Node
+ *   scripts すべてで動くため）
+ *
+ * ADR-0029 連携: 新しい required env を追加する PR は `scripts/check-new-required-env.mjs`
+ * が PR 本文の「配布済み:」証跡を強制する。本ファイルへの required 追加も同ルールの対象。
+ */
+
+import { z } from 'zod';
+
+const booleanStringSchema = z
+	.enum(['true', 'false'])
+	.transform((v) => v === 'true')
+	.optional();
+
+const envSchema = z.object({
+	// ----- Runtime mode -----
+	NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+
+	/**
+	 * アプリ実行モード（ADR-0040）。P2 で `resolveRuntimeMode()` が解釈する。
+	 * env で明示されない場合は P2 が NODE_ENV / AWS_LAMBDA_FUNCTION_NAME /
+	 * IS_NUC_DEPLOY 等から推論する。
+	 */
+	APP_MODE: z.enum(['build', 'demo', 'local-debug', 'aws-prod', 'nuc-prod']).optional(),
+
+	/** NUC 本番デプロイ判定（IS_NUC_DEPLOY=true で nuc-prod モード） */
+	IS_NUC_DEPLOY: booleanStringSchema,
+
+	/** メンテナンスモード */
+	MAINTENANCE_MODE: booleanStringSchema,
+
+	// ----- Auth -----
+	AUTH_MODE: z.enum(['local', 'cognito']).default('local'),
+	COGNITO_DEV_MODE: booleanStringSchema,
+	COGNITO_USER_POOL_ID: z.string().optional(),
+	COGNITO_CLIENT_ID: z.string().optional(),
+	COGNITO_CLIENT_SECRET: z.string().optional(),
+	COGNITO_DOMAIN: z.string().optional(),
+	COGNITO_CALLBACK_URL: z.string().url().optional(),
+	COGNITO_LOGOUT_URL: z.string().url().optional(),
+
+	// ----- AWS -----
+	AWS_REGION: z.string().default('us-east-1'),
+	AWS_LAMBDA_FUNCTION_NAME: z.string().optional(),
+	DYNAMODB_TABLE: z.string().optional(),
+	DYNAMODB_TABLE_NAME: z.string().optional(),
+	TABLE_NAME: z.string().optional(),
+	DYNAMODB_ENDPOINT: z.string().url().optional(),
+	ASSETS_BUCKET: z.string().optional(),
+
+	// ----- Database -----
+	DATABASE_URL: z.string().default('./data/ganbari-quest.db'),
+	DATA_SOURCE: z.enum(['sqlite', 'dynamodb']).default('sqlite'),
+	SCHEMA_VALIDATION_MODE: z.enum(['warn', 'strict']).optional(),
+
+	// ----- Stripe -----
+	STRIPE_SECRET_KEY: z.string().optional(),
+	STRIPE_WEBHOOK_SECRET: z.string().optional(),
+	STRIPE_PRICE_MONTHLY: z.string().optional(),
+	STRIPE_PRICE_YEARLY: z.string().optional(),
+	STRIPE_PRICE_FAMILY_MONTHLY: z.string().optional(),
+	STRIPE_PRICE_FAMILY_YEARLY: z.string().optional(),
+	STRIPE_MOCK: booleanStringSchema,
+
+	// ----- License (ADR-0026) -----
+	AWS_LICENSE_SECRET: z.string().min(32).optional(),
+	ALLOW_LEGACY_LICENSE_KEYS: booleanStringSchema,
+
+	// ----- Ops (ADR-0033) -----
+	CRON_SECRET: z.string().min(32).optional(),
+	OPS_SECRET_KEY: z.string().optional(),
+	OPS_DOMAIN_COST_JPY: z.coerce.number().int().default(117),
+	OPS_VIRTUAL_OFFICE_COST_JPY: z.coerce.number().int().default(0),
+
+	// ----- Debug (dev only, #758) -----
+	DEBUG_PLAN: z.enum(['free', 'standard', 'family']).optional(),
+	DEBUG_TRIAL: z.enum(['active', 'expired', 'not-started']).optional(),
+	DEBUG_TRIAL_TIER: z.enum(['standard', 'family']).optional(),
+
+	// ----- Logger -----
+	LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).optional(),
+
+	// ----- Push Notification -----
+	VAPID_PUBLIC_KEY: z.string().optional(),
+	VAPID_PRIVATE_KEY: z.string().optional(),
+	VAPID_SUBJECT: z.string().default('mailto:noreply@ganbari-quest.com'),
+
+	// ----- AI Provider -----
+	AI_PROVIDER: z.enum(['gemini', 'bedrock', 'mock']).optional(),
+	GEMINI_API_KEY: z.string().optional(),
+	GEMINI_MODEL: z.string().default('gemini-2.0-flash'),
+	BEDROCK_MODEL_ID: z.string().default('us.anthropic.claude-haiku-4-5-20251001-v1:0'),
+	BEDROCK_REGION: z.string().optional(),
+	BEDROCK_DISABLED: booleanStringSchema,
+
+	// ----- Analytics -----
+	ANALYTICS_ENABLED: booleanStringSchema,
+	ANALYTICS_TABLE_NAME: z.string().optional(),
+	UMAMI_API_KEY: z.string().optional(),
+	PUBLIC_UMAMI_WEBSITE_ID: z.string().optional(),
+	PUBLIC_UMAMI_HOST: z.string().url().optional(),
+	PUBLIC_SENTRY_DSN: z.string().optional(),
+
+	// ----- Context Token -----
+	CONTEXT_TOKEN_SECRET: z.string().optional(),
+});
+
+export type TypedEnv = z.infer<typeof envSchema>;
+
+let cached: TypedEnv | null = null;
+
+/**
+ * env を 1 回だけ parse してキャッシュする。バリデーション失敗時は詳細な
+ * エラーメッセージ付きで throw する（起動を止める）。
+ *
+ * テスト時に env を切り替えたい場合は `resetEnvForTesting()` を呼ぶこと。
+ */
+export function getEnv(): TypedEnv {
+	if (cached) return cached;
+	const result = envSchema.safeParse(process.env);
+	if (!result.success) {
+		const issues = result.error.issues
+			.map((i) => `  - ${i.path.join('.')}: ${i.message}`)
+			.join('\n');
+		throw new Error(
+			`[runtime/env] Environment variable validation failed:\n${issues}\n\nSee src/lib/runtime/env.ts for the schema.`,
+		);
+	}
+	cached = result.data;
+	return cached;
+}
+
+/**
+ * テスト専用: キャッシュをリセットして次回 `getEnv()` で再 parse させる。
+ * production / dev コードから呼んではならない。
+ */
+export function resetEnvForTesting(): void {
+	cached = null;
+}
+
+/**
+ * Top-level export for ergonomics: `import { env } from '$lib/runtime/env'`.
+ *
+ * 注意: module load 時に getEnv() が走るため、env が不正な状態でこのモジュールが
+ * import されるとアプリ起動が止まる（狙った挙動）。テストで env をモックしたい
+ * 場合は `getEnv()` / `resetEnvForTesting()` を明示的に呼ぶこと。
+ */
+export const env: TypedEnv = getEnv();

--- a/tests/unit/runtime/env.test.ts
+++ b/tests/unit/runtime/env.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getEnv, resetEnvForTesting } from '$lib/runtime/env';
+
+describe('runtime/env Typed Config Object (ADR-0040 P1)', () => {
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		resetEnvForTesting();
+		// Start from a clean slate — each test sets only what it needs.
+		for (const k of Object.keys(process.env)) {
+			delete process.env[k];
+		}
+	});
+
+	afterEach(() => {
+		resetEnvForTesting();
+		for (const k of Object.keys(process.env)) {
+			delete process.env[k];
+		}
+		for (const [k, v] of Object.entries(originalEnv)) {
+			if (v !== undefined) process.env[k] = v;
+		}
+	});
+
+	it('parses empty env with defaults applied', () => {
+		const env = getEnv();
+		expect(env.NODE_ENV).toBe('development');
+		expect(env.AUTH_MODE).toBe('local');
+		expect(env.AWS_REGION).toBe('us-east-1');
+		expect(env.DATABASE_URL).toBe('./data/ganbari-quest.db');
+		expect(env.DATA_SOURCE).toBe('sqlite');
+		expect(env.OPS_DOMAIN_COST_JPY).toBe(117);
+		expect(env.VAPID_SUBJECT).toBe('mailto:noreply@ganbari-quest.com');
+		expect(env.GEMINI_MODEL).toBe('gemini-2.0-flash');
+	});
+
+	it('coerces boolean string envs', () => {
+		process.env.MAINTENANCE_MODE = 'true';
+		process.env.STRIPE_MOCK = 'false';
+		process.env.IS_NUC_DEPLOY = 'true';
+		const env = getEnv();
+		expect(env.MAINTENANCE_MODE).toBe(true);
+		expect(env.STRIPE_MOCK).toBe(false);
+		expect(env.IS_NUC_DEPLOY).toBe(true);
+	});
+
+	it('coerces numeric envs', () => {
+		process.env.OPS_DOMAIN_COST_JPY = '250';
+		process.env.OPS_VIRTUAL_OFFICE_COST_JPY = '1500';
+		const env = getEnv();
+		expect(env.OPS_DOMAIN_COST_JPY).toBe(250);
+		expect(env.OPS_VIRTUAL_OFFICE_COST_JPY).toBe(1500);
+	});
+
+	it('accepts all valid APP_MODE values (ADR-0040)', () => {
+		const modes = ['build', 'demo', 'local-debug', 'aws-prod', 'nuc-prod'] as const;
+		for (const mode of modes) {
+			resetEnvForTesting();
+			process.env.APP_MODE = mode;
+			const env = getEnv();
+			expect(env.APP_MODE).toBe(mode);
+		}
+	});
+
+	it('rejects invalid APP_MODE', () => {
+		process.env.APP_MODE = 'bogus';
+		expect(() => getEnv()).toThrow(/APP_MODE/);
+	});
+
+	it('rejects invalid boolean string', () => {
+		process.env.MAINTENANCE_MODE = 'yes';
+		expect(() => getEnv()).toThrow(/MAINTENANCE_MODE/);
+	});
+
+	it('accepts DEBUG_PLAN variants (#758)', () => {
+		for (const plan of ['free', 'standard', 'family']) {
+			resetEnvForTesting();
+			process.env.DEBUG_PLAN = plan;
+			const env = getEnv();
+			expect(env.DEBUG_PLAN).toBe(plan);
+		}
+	});
+
+	it('rejects AWS_LICENSE_SECRET shorter than 32 chars (ADR-0026)', () => {
+		process.env.AWS_LICENSE_SECRET = 'too-short';
+		expect(() => getEnv()).toThrow(/AWS_LICENSE_SECRET/);
+	});
+
+	it('accepts AWS_LICENSE_SECRET at exactly 32 chars', () => {
+		process.env.AWS_LICENSE_SECRET = 'a'.repeat(32);
+		const env = getEnv();
+		expect(env.AWS_LICENSE_SECRET).toBe('a'.repeat(32));
+	});
+
+	it('rejects CRON_SECRET shorter than 32 chars', () => {
+		process.env.CRON_SECRET = 'short';
+		expect(() => getEnv()).toThrow(/CRON_SECRET/);
+	});
+
+	it('caches parse result across calls', () => {
+		const first = getEnv();
+		const second = getEnv();
+		expect(second).toBe(first);
+	});
+
+	it('resetEnvForTesting() forces re-parse', () => {
+		process.env.AUTH_MODE = 'local';
+		const first = getEnv();
+		expect(first.AUTH_MODE).toBe('local');
+
+		resetEnvForTesting();
+		process.env.AUTH_MODE = 'cognito';
+		const second = getEnv();
+		expect(second.AUTH_MODE).toBe('cognito');
+	});
+
+	it('includes all violating fields in thrown error', () => {
+		process.env.APP_MODE = 'bad';
+		process.env.MAINTENANCE_MODE = 'nope';
+		try {
+			getEnv();
+			throw new Error('expected throw');
+		} catch (e) {
+			const msg = (e as Error).message;
+			expect(msg).toContain('APP_MODE');
+			expect(msg).toContain('MAINTENANCE_MODE');
+		}
+	});
+});


### PR DESCRIPTION
## Summary

ADR-0040 Phase 1 実装。env を Zod schema で型付けし、唯一の読込点 `$lib/runtime/env` を新設する。

Refs: #1202 (Epic), ADR-0040
Depends on: #1203 (ADR-0040 docs PR) — マージは #1203 → 本 PR の順推奨

## 変更ファイル

| ファイル | 種別 | 説明 |
|---------|------|------|
| `src/lib/runtime/env.ts` | new | Zod で型付けされた env (50+ 項目) |
| `tests/unit/runtime/env.test.ts` | new | 13 テスト (defaults/coerce/reject) |
| `scripts/check-no-direct-env-access.mjs` | new | CI 禁則 (grandfather list 方式) |
| `.github/workflows/ci.yml` | mod | 新 check をパイプラインに追加 |

## 設計（ADR-0040 P1 準拠）

- **唯一の読込点**: `src/lib/runtime/env.ts`
- **Branch by Abstraction** (Fowler): 既存 35 ファイルは grandfather 許可、P2-P4 で段階移行
- **新規ファイル** / **grandfather 外での新規直接参照** は即時 CI fail
- **ADR-0029 連携**: 新 required env 追加時は `check-new-required-env.mjs` が PR 本文の「配布済み:」証跡を強制

## Grandfather list (35 ファイル)

P4 完了時にゼロになる予定:

- `src/hooks.server.ts`
- `src/lib/analytics/providers/**` (3)
- `src/lib/server/ai/**` (3)
- `src/lib/server/auth/**` (6)
- `src/lib/server/db/**` (5)
- `src/lib/server/services/**` (9)
- `src/lib/server/stripe/**` (2)
- `src/routes/api/**` (4)
- `src/lib/server/{logger,debug-plan,cookie-config}.ts` (3)

## 設計ポリシー確認 (ADR-0035)

- 本 PR は ADR-0040 で PO 合意済み (2026-04-19)
- Epic #1202 の P1 フェーズ該当
- 新しい domain / interface / テーブル / AWS リソースを追加しない → §ADR-0035 の追加合意対象外

## 配布済み env / secret (ADR-0029)

本 PR は既存 env の参照方法を変更するのみ。新しい required env は導入しない。
したがって「配布済み:」証跡の追加は不要（`check-new-required-env.mjs` 対象外）。

## AC 検証マップ (ADR-0038)

| AC | 検証方法 | 状態 |
|----|---------|------|
| Zod schema が 50+ env を型付け | `src/lib/runtime/env.ts` で 50+ フィールド定義 | ✅ |
| module load 時 parse / 失敗時 throw | `env.test.ts` `rejects invalid APP_MODE` | ✅ 通過 |
| 新規ファイルでの直接参照禁止 | `check-no-direct-env-access.mjs` CI 統合 | ✅ 整合 |
| 既存 grandfather は許容 | `GRANDFATHER` set (35 entries) | ✅ 通過 |
| ADR-0029 との連携 | ドキュメントに明記 + required は `.min(32)` 強制 | ✅ |
| 全 5 APP_MODE 値が valid | `env.test.ts` 'accepts all valid APP_MODE values' | ✅ 通過 |

## Test plan

- [x] `npx vitest run tests/unit/runtime/env.test.ts` — 13 テスト全通過
- [x] `npx vitest run` — 既存含む 3502 テスト全通過
- [x] `npx svelte-check` — 0 errors (既存 warnings はそのまま)
- [x] `node scripts/check-no-direct-env-access.mjs` — OK (grandfather 外で違反なし)
- [x] `npx biome check src/lib/runtime/` — 0 errors (script の console.log warning は既存 check-*.mjs と同様許容)
- [ ] CI 全緑確認後 Ready for Review

## Next phase (Epic #1202)

- P2: `RuntimeMode` 型 + `resolveRuntimeMode(env, url, cookie)` 関数
- P3: `EvaluationContext` + AsyncLocalStorage 拡張
- P4: Policy Gate `capabilities.ts` + `can()` で既存分岐を段階置換
- P5: Playwright projects でモード×プランマトリクス

🤖 Generated with [Claude Code](https://claude.com/claude-code)