### PR TITLE
feat: #1469 HealthCheck 週次ハートビート — SSM 週次統計 + Discord サマリー通知

### DIFF
--- a/infra/lambda/health-check/index.ts
+++ b/infra/lambda/health-check/index.ts
@@ -19,6 +19,7 @@
  * - Notifies Discord only on failure/degraded (v1: no state tracking)
  * - Timeout: 10s per check, 30s total Lambda timeout
  * - #1470 Phase 2: SSM Parameter Store で前回通知ステータスを記憶し、復旧時に通知
+ * - #1469: SSM Parameter Store で週次実行統計を記憶し、週次ハートビートを Discord 通知
  */
 
 import * as http from 'node:http';
@@ -50,6 +51,16 @@ interface OverallStatus {
 
 type NotifiedStatus = 'normal' | 'degraded' | 'down';
 
+// #1469: 週次統計の永続化型
+interface WeeklyStats {
+	weekStart: string; // YYYY-MM-DD (日曜 UTC = 月曜 09:00 JST 起点)
+	total: number;
+	normal: number;
+	degraded: number;
+	down: number;
+	totalResponseMs: number;
+}
+
 // ----------------------------------------------------------------
 // Configuration
 // ----------------------------------------------------------------
@@ -77,6 +88,9 @@ const RETRY_DELAY_MS = Number.parseInt(process.env.HEALTH_CHECK_RETRY_DELAY_MS ?
 // #1470: 前回通知ステータス保持用 SSM パラメータ名
 const SSM_PARAM_NAME =
 	process.env.SSM_LAST_NOTIFIED_STATUS_PARAM ?? '/ganbari-quest/health-check/last-notified-status';
+// #1469: 週次統計保持用 SSM パラメータ名
+const SSM_WEEKLY_STATS_PARAM =
+	process.env.SSM_WEEKLY_STATS_PARAM ?? '/ganbari-quest/health-check/weekly-stats';
 
 const ssmClient = new SSMClient({});
 
@@ -144,6 +158,9 @@ export async function handler(): Promise<OverallStatus> {
 		);
 	}
 
+	// #1469: 週次統計を更新し、週が変わったらハートビートを送信
+	await updateWeeklyStats(overallStatus, finalCheck.responseTimeMs);
+
 	// Always log result for CloudWatch (生 URL は調査用に残す)
 	console.log(JSON.stringify(result));
 
@@ -171,6 +188,40 @@ async function getLastNotifiedStatus(): Promise<NotifiedStatus | null> {
 	}
 }
 
+// ----------------------------------------------------------------
+// Weekly Stats — SSM (#1469)
+// ----------------------------------------------------------------
+
+// 日曜 00:00 UTC = 月曜 09:00 JST を週の起点とする
+function getSundayWeekStart(date: Date): string {
+	const d = new Date(date);
+	d.setUTCDate(d.getUTCDate() - d.getUTCDay()); // getUTCDay(): 0=Sun
+	d.setUTCHours(0, 0, 0, 0);
+	return d.toISOString().slice(0, 10);
+}
+
+async function getWeeklyStats(): Promise<WeeklyStats | null> {
+	try {
+		const res = await ssmClient.send(new GetParameterCommand({ Name: SSM_WEEKLY_STATS_PARAM }));
+		const value = res.Parameter?.Value;
+		if (!value) return null;
+		const parsed = JSON.parse(value) as Partial<WeeklyStats>;
+		if (typeof parsed.weekStart !== 'string') return null;
+		return {
+			weekStart: parsed.weekStart,
+			total: parsed.total ?? 0,
+			normal: parsed.normal ?? 0,
+			degraded: parsed.degraded ?? 0,
+			down: parsed.down ?? 0,
+			totalResponseMs: parsed.totalResponseMs ?? 0,
+		};
+	} catch (err) {
+		if (err instanceof ParameterNotFound) return null;
+		console.error('SSM getWeeklyStats error:', err);
+		return null;
+	}
+}
+
 async function setLastNotifiedStatus(status: NotifiedStatus): Promise<void> {
 	try {
 		await ssmClient.send(
@@ -183,6 +234,53 @@ async function setLastNotifiedStatus(status: NotifiedStatus): Promise<void> {
 		);
 	} catch (err) {
 		console.error('SSM setLastNotifiedStatus error:', err);
+	}
+}
+
+async function setWeeklyStats(stats: WeeklyStats): Promise<void> {
+	try {
+		await ssmClient.send(
+			new PutParameterCommand({
+				Name: SSM_WEEKLY_STATS_PARAM,
+				Value: JSON.stringify(stats),
+				Type: 'String',
+				Overwrite: true,
+			}),
+		);
+	} catch (err) {
+		console.error('SSM setWeeklyStats error:', err);
+	}
+}
+
+async function updateWeeklyStats(
+	status: OverallStatus['status'],
+	responseTimeMs: number,
+): Promise<void> {
+	const currentWeekStart = getSundayWeekStart(new Date());
+	const prevStats = await getWeeklyStats();
+
+	if (prevStats !== null && prevStats.weekStart !== currentWeekStart) {
+		// 週が切り替わった → 前週のサマリーをハートビートとして送信してからリセット
+		await notifyDiscordHeartbeat(prevStats);
+		const newStats: WeeklyStats = {
+			weekStart: currentWeekStart,
+			total: 1,
+			normal: status === 'normal' ? 1 : 0,
+			degraded: status === 'degraded' ? 1 : 0,
+			down: status === 'down' ? 1 : 0,
+			totalResponseMs: responseTimeMs,
+		};
+		await setWeeklyStats(newStats);
+	} else {
+		const updated: WeeklyStats = {
+			weekStart: currentWeekStart,
+			total: (prevStats?.total ?? 0) + 1,
+			normal: (prevStats?.normal ?? 0) + (status === 'normal' ? 1 : 0),
+			degraded: (prevStats?.degraded ?? 0) + (status === 'degraded' ? 1 : 0),
+			down: (prevStats?.down ?? 0) + (status === 'down' ? 1 : 0),
+			totalResponseMs: (prevStats?.totalResponseMs ?? 0) + responseTimeMs,
+		};
+		await setWeeklyStats(updated);
 	}
 }
 
@@ -357,6 +455,52 @@ async function notifyDiscordRecovery(
 			message: 'sending recovery notification',
 			previousStatus,
 			currentStatus: result.status,
+		}),
+	);
+
+	await postDiscordEmbed(embed);
+}
+
+// #1469: 週次ハートビート通知
+async function notifyDiscordHeartbeat(stats: WeeklyStats): Promise<void> {
+	if (!DISCORD_WEBHOOK_URL) {
+		console.log('DISCORD_WEBHOOK_HEALTH not set, skipping heartbeat notification');
+		return;
+	}
+
+	const avgResponseMs = stats.total > 0 ? Math.round(stats.totalResponseMs / stats.total) : 0;
+	const weekEndDate = new Date(`${stats.weekStart}T00:00:00Z`);
+	weekEndDate.setUTCDate(weekEndDate.getUTCDate() + 6);
+	const weekRange = `${stats.weekStart} 〜 ${weekEndDate.toISOString().slice(0, 10)}`;
+
+	const embed = {
+		title: '\u{1F49A} HealthCheck 週次サマリー',
+		description: '監視が正常に稼働しています。',
+		color: 0x00cc44,
+		fields: [
+			{ name: '期間', value: weekRange, inline: false },
+			{ name: '実行回数', value: `${stats.total} 回`, inline: true },
+			{ name: '正常', value: `${stats.normal} 回`, inline: true },
+			{
+				name: '異常（degraded + down）',
+				value: `${stats.degraded + stats.down} 回`,
+				inline: true,
+			},
+			{ name: '平均応答時間', value: `${avgResponseMs.toLocaleString()}ms`, inline: true },
+			{ name: '環境', value: HEALTH_CHECK_ENVIRONMENT, inline: true },
+		],
+		timestamp: new Date().toISOString(),
+	};
+
+	console.log(
+		JSON.stringify({
+			level: 'info',
+			message: 'sending weekly heartbeat notification',
+			weekStart: stats.weekStart,
+			total: stats.total,
+			normal: stats.normal,
+			degraded: stats.degraded,
+			down: stats.down,
 		}),
 	);
 

--- a/infra/lib/ops-stack.ts
+++ b/infra/lib/ops-stack.ts
@@ -389,6 +389,14 @@ export class OpsStack extends cdk.Stack {
 		// からは常時 403 になる。Function URL (authType: NONE) を直叩きして Lambda/DB の
 		// 生存確認に用途を限定する。CloudFront 層の障害は本 Lambda では検知できない
 		// （別途 CloudWatch Synthetics 等で補完する方針 — 本 Issue のスコープ外）。
+		// #1469: 週次実行統計を保持する SSM パラメータ
+		const weeklyStatsParam = new ssm.StringParameter(this, 'HealthCheckWeeklyStats', {
+			parameterName: '/ganbari-quest/health-check/weekly-stats',
+			stringValue: '{}',
+			description: 'Health check Lambda の週次実行統計（ハートビート通知用）',
+			tier: ssm.ParameterTier.STANDARD,
+		});
+
 		const healthCheckFn = new lambdaNode.NodejsFunction(this, 'HealthCheckFn', {
 			functionName: 'ganbari-quest-health-check',
 			entry: path.join(__dirname, '..', 'lambda', 'health-check', 'index.ts'),
@@ -399,6 +407,7 @@ export class OpsStack extends cdk.Stack {
 			timeout: cdk.Duration.seconds(30),
 			environment: {
 				HEALTH_CHECK_URL: props.functionUrl.url,
+				SSM_WEEKLY_STATS_PARAM: weeklyStatsParam.parameterName,
 				...(discordWebhookHealth ? { DISCORD_WEBHOOK_HEALTH: discordWebhookHealth } : {}),
 			},
 			bundling: {
@@ -416,11 +425,11 @@ export class OpsStack extends cdk.Stack {
 			tier: ssm.ParameterTier.STANDARD,
 		});
 
-		// #1470: SSM GetParameter / PutParameter 権限を付与
+		// #1470 + #1469: SSM GetParameter / PutParameter 権限を付与（2 パラメータ）
 		healthCheckFn.addToRolePolicy(
 			new iam.PolicyStatement({
 				actions: ['ssm:GetParameter', 'ssm:PutParameter'],
-				resources: [lastNotifiedStatusParam.parameterArn],
+				resources: [lastNotifiedStatusParam.parameterArn, weeklyStatsParam.parameterArn],
 			}),
 		);
 

--- a/tests/unit/infra/health-check-lambda.test.ts
+++ b/tests/unit/infra/health-check-lambda.test.ts
@@ -16,11 +16,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // already initialized when the factory is first called.
 // ----------------------------------------------------------------
 
+// SSM パラメータ名定数（lambda の default と揃える）
+const WEEKLY_STATS_KEY = '/ganbari-quest/health-check/weekly-stats';
+
 interface SsmStoreState {
-	stored: string | null;
+	params: Record<string, string>;
 	putCalls: Array<{ Name: string; Value: string }>;
 }
-const ssmStore: SsmStoreState = { stored: null, putCalls: [] };
+const ssmStore: SsmStoreState = { params: {}, putCalls: [] };
 
 vi.mock('@aws-sdk/client-ssm', () => {
 	class ParameterNotFound extends Error {
@@ -38,14 +41,16 @@ vi.mock('@aws-sdk/client-ssm', () => {
 	class MockSSMClient {
 		send(cmd: unknown): Promise<unknown> {
 			if (cmd instanceof GetParameterCommand) {
-				if (ssmStore.stored === null) {
+				const name = (cmd as GetParameterCommand).input.Name;
+				const value = ssmStore.params[name];
+				if (value === undefined) {
 					return Promise.reject(new ParameterNotFound());
 				}
-				return Promise.resolve({ Parameter: { Value: ssmStore.stored } });
+				return Promise.resolve({ Parameter: { Value: value } });
 			}
 			if (cmd instanceof PutParameterCommand) {
 				const { Name, Value } = (cmd as PutParameterCommand).input;
-				ssmStore.stored = Value;
+				ssmStore.params[Name] = Value;
 				ssmStore.putCalls.push({ Name, Value });
 				return Promise.resolve({});
 			}
@@ -58,35 +63,6 @@ vi.mock('@aws-sdk/client-ssm', () => {
 // ----------------------------------------------------------------
 // Test harness
 // ----------------------------------------------------------------
-
-// @aws-sdk/client-ssm は Lambda ランタイム組み込み。vitest 環境ではモックで代替。
-// send() は常に {} を返す → getLastNotifiedStatus() は Parameter.Value が undefined のため null を返す（初回扱い）。
-// setLastNotifiedStatus() は PutParameterCommand を送信するが、テストでは no-op。
-vi.mock('@aws-sdk/client-ssm', () => {
-	class ParameterNotFound extends Error {
-		constructor() {
-			super('ParameterNotFound');
-			this.name = 'ParameterNotFound';
-		}
-	}
-	class MockSSMClient {
-		send(_cmd: unknown) {
-			return Promise.resolve({});
-		}
-	}
-	class GetParameterCommand {
-		constructor(public input: unknown) {}
-	}
-	class PutParameterCommand {
-		constructor(public input: unknown) {}
-	}
-	return {
-		SSMClient: MockSSMClient,
-		GetParameterCommand,
-		PutParameterCommand,
-		ParameterNotFound,
-	};
-});
 
 type ProbeBehavior =
 	| { kind: 'ok'; delayMs?: number }
@@ -211,7 +187,7 @@ describe('#1257 health-check Lambda Phase 1', () => {
 		delete process.env.DEGRADED_THRESHOLD_MS;
 		delete process.env.HEALTH_CHECK_RETRY_DELAY_MS;
 		delete process.env.HEALTH_CHECK_ENVIRONMENT;
-		ssmStore.stored = null;
+		ssmStore.params = {};
 		ssmStore.putCalls = [];
 	});
 
@@ -365,7 +341,7 @@ describe('#1257 health-check Lambda Phase 1', () => {
 
 	describe('G4. 週次ハートビート (#1469)', () => {
 		beforeEach(() => {
-			ssmStore.stored = null;
+			ssmStore.params = {};
 			ssmStore.putCalls = [];
 		});
 
@@ -375,17 +351,18 @@ describe('#1257 health-check Lambda Phase 1', () => {
 
 			await handler();
 
-			expect(ssmStore.putCalls).toHaveLength(1);
-			const written = JSON.parse(ssmStore.putCalls[0]!.Value);
-			expect(written.weekStart).toBe(currentWeekStart());
-			expect(written.total).toBe(1);
-			expect(written.normal).toBe(1);
-			expect(written.degraded).toBe(0);
-			expect(written.down).toBe(0);
+			const weeklyPut1 = ssmStore.putCalls.find((c) => c.Name === WEEKLY_STATS_KEY);
+			expect(weeklyPut1).toBeDefined();
+			const written1 = JSON.parse(weeklyPut1!.Value);
+			expect(written1.weekStart).toBe(currentWeekStart());
+			expect(written1.total).toBe(1);
+			expect(written1.normal).toBe(1);
+			expect(written1.degraded).toBe(0);
+			expect(written1.down).toBe(0);
 		});
 
 		it('同じ週の 2 回目実行 → カウンタが累積される', async () => {
-			ssmStore.stored = JSON.stringify({
+			ssmStore.params[WEEKLY_STATS_KEY] = JSON.stringify({
 				weekStart: currentWeekStart(),
 				total: 5,
 				normal: 4,
@@ -401,17 +378,18 @@ describe('#1257 health-check Lambda Phase 1', () => {
 
 			// 同週なのでハートビート通知なし
 			expect(harness.discordPosts).toHaveLength(0);
-			expect(ssmStore.putCalls).toHaveLength(1);
-			const written = JSON.parse(ssmStore.putCalls[0]!.Value);
-			expect(written.weekStart).toBe(currentWeekStart());
-			expect(written.total).toBe(6);
-			expect(written.normal).toBe(5);
-			expect(written.degraded).toBe(1);
+			const weeklyPut2 = ssmStore.putCalls.find((c) => c.Name === WEEKLY_STATS_KEY);
+			expect(weeklyPut2).toBeDefined();
+			const written2 = JSON.parse(weeklyPut2!.Value);
+			expect(written2.weekStart).toBe(currentWeekStart());
+			expect(written2.total).toBe(6);
+			expect(written2.normal).toBe(5);
+			expect(written2.degraded).toBe(1);
 		});
 
 		it('週が変わった → ハートビート Discord 通知 + 新週の統計を書き込む', async () => {
 			const prev = prevWeekStart();
-			ssmStore.stored = JSON.stringify({
+			ssmStore.params[WEEKLY_STATS_KEY] = JSON.stringify({
 				weekStart: prev,
 				total: 168,
 				normal: 165,
@@ -443,15 +421,16 @@ describe('#1257 health-check Lambda Phase 1', () => {
 			expect(abnormalField?.value).toBe('3 回');
 
 			// SSM に新週の統計が書き込まれる
-			expect(ssmStore.putCalls).toHaveLength(1);
-			const written = JSON.parse(ssmStore.putCalls[0]!.Value);
-			expect(written.weekStart).toBe(currentWeekStart());
-			expect(written.total).toBe(1);
+			const weeklyPut3 = ssmStore.putCalls.find((c) => c.Name === WEEKLY_STATS_KEY);
+			expect(weeklyPut3).toBeDefined();
+			const written3 = JSON.parse(weeklyPut3!.Value);
+			expect(written3.weekStart).toBe(currentWeekStart());
+			expect(written3.total).toBe(1);
 		});
 
 		it('週切替 + 障害 → ハートビート 1 件 + 障害通知 1 件 = 合計 2 件', async () => {
 			const prev = prevWeekStart();
-			ssmStore.stored = JSON.stringify({
+			ssmStore.params[WEEKLY_STATS_KEY] = JSON.stringify({
 				weekStart: prev,
 				total: 10,
 				normal: 10,
@@ -487,11 +466,13 @@ describe('#1257 health-check Lambda Phase 1', () => {
 
 			await handler();
 
-			expect(ssmStore.putCalls).toHaveLength(1);
-			const written = JSON.parse(ssmStore.putCalls[0]!.Value);
-			expect(written.total).toBe(1);
-			expect(written.degraded).toBe(1);
-			expect(written.normal).toBe(0);
+			// degraded 時は setLastNotifiedStatus + setWeeklyStats の 2 回書き込み
+			const weeklyPut5 = ssmStore.putCalls.find((c) => c.Name === WEEKLY_STATS_KEY);
+			expect(weeklyPut5).toBeDefined();
+			const written5 = JSON.parse(weeklyPut5!.Value);
+			expect(written5.total).toBe(1);
+			expect(written5.degraded).toBe(1);
+			expect(written5.normal).toBe(0);
 		});
 	});
 });

--- a/tests/unit/infra/health-check-lambda.test.ts
+++ b/tests/unit/infra/health-check-lambda.test.ts
@@ -4,9 +4,60 @@
 //       代わりに `App Lambda (/api/health)` 論理名が出る
 //   G2. DEGRADED_THRESHOLD_MS が 8000ms になっている (env 未設定時のデフォルト)
 //   G3. 二段プローブ: 1 回目 degraded + 2 回目 ok → 通知 0 件、2 回連続 degraded → 通知 1 件
+// #1469 週次ハートビート:
+//   G4. 週次統計が SSM に累積され、週が変わったら Discord にサマリーが送信される
 
 import * as http from 'node:http';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ----------------------------------------------------------------
+// SSM mock state (mutable — shared between factory closure and tests)
+// vi.mock is hoisted but its factory runs lazily, so this object is
+// already initialized when the factory is first called.
+// ----------------------------------------------------------------
+
+interface SsmStoreState {
+	stored: string | null;
+	putCalls: Array<{ Name: string; Value: string }>;
+}
+const ssmStore: SsmStoreState = { stored: null, putCalls: [] };
+
+vi.mock('@aws-sdk/client-ssm', () => {
+	class ParameterNotFound extends Error {
+		constructor() {
+			super('ParameterNotFound');
+			this.name = 'ParameterNotFound';
+		}
+	}
+	class GetParameterCommand {
+		constructor(public input: { Name: string }) {}
+	}
+	class PutParameterCommand {
+		constructor(public input: { Name: string; Value: string; [k: string]: unknown }) {}
+	}
+	class MockSSMClient {
+		send(cmd: unknown): Promise<unknown> {
+			if (cmd instanceof GetParameterCommand) {
+				if (ssmStore.stored === null) {
+					return Promise.reject(new ParameterNotFound());
+				}
+				return Promise.resolve({ Parameter: { Value: ssmStore.stored } });
+			}
+			if (cmd instanceof PutParameterCommand) {
+				const { Name, Value } = (cmd as PutParameterCommand).input;
+				ssmStore.stored = Value;
+				ssmStore.putCalls.push({ Name, Value });
+				return Promise.resolve({});
+			}
+			return Promise.resolve({});
+		}
+	}
+	return { SSMClient: MockSSMClient, GetParameterCommand, PutParameterCommand, ParameterNotFound };
+});
+
+// ----------------------------------------------------------------
+// Test harness
+// ----------------------------------------------------------------
 
 // @aws-sdk/client-ssm は Lambda ランタイム組み込み。vitest 環境ではモックで代替。
 // send() は常に {} を返す → getLastNotifiedStatus() は Parameter.Value が undefined のため null を返す（初回扱い）。
@@ -127,6 +178,25 @@ async function loadHandler(h: TestHarness, envOverrides: Record<string, string> 
 	return mod.handler;
 }
 
+// Replicates getSundayWeekStart() from the lambda for test assertions
+function currentWeekStart(): string {
+	const d = new Date();
+	d.setUTCDate(d.getUTCDate() - d.getUTCDay());
+	d.setUTCHours(0, 0, 0, 0);
+	return d.toISOString().slice(0, 10);
+}
+
+function prevWeekStart(): string {
+	const d = new Date();
+	d.setUTCDate(d.getUTCDate() - d.getUTCDay() - 7);
+	d.setUTCHours(0, 0, 0, 0);
+	return d.toISOString().slice(0, 10);
+}
+
+// ----------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------
+
 describe('#1257 health-check Lambda Phase 1', () => {
 	let harness: TestHarness | null = null;
 
@@ -141,6 +211,8 @@ describe('#1257 health-check Lambda Phase 1', () => {
 		delete process.env.DEGRADED_THRESHOLD_MS;
 		delete process.env.HEALTH_CHECK_RETRY_DELAY_MS;
 		delete process.env.HEALTH_CHECK_ENVIRONMENT;
+		ssmStore.stored = null;
+		ssmStore.putCalls = [];
 	});
 
 	describe('G1. URL masking', () => {
@@ -288,6 +360,138 @@ describe('#1257 health-check Lambda Phase 1', () => {
 			expect(harness.discordPosts).toHaveLength(0);
 			// probes の残数が 0 (= 1 回しか消費されていない)
 			expect(harness.probes).toHaveLength(0);
+		});
+	});
+
+	describe('G4. 週次ハートビート (#1469)', () => {
+		beforeEach(() => {
+			ssmStore.stored = null;
+			ssmStore.putCalls = [];
+		});
+
+		it('初回実行（SSM なし）→ 今週の統計が SSM に書き込まれる', async () => {
+			harness = await startHarness([{ kind: 'ok' }]);
+			const handler = await loadHandler(harness);
+
+			await handler();
+
+			expect(ssmStore.putCalls).toHaveLength(1);
+			const written = JSON.parse(ssmStore.putCalls[0].Value);
+			expect(written.weekStart).toBe(currentWeekStart());
+			expect(written.total).toBe(1);
+			expect(written.normal).toBe(1);
+			expect(written.degraded).toBe(0);
+			expect(written.down).toBe(0);
+		});
+
+		it('同じ週の 2 回目実行 → カウンタが累積される', async () => {
+			ssmStore.stored = JSON.stringify({
+				weekStart: currentWeekStart(),
+				total: 5,
+				normal: 4,
+				degraded: 1,
+				down: 0,
+				totalResponseMs: 2500,
+			});
+
+			harness = await startHarness([{ kind: 'ok' }]);
+			const handler = await loadHandler(harness);
+
+			await handler();
+
+			// 同週なのでハートビート通知なし
+			expect(harness.discordPosts).toHaveLength(0);
+			expect(ssmStore.putCalls).toHaveLength(1);
+			const written = JSON.parse(ssmStore.putCalls[0].Value);
+			expect(written.weekStart).toBe(currentWeekStart());
+			expect(written.total).toBe(6);
+			expect(written.normal).toBe(5);
+			expect(written.degraded).toBe(1);
+		});
+
+		it('週が変わった → ハートビート Discord 通知 + 新週の統計を書き込む', async () => {
+			const prev = prevWeekStart();
+			ssmStore.stored = JSON.stringify({
+				weekStart: prev,
+				total: 168,
+				normal: 165,
+				degraded: 2,
+				down: 1,
+				totalResponseMs: 252_000,
+			});
+
+			harness = await startHarness([{ kind: 'ok' }]);
+			const handler = await loadHandler(harness);
+
+			await handler();
+
+			// ハートビート通知が 1 件送信される
+			expect(harness.discordPosts).toHaveLength(1);
+			const post = harness.discordPosts[0] as {
+				embeds: Array<{
+					title: string;
+					fields: Array<{ name: string; value: string }>;
+				}>;
+			};
+			const embed = post.embeds[0];
+			if (!embed) throw new Error('embed missing');
+			expect(embed.title).toContain('週次サマリー');
+
+			const totalField = embed.fields.find((f) => f.name === '実行回数');
+			expect(totalField?.value).toBe('168 回');
+			const abnormalField = embed.fields.find((f) => f.name === '異常（degraded + down）');
+			expect(abnormalField?.value).toBe('3 回');
+
+			// SSM に新週の統計が書き込まれる
+			expect(ssmStore.putCalls).toHaveLength(1);
+			const written = JSON.parse(ssmStore.putCalls[0].Value);
+			expect(written.weekStart).toBe(currentWeekStart());
+			expect(written.total).toBe(1);
+		});
+
+		it('週切替 + 障害 → ハートビート 1 件 + 障害通知 1 件 = 合計 2 件', async () => {
+			const prev = prevWeekStart();
+			ssmStore.stored = JSON.stringify({
+				weekStart: prev,
+				total: 10,
+				normal: 10,
+				degraded: 0,
+				down: 0,
+				totalResponseMs: 10_000,
+			});
+
+			harness = await startHarness([
+				{ kind: 'down', statusCode: 500 },
+				{ kind: 'down', statusCode: 500 },
+			]);
+			const handler = await loadHandler(harness);
+
+			await handler();
+
+			// 障害通知 + ハートビートの 2 件
+			expect(harness.discordPosts).toHaveLength(2);
+			// 1 件目: 障害通知
+			const failPost = harness.discordPosts[0] as { embeds: Array<{ title: string }> };
+			expect(failPost.embeds[0]?.title).toContain('down');
+			// 2 件目: ハートビート
+			const heartbeatPost = harness.discordPosts[1] as { embeds: Array<{ title: string }> };
+			expect(heartbeatPost.embeds[0]?.title).toContain('週次サマリー');
+		});
+
+		it('degraded で終わった週 → 統計の degraded カウントが反映される', async () => {
+			harness = await startHarness([
+				{ kind: 'slow', delayMs: 150 },
+				{ kind: 'slow', delayMs: 150 },
+			]);
+			const handler = await loadHandler(harness, { DEGRADED_THRESHOLD_MS: '50' });
+
+			await handler();
+
+			expect(ssmStore.putCalls).toHaveLength(1);
+			const written = JSON.parse(ssmStore.putCalls[0].Value);
+			expect(written.total).toBe(1);
+			expect(written.degraded).toBe(1);
+			expect(written.normal).toBe(0);
 		});
 	});
 });

--- a/tests/unit/infra/health-check-lambda.test.ts
+++ b/tests/unit/infra/health-check-lambda.test.ts
@@ -376,7 +376,7 @@ describe('#1257 health-check Lambda Phase 1', () => {
 			await handler();
 
 			expect(ssmStore.putCalls).toHaveLength(1);
-			const written = JSON.parse(ssmStore.putCalls[0].Value);
+			const written = JSON.parse(ssmStore.putCalls[0]!.Value);
 			expect(written.weekStart).toBe(currentWeekStart());
 			expect(written.total).toBe(1);
 			expect(written.normal).toBe(1);
@@ -402,7 +402,7 @@ describe('#1257 health-check Lambda Phase 1', () => {
 			// 同週なのでハートビート通知なし
 			expect(harness.discordPosts).toHaveLength(0);
 			expect(ssmStore.putCalls).toHaveLength(1);
-			const written = JSON.parse(ssmStore.putCalls[0].Value);
+			const written = JSON.parse(ssmStore.putCalls[0]!.Value);
 			expect(written.weekStart).toBe(currentWeekStart());
 			expect(written.total).toBe(6);
 			expect(written.normal).toBe(5);
@@ -444,7 +444,7 @@ describe('#1257 health-check Lambda Phase 1', () => {
 
 			// SSM に新週の統計が書き込まれる
 			expect(ssmStore.putCalls).toHaveLength(1);
-			const written = JSON.parse(ssmStore.putCalls[0].Value);
+			const written = JSON.parse(ssmStore.putCalls[0]!.Value);
 			expect(written.weekStart).toBe(currentWeekStart());
 			expect(written.total).toBe(1);
 		});
@@ -488,7 +488,7 @@ describe('#1257 health-check Lambda Phase 1', () => {
 			await handler();
 
 			expect(ssmStore.putCalls).toHaveLength(1);
-			const written = JSON.parse(ssmStore.putCalls[0].Value);
+			const written = JSON.parse(ssmStore.putCalls[0]!.Value);
 			expect(written.total).toBe(1);
 			expect(written.degraded).toBe(1);
 			expect(written.normal).toBe(0);


### PR DESCRIPTION
## Summary

- `infra/lambda/health-check/index.ts`: SSM Parameter Store に週次実行統計を保存し、週が切り替わる際に Discord へ週次サマリー（ハートビート）を通知する機能を追加
- `infra/lib/ops-stack.ts`: `/ganbari-quest/health-check/weekly-stats` SSM パラメータを CDK で定義し、Lambda に IAM 読み書き権限を付与。`SSM_WEEKLY_STATS_PARAM` 環境変数を注入
- `tests/unit/infra/health-check-lambda.test.ts`: `vi.mock('@aws-sdk/client-ssm')` でコントローラブルな SSM モックを導入し、週次統計 G4 テスト 5 件を追加（計 15 テスト全通過）
- `package.json`: `@aws-sdk/client-ssm` を production dependency に追加（Vite import-analysis 対策）

## 実装の要点

**週の起点**: 日曜 00:00 UTC = 月曜 09:00 JST（`getSundayWeekStart(date)`）

**実行フロー**（毎回）:
1. `getWeeklyStats()`: SSM から前回統計を取得（なければ `null`）
2. `weekStart` が今週と異なる → `notifyDiscordHeartbeat(prevStats)` 送信 → 新週統計で上書き
3. 同週 → カウンタ累積で上書き

**Discord ハートビート embed**: 期間・実行回数・正常数・異常数（degraded+down）・平均応答時間・環境

## Test plan

- [x] `npx vitest run tests/unit/infra/health-check-lambda.test.ts` — 15/15 pass
- [x] `npx biome check` 対象ファイル — クリーン
- [ ] CDK synth でスタック変更確認（CI で自動検証）
- [ ] Lambda デプロイ後、EventBridge 手動 Invoke で SSM パラメータが書き込まれることを確認

## スクリーンショット / ビジュアルデモ

Lambda のみの変更のため UI スクリーンショットなし。

Closes #1469

🤖 Generated with [Claude Code](https://claude.com/claude-code)