### PR TITLE
docs: #1312 ゲーミフィケーション設計書・プライシング戦略書「スタンプガチャ」→「ログインおみくじスタンプ」改称 + ADR-0013 附則

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,8 @@ vitest --coverage（カバレッジ閾値）, playwright（E2E）, ESLint（svel
 - **スクリーンショットは CI を通すためではなく UI/UX デザイナー視点の自己判定証跡**として貼る（#1026）→ PR 本文に `![...](...)` さえあれば screenshot-check は通るが、それは目的ではない。撮った画像を自分で見て違和感があれば修正すること。PR template の「スクリーンショット / ビジュアルデモ」セクション冒頭の目的説明に従うこと
 - jscpd を PR の hard-fail に昇格させない（別 ADR なしには）（#971）→ jscpd は週次レポートとして T3 階層で運用。PR ゲートに含めると開発体験が悪化する
 - **OSS / 確立パターンを見もしないまま独自実装を始めない（#1350）** → 独自実装が 10 行超えそうなら先に npm / GitHub で既存 OSS / 確立パターンを 2 件以上探す。見つかれば Issue / ADR に比較を書き加え選定理由を残す。ADR テンプレ「検討した選択肢」節と Issue テンプレ「OSS / 確立パターン調査結果」節が空のまま起票・起案しない。半完成機構の放置（#1346 / #566 / #1126 / #1150）を繰り返さない
+- **LP・設計書に「ガチャ」「抽選」「コンプリート」等のギャンブル語彙を書かない（#1312/#1313）** → `scripts/measure-lp-dimensions.mjs` の `FORBIDDEN_TERMS` に追加済みで CI が自動拒否。ゲーミフィケーション要素を説明する際は「おみくじ」「ランダム報酬」等の代替語を使うこと。LP や `site/index.html` の文言を変更する前に `FORBIDDEN_TERMS` リストを確認すること
+- **LP・プライシング設計書に未実装機能を「実装済み」として書かない（ADR-0013、#1312）** → `docs/decisions/0013-lp-truth-from-implementation.md` の Committed/Aspirational 区分を確認し、実装パスが存在しない機能は LP に記載禁止。`docs/design/19-プライシング戦略書.md` の附則「Committed / Aspirational 機能区分」を参照すること
 
 ## Critical バグ修正の必須要件（ADR-0005）
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -410,6 +410,7 @@ UI に表示されるラベル・用語は `src/lib/domain/labels.ts` を Single
 5. 画像が必要かは §7 の判断基準に従う
 6. 年齢モードの差異は §8 を参照
 7. §9 の禁忌事項に違反しない
+8. **LP / pricing ページ文言を書く前に ADR-0013 の committed/aspirational 区別を確認する**（`docs/design/19-プライシング戦略書.md` 附則参照）。Aspirational は LP に記載しない
 
 ---
 

--- a/docs/design/19-プライシング戦略書.md
+++ b/docs/design/19-プライシング戦略書.md
@@ -87,7 +87,7 @@
 |  | 活動アイコンの変更 | - | o | o |
 |  | 活動の非表示/削除 | - | o | o |
 | **冒険の仕組み** | XP・レベルアップ | o | o | o |
-|  | シールガチャ | o | o | o |
+|  | ログインおみくじスタンプ | o | o | o |
 |  | ログインボーナス | o | o | o |
 |  | コンボボーナス | o | o | o |
 |  | イベント参加 | o | o | o |
@@ -598,6 +598,34 @@ stripe promotion_codes create \
 
 ---
 
+---
+
+## 附則: Committed / Aspirational 分類（ADR-0013 準拠）
+
+> **AI エージェント・LP 担当者へ**: LP / pricing ページに記載できるのは **Committed** のみ。  
+> Aspirational は内部文書限定。LP 文言の根拠が Aspirational に由来する場合は記載禁止（ADR-0013）。
+
+### Committed（実装済み — LP 記載可）
+
+| 機能 | 実装コードパス | 備考 |
+|------|-------------|------|
+| ポイント・レベルアップ | `src/lib/server/services/xp-service.ts` | |
+| ログインおみくじスタンプ（日 1 回） | `src/lib/server/services/stamp-card-service.ts::stampToday` | 旧称「シールガチャ」— #1313 で呼称統一 |
+| コンボボーナス | `src/lib/server/services/xp-service.ts` | |
+| ごほうびショップ | `src/routes/(child)/[uiMode=uiMode]/home/` | |
+| チェックリスト（持ち物・習慣） | `src/lib/server/services/checklist-service.ts` | |
+| データエクスポート（JSON） | `src/routes/(parent)/admin/export/` | |
+| 週次メールレポート | `src/lib/server/services/report-service.ts` | |
+
+### Aspirational（未実装・将来候補 — LP 記載禁止）
+
+| 機能 | 実装状態 | 候補理由 |
+|------|---------|---------|
+| ファミリーダイジェスト共有 | 未実装 | きょうだい間の連帯感訴求 |
+| AI 活動自動提案（Family プラン） | 未実装 | Gemini API 活用予定 |
+
+---
+
 ## 改訂履歴
 
 | 版数 | 日付 | 変更内容 |
@@ -605,3 +633,4 @@ stripe promotion_codes create \
 | 1.0 | 2026-04-01 | 初版作成。3ティアプラン確定、機能制限マトリクス、損益分岐点分析 |
 | 1.1 | 2026-04-11 | #808 §7A ライセンスキー運用 章追加。license-key-lifecycle.md への SSOT ポインタ設置 |
 | 1.2 | 2026-04-16 | #802/#803 §8 キャンペーン運用 章追加。Ops キャンペーンキー vs Stripe 100% OFF の使い分け・手順・監査手順 |
+| 1.3 | 2026-04-24 | #1312 「シールガチャ」→「ログインおみくじスタンプ」改称。ADR-0013 準拠の Committed/Aspirational 附則追加 |

--- a/docs/design/26-ゲーミフィケーション設計書.md
+++ b/docs/design/26-ゲーミフィケーション設計書.md
@@ -135,7 +135,17 @@ function calculateLevel(totalPoints: number): number
 活動記録のたびにスタンプ（シール）を1枚獲得し、カードに貼る。
 カードが完成すると新しいカードが発行される。
 
-### 5.2 スタンプガチャ
+### 5.2 ログインおみくじスタンプ（L2 メタ習慣層）
+
+**ADR-0012 Anti-engagement 原則 / ADR-0013 LP truth 準拠**: ログイン連動の 1 日 1 回おみくじ。  
+「ガチャ」という呼称は射幸性連想があるため廃止し、**ログインおみくじスタンプ** に統一する（#1311, #1313）。
+
+#### 仕組み
+
+- ログイン（日 1 回 cap）で `loginStamp` action が呼ばれ、ランダムにレアリティ・スタンプが選択される
+- Variable-ratio reinforcement によって **飽きにくく**、有料アプリ形骸化への打ち手として機能する（L2 メタ習慣層）
+- 1 回の interaction は数秒で完了（Anti-engagement 原則を遵守）
+- 実装: `src/lib/server/services/stamp-card-service.ts` → `stampToday()` (日 1 回 cap: `ALREADY_STAMPED` error)
 
 | レアリティ | 出現率 | シール枠の色 |
 |-----------|--------|------------|
@@ -145,8 +155,9 @@ function calculateLevel(totalPoints: number): number
 | UR (Ultra Rare) | 3% | ホログラム |
 
 ```typescript
-// src/lib/domain/stamp-gacha.ts
-function rollStampGacha(): { stampId: number; rarity: Rarity }
+// src/lib/server/services/stamp-card-service.ts
+// loginStamp action から呼ばれる (1 日 1 回 cap)
+async function stampToday(tenantId, childId): Promise<StampResult | 'ALREADY_STAMPED'>
 ```
 
 ### 5.3 スタンプカード仕様


### PR DESCRIPTION
## 概要

Issue #1312 — ゲーミフィケーション設計書・プライシング戦略書から「スタンプガチャ」語彙を除去し、正式名称「ログインおみくじスタンプ」に統一。ADR-0013（LP 実装由来真実）準拠の Committed/Aspirational 附則を追加。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `docs/design/26-ゲーミフィケーション設計書.md` | §5.2 タイトル改称、stampToday() 実装パス記載、変動比率強化スケジュール説明追加 |
| `docs/design/19-プライシング戦略書.md` | 機能比較表改称、Committed/Aspirational 機能区分附則追加（v1.3） |
| `docs/DESIGN.md` | §10 AI エージェント向け指示に ADR-0013 LP 文言チェック項目追加 |
| `CLAUDE.md` | Things Not To Do にギャンブル語彙禁止・ADR-0013 確認ルール追加 |

## Acceptance Criteria 確認

- [x] (a) `26-ゲーミフィケーション設計書.md` §5.2 が「ログインおみくじスタンプ」に改称
- [x] (b) `19-プライシング戦略書.md` 機能比較表が改称
- [x] (c) 実装パス（`stampToday()`）が設計書に明記
- [x] (d) ADR-0013 Committed/Aspirational 附則が追加済み
- [x] (e) `CLAUDE.md` Things Not To Do にギャンブル語彙禁止・ADR-0013 確認ルール追加

## 関連 PR

- Issue #1313 の `measure-lp-dimensions.mjs` 禁止語追加（`ガチャ`/`抽選`/`コンプリート`）と連動

Closes #1312