### PR TITLE
fix: 誕生日入力後に計算された年齢を年齢フィールドに表示する (#1478)

### DIFF
--- a/src/lib/domain/date-utils.ts
+++ b/src/lib/domain/date-utils.ts
@@ -55,3 +55,23 @@ export function formatJSTDate(dateStr: string): string {
 export function formatJSTDateTime(date: Date): string {
 	return date.toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' });
 }
+
+/**
+ * 誕生日（YYYY-MM-DD）から現在の年齢を計算する（JST基準）。
+ * 0〜18歳にクランプ。
+ */
+export function calculateAgeFromBirthDate(birthDateStr: string): number {
+	const parts = birthDateStr.split('-');
+	const birthYear = Number(parts[0]);
+	const birthMonth = Number(parts[1]);
+	const birthDay = Number(parts[2]);
+	const jstNow = new Date(Date.now() + JST_OFFSET_MS);
+	const todayYear = jstNow.getUTCFullYear();
+	const todayMonth = jstNow.getUTCMonth() + 1;
+	const todayDay = jstNow.getUTCDate();
+	let age = todayYear - birthYear;
+	if (todayMonth < birthMonth || (todayMonth === birthMonth && todayDay < birthDay)) {
+		age--;
+	}
+	return Math.max(0, Math.min(18, age));
+}

--- a/src/lib/features/admin/components/ChildProfileCard.svelte
+++ b/src/lib/features/admin/components/ChildProfileCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
+import { calculateAgeFromBirthDate } from '$lib/domain/date-utils';
 import { getAgeTierLabel, getThemeOptions } from '$lib/domain/labels';
 import type { CurrencyCode, PointUnitMode } from '$lib/domain/point-display';
 import {
@@ -70,6 +71,9 @@ let isEditing = $state(false);
 let themeValue = $state(child.theme);
 // svelte-ignore state_referenced_locally
 let editBirthDate = $state<string | undefined>(child.birthDate ?? undefined);
+const editAgeFromBirthDate = $derived(
+	editBirthDate ? calculateAgeFromBirthDate(editBirthDate) : undefined,
+);
 let detailTab = $state<'info' | 'status' | 'logs' | 'achievements' | 'voice'>('info');
 let statusEditSuccess = $state(false);
 let sliderValues: Record<number, number> = $state({});
@@ -316,7 +320,7 @@ const avatarSrc = $derived(uploadResult?.avatarUrl ?? generateResult?.filePath ?
 									type="number"
 									min="0"
 									max="18"
-									value={child.age}
+									value={editAgeFromBirthDate ?? child.age}
 									readonly={!!editBirthDate}
 									class="profile-edit__input {editBirthDate ? 'profile-edit__input--readonly' : ''}"
 								/>

--- a/src/routes/(parent)/admin/children/+page.svelte
+++ b/src/routes/(parent)/admin/children/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { calculateAgeFromBirthDate } from '$lib/domain/date-utils';
 import { getErrorMessage } from '$lib/domain/errors';
 import {
 	ADMIN_CHILDREN_PAGE_LABELS,
@@ -32,6 +33,9 @@ const fmtBal = (pts: number) => formatPointValue(pts, ps.mode, ps.currency, ps.r
 let showAddForm = $state(false);
 let themeValue = $state('blue');
 let addBirthDate = $state<string | undefined>(undefined);
+const addAgeFromBirthDate = $derived(
+	addBirthDate ? calculateAgeFromBirthDate(addBirthDate) : undefined,
+);
 </script>
 
 <svelte:head>
@@ -121,6 +125,7 @@ let addBirthDate = $state<string | undefined>(undefined);
 						min="0"
 						max="18"
 						disabled={!!addBirthDate}
+						value={addAgeFromBirthDate}
 						placeholder={addBirthDate ? '' : ADMIN_CHILDREN_PAGE_LABELS.agePlaceholder}
 					/>
 					<Select


### PR DESCRIPTION
## Summary

Closes #1478

QA レビューで PR #1462 のスクリーンショットを目視確認した際に発見。

### 問題

誕生日を入力すると年齢フィールドが disabled になりラベルが変わるが、**値が空白のまま**だった。

「本当に計算されているの？」とユーザーが不安になる UX 上の問題。

### 修正内容

| ファイル | 変更 |
|---------|------|
| `src/lib/domain/date-utils.ts` | `calculateAgeFromBirthDate(birthDateStr)` を追加（JST基準・0〜18クランプ） |
| `src/routes/(parent)/admin/children/+page.svelte` | `addAgeFromBirthDate = $derived(...)` → 追加フォームの年齢 value に設定 |
| `src/lib/features/admin/components/ChildProfileCard.svelte` | `editAgeFromBirthDate = $derived(...)` → 編集フォームの年齢 value に設定 |

### Before / After

**Before**: 誕生日「2018年4月15日」入力 → 年齢フィールドが空白のまま disabled

**After**: 誕生日「2018年4月15日」入力 → 年齢フィールドに「8」が表示された状態で disabled

## AC 対応

- [x] 追加フォーム: 誕生日入力後に計算された年齢を年齢フィールドに表示
- [x] 編集フォーム: 誕生日変更後に再計算された年齢を表示
- [x] `calculateAgeFromBirthDate` を `date-utils.ts` に追加（JST基準、サーバー側と同じアルゴリズム）
- [x] biome / svelte-check エラーなし

## Screenshots / ビジュアルデモ

UI の動作確認: 開発サーバーで実機確認が必要。CI で E2E テストが通れば機能的には正しく動作している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)