### PR TITLE
test: #1259 Phase 3 eslint-plugin-playwright ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
         continue-on-error: true
         run: npx eslint "src/**/*.ts"
 
+      - name: ESLint Playwright (no-networkidle / no-wait-for-timeout, #1259)
+        run: npx eslint "tests/**/*.ts"
+
       - name: Knip (unused exports/files/deps detection, #970)
         continue-on-error: true
         run: npx knip

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
 
 import tsParser from '@typescript-eslint/parser';
+import playwright from 'eslint-plugin-playwright';
 import sonarjs from 'eslint-plugin-sonarjs';
 import storybook from 'eslint-plugin-storybook';
 import svelte from 'eslint-plugin-svelte';
@@ -111,4 +112,20 @@ export default [
 		},
 	},
 	...storybook.configs['flat/recommended'],
+	// Playwright: tests/**/*.ts で非推奨 API の新規流入を error で自動拒否 (#1259 Phase 3)
+	// - no-wait-for-timeout: 固定待機禁止 (tests/CLAUDE.md 明記済み、Phase 2 で既存箇所排除)
+	// - no-networkidle: Playwright 公式 API ref で DISCOURAGED (Phase 1 で既存箇所排除)
+	{
+		files: ['tests/**/*.ts'],
+		plugins: {
+			playwright,
+		},
+		languageOptions: {
+			parser: tsParser,
+		},
+		rules: {
+			'playwright/no-wait-for-timeout': 'error',
+			'playwright/no-networkidle': 'error',
+		},
+	},
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
 				"cspell": "^10.0.0",
 				"drizzle-kit": "^0.31.10",
 				"eslint": "^10.2.0",
+				"eslint-plugin-playwright": "^2.10.2",
 				"eslint-plugin-sonarjs": "^4.0.3",
 				"eslint-plugin-storybook": "^10.3.5",
 				"eslint-plugin-svelte": "^3.17.0",
@@ -11407,6 +11408,35 @@
 				"jiti": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/eslint-plugin-playwright": {
+			"version": "2.10.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.2.tgz",
+			"integrity": "sha512-0N+2OWc3NZbOZ0gK8mp2TK6Qu3UWcJTQ9rqU0UM2yRJXgT758pvpY0lsOLIySfbyFrLqn3TcXjixbmcK90VnuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"globals": "^17.3.0"
+			},
+			"engines": {
+				"node": ">=16.9.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.40.0"
+			}
+		},
+		"node_modules/eslint-plugin-playwright/node_modules/globals": {
+			"version": "17.5.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+			"integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint-plugin-sonarjs": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"cspell": "^10.0.0",
 		"drizzle-kit": "^0.31.10",
 		"eslint": "^10.2.0",
+		"eslint-plugin-playwright": "^2.10.2",
 		"eslint-plugin-sonarjs": "^4.0.3",
 		"eslint-plugin-storybook": "^10.3.5",
 		"eslint-plugin-svelte": "^3.17.0",

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -7,7 +7,8 @@
 - **カバレッジ閾値の引き下げ** — `vite.config.ts` の `thresholds` を下げる PR はマージ不可。引き下げが必要な場合は ADR に理由と復元計画を同時にコミット
 - **バグ隠蔽ヘルパー（ダイアログゴースト除去等）** — アプリのバグをテスト側で隠すのは禁止。アプリ側を修正する
 - **`test.skip()` の安易な使用** — テストが通らないならアプリを直す。正当な理由（環境依存等）のみ許容
-- **`waitForTimeout()` の新規使用** — E2E テストで固定待機を使わない。`waitForSelector()` / `waitForResponse()` を使う
+- **`waitForTimeout()` の新規使用** — E2E テストで固定待機を使わない。`waitForSelector()` / `waitForResponse()` / `waitForURL()` / `waitForFunction()` / Web Animations API (`el.getAnimations({ subtree: true }).map(a => a.finished)`) を使う。**ESLint (`playwright/no-wait-for-timeout: error`) が自動拒否** (#1259 Phase 3)
+- **`{ waitUntil: 'networkidle' }` の新規使用** — Playwright 公式で DISCOURAGED。Single Page App では never idle になる。`domcontentloaded` + web-first assertion (`toBeVisible()` / `toHaveText()`) を使う。**ESLint (`playwright/no-networkidle: error`) が自動拒否** (#1259 Phase 3)
 - **サービスを呼ばないサービステスト** — `xxx-service.test.ts` は必ずサービスの公開 API を import して呼ぶ。DB 直接操作のみのテストは禁止
 - **テスト内で実装ロジックを再実装** — 実装の関数を呼んで結果を検証する。テスト内で同じロジックを書いて「一致した」は無意味
 

--- a/tests/e2e/tutorial-verification.spec.ts
+++ b/tests/e2e/tutorial-verification.spec.ts
@@ -72,6 +72,11 @@ test.describe('チュートリアル全ステップ検証', () => {
 			// バブルが表示されるまで待機（ページ遷移+MutationObserver+アニメーション考慮）
 			const bubble = page.locator('.tutorial-bubble');
 			await bubble.waitFor({ state: 'visible', timeout: 8000 });
+			// #1259 Phase 3: bubble-appear animation (0.3s) 完了を Web Animations API で待つ
+			// （旧 waitForTimeout(800) の正しい置換。未完了で boundingBox 取得するとビューポート越え誤検知になる）
+			await bubble.evaluate((el) =>
+				Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)).then(() => {}),
+			);
 
 			// ステップ情報を取得
 			const title = await bubble.locator('.tutorial-title').textContent();
@@ -210,6 +215,10 @@ test.describe('チュートリアル全ステップ検証', () => {
 
 			const bubble = page.locator('.tutorial-bubble');
 			await bubble.waitFor({ state: 'visible', timeout: 8000 });
+			// #1259 Phase 3: bubble-appear animation (0.3s) 完了を Web Animations API で待つ
+			await bubble.evaluate((el) =>
+				Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)).then(() => {}),
+			);
 
 			const title = await bubble.locator('.tutorial-title').textContent();
 			const progress = await bubble.locator('.tutorial-progress-text').textContent();


### PR DESCRIPTION
closes #1259

## Summary

Phase 1 (networkidle 28件排除 / PR #1271) と Phase 2 (waitForTimeout 11件排除 / PR #1273) で達成した状態を ESLint レベルで固定化する。新規 PR で反パターンが流入すると CI が hard-fail する。

- `eslint-plugin-playwright@^2.10.2` を devDependency に追加
- `eslint.config.js`: `tests/**/*.ts` で `playwright/no-wait-for-timeout: error` + `playwright/no-networkidle: error`
- `.github/workflows/ci.yml`: `ESLint Playwright` ジョブを hard-fail（continue-on-error 無し）で追加
- `tests/CLAUDE.md`: 禁止事項セクションを「ESLint が自動拒否」に更新、代替 API (`waitForURL` / `waitForFunction` / Web Animations API) を明記

## AC verification map (#1259 Phase 3)

| AC 項目 | 証跡 |
|---|---|
| eslint-plugin-playwright を devDependencies に追加 | `package.json` diff — L40 `"eslint-plugin-playwright": "^2.10.2"` |
| `playwright/no-wait-for-timeout` + `no-networkidle` を error レベル設定 | `eslint.config.js` L118-130 追加ブロック |
| `npx eslint "tests/**/*.ts"` が 0 エラー | ローカル実行: `✖ 5 problems (0 errors, 5 warnings)` — 既存 unused disable 警告のみ |
| 故意に waitForTimeout を追加した PR で CI が red になる実証 | 手元で一時違反ファイル作成 → `✖ 2 problems (2 errors, 0 warnings)` 発火確認（commit 前に削除） |
| `tests/CLAUDE.md` の禁止事項セクションを「ESLint が自動拒否」に更新 | `tests/CLAUDE.md` L13-14 diff |

## Self-Review evidence (ADR-0044)

- [x] ローカル `npx eslint "tests/**/*.ts"` → 0 errors
- [x] ローカル `npx biome check` → OK
- [x] 違反ファイル一時作成でラチェット発火確認 (2 errors)
- [x] CI workflow は既存の SonarJS ステップ (continue-on-error) と独立した hard-fail ステップ
- [x] Phase 1 (#1271) / Phase 2 (#1273) は既に main に merge 済み、残違反 0 件を実測済み

## Test plan

- [ ] CI: lint ジョブ内の `ESLint Playwright` ステップが green
- [ ] CI: 既存 SonarJS ステップに影響なし（別ステップ / 別設定ブロック）
- [ ] CI: e2e-test ジョブが既存同様 green

---

Phase 1 (#1271) / Phase 2 (#1273) / Phase 3 (本PR) 完走で Issue #1259 完了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up (746c883e): Phase 2 regression fix

PR #1273 (Phase 2) merge 直後の main CI (run 24679381482) で `tutorial-verification.spec.ts` Step 22 がバブル下端 viewport 越え (807.5 > 800) で fail。

**原因**: Phase 2 で削除した `waitForTimeout(800)` は bubble-appear animation (0.3s, `transform: translateY/scale`) の settle 待ちを担っていたが、`bubble.waitFor({ state: 'visible' })` だけでは animation 未完了状態で boundingBox を取得してしまう。

**修正**: desktop / mobile 両方に Web Animations API による animation settle 待機を追加:
```ts
await bubble.evaluate((el) =>
  Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)).then(() => {}),
);
```

これは Phase 3 の ESLint ratchet が強制する正しいパターン (tutorial-dialog-primitive-screenshots.spec.ts と同一)。`waitForTimeout` を一切追加せずに解決。

