### PR TITLE
docs: #1211 ADR-0040 に P1 実装補正メモ追加

### DIFF
--- a/docs/decisions/0040-runtime-mode-license-unified-architecture.md
+++ b/docs/decisions/0040-runtime-mode-license-unified-architecture.md
@@ -249,9 +249,24 @@ export function ensureCan(ctx: EvaluationContext, cap: Capability): void;
 - **"機能が使えるか" は純粋関数で表現できる** — Side effect（認可エラー throw）は呼び出し側の `ensureCan()` に閉じ込める
 - **Pre-PMF では外部依存より内部整理** — SaaS を入れる前に、自社コードの境界を整えるほうが ROI が高い（ADR-0034 と同じ哲学）
 
+## 実装補正メモ (P1) — #1211
+
+P1 実装 (PR #1204: `src/lib/runtime/env.ts`) 時点で、本 ADR 本文の擬似コードと実装に次の 2 件の差分が発生した。
+**ADR-0003「設計書は Single Source of Truth」に基づき、本 ADR の擬似コードは実装側の記述を正とする**（本 ADR 本文は改訂せず、補足としてここに追認する — supersede ではない）。
+
+| 項目 | 本 ADR 擬似コード | P1 実装 (`src/lib/runtime/env.ts`) | 採用 | 理由 |
+|------|------------------|------------------------------------|------|------|
+| `AUTH_MODE` enum | `['auto', 'cognito']` | `['local', 'cognito']` | **実装が正** | 既存コード (`src/lib/server/auth/`) が以前から `local \| cognito` を参照しており、`'auto'` を導入すると既存参照を全て書き換える必要がある。既存整合性を優先 |
+| `COGNITO_DEV_MODE` schema | `z.coerce.boolean().optional()` | `booleanStringSchema` (`z.enum(['true', 'false']).transform(...)`) | **実装が正** | `z.coerce.boolean()` は `Boolean("false")` が JS 仕様で `true` になる落とし穴があり、`COGNITO_DEV_MODE=false` が truthy 判定される不具合を生む。`z.enum(['true', 'false']).transform((v) => v === 'true')` で文字列比較する方式を採用 |
+
+### スコープ
+
+本補正は ADR のヘッダ (`status: accepted`) を変更しない。supersede ではなく、P1 実装時点での「正仕様」を補足情報として記録する。今後の P2〜P5 でも類似の実装補正が発生した場合は本セクションに追記する。
+
 ## 参考
 
 - Martin Fowler, "Branch by Abstraction" — https://martinfowler.com/bliki/BranchByAbstraction.html
 - OpenFeature Evaluation Context 仕様 — https://openfeature.dev/specification/sections/evaluation-context
 - [SvelteKit Hooks docs](https://svelte.dev/docs/kit/hooks)
 - ADR-0039 (前身) — デモモードを実行モードとして統合
+- ADR-0003 — 設計書は Single Source of Truth（本 ADR 補正メモの根拠）


### PR DESCRIPTION
## 概要

ADR-0040 本文の擬似コードと P1 実装 (PR #1204 `src/lib/runtime/env.ts`) に 2 件の差分があり、ADR-0003「設計書は Single Source of Truth」に基づき ADR 側に実装を追認する「実装補正メモ」セクションを末尾に追加。

closes #1211

## 差分 2 件

| 項目 | ADR 擬似コード | P1 実装 | 採用 |
|---|---|---|---|
| `AUTH_MODE` enum | `['auto', 'cognito']` | `['local', 'cognito']` | 実装が正 |
| `COGNITO_DEV_MODE` | `z.coerce.boolean().optional()` | `booleanStringSchema` | 実装が正 |

## AC 検証マップ (ADR-0038)

| # | Acceptance Criteria | 検証方法 | 結果 |
|---|---|---|---|
| 1 | ADR-0040 末尾に「実装補正メモ (P1)」セクション追加 | ファイル確認 | ✅ `docs/decisions/0040-runtime-mode-license-unified-architecture.md:L252-263` に追加 |
| 2 | 2 件の差分を表形式で記載 | 同上 | ✅ 表組みで `AUTH_MODE` enum / `COGNITO_DEV_MODE` schema 2 行を記載 |
| 3 | ADR-0003 に基づき追認する旨を明記 | 同上 | ✅ "ADR-0003「設計書は Single Source of Truth」に基づき、本 ADR の擬似コードは実装側の記述を正とする" |
| 4 | supersede ではなく補足である旨を明記 | 同上 | ✅ "### スコープ" で "supersede ではなく、P1 実装時点での「正仕様」を補足情報として記録する" |
| 5 | CI `design-doc-check` 緑 | CI 実行 | 後述（CI 後に確認） |

## 設計制約遵守

- [x] ADR ヘッダ (`status: accepted`) 変更なし
- [x] supersede ではなく補足である旨を明記

## Things Not To Do チェック

- [x] ADR-0029 禁止 5 項目該当なし — docs のみ
- [x] 新規 env/secret なし
- [x] 用語ハードコード該当なし

## 配布済み env / secret (ADR-0029)
該当なし (docs-only)。

## スクリーンショット / ビジュアルデモ
UI 変更なし (ADR 更新のみ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)