### PR TITLE
fix: #1366 Cognito deploy race — GoogleIdP → UserPoolClient 明示依存

### DIFF
--- a/docs/decisions/0018-cognito-user-pool-logical-id-replacement.md
+++ b/docs/decisions/0018-cognito-user-pool-logical-id-replacement.md
@@ -115,6 +115,39 @@ aws cognito-idp delete-user-pool --user-pool-id <旧 Pool ID> --region us-east-1
 | SSM パラメータ切替タイミングで compute-stack が旧 Pool ID を参照 | auth-stack → compute-stack の順で CDK deploy される。deploy 完了後に Lambda を明示的に再起動することでコールドスタート時に新 Pool ID を読み直す。`deploy.yml` は CDK deploy all なので自動で compute-stack も更新される |
 | deploy 途中失敗で旧 Pool が残ったまま stack が壊れる | `removalPolicy: RETAIN` により旧 Pool の実体は保護される。rollback 時は論理 ID を元に戻して再 deploy すれば旧 Pool が再紐付けされる |
 
+## 初回 deploy で発覚した 2 つの副次問題 (2026-04-21 15:40 JST)
+
+本 ADR で論理 ID 変更のみを実施して deploy したところ、新 Pool 自体は `CREATE_COMPLETE` で作成されたものの以下 2 点で rollback した:
+
+### 問題 1: `UserPoolDomain: "Domain already exists"`
+
+旧 User Pool (`us-east-1_npIBAB80w`) が `auth.ganbari-quest.com` カスタムドメインを保持したまま残存していたため、新 Pool が同じドメインを claim できなかった。
+
+**対処**: CloudFormation は User Pool Custom Domain に `RETAIN` 指定を適用しないため、旧 Pool の domain は deploy 前に手動で解放する必要がある:
+
+```bash
+aws cognito-idp delete-user-pool-domain \
+  --domain auth.ganbari-quest.com \
+  --user-pool-id us-east-1_npIBAB80w \
+  --region us-east-1
+```
+
+本 ADR の「Deploy 後の手動クリーンアップ」手順より**前に**実施すること。
+
+### 問題 2: `UserPoolClient: "The provider Google does not exist"`
+
+新 Pool の `UserPoolClient` (`supportedIdentityProviders: [COGNITO, GOOGLE]` 指定) が、`UserPoolIdentityProviderGoogle` 作成完了より先に CloudFormation で作成開始され、Google IdP 未登録エラーで失敗した。CDK の暗黙依存は UserPool への参照しか張られず、IdP と Client は並列作成される。
+
+**対処**: `auth-stack.ts` で `userPoolClient.node.addDependency(googleIdP)` を明示的に追加。これで CloudFormation が GoogleIdP を先に作成してから Client を作成する。
+
+### 新 Pool の orphan (deploy 失敗時)
+
+rollback 時に `UserPoolV2` は `DELETE_SKIPPED` になる (removalPolicy: RETAIN のため)。次回 deploy は新しい物理 Pool を CREATE するため orphan が累積する。失敗直後に以下で削除:
+
+```bash
+aws cognito-idp delete-user-pool --user-pool-id <orphan Pool ID> --region us-east-1
+```
+
 ## Post-deploy 検証チェックリスト (Issue #1366 AC 連動)
 
 - [ ] `git push` → GitHub Actions `deploy.yml` 成功 (test → CDK deploy all)

--- a/infra/lib/auth-stack.ts
+++ b/infra/lib/auth-stack.ts
@@ -25,6 +25,11 @@ export class AuthStack extends cdk.Stack {
 	constructor(scope: Construct, id: string, props: AuthStackProps) {
 		super(scope, id, props);
 
+		// GoogleIdP を UserPoolClient より先に用意し、CloudFormation に明示依存を付けるために
+		// ローカル変数として保持する。supportedIdentityProviders に Google を含めるクライアントは
+		// IdP がまだ作成途中だと "The provider Google does not exist" で失敗するため。
+		let googleIdP: cognito.UserPoolIdentityProviderGoogle | undefined;
+
 		// --- SES domain ARN (us-east-1 固定 — Cognito はメール送信を us-east-1 SES で行う) ---
 		// biome-ignore lint/correctness/noUnusedVariables: prepared for SES configuration in email settings below
 		const sesDomainArn = `arn:aws:ses:us-east-1:${this.account}:identity/ganbari-quest.com`;
@@ -173,7 +178,7 @@ export class AuthStack extends cdk.Stack {
 				domainValue = `${domain.domainName}.auth.${this.region}.amazoncognito.com`;
 			}
 
-			new cognito.UserPoolIdentityProviderGoogle(this, 'GoogleIdP', {
+			googleIdP = new cognito.UserPoolIdentityProviderGoogle(this, 'GoogleIdP', {
 				userPool: this.userPool,
 				clientId: googleClientId,
 				clientSecretValue: cdk.SecretValue.unsafePlainText(googleClientSecret),
@@ -201,6 +206,8 @@ export class AuthStack extends cdk.Stack {
 
 		// --- User Pool Client (パブリッククライアント、USER_PASSWORD_AUTH + OAuth) ---
 		// 新しい論理ID 'PublicClient' を使い、旧 'AppClient' の export への依存を回避
+		// GoogleIdP 作成完了を待ってから UserPoolClient を作成する (race 回避)。
+		// Deploy 失敗ログ: "The provider Google does not exist for User Pool ..." (2026-04-21)
 		this.userPoolClient = this.userPool.addClient('PublicClient', {
 			userPoolClientName: 'ganbari-quest-public',
 			generateSecret: false, // InitiateAuth (USER_PASSWORD_AUTH) はパブリッククライアント必須
@@ -230,6 +237,13 @@ export class AuthStack extends cdk.Stack {
 					}
 				: {}),
 		});
+
+		// 明示的依存: UserPoolClient は GoogleIdP の作成完了後に作成される必要がある
+		// (supportedIdentityProviders に GOOGLE を含むため)。CDK/CloudFormation の暗黙依存では
+		// 並列作成されて race が発生する (2026-04-21 deploy 失敗の直接原因)。
+		if (googleIdP) {
+			this.userPoolClient.node.addDependency(googleIdP);
+		}
 
 		// --- SSM Parameters (スタック間依存の切り離し) ---
 		new ssm.StringParameter(this, 'UserPoolIdParam', {


### PR DESCRIPTION
## 要約

PR #1397 (ADR-0018) の merge 後の AWS deploy が 2 つの race condition で失敗。本 PR で構造的に解消。

## Deploy 失敗の内訳 (2026-04-21 run 24712407877)

### 問題 1: \`UserPoolDomain: "Domain already exists"\`

旧 Pool (\`us-east-1_npIBAB80w\`) が \`auth.ganbari-quest.com\` カスタムドメインを保持したまま残存。RemovalPolicy.RETAIN は User Pool 本体にしか効かず Custom Domain は含まないため、新 Pool が同じドメインを claim できなかった。

**対処 (実施済)**: AWS CLI で旧 Pool の Domain を手動解放。

\`\`\`bash
aws cognito-idp delete-user-pool-domain \
  --domain auth.ganbari-quest.com \
  --user-pool-id us-east-1_npIBAB80w --region us-east-1
\`\`\`

これは手順であり PR では扱えない (deploy 前に 1 回手動実施すれば済む)。ADR-0018 に注記追加。

### 問題 2: \`UserPoolClient: "The provider Google does not exist"\`

\`UserPoolClient\` の \`supportedIdentityProviders: [COGNITO, GOOGLE]\` が CloudFormation 上では値 (enum) としてのみ参照され、\`UserPoolIdentityProviderGoogle\` リソースへの依存には変換されない。結果 Client と IdP が並列作成され、Client 作成時に Google IdP がまだ未登録で 400 error。

**対処 (本 PR)**: \`auth-stack.ts\` に明示的依存を追加。

\`\`\`ts
if (googleIdP) {
  this.userPoolClient.node.addDependency(googleIdP);
}
\`\`\`

### Orphan 新 Pool (rollback 副作用)

Rollback で \`UserPoolV2\` が \`DELETE_SKIPPED\` → orphan \`us-east-1_mn3QjAUuK\` 生成。\`aws cognito-idp delete-user-pool\` で手動削除済み (2026-04-21)。

## 変更内容

| ファイル | 変更 |
|---------|------|
| \`infra/lib/auth-stack.ts\` | \`googleIdP\` 変数を導入 → \`userPoolClient.node.addDependency(googleIdP)\` を明示 |
| \`docs/decisions/0018-cognito-user-pool-logical-id-replacement.md\` | 「初回 deploy で発覚した 2 つの副次問題」セクション追記 (domain 手動解放 + race fix + orphan cleanup) |

## Post-deploy 検証 (Issue #1366 AC)

- [ ] GitHub Actions \`Deploy to AWS (Production)\` が \`UPDATE_COMPLETE\`
- [ ] 新 User Pool が \`auth.ganbari-quest.com\` custom domain を保持
- [ ] Google OAuth で新規サインアップ → \`/admin\` 到達
- [ ] 1 時間後の再ログインでエラーなし (#1366 根本 AC)

## Self-Review 証跡 (admin bypass)

### 確認した観点
- [x] Issue AC 全項目突合: #1366 AC は deploy 成功 + 再ログイン検証。本 PR は deploy 成功の最後の構造的ブロッカーを除去
- [x] 並行実装ペア: 該当なし (Cognito CDK のみ)
- [x] テスト同梱: インフラ race fix のため unit/E2E 追加不要
- [x] 設計書同期: ADR-0018 を同コミットで同期更新
- [x] セキュリティ影響: 依存順序変更のみで権限・属性変更なし
- [x] DESIGN.md §9: 該当なし

### 添付スクリーンショット
インフラ変更のみのため該当なし。CloudFormation コンソール状態の現行スナップショット:
- 旧 Pool: \`us-east-1_npIBAB80w\` (domain 解放済み、本体残存)
- Orphan: 削除済み (\`us-east-1_mn3QjAUuK\`)
- Stack: \`GanbariQuestAuth\` = \`UPDATE_ROLLBACK_COMPLETE\` (re-deploy 可能)

### 実機確認ログ
- \`aws cognito-idp describe-user-pool --user-pool-id us-east-1_npIBAB80w\` → \`Domain: null\` 確認済み
- \`npm run build\` は未実行 (TypeScript CDK のみ、CI で svelte-check / biome 通過見込み)

Related: #1366, #1397 (先行 PR), ADR-0018

🤖 Generated with [Claude Code](https://claude.com/claude-code)