### PR TITLE
refactor: #1208 scripts/ の waitForTimeout を決定論待機に置換 + CI lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
       - name: DynamoDB stub/no-op implementation check (#1021 / ADR-0034)
         run: node scripts/check-dynamodb-stub.mjs
 
+      - name: No waitForTimeout in scripts/ check (#1208)
+        run: node scripts/check-no-waitfortimeout.mjs
+
       - name: Spell check (cspell, warn-only) (#979 / ADR-0032 T3→T1)
         run: npm run cspell || true
 

--- a/scripts/capture-hp-screenshots.mjs
+++ b/scripts/capture-hp-screenshots.mjs
@@ -12,7 +12,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { chromium } from 'playwright';
-import { convertToWebP, withScreenshotParam } from './lib/screenshot-helpers.mjs';
+import {
+	convertToWebP,
+	waitForStablePage,
+	withScreenshotParam,
+} from './lib/screenshot-helpers.mjs';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
 const OUTPUT_DIR = path.resolve('site/screenshots');
@@ -203,14 +207,12 @@ async function captureScreenshots() {
 					timeout: 15000,
 				});
 
-				// Wait for animations to settle
-				await page.waitForTimeout(1500);
+				await waitForStablePage(page);
 
-				// Scroll to specific element if specified
 				if (shot.scrollTo) {
 					try {
 						await page.locator(shot.scrollTo).first().scrollIntoViewIfNeeded();
-						await page.waitForTimeout(500);
+						await waitForStablePage(page, { skipNetworkIdle: true });
 					} catch {
 						// Element not found, take screenshot from current position
 					}

--- a/scripts/capture-screenshots.mjs
+++ b/scripts/capture-screenshots.mjs
@@ -8,6 +8,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { chromium } from 'playwright';
+import { waitForStablePage } from './lib/screenshot-helpers.mjs';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
 const OUTPUT_DIR = path.resolve('static/assets/marketing/screenshots');
@@ -68,8 +69,7 @@ async function captureScreenshots() {
 				waitUntil: 'networkidle',
 				timeout: 15000,
 			});
-			// Wait for animations to settle
-			await tab.waitForTimeout(1000);
+			await waitForStablePage(tab);
 
 			const outputPath = path.join(OUTPUT_DIR, `${page.name}.png`);
 			await tab.screenshot({

--- a/scripts/check-no-waitfortimeout.mjs
+++ b/scripts/check-no-waitfortimeout.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-no-waitfortimeout.mjs (#1208)
+ *
+ * scripts/ 配下の `.mjs` / `.js` / `.cjs` に対し、`page.waitForTimeout(N)` / `.waitForTimeout(N)`
+ * の実呼び出しを禁止する lint。`scripts/lib/screenshot-helpers.mjs` の `waitForStablePage()`
+ * などに置き換える (ADR-0020 と同方針)。
+ *
+ * 許容: コメント / doc 内の文字列参照 (このファイル自身を含む)
+ * 禁止: `.waitForTimeout(...)` メソッド呼び出し
+ *
+ * 終了コード: 違反なし=0 / 違反あり=1
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve('scripts');
+const EXT = new Set(['.mjs', '.js', '.cjs']);
+const violations = [];
+
+function walk(dir) {
+	for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+		const p = path.join(dir, ent.name);
+		if (ent.isDirectory()) {
+			if (ent.name === 'node_modules' || ent.name.startsWith('.')) continue;
+			walk(p);
+		} else if (EXT.has(path.extname(ent.name))) {
+			check(p);
+		}
+	}
+}
+
+function check(file) {
+	const src = fs.readFileSync(file, 'utf8');
+	const lines = src.split(/\r?\n/);
+	let inBlockComment = false;
+	for (let i = 0; i < lines.length; i++) {
+		let line = lines[i];
+		// 複数行ブロックコメント (/** ... */) のトラッキング
+		if (inBlockComment) {
+			const endIdx = line.indexOf('*/');
+			if (endIdx === -1) continue;
+			line = line.slice(endIdx + 2);
+			inBlockComment = false;
+		}
+		// 同一行内ブロックコメント除去
+		line = line.replace(/\/\*[\s\S]*?\*\//g, '');
+		// ブロックコメント開始 (閉じ無し)
+		const startIdx = line.indexOf('/*');
+		if (startIdx !== -1 && line.indexOf('*/', startIdx) === -1) {
+			inBlockComment = true;
+			line = line.slice(0, startIdx);
+		}
+		// 行コメント除去 + 文字列リテラル内は誤検知避けのためそのまま照合
+		const stripped = line.replace(/\/\/.*$/, '');
+		// バックティック / 引用符内の記述はスキップ (\`...waitForTimeout...\`)
+		const inStringMatch = /['"`][^'"`]*\.waitForTimeout\s*\(/.test(stripped);
+		if (!inStringMatch && /(\w|\))\.waitForTimeout\s*\(/.test(stripped)) {
+			violations.push({ file, line: i + 1, text: line.trim() });
+		}
+	}
+}
+
+walk(ROOT);
+
+if (violations.length > 0) {
+	console.error('❌ scripts/ 配下で禁止された waitForTimeout 呼び出しが見つかりました (#1208)');
+	for (const v of violations) {
+		console.error(`  ${v.file}:${v.line}  ${v.text}`);
+	}
+	console.error(
+		'\nscripts/lib/screenshot-helpers.mjs の waitForStablePage() 等に置き換えてください。',
+	);
+	process.exit(1);
+}
+
+console.log(`✅ scripts/ 配下に waitForTimeout の呼び出しなし (検査対象: ${ROOT})`);

--- a/scripts/demo-review-screenshots.mjs
+++ b/scripts/demo-review-screenshots.mjs
@@ -23,6 +23,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { chromium } from 'playwright';
+import { waitForStablePage } from './lib/screenshot-helpers.mjs';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
 const OUTPUT_DIR = path.resolve('tmp/demo-review');
@@ -48,7 +49,7 @@ async function captureGuideTour(browser, viewport) {
 
 	// 1. /demo トップページ
 	await page.goto(`${BASE_URL}/demo`, { waitUntil: 'networkidle' });
-	await page.waitForTimeout(500);
+	await waitForStablePage(page);
 	await shot('10-demo-top');
 
 	// 2. ガイド開始
@@ -61,8 +62,7 @@ async function captureGuideTour(browser, viewport) {
 		return;
 	}
 	await startBtn.click();
-	await page.waitForLoadState('networkidle');
-	await page.waitForTimeout(800); // DOM安定待ち
+	await waitForStablePage(page);
 	await shot('40-guide-step1');
 
 	// 3. Step 1 → Step 5 まで順に つぎへ を押す
@@ -74,8 +74,7 @@ async function captureGuideTour(browser, viewport) {
 			break;
 		}
 		await nextBtn.click();
-		await page.waitForLoadState('networkidle').catch(() => {});
-		await page.waitForTimeout(800); // DOM安定待ち
+		await waitForStablePage(page);
 		await shot(`${40 + (i - 1) * 10}-guide-step${i}`);
 	}
 

--- a/scripts/lib/screenshot-helpers.mjs
+++ b/scripts/lib/screenshot-helpers.mjs
@@ -55,3 +55,46 @@ export async function convertToWebP(filePath, options = {}) {
 		return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
 	}
 }
+
+/**
+ * ページ描画安定待ち (#1208 — `waitForTimeout` 置換の SSOT)
+ *
+ * `scripts/**` 内で `page.waitForTimeout(N)` を使っていた「DOM/アニメ settle 待ち」を
+ * 決定論的な待機に置換するためのヘルパー。`waitForTimeout` を内包しない実装。
+ *
+ * 次の順序で待機する:
+ *   1. `waitForLoadState('networkidle')` (任意 / `networkIdleTimeout` ms でタイムアウトを許容)
+ *   2. `options.selector` があれば `waitForSelector` (visible 状態まで)
+ *   3. `document.fonts.ready` + 2 フレーム requestAnimationFrame
+ *      — フォントレイアウトとアニメーション 1 フレーム分の settle を保証
+ *
+ * pixel diff への影響を最小化するため、従来の固定待機とほぼ同じ安定度が得られる。
+ *
+ * @param {import('playwright').Page} page
+ * @param {object} [options]
+ * @param {string} [options.selector] - 表示を待つ要素 (visible)
+ * @param {number} [options.networkIdleTimeout=5000] - networkidle 待機の最大 ms
+ * @param {boolean} [options.skipNetworkIdle=false] - networkidle 待機をスキップ
+ */
+export async function waitForStablePage(page, options = {}) {
+	const { selector, networkIdleTimeout = 5000, skipNetworkIdle = false } = options;
+	if (!skipNetworkIdle) {
+		await page.waitForLoadState('networkidle', { timeout: networkIdleTimeout }).catch(() => {
+			// ネットワーク活動が続いていても他のシグナルで進む
+		});
+	}
+	if (selector) {
+		await page.waitForSelector(selector, { state: 'visible', timeout: 10000 });
+	}
+	await page.evaluate(
+		() =>
+			new Promise((resolve) => {
+				const finish = () => requestAnimationFrame(() => requestAnimationFrame(resolve));
+				if (document.fonts?.ready) {
+					document.fonts.ready.then(finish);
+				} else {
+					finish();
+				}
+			}),
+	);
+}

--- a/scripts/measure-lp-dimensions.mjs
+++ b/scripts/measure-lp-dimensions.mjs
@@ -16,6 +16,7 @@ import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { extname, join, resolve } from 'node:path';
 import { chromium } from 'playwright';
+import { waitForStablePage } from './lib/screenshot-helpers.mjs';
 
 // biome-ignore lint/suspicious/noConsole: CLI script requires console output
 const log = (...a) => console.log(...a);
@@ -131,7 +132,7 @@ async function extractCtaVariants(page) {
 async function measureHeight(page, url, width) {
 	await page.setViewportSize({ width, height: 900 });
 	await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
-	await page.waitForTimeout(500);
+	await waitForStablePage(page);
 	return await page.evaluate(() => document.body.scrollHeight);
 }
 

--- a/scripts/render-ci-pipeline-diagram.mjs
+++ b/scripts/render-ci-pipeline-diagram.mjs
@@ -89,7 +89,7 @@ async function main() {
 	const page = await context.newPage();
 	await page.setContent(HTML, { waitUntil: 'networkidle' });
 	await page.waitForFunction(() => window.__mermaidReady === true, { timeout: 10000 });
-	await page.waitForTimeout(500); // mermaid SVG の描画完了待ち
+	await page.waitForSelector('.mermaid svg', { state: 'visible', timeout: 10000 });
 
 	const outPath = path.join(OUTPUT_DIR, 'ci-pipeline-flow.png');
 	await page.screenshot({ path: outPath, fullPage: true });

--- a/scripts/screenshot-checklist-kind-split.mjs
+++ b/scripts/screenshot-checklist-kind-split.mjs
@@ -5,6 +5,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { chromium } from 'playwright';
+import { waitForStablePage } from './lib/screenshot-helpers.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUT_DIR = path.resolve(__dirname, '..', 'docs/screenshots/1168-checklist-kind-split');
@@ -27,7 +28,8 @@ async function login(page, email, password) {
 	await page.locator('button[type="submit"]:not([disabled])').waitFor({ timeout: 10000 });
 	await page.click('button[type="submit"]');
 	await page.waitForLoadState('domcontentloaded', { timeout: 60000 });
-	await page.waitForTimeout(2000);
+	await page.waitForURL((url) => !url.pathname.startsWith('/auth/login'), { timeout: 30000 });
+	await waitForStablePage(page);
 }
 
 async function shot(page, name) {
@@ -44,15 +46,23 @@ async function shot(page, name) {
 	// 1. 親: 管理画面 チェックリスト（タブ: ルーティン / 持ち物）
 	await login(page, 'family@example.com', 'Gq!Dev#Fam2026xyz');
 	await page.goto(`${BASE}/admin/checklists`);
-	await page.waitForLoadState('networkidle');
-	await page.waitForTimeout(1000);
+	await waitForStablePage(page, { selector: 'button[role="tab"]' });
 	await shot(page, 'admin-checklists-routine-tab');
 
 	// 2. 持ち物タブをクリック
 	const itemTab = page.locator('button[role="tab"]').filter({ hasText: '持ち物' });
 	if (await itemTab.count()) {
 		await itemTab.first().click();
-		await page.waitForTimeout(500);
+		await page
+			.waitForFunction(
+				() =>
+					document
+						.querySelector('[role="tab"][aria-selected="true"]')
+						?.textContent?.includes('持ち物'),
+				{ timeout: 5000 },
+			)
+			.catch(() => {});
+		await waitForStablePage(page, { skipNetworkIdle: true });
 		await shot(page, 'admin-checklists-item-tab');
 	}
 
@@ -60,7 +70,7 @@ async function shot(page, name) {
 	const addBtn = page.locator('button').filter({ hasText: 'テンプレート作成' }).first();
 	if (await addBtn.count()) {
 		await addBtn.click();
-		await page.waitForTimeout(800);
+		await waitForStablePage(page, { selector: '[role="dialog"]', skipNetworkIdle: true });
 		await shot(page, 'admin-checklists-create-dialog');
 	} else {
 		console.log('⚠️  "テンプレート作成" ボタンが見つからない');

--- a/scripts/screenshot-children.mjs
+++ b/scripts/screenshot-children.mjs
@@ -1,5 +1,6 @@
 // Quick screenshot script for #0273 visual verification
 import { chromium } from 'playwright';
+import { waitForStablePage } from './lib/screenshot-helpers.mjs';
 
 const BASE = 'http://localhost:5173';
 
@@ -15,7 +16,7 @@ async function main() {
 
 	// Navigate to children page
 	await mPage.goto(`${BASE}/admin/children`, { waitUntil: 'networkidle' });
-	await mPage.waitForTimeout(500);
+	await waitForStablePage(mPage);
 	await mPage.screenshot({ path: 'screenshots/0273-children-list-mobile.png', fullPage: true });
 	console.log('✅ Mobile: children list');
 
@@ -23,7 +24,7 @@ async function main() {
 	const firstChild = mPage.locator('[data-tutorial="child-card"]');
 	if (await firstChild.count()) {
 		await firstChild.click();
-		await mPage.waitForTimeout(500);
+		await waitForStablePage(mPage, { skipNetworkIdle: true });
 		await mPage.screenshot({ path: 'screenshots/0273-children-detail-mobile.png', fullPage: true });
 		console.log('✅ Mobile: children detail (view mode)');
 
@@ -31,7 +32,7 @@ async function main() {
 		const editBtn = mPage.locator('button:has-text("編集")').first();
 		if (await editBtn.count()) {
 			await editBtn.click();
-			await mPage.waitForTimeout(300);
+			await waitForStablePage(mPage, { skipNetworkIdle: true });
 			await mPage.screenshot({ path: 'screenshots/0273-children-edit-mobile.png', fullPage: true });
 			console.log('✅ Mobile: children edit mode');
 		}
@@ -44,14 +45,14 @@ async function main() {
 	});
 	const tPage = await tablet.newPage();
 	await tPage.goto(`${BASE}/admin/children`, { waitUntil: 'networkidle' });
-	await tPage.waitForTimeout(500);
+	await waitForStablePage(tPage);
 	await tPage.screenshot({ path: 'screenshots/0273-children-list-tablet.png', fullPage: true });
 	console.log('✅ Tablet: children list');
 
 	const firstChildTab = tPage.locator('[data-tutorial="child-card"]');
 	if (await firstChildTab.count()) {
 		await firstChildTab.click();
-		await tPage.waitForTimeout(500);
+		await waitForStablePage(tPage, { skipNetworkIdle: true });
 		await tPage.screenshot({ path: 'screenshots/0273-children-detail-tablet.png', fullPage: true });
 		console.log('✅ Tablet: children detail (view mode)');
 	}

--- a/scripts/screenshot-stamp-card.mjs
+++ b/scripts/screenshot-stamp-card.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { chromium } from 'playwright';
+import { waitForStablePage } from './lib/screenshot-helpers.mjs';
 
 const BASE_URL = process.env.BASE_URL || 'http://192.168.68.79:3000';
 
@@ -13,7 +14,7 @@ async function main() {
 
 	// 1. Child selection page
 	await page.goto(`${BASE_URL}/kinder/home`, { waitUntil: 'networkidle', timeout: 15000 });
-	await page.waitForTimeout(1000);
+	await waitForStablePage(page);
 	await page.screenshot({ path: 'tmp/nuc-1-childselect.png', fullPage: true });
 	console.log('1. Child selection page saved');
 
@@ -21,7 +22,7 @@ async function main() {
 	const childBtn = page.locator('[data-testid^="child-select-"]').first();
 	if (await childBtn.isVisible({ timeout: 3000 })) {
 		await childBtn.click();
-		await page.waitForTimeout(3000);
+		await waitForStablePage(page);
 		await page.screenshot({ path: 'tmp/nuc-2-afterselect.png', fullPage: true });
 		console.log('2. After child select saved');
 
@@ -33,7 +34,7 @@ async function main() {
 				.first();
 			if (await btn.isVisible({ timeout: 1000 }).catch(() => false)) {
 				await btn.click();
-				await page.waitForTimeout(1000);
+				await waitForStablePage(page, { skipNetworkIdle: true });
 			}
 		}
 		await page.screenshot({ path: 'tmp/nuc-3-home.png', fullPage: true });
@@ -54,7 +55,7 @@ async function main() {
 		// 5. Try clicking stamp button
 		if (await stampBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
 			await stampBtn.click();
-			await page.waitForTimeout(800);
+			await waitForStablePage(page, { selector: '[role="dialog"]', skipNetworkIdle: true });
 			await page.screenshot({ path: 'tmp/nuc-4-stampcard.png', fullPage: false });
 			console.log('4. Stamp card dialog saved');
 		} else {

--- a/scripts/take-lp-screenshots.mjs
+++ b/scripts/take-lp-screenshots.mjs
@@ -2,7 +2,11 @@
 import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { chromium } from 'playwright';
-import { convertToWebP, withScreenshotParam } from './lib/screenshot-helpers.mjs';
+import {
+	convertToWebP,
+	waitForStablePage,
+	withScreenshotParam,
+} from './lib/screenshot-helpers.mjs';
 
 // biome-ignore lint/suspicious/noConsole: CLI script requires console output
 const log = (...a) => console.log(...a);
@@ -84,7 +88,8 @@ async function waitForApp(page) {
 			timeout: 15000,
 		});
 	} catch {
-		await page.waitForTimeout(3000);
+		// `window.__APP_HYDRATED__` が立たない route は DOM の主要要素で代替待機
+		await page.waitForSelector('body > *', { state: 'visible', timeout: 5000 }).catch(() => {});
 	}
 }
 
@@ -98,7 +103,7 @@ async function captureAgeMode(browser, { mode, filePrefix }) {
 
 		await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
 		await waitForApp(page);
-		await page.waitForTimeout(500);
+		await waitForStablePage(page, { skipNetworkIdle: true });
 
 		const filePath = `${OUTPUT_DIR}/${filePrefix}${suffix}.webp`;
 		await page.screenshot({ path: filePath, fullPage: false, type: 'png' });
@@ -122,7 +127,7 @@ async function captureGeneric(browser, screenshots, viewportKeys, mobileSuffix =
 				timeout: 60000,
 			});
 			await waitForApp(page);
-			await page.waitForTimeout(500);
+			await waitForStablePage(page, { skipNetworkIdle: true });
 
 			const filePath = `${OUTPUT_DIR}/${file}${suffix}.webp`;
 			await page.screenshot({ path: filePath, fullPage: false, type: 'png' });


### PR DESCRIPTION
closes #1208

## Summary
- `scripts/**` の 22 箇所の `page.waitForTimeout(N)` を `waitForStablePage()` / `waitForSelector()` / `waitForFunction()` に置換
- `scripts/lib/screenshot-helpers.mjs` に `waitForStablePage(page, options?)` を追加 (networkidle + optional selector + `document.fonts.ready` + 2× requestAnimationFrame。`waitForTimeout` を内包しない実装)
- CI (`lint-and-test`) に `scripts/check-no-waitfortimeout.mjs` を追加し、今後 `scripts/` で新規の `waitForTimeout` を追加するとマージ不可

## AC マッピング (#1208)
- [x] `scripts/**/*.mjs` 内の `waitForTimeout` 呼び出しが 0 件 — `grep -n "\.waitForTimeout"` で 0 件 (doc 内参照のみ残存)
- [x] `scripts/` 内 `waitForTimeout` 禁止の CI lint ルール追加 — `scripts/check-no-waitfortimeout.mjs` (JSDoc/文字列リテラル内は除外) + `ci.yml` lint-and-test に追加
- [x] #1206 の共通ヘルパー側で待機ロジックを統一 — `scripts/lib/screenshot-helpers.mjs` に `waitForStablePage()` を追加
- [x] 新規 `waitForTimeout` 追加は今後一切禁止 — CI lint で自動ブロック
- [ ] スクリーンショット出力の pixel diff が既存と±5% 以内 — **現時点では定量比較していない** (実機での撮影が CI 内では実施できない)。本 PR の wait ロジックは「networkidle → selector visible → fonts.ready → 2× RAF」で従来の「固定 N ms 待ち」より厳密 (Playwright 公式推奨方針)。LP 撮影の CI ジョブ (pages.yml) が通れば実質的なリグレッション検知になる
- [ ] screenshot-check / lp-metrics の実行時間が±10% 以内 — 本 PR マージ後に次回 pages.yml / lp-metrics.yml のラン時間で確認 (事前予測)

## 変更ファイル一覧
- **新規**: `scripts/check-no-waitfortimeout.mjs` (lint)
- **SSOT 拡張**: `scripts/lib/screenshot-helpers.mjs` (`waitForStablePage` 追加)
- **CI**: `.github/workflows/ci.yml` (lint-and-test に新チェック追加)
- **置換対象 9 script**:
  - `scripts/capture-hp-screenshots.mjs` (2→0)
  - `scripts/capture-screenshots.mjs` (1→0)
  - `scripts/demo-review-screenshots.mjs` (3→0)
  - `scripts/measure-lp-dimensions.mjs` (1→0)
  - `scripts/render-ci-pipeline-diagram.mjs` (1→0、`waitForSelector('.mermaid svg')` に)
  - `scripts/screenshot-checklist-kind-split.mjs` (4→0、タブ遷移は `aria-selected` を監視)
  - `scripts/screenshot-children.mjs` (6→0)
  - `scripts/screenshot-stamp-card.mjs` (4→0、ダイアログは `[role=\"dialog\"]` を監視)
  - `scripts/take-lp-screenshots.mjs` (3→0、`waitForApp` の fallback も `waitForSelector` に)

## 検証
- `node scripts/check-no-waitfortimeout.mjs` → ✅ 0 violations (sanity-test の意図的注入でも検出を確認)
- `npx biome check <対象 11 ファイル> --diagnostic-level=error` → errors 0
- `npx svelte-check` → 0 errors / 45 warnings (既存)
- `npx vitest run` → 183 files / 3651 tests passed (本ブランチは main 起点のため FormField test +14 は含まず)

## Blocker 解消
- #1206 (screenshot-helpers SSOT) はマージ済み (2026-04-19 close)。本 Issue は #1206 に `waitForStablePage` ヘルパーを追加する形で実装しており、Issue 本文の「並行実装」制約と整合

## Test plan
- [x] Lint 追加 (`check-no-waitfortimeout.mjs`) 単体で正検出・誤検出を確認
- [x] biome / svelte-check / vitest 全緑
- [ ] CI 全緑確認後に Ready for Review 化 (feedback_no_ready_before_ci.md 準拠)
- [ ] マージ後に pages.yml / lp-metrics.yml が緑であることを確認 (pixel diff / 所要時間の実測)

🤖 Generated with [Claude Code](https://claude.com/claude-code)