### PR TITLE
fix(sec): #1387 ライセンスキー生成の modulo bias を crypto.randomInt に置換 — CodeQL #14

### DIFF
--- a/src/lib/server/services/cloud-export-service.ts
+++ b/src/lib/server/services/cloud-export-service.ts
@@ -1,6 +1,7 @@
 // src/lib/server/services/cloud-export-service.ts
 // クラウドエクスポート共有サービス（PIN付きS3保管 + インポート）
 
+import { randomInt } from 'node:crypto';
 import { getAuthMode } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import type { CloudExportRecord, CloudExportType } from '$lib/server/db/types';
@@ -19,9 +20,12 @@ const EXPIRY_DAYS = 7;
 
 /** PIN コードを生成（6桁英数字） */
 function generatePin(): string {
+	// #1387: Math.random() は暗号論的に非安全で PIN が予測可能になる。
+	// 家族データ共有エクスポートを保護する PIN のため crypto.randomInt で
+	// 真に一様な乱数を使う。
 	let pin = '';
 	for (let i = 0; i < PIN_LENGTH; i++) {
-		pin += PIN_CHARS[Math.floor(Math.random() * PIN_CHARS.length)];
+		pin += PIN_CHARS[randomInt(0, PIN_CHARS.length)];
 	}
 	return pin;
 }

--- a/src/lib/server/services/license-key-service.ts
+++ b/src/lib/server/services/license-key-service.ts
@@ -1,7 +1,7 @@
 // src/lib/server/services/license-key-service.ts
 // ライセンスキー生成・検証・消費サービス (#0247, #319 HMAC署名対応)
 
-import { createHmac, randomBytes } from 'node:crypto';
+import { createHmac, randomInt } from 'node:crypto';
 import {
 	LICENSE_KEY_STATUS,
 	type LicenseKeyStatus,
@@ -119,13 +119,15 @@ export function verifyKeySignature(key: string, secret: string): boolean {
 
 /** ライセンスキーを生成。秘密鍵があれば HMAC 署名付き形式 */
 export function generateLicenseKey(): string {
-	const bytes = randomBytes(12);
+	// #1387: randomBytes()[i] % KEY_CHARS.length は CodeQL js/biased-cryptographic-random が
+	// 警告する modulo-bias パターン。KEY_CHARS.length=32 は偶然 256 の約数で実害ゼロだが、
+	// ruleset 上 fix 対象。randomInt(0, n) は Node.js 内部で rejection sampling を行い、
+	// [0, n) で真に一様分布する整数を返す。
 	const segments: string[] = [];
 	for (let s = 0; s < 3; s++) {
 		let seg = '';
 		for (let i = 0; i < 4; i++) {
-			const b = bytes[s * 4 + i] ?? 0;
-			seg += KEY_CHARS[b % KEY_CHARS.length];
+			seg += KEY_CHARS[randomInt(0, KEY_CHARS.length)];
 		}
 		segments.push(seg);
 	}

--- a/tests/unit/services/license-key-service.test.ts
+++ b/tests/unit/services/license-key-service.test.ts
@@ -195,6 +195,25 @@ describe('generateLicenseKey', () => {
 		expect(segments[3]).toHaveLength(4);
 		expect(segments[4]).toHaveLength(5);
 	});
+
+	// #1387: crypto.randomInt 移行後の分布テスト。modulo bias があれば偏りが出るので検知できる。
+	it('1000 回生成したキー本体の文字分布が偏らない（CodeQL modulo-bias 回帰防止）', () => {
+		process.env.AWS_LICENSE_SECRET = '';
+		const charCounts = new Map<string, number>();
+		for (let i = 0; i < 1000; i++) {
+			const key = generateLicenseKey();
+			// "GQ-" を除いた 12 文字（ハイフンを除去）
+			const body = key.replace(/^GQ-/, '').replace(/-/g, '');
+			for (const c of body) {
+				charCounts.set(c, (charCounts.get(c) ?? 0) + 1);
+			}
+		}
+		const counts = Array.from(charCounts.values());
+		const mean = counts.reduce((a, b) => a + b, 0) / counts.length;
+		const maxDev = Math.max(...counts.map((c) => Math.abs(c - mean)));
+		// 平均からの最大乖離が 25% 以内（1000 サンプルの一様分布近似）
+		expect(maxDev / mean).toBeLessThan(0.25);
+	});
 });
 
 // ============================================================


### PR DESCRIPTION
Closes #1387

## Summary

CodeQL `js/biased-cryptographic-random` (security-severity:high) の警告箇所 `src/lib/server/services/license-key-service.ts:128` を `crypto.randomInt` に置換。

並行実装チェック (`grep -n 'Math.random\|randomBytes.*\[.*\] *%' src/`) で発見した **Math.random() で生成される cloud-export PIN** も同 PR で修正 — 家族データ共有保護 PIN のため、実質的にはこちらが優先度的に最も危険。

## 変更

### `src/lib/server/services/license-key-service.ts`
- `import { createHmac, randomBytes }` → `import { createHmac, randomInt }`
- \`KEY_CHARS[bytes[i] % KEY_CHARS.length]\` → \`KEY_CHARS[randomInt(0, KEY_CHARS.length)]\`
- KEY_CHARS.length = 32（256 の約数）なので実害はゼロだったが、CodeQL rule は modulo パターンを警告する

### `src/lib/server/services/cloud-export-service.ts`
- \`PIN_CHARS[Math.floor(Math.random() * PIN_CHARS.length)]\` → \`PIN_CHARS[randomInt(0, PIN_CHARS.length)]\`
- 6 桁 PIN = 家族データ共有エクスポートの認証鍵 → \`Math.random()\` は暗号論的に非安全

### `tests/unit/services/license-key-service.test.ts`
- 1000 回生成時の文字分布回帰防止テスト追加
- modulo bias があれば検知できる（平均からの最大乖離 25% 以内）

## Acceptance Criteria

- [x] `license-key-service.ts:121-141` を `crypto.randomInt` 版に書き換え
- [x] 既存ライセンスキーの検証ロジック (`validateLicenseKey` 等) は変更不要であることを確認（署名・charset のみ見ている）
- [x] 単体テスト追加: 分布テスト + 既存 96 テスト通過
- [x] PIN 生成も同 PR で修正（Issue 並行実装チェック指示）
- [ ] 既存 E2E (ライセンス系) が通過 — CI 検証
- [ ] CodeQL alert #14 が `fixed` に遷移 — PR merge 後に確認

## 並行実装チェック結果

- `randomBytes(n)[i] % X` パターン: license-key-service.ts の 1 箇所のみ（今回修正）
- `Math.random()` for security-sensitive random: cloud-export PIN も発見 → 同 PR 修正済
- UI effects 用の `Math.random()` (CelebrationEffect / SiblingCelebration / NativeSelect id) はセキュリティ非関連のため対象外

## 既存キー互換性

フォーマット (\`GQ-XXXX-XXXX-XXXX[-HMAC]\`) / KEY_CHARS / HMAC 計算ロジックは変更なし → 既発行キーは影響なし。新規生成キーのランダム性が改善するのみ。

## Test plan

- [x] `npx vitest run tests/unit/services/license-key-service.test.ts` — 96/96 pass (分布テスト含む)
- [x] `npx svelte-check` — 0 errors
- [x] `npx biome check` — 変更ファイル clean（既存 warning は本 PR の対象外）
- [ ] CI 全緑確認後に Ready 昇格
- [ ] merge 後 CodeQL alert #14 の `fixed` 遷移確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)