### PR TITLE
fix(sec): gdrive-auth-setup.cjs XSS via exception を解消 (CodeQL #15)

### DIFF
--- a/scripts/gdrive-auth-setup.cjs
+++ b/scripts/gdrive-auth-setup.cjs
@@ -19,8 +19,8 @@
 //   GDRIVE_FOLDER_ID=<create a folder in GDrive and copy its ID from URL>
 
 const { google } = require('googleapis');
-const http = require('http');
-const url = require('url');
+const http = require('node:http');
+const url = require('node:url');
 
 const clientId = process.argv[2];
 const clientSecret = process.argv[3];
@@ -61,7 +61,7 @@ const server = http.createServer(async (req, res) => {
 	if (parsed.pathname === '/oauth2callback') {
 		const code = parsed.query.code;
 		if (!code) {
-			res.writeHead(400);
+			res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
 			res.end('Error: No authorization code received');
 			return;
 		}
@@ -91,8 +91,10 @@ const server = http.createServer(async (req, res) => {
 			server.close();
 			process.exit(0);
 		} catch (err) {
-			res.writeHead(500);
-			res.end('Error: ' + err.message);
+			// #1388: err.message をレスポンスに埋めると XSS 経路になる (CodeQL js/xss-through-exception)。
+			// Content-Type を text/plain に固定しつつ固定文言のみ返す。詳細は CLI console に出力。
+			res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+			res.end('OAuth token exchange failed. See CLI console for details.');
 			console.error('Token exchange failed:', err.message);
 		}
 	}


### PR DESCRIPTION
## 概要

`scripts/gdrive-auth-setup.cjs` で `err.message` を未エスケープのままHTTPレスポンスボディに埋めていた CodeQL `js/xss-through-exception` (severity:medium) を解消する。

Closes #1388

## 変更内容

| ファイル | 変更 |
|---------|------|
| `scripts/gdrive-auth-setup.cjs` | catch ブロックを固定文言 + Content-Type 明示に変更。全 writeHead に Content-Type 追加。node: プロトコル統一。 |

## 修正前後

```js
// Before
} catch (err) {
  res.writeHead(500);
  res.end('Error: ' + err.message);  // ← XSS 経路
  console.error('Token exchange failed:', err.message);
}

// After
} catch (err) {
  // Content-Type text/plain + 固定文言でブラウザに HTML 解釈させない
  res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
  res.end('OAuth token exchange failed. See CLI console for details.');
  console.error('Token exchange failed:', err.message);
}
```

## AC 検証マップ

| AC | 結果 |
|----|------|
| `catch` ブロックを固定文言版に書き換え | ✅ `scripts/gdrive-auth-setup.cjs:96-97` |
| 全 `res.writeHead` に Content-Type 明示 | ✅ L64 (400), L71 (200, 既存), L96 (500) |
| `scripts/` 配下の他スクリプトに同パターンなし | ✅ `grep -r "res.end.*err" scripts/` — マッチなし |
| biome check クリーン | ✅ `No fixes applied` |
| node: プロトコル統一 (biome style info 解消) | ✅ `require('node:http')`, `require('node:url')` |

## 並行実装チェック

- `src/routes/**/+server.ts` は SvelteKit `error()` / `json()` 経由のため該当なし
- `scripts/capture-*.mjs`, `scripts/measure-lp-dimensions.mjs` は固定文言のみ + Content-Type 明示済みのため該当なし

## スクリーンショット / ビジュアルデモ

UIなし（CLIスクリプト修正のみ）

## Test plan

- [ ] CI (biome / svelte-check / vitest) 全通過確認
- [ ] CodeQL alert #15 が PR merge 後に `fixed` に遷移することを確認（merge後PO確認）

## 設計ポリシー確認

P7: バグ修正・セキュリティクリーンアップ。新テーブル / 新 interface / AWS リソース追加なし。PO 事前承認不要。