### PR TITLE
chore(auth): add dev:cognito-signup script and document its usage (#1662)

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -165,6 +165,9 @@ npm run dev:cognito
 # → AUTH_MODE=cognito COGNITO_DEV_MODE=true vite dev --port 5174 --strictPort
 # → http://localhost:5174 で Cognito モック認証が有効
 # → 既に 5174 が使用中だと即 fail する（--strictPort: #1168 で 5175 fallback の 500 回避）
+
+# signup ページは AUTH_MODE=cognito 単独起動が必要（COGNITO_DEV_MODE=true だと /auth/login にリダイレクトされるため）
+npm run dev:cognito-signup
 ```
 
 ### DEV_USERS 一覧

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"dev:cognito": "cross-env AUTH_MODE=cognito COGNITO_DEV_MODE=true vite dev --port 5174 --strictPort",
+		"dev:cognito-signup": "cross-env AUTH_MODE=cognito vite dev --port 5174 --strictPort",
 		"version:generate": "tsx scripts/generate-version.ts",
 		"build": "vite build",
 		"preview": "vite preview",


### PR DESCRIPTION
## 顧客価値・目的
**対象ユーザー**: 開発者 / QA
**解決する課題**: `npm run dev:cognito` で `COGNITO_DEV_MODE=true` になるため、`/auth/signup` がログイン画面にリダイレクトされて目視確認ができない問題。
**期待される効果**: `npm run dev:cognito-signup` を使用することで、安全に signup ページの実アプリ UI が確認・スクリーンショット撮影可能になる。

## 関連 Issue
closes #1662

## AC 検証マップ (ADR-0004)
| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | dev:cognito-signup 専用 script を package.json に新設（COGNITO_DEV_MODE 抜き起動） | `grep dev:cognito-signup package.json` | `package.json` L15 に `"dev:cognito-signup": "cross-env AUTH_MODE=cognito vite dev --port 5174 --strictPort"` を追加 |
| AC2 | docs/CLAUDE.md のローカル Cognito 認証検証環境セクションに「signup ページは AUTH_MODE=cognito 単独起動が必要」と明記 | `grep -A1 'dev:cognito-signup' docs/CLAUDE.md` | `docs/CLAUDE.md` L168-170 に signup ページの例外と新 script 用法を追記 |
| AC3 | PR #1661 のスクリーンショット撮影手順がフォローアップ Issue で再発防止できる状態 | docs/CLAUDE.md の追記内容を確認 | 認証画面検証時に signup は `npm run dev:cognito-signup` を使うことが明記され再発防止可能 |

## 変更タイプ
- [x] infra: インフラ・CI/CD
- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント
**変更レイヤー**:
- [x] 設定・CI (`package.json`)

**影響を受ける画面・機能**:
開発環境の signup 画面の目視確認手段（ローカル開発手順のみ）。本番ランタイムには影響なし。

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | `dev:cognito` (`AUTH_MODE=cognito COGNITO_DEV_MODE=true`) | 同一の vite dev script を `COGNITO_DEV_MODE` 抜きで再公開した派生 script |
| 一貫性 | port 5174 / strictPort / cross-env を踏襲 | 同 port / 同フラグセットを踏襲し設定差は `COGNITO_DEV_MODE` のみ |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: なし
- **リファクタリングが必要だが今回見送った箇所と理由**: なし（Issue #1662 では選択肢 A: signup redirect ロジック書き換えは過剰判定で B+C を採用）
- **削除したコード・機能**: なし

## 設計方針・将来性

**採用した設計方針**: ローカル開発手順の差分を 1 行の npm script として表面化し、docs/CLAUDE.md と物理的に同じ場所で説明することで再発防止。

**想定する将来の拡張**: 他の認証フロー（password reset, MFA enroll 等）でも同様の COGNITO_DEV_MODE 副作用が出た場合、同じパターンで `dev:cognito-<flow>` を追加可能。

**意図的に対応しなかった範囲とその理由**: signup ページの redirect ロジック書き換え（Issue #1662 選択肢 A）は signup 認証フロー全体に影響するため Pre-PMF では過剰と判断（ADR-0010）。

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）
- [x] **該当なし** — npm script 追加 + docs 追記のため設計ポリシー確認不要

## テスト戦略

### 追加・変更したテスト
**単体テスト**: なし（npm script 追加 + docs のみ）
**E2Eテスト**: なし（npm script 追加 + docs のみ）

### テスト実行結果
| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check package.json` | PASS | exit 0 |

**追加した E2E テストの詳細**: なし

**網羅性の判断根拠**: 変更は `package.json` の scripts に 1 行追加と `docs/CLAUDE.md` への 3 行追記のみ。ランタイムコードは未変更のため自動テスト追加は不要。

### DynamoDB 実装完成度（#1021 — 段階的対応禁止 / ADR-0010）
- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | 対象外 | local dev script 追加。本番ランタイムに影響なし |
| パフォーマンス | 対象外 | バンドル変更なし |
| アクセシビリティ | 対象外 | UI 変更なし |
| ロギング・モニタリング | 対象外 | ログ変更なし |
| ドキュメント | docs/CLAUDE.md 更新済み | signup ページ例外と新 script 用法を明記 |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **DRY / 横展開**: `dev:cognito` script の置き場所と隣接して追加。同種の派生 script 横展開はなし
- [x] **YAGNI**: 必要最小限の派生 script のみ追加

### セキュリティ（OSS 公開前提）
- [x] **N/A** — セキュリティ関連の変更なし（local dev only な npm script）

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] **N/A** — パフォーマンスへの影響なし

## スクリーンショット / ビジュアルデモ

### 目的（誤解防止）
N/A — UI 変更なし。本 PR は `npm run dev:cognito-signup` script の追加と docs 追記のみ。

### 変更前後の比較
| Before | After |
|--------|-------|
| `npm run dev:cognito` だと signup フォームが /auth/login に redirect され目視不可 | `npm run dev:cognito-signup` で COGNITO_DEV_MODE 抜き起動が可能 |

### Playwright スクリーンショット
N/A — UI 変更なし

### インタラクティブ状態の確認（#1481）
- [x] **N/A** — インタラクティブ状態変化なし

### モバイルビューポート（#1481）
- [x] **N/A** — LP / infra / 設定ファイルのみの変更

## 実機操作検証
- [x] 対象 npm script (`npm run dev:cognito-signup`) を起動し、`/auth/signup` のフォームが redirect されず描画されることを目視確認した

## ダイアログ・オーバーレイ検証
- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更
- [x] このPRに破壊的変更は**含まれない**

## レビュー依頼事項・QA
特になし（npm script 1 行 + docs 3 行のみ）

## 横展開・影響波及チェック

### 並行実装影響確認（必須）
- [x] **該当なし** — local dev 用 npm script のため並行実装の影響範囲外

### 並行 PR 影響確認 (#1200)
- [x] 本 PR が変更する `package.json` / `docs/CLAUDE.md` を同時期に変更する open PR は確認済み

### LP 変更時の追加チェック（#1282 / ADR-0010 Pre-PMF）
- [x] **N/A** — LP (`site/**`) の変更なし

### LP / 販促文言変更時の実装パス明示（ADR-0013 / #1314）
- [x] **N/A** — LP / 販促文言を変更していない

### その他
- [x] **labels SSOT (ADR-0009)**: N/A — ユーザー向け文言の追加/変更なし
- [x] **設計書（CRITICAL）**: docs/CLAUDE.md を同 PR で更新済み（`infra/CLAUDE.md` の必須 env チェックには該当しない）

## Ready for Review チェックリスト
- [x] CI が全て通過している（PR 本文整備で AC map / 必須セクション失敗を解消）
- [x] セルフレビュー済み
- [x] **全 AC が実装済みであること**

## Critical 修正の追加要件（#612）
- [x] **N/A** — Critical 修正ではない

## 新規 env / secret 追加チェック（ADR-0006 / #914）
- [x] **N/A** — 新規 env / secret の追加なし

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし（npm script は local dev only）

### スコープ完全性
- [x] **見落とし確認**: 当初コミットで textlint 系 devDependencies (Issue #1677 範囲) が混入していたが、スコープ縮小で除去済み。Issue #1677 は別 PR で対応する

## デプロイ検証（#710 — マージ後必須）
- [x] **N/A** — デプロイ検証不要（local dev script + docs のみの変更）

## 完了チェックリスト
- [x] `npx biome check package.json` — lint エラーなし
- [x] PRのサイズが適切（2 files / +4 行）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）
（QM 記入欄）
