### PR TITLE
chore: #1205 lp-metrics.json を biome.json files.ignore に追加

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -126,7 +126,8 @@
 			"!**/storybook-static",
 			"!**/app.css",
 			"!**/.claude",
-			"!**/*.md"
+			"!**/*.md",
+			"!**/lp-metrics.json"
 		]
 	}
 }


### PR DESCRIPTION
## Summary

- `scripts/measure-lp-dimensions.mjs` が生成する `lp-metrics.json` は `.gitignore` 済みだが Biome は独自の探索パスで format チェック対象として拾っていた
- `biome.json` の `files.ignore` に `!**/lp-metrics.json` を追加して除外
- 変更は biome.json 1 行のみ

## Closes

Closes #1205

## AC 突合

| AC | 結果 | 根拠 |
|----|------|------|
| `biome.json` の `files.ignore` に `lp-metrics.json` を追加 | ✅ | biome.json:130 に `!**/lp-metrics.json` 追記 |
| `npx biome check .` で該当ファイルに関する警告/エラーが 0 | ✅ | `npx biome check lp-metrics.json` → `These paths were provided but ignored: lp-metrics.json` に変化 |
| main 基準で修正前後の biome 出力 diff | ✅ | 修正前: format 指摘あり → 修正後: `ignored` として除外 |

## Test plan

- [x] `npx biome check biome.json` → PASS
- [x] `npx biome check lp-metrics.json` → ignored として除外されることを確認
- [ ] CI の biome check ジョブ PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)