### PR TITLE
fix(#1522): birthday-bonus-service の age 更新を削除 — 重複を age-recalc cron に移譲

### DIFF
--- a/docs/design/26-ゲーミフィケーション設計書.md
+++ b/docs/design/26-ゲーミフィケーション設計書.md
@@ -487,7 +487,7 @@ birthDate が変更された場合:
 
 ```
 claimBirthdayBonus():
-  child.age                   = calculateAge(birthDate, today)
+  child.age                   = (更新しない — age-recalc cron (#1381) に移譲, #1522)
   child.uiMode                = getDefaultUiMode(newAge)      ← uiModeManuallySet に関わらず常に上書き
                                                                  (ポリシー: 誕生日は節目、保護者が必要なら再設定)
   child.lastBirthdayBonusYear = currentYear                   ← 重複 claim 防止
@@ -545,7 +545,7 @@ claimBirthdayBonus():
 |---------|------|
 | `src/lib/domain/validation/age-tier.ts` | `getDefaultUiMode()` / `recalcUiMode()` / `UiMode` 型 |
 | `src/lib/server/services/child-service.ts` | `editChild()` — `uiModeManuallySet` を考慮した `recalcUiMode()` 呼出し |
-| `src/lib/server/services/birthday-bonus-service.ts` | `calculateAge()` / `claimBirthdayBonus()` — age + uiMode 更新 |
+| `src/lib/server/services/birthday-bonus-service.ts` | `calculateAge()` / `claimBirthdayBonus()` — uiMode 更新（age 更新は age-recalc cron に移譲, #1522） |
 | `src/lib/server/services/age-recalc-service.ts` | `recalcAllChildrenAges()` — 年齢自動インクリメント cron サービス (#1381) |
 | `src/routes/api/cron/age-recalc/+server.ts` | cron エンドポイント — verifyCronAuth 認証 + dryRun 対応 (#1381) |
 | `src/lib/server/cron/schedule-registry.ts` | cron スケジュール登録（`age-recalc`、毎日 00:00 JST） |
@@ -555,15 +555,15 @@ claimBirthdayBonus():
 
 ### 15.9 birthday-bonus-service との責務分担
 
-`birthday-bonus-service.claimBirthdayBonus()` と `child-service.editChild()` は age/uiMode 更新ロジックをそれぞれ持つ。以下のルールで責務を分離する。
+`birthday-bonus-service.claimBirthdayBonus()` と `child-service.editChild()` は uiMode 更新ロジックをそれぞれ持つ。以下のルールで責務を分離する。
 
-| 操作 | 担当サービス | uiModeManuallySet の考慮 |
-|------|------------|------------------------|
-| 保護者が管理画面で age / uiMode を編集 | `child-service.editChild()` | 考慮する。`recalcUiMode()` 経由 |
-| 誕生日ボーナス claim (子供画面 / cron) | `birthday-bonus-service.claimBirthdayBonus()` | **考慮しない**。誕生日は成長の節目のため `getDefaultUiMode()` で常に上書き |
-| 年齢自動インクリメント cron (#1381) | `age-recalc-service.recalcAllChildrenAges()` | **考慮する**。`recalcUiMode()` を使用。保護者の手動設定を維持 |
+| 操作 | 担当サービス | age 更新 | uiModeManuallySet の考慮 |
+|------|------------|---------|------------------------|
+| 保護者が管理画面で age / uiMode を編集 | `child-service.editChild()` | あり | 考慮する。`recalcUiMode()` 経由 |
+| 誕生日ボーナス claim (子供画面 / cron) | `birthday-bonus-service.claimBirthdayBonus()` | **なし**（#1522 で削除。age 更新は age-recalc cron に移譲） | **考慮しない**。誕生日は成長の節目のため `getDefaultUiMode()` で常に上書き |
+| 年齢自動インクリメント cron (#1381) | `age-recalc-service.recalcAllChildrenAges()` | あり | **考慮する**。`recalcUiMode()` を使用。保護者の手動設定を維持 |
 
-**ポリシー根拠**: 誕生日ボーナス claim 時は成長の節目であるため、年齢帯 UI を自動追従させることを優先する。保護者が UI を特定年齢帯に固定したい場合は、ボーナス受取後に管理画面から再設定する。
+**ポリシー根拠**: 誕生日ボーナス claim 時は成長の節目であるため、uiMode を自動追従させることを優先する（`getDefaultUiMode()` で常に上書き）。age 自体の更新は毎日 00:00 JST の `age-recalc` cron（#1381）が担うため、`claimBirthdayBonus()` 内での age 更新は重複となる。#1522 にて削除済み。保護者が uiMode を特定年齢帯に固定したい場合は、ボーナス受取後に管理画面から再設定する。
 
 ---
 

--- a/src/lib/server/services/birthday-bonus-service.ts
+++ b/src/lib/server/services/birthday-bonus-service.ts
@@ -163,11 +163,10 @@ export async function claimBirthdayBonus(
 	// uiMode も自動的に再計算する。ポリシー: 常に自動上書き（手動設定は誕生日後に再調整）。
 	const newUiMode = getDefaultUiMode(newAge);
 
-	// 年齢更新 + uiMode 再計算 + 重複防止フラグ設定
+	// uiMode 再計算 + 重複防止フラグ設定（age 更新は age-recalc cron に移譲）
 	await updateChild(
 		childId,
 		{
-			age: newAge,
 			uiMode: newUiMode,
 			lastBirthdayBonusYear: currentYear,
 		},

--- a/tests/unit/services/birthday-bonus-service.test.ts
+++ b/tests/unit/services/birthday-bonus-service.test.ts
@@ -189,7 +189,7 @@ describe('checkBirthdayStatus', () => {
 });
 
 // ============================================================
-// #580: claimBirthdayBonus — age + uiMode の同時更新テスト
+// #580: claimBirthdayBonus — uiMode 更新テスト（age 更新は age-recalc cron に移譲 #1522）
 // ============================================================
 describe('claimBirthdayBonus — uiMode 自動再計算（#580）', () => {
 	function makeChildForClaim(overrides: Partial<Child> = {}): Child {
@@ -233,13 +233,18 @@ describe('claimBirthdayBonus — uiMode 自動再計算（#580）', () => {
 		expect('error' in result).toBe(false);
 		if ('error' in result) return;
 		expect(result.newAge).toBe(3);
+		// age 更新は age-recalc cron に移譲（#1522）。updateChild には uiMode + lastBirthdayBonusYear のみ渡す
 		expect(mockUpdateChild).toHaveBeenCalledWith(
 			1,
 			expect.objectContaining({
-				age: 3,
 				uiMode: 'preschool',
 				lastBirthdayBonusYear: 2026,
 			}),
+			'tenant-1',
+		);
+		expect(mockUpdateChild).toHaveBeenCalledWith(
+			1,
+			expect.not.objectContaining({ age: expect.anything() }),
 			'tenant-1',
 		);
 	});
@@ -254,9 +259,15 @@ describe('claimBirthdayBonus — uiMode 自動再計算（#580）', () => {
 		expect('error' in result).toBe(false);
 		if ('error' in result) return;
 		expect(result.newAge).toBe(6);
+		// age 更新は age-recalc cron に移譲（#1522）。updateChild には uiMode のみ渡す
 		expect(mockUpdateChild).toHaveBeenCalledWith(
 			1,
-			expect.objectContaining({ age: 6, uiMode: 'elementary' }),
+			expect.objectContaining({ uiMode: 'elementary' }),
+			'tenant-1',
+		);
+		expect(mockUpdateChild).toHaveBeenCalledWith(
+			1,
+			expect.not.objectContaining({ age: expect.anything() }),
 			'tenant-1',
 		);
 	});
@@ -271,9 +282,15 @@ describe('claimBirthdayBonus — uiMode 自動再計算（#580）', () => {
 		expect('error' in result).toBe(false);
 		if ('error' in result) return;
 		expect(result.newAge).toBe(13);
+		// age 更新は age-recalc cron に移譲（#1522）。updateChild には uiMode のみ渡す
 		expect(mockUpdateChild).toHaveBeenCalledWith(
 			1,
-			expect.objectContaining({ age: 13, uiMode: 'junior' }),
+			expect.objectContaining({ uiMode: 'junior' }),
+			'tenant-1',
+		);
+		expect(mockUpdateChild).toHaveBeenCalledWith(
+			1,
+			expect.not.objectContaining({ age: expect.anything() }),
 			'tenant-1',
 		);
 	});
@@ -288,9 +305,15 @@ describe('claimBirthdayBonus — uiMode 自動再計算（#580）', () => {
 		expect('error' in result).toBe(false);
 		if ('error' in result) return;
 		expect(result.newAge).toBe(16);
+		// age 更新は age-recalc cron に移譲（#1522）。updateChild には uiMode のみ渡す
 		expect(mockUpdateChild).toHaveBeenCalledWith(
 			1,
-			expect.objectContaining({ age: 16, uiMode: 'senior' }),
+			expect.objectContaining({ uiMode: 'senior' }),
+			'tenant-1',
+		);
+		expect(mockUpdateChild).toHaveBeenCalledWith(
+			1,
+			expect.not.objectContaining({ age: expect.anything() }),
 			'tenant-1',
 		);
 	});
@@ -305,9 +328,15 @@ describe('claimBirthdayBonus — uiMode 自動再計算（#580）', () => {
 		expect('error' in result).toBe(false);
 		if ('error' in result) return;
 		expect(result.newAge).toBe(7);
+		// age 更新は age-recalc cron に移譲（#1522）。updateChild には uiMode のみ渡す
 		expect(mockUpdateChild).toHaveBeenCalledWith(
 			1,
-			expect.objectContaining({ age: 7, uiMode: 'elementary' }),
+			expect.objectContaining({ uiMode: 'elementary' }),
+			'tenant-1',
+		);
+		expect(mockUpdateChild).toHaveBeenCalledWith(
+			1,
+			expect.not.objectContaining({ age: expect.anything() }),
 			'tenant-1',
 		);
 	});


### PR DESCRIPTION
## 概要

PR #1520（feat(#1381)）で `/api/cron/age-recalc` を実装し、子供の年齢は毎日 00:00 JST に自動インクリメントされるようになった。しかし `birthday-bonus-service.ts` の `claimBirthdayBonus()` も `updateChild` で `age` を更新しており重複していた。本 PR はその重複を解消する。

## 変更内容

### `src/lib/server/services/birthday-bonus-service.ts`

- `claimBirthdayBonus()` の `updateChild` 呼び出しから `age: newAge` を削除
- コメントを「年齢更新 + uiMode 再計算 + 重複防止フラグ設定」→「uiMode 再計算 + 重複防止フラグ設定（age 更新は age-recalc cron に移譲）」に更新
- `uiMode: newUiMode` と `lastBirthdayBonusYear: currentYear` は維持（誕生日は成長の節目ポリシー）
- `newAge` 変数自体は削除しない（戻り値・ポイント計算・`getDefaultUiMode()` で引き続き使用）

### `tests/unit/services/birthday-bonus-service.test.ts`

- `updateChild` に `age` が渡らないことを `expect.not.objectContaining({ age: expect.anything() })` で検証するアサーションを追加
- テストコメントを更新（age 更新は age-recalc cron に移譲 #1522 を明記）

### `docs/design/26-ゲーミフィケーション設計書.md`

- §15.3「誕生日ボーナス claim 時」の状態遷移図で `child.age` 更新が削除されたことを明記
- §15.8 実装ファイル参照表を更新（`age + uiMode 更新` → `uiMode 更新（age 更新は age-recalc cron に移譲, #1522）`）
- §15.9 責務分担表に「age 更新」列を追加し、`claimBirthdayBonus()` が `age` 更新を行わなくなったことを明記。ポリシー根拠文も更新

## AC 検証マップ

| AC 番号 | AC 内容 | 対応状況 | 根拠/エビデンス |
|--------|---------|---------|----------------|
| AC1 | birthday-bonus-service.ts から age 更新コードを削除 | ✓ | `updateChild` から `age: newAge` を削除。コメントも更新 |
| AC2 | 誕生日ボーナス挙動（uiMode の上書きポリシー）が維持 | ✓ | `uiMode: newUiMode` は維持。`getDefaultUiMode()` で常に上書き |
| AC3 | 既存テストが引き続き通過 | ✓ | `npx vitest run` — 3821 tests passed (194 files) |
| AC4 | 設計書 §15.9 の責務分担表を更新 | ✓ | §15.3 / §15.8 / §15.9 を更新（age 更新削除・責務分担を明記） |

## テスト結果

```
Test Files  194 passed (194)
     Tests  3821 passed (3821)
```

## スクリーンショット / ビジュアルデモ

本 PR は UI 変更なし（サービス層・設計書のみ変更）のため N/A。

Closes #1522