### PR TITLE
fix: tutorial-verification mobile flaky 修正 (bubble.finished AbortError 耐性)

### DIFF
--- a/tests/e2e/tutorial-verification.spec.ts
+++ b/tests/e2e/tutorial-verification.spec.ts
@@ -73,9 +73,10 @@ test.describe('チュートリアル全ステップ検証', () => {
 			const bubble = page.locator('.tutorial-bubble');
 			await bubble.waitFor({ state: 'visible', timeout: 8000 });
 			// #1259 Phase 3: bubble-appear animation (0.3s) 完了を Web Animations API で待つ
-			// （旧 waitForTimeout(800) の正しい置換。未完了で boundingBox 取得するとビューポート越え誤検知になる）
+			// .finished は Svelte 再レンダでアニメが cancel されると AbortError で reject する。
+			// positioning 再計算による再レンダ耐性のため catch で吸収する
 			await bubble.evaluate((el) =>
-				Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)).then(() => {}),
+				Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished.catch(() => {}))),
 			);
 
 			// ステップ情報を取得
@@ -216,8 +217,10 @@ test.describe('チュートリアル全ステップ検証', () => {
 			const bubble = page.locator('.tutorial-bubble');
 			await bubble.waitFor({ state: 'visible', timeout: 8000 });
 			// #1259 Phase 3: bubble-appear animation (0.3s) 完了を Web Animations API で待つ
+			// .finished は Svelte 再レンダでアニメが cancel されると AbortError で reject する。
+			// positioning 再計算による再レンダ耐性のため catch で吸収する
 			await bubble.evaluate((el) =>
-				Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)).then(() => {}),
+				Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished.catch(() => {}))),
 			);
 
 			const title = await bubble.locator('.tutorial-title').textContent();


### PR DESCRIPTION
## Summary

#1259 Phase 3 で導入した `bubble.evaluate(getAnimations.finished)` 待機が mobile e2e で AbortError により flaky 化していた問題の hotfix。main CI #24682229163 / PR #1275 で連続失敗を確認。

## 失敗

`tests/e2e/tutorial-verification.spec.ts:173` モバイル版が retry #2 含め 3 連続失敗:

\`\`\`
Error: locator.evaluate: AbortError: The user aborted a request.
  217 | await bubble.waitFor({ state: 'visible', timeout: 8000 });
\`\`\`

## 根本原因

Svelte の positioning 再計算で bubble element が detach/re-attach される際に `bubble-appear` animation が cancel され、cancelled animation の `.finished` promise が AbortError で reject。`Promise.all` 全体が reject → `evaluate` abort。

## 対応

\`\`\`diff
- el.getAnimations({ subtree: true }).map((a) => a.finished)
+ el.getAnimations({ subtree: true }).map((a) => a.finished.catch(() => {}))
\`\`\`

`.finished` の reject を各 promise で吸収。cancel 含め「animation が何らかの形で終わった」時点で次に進む。boundingBox 測定前の stabilization 目的に合致。

## Self-Review 証跡 (admin bypass 準備)

### 確認した観点
- [x] Issue AC 全項目突合: 本 PR は post-merge hotfix (Issue 紐付けなし、#1259 Phase 3 の regression 修正)
- [x] UI/UX 禁忌事項 (DESIGN.md §9): UI 変更なし (test code のみ)
- [x] 並行実装ペア同期確認: test code のみ、該当なし
- [x] テスト同梱: 本 PR 自体がテスト修正
- [x] 設計書同期: tests/CLAUDE.md は Phase 3 で既に Web Animations API 方針を記載済。`.catch(() => {})` は実装詳細でドキュメント追記不要
- [x] セキュリティ・プライバシー影響: なし

### 実機確認ログ
- `npx biome check tests/e2e/tutorial-verification.spec.ts` → 0 error (pre-existing 9 warnings 同値、複雑度警告は本 PR で増加せず)
- ローカル再現は CI mobile viewport + timing 依存のため困難 → CI 結果で判定

## Test plan

- [ ] CI: e2e-test (3) が mobile shard で pass する
- [ ] CI: 既存テスト (desktop / shard 1,2) は回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)