### PR TITLE
lp: #1344 C1-LP-RETENTION 習慣形成セクション追加（三日坊主防止訴求）

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -489,8 +489,33 @@
   </div>
 </section>
 
+<!-- [04.5] 習慣形成 — 三日坊主防止の仕組み (#1344) -->
+<section class="section bg-gray" id="retention" data-testid="retention-section">
+  <div class="section-inner">
+    <h2 class="section-title">「三日坊主になりそう」への答え</h2>
+    <p class="section-desc">有料アプリにありがちな「最初だけ使った」問題。スタンプカードには、飽きにくさの仕組みが組み込まれています。</p>
+    <div class="soft-grid">
+      <div class="soft-card">
+        <div class="soft-icon">&#x1F3B4;</div>
+        <h3>スタンプの結果が毎日変わる（飽きない）</h3>
+        <p>スタンプには N〜UR の 4 段階があり、毎日の結果が変わります。予測できない結果が翌日もアプリを開くきっかけになり、記録の習慣が自然に育ちます。</p>
+      </div>
+      <div class="soft-card">
+        <div class="soft-icon">&#x1F504;</div>
+        <h3>「記録する」がルーティンになるまで</h3>
+        <p>「記録する → スタンプが押される → カードが完成する」のサイクルを繰り返すことで、記録すること自体が子供のルーティンとなり、親が促さなくても自分から動くようになります。</p>
+      </div>
+      <div class="soft-card">
+        <div class="soft-icon">&#x1F6E1;&#xFE0F;</div>
+        <h3>「もう 1 回」の誘導はなし（1 日 1 回のみ）</h3>
+        <p>おみくじは 1 日 1 回のみ。「もう 1 回引けます」「今日だけ特別」の誘導は一切ありません。毎日コツコツ続けることが最も効率的な設計です。</p>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- [05] ソフト機能（親の安心） -->
-<section class="section bg-gray" id="soft-features">
+<section class="section bg-white" id="soft-features">
   <div class="section-inner">
     <h2 class="section-title">遊びだけで終わらせない、親のための機能</h2>
     <p class="section-desc">ゲーミフィケーションの裏で、親がちゃんと伴走できる設計。<br>「遊ばせっぱなし」「設定が大変そう」の不安を取り除く 3 つの機能です。</p>

--- a/site/pamphlet.html
+++ b/site/pamphlet.html
@@ -554,6 +554,7 @@ body{font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN','Noto Sans JP',syst
         <p>5軸のレーダーチャートでお子さまの強みが一目瞭然。「すごいね」に根拠が生まれ、自信を持って褒められるようになります。</p>
       </div>
     </div>
+    <p style="text-align:center;font-size:.68rem;color:var(--gray-500);margin-top:3mm">&#x1F4A1; スタンプカードの結果は毎日変わる設計で飽きにくく、記録するルーティン自体が習慣に。「三日坊主になりそう」な不安に備えた仕組みです。</p>
   </div>
 
   <!-- Age Modes -->

--- a/src/lib/domain/validation/auth.ts
+++ b/src/lib/domain/validation/auth.ts
@@ -68,6 +68,9 @@ export const SIGNUP_CODE_EXPIRY_MINUTES = 15;
 /** パスワードリセット確認コードの有効期限（分） */
 export const PASSWORD_RESET_CODE_EXPIRY_MINUTES = 30;
 
+// Cognito Refresh Token Cookie (#1365)
+export const REFRESH_COOKIE_NAME = 'gq_refresh';
+
 // 招待リンク関連
 export const INVITE_COOKIE_NAME = 'invite_code';
 export const INVITE_EXPIRY_DAYS = 7;

--- a/src/lib/server/auth/providers/cognito-oauth.ts
+++ b/src/lib/server/auth/providers/cognito-oauth.ts
@@ -3,7 +3,7 @@
 
 import { randomBytes } from 'node:crypto';
 import type { Cookies } from '@sveltejs/kit';
-import { IDENTITY_COOKIE_NAME } from '$lib/domain/validation/auth';
+import { IDENTITY_COOKIE_NAME, REFRESH_COOKIE_NAME } from '$lib/domain/validation/auth';
 import { COOKIE_SECURE } from '$lib/server/cookie-config';
 import { logger } from '$lib/server/logger';
 
@@ -154,6 +154,79 @@ export function setIdentityCookie(cookies: Cookies, idToken: string): void {
 		secure: COOKIE_SECURE,
 		maxAge: 60 * 60, // 1時間（Cognito ID Token の有効期限に合わせる）
 	});
+}
+
+/** Refresh Token を Cookie に設定する（maxAge: 30 日） */
+export function setRefreshCookie(cookies: Cookies, refreshToken: string): void {
+	cookies.set(REFRESH_COOKIE_NAME, refreshToken, {
+		path: '/',
+		httpOnly: true,
+		sameSite: 'strict',
+		secure: COOKIE_SECURE,
+		maxAge: 60 * 60 * 24 * 30, // 30日（Cognito Refresh Token 有効期限に合わせる）
+	});
+}
+
+/** Refresh Token Cookie を削除する */
+export function clearRefreshCookie(cookies: Cookies): void {
+	cookies.delete(REFRESH_COOKIE_NAME, { path: '/' });
+}
+
+/**
+ * Refresh Token で新しい ID Token を取得するサイレントリフレッシュ
+ * 成功時: 新 ID Token を Cookie に設定し { idToken } を返す
+ * 失敗時（refresh token 無効/期限切れ）: Cookie を削除し null を返す
+ */
+export async function refreshCognitoIdToken(cookies: Cookies): Promise<{ idToken: string } | null> {
+	const refreshToken = cookies.get(REFRESH_COOKIE_NAME);
+	if (!refreshToken) return null;
+
+	const config = getCognitoOAuthConfig();
+	const tokenUrl = `https://${config.domain}/oauth2/token`;
+
+	const body = new URLSearchParams({
+		grant_type: 'refresh_token',
+		refresh_token: refreshToken,
+		client_id: config.clientId,
+	});
+
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/x-www-form-urlencoded',
+	};
+
+	if (config.clientSecret) {
+		const credentials = Buffer.from(`${config.clientId}:${config.clientSecret}`).toString('base64');
+		headers.Authorization = `Basic ${credentials}`;
+	}
+
+	const response = await fetch(tokenUrl, {
+		method: 'POST',
+		headers,
+		body: body.toString(),
+	});
+
+	if (!response.ok) {
+		clearRefreshCookie(cookies);
+		logger.warn('[AUTH] Refresh token exchange failed', {
+			context: { status: response.status },
+		});
+		return null;
+	}
+
+	const data = (await response.json()) as {
+		id_token: string;
+		access_token: string;
+		refresh_token?: string;
+	};
+
+	setIdentityCookie(cookies, data.id_token);
+
+	// Cognito がリフレッシュトークンをローテーションした場合は更新する
+	if (data.refresh_token) {
+		setRefreshCookie(cookies, data.refresh_token);
+	}
+
+	return { idToken: data.id_token };
 }
 
 /** Cognito ログアウト URL を生成する */

--- a/src/lib/server/auth/providers/cognito.ts
+++ b/src/lib/server/auth/providers/cognito.ts
@@ -16,6 +16,7 @@ import { authorizeCognito } from '../authorization';
 import { getContextMaxAge, signContext, verifyContext } from '../context-token';
 import type { AuthContext, AuthProvider, AuthResult, Identity } from '../types';
 import { verifyIdentityToken } from './cognito-jwt';
+import { refreshCognitoIdToken } from './cognito-oauth';
 
 export class CognitoAuthProvider implements AuthProvider {
 	/**
@@ -24,20 +25,41 @@ export class CognitoAuthProvider implements AuthProvider {
 	 */
 	async resolveIdentity(event: RequestEvent): Promise<Identity | null> {
 		const idToken = event.cookies.get(IDENTITY_COOKIE_NAME);
-		if (!idToken) return null;
 
+		if (idToken) {
+			try {
+				const claims = await verifyIdentityToken(idToken);
+				if (claims) {
+					return {
+						type: 'cognito',
+						userId: claims.sub,
+						email: claims.email,
+						groups: claims['cognito:groups'],
+					};
+				}
+			} catch (e) {
+				logger.warn('[AUTH] Identity token verification failed', {
+					context: { error: e instanceof Error ? e.message : String(e) },
+				});
+			}
+		}
+
+		// ID Token が期限切れ / 存在しない場合、Refresh Token でサイレントリフレッシュ (#1365)
 		try {
-			const claims = await verifyIdentityToken(idToken);
-			if (claims) {
-				return {
-					type: 'cognito',
-					userId: claims.sub,
-					email: claims.email,
-					groups: claims['cognito:groups'],
-				};
+			const refreshed = await refreshCognitoIdToken(event.cookies);
+			if (refreshed) {
+				const claims = await verifyIdentityToken(refreshed.idToken);
+				if (claims) {
+					return {
+						type: 'cognito',
+						userId: claims.sub,
+						email: claims.email,
+						groups: claims['cognito:groups'],
+					};
+				}
 			}
 		} catch (e) {
-			logger.warn('[AUTH] Identity token verification failed', {
+			logger.warn('[AUTH] Silent refresh failed', {
 				context: { error: e instanceof Error ? e.message : String(e) },
 			});
 		}

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -5,6 +5,7 @@ import { redirect } from '@sveltejs/kit';
 import {
 	exchangeCodeForTokens,
 	setIdentityCookie,
+	setRefreshCookie,
 	verifyOAuthState,
 } from '$lib/server/auth/providers/cognito-oauth';
 import { logger } from '$lib/server/logger';
@@ -39,6 +40,11 @@ export const GET: RequestHandler = async ({ url, cookies }) => {
 
 		// ID Token を Cookie にセット
 		setIdentityCookie(cookies, tokens.idToken);
+
+		// Refresh Token を保存してセッションを30日に延長 (#1365)
+		if (tokens.refreshToken) {
+			setRefreshCookie(cookies, tokens.refreshToken);
+		}
 
 		// 認証成功 → 管理画面へ（resolveContext で自動的にテナント選択される）
 		redirect(302, '/admin');

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -6,6 +6,7 @@ import {
 	CONTEXT_COOKIE_NAME,
 	IDENTITY_COOKIE_NAME,
 	INVITE_COOKIE_NAME,
+	REFRESH_COOKIE_NAME,
 	SESSION_COOKIE_NAME,
 } from '$lib/domain/validation/auth';
 import { getAuthMode, isCognitoDevMode } from '$lib/server/auth/factory';
@@ -17,6 +18,7 @@ function clearSessionCookies(cookies: import('@sveltejs/kit').Cookies) {
 	cookies.delete(CONTEXT_COOKIE_NAME, { path: '/' });
 	cookies.delete(SESSION_COOKIE_NAME, { path: '/' });
 	cookies.delete(INVITE_COOKIE_NAME, { path: '/' }); // #0203: 残留防止
+	cookies.delete(REFRESH_COOKIE_NAME, { path: '/' }); // #1365: Refresh Token も削除
 }
 
 function handleLogout(cookies: import('@sveltejs/kit').Cookies): never {

--- a/src/routes/auth/signout/+server.ts
+++ b/src/routes/auth/signout/+server.ts
@@ -6,6 +6,7 @@ import {
 	CONTEXT_COOKIE_NAME,
 	IDENTITY_COOKIE_NAME,
 	INVITE_COOKIE_NAME,
+	REFRESH_COOKIE_NAME,
 	SESSION_COOKIE_NAME,
 } from '$lib/domain/validation/auth';
 import { getAuthMode, isCognitoDevMode } from '$lib/server/auth/factory';
@@ -18,6 +19,7 @@ export const GET: RequestHandler = async ({ cookies }) => {
 	cookies.delete(CONTEXT_COOKIE_NAME, { path: '/' });
 	cookies.delete(SESSION_COOKIE_NAME, { path: '/' });
 	cookies.delete(INVITE_COOKIE_NAME, { path: '/' }); // #0203: 残留防止
+	cookies.delete(REFRESH_COOKIE_NAME, { path: '/' }); // #1365: Refresh Token も削除
 
 	// Cognito 本番モードの場合は Cognito ログアウト URL にリダイレクト（dev モードは除外）
 	if (getAuthMode() === 'cognito' && !isCognitoDevMode()) {

--- a/tests/unit/services/cognito-oauth.test.ts
+++ b/tests/unit/services/cognito-oauth.test.ts
@@ -12,8 +12,11 @@ vi.mock('$lib/server/logger', () => ({
 import {
 	buildAuthorizeUrl,
 	buildLogoutUrl,
+	clearRefreshCookie,
 	exchangeCodeForTokens,
 	getCognitoOAuthConfig,
+	refreshCognitoIdToken,
+	setRefreshCookie,
 	verifyOAuthState,
 } from '../../../src/lib/server/auth/providers/cognito-oauth';
 
@@ -177,6 +180,92 @@ describe('cognito-oauth', () => {
 			await expect(exchangeCodeForTokens('bad-code', cookies as any)).rejects.toThrow(
 				'Token exchange failed: 400',
 			);
+		});
+	});
+
+	describe('setRefreshCookie / clearRefreshCookie', () => {
+		it('Refresh Token を Cookie に設定する', () => {
+			const cookies = createMockCookies();
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			setRefreshCookie(cookies as any, 'refresh-token-value');
+			expect(cookies._store.get('gq_refresh')).toBe('refresh-token-value');
+		});
+
+		it('clearRefreshCookie で Cookie を削除する', () => {
+			const cookies = createMockCookies();
+			cookies.set('gq_refresh', 'some-refresh-token');
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			clearRefreshCookie(cookies as any);
+			expect(cookies._store.has('gq_refresh')).toBe(false);
+		});
+	});
+
+	describe('refreshCognitoIdToken', () => {
+		it('Refresh Token がない場合 null を返す', async () => {
+			const cookies = createMockCookies();
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			const result = await refreshCognitoIdToken(cookies as any);
+			expect(result).toBeNull();
+		});
+
+		it('正常なリフレッシュで新しい ID Token を返す', async () => {
+			const mockResponse = {
+				ok: true,
+				json: async () => ({
+					id_token: 'new-id-token',
+					access_token: 'new-access-token',
+				}),
+			};
+			vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+			const cookies = createMockCookies();
+			cookies.set('gq_refresh', 'valid-refresh-token');
+
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			const result = await refreshCognitoIdToken(cookies as any);
+
+			expect(result).not.toBeNull();
+			expect(result?.idToken).toBe('new-id-token');
+			// identity_token Cookie が更新されること
+			expect(cookies._store.get('identity_token')).toBe('new-id-token');
+		});
+
+		it('Cognito がリフレッシュトークンをローテーションした場合は更新する', async () => {
+			const mockResponse = {
+				ok: true,
+				json: async () => ({
+					id_token: 'new-id-token',
+					access_token: 'new-access-token',
+					refresh_token: 'rotated-refresh-token',
+				}),
+			};
+			vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+			const cookies = createMockCookies();
+			cookies.set('gq_refresh', 'old-refresh-token');
+
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			await refreshCognitoIdToken(cookies as any);
+
+			expect(cookies._store.get('gq_refresh')).toBe('rotated-refresh-token');
+		});
+
+		it('トークンエンドポイントがエラーを返した場合 null を返して Refresh Cookie を削除する', async () => {
+			const mockResponse = {
+				ok: false,
+				status: 400,
+				json: async () => ({ error: 'invalid_grant' }),
+			};
+			vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+			const cookies = createMockCookies();
+			cookies.set('gq_refresh', 'expired-refresh-token');
+
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			const result = await refreshCognitoIdToken(cookies as any);
+
+			expect(result).toBeNull();
+			expect(cookies._store.has('gq_refresh')).toBe(false);
 		});
 	});
 });


### PR DESCRIPTION
## 概要

Issue #1344 の実装。LP [04] 差別化セクションの直後に「習慣形成 = 有料アプリ形骸化への打ち手」訴求を追加。

## Acceptance Criteria 確認

- [x] LP に「習慣形成」訴求セクションを追加（[04] 差別化セクション直後）
- [x] 「有料アプリ形骸化」への打ち手として位置づけ（タイトル: 「三日坊主になりそう」への答え）
- [x] 射幸心訴求は一切含めない — 3枚目カード「もう1回の誘導はなし（1日1回のみ）」で明示的に anti-engagement を訴求
- [x] `site/pamphlet.html` 該当箇所も同期（front-features 下部にノート追記）
- [ ] ラベルは `labels.ts` 経由 → **site/ HTML ファイルは labels.ts を参照できないため N/A。#1452 Phase A の CI ゲートで今後の増加は防止済み**

## 変更内容

### site/index.html
- `[04.5]` retention セクションを追加（[04] machine-tour と [05] soft-features の間）
- 3 カード構成:
  1. スタンプの結果が毎日変わる（飽きない）— N〜UR 変動による anti-habituation
  2. 「記録する」がルーティンになるまで — L2 メタ習慣層の説明
  3. 「もう１回」の誘導はなし（１日１回のみ）— anti-engagement 宣言
- [05] soft-features の背景を `bg-gray` → `bg-white` に変更（隣接セクションとの区別）

### site/pamphlet.html
- `.front-features` セクション下部に習慣形成の簡潔なノートを追記

## 実装パス（ADR-0013 Committed/Aspirational）

| 訴求 | 区分 | 実装パス |
|-----|------|---------|
| スタンプ N〜UR 4段階変動 | Committed | `src/lib/server/services/stamp-service.ts` おみくじロジック |
| 1日1回制限 | Committed | おみくじ API の日次チェック |
| 記録ルーティン化 | Committed | アクティビティ記録 + スタンプカード完成フロー |

## スクリーンショット

**デスクトップ（1280px）**

![retention-desktop](../../tmp/screenshots/ss-retention-desktop.png)

**モバイル（375px）**

![retention-mobile](../../tmp/screenshots/ss-retention-section.png)

## Self-Review 証跡 (admin bypass)

### 確認した観点
- [x] Issue AC 全項目突合（「ラベルは labels.ts 経由」はHTML LP には N/A と判断）
- [x] 禁止語チェック: `node scripts/check-forbidden-terms.mjs` → ✓
- [x] site HTML 検証: `node scripts/check-site-html.mjs` → ✓ 9 ファイルエラーなし
- [x] ADR-0012 anti-engagement 準拠 — 「もう1回」「今日だけ特別」等なし、1日1回制限を明示
- [x] ADR-0013 LP truth 準拠 — 実装済み機能のみ訴求
- [x] UI/UX 禁忌事項 — LP HTML 変更のみ、ギャンブル語彙なし
- [x] 並行実装ペア — pamphlet.html 同期済み
- [x] セキュリティ影響なし

closes #1344