### PR TITLE
fix: #1355 /consent の <title> タグを hasExistingConsent 分岐に対応

### DIFF
--- a/src/routes/consent/+page.svelte
+++ b/src/routes/consent/+page.svelte
@@ -26,7 +26,7 @@ const submitBlockReason = $derived.by(() => {
 </script>
 
 <svelte:head>
-	<title>規約への同意 - がんばりクエスト</title>
+	<title>{data.hasExistingConsent ? '規約に変更がありました' : '規約への同意'} - がんばりクエスト</title>
 </svelte:head>
 
 <!--

--- a/tests/unit/routes/consent-page-title.test.ts
+++ b/tests/unit/routes/consent-page-title.test.ts
@@ -1,0 +1,42 @@
+// tests/unit/routes/consent-page-title.test.ts
+// #1355: /consent の <title> タグが hasExistingConsent 分岐に対応していることを検証
+
+import { cleanup, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$app/forms', () => ({
+	enhance: () => ({ destroy: () => {} }),
+}));
+
+import ConsentPage from '../../../src/routes/consent/+page.svelte';
+
+function makeData(hasExistingConsent: boolean) {
+	return {
+		role: null,
+		requestId: 'test-request-id',
+		isDemo: false,
+		hasExistingConsent,
+		termsAccepted: !hasExistingConsent,
+		privacyAccepted: !hasExistingConsent,
+		currentTermsVersion: '2026-04-01',
+		currentPrivacyVersion: '2026-04-01',
+		previousTermsVersion: hasExistingConsent ? '2025-01-01' : null,
+		previousPrivacyVersion: hasExistingConsent ? '2025-01-01' : null,
+	};
+}
+
+describe('/consent <title> 分岐 (#1355)', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('hasExistingConsent=false のとき「規約への同意 - がんばりクエスト」', () => {
+		render(ConsentPage, { data: makeData(false), form: null });
+		expect(document.title).toBe('規約への同意 - がんばりクエスト');
+	});
+
+	it('hasExistingConsent=true のとき「規約に変更がありました - がんばりクエスト」', () => {
+		render(ConsentPage, { data: makeData(true), form: null });
+		expect(document.title).toBe('規約に変更がありました - がんばりクエスト');
+	});
+});


### PR DESCRIPTION
Closes #1355

## Summary

- `/consent` ページのブラウザタブ `<title>` が `hasExistingConsent` 分岐に追従していなかった
- 既存同意者が規約更新で再同意する際も `規約への同意 - がんばりクエスト` のまま固定表示されていた
- h1 見出し / 説明文は既に分岐済み（44-60 行）だったが `<title>` だけが固定値で不整合
- `<svelte:head>` 内で 3 項演算にしてページ内容と一致させた

## 変更

| 分岐 | before | after |
|------|--------|-------|
| `hasExistingConsent=false` | 規約への同意 - がんばりクエスト | 規約への同意 - がんばりクエスト（変更なし） |
| `hasExistingConsent=true` | 規約への同意 - がんばりクエスト | **規約に変更がありました - がんばりクエスト** |

## テスト

- `tests/unit/routes/consent-page-title.test.ts` を新規追加
  - `@testing-library/svelte` の `render` + `document.title` で両分岐を検証
  - 2 件の vitest ケース、全 pass
- `tests/unit/routes/consent-load.test.ts` は load 関数のテストで component 側は検証対象外だったため別ファイル化

## Acceptance Criteria

- [x] `hasExistingConsent=false` のとき タブタイトル「規約への同意 - がんばりクエスト」
- [x] `hasExistingConsent=true` のとき タブタイトル「規約に変更がありました - がんばりクエスト」
- [x] component レベルの `document.title` 検証テストを追加

## スクリーンショット / ビジュアルデモ

title 属性のみの変更で UI 画面上の視覚的変化はなし（ブラウザタブ名のみ）。
unit test で両分岐の `document.title` を直接アサートして挙動を担保している。

## Test plan

- [x] `npx vitest run tests/unit/routes/consent-page-title.test.ts` — 2 passed
- [x] `npx svelte-check` — 0 errors
- [x] `npx biome check` — clean
- [ ] CI green 確認後に Ready に昇格

🤖 Generated with [Claude Code](https://claude.com/claude-code)