### PR TITLE
refactor: #1215 P3 EvaluationContext + AsyncLocalStorage 拡張 (ADR-0040)

### DIFF
--- a/docs/decisions/0040-runtime-mode-license-unified-architecture.md
+++ b/docs/decisions/0040-runtime-mode-license-unified-architecture.md
@@ -96,25 +96,53 @@ export type TypedEnv = z.infer<typeof envSchema>;
 OpenFeature の evaluation context 概念を参考にした**リクエスト単位の "文脈オブジェクト"**。
 
 ```ts
-// src/lib/runtime/evaluation-context.ts (設計のみ、実装は P3 で行う)
-export type RuntimeMode = 'build' | 'demo' | 'local-debug' | 'aws-prod' | 'nuc-prod';
+// src/lib/runtime/evaluation-context.ts (実装は P3 / #1215 で完了)
+import type { RuntimeMode } from './runtime-mode';
+
+export interface EvaluationUser {
+  id: string;
+  role: 'owner' | 'parent' | 'child';
+  groups: readonly string[];
+}
+
+export interface EvaluationPlan {
+  tier: 'free' | 'standard' | 'family';
+  status: 'none' | 'active' | 'grace_period' | 'canceled';
+  trialState: 'none' | 'active' | 'expired';
+}
+
+export interface EvaluationLicenseKey {
+  valid: boolean;
+  expiresAt: Date | null;
+}
 
 export interface EvaluationContext {
   /** 実行モード。env + URL + cookie から P2 の resolveRuntimeMode が決定 */
   mode: RuntimeMode;
-
-  /** 認証結果。demo / build では null */
-  user: { id: string; role: 'owner' | 'parent' | 'child'; groups: readonly string[] } | null;
-
-  /** ライセンスプラン（ADR-0024 の resolvePlanTier 結果）*/
-  plan: { tier: 'free' | 'standard' | 'family'; status: 'none' | 'active' | 'grace_period' | 'canceled'; trialState: 'none' | 'active' | 'expired'; } | null;
-
-  /** NUC モードのみ ADR-0026 のライセンスキー検証結果が入る */
-  licenseKey: { valid: boolean; expiresAt: Date | null } | null;
-
-  /** 現在時刻（テストで固定化するためのファネル）*/
+  /** 認証結果。demo / build / 未ログインでは null */
+  user: EvaluationUser | null;
+  /** ライセンスプラン（ADR-0024 の resolvePlanTier 結果）。demo / 未認証は null */
+  plan: EvaluationPlan | null;
+  /** nuc-prod モードのみ ADR-0026 のライセンスキー検証結果が入る */
+  licenseKey: EvaluationLicenseKey | null;
+  /** 現在時刻（テストで固定化するためのファネル） */
   now: Date;
 }
+
+/** 純関数ビルダ。I/O は hooks.server.ts 側で行う */
+export function buildEvaluationContext(input: {
+  mode: RuntimeMode;
+  user?: EvaluationUser | null;
+  plan?: EvaluationPlan | null;
+  licenseKey?: EvaluationLicenseKey | null;
+  now?: Date;
+}): EvaluationContext;
+
+/** AsyncLocalStorage 外 (build script / 未ラップのテスト) では undefined */
+export function getEvaluationContext(): EvaluationContext | undefined;
+
+/** hooks.server.ts が 1 リクエスト 1 回だけ呼ぶ。AsyncLocalStorage 外では no-op */
+export function setEvaluationContext(ctx: EvaluationContext): void;
 ```
 
 - `hooks.server.ts` で **1 リクエスト 1 回だけ** 構築し、#788 で導入済みの `runWithRequestContext` (AsyncLocalStorage) に注入

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,6 +5,7 @@ import { analytics } from '$lib/analytics';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { env } from '$lib/runtime/env';
+import { buildEvaluationContext, setEvaluationContext } from '$lib/runtime/evaluation-context';
 import { resolveRuntimeMode } from '$lib/runtime/runtime-mode';
 import { getAuthMode, getAuthProvider } from '$lib/server/auth/factory';
 import { applyDebugPlanOverride } from '$lib/server/debug-plan';
@@ -342,6 +343,16 @@ export const handle: Handle = ({ event, resolve }) =>
 				demoPlan,
 			);
 			event.locals.context = applyDebugPlanOverride(baseDemoContext);
+
+			// ADR-0040 P3 (#1215): デモ実行時の EvaluationContext を注入。
+			// demo は非認証のため user / plan / licenseKey は null。
+			// mode='demo' により P4 Policy Gate で write 系 capability が deny される。
+			setEvaluationContext(
+				buildEvaluationContext({
+					mode: event.locals.runtimeMode,
+				}),
+			);
+
 			const response = await resolve(event);
 			if (!path.startsWith('/_app/') && !path.startsWith('/favicon')) {
 				logger.request(event.request.method, path, response.status, Date.now() - start, {
@@ -361,6 +372,16 @@ export const handle: Handle = ({ event, resolve }) =>
 		event.locals.authenticated = identity !== null;
 		event.locals.identity = identity;
 		event.locals.context = context;
+
+		// ADR-0040 P3 (#1215): 認証解決完了後の EvaluationContext を注入。
+		// P3 スコープでは mode のみ真面目に投影し、user / plan / licenseKey の詳細投影は
+		// P4 で capability 判定が必要になった時点で追加する（resolvePlanTier の I/O を
+		// hooks で先取りしないため）。既存の event.locals.* は互換のため変更しない。
+		setEvaluationContext(
+			buildEvaluationContext({
+				mode: event.locals.runtimeMode,
+			}),
+		);
 
 		// 2) ルート保護
 

--- a/src/lib/runtime/evaluation-context.ts
+++ b/src/lib/runtime/evaluation-context.ts
@@ -1,0 +1,114 @@
+/**
+ * EvaluationContext (ADR-0040 Phase 3 / #1215)
+ *
+ * リクエスト単位の "文脈オブジェクト"。OpenFeature の evaluation context 概念を参考に、
+ * mode × user × plan × licenseKey × now を 1 つに束ねて hooks.server.ts で 1 回だけ
+ * 構築し、#788 の AsyncLocalStorage に注入する。
+ *
+ * 目的:
+ * - P4 Policy Gate の `can(ctx, capability)` が 4 因子を個別取得する必要を無くす
+ * - テストで mode + plan + user を固定するときに個別 mock が不要になる
+ * - `+page.server.ts` の load や services が `getEvaluationContext()` で統一参照できる
+ *
+ * 設計上の制約:
+ * - `buildEvaluationContext` は **純関数** (I/O なし)。I/O は hooks.server.ts 側が担う
+ * - server→client に **全量露出しない** (ADR-0009 教訓)。load は必要な投影だけ client に渡す
+ * - 既存の `event.locals.*` / `resolvePlanTier` / `getTrialStatus` は変更しない (共存期間)
+ */
+
+import { getRequestContext } from '$lib/server/request-context';
+import type { RuntimeMode } from './runtime-mode';
+
+/** 認証されたユーザーの識別情報（投影） */
+export interface EvaluationUser {
+	/** Identity 固有の ID (local: 'local', cognito: userId) */
+	id: string;
+	/** テナント内ロール */
+	role: 'owner' | 'parent' | 'child';
+	/** Cognito groups 等の外部グループ所属 (ops 認可などに利用) */
+	groups: readonly string[];
+}
+
+/** プラン解決結果（ADR-0024 の resolvePlanTier / trial-service 結果の投影） */
+export interface EvaluationPlan {
+	/** プランティア（free / standard / family） */
+	tier: 'free' | 'standard' | 'family';
+	/** サブスクリプション状態 */
+	status: 'none' | 'active' | 'grace_period' | 'canceled';
+	/** トライアル状態 */
+	trialState: 'none' | 'active' | 'expired';
+}
+
+/** ライセンスキー検証結果（ADR-0026、nuc-prod モードのみ） */
+export interface EvaluationLicenseKey {
+	valid: boolean;
+	expiresAt: Date | null;
+}
+
+/**
+ * リクエスト単位の文脈オブジェクト。
+ *
+ * hooks.server.ts が認証解決完了後に 1 回だけ構築し、P4 Policy Gate の `can()` が参照する。
+ */
+export interface EvaluationContext {
+	/** 実行モード。env + URL + cookie から P2 の resolveRuntimeMode が決定 */
+	mode: RuntimeMode;
+	/** 認証結果。demo / build / 未ログインでは null */
+	user: EvaluationUser | null;
+	/** ライセンスプラン。未認証 / demo / プラン未確定のうちは null */
+	plan: EvaluationPlan | null;
+	/** NUC モードのみ ADR-0026 のライセンスキー検証結果が入る。それ以外は null */
+	licenseKey: EvaluationLicenseKey | null;
+	/** 現在時刻。テストで固定化するためのファネル */
+	now: Date;
+}
+
+/** buildEvaluationContext の入力。純関数として扱えるよう、全て明示的に渡す */
+export interface BuildEvaluationContextInput {
+	mode: RuntimeMode;
+	user?: EvaluationUser | null;
+	plan?: EvaluationPlan | null;
+	licenseKey?: EvaluationLicenseKey | null;
+	/** 省略時は `new Date()`。テスト時は固定化したい日時を渡す */
+	now?: Date;
+}
+
+/**
+ * EvaluationContext を純粋に構築する。I/O は一切行わない。
+ *
+ * hooks.server.ts / テストの両方から同じ関数で組み立てることで、
+ * 実環境と単体テストの context が乖離しないことを保証する。
+ */
+export function buildEvaluationContext(input: BuildEvaluationContextInput): EvaluationContext {
+	return {
+		mode: input.mode,
+		user: input.user ?? null,
+		plan: input.plan ?? null,
+		licenseKey: input.licenseKey ?? null,
+		now: input.now ?? new Date(),
+	};
+}
+
+/**
+ * 現在のリクエストの EvaluationContext を取得する。
+ *
+ * AsyncLocalStorage 外（バックグラウンドジョブ、build script、未注入のテスト等）では
+ * `undefined` を返す。呼び出し側は fallback ロジックを用意するか、
+ * hooks での注入が保証される経路でのみ使うこと。
+ */
+export function getEvaluationContext(): EvaluationContext | undefined {
+	return getRequestContext()?.evaluationContext;
+}
+
+/**
+ * 現在のリクエストに EvaluationContext を注入する。
+ *
+ * hooks.server.ts から認証解決完了後に 1 回だけ呼ぶ想定。
+ * AsyncLocalStorage 外（未ラップのコンテキスト）から呼ばれた場合は no-op（sink）。
+ * ネスト呼び出しは既存の `runWithRequestContext` の「既存を再利用」仕様に従う。
+ */
+export function setEvaluationContext(ctx: EvaluationContext): void {
+	const store = getRequestContext();
+	if (!store) return;
+	store.evaluationContext = ctx;
+}

--- a/src/lib/server/request-context.ts
+++ b/src/lib/server/request-context.ts
@@ -15,6 +15,7 @@
 // 同一リクエスト内で状態が変わる操作の直後に呼ぶ。
 
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { EvaluationContext } from '$lib/runtime/evaluation-context';
 import type { PlanTier } from '$lib/server/services/plan-limit-service';
 import type { TrialStatus } from '$lib/server/services/trial-service';
 
@@ -23,6 +24,12 @@ interface RequestContext {
 	planTierCache: Map<string, PlanTier>;
 	/** key: tenantId */
 	trialStatusCache: Map<string, TrialStatus>;
+	/**
+	 * ADR-0040 P3 (#1215): hooks.server.ts で認証解決完了後に 1 回だけ構築される
+	 * 実行文脈。Policy Gate (P4) が `can()` で参照する。
+	 * hooks が注入する前は undefined。
+	 */
+	evaluationContext?: EvaluationContext;
 }
 
 const store = new AsyncLocalStorage<RequestContext>();

--- a/tests/unit/runtime/evaluation-context.test.ts
+++ b/tests/unit/runtime/evaluation-context.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	buildEvaluationContext,
+	type EvaluationContext,
+	type EvaluationPlan,
+	type EvaluationUser,
+	getEvaluationContext,
+	setEvaluationContext,
+} from '$lib/runtime/evaluation-context';
+import type { RuntimeMode } from '$lib/runtime/runtime-mode';
+import { runWithRequestContext } from '$lib/server/request-context';
+
+describe('runtime/evaluation-context buildEvaluationContext (ADR-0040 P3 / #1215)', () => {
+	it('builds a context with mode only and nullable others defaulted', () => {
+		const ctx = buildEvaluationContext({ mode: 'local-debug' });
+		expect(ctx.mode).toBe('local-debug');
+		expect(ctx.user).toBeNull();
+		expect(ctx.plan).toBeNull();
+		expect(ctx.licenseKey).toBeNull();
+		expect(ctx.now).toBeInstanceOf(Date);
+	});
+
+	it('returns the exact provided values (pure builder)', () => {
+		const now = new Date('2026-04-19T00:00:00Z');
+		const user: EvaluationUser = { id: 'user-1', role: 'owner', groups: ['ops'] };
+		const plan: EvaluationPlan = { tier: 'family', status: 'active', trialState: 'none' };
+		const ctx = buildEvaluationContext({
+			mode: 'aws-prod',
+			user,
+			plan,
+			licenseKey: { valid: true, expiresAt: new Date('2027-01-01Z') },
+			now,
+		});
+		expect(ctx.mode).toBe('aws-prod');
+		expect(ctx.user).toEqual(user);
+		expect(ctx.plan).toEqual(plan);
+		expect(ctx.licenseKey).toEqual({ valid: true, expiresAt: new Date('2027-01-01Z') });
+		expect(ctx.now).toBe(now);
+	});
+
+	it('supports all 5 runtime modes', () => {
+		const modes: RuntimeMode[] = ['build', 'demo', 'local-debug', 'aws-prod', 'nuc-prod'];
+		for (const mode of modes) {
+			const ctx = buildEvaluationContext({ mode });
+			expect(ctx.mode).toBe(mode);
+		}
+	});
+
+	it('supports user=null (demo / build / unauthenticated)', () => {
+		const ctx = buildEvaluationContext({ mode: 'demo', user: null });
+		expect(ctx.user).toBeNull();
+	});
+
+	it('supports user with each role', () => {
+		const roles: EvaluationUser['role'][] = ['owner', 'parent', 'child'];
+		for (const role of roles) {
+			const ctx = buildEvaluationContext({
+				mode: 'local-debug',
+				user: { id: 'u', role, groups: [] },
+			});
+			expect(ctx.user?.role).toBe(role);
+		}
+	});
+
+	it('supports plan=null (unauthenticated / demo)', () => {
+		const ctx = buildEvaluationContext({ mode: 'demo', plan: null });
+		expect(ctx.plan).toBeNull();
+	});
+
+	it('supports each plan tier', () => {
+		const tiers: EvaluationPlan['tier'][] = ['free', 'standard', 'family'];
+		for (const tier of tiers) {
+			const ctx = buildEvaluationContext({
+				mode: 'aws-prod',
+				plan: { tier, status: 'active', trialState: 'none' },
+			});
+			expect(ctx.plan?.tier).toBe(tier);
+		}
+	});
+
+	it('supports each plan status', () => {
+		const statuses: EvaluationPlan['status'][] = ['none', 'active', 'grace_period', 'canceled'];
+		for (const status of statuses) {
+			const ctx = buildEvaluationContext({
+				mode: 'aws-prod',
+				plan: { tier: 'standard', status, trialState: 'none' },
+			});
+			expect(ctx.plan?.status).toBe(status);
+		}
+	});
+
+	it('supports each trialState', () => {
+		const states: EvaluationPlan['trialState'][] = ['none', 'active', 'expired'];
+		for (const trialState of states) {
+			const ctx = buildEvaluationContext({
+				mode: 'local-debug',
+				plan: { tier: 'standard', status: 'none', trialState },
+			});
+			expect(ctx.plan?.trialState).toBe(trialState);
+		}
+	});
+
+	it('accepts licenseKey with valid=true/false and expiresAt', () => {
+		const expires = new Date('2030-01-01Z');
+		const ctxValid = buildEvaluationContext({
+			mode: 'nuc-prod',
+			licenseKey: { valid: true, expiresAt: expires },
+		});
+		expect(ctxValid.licenseKey).toEqual({ valid: true, expiresAt: expires });
+
+		const ctxInvalid = buildEvaluationContext({
+			mode: 'nuc-prod',
+			licenseKey: { valid: false, expiresAt: null },
+		});
+		expect(ctxInvalid.licenseKey).toEqual({ valid: false, expiresAt: null });
+	});
+
+	it('now defaults to a fresh Date, but can be injected for test stabilization', () => {
+		const fixed = new Date('2026-01-01T12:34:56Z');
+		const ctx = buildEvaluationContext({ mode: 'local-debug', now: fixed });
+		expect(ctx.now).toBe(fixed);
+
+		const defaulted = buildEvaluationContext({ mode: 'local-debug' });
+		const delta = Math.abs(defaulted.now.getTime() - Date.now());
+		expect(delta).toBeLessThan(5_000);
+	});
+});
+
+describe('runtime/evaluation-context AsyncLocalStorage integration', () => {
+	it('getEvaluationContext returns undefined outside runWithRequestContext', () => {
+		expect(getEvaluationContext()).toBeUndefined();
+	});
+
+	it('setEvaluationContext is a no-op outside runWithRequestContext (no throw)', () => {
+		expect(() => setEvaluationContext(buildEvaluationContext({ mode: 'demo' }))).not.toThrow();
+		// 外側には残らない
+		expect(getEvaluationContext()).toBeUndefined();
+	});
+
+	it('set then get within runWithRequestContext round-trips', async () => {
+		const ctx: EvaluationContext = buildEvaluationContext({
+			mode: 'nuc-prod',
+			user: { id: 'u-1', role: 'owner', groups: [] },
+			plan: { tier: 'family', status: 'active', trialState: 'none' },
+			licenseKey: { valid: true, expiresAt: new Date('2030-12-31Z') },
+			now: new Date('2026-04-19T00:00:00Z'),
+		});
+
+		await runWithRequestContext(async () => {
+			setEvaluationContext(ctx);
+			expect(getEvaluationContext()).toBe(ctx);
+		});
+
+		// ストア外に抜けたら undefined
+		expect(getEvaluationContext()).toBeUndefined();
+	});
+
+	it('two nested runWithRequestContext share the outer store (set visible inside)', async () => {
+		const outer = buildEvaluationContext({ mode: 'aws-prod' });
+		const inner = buildEvaluationContext({ mode: 'demo' });
+
+		await runWithRequestContext(async () => {
+			setEvaluationContext(outer);
+			await runWithRequestContext(async () => {
+				// request-context.ts の仕様: ネスト時は既存を再利用
+				expect(getEvaluationContext()).toBe(outer);
+				// 内側で上書きすると外側にも反映される（同一ストア）
+				setEvaluationContext(inner);
+				expect(getEvaluationContext()).toBe(inner);
+			});
+			expect(getEvaluationContext()).toBe(inner);
+		});
+	});
+
+	it('separate runWithRequestContext calls do not leak contexts to each other', async () => {
+		const a = buildEvaluationContext({ mode: 'aws-prod' });
+		const b = buildEvaluationContext({ mode: 'nuc-prod' });
+
+		await runWithRequestContext(async () => {
+			setEvaluationContext(a);
+			expect(getEvaluationContext()?.mode).toBe('aws-prod');
+		});
+
+		await runWithRequestContext(async () => {
+			expect(getEvaluationContext()).toBeUndefined();
+			setEvaluationContext(b);
+			expect(getEvaluationContext()?.mode).toBe('nuc-prod');
+		});
+	});
+});

--- a/tests/unit/services/hooks-integration.test.ts
+++ b/tests/unit/services/hooks-integration.test.ts
@@ -84,6 +84,9 @@ vi.mock('$lib/server/discord-alert', () => ({
 
 vi.mock('$lib/server/request-context', () => ({
 	runWithRequestContext: (fn: () => unknown) => fn(),
+	// ADR-0040 P3 (#1215): hooks.server.ts が setEvaluationContext 経由で参照する。
+	// ALS 外扱い（undefined 返却）で setEvaluationContext は no-op になる。
+	getRequestContext: () => undefined,
 }));
 
 vi.mock('$lib/server/routing/legacy-url-map', () => ({


### PR DESCRIPTION
## Summary

ADR-0040 Phase 3 (#1215): リクエスト単位の実行文脈 `EvaluationContext` を導入し、既存 `runWithRequestContext` (#788) の AsyncLocalStorage を 3 層アーキテクチャの第 2 層として拡張する。

- `buildEvaluationContext()` — 純関数ビルダー（I/O なし、hooks / テスト両方から同じ関数で組み立て）
- `getEvaluationContext()` / `setEvaluationContext()` — ALS ラッパ（外側では undefined / no-op）
- `hooks.server.ts` — demo / 通常認証の両経路で認証解決後に `mode` のみ注入（P3 時点）
- ADR-0040 §第 2 層 の code example を実装と同期

**P3 スコープ**: 骨格のみ。`user` / `plan` / `licenseKey` は P4 で本格注入し `can()` を実装する。

Closes: N/A（Epic #1202 の P3 完了。マージ後に checklist を更新）

## Why this design

- OpenFeature の evaluation context 概念を参考に、4 因子 + `now` を 1 オブジェクトに束ねる
- `can(ctx, capability)` が個別取得する必要をなくす（P4 の設計負債を先回りで回避）
- テストで mode + plan + user を固定する際の個別 mock を不要化
- AsyncLocalStorage 外では `undefined` / no-op にすることで、ネスト済みの既存テスト群に互換

## 設計上の制約（実装遵守）

- [x] `buildEvaluationContext` は純関数（I/O なし）。I/O は hooks.server.ts 側
- [x] server→client に全量露出しない（ADR-0009 教訓）。load は必要な投影だけ client に渡す
- [x] 既存の `event.locals.*` / `resolvePlanTier` / `getTrialStatus` は変更しない（共存期間）
- [x] `runWithRequestContext` の「既存を再利用」仕様に従う（ネスト時は外側を共有）

## Test plan

- [x] `npx vitest run tests/unit/runtime/evaluation-context.test.ts` — 16 tests passed
  - builder 10 件: mode only / all fields / 5 modes / 3 roles / 3 tiers / 4 statuses / 3 trial states / licenseKey valid+invalid / now default+injected
  - ALS 4 件: 外側で undefined / no-op / round-trip / nested shared / 独立
- [x] `npx svelte-check` — 0 errors (既存 warning のみ)
- [x] `npx biome check .` — pass（Organize Imports 1 件を自動修正済み）

## Out of scope（P4 以降）

- `user` / `plan` / `licenseKey` の実データ注入 → P4 (#59)
- `can(ctx, capability)` Policy Gate → P4 (#59)
- Playwright での mode×plan マトリクス → P5 (#60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)