### PR TITLE
infra: #1545-C5 CodeQL パスフィルター精緻化

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,12 +3,22 @@ name: "CodeQL"
 on:
   push:
     branches: [main]
-    paths: ['src/**', 'static/**', '**/*.js', '**/*.ts']
+    # #1553: プロダクションコード変更時のみ実行（tests/ scripts/ docs/ site/ 変更は不要）
+    paths:
+      - 'src/**'
+      - 'static/**'
+      - 'package.json'
+      - 'package-lock.json'
   pull_request:
     branches: [main]
     # #1218: ready_for_review は除外（Draft でも走るため再実行は無駄）。
     types: [opened, synchronize, reopened]
-    paths: ['src/**', 'static/**', '**/*.js', '**/*.ts']
+    # #1553: プロダクションコード変更時のみ実行（tests/ scripts/ docs/ site/ 変更は不要）
+    paths:
+      - 'src/**'
+      - 'static/**'
+      - 'package.json'
+      - 'package-lock.json'
   schedule:
     - cron: "0 6 * * 1" # Every Monday at 6:00 UTC
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者・CI/CD パイプライン）

**解決する課題**:
CodeQL セキュリティスキャンが `**/*.js` / `**/*.ts` という広範なグロブパターンにより、`tests/` や `scripts/` の変更のみの PR でも不要に起動していた。30分かかる重いジョブが無関係な変更でトリガーされる開発スループット損失を解消する。

**期待される効果**:
テストコード・スクリプトのみを変更する PR では CodeQL が skip され、CI フィードバック時間の短縮とコスト削減が実現する。プロダクションコード (`src/`, `static/`) や依存関係 (`package.json`) 変更時は引き続き実行される。

## 関連 Issue

closes #1553

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | CodeQL ワークフローの paths フィルターが `src/**` を含む | `.github/workflows/codeql.yml` の `paths:` を目視確認 | `src/**` が paths に含まれる PASS |
| AC2 | `tests/**` のみ変更した PR では CodeQL がスキップされる | paths フィルターに `tests/**` が含まれないことを確認 | `tests/**` はパスに含まれないため skip PASS |
| AC3 | `scripts/**` のみ変更した PR では CodeQL がスキップされる | paths フィルターに `scripts/**` が含まれないことを確認 | `scripts/**` はパスに含まれないため skip PASS |
| AC4 | `src/` 変更時は CodeQL が実行される | paths フィルターに `src/**` が含まれることを確認 | `src/**` が含まれるため実行 PASS |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
CI/CD パイプラインの CodeQL ワークフローのみ。アプリケーションコードへの影響なし。

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | paths: src/**, static/**, **/*.js, **/*.ts | paths: src/**, static/**, package.json, package-lock.json |
| 一貫性 | `**/*.ts` で tests/ scripts/ も含まれてしまう | プロダクションコードディレクトリに明示的に限定 |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: `**/*.js` / `**/*.ts` グロブを削除し、明示的なパスリストに置換
- **リファクタリングが必要だが今回見送った箇所と理由**: なし
- **削除したコード・機能**: 広範すぎる `**/*.js` / `**/*.ts` パターン

## 設計方針・将来性

**採用した設計方針**:
`paths-ignore` で除外リストを管理するより、`paths` で許可リストを管理する方式を採用。
新しいディレクトリが追加されても、`src/` 配下に置かれる限り自動的にスキャン対象になる。

**想定する将来の拡張**:
- `infra/` 配下に TypeScript 実装が増えた場合は `infra/**` を追加する必要がある（現時点では CDK が JS/TS だが CodeQL スキャン対象として追加検討可）

**意図的に対応しなかった範囲とその理由**:
- `infra/**` を追加しない: CDK コードは AWS インフラ定義であり、セキュリティ脆弱性の影響範囲が異なる。将来必要性が出た場合に別 Issue で検討する

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — 既存機能の bug fix / refactor / docs のため設計ポリシー確認不要

## テスト戦略

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check .` | PASS | ワークフロー YAML は biome 対象外 |
| 型チェック | `npx svelte-check` | PASS | ワークフロー YAML は型チェック対象外 |
| 単体テスト | `npx vitest run` | PASS | アプリコードの変更なし |
| E2E テスト | N/A | N/A | アプリコードの変更なし |

### DynamoDB 実装完成度

- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | CodeQL の実行頻度最適化（週次スケジュール実行は維持） | プロダクションコード変更時は引き続き実行 |
| パフォーマンス | tests/ scripts/ 変更時の不要スキャンを排除 | CI コスト削減・フィードバック時間短縮 |
| アクセシビリティ | N/A | UI 変更なし |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: 変更は CodeQL ワークフローの paths フィルターのみ
- [x] **DRY / 横展開**: 他のワークフローでの同種問題は C1/C2/C3 として別 Issue 管理済み
- [x] **YAGNI**: 最小限の変更のみ実施

### セキュリティ
- [x] **N/A** — セキュリティ関連の変更なし（週次スケジュール実行は維持し全体スキャンは継続）

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] **N/A** — パフォーマンスへの影響なし

## スクリーンショット / ビジュアルデモ

- [x] **N/A** — LP / infra / 設定ファイルのみの変更

## 実機操作検証

- [x] **N/A** — UI 変更なし

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

補足: 週次スケジュール実行（毎週月曜 06:00 UTC）は変更しておらず、全量スキャンは継続する。

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **該当なし** — 並行実装の影響範囲外の変更

### 並行 PR 影響確認

- [x] 本 PR が変更するファイル (`.github/workflows/codeql.yml`) を同時期に変更する open PR が他に無いことを確認した

### LP 変更時の追加チェック

- [x] **N/A** — LP (`site/**`) の変更なし

### その他

- [x] **用語変更**: 変更なし
- [x] **labels SSOT**: N/A — ユーザー向け文言の追加/変更なし
- [x] **設計書（CRITICAL）**: インフラ設定ファイルのみの変更のため設計書更新不要

## レビュー依頼事項・QA

CI ワークフロー（codeql.yml）設定のみの変更です。`paths` フィルターがプロダクションコードを適切にカバーし、tests/ scripts/ 変更時にスキップされる設計になっているか確認をお願いします。

## Ready for Review チェックリスト

- [x] CI が全て通過している（codeql.yml のみの変更のため ci.yml のジョブはスキップ — 正常動作）
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）
- [x] **全 AC が実装済みであること**（AC1〜AC4 全て実装済み）

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし

### スコープ完全性
- [x] **見落とし確認**: #1545 の他の子タスク (C1/C2/C3/C4/C6) は別 Issue として管理済み

## デプロイ検証（#710 — マージ後必須）

- [x] **N/A** — デプロイ検証不要（CI 設定のみの変更）

## 完了チェックリスト

- [x] `npx biome check .` — lint エラーなし（ワークフロー YAML は対象外）
- [x] `npx svelte-check` — 型エラーなし（ワークフロー YAML は対象外）
- [x] `npx vitest run` — ユニットテスト全通過（アプリコード変更なし）
- [x] `npx playwright test` — N/A（CI 設定のみの変更のため E2E 対象外）
- [x] PRのサイズが適切（1ファイル、14行変更）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

- [x] Issue AC 全項目が PR diff で達成されていることを確認した
- [x] 添付スクリーンショットを全て目視した（UI 変更なし N/A）
- [x] `docs/DESIGN.md` 9 禁忌事項 6 点のいずれにも該当しないことを確認した（UI 変更なし）
- [x] 並行実装の同期漏れが無いことを確認した（CI 設定のみ対象外）
- [x] スコープ外の気付きがあれば Issue 起票済み（なし）
- [x] CI を上記チェック後の補助情報として確認した

### QM 所見

UI 変更なし（codeql.yml 1 ファイルのみ変更）。スクリーンショット N/A。diff 確認: `**/*.js` / `**/*.ts` という広範グロブを削除し、`src/**`, `static/**`, `package.json`, `package-lock.json` の明示的許可リストに置換。tests/ scripts/ 配下の変更では CodeQL がスキップされる設計になっている。週次スケジュール実行は変更なし（全量スキャン継続）。AC 全 4 項目を diff で突合済み。破壊的変更なし。