### PR TITLE
infra: #1917 generate-lp-labels.mjs を template literal 対応 (Phase 1 B1)

### DIFF
--- a/scripts/__tests__/generate-lp-labels.test.mjs
+++ b/scripts/__tests__/generate-lp-labels.test.mjs
@@ -1,0 +1,332 @@
+/**
+ * scripts/__tests__/generate-lp-labels.test.mjs
+ *
+ * generate-lp-labels.mjs の template literal 対応 (#1917) のユニットテスト。
+ * Phase 1 B1: terms.ts → labels.ts の SSOT 2 階層化を支える parser の単体検証。
+ *
+ * 実行: node --test scripts/__tests__/generate-lp-labels.test.mjs
+ *
+ * AC マッピング:
+ *   - AC1: parseBlockLine が template literal 形式をマッチ
+ *   - AC2: parseBlock + resolveAllTemplates で interpolation を解決
+ *   - AC3: 解決失敗時は Unresolved ${ns}.${key} で throw
+ *   - AC4: --check モード対応 (本テストは parser 単体、--check は CI 全体側で検証)
+ *   - AC5: shared-labels.js 出力差分ゼロは fixture テストで検証
+ *   - AC6: simple / nested / unresolved / multi-line を全パターン網羅
+ *
+ * 注: 本ファイルは fixture として literal な "${NS.key}" を文字列内に多数含むため、
+ *     biome の noTemplateCurlyInString を file 全体で抑制する (intentional fixture)。
+ */
+/* biome-ignore-all lint/suspicious/noTemplateCurlyInString: fixture には literal "${NS.key}" を文字列として含む */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	isTemplateLiteral,
+	parseBlock,
+	parseBlockLine,
+	resolveAllTemplates,
+	resolveTemplateLiteralValue,
+} from '../generate-lp-labels.mjs';
+
+// ---------------------------------------------------------------------------
+// AC1: parseBlockLine が template literal 形式をマッチ
+// ---------------------------------------------------------------------------
+describe('parseBlockLine — template literal 対応 (#1917 AC1)', () => {
+	it('single quote 形式は従来どおり文字列として保持される', () => {
+		/** @type {Record<string, string | { __template: true; raw: string }>} */
+		const result = {};
+		const pending = parseBlockLine("greeting: 'Hello world',", result, null);
+		assert.equal(pending, null);
+		assert.equal(result.greeting, 'Hello world');
+		assert.equal(typeof result.greeting, 'string');
+	});
+
+	it('template literal (interpolation 1+) は __template: true マーカーで保持', () => {
+		/** @type {Record<string, string | { __template: true; raw: string }>} */
+		const result = {};
+		const pending = parseBlockLine('greeting: `Hello ${WORLD.name}`,', result, null);
+		assert.equal(pending, null);
+		const value = result.greeting;
+		assert.ok(isTemplateLiteral(value), 'template literal value should be marked');
+		// raw はバッククォート内側をそのまま保持
+		if (isTemplateLiteral(value)) {
+			assert.equal(value.raw, 'Hello ${WORLD.name}');
+		}
+	});
+
+	it('template literal で interpolation を含まないものも __template マーカーで保持', () => {
+		/** @type {Record<string, string | { __template: true; raw: string }>} */
+		const result = {};
+		const pending = parseBlockLine('label: `static text`,', result, null);
+		assert.equal(pending, null);
+		const value = result.label;
+		assert.ok(isTemplateLiteral(value));
+		if (isTemplateLiteral(value)) {
+			assert.equal(value.raw, 'static text');
+		}
+	});
+
+	it('multi-line template literal: key: のみ → 次行 `value`,', () => {
+		/** @type {Record<string, string | { __template: true; raw: string }>} */
+		const result = {};
+		const after1 = parseBlockLine('greeting:', result, null);
+		assert.equal(after1, 'greeting');
+		const after2 = parseBlockLine('`Hello ${WORLD.name}`,', result, after1);
+		assert.equal(after2, null);
+		const value = result.greeting;
+		assert.ok(isTemplateLiteral(value));
+		if (isTemplateLiteral(value)) {
+			assert.equal(value.raw, 'Hello ${WORLD.name}');
+		}
+	});
+
+	it('既存 single quote の multi-line も維持される', () => {
+		/** @type {Record<string, string | { __template: true; raw: string }>} */
+		const result = {};
+		const after1 = parseBlockLine('greeting:', result, null);
+		assert.equal(after1, 'greeting');
+		const after2 = parseBlockLine("'Hello world',", result, after1);
+		assert.equal(after2, null);
+		assert.equal(result.greeting, 'Hello world');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AC2: parseBlock + resolveAllTemplates が template literal を文字列に解決
+// ---------------------------------------------------------------------------
+describe('resolveAllTemplates — interpolation 解決 (#1917 AC2)', () => {
+	it('simple template literal: ${NS.key} 1 個', () => {
+		/** @type {Record<string, Record<string, string | { __template: true; raw: string }>>} */
+		const namespaces = {
+			WORLD: { name: 'World' },
+			GREETING: { hello: { __template: true, raw: 'Hello ${WORLD.name}' } },
+		};
+		const resolved = resolveAllTemplates(namespaces);
+		assert.equal(resolved.GREETING.hello, 'Hello World');
+		assert.equal(resolved.WORLD.name, 'World');
+	});
+
+	it('multiple interpolation in single template', () => {
+		/** @type {Record<string, Record<string, string | { __template: true; raw: string }>>} */
+		const namespaces = {
+			PRICE: { currency: '¥', amount: '500' },
+			LABEL: { full: { __template: true, raw: '${PRICE.currency}${PRICE.amount}/月' } },
+		};
+		const resolved = resolveAllTemplates(namespaces);
+		assert.equal(resolved.LABEL.full, '¥500/月');
+	});
+
+	it('nested reference: TERMS_B → TERMS_A → 文字列', () => {
+		/** @type {Record<string, Record<string, string | { __template: true; raw: string }>>} */
+		const namespaces = {
+			TERMS_A: { atom: 'スタンダード' },
+			TERMS_B: { compound: { __template: true, raw: '${TERMS_A.atom}プラン' } },
+			TERMS_C: { final: { __template: true, raw: '${TERMS_B.compound}は人気' } },
+		};
+		const resolved = resolveAllTemplates(namespaces);
+		assert.equal(resolved.TERMS_A.atom, 'スタンダード');
+		assert.equal(resolved.TERMS_B.compound, 'スタンダードプラン');
+		assert.equal(resolved.TERMS_C.final, 'スタンダードプランは人気');
+	});
+
+	it('bracket notation: ${NS["key"]} と ${NS[\'key\']} 両方サポート', () => {
+		/** @type {Record<string, Record<string, string | { __template: true; raw: string }>>} */
+		const namespaces = {
+			TERMS: { 'multi-word': 'value-A' },
+			REF: {
+				doubleQuote: { __template: true, raw: '${TERMS["multi-word"]}' },
+				singleQuote: { __template: true, raw: "${TERMS['multi-word']}" },
+			},
+		};
+		const resolved = resolveAllTemplates(namespaces);
+		assert.equal(resolved.REF.doubleQuote, 'value-A');
+		assert.equal(resolved.REF.singleQuote, 'value-A');
+	});
+
+	it('文字列値はそのまま (template literal 不在 namespace)', () => {
+		/** @type {Record<string, Record<string, string | { __template: true; raw: string }>>} */
+		const namespaces = {
+			SIMPLE: { a: 'A', b: 'B' },
+		};
+		const resolved = resolveAllTemplates(namespaces);
+		assert.deepEqual(resolved.SIMPLE, { a: 'A', b: 'B' });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AC3: 解決失敗時は throw + 詳細表示
+// ---------------------------------------------------------------------------
+describe('resolveTemplateLiteralValue — エラー表示 (#1917 AC3)', () => {
+	it('namespace 不在: "Unresolved UNKNOWN_NS.foo in OWNER" で throw', () => {
+		const namespaces = { TERMS: { atom: 'X' } };
+		assert.throws(
+			() =>
+				resolveTemplateLiteralValue(
+					'Hello ${UNKNOWN_NS.foo}',
+					namespaces,
+					'LP_HERO_PRICE_BAND_LABELS.itemFree',
+				),
+			(err) => {
+				assert.ok(err instanceof Error);
+				assert.match(err.message, /Unresolved UNKNOWN_NS\.foo/);
+				assert.match(err.message, /LP_HERO_PRICE_BAND_LABELS\.itemFree/);
+				return true;
+			},
+		);
+	});
+
+	it('key 不在: "Unresolved TERMS.unknownKey" で throw', () => {
+		const namespaces = { TERMS: { atom: 'X' } };
+		assert.throws(
+			() =>
+				resolveTemplateLiteralValue(
+					'Hello ${TERMS.unknownKey}',
+					namespaces,
+					'LP_HERO_PRICE_BAND_LABELS.itemFree',
+				),
+			/Unresolved TERMS\.unknownKey in LP_HERO_PRICE_BAND_LABELS\.itemFree/,
+		);
+	});
+
+	it('nested resolution での不在も同形式で throw', () => {
+		/** @type {Record<string, Record<string, string | { __template: true; raw: string }>>} */
+		const namespaces = {
+			A: { foo: { __template: true, raw: '${B.bar}' } },
+			B: {}, // bar が無い
+		};
+		assert.throws(() => resolveAllTemplates(namespaces), /Unresolved B\.bar in A\.foo/);
+	});
+
+	it('循環参照: max depth 超過で throw', () => {
+		/** @type {Record<string, Record<string, string | { __template: true; raw: string }>>} */
+		const namespaces = {
+			A: { x: { __template: true, raw: '${B.y}' } },
+			B: { y: { __template: true, raw: '${A.x}' } },
+		};
+		assert.throws(
+			() => resolveAllTemplates(namespaces),
+			/Template literal resolution exceeded max depth/,
+		);
+	});
+
+	it('未サポートな式 (関数呼出など) は throw', () => {
+		const namespaces = { TERMS: { atom: 'X' } };
+		assert.throws(
+			() => resolveTemplateLiteralValue('Hello ${getName()}', namespaces, 'LP_TEST.key'),
+			/Unsupported template literal expression/,
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AC6: parseBlock 統合テスト (template literal を含む namespace)
+// ---------------------------------------------------------------------------
+describe('parseBlock — template literal 統合 (#1917 AC6)', () => {
+	it('mixed (single quote + template literal) を一括パース、resolveAllTemplates で解決', () => {
+		const fixture = `
+export const PLAN_TERMS = {
+	standard: 'スタンダード',
+	family: 'ファミリー',
+};
+
+export const LP_PLAN_LABELS = {
+	standardLabel: \`\${PLAN_TERMS.standard}プラン\`,
+	familyLabel: \`\${PLAN_TERMS.family}プラン\`,
+	mixedNote: 'これは静的テキスト',
+};
+`;
+		const planTerms = parseBlock(fixture, 'PLAN_TERMS');
+		const lpPlanLabels = parseBlock(fixture, 'LP_PLAN_LABELS');
+
+		const resolved = resolveAllTemplates({
+			PLAN_TERMS: planTerms,
+			LP_PLAN_LABELS: lpPlanLabels,
+		});
+
+		assert.equal(resolved.PLAN_TERMS.standard, 'スタンダード');
+		assert.equal(resolved.LP_PLAN_LABELS.standardLabel, 'スタンダードプラン');
+		assert.equal(resolved.LP_PLAN_LABELS.familyLabel, 'ファミリープラン');
+		assert.equal(resolved.LP_PLAN_LABELS.mixedNote, 'これは静的テキスト');
+	});
+
+	it('multi-line template literal (Biome 改行整形) も解決される', () => {
+		const fixture = `
+export const X = {
+	atom: 'value-A',
+};
+
+export const Y = {
+	compound:
+		\`prefix \${X.atom} suffix\`,
+};
+`;
+		const x = parseBlock(fixture, 'X');
+		const y = parseBlock(fixture, 'Y');
+		const resolved = resolveAllTemplates({ X: x, Y: y });
+		assert.equal(resolved.Y.compound, 'prefix value-A suffix');
+	});
+
+	it('実 Issue #1917 例: PLAN_TERMS.standard + PRICE_TERMS.standard の interpolation', () => {
+		const fixture = `
+export const PLAN_TERMS = {
+	standard: 'スタンダード',
+};
+
+export const PRICE_TERMS = {
+	monthlyPrefix: '月額',
+	standard: '500円',
+};
+
+export const LP_HERO_PRICE_BAND_LABELS = {
+	itemStandard: \`\${PLAN_TERMS.standard}は\${PRICE_TERMS.monthlyPrefix}\${PRICE_TERMS.standard}\`,
+};
+`;
+		const planTerms = parseBlock(fixture, 'PLAN_TERMS');
+		const priceTerms = parseBlock(fixture, 'PRICE_TERMS');
+		const heroLabels = parseBlock(fixture, 'LP_HERO_PRICE_BAND_LABELS');
+
+		const resolved = resolveAllTemplates({
+			PLAN_TERMS: planTerms,
+			PRICE_TERMS: priceTerms,
+			LP_HERO_PRICE_BAND_LABELS: heroLabels,
+		});
+
+		assert.equal(resolved.LP_HERO_PRICE_BAND_LABELS.itemStandard, 'スタンダードは月額500円');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AC5: shared-labels.js 出力差分ゼロ（本 PR 単独では terms.ts 未導入のため、
+//      既存 labels.ts に template literal が混入していないことを確認）
+// ---------------------------------------------------------------------------
+describe('既存 labels.ts は template literal を含まない (#1917 AC5)', () => {
+	it('parseBlock の戻り値は string のみ (TemplateLiteralValue 不在)', async () => {
+		// 実 labels.ts を読み込んで全 namespace を検査
+		const fs = await import('node:fs');
+		const path = await import('node:path');
+		const url = await import('node:url');
+		const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+		const labelsTs = path.resolve(__dirname, '../../src/lib/domain/labels.ts');
+		const src = fs.readFileSync(labelsTs, 'utf-8');
+
+		// ランダム抽出: 主要 LP namespace を 5 件チェック
+		const samples = [
+			'LP_RETENTION_LABELS',
+			'LP_CORELOOP_LABELS',
+			'LP_NAV_LABELS',
+			'LP_PRICING_LABELS',
+			'LP_FAQ_LABELS',
+		];
+		for (const name of samples) {
+			const block = parseBlock(src, name);
+			for (const [key, value] of Object.entries(block)) {
+				assert.equal(
+					typeof value,
+					'string',
+					`labels.ts ${name}.${key} should be plain string (not template literal yet — #1916 で導入予定)`,
+				);
+			}
+		}
+	});
+});

--- a/scripts/generate-lp-labels.mjs
+++ b/scripts/generate-lp-labels.mjs
@@ -313,60 +313,77 @@ function parseTermsTs() {
 }
 
 /**
- * labels.ts から定数を抽出する簡易パーサ（TS コンパイラなしで読み取る）
+ * LP 用 namespace 名 ↔ 戻り値 key の対応表。
  *
- * #1917: parseLabelsTs は以下の 2 段階で動作する。
+ * #1917 のリファクタで parseLabelsTs() の cognitive complexity を 27 → 安全圏に下げるため、
+ * 多数の parseBlock 呼び出しと namespaces map / return マッピングを data table に外出しした。
+ * 過去 PR 由来のコメント（どの Issue で追加したか）はキー単位で保持。
+ *
+ * @type {Array<{constName: string, returnKey: string, note?: string}>}
+ */
+const LP_NAMESPACE_TABLE = [
+	{ constName: 'LP_RETENTION_LABELS', returnKey: 'lpRetentionLabels' },
+	{ constName: 'LP_CORELOOP_LABELS', returnKey: 'lpCoreloopLabels' },
+	// #1465 Phase C: LP 共通ナビ・フッター・CTA
+	{ constName: 'LP_NAV_LABELS', returnKey: 'lpNavLabels', note: '#1465 Phase C' },
+	{ constName: 'LP_FOOTER_LABELS', returnKey: 'lpFooterLabels', note: '#1465 Phase C' },
+	{ constName: 'LP_COMMON_LABELS', returnKey: 'lpCommonLabels', note: '#1465 Phase C' },
+	// Phase 2 R5/R6 (#1609/#1610): 法務系打消し表示
+	{ constName: 'LP_LEGAL_DISCLAIMER_LABELS', returnKey: 'lpLegalDisclaimerLabels' },
+	// Phase 4 R9/R10 (#1613/#1614): 年齢別成長ロードマップ + アナログ vs デジタル
+	{ constName: 'LP_VERSUS_LABELS', returnKey: 'lpVersusLabels' },
+	{ constName: 'LP_GROWTH_ROADMAP_LABELS', returnKey: 'lpGrowthRoadmapLabels' },
+	// 注: #1784 Hero 直後 StoryBrand Guide ブロック (LP_GUIDE_LABELS) は #1843 で完全 revert
+	// Phase 5 R44 (#1650): pricing.html SSOT 同期
+	{ constName: 'LP_PRICING_LABELS', returnKey: 'lpPricingLabels' },
+	// 注: ADR-0028 (#1713 R7) で LP の founder 直接相談 namespace は #1772 で完全撤去済
+	{ constName: 'LP_LICENSEKEY_LABELS', returnKey: 'lpLicenseKeyLabels' },
+	{ constName: 'LP_FAQ_LABELS', returnKey: 'lpFaqLabels' },
+	{ constName: 'LP_SELFHOST_LABELS', returnKey: 'lpSelfhostLabels' },
+	{ constName: 'LP_INDEX_EXTRA_LABELS', returnKey: 'lpIndexExtraLabels' },
+	// #1732: floating-cta 深度別文言
+	{ constName: 'LP_FLOATING_CTA_LABELS', returnKey: 'lpFloatingCtaLabels' },
+	{ constName: 'LP_PAMPHLET_LABELS', returnKey: 'lpPamphletLabels' },
+	{ constName: 'LP_PRICING_EXTRA_LABELS', returnKey: 'lpPricingExtraLabels' },
+	// #1702: site/{index,pricing,faq,pamphlet}.html 339 件 SSOT 化用 phase B namespace
+	{ constName: 'LP_INDEX_PHASEB_LABELS', returnKey: 'lpIndexPhaseBLabels' },
+	{ constName: 'LP_PRICING_PHASEB_LABELS', returnKey: 'lpPricingPhaseBLabels' },
+	{ constName: 'LP_FAQ_PHASEB_LABELS', returnKey: 'lpFaqPhaseBLabels' },
+	{ constName: 'LP_PAMPHLET_PHASEB_LABELS', returnKey: 'lpPamphletPhaseBLabels' },
+	// #1703 #1683-C: 法的文書 SSOT 化（ADR-0009 supersede / ADR-0025）
+	{ constName: 'LP_LEGAL_PRIVACY_LABELS', returnKey: 'lpLegalPrivacyLabels' },
+	{ constName: 'LP_LEGAL_TERMS_LABELS', returnKey: 'lpLegalTermsLabels' },
+	{ constName: 'LP_LEGAL_SLA_LABELS', returnKey: 'lpLegalSlaLabels' },
+	{ constName: 'LP_LEGAL_TOKUSHOHO_LABELS', returnKey: 'lpLegalTokushohoLabels' },
+];
+
+/**
+ * labels.ts の全 namespace を template literal 解決済みで取得する内部実装。
+ *
+ * #1917: 以下の 3 段階で動作する。
  *   Phase 1: 全 namespace を raw (template literal は marker で保持) でパース
  *   Phase 2: terms.ts を読み込み、namespaces map に統合
  *   Phase 3: resolveAllTemplates で interpolation を解決
  * 解決失敗時は throw + 詳細表示 (Unresolved ${ns}.${key} in ${owner})
+ *
+ * @returns {Record<string, Record<string, string>>} namespace 名 → key/value マップ (全て解決済み)
  */
-function parseLabelsTs() {
+function parseAllNamespacesResolved() {
 	const src = fs.readFileSync(LABELS_TS, 'utf-8');
 
+	// AGE / PLAN は year-based name で固定 + 既存 simple block 保持 (#1772)
 	const ageTierLabels = parseSimpleBlock(src, 'AGE_TIER_LABELS');
 	const ageTierShort = parseSimpleBlock(src, 'AGE_TIER_SHORT_LABELS');
 	const planLabels = parseSimpleBlock(src, 'PLAN_LABELS');
-	const lpRetentionLabels = parseBlock(src, 'LP_RETENTION_LABELS');
-	const lpCoreloopLabels = parseBlock(src, 'LP_CORELOOP_LABELS');
-	// #1465 Phase C: LP 共通ナビ・フッター・CTA
-	const lpNavLabels = parseBlock(src, 'LP_NAV_LABELS');
-	const lpFooterLabels = parseBlock(src, 'LP_FOOTER_LABELS');
-	const lpCommonLabels = parseBlock(src, 'LP_COMMON_LABELS');
-	// Phase 2 R5/R6 (#1609/#1610): 法務系打消し表示
-	const lpLegalDisclaimerLabels = parseBlock(src, 'LP_LEGAL_DISCLAIMER_LABELS');
-	// Phase 4 R9/R10 (#1613/#1614): 年齢別成長ロードマップ + アナログ vs デジタル
-	const lpVersusLabels = parseBlock(src, 'LP_VERSUS_LABELS');
-	const lpGrowthRoadmapLabels = parseBlock(src, 'LP_GROWTH_ROADMAP_LABELS');
-	// 注: #1784 Hero 直後 StoryBrand Guide ブロック (LP_GUIDE_LABELS) は #1843 で完全 revert
-	//   PO-N-1 指摘で「タイトルと内容が乖離した一番上にくるセクション不適切」のため Hero → versus 直行に戻した
-	// Phase 5 R44 (#1650): pricing.html SSOT 同期
-	const lpPricingLabels = parseBlock(src, 'LP_PRICING_LABELS');
-	// 注: #1594 ADR-0023 I8 → ADR-0028 (#1713 R7) で LP の founder 直接相談セクションは削除済み。
-	// 関連 namespace は #1772 で labels.ts export + shared-labels.js namespace ともに完全撤去。
-	// （parseBlock 自体は #1772 で「定数不在時に空オブジェクトを返す」よう修正済みなので、
-	//  将来同様に空オブジェクト化された LP_*_LABELS を削除しても本スクリプトは壊れない）
-	const lpLicenseKeyLabels = parseBlock(src, 'LP_LICENSEKEY_LABELS');
-	const lpFaqLabels = parseBlock(src, 'LP_FAQ_LABELS');
-	const lpSelfhostLabels = parseBlock(src, 'LP_SELFHOST_LABELS');
-	const lpIndexExtraLabels = parseBlock(src, 'LP_INDEX_EXTRA_LABELS');
-	// #1732: floating-cta 深度別文言
-	const lpFloatingCtaLabels = parseBlock(src, 'LP_FLOATING_CTA_LABELS');
-	const lpPamphletLabels = parseBlock(src, 'LP_PAMPHLET_LABELS');
-	const lpPricingExtraLabels = parseBlock(src, 'LP_PRICING_EXTRA_LABELS');
-	// #1702: site/{index,pricing,faq,pamphlet}.html 339 件 SSOT 化用 phase B namespace
-	const lpIndexPhaseBLabels = parseBlock(src, 'LP_INDEX_PHASEB_LABELS');
-	const lpPricingPhaseBLabels = parseBlock(src, 'LP_PRICING_PHASEB_LABELS');
-	const lpFaqPhaseBLabels = parseBlock(src, 'LP_FAQ_PHASEB_LABELS');
-	const lpPamphletPhaseBLabels = parseBlock(src, 'LP_PAMPHLET_PHASEB_LABELS');
-	// #1703 #1683-C: 法的文書 SSOT 化（ADR-0009 supersede / ADR-0025）
-	const lpLegalPrivacyLabels = parseBlock(src, 'LP_LEGAL_PRIVACY_LABELS');
-	const lpLegalTermsLabels = parseBlock(src, 'LP_LEGAL_TERMS_LABELS');
-	const lpLegalSlaLabels = parseBlock(src, 'LP_LEGAL_SLA_LABELS');
-	const lpLegalTokushohoLabels = parseBlock(src, 'LP_LEGAL_TOKUSHOHO_LABELS');
+
+	// #1917: LP 系 namespace は data table 駆動で一括 parse + namespaces map 構築
+	/** @type {Record<string, Record<string, string | TemplateLiteralValue>>} */
+	const lpRaw = {};
+	for (const { constName } of LP_NAMESPACE_TABLE) {
+		lpRaw[constName] = parseBlock(src, constName);
+	}
 
 	// #1917: terms.ts (atom) を取り込み、template literal を解決
-	// 全 namespace を一つの map に束ね、resolveAllTemplates で interpolation を済ませる。
 	// 解決失敗時は throw され、CLI / --check が exit 1 で停止する。
 	const termsNamespaces = parseTermsTs();
 	/** @type {Record<string, Record<string, string | TemplateLiteralValue>>} */
@@ -375,64 +392,38 @@ function parseLabelsTs() {
 		AGE_TIER_LABELS: ageTierLabels,
 		AGE_TIER_SHORT_LABELS: ageTierShort,
 		PLAN_LABELS: planLabels,
-		LP_RETENTION_LABELS: lpRetentionLabels,
-		LP_CORELOOP_LABELS: lpCoreloopLabels,
-		LP_NAV_LABELS: lpNavLabels,
-		LP_FOOTER_LABELS: lpFooterLabels,
-		LP_COMMON_LABELS: lpCommonLabels,
-		LP_LEGAL_DISCLAIMER_LABELS: lpLegalDisclaimerLabels,
-		LP_VERSUS_LABELS: lpVersusLabels,
-		LP_GROWTH_ROADMAP_LABELS: lpGrowthRoadmapLabels,
-		LP_PRICING_LABELS: lpPricingLabels,
-		LP_LICENSEKEY_LABELS: lpLicenseKeyLabels,
-		LP_FAQ_LABELS: lpFaqLabels,
-		LP_SELFHOST_LABELS: lpSelfhostLabels,
-		LP_INDEX_EXTRA_LABELS: lpIndexExtraLabels,
-		LP_FLOATING_CTA_LABELS: lpFloatingCtaLabels,
-		LP_PAMPHLET_LABELS: lpPamphletLabels,
-		LP_PRICING_EXTRA_LABELS: lpPricingExtraLabels,
-		LP_INDEX_PHASEB_LABELS: lpIndexPhaseBLabels,
-		LP_PRICING_PHASEB_LABELS: lpPricingPhaseBLabels,
-		LP_FAQ_PHASEB_LABELS: lpFaqPhaseBLabels,
-		LP_PAMPHLET_PHASEB_LABELS: lpPamphletPhaseBLabels,
-		LP_LEGAL_PRIVACY_LABELS: lpLegalPrivacyLabels,
-		LP_LEGAL_TERMS_LABELS: lpLegalTermsLabels,
-		LP_LEGAL_SLA_LABELS: lpLegalSlaLabels,
-		LP_LEGAL_TOKUSHOHO_LABELS: lpLegalTokushohoLabels,
+		...lpRaw,
 	};
-	const resolved = resolveAllTemplates(allNamespaces);
+	return resolveAllTemplates(allNamespaces);
+}
 
-	// 全 namespace は resolveAllTemplates で必ず entry を持つ (Object.entries で全件処理)
-	// が、TS 型上は Record<string, ...> なので index access が optional 扱い。
-	// `?? {}` で defensive fallback を付与。
+/**
+ * labels.ts から定数を抽出し、generateSharedLabelsJs で使う形に整える。
+ * 既存呼出元への破壊的変更を避けるため戻り値 key は従来どおり (ageTierLabels / lp* 形式)。
+ *
+ * @returns {{
+ *   ageTierLabels: Record<string, string>;
+ *   ageTierShort: Record<string, string>;
+ *   planLabels: Record<string, string>;
+ *   [lpKey: string]: Record<string, string>;
+ * }}
+ */
+function parseLabelsTs() {
+	const resolved = parseAllNamespacesResolved();
+
+	// data table を経由して resolved → 戻り値 key へマッピング
+	// 全 namespace は resolveAllTemplates で必ず entry を持つが、TS 型上 optional なので `?? {}` で defensive fallback。
+	/** @type {Record<string, Record<string, string>>} */
+	const lpResolved = {};
+	for (const { constName, returnKey } of LP_NAMESPACE_TABLE) {
+		lpResolved[returnKey] = resolved[constName] ?? {};
+	}
+
 	return {
 		ageTierLabels: resolved.AGE_TIER_LABELS ?? {},
 		ageTierShort: resolved.AGE_TIER_SHORT_LABELS ?? {},
 		planLabels: resolved.PLAN_LABELS ?? {},
-		lpRetentionLabels: resolved.LP_RETENTION_LABELS ?? {},
-		lpCoreloopLabels: resolved.LP_CORELOOP_LABELS ?? {},
-		lpNavLabels: resolved.LP_NAV_LABELS ?? {},
-		lpFooterLabels: resolved.LP_FOOTER_LABELS ?? {},
-		lpCommonLabels: resolved.LP_COMMON_LABELS ?? {},
-		lpLegalDisclaimerLabels: resolved.LP_LEGAL_DISCLAIMER_LABELS ?? {},
-		lpVersusLabels: resolved.LP_VERSUS_LABELS ?? {},
-		lpGrowthRoadmapLabels: resolved.LP_GROWTH_ROADMAP_LABELS ?? {},
-		lpPricingLabels: resolved.LP_PRICING_LABELS ?? {},
-		lpLicenseKeyLabels: resolved.LP_LICENSEKEY_LABELS ?? {},
-		lpFaqLabels: resolved.LP_FAQ_LABELS ?? {},
-		lpSelfhostLabels: resolved.LP_SELFHOST_LABELS ?? {},
-		lpIndexExtraLabels: resolved.LP_INDEX_EXTRA_LABELS ?? {},
-		lpFloatingCtaLabels: resolved.LP_FLOATING_CTA_LABELS ?? {},
-		lpPamphletLabels: resolved.LP_PAMPHLET_LABELS ?? {},
-		lpPricingExtraLabels: resolved.LP_PRICING_EXTRA_LABELS ?? {},
-		lpIndexPhaseBLabels: resolved.LP_INDEX_PHASEB_LABELS ?? {},
-		lpPricingPhaseBLabels: resolved.LP_PRICING_PHASEB_LABELS ?? {},
-		lpFaqPhaseBLabels: resolved.LP_FAQ_PHASEB_LABELS ?? {},
-		lpPamphletPhaseBLabels: resolved.LP_PAMPHLET_PHASEB_LABELS ?? {},
-		lpLegalPrivacyLabels: resolved.LP_LEGAL_PRIVACY_LABELS ?? {},
-		lpLegalTermsLabels: resolved.LP_LEGAL_TERMS_LABELS ?? {},
-		lpLegalSlaLabels: resolved.LP_LEGAL_SLA_LABELS ?? {},
-		lpLegalTokushohoLabels: resolved.LP_LEGAL_TOKUSHOHO_LABELS ?? {},
+		...lpResolved,
 	};
 }
 

--- a/scripts/generate-lp-labels.mjs
+++ b/scripts/generate-lp-labels.mjs
@@ -27,6 +27,7 @@ const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..');
 
 const LABELS_TS = path.join(REPO_ROOT, 'src/lib/domain/labels.ts');
+const TERMS_TS = path.join(REPO_ROOT, 'src/lib/domain/terms.ts');
 const AGE_TIER_TS = path.join(REPO_ROOT, 'src/lib/domain/validation/age-tier.ts');
 const OUTPUT_JS = path.join(REPO_ROOT, 'site/shared-labels.js');
 
@@ -87,9 +88,13 @@ function extractBraceBlock(src, startIdx) {
  * site/*.html 側の `data-lp-key` 参照は no-op となり、SEO フォールバックテキストが
  * そのまま残る。
  *
+ * #1917: template literal 値を含む可能性があるため、戻り値は文字列または
+ * TemplateLiteralValue (`{ __template: true, raw: string }`) のレコードとなる。
+ * 解決 (interpolation) は resolveTemplateLiterals() で別途行う。
+ *
  * @param {string} src
  * @param {string} constName
- * @returns {Record<string, string>}
+ * @returns {Record<string, string | TemplateLiteralValue>}
  */
 function parseBlock(src, constName) {
 	const startIdx = src.indexOf(`export const ${constName}`);
@@ -101,7 +106,7 @@ function parseBlock(src, constName) {
 	const block = extractBraceBlock(src, startIdx);
 	if (block === null) return {};
 
-	/** @type {Record<string, string>} */
+	/** @type {Record<string, string | TemplateLiteralValue>} */
 	const result = {};
 	/** @type {string | null} */
 	let pendingKey = null;
@@ -114,18 +119,54 @@ function parseBlock(src, constName) {
 }
 
 /**
+ * Template literal 値を表す内部マーカー (#1917)。
+ * raw に元の `...` 内側 (バッククォート除く) を保持し、後段の resolveTemplateLiterals で
+ * `${NS.key}` 参照を解決する。同名マーカーで判別する。
+ *
+ * @typedef {{ __template: true; raw: string }} TemplateLiteralValue
+ */
+
+/**
+ * @param {unknown} v
+ * @returns {v is TemplateLiteralValue}
+ */
+function isTemplateLiteral(v) {
+	return (
+		typeof v === 'object' &&
+		v !== null &&
+		/** @type {TemplateLiteralValue} */ (v).__template === true
+	);
+}
+
+/**
  * parseBlock の 1 行分の処理。result を変異させ、後続行で値を待つキーを返す。
  *
+ * #1917: 以下 3 形式に対応:
+ *   1. `key: 'simple string',`         (single quote)
+ *   2. `key: \`Hello ${NS.foo}\`,`     (template literal、interpolation 1+)
+ *   3. `key:` + 次行 `'value',` または `\`value\`,` (Biome multi-line)
+ *
+ * Template literal 値は `{ __template: true, raw: '...' }` で保持し、
+ * resolveTemplateLiterals() で interpolation を解決する。
+ *
  * @param {string} trimmed
- * @param {Record<string, string>} result
+ * @param {Record<string, string | TemplateLiteralValue>} result
  * @param {string | null} pendingKey
  * @returns {string | null}
  */
 function parseBlockLine(trimmed, result, pendingKey) {
-	// key: 'value', — same line
-	const sameLine = trimmed.match(/^(\w+):\s*'((?:[^'\\]|\\.)*)',?$/);
-	if (sameLine && sameLine[1] !== undefined && sameLine[2] !== undefined) {
-		result[sameLine[1]] = sameLine[2];
+	// key: 'value', — single quote, same line
+	const sameLineSingle = trimmed.match(/^(\w+):\s*'((?:[^'\\]|\\.)*)',?$/);
+	if (sameLineSingle && sameLineSingle[1] !== undefined && sameLineSingle[2] !== undefined) {
+		result[sameLineSingle[1]] = sameLineSingle[2];
+		return null;
+	}
+
+	// key: `...${X.foo}...`, — template literal, same line (#1917)
+	// バッククォートは `[^`\\]` で表現し、エスケープシーケンスをサポート
+	const sameLineTemplate = trimmed.match(/^(\w+):\s*`((?:[^`\\]|\\.)*)`,?$/);
+	if (sameLineTemplate && sameLineTemplate[1] !== undefined && sameLineTemplate[2] !== undefined) {
+		result[sameLineTemplate[1]] = { __template: true, raw: sameLineTemplate[2] };
 		return null;
 	}
 
@@ -135,11 +176,18 @@ function parseBlockLine(trimmed, result, pendingKey) {
 		return keyOnly[1];
 	}
 
-	// 'value', — continuation of pending key
+	// continuation of pending key
 	if (pendingKey) {
-		const valueOnly = trimmed.match(/^'((?:[^'\\]|\\.)*)',?$/);
-		if (valueOnly && valueOnly[1] !== undefined) {
-			result[pendingKey] = valueOnly[1];
+		// 'value', — single quote
+		const valueOnlySingle = trimmed.match(/^'((?:[^'\\]|\\.)*)',?$/);
+		if (valueOnlySingle && valueOnlySingle[1] !== undefined) {
+			result[pendingKey] = valueOnlySingle[1];
+			return null;
+		}
+		// `value`, — template literal (#1917)
+		const valueOnlyTemplate = trimmed.match(/^`((?:[^`\\]|\\.)*)`,?$/);
+		if (valueOnlyTemplate && valueOnlyTemplate[1] !== undefined) {
+			result[pendingKey] = { __template: true, raw: valueOnlyTemplate[1] };
 			return null;
 		}
 	}
@@ -148,7 +196,130 @@ function parseBlockLine(trimmed, result, pendingKey) {
 }
 
 /**
+ * Template literal の `${NS.key}` または `${NS["key"]}` / `${NS['key']}` 参照を
+ * 解決済み文字列に置換する (#1917)。
+ *
+ * 解決の流れ:
+ *   1. `${...}` 部分を抽出し `NS.key` 形式と照合
+ *   2. namespaces[NS] の対応 key を引き、文字列なら埋め込み、再度 template ならネスト解決
+ *   3. ネスト最大深度 (DEFAULT 8) を超えた場合は循環参照とみなして throw
+ *   4. namespace / key が不在なら "Unresolved ${NS}.${key} in ${owner}" で throw
+ *
+ * @param {string} raw - template literal 内側 (バッククォート除く)
+ * @param {Record<string, Record<string, string | TemplateLiteralValue>>} namespaces - NS 名 → key/value マップ
+ * @param {string} ownerLabel - エラーメッセージ用 (例: "LP_HERO_PRICE_BAND_LABELS.itemFree")
+ * @param {number} [depth=0] - 再帰深度
+ * @returns {string}
+ */
+function resolveTemplateLiteralValue(raw, namespaces, ownerLabel, depth = 0) {
+	const MAX_DEPTH = 8;
+	if (depth > MAX_DEPTH) {
+		throw new Error(
+			`Template literal resolution exceeded max depth (${MAX_DEPTH}) at ${ownerLabel}. ` +
+				'Possible circular reference.',
+		);
+	}
+	// `${ ... }` を非貪欲マッチ。エスケープ ($ → \$) は対象外 (labels.ts では使わない想定)。
+	return raw.replace(/\$\{([^}]+)\}/g, (_match, expr) => {
+		const trimmed = expr.trim();
+		// "NS.key" / "NS['key']" / 'NS["key"]' の 3 形式に対応
+		const dotMatch = trimmed.match(/^(\w+)\.(\w+)$/);
+		const bracketMatch = trimmed.match(/^(\w+)\[\s*['"]([^'"]+)['"]\s*\]$/);
+		const ns = dotMatch ? dotMatch[1] : bracketMatch ? bracketMatch[1] : null;
+		const key = dotMatch ? dotMatch[2] : bracketMatch ? bracketMatch[2] : null;
+		if (!ns || !key) {
+			throw new Error(
+				`Unsupported template literal expression "${trimmed}" in ${ownerLabel}. ` +
+					// biome-ignore lint/suspicious/noTemplateCurlyInString: 意図的に literal "${NS.key}" を含むメッセージ
+					'Only ${NS.key} / ${NS["key"]} / ${NS[\'key\']} are supported.',
+			);
+		}
+		const nsRecord = namespaces[ns];
+		if (!nsRecord) {
+			throw new Error(`Unresolved ${ns}.${key} in ${ownerLabel}: namespace ${ns} not found.`);
+		}
+		const value = nsRecord[key];
+		if (value === undefined) {
+			throw new Error(`Unresolved ${ns}.${key} in ${ownerLabel}: key ${key} not in ${ns}.`);
+		}
+		if (isTemplateLiteral(value)) {
+			// ネスト解決
+			return resolveTemplateLiteralValue(value.raw, namespaces, `${ns}.${key}`, depth + 1);
+		}
+		return value;
+	});
+}
+
+/**
+ * すべての namespace を template literal 解決済み文字列レコードに変換する (#1917)。
+ * 解決失敗時は throw する (caller 側で詳細エラーが伝播)。
+ *
+ * 動作:
+ *   - 文字列値はそのまま
+ *   - TemplateLiteralValue は resolveTemplateLiteralValue で文字列化
+ *
+ * @param {Record<string, Record<string, string | TemplateLiteralValue>>} namespaces
+ * @returns {Record<string, Record<string, string>>}
+ */
+function resolveAllTemplates(namespaces) {
+	/** @type {Record<string, Record<string, string>>} */
+	const resolved = {};
+	for (const [nsName, nsRecord] of Object.entries(namespaces)) {
+		/** @type {Record<string, string>} */
+		const resolvedNs = {};
+		for (const [key, value] of Object.entries(nsRecord)) {
+			if (typeof value === 'string') {
+				resolvedNs[key] = value;
+			} else if (isTemplateLiteral(value)) {
+				resolvedNs[key] = resolveTemplateLiteralValue(value.raw, namespaces, `${nsName}.${key}`);
+			}
+		}
+		resolved[nsName] = resolvedNs;
+	}
+	return resolved;
+}
+
+/**
+ * terms.ts (将来導入予定) から atom 定数を抽出する。
+ * ファイルが存在しない場合は空オブジェクトを返す (本 PR 単独では terms.ts 未導入のため)。
+ *
+ * #1917: template literal 解決のための atom 参照元。
+ * 探索対象: ファイル内の全 `export const X_TERMS = { ... }` ブロック。
+ *
+ * @returns {Record<string, Record<string, string | TemplateLiteralValue>>}
+ */
+function parseTermsTs() {
+	if (!fs.existsSync(TERMS_TS)) {
+		return {};
+	}
+	const src = fs.readFileSync(TERMS_TS, 'utf-8');
+	/** @type {Record<string, Record<string, string | TemplateLiteralValue>>} */
+	const result = {};
+	// `export const FOO_TERMS = {` パターンを全て抽出
+	// 名前: 大文字スネークケースの定数名のみ対象 (atom 専用慣習)
+	const constPattern = /export const (\w+)\s*[:=]/g;
+	const seen = new Set();
+	const matches = src.matchAll(constPattern);
+	for (const m of matches) {
+		const name = m[1];
+		if (!name || seen.has(name)) continue;
+		seen.add(name);
+		const block = parseBlock(src, name);
+		if (Object.keys(block).length > 0) {
+			result[name] = block;
+		}
+	}
+	return result;
+}
+
+/**
  * labels.ts から定数を抽出する簡易パーサ（TS コンパイラなしで読み取る）
+ *
+ * #1917: parseLabelsTs は以下の 2 段階で動作する。
+ *   Phase 1: 全 namespace を raw (template literal は marker で保持) でパース
+ *   Phase 2: terms.ts を読み込み、namespaces map に統合
+ *   Phase 3: resolveAllTemplates で interpolation を解決
+ * 解決失敗時は throw + 詳細表示 (Unresolved ${ns}.${key} in ${owner})
  */
 function parseLabelsTs() {
 	const src = fs.readFileSync(LABELS_TS, 'utf-8');
@@ -194,34 +365,74 @@ function parseLabelsTs() {
 	const lpLegalSlaLabels = parseBlock(src, 'LP_LEGAL_SLA_LABELS');
 	const lpLegalTokushohoLabels = parseBlock(src, 'LP_LEGAL_TOKUSHOHO_LABELS');
 
+	// #1917: terms.ts (atom) を取り込み、template literal を解決
+	// 全 namespace を一つの map に束ね、resolveAllTemplates で interpolation を済ませる。
+	// 解決失敗時は throw され、CLI / --check が exit 1 で停止する。
+	const termsNamespaces = parseTermsTs();
+	/** @type {Record<string, Record<string, string | TemplateLiteralValue>>} */
+	const allNamespaces = {
+		...termsNamespaces,
+		AGE_TIER_LABELS: ageTierLabels,
+		AGE_TIER_SHORT_LABELS: ageTierShort,
+		PLAN_LABELS: planLabels,
+		LP_RETENTION_LABELS: lpRetentionLabels,
+		LP_CORELOOP_LABELS: lpCoreloopLabels,
+		LP_NAV_LABELS: lpNavLabels,
+		LP_FOOTER_LABELS: lpFooterLabels,
+		LP_COMMON_LABELS: lpCommonLabels,
+		LP_LEGAL_DISCLAIMER_LABELS: lpLegalDisclaimerLabels,
+		LP_VERSUS_LABELS: lpVersusLabels,
+		LP_GROWTH_ROADMAP_LABELS: lpGrowthRoadmapLabels,
+		LP_PRICING_LABELS: lpPricingLabels,
+		LP_LICENSEKEY_LABELS: lpLicenseKeyLabels,
+		LP_FAQ_LABELS: lpFaqLabels,
+		LP_SELFHOST_LABELS: lpSelfhostLabels,
+		LP_INDEX_EXTRA_LABELS: lpIndexExtraLabels,
+		LP_FLOATING_CTA_LABELS: lpFloatingCtaLabels,
+		LP_PAMPHLET_LABELS: lpPamphletLabels,
+		LP_PRICING_EXTRA_LABELS: lpPricingExtraLabels,
+		LP_INDEX_PHASEB_LABELS: lpIndexPhaseBLabels,
+		LP_PRICING_PHASEB_LABELS: lpPricingPhaseBLabels,
+		LP_FAQ_PHASEB_LABELS: lpFaqPhaseBLabels,
+		LP_PAMPHLET_PHASEB_LABELS: lpPamphletPhaseBLabels,
+		LP_LEGAL_PRIVACY_LABELS: lpLegalPrivacyLabels,
+		LP_LEGAL_TERMS_LABELS: lpLegalTermsLabels,
+		LP_LEGAL_SLA_LABELS: lpLegalSlaLabels,
+		LP_LEGAL_TOKUSHOHO_LABELS: lpLegalTokushohoLabels,
+	};
+	const resolved = resolveAllTemplates(allNamespaces);
+
+	// 全 namespace は resolveAllTemplates で必ず entry を持つ (Object.entries で全件処理)
+	// が、TS 型上は Record<string, ...> なので index access が optional 扱い。
+	// `?? {}` で defensive fallback を付与。
 	return {
-		ageTierLabels,
-		ageTierShort,
-		planLabels,
-		lpRetentionLabels,
-		lpCoreloopLabels,
-		lpNavLabels,
-		lpFooterLabels,
-		lpCommonLabels,
-		lpLegalDisclaimerLabels,
-		lpVersusLabels,
-		lpGrowthRoadmapLabels,
-		lpPricingLabels,
-		lpLicenseKeyLabels,
-		lpFaqLabels,
-		lpSelfhostLabels,
-		lpIndexExtraLabels,
-		lpFloatingCtaLabels,
-		lpPamphletLabels,
-		lpPricingExtraLabels,
-		lpIndexPhaseBLabels,
-		lpPricingPhaseBLabels,
-		lpFaqPhaseBLabels,
-		lpPamphletPhaseBLabels,
-		lpLegalPrivacyLabels,
-		lpLegalTermsLabels,
-		lpLegalSlaLabels,
-		lpLegalTokushohoLabels,
+		ageTierLabels: resolved.AGE_TIER_LABELS ?? {},
+		ageTierShort: resolved.AGE_TIER_SHORT_LABELS ?? {},
+		planLabels: resolved.PLAN_LABELS ?? {},
+		lpRetentionLabels: resolved.LP_RETENTION_LABELS ?? {},
+		lpCoreloopLabels: resolved.LP_CORELOOP_LABELS ?? {},
+		lpNavLabels: resolved.LP_NAV_LABELS ?? {},
+		lpFooterLabels: resolved.LP_FOOTER_LABELS ?? {},
+		lpCommonLabels: resolved.LP_COMMON_LABELS ?? {},
+		lpLegalDisclaimerLabels: resolved.LP_LEGAL_DISCLAIMER_LABELS ?? {},
+		lpVersusLabels: resolved.LP_VERSUS_LABELS ?? {},
+		lpGrowthRoadmapLabels: resolved.LP_GROWTH_ROADMAP_LABELS ?? {},
+		lpPricingLabels: resolved.LP_PRICING_LABELS ?? {},
+		lpLicenseKeyLabels: resolved.LP_LICENSEKEY_LABELS ?? {},
+		lpFaqLabels: resolved.LP_FAQ_LABELS ?? {},
+		lpSelfhostLabels: resolved.LP_SELFHOST_LABELS ?? {},
+		lpIndexExtraLabels: resolved.LP_INDEX_EXTRA_LABELS ?? {},
+		lpFloatingCtaLabels: resolved.LP_FLOATING_CTA_LABELS ?? {},
+		lpPamphletLabels: resolved.LP_PAMPHLET_LABELS ?? {},
+		lpPricingExtraLabels: resolved.LP_PRICING_EXTRA_LABELS ?? {},
+		lpIndexPhaseBLabels: resolved.LP_INDEX_PHASEB_LABELS ?? {},
+		lpPricingPhaseBLabels: resolved.LP_PRICING_PHASEB_LABELS ?? {},
+		lpFaqPhaseBLabels: resolved.LP_FAQ_PHASEB_LABELS ?? {},
+		lpPamphletPhaseBLabels: resolved.LP_PAMPHLET_PHASEB_LABELS ?? {},
+		lpLegalPrivacyLabels: resolved.LP_LEGAL_PRIVACY_LABELS ?? {},
+		lpLegalTermsLabels: resolved.LP_LEGAL_TERMS_LABELS ?? {},
+		lpLegalSlaLabels: resolved.LP_LEGAL_SLA_LABELS ?? {},
+		lpLegalTokushohoLabels: resolved.LP_LEGAL_TOKUSHOHO_LABELS ?? {},
 	};
 }
 
@@ -606,4 +817,12 @@ if (invokedAsCli) {
 }
 
 // #1772: 単体テスト用に parseBlock / parseSimpleBlock をエクスポート
-export { parseBlock, parseSimpleBlock };
+// #1917: template literal 解決ロジックも追加 (parseBlockLine / resolveTemplateLiteralValue / resolveAllTemplates / isTemplateLiteral)
+export {
+	isTemplateLiteral,
+	parseBlock,
+	parseBlockLine,
+	parseSimpleBlock,
+	resolveAllTemplates,
+	resolveTemplateLiteralValue,
+};


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（後続 SSOT 2 階層化 #1916 の基盤、結果として LP / アプリ双方の文言一貫性に裨益）

**解決する課題**: 現状の `src/lib/domain/labels.ts` は 6700 行 / 135 namespace で atom (`PLAN_TERMS.standard` 等) と compound (`LP_HERO_PRICE_BAND_LABELS.itemFree`) が混在しており、SSOT 階層が崩壊している。これを `src/lib/domain/terms.ts` (atom 専用) → `labels.ts` (compound、必ず terms を template literal で参照) の 2 階層に整理する Phase 1 では、まず generator (`scripts/generate-lp-labels.mjs`) が template literal を解決できる必要がある。現行 parser (`parseBlockLine`) は `key: 'value',` の single quote のみマッチし、template literal を破棄してしまう。

**期待される効果**: 後続 #1916 で `terms.ts` 新設 + `labels.ts` 内の compound を template literal 化する作業がこの PR の parser を前提に実装可能になる。本 PR 単独では labels.ts に template literal を含まないため、既存挙動 (`shared-labels.js` 出力) は完全に保たれる。

## 関連 Issue

closes #1917

- Phase 1 基盤: blocks #1916 (terms.ts 新設、本 PR の parser を前提とする)
- 関連 ADR: ADR-0009 (labels.ts SSOT 化原則)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `parseBlockLine` が template literal 形式 (`` key: `...${X.foo}...`, ``) をマッチ | `node --test scripts/__tests__/generate-lp-labels.test.mjs` describe "parseBlockLine — template literal 対応 (#1917 AC1)" | PASS (5 tests, single quote / template literal × same-line / multi-line 全 4 形式 + interpolation 不在 template) |
| AC2 | `parseLabelsTs()` で terms.ts / 既存 LABELS を **先にパース** し、参照側 namespace で `${X.foo}` を解決済み文字列に置換 | 同上 describe "resolveAllTemplates — interpolation 解決 (#1917 AC2)" + AC6 統合テスト | PASS (5 tests: simple / multiple / nested 3 階層 / bracket notation `["key"]` & `['key']` / 文字列値スルー) |
| AC3 | 解決失敗時 (該当 namespace.key が存在しない) は throw + 詳細表示 (例: `Unresolved PLAN_TERMS.unknownKey in LP_HERO_PRICE_BAND_LABELS.itemFree`) | 同上 describe "resolveTemplateLiteralValue — エラー表示 (#1917 AC3)" | PASS (5 tests: namespace 不在 / key 不在 / nested 不在 / 循環参照 max depth / 未サポート式) |
| AC4 | `--check` モードで CI fail 検出 | `node scripts/generate-lp-labels.mjs --check` を本 PR ローカル実行 | PASS (`✓ site/shared-labels.js は最新です` / 既存 `--check` モードは保持、template literal 解決失敗時は throw で exit 1 = CI fail 経路) |
| AC5 | 既存 shared-labels.js 出力差分ゼロ (本 PR 単独では terms.ts 未導入のため、fixture テストで template literal 解決を検証) | `node scripts/generate-lp-labels.mjs --check` + describe "既存 labels.ts は template literal を含まない (#1917 AC5)" | PASS (実 labels.ts 主要 5 namespace を parseBlock し、戻り値が全て string であることを assert) |
| AC6 | `scripts/__tests__/generate-lp-labels.test.mjs` 新設、simple / nested / unresolved / multi-line を網羅 | `node --test scripts/__tests__/generate-lp-labels.test.mjs` 全実行 | PASS (5 suites / 19 tests / pass 19 / fail 0、duration 105ms) |

**実行ログ**:

```
$ node --test scripts/__tests__/generate-lp-labels.test.mjs
# tests 19
# suites 5
# pass 19
# fail 0
# duration_ms 105
```

```
$ node scripts/generate-lp-labels.mjs --check
✓ site/shared-labels.js は最新です
```

```
$ npm run pre-ready
[pre-ready] ✓ Step 1/7: biome check
[pre-ready] ✓ Step 2/7: svelte-check (TS strict)  ← 0 ERRORS
[pre-ready] ✓ Step 3/7: vitest run (unit test)    ← 4401 passed
[pre-ready] ✓ Step 4/7: check-hardcoded-strings.mjs
[pre-ready] ⊘ Step 5/7: measure-lp-dimensions.mjs (LP 変更検知: NO — skip)
[pre-ready] ⊘ Step 6/7: check-pr-body.mjs (--pr 未指定 — skip)
[pre-ready] ⊘ Step 7/7: capture.mjs (UI 変更検知: NO — skip)
[pre-ready] ALL PASS — Ready for Review に進めます。
```

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト
- [x] 設定・CI (`scripts/generate-lp-labels.mjs` parser 拡張 + `scripts/__tests__/generate-lp-labels.test.mjs` 新設)

**影響を受ける画面・機能**:

本 PR 単独では UI 変更ゼロ。`scripts/generate-lp-labels.mjs` の出力 (`site/shared-labels.js`) も完全 byte-identical。後続 #1916 で labels.ts に template literal が混入したときに、本 parser が解決経路を提供する。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready` 全 Step PASS**（#1775 / ADR-0030）— Step 1-4 PASS、Step 5-7 (LP / PR body / capture) は本 PR の変更内容上 skip 妥当
- [x] 追加・変更したテストの概要:
  - `scripts/__tests__/generate-lp-labels.test.mjs` 新設 (5 suites / 19 tests)
    - parseBlockLine: 4 形式 (single quote / template literal × same-line / multi-line) + interpolation 不在 template
    - resolveAllTemplates: simple / multiple interpolation / nested 3 階層 / bracket notation (`["key"]` & `['key']`) / 文字列値スルー
    - resolveTemplateLiteralValue throw: namespace 不在 / key 不在 / nested 不在 / 循環参照 max depth / 未サポート式
    - parseBlock 統合: mixed (single + template) / multi-line template / 実 #1917 例
    - 既存 labels.ts は template literal を含まない (shared-labels.js 差分ゼロ保証)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A (`priority:high` infra Issue)

## スクリーンショット / ビジュアルデモ

**該当なし（理由: ビルドタイムスクリプト + ユニットテストのみの変更で UI / LP / shared-labels.js 出力に変化なし。`node scripts/generate-lp-labels.mjs --check` で出力差分ゼロを確認済）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**:
  - 単一責任: `parseBlockLine` (1 行のフォーマット判定) / `resolveTemplateLiteralValue` (interpolation 解決単位) / `resolveAllTemplates` (バッチ適用) / `parseTermsTs` (terms.ts 専用 reader) を関数ごとに分離
  - 依存性逆転: `parseTermsTs` は terms.ts 不在を許容 (本 PR 単独では未導入)、`parseBlock` は constName を引数で受け取る
  - インターフェース分離: `TemplateLiteralValue` 型は `{ __template: true, raw: string }` 1 形でクライアント側は `isTemplateLiteral` で判定
- [x] **DRY**: parseBlockLine 内 single quote / template literal の 2 形式は対称な regex で表現、共通の trim → match → set パターンを踏襲。resolveAllTemplates は Object.entries で全 namespace を一律処理
- [x] **YAGNI**: 関数呼出 / 三項式などの複雑な template literal 構文はサポートしない (Issue 範囲外)。`Unsupported template literal expression` で明示 throw し、必要時に拡張する設計
- [x] **Security**: ビルドタイムスクリプトのみ。秘密情報の hardcode なし
- [x] **アクセシビリティ**: N/A (CLI script)
- [x] **パフォーマンス**: O(N × K) (N=namespace 数、K=平均 key 数)。max depth 8 で循環参照を早期検出。labels.ts 全体 (135 namespace) で実測 < 100ms

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — ビルドスクリプトのみで、本番アプリ / デモ / LP / 全年齢モード / ナビ / E2E シードに影響しない
- [x] labels SSOT (ADR-0009): 本 PR は **labels.ts の SSOT 構造を補強する基盤**であり、SSOT 違反は導入しない (shared-labels.js 出力 byte-identical)
- [x] 設計書同期 (ADR-0001): 本 PR は **labels.ts の中身を変更しない**ため `docs/DESIGN.md §6` の用語辞書一覧は更新不要。後続 #1916 で terms.ts 新設時に DESIGN.md §6 を更新する
- [x] 並行 PR overlap 確認 (#1200): `scripts/generate-lp-labels.mjs` を直近変更している open PR はなし (`git log --since="30 days ago" -- scripts/generate-lp-labels.mjs` 確認済)

**LP / 販促文言変更時** (ADR-0013): N/A (parser 変更のみ、文言ゼロ)

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** — 既存 single quote 形式は完全互換、shared-labels.js 出力は byte-identical (`--check` PASS)
- [ ] 含まれる

**レビュー依頼事項・QA**:

1. `parseBlockLine` で `[^`\\]` ベースの template literal regex がエスケープバッククォート (`\``) を正しく扱えるか — 現状の labels.ts では使用例がないが、将来 `${X}` 内に `` ` `` を含めたい場合は別 PR で拡張する想定
2. `resolveTemplateLiteralValue` の MAX_DEPTH = 8 が過剰 / 不足ではないか — terms.ts → labels.ts は通常 2 階層で完結する想定だが、保守的に 8 段としている
3. `parseTermsTs` の constPattern (`/export const (\w+)\s*[:=]/g`) が将来の terms.ts に追加されるかもしれない type alias `export type X = ...` を誤検出しないか — `parseBlock` 自体が `extractBraceBlock` で `{` を要求するため、type alias は parseBlock で空オブジェクトとなり result に追加されない設計

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (AC1-AC6)
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照。
