### PR TITLE
fix(sec): ci.yml 全 job に permissions block を明示 (CodeQL #6/#7/#8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ permissions:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       app: ${{ steps.filter.outputs.app }}
       deps: ${{ steps.filter.outputs.deps }}
@@ -64,6 +66,8 @@ jobs:
     # lint-and-test 内の Storybook build check を走らせるため stories を含める
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.stories == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -136,6 +140,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.deps == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -180,6 +186,8 @@ jobs:
     needs: [unit-test]
     if: always() && (needs.unit-test.result == 'success' || needs.unit-test.result == 'failure')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -218,6 +226,8 @@ jobs:
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.deps == 'true' || needs.changes.outputs.stories == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -255,6 +265,8 @@ jobs:
     # #1006 Phase 2: --shard matrix で 3 並列化 (7m 37s → ~3m 目標)
     needs: [changes]
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.deps == 'true'
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -316,6 +328,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [e2e-test]
     if: always() && (needs.e2e-test.result == 'success' || needs.e2e-test.result == 'failure')
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -348,6 +362,8 @@ jobs:
     # #923 Phase 1: lint-and-test 依存を外して並列化 (e2e-test と同じ理由)
     needs: [changes]
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.deps == 'true'
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -361,6 +377,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.site == 'true' || needs.changes.outputs.app == 'true'
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -382,6 +400,9 @@ jobs:
   new-env-distribution-check:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -407,6 +428,9 @@ jobs:
   schema-change-tests-check:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -430,6 +454,8 @@ jobs:
   # so skipped jobs (via path filter) don't block merges.
   ci-gate:
     if: always()
+    permissions:
+      contents: read
     needs:
       [
         changes,


### PR DESCRIPTION
## 概要

CodeQL `actions/missing-workflow-permissions` (alert #6/#7/#8) が `.github/workflows/ci.yml` の各 job で `permissions:` block が未定義と警告しているのを修正する。

Closes #1385

## 変更内容

| 変更 | 内容 |
|------|------|
| `ci.yml` の全 12 job | 各 job に `permissions:` block を追加 |

top-level の `permissions: contents: read / pull-requests: read` は継承設定として維持しつつ、job 単位に明示（Issue 提案の「冗長だが明示的」アプローチ）。

## 各 job の割り当て権限

| job | permissions |
|-----|-------------|
| changes | `contents: read` |
| lint-and-test | `contents: read` |
| unit-test | `contents: read` |
| unit-test-merge | `contents: read` |
| storybook-test | `contents: read` |
| e2e-test | `contents: read` |
| e2e-merge-reports | `contents: read` |
| docker-build | `contents: read` |
| site-check | `contents: read` |
| new-env-distribution-check | `contents: read` + `pull-requests: read` |
| schema-change-tests-check | `contents: read` + `pull-requests: read` |
| ci-gate | `contents: read` |

## AC 検証マップ

| AC | 結果 |
|----|------|
| 全 job に `permissions:` block 追加 | ✅ 12 job すべて追加 |
| 各 job で必要最小権限 | ✅ PR 本文アクセス系のみ pull-requests: read 追加 |
| `permissions: write-all` 不使用 | ✅ |
| 他 workflow 監査 | ✅ 下記参照 |

## 他 workflow 監査結果

| ファイル | 状態 |
|---------|------|
| `deploy.yml` | top-level + 一部 job-level — 対応済み |
| `draft-on-ci-fail.yml` | top-level あり — CodeQL 対象外 |
| `lp-metrics.yml` | top-level あり — CodeQL 対象外 |
| `pr-file-overlap.yml` | top-level あり — CodeQL 対象外 |
| `deploy-nuc.yml` | **permissions 未定義** — follow-up Issue で対応推奨 |

`deploy-nuc.yml` の修正は本 PR スコープ外（CodeQL alert が別番号で出ている場合は別 Issue 化）。

## スクリーンショット / ビジュアルデモ

CI 設定変更のみ。UI なし。

## Test plan

- [ ] CI 全ジョブが既存と同じ動作 (権限不足による失敗が無い)
- [ ] CodeQL alert #6 / #7 / #8 が PR merge 後に `fixed` に遷移することを確認