### PR TITLE
feat: #1202 P2 RuntimeMode 型 + resolveRuntimeMode (ADR-0040)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - run: npm ci
 
       - name: Biome lint
-        run: npx biome check .
+        run: npx biome check --max-diagnostics=2000 --reporter=github .
 
       - name: Parallel implementation sync check (#565)
         run: npm run lint:parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - run: npm ci
 
       - name: Biome lint
-        run: npx biome check --max-diagnostics=2000 --reporter=github .
+        run: npx biome check --diagnostic-level=error --max-diagnostics=20 .
 
       - name: Parallel implementation sync check (#565)
         run: npm run lint:parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - run: npm ci
 
       - name: Biome lint
-        run: npx biome check --diagnostic-level=error --max-diagnostics=20 .
+        run: npx biome check .
 
       - name: Parallel implementation sync check (#565)
         run: npm run lint:parallel

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -18,6 +18,8 @@ declare global {
 			// cookie `gq_demo=1` から確定。`+layout.server.ts` が `data.isDemo` として
 			// client に配布する。
 			isDemo: boolean;
+			/** ADR-0040 P2: リクエストごとの実行モード（hooks.server.ts で解決） */
+			runtimeMode: import('$lib/runtime/runtime-mode').RuntimeMode;
 		}
 		// interface PageData {}
 		// interface PageState {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -4,6 +4,8 @@ import { building } from '$app/environment';
 import { analytics } from '$lib/analytics';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { env } from '$lib/runtime/env';
+import { resolveRuntimeMode } from '$lib/runtime/runtime-mode';
 import { getAuthMode, getAuthProvider } from '$lib/server/auth/factory';
 import { applyDebugPlanOverride } from '$lib/server/debug-plan';
 import {
@@ -275,6 +277,17 @@ export const handle: Handle = ({ event, resolve }) =>
 
 			event.locals.isDemo = demoActive;
 		}
+
+		// ADR-0040 P2: 実行モードをリクエスト単位で解決。以降のガード／UI 出力は
+		// 本モードを起点に判断する想定（P4 で capability gate に昇格予定）。
+		// isDemo 解決より後に呼ぶことで、`?mode=demo` / cookie / `/demo/*` すべて
+		// を 'demo' に正しく落とし込む。
+		event.locals.runtimeMode = resolveRuntimeMode({
+			env,
+			pathname: path,
+			isBuilding: building,
+			isDemoRequest: event.locals.isDemo,
+		});
 
 		// 2) デモ入口/退出ルート
 		// /demo/exit: cookie を消して本番に戻す

--- a/src/lib/runtime/runtime-mode.ts
+++ b/src/lib/runtime/runtime-mode.ts
@@ -1,0 +1,95 @@
+/**
+ * Runtime Mode (ADR-0040 Phase 2)
+ *
+ * アプリ実行モードの判定。5 モードは互いに排他的で、capability gate (P4) や
+ * Playwright テストマトリクス (P5) の基礎となる。
+ *
+ * | Mode        | 条件                                                                    |
+ * | ----------- | ----------------------------------------------------------------------- |
+ * | build       | Vite build / SvelteKit prerender 中                                     |
+ * | demo        | `/demo` 配下のリクエスト（匿名、DB なし、読み取り専用）                  |
+ * | local-debug | `npm run dev` 環境（local auth / sqlite / AUTH_MODE=local）             |
+ * | aws-prod    | AWS Lambda ランタイム（AWS_LAMBDA_FUNCTION_NAME が設定されている）      |
+ * | nuc-prod    | NUC on-prem 本番（IS_NUC_DEPLOY=true）                                  |
+ *
+ * 判定は **純関数** として実装する（process.env / building / url に直接依存しない）。
+ * テスト容易性と、将来 EvaluationContext (P3) 経由で差し替え可能にするため。
+ *
+ * 優先順位:
+ * 1. `env.APP_MODE` が明示設定されていれば、無条件でそれを返す（override）
+ * 2. `isBuilding === true` なら `'build'`
+ * 3. `isDemoRequest === true`（hooks.server.ts で resolveDemoActive から決まる）なら `'demo'`
+ * 4. `isDemoRequest` 未指定 + pathname が `/demo` / `/demo/...` なら `'demo'`（後方互換）
+ * 5. `env.IS_NUC_DEPLOY === true` なら `'nuc-prod'`
+ * 6. `env.AWS_LAMBDA_FUNCTION_NAME` が設定されていれば `'aws-prod'`
+ * 7. それ以外は `'local-debug'`
+ *
+ * 設計上の注意:
+ * - NUC と AWS Lambda が同時に true になることは物理的にない（排他性は運用で担保）
+ * - デモ + `IS_NUC_DEPLOY` が同時に成立する場合は `'demo'` を優先する。
+ *   nuc-prod の本番環境でデモを公開するユースケースがあり得るため。
+ * - `APP_MODE` が最優先なのは、テスト／デバッグで意図的にモードを固定したい場合に
+ *   他の条件（Lambda か否か等）と戦わずに済むようにするため。
+ * - `isDemoRequest` は ADR-0039 / #1199 準拠。hooks.server.ts が `?mode=demo` /
+ *   cookie `gq_demo=1` / `/demo/*` から解決した `event.locals.isDemo` を渡す想定。
+ *   pathname フォールバックは非 HTTP コンテキスト（テスト、build script）用。
+ */
+
+import type { TypedEnv } from './env';
+
+export const RUNTIME_MODES = ['build', 'demo', 'local-debug', 'aws-prod', 'nuc-prod'] as const;
+export type RuntimeMode = (typeof RUNTIME_MODES)[number];
+
+/**
+ * resolveRuntimeMode の入力。純関数として扱えるよう、すべて明示的に渡す。
+ */
+export interface ResolveRuntimeModeInput {
+	/** Typed env のうち mode 判定に関係するフィールドのみ */
+	env: Pick<TypedEnv, 'APP_MODE' | 'IS_NUC_DEPLOY' | 'AWS_LAMBDA_FUNCTION_NAME' | 'NODE_ENV'>;
+	/** リクエスト URL の pathname。build 時や CLI 呼び出しでは undefined を渡す */
+	pathname?: string;
+	/** `$app/environment` の `building` フラグ。Node scripts からは false でよい */
+	isBuilding?: boolean;
+	/**
+	 * ADR-0039 / #1199: hooks.server.ts で resolveDemoActive から決まる isDemo 結果。
+	 * 指定された場合は pathname の `/demo` フォールバックよりも優先される。
+	 */
+	isDemoRequest?: boolean;
+}
+
+export function resolveRuntimeMode(input: ResolveRuntimeModeInput): RuntimeMode {
+	const { env, pathname, isBuilding, isDemoRequest } = input;
+
+	if (env.APP_MODE) return env.APP_MODE;
+	if (isBuilding) return 'build';
+	if (isDemoRequest === true) return 'demo';
+	if (
+		isDemoRequest === undefined &&
+		pathname &&
+		(pathname === '/demo' || pathname.startsWith('/demo/'))
+	) {
+		return 'demo';
+	}
+	if (env.IS_NUC_DEPLOY === true) return 'nuc-prod';
+	if (env.AWS_LAMBDA_FUNCTION_NAME && env.AWS_LAMBDA_FUNCTION_NAME.length > 0) return 'aws-prod';
+	return 'local-debug';
+}
+
+/**
+ * モードごとの永続化／認証／決済の標準的な挙動。P4 の Policy Gate が参照する想定。
+ * 本ファイルでは型と素朴なプロパティのみ提供し、実際の可否判断は P4 の `can()` が行う。
+ */
+export const RUNTIME_MODE_PROFILES: Record<
+	RuntimeMode,
+	{
+		persistence: 'none' | 'local-sqlite' | 'dynamodb';
+		authMode: 'none' | 'local' | 'cognito';
+		acceptsWrites: boolean;
+	}
+> = {
+	build: { persistence: 'none', authMode: 'none', acceptsWrites: false },
+	demo: { persistence: 'none', authMode: 'none', acceptsWrites: false },
+	'local-debug': { persistence: 'local-sqlite', authMode: 'local', acceptsWrites: true },
+	'aws-prod': { persistence: 'dynamodb', authMode: 'cognito', acceptsWrites: true },
+	'nuc-prod': { persistence: 'local-sqlite', authMode: 'cognito', acceptsWrites: true },
+};

--- a/tests/unit/runtime/runtime-mode.test.ts
+++ b/tests/unit/runtime/runtime-mode.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TypedEnv } from '$lib/runtime/env';
+import {
+	RUNTIME_MODE_PROFILES,
+	RUNTIME_MODES,
+	type RuntimeMode,
+	resolveRuntimeMode,
+} from '$lib/runtime/runtime-mode';
+
+type ModeEnv = Pick<
+	TypedEnv,
+	'APP_MODE' | 'IS_NUC_DEPLOY' | 'AWS_LAMBDA_FUNCTION_NAME' | 'NODE_ENV'
+>;
+
+const baseEnv: ModeEnv = {
+	APP_MODE: undefined,
+	IS_NUC_DEPLOY: undefined,
+	AWS_LAMBDA_FUNCTION_NAME: undefined,
+	NODE_ENV: 'development',
+};
+
+describe('runtime/runtime-mode resolveRuntimeMode (ADR-0040 P2)', () => {
+	it('returns local-debug when nothing is set', () => {
+		expect(resolveRuntimeMode({ env: baseEnv })).toBe('local-debug');
+	});
+
+	it('returns build when isBuilding=true and APP_MODE is unset', () => {
+		expect(resolveRuntimeMode({ env: baseEnv, isBuilding: true })).toBe('build');
+	});
+
+	it('returns demo when isDemoRequest=true (primary signal, ADR-0039/#1199)', () => {
+		expect(resolveRuntimeMode({ env: baseEnv, isDemoRequest: true })).toBe('demo');
+		expect(resolveRuntimeMode({ env: baseEnv, pathname: '/', isDemoRequest: true })).toBe('demo');
+	});
+
+	it('returns local-debug when isDemoRequest=false even if pathname is /demo', () => {
+		// 明示的に isDemoRequest=false を渡した場合は pathname フォールバックも抑止される
+		expect(
+			resolveRuntimeMode({ env: baseEnv, pathname: '/demo', isDemoRequest: false }),
+		).toBe('local-debug');
+	});
+
+	it('returns demo via pathname fallback when isDemoRequest is undefined', () => {
+		expect(resolveRuntimeMode({ env: baseEnv, pathname: '/demo' })).toBe('demo');
+		expect(resolveRuntimeMode({ env: baseEnv, pathname: '/demo/upper' })).toBe('demo');
+	});
+
+	it('returns local-debug for non-demo pathnames', () => {
+		expect(resolveRuntimeMode({ env: baseEnv, pathname: '/' })).toBe('local-debug');
+		expect(resolveRuntimeMode({ env: baseEnv, pathname: '/admin' })).toBe('local-debug');
+		expect(resolveRuntimeMode({ env: baseEnv, pathname: '/demonstrate' })).toBe('local-debug');
+	});
+
+	it('returns nuc-prod when IS_NUC_DEPLOY is true', () => {
+		expect(resolveRuntimeMode({ env: { ...baseEnv, IS_NUC_DEPLOY: true } })).toBe('nuc-prod');
+	});
+
+	it('returns aws-prod when AWS_LAMBDA_FUNCTION_NAME is set', () => {
+		expect(
+			resolveRuntimeMode({
+				env: { ...baseEnv, AWS_LAMBDA_FUNCTION_NAME: 'ganbari-quest-prod' },
+			}),
+		).toBe('aws-prod');
+	});
+
+	it('treats empty AWS_LAMBDA_FUNCTION_NAME as not set', () => {
+		expect(resolveRuntimeMode({ env: { ...baseEnv, AWS_LAMBDA_FUNCTION_NAME: '' } })).toBe(
+			'local-debug',
+		);
+	});
+
+	it('prefers explicit APP_MODE over all other signals', () => {
+		// APP_MODE が他の全条件より強いことを確認
+		for (const mode of RUNTIME_MODES) {
+			expect(
+				resolveRuntimeMode({
+					env: {
+						APP_MODE: mode,
+						IS_NUC_DEPLOY: true,
+						AWS_LAMBDA_FUNCTION_NAME: 'lambda',
+						NODE_ENV: 'production',
+					},
+					pathname: '/demo',
+					isBuilding: true,
+				}),
+			).toBe(mode);
+		}
+	});
+
+	it('prefers demo over nuc-prod when both would apply', () => {
+		// nuc-prod サーバー上でも /demo は demo として扱う
+		expect(
+			resolveRuntimeMode({
+				env: { ...baseEnv, IS_NUC_DEPLOY: true },
+				pathname: '/demo/upper',
+			}),
+		).toBe('demo');
+	});
+
+	it('prefers demo over aws-prod when both would apply', () => {
+		expect(
+			resolveRuntimeMode({
+				env: { ...baseEnv, AWS_LAMBDA_FUNCTION_NAME: 'ganbari-quest-prod' },
+				pathname: '/demo',
+			}),
+		).toBe('demo');
+	});
+
+	it('prefers build over demo / nuc / aws', () => {
+		// ビルド中は「リクエスト」という概念がないが、prerender で pathname が
+		// 渡されうる。build が最強（APP_MODE 未指定時）。
+		expect(
+			resolveRuntimeMode({
+				env: { ...baseEnv, IS_NUC_DEPLOY: true, AWS_LAMBDA_FUNCTION_NAME: 'lambda' },
+				pathname: '/demo',
+				isBuilding: true,
+			}),
+		).toBe('build');
+	});
+
+	it('prefers nuc-prod over aws-prod when both are set (should not happen in practice)', () => {
+		// 物理的には共存しないが、設定ミス耐性として IS_NUC_DEPLOY を優先する
+		expect(
+			resolveRuntimeMode({
+				env: {
+					...baseEnv,
+					IS_NUC_DEPLOY: true,
+					AWS_LAMBDA_FUNCTION_NAME: 'should-be-ignored',
+				},
+			}),
+		).toBe('nuc-prod');
+	});
+
+	it('returns the same mode regardless of NODE_ENV', () => {
+		// NODE_ENV は mode 判定に直接は影響しない（env override や debug 用途のため）
+		const prodEnv: ModeEnv = { ...baseEnv, NODE_ENV: 'production' };
+		expect(resolveRuntimeMode({ env: prodEnv })).toBe('local-debug');
+	});
+});
+
+describe('runtime/runtime-mode RUNTIME_MODES list integrity', () => {
+	it('exports exactly 5 modes', () => {
+		expect(RUNTIME_MODES).toHaveLength(5);
+	});
+
+	it('includes all known modes', () => {
+		const expected: RuntimeMode[] = ['build', 'demo', 'local-debug', 'aws-prod', 'nuc-prod'];
+		for (const mode of expected) {
+			expect(RUNTIME_MODES).toContain(mode);
+		}
+	});
+
+	it('has a profile for every mode', () => {
+		for (const mode of RUNTIME_MODES) {
+			expect(RUNTIME_MODE_PROFILES[mode]).toBeDefined();
+		}
+	});
+});
+
+describe('runtime/runtime-mode RUNTIME_MODE_PROFILES sanity', () => {
+	it('build and demo do not accept writes', () => {
+		expect(RUNTIME_MODE_PROFILES.build.acceptsWrites).toBe(false);
+		expect(RUNTIME_MODE_PROFILES.demo.acceptsWrites).toBe(false);
+	});
+
+	it('local-debug uses local-sqlite + local auth', () => {
+		expect(RUNTIME_MODE_PROFILES['local-debug']).toMatchObject({
+			persistence: 'local-sqlite',
+			authMode: 'local',
+			acceptsWrites: true,
+		});
+	});
+
+	it('aws-prod uses dynamodb + cognito', () => {
+		expect(RUNTIME_MODE_PROFILES['aws-prod']).toMatchObject({
+			persistence: 'dynamodb',
+			authMode: 'cognito',
+			acceptsWrites: true,
+		});
+	});
+
+	it('nuc-prod uses local-sqlite + cognito', () => {
+		expect(RUNTIME_MODE_PROFILES['nuc-prod']).toMatchObject({
+			persistence: 'local-sqlite',
+			authMode: 'cognito',
+			acceptsWrites: true,
+		});
+	});
+});

--- a/tests/unit/runtime/runtime-mode.test.ts
+++ b/tests/unit/runtime/runtime-mode.test.ts
@@ -36,9 +36,9 @@ describe('runtime/runtime-mode resolveRuntimeMode (ADR-0040 P2)', () => {
 
 	it('returns local-debug when isDemoRequest=false even if pathname is /demo', () => {
 		// 明示的に isDemoRequest=false を渡した場合は pathname フォールバックも抑止される
-		expect(
-			resolveRuntimeMode({ env: baseEnv, pathname: '/demo', isDemoRequest: false }),
-		).toBe('local-debug');
+		expect(resolveRuntimeMode({ env: baseEnv, pathname: '/demo', isDemoRequest: false })).toBe(
+			'local-debug',
+		);
 	});
 
 	it('returns demo via pathname fallback when isDemoRequest is undefined', () => {


### PR DESCRIPTION
## Summary
- ADR-0040 Phase 2。5 実行モード（build / demo / local-debug / aws-prod / nuc-prod）を判定する純関数 `resolveRuntimeMode` を追加
- `src/lib/runtime/runtime-mode.ts` に `RuntimeMode` 型 + `RUNTIME_MODES` / `RUNTIME_MODE_PROFILES` をエクスポート
- `src/hooks.server.ts` で `event.locals.runtimeMode` を populate（App.Locals 型拡張）
- #1199（ADR-0039 デモモード refactor）と整合: `isDemoRequest` signal を追加し、hooks.server.ts では `event.locals.isDemo` 解決後に `resolveRuntimeMode` を呼ぶ
- 単体テスト 22 件追加（全モード判定 / 優先順位 / 境界 / isDemoRequest signal / pathname フォールバック）

## 設計ポイント

### 優先順位
1. `env.APP_MODE` が明示されていれば無条件でそれを返す（テスト／デバッグで固定したい場合）
2. `isBuilding === true` → `'build'`
3. `isDemoRequest === true` → `'demo'`（ADR-0039 / #1199 に準拠、hooks.server.ts から渡す）
4. `isDemoRequest === undefined` かつ pathname が `/demo` or `/demo/...` → `'demo'`（pathname フォールバック、非 HTTP 呼び出し向け）
5. `env.IS_NUC_DEPLOY === true` → `'nuc-prod'`
6. `env.AWS_LAMBDA_FUNCTION_NAME` が非空 → `'aws-prod'`
7. それ以外 → `'local-debug'`

### なぜ純関数？
- テストで `process.env` / `$app/environment` をモックしなくて済む
- P3 で `EvaluationContext` に畳み込む際、差し替え可能な単位として独立させておきたい

### `isDemoRequest` signal（#1199 整合）
- #1199 で demo は `?mode=demo` / cookie `gq_demo=1` / `/demo/*` の 3 経路で判定されるようになった
- hooks.server.ts はそれらを `resolveDemoActive()` で一度解決し `event.locals.isDemo` に格納する
- P2 では `resolveRuntimeMode` をその**後**に呼び、`isDemoRequest: event.locals.isDemo` を渡すことで全 3 経路を `'demo'` に落とし込む
- pathname ベースの demo 検出は「`isDemoRequest` 未指定」のときのみ効くフォールバックに降格（テスト・スクリプト用）

### `/demo` 判定の境界
`pathname.startsWith('/demo')` だと `/demonstrate` / `/demon` が誤マッチするため
`pathname === '/demo' || pathname.startsWith('/demo/')` に限定（テストで回帰を固定）。

### nuc-prod と aws-prod の排他性
物理的には共存しないが、設定ミス耐性として `IS_NUC_DEPLOY` を優先する仕様。

## Test plan
- [x] `npx vitest run tests/unit/runtime/runtime-mode.test.ts` 22 件通過
- [x] `npx vitest run` 全 3529 件通過
- [x] `npx svelte-check` エラー 0
- [x] `npx biome check` 新規エラーなし
- [x] main にリベース済み（#1199 / #1204 との conflict 解決: `isDemo` と `runtimeMode` を共存）

## ADR-0040 進捗
- [x] **P1**: Typed Config Object (`src/lib/runtime/env.ts`) — #1204 ✅ マージ済
- [x] **P2**: RuntimeMode 型 + resolveRuntimeMode — 本 PR
- [ ] P3: EvaluationContext + AsyncLocalStorage 拡張
- [ ] P4: Policy Gate (`can()`) 導入
- [ ] P5: Playwright projects でモード×プランマトリクス

Refs #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)