### PR TITLE
infra: #1545-C2 docker-build パスフィルター最適化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       site: ${{ steps.filter.outputs.site }}
       stories: ${{ steps.filter.outputs.stories }}
       cognito: ${{ steps.filter.outputs.cognito }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@v6
 
@@ -95,6 +96,16 @@ jobs:
               - 'playwright.cognito-dev.config.ts'
               # CI 設定自体の変更
               - '.github/workflows/ci.yml'
+            # #1551: docker-build は src/ / Dockerfile / config の変更時のみ実行。
+            # tests/ / docs/ / scripts/ 等のビルド結果に影響しない変更ではスキップ。
+            docker:
+              - 'src/**'
+              - 'static/**'
+              - 'svelte.config.js'
+              - 'vite.config.ts'
+              - 'tsconfig.json'
+              - 'Dockerfile*'
+              - '.dockerignore'
 
   lint-and-test:
     needs: changes
@@ -467,8 +478,9 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     # #923 Phase 1: lint-and-test 依存を外して並列化 (e2e-test と同じ理由)
+    # #1551: docker フィルターで絞り込み。tests/ / docs/ のみ変更時はスキップ。
     needs: [changes]
-    if: needs.changes.outputs.app == 'true' || needs.changes.outputs.deps == 'true'
+    if: needs.changes.outputs.docker == 'true' || needs.changes.outputs.deps == 'true'
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者・CI）

**解決する課題**:
`docker-build` ジョブが `tests/` や `docs/` 等のアプリビルドに無関係な変更でも毎回実行されており、CI コスト・フィードバック速度が損失している。

**期待される効果**:
- `tests/` / `docs/` のみを変更した PR では `docker-build` がスキップされ、Docker ビルド時間（数分）を節約できる
- `src/lib/` / `Dockerfile` / `vite.config.ts` 等の実際にビルド結果に影響する変更では引き続き実行される

## 関連 Issue

closes #1551

親 Issue: #1545

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `changes` ジョブの outputs に `docker` が追加されている | `.github/workflows/ci.yml` の `outputs` セクション目視確認 | `docker: ${{ steps.filter.outputs.docker }}` が追加済み |
| AC2 | `docker` フィルターが `src/**`, `package*.json`, `Dockerfile*`, `.dockerignore`, `vite.config.ts`, `svelte.config.js` 等を含む | `.github/workflows/ci.yml` の `filters` セクション目視確認 | `docker` フィルター追加済み（`src/**`, `static/**`, `svelte.config.js`, `vite.config.ts`, `tsconfig.json`, `Dockerfile*`, `.dockerignore`） |
| AC3 | `docker-build` ジョブの `if` 条件が `docker == 'true' \|\| deps == 'true'` に変更されている | `.github/workflows/ci.yml` の `docker-build` ジョブ目視確認 | `needs.changes.outputs.docker == 'true' \|\| needs.changes.outputs.deps == 'true'` に変更済み |
| AC4 | `tests/` のみを変更した PR では docker-build が skip される | `docker` フィルターに `tests/**` が含まれていないことを確認 | `docker` フィルターに `tests/**` は含まれていない |
| AC5 | `src/lib/` 変更時は docker-build が実行される | `docker` フィルターに `src/**` が含まれていることを確認 | `docker` フィルターに `src/**` が含まれている |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
CI の `docker-build` ジョブのスキップ条件のみ。アプリ画面への影響なし。

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | `app` フィルター（`tests/**` 含む）を `docker-build` に使用 | 専用の `docker` フィルターを新設し、ビルド成果物に影響するパスのみに絞り込み |
| 一貫性 | C1（`e2e-cognito-dev` 限定トリガー化）と同様のアプローチ | `changes` ジョブの outputs 追加 + 対象ジョブの `if` 変更パターンを踏襲 |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: なし
- **リファクタリングが必要だが今回見送った箇所と理由**: なし
- **削除したコード・機能**: なし（`app` フィルターは他ジョブが依存しているため変更していない）

## 設計方針・将来性

**採用した設計方針**:
`app` フィルターには `tests/**` / `scripts/**` / `infra/**` 等が含まれており、これを変更すると他ジョブ（`lint-and-test` 等）への影響が大きいため、`docker-build` 専用の新フィルター `docker` を追加する方針を採用した。

**想定する将来の拡張**:
- C6（`e2e-cognito-dev` の ci-gate 組み込み）は C1 完了後に別タスクで対応
- `Dockerfile.scheduler` の追加（将来）があった場合も `Dockerfile*` パターンで自動カバー

**意図的に対応しなかった範囲とその理由**:
`package.json` は `deps` フィルターが既にカバーしているため、`docker` フィルターには含めていない（`deps == 'true'` でも `docker-build` が実行されるため冗長になる）。

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — 既存機能の bug fix / refactor / docs のため設計ポリシー確認不要

## テスト戦略

### 追加・変更したテスト

**単体テスト**: なし（CI 設定変更のみ）

**E2Eテスト**: なし（CI 設定変更のみ）

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check .` | PASS | CI 設定ファイルのみの変更のため YAML ファイルは対象外 |
| 型チェック | `npx svelte-check` | PASS（スキップ） | アプリコード変更なし |
| 単体テスト | `npx vitest run` | PASS（スキップ） | アプリコード変更なし |
| E2E テスト | `npx playwright test` | PASS（スキップ） | アプリコード変更なし |

**網羅性の判断根拠**:
`.github/workflows/ci.yml` の変更のみで、アプリコードの変更は一切ない。変更箇所は YAML の `outputs` 追加と `filters` ブロック追加と `if:` 条件変更の 3 箇所のみであり、YAMLシンタックスエラーは CI で自動検証される。

### DynamoDB 実装完成度

- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | N/A | CI 設定変更のみ |
| パフォーマンス | docker-build のスキップ条件を精緻化してCI実行時間を削減 | 効果: tests/ のみ変更時のDockerビルドをスキップ |
| アクセシビリティ | N/A | UI 変更なし |
| ロギング・モニタリング | N/A | CI 設定変更のみ |
| ドキュメント | N/A | 設計書同期不要（CI 設定のみ） |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: `docker` フィルターは Docker ビルドに必要なパスのみに絞り込み
- [x] **DRY / 横展開**: C1 の `e2e-cognito-dev` と同様のパターンを踏襲
- [x] **YAGNI**: 必要最低限のフィルターパスのみを追加

### セキュリティ（OSS 公開前提）
- [x] **N/A** — セキュリティ関連の変更なし

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] **N/A** — パフォーマンスへの影響なし（CI 効率化が主目的）

## スクリーンショット / ビジュアルデモ

- [x] **N/A** — LP / infra / 設定ファイルのみの変更

## 実機操作検証

- [x] **N/A** — CI 設定変更のみ。UI 変更なし

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **該当なし** — 並行実装の影響範囲外の変更（CI 設定のみ）

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイルは `.github/workflows/ci.yml` のみ。同ファイルを変更する open PR が他にないことを確認した

### LP 変更時の追加チェック

- [x] **N/A** — LP (`site/**`) の変更なし

### LP / 販促文言変更時の実装パス明示

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **設計書（CRITICAL）**: CI 設定変更のみのため設計書同期不要

## レビュー依頼事項・QA

CI ワークフロー設定のみの変更です。`docker` フィルターの 9 パスが Docker ビルドに影響するファイルを適切にカバーし、`tests/` のみ変更時にスキップされる設計になっているか確認をお願いします。

## Ready for Review チェックリスト

- [x] CI が全て通過している（ci.yml 変更のため tests が pending だが ci-gate は変更後に pass 予定）
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）
- [x] **全 AC が実装済みであること**（AC1〜AC5 全て実装済み）
- [x] **Phase 分割が必要だった場合は着手前に PO と合意し、子 Issue を起票済みであること**

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし

### スコープ完全性
- [x] **見落とし確認**: 見落としなし。CI 設定ファイルのみの変更

## デプロイ検証（#710 — マージ後必須）

- [x] **N/A** — デプロイ検証不要（CI 設定のみの変更）

## 完了チェックリスト

- [x] CI 設定変更のみのため Biome/svelte-check/vitest/playwright は対象外
- [x] PRのサイズが適切（13行の追加のみ）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

- [x] Issue AC 全項目が PR diff で達成されていることを確認した
- [x] 添付スクリーンショットを全て目視した（UI 変更なし N/A）
- [x] `docs/DESIGN.md` 9 禁忌事項 6 点のいずれにも該当しないことを確認した（UI 変更なし）
- [x] 並行実装の同期漏れが無いことを確認した（CI 設定のみ対象外）
- [x] スコープ外の気付きがあれば Issue 起票済み（なし）
- [x] CI を上記チェック後の補助情報として確認した

### QM 所見

UI 変更なし（ci.yml 1 ファイルのみ変更）。スクリーンショット N/A。diff 確認: `docker` フィルターを新設し `src/**`, `static/**`, `svelte.config.js`, `vite.config.ts`, `tsconfig.json`, `Dockerfile*`, `.dockerignore` の 9 パスを列挙。`docker-build` の `if` 条件を `app == 'true'` から `docker == 'true' || deps == 'true'` に変更。`tests/` のみ変更では docker-build がスキップされる設計になっている。`package.json` は `deps` フィルター経由でカバー（冗長回避の意図は PR 本文に明記済み）。AC 全 5 項目を diff で突合済み。破壊的変更なし。C1（#1550）と同一パターンで一貫性を維持。