### PR TITLE
refactor: #1862 Dev Agent spawn 共通制約 SSOT 化で 1.5-2K tokens/spawn 削減

### DIFF
--- a/.claude/agents/dev-session.md
+++ b/.claude/agents/dev-session.md
@@ -20,6 +20,35 @@ description: Use when implementing features, fixing bugs, writing tests, managin
 
 Issue の Acceptance Criteria を全て満たし、QA が一発で Approve できる品質の PR を提出する。
 
+## Dev Agent 共通制約 (spawn 時に毎回適用される SSOT — #1862)
+
+メインセッションが Dev Agent を spawn する際、prompt 内で「**`.claude/agents/dev-session.md` 規約準拠**」と 1 行参照すれば以下が自動適用される。spawn 側で個別記述不要。
+
+### Git 運用
+
+- **worktree モード推奨**（isolation: "worktree"、`.claude/worktrees/...`）
+- **amend 禁止、新規コミットで対応**（CLAUDE.md 全体ルール）
+- **`--no-verify` 禁止**、hooks 失敗時は根本原因を直す（assertion 弱体化禁止 ADR-0006）
+- push は **`--force-with-lease`**（ADR-0026 force push 禁止）
+
+### 検証
+
+- **`npm run pre-ready -- --pr <num>` で全 7 Step PASS**（ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body / capture を順次実行
+- 失敗があれば修正 → 再 push → CI 緑確認まで完結
+
+### PR 運用
+
+- PR body 必須セクション欠落・禁止語があれば修正（`scripts/check-pr-body.mjs` が検出）
+- **merge は QM/POREVIEWER 責務**。自分で `gh pr merge` しない（feedback_no_autonomous_qa_merge.md / ADR-0022）
+- `gh pr ready` までが Dev Agent の範囲
+
+### 報告フォーマット
+
+完了時に 200 字程度で:
+- 作業結果（実装内容 / 衝突解消方針 / 検証結果）
+- PR 最終状態（Ready / mergeable / CI）
+- 残課題があれば明記
+
 ## 作業の進め方
 
 ### コミット前チェック（全て通過必須）


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: メインセッション + Dev Agent (Implementation / Fix / Re-Review 等)

**解決する課題**: メインセッションが Dev Agent を spawn する際、prompt 内に毎回 200-400 字の共通制約（worktree モード / amend 禁止 / `--no-verify` 禁止 / force-with-lease / merge は QM 責務 / pre-ready 検証 / PR body チェック）を繰り返し記述していた。1 ターン 1-3 Agent spawn として 1.5-2K tokens の浪費。

**期待される効果**: spawn 側 prompt は「`.claude/agents/dev-session.md` 規約準拠」1 行参照に圧縮可能。1.5-2K tokens/spawn 削減。spawn 頻度が高いほど累積効果大。

## 関連 Issue

closes #1862

関連: #1855 / #1856 / #1857 (QA 系列、merged) / #1858 / #1859 / #1860 (PO 系列、並走)

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 |
|----|-----|---------|------|
| AC1 | `.claude/agents/dev-session.md` に「Dev Agent 共通制約」セクション新設、4 軸 SSOT 化 | `grep -A 30 "## Dev Agent 共通制約" .claude/agents/dev-session.md` | ✅ Git 運用 / 検証 / PR 運用 / 報告フォーマットの 4 軸が含まれる |
| AC2 | spawn 側 prompt 共通制約は 1 行参照に置換可能 | セクション内に「`.claude/agents/dev-session.md` 規約準拠」と 1 行参照すれば自動適用と明記 | ✅ |
| AC3 | 既存 memory（feedback_agent_split_workflow / feedback_no_autonomous_qa_merge / feedback_delegate_all_implementation）の規約と矛盾しない | 各 ADR / memory への参照を明記 | ✅ |
| AC4 | dogfood — 次の Dev Agent spawn で prompt 文字数が baseline 比 30% 以上削減 | post-merge 測定 | ⏳ |
| AC5 | 既存 PR 運用フロー regression なし | `gh pr checks` 全 green | （Ready 後確認） |

## 変更タイプ

- [x] refactor: リファクタリング

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`.claude/agents/dev-session.md`)

**影響を受ける画面・機能**: なし。Dev Agent spawn 時の prompt 構成にのみ影響。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 1862` 全 Step PASS**（push 後実行）
- [x] 追加・変更したテスト: **N/A** — `.md` 文書のみ
- [x] **新規 env / secret 追加時** (ADR-0006): **N/A**
- [x] **DynamoDB 実装変更時** (ADR-0010): **N/A**
- [x] **Critical バグ修正の場合** (ADR-0002): **N/A**

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs のみ）** — `.claude/agents/dev-session.md` 1 ファイルのみ。

## コード品質セルフレビュー (#1481)

- [x] **DRY**: spawn 側で繰り返していた共通制約を SSOT 化、メインセッションと dev-session.md の二重管理を解消
- [x] **YAGNI**: 4 軸（Git / 検証 / PR / 報告）に絞り、Issue 固有指示は引き続き spawn 側で記述
- [x] **Security**: 安全装置（ADR-0026 force push 禁止 / ADR-0030 pre-ready / ADR-0022 QM merge）はすべて新セクション内で参照
- [x] **A11y / Performance**: **N/A**

## 横展開・影響波及チェック

**並行実装ペア**: **N/A** — `.claude/agents/` 配下の単一ファイル

**LP / 販促文言変更時**: **N/A**

**並行 PR overlap** (#1200): 確認済み。`.claude/agents/dev-session.md` を同時期に変更する open PR は 0 件。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項**:
1. 「Dev Agent 共通制約」セクションが既存の `## やってはいけないこと` / `## Write tool 例外` セクションと重複していないか確認
2. dogfood で実際に prompt 文字数が削減されるかは post-merge で測定（次回 Dev Agent spawn 時）

## 配布済み env / secret (ADR-0006)

- [x] **N/A** — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 1862` 全 Step PASS** をローカル確認 (push 後実行)
- [x] セルフレビュー済み
- [x] 全 AC が実装済み（AC4 dogfood は post-merge）
- [x] UI 変更なし
- [x] 認証画面変更なし

## QM レビュー結果

QM が approve 時に記入。フォーマット: [docs/sessions/qa-session.md §「Tier 2 手順 5」](docs/sessions/qa-session.md) 参照。
