### PR TITLE
marketing: #1843 LP #guide StoryBrand Guide ブロック完全 revert (PO-N-1)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -477,7 +477,6 @@ UI に表示されるラベル・用語は `src/lib/domain/labels.ts` を Single
 | `BABY_HOME_LABELS` | const |  |
 | `ONBOARDING_LABELS` | const |  |
 | `LP_VERSUS_LABELS` | const |  |
-| `LP_GUIDE_LABELS` | const |  |
 | `LP_GROWTH_ROADMAP_LABELS` | const |  |
 | `LP_CORELOOP_LABELS` | const |  |
 | `CHILD_SHOP_LABELS` | const |  |

--- a/docs/design/lp-content-map.md
+++ b/docs/design/lp-content-map.md
@@ -255,39 +255,7 @@ LP 9 セクションを 4 トーンに分類し、各トーンに「規範のど
   - `h1` の `max-width` は 1200px、PC (≥1024px) では `font-size: 2.9rem` / `padding: 80px 24px 64px` に拡大
   - `hero-sub` は `max-width: 780px` / `font-size: 1.12rem` (PC のみ)
 
-#### [01b] StoryBrand Guide — なぜ「卒業」を成功と呼ぶのか（#1784）
-
-##### §1. 設計背景（why）
-
-PO-R-1（魅力伝わらない）の構造原因として「StoryBrand Guide（信頼できる導き手）が IA 上ほぼ不在」を解消するために、**Hero 直後・versus 直前**に Guide 専用のミニセクションを追加する。
-versus は Plan の役割（解決策の提示）を担うため、その前段で「なぜ私たちを信用してよいか」を明示しておかないと、比較表だけでは態度反転に必要な権威性が不足する。
-Pre-PMF（ADR-0010）で testimonial を出せない制約下でも、**設計哲学による credibility（Anti-engagement / コアターゲット / 家族限定）**は表明できる。これを 1 scrshot + 3 行で簡潔に表す。
-
-##### §2. 設計原則（rules）
-
-1. **Hero 直後・versus 直前に固定配置**: `[01] Hero` の終了直後・`[02] versus` の直前に挿入する（`<section id="guide">`）。
-2. **1 scrshot + 3 行に圧縮、追加要素禁止**: 3 つの設計哲学（Anti-engagement / コアターゲット / 家族限定）を Title + 1 文の Description で表現し、4 行以上に拡張しない。FAQ 寄りの細かい条項や testimonial 風の文章は本セクションに置かない。
-3. **CTA 非設置**: 本セクション内に CTA を配置しない（Hero / floating-cta / footer signup に集約（#1838 で旧 [09] 最終 CTA を削除））。`ctaVariants ≤ 3` 制限を侵食しない。
-4. **scrshot は実画面のみ**（ADR-0013 LP truth）: 「ポイントとカテゴリの可視化」を表す代表画面 (`feature-point-level{,-desktop}.webp`) を流用し、専用画像を新規撮影しない（撮影元 = `/demo/lower/home`）。
-5. **ラベル SSOT 準拠 (ADR-0009)**: 全文言は `LP_GUIDE_LABELS`（`src/lib/domain/labels.ts`）→ `site/shared-labels.js` 経由で `data-lp-key="guide.*"` で注入。本 HTML 内に日本語直書きを残さない。
-6. **メトリクス維持**: 本セクション追加で `mobileHeight ≤ 15000` / `desktopHeight ≤ 8000` / `forbiddenTerms = 0` / `ctaVariants ≤ 3` を維持する。
-
-##### §3. 仕様（what）
-
-- **配置**: `<section id="guide" class="section bg-white">` を `[01] Hero` 直後・`[02] versus` 直前に配置（`site/index.html` `LP-LANDMARK:guide`）
-- **H2**: 「なぜがんばりクエストは「卒業」を成功と呼ぶのか」（`data-lp-key="guide.sectionTitle"`）
-- **構造**: `.guide-grid > .guide-shot + .guide-points (ul > li.guide-point × 3)` の 2 カラム + 3 行構造（PC 横長 / モバイル縦積み）
-- **3 行内訳**:
-
-| Title | Description（1 文） |
-|------|-------------------|
-| 滞在時間を伸ばさない設計 | 連続ガチャや通知連打は採用しません。記録は数秒で終わるのが正しい使い方です。 |
-| 3-18 歳のコアターゲット | 年齢が上がるほど自分でペースを決められるよう、UI と機能が段階的に変わります。 |
-| 家族だけの閉じた空間 | 広告も他家庭との比較もありません。子供のがんばりは家族にしか見えません。 |
-
-- **scrshot**: `screenshots/feature-point-level{,-desktop}.webp`（撮影元 = `/demo/lower/home`、core-loop の aside scrshot と共有）
-- **CSS スタイル** (実装が SSOT — `site/index.html` `.guide-shot` 定義が一次情報): `#guide` は `padding:12px 16px` / PC (≥1024px) で `padding:12px 16px`。`.guide-grid` は PC (≥768px) で `0.9fr 1.6fr` 2 カラム、`.guide-shot` は `aspect-ratio:16/9` / max-height 120/140/150px (mobile/≥768px/≥1024px)。`.guide-point` は brand 色のグラデ背景 + brand-200 border
-- **同期対象**: `site/pamphlet.html` には現時点で本セクションを反映しない（pamphlet は evaluate モード用 / A4 印刷前提のため要約版を維持）
+> 注: 旧 [01b] StoryBrand Guide ブロック (#1784 で導入) は **#1843 で完全 revert** した。PO-N-1 指摘「タイトルと内容が乖離した一番上にくるセクション不適切」を受け、Hero 直後 30 秒離脱判断ゾーンに「理念」セクションを置く構成自体を不適切と判断。同じ訴求軸（Anti-engagement / 3-18 歳 / 家族限定）は trust + growth-roadmap で既に伝わるため情報欠落は発生しない。IA は Hero → versus 直行に戻した。
 
 #### [02] アナログ vs デジタル — シール帳・ホワイトボードと何が違うのか（#1597 ADR-0023 I5 / #1614 R10 / #1784 vc-digital scrshot 配置）
 

--- a/scripts/generate-lp-labels.mjs
+++ b/scripts/generate-lp-labels.mjs
@@ -167,8 +167,8 @@ function parseLabelsTs() {
 	// Phase 4 R9/R10 (#1613/#1614): 年齢別成長ロードマップ + アナログ vs デジタル
 	const lpVersusLabels = parseBlock(src, 'LP_VERSUS_LABELS');
 	const lpGrowthRoadmapLabels = parseBlock(src, 'LP_GROWTH_ROADMAP_LABELS');
-	// #1784: Hero 直後 StoryBrand Guide ブロック
-	const lpGuideLabels = parseBlock(src, 'LP_GUIDE_LABELS');
+	// 注: #1784 Hero 直後 StoryBrand Guide ブロック (LP_GUIDE_LABELS) は #1843 で完全 revert
+	//   PO-N-1 指摘で「タイトルと内容が乖離した一番上にくるセクション不適切」のため Hero → versus 直行に戻した
 	// Phase 5 R44 (#1650): pricing.html SSOT 同期
 	const lpPricingLabels = parseBlock(src, 'LP_PRICING_LABELS');
 	// 注: #1594 ADR-0023 I8 → ADR-0028 (#1713 R7) で LP の founder 直接相談セクションは削除済み。
@@ -206,7 +206,6 @@ function parseLabelsTs() {
 		lpLegalDisclaimerLabels,
 		lpVersusLabels,
 		lpGrowthRoadmapLabels,
-		lpGuideLabels,
 		lpPricingLabels,
 		lpLicenseKeyLabels,
 		lpFaqLabels,
@@ -271,7 +270,6 @@ function generateSharedLabelsJs() {
 		lpLegalDisclaimerLabels,
 		lpVersusLabels,
 		lpGrowthRoadmapLabels,
-		lpGuideLabels,
 		lpPricingLabels,
 		lpLicenseKeyLabels,
 		lpFaqLabels,
@@ -327,8 +325,7 @@ function generateSharedLabelsJs() {
 		legalDisclaimer: lpLegalDisclaimerLabels,
 		versus: lpVersusLabels,
 		growthRoadmap: lpGrowthRoadmapLabels,
-		// #1784: Hero 直後 StoryBrand Guide ブロック（site/index.html [01b] guide セクション）
-		guide: lpGuideLabels,
+		// 注: #1784 guide: lpGuideLabels は #1843 で完全 revert（PO-N-1 指摘で Hero → versus 直行へ復帰）
 		pricing: lpPricingLabels,
 		// 注: ADR-0028 (#1713 R7) で LP の founder 直接相談セクション削除 → #1772 で namespace 完全撤去
 		licenseKey: lpLicenseKeyLabels,

--- a/site/index.html
+++ b/site/index.html
@@ -330,31 +330,6 @@
   .versus-shot{max-height:90px}
 }
 
-/* #1784: StoryBrand Guide ブロック (Hero 直後 / versus 直前) — 1 scrshot + 3 points
-   PC では scrshot 左 + 3 points 右の左右 2 column にして高さを抑え、desktopHeight ≤ 8000 を侵食しない */
-#guide{padding:10px 16px}
-.guide-inner{max-width:1280px;margin:0 auto}
-#guide .section-title{font-size:1.15rem;margin-bottom:2px}
-#guide .section-desc{font-size:.8rem;margin-bottom:6px;line-height:1.5}
-.guide-grid{display:grid;grid-template-columns:1fr;gap:6px;align-items:stretch}
-.guide-shot{border-radius:var(--radius);overflow:hidden;background:#fff;border:1px solid var(--brand-200);box-shadow:0 2px 8px rgba(0,0,0,.06);aspect-ratio:16/9;max-height:120px}
-.guide-shot picture,.guide-shot img{width:100%;height:100%;display:block;object-fit:cover;object-position:top center}
-.guide-points{list-style:none;padding:0;margin:0;display:grid;gap:4px}
-.guide-point{background:linear-gradient(135deg,var(--brand-50) 0%,#fef9e7 100%);border:1px solid var(--brand-200);border-radius:var(--radius);padding:5px 10px}
-.guide-point h3{font-size:.8rem;font-weight:700;color:var(--brand-700);margin:0 0 1px;line-height:1.3}
-.guide-point p{font-size:.7rem;color:var(--gray-700);margin:0;line-height:1.4}
-@media(min-width:768px){
-  .guide-grid{grid-template-columns:0.9fr 1.6fr;gap:12px;align-items:center}
-  .guide-shot{max-height:140px}
-}
-@media(min-width:1024px){
-  #guide{padding:12px 16px}
-  #guide .section-title{font-size:1.3rem}
-  .guide-shot{max-height:150px}
-  .guide-point h3{font-size:.86rem}
-  .guide-point p{font-size:.76rem}
-}
-
 /* Trust badges (#1620 R16: PC 4 列化、モバイル 2×2 維持) */
 .trust-badges{display:grid;grid-template-columns:repeat(2,1fr);gap:20px;max-width:900px;margin:0 auto}
 @media(max-width:640px){.trust-badges{gap:12px}}
@@ -548,41 +523,6 @@
   </div>
 </section>
 <!-- LP-LANDMARK:hero end -->
-
-<!-- LP-LANDMARK:guide start — #1784 StoryBrand Guide（信頼できる導き手）ブロック
-     Hero 直後・versus 直前に配置し、「なぜがんばりクエストを信用してよいか」を 1 scrshot + 3 行で訴求
-     ADR-0010 (Pre-PMF) / ADR-0012 (Anti-engagement) / ADR-0013 (LP truth) と整合
-     設計書: docs/design/lp-content-map.md §[01b] guide -->
-<!-- [01b] StoryBrand Guide — なぜがんばりクエストは「卒業」を成功と呼ぶのか -->
-<section class="section bg-white" id="guide" data-testid="guide-section">
-  <div class="section-inner guide-inner">
-    <h2 class="section-title" data-lp-key="guide.sectionTitle">なぜがんばりクエストは「卒業」を成功と呼ぶのか</h2>
-    <p class="section-desc" data-lp-key="guide.sectionDesc">長く使ってもらうためのアプリではなく、子供が自律したら卒業するアプリとして設計しています。</p>
-    <div class="guide-grid">
-      <div class="guide-shot">
-        <picture>
-          <source srcset="screenshots/feature-point-level-desktop.webp" media="(min-width:1024px)" type="image/webp">
-          <img src="screenshots/feature-point-level.webp" alt="がんばりクエストの代表画面 — ポイントとカテゴリの可視化" loading="lazy" data-lightbox>
-        </picture>
-      </div>
-      <ul class="guide-points">
-        <li class="guide-point">
-          <h3 data-lp-key="guide.pointAntiEngagementTitle">滞在時間を伸ばさない設計</h3>
-          <p data-lp-key="guide.pointAntiEngagementDesc">連続演出や通知連打は採用しません。記録は数秒で終わるのが正しい使い方です。</p>
-        </li>
-        <li class="guide-point">
-          <h3 data-lp-key="guide.pointCoreTargetTitle">3-18 歳のコアターゲット</h3>
-          <p data-lp-key="guide.pointCoreTargetDesc">年齢が上がるほど自分でペースを決められるよう、UI と機能が段階的に変わります。</p>
-        </li>
-        <li class="guide-point">
-          <h3 data-lp-key="guide.pointFamilyOnlyTitle">家族だけの閉じた空間</h3>
-          <p data-lp-key="guide.pointFamilyOnlyDesc">広告も他家庭との比較もありません。子供のがんばりは家族にしか見えません。</p>
-        </li>
-      </ul>
-    </div>
-  </div>
-</section>
-<!-- LP-LANDMARK:guide end -->
 
 <!-- LP-LANDMARK:versus start — シール帳・ホワイトボードでもいいんじゃない？に対する優位訴求 (#1614 R10)
      親 P1 が「30 秒で離脱判断」する直前に「アナログでは届かない 5 つの差」を比較表で提示

--- a/site/shared-labels.js
+++ b/site/shared-labels.js
@@ -245,17 +245,6 @@
 			"seniorShotAlt": "高校生ホーム画面 — 15 年分のログと進路素材",
 			"graduateShotAlt": "卒業画面 — 履歴エクスポートと家族の手元に残す記録"
 		},
-		"guide": {
-			"sectionTitle": "なぜがんばりクエストは「卒業」を成功と呼ぶのか",
-			"sectionDesc": "長く使ってもらうためのアプリではなく、子供が自律したら卒業するアプリとして設計しています。",
-			"pointAntiEngagementTitle": "滞在時間を伸ばさない設計",
-			"pointAntiEngagementDesc": "連続演出や通知連打は採用しません。記録は数秒で終わるのが正しい使い方です。",
-			"pointCoreTargetTitle": "3-18 歳のコアターゲット",
-			"pointCoreTargetDesc": "年齢が上がるほど自分でペースを決められるよう、UI と機能が段階的に変わります。",
-			"pointFamilyOnlyTitle": "家族だけの閉じた空間",
-			"pointFamilyOnlyDesc": "広告も他家庭との比較もありません。子供のがんばりは家族にしか見えません。",
-			"shotAlt": "がんばりクエストの代表画面 — ポイントとカテゴリの可視化"
-		},
 		"pricing": {
 			"pageTitle": "料金プラン - がんばりクエスト",
 			"metaDescription": "がんばりクエストの料金プラン。基本無料で始められます。スタンダード月額500円（税込）、ファミリー月額780円（税込）。すべての有料プランに7日間の無料体験付き。",

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4327,28 +4327,6 @@ export const LP_VERSUS_LABELS = {
 } as const;
 
 // ============================================================
-// LP Hero 直後 StoryBrand Guide ブロック — #1784
-// 「なぜがんばりクエストは『卒業』を成功と呼ぶのか」を 1 scrshot + 3 行で訴求
-// StoryBrand 7 要素の Guide（信頼できる導き手）に該当
-// SSOT: site/index.html [01b] guide セクション用ラベル
-// ============================================================
-
-export const LP_GUIDE_LABELS = {
-	sectionTitle: 'なぜがんばりクエストは「卒業」を成功と呼ぶのか',
-	sectionDesc:
-		'長く使ってもらうためのアプリではなく、子供が自律したら卒業するアプリとして設計しています。',
-	pointAntiEngagementTitle: '滞在時間を伸ばさない設計',
-	pointAntiEngagementDesc:
-		'連続演出や通知連打は採用しません。記録は数秒で終わるのが正しい使い方です。',
-	pointCoreTargetTitle: '3-18 歳のコアターゲット',
-	pointCoreTargetDesc:
-		'年齢が上がるほど自分でペースを決められるよう、UI と機能が段階的に変わります。',
-	pointFamilyOnlyTitle: '家族だけの閉じた空間',
-	pointFamilyOnlyDesc: '広告も他家庭との比較もありません。子供のがんばりは家族にしか見えません。',
-	shotAlt: 'がんばりクエストの代表画面 — ポイントとカテゴリの可視化',
-} as const;
-
-// ============================================================
 // LP [05b] 年齢別成長ロードマップ — 卒業を最終地点に (#1613 R9)
 // StoryBrand 7 要素「Success」と整合
 // SSOT: site/index.html [05b] セクション用ラベル


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: LP 訪問者（保護者 P1、35 歳共働き）

**解決する課題**: PR #1826 で導入した Hero 直後 StoryBrand Guide ブロック（`<section id="guide">`）が、PO-N-1（`tmp/reviews/lp-2026-05-02/materials/po-direct-findings.md`）で「タイトルと内容が乖離した一番上にくるセクション不適切」と指摘された。Hero 直後の 30 秒離脱判断ゾーンに「なぜがんばりクエストは『卒業』を成功と呼ぶのか」という問いかけ系タイトルの理念セクションを置く構成自体が、押し売り感を生み態度反転を阻害していた。

**期待される効果**: Hero → versus 直行の従来 IA に戻すことで、親 P1 が hero でファーストインプレッションを得た直後に「シール帳・ホワイトボードと何が違うのか」という具体的な比較訴求 (`#versus`) で離脱の臨界点を突破できる。同じ訴求軸（Anti-engagement / 3-18 歳コアターゲット / 家族限定）は trust + growth-roadmap で既に伝わっており情報欠落は発生しない。

## 関連 Issue

closes #1843

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | PR scrshot に修正前と修正後の本番 LP 同セクションを並記 | Before: PO 添付の本番 LP SS / After: 本 PR で撮影した fullpage SS | PASS — 下記「スクリーンショット / ビジュアルデモ」§ に Before/After mobile/desktop 4 スロット添付 |
| AC2 | `grep -rn 'data-lp-key="guide\.' site/` → 0 件 | `grep` コマンド | PASS — 0 件 (出力空) |
| AC3 | `grep -rn '"guide"\s*:' site/shared-labels.js` → 0 件 | `grep` コマンド | PASS — 0 件 (出力空) |
| AC4 | `grep -rn 'id="guide"\|guide-grid\|guide-points\|guide-point\|guide-shot\|guide-inner' site/` → 0 件 | `grep -rnE` コマンド | PASS — 0 件 (出力空) |
| AC5 | `node scripts/measure-lp-dimensions.mjs` で desktopHeight が PR #1836 の許容範囲内 | `node scripts/measure-lp-dimensions.mjs` 実行 | PASS — desktopHeight=6723 ≤ 8000 (warn 帯 7800 も下回り、`#guide` 削減で約 1235px 改善 = 7958 → 6723) / mobileHeight=10741 ≤ 15000 / forbiddenTerms 全 0 / ctaVariants 3 種維持 |
| AC6 | `playwright test tests/e2e/lp-fullpage.spec.ts` 全 pass（fullpage 撮影が壊れていないこと） | `lp-fullpage.spec.ts` は実体不在のため LP 描画系 spec で代替: `lp-first-view` + `lp-innerhtml-structure` + `lp-copy-layout` を tablet project で実行 | PASS — 14 spec 全 pass |
| AC7 | no-touch-zones (#hero / #age-panel / #pricing / #trust / #cta-bottom / #soft-features 構造 / #faq / header / footer) が変更されていないこと | `git diff site/index.html` で該当 id / `<header` / `<footer` 行の変更有無を確認 | PASS — 該当行の `+/-` diff 0 件、`#guide` 削除のみで no-touch-zones 一切変更なし |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [x] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`) — `LP_GUIDE_LABELS` export 削除のみ
- [ ] インフラ (`infra/`)
- [x] LP サイト (`site/`) — `<section id="guide">` + 関連 CSS + shared-labels.js guide ブロック削除
- [x] 設定・CI (`scripts/generate-lp-labels.mjs`) — `lpGuideLabels` 3 箇所参照削除

**影響を受ける画面・機能**:
- LP `site/index.html` の Hero 直後セクション（`#guide` 削除 → `#versus` 直行）
- 設計書 `docs/design/lp-content-map.md` §[01b] guide 節（削除 + 削除理由を注記化）
- 自動生成 `docs/DESIGN.md` §6 用語辞書（`LP_GUIDE_LABELS` 行が削除）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — Ready 前に実行（後述）
- [x] 追加・変更したテストの概要: N/A（revert タスクのため新規テスト不要。既存 LP 系 E2E 14 件で破壊なしを確認）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high の refactor、bug fix ではない）

### 個別テスト結果

| テスト種別 | コマンド | 結果 |
|-----------|---------|------|
| Lint | `npx biome check .` | PASS — 1290 files checked, 0 fixes |
| 型チェック | `npx svelte-check` | PASS — 0 errors / 13 warnings (既存 +page.svelte の preexisting) |
| 単体テスト | `npx vitest run` | PASS — 4384 tests passed (229 files) |
| E2E (LP 系) | `npx playwright test tests/e2e/lp-first-view.spec.ts tests/e2e/lp-innerhtml-structure.spec.ts tests/e2e/lp-copy-layout.spec.ts --project=tablet` | PASS — 14 tests passed |
| LP メトリクス | `node scripts/measure-lp-dimensions.mjs` | PASS — mobile=10741 / desktop=6723 / forbiddenTerms 全 0 / ctaVariants=3 |
| Hardcoded JP | `node scripts/check-hardcoded-strings.mjs` | PASS — 0 violations (baseline 0) |
| Plan literals | `node scripts/check-no-plan-literals.mjs` | PASS — リテラル直書きなし |
| LP residue | `node scripts/check-lp-removal-residue.mjs` | PASS — 新規残骸 0 件 (baseline 19 件と同等) |

## スクリーンショット / ビジュアルデモ

UI 変更（LP セクション削除）のため Before/After 4 スロット添付。撮影は `scripts/capture.mjs --pr 1843 --server-mode lp --url /index.html --presets mobile,desktop --full-page` で実施し、SS と DOM スナップショットを同一 page で取得（#1747 AC4 / #1766）。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** (本番 LP / `#guide` 存在時) | PO 添付: `tmp/reviews/user_capture/スクリーンショット 2026-05-02 163231.png`（PO 環境スクショ、Hero 直後に青い 3 ポイントカード `#guide` がある状態） | 同左 |
| **修正後** (本 PR / Hero → versus 直行) | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1843/index-html.png) [DOM HTML](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1843/index-html.dom.html) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1843/index-html-desktop.webp) [DOM HTML](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1843/index-html-desktop.dom.html) |

**修正後 SS の確認ポイント**:
- Hero 終了直後（タイトル「『やりなさい』を『やりたい！』に変える家族 RPG」直下）に、青い 3 ポイントカード `#guide` が **存在しない**
- そのまま `#versus`（シール帳・ホワイトボードと何が違うのか比較表）へ直行している
- DOM HTML L523-530 で `LP-LANDMARK:hero end` → `LP-LANDMARK:versus start` → `<section id="versus">` の隣接を構造的に確認

**修正前 SS について**: PO-N-1 添付の `tmp/reviews/user_capture/スクリーンショット 2026-05-02 163231.png` が Issue body で参照されており、Hero 直後に「なぜがんばりクエストは『卒業』を成功と呼ぶのか」見出し + 1 scrshot + 3 ポイント（青グラデ背景）が表示されている本番 LP の状態を示す。本 PR では同セクションを完全に削除した状態を撮影しており、Before/After の対比が成立する。

**インタラクティブ状態**: N/A（インタラクションなしの静的セクション削除）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 / 依存性逆転 / インターフェース分離 — `LP_GUIDE_LABELS` 単独 export を削除しただけで、他層への影響なし
- [x] **DRY**: 同一ロジックの他箇所残存なし — `grep` で `LP_GUIDE_LABELS` / `lpGuideLabels` / `guide.section` / `guide.point` / `id="guide"` / `guide-*` class を全件確認、site/ 内に 0 件 + scripts/generate-lp-labels.mjs に revert 注記コメント 2 件のみ残存
- [x] **YAGNI**: 不要な抽象化を追加していない（純粋な削除）
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A（セクション削除のみ、a11y 変化なし）
- [x] **パフォーマンス**: バンドルサイズ削減（labels.ts 22 行 + shared-labels.js 11 行 + HTML 27 行 + CSS 21 行削減）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — N/A（LP のみ）
- [x] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: 削除のみのため新規 Aspirational 文言なし。同じ訴求軸（Anti-engagement / 3-18 歳 / 家族限定）は trust badges + growth-roadmap で既に伝わっているため情報欠落なし
- [x] 全年齢モード 5 種に横展開 — N/A（LP）
- [x] ナビゲーション 3 種に反映 — N/A（LP）
- [x] E2E / ユニットシード + チュートリアル同期 — N/A（DB 変更なし）
- [x] **labels SSOT** (ADR-0009): `LP_GUIDE_LABELS` を `src/lib/domain/labels.ts` から削除し、`scripts/generate-lp-labels.mjs` で `site/shared-labels.js` を再生成。手動編集差分と自動生成差分の完全一致を `git diff` で確認
- [x] **設計書同期** (ADR-0001): `docs/design/lp-content-map.md` §[01b] guide 節を本 PR 内で削除（別 Issue 切出し禁止のルール準拠）+ 削除理由を注記として残す + 自動生成 `docs/DESIGN.md` §6 から `LP_GUIDE_LABELS` 行も同期削除（`scripts/generate-design-md-sections.mjs` 実行）
- [x] **並行 PR overlap** (#1200): 本 PR が変更するファイル (`site/index.html` / `site/shared-labels.js` / `src/lib/domain/labels.ts` / `docs/design/lp-content-map.md` / `scripts/generate-lp-labels.mjs` / `docs/DESIGN.md`) の同時期 open PR は無し

**LP / 販促文言変更時** (ADR-0013 / #1314):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| 「滞在時間を伸ばさない設計」「3-18 歳のコアターゲット」「家族だけの閉じた空間」3 ポイント文言 | 削除 — 同じ訴求軸は trust badges (`site/index.html` `#trust` 4 badges) と growth-roadmap (`site/index.html` `#growth-roadmap` 5 stages) で継続訴求 | N/A（削除のため Committed/Aspirational 区分対象外） |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
- 削除のみの最小変更（+4 / -133 行）。`#guide` セクションが完全消滅し Hero → versus 直行の従来 IA に戻ったことを SS 4 スロットと DOM HTML で確認できる
- `LP_GUIDE_LABELS` を labels.ts から削除しても、`shared-labels.js` を再生成した結果は手動編集と完全一致 (11 行削減)。SSOT chain の整合は維持
- desktopHeight=6723 は #1840 累積 desktopHeight gate (warn 7800 / fail 8000) を大幅に下回るため、main rebase 後の累積測定でも問題は出ない見込み

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカルで確認済み（biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / pr-body の 6 step すべて PASS、後続 step で `gh pr ready` 実施）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1-7 全項目検証マップで PASS）
- [x] Phase 分割なし（1 PR 完結、最小 revert）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認（hex 直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / `<style>` 50 行超 — 全て削除のみで新規違反 0）
- [x] 認証画面変更なし（LP のみ）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
