### PR TITLE
design: #1847 LP #soft-features 3 cards CSS 完全均質化 (featured 強調撤去) (PO-N-5)

### DIFF
--- a/docs/design/lp-content-map.md
+++ b/docs/design/lp-content-map.md
@@ -138,20 +138,21 @@ LP 9 セクションが独立に最適化されて scrshot 配置・ベネフィ
 
 「短文 + 大 scrshot で意思決定を駆動する」原型。ペルソナ訴求セクション（[02][02b][05][05b]）はこの規範に整合させる。
 
-### 3.5.2 規範 B: [05] soft-features — featured 1 + 並列 2 cards
+### 3.5.2 規範 B: [05] soft-features — 並列 3 cards 完全均質化 (#1847 PO-N-5)
 
 | 項目 | 規範値 |
 |------|--------|
-| 構造 | featured card 1 (大 scrshot + 短文) + 並列 cards 3 (各 scrshot + h3 + 1 文) |
+| 構造 | 並列 cards 3 (各 scrshot + h3 + 1 文) — featured 強調なし、3 cards 視覚均質 |
 | 情報密度 | **mid** |
 | scrshot 占有率 | **高** (≥ 30%) |
 | 主語 | 親 (「親が安心できる運用補助」明示) |
-| ブロック数 / カード数 | 4 cards (featured 1 + 並列 3) |
+| ブロック数 / カード数 | 3 cards (並列 3 / 均等幅) |
 | ベネフィット行数 | 各 1 文 (≤ 2 行) |
 | 文字 px 占有率 | 35-45% |
-| 色面積 | featured のみアクセントカラー、並列 cards は中性面 |
+| 色面積 | 全 cards 中性面 (featured アクセント撤廃、視覚均質化) |
 
-「3-4 cards の並列で機構を整然と提示する」原型。機構説明セクション（[03][04]）はこの規範に整合させる。
+「3 cards の並列で機構を整然と提示する」原型。機構説明セクション（[03][04]）はこの規範に整合させる。
+過去の featured 強調 (1 枚目だけ h3 拡大 + brand-700 色 / soft-shot max-height 拡大 / grid 1.2fr) は #1847 PO-N-5 (解釈 B 完全均質化) で完全撤去された。
 
 ### 3.5.3 4 トーンマップ
 
@@ -359,13 +360,14 @@ ADR-0013 LP 実装 SSOT（Committed のみ訴求）/ ADR-0012 Anti-engagement（
 - 1440px+ では `max-width: 1320px` / `gap: 24px` に拡張しゆとりを確保
 - mobile (<1024px) は `grid-template-columns: repeat(auto-fit, minmax(240px, 1fr))` で 1〜2 列フルード
 
-#### [05] ソフト機能（親の安心）— 3 カード構成（#1720 R4 で 4→3 圧縮、月次レポート featured 凸構成）
+#### [05] ソフト機能（親の安心）— 3 カード構成（#1720 R4 で 4→3 圧縮、#1847 PO-N-5 で featured 強調完全撤去・3 cards 視覚均質化）
 
-1. **成長の記録（月次レポート）** (`data-testid="feature-monthly-report"`, `soft-card--featured`): 月次レポートで活動・ポイント推移を可視化（`/admin/reports` 実装済み）。featured カードとして 1.2fr の幅で border + 微妙なシャドウで強調
+1. **成長の記録（月次レポート）** (`data-testid="feature-monthly-report"`): 月次レポートで活動・ポイント推移を可視化（`/admin/reports` 実装済み）
 2. **家庭に寄り添う運用補助** (`data-testid="feature-auto-sleep"`): 自動スリープ + おうえんメッセージを統合した 1 カード。設定時間超過で自動スリープ（`src/lib/features/auto-sleep.ts` 実装済み, #1292）+ 必要時に親→子のおうえんメッセージ（Family プランで家族全員から送信可）
 3. **設定の自由度** (`data-testid="feature-customization"`): 活動・ポイント配分・ごほうびをカスタマイズ可能
 - → **意図的にゲーム要素を挟まない**。親が「これは遊びだけでは終わらない」と判断するセクション
-- PC は 1 行 3 cards 並列（`grid-template-columns: 1.2fr 1fr 1fr`、max-width 1080px）。モバイルは 1 列縦積み
+- PC は 1 行 3 cards 並列（`grid-template-columns: repeat(3,1fr)`、max-width 1080px、#1847 PO-N-5 で `1.2fr 1fr 1fr` から完全均等幅化）。モバイルは 1 列縦積み
+- 全 cards で h3 サイズ・色・soft-shot max-height が完全に同一（#1847 で `.soft-card--featured` class とその関連 CSS 4 ルールを撤去、視覚均質化）
 - 旧カード「みんなのテンプレート」「親の作業は 1 日 5 分」は削除（[04] / 設定自由度カードに統合）。旧カード「おうえんメッセージ」は #1720 で「家庭に寄り添う運用補助」に統合
 
 #### [05b] 年齢別成長ロードマップ — 卒業を最終地点として位置付ける (#1613 R9 / #1848)

--- a/site/index.html
+++ b/site/index.html
@@ -247,27 +247,25 @@
 .soft-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:24px;max-width:900px;margin:0 auto}
 #soft-features .soft-grid{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
 #soft-features.section{padding-bottom:28px}
-/* #1720 R4: 3 cards 圧縮レイアウト — PC は 1 行に 3 cards 並列、月次レポート featured を border + 微妙なシャドウで強調（縦伸び抑制のためフル幅は不採用） */
+/* #1847 PO-N-5: 3 cards CSS 完全均質化 — featured 強調差分（grid 1.2fr / h3 拡大色変更 / soft-shot max-height 拡大）撤去、
+   PC でも均等幅 + 全 cards 同一 h3 サイズ + 同一 soft-shot 高さに統一 */
 @media(min-width:768px){
-  #soft-features .soft-grid--three{grid-template-columns:1.2fr 1fr 1fr;max-width:1080px}
+  #soft-features .soft-grid--three{grid-template-columns:repeat(3,1fr);max-width:1080px}
 }
 /* #1785 R-CRT-2: 5 系統 → 1 種統一 — featured の box-shadow / 太枠 border 撤去。
-   featured 強調はタイトル文字色 (--brand-700) のみで実現（box-shadow 0 件、grep `box-shadow.*rgba.*120` 0 件） */
+   #1847 PO-N-5: featured 強調 (h3 拡大 + 文字色変更 / soft-shot max-height 拡大) も完全撤去し 3 cards 視覚均質化 */
 .soft-card{background:#fff;border:1px solid var(--gray-300);border-radius:var(--radius);padding:20px 18px;display:flex;flex-direction:column}
 .soft-card h3{font-size:1.05rem;font-weight:700;margin-bottom:6px;color:var(--gray-900)}
-.soft-card.soft-card--featured h3{font-size:1.15rem;color:var(--brand-700)}
 .soft-card p{font-size:.86rem;color:var(--gray-600);line-height:1.6}
 /* #1707 R2 / #1793: soft-card 内に家庭で楽になる / 家庭ごとにカスタマイズできる 1 行ベネフィットと screenshot を追加 */
 /* #1707 PR Phase 3-B fix: 料金プロミスバンドを docHeight 75% 以内に収めるため scrshot 高さを圧縮 */
 /* #1785 R-CRT-2: soft-shot からも border / background / border-radius を撤去 */
 .soft-card .soft-shot{overflow:hidden;aspect-ratio:390/844;max-height:96px;margin:8px 0}
-.soft-card.soft-card--featured .soft-shot{max-height:120px}
 .soft-card .soft-shot img{width:100%;height:100%;object-fit:contain;object-position:center}
 .soft-card .soft-benefit{font-size:.78rem;color:var(--gray-700);line-height:1.5;margin-top:auto}
 .soft-card .soft-benefit strong{color:var(--brand-700)}
 @media(min-width:1024px){
   .soft-card .soft-shot{max-height:160px}
-  .soft-card.soft-card--featured .soft-shot{max-height:180px}
 }
 
 /* Pricing promise band (#1293: freemium × 低価格帯の price disambiguation) */
@@ -750,7 +748,7 @@
     <h2 class="section-title" data-lp-key="indexB.k37">親が安心できる運用補助</h2>
     <p class="section-desc" data-lp-key="indexB.k38">ゲーミフィケーションの裏で、親がちゃんと伴走できる設計。「遊ばせっぱなし」「設定が大変そう」の不安を取り除く 3 つの機能です。</p>
     <div class="soft-grid soft-grid--three">
-      <div class="soft-card soft-card--featured" data-testid="feature-monthly-report">
+      <div class="soft-card" data-testid="feature-monthly-report">
         <h3 data-lp-key="indexB.k39">成長の記録（月次レポート）</h3>
         <p data-lp-key="indexB.k40">月次レポートで活動・ポイント推移をひと目で把握。子供の成長を記録として残せます。</p>
         <div class="soft-shot">


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: LP 訪問者（親、潜在的なサインアップ候補）

**解決する課題**: LP `#soft-features` セクションの 3 cards のうち 1 枚（月次レポート）だけ h3 サイズ・色・grid 幅・soft-shot 高さが他 2 cards と異なる「中途半端な統一」状態が残存し、訪問者の視線が 1 枚目だけに引きずられて 3 機能が並列で語られる本来の意図（並列 3 機能で「親が安心できる運用補助」を等価に提示）が伝わらない。PO 直接指摘 PO-N-5 (`tmp/reviews/lp-2026-05-02/materials/po-direct-findings.md`) で問題提起された。

**期待される効果**: 3 cards を視覚的に完全均質化することで、訪問者は 3 機能を並列に等価で受け取り、「親が安心できる運用補助」を 1 単位の安心感として把握できる。featured 強調による視線誘導の偏りが解消され、LP IA の「機構説明セクションは並列 3 cards で整然と提示する」(規範 B) 原型に整合する。

## 関連 Issue

closes #1847

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | PR scrshot に修正前と修正後の `#soft-features` 並記（PC 1280px + mobile 375px） | `scripts/capture.mjs --section "#soft-features"` で同セクションのみ要素切り出し。After は本 branch (port 5281) / Before は `main` worktree (port 5280) で同一スクリプト・同一ビューポート。4 SS とも `screenshots` branch (commit `6ff50fff`) に push 済、raw URL HTTP 200 確認 | After / Before の Mobile / Desktop 計 4 SS を本 PR § スクリーンショット に GitHub 上で表示可能な形 (`![]()` Markdown) で添付 |
| AC2 | `grep -n 'soft-card--featured' site/index.html` → 0 件 | `Grep` ツールで pattern 検索 | 結果 0 件（`.soft-card.soft-card--featured h3` 1 行 / `.soft-card.soft-card--featured .soft-shot` 2 箇所 / `class="soft-card soft-card--featured"` 1 箇所 = 計 4 箇所削除） |
| AC3 | `grep -n 'soft-card--featured' site/` 全体 → 0 件 | `Grep` 全 site/ 配下走査 | 結果 0 件 |
| AC4 | PC 1280px で 3 cards が均等幅・h3 サイズ・色がすべて同一 | After Desktop SS で目視確認 + CSS diff で `grid-template-columns: repeat(3,1fr)` + featured h3 強調撤去確認 | `after-soft-features-desktop.png` で 3 cards 均等幅 + 全 h3 同一サイズ・gray-900 色を目視確認。Before との比較で 1 枚目 h3 の青色強調 (`color:var(--brand-700)` + `font-size:1.15rem`) 消失も確認 |
| AC5 | mobile 375px で 3 cards が縦積みかつ h3 サイズが全て同一 | After Mobile SS で目視確認 | `after-soft-features-mobile.png` で 3 cards 縦積み + 全 h3 同一サイズ目視確認 |
| AC6 | no-touch-zones（#hero / #age-panel / #pricing / #trust / #cta-bottom / #faq / header / footer / `#soft-features` セクションタイトル + sectionDesc）不変 | `git diff main -- site/index.html` で touch 範囲確認 | diff は L250-254 (CSS コメント置換) / L258 削除 / L264 削除 / L270 削除 / L753 class のみ。`<h2 class="section-title" data-lp-key="indexB.k37">親が安心できる運用補助</h2>` および `<p class="section-desc" data-lp-key="indexB.k38">…</p>` 不変 |
| AC7 | `data-testid` 値 (`feature-monthly-report` 等) 不変 | `Grep` で data-testid 出現箇所確認 | L753 `<div class="soft-card" data-testid="feature-monthly-report">` 維持。L756 srcset / L757 img src の `feature-monthly-report.webp` も不変 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [x] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [x] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- LP `site/index.html` `#soft-features` セクション (3 cards) のみ。本番アプリ (`src/`) と LP の他セクションには影響しない。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載: N/A — 既存 LP E2E (lp-first-view / lp-innerhtml-structure / lp-copy-layout) で `#soft-features` セクションの存在 / 構造を担保。3 cards CSS 均質化はビジュアル変更のため CSS 削除のみで E2E 改修不要。
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — `priority:medium` の design refactor

## スクリーンショット / ビジュアルデモ

**4 スロット添付**（#1740）— `screenshots` branch commit `6ff50fff` に push 済 / raw URL HTTP 200 確認済:

### 修正前 (main, `soft-card--featured` あり — 1 枚目だけ青色 h3 + フォント大)

#### Mobile 375px

![before-soft-features-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1877/before-soft-features-mobile.png)

#### Desktop 1280px

![before-soft-features-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1877/before-soft-features-desktop.png)

### 修正後 (本 PR、3 cards 完全均質化)

#### Mobile 375px

![after-soft-features-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1877/after-soft-features-mobile.png)

#### Desktop 1280px

![after-soft-features-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1877/after-soft-features-desktop.png)

### 撮影手順 (#1741 GitHub 上で表示可能化)

- 撮影元: `site/index.html` `#soft-features` セクション（`scripts/capture.mjs --section "#soft-features"` で要素切り出し）
- Before server: `main` worktree が `npx serve site` (port 5280) で配信中の状態で `--base-url http://localhost:5280` 指定
- After server: 本 branch worktree で `npx serve site --listen 5281` を起動し `--base-url http://localhost:5281` 指定
- 共通 viewport: mobile = 390×844 / desktop = 1280×800（`scripts/capture.mjs` の preset SSOT）
- 配信元: `screenshots` branch (https://github.com/Takenori-Kusaka/ganbari-quest/tree/screenshots/pr-1877)、commit `6ff50fff`

### 目視差分の説明

- **Before Mobile/Desktop**: 1 枚目「成長の記録（月次レポート）」だけ h3 が `var(--brand-700)` 青色 + `font-size:1.15rem` で他 2 cards より目立つ → 訪問者の視線が 1 枚目のみに引っ張られる
- **After Mobile**: 3 cards 縦積み、全 h3 が同一サイズ・`var(--gray-900)` 同色。1 枚目の視覚浮きが完全消失
- **After Desktop**: 3 cards が `grid-template-columns: repeat(3,1fr)` で均等幅、全 h3 同一・soft-shot 最大高さ 96px で完全均質化

**インタラクティブ状態**: N/A — 静的 LP セクション、disabled / readonly フィールドなし。

**DOM スナップショット (#1747 / #1766)**: 撮影と同 page で取得した DOM HTML はローカル `tmp/screenshots/pr-1877/*.dom.html` に保存。Before DOM は `soft-card--featured` を 4 件含み、After DOM は 0 件であることをローカルで grep 確認済。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: CSS と HTML の単一責任で完結。`soft-card--featured` という modifier class の特殊化を撤去し、`soft-card` 基底のみで 3 cards を表現することで I（インターフェース分離）整合
- [x] **DRY**: featured 強調の散在 (CSS 4 ルール + HTML 1 箇所 + コメント 2 箇所) を一括撤去、`grep` で `soft-card--featured` 完全絶滅確認 (AC2 / AC3)
- [x] **YAGNI**: 撤去のみで抽象化追加なし。今後 featured が再び必要になったら ADR で議論する前提
- [x] **Security（OSS 公開前提）**: 静的 HTML/CSS のみ、認証・データ流れに影響しない / N/A
- [x] **アクセシビリティ**: h3 階層は維持、コントラストは `--gray-900` (DESIGN.md セマンティックトークン) で WCAG AA 担保
- [x] **パフォーマンス**: CSS ルール 3 行削除 + HTML class 名 1 箇所縮小により bundle 軽量化（軽微）

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期
- [x] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: LP 記載がアプリ実装と一致 — `data-testid="feature-monthly-report"` は不変、`/admin/reports` 実装事実と整合
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [ ] E2E / ユニットシード / チュートリアルを同期
- [x] **labels SSOT** (ADR-0009): LP 文言 `data-lp-key="indexB.k37"` / `k38` / `k39` / `k40` などは不変、リテラル直書きなし
- [x] **設計書同期** (ADR-0001): `docs/design/lp-content-map.md` §3.5.2 規範 B (#1847 完全均質化反映) + §[05] ソフト機能 (#1847 PO-N-5 反映) を本 PR で更新
- [x] **並行 PR overlap** (#1200): `site/index.html` 変更は本 PR と PR #1876 (#1846 machine-tour grid) で同時期にあるが、変更行範囲（本 PR L250-254/258/264/270/753 vs PR #1876 L228-235）は完全非重複、main から派生で衝突なし

**LP / 販促文言変更時** (ADR-0013 / #1314):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A — 本 PR は文言変更なし、CSS と class 名のみの変更 | N/A | N/A |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
- After SS で 3 cards の h3 サイズ・色・soft-shot 高さが完全に同一であることを目視確認お願いします
- `git diff main -- site/index.html` で no-touch-zones (sectionTitle / sectionDesc / data-testid) が不変であることを確認お願いします
- `docs/design/lp-content-map.md` 同期更新が PO-N-5 解釈 B (完全均質化) と整合していることを確認お願いします

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（残存 AC なし）
- [x] Phase 分割した場合: 該当なし — 単一 PR で完結
- [x] UI 変更時: SS 撮影 (Mobile 375px / Desktop 1280px) + DESIGN.md §9 禁忌 6 点目視確認（hex 直書きなし / プリミティブ再実装なし / 内部コード露出なし / 用語ハードコードなし / インラインスタイルなし / `<style>` 50 行超えなし）
- [x] 認証画面変更時: N/A — LP 静的ページのみ

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

