### PR TITLE
fix: capture.mjs --flow が Windows で失敗する2つの問題を修正 (#1471)

### DIFF
--- a/scripts/capture.mjs
+++ b/scripts/capture.mjs
@@ -13,6 +13,7 @@
  */
 
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 import { FlowRecorder, resolvePreset, ScreenshotCapture } from './lib/screenshot-helpers.mjs';
 
@@ -126,9 +127,10 @@ async function runFlowMode() {
 	}
 
 	const actionsAbsPath = path.resolve(actionsPath);
+	const actionsFileUrl = pathToFileURL(actionsAbsPath).href;
 	let actionsModule;
 	try {
-		actionsModule = await import(actionsAbsPath);
+		actionsModule = await import(actionsFileUrl);
 	} catch (err) {
 		console.error(`エラー: actions スクリプトを読み込めません: ${actionsAbsPath}`);
 		console.error(err.message);
@@ -152,13 +154,16 @@ async function runFlowMode() {
 		cellHeight,
 	});
 
+	// Git Bash (MINGW) は /foo/bar を C:/Program Files/Git/foo/bar に変換するため、
+	// FlowRecorder と同じ正規化を表示用にも適用する
+	const normalizedUrl = `/${url.replace(/^\/+/, '').replace(/^[A-Za-z]:\/.*Git\//, '')}`;
 	console.log(`=== フロースタンプシート生成: ${flow} ===`);
-	console.log(`URL: ${baseUrl}${url}`);
+	console.log(`URL: ${baseUrl}${normalizedUrl}`);
 	console.log(`出力: ${outputDir}\n`);
 
 	try {
 		const result = await recorder.record({
-			url,
+			url: normalizedUrl,
 			flowName: flow,
 			actions: actionsFn,
 			preset: presetNames[0] ?? 'desktop',


### PR DESCRIPTION
## Summary

Closes #1471

`scripts/capture.mjs --flow` が Windows 環境で2つの原因により失敗していた問題を修正。

- **問題1: ESM dynamic import が Windows パスを拒否**
  - `import(actionsAbsPath)` に `C:\...` 形式のパスを渡すと Node.js が ESM として解釈できずエラー
  - `pathToFileURL(actionsAbsPath).href` で `file://C:/...` URL 形式に変換して解決

- **問題2: Git Bash (MINGW) による URL パス自動変換**
  - `--url /admin/children` を CLI に渡すと Git Bash が `C:/Program Files/Git/admin/children` に変換
  - 受け取った URL から MINGW 変換の痕跡をストリップする正規化を追加: `.replace(/^[A-Za-z]:\/.*Git\//, '')`

## 変更ファイル

- `scripts/capture.mjs` — `pathToFileURL` import 追加、`normalizedUrl` 正規化ロジック追加

## Test plan

- [ ] `npm run capture -- --flow children-birthday-form --url /demo/admin/children --actions tmp/capture-flows/children-birthday-form.mjs` を Windows (Git Bash) で実行してエラーなく完了することを確認
- [ ] CI lint / type-check pass

## Screenshots / ビジュアルデモ

本 PR はスクリプト修正のみ。UI 変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)