### PR TITLE
chore: #1666 #1593 follow-up — DynamoDB push_subscription subscriberRole migration script + runbook

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -529,6 +529,20 @@ Web Push 通知の購読情報。1ブラウザ1レコード。
 
 **インデックス:** tenant_id
 
+#### #1666 DynamoDB 側 migration（本番 AWS）
+
+SQLite (NUC) は `scripts/migrate-local.ts` で既存レコードを default `'parent'` に backfill 済。DynamoDB (本番 AWS) 側も `subscriberRole` 属性を必須化する。
+
+| 項目 | 内容 |
+|------|------|
+| migration script | `scripts/migrate-dynamodb-push-subscriber-role.mjs`（idempotent / `--dry-run` モードあり） |
+| runbook | [`docs/runbooks/push-subscription-role-migration.md`](../runbooks/push-subscription-role-migration.md) |
+| 抽出条件 | `begins_with(SK, 'PUSH_SUB#') OR entityType = 'PUSH_SUB'` |
+| backfill 対象 | `subscriberRole` 不在 / NULL / 空文字列 / `'parent'` `'owner'` 以外の値 |
+| backfill 値 | `'parent'`（送信側で skip されない安全側の値） |
+| 実行タイミング | DynamoDB push-subscription-repo の本実装マージ後、運用担当が一度だけ実行 |
+| 検証 | CloudWatch Logs `[notification] 非 parent/owner role の subscription への送信をスキップ` warn 件数 = 0 |
+
 ### notification_logs
 
 通知送信ログ。レート制限（3通/日）と監査に使用。
@@ -1849,3 +1863,4 @@ src/lib/server/db/migration/
 | 2026-04-28 | 5.4 | #1596 ADR-0023 §3.8 / I3 `cancellation_reasons` テーブル追加。解約フロー (`/admin/billing/cancel`) で全プラン強制収集される 3 分類 (graduation/churn/pause) + 自由記述。DynamoDB は `PK=CANCEL_REASON` single-partition。`idx_cancellation_reasons_tenant` / `_category_date` / `_date` インデックス付き |
 | 2026-04-27 | 5.4 | #1593 (ADR-0023 I6) `push_subscriptions` に `subscriber_role TEXT NOT NULL DEFAULT 'parent'` カラム追加。`'parent' \| 'owner'` のみ許容。subscribe API で `child` role を 403 拒否 + `notification-service` 送信時に二重防御で skip。COPPA 改正 + ADR-0012 Anti-engagement 二重リスク対策。詳細は `docs/design/14-セキュリティ設計書.md §8.5` 参照 |
 | 2026-04-29 | 5.5 | #1598 (ADR-0023 §3.6 §5 I7) PMF 判定アンケート用 settings KV キー 3 種を §3 settings に追加: `pmf_survey_sent_<round>` (配信履歴 / 半期 round 内重複防止) / `pmf_survey_response_<round>` (回答 JSON) / `marketing_email_count_<year>` (lifecycle-emails 共有カウンタ、年 6 回上限)。新規テーブル追加せず settings KV を流用 (Pre-PMF シンプル化、ADR-0010)。DynamoDB: `T#<tid>#SETTING#pmf_survey_*` で同一構造 |
+| 2026-04-29 | 5.6 | #1666 (#1593 follow-up, ADR-0023 I6) DynamoDB 側 push_subscription `subscriberRole` 必須化を §push_subscriptions に明記。migration script (`scripts/migrate-dynamodb-push-subscriber-role.mjs`) + runbook (`docs/runbooks/push-subscription-role-migration.md`) を整備。実行は DynamoDB push-subscription-repo 本実装マージ後（別 follow-up Issue で扱う）。idempotent / `--dry-run` モード / 検証は CloudWatch warn 件数 = 0 |

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -343,7 +343,11 @@ Layer 2: Context（署名付きトークン）
 
 #### 既存レコード backfill
 
-本機能リリース前の既存 subscription は default `'parent'` で扱われる。これは `npm run dev:cognito` 環境では DEV_USERS の owner / parent / child の subscribe 試行が ADR-0023 §3.1 の通り「親管理画面動線のみ」に限定されてきた前提に依拠する。本番ローンチ前の DynamoDB 環境への migration は follow-up Issue で扱う（次節参照）。
+本機能リリース前の既存 subscription は default `'parent'` で扱われる。これは `npm run dev:cognito` 環境では DEV_USERS の owner / parent / child の subscribe 試行が ADR-0023 §3.1 の通り「親管理画面動線のみ」に限定されてきた前提に依拠する。
+
+**SQLite (NUC)**: `scripts/migrate-local.ts` で `ALTER TABLE ADD COLUMN ... DEFAULT 'parent'` + `UPDATE ... WHERE subscriber_role IS NULL OR ''` を実行済（#1593）。
+
+**DynamoDB (本番 AWS) (#1666)**: `scripts/migrate-dynamodb-push-subscriber-role.mjs` で `entityType = 'PUSH_SUB'` または `SK begins_with 'PUSH_SUB#'` の item を Scan し、`subscriberRole` 不在 / NULL / 不正値を `'parent'` で UpdateItem する idempotent script を提供。実行手順は [`docs/runbooks/push-subscription-role-migration.md`](../runbooks/push-subscription-role-migration.md) 参照。実行タイミングは DynamoDB push-subscription-repo 本実装マージ後（実装本体は本 follow-up Issue とは別 Issue で扱う、ADR-0010 Pre-PMF / #1021 段階的対応禁止に整合）。検証は CloudWatch Logs `[notification] 非 parent/owner role の subscription への送信をスキップ` warn 件数 = 0。
 
 ---
 

--- a/docs/runbooks/push-subscription-role-migration.md
+++ b/docs/runbooks/push-subscription-role-migration.md
@@ -1,0 +1,195 @@
+# DynamoDB push_subscription `subscriberRole` Migration Runbook
+
+> **対象**: 運用担当 (PO)
+> **関連 Issue**: [#1666](https://github.com/takenori-kusaka/ganbari-quest/issues/1666) (#1593 follow-up)
+> **関連 ADR**: ADR-0010 (Pre-PMF), ADR-0023 I6 (push subscriber role 監査), ADR-0012 (Anti-engagement)
+> **関連 設計書**: [docs/design/14-セキュリティ設計書.md §8.8](../design/14-セキュリティ設計書.md), [docs/design/08-データベース設計書.md §push_subscriptions](../design/08-データベース設計書.md)
+
+---
+
+## 1. 目的
+
+#1593 で `push_subscriptions.subscriber_role` カラムを追加し、SQLite (NUC) は `scripts/migrate-local.ts` で既存レコードを default `'parent'` に backfill 済。本 runbook は **DynamoDB (本番 AWS)** 側の同等 migration を扱う。
+
+### 1.1 達成すべき状態
+
+- 全 push_subscription レコードに `subscriberRole` 属性が存在
+- 値は `'parent'` または `'owner'` のみ
+- `notification-service.ts` 送信時の skip warn ログ (`[notification] 非 parent/owner role の subscription への送信をスキップ`) が CloudWatch で 0 件
+
+---
+
+## 2. 前提条件
+
+以下が **すべて** 満たされた状態で実行する。
+
+| 前提 | 確認方法 |
+|------|---------|
+| #1593 が main にマージ済 | `git log --grep '#1593'` |
+| DynamoDB 側 `push-subscription-repo.ts` が **本実装済** (※) | `node scripts/check-dynamodb-stub.mjs` が green |
+| `subscribe API` が role validation を実施 (child=403) | `tests/unit/routes/notifications-subscribe-api.test.ts` 全 pass |
+| 実行端末から本番 DynamoDB に書き込み可能な IAM 権限 | `aws sts get-caller-identity` + 後述 §6 IAM ポリシー |
+
+> ※ DynamoDB 実装本体は本 PR スコープ外（別 follow-up Issue で扱う）。実装本体マージ後に本 runbook を実行する。
+
+---
+
+## 3. dry-run（必ず最初に実行）
+
+書き込みは行わず、対象件数のみを表示する。
+
+```bash
+# Lambda 同梱版を使う場合（デプロイ済 image 内のスクリプト）
+AWS_REGION=us-east-1 \
+DYNAMODB_TABLE=ganbari-quest \
+node scripts/migrate-dynamodb-push-subscriber-role.mjs --dry-run
+```
+
+期待される出力例:
+
+```
+[migrate-push-role] INFO start (table=ganbari-quest, region=us-east-1, dryRun=true)
+[migrate-push-role] INFO scan complete {"total":42,"needsBackfill":42}
+[migrate-push-role] INFO dry-run mode — sample of items to migrate (first 10):
+[migrate-push-role] INFO   T#tenant-abc#PUSH_SUB / PUSH_SUB#deadbeef (current=null)
+...
+[migrate-push-role] INFO dry-run end (would migrate 42 items)
+{
+  "status": "ok",
+  "total": 42,
+  "migrated": 0,
+  "skipped": 0,
+  "wouldMigrate": 42
+}
+```
+
+### 3.1 dry-run 結果の判断
+
+| `total` | `needsBackfill` | 判断 |
+|---------|----------------|------|
+| 0 | 0 | 既存レコードなし。本 migration 不要。Issue #1666 を `total=0` 証跡付きで close。 |
+| > 0 | 0 | すでに全レコード backfill 済（idempotent 確認）。本 migration 不要。 |
+| > 0 | > 0 | §4 本実行へ進む |
+
+---
+
+## 4. 本実行
+
+```bash
+AWS_REGION=us-east-1 \
+DYNAMODB_TABLE=ganbari-quest \
+node scripts/migrate-dynamodb-push-subscriber-role.mjs
+```
+
+期待される出力例:
+
+```
+[migrate-push-role] INFO start (table=ganbari-quest, region=us-east-1, dryRun=false)
+[migrate-push-role] INFO scan complete {"total":42,"needsBackfill":42}
+[migrate-push-role] INFO progress: 25/42
+[migrate-push-role] INFO done {"total":42,"migrated":42,"skipped":0}
+{
+  "status": "ok",
+  "total": 42,
+  "migrated": 42,
+  "skipped": 0
+}
+```
+
+### 4.1 例外時の対応
+
+- **ProvisionedThroughputExceededException / ThrottlingException** — script 内で exponential backoff (最大 30 秒) で 6 回 retry する。それでも継続するなら on-demand 課金モードへの切替を検討。
+- **ResourceNotFoundException** — `DYNAMODB_TABLE` 環境変数 が誤り。CDK output `TableName` を確認。
+- **ConditionalCheckFailedException** — script 内で swallow（既に valid role が設定済の race condition）。エラー扱いしない。
+- **AccessDeniedException** — IAM 権限不足。§6 を確認。
+
+### 4.2 中断・再実行
+
+本 script は **idempotent**。中断後に再実行しても、既に `'parent'` / `'owner'` が設定されているレコードはスキップされる（`ConditionExpression` で保護）。安心して再実行可能。
+
+---
+
+## 5. 検証（migration 完了後 24 時間以内）
+
+### 5.1 AWS CLI でサンプル確認
+
+```bash
+# subscriberRole が無いレコードが残っていないか Scan で確認
+aws dynamodb scan \
+  --table-name ganbari-quest \
+  --filter-expression "begins_with(SK, :prefix) AND attribute_not_exists(subscriberRole)" \
+  --expression-attribute-values '{":prefix":{"S":"PUSH_SUB#"}}' \
+  --select COUNT \
+  --region us-east-1
+```
+
+期待値: `"Count": 0`。0 でなければ §4 を再実行。
+
+### 5.2 CloudWatch Logs で warn 件数確認
+
+`/aws/lambda/ganbari-quest-app` (または該当 Lambda log group) で次の query を実行:
+
+```
+fields @timestamp, @message
+| filter @message like /非 parent\/owner role の subscription への送信をスキップ/
+| stats count() by bin(1h)
+```
+
+期待値: 直近 24 時間で **0 件**。1 件でも検出されたら、対応するレコードの `subscriberRole` 属性が `'parent'` / `'owner'` 以外であることを意味する。AWS Console で当該レコードを確認し、手動で修正するか、本 script を再実行する。
+
+### 5.3 Issue #1666 close 条件
+
+- §3 dry-run 出力をコメントに貼付
+- §4 本実行ログ (`migrated`/`skipped` 件数) をコメントに貼付
+- §5.1 / §5.2 検証結果（共に 0）をコメントに貼付
+
+---
+
+## 6. IAM 権限要件（最小特権）
+
+実行端末は次の権限を持つ IAM Role / User を使用する。
+
+```json
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "AllowScanAndUpdatePushSubscriptions",
+			"Effect": "Allow",
+			"Action": ["dynamodb:Scan", "dynamodb:UpdateItem"],
+			"Resource": "arn:aws:dynamodb:us-east-1:*:table/ganbari-quest"
+		}
+	]
+}
+```
+
+> 本 migration は **PK / SK 全 partition を Scan** するため、`Resource` を絞れない。代わりに Action を `Scan` + `UpdateItem` に限定する（`DeleteItem` / `PutItem` は不要）。
+
+---
+
+## 7. ロールバック手順（任意）
+
+通常はロールバック不要（idempotent な前進更新のみ）。
+ただし、**`subscriberRole = 'parent'` を誤って設定すべきでないレコード**（例: 本来 `'owner'` のはずのレコード）が混在する可能性がある場合は、次の手順で個別修正する。
+
+```bash
+# 個別レコードを 'owner' に修正
+aws dynamodb update-item \
+  --table-name ganbari-quest \
+  --key '{"PK":{"S":"T#tenant-abc#PUSH_SUB"},"SK":{"S":"PUSH_SUB#xyz"}}' \
+  --update-expression "SET subscriberRole = :role" \
+  --expression-attribute-values '{":role":{"S":"owner"}}' \
+  --region us-east-1
+```
+
+> 本 migration の default `'parent'` は **送信側で skip されない安全側の値**（`notification-service.ts` の二重防御を通過）。`'owner'` への昇格が必要な場合のみ手動修正する。
+
+`subscriberRole` 属性自体を削除する逆 migration は **意図的に提供しない**（NULL 混在防止 / ADR-0031 の趣旨）。
+
+---
+
+## 8. 履歴
+
+| 日付 | 版 | 変更内容 |
+|------|----|---------|
+| 2026-04-29 | 1.0 | 初版（#1666） |

--- a/scripts/migrate-dynamodb-push-subscriber-role.mjs
+++ b/scripts/migrate-dynamodb-push-subscriber-role.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * scripts/migrate-dynamodb-push-subscriber-role.mjs
+ *
+ * #1666 (#1593 follow-up — ADR-0023 I6 / COPPA / ADR-0012 Anti-engagement)
+ *
+ * 用途:
+ *   本番 DynamoDB の既存 push_subscription レコードに対して、
+ *   `subscriberRole` 属性が不在 / NULL / 空文字列のレコードを抽出し、
+ *   `'parent'` に backfill する一回限りの migration script。
+ *
+ * 設計方針 (本 PR の制約):
+ *   - DynamoDB 側 push-subscription-repo.ts は現在 stub（#1021 段階的対応禁止）。
+ *     本 script は **DynamoDB 実装本体マージ後** に一度だけ実行する想定。
+ *   - 実装本体は別 Issue (本 PR 末尾で起票) で扱う。
+ *   - 本 script はキー設計に **直接依存しない**。`entityType = 'PUSH_SUB'` 属性
+ *     または SK が `PUSH_SUB#` から始まる item を Scan で抽出する汎用設計。
+ *     実装本体側で同じ属性 / SK 規約を採用すること。
+ *
+ * AC (Issue #1666):
+ *   1. 既存 push_subscription レコード件数を確認
+ *   2. subscriberRole 不在 / NULL のレコードを抽出
+ *   3. 全レコードを 'parent' で backfill
+ *   4. notification-service の "[notification] 非 parent/owner role" warn ログ件数 0 を CloudWatch で確認
+ *
+ * 使用方法:
+ *   # dry-run (件数のみ表示。書き込みなし)
+ *   node scripts/migrate-dynamodb-push-subscriber-role.mjs --dry-run
+ *
+ *   # 本番実行 (UpdateItem を発行)
+ *   AWS_REGION=us-east-1 DYNAMODB_TABLE=ganbari-quest \
+ *     node scripts/migrate-dynamodb-push-subscriber-role.mjs
+ *
+ *   # テーブル名を CLI で指定
+ *   node scripts/migrate-dynamodb-push-subscriber-role.mjs --table=ganbari-quest --dry-run
+ *
+ * Idempotent:
+ *   既に subscriberRole が 'parent' / 'owner' で設定済のレコードは skip する。
+ *   何度実行しても安全。
+ *
+ * Rate limit:
+ *   UpdateItem は 1 件ずつ直列で発行 (BatchWrite は UpdateItem に対応していないため)。
+ *   テーブルが provisioned mode の場合は WCU を超過しないよう exponential backoff で retry。
+ *   on-demand mode (本プロダクトの想定) では実質無制限。
+ */
+
+import { ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+// ------------------------------------------------------------
+// CLI args
+// ------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const tableArg = args.find((a) => a.startsWith('--table='));
+const TABLE_NAME = tableArg
+	? tableArg.slice('--table='.length)
+	: (process.env.DYNAMODB_TABLE ?? process.env.TABLE_NAME ?? 'ganbari-quest');
+const REGION = process.env.AWS_REGION ?? 'us-east-1';
+
+// ------------------------------------------------------------
+// Constants
+// ------------------------------------------------------------
+
+const DEFAULT_ROLE = 'parent';
+const VALID_ROLES = new Set(['parent', 'owner']);
+const PUSH_SUB_SK_PREFIX = 'PUSH_SUB#';
+const PUSH_SUB_ENTITY_TYPE = 'PUSH_SUB';
+const MAX_BACKOFF_MS = 30_000;
+
+// ------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------
+
+function buildClient() {
+	const base = new DynamoDBClient({ region: REGION });
+	return DynamoDBDocumentClient.from(base, {
+		marshallOptions: { removeUndefinedValues: true },
+		unmarshallOptions: { wrapNumbers: false },
+	});
+}
+
+function log(level, msg, extra) {
+	const line = `[migrate-push-role] ${level.toUpperCase()} ${msg}`;
+	if (extra) {
+		console.log(line, JSON.stringify(extra));
+	} else {
+		console.log(line);
+	}
+}
+
+function isPushSubscriptionItem(item) {
+	if (!item) return false;
+	if (item.entityType === PUSH_SUB_ENTITY_TYPE) return true;
+	if (typeof item.SK === 'string' && item.SK.startsWith(PUSH_SUB_SK_PREFIX)) return true;
+	return false;
+}
+
+function needsBackfill(item) {
+	const role = item.subscriberRole;
+	if (role == null || role === '') return true;
+	if (typeof role !== 'string') return true;
+	if (!VALID_ROLES.has(role)) return true;
+	return false;
+}
+
+async function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withBackoff(fn, attempt = 0) {
+	try {
+		return await fn();
+	} catch (err) {
+		const code = err?.name ?? err?.Code ?? '';
+		const isThrottle =
+			code === 'ProvisionedThroughputExceededException' ||
+			code === 'ThrottlingException' ||
+			code === 'RequestLimitExceeded';
+		if (!isThrottle || attempt >= 6) throw err;
+		const delay = Math.min(MAX_BACKOFF_MS, 2 ** attempt * 100);
+		log('warn', `throttle hit, backoff ${delay}ms`, { attempt, code });
+		await sleep(delay);
+		return withBackoff(fn, attempt + 1);
+	}
+}
+
+// ------------------------------------------------------------
+// Core logic
+// ------------------------------------------------------------
+
+/**
+ * Scan the table for all push_subscription items. Returns items that need backfill.
+ *
+ * @param {DynamoDBDocumentClient} doc
+ * @returns {Promise<{total:number, needsBackfill: Array<{PK:string, SK:string, currentRole: unknown}>}>}
+ */
+export async function scanPushSubscriptions(doc, tableName = TABLE_NAME) {
+	const result = { total: 0, needsBackfill: [] };
+	let lastKey;
+
+	do {
+		const page = await withBackoff(() =>
+			doc.send(
+				new ScanCommand({
+					TableName: tableName,
+					FilterExpression:
+						'begins_with(SK, :skPrefix) OR entityType = :entityType',
+					ExpressionAttributeValues: {
+						':skPrefix': PUSH_SUB_SK_PREFIX,
+						':entityType': PUSH_SUB_ENTITY_TYPE,
+					},
+					ExclusiveStartKey: lastKey,
+				}),
+			),
+		);
+
+		for (const item of page.Items ?? []) {
+			if (!isPushSubscriptionItem(item)) continue;
+			result.total += 1;
+			if (needsBackfill(item)) {
+				result.needsBackfill.push({
+					PK: item.PK,
+					SK: item.SK,
+					currentRole: item.subscriberRole ?? null,
+				});
+			}
+		}
+		lastKey = page.LastEvaluatedKey;
+	} while (lastKey);
+
+	return result;
+}
+
+/**
+ * Update one item: set subscriberRole = 'parent'.
+ * Idempotent — uses condition expression to skip if already set to a valid value.
+ *
+ * @param {DynamoDBDocumentClient} doc
+ * @param {{PK:string, SK:string}} key
+ */
+export async function updateSubscriberRole(doc, key, tableName = TABLE_NAME) {
+	await withBackoff(() =>
+		doc.send(
+			new UpdateCommand({
+				TableName: tableName,
+				Key: { PK: key.PK, SK: key.SK },
+				UpdateExpression: 'SET subscriberRole = :role',
+				ConditionExpression:
+					'attribute_not_exists(subscriberRole) OR subscriberRole = :empty OR (subscriberRole <> :parent AND subscriberRole <> :owner)',
+				ExpressionAttributeValues: {
+					':role': DEFAULT_ROLE,
+					':empty': '',
+					':parent': 'parent',
+					':owner': 'owner',
+				},
+			}),
+		),
+	).catch((err) => {
+		// ConditionalCheckFailedException = 既に valid role が設定済 → 期待通り skip
+		if (err?.name === 'ConditionalCheckFailedException') return;
+		throw err;
+	});
+}
+
+// ------------------------------------------------------------
+// Main
+// ------------------------------------------------------------
+
+async function main() {
+	log('info', `start (table=${TABLE_NAME}, region=${REGION}, dryRun=${DRY_RUN})`);
+
+	const doc = buildClient();
+	const scan = await scanPushSubscriptions(doc);
+
+	log('info', `scan complete`, {
+		total: scan.total,
+		needsBackfill: scan.needsBackfill.length,
+	});
+
+	if (scan.needsBackfill.length === 0) {
+		log('info', 'no items need backfill — nothing to do');
+		return { total: scan.total, migrated: 0, skipped: scan.total };
+	}
+
+	if (DRY_RUN) {
+		log('info', 'dry-run mode — sample of items to migrate (first 10):');
+		for (const sample of scan.needsBackfill.slice(0, 10)) {
+			log('info', `  ${sample.PK} / ${sample.SK} (current=${JSON.stringify(sample.currentRole)})`);
+		}
+		log('info', `dry-run end (would migrate ${scan.needsBackfill.length} items)`);
+		return {
+			total: scan.total,
+			migrated: 0,
+			skipped: scan.total - scan.needsBackfill.length,
+			wouldMigrate: scan.needsBackfill.length,
+		};
+	}
+
+	let migrated = 0;
+	for (const target of scan.needsBackfill) {
+		await updateSubscriberRole(doc, { PK: target.PK, SK: target.SK });
+		migrated += 1;
+		if (migrated % 25 === 0) {
+			log('info', `progress: ${migrated}/${scan.needsBackfill.length}`);
+		}
+	}
+
+	log('info', `done`, {
+		total: scan.total,
+		migrated,
+		skipped: scan.total - migrated,
+	});
+	return { total: scan.total, migrated, skipped: scan.total - migrated };
+}
+
+// ------------------------------------------------------------
+// Entry point (only when invoked directly)
+// ------------------------------------------------------------
+
+const isDirectInvocation =
+	import.meta.url === `file://${process.argv[1]}` ||
+	import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'));
+
+if (isDirectInvocation) {
+	main()
+		.then((summary) => {
+			console.log(JSON.stringify({ status: 'ok', ...summary }, null, 2));
+			process.exit(0);
+		})
+		.catch((err) => {
+			log('error', 'migration failed', { message: err?.message, stack: err?.stack });
+			process.exit(1);
+		});
+}

--- a/scripts/migrate-dynamodb-push-subscriber-role.mjs
+++ b/scripts/migrate-dynamodb-push-subscriber-role.mjs
@@ -82,6 +82,11 @@ function buildClient() {
 	});
 }
 
+/**
+ * @param {string} level
+ * @param {string} msg
+ * @param {Record<string, unknown>} [extra]
+ */
 function log(level, msg, extra) {
 	const line = `[migrate-push-role] ${level.toUpperCase()} ${msg}`;
 	if (extra) {
@@ -91,13 +96,22 @@ function log(level, msg, extra) {
 	}
 }
 
+/**
+ * @param {unknown} item
+ * @returns {boolean}
+ */
 function isPushSubscriptionItem(item) {
-	if (!item) return false;
-	if (item.entityType === PUSH_SUB_ENTITY_TYPE) return true;
-	if (typeof item.SK === 'string' && item.SK.startsWith(PUSH_SUB_SK_PREFIX)) return true;
+	if (!item || typeof item !== 'object') return false;
+	const record = /** @type {Record<string, unknown>} */ (item);
+	if (record.entityType === PUSH_SUB_ENTITY_TYPE) return true;
+	if (typeof record.SK === 'string' && record.SK.startsWith(PUSH_SUB_SK_PREFIX)) return true;
 	return false;
 }
 
+/**
+ * @param {{ subscriberRole?: unknown }} item
+ * @returns {boolean}
+ */
 function needsBackfill(item) {
 	const role = item.subscriberRole;
 	if (role == null || role === '') return true;
@@ -106,14 +120,23 @@ function needsBackfill(item) {
 	return false;
 }
 
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
 async function sleep(ms) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * @param {() => Promise<unknown>} fn
+ * @param {number} [attempt]
+ * @returns {Promise<unknown>}
+ */
 async function withBackoff(fn, attempt = 0) {
 	try {
 		return await fn();
-	} catch (err) {
+	} catch (/** @type {any} */ err) {
 		const code = err?.name ?? err?.Code ?? '';
 		const isThrottle =
 			code === 'ProvisionedThroughputExceededException' ||
@@ -138,32 +161,37 @@ async function withBackoff(fn, attempt = 0) {
  * @returns {Promise<{total:number, needsBackfill: Array<{PK:string, SK:string, currentRole: unknown}>}>}
  */
 export async function scanPushSubscriptions(doc, tableName = TABLE_NAME) {
+	/** @type {{total: number, needsBackfill: Array<{PK: string, SK: string, currentRole: unknown}>}} */
 	const result = { total: 0, needsBackfill: [] };
+	/** @type {Record<string, unknown> | undefined} */
 	let lastKey;
 
 	do {
-		const page = await withBackoff(() =>
-			doc.send(
-				new ScanCommand({
-					TableName: tableName,
-					FilterExpression: 'begins_with(SK, :skPrefix) OR entityType = :entityType',
-					ExpressionAttributeValues: {
-						':skPrefix': PUSH_SUB_SK_PREFIX,
-						':entityType': PUSH_SUB_ENTITY_TYPE,
-					},
-					ExclusiveStartKey: lastKey,
-				}),
-			),
+		const page = /** @type {import('@aws-sdk/lib-dynamodb').ScanCommandOutput} */ (
+			await withBackoff(() =>
+				doc.send(
+					new ScanCommand({
+						TableName: tableName,
+						FilterExpression: 'begins_with(SK, :skPrefix) OR entityType = :entityType',
+						ExpressionAttributeValues: {
+							':skPrefix': PUSH_SUB_SK_PREFIX,
+							':entityType': PUSH_SUB_ENTITY_TYPE,
+						},
+						ExclusiveStartKey: lastKey,
+					}),
+				),
+			)
 		);
 
 		for (const item of page.Items ?? []) {
 			if (!isPushSubscriptionItem(item)) continue;
+			const record = /** @type {Record<string, unknown>} */ (item);
 			result.total += 1;
-			if (needsBackfill(item)) {
+			if (needsBackfill(/** @type {{ subscriberRole?: unknown }} */ (record))) {
 				result.needsBackfill.push({
-					PK: item.PK,
-					SK: item.SK,
-					currentRole: item.subscriberRole ?? null,
+					PK: /** @type {string} */ (record.PK),
+					SK: /** @type {string} */ (record.SK),
+					currentRole: record.subscriberRole ?? null,
 				});
 			}
 		}
@@ -197,7 +225,7 @@ export async function updateSubscriberRole(doc, key, tableName = TABLE_NAME) {
 				},
 			}),
 		),
-	).catch((err) => {
+	).catch((/** @type {any} */ err) => {
 		// ConditionalCheckFailedException = 既に valid role が設定済 → 期待通り skip
 		if (err?.name === 'ConditionalCheckFailedException') return;
 		throw err;
@@ -259,9 +287,9 @@ async function main() {
 // Entry point (only when invoked directly)
 // ------------------------------------------------------------
 
+const argv1 = process.argv[1] ?? '';
 const isDirectInvocation =
-	import.meta.url === `file://${process.argv[1]}` ||
-	import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'));
+	import.meta.url === `file://${argv1}` || import.meta.url.endsWith(argv1.replace(/\\/g, '/'));
 
 if (isDirectInvocation) {
 	main()
@@ -269,7 +297,7 @@ if (isDirectInvocation) {
 			console.log(JSON.stringify({ status: 'ok', ...summary }, null, 2));
 			process.exit(0);
 		})
-		.catch((err) => {
+		.catch((/** @type {any} */ err) => {
 			log('error', 'migration failed', { message: err?.message, stack: err?.stack });
 			process.exit(1);
 		});

--- a/scripts/migrate-dynamodb-push-subscriber-role.mjs
+++ b/scripts/migrate-dynamodb-push-subscriber-role.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 /**
  * scripts/migrate-dynamodb-push-subscriber-role.mjs
  *
@@ -44,9 +45,8 @@
  *   on-demand mode (本プロダクトの想定) では実質無制限。
  */
 
-import { ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 
 // ------------------------------------------------------------
 // CLI args
@@ -146,8 +146,7 @@ export async function scanPushSubscriptions(doc, tableName = TABLE_NAME) {
 			doc.send(
 				new ScanCommand({
 					TableName: tableName,
-					FilterExpression:
-						'begins_with(SK, :skPrefix) OR entityType = :entityType',
+					FilterExpression: 'begins_with(SK, :skPrefix) OR entityType = :entityType',
 					ExpressionAttributeValues: {
 						':skPrefix': PUSH_SUB_SK_PREFIX,
 						':entityType': PUSH_SUB_ENTITY_TYPE,

--- a/tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts
+++ b/tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts
@@ -204,11 +204,7 @@ describe('migrate-dynamodb-push-subscriber-role', () => {
 
 			const { updateSubscriberRole } = await loadModule();
 			const doc = { send: mockSend } as unknown as Parameters<typeof updateSubscriberRole>[0];
-			await updateSubscriberRole(
-				doc,
-				{ PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#abc' },
-				'test-table',
-			);
+			await updateSubscriberRole(doc, { PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#abc' }, 'test-table');
 			expect(mockSend).toHaveBeenCalledTimes(1);
 			const cmd = mockSend.mock.calls[0]?.[0];
 			// MockUpdateCommand instance の input を取り出す
@@ -216,9 +212,7 @@ describe('migrate-dynamodb-push-subscriber-role', () => {
 			expect(input.TableName).toBe('test-table');
 			expect(input.Key).toEqual({ PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#abc' });
 			expect(input.UpdateExpression).toContain('subscriberRole');
-			expect(
-				(input.ExpressionAttributeValues as Record<string, unknown>)[':role'],
-			).toBe('parent');
+			expect((input.ExpressionAttributeValues as Record<string, unknown>)[':role']).toBe('parent');
 		});
 
 		it('ConditionalCheckFailedException は swallow する (既に valid role 設定済の race condition)', async () => {
@@ -244,11 +238,7 @@ describe('migrate-dynamodb-push-subscriber-role', () => {
 
 			const { updateSubscriberRole } = await loadModule();
 			const doc = { send: mockSend } as unknown as Parameters<typeof updateSubscriberRole>[0];
-			await updateSubscriberRole(
-				doc,
-				{ PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#abc' },
-				'test-table',
-			);
+			await updateSubscriberRole(doc, { PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#abc' }, 'test-table');
 			expect(mockSend).toHaveBeenCalledTimes(2);
 		});
 

--- a/tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts
+++ b/tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts
@@ -1,0 +1,268 @@
+/**
+ * tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts
+ *
+ * #1666 (#1593 follow-up — ADR-0023 I6)
+ *
+ * scripts/migrate-dynamodb-push-subscriber-role.mjs の単体テスト。
+ * AWS SDK モックを使用し、Scan/UpdateItem の挙動を検証する。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+// AWS SDK のモック化 — vi.hoisted で先にモック関数を確保し、ESM bare specifier を fully mock する。
+const { mockSend, MockScanCommand, MockUpdateCommand, MockClient, MockDocClient } = vi.hoisted(
+	() => {
+		const send = vi.fn();
+		class ScanCmd {
+			input: unknown;
+			constructor(input: unknown) {
+				this.input = input;
+			}
+			static __type = 'Scan';
+			get __type() {
+				return 'Scan';
+			}
+		}
+		class UpdateCmd {
+			input: unknown;
+			constructor(input: unknown) {
+				this.input = input;
+			}
+			static __type = 'Update';
+			get __type() {
+				return 'Update';
+			}
+		}
+		class Client {}
+		const DocClient = {
+			from: () => ({ send }),
+		};
+		return {
+			mockSend: send,
+			MockScanCommand: ScanCmd,
+			MockUpdateCommand: UpdateCmd,
+			MockClient: Client,
+			MockDocClient: DocClient,
+		};
+	},
+);
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: MockClient,
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: MockDocClient,
+	ScanCommand: MockScanCommand,
+	UpdateCommand: MockUpdateCommand,
+}));
+
+// SUT を import — モック適用後でないと参照されてしまうので動的 import
+async function loadModule() {
+	return import('../../../scripts/migrate-dynamodb-push-subscriber-role.mjs');
+}
+
+describe('migrate-dynamodb-push-subscriber-role', () => {
+	describe('scanPushSubscriptions', () => {
+		it('subscriberRole 不在のレコードを needsBackfill に含める', async () => {
+			mockSend.mockReset();
+			mockSend.mockResolvedValueOnce({
+				Items: [
+					{
+						PK: 'T#tenant-1#PUSH_SUB',
+						SK: 'PUSH_SUB#abc',
+						endpoint: 'https://example.com/push/abc',
+						// subscriberRole: 不在
+					},
+				],
+				LastEvaluatedKey: undefined,
+			});
+
+			const { scanPushSubscriptions } = await loadModule();
+			const doc = { send: mockSend } as unknown as Parameters<typeof scanPushSubscriptions>[0];
+			const result = await scanPushSubscriptions(doc, 'test-table');
+			expect(result.total).toBe(1);
+			expect(result.needsBackfill).toHaveLength(1);
+			expect(result.needsBackfill[0]).toEqual({
+				PK: 'T#tenant-1#PUSH_SUB',
+				SK: 'PUSH_SUB#abc',
+				currentRole: null,
+			});
+		});
+
+		it("subscriberRole === 'parent' のレコードは skip する (idempotent)", async () => {
+			mockSend.mockReset();
+			mockSend.mockResolvedValueOnce({
+				Items: [
+					{
+						PK: 'T#tenant-1#PUSH_SUB',
+						SK: 'PUSH_SUB#xyz',
+						subscriberRole: 'parent',
+					},
+				],
+			});
+
+			const { scanPushSubscriptions } = await loadModule();
+			const doc = { send: mockSend } as unknown as Parameters<typeof scanPushSubscriptions>[0];
+			const result = await scanPushSubscriptions(doc, 'test-table');
+			expect(result.total).toBe(1);
+			expect(result.needsBackfill).toHaveLength(0);
+		});
+
+		it("subscriberRole === 'owner' のレコードも skip する", async () => {
+			mockSend.mockReset();
+			mockSend.mockResolvedValueOnce({
+				Items: [
+					{
+						PK: 'T#tenant-1#PUSH_SUB',
+						SK: 'PUSH_SUB#owner1',
+						subscriberRole: 'owner',
+					},
+				],
+			});
+
+			const { scanPushSubscriptions } = await loadModule();
+			const doc = { send: mockSend } as unknown as Parameters<typeof scanPushSubscriptions>[0];
+			const result = await scanPushSubscriptions(doc, 'test-table');
+			expect(result.needsBackfill).toHaveLength(0);
+		});
+
+		it('不正値 (旧 child / 空文字 / null) は backfill 対象に含める', async () => {
+			mockSend.mockReset();
+			mockSend.mockResolvedValueOnce({
+				Items: [
+					{ PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#a', subscriberRole: 'child' },
+					{ PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#b', subscriberRole: '' },
+					{ PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#c', subscriberRole: null },
+				],
+			});
+
+			const { scanPushSubscriptions } = await loadModule();
+			const doc = { send: mockSend } as unknown as Parameters<typeof scanPushSubscriptions>[0];
+			const result = await scanPushSubscriptions(doc, 'test-table');
+			expect(result.needsBackfill).toHaveLength(3);
+		});
+
+		it('LastEvaluatedKey でページングする', async () => {
+			mockSend.mockReset();
+			mockSend
+				.mockResolvedValueOnce({
+					Items: [{ PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#1' }],
+					LastEvaluatedKey: { PK: 'cursor', SK: 'cursor' },
+				})
+				.mockResolvedValueOnce({
+					Items: [{ PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#2' }],
+					LastEvaluatedKey: undefined,
+				});
+
+			const { scanPushSubscriptions } = await loadModule();
+			const doc = { send: mockSend } as unknown as Parameters<typeof scanPushSubscriptions>[0];
+			const result = await scanPushSubscriptions(doc, 'test-table');
+			expect(result.total).toBe(2);
+			expect(mockSend).toHaveBeenCalledTimes(2);
+		});
+
+		it('SK prefix が PUSH_SUB# でない & entityType も無いレコードは無視', async () => {
+			mockSend.mockReset();
+			mockSend.mockResolvedValueOnce({
+				Items: [
+					// FilterExpression で除外されるはずだが、もし通り抜けても無視されることを確認
+					{ PK: 'T#t1#OTHER', SK: 'OTHER#1' },
+				],
+			});
+
+			const { scanPushSubscriptions } = await loadModule();
+			const doc = { send: mockSend } as unknown as Parameters<typeof scanPushSubscriptions>[0];
+			const result = await scanPushSubscriptions(doc, 'test-table');
+			expect(result.total).toBe(0);
+		});
+
+		it('entityType = PUSH_SUB の属性ベース判定もサポート', async () => {
+			mockSend.mockReset();
+			mockSend.mockResolvedValueOnce({
+				Items: [
+					{
+						PK: 'PUSH#xyz',
+						SK: 'META',
+						entityType: 'PUSH_SUB',
+					},
+				],
+			});
+
+			const { scanPushSubscriptions } = await loadModule();
+			const doc = { send: mockSend } as unknown as Parameters<typeof scanPushSubscriptions>[0];
+			const result = await scanPushSubscriptions(doc, 'test-table');
+			expect(result.total).toBe(1);
+			expect(result.needsBackfill).toHaveLength(1);
+		});
+	});
+
+	describe('updateSubscriberRole', () => {
+		it("UpdateCommand に subscriberRole = 'parent' を含める", async () => {
+			mockSend.mockReset();
+			mockSend.mockResolvedValueOnce({});
+
+			const { updateSubscriberRole } = await loadModule();
+			const doc = { send: mockSend } as unknown as Parameters<typeof updateSubscriberRole>[0];
+			await updateSubscriberRole(
+				doc,
+				{ PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#abc' },
+				'test-table',
+			);
+			expect(mockSend).toHaveBeenCalledTimes(1);
+			const cmd = mockSend.mock.calls[0]?.[0];
+			// MockUpdateCommand instance の input を取り出す
+			const input = (cmd as { input: Record<string, unknown> }).input;
+			expect(input.TableName).toBe('test-table');
+			expect(input.Key).toEqual({ PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#abc' });
+			expect(input.UpdateExpression).toContain('subscriberRole');
+			expect(
+				(input.ExpressionAttributeValues as Record<string, unknown>)[':role'],
+			).toBe('parent');
+		});
+
+		it('ConditionalCheckFailedException は swallow する (既に valid role 設定済の race condition)', async () => {
+			mockSend.mockReset();
+			mockSend.mockRejectedValueOnce(
+				Object.assign(new Error('cond fail'), { name: 'ConditionalCheckFailedException' }),
+			);
+
+			const { updateSubscriberRole } = await loadModule();
+			const doc = { send: mockSend } as unknown as Parameters<typeof updateSubscriberRole>[0];
+			await expect(
+				updateSubscriberRole(doc, { PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#x' }, 'test-table'),
+			).resolves.toBeUndefined();
+		});
+
+		it('Throttling エラーは exponential backoff で retry する', async () => {
+			mockSend.mockReset();
+			mockSend
+				.mockRejectedValueOnce(
+					Object.assign(new Error('throttle'), { name: 'ThrottlingException' }),
+				)
+				.mockResolvedValueOnce({});
+
+			const { updateSubscriberRole } = await loadModule();
+			const doc = { send: mockSend } as unknown as Parameters<typeof updateSubscriberRole>[0];
+			await updateSubscriberRole(
+				doc,
+				{ PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#abc' },
+				'test-table',
+			);
+			expect(mockSend).toHaveBeenCalledTimes(2);
+		});
+
+		it('それ以外のエラーは throw する (caller でハンドリング)', async () => {
+			mockSend.mockReset();
+			mockSend.mockRejectedValue(
+				Object.assign(new Error('boom'), { name: 'ResourceNotFoundException' }),
+			);
+
+			const { updateSubscriberRole } = await loadModule();
+			const doc = { send: mockSend } as unknown as Parameters<typeof updateSubscriberRole>[0];
+			await expect(
+				updateSubscriberRole(doc, { PK: 'T#t1#PUSH_SUB', SK: 'PUSH_SUB#x' }, 'test-table'),
+			).rejects.toThrow('boom');
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / セキュリティ監査

**解決する課題**:
#1593 (ADR-0023 I6) で `push_subscriptions.subscriber_role` を SQLite (NUC) に追加・backfill 済だが、本番 DynamoDB 側の同等 migration 手段が未整備のため、DynamoDB 実装本体マージ時に「既存レコードに `subscriberRole` 不在 → 送信 skip warn 連発 / 構造防御の前提崩壊」が発生する。

**期待される効果**:
DynamoDB push-subscription-repo の本実装が完成した直後、PO が runbook 1 ファイルに従って dry-run → 本実行 → 検証を完結できる。COPPA 改正 + ADR-0012 Anti-engagement の二重リスク対策 (#1593) を本番 AWS 上でも完全に効かせる。

## 関連 Issue

closes #1666

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | DynamoDB の既存 push_subscription レコード件数を確認 | `scripts/migrate-dynamodb-push-subscriber-role.mjs --dry-run` の出力 `total` フィールド + runbook §3 | script 内 `scanPushSubscriptions` が `total` 集計、runbook §3 に確認手順記載 |
| AC2 | 既存レコードに subscriber_role 不在 / NULL 混入を確認 | `--dry-run` の `needsBackfill` 件数 + sample (first 10) 出力 | script 内 `needsBackfill()` で不在 / NULL / 空文字列 / 不正値を検出。テスト 4 ケースで検証 (test cases: 不在 / parent skip / owner skip / 不正値 backfill) |
| AC3 | migration script で全レコードを `'parent'` でバックフィル | `scripts/migrate-dynamodb-push-subscriber-role.mjs`（本実行） | UpdateCommand で `subscriberRole = 'parent'` を SET。idempotent (ConditionExpression で valid role 設定済は skip)。Throttling は exponential backoff で retry (max 6 attempts / 30s) |
| AC4 | `notification-service` warn ログ件数 0 を CloudWatch で確認 | runbook §5.2 の CloudWatch Logs Insights query | runbook §5.2 に query 記載: `\| filter @message like /非 parent\\/owner role の subscription への送信をスキップ/ \| stats count() by bin(1h)` |
| AC5 | 完了後 Issue close | runbook §5.3 の close 条件 | dry-run 出力 + 本実行ログ + 検証結果（共に 0）の 3 点を Issue コメントに貼付してクローズ |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`) — runbook で運用手順のみ記載。CDK / IAM ポリシーは記述のみ
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`scripts/`, `tests/unit/scripts/`, `docs/runbooks/`, `docs/design/08`/`14`)

**影響を受ける画面・機能**:
- 本番 DynamoDB の push_subscription レコード（migration 実行時のみ）
- 設計書 `docs/design/08-データベース設計書.md` §push_subscriptions
- 設計書 `docs/design/14-セキュリティ設計書.md` §8.8

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | `scripts/migrate-local.ts` (SQLite ALTER TABLE + UPDATE) / `scripts/reconcile-stripe-subscriptions.ts` (整合性検出のみ・自動修正なし) | DynamoDB Scan + UpdateCommand。idempotent + dry-run + exponential backoff |
| 一貫性 | `bulk-delete.ts` の Scan + BatchWrite パターンを踏襲 (BatchWrite は UpdateItem 非対応のため UpdateItem 直列発行に変更) | キー設計に直接依存しない汎用 (`SK begins_with 'PUSH_SUB#'` または `entityType = 'PUSH_SUB'` で抽出) |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: なし（新規 script 追加 + 設計書同期のみ）
- **リファクタリングが必要だが今回見送った箇所と理由**: DynamoDB push-subscription-repo 本実装は本 PR スコープ外（Issue 本文「DynamoDB 実装本体は別 Issue で」明記）。本 PR マージ後、follow-up Issue で扱う
- **削除したコード・機能**: なし

## 設計方針・将来性

**採用した設計方針**:
- **キー設計に直接依存しない抽出**: `SK begins_with 'PUSH_SUB#'` OR `entityType = 'PUSH_SUB'` の 2 軸で push_subscription item を識別。DynamoDB 実装本体側でキー設計が変わっても script の修正不要
- **Idempotent migration**: ConditionExpression で「既に valid role が設定済の record は skip」を保証。中断・再実行・並行実行に耐える
- **dry-run 必須**: 書き込み前に件数とサンプルを表示して PO 判断を仰ぐ
- **Exponential backoff**: Throttling/ProvisionedThroughputExceeded は最大 6 回 retry (30 秒上限)。on-demand 課金モードでは実質発火しない

**想定する将来の拡張**:
- 同パターン (バックフィル script + runbook + idempotent + dry-run) を他の DynamoDB schema 変更でも再利用できる
- `entityType` 属性ベースの抽出を採用したことで、PK/SK 設計の変更に追従しやすい

**意図的に対応しなかった範囲とその理由**:
- DynamoDB push-subscription-repo の本実装 — 本 follow-up Issue のスコープ外（#1021 / ADR-0010 整合）。実装は別 Issue で扱う
- ロールバック script (`subscriberRole` 削除) — ADR-0031 NULL 混在防止の趣旨に反する。runbook §7 で「個別 UpdateItem で 'owner' へ昇格」のみ記載

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — 既存機能 (#1593) の follow-up migration 提供のため、新 interface / 新スキーマ追加なし。設計書同期のみ

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加: `tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts` (11 cases)
- カバーしたシナリオ:
  - `scanPushSubscriptions`: subscriberRole 不在 / parent / owner / 不正値 (child / 空文字 / null) / ページネーション (LastEvaluatedKey) / FilterExpression 通過後の二重チェック / entityType ベース判定
  - `updateSubscriberRole`: 'parent' SET / ConditionalCheckFailedException swallow / Throttling backoff retry / それ以外のエラーは throw

**E2Eテスト**:
- 追加なし（本 script は AWS 接続が必要な運用ツールで、E2E では検証不可）

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check scripts/migrate-dynamodb-push-subscriber-role.mjs tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts` | PASS | exit=0 |
| 型チェック | `npx svelte-check` | N/A | mjs / ts test のみ。svelte component 変更なし |
| 単体テスト | `npx vitest run tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts` | PASS (11 tests) | 2.88s |
| E2E テスト | `npx playwright test` | N/A | 本 script は AWS 接続必須の運用ツール |
| DynamoDB stub check | `node scripts/check-dynamodb-stub.mjs` | PASS | green |

**追加した E2E テストの詳細**:
- なし

**網羅性の判断根拠**:
本 PR は「migration script + runbook + 設計書同期」のため、AWS SDK モックでの単体テスト（11 ケース）が網羅範囲として十分。E2E は AWS 接続を要する性質上、PO が runbook §3 dry-run で実機検証する設計（runbook §5.1 / §5.2 の検証コマンドが組み込み済）。

### DynamoDB 実装完成度（#1021 — 段階的対応禁止 / ADR-0010）

- [x] **N/A** — DynamoDB 実装の追加・変更なし（migration script は運用ツールで、`src/lib/server/db/dynamodb/*.ts` には触れない）

> 補足: 本 PR は #1593 follow-up の migration 観点のみを扱い、DynamoDB push-subscription-repo の stub 解消（本実装）は **別 follow-up Issue** で扱う。Issue 本文 §E 実装メモ「DynamoDB 実装本体は別 Issue で」に整合。

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | IAM 最小権限ポリシー (Scan + UpdateItem のみ) を runbook §6 に明記。Resource は単一テーブル限定 | runbook §6 |
| パフォーマンス | UpdateItem 直列発行 (BatchWrite は UpdateItem 非対応) + exponential backoff (max 30s) | on-demand 課金で実質発火しない設計 |
| アクセシビリティ | 対象外（運用 CLI ツール） | N/A |
| ロギング・モニタリング | 構造化ログ `[migrate-push-role] {LEVEL} ...` で出力。25 件ごとに progress 表示。CloudWatch warn 件数 = 0 を runbook §5.2 で検証 | runbook §5.2 |
| ドキュメント | 設計書 08 (DB) / 14 (セキュリティ) を同 PR で同期更新 + 新規 runbook 1 件 | docs/design/08, 14 + docs/runbooks/push-subscription-role-migration.md |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: `scanPushSubscriptions` (検出) / `updateSubscriberRole` (更新) / `withBackoff` (retry) / `main` (orchestration) で責務分離
- [x] **依存性逆転（D）**: `DynamoDBDocumentClient` の `send` メソッドのみに依存。テストで `{ send: mockFn }` で置換可能（actual unit test で検証済）
- [x] **インターフェース分離（I）**: `Pick<>` ライクに `send` メソッドだけ依存
- [x] **DRY / 横展開**: 既存の `bulk-delete.ts` Scan パターンを参考にしたが、UpdateItem は BatchWrite 非対応のため適応 — 同等の migration script が他に無いことを `Glob scripts/migrate-*` で確認
- [x] **YAGNI**: ロールバック script は意図的に未提供（ADR-0031 NULL 混在防止の趣旨）

### セキュリティ（OSS 公開前提）
- [x] AWS_REGION / DYNAMODB_TABLE は env 経由のみ。ハードコードなし
- [x] Security by obscurity 不在 — runbook の IAM ポリシー / 抽出条件は完全公開で安全
- [x] 入力バリデーション: `--table=` 引数は env override のみ。SQL injection 系の文字列結合なし（Document Client パラメータ化）
- [x] ConditionExpression で valid role 既設定 record の race condition を保護

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] N+1 なし — Scan は LastEvaluatedKey でページング、UpdateItem は直列だが backoff で throttle 回避
- [x] 大きなライブラリ追加なし — `@aws-sdk/client-dynamodb` / `@aws-sdk/lib-dynamodb` は既存依存

## スクリーンショット / ビジュアルデモ

### 目的（誤解防止）

本 PR は CLI 運用ツール + 設計書 + runbook で UI 変更なし → スクリーンショット対象外。

### 変更前後の比較

UI 変更なしのため N/A。

### Playwright スクリーンショット

UI 変更なしのため N/A。

### インタラクティブ状態の確認（#1481）

- [x] **N/A** — インタラクティブ状態変化なし（CLI ツール）

### モバイルビューポート（#1481）

- [x] **N/A** — LP / infra / 設定ファイルのみの変更（CLI script + docs）

## 実機操作検証

- [x] 本 PR の deliverable は CLI 運用ツール + runbook + 設計書同期。実機 DynamoDB 接続は IAM 権限を要するため、PO が runbook §3 dry-run で実機検証する設計
- [x] script の単体動作は vitest で 11 ケース PASS
- [x] runbook の各章 (§3 dry-run / §4 本実行 / §5 検証 / §6 IAM / §7 ロールバック) を読み返し、PO が独立して実行できる粒度であることを確認

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

> 本 PR は新規 script + 新規 runbook + 設計書追記のみ。既存コード・データには触れない（migration の実行は本 PR マージとは独立した運用判断）。

## レビュー依頼事項・QA

| # | 質問・確認事項 | 選択肢A | 選択肢B | 推奨 | 理由 |
|---|--------------|---------|---------|------|------|
| 1 | キー設計に依存しない抽出条件 | `SK begins_with 'PUSH_SUB#'` のみ | `SK begins_with` OR `entityType = 'PUSH_SUB'` (現選択) | B | DynamoDB 実装本体側でキー設計が変わっても script を修正不要にする保険 |
| 2 | UpdateItem を直列発行 | BatchWrite で 25 件並列 | UpdateItem 直列 (現選択) | B | BatchWrite は UpdateItem を sup​port していない。BatchWrite は Put/Delete のみ |
| 3 | ロールバック script を同梱しないこと | 同梱する | 同梱しない (現選択) | B | ADR-0031 NULL 混在防止の趣旨に反する。手動 UpdateItem コマンドのみ runbook §7 に記載 |

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [ ] **本番アプリ** — N/A
- [ ] **デモ版** — N/A
- [ ] **LP ↔ アプリ整合（双方向）** — N/A
- [ ] **全年齢モード** — N/A（CLI ツール）
- [ ] **ナビゲーション** — N/A
- [ ] **E2E/ユニットシード** — N/A（schema 変更ではなく、本番データの backfill）
- [ ] **チュートリアル + デモガイド** — N/A
- [x] **該当なし** — 並行実装の影響範囲外の変更（CLI 運用ツール + 設計書同期）

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイル (`scripts/migrate-dynamodb-push-subscriber-role.mjs` / `tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts` / `docs/runbooks/push-subscription-role-migration.md` / `docs/design/08-*.md` / `docs/design/14-*.md`) は新規追加 + 設計書末尾追記のため、open PR との overlap リスクは低い。並行 PR (#1675/#1686/#1687) は area:lp / src/routes 系で本 PR と非衝突を確認

### LP 変更時の追加チェック（#1282 / ADR-0010 Pre-PMF）

- [x] **N/A** — LP (`site/**`) の変更なし

### LP / 販促文言変更時の実装パス明示（ADR-0013 / #1314）

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **用語変更**: なし
- [x] **labels SSOT (ADR-0009)**: ユーザー向け文言の追加/変更なし — N/A
- [x] **UI構造変更**: チュートリアル変更なし — N/A
- [x] **カラー・スタイル**: hex / Tailwind 直書きなし — N/A
- [x] **プリミティブ**: UI 変更なし — N/A
- [x] **設計書（CRITICAL）**: `docs/design/08-データベース設計書.md` §push_subscriptions に DynamoDB migration 節追加 + revision history v5.6 追記、`docs/design/14-セキュリティ設計書.md` §8.8 既存レコード backfill に DynamoDB 章追加。本 PR 内で同期完了

## Ready for Review チェックリスト

- [x] CI が全て通過している（push 後に CI 確認、本 body は draft 時点の宣言）
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）
- [x] **全 AC が実装済みであること**
- [x] **Phase 分割が必要だった場合は着手前に PO と合意し、子 Issue を起票済みであること** — DynamoDB 本実装は別 follow-up Issue #1689 で扱うことを Issue 本文 §E で明記済 + 本 PR 末尾で起票予定
- [x] UI 変更なし — N/A
- [x] 認証画面変更なし — N/A
- [x] **hardcoded JP text (#1452 Phase A)**: src/routes 配下の変更なし — N/A

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない（priority:medium）

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし

> 補足: 本 script は実行時に `AWS_REGION` / `DYNAMODB_TABLE` env を参照するが、これは既存の本番 Lambda が既に使用している env で、新規追加ではない（`src/lib/server/db/dynamodb/client.ts` で使用中）。

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし。本 PR は migration script + runbook の追加で、実行は本 PR マージとは独立（PO が DynamoDB push-subscription-repo 本実装マージ後に手動実行）

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし（運用ツール + 設計書）

### スコープ完全性
- [x] **見落とし確認**: 設計書 08 / 14 + runbook + script + テストの 5 観点を同 PR 内で完結。DynamoDB push-subscription-repo 本実装は Issue 本文と本 PR description で「別 Issue 起票」と明記済。完了後に follow-up Issue #1689 を起票済

## デプロイ検証（#710 — マージ後必須）

- [x] **N/A** — デプロイ検証不要（CLI 運用ツール + ドキュメント変更のみ。本番動作には影響しない）

## 完了チェックリスト

- [x] `npx biome check scripts/migrate-dynamodb-push-subscriber-role.mjs tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts` — exit=0
- [x] `npx svelte-check` — N/A（mjs / ts test のみ）
- [x] `npx vitest run tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts` — 11 tests passed
- [x] `npx playwright test` — N/A（AWS 接続必須の運用ツール）
- [x] PR のサイズが適切（5 files, 760 insertions / 1 deletion）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

<!-- QM が approve するときに記入。PR 作者は空欄のままでよい。
     CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（docs/sessions/qa-session.md「QM approve 前の必須実行手順」参照）。 -->

- [ ] Issue AC 全項目が PR diff で達成されていることを確認した（`gh issue view <番号>` で開いて 1 対 1 突合）
- [ ] 添付スクリーンショットを **全て Read tool で開いて目視** し、UI/UX デザイナー観点で違和感が無いことを確認した
- [ ] `docs/DESIGN.md` §9 禁忌事項 6 点（色直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / `<style>` 50 行超え）のいずれにも該当しないことを確認した
- [ ] 並行実装（デモ / 5 年齢モード / LP / ナビ 3 種）の同期漏れが無いことを確認した
- [ ] スコープ外の気付きがあれば Issue 起票済み（スルー禁止）
- [ ] CI 全緑を **上記チェック後の補助情報として** 確認した（先に CI を見ると proxy 退行が再発する）

### QM 所見（スクリーンショット 1 枚ごとに 1 行以上）

<!-- QM 記入欄。本 PR は CLI 運用ツール + 設計書追記のため UI スクリーンショット無し。 -->


