### PR TITLE
fix: #1383 TrialBanner タイトル「試すます」→「試せます」修正 + E2E assertion 強化

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -247,6 +247,10 @@ export const ACTION_LABELS = {
 	later: 'あとで',
 	freeTrial: '無料体験',
 	freeTrialWord: '無料で試す',
+	// #1383: タイトル文脈用の可能形 (「7日間、全機能を無料で試せます」)。
+	// freeTrialWord (終止形) を「〜ます」に連結すると「試すます」と非文法になるため、
+	// 完全活用済みの文言を個別定数化する。
+	freeTrialDesc: '無料で試せます',
 	submitting: '開始中...',
 	// #1167: 詳細ページへの誘導 CTA。活動パック / マーケット一覧の「中身を確認する」導線に使用
 	viewDetail: 'くわしく見る',
@@ -274,7 +278,7 @@ export const TRIAL_LABELS = {
 	bannerTitleActive: (days: number) => `${ACTION_LABELS.freeTrial}中（残り${days}日）`,
 	bannerTitleUrgent: `${ACTION_LABELS.freeTrial}は明日で終了します`,
 	bannerDescActive: '全機能をお試しいただけます。',
-	bannerTitleNotStarted: `7日間、全機能を${ACTION_LABELS.freeTrialWord}ます`,
+	bannerTitleNotStarted: `7日間、全機能を${ACTION_LABELS.freeTrialDesc}`,
 	bannerDescNotStarted: `${PLAN_LABELS.standard}のすべての機能をお使いいただけます。カード登録不要。`,
 	bannerCtaNotStarted: ACTION_LABELS.viewPlans,
 	bannerCtaStart: `7日間 ${ACTION_LABELS.freeTrialWord}`,

--- a/tests/e2e/trial-flow.spec.ts
+++ b/tests/e2e/trial-flow.spec.ts
@@ -57,8 +57,8 @@ test.describe('#752 トライアルフロー', () => {
 		await expect(banner).toBeVisible({ timeout: 30_000 });
 		// "7日間 無料で試す" ボタンが存在
 		await expect(page.getByTestId('trial-banner-start-button')).toBeVisible();
-		// バナーに「7日間、全機能を無料で試せます」テキスト
-		await expect(banner).toContainText('7日間');
+		// #1383: 誤字「試すます」→「試せます」を検知できるよう完全一致でアサート
+		await expect(banner).toContainText('7日間、全機能を無料で試せます');
 	});
 
 	// ========================================================


### PR DESCRIPTION
Closes #1383

## Summary

- `TrialBanner` (free ユーザー向けの未開始状態) タイトルの日本語文法誤り「試すます」を「試せます」(可能形) に修正
- `ACTION_LABELS.freeTrialWord = '無料で試す'` (終止形) を `${...}ます` に連結したのが原因
- Issue 提案 **案 A** 採用: `ACTION_LABELS.freeTrialDesc = '無料で試せます'` を新設し、タイトル側だけ可能形に切替
- CTA ボタン「7日間 無料で試す」(`bannerCtaStart`) は名詞化として文法的に成立しているため変更なし
- E2E assertion が `toContainText('7日間')` と弱く誤字を検知できていなかった → フル文字列一致に強化

## 変更

### `src/lib/domain/labels.ts`
- `ACTION_LABELS.freeTrialDesc: '無料で試せます'` を追加（説明文脈用の可能形）
- `TRIAL_LABELS.bannerTitleNotStarted` を `${freeTrialWord}ます` → `${freeTrialDesc}` に置換

### `tests/e2e/trial-flow.spec.ts:61`
- `await expect(banner).toContainText('7日間');`
  → `await expect(banner).toContainText('7日間、全機能を無料で試せます');`

## Before / After

| 分岐 | before | after |
|------|--------|-------|
| TrialBanner タイトル | 7日間、全機能を**無料で試すます** | 7日間、全機能を**無料で試せます** |
| CTA ボタン | 7日間 無料で試す | 7日間 無料で試す（変更なし） |

## Acceptance Criteria

- [x] `src/lib/domain/labels.ts` `bannerTitleNotStarted` を修正し「試せます」となる
- [x] `ACTION_LABELS.freeTrialDesc` を追加（Issue 提案の案 A）
- [x] 既存 `bannerCtaStart` (「7日間 無料で試す」) は変更しない
- [x] `tests/e2e/trial-flow.spec.ts:61` の assertion をフル文字列一致に強化
- [ ] 実機検証 (`npm run dev:cognito`, `free@example.com`) と修正後スクリーンショット — follow-up
- [x] 並行実装チェック: `試すます` / `freeTrialWord}ます` の他箇所出現なし確認済み

## 並行実装チェック結果

`grep -rn "試すます\|freeTrialWord}ます" src/ tests/ site/` — 修正対象 1 箇所のみ。他に誤字なし。

## スクリーンショット / ビジュアルデモ

文言のみの変更。実機スクリーンショットは `npm run dev:cognito` 起動 + free ユーザーログインが必要で、
auto-loop セッション中の安全な実施が難しいため follow-up で添付予定。
E2E assertion をフル文字列一致に強化したため、CI が表示文言を直接担保する。

## Test plan

- [x] `npx vitest run tests/unit/components/trial-banner-display.test.ts` — 13/13 pass
- [x] `npx svelte-check` — 0 errors
- [x] `npx biome check` — clean
- [ ] CI 全緑確認後に Ready 昇格

🤖 Generated with [Claude Code](https://claude.com/claude-code)