### PR TITLE
refactor: #1206 screenshot 撮影 2 スクリプトの共通部分を SSOT 化

### DIFF
--- a/scripts/capture-hp-screenshots.mjs
+++ b/scripts/capture-hp-screenshots.mjs
@@ -12,6 +12,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { chromium } from 'playwright';
+import { convertToWebP, withScreenshotParam } from './lib/screenshot-helpers.mjs';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
 const OUTPUT_DIR = path.resolve('site/screenshots');
@@ -166,18 +167,6 @@ if (!onlyGroup || onlyGroup === 'feature') ALL_SCREENSHOTS.push(...FEATURE_SCREE
 if (!onlyGroup || onlyGroup === 'age') ALL_SCREENSHOTS.push(...AGE_SCREENSHOTS);
 
 // ============================================================
-// Helper: `?screenshot=1` で demo 固有 UI を非表示化
-// ============================================================
-
-// `?screenshot=1` で demo 固有 UI（バナー・プラン切替・ガイドバー・フローティング CTA）を
-// 非表示にし、実アプリと同じ見た目の SS を取得する。根本解決（demo/app 統合）は別 Issue。
-const SCREENSHOT_QUERY = 'screenshot=1';
-
-function withScreenshotParam(path) {
-	return `${path}${path.includes('?') ? '&' : '?'}${SCREENSHOT_QUERY}`;
-}
-
-// ============================================================
 // Main capture function
 // ============================================================
 
@@ -249,23 +238,22 @@ async function captureScreenshots() {
 	await browser.close();
 	console.log(`\n撮影完了: ${successCount}/${totalFiles} ファイル`);
 
-	// WebP conversion using sharp Node API
+	// WebP conversion using scripts/lib/screenshot-helpers.mjs
 	if (doWebp && pngFiles.length > 0) {
-		const sharp = (await import('sharp')).default;
 		console.log('\n=== WebP変換 ===');
 		let convertCount = 0;
 		for (const pngPath of pngFiles) {
 			const webpPath = pngPath.replace(/\.png$/, '.webp');
-			try {
-				await sharp(pngPath).webp({ quality: 80 }).toFile(webpPath);
+			const result = await convertToWebP(pngPath, { quality: 80, outPath: webpPath });
+			if (result.ok) {
 				const stat = fs.statSync(webpPath);
 				console.log(`  -> ${path.basename(webpPath)} (${(stat.size / 1024).toFixed(0)} KB)`);
 				convertCount++;
-			} catch (error) {
+			} else {
 				console.error(`  WebP変換失敗: ${path.basename(pngPath)}`);
-				console.error(`    原因: ${error.message}`);
-				if (error.stderr) {
-					console.error(`    stderr: ${error.stderr}`);
+				console.error(`    原因: ${result.error.message}`);
+				if (result.error.stderr) {
+					console.error(`    stderr: ${result.error.stderr}`);
 				}
 			}
 		}

--- a/scripts/lib/screenshot-helpers.mjs
+++ b/scripts/lib/screenshot-helpers.mjs
@@ -1,0 +1,57 @@
+/**
+ * scripts/lib/screenshot-helpers.mjs (#1206)
+ *
+ * `take-lp-screenshots.mjs` / `capture-hp-screenshots.mjs` 共通ユーティリティの SSOT。
+ * 両スクリプトで重複していた定数・helper を統一し、#1180 (`?mode=demo` 移行) 時の
+ * 片側更新忘れを防ぐ。
+ *
+ * 注意: VIEWPORTS の寸法は意図的に統一していない（take-lp は desktop=1280x800、
+ * capture-hp は desktop=1440x900）。既存 SS 出力との互換性のため、各スクリプトで
+ * それぞれ定義すること。共通化するのは「クエリ文字列」「WebP 変換」のみ。
+ */
+
+import fs from 'node:fs';
+
+/**
+ * `?screenshot=1` で demo 固有 UI（バナー・プラン切替・ガイドバー・フローティング CTA）
+ * を非表示化する URL パラメータ。根本解決（demo/app 統合）は #1180 で別途。
+ */
+export const SCREENSHOT_QUERY = 'screenshot=1';
+
+/**
+ * パスに screenshot パラメータを追加する。既存クエリが無ければ `?`、あれば `&` を付ける。
+ * @param {string} path - 例: `/demo/lower/home` または `/demo/checklist?childId=904`
+ * @returns {string}
+ */
+export function withScreenshotParam(path) {
+	return `${path}${path.includes('?') ? '&' : '?'}${SCREENSHOT_QUERY}`;
+}
+
+/**
+ * PNG/任意画像ファイルを WebP に変換する。既存ファイルを上書きするか、別ファイルに書くかは
+ * `outPath` の有無で切り替える。
+ *
+ * - `outPath` 省略: 入力ファイルを WebP バイナリで上書き（take-lp 互換）
+ * - `outPath` 指定: `<outPath>.webp` として出力（capture-hp 互換）
+ *
+ * @param {string} filePath - 入力画像パス
+ * @param {object} [options]
+ * @param {number} [options.quality=85] - WebP 品質 (0-100)
+ * @param {string} [options.outPath] - 出力パス（省略時は `filePath` を上書き）
+ * @returns {Promise<{ ok: true; outPath: string } | { ok: false; error: Error }>}
+ */
+export async function convertToWebP(filePath, options = {}) {
+	const { quality = 85, outPath } = options;
+	try {
+		const sharp = (await import('sharp')).default;
+		if (outPath) {
+			await sharp(filePath).webp({ quality }).toFile(outPath);
+			return { ok: true, outPath };
+		}
+		const webpBuf = await sharp(filePath).webp({ quality }).toBuffer();
+		fs.writeFileSync(filePath, webpBuf);
+		return { ok: true, outPath: filePath };
+	} catch (error) {
+		return { ok: false, error };
+	}
+}

--- a/scripts/lib/screenshot-helpers.mjs
+++ b/scripts/lib/screenshot-helpers.mjs
@@ -52,6 +52,6 @@ export async function convertToWebP(filePath, options = {}) {
 		fs.writeFileSync(filePath, webpBuf);
 		return { ok: true, outPath: filePath };
 	} catch (error) {
-		return { ok: false, error };
+		return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
 	}
 }

--- a/scripts/take-lp-screenshots.mjs
+++ b/scripts/take-lp-screenshots.mjs
@@ -2,6 +2,7 @@
 import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { chromium } from 'playwright';
+import { convertToWebP, withScreenshotParam } from './lib/screenshot-helpers.mjs';
 
 // biome-ignore lint/suspicious/noConsole: CLI script requires console output
 const log = (...a) => console.log(...a);
@@ -85,25 +86,6 @@ async function waitForApp(page) {
 	} catch {
 		await page.waitForTimeout(3000);
 	}
-}
-
-async function convertToWebP(filePath) {
-	try {
-		const sharp = await import('sharp');
-		const webpBuf = await sharp.default(filePath).webp({ quality: 85 }).toBuffer();
-		writeFileSync(filePath, webpBuf);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-// `?screenshot=1` で demo 固有 UI（バナー・プラン切替・ガイドバー・フローティング CTA）を
-// 非表示にし、実アプリと同じ見た目の SS を取得する。根本解決（demo/app 統合）は別 Issue。
-const SCREENSHOT_QUERY = 'screenshot=1';
-
-function withScreenshotParam(path) {
-	return `${path}${path.includes('?') ? '&' : '?'}${SCREENSHOT_QUERY}`;
 }
 
 async function captureAgeMode(browser, { mode, filePrefix }) {

--- a/tests/unit/scripts/screenshot-helpers.test.ts
+++ b/tests/unit/scripts/screenshot-helpers.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+// @ts-expect-error — JS module, no types
+import { SCREENSHOT_QUERY, withScreenshotParam } from '../../../scripts/lib/screenshot-helpers.mjs';
+
+describe('scripts/lib/screenshot-helpers — #1206 SSOT', () => {
+	it('SCREENSHOT_QUERY は "screenshot=1"', () => {
+		expect(SCREENSHOT_QUERY).toBe('screenshot=1');
+	});
+
+	describe('withScreenshotParam', () => {
+		it('クエリなしパスには ? を付ける', () => {
+			expect(withScreenshotParam('/demo/lower/home')).toBe('/demo/lower/home?screenshot=1');
+		});
+
+		it('既存クエリがあれば & を付ける', () => {
+			expect(withScreenshotParam('/demo/checklist?childId=904')).toBe(
+				'/demo/checklist?childId=904&screenshot=1',
+			);
+		});
+
+		it('複数クエリがあっても & でつなぐ', () => {
+			expect(withScreenshotParam('/a?b=1&c=2')).toBe('/a?b=1&c=2&screenshot=1');
+		});
+
+		it('ルートパス "/" も処理できる', () => {
+			expect(withScreenshotParam('/')).toBe('/?screenshot=1');
+		});
+	});
+});

--- a/tests/unit/scripts/screenshot-helpers.test.ts
+++ b/tests/unit/scripts/screenshot-helpers.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 
-// @ts-expect-error — JS module, no types
 import { SCREENSHOT_QUERY, withScreenshotParam } from '../../../scripts/lib/screenshot-helpers.mjs';
 
 describe('scripts/lib/screenshot-helpers — #1206 SSOT', () => {


### PR DESCRIPTION
## 背景

`scripts/take-lp-screenshots.mjs` と `scripts/capture-hp-screenshots.mjs` は用途は異なるが、以下の共通要素を重複保持していた。片側更新忘れで #1180 (`?screenshot=1` → `?mode=demo` 移行) 時の事故リスクあり。

- `SCREENSHOT_QUERY = 'screenshot=1'` 定数
- `withScreenshotParam(path)` helper
- `convertToWebP(filePath)` helper（sharp 経由、quality 設定が微妙に異なる）

## Summary

- `scripts/lib/screenshot-helpers.mjs` を新設し両スクリプトが import
- `convertToWebP` は引数で動作を切替:
  - `outPath` 省略 → 入力を WebP で上書き（take-lp 互換、default quality=85）
  - `outPath` 指定 → 別ファイルに出力（capture-hp 互換、quality=80）
- `tests/unit/scripts/screenshot-helpers.test.ts` 新設（5 assertion）

### 意図的に抽出しなかったもの

`VIEWPORTS` の desktop 寸法は両スクリプトで意図的に異なる（take-lp=1280x800 / capture-hp=1440x900）。既存 SS 出力互換のため統一しない。helper 側にコメントで明記。

## AC 突合

- [x] `scripts/lib/screenshot-helpers.mjs` 新設
- [x] `scripts/take-lp-screenshots.mjs` から共通部分を削除して import
- [x] `scripts/capture-hp-screenshots.mjs` から共通部分を削除して import
- [x] 両スクリプトの I/O 仕様維持 (convertToWebP の quality / outPath 引数差分で吸収)
- [ ] PR #1184 (CI 自動撮影) の CI 緑 → PR merge 後 main 取込で確認

## Test plan

- [x] `node -e "import('./scripts/lib/screenshot-helpers.mjs')..."` — smoke 通過
- [x] `node --check scripts/take-lp-screenshots.mjs && node --check scripts/capture-hp-screenshots.mjs` — 構文 OK
- [x] `npx vitest run tests/unit/scripts` — 5/5 passed
- [x] `npx biome check` — 新規 warning なし（既存 noConsole 警告のみ）
- [ ] CI lp-metrics / screenshot-check ジョブ

## 後続 Issue

#1208 (scripts/ の waitForTimeout 置換) は本 PR の helper 統合後、同 helper に `waitForStablePage()` を追加して対応予定。

## Closes

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)