### PR TITLE
fix: #1253 ごほうび (special_rewards) の import 処理追加（片肺解消）

### DIFF
--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -12,6 +12,7 @@ import {
 import { insertTemplate, insertTemplateItem } from '$lib/server/db/checklist-repo';
 import { insertChild } from '$lib/server/db/child-repo';
 import { insertLoginBonus } from '$lib/server/db/login-bonus-repo';
+import { findSpecialRewards, insertSpecialReward } from '$lib/server/db/special-reward-repo';
 import { insertStatusHistory, upsertStatus } from '$lib/server/db/status-repo';
 import { logger } from '$lib/server/logger';
 
@@ -31,6 +32,8 @@ export interface ImportResult {
 	statusesImported: number;
 	achievementsImported: number;
 	titlesImported: number;
+	specialRewardsImported: number;
+	specialRewardsSkipped: number;
 	errors: string[];
 	warnings: string[];
 }
@@ -86,6 +89,7 @@ export function previewImport(data: ExportData) {
 		titles: data.data.childTitles.length,
 		loginBonuses: data.data.loginBonuses.length,
 		checklistTemplates: data.data.checklistTemplates.length,
+		specialRewards: data.data.specialRewards.length,
 	};
 }
 
@@ -105,6 +109,8 @@ export async function importFamilyData(data: ExportData, tenantId: string): Prom
 		statusesImported: 0,
 		achievementsImported: 0,
 		titlesImported: 0,
+		specialRewardsImported: 0,
+		specialRewardsSkipped: 0,
 		errors,
 		warnings,
 	};
@@ -323,6 +329,9 @@ export async function importFamilyData(data: ExportData, tenantId: string): Prom
 		}
 	}
 
+	// 9. 特別報酬 (ごほうび) (#1253)
+	await importSpecialRewards(data, childIdMap, tenantId, result);
+
 	// 10. ステータス履歴
 	for (const sh of data.data.statusHistory) {
 		const childId = childIdMap.get(sh.childRef);
@@ -347,4 +356,53 @@ export async function importFamilyData(data: ExportData, tenantId: string): Prom
 
 	logger.info('[import] インポート完了', { context: { ...result } });
 	return result;
+}
+
+async function importSpecialRewards(
+	data: ExportData,
+	childIdMap: Map<string, number>,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	const { errors, warnings } = result;
+	const existingRewardsByChild = new Map<number, Set<string>>();
+	for (const sr of data.data.specialRewards) {
+		const childId = childIdMap.get(sr.childRef);
+		if (!childId) continue;
+
+		if (!existingRewardsByChild.has(childId)) {
+			const existing = await findSpecialRewards(childId, tenantId);
+			existingRewardsByChild.set(childId, new Set(existing.map((e) => e.title)));
+		}
+		const existingTitles = existingRewardsByChild.get(childId);
+		if (!existingTitles) continue;
+
+		if (existingTitles.has(sr.title)) {
+			result.specialRewardsSkipped++;
+			continue;
+		}
+
+		try {
+			await insertSpecialReward(
+				{
+					childId,
+					title: sr.title,
+					description: sr.description ?? undefined,
+					points: sr.points,
+					icon: sr.icon ?? undefined,
+					category: sr.category,
+				},
+				tenantId,
+			);
+			result.specialRewardsImported++;
+			existingTitles.add(sr.title);
+		} catch (e) {
+			errors.push(`ごほうび「${sr.title}」のインポートに失敗: ${String(e)}`);
+		}
+	}
+	if (result.specialRewardsSkipped > 0) {
+		warnings.push(
+			`ごほうび ${result.specialRewardsSkipped} 件が既存と同名のためスキップされました`,
+		);
+	}
 }

--- a/tests/unit/services/import-service.test.ts
+++ b/tests/unit/services/import-service.test.ts
@@ -17,6 +17,8 @@ const mockInsertChildAchievement = vi.fn();
 const mockInsertLoginBonus = vi.fn();
 const mockInsertTemplate = vi.fn();
 const mockInsertTemplateItem = vi.fn();
+const mockFindSpecialRewards = vi.fn();
+const mockInsertSpecialReward = vi.fn();
 
 vi.mock('$lib/server/db/activity-repo', () => ({
 	findActivities: (...args: unknown[]) => mockFindActivities(...args),
@@ -46,6 +48,11 @@ vi.mock('$lib/server/db/login-bonus-repo', () => ({
 vi.mock('$lib/server/db/checklist-repo', () => ({
 	insertTemplate: (...args: unknown[]) => mockInsertTemplate(...args),
 	insertTemplateItem: (...args: unknown[]) => mockInsertTemplateItem(...args),
+}));
+
+vi.mock('$lib/server/db/special-reward-repo', () => ({
+	findSpecialRewards: (...args: unknown[]) => mockFindSpecialRewards(...args),
+	insertSpecialReward: (...args: unknown[]) => mockInsertSpecialReward(...args),
 }));
 
 vi.mock('$lib/server/logger', () => ({
@@ -126,6 +133,7 @@ beforeEach(() => {
 	// Default: lookup mocks return empty arrays
 	mockFindActivities.mockResolvedValue([]);
 	mockFindAllAchievements.mockResolvedValue([]);
+	mockFindSpecialRewards.mockResolvedValue([]);
 });
 
 // ============================================================
@@ -338,6 +346,26 @@ describe('previewImport', () => {
 				items: [],
 			},
 		];
+		data.data.specialRewards = [
+			{
+				childRef: 'c1',
+				title: 'おこづかい',
+				description: null,
+				points: 100,
+				icon: null,
+				category: 'money',
+				grantedAt: '2026-03-15T00:00:00Z',
+			},
+			{
+				childRef: 'c2',
+				title: 'おもちゃ',
+				description: null,
+				points: 50,
+				icon: null,
+				category: 'toy',
+				grantedAt: '2026-03-15T00:00:00Z',
+			},
+		];
 
 		const preview = previewImport(data);
 
@@ -348,6 +376,7 @@ describe('previewImport', () => {
 		expect(preview.achievements).toBe(1);
 		expect(preview.loginBonuses).toBe(2);
 		expect(preview.checklistTemplates).toBe(1);
+		expect(preview.specialRewards).toBe(2);
 	});
 
 	it('空の配列の場合は全てゼロを返す', () => {
@@ -361,6 +390,7 @@ describe('previewImport', () => {
 		expect(preview.achievements).toBe(0);
 		expect(preview.loginBonuses).toBe(0);
 		expect(preview.checklistTemplates).toBe(0);
+		expect(preview.specialRewards).toBe(0);
 	});
 });
 
@@ -1041,6 +1071,147 @@ describe('importFamilyData', () => {
 			expect(result.errors).toEqual(
 				expect.arrayContaining([expect.stringContaining('失敗リスト')]),
 			);
+		});
+	});
+
+	describe('特別報酬 (ごほうび) のインポート (#1253)', () => {
+		const baseReward = {
+			childRef: 'c1' as const,
+			description: null,
+			icon: null,
+			category: 'money',
+			grantedAt: '2026-03-15T00:00:00Z',
+		};
+
+		it('既存と重複しない場合は全件 insert される', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.specialRewards = [
+				{ ...baseReward, title: 'おこづかい', points: 100 },
+				{ ...baseReward, title: 'おもちゃ', points: 50 },
+			];
+
+			mockInsertChild.mockResolvedValue({ id: 101 });
+			mockFindSpecialRewards.mockResolvedValue([]);
+			mockInsertSpecialReward.mockResolvedValue({ id: 1 });
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.specialRewardsImported).toBe(2);
+			expect(result.specialRewardsSkipped).toBe(0);
+			expect(mockInsertSpecialReward).toHaveBeenCalledTimes(2);
+			expect(mockInsertSpecialReward).toHaveBeenCalledWith(
+				expect.objectContaining({
+					childId: 101,
+					title: 'おこづかい',
+					points: 100,
+					category: 'money',
+				}),
+				TENANT,
+			);
+		});
+
+		it('全件同名で既存と重複する場合は全件 skip される', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.specialRewards = [
+				{ ...baseReward, title: 'おこづかい', points: 100 },
+				{ ...baseReward, title: 'おもちゃ', points: 50 },
+			];
+
+			mockInsertChild.mockResolvedValue({ id: 101 });
+			mockFindSpecialRewards.mockResolvedValue([
+				{ id: 10, title: 'おこづかい' },
+				{ id: 11, title: 'おもちゃ' },
+			]);
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.specialRewardsImported).toBe(0);
+			expect(result.specialRewardsSkipped).toBe(2);
+			expect(mockInsertSpecialReward).not.toHaveBeenCalled();
+			expect(result.warnings).toEqual(expect.arrayContaining([expect.stringContaining('2 件')]));
+		});
+
+		it('一部重複の場合は部分 skip + 件数レポートが正しい', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.specialRewards = [
+				{ ...baseReward, title: 'おこづかい', points: 100 },
+				{ ...baseReward, title: '新作ゲーム', points: 200 },
+				{ ...baseReward, title: 'おもちゃ', points: 50 },
+			];
+
+			mockInsertChild.mockResolvedValue({ id: 101 });
+			mockFindSpecialRewards.mockResolvedValue([{ id: 10, title: 'おこづかい' }]);
+			mockInsertSpecialReward.mockResolvedValue({ id: 1 });
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.specialRewardsImported).toBe(2);
+			expect(result.specialRewardsSkipped).toBe(1);
+			expect(mockInsertSpecialReward).toHaveBeenCalledTimes(2);
+			const calledTitles = mockInsertSpecialReward.mock.calls.map((c) => c[0].title);
+			expect(calledTitles).toEqual(expect.arrayContaining(['新作ゲーム', 'おもちゃ']));
+			expect(calledTitles).not.toContain('おこづかい');
+		});
+
+		it('childRef が不明な場合は skip され insert されない', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.specialRewards = [
+				{ ...baseReward, childRef: 'unknown', title: 'ghost', points: 10 },
+			];
+
+			mockInsertChild.mockResolvedValue({ id: 101 });
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.specialRewardsImported).toBe(0);
+			expect(result.specialRewardsSkipped).toBe(0);
+			expect(mockInsertSpecialReward).not.toHaveBeenCalled();
+			expect(mockFindSpecialRewards).not.toHaveBeenCalled();
+		});
+
+		it('複数子供に対して existing titles が独立してキャッシュされる', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1', 'たろう'), makeChild('c2', 'はなこ')];
+			data.data.specialRewards = [
+				{ ...baseReward, childRef: 'c1', title: 'おこづかい', points: 100 },
+				{ ...baseReward, childRef: 'c2', title: 'おこづかい', points: 200 },
+			];
+
+			mockInsertChild.mockResolvedValueOnce({ id: 101 }).mockResolvedValueOnce({ id: 102 });
+			// c1 has existing 'おこづかい', c2 has none
+			mockFindSpecialRewards
+				.mockResolvedValueOnce([{ id: 5, title: 'おこづかい' }]) // childId 101
+				.mockResolvedValueOnce([]); // childId 102
+			mockInsertSpecialReward.mockResolvedValue({ id: 1 });
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.specialRewardsImported).toBe(1);
+			expect(result.specialRewardsSkipped).toBe(1);
+			expect(mockInsertSpecialReward).toHaveBeenCalledTimes(1);
+			expect(mockInsertSpecialReward).toHaveBeenCalledWith(
+				expect.objectContaining({ childId: 102, title: 'おこづかい' }),
+				TENANT,
+			);
+		});
+
+		it('insertSpecialReward の失敗時はエラーが追加される', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.specialRewards = [{ ...baseReward, title: '失敗', points: 100 }];
+
+			mockInsertChild.mockResolvedValue({ id: 101 });
+			mockFindSpecialRewards.mockResolvedValue([]);
+			mockInsertSpecialReward.mockRejectedValue(new Error('DB error'));
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.specialRewardsImported).toBe(0);
+			expect(result.errors).toEqual(expect.arrayContaining([expect.stringContaining('失敗')]));
 		});
 	});
 


### PR DESCRIPTION
Fixes #1253

## Summary

- export-service に特別報酬 (ごほうび) の export 処理はあるのに import-service には存在せず、ユーザーがバックアップ → リストアすると **ごほうびだけが消える** 片肺状態を修正
- `importFamilyData` に section 9 として `specialRewards` の import ブロックを追加（名前完全一致で既存と重複なら skip + 警告）
- `previewImport` に specialRewards 件数、`ImportResult` に `specialRewardsImported` / `specialRewardsSkipped` を追加
- 子供ごとに既存 title 集合を Map でキャッシュし、N+1 クエリを回避
- replace モード (`mode=replace`) は既存 `clearAllFamilyData` の CASCADE 削除で担保済みのため追加実装なし

## 設計上の判断

- 重複検知は **silent try-catch を採用せず事前名前集合方式**（Issue B で全体統一予定の方針に先行して準拠）
- `importFamilyData` の複雑度はベースライン 59 を維持するためヘルパー関数 `importSpecialRewards` に抽出
- DB 操作は `special-reward-repo` 経由で Repository パターン（ADR-0015）準拠

## Test plan

- [x] `npx biome check src/lib/server/services/import-service.ts tests/unit/services/import-service.test.ts` — 警告増加なし（baseline 59 維持）
- [x] `npx svelte-check` — 0 errors
- [x] `npx vitest run tests/unit/services/import-service.test.ts` — 48/48 pass（新規 6 件含む）
- [x] `npx vitest run tests/unit/services/ tests/unit/routes/` — 1921/1921 pass
- [ ] CI 全緑確認後 Ready for Review 昇格

### 追加した単体テストケース (6件)

1. 新規のみ（重複なし）— 全件 insert、件数レポート正確
2. 全件同名で既存と重複 — 全件 skip + warning
3. 一部重複 — 部分 skip + 件数レポート正確
4. 子供不明 (childRef 存在せず) — skip、`findSpecialRewards` 呼び出しなし
5. 複数子供で existing titles 独立キャッシュ — child A と child B で分離
6. `insertSpecialReward` 失敗時 — errors 配列に追加

## AC 検証対応

| Issue AC | 対応 |
|----------|------|
| import 処理追加 | `import-service.ts:332-333` で `importSpecialRewards` 呼出し |
| 名前完全一致で skip + 警告 | `importSpecialRewards` 内 `existingTitles.has(sr.title)` で判定 |
| skip 件数をレポート | `ImportResult.specialRewardsSkipped` |
| replace モード整合 | 既存 `clearAllFamilyData` の CASCADE で担保 |
| preview に件数含む | `previewImport()` に `specialRewards: data.data.specialRewards.length` |
| 単体テスト 3 件以上 | 6 件追加 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)