### PR TITLE
feat: #1689 #1666 follow-up — DynamoDB push-subscription-repo 本実装 (stub 解消)

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -543,6 +543,42 @@ SQLite (NUC) は `scripts/migrate-local.ts` で既存レコードを default `'p
 | 実行タイミング | DynamoDB push-subscription-repo の本実装マージ後、運用担当が一度だけ実行 |
 | 検証 | CloudWatch Logs `[notification] 非 parent/owner role の subscription への送信をスキップ` warn 件数 = 0 |
 
+#### #1689 DynamoDB キー設計（push_subscription / notification_log 単一テーブル）
+
+##### 設計背景
+
+`push_subscriptions` / `notification_logs` テーブルは SQLite (NUC) で先行実装され、本番 AWS 側 (`src/lib/server/db/dynamodb/push-subscription-repo.ts`) は #1666 PR merge 時点では `Not implemented` stub のままだった (#1021 段階的リリース禁止に抵触)。本 Issue (#1689) で SQLite 機能等価の DynamoDB 本実装を起こし stub を解消する。
+
+##### 設計原則
+
+1. **Pre-PMF 規模での GSI 不要原則** (ADR-0010): 1 家族あたり <10 デバイス・<100 通知/日 の規模では PK 単一 Query で十分。追加 GSI を作ると DynamoDB ストレージコストが線形に増える上、新規 IAM 権限・運用上の障害点も増える。
+2. **migration script (#1666) との SK prefix 互換**: 既存の `scripts/migrate-dynamodb-push-subscriber-role.mjs` が `begins_with(SK, 'PUSH_SUB#')` で対象を Scan する設計のため、SK 規約は `PUSH_SUB#<...>` を厳守する。
+3. **endpoint 単位の高速 lookup**: `findByEndpoint(endpoint, tenantId)` は `(endpoint, tenantId)` の組で呼ばれるため、endpoint の SHA-256 ハッシュ (先頭 16 hex) を SK に埋め込み、PK + SK で GetItem 1 回で取得する。Scan 不要。
+4. **subscriberRole 必須属性** (#1593 ADR-0023 I6): PutItem 時に `'parent' | 'owner'` を必ず付与。不正値 (旧 `'child'` / NULL / 空文字列) は送信側 (`notification-service.ts`) で skip される二重防御。
+
+##### キー設計表
+
+| エンティティ | PK | SK | 補足 |
+|------------|----|----|------|
+| push_subscription | `T#<tenantId>#PUSH_SUB` | `PUSH_SUB#<endpointHash>` | endpointHash = SHA-256(endpoint) 先頭 16 hex (64 bit、衝突確率 < 10^-9 / 同一テナント内) |
+| notification_log | `T#<tenantId>#NOTIF_LOG` | `NOTIF#<sentAt>#<paddedId>` | sentAt = ISO 8601 (`YYYY-MM-DDTHH:mm:ss.sssZ`)、paddedId = `nextId('notificationLog', tenantId)` を 8 桁 0 埋め |
+
+##### アクセスパターン
+
+| 関数 | DynamoDB 操作 | キー条件 |
+|------|--------------|---------|
+| `findByTenant(tenantId)` | Query | `PK = T#<tid>#PUSH_SUB AND begins_with(SK, 'PUSH_SUB#')` |
+| `findByEndpoint(endpoint, tenantId)` | GetItem | `PK = T#<tid>#PUSH_SUB, SK = PUSH_SUB#<endpointHash>` (取得後に endpoint 完全一致で hash 衝突を二重チェック) |
+| `insert(input)` | PutItem | counter で id 採番 → 上記キーで PutItem |
+| `deleteByEndpoint(endpoint, tenantId)` | DeleteItem | `PK = T#<tid>#PUSH_SUB, SK = PUSH_SUB#<endpointHash>` |
+| `insertLog(input)` | PutItem | counter で id 採番 → `PK = T#<tid>#NOTIF_LOG, SK = NOTIF#<sentAt>#<paddedId>` |
+| `countTodayLogs(tenantId, today)` | Query (`Select=COUNT`) | `PK = T#<tid>#NOTIF_LOG AND SK BETWEEN 'NOTIF#<today>T00:00:00' AND 'NOTIF#<today>T99:99:99'` |
+| `findRecentLogs(tenantId, limit)` | Query (`ScanIndexForward=false`) | `PK = T#<tid>#NOTIF_LOG AND begins_with(SK, 'NOTIF#') LIMIT <limit>` |
+
+##### CDK 変更有無
+
+CDK (`infra/lib/storage-stack.ts`) の `MainTable` は単一テーブル設計 (PK + SK + GSI1 + GSI2) を既に有しており、本 Issue は **追加 GSI なしで実現できるため CDK 変更不要**。新規 PK prefix (`T#<tid>#PUSH_SUB` / `T#<tid>#NOTIF_LOG`) は既存テーブルにそのまま乗る。
+
 ### notification_logs
 
 通知送信ログ。レート制限（3通/日）と監査に使用。
@@ -1908,3 +1944,4 @@ src/lib/server/db/migration/
 | 2026-04-29 | 5.5 | #1598 (ADR-0023 §3.6 §5 I7) PMF 判定アンケート用 settings KV キー 3 種を §3 settings に追加: `pmf_survey_sent_<round>` (配信履歴 / 半期 round 内重複防止) / `pmf_survey_response_<round>` (回答 JSON) / `marketing_email_count_<year>` (lifecycle-emails 共有カウンタ、年 6 回上限)。新規テーブル追加せず settings KV を流用 (Pre-PMF シンプル化、ADR-0010)。DynamoDB: `T#<tid>#SETTING#pmf_survey_*` で同一構造 |
 | 2026-04-29 | 5.6 | #1666 (#1593 follow-up, ADR-0023 I6) DynamoDB 側 push_subscription `subscriberRole` 必須化を §push_subscriptions に明記。migration script (`scripts/migrate-dynamodb-push-subscriber-role.mjs`) + runbook (`docs/runbooks/push-subscription-role-migration.md`) を整備。実行は DynamoDB push-subscription-repo 本実装マージ後（別 follow-up Issue で扱う）。idempotent / `--dry-run` モード / 検証は CloudWatch warn 件数 = 0 |
 | 2026-04-29 | 5.7 | #1603 (ADR-0023 §3.8 / §5 I10) `graduation_consent` テーブル追加。卒業フロー専用ページ (`/admin/billing/cancel/graduation`) で「卒業」を選択した親が任意で提出する事例公開承諾 + 利用期間記録。DynamoDB は `PK=GRADUATION_CONSENT` single-partition (#1596 同パターン)。`idx_graduation_consent_tenant` / `_consented_date` / `_date` インデックス付き。実名禁止 (nickname 任意指定 30 文字以内) + 撤回フローを `site/privacy.html` 第6条の2 に記載 |
+| 2026-04-29 | 5.8 | #1689 (#1666 follow-up, ADR-0023 I6 / ADR-0010 / #1021 段階的リリース禁止) DynamoDB `push-subscription-repo.ts` を SQLite 機能等価で本実装。stub 解消。キー設計: `push_subscription` = PK `T#<tid>#PUSH_SUB` + SK `PUSH_SUB#<endpointHash>` (SHA-256 16hex), `notification_log` = PK `T#<tid>#NOTIF_LOG` + SK `NOTIF#<sentAt>#<paddedId>`。追加 GSI 不要 (Pre-PMF 規模)、CDK 変更不要。migration script (#1666) との SK prefix 互換を維持。詳細は §push_subscriptions §1689 参照 |

--- a/src/lib/server/db/dynamodb/keys.ts
+++ b/src/lib/server/db/dynamodb/keys.ts
@@ -2,6 +2,8 @@
 // PK/SK generation helpers for single-table design
 // All entity keys are defined here for type-safe, consistent key construction.
 
+import { createHash } from 'node:crypto';
+
 // ============================================================
 // Numeric ID padding (8 digits for lexicographic sort)
 // ============================================================
@@ -28,6 +30,8 @@ const PREFIX = {
 	CKTPL: 'CKTPL',
 	BENCH: 'BENCH',
 	INQUIRY: 'INQUIRY',
+	PUSH_SUB: 'PUSH_SUB',
+	NOTIF_LOG: 'NOTIF_LOG',
 } as const;
 
 // ============================================================
@@ -509,6 +513,66 @@ export function counterKey(entity: string, tenantId: string): DynamoKey {
 }
 
 // ============================================================
+// Push subscription / notification log (#1689 / ADR-0023 I6)
+// ============================================================
+//
+// 設計方針:
+//   - Tenant 単位の write/read のみがアクセスパターン (低頻度: 1 デバイス/家族 想定)
+//   - findByEndpoint は (endpoint, tenantId) を受けるため endpointHash で SK lookup → GetItem 1 回
+//   - 追加 GSI は Pre-PMF 規模では不要 (ADR-0010 過剰防衛禁止)
+//   - migration script (#1666) は SK が `PUSH_SUB#` 始まりの item を Scan する設計のため、
+//     SK = `PUSH_SUB#<endpointHash>` の規約を厳守すること
+
+const PUSH_SUB_HASH_LENGTH = 16; // SHA-256 16 hex chars (64 bit) — 衝突確率 < 10^-9
+
+/**
+ * Endpoint の決定的ハッシュを生成する。
+ * Service Worker push endpoint URL は長い (200+ chars) ため、SHA-256 先頭 16 桁を SK に使う。
+ *
+ * 衝突対策: 同一テナント内で 2^32 個の異なる endpoint がない限り衝突しない (生年単位 1 家族 < 10 デバイス想定)。
+ * 万一衝突しても tenantId 範囲なので影響範囲は単一家族の 1 通知のみ。
+ */
+export function pushSubscriptionEndpointHash(endpoint: string): string {
+	return createHash('sha256').update(endpoint).digest('hex').slice(0, PUSH_SUB_HASH_LENGTH);
+}
+
+/** Push subscription: PK=T#<tenantId>#PUSH_SUB, SK=PUSH_SUB#<endpointHash> */
+export function pushSubscriptionKey(tenantId: string, endpointHash: string): DynamoKey {
+	return {
+		PK: tenantPK(PREFIX.PUSH_SUB, tenantId),
+		SK: `${PREFIX.PUSH_SUB}#${endpointHash}`,
+	};
+}
+
+/** Push subscription PK for tenant Query */
+export function pushSubscriptionTenantPK(tenantId: string): string {
+	return tenantPK(PREFIX.PUSH_SUB, tenantId);
+}
+
+/** Push subscription SK prefix for filtering */
+export function pushSubscriptionSKPrefix(): string {
+	return `${PREFIX.PUSH_SUB}#`;
+}
+
+/** Notification log: PK=T#<tenantId>#NOTIF_LOG, SK=NOTIF#<sentAt>#<id> */
+export function notificationLogKey(tenantId: string, sentAt: string, id: number): DynamoKey {
+	return {
+		PK: tenantPK(PREFIX.NOTIF_LOG, tenantId),
+		SK: `NOTIF#${sentAt}#${padId(id)}`,
+	};
+}
+
+/** Notification log PK for tenant Query */
+export function notificationLogTenantPK(tenantId: string): string {
+	return tenantPK(PREFIX.NOTIF_LOG, tenantId);
+}
+
+/** Notification log SK prefix for date-range queries */
+export function notificationLogDatePrefix(date: string): string {
+	return `NOTIF#${date}`;
+}
+
+// ============================================================
 // GSI2 key builders (for category-based activity queries)
 // ============================================================
 
@@ -561,6 +625,8 @@ export const ENTITY_NAMES = {
 	activityMastery: 'activityMastery',
 	inquiry: 'inquiry',
 	voice: 'voice',
+	pushSubscription: 'pushSubscription',
+	notificationLog: 'notificationLog',
 } as const;
 
 export type EntityName = (typeof ENTITY_NAMES)[keyof typeof ENTITY_NAMES];

--- a/src/lib/server/db/dynamodb/push-subscription-repo.ts
+++ b/src/lib/server/db/dynamodb/push-subscription-repo.ts
@@ -1,42 +1,293 @@
+// src/lib/server/db/dynamodb/push-subscription-repo.ts
+// DynamoDB implementation of IPushSubscriptionRepo
+//
+// #1689 (#1666 follow-up — ADR-0023 I6 / ADR-0010 / #1021 段階的リリース禁止)
+//
+// 設計方針:
+//   - SQLite 実装 (src/lib/server/db/sqlite/push-subscription-repo.ts) と機能等価
+//   - キー設計:
+//       push_subscription:  PK = T#<tenantId>#PUSH_SUB,  SK = PUSH_SUB#<endpointHash>
+//       notification_log:   PK = T#<tenantId>#NOTIF_LOG, SK = NOTIF#<sentAt>#<paddedId>
+//   - 追加 GSI なし: Pre-PMF 規模 (1家族あたり <10 デバイス, <100 通知/日) では PK Query で十分
+//   - subscriberRole は必須属性として PutItem 時に付与 (#1593 ADR-0023 I6 二重防御)
+//   - migration script (#1666) と同じ SK = `PUSH_SUB#` prefix 規約を使用
+
+import {
+	DeleteCommand,
+	GetCommand,
+	PutCommand,
+	QueryCommand,
+	type QueryCommandInput,
+} from '@aws-sdk/lib-dynamodb';
 import type {
 	InsertNotificationLogInput,
 	InsertPushSubscriptionInput,
 	NotificationLog,
+	PushSubscriberRole,
 	PushSubscriptionRecord,
 } from '../types';
+import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
+import {
+	notificationLogDatePrefix,
+	notificationLogKey,
+	notificationLogTenantPK,
+	pushSubscriptionEndpointHash,
+	pushSubscriptionKey,
+	pushSubscriptionSKPrefix,
+	pushSubscriptionTenantPK,
+} from './keys';
 
-const NOT_IMPL = 'DynamoDB push-subscription-repo not implemented';
+// ============================================================
+// Item types (DynamoDB attribute layout)
+// ============================================================
 
-export async function findByTenant(_tenantId: string): Promise<PushSubscriptionRecord[]> {
-	throw new Error(NOT_IMPL);
+interface PushSubscriptionItem {
+	PK: string;
+	SK: string;
+	id: number;
+	tenantId: string;
+	endpoint: string;
+	keysP256dh: string;
+	keysAuth: string;
+	userAgent: string | null;
+	subscriberRole: PushSubscriberRole;
+	createdAt: string;
+}
+
+interface NotificationLogItem {
+	PK: string;
+	SK: string;
+	id: number;
+	tenantId: string;
+	notificationType: string;
+	title: string;
+	body: string;
+	sentAt: string;
+	success: number; // 0 / 1 (SQLite 互換のため number で保持)
+	errorMessage: string | null;
+}
+
+// ============================================================
+// Mappers
+// ============================================================
+
+function mapPushItem(item: Record<string, unknown>): PushSubscriptionRecord {
+	const i = item as unknown as PushSubscriptionItem;
+	// #1593 backfill 観点: 不正値 ('child' / NULL / 空文字列) は string のまま渡す。
+	// 送信側 (notification-service) で skip される二重防御があるため、ここでは再キャストしない。
+	return {
+		id: i.id,
+		tenantId: i.tenantId,
+		endpoint: i.endpoint,
+		keysP256dh: i.keysP256dh,
+		keysAuth: i.keysAuth,
+		userAgent: i.userAgent ?? null,
+		subscriberRole: i.subscriberRole,
+		createdAt: i.createdAt,
+	};
+}
+
+function mapLogItem(item: Record<string, unknown>): NotificationLog {
+	const i = item as unknown as NotificationLogItem;
+	return {
+		id: i.id,
+		tenantId: i.tenantId,
+		notificationType: i.notificationType,
+		title: i.title,
+		body: i.body,
+		sentAt: i.sentAt,
+		success: i.success,
+		errorMessage: i.errorMessage ?? null,
+	};
+}
+
+// ============================================================
+// Push subscription operations
+// ============================================================
+
+export async function findByTenant(tenantId: string): Promise<PushSubscriptionRecord[]> {
+	const all: PushSubscriptionRecord[] = [];
+	let exclusiveStartKey: Record<string, unknown> | undefined;
+	const pk = pushSubscriptionTenantPK(tenantId);
+	const skPrefix = pushSubscriptionSKPrefix();
+
+	do {
+		const input: QueryCommandInput = {
+			TableName: TABLE_NAME,
+			KeyConditionExpression: 'PK = :pk AND begins_with(SK, :skPrefix)',
+			ExpressionAttributeValues: {
+				':pk': pk,
+				':skPrefix': skPrefix,
+			},
+			ExclusiveStartKey: exclusiveStartKey,
+		};
+		const res = await getDocClient().send(new QueryCommand(input));
+		for (const item of res.Items ?? []) {
+			all.push(mapPushItem(item));
+		}
+		exclusiveStartKey = res.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (exclusiveStartKey);
+
+	return all;
 }
 
 export async function findByEndpoint(
-	_endpoint: string,
-	_tenantId: string,
+	endpoint: string,
+	tenantId: string,
 ): Promise<PushSubscriptionRecord | undefined> {
-	throw new Error(NOT_IMPL);
+	const endpointHash = pushSubscriptionEndpointHash(endpoint);
+	const key = pushSubscriptionKey(tenantId, endpointHash);
+	const res = await getDocClient().send(
+		new GetCommand({
+			TableName: TABLE_NAME,
+			Key: key,
+		}),
+	);
+	if (!res.Item) return undefined;
+	// 念のため endpoint 完全一致で確認（hash 衝突対策の二重防御）
+	const record = mapPushItem(res.Item);
+	if (record.endpoint !== endpoint) return undefined;
+	return record;
 }
 
-export async function insert(_input: InsertPushSubscriptionInput): Promise<PushSubscriptionRecord> {
-	throw new Error(NOT_IMPL);
+export async function insert(input: InsertPushSubscriptionInput): Promise<PushSubscriptionRecord> {
+	const createdAt = new Date().toISOString();
+	const id = await nextId('pushSubscription', input.tenantId);
+	const endpointHash = pushSubscriptionEndpointHash(input.endpoint);
+
+	const item: PushSubscriptionItem = {
+		...pushSubscriptionKey(input.tenantId, endpointHash),
+		id,
+		tenantId: input.tenantId,
+		endpoint: input.endpoint,
+		keysP256dh: input.keysP256dh,
+		keysAuth: input.keysAuth,
+		userAgent: input.userAgent ?? null,
+		subscriberRole: input.subscriberRole satisfies PushSubscriberRole,
+		createdAt,
+	};
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: item,
+		}),
+	);
+
+	return {
+		id,
+		tenantId: input.tenantId,
+		endpoint: input.endpoint,
+		keysP256dh: input.keysP256dh,
+		keysAuth: input.keysAuth,
+		userAgent: input.userAgent ?? null,
+		subscriberRole: input.subscriberRole,
+		createdAt,
+	};
 }
 
-export async function deleteByEndpoint(_endpoint: string, _tenantId: string): Promise<void> {
-	throw new Error(NOT_IMPL);
+export async function deleteByEndpoint(endpoint: string, tenantId: string): Promise<void> {
+	const endpointHash = pushSubscriptionEndpointHash(endpoint);
+	const key = pushSubscriptionKey(tenantId, endpointHash);
+	await getDocClient().send(
+		new DeleteCommand({
+			TableName: TABLE_NAME,
+			Key: key,
+		}),
+	);
 }
 
-export async function insertLog(_input: InsertNotificationLogInput): Promise<NotificationLog> {
-	throw new Error(NOT_IMPL);
+// ============================================================
+// Notification log operations
+// ============================================================
+
+export async function insertLog(input: InsertNotificationLogInput): Promise<NotificationLog> {
+	const sentAt = new Date().toISOString();
+	const id = await nextId('notificationLog', input.tenantId);
+	const successInt = input.success ? 1 : 0;
+
+	const item: NotificationLogItem = {
+		...notificationLogKey(input.tenantId, sentAt, id),
+		id,
+		tenantId: input.tenantId,
+		notificationType: input.notificationType,
+		title: input.title,
+		body: input.body,
+		sentAt,
+		success: successInt,
+		errorMessage: input.errorMessage ?? null,
+	};
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: item,
+		}),
+	);
+
+	return {
+		id,
+		tenantId: input.tenantId,
+		notificationType: input.notificationType,
+		title: input.title,
+		body: input.body,
+		sentAt,
+		success: successInt,
+		errorMessage: input.errorMessage ?? null,
+	};
 }
 
-export async function countTodayLogs(_tenantId: string, _today: string): Promise<number> {
-	throw new Error(NOT_IMPL);
+/**
+ * 当日 (today) の通知ログ件数をカウント。
+ * SQLite 実装と一致: today (YYYY-MM-DD) 始まりの sentAt 範囲を集計。
+ *
+ * SK = `NOTIF#<sentAt>#<paddedId>` のため `NOTIF#<today>T00:00:00` ~ `NOTIF#<today>T99:99:99`
+ * の範囲 Query で当日分を抽出可能 (sentAt は ISO 8601、辞書順比較で OK)。
+ */
+export async function countTodayLogs(tenantId: string, today: string): Promise<number> {
+	const pk = notificationLogTenantPK(tenantId);
+	const skStart = `${notificationLogDatePrefix(today)}T00:00:00`;
+	const skEnd = `${notificationLogDatePrefix(today)}T99:99:99`;
+
+	let count = 0;
+	let exclusiveStartKey: Record<string, unknown> | undefined;
+	do {
+		const input: QueryCommandInput = {
+			TableName: TABLE_NAME,
+			KeyConditionExpression: 'PK = :pk AND SK BETWEEN :skStart AND :skEnd',
+			ExpressionAttributeValues: {
+				':pk': pk,
+				':skStart': skStart,
+				':skEnd': skEnd,
+			},
+			Select: 'COUNT',
+			ExclusiveStartKey: exclusiveStartKey,
+		};
+		const res = await getDocClient().send(new QueryCommand(input));
+		count += res.Count ?? 0;
+		exclusiveStartKey = res.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (exclusiveStartKey);
+
+	return count;
 }
 
-export async function findRecentLogs(
-	_tenantId: string,
-	_limit: number,
-): Promise<NotificationLog[]> {
-	throw new Error(NOT_IMPL);
+/**
+ * 最新の通知ログ N 件を返す (sentAt 降順)。
+ * SK が `NOTIF#<sentAt>#<id>` で時刻順なので ScanIndexForward=false で逆順 + Limit。
+ */
+export async function findRecentLogs(tenantId: string, limit: number): Promise<NotificationLog[]> {
+	const pk = notificationLogTenantPK(tenantId);
+	const input: QueryCommandInput = {
+		TableName: TABLE_NAME,
+		KeyConditionExpression: 'PK = :pk AND begins_with(SK, :skPrefix)',
+		ExpressionAttributeValues: {
+			':pk': pk,
+			':skPrefix': 'NOTIF#',
+		},
+		ScanIndexForward: false, // 降順
+		Limit: limit,
+	};
+	const res = await getDocClient().send(new QueryCommand(input));
+	return (res.Items ?? []).map(mapLogItem);
 }

--- a/tests/unit/db/dynamodb-push-subscription-repo.test.ts
+++ b/tests/unit/db/dynamodb-push-subscription-repo.test.ts
@@ -1,0 +1,495 @@
+/**
+ * tests/unit/db/dynamodb-push-subscription-repo.test.ts
+ *
+ * #1689 (#1666 follow-up — ADR-0023 I6 / ADR-0010 / #1021 段階的リリース禁止)
+ *
+ * DynamoDB push-subscription-repo の本実装単体テスト。
+ * AWS SDK を hoisted mock で置き換え、SQLite 機能等価の 7 関数を網羅する。
+ *
+ * テスト戦略:
+ *   - findByTenant / findByEndpoint / insert / deleteByEndpoint / insertLog /
+ *     countTodayLogs / findRecentLogs を全て個別 describe で検証
+ *   - 各関数で送信される Command の input (KeyConditionExpression / Key 等) を assert
+ *   - subscriberRole 必須属性が PutItem に含まれることを確認 (#1593 ADR-0023 I6)
+ *   - 機能等価性: SQLite と同じ入出力契約 (PushSubscriptionRecord / NotificationLog)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock setup (vi.hoisted で先にモック関数とコマンドクラスを確保)
+const {
+	mockSend,
+	MockGetCommand,
+	MockPutCommand,
+	MockQueryCommand,
+	MockDeleteCommand,
+	MockUpdateCommand,
+} = vi.hoisted(() => {
+	const send = vi.fn();
+	class GetCmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	class PutCmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	class QueryCmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	class DeleteCmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	class UpdateCmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	return {
+		mockSend: send,
+		MockGetCommand: GetCmd,
+		MockPutCommand: PutCmd,
+		MockQueryCommand: QueryCmd,
+		MockDeleteCommand: DeleteCmd,
+		MockUpdateCommand: UpdateCmd,
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	GetCommand: MockGetCommand,
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	DeleteCommand: MockDeleteCommand,
+	UpdateCommand: MockUpdateCommand,
+}));
+
+// SUT — モック適用後に動的 import
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/push-subscription-repo');
+}
+
+const TENANT_ID = 'tenant-1';
+const ENDPOINT = 'https://fcm.googleapis.com/fcm/send/abc-def-123';
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// findByTenant
+// ============================================================
+
+describe('findByTenant', () => {
+	it('Query で tenant の全レコードを返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				{
+					PK: 'T#tenant-1#PUSH_SUB',
+					SK: 'PUSH_SUB#abc',
+					id: 1,
+					tenantId: TENANT_ID,
+					endpoint: ENDPOINT,
+					keysP256dh: 'p256dh-1',
+					keysAuth: 'auth-1',
+					userAgent: 'Chrome',
+					subscriberRole: 'parent',
+					createdAt: '2026-04-29T00:00:00.000Z',
+				},
+			],
+		});
+
+		const { findByTenant } = await loadRepo();
+		const result = await findByTenant(TENANT_ID);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			id: 1,
+			tenantId: TENANT_ID,
+			endpoint: ENDPOINT,
+			subscriberRole: 'parent',
+		});
+		// QueryCommand に PK 条件が含まれる
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: {
+				KeyConditionExpression?: string;
+				ExpressionAttributeValues?: Record<string, string>;
+			};
+		};
+		expect(callArg.input.KeyConditionExpression).toContain('PK = :pk');
+		expect(callArg.input.ExpressionAttributeValues?.[':pk']).toBe('T#tenant-1#PUSH_SUB');
+	});
+
+	it('LastEvaluatedKey でページングする', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [
+					{
+						PK: 'T#tenant-1#PUSH_SUB',
+						SK: 'PUSH_SUB#1',
+						id: 1,
+						tenantId: TENANT_ID,
+						endpoint: 'e1',
+						keysP256dh: 'p1',
+						keysAuth: 'a1',
+						userAgent: null,
+						subscriberRole: 'parent',
+						createdAt: '2026-04-29T00:00:00.000Z',
+					},
+				],
+				LastEvaluatedKey: { PK: 'cursor', SK: 'cursor' },
+			})
+			.mockResolvedValueOnce({
+				Items: [
+					{
+						PK: 'T#tenant-1#PUSH_SUB',
+						SK: 'PUSH_SUB#2',
+						id: 2,
+						tenantId: TENANT_ID,
+						endpoint: 'e2',
+						keysP256dh: 'p2',
+						keysAuth: 'a2',
+						userAgent: null,
+						subscriberRole: 'parent',
+						createdAt: '2026-04-29T00:00:00.000Z',
+					},
+				],
+				LastEvaluatedKey: undefined,
+			});
+
+		const { findByTenant } = await loadRepo();
+		const result = await findByTenant(TENANT_ID);
+		expect(result).toHaveLength(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+
+	it('レコード 0 件のときは空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findByTenant } = await loadRepo();
+		const result = await findByTenant(TENANT_ID);
+		expect(result).toEqual([]);
+	});
+});
+
+// ============================================================
+// findByEndpoint
+// ============================================================
+
+describe('findByEndpoint', () => {
+	it('endpoint hash → GetItem で 1 件取得する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Item: {
+				PK: 'T#tenant-1#PUSH_SUB',
+				SK: 'PUSH_SUB#aabbccdd11223344',
+				id: 7,
+				tenantId: TENANT_ID,
+				endpoint: ENDPOINT,
+				keysP256dh: 'p1',
+				keysAuth: 'a1',
+				userAgent: 'Safari',
+				subscriberRole: 'owner',
+				createdAt: '2026-04-29T00:00:00.000Z',
+			},
+		});
+
+		const { findByEndpoint } = await loadRepo();
+		const result = await findByEndpoint(ENDPOINT, TENANT_ID);
+		expect(result).toBeDefined();
+		expect(result?.endpoint).toBe(ENDPOINT);
+		expect(result?.subscriberRole).toBe('owner');
+
+		// GetCommand が使われたこと
+		const callArg = mockSend.mock.calls[0]?.[0] as { input: { Key?: { PK: string; SK: string } } };
+		expect(callArg.input.Key?.PK).toBe('T#tenant-1#PUSH_SUB');
+		expect(callArg.input.Key?.SK).toMatch(/^PUSH_SUB#[0-9a-f]{16}$/);
+	});
+
+	it('Item 不在のときは undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Item: undefined });
+		const { findByEndpoint } = await loadRepo();
+		const result = await findByEndpoint(ENDPOINT, TENANT_ID);
+		expect(result).toBeUndefined();
+	});
+
+	it('hash 衝突時は endpoint 不一致で undefined を返す（二重防御）', async () => {
+		mockSend.mockResolvedValueOnce({
+			Item: {
+				PK: 'T#tenant-1#PUSH_SUB',
+				SK: 'PUSH_SUB#aabbccdd11223344',
+				id: 9,
+				tenantId: TENANT_ID,
+				// 衝突した別 endpoint
+				endpoint: 'https://example.com/different-endpoint',
+				keysP256dh: 'p1',
+				keysAuth: 'a1',
+				userAgent: null,
+				subscriberRole: 'parent',
+				createdAt: '2026-04-29T00:00:00.000Z',
+			},
+		});
+
+		const { findByEndpoint } = await loadRepo();
+		const result = await findByEndpoint(ENDPOINT, TENANT_ID);
+		expect(result).toBeUndefined();
+	});
+});
+
+// ============================================================
+// insert
+// ============================================================
+
+describe('insert', () => {
+	it('subscriberRole=parent を必須属性として PutItem する (#1593 ADR-0023 I6)', async () => {
+		// counter.nextId 用の UpdateCommand → PutCommand の順
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 42 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insert } = await loadRepo();
+		const result = await insert({
+			tenantId: TENANT_ID,
+			endpoint: ENDPOINT,
+			keysP256dh: 'p256dh-1',
+			keysAuth: 'auth-1',
+			userAgent: 'Chrome',
+			subscriberRole: 'parent',
+		});
+
+		expect(result.id).toBe(42);
+		expect(result.subscriberRole).toBe('parent');
+
+		// PutCommand の Item に subscriberRole が含まれる
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.subscriberRole).toBe('parent');
+		expect(putCall.input.Item?.PK).toBe('T#tenant-1#PUSH_SUB');
+		expect(putCall.input.Item?.SK).toMatch(/^PUSH_SUB#[0-9a-f]{16}$/);
+		expect(putCall.input.Item?.endpoint).toBe(ENDPOINT);
+		expect(putCall.input.Item?.id).toBe(42);
+	});
+
+	it('subscriberRole=owner も保存できる', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+
+		const { insert } = await loadRepo();
+		const result = await insert({
+			tenantId: TENANT_ID,
+			endpoint: ENDPOINT,
+			keysP256dh: 'p',
+			keysAuth: 'a',
+			subscriberRole: 'owner',
+		});
+
+		expect(result.subscriberRole).toBe('owner');
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.subscriberRole).toBe('owner');
+	});
+
+	it('userAgent 未指定時は null を保存する', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+
+		const { insert } = await loadRepo();
+		const result = await insert({
+			tenantId: TENANT_ID,
+			endpoint: ENDPOINT,
+			keysP256dh: 'p',
+			keysAuth: 'a',
+			subscriberRole: 'parent',
+		});
+
+		expect(result.userAgent).toBeNull();
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.userAgent).toBeNull();
+	});
+});
+
+// ============================================================
+// deleteByEndpoint
+// ============================================================
+
+describe('deleteByEndpoint', () => {
+	it('endpoint hash → DeleteItem する', async () => {
+		mockSend.mockResolvedValueOnce({});
+		const { deleteByEndpoint } = await loadRepo();
+		await deleteByEndpoint(ENDPOINT, TENANT_ID);
+
+		const callArg = mockSend.mock.calls[0]?.[0] as { input: { Key?: { PK: string; SK: string } } };
+		expect(callArg.input.Key?.PK).toBe('T#tenant-1#PUSH_SUB');
+		expect(callArg.input.Key?.SK).toMatch(/^PUSH_SUB#[0-9a-f]{16}$/);
+	});
+});
+
+// ============================================================
+// insertLog
+// ============================================================
+
+describe('insertLog', () => {
+	it('成功通知ログを保存する (success=1)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 100 } }).mockResolvedValueOnce({});
+
+		const { insertLog } = await loadRepo();
+		const result = await insertLog({
+			tenantId: TENANT_ID,
+			notificationType: 'task_reminder',
+			title: 'Test Title',
+			body: 'Test Body',
+			success: true,
+		});
+
+		expect(result.id).toBe(100);
+		expect(result.success).toBe(1);
+		expect(result.errorMessage).toBeNull();
+
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.PK).toBe('T#tenant-1#NOTIF_LOG');
+		expect(putCall.input.Item?.SK).toMatch(/^NOTIF#[\dT:.\-Z]+#\d{8}$/);
+		expect(putCall.input.Item?.success).toBe(1);
+	});
+
+	it('失敗通知ログを errorMessage 付きで保存する (success=0)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 200 } }).mockResolvedValueOnce({});
+
+		const { insertLog } = await loadRepo();
+		const result = await insertLog({
+			tenantId: TENANT_ID,
+			notificationType: 'task_reminder',
+			title: 'T',
+			body: 'B',
+			success: false,
+			errorMessage: 'Push service rejected',
+		});
+
+		expect(result.success).toBe(0);
+		expect(result.errorMessage).toBe('Push service rejected');
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.success).toBe(0);
+		expect(putCall.input.Item?.errorMessage).toBe('Push service rejected');
+	});
+});
+
+// ============================================================
+// countTodayLogs
+// ============================================================
+
+describe('countTodayLogs', () => {
+	it('当日の SK 範囲で COUNT クエリを発行する', async () => {
+		mockSend.mockResolvedValueOnce({ Count: 5 });
+		const { countTodayLogs } = await loadRepo();
+		const result = await countTodayLogs(TENANT_ID, '2026-04-29');
+
+		expect(result).toBe(5);
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: {
+				KeyConditionExpression?: string;
+				ExpressionAttributeValues?: Record<string, string>;
+				Select?: string;
+			};
+		};
+		expect(callArg.input.KeyConditionExpression).toContain('PK = :pk');
+		expect(callArg.input.KeyConditionExpression).toContain('SK BETWEEN');
+		expect(callArg.input.Select).toBe('COUNT');
+		expect(callArg.input.ExpressionAttributeValues?.[':pk']).toBe('T#tenant-1#NOTIF_LOG');
+		expect(callArg.input.ExpressionAttributeValues?.[':skStart']).toBe('NOTIF#2026-04-29T00:00:00');
+		expect(callArg.input.ExpressionAttributeValues?.[':skEnd']).toBe('NOTIF#2026-04-29T99:99:99');
+	});
+
+	it('レコード 0 件のときは 0 を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Count: 0 });
+		const { countTodayLogs } = await loadRepo();
+		const result = await countTodayLogs(TENANT_ID, '2026-04-29');
+		expect(result).toBe(0);
+	});
+
+	it('LastEvaluatedKey でページング合算する', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Count: 100, LastEvaluatedKey: { PK: 'c', SK: 'c' } })
+			.mockResolvedValueOnce({ Count: 50, LastEvaluatedKey: undefined });
+		const { countTodayLogs } = await loadRepo();
+		const result = await countTodayLogs(TENANT_ID, '2026-04-29');
+		expect(result).toBe(150);
+	});
+});
+
+// ============================================================
+// findRecentLogs
+// ============================================================
+
+describe('findRecentLogs', () => {
+	it('ScanIndexForward=false + Limit で降順取得する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				{
+					PK: 'T#tenant-1#NOTIF_LOG',
+					SK: 'NOTIF#2026-04-29T10:00:00.000Z#00000002',
+					id: 2,
+					tenantId: TENANT_ID,
+					notificationType: 'task',
+					title: 'Latest',
+					body: 'Body 2',
+					sentAt: '2026-04-29T10:00:00.000Z',
+					success: 1,
+					errorMessage: null,
+				},
+				{
+					PK: 'T#tenant-1#NOTIF_LOG',
+					SK: 'NOTIF#2026-04-29T09:00:00.000Z#00000001',
+					id: 1,
+					tenantId: TENANT_ID,
+					notificationType: 'task',
+					title: 'Older',
+					body: 'Body 1',
+					sentAt: '2026-04-29T09:00:00.000Z',
+					success: 1,
+					errorMessage: null,
+				},
+			],
+		});
+
+		const { findRecentLogs } = await loadRepo();
+		const result = await findRecentLogs(TENANT_ID, 10);
+
+		expect(result).toHaveLength(2);
+		expect(result[0]?.title).toBe('Latest');
+
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: { ScanIndexForward?: boolean; Limit?: number };
+		};
+		expect(callArg.input.ScanIndexForward).toBe(false);
+		expect(callArg.input.Limit).toBe(10);
+	});
+});
+
+// ============================================================
+// 機能等価性チェック (interface 適合)
+// ============================================================
+
+describe('interface 適合 (SQLite との機能等価性)', () => {
+	it('IPushSubscriptionRepo の全メソッドを export している', async () => {
+		const repo = await loadRepo();
+		expect(typeof repo.findByTenant).toBe('function');
+		expect(typeof repo.findByEndpoint).toBe('function');
+		expect(typeof repo.insert).toBe('function');
+		expect(typeof repo.deleteByEndpoint).toBe('function');
+		expect(typeof repo.insertLog).toBe('function');
+		expect(typeof repo.countTodayLogs).toBe('function');
+		expect(typeof repo.findRecentLogs).toBe('function');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 運営

**解決する課題**:
本番 AWS 環境で push_subscription / notification 機能を使う際、DynamoDB 側 `push-subscription-repo.ts` が `Not implemented` stub のままであり、`subscribe API` / `notification-service` / `subscriber_role` 監査が実効化されていなかった (#1666 で migration script + runbook は整備済 / 実装本体は本 Issue に切り出し)。

**期待される効果**:
- SQLite (NUC) と機能等価な push_subscription 永続化が AWS Lambda + DynamoDB 上で動作
- ADR-0023 I6 の `subscriber_role` 二重防御 (#1593) が本番でも実効化
- `#1021` 段階的リリース禁止 / ADR-0010 違反状態の解消

## 関連 Issue

closes #1689

Related: #1666, #1593, #1021, ADR-0010, ADR-0023 I6, ADR-0012

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | DynamoDB `push-subscription-repo.ts` 全 7 関数 (findByTenant / findByEndpoint / insert / deleteByEndpoint / insertLog / countTodayLogs / findRecentLogs) を本実装 | `src/lib/server/db/dynamodb/push-subscription-repo.ts` 全 7 関数 export 済み (interface 適合テストで自動検証) | PASS — 17 ユニットテスト全件 green |
| AC2 | DynamoDB キー設計を `keys.ts` に追加 (推奨案: PK = `T#<tenantId>#PUSH_SUB`、SK = `PUSH_SUB#<endpointHash>`) | `src/lib/server/db/dynamodb/keys.ts` の `pushSubscriptionKey` / `pushSubscriptionEndpointHash` / `pushSubscriptionTenantPK` / `pushSubscriptionSKPrefix` 追加 | PASS — 推奨案そのまま採用、SHA-256 16hex (64 bit) を採用 |
| AC3 | notification log のキー設計も追加 (推奨案: PK = `T#<tenantId>#NOTIF_LOG`、SK = `NOTIF#<sentAt>#<id>`) | `keys.ts` の `notificationLogKey` / `notificationLogTenantPK` / `notificationLogDatePrefix` 追加 | PASS — `<id>` は `padId(8)` (8 桁 0 埋め) で辞書順整合 |
| AC4 | SQLite 側と機能等価であることを保証する unit test (両実装で同シナリオを通すテーブル駆動テスト推奨) | `tests/unit/db/dynamodb-push-subscription-repo.test.ts` (17 件 / 7 関数全カバー + interface 適合) | PASS — `npx vitest run tests/unit/db/dynamodb-push-subscription-repo.test.ts` 17 passed |
| AC5 | `subscriberRole` 属性を必須属性として PutItem 時に付与 (`'parent' \| 'owner'` の型保証) | `insert` 内 `subscriberRole: input.subscriberRole satisfies PushSubscriberRole`、test "subscriberRole=parent を必須属性として PutItem する" / "subscriberRole=owner も保存できる" で検証 | PASS — `satisfies` で型保証 + テストで Item 内属性 assert |
| AC6 | `scripts/check-dynamodb-stub.mjs` で push-subscription-repo.ts が pass する (grandfathered 不要) | `node scripts/check-dynamodb-stub.mjs` | PASS — `[check-dynamodb-stub] OK — stub なし / 未実装マーカーなし / 空実装なし` の検出ゼロを CI で確認 |
| AC7 | 本 Issue 完了後、#1666 で整備した `scripts/migrate-dynamodb-push-subscriber-role.mjs` を AWS 本番で実行 (runbook §3-§5 に従う) | 本 PR merge 後の運用作業 (post-merge 運用工程 — issue body §C 末尾) | DEFERRED — 運用担当による migration 実行は merge & deploy 後 (post-merge 運用、本 PR スコープ外) |
| AC8 | `docs/design/08-データベース設計書.md` に DynamoDB キー設計を追記 | §push_subscriptions に「#1689 DynamoDB キー設計」サブセクション追加 (設計背景 / 設計原則 / キー設計表 / アクセスパターン / CDK 変更有無) | PASS — 3 部構成原則 (#1329) 準拠 |
| AC9 | CDK (`infra/lib/storage-stack.ts`) は既存の単一テーブル設計に乗るため変更不要を確認 | 既存 MainTable (PK + SK + GSI1 + GSI2) で実現可能を確認、新規 GSI 不要 (Pre-PMF 規模 ADR-0010) | PASS — CDK 差分ゼロ |

## 変更タイプ

- [x] feat: 新機能

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — DynamoDB repo 実装のみ (SQLite schema は変更なし)

**影響を受ける画面・機能**:
- 親管理画面の push 通知 subscribe / unsubscribe (本番 AWS 環境)
- `notification-service.sendPushNotification` の本番側永続化
- `subscriber_role` 監査ログ (#1593 ADR-0023 I6)

## 既存実装との比較

| 観点 | 既存実装 (stub) | 今回の変更 |
|------|-----------------|-----------|
| 実装パターン | 全関数 `throw new Error('Not implemented')` | SQLite 機能等価の本実装 (cancellation-reason-repo / graduation-consent-repo の単純 CRUD パターンを踏襲) |
| 一貫性 | factory.ts 経由で interface 統一済み | 同 — interface 契約は一切変更せず |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: なし (既存パターンに合わせた純粋追加)
- **リファクタリングが必要だが今回見送った箇所と理由**: なし
- **削除したコード・機能**: stub 実装 7 関数 (本実装に置換)

## 設計方針・将来性

**採用した設計方針**:
- PK = `T#<tenantId>#<entity>` のテナントスコープ + 単一 partition Query で取得 (既存 inquiry-repo / cancellation-reason-repo パターン踏襲)
- endpoint の SHA-256 16 hex を SK に埋め込み、`findByEndpoint(endpoint, tenantId)` を GetItem 1 回で実現 (Scan 回避)
- counter.ts の `nextId('pushSubscription' / 'notificationLog', tenantId)` でテナントスコープの atomic 採番

**想定する将来の拡張**:
- 通知ログ 90 日 TTL: 必要時に `ttl` 属性を Item に追加するだけで実現可能 (本 PR では Pre-PMF スコープ外)
- 端末ベース endpoint lookup の最適化: 規模拡大時に GSI1 (inverted index) 経由で `SK = PUSH_SUB#<hash>` から逆引き可能 (CDK 変更不要)

**意図的に対応しなかった範囲とその理由**:
- 追加 GSI (endpoint-only / sentAt 月別等): Pre-PMF 規模では PK Query で十分 (ADR-0010 過剰防衛禁止)
- 通知ログの S3 アーカイブ移行: TTL の方が運用コスト低 (ADR-0010)

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — 既存 interface (`IPushSubscriptionRepo`) に対する DynamoDB 側実装の補完であり、新規 interface / 新テーブル追加ではない (#1689 で PO 合意済 — Issue 本文の AC 全項目を実装)

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加: `tests/unit/db/dynamodb-push-subscription-repo.test.ts` (17 件 / 8 describe block)
- カバーしたシナリオ:
  - `findByTenant`: 正常 / ページング / 空配列
  - `findByEndpoint`: 正常 / Item 不在 / hash 衝突時の二重防御
  - `insert`: subscriberRole=parent / subscriberRole=owner / userAgent null
  - `deleteByEndpoint`: PK/SK 構築の検証
  - `insertLog`: success=1 / success=0 + errorMessage
  - `countTodayLogs`: 範囲 Query / 0 件 / ページング合算
  - `findRecentLogs`: ScanIndexForward=false + Limit
  - interface 適合: 7 関数全 export を確認

**E2E テスト**:
- 追加なし (DynamoDB 本番接続テストはモックでカバー、実環境動作は merge 後の AWS 環境で migration script 実行で確認 — AC7)

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check .` | PASS | 変更ファイルでフォーマット適用済 |
| 型チェック | `npx svelte-check` | PASS | 0 errors / 0 warnings |
| 単体テスト | `npx vitest run tests/unit/db/dynamodb-push-subscription-repo.test.ts` | PASS (17 tests) | 7 関数全カバー + interface 適合 |
| 単体テスト (依存) | `npx vitest run tests/unit/services/notification-service.test.ts tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts` | PASS (33 tests) | 周辺テストも green |
| E2E テスト | `npx playwright test` | 該当なし | DB layer のみで E2E 影響なし |

**追加した E2E テストの詳細**:
追加なし (DB layer のみの変更で E2E 影響範囲外。実 DynamoDB との結合は merge 後の migration script 実行で検証する — AC7)。

**網羅性の判断根拠**:
SQLite 側 (`src/lib/server/db/sqlite/push-subscription-repo.ts`) は既存の `notification-service.test.ts` で総合的にカバーされており、DynamoDB 側は AWS SDK レベルでの送信 Command の input (PK/SK/Item 属性) を直接 assert することで機能等価性を担保。実 DynamoDB との結合は merge 後の migration script 実行 (#1666 runbook §3-§5) で検証する。

### DynamoDB 実装完成度（#1021 — 段階的対応禁止 / ADR-0010）

- [x] ADR-0010（Pre-PMF セキュリティ最小化方針）の採用マトリクスで **interface を追加すべき機能** と判定した (#1593 で `subscriberRole` 二重防御を採用、push_subscription は通知 subscribe の必須経路)
- [x] interface を追加した PR で **SQLite + DynamoDB 両実装を完成**させた (本 PR で stub 解消、SQLite 側は既存実装)
- [x] `scripts/check-dynamodb-stub.mjs` がローカルで PASS する
- [x] CDK (`infra/lib/storage-stack.ts`) の DynamoDB テーブル / GSI 定義は既存単一テーブルで実現可能 (新規テーブル / GSI 不要 — AC9)
- [ ] `DATA_SOURCE=dynamodb` 相当（staging）で実機動作確認 — DEFERRED (AC7: post-merge migration で確認)
- [ ] DynamoDB コンソールで当該テーブルに書込みが発生することを確認 — DEFERRED (AC7)
- [ ] Lambda CloudWatch Logs に想定イベントが出ることを確認 — DEFERRED (AC7)

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | 入力 endpoint は SHA-256 hash 化して SK に格納、生 endpoint は Item 属性のみ。tenant スコープ PK で cross-tenant 漏洩を構造的に防止 | OWASP Top 10 — Broken Access Control / IDOR を構造的に予防 |
| パフォーマンス | findByEndpoint は GetItem 1 回 (Scan 回避)、findByTenant は単一 partition Query。ループ内 DB クエリなし | Pre-PMF 規模で Provisioned/On-Demand いずれでも十分 |
| アクセシビリティ | 該当なし (DB layer) | UI 変更なし |
| ロギング・モニタリング | `notification_logs` 永続化により subscribe / send 失敗を後追い可能 | CloudWatch Logs と組み合わせて運用 |
| ドキュメント | `docs/design/08-データベース設計書.md` §push_subscriptions に DynamoDB キー設計を追記 | 設計書同期済 |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: 7 関数それぞれ単一の DB 操作 (find / insert / delete / count) のみを担当
- [x] **依存性逆転（D）**: `IPushSubscriptionRepo` interface 経由で呼び出され、factory.ts の DI で SQLite/DynamoDB を切替
- [x] **インターフェース分離（I）**: `IPushSubscriptionRepo` は push_subscription 関連 7 関数のみで構成 (巨大 interface への依存なし)
- [x] **DRY / 横展開**: 同パターンの repo (cancellation-reason-repo / graduation-consent-repo) を `grep` で確認、既存パターン踏襲を確認
- [x] **YAGNI**: 90 日 TTL / endpoint-only GSI 等、現在の要件に不要な抽象化は追加していない

### セキュリティ（OSS 公開前提）
- [x] 秘密情報のハードコードなし (PK/SK は構造化された定数のみ)
- [x] Security by obscurity 依存なし — endpoint hash 化はセキュリティではなく辞書順整合性のため
- [x] 入力バリデーションは呼出側 (notification-service / subscribe API) で実施済 (本 repo 層は型レベルで `subscriberRole: 'parent' | 'owner'` を強制)

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] N+1 クエリなし (findByTenant は単一 Query、ページングは LastEvaluatedKey で順次取得)
- [x] バンドルサイズへの影響なし (AWS SDK は既存依存)

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

stub 実装 (`throw new Error`) を本実装に置換するのみ。interface 契約は変更なし。SQLite 経路には一切影響なし。

## レビュー依頼事項・QA

- DynamoDB キー設計レビュー: PK = `T#<tid>#PUSH_SUB` + SK = `PUSH_SUB#<endpointHash>` が migration script (#1666) の `begins_with(SK, 'PUSH_SUB#')` 規約と整合していることを確認願います
- endpointHash の 64 bit (16 hex) 衝突確率: 同一テナント内 1 家族 < 10 デバイス前提で衝突確率 < 10^-9。問題があれば 32 hex (128 bit) への引き上げを検討

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **本番アプリ** — 該当なし (DB layer のみの変更)
- [x] **デモ版** — 該当なし
- [x] **LP ↔ アプリ整合**:
  - [x] **N/A** — LP / アプリの文言・機能に影響しない変更
- [x] **全年齢モード** — 該当なし (DB layer)
- [x] **ナビゲーション** — 該当なし
- [x] **E2E/ユニットシード** — 該当なし (SQLite schema 変更なし)
- [x] **チュートリアル + デモガイド** — 該当なし

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイル (`src/lib/server/db/dynamodb/push-subscription-repo.ts`, `keys.ts`, `docs/design/08-データベース設計書.md`, `tests/unit/db/dynamodb-push-subscription-repo.test.ts`) を **同時期に変更する open PR が他に無い** ことを確認済み

### LP 変更時の追加チェック（#1282 / ADR-0010 Pre-PMF）

- [x] **N/A** — LP (`site/**`) の変更なし

### LP / 販促文言変更時の実装パス明示（ADR-0013 / #1314）

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **用語変更**: なし
- [x] **labels SSOT (ADR-0009)**: 該当なし (ユーザー向け文言の追加なし)
- [x] **UI構造変更**: なし
- [x] **カラー・スタイル**: hex / Tailwind 直書きなし (ts ファイルのみ)
- [x] **プリミティブ**: 該当なし (UI 変更なし)
- [x] **設計書（CRITICAL）**: `docs/design/08-データベース設計書.md` を同一 PR 内で更新済 (DB 変更 → 08)

## スクリーンショット / ビジュアルデモ

DB layer のみの変更で UI への直接的影響はないため、スクリーンショット撮影対象なし。本 PR の変更内容を視覚的に確認するための図表は `docs/design/08-データベース設計書.md` §push_subscriptions §1689 のキー設計表を参照。

### 変更前後の比較

| Before | After |
|--------|-------|
| N/A — UI 変更なし | N/A — UI 変更なし |

### Playwright スクリーンショット

| 画面 | ビューポート | スクリーンショット |
|------|------------|------------------|
| N/A | N/A | N/A — DB layer のみの変更で UI 影響なし |

### インタラクティブ状態の確認（#1481）

- [x] **N/A** — インタラクティブ状態変化なし (DB layer)

### モバイルビューポート（#1481）

- [x] **N/A** — LP / infra / 設定ファイルのみの変更 (DB repo 実装、UI なし)

## 実機操作検証

- [x] **N/A** — UI/UX 変更なし。DB layer (DynamoDB repo) の stub 解消のみで、実機画面操作の差分は発生しない。実 AWS DynamoDB との結合検証は merge & deploy 後の migration script 実行 (AC7 / #1666 runbook §3-§5) で行う

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし (DB layer のみの変更)

## Ready for Review チェックリスト

- [x] CI が全て通過している (push 後に確認)
- [x] セルフレビュー済み (不要な差分・デバッグコードなし)
- [x] **全 AC が実装済み** (AC1-9 のうち AC7 のみ post-merge 運用作業として deferred、それ以外は完了)
- [x] **Phase 分割なし** (純粋な stub 解消 1 PR で完結)
- [x] UI 変更なし → 該当なし
- [x] 認証画面変更なし → 該当なし
- [x] **hardcoded JP text**: 該当なし (新規追加の日本語テキストはコメントのみ — `.svelte` 配下の変更なし)

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない (priority:medium / type:feat)

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし (既存 `DYNAMODB_TABLE` / `AWS_REGION` を流用)

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし (DynamoDB repo 実装のみ)
- 評価結果: **RISK: low** — 既存 stub からの置換で互換性破壊なし。Empty テーブルへの初回書き込み時にも問題なし (既存動作: stub が throw → 親画面に subscribe エラーが返るのみ)

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし (Lambda の cold start に影響する依存追加なし、AWS SDK は既存依存)

### スコープ完全性
- [x] **見落とし確認**: Issue AC 全項目を網羅。post-merge での migration script 実行 (#1666 runbook) は Issue C-AC7 に明記済 + #1666 で対応済の運用手順を流用するため別 Issue 起票不要

## デプロイ検証（#710 — マージ後必須）

- [ ] `gh run list --branch main --workflow deploy.yml` でデプロイワークフローが**成功**していることを確認 (post-merge)
- [x] site/ の変更なし
- [x] **後続作業**: merge & deploy 後、`scripts/migrate-dynamodb-push-subscriber-role.mjs` を runbook (`docs/runbooks/push-subscription-role-migration.md`) §3-§5 に従って実行 (AC7)

## 完了チェックリスト

- [x] `npx biome check .` — lint エラーなし (変更ファイルでフォーマット適用済)
- [x] `npx svelte-check` — 型エラーなし (0 errors / 0 warnings)
- [x] `npx vitest run tests/unit/db/dynamodb-push-subscription-repo.test.ts` — 17 件全通過
- [x] `npx vitest run tests/unit/services/notification-service.test.ts tests/unit/scripts/migrate-dynamodb-push-subscriber-role.test.ts` — 33 件全通過 (依存テスト)
- [x] PRサイズ適切 (4 ファイル / 実装 ~210 行 + キー定義 ~70 行 + テスト ~440 行 + 設計書 ~40 行)

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

<!-- QM が approve するときに記入。PR 作者は空欄のままでよい。 -->

