### PR TITLE
feat: /consent の文言を CONSENT_LABELS.errors に SSOT 化 (#1356)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -189,12 +189,14 @@ SSR 二重適用は `data-budoux-applied` フラグで回避。詳細は [ADR-00
 |--------------|---------------|
 | Alert | `$lib/ui/primitives/Alert.svelte` |
 | Badge | `$lib/ui/primitives/Badge.svelte` |
+| BirthdayInput | `$lib/ui/primitives/BirthdayInput.svelte` |
 | Button | `$lib/ui/primitives/Button.svelte` |
 | Card | `$lib/ui/primitives/Card.svelte` |
 | Dialog | `$lib/ui/primitives/Dialog.svelte` |
 | Divider | `$lib/ui/primitives/Divider.svelte` |
 | FormField | `$lib/ui/primitives/FormField.svelte` |
 | IconButton | `$lib/ui/primitives/IconButton.svelte` |
+| NativeSelect | `$lib/ui/primitives/NativeSelect.svelte` |
 | PinInput | `$lib/ui/primitives/PinInput.svelte` |
 | Progress | `$lib/ui/primitives/Progress.svelte` |
 | Select | `$lib/ui/primitives/Select.svelte` |
@@ -287,6 +289,10 @@ UI に表示されるラベル・用語は `src/lib/domain/labels.ts` を Single
 <!-- AUTOGEN:labels -->
 | エクスポート | 種類 | 用途 |
 |------------|------|------|
+| `APP_LABELS` | const |  |
+| `PAGE_TITLES` | const |  |
+| `UI_LABELS` | const |  |
+| `SETUP_LABELS` | const |  |
 | `NAV_CATEGORIES` | const | ナビゲーションカテゴリ名 |
 | `NAV_ITEM_LABELS` | const | ナビゲーション項目ラベル |
 | `AGE_TIER_LABELS` | const | 年齢区分ラベル（フル） |
@@ -307,6 +313,83 @@ UI に表示されるラベル・用語は `src/lib/domain/labels.ts` を Single
 | `MARKETPLACE_LABELS` | const |  |
 | `MARKETPLACE_FILTER_LABELS` | const |  |
 | `TUTORIAL_LABELS` | const |  |
+| `DEMO_LABELS` | const |  |
+| `OYAKAGI_LABELS` | const |  |
+| `IMPORT_LABELS` | const |  |
+| `SETTINGS_LABELS` | const |  |
+| `LICENSE_PAGE_LABELS` | const |  |
+| `REPORTS_LABELS` | const |  |
+| `OPS_LABELS` | const |  |
+| `POINTS_LABELS` | const |  |
+| `SIGNUP_LABELS` | const |  |
+| `ANALYTICS_LABELS` | const |  |
+| `BILLING_LABELS` | const |  |
+| `OPS_LICENSE_ISSUE_LABELS` | const |  |
+| `OPS_REVENUE_LABELS` | const |  |
+| `OPS_BUSINESS_LABELS` | const |  |
+| `CHILD_HOME_LABELS` | const |  |
+| `DEMO_SIGNUP_LABELS` | const |  |
+| `CHALLENGES_LABELS` | const |  |
+| `LOGIN_LABELS` | const |  |
+| `MEMBERS_LABELS` | const |  |
+| `DEMO_TOP_LABELS` | const |  |
+| `GROWTH_BOOK_LABELS` | const |  |
+| `OPS_ANALYTICS_LABELS` | const |  |
+| `DEMO_SETTINGS_LABELS` | const |  |
+| `ERROR_PAGE_LABELS` | const |  |
+| `OPS_LICENSE_KEY_LABELS` | const |  |
+| `STATUS_LABELS` | const |  |
+| `PRICING_PAGE_LABELS` | const |  |
+| `CONSENT_LABELS` | const |  |
+| `DEMO_STATUS_LABELS` | const |  |
+| `OPS_COSTS_LABELS` | const |  |
+| `REWARDS_LABELS` | const |  |
+| `DEMO_MEMBERS_LABELS` | const |  |
+| `OPS_EXPORT_LABELS` | const |  |
+| `MESSAGES_LABELS` | const |  |
+| `OPS_COHORT_LABELS` | const |  |
+| `SETUP_FIRST_ADVENTURE_LABELS` | const |  |
+| `DEMO_POINTS_LABELS` | const |  |
+| `ACHIEVEMENTS_LABELS` | const |  |
+| `ACTIVITIES_INTRODUCE_LABELS` | const |  |
+| `DEMO_MESSAGES_LABELS` | const |  |
+| `EVENTS_LABELS` | const |  |
+| `FORGOT_PASSWORD_LABELS` | const |  |
+| `DEMO_REWARDS_LABELS` | const |  |
+| `SETUP_COMPLETE_LABELS` | const |  |
+| `CERTIFICATE_DETAIL_LABELS` | const |  |
+| `DEMO_CHILD_HOME_LABELS` | const |  |
+| `DEMO_ADMIN_HOME_LABELS` | const |  |
+| `SETUP_CHILDREN_LABELS` | const |  |
+| `ADMIN_CHILDREN_LABELS` | const |  |
+| `DEMO_REPORTS_LABELS` | const |  |
+| `ADMIN_CHILDREN_PAGE_LABELS` | const |  |
+| `CERTIFICATES_PAGE_LABELS` | const |  |
+| `PACKS_PAGE_LABELS` | const |  |
+| `OPS_LAYOUT_LABELS` | const |  |
+| `SETUP_QUESTIONNAIRE_LABELS` | const |  |
+| `CHILD_STATUS_LABELS` | const |  |
+| `AUTH_INVITE_LABELS` | const |  |
+| `DEMO_ACHIEVEMENTS_LABELS` | const |  |
+| `DEMO_LAYOUT_LABELS` | const |  |
+| `SETUP_PACKS_LABELS` | const |  |
+| `PARENT_LOGIN_LABELS` | const |  |
+| `VIEW_PAGE_LABELS` | const |  |
+| `DEMO_BATTLE_LABELS` | const |  |
+| `DEMO_ACTIVITIES_LABELS` | const |  |
+| `DEMO_CHECKLISTS_LABELS` | const |  |
+| `DEMO_EVENTS_LABELS` | const |  |
+| `SWITCH_PAGE_LABELS` | const |  |
+| `OPS_LICENSE_PAGE_LABELS` | const |  |
+| `DEMO_CHALLENGES_LABELS` | const |  |
+| `DEMO_CHILD_ACHIEVEMENTS_LABELS` | const |  |
+| `formatCount` | function |  |
+| `formatAge` | function |  |
+| `formatAgeRange` | function |  |
+| `formatStreak` | function |  |
+| `formatTimes` | function |  |
+| `formatPeople` | function |  |
+| `formatDateRange` | function |  |
 | `getAgeTierLabel` | function | 年齢区分ラベル取得 |
 | `getAgeTierShortLabel` | function | 年齢区分短縮ラベル取得 |
 | `getPlanLabel` | function | プランラベル取得 |
@@ -321,6 +404,7 @@ UI に表示されるラベル・用語は `src/lib/domain/labels.ts` を Single
 | `ChecklistKind` | type |  |
 | `MarketplaceGender` | type |  |
 | `MarketplaceSortKey` | type |  |
+| `ImportSkipReason` | type |  |
 <!-- /AUTOGEN:labels -->
 
 ### ルール

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2344,6 +2344,15 @@ export const CONSENT_LABELS = {
 	// Submit button
 	submitLoading: '同意中...',
 	submitButton: '同意して続ける',
+
+	// Error messages (used in +page.svelte and +page.server.ts)
+	errors: {
+		loginRequired: 'ログインが必要です',
+		bothRequired: '利用規約とプライバシーポリシーの両方に同意してください',
+		recordFailed: '同意の記録に失敗しました。もう一度お試しください。',
+		termsRequired: '利用規約への同意が必要です',
+		privacyRequired: 'プライバシーポリシーへの同意が必要です',
+	},
 } as const;
 
 // ============================================================

--- a/src/routes/consent/+page.server.ts
+++ b/src/routes/consent/+page.server.ts
@@ -1,6 +1,7 @@
 // /consent — 規約再同意ページ (#0192)
 
 import { fail, redirect } from '@sveltejs/kit';
+import { CONSENT_LABELS } from '$lib/domain/labels';
 import { getAuthMode } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
 import {
@@ -44,7 +45,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 export const actions: Actions = {
 	default: async ({ request, locals, getClientAddress }) => {
 		if (!locals.authenticated || !locals.context?.tenantId) {
-			return fail(401, { error: 'ログインが必要です' });
+			return fail(401, { error: CONSENT_LABELS.errors.loginRequired });
 		}
 
 		const formData = await request.formData();
@@ -53,7 +54,7 @@ export const actions: Actions = {
 
 		if (!agreedTerms || !agreedPrivacy) {
 			return fail(400, {
-				error: '利用規約とプライバシーポリシーの両方に同意してください',
+				error: CONSENT_LABELS.errors.bothRequired,
 			});
 		}
 
@@ -68,7 +69,7 @@ export const actions: Actions = {
 			logger.error('[CONSENT] Failed to record re-consent', {
 				error: err instanceof Error ? err.message : String(err),
 			});
-			return fail(500, { error: '同意の記録に失敗しました。もう一度お試しください。' });
+			return fail(500, { error: CONSENT_LABELS.errors.recordFailed });
 		}
 
 		redirect(302, '/admin');

--- a/src/routes/consent/+page.svelte
+++ b/src/routes/consent/+page.svelte
@@ -20,8 +20,8 @@ const canSubmit = $derived(
 );
 const submitBlockReason = $derived.by(() => {
 	if (loading) return '';
-	if (needsTerms && !agreedTerms) return '利用規約への同意が必要です';
-	if (needsPrivacy && !agreedPrivacy) return 'プライバシーポリシーへの同意が必要です';
+	if (needsTerms && !agreedTerms) return CONSENT_LABELS.errors.termsRequired;
+	if (needsPrivacy && !agreedPrivacy) return CONSENT_LABELS.errors.privacyRequired;
 	return '';
 });
 </script>


### PR DESCRIPTION
## Summary

- `CONSENT_LABELS` に `errors` サブオブジェクトを追加（5 キー）
- `+page.svelte` の `submitBlockReason` ハードコード文字列 2 件を `CONSENT_LABELS.errors` 経由に変更
- `+page.server.ts` の `fail()` エラー文字列 3 件を `CONSENT_LABELS.errors` 経由に変更
- `scripts/generate-design-md-sections.mjs` で `docs/DESIGN.md` §6 を自動更新

## Acceptance Criteria

- [x] `CONSENT_LABELS.errors` を `src/lib/domain/labels.ts` に追加
- [x] `+page.svelte` のハードコード文字列を `CONSENT_LABELS.errors` 経由に変更
- [x] `+page.server.ts` のエラー文字列を `CONSENT_LABELS.errors` 経由に変更
- [x] 既存テスト全通過（192 files, 3812 tests passed）
- [x] `docs/DESIGN.md` §6 を `generate-design-md-sections.mjs` で更新

## Test plan

- [x] `npx biome check .` — エラーなし
- [x] `npx svelte-check` — 型エラーなし
- [x] `npx vitest run` — 3812 tests passed
- [x] `node scripts/check-hardcoded-strings.mjs` — baseline 内（682 → 682）

## スクリーンショット / ビジュアルデモ

本 PR は **内部コードのリファクタリング（文字列定数の SSOT 化）のみ** です。
`/consent` 画面のエラーメッセージ文言は変更なし。UI の見た目・表示テキストに差分はありません。

> 視覚的変化なし — ハードコード文字列を `CONSENT_LABELS.errors` 経由に変更したのみ。
> 表示テキストは変更前後で完全に同一です。

![視覚的変化なし](https://placehold.co/1x1/transparent/transparent)

Closes #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)