### PR TITLE
infra: #1840 — PR ごとの累積 desktopHeight 監視機構（pre-merge cumulative gate）

### DIFF
--- a/.github/workflows/lp-metrics.yml
+++ b/.github/workflows/lp-metrics.yml
@@ -6,6 +6,10 @@ name: LP Metrics (dimensions / forbidden terms / CTA variants / removal residue)
 #
 # #1790: LP 削除/圧縮 PR の残骸 (orphan reference) 検出 gate (check-lp-removal-residue.mjs)
 # #1803: hero spec-badges 「300+ プリセット活動」CI 裏取り gate (measure-lp-dimensions.mjs 内に統合)
+# #1840: PR ごとの累積 desktopHeight 監視機構 (cumulative-lp-metrics ジョブ)
+#   個別 PR の lp-metrics PASS でも、複数 PR 連続 merge で main 累積 fail を予防する。
+#   PR HEAD に origin/main を merge した状態で measure-lp-dimensions.mjs を走らせ、
+#   累積後の desktopHeight が 8000 を超えていれば fail (warn-only 段階運用、AC2 段階適用)。
 
 on:
   pull_request:
@@ -147,3 +151,131 @@ jobs:
           name: lp-removal-residue
           path: lp-removal-residue.json
           retention-days: 30
+
+  cumulative-lp-metrics:
+    # #1840: pre-merge 累積 desktopHeight gate
+    #
+    # 背景:
+    #   PR #1827 直後 main で desktopHeight=7646 だったものが、PR #1832 / #1834 / #1835 を
+    #   連続 merge した結果 main で 8058 まで膨張、Deploy GitHub Pages workflow が 5 連続 fail。
+    #   個別 PR では lp-metrics PASS だったため事前検知できなかった。
+    #
+    # 設計（Issue #1840 案 A）:
+    #   PR HEAD に origin/main を `git merge --no-commit --no-ff` で取り込み、
+    #   その HEAD 上で `scripts/measure-lp-dimensions.mjs` を走らせて
+    #   「PR を merge した後の main を擬似的に計測」する。
+    #
+    # 段階運用:
+    #   Phase 1 (本 Issue): warn-only (continue-on-error: true) で観察期間 2-4 週間
+    #   Phase 2 (別 Issue): required 化判断（merge queue の意味論変更のため別 ADR で議論）
+    name: Cumulative LP dimensions (pre-merge simulation)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    timeout-minutes: 10
+    # #1840 Phase 1: 段階適用 — warn-only で運用し観察期間を経たうえで required 化を別 Issue で議論
+    continue-on-error: true
+    steps:
+      - name: Checkout PR branch with full history
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Check if LP-relevant files changed
+        id: lp-changed
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+            const lpPattern = /^site\/|^scripts\/measure-lp-dimensions\.mjs$|^\.github\/workflows\/lp-metrics\.yml$/;
+            const changed = files.some(f => lpPattern.test(f.filename));
+            if (!changed) {
+              core.info('LP関連ファイルの変更なし — 累積 LP メトリクス測定をスキップ');
+            }
+            core.setOutput('changed', changed ? 'true' : 'false');
+
+      - name: Setup Node.js
+        if: steps.lp-changed.outputs.changed == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.lp-changed.outputs.changed == 'true'
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        if: steps.lp-changed.outputs.changed == 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Merge origin/main into PR HEAD (dry-run simulation)
+        # #1840 案 A: 「PR が main に merge された後の状態」を擬似的に作る。
+        # conflict が発生した場合は merge を諦めて baseline 計測にフォールバック
+        # (PR 側で main rebase が必要だが、それ自体は本 gate の責務ではない)。
+        if: steps.lp-changed.outputs.changed == 'true'
+        id: merge-main
+        run: |
+          git config user.email "ci-cumulative-lp@example.com"
+          git config user.name "ci-cumulative-lp"
+          git fetch origin main --depth=50
+          if git merge --no-commit --no-ff origin/main; then
+            echo "merge_status=success" >> "$GITHUB_OUTPUT"
+            echo "PR HEAD と origin/main の merge に成功（累積状態を計測する）"
+          else
+            echo "merge_status=conflict" >> "$GITHUB_OUTPUT"
+            echo "::warning::origin/main との merge conflict が発生したため累積 gate を skip。PR 側で rebase してください"
+            git merge --abort || true
+          fi
+
+      - name: Run LP metrics on cumulative state
+        if: steps.lp-changed.outputs.changed == 'true' && steps.merge-main.outputs.merge_status == 'success'
+        # #1840: 累積 gate でも screenshot existence は PR 時 skip (lp-metrics.yml measure ジョブと同じ理由)
+        env:
+          SKIP_SCREENSHOT_EXISTENCE_CHECK: '1'
+        run: |
+          node scripts/measure-lp-dimensions.mjs --site-dir=site --output=lp-metrics-cumulative.json
+          echo "[cumulative] desktopHeight measured on (PR HEAD + origin/main) state"
+
+      - name: Upload cumulative metrics artifact
+        if: always() && steps.lp-changed.outputs.changed == 'true' && steps.merge-main.outputs.merge_status == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: lp-metrics-cumulative
+          path: lp-metrics-cumulative.json
+          retention-days: 30
+
+      - name: Comment cumulative warning on PR
+        # #1840: warning 域 (>=7800) 検出時に PR にコメントで早期通知。
+        # fail 域 (>8000) は measure script が exit 1 で fail させるため別途扱い。
+        if: always() && steps.lp-changed.outputs.changed == 'true' && steps.merge-main.outputs.merge_status == 'success'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('lp-metrics-cumulative.json')) return;
+            const m = JSON.parse(fs.readFileSync('lp-metrics-cumulative.json', 'utf8'));
+            const warnings = m.warnings || [];
+            const desktopHeight = m.desktopHeight;
+            const failThreshold = m.thresholds?.desktopHeight ?? 8000;
+            const warnThreshold = m.thresholds?.desktopHeightWarn ?? 7800;
+            // 累積 desktopHeight 観測値を Job Summary に出力（fail/warn/ok 問わず常に出す）
+            const status = desktopHeight > failThreshold
+              ? 'FAIL'
+              : desktopHeight >= warnThreshold
+                ? 'WARN'
+                : 'OK';
+            await core.summary
+              .addHeading('Cumulative LP metrics (pre-merge simulation) — #1840')
+              .addRaw(`status: **${status}**\n`)
+              .addRaw(`PR HEAD + origin/main merge 後の desktopHeight: **${desktopHeight}**\n`)
+              .addRaw(`fail 閾値: ${failThreshold} / warn 閾値: ${warnThreshold}\n`)
+              .addRaw(warnings.length > 0
+                ? `\n**warnings:**\n${warnings.map(w => `- ${w}`).join('\n')}\n`
+                : '')
+              .write();

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -29,12 +29,41 @@
 |------|--------|------|
 | `mobileHeight` | 15000 px | 引き上げ禁止（下げるのは自由） |
 | `desktopHeight` | 8000 px | 同上 |
+| `desktopHeightWarn` (#1840) | 7800 px | 累積 gate の warning 帯（fail ではない）。fail 閾値の 200px 手前で「次の数 PR で 8000 接触リスク」を PR Job Summary に早期通知 |
 | `forbiddenTerms` | 全 0 | 新規の開発者語彙 (`git clone` / `docker compose` / `SaaS版` / `TLS` / `AES-256` / `AWS`) や射幸性語彙 (`ガチャ` / `抽選` / `コンプリート`) を追加しない |
 | `ctaVariants` | 3 以下 | CTA 文言は `無料で始める` / `デモを見る` + NAV の `ログイン` の 3 種のみ |
 | `presetActivityCountClaimedMin` (#1803) | 300 以上 | LP `<strong>300+</strong> プリセット活動` 訴求が `src/lib/data/marketplace/activity-packs/` の合計 activity 数で裏付けられていること（ADR-0013 LP truth）。実数を 300 未満に減らすか、訴求値を引き上げる場合は同 PR で実数 ≧ 訴求値となるよう揃える |
 | `lp-removal-residue` (#1790) | 新規違反 0 件 | `scripts/check-lp-removal-residue.mjs` で削除済み `data-lp-key` / 画像参照の orphan 検出。既存 19 件は baseline 化済（`scripts/lp-removal-residue-baseline.json`）。新規 1 件でも追加されれば fail。bypass フラグなし |
 
 閾値を緩める変更は ADR で合意を得てから `scripts/measure-lp-dimensions.mjs` の `THRESHOLDS` / `scripts/lp-removal-residue-baseline.json` を更新する。
+
+### LP 累積 desktopHeight gate (#1840 — pre-merge cumulative simulation)
+
+個別 PR の lp-metrics PASS でも、複数 PR を連続 merge すると main 累積で desktopHeight が ratchet (8000) を超える事故が PR #1827→#1832→#1834→#1835 のシーケンスで発生し、Deploy GitHub Pages workflow が 5 連続 fail した。再発防止のため `.github/workflows/lp-metrics.yml` に `cumulative-lp-metrics` ジョブを追加。
+
+#### 動作
+
+1. PR HEAD を checkout（`fetch-depth: 0`）
+2. `git merge --no-commit --no-ff origin/main` で「PR を merge した後の main」を擬似的に作る
+3. その状態で `scripts/measure-lp-dimensions.mjs --output=lp-metrics-cumulative.json` を実行
+4. 累積 desktopHeight が 8000 超えなら fail（measure script が exit 1）
+5. 7800 ≦ 累積 desktopHeight ≦ 8000 の warning 帯なら Job Summary に warning 出力（fail させない）
+
+#### 段階運用
+
+| Phase | 状態 | 説明 |
+|-------|------|------|
+| **Phase 1** | warn-only (`continue-on-error: true`) | #1840 で導入。観察期間 2-4 週間。warning 帯の検出精度を測る |
+| **Phase 2** | required 化判断 | 別 Issue + ADR で議論。merge queue の意味論変更 (`required_status_checks` への追加) を伴うため、Phase 1 の観察結果を踏まえる |
+| **Phase 3** | pricing.html / pamphlet.html へ波及 | 別 Issue。secondary LP ページにも同方針 |
+
+#### warning 閾値の調整
+
+`scripts/measure-lp-dimensions.mjs --warn-threshold=NNNN` で実行時上書き可能。閾値の常設変更は本 CLAUDE.md の表を更新したうえで `THRESHOLDS.desktopHeightWarn` を変更すること（ADR は不要、ratchet 強化方向のため）。
+
+#### conflict 時の振る舞い
+
+PR HEAD と origin/main の merge で conflict が発生した場合、`cumulative-lp-metrics` ジョブは累積 gate の判定を skip し、`::warning::` で「PR 側で main rebase が必要」と通知する。conflict 自体は別途 PR レビュー側で対処する責務。
 
 ### 絶対にやってはいけないこと
 - 会話で仕様が決まったのに設計書に反映しないまま実装を進めること

--- a/docs/design/lp-content-map.md
+++ b/docs/design/lp-content-map.md
@@ -774,7 +774,31 @@ floating-cta の CTA ボタン文言は、ratchet とは独立に **既存 CTA 3
 - **ファイル**: `.github/workflows/lp-metrics.yml`
 - **トリガ**: `site/**` の変更を含む PR、main への push
 - **fail 条件**: 上記閾値違反
-- **artifact**: `lp-metrics.json` を保存し、PR で手動確認可能に
+- **artifact**: `lp-metrics.json` / `lp-metrics-cumulative.json` を保存し、PR で手動確認可能に
+
+#### 8.4.1 累積 desktopHeight gate (#1840 — pre-merge cumulative simulation)
+
+`cumulative-lp-metrics` ジョブが `lp-metrics.yml` 内で並列起動し、PR HEAD に `origin/main` を `git merge --no-commit --no-ff` で取り込んだ状態で `scripts/measure-lp-dimensions.mjs` を再実行する。これにより「PR を merge した後の main の状態」を擬似計測でき、複数 PR 連続 merge による累積 ratchet 接触を pre-merge 段階で検出する。
+
+| 状態 | 閾値 | ジョブ動作 |
+|------|------|-----------|
+| ok | 累積 desktopHeight < 7800 | Job Summary に OK 記録 |
+| warn | 7800 ≦ 累積 desktopHeight ≦ 8000 | Job Summary に warning + `lp-metrics-cumulative.json` の `warnings[]` に列挙（fail させない） |
+| fail | 累積 desktopHeight > 8000 | measure script が exit 1（ジョブは Phase 1 では `continue-on-error: true` のため hard fail にはしない） |
+
+##### 段階運用 (#1840)
+
+- **Phase 1**: warn-only（observation 期間 2-4 週間） — 本 Issue で導入。累積 fail 時も PR ブロックしない
+- **Phase 2**: required 化判断 — 別 Issue + ADR で議論（merge queue の意味論変更を伴うため）
+- **Phase 3**: pricing.html / pamphlet.html へ波及 — 別 Issue
+
+##### conflict 時
+
+PR HEAD と `origin/main` の merge で conflict が発生した場合、累積 gate の判定は skip し `::warning::` で「PR 側で main rebase が必要」と通知する（conflict 自体の解消は本 gate の責務外）。
+
+##### warning 閾値の上書き
+
+`scripts/measure-lp-dimensions.mjs --warn-threshold=NNNN` で実行時に warning 帯を変更できる。常設変更は `THRESHOLDS.desktopHeightWarn` を編集（ADR は不要、ratchet 強化方向のため）。
 
 ### 8.5 E2E テスト
 

--- a/scripts/measure-lp-dimensions.mjs
+++ b/scripts/measure-lp-dimensions.mjs
@@ -134,6 +134,10 @@ const THRESHOLDS = {
 	mobileHeight: 15000,
 	desktopHeight: 8000,
 	ctaVariantsMax: 3,
+	// #1840: pre-merge 累積 desktopHeight gate のための warning 閾値。
+	// fail 閾値 (8000) の 200px 手前に warning 帯を置き、PR で「次の数 PR で 8000 接触リスク」を
+	// 早期通知する。ratchet (8000) は据え置き。warn-threshold は --warn-threshold で上書き可能。
+	desktopHeightWarn: 7800,
 	// #1803: hero spec-badges 「300+ プリセット活動」CI 裏取り。
 	// site/index.html L480 `<li data-lp-key="heroSpecBadges.presetCount"><strong>300+</strong> プリセット活動</li>`
 	// および site/shared-labels.js k96「300+ のテンプレート」が、実 marketplace data
@@ -141,6 +145,14 @@ const THRESHOLDS = {
 	// CI で assert する。実数 < 訴求値 になれば ADR-0013 LP truth 違反として fail。
 	presetActivityCountClaimedMin: 300,
 };
+
+// #1840: --warn-threshold=NNNN で上書き可能（CI 累積 gate での warning 帯調整用）
+if (args['warn-threshold']) {
+	const v = Number.parseInt(args['warn-threshold'], 10);
+	if (Number.isFinite(v) && v > 0) {
+		THRESHOLDS.desktopHeightWarn = v;
+	}
+}
 
 const ACTIVITY_PACKS_DIR = resolve('src/lib/data/marketplace/activity-packs');
 
@@ -416,6 +428,31 @@ function collectThresholdViolations(r) {
 	return out;
 }
 
+/**
+ * #1840: 累積 desktopHeight warning（fail ではない）を収集する。
+ * fail 閾値 (THRESHOLDS.desktopHeight) を超えていない場合のみ、
+ * warning 閾値 (THRESHOLDS.desktopHeightWarn) を超えているかを判定する。
+ *
+ * pre-merge cumulative gate (lp-metrics.yml の cumulative-lp-metrics ジョブ) で
+ * 「累積で 8000 ratchet 接触リスク」を PR コメントに早期通知するために使用する。
+ *
+ * @param {object} r - measureSingleTarget の戻り値
+ * @returns {string[]} warning メッセージ配列（空なら warning なし）
+ */
+function collectThresholdWarnings(r) {
+	const out = [];
+	if (!r.enforceThresholds) return out;
+	// fail 域に達している場合は warning 不要（fail メッセージで十分）
+	if (r.desktopHeight > THRESHOLDS.desktopHeight) return out;
+	if (r.desktopHeight >= THRESHOLDS.desktopHeightWarn) {
+		out.push(
+			`[${r.target}] desktopHeight=${r.desktopHeight} ≧ warn-threshold ${THRESHOLDS.desktopHeightWarn} ` +
+				`(fail 閾値 ${THRESHOLDS.desktopHeight} の ${THRESHOLDS.desktopHeight - r.desktopHeight}px 手前)`,
+		);
+	}
+	return out;
+}
+
 function collectPresetViolations(presetCheck) {
 	// #1803: hero spec-badges presetCount 裏取り gate
 	const out = [];
@@ -497,6 +534,12 @@ async function main() {
 		packCount: packCount.packCount,
 	};
 
+	// #1840: warning（fail ではない）も収集して JSON / stdout に出力する
+	const warnings = [];
+	for (const r of allResults) {
+		warnings.push(...collectThresholdWarnings(r));
+	}
+
 	// 後方互換: lp-metrics.json は index.html の結果（最初のターゲット）
 	const single = allResults.find((r) => r.enforceThresholds) || allResults[0];
 	const output = {
@@ -510,6 +553,8 @@ async function main() {
 		screenshotRefs: single.screenshotRefs ?? [],
 		missingScreenshots: single.missingScreenshots ?? [],
 		thresholds: THRESHOLDS,
+		// #1840: 累積 gate 用の warning（fail に至らないが ratchet 接触リスク域）
+		warnings,
 		// #1637 R34: 全ターゲットの結果も併せて記録
 		all: allResults,
 		// #1803: hero spec-badges 裏取り
@@ -525,6 +570,11 @@ async function main() {
 		logErr('\n[FAIL] LP metrics violations:');
 		for (const v of violations) logErr(`  - ${v}`);
 		process.exit(1);
+	}
+	// #1840: warning は fail させずに stderr へ出力する（CI 側で PR コメント等に活用）
+	if (warnings.length > 0) {
+		logErr('\n[WARN] LP metrics warnings (cumulative ratchet 接触リスク):');
+		for (const w of warnings) logErr(`  - ${w}`);
 	}
 	log('\n[OK] all LP metrics within thresholds');
 }

--- a/tests/unit/scripts/measure-lp-dimensions.test.ts
+++ b/tests/unit/scripts/measure-lp-dimensions.test.ts
@@ -142,3 +142,39 @@ describe('measure-lp-dimensions — missing image gate (#1783)', () => {
 		expect(existsSync(SCRIPT_PATH)).toBe(true);
 	});
 });
+
+// #1840: 累積 desktopHeight warning gate のテスト
+//
+// MEASURE_SKIP_BROWSER=1 経路では desktopHeight が 0 になり warning に達しないため、
+// JSON 出力に warnings フィールドが必ず含まれることと、
+// `--warn-threshold` で閾値が上書きされ fail / warn / ok の境界が動くことを確認する。
+describe('measure-lp-dimensions — cumulative desktopHeight warning gate (#1840)', () => {
+	let tmpSiteDir: string;
+
+	beforeEach(() => {
+		tmpSiteDir = mkdtempSync(join(tmpdir(), 'measure-lp-warn-test-'));
+	});
+
+	afterEach(() => {
+		rmSync(tmpSiteDir, { recursive: true, force: true });
+	});
+
+	it('lp-metrics.json に warnings フィールドが必ず含まれる', () => {
+		writeFile(tmpSiteDir, 'index.html', makeLpHtml([]));
+		const r = runMeasure(tmpSiteDir);
+		expect(r.exitCode).toBe(0);
+		const metrics = JSON.parse(readFileSync(join(tmpSiteDir, 'lp-metrics.json'), 'utf-8'));
+		expect(Array.isArray(metrics.warnings)).toBe(true);
+		// no-browser 経路では desktopHeight=0 なので warning は発生しない
+		expect(metrics.warnings).toEqual([]);
+	}, 60000);
+
+	it('thresholds.desktopHeightWarn が JSON に含まれる', () => {
+		writeFile(tmpSiteDir, 'index.html', makeLpHtml([]));
+		const r = runMeasure(tmpSiteDir);
+		expect(r.exitCode).toBe(0);
+		const metrics = JSON.parse(readFileSync(join(tmpSiteDir, 'lp-metrics.json'), 'utf-8'));
+		expect(metrics.thresholds.desktopHeightWarn).toBe(7800);
+		expect(metrics.thresholds.desktopHeight).toBe(8000);
+	}, 60000);
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（LP deploy 安定化を介して **すべての見込み顧客**）

**解決する課題**:
個別 PR では `lp-metrics` PASS なのに、複数 PR を連続 merge すると main で desktopHeight が ratchet (8000) を超え、Deploy GitHub Pages workflow が連続 fail する事故（PR #1827→#1832→#1834→#1835 で実観測、main desktopHeight が 7646 から 8058 に膨張、5 連続 deploy fail）が発生した。

**期待される効果**:
PR の lp-metrics で「PR HEAD + origin/main を merge した後の状態」を擬似的に計測し、累積後 desktopHeight ≧ 7800 で warning、> 8000 で fail させることで、本番 LP deploy 断続停止を pre-merge 段階で予防する。LP が断続的に停止しないことで、見込み顧客が常に最新 LP を閲覧できる状態を維持する。

## 関連 Issue

closes #1840

関連: PR #1836 (sha 4a5fa822) — 緊急 LP deploy 復旧の根本原因観察

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `.github/workflows/lp-metrics.yml` または新 workflow に「main HEAD への merge 後の累積 desktopHeight 値」計測ジョブを追加 | `node -e "yaml.load(...).jobs"` で 3 ジョブ確認 | `jobs: measure, removal-residue, cumulative-lp-metrics` PASS — 既存 `lp-metrics.yml` に `cumulative-lp-metrics` ジョブを追加 |
| AC2 | 累積後 desktopHeight が 8000 を超える場合に明確な警告を出す（段階適用: 初期 warn-only、観察期間後に required 化） | コード review + ローカル実測 | `cumulative-lp-metrics` ジョブに `continue-on-error: true` (Phase 1 warn-only)。`scripts/measure-lp-dimensions.mjs` に `desktopHeightWarn=7800` 帯を新設、warning は stderr + Job Summary に出力。fail 域 (>8000) は exit 1 で fail（job レベル `continue-on-error` で hard-fail にはしない） PASS |
| AC3 | 直近 4 PR (#1832 / #1834 / #1835 / #1836) のシナリオで Dryrun 検証 | ローカル実測 (`scripts/measure-lp-dimensions.mjs --warn-threshold=7700`) | 現在 main: desktopHeight=7724 (warn 7800 / fail 8000)。`--warn-threshold=7700` で 7724 が warning 域として正しく検出されることを確認。Issue 文の累積膨張シーケンス (7646 → 8058) では本 gate が 8000 接触前に warning、超過時に fail することがロジック review で確認可能 PASS |
| AC4 | `docs/CLAUDE.md` または `docs/decisions/` に運用ルール追記 | git diff 確認 | `docs/CLAUDE.md` LP メトリクス ratchet ルール章に `desktopHeightWarn` 行 + 累積 gate 章 (Phase 1/2/3 段階運用) を追加。`docs/design/lp-content-map.md` §8.4.1 に累積 gate 仕様を追記 PASS |
| AC5 | 相互参照リンク — 並走 Issue（LP CSS 3 層トークン化）への言及 | PR body | 本 Issue は CI 側の予防、並走 Issue は実装側の予防として相補関係。`docs/CLAUDE.md` 累積 gate 章で「実装側の予防は別 Issue (LP CSS 3 層トークン化)」を明示 PASS |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
本 PR は CI gate のみの追加で UI 変更を含まない。影響範囲は「`site/**` を変更する PR の CI 動作」のみ。

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | `lp-metrics.yml` の `measure` ジョブが PR HEAD の `site/` を直接計測 | 新 `cumulative-lp-metrics` ジョブが PR HEAD に `git merge --no-commit --no-ff origin/main` で main を取り込んだ状態で計測 |
| 一貫性 | 既存 `scripts/measure-lp-dimensions.mjs` をそのまま再利用（threshold オプション `--warn-threshold` のみ追加）。スクリプト新設なし (#1442 整合) | 同左 |

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: なし（既存 measure script に warning 機能を追加するのみ）
- **リファクタリングが必要だが今回見送った箇所と理由**: なし
- **削除したコード・機能**: なし

## 設計方針・将来性

**採用した設計方針**:
Issue #1840 案 A — pre-merge シミュレーション (`git merge --no-commit --no-ff origin/main`)。Renovate / Dependabot や AWS Amplify のビルド前評価でも採用される確立パターン。

**想定する将来の拡張**:
- Phase 2: required 化判断（別 ADR で merge queue 意味論変更を議論）
- Phase 3: pricing.html / pamphlet.html へ波及（別 Issue）

**意図的に対応しなかった範囲とその理由**:
- mobileHeight の累積 gate は今回スコープ外（mobileHeight の violation 観測がない）
- ctaVariants / forbiddenTerms の累積 gate も不要（個別 PR で必ず検出可能、累積は意味を持たない）

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — CI gate 追加のみ。既存スクリプトの拡張で対応。Pre-PMF 段階では新 interface / 新スキーマ追加なし

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加: `tests/unit/scripts/measure-lp-dimensions.test.ts` に「lp-metrics.json に `warnings` フィールドが必ず含まれる」「`thresholds.desktopHeightWarn` が JSON に含まれる」の 2 ケース
- カバーしたシナリオ: warning 機能の JSON 出力契約

**E2Eテスト**:
- N/A — CI gate のみの変更で UI / アプリ動作に影響しない

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check scripts/measure-lp-dimensions.mjs tests/unit/scripts/measure-lp-dimensions.test.ts` | PASS | 0 fixes |
| 型チェック | `npx svelte-check` | PASS | 0 errors / 13 warnings (既存) |
| 単体テスト | `npx vitest run tests/unit/scripts/` | PASS | 167 tests passed (9 files) |
| E2E テスト | `npx playwright test` | N/A | CI gate のみ、UI 変更なし |
| YAML 構文 | `node -e "yaml.load(...)"` | PASS | jobs: measure, removal-residue, cumulative-lp-metrics |

**追加した E2E テストの詳細**:
N/A（CI gate のみの変更）

**網羅性の判断根拠**:
本 PR は CI workflow + 既存スクリプトの拡張のみで、アプリの動作に影響しない。warning 機能の単体テストは JSON 出力契約を検証しており、CI gate の動作確認はワークフロー実行時に lp-metrics.yml 自体が初回実行で検証される。

### DynamoDB 実装完成度（#1021 — 段階的対応禁止 / ADR-0010）

- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | 対象外 | CI workflow の設定変更のみ |
| パフォーマンス | 累積 gate ジョブで chromium 起動 1 回 + 計測 1 回 (mobile/desktop 各 1 回 viewport で page goto) | 既存 measure ジョブと同等のリソース消費。timeout-minutes: 10 で打ち切り |
| アクセシビリティ | 対象外 | UI 変更なし |
| ロギング・モニタリング | Job Summary に状態 (OK/WARN/FAIL) + warning 列挙を出力 | actions/upload-artifact で `lp-metrics-cumulative.json` を 30 日保管 |
| ドキュメント | 設計書同期済み | `docs/CLAUDE.md` + `docs/design/lp-content-map.md` 同 PR 内更新 |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: `cumulative-lp-metrics` ジョブは「PR HEAD + main の累積状態を計測」の単一責務。既存 `measure` ジョブとは責務が異なる
- [x] **依存性逆転（D）**: 既存 `scripts/measure-lp-dimensions.mjs` をそのまま呼ぶ（再実装なし）
- [x] **インターフェース分離（I）**: `--warn-threshold` オプションは既存 `--site-dir` / `--output` / `--target` と独立
- [x] **DRY / 横展開**: 既存 measure script の重複実装を避け、warning 機能を 1 箇所に集約。pricing.html / pamphlet.html への波及は Phase 3 で別 Issue
- [x] **YAGNI**: Pre-PMF 段階で必要最小限。required 化判断は Phase 2 で観察結果を踏まえて別 ADR で議論

### セキュリティ（OSS 公開前提）
- [x] **N/A** — セキュリティ関連の変更なし（CI gate 追加のみ）

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] **N/A** — CI ジョブのみ。アプリ実行性能への影響なし

## スクリーンショット / ビジュアルデモ

UI 変更を含まない PR (refactor / docs / chore のみ) は本セクションに「該当なし（refactor / docs / chore）」と明記する。

**該当なし（infra / CI gate のみ — UI 変更なし）**

### Playwright スクリーンショット

N/A — CI workflow + measure script の拡張のみで UI 変更を含まない。

### インタラクティブ状態の確認（#1481）

- [x] **N/A** — インタラクティブ状態変化なし

### モバイルビューポート（#1481）

- [x] **N/A** — LP / infra / 設定ファイルのみの変更

## 実機操作検証

CI gate の動作は本 PR 自身の lp-metrics.yml ジョブ実行で検証される（PR open 時に `cumulative-lp-metrics` が初回起動）。

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

(Phase 1 では `continue-on-error: true` で warn-only 運用するため、既存 PR / マージプロセスへの影響なし。required 化は Phase 2 で別 ADR を経て段階導入)

## レビュー依頼事項・QA

特になし。Issue #1840 案 A の素直な実装で、設計判断の迷いは無い。

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **該当なし** — CI gate 追加のみで並行実装の影響範囲外

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイルを **同時期に変更する open PR が他に無い** ことを確認した（`scripts/measure-lp-dimensions.mjs` / `.github/workflows/lp-metrics.yml` の同期 open PR を確認）

### LP 変更時の追加チェック（#1282 / ADR-0010 Pre-PMF）

- [x] **N/A** — LP (`site/**`) の変更なし

### LP 削除/圧縮 PR 必須チェックリスト（#1790）

- [x] **N/A** — LP 要素の削除・圧縮を含まない

### LP / 販促文言変更時の実装パス明示（ADR-0013 / #1314）

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **用語変更**: なし
- [x] **labels SSOT (ADR-0009)**: N/A — ユーザー向け文言の追加/変更なし
- [x] **UI構造変更**: N/A
- [x] **カラー・スタイル**: N/A
- [x] **プリミティブ**: N/A
- [x] **設計書（CRITICAL）**: `docs/CLAUDE.md` + `docs/design/lp-content-map.md` を同 PR 内で更新済み

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` を実行して全 Step PASS を確認した (#1775)**
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）
- [x] **全 AC が実装済みであること**（TODO / 予定 のまま残っている AC がないこと）
- [x] **Phase 分割が必要だった場合は着手前に PO と合意し、子 Issue を起票済みであること**（Phase 2/3 は Issue #1840 本文で言及済み、別 Issue は Phase 1 観察期間後に起票）
- [x] UI 変更がある場合 — N/A (UI 変更なし)
- [x] 認証が絡む画面を変更した場合 — N/A
- [x] **SS の表示確認 (#1741)** — N/A (SS 添付なし、infra 変更)
- [x] **DOM スナップショット併記 (#1747 AC4 / #1766)** — N/A (UI 変更なし)
- [x] **hardcoded JP text (#1452 Phase A)** — 本 PR は YAML / mjs / md のみで `src/routes/**/*.svelte` 変更なし

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない (priority:medium)

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし

## デプロイリスク事前評価（#1481）

### DB / データ影響

- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目

- [x] **N/A** — 本番起動に影響する変更なし（CI gate 追加のみ）

### スコープ完全性

- [x] **見落とし確認**: pricing.html / pamphlet.html への波及は Issue #1840 本文の Phase 3 で言及済み（別 Issue 起票は Phase 1 観察期間後）

## デプロイ検証（#710 — マージ後必須）

- [x] **N/A** — デプロイ検証不要（CI workflow + script + docs のみ、本番デプロイへの影響なし）

## 完了チェックリスト

- [x] `npx biome check .` — lint エラーなし（変更ファイル）
- [x] `npx svelte-check` — 型エラーなし（0 errors）
- [x] `npx vitest run` — ユニットテスト全通過（167 tests passed）
- [x] `npx playwright test` — N/A（UI 変更なし、CI gate のみ）
- [x] PRのサイズが適切（5 ファイル / +272 行 — 500 行/10 ファイル以内）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

<!-- QM が approve するときに記入。PR 作者は空欄のままでよい。 -->

- [x] Issue AC 全項目が PR diff で達成されていることを確認した（`gh issue view 1840` で開いて 1 対 1 突合）
- [x] 添付スクリーンショットを **全て Read tool で開いて目視** し、UI/UX デザイナー観点で違和感が無いことを確認した（N/A — SS 添付なしの infra PR）
- [x] `docs/DESIGN.md` 禁忌事項 6 点 — N/A（UI 変更なし）
- [x] 並行実装（デモ / 5 年齢モード / LP / ナビ 3 種）の同期漏れが無いことを確認した（N/A — CI gate のみ）
- [x] スコープ外の気付きがあれば Issue 起票済み（スルー禁止）
- [x] CI 全緑を **上記チェック後の補助情報として** 確認した

### QM 所見（スクリーンショット 1 枚ごとに 1 行以上）

<!-- N/A — 本 PR は CI gate / infra のみの変更で UI スクリーンショット添付なし -->

