### PR TITLE
fix(sec): #1386 isAwsEnv の URL 判定を new URL() + hostname 比較に — CodeQL #9/#10

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -9,10 +9,27 @@ type Page = import('@playwright/test').Page;
 // 環境判定
 // ============================================================
 
-/** AWS 環境で実行中かどうか（playwright.aws.config.ts 経由） */
+/** AWS 環境で実行中かどうか（playwright.aws.config.ts 経由）
+ *
+ * #1386: `.includes()` による部分一致は URL の位置を検証せず、
+ * `https://evil.com/ganbari-quest.com/` や `https://ganbari-quest.com.attacker.com/`
+ * のような suffix / path 攻撃を誤って true と判定してしまう
+ * (CodeQL js/incomplete-url-substring-sanitization, severity:high)。
+ * `new URL()` で hostname を取り出し、完全一致 / サブドメイン一致で判定する。
+ */
 export function isAwsEnv(): boolean {
 	const baseUrl = process.env.E2E_BASE_URL ?? '';
-	return baseUrl.includes('ganbari-quest.com') || baseUrl.includes('amazonaws.com');
+	if (!baseUrl) return false;
+	try {
+		const host = new URL(baseUrl).hostname.toLowerCase();
+		return (
+			host === 'ganbari-quest.com' ||
+			host.endsWith('.ganbari-quest.com') ||
+			host.endsWith('.amazonaws.com')
+		);
+	} catch {
+		return false;
+	}
 }
 
 /** ローカル環境で実行中かどうか */

--- a/tests/unit/e2e-helpers.test.ts
+++ b/tests/unit/e2e-helpers.test.ts
@@ -1,0 +1,49 @@
+// tests/unit/e2e-helpers.test.ts
+// #1386: isAwsEnv の URL 判定が new URL() + hostname 比較になっており、
+// includes() 時代の suffix / path 攻撃を受けないことを検証する。
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isAwsEnv, isLocalEnv } from '../e2e/helpers';
+
+describe('isAwsEnv (#1386)', () => {
+	const original = process.env.E2E_BASE_URL;
+
+	beforeEach(() => {
+		process.env.E2E_BASE_URL = '';
+	});
+	afterEach(() => {
+		process.env.E2E_BASE_URL = original;
+	});
+
+	it.each([
+		['https://ganbari-quest.com/', true],
+		['https://www.ganbari-quest.com/', true],
+		['https://api.ganbari-quest.com/', true],
+		['https://dxxxxx.cloudfront.amazonaws.com/', true],
+		['https://abcdef.execute-api.ap-northeast-1.amazonaws.com/', true],
+		['http://localhost:5173/', false],
+		['http://127.0.0.1:5173/', false],
+		// suffix 攻撃: ホスト末尾が別ドメイン
+		['https://ganbari-quest.com.attacker.com/', false],
+		['https://amazonaws.com.attacker.com/', false],
+		// path に含まれているだけ
+		['https://evil.com/ganbari-quest.com/', false],
+		['https://evil.com/amazonaws.com', false],
+		// 類似名での誤判定
+		['https://my-ganbari-quest.comedy.com/', false],
+		// 空文字 / 不正 URL
+		['', false],
+		['not a url', false],
+	])('E2E_BASE_URL=%s → %s', (url, expected) => {
+		process.env.E2E_BASE_URL = url;
+		expect(isAwsEnv()).toBe(expected);
+	});
+
+	it('isLocalEnv は isAwsEnv の反転', () => {
+		process.env.E2E_BASE_URL = 'https://ganbari-quest.com/';
+		expect(isLocalEnv()).toBe(false);
+		process.env.E2E_BASE_URL = 'http://localhost:5173/';
+		expect(isLocalEnv()).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #1386

## Summary

CodeQL `js/incomplete-url-substring-sanitization` (security-severity:high) の警告箇所 `tests/e2e/helpers.ts:15` を修正。

\`baseUrl.includes('ganbari-quest.com') || baseUrl.includes('amazonaws.com')\` は suffix / path 位置に該当文字列があるだけで true となる脆弱パターン。`new URL()` で parse して `hostname` の末尾比較に置換。

## 変更

### `tests/e2e/helpers.ts`
- \`includes()\` 判定 → \`new URL(baseUrl).hostname\` の厳密比較
- host === 'ganbari-quest.com' / endsWith('.ganbari-quest.com') / endsWith('.amazonaws.com')
- 不正 URL は try/catch で false

### `tests/unit/e2e-helpers.test.ts` (新規)
- 15 ケースの table test を新規追加。攻撃 URL が正しく false 判定されることを担保
  - suffix 攻撃: `https://ganbari-quest.com.attacker.com/` → false
  - path 含有: `https://evil.com/ganbari-quest.com/` → false
  - 類似名: `https://my-ganbari-quest.comedy.com/` → false
  - 正常: production / CloudFront / API Gateway / localhost を適切に判定

## Acceptance Criteria

- [x] `tests/e2e/helpers.ts:13-16` を URL parse 版に書き換え
- [x] 攻撃的 URL に対する false 判定の単体テスト追加 (15 ケース)
- [x] 既存 E2E で `isAwsEnv()` を使う箇所の挙動が変わらないことを確認（正常ホスト判定は維持）
- [ ] CodeQL alert #9 / #10 が `fixed` に遷移 — PR merge 後に確認

## 並行実装チェック結果

`grep -n "\.includes\(['\"][^'\"]*\.(com|net|org|amazonaws|cloudfront)"` — src/ 配下にはセキュリティ関連の URL 部分判定なし。scripts/check-site-html.mjs の `mailto:` チェックは文字列検索でありセキュリティ境界外。

## Test plan

- [x] `npx vitest run tests/unit/e2e-helpers.test.ts` — 15/15 pass
- [x] `npx svelte-check` — 0 errors
- [x] `npx biome check` — clean
- [ ] CI 全緑確認後に Ready 昇格
- [ ] merge 後 CodeQL alert #9/#10 の `fixed` 遷移確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)