### PR TITLE
refactor: Phase 5 P2 LP仕上げ R13-R15 (priority:high PC 横長レイアウト 3 Issue 統合)

### DIFF
--- a/docs/design/lp-content-map.md
+++ b/docs/design/lp-content-map.md
@@ -137,7 +137,7 @@ baby/preschool では 404、elementary+ で通常動作。詳細は #1323 (B4+5-
 | 08 | FAQ | Top 3 のみ (残りは /faq) | 1200 | 700 |
 | 08b | founder 直接相談 (#1594) | Pre-PMF 期 founder と直接対話する入口 | 600 | 400 |
 | 09 | 最終 CTA | 「7 日間、家族で試す」 | 700 | 500 |
-| | **合計（実測 2026-04-28）** | | **~13443** | **~7327** |
+| | **合計（実測 2026-04-29）** | | **~13662** | **~7458** |
 
 > #1621 R17 で [06b] retention セクションを削除し、コア訴求（変動比率/射幸心 → 1 日 1 回まで・煽らない設計）を [03] コアループ L2 (習慣カード) へ統合した。
 > #1622 R18 で [04] 機構ツアーを 5 → 4 カードに圧縮（[03] と重複する①おみくじを削除し、③コンボ系を「ルーティンチェックリスト」に再定義、用語を ADR-0012 整合へ刷新）。
@@ -157,6 +157,10 @@ baby/preschool では 404、elementary+ で通常動作。詳細は #1323 (B4+5-
 - **CTA 2 つ**: `無料で始める`（プライマリ）/ `デモを見る`（セカンダリ）
 - **補足テキスト**: 「家族何人でも無料ではじめられます / クレジットカード登録不要」
 - **ビジュアル**: ヒーローイラスト + アプリスクショ（モバイル/デスクトップで切替）
+- **PC 横長レイアウト** (#1617 R13 / Phase 5 P2):
+  - `<br>` 強制改行は使わず `text-wrap: balance; word-break: auto-phrase;` (ADR-0016) で自然折り返し
+  - `h1` の `max-width` は 1200px、PC (≥1024px) では `font-size: 2.9rem` / `padding: 80px 24px 64px` に拡大
+  - `hero-sub` は `max-width: 780px` / `font-size: 1.12rem` (PC のみ)
 
 #### [02] 年齢スイッチャー (改訂後: 2 パネル構成 #1320)
 
@@ -182,6 +186,11 @@ baby/preschool では 404、elementary+ で通常動作。詳細は #1323 (B4+5-
 - **訴求**: 親視点（プリセット設定 2 分・定量把握）と子供視点（活動→ポイント→ショップ交換）を同一セクション内で両面訴求
 - **ごほうびショップ唯一の出口**: ポイントは「欲しいものと交換できる経済通貨」として機能し、子供の自律的目標設定を促す
 - **禁句**: 「シールガチャ」(#1311 で撤回)、「UR を引く」等の射幸心文言 (ADR-0012 / ADR-0013)
+- **PC 横長 2 カラムレイアウト** (#1619 R15 / Phase 5 P2):
+  - `core-loop-2col` を 1024px+ で `grid-template-columns: minmax(0,1fr) 280px` に展開（左 text 8 / 右 aside 4）
+  - 右側 `core-loop-aside` に screenshot を `position: sticky; top: 24px` で配置（スクロール中も見え続ける）
+  - 1440px+ では aside 幅を 320px、`core-loop-section-inner` を 1360px max-width に拡張し screenshot を大きく訴求
+  - mobile (<1024px) では従来通り 1 カラム縦積み（aside は `display: none`）
 
 #### [04] 機構ツアー — 補足機構 4 つ（#1622 R18 で再定義）
 
@@ -196,6 +205,13 @@ baby/preschool では 404、elementary+ で通常動作。詳細は #1323 (B4+5-
 
 > 用語は `CHECKLIST_KIND_LABELS` (#1168) に同期し、**同じ段落内で「持ち物チェックリスト」「ルーティンチェックリスト」「やることリスト」を混在させない** こと。
 > #1629 R25 で「コンボ」「ゲーミフィケーション全開」「変動比率」「射幸」「メタ層」「シールくじ」は禁止語彙とし `scripts/measure-lp-dimensions.mjs` の FORBIDDEN_TERMS で CI 検出（#1637 R34 で TARGET_HTML 配列化）。
+
+**PC 横長レイアウト** (#1618 R14 / Phase 5 P2):
+
+- 1024px+ で `grid-template-columns: repeat(4, 1fr)` の 4 列固定 + `grid-auto-rows: 1fr` で行高を揃える（4+1 半端配置を排除）
+- 画像有無で高さがバラつかないよう `tour-shot` / `tour-shot-placeholder` ともに `min-height: 200px`、`tour-card` は `min-height: 480px`
+- 1440px+ では `max-width: 1320px` / `gap: 24px` に拡張しゆとりを確保
+- mobile (<1024px) は `grid-template-columns: repeat(auto-fit, minmax(240px, 1fr))` で 1〜2 列フルード
 
 #### [05] ソフト機能（親の安心）— 4 カード構成（#1287 で 3→4 カードに拡張）
 

--- a/site/index.html
+++ b/site/index.html
@@ -81,11 +81,16 @@
 }
 </script>
 <style>
-/* Hero (#1617 R13: max-width 拡張 + text-wrap balance + auto-phrase) */
+/* Hero (#1617 R13: max-width 拡張 + text-wrap balance + auto-phrase / Phase 5 P2: PC 横長で h1 を拡大しゆとり padding) */
 .hero{background:linear-gradient(135deg,var(--brand-100) 0%,#f0f7ff 50%,#fef9e7 100%);padding:64px 16px 48px;text-align:center}
 .hero h1{font-size:2.4rem;font-weight:800;color:var(--gray-900);margin-bottom:16px;line-height:1.3;max-width:1200px;margin-left:auto;margin-right:auto;text-wrap:balance;word-break:auto-phrase}
 .hero h1 span{color:var(--brand-700)}
 .hero-sub{font-size:1.05rem;color:var(--gray-600);margin-bottom:28px;max-width:720px;margin-left:auto;margin-right:auto;line-height:1.7;text-wrap:balance;word-break:auto-phrase}
+@media(min-width:1024px){
+  .hero{padding:80px 24px 64px}
+  .hero h1{font-size:2.9rem;margin-bottom:20px}
+  .hero-sub{font-size:1.12rem;max-width:780px}
+}
 .hero-cta{display:flex;gap:16px;justify-content:center;flex-wrap:wrap;margin-bottom:14px}
 .hero-note{font-size:.85rem;color:var(--gray-500);margin-bottom:14px}
 /* #1625 R21: 価格 anchor 1 行バンド */
@@ -167,7 +172,8 @@
 }
 
 /* PC 2 カラムレイアウト (#1619 R15: text 8 / aside 4 で screenshot を sticky 配置)
-   仕組みグリッドは 3 カラム維持（縦積みすると高さが伸びすぎるため） */
+   仕組みグリッドは 3 カラム維持（縦積みすると高さが伸びすぎるため）
+   Phase 5 P2: 1440px+ で aside を 320px に拡張、screenshot をより視認しやすく */
 .core-loop-2col{display:block}
 .core-loop-aside{display:none}
 @media(min-width:1024px){
@@ -178,6 +184,12 @@
   .core-loop-aside .core-loop-note{margin:10px 0 0;text-align:left;font-size:.78rem;line-height:1.5}
   /* 2 カラム時の screenshot は縦長に戻す（モバイル UI を訴求するため） */
   .core-loop-2col .core-loop-aside .core-loop-visual picture source[media*="1024"]{display:none}
+}
+@media(min-width:1440px){
+  .core-loop-section-inner{max-width:1360px}
+  .core-loop-2col{grid-template-columns:minmax(0,1fr) 320px;gap:32px}
+  .core-loop-aside .core-loop-visual{max-width:300px;max-height:480px}
+  .core-loop-aside .core-loop-note{font-size:.82rem}
 }
 /* #1284: aspect-ratio を維持しつつ画像全体を表示するため max-height 拡張 + object-fit:contain に変更 */
 .core-loop-visual{max-width:280px;margin:0 auto;border-radius:12px;overflow:hidden;border:1px solid var(--gray-200);aspect-ratio:390/844;max-height:380px;background:var(--gray-50)}
@@ -211,11 +223,16 @@
 /* 画像なし tour-card の plate (#1618 R14): 画像 tour-shot 同等の余白で高さを揃える */
 .tour-card .tour-shot-placeholder{margin-top:auto;min-height:160px;display:flex;align-items:center;justify-content:center;color:var(--gray-300);font-size:2.5rem;background:var(--gray-50);border-radius:8px;border:1px dashed var(--gray-200)}
 @media(min-width:1024px){
-  /* PC 整然配置: #1622 R18 で 5→4 カードに圧縮。4 列固定で半端なし */
-  .machine-tour{grid-template-columns:repeat(4,1fr);gap:18px}
-  .tour-card{min-height:460px}
-  .tour-card .tour-shot{max-height:200px}
-  .tour-card .tour-shot-placeholder{min-height:180px}
+  /* PC 整然配置 (#1618 R14 / Phase 5 P2): 4 列固定で半端なし、grid-auto-rows で行高を揃える */
+  .machine-tour{grid-template-columns:repeat(4,1fr);gap:20px;grid-auto-rows:1fr}
+  .tour-card{min-height:480px;padding:24px 22px}
+  /* 画像 / placeholder どちらでも同じ最終 panel サイズに揃える */
+  .tour-card .tour-shot{max-height:200px;min-height:200px}
+  .tour-card .tour-shot-placeholder{min-height:200px}
+}
+@media(min-width:1440px){
+  .machine-tour{max-width:1320px;gap:24px}
+  .tour-card{padding:28px 24px}
 }
 
 /* Soft features */


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: PC（1440 / 1920px）でアクセスする見込み顧客（親 P1 / P2）

**解決する課題**:
LP 仕上げレビュー (ADR-0023) Phase 5 P2 で残されている priority:high の **PC 横長レイアウト最適化** 3 Issue。Hero（#1617 R13）/ tour-card 4 件の高さ揃え（#1618 R14）/ core-loop-visual の 2 カラム化（#1619 R15）について、Phase 4 PR #1668 で投入したベース実装をさらに 1280px+ / 1440px+ ブレークポイントで仕上げる。

**期待される効果**:
- PC ビューポート（≥1024px）で Hero h1 が 2.4rem → 2.9rem に拡大され、ファーストビューで視認性が高まる
- machine-tour 4 カードが画像有無に関わらず同一行高に揃い「整然とした視覚的安定」を提供
- core-loop-visual の screenshot が PC 1440px+ で 320px 幅に拡張され、子供 UI のスクショが訴求素材として大きく見える

## 関連 Issue

closes #1617 / closes #1618 / closes #1619

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| #1617 AC1 | Hero `<br>` 強制改行を削除（PC・モバイル共通） | `grep -n "<br>" site/index.html` の Hero セクション内 | line 389-447 (Hero) 内に `<br>` 0 件。残存は line 868 (legal disclaimer) / 922 (footer) の Hero 外のみ |
| #1617 AC2 | Hero max-width 1080→1200px 拡張 | `grep "max-width:1200" site/index.html` | site/index.html L86 `.hero h1{max-width:1200px}` で適用済（PR #1668 で投入、本 PR で維持） |
| #1617 AC3 | text-wrap: balance + word-break: auto-phrase 適用 | `grep "text-wrap:balance" site/index.html` | L86 `.hero h1` / L88 `.hero-sub` 両方に適用済 (ADR-0016) |
| #1617 AC4 | BudouX フォールバック検討 | 設計書記載 | Pre-PMF 段階では CSS のみで十分と判断（site/ への 15KB バンドル増は見送り）。`docs/design/lp-content-map.md` [01] Hero に判断結果を記載 |
| #1617 AC5 | PC 1440px / 1920px のスクリーンショット添付（修正前後比較） | desktop preset 1280px キャプチャ + full-page | 後述 §スクリーンショット の Before/After 表参照 |
| #1617 AC6 | モバイル（375px）でも崩れていない | mobile preset (390x844) キャプチャ | `after-mobile-viewport.png` で Hero h1 が 1.85rem (line 365) で適切な改行 |
| #1617 AC7 | mobileHeight / desktopHeight 閾値遵守 | `node scripts/measure-lp-dimensions.mjs` | mobile=13662 (≤15200) / desktop=7458 (≤8000) ✓ |
| #1618 AC1 | machine-tour PC 整然配置 | `grep "repeat(4,1fr)" site/index.html` | L218 `.machine-tour{grid-template-columns:repeat(4,1fr); grid-auto-rows:1fr}` 4 列固定で半端なし |
| #1618 AC2 | 画像有無の高さ揃え | grep 結果 | L221 `.tour-card .tour-shot{min-height:200px}` / L222 `.tour-card .tour-shot-placeholder{min-height:200px}` で完全統一 + L219 `tour-card{min-height:480px}` で行高揃え |
| #1618 AC3 | PC 1440px / 1920px のスクショ | full-page desktop キャプチャ | `after-desktop-fullpage.png` で 4 カードが等高で整列確認 |
| #1618 AC4 | モバイル 375px / 414px で崩れない | mobile preset キャプチャ | `after-mobile-viewport.png` で `repeat(auto-fit, minmax(240px, 1fr))` (L201) により 1 列維持 |
| #1618 AC5 | mobileHeight / desktopHeight 閾値遵守 | 同上 | mobile=13662 / desktop=7458 ✓ |
| #1619 AC1 | core-loop-visual PC 2 カラム化 | `grep "core-loop-2col" site/index.html` | L171-188 で `display: block` (mobile default) → 1024px+ で `grid-template-columns: minmax(0,1fr) 280px` / 1440px+ で `1fr 320px` |
| #1619 AC2 | L1 / L2 / L3 とscreenshot の対応関係視覚化 | core-loop-2col + sticky aside | 左 text に L1/L2/L3 の 3 層、右 aside に point-level screenshot を sticky で配置 |
| #1619 AC3 | sticky 配置 | grep | L176 `.core-loop-aside{position:sticky;top:24px}` 適用済 |
| #1619 AC4 | モバイル 375px / 414px は従来の縦並び維持 | mobile preset | `core-loop-2col{display:block}` (L171) / `core-loop-aside{display:none}` (L172) でデフォルト = 縦積み |
| #1619 AC5 | PC 1440px / 1920px のスクショ | full-page | `after-desktop-fullpage.png` の core-loop セクションで 2 カラム配置を確認 |
| #1619 AC6 | mobileHeight / desktopHeight 閾値遵守 | 同上 | mobile=13662 / desktop=7458 ✓ |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [x] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [x] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [x] LP サイト (`site/`)
- [x] 設計書（`docs/design/lp-content-map.md`）

**影響を受ける画面・機能**:
- `site/index.html` [01] Hero — PC 横長 h1 拡大 / padding ゆとり化
- `site/index.html` [03] core-loop — PC 2 カラム aside 320px (1440px+)
- `site/index.html` [04] machine-tour — PC 4 列 grid-auto-rows:1fr で行高揃え

## 既存実装との比較

| 観点 | 既存実装 (#1668 Phase 4) | 今回の変更 (Phase 5 P2) |
|------|-------------------------|------------------------|
| Hero h1 PC | `font-size: 2.4rem` 固定 / max-width 1200px / balance | 1024px+ で **2.9rem** に拡大、padding 80px に拡張 |
| tour-card PC 行高 | `min-height: 460px` のみ | `grid-auto-rows: 1fr` 追加で**完全な行高揃え**、画像 / placeholder ともに `min-height: 200px` |
| core-loop aside | 固定 280px (1024px+) | 1440px+ で **320px** に拡張、screenshot max-width 300px |
| 1440px+ 専用ブレークポイント | なし | `@media(min-width:1440px)` 3 セクション全てに追加 |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: なし（Phase 4 PR #1668 で投入された CSS を踏襲、ブレークポイントを拡張）
- **リファクタリングが必要だが今回見送った箇所と理由**: なし
- **削除したコード・機能**: なし

## 設計方針・将来性

**採用した設計方針**:
- ブレークポイント階段（mobile <640px → tablet 640〜1023px → desktop 1024〜1439px → wide 1440px+）で段階的にゆとりを増やす
- `text-wrap: balance` + `word-break: auto-phrase` (ADR-0016) を信頼し `<br>` 強制改行を排除
- `grid-auto-rows: 1fr` で「カード行の最大高さに合わせて全カードが揃う」CSS Grid の native 機能で実現

**想定する将来の拡張**:
- 1920px や 4K 想定なら 1600px+ の追加ブレークポイントで max-width 1480px 等に拡張可能（現時点で 1280-1440px が PC 訴求の主層なため後回し）

**意図的に対応しなかった範囲とその理由**:
- BudouX フォールバック導入は見送り — Pre-PMF 段階では `text-wrap: balance` の CSS だけで十分。長文 LP 段落で破綻が観測されてから検討する

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — LP CSS のみの調整で interface / DB / 課金変更なし

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加/変更したテスト: なし（CSS のみの変更）
- カバーしたシナリオ: N/A

**E2Eテスト**:
- 追加/変更したテスト: なし（既存 LP セクション存在チェックは維持される）
- カバーしたユーザーフロー: N/A

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check site/` | PASS | exit=0 |
| LP メトリクス | `node scripts/measure-lp-dimensions.mjs` | PASS | mobile=13662 / desktop=7458 / forbiddenTerms=0 / ctaVariants=3 |
| 型チェック | `npx svelte-check` | N/A | site/ は静的 HTML のため型チェック対象外 |
| 単体テスト | `npx vitest run` | N/A | site/ のみ変更で TypeScript / Svelte に影響なし |
| E2E テスト | `npx playwright test` | CI で実行 | LP のレイアウト変更のみで semantic content 不変 |

**追加した E2E テストの詳細**: なし

**網羅性の判断根拠**:
LP の CSS-only 変更で、HTML 構造・テキスト・data-testid は不変。既存 E2E は LP セクション存在を確認するもので影響を受けない。レイアウト確認は LP メトリクススクリプト (`measure-lp-dimensions.mjs`) と目視スクリーンショットでカバー。

### DynamoDB 実装完成度（#1021）

- [x] **N/A** — DynamoDB 実装の変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | N/A | LP CSS のみ |
| パフォーマンス | CSS バンドルサイズ +約 200 byte | 1440px+ ブレークポイント 3 セクション分のみ |
| アクセシビリティ | フォントサイズ拡大により可読性向上 | h1 2.4 → 2.9rem は WCAG AA で問題なし（line-height: 1.3 維持） |
| ロギング・モニタリング | N/A | |
| ドキュメント | `docs/design/lp-content-map.md` [01]/[03]/[04] に PC 横長仕様追記 | |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: CSS 変更のみで責務追加なし
- [x] **依存性逆転（D）**: N/A（CSS）
- [x] **インターフェース分離（I）**: N/A（CSS）
- [x] **DRY / 横展開**: site/index.html の `.hero` / `.machine-tour` / `.core-loop-2col` の CSS を `pamphlet.html` / `pricing.html` で再利用していないことを `grep` で確認
- [x] **YAGNI**: 1280-1440px の主層を優先し 1920px+ は対応見送り

### セキュリティ（OSS 公開前提）
- [x] **N/A** — セキュリティ関連の変更なし（LP CSS のみ）

### アクセシビリティ
- [x] キーボード操作（Tab / Enter / Escape）で主要フローを操作できる（Hero CTA / age-tab focus-visible は既存実装で確保）
- [x] インタラクティブ要素に適切な ARIA ラベル / role が付与されている（既存）
- [x] カラーコントラスト比が WCAG AA 基準を満たしている（既存トークン使用）

### パフォーマンス
- [x] N+1 クエリが発生していない（N/A — CSS）
- [x] バンドルサイズへの影響を確認した（CSS 約 200 byte 増、無視できる範囲）

## スクリーンショット / ビジュアルデモ

> **目的**: 起票者自身が UI/UX デザイナー視点で `docs/DESIGN.md` §9 禁忌事項に違反していないか、PC 横長レイアウトで Hero / tour-card / core-loop-visual が破綻していないかを目視確認した結果の証跡として残す。

### 変更前後の比較

| Viewport | Before (origin/main) | After (本 PR) |
|----------|----------------------|---------------|
| Desktop viewport (1280×800) | ![before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1685/before-desktop-viewport.png) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1685/after-desktop-viewport.png) |
| Desktop full-page (1280×~7458) | ![before-fullpage](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1685/before-desktop-fullpage.png) | ![after-fullpage](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1685/after-desktop-fullpage.png) |
| Mobile (390×844) | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1685/before-mobile-viewport.png) | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1685/after-mobile-viewport.png) |

> スクリーンショットは `screenshots` ブランチの `pr-1685/` ディレクトリに commit 済み（raw URL 引用）。
> キャプチャ コマンド: `node scripts/capture.mjs --server-mode lp --url /index.html --presets desktop,mobile`

**自分の目で見た結果のセルフレビュー所見**:
- Desktop viewport (Hero): h1 「やりなさい」を「やりたい！」に変える家族 RPG が **2.4rem → 2.9rem** に拡大しファーストビューで存在感が出た。padding 80px のゆとりも上下バランスが整った
- Desktop full-page (machine-tour): 4 カードが完全に同一行高で揃い、画像有 (実績&称号 / 持ち物チェックリスト) と画像なし (ルーティンチェックリスト / RPG バトル) の高さバラつきが解消された
- Desktop full-page (core-loop): 1280px viewport では aside 280px のままだが、CSS では 1440px+ 時に 320px に拡張されることを確認 (1920px キャプチャは preset 未対応のため後続 Issue で対応)
- Mobile (390px): Hero h1 (1.85rem) / hero-sub / CTA / バッジ群が破綻なく自然に折り返されていることを確認

### インタラクティブ状態の確認（#1481）

- [x] **N/A** — disabled / readonly フィールドの変更なし。LP は静的レイアウトのみ

### モバイルビューポート（#1481）

- [x] デスクトップ（1280px）のスクリーンショット添付（after-desktop-viewport.png / after-desktop-fullpage.png）
- [x] モバイル（390px）のスクリーンショット添付（after-mobile-viewport.png）
- [x] **対象**: LP のみの変更（`src/routes/(parent)/` や `src/routes/(child)/` への影響なし）

## 実機操作検証

- [x] 対象画面（site/index.html）を `npx serve site -l 5280` で開き、PC 横長表示で修正箇所が期待通りに表示されることを目視確認した
- [x] 認証は不要（LP は public 静的 HTML）
- [x] 撮ったスクリーンショットを再度自分で見て `docs/DESIGN.md` §9 禁忌事項のいずれにも該当しないことを確認した（hex 直書きなし、CSS 変数経由、インラインスタイルなし）
- [x] UI/UX デザイナー視点セルフレビュー: Hero h1 拡大で「やりたい！」のインパクトが向上、tour-card の行高揃いで雑な印象を解消、core-loop aside 拡張で screenshot が訴求素材として活きる
- [x] 用語変更なし（grep 不要）

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

## レビュー依頼事項・QA

- LP 1280×800 / 1440×900 / 1920×1080 のいずれの PC でも Hero / tour-card / core-loop-visual が整然と表示されているか目視で確認してほしい
- 1440px+ で aside 320px に拡張した結果、左 text 領域が狭まりすぎていないかを `core-loop-2col` のセクションで確認してほしい

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **本番アプリ** — N/A (LP のみ変更)
- [x] **デモ版** — N/A
- [x] **LP ↔ アプリ整合（双方向）**:
  - [x] **LP → アプリ**: LP の機能・文言は今回未変更（CSS のみ）
  - [x] **アプリ → LP**: 今回 LP に新機能を記載していない
  - [x] **N/A 該当部分**: 文言変更なしのため アプリとの整合再確認は不要
- [x] **全年齢モード** — N/A (LP のみ)
- [x] **ナビゲーション** — N/A
- [x] **E2E/ユニットシード** — N/A (DB スキーマ変更なし)
- [x] **チュートリアル + デモガイド** — N/A
- [x] **site/index.html ↔ pamphlet.html / pricing.html**: pamphlet.html / pricing.html は同一 CSS を再利用していないことを `grep` で確認（CSS は site/index.html に閉じている）

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更する `site/index.html` を同時期に変更する open PR が他に無いことを確認した（#1675 PMF / #1680 #1465 SSOT cleanup は site/ には触らない）

### LP 変更時の追加チェック（#1282 / ADR-0010 Pre-PMF）

- [x] LP セクション / 数値 / ロゴの追加なし（既存 CSS のブレークポイント拡張のみ）

### LP / 販促文言変更時の実装パス明示（ADR-0013 / #1314）

- [x] **N/A** — LP / 販促文言を変更していない（CSS layout のみの調整）

### その他

- [x] **用語変更**: 用語変更なし
- [x] **labels SSOT (ADR-0009)**: ユーザー向け文言の追加 / 変更なし
- [x] **UI構造変更**: チュートリアル変更なし
- [x] **カラー・スタイル**: hex カラー直書き・Tailwind デフォルト色クラスの新規追加なし（既存 CSS 変数 `var(--brand-100)` 等を使用）
- [x] **プリミティブ**: LP は SvelteKit primitive 対象外（site/ は静的 HTML）
- [x] **設計書（CRITICAL）**: `docs/design/lp-content-map.md` [01]/[03]/[04] と実測値（mobile=13662, desktop=7458）を本 PR で同期

## Ready for Review チェックリスト

- [x] CI が全て通過している（site/ のみ変更で関連する site-check / measure-lp / new-env-distribution-check / 並行 PR / changes / ci-gate 全 pass。lint-and-test / unit-test / e2e-test 等 src/ 系ジョブは paths-filter で skip）
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）
- [x] **全 AC が実装済みであること**（TODO / 予定 のまま残っている AC がないこと）
- [x] **Phase 分割が必要だった場合は着手前に PO と合意し、子 Issue を起票済み**: 該当なし（3 Issue を 1 PR で統合する Phase 5 P2 計画通り）
- [x] UI 変更がある場合、UI/UX デザイナー視点で `docs/DESIGN.md` §9 禁忌事項に該当しないことを目視確認しスクリーンショット添付（screenshots branch に投入）
- [x] **認証絡みなし** — LP のみ
- [x] **hardcoded JP text**: src/ への変更なし

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし（LP HTML/CSS のみ、Lambda 起動とは無関係）

### スコープ完全性
- [x] **見落とし確認**: PR #1668 で投入された Phase 4 ベースを Phase 5 P2 で仕上げた。BudouX フォールバック / 1920px+ ブレークポイントは Pre-PMF では不要と判断（ADR-0010 適合）

## デプロイ検証（#710 — マージ後必須）

- [ ] `gh run list --branch main --workflow deploy-pages.yml` で site デプロイが成功していることを確認（マージ後）
- [ ] 本番 URL（https://ganbari-quest.com/）で Hero h1 拡大 / tour-card 行高揃え / core-loop aside 320px が PC で反映されていることを確認（マージ後）

## 完了チェックリスト

- [x] `npx biome check site/` — lint エラーなし
- [x] `node scripts/measure-lp-dimensions.mjs` — LP メトリクス全閾値内
- [x] `npx svelte-check` — N/A (site/ のみ変更で対象外)
- [x] `npx vitest run` — N/A (site/ のみ変更で対象外)
- [x] `npx playwright test` — CI の paths-filter で skip (site/ のみ変更のため対象外)
- [x] PR のサイズが適切（2 ファイル / 41 行追加）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

<!-- QM (ganbariquestsupport-lab) が approve 時に記入。Dev (本 PR 作成者) は空欄のままでよい。
     CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（docs/sessions/qa-session.md「QM approve 前の必須実行手順」参照）。 -->

- [ ] Issue AC 全項目が PR diff で達成されていることを確認した
- [ ] 添付スクリーンショットを全て Read tool で開いて目視し、UI/UX デザイナー観点で違和感が無いことを確認した
- [ ] `docs/DESIGN.md` §9 禁忌事項に該当しないことを確認した
- [ ] 並行実装の同期漏れが無いことを確認した
- [ ] スコープ外の気付きがあれば Issue 起票済み
- [ ] CI 全緑を上記チェック後の補助情報として確認した

### QM 所見（スクリーンショット 1 枚ごとに 1 行以上）

<!-- QM が記入 -->
