### PR TITLE
docs: #1211 ADR-0040 に P1 実装補正メモを追記

### DIFF
--- a/docs/decisions/0040-runtime-mode-license-unified-architecture.md
+++ b/docs/decisions/0040-runtime-mode-license-unified-architecture.md
@@ -249,6 +249,17 @@ export function ensureCan(ctx: EvaluationContext, cap: Capability): void;
 - **"機能が使えるか" は純粋関数で表現できる** — Side effect（認可エラー throw）は呼び出し側の `ensureCan()` に閉じ込める
 - **Pre-PMF では外部依存より内部整理** — SaaS を入れる前に、自社コードの境界を整えるほうが ROI が高い（ADR-0034 と同じ哲学）
 
+## 実装補正メモ (P1)
+
+ADR-0003（設計書は Single Source of Truth）に基づき、実装と本 ADR 擬似コードの乖離は ADR 側で追認する。以下は P1 実装 (PR #1204) 時点で本文擬似コードと差分が発生した箇所の追認メモ。本 ADR の status / 決定事項自体は変更しない（supersede ではなく補足）。
+
+| 項目 | 本文擬似コード | P1 実装 (`src/lib/runtime/env.ts`) | 追認理由 |
+|------|---------------|----------------------------------|---------|
+| `AUTH_MODE` enum | `z.enum(['auto', 'cognito'])` | `z.enum(['local', 'cognito'])` | 既存 `src/lib/server/auth/` 参照が `local\|cognito` 前提のため、実装を正とした。`auto` は `DEV` mode + `AUTH_MODE` 未指定時の派生状態として `resolveAuthMode()` で扱う |
+| `COGNITO_DEV_MODE` | `z.coerce.boolean().optional()` | `booleanStringSchema`（独自） | `z.coerce.boolean()` は JS の `Boolean("false") === true` 挙動を継承し、`"false"` を `true` と解釈してしまう。`booleanStringSchema` は `'true'` / `'false'` / `'1'` / `'0'` を明示的に判定する |
+
+(Issue #1211 / レビュー agentId `a962a9ce212bd4ec5` の指摘を反映)
+
 ## 参考
 
 - Martin Fowler, "Branch by Abstraction" — https://martinfowler.com/bliki/BranchByAbstraction.html


### PR DESCRIPTION
## Summary

- ADR-0040 本文の擬似コードと P1 実装 (PR #1204) の差分 2 件を ADR 末尾で追認
- supersede ではなく「実装補正メモ (P1)」として補足情報を追加（ADR status は accepted のまま）
- `AUTH_MODE` enum と `COGNITO_DEV_MODE` の差分 2 件（既存コード整合 / JS 挙動回避が理由）

## Closes

Closes #1211

## AC 突合 (Issue #1211)

| AC | 結果 | 根拠 |
|----|------|------|
| ADR-0040 末尾に「実装補正メモ (P1)」セクション追加 | ✅ | `docs/decisions/0040-runtime-mode-license-unified-architecture.md:252` に新セクション追加 |
| 2 件の差分を表形式で記載 | ✅ | `AUTH_MODE` / `COGNITO_DEV_MODE` の 2 行表 |
| ADR-0003 に基づき ADR 側で追認する旨を明記 | ✅ | セクション冒頭「ADR-0003（設計書は Single Source of Truth）に基づき、実装と本 ADR 擬似コードの乖離は ADR 側で追認する」 |
| CI `design-doc-check` 緑 | 🟡 | push 後に確認 |

## 実装実態の照合根拠

- `src/lib/runtime/env.ts:46` — `AUTH_MODE: z.enum(['local', 'cognito']).default('local')`
- `src/lib/runtime/env.ts:47` — `COGNITO_DEV_MODE: booleanStringSchema`
- `src/lib/runtime/env.ts:23` — `booleanStringSchema` 定義（'true'/'false'/'1'/'0' を明示判定）

## 変更タイプ

- [x] docs: ドキュメント（ADR 追記のみ、実装コード変更なし）

## 破壊的変更

- [x] 含まれない（ADR 本文の status/決定事項は変更せず補足セクション追加のみ）

## Test plan

- [x] ADR 本文を通読し、意味が通ることを確認
- [ ] CI の design-doc-check / markdown-lint が PASS すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)