### PR TITLE
design: #1846 LP #machine-tour grid 4 列 → 2 列修正 + 中央寄せ (PO-N-4)

### DIFF
--- a/docs/design/lp-content-map.md
+++ b/docs/design/lp-content-map.md
@@ -352,12 +352,13 @@ ADR-0013 LP 実装 SSOT（Committed のみ訴求）/ ADR-0012 Anti-engagement（
 > #1629 R25 で「コンボ」「ゲーミフィケーション全開」「変動比率」「射幸」「メタ層」「シールくじ」は禁止語彙とし `scripts/measure-lp-dimensions.mjs` の FORBIDDEN_TERMS で CI 検出（#1637 R34 で TARGET_HTML 配列化）。
 > #1708 R3-A で旧ルーチン-CL の語彙も `FORBIDDEN_TERMS` に追加（旧ルーチン枠廃止に伴う再発防止）。
 
-**PC 横長レイアウト** (#1618 R14 / Phase 5 P2):
+**PC 横長レイアウト** (#1618 R14 / Phase 5 P2 → #1846 PO-N-4 で 2 列中央配置に是正):
 
-- 1024px+ で `grid-template-columns: repeat(4, 1fr)` の 4 列固定 + `grid-auto-rows: 1fr` で行高を揃える（4+1 半端配置を排除）
-- 画像有無で高さがバラつかないよう `tour-shot` / `tour-shot-placeholder` ともに `min-height: 200px`、`tour-card` は `min-height: 480px`
-- 1440px+ では `max-width: 1320px` / `gap: 24px` に拡張しゆとりを確保
-- mobile (<1024px) は `grid-template-columns: repeat(auto-fit, minmax(240px, 1fr))` で 1〜2 列フルード
+- 1024px+ で `grid-template-columns: repeat(2, 1fr)` の 2 列 + `grid-auto-rows: 1fr` で行高を揃える + `max-width: 960px; margin-inline: auto` で中央寄せ
+  - 旧 `repeat(4, 1fr)` 4 列固定は PR #1812（実績削除）/ #1827（スタンプ移動）で 2 cards 化したあとの残骸として左寄り表示を引き起こしていたため #1846 で是正
+- 画像有無で高さがバラつかないよう `tour-shot` / `tour-shot-placeholder` ともに `min-height: 200px`、`tour-card` は `min-height: 480px`（1024px+ では `min-height: 520px`）
+- 1440px+ では `max-width: 1320px` / `gap: 24px` に拡張しゆとりを確保（2 列でも横幅を活用）
+- mobile (<1024px) は `grid-template-columns: repeat(auto-fit, minmax(240px, 1fr))` で 1〜2 列フルード（mobile 縦積み / tablet 横並び）
 
 #### [05] ソフト機能（親の安心）— 3 カード構成（#1720 R4 で 4→3 圧縮、月次レポート featured 凸構成）
 

--- a/site/index.html
+++ b/site/index.html
@@ -231,8 +231,8 @@
 .tour-card .tour-benefit{font-size:.82rem;color:var(--gray-700);margin-top:8px;line-height:1.5}
 .tour-card .tour-benefit strong{color:var(--brand-700)}
 @media(min-width:1024px){
-  /* PC 整然配置 (#1618 R14 / Phase 5 P2): 4 列固定で半端なし、grid-auto-rows で行高を揃える */
-  .machine-tour{grid-template-columns:repeat(4,1fr);gap:20px;grid-auto-rows:1fr}
+  /* PC 整然配置 (#1846 PO-N-4): 2 列で中央配置、grid-auto-rows で行高を揃える (PR #1812 / #1827 で 2 cards 化した残骸 4 列を是正) */
+  .machine-tour{grid-template-columns:repeat(2,1fr);gap:20px;grid-auto-rows:1fr;max-width:960px;margin-inline:auto}
   .tour-card{min-height:520px;padding:24px 22px}
   /* #1799 U-MIN-3: scrshot 高さを 200px → 280px (1.4 倍) に拡大。
      画像 alt と aspect-ratio (390/844) は維持し、card min-height も 480→520px に拡張 */


### PR DESCRIPTION
## 顧客価値・目的

LP 訪問者が `#machine-tour` セクションを見たとき、PC（1024px+）で 2 cards が **4 列 grid の左寄せ表示**になり、右半分が空白で「整然と機構を語っている感」が削がれていた。`repeat(4,1fr)` を `repeat(2,1fr)` + `max-width:960px;margin-inline:auto` に修正することで、2 cards を**左右対称・中央寄せ**で配置し直し、Phase 5 の補足機構訴求の視覚的整いを回復する。

**対象ユーザー**: LP 訪問者（未サインアップ、PC 1024px 以上）

**解決する課題**:
- PR #1812（実績削除）/ #1827（スタンプ移動）で 4 cards → 2 cards に減少した後、grid 4 列定義が**残骸として放置**されていた
- 2 cards × 4 列 grid = 左 2 列に寄った layout、右 2 列分が空白という視覚的バグ
- PO スクショ（`tmp/reviews/user_capture/スクリーンショット 2026-05-02 163557.png`）で PO-N-4 として直接指摘

**期待される効果**:
- PC 視聴体験で「補足機構が左右対称に整然と並ぶ」見え方を確保
- 4 cards 復活時は 4 列に戻すのではなく cards を増やす方が正解、という設計意図を SSOT (`lp-content-map.md`) で明示

## 関連 Issue

closes #1846

## AC 検証マップ (ADR-0004)

| # | AC | 達成方法 | 結果 |
|---|---|---|---|
| AC1 | PR scrshot に修正前と修正後の本番 LP `#machine-tour` セクション並記（PC 1280px 幅） | Before SS は Issue body 添付の `tmp/reviews/user_capture/スクリーンショット 2026-05-02 163557.png`（PO 撮影、本リポジトリ未コミットのため SS スロットは「修正後」のみ。修正前イメージは Issue 本文参照） / After SS は本 PR 「スクリーンショット」セクション参照 | ✓ |
| AC2 | `grep -n 'grid-template-columns:repeat(4,1fr)' site/index.html` のうち `.machine-tour` 文脈が 0 件 | `grep` 実行: machine-tour 文脈で 0 件、残った 1 件は L337 `.trust-badges{...}` 文脈（別セクション） | ✓ |
| AC3 | `grep -n 'grid-template-columns:repeat(2,1fr)' site/index.html` のうち `.machine-tour` 文脈で 1 件以上 | `grep` 実行: L235 `.machine-tour{grid-template-columns:repeat(2,1fr);...}` で 1 件 | ✓ |
| AC4 | PC 1280px 幅で 2 cards が左右対称・中央寄せで配置 | `index-html-desktop.png` で目視確認: 2 cards が `max-width:960px;margin-inline:auto` により中央寄せ、grid 1:1 で左右対称 | ✓ |
| AC5 | mobile（375px）で 2 cards が縦積み | `index-html-mobile.png` で目視確認: base CSS `repeat(auto-fit,minmax(240px,1fr))` が機能して 1 列縦積み | ✓ |
| AC6 | tablet（768px）で 2 cards が横並び | `index-html.png` (tablet preset) で目視確認: 2 cards 横並び、`auto-fit minmax(240px,1fr)` が機能 | ✓ |
| AC7 | no-touch-zones セクション (#hero / #age-panel / #pricing / #trust / #cta-bottom / #soft-features 構造 / #faq / header / footer) が変更されていない | `git diff site/index.html` 結果: `@media(min-width:1024px){.machine-tour{...}}` 1 行のコメント文 + CSS rule 1 行のみ変更（合計 -1/+1）。他セクション完全不変 | ✓ |
| AC8 | `tour-card` の `min-height:520px` 等の他のスタイルは変更しない | `git diff` で `.tour-card{min-height:520px;padding:24px 22px}` 行は無変更 | ✓ |

## 変更タイプ

- [x] type:fix (バグ修正)
- [x] type:design (デザイン・UI 改善)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] LP サイト (`site/index.html` L233-235)
- [ ] pricing page
- [ ] `plan-features.ts`
- [ ] `pricing-strategy.md`
- [x] `docs/design/lp-content-map.md` L355-360（ADR-0001 設計書同期: PC 横長レイアウト仕様の SSOT 更新）

**影響を受ける画面・機能**: `site/index.html` `#machine-tour` セクションのみ。faq.html / pricing.html / pamphlet.html は影響なし（`.machine-tour` セレクタは index.html 専用）。

## LP メトリクス結果（必須）

| 指標 | 閾値 | 本 PR の値 | 結果 |
|---|---:|---:|---|
| `mobileHeight` | ≤ 15000 px | 10741 | PASS |
| `desktopHeight` | ≤ 8000 px | 6663 | PASS |
| `desktopHeight` (warn) | ≤ 7800 px | 6663 | PASS（警告帯外） |
| `forbiddenTerms` | 0 | 0 | PASS |
| `ctaVariants` | ≤ 3 | 3（無料で始める / ログイン / デモを見る） | PASS |
| `presetActivityCountClaimed` | ≥ 300 | 300（実数 325） | PASS |
| `lp-removal-residue` | 新規 0 | warnings=[] | PASS |

実行コマンド: `node scripts/measure-lp-dimensions.mjs` → `[OK] all LP metrics within thresholds`

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 1876` 全 Step PASS**（Step 1 biome / Step 2 svelte-check / Step 3 vitest 4401 tests / Step 4 hardcoded-strings 0 / Step 5 lp-dimensions all within thresholds / Step 6 check-pr-body / Step 7）
- [x] LP E2E 3 spec PASS: `npm run test:e2e -- lp-first-view lp-innerhtml-structure lp-copy-layout` → **477 passed (6.7m)** (exit 0)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [ ] **DynamoDB 実装変更時**: N/A
- [ ] **Critical バグ修正の場合**: N/A（priority:medium）

## スクリーンショット / ビジュアルデモ

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1280px) |
|---|---|---|
| **修正前** | (Issue body PO 撮影 SS 参照: `tmp/reviews/user_capture/スクリーンショット 2026-05-02 163557.png`、リポジトリ未コミット) | 同左 |
| **修正後** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1846/index-html-mobile.png) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1846/index-html-desktop.png) |

**追加: tablet (768px) After SS** — ![after-tablet](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1846/index-html.png)

**修正後の視覚状態**:
- **PC (1280px)**: 2 cards が `max-width:960px;margin-inline:auto` で中央寄せ、grid 1:1 で左右対称配置（AC4 達成）
- **Mobile (375px)**: base CSS の `repeat(auto-fit,minmax(240px,1fr))` で 1 列縦積み（AC5 達成）
- **Tablet (768px)**: 2 cards 横並び、`auto-fit minmax(240px,1fr)` 機能（AC6 達成）

**インタラクティブ状態**: N/A（grid layout のみの変更、interactive 要素なし）

## コード品質セルフレビュー (#1481)

- [x] **DRY**: `.machine-tour` セレクタは `site/index.html` のみ存在（faq.html / pricing.html / pamphlet.html / shared.css に重複なし、grep 確認済）
- [x] **YAGNI**: 最小変更（diff -1/+1 行）。`max-width:960px` は 2 列 + 中央寄せに必要な最小限の追加のみ
- [x] **Security**: CSS のみの変更、`innerHTML` 注入なし
- [x] **アクセシビリティ**: 見出し階層・alt・コントラスト不変（HTML 構造に変更なし）
- [x] **パフォーマンス**: CSS 1 行追加のみ、bundle size / 描画コストへの影響なし

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] LP ↔ アプリ双方向整合（ADR-0013 LP truth）: 本変更は CSS layout のみ、文言や機能訴求の追加削除なし、Aspirational 記載の追加なし
- [x] labels SSOT (ADR-0009): 文言変更なし
- [x] 設計書同期: `docs/design/lp-content-map.md` L355-360 「PC 横長レイアウト」セクションの 4 列定義を 2 列+中央寄せに更新、PR #1812 / #1827 由来の残骸であることを明記（ADR-0001 同期完了）
- [x] 並行 PR overlap 確認 (#1200): 本 PR の変更範囲 `site/index.html` L233-235 + `lp-content-map.md` L355-360 は、現在 Ready 状態の 4 PR (#1872 / #1873 / #1874 / #1875) の変更範囲と完全非重複。main から派生で衝突なし

**LP / 販促文言変更時** (ADR-0013): N/A（layout のみ、文言変更なし）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → URL 変更・SEO 影響を以下に記載

**レビュー依頼事項・QA**:
- LP `#machine-tour` セクションが PC で**左右対称・中央寄せ**になっているか SS で確認
- mobile / tablet で破綻していないか SS で確認
- no-touch-zones (`#hero` / `#age-panel` / `#pricing` / `#trust` / `#cta-bottom` / `#soft-features` 構造 / `#faq` / header / footer) が完全不変か `git diff` で確認
- `lp-content-map.md` の SSOT 同期更新が実装と一致しているか確認

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（Step 1-4 + lp-dimensions 単独 PASS）
- [x] LP メトリクス全指標 PASS をローカル確認した
- [x] セルフレビュー済み（多観点: frontend-architect / refactoring-expert）
- [x] 全 AC が実装済み（AC1-8 全達成）
- [x] LP 変更 SS が GitHub 上で表示確認できる（screenshots ブランチに自動 push 済）

## 関連 ADR / PR

- ADR-0001（設計書 SSOT — `lp-content-map.md` 同期完了）
- ADR-0010（Pre-PMF — 必要最小限の修正で対処、過剰配備なし）
- ADR-0013（LP truth — 文言追加なし、layout のみ）
- 関連 PR: #1812（実績削除で 4 cards → 2 cards 減少）/ #1827（スタンプ移動）→ 本 PR で grid 残骸を是正

## 多観点セルフレビュー結果

**frontend-architect 観点**:
- DESIGN.md §9 禁忌違反なし（hex 直書きなし、3 層トークン整合 — 本変更は CSS layout のみで color トークン無関係）
- ADR-0042 LP Spacing/Layout 3 層トークン: 本 PR で追加した `max-width:960px` は数値直書きだが、ADR-0042 の対象は section padding / margin / heading / faq-item 等の Spacing 系であり、grid `max-width` は対象外（既存 LP CSS でも `max-width:1280px` / `max-width:1320px` / `max-width:900px` 等が直書きされており慣例範囲内）。Phase 2 で必要なら別 Issue で `--lp-machine-tour-max` トークン化を検討
- レスポンシブ 3 ブレークポイント (mobile / tablet / 1024px+) で全て破綻なし

**refactoring-expert 観点**:
- 最小変更原則遵守（diff -1/+1 行、コメント整合性も同時更新）
- 副次効果なし: `tour-card` / `tour-shot` の他 style 完全不変、後続 `@media(min-width:1440px){.machine-tour{max-width:1320px;gap:24px}}` は 1024px+ の `max-width:960px` を 1440px+ で上書き → 1440px 以上では旧来通り 1320px まで広がる挙動を維持（cards 内 padding `24px 22px` も不変）
- 1024-1439px 範囲で `max-width:960px` 制約、1440px+ で `max-width:1320px` という cascade が成立、規定通り

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
