### PR TITLE
docs(#1379): §13 実装乖離修正 — uiModeManuallySet を Committed に更新

### DIFF
--- a/docs/design/26-ゲーミフィケーション設計書.md
+++ b/docs/design/26-ゲーミフィケーション設計書.md
@@ -380,7 +380,7 @@ async function stampToday(tenantId, childId): Promise<StampResult | 'ALREADY_STA
 | `child.birthDate` | `TEXT` (YYYY-MM-DD), nullable | **誕生日 SSOT**。入力された場合は年齢の唯一の真実の源 |
 | `child.age` | `INTEGER` | 年齢キャッシュ。`birthDate` がある場合は `calculateAge(birthDate)` で計算。ない場合はユーザー直接入力値 |
 | `child.uiMode` | `TEXT` ('baby'\|'preschool'\|'elementary'\|'junior'\|'senior') | 年齢 UI モード。`getDefaultUiMode(age)` から導出。誕生日ボーナス claim 時に自動更新 |
-| `child.uiModeManuallySet` | — | **未実装 (Aspirational / Sub B-4)**。親が uiMode を手動設定したフラグ。将来の年齢自動インクリメント cron で更新対象外にする |
+| `child.uiModeManuallySet` | `INTEGER` (0 or 1), default 0 | **Committed (#1382, PR #1463 実装済み)**。親が uiMode を明示的に選択したフラグ。`1` の場合、age 変更時の `uiMode` 自動再計算をスキップする |
 
 ### 13.2 年齢から uiMode へのマッピング
 
@@ -410,24 +410,32 @@ birthDate 入力なし (年齢のみ):
   child.uiMode    = getDefaultUiMode(age)
 ```
 
-#### 子供更新時 (`/admin/children` POST ?/update)
+#### 子供更新時 (`/admin/children` POST ?/update を経由した `child-service.editChild()`)
 
 ```
+uiMode が明示指定された場合:
+  child.uiMode            = 指定値
+  child.uiModeManuallySet = 1          ← 手動設定フラグを立てる
+
+age が変更された場合 (uiMode 未指定):
+  child.age = Number(ageStr)
+  child.uiMode = recalcUiMode(existing, newAge):
+    uiModeManuallySet = 1 → 既存 uiMode を維持 (保護者 overrides 尊重)
+    uiModeManuallySet = 0 → getDefaultUiMode(newAge) で自動再計算
+
 birthDate が変更された場合:
   child.birthDate = birthDate (または null)
-  birthDate あり → child.age = calculateAge(birthDate)
-  birthDate なし → child.age = Number(ageStr) (入力があれば)
-
-birthDate が変更されない場合:
-  child.age = Number(ageStr) (入力があれば)
+  birthDate あり → child.age = calculateAge(birthDate) → uiMode も recalcUiMode で更新
+  birthDate なし → child.age = Number(ageStr) (入力があれば) → uiMode も recalcUiMode で更新
 ```
 
-#### 誕生日ボーナス claim 時 (`/api/cron/birthday-bonus` or 子供画面)
+#### 誕生日ボーナス claim 時 (`birthday-bonus-service.claimBirthdayBonus()`)
 
 ```
 claimBirthdayBonus():
   child.age                   = calculateAge(birthDate, today)
-  child.uiMode                = getDefaultUiMode(newAge)      ← 常に上書き (manuallySet 未実装)
+  child.uiMode                = getDefaultUiMode(newAge)      ← uiModeManuallySet に関わらず常に上書き
+                                                                 (ポリシー: 誕生日は節目、保護者が必要なら再設定)
   child.lastBirthdayBonusYear = currentYear                   ← 重複 claim 防止
   PointEntry 追加             = age × 100 × birthdayBonusMultiplier
 ```
@@ -445,8 +453,9 @@ claimBirthdayBonus():
 - `birthDate` は YYYY-MM-DD 形式のみ許可
 - `birthDate` が未来日の場合はエラー
 - `age` は 0 〜 18 の整数のみ許可
-- 現状: `birthDate` と `age` は**どちらか片方の入力で登録可能**（両方入力した場合は `birthDate` 優先）
-- **Issue**: 両方未入力でも登録できてしまう状態が implicit（Sub B-2 で「どちらか必須」チェックを追加）
+- `birthDate` と `age` は**どちらか片方の入力が必須**（#1380, PR #1462 で実装済み）
+- 両方入力した場合は `birthDate` 優先（`age` は `calculateAge(birthDate)` で上書き）
+- `birthDate` 入力時は `age` 欄を disabled にして自動計算値を表示
 
 ### 13.6 誕生日ボーナスの演出（Committed）
 
@@ -477,10 +486,24 @@ claimBirthdayBonus():
 
 | ファイル | 役割 |
 |---------|------|
-| `src/lib/domain/validation/age-tier.ts` | `getDefaultUiMode()` / `UiMode` 型 |
-| `src/lib/server/services/birthday-bonus-service.ts` | `calculateAge()` / `claimBirthdayBonus()` |
+| `src/lib/domain/validation/age-tier.ts` | `getDefaultUiMode()` / `recalcUiMode()` / `UiMode` 型 |
+| `src/lib/server/services/child-service.ts` | `editChild()` — `uiModeManuallySet` を考慮した `recalcUiMode()` 呼出し |
+| `src/lib/server/services/birthday-bonus-service.ts` | `calculateAge()` / `claimBirthdayBonus()` — age + uiMode 更新 |
 | `src/routes/(parent)/admin/children/+page.server.ts` | 子供登録・更新フォームのバリデーション |
 | `src/lib/server/db/child-repo.ts` | DB アクセス (`updateChild`) |
+| `src/lib/server/db/schema.ts` | `children` テーブル: `uiModeManuallySet` カラム定義 |
+
+### 13.9 birthday-bonus-service との責務分担
+
+`birthday-bonus-service.claimBirthdayBonus()` と `child-service.editChild()` は age/uiMode 更新ロジックをそれぞれ持つ。以下のルールで責務を分離する。
+
+| 操作 | 担当サービス | uiModeManuallySet の考慮 |
+|------|------------|------------------------|
+| 保護者が管理画面で age / uiMode を編集 | `child-service.editChild()` | 考慮する。`recalcUiMode()` 経由 |
+| 誕生日ボーナス claim (子供画面 / cron) | `birthday-bonus-service.claimBirthdayBonus()` | **考慮しない**。誕生日は成長の節目のため `getDefaultUiMode()` で常に上書き |
+| 年齢自動インクリメント cron (Sub B-3、**未実装**) | `age-recalc-service` (未実装) | 考慮する予定。`recalcUiMode()` を使用する設計 |
+
+**ポリシー根拠**: 誕生日ボーナス claim 時は成長の節目であるため、年齢帯 UI を自動追従させることを優先する。保護者が UI を特定年齢帯に固定したい場合は、ボーナス受取後に管理画面から再設定する。
 
 ---
 

--- a/docs/design/parallel-implementations.md
+++ b/docs/design/parallel-implementations.md
@@ -254,20 +254,23 @@ grep -n "bottom-nav\|data-testid" src/lib/ui/components/BottomNav.svelte
 
 | 場所 | 内容 |
 |------|------|
-| `child.birthDate` / `child.age` / `child.uiMode` | DB カラム（SSOT 優先度: birthDate > age > uiMode） |
-| `src/lib/domain/validation/age-tier.ts` | `getDefaultUiMode(age)` — uiMode 導出ロジック |
+| `child.birthDate` / `child.age` / `child.uiMode` / `child.uiModeManuallySet` | DB カラム（SSOT 優先度: birthDate > age > uiMode） |
+| `src/lib/domain/validation/age-tier.ts` | `getDefaultUiMode(age)` / `recalcUiMode()` — uiMode 導出ロジック |
+| `src/lib/server/services/child-service.ts` | `editChild()` — `uiModeManuallySet` を考慮した `recalcUiMode()` 呼出し |
 | `src/lib/server/services/birthday-bonus-service.ts` | `calculateAge()` / `claimBirthdayBonus()` — age 更新 + uiMode 再計算 |
 | `src/routes/(parent)/admin/children/+page.server.ts` | 子供登録・更新フォームの age/birthDate バリデーション |
 | `docs/design/26-ゲーミフィケーション設計書.md §13` | 仕様 SSOT |
 
 **同期メカニズム**:
-- `birthDate` が変化した場合は必ず `calculateAge(birthDate)` で age を再計算し、`getDefaultUiMode(age)` で uiMode も更新する
-- `uiModeManuallySet` フラグが導入された後は、`false` の場合のみ自動更新する（Sub B-4、未実装）
+- `birthDate` が変化した場合は必ず `calculateAge(birthDate)` で age を再計算し、`recalcUiMode()` で uiMode も更新する
+- `uiModeManuallySet = 1` (保護者が明示設定) の場合は age 変更時も uiMode を維持する。`recalcUiMode()` がこの判断を担う（#1382, PR #1463 実装済み）
+- 誕生日ボーナス claim 時は `uiModeManuallySet` に関わらず uiMode を上書きする（設計ポリシー: 誕生日は成長の節目）
 
 **修正時チェック**:
 - [ ] birthDate / age バリデーション変更 → `children/+page.server.ts` と `birthday-bonus-service.ts` の両方を確認
 - [ ] `getDefaultUiMode` の年齢境界変更 → `age-tier.ts` 1 箇所（副作用: 全 child の uiMode が次回更新時に変化する）
-- [ ] age 自動インクリメント実装 (Sub B-3) → `schedule-registry.ts` に cron 登録 + E2E テスト追加
+- [ ] `uiModeManuallySet` ロジック変更 → `age-tier.ts` の `recalcUiMode()` と `child-service.ts` の `editChild()` の両方を確認
+- [ ] age 自動インクリメント実装 (Sub B-3) → `schedule-registry.ts` に cron 登録 + `recalcUiMode()` 使用 + E2E テスト追加
 
 ---
 


### PR DESCRIPTION
## Summary

PR #1460 でマージした設計書 §13 では、`uiModeManuallySet` を「未実装 (Aspirational / Sub B-4)」と誤記していた。その後 #1382 (PR #1463, 2026-04-24 マージ) で実装済みになっていたが、設計書が更新されていなかった。

## 変更内容

### `26-ゲーミフィケーション設計書.md §13`

- **§13.1**: `uiModeManuallySet` の型を `INTEGER (0 or 1)` に明記、状態を **Committed (#1382, PR #1463)** に変更
- **§13.3 子供更新時**: `child-service.editChild()` 経由の `recalcUiMode()` ロジックを追記
  - `uiMode` 明示指定時は `uiModeManuallySet = 1` を立てる
  - age 変更時は `recalcUiMode()` で manuallySet フラグを考慮して自動再計算
- **§13.3 誕生日 claim 時**: `manuallySet` に関わらず常に上書きするポリシーを明記（コメントの `manuallySet 未実装` を削除）
- **§13.5**: Sub B-2 (#1380, PR #1462) 実装済みとして「どちらか必須」表現を更新
- **§13.8**: `child-service.ts` / `recalcUiMode()` / `schema.ts` を実装ファイルに追加
- **§13.9 新設**: `birthday-bonus-service` との責務分担テーブル（Issue #1379 AC 項目6）

### `parallel-implementations.md §10`

- `uiModeManuallySet` を並行実装ペアのカラム一覧に追加
- 同期メカニズムを `recalcUiMode()` 実装後の正確な状態に更新
- 修正時チェックリストに `recalcUiMode()` 変更時の確認項目を追加

## 動機

ADR-0001 (設計書 SSOT) に従い、実装と乖離した設計書は「仕様が存在しない」のと同義。Sub B-3 実装時に本設計書を参照できる粒度を維持する。

## Issue AC 確認

- [x] `§13` に 6 項目（データモデル/状態遷移/SSOT/フォーム UX/自動インクリメント/既存サービス関係）を記載
- [x] Committed（実装済み）と Aspirational（未実装）を明確に区別
- [x] 既存の implicit 仕様（`uiModeManuallySet` の実装状況）を明示化
- [x] Sub B-2/B-3/B-4 の実装時に本設計書を参照できる粒度を維持

## AC 検証マップ

| AC 番号 | AC 内容 | 検証方法 | 結果 |
|---------|---------|---------|------|
| AC-1 | `26-ゲーミフィケーション設計書.md §13` を拡張 (案 A 採用) | PR diff で §13 の変更を確認 | §13.1〜§13.9 まで拡張済み |
| AC-2 | 6 項目（データモデル/状態遷移/SSOT/フォーム UX/自動インクリメント/既存サービス関係）を記載 | §13.1〜§13.9 の各節を確認 | §13.1(データモデル) §13.3(状態遷移) §13.4(SSOT) §13.5(フォーム UX) §13.7(自動インクリメント) §13.9(既存サービス関係) 全て記載済み |
| AC-3 | Committed と Aspirational を明確に区別 | §13.1 の `uiModeManuallySet` 行と §13.7 ヘッダーを確認 | §13.1: Committed (#1382) / §13.7: Aspirational (Sub B-3 未実装) と明示区別済み |
| AC-4 | Sub B-2/B-3/B-4 の実装時に参照できる粒度 | §13.8 実装ファイル参照と §13.9 責務分担テーブルを確認 | `child-service.ts` / `recalcUiMode()` / `schema.ts` を追記、責務分担テーブル新設済み |
| AC-5 | 既存の implicit 仕様（誕生日優先で年齢破棄等）を明示化 | §13.5 フォーム UX バリデーション節を確認 | 「どちらか必須」が PR #1462 で実装済みと明記、誕生日優先ポリシーも明示済み |

## スクリーンショット

docs-only 変更のため不要

closes #1379

🤖 Generated with [Claude Code](https://claude.com/claude-code)