### PR TITLE
refactor: #1860 po-session.md 150→94 行スリム化 + Skill 双方向リンク化

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -3,6 +3,8 @@ name: Issue Triage
 description: Use when creating a new GitHub Issue. Forces Pre-PMF bias check, marketing/legal/finance/customer perspectives, and root cause analysis before submission.
 ---
 
+> **親 SSOT**: [PO Session — Goal 1](../../../docs/sessions/po-session.md) / **関連 Skill**: [LP Review (Goal 2)](../lp-review/SKILL.md)
+
 # Issue 起票フェーズゲート
 
 新しい Issue を起票する前に、以下の 6 ステップを順番に実行してください。

--- a/.claude/skills/lp-review/SKILL.md
+++ b/.claude/skills/lp-review/SKILL.md
@@ -3,6 +3,8 @@ name: LP Review
 description: Use when conducting LP (Landing Page) review rounds. Initializes templates for materials/findings/integration/issue-list, spawns 3 specialist agents in parallel, and enforces SSOT for PO screenshots. Replaces ad-hoc per-round file creation.
 ---
 
+> **親 SSOT**: [PO Session — Goal 2](../../../docs/sessions/po-session.md) / **関連 Skill**: [Issue Triage (Goal 1)](../issue-triage/SKILL.md)
+
 # LP レビューワークフロー
 
 LP (`site/**`) の re-review を行う際の 6 ステップ手順。各ラウンド開始時に `node .claude/skills/lp-review/scripts/init-round.mjs --round YYYY-MM-DD` でテンプレを `tmp/reviews/lp-YYYY-MM-DD/` に展開してから開始する。

--- a/docs/sessions/po-session.md
+++ b/docs/sessions/po-session.md
@@ -1,14 +1,12 @@
 # PO (プロダクトオーナー) セッション起動プロンプト
 
-> **目的**: あらゆる事業観点から Issue 作成・優先度付けを行い、事業採算性・成長性に責任を持つ
->
-> **SSOT**: ADR-0003（Issue 品質）/ ADR-0008（設計ポリシー先行確認）/ ADR-0010（Pre-PMF）/ ADR-0022（QM Approve 体制、Reviewer 越境検知）
+> **5 ロール**: PO / BA / Marketing / Legal / Persona ｜ **Goal 1**: Issue 起票 → [Skill: issue-triage](../../.claude/skills/issue-triage/SKILL.md) ｜ **Goal 2**: LP レビュー → [Skill: lp-review](../../.claude/skills/lp-review/SKILL.md) ｜ **Goal 3**: 優先度・事業判断 → 本ファイル
+> **目的**: 事業観点から Issue 作成・優先度付けを行い、事業採算性・成長性に責任を持つ
+> **SSOT**: ADR-0003（Issue 品質）/ ADR-0008（設計ポリシー）/ ADR-0010（Pre-PMF）/ ADR-0022（QM Approve）
 
-## 使い方
+## 5 ロール（PO 判断軸の SSOT）
 
-新セッションで以下を copy & paste。`[ここに...]` を実内容に置換:
-
----
+新セッションで以下を copy & paste（`[ここに...]` を実内容に置換）。各 Goal は Skill / ADR にリンク済み。
 
 ```
 あなたはプロダクトオーナー（PO）セッションの担当です。
@@ -23,126 +21,72 @@
 
 ## ミッション
 
-開発実装チーム（Dev セッション）と品質管理チーム（QA セッション）が**事業的に正しい行動をし続ける**ための、十分な意思入れと誰が読んでも同じ理解ができる Issue を作成する。
+開発実装チーム（Dev）と品質管理チーム（QA）が**事業的に正しい行動をし続ける**ための、十分な意思入れと誰が読んでも同じ理解ができる Issue を作成する。
 
-## 必ず守ること
+## Goal 1 (Issue 起票) — PO 特有判断軸
 
-### Issue 起票時の必須記載項目（顧客価値起点）
+詳細手順 → [Skill: issue-triage](../../.claude/skills/issue-triage/SKILL.md)。PO 固有:
 
-すべての Issue は本文に明記必須:
+- **本質目標宣言（Why、#1466）**: 「誰の / 何の問題を / どのような状態にすることで / 解決するか」を起票前に言語化（手段でなく目的）
+- **テンプレ選択**: 実装系 → `dev_ticket.yml` / PO 起票系 → `process_ticket.yml` (#1859)
+- **顧客価値 ABC**: A. 誰が / B. どんな状況で / C. 何を得るか
+- **本番動作**: `DATA_SOURCE=dynamodb` 相当で動作する状態を完了条件に。「土台提供」「follow-up で本実装」禁止
 
-#### A. 顧客価値の定義
-- **誰が** — 顧客 / 運営 / ops 担当者の具体的な誰か
-- **どんな状況で** — どんなタスク / どんな問題に直面しているとき
-- **何を得るか** — 完了するとその人は何ができるようになる / 何が見えるようになるか
+## Goal 2 (LP レビュー) — PO 統合判断
 
-例: 「ops 担当者は、不正利用が疑われる IP を確認するときに、/ops 画面で直近 10 分間の検証失敗回数上位を一覧できる」
+詳細手順 → [Skill: lp-review](../../.claude/skills/lp-review/SKILL.md)。PO 固有:
 
-#### B. 本番環境で「動く」とはどういう状態か
-- どの URL / 画面 / DynamoDB テーブル / ログ / メトリクスに何が出るべきか
-- 曖昧さのない**観測可能信号** (例: DynamoDB コンソールで OpsAuditLog に N 件 / CloudWatch Logs に `[AUDIT]` prefix)
+- **4 決定論点**: 3 専門 Agent (UI/UX / Consultant / PM) findings から方針判断必要論点を 4 件以下に集約
+- **no-touch-zones 整合**: Issue 起票計画が A-E 節を侵犯しないか確認（違反は ADR supersede が先）
+- **PO スクショ SSOT 化**: 各 Issue 本文は `materials/po-direct-findings.md` への 1 行リンクのみ。画像物理パス二重貼り禁止
 
-#### C. 完了判定基準（観測可能）
-- 本番環境（`DATA_SOURCE=dynamodb`）で動作する状態
-- 顧客 / 運営が**実際に見て確認できる**成果物
-- 証跡（SS / ログ / DynamoDB レコード）が提示可能
-
-### 「土台提供」「follow-up で本実装」原則禁止
-
-部分的に出して後で完成は **顧客価値ゼロの状態を本番に置く** ことに等しい。stub merge（型定義 / interface / テストのみ）は原則禁止。詳細は ADR-0003 / ADR-0005。
-
-### Issue 起票前のフェーズゲート
-
-順番に通す:
-
-1. **本質目標宣言（Why、#1466）** — 起票前に必ず以下形式で言語化:
-   ```
-   ## この Issue の本質目標（Why）
-   誰の / 何の問題を / どのような状態にすることで / 解決するか
-   ※ 手段（CI スクリプト追加・ファイル移行等）を書かない
-   ※ 「〜できるようになる」「〜が構造的に不可能になる」の形で書く
-   ```
-2. 根本原因特定（症状でなく原因、ADR-0003）
-3. **Pre-PMF バイアスチェック（ADR-0010）** — 課金・管理画面偏重 / Growth 欠落になっていないか
-4. マーケ/Growth 視点 — サインアップ 20 名/月（V2MOM Q2）への貢献度
-5. 法務/コンプラ視点 — 法的リスク
-6. 財務視点 — AWS コスト影響、事業計画原価枠 (`docs/design/12-事業計画書.md` Year 1 KPI)
-7. 仮想顧客レビュー — ペルソナ（3 歳児の親 / 小学生の親 / 中学生本人）の歓迎度
+## Goal 3 (優先度判断 / 事業判断)
 
 ### priority 判定基準
 
-| priority | 定義 |
-|---|---|
-| `critical` | 顧客 / 運営が明確に損害（不正検知不能 / 監査ログ欠損 / 課金ずれ / データ喪失） |
-| `high` | 顧客価値が劣化するが運用回避可能 |
-| `medium` | 顧客は気付かないが内部改善（DX / コードベース健全化） |
-| `low` | nice-to-have |
+- `critical`: 顧客 / 運営が明確に損害（不正検知不能 / 監査ログ欠損 / 課金ずれ / データ喪失）。**本番で動かない / 段階実装で途中までの状態も `critical` 扱い**
+- `high`: 顧客価値劣化、運用回避可能 / `medium`: 内部改善 (DX) / `low`: nice-to-have
 
-**重要**: 本番で動かない / 段階実装で途中までの状態は **顧客損害** = `critical`。
+### Pre-PMF バイアスチェック（ADR-0010）
 
-### PO が出す「OK」の質
+`type:feat` 新規起票時: 「サインアップ 20 名/月（V2MOM Q2）なしで到達できるか」自問。可 → `medium` 以下 / 不可 → `high` 以上で根拠明記。新規機能 Issue 連続時は Growth / Marketing / Activation を 1 本挟む。過剰防衛設計（汎用監査ログ / S3+Athena / WAF / IP ブルートフォース検知）追加禁止。
 
-- PR 本文の Test plan 全項目チェックを PO 確認 → ready for review → approve
-- 視覚変更は SS / 動画添付確認必須
-- 監査 / 認可 / 課金系は staging 実機証跡（DynamoDB / CloudWatch SS）要求
-- 「テスト通過」「設計書あり」だけで OK としない。**顧客が何を得たか**確認
+### Reviewer 越境検知（ADR-0022 / #1022）
 
-### Reviewer 越境検知（#1022 / ADR-0022）
+Reviewer が「Dev PR に直接 push」「rebase / SS 肩代わり」「scope 大幅変更」「勝手にマージ / close」した場合、PO が即時是正（Issue で Dev に修正依頼 / リソース制約は PO 調整 / 方針転換は PO 判断）。
 
-PO は Reviewer（QA セッション含む）が Dev 作業範囲に越境していないか監視:
+### 設計ポリシー合意（ADR-0008）
 
-| 越境パターン | 正しい対応 |
-|---|---|
-| Reviewer が Dev PR に直接 push / 修正 | Issue で Dev に修正依頼 |
-| Reviewer が rebase / SS を肩代わり | Dev のリソース制約は PO が調整 |
-| Reviewer が Dev 未同意で scope 大幅変更 | PO が方針決定し Issue で明示依頼 |
-| Reviewer が Dev 担当中の PR を勝手にマージ / close | PR close / 方針転換は PO 判断 |
+新テーブル / 新 interface / セキュリティ機能 / 課金変更 / AWS リソース追加 / 3 人日以上 → 着手前に PO 合意必須（「PO 設計承認済み」ラベル / ADR 先行起票 / Issue コメント明示同意）。
 
-### 設計ポリシー合意（ADR-0008、#1023）
+### PO の境界線・Issue 品質
 
-以下カテゴリの Issue 起票時、PO は設計ポリシー合意を明示:
+- 実装しない（Dev の仕事）/ AWS CLI で CDK 管理リソース直接変更しない / `aws ce get-*` 禁止（$0.01/回）/ テスト・CI を直接修正しない
+- 成果物なしで Issue close 禁止 / 「テスト通過」だけで完了承認しない（顧客価値の観測可能証跡確認）
+- 解決策 1 つに絞る（A or B 併記禁止）/ AC に全境界条件 / 再発問題はスクラップ&ビルド前提 / 同一領域過去 Issue 確認 / 本番動作を完了条件に
 
-新テーブル / 新スキーマ / 新 interface / セキュリティ機能 / 課金変更 / AWS リソース追加 / 3 人日以上の工数
+## 技術手順（HEREDOC 禁止 #1172）
 
-合意表明形式（いずれか）:
-- 「PO 設計承認済み」ラベル付与 / ADR 先行起票 + Issue リンク / Issue コメントで明示同意
-
-### 境界線（やってはいけないこと）
-
-- 実装しない（Dev セッションの仕事）/ AWS CLI で CDK 管理リソース直接変更しない
-- `aws ce get-*` 実行しない（$0.01/回、cost-audit.yml の月次レポート参照）
-- テスト・CI を直接修正しない（Dev/QA の責務）
-- 成果物なしで Issue を close しない / 「テスト通過」「設計書更新」だけで完了承認しない
-
-### Issue 品質基準
-
-- 解決策 1 つに絞る（「A or B」併記禁止）/ AC に全境界条件 / 設計上の制約明記
-- 再発問題はスクラップ&ビルド前提 / 同一領域過去 Issue 確認
-- 本番動作（`DATA_SOURCE=dynamodb`）を完了条件に / 顧客価値の明文化
-
-## 技術手順
-
-`gh issue create` の本文は **必ずファイル経由** (`--body-file`)。インライン HEREDOC は禁止 (#1172、bash の EOF 解釈失敗事故あり)。
+`gh issue create` の本文は **必ず `--body-file`**。インライン HEREDOC 禁止（bash の EOF 解釈失敗事故あり）。
 
 ```bash
-# 1. tmp/issue-bodies/<slug>.md に本文を書く
+# 1. tmp/issue-bodies/<slug>.md に本文を書く（Write tool 例外として許容、#1804）
 # 2. gh issue create --title "..." --label "..." --body-file tmp/issue-bodies/<slug>.md
 # 3. 起票成功確認後 rm tmp/issue-bodies/<slug>.md
 ```
-
-`tmp/` は `.gitignore` 対象。sub-agent 例外（#1804）: `tmp/issue-bodies/` / `tmp/pr-bodies/` への Write tool 使用は許容（report file ではないため）。
 
 ## 参照ドキュメント
 
 | ドキュメント | 用途 |
 |---|---|
+| [Skill: issue-triage](../../.claude/skills/issue-triage/SKILL.md) | Goal 1 詳細手順 |
+| [Skill: lp-review](../../.claude/skills/lp-review/SKILL.md) | Goal 2 詳細手順 |
 | `docs/design/12-事業計画書.md` | コスト・採算性判断 |
 | `docs/design/34-V2MOM.md` | 目標・優先度判断 |
 | `docs/design/11-ペルソナ設計.md` | ユーザー視点検討 |
 | `docs/design/33-ビジネスモデルキャンバス.md` | 事業構造判断 |
 | `.github/CLAUDE.md` | Issue 起票ルール / ラベル体系 |
-| ADR-0003 | Issue 品質 |
-| ADR-0010 | Pre-PMF 優先度判断 |
+| ADR-0003 / ADR-0010 / ADR-0022 | Issue 品質 / Pre-PMF / QM Approve |
 
 ## 今回の依頼
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: PO Orchestrator + Claude Code（PO セッション起動時）

**解決する課題**: #1857 で po-session.md を 231 → 150 行 (▲35%) に圧縮済みだが、当初目標 ≤100 には未達。さらに #1858 で `lp-review` Skill が新設されたため、Goal 1 (Issue 起票) / Goal 2 (LP レビュー) の手順詳細を Skill に SSOT 化することで二重管理を解消し、po-session.md は「Goal インデックス + PO 判断軸 SSOT」に純化できる。

**期待される効果**: 150 → 94 行 (▲37%)。Skill との双方向リンク化により、PO Orchestrator が「session.md → Skill → 詳細手順」を 1 ホップで到達可能に。

## 関連 Issue

closes #1860

関連: #1855 (PR template、merged) / #1856 (CLAUDE.md、merged) / #1857 (session.md、merged) / #1858 (lp-review Skill、merged) / #1859 (process_ticket.yml、merged) / #1862 (Dev Agent preamble、merged)

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 |
|----|-----|---------|------|
| AC1 | po-session.md ≤ 100 行 | `wc -l docs/sessions/po-session.md` | **94 行** ✅ |
| AC2 | 削除 → SSOT 移動先対応マップ | 本 PR 本文「## 削除 → SSOT 対応マップ」 | ✅ |
| AC3 | 各 Skill 冒頭 3 行に親 SSOT 参照 | `head -7 .claude/skills/{issue-triage,lp-review}/SKILL.md` | ✅ 両 SKILL.md に「親 SSOT: PO Session — Goal N」+「関連 Skill: ...」配置 |
| AC4 | po-session.md 冒頭 5 行に PO 5 ロール + Goal 一覧 + Skill リンク | `head -5 docs/sessions/po-session.md` | ✅ line 3 のブロッククォートに 5 ロール + 3 Goal + 2 Skill リンク全て見える |
| AC5 | 削除内容が消失していないことを SSOT 移動先で証明 | PR 本文の対応マップ + 本 PR は #1858 lp-review Skill / 既存 issue-triage Skill に SSOT があることを前提 | ✅ |
| AC6 | 既存 CI 破壊なし | `gh pr checks` 全 green | （Ready 後確認） |
| AC7 | dogfood — Skill 1 ホップで詳細到達 | post-merge | ⏳ |

## 変更タイプ

- [x] refactor: リファクタリング
- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] `docs/sessions/po-session.md` (150 → 94 行)
- [x] `.claude/skills/issue-triage/SKILL.md` (冒頭に親 SSOT 参照追加、+2 行)
- [x] `.claude/skills/lp-review/SKILL.md` (冒頭に親 SSOT 参照追加、+2 行)

**影響を受ける画面・機能**: なし。実装コード変更なし。PO セッション起動時の context 注入が ▲37% 削減 + 双方向リンクによる探索効率向上。

## 削除 → SSOT 対応マップ

### po-session.md (150 → 94 行)

| 削除 / 圧縮箇所 | 旧行数 | 移動先 SSOT |
|---|---:|---|
| Goal 1 (Issue 起票) 6 ステップ詳細 + フェーズゲート | ~30 | `.claude/skills/issue-triage/SKILL.md`（既存）+ po-session.md には PO 特有判断軸（Why 宣言 / テンプレ選択 / ABC / 本番動作）4 行のみ |
| Goal 2 (LP レビュー) workflow 詳細 | ~25 | `.claude/skills/lp-review/SKILL.md`（#1858 新設）+ po-session.md には PO 統合判断（4 決定論点 / no-touch-zones 整合 / SSOT 化）3 行のみ |
| priority 判定基準 4 行表 | 7 | 段落形式に圧縮（2 行） |
| Pre-PMF バイアスチェック詳細 | 8 | 1 段落に圧縮（2 行） |
| Reviewer 越境検知 4 行表 | 7 | 1 段落に圧縮（2 行） |
| 設計ポリシー合意（ADR-0008）カテゴリ表 | 9 | 1 段落に圧縮（1 行） |
| PO の境界線 / Issue 品質基準 各セクション | 12 | 統合段落に圧縮（3 行） |
| HEREDOC 禁止技術手順詳細解説 | 25 | コア手順 (3 行) のみ。詳細は `.github/CLAUDE.md` 参照 |
| 5 ロール詳細解説 | 50 | 維持（PO 判断軸 SSOT、コメント部のみ簡潔化） |

### Skill 双方向リンク追加

| ファイル | 追加内容 |
|---|---|
| `.claude/skills/issue-triage/SKILL.md` | 冒頭に「**親 SSOT**: [PO Session — Goal 1](../../../docs/sessions/po-session.md) / **関連 Skill**: [LP Review (Goal 2)](../lp-review/SKILL.md)」 |
| `.claude/skills/lp-review/SKILL.md` | 冒頭に「**親 SSOT**: [PO Session — Goal 2](../../../docs/sessions/po-session.md) / **関連 Skill**: [Issue Triage (Goal 1)](../issue-triage/SKILL.md)」 |

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 1869` 全 Step PASS**（push 後実行）
- [x] 追加・変更したテスト: **N/A** — `.md` 文書のみ
- [x] **新規 env / secret 追加時** (ADR-0006): **N/A**
- [x] **DynamoDB 実装変更時** (ADR-0010): **N/A**
- [x] **Critical バグ修正の場合** (ADR-0002): **N/A**

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs のみ）** — `.md` 3 ファイルの編集のみ。

## コード品質セルフレビュー (#1481)

- [x] **DRY**: po-session.md と Skill (issue-triage / lp-review) の二重管理を解消、Skill を SSOT 化
- [x] **YAGNI**: po-session.md は「PO 5 ロール + Goal インデックス + 判断軸」の核に純化
- [x] **Security**: 安全装置（PO 確認 / Pre-PMF バイアス / Reviewer 越境検知 / 設計ポリシー合意）は全て po-session.md または Skill 側に保持
- [x] **A11y / Performance**: **N/A**

## 横展開・影響波及チェック

**並行実装ペア**: **N/A** — `.md` 3 ファイルのみ

**LP / 販促文言変更時**: **N/A**

**並行 PR overlap** (#1200): 確認済み。`docs/sessions/po-session.md` / `.claude/skills/{issue-triage,lp-review}/SKILL.md` を同時期に変更する open PR は 0 件。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項**:
1. po-session.md 冒頭の Goal インデックスが PO Orchestrator にとって 1 ホップ到達できる構造か確認
2. Skill 双方向リンクが「session → Skill → ADR」探索チェーンを正しく確立できているか確認
3. Goal 3 (優先度判断 / 事業判断) を Skill 化しなかった判断（Skill 化するほど定型化されていない、Issue ごとの判断軸が必要）が妥当か確認
4. dogfood は post-merge の次回 PO 系作業 (LP review 4th round 等) で実施

## 配布済み env / secret (ADR-0006)

- [x] **N/A** — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 1869` 全 Step PASS** をローカル確認 (push 後実行)
- [x] セルフレビュー済み
- [x] 全 AC が実装済み（AC7 dogfood は post-merge）
- [x] UI 変更なし
- [x] 認証画面変更なし

## QM レビュー結果

QM が approve 時に記入。フォーマット: [docs/sessions/qa-session.md §「Tier 2 手順 5」](docs/sessions/qa-session.md) 参照。
