### PR TITLE
feat: #1375 NUC docker-compose scheduler コンテナ追加 — node-cron + ADR-0020

### DIFF
--- a/Dockerfile.scheduler
+++ b/Dockerfile.scheduler
@@ -1,0 +1,31 @@
+# Dockerfile.scheduler — NUC cron scheduler コンテナ (#1375)
+#
+# node-cron で schedule-registry.ts の定義に従い /api/cron/* エンドポイントを呼び出す。
+# docker compose --profile scheduler up で opt-in 起動。
+#
+# メモリフットプリント目標: < 100MB（node-cron + tsx のみで常駐する軽量プロセス）
+
+# Stage 1: npm ci（ネイティブモジュールビルドツールを含む）
+FROM node:22-alpine AS deps
+RUN apk add --no-cache python3 make g++
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+# Stage 2: Runtime（最小コピー）
+FROM node:22-alpine AS runtime
+WORKDIR /app
+
+# node_modules 全体をコピー（tsx + node-cron が含まれる）
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/package.json ./
+
+# scheduler に必要なソースのみコピー（SvelteKit ビルド成果物は不要）
+COPY src/lib/server/cron/ ./src/lib/server/cron/
+COPY scripts/scheduler.ts ./scripts/scheduler.ts
+COPY tsconfig.json ./
+
+ENV TZ=Asia/Tokyo
+ENV NODE_ENV=production
+
+CMD ["node_modules/.bin/tsx", "scripts/scheduler.ts"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,25 @@ services:
     profiles:
       - backup
 
+  # Cron scheduler service (#1375: NUC 統一スケジューラ)
+  # Enable: docker compose --profile scheduler up -d
+  # CRON_SECRET must be set in .env before enabling.
+  scheduler:
+    build:
+      context: .
+      dockerfile: Dockerfile.scheduler
+    environment:
+      - APP_URL=http://app:3000
+      - TZ=Asia/Tokyo
+    env_file:
+      - path: .env
+        required: false
+    depends_on:
+      - app
+    restart: unless-stopped
+    profiles:
+      - scheduler
+
   # Optional: Caddy reverse proxy for HTTPS
   # Uncomment and create a Caddyfile to enable
   # caddy:

--- a/docs/decisions/0020-nuc-scheduler-choice.md
+++ b/docs/decisions/0020-nuc-scheduler-choice.md
@@ -1,0 +1,80 @@
+# 0020. NUC スケジューラ方式選定 — node-cron + 専用コンテナ
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | accepted |
+| 日付 | 2026-04-24 |
+| 起票者 | 開発チーム |
+| 関連 Issue | #1375, #1374 |
+
+## コンテキスト
+
+NUC Docker 環境で `/api/cron/license-expire` / `/api/cron/retention-cleanup` / `/api/cron/trial-notifications` を定期実行する仕組みが存在しない。
+既存の `backup` サービスは crond で日次バックアップを行うが、設計上 cron ジョブ汎用化は想定されていない。
+
+要件:
+- 既存 `src/lib/server/cron/schedule-registry.ts`（新設 SSOT）を参照できること
+- docker-compose 内で完結（ホスト OS 依存なし）
+- スケジュール定義は TypeScript で型安全に管理
+- `docker compose --profile scheduler up` で opt-in 起動
+- 通常 `npm run dev` では scheduler 不起動
+
+## 検討した選択肢（OSS / 確立パターン最低 2 件必須 — #1350）
+
+### 選択肢 A: crond（Alpine 標準）
+
+- 概要: Docker コンテナ内で Alpine の crond を使い、static な crontab で endpoint を curl する
+- 採用実績: 既存 `backup` サービスで採用済み
+- メリット: 既存パターン踏襲・学習コスト 0・追加 npm パッケージ不要
+- デメリット: `schedule-registry.ts` との二重管理（crontab + TypeScript の 2 箇所を更新）・SSOT 違反
+- Pre-PMF コスト: 低（curl のみ追加）。ただし crontab 更新漏れリスクが残る
+
+### 選択肢 B: node-cron（採用）
+
+- 概要: `node-cron` npm パッケージで cron 式を Node.js プロセス内で解釈し、schedule-registry.ts を直接 import
+- npm: [node-cron](https://www.npmjs.com/package/node-cron)（週 1 億 DL 超・MIT）
+- 採用実績: Express/NestJS 等の Node サーバで広く使われる定番ライブラリ
+- メリット: schedule-registry.ts を SSOT として直接参照可能・TypeScript 統一・型安全なスケジュール定義
+- デメリット: Node.js プロセスの常駐が必要
+- Pre-PMF コスト: 低（node-cron 150KB 未満・tsx は既存 devDep）
+
+### 選択肢 C: bree（Worker Thread ベース）
+
+- 概要: Worker Thread で各ジョブを独立実行する高機能スケジューラ
+- npm: [bree](https://www.npmjs.com/package/bree)（Cabin.js チーム）
+- メリット: retry / timeout 組込・ジョブ独立実行でクラッシュ分離
+- デメリット: Pre-PMF にはオーバースペック（3 エンドポイントの HTTP POST に retry/worker は不要）
+- Pre-PMF コスト: 中（学習コスト + ジョブファイル分割構造が必要）
+
+### 選択肢 D: systemd-timer（ホスト OS）
+
+- 概要: NUC の systemd で timer unit を定義し、docker 外から curl
+- メリット: OS native・コンテナ外のログ管理が容易
+- デメリット: docker-compose 内で完結しない・NUC セットアップ手順が複雑化・git 管理外になる
+- Pre-PMF コスト: 高（NUC セットアップドキュメント + timer unit ファイル管理）
+
+## 決定
+
+**選択肢 B（node-cron + 専用コンテナ）** を採用する。
+
+理由:
+1. `schedule-registry.ts` を SSOT として直接 import でき、二重管理が不要
+2. TypeScript で schedule 定義が型安全（`CronJob` 型）
+3. docker-compose `profiles: scheduler` で opt-in、通常開発に影響なし
+4. Pre-PMF フェーズで必要十分（選択肢 C/D は過剰）
+5. `tsx` が既存 devDependencies に存在し、追加インストールが最小
+
+## 結果
+
+- `src/lib/server/cron/schedule-registry.ts` を新設（SSOT）
+- `scripts/scheduler.ts` を専用コンテナのエントリポイントとして新設
+- `Dockerfile.scheduler` を新設（node:22-alpine + tsx + node-cron）
+- `docker-compose.yml` に `scheduler` サービスを `profiles: scheduler` で追加
+- `CRON_SECRET` を NUC 本番 env として `infra/CLAUDE.md` に追記
+- 各 cron endpoint への POST は `x-cron-secret` + `Authorization: Bearer` 両ヘッダを付与（既存 endpoint の auth パターン差異を吸収）
+
+## 制約
+
+- scheduler コンテナはDB に直接アクセスしない（HTTP POST 経由のみ）
+- crontab を schedule-registry.ts と別に管理しない（SSOT 原則）
+- NUC 本番での `profiles: scheduler` 有効化は `deploy-nuc.yml` の `docker compose up` コマンド修正で行う（本 ADR では scheduler コンテナ定義まで、deploy 組込は Sub A-3 #1377 のスコープ）

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -20,7 +20,7 @@ production に新しい env を追加した場合は以下 **4 経路すべて**
 | `STRIPE_SECRET_KEY` | Stripe 課金 | 未設定可 | 未設定可 | 本番値必須 | （NUC は Stripe 無効） | Stripe Dashboard |
 | `STRIPE_WEBHOOK_SECRET` | Stripe webhook 検証 | 未設定可 | 未設定可 | 本番値必須 | （NUC は Stripe 無効） | Stripe Dashboard |
 | `GEMINI_API_KEY` | Gemini API (任意) | 未設定可 | 未設定可 | 任意 | 任意 | https://aistudio.google.com/ |
-| `CRON_SECRET` | `/api/cron/retention-cleanup` Bearer（#820 / ADR-0033（archive）） | 未設定可 | 未設定可 | **本番値必須** | （NUC は cron 無効） | `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"` |
+| `CRON_SECRET` | `/api/cron/*` 認証トークン（#820 / ADR-0033（archive） / #1375 NUC scheduler） | 未設定可 | 未設定可 | **本番値必須** | **本番値必須**（scheduler コンテナで使用） | `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"` |
 | `OPS_SECRET_KEY` | (deprecated) `CRON_SECRET` 後方互換フォールバック（ADR-0033（archive）、PR-D-2 で削除予定） | 未設定可 | 未設定可 | 任意（新規は `CRON_SECRET` 推奨） | （NUC は無効） | 既存値を維持 |
 
 > **重要**: #3 と #4 は **同一値** を使うこと（両環境で署名したライセンスキーが相互に検証できるように）。GitHub Secrets に登録した同一値が、CDK context 経由で Lambda env に注入されると同時に、self-hosted runner 経由で NUC の `.env` にも書き出される。
@@ -114,3 +114,30 @@ ssh <NUC_USER>@<NUC_HOST> "cd <NUC_APP_DIR> && git pull && docker compose build 
 # 4. 動作確認
 ssh <NUC_USER>@<NUC_HOST> "curl -s http://localhost:3000/api/health"
 ```
+
+### NUC Scheduler コンテナ起動手順（#1375 — ADR-0020）
+
+cron ジョブ（license-expire / retention-cleanup / trial-notifications）を NUC で実行するには
+`profiles: scheduler` を有効化して起動する。
+
+```bash
+# 前提: CRON_SECRET が .env に設定されていること
+# （deploy-nuc.yml の Generate .env ステップで自動設定される）
+
+# scheduler コンテナを含めて起動
+docker compose --profile scheduler up -d
+
+# scheduler ログ確認
+docker compose logs -f scheduler
+
+# 手動で特定 cron ジョブをテスト実行（dryRun: true）
+curl -s -X POST http://localhost:3000/api/cron/retention-cleanup \
+  -H "x-cron-secret: <CRON_SECRET>" \
+  -H "Content-Type: application/json" \
+  -d '{"dryRun": true}'
+```
+
+**注意**:
+- `docker compose up -d` のみ（profiles なし）では scheduler は起動しない。`--profile scheduler` が必須
+- Sub A-3 (#1377) の実装前は、`deploy-nuc.yml` への `--profile scheduler` 組込は行わない（手動有効化）
+- scheduler コンテナは `app` コンテナに依存（`depends_on: app`）。app が起動していること確認後に起動すること

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"drizzle-orm": "^0.45.2",
 				"fflate": "^0.8.2",
 				"jose": "^6.2.2",
+				"node-cron": "^4.2.1",
 				"qrcode": "^1.5.4",
 				"stripe": "^22.0.2",
 				"web-push": "^3.6.7",
@@ -13086,6 +13087,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^18 || ^20 || >= 21"
+			}
+		},
+		"node_modules/node-cron": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+			"integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/node-domexception": {

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
 		"drizzle-orm": "^0.45.2",
 		"fflate": "^0.8.2",
 		"jose": "^6.2.2",
+		"node-cron": "^4.2.1",
 		"qrcode": "^1.5.4",
 		"stripe": "^22.0.2",
 		"web-push": "^3.6.7",

--- a/scripts/scheduler.ts
+++ b/scripts/scheduler.ts
@@ -1,0 +1,65 @@
+// scripts/scheduler.ts
+// #1375: NUC scheduler コンテナのエントリポイント
+//
+// docker compose --profile scheduler up で起動する専用コンテナから実行される。
+// schedule-registry.ts を SSOT として参照し、node-cron で定期的に
+// /api/cron/* エンドポイントへ HTTP POST する。
+//
+// 環境変数:
+//   CRON_SECRET  — cron 認証トークン（必須）
+//   APP_URL      — SvelteKit アプリの URL（デフォルト: http://app:3000）
+//
+// 注意: DB への直接アクセス禁止。HTTP POST 経由のみ。
+
+import cron from 'node-cron';
+import { scheduleRegistry } from '../src/lib/server/cron/schedule-registry.js';
+
+const APP_URL = process.env.APP_URL ?? 'http://app:3000';
+const CRON_SECRET = process.env.CRON_SECRET ?? '';
+
+if (!CRON_SECRET) {
+	console.error('[scheduler] CRON_SECRET is not set. Exiting.');
+	process.exit(1);
+}
+
+async function callEndpoint(job: { name: string; endpoint: string }): Promise<void> {
+	const url = `${APP_URL}${job.endpoint}`;
+	const startedAt = new Date().toISOString();
+	try {
+		const res = await fetch(url, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				// license-expire は Authorization: Bearer を使用。
+				// retention-cleanup / trial-notifications は x-cron-secret を使用。
+				// 両ヘッダを送ることで既存 endpoint の auth パターン差異を吸収する。
+				Authorization: `Bearer ${CRON_SECRET}`,
+				'x-cron-secret': CRON_SECRET,
+			},
+		});
+		if (res.ok) {
+			console.log(`[scheduler] ${startedAt} ${job.name}: OK (${res.status})`);
+		} else {
+			const body = await res.text().catch(() => '');
+			console.error(`[scheduler] ${startedAt} ${job.name}: FAILED (${res.status}) ${body}`);
+		}
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.error(`[scheduler] ${startedAt} ${job.name}: ERROR ${message}`);
+	}
+}
+
+for (const job of scheduleRegistry) {
+	cron.schedule(
+		job.cronExpression,
+		() => {
+			void callEndpoint(job);
+		},
+		{ timezone: 'Asia/Tokyo' },
+	);
+	console.log(
+		`[scheduler] registered: ${job.name} (${job.cronExpression} JST) → ${APP_URL}${job.endpoint}`,
+	);
+}
+
+console.log(`[scheduler] started. APP_URL=${APP_URL}, jobs=${scheduleRegistry.length}`);

--- a/src/lib/server/cron/schedule-registry.ts
+++ b/src/lib/server/cron/schedule-registry.ts
@@ -1,0 +1,45 @@
+// src/lib/server/cron/schedule-registry.ts
+// #1375: cron ジョブ定義の SSOT
+//
+// NUC scheduler コンテナ (scripts/scheduler.ts) と AWS EventBridge (#1376) の
+// 両方がここを参照することで、スケジュール定義の二重管理を防ぐ。
+//
+// cronExpression は Asia/Tokyo タイムゾーンで解釈される（コンテナ TZ=Asia/Tokyo）。
+// AWS EventBridge は UTC 固定のため、Sub A-2 (#1376) 実装時に utcExpression も参照すること。
+
+export interface CronJob {
+	/** ジョブ識別名（ログ・監視用） */
+	name: string;
+	/** 呼び出す SvelteKit cron エンドポイントのパス */
+	endpoint: string;
+	/** cron 式（Asia/Tokyo）*/
+	cronExpression: string;
+	/** AWS EventBridge 用 UTC cron 式（"cron(分 時 日 月 ? 年)" 形式）*/
+	utcCronExpression: string;
+	/** 概要説明 */
+	description: string;
+}
+
+export const scheduleRegistry: CronJob[] = [
+	{
+		name: 'license-expire',
+		endpoint: '/api/cron/license-expire',
+		cronExpression: '0 0 * * *', // 毎日 00:00 JST
+		utcCronExpression: 'cron(0 15 * * ? *)', // 毎日 15:00 UTC = 翌日 00:00 JST
+		description: 'ライセンスキー期限切れ自動失効バッチ (#821)',
+	},
+	{
+		name: 'retention-cleanup',
+		endpoint: '/api/cron/retention-cleanup',
+		cronExpression: '0 1 * * *', // 毎日 01:00 JST
+		utcCronExpression: 'cron(0 16 * * ? *)', // 毎日 16:00 UTC = 翌日 01:00 JST
+		description: '保存期間超過データの自動削除バッチ (#717, #729)',
+	},
+	{
+		name: 'trial-notifications',
+		endpoint: '/api/cron/trial-notifications',
+		cronExpression: '0 9 * * *', // 毎日 09:00 JST
+		utcCronExpression: 'cron(0 0 * * ? *)', // 毎日 00:00 UTC = 09:00 JST
+		description: 'トライアル終了通知バッチ (#737)',
+	},
+];


### PR DESCRIPTION
## 概要

closes #1375

NUC ローカルサーバーで cron ジョブを実行するための専用 scheduler コンテナを追加する。
`docker compose --profile scheduler up` でオプトイン起動できる設計（既存の `backup` プロファイルと同パターン）。

## 変更内容

### ADR-0020 (docs/decisions/0020-nuc-scheduler-choice.md)
4 方式を比較し node-cron を採用:
- A: crond（Alpine 組み込み）— TypeScript SSOT 困難
- B: **node-cron v4（採用）** — TypeScript 直書き、tsx 既存 devDeps、Pre-PMF 規模に適切
- C: bree — Worker Threads 機能過剰
- D: systemd-timer — ホスト依存でコンテナ外に出る

### schedule-registry.ts (src/lib/server/cron/schedule-registry.ts)
全 cron ジョブ定義の SSOT。3 ジョブを登録:
| name | endpoint | cronExpression (JST) | 説明 |
|------|----------|---------------------|------|
| license-expire | /api/cron/license-expire | 0 0 * * * | 毎日 00:00 (#821) |
| retention-cleanup | /api/cron/retention-cleanup | 0 1 * * * | 毎日 01:00 (#717, #729) |
| trial-notifications | /api/cron/trial-notifications | 0 9 * * * | 毎日 09:00 (#737) |

`utcCronExpression` フィールドも持ち、Sub A-2 (#1376) の AWS EventBridge 統合時に利用。

### scheduler.ts (scripts/scheduler.ts)
- CRON_SECRET 未設定時は即 exit(1)
- 両 auth ヘッダ（Authorization: Bearer + x-cron-secret）を送信してエンドポイントの auth パターン差異を吸収
- timezone: 'Asia/Tokyo' で JST 基準動作

### Dockerfile.scheduler
2 ステージ Alpine ビルド。tsx（devDeps に既存）で TypeScript を直接実行。

### docker-compose.yml
```yaml
scheduler:
  build:
    context: .
    dockerfile: Dockerfile.scheduler
  environment:
    - APP_URL=http://app:3000
    - TZ=Asia/Tokyo
  env_file:
    - path: .env
      required: false
  depends_on:
    - app
  restart: unless-stopped
  profiles:
    - scheduler
```

## テスト

```bash
# CRON_SECRET なしで exit(1) することを確認
npx tsx scripts/scheduler.ts
# → [scheduler] CRON_SECRET is not set. Exiting.

# 3 ジョブが登録されることを確認
CRON_SECRET=test123 APP_URL=http://localhost:9999 npx tsx scripts/scheduler.ts
# → [scheduler] registered: license-expire (0 0 * * * JST) ...
# → [scheduler] registered: retention-cleanup (0 1 * * * JST) ...
# → [scheduler] registered: trial-notifications (0 9 * * * JST) ...
# → [scheduler] started. APP_URL=http://localhost:9999, jobs=3

# ユニットテスト全通過
npx vitest run  # 3798 tests passed
npx biome check .  # clean
```

## 手動テスト（手順: infra/CLAUDE.md 参照）

```bash
# CRON_SECRET が .env に設定されている前提
docker compose --profile scheduler up -d
docker compose logs -f scheduler

# 手動で cron エンドポイント疎通確認
curl -s -X POST http://localhost:3000/api/cron/retention-cleanup \
  -H "x-cron-secret: <CRON_SECRET>" \
  -H "Content-Type: application/json" \
  -d '{"dryRun": true}'
```

## 注意事項

- Sub A-3 (#1377) の実装前は `deploy-nuc.yml` への `--profile scheduler` 自動組込は行わない（手動有効化）
- `CRON_SECRET` は既存の GitHub Secrets に登録済み（infra/CLAUDE.md 参照）