### PR TITLE
infra: #1197 #1198 QM 必須実行手順 / PR template QM セクション追加

### DIFF
--- a/.claude/agents/qa-session.md
+++ b/.claude/agents/qa-session.md
@@ -19,6 +19,45 @@ description: Use when reviewing PRs, running quality checks, performing regressi
 
 Ready for Review の PR を検出してレビュー・修正・マージする。Dev セッションの成果を商品品質に引き上げる最後の砦。
 
+## QM approve 前の必須実行手順（CI 緑でも approve 出さない — #1197 / #1198）
+
+以下を **1 PR につき全て実行** する。どれか 1 つでも欠けていれば approve しない。
+順序を逆転させない（CI 確認は最後）。
+
+1. **Issue 照合**:
+   - `gh issue view <closes #X の X>` で Issue を開く
+   - Acceptance Criteria の各項目を PR diff と 1 対 1 で突合
+   - ずれがあれば blocking で指摘（PR 作者に質問）
+
+2. **スクリーンショット実視認**（PR 本文の `![]()` / `<img>` / 外部 URL 全て）:
+   - 画像を Read tool または外部ビューアで **実際に開いて見る**
+   - **見たと書くだけでなく、1 画像につき最低 1 行の所見を approve body に残す**
+   - 観点: `docs/DESIGN.md` §9 禁忌事項 6 点 / 年齢モード別 tapSize・fontScale /
+     競合比較 / ダークパターン混入 / Before/After の変化が意図通りか
+
+3. **スクリーンショット欠落の検知**:
+   - UI / LP 変更を含む PR に画像添付が無い → blocking で指摘
+   - CI の `screenshot-check` は「画像があるか」のみ検証。内容吟味は QM 専権
+
+4. **CI ステータス確認**:
+   - `gh pr checks <番号>` で全緑を**補助情報として**確認
+   - 上記 1–3 を終えた後に実施。順序を逆転させない
+
+5. **承認 / マージ判断**:
+   - 全項目クリア → `gh pr review --approve --body "<所見をまとめる>"`
+   - マージは `gh pr merge --squash`（PR 本文・設計書が最新を再確認後）
+   - マージ後: `gh run watch` でデプロイ結果まで追跡
+
+### QM が絶対にやってはいけないこと
+
+- **CI 緑 = approve**: 自動マージツール化した瞬間に QM ロールは終わる
+- **スクリーンショット未視認で approve**: 添付されているだけで内容未確認は不可
+- **Issue の closes #X の X を開かずに approve**: AC 照合漏れの温床
+- **「見ました」とだけ書く所見**: 具体的な所見（色・形・tapSize・違和感の有無）を残す
+- **複数 PR 同時処理**: 1 件ずつ精査。まとめ承認は品質粒度を落とす
+
+起動時に必ず `memory/feedback_quality_manager_is_not_ci_gate.md` を読み直す。
+
 ## PR レビューフロー
 
 ### 1. コンテキスト理解

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -368,3 +368,26 @@ await page.screenshot({ path: 'screenshots/admin-home-after.png', fullPage: true
 - [ ] `npx vitest run` — ユニットテスト全通過
 - [ ] `npx playwright test` — E2Eテスト全通過
 - [ ] PRのサイズが適切（目安: 500行/10ファイル以内。超える場合は分割を検討）
+
+---
+
+## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）
+
+<!-- ⚠️ QM が approve するときに記入。PR 作者は空欄のまま Ready にしてよい。
+     CI 緑 = approve ではない。以下 5 項目を実行した証跡を残さずに approve しない。 -->
+
+- [ ] **Issue AC 照合**: `closes #X` の Issue を開き、Acceptance Criteria 全項目が PR diff で達成されていることを確認した
+- [ ] **スクリーンショット実視認**: 添付画像を全て目視し、UI/UX デザイナー観点で違和感が無いことを確認した
+- [ ] **禁忌事項チェック**: `docs/DESIGN.md` §9 禁忌事項 6 点（色直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / `<style>` 50 行超え）のいずれにも該当しないことを確認した
+- [ ] **並行実装同期**: デモ / 5 年齢モード / LP / ナビ 3 種の同期漏れが無いことを確認した
+- [ ] **スコープ外起票**: 気付きがあれば Issue 起票済み（スルー禁止）
+
+### QM 所見（スクリーンショット 1 枚ごとに 1 行以上）
+
+<!-- 「見た」とだけ書かない。具体的に何を確認したかを残す。
+例:
+- `marketplace-desktop-viewport.png`: フィルタチップが `var(--color-action-primary)` を使用、Button primitive 利用確認
+- `marketplace-mobile-dialog.png`: bottom sheet が高さ 60% で親指操作圏 (#1171 AC3) を満たす
+-->
+
+詳細手順: `docs/sessions/qa-session.md` 「QM approve 前の必須実行手順」

--- a/docs/sessions/qa-session.md
+++ b/docs/sessions/qa-session.md
@@ -27,6 +27,46 @@ https://github.com/Takenori-Kusaka/ganbari-quest/pulls を監視し、Ready for 
 
 Issue は PO セッションが作成し、PR は Dev セッションが提出します。あなたはその成果を商品品質に引き上げる最後の砦です。
 
+## QM approve 前の必須実行手順（CI 緑でも approve 出さない — #1197 / #1198）
+
+以下を **1 PR につき全て実行** する。どれか 1 つでも欠けていれば approve しない。
+順序を逆転させない（CI 確認は最後）。
+
+1. **Issue 照合**:
+   - `gh issue view <closes #X の X>` で Issue を開く
+   - Acceptance Criteria の各項目を PR diff と 1 対 1 で突合
+   - ずれがあれば blocking で指摘（PR 作者に質問）
+
+2. **スクリーンショット実視認**（PR 本文の `![]()` / `<img>` / 外部 URL 全て）:
+   - 画像を Read tool または外部ビューアで **実際に開いて見る**
+   - **見たと書くだけでなく、1 画像につき最低 1 行の所見を approve body に残す**
+   - 例: 「desktop SS で primitives Button が使われていることを確認」「mobile SS で tapSize=56px (elementary) が効いていることを確認」
+   - 観点: `docs/DESIGN.md` §9 禁忌事項 6 点 / 年齢モード別 tapSize・fontScale /
+     競合比較 / ダークパターン混入 / Before/After の変化が意図通りか
+
+3. **スクリーンショット欠落の検知**:
+   - UI / LP 変更を含む PR なのに画像添付が無い → blocking で指摘
+   - CI の `screenshot-check` は「画像があるか」のみ検証。内容吟味は QM 専権
+
+4. **CI ステータス確認**:
+   - `gh pr checks <番号>` で全緑を**補助情報として**確認
+   - 上記 1–3 を終えた後に実施。順序を逆転させない
+
+5. **承認 / マージ判断**:
+   - 全項目クリア → `gh pr review --approve --body "<所見をまとめる>"`
+   - マージは `gh pr merge --squash`（PR 本文・設計書が最新を再確認後）
+   - マージ後: **本番環境へ自動デプロイ**されることを意識。`gh run watch` でデプロイ結果まで確認
+
+### QM が絶対にやってはいけないこと
+
+- **CI 緑 = approve**: 自動マージツール化した瞬間に QM ロールは終わる
+- **スクリーンショット未視認で approve**: 添付されているだけで内容未確認は不可
+- **Issue の closes #X の X を開かずに approve**: AC 照合漏れの温床
+- **「見ました」とだけ書く所見**: 具体的な所見（色・形・tapSize・違和感の有無）を残す
+- **複数 PR 同時処理**: 1 件ずつ精査。まとめ承認は品質粒度を落とす
+
+起動時に必ず `memory/feedback_quality_manager_is_not_ci_gate.md` を読み直す。
+
 ## 作業の進め方
 
 ### 起動時


### PR DESCRIPTION
## Summary

Quality Manager の「CI 緑 = approve」退行（2026-04-06 と 2026-04-19 の 2 回 PO から同一指摘）を構造対策。

- `.claude/agents/qa-session.md` と `docs/sessions/qa-session.md` の冒頭に「QM approve 前の必須実行手順」順序付きリストを配置: Issue 照合 → SS 実視認 → SS 欠落検知 → CI 確認 → 承認判断
- `.github/PULL_REQUEST_TEMPLATE.md` の末尾に「Quality Manager レビュー結果」セクションを追加（QM が approve 時に記入する 5 項目 + スクリーンショット 1 枚ごとに所見 1 行以上の所見欄）
- 「CI 緑 = approve ではない」「SS 未視認 approve 禁止」「Issue の closes を開かず approve 禁止」を禁忌として明文化

memory の `feedback_quality_manager_is_not_ci_gate.md` は 2026-04-19 に既に作成済み（MEMORY.md からリンク済み）。

## Issue AC 対応

### #1197 AC
- [x] `.claude/agents/qa-session.md` に必須チェックリスト追記
- [x] `memory/feedback_quality_manager_is_not_ci_gate.md` (既存) で `MEMORY.md` からリンク済み
- [x] 本 PR の QM 承認時に QM セクションを埋めて dogfooding する

### #1198 AC
- [x] AC1: `docs/sessions/qa-session.md` に「QM 必須実行手順」順序付きリスト追記
- [x] AC2: `.github/PULL_REQUEST_TEMPLATE.md` に「Quality Manager レビュー結果」セクション追加
- [x] AC3: `memory/feedback_quality_manager_is_not_ci_gate.md` (既存、リンク済み)

## 変更タイプ

- [x] infra: インフラ・CI/CD
- [x] docs: ドキュメント

## Test plan

- [x] ドキュメントのみの変更（コード変更なし）
- [ ] CI: markdown / template lint 通過

Closes #1197
Closes #1198

🤖 Generated with [Claude Code](https://claude.com/claude-code)