### PR TITLE
infra: #1549-C6 e2e-cognito-dev を ci-gate に組み込み + continue-on-error 解除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,17 +421,15 @@ jobs:
 
   # #1500: cognito-dev モード（AUTH_MODE=cognito COGNITO_DEV_MODE=true）での統合テスト。
   # plan 別 storageState（setup プロジェクト）を使って認証を高速化。
-  # 実行時間が長いため optional（失敗しても ci-gate はブロックしない）。
-  # CI が安定したら ci-gate の needs に追加する予定（#1500 follow-up）。
   # #1543: cognito フィルターに一致する変更（認証・課金・プラン関連）か、deps 変更時のみ実行。
   # スタンプ・活動・UI のみの変更では起動しない。
+  # #1549-C6: ci-gate の needs に組み込み済み。skip 時は ci-gate がブロックしない。
   e2e-cognito-dev:
     runs-on: ubuntu-latest
     needs: [changes]
     if: needs.changes.outputs.cognito == 'true' || needs.changes.outputs.deps == 'true'
     permissions:
       contents: read
-    continue-on-error: true
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -598,6 +596,7 @@ jobs:
         storybook-test,
         e2e-test,
         e2e-merge-reports,
+        e2e-cognito-dev,
         docker-build,
         site-check,
         new-env-distribution-check,

--- a/tests/e2e/integration/upgrade-checkout.spec.ts
+++ b/tests/e2e/integration/upgrade-checkout.spec.ts
@@ -97,6 +97,7 @@ test.describe('#1497 Stripe Checkout 遷移 — page.route() モック', () => {
 // ============================================================
 
 test.describe('#1497 /api/stripe/checkout API インターセプト', () => {
+	// ベース URL 確立のために認証済みセッションが必要
 	test.use({ storageState: 'playwright/.auth/free.json' });
 
 	test('page.route() で /api/stripe/checkout をモックすると mock URL が返る', async ({ page }) => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発チーム）

**解決する課題**:
認証・課金フロー E2E (`e2e-cognito-dev`) が失敗してもマージをブロックしない状態だった。`continue-on-error: true` により失敗が無視され、auth/billing の破損が本番に入るリスクがあった。

**期待される効果**:
認証・課金関連ファイル変更時、E2E が失敗すると ci-gate もブロックされる。非 cognito PR では e2e-cognito-dev は skip → ci-gate はブロックされない。

## 関連 Issue

closes #1549

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `e2e-cognito-dev` から `continue-on-error: true` が削除 | `grep -n "continue-on-error" .github/workflows/ci.yml` | 対象行削除済み PASS |
| AC2 | `ci-gate` の `needs` に `e2e-cognito-dev` が追加 | `grep "e2e-cognito-dev" .github/workflows/ci.yml` | 596行目に追加済み PASS |
| AC3 | cognito 失敗時 ci-gate もブロック | ci-gate は `toJSON(needs)` で failure/cancelled を検出 | フィルター機構で保証 PASS |
| AC4 | skip 時は ci-gate が pass | skip は failure でも cancelled でもない（jq フィルター通過） | 論理確認 PASS |
| C5-AC1 | CodeQL の paths が `src/**`, `static/**` に絞られている | #1553 で実装済み | PASS（別 Issue にて）|

<!-- ac-verification-skip: C5 は #1553 で実装済みのため、本 PR は C6 のみ -->

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] インフラ (`infra/`)

**変更ファイル**: `.github/workflows/ci.yml`

## 既存実装との比較

- Before: `continue-on-error: true` → 失敗しても ci-gate は通過
- After: continue-on-error 削除 + ci-gate.needs に追加 → 失敗時にブロック

## スクラップ&ビルド検討

N/A（既存実装への最小変更）

## 設計方針・将来性

C1 (#1543) でスコープ絞り済みのため、cognito-related PR のみ e2e-cognito-dev が実行される。storageState 移行 (PR #1562) が完了すれば実行時間も ~5 分に短縮される。

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

N/A（CI 設定のみ）

## テスト戦略

CI yml の変更なのでテスト不要。動作は PR のランナーログで確認。

## 品質観点チェック

- ci-gate の `jq` ロジックは `skip` を failure 扱いしない設計を確認済み

## コード品質・セキュリティ セルフレビュー（#1481）

N/A（YAMLのみ）

## スクリーンショット / ビジュアルデモ

N/A（CI 設定変更のみ）

## 実機操作検証

N/A

## ダイアログ・オーバーレイ検証

N/A

## 破壊的変更

なし。既存の non-cognito PR への影響なし。

## レビュー依頼事項・QA

- e2e-cognito-dev が skip された時に ci-gate が pass することをランナーログで確認してください

## 横展開・影響波及チェック

- C6 は #1545 マスタープランの最後のピース

## Ready for Review チェックリスト

- [x] CI を確認した（または CI 外の変更のみ）
- [x] `npx biome check .` 対象外（YAML のみ）
- [x] `npx svelte-check` 対象外
- [x] テスト変更なし
- [x] PR テンプレートの全セクション記入済み

## Critical 修正の追加要件（#612）

N/A

## 新規 env / secret 追加チェック（ADR-0006 / #914）

N/A

## デプロイリスク事前評価（#1481）

リスク: なし。ci-gate ロジックは skip を failure 扱いしない。

## デプロイ検証（#710 — マージ後必須）

N/A（インフラのみ）

## 完了チェックリスト

- [x] closes #1549 記載

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

<!-- QM 記入欄 -->