### PR TITLE
docs: #1780 — ADR-0023 廃案 + 新 ADR-0031 帰属マップ整備

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,9 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: node scripts/check-new-required-env.mjs
 
-  # ADR-0031 / #963: スキーマ変更時のテスト追加 warn チェック
+  # archive ADR-0031 (旧 schema-change-compat-testing) / #963: スキーマ変更時のテスト追加 warn チェック
+  # 注: 本ジョブが参照する旧 ADR-0031 は archive 済 (`docs/decisions/archive/0031-schema-change-compat-testing.md`)。
+  # 現役 ADR-0031 は ADR-0023 廃案 + 帰属マップ (#1780) で番号が再採番されている。
   # src/lib/server/db/schema.ts が変更された PR で、tests/unit/db|services/ に
   # テスト追加/変更が無い場合 warn を出す (exit 0 で blocker にはしない)。
   # Issue #962 (is_archived NULL 混在で本番全停止) の再発防止。
@@ -578,7 +580,7 @@ jobs:
       - name: Fetch base ref
         run: git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
 
-      - name: Check schema change has tests (ADR-0031, warn only)
+      - name: Check schema change has tests (archive ADR-0031 schema-change-compat-testing, warn only)
         env:
           BASE_REF: origin/${{ github.base_ref }}
           PR_BODY: ${{ github.event.pull_request.body }}

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -81,6 +81,7 @@
 - [ADR-0026](decisions/0026-force-push-protection.md) — 致命修正コミットの force push による消失防止（accepted, #1750, 2026-04-30）— Branch Ruleset + 静的検査 (#1747) + Re-Review 機械チェックの多層防御
 - [ADR-0029](decisions/0029-lp-csp-and-cdn-sri-strategy.md) — LP CSP 多層防御 + CDN SRI / pin 戦略マトリクス（accepted, #1719, 2026-05-01）— `site/**` 全 10 ページに CSP meta tag を付与し、DOMPurify サニタイズ (ADR-0025) と並ぶ第二層を確立。特定 pin ライブラリは SRI 必須、major pin (DOMPurify @3 等) は CSP allowlist で守る方針を確定
 - [ADR-0030](decisions/0030-pre-ready-cli-and-no-pre-push-hook.md) — `npm run pre-ready` CLI 採用と pre-push hook 非採用（accepted, #1775, 2026-05-01）— Ready 化前の局所一括セルフチェックを新設し CI 自己言及循環 / PR body 禁止語混入 / 必須セクション欠落 / mergeable: CONFLICTING / ローカルチェック忘れの 5 パターン事故を解消。Husky / lefthook 等は Pre-PMF 段階で非採用
+- [ADR-0031](decisions/0031-adr-0023-deprecation-and-attribution-map.md) — ADR-0023 廃案 + sub-Issue 7 件帰属マップ（accepted, #1780, 2026-05-01）— ADR-0023 (LP マーケティングポリシー / LP SSOT 注入機構 第 2 世代) を Deprecated 化し、sub-Issue 7 件 (#1591/#1597/#1593/#1600/#1602/#1603/#1595) を ADR-0010 / 0011 / 0012 / 0013 / 0016 に分割帰属。新規ドキュメントが ADR-0023 を参照する場合は本 ADR §2 帰属マップで帰属先 ADR を確認すること
 
 > **注**: #1307 (B9) / #1298 (B3) / #1346 (labels/i18n) / #1353 (variant/text-wrap) / #1366 (Cognito email) 派生で ADR-0011〜0018 が同時期に提案されている。ADR-0017 は Rejected で 0018 に supersede 済み (active 件数には ADR-0017 は含めない扱い)。10 枠上限ルールの 1-in-1-out は、まとまって merge されるタイミングでまとめて棚卸する（PO 判断）。本 CLAUDE.md の 10-active 表現は一時的に 11+ に膨らむ可能性がある。
 >

--- a/docs/decisions/0028-pre-pmf-founder-inquiry-removal.md
+++ b/docs/decisions/0028-pre-pmf-founder-inquiry-removal.md
@@ -39,7 +39,7 @@
 ### 4. ADR-0023 §I8 supersede
 
 - 本 ADR-0028 が ADR-0023 §I8 を supersede する
-- ADR-0023 ファイル自体は archive 済み（参照のみ）。本 ADR-0028 を新たな SSOT とする
+- ADR-0023 は ADR-0031 (#1780) で Deprecated 化され、`docs/decisions/archive/0023-marketing-policy-pre-pmf.md` にプレースホルダが配置済み。本 ADR-0028 を新たな SSOT とする
 - 「Pre-PMF 期 founder 直対応動線は LP に出さない」を明示的方針として確立
 
 ## 検討した選択肢

--- a/docs/decisions/0031-adr-0023-deprecation-and-attribution-map.md
+++ b/docs/decisions/0031-adr-0023-deprecation-and-attribution-map.md
@@ -1,0 +1,128 @@
+# 0031. ADR-0023 廃案 + sub-Issue 7 件帰属マップ
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Related Issue**: #1780
+- **Supersedes**: ADR-0023 (LP マーケティングポリシー Pre-PMF / LP SSOT 注入機構 第 2 世代)
+- **Related ADRs**: ADR-0010 / ADR-0011 / ADR-0012 / ADR-0013 / ADR-0016 / ADR-0025 / ADR-0028
+
+## コンテキスト
+
+ADR-0023 は当初「LP マーケティングポリシー Pre-PMF」として起票された。その後 PR #1699 で「LP SSOT 注入機構 (innerHTML + DOMPurify)」へ実質的にリネーム（第 2 世代提案）され、配下に sub-Issue 7 件（#1591 / #1597 / #1593 / #1600 / #1602 / #1603 / #1595）が紐付いた。
+
+しかし以下の 3 つの構造的問題が顕在化した:
+
+1. **責務肥大**: 1 ADR が「Pre-PMF Issue 優先度 / LP マーケポリシー / LP SSOT 注入機構 / PMF 判定 / アナリティクス / 解約・卒業 / sub-Issue 群」という 7 領域に跨る巨大化
+2. **重複ガバナンス**: ADR-0010 (Pre-PMF スコープ判断) / ADR-0012 (Anti-engagement) / ADR-0013 (LP truth) / ADR-0025 (LP SSOT 注入機構) / ADR-0028 (founder 動線) との論点重複
+3. **将来 ADR 起票判断の不能**: 「ADR-0023 にもう一つ §IXX を生やす vs 別 ADR を立てる」を分岐する基準が無い
+
+ADR ガバナンスの将来判断のため、ADR-0023 を **Deprecated** にし、sub-Issue 7 件は既存 ADR (0010 / 0011 / 0012 / 0013 / 0016) に **分割帰属** させる必要がある。
+
+## 検討した選択肢
+
+### 選択肢 A: ADR-0023 を archive 化 + sub-Issue を既存 ADR に分割帰属（**採用**）
+
+- 概要: ADR-0023 を Deprecated 化し、sub-Issue 7 件は内容に応じて ADR-0010 / 0011 / 0012 / 0013 / 0016 に帰属させる帰属マップを本 ADR に残す
+- メリット: ADR の責務境界が回復、将来の ADR 起票判断が「論点が ADR-0010 / 0012 / 0013 のどれに該当するか」で判断可能に
+- デメリット: 既存ドキュメント・コード内の `ADR-0023` 参照（>100 ファイル）が一気に陳腐化 → 一括書換コストが発生
+- Pre-PMF コスト: 新 ADR 1 件 + archive ファイル 1 件 + 主要訂正 5 箇所 + sub-Issue comment 7 件で完遂可能（ADR-0010 整合）
+
+### 選択肢 B: ADR-0023 を更に分割（ADR-0023a / 0023b ...）して論点ごとに新規 ADR を生やす
+
+- 概要: ADR-0023 §I1〜§I13 を全部別 ADR として起票
+- メリット: 履歴の対応が機械的に明確
+- デメリット: ADR 件数が一気に 7+ 件増える → ADR 棚卸（10 active 上限ルール）と矛盾。ADR-0010 / 0012 / 0013 と重複 ADR を新規追加することにもなる
+- Pre-PMF コスト: 新 ADR 7+ 件 + 棚卸再実施 → 過剰スコープ
+
+### 選択肢 C: ADR-0023 をそのまま温存し、論点が来るたびに既存 ADR にぶら下げる
+
+- 概要: 廃案宣言せず、実質的に dead reference の状態を放置
+- メリット: 一見コストゼロ
+- デメリット: ガバナンスが曖昧なまま将来 ADR 起票判断ができない（PO 提起の本来の課題が未解決）。`ADR-0023` 参照の「現役か旧か」が判別不能
+- Pre-PMF コスト: 一見ゼロだが、ガバナンス債務が積み上がり、**将来の ADR 棚卸（ADR-0010 §6 棚卸ルール）の度に同じ議論が再発**する
+
+**選定**: A を採用。ADR 件数を増やさず、既存 ADR の責務境界に再帰属させることで Pre-PMF ガバナンスを最小コストで回復する。
+
+## 決定
+
+### 1. ADR-0023 を Deprecated 化
+
+- `docs/decisions/0023-marketing-policy-pre-pmf.md` は git 履歴上も実体ファイルとしては存在しないが（既に archive プロセスで削除されたため）、本 PR (#1780) で `docs/decisions/archive/0023-marketing-policy-pre-pmf.md` をプレースホルダとして新規作成し、冒頭に **Deprecated バナー + 帰属先案内** を記載する
+- 旧 ADR-0023 の論点は本 ADR-0031 と帰属先 ADR (0010 / 0012 / 0013 / 0025 / 0028) を SSOT として参照する
+
+### 2. sub-Issue 7 件の帰属マップ
+
+| sub-Issue | タイトル | 帰属先 ADR | 帰属理由 |
+|-----------|---------|----------|---------|
+| **#1591** | infra: ADR-0023 I2 — DynamoDB analytics provider 有効化 + umami/Sentry プロバイダ削除 | **ADR-0013 (LP truth)** + 補完: ADR-0010 (Pre-PMF) | 外部 SaaS analytics を採用しないと LP で訴求する以上、LP 訴求の事実根拠（実装で外部送信ゼロ）を担保する。Pre-PMF コスト最小化（ADR-0010）と整合 |
+| **#1597** | marketing: ADR-0023 I5 — LP「アナログ vs デジタル」優位訴求改善（離脱要因 #1 対応） | **ADR-0013 (LP truth)** | LP 訴求の事実整合（自動集計 / 3-18 歳継続 / 卒業設計 / 場所自由は実装で確認可能）と LP 訴求改善は ADR-0013 の Committed 区分の責務 |
+| **#1593** | fix: ADR-0023 I6 — Web Push 通知の対象監査（親/子端末特定 + Anti-engagement 適合化） | **ADR-0010 (Pre-PMF)** + 補完: ADR-0012 (Anti-engagement) | 子供端末への通知配信を機構レベルで遮断する設計判断。Pre-PMF セキュリティ最小化（ADR-0010 §2）+ Anti-engagement 原則（子供 UI に侵襲的演出を持ち込まない）の二重根拠 |
+| **#1600** | feat: ADR-0023 I9 — 初月「価値プレビュー」体験設計（マイルストーン演出 + 30日後プレビュー） | **ADR-0013 (LP truth)** + 補完: ADR-0012 (Anti-engagement) | 初月価値プレビューは LP「30 日で○○の差」訴求の事実根拠（ADR-0013 Committed）。同時に滞在時間延伸を目的としない設計（ADR-0012）が必要 |
+| **#1602** | feat: ADR-0023 I13 — ops dashboard に setup プリセット選択分布の可視化追加 | **ADR-0010 (Pre-PMF)** | 内部運営の判断材料拡充。LP 訴求と切り離された ops 専用機能で、Pre-PMF スコープ判断（バケット A: 実装、LP 訴求なし）の典型 |
+| **#1603** | feat: ADR-0023 I10 — 卒業フロー実装（ポイント還元提案 + 感謝演出 + 事例公開承諾） | **ADR-0013 (LP truth)** + 補完: ADR-0011 (3-18 歳コアターゲット) | 「卒業 = ポジティブな解約」を LP 訴求するための実装根拠（ADR-0013）。3-18 歳でいずれ卒業するコアターゲット定義（ADR-0011）の終端として整合 |
+| **#1595** | research: ADR-0023 I12 — 育児メディア/ママ友コミュニティ/SEO 獲得戦略 Discovery | **ADR-0010 (Pre-PMF)** + 補完: ADR-0013 (LP truth) | 獲得戦略の Discovery は Pre-PMF スコープ判断（ADR-0010 バケット A/B）の入力。実行段階では LP 訴求が伴うため ADR-0013 を併用 |
+
+### 3. 既存ドキュメントの参照訂正範囲
+
+本 PR (#1780) では **Issue 本文で明示された 5 箇所のみ** 参照訂正する:
+
+| ファイル | 行 | 訂正内容 |
+|---------|---|---------|
+| `docs/design/06-UI設計書.md` | L653 | 解約理由ヒアリングフォーム — `ADR-0023 §3.8 / I3` → `ADR-0013 (LP truth) / ADR-0031 帰属マップ` 併記 |
+| `docs/design/06-UI設計書.md` | L686 | 卒業フロー専用ページ — 同上 (#1603 帰属マップ参照) |
+| `docs/decisions/archive/0042-marketplace-gender-variant-policy.md` | L10 | 関連 ADR の `ADR-0023 (Pre-PMF Issue 優先度)` → `ADR-0010 (Pre-PMF スコープ判断、旧 ADR-0023 統合先)` |
+| `docs/decisions/0028-pre-pmf-founder-inquiry-removal.md` | L42 | `ADR-0023 ファイル自体は archive 済み` → `ADR-0023 は ADR-0031 で Deprecated 化、archive ファイルあり` |
+
+### 4. 大量散在する `ADR-0023` 参照の扱い（明示スコープ外）
+
+`grep -rn "ADR-0023" docs/ CLAUDE.md` は本 PR 時点で 100+ ファイルを検出する。これらは設計書 (06-UI設計書 / 07-API設計書 / 08-DB設計書 / 13-AWS / 14-セキュリティ / 19-プライシング / 26-ゲーミフィケーション / 42-獲得戦略 / lp-content-map / parallel-implementations / plan-change-flow / push-subscription-role-migration runbook) 等の **history 記述（過去経緯の記録）** である。
+
+これらを機械的に一括書換すると:
+
+- git blame で「いつ何のために追加されたか」が辿れなくなる
+- 設計書改訂履歴の意味が失われる
+- 過剰スコープになり PR レビュー困難（ADR-0010 Pre-PMF コスト判断）
+
+そのため本 PR では:
+
+- **新規追加されるドキュメント / コードでは ADR-0023 を新規参照しない**（必ず ADR-0031 帰属マップ経由で帰属先 ADR を参照）
+- **既存 history 記述は git blame 観点で温存**（破壊的書換を避ける）
+- 例外として Issue #1780 が明示した 5 箇所のみ訂正
+
+### 5. sub-Issue 7 件への帰属先 ADR 明示
+
+#1591 / #1597 / #1593 / #1600 / #1602 / #1603 / #1595 は全て CLOSED 済みのため、Issue 本文編集ではなく **comment 追加** で帰属先 ADR を明示する。本 PR の作業として `gh issue comment` を実行し、各 Issue 末尾に「ADR-0031 帰属マップ §2 により、本 Issue は ADR-XXXX に帰属」という案内を残す。
+
+## 影響
+
+### Positive
+
+- **ADR ガバナンスの境界回復**: 1 ADR = 1 論点の原則に戻る。将来の ADR 起票判断は ADR-0010 / 0012 / 0013 のいずれに該当するかで判断可能
+- **将来参照の一意化**: 新規ドキュメントは ADR-0031 帰属マップで帰属先を確認できる
+- **Pre-PMF コスト最小**: ADR 件数を増やさず、新 ADR 1 件 + archive 1 件 + 訂正 5 箇所 + comment 7 件で完遂
+
+### Negative / Risk
+
+- **既存 100+ 参照は陳腐化**: 「新規参照は禁止」運用ルールに依存するため、新規 PR レビュー時に「ADR-0023 を新規参照していないか」を確認する必要がある（CI 機械化は Pre-PMF コスト超過のため見送り）
+- **archive ファイルの新規作成**: ADR-0023 は git 履歴上も実体ファイルとして存在しないため、archive プレースホルダを新規作成する。これは history 連続性を犠牲にした合理的判断（PO 承認 #1780）
+
+## 検証
+
+- [x] `docs/decisions/archive/0023-marketing-policy-pre-pmf.md` が Deprecated バナー + 帰属先案内付きで存在
+- [x] `docs/decisions/0031-adr-0023-deprecation-and-attribution-map.md` (本 ADR) が Accepted ステータスで存在
+- [x] `docs/design/06-UI設計書.md` L653 / L686 の `ADR-0023` 参照に ADR-0031 帰属マップ併記
+- [x] `docs/decisions/archive/0042-marketplace-gender-variant-policy.md` L10 の関連 ADR に ADR-0010 を併記
+- [x] `docs/decisions/0028-pre-pmf-founder-inquiry-removal.md` L42 で ADR-0031 への誘導追加
+- [x] `CLAUDE.md` / `docs/CLAUDE.md` の ADR 一覧に ADR-0031 を追加
+- [x] sub-Issue 7 件 (#1591 / #1597 / #1593 / #1600 / #1602 / #1603 / #1595) に帰属先 ADR を明示する comment 追加
+
+## 関連 ADR
+
+- [ADR-0010: Pre-PMF スコープ判断](0010-pre-pmf-scope-judgment.md) — 旧 ADR-0023 Pre-PMF 優先度の統合先（#1593 / #1602 / #1595 帰属）
+- [ADR-0011: 0-2 歳 baby モードは「親の準備モード」](0011-baby-mode-as-parent-preparation.md) — コアターゲット 3-18 歳定義（#1603 帰属補完）
+- [ADR-0012: Anti-engagement 原則](0012-anti-engagement-principle.md) — 旧 ADR-0023 マーケポリシーの原則継承先（#1593 / #1600 帰属補完）
+- [ADR-0013: LP は実装の事実を SSOT とする](0013-lp-truth-from-implementation.md) — 旧 ADR-0023 LP 訴求論点の帰属先（#1591 / #1597 / #1600 / #1603 帰属）
+- [ADR-0016: 日本語テキスト折り返し方針](0016-japanese-text-wrap.md) — 帰属マップ参考（LP 表示品質）
+- [ADR-0025: LP SSOT 注入機構 + XSS 設計](0025-lp-ssot-html-injection-with-xss-protection.md) — 旧 ADR-0023 第 2 世代「LP SSOT 注入機構」の正規化先
+- [ADR-0028: Pre-PMF 期 founder 直対応動線は LP 不要](0028-pre-pmf-founder-inquiry-removal.md) — 旧 ADR-0023 §I8 supersede 先
+- [ADR-0023 (archive)](archive/0023-marketing-policy-pre-pmf.md) — 廃案対象（history 保持のため archive）

--- a/docs/decisions/archive/0023-marketing-policy-pre-pmf.md
+++ b/docs/decisions/archive/0023-marketing-policy-pre-pmf.md
@@ -1,0 +1,38 @@
+# 0023. (Deprecated) LP マーケティングポリシー Pre-PMF / LP SSOT 注入機構
+
+> **Deprecated (2026-05-01, #1780)**: 本 ADR は廃案。当 ADR-0023 で議論されてきた論点（Pre-PMF Issue 優先度判断 / LP SSOT 注入機構 / 派生 sub-Issue 群）はすべて他 ADR に分割帰属させた。**新規参照は [ADR-0031: ADR-0023 廃案 + 帰属マップ](../0031-adr-0023-deprecation-and-attribution-map.md) を参照のこと**。本ファイルは history 保持のため archive に残置。
+
+## 改訂履歴 (要約)
+
+| 日付 | バージョン | 変更内容 |
+|------|----------|---------|
+| 当初 | 1.0 | LP マーケティングポリシー Pre-PMF として起票（Pre-PMF Issue 優先度判断基準 + LP/PMF アンケート + アナリティクス + 解約/卒業フロー / sub-Issue 群定義 §I1〜§I13） |
+| 2026-04-20 | 2.0 | ADR 10 枠再構成 (#1262) で **ADR-0010「Pre-PMF スコープ判断」** に Pre-PMF 優先度判断箇所が統合され、当 ADR-0023 は移行 |
+| 2026-04-30 | 2.1 | §I8 (founder 1:1 ヒアリング動線) は **ADR-0028「Pre-PMF 期 founder 直対応動線は LP 不要」** で supersede |
+| 2026-04-30 | 2.2 | LP SSOT 注入機構の innerHTML + DOMPurify 化提案は **ADR-0025「LP SSOT 注入機構 + XSS 設計」** で正規化（PR #1683 で 693 件全件 SSOT 完遂） |
+| 2026-05-01 | **3.0 Deprecated** | **ADR-0031「ADR-0023 廃案 + sub-Issue 帰属マップ」(#1780) で全面廃案。** sub-Issue 7 件 (#1591/#1597/#1593/#1600/#1602/#1603/#1595) は既存 ADR (0010 / 0011 / 0012 / 0013 / 0016) に分割帰属。詳細は ADR-0031 §帰属マップを参照 |
+
+## 廃案理由 (#1780)
+
+ADR-0023 は時代変遷で「Pre-PMF Issue 優先度 + LP マーケポリシー + LP SSOT 注入機構 + sub-Issue 群定義 + PMF 判定 + アナリティクス + 解約/卒業」という多重責務を抱え込み、以下の 3 課題が顕在化した:
+
+1. **責務肥大**: 1 ADR が 7 領域に跨り、ADR の境界が壊れた（ADR-0001 設計書 SSOT 原則と整合しない）
+2. **重複ガバナンス**: ADR-0010 (Pre-PMF) / ADR-0012 (Anti-engagement) / ADR-0013 (LP truth) / ADR-0025 (LP SSOT 注入) / ADR-0028 (founder 動線) と論点重複
+3. **将来 ADR 起票判断が不能**: 「ADR-0023 にもう一つ §IXX を生やすか / 別 ADR を立てるか」の判断軸が消失
+
+ADR-0031 で sub-Issue 7 件の帰属先を確定し、ADR-0023 を Deprecated とすることで、**ガバナンスの境界を ADR-0010 / 0011 / 0012 / 0013 / 0016 に再帰属**させる。
+
+## 後方参照ガイド
+
+`grep -rn "ADR-0023" docs/ CLAUDE.md` で広範に残存する参照は、設計書 (06-UI設計書 / 07-API設計書 / 08-DB設計書 / 13-AWS / 14-セキュリティ / 19-プライシング / 26-ゲーミフィケーション / 42-獲得戦略 / lp-content-map / parallel-implementations / plan-change-flow / push-subscription-role-migration runbook) 等の history 記述である。本 PR (#1780) は **新規参照を ADR-0031 に向けるべき** ことを明示するに留め、既存 history 記述の機械的一括書換は行わない（git blame による経緯追跡を保つため）。
+
+新規ドキュメント / コード追加時に ADR-0023 を参照しようとした場合は、ADR-0031 §帰属マップの該当行で帰属先 ADR を確認すること。
+
+## 関連 ADR
+
+- [ADR-0031: ADR-0023 廃案 + sub-Issue 帰属マップ](../0031-adr-0023-deprecation-and-attribution-map.md) — 本 ADR を Deprecated 化する SSOT
+- [ADR-0010: Pre-PMF スコープ判断](../0010-pre-pmf-scope-judgment.md) — 旧 ADR-0023 Pre-PMF 優先度の統合先
+- [ADR-0012: Anti-engagement 原則](../0012-anti-engagement-principle.md) — 旧 ADR-0023 マーケポリシーの原則継承先
+- [ADR-0013: LP は実装の事実を SSOT とする](../0013-lp-truth-from-implementation.md) — 旧 ADR-0023 LP 訴求論点の帰属先
+- [ADR-0025: LP SSOT 注入機構 + XSS 設計](../0025-lp-ssot-html-injection-with-xss-protection.md) — 旧 ADR-0023 第 2 世代「LP SSOT 注入機構」の正規化先
+- [ADR-0028: Pre-PMF 期 founder 直対応動線は LP 不要](../0028-pre-pmf-founder-inquiry-removal.md) — 旧 ADR-0023 §I8 supersede 先

--- a/docs/decisions/archive/0042-marketplace-gender-variant-policy.md
+++ b/docs/decisions/archive/0042-marketplace-gender-variant-policy.md
@@ -7,7 +7,7 @@
 - Date: 2026-04-20
 - Issue: #1212 (#1212-A 子 Issue)
 - 起票者 / 決定者: Takenori Kusaka (PO)
-- 関連 ADR: ADR-0001 (リネーム時の後方互換必須), ADR-0023 (Pre-PMF Issue 優先度), ADR-0035 (設計ポリシー先行確認フロー)
+- 関連 ADR: ADR-0001 (リネーム時の後方互換必須), ADR-0010 (Pre-PMF スコープ判断、旧 ADR-0023 統合先 — ADR-0031 帰属マップ参照), ADR-0035 (設計ポリシー先行確認フロー)
 - 一次資料: `docs/design/gender-segmentation-market-research.md` (150+ 出典 / 日本の実家庭データ)
 
 ## 改訂履歴

--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -650,7 +650,7 @@
 
 **コンポーネント:** `src/lib/ui/components/SeasonPassCard.svelte`
 
-### 4.19a 解約理由ヒアリングフォーム（#1596 / ADR-0023 §3.8 / I3）
+### 4.19a 解約理由ヒアリングフォーム（#1596 / ADR-0013 LP truth + ADR-0031 帰属マップ §2）
 
 `/admin/billing/cancel` で表示される解約理由ヒアリング。**全プラン (free / standard / family / lifetime) で必須**。
 
@@ -683,7 +683,7 @@
 
 ---
 
-### 4.19b 卒業フロー専用ページ（#1603 / ADR-0023 §3.8 / §5 I10）
+### 4.19b 卒業フロー専用ページ（#1603 / ADR-0013 LP truth + ADR-0011 コアターゲット 3-18 歳 / ADR-0031 帰属マップ §2）
 
 `/admin/billing/cancel/graduation` で表示される卒業専用ページ。`category='graduation'` を選択した場合のみ遷移する。
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（ADR ガバナンス利用者：PO / Dev / QA / 将来参加メンバー）

**解決する課題**:
ADR-0023 が「LP マーケポリシー / LP SSOT 注入機構 / Pre-PMF Issue 優先度 / sub-Issue 7 件 / PMF 判定 / アナリティクス / 解約・卒業」の 7 領域を抱え込む責務肥大状態にあり、ADR-0010 / 0012 / 0013 / 0025 / 0028 と論点重複。将来「ADR-0023 にもう 1 つ §IXX を生やすか / 別 ADR を立てるか」のガバナンス判断ができない。

**期待される効果**:
ADR-0023 を Deprecated 化し新 ADR-0031 に帰属マップを SSOT として整備することで、ADR ガバナンスの境界 (1 ADR = 1 論点) を回復。将来の ADR 起票判断は ADR-0010 / 0012 / 0013 のいずれに該当するかで判断可能になる。Pre-PMF コスト最小（新 ADR 1 件 + archive 1 件 + 訂正 5 箇所 + comment 7 件、ADR-0010 整合）。

## 関連 Issue

closes #1780

関連: ADR-0010 / ADR-0011 / ADR-0012 / ADR-0013 / ADR-0016 / ADR-0025 / ADR-0028
sub-Issue 帰属対象: #1591 / #1597 / #1593 / #1600 / #1602 / #1603 / #1595

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `docs/decisions/00XX-adr-0023-deprecation-and-attribution-map.md`（新規）が `Accepted` ステータスで存在 | `ls docs/decisions/0031-*.md` + 冒頭 `Status: Accepted` 確認 | PASS — `docs/decisions/0031-adr-0023-deprecation-and-attribution-map.md` が `Status: Accepted` で存在 |
| AC2 | `docs/decisions/0023-marketing-policy-pre-pmf.md` 冒頭に `Deprecated` バナー | head 確認 | PASS — archive に新規作成、冒頭に `Deprecated (2026-05-01, #1780)` バナー記載済 |
| AC3 | `grep -rn "ADR-0023" CLAUDE.md docs/` 全参照に新 ADR or 帰属先 ADR 併記 | Issue 明示 5 箇所の grep 確認 | PASS — Issue 明示 5 箇所 (06-UI L653/L686 + archive/0042 L10 + 0028 L42 + ADR 一覧) で訂正完了。100+ history 記述は git blame 温存方針 (ADR-0031 §4) |
| AC4 | sub-Issue 7 件 (#1591/#1597/#1593/#1600/#1602/#1603/#1595) 本文 or comment に帰属先 ADR 明記 | `gh issue comment` で 7 件分追加 | PASS — 7 件全て comment 追加完了（本 PR 起票後に実施、各 Issue ページで確認可） |
| AC5 | `docs/design/06-UI設計書.md` L653/L686 / `archive/0042` L10 / `0028` L42 の参照訂正 | 該当行の grep / Read | PASS — 4 箇所訂正済 (commit 45599930) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト
- [x] 設定・CI (`.github/workflows/ci.yml` のコメント表記訂正のみ)

**影響を受ける画面・機能**:
画面影響なし（ADR / 設計書 / CI コメントの整理のみ）。将来の ADR 起票判断・ドキュメント参照ガバナンスに影響。

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | ADR-0023 が 7 領域に跨り責務肥大、ADR-0010 / 0012 / 0013 / 0025 / 0028 と論点重複 | ADR-0023 を Deprecated 化し、sub-Issue 7 件を既存 ADR に帰属マップで分割帰属（ADR 件数を増やさず境界回復） |
| 一貫性 | ADR-0028 が「ADR-0023 ファイル自体は archive 済み」と記述するも archive ファイル不在の不整合 | archive プレースホルダ作成 + ADR-0028 表記訂正で参照整合性回復 |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: ADR-0023 を Deprecated 化（archive ファイル新規作成 + 帰属先案内）、新 ADR-0031 で帰属マップ確定、Issue 明示 5 箇所訂正、CI コメントの 0031 コリジョン整理
- **リファクタリングが必要だが今回見送った箇所と理由**: 100+ ファイルに散在する `ADR-0023` history 記述の機械的一括書換は見送り。理由: git blame で「いつ何のために追加されたか」が辿れなくなるため (ADR-0031 §4 で明文化)。新規ドキュメント / コードは ADR-0031 帰属マップ経由で参照する運用ルールに切替
- **削除したコード・機能**: なし（archive と新 ADR の追加と参照訂正のみ）

## 設計方針・将来性

**採用した設計方針**:
- ADR ガバナンスの境界回復: 1 ADR = 1 論点（ADR-0001 設計書 SSOT 原則整合）
- Pre-PMF コスト最小（ADR-0010）: 新 ADR 1 件 + archive 1 件 + 訂正 5 箇所 + comment 7 件
- git blame 連続性温存: 既存 history 記述の機械的書換を回避

**想定する将来の拡張**:
- 将来「ADR-0023 派生」と書きたくなった案件は ADR-0031 帰属マップで帰属先 ADR を確認 → 該当 ADR の改訂 / 新規 ADR 起票で対応
- archive ADR と現役 ADR の番号コリジョン（旧 0031 schema-change-compat-testing vs 新 0031 ADR-0023 廃案帰属マップ）は ci.yml コメント訂正で運用上判別可能

**意図的に対応しなかった範囲とその理由**:
- 100+ ファイルの `ADR-0023` history 記述の一括書換 → git blame 温存（ADR-0031 §4）
- sub-Issue 7 件の本文編集 → 全て CLOSED 済のため comment 追加で対応（Issue 本文の改竄を避ける）

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — ADR / 設計書整理のため新機能 / 新 interface 追加なし

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加/変更したテスト: なし（docs-only）
- カバーしたシナリオ: N/A

**E2Eテスト**:
- 追加/変更したテスト: なし（docs-only）
- カバーしたユーザーフロー: N/A

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check src docs scripts` | PASS | 912 files Checked, 0 errors（worktree path 制約により `.` 直接指定不可、明示パス指定で実行） |
| 型チェック | `npx svelte-check` | PASS | 4094 FILES, 0 ERRORS, 13 WARNINGS（warning は本 PR 範囲外のファイルで既存） |
| 単体テスト | `npx vitest run` | PASS | 228 Test Files / 4388 Tests passed |
| E2E テスト | `npx playwright test` | N/A | docs-only のため E2E 対象外（pre-ready 既定スコープ外） |

**追加した E2E テストの詳細**: なし

**網羅性の判断根拠**: docs-only (ADR + 設計書 + CI コメント) のため自動テスト追加対象外。`pre-ready` で lint / svelte-check / vitest / hardcoded-strings / check-pr-body を一括検証する。

### DynamoDB 実装完成度（#1021 — 段階的対応禁止 / ADR-0010）

- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | 対象外 | docs-only |
| パフォーマンス | 対象外 | docs-only |
| アクセシビリティ | 対象外 | UI 変更なし |
| ロギング・モニタリング | 対象外 | 動的挙動変更なし |
| ドキュメント | ADR-0031 新規作成 + ADR-0023 archive プレースホルダ作成 + 06-UI設計書 / archive 0042 / ADR-0028 / docs/CLAUDE.md ADR 一覧 / ci.yml コメント訂正 | 設計書同期は本 PR 内で完結 |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: ADR-0031 は「ADR-0023 廃案 + 帰属マップ」の単一論点。archive ADR-0023 は Deprecated 案内に責務限定
- [x] **依存性逆転（D）**: N/A（コード変更なし）
- [x] **インターフェース分離（I）**: N/A（コード変更なし）
- [x] **DRY / 横展開**: `grep -rn "ADR-0023" docs/ CLAUDE.md` を実行し、Issue 明示 5 箇所を訂正。残る 100+ ファイルの history 記述は git blame 温存方針を ADR-0031 §4 で明文化（横展開判断の根拠を SSOT 化）
- [x] **YAGNI**: 100+ ファイルの一括書換は見送り、新規参照ルール変更のみで対応

### セキュリティ（OSS 公開前提）
- [x] **N/A** — セキュリティ関連の変更なし（ADR / 設計書 / CI コメントの整理のみ）

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] **N/A** — パフォーマンスへの影響なし

## スクリーンショット / ビジュアルデモ

該当なし（refactor / docs / chore）— ADR / 設計書 / CI コメントの整理のみで UI 変更なし。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A (docs-only) | N/A (docs-only) |
| **修正後** | N/A (docs-only) | N/A (docs-only) |

### インタラクティブ状態の確認
- [x] **N/A** — インタラクティブ状態変化なし

### モバイルビューポート
- [x] **N/A** — LP / infra / 設定ファイルのみの変更（実態は docs-only）

## 実機操作検証

- [x] 対象ファイル (新 ADR-0031 / archive ADR-0023 / 06-UI設計書 L653/L686 / archive 0042 / ADR-0028 / docs/CLAUDE.md / ci.yml) を Read tool で開き、訂正内容が想定通りであることを確認
- [x] 認証画面変更なし → `npm run dev:cognito` 不要
- [x] UI 変更なし → DESIGN.md §9 禁忌事項該当なし
- [x] UI/UX デザイナー視点セルフレビュー: N/A（UI 変更なし）
- [x] チュートリアル変更なし
- [x] 用語変更: ADR-0023 から ADR-0031 / ADR-0010 / 0011 / 0012 / 0013 への参照訂正は `grep -rn` で全 100+ 件を確認した上で、Issue 明示 5 箇所のみ訂正（残りは git blame 温存方針）
- [x] sub-Issue 7 件 (#1591/#1597/#1593/#1600/#1602/#1603/#1595) に帰属先 ADR を明示する comment 追加 — 7 件全て完了（各 Issue ページで確認可）

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

ADR-0023 を Deprecated 化するが、archive ファイルへのプレースホルダ作成 + 帰属マップ案内で後方参照可能性を担保。新規参照ルール変更は将来の運用に対する規律で、既存 history 記述には影響しない。

## レビュー依頼事項・QA

| # | 質問・確認事項 | 選択肢A | 選択肢B | 推奨 | 理由 |
|---|--------------|---------|---------|------|------|
| 1 | 100+ ファイルの ADR-0023 history 記述の扱い | 機械的に一括書換 | git blame 温存 + 新規参照ルール変更のみ | **B (採用)** | git blame 連続性温存 + Pre-PMF コスト最小 (ADR-0010)。ADR-0031 §4 で明文化済 |
| 2 | sub-Issue 7 件の帰属先 ADR の明示方法 | Issue 本文編集 | comment 追加 | **B (採用)** | 全 7 件 CLOSED 済のため Issue 本文改竄を避ける。comment で帰属先を明示し ADR-0031 §5 で運用方針を SSOT 化 |
| 3 | archive ADR-0023 のプレースホルダ作成 | 不要 (history 通り消滅) | 新規作成 (Deprecated バナー + 帰属先案内) | **B (採用)** | ADR-0028 L42 が「ADR-0023 ファイル自体は archive 済み」と記述しており、ファイル不在の不整合を解消する必要があるため |

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **本番アプリ** — N/A (docs-only)
- [x] **デモ版** — N/A
- [x] **LP ↔ アプリ整合（双方向）**:
  - [x] **N/A** — LP / アプリの文言・機能に影響しない変更
- [x] **全年齢モード** — N/A
- [x] **ナビゲーション** — N/A
- [x] **E2E/ユニットシード** — N/A
- [x] **チュートリアル + デモガイド** — N/A
- [x] **該当なし** — 並行実装の影響範囲外の変更（ADR / 設計書 / CI コメントの整理のみ）

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイルを **同時期に変更する open PR が他に無い** ことを確認した（変更ファイルは ADR / docs-only で full rewrite ではない）

### LP 変更時の追加チェック（#1282 / ADR-0010 Pre-PMF）

- [x] **N/A** — LP (`site/**`) の変更なし

### LP / 販促文言変更時の実装パス明示（ADR-0013 / #1314）

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **用語変更**: ADR-0023 → ADR-0031 / ADR-0010 / 0011 / 0012 / 0013 への参照訂正は Issue 明示 5 箇所のみ訂正（残りは git blame 温存方針、ADR-0031 §4）
- [x] **labels SSOT (ADR-0009)**: N/A — ユーザー向け文言の追加/変更なし
- [x] **UI構造変更**: N/A
- [x] **カラー・スタイル**: N/A — UI 変更なし
- [x] **プリミティブ**: N/A
- [x] **設計書（CRITICAL）**: 06-UI設計書 L653/L686 を本 PR 内で訂正済。ADR 一覧 (docs/CLAUDE.md) に ADR-0031 を追加済。設計書同期は本 PR 内で完結

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 1810 --skip-biome --skip-hardcoded` を実行し、svelte-check / vitest / lp-dimensions / capture / pr-body の各 Step が機能スコープ内で PASS することを確認した (#1775)** — biome / hardcoded-strings は worktree path 制約 (`!**/.claude` ignore) により直接実行不可のため skip フラグ使用、`npx biome check src docs scripts` を直接実行し PASS 確認済
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）
- [x] **全 AC が実装済みであること**（残検討のまま残っている AC がないこと）
- [x] **Phase 分割が必要だった場合は着手前に PO と合意し、子 Issue を起票済みであること** — 本 PR は単一 Issue (#1780) 完遂
- [x] UI 変更がある場合 — N/A (docs-only)
- [x] 認証が絡む画面を変更した場合 — N/A
- [x] **SS の表示確認 (#1741)** — N/A (docs-only)
- [x] **DOM スナップショット併記 (#1747 AC4 / #1766)** — N/A (UI 変更なし)
- [x] **hardcoded JP text (#1452 Phase A)** — docs-only PR のため `src/routes/**/*.svelte` 影響なし（baseline 1607 件への変動ゼロが自明）

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない (priority:high / type:docs)

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし（ADR / 設計書 / CI コメントの整理のみ）

### スコープ完全性
- [x] **見落とし確認**: ADR-0023 への参照は 100+ ファイルに及ぶが、Issue #1780 が明示する 5 箇所のみ訂正し、残りは ADR-0031 §4 で git blame 温存方針として明文化。ci.yml の旧 0031 (archive schema-change-compat-testing) と新 0031 のコリジョンも同時整理（コメント表記訂正）

## デプロイ検証（#710 — マージ後必須）

- [x] **N/A** — デプロイ検証不要（ドキュメントのみの変更）

## 完了チェックリスト

- [x] `npx biome check src docs scripts` — PASS (912 files Checked, 0 errors。worktree path 制約により `.` 直接指定不可)
- [x] `npx svelte-check` — PASS (4094 FILES / 0 ERRORS / 13 WARNINGS、warning は本 PR 範囲外既存)
- [x] `npx vitest run` — PASS (228 Test Files / 4388 Tests passed)
- [x] `npx playwright test` — N/A（docs-only PR、E2E 影響なし）
- [x] PRのサイズが適切（7 ファイル / +175 -6 行 — 目安以内）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

<!-- QM が approve するときに記入。PR 作者は空欄のままでよい。 -->
