### PR TITLE
fix(#1483): generate-marketing-images.mjs を brand-style-guide.js SSOT に準拠

### DIFF
--- a/scripts/generate-marketing-images.mjs
+++ b/scripts/generate-marketing-images.mjs
@@ -8,7 +8,11 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { GoogleGenAI } from '@google/genai';
+import { BRAND_STYLE_BLOCK, NEGATIVE_PROMPTS } from './lib/brand-style-guide.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const API_KEY = process.env.GEMINI_API_KEY;
 if (!API_KEY) {
@@ -18,17 +22,27 @@ if (!API_KEY) {
 }
 
 const ai = new GoogleGenAI({ apiKey: API_KEY });
-const LOGO_PATH = path.resolve('site/icon-character.png');
+
+// 参照画像: brand/master-character-sheet.png → fallback: site/icon-character.png
+const MASTER_SHEET = path.resolve(
+	__dirname,
+	'..',
+	'static/assets/brand/master-character-sheet.png',
+);
+const LOGO_PATH = fs.existsSync(MASTER_SHEET)
+	? MASTER_SHEET
+	: path.resolve(__dirname, '..', 'site/icon-character.png');
 
 // Ensure output directories exist
-const MARKETING_DIR = path.resolve('static/assets/marketing');
-const SITE_DIR = path.resolve('site');
+const MARKETING_DIR = path.resolve(__dirname, '..', 'static/assets/marketing');
+const SITE_DIR = path.resolve(__dirname, '..', 'site');
 fs.mkdirSync(MARKETING_DIR, { recursive: true });
 
 // Load reference character image
 const logoBase64 = fs.readFileSync(LOGO_PATH).toString('base64');
 
-const COMMON_STYLE = `
+// brand-style-guide.js の BRAND_STYLE_BLOCK をベースに marketing 向け追加指示を付加
+const COMMON_STYLE = `${BRAND_STYLE_BLOCK}
 STYLE REQUIREMENTS (CRITICAL):
 - Use the same art style as the reference character (cute anime/chibi style with golden helmet, blue cape, magic wand with star)
 - The character from the reference image MUST be the main element — a cute child adventurer
@@ -39,7 +53,7 @@ STYLE REQUIREMENTS (CRITICAL):
 - NOT transparent background — use soft gradient backgrounds
 - The overall feeling should be warm, inviting, and adventurous
 - Bright, cheerful color palette
-`;
+${NEGATIVE_PROMPTS}`;
 
 const IMAGES = [
 	{


### PR DESCRIPTION
## 顧客価値・目的

#1483 ブランドビジュアル SSOT 確立の仕上げ。`generate-marketing-images.mjs` が独自のスタイル定数を持っており SSOT 原則に違反していたため、`scripts/lib/brand-style-guide.js` から `BRAND_STYLE_BLOCK` と `NEGATIVE_PROMPTS` をインポートする形に修正。

closes #1483

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 |
|----|------|---------|------|
| A-1〜A-6 | gemini_image_generation_guide.md 全セクション | ファイル読込 | ✓ 全セクション確認済み |
| B | master-character-sheet.png 存在 | ls確認 | ✓ static/assets/brand/ に存在 |
| C | generate-image.mjs CLI 動作 | --dry-run 確認 | ✓ |
| C (fix) | generate-marketing-images.mjs が brand-style-guide.js を参照 | 本PR変更 | ✓ |
| D | asset-catalog.md 全エントリにプロンプト列 | ファイル読込 | ✓ |
| E | レビューチェックリスト存在 | ファイル読込 | ✓ |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲

- `scripts/generate-marketing-images.mjs` のみ（実行時動作は同一）

## スクリーンショット

UI 変更なし。N/A

## 破壊的変更

なし