### PR TITLE
infra: CDK diff Replacement 検知を deploy 前必須ゲートとして組み込む (closes #1400)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,17 @@ jobs:
         working-directory: infra/
         run: npm ci
 
-      # Phase 1: Deploy Storage stack (ECR repo, DynamoDB, S3)
+      # Phase 1: Replacement check + Deploy Storage stack (ECR repo, DynamoDB, S3)
+      # #1400: cdk diff で Replacement/Destroy リソースを検出し、未承認なら deploy をブロック
+      - name: CDK diff — replacement check (Storage)
+        working-directory: infra/
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          npx cdk diff GanbariQuestStorage \
+            -c domainName=${{ env.DOMAIN_NAME }} \
+            -c certificateArn=${{ env.CERTIFICATE_ARN }} \
+            2>&1 | COMMIT_MSG="$COMMIT_MSG" node ../scripts/check-cdk-replacement.mjs
+
       - name: CDK Deploy Storage
         working-directory: infra/
         run: >-
@@ -153,7 +163,33 @@ jobs:
           fi
           # Note: Cost Anomaly Monitoring はデフォルトモニターを使用（CDK管理外）
 
-      # Phase 3: Deploy Compute + Network stacks (Lambda, CloudFront)
+      # Phase 3: Replacement check + Deploy Compute + Network stacks (Lambda, CloudFront)
+      # #1400: Auth / Network / Compute スタック（特に Cognito User Pool）の Replacement を検知
+      - name: CDK diff — replacement check (all stacks)
+        working-directory: infra/
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          npx cdk diff --all \
+            -c domainName=${{ env.DOMAIN_NAME }} \
+            -c certificateArn=${{ env.CERTIFICATE_ARN }} \
+            -c feedbackDiscordWebhookUrl=${{ secrets.FEEDBACK_DISCORD_WEBHOOK_URL }} \
+            -c geminiApiKey=${{ secrets.GEMINI_API_KEY }} \
+            -c adminAllowedIps=${{ secrets.ADMIN_ALLOWED_IPS }} \
+            -c stripeSecretKey=${{ secrets.STRIPE_SECRET_KEY }} \
+            -c stripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET }} \
+            -c stripePriceMonthly=${{ vars.STRIPE_PRICE_MONTHLY }} \
+            -c stripePriceYearly=${{ vars.STRIPE_PRICE_YEARLY }} \
+            -c stripePriceFamilyMonthly=${{ vars.STRIPE_PRICE_FAMILY_MONTHLY }} \
+            -c stripePriceFamilyYearly=${{ vars.STRIPE_PRICE_FAMILY_YEARLY }} \
+            -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }} \
+            -c cronSecret=${{ secrets.CRON_SECRET }} \
+            -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
+            -c awsLicenseSecret=${{ secrets.AWS_LICENSE_SECRET }} \
+            -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }} \
+            ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }} \
+            ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }} \
+            2>&1 | COMMIT_MSG="$COMMIT_MSG" node ../scripts/check-cdk-replacement.mjs
+
       - name: CDK Deploy all stacks
         working-directory: infra/
         run: >-

--- a/docs/decisions/0019-cdk-replacement-detection-gate.md
+++ b/docs/decisions/0019-cdk-replacement-detection-gate.md
@@ -1,0 +1,127 @@
+# 0019. CDK Replacement 検知を deploy 前必須ゲートとして組み込む
+
+- **Status**: Accepted
+- **Date**: 2026-04-24
+- **Related Issue**: #1400
+- **Related Incidents**: #1366, ADR-0017 (Rejected), ADR-0018 (Accepted)
+
+## 背景
+
+2026-04-21 に #1366 の CDK 変更 (Cognito User Pool の `email: mutable: false → true`) を本番
+deploy したところ、AWS CloudFormation が in-place UpdateUserPool を試行して `UPDATE_ROLLBACK_FAILED`
+で stuck する事故が発生した (ADR-0017 参照)。
+
+根本的な構造的欠陥:
+
+- `.github/workflows/deploy.yml` は `cdk deploy` を直接実行しており、deploy 前に `cdk diff` で
+  Replacement が起きるかを確認する仕組みがなかった
+- PR レビュー時点で「CDK が in-place Update を試みる」と気づけなかった
+- ADR を書いても、実際の deploy で初めて判明するリスクが残ったまま
+
+## 決定
+
+### 1. `scripts/check-cdk-replacement.mjs` の作成
+
+CDK diff の stdout を解析して Replacement / Destroy 対象の論理 ID を抽出するスクリプト。
+
+**検出パターン**:
+
+| パターン | 説明 |
+|---------|------|
+| `[-] AWS::Type LogicalId ...` | リソース削除 (destroy) |
+| `[~] AWS::Type LogicalId ... (replace/replacement)` | リソース置き換え |
+| プロパティ行の `(may cause replacement)` / `(requires replacement)` | プロパティ変更が置き換えを誘発 |
+
+**承認メカニズム**:
+- PR 本文またはコミットメッセージに `replacement-approved: LogicalId1,LogicalId2` を記載
+- squash merge のコミットメッセージに PR 本文が含まれるため、PR 本文への記載で十分
+- 承認がない場合は exit 1 でデプロイをブロック
+
+### 2. `.github/workflows/deploy.yml` への組み込み
+
+CDK deploy ステップの **直前** に `cdk diff | check-cdk-replacement.mjs` を実行する:
+
+- Phase 1: `GanbariQuestStorage` deploy 前に Storage スタック diff チェック
+- Phase 3: `--all` deploy 前に全スタック diff チェック (Auth スタックの Cognito User Pool 等が対象)
+
+コミットメッセージを `git log -1 --pretty=%B` で取得し、`COMMIT_MSG` 環境変数として渡す。
+
+### 3. `.github/pull_request_template.md` への `replacement-approved` セクション追加
+
+CDK Replacement が予想される PR で、作者がマーカーを記載する場所と使い方の説明を追加。
+
+## 承認マーカーの使い方
+
+CDK diff ステップが以下を出力した場合:
+
+```
+CDK Replacement / Destroy detected (2 resource(s)):
+  [destroy] UserPool — NOT APPROVED
+  [destroy] UserPool/PublicClient — NOT APPROVED
+
+DEPLOY BLOCKED: 2 unapproved replacement(s) detected.
+Add the following line to the PR body (squash merge commit message) to approve:
+  replacement-approved: UserPool,UserPool/PublicClient
+```
+
+PR 本文に以下を追加する:
+
+```
+replacement-approved: UserPool,UserPool/PublicClient
+```
+
+## 検討した代替案
+
+### A. CDK changeset を全 PR で実行する
+
+- **メリット**: より正確な Replacement 検知 (CloudFormation Changeset ベース)
+- **デメリット**: 全 PR で AWS 認証と実 stack 参照が必要。PR CI コストが増大。
+  フル spun-up は Pre-PMF ではオーバーエンジニアリング (ADR-0010)
+
+### B. cdk diff --strict で CI 失敗させる
+
+- **メリット**: 実装シンプル
+- **デメリット**: 変更があるだけで失敗するため、通常の変更もブロックされる。運用不可能。
+
+### C. PR レビュー時の目視確認のみ
+
+- **メリット**: 変更なし
+- **デメリット**: ADR-0017 の事故と同じ経路が再発する。機械チェックなしは再発防止にならない。
+
+## 制約・注意事項
+
+### cdk diff の制限
+
+- `cdk diff` は CloudFormation API で現在のスタック状態を取得するため、AWS 認証が必要
+  → deploy ジョブ (OIDC 認証済み) 内でのみ実行可能。PR CI には含まない。
+- Storage スタックが未デプロイ (初回デプロイ) の場合、diff はすべて `[+]` (新規追加) のみ → Replacement なし → 正常通過
+- `cdk diff` は `--strict` なしで使用。`--strict` は変更があるだけで exit 1 になる
+
+### 承認の取り消し
+
+`replacement-approved` マーカーを含む PR が一度マージされた後でも、次の deploy では
+再度 diff チェックが走る。意図的な Replacement が完了した後は、後続 PR に不要なマーカーは
+残さなくてよい (squash merge のコミットメッセージはそのコミット固定で、後続のコミットには引き継がれない)。
+
+### CloudFormation Logical ID の識別方法
+
+CDK diff 出力の形式:
+```
+[-] AWS::ResourceType CDK_CONSTRUCT_ID CF_LOGICAL_ID_WITH_HASH
+```
+
+`check-cdk-replacement.mjs` は `CDK_CONSTRUCT_ID` (3番目のトークン) を識別子として使用する。
+承認マーカーには `CDK_CONSTRUCT_ID` を記載すること。
+
+例: `[-] AWS::Cognito::UserPool UserPool UserPool6BA7E5F2`
+→ 承認に必要なのは `UserPool` (CF hash の `6BA7E5F2` は不要)
+
+## 教訓 (ADR-0017 から)
+
+本 ADR は ADR-0017 postmortem の「構造的欠陥」に対する機械的ゲートである:
+
+> 本番 deploy 先行の破壊的変更は、まず staging / CDK synth diff で Replacement 挙動を確認する
+> 段取りが ADR に含まれていなかったのが構造的欠陥
+
+「ADR を書く」だけでは防げない。機械チェックを deploy フローに組み込むことで、
+次回の CDK Replacement 事故を予防する。

--- a/scripts/__tests__/check-cdk-replacement.test.mjs
+++ b/scripts/__tests__/check-cdk-replacement.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * scripts/__tests__/check-cdk-replacement.test.mjs
+ *
+ * check-cdk-replacement.mjs のユニットテスト (Node.js 22 組み込みテストランナー)
+ *
+ * 実行: node --test scripts/__tests__/check-cdk-replacement.test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { detectReplacements, parseApprovedIds, stripAnsi } from '../check-cdk-replacement.mjs';
+
+// ---------------------------------------------------------------------------
+// ADR-0018 相当 fixture: Cognito User Pool 論理 ID 変更による Replacement
+// (UserPool6BA7E5F2 → UserPoolV2XXXXXXXX の re-create)
+// ---------------------------------------------------------------------------
+const ADR_0018_DIFF = `
+Stack GanbariQuestAuth
+Resources
+[+] AWS::Cognito::UserPool UserPool UserPoolV2XXXXXXXX
+[+] AWS::Cognito::UserPoolClient UserPool/PublicClient UserPoolV2PublicClientABCD
+[+] AWS::Route53::RecordSet AuthDomainAlias AuthDomainAliasNew1234
+[-] AWS::Cognito::UserPool UserPool UserPool6BA7E5F2
+[-] AWS::Cognito::UserPoolClient UserPool/PublicClient UserPoolPublicClient1A2B3C
+[-] AWS::Route53::RecordSet AuthDomainAlias AuthDomainAliasOld5678
+`
+	.trim()
+	.split('\n');
+
+// ---------------------------------------------------------------------------
+// プロパティレベル置き換え fixture: RDS インスタンスクラス変更
+// ---------------------------------------------------------------------------
+const PROPERTY_REPLACE_DIFF = `
+Stack GanbariQuestStorage
+Resources
+[~] AWS::RDS::DBInstance Database DatabaseABCDEF
+ └─ [~] DBInstanceClass: "db.t3.micro" -> "db.t3.small" (may cause replacement)
+`
+	.trim()
+	.split('\n');
+
+// ---------------------------------------------------------------------------
+// 変更なし fixture
+// ---------------------------------------------------------------------------
+const NO_CHANGE_DIFF = `
+Stack GanbariQuestCompute
+Resources
+[~] AWS::Lambda::Function Handler HandlerXXXXXX
+ └─ [~] Description: "old" -> "new"
+`
+	.trim()
+	.split('\n');
+
+// ---------------------------------------------------------------------------
+// ANSI カラーコード付き fixture
+// ---------------------------------------------------------------------------
+const ANSI_DIFF = [
+	'\x1b[1m\x1b[31m[-]\x1b[0m AWS::Cognito::UserPool UserPool UserPool6BA7E5F2',
+	'\x1b[1m\x1b[32m[+]\x1b[0m AWS::Cognito::UserPool UserPool UserPoolV2XXXXXXXX',
+];
+
+describe('detectReplacements', () => {
+	it('ADR-0018: [-] lines are detected as destroy (by CDK construct ID)', () => {
+		const result = detectReplacements(ADR_0018_DIFF);
+		// CDK diff format: [marker] ResourceType CDK_ID CF_HASH
+		// detectReplacements uses CDK_ID (token[2]) as the identifier
+		assert.equal(result.has('UserPool'), true);
+		assert.equal(result.get('UserPool'), 'destroy');
+		assert.equal(result.has('UserPool/PublicClient'), true);
+		assert.equal(result.get('UserPool/PublicClient'), 'destroy');
+		assert.equal(result.has('AuthDomainAlias'), true);
+	});
+
+	it('ADR-0018: [+] lines are NOT flagged as replacement', () => {
+		const result = detectReplacements(ADR_0018_DIFF);
+		// [+] lines (new resources being created) should not be flagged
+		assert.equal(result.has('UserPoolV2'), false);
+	});
+
+	it('property-level (may cause replacement) is detected via parent resource CDK ID', () => {
+		const result = detectReplacements(PROPERTY_REPLACE_DIFF);
+		assert.equal(result.has('Database'), true);
+		assert.equal(result.get('Database'), 'may-cause-replacement');
+	});
+
+	it('ordinary modifications without replacement are not flagged', () => {
+		const result = detectReplacements(NO_CHANGE_DIFF);
+		assert.equal(result.size, 0);
+	});
+
+	it('ANSI escape codes are stripped before parsing', () => {
+		const result = detectReplacements(ANSI_DIFF);
+		assert.equal(result.has('UserPool'), true);
+		assert.equal(result.get('UserPool'), 'destroy');
+		assert.equal(result.has('UserPoolV2'), false);
+	});
+
+	it('empty input produces no results', () => {
+		const result = detectReplacements([]);
+		assert.equal(result.size, 0);
+	});
+});
+
+describe('parseApprovedIds', () => {
+	it('parses single id from PR body', () => {
+		const approved = parseApprovedIds('replacement-approved: UserPool6BA7E5F2', '');
+		assert.equal(approved.has('UserPool6BA7E5F2'), true);
+	});
+
+	it('parses comma-separated ids', () => {
+		const approved = parseApprovedIds(
+			'replacement-approved: UserPool6BA7E5F2,UserPoolPublicClient1A2B3C',
+			'',
+		);
+		assert.equal(approved.has('UserPool6BA7E5F2'), true);
+		assert.equal(approved.has('UserPoolPublicClient1A2B3C'), true);
+	});
+
+	it('parses ids from commit message', () => {
+		const approved = parseApprovedIds('', 'replacement-approved: AuthDomainAliasOld5678');
+		assert.equal(approved.has('AuthDomainAliasOld5678'), true);
+	});
+
+	it('returns empty set when no marker present', () => {
+		const approved = parseApprovedIds('normal PR body', 'feat: some commit');
+		assert.equal(approved.size, 0);
+	});
+
+	it('is case-insensitive for the marker keyword', () => {
+		const approved = parseApprovedIds('Replacement-Approved: UserPool6BA7E5F2', '');
+		assert.equal(approved.has('UserPool6BA7E5F2'), true);
+	});
+});
+
+describe('stripAnsi', () => {
+	it('removes ANSI color codes', () => {
+		assert.equal(stripAnsi('\x1b[31mred\x1b[0m'), 'red');
+		assert.equal(stripAnsi('\x1b[1m\x1b[32m[+]\x1b[0m normal text'), '[+] normal text');
+	});
+});

--- a/scripts/check-cdk-replacement.mjs
+++ b/scripts/check-cdk-replacement.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-cdk-replacement.mjs
+ *
+ * CDK diff の stdout を解析して Replacement / Destroy が必要なリソースを検出し、
+ * 承認マーカーがない場合は exit 1 でデプロイを止める。
+ *
+ * Usage (deploy.yml から呼び出す):
+ *   cdk diff ... 2>&1 | COMMIT_MSG="$(git log -1 --pretty=%B)" node scripts/check-cdk-replacement.mjs
+ *
+ * Approval (PR 本文またはコミットメッセージに記載):
+ *   replacement-approved: LogicalId1,LogicalId2
+ *
+ * Ref: docs/decisions/0019-cdk-replacement-detection-gate.md (#1400)
+ */
+
+import * as readline from 'node:readline';
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI エスケープコード検出に ESC 文字が必要
+const ANSI_ESCAPE = /\x1b\[[0-9;]*[mGKHF]/g;
+
+/**
+ * CDK diff 出力行から ANSI エスケープコードを除去する
+ * @param {string} str
+ * @returns {string}
+ */
+export function stripAnsi(str) {
+	return str.replace(ANSI_ESCAPE, '');
+}
+
+/**
+ * CDK diff 出力行からリソースの論理 ID を抽出する
+ * 形式: [~|+|-] AWS::Type LogicalId [CFHash] [(action)]
+ * @param {string} line stripped line
+ * @returns {string}
+ */
+export function extractLogicalId(line) {
+	// トークン: [0]=[~], [1]=AWS::Type, [2]=LogicalId, [3]=CFHash (optional), [4+]=(action) (optional)
+	const tokens = line.trim().split(/\s+/);
+	// tokens[2] が存在しない場合は line 全体を返す
+	return tokens[2] ?? line.trim();
+}
+
+/**
+ * CDK diff の stdout 行リストを解析して Replacement/Destroy リソースを抽出する
+ *
+ * 検出パターン:
+ *   - [-] AWS::Type LogicalId ... — リソース削除 (destroy)
+ *   - [~] AWS::Type LogicalId ... (replace) / (replacement) — リソース置き換え
+ *   - プロパティ行の (may cause replacement) / (requires replacement) / (REPLACEMENT)
+ *
+ * @param {string[]} lines
+ * @returns {Map<string, string>} logicalId → reason
+ */
+export function detectReplacements(lines) {
+	const replacements = new Map();
+	let currentResourceId = null;
+
+	for (const rawLine of lines) {
+		const line = stripAnsi(rawLine).trimEnd();
+		const trimmed = line.trim();
+
+		if (!trimmed) {
+			currentResourceId = null;
+			continue;
+		}
+
+		// リソース行: [+|-|~] AWS::... (インデントなし)
+		const resourceMatch = /^\[([+\-~])\]\s+(AWS::\S+)\s+(\S+)/.exec(trimmed);
+		if (resourceMatch) {
+			const marker = resourceMatch[1];
+			const logicalId = resourceMatch[3];
+
+			if (marker === '-') {
+				// [-] = リソース削除
+				replacements.set(logicalId, 'destroy');
+				currentResourceId = logicalId;
+			} else if (marker === '~') {
+				// [~] with (replace) / (replacement) suffix = 明示的な置き換え
+				const hasReplaceSuffix = /\(replace(?:ment)?\)\s*$/i.test(trimmed);
+				if (hasReplaceSuffix) {
+					replacements.set(logicalId, 'replace');
+				}
+				currentResourceId = logicalId;
+			} else {
+				// [+] = 追加 (新規リソース。単独では Replacement 扱いしない)
+				currentResourceId = logicalId;
+			}
+			continue;
+		}
+
+		// プロパティ行: (may cause replacement) / (requires replacement) / (REPLACEMENT)
+		if (
+			/(may cause replacement|requires? replacement|REPLACEMENT)/i.test(trimmed) &&
+			currentResourceId !== null &&
+			!replacements.has(currentResourceId)
+		) {
+			replacements.set(currentResourceId, 'may-cause-replacement');
+		}
+	}
+
+	return replacements;
+}
+
+/**
+ * PR 本文またはコミットメッセージから承認済み論理 ID 一覧を抽出する
+ *
+ * 形式: replacement-approved: LogicalId1,LogicalId2
+ *
+ * @param {string} prBody
+ * @param {string} commitMsg
+ * @returns {Set<string>}
+ */
+export function parseApprovedIds(prBody = '', commitMsg = '') {
+	const approved = new Set();
+
+	for (const source of [prBody, commitMsg]) {
+		const pattern = /replacement-approved:\s*([^\n\r]+)/gi;
+		let match = pattern.exec(source);
+		while (match !== null) {
+			const ids = match[1]
+				.split(/[,\s]+/)
+				.map((s) => s.trim())
+				.filter(Boolean);
+			for (const id of ids) {
+				approved.add(id);
+			}
+			match = pattern.exec(source);
+		}
+	}
+
+	return approved;
+}
+
+/**
+ * stdin から CDK diff 出力を読み込んで Replacement を検証するメイン処理
+ */
+async function main() {
+	const rl = readline.createInterface({ input: process.stdin, terminal: false });
+	const lines = [];
+	for await (const line of rl) {
+		lines.push(line);
+	}
+
+	const replacements = detectReplacements(lines);
+
+	if (replacements.size === 0) {
+		console.log('check-cdk-replacement: no replacements or destroys detected. OK.');
+		process.exit(0);
+	}
+
+	const prBody = process.env.PR_BODY ?? '';
+	const commitMsg = process.env.COMMIT_MSG ?? '';
+	const approved = parseApprovedIds(prBody, commitMsg);
+
+	const unapproved = [];
+	console.log(`\nCDK Replacement / Destroy detected (${replacements.size} resource(s)):`);
+	for (const [logicalId, reason] of replacements) {
+		const isApproved = approved.has(logicalId);
+		console.log(`  [${reason}] ${logicalId} — ${isApproved ? 'APPROVED' : 'NOT APPROVED'}`);
+		if (!isApproved) {
+			unapproved.push({ logicalId, reason });
+		}
+	}
+
+	if (unapproved.length === 0) {
+		console.log('\nAll replacements are approved. Proceeding with deploy.');
+		process.exit(0);
+	}
+
+	console.error(`\nDEPLOY BLOCKED: ${unapproved.length} unapproved replacement(s) detected.`);
+	console.error('Add the following line to the PR body (squash merge commit message) to approve:');
+	console.error(`  replacement-approved: ${unapproved.map((u) => u.logicalId).join(',')}`);
+	console.error('\nRef: docs/decisions/0019-cdk-replacement-detection-gate.md');
+	process.exit(1);
+}
+
+// ESM: import.meta.url で直接実行を判定
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((err) => {
+		console.error('check-cdk-replacement.mjs fatal error:', err.message);
+		process.exit(1);
+	});
+}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（運用者）

**解決する課題**:
#1366 の deploy 事故（Cognito User Pool の in-place Update が UPDATE_ROLLBACK_FAILED で stuck）の再発防止。
CDK diff で Replacement/Destroy を検出し、未承認なら deploy を自動ブロックする機械的ゲートを追加する。

**期待される効果**:
- 意図しない CloudFormation Replacement（Cognito User Pool, RDS, DynamoDB テーブル等）が本番 deploy 時に初めて発覚するリスクをゼロにする
- 承認マーカー（`replacement-approved: LogicalId`）を PR 本文に記載することで、意図的な Replacement を明示的に承認できる

## 関連 Issue

closes #1400

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | check-cdk-replacement.mjs が cdk diff stdout を解析して Replacement/Destroy 論理 ID を出力 | `node --test scripts/__tests__/check-cdk-replacement.test.mjs` | 12 tests pass |
| AC2 | deploy.yml に cdk-diff-replacement-check step を追加（CDK Deploy 前に実行） | deploy.yml diff 確認 | Phase1/Phase3 の両 deploy 前に追加済み |
| AC3 | Replacement 検知時は承認マーカーを照合して fail/pass | scripts/__tests__/ の ADR-0018 fixture テスト | UserPool/UserPool/PublicClient が destroy として検出されることを確認 |
| AC4 | pull_request_template.md に replacement-approved の記載方法を追加 | PR template diff 確認 | 「CDK Replacement 承認」セクションを追加済み |
| AC5 | fixture test 1件追加（ADR-0018 相当） | scripts/__tests__/check-cdk-replacement.test.mjs | ADR_0018_DIFF fixture + 12ケース全通過 |
| AC6 | ADR 起票 | docs/decisions/0019-cdk-replacement-detection-gate.md | 作成済み |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 変更内容詳細

### `scripts/check-cdk-replacement.mjs`

CDK diff stdout を解析するスクリプト。検出パターン:
- `[-] AWS::Type LogicalId ...` — リソース削除
- `[~] AWS::Type LogicalId ... (replace/replacement)` — リソース置き換え
- プロパティ行の `(may cause replacement)` / `(requires replacement)` — プロパティ変更が置き換えを誘発

承認は `COMMIT_MSG` 環境変数内の `replacement-approved: LogicalId1,LogicalId2` マーカーで判定。

### `scripts/__tests__/check-cdk-replacement.test.mjs`

Node.js 22 組み込みテストランナー (`node:test`) による 12 ケースのユニットテスト:
- ADR-0018 相当 (Cognito User Pool 論理 ID 変更) の fixture
- プロパティレベル `(may cause replacement)` の検出
- ANSI カラーコード付き出力の処理
- parseApprovedIds の各種パターン

### `.github/workflows/deploy.yml`

Phase 1 (GanbariQuestStorage) と Phase 3 (--all) の CDK deploy 前に `cdk diff | check-cdk-replacement.mjs` を追加。

```yaml
- name: CDK diff — replacement check (Storage)
  working-directory: infra/
  run: |
    COMMIT_MSG=$(git log -1 --pretty=%B)
    npx cdk diff GanbariQuestStorage ... 2>&1 | COMMIT_MSG="$COMMIT_MSG" node ../scripts/check-cdk-replacement.mjs
```

### `.github/pull_request_template.md`

「CDK Replacement 承認」セクションを追加。いつ使うか/使い方を説明。

### `docs/decisions/0019-cdk-replacement-detection-gate.md`

ADR-0019 を起票。ADR-0017 postmortem の構造的欠陥に対する機械的ゲートとして位置づけ。

## テスト戦略

| テスト種別 | コマンド | 結果 |
|-----------|---------|------|
| Script unit test | `node --test scripts/__tests__/check-cdk-replacement.test.mjs` | 12 tests pass |
| Lint | `npx biome check scripts/check-cdk-replacement.mjs scripts/__tests__/...` | CLEAN |

## 横展開・影響波及チェック

- [x] **該当なし** — 並行実装の影響範囲外の変更（infra スクリプト + CI workflow のみ）

## CDK Replacement 承認 (infra 変更の場合のみ)

- [x] **N/A** — 本 PR 自体は CDK スタック変更なし（スクリプト・CI 変更のみ）

replacement-approved: <!-- N/A -->

## デプロイ検証（#710 — マージ後必須）

- [ ] `gh run list --branch main --workflow deploy.yml` でデプロイワークフローが**成功**していることを確認

## Self-Review 証跡 (admin bypass)

### 確認した観点
- [x] Issue AC 全項目突合（Issue #1400 の Acceptance Criteria に対する達成状況）
- [x] 並行実装ペア（`docs/design/parallel-implementations.md`）の同期確認 — 該当なし
- [x] テスト同梱（script unit test 12件）
- [x] 設計書同期（ADR-0019 起票）
- [x] セキュリティ・プライバシー影響無し（deploy ゲート追加のみ）

### 添付スクリーンショット
- UI 変更なし（CI/CD スクリプト + workflow の変更のみ）

### 実機確認ログ
- `node --test scripts/__tests__/check-cdk-replacement.test.mjs` → 12 tests pass
- `npx biome check ...` → CLEAN