### PR TITLE
refactor: #1210 check-no-direct-env-access.mjs に bracket / $env import 検出を追加

### DIFF
--- a/scripts/check-no-direct-env-access.mjs
+++ b/scripts/check-no-direct-env-access.mjs
@@ -122,11 +122,15 @@ export function detectEnvAccessInLine(line) {
  * @param {string} text
  * @returns {Array<{ line: number; kind: 'process.env' | '$env-import'; match: string; snippet: string }>}
  */
+/**
+ * @param {string} text
+ * @returns {Array<{line: number, kind: string, match: string, snippet: string}>}
+ */
 export function detectEnvAccessInText(text) {
 	const lines = text.split(/\r?\n/);
 	const hits = [];
 	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
+		const line = lines[i] ?? '';
 		// block comments / line comments で import 例示などは許す
 		if (/^\s*\/\//.test(line) || /^\s*\*/.test(line)) continue;
 		const hit = detectEnvAccessInLine(line);
@@ -142,12 +146,18 @@ export function detectEnvAccessInText(text) {
 	return hits;
 }
 
+/** @param {string} absFile */
 function shouldExclude(absFile) {
 	const rel = path.relative(REPO_ROOT, absFile);
 	if (rel.replace(/\\/g, '/') === SSOT) return true;
 	return EXCLUDE_PATTERNS.some((p) => p.test(rel));
 }
 
+/**
+ * @param {string} dir
+ * @param {string[]} [out]
+ * @returns {string[]}
+ */
 function walk(dir, out = []) {
 	if (!fs.existsSync(dir)) return out;
 	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -160,6 +170,7 @@ function walk(dir, out = []) {
 	return out;
 }
 
+/** @param {string} absFile */
 function checkFile(absFile) {
 	const rel = path.relative(REPO_ROOT, absFile);
 	if (GRANDFATHER.has(rel)) return null; // allowed for now
@@ -170,6 +181,7 @@ function checkFile(absFile) {
 }
 
 function main() {
+	/** @type {string[]} */
 	const files = [];
 	for (const root of SEARCH_ROOTS) {
 		walk(path.join(REPO_ROOT, root), files);

--- a/scripts/check-no-direct-env-access.mjs
+++ b/scripts/check-no-direct-env-access.mjs
@@ -1,15 +1,14 @@
 #!/usr/bin/env node
 /**
- * scripts/check-no-direct-env-access.mjs (ADR-0040 P1)
+ * scripts/check-no-direct-env-access.mjs (ADR-0040 P1, #1210 で拡張)
  *
- * `process.env.X` の直接参照を検出する。唯一の読込点は
- * `src/lib/runtime/env.ts` のみ。新規ファイル / grandfather 外のファイルに
- * 直接参照が入ったら CI を fail させる。
+ * 以下 2 種類の env 読込を検出し、`src/lib/runtime/env.ts` 以外での使用を禁ずる:
+ *   1. `process.env.X` / `process.env['X']` / `process.env["X"]`
+ *   2. `$env/(dynamic|static)/(private|public)` 経由 import
  *
  * 設計:
- *  - grandfather list = ADR-0040 採択時点 (2026-04-19) に既に process.env を
- *    直接参照していた 35 ファイル。P2-P4 で段階的に `$lib/runtime/env` 経由へ
- *    移行する
+ *  - grandfather list = ADR-0040 採択時点 (2026-04-19) に既に直接参照していた
+ *    ファイル群。P2-P4 で段階的に `$lib/runtime/env` 経由へ移行する
  *  - 新規ファイル追加時は即時 fail
  *  - grandfather ファイルの「新しい env 追加」は静的に検出しづらいため、
  *    レビュアー責任 + `check-new-required-env.mjs` (ADR-0029) で補完
@@ -34,9 +33,13 @@ const SSOT = 'src/lib/runtime/env.ts';
  * していたファイル。P2-P4 で `$lib/runtime/env` 経由へ段階的に移行する。
  *
  * このリストは P4 完了時にゼロになる予定。新規追加は禁止（レビュアーが reject）。
+ *
+ * #1210 で追加:
+ *  - `$env/dynamic/private` 利用 4 ファイルを grandfather に追加
  */
 const GRANDFATHER = new Set(
 	[
+		// --- process.env 直接参照 (ADR-0040 P1 採択時点) ---
 		'src/hooks.server.ts',
 		'src/lib/analytics/providers/dynamo.ts',
 		'src/lib/analytics/providers/sentry.ts',
@@ -72,6 +75,11 @@ const GRANDFATHER = new Set(
 		'src/routes/api/health/+server.ts',
 		'src/routes/api/v1/admin/tenant-cleanup/+server.ts',
 		'src/routes/api/v1/settings/vapid-key/+server.ts',
+		// --- $env/dynamic/private 経由 (#1210 で追加、P4 で移行) ---
+		'src/lib/server/discord-alert.ts',
+		'src/lib/server/services/discord-notify-service.ts',
+		'src/lib/server/services/pricing-trigger-service.ts',
+		// email-service.ts は上で既に掲載済み
 	].map((p) => p.replace(/\//g, path.sep)),
 );
 
@@ -82,8 +90,57 @@ const EXTENSIONS = new Set(['.ts', '.svelte']);
 /** 除外 (定義上 process.env を参照しても問題ないもの) */
 const EXCLUDE_PATTERNS = [/\.test\.ts$/, /\.spec\.ts$/];
 
-/** 検出パターン */
-const ENV_REGEX = /\bprocess\.env\.[A-Z][A-Z0-9_]*/;
+/**
+ * 検出パターン:
+ * - `process.env.FOO_BAR` (ドット記法)
+ * - `process.env['FOO']` / `process.env["FOO"]` (ブラケット記法)
+ */
+const PROCESS_ENV_REGEX = /\bprocess\.env(?:\.[A-Z][A-Z0-9_]*|\[\s*['"][A-Z][A-Z0-9_]*['"]\s*\])/;
+
+/**
+ * SvelteKit $env import 検出 (dynamic/static × private/public)。
+ * 例: `import { env } from '$env/dynamic/private';`
+ */
+const SVELTE_ENV_IMPORT_REGEX = /from\s+['"]\$env\/(?:dynamic|static)\/(?:private|public)['"]/;
+
+/**
+ * 1 行文字列を検査して、マッチした検出種別を返す。
+ * コメント行は呼び出し側で除外する。
+ * @param {string} line
+ * @returns {null | { kind: 'process.env' | '$env-import'; match: string }}
+ */
+export function detectEnvAccessInLine(line) {
+	const p = line.match(PROCESS_ENV_REGEX);
+	if (p) return { kind: 'process.env', match: p[0] };
+	const s = line.match(SVELTE_ENV_IMPORT_REGEX);
+	if (s) return { kind: '$env-import', match: s[0] };
+	return null;
+}
+
+/**
+ * ファイル本文全体を検査して、検出行の配列を返す (grandfather 判定は呼び出し側)。
+ * @param {string} text
+ * @returns {Array<{ line: number; kind: 'process.env' | '$env-import'; match: string; snippet: string }>}
+ */
+export function detectEnvAccessInText(text) {
+	const lines = text.split(/\r?\n/);
+	const hits = [];
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		// block comments / line comments で import 例示などは許す
+		if (/^\s*\/\//.test(line) || /^\s*\*/.test(line)) continue;
+		const hit = detectEnvAccessInLine(line);
+		if (hit) {
+			hits.push({
+				line: i + 1,
+				kind: hit.kind,
+				match: hit.match,
+				snippet: line.trim().slice(0, 120),
+			});
+		}
+	}
+	return hits;
+}
 
 function shouldExclude(absFile) {
 	const rel = path.relative(REPO_ROOT, absFile);
@@ -107,17 +164,7 @@ function checkFile(absFile) {
 	const rel = path.relative(REPO_ROOT, absFile);
 	if (GRANDFATHER.has(rel)) return null; // allowed for now
 	const text = fs.readFileSync(absFile, 'utf8');
-	const lines = text.split(/\r?\n/);
-	const hits = [];
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
-		// block comments / line comments で import 例示などは許す
-		if (/^\s*\/\//.test(line) || /^\s*\*/.test(line)) continue;
-		const m = line.match(ENV_REGEX);
-		if (m) {
-			hits.push({ line: i + 1, match: m[0], snippet: line.trim().slice(0, 120) });
-		}
-	}
+	const hits = detectEnvAccessInText(text);
 	if (hits.length === 0) return null;
 	return { file: rel.replace(/\\/g, '/'), hits };
 }
@@ -133,18 +180,16 @@ function main() {
 		if (r) violations.push(r);
 	}
 	if (violations.length === 0) {
-		console.log(
-			'[check-no-direct-env-access] OK — grandfather 外のファイルに process.env 直接参照なし',
-		);
+		console.log('[check-no-direct-env-access] OK — grandfather 外のファイルに env 直接参照なし');
 		process.exit(0);
 	}
 	console.error(
-		`[check-no-direct-env-access] NG — ${violations.length} ファイルに新規の process.env 直接参照があります (ADR-0040):\n`,
+		`[check-no-direct-env-access] NG — ${violations.length} ファイルに新規の env 直接参照があります (ADR-0040):\n`,
 	);
 	for (const v of violations) {
 		console.error(`  ${v.file}`);
 		for (const h of v.hits) {
-			console.error(`    line ${h.line}: ${h.match}`);
+			console.error(`    line ${h.line} [${h.kind}]: ${h.match}`);
 			console.error(`      ${h.snippet}`);
 		}
 	}
@@ -161,4 +206,7 @@ function main() {
 	process.exit(1);
 }
 
-main();
+// スクリプトとして直接実行された場合のみ main を起動 (テストから import 時は skip)
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+	main();
+}

--- a/tests/unit/scripts/check-no-direct-env-access.test.ts
+++ b/tests/unit/scripts/check-no-direct-env-access.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-// @ts-expect-error — JS module, no types
 import {
 	detectEnvAccessInLine,
 	detectEnvAccessInText,
@@ -94,12 +93,12 @@ const a = process.env.FOO;
 const b = process.env['BAR'];`;
 			const hits = detectEnvAccessInText(text);
 			expect(hits).toHaveLength(3);
-			expect(hits[0].line).toBe(1);
-			expect(hits[0].kind).toBe('$env-import');
-			expect(hits[1].line).toBe(2);
-			expect(hits[1].kind).toBe('process.env');
-			expect(hits[2].line).toBe(3);
-			expect(hits[2].kind).toBe('process.env');
+			expect(hits[0]?.line).toBe(1);
+			expect(hits[0]?.kind).toBe('$env-import');
+			expect(hits[1]?.line).toBe(2);
+			expect(hits[1]?.kind).toBe('process.env');
+			expect(hits[2]?.line).toBe(3);
+			expect(hits[2]?.kind).toBe('process.env');
 		});
 
 		it('// コメント行はスキップする', () => {
@@ -107,8 +106,8 @@ const b = process.env['BAR'];`;
 const real = process.env.REAL;`;
 			const hits = detectEnvAccessInText(text);
 			expect(hits).toHaveLength(1);
-			expect(hits[0].line).toBe(2);
-			expect(hits[0].match).toContain('REAL');
+			expect(hits[0]?.line).toBe(2);
+			expect(hits[0]?.match).toContain('REAL');
 		});
 
 		it('* ブロックコメント行はスキップする', () => {
@@ -116,7 +115,7 @@ const real = process.env.REAL;`;
 const real = process.env.REAL;`;
 			const hits = detectEnvAccessInText(text);
 			expect(hits).toHaveLength(1);
-			expect(hits[0].match).toContain('REAL');
+			expect(hits[0]?.match).toContain('REAL');
 		});
 
 		it('検出がゼロなら空配列を返す', () => {

--- a/tests/unit/scripts/check-no-direct-env-access.test.ts
+++ b/tests/unit/scripts/check-no-direct-env-access.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+// @ts-expect-error — JS module, no types
+import {
+	detectEnvAccessInLine,
+	detectEnvAccessInText,
+} from '../../../scripts/check-no-direct-env-access.mjs';
+
+type LineHit = {
+	kind: 'process.env' | '$env-import';
+	match: string;
+} | null;
+
+describe('check-no-direct-env-access (#1210 拡張)', () => {
+	describe('detectEnvAccessInLine — ドット記法', () => {
+		it('process.env.FOO を検出する', () => {
+			const r = detectEnvAccessInLine('const x = process.env.FOO;') as LineHit;
+			expect(r).not.toBeNull();
+			expect(r?.kind).toBe('process.env');
+			expect(r?.match).toBe('process.env.FOO');
+		});
+
+		it('アンダースコア付きの大文字 env を検出する', () => {
+			const r = detectEnvAccessInLine('if (process.env.MY_LONG_NAME_2) doStuff();') as LineHit;
+			expect(r?.match).toBe('process.env.MY_LONG_NAME_2');
+		});
+	});
+
+	describe('detectEnvAccessInLine — ブラケット記法 (#1210 追加)', () => {
+		it("process.env['FOO'] を検出する", () => {
+			const r = detectEnvAccessInLine("const x = process.env['FOO'];") as LineHit;
+			expect(r).not.toBeNull();
+			expect(r?.kind).toBe('process.env');
+		});
+
+		it('process.env["FOO"] (double quote) を検出する', () => {
+			const r = detectEnvAccessInLine('const x = process.env["FOO_BAR"];') as LineHit;
+			expect(r).not.toBeNull();
+			expect(r?.kind).toBe('process.env');
+		});
+
+		it('ブラケット内の空白を許容する', () => {
+			const r = detectEnvAccessInLine("process.env[ 'FOO' ]") as LineHit;
+			expect(r).not.toBeNull();
+		});
+	});
+
+	describe('detectEnvAccessInLine — $env import (#1210 追加)', () => {
+		it("'$env/dynamic/private' import を検出する", () => {
+			const r = detectEnvAccessInLine("import { env } from '$env/dynamic/private';") as LineHit;
+			expect(r).not.toBeNull();
+			expect(r?.kind).toBe('$env-import');
+		});
+
+		it("'$env/static/private' import を検出する", () => {
+			const r = detectEnvAccessInLine('import { SECRET } from "$env/static/private";') as LineHit;
+			expect(r?.kind).toBe('$env-import');
+		});
+
+		it("'$env/dynamic/public' import を検出する", () => {
+			const r = detectEnvAccessInLine("import { env } from '$env/dynamic/public';") as LineHit;
+			expect(r?.kind).toBe('$env-import');
+		});
+	});
+
+	describe('detectEnvAccessInLine — false positive 回避', () => {
+		it('小文字の変数名にはマッチしない', () => {
+			const r = detectEnvAccessInLine('const foo = process.env.lowercase;');
+			expect(r).toBeNull();
+		});
+
+		it('単なる文字列 "process.env" にはマッチしない', () => {
+			const r = detectEnvAccessInLine('const msg = "process.env is global";');
+			expect(r).toBeNull();
+		});
+
+		it('$env を含むが import ではない文字列にはマッチしない', () => {
+			const r = detectEnvAccessInLine('// see $env/dynamic/private docs');
+			// コメント除外は detectEnvAccessInText 側で行う。行レベルでは正規表現が
+			// from '...' を要求するためこの文字列は素通りすべき
+			expect(r).toBeNull();
+		});
+
+		it('通常の変数参照 envFoo にはマッチしない', () => {
+			const r = detectEnvAccessInLine('const x = envFoo.BAR;');
+			expect(r).toBeNull();
+		});
+	});
+
+	describe('detectEnvAccessInText — 複数行・コメント除外', () => {
+		it('複数の検出を行番号付きで返す', () => {
+			const text = `import { env } from '$env/dynamic/private';
+const a = process.env.FOO;
+const b = process.env['BAR'];`;
+			const hits = detectEnvAccessInText(text);
+			expect(hits).toHaveLength(3);
+			expect(hits[0].line).toBe(1);
+			expect(hits[0].kind).toBe('$env-import');
+			expect(hits[1].line).toBe(2);
+			expect(hits[1].kind).toBe('process.env');
+			expect(hits[2].line).toBe(3);
+			expect(hits[2].kind).toBe('process.env');
+		});
+
+		it('// コメント行はスキップする', () => {
+			const text = `// const ignored = process.env.SKIP;
+const real = process.env.REAL;`;
+			const hits = detectEnvAccessInText(text);
+			expect(hits).toHaveLength(1);
+			expect(hits[0].line).toBe(2);
+			expect(hits[0].match).toContain('REAL');
+		});
+
+		it('* ブロックコメント行はスキップする', () => {
+			const text = ` * @example process.env.DOC_ONLY
+const real = process.env.REAL;`;
+			const hits = detectEnvAccessInText(text);
+			expect(hits).toHaveLength(1);
+			expect(hits[0].match).toContain('REAL');
+		});
+
+		it('検出がゼロなら空配列を返す', () => {
+			const hits = detectEnvAccessInText("import { env } from '$lib/runtime/env';");
+			expect(hits).toEqual([]);
+		});
+	});
+});


### PR DESCRIPTION
## 背景

ADR-0040 P1 の `scripts/check-no-direct-env-access.mjs` は `process.env.X` (ドット記法) のみ検出していた。以下 2 パターンが false negative:

1. ブラケット記法 `process.env['X']` / `process.env["X"]`
2. SvelteKit `$env/(dynamic|static)/(private|public)` 経由 import

実スキャンで `$env/dynamic/private` 経由の env 読込が **4 ファイル**で使われており、ADR-0040 の「env 読込を SSOT に一本化」に反する状態だった。

## Summary

- 検出 regex を拡張 (`PROCESS_ENV_REGEX` / `SVELTE_ENV_IMPORT_REGEX`)
- 既存 `$env` 利用 4 ファイルを grandfather list に追加（P4 で SSOT 経由に移行）
  - `src/lib/server/discord-alert.ts`
  - `src/lib/server/services/discord-notify-service.ts`
  - `src/lib/server/services/email-service.ts` *(既存掲載済み)*
  - `src/lib/server/services/pricing-trigger-service.ts`
- スクリプト内部の純粋関数 (`detectEnvAccessInLine` / `detectEnvAccessInText`) を export しテスト可能に
- `tests/unit/scripts/check-no-direct-env-access.test.ts` 新設 (16 assertion)

## AC 突合

- [x] ブラケット記法 `process.env['X']` を検出
- [x] `$env/dynamic/private` / `$env/static/private` import を検出（`$env/*/public` も対応）
- [x] 既存 grandfather list (35 files) は維持
- [x] ユニットテスト追加（両パターンの detect / false-positive 回避）
- [ ] CI (`lint-and-test` ジョブ) が緑 → push 後確認

## 設計制約準拠

- [x] 既存 script の構造 (grandfather list 方式) を維持
- [x] コメント行除外ロジック維持
- [x] Windows path separator 対応維持 (`path.sep` 置換 + `fileURLToPath` による isMain 判定)

## Test plan

- [x] `node scripts/check-no-direct-env-access.mjs` — OK (0 violations)
- [x] `npx vitest run tests/unit/scripts/check-no-direct-env-access.test.ts` — 16/16 passed
- [x] `npx biome check` — clean (auto-fix 適用済み)
- [ ] CI: lint-and-test ジョブ

## Closes

Closes #1210

🤖 Generated with [Claude Code](https://claude.com/claude-code)