### PR TITLE
lp: #1302 年齢モード表記を 5 → 4 コアモード + 準備モードに変更

### DIFF
--- a/scripts/generate-lp-labels.mjs
+++ b/scripts/generate-lp-labels.mjs
@@ -152,16 +152,19 @@ function generateSharedLabelsJs() {
 	const { ageTierLabels, ageTierShort, planLabels, lpRetentionLabels } = parseLabelsTs();
 	const ageTierConfig = parseAgeTierTs();
 
+	// LP-specific label overrides (ADR-0011: baby = 準備モード in LP context)
+	const LP_NAME_OVERRIDES = { baby: '準備モード' };
+	const LP_FORMAL_OVERRIDES = { baby: '準備モード（0〜2歳）' };
+
 	// 各年齢区分の name / range / formal / ageMin / ageMax を統合
 	const ageTiers = {};
 	for (const mode of ['baby', 'preschool', 'elementary', 'junior', 'senior']) {
-		const formal = ageTierLabels[mode];
+		const formal = LP_FORMAL_OVERRIDES[mode] ?? ageTierLabels[mode];
 		const range = ageTierShort[mode];
 		const config = ageTierConfig[mode];
-		// name は formal の括弧より前の部分 + 'モード'
 		const baseName = formal.split('（')[0];
 		ageTiers[mode] = {
-			name: `${baseName}モード`,
+			name: LP_NAME_OVERRIDES[mode] ?? `${baseName}モード`,
 			range,
 			formal,
 			ageMin: config.ageMin,

--- a/scripts/take-lp-screenshots.mjs
+++ b/scripts/take-lp-screenshots.mjs
@@ -43,7 +43,6 @@ const TARGET_MODE = args.mode || null;
 const OUTPUT_DIR = COMPARE_MODE ? STAGING_DIR : PROD_DIR;
 
 const AGE_MODES = [
-	{ mode: 'baby', filePrefix: 'age-baby', label: '乳幼児 (0-2歳)' },
 	{ mode: 'preschool', filePrefix: 'age-kinder', label: '幼児 (3-5歳)' },
 	{ mode: 'elementary', filePrefix: 'age-lower', label: '小学生 (6-12歳)' },
 	{ mode: 'junior', filePrefix: 'age-upper', label: '中学生 (13-15歳)' },

--- a/site/index.html
+++ b/site/index.html
@@ -306,25 +306,18 @@
 <section class="section bg-white" id="age-switcher">
   <div class="section-inner">
     <h2 class="section-title">お子さまの年齢で、画面とむずかしさが変わります</h2>
-    <p class="section-desc">0 歳から 18 歳まで、5 つのモードが自動で切り替わり。<br>タップで「今のお子さまに合う UI」をご覧ください。</p>
+    <p class="section-desc">3 歳から 18 歳まで、4 つのコアモードが自動で切り替わり。<br>タップで「今のお子さまに合う UI」をご覧ください。</p>
+    <p class="section-sub-note" style="text-align:center;font-size:.88rem;color:var(--gray-500);margin-top:-.5rem;margin-bottom:1.5rem">
+      0-2 歳のお子様は「準備モード」でご登録いただけます。<a href="faq.html#baby-mode" style="color:var(--brand-700)">詳しくはこちら</a>
+    </p>
     <div class="age-switcher">
       <div class="age-tabs" role="tablist">
-        <button type="button" class="age-tab active" data-age="baby" role="tab" aria-selected="true">乳幼児 (0-2)</button>
-        <button type="button" class="age-tab" data-age="kinder" role="tab" aria-selected="false">幼児 (3-5)</button>
+        <button type="button" class="age-tab active" data-age="kinder" role="tab" aria-selected="true">幼児 (3-5)</button>
         <button type="button" class="age-tab" data-age="lower" role="tab" aria-selected="false">小学生 (6-12)</button>
         <button type="button" class="age-tab" data-age="upper" role="tab" aria-selected="false">中学生 (13-15)</button>
         <button type="button" class="age-tab" data-age="teen" role="tab" aria-selected="false">高校生 (16-18)</button>
       </div>
-      <div class="age-panel active" data-panel="baby" role="tabpanel">
-        <div class="age-panel-shot"><img src="screenshots/age-baby.webp" alt="乳幼児向け画面" data-lightbox></div>
-        <div class="age-panel-body">
-          <h3>大きなタップ領域・シンプルな色</h3>
-          <span class="age-panel-feature">代表機能: 絵本のようなシール帳</span>
-          <p class="age-panel-desc">トイレやおむつ交換など、親が記録する活動を中心に設計。シールをタップするたびにアニメーションで「できたね！」を祝います。</p>
-          <p class="age-panel-cta"><a href="https://ganbari-quest.com/demo" class="btn btn-demo">デモを見る</a></p>
-        </div>
-      </div>
-      <div class="age-panel" data-panel="kinder" role="tabpanel">
+      <div class="age-panel active" data-panel="kinder" role="tabpanel">
         <div class="age-panel-shot"><img src="screenshots/age-kinder.webp" alt="幼児向け画面" data-lightbox></div>
         <div class="age-panel-body">
           <h3>ひらがな中心・丸みのあるボタン</h3>

--- a/site/pamphlet.html
+++ b/site/pamphlet.html
@@ -579,11 +579,11 @@ body{font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN','Noto Sans JP',syst
 
   <!-- Age Modes -->
   <div class="front-ages">
-    <h2>&#x1F308; 0歳から18歳まで &#8212; 5つの年齢モード</h2>
+    <h2>&#x1F308; 3歳から18歳まで &#8212; 4つのコアモード + 準備モード</h2>
     <div class="age-row">
       <div class="age-item" data-age-tier="baby">
         <div class="ai-emoji">&#x1F476;</div>
-        <div class="ai-name" data-label="age-tier-name">乳幼児モード</div>
+        <div class="ai-name" data-label="age-tier-name">準備モード</div>
         <div class="ai-range" data-label="age-tier-range">0&#x301C;2歳</div>
       </div>
       <div class="age-item" data-age-tier="preschool">

--- a/site/shared-labels.js
+++ b/site/shared-labels.js
@@ -22,9 +22,9 @@
 
 	const AGE_TIERS = {
 		"baby": {
-			"name": "乳幼児モード",
+			"name": "準備モード",
 			"range": "0〜2歳",
-			"formal": "乳幼児（0〜2歳）",
+			"formal": "準備モード（0〜2歳）",
 			"ageMin": 0,
 			"ageMax": 2
 		},


### PR DESCRIPTION
## Summary

- `site/index.html`: age switcher から baby タブ/パネルを削除し、幼児 (3-5) をデフォルト表示に変更。0-2 歳向けに「準備モード」案内注記を追加
- `site/pamphlet.html`: 見出しを「5つの年齢モード」→「4つのコアモード + 準備モード」に変更、乳幼児モード→準備モードに更新
- `site/shared-labels.js`: baby の `name`/`formal` を「準備モード」に更新（ジェネレーター再実行済み）
- `scripts/generate-lp-labels.mjs`: `LP_NAME_OVERRIDES` / `LP_FORMAL_OVERRIDES` を追加し baby を「準備モード」として再生成可能に（ADR-0011 準拠）
- `scripts/take-lp-screenshots.mjs`: `AGE_MODES` から baby エントリを削除

## AC チェック

- [x] `site/index.html` の age switcher から baby タブが除去されている
- [x] 準備モードへの案内リンク 1 本が存在する（`faq.html#baby-mode`）
- [x] `site/pamphlet.html` も同期（「4つのコアモード + 準備モード」）
- [x] `site/shared-labels.js` で baby が準備モードとして別扱いされている
- [x] `scripts/take-lp-screenshots.mjs` が新体系で動作（baby エントリ削除）
- [x] `scripts/measure-lp-dimensions.mjs` 閾値内（mobileHeight: 13174 < 15000, desktopHeight: 7791 < 8000）
- [x] PC / モバイル screenshot 添付（下記）
- [ ] Playwright LP smoke — CI で確認
- [x] ADR-0011 の「baby = 親の準備モード」と整合

## スクリーンショット / ビジュアルデモ

> 自己判定: baby タブが消え、幼児 (3-5) がデフォルト表示。準備モード案内テキスト（グレー小文字）が正しく表示されている。モバイルでも 2×2 グリッドで 4 タブが整列している。

**PC (1280px) — 4 タブ + 準備モード案内**

baby タブ（乳幼児 0-2）が除去され、幼児 (3-5) がデフォルト active になった。
「0-2 歳のお子様は「準備モード」でご登録いただけます。詳しくはこちら」の案内テキストを確認。

**Mobile (390px) — 4 タブ 2×2 グリッド**

幼児 / 小学生 / 中学生 / 高校生 の 4 タブが 2×2 で整列。baby タブなし。

## Test plan

- [x] `node scripts/measure-lp-dimensions.mjs` → `[OK] all LP metrics within thresholds`
- [x] `node scripts/check-hardcoded-strings.mjs` → baseline 内（500 件、増加なし）
- [x] `node scripts/generate-lp-labels.mjs` → `site/shared-labels.js` が準備モードで再生成される
- [ ] CI (lp-metrics.yml) 緑確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)