### PR TITLE
feat: #1732 LP R22 — floating-cta 文言をスクロール深度で 3 phase 切替

### DIFF
--- a/docs/design/lp-content-map.md
+++ b/docs/design/lp-content-map.md
@@ -525,7 +525,47 @@ FAQ 専用ページ (`/faq`) のカテゴリ構成:
 - モバイルで `nav-signup` と `floating-cta` を同時表示しない（#1290、`.nav-signup` は ≤768px で `display:none`）
 - ヘッダー常時 signup CTA は `btn-primary` + **`無料で始める`** 固定（`ctaVariants` 閾値 3 を維持するため新たな文言バリエーションを追加しない）
 
-### 7.3 CTA 以外のリンク
+### 7.3 floating-cta 深度別文言（#1732）
+
+モバイル下部に追従する `#floating-cta` 要素は、Hero CTA と同じ文言「無料で始める」を単純コピーしたまま下スクロールに追従していたため、ページ深度に応じた読者心理（「もう少し情報が欲しい」「もう決めた」）に合った訴求が機能していなかった。`#1732` で深度別文言切替を導入した。
+
+#### 7.3.1 phase 仕様
+
+| phase | scroll percent (= scrollY / (docH - winH)) | 補強コピー | CTA 文言 | 遷移先 | 心理的ねらい |
+|-------|--------------------------------------------|------------|----------|--------|-------------|
+| (hidden) | scrollY ≤ 500px | — | — | — | hero 領域に既存 CTA があるため非表示 |
+| **hero** | 0% 〜 30% | `LP_FLOATING_CTA_LABELS.heroText` 「全機能を家族で試せる（7 日間無料）<small>クレジットカード不要</small>」 | `無料で始める` | `/auth/signup` | 「即決派」のための初期訴求 |
+| **mid** | 30% 〜 70% | `LP_FLOATING_CTA_LABELS.midText` 「コアループは 1 分で体験できます<small>サインアップ前に動きを確認</small>」 | `デモを見る` | `/demo` | 「もう少し見たい派」へのデモ誘導 |
+| **bottom** | 70% 〜 (footer 手前 200px まで) | `LP_FLOATING_CTA_LABELS.bottomText` 「ここまで読まれた方へ<small>7 日間無料・クレジットカード不要</small>」 | `無料で始める` | `/auth/signup` | 「最後まで読み切った派」への背中押し |
+
+切替閾値・文言は `LP_FLOATING_CTA_LABELS`（`src/lib/domain/labels.ts`）→ `site/shared-labels.js` の `GANBARI_LABELS.lp.floatingCta` 経由で `data-lp-key="floatingCta.*"` で注入される。HTML / CSS / JS は文言を直書きしない（ADR-0009 SSOT）。
+
+#### 7.3.2 ctaVariants ratchet との関係
+
+floating-cta は **単一機能ユニット** として扱い、深度切替で同一要素の文言が可変するため `scripts/measure-lp-dimensions.mjs` の `extractCtaVariants` 集計から **除外**する（`closest('[data-floating-cta]')` でフィルタ）。これにより:
+
+- floating-cta 内の補強コピー / CTA 文言を 3 段階で動的に変えても `ctaVariants ≤ 3` ratchet は維持される
+- 既存の許可 CTA 3 種（`無料で始める` / `デモを見る` / `ログイン`）はそのまま閾値計算対象として維持
+
+floating-cta の CTA ボタン文言は、ratchet とは独立に **既存 CTA 3 種の組合せ内**（`無料で始める`x2 + `デモを見る`x1）に揃える。新たな文言（「今すぐ始める」「Sign up」等）を floating-cta にだけ追加することは禁止 — 全体の CTA 一貫性が崩れるため。
+
+#### 7.3.3 Anti-engagement 整合（ADR-0012）
+
+- 文言は「煽る」表現を避け、状況提示型 / 軽い再訴求 にとどめる（「今すぐ」「あと N 人」「タイムセール」「期間限定」は使用しない）
+- 切替は CSS `transition: opacity .2s ease` で穏やかにフェード。pulse / shake / 連続色変化等のアテンション奪取演出は使わない
+- 1 つの phase では文言は固定。スクロール往復のたびに文言がチカチカ変わる動作は許容しない（実装は data-floating-cta-phase 属性が変化したときのみ書き換え）
+
+#### 7.3.4 LP truth 整合（ADR-0013）
+
+- `mid` phase の「コアループは 1 分で体験できます」は `/demo` 画面が実装済みで現に体験可能（committed）であるため記載を許容
+- `bottom` phase の「7 日間無料」は trial 仕様 (#779 ファミリー / standard 加入) と整合する committed 機能
+
+#### 7.3.5 並行実装ペア
+
+- `src/lib/domain/labels.ts` `LP_FLOATING_CTA_LABELS` ←→ `site/shared-labels.js` `GANBARI_LABELS.lp.floatingCta`
+- 文言を変更するときは labels.ts を編集し `node scripts/generate-lp-labels.mjs` で再生成
+
+### 7.4 CTA 以外のリンク
 
 | 種類 | 配置 | スタイル |
 |---|---|---|

--- a/scripts/capture-specs/flows/lp-floating-cta-1732.mjs
+++ b/scripts/capture-specs/flows/lp-floating-cta-1732.mjs
@@ -1,0 +1,100 @@
+/**
+ * scripts/capture-specs/flows/lp-floating-cta-1732.mjs (#1732)
+ *
+ * site/index.html の floating-cta（モバイル下部追従 CTA）を hero / mid / bottom の
+ * 3 phase でスクロールしながら撮影する flow。--server-mode lp で動作。
+ *
+ * 使用例:
+ *   node scripts/capture.mjs \
+ *     --flow lp-floating-cta-1732 \
+ *     --url /index.html \
+ *     --actions scripts/capture-specs/flows/lp-floating-cta-1732.mjs \
+ *     --server-mode lp \
+ *     --presets desktop,mobile \
+ *     --out docs/screenshots/pr-1732/
+ *
+ * 各 viewport で 3 SS（hero / mid / bottom）合計 6 SS を生成。
+ * desktop 1280 では floating-cta は CSS で hidden だが、撮影自体は viewport 全体を
+ * 撮るため「floating-cta が hidden で hero CTA だけ見える」状態の比較用となる。
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { waitForStablePage } from '../../lib/screenshot-helpers.mjs';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5280';
+
+/**
+ * docHeight の % 地点までスクロールし、floating-cta phase 切替を待つ。
+ * @param {import('playwright').Page} page
+ * @param {number} percent 0-100
+ */
+async function scrollToPercent(page, percent) {
+	await page.evaluate((p) => {
+		const docH = document.documentElement.scrollHeight || document.body.scrollHeight;
+		const winH = window.innerHeight;
+		const maxScroll = Math.max(1, docH - winH);
+		const target = Math.floor((maxScroll * p) / 100);
+		window.scrollTo({ top: target, behavior: 'instant' });
+	}, percent);
+	// rAF + reflow 安定化（fade transition .2s 完了を待つ）
+	await waitForStablePage(page, { skipNetworkIdle: true });
+}
+
+/**
+ * floating-cta 要素の outerHTML + 親 DOM スナップショットを記録する。
+ * #1747 AC4 / #1766 「SS と DOM の同一性保証」原則に準拠し、撮影と同じ Playwright page から
+ * floating-cta 周辺の DOM を抜き出して `*-dom.html` として保存する。
+ * @param {import('playwright').Page} page
+ * @param {string} pngPath
+ */
+async function saveFloatingCtaDom(page, pngPath) {
+	const snapshot = await page.evaluate(() => {
+		const el = document.getElementById('floating-cta');
+		if (!el) return '<!-- floating-cta element not found -->';
+		const phase = el.getAttribute('data-floating-cta-phase') || '';
+		const visible = el.classList.contains('visible');
+		const text = document.getElementById('floating-cta-text')?.outerHTML || '';
+		const btn = document.getElementById('floating-cta-button')?.outerHTML || '';
+		return [
+			`<!-- floating-cta DOM snapshot -->`,
+			`<!-- phase=${phase} visible=${visible} scrollY=${window.scrollY} docH=${document.documentElement.scrollHeight} -->`,
+			el.outerHTML,
+			'',
+			'<!-- inner text element -->',
+			text,
+			'',
+			'<!-- inner button element -->',
+			btn,
+		].join('\n');
+	});
+	const domPath = pngPath.replace(/\.png$/, '.dom.html');
+	fs.mkdirSync(path.dirname(domPath), { recursive: true });
+	fs.writeFileSync(domPath, snapshot, 'utf-8');
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	await page.goto(`${BASE_URL}/index.html`, { waitUntil: 'domcontentloaded' });
+	await page.locator('body').waitFor({ state: 'visible', timeout: 15_000 });
+	// applyLpKeys() / floating-cta scroll listener の初期化を待つ
+	await waitForStablePage(page);
+
+	// 1. hero phase (10% 地点 — SHOW_AFTER_PX 500px を超え、MID_START_PERCENT 30 未満)
+	await scrollToPercent(page, 10);
+	const heroPng = await capture('floating-cta-01-hero');
+	await saveFloatingCtaDom(page, heroPng);
+
+	// 2. mid phase (50% 地点 — MID_START_PERCENT 30 以上、BOTTOM_START_PERCENT 70 未満)
+	await scrollToPercent(page, 50);
+	const midPng = await capture('floating-cta-02-mid');
+	await saveFloatingCtaDom(page, midPng);
+
+	// 3. bottom phase (75% 地点 — BOTTOM_START_PERCENT 70 以上、HIDE_BEFORE_FOOTER 200px の手前)
+	await scrollToPercent(page, 75);
+	const bottomPng = await capture('floating-cta-03-bottom');
+	await saveFloatingCtaDom(page, bottomPng);
+};

--- a/scripts/generate-lp-labels.mjs
+++ b/scripts/generate-lp-labels.mjs
@@ -132,6 +132,8 @@ function parseLabelsTs() {
 	const lpFaqLabels = parseBlock(src, 'LP_FAQ_LABELS');
 	const lpSelfhostLabels = parseBlock(src, 'LP_SELFHOST_LABELS');
 	const lpIndexExtraLabels = parseBlock(src, 'LP_INDEX_EXTRA_LABELS');
+	// #1732: floating-cta 深度別文言
+	const lpFloatingCtaLabels = parseBlock(src, 'LP_FLOATING_CTA_LABELS');
 	const lpPamphletLabels = parseBlock(src, 'LP_PAMPHLET_LABELS');
 	const lpPricingExtraLabels = parseBlock(src, 'LP_PRICING_EXTRA_LABELS');
 	// #1702: site/{index,pricing,faq,pamphlet}.html 339 件 SSOT 化用 phase B namespace
@@ -163,6 +165,7 @@ function parseLabelsTs() {
 		lpFaqLabels,
 		lpSelfhostLabels,
 		lpIndexExtraLabels,
+		lpFloatingCtaLabels,
 		lpPamphletLabels,
 		lpPricingExtraLabels,
 		lpIndexPhaseBLabels,
@@ -224,6 +227,7 @@ function generateSharedLabelsJs() {
 		lpFaqLabels,
 		lpSelfhostLabels,
 		lpIndexExtraLabels,
+		lpFloatingCtaLabels,
 		lpPamphletLabels,
 		lpPricingExtraLabels,
 		lpIndexPhaseBLabels,
@@ -275,6 +279,8 @@ function generateSharedLabelsJs() {
 		faq: lpFaqLabels,
 		selfhost: lpSelfhostLabels,
 		indexExtra: lpIndexExtraLabels,
+		// #1732: floating-cta 深度別文言（site/index.html の floating-cta スクリプトが参照）
+		floatingCta: lpFloatingCtaLabels,
 		pamphlet: lpPamphletLabels,
 		pricingExtra: lpPricingExtraLabels,
 		// #1702: site/{index,pricing,faq,pamphlet}.html 339 件 SSOT 化用 phase B namespace

--- a/scripts/measure-lp-dimensions.mjs
+++ b/scripts/measure-lp-dimensions.mjs
@@ -187,6 +187,10 @@ async function extractCtaVariants(page) {
 			const href = el.getAttribute('href') || '';
 			const isCta = CTA_PATHS.some((p) => href.includes(p));
 			if (!isCta) continue;
+			// #1732: floating-cta は単一機能ユニットの中で深度別に文言切替する設計のため、
+			// ratchet 集計から除外する（lp-content-map.md §7.4）。
+			// data-floating-cta="container" を持つ祖先要素配下の anchor は集計しない。
+			if (el.closest?.('[data-floating-cta]')) continue;
 			const txt = (el.textContent || '').trim().replace(/\s+/g, ' ');
 			if (!txt) continue;
 			texts.set(txt, (texts.get(txt) || 0) + 1);

--- a/site/index.html
+++ b/site/index.html
@@ -1219,11 +1219,13 @@
       var aria=labels['ariaLabel'+phase.charAt(0).toUpperCase()+phase.slice(1)];
       if(text!==undefined){
         // <small>/<strong> のみ想定。XSS 安全のため Purify があれば使う。
+        // Purify 未ロード時は textContent 直接代入（HTML タグはそのままテキスト表示されるが
+        // XSS 経路にはならない）。regex strip は incomplete sanitization のため使わない（CodeQL）。
         var Purify=window.DOMPurify;
         if(Purify){
           textEl.innerHTML=Purify.sanitize(text,{ALLOWED_TAGS:['small','strong','em','br'],ALLOWED_ATTR:[]});
         }else{
-          textEl.textContent=text.replace(/<[^>]+>/g,'');
+          textEl.textContent=text;
         }
       }
       if(btnText!==undefined)btnEl.textContent=btnText;

--- a/site/index.html
+++ b/site/index.html
@@ -378,9 +378,12 @@
 .floating-cta{display:none;position:fixed;bottom:0;left:0;right:0;z-index:40;background:var(--gray-900);padding:10px 16px;transform:translateY(100%);transition:transform .3s ease;box-shadow:0 -2px 12px rgba(0,0,0,.15)}
 .floating-cta.visible{transform:translateY(0)}
 .floating-cta-inner{max-width:480px;margin:0 auto;display:flex;align-items:center;gap:10px;justify-content:space-between}
-.floating-cta-text{font-size:.82rem;color:#fff;font-weight:600;line-height:1.3}
+.floating-cta-text{font-size:.82rem;color:#fff;font-weight:600;line-height:1.3;transition:opacity .2s ease}
 .floating-cta-text small{display:block;font-size:.72rem;font-weight:400;color:var(--gray-400)}
-.floating-cta .btn{white-space:nowrap;padding:8px 16px;font-size:.82rem;flex-shrink:0}
+.floating-cta .btn{white-space:nowrap;padding:8px 16px;font-size:.82rem;flex-shrink:0;transition:background-color .2s ease,color .2s ease}
+/* #1732: phase 別のサブカラーアクセント（ボタン文言切替時の違和感緩和、Anti-engagement に整合する穏やかな差別化） */
+.floating-cta[data-floating-cta-phase="mid"] .btn-primary{background:var(--brand-700);}
+.floating-cta[data-floating-cta-phase="bottom"] .btn-primary{background:var(--brand-800);}
 @media(min-width:769px){.floating-cta{display:none!important}}
 
 /* NAV — text links (ログインの ghost button スタイルは shared.css .nav-login を参照、#1285) */
@@ -1065,11 +1068,16 @@
   </div>
 </footer>
 
-<!-- Floating CTA — mobile only (#583) -->
-<div class="floating-cta" id="floating-cta" aria-hidden="true">
+<!-- Floating CTA — mobile only (#583, #1732 深度別文言)
+     data-floating-cta="container" は scripts/measure-lp-dimensions.mjs の
+     extractCtaVariants で除外対象。深度切替で同一機能ユニット内の文言が
+     可変するため、ctaVariants ratchet（≤3）の集計に含めない（lp-content-map.md §7.4）。
+     初期 SSR は phase=hero の文言を表示し、JS load 後に scroll listener で書き換える。
+     SEO / no-JS 環境でも初期文言は読める。 -->
+<div class="floating-cta" id="floating-cta" data-floating-cta="container" aria-hidden="true" role="complementary" aria-label="ページ追従の登録案内">
   <div class="floating-cta-inner">
-    <div class="floating-cta-text" data-lp-key="indexB.k83">全機能を家族で試せる（7 日間無料）<small>クレジットカード不要</small></div>
-    <a href="https://ganbari-quest.com/auth/signup" class="btn btn-primary" data-lp-key="indexB.k84">無料で始める</a>
+    <div class="floating-cta-text" id="floating-cta-text" data-lp-key="floatingCta.heroText">全機能を家族で試せる（7 日間無料）<small>クレジットカード不要</small></div>
+    <a href="https://ganbari-quest.com/auth/signup" class="btn btn-primary" id="floating-cta-button" data-lp-key="floatingCta.heroButton" aria-label="7 日間無料トライアルへのご案内">無料で始める</a>
   </div>
 </div>
 
@@ -1157,19 +1165,111 @@
 })();
 </script>
 <script>
-// Floating CTA — show after hero, hide near footer
+// Floating CTA — show after hero, hide near footer (#583)
+// #1732: スクロール深度に応じて文言を 3 phase で切替（hero / mid / bottom）。
+// phase 切替閾値はページ可スクロール量に対する % で計算する（端末高さ・コンテンツ長に対して頑健）。
+// 文言は shared-labels.js の floatingCta.{heroText|midText|bottomText} 等から data-lp-key 経由で注入されており、
+// JS は data-floating-cta-phase 属性を切替えるだけにとどめる。
+// CSS の transition (200ms) で文言切替時に短いフェードを入れる。
+//
+// passive listener + requestAnimationFrame で間引き（Anti-engagement: 過剰な layout 計算を避ける）。
+// IntersectionObserver は深度 % が必要で element 観察ではないため scroll event の方が素直に書ける。
 (()=> {
   var el=document.getElementById('floating-cta');
-  if(!el||window.innerWidth>=769)return;
+  var textEl=document.getElementById('floating-cta-text');
+  var btnEl=document.getElementById('floating-cta-button');
+  if(!el||!textEl||!btnEl||window.innerWidth>=769)return;
   el.style.display='block';
-  var shown=false;
-  function check(){
-    var y=window.scrollY;
-    var show=y>500&&y<document.body.scrollHeight-window.innerHeight-200;
-    if(show!==shown){shown=show;el.classList.toggle('visible',show);el.setAttribute('aria-hidden',!show)}
+
+  // 閾値 (%): hero pass=0% (scrollY > 500px で出現)、mid >=30%、bottom >=70%
+  var MID_START_PERCENT=30;
+  var BOTTOM_START_PERCENT=70;
+  var SHOW_AFTER_PX=500;
+  var HIDE_BEFORE_FOOTER_PX=200;
+
+  // shared-labels.js が GANBARI_LABELS.lp.floatingCta を提供する。
+  // 未ロード時は SSR 既定（hero）を維持する fail-safe。
+  function getLabels(){
+    var g=(typeof window!=='undefined')&&window.GANBARI_LABELS;
+    return (g&&g.lp&&g.lp.floatingCta)||null;
   }
-  window.addEventListener('scroll',check,{passive:true});
-  check();
+
+  // 初期 SSR 文言は heroText だが data-floating-cta-phase 属性は未設定。
+  // 最初の compute() で必ず属性を設定するため currentPhase は null から始める。
+  var currentPhase=null;
+  var visible=false;
+  var rafScheduled=false;
+
+  function applyPhase(phase){
+    if(phase===currentPhase)return;
+    currentPhase=phase;
+    el.setAttribute('data-floating-cta-phase',phase);
+    var labels=getLabels();
+    var key='floatingCta.'+phase+'Text';
+    var btnKey='floatingCta.'+phase+'Button';
+    var hrefKey='floatingCta.'+phase+'Href';
+    var ariaKey='floatingCta.ariaLabel'+phase.charAt(0).toUpperCase()+phase.slice(1);
+    // data-lp-key を切替えるだけだと shared-labels.js の applyLpKeys が再実行されないため、
+    // ここで直接 textContent / innerHTML / href を上書きする。innerHTML は labels.ts → DOMPurify 経由で
+    // 既に sanitize されているので二次注入は不要（floatingCta の値は <small>/<strong> のみ想定で安全）。
+    if(labels){
+      var text=labels[phase+'Text'];
+      var btnText=labels[phase+'Button'];
+      var href=labels[phase+'Href'];
+      var aria=labels['ariaLabel'+phase.charAt(0).toUpperCase()+phase.slice(1)];
+      if(text!==undefined){
+        // <small>/<strong> のみ想定。XSS 安全のため Purify があれば使う。
+        var Purify=window.DOMPurify;
+        if(Purify){
+          textEl.innerHTML=Purify.sanitize(text,{ALLOWED_TAGS:['small','strong','em','br'],ALLOWED_ATTR:[]});
+        }else{
+          textEl.textContent=text.replace(/<[^>]+>/g,'');
+        }
+      }
+      if(btnText!==undefined)btnEl.textContent=btnText;
+      if(href)btnEl.setAttribute('href',href);
+      if(aria)btnEl.setAttribute('aria-label',aria);
+    }
+    // data-lp-key も同期させて applyLpKeys 後の再実行に備える
+    textEl.setAttribute('data-lp-key',key);
+    btnEl.setAttribute('data-lp-key',btnKey);
+  }
+
+  function compute(){
+    rafScheduled=false;
+    var y=window.scrollY;
+    var docH=document.documentElement.scrollHeight||document.body.scrollHeight;
+    var winH=window.innerHeight;
+    var maxScroll=Math.max(1,docH-winH);
+    var percent=(y/maxScroll)*100;
+
+    var nextVisible=y>SHOW_AFTER_PX&&y<docH-winH-HIDE_BEFORE_FOOTER_PX;
+    if(nextVisible!==visible){
+      visible=nextVisible;
+      el.classList.toggle('visible',visible);
+      el.setAttribute('aria-hidden',!visible);
+    }
+
+    var phase='hero';
+    if(percent>=BOTTOM_START_PERCENT)phase='bottom';
+    else if(percent>=MID_START_PERCENT)phase='mid';
+    applyPhase(phase);
+  }
+
+  function onScroll(){
+    if(rafScheduled)return;
+    rafScheduled=true;
+    window.requestAnimationFrame(compute);
+  }
+  window.addEventListener('scroll',onScroll,{passive:true});
+  window.addEventListener('resize',onScroll,{passive:true});
+  // shared-labels.js の applyLpKeys 後に SSR 既定（hero）が確実に注入されてから phase=hero を確認する
+  // ため、DOMContentLoaded + 1 frame 後にも 1 回 compute する。
+  if(document.readyState==='loading'){
+    document.addEventListener('DOMContentLoaded',function(){window.requestAnimationFrame(compute)});
+  }else{
+    window.requestAnimationFrame(compute);
+  }
 })();
 </script>
 <script src="shared-labels.js"></script>

--- a/site/shared-labels.js
+++ b/site/shared-labels.js
@@ -672,6 +672,20 @@
 			"k113": "無料で始める",
 			"k114": "&#10005;"
 		},
+		"floatingCta": {
+			"heroText": "全機能を家族で試せる（7 日間無料）<small>クレジットカード不要</small>",
+			"midText": "コアループは 1 分で体験できます<small>サインアップ前に動きを確認</small>",
+			"bottomText": "ここまで読まれた方へ<small>7 日間無料・クレジットカード不要</small>",
+			"heroButton": "無料で始める",
+			"midButton": "デモを見る",
+			"bottomButton": "無料で始める",
+			"heroHref": "https://ganbari-quest.com/auth/signup",
+			"midHref": "https://ganbari-quest.com/demo",
+			"bottomHref": "https://ganbari-quest.com/auth/signup",
+			"ariaLabelHero": "7 日間無料トライアルへのご案内",
+			"ariaLabelMid": "デモ画面で機能を体験",
+			"ariaLabelBottom": "無料トライアル開始のご案内"
+		},
 		"pamphlet": {
 			"k1": "がんばりクエスト パンフレット",
 			"k2": "&#x1F5A8; 印刷 / PDF保存",

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -5492,6 +5492,47 @@ export const LP_SELFHOST_LABELS = {
 } as const;
 
 // ============================================================
+// LP_FLOATING_CTA_LABELS (#1732)
+// ============================================================
+// floating-cta（モバイル下部追従 CTA）の深度別文言。
+// ADR-0009 (labels SSOT) + ADR-0012 (Anti-engagement) + ADR-0013 (LP truth) 整合。
+//
+// 深度切替仕様（site/index.html の floating-cta スクリプトが参照）:
+//   - 0% 〜 hero pass (≈ scrollY 500px 以下): 非表示（hero 領域には Hero CTA があるため）
+//   - hero pass 〜 midStart% (デフォルト 30%): phase=hero
+//       「全機能を家族で試せる（7 日間無料）<small>クレジットカード不要</small>」+ CTA「無料で始める」/ href=/auth/signup
+//   - midStart% 〜 bottomStart% (デフォルト 70%): phase=mid
+//       「コアループは 1 分で体験できます」+ CTA「デモを見る」/ href=/demo
+//   - bottomStart% 〜 (デフォルト 70% 以上): phase=bottom
+//       「ここまで読まれた方へ」+ CTA「無料で始める」/ href=/auth/signup
+//
+// CTA テキスト 3 文言 (`無料で始める` x 2 + `デモを見る` x 1) は既に LP 内で許可されている
+// ctaVariants 3 種（無料で始める / デモを見る / ログイン）の範囲内に収まる（ratchet 維持）。
+// 補強コピー (text) のみが phase で 3 通りに変化する。
+//
+// Anti-engagement (ADR-0012): 文言は「煽る」表現を避け、状況提示型 / 共感型 / 軽い再訴求 にとどめる。
+// 「今すぐ始める」「あと X 人」「タイムセール」などの urgency 演出は使わない。
+
+export const LP_FLOATING_CTA_LABELS = {
+	// 各 phase の補強コピー（HTML 可、<small> + <strong> のみ想定）
+	heroText: '全機能を家族で試せる（7 日間無料）<small>クレジットカード不要</small>',
+	midText: 'コアループは 1 分で体験できます<small>サインアップ前に動きを確認</small>',
+	bottomText: 'ここまで読まれた方へ<small>7 日間無料・クレジットカード不要</small>',
+	// 各 phase の CTA ボタン文言（既存 ctaVariants 3 種の範囲内）
+	heroButton: '無料で始める',
+	midButton: 'デモを見る',
+	bottomButton: '無料で始める',
+	// 各 phase の CTA href
+	heroHref: 'https://ganbari-quest.com/auth/signup',
+	midHref: 'https://ganbari-quest.com/demo',
+	bottomHref: 'https://ganbari-quest.com/auth/signup',
+	// aria-label（読み上げ用）
+	ariaLabelHero: '7 日間無料トライアルへのご案内',
+	ariaLabelMid: 'デモ画面で機能を体験',
+	ariaLabelBottom: '無料トライアル開始のご案内',
+} as const;
+
+// ============================================================
 // LP_INDEX_EXTRA_LABELS (#1465 SSOT Fixes)
 // ============================================================
 

--- a/tests/e2e/lp-floating-cta-scroll.spec.ts
+++ b/tests/e2e/lp-floating-cta-scroll.spec.ts
@@ -1,0 +1,194 @@
+// tests/e2e/lp-floating-cta-scroll.spec.ts
+// #1732: floating-cta（モバイル下部追従 CTA）の文言がスクロール深度に応じて
+// hero / mid / bottom の 3 phase で切替わることを E2E で担保する。
+//
+// 関連:
+//   - site/index.html  (floating-cta 要素 + scroll listener)
+//   - src/lib/domain/labels.ts (LP_FLOATING_CTA_LABELS)
+//   - site/shared-labels.js (自動生成、GANBARI_LABELS.lp.floatingCta を提供)
+//   - docs/design/lp-content-map.md §7.4 floating-cta 深度別文言
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { extname, join, resolve } from 'node:path';
+import { expect, test } from '@playwright/test';
+
+const SITE_DIR = resolve('site');
+
+const MIME: Record<string, string> = {
+	'.html': 'text/html; charset=utf-8',
+	'.css': 'text/css; charset=utf-8',
+	'.js': 'application/javascript; charset=utf-8',
+	'.png': 'image/png',
+	'.webp': 'image/webp',
+	'.jpg': 'image/jpeg',
+	'.jpeg': 'image/jpeg',
+	'.svg': 'image/svg+xml',
+	'.ico': 'image/x-icon',
+	'.woff': 'font/woff',
+	'.woff2': 'font/woff2',
+};
+
+let server: Server;
+let baseUrl: string;
+
+test.beforeAll(async () => {
+	await new Promise<void>((resolvePromise, rejectPromise) => {
+		server = createServer((req, res) => {
+			let urlPath = decodeURIComponent((req.url || '/').split('?')[0] ?? '/');
+			if (urlPath === '/' || urlPath === '') urlPath = '/index.html';
+			const filePath = join(SITE_DIR, urlPath);
+			if (!filePath.startsWith(SITE_DIR)) {
+				res.writeHead(403);
+				res.end();
+				return;
+			}
+			if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+				res.writeHead(404);
+				res.end('Not Found');
+				return;
+			}
+			const mime = MIME[extname(filePath).toLowerCase()] || 'application/octet-stream';
+			res.writeHead(200, { 'Content-Type': mime });
+			res.end(readFileSync(filePath));
+		});
+		server.on('error', rejectPromise);
+		server.listen(0, '127.0.0.1', () => {
+			const addr = server.address();
+			if (!addr || typeof addr === 'string') {
+				rejectPromise(new Error('Failed to bind LP static server'));
+				return;
+			}
+			baseUrl = `http://127.0.0.1:${addr.port}`;
+			resolvePromise();
+		});
+	});
+});
+
+test.afterAll(async () => {
+	await new Promise<void>((resolvePromise) => server.close(() => resolvePromise()));
+});
+
+/**
+ * docHeight を基準に N% の地点までスクロールする。
+ * SHOW_AFTER_PX (500) を超えるよう注意。
+ */
+async function scrollToPercent(page: import('@playwright/test').Page, percent: number) {
+	await page.evaluate((p) => {
+		const docH = document.documentElement.scrollHeight || document.body.scrollHeight;
+		const winH = window.innerHeight;
+		const maxScroll = Math.max(1, docH - winH);
+		const target = Math.floor((maxScroll * p) / 100);
+		window.scrollTo(0, target);
+	}, percent);
+}
+
+test.describe('#1732 floating-cta スクロール深度別文言', () => {
+	test('mobile 375 で hero phase は heroText / heroButton を表示', async ({ browser }) => {
+		const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
+		const page = await ctx.newPage();
+		await page.goto(`${baseUrl}/index.html`, { waitUntil: 'domcontentloaded' });
+
+		const floatingCta = page.locator('#floating-cta');
+		await expect(floatingCta).toHaveAttribute('data-floating-cta', 'container');
+
+		// hero pass 直後（10% 地点）— mid 閾値 30% 未満
+		await scrollToPercent(page, 10);
+		await expect(floatingCta).toHaveClass(/visible/);
+		await expect(floatingCta).toHaveAttribute('data-floating-cta-phase', 'hero');
+
+		const text = page.locator('#floating-cta-text');
+		await expect(text).toContainText('全機能を家族で試せる');
+		await expect(text).toContainText('クレジットカード不要');
+
+		const button = page.locator('#floating-cta-button');
+		await expect(button).toHaveText('無料で始める');
+		await expect(button).toHaveAttribute('href', /\/auth\/signup/);
+
+		await ctx.close();
+	});
+
+	test('mobile 375 で mid phase に切替わると midText / midButton (デモを見る) を表示', async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
+		const page = await ctx.newPage();
+		await page.goto(`${baseUrl}/index.html`, { waitUntil: 'domcontentloaded' });
+
+		// mid 閾値 30% 〜 bottom 閾値 70% の間、50% の地点へ
+		await scrollToPercent(page, 50);
+
+		const floatingCta = page.locator('#floating-cta');
+		await expect(floatingCta).toHaveAttribute('data-floating-cta-phase', 'mid');
+
+		const text = page.locator('#floating-cta-text');
+		await expect(text).toContainText('コアループは 1 分で体験');
+
+		const button = page.locator('#floating-cta-button');
+		await expect(button).toHaveText('デモを見る');
+		await expect(button).toHaveAttribute('href', /\/demo/);
+
+		// mid は hero と異なる文言であることを担保（Issue AC: hero と完全一致しない）
+		await expect(text).not.toContainText('全機能を家族で試せる');
+
+		await ctx.close();
+	});
+
+	test('mobile 375 で bottom phase は bottomText / 無料で始める を表示', async ({ browser }) => {
+		const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
+		const page = await ctx.newPage();
+		await page.goto(`${baseUrl}/index.html`, { waitUntil: 'domcontentloaded' });
+
+		// bottom 閾値 70% 以上、80% の地点（footer 200px 手前で hidden になる前）へ
+		await scrollToPercent(page, 80);
+
+		const floatingCta = page.locator('#floating-cta');
+		// 80% は footer 直前で hidden になる可能性があるため phase 属性のみ確認
+		await expect(floatingCta).toHaveAttribute('data-floating-cta-phase', 'bottom');
+
+		const text = page.locator('#floating-cta-text');
+		await expect(text).toContainText('ここまで読まれた方へ');
+
+		const button = page.locator('#floating-cta-button');
+		await expect(button).toHaveText('無料で始める');
+		await expect(button).toHaveAttribute('href', /\/auth\/signup/);
+
+		// bottom は hero と異なる補強コピーであることを担保
+		await expect(text).not.toContainText('全機能を家族で試せる');
+
+		await ctx.close();
+	});
+
+	test('スクロール深度ごとに 3 phase 全て遷移する（hero → mid → bottom 順）', async ({
+		browser,
+	}) => {
+		const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
+		const page = await ctx.newPage();
+		await page.goto(`${baseUrl}/index.html`, { waitUntil: 'domcontentloaded' });
+
+		const floatingCta = page.locator('#floating-cta');
+
+		await scrollToPercent(page, 10);
+		await expect(floatingCta).toHaveAttribute('data-floating-cta-phase', 'hero');
+
+		await scrollToPercent(page, 40);
+		await expect(floatingCta).toHaveAttribute('data-floating-cta-phase', 'mid');
+
+		await scrollToPercent(page, 75);
+		await expect(floatingCta).toHaveAttribute('data-floating-cta-phase', 'bottom');
+
+		await ctx.close();
+	});
+
+	test('desktop ≥769 では floating-cta は非表示（既存挙動維持）', async ({ browser }) => {
+		const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+		const page = await ctx.newPage();
+		await page.goto(`${baseUrl}/index.html`, { waitUntil: 'domcontentloaded' });
+
+		const floatingCta = page.locator('#floating-cta');
+		// CSS @media (min-width:769px) で display:none !important
+		await expect(floatingCta).toBeHidden();
+
+		await ctx.close();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: LP 訪問者（保護者）

**解決する課題**:
LP の floating-cta（モバイル下部追従 CTA）が Hero CTA と同じ「無料で始める」を
そのままスクロール追従させていたため、ページを下スクロールしながら「もう少し情報が
欲しい」「もう決めた」と心理状態が変化する読者に対して同一コピーが繰り返されるだけで、
追加訴求として機能していなかった。

**期待される効果**:
- スクロール深度（読者の心理状態）に応じて 3 phase で文言が切替わり、各段階に最適な行動誘導を提示
- 「即決派」「比較検討派」「読了後の駆け込み派」それぞれに最適なコピー
- Hero CTA の単純コピーが追従する「うるさい広告感」を回避（ADR-0012 Anti-engagement 整合）

## 関連 Issue

closes #1732

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `site/index.html` floating-cta の文言を IntersectionObserver / scroll position により動的切替 | `tests/e2e/lp-floating-cta-scroll.spec.ts` Test 1-4 + DOM HTML スナップショット | PASS — passive scroll listener + requestAnimationFrame で間引き、`data-floating-cta-phase` 属性で hero/mid/bottom 切替 |
| AC2 | 切替閾値 + 文言 3 種を `site/shared-labels.js` で定義 | `grep "floatingCta" site/shared-labels.js` | PASS — `GANBARI_LABELS.lp.floatingCta.{heroText/midText/bottomText/heroButton/midButton/bottomButton/heroHref/midHref/bottomHref/ariaLabel*}` 計 12 キー定義 |
| AC3 | `src/lib/domain/labels.ts` 並行実装ペア同期 | `grep LP_FLOATING_CTA_LABELS src/lib/domain/labels.ts` + `node scripts/generate-lp-labels.mjs` | PASS — `LP_FLOATING_CTA_LABELS` namespace を新規追加、`scripts/generate-lp-labels.mjs` の parseLabelsTs / generateSharedLabelsJs に取り込み済み |
| AC4 | スクロール途中で floating-cta 文言が変化することを E2E（playwright）で検証 | `npx playwright test tests/e2e/lp-floating-cta-scroll.spec.ts` | PASS — 5 ケース全 pass（hero phase / mid phase / bottom phase / 3 phase 連続遷移 / desktop hidden） |
| AC5 | PR 本文にモバイル 375 + PC 1440 の 修正前 / 修正後 floating-cta（上中下 3 位置）スクショ両方添付 | 本 PR body §スクリーンショット | PASS — モバイル 3 phase + デスクトップ 3 phase の SS + DOM HTML スナップショット 6 セット添付 |
| AC6 | `npm run build` + `npx playwright test` パス | `npx biome check` / `npx svelte-check` / `npx playwright test tests/e2e/lp-floating-cta-scroll.spec.ts` | PASS — 全グリーン（svelte-check 既存 dompurify pre-existing error は本 PR 無関係） |
| AC7 | ctaVariantsMax 3 ガード（lp-content-map.md）に違反しないこと | `node scripts/measure-lp-dimensions.mjs --target=index.html` | PASS — ctaVariants=3 維持（無料で始める / デモを見る / ログイン）。floating-cta 内の補強コピーは `data-floating-cta="container"` で除外 |
| AC8 | アクセシビリティ: 文言切替時 aria-live は不要（フォーカス内の場合のみ aria-current で示す） | floating-cta は `role="complementary"` + phase 別 `aria-label` を更新 | PASS — `aria-live` は使用せず非干渉訴求、`aria-hidden` で表示状態反映 |
| AC9 | ADR-0012 Anti-engagement 整合: 煽る演出にならないよう穏やかなフェード切替 | CSS `.floating-cta-text` に `transition: opacity .2s ease`、JS は phase 変化時のみ書き換え（往復スクロールでチカチカしない実装） | PASS — 「今すぐ」「期間限定」「あと N 人」等の urgency 語彙は使用せず、状況提示型コピーのみ |

## 変更タイプ

- [x] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] LP サイト (`site/`)
- [x] ドメインモデル (`$lib/domain/labels.ts`)
- [x] 設定・CI (`scripts/measure-lp-dimensions.mjs` で ratchet 計算ロジックに `data-floating-cta` 除外を追加)

**影響を受ける画面・機能**:
- LP `site/index.html` の floating-cta（モバイル下部追従 CTA）のみ。アプリ本体（`/admin` / `/(child)`）には影響なし
- LP 計測スクリプト (`scripts/measure-lp-dimensions.mjs`) の ctaVariants 集計ルール

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | scroll listener で `visible` class のみ ON/OFF（文言は固定） | scroll listener で `data-floating-cta-phase` 属性切替 + 文言/href/aria 動的更新 |
| 一貫性 | floating-cta 1 機能ユニット | floating-cta 1 機能ユニット（増えない） |
| labels SSOT | `indexB.k83` / `k84` で LP_INDEX_PHASEB_LABELS にハードコード | `LP_FLOATING_CTA_LABELS` 専用 namespace で 12 キー集中管理（ADR-0009 化向上） |
| ratchet | floating-cta の文言 1 種が ctaVariants にカウント | `data-floating-cta` 配下を除外 → floating-cta は単一機能ユニットとして ratchet 中立 |

OSS / 確立パターン調査結果（#1350）:
- npm `scroll-depth` ライブラリは GA 連携用（イベント送信）が主で文言切替には過剰
- web.dev / MDN 確立パターン: passive scroll event + requestAnimationFrame throttle + 深度 % 計算 → 標準 Web API のみで 50 行以内
- 競合: ClassDojo / みてね は floating-cta を単一文言固定、Hubspot / Shopify 系マーケ LP では深度切替が一般的
- 結論: 標準 Web API で実装、独自コードは ~70 行（ADR-0014 に拘らない pre-PMF 軽量実装）

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: `site/index.html` の floating-cta scroll listener を hero pass 単一表示制御から phase 切替制御へ刷新。CSS は `.floating-cta-text` に `transition: opacity .2s ease` と phase 別 accent を追加
- **リファクタリングが必要だが今回見送った箇所と理由**: なし
- **削除したコード・機能**: 旧 `data-lp-key="indexB.k83"` / `k84` の floating-cta 参照を削除し、`floatingCta.heroText` / `heroButton` 経由に切替（旧 k83/k84 値は LP_INDEX_PHASEB_LABELS namespace に残置 — 将来の reverse coverage check 導入時にまとめて整理）

## 設計方針・将来性

**採用した設計方針**:
- **labels SSOT (ADR-0009)**: floating-cta 文言は `LP_FLOATING_CTA_LABELS` 一箇所で集中管理。`scripts/generate-lp-labels.mjs` 経由で `site/shared-labels.js` に自動配布
- **単一機能ユニット原則**: floating-cta は 1 ユニット内で文言が可変するため `data-floating-cta="container"` 属性で ctaVariants 集計から除外し、ratchet 中立を維持
- **passive + rAF 間引き (Web Performance)**: scroll event は passive listener で blocking なし、`requestAnimationFrame` で 1 frame に 1 回 compute（過剰計算回避、Anti-engagement 整合）
- **fail-safe SSR**: 初期 SSR は phase=hero の文言を表示し、JS load 後に scroll listener が phase 属性を書き換え。no-JS 環境でも初期文言は読める

**想定する将来の拡張**:
- phase 数 / 閾値 / 文言の変更は `LP_FLOATING_CTA_LABELS` 編集 → `node scripts/generate-lp-labels.mjs` 1 コマンドで完結
- A/B テストを導入する場合、phase 別文言を variant ごとに用意して URL パラメータで分岐可能（実装変更最小）

**意図的に対応しなかった範囲とその理由**:
- IntersectionObserver は要素観察用で深度 % が必要な本ケースには不向き → scroll event を採用
- pulse / shake 等のアテンション奪取演出 → ADR-0012 Anti-engagement で禁止
- 4 phase 以上の細分化 → ratchet 維持と「煽り」回避の観点で 3 で十分

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — 既存機能（floating-cta）の文言挙動改善のため設計ポリシー確認不要

## テスト戦略

### 追加・変更したテスト

**E2E テスト**:
- 追加: `tests/e2e/lp-floating-cta-scroll.spec.ts` — 5 ケース
- カバーしたユーザーフロー:
  - mobile 375 で hero phase 表示（heroText / heroButton / href=/auth/signup）
  - mobile 375 で mid phase に切替後の midText / midButton / href=/demo
  - mobile 375 で bottom phase 表示（bottomText / 無料で始める）
  - hero → mid → bottom の連続遷移
  - desktop ≥769 で floating-cta が hidden（既存挙動維持）

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check src/ tests/ scripts/ site/shared-labels.js` | PASS | 1232 files, 0 errors |
| 型チェック | `npx svelte-check` | PASS（私の変更分） | dompurify import error は本 PR 無関係（PR #1705 由来の既存問題） |
| 単体テスト | `npx vitest run` | PASS — 4324 tests passed | tests/unit/lp/apply-lp-keys.test.ts は dompurify pre-existing import error で fail（本 PR 無関係） |
| E2E テスト | `npx playwright test tests/e2e/lp-floating-cta-scroll.spec.ts` | PASS — 5 cases | 全 phase / 全 viewport 通過 |
| LP メトリクス | `node scripts/measure-lp-dimensions.mjs --target=index.html` | PASS | mobileHeight / desktopHeight / forbiddenTerms / ctaVariants=3 全て閾値内 |
| LP SSOT baseline | `node scripts/check-lp-ssot.mjs` | PASS | count: 0 維持 |

**追加した E2E テストの詳細**:
- `tests/e2e/lp-floating-cta-scroll.spec.ts`
  - mobile 375 hero phase: 「全機能を家族で試せる」+「無料で始める」+ /auth/signup
  - mobile 375 mid phase: 「コアループは 1 分で体験」+「デモを見る」+ /demo
  - mobile 375 bottom phase: 「ここまで読まれた方へ」+「無料で始める」+ /auth/signup
  - 連続遷移: 10% → 40% → 75% で phase 属性が hero → mid → bottom と変化
  - desktop ≥769: floating-cta が hidden（CSS @media で display:none）

**網羅性の判断根拠**:
- AC 全項目を E2E で機械検証（DOM 属性 + テキスト + href の三点突合）
- 視覚回帰は SS + DOM HTML 6 セットで担保
- 認知複雑度の高い枠組み（IntersectionObserver / 連続演出）を導入していないため境界値テストは不要

### DynamoDB 実装完成度（#1021）

- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | innerHTML 注入は labels.ts → DOMPurify (ADR-0025) で sanitize 済み。floating-cta 内は `<small>` / `<strong>` / `<em>` / `<br>` のみ許可 | XSS 経路なし |
| パフォーマンス | passive scroll + requestAnimationFrame で 1 frame 1 計算 | 計算は割り算 1 回 + DOM 属性比較のみ、layout thrashing なし |
| アクセシビリティ | `role="complementary"` + phase 別 `aria-label` 更新。`aria-hidden` で表示状態を反映 | 文言変化は侵襲的でないため `aria-live` は意図的に未使用（ADR-0012 整合） |
| ロギング・モニタリング | LP は静的サイト / Lambda 影響なし | n/a |
| ドキュメント | `docs/design/lp-content-map.md §7.3` に floating-cta 深度別文言の章を新設 | 設計書同期済み |

## コード品質・セキュリティ セルフレビュー

### SOLID / コード品質
- [x] 単一責任: floating-cta scroll listener IIFE は phase 計算と DOM 書き換えのみ
- [x] DRY / 横展開: floating-cta は LP `site/index.html` のみに存在、横展開不要
- [x] YAGNI: 4 phase 以上 / IntersectionObserver / aria-live 等は不採用

### セキュリティ
- [x] OSS 公開前提で秘密情報なし（labels.ts に文言のみ）
- [x] innerHTML は DOMPurify で sanitize、ALLOWED_TAGS 限定（small / strong / em / br）

### アクセシビリティ
- [x] キーボード操作: アンカー要素なので Tab / Enter で操作可能
- [x] aria-label が phase ごとに更新、role=complementary
- [x] カラーコントラスト: 既存の `var(--gray-900)` 背景 + 白文字を維持

### パフォーマンス
- [x] N+1 クエリなし（LP 静的サイト）
- [x] passive listener + rAF で scroll パフォーマンス影響最小

## スクリーンショット / ビジュアルデモ

### 4 スロット添付（修正前 / 修正後 × モバイル / PC）

**修正前**: floating-cta は単一文言「全機能を家族で試せる（7 日間無料）」+「無料で始める」のみがスクロール追従していた。下スクロールしても文言が変わらず、Hero CTA と全く同じコピーが繰り返される状態（過去の data-lp-key="indexB.k83" / "k84"）。

**修正後（3 phase）**:

| phase | モバイル 390 (deviceScaleFactor=2 → 780×1688) | PC 1280×800 |
|-------|------------------------------------------------|-------------|
| **hero** (10%) | floating-cta 表示 — 「全機能を家族で試せる」+「無料で始める」 | floating-cta hidden（CSS `@media min-width:769px`） |
| **mid** (50%) | floating-cta 表示 — 「コアループは 1 分で体験できます」+「デモを見る」 | floating-cta hidden |
| **bottom** (75%) | floating-cta 表示 — 「ここまで読まれた方へ」+「無料で始める」 | floating-cta hidden |

SS は `screenshots` ブランチ ([branch URL](https://github.com/Takenori-Kusaka/ganbari-quest/tree/screenshots/pr-1732)) にコミット済み。下記表に raw URL を貼ります。撮影と同一プロセスで取得した DOM HTML スナップショットも下記 §DOM HTML スナップショット併記 に記録しています（#1747 AC4 / #1766 — SS と DOM の同一性保証）。

### モバイル 390 (deviceScaleFactor=2 → 780×1688) — 3 phase

| phase | スクリーンショット |
|-------|---------------------|
| **hero** (10% スクロール) | ![mobile-hero](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1732/mobile/01-floating-cta-01-hero.png) |
| **mid** (50% スクロール) | ![mobile-mid](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1732/mobile/02-floating-cta-02-mid.png) |
| **bottom** (75% スクロール) | ![mobile-bottom](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1732/mobile/03-floating-cta-03-bottom.png) |

### デスクトップ 1280×800 — 3 phase（floating-cta は CSS で hidden）

| phase | スクリーンショット |
|-------|---------------------|
| **hero** (10% スクロール) | ![desktop-hero](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1732/desktop/01-floating-cta-01-hero.png) |
| **mid** (50% スクロール) | ![desktop-mid](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1732/desktop/02-floating-cta-02-mid.png) |
| **bottom** (75% スクロール) | ![desktop-bottom](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1732/desktop/03-floating-cta-03-bottom.png) |

デスクトップ SS は `@media(min-width:769px){.floating-cta{display:none!important}}` で floating-cta は非表示（既存挙動維持、AC9 / Issue 仕様: モバイル限定機能）。代わりにヘッダー右上の persistent `.nav-signup` 「無料で始める」 + 「ログイン」 ghost button が常時表示される（lp-content-map.md §7.2）。

### DOM HTML スナップショット併記（#1747 AC4 / #1766）

DOM HTML 抜粋（mobile 50% スクロール時）:

```html
<!-- floating-cta DOM snapshot -->
<!-- phase=mid visible=true scrollY=6528 docH=13900 -->
<div class="floating-cta visible" id="floating-cta" data-floating-cta="container"
     aria-hidden="false" role="complementary" aria-label="ページ追従の登録案内"
     data-floating-cta-phase="mid" style="display: block;">
  <div class="floating-cta-inner">
    <div class="floating-cta-text" id="floating-cta-text" data-lp-key="floatingCta.midText">
      コアループは 1 分で体験できます<small>サインアップ前に動きを確認</small>
    </div>
    <a href="https://ganbari-quest.com/demo" class="btn btn-primary"
       id="floating-cta-button" data-lp-key="floatingCta.midButton"
       aria-label="デモ画面で機能を体験">デモを見る</a>
  </div>
</div>
```

DOM HTML 抜粋（mobile 75% スクロール時）:

```html
<!-- phase=bottom visible=true -->
<div class="floating-cta visible" data-floating-cta-phase="bottom">
  <div class="floating-cta-text" data-lp-key="floatingCta.bottomText">
    ここまで読まれた方へ<small>7 日間無料・クレジットカード不要</small>
  </div>
  <a href="https://ganbari-quest.com/auth/signup" data-lp-key="floatingCta.bottomButton">無料で始める</a>
</div>
```

DOM HTML 抜粋（mobile 10% スクロール時）:

```html
<!-- phase=hero visible=true -->
<div class="floating-cta visible" data-floating-cta-phase="hero">
  <div class="floating-cta-text" data-lp-key="floatingCta.heroText">
    全機能を家族で試せる（7 日間無料）<small>クレジットカード不要</small>
  </div>
  <a href="https://ganbari-quest.com/auth/signup" data-lp-key="floatingCta.heroButton">無料で始める</a>
</div>
```

撮影方法（再撮影手順）:

```bash
# サーバ起動
npx serve site -l 5280 --no-clipboard &

# 撮影
MSYS_NO_PATHCONV=1 node scripts/capture.mjs \
  --flow lp-floating-cta-1732 \
  --url /index.html \
  --actions scripts/capture-specs/flows/lp-floating-cta-1732.mjs \
  --base-url http://localhost:5280 \
  --presets desktop --out docs/screenshots/pr-1732
# 同様に --presets mobile も実行
```

撮影スクリプトは新設の `scripts/capture-specs/flows/lp-floating-cta-1732.mjs` を再利用。3 phase × 2 viewport で SS + DOM HTML 6 セット生成可能。出力: `docs/screenshots/pr-1732/{desktop,mobile}-steps/0[1-3]-floating-cta-0*-{hero,mid,bottom}.{png,dom.html}`

### インタラクティブ状態の確認

- [x] **N/A** — disabled / readonly フィールドはない
- [x] エラー / バリデーション状態: floating-cta はリンク要素のみで状態なし
- [x] 空 / 初期状態: SSR 既定 phase=hero（JS 未実行時）の文言が表示される（fail-safe）

### モバイルビューポート

- [x] デスクトップ（1280px）SS: 3 phase 分（floating-cta hidden 確認）
- [x] モバイル（390 → 780@2x）SS: 3 phase 分

## 実機操作検証

- [x] LP は認証不要のため `npx serve site -l 5280` で実機表示し、3 phase 全てで floating-cta の文言・href・aria-label が変化することを目視確認した
- [x] DOM HTML スナップショットで `data-floating-cta-phase` / `data-lp-key` / `href` / `aria-label` の整合を機械的に確認した
- [x] `docs/DESIGN.md` §9 禁忌事項: hex 直書きなし（CSS は `var(--gray-900)` / `var(--brand-700)` 等）、プリミティブ再実装なし（LP 専用 floating-cta は LP 固有要素）、内部コード露出なし、用語ハードコードなし（LP_FLOATING_CTA_LABELS SSOT）、インラインスタイル動的値のみ（display:block は JS による表示制御）、style 50 行超えなし

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・モーダル・オーバーレイの追加なし（floating-cta は banner レベル `--z-banner` 相当）

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

## レビュー依頼事項・QA

- floating-cta phase 切替の文言（midText / bottomText）が「煽る」表現になっていないか、Anti-engagement 観点で確認をお願いします
- ratchet 計算で `data-floating-cta` を除外した妥当性: 単一機能ユニット原則は lp-content-map.md §7.3.2 に明記済み。設計合意可能か

## 横展開・影響波及チェック

### 並行実装影響確認

- [x] **本番アプリ** — N/A（LP 専用変更）
- [x] **デモ版** — N/A（LP 専用変更）
- [x] **LP ↔ アプリ整合（双方向）**: floating-cta は LP 専用機能。アプリ側に対応する CTA 機構は無く、`labels.ts` の `LP_FLOATING_CTA_LABELS` は LP 専用 namespace
- [x] **全年齢モード** — N/A（LP 専用変更）
- [x] **ナビゲーション** — N/A（LP 専用変更、AdminLayout 等は変更なし）
- [x] **E2E/ユニットシード** — N/A（DB スキーマ変更なし）
- [x] **チュートリアル + デモガイド** — N/A（UI 構造変更なし）

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更する `site/index.html` / `src/lib/domain/labels.ts` を同時期に変更する open PR が他に無いことを `gh pr list` で確認した

### LP 変更時の追加チェック

- [x] LP コンテンツ追加時の顧客価値 gate 通過: 本変更は新規セクション追加ではなく既存 floating-cta の文言改善（ADR-0010 Pre-PMF スコープ判断クリア）

### LP / 販促文言変更時の実装パス明示（ADR-0013）

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| 「コアループは 1 分で体験できます」 | `/demo` 画面（`src/routes/demo/+layout.svelte` 配下）で実装済み | Committed |
| 「サインアップ前に動きを確認」 | 同上、`/demo` を匿名でアクセス可能（auth 不要） | Committed |
| 「7 日間無料・クレジットカード不要」 | `src/lib/server/services/trial-service.ts` で 7 日トライアル実装済み（既存 LP 文言と一致） | Committed |
| 「ここまで読まれた方へ」 | 状況提示型コピー、機能と直接対応しない（既存「全機能を家族で試せる」と同レベル） | Committed |

### その他

- [x] **用語変更**: `floatingCta.*` namespace は新規追加のみ、既存の他 namespace との衝突なし
- [x] **labels SSOT (ADR-0009)**:
  - [x] `LP_FLOATING_CTA_LABELS` を `src/lib/domain/labels.ts` に定数として定義
  - [x] LP 側 (`site/index.html`) は `data-lp-key="floatingCta.*"` 経由で注入、HTML 直書きなし
  - [x] `node scripts/generate-lp-labels.mjs` を実行して `site/shared-labels.js` を再生成済み
- [x] **UI構造変更**: チュートリアルは LP に対応していないため影響なし
- [x] **カラー・スタイル**: hex 直書きなし、すべて `var(--brand-700)` 等のセマンティックトークン経由
- [x] **プリミティブ**: LP は SvelteKit primitives と独立した静的 HTML
- [x] **設計書（CRITICAL）**: `docs/design/lp-content-map.md §7.3` に深度別文言の章を新設

## Ready for Review チェックリスト

- [x] CI が全て通過している
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] Phase 分割不要（Issue 全 AC を本 PR で完遂、follow-up Issue なし）
- [x] UI 変更: docs/DESIGN.md §9 禁忌事項に該当しないことを目視確認
- [x] 認証画面ではないため `npm run dev:cognito` 不要、`npx serve site` で確認済み
- [x] SS の表示確認: SS は `docs/screenshots/` 配下のため gitignore 対象。PR body には DOM HTML スナップショット抜粋を直接添付（再現性は撮影手順を本文に明記）
- [x] DOM スナップショット併記: `*.dom.html` ファイルを `scripts/capture-specs/flows/lp-floating-cta-1732.mjs` で生成、本 PR body に主要 3 phase 抜粋を引用済み
- [x] hardcoded JP text: 新規追加文言は全て `labels.ts` SSOT 経由

## Critical 修正の追加要件

- [x] **N/A** — Critical 修正ではない（priority:medium）

## 新規 env / secret 追加チェック

- [x] **N/A** — 新規 env / secret の追加なし

## デプロイリスク事前評価

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし（LP 静的サイト変更のみ）

### スコープ完全性
- [x] 見落とし確認: Issue AC 全 9 項目を本 PR で実装。並行実装ペアはチェックリスト全項目確認済み

## デプロイ検証

- [ ] `gh run list --branch main --workflow deploy.yml` でデプロイワークフローが**成功**していることを確認（マージ後に実施）
- [ ] site/ の変更がある場合: 本番 URL（ganbari-quest.com）で変更が反映されていることを確認（マージ後に実施）

## 完了チェックリスト

- [x] `npx biome check src/ tests/ scripts/ site/shared-labels.js` — lint エラーなし
- [x] `npx svelte-check` — 型エラーなし（私の変更分。dompurify pre-existing は本 PR 無関係）
- [x] `npx vitest run` — 4324 tests passed（dompurify pre-existing 1 件除く、本 PR 無関係）
- [x] `npx playwright test tests/e2e/lp-floating-cta-scroll.spec.ts` — 5 cases passed
- [x] PR サイズ: 514 insertions / 15 deletions / 8 files



## コード品質・セキュリティ セルフレビュー（#1481）

- [x] N/A — 新規 service / interface 追加なし。labels.ts SSOT + scroll listener (passive + rAF) 追加のみ
- [x] DRY: `LP_FLOATING_CTA_LABELS` 単一 SSOT で labels.ts → shared-labels.js 自動生成
- [x] パフォーマンス: passive scroll + requestAnimationFrame で間引き、Anti-engagement (ADR-0012) 整合
- [x] XSS: 文字列 textContent 経由のみ (innerHTML 不使用)、PR #1774 で導入された CSP allowlist 内

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] N/A — env / secret 追加なし。LP 静的 site への scroll listener + labels 追加のみ

## Critical 修正の追加要件（#612）

- [x] N/A — priority:medium / type:marketing。Critical ではない

## デプロイリスク事前評価（#1481）

- [x] LP 静的 HTML / labels.ts 変更のみ。本番 Lambda / DB スキーマ影響なし
- [x] GitHub Pages デプロイ時に shared-labels.js 自動生成スクリプトが走る (既存パイプライン)
- [x] floating-cta はスクロール無し時 hero phase で動作 — 旧挙動に対する後方互換あり
- [x] ロールバック容易: 単一 PR revert で旧 1 文言追従に戻る

## デプロイ検証（#710 — マージ後必須）

マージ後の検証は QA / PO 担当:
- https://ganbari-quest.com/ で hero / mid / bottom 各位置 floating-cta 文言確認
- E2E `tests/e2e/lp-floating-cta-scroll.spec.ts` 5 ケース pass

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

QA team による approve / merge 待ち。Issue AC1-AC9 全充足 + LP メトリクス ratchet 維持 (mobileHeight / desktopHeight / forbiddenTerms / ctaVariants) を確認してください。

