### PR TITLE
test: #1259 Phase 2 waitForTimeout 排除 (E2E 11 箇所)

### DIFF
--- a/tests/e2e/error-page-fallback.spec.ts
+++ b/tests/e2e/error-page-fallback.spec.ts
@@ -26,8 +26,12 @@ test.describe('#577 エラー画面フォールバック', () => {
 
 		test('404 画面から自動リダイレクトしない（親ロール）', async ({ page }) => {
 			await page.goto('/this-path-does-not-exist-xyz');
-			// 4 秒待機しても /switch に飛ばない
-			await page.waitForTimeout(4000);
+			// 4 秒以内に /switch にリダイレクトしないことを negative wait で検証 (#1259)
+			const redirected = await page
+				.waitForURL(/\/switch/, { timeout: 4000 })
+				.then(() => true)
+				.catch(() => false);
+			expect(redirected).toBe(false);
 			expect(page.url()).toMatch(/this-path-does-not-exist-xyz/);
 		});
 	});

--- a/tests/e2e/global-setup-aws.ts
+++ b/tests/e2e/global-setup-aws.ts
@@ -253,8 +253,17 @@ async function addChildViaSetup(
 	const addBtn = page.getByRole('button', { name: /追加|登録/ });
 	await addBtn.click();
 
-	// 成功メッセージまたは登録済みリストの更新を待つ
-	await page.waitForTimeout(1000);
+	// 成功メッセージまたは nickname input のクリアを待つ (#1259: waitForTimeout 置換)
+	await page
+		.waitForFunction(
+			() => {
+				const input = document.querySelector('input[name="nickname"]') as HTMLInputElement | null;
+				return !input || input.value === '';
+			},
+			null,
+			{ timeout: 3000 },
+		)
+		.catch(() => {});
 }
 
 /** API 経由で E2E テスト用の活動マスタデータを投入する */
@@ -334,9 +343,8 @@ async function addChildViaAdmin(
 	const addToggle = page.getByRole('button', { name: /こどもを追加/ });
 	await addToggle.waitFor({ timeout: 10000 });
 	await addToggle.click();
-	await page.waitForTimeout(500);
 
-	// フォームが表示されるのを待つ
+	// フォームが表示されるのを待つ (#1259: アコーディオン animation 後の出現を nicknameInput.waitFor で待つ)
 	const nicknameInput = page.locator('input[name="nickname"]');
 	await nicknameInput.waitFor({ timeout: 5000 });
 	await nicknameInput.fill(nickname);

--- a/tests/e2e/tutorial-dialog-primitive-screenshots.spec.ts
+++ b/tests/e2e/tutorial-dialog-primitive-screenshots.spec.ts
@@ -55,7 +55,10 @@ test.describe('#1192 TutorialQuickCompleteDialog 3 ダイアログ撮影', () =>
 		// Resume prompt の dialog を text ベースで取得 (data-testid propagation 不確実)
 		const resume = page.locator('[role="dialog"]').filter({ hasText: '前回の途中から続けますか' });
 		await resume.waitFor({ state: 'visible', timeout: 10_000 });
-		await page.waitForTimeout(400);
+		// #1259: 開閉 animation 完了を Web Animations API で待つ (waitForTimeout 置換)
+		await resume.evaluate((el) =>
+			Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)).then(() => {}),
+		);
 		await page.screenshot({
 			path: path.join(OUT, '01-resume-prompt.png'),
 			fullPage: false,
@@ -93,14 +96,17 @@ test.describe('#1192 TutorialQuickCompleteDialog 3 ダイアログ撮影', () =>
 			const nextBtn = bubble.locator('button:has-text("次へ"), button:has-text("完了")');
 			if (await nextBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
 				await nextBtn.click();
-				await page.waitForTimeout(500);
+				// #1259: 次のバブル or qcLocator が出るまで次ループで polling するため待機不要
 			} else {
 				break;
 			}
 		}
 
 		await qcLocator.waitFor({ state: 'visible', timeout: 10_000 });
-		await page.waitForTimeout(400);
+		// #1259: 開閉 animation 完了を Web Animations API で待つ (waitForTimeout 置換)
+		await qcLocator.evaluate((el) =>
+			Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)).then(() => {}),
+		);
 		await page.screenshot({
 			path: path.join(OUT, '02-quick-complete.png'),
 			fullPage: false,
@@ -127,7 +133,10 @@ test.describe('#1192 TutorialQuickCompleteDialog 3 ダイアログ撮影', () =>
 			.locator('[role="dialog"]')
 			.filter({ hasText: 'チュートリアルを終了しますか' });
 		await exitDlg.waitFor({ state: 'visible', timeout: 10_000 });
-		await page.waitForTimeout(400);
+		// #1259: 開閉 animation 完了を Web Animations API で待つ (waitForTimeout 置換)
+		await exitDlg.evaluate((el) =>
+			Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)).then(() => {}),
+		);
 		await page.screenshot({
 			path: path.join(OUT, '03-exit-confirm.png'),
 			fullPage: false,

--- a/tests/e2e/tutorial-verification.spec.ts
+++ b/tests/e2e/tutorial-verification.spec.ts
@@ -148,15 +148,13 @@ test.describe('チュートリアル全ステップ検証', () => {
 					break;
 				}
 				await nextBtn.click();
-				// ページ遷移の可能性があるのでバブルが再表示されるまで待機
-				await page.waitForTimeout(800);
 
-				// #955: クイック完了ダイアログが表示された場合は「もっと詳しく見る」で継続
+				// #955 / #1259: クイック完了ダイアログが出るまで 2.5s polling で待つ (出なければ次ループ先頭の bubble.waitFor が担保)
 				const continueBtn = page.locator('button:has-text("もっと詳しく見る")');
-				if (await continueBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+				if (await continueBtn.isVisible({ timeout: 2500 }).catch(() => false)) {
 					console.log(`  → クイック完了ダイアログ: 「もっと詳しく見る」で全ステップ継続`);
 					await continueBtn.click();
-					await page.waitForTimeout(800);
+					// 次のバブル出現は次ループ先頭で待機
 				}
 			} else {
 				console.log(`[End] 次へボタンが見つからない (step ${stepNum})`);
@@ -255,14 +253,13 @@ test.describe('チュートリアル全ステップ検証', () => {
 					break;
 				}
 				await nextBtn.click();
-				await page.waitForTimeout(800);
 
-				// #955: クイック完了ダイアログが表示された場合は「もっと詳しく見る」で継続
+				// #955 / #1259: クイック完了ダイアログが出るまで 2.5s polling で待つ (出なければ次ループ先頭の bubble.waitFor が担保)
 				const continueBtn = page.locator('button:has-text("もっと詳しく見る")');
-				if (await continueBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+				if (await continueBtn.isVisible({ timeout: 2500 }).catch(() => false)) {
 					console.log(`  → クイック完了ダイアログ: 「もっと詳しく見る」で全ステップ継続`);
 					await continueBtn.click();
-					await page.waitForTimeout(800);
+					// 次のバブル出現は次ループ先頭で待機
 				}
 			} else {
 				break;


### PR DESCRIPTION
Issue #1259 Phase 2 / 3 のうち **Phase 2 単独 PR**。Phase 1 (#1271 merged) に続き、E2E に残存する `waitForTimeout` 11 箇所を Playwright 公式推奨パターンへ置換する。

## Summary

- `error-page-fallback.spec.ts` (1 箇所): negative-wait を `page.waitForURL(pattern).catch()` で表現
- `global-setup-aws.ts` (2 箇所): `waitForFunction` による DOM polling / アコーディオン animation は後続 `waitFor` が担保
- `tutorial-dialog-primitive-screenshots.spec.ts` (4 箇所): screenshot 前の animation settle を Web Animations API で待機、ループ内 500ms を削除
- `tutorial-verification.spec.ts` (4 箇所): 次ボタン後 800ms + continueBtn check 1000ms → 2500ms polling に集約

## Before / After

| 指標 | Before (この PR 直前) | After |
|------|---------------------|-------|
| `grep -rn "waitForTimeout(" tests/ --include="*.ts"` | 11 箇所 | **0 箇所** ✅ |
| `grep -rn "waitForTimeout" tests/` (comment 含む) | 17 箇所 | 6 箇所 (comment のみ) |

Verification コマンド:

```bash
# コード呼び出し箇所 (comment 除外)
$ grep -rn "waitForTimeout(" tests/ --include="*.ts"
(no output)

# comment 含む全言及
$ grep -rn "waitForTimeout" tests/ --include="*.ts"
tests/e2e/global-setup-aws.ts:256:	// ... (#1259: waitForTimeout 置換)
tests/e2e/helpers.ts:114:		// 旧: waitForTimeout(3500) → ...
tests/e2e/pin-activity.spec.ts:92:			// ... (#1213: waitForTimeout 排除)
tests/e2e/tutorial-dialog-primitive-screenshots.spec.ts:58:		// ... (waitForTimeout 置換)
tests/e2e/tutorial-dialog-primitive-screenshots.spec.ts:106:		// ...
tests/e2e/tutorial-dialog-primitive-screenshots.spec.ts:136:		// ...
```

## AC 検証マップ (ADR-0036/0038)

| AC | 検証手段 | 証跡 |
|----|---------|------|
| grep 0 件 | `grep -rn "waitForTimeout(" tests/ --include="*.ts"` | 上記 Before/After 表 ✅ |
| 対象 7 ファイル置換 | helpers.ts / pin-activity.spec.ts は既に comment 化済みのため今回 4 ファイル変更 | `git diff --stat` で 4 files changed ✅ |
| error-page-fallback negative-wait 等価検証 | `page.waitForURL(/\/switch/).catch()` で 4 秒以内の redirect 不在を assert | `tests/e2e/error-page-fallback.spec.ts:28-34` ✅ |
| `npm run test:e2e` 全通過 | **CI の e2e-test (1/2/3) で確認** | PR push 後 CI 緑確認で担保 |

## Self-Review 証跡 (ADR-0044)

### 実装越境チェック
- Issue の Phase 2 AC のみ実装。Phase 3 (ESLint ratchet) は別 PR に分離 (Issue の「Phase 1-3 を独立した PR で出す」明記に従う)

### 設計上の制約準拠
- `expect.poll()` 多用なし (1 箇所も使用せず、全て `toBeVisible` / `waitForFunction` / `waitForURL` で表現)
- マジックナンバー: `timeout: 2500` 等が直書きだが、個別 assert ローカルに閉じた値で helpers.ts 定数化が過剰と判断 (Issue §設計上の制約は「`timeout: 8000` のような helpers.ts 共有定数化対象」を意図しており、ここは spec 内固有タイミング)
- `catch(() => {})` 握り潰し: `error-page-fallback.spec.ts` の `.catch(() => false)` は negative-wait の正しい表現 (リダイレクトが起きない=timeout 例外=期待挙動)。`global-setup-aws.ts` の `.catch(() => {})` は best-effort seed の従前挙動維持

### テスト品質 (ADR-0020)
- assertion 弱体化なし: `error-page-fallback.spec.ts` は `expect(redirected).toBe(false)` + `expect(page.url()).toMatch(...)` の 2 段で具体化
- timeout 延長は 1000ms → 2500ms のみ (800ms + 1000ms 元構成の合計に合わせた最小延長)
- skip 追加なし

### 並行実装チェック
- 該当なし (E2E 内部変更のみ、ユーザ向け UI / ラベル / 本番コード変更なし)

## Test plan

- [x] `grep -rn "waitForTimeout(" tests/ --include="*.ts"` → 0 件
- [x] `npx biome check` — 新規 error 0 (既存 warn 36 件は noConsole、今回未触即)
- [x] `npx svelte-check` — 0 errors
- [ ] CI e2e-test (1/2/3) 全緑 — push 後確認
- [ ] Ready for Review 昇格 → merge
- [ ] Phase 3 (ESLint ratchet) を別 PR で起票

## 関連

- closes part of #1259 (Phase 2 のみ、Phase 3 は別 PR)
- #1271 (merged) Phase 1 networkidle 28 箇所排除
- #1213 pin-activity flaky 是正 (既に comment 化済み)
- ADR-0020 テスト品質ラチェット

🤖 Generated with [Claude Code](https://claude.com/claude-code)