### PR TITLE
fix: 子供追加フォームのテーマカラーラベルを labels.ts SSOT に統一 (closes #1370)

### DIFF
--- a/src/routes/(parent)/admin/children/+page.svelte
+++ b/src/routes/(parent)/admin/children/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { getErrorMessage } from '$lib/domain/errors';
+import { getThemeOptions } from '$lib/domain/labels';
 import { formatPointValue } from '$lib/domain/point-display';
 import ChildListCard from '$lib/features/admin/components/ChildListCard.svelte';
 import ChildProfileCard from '$lib/features/admin/components/ChildProfileCard.svelte';
@@ -119,13 +120,10 @@ let showAddForm = $state(false);
 						id="add-theme"
 						name="theme"
 						label="テーマカラー"
-						options={[
-							{ value: 'pink', label: '🩷 ピンク' },
-							{ value: 'blue', label: '💙 ブルー' },
-							{ value: 'green', label: '💚 みどり' },
-							{ value: 'orange', label: '🧡 オレンジ' },
-							{ value: 'purple', label: '💜 むらさき' },
-						]}
+						options={getThemeOptions().map((opt) => ({
+						value: opt.value,
+						label: `${opt.emoji} ${opt.label}`,
+					}))}
 					/>
 				</div>
 				<Button type="submit" variant="success" size="sm">追加する</Button>


### PR DESCRIPTION
## 概要

子供追加フォームのテーマカラー選択肢が `labels.ts` の `getThemeOptions()` を使わず、日本語ラベルをハードコードしていた問題を修正。

## 変更内容

- `src/routes/(parent)/admin/children/+page.svelte` の `NativeSelect` options を `getThemeOptions()` で生成するよう変更
- 既存の `ChildProfileCard.svelte` と同じパターンに統一

## Before / After

```diff
- options={[
-   { value: 'pink', label: '🩷 ピンク' },
-   { value: 'blue', label: '💙 ブルー' },
-   { value: 'green', label: '💚 みどり' },
-   { value: 'orange', label: '🧡 オレンジ' },
-   { value: 'purple', label: '💜 むらさき' },
- ]}
+ options={getThemeOptions().map((opt) => ({
+   value: opt.value,
+   label: `${opt.emoji} ${opt.label}`,
+ }))}
```

## 検証

- `npx biome check .` — エラーなし
- `npx svelte-check` — エラーなし
- `grep -r "みどり\|むらさき" src/ site/` — 他に直書き箇所なし

closes #1370