### PR TITLE
fix: #1205 biome.json で lp-metrics.json を除外

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -126,7 +126,8 @@
 			"!**/storybook-static",
 			"!**/app.css",
 			"!**/.claude",
-			"!**/*.md"
+			"!**/*.md",
+			"!**/lp-metrics.json"
 		]
 	}
 }


### PR DESCRIPTION
## 概要
`scripts/measure-lp-dimensions.mjs` が生成する `lp-metrics.json` は `.gitignore` 済みだが、Biome は独自のファイル探索で拾うため `npx biome check .` が format error で停止する問題を修正。

`biome.json` の `files.includes` に `!**/lp-metrics.json` を追加し除外。

closes #1205

## AC 検証マップ (ADR-0038)

| # | Acceptance Criteria | 検証方法 | 結果 |
|---|---|---|---|
| 1 | `biome.json` の `files.ignore` に `lp-metrics.json` を追加 | `git diff biome.json` | ✅ `"!**/lp-metrics.json"` を `files.includes` に追加（Biome 2.x は `files.ignore` ではなく `files.includes` に `!` プレフィックスで除外するのが正しい書き方） |
| 2 | `npx biome check .` で該当ファイルに関する警告/エラーが 0 になる | コマンド実行 | ✅ 修正後の出力に `lp-metrics.json` 関連の指摘 0 件（608 warnings は既存他ファイル分、errors 0） |
| 3 | main 基準で修正前後の biome 出力を diff で証跡提示 | 下記 | ✅ 下記に提示 |

### 修正前後の biome 出力 diff

```text
$ npx biome check lp-metrics.json

=== BEFORE (main) ===
Checked 1 file in 1924ms. No fixes applied.
Found 1 error.
  × Some errors were emitted while running checks.

=== AFTER (this PR) ===
  i These paths were provided but ignored:
  - lp-metrics.json
Checked 0 files in 1ms. No fixes applied.
```

## 補足
Issue 本文には `files.ignore` とあるが、Biome v2 のスキーマでは `files.ignore` は廃止され `files.includes` に `!` プレフィックスで除外を書く仕様になっている（`biome.json:113-131` の既存パターンと同じ方式）。

## Things Not To Do チェック
- [x] 禁止 5 項目 (ADR-0029) 該当なし — 単なる設定追加
- [x] 新規 env/secret なし

## スクリーンショット / ビジュアルデモ
UI 変更なし（ビルド設定のみ）。

## 配布済み env / secret (ADR-0029)
該当なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)