### PR TITLE
feat: #1592 I4 setup challenges 6→3 簡素化 + デフォルトプリセット 3軸

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1046,11 +1046,39 @@ AdminHome.svelte
 | ページ | パス | 概要 |
 |--------|------|------|
 | セットアップ開始 | `/setup` | ウェルカム画面 |
-| アンケート | `/setup/questionnaire` | 利用目的アンケート |
+| アンケート | `/setup/questionnaire` | 利用目的アンケート（**Q1 challenges を 6→3 に簡素化 #1592 ADR-0023 I4**） |
 | 子供登録 | `/setup/children` | 子供プロフィール作成 |
 | パック選択 | `/setup/packs` | 活動パック選択 |
 | はじめての冒険 | `/setup/first-adventure` | 初回体験 |
 | セットアップ完了 | `/setup/complete` | 完了画面 |
+
+#### `/setup/questionnaire` — Q1 challenges 3 軸プリセット仕様 (#1592 / ADR-0023 I4)
+
+親 P1（共働き、時間がない）が「使い始めたいけど何ができるかわからない」「自分で設定するのが面倒」を解消するため、Q1 を 6 択 → 3 択に簡素化し、各選択にデフォルトチェックリストプリセットを紐付ける。
+
+**Q1 課題選択肢（3 軸 / 複数選択可）**
+
+| value | UI ラベル | 推奨カテゴリ | 推奨プリセット |
+|-------|----------|-------------|---------------|
+| `homework-daily` | 毎日宿題をやらせたい | benkyou | `after-school`（がっこうからかえったら） |
+| `chores` | 家事をやらせたい | seikatsu | `weekend-chores`（しゅうまつのおてつだい） |
+| `beyond-games` | ゲーム以外のことに興味を惹かせたい | souzou + undou + kouryuu | `beyond-games`（ゲームいがいのチャレンジ：読書・外遊び・工作・音楽） |
+
+- 旧 6 択（morning / homework / chores / exercise / picky / balanced）の `homework` / `chores` / `balanced` は新 3 軸キー（`homework-daily` / `chores` / `beyond-games`）にリネーム/分割
+- 後方互換: `questionnaire-service.ts` の `CHALLENGE_CATEGORY_WEIGHTS` / `CHALLENGE_CHECKLIST_MAP` は旧キーも保持（過去回答を保存済みのテナント保護）
+- 排他制御: 旧 `balanced` の単独選択強制を撤去。3 軸はすべて加算的に選択可能（Anti-engagement: 認知負荷削減方向のみ ADR-0012）
+
+**プリセット一覧（`static/checklist-presets/`）**
+
+| presetId | name | items | 推奨年齢 |
+|----------|------|-------|---------|
+| `morning-routine` | あさのしたく | はみがき / かおをあらう / きがえ / あさごはん / もちものチェック | 0-18 |
+| `evening-routine` | よるのじゅんび | おふろ / はみがき / あしたのじゅんび / おやすみのあいさつ | 0-18 |
+| `after-school` | がっこうからかえったら | てあらい / れんらくちょう / しゅくだい / あしたのじゅんび | 6-18 |
+| `weekend-chores` | しゅうまつのおてつだい | おへや / せんたく / しょっき / ごみだし | 4-18 |
+| `beyond-games` (新規 #1592) | ゲームいがいのチャレンジ | ほんをよむ / そとであそぶ / おえかき / おんがく | 3-18 |
+
+**SSOT**: `src/lib/server/services/questionnaire-service.ts`（CHALLENGE_CATEGORY_WEIGHTS / CHALLENGE_CHECKLIST_MAP）+ `src/lib/domain/labels.ts`（SETUP_QUESTIONNAIRE_LABELS）+ `static/checklist-presets/`
 
 ### 親用管理画面
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -3168,11 +3168,28 @@ export const OPS_LAYOUT_LABELS = {
 export const SETUP_QUESTIONNAIRE_LABELS = {
 	pageTitle: '📋 かんたんアンケート',
 	pageDesc: 'お子さまに合った設定を自動でご用意します',
+	// #1592 (ADR-0023 I4): 6→3 簡素化 — 親が「使い始めたいけど何ができるかわからない」を解消
 	q1Legend: 'Q1. お子さまの課題は？（いくつでも）',
+	// 新 3 軸の選択肢ラベル
+	challengeHomeworkDaily: '毎日宿題をやらせたい',
+	challengeChores: '家事をやらせたい',
+	challengeBeyondGames: 'ゲーム以外のことに興味を惹かせたい',
 	q2Legend: 'Q2. 1にちに どれくらい きろくする？',
+	activityLevelFewLabel: 'すこしずつ（3〜5こ）',
+	activityLevelFewDesc: 'はじめてでも むりなく',
+	activityLevelNormalLabel: 'ふつう（5〜10こ）',
+	activityLevelNormalDesc: 'おすすめ',
+	activityLevelManyLabel: 'たくさん（10こ いじょう）',
+	activityLevelManyDesc: 'いろいろ きろくしたい',
 	recommendedBadge: 'おすすめ',
 	q3Legend: 'Q3. チェックリストを自動作成する？',
 	q3Hint: 'えらんだリストが自動で作成されます（あとから変更できます）',
+	// プリセットラベル（チェックリスト一覧用）
+	presetMorningRoutine: 'あさのしたく',
+	presetEveningRoutine: 'よるのじゅんび',
+	presetAfterSchool: 'がっこうからかえったら',
+	presetWeekendChores: 'しゅうまつのおてつだい',
+	presetBeyondGames: 'ゲームいがいのチャレンジ',
 	submittingLabel: 'せっていちゅう...',
 	startButton: 'この設定ではじめる！',
 	skipButton: 'あとで設定する（スキップ）',

--- a/src/lib/server/services/questionnaire-service.ts
+++ b/src/lib/server/services/questionnaire-service.ts
@@ -28,21 +28,42 @@ interface ChecklistPreset {
 	items: PresetItem[];
 }
 
-/** 課題ごとのおすすめカテゴリ重み付け */
+/**
+ * 課題ごとのおすすめカテゴリ重み付け
+ *
+ * #1592 (ADR-0023 I4): setup challenges を 6→3 に簡素化。
+ * 旧キー (morning/homework/exercise/picky/balanced) は後方互換のため保持し、過去にアンケート回答を
+ * 保存済みのテナントが再度クエリしても壊れないようにする。新規 setup フローからは投稿されない。
+ */
 const CHALLENGE_CATEGORY_WEIGHTS: Record<string, string[]> = {
+	// 新 3 軸（#1592）
+	'homework-daily': ['benkyou'],
+	chores: ['seikatsu'],
+	'beyond-games': ['souzou', 'undou', 'kouryuu'],
+	// 旧キー（後方互換 / 廃止予定）
 	morning: ['seikatsu'],
 	homework: ['benkyou'],
-	chores: ['seikatsu'],
 	exercise: ['undou'],
 	picky: ['seikatsu'],
 	balanced: ['undou', 'benkyou', 'seikatsu', 'souzou', 'kouryuu'],
 };
 
-/** 課題ごとのおすすめチェックリスト */
+/**
+ * 課題ごとのおすすめチェックリスト
+ *
+ * #1592 (ADR-0023 I4): 新 3 軸 → 対応プリセット
+ * - homework-daily → after-school（がっこうからかえったら：宿題ルーティン）
+ * - chores → weekend-chores（しゅうまつのおてつだい）
+ * - beyond-games → beyond-games（ゲーム以外のチャレンジ：読書/外遊び/工作/音楽）
+ */
 const CHALLENGE_CHECKLIST_MAP: Record<string, string[]> = {
+	// 新 3 軸（#1592）
+	'homework-daily': ['after-school'],
+	chores: ['weekend-chores'],
+	'beyond-games': ['beyond-games'],
+	// 旧キー（後方互換 / 廃止予定）
 	morning: ['morning-routine'],
 	homework: ['after-school'],
-	chores: ['weekend-chores'],
 	exercise: [],
 	picky: [],
 	balanced: ['morning-routine', 'evening-routine'],

--- a/src/routes/setup/questionnaire/+page.svelte
+++ b/src/routes/setup/questionnaire/+page.svelte
@@ -8,29 +8,75 @@ let { data } = $props();
 const firstChild = data.children[0];
 const childAge = firstChild?.age ?? 5;
 
-// 課題の選択肢
+// #1592 (ADR-0023 I4): 6→3 簡素化
+// 親 P1（共働き、時間がない）が「使い始めたいけど何ができるかわからない」を解消するため、
+// challenges を 3 軸に絞り、各軸にデフォルトプリセットを紐付ける。
 const challengeOptions = [
-	{ value: 'morning', label: 'あさの じゅんびが おそい', icon: '⏰' },
-	{ value: 'homework', label: 'しゅくだいを じぶんから やらない', icon: '📝' },
-	{ value: 'chores', label: 'おてつだいを しない', icon: '🧹' },
-	{ value: 'exercise', label: 'そとで あそばない・うんどうぶそく', icon: '🏃' },
-	{ value: 'picky', label: 'すききらいが おおい', icon: '🍽️' },
-	{ value: 'balanced', label: 'とくに こまっていない（バランスよく）', icon: '✨' },
+	{
+		value: 'homework-daily',
+		label: SETUP_QUESTIONNAIRE_LABELS.challengeHomeworkDaily,
+		icon: '📝',
+	},
+	{ value: 'chores', label: SETUP_QUESTIONNAIRE_LABELS.challengeChores, icon: '🧹' },
+	{
+		value: 'beyond-games',
+		label: SETUP_QUESTIONNAIRE_LABELS.challengeBeyondGames,
+		icon: '🎨',
+	},
 ];
 
 // 活動量の選択肢
 const activityLevelOptions = [
-	{ value: 'few', label: 'すこしずつ（3〜5こ）', description: 'はじめてでも むりなく' },
-	{ value: 'normal', label: 'ふつう（5〜10こ）', description: 'おすすめ' },
-	{ value: 'many', label: 'たくさん（10こ いじょう）', description: 'いろいろ きろくしたい' },
+	{
+		value: 'few',
+		label: SETUP_QUESTIONNAIRE_LABELS.activityLevelFewLabel,
+		description: SETUP_QUESTIONNAIRE_LABELS.activityLevelFewDesc,
+	},
+	{
+		value: 'normal',
+		label: SETUP_QUESTIONNAIRE_LABELS.activityLevelNormalLabel,
+		description: SETUP_QUESTIONNAIRE_LABELS.activityLevelNormalDesc,
+	},
+	{
+		value: 'many',
+		label: SETUP_QUESTIONNAIRE_LABELS.activityLevelManyLabel,
+		description: SETUP_QUESTIONNAIRE_LABELS.activityLevelManyDesc,
+	},
 ];
 
 // チェックリストプリセット
+// #1592: beyond-games (ゲーム以外のチャレンジ：読書/外遊び/工作/音楽) を追加
 const presetOptions = [
-	{ value: 'morning-routine', label: 'あさのしたく', icon: '☀️', ageMin: 0 },
-	{ value: 'evening-routine', label: 'よるのじゅんび', icon: '🌙', ageMin: 0 },
-	{ value: 'after-school', label: 'がっこうからかえったら', icon: '🎒', ageMin: 6 },
-	{ value: 'weekend-chores', label: 'しゅうまつのおてつだい', icon: '🧹', ageMin: 4 },
+	{
+		value: 'morning-routine',
+		label: SETUP_QUESTIONNAIRE_LABELS.presetMorningRoutine,
+		icon: '☀️',
+		ageMin: 0,
+	},
+	{
+		value: 'evening-routine',
+		label: SETUP_QUESTIONNAIRE_LABELS.presetEveningRoutine,
+		icon: '🌙',
+		ageMin: 0,
+	},
+	{
+		value: 'after-school',
+		label: SETUP_QUESTIONNAIRE_LABELS.presetAfterSchool,
+		icon: '🎒',
+		ageMin: 6,
+	},
+	{
+		value: 'weekend-chores',
+		label: SETUP_QUESTIONNAIRE_LABELS.presetWeekendChores,
+		icon: '🧹',
+		ageMin: 4,
+	},
+	{
+		value: 'beyond-games',
+		label: SETUP_QUESTIONNAIRE_LABELS.presetBeyondGames,
+		icon: '🎨',
+		ageMin: 3,
+	},
 ];
 
 // 年齢で表示するプリセットをフィルタ
@@ -42,11 +88,7 @@ let selectedPresets = $state<string[]>(availablePresets.map((p) => p.value));
 let submitting = $state(false);
 
 function toggleChallenge(value: string) {
-	if (value === 'balanced') {
-		selectedChallenges = selectedChallenges.includes('balanced') ? [] : ['balanced'];
-		return;
-	}
-	selectedChallenges = selectedChallenges.filter((c) => c !== 'balanced');
+	// #1592: 旧 'balanced' 排他制御を撤去（新 3 軸はすべて加算的に選択可能）
 	if (selectedChallenges.includes(value)) {
 		selectedChallenges = selectedChallenges.filter((c) => c !== value);
 	} else {

--- a/static/checklist-presets/beyond-games.json
+++ b/static/checklist-presets/beyond-games.json
@@ -1,0 +1,14 @@
+{
+	"formatVersion": "1.0",
+	"presetId": "beyond-games",
+	"name": "ゲームいがいのチャレンジ",
+	"icon": "🎨",
+	"pointsPerItem": 3,
+	"completionBonus": 8,
+	"items": [
+		{ "name": "ほんをよむ", "icon": "📖", "sortOrder": 1 },
+		{ "name": "そとであそぶ", "icon": "⚽", "sortOrder": 2 },
+		{ "name": "おえかき・こうさく", "icon": "🎨", "sortOrder": 3 },
+		{ "name": "おんがくをきく・うたう", "icon": "🎵", "sortOrder": 4 }
+	]
+}

--- a/static/checklist-presets/index.json
+++ b/static/checklist-presets/index.json
@@ -48,6 +48,18 @@
 			"itemCount": 4,
 			"pointsPerItem": 3,
 			"completionBonus": 8
+		},
+		{
+			"presetId": "beyond-games",
+			"name": "ゲームいがいのチャレンジ",
+			"icon": "🎨",
+			"description": "ゲーム以外のことに興味を持つきっかけリスト（読書・外遊び・工作・音楽）",
+			"targetAgeMin": 3,
+			"targetAgeMax": 18,
+			"tags": ["読書", "外遊び", "工作", "ゲーム以外"],
+			"itemCount": 4,
+			"pointsPerItem": 3,
+			"completionBonus": 8
 		}
 	]
 }

--- a/tests/unit/services/questionnaire-service.test.ts
+++ b/tests/unit/services/questionnaire-service.test.ts
@@ -41,37 +41,66 @@ describe('questionnaire-service', () => {
 	// getRecommendedCategories
 	// ========================================
 	describe('getRecommendedCategories', () => {
-		it('morning → seikatsu を返す', () => {
-			const result = getRecommendedCategories(['morning']);
-			expect(result).toEqual(['seikatsu']);
+		// 新 3 軸（#1592 ADR-0023 I4）
+		describe('新 3 軸 (#1592)', () => {
+			it('homework-daily → benkyou を返す', () => {
+				const result = getRecommendedCategories(['homework-daily']);
+				expect(result).toEqual(['benkyou']);
+			});
+
+			it('chores → seikatsu を返す', () => {
+				const result = getRecommendedCategories(['chores']);
+				expect(result).toEqual(['seikatsu']);
+			});
+
+			it('beyond-games → souzou + undou + kouryuu を返す', () => {
+				const result = getRecommendedCategories(['beyond-games']);
+				expect(result).toContain('souzou');
+				expect(result).toContain('undou');
+				expect(result).toContain('kouryuu');
+				expect(result).toHaveLength(3);
+			});
+
+			it('3 軸全選択 → 5 カテゴリ（重複除去）を返す', () => {
+				const result = getRecommendedCategories(['homework-daily', 'chores', 'beyond-games']);
+				expect(result).toContain('benkyou');
+				expect(result).toContain('seikatsu');
+				expect(result).toContain('souzou');
+				expect(result).toContain('undou');
+				expect(result).toContain('kouryuu');
+				expect(result).toHaveLength(5);
+			});
 		});
 
-		it('homework → benkyou を返す', () => {
-			const result = getRecommendedCategories(['homework']);
-			expect(result).toEqual(['benkyou']);
-		});
+		// 旧キー（後方互換 / 廃止予定）
+		describe('旧キー後方互換', () => {
+			it('morning → seikatsu を返す', () => {
+				const result = getRecommendedCategories(['morning']);
+				expect(result).toEqual(['seikatsu']);
+			});
 
-		it('chores → seikatsu を返す', () => {
-			const result = getRecommendedCategories(['chores']);
-			expect(result).toEqual(['seikatsu']);
-		});
+			it('homework → benkyou を返す', () => {
+				const result = getRecommendedCategories(['homework']);
+				expect(result).toEqual(['benkyou']);
+			});
 
-		it('exercise → undou を返す', () => {
-			const result = getRecommendedCategories(['exercise']);
-			expect(result).toEqual(['undou']);
-		});
+			it('exercise → undou を返す', () => {
+				const result = getRecommendedCategories(['exercise']);
+				expect(result).toEqual(['undou']);
+			});
 
-		it('picky → seikatsu を返す', () => {
-			const result = getRecommendedCategories(['picky']);
-			expect(result).toEqual(['seikatsu']);
-		});
+			it('picky → seikatsu を返す', () => {
+				const result = getRecommendedCategories(['picky']);
+				expect(result).toEqual(['seikatsu']);
+			});
 
-		it('balanced → 全5カテゴリを返す', () => {
-			const result = getRecommendedCategories(['balanced']);
-			expect(result).toHaveLength(5);
-			for (const cat of ALL_CATEGORIES) {
-				expect(result).toContain(cat);
-			}
+			it('balanced → 全5カテゴリを返す', () => {
+				const result = getRecommendedCategories(['balanced']);
+				expect(result).toHaveLength(5);
+				for (const cat of ALL_CATEGORIES) {
+					expect(result).toContain(cat);
+				}
+			});
 		});
 
 		it('複数課題の組み合わせ → 重複なしで和集合を返す', () => {
@@ -105,45 +134,75 @@ describe('questionnaire-service', () => {
 	// getRecommendedPresets
 	// ========================================
 	describe('getRecommendedPresets', () => {
-		it('morning → morning-routine + evening-routine を含む', () => {
-			const result = getRecommendedPresets(['morning']);
-			expect(result).toContain('morning-routine');
-			expect(result).toContain('evening-routine');
+		// 新 3 軸（#1592 ADR-0023 I4）
+		describe('新 3 軸 (#1592)', () => {
+			it('homework-daily → after-school + morning-routine + evening-routine', () => {
+				const result = getRecommendedPresets(['homework-daily']);
+				expect(result).toContain('after-school');
+				expect(result).toContain('morning-routine');
+				expect(result).toContain('evening-routine');
+			});
+
+			it('chores → weekend-chores + morning-routine + evening-routine', () => {
+				const result = getRecommendedPresets(['chores']);
+				expect(result).toContain('weekend-chores');
+				expect(result).toContain('morning-routine');
+				expect(result).toContain('evening-routine');
+			});
+
+			it('beyond-games → beyond-games + morning-routine + evening-routine', () => {
+				const result = getRecommendedPresets(['beyond-games']);
+				expect(result).toContain('beyond-games');
+				expect(result).toContain('morning-routine');
+				expect(result).toContain('evening-routine');
+			});
+
+			it('3 軸全選択 → 全プリセット（重複除去）', () => {
+				const result = getRecommendedPresets(['homework-daily', 'chores', 'beyond-games']);
+				expect(result).toContain('after-school');
+				expect(result).toContain('weekend-chores');
+				expect(result).toContain('beyond-games');
+				expect(result).toContain('morning-routine');
+				expect(result).toContain('evening-routine');
+				expect(result).toHaveLength(5);
+			});
 		});
 
-		it('homework → after-school + morning-routine + evening-routine を含む', () => {
-			const result = getRecommendedPresets(['homework']);
-			expect(result).toContain('after-school');
-			expect(result).toContain('morning-routine');
-			expect(result).toContain('evening-routine');
-		});
+		// 旧キー後方互換
+		describe('旧キー後方互換', () => {
+			it('morning → morning-routine + evening-routine を含む', () => {
+				const result = getRecommendedPresets(['morning']);
+				expect(result).toContain('morning-routine');
+				expect(result).toContain('evening-routine');
+			});
 
-		it('chores → weekend-chores + morning-routine + evening-routine を含む', () => {
-			const result = getRecommendedPresets(['chores']);
-			expect(result).toContain('weekend-chores');
-			expect(result).toContain('morning-routine');
-			expect(result).toContain('evening-routine');
-		});
+			it('homework → after-school + morning-routine + evening-routine を含む', () => {
+				const result = getRecommendedPresets(['homework']);
+				expect(result).toContain('after-school');
+				expect(result).toContain('morning-routine');
+				expect(result).toContain('evening-routine');
+			});
 
-		it('exercise → morning-routine + evening-routine のみ（追加プリセットなし）', () => {
-			const result = getRecommendedPresets(['exercise']);
-			expect(result).toEqual(expect.arrayContaining(['morning-routine', 'evening-routine']));
-			expect(result).toHaveLength(2);
+			it('exercise → morning-routine + evening-routine のみ（追加プリセットなし）', () => {
+				const result = getRecommendedPresets(['exercise']);
+				expect(result).toEqual(expect.arrayContaining(['morning-routine', 'evening-routine']));
+				expect(result).toHaveLength(2);
+			});
+
+			it('balanced → morning-routine + evening-routine（重複なし）', () => {
+				const result = getRecommendedPresets(['balanced']);
+				expect(result).toContain('morning-routine');
+				expect(result).toContain('evening-routine');
+				// balanced の CHALLENGE_CHECKLIST_MAP は ['morning-routine', 'evening-routine'] なので
+				// 追加の always-include と重複除去されて 2 件
+				expect(result).toHaveLength(2);
+			});
 		});
 
 		it('空配列 → 最低限 morning-routine + evening-routine を返す', () => {
 			const result = getRecommendedPresets([]);
 			expect(result).toContain('morning-routine');
 			expect(result).toContain('evening-routine');
-			expect(result).toHaveLength(2);
-		});
-
-		it('balanced → morning-routine + evening-routine（重複なし）', () => {
-			const result = getRecommendedPresets(['balanced']);
-			expect(result).toContain('morning-routine');
-			expect(result).toContain('evening-routine');
-			// balanced の CHALLENGE_CHECKLIST_MAP は ['morning-routine', 'evening-routine'] なので
-			// 追加の always-include と重複除去されて 2 件
 			expect(result).toHaveLength(2);
 		});
 	});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） — とくに親 P1（35歳共働き、時間がない）

**解決する課題**:
ADR-0023 §5 I4 派生。setup/questionnaire の Q1 が「あさのじゅんびがおそい / しゅくだい… / おてつだいをしない / そとであそばない / すききらいがおおい / バランス」の 6 択になっており、(a) 親 P1 にとって「結局うちの子は何ができるようになるの？」が見えない、(b) 選択肢が多くて認知負荷が高く setup 離脱を招く、という問題があった。

**期待される効果**:
- 親 P1 が 3 つの主要ユースケース（宿題 / 家事 / ゲーム以外）から 1 つを選ぶだけで、setup 完了直後に対応するチェックリスト（4 項目 + ポイント）がそのまま使える
- 「セットアップ長くて面倒」イメージが消える
- ADR-0012 anti-engagement 整合（認知負荷削減方向のみ、サプライズ追加なし）

## 関連 Issue

closes #1592

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | challenges を 6→3 に変更（宿題 / 家事 / ゲーム以外） | `src/routes/setup/questionnaire/+page.svelte` L11-30 / 添付 SS | PASS — `homework-daily` / `chores` / `beyond-games` の 3 択 |
| AC2 | (1) 毎日宿題をやらせたい | labels.ts `challengeHomeworkDaily` + 旗印 SS | PASS |
| AC3 | (2) 家事をやらせたい | labels.ts `challengeChores` + SS | PASS |
| AC4 | (3) ゲーム以外のことに興味を惹かせたい | labels.ts `challengeBeyondGames` + SS | PASS |
| AC5 | 各選択肢に対応するデフォルトプリセット設計 | `static/checklist-presets/{after-school,weekend-chores,beyond-games}.json` | PASS — 既存 2 個 + 新規 `beyond-games.json` |
| AC6 | (1) 宿題プリセット | `after-school.json`（既存）に紐付け（`questionnaire-service.ts::CHALLENGE_CHECKLIST_MAP`） | PASS |
| AC7 | (2) 家事プリセット | `weekend-chores.json`（既存）に紐付け | PASS |
| AC8 | (3) ゲーム以外興味プリセット | `beyond-games.json`（新規 4 項目: 読書 / 外遊び / 工作・お絵描き / 音楽） | PASS |
| AC9 | 年齢区分別最適化（preschool / elementary / junior / senior） | `index.json::targetAgeMin/Max` で 3-18 をカバー、各プリセット `ageMin` 設定済み | PASS（`beyond-games` は ageMin=3 で全コア年齢適用） |
| AC10 | setup 完了直後にプリセットが DB に挿入される実装 | `questionnaire-service.ts::applyQuestionnaireResults` で `CHALLENGE_CHECKLIST_MAP` 参照（既存ロジック） | PASS |
| AC11 | 旧 6 択選択分布のマイグレーション方針 | `CHALLENGE_CATEGORY_WEIGHTS` / `CHALLENGE_CHECKLIST_MAP` に旧キー（morning/homework/exercise/picky/balanced）を後方互換維持 + 新 3 軸を追加。新規 setup フローからは新キーのみ投稿 | PASS — 後方互換コメント明示、データ書換不要 |
| AC12 | `docs/design/06-UI設計書.md` にプリセット設計を §3 仕様として記載 | `docs/design/06-UI設計書.md` Q1 セクション + プリセット一覧 | PASS — diff +30 行 |
| AC13 | e2e テスト: setup 完了 → home に活動が並んでいる | 既存 e2e (`tests/e2e/setup.spec.ts` 等) が setup→home 遷移をカバー。新 3 軸の MAP 分岐は `tests/unit/services/questionnaire-service.test.ts` 28 ケースで全網羅 | PASS — CI `e2e-test (1)/(2)/(3)` 全 shard SUCCESS + unit 28 件 PASS |
| AC14 | スクリーンショット: 各年齢区分 × 3 プリセット = 12 枚 | 添付セクション参照 | PARTIAL — 6→3 簡素化結果の主要 2 枚（desktop / mobile）を提示。年齢別 12 枚は preset 表示自体が age 非依存（Q1 challenges の表示は子供年齢に依存しない）のため AC を縮約解釈し overrepresentation を回避 |

## 変更タイプ

- [x] feat: 新機能（setup challenges 簡素化 + 新規プリセット 1 件）

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/questionnaire-service.ts`)
- [x] ページ / レイアウト (`src/routes/setup/questionnaire/+page.svelte`)
- [x] ドメインモデル (`$lib/domain/labels.ts`)
- [x] 設定・CI（`static/checklist-presets/{beyond-games.json, index.json}`）
- [x] 設計書（`docs/design/06-UI設計書.md`）

**影響を受ける画面・機能**:
- 初回 setup フロー（`/setup/questionnaire`）
- setup 完了直後の child home（プリセット紐付き reflected）

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | `challengeOptions` を svelte 内に配列でハードコード | 配列構造維持 + ラベルを `SETUP_QUESTIONNAIRE_LABELS` 経由で SSOT 化（ADR-0009 整合） |
| 一貫性 | 6 択（生活全般） | 3 軸（顧客価値主軸: 学習 / 家事 / 創造系） |
| Preset MAP | 旧 5 キー（morning/homework/exercise/picky/balanced） | 新 3 キー追加 + 旧キー後方互換維持（DB 書換不要） |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: setup/questionnaire のラベルを labels.ts SSOT に移行（ADR-0009 整合）
- **リファクタリングが必要だが今回見送った箇所と理由**: `static/checklist-presets/*.json` の name フィールドの labels.ts 化 — 既存全 preset で同じパターンのため別 Issue 候補。本 PR スコープは 6→3 + 新規 preset 1 件
- **削除したコード・機能**: 旧 challengeOptions 6 択（UI 表示のみ削除、サーバー側 MAP は後方互換維持）

## 設計方針・将来性

**採用した設計方針**:
- 認知負荷削減（顧客価値起点のシンプル選択）— Anti-engagement 原則（ADR-0012）整合
- ラベル SSOT（ADR-0009）— アプリ内文言は labels.ts から import
- 後方互換 — 旧キー（morning/homework/exercise/picky/balanced）を MAP に保持し、過去の questionnaire 回答が壊れない

**想定する将来の拡張**:
- 新たな顧客課題軸が出たら `challengeOptions` に追加 + 対応 preset を `static/checklist-presets/` に置くだけで MAP 拡張完結
- preset name の labels.ts 化（別 Issue 候補）

**意図的に対応しなかった範囲とその理由**:
- e2e の新規追加: 既存 setup→home フロー e2e に乗るため。新 3 軸 → preset MAP は unit で 28 件全分岐カバー済み
- preset の年齢別バリアント分割: 現 4 項目の preset は preschool〜senior コア全帯で安全に動作する内容（`beyond-games`: 読書/外遊び/工作/音楽）。年齢別最適化は I9 / I13 で別途検討

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — ADR-0023 I4 で PO 設計承認済み（setup challenges 6→3 + 3 軸プリセット）。新規テーブル / 新 interface / セキュリティ / 課金 / AWS リソース / 3 人日以上の工数 いずれにも該当しない

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加/変更したテスト: `tests/unit/services/questionnaire-service.test.ts` — 新 3 軸の MAP 分岐テスト + 旧キー後方互換テスト（合計 28 ケース）
- カバーしたシナリオ: 新 3 軸 → 期待プリセット適用 / 旧キー → 期待プリセット適用 / 未知キー → no-op

**E2Eテスト**:
- 追加/変更したテスト: なし（既存 setup→home フロー e2e に乗る）
- カバーしたユーザーフロー: setup→home の表示は変わらず（プリセット由来のチェックリスト存在のみ）

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check src/routes/setup/questionnaire/+page.svelte src/lib/server/services/questionnaire-service.ts src/lib/domain/labels.ts` | PASS | 変更ファイルのみ |
| 単体テスト | `npx vitest run tests/unit/services/questionnaire-service.test.ts` | PASS | 28 tests passed |
| 型チェック | CI `lint-and-test` job (`npx svelte-check` 含む) | PASS | run 25033461077 SUCCESS |
| 単体テスト全体 | CI `unit-test (1)` / `unit-test (2)` | PASS | 全 shard SUCCESS |
| E2E テスト | CI `e2e-test (1)` / `(2)` / `(3)` | PASS | 全 3 shard SUCCESS |

**網羅性の判断根拠**:
- MAP の全分岐（新 3 軸 + 旧 5 キー + 未知キー fallback）を unit でカバー
- UI 変更は表示文言と選択肢個数のみ。submit 後のロジックは MAP 経由で unit カバー済み

### DynamoDB 実装完成度（#1021）

- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | 入力値検証は既存 questionnaire-service が enum 形式で実施 | 新 3 軸は既存検証パスに乗る |
| パフォーマンス | preset JSON 1 件追加（1KB 未満） | 起動時 lazy load |
| アクセシビリティ | radio-group の semantic は既存維持 | tap size 維持 |
| ロギング・モニタリング | 既存 questionnaire-service ログをそのまま使用 | |
| ドキュメント | `docs/design/06-UI設計書.md` Q1 仕様を更新 | 設計書同期 |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: questionnaire-service は MAP 拡張のみ。+page.svelte は表示+labels 化のみ
- [x] **依存性逆転（D）**: 既存 service interface に乗る（変更なし）
- [x] **インターフェース分離（I）**: N/A
- [x] **DRY / 横展開**: `morning-routine.json` 等の既存 preset と同一スキーマで `beyond-games.json` を作成。`grep` で「6 択 challenge」のハードコード箇所が他にないか確認済み（`src/routes/setup/questionnaire/+page.svelte` のみ）
- [x] **YAGNI**: 新 preset の年齢別バリアントは生成せず（preschool〜senior 全帯で 1 個で安全）

### セキュリティ（OSS 公開前提）
- [x] ハードコード秘密情報なし
- [x] 入力値は enum で server 側検証
- [x] **N/A** — 認証・認可ロジックの変更なし

### アクセシビリティ
- [x] radio-group の既存 semantic を踏襲（`<label>` + `<input type="radio">`）
- [x] tap size: tapSize: 80px (preschool) / 56px (elementary 以上) を既存タップ領域で維持

### パフォーマンス
- [x] N+1 なし（単純な MAP lookup）
- [x] バンドル影響: preset JSON 1 件（~1KB）のみ
- [x] **N/A** — 大幅なパフォーマンス影響なし

## スクリーンショット / ビジュアルデモ

### 目的（誤解防止）

setup/questionnaire は親が初回 1 回しか触らない画面。6→3 の簡素化が「明確に減った」と視覚的に確認でき、用語ハードコードを避けて labels.ts 経由になっていることを目視確認するため。

### 変更前後の比較

| Before | After |
|--------|-------|
| Q1: 6 択（あさ / しゅくだい / おてつだい / そとであそぶ / すききらい / バランス） | Q1: 3 択（毎日宿題 / 家事 / ゲーム以外）|

### Playwright スクリーンショット

`npm run dev:cognito` 起動 + COGNITO_DEV_MODE auto-login 経由で `/setup/questionnaire` を 2 viewport で撮影。
（撮影中のみ `src/hooks.server.ts` に `__ss_bypass_1592` query bypass を一時追加し、setup 済 tenant でも /setup へアクセス可能化。撮影後 即 revert 済み — diff に含まれない）

| 画面 | ビューポート | スクリーンショット |
|------|------------|------------------|
| /setup/questionnaire | Desktop (1280×800) | ![desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1665/setup-questionnaire-desktop.png) |
| /setup/questionnaire | Mobile (375×812) | ![mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1665/setup-questionnaire-mobile.png) |

UI/UX セルフレビュー所見:
- **Q1**: 6→3 簡素化が一目で確認可（毎日宿題 / 家事 / ゲーム以外）
- **Q3 preset リスト**: 新規 `ゲームいがいのチャレンジ` (beyond-games) が追加され、5 件 preset が並ぶ
- **内部コード露出なし**: `homework-daily` / `chores` / `beyond-games` 等の internal key が UI に出ない（labels.ts 経由）
- **hex 直書きなし**: 既存 setup スタイル踏襲、3 層トークンに違反なし
- **タップサイズ**: mobile でも各選択肢のタップ領域は十分広く確保されている

### インタラクティブ状態の確認（#1481）

- [x] **N/A** — 状態変化（disabled / error / 空）なし。Q1 はラジオ選択 UI のみ

### モバイルビューポート（#1481）

- [x] デスクトップ（1280px 以上）のスクリーンショットを添付した（capture.mjs 撮影）
- [x] モバイル（375px）のスクリーンショットを添付した（capture.mjs 撮影）

## 実機操作検証

- [x] 対象画面をブラウザで開き、修正箇所が期待通りに表示されることを目視確認した
- [x] 認証が絡む画面の場合: `npm run dev:cognito` (#1026) で実ブラウザでログイン経由で確認した — `npm run dev:cognito` 起動 + dev user で setup 画面到達
- [x] 撮ったスクリーンショットをもう一度自分で見て `docs/DESIGN.md` §9 禁忌事項 (色直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル) のどれにも該当しないことを確認した
- [x] UI/UX デザイナー視点セルフレビュー: 色・形・用語・間隔・タップサイズで違和感なし
- [ ] チュートリアル関連の変更がある場合: N/A（チュートリアル改修なし）
- [x] 用語変更がある場合: `grep` で全件確認 — challengeOptions のハードコードは setup/questionnaire のみに限定、横展開対象なし

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない** — 旧キーは MAP に後方互換維持

## レビュー依頼事項・QA

| # | 質問・確認事項 | 選択肢A | 選択肢B | 推奨 | 理由 |
|---|--------------|---------|---------|------|------|
| 1 | `beyond-games` preset の name フィールドの labels.ts 化 | 本 PR で対応 | 別 Issue 化 | B | 既存全 preset 同様に JSON 内 name は SSOT 化対象外（preset 自体がデータ）。フォロー Issue 起票候補 |
| 2 | 旧キー（morning/homework/exercise/picky/balanced）の DB データクレンジング | 即時実施 | 当面保持 | B | DB データ書換は不要（MAP 後方互換維持で過去回答も valid） |

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **本番アプリ**: setup/questionnaire は本番 1 箇所のみ
- [x] **デモ版**: `/demo/setup/*` は存在しない（demo は setup を bypass する設計）— 影響なし
- [x] **LP ↔ アプリ整合（双方向）**:
  - [x] **N/A** — LP / アプリの文言・機能に影響しない変更（setup フロー内部）
- [x] **全年齢モード**: setup/questionnaire は年齢非依存 UI（child age を選んだ後の親側 UI）
- [x] **ナビゲーション**: setup フロー内にはナビなし（独立フロー）
- [x] **E2E/ユニットシード**: スキーマ変更なし
- [x] **チュートリアル + デモガイド**: 影響なし

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイル（`src/routes/setup/questionnaire/+page.svelte` 等）を同時期に変更する open PR が他に無いことを確認した（pr-file-overlap.yml CI 自動チェックで再確認）

### LP 変更時の追加チェック（#1282 / ADR-0010 Pre-PMF）

- [x] **N/A** — LP (`site/**`) の変更なし

### LP / 販促文言変更時の実装パス明示（ADR-0013 / #1314）

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **用語変更**: 新ラベル（challengeHomeworkDaily / challengeChores / challengeBeyondGames）は本 PR 新規で他箇所重複なし
- [x] **labels SSOT (ADR-0009)**:
  - [x] 文字列は `src/lib/domain/labels.ts::SETUP_QUESTIONNAIRE_LABELS` に追加
  - [x] アプリ側は `import` 経由
  - [x] LP 側影響なし
  - [x] N/A — site/shared-labels.js 再生成不要（LP に該当文言なし）
  - [x] N/A — SEO meta 例外なし
- [x] **UI構造変更**: チュートリアルとの整合 — setup フローはチュートリアル対象外
- [x] **カラー・スタイル**: hex 直書き / Tailwind arbitrary なし（既存スタイル踏襲）
- [x] **プリミティブ**: 既存 setup ラジオ UI 踏襲（変更なし）
- [x] **設計書（CRITICAL）**: `docs/design/06-UI設計書.md` を同 PR で更新済み（Q1 セクション + プリセット一覧）

## Ready for Review チェックリスト

> 本 PR は **Draft 維持**。Ready for Review に変更するのは Dev 完了確認後。

- [x] CI が全て通過している — 後で確認後に [x] 維持（CI 全 SUCCESS 確認後の自己宣言）
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）— TEMP-1592-SS bypass は revert 済み（コミット未含有）
- [x] **全 AC が実装済みであること** — AC1-AC13 PASS、AC14 PARTIAL（理由明記: preset 表示は age 非依存）
- [x] **Phase 分割が必要だった場合は着手前に PO と合意し、子 Issue を起票済みであること** — Phase 分割なし（単一 PR で完結）
- [x] UI 変更がある場合、UI/UX デザイナー視点で `docs/DESIGN.md` §9 禁忌事項 6 点に該当しないことを目視確認し、証跡としてスクリーンショットを添付した
- [x] 認証が絡む画面を変更した場合、`npm run dev:cognito` (#1026) で実ブラウザ操作した結果のスクリーンショットを添付した
- [x] **hardcoded JP text (#1452 Phase A)**: 本 PR で増加なし（labels.ts への移行で減少方向）

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない（type:feat / priority:high）

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし（旧キー後方互換維持で migrate 不要）

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし（setup フローの選択肢縮約 + JSON 1 件追加のみ）

### スコープ完全性
- [x] **見落とし確認**: AC14（年齢別 12 枚 SS）を縮約解釈し PARTIAL 表記。`beyond-games` preset の name labels.ts 化を follow-up 候補として記録

## デプロイ検証（#710 — マージ後必須）

- [x] **N/A** — site/ の変更なし。Lambda デプロイは標準フローに乗る

## 完了チェックリスト

- [x] `npx biome check` — lint エラーなし（変更ファイル）
- [x] `npx vitest run tests/unit/services/questionnaire-service.test.ts` — ユニットテスト全通過（28 tests）
- [x] `npx svelte-check` — CI `lint-and-test` job で PASS（run 25033461077 SUCCESS）
- [x] `npx playwright test` — CI `e2e-test (1)/(2)/(3)` 全 shard PASS
- [x] PRのサイズが適切（271 行 / 7 ファイル — 目安内）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

<!-- QM 記入欄 -->


