### PR TITLE
chore: #1218 Draft→Ready 化時の CI 重複実行を排除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    # #1218: `ready_for_review` をトリガーに含めない。
+    # 本 CI は Draft PR でも opened/synchronize で実行されるため、Draft→Ready 化で
+    # 同一 SHA を再実行しても結果が変わらず、runtime（特に e2e-test）が無駄になる。
+    # Draft スキップ系 workflow (pr-ui-check / pr-ac-verification-check / lp-metrics)
+    # とは役割が異なる点に注意。
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,8 @@ on:
     paths: ['src/**', 'static/**', '**/*.js', '**/*.ts']
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    # #1218: ready_for_review は除外（Draft でも走るため再実行は無駄）。
+    types: [opened, synchronize, reopened]
     paths: ['src/**', 'static/**', '**/*.js', '**/*.ts']
   schedule:
     - cron: "0 6 * * 1" # Every Monday at 6:00 UTC

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,8 @@ name: "Dependency Review"
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    # #1218: ready_for_review は除外（Draft でも走るため再実行は無駄）。
+    types: [opened, synchronize, reopened]
     paths:
       - 'package.json'
       - 'package-lock.json'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,7 +2,8 @@ name: "Labeler"
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # #1218: ready_for_review は除外（Draft でも走るため再実行は無駄）。
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -7,7 +7,8 @@ name: PR Size Check
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    # #1218: ready_for_review は除外（Draft でも走るため再実行は無駄）。
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read


### PR DESCRIPTION
closes #1218

## Summary

Draft PR を Ready for Review に変更した際、同一 SHA で全 CI が再実行される問題（#1218）を解消する。

グループ A（Draft でも走る系）5 workflow から `ready_for_review` trigger を削除。

## 実測データ（PR #1216 の CI run 一覧）

| 時刻 | event | SHA | 結果 |
|------|-------|-----|------|
| 06:36:45Z | synchronize | 6b7b86d0 | 全 workflow success |
| 06:45:12Z | **ready_for_review** | **同じ 6b7b86d0** | 全 workflow success（**再実行・無駄**） |

## 変更

### 対象（ready_for_review を types から削除）

- `.github/workflows/ci.yml` — 主要 CI（+ 方針コメント追記）
- `.github/workflows/codeql.yml`
- `.github/workflows/dependency-review.yml`
- `.github/workflows/pr-size-check.yml`
- `.github/workflows/labeler.yml`

### 対象外（変更なし、`ready_for_review` 必須）

以下は `if: github.event.pull_request.draft == false` で Draft スキップしているため、Ready 化が初回実行。

- `.github/workflows/pr-ui-check.yml`
- `.github/workflows/pr-ac-verification-check.yml`
- `.github/workflows/lp-metrics.yml`

## 影響範囲

- **Branch protection の required status check**: 最新 run が対象。Draft 時の success run が残るので Ready 化後も pass 扱いが残り merge 可能
- **`draft-on-ci-fail.yml` (#1074)**: CI 結果イベント監視のため types 変更の影響なし
- **Draft→Ready 前の CI 緑確認運用**: Draft で全 CI 緑を確認してから Ready にする運用（`feedback_no_ready_before_ci`）は温存される

## 期待効果

1 PR あたり概算 30-40 分の CI runtime 削減（e2e-test 3 shard × 6-7 分が支配的）。

## Test plan

- [x] 5 workflow の YAML syntax 検証（js-yaml parse OK）
- [ ] 本 PR を Draft で open → CI 走行確認（通常通り opened で走る）
- [ ] 本 PR を Ready 化 → **同一 SHA で CI が再実行されないこと**を最終検証として確認
- [ ] グループ B 3 workflow は `ready_for_review` 維持で Draft→Ready 化で初回実行されること（`lp-metrics` / `pr-ui-check` / `pr-ac-verification-check`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)