### PR TITLE
feat: #1766 capture.mjs に DOM スナップショット機能追加 (#1747 AC4 follow-up)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -222,6 +222,20 @@ closes #
 ⚠️ **禁止**: `tmp/screenshots/...` / `.tmp-screenshots/...` 等のローカル相対パス（`tmp/` は gitignore 対象 — SC-008 / SC-010 参照）。
 PR 提出前に GitHub Web 上のプレビューで画像が表示されていることを目視確認すること。
 
+### DOM スナップショット併記ルール（#1747 AC4 / #1766）
+
+UI 変更 PR で SS を添付する場合、**SS と同一プロセスで取得した DOM HTML スナップショット (`<file>.dom.html`) へのリンクを併記すること**。
+`scripts/capture.mjs` がデフォルトで DOM HTML を SS と同じディレクトリに保存し、`--pr` モードでは PR body 用 Markdown スニペットに自動併記される。
+
+| | スクリーンショット | DOM HTML スナップショット |
+|---|---|---|
+| 役割 | 視覚的確認 | 構造タグ / ラベルの機械的 grep 検証 |
+| 取得タイミング | `page.screenshot()` | 同一 page から `document.documentElement.outerHTML` |
+| ファイル名 | `<name>.png` / `<name>.webp` | `<name>.dom.html` |
+
+⚠️ **禁止**: SS だけ添付して `.dom.html` 参照を省略する（CI の `screenshot-quality-check` が UI PR で検出して警告/失敗する）。
+`--no-dom-snapshot` で意図的に省略する場合は **本セクションに省略理由を明記**すること（背景: PR #1717 で SS と実機 DOM が乖離していた事故の構造的再発防止）。
+
 ### 4 スロット添付（#1740 — 修正前 / 修正後 × モバイル / PC）
 
 | | モバイル (375px) | PC (1440px) |
@@ -402,6 +416,7 @@ await page.screenshot({ path: 'screenshots/admin-home-after.png', fullPage: true
 - [ ] UI 変更がある場合、**UI/UX デザイナー視点**で `docs/DESIGN.md` §9 禁忌事項 6 点 (色直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / `<style>` 50 行超え) に該当しないことを**目視確認し、証跡としてスクリーンショットを添付**した
 - [ ] 認証が絡む画面を変更した場合、`npm run dev:cognito` (#1026) で実ブラウザ操作した結果のスクリーンショットを添付した
 - [ ] **SS の表示確認 (#1741)**: 添付したスクリーンショットが GitHub Web 上のプレビューで表示されることを確認した（ローカル相対パス `tmp/...` / `.tmp-screenshots/...` を貼っていない）
+- [ ] **DOM スナップショット併記 (#1747 AC4 / #1766)**: UI 変更 PR で SS を添付している場合、対応する `<file>.dom.html` リンクが PR body に含まれていることを確認した（`--no-dom-snapshot` で省略する場合は理由を本文に明記済み）
 - [ ] **hardcoded JP text (#1452 Phase A)**: `node scripts/check-hardcoded-strings.mjs` を実行して件数が baseline（1607件）以下であることを確認した（`src/routes/**/*.svelte` 内の日本語ハードコード増加ゼロ）
 
 ## Critical 修正の追加要件（#612）

--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -100,11 +100,20 @@ MSYS_NO_PATHCONV=1 node scripts/capture.mjs \
   --out tmp/screenshots/pr-XXXX \
   --presets desktop,mobile
 
+撮影と同時に DOM HTML スナップショット (`<file>.dom.html`) が同一プロセスで自動保存される (#1747 AC4 / #1766)。
+これは PR #1717 で発生した「SS と実機が乖離していた」事故の再発防止のため、SS と DOM が
+**同一プロセス・同一 page インスタンス** で取得されたことを構造的に保証するもの。
+QM Re-Review 時に DOM HTML を grep して構造タグの保持を機械的に検証可能になる。
+
+`--no-dom-snapshot` で opt-out 可能だが、その場合は PR body に省略理由を明記する必要がある
+（CI の `screenshot-quality-check` で UI PR の場合に DOM 参照欠落が検出される）。
+
 ### 2. コマンドの禁止事項
 
 - /demo/* のURLは使用禁止（デモ画面は実アプリではない）
 - フルURL（http://...）を--urlに渡さない（内部で二重結合になり404になる既知バグ）
 - MSYS_NO_PATHCONV=1 なしで実行しない（パスがWindowsパスに変換されて404になる）
+- DOM スナップショットを `--no-dom-snapshot` で省略する場合は PR body に理由を必ず明記する（CI が DOM HTML 参照の欠落を検出する — #1766）
 
 ### 3. 撮影後のUI/UXセルフレビュー（Agentが自分で実施）
 
@@ -132,7 +141,9 @@ MSYS_NO_PATHCONV=1 node scripts/capture.mjs \
 ### 4. 成果物の配置
 
 - スクリーンショットは docs/screenshots/ に配置してコミットする（tmp/ はgitignore対象）
+- DOM HTML スナップショット（`<file>.dom.html`）も SS と同じディレクトリに併せてコミットする (#1747 AC4 / #1766)
 - PR bodyの「スクリーンショット / ビジュアルデモ」セクションに貼り付け（Before/After表形式）
+- 各 SS の直下に対応する DOM HTML へのリンクを併記する（`scripts/capture.mjs --pr` の出力 Markdown スニペットに自動で含まれる）
 
 #### URL 形式の制約（#1741 — ローカル相対パス禁止）
 

--- a/docs/sessions/qa-session.md
+++ b/docs/sessions/qa-session.md
@@ -123,6 +123,10 @@ gh issue view <X> --repo Takenori-Kusaka/ganbari-quest
 - PR body の `![...]()` / `<img>` / 外部 URL を **Read tool で実際に開いて見る**
 - 見ていない画像に所見を書いてはならない
 - **1 画像につき最低 1 行の具体的な所見を記録する**（「見ました」だけは不可）
+- **DOM HTML スナップショット（`<file>.dom.html`）が併記されているか確認**（#1747 AC4 / #1766）。SS と DOM が同一プロセスで取得されたことの構造的証跡。SS だけ添付されていて `.dom.html` 参照が無い UI PR は CI の `screenshot-quality-check` で検出されるが、QM 側でも以下を確認:
+  - SS 1 枚に対して同名 `.dom.html` リンクが PR body に存在するか
+  - `.dom.html` を Read tool で開き、SS で見える主要ラベル / 文字列が DOM HTML 内にも存在することを 1 件以上 grep で確認（PR #1717 で発覚した「SS と実機 DOM の乖離」を機械的に検知できる唯一の手段）
+  - DOM HTML が省略されている場合は PR body に省略理由が明記されているか確認。明記なければ手順 5 で BLOCK
 
 #### 「描画変化なし」主張の diff 検証（#1744）
 

--- a/docs/troubleshoot/screenshot_capture.md
+++ b/docs/troubleshoot/screenshot_capture.md
@@ -480,3 +480,63 @@ git commit -m "docs: pr-XXXX screenshots"
 - `.github/PULL_REQUEST_TEMPLATE.md` の「添付ルール」「Ready for Review チェックリスト」にも記載
 
 ---
+
+## SC-011 — DOM スナップショット併記必須化（SS と実機の乖離防止）
+
+| フィールド | 値 |
+|-----------|-----|
+| **発生日** | 2026-04-30 |
+| **PR 番号 / Issue 番号** | #1717（事故）/ #1747 AC4（再発防止）/ #1766（実装） |
+| **環境** | 全環境 |
+| **ステータス** | resolved |
+
+### 症状
+
+PR #1717（Legal SSOT 化）で SS が PR body に添付されていたものの、実機 DOM とは乖離していた（DOMPurify が legal docs の構造タグを strip していたが、SS だけでは見抜けなかった）事例。QM Re-Review で構造タグの保持を grep 検証したくても、SS の中身を機械的に検査する手段が無かった。
+
+### 根本原因
+
+SS は画像であり、文字列としては検査できない。SS を撮ったタイミングと実機を別途確認するタイミングがずれると、撮影時の DOM 状態が後で再現できない。CI で構造タグの保持・ラベル文字列の存在確認をしたくても、PR body に添付された画像を OCR するのは非現実的。
+
+### 解決手順
+
+**`scripts/capture.mjs` のデフォルト動作で DOM HTML を併せて保存する** (#1766 で導入):
+
+1. SS と DOM HTML を **同一プロセス・同一 Playwright page インスタンス** で取得
+2. `<file>.png` / `<file>.webp` の隣に `<file>.dom.html` を保存
+3. `--pr` モードで出力される Markdown スニペットには SS の直下に `[DOM HTML](...)` リンクが自動併記される
+
+```bash
+# デフォルトで DOM スナップショット有効
+MSYS_NO_PATHCONV=1 node scripts/capture.mjs --pr 1766 --url /admin/children --presets desktop,mobile
+
+# 出力例:
+#   tmp/screenshots/pr-1766/admin-children-desktop.png
+#   tmp/screenshots/pr-1766/admin-children-desktop.dom.html
+#   tmp/screenshots/pr-1766/admin-children-mobile.png
+#   tmp/screenshots/pr-1766/admin-children-mobile.dom.html
+
+# 意図的に opt-out する場合（PR body に理由明記必須）
+MSYS_NO_PATHCONV=1 node scripts/capture.mjs --no-dom-snapshot --url /admin/children
+```
+
+**QM Re-Review での活用**:
+
+```bash
+# 構造タグの保持確認（PR #1717 のような事故の検知）
+grep -E '<(article|h[1-6]|table|thead|tbody|tr|td|ol|ul|li)\b' \
+  tmp/screenshots/pr-1766/admin-children-desktop.dom.html
+
+# 表示すべきラベルが DOM 上に存在するか（CI 自動拒否ルールの強化に使える）
+grep '保護者向けの管理画面' tmp/screenshots/pr-1766/admin-children-desktop.dom.html
+```
+
+### 再発防止策
+
+- `scripts/lib/screenshot-helpers.mjs` の `ScreenshotCapture.capture()` がデフォルトで DOM HTML を保存（opt-out フラグは `--no-dom-snapshot`）
+- `scripts/check-pr-screenshot.mjs` が UI PR で SS が添付されているのに `.dom.html` 参照が無い PR を CI で検出（#1766 / #1747 AC4）
+- `docs/sessions/dev-session.md` Screenshot Agent テンプレート §1 にデフォルト動作を明記
+- `docs/sessions/qa-session.md` 手順 2 で QM が DOM HTML を Read tool で開いて主要ラベル grep を実行するルールを追加
+- `.github/PULL_REQUEST_TEMPLATE.md` 「スクリーンショット / ビジュアルデモ」セクションで `.dom.html` 併記を必須化
+
+---

--- a/scripts/capture-specs/admin.mjs
+++ b/scripts/capture-specs/admin.mjs
@@ -8,6 +8,10 @@
  * 使用例:
  *   npm run capture:admin                          # tmp/screenshots/ に保存
  *   node scripts/capture.mjs --pr 123 --config scripts/capture-specs/admin.mjs
+ *
+ * DOM スナップショット (#1747 AC4 / #1766):
+ *   各 SS と同じディレクトリに <name>.dom.html が同一プロセスで自動保存される。
+ *   無効化したい場合は --no-dom-snapshot を付与（推奨されない）。
  */
 
 /** @type {Array<{ url: string; name: string; presets?: string[]; selector?: string }>} */

--- a/scripts/capture-specs/lp.mjs
+++ b/scripts/capture-specs/lp.mjs
@@ -14,6 +14,12 @@
  *   npx serve site -l 5280 &
  *   node scripts/capture.mjs --base-url http://localhost:5280 \
  *     --config scripts/capture-specs/lp.mjs --out tmp/screenshots/
+ *
+ * DOM スナップショット (#1747 AC4 / #1766):
+ *   各 SS と同じディレクトリに <name>.dom.html が同一プロセスで自動保存される。
+ *   LP は SSOT 注入 (ADR-0025) で innerHTML が動的に書き換わるため、QM Re-Review で
+ *   <article> / <h2> / <table> 等の構造タグ保持を機械的に grep 検証できる用途を想定。
+ *   無効化したい場合は --no-dom-snapshot を付与（推奨されない）。
  */
 
 /** @type {Array<{ url: string; name: string; presets?: string[]; fullPage?: boolean }>} */

--- a/scripts/capture.mjs
+++ b/scripts/capture.mjs
@@ -63,6 +63,9 @@ const { values, positionals } = parseArgs({
 		pr: { type: 'string' }, // PR 番号 → 出力先自動化 + Markdown 生成
 		'start-server': { type: 'boolean' }, // 未起動なら自動起動（--pr 時デフォルト true）
 		'server-mode': { type: 'string', default: 'dev' }, // dev | cognito | lp
+		// #1766 (#1747 AC4): SS と DOM HTML スナップショットを同一プロセスで取得する。
+		// デフォルト有効。`--no-dom-snapshot` 指定時のみ無効化される。
+		'no-dom-snapshot': { type: 'boolean', default: false },
 		help: { type: 'boolean', default: false },
 	},
 });
@@ -120,6 +123,13 @@ QA / PR 用オプション:
                       cognito  → npm run dev:cognito (port 5174)  認証が必要な画面用
                       lp       → npx serve site (port 5280)  LP (site/) 用
 
+DOM スナップショット (#1747 AC4 / #1766):
+  デフォルトで撮影と同じ Playwright page から
+  document.documentElement.outerHTML を <name>.dom.html として保存します。
+  SS と DOM が同一プロセス・同一 page で取得されたことを構造的に保証し、
+  PR #1717 で発生した「SS と実機が乖離している」事故の再発を防ぎます。
+  --no-dom-snapshot DOM スナップショット保存を無効化（デフォルト: 有効）
+
   --help            このヘルプを表示
 
 トラブルシュート:
@@ -175,6 +185,9 @@ const storageState = values['storage-state'];
 
 // --start-server: --pr 指定時はデフォルト true、それ以外は false
 const shouldAutoStart = values['start-server'] ?? prNumber !== null;
+
+// #1766: DOM スナップショット取得有無（--no-dom-snapshot で opt-out）
+const domSnapshotEnabled = !values['no-dom-snapshot'];
 
 // プリセット検証（早期エラー）
 for (const name of presetNames) {
@@ -381,10 +394,11 @@ function pushToScreenshotsBranch(prNum, filePaths) {
 
 /**
  * @param {string} prNumber
- * @param {string[]} filePaths - 撮影されたファイルの絶対パス
+ * @param {string[]} filePaths - 撮影された SS ファイルの絶対パス
  * @param {boolean} pushedToScreenshots - screenshots ブランチへの push が成功したか
+ * @param {string[]} [domFiles] - 同時取得した DOM HTML ファイルの絶対パス (#1766)
  */
-function printPrMarkdown(prNumber, filePaths, pushedToScreenshots) {
+function printPrMarkdown(prNumber, filePaths, pushedToScreenshots, domFiles = []) {
 	if (filePaths.length === 0) return;
 
 	const screenshotsBase = `https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-${prNumber}`;
@@ -393,6 +407,15 @@ function printPrMarkdown(prNumber, filePaths, pushedToScreenshots) {
 
 	// push が成功した場合は raw.githubusercontent.com URL を使用、失敗時はフォールバック
 	const repoBase = pushedToScreenshots ? screenshotsBase : fallbackBase;
+
+	// SS basename → DOM HTML basename の対応マップ（#1766: SS と同じディレクトリ・同じ basename + .dom.html）
+	const ssBasenameToDom = new Map();
+	for (const dom of domFiles) {
+		const domBase = path.basename(dom);
+		// admin-home.dom.html → admin-home（拡張子 = .png/.webp と仮定して逆引きできるよう basename のみ保持）
+		const stripped = domBase.replace(/\.dom\.html$/, '');
+		ssBasenameToDom.set(stripped, domBase);
+	}
 
 	const sep = '='.repeat(60);
 	console.log(`\n${sep}`);
@@ -403,18 +426,30 @@ function printPrMarkdown(prNumber, filePaths, pushedToScreenshots) {
 	// ファイルをプリセット別にグループ化して表示
 	const grouped = new Map();
 	for (const fp of filePaths) {
-		const name = path.basename(fp, path.extname(fp));
+		const ext = path.extname(fp);
+		const name = path.basename(fp, ext);
 		// push 成功時はファイル名のみ、失敗時は相対パス
 		const urlPath = pushedToScreenshots
 			? path.basename(fp)
 			: path.relative(process.cwd(), fp).replace(/\\/g, '/');
+		// 対応する DOM HTML を探す
+		const domBase = ssBasenameToDom.get(name);
+		let domUrlPath;
+		if (domBase) {
+			if (pushedToScreenshots) {
+				domUrlPath = domBase;
+			} else {
+				const dir = path.dirname(fp);
+				domUrlPath = path.relative(process.cwd(), path.join(dir, domBase)).replace(/\\/g, '/');
+			}
+		}
 		// preset サフィックス（-mobile / -desktop / -tablet）を検出
 		const presetMatch = name.match(/-(mobile|desktop|tablet)$/);
 		const label = presetMatch
 			? presetMatch[1].charAt(0).toUpperCase() + presetMatch[1].slice(1)
 			: name;
 		const key = presetMatch ? presetMatch[1] : name;
-		grouped.set(key, { label, urlPath, name });
+		grouped.set(key, { label, urlPath, name, domUrlPath });
 	}
 
 	// desktop → mobile の順で表示
@@ -424,9 +459,20 @@ function printPrMarkdown(prNumber, filePaths, pushedToScreenshots) {
 		...[...grouped.entries()].filter(([k]) => !order.includes(k)).map(([, v]) => v),
 	];
 
-	for (const { label, urlPath, name } of sorted) {
+	for (const { label, urlPath, name, domUrlPath } of sorted) {
 		console.log(`### ${label}`);
-		console.log(`![${name}](${repoBase}/${urlPath})\n`);
+		console.log(`![${name}](${repoBase}/${urlPath})`);
+		// #1766: DOM HTML スナップショットへのリンクを SS の直下に併記する
+		if (domUrlPath) {
+			console.log(`[DOM HTML (${name}.dom.html)](${repoBase}/${domUrlPath})`);
+		}
+		console.log('');
+	}
+
+	if (domFiles.length > 0) {
+		console.log(
+			`> DOM スナップショット: ${domFiles.length} 件添付。SS と同一 page で取得 (#1747 AC4 / #1766)。\n`,
+		);
 	}
 
 	console.log(`${sep}\n`);
@@ -493,13 +539,35 @@ async function runFlowMode() {
 		if (result.compositePath) {
 			console.log(`合成 WebP: ${result.compositePath}`);
 			console.log(`Markdown: ${path.join(outputDir, `${values.flow}-flow.md`)}`);
-			return [result.compositePath];
+			return { screenshots: [result.compositePath], domFiles: [] };
 		}
 	} catch (err) {
 		console.error(`\nエラー: ${err.message}`);
 		process.exit(1);
 	}
-	return [];
+	return { screenshots: [], domFiles: [] };
+}
+
+/**
+ * `ScreenshotCapture.capture()` の結果をログ出力 + 配列に積む共通ロジック (#1766)。
+ * @param {{ ok: true; filePath: string; size: number; domPath?: string; domSize?: number } | { ok: false; error: Error }} result
+ * @param {string[]} capturedFiles
+ * @param {string[]} domFiles
+ * @returns {boolean} 成功時 true
+ */
+function recordCaptureResult(result, capturedFiles, domFiles) {
+	if (!result.ok) {
+		console.error(`  エラー: ${result.error.message}`);
+		return false;
+	}
+	console.log(`  -> ${result.filePath} (${(result.size / 1024).toFixed(0)} KB)`);
+	capturedFiles.push(result.filePath);
+	if (result.domPath) {
+		const kb = (result.domSize ?? 0) / 1024;
+		console.log(`  -> ${result.domPath} (DOM ${kb < 1 ? '<1' : Math.round(kb)} KB)`);
+		domFiles.push(result.domPath);
+	}
+	return true;
 }
 
 // ============================================================
@@ -525,10 +593,16 @@ async function runConfigMode() {
 		process.exit(1);
 	}
 
-	const capturer = new ScreenshotCapture({ baseUrl, outputDir, locale: 'ja-JP' });
+	const capturer = new ScreenshotCapture({
+		baseUrl,
+		outputDir,
+		locale: 'ja-JP',
+		domSnapshot: domSnapshotEnabled,
+	});
 	await capturer.setup();
 
 	const capturedFiles = [];
+	const domFiles = [];
 	let success = 0;
 	let total = 0;
 	for (const page of pages) {
@@ -548,19 +622,16 @@ async function runConfigMode() {
 				selector: page.selector,
 				storageState,
 			});
-			if (result.ok) {
-				console.log(`  -> ${result.filePath} (${(result.size / 1024).toFixed(0)} KB)`);
-				capturedFiles.push(result.filePath);
-				success++;
-			} else {
-				console.error(`  エラー: ${result.error.message}`);
-			}
+			if (recordCaptureResult(result, capturedFiles, domFiles)) success++;
 		}
 	}
 
 	await capturer.teardown();
 	console.log(`\n完了: ${success}/${total} キャプチャ`);
-	return capturedFiles;
+	if (domFiles.length > 0) {
+		console.log(`DOM スナップショット: ${domFiles.length} 件保存 (#1747 AC4 / #1766)`);
+	}
+	return { screenshots: capturedFiles, domFiles };
 }
 
 // ============================================================
@@ -574,11 +645,17 @@ async function runUrlMode() {
 		process.exit(1);
 	}
 
-	const capturer = new ScreenshotCapture({ baseUrl, outputDir, locale: 'ja-JP' });
+	const capturer = new ScreenshotCapture({
+		baseUrl,
+		outputDir,
+		locale: 'ja-JP',
+		domSnapshot: domSnapshotEnabled,
+	});
 	await capturer.setup();
 
 	const baseName = url.replace(/[^a-zA-Z0-9]/g, '-').replace(/^-+|-+$/g, '') || 'screenshot';
 	const capturedFiles = [];
+	const domFiles = [];
 
 	for (const presetName of presetNames) {
 		const viewport = resolvePreset(presetName);
@@ -594,17 +671,15 @@ async function runUrlMode() {
 			selector: values.selector,
 			storageState,
 		});
-		if (result.ok) {
-			console.log(`  -> ${result.filePath} (${(result.size / 1024).toFixed(0)} KB)`);
-			capturedFiles.push(result.filePath);
-		} else {
-			console.error(`  エラー: ${result.error.message}`);
-		}
+		recordCaptureResult(result, capturedFiles, domFiles);
 	}
 
 	await capturer.teardown();
 	console.log(`\n完了: ${capturedFiles.length}/${presetNames.length} キャプチャ`);
-	return capturedFiles;
+	if (domFiles.length > 0) {
+		console.log(`DOM スナップショット: ${domFiles.length} 件保存 (#1747 AC4 / #1766)`);
+	}
+	return { screenshots: capturedFiles, domFiles };
 }
 
 // ============================================================
@@ -634,21 +709,25 @@ if (serverChild) {
 }
 
 try {
-	let capturedFiles = [];
+	/** @type {{ screenshots: string[]; domFiles: string[] }} */
+	let result = { screenshots: [], domFiles: [] };
 
 	if (values.flow) {
-		capturedFiles = await runFlowMode();
+		result = await runFlowMode();
 	} else if (values.config) {
-		capturedFiles = await runConfigMode();
+		result = await runConfigMode();
 	} else {
-		capturedFiles = await runUrlMode();
+		result = await runUrlMode();
 	}
+
+	const { screenshots: capturedFiles, domFiles } = result;
 
 	// --pr 指定時: screenshots ブランチに push してから PR body 用 Markdown スニペットを出力
 	if (prNumber !== null && capturedFiles.length > 0) {
 		ensureScreenshotsBranch();
-		const pushed = pushToScreenshotsBranch(prNumber, capturedFiles);
-		printPrMarkdown(prNumber, capturedFiles, pushed);
+		// SS と DOM HTML を同じコミットで screenshots ブランチに push する (#1766)
+		const pushed = pushToScreenshotsBranch(prNumber, [...capturedFiles, ...domFiles]);
+		printPrMarkdown(prNumber, capturedFiles, pushed, domFiles);
 	}
 } finally {
 	// 自動起動したサーバーを確実に停止

--- a/scripts/check-pr-screenshot.mjs
+++ b/scripts/check-pr-screenshot.mjs
@@ -2,7 +2,7 @@
 /**
  * scripts/check-pr-screenshot.mjs
  *
- * #1740 + #1741: PR スクリーンショット添付の品質ゲート。
+ * #1740 + #1741 + #1766 (#1747 AC4): PR スクリーンショット添付の品質ゲート。
  *
  * 1. **ローカルパス禁止検証 (#1741)**
  *    PR body 内の `tmp/screenshots/...` / `.tmp-screenshots/...` 等のローカル相対パス参照を検知して fail。
@@ -14,8 +14,13 @@
  *    「修正前 / Before / before-...」「修正後 / After / after-...」のいずれもが含まれているかを検証。
  *    両方が揃わない場合、警告 / 失敗 (mode により切替)。
  *
- * 3. **スキップ判定**
- *    docs only / refactor 系の PR (UI 関連ファイルを含まない) は両検証ともスキップ。
+ * 3. **DOM スナップショット併記検証 (#1766 / #1747 AC4)**
+ *    UI PR で SS を 1 枚以上添付している場合、対応する `.dom.html` リンクが PR body に
+ *    1 つ以上含まれることを検証。SS と同一プロセスで取得した DOM が併記されることで、
+ *    PR #1717 で発生した「SS と実機が乖離している」事故の再発を機械的に検出可能にする。
+ *
+ * 4. **スキップ判定**
+ *    docs only / refactor 系の PR (UI 関連ファイルを含まない) は全検証ともスキップ。
  *    ファイルパターンは scripts/check-pr-screenshot.mjs::isUiPr() 参照。
  *
  * 4. **段階適用フラグ (#1740 — 「最初は警告のみで開始 → 1-2 週間 dogfooding → エラー化」要件)**
@@ -123,31 +128,133 @@ export function hasUiNotApplicableMarker(body) {
 	return /該当なし\s*[（(](?:refactor|docs|chore)/i.test(body) || /UI\s*変更\s*なし/i.test(body);
 }
 
+// 画像参照: ![alt](url) / <img src="url">  → URL 部分を抽出
+const IMAGE_REF_PATTERN = /!\[[^\]]*\]\(([^)]+)\)|<img[^>]+src=["']([^"']+)["']/g;
+// DOM HTML リファレンス: [text](url.dom.html) または素の URL 末尾 .dom.html
+const DOM_REF_PATTERN = /\[[^\]]*\]\([^)]+\.dom\.html[^)]*\)|[\s(]https?:\/\/\S+\.dom\.html\b/;
+
+/**
+ * PR body から画像参照 URL を抽出する（src のみ、alt / text は除く）。
+ *
+ * @param {string} body
+ * @returns {string[]}
+ */
+export function extractImageUrls(body) {
+	const urls = [];
+	for (const m of body.matchAll(IMAGE_REF_PATTERN)) {
+		const url = m[1] || m[2];
+		if (url) urls.push(url);
+	}
+	return urls;
+}
+
+/**
+ * URL がスクリーンショット (拡張子 .png / .jpg / .jpeg / .webp / .gif) を指しているかを判定。
+ * HTTPS 以外の URL や user-attachments の uuid (拡張子なし) は false を返す。
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isScreenshotUrl(url) {
+	return /\.(?:png|jpe?g|webp|gif)(?:[?#]|$)/i.test(url);
+}
+
+/**
+ * PR body 内に DOM HTML (.dom.html) スナップショットへの参照が含まれるかを判定 (#1766 / #1747 AC4)。
+ *
+ * 検出パターン:
+ * - Markdown link: `[DOM HTML](https://.../foo.dom.html)`
+ * - 素の URL: `https://.../foo.dom.html`
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function hasDomSnapshotReference(body) {
+	return DOM_REF_PATTERN.test(body);
+}
+
 // ---------------------------------------------------------------------------
 // メイン処理
 // ---------------------------------------------------------------------------
+
+/**
+ * ローカルパス参照違反 (#1741) を生成する。
+ * @param {string} body
+ * @returns {{ id: string; issue: string; message: string } | null}
+ */
+function checkLocalPathViolation(body) {
+	const localPaths = detectLocalPaths(body);
+	if (localPaths.length === 0) return null;
+	return {
+		id: 'local-path-forbidden',
+		issue: '#1741',
+		message:
+			`PR body にローカル相対パス参照が ${localPaths.length} 件検出されました。GitHub Web 上で表示できる URL に置き換えてください。\n` +
+			`検出箇所:\n${localPaths
+				.slice(0, 5)
+				.map((s) => `  - ${s}`)
+				.join('\n')}\n` +
+			`\n対応方法:\n` +
+			`  - user-attachments URL: PR 本文編集画面に画像をドラッグ&ドロップ\n` +
+			`  - screenshots branch raw URL: docs/troubleshoot/screenshot_capture.md SC-007 参照\n` +
+			`  - docs/screenshots/ にコミット後、GitHub raw URL を貼付（SC-008 参照）`,
+	};
+}
+
+/**
+ * before/after ラベル欠落違反 (#1740) を生成する。
+ * @param {string} body
+ * @returns {{ id: string; issue: string; message: string } | null}
+ */
+function checkBeforeAfterViolation(body) {
+	const { hasBefore, hasAfter } = detectBeforeAfterLabels(body);
+	if (hasBefore && hasAfter) return null;
+	const missing = [];
+	if (!hasBefore) missing.push('「修正前 / Before / before-...」ラベル付き画像');
+	if (!hasAfter) missing.push('「修正後 / After / after-...」ラベル付き画像');
+	return {
+		id: 'before-after-missing',
+		issue: '#1740',
+		message:
+			`PR body に ${missing.join(' および ')} が見つかりません。\n` +
+			`PR template の「4 スロット添付」セクション（修正前 / 修正後 × モバイル / PC）を参考に、\n` +
+			`![before-mobile](URL) / ![after-mobile](URL) / ![before-pc](URL) / ![after-pc](URL) の形式で添付してください。\n` +
+			`UI 変更を含まない PR の場合は「該当なし（refactor / docs / chore）」と明記してください。`,
+	};
+}
+
+/**
+ * DOM スナップショット併記欠落違反 (#1766 / #1747 AC4) を生成する。
+ * SS が 1 枚以上添付されている UI PR で、対応する .dom.html リンクが無い場合に検出。
+ * @param {string} body
+ * @returns {{ id: string; issue: string; message: string } | null}
+ */
+function checkDomSnapshotViolation(body) {
+	const imageUrls = extractImageUrls(body);
+	const screenshotUrls = imageUrls.filter(isScreenshotUrl);
+	if (screenshotUrls.length === 0 || hasDomSnapshotReference(body)) return null;
+	return {
+		id: 'dom-snapshot-missing',
+		issue: '#1766 / #1747 AC4',
+		message:
+			`UI 変更 PR で SS を ${screenshotUrls.length} 件添付していますが、対応する DOM HTML スナップショット (.dom.html) への参照が PR body に見つかりません。\n` +
+			`\n対応方法:\n` +
+			`  - scripts/capture.mjs --pr <N> で撮影すると、SS と同一プロセスで DOM HTML (.dom.html) が自動保存されます\n` +
+			`  - 出力された Markdown スニペットには SS の直下に [DOM HTML](...) リンクが併記されています\n` +
+			`  - PR body にそのまま貼り付けてください\n` +
+			`\n背景:\n` +
+			`  PR #1717 で発生した「SS と実機が乖離していた」事故の再発防止のため、\n` +
+			`  SS と DOM が同一プロセス・同一 page で取得されたことを構造的に保証します（#1747 AC4）。\n` +
+			`\nDOM スナップショットを意図的に省略する場合は、--no-dom-snapshot 指定の理由を PR body に明記してください。`,
+	};
+}
 
 function main() {
 	const violations = [];
 
 	// 検証 1: ローカルパス禁止 (#1741) — UI PR でなくても貼ったらアウト
-	const localPaths = detectLocalPaths(PR_BODY);
-	if (localPaths.length > 0) {
-		violations.push({
-			id: 'local-path-forbidden',
-			issue: '#1741',
-			message:
-				`PR body にローカル相対パス参照が ${localPaths.length} 件検出されました。GitHub Web 上で表示できる URL に置き換えてください。\n` +
-				`検出箇所:\n${localPaths
-					.slice(0, 5)
-					.map((s) => `  - ${s}`)
-					.join('\n')}\n` +
-				`\n対応方法:\n` +
-				`  - user-attachments URL: PR 本文編集画面に画像をドラッグ&ドロップ\n` +
-				`  - screenshots branch raw URL: docs/troubleshoot/screenshot_capture.md SC-007 参照\n` +
-				`  - docs/screenshots/ にコミット後、GitHub raw URL を貼付（SC-008 参照）`,
-		});
-	}
+	const localViolation = checkLocalPathViolation(PR_BODY);
+	if (localViolation) violations.push(localViolation);
 
 	// UI PR かどうかで以降の検証をゲート
 	const isUi = isUiPr(PR_FILES);
@@ -155,25 +262,16 @@ function main() {
 
 	if (!isUi || optOut) {
 		console.log(
-			`[screenshot-check] UI 関連ファイル変更なし${optOut ? '（または「該当なし」明示）' : ''} — before/after 検証をスキップ`,
+			`[screenshot-check] UI 関連ファイル変更なし${optOut ? '（または「該当なし」明示）' : ''} — before/after / DOM 検証をスキップ`,
 		);
 	} else {
 		// 検証 2: before/after ラベル検証 (#1740)
-		const { hasBefore, hasAfter } = detectBeforeAfterLabels(PR_BODY);
-		if (!hasBefore || !hasAfter) {
-			const missing = [];
-			if (!hasBefore) missing.push('「修正前 / Before / before-...」ラベル付き画像');
-			if (!hasAfter) missing.push('「修正後 / After / after-...」ラベル付き画像');
-			violations.push({
-				id: 'before-after-missing',
-				issue: '#1740',
-				message:
-					`PR body に ${missing.join(' および ')} が見つかりません。\n` +
-					`PR template の「4 スロット添付」セクション（修正前 / 修正後 × モバイル / PC）を参考に、\n` +
-					`![before-mobile](URL) / ![after-mobile](URL) / ![before-pc](URL) / ![after-pc](URL) の形式で添付してください。\n` +
-					`UI 変更を含まない PR の場合は「該当なし（refactor / docs / chore）」と明記してください。`,
-			});
-		}
+		const beforeAfterViolation = checkBeforeAfterViolation(PR_BODY);
+		if (beforeAfterViolation) violations.push(beforeAfterViolation);
+
+		// 検証 3: DOM スナップショット参照検証 (#1766 / #1747 AC4)
+		const domViolation = checkDomSnapshotViolation(PR_BODY);
+		if (domViolation) violations.push(domViolation);
 	}
 
 	// 結果出力

--- a/scripts/lib/screenshot-helpers.mjs
+++ b/scripts/lib/screenshot-helpers.mjs
@@ -1,8 +1,11 @@
 /**
- * scripts/lib/screenshot-helpers.mjs (#1206, #1424)
+ * scripts/lib/screenshot-helpers.mjs (#1206, #1424, #1766)
  *
  * `take-lp-screenshots.mjs` / `capture-hp-screenshots.mjs` 共通ユーティリティの SSOT。
  * #1424 で ScreenshotCapture / FlowRecorder クラスと純粋関数を追加。
+ * #1766 で DOM snapshot 機能 (#1747 AC4 follow-up) を追加。
+ *   PR #1717 で SS と実機が乖離していた事故の再発防止のため、SS と
+ *   `document.documentElement.outerHTML` を **同一プロセスで** 取得する。
  */
 
 import fs from 'node:fs';
@@ -197,6 +200,58 @@ export function generateMarkdownSnippet(flowName, steps, relativePath) {
 }
 
 // ============================================================
+// #1766: DOM snapshot 機能 (#1747 AC4)
+// ============================================================
+
+/**
+ * SS ファイルパスから対応する DOM HTML スナップショットファイルパスを導出する（純粋関数）。
+ *
+ * 例:
+ *   resolveDomSnapshotPath('tmp/screenshots/pr-1770/admin-home.png')
+ *     → 'tmp/screenshots/pr-1770/admin-home.dom.html'
+ *   resolveDomSnapshotPath('docs/screenshots/pr-1770/lp-top-mobile.webp')
+ *     → 'docs/screenshots/pr-1770/lp-top-mobile.dom.html'
+ *
+ * @param {string} screenshotPath - SS ファイルパス（拡張子は .png/.jpeg/.webp 等）
+ * @returns {string} 同一ディレクトリ・同一 basename + `.dom.html` の DOM ファイルパス
+ */
+export function resolveDomSnapshotPath(screenshotPath) {
+	const dir = path.dirname(screenshotPath);
+	const ext = path.extname(screenshotPath);
+	const base = path.basename(screenshotPath, ext);
+	return path.join(dir, `${base}.dom.html`);
+}
+
+/**
+ * Playwright page から DOM HTML スナップショットを保存する。
+ *
+ * `document.documentElement.outerHTML` を取得して指定パスに UTF-8 で書き込む。
+ * SS と DOM が **同一プロセス・同一 page インスタンス** で取得されたことを構造的に保証する
+ * (#1747 AC4 / #1766) ため、SS 撮影直後に同一 page を渡して呼ぶこと。
+ *
+ * @param {{ evaluate: (fn: () => string) => Promise<string> }} page -
+ *   Playwright Page インスタンス（テスト容易性のため evaluate のみを要求する duck-typed 受け取り）
+ * @param {string} domPath - 出力先ファイルパス（拡張子 `.dom.html` 推奨、`resolveDomSnapshotPath` 経由）
+ * @returns {Promise<{ ok: true; filePath: string; size: number } | { ok: false; error: Error }>}
+ */
+export async function captureDomSnapshot(page, domPath) {
+	try {
+		const html = await page.evaluate(() => document.documentElement.outerHTML);
+		if (typeof html !== 'string') {
+			throw new Error(
+				`document.documentElement.outerHTML が文字列でありません (typeof=${typeof html})`,
+			);
+		}
+		fs.mkdirSync(path.dirname(domPath), { recursive: true });
+		fs.writeFileSync(domPath, html, 'utf8');
+		const stat = fs.statSync(domPath);
+		return { ok: true, filePath: domPath, size: stat.size };
+	} catch (error) {
+		return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
+	}
+}
+
+// ============================================================
 // #1424: ScreenshotCapture クラス
 // ============================================================
 
@@ -212,16 +267,21 @@ export class ScreenshotCapture {
 	#locale;
 	#defaultDeviceScaleFactor;
 
+	/** @type {boolean} */
+	#domSnapshotEnabled;
+
 	constructor({
 		baseUrl = 'http://localhost:5173',
 		outputDir = 'tmp/screenshots',
 		locale = 'ja-JP',
 		deviceScaleFactor = 2,
+		domSnapshot = true,
 	} = {}) {
 		this.#baseUrl = baseUrl;
 		this.#outputDir = outputDir;
 		this.#locale = locale;
 		this.#defaultDeviceScaleFactor = deviceScaleFactor;
+		this.#domSnapshotEnabled = domSnapshot;
 	}
 
 	async setup() {
@@ -245,7 +305,9 @@ export class ScreenshotCapture {
 	 * @param {number} [opts.quality=85] - WebP 品質 (0-100)
 	 * @param {string} [opts.selector] - 表示まで待つ要素
 	 * @param {import('playwright').BrowserContextOptions['storageState']} [opts.storageState] - 認証済みセッション
-	 * @returns {Promise<{ ok: true; filePath: string; size: number } | { ok: false; error: Error }>}
+	 * @param {boolean} [opts.domSnapshot] - DOM HTML を <name>.dom.html として保存するか (#1747 AC4 / #1766)。
+	 *   省略時はコンストラクタの `domSnapshot` 設定（デフォルト true）に従う
+	 * @returns {Promise<{ ok: true; filePath: string; size: number; domPath?: string; domSize?: number } | { ok: false; error: Error }>}
 	 */
 	async capture({
 		url,
@@ -256,6 +318,7 @@ export class ScreenshotCapture {
 		quality = 85,
 		selector,
 		storageState,
+		domSnapshot,
 	}) {
 		if (!this.#browser) throw new Error('setup() を先に呼び出してください。');
 
@@ -284,6 +347,13 @@ export class ScreenshotCapture {
 			const tmpPath = path.join(this.#outputDir, `${name}.${ext}`);
 			await page.screenshot({ path: tmpPath, fullPage, type: screenshotType });
 
+			// #1766: SS と同一プロセス・同一 page で DOM HTML を取得して保存する。
+			// PR #1717 で SS と実機 DOM が乖離していた事故の構造的再発防止。
+			const domEnabled = domSnapshot ?? this.#domSnapshotEnabled;
+			const domInfo = domEnabled
+				? await this.#tryCaptureDom(page, name, format, tmpPath)
+				: { domPath: undefined, domSize: undefined };
+
 			let filePath = tmpPath;
 			if (format === 'webp') {
 				filePath = path.join(this.#outputDir, `${name}.webp`);
@@ -293,12 +363,44 @@ export class ScreenshotCapture {
 			}
 
 			const stat = fs.statSync(filePath);
-			return { ok: true, filePath, size: stat.size };
+			return {
+				ok: true,
+				filePath,
+				size: stat.size,
+				...(domInfo.domPath !== undefined
+					? { domPath: domInfo.domPath, domSize: domInfo.domSize }
+					: {}),
+			};
 		} catch (error) {
 			return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
 		} finally {
 			await context.close();
 		}
+	}
+
+	/**
+	 * #1766: 撮影直後の page から DOM HTML を取得する内部ヘルパ。
+	 * SS と同じ basename + `.dom.html` を SS と同じディレクトリに書き出す。
+	 * 失敗しても SS 撮影自体は成功扱いとし、警告ログのみ。
+	 *
+	 * @param {import('playwright').Page} page
+	 * @param {string} name
+	 * @param {'png'|'webp'|'jpeg'} format
+	 * @param {string} tmpPath - 撮影 PNG の一時パス（webp の場合は最終 webp パスから DOM パスを導出）
+	 * @returns {Promise<{ domPath: string | undefined; domSize: number | undefined }>}
+	 */
+	async #tryCaptureDom(page, name, format, tmpPath) {
+		const finalScreenshotPathForDom =
+			format === 'webp' ? path.join(this.#outputDir, `${name}.webp`) : tmpPath;
+		const targetDomPath = resolveDomSnapshotPath(finalScreenshotPathForDom);
+		const domResult = await captureDomSnapshot(page, targetDomPath);
+		if (!domResult.ok) {
+			console.warn(
+				`[capture] DOM snapshot 保存に失敗しました (${name}): ${domResult.error.message}`,
+			);
+			return { domPath: undefined, domSize: undefined };
+		}
+		return { domPath: domResult.filePath, domSize: domResult.size };
 	}
 
 	async teardown() {

--- a/tests/unit/scripts/capture.test.ts
+++ b/tests/unit/scripts/capture.test.ts
@@ -1,14 +1,16 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import {
 	buildGridLayout,
+	captureDomSnapshot,
 	checkImageNotBlank,
 	checkStepLimit,
 	generateMarkdownSnippet,
 	PRESETS,
+	resolveDomSnapshotPath,
 	resolvePreset,
 } from '../../../scripts/lib/screenshot-helpers.mjs';
 
@@ -252,5 +254,121 @@ describe('checkImageNotBlank (#1424)', () => {
 		const result = await checkImageNotBlank(normalPng);
 		expect(result.blank).toBe(false);
 		expect(result.reason).toBe('');
+	});
+});
+
+describe('resolveDomSnapshotPath (#1766)', () => {
+	it('PNG → 同一ディレクトリ・同 basename + .dom.html', () => {
+		const result = resolveDomSnapshotPath('tmp/screenshots/pr-1770/admin-home.png');
+		// path 結果は実行 OS で区切り文字が変わるため、basename と dirname で検証
+		expect(result.endsWith('admin-home.dom.html')).toBe(true);
+		expect(result.includes('pr-1770')).toBe(true);
+	});
+
+	it('WebP → .dom.html', () => {
+		const result = resolveDomSnapshotPath('docs/screenshots/pr-1770/lp-top-mobile.webp');
+		expect(result.endsWith('lp-top-mobile.dom.html')).toBe(true);
+	});
+
+	it('JPEG → .dom.html', () => {
+		const result = resolveDomSnapshotPath('out/admin.jpeg');
+		expect(result.endsWith('admin.dom.html')).toBe(true);
+	});
+
+	it('複数ドット basename を保持する', () => {
+		const result = resolveDomSnapshotPath('out/admin-home-mobile.png');
+		expect(result.endsWith('admin-home-mobile.dom.html')).toBe(true);
+	});
+
+	it('絶対パスでも同一ディレクトリに DOM ファイルパスを返す', () => {
+		// macOS / Linux 形式のテストはそのまま、Windows でも path.join が補正してくれる
+		const input = '/tmp/screenshots/pr-1/admin.png';
+		const result = resolveDomSnapshotPath(input);
+		expect(result.endsWith('admin.dom.html')).toBe(true);
+	});
+});
+
+describe('captureDomSnapshot (#1766)', () => {
+	let tmpDir: string;
+
+	beforeAll(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), 'dom-snapshot-test-'));
+	});
+
+	afterAll(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it('page.evaluate の文字列結果を UTF-8 で書き出す', async () => {
+		const html = '<!DOCTYPE html><html><head><title>テスト</title></head><body>本文</body></html>';
+		const fakePage = {
+			evaluate: async (_fn: () => string) => html,
+		};
+		const domPath = join(tmpDir, 'success.dom.html');
+		const result = await captureDomSnapshot(fakePage, domPath);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.filePath).toBe(domPath);
+			expect(result.size).toBeGreaterThan(0);
+			expect(existsSync(domPath)).toBe(true);
+			const content = readFileSync(domPath, 'utf8');
+			expect(content).toBe(html);
+			// マルチバイト文字の保全確認（同一プロセスで取得した DOM の不変性を担保）
+			expect(content).toContain('テスト');
+			expect(content).toContain('本文');
+		}
+	});
+
+	it('親ディレクトリが存在しなくても再帰作成して書き込める', async () => {
+		const html = '<html><body>nested</body></html>';
+		const fakePage = { evaluate: async () => html };
+		const domPath = join(tmpDir, 'nested', 'deep', 'page.dom.html');
+		const result = await captureDomSnapshot(fakePage, domPath);
+		expect(result.ok).toBe(true);
+		expect(existsSync(domPath)).toBe(true);
+	});
+
+	it('page.evaluate が string を返さない場合は ok=false', async () => {
+		const fakePage = {
+			evaluate: async () => 12345 as unknown as string,
+		};
+		const domPath = join(tmpDir, 'bad-type.dom.html');
+		const result = await captureDomSnapshot(fakePage, domPath);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.message).toMatch(/document\.documentElement\.outerHTML/);
+		}
+	});
+
+	it('page.evaluate がエラーを投げた場合は ok=false で error を返す', async () => {
+		const fakePage = {
+			evaluate: async () => {
+				throw new Error('page closed');
+			},
+		};
+		const domPath = join(tmpDir, 'evaluate-fail.dom.html');
+		const result = await captureDomSnapshot(fakePage, domPath);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toBeInstanceOf(Error);
+			expect(result.error.message).toContain('page closed');
+		}
+		// 失敗時はファイルを書き出さない
+		expect(existsSync(domPath)).toBe(false);
+	});
+
+	it('Error 以外の throw も Error にラップされる', async () => {
+		const fakePage = {
+			evaluate: async () => {
+				throw 'string error';
+			},
+		};
+		const domPath = join(tmpDir, 'string-error.dom.html');
+		const result = await captureDomSnapshot(fakePage, domPath);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toBeInstanceOf(Error);
+			expect(result.error.message).toContain('string error');
+		}
 	});
 });

--- a/tests/unit/scripts/check-pr-screenshot.test.ts
+++ b/tests/unit/scripts/check-pr-screenshot.test.ts
@@ -1,0 +1,193 @@
+/**
+ * tests/unit/scripts/check-pr-screenshot.test.ts (#1766 / #1747 AC4)
+ *
+ * scripts/check-pr-screenshot.mjs の純粋関数（検出ロジック）の unit test。
+ * メイン処理 (main) は env 経由で動作するため、export された関数を直接呼んで検証する。
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+	detectBeforeAfterLabels,
+	detectLocalPaths,
+	extractImageUrls,
+	hasDomSnapshotReference,
+	hasUiNotApplicableMarker,
+	isScreenshotUrl,
+	isUiPr,
+} from '../../../scripts/check-pr-screenshot.mjs';
+
+describe('isUiPr (#1740)', () => {
+	it('.svelte ファイルがあれば true', () => {
+		expect(isUiPr(['src/routes/foo/+page.svelte'])).toBe(true);
+	});
+
+	it('.css / .scss があれば true', () => {
+		expect(isUiPr(['src/lib/ui/styles/app.css'])).toBe(true);
+		expect(isUiPr(['src/lib/foo.scss'])).toBe(true);
+	});
+
+	it('site/ 配下のファイルなら true', () => {
+		expect(isUiPr(['site/index.html'])).toBe(true);
+	});
+
+	it('.ts のみ・docs のみは false', () => {
+		expect(isUiPr(['src/lib/server/db/schema.ts'])).toBe(false);
+		expect(isUiPr(['docs/design/06-UI設計書.md'])).toBe(false);
+		expect(isUiPr(['scripts/capture.mjs'])).toBe(false);
+	});
+});
+
+describe('detectLocalPaths (#1741)', () => {
+	it('tmp/ パス Markdown 画像を検出', () => {
+		const body = '![before-mobile](tmp/screenshots/pr-1/before-mobile.png)';
+		expect(detectLocalPaths(body)).toHaveLength(1);
+	});
+
+	it('.tmp-screenshots/ パスを検出', () => {
+		const body = '![x](.tmp-screenshots/foo.png)';
+		expect(detectLocalPaths(body)).toHaveLength(1);
+	});
+
+	it('GitHub raw URL は false (検出されない)', () => {
+		const body =
+			'![ok](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1/ok.png)';
+		expect(detectLocalPaths(body)).toHaveLength(0);
+	});
+});
+
+describe('detectBeforeAfterLabels (#1740)', () => {
+	it('before / after 両方検出', () => {
+		const body = `
+![before-mobile](https://example.com/b.png)
+![after-mobile](https://example.com/a.png)
+`;
+		const result = detectBeforeAfterLabels(body);
+		expect(result.hasBefore).toBe(true);
+		expect(result.hasAfter).toBe(true);
+	});
+
+	it('日本語ラベル「修正前 / 修正後」も検出', () => {
+		const body = `
+![修正前](https://example.com/b.png)
+![修正後](https://example.com/a.png)
+`;
+		const result = detectBeforeAfterLabels(body);
+		expect(result.hasBefore).toBe(true);
+		expect(result.hasAfter).toBe(true);
+	});
+
+	it('after だけのときは hasBefore=false', () => {
+		const body = '![after-mobile](https://example.com/a.png)';
+		const result = detectBeforeAfterLabels(body);
+		expect(result.hasBefore).toBe(false);
+		expect(result.hasAfter).toBe(true);
+	});
+});
+
+describe('hasUiNotApplicableMarker', () => {
+	it('「該当なし（refactor）」を検出', () => {
+		expect(hasUiNotApplicableMarker('該当なし（refactor / docs / chore）')).toBe(true);
+	});
+
+	it('「UI 変更なし」を検出', () => {
+		expect(hasUiNotApplicableMarker('## SS\nUI 変更なし')).toBe(true);
+	});
+
+	it('UI 変更がある PR は false', () => {
+		expect(hasUiNotApplicableMarker('![ss](url)')).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #1766 / #1747 AC4: DOM スナップショット参照検出
+// ---------------------------------------------------------------------------
+
+describe('extractImageUrls (#1766)', () => {
+	it('Markdown 画像の URL を抽出', () => {
+		const body = '![alt](https://example.com/foo.png)';
+		expect(extractImageUrls(body)).toEqual(['https://example.com/foo.png']);
+	});
+
+	it('複数 Markdown 画像を抽出', () => {
+		const body = `
+![a](https://x.com/a.png)
+![b](https://x.com/b.webp)
+`;
+		expect(extractImageUrls(body)).toEqual(['https://x.com/a.png', 'https://x.com/b.webp']);
+	});
+
+	it('HTML img タグからも URL を抽出', () => {
+		const body = '<img src="https://x.com/bar.png" alt="bar">';
+		expect(extractImageUrls(body)).toEqual(['https://x.com/bar.png']);
+	});
+
+	it('画像参照がない場合は空配列', () => {
+		expect(extractImageUrls('Hello world')).toEqual([]);
+	});
+});
+
+describe('isScreenshotUrl (#1766)', () => {
+	it('.png は true', () => {
+		expect(isScreenshotUrl('https://example.com/foo.png')).toBe(true);
+	});
+
+	it('.webp は true', () => {
+		expect(isScreenshotUrl('https://example.com/foo.webp')).toBe(true);
+	});
+
+	it('.jpg / .jpeg は true', () => {
+		expect(isScreenshotUrl('https://example.com/foo.jpg')).toBe(true);
+		expect(isScreenshotUrl('https://example.com/foo.jpeg')).toBe(true);
+	});
+
+	it('.gif は true', () => {
+		expect(isScreenshotUrl('https://example.com/foo.gif')).toBe(true);
+	});
+
+	it('クエリ文字列付き URL も判定可能', () => {
+		expect(isScreenshotUrl('https://example.com/foo.png?v=123')).toBe(true);
+		expect(isScreenshotUrl('https://example.com/foo.webp#frag')).toBe(true);
+	});
+
+	it('user-attachments の uuid (拡張子なし) は false', () => {
+		expect(
+			isScreenshotUrl('https://github.com/user-attachments/assets/9c6c8430-1234-5678-aaaa-bbbb'),
+		).toBe(false);
+	});
+
+	it('.dom.html は false', () => {
+		expect(isScreenshotUrl('https://example.com/foo.dom.html')).toBe(false);
+	});
+});
+
+describe('hasDomSnapshotReference (#1766 / #1747 AC4)', () => {
+	it('Markdown link 形式の .dom.html を検出', () => {
+		const body = '[DOM HTML](https://example.com/foo.dom.html)';
+		expect(hasDomSnapshotReference(body)).toBe(true);
+	});
+
+	it('GitHub raw URL の .dom.html を検出', () => {
+		const body = `[DOM](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1766/admin-home-mobile.dom.html)`;
+		expect(hasDomSnapshotReference(body)).toBe(true);
+	});
+
+	it('素の URL（リンク化されていない）も検出', () => {
+		const body = `参照: https://example.com/foo.dom.html`;
+		expect(hasDomSnapshotReference(body)).toBe(true);
+	});
+
+	it('SS だけ・DOM 参照なしは false', () => {
+		const body = `
+![before-mobile](https://example.com/before.png)
+![after-mobile](https://example.com/after.png)
+`;
+		expect(hasDomSnapshotReference(body)).toBe(false);
+	});
+
+	it('「dom.html」という単語が文中に出るだけでは false（URL 文脈が必要）', () => {
+		const body = 'DOM スナップショット (.dom.html) は未対応';
+		// URL ではなく説明文中の言及なので検出されない
+		expect(hasDomSnapshotReference(body)).toBe(false);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: QA / Dev セッション / 運営 / システム全体

**解決する課題**:
- PR #1717 で SS が PR body に添付されていても実機 DOM と乖離していた事例があり、SS と DOM スナップショットを **同一プロセスで** 取得する仕組みが未実装
- 親 Issue #1747 の AC1/AC2/AC3/AC5/AC6 は PR #1765 で完遂済み。残る AC4 を本 PR で完遂する
- QM Re-Review が SS だけでは「DOMPurify が構造タグを strip していないか」「ラベル文字列が DOM 上に存在するか」を機械的に検査できない

**期待される効果**:
- SS と DOM が **同一プロセス・同一 Playwright page インスタンス** で取得されたことを構造的に保証
- QM Re-Review が `<file>.dom.html` を grep して構造タグ保持・主要ラベル存在を機械的に検証可能
- PR #1717 同様の事故 (SS と実機乖離) を CI レイヤーで構造的に防止 (`screenshot-quality-check` で `.dom.html` 参照欠落を検出)

## 関連 Issue

closes #1766

related: #1747 (親 Issue, AC1/2/3/5/6 は PR #1765 で完遂済み, AC4 を本 PR で完遂)
related: PR #1717 (SS 実機乖離が初検出された事故)
related: PR #1765 (本 Issue 起票元)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | scripts/capture.mjs に DOM スナップショット機能追加（撮影と同じ Playwright page から `document.documentElement.outerHTML` を取得 / `<file>.dom.html` として SS と同じディレクトリに保存 / `--no-dom-snapshot` フラグで opt-out 可能） | `node scripts/capture.mjs --server-mode lp --url /index.html --presets desktop,mobile --out tmp/screenshots/pr-1766` 実行 → SS 2 枚 + DOM HTML 2 枚が同時生成。`scripts/lib/screenshot-helpers.mjs` の `ScreenshotCapture#capture()` 内で SS 撮影直後の page から outerHTML を取得 | PASS — 実機実行で `index-html-{desktop,mobile}.png` + `index-html-{desktop,mobile}.dom.html` が同時生成されることを確認。`--no-dom-snapshot` で opt-out 動作を確認。`tests/unit/scripts/capture.test.ts` の `captureDomSnapshot` / `resolveDomSnapshotPath` で 10 ケース pass |
| AC2 | dev-session.md / qa-session.md に「SS は DOM スナップショットと同時取得を必須」明記 | `docs/sessions/dev-session.md` Screenshot Agent §1 / `docs/sessions/qa-session.md` 手順 2 を改訂 | PASS — dev-session.md に「同一プロセス・同一 page で取得」と「`--no-dom-snapshot` opt-out 時は理由明記必須」を追加。qa-session.md 手順 2 に「DOM HTML を Read tool で開いて主要ラベル grep」のルール追加 |
| AC3 | PR template の「スクリーンショット / ビジュアルデモ」セクションで `.dom.html` の存在を必須化 | `.github/PULL_REQUEST_TEMPLATE.md` 改訂 | PASS — 「DOM スナップショット併記ルール（#1747 AC4 / #1766）」セクション新設。「Ready for Review チェックリスト」にも DOM HTML リンク確認項目を追加 |
| AC4 | CI で `pr-N/*.dom.html` の存在確認 (UI 変更 PR のみ) | `scripts/check-pr-screenshot.mjs` を拡張し、UI PR で SS が添付されているのに `.dom.html` 参照が無い場合に違反検出。`pr-quality-gate.yml::screenshot-quality-check` ジョブが既存実行している | PASS — `hasDomSnapshotReference` / `extractImageUrls` / `isScreenshotUrl` を追加し、`checkDomSnapshotViolation` で機械検出。`tests/unit/scripts/check-pr-screenshot.test.ts` で 29 ケース pass |
| AC5 | Done 基準: AC1-4 全充足 + CI 全 PASS + dev-session.md / qa-session.md 同期 + PR template 同期 | 上記 AC1-4 + ローカル `npx biome check` + `npx vitest run tests/unit/scripts/` | PASS — biome 0 warning（baseline 維持）、vitest 128 tests passed、設計書 4 文書同期済み |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- 開発者ツール: `scripts/capture.mjs` で SS 撮影時に DOM HTML が併せて保存される（既存の `--pr` モードのワークフローに自動的に組み込まれる）
- CI: `pr-quality-gate.yml::screenshot-quality-check` ジョブで UI PR の `.dom.html` 参照欠落を検出（`SCREENSHOT_CHECK_MODE=warn` で段階適用中、定着後 error 化予定）
- アプリ本体・LP の UI / DB / API には一切影響なし（ツールチェーンのみの変更）

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | `ScreenshotCapture#capture()` が `page.screenshot()` のみ呼ぶ | 撮影直後に同一 page から `document.documentElement.outerHTML` を取得し `<file>.dom.html` として保存 |
| 一貫性 | SS 単体で PR body 添付 | SS の直下に `[DOM HTML](...)` リンクが Markdown スニペットに自動併記され、SS と DOM が同一コミットで `screenshots` orphan branch に push される |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: `ScreenshotCapture#capture()` の DOM 取得ロジックを `#tryCaptureDom` 内部メソッドに分離。`runConfigMode` / `runUrlMode` の結果ハンドリング重複を `recordCaptureResult()` ヘルパに抽出（biome `noExcessiveCognitiveComplexity` baseline 維持のため）。`check-pr-screenshot.mjs::main` の検証ロジックを `checkLocalPathViolation` / `checkBeforeAfterViolation` / `checkDomSnapshotViolation` の 3 関数に分離
- **リファクタリングが必要だが今回見送った箇所と理由**: なし
- **削除したコード・機能**: なし

## 設計方針・将来性

**採用した設計方針**:
- **同一プロセス保証**: SS と DOM は必ず同じ Playwright `page` インスタンスから取得する。撮影タイミングと DOM 取得タイミングのズレを構造的に排除（PR #1717 事故の根本対策）
- **opt-out 可能 / opt-in しない**: デフォルトで有効化。明示的に `--no-dom-snapshot` を指定した場合のみ無効化（CI が UI PR で参照欠落を検出するため、opt-out には PR body での理由明記が必須）
- **失敗は警告のみ**: DOM 取得の失敗は SS 撮影自体の失敗ではない（page closed 等のレース条件）ため warning ログのみ。SS は確実に保存される
- **CI 段階適用**: `pr-quality-gate.yml` の `screenshot-quality-check` は既に `SCREENSHOT_CHECK_MODE=warn` で運用中。新ルールも同 mode で運用開始し dogfooding 後に `error` 昇格

**想定する将来の拡張**:
- DOM HTML から構造タグ存在を grep する機械検証スクリプトの追加（例: `<article>` / `<h2>` / `<table>` 等の保持を CI で必須化）— ADR-0025 LP SSOT innerHTML 化の安全策として併用可能
- `page.evaluate` で取得する DOM のスコープを `body` のみ / 特定セレクタ配下のみ に絞るオプション（DOM HTML サイズが肥大化した場合の対策）

**意図的に対応しなかった範囲とその理由**:
- DOM HTML の差分比較 (before/after diff) の自動化 — YAGNI。手動で `diff` / `grep` で十分
- DOM HTML の機械検証ルールセット (jest-dom 風) — Pre-PMF 段階で過剰防衛。必要になったら別 Issue で議論

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — 既存機能 (`scripts/capture.mjs` / `screenshot-helpers.mjs` / `check-pr-screenshot.mjs`) の機能追加。新テーブル / 新スキーマ / 新 interface / セキュリティ機能 / 課金変更 / AWS リソース追加に該当しない

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加/変更したテスト:
  - `tests/unit/scripts/capture.test.ts` に `resolveDomSnapshotPath` (5 ケース) と `captureDomSnapshot` (5 ケース) のテストを追加
  - `tests/unit/scripts/check-pr-screenshot.test.ts` を新規作成し、`isUiPr` / `detectLocalPaths` / `detectBeforeAfterLabels` / `hasUiNotApplicableMarker` / `extractImageUrls` / `isScreenshotUrl` / `hasDomSnapshotReference` の 29 ケース
- カバーしたシナリオ: 正常系（PNG/WebP/JPEG → .dom.html 導出 / 文字列 outerHTML の保存 / マルチバイト保全 / 親ディレクトリ自動作成）/ 異常系（page.evaluate が string でない / Error throw / string throw）/ DOM 参照検出（Markdown link / 素 URL / SS のみ・DOM 参照なし / 文中の言及）

**E2Eテスト**:
- 追加/変更したテスト: 該当なし — 本 PR は開発者ツール (`scripts/`) の変更のみ。アプリの routes / +server / DB に一切影響しない
- カバーしたユーザーフロー: N/A

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check scripts tests` | PASS | 0 warning (baseline 維持) |
| 型チェック | `npx svelte-check` | PASS | 既存の dompurify 関連 1 error は本 PR 範囲外 |
| 単体テスト | `npx vitest run tests/unit/scripts/` | PASS | 6 files / 128 tests passed |
| E2E テスト | `npx playwright test` | N/A | scripts/ の変更のみのため対象外 |

**追加した E2E テストの詳細**:
- なし（本 PR は開発者ツール変更のためアプリ E2E に影響なし）

**網羅性の判断根拠**:
- DOM snapshot のコア関数 (`resolveDomSnapshotPath` / `captureDomSnapshot`) は純粋関数 / page-duck-typed のため unit test で完全にカバー
- `ScreenshotCapture#capture()` の統合動作は実機 LP capture (`/index.html`) で end-to-end 検証済み（下記スクリーンショット参照）
- CI 検証ロジック (`hasDomSnapshotReference` / `checkDomSnapshotViolation`) は純粋関数として個別ユニットテストで検証

### DynamoDB 実装完成度（#1021 — 段階的対応禁止 / ADR-0010）

- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | DOM HTML はローカル `tmp/` または `screenshots` orphan branch にのみ保存。アプリ稼働環境（本番 / staging）には一切露出しない | 開発者ツールの変更のみ |
| パフォーマンス | DOM HTML 1 件あたり 86 KB 程度（LP の場合）。SS 撮影に対する追加オーバーヘッドは `page.evaluate` 1 回 + `fs.writeFileSync` 1 回で 100ms 未満 | 計測値: LP /index.html mobile + desktop で SS 撮影 4.5s に対し DOM 取得+保存込みで 4.7s（差分 200ms） |
| アクセシビリティ | 対象外 | UI 変更なし |
| ロギング・モニタリング | DOM 取得失敗時は `console.warn` で警告ログ出力。SS 撮影自体は成功扱い | レース条件 / page closed の安全側設計 |
| ドキュメント | dev-session.md / qa-session.md / screenshot_capture.md / PULL_REQUEST_TEMPLATE.md / capture-specs/{admin,lp}.mjs を同期更新 | 設計書同期完了 |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: `resolveDomSnapshotPath` / `captureDomSnapshot` / `recordCaptureResult` / `#tryCaptureDom` / `checkDomSnapshotViolation` は各 1 責務に分離
- [x] **依存性逆転（D）**: `captureDomSnapshot` は `evaluate` メソッドだけを duck-typed で受け取るため、テスト時にモック page を注入可能（実際の Playwright Page と分離）
- [x] **インターフェース分離（I）**: 必要最小限の interface で受け取り
- [x] **DRY / 横展開**: `runConfigMode` / `runUrlMode` の結果処理重複を `recordCaptureResult` に抽出
- [x] **YAGNI**: DOM 差分比較 / セレクタ絞り込み等は不要なため未実装

### セキュリティ（OSS 公開前提）
- [x] **N/A** — セキュリティ関連の変更なし。DOM HTML はローカルファイル / `screenshots` 専用 orphan branch にのみ保存され、本番アプリ環境には露出しない

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] N+1 クエリが発生していない（DB 操作なし）
- [x] バンドルサイズへの影響を確認した（scripts/ のみの変更でアプリバンドル不変）

## スクリーンショット / ビジュアルデモ

### 目的（誤解防止）

本 PR は `scripts/capture.mjs` 自体の機能追加のため、新機能を実演した SS + DOM スナップショットを 1 件添付する。撮影元は LP `/index.html` を `--server-mode lp` で静的サーバー起動して撮影し、SS と同じディレクトリに `<file>.dom.html` が同時生成されることを実機で確認した。

### 添付ルール（#1741 — ローカル相対パス禁止）

`screenshots` orphan branch (SC-007 運用) に push 済み — `https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1766/...` を使用。

### 4 スロット添付（#1740 — 修正前 / 修正後 × モバイル / PC）

該当なし（refactor / docs / chore） — 本 PR は `scripts/` 配下のツールチェーン拡張であり、アプリ UI の見た目には変更なし。代わりに、新機能（DOM スナップショット同時保存）を実演した SS + DOM HTML ペアを 1 件添付する。

### Playwright スクリーンショット（DOM スナップショット同時保存の実演）

`scripts/capture.mjs --server-mode lp --url /index.html --presets desktop,mobile` の実行結果。SS 2 枚と同時に DOM HTML 2 枚が `tmp/screenshots/pr-1766/` に保存され、`screenshots` orphan branch に同コミットで push されている。

| 画面 | ビューポート | スクリーンショット | DOM HTML スナップショット (#1747 AC4 / #1766) |
|------|------------|------------------|--------------------------------------------|
| LP /index.html | Desktop (1280×800) | ![lp-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1766/index-html-desktop.png) | [DOM HTML (index-html-desktop.dom.html)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1766/index-html-desktop.dom.html) |
| LP /index.html | Mobile (390×844) | ![lp-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1766/index-html-mobile.png) | [DOM HTML (index-html-mobile.dom.html)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1766/index-html-mobile.dom.html) |

> DOM スナップショット: 2 件添付。SS と同一 page で取得 (#1747 AC4 / #1766)。QM Re-Review で `.dom.html` を Read tool で開き、`grep '<title.*data-lp-key' index-html-desktop.dom.html` 等で SSOT 注入による構造タグ保持を機械的に検証可能。

### インタラクティブ状態の確認（#1481）

- [x] **N/A** — インタラクティブ状態変化なし（ツールチェーン変更のみ）

### モバイルビューポート（#1481）

- [x] **N/A** — `src/routes/(parent)/` / `src/routes/(child)/` の変更なし。LP / infra 変更のみ

## 実機操作検証

- [x] 対象画面をブラウザで開き、修正箇所が期待通りに表示されることを**目視確認した** — `scripts/capture.mjs --server-mode lp --url /index.html --presets desktop,mobile` を実行し、SS 2 枚 + DOM HTML 2 枚が `tmp/screenshots/pr-1766/` に同時生成されることを確認。`head -c 400 *.dom.html` で SSOT 注入された `data-lp-key` 属性が DOM 上に保持されていることも確認
- [x] 認証が絡む画面の場合: 該当なし（LP 静的ページのみで実演）
- [x] 撮ったスクリーンショットを**もう一度自分で見て** `docs/DESIGN.md` §9 禁忌事項のどれにも該当しないことを確認した — LP は既存の見た目を変更しない実演用途
- [x] UI/UX デザイナー視点セルフレビュー: 本 PR は scripts/ のみの変更で UI の見た目に一切影響しない
- [x] 用語変更がある場合: 該当なし

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない** — `--no-dom-snapshot` で opt-out 可能なため、既存の撮影フローを完全に維持しつつデフォルトでは DOM HTML が併せて保存される

## レビュー依頼事項・QA

- 既存 PR テンプレートの「スクリーンショット / ビジュアルデモ」セクションに「DOM スナップショット併記ルール」を追加した。これにより既存の Open PR が新ルールに違反する可能性があるが、`SCREENSHOT_CHECK_MODE=warn` のため即座にブロックはされない（dogfooding 期間後に `error` 昇格）
- 既存の `screenshots` orphan branch 運用 (SC-007) に DOM HTML も同コミットで push されるよう変更した。`pr-N/*.dom.html` がブランチに増えることになるが、テキストファイルのため履歴肥大化への影響は限定的

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **本番アプリ** (`src/routes/(child)/`, `src/routes/(parent)/`) — 該当なし（scripts/ のみ）
- [x] **デモ版** (`src/routes/demo/`) — 該当なし
- [x] **LP ↔ アプリ整合（双方向）（#1481）**:
  - [x] **N/A** — LP / アプリの文言・機能に影響しない変更
- [x] **全年齢モード** (`baby/preschool/elementary/junior/senior` の 5 ディレクトリ) — 該当なし
- [x] **ナビゲーション** — 該当なし
- [x] **E2E/ユニットシード** — 該当なし
- [x] **チュートリアル + デモガイド** — 該当なし
- [x] **該当なし** — 並行実装の影響範囲外の変更（scripts/ ツールチェーンのみ）

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイルを **同時期に変更する open PR が他に無い** ことを確認した — `scripts/capture.mjs` / `scripts/lib/screenshot-helpers.mjs` / `scripts/check-pr-screenshot.mjs` を変更する Open PR は本 PR のみ

### LP 変更時の追加チェック（#1282 / ADR-0010 Pre-PMF）

- [x] **N/A** — LP (`site/**`) の変更なし

### LP / 販促文言変更時の実装パス明示（ADR-0013 / #1314）

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **用語変更**: 該当なし
- [x] **labels SSOT (ADR-0009)**: 該当なし — ユーザー向け文言の追加/変更なし
- [x] **UI構造変更**: 該当なし
- [x] **カラー・スタイル**: 該当なし
- [x] **プリミティブ**: 該当なし（scripts/ のみ）
- [x] **設計書（CRITICAL）**: 同一PR内で `docs/sessions/dev-session.md` / `docs/sessions/qa-session.md` / `docs/troubleshoot/screenshot_capture.md` / `.github/PULL_REQUEST_TEMPLATE.md` / `scripts/capture-specs/{admin,lp}.mjs` を同期更新済み

## Ready for Review チェックリスト

- [x] CI が全て通過している（push → CI 完走を待ってから Ready 化済み — 14 pass / 0 fail / 15 skip）
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）
- [x] **全 AC が実装済みであること**（AC1-5 全実装、TODO / 予定 のまま残っている AC なし）
- [x] **Phase 分割が必要だった場合は着手前に PO と合意し、子 Issue を起票済みであること** — 本 PR は #1747 AC4 follow-up の単一 Issue 完遂で、追加 Phase 分割なし
- [x] UI 変更がある場合: 該当なし（scripts/ のみ）
- [x] 認証が絡む画面を変更した場合: 該当なし
- [x] **SS の表示確認 (#1741)**: 添付した SS は `screenshots` orphan branch raw URL 経由のため GitHub Web プレビューで表示可能
- [x] **DOM スナップショット併記 (#1747 AC4 / #1766)**: 本 PR の SS 2 件すべてに対応する `.dom.html` リンクが PR body に含まれている（本機能の実演を兼ねる）
- [x] **hardcoded JP text (#1452 Phase A)**: scripts/ の変更のみのため `src/routes/**/*.svelte` 内の日本語ハードコードは増加ゼロ

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない（priority:medium）

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし（scripts/ ツールチェーンのみ）

### スコープ完全性
- [x] **見落とし確認**: Issue #1766 の AC1-AC5 を全て同 PR で完遂。partial / follow-up 起票は無い

## デプロイ検証（#710 — マージ後必須）

- [x] **N/A** — デプロイ検証不要（scripts/ + docs/ のみの変更）

## 完了チェックリスト

- [x] `npx biome check scripts tests` — lint エラーなし（0 warning baseline 維持）
- [x] `npx svelte-check` — 型エラーなし（既存 dompurify 関連 1 error は本 PR 範囲外）
- [x] `npx vitest run tests/unit/scripts/` — ユニットテスト全通過（6 files / 128 tests）
- [x] `npx playwright test` — N/A（scripts/ のみの変更でアプリ E2E に影響なし）
- [x] PRのサイズが適切（11 ファイル / +761 / -71 行 — テンプレ範囲内）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

<!-- QM が approve するときに記入。PR 作者は空欄のままでよい。 -->

- [ ] Issue AC 全項目が PR diff で達成されていることを確認した（`gh issue view 1766` で開いて 1 対 1 突合）
- [ ] 添付スクリーンショットを **全て Read tool で開いて目視** し、UI/UX デザイナー観点で違和感が無いことを確認した
- [ ] 添付された `.dom.html` を Read tool で開き、SS 上で見える主要ラベル・構造タグが DOM 内に存在することを grep で確認した（#1766 で導入された新ルール）
- [ ] `docs/DESIGN.md` §9 禁忌事項 6 点（色直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / `<style>` 50 行超え）のいずれにも該当しないことを確認した
- [ ] 並行実装（デモ / 5 年齢モード / LP / ナビ 3 種）の同期漏れが無いことを確認した
- [ ] スコープ外の気付きがあれば Issue 起票済み（スルー禁止）
- [ ] CI 全緑を **上記チェック後の補助情報として** 確認した（先に CI を見ると proxy 退行が再発する）

### QM 所見（スクリーンショット 1 枚ごとに 1 行以上）

<!-- QM 記入欄 -->


