### PR TITLE
fix: #1363 初回セットアップ「子供を登録する」リンクを /admin/children に修正

### DIFF
--- a/src/lib/server/services/onboarding-service.ts
+++ b/src/lib/server/services/onboarding-service.ts
@@ -55,7 +55,7 @@ export async function getOnboardingProgress(
 			key: 'children',
 			label: '子供を登録する',
 			completed: children.length > 0,
-			href: `${basePath}/members`,
+			href: `${basePath}/children`,
 		},
 		{
 			key: 'activities',

--- a/tests/unit/services/onboarding-service.test.ts
+++ b/tests/unit/services/onboarding-service.test.ts
@@ -203,13 +203,22 @@ describe('onboarding-service', () => {
 
 			const result = await getOnboardingProgress(TENANT, customBase);
 
-			expect(result.items[0]?.href).toBe('/custom/path/members');
+			expect(result.items[0]?.href).toBe('/custom/path/children');
 			expect(result.items[1]?.href).toBe('/custom/path/activities');
 			expect(result.items[2]?.href).toBe('/custom/path/rewards');
 			expect(result.items[3]?.href).toBe('/custom/path/settings');
 			expect(result.items[4]?.href).toBe('/custom/path/checklists');
 			// child_screen is always /switch regardless of basePath
 			expect(result.items[5]?.href).toBe('/switch');
+		});
+
+		it('children 項目の href は /admin/children (members ではない) を指す (#1363)', async () => {
+			setupDefaults();
+
+			const result = await getOnboardingProgress(TENANT, '/admin');
+
+			const childrenItem = result.items.find((i) => i.key === 'children');
+			expect(childrenItem?.href).toBe('/admin/children');
 		});
 
 		it('子供がテンプレートを持っている場合 checklist は completed', async () => {


### PR DESCRIPTION
## Summary

closes #1363

onboarding チェックリストの children 項目の `href` が `/admin/members` (招待画面) を指していたため、新規サインアップ直後のアクティベーション動線で:

1. 「子供を登録する」→ `/admin/members` に着地
2. 招待リンクを作成しても `children.length` は増えない (招待は member 追加、children プロファイルではない)
3. チェックリストの ✅ が付かない → 離脱

という構造的誘導ミスを起こしていた。1 行修正 + 回帰テスト。

## 変更点

- `src/lib/server/services/onboarding-service.ts:58` — `href: \`${basePath}/members\`` → `\`${basePath}/children\``
- `tests/unit/services/onboarding-service.test.ts` — 既存の `basePath が href に正しく適用される` テストを `/custom/path/children` に更新 + `#1363` 明示の回帰テスト (`/admin/children` を verify) を新規追加

## AC 突合

- [x] `src/lib/server/services/onboarding-service.ts` の `children` 項目の `href` を `${basePath}/children` に修正
- [x] `tests/unit/services/onboarding-service.test.ts` に `/admin/children` を検証するテストケース追加 (1 件新規 + 1 件更新)
- [ ] 実機確認 (`npm run dev:cognito`) — 別途実施予定
- [x] demo 側確認 — demo 側は onboarding-service を import していないため対象外 (grep 済み: demo 側 0 件)

## 影響範囲

- `AdminHome.svelte` / `OnboardingChecklist.svelte` が利用する `OnboardingProgress.items[key=children].href` のみ
- production の onboarding AdminHome 1 箇所のみ
- DB / スキーマ / API 非変更

## Test plan

- [x] `npx vitest run tests/unit/services/onboarding-service.test.ts` — 24 passed (was 23)
- [x] `npx biome check` — clean
- [x] `npx svelte-check` — 0 errors (既存 warning のみ)
- [ ] CI 全緑確認後 Ready に昇格

🤖 Generated with [Claude Code](https://claude.com/claude-code)