### PR TITLE
docs: #1280 source code 内の旧 ADR path 参照 8 箇所を新体系へ更新

### DIFF
--- a/.github/workflows/deploy-nuc.yml
+++ b/.github/workflows/deploy-nuc.yml
@@ -63,7 +63,7 @@ jobs:
             Write-Host "::error::AWS_LICENSE_SECRET is not set in GitHub Actions Secrets."
             Write-Host "::error::Generate hex with: node -e ""console.log(require('crypto').randomBytes(32).toString('hex'))"""
             Write-Host "::error::Register with: gh secret set AWS_LICENSE_SECRET --body <hex> --repo Takenori-Kusaka/ganbari-quest"
-            Write-Host "::error::See docs/decisions/0026-license-key-architecture.md and infra/CLAUDE.md."
+            Write-Host "::error::See docs/decisions/archive/0026-license-key-architecture.md and infra/CLAUDE.md."
             exit 1
           }
           # `.env` を毎回 GHA Secrets から再生成（rotate 対応・冪等）。

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -82,7 +82,7 @@ export class ComputeStack extends cdk.Stack {
 				'[ComputeStack] awsLicenseSecret context is empty. ' +
 					// biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions template syntax, not JS template literal
 					'Pass -c awsLicenseSecret=${{ secrets.AWS_LICENSE_SECRET }} in the deploy workflow. ' +
-					'See docs/decisions/0026-license-key-architecture.md and infra/CLAUDE.md.',
+					'See docs/decisions/archive/0026-license-key-architecture.md and infra/CLAUDE.md.',
 			);
 		}
 

--- a/scripts/check-admin-bypass-evidence.mjs
+++ b/scripts/check-admin-bypass-evidence.mjs
@@ -207,7 +207,7 @@ async function postMissingEvidenceComment(prNumber) {
 		'（`npm run dev:cognito` での手動確認ログ 等）',
 		'```',
 		'',
-		'参考: [ADR-0044](https://github.com/Takenori-Kusaka/ganbari-quest/blob/main/docs/decisions/0044-admin-bypass-evidence.md) / [Issue #1201](https://github.com/Takenori-Kusaka/ganbari-quest/issues/1201)',
+		'参考: [ADR-0044 (archive)](https://github.com/Takenori-Kusaka/ganbari-quest/blob/main/docs/decisions/archive/0044-admin-bypass-evidence.md) / [Issue #1201](https://github.com/Takenori-Kusaka/ganbari-quest/issues/1201)',
 	].join('\n');
 
 	if (DRY_RUN) {

--- a/scripts/check-dynamodb-stub.mjs
+++ b/scripts/check-dynamodb-stub.mjs
@@ -165,8 +165,8 @@ function main() {
 	console.error(
 		'\nPO 方針: main マージ = 即本番デプロイ = 即顧客提供。\n' +
 			'interface を追加した PR で SQLite + DynamoDB 両実装を完成させてください。\n' +
-			'Pre-PMF で不採用の機能は interface 自体を追加しないこと（ADR-0034）。\n' +
-			'詳細: docs/sessions/dev-session.md 「段階的リリース禁止」セクション / docs/decisions/0034-pre-pmf-security-minimum.md',
+			'Pre-PMF で不採用の機能は interface 自体を追加しないこと（ADR-0010）。\n' +
+			'詳細: docs/sessions/dev-session.md 「段階的リリース禁止」セクション / docs/decisions/0010-pre-pmf-scope-judgment.md',
 	);
 	process.exit(1);
 }

--- a/scripts/check-new-required-env.mjs
+++ b/scripts/check-new-required-env.mjs
@@ -305,7 +305,7 @@ function main() {
 		);
 		console.error(`  - 配布済み: ${missing[0]} → NUC .env (本機 + バックアップ機)`);
 		console.error('');
-		console.error('See: docs/decisions/0029-safety-assertion-erosion-ban.md');
+		console.error('See: docs/decisions/0006-safety-assertion-erosion-ban.md');
 		process.exit(1);
 	}
 

--- a/scripts/check-schema-change-tests.mjs
+++ b/scripts/check-schema-change-tests.mjs
@@ -99,7 +99,7 @@ function main() {
 	console.warn('⚠️  If this PR is a pure format/comment change, add');
 	console.warn(`⚠️  "${SKIP_MARKER}" to the PR body to silence this warning.`);
 	console.warn('');
-	console.warn('⚠️  Reference: docs/decisions/0031-schema-change-compat-testing.md');
+	console.warn('⚠️  Reference: docs/decisions/archive/0031-schema-change-compat-testing.md');
 	console.warn('');
 }
 

--- a/src/lib/server/services/license-key-service.ts
+++ b/src/lib/server/services/license-key-service.ts
@@ -73,7 +73,7 @@ export function assertLicenseKeyConfigured(): void {
 			'[LICENSE] AWS_LICENSE_SECRET is required in production. ' +
 				"Generate one with: `node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"` " +
 				'and set it in your environment (e.g. AWS SSM Parameter Store). ' +
-				'See .env.example and docs/decisions/0026-license-key-architecture.md.',
+				'See .env.example and docs/decisions/archive/0026-license-key-architecture.md.',
 		);
 	}
 

--- a/src/routes/ops/+page.svelte
+++ b/src/routes/ops/+page.svelte
@@ -191,7 +191,7 @@ const adminBypass = $derived(data.adminBypass);
 		{/if}
 		<div class="text-xs text-[var(--color-text-muted)] mt-3">
 			取得日時: {new Date(adminBypass.fetchedAt).toLocaleString('ja-JP')}
-			| 運用ルール: <a href="https://github.com/Takenori-Kusaka/ganbari-quest/blob/main/docs/decisions/0044-admin-bypass-evidence.md" class="underline">ADR-0044</a>
+			| 運用ルール: <a href="https://github.com/Takenori-Kusaka/ganbari-quest/blob/main/docs/decisions/archive/0044-admin-bypass-evidence.md" class="underline">ADR-0044 (archive)</a>
 		</div>
 	</Card>
 


### PR DESCRIPTION
closes #1280
Refs #1262 (sub-C follow-up)

## Summary

PR #1279 (sub-C docs cleanup) で PO scope 外とした source code 側の旧 ADR path 参照 8 箇所を更新する。

## 変更内容

| ファイル | 旧参照 | 新参照 |
|---------|-------|-------|
| `.github/workflows/deploy-nuc.yml:66` | `0026-license-key-architecture.md` | `archive/0026-license-key-architecture.md` |
| `infra/lib/compute-stack.ts:85` | `0026-license-key-architecture.md` | `archive/0026-license-key-architecture.md` |
| `scripts/check-admin-bypass-evidence.mjs:210` | `0044-admin-bypass-evidence.md` | `archive/0044-admin-bypass-evidence.md` |
| `scripts/check-dynamodb-stub.mjs:169` | `0034-pre-pmf-security-minimum.md` | `0010-pre-pmf-scope-judgment.md` |
| `scripts/check-new-required-env.mjs:308` | `0029-safety-assertion-erosion-ban.md` | `0006-safety-assertion-erosion-ban.md` |
| `scripts/check-schema-change-tests.mjs:102` | `0031-schema-change-compat-testing.md` | `archive/0031-schema-change-compat-testing.md` |
| `src/lib/server/services/license-key-service.ts:76` | `0026-license-key-architecture.md` | `archive/0026-license-key-architecture.md` |
| `src/routes/ops/+page.svelte:194` | `0044-admin-bypass-evidence.md` | `archive/0044-admin-bypass-evidence.md` |

## AC 検証

```bash
git grep -E 'decisions/(0026-license-key-architecture|0031-schema-change-compat-testing|0044-admin-bypass-evidence|0029-safety-assertion-erosion-ban|0034-pre-pmf-security-minimum)\.md' -- '*.ts' '*.mjs' '*.svelte' '*.yml'
# → 0 件 (Issue #1280 AC 達成)
```

残存する `decisions/` 参照はすべて新 active 体系 (`0006` / `0007` / `0010`) または `archive/` path のみ。

## Test plan

- [x] 静的検証: `git grep` が 0 件
- [x] biome check: 変更ファイルに新規 warning / error 無し (既存 2 warnings は main 同一)
- [ ] CI 全緑確認後 Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)