### PR TITLE
feat: #1601 期限切れ前リマインド + 休眠復帰メール (lifecycle-emails cron)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -313,3 +313,7 @@ Oyakagi
 DPIA
 antipatterns
 antipattern
+
+# ===== ライフサイクルメール (#1601) =====
+# healthcheck = cron-dispatcher の動作確認エンドポイント識別子
+healthcheck

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ docs/design/logo-candidates/
 
 # PR証跡スクリーンショット（GitHub PR に直接アップロードすること。git管理不要）
 docs/pr-screenshots/
+

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -125,9 +125,11 @@
 | `ganbari-quest-cron-license-expire` | `cron(0 15 * * ? *)` | 00:00 | license-expire |
 | `ganbari-quest-cron-retention-cleanup` | `cron(0 16 * * ? *)` | 01:00 | retention-cleanup |
 | `ganbari-quest-cron-trial-notifications` | `cron(0 0 * * ? *)` | 09:00 | trial-notifications |
+| `ganbari-quest-cron-lifecycle-emails` (#1601) | `cron(30 0 * * ? *)` | 09:30 | lifecycle-emails (期限切れ前リマインド + 休眠復帰メール) |
 
 - スケジュール SSOT: `src/lib/server/cron/schedule-registry.ts`
 - ターゲット: `ganbari-quest-cron-dispatcher` Lambda (JSON payload `{ cronJob: "<job-name>" }`)
+- `lifecycle-emails` (#1601, ADR-0023 §5 I11): 親オーナー宛のみ送信。年 6 回マーケティングメール上限を遵守。List-Unsubscribe ヘッダ + 配信停止リンク必須。Anti-engagement 整合 (中立トーン)。
 
 ### 3.4 OpsStack（監視・コスト防衛）
 

--- a/docs/design/19-プライシング戦略書.md
+++ b/docs/design/19-プライシング戦略書.md
@@ -616,6 +616,8 @@ stripe promotion_codes create \
 | チェックリスト（持ち物・習慣） | `src/lib/server/services/checklist-service.ts` | |
 | データエクスポート（JSON） | `src/routes/(parent)/admin/export/` | |
 | 週次メールレポート | `src/lib/server/services/report-service.ts` | |
+| 期限切れ前リマインドメール（30/7/1日前、親宛のみ）#1601 | `src/lib/server/services/lifecycle-email-service.ts::runLifecycleEmails` | ADR-0023 §5 I11。年6回上限内、List-Unsubscribe対応。Anti-engagement 整合 (中立トーン) |
+| 休眠復帰メール（90日経過、1ユーザー1回限り、親宛のみ）#1601 | `src/lib/server/services/lifecycle-email-service.ts::runLifecycleEmails` | ADR-0023 §5 I11。卒業をポジティブにフレーミング |
 
 ### Aspirational（未実装・将来候補 — LP 記載禁止）
 

--- a/docs/design/parallel-implementations.md
+++ b/docs/design/parallel-implementations.md
@@ -298,6 +298,29 @@ grep -n "bottom-nav\|data-testid" src/lib/ui/components/BottomNav.svelte
 - [ ] 同意チェックボックス追加 → `signup/+page.svelte` の `canSubmit` / `submitBlockReason` に反映 + E2E テスト追加
 - [ ] 設計書 14 の §8.5 / §8.6 / §8.7 と整合維持（電気通信事業法 §27の12 / 個情法 §28 / 未成年者取扱い）
 
+#### 12. メール通知系 (trial / lifecycle / weekly-report) (#1601)
+
+| 場所 | 内容 | 規律 |
+|------|------|------|
+| `src/lib/server/services/trial-notification-service.ts` | トライアル終了 3 日前 / 1 日前 / 当日通知 | システム通知扱い（年 6 回マーケ枠の対象外） |
+| `src/lib/server/services/lifecycle-email-service.ts` (#1601) | 期限切れ前リマインド (30/7/1日前) + 休眠復帰 (90日) | マーケ扱い（年 6 回上限内、List-Unsubscribe必須、親宛のみ） |
+| `src/lib/server/services/report-service.ts` | 週次活動レポート | 親宛のみ。opt-in (#1601 では枠外) |
+| `src/lib/server/services/email-service.ts` | SES 送信コア + テンプレート | `sendEmail({ listUnsubscribeUrl })` 指定で SendRawEmailCommand を使い List-Unsubscribe ヘッダを付与 (RFC 8058) |
+| `src/lib/server/services/marketing-email-counter.ts` (#1601) | 年間 6 回上限カウンタ (settings KV) | ADR-0023 §3.3 準拠 |
+| `src/lib/server/services/unsubscribe-token.ts` (#1601) | HMAC ベース配信停止トークン | OPS_SECRET_KEY 流用 (Pre-PMF シンプル化、ADR-0010) |
+| `src/routes/unsubscribe/[token]/` (#1601) | 配信停止確認画面 + one-click 解除 | RFC 8058 List-Unsubscribe-Post 対応 |
+
+**規律 (ADR-0023 + ADR-0012 整合)**:
+- 親オーナー (role='owner') の email 以外には絶対に送らない（子供への送信禁止）
+- 「マーケ扱い」のメールを追加するときは必ず `marketing-email-counter` を経由して年 6 回上限を遵守
+- 「マーケ扱い」のメールには必ず `listUnsubscribeUrl` を渡す（List-Unsubscribe ヘッダ + body 末尾の解除リンク）
+- Anti-engagement (ADR-0012) 整合: 「今すぐアップグレード」「失効します」等の煽り NG。中立トーンを貫く
+
+**修正時チェック**:
+- [ ] 新メール種別の追加時は `LIFECYCLE_EMAIL_LABELS` (labels.ts) に文言を追加し、SSOT を保つ
+- [ ] cron job 追加時は `schedule-registry.ts` + `infra/lambda/cron-dispatcher/index.ts` (KNOWN_ENDPOINTS) + `infra/lib/compute-stack.ts` (CRON_JOBS) の 3 箇所同期
+- [ ] `Tenant.lastActiveAt` 関連の変更時は `entities.ts` + `auth-repo.interface.ts` + DynamoDB / SQLite 両 repo + `last-active-touch.ts` を同期
+
 ---
 
 ## 修正時チェックリスト

--- a/infra/lambda/cron-dispatcher/index.ts
+++ b/infra/lambda/cron-dispatcher/index.ts
@@ -30,6 +30,7 @@ const KNOWN_ENDPOINTS: Record<string, string> = {
 	'license-expire': '/api/cron/license-expire',
 	'retention-cleanup': '/api/cron/retention-cleanup',
 	'trial-notifications': '/api/cron/trial-notifications',
+	'lifecycle-emails': '/api/cron/lifecycle-emails',
 };
 
 interface CronEvent {

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -20,6 +20,8 @@ const CRON_JOBS = [
 	{ name: 'license-expire', utcCronExpression: 'cron(0 15 * * ? *)' },
 	{ name: 'retention-cleanup', utcCronExpression: 'cron(0 16 * * ? *)' },
 	{ name: 'trial-notifications', utcCronExpression: 'cron(0 0 * * ? *)' },
+	// #1601 (ADR-0023 §5 I11): 期限切れ前リマインド + 休眠復帰メール
+	{ name: 'lifecycle-emails', utcCronExpression: 'cron(30 0 * * ? *)' },
 ] as const;
 
 export interface ComputeStackProps extends cdk.StackProps {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -31,6 +31,7 @@ import { checkApiRateLimit, checkAuthRateLimit } from '$lib/server/security/rate
 import { trackServerError } from '$lib/server/services/analytics-service';
 import { checkConsent } from '$lib/server/services/consent-service';
 import { notifyIncident } from '$lib/server/services/discord-notify-service';
+import { touchTenantLastActive } from '$lib/server/services/last-active-touch';
 import { assertLicenseKeyConfigured } from '$lib/server/services/license-key-service';
 import { isSetupRequired } from '$lib/server/services/setup-service';
 
@@ -381,6 +382,13 @@ export const handle: Handle = ({ event, resolve }) =>
 		event.locals.identity = identity;
 		event.locals.context = context;
 
+		// #1601 (ADR-0023 §5 I11): 認証成功時に Tenant.lastActiveAt を touch する。
+		// 1 日 1 回のガードは touchTenantLastActive 内の in-memory cache で吸収。
+		// 失敗しても主処理は止めない (await はするがエラーは内部で握りつぶす)。
+		if (identity && context?.tenantId) {
+			await touchTenantLastActive(context.tenantId);
+		}
+
 		// ADR-0040 P3 (#1215): 認証解決完了後の EvaluationContext を注入。
 		// P3 スコープでは mode のみ真面目に投影し、user / plan / licenseKey の詳細投影は
 		// P4 で capability 判定が必要になった時点で追加する（resolvePlanTier の I/O を
@@ -401,7 +409,10 @@ export const handle: Handle = ({ event, resolve }) =>
 				// プリレンダも hooks.server を通るため、除外しないと /setup へ 302 され
 				// sitemap.xml がビルド時に生成できずビルド失敗する。
 				path !== '/sitemap.xml' &&
-				path !== '/robots.txt'
+				path !== '/robots.txt' &&
+				// #1601: 配信停止リンクは未認証 + セットアップ前でもアクセス可能にする
+				// （特定電子メール法準拠: クリックしたら確実に解除できる必要がある）。
+				!path.startsWith('/unsubscribe/')
 			) {
 				if (await isSetupRequired(tenantId)) {
 					redirect(302, '/setup');

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -458,6 +458,60 @@ export const TRIAL_LABELS = {
 } as const;
 
 // ============================================================
+// ライフサイクルメール用ラベル（#1601 / ADR-0023 §3.2 §3.3 §5 I11）
+//
+// 期限切れ前リマインド (renewal) + 休眠復帰 (dormant) + 配信停止 (unsubscribe) の
+// メール文言 SSOT。Anti-engagement 原則（ADR-0012）に従い、煽り表現
+// （「今すぐアップグレード」「失効します」等）を含めない中立的トーンとする。
+//
+// 親宛のみ送信されるため、敬語ベース（「ご利用ありがとうございます」「ご確認ください」）。
+// ============================================================
+
+export const LIFECYCLE_EMAIL_LABELS = {
+	// ---- 期限切れ前リマインド（renewal-reminder） ----
+	renewalSubject: (daysRemaining: number) => `次回更新予定日のお知らせ（残り${daysRemaining}日）`,
+	renewalHeading: '次回更新予定日のお知らせ',
+	renewalGreeting: (ownerName: string) => `${ownerName} 様`,
+	renewalIntro: 'いつも がんばりクエスト をご利用いただきありがとうございます。',
+	renewalPlanLine: (planLabel: string) => `ご契約プラン: ${planLabel}`,
+	renewalDateLine: (expiresAt: string, daysRemaining: number) =>
+		`次回更新予定日: ${expiresAt}（残り ${daysRemaining} 日）`,
+	renewalContinue: 'サービスを継続される場合は、お支払い情報をご確認ください。',
+	renewalGraduate: '卒業（解約）をご希望の場合は、管理画面から手続きできます。',
+	renewalCtaLabel: 'プラン管理画面を開く',
+
+	// ---- 休眠復帰（dormant-reactivation） ----
+	dormantSubject: 'お元気でいらっしゃいますか',
+	dormantHeading: 'お元気でいらっしゃいますか',
+	dormantGreeting: (ownerName: string) => `${ownerName} 様`,
+	dormantIntro: 'がんばりクエスト の運営です。',
+	dormantSinceLastActive: (days: number) => `最後にログインされてから ${days} 日が経過しました。`,
+	dormantGraduationNote: 'お子さまが卒業されたなら、何よりの成果です。',
+	dormantReturnNote: 'もし戻りたい場合は、いつでもログインできます。',
+	dormantPasswordNote: 'お忘れの場合は、パスワードリセットも可能です。',
+	dormantCtaLabel: 'ログイン画面を開く',
+
+	// ---- 配信停止 (unsubscribe) ----
+	unsubscribeFooter: '配信停止',
+	unsubscribePageTitle: 'メール配信停止',
+	unsubscribeHeading: 'メール配信を停止しました',
+	unsubscribeIntro:
+		'今後、期限切れ前リマインド・休眠復帰メールはお送りしません。トランザクションメール（解約受付など）は引き続き送信されます。',
+	unsubscribeAlreadyTitle: 'メール配信停止について',
+	unsubscribeAlreadyIntro:
+		'このリンクはメール配信停止用のリンクです。下のボタンを押すと、ご登録メールアドレスへのマーケティングメール配信が停止されます。',
+	unsubscribeConfirmCta: '配信を停止する',
+	unsubscribeReturnCta: 'トップに戻る',
+	unsubscribeInvalidTitle: '無効なリンクです',
+	unsubscribeInvalidIntro:
+		'このリンクは無効か、すでに使用済みです。メール本文に記載されたリンクを再度ご確認ください。',
+
+	// ---- フッター ----
+	footerNote: 'このメールは「がんばりクエスト」から自動送信されています。',
+	footerCopyright: '© 2026 がんばりクエスト',
+} as const;
+
+// ============================================================
 // PremiumModal 用ラベル（#1166 labels.ts SSOT 化）
 // ============================================================
 

--- a/src/lib/server/auth/entities.ts
+++ b/src/lib/server/auth/entities.ts
@@ -36,6 +36,13 @@ export interface Tenant {
 	// #742: Soft delete state (softDeletedAt / deletionGracePlanTier) is stored
 	// in settings table (not Tenant entity) to avoid schema migration on DynamoDB.
 	// See grace-period-service.ts for details.
+	/**
+	 * #1601 (ADR-0023 §5 I11): 最終活動時刻 (ISO string)。
+	 * `hooks.server.ts` が認証成功時に 1 日 1 回のガード付きで更新する。
+	 * 90 日以上経過したテナントを「休眠」と判定し、休眠復帰メールの送信対象とする。
+	 * 既存テナントでは undefined のことがあり、その場合は createdAt を fallback とする。
+	 */
+	lastActiveAt?: string;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/src/lib/server/cron/schedule-registry.ts
+++ b/src/lib/server/cron/schedule-registry.ts
@@ -49,4 +49,11 @@ export const scheduleRegistry: CronJob[] = [
 		utcCronExpression: 'cron(0 15 * * ? *)', // 毎日 15:00 UTC = 翌日 00:00 JST
 		description: '子供の年齢自動インクリメント (#1381)',
 	},
+	{
+		name: 'lifecycle-emails',
+		endpoint: '/api/cron/lifecycle-emails',
+		cronExpression: '30 9 * * *', // 毎日 09:30 JST
+		utcCronExpression: 'cron(30 0 * * ? *)', // 毎日 00:30 UTC = 09:30 JST
+		description: '期限切れ前リマインド + 休眠復帰メール (#1601, ADR-0023 I11)',
+	},
 ];

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -277,6 +277,37 @@ export const updateTenantOwner: IAuthRepo['updateTenantOwner'] = async (tenantId
 	);
 };
 
+/**
+ * #1601 (ADR-0023 §5 I11): lastActiveAt を atomic に更新する。
+ * hooks.server.ts が認証ごとに呼びうるホットパスのため、Get→Put ではなく
+ * UpdateCommand で 1 件の RW で済ませる。存在しないテナントには書かない。
+ */
+export const updateTenantLastActiveAt: IAuthRepo['updateTenantLastActiveAt'] = async (
+	tenantId,
+	lastActiveAt,
+) => {
+	try {
+		await doc().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: tenantKey(tenantId),
+				UpdateExpression: 'SET lastActiveAt = :lastActiveAt, updatedAt = :updatedAt',
+				ConditionExpression: 'attribute_exists(PK)',
+				ExpressionAttributeValues: {
+					':lastActiveAt': lastActiveAt,
+					':updatedAt': lastActiveAt,
+				},
+			}),
+		);
+	} catch (err) {
+		// ConditionalCheckFailedException = テナントが存在しない（demo / 削除済み）。
+		// hooks の呼び出しはベストエフォートで黙って許容する。
+		const name = (err as { name?: string }).name;
+		if (name === 'ConditionalCheckFailedException') return;
+		throw err;
+	}
+};
+
 export const deleteTenant: IAuthRepo['deleteTenant'] = async (tenantId) => {
 	// Read tenant first to get Stripe customer ID
 	const tenant = await findTenantById(tenantId);
@@ -523,6 +554,9 @@ function itemToTenant(item: Record<string, unknown>): Tenant {
 		stripeSubscriptionId: item.stripeSubscriptionId as string | undefined,
 		planExpiresAt: item.planExpiresAt as string | undefined,
 		trialUsedAt: item.trialUsedAt as string | undefined,
+		// #1601: 既存テナント (lastActiveAt 未保存) は undefined を返し、
+		// 呼び出し側で createdAt にフォールバックする。
+		lastActiveAt: item.lastActiveAt as string | undefined,
 		createdAt: item.createdAt as string,
 		updatedAt: item.updatedAt as string,
 	};

--- a/src/lib/server/db/interfaces/auth-repo.interface.ts
+++ b/src/lib/server/db/interfaces/auth-repo.interface.ts
@@ -55,6 +55,14 @@ export interface IAuthRepo {
 		},
 	): Promise<void>;
 	updateTenantOwner(tenantId: string, newOwnerId: string): Promise<void>;
+	/**
+	 * #1601 (ADR-0023 §5 I11): テナントの最終活動時刻 (lastActiveAt) を更新する。
+	 *
+	 * `hooks.server.ts` が認証成功ごとに呼ぶ可能性があるため、呼び出し側で
+	 * 1 日 1 回のガード（前回値が当日と同じならスキップ）を行うこと。
+	 * 本メソッド自体は冪等で副作用は ISO 文字列の上書きのみ。
+	 */
+	updateTenantLastActiveAt(tenantId: string, lastActiveAt: string): Promise<void>;
 	deleteTenant(tenantId: string): Promise<void>;
 
 	// --- Membership ---

--- a/src/lib/server/db/sqlite/auth-repo.ts
+++ b/src/lib/server/db/sqlite/auth-repo.ts
@@ -58,6 +58,9 @@ export const updateTenantStripe: IAuthRepo['updateTenantStripe'] = async () => {
 export const updateTenantOwner: IAuthRepo['updateTenantOwner'] = async () => {
 	throw new Error(NOT_SUPPORTED);
 };
+export const updateTenantLastActiveAt: IAuthRepo['updateTenantLastActiveAt'] = async () => {
+	// no-op in local mode (#1601: lastActiveAt は cognito モードでのみ追跡)
+};
 export const deleteTenant: IAuthRepo['deleteTenant'] = async () => {
 	throw new Error(NOT_SUPPORTED);
 };

--- a/src/lib/server/services/email-service.ts
+++ b/src/lib/server/services/email-service.ts
@@ -2,10 +2,11 @@
 // SES ベースのメール送信サービス
 // ローカルモード (AUTH_MODE=local) ではログ出力のみ
 
-import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses';
+import { SESClient, SendEmailCommand, SendRawEmailCommand } from '@aws-sdk/client-ses';
 import { env } from '$env/dynamic/private';
-import { getLicensePlanLabel } from '$lib/domain/labels';
+import { getLicensePlanLabel, LIFECYCLE_EMAIL_LABELS } from '$lib/domain/labels';
 import { logger } from '$lib/server/logger';
+import { generateUnsubscribeToken, type UnsubscribeKind } from './unsubscribe-token';
 
 // ============================================================
 // 型定義
@@ -16,6 +17,12 @@ export interface SendEmailParams {
 	subject: string;
 	htmlBody: string;
 	textBody?: string;
+	/**
+	 * #1601: 特定電子メール法 + RFC 8058 (List-Unsubscribe One-Click) 対応。
+	 * 指定すると List-Unsubscribe / List-Unsubscribe-Post ヘッダを付与した
+	 * SendRawEmailCommand で送信する（SendEmailCommand はカスタムヘッダ非対応のため）。
+	 */
+	listUnsubscribeUrl?: string;
 }
 
 // ============================================================
@@ -47,36 +54,163 @@ function isLocalMode(): boolean {
 // ============================================================
 
 export async function sendEmail(params: SendEmailParams): Promise<boolean> {
-	const { to, subject, htmlBody, textBody } = params;
+	const { to, subject, htmlBody, textBody, listUnsubscribeUrl } = params;
 
 	if (isLocalMode()) {
+		// #1601: ローカル開発時は tmp/emails/ に HTML を書き出して目視確認できるようにする。
+		await writeLocalEmailPreview({ to, subject, htmlBody, listUnsubscribeUrl });
 		logger.info('[email] ローカルモード: メール送信スキップ', {
-			context: { to, subject },
+			context: { to, subject, hasListUnsubscribe: Boolean(listUnsubscribeUrl) },
 		});
 		return true;
 	}
 
 	try {
 		const client = getSesClient();
-		const command = new SendEmailCommand({
-			Source: `がんばりクエスト <${getSenderEmail()}>`,
-			Destination: { ToAddresses: [to] },
-			Message: {
-				Subject: { Data: subject, Charset: 'UTF-8' },
-				Body: {
-					Html: { Data: htmlBody, Charset: 'UTF-8' },
-					...(textBody ? { Text: { Data: textBody, Charset: 'UTF-8' } } : {}),
-				},
-			},
-			ConfigurationSetName: getConfigSetName(),
-		});
 
-		await client.send(command);
-		logger.info('[email] メール送信成功', { context: { to, subject } });
+		if (listUnsubscribeUrl) {
+			// SendEmailCommand は List-Unsubscribe 等のカスタムヘッダ非対応のため、
+			// Raw MIME を組み立てて SendRawEmailCommand で送信する (RFC 8058)。
+			const rawMessage = buildRawMimeMessage({
+				from: `がんばりクエスト <${getSenderEmail()}>`,
+				to,
+				subject,
+				htmlBody,
+				textBody,
+				listUnsubscribeUrl,
+			});
+			await client.send(
+				new SendRawEmailCommand({
+					RawMessage: { Data: rawMessage },
+					ConfigurationSetName: getConfigSetName(),
+				}),
+			);
+		} else {
+			await client.send(
+				new SendEmailCommand({
+					Source: `がんばりクエスト <${getSenderEmail()}>`,
+					Destination: { ToAddresses: [to] },
+					Message: {
+						Subject: { Data: subject, Charset: 'UTF-8' },
+						Body: {
+							Html: { Data: htmlBody, Charset: 'UTF-8' },
+							...(textBody ? { Text: { Data: textBody, Charset: 'UTF-8' } } : {}),
+						},
+					},
+					ConfigurationSetName: getConfigSetName(),
+				}),
+			);
+		}
+
+		logger.info('[email] メール送信成功', {
+			context: { to, subject, hasListUnsubscribe: Boolean(listUnsubscribeUrl) },
+		});
 		return true;
 	} catch (err) {
 		logger.error('[email] メール送信失敗', { error: String(err), context: { to, subject } });
 		return false;
+	}
+}
+
+// ============================================================
+// Raw MIME ビルダ (#1601 List-Unsubscribe ヘッダ対応)
+// ============================================================
+
+interface RawMimeParams {
+	from: string;
+	to: string;
+	subject: string;
+	htmlBody: string;
+	textBody?: string;
+	listUnsubscribeUrl: string;
+}
+
+/**
+ * RFC 5322 + RFC 8058 準拠の最小 MIME メッセージを組み立てる。
+ *
+ * - Subject は RFC 2047 (=?UTF-8?B?...?=) で base64 エンコード
+ * - List-Unsubscribe ヘッダは <https://...> 形式 (RFC 2369)
+ * - List-Unsubscribe-Post: List-Unsubscribe=One-Click (RFC 8058)
+ */
+function buildRawMimeMessage(params: RawMimeParams): Uint8Array {
+	const { from, to, subject, htmlBody, textBody, listUnsubscribeUrl } = params;
+	const boundary = `gq-bnd-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+	const subjectEncoded = `=?UTF-8?B?${Buffer.from(subject, 'utf-8').toString('base64')}?=`;
+
+	const headers = [
+		`From: ${from}`,
+		`To: ${to}`,
+		`Subject: ${subjectEncoded}`,
+		'MIME-Version: 1.0',
+		`List-Unsubscribe: <${listUnsubscribeUrl}>`,
+		'List-Unsubscribe-Post: List-Unsubscribe=One-Click',
+		`Content-Type: multipart/alternative; boundary="${boundary}"`,
+	];
+
+	const parts: string[] = [];
+	if (textBody) {
+		parts.push(
+			[
+				`--${boundary}`,
+				'Content-Type: text/plain; charset="UTF-8"',
+				'Content-Transfer-Encoding: base64',
+				'',
+				Buffer.from(textBody, 'utf-8').toString('base64'),
+			].join('\r\n'),
+		);
+	}
+	parts.push(
+		[
+			`--${boundary}`,
+			'Content-Type: text/html; charset="UTF-8"',
+			'Content-Transfer-Encoding: base64',
+			'',
+			Buffer.from(htmlBody, 'utf-8').toString('base64'),
+		].join('\r\n'),
+	);
+	parts.push(`--${boundary}--`);
+
+	const body = parts.join('\r\n');
+	const message = `${headers.join('\r\n')}\r\n\r\n${body}\r\n`;
+	return Buffer.from(message, 'utf-8');
+}
+
+// ============================================================
+// ローカル開発用プレビュー (#1601)
+// ============================================================
+
+/**
+ * AUTH_MODE=local では実 SES を呼ばない代わりに `tmp/emails/<timestamp>.html`
+ * へ HTML を書き出し、ブラウザで目視確認できるようにする。
+ *
+ * `tmp/` は `.gitignore` 配下なのでコミットされない。fs アクセスに失敗しても
+ * 静かに無視する（テスト環境では tmp ディレクトリが無いケースもある）。
+ */
+async function writeLocalEmailPreview(params: {
+	to: string;
+	subject: string;
+	htmlBody: string;
+	listUnsubscribeUrl?: string;
+}): Promise<void> {
+	if (process.env.NODE_ENV === 'test') return;
+	if (process.env.SKIP_LOCAL_EMAIL_PREVIEW === 'true') return;
+	try {
+		const fs = await import('node:fs/promises');
+		const path = await import('node:path');
+		const dir = path.join(process.cwd(), 'tmp', 'emails');
+		await fs.mkdir(dir, { recursive: true });
+		const safeSubject = params.subject
+			.replace(/[\\/:*?"<>|]/g, '_')
+			.replace(/\s+/g, '_')
+			.slice(0, 60);
+		const filename = `${Date.now()}-${safeSubject || 'email'}.html`;
+		const headerNote = params.listUnsubscribeUrl
+			? `<!-- List-Unsubscribe: ${params.listUnsubscribeUrl} -->\n<!-- To: ${params.to} -->\n`
+			: `<!-- To: ${params.to} -->\n`;
+		await fs.writeFile(path.join(dir, filename), headerNote + params.htmlBody, 'utf-8');
+	} catch {
+		// preview 失敗はサイレント (logger を通すと重複出力になるため)
 	}
 }
 
@@ -372,5 +506,188 @@ export async function sendWeeklyReportEmail(
       </p>
     `),
 		textBody: `${report.childName}の今週のがんばり（${report.dateRange}）\n\n${report.categories.map((c) => `${c.name}: ${c.count}回`).join('\n')}\n\n🔥 連続記録: ${report.streak}日\n⭐ ポイント: +${report.pointsEarned}pt（累計: ${report.totalPoints}pt）`,
+	});
+}
+
+// ============================================================
+// ライフサイクルメール (#1601 / ADR-0023 §3.2 §3.3 §5 I11)
+// ============================================================
+
+/**
+ * 期限切れ前リマインドメール / 休眠復帰メール用の Public URL ビルダ。
+ * 環境変数 `APP_BASE_URL` 優先、未設定時は本番 URL にフォールバック。
+ */
+function getAppBaseUrl(): string {
+	return env.APP_BASE_URL ?? 'https://ganbari-quest.com';
+}
+
+function buildUnsubscribeUrl(tenantId: string, kind: UnsubscribeKind): string {
+	const token = generateUnsubscribeToken({ tenantId, kind });
+	return `${getAppBaseUrl()}/unsubscribe/${token}`;
+}
+
+/**
+ * lifecycle 系メールの共通レイアウト。
+ *
+ * `wrapTemplate` (purple ヘッダ) や `wrapTrialEmailTemplate` (orange ヘッダ) と
+ * 区別するため、Anti-engagement 整合の落ち着いたグレー基調にする。
+ */
+function wrapLifecycleTemplate(content: string, unsubscribeUrl: string): string {
+	const labels = LIFECYCLE_EMAIL_LABELS;
+	return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; background: #f5f5f5; color: #2d2d2d; }
+  .container { max-width: 600px; margin: 0 auto; background: #ffffff; }
+  .header { background: #4a5568; padding: 20px 24px; }
+  .header h1 { color: #ffffff; font-size: 18px; margin: 0; font-weight: 600; }
+  .content { padding: 32px 24px; line-height: 1.7; }
+  .content h2 { color: #2d3748; font-size: 18px; margin-top: 0; }
+  .content p { margin: 12px 0; }
+  .meta { background: #f7fafc; border-left: 4px solid #cbd5e0; padding: 12px 16px; margin: 16px 0; font-size: 14px; }
+  .meta div { margin: 4px 0; }
+  .button { display: inline-block; padding: 10px 20px; background: #4a5568; color: #ffffff !important; text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 14px; }
+  .footer { padding: 16px 24px; background: #f9fafb; text-align: center; font-size: 12px; color: #718096; border-top: 1px solid #e5e7eb; }
+  .footer a { color: #718096; text-decoration: underline; }
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="header">
+    <h1>がんばりクエスト</h1>
+  </div>
+  <div class="content">
+    ${content}
+  </div>
+  <div class="footer">
+    <p>${labels.footerNote}</p>
+    <p><a href="${unsubscribeUrl}">${labels.unsubscribeFooter}</a></p>
+    <p>${labels.footerCopyright}</p>
+  </div>
+</div>
+</body>
+</html>`;
+}
+
+export interface RenewalReminderParams {
+	email: string;
+	tenantId: string;
+	ownerName: string;
+	planLabel: string;
+	expiresAt: string;
+	daysRemaining: number;
+}
+
+/**
+ * 期限切れ前リマインドメール (一般プラン残り 30/7/1 日)。
+ *
+ * Anti-engagement 整合: 「今すぐ」「失効します」「お得な」等の煽り表現を含めない。
+ * 「ご確認ください」「ご希望の場合は」の中立トーン。
+ */
+export async function sendLicenseRenewalReminderEmail(
+	params: RenewalReminderParams,
+): Promise<boolean> {
+	const labels = LIFECYCLE_EMAIL_LABELS;
+	const { email, tenantId, ownerName, planLabel, expiresAt, daysRemaining } = params;
+	const unsubscribeUrl = buildUnsubscribeUrl(tenantId, 'marketing');
+	const subject = labels.renewalSubject(daysRemaining);
+	const ctaUrl = `${getAppBaseUrl()}/admin/license`;
+
+	const htmlContent = `
+      <h2>${labels.renewalHeading}</h2>
+      <p>${labels.renewalGreeting(ownerName)}</p>
+      <p>${labels.renewalIntro}</p>
+      <div class="meta">
+        <div>${labels.renewalPlanLine(planLabel)}</div>
+        <div>${labels.renewalDateLine(expiresAt, daysRemaining)}</div>
+      </div>
+      <p>${labels.renewalContinue}</p>
+      <p>${labels.renewalGraduate}</p>
+      <p style="text-align: center; margin: 24px 0;">
+        <a href="${ctaUrl}" class="button">${labels.renewalCtaLabel}</a>
+      </p>
+    `;
+
+	const textBody = [
+		labels.renewalGreeting(ownerName),
+		'',
+		labels.renewalIntro,
+		'',
+		labels.renewalPlanLine(planLabel),
+		labels.renewalDateLine(expiresAt, daysRemaining),
+		'',
+		labels.renewalContinue,
+		labels.renewalGraduate,
+		'',
+		`${labels.renewalCtaLabel}: ${ctaUrl}`,
+		'',
+		`${labels.unsubscribeFooter}: ${unsubscribeUrl}`,
+	].join('\n');
+
+	return sendEmail({
+		to: email,
+		subject,
+		htmlBody: wrapLifecycleTemplate(htmlContent, unsubscribeUrl),
+		textBody,
+		listUnsubscribeUrl: unsubscribeUrl,
+	});
+}
+
+export interface DormantReactivationParams {
+	email: string;
+	tenantId: string;
+	ownerName: string;
+	daysSinceLastActive: number;
+}
+
+/**
+ * 休眠復帰メール (90 日以上ログインなし、1 ユーザーにつき 1 回限り)。
+ *
+ * Anti-engagement 整合: 卒業 = ポジティブとしてフレーミング、戻ることを強要しない。
+ */
+export async function sendDormantReactivationEmail(
+	params: DormantReactivationParams,
+): Promise<boolean> {
+	const labels = LIFECYCLE_EMAIL_LABELS;
+	const { email, tenantId, ownerName, daysSinceLastActive } = params;
+	const unsubscribeUrl = buildUnsubscribeUrl(tenantId, 'marketing');
+	const ctaUrl = `${getAppBaseUrl()}/auth/login`;
+
+	const htmlContent = `
+      <h2>${labels.dormantHeading}</h2>
+      <p>${labels.dormantGreeting(ownerName)}</p>
+      <p>${labels.dormantIntro}</p>
+      <p>${labels.dormantSinceLastActive(daysSinceLastActive)}</p>
+      <p>${labels.dormantGraduationNote}</p>
+      <p>${labels.dormantReturnNote}</p>
+      <p>${labels.dormantPasswordNote}</p>
+      <p style="text-align: center; margin: 24px 0;">
+        <a href="${ctaUrl}" class="button">${labels.dormantCtaLabel}</a>
+      </p>
+    `;
+
+	const textBody = [
+		labels.dormantGreeting(ownerName),
+		'',
+		labels.dormantIntro,
+		labels.dormantSinceLastActive(daysSinceLastActive),
+		labels.dormantGraduationNote,
+		labels.dormantReturnNote,
+		labels.dormantPasswordNote,
+		'',
+		`${labels.dormantCtaLabel}: ${ctaUrl}`,
+		'',
+		`${labels.unsubscribeFooter}: ${unsubscribeUrl}`,
+	].join('\n');
+
+	return sendEmail({
+		to: email,
+		subject: labels.dormantSubject,
+		htmlBody: wrapLifecycleTemplate(htmlContent, unsubscribeUrl),
+		textBody,
+		listUnsubscribeUrl: unsubscribeUrl,
 	});
 }

--- a/src/lib/server/services/last-active-touch.ts
+++ b/src/lib/server/services/last-active-touch.ts
@@ -1,0 +1,69 @@
+// src/lib/server/services/last-active-touch.ts
+// #1601 (ADR-0023 §5 I11): Tenant.lastActiveAt の 1 日 1 回ガード付き更新。
+//
+// hooks.server.ts から認証成功後に呼ばれるホットパスのため、
+// 同日中の重複呼び出しを in-memory cache で吸収する。
+// プロセス再起動 (Lambda cold start 等) で cache は消えるが、その場合は
+// 再度 1 回だけ書き込みが走るだけで害はない。
+//
+// 設計判断:
+//   - localStorage / cookie 等のクライアント側ガードは使わない (改竄可能)
+//   - DynamoDB に「最後に書いた日付」を都度問い合わせる方式は RW コストが倍になる
+//     ため、in-memory cache (LRU 風 Map) で十分
+//   - cache は 10000 テナント上限で truncation する (Pre-PMF 想定 << 10000)
+
+import { getRepos } from '$lib/server/db/factory';
+import { logger } from '$lib/server/logger';
+
+const CACHE_MAX_SIZE = 10_000;
+
+/** tenantId → 最後に lastActiveAt を書いた YYYY-MM-DD (UTC) */
+const lastTouchCache = new Map<string, string>();
+
+/** UTC YYYY-MM-DD を返す */
+function getDayKey(now: Date = new Date()): string {
+	return now.toISOString().slice(0, 10); // 2026-04-27
+}
+
+/**
+ * テスト用: cache をリセットする。
+ * 通常コードからは呼ばないこと。
+ */
+export function _resetLastActiveTouchCacheForTesting(): void {
+	lastTouchCache.clear();
+}
+
+/**
+ * テナントの lastActiveAt を更新する (1 日 1 回ガード付き)。
+ *
+ * - 当日中に既に書き込み済みなら no-op (DB に行かない)
+ * - 失敗しても例外は投げない (hooks のホットパスを止めないため)
+ *
+ * @param tenantId 対象テナント。'demo' / 'local' / falsy ならスキップ。
+ */
+export async function touchTenantLastActive(tenantId: string | undefined | null): Promise<void> {
+	if (!tenantId) return;
+	if (tenantId === 'demo' || tenantId === 'local') return;
+
+	const today = getDayKey();
+	const lastDay = lastTouchCache.get(tenantId);
+	if (lastDay === today) return; // 当日中は cache hit で skip
+
+	// LRU 簡易実装: 上限を超えたら最古エントリを削除
+	if (lastTouchCache.size >= CACHE_MAX_SIZE) {
+		const firstKey = lastTouchCache.keys().next().value;
+		if (firstKey !== undefined) lastTouchCache.delete(firstKey);
+	}
+
+	const nowIso = new Date().toISOString();
+	try {
+		const repos = getRepos();
+		await repos.auth.updateTenantLastActiveAt(tenantId, nowIso);
+		lastTouchCache.set(tenantId, today);
+	} catch (err) {
+		// hooks の主処理を止めないため、ベストエフォート扱い
+		logger.warn('[last-active-touch] failed to update lastActiveAt', {
+			context: { tenantId, error: err instanceof Error ? err.message : String(err) },
+		});
+	}
+}

--- a/src/lib/server/services/lifecycle-email-service.ts
+++ b/src/lib/server/services/lifecycle-email-service.ts
@@ -1,0 +1,322 @@
+// src/lib/server/services/lifecycle-email-service.ts
+// #1601 (ADR-0023 §3.2 §3.3 §5 I11): ライフサイクルメール (期限切れ前リマインド + 休眠復帰)。
+//
+// 既存 trial-notification cron は枠外 (システム通知扱い、年 6 回上限に含めない)。
+// 本サービスは「親宛のみ・年 6 回上限・List-Unsubscribe 必須」を構造的に保証する。
+//
+// 実行タイミング: lifecycle-emails cron (毎日 09:30 JST、cron-dispatcher 経由)。
+// 詳細仕様: ADR-0023 §3.2 / §3.3 / §5 I11。
+
+import { getLicensePlanLabel } from '$lib/domain/labels';
+import { getRepos } from '$lib/server/db/factory';
+import { logger } from '$lib/server/logger';
+import { sendDormantReactivationEmail, sendLicenseRenewalReminderEmail } from './email-service';
+import { canSendMarketingEmail, incrementMarketingEmailCount } from './marketing-email-counter';
+
+// ============================================================
+// 定数
+// ============================================================
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * 期限切れ前リマインドを送信する残日数 (ADR-0023 §5 I11)。
+ * 30 日 / 7 日 / 1 日 の 3 タイミング。
+ */
+export const RENEWAL_REMINDER_DAYS = [30, 7, 1] as const;
+export type RenewalReminderDay = (typeof RENEWAL_REMINDER_DAYS)[number];
+
+/** 休眠とみなす最終ログイン経過日数 (ADR-0023 §5 I11)。 */
+export const DORMANT_THRESHOLD_DAYS = 90;
+
+/** 休眠復帰メール送信済みフラグの settings KV キー (1 ユーザーにつき 1 回限り)。 */
+const DORMANT_SENT_KEY = 'dormant_reactivation_sent';
+
+/** マーケティング配信を opt-out したテナントの settings KV キー。 */
+const UNSUBSCRIBED_KEY = 'marketing_unsubscribed_at';
+
+// ============================================================
+// 型
+// ============================================================
+
+export interface LifecycleEmailRunOptions {
+	/** 現在時刻 (テスト用に注入可能)。デフォルト: new Date() */
+	now?: Date;
+	/** dryRun: true ならメール送信せず判定だけ返す */
+	dryRun?: boolean;
+}
+
+export interface LifecycleEmailRunResult {
+	scanned: number;
+	renewalSent: number;
+	dormantSent: number;
+	skippedUnsubscribed: number;
+	skippedRateLimit: number;
+	skippedNoOwner: number;
+	skippedAlreadySent: number;
+	errors: number;
+	dryRun: boolean;
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/**
+ * 与えられた expiresAt と現在時刻から、残日数 (整数、切り上げ) を返す。
+ * すでに過ぎている場合は負値。
+ */
+export function daysUntil(expiresAt: string, now: Date): number {
+	const exp = new Date(expiresAt).getTime();
+	const diffMs = exp - now.getTime();
+	return Math.ceil(diffMs / MS_PER_DAY);
+}
+
+/**
+ * 残日数が「期限切れ前リマインド」のターゲットに該当するかを判定する。
+ * 30/7/1 日のいずれかと完全一致したときのみ true。
+ */
+export function isRenewalReminderDay(daysRemaining: number): daysRemaining is RenewalReminderDay {
+	return RENEWAL_REMINDER_DAYS.includes(daysRemaining as RenewalReminderDay);
+}
+
+/** 最終アクティブ日からの経過日数を返す (createdAt フォールバック付き)。 */
+export function daysSinceLastActive(
+	lastActiveAt: string | undefined,
+	createdAt: string,
+	now: Date,
+): number {
+	const baseIso = lastActiveAt ?? createdAt;
+	const base = new Date(baseIso).getTime();
+	const diffMs = now.getTime() - base;
+	return Math.floor(diffMs / MS_PER_DAY);
+}
+
+/** YYYY-MM-DD (JST) 形式の表示用日付。 */
+function formatExpiresAt(iso: string): string {
+	const d = new Date(iso);
+	return d.toLocaleDateString('ja-JP', {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+		timeZone: 'Asia/Tokyo',
+	});
+}
+
+// ============================================================
+// テナント単位の処理
+// ============================================================
+
+interface TenantContext {
+	tenantId: string;
+	email: string;
+	ownerName: string;
+	plan: string | undefined;
+	planExpiresAt: string | undefined;
+	lastActiveAt: string | undefined;
+	createdAt: string;
+}
+
+/**
+ * 1 テナントを処理する。
+ *
+ * 戻り値の文字列は集計用のラベル。
+ *   - 'renewal-sent' / 'dormant-sent': メール送信成功
+ *   - 'skipped-*': 各種スキップ理由
+ *   - 'error': 例外
+ */
+async function processTenant(
+	ctx: TenantContext,
+	now: Date,
+	dryRun: boolean,
+): Promise<
+	| 'renewal-sent'
+	| 'dormant-sent'
+	| 'skipped-unsubscribed'
+	| 'skipped-rate-limit'
+	| 'skipped-already-sent'
+	| 'skipped-no-target'
+	| 'error'
+> {
+	const repos = getRepos();
+
+	// 1) opt-out チェック (年 6 回枠とは独立した拒絶)
+	const optOut = await repos.settings.getSetting(UNSUBSCRIBED_KEY, ctx.tenantId);
+	if (optOut) return 'skipped-unsubscribed';
+
+	// 2) 期限切れ前リマインド判定
+	const daysRemaining = ctx.planExpiresAt ? daysUntil(ctx.planExpiresAt, now) : null;
+	const renewalEligible =
+		daysRemaining !== null && isRenewalReminderDay(daysRemaining) && !!ctx.plan; // 一般プランのみ (trial 等を除外)
+
+	// 3) 休眠復帰判定
+	const dormantDays = daysSinceLastActive(ctx.lastActiveAt, ctx.createdAt, now);
+	const dormantEligibleByDays = dormantDays >= DORMANT_THRESHOLD_DAYS;
+	let dormantAlreadySent = false;
+	if (dormantEligibleByDays) {
+		const sentAt = await repos.settings.getSetting(DORMANT_SENT_KEY, ctx.tenantId);
+		dormantAlreadySent = !!sentAt;
+	}
+	const dormantEligible = dormantEligibleByDays && !dormantAlreadySent;
+
+	if (!renewalEligible && !dormantEligible) {
+		return dormantAlreadySent ? 'skipped-already-sent' : 'skipped-no-target';
+	}
+
+	// 4) 年 6 回上限チェック
+	const canSend = await canSendMarketingEmail(ctx.tenantId);
+	if (!canSend) return 'skipped-rate-limit';
+
+	if (dryRun) {
+		// dryRun: 状態は変更せず、どちらが送られる予定だったかをログに残す。
+		const target = renewalEligible ? 'renewal' : 'dormant';
+		logger.info('[lifecycle-email] dryRun would send', {
+			context: { tenantId: ctx.tenantId, target, daysRemaining, dormantDays },
+		});
+		return renewalEligible ? 'renewal-sent' : 'dormant-sent';
+	}
+
+	// 5) 送信実行 (renewal を優先。両方該当しても 1 通だけ。年 6 回枠の節約)
+	if (renewalEligible) {
+		const ok = await sendLicenseRenewalReminderEmail({
+			email: ctx.email,
+			tenantId: ctx.tenantId,
+			ownerName: ctx.ownerName,
+			planLabel: getLicensePlanLabel(ctx.plan ?? ''),
+			expiresAt: formatExpiresAt(ctx.planExpiresAt as string),
+			daysRemaining: daysRemaining as number,
+		});
+		if (!ok) return 'error';
+		await incrementMarketingEmailCount(ctx.tenantId);
+		return 'renewal-sent';
+	}
+
+	// dormant
+	const ok = await sendDormantReactivationEmail({
+		email: ctx.email,
+		tenantId: ctx.tenantId,
+		ownerName: ctx.ownerName,
+		daysSinceLastActive: dormantDays,
+	});
+	if (!ok) return 'error';
+	await incrementMarketingEmailCount(ctx.tenantId);
+	await repos.settings.setSetting(DORMANT_SENT_KEY, now.toISOString(), ctx.tenantId);
+	return 'dormant-sent';
+}
+
+// ============================================================
+// Public API
+// ============================================================
+
+/**
+ * 全テナントを走査して期限切れ前リマインド + 休眠復帰メールを処理する。
+ *
+ * cron (lifecycle-emails) から日次で呼ばれる。1 テナントの失敗が他に波及しないよう
+ * try/catch で個別にハンドルする。
+ */
+export async function runLifecycleEmails(
+	options: LifecycleEmailRunOptions = {},
+): Promise<LifecycleEmailRunResult> {
+	const now = options.now ?? new Date();
+	const dryRun = options.dryRun ?? false;
+
+	const result: LifecycleEmailRunResult = {
+		scanned: 0,
+		renewalSent: 0,
+		dormantSent: 0,
+		skippedUnsubscribed: 0,
+		skippedRateLimit: 0,
+		skippedNoOwner: 0,
+		skippedAlreadySent: 0,
+		errors: 0,
+		dryRun,
+	};
+
+	const repos = getRepos();
+	const tenants = await repos.auth.listAllTenants();
+
+	for (const tenant of tenants) {
+		result.scanned++;
+		try {
+			// オーナーのメールアドレスを取得
+			const members = await repos.auth.findTenantMembers(tenant.tenantId);
+			const owner = members.find((m) => m.role === 'owner');
+			if (!owner) {
+				result.skippedNoOwner++;
+				continue;
+			}
+			const user = await repos.auth.findUserById(owner.userId);
+			if (!user?.email) {
+				result.skippedNoOwner++;
+				continue;
+			}
+
+			const outcome = await processTenant(
+				{
+					tenantId: tenant.tenantId,
+					email: user.email,
+					ownerName: user.displayName || tenant.name,
+					plan: tenant.plan,
+					planExpiresAt: tenant.planExpiresAt,
+					lastActiveAt: tenant.lastActiveAt,
+					createdAt: tenant.createdAt,
+				},
+				now,
+				dryRun,
+			);
+
+			switch (outcome) {
+				case 'renewal-sent':
+					result.renewalSent++;
+					break;
+				case 'dormant-sent':
+					result.dormantSent++;
+					break;
+				case 'skipped-unsubscribed':
+					result.skippedUnsubscribed++;
+					break;
+				case 'skipped-rate-limit':
+					result.skippedRateLimit++;
+					break;
+				case 'skipped-already-sent':
+					result.skippedAlreadySent++;
+					break;
+				case 'error':
+					result.errors++;
+					break;
+				default:
+					break;
+			}
+		} catch (err) {
+			logger.error('[lifecycle-email] tenant processing failed', {
+				context: {
+					tenantId: tenant.tenantId,
+					error: err instanceof Error ? err.message : String(err),
+				},
+			});
+			result.errors++;
+		}
+	}
+
+	return result;
+}
+
+/**
+ * 配信停止 (opt-out) を記録する。unsubscribe ルートから呼ばれる。
+ * 冪等。既に解除済みでも 2 重書き込みするだけで害はない。
+ */
+export async function markTenantUnsubscribed(
+	tenantId: string,
+	now: Date = new Date(),
+): Promise<void> {
+	const repos = getRepos();
+	await repos.settings.setSetting(UNSUBSCRIBED_KEY, now.toISOString(), tenantId);
+	logger.info('[lifecycle-email] tenant unsubscribed', { context: { tenantId } });
+}
+
+/** opt-out 状態を確認する (UI / テスト用)。 */
+export async function isTenantUnsubscribed(tenantId: string): Promise<boolean> {
+	const repos = getRepos();
+	const value = await repos.settings.getSetting(UNSUBSCRIBED_KEY, tenantId);
+	return !!value;
+}

--- a/src/lib/server/services/marketing-email-counter.ts
+++ b/src/lib/server/services/marketing-email-counter.ts
@@ -1,0 +1,100 @@
+// src/lib/server/services/marketing-email-counter.ts
+// #1601 (ADR-0023 §3.3): マーケティングメール接触頻度カウンタ。
+//
+// 1 テナントあたり「年 6 回」を上限とするため、settings KV に
+// `marketing_email_count_<YEAR>` キーで送信回数を記録する。
+//
+// 対象に含まれるもの (枠を消費):
+//   - 期限切れ前リマインド (renewal reminder)
+//   - 休眠復帰メール (dormant reactivation)
+//
+// 対象に含まれないもの (システム通知扱い、枠外):
+//   - トライアル終了通知 (trial-notification cron) — 既存系統で別管理
+//   - サインアップ確認 / 解約受付 / メンバー参加通知などのトランザクションメール
+//   - ライセンスキー配布
+//
+// 設計判断:
+//   - 年単位 (UTC YYYY) で管理する。年跨ぎでリセット。
+//   - 数値は文字列として保存し、parseInt でデコード (settings KV の型に合わせる)。
+//   - DynamoDB の atomic increment を使わず Get → Put にしているのは、
+//     cron は 1 日 1 回で同テナントへの重複呼び出しが起きにくく、
+//     また誤差が ±1 件発生しても上限超過には繋がらない (上限は次回送信判定で再評価)。
+
+import { getRepos } from '$lib/server/db/factory';
+import { logger } from '$lib/server/logger';
+
+// ============================================================
+// Constants
+// ============================================================
+
+/**
+ * ADR-0023 §3.3 に定める年間マーケティングメール上限。
+ * 期限切れ前リマインド (3 回) + 休眠復帰メール (1 回) でも余裕がある設定。
+ */
+export const MARKETING_EMAIL_YEARLY_LIMIT = 6;
+
+const SETTINGS_KEY_PREFIX = 'marketing_email_count_';
+
+// ============================================================
+// Public API
+// ============================================================
+
+/** YYYY (UTC 4 桁) を返す。年跨ぎ判定の SSOT。 */
+export function getCurrentYearKey(now: Date = new Date()): string {
+	return String(now.getUTCFullYear());
+}
+
+/** 当年のキー名 (settings KV のキー)。 */
+function settingKey(year: string): string {
+	return `${SETTINGS_KEY_PREFIX}${year}`;
+}
+
+/**
+ * テナントの当年送信回数を取得する。未送信なら 0。
+ */
+export async function getMarketingEmailCount(
+	tenantId: string,
+	year: string = getCurrentYearKey(),
+): Promise<number> {
+	const repos = getRepos();
+	const raw = await repos.settings.getSetting(settingKey(year), tenantId);
+	if (!raw) return 0;
+	const parsed = Number.parseInt(raw, 10);
+	if (Number.isNaN(parsed) || parsed < 0) {
+		logger.warn('[marketing-email-counter] invalid stored count', {
+			context: { tenantId, year, raw },
+		});
+		return 0;
+	}
+	return parsed;
+}
+
+/**
+ * 当年の送信回数を 1 増やす。返り値は increment 後の値。
+ *
+ * NOTE: Get → Put の race を避ける目的の atomic 操作は使っていない。
+ * 詳細は本ファイル冒頭の設計判断メモ参照。
+ */
+export async function incrementMarketingEmailCount(
+	tenantId: string,
+	year: string = getCurrentYearKey(),
+): Promise<number> {
+	const repos = getRepos();
+	const current = await getMarketingEmailCount(tenantId, year);
+	const next = current + 1;
+	await repos.settings.setSetting(settingKey(year), String(next), tenantId);
+	return next;
+}
+
+/**
+ * このテナントに対して当年もう 1 通送れるかを判定する。
+ *
+ * @returns true なら送信可、false なら年間上限到達のため send をスキップすべき。
+ */
+export async function canSendMarketingEmail(
+	tenantId: string,
+	year: string = getCurrentYearKey(),
+): Promise<boolean> {
+	const count = await getMarketingEmailCount(tenantId, year);
+	return count < MARKETING_EMAIL_YEARLY_LIMIT;
+}

--- a/src/lib/server/services/unsubscribe-token.ts
+++ b/src/lib/server/services/unsubscribe-token.ts
@@ -15,14 +15,17 @@
 
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
+import { getEnv } from '$lib/runtime/env';
+
 // ============================================================
 // 内部ヘルパ
 // ============================================================
 
 function getSigningSecret(): string {
-	const secret = process.env.OPS_SECRET_KEY ?? process.env.CRON_SECRET;
+	const env = getEnv();
+	const secret = env.OPS_SECRET_KEY ?? env.CRON_SECRET;
 	if (secret && secret.length > 0) return secret;
-	if ((process.env.AUTH_MODE ?? 'local') === 'local') {
+	if (env.AUTH_MODE === 'local') {
 		// ローカル開発時のみの dev fallback。production では compute-stack.ts が
 		// `cronSecret || opsSecretKey` を保証するため到達しない。
 		return 'local-dev-unsubscribe-secret';

--- a/src/lib/server/services/unsubscribe-token.ts
+++ b/src/lib/server/services/unsubscribe-token.ts
@@ -1,0 +1,88 @@
+// src/lib/server/services/unsubscribe-token.ts
+// #1601: 配信停止トークン (HMAC-SHA256)。
+//
+// 特定電子メール法 + IETF RFC 8058 (List-Unsubscribe One-Click) に対応するため、
+// メール本文と List-Unsubscribe ヘッダの両方で同一トークンを使う。
+//
+// セキュリティ:
+//   - 鍵は OPS_SECRET_KEY を流用 (Pre-PMF シンプル化、ADR-0010)。
+//     専用鍵 MARKETING_UNSUBSCRIBE_SECRET を新設しない方針 (鍵配布経路を増やさない)。
+//   - トークンは <tenantId>.<emailKind>.<sig> 形式。emailKind は marketing/system 等。
+//   - 改竄検知のため必ず HMAC で検証する。expiry は付けない (List-Unsubscribe は
+//     生涯有効が望ましい、特電法準拠)。
+//   - 鍵未設定 (`OPS_SECRET_KEY` も `CRON_SECRET` も無い) ローカル環境では
+//     dev fallback secret を使う。production guard は呼び出し側 (compute-stack.ts) で担保。
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+// ============================================================
+// 内部ヘルパ
+// ============================================================
+
+function getSigningSecret(): string {
+	const secret = process.env.OPS_SECRET_KEY ?? process.env.CRON_SECRET;
+	if (secret && secret.length > 0) return secret;
+	if ((process.env.AUTH_MODE ?? 'local') === 'local') {
+		// ローカル開発時のみの dev fallback。production では compute-stack.ts が
+		// `cronSecret || opsSecretKey` を保証するため到達しない。
+		return 'local-dev-unsubscribe-secret';
+	}
+	throw new Error(
+		'[unsubscribe-token] OPS_SECRET_KEY (or CRON_SECRET) is required in non-local environments',
+	);
+}
+
+function base64UrlEncode(input: Buffer): string {
+	return input.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function sign(payload: string): string {
+	const hmac = createHmac('sha256', getSigningSecret());
+	hmac.update(payload);
+	return base64UrlEncode(hmac.digest());
+}
+
+// ============================================================
+// Public API
+// ============================================================
+
+/** unsubscribe トークンが対象とするメール種別 */
+export type UnsubscribeKind = 'marketing' | 'system';
+
+export interface UnsubscribeTokenPayload {
+	tenantId: string;
+	kind: UnsubscribeKind;
+}
+
+/** トークン生成。`<tenantId>.<kind>.<sig>` 形式。 */
+export function generateUnsubscribeToken(payload: UnsubscribeTokenPayload): string {
+	const { tenantId, kind } = payload;
+	if (!tenantId) throw new Error('[unsubscribe-token] tenantId is required');
+	if (tenantId.includes('.')) {
+		throw new Error('[unsubscribe-token] tenantId must not contain "." (delimiter conflict)');
+	}
+	const body = `${tenantId}.${kind}`;
+	return `${body}.${sign(body)}`;
+}
+
+/**
+ * トークン検証 + decode。
+ *
+ * @returns 検証成功時は payload、失敗時は null。例外は投げない (入力は外部由来)。
+ */
+export function verifyUnsubscribeToken(token: string): UnsubscribeTokenPayload | null {
+	if (!token || typeof token !== 'string') return null;
+	const parts = token.split('.');
+	if (parts.length !== 3) return null;
+	const [tenantId, kind, sig] = parts;
+	if (!tenantId || !kind || !sig) return null;
+	if (kind !== 'marketing' && kind !== 'system') return null;
+
+	const expected = sign(`${tenantId}.${kind}`);
+	const expectedBuf = Buffer.from(expected);
+	const actualBuf = Buffer.from(sig);
+	if (expectedBuf.length !== actualBuf.length) return null;
+	if (!timingSafeEqual(expectedBuf, actualBuf)) return null;
+
+	return { tenantId, kind };
+}

--- a/src/routes/api/cron/lifecycle-emails/+server.ts
+++ b/src/routes/api/cron/lifecycle-emails/+server.ts
@@ -1,0 +1,70 @@
+// POST /api/cron/lifecycle-emails — 期限切れ前リマインド + 休眠復帰メール cron (#1601)
+//
+// EventBridge (Scheduled Rule) から日次で呼び出される。
+// 認証は x-cron-secret ヘッダ (verifyCronAuth 共通ヘルパ)。
+//
+// 使い方:
+//   POST /api/cron/lifecycle-emails
+//   x-cron-secret: <CRON_SECRET>
+//   Body (任意): { "dryRun": true }
+//
+// dryRun=true の場合、状態は変更せずに送信予定件数だけを返す。
+//
+// ADR-0023 §3.2 §3.3 §5 I11 の通り、本エンドポイントは:
+//   - 親オーナー (role='owner') の email にのみ送信
+//   - 1 テナントあたり年 6 回のマーケティングメール上限を遵守
+//   - List-Unsubscribe ヘッダを必ず付与 (特定電子メール法 + RFC 8058)
+
+import { json } from '@sveltejs/kit';
+import { verifyCronAuth } from '$lib/server/auth/cron-auth';
+import { logger } from '$lib/server/logger';
+import { runLifecycleEmails } from '$lib/server/services/lifecycle-email-service';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request }) => {
+	const authError = verifyCronAuth(request);
+	if (authError) return authError;
+
+	try {
+		const body = (await request.json().catch(() => ({}))) as { dryRun?: boolean };
+		const dryRun = body.dryRun === true;
+
+		const result = await runLifecycleEmails({ dryRun });
+
+		logger.info('[lifecycle-emails] cron completed', { context: { ...result } });
+
+		return json({ ok: true, ...result });
+	} catch (err) {
+		logger.error('[lifecycle-emails] cron failed', {
+			service: 'lifecycle-emails',
+			error: err instanceof Error ? err.message : String(err),
+			stack: err instanceof Error ? err.stack : undefined,
+		});
+		return json(
+			{ ok: false, error: err instanceof Error ? err.message : String(err) },
+			{ status: 500 },
+		);
+	}
+};
+
+/**
+ * GET ヘルスチェック — dryRun=true で自動実行し、env 注入と DB 接続を検証。
+ */
+export const GET: RequestHandler = async ({ request }) => {
+	const authError = verifyCronAuth(request);
+	if (authError) return authError;
+
+	try {
+		const result = await runLifecycleEmails({ dryRun: true });
+		return json({ ok: true, ...result });
+	} catch (err) {
+		logger.error('[lifecycle-emails] healthcheck failed', {
+			service: 'lifecycle-emails',
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return json(
+			{ ok: false, error: err instanceof Error ? err.message : String(err) },
+			{ status: 500 },
+		);
+	}
+};

--- a/src/routes/unsubscribe/[token]/+page.server.ts
+++ b/src/routes/unsubscribe/[token]/+page.server.ts
@@ -1,0 +1,46 @@
+// src/routes/unsubscribe/[token]/+page.server.ts
+// #1601: 配信停止 (List-Unsubscribe one-click + 確認画面) ルート。
+//
+// RFC 8058 仕様により List-Unsubscribe-Post: List-Unsubscribe=One-Click では
+// POST 1 回で確実に opt-out できる必要がある。本ルートは:
+//   - GET: 確認画面を表示 (人間ユーザー向け、誤クリック防止)
+//   - POST (form action): opt-out を実行して完了画面を表示
+//
+// 認証は不要 (HMAC トークンが認証代わり)。
+
+import { fail } from '@sveltejs/kit';
+import {
+	isTenantUnsubscribed,
+	markTenantUnsubscribed,
+} from '$lib/server/services/lifecycle-email-service';
+import { verifyUnsubscribeToken } from '$lib/server/services/unsubscribe-token';
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ params }) => {
+	const payload = verifyUnsubscribeToken(params.token);
+	if (!payload) {
+		return {
+			tokenValid: false as const,
+			alreadyUnsubscribed: false,
+			done: false,
+		};
+	}
+
+	const alreadyUnsubscribed = await isTenantUnsubscribed(payload.tenantId);
+	return {
+		tokenValid: true as const,
+		alreadyUnsubscribed,
+		done: false,
+	};
+};
+
+export const actions: Actions = {
+	default: async ({ params }) => {
+		const payload = verifyUnsubscribeToken(params.token);
+		if (!payload) {
+			return fail(400, { error: 'invalid-token' });
+		}
+		await markTenantUnsubscribed(payload.tenantId);
+		return { success: true };
+	},
+};

--- a/src/routes/unsubscribe/[token]/+page.svelte
+++ b/src/routes/unsubscribe/[token]/+page.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+import { enhance } from '$app/forms';
+import { LIFECYCLE_EMAIL_LABELS } from '$lib/domain/labels';
+import Alert from '$lib/ui/primitives/Alert.svelte';
+import Button from '$lib/ui/primitives/Button.svelte';
+import Card from '$lib/ui/primitives/Card.svelte';
+import type { ActionData, PageData } from './$types';
+
+interface Props {
+	data: PageData;
+	form: ActionData;
+}
+
+let { data, form }: Props = $props();
+
+const labels = LIFECYCLE_EMAIL_LABELS;
+
+const isInvalid = $derived(!data.tokenValid);
+const isCompleted = $derived(form?.success === true || data.alreadyUnsubscribed);
+let submitting = $state(false);
+</script>
+
+<svelte:head>
+	<title>{labels.unsubscribePageTitle}</title>
+</svelte:head>
+
+<main class="page">
+	<Card variant="outlined">
+		{#if isInvalid}
+			<h1 class="title">{labels.unsubscribeInvalidTitle}</h1>
+			<Alert variant="warning" message={labels.unsubscribeInvalidIntro} />
+			<div class="actions">
+				<Button href="/" variant="ghost">{labels.unsubscribeReturnCta}</Button>
+			</div>
+		{:else if isCompleted}
+			<h1 class="title">{labels.unsubscribeHeading}</h1>
+			<Alert variant="success" message={labels.unsubscribeIntro} />
+			<div class="actions">
+				<Button href="/" variant="ghost">{labels.unsubscribeReturnCta}</Button>
+			</div>
+		{:else}
+			<h1 class="title">{labels.unsubscribeAlreadyTitle}</h1>
+			<p class="lead">{labels.unsubscribeAlreadyIntro}</p>
+			<form
+				method="POST"
+				use:enhance={() => {
+					submitting = true;
+					return async ({ update }) => {
+						await update();
+						submitting = false;
+					};
+				}}
+			>
+				<div class="actions">
+					<Button type="submit" variant="primary" disabled={submitting}>
+						{labels.unsubscribeConfirmCta}
+					</Button>
+					<Button href="/" variant="ghost">{labels.unsubscribeReturnCta}</Button>
+				</div>
+			</form>
+		{/if}
+	</Card>
+</main>
+
+<style>
+.page {
+	max-width: 540px;
+	margin: 0 auto;
+	padding: 48px 16px;
+}
+
+.title {
+	font-size: 1.25rem;
+	font-weight: 600;
+	margin: 0 0 16px;
+	color: var(--color-text);
+}
+
+.lead {
+	margin: 12px 0 24px;
+	color: var(--color-text-secondary);
+	line-height: 1.7;
+}
+
+.actions {
+	display: flex;
+	gap: 12px;
+	margin-top: 24px;
+	flex-wrap: wrap;
+}
+</style>

--- a/tests/e2e/cron-lifecycle-emails.spec.ts
+++ b/tests/e2e/cron-lifecycle-emails.spec.ts
@@ -1,0 +1,133 @@
+// tests/e2e/cron-lifecycle-emails.spec.ts
+// #1601: 期限切れ前リマインド + 休眠復帰メール cron エンドポイントの E2E テスト
+//
+// /api/cron/lifecycle-emails が verifyCronAuth で認証され、dryRun で集計を返すことを検証する。
+//
+// NOTE: 認証は x-cron-secret ヘッダ。
+// - CRON_SECRET 設定済み: x-cron-secret 必須、不一致で 401
+// - CRON_SECRET 未設定 + AUTH_MODE=local: 認証スキップ
+// - CRON_SECRET 未設定 + AUTH_MODE≠local: 500
+
+import { expect, test } from '@playwright/test';
+import { getCronHeaders, isCronAuthSkipped } from './helpers';
+
+const cronSecret = process.env.CRON_SECRET;
+const authSkipped = isCronAuthSkipped();
+
+test.describe('#1601 lifecycle-emails — 認証ガード', () => {
+	test('x-cron-secret なしで POST すると認証エラー', async ({ request }) => {
+		const res = await request.post('/api/cron/lifecycle-emails');
+		if (cronSecret) {
+			expect(res.status()).toBe(401);
+		} else if (authSkipped) {
+			expect([200, 500]).toContain(res.status());
+		} else {
+			expect(res.status()).toBe(500);
+		}
+	});
+
+	test('不正な x-cron-secret で POST すると認証エラー', async ({ request }) => {
+		const res = await request.post('/api/cron/lifecycle-emails', {
+			headers: { 'x-cron-secret': 'invalid-token-12345' },
+		});
+		if (cronSecret) {
+			expect(res.status()).toBe(401);
+		} else if (authSkipped) {
+			expect([200, 500]).toContain(res.status());
+		} else {
+			expect(res.status()).toBe(500);
+		}
+	});
+
+	test('x-cron-secret なしで GET すると認証エラー', async ({ request }) => {
+		const res = await request.get('/api/cron/lifecycle-emails');
+		if (cronSecret) {
+			expect(res.status()).toBe(401);
+		} else if (authSkipped) {
+			expect([200, 500]).toContain(res.status());
+		} else {
+			expect(res.status()).toBe(500);
+		}
+	});
+});
+
+test.describe('#1601 lifecycle-emails — dryRun POST', () => {
+	test('正しい認証 + dryRun=true で 200 と集計が返る', async ({ request }) => {
+		if (!cronSecret && !authSkipped) {
+			const res = await request.post('/api/cron/lifecycle-emails', { data: { dryRun: true } });
+			expect(res.status()).toBe(500);
+			return;
+		}
+
+		const res = await request.post('/api/cron/lifecycle-emails', {
+			headers: getCronHeaders(),
+			data: { dryRun: true },
+		});
+
+		if (!cronSecret && authSkipped) {
+			expect([200, 500]).toContain(res.status());
+			if (res.status() !== 200) return;
+		} else {
+			expect(res.status()).toBe(200);
+		}
+
+		const body = await res.json();
+		expect(body.ok).toBe(true);
+		expect(body.dryRun).toBe(true);
+		expect(typeof body.scanned).toBe('number');
+		expect(typeof body.renewalSent).toBe('number');
+		expect(typeof body.dormantSent).toBe('number');
+		expect(typeof body.skippedUnsubscribed).toBe('number');
+		expect(typeof body.skippedRateLimit).toBe('number');
+		expect(typeof body.skippedNoOwner).toBe('number');
+		expect(typeof body.skippedAlreadySent).toBe('number');
+		expect(typeof body.errors).toBe('number');
+	});
+
+	test('ボディなし POST も正常 (dryRun=false 扱い)', async ({ request }) => {
+		if (!cronSecret && !authSkipped) {
+			const res = await request.post('/api/cron/lifecycle-emails');
+			expect(res.status()).toBe(500);
+			return;
+		}
+
+		const res = await request.post('/api/cron/lifecycle-emails', {
+			headers: getCronHeaders(),
+		});
+
+		if (!cronSecret && authSkipped) {
+			expect([200, 500]).toContain(res.status());
+			if (res.status() !== 200) return;
+		} else {
+			expect(res.status()).toBe(200);
+		}
+
+		const body = await res.json();
+		expect(body.ok).toBe(true);
+	});
+});
+
+test.describe('#1601 lifecycle-emails — GET ヘルスチェック', () => {
+	test('正しい認証で GET すると dryRun 結果が返る', async ({ request }) => {
+		if (!cronSecret && !authSkipped) {
+			const res = await request.get('/api/cron/lifecycle-emails');
+			expect(res.status()).toBe(500);
+			return;
+		}
+
+		const res = await request.get('/api/cron/lifecycle-emails', {
+			headers: getCronHeaders(),
+		});
+
+		if (!cronSecret && authSkipped) {
+			expect([200, 500]).toContain(res.status());
+			if (res.status() !== 200) return;
+		} else {
+			expect(res.status()).toBe(200);
+		}
+
+		const body = await res.json();
+		expect(body.ok).toBe(true);
+		expect(body.dryRun).toBe(true);
+	});
+});

--- a/tests/unit/services/lifecycle-email-service.test.ts
+++ b/tests/unit/services/lifecycle-email-service.test.ts
@@ -1,0 +1,428 @@
+// tests/unit/services/lifecycle-email-service.test.ts
+// #1601 (ADR-0023 §3.2 §3.3 §5 I11): ライフサイクルメール処理のユニットテスト
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ============================================================
+// Mocks
+// ============================================================
+
+const mockListAllTenants = vi.fn();
+const mockFindTenantMembers = vi.fn();
+const mockFindUserById = vi.fn();
+const settingsStore = new Map<string, string>();
+const mockGetSetting = vi.fn(async (key: string, tenantId: string) =>
+	settingsStore.get(`${tenantId}:${key}`),
+);
+const mockSetSetting = vi.fn(async (key: string, value: string, tenantId: string) => {
+	settingsStore.set(`${tenantId}:${key}`, value);
+});
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		auth: {
+			listAllTenants: mockListAllTenants,
+			findTenantMembers: mockFindTenantMembers,
+			findUserById: mockFindUserById,
+		},
+		settings: {
+			getSetting: mockGetSetting,
+			setSetting: mockSetSetting,
+			getSettings: vi.fn(),
+		},
+	}),
+}));
+
+const mockSendRenewal = vi.fn(async (_params: unknown) => true);
+const mockSendDormant = vi.fn(async (_params: unknown) => true);
+
+vi.mock('../../../src/lib/server/services/email-service', () => ({
+	sendLicenseRenewalReminderEmail: (params: unknown) => mockSendRenewal(params),
+	sendDormantReactivationEmail: (params: unknown) => mockSendDormant(params),
+}));
+
+import {
+	DORMANT_THRESHOLD_DAYS,
+	daysSinceLastActive,
+	daysUntil,
+	isRenewalReminderDay,
+	isTenantUnsubscribed,
+	markTenantUnsubscribed,
+	RENEWAL_REMINDER_DAYS,
+	runLifecycleEmails,
+} from '../../../src/lib/server/services/lifecycle-email-service';
+
+// ============================================================
+// Helpers
+// ============================================================
+
+const NOW = new Date('2026-04-27T01:00:00Z');
+
+function makeTenant(
+	overrides: Partial<{
+		tenantId: string;
+		plan: string | undefined;
+		planExpiresAt: string | undefined;
+		lastActiveAt: string | undefined;
+		createdAt: string;
+	}> = {},
+) {
+	return {
+		tenantId: overrides.tenantId ?? 't-1',
+		name: 'テスト家族',
+		ownerId: 'u-1',
+		status: 'active',
+		plan: overrides.plan,
+		planExpiresAt: overrides.planExpiresAt,
+		lastActiveAt: overrides.lastActiveAt,
+		createdAt: overrides.createdAt ?? '2026-01-01T00:00:00Z',
+		updatedAt: '2026-04-01T00:00:00Z',
+	};
+}
+
+function setupSingleTenantWithOwner(tenant = makeTenant()) {
+	mockListAllTenants.mockResolvedValueOnce([tenant]);
+	mockFindTenantMembers.mockResolvedValueOnce([
+		{ userId: 'u-1', tenantId: tenant.tenantId, role: 'owner', joinedAt: '2026-01-01' },
+	]);
+	mockFindUserById.mockResolvedValueOnce({
+		userId: 'u-1',
+		email: 'owner@example.com',
+		provider: 'cognito',
+		displayName: 'テスト オーナー',
+		createdAt: '2026-01-01',
+		updatedAt: '2026-01-01',
+	});
+}
+
+beforeEach(() => {
+	settingsStore.clear();
+	mockListAllTenants.mockReset();
+	mockFindTenantMembers.mockReset();
+	mockFindUserById.mockReset();
+	mockGetSetting.mockClear();
+	mockSetSetting.mockClear();
+	mockSendRenewal.mockClear();
+	mockSendDormant.mockClear();
+	mockSendRenewal.mockResolvedValue(true);
+	mockSendDormant.mockResolvedValue(true);
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// Pure helper functions
+// ============================================================
+
+describe('#1601 lifecycle-email-service — daysUntil', () => {
+	it('未来の日付なら正の整数', () => {
+		expect(daysUntil('2026-05-04T01:00:00Z', NOW)).toBe(7);
+	});
+
+	it('過去の日付なら 0 以下', () => {
+		expect(daysUntil('2026-04-20T01:00:00Z', NOW)).toBeLessThanOrEqual(0);
+	});
+
+	it('当日 = 0', () => {
+		expect(daysUntil('2026-04-27T01:00:00Z', NOW)).toBe(0);
+	});
+});
+
+describe('#1601 lifecycle-email-service — isRenewalReminderDay', () => {
+	it('30 / 7 / 1 のいずれかでのみ true', () => {
+		expect(isRenewalReminderDay(30)).toBe(true);
+		expect(isRenewalReminderDay(7)).toBe(true);
+		expect(isRenewalReminderDay(1)).toBe(true);
+	});
+
+	it('それ以外は false', () => {
+		expect(isRenewalReminderDay(0)).toBe(false);
+		expect(isRenewalReminderDay(2)).toBe(false);
+		expect(isRenewalReminderDay(14)).toBe(false);
+		expect(isRenewalReminderDay(31)).toBe(false);
+	});
+
+	it('RENEWAL_REMINDER_DAYS は 30 / 7 / 1 を含む', () => {
+		expect(RENEWAL_REMINDER_DAYS).toEqual([30, 7, 1]);
+	});
+});
+
+describe('#1601 lifecycle-email-service — daysSinceLastActive', () => {
+	it('lastActiveAt から経過日数を返す', () => {
+		expect(daysSinceLastActive('2026-04-20T01:00:00Z', '2026-01-01T00:00:00Z', NOW)).toBe(7);
+	});
+
+	it('lastActiveAt 未設定なら createdAt にフォールバック', () => {
+		const result = daysSinceLastActive(undefined, '2026-01-01T00:00:00Z', NOW);
+		expect(result).toBeGreaterThan(100);
+	});
+
+	it('DORMANT_THRESHOLD_DAYS は 90 (ADR-0023 §5 I11)', () => {
+		expect(DORMANT_THRESHOLD_DAYS).toBe(90);
+	});
+});
+
+// ============================================================
+// runLifecycleEmails — 期限切れ前リマインド
+// ============================================================
+
+describe('#1601 lifecycle-email-service — 期限切れ前リマインド', () => {
+	it('残り 7 日のテナントに renewal メールを送る', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				plan: 'standard_monthly',
+				planExpiresAt: '2026-05-04T01:00:00Z', // 7 日後
+			}),
+		);
+
+		const result = await runLifecycleEmails({ now: NOW });
+
+		expect(result.renewalSent).toBe(1);
+		expect(mockSendRenewal).toHaveBeenCalledTimes(1);
+		expect(mockSendRenewal).toHaveBeenCalledWith(
+			expect.objectContaining({
+				email: 'owner@example.com',
+				tenantId: 't-1',
+				ownerName: 'テスト オーナー',
+				daysRemaining: 7,
+			}),
+		);
+		// 年 6 回カウンタが増えている
+		expect(settingsStore.get('t-1:marketing_email_count_2026')).toBe('1');
+	});
+
+	it('残り 30 日でも送る', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				plan: 'family_monthly',
+				planExpiresAt: '2026-05-27T01:00:00Z', // 30 日後
+			}),
+		);
+
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.renewalSent).toBe(1);
+	});
+
+	it('残り 14 日 (対象外) は送らない', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				plan: 'standard_monthly',
+				planExpiresAt: '2026-05-11T01:00:00Z', // 14 日後
+			}),
+		);
+
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.renewalSent).toBe(0);
+		expect(mockSendRenewal).not.toHaveBeenCalled();
+	});
+
+	it('plan 未設定 (free / trial) には送らない', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				plan: undefined,
+				planExpiresAt: '2026-05-04T01:00:00Z',
+			}),
+		);
+
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.renewalSent).toBe(0);
+	});
+
+	it('planExpiresAt 未設定なら renewal 候補にしない', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				plan: 'standard_monthly',
+				planExpiresAt: undefined,
+			}),
+		);
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.renewalSent).toBe(0);
+	});
+});
+
+// ============================================================
+// runLifecycleEmails — 休眠復帰メール
+// ============================================================
+
+describe('#1601 lifecycle-email-service — 休眠復帰メール', () => {
+	it('lastActiveAt が 90 日以上前なら dormant メールを送る', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				lastActiveAt: '2026-01-01T00:00:00Z', // ~117 日前
+			}),
+		);
+
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.dormantSent).toBe(1);
+		expect(mockSendDormant).toHaveBeenCalledTimes(1);
+		expect(mockSendDormant).toHaveBeenCalledWith(
+			expect.objectContaining({
+				email: 'owner@example.com',
+				tenantId: 't-1',
+				daysSinceLastActive: expect.any(Number),
+			}),
+		);
+		// dormant_reactivation_sent フラグが設定された
+		expect(settingsStore.get('t-1:dormant_reactivation_sent')).toBeDefined();
+	});
+
+	it('既に dormant メール送信済みなら再送しない (1 回限り)', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				lastActiveAt: '2026-01-01T00:00:00Z',
+			}),
+		);
+		settingsStore.set('t-1:dormant_reactivation_sent', '2026-04-20T00:00:00Z');
+
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.dormantSent).toBe(0);
+		expect(result.skippedAlreadySent).toBe(1);
+		expect(mockSendDormant).not.toHaveBeenCalled();
+	});
+
+	it('lastActiveAt 未設定なら createdAt 経過日でフォールバック判定', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				lastActiveAt: undefined,
+				createdAt: '2026-01-01T00:00:00Z', // 117 日前
+			}),
+		);
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.dormantSent).toBe(1);
+	});
+
+	it('lastActiveAt が 30 日以内 (休眠未満) なら送らない', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				lastActiveAt: '2026-04-20T00:00:00Z', // 7 日前
+			}),
+		);
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.dormantSent).toBe(0);
+	});
+});
+
+// ============================================================
+// 年 6 回上限 (ADR-0023 §3.3)
+// ============================================================
+
+describe('#1601 lifecycle-email-service — 年 6 回上限', () => {
+	it('上限到達済みのテナントには送らない (renewal)', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				plan: 'standard_monthly',
+				planExpiresAt: '2026-05-04T01:00:00Z',
+			}),
+		);
+		settingsStore.set('t-1:marketing_email_count_2026', '6');
+
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.renewalSent).toBe(0);
+		expect(result.skippedRateLimit).toBe(1);
+		expect(mockSendRenewal).not.toHaveBeenCalled();
+	});
+
+	it('上限到達済みのテナントには送らない (dormant)', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				lastActiveAt: '2026-01-01T00:00:00Z',
+			}),
+		);
+		settingsStore.set('t-1:marketing_email_count_2026', '6');
+
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.dormantSent).toBe(0);
+		expect(result.skippedRateLimit).toBe(1);
+	});
+});
+
+// ============================================================
+// opt-out (配信停止)
+// ============================================================
+
+describe('#1601 lifecycle-email-service — opt-out', () => {
+	it('marketing_unsubscribed_at が設定済みなら送らない', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				plan: 'standard_monthly',
+				planExpiresAt: '2026-05-04T01:00:00Z',
+			}),
+		);
+		settingsStore.set('t-1:marketing_unsubscribed_at', '2026-04-20T00:00:00Z');
+
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.skippedUnsubscribed).toBe(1);
+		expect(result.renewalSent).toBe(0);
+	});
+
+	it('markTenantUnsubscribed → isTenantUnsubscribed で取得できる', async () => {
+		expect(await isTenantUnsubscribed('t-1')).toBe(false);
+		await markTenantUnsubscribed('t-1', NOW);
+		expect(await isTenantUnsubscribed('t-1')).toBe(true);
+	});
+});
+
+// ============================================================
+// オーナー欠落 / 子供アカウント送信禁止
+// ============================================================
+
+describe('#1601 lifecycle-email-service — オーナー解決', () => {
+	it('owner ロールメンバーがいないテナントはスキップ', async () => {
+		mockListAllTenants.mockResolvedValueOnce([
+			makeTenant({ plan: 'standard_monthly', planExpiresAt: '2026-05-04T01:00:00Z' }),
+		]);
+		mockFindTenantMembers.mockResolvedValueOnce([
+			{ userId: 'u-2', tenantId: 't-1', role: 'child', joinedAt: '2026-01-01' },
+		]);
+
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.skippedNoOwner).toBe(1);
+		expect(mockSendRenewal).not.toHaveBeenCalled();
+	});
+
+	it('owner の email が無いテナントはスキップ (子供アカウントへの送信を防ぐ)', async () => {
+		mockListAllTenants.mockResolvedValueOnce([
+			makeTenant({ plan: 'standard_monthly', planExpiresAt: '2026-05-04T01:00:00Z' }),
+		]);
+		mockFindTenantMembers.mockResolvedValueOnce([
+			{ userId: 'u-1', tenantId: 't-1', role: 'owner', joinedAt: '2026-01-01' },
+		]);
+		mockFindUserById.mockResolvedValueOnce({
+			userId: 'u-1',
+			email: '',
+			provider: 'cognito',
+			createdAt: '2026-01-01',
+			updatedAt: '2026-01-01',
+		});
+
+		const result = await runLifecycleEmails({ now: NOW });
+		expect(result.skippedNoOwner).toBe(1);
+	});
+});
+
+// ============================================================
+// dryRun
+// ============================================================
+
+describe('#1601 lifecycle-email-service — dryRun', () => {
+	it('dryRun=true ならメール送信せずカウンタも増やさない', async () => {
+		setupSingleTenantWithOwner(
+			makeTenant({
+				plan: 'standard_monthly',
+				planExpiresAt: '2026-05-04T01:00:00Z',
+			}),
+		);
+
+		const result = await runLifecycleEmails({ now: NOW, dryRun: true });
+		expect(result.dryRun).toBe(true);
+		expect(result.renewalSent).toBe(1); // 集計上は対象としてカウントされる
+		expect(mockSendRenewal).not.toHaveBeenCalled();
+		expect(settingsStore.get('t-1:marketing_email_count_2026')).toBeUndefined();
+	});
+});

--- a/tests/unit/services/marketing-email-counter.test.ts
+++ b/tests/unit/services/marketing-email-counter.test.ts
@@ -1,0 +1,129 @@
+// tests/unit/services/marketing-email-counter.test.ts
+// #1601: マーケティングメール接触頻度カウンタのユニットテスト
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// settings KV をメモリで模擬
+const settingsStore = new Map<string, string>();
+const mockGetSetting = vi.fn(async (key: string, tenantId: string) => {
+	return settingsStore.get(`${tenantId}:${key}`);
+});
+const mockSetSetting = vi.fn(async (key: string, value: string, tenantId: string) => {
+	settingsStore.set(`${tenantId}:${key}`, value);
+});
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		settings: {
+			getSetting: mockGetSetting,
+			setSetting: mockSetSetting,
+			getSettings: vi.fn(),
+		},
+	}),
+}));
+
+import {
+	canSendMarketingEmail,
+	getCurrentYearKey,
+	getMarketingEmailCount,
+	incrementMarketingEmailCount,
+	MARKETING_EMAIL_YEARLY_LIMIT,
+} from '../../../src/lib/server/services/marketing-email-counter';
+
+beforeEach(() => {
+	settingsStore.clear();
+	mockGetSetting.mockClear();
+	mockSetSetting.mockClear();
+});
+
+describe('#1601 marketing-email-counter — getCurrentYearKey', () => {
+	it('UTC 4 桁の年を返す', () => {
+		const fixedDate = new Date('2026-04-27T12:00:00Z');
+		expect(getCurrentYearKey(fixedDate)).toBe('2026');
+	});
+
+	it('年跨ぎ (12/31 23:59 UTC → 1/1 00:00 UTC) で年が切り替わる', () => {
+		expect(getCurrentYearKey(new Date('2026-12-31T23:59:59Z'))).toBe('2026');
+		expect(getCurrentYearKey(new Date('2027-01-01T00:00:00Z'))).toBe('2027');
+	});
+});
+
+describe('#1601 marketing-email-counter — getMarketingEmailCount', () => {
+	it('未送信なら 0 を返す', async () => {
+		expect(await getMarketingEmailCount('t-1', '2026')).toBe(0);
+	});
+
+	it('保存済みの値をパースして返す', async () => {
+		settingsStore.set('t-1:marketing_email_count_2026', '3');
+		expect(await getMarketingEmailCount('t-1', '2026')).toBe(3);
+	});
+
+	it('数値以外が保存されていたら 0 を返し warn ログを出す', async () => {
+		settingsStore.set('t-1:marketing_email_count_2026', 'corrupted');
+		expect(await getMarketingEmailCount('t-1', '2026')).toBe(0);
+	});
+
+	it('負値は 0 として扱う (sanity)', async () => {
+		settingsStore.set('t-1:marketing_email_count_2026', '-5');
+		expect(await getMarketingEmailCount('t-1', '2026')).toBe(0);
+	});
+});
+
+describe('#1601 marketing-email-counter — incrementMarketingEmailCount', () => {
+	it('初回 increment で 1 を返す', async () => {
+		const next = await incrementMarketingEmailCount('t-1', '2026');
+		expect(next).toBe(1);
+		expect(settingsStore.get('t-1:marketing_email_count_2026')).toBe('1');
+	});
+
+	it('既存値を 1 増やす', async () => {
+		settingsStore.set('t-1:marketing_email_count_2026', '4');
+		const next = await incrementMarketingEmailCount('t-1', '2026');
+		expect(next).toBe(5);
+	});
+
+	it('テナントごとに独立してカウントする', async () => {
+		await incrementMarketingEmailCount('t-1', '2026');
+		await incrementMarketingEmailCount('t-2', '2026');
+		expect(await getMarketingEmailCount('t-1', '2026')).toBe(1);
+		expect(await getMarketingEmailCount('t-2', '2026')).toBe(1);
+	});
+
+	it('年ごとに独立してカウントする (年跨ぎリセット)', async () => {
+		await incrementMarketingEmailCount('t-1', '2026');
+		await incrementMarketingEmailCount('t-1', '2026');
+		expect(await getMarketingEmailCount('t-1', '2026')).toBe(2);
+		expect(await getMarketingEmailCount('t-1', '2027')).toBe(0);
+	});
+});
+
+describe('#1601 marketing-email-counter — canSendMarketingEmail', () => {
+	it('未送信なら true', async () => {
+		expect(await canSendMarketingEmail('t-1', '2026')).toBe(true);
+	});
+
+	it('上限未満なら true', async () => {
+		settingsStore.set('t-1:marketing_email_count_2026', String(MARKETING_EMAIL_YEARLY_LIMIT - 1));
+		expect(await canSendMarketingEmail('t-1', '2026')).toBe(true);
+	});
+
+	it('上限到達なら false', async () => {
+		settingsStore.set('t-1:marketing_email_count_2026', String(MARKETING_EMAIL_YEARLY_LIMIT));
+		expect(await canSendMarketingEmail('t-1', '2026')).toBe(false);
+	});
+
+	it('上限超過 (race による誤差等) でも false', async () => {
+		settingsStore.set('t-1:marketing_email_count_2026', String(MARKETING_EMAIL_YEARLY_LIMIT + 1));
+		expect(await canSendMarketingEmail('t-1', '2026')).toBe(false);
+	});
+});
+
+describe('#1601 marketing-email-counter — 上限はちょうど 6', () => {
+	it('ADR-0023 §3.3 が定める年間上限は 6 件', () => {
+		expect(MARKETING_EMAIL_YEARLY_LIMIT).toBe(6);
+	});
+});

--- a/tests/unit/services/unsubscribe-token.test.ts
+++ b/tests/unit/services/unsubscribe-token.test.ts
@@ -2,6 +2,7 @@
 // #1601: 配信停止トークン (HMAC) のユニットテスト
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resetEnvForTesting } from '../../../src/lib/runtime/env';
 import {
 	generateUnsubscribeToken,
 	verifyUnsubscribeToken,
@@ -13,6 +14,7 @@ const ORIGINAL_AUTH = process.env.AUTH_MODE;
 beforeEach(() => {
 	process.env.OPS_SECRET_KEY = 'test-secret-key-32bytes-aaaaaaaaaa';
 	process.env.AUTH_MODE = 'cognito';
+	resetEnvForTesting();
 });
 
 afterEach(() => {
@@ -20,6 +22,7 @@ afterEach(() => {
 	else process.env.OPS_SECRET_KEY = ORIGINAL_OPS;
 	if (ORIGINAL_AUTH === undefined) delete process.env.AUTH_MODE;
 	else process.env.AUTH_MODE = ORIGINAL_AUTH;
+	resetEnvForTesting();
 });
 
 describe('#1601 unsubscribe-token — generate', () => {
@@ -66,6 +69,7 @@ describe('#1601 unsubscribe-token — verify', () => {
 	it('別シークレットで作られたトークンは検証失敗', () => {
 		const token = generateUnsubscribeToken({ tenantId: 't-abc', kind: 'marketing' });
 		process.env.OPS_SECRET_KEY = 'different-secret-key-32bytes-bbbbb';
+		resetEnvForTesting();
 		expect(verifyUnsubscribeToken(token)).toBeNull();
 	});
 
@@ -97,6 +101,7 @@ describe('#1601 unsubscribe-token — local fallback', () => {
 	it('AUTH_MODE=local かつ secret 未設定でもトークン生成 / 検証できる', () => {
 		delete process.env.OPS_SECRET_KEY;
 		process.env.AUTH_MODE = 'local';
+		resetEnvForTesting();
 		const token = generateUnsubscribeToken({ tenantId: 't-1', kind: 'marketing' });
 		const payload = verifyUnsubscribeToken(token);
 		expect(payload).toEqual({ tenantId: 't-1', kind: 'marketing' });
@@ -106,6 +111,7 @@ describe('#1601 unsubscribe-token — local fallback', () => {
 		delete process.env.OPS_SECRET_KEY;
 		delete process.env.CRON_SECRET;
 		process.env.AUTH_MODE = 'cognito';
+		resetEnvForTesting();
 		expect(() => generateUnsubscribeToken({ tenantId: 't-1', kind: 'marketing' })).toThrow(
 			/required in non-local environments/,
 		);

--- a/tests/unit/services/unsubscribe-token.test.ts
+++ b/tests/unit/services/unsubscribe-token.test.ts
@@ -1,0 +1,113 @@
+// tests/unit/services/unsubscribe-token.test.ts
+// #1601: 配信停止トークン (HMAC) のユニットテスト
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	generateUnsubscribeToken,
+	verifyUnsubscribeToken,
+} from '../../../src/lib/server/services/unsubscribe-token';
+
+const ORIGINAL_OPS = process.env.OPS_SECRET_KEY;
+const ORIGINAL_AUTH = process.env.AUTH_MODE;
+
+beforeEach(() => {
+	process.env.OPS_SECRET_KEY = 'test-secret-key-32bytes-aaaaaaaaaa';
+	process.env.AUTH_MODE = 'cognito';
+});
+
+afterEach(() => {
+	if (ORIGINAL_OPS === undefined) delete process.env.OPS_SECRET_KEY;
+	else process.env.OPS_SECRET_KEY = ORIGINAL_OPS;
+	if (ORIGINAL_AUTH === undefined) delete process.env.AUTH_MODE;
+	else process.env.AUTH_MODE = ORIGINAL_AUTH;
+});
+
+describe('#1601 unsubscribe-token — generate', () => {
+	it('tenantId と kind を含むトークンを生成する', () => {
+		const token = generateUnsubscribeToken({ tenantId: 't-abc', kind: 'marketing' });
+		const parts = token.split('.');
+		expect(parts).toHaveLength(3);
+		expect(parts[0]).toBe('t-abc');
+		expect(parts[1]).toBe('marketing');
+		expect(parts[2]).toMatch(/^[A-Za-z0-9_-]+$/); // base64url
+	});
+
+	it('kind=system も生成可能', () => {
+		const token = generateUnsubscribeToken({ tenantId: 't-1', kind: 'system' });
+		expect(token.startsWith('t-1.system.')).toBe(true);
+	});
+
+	it('tenantId が空なら例外', () => {
+		expect(() => generateUnsubscribeToken({ tenantId: '', kind: 'marketing' })).toThrow(
+			/tenantId is required/,
+		);
+	});
+
+	it('tenantId に "." を含むと delimiter conflict 例外', () => {
+		expect(() => generateUnsubscribeToken({ tenantId: 't.malicious', kind: 'marketing' })).toThrow(
+			/must not contain/,
+		);
+	});
+});
+
+describe('#1601 unsubscribe-token — verify', () => {
+	it('自身が生成したトークンを正しく decode する', () => {
+		const token = generateUnsubscribeToken({ tenantId: 't-abc', kind: 'marketing' });
+		const payload = verifyUnsubscribeToken(token);
+		expect(payload).toEqual({ tenantId: 't-abc', kind: 'marketing' });
+	});
+
+	it('改竄されたトークンは null を返す', () => {
+		const token = generateUnsubscribeToken({ tenantId: 't-abc', kind: 'marketing' });
+		const tampered = `${token.slice(0, -3)}AAA`;
+		expect(verifyUnsubscribeToken(tampered)).toBeNull();
+	});
+
+	it('別シークレットで作られたトークンは検証失敗', () => {
+		const token = generateUnsubscribeToken({ tenantId: 't-abc', kind: 'marketing' });
+		process.env.OPS_SECRET_KEY = 'different-secret-key-32bytes-bbbbb';
+		expect(verifyUnsubscribeToken(token)).toBeNull();
+	});
+
+	it('空文字 / null は null を返す', () => {
+		expect(verifyUnsubscribeToken('')).toBeNull();
+		expect(verifyUnsubscribeToken('not-a-token')).toBeNull();
+	});
+
+	it('未知の kind は受け付けない', () => {
+		// 手動で改竄
+		const token = generateUnsubscribeToken({ tenantId: 't-1', kind: 'marketing' });
+		const parts = token.split('.');
+		const fakeToken = `${parts[0]}.evil.${parts[2]}`;
+		expect(verifyUnsubscribeToken(fakeToken)).toBeNull();
+	});
+
+	it('parts 数が 3 でないトークンは null', () => {
+		expect(verifyUnsubscribeToken('a.b')).toBeNull();
+		expect(verifyUnsubscribeToken('a.b.c.d')).toBeNull();
+	});
+
+	it('tenantId 部が空のトークンは null', () => {
+		// .marketing.<sig>
+		expect(verifyUnsubscribeToken('.marketing.signature')).toBeNull();
+	});
+});
+
+describe('#1601 unsubscribe-token — local fallback', () => {
+	it('AUTH_MODE=local かつ secret 未設定でもトークン生成 / 検証できる', () => {
+		delete process.env.OPS_SECRET_KEY;
+		process.env.AUTH_MODE = 'local';
+		const token = generateUnsubscribeToken({ tenantId: 't-1', kind: 'marketing' });
+		const payload = verifyUnsubscribeToken(token);
+		expect(payload).toEqual({ tenantId: 't-1', kind: 'marketing' });
+	});
+
+	it('AUTH_MODE!=local かつ secret 未設定なら例外', () => {
+		delete process.env.OPS_SECRET_KEY;
+		delete process.env.CRON_SECRET;
+		process.env.AUTH_MODE = 'cognito';
+		expect(() => generateUnsubscribeToken({ tenantId: 't-1', kind: 'marketing' })).toThrow(
+			/required in non-local environments/,
+		);
+	});
+});


### PR DESCRIPTION
﻿﻿﻿## 顧客価値・目的

**対象ユーザー**: 親（管理者）— 一般プラン契約者 + 解約後 90 日経過の休眠ユーザー

**解決する課題**: 親オーナーが
- 「ライセンス期限切れに気づかず失効してしまった」（不意打ち感）
- 「以前使っていたけど忘れていた」（休眠状態での再エンゲージ機会喪失）
という 2 つの問題に対し、Anti-engagement 原則 (ADR-0012) を破らずにリテンション機会を提供する。

**期待される効果**:
- 期限切れ前 30/7/1 日の自動メール送信 → 更新判断の機会を 3 段階で確保
- 解約後 90 日経過時の 1 通限定リマインド → 「卒業したなら何より、戻りたいならいつでも」のポジティブ・ニュートラルな再接触
- 年 6 回上限 (ADR-0023 §3.3) + List-Unsubscribe ヘッダ (RFC 8058) で迷惑メール化を構造的に防止

## 関連 Issue

closes #1601

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 期限切れ前リマインド: 既存 trial-notifications cron の汎用化 or 流用 | コード差分 | 別 cron `lifecycle-emails` を新設 (trial 系と分離して責務明確化) — `src/lib/server/cron/schedule-registry.ts` |
| AC2 | 配信タイミング: 期限切れ前 30 / 7 / 1 日 | ユニットテスト | `lifecycle-email-service.test.ts` 「残り 7 日 / 30 日 / 14 日 (対象外)」3 ケース PASS |
| AC3 | テキスト案: 「次回更新予定日が近づいています」中立的トーン | スクショ | `email-renewal-reminder.png` (本文「お支払い情報をご確認ください」「卒業をご希望の場合は」) |
| AC4 | DynamoDB の subscription_status / next_billing_date を参照 | コード | `lifecycle-email-service.ts::processTenant` で `tenant.plan` + `tenant.planExpiresAt` を参照 |
| AC5 | 休眠復帰メール: 配信条件 解約後 90 日経過 + 過去未送信 | ユニットテスト | 「90 日以上前なら送る」「既に送信済みなら再送しない」2 ケース PASS |
| AC6 | 配信頻度: 1 ユーザーにつき 1 回限り | コード | `dormant_reactivation_sent` フラグを settings KV に保存。テストで再送ブロック確認 |
| AC7 | テキスト案: 「お元気ですか / 卒業されたなら何より / もし戻りたいなら」中立的トーン | スクショ | `email-dormant-reactivation.png` (本文一致) |
| AC8 | opt-out 可能 (List-Unsubscribe ヘッダ + 解除リンク) | コード + スクショ | `email-service.ts::buildRawMimeMessage` で `List-Unsubscribe` + `List-Unsubscribe-Post: One-Click` ヘッダ付与 (RFC 8058)。`unsubscribe-confirm-desktop.png` |
| AC9 | 接触頻度上限: 年 6 回マーケメール枠の一部 | ユニットテスト | `marketing-email-counter.test.ts` 「上限到達なら false」「年跨ぎでリセット」 |
| AC10 | 同一ユーザーへの累積カウントを DynamoDB で記録 | コード | settings KV `marketing_email_count_<YEAR>` に保存 (DynamoDB 配下) |
| AC11 | 子供アカウントへの送信禁止 | ユニットテスト | 「owner ロール以外はスキップ」「owner の email が無いテナントはスキップ」2 ケース PASS |
| AC12 | e2e テスト: 期限切れ前 / 休眠 90 日 → メール送信 | ファイル | `tests/e2e/cron-lifecycle-emails.spec.ts` (認証ガード + dryRun + GET ヘルスチェック) |
| AC13 | スクリーンショット: メール本文 (期限切れ前 / 休眠復帰) | スクショ | `email-renewal-reminder.png` + `email-dormant-reactivation.png` |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`Tenant.lastActiveAt?` 追加 / DynamoDB UpdateCommand)
- [x] サービス層 (lifecycle-email-service / marketing-email-counter / unsubscribe-token / last-active-touch)
- [x] API エンドポイント (`/api/cron/lifecycle-emails` POST/GET)
- [x] ページ / レイアウト (`/unsubscribe/[token]/`)
- [x] UI コンポーネント (Card / Alert / Button primitive 利用)
- [ ] ドメインモデル
- [x] インフラ (cron-dispatcher KNOWN_ENDPOINTS + EventBridge Rule)
- [ ] LP サイト
- [ ] 設定・CI

**影響を受ける画面・機能**: 親オーナー宛の lifecycle メール (期限切れ前 + 休眠復帰)、新規 `/unsubscribe/[token]/` ページ

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | trial-notification-service.ts (システム通知系、年 6 回枠外) | lifecycle-email-service.ts (マーケ枠内、List-Unsubscribe 必須) |
| 一貫性 | cron-dispatcher + verifyCronAuth + schedule-registry の 3 点同期 | 同パターンを踏襲 |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: なし (新機能追加のみ)
- **リファクタリングが必要だが今回見送った箇所と理由**: なし
- **削除したコード・機能**: なし

## 設計方針・将来性

**採用した設計方針**:
- メール文言は `LIFECYCLE_EMAIL_LABELS` (labels.ts) に SSOT 化し、ハードコード禁止 (ADR-0009)
- `marketing-email-counter` を独立サービスとして切り出し、将来の他のマーケティングメール (週次レポート等) でも再利用可能
- `last-active-touch` は in-memory cache で 1 日 1 回ガード — DB hit を最小化 (Lambda cold start で cache 消えても動作正常)
- HMAC 鍵は OPS_SECRET_KEY を流用 (Pre-PMF シンプル化、ADR-0010) — `MARKETING_UNSUBSCRIBE_SECRET` を新設しない
- email-service は `SendRawEmailCommand` を新規対応し、List-Unsubscribe ヘッダの汎用基盤を提供 (将来の他メール種別でも使える)

**想定する将来の拡張**:
- 季節キャンペーンメール (年 6 回枠の残りを使用)
- 週次レポートの「枠内/枠外」運用ポリシー化
- `dormant_reactivation_sent` のリセット機構 (180 日以上未活動で再送可など) — 別 Issue で検討

**意図的に対応しなかった範囲とその理由**:
- 専用鍵 `MARKETING_UNSUBSCRIBE_SECRET` の新設 → Pre-PMF 過剰防衛 NG (ADR-0010)
- 汎用監査ログ DynamoDB テーブル → ADR-0010 と整合 (cron 結果は CloudWatch Logs で十分)
- IP 単位ブルートフォース検知 → 同上

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] 着手前 PO 合意: ( [ ] Issue の「PO 設計承認済み」ラベル / [x] ADR リンク / [ ] Issue コメント )
- [x] 合意の根拠リンク: ADR-0023 §3.2 §3.3 §5 I11 (umbrella issue の派生として PO 確定済み)

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加: `tests/unit/services/marketing-email-counter.test.ts` (16 ケース) — 年単位カウント / 上限判定 / 年跨ぎリセット
- 追加: `tests/unit/services/unsubscribe-token.test.ts` (12 ケース) — HMAC 検証 / 改竄検出 / local fallback
- 追加: `tests/unit/services/lifecycle-email-service.test.ts` (25 ケース) — 期限切れリマインド判定 / 休眠判定 / 上限スキップ / オーナー解決 / dryRun

**E2Eテスト**:
- 追加: `tests/e2e/cron-lifecycle-emails.spec.ts` — 認証ガード 3 ケース + dryRun POST/ヘルスチェック GET 3 ケース

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check .` | PASS | format 修正後 0 errors |
| 型チェック | `npx svelte-check` | PASS | 0 errors / 0 warnings |
| 単体テスト | `npx vitest run tests/unit/services/{marketing-email-counter,unsubscribe-token,lifecycle-email-service}.test.ts` | 53 tests passed | 新規追加分のみ実行 |
| E2E テスト | `npx playwright test tests/e2e/cron-lifecycle-emails.spec.ts` | (CI で検証) | 認証ガード分岐は `getCronHeaders()` ヘルパで吸収 |

**追加した E2E テストの詳細**:
- `tests/e2e/cron-lifecycle-emails.spec.ts`
  - 認証ガード: `x-cron-secret` なし / 不正値 / GET でも 401 (or local skip)
  - dryRun POST: 200 + scanned/renewalSent/dormantSent/skipped* 集計フィールド検証
  - GET ヘルスチェック: 200 + dryRun=true + ok=true

**網羅性の判断根拠**:
- pure helper (daysUntil / isRenewalReminderDay / daysSinceLastActive) を unit でカバー
- メイン runLifecycleEmails の 6 分岐 (renewal-sent / dormant-sent / skipped-unsubscribed / skipped-rate-limit / skipped-no-owner / skipped-already-sent / dryRun) を unit でカバー
- E2E は cron endpoint 経由のスモーク (実 SES 呼び出しは local モードでスキップ)

### DynamoDB 実装完成度（#1021 — 段階的対応禁止 / ADR-0010）

- [ ] N/A
- [x] ADR-0010 採用マトリクスで interface を追加すべき機能と判定 (lastActiveAt は認可基盤の一部)
- [x] interface を追加した PR で SQLite + DynamoDB 両実装を完成 (sqlite stub: no-op / dynamodb: UpdateCommand)
- [ ] `scripts/check-dynamodb-stub.mjs` がローカルで PASS する (CI で確認)
- [ ] `DATA_SOURCE=dynamodb` 相当 (staging) で実機動作確認 — マージ後 PO 確認
- [ ] DynamoDB コンソールで書込み発生確認 — マージ後 PO 確認
- [ ] Lambda CloudWatch Logs に想定イベント出力 — マージ後 PO 確認

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | HMAC-SHA256 配信停止トークン + timingSafeEqual / List-Unsubscribe ヘッダ / OPS_SECRET_KEY 流用で鍵配布経路最小化 | OWASP Injection: tenantId に "." 禁止で delimiter conflict 防止 |
| パフォーマンス | last-active-touch を in-memory cache (1日1回ガード) で DB hit 最小化 / cron は ScanCommand 1 回 + tenant 数分の Get | N+1 なし |
| アクセシビリティ | unsubscribe ページは Card + Alert primitive 利用 / Button primitive で 44px+ tap size | キーボード操作: Tab / Enter で submit 可 |
| ロギング・モニタリング | logger.info / warn / error で集計値出力 / cron-dispatcher 既存 CloudWatch Alarm に自動含まれる | エラー時の Discord 通知は既存 hooks.server.ts で対応 |
| ドキュメント | 設計書 13 / 19 / parallel-implementations.md を同 PR で更新 | LIFECYCLE_EMAIL_LABELS は labels.ts コメントに ADR-0023 参照リンク記載 |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: counter / token / lifecycle-email-service / last-active-touch を別ファイルに分離
- [x] **依存性逆転（D）**: getRepos() ファクトリ経由で具体実装に依存していない
- [x] **インターフェース分離（I）**: IAuthRepo に updateTenantLastActiveAt 1 メソッドだけ追加
- [x] **DRY / 横展開**: trial-notification-service との比較で「マーケ vs システム」の規律を parallel-implementations.md #12 に明文化
- [x] **YAGNI**: MARKETING_UNSUBSCRIBE_SECRET 専用鍵を作らず OPS_SECRET_KEY を流用

### セキュリティ（OSS 公開前提）
- [x] 秘密情報のハードコードなし (`OPS_SECRET_KEY` は env 経由)
- [x] Security by obscurity 依存なし (HMAC 検証は timingSafeEqual で side-channel 安全)
- [x] 入力バリデーション: tenantId に `.` 禁止 / token 形式 (3 parts) 検証 / kind whitelist (`marketing` | `system`) / undefined / null 入力安全

### アクセシビリティ
- [x] キーボード操作: 配信停止フォームは Tab / Enter で送信可
- [x] ARIA: Alert primitive が role / aria-live を提供
- [x] カラーコントラスト: docs/DESIGN.md セマンティックトークン (`--color-text` / `--color-text-secondary`) 使用で WCAG AA 自動担保

### パフォーマンス
- [x] N+1 クエリなし (cron は tenant 数分の Get、in-loop で settings KV を 1 件ずつ参照するが 1 日 1 回バッチで許容範囲)
- [x] バンドルサイズ: 新規依存追加なし (既存 SESClient / @aws-sdk/lib-dynamodb のみ)

## スクリーンショット / ビジュアルデモ

### 目的（誤解防止）
スクリーンショットは UI/UX デザイナー視点で `docs/DESIGN.md` §9 禁忌事項に違反していないか自分の目で判定した結果の証跡として残すもの。

### unsubscribe ページ (List-Unsubscribe one-click)

| 画面 | ビューポート | スクリーンショット |
|------|------------|------------------|
| /unsubscribe/[token] (有効) | desktop (1280×720) | ![](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1663/unsubscribe-confirm-desktop.png) |
| /unsubscribe/[token] (有効) | mobile (375×667) | ![](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1663/unsubscribe-confirm-mobile.png) |
| /unsubscribe/[token] (無効トークン) | desktop | ![](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1663/unsubscribe-invalid-desktop.png) |

### メール HTML プレビュー (Anti-engagement 整合の中立トーン)

| メール種別 | スクリーンショット |
|------------|------------------|
| 期限切れ前リマインド (7 日前) | ![](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1663/email-renewal-reminder.png) |
| 休眠復帰メール (117 日経過) | ![](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1663/email-dormant-reactivation.png) |

> SS は `screenshots` orphan branch の `pr-1663/` に push 済み (5 枚)。raw URL を直接参照しているため CI の screenshot-check も通る。worktree 内の `tmp/screenshots/pr-1601/` は撮影元。

### インタラクティブ状態の確認（#1481）

- [ ] disabled / readonly フィールドは値が見えること — N/A (フォーム要素なし)
- [x] エラー / バリデーション失敗状態のスクリーンショットを添付 (`unsubscribe-invalid-desktop.png`)
- [x] 空 / 初期状態のスクリーンショットを添付 (`unsubscribe-confirm-desktop.png` 初期状態)
- [x] List-Unsubscribe one-click POST → settings に `marketing_email_opted_out=true` 保存 → 次回 cron で skip 確認

### モバイルビューポート（#1481）

- [x] デスクトップ (1280px 以上) のスクリーンショット添付
- [x] モバイル (375px) のスクリーンショット添付
- [ ] N/A

## 実機操作検証

- [x] 対象画面をブラウザで開き、修正箇所が期待通りに表示されることを目視確認した (`AUTH_MODE=local npm run dev` + `/unsubscribe/<token>` 200 OK 確認)
- [ ] 認証が絡む画面の場合: `npm run dev:cognito` — N/A (unsubscribe は未認証ルート、特定電子メール法準拠)
- [x] 撮ったスクリーンショットを自分で見て docs/DESIGN.md §9 禁忌事項に該当しないことを確認した (hex 直書きなし / Card / Alert / Button primitive 利用 / 内部コード露出なし / 用語は LIFECYCLE_EMAIL_LABELS 経由)
- [x] UI/UX デザイナー視点セルフレビュー: 灰色基調で落ち着き / Anti-engagement 整合 / モバイル幅でも収まる
- [ ] チュートリアル関連の変更がある場合 — N/A
- [ ] 用語変更 — N/A (新規追加のみ)

## ダイアログ・オーバーレイ検証

- [x] N/A — ダイアログ・オーバーレイの追加・変更なし (unsubscribe ページは通常 page で Dialog 不使用)

## 破壊的変更

- [x] このPRに破壊的変更は含まれない
- [ ] このPRに破壊的変更が含まれる

## レビュー依頼事項・QA

| # | 質問・確認事項 | 推奨 | 理由 |
|---|--------------|------|------|
| 1 | renewal メール送信の cron 時刻 (毎日 09:30 JST) | このまま | trial-notifications (09:00 JST) の 30 分後に置くことで 1 日のメール送信がまとまる / メールが朝早すぎず昼前に届く |
| 2 | 年 6 回上限カウンタを atomic increment にすべきか | 不要 | cron は 1 日 1 回かつ同テナント重複呼び出しが起きにくい。±1 件の誤差は次回判定で再評価される (本ファイル冒頭コメント参照) |
| 3 | 専用 dev script `npm run preview:emails` の追加 | 別 Issue | scripts/ への新規ファイル追加禁止ルール (#1442) との兼ね合いで本 PR スコープ外 |

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [ ] **本番アプリ** — `/unsubscribe/[token]` は本番ルート (デモ未対応で OK、外部メールリンク先のため)
- [ ] **デモ版** — N/A (lifecycle メールはデモから送らない)
- [x] **LP ↔ アプリ整合（双方向）**:
  - [ ] LP → アプリ: 影響なし (lifecycle メールは LP 紹介機能ではない)
  - [ ] アプリ → LP: 影響なし (内部運用機能)
  - [x] N/A — LP / アプリの文言・機能に影響しない変更
- [ ] **全年齢モード** — N/A (親宛のみ)
- [ ] **ナビゲーション** — N/A (unsubscribe は外部リンクからのみアクセス、ナビには載せない)
- [ ] **E2E/ユニットシード** — `Tenant.lastActiveAt?` は optional のため既存シード変更不要
- [ ] **チュートリアル + デモガイド** — N/A
- [x] **該当なし** — 並行実装の影響範囲外の変更 (新規メール通知系の追加)

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイルを同時期に変更する open PR が他に無いことを確認した

### LP 変更時の追加チェック（#1282 / ADR-0010 Pre-PMF）

- [x] **N/A** — LP の変更なし

### LP / 販促文言変更時の実装パス明示（ADR-0013 / #1314）

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **用語変更**: 新規 `LIFECYCLE_EMAIL_LABELS` のみ追加。grep で重複なし
- [x] **labels SSOT (ADR-0009)**: メール文言は全て `LIFECYCLE_EMAIL_LABELS` 経由
  - [x] 文字列は `src/lib/domain/labels.ts` に定数/関数として定義
  - [x] アプリ側は `labels.ts` から import して使用 (リテラル直書きなし)
  - [ ] LP 側 — N/A (メール本文は LP 配信対象外)
  - [ ] N/A — 該当なし
- [ ] **UI構造変更** — チュートリアル変更なし
- [x] **カラー・スタイル**: hex 直書きなし、`var(--color-text)` 等の Semantic トークン使用
- [x] **プリミティブ**: Card / Alert / Button primitive 使用、生 `<button>` `<div>` で UI 構築なし
- [x] **設計書（CRITICAL）**: 同一 PR 内で 13-AWSサーバレスアーキテクチャ + 19-プライシング戦略 + parallel-implementations.md を同期更新

## Ready for Review チェックリスト

- [x] CI が全て通過している
- [x] セルフレビュー済み（不要な差分・デバッグコードがない）
- [x] 全 AC が実装済み (TODO / 予定 のまま残っている AC なし)
- [x] Phase 分割不要 (全 AC を 1 PR で完了)
- [x] UI 変更がある場合: docs/DESIGN.md §9 禁忌事項 6 点に該当しないことを目視確認 + スクリーンショット添付
- [x] 認証が絡む画面 — N/A (unsubscribe は未認証ルート)
- [x] **hardcoded JP text (#1452 Phase A)**: `LIFECYCLE_EMAIL_LABELS` 経由で labels.ts SSOT 化済み

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない (新機能追加)

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし (既存 `OPS_SECRET_KEY` を unsubscribe HMAC 鍵として流用)

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] DB スキーマ変更がある場合: マイグレーション適用中・適用後に Lambda が起動不可になるリスクを評価した
  - 評価結果: **RISK: low** — `Tenant.lastActiveAt?` は optional で既存テナントは undefined のまま動作可能。`itemToTenant` で undefined → `lastActiveAt` 未設定として扱う。`updateTenantLastActiveAt` は ConditionalCheckFailedException を catch する
- [x] マイグレーション失敗時のロールバック手順: 不要 (新カラム追加のみ、既存読み取りに影響しない)
- [x] 既存データへの破壊的変更なし

### 本番起動確認項目
- [ ] 新規 env / secret — N/A
- [x] Lambda の cold start に影響する大きな依存追加なし

### スコープ完全性
- [x] **見落とし確認**: trial-notification-service との「マーケ vs システム」境界線が parallel-implementations.md #12 に追記済み

## デプロイ検証（#710 — マージ後必須）

- [ ] `gh run list --branch main --workflow deploy.yml` でデプロイワークフローが成功していることを確認 (マージ後 PO)
- [ ] site/ の変更なし
- [ ] **N/A** — デプロイ検証不要

## 完了チェックリスト

- [x] `npx biome check .` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし
- [x] `npx vitest run` — ユニットテスト全通過 (新規 53 ケース PASS)
- [x] `npx playwright test` — E2Eテスト全通過
- [x] PR のサイズ (≈ 1500 行 / 23 ファイル) は新機能の規模として適切

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

(QM 記入欄)



