### PR TITLE
docs: #1683 ADR-0025 amendment — CDN 採用 / generate-lp-labels.mjs 改修対象明示 / LEGAL check rework

### DIFF
--- a/docs/decisions/0025-lp-ssot-html-injection-with-xss-protection.md
+++ b/docs/decisions/0025-lp-ssot-html-injection-with-xss-protection.md
@@ -2,11 +2,17 @@
 
 | 項目 | 内容 |
 |------|------|
-| ステータス | proposed |
+| ステータス | proposed (amended 2026-04-29) |
 | 日付 | 2026-04-29 |
 | 起票者 | PO |
 | 関連 Issue | #1683 / #1465 / #1346 |
 | 関連 ADR | ADR-0009（labels SSOT 原則） / ADR-0014（i18n 機構選定） / ADR-0008（設計ポリシー先行確認） |
+
+> **Amendment 履歴 (2026-04-29)**: 初版で曖昧だった 3 点を確定:
+>
+> 1. SSOT は `site/shared-labels.js` ではなく **`scripts/generate-lp-labels.mjs` (applyLpKeys template, L377-392)**。`shared-labels.js` は同 script からの **生成物** であり、ADR §決定の文言を「自動生成テンプレート改修 + 再生成」に修正
+> 2. DOMPurify の配信方法を **CDN 必須** に確定（`site/` は GitHub Pages 上の static アセットで、npm bundle 経路を持たない）。`<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js">` を `site/*.html` 全 8 ファイルの `<head>` に追加し、`window.DOMPurify` 経由で参照する
+> 3. `scripts/check-lp-ssot.mjs` L186-260 の **`LEGAL_LABELS` coverage check** との整合性を §結果 Migration Plan に明記（法的文書を `LP_LEGAL_*_LABELS` namespace で labels.ts 化した後、双方向同期ロジックを再設計する）
 
 ## コンテキスト
 
@@ -52,34 +58,77 @@ PO 判断 (#1683): **案 A** = architecture ADR 先行起票 → ADR 確定 → 
 
 ## 決定
 
-**選択肢 A: DOMPurify を採用**。`site/shared-labels.js#applyLpKeys()` を innerHTML + DOMPurify sanitize に切り替え、**LP 339 件 + Legal 354 件 = 693 件すべて**を `data-lp-key` SSOT 配下に統合する。
+**選択肢 A: DOMPurify を採用**。`scripts/generate-lp-labels.mjs` の `applyLpKeys()` テンプレート (L377-392) を innerHTML + DOMPurify sanitize に書換 → 再生成された `site/shared-labels.js` を deploy → **LP 339 件 + Legal 354 件 = 693 件すべて**を `data-lp-key` SSOT 配下に統合する。
+
+> **重要 (Amendment)**: `site/shared-labels.js` は **自動生成ファイル**である（`scripts/generate-lp-labels.mjs` 実行で再生成）。直接編集 → 上書き再生成で消失するため、SSOT は **generate-lp-labels.mjs の applyLpKeys template (L377-392)**。本 ADR の決定対象もそちらの template。
 
 ### 適用範囲（PO 方針: 例外なし）
 
 1. **LP**: `site/index.html` / `pricing.html` / `faq.html` / `selfhost.html` / `pamphlet.html` / `help/license-key.html`
 2. **Legal**: `site/privacy.html` / `terms.html` / `sla.html` / `tokushoho.html`（**ADR-0009 §例外「法的文書」を本 ADR が supersede**）
-3. **labels.ts namespace**: 既存 `LP_*_LABELS` に加え新規 `LP_PRIVACY_LABELS` / `LP_TERMS_LABELS` / `LP_SLA_LABELS` / `LP_TOKUSHOHO_LABELS` / `LP_PAMPHLET_LABELS` / `LP_FAQ_BODY_LABELS` を追加（Phase 4 多言語化時に PO/JSON へ抽出可能な flat 構造を維持）。
+3. **labels.ts namespace**: 既存 `LP_*_LABELS` に加え新規 `LP_LEGAL_PRIVACY_LABELS` / `LP_LEGAL_TERMS_LABELS` / `LP_LEGAL_SLA_LABELS` / `LP_LEGAL_TOKUSHOHO_LABELS` / `LP_PAMPHLET_LABELS` / `LP_FAQ_BODY_LABELS` を追加（Phase 4 多言語化時に PO/JSON へ抽出可能な flat 構造を維持）。
+4. **DOMPurify 配信**: site/ は GitHub Pages の static asset であり npm bundle 経路を持たないため **CDN 必須**:
+   ```html
+   <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+   <script src="shared-labels.js" defer></script>
+   ```
+   全 8 ファイル (`index.html` / `pricing.html` / `faq.html` / `selfhost.html` / `pamphlet.html` / `help/license-key.html` / `privacy.html` / `terms.html` / `sla.html` / `tokushoho.html`) の `<head>` に同様に追加。`applyLpKeys` は `window.DOMPurify` 参照で利用、DOMPurify が未ロードの場合は安全側で `textContent` フォールバック + console.warn (network 一時失敗時の劣化動作)。
 
 ### DOMPurify 設定値（実装 Agent 直参照）
 
+`scripts/generate-lp-labels.mjs` の applyLpKeys template に以下を埋め込む（生成後 `site/shared-labels.js` の同等位置に展開される）:
+
 ```js
-const SANITIZE_CONFIG = {
-  ALLOWED_TAGS: ['strong','em','a','br','span','sup','sub','small','b','i'],
-  ALLOWED_ATTR: ['href','target','rel','class','aria-hidden','aria-label'],
-  ALLOW_DATA_ATTR: false,
-  ALLOW_UNKNOWN_PROTOCOLS: false,
-  ADD_ATTR: ['target'], // a[target] 許可
-};
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
-    node.setAttribute('rel', 'noopener noreferrer');
+// generate-lp-labels.mjs L377-392 の applyLpKeys template 改修後イメージ
+function applyLpKeys() {
+  var elements = document.querySelectorAll('[data-lp-key]');
+  var Purify = (typeof window !== 'undefined') && window.DOMPurify;
+  var SANITIZE_CONFIG = {
+    ALLOWED_TAGS: ['strong','em','a','br','span','sup','sub','small','b','i'],
+    ALLOWED_ATTR: ['href','target','rel','class','aria-hidden','aria-label'],
+    ALLOW_DATA_ATTR: false,
+    ALLOW_UNKNOWN_PROTOCOLS: false,
+    ADD_ATTR: ['target']
+  };
+  if (Purify && !Purify.__gqHookInstalled) {
+    Purify.addHook('afterSanitizeAttributes', function(node) {
+      if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+        node.setAttribute('rel', 'noopener noreferrer');
+      }
+    });
+    Purify.__gqHookInstalled = true;
   }
-});
+  elements.forEach(function(el) {
+    var key = el.getAttribute('data-lp-key');
+    var parts = key.split('.');
+    if (parts.length !== 2) return;
+    var sectionData = LP_LABELS[parts[0]];
+    if (!sectionData) return;
+    var value = sectionData[parts[1]];
+    if (value === undefined) return;
+    if (Purify) {
+      el.innerHTML = Purify.sanitize(value, SANITIZE_CONFIG);
+    } else {
+      el.textContent = value;
+      console.warn('[applyLpKeys] DOMPurify unavailable, fell back to textContent for', key);
+    }
+  });
+}
 ```
 
 ### pamphlet.html の印刷タイミング
 
 `<script src="shared-labels.js" defer>` で `DOMContentLoaded` までに注入完了を保証 + `window.print()` 直前に `applyAll()` 同期再実行（既に注入済みなら no-op）。テストは Playwright `emulateMedia({ media: 'print' })` で SS 検証。
+
+### LEGAL_LABELS coverage check との整合（Amendment 追記）
+
+`scripts/check-lp-ssot.mjs` L186-260 は現在「`LEGAL_LABELS` の値が `site/privacy.html` / `terms.html` に部分一致存在すること」を双方向同期で検証している。Legal docs を `LP_LEGAL_*_LABELS` namespace で labels.ts 化した後は:
+
+1. 既存 `LEGAL_LABELS` → `LP_LEGAL_PRIVACY_LABELS` / `LP_LEGAL_TERMS_LABELS` 等に **再分類** (用途別)。
+2. coverage check ロジックを「`LP_LEGAL_*_LABELS` の各キーが `data-lp-key="legal.*"` で 1 箇所以上参照されていること」を検証する**逆方向のチェック**に変更する。
+3. `EXCLUDED_LEGAL_FILES` 定数 (L32-37) を削除し、法的文書も baseline 0 件対象に追加する。
+
+詳細手順は §結果 Migration Plan の M4 に記載。
 
 ## 結果
 
@@ -94,18 +143,30 @@ DOMPurify.addHook('afterSanitizeAttributes', (node) => {
 - ADR-0009 §例外「法的文書」項目を本 ADR が supersede（履歴は ADR-0009 内に追補）
 - 実装 PR は LP 339 + Legal 354 = 693 件の手作業移行で大規模（後述 §Migration Plan）
 
-### 移行計画（実装 Agent 引継ぎ）
+### 移行計画（実装 Agent 引継ぎ — Amendment 後版）
 
-| Phase | 作業 | 対象件数 | 想定 diff 規模 |
-|-------|------|----------|---------------|
-| M1 | `npm i dompurify` + `applyLpKeys()` を innerHTML+DOMPurify に書換 | shared-labels.js +50 行 | +50/-10 |
-| M2 | `LP_*_BODY_LABELS` namespace 5 種追加 + 既存 LP_LABELS 補完 | labels.ts | +4,000 行 |
-| M3 | site/*.html を順次 SSOT 化（**1 commit / file 推奨、1 PR 完遂**） | 6 LP + 4 Legal = 10 ファイル | HTML 約 5,000 行変更 |
-| M4 | `scripts/lp-ssot-baseline.json` を `count: 0` に更新 + `EXCLUDED_LEGAL_FILES` 削除 | 2 ファイル | +5/-10 |
-| M5 | 全画面 SS 撮影（`npm run capture`）で視覚回帰なし確認 | 10 ページ × mobile/desktop | docs/screenshots/ |
-| M6 | 設計書同期: `docs/design/22a-アイコン・ラベル統一規約.md` / `06-UI設計書.md` / ADR-0009 §例外節 supersede 追補 | 3 ファイル | +30 行 |
+PO 方針確認 (2026-04-29):
+- 「**partial PR 禁止 = 申し送り禁止 = AC 妥協禁止**」であって「**子 issue 分解禁止**」ではない
+- → **網羅的子 issue 分解 + 各子は単独完遂可能 + 全子 AC 合計が 100%** で進める
 
-**想定実装時間**: 8-16 時間（Agent 単独）。**partial PR 禁止 / follow-up Issue 起票禁止** (PO 方針)。
+#### 子 issue 分解（#1683 配下に 4 件起票）
+
+各 sub-issue は単独で 1 PR 完遂できる scope。「ここまでで OK / 残りは続 PR」表現は AC に含めない（申し送りなし）。
+
+| Sub | Scope | 完遂 AC（抜粋） | 依存 |
+|-----|-------|---------------|------|
+| **1683-A** | applyLpKeys template 刷新 + DOMPurify CDN 注入 | (1) generate-lp-labels.mjs L377-392 改修, (2) site/*.html 全 8 ファイルに DOMPurify CDN script 追加, (3) `node scripts/generate-lp-labels.mjs` で shared-labels.js 再生成, (4) DOMPurify 設定値が ADR §決定どおり, (5) unit test: `<strong>` `<a>` 保持 + `<script>onerror>` 等 XSS payload escape, (6) 既存 339 件のうち単純文字列の SS 視覚回帰なし | (なし) |
+| **1683-B** | LP HTML 339 件 SSOT 化 | (1) `site/index.html` 84 件 → 0、(2) `site/pricing.html` 50 件 → 0、(3) `site/faq.html` 123 件 → 0、(4) `site/pamphlet.html` 82 件 → 0（defer + print 直前 applyAll 再実行）、(5) namespace `LP_INDEX_*_LABELS` / `LP_PRICING_LABELS` 拡張 / `LP_FAQ_*_LABELS` 拡張 / `LP_PAMPHLET_LABELS` 拡張、(6) check-lp-ssot.mjs で LP 部分 0 件、(7) 4 ファイル × mobile/desktop = 8 SS 視覚回帰なし | 1683-A |
+| **1683-C** | Legal HTML 354 件 SSOT 化 + LEGAL coverage check rework | (1) `site/privacy.html` 133 件 → 0、(2) `site/terms.html` 118 件 → 0、(3) `site/sla.html` 58 件 → 0、(4) `site/tokushoho.html` 45 件 → 0、(5) namespace `LP_LEGAL_PRIVACY_LABELS` / `LP_LEGAL_TERMS_LABELS` / `LP_LEGAL_SLA_LABELS` / `LP_LEGAL_TOKUSHOHO_LABELS` 新設、(6) check-lp-ssot.mjs L186-260 を「`LP_LEGAL_*_LABELS` の各キーが `data-lp-key` で参照されていること」検証に変更、(7) `EXCLUDED_LEGAL_FILES` (L32-37) 削除、(8) ADR-0009 §例外「法的文書」項目に supersede 表記、(9) 4 ファイル × mobile/desktop = 8 SS 視覚回帰なし | 1683-A（1683-B と並列可） |
+| **1683-D** | 検証 / baseline 0 化 / 設計書同期 / pamphlet 印刷 SS テスト | (1) `scripts/lp-ssot-baseline.json` を `count: 0` に更新、(2) Playwright `emulateMedia({ media: 'print' })` SS テスト追加 (`tests/e2e/pamphlet-print-ssot.spec.ts`)、(3) `docs/design/22a-アイコン・ラベル統一規約.md` SSOT 100% 達成記載、(4) `docs/design/06-UI設計書.md` 関連節更新、(5) `docs/decisions/0009-labels-ssot-principle.md` §例外 supersede 追補、(6) 全 10 ページ × mobile/desktop = 20 SS 視覚回帰なし、(7) #1683 umbrella close | 1683-A + 1683-B + 1683-C 全完了 |
+
+#### 完遂判定
+
+- 1683-A/B/C/D の全 PR が main にマージされ、AC が `[x]` 化され、**`scripts/lp-ssot-baseline.json` の `count = 0` + `EXCLUDED_LEGAL_FILES = []`** が成立した時点で #1683 を close
+- 各 sub-issue は AC 100% 完遂時点で個別 close（partial close 禁止）
+- 全子完了後、本 ADR を `proposed` → `accepted` に昇格
+
+**想定実装時間**: 8-16 時間 / sub × 4 = 32-64 時間（Agent 単独 4 セッション）。**partial PR 禁止 / 申し送り禁止 / AC 妥協禁止** (PO 方針)。
 
 ## 関連
 - ADR-0009（labels.ts SSOT 原則）— 本 ADR 承認時に §例外「法的文書」を supersede 表記


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発チーム / 設計レビュー担当（PO / QA Agent / 後続 Dev Agent 4 名）

**解決する課題**:
ADR-0025 初版で曖昧だった 3 点（SSOT 場所 / DOMPurify 配信 / LEGAL coverage check 整合性）を確定し、後続 Dev Agent が「実装方針が読めない → fail report」を返すループを断ち切る。直前 attempt で「`shared-labels.js` を直接書き換えるべきか / npm 依存を入れるべきか / 既存 LEGAL coverage check と整合するか」が判断できず実装中断に至ったため、4 件の sub-issue 起票前に ADR を amend する。

**期待される効果**:
- 後続 Dev Agent が ADR のみ読めば applyLpKeys template の改修対象 (`scripts/generate-lp-labels.mjs` L377-392)、DOMPurify 配信方法（CDN）、LEGAL coverage check 再設計手順が一意に決まる
- `site/shared-labels.js` を直接編集して再生成で消失する事故を防止
- 4 件の sub-issue (1683-A/B/C/D) を本 PR merge 後に起票し、partial PR / 申し送りなしで完遂可能な scope で並列着手できる

## 関連 Issue

closes # （なし — 本 PR 自体は ADR amendment のみで Issue close しない）
related: #1683 (umbrella, sub-issue 4 件起票後本 amendment を根拠に着手) / #1465 (wontfix, supersede 元) / #1346 (labels 機構 umbrella) / #1350 (OSS 先調査ルール)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | ADR-0025 §決定の文言が「`scripts/generate-lp-labels.mjs` の applyLpKeys template (L377-392) を改修して `site/shared-labels.js` を再生成」に修正されている | `git diff docs/decisions/0025-lp-ssot-html-injection-with-xss-protection.md` | "scripts/generate-lp-labels.mjs" / "applyLpKeys template (L377-392)" / "自動生成ファイル" を含むことを diff で確認 (PASS) |
| AC2 | DOMPurify 配信方法が CDN 必須として明示され、CDN URL (`cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js`) が ADR §決定に書かれている | `grep -F 'cdn.jsdelivr.net/npm/dompurify@3' docs/decisions/0025-*.md` | 1 hit (PASS) |
| AC3 | LEGAL_LABELS coverage check (check-lp-ssot.mjs L186-260) との整合性が ADR §決定 / Migration Plan に追記され、双方向 → 逆方向（labels → HTML 参照）への変更手順が記述されている | ADR diff の §決定 4 項目目 / §LEGAL_LABELS coverage check との整合 節 | 「`LP_LEGAL_*_LABELS` の各キーが `data-lp-key` で参照されている」逆方向検証 + EXCLUDED_LEGAL_FILES 削除手順 (PASS) |
| AC4 | Migration Plan が「子 issue 分解前提」に書き換わり、4 件 sub-issue (1683-A/B/C/D) の AC 抜粋・依存順・完遂判定が明記されている | ADR §結果 §移行計画 表 | 4 行の表 + 完遂判定節 (PASS) |
| AC5 | 各 sub-issue の AC が「ここまでで OK」「残りは続 PR」を含まない | ADR §結果 §移行計画 表本文の grep | 「partial PR 禁止 / 申し送り禁止 / AC 妥協禁止」記載 (PASS) |
| AC6 | ADR amendment 履歴がヘッダ表直下に明示され、何が変わったかが 3 点で要約されている | ADR L11-L17 | 「Amendment 履歴 (2026-04-29)」3 点要約 (PASS) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト
- [x] 設定・CI（厳密には `docs/decisions/` 配下の ADR ファイルのみ）

**影響を受ける画面・機能**: なし（ADR amendment のみで実装変更ゼロ）。ただし本 ADR 確定後に起票される 4 件の sub-issue が `site/*.html` 全 10 ファイル (LP 6 + Legal 4) と `scripts/generate-lp-labels.mjs` / `scripts/check-lp-ssot.mjs` / `src/lib/domain/labels.ts` を変更する。

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | `site/shared-labels.js#applyLpKeys()` で `el.textContent = value` 注入 / `EXCLUDED_LEGAL_FILES` で 354 件除外 | `scripts/generate-lp-labels.mjs` の applyLpKeys template を `el.innerHTML = DOMPurify.sanitize(value)` に書換、CDN 経由で DOMPurify 配信、Legal も SSOT 配下に統合 |
| 一貫性 | ADR-0009 §例外「法的文書」で除外運用 | 本 ADR 確定後に ADR-0009 §例外を supersede（sub-issue 1683-C 内で実施） |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: なし（ADR amendment のみ）
- **リファクタリングが必要だが今回見送った箇所と理由**: なし（実装範囲は本 ADR scope 外）
- **削除したコード・機能**: なし

## 設計方針・将来性

**採用した設計方針**:
- 「partial PR 禁止 = 申し送り禁止 = AC 妥協禁止」の PO 方針を「子 issue 分解禁止」と混同しない。**網羅性のある子 issue + 各子は単独完遂可能 + 全子 AC 合計が 100%** で進める
- SSOT は generated file ではなく generator template（`scripts/generate-lp-labels.mjs`）であることを明示（再生成で上書きされる事故防止）
- DOMPurify CDN は `cdn.jsdelivr.net` の `dompurify@3` major pin（`/npm/dompurify@3/dist/purify.min.js`）。bundle なし、SRI hash は phase B 以降の運用で別途検討（Pre-PMF では cdn.jsdelivr.net の信頼性で十分、ADR-0010 過剰防衛禁止に整合）

**想定する将来の拡張**:
- ADR-0014（i18n 機構選定）で Paraglide に移行する際、`LP_LEGAL_*_LABELS` flat 構造をそのまま PO/JSON ファイルに抽出可能
- DOMPurify が SRI hash 必須になった場合、generate-lp-labels.mjs のみ改修すれば全 10 ファイル一斉対応可能

**意図的に対応しなかった範囲とその理由**:
- DOMPurify SRI hash の固定（Pre-PMF 過剰、cdn.jsdelivr.net 信頼）
- Legal docs の Markdown 化（ADR-0014 の i18n 機構と統合する別議論、本 ADR scope 外）

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — ADR 改定のみで新機能 / 新 interface / 新スキーマ / セキュリティ機能 / 課金変更 / AWS リソース追加 / 3 人日以上の工数 のいずれにも該当しない（ただし本 ADR 自体が ADR-0008 の設計ポリシー先行確認の成果物。実装 sub-issue は本 ADR を根拠に着手）

## テスト戦略

### 追加・変更したテスト

**単体テスト**: なし（ADR docs のみの変更）

**E2Eテスト**: なし（実装は sub-issue で追加）

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check .` | PASS | docs のみ変更のため lint 影響なし（CI 上で確認） |
| 型チェック | `npx svelte-check` | PASS | docs のみ変更のため型影響なし |
| 単体テスト | `npx vitest run` | PASS | docs のみ変更のためテスト影響なし |
| E2E テスト | `npx playwright test` | PASS | docs のみ変更のため E2E 影響なし |

**網羅性の判断根拠**: ADR amendment のみで実装ゼロ。テストは実装 sub-issue で追加する（applyLpKeys unit test、pamphlet print E2E 等）。

### DynamoDB 実装完成度（#1021 — 段階的対応禁止 / ADR-0010）

- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | DOMPurify 設定値（ALLOWED_TAGS / ALLOWED_ATTR / hook で `rel=noopener noreferrer` 強制）を ADR §決定に明示 | XSS 防御は OWASP 推奨の DOMPurify v3 採用、自前 sanitizer は ADR §検討した選択肢 D で却下済み |
| パフォーマンス | DOMPurify CDN bundle ~22KB gzip（LP 1 ロードのみ） | ADR-0010 Pre-PMF 過剰防衛禁止に整合 |
| アクセシビリティ | ALLOWED_ATTR に `aria-hidden` / `aria-label` 含む | nested HTML 内の ARIA 属性を保持 |
| ロギング・モニタリング | applyLpKeys の DOMPurify 未ロード時 `console.warn` フォールバック | network 一時失敗での劣化動作を可視化 |
| ドキュメント | ADR-0025 amendment 完了。ADR-0009 supersede 表記は実装 sub-issue で実施 | 設計書同期は実装 sub-issue で完遂 |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **N/A** — docs のみの変更（実装コードは sub-issue で記述）

### セキュリティ（OSS 公開前提）
- [x] **N/A** — docs のみで秘密情報なし。DOMPurify CDN URL 明示は ADR-0010 過剰防衛禁止に整合（cdn.jsdelivr.net は public CDN）

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] **N/A** — パフォーマンスへの影響なし（実装 sub-issue で評価）

## スクリーンショット / ビジュアルデモ

### 目的（誤解防止）

本 PR は ADR amendment のみで `.svelte` / `.html` / `.css` への変更が一切ないため、UI/UX デザイナー視点の判定が発生しない。スクリーンショットは添付しない（PR template のスクリーンショット要求は UI 変更がある PR に対するもので、本 PR は該当しない）。

### 変更前後の比較

| Before | After |
|--------|-------|
| ADR-0025 初版（曖昧 3 点 + 単一 PR 想定） | ADR-0025 amended（3 点確定 + 子 issue 分解 4 件想定） |

### Playwright スクリーンショット

N/A — UI 変更なし。

### インタラクティブ状態の確認（#1481）

- [x] **N/A** — インタラクティブ状態変化なし

### モバイルビューポート（#1481）

- [x] **N/A** — LP / infra / 設定ファイルのみの変更（厳密には ADR docs のみ）

## 実機操作検証

- [x] N/A — UI 変更なし。ADR docs のみの変更のため目視確認・実機操作不要

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

## レビュー依頼事項・QA

| # | 質問・確認事項 | 選択肢A | 選択肢B | 推奨 | 理由 |
|---|--------------|---------|---------|------|------|
| 1 | DOMPurify CDN provider | cdn.jsdelivr.net | unpkg.com | jsdelivr | jsdelivr は free + 高 uptime + version pin 安定（GitHub 推奨）。unpkg は同等だが jsdelivr の方がアクセシビリティ実績が高い |
| 2 | DOMPurify version pin 範囲 | `dompurify@3` (major) | `dompurify@3.2.4` (patch) | major pin | Pre-PMF では major pin で十分（v4 リリース時に明示的に追従）。patch pin は SRI hash 必須化と同時に検討 |
| 3 | sub-issue 1683-B/C を並列着手させるか直列か | 並列 | 1683-B 完了後 1683-C | 並列 | namespace 別（LP 既存 vs LP_LEGAL 新規）でファイル overlap なし、generator template (1683-A) は前提依存のみ |

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **該当なし** — ADR docs のみで並行実装なし（実装 sub-issue で評価）

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイルを **同時期に変更する open PR が他に無い** ことを確認した（`docs/decisions/0025-*.md` は本 worktree のみで触っている）

### LP 変更時の追加チェック（#1282 / ADR-0010 Pre-PMF）

- [x] **N/A** — LP (`site/**`) の変更なし

### LP / 販促文言変更時の実装パス明示（ADR-0013 / #1314）

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **用語変更**: 該当なし（ADR docs のみ）
- [x] **labels SSOT (ADR-0009)**: N/A — 本 PR では label 追加なし
- [x] **UI構造変更**: N/A
- [x] **カラー・スタイル**: N/A
- [x] **プリミティブ**: N/A
- [x] **設計書（CRITICAL）**: 本 PR 自体が設計書同期（ADR-0025 amendment）

## Ready for Review チェックリスト

- [x] CI が全て通過している（PR テンプレート必須ゲート 5 ジョブを本修正で全緑化）
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）
- [x] **全 AC が実装済みであること**（AC1-6 が全て [x]）
- [x] **Phase 分割が必要だった場合は着手前に PO と合意し、子 Issue を起票済みであること**（本 ADR amendment は子 issue 分解の根拠を確定する PR で、PO 合意済み方針に沿う）
- [x] UI 変更なしのためスクリーンショット要件 N/A（PR template § スクリーンショット で説明）
- [x] 認証画面変更なし — `npm run dev:cognito` 起動不要
- [x] **hardcoded JP text**: docs のみ変更のため `src/routes/**/*.svelte` に影響なし

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない（ADR amendment）

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし（ADR docs のみ）

### スコープ完全性
- [x] **見落とし確認**: 本 PR は ADR の 3 点曖昧確定のみ scope。「ADR 修正中に発見した曖昧点」は本 PR の §決定 / §結果 / §LEGAL coverage check に書き切った（partial 残しなし）

## デプロイ検証（#710 — マージ後必須）

- [x] **N/A** — デプロイ検証不要（ドキュメントのみの変更）

## 完了チェックリスト

- [x] `npx biome check .` — lint エラーなし（docs のみ変更で lint 影響なし、CI で確認）
- [x] `npx svelte-check` — 型エラーなし（docs のみ変更で型影響なし、CI で確認）
- [x] `npx vitest run` — ユニットテスト全通過（docs のみ変更でテスト影響なし、CI で確認）
- [x] `npx playwright test` — E2Eテスト全通過（docs のみ変更で E2E 影響なし、CI で確認）
- [x] PRのサイズが適切（docs/decisions/0025-*.md のみ +85/-24、十分小粒）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

<!-- QM が approve するときに記入。PR 作者は空欄のままでよい。 -->
