### PR TITLE
chore: #1740 #1741 — PR template SS 強化 (修正前/後 × M/PC 4スロット) + ローカルパス禁止 CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -211,20 +211,25 @@ closes #
 
 認証が絡む画面（login / signup / 管理画面 / ops / プラン別 UI）は `npm run dev`（自動認証モード）ではログインフォームが描画されないため、必ず `npm run dev:cognito` (#1026) を起動して実ブラウザで操作したスクリーンショットを使う。
 
-### 変更前後の比較
+### 添付ルール（#1741 — ローカル相対パス禁止）
 
-| Before | After |
-|--------|-------|
-|        |       |
+スクリーンショット URL は **GitHub 上で表示できるもののみ** 受け付ける。以下のいずれかを使うこと:
 
-<!-- モバイル/タブレットに影響する場合はビューポート別に提示 -->
-<!--
-| Viewport | Before | After |
-|----------|--------|-------|
-| Mobile   |        |       |
-| Tablet   |        |       |
-| Desktop  |        |       |
--->
+- **user-attachments URL** — `https://github.com/user-attachments/assets/...`（PR 本文編集画面に画像をドラッグ&ドロップで自動生成）
+- **screenshots branch raw URL** — `https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-XXXX/<file>.png`（SC-007 参照）
+- **docs/screenshots/ raw URL** — `https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/<branch>/docs/screenshots/<file>.png`
+
+⚠️ **禁止**: `tmp/screenshots/...` / `.tmp-screenshots/...` 等のローカル相対パス（`tmp/` は gitignore 対象 — SC-008 / SC-010 参照）。
+PR 提出前に GitHub Web 上のプレビューで画像が表示されていることを目視確認すること。
+
+### 4 スロット添付（#1740 — 修正前 / 修正後 × モバイル / PC）
+
+| | モバイル (375px) | PC (1440px) |
+|---|---|---|
+| **修正前** | `![before-mobile](URL)` | `![before-pc](URL)` |
+| **修正後** | `![after-mobile](URL)` | `![after-pc](URL)` |
+
+UI 変更を含まない PR (refactor / docs / chore のみ) は本セクションに「該当なし（refactor / docs / chore）」と明記する。
 
 ### Playwright スクリーンショット
 
@@ -396,6 +401,7 @@ await page.screenshot({ path: 'screenshots/admin-home-after.png', fullPage: true
 - [ ] **Phase 分割が必要だった場合は着手前に PO と合意し、子 Issue を起票済みであること**（レビュー時に「Phase 1/2 分割提案」はしない）
 - [ ] UI 変更がある場合、**UI/UX デザイナー視点**で `docs/DESIGN.md` §9 禁忌事項 6 点 (色直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / `<style>` 50 行超え) に該当しないことを**目視確認し、証跡としてスクリーンショットを添付**した
 - [ ] 認証が絡む画面を変更した場合、`npm run dev:cognito` (#1026) で実ブラウザ操作した結果のスクリーンショットを添付した
+- [ ] **SS の表示確認 (#1741)**: 添付したスクリーンショットが GitHub Web 上のプレビューで表示されることを確認した（ローカル相対パス `tmp/...` / `.tmp-screenshots/...` を貼っていない）
 - [ ] **hardcoded JP text (#1452 Phase A)**: `node scripts/check-hardcoded-strings.mjs` を実行して件数が baseline（1607件）以下であることを確認した（`src/routes/**/*.svelte` 内の日本語ハードコード増加ゼロ）
 
 ## Critical 修正の追加要件（#612）

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -14,7 +14,7 @@ jobs:
     # Draft PRは作業中なのでスキップ
     if: github.event.pull_request.draft == false
     steps:
-      - name: Check PR body for screenshots
+      - name: Check PR body for screenshots (legacy: 画像有無)
         uses: actions/github-script@v9
         with:
           script: |
@@ -57,6 +57,37 @@ jobs:
             } else {
               core.info('✅ スクリーンショットが検出されました。');
             }
+
+  # ============================================================
+  # #1740 + #1741 — PR スクリーンショット品質チェック
+  #   - #1741: ローカル相対パス (`tmp/`, `.tmp-screenshots/`) 参照を検出
+  #   - #1740: 「修正前 / 修正後」両ラベル付き画像の存在を検証
+  #   - 段階適用: SCREENSHOT_CHECK_MODE=warn (default) で warning として記録、
+  #     dogfooding 期間後に env を `error` に変更して hard-fail に昇格する
+  # ============================================================
+  screenshot-quality-check:
+    name: "SS 品質チェック (修正前/後 + ローカルパス禁止)"
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: scripts/check-pr-screenshot.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Run check-pr-screenshot.mjs
+        env:
+          # 段階適用 (#1740): 最初は warn-only、定着後に error 化
+          SCREENSHOT_CHECK_MODE: warn
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # PR の変更ファイル一覧を取得
+          PR_FILES=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --json files --jq '.files[].path' | tr '\r' ' ')
+          export PR_FILES
+          node scripts/check-pr-screenshot.mjs
 
   design-doc-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -14,7 +14,7 @@ jobs:
     # Draft PRは作業中なのでスキップ
     if: github.event.pull_request.draft == false
     steps:
-      - name: Check PR body for screenshots (legacy: 画像有無)
+      - name: "Check PR body for screenshots (legacy: 画像有無)"
         uses: actions/github-script@v9
         with:
           script: |

--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -133,7 +133,21 @@ MSYS_NO_PATHCONV=1 node scripts/capture.mjs \
 
 - スクリーンショットは docs/screenshots/ に配置してコミットする（tmp/ はgitignore対象）
 - PR bodyの「スクリーンショット / ビジュアルデモ」セクションに貼り付け（Before/After表形式）
-- GitHub raw URL形式: https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/[branch]/docs/screenshots/[file]
+
+#### URL 形式の制約（#1741 — ローカル相対パス禁止）
+
+PR body の SS 添付には **GitHub Web 上で表示できる URL のみ** 使用可。以下のいずれかを使う:
+
+- **user-attachments URL**: `https://github.com/user-attachments/assets/<uuid>`
+  （PR 本文編集画面に画像をドラッグ&ドロップで自動生成。Web UI からの編集が必須）
+- **screenshots branch raw URL**: `https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-XXXX/<file>.png`
+  （SC-007 の orphan branch 運用。bundle PR で SS が大量にある場合に推奨）
+- **docs/screenshots/ raw URL**: `https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/<branch>/docs/screenshots/<file>.png`
+  （単体 PR で SS が少数なら直 commit が簡単）
+
+⚠️ **禁止**: `tmp/screenshots/...` / `.tmp-screenshots/...` のローカル相対パス（`tmp/` は gitignore のため commit できない）。
+⚠️ **必須**: PR 提出前に GitHub Web 上のプレビューで画像が表示されていることを目視確認すること。
+URL を貼っただけで満足せず、自分の目で「見えていること」を確かめる。詳細は SC-010 / SC-008 参照。
 
 ### 5. レビュー結果の報告形式
 
@@ -272,6 +286,8 @@ gh issue list --state open --label "priority:high" --json number,title,labels \
    - 対象: `src/routes/**/*.svelte` / `src/lib/ui/**/*.svelte` / `src/lib/features/**/*.svelte` / `site/**/*.js` / `site/**/*.html` / `site/**/*.css` を変更した PR
    - 撮ったスクショを自分で見て、意図通りの表示になっていることを確認してから添付する（CI 通過のためではなく自己判定の証跡）
    - スクリーンショットは `docs/screenshots/` に配置してコミットし、GitHub raw URL を PR body に記載する（`tmp/` は gitignore のため不可）
+   - **#1741**: PR body には **user-attachments URL / screenshots branch raw URL / docs/screenshots/ raw URL** のいずれかのみ可。`tmp/screenshots/...` の相対パス参照は CI (`scripts/check-pr-screenshot.mjs`) が検出して警告（段階適用後 fail 化予定）
+   - **#1740**: 4 スロット (修正前 × モバイル / 修正前 × PC / 修正後 × モバイル / 修正後 × PC) の `![before-mobile](URL)` / `![after-pc](URL)` 形式で添付し、CI の `screenshot-quality-check` が両ラベルの存在を検証する
 7. CI 全通過後に Ready for Review: `gh pr ready <番号>`
 
 ### 新規実装時

--- a/docs/troubleshoot/screenshot_capture.md
+++ b/docs/troubleshoot/screenshot_capture.md
@@ -427,3 +427,56 @@ lsof -ti:5173 | xargs kill -9
 - VS Code / IDE のターミナルが node process を生かしている可能性をまず疑う
 
 ---
+
+## SC-010 — SS が PR 本文で表示されない（ローカル相対パス添付）
+
+| フィールド | 値 |
+|-----------|-----|
+| **発生日** | 2026-04-29 |
+| **PR 番号** | #1691（観察） / #1740 + #1741（再発防止策確立） |
+| **環境** | 全環境 |
+| **ステータス** | resolved |
+
+### 症状
+
+PR body にスクリーンショットを添付したつもりだが、GitHub Web 上で開くと画像が表示されず壊れたリンクのアイコンだけが見える。
+PR body のソースを見ると `![before](tmp/screenshots/pr-XXXX/before.png)` のようなローカル相対パスが書かれている。
+
+QM Re-Review 時に SS 視認不可で、QM 側で代替撮影することになる（PR #1691 で実発生）。
+
+### 根本原因
+
+- `tmp/` ディレクトリは `.gitignore` で除外されている（SC-008 参照）。リポジトリにコミットされていないファイルへの相対パスは、GitHub の renderer から解決できない。
+- PR 作成時に `scripts/capture.mjs --out tmp/screenshots/pr-XXXX` で撮影したファイルパスをそのまま貼り付けると、GitHub では表示されない。
+- ローカルの VS Code Markdown プレビュー等では「ファイルが手元にあるため」表示されてしまうため、本人の手元では問題に気付けない。
+
+### 解決手順
+
+PR body の SS 添付には **GitHub Web 上で表示できる URL のみ** を使う:
+
+```bash
+# 推奨 1: 撮影 → docs/screenshots/ にコピー → コミット → raw URL
+MSYS_NO_PATHCONV=1 node scripts/capture.mjs --url /admin/children --out tmp/screenshots/pr-XXXX --presets desktop,mobile
+mkdir -p docs/screenshots/pr-XXXX
+cp tmp/screenshots/pr-XXXX/*.png docs/screenshots/pr-XXXX/
+git add docs/screenshots/pr-XXXX/
+git commit -m "docs: pr-XXXX screenshots"
+# PR body に貼る:
+#   ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/<branch>/docs/screenshots/pr-XXXX/before-mobile.png)
+
+# 推奨 2: GitHub Web の PR 編集画面に画像をドラッグ&ドロップ → user-attachments URL が自動生成される
+#   ![after-pc](https://github.com/user-attachments/assets/<uuid>)
+
+# 推奨 3: bundle PR (SS 大量) は SC-007 の screenshots orphan branch を使う
+```
+
+**提出前の必須確認**: PR 本文を保存後、GitHub Web 上のプレビューで画像が表示されていることを目視確認する。表示されていなければ URL を直す。
+
+### 再発防止策
+
+- `scripts/check-pr-screenshot.mjs` (#1740 + #1741) が PR body 内の `tmp/` / `.tmp-screenshots/` 参照を検出し、CI (`pr-quality-gate.yml::screenshot-quality-check`) で警告/失敗する
+- 段階適用フラグ `SCREENSHOT_CHECK_MODE=warn|error` で運用。最初は warn-only で運用し、定着後に `error` に昇格する設計（ADR-0006 ratchet 原則）
+- `docs/sessions/dev-session.md` Screenshot Agent テンプレート §「URL 形式の制約」に明記済
+- `.github/PULL_REQUEST_TEMPLATE.md` の「添付ルール」「Ready for Review チェックリスト」にも記載
+
+---

--- a/scripts/__tests__/check-pr-screenshot.test.mjs
+++ b/scripts/__tests__/check-pr-screenshot.test.mjs
@@ -1,0 +1,183 @@
+/**
+ * scripts/__tests__/check-pr-screenshot.test.mjs
+ *
+ * #1740 + #1741 — PR スクリーンショットチェッカーのユニットテスト。
+ *
+ * 実行: node --test scripts/__tests__/check-pr-screenshot.test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	detectBeforeAfterLabels,
+	detectLocalPaths,
+	hasUiNotApplicableMarker,
+	isUiPr,
+} from '../check-pr-screenshot.mjs';
+
+// ---------------------------------------------------------------------------
+// detectLocalPaths (#1741) — ローカル相対パス禁止
+// ---------------------------------------------------------------------------
+
+describe('detectLocalPaths (#1741)', () => {
+	it('Markdown image with tmp/screenshots を検出する', () => {
+		const body = '本文\n![before](tmp/screenshots/pr-1234/before.png)\n他の本文';
+		const violations = detectLocalPaths(body);
+		assert.equal(violations.length, 1);
+		assert.match(violations[0], /tmp\/screenshots\/pr-1234\/before\.png/);
+	});
+
+	it('Markdown image with .tmp-screenshots を検出する', () => {
+		const body = '![after](.tmp-screenshots/foo.png)';
+		const violations = detectLocalPaths(body);
+		assert.equal(violations.length, 1);
+	});
+
+	it('HTML img with tmp/ を検出する', () => {
+		const body = '<img src="tmp/screenshots/x.png" alt="x">';
+		const violations = detectLocalPaths(body);
+		assert.equal(violations.length, 1);
+	});
+
+	it('user-attachments URL は許可される（違反なし）', () => {
+		const body =
+			'![before](https://github.com/user-attachments/assets/abc123-uuid)\n' +
+			'![after](https://github.com/user-attachments/assets/def456-uuid)';
+		const violations = detectLocalPaths(body);
+		assert.equal(violations.length, 0);
+	});
+
+	it('screenshots branch raw URL は許可される', () => {
+		const body =
+			'![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1234/before.png)';
+		const violations = detectLocalPaths(body);
+		assert.equal(violations.length, 0);
+	});
+
+	it('docs/screenshots/ は raw URL ならば許可', () => {
+		const body =
+			'![ok](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/main/docs/screenshots/x.png)';
+		const violations = detectLocalPaths(body);
+		assert.equal(violations.length, 0);
+	});
+
+	it('複数ローカルパスを全て検出する', () => {
+		const body = '![a](tmp/x.png)\n![b](.tmp-screenshots/y.png)\n<img src="tmp/z.png" alt="z">';
+		const violations = detectLocalPaths(body);
+		assert.equal(violations.length, 3);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// detectBeforeAfterLabels (#1740) — 修正前 / 修正後ラベル検証
+// ---------------------------------------------------------------------------
+
+describe('detectBeforeAfterLabels (#1740)', () => {
+	it('日本語ラベル「修正前」「修正後」両方ある', () => {
+		const body =
+			'## SS\n![修正前-mobile](https://example.com/a.png)\n![修正後-mobile](https://example.com/b.png)';
+		const result = detectBeforeAfterLabels(body);
+		assert.equal(result.hasBefore, true);
+		assert.equal(result.hasAfter, true);
+	});
+
+	it('英語ラベル before / after 両方ある', () => {
+		const body = '![before-pc](https://example.com/a.png)\n![after-pc](https://example.com/b.png)';
+		const result = detectBeforeAfterLabels(body);
+		assert.equal(result.hasBefore, true);
+		assert.equal(result.hasAfter, true);
+	});
+
+	it('混在 (修正前 + after)', () => {
+		const body = '![修正前](https://x.com/a.png)\n![after-mobile](https://x.com/b.png)';
+		const result = detectBeforeAfterLabels(body);
+		assert.equal(result.hasBefore, true);
+		assert.equal(result.hasAfter, true);
+	});
+
+	it('before のみ', () => {
+		const body = '![before](https://x.com/a.png)';
+		const result = detectBeforeAfterLabels(body);
+		assert.equal(result.hasBefore, true);
+		assert.equal(result.hasAfter, false);
+	});
+
+	it('after のみ', () => {
+		const body = '![after](https://x.com/a.png)';
+		const result = detectBeforeAfterLabels(body);
+		assert.equal(result.hasBefore, false);
+		assert.equal(result.hasAfter, true);
+	});
+
+	it('画像なし', () => {
+		const body = '本文のみ';
+		const result = detectBeforeAfterLabels(body);
+		assert.equal(result.hasBefore, false);
+		assert.equal(result.hasAfter, false);
+	});
+
+	it('HTML img alt で「修正後」', () => {
+		const body = '![修正前](url1)\n<img src="url2" alt="修正後 mobile">';
+		const result = detectBeforeAfterLabels(body);
+		assert.equal(result.hasBefore, true);
+		assert.equal(result.hasAfter, true);
+	});
+
+	it('case-insensitive: BEFORE / After', () => {
+		const body = '![BEFORE-x](url1)\n![After-y](url2)';
+		const result = detectBeforeAfterLabels(body);
+		assert.equal(result.hasBefore, true);
+		assert.equal(result.hasAfter, true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isUiPr — UI 関連ファイル判定
+// ---------------------------------------------------------------------------
+
+describe('isUiPr', () => {
+	it('.svelte ファイルがあれば UI PR', () => {
+		assert.equal(isUiPr(['src/routes/admin/+page.svelte']), true);
+	});
+
+	it('site/ 配下の変更も UI PR', () => {
+		assert.equal(isUiPr(['site/index.html']), true);
+	});
+
+	it('.css ファイルも UI PR', () => {
+		assert.equal(isUiPr(['src/lib/ui/styles/app.css']), true);
+	});
+
+	it('docs / scripts のみは UI PR ではない', () => {
+		assert.equal(
+			isUiPr(['docs/decisions/0001.md', 'scripts/check.mjs', '.github/workflows/ci.yml']),
+			false,
+		);
+	});
+
+	it('空配列', () => {
+		assert.equal(isUiPr([]), false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// hasUiNotApplicableMarker — opt-out
+// ---------------------------------------------------------------------------
+
+describe('hasUiNotApplicableMarker', () => {
+	it('「該当なし（refactor）」表記を検出', () => {
+		assert.equal(hasUiNotApplicableMarker('該当なし（refactor / docs / chore）'), true);
+	});
+
+	it('「該当なし(docs)」半角括弧版も検出', () => {
+		assert.equal(hasUiNotApplicableMarker('該当なし(docs only)'), true);
+	});
+
+	it('「UI 変更なし」表記も検出', () => {
+		assert.equal(hasUiNotApplicableMarker('本 PR は UI 変更なし。'), true);
+	});
+
+	it('該当語句なしなら false', () => {
+		assert.equal(hasUiNotApplicableMarker('普通の PR 本文'), false);
+	});
+});

--- a/scripts/check-pr-screenshot.mjs
+++ b/scripts/check-pr-screenshot.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-pr-screenshot.mjs
+ *
+ * #1740 + #1741: PR スクリーンショット添付の品質ゲート。
+ *
+ * 1. **ローカルパス禁止検証 (#1741)**
+ *    PR body 内の `tmp/screenshots/...` / `.tmp-screenshots/...` 等のローカル相対パス参照を検知して fail。
+ *    GitHub web 上で表示できない URL を使うと QM 代替撮影が必要になる事故を防ぐ
+ *    (PR #1691 で観察された運用問題の構造対策)。
+ *
+ * 2. **修正前 / 修正後ラベル検証 (#1740)**
+ *    PR body の Markdown 画像 (`![alt](url)`) または HTML img の alt / surrounding text に
+ *    「修正前 / Before / before-...」「修正後 / After / after-...」のいずれもが含まれているかを検証。
+ *    両方が揃わない場合、警告 / 失敗 (mode により切替)。
+ *
+ * 3. **スキップ判定**
+ *    docs only / refactor 系の PR (UI 関連ファイルを含まない) は両検証ともスキップ。
+ *    ファイルパターンは scripts/check-pr-screenshot.mjs::isUiPr() 参照。
+ *
+ * 4. **段階適用フラグ (#1740 — 「最初は警告のみで開始 → 1-2 週間 dogfooding → エラー化」要件)**
+ *    env `SCREENSHOT_CHECK_MODE` で動作切替:
+ *    - `warn` (default): すべての違反を warning として記録、exit 0
+ *    - `error`: 違反があれば exit 1 (CI を red にする)
+ *
+ *    ローカルパス禁止 (#1741) は警告でもログとして表示される。CI ジョブ側で
+ *    `SCREENSHOT_CHECK_MODE: warn` で warming 期間を運用し、定着後に `error` に昇格する設計。
+ *
+ * 想定実行環境: GitHub Actions の pull_request トリガ
+ *   env:
+ *     PR_BODY:   ${{ github.event.pull_request.body }}
+ *     PR_FILES:  改行区切りの変更ファイル一覧（gh pr view --json files で取得）
+ *     SCREENSHOT_CHECK_MODE: 'warn' (default) | 'error'
+ *
+ * ローカル実行例:
+ *   PR_BODY="$(gh pr view 1740 --json body --jq .body)" \
+ *   PR_FILES="$(gh pr view 1740 --json files --jq '.files[].path' | tr '\n' '\n')" \
+ *     node scripts/check-pr-screenshot.mjs
+ *
+ * exit:
+ *   0 = OK, または warn モードで違反あり
+ *   1 = error モードで違反あり
+ *   2 = internal error
+ */
+
+const MODE = (process.env.SCREENSHOT_CHECK_MODE || 'warn').toLowerCase();
+const PR_BODY = process.env.PR_BODY || '';
+const PR_FILES = (process.env.PR_FILES || '')
+	.split('\n')
+	.map((s) => s.trim())
+	.filter(Boolean);
+
+// ---------------------------------------------------------------------------
+// 検証関数（pure functions, named exports for unit testing）
+// ---------------------------------------------------------------------------
+
+const UI_FILE_PATTERN = /\.(svelte|svelte\.ts|svelte\.js|css|scss)$|^site\//;
+
+/**
+ * 変更ファイル一覧から UI 関連ファイルが含まれるかを判定。
+ * 含まれない場合 SS は不要（docs only / refactor / chore のみの PR）。
+ *
+ * @param {string[]} files
+ * @returns {boolean}
+ */
+export function isUiPr(files) {
+	return files.some((f) => UI_FILE_PATTERN.test(f));
+}
+
+const LOCAL_PATH_PATTERNS = [
+	// Markdown image: ![alt](tmp/...) / ![alt](.tmp-screenshots/...)
+	/!\[[^\]]*\]\((?:\.\/)?(?:tmp|\.tmp-screenshots)\/[^)]+\)/g,
+	// HTML img: <img src="tmp/..."> / <img src=".tmp-screenshots/...">
+	/<img[^>]+src=["'](?:\.\/)?(?:tmp|\.tmp-screenshots)\/[^"']+["'][^>]*>/g,
+];
+
+/**
+ * PR body 内のローカル相対パス参照（tmp/ / .tmp-screenshots/）を検出する。
+ *
+ * @param {string} body
+ * @returns {string[]} 検出された違反箇所の文字列配列
+ */
+export function detectLocalPaths(body) {
+	const violations = [];
+	for (const pattern of LOCAL_PATH_PATTERNS) {
+		const matches = body.matchAll(pattern);
+		for (const m of matches) {
+			violations.push(m[0]);
+		}
+	}
+	return violations;
+}
+
+const BEFORE_LABEL_PATTERN =
+	/!\[[^\]]*(?:修正前|before)[^\]]*\]|<img[^>]*alt=["'][^"']*(?:修正前|before)[^"']*["']/i;
+const AFTER_LABEL_PATTERN =
+	/!\[[^\]]*(?:修正後|after)[^\]]*\]|<img[^>]*alt=["'][^"']*(?:修正後|after)[^"']*["']/i;
+
+/**
+ * PR body から「修正前」「修正後」両方のラベル付き画像参照が見つかるかを判定。
+ *
+ * 検出パターン:
+ * - ![before-mobile](url) / ![Before: ...](url) / ![修正前](url)
+ * - <img alt="after-pc" .../> / <img alt="修正後" .../>
+ *
+ * @param {string} body
+ * @returns {{ hasBefore: boolean, hasAfter: boolean }}
+ */
+export function detectBeforeAfterLabels(body) {
+	return {
+		hasBefore: BEFORE_LABEL_PATTERN.test(body),
+		hasAfter: AFTER_LABEL_PATTERN.test(body),
+	};
+}
+
+/**
+ * 「該当なし」明示記述の検出。refactor / docs / chore のみで UI 影響がない PR の opt-out 用。
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function hasUiNotApplicableMarker(body) {
+	return /該当なし\s*[（(](?:refactor|docs|chore)/i.test(body) || /UI\s*変更\s*なし/i.test(body);
+}
+
+// ---------------------------------------------------------------------------
+// メイン処理
+// ---------------------------------------------------------------------------
+
+function main() {
+	const violations = [];
+
+	// 検証 1: ローカルパス禁止 (#1741) — UI PR でなくても貼ったらアウト
+	const localPaths = detectLocalPaths(PR_BODY);
+	if (localPaths.length > 0) {
+		violations.push({
+			id: 'local-path-forbidden',
+			issue: '#1741',
+			message:
+				`PR body にローカル相対パス参照が ${localPaths.length} 件検出されました。GitHub Web 上で表示できる URL に置き換えてください。\n` +
+				`検出箇所:\n${localPaths
+					.slice(0, 5)
+					.map((s) => `  - ${s}`)
+					.join('\n')}\n` +
+				`\n対応方法:\n` +
+				`  - user-attachments URL: PR 本文編集画面に画像をドラッグ&ドロップ\n` +
+				`  - screenshots branch raw URL: docs/troubleshoot/screenshot_capture.md SC-007 参照\n` +
+				`  - docs/screenshots/ にコミット後、GitHub raw URL を貼付（SC-008 参照）`,
+		});
+	}
+
+	// UI PR かどうかで以降の検証をゲート
+	const isUi = isUiPr(PR_FILES);
+	const optOut = hasUiNotApplicableMarker(PR_BODY);
+
+	if (!isUi || optOut) {
+		console.log(
+			`[screenshot-check] UI 関連ファイル変更なし${optOut ? '（または「該当なし」明示）' : ''} — before/after 検証をスキップ`,
+		);
+	} else {
+		// 検証 2: before/after ラベル検証 (#1740)
+		const { hasBefore, hasAfter } = detectBeforeAfterLabels(PR_BODY);
+		if (!hasBefore || !hasAfter) {
+			const missing = [];
+			if (!hasBefore) missing.push('「修正前 / Before / before-...」ラベル付き画像');
+			if (!hasAfter) missing.push('「修正後 / After / after-...」ラベル付き画像');
+			violations.push({
+				id: 'before-after-missing',
+				issue: '#1740',
+				message:
+					`PR body に ${missing.join(' および ')} が見つかりません。\n` +
+					`PR template の「4 スロット添付」セクション（修正前 / 修正後 × モバイル / PC）を参考に、\n` +
+					`![before-mobile](URL) / ![after-mobile](URL) / ![before-pc](URL) / ![after-pc](URL) の形式で添付してください。\n` +
+					`UI 変更を含まない PR の場合は「該当なし（refactor / docs / chore）」と明記してください。`,
+			});
+		}
+	}
+
+	// 結果出力
+	if (violations.length === 0) {
+		console.log('[screenshot-check] OK — 違反なし');
+		return 0;
+	}
+
+	const isError = MODE === 'error';
+	const prefix = isError ? '[screenshot-check] ERROR' : '[screenshot-check] WARN';
+
+	for (const v of violations) {
+		console.log(`\n${prefix} (${v.id}, ${v.issue}):`);
+		console.log(v.message);
+	}
+
+	console.log(
+		`\n[screenshot-check] mode=${MODE}, violations=${violations.length} ` +
+			`(${isError ? 'CI を red にします' : '段階適用中: warning として記録、CI は通過させます (#1740 段階適用フラグ)'})`,
+	);
+
+	return isError ? 1 : 0;
+}
+
+import { resolve as pathResolve } from 'node:path';
+// CLI 実行時のみ main を呼ぶ（テスト import 時は呼ばない）
+// Windows では import.meta.url が file:///C:/... 形式、process.argv[1] が C:\... 形式になるため
+// fileURLToPath で双方を絶対パスに正規化して比較する
+import { fileURLToPath } from 'node:url';
+
+const isMain = (() => {
+	try {
+		return pathResolve(fileURLToPath(import.meta.url)) === pathResolve(process.argv[1] || '');
+	} catch {
+		return false;
+	}
+})();
+
+if (isMain) {
+	try {
+		process.exit(main());
+	} catch (err) {
+		console.error('[screenshot-check] internal error:', err);
+		process.exit(2);
+	}
+}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（PO + Dev + QA セッション、特に Auto Mode で動作する Agent）

**解決する課題**:
PR レビューで「修正前/後の比較スクショなし」「ローカル相対パス添付で QM が画像を見られない」事故が #1691 等で頻発。Issue の AC を観測可能な完了条件として検証できないままマージされ、PO 直接レビューで 16 項目もの未対応が後追いで発見される構造的劣化が起きている。

**期待される効果**:
- PR template が **修正前 / 修正後 × モバイル 375 / PC 1440 の 4 スロット** を明示し、Dev 自身が UI/UX デザイナー視点で前後比較を自己検証する規律が定着
- ローカル相対パス（`tmp/screenshots/...`）添付を CI で検出して警告 → エラー化（段階適用）することで、QM が代替撮影しなくても全 PR で SS が表示される
- 規律が形骸化したときに CI が物理的に止める

## 関連 Issue

closes #1740
closes #1741

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| #1740-AC1 | PR template「## スクリーンショット / ビジュアルデモ」に修正前/後 × モバイル 375 / PC 1440 の 4 スロット明示 | `.github/PULL_REQUEST_TEMPLATE.md` を grep | `### 4 スロット添付（#1740 — 修正前 / 修正後 × モバイル / PC）` セクション追加、`![before-mobile](URL)` / `![before-pc](URL)` / `![after-mobile](URL)` / `![after-pc](URL)` の 4 プレースホルダー記載 |
| #1740-AC2 | 各スロットに `![label](url)` プレースホルダー | テンプレ目視 | 4 行のテーブルに 4 つの `![...](URL)` 形式 |
| #1740-AC3 | 「スクショは CI 通過のためでなく UI/UX 自己判定証跡」目的説明を冒頭に明示 | テンプレ §「目的（誤解防止）」 | 既存の目的説明節を維持（`docs/DESIGN.md` §9 禁忌事項に違反していないかを「自分の目で判定した結果の証跡」を明文化済） |
| #1740-AC4 | `scripts/check-pr-screenshot.mjs` で「修正前 / Before / before-...」「修正後 / After / after-...」両方の存在検証 | `node --test scripts/__tests__/check-pr-screenshot.test.mjs` | 24/24 tests PASS（`detectBeforeAfterLabels`: 日本語/英語/混在/case-insensitive/HTML alt 全て検証） |
| #1740-AC5 | docs only / refactor のみの PR はスキップ | unit test `isUiPr` + 手動 smoke | `isUiPr(['docs/decisions/0001.md', 'scripts/check.mjs', '.github/workflows/ci.yml'])` → false, `hasUiNotApplicableMarker('該当なし（refactor / docs / chore）')` → true |
| #1740-AC6 | `.github/workflows/pr-quality-gate.yml` の screenshot-check 強化 | workflow diff | `screenshot-quality-check` job 追加（既存 `screenshot-check` job は legacy として共存） |
| #1740-AC7 | 段階適用: 最初は警告のみ → エラー化 | `SCREENSHOT_CHECK_MODE` env で切替 | `warn`(default): exit 0 + WARN 出力 / `error`: exit 1 + ERROR 出力。手動 smoke で両分岐確認済 |
| #1741-AC1 | `docs/sessions/dev-session.md` に「SS は user-attachments URL or screenshots branch raw URL のみ。ローカル相対パス禁止」明文化 | dev-session.md §「URL 形式の制約（#1741 — ローカル相対パス禁止）」 | 「user-attachments URL / screenshots branch raw URL / docs/screenshots/ raw URL」の 3 種を許可、`tmp/...` / `.tmp-screenshots/...` を禁止と明記 |
| #1741-AC2 | `docs/troubleshoot/screenshot_capture.md` に SC-NNN として「SS が PR 表示されない症状（ローカルパス添付）」追加 | screenshot_capture.md §SC-010 | 既存 SC-001〜009 と同形式（症状/根本原因/解決手順/再発防止策）で SC-010 追加 |
| #1741-AC3 | PR template に「SS は GitHub 上で表示確認すること」チェック項目追加 | PR template Ready for Review チェックリスト | `[ ] **SS の表示確認 (#1741)**: 添付したスクリーンショットが GitHub Web 上のプレビューで表示されることを確認した（ローカル相対パス `tmp/...` / `.tmp-screenshots/...` を貼っていない）` 追加 |
| #1741-AC4 | CI で PR body 内の `tmp/` / `.tmp-screenshots/` 相対パス参照を検知して fail | `scripts/check-pr-screenshot.mjs::detectLocalPaths` + workflow ジョブ | 24 unit tests のうち `detectLocalPaths` 7 ケースで Markdown / HTML img / 複数同時検出を verify。`SCREENSHOT_CHECK_MODE=warn`(default)で警告 → 定着後 `error` で fail に昇格する設計 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（UI そのものへの影響はゼロ）。CI ジョブ + PR テンプレ + 開発者向けドキュメント（dev-session.md / troubleshoot KB）への影響のみ。

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | 既存 `screenshot-check` job: PR body に画像 1 枚でもあれば pass の最低限ゲート | 新 `screenshot-quality-check` job: 修正前/修正後ラベル + ローカルパス検出。既存 job は legacy として共存させ、段階適用フラグで warn → error 移行可能にした |
| 一貫性 | 既存 `scripts/check-pr-file-overlap.mjs` の env 駆動 + named export pattern を踏襲 | 同様に `process.env.SCREENSHOT_CHECK_MODE` / pure function named exports / `node --test` ユニットテスト構成 |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: なし（既存 `screenshot-check` job は legacy として残し、新ジョブを並走させる）
- **リファクタリングが必要だが今回見送った箇所と理由**: legacy `screenshot-check` job（画像 1 枚でも pass の弱いゲート）は 2026-05 中旬に新 job が `error` モードで安定稼働を確認できた後に削除予定。今 PR で消すと退行リスクがあるため共存
- **削除したコード・機能**: なし

## 設計方針・将来性

**採用した設計方針**:
- **段階適用フラグ駆動**: env `SCREENSHOT_CHECK_MODE=warn|error` で切替、warn=exit 0、error=exit 1。Issue 要件の「最初は警告のみ → 1-2 週間 dogfooding → エラー化」を**本 PR 内で完成形として実装**した（warn-only 期間用に別 PR を起票しない）
- **pure function + CLI guard 分離**: `detectLocalPaths` / `detectBeforeAfterLabels` / `isUiPr` / `hasUiNotApplicableMarker` を named export し、`node --test` で 24 ケースを単体検証。`fileURLToPath + path.resolve` で Windows / Linux 両方で CLI guard が正しく動く
- **既存 KB 形式踏襲**: troubleshoot SC-010 は既存 SC-001〜009 のフィールド構成（発生日 / PR / 環境 / ステータス / 症状 / 根本原因 / 解決手順 / 再発防止策）と完全一致

**想定する将来の拡張**:
- warn 期間で運用確認後、`SCREENSHOT_CHECK_MODE: error` への env 変更 1 行で hard-fail に昇格可能
- 検出パターンは正規表現を const で抜き出してあるため、追加禁止パスや label を加えるのが容易

**意図的に対応しなかった範囲とその理由**:
- error モード昇格は本 PR では実施しない（dogfooding 期間が必要、Issue が「段階適用」を明示）。ただしロジック自体は完成しているため別 PR / follow-up Issue は不要

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — CI 強化 + ドキュメント整備の運用改善。新規 interface / 新スキーマ / セキュリティ機能 / 課金変更 / AWS リソース / 3 人日以上の工数 いずれも該当しない

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加/変更したテスト: `scripts/__tests__/check-pr-screenshot.test.mjs` 新規 24 ケース
- カバーしたシナリオ:
  - `detectLocalPaths` (#1741): Markdown image with tmp/ / .tmp-screenshots/、HTML img、user-attachments / screenshots branch raw URL は許可、複数同時検出
  - `detectBeforeAfterLabels` (#1740): 日本語/英語/混在/case-insensitive/HTML alt/before のみ/after のみ/画像なし
  - `isUiPr`: .svelte / site/ / .css は UI、docs / scripts / .github は非 UI、空配列
  - `hasUiNotApplicableMarker`: 「該当なし（refactor）」/ 「該当なし(docs)」/ 「UI 変更なし」/ 該当語句なし

**E2Eテスト**:
- 追加/変更したテスト: なし（CI ロジック + ドキュメントのみ。UI / E2E 影響なし）
- カバーしたユーザーフロー: N/A

### テスト実行結果

| テスト種別 | コマンド | 結果 |
|-----------|---------|------|
| Lint | `npx biome check scripts/` | PASS (Checked 58 files in 262ms. No fixes applied) |
| 型チェック | `npx svelte-check` | N/A — .svelte / TS 変更なし |
| 単体テスト | `node --test scripts/__tests__/check-pr-screenshot.test.mjs` | 24 tests passed (suites 4, fail 0) |
| 単体テスト (CI 互換) | `npx vitest run` | N/A — 本スクリプトは Node.js 組込テストランナー使用 (既存 `check-cdk-replacement.test.mjs` と同形式) |
| E2E テスト | `npx playwright test` | N/A — UI 変更なし |
| 手動 smoke (warn mode) | `PR_BODY='![before-mobile](tmp/x.png)' PR_FILES='src/routes/admin/+page.svelte' SCREENSHOT_CHECK_MODE=warn node scripts/check-pr-screenshot.mjs` | exit=0 + WARN 出力 (local-path-forbidden + before-after-missing) |
| 手動 smoke (error mode) | 同上 + SCREENSHOT_CHECK_MODE=error | exit=1 + ERROR 出力 |
| 手動 smoke (OK case) | `PR_BODY='![before-mobile](https://github.com/user-attachments/assets/x1)\n![after-mobile](https://...)' PR_FILES='src/routes/admin/+page.svelte'` | exit=0 + 「OK — 違反なし」 |
| 手動 smoke (docs only skip) | `PR_FILES='docs/decisions/0010.md\n.github/CLAUDE.md'` | exit=0 + 「UI 関連ファイル変更なし — before/after 検証をスキップ」 |

**追加した E2E テストの詳細**: 該当なし（CI スクリプト変更）。

**網羅性の判断根拠**: 本変更の対象は (1) PR template Markdown、(2) Node.js スクリプト、(3) GitHub Actions workflow YAML、(4) 開発者向け .md ドキュメント。アプリ実行コードへの影響ゼロ。Node.js スクリプトのロジックは pure function に分離し 24 unit test で全分岐を網羅。ワークフロー YAML は既存 `pr-quality-gate.yml` と同パターンで追加し、PR がマージされて初めて GitHub Actions 上で実行される（オフライン検証は smoke test で代替）。

### DynamoDB 実装完成度（#1021 — 段階的対応禁止 / ADR-0010）

- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | N/A | 認証・認可・入力検証への影響なし |
| パフォーマンス | N/A | CI ジョブ追加（数秒）+ PR template 追記。ランタイムコスト無し |
| アクセシビリティ | N/A | UI 変更なし |
| ロギング・モニタリング | check-pr-screenshot.mjs は console.log で WARN/ERROR を明示出力 | 段階適用フラグの mode を末尾サマリで明示するため、Actions ログから運用状況を追跡可能 |
| ドキュメント | docs/sessions/dev-session.md + docs/troubleshoot/screenshot_capture.md (SC-010) + PR template の 3 箇所を同期更新 | SSOT 維持 |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: `detectLocalPaths` / `detectBeforeAfterLabels` / `isUiPr` / `hasUiNotApplicableMarker` を独立 pure function に分離
- [x] **依存性逆転（D）**: env 経由で入力を受け、ファイルシステム / GitHub API には触らない（ジョブ側で gh CLI が PR_FILES を構築）
- [x] **インターフェース分離（I）**: 各関数の引数は最小限（body string / files string[]）
- [x] **DRY / 横展開**: `scripts/check-pr-file-overlap.mjs` の env 駆動 pattern を踏襲。既存 `pr-quality-gate.yml::screenshot-check` legacy job は退行防止のため共存（warn 期間後に削除予定）
- [x] **YAGNI**: 段階適用フラグは Issue 要件で明示されているため過剰実装ではない。検出パターンは現要件 (`tmp/` + `.tmp-screenshots/`) のみに絞り、将来の追加用に const で抽出済

### セキュリティ（OSS 公開前提）
- [x] **N/A** — 秘密情報を扱わない。env 経由で公開 PR body を読むだけ

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] **N/A** — N+1 / バンドル影響なし。CI ジョブの所要時間は数秒（regex マッチのみ）

## スクリーンショット / ビジュアルデモ

### 目的（誤解防止）

スクリーンショットは **CI の screenshot-check を通すために貼るものではない**。
起票者自身が **UI/UX デザイナー視点** で `docs/DESIGN.md` §9 禁忌事項に違反していないかを **自分の目で判定した結果の証跡** として残すもの。

### 添付ルール（#1741 — ローカル相対パス禁止）

本 PR は **CI / docs / PR template の変更のみで UI 変更なし**のため、4 スロット SS は不要。

### 4 スロット添付（#1740 — 修正前 / 修正後 × モバイル / PC）

該当なし（refactor / docs / chore — UI 変更なし、CI と PR template とドキュメントのみの変更）

### Playwright スクリーンショット

| 画面 | ビューポート | スクリーンショット |
|------|------------|------------------|
| N/A — UI 変更なし | N/A | N/A |

### インタラクティブ状態の確認（#1481）

- [x] **N/A** — インタラクティブ状態変化なし

### モバイルビューポート（#1481）

- [x] **N/A** — LP / infra / 設定ファイルのみの変更

## 実機操作検証

- [x] 対象画面をブラウザで開き、修正箇所が期待通りに表示されることを目視確認した — N/A (UI 変更なし)
- [x] 認証が絡む画面の場合: `npm run dev:cognito` で確認 — N/A (UI 変更なし)
- [x] 撮ったスクリーンショットを §9 禁忌事項照合 — N/A (UI 変更なし)
- [x] UI/UX デザイナー視点セルフレビュー — N/A (UI 変更なし)
- [x] チュートリアル関連の変更 — N/A
- [x] 用語変更 — N/A

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**
- [ ] このPRに破壊的変更が**含まれる**（以下に詳細を記載）

## レビュー依頼事項・QA

| # | 質問・確認事項 | 選択肢A | 選択肢B | 推奨 | 理由 |
|---|--------------|---------|---------|------|------|
| 1 | warn → error 昇格のタイミング | 本 PR で error にする | warn で merge し別 PR で error 化 | warn でマージ | Issue が「段階適用: 最初は警告のみで開始 → 1-2 週間 → 必須化」を明示しており、本 PR で `warn` 設定で完成形にしてある。env 1 行変更で error 昇格できるため別 PR / follow-up Issue 起票は不要（QM Approve 後の運用判断） |
| 2 | legacy `screenshot-check` job の扱い | 本 PR で削除 | 共存（推奨） | 共存 | 新 job が `error` モードで安定稼働した時点で削除する方が安全。今削除すると退行リスク |

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **本番アプリ** (`src/routes/(child)/`, `src/routes/(parent)/`) — N/A (UI 変更なし)
- [x] **デモ版** (`src/routes/demo/`) — N/A
- [x] **LP ↔ アプリ整合（双方向）（#1481）**:
  - [x] **N/A** — LP / アプリの文言・機能に影響しない変更（CI + 開発者向けドキュメント + PR template のみ）
- [x] **全年齢モード** (`baby/preschool/elementary/junior/senior` の 5 ディレクトリ) — N/A
- [x] **ナビゲーション** (`AdminLayout` + `AdminMobileNav` + `BottomNav`) — N/A
- [x] **E2E/ユニットシード** (`tests/e2e/global-setup.ts`, `tests/unit/helpers/test-db.ts`, `src/lib/server/demo/demo-data.ts`) — N/A (DB スキーマ変更なし)
- [x] **チュートリアル + デモガイド** (`tutorial-chapters.ts`, `demo-guide-state.svelte.ts`) — N/A (UI 構造変更なし)
- [x] **該当なし** — 並行実装の影響範囲外の変更

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイルを **同時期に変更する open PR が他に無い** ことを確認した
  - 変更ファイル: `.github/PULL_REQUEST_TEMPLATE.md` / `.github/workflows/pr-quality-gate.yml` / `docs/sessions/dev-session.md` / `docs/troubleshoot/screenshot_capture.md` / `scripts/check-pr-screenshot.mjs` (新規) / `scripts/__tests__/check-pr-screenshot.test.mjs` (新規)
  - 並行 PR (A2: docs/sessions / A3: backend) との overlap 可能性: docs/sessions/dev-session.md は A2 と overlap しうる → CI の `pr-file-overlap` が overlap を検出した場合は最終 push 直前に rebase する

### LP 変更時の追加チェック（#1282 / ADR-0010 Pre-PMF）

- [x] **N/A** — LP (`site/**`) の変更なし

### LP / 販促文言変更時の実装パス明示（ADR-0013 / #1314）

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **用語変更**: 用語追加・変更なし
- [x] **labels SSOT (ADR-0009)**:
  - [x] N/A — ユーザー向け文言の追加/変更なし
- [x] **UI構造変更**: チュートリアル変更なし
- [x] **カラー・スタイル**: hex 直書きなし
- [x] **プリミティブ**: UI 変更なし
- [x] **設計書（CRITICAL）**: 設計書の更新ルール表（`docs/CLAUDE.md`）に該当する変更なし。ただし `docs/sessions/dev-session.md` (Dev セッション運用 SSOT) と `docs/troubleshoot/screenshot_capture.md` (SS 撮影 KB SSOT) は同 PR 内で更新済み

## Ready for Review チェックリスト

- [x] CI が全て通過している
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）
- [x] **全 AC が実装済みであること**（TODO / 予定 のまま残っている AC がないこと）— #1740 AC1〜7 + #1741 AC1〜4 の 11 件すべて実装済
- [x] **Phase 分割が必要だった場合は着手前に PO と合意し、子 Issue を起票済みであること** — Phase 分割なし（段階適用フラグは本 PR 内で完成）
- [x] UI 変更がある場合 — N/A (UI 変更なし)
- [x] 認証が絡む画面 — N/A
- [x] **SS の表示確認 (#1741)**: SS 添付なし (UI 変更なし)
- [x] **hardcoded JP text (#1452 Phase A)**: `src/routes/**/*.svelte` 変更なし（baseline 影響なし）

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない（priority:medium の運用プロセス改善）

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の production guard 追加なし。`SCREENSHOT_CHECK_MODE` は CI の workflow YAML 内デフォルト値駆動（必須化されておらず、未設定でも `warn` で動作）

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし（CI ジョブ追加 + PR template + ドキュメント）

### スコープ完全性
- [x] **見落とし確認**: 両 Issue (#1740 / #1741) の全 AC を 1 PR で完遂。partial PR / follow-up Issue 起票なし

## デプロイ検証（#710 — マージ後必須）

- [x] **N/A** — デプロイ検証不要（CI スクリプト + ドキュメント + PR template のみ。本番ランタイムへの影響なし）

## 完了チェックリスト

- [x] `npx biome check scripts/` — lint エラーなし (Checked 58 files in 262ms. No fixes applied)
- [x] `npx svelte-check` — N/A（.svelte / TS 変更なし）
- [x] `node --test scripts/__tests__/check-pr-screenshot.test.mjs` — 24/24 PASS
- [x] `npx playwright test` — N/A（UI 変更なし）
- [x] PRのサイズが適切（目安: 500行/10ファイル以内。超える場合は分割を検討） — 6 files / 525 insertions / 14 deletions（unit test の 24 ケース・SC-010 KB エントリ・PR template 詳細記述で行数が増えたが、論理的に 1 セットの変更）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

<!-- QM が approve するときに記入。PR 作者は空欄のままでよい。 -->

