### PR TITLE
design: #1845 — core-loop-summary fallback 運用確定 (Gemini 鍵未配備対応)

### DIFF
--- a/docs/design/asset-catalog.md
+++ b/docs/design/asset-catalog.md
@@ -150,8 +150,36 @@ npm run capture:feature -- feature-routine-checklist
 
 | ファイル名 | 配置 | サイズ | 生成方法 |
 |----------|------|--------|---------|
-| `core-loop-summary.png` | `site/assets/lp/` (配信) + `static/assets/lp/` (アプリ側) | 1280×640 PNG | `npm run generate:coreloop-summary`（Gemini API）/ 暫定 SVG ベース PNG |
+| `core-loop-summary.png` | `site/assets/lp/` (配信) + `static/assets/lp/` (アプリ側) | 1280×640 PNG | `npm run generate:coreloop-summary`（Gemini API）/ 暫定 SVG ベース PNG（Gemini 鍵未配備環境では本暫定が SSOT、#1845 で fallback 運用を確定）|
 | `core-loop-summary.svg` | `static/assets/lp/`（暫定再現用） | 640×320 viewBox | 手書き（Gemini API 鍵が無い環境用のフォールバック）|
+
+#### #1845: Gemini Pro 3.1 image での再生成手順（API 鍵配備環境）
+
+PO 指示（PO-N-3）で「Gemini Pro 3.1 image (gemini-2.5-pro) による本格生成画像への置換」が
+要求されている。鍵配備済み環境では以下の順序で再生成を実行すること。Issue #1845 完遂時に
+SVG は `static/assets/lp/_archive/core-loop-summary.svg.bak` へ退避する想定（履歴保全）。
+
+```bash
+# 1. .env.local に GEMINI_API_KEY を配備（https://aistudio.google.com/apikey で取得）
+echo 'GEMINI_API_KEY=<your-key>' >> .env.local
+
+# 2. Gemini Pro 3.1 image での再生成
+npm run generate:coreloop-summary
+#   → static/assets/lp/core-loop-summary.png (1280×640) 出力
+#   → site/assets/lp/core-loop-summary.png にも自動配備
+
+# 3. 画像アセット追加時のレビューチェックリスト 6 項目を全件目視確認
+#   （「画像アセット追加時のレビューチェックリスト」§ を参照）
+
+# 4. 暫定 SVG を archive へ退避（再生成成功後のみ）
+mkdir -p static/assets/lp/_archive
+git mv static/assets/lp/core-loop-summary.svg \
+       static/assets/lp/_archive/core-loop-summary.svg.bak
+```
+
+**鍵未配備環境の動作**: `scripts/generate-coreloop-summary.mjs` は GEMINI_API_KEY 不在時に
+exit 2 で停止し、上記手順 1（鍵取得 + 配備）と暫定 SVG → PNG 決定的変換コマンドを案内する。
+このとき暫定 PNG（SVG ベース）が SSOT として運用される。
 
 ### 構図仕様
 

--- a/scripts/generate-coreloop-summary.mjs
+++ b/scripts/generate-coreloop-summary.mjs
@@ -60,6 +60,49 @@ const isDryRun = args.includes('--dry-run');
 // 出力先: 開発側は static/assets/lp/、デプロイ側は site/assets/lp/ (CI / Pages 配備時にコピー)
 const OUTPUT_PATH = 'static/assets/lp/core-loop-summary.png';
 
+// #1845: GEMINI_API_KEY 早期検出 — wrapper 段階で鍵未配備を検出し、fallback コマンドを案内する
+//   (内部で呼ぶ generate-image.mjs も同様の検出を行うが、wrapper 段階で
+//    coreloop summary 固有の fallback パス案内を表示することで開発者の判断を早める)
+function loadEnvFile(filePath) {
+	if (!fs.existsSync(filePath)) return;
+	const content = fs.readFileSync(filePath, 'utf-8');
+	for (const line of content.split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith('#')) continue;
+		const eq = trimmed.indexOf('=');
+		if (eq === -1) continue;
+		const key = trimmed.slice(0, eq).trim();
+		const value = trimmed
+			.slice(eq + 1)
+			.trim()
+			.replace(/^["']|["']$/g, '');
+		if (!process.env[key]) process.env[key] = value;
+	}
+}
+loadEnvFile(path.resolve(REPO_ROOT, '.env.local'));
+loadEnvFile(path.resolve(REPO_ROOT, '.env'));
+
+if (!isDryRun && !process.env.GEMINI_API_KEY) {
+	console.error('エラー: GEMINI_API_KEY が設定されていません。');
+	console.error('');
+	console.error('  Gemini API での再生成には以下の手順で .env.local に鍵を配備してください:');
+	console.error('    1. https://aistudio.google.com/apikey で API key を取得');
+	console.error('    2. リポジトリルートの .env.local に  GEMINI_API_KEY=<key>  を記載');
+	console.error('    3. npm run generate:coreloop-summary を再実行');
+	console.error('');
+	console.error('  鍵が配備できない場合のフォールバック (SVG → PNG 決定的変換):');
+	console.error("    node -e \"require('sharp')('static/assets/lp/core-loop-summary.svg')\\");
+	console.error("      .resize(1280,640).png().toFile('static/assets/lp/core-loop-summary.png')\"");
+	console.error(
+		'    cp static/assets/lp/core-loop-summary.png site/assets/lp/core-loop-summary.png',
+	);
+	console.error('');
+	console.error(
+		'  詳細: docs/design/asset-catalog.md「LP コアループ 1-shot summary 画像 (#1787)」セクション',
+	);
+	process.exit(2);
+}
+
 const childArgs = [
 	path.join(REPO_ROOT, 'scripts/generate-image.mjs'),
 	'--prompt',


### PR DESCRIPTION
﻿## 顧客価値・目的

**対象ユーザー**: 運営（PO） / 将来 LP 訪問者

**解決する課題**:
PO-N-3 指示「`core-loop-summary.png` を Gemini Pro 3.1 image (gemini-2.5-pro) で本格生成画像に置換」に対し、現作業環境で `GEMINI_API_KEY` が未配備のため Gemini API 呼び出しが不可能。鍵配備を待たずに進める fallback 運用と、配備後の再生成手順を SSOT 化することで、Issue #1845 の正規完遂までの間 LP の core-loop summary が「暫定状態だと気付かれる」状況を最小化する。

**期待される効果**:
- 鍵配備済み環境での再生成手順が `docs/design/asset-catalog.md` に明文化され、後で誰が実行しても同じ結果になる
- `scripts/generate-coreloop-summary.mjs` が wrapper 段階で鍵未配備を早期検出し、fallback コマンドを案内するため「鍵が無くて何もできない」状態が発生しない
- 暫定 PNG（SVG ベース）が「Gemini 鍵未配備時の SSOT」として明示され、現状の LP は引き続き broken image になることなく fallback PNG で表示される

## 関連 Issue

Refs #1845

(注: AC1-4 が鍵配備待ちで未達のため Issue は open のまま維持。鍵配備後の本格生成 + SVG archive 移動 commit/PR で完遂後に close)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | PR scrshot に再生成前と再生成後の本番 LP core-loop ブロックを並記 | LP に画像変更なし → Before/After 同一 | **未達 (鍵配備待ち)** — `static/assets/lp/core-loop-summary.png` (md5 `f188267c2ee4788c528b86d551146c8f`) は本 PR 内では未変更。fallback PNG の現状が SSOT として継続。鍵配備後の別 commit で「Gemini 生成 PNG」を adopt 後、Before/After SS を取得する想定 |
| AC2 | `static/assets/lp/core-loop-summary.png` の生成元が Gemini API レスポンスである証跡 | `git diff --stat origin/main` | **未達 (鍵配備待ち)** — PNG ファイルは本 PR の差分対象外。Gemini API call 不能のため。鍵配備後の別 commit で `npm run generate:coreloop-summary` 出力ログを記録 |
| AC3 | `static/assets/lp/core-loop-summary.svg` が `_archive/` に移動済み | `git ls-files static/assets/lp/` | **未達 (鍵配備待ち)** — SVG は LP 表示 fallback 経路を維持するため archive せず据え置き。鍵配備後の Gemini PNG 確認後に `git mv` する手順を `docs/design/asset-catalog.md` に明文化済 |
| AC4 | 新 PNG が「画像アセット追加時のレビューチェックリスト」6 項目を満たす | self-check | **未達 (鍵配備待ち)** — 新 PNG 未生成のため self-check 対象なし |
| AC5 | broken image gate が pass | LP メトリクス | **PASS** — `SKIP_SCREENSHOT_EXISTENCE_CHECK=1 node scripts/measure-lp-dimensions.mjs` は `[OK] all LP metrics within thresholds`（PNG 既存のまま継続） |
| AC6 | no-touch-zones セクション（#hero / #age-panel / #pricing / 他 LP 構造）が変更されていないこと | `git diff --stat` | **PASS** — `site/**` 配下 0 件変更、`static/assets/lp/*.png` も 0 件変更（md5 不変）。変更は `scripts/` + `docs/design/` のみ |

**重要な注記**: AC1-4 が未達となるのは、本作業環境に `GEMINI_API_KEY` が配備されていないため。Issue は本来 `status:blocked` 相当だが、タスク指示「fallback の SVG 維持 + PR body に PO 環境再生成手順記載」に従い、鍵配備後に別 commit で AC1-4 を完遂する想定で本 PR を Ready 化する。鍵配備後の再生成は `docs/design/asset-catalog.md`「#1845: Gemini Pro 3.1 image での再生成手順」§ の通りに実行する。

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [x] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`scripts/`, `docs/`)

**影響を受ける画面・機能**:
LP の core-loop summary 表示自体への影響なし（PNG ファイル無変更）。`scripts/generate-coreloop-summary.mjs` は dev / CI が叩く側のみで本番 runtime には影響しない。

## 既存実装との比較

| 観点 | 既存実装 | 今回の変更 |
|------|---------|-----------|
| 実装パターン | `scripts/generate-image.mjs` 内部で API 鍵検出後 exit 1 | wrapper 段階でも事前検出し、coreloop summary 固有の fallback コマンドを案内 (exit 2) |
| 一貫性 | 鍵不在時のメッセージは generic | core-loop summary 固有の sharp fallback コマンド + SSOT セクション参照を明示 |

`docs/design/asset-catalog.md` の core-loop summary セクションに #1845 サブ § を追記。SSOT 構造（`asset-catalog.md` を SSOT、scripts は generator）を維持する形での増分。

## スクラップ&ビルド検討

- **今回のスコープでリファクタリングした箇所**: なし（最小増分）
- **リファクタリングが必要だが今回見送った箇所と理由**: `scripts/generate-image.mjs` の env 読込部と `scripts/generate-coreloop-summary.mjs` の env 読込部が duplicate（共通 `scripts/lib/env-loader.mjs` 化候補）。鍵未配備の早期検出を最優先したため別 Issue 化想定
- **削除したコード・機能**: なし

## 設計方針・将来性

**採用した設計方針**:
- wrapper 段階での早期 fail（exit 2）で「呼び出し側に fallback の判断を 1 ステップで委ねる」運用を確定
- 「鍵未配備時 = fallback PNG が SSOT」を `docs/design/asset-catalog.md` に明文化することで、観測者（PO / QA / 後続 Dev）が「いつ Gemini PNG に切り替わるか」を時系列で追えるようにする

**想定する将来の拡張**:
- 別 Issue / 別 PR で API 鍵配備後に `npm run generate:coreloop-summary` を実行し PNG 差替 + SVG archive 移動を完了させる（AC1-4 を完遂）
- env-loader 共通化（前述の S&B 検討項目）

**意図的に対応しなかった範囲とその理由**:
- 暫定 SVG / PNG の差替: 鍵未配備のため API call 不能。鍵配備後の別 commit で実施
- LP screenshot 撮影: 画像変更なしのため Before/After SS が同一になる。SS 添付は CI gate を通すための形式となるため意図的に省略（後述「スクリーンショット / ビジュアルデモ」§ で詳述）

## 設計ポリシー確認（新機能 / 新 interface の場合 — #1023 / ADR-0008）

- [x] **該当なし** — 既存機構の error handling 改善 + docs 増分。新 interface / 新スキーマ無し

## テスト戦略

### 追加・変更したテスト

**単体テスト**:
- 追加/変更したテスト: なし（scripts/* は test 対象外、docs 変更）
- カバーしたシナリオ: N/A

**E2Eテスト**:
- 追加/変更したテスト: なし（LP 画像変更なし）
- カバーしたユーザーフロー: N/A

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|-----------|---------|------|------|
| Lint | `npx biome check scripts/generate-coreloop-summary.mjs docs/design/asset-catalog.md` | PASS | `Checked 1 file in 248ms. No fixes applied.` (生成スクリプトは format 適用後 PASS) |
| 型チェック | `npx svelte-check` | N/A | 変更ファイルが `.mjs` / `.md` のため対象外 |
| 単体テスト | `npx vitest run` | N/A | scripts/* は対象外 |
| E2E テスト | `npx playwright test` | N/A | LP 画像変更なし |
| LP メトリクス | `SKIP_SCREENSHOT_EXISTENCE_CHECK=1 node scripts/measure-lp-dimensions.mjs` | PASS | `[OK] all LP metrics within thresholds` |
| Script 実機検証 (鍵不在) | `node scripts/generate-coreloop-summary.mjs` | exit 2 + fallback コマンド表示 | 期待通り (鍵不在時の早期 fail) |
| Script 実機検証 (dry-run) | `node scripts/generate-coreloop-summary.mjs --dry-run` | exit 0 + プロンプト表示 | 期待通り |

**追加した E2E テストの詳細**: なし

**網羅性の判断根拠**:
- 変更は `scripts/generate-coreloop-summary.mjs` のエラーハンドリング分岐 + `docs/design/asset-catalog.md` の文書増分のみ
- runtime（LP 表示）への影響は皆無（PNG 不変）
- スクリプトの動作は鍵不在時 (exit 2) / dry-run 時 (exit 0 + プロンプト出力) の 2 パターンを実機検証済

### DynamoDB 実装完成度

- [x] **N/A** — DynamoDB 実装の追加・変更なし

## 品質観点チェック

| 観点 | 対応内容 | 備考 |
|------|---------|------|
| セキュリティ | API 鍵を `.env.local` 経由で読込（既存パターン踏襲、ハードコード無し） | OSS 公開前提 |
| パフォーマンス | 影響なし（dev tooling のみ） | runtime 不影響 |
| アクセシビリティ | 影響なし（UI 変更なし） | LP 画像不変 |
| ロギング・モニタリング | スクリプト実行時の console.error で fallback コマンド案内 | 観測性向上 |
| ドキュメント | `docs/design/asset-catalog.md` に #1845 サブ § を追加 | SSOT 同期 |

## コード品質・セキュリティ セルフレビュー（#1481）

### SOLID / コード品質
- [x] **単一責任（S）**: wrapper script は「鍵検出 + fallback 案内 + generate-image.mjs 呼び出し」に責務統合
- [x] **DRY / 横展開**: env 読込コードは `generate-image.mjs` と類似だが、wrapper 段階で fail させる目的のため重複は意図的（共通化候補は S&B 検討項目に明記）
- [x] **YAGNI**: 鍵検出以上の防御は追加していない

### セキュリティ（OSS 公開前提）
- [x] ソースコードが GitHub Public に公開される前提で API 鍵がハードコードされていないことを確認
- [x] **N/A** — 入力バリデーション境界に変更なし

### アクセシビリティ
- [x] **N/A** — UI 変更なし

### パフォーマンス
- [x] **N/A** — runtime に影響なし

## スクリーンショット / ビジュアルデモ

### 4 スロット添付

UI 変更を含まない PR （docs / scripts のみ）のため、**該当なし（docs / scripts のみ、LP 画像差替は GEMINI_API_KEY 配備待ちで未実施）**。

`static/assets/lp/core-loop-summary.png` の md5 は origin/main と本 PR HEAD で同一 (`f188267c2ee4788c528b86d551146c8f`)。LP `site/index.html` も無変更 (`git diff origin/main..HEAD -- site/index.html` = empty)。SS を撮っても Before/After が一致するため意図的に省略。

鍵配備後に別 commit で Gemini PNG 差替を行う際は、その commit で改めて mobile + desktop の core-loop section SS（Before = 暫定 PNG / After = Gemini PNG）を 4 スロット形式で添付する。

### Playwright スクリーンショット

| 画面 | ビューポート | スクリーンショット |
|------|------------|------------------|
| 該当なし（UI 変更なし） | — | — |

### インタラクティブ状態の確認（#1481）

- [x] **N/A** — インタラクティブ状態変化なし

### モバイルビューポート（#1481）

- [x] **N/A** — LP / infra / 設定ファイルのみの変更（実際は scripts + docs）

## 実機操作検証

- [x] スクリプトを実機実行し、鍵不在時 exit 2 + fallback コマンド案内 / dry-run 時 exit 0 + プロンプト表示の 2 パターンを目視確認
- [x] **N/A** — 認証画面の変更なし
- [x] **N/A** — UI 変更なし
- [x] **N/A** — UI/UX デザイナー視点セルフレビュー対象なし
- [x] **N/A** — チュートリアル変更なし
- [x] **N/A** — 用語変更なし

## ダイアログ・オーバーレイ検証

- [x] **N/A** — ダイアログ・オーバーレイの変更なし

## 破壊的変更

- [x] このPRに破壊的変更は**含まれない**

## レビュー依頼事項・QA

| # | 質問・確認事項 | 選択肢A | 選択肢B | 推奨 | 理由 |
|---|--------------|---------|---------|------|------|
| 1 | 鍵未配備状態で本 PR をマージするか / `status:blocked` で待つか | A: マージして fallback 運用を SSOT 化 | B: 鍵配備まで保留 | A | タスク指示が「fallback の SVG 維持 + PR body に PO 環境再生成手順記載」を許可しており、PR 単体で「鍵配備後に何をすべきか」が SSOT 化される価値がある |
| 2 | Issue を closes するか open のまま残すか | A: 本 PR で `closes #1845` | B: open のまま、AC1-4 完遂後に close | **B（決定済）** | AC1-4 が鍵配備待ちで未達のため、Issue link 句を `Refs #1845` に書き換え済（GitHub auto-close 回避）。鍵配備後の本格生成 commit/PR で完遂後に close する |

## 横展開・影響波及チェック

### 並行実装影響確認（必須）

- [x] **本番アプリ** — 該当なし
- [x] **デモ版** — 該当なし
- [x] **LP ↔ アプリ整合**: **N/A** — LP / アプリの文言・機能に影響しない変更（画像 md5 不変）
- [x] **全年齢モード** — 該当なし
- [x] **ナビゲーション** — 該当なし
- [x] **E2E/ユニットシード** — 該当なし
- [x] **チュートリアル + デモガイド** — 該当なし
- [x] **該当なし** — 並行実装の影響範囲外の変更

### 並行 PR 影響確認 (#1200)

- [x] 本 PR が変更するファイル (`scripts/generate-coreloop-summary.mjs` / `docs/design/asset-catalog.md`) を同時期に変更する open PR が他に無いことを `gh pr list` で確認済

### LP 変更時の追加チェック

- [x] **N/A** — LP (`site/**`) の変更なし

### LP 削除/圧縮 PR 必須チェックリスト

- [x] **N/A** — LP 要素の削除・圧縮を含まない

### LP / 販促文言変更時の実装パス明示

- [x] **N/A** — LP / 販促文言を変更していない

### その他

- [x] **N/A** — 用語変更なし
- [x] **N/A** — UI構造変更なし
- [x] **N/A** — カラー・スタイル変更なし
- [x] **N/A** — プリミティブ使用なし
- [x] **設計書（CRITICAL）**: `docs/design/asset-catalog.md` に Issue #1845 関連サブ § を追加して SSOT 同期済（同一 PR 内）

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` を実行して全 Step PASS を確認した** — biome / svelte-check (N/A) / vitest (N/A) / hardcoded-strings / lp-dimensions / check-pr-body 個別実行で同等の検証を完了
- [x] セルフレビュー済み（不要な差分・デバッグコードがないこと）
- [x] **全 AC が実装済みであること** — N/A: AC1-4 は GEMINI_API_KEY 配備待ちのため本 PR では実装不能。タスク指示「fallback の SVG 維持 + PR body に PO 環境再生成手順記載」に従い、鍵配備後の追加 commit で AC1-4 を完遂する手順を `docs/design/asset-catalog.md` に SSOT 化済（PR レビュー時に PO 判断を仰ぐ）
- [x] **Phase 分割が必要だった場合は着手前に PO と合意し、子 Issue を起票済みであること** — 鍵配備後の再生成は同一 Issue #1845 内の追加 commit で対応想定
- [x] **N/A** — UI 変更なし
- [x] **N/A** — 認証絡む画面なし
- [x] **N/A** — SS 添付なし（docs / scripts のみ）
- [x] **N/A** — DOM スナップショット併記対象なし（SS なし）
- [x] **hardcoded JP text**: `node scripts/check-hardcoded-strings.mjs` 実行 — 変更対象が `.svelte` 以外のため検査対象外（baseline 不変）

## Critical 修正の追加要件（#612）

- [x] **N/A** — Critical 修正ではない

## 新規 env / secret 追加チェック（ADR-0006 / #914）

- [x] **N/A** — 新規 env / secret の追加なし。`GEMINI_API_KEY` は既存 env、本 PR で wrapper 段階の事前検出を追加したのみ（production guard 化ではない、dev tooling）

## デプロイリスク事前評価（#1481）

### DB / データ影響
- [x] **N/A** — DB スキーマ変更なし

### 本番起動確認項目
- [x] **N/A** — 本番起動に影響する変更なし

### スコープ完全性
- [x] **見落とし確認**: Issue #1845 AC1-4 が鍵配備待ちで本 PR 内では未達である事実を本文 AC 検証マップに明記。鍵配備後の再生成手順を `docs/design/asset-catalog.md` に SSOT 化済

## デプロイ検証（#710 — マージ後必須）

- [x] **N/A** — ドキュメントのみの変更（scripts は dev tooling、本番 runtime に影響なし）

## 完了チェックリスト

- [x] `npx biome check .` — lint エラーなし（変更ファイル）
- [x] `npx svelte-check` — N/A（`.mjs` / `.md` のため対象外）
- [x] `npx vitest run` — N/A（scripts/* は対象外）
- [x] `npx playwright test` — N/A（LP 画像変更なし）
- [x] PRのサイズが適切（72 行追加、2 ファイル）

## Quality Manager レビュー結果（QM が記入 — #1197 / #1198）

(QM が approve 時に記入)


