### PR TITLE
docs(#1379): 年齢・誕生日仕様を ゲーミフィケーション設計書 §13 に記載

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -148,7 +148,7 @@ src/lib/server/db/
 | age | INTEGER | NO | - | 年齢 |
 | birth_date | TEXT | YES | NULL | 誕生日（YYYY-MM-DD） |
 | theme | TEXT | NO | 'pink' | テーマ名 |
-| ui_mode | TEXT | NO | 'kinder' | UIモード（baby/kinder/lower/upper/teen） |
+| ui_mode | TEXT | NO | 'preschool' | UIモード（baby/preschool/elementary/junior/senior）。`getDefaultUiMode(age)` で導出 |
 | avatar_url | TEXT | YES | NULL | アバター画像URL |
 | active_title_id | INTEGER | YES | NULL | 装備中の称号ID |
 | display_config | TEXT | YES | NULL | 表示設定（JSON: cardSize, itemsPerCategory, collapsible） |

--- a/docs/design/26-ゲーミフィケーション設計書.md
+++ b/docs/design/26-ゲーミフィケーション設計書.md
@@ -369,18 +369,118 @@ async function stampToday(tenantId, childId): Promise<StampResult | 'ALREADY_STA
 
 ---
 
-## 13. 誕生日機能
+## 13. 年齢・誕生日設計
 
-子供の誕生日に特別演出。
+> **#1379 Sub B-1**: 実装から仕様を復元 (ADR-0001 準拠)。Committed（実装済み）と Aspirational（未実装）を明確に区別する (ADR-0013)。
+
+### 13.1 データモデル
+
+| カラム | 型 | 役割 |
+|--------|-----|------|
+| `child.birthDate` | `TEXT` (YYYY-MM-DD), nullable | **誕生日 SSOT**。入力された場合は年齢の唯一の真実の源 |
+| `child.age` | `INTEGER` | 年齢キャッシュ。`birthDate` がある場合は `calculateAge(birthDate)` で計算。ない場合はユーザー直接入力値 |
+| `child.uiMode` | `TEXT` ('baby'\|'preschool'\|'elementary'\|'junior'\|'senior') | 年齢 UI モード。`getDefaultUiMode(age)` から導出。誕生日ボーナス claim 時に自動更新 |
+| `child.uiModeManuallySet` | — | **未実装 (Aspirational / Sub B-4)**。親が uiMode を手動設定したフラグ。将来の年齢自動インクリメント cron で更新対象外にする |
+
+### 13.2 年齢から uiMode へのマッピング
+
+`getDefaultUiMode(age: number)` (`src/lib/domain/validation/age-tier.ts`):
+
+| 年齢 | uiMode | 日本語名 |
+|------|--------|---------|
+| 0 〜 2 | `baby` | 乳幼児 |
+| 3 〜 5 | `preschool` | 幼児 |
+| 6 〜 12 | `elementary` | 小学生 |
+| 13 〜 15 | `junior` | 中学生 |
+| 16 以上 | `senior` | 高校生 |
+
+### 13.3 状態遷移（Committed / 現行実装）
+
+#### 子供登録時 (`/admin/children` POST ?/create)
+
+```
+birthDate 入力あり:
+  child.birthDate = birthDate
+  child.age       = calculateAge(birthDate)   ← (0 〜 18 クランプ)
+  child.uiMode    = getDefaultUiMode(age)
+
+birthDate 入力なし (年齢のみ):
+  child.birthDate = null
+  child.age       = Number(ageStr)            ← 0 〜 18 の範囲でバリデーション
+  child.uiMode    = getDefaultUiMode(age)
+```
+
+#### 子供更新時 (`/admin/children` POST ?/update)
+
+```
+birthDate が変更された場合:
+  child.birthDate = birthDate (または null)
+  birthDate あり → child.age = calculateAge(birthDate)
+  birthDate なし → child.age = Number(ageStr) (入力があれば)
+
+birthDate が変更されない場合:
+  child.age = Number(ageStr) (入力があれば)
+```
+
+#### 誕生日ボーナス claim 時 (`/api/cron/birthday-bonus` or 子供画面)
+
+```
+claimBirthdayBonus():
+  child.age                   = calculateAge(birthDate, today)
+  child.uiMode                = getDefaultUiMode(newAge)      ← 常に上書き (manuallySet 未実装)
+  child.lastBirthdayBonusYear = currentYear                   ← 重複 claim 防止
+  PointEntry 追加             = age × 100 × birthdayBonusMultiplier
+```
+
+### 13.4 SSOT 優先度表
+
+| 情報 | Primary SSOT | Derived From |
+|------|-------------|--------------|
+| 誕生日 | `child.birthDate` | — |
+| 年齢 | `child.age` (ただし birthDate がある場合は `calculateAge(birthDate)` で上書き) | `calculateAge(birthDate)` |
+| uiMode | `child.uiMode` (ただし `!uiModeManuallySet` なら age 変化時に再計算) | `getDefaultUiMode(age)` |
+
+### 13.5 フォーム UX バリデーション（Committed）
+
+- `birthDate` は YYYY-MM-DD 形式のみ許可
+- `birthDate` が未来日の場合はエラー
+- `age` は 0 〜 18 の整数のみ許可
+- 現状: `birthDate` と `age` は**どちらか片方の入力で登録可能**（両方入力した場合は `birthDate` 優先）
+- **Issue**: 両方未入力でも登録できてしまう状態が implicit（Sub B-2 で「どちらか必須」チェックを追加）
+
+### 13.6 誕生日ボーナスの演出（Committed）
 
 | 要素 | 仕様 |
 |------|------|
-| バナー | 誕生日当日にホーム画面上部に表示 |
+| バナー | 誕生日から 3 日以内にホーム画面上部に表示 |
 | モーダル | 初回アクセス時に特別メッセージ |
-| ボーナス | ポイント ×3（終日） |
+| 請求期間 | 誕生日当日〜2 日後（`CLAIM_WINDOW_DAYS = 3`） |
+| ボーナス | `age × 100 × birthdayBonusMultiplier` ポイント |
+| 重複防止 | `lastBirthdayBonusYear` で同一年の二重 claim を防止 |
 
 コンポーネント: `BirthdayBanner.svelte`, `BirthdayModal.svelte`
 サービス: `birthday-bonus-service.ts`
+
+### 13.7 年齢自動インクリメント（Aspirational / Sub B-3）
+
+> **未実装**: 以下は Sub B-3 で実装予定の仕様。現時点では birthDate があっても誕生日が来ても age は自動インクリメントされない。
+
+```
+毎日 00:00 JST に /api/cron/age-recalc を実行:
+  birthDate がある全 child を対象
+  今日 = birthMonth/birthDay の子供:
+    age = age + 1
+    uiModeManuallySet が false の場合: uiMode = getDefaultUiMode(age)
+```
+
+### 13.8 実装ファイル参照
+
+| ファイル | 役割 |
+|---------|------|
+| `src/lib/domain/validation/age-tier.ts` | `getDefaultUiMode()` / `UiMode` 型 |
+| `src/lib/server/services/birthday-bonus-service.ts` | `calculateAge()` / `claimBirthdayBonus()` |
+| `src/routes/(parent)/admin/children/+page.server.ts` | 子供登録・更新フォームのバリデーション |
+| `src/lib/server/db/child-repo.ts` | DB アクセス (`updateChild`) |
 
 ---
 

--- a/docs/design/parallel-implementations.md
+++ b/docs/design/parallel-implementations.md
@@ -250,6 +250,27 @@ grep -n "bottom-nav\|data-testid" src/lib/ui/components/BottomNav.svelte
 
 ---
 
+#### 10. 年齢・誕生日 (age / birthDate / uiMode) (#1378)
+
+| 場所 | 内容 |
+|------|------|
+| `child.birthDate` / `child.age` / `child.uiMode` | DB カラム（SSOT 優先度: birthDate > age > uiMode） |
+| `src/lib/domain/validation/age-tier.ts` | `getDefaultUiMode(age)` — uiMode 導出ロジック |
+| `src/lib/server/services/birthday-bonus-service.ts` | `calculateAge()` / `claimBirthdayBonus()` — age 更新 + uiMode 再計算 |
+| `src/routes/(parent)/admin/children/+page.server.ts` | 子供登録・更新フォームの age/birthDate バリデーション |
+| `docs/design/26-ゲーミフィケーション設計書.md §13` | 仕様 SSOT |
+
+**同期メカニズム**:
+- `birthDate` が変化した場合は必ず `calculateAge(birthDate)` で age を再計算し、`getDefaultUiMode(age)` で uiMode も更新する
+- `uiModeManuallySet` フラグが導入された後は、`false` の場合のみ自動更新する（Sub B-4、未実装）
+
+**修正時チェック**:
+- [ ] birthDate / age バリデーション変更 → `children/+page.server.ts` と `birthday-bonus-service.ts` の両方を確認
+- [ ] `getDefaultUiMode` の年齢境界変更 → `age-tier.ts` 1 箇所（副作用: 全 child の uiMode が次回更新時に変化する）
+- [ ] age 自動インクリメント実装 (Sub B-3) → `schedule-registry.ts` に cron 登録 + E2E テスト追加
+
+---
+
 ## 修正時チェックリスト
 
 **すべての修正前に、以下のどれに該当するか確認し、対応するペアを触ること**:


### PR DESCRIPTION
## Summary

- `docs/design/26-ゲーミフィケーション設計書.md §13` を大幅拡張（7 行 → 108 行）
- `docs/design/parallel-implementations.md` に年齢・誕生日ペア（§10）を追加
- `docs/design/08-データベース設計書.md` の `ui_mode` default/enum 値を実装値に訂正

## Acceptance Criteria 対応状況

- [x] §13 を拡張（データモデル / 状態遷移 / SSOT / フォームUX / 自動インクリメント / 既存サービス関係）
- [x] 6 項目すべて記載
- [x] Sub B-2 / B-3 / B-4 の実装時に参照できる粒度
- [x] 実装の implicit 仕様（birthDate優先で年齢を上書き等）を明示化
- [x] parallel-implementations.md に年齢・誕生日ペアを追加
- [x] DB設計書との整合確認・更新

## 補足

- `uiModeManuallySet` は未実装（Aspirational / Sub B-4）として明記
- 年齢自動インクリメント cron は未実装（Aspirational / Sub B-3）として明記
- ADR-0013 (Committed/Aspirational 分離) に準拠

## Test plan

- [x] 設計書ファイル変更のみ（コード変更なし）
- [x] `npx biome check .` / `npx svelte-check` / `npx vitest run` は対象外（docs のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)