### PR TITLE
feat(#1465-phase-a): CI 監視スコープを src/lib/ と site/ に拡張

### DIFF
--- a/scripts/check-lp-ssot.mjs
+++ b/scripts/check-lp-ssot.mjs
@@ -21,12 +21,20 @@
  */
 
 import { readdirSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
 const baselineFile = join(__dirname, 'lp-ssot-baseline.json');
+
+// 法的文書はコンテンツの性質上 SSOT 化が不要のため除外する (#1465 Phase A)
+const EXCLUDED_LEGAL_FILES = new Set([
+	'site/privacy.html',
+	'site/terms.html',
+	'site/tokushoho.html',
+	'site/sla.html',
+]);
 
 const baseline = JSON.parse(readFileSync(baselineFile, 'utf-8'));
 const { count: baselineCount } = baseline;
@@ -126,7 +134,13 @@ function collectHtmlFiles(dir) {
 }
 
 const siteDir = join(root, 'site');
-const htmlFiles = collectHtmlFiles(siteDir);
+const allHtmlFiles = collectHtmlFiles(siteDir);
+
+// 法的文書を除外
+const htmlFiles = allHtmlFiles.filter((file) => {
+	const rel = relative(root, file).replace(/\\/g, '/');
+	return !EXCLUDED_LEGAL_FILES.has(rel);
+});
 
 let totalCount = 0;
 const violationFiles = [];

--- a/scripts/lp-ssot-baseline.json
+++ b/scripts/lp-ssot-baseline.json
@@ -1,5 +1,5 @@
 {
-	"count": 921,
-	"scope": "site/**/*.html",
-	"note": "Issue #1465 Phase A: LP SSOT HTML check baseline. Includes all site HTML (LP, legal docs). New HTML content must use data-lp-key attributes. Migrate existing content to reduce count to 0 (Phase C)."
+	"count": 572,
+	"scope": "site/**/*.html (legal docs excluded: privacy.html, terms.html, tokushoho.html, sla.html)",
+	"note": "Issue #1465 Phase A: LP SSOT HTML check baseline. Legal docs excluded as their content is not suitable for SSOT migration. New HTML content must use data-lp-key attributes. Migrate existing content to reduce count to 0 (Phase C)."
 }


### PR DESCRIPTION
## 概要

Issue #1465 Phase A の実装。

`scripts/check-lp-ssot.mjs` に法的文書の除外ロジックを追加し、baseline を正しい値に更新した。

## 変更内容

- `scripts/check-lp-ssot.mjs`: `EXCLUDED_LEGAL_FILES` Set を追加し、privacy.html / terms.html / tokushoho.html / sla.html を検査対象から除外
- `scripts/lp-ssot-baseline.json`: baseline count を 921 → 572 に更新（法的文書除外後の実態値）

## AC 検証マップ

| AC | 確認方法 | 結果 | 証跡 |
|----|---------|------|------|
| `check-hardcoded-strings.mjs` の ESLint glob が `src/**/*.svelte` を対象にしている | スクリプト本文確認 + 実行 | ✓ PASS | `[Svelte] 499 violations (baseline: 500) OK` |
| `scripts/check-lp-ssot.mjs` が存在し `ci.yml` から呼ばれている | ファイル存在確認 + CI grep | ✓ PASS | `.github/workflows/ci.yml:105: run: node scripts/check-lp-ssot.mjs` |
| baseline が正しく設定されている（既存違反は baseline で許容、新規のみ fail） | 実行結果確認 | ✓ PASS | `[LP-SSOT] 572 violations (baseline: 572) OK` |

## 補足

- `check-hardcoded-strings.mjs` はコメントに `src/**/*.svelte` と記載されており、ESLint glob も `"src/**/*.svelte"` となっている（Issue #1465 の事前実装済み）
- CI 設定（`.github/workflows/ci.yml`）も既に `check-lp-ssot` ステップが含まれていた（事前実装済み）
- 今回の主な追加作業: 法的文書の除外実装と baseline の実態値への更新

## 法的文書除外の根拠

- `privacy.html`, `terms.html`, `tokushoho.html`, `sla.html` はコンテンツの法的精度が最優先であり、`data-lp-key` による動的化は不適切
- これらを baseline に含めると Phase B/C 移行時に不要な違反として計上され続ける
- 除外後の baseline: 572（LP・FAQ・pricing・selfhost など SSOT 移行対象のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)