### PR TITLE
test: #1535 upgrade-checkout を integration/ に移動 + loginAsPlan() 完全廃止

### DIFF
--- a/playwright.cognito-dev.config.ts
+++ b/playwright.cognito-dev.config.ts
@@ -41,75 +41,14 @@ export default defineConfig({
 		// 後続プロジェクトはそれぞれ dependencies: ['setup'] + storageState で認証済み状態から開始。
 		{ name: 'setup', testMatch: /auth\.setup\.ts$/ },
 
-		// #1500: plan 別プロジェクト（各 spec が loginAsPlan() を呼ぶ代わりに
-		// storageState でセッションを再利用する）
-		//
-		// spec が期待するユーザーと各プロジェクトの対応:
-		//   as-free         → free@example.com    (plan=free)
-		//   as-standard     → standard@example.com (plan=standard)
-		//   as-family       → family@example.com   (plan=family)
-		//   as-trial-expired→ trial-expired@example.com (plan=free, trial 期限切れ)
-		//   as-owner        → owner@example.com    (owner ロール、plan=family)
-		//   as-ops          → ops@example.com      (ops ロール)
-		//
-		// #1535: 全対象 spec の loginAsPlan() を storageState ベースに移行完了。
-		// 各 spec は test.use({ storageState: '...' }) で認証済みセッションを再利用する。
+		// #1535: 6プロジェクト → chromium 1プロジェクトに集約してタイムアウト解消。
+		// 各 spec が test.use({ storageState: '...' }) で describe/spec レベルのstorageStateを指定するため、
+		// プロジェクトレベルの storageState は不要。全 spec を1回だけ実行する。
 		{
-			name: 'as-owner',
+			name: 'chromium',
 			dependencies: ['setup'],
 			use: {
 				...devices['Desktop Chrome'],
-				storageState: 'playwright/.auth/owner.json',
-				viewport: { width: 1280, height: 800 },
-			},
-			testIgnore: [/auth\.setup\.ts$/, /account-deletion\.spec\.ts$/],
-		},
-		{
-			name: 'as-free',
-			dependencies: ['setup'],
-			use: {
-				...devices['Desktop Chrome'],
-				storageState: 'playwright/.auth/free.json',
-				viewport: { width: 1280, height: 800 },
-			},
-			testIgnore: [/auth\.setup\.ts$/, /account-deletion\.spec\.ts$/],
-		},
-		{
-			name: 'as-standard',
-			dependencies: ['setup'],
-			use: {
-				...devices['Desktop Chrome'],
-				storageState: 'playwright/.auth/standard.json',
-				viewport: { width: 1280, height: 800 },
-			},
-			testIgnore: [/auth\.setup\.ts$/, /account-deletion\.spec\.ts$/],
-		},
-		{
-			name: 'as-family',
-			dependencies: ['setup'],
-			use: {
-				...devices['Desktop Chrome'],
-				storageState: 'playwright/.auth/family.json',
-				viewport: { width: 1280, height: 800 },
-			},
-			testIgnore: [/auth\.setup\.ts$/, /account-deletion\.spec\.ts$/],
-		},
-		{
-			name: 'as-trial-expired',
-			dependencies: ['setup'],
-			use: {
-				...devices['Desktop Chrome'],
-				storageState: 'playwright/.auth/trial-expired.json',
-				viewport: { width: 1280, height: 800 },
-			},
-			testIgnore: [/auth\.setup\.ts$/, /account-deletion\.spec\.ts$/],
-		},
-		{
-			name: 'as-ops',
-			dependencies: ['setup'],
-			use: {
-				...devices['Desktop Chrome'],
-				storageState: 'playwright/.auth/ops.json',
 				viewport: { width: 1280, height: 800 },
 			},
 			testIgnore: [/auth\.setup\.ts$/, /account-deletion\.spec\.ts$/],

--- a/playwright.cognito-dev.config.ts
+++ b/playwright.cognito-dev.config.ts
@@ -19,8 +19,9 @@ export default defineConfig({
 	// #755: account-deletion のアカウント削除フロー spec を追加
 	// #1497: upgrade-checkout の Stripe Checkout インターセプト spec を追加
 	// #1500: plan 別 storageState プロジェクトで loginAsPlan() を撤廃
+	// #1535: upgrade-checkout を tests/e2e/integration/ に移動
 	testMatch:
-		/(cognito-auth|plan-gated-features|plan-standard|plan-family|plan-free|premium-welcome|trial-flow|ops-license|ops-license-issue|upgrade-flow|pricing-page-signup|trial-banner-display|account-deletion|upgrade-checkout)\.spec\.ts$/,
+		/(cognito-auth|plan-gated-features|plan-standard|plan-family|plan-free|premium-welcome|trial-flow|ops-license|ops-license-issue|upgrade-flow|pricing-page-signup|trial-banner-display|account-deletion|integration\/upgrade-checkout)\.spec\.ts$/,
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 1,
@@ -51,10 +52,8 @@ export default defineConfig({
 		//   as-owner        → owner@example.com    (owner ロール、plan=family)
 		//   as-ops          → ops@example.com      (ops ロール)
 		//
-		// ただし現時点ではどの spec もまだ loginAsPlan() を各テスト内で呼んでいる。
-		// storageState を使うには spec 側でログイン済みを前提とした goto() から始める必要がある。
-		// そのため本プロジェクトは storageState を設定するが、spec 側は段階的に移行する。
-		// loginAsPlan() を呼ぶ spec は storageState を無視して再ログインするため互換性は維持される。
+		// #1535: 全対象 spec の loginAsPlan() を storageState ベースに移行完了。
+		// 各 spec は test.use({ storageState: '...' }) で認証済みセッションを再利用する。
 		{
 			name: 'as-owner',
 			dependencies: ['setup'],

--- a/tests/e2e/integration/upgrade-checkout.spec.ts
+++ b/tests/e2e/integration/upgrade-checkout.spec.ts
@@ -1,8 +1,9 @@
-// tests/e2e/upgrade-checkout.spec.ts
+// tests/e2e/integration/upgrade-checkout.spec.ts
 // #1497: Stripe チェックアウト E2E テスト（page.route() インターセプト）
 // #1500: テスト分類 = Integration（page.route() で Stripe を完全モック化しているため）
 //        cognito-dev 認証が必要なため playwright.cognito-dev.config.ts で管理するが、
 //        実 Stripe API は一切呼び出さない。tests/CLAUDE.md §テスト分類 参照。
+// #1535: tests/e2e/integration/ に移動 + storageState ベースに移行
 //
 // Stripe Checkout API を page.route() でモック化し、
 // /admin/license のアップグレード CTA → Stripe Checkout 遷移の導線を検証する。
@@ -10,16 +11,13 @@
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts upgrade-checkout
 
 import { expect, test } from '@playwright/test';
-import { loginAsPlan } from './plan-login-helpers';
 
 // ============================================================
 // Stripe Checkout API モック
 // ============================================================
 
 test.describe('#1497 Stripe Checkout 遷移 — page.route() モック', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+	test.use({ storageState: 'playwright/.auth/free.json' });
 
 	test('free プランで /api/stripe/checkout をモックすると checkout.stripe.com へ遷移する', async ({
 		page,
@@ -33,8 +31,7 @@ test.describe('#1497 Stripe Checkout 遷移 — page.route() モック', () => {
 			});
 		});
 
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 30_000 });
 
 		// Stripe が有効な場合のみプラン選択カードが表示される
 		// 無効な環境では「決済機能は現在準備中です」が表示されるためスキップ

--- a/tests/e2e/integration/upgrade-checkout.spec.ts
+++ b/tests/e2e/integration/upgrade-checkout.spec.ts
@@ -97,6 +97,8 @@ test.describe('#1497 Stripe Checkout 遷移 — page.route() モック', () => {
 // ============================================================
 
 test.describe('#1497 /api/stripe/checkout API インターセプト', () => {
+	test.use({ storageState: 'playwright/.auth/free.json' });
+
 	test('page.route() で /api/stripe/checkout をモックすると mock URL が返る', async ({ page }) => {
 		const mockCheckoutUrl = 'https://checkout.stripe.com/mock-test-session-abc123';
 
@@ -108,6 +110,10 @@ test.describe('#1497 /api/stripe/checkout API インターセプト', () => {
 				body: JSON.stringify({ url: mockCheckoutUrl }),
 			});
 		});
+
+		// fetch の相対 URL 解決に必要なベース URL を確立する
+		// （about:blank のままでは fetch('/api/...') が TypeError になるため）
+		await page.goto('/', { waitUntil: 'commit', timeout: 30_000 });
 
 		// fetch でモックエンドポイントを呼び出す
 		const result = await page.evaluate(async (_url) => {

--- a/tests/e2e/plan-family.spec.ts
+++ b/tests/e2e/plan-family.spec.ts
@@ -10,29 +10,16 @@
 //  - family 限定機能（ひとことメッセージ等）が enabled で操作可能なこと
 //  - PlanStatusCard が family を示すこと
 //
+// #1535: loginAsPlan() を storageState ベースに移行
+//
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts plan-family
 
 import { expect, test } from '@playwright/test';
-import { loginAsPlan, warmupAdminPages } from './plan-login-helpers';
 
-test.beforeAll(async ({ browser }) => {
-	test.setTimeout(360_000);
-	await warmupAdminPages(browser, [
-		'/admin',
-		'/admin/license',
-		'/admin/reports',
-		'/admin/settings',
-		'/admin/messages',
-	]);
-});
+test.use({ storageState: 'playwright/.auth/family.json' });
 
 test.describe('#779 family プラン — 全機能解放確認', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
-
 	test('/admin/license の PlanStatusCard が family を示す', async ({ page }) => {
-		await loginAsPlan(page, 'family');
 		await page.goto('/admin/license');
 		const card = page.getByTestId('plan-status-card');
 		await expect(card).toBeVisible();
@@ -44,7 +31,6 @@ test.describe('#779 family プラン — 全機能解放確認', () => {
 	});
 
 	test('/admin にホームを開いても free 用アップグレード CTA が出ない', async ({ page }) => {
-		await loginAsPlan(page, 'family');
 		await page.goto('/admin');
 		// family のときは PlanStatusCard が data-plan-tier="family" で表示される
 		const card = page.getByTestId('plan-status-card');
@@ -55,13 +41,11 @@ test.describe('#779 family プラン — 全機能解放確認', () => {
 	});
 
 	test('/admin/reports — weekly-report-upsell バナーが出ない', async ({ page }) => {
-		await loginAsPlan(page, 'family');
 		await page.goto('/admin/reports');
 		await expect(page.getByTestId('weekly-report-upsell')).toHaveCount(0);
 	});
 
 	test('/admin/settings — エクスポートボタンが有効化されている', async ({ page }) => {
-		await loginAsPlan(page, 'family');
 		await page.goto('/admin/settings');
 		await expect(page.getByTestId('data-export-section')).toBeVisible();
 		await expect(page.getByTestId('export-upsell')).toHaveCount(0);
@@ -71,7 +55,6 @@ test.describe('#779 family プラン — 全機能解放確認', () => {
 	});
 
 	test('/admin/messages — ひとことメッセージは family 限定機能として有効', async ({ page }) => {
-		await loginAsPlan(page, 'family');
 		await page.goto('/admin/messages');
 		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
 		await expect(textBtn).toBeVisible();

--- a/tests/e2e/plan-free.spec.ts
+++ b/tests/e2e/plan-free.spec.ts
@@ -11,33 +11,18 @@
 //  - plan-standard / plan-family の negative assertion とミラー関係になり、
 //    プラン境界の回帰検知を双方向で担保する
 //
+// #1535: loginAsPlan() を storageState ベースに移行
+//
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts plan-free
 
 import { expect, test } from '@playwright/test';
-import { loginAsPlan, warmupAdminPages } from './plan-login-helpers';
 
-test.beforeAll(async ({ browser }) => {
-	test.setTimeout(360_000);
-	await warmupAdminPages(browser, [
-		'/admin',
-		'/admin/license',
-		'/admin/reports',
-		'/admin/settings',
-		'/admin/messages',
-		'/admin/rewards',
-		'/admin/activities',
-	]);
-});
+test.use({ storageState: 'playwright/.auth/free.json' });
 
 test.describe('#751 free プラン — 機能ゲート', () => {
-	test.beforeEach(() => {
-		test.slow(); // Vite dev のコールドコンパイルでタイムアウトを 3x 延長
-	});
-
 	test('/admin/license の PlanStatusCard が free を示し、アップグレード CTA が見える', async ({
 		page,
 	}) => {
-		await loginAsPlan(page, 'free');
 		await page.goto('/admin/license');
 		const card = page.getByTestId('plan-status-card');
 		await expect(card).toBeVisible();
@@ -49,7 +34,6 @@ test.describe('#751 free プラン — 機能ゲート', () => {
 	});
 
 	test('/admin ホームに無料プラン用 PlanStatusCard が表示される', async ({ page }) => {
-		await loginAsPlan(page, 'free');
 		await page.goto('/admin');
 		// free のときは PlanStatusCard が data-plan-tier="free" で表示される
 		const card = page.getByTestId('plan-status-card');
@@ -60,14 +44,12 @@ test.describe('#751 free プラン — 機能ゲート', () => {
 	});
 
 	test('/admin/reports — weekly-report-upsell バナーが表示される', async ({ page }) => {
-		await loginAsPlan(page, 'free');
 		await page.goto('/admin/reports');
 		// #735: 無料プラン向け upsell はタブの外に出し、ページ到達時点で常に表示される
 		await expect(page.getByTestId('weekly-report-upsell')).toBeVisible();
 	});
 
 	test('/admin/settings — エクスポートはアップセル表示で disabled', async ({ page }) => {
-		await loginAsPlan(page, 'free');
 		await page.goto('/admin/settings');
 		// free 用アップセルカードが見える
 		await expect(page.getByTestId('export-upsell')).toBeVisible();
@@ -80,7 +62,6 @@ test.describe('#751 free プラン — 機能ゲート', () => {
 	test('/admin/activities — AiSuggestPanel が plan-locked + アップセル CTA を出す', async ({
 		page,
 	}) => {
-		await loginAsPlan(page, 'free');
 		await page.goto('/admin/activities');
 		// Svelte ハイドレーション完了を待つ（FAB の onclick ハンドラ束縛を保証）。
 		// FAB の確実な可視化で ready 状態を検知する（auto-retry assertion）。
@@ -104,7 +85,6 @@ test.describe('#751 free プラン — 機能ゲート', () => {
 	test('/admin/rewards — アップグレードバナーが表示される', async ({ page }) => {
 		// plan-gated-features.spec.ts でも検証済みだが、
 		// free プランの正面検証パッケージとしてここでも押さえる
-		await loginAsPlan(page, 'free');
 		await page.goto('/admin/rewards');
 		await expect(page.getByTestId('rewards-upgrade-banner')).toBeVisible();
 		await expect(page.getByTestId('rewards-upgrade-cta')).toBeVisible();
@@ -113,7 +93,6 @@ test.describe('#751 free プラン — 機能ゲート', () => {
 	test('/admin/messages — ひとことメッセージは disabled（family 限定機能）', async ({ page }) => {
 		// plan-gated-features.spec.ts と意図的に重複させ、free 単体でも完結する
 		// 機能疎通スイートにする
-		await loginAsPlan(page, 'free');
 		await page.goto('/admin/messages');
 		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
 		await expect(textBtn).toBeVisible();

--- a/tests/e2e/plan-gated-features.spec.ts
+++ b/tests/e2e/plan-gated-features.spec.ts
@@ -7,6 +7,8 @@
 // DevCognitoAuthProvider のプラン別ダミーユーザー（free/standard/family）で
 // ログイン → 実際のプランゲート UI を検証する。
 //
+// #1535: loginAsPlan() を storageState ベースに移行（describe ブロック分割）
+//
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts plan-gated-features
 //
 // 対応ゲート:
@@ -14,38 +16,33 @@
 //  - /admin/messages: ひとことメッセージボタン（free/standard は disabled、family は enabled）
 
 import { expect, test } from '@playwright/test';
-import { loginAsPlan as loginAs, warmupAdminPages } from './plan-login-helpers';
-
-// Vite dev のコールドコンパイルで /auth/login と /admin 配下の初回ビルドが
-// 数分かかることがあるため、テスト前に warmup でプリコンパイルを走らせる。
-test.beforeAll(async ({ browser }) => {
-	test.setTimeout(360_000);
-	await warmupAdminPages(browser, ['/admin/rewards', '/admin/messages']);
-});
 
 // ============================================================
 // /admin/rewards — #728 カスタムごほうびプランゲート
 // ============================================================
-test.describe('#776 /admin/rewards プランゲート', () => {
-	test.beforeEach(() => {
-		test.slow(); // Vite dev のコールドコンパイルでタイムアウトを 3x 延長
-	});
+test.describe('#776 /admin/rewards プランゲート — free', () => {
+	test.use({ storageState: 'playwright/.auth/free.json' });
 
 	test('free プランではアップグレードバナーが表示される', async ({ page }) => {
-		await loginAs(page, 'free');
 		await page.goto('/admin/rewards');
 		await expect(page.getByTestId('rewards-upgrade-banner')).toBeVisible();
 		await expect(page.getByTestId('rewards-upgrade-cta')).toBeVisible();
 	});
+});
+
+test.describe('#776 /admin/rewards プランゲート — standard', () => {
+	test.use({ storageState: 'playwright/.auth/standard.json' });
 
 	test('standard プランではアップグレードバナーが表示されない', async ({ page }) => {
-		await loginAs(page, 'standard');
 		await page.goto('/admin/rewards');
 		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
 	});
+});
+
+test.describe('#776 /admin/rewards プランゲート — family', () => {
+	test.use({ storageState: 'playwright/.auth/family.json' });
 
 	test('family プランではアップグレードバナーが表示されない', async ({ page }) => {
-		await loginAs(page, 'family');
 		await page.goto('/admin/rewards');
 		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
 	});
@@ -54,31 +51,34 @@ test.describe('#776 /admin/rewards プランゲート', () => {
 // ============================================================
 // /admin/messages — #0270 自由テキストメッセージプランゲート
 // ============================================================
-test.describe('#776 /admin/messages プランゲート', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+test.describe('#776 /admin/messages プランゲート — free', () => {
+	test.use({ storageState: 'playwright/.auth/free.json' });
 
 	test('free プランではひとことメッセージボタンが disabled', async ({ page }) => {
-		await loginAs(page, 'free');
 		await page.goto('/admin/messages');
 		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
 		await expect(textBtn).toBeVisible();
 		await expect(textBtn).toBeDisabled();
 	});
+});
+
+test.describe('#776 /admin/messages プランゲート — standard', () => {
+	test.use({ storageState: 'playwright/.auth/standard.json' });
 
 	test('standard プランでもひとことメッセージボタンは disabled（family 限定）', async ({
 		page,
 	}) => {
-		await loginAs(page, 'standard');
 		await page.goto('/admin/messages');
 		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
 		await expect(textBtn).toBeVisible();
 		await expect(textBtn).toBeDisabled();
 	});
+});
+
+test.describe('#776 /admin/messages プランゲート — family', () => {
+	test.use({ storageState: 'playwright/.auth/family.json' });
 
 	test('family プランではひとことメッセージボタンが有効', async ({ page }) => {
-		await loginAs(page, 'family');
 		await page.goto('/admin/messages');
 		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
 		await expect(textBtn).toBeVisible();

--- a/tests/e2e/plan-standard.spec.ts
+++ b/tests/e2e/plan-standard.spec.ts
@@ -11,29 +11,16 @@
 //  - 同時に「ある機能はまだ family 限定で disabled のままか」も確認し、
 //    standard ↔ family のプラン境界を回帰検知できるようにする
 //
+// #1535: loginAsPlan() を storageState ベースに移行
+//
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts plan-standard
 
 import { expect, test } from '@playwright/test';
-import { loginAsPlan, warmupAdminPages } from './plan-login-helpers';
 
-test.beforeAll(async ({ browser }) => {
-	test.setTimeout(360_000);
-	await warmupAdminPages(browser, [
-		'/admin',
-		'/admin/license',
-		'/admin/reports',
-		'/admin/settings',
-		'/admin/messages',
-	]);
-});
+test.use({ storageState: 'playwright/.auth/standard.json' });
 
 test.describe('#779 standard プラン — 機能疎通', () => {
-	test.beforeEach(() => {
-		test.slow(); // Vite dev のコールドコンパイルでタイムアウトを 3x 延長
-	});
-
 	test('/admin/license の PlanStatusCard が standard を示す', async ({ page }) => {
-		await loginAsPlan(page, 'standard');
 		await page.goto('/admin/license');
 		const card = page.getByTestId('plan-status-card');
 		await expect(card).toBeVisible();
@@ -45,7 +32,6 @@ test.describe('#779 standard プラン — 機能疎通', () => {
 	});
 
 	test('/admin にホームを開いても free 用アップグレード CTA が出ない', async ({ page }) => {
-		await loginAsPlan(page, 'standard');
 		await page.goto('/admin');
 		// standard のときは PlanStatusCard が data-plan-tier="standard" で表示される
 		const card = page.getByTestId('plan-status-card');
@@ -56,13 +42,11 @@ test.describe('#779 standard プラン — 機能疎通', () => {
 	});
 
 	test('/admin/reports — weekly-report-upsell バナーが出ない', async ({ page }) => {
-		await loginAsPlan(page, 'standard');
 		await page.goto('/admin/reports');
 		await expect(page.getByTestId('weekly-report-upsell')).toHaveCount(0);
 	});
 
 	test('/admin/settings — エクスポートボタンが有効化されている', async ({ page }) => {
-		await loginAsPlan(page, 'standard');
 		await page.goto('/admin/settings');
 		await expect(page.getByTestId('data-export-section')).toBeVisible();
 		// free 用アップセルは出ない
@@ -75,7 +59,6 @@ test.describe('#779 standard プラン — 機能疎通', () => {
 
 	test('/admin/messages — ひとことメッセージは family 限定で disabled のまま', async ({ page }) => {
 		// プラン境界の回帰検知: standard はまだ family 限定機能にアクセスできない
-		await loginAsPlan(page, 'standard');
 		await page.goto('/admin/messages');
 		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
 		await expect(textBtn).toBeVisible();

--- a/tests/e2e/premium-welcome.spec.ts
+++ b/tests/e2e/premium-welcome.spec.ts
@@ -18,12 +18,13 @@
 //    ローカル E2E では beforeEach で settings 行を削除して初回表示状態を再現し、
 //    afterEach で `'true'` に戻すことで他 spec への副作用を防ぐ。
 //
+// #1535: loginAsPlan() を storageState ベースに移行（describe ブロック分割）
+//
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts premium-welcome
 
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import Database from 'better-sqlite3';
-import { loginAsPlan, warmupAdminPages } from './plan-login-helpers';
 
 const DB_PATH = path.resolve('data/ganbari-quest.db');
 
@@ -47,24 +48,19 @@ function markWelcomeDismissed(): void {
 	}
 }
 
-test.beforeAll(async ({ browser }) => {
-	test.setTimeout(360_000);
-	await warmupAdminPages(browser, ['/admin']);
-});
-
 test.afterEach(() => {
 	// 他 spec の /admin 訪問にモーダルがかぶらないよう必ず dismissed 状態に戻す
 	markWelcomeDismissed();
 });
 
-test.describe('#778 PremiumWelcome モーダル', () => {
+test.describe('#778 PremiumWelcome モーダル — standard', () => {
+	test.use({ storageState: 'playwright/.auth/standard.json' });
+
 	test.beforeEach(() => {
-		test.slow(); // Vite dev のコールドコンパイルでタイムアウトを 3x 延長
 		resetWelcomeFlag();
 	});
 
 	test('standard プラン初回 /admin で歓迎モーダルが表示される', async ({ page }) => {
-		await loginAsPlan(page, 'standard');
 		await page.goto('/admin');
 		const dialog = page.getByRole('dialog', { name: /スタンダード.*ようこそ/ });
 		await expect(dialog).toBeVisible();
@@ -75,18 +71,7 @@ test.describe('#778 PremiumWelcome モーダル', () => {
 		await expect(dialog.getByText('特別なごほうび設定')).toBeVisible();
 	});
 
-	test('family プラン初回 /admin で歓迎モーダルが表示される', async ({ page }) => {
-		await loginAsPlan(page, 'family');
-		await page.goto('/admin');
-		const dialog = page.getByRole('dialog', { name: /ファミリー.*ようこそ/ });
-		await expect(dialog).toBeVisible();
-		// family 固有の項目（PREMIUM_UNLOCKED_FEATURES.family より）
-		await expect(dialog.getByText('きょうだいランキング')).toBeVisible();
-		await expect(dialog.getByText('ひとことメッセージ（自由テキスト）')).toBeVisible();
-	});
-
 	test('「さっそく始める」で閉じた後はリロードしても表示されない', async ({ page }) => {
-		await loginAsPlan(page, 'standard');
 		await page.goto('/admin');
 		const dialog = page.getByRole('dialog', { name: /スタンダード.*ようこそ/ });
 		await expect(dialog).toBeVisible();
@@ -96,9 +81,33 @@ test.describe('#778 PremiumWelcome モーダル', () => {
 		await page.reload();
 		await expect(page.getByRole('dialog', { name: /ようこそ/ })).toHaveCount(0);
 	});
+});
+
+test.describe('#778 PremiumWelcome モーダル — family', () => {
+	test.use({ storageState: 'playwright/.auth/family.json' });
+
+	test.beforeEach(() => {
+		resetWelcomeFlag();
+	});
+
+	test('family プラン初回 /admin で歓迎モーダルが表示される', async ({ page }) => {
+		await page.goto('/admin');
+		const dialog = page.getByRole('dialog', { name: /ファミリー.*ようこそ/ });
+		await expect(dialog).toBeVisible();
+		// family 固有の項目（PREMIUM_UNLOCKED_FEATURES.family より）
+		await expect(dialog.getByText('きょうだいランキング')).toBeVisible();
+		await expect(dialog.getByText('ひとことメッセージ（自由テキスト）')).toBeVisible();
+	});
+});
+
+test.describe('#778 PremiumWelcome モーダル — free（表示なし確認）', () => {
+	test.use({ storageState: 'playwright/.auth/free.json' });
+
+	test.beforeEach(() => {
+		resetWelcomeFlag();
+	});
 
 	test('free プランでは歓迎モーダルは出ない（プラン条件ガード）', async ({ page }) => {
-		await loginAsPlan(page, 'free');
 		await page.goto('/admin');
 		// AdminHome の {#if welcomeVisible && (planTier === 'standard' || 'family')} ガード
 		await expect(page.getByRole('dialog', { name: /ようこそ/ })).toHaveCount(0);

--- a/tests/e2e/pricing-page-signup.spec.ts
+++ b/tests/e2e/pricing-page-signup.spec.ts
@@ -11,23 +11,81 @@
 //   3. トライアル開始後に /admin で TrialBanner が「残り 7 日」を表示
 //   4. /admin/license で planTier が standard に昇格していること
 //
+// #1535: loginAsPlan() を storageState ベースに移行
+//
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts pricing-page-signup
 
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
-import { loginAsPlan, warmupAdminPages } from './plan-login-helpers';
 
-test.beforeAll(async ({ browser }) => {
-	test.setTimeout(360_000);
-	await warmupAdminPages(browser, ['/pricing', '/admin', '/admin/license']);
+// ========================================================
+// 1. /pricing の「7日間 無料体験」ボタンの href 検証
+//    （認証不要なページ）
+// ========================================================
+test('/pricing の CTA リンクが /auth/signup?plan=X を指す', async ({ page }) => {
+	await page.goto('/pricing', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+
+	// standard プランの CTA
+	const standardCta = page.locator('[data-plan="standard"]').getByTestId('pricing-cta');
+	await expect(standardCta).toBeVisible({ timeout: 30_000 });
+	await expect(standardCta).toHaveAttribute('href', '/auth/signup?plan=standard');
+	await expect(standardCta).toHaveText('7日間 無料体験');
+
+	// family プランの CTA
+	const familyCta = page.locator('[data-plan="family"]').getByTestId('pricing-cta');
+	await expect(familyCta).toBeVisible();
+	await expect(familyCta).toHaveAttribute('href', '/auth/signup?plan=family');
+	await expect(familyCta).toHaveText('7日間 無料体験');
+
+	// free プランの CTA（トライアルなし）
+	const freeCta = page.locator('[data-plan="free"]').getByTestId('pricing-cta');
+	await expect(freeCta).toBeVisible();
+	await expect(freeCta).toHaveAttribute('href', '/auth/signup');
+	await expect(freeCta).toHaveText('無料ではじめる');
 });
 
-test.describe('#757 pricing → signup → トライアル自動開始', () => {
-	test.describe.configure({ mode: 'serial' });
-
-	test.beforeEach(() => {
-		test.slow(); // Vite dev のコールドコンパイルでタイムアウトを 3x 延長
+// ========================================================
+// 2. signup 画面で plan パラメータが反映される
+//    （cognito-dev モードでは redirect されるが、UI テキストを検証）
+//    （認証不要なページ）
+// ========================================================
+test('/auth/signup?plan=standard で plan パラメータが signup UI に反映される', async ({ page }) => {
+	// cognito-dev モードでは /auth/signup → /auth/login にリダイレクトされる。
+	// リダイレクト後のログインフォームが表示されることで、signup ルートが
+	// 機能していることを間接的に確認する。
+	await page.goto('/auth/signup?plan=standard', {
+		waitUntil: 'commit',
+		timeout: 30_000,
 	});
+
+	// cognito-dev モードでは /auth/login にリダイレクトされる
+	await page.waitForURL(/\/auth\/login/, { timeout: 30_000 });
+	// ログインフォームが表示される
+	await expect(page.getByLabel('メールアドレス')).toBeVisible({ timeout: 30_000 });
+});
+
+// ========================================================
+// 6. pricing → signup?plan=family の href も正しい
+//    （認証不要なページ）
+// ========================================================
+test('/pricing の family プラン CTA が plan=family パラメータを含む', async ({ page }) => {
+	await page.goto('/pricing', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+
+	const familyCta = page.locator('[data-plan="family"]').getByTestId('pricing-cta');
+	await expect(familyCta).toBeVisible({ timeout: 30_000 });
+
+	const href = await familyCta.getAttribute('href');
+	expect(href).toBe('/auth/signup?plan=family');
+});
+
+// ========================================================
+// 3〜5. free ユーザーでトライアル開始 → バナー確認
+//       （storageState で free ユーザーとして認証済み）
+//       serial モードで順番に実行（テスト4・5はテスト3の副作用に依存）
+// ========================================================
+test.describe('#757 free ユーザートライアル開始フロー', () => {
+	test.use({ storageState: 'playwright/.auth/free.json' });
+	test.describe.configure({ mode: 'serial' });
 
 	// テスト終了後に dev-tenant-free のトライアルをクリーンアップ
 	// （trial-flow.spec.ts や plan-free.spec.ts への副作用防止）
@@ -49,59 +107,8 @@ test.describe('#757 pricing → signup → トライアル自動開始', () => {
 		}
 	});
 
-	// ========================================================
-	// 1. /pricing の「7日間 無料体験」ボタンの href 検証
-	// ========================================================
-	test('/pricing の CTA リンクが /auth/signup?plan=X を指す', async ({ page }) => {
-		await page.goto('/pricing', { waitUntil: 'domcontentloaded', timeout: 180_000 });
-
-		// standard プランの CTA
-		const standardCta = page.locator('[data-plan="standard"]').getByTestId('pricing-cta');
-		await expect(standardCta).toBeVisible({ timeout: 30_000 });
-		await expect(standardCta).toHaveAttribute('href', '/auth/signup?plan=standard');
-		await expect(standardCta).toHaveText('7日間 無料体験');
-
-		// family プランの CTA
-		const familyCta = page.locator('[data-plan="family"]').getByTestId('pricing-cta');
-		await expect(familyCta).toBeVisible();
-		await expect(familyCta).toHaveAttribute('href', '/auth/signup?plan=family');
-		await expect(familyCta).toHaveText('7日間 無料体験');
-
-		// free プランの CTA（トライアルなし）
-		const freeCta = page.locator('[data-plan="free"]').getByTestId('pricing-cta');
-		await expect(freeCta).toBeVisible();
-		await expect(freeCta).toHaveAttribute('href', '/auth/signup');
-		await expect(freeCta).toHaveText('無料ではじめる');
-	});
-
-	// ========================================================
-	// 2. signup 画面で plan パラメータが反映される
-	//    （cognito-dev モードでは redirect されるが、UI テキストを検証）
-	// ========================================================
-	test('/auth/signup?plan=standard で plan パラメータが signup UI に反映される', async ({
-		page,
-	}) => {
-		// cognito-dev モードでは /auth/signup → /auth/login にリダイレクトされる。
-		// リダイレクト後のログインフォームが表示されることで、signup ルートが
-		// 機能していることを間接的に確認する。
-		await page.goto('/auth/signup?plan=standard', {
-			waitUntil: 'commit',
-			timeout: 180_000,
-		});
-
-		// cognito-dev モードでは /auth/login にリダイレクトされる
-		await page.waitForURL(/\/auth\/login/, { timeout: 30_000 });
-		// ログインフォームが表示される
-		await expect(page.getByLabel('メールアドレス')).toBeVisible({ timeout: 30_000 });
-	});
-
-	// ========================================================
-	// 3. free ユーザーでトライアル開始 → TrialBanner 表示
-	//    （signup 後のトライアル自動開始をシミュレート）
-	// ========================================================
 	test('free ユーザーでトライアル開始後に TrialBanner が「無料体験中」を表示', async ({ page }) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		// まずトライアル未開始状態を確認
 		const startButton = page.getByTestId('trial-banner-start-button');
@@ -117,15 +124,11 @@ test.describe('#757 pricing → signup → トライアル自動開始', () => {
 		await expect(page.getByTestId('trial-banner-active-cta')).toBeVisible();
 	});
 
-	// ========================================================
-	// 4. トライアル開始後 — /admin/license で standard に昇格
-	// ========================================================
 	test('トライアル開始後に /admin/license で planTier が standard に昇格している', async ({
 		page,
 	}) => {
 		// 前のテストでトライアルが開始されている前提（同一 tenant DB が共有）
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 30_000 });
 
 		// PlanStatusCard にトライアルバッジが表示される
 		const trialBadge = page.getByTestId('plan-status-trial-badge');
@@ -133,12 +136,8 @@ test.describe('#757 pricing → signup → トライアル自動開始', () => {
 		await expect(trialBadge).toContainText(/残り.*日/);
 	});
 
-	// ========================================================
-	// 5. TrialBanner の「プランを見る」CTA が /pricing に遷移
-	// ========================================================
 	test('TrialBanner の CTA が /pricing へのリンクである', async ({ page }) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		// active バナーの CTA リンクを検証
 		const cta = page.getByTestId('trial-banner-active-cta');
@@ -149,18 +148,5 @@ test.describe('#757 pricing → signup → トライアル自動開始', () => {
 		expect(href).toBeTruthy();
 		// CTA は /pricing またはライセンスページへのリンク
 		expect(href).toMatch(/\/(pricing|admin\/license)/);
-	});
-
-	// ========================================================
-	// 6. pricing → signup?plan=family の href も正しい
-	// ========================================================
-	test('/pricing の family プラン CTA が plan=family パラメータを含む', async ({ page }) => {
-		await page.goto('/pricing', { waitUntil: 'domcontentloaded', timeout: 180_000 });
-
-		const familyCta = page.locator('[data-plan="family"]').getByTestId('pricing-cta');
-		await expect(familyCta).toBeVisible({ timeout: 30_000 });
-
-		const href = await familyCta.getAttribute('href');
-		expect(href).toBe('/auth/signup?plan=family');
 	});
 });

--- a/tests/e2e/trial-banner-display.spec.ts
+++ b/tests/e2e/trial-banner-display.spec.ts
@@ -9,27 +9,20 @@
 // 検証するのに対し、この spec は「各プラン × 各トライアル状態」のマトリクスで
 // バナーの表示/非表示を網羅的に検証する。
 //
+// #1535: loginAsPlan() を storageState ベースに移行（describe ブロック分割）
+//
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts trial-banner-display
 
 import { expect, test } from '@playwright/test';
-import { loginAsPlan, warmupAdminPages } from './plan-login-helpers';
-
-test.beforeAll(async ({ browser }) => {
-	test.setTimeout(360_000);
-	await warmupAdminPages(browser, ['/admin']);
-});
 
 // ============================================================
 // free プラン — トライアル未使用 → not-started バナー
 // ============================================================
 test.describe('#750 TrialBanner 表示 — free（トライアル未使用）', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+	test.use({ storageState: 'playwright/.auth/free.json' });
 
 	test('free ユーザーの /admin に not-started バナーが表示される', async ({ page }) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		const banner = page.getByTestId('trial-banner-not-started');
 		await expect(banner).toBeVisible({ timeout: 30_000 });
@@ -38,8 +31,7 @@ test.describe('#750 TrialBanner 表示 — free（トライアル未使用）', 
 	});
 
 	test('not-started バナーに「カード登録不要」のテキストがある', async ({ page }) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		const banner = page.getByTestId('trial-banner-not-started');
 		await expect(banner).toBeVisible({ timeout: 30_000 });
@@ -51,13 +43,10 @@ test.describe('#750 TrialBanner 表示 — free（トライアル未使用）', 
 // trial-expired — 期限切れ → expired バナー
 // ============================================================
 test.describe('#750 TrialBanner 表示 — trial-expired', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+	test.use({ storageState: 'playwright/.auth/trial-expired.json' });
 
 	test('トライアル期限切れユーザーの /admin に expired バナーが表示される', async ({ page }) => {
-		await loginAsPlan(page, 'trial-expired');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		const banner = page.getByTestId('trial-banner-expired');
 		await expect(banner).toBeVisible({ timeout: 30_000 });
@@ -65,8 +54,7 @@ test.describe('#750 TrialBanner 表示 — trial-expired', () => {
 	});
 
 	test('expired バナーにアップグレード CTA が表示される', async ({ page }) => {
-		await loginAsPlan(page, 'trial-expired');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		const cta = page.getByTestId('trial-banner-expired-cta');
 		await expect(cta).toBeVisible({ timeout: 30_000 });
@@ -74,8 +62,7 @@ test.describe('#750 TrialBanner 表示 — trial-expired', () => {
 	});
 
 	test('expired ユーザーには「開始」ボタンが表示されない', async ({ page }) => {
-		await loginAsPlan(page, 'trial-expired');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		// expired バナーが表示されるまで待つ
 		await page.getByTestId('trial-banner-expired').waitFor({ state: 'visible', timeout: 30_000 });
@@ -86,14 +73,11 @@ test.describe('#750 TrialBanner 表示 — trial-expired', () => {
 // ============================================================
 // standard / family プラン — トライアルバナー非表示
 // ============================================================
-test.describe('#750 TrialBanner 表示 — 有料プラン', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+test.describe('#750 TrialBanner 表示 — standard（有料プラン）', () => {
+	test.use({ storageState: 'playwright/.auth/standard.json' });
 
 	test('standard プランユーザーにはトライアルバナーが表示されない', async ({ page }) => {
-		await loginAsPlan(page, 'standard');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		// /admin のメインコンテンツが描画されるまで待つ
 		await page.waitForLoadState('domcontentloaded');
@@ -104,10 +88,13 @@ test.describe('#750 TrialBanner 表示 — 有料プラン', () => {
 		// active バナーには testid がないため、「無料体験中」テキストの不在で確認
 		await expect(page.getByText('無料体験中')).toHaveCount(0);
 	});
+});
+
+test.describe('#750 TrialBanner 表示 — family（有料プラン）', () => {
+	test.use({ storageState: 'playwright/.auth/family.json' });
 
 	test('family プランユーザーにはトライアルバナーが表示されない', async ({ page }) => {
-		await loginAsPlan(page, 'family');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		await page.waitForLoadState('domcontentloaded');
 

--- a/tests/e2e/trial-flow.spec.ts
+++ b/tests/e2e/trial-flow.spec.ts
@@ -6,25 +6,23 @@
 // - dev-tenant-trial-expired: トライアル期限切れ済みの free ユーザー
 //   （global-setup.ts で trial_history に過去日レコードをシード）
 //
+// #1535: loginAsPlan() を storageState ベースに移行（describe ブロック分割）
+//        beforeAll warmup は削除（storageState + dev サーバーなら不要）
+//        DB クリーンアップロジックは保持（テスト間副作用防止のため必要）
+//
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts trial-flow
 
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
-import { loginAsPlan, warmupAdminPages } from './plan-login-helpers';
 
-test.beforeAll(async ({ browser }) => {
-	test.setTimeout(360_000);
-	await warmupAdminPages(browser, ['/admin', '/admin/license']);
-});
-
-test.describe('#752 トライアルフロー', () => {
+// ============================================================
+// free ユーザーのトライアルフロー（開始 → active → license 確認）
+// serial モードで順番に実行（テスト3はテスト2の副作用に依存）
+// ============================================================
+test.describe('#752 トライアルフロー — free ユーザー', () => {
+	test.use({ storageState: 'playwright/.auth/free.json' });
 	// MUST: テスト 3 はテスト 2 でトライアルが開始された状態に依存するため serial 実行必須
-	// fullyParallel: true（playwright.cognito-dev.config.ts）との矛盾を解消
 	test.describe.configure({ mode: 'serial' });
-
-	test.beforeEach(() => {
-		test.slow(); // Vite dev のコールドコンパイルでタイムアウトを 3x 延長
-	});
 
 	// テスト 2 で dev-tenant-free のトライアルを開始するため、
 	// テスト終了後にクリーンアップして plan-free.spec.ts への副作用を防ぐ
@@ -50,8 +48,7 @@ test.describe('#752 トライアルフロー', () => {
 	// 1. 未使用 free ユーザーにトライアル開始導線が表示
 	// ========================================================
 	test('free ユーザーに TrialBanner の「開始」状態が表示される', async ({ page }) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		const banner = page.getByTestId('trial-banner-not-started');
 		await expect(banner).toBeVisible({ timeout: 30_000 });
@@ -65,8 +62,7 @@ test.describe('#752 トライアルフロー', () => {
 	// 2. 「7日間無料で試す」ボタンでトライアル開始 → active 状態
 	// ========================================================
 	test('トライアル開始ボタンクリック → active バナーに切り替わる', async ({ page }) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		// 「開始」バナーが表示されるまで待機
 		await page
@@ -93,20 +89,25 @@ test.describe('#752 トライアルフロー', () => {
 		// トライアル中は resolvePlanTier() が planTier='standard' に昇格させるため、
 		// license ページの `{#if planTier === 'free'}` トライアルセクションは表示されない。
 		// 代わりに PlanStatusCard の trial-badge（isTrialActive で描画）で検証する。
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 30_000 });
 
 		const trialBadge = page.getByTestId('plan-status-trial-badge');
 		await expect(trialBadge).toBeVisible({ timeout: 30_000 });
 		await expect(trialBadge).toContainText(/残り.*日/);
 	});
+});
+
+// ============================================================
+// trial-expired ユーザーの確認
+// ============================================================
+test.describe('#752 トライアルフロー — trial-expired ユーザー', () => {
+	test.use({ storageState: 'playwright/.auth/trial-expired.json' });
 
 	// ========================================================
 	// 4. トライアル期限切れユーザー — expired バナー表示
 	// ========================================================
 	test('トライアル期限切れユーザーに expired バナーが表示される', async ({ page }) => {
-		await loginAsPlan(page, 'trial-expired');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		const expiredBanner = page.getByTestId('trial-banner-expired');
 		await expect(expiredBanner).toBeVisible({ timeout: 30_000 });
@@ -120,8 +121,7 @@ test.describe('#752 トライアルフロー', () => {
 	// 5. 期限切れユーザー — 再トライアル開始ボタンが存在しない
 	// ========================================================
 	test('トライアル使用済みユーザーには「開始」ボタンが表示されない', async ({ page }) => {
-		await loginAsPlan(page, 'trial-expired');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		// expired バナーが表示されるまで待つ
 		await page.getByTestId('trial-banner-expired').waitFor({ state: 'visible', timeout: 30_000 });
@@ -133,8 +133,7 @@ test.describe('#752 トライアルフロー', () => {
 	// 6. 期限切れ後に /admin/license でトライアル終了状態が表示される
 	// ========================================================
 	test('期限切れ後の /admin/license でトライアル終了が反映される', async ({ page }) => {
-		await loginAsPlan(page, 'trial-expired');
-		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 30_000 });
 
 		// license ページの PlanStatusCard が free を示す
 		const card = page.getByTestId('plan-status-card');

--- a/tests/e2e/upgrade-flow.spec.ts
+++ b/tests/e2e/upgrade-flow.spec.ts
@@ -9,35 +9,23 @@
 //  - POST /api/stripe/checkout は Stripe が無効な環境では 503 を返す
 //  - アップグレード成功後の動作は PremiumWelcome spec (#778) で検証済み
 //
+// #1535: loginAsPlan() を storageState ベースに移行（describe ブロック分割）
+//        beforeAll warmup は削除（storageState + dev サーバーなら不要）
+//
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts upgrade-flow
 
 import { expect, test } from '@playwright/test';
-import { loginAsPlan, warmupAdminPages } from './plan-login-helpers';
-
-test.beforeAll(async ({ browser }) => {
-	test.setTimeout(360_000);
-	await warmupAdminPages(browser, [
-		'/admin',
-		'/admin/license',
-		'/admin/rewards',
-		'/admin/activities',
-		'/pricing',
-	]);
-});
 
 // ============================================================
-// 1. PlanStatusCard からのアップグレード CTA
+// 1. PlanStatusCard からのアップグレード CTA（free）
 // ============================================================
-test.describe('#753 PlanStatusCard → /admin/license', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+test.describe('#753 PlanStatusCard → /admin/license — free', () => {
+	test.use({ storageState: 'playwright/.auth/free.json' });
 
 	test('free プランの PlanStatusCard に「スタンダードにアップグレード」CTA がある', async ({
 		page,
 	}) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 30_000 });
 
 		const card = page.getByTestId('plan-status-card');
 		await expect(card).toBeVisible({ timeout: 30_000 });
@@ -49,8 +37,7 @@ test.describe('#753 PlanStatusCard → /admin/license', () => {
 	});
 
 	test('free プランの PlanStatusCard に「ファミリーへ」CTA がある', async ({ page }) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 30_000 });
 
 		const familyCta = page.getByTestId('plan-status-family-cta');
 		const count = await familyCta.count();
@@ -64,12 +51,18 @@ test.describe('#753 PlanStatusCard → /admin/license', () => {
 		await expect(familyCta).toBeVisible({ timeout: 10_000 });
 		await expect(familyCta).toContainText(/ファミリー/);
 	});
+});
+
+// ============================================================
+// 1. PlanStatusCard からのアップグレード CTA（standard）
+// ============================================================
+test.describe('#753 PlanStatusCard → /admin/license — standard', () => {
+	test.use({ storageState: 'playwright/.auth/standard.json' });
 
 	test('standard プランの PlanStatusCard にファミリーアップグレード CTA がある', async ({
 		page,
 	}) => {
-		await loginAsPlan(page, 'standard');
-		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 30_000 });
 
 		const card = page.getByTestId('plan-status-card');
 		await expect(card).toBeVisible({ timeout: 30_000 });
@@ -81,10 +74,16 @@ test.describe('#753 PlanStatusCard → /admin/license', () => {
 		const portalOrPreparing = portalBtn.or(preparingText);
 		await expect(portalOrPreparing).toBeVisible({ timeout: 10_000 });
 	});
+});
+
+// ============================================================
+// 1. PlanStatusCard からのアップグレード CTA（family）
+// ============================================================
+test.describe('#753 PlanStatusCard → /admin/license — family', () => {
+	test.use({ storageState: 'playwright/.auth/family.json' });
 
 	test('family プランの PlanStatusCard にアップグレード CTA は表示されない', async ({ page }) => {
-		await loginAsPlan(page, 'family');
-		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 30_000 });
 
 		const card = page.getByTestId('plan-status-card');
 		await expect(card).toBeVisible({ timeout: 30_000 });
@@ -99,18 +98,15 @@ test.describe('#753 PlanStatusCard → /admin/license', () => {
 });
 
 // ============================================================
-// 2. /admin/rewards からの disabled CTA → /admin/license
+// 2. /admin/rewards からの disabled CTA → /admin/license（free）
 // ============================================================
 test.describe('#753 /admin/rewards → アップグレード導線', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+	test.use({ storageState: 'playwright/.auth/free.json' });
 
 	test('free プランで rewards-upgrade-banner が表示され、CTA が /admin/license へリンクする', async ({
 		page,
 	}) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin/rewards', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/rewards', { waitUntil: 'commit', timeout: 30_000 });
 
 		const banner = page.getByTestId('rewards-upgrade-banner');
 		await expect(banner).toBeVisible({ timeout: 30_000 });
@@ -125,16 +121,13 @@ test.describe('#753 /admin/rewards → アップグレード導線', () => {
 });
 
 // ============================================================
-// 3. /admin/activities の AiSuggestPanel disabled CTA → /admin/license
+// 3. /admin/activities の AiSuggestPanel disabled CTA → /admin/license（free）
 // ============================================================
 test.describe('#753 /admin/activities AI → アップグレード導線', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+	test.use({ storageState: 'playwright/.auth/free.json' });
 
 	test('free プランで AI パネルの upgrade-cta が /admin/license へリンクする', async ({ page }) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin/activities', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/activities', { waitUntil: 'commit', timeout: 30_000 });
 
 		// FAB から追加ダイアログを開き AI モードを選択
 		await page.waitForLoadState('domcontentloaded');
@@ -158,16 +151,13 @@ test.describe('#753 /admin/activities AI → アップグレード導線', () =>
 });
 
 // ============================================================
-// 4. /pricing からのサインアップ → /admin/license 導線
+// 4. /pricing からのサインアップ → /admin/license 導線（free）
 // ============================================================
 test.describe('#753 /pricing → アップグレード導線', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+	test.use({ storageState: 'playwright/.auth/free.json' });
 
 	test('/pricing ページにプランカードと CTA が表示される', async ({ page }) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/pricing', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/pricing', { waitUntil: 'commit', timeout: 30_000 });
 
 		await expect(page.getByTestId('pricing-heading')).toBeVisible({ timeout: 30_000 });
 
@@ -185,6 +175,7 @@ test.describe('#753 /pricing → アップグレード導線', () => {
 
 // ============================================================
 // 5. /admin/license でプラン選択 → Stripe Checkout 遷移 (mock)
+//    （認証不要な API テスト）
 // ============================================================
 test.describe('#753 Stripe Checkout 遷移 — API', () => {
 	test('POST /api/stripe/checkout に有効なプランで 503 が返る（Stripe 未設定環境）', async ({
@@ -213,16 +204,13 @@ test.describe('#753 Stripe Checkout 遷移 — API', () => {
 });
 
 // ============================================================
-// 6. /admin/license のプラン選択 UI
+// 6. /admin/license のプラン選択 UI（free）
 // ============================================================
-test.describe('#753 /admin/license プラン選択 UI', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+test.describe('#753 /admin/license プラン選択 UI — free', () => {
+	test.use({ storageState: 'playwright/.auth/free.json' });
 
 	test('free プランで /admin/license にプラン選択カードが表示される', async ({ page }) => {
-		await loginAsPlan(page, 'free');
-		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 30_000 });
 
 		// Stripe が無効な環境では「決済機能は現在準備中です」が出る。
 		// Stripe 有効環境ではプラン選択カードが表示される。
@@ -249,12 +237,18 @@ test.describe('#753 /admin/license プラン選択 UI', () => {
 		await expect(page.getByText('月額')).toBeVisible();
 		await expect(page.getByText(/年額/)).toBeVisible();
 	});
+});
+
+// ============================================================
+// 6. /admin/license のプラン選択 UI（standard）
+// ============================================================
+test.describe('#753 /admin/license プラン選択 UI — standard', () => {
+	test.use({ storageState: 'playwright/.auth/standard.json' });
 
 	test('standard プランでは Stripe Portal ボタンが表示される（サブスク有りの場合）', async ({
 		page,
 	}) => {
-		await loginAsPlan(page, 'standard');
-		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/license', { waitUntil: 'commit', timeout: 30_000 });
 
 		// standard はサブスクリプション有りなので Portal ボタンが出る、
 		// または dev 環境では Stripe 未設定で「決済機能は現在準備中です」が出る
@@ -266,53 +260,53 @@ test.describe('#753 /admin/license プラン選択 UI', () => {
 });
 
 // ============================================================
-// 7. アップグレード成功後の PremiumWelcome モーダル表示
+// 7. アップグレード成功後の PremiumWelcome モーダル表示（standard / family）
 // ============================================================
-test.describe('#753 PremiumWelcome モーダル — 表示確認', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+test.describe('#753 PremiumWelcome モーダル — standard', () => {
+	test.use({ storageState: 'playwright/.auth/standard.json' });
 
 	test('standard プランで /admin に歓迎モーダルの条件がある', async ({ page }) => {
 		// PremiumWelcome の詳細テストは premium-welcome.spec.ts に委譲。
 		// ここではアップグレード導線の一部として、standard/family ログイン後に
 		// /admin にアクセスできることを確認する。
-		await loginAsPlan(page, 'standard');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		// /admin に到達していることを確認
 		await expect(page).toHaveURL(/\/admin/);
 	});
+});
+
+test.describe('#753 PremiumWelcome モーダル — family', () => {
+	test.use({ storageState: 'playwright/.auth/family.json' });
 
 	test('family プランで /admin に到達できる', async ({ page }) => {
-		await loginAsPlan(page, 'family');
-		await page.goto('/admin', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
 
 		await expect(page).toHaveURL(/\/admin/);
 	});
 });
 
 // ============================================================
-// 8. アップグレード成功後の機能即時有効化
+// 8. アップグレード成功後の機能即時有効化（standard / family）
 // ============================================================
-test.describe('#753 アップグレード後の機能有効化', () => {
-	test.beforeEach(() => {
-		test.slow();
-	});
+test.describe('#753 アップグレード後の機能有効化 — standard', () => {
+	test.use({ storageState: 'playwright/.auth/standard.json' });
 
 	test('standard プランでカスタムごほうびが有効（rewards-upgrade-banner 非表示）', async ({
 		page,
 	}) => {
-		await loginAsPlan(page, 'standard');
-		await page.goto('/admin/rewards', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/rewards', { waitUntil: 'commit', timeout: 30_000 });
 
 		// standard では rewards-upgrade-banner は非表示
 		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
 	});
+});
+
+test.describe('#753 アップグレード後の機能有効化 — family', () => {
+	test.use({ storageState: 'playwright/.auth/family.json' });
 
 	test('family プランでひとことメッセージが有効', async ({ page }) => {
-		await loginAsPlan(page, 'family');
-		await page.goto('/admin/messages', { waitUntil: 'commit', timeout: 180_000 });
+		await page.goto('/admin/messages', { waitUntil: 'commit', timeout: 30_000 });
 
 		const textBtn = page.getByRole('button', { name: /ひとことメッセージ/ });
 		await expect(textBtn).toBeVisible({ timeout: 30_000 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（CI/CD）

**解決する課題**:
E2E テストで `loginAsPlan()` によるフルログインが毎テストケースで実行されており、テスト実行時間が長くなっていた。また `upgrade-checkout.spec.ts` が `tests/e2e/` 直下にあり、Integration 分類のファイルとして `tests/e2e/integration/` に置かれるべきだった。

**期待される効果**:
storageState による認証セッション再利用で、ログインコストを setup プロジェクトの一度だけに削減。テスト実行速度が向上し、CI の integration-test ジョブが 5 分以内に収まる。

## 関連 Issue

closes #1535

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | upgrade-checkout.spec.ts を tests/e2e/integration/ に移動 | `git log --oneline` + diff で rename 確認 | `tests/e2e/upgrade-checkout.spec.ts → tests/e2e/integration/upgrade-checkout.spec.ts` (rename) |
| AC2 | loginAsPlan() 呼び出しを 0 回に削減（account-deletion.spec.ts 除く） | `grep -r "loginAsPlan" tests/e2e/ --include="*.ts"` | account-deletion.spec.ts のみ残存（別 PR #1560 対応中） |
| AC3 | CI integration-test ジョブが 5 分以内で success | CI 実行ログ確認 | PASS — e2e-cognito-dev: 2m22s（GitHub Actions run #24955566998） |
| AC4 | CI 全体の実行時間が 10 分以内を維持 | CI 実行ログ確認 | PASS — e2e-test 最長 7m7s、全ジョブ 10 分以内（GitHub Actions run #24955566998） |

## 変更タイプ

- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — playwright.cognito-dev.config.ts

**影響を受ける画面・機能**:
E2E テスト実行の認証方式のみ。アプリ本体のコードは一切変更なし。

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 認証方式 | 各テストで `loginAsPlan()` によるフルログイン | `test.use({ storageState })` で setup プロジェクトが保存した認証済みセッションを再利用 |
| テスト構造 | 複数ロール混在 describe に beforeAll warmup | ロール別 describe ブロック + `test.use(storageState)` |
| タイムアウト | `timeout: 180_000` + `test.slow()` | `timeout: 30_000`（warmup 不要のため） |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: `beforeAll warmupAdminPages` を全スペックから削除（storageState + dev サーバーなら warmup 不要）。複数ロール混在 describe を describe ブロック分割へリファクタリング。
- **リファクタリングが必要だが今回見送った箇所と理由**: `account-deletion.spec.ts` — 別 PR (#1560) 対応中のため本 PR では未変更
- **削除したコード・機能**: `warmupAdminPages` 呼び出し（全対象ファイル）、`loginAsPlan` 呼び出し（全対象ファイル）

## 設計方針・将来性

**採用した設計方針**:
`test.use({ storageState })` をファイルトップレベルまたは describe ブロックに置くパターン。混在ロールは describe 分割で表現。

**想定する将来の拡張**:
新規 cognito-dev spec を追加する場合、`loginAsPlan()` を使わず最初から `test.use({ storageState })` パターンで実装できる。

**意図的に対応しなかった範囲とその理由**:
`plan-login-helpers.ts` の `loginAsPlan` 関数自体は `account-deletion.spec.ts` から参照されているため保持。全参照がゼロになれば別 PR でファイルごと削除予定。

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — 既存機能の bug fix / refactor / docs のため設計ポリシー確認不要

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加/変更なし

**E2Eテスト**:
- 変更したテスト: plan-family / plan-free / plan-standard / plan-gated-features / premium-welcome / pricing-page-signup / trial-banner-display / trial-flow / upgrade-flow / upgrade-checkout (移動)
- カバーするユーザーフロー: 各プラン別の機能ゲート UI 確認、トライアル開始/終了フロー、アップグレード導線確認（認証方式の変更のみでテスト内容自体は同等）

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check .` (変更ファイル) | PASS | 11 files checked, no fixes applied |
| 型チェック | `npx svelte-check` | PASS | 0 errors, 0 warnings |
| 単体テスト | `npx vitest run` | PASS | GitHub Actions unit-test (1)(2): PASS（run #24955566998） |
| E2E テスト | `npx playwright test --config playwright.cognito-dev.config.ts` | PASS | GitHub Actions e2e-test (1)(2)(3) + e2e-cognito-dev: PASS（run #24955566998） |

**網羅性の判断根拠**:
テストコードのみ変更（認証方式の差し替えとファイル移動）。アプリコードは変更なし。各テストのアサーション内容は変更なし。

### DynamoDB 実装完成度（#1021）

- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | N/A | テストコードのみの変更 |
| パフォーマンス | テスト実行時間の短縮 | storageState 再利用によりログイン処理を削減 |
| アクセシビリティ | N/A | UI 変更なし |
| ロギング・モニタリング | N/A | |
| ドキュメント | N/A | テストファイル移動のみ。設計書への影響なし |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: 各 describe ブロックがロール別に分割されており単一責務
- [x] **DRY / 横展開**: `loginAsPlan()` 呼び出しパターンを全対象ファイルで一括移行済み
- [x] **YAGNI**: 不要な抽象化は追加していない

### セキュリティ（OSS 公開前提）
- [x] **N/A** — セキュリティ関連の変更なし

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] **N/A** — テストコードのみ

## スクリーンショット / ビジュアルデモ

N/A — UI 変更なし（テストコードとプレイライト設定のみの変更）

## 実機操作検証

N/A — UI 変更なし

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

## レビュー依頼事項・QA

特になし。

`pricing-page-signup.spec.ts` のテスト 3〜5（認証必要な free ユーザーフロー）は `test.describe('#757 free ユーザートライアル開始フロー')` に集約し、`test.use({ storageState: 'playwright/.auth/free.json' })` を付与しています。テスト 1・2・6（`/pricing` 等の認証不要ページ）はトップレベルに置いてあり、`as-*` プロジェクトの storageState が任意に適用されます。

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **該当なし** — 並行実装の影響範囲外の変更（テストコードのみ）

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイルを同時期に変更する open PR が他に無いことを確認した
  - `account-deletion.spec.ts` を変更する PR #1560 が進行中だが、本 PR は `account-deletion.spec.ts` を変更しないため衝突なし

### LP 変更時の追加チェック

- [x] **N/A** — LP の変更なし

### LP / 販促文言変更時の実装パス明示

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **N/A** — ユーザー向け文言の追加/変更なし（テストコードのみ）
- [x] **設計書（CRITICAL）**: テストコードのみの変更のため設計書更新不要

## Ready for Review チェックリスト

- [x] CI が全て通過している（GitHub Actions run #24955566998 — lint-and-test / unit-test / e2e-test / e2e-cognito-dev 全 PASS）
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）
- [x] **全 AC が実装済みであること**（AC1・AC2 は実装済み。AC3・AC4 は CI 通過で確認）
- [x] UI 変更なし

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし

### スコープ完全性
- [x] 見落とし確認: `account-deletion.spec.ts` は別 PR #1560 対応中のため意図的に除外。`plan-login-helpers.ts` の `loginAsPlan` 関数は `account-deletion.spec.ts` 参照があるため保持（全参照消去後に削除予定）。

## デプロイ検証（#710 — マージ後必須）

- [x] **N/A** — デプロイ検証不要（テストコードのみの変更）

## 完了チェックリスト

- [x] `npx biome check .` — lint エラーなし（11 files checked, no fixes applied）
- [x] `npx svelte-check` — 型エラーなし（0 errors, 0 warnings）
- [x] `npx vitest run` — CI で確認済み（GitHub Actions unit-test: PASS）
- [x] `npx playwright test` — CI で確認済み（GitHub Actions e2e-test / e2e-cognito-dev: PASS）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

<!-- QM が approve するときに記入 -->
