### PR TITLE
refactor: #1928 cloud-export-service.ts PLAN リテラル撤廃 (Phase 2 C3)

### DIFF
--- a/src/lib/server/services/cloud-export-service.ts
+++ b/src/lib/server/services/cloud-export-service.ts
@@ -2,6 +2,7 @@
 // クラウドエクスポート共有サービス（PIN付きS3保管 + インポート）
 
 import { randomInt } from 'node:crypto';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { getAuthMode } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import type { CloudExportRecord, CloudExportType } from '$lib/server/db/types';
@@ -142,7 +143,7 @@ export async function createCloudExport(options: CloudExportOptions): Promise<Cl
 	const tier: PlanTier = await resolveFullPlanTier(tenantId, licenseStatus, planId);
 	const limits = getPlanLimits(tier);
 	if (limits.maxCloudExports === 0) {
-		throw new Error('クラウドエクスポートはスタンダードプラン以上でご利用いただけます');
+		throw new Error(PLAN_GATE_LABELS.standardOrAboveFor('クラウドエクスポート'));
 	}
 
 	// 保管数上限チェック


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / システム全体（保守性）

**解決する課題**: クラウドエクスポート機能のプラン制限エラーメッセージが `cloud-export-service.ts` 内に直書きリテラル（"クラウドエクスポートはスタンダードプラン以上でご利用いただけます"）として存在し、プラン名（"スタンダード"）の変更や文言調整が散在 PR に分裂する。terms.ts SSOT 2 階層化（#1916 / ADR-0045）の Phase 2 として、char-by-char 一致を保証しながら atom (PLAN_FULL_TERMS) → compound (PLAN_GATE_LABELS) → 表示文字列の参照経路に統一する。

**期待される効果**: プラン名 1 行修正で全 11+ 箇所のエラーメッセージに伝播。新規プラン追加・名称変更時の散在修正コスト削減。文言一貫性の構造的担保。

## 関連 Issue

closes #1928

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/lib/server/services/cloud-export-service.ts L145 "クラウドエクスポートはスタンダードプラン以上でご利用いただけます" を PLAN_GATE_LABELS.standardOrAboveFor 経由に | `git diff src/lib/server/services/cloud-export-service.ts` | PASS — `throw new Error(PLAN_GATE_LABELS.standardOrAboveFor('クラウドエクスポート'))` に置換 |
| AC2 | 既存 vitest PASS | `npx vitest run tests/unit/services/cloud-export-service.test.ts` | PASS — 16 tests passed (test file 内の `'スタンダードプラン以上'` 部分一致 assertion も継続成立) |
| AC3 | grep 'スタンダードプラン' src/lib/server/services/cloud-export-service.ts で 0 件 | `grep 'スタンダードプラン' src/lib/server/services/cloud-export-service.ts` | PASS — No matches found |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- 親管理画面のクラウドエクスポート機能（プラン制限超過時のエラーメッセージのみ。表示文字列は char-by-char 不変）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 個別 gate (biome / svelte-check / vitest / check-no-plan-literals) PASS をローカル確認
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - N/A — 既存 `tests/unit/services/cloud-export-service.test.ts` の assertion (`rejects.toThrow('スタンダードプラン以上')`) は部分一致のため変更不要。リテラル → compound 参照変換のため挙動不変
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: refactor のみ。サービス層のエラーメッセージリテラルを compound 関数呼び出しに置換するだけで、表示文字列は char-by-char 不変（`PLAN_GATE_LABELS.standardOrAboveFor('クラウドエクスポート')` は `${feature}は${PLAN_FULL_TERMS.standard}以上でご利用いただけます` を返す = "クラウドエクスポートはスタンダードプラン以上でご利用いただけます" と完全一致）。UI 変更ゼロ。

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A — UI 変更なし | N/A — UI 変更なし |
| **修正後** | N/A — UI 変更なし | N/A — UI 変更なし |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（プラン制限エラー文言生成は PLAN_GATE_LABELS namespace の責務。cloud-export-service は consumer に純化）
- [x] **DRY**: `grep 'クラウドエクスポートはスタンダードプラン以上'` で他箇所重複なし。Phase 2 C0-C15 全体では 11+ 箇所が PLAN_GATE_LABELS に集約予定（#1925）
- [x] **YAGNI**: 既存テンプレート関数の利用のみ。新規抽象化なし
- [x] **Security（OSS 公開前提）**: N/A — 文言置換のみ、認可ロジック不変
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: N/A — テンプレート関数呼び出し 1 回のみ追加（無視可能）

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [ ] E2E / ユニットシード + チュートリアル を同期
- [x] **labels SSOT** (ADR-0009 / ADR-0045): エラーメッセージは `src/lib/domain/labels.ts` の `PLAN_GATE_LABELS.standardOrAboveFor` 経由で組み立て、リテラル直書き 0 件
- [ ] **設計書同期** (ADR-0001): 影響を受ける `docs/design/` の設計書を同 PR で更新 — 該当なし（リテラル → compound 参照変換のみ、仕様変更なし）
- [x] **並行 PR overlap** (#1200): Phase 2 C0 (#1925, merged) → C3 (#1928, this PR) の直列依存。同ファイル変更の他 open PR なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314):

該当なし — N/A。LP / pricing / plan-features.ts / pricing-strategy.md の文言変更なし。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
- char-by-char 一致の確認: `PLAN_GATE_LABELS.standardOrAboveFor('クラウドエクスポート')` = `クラウドエクスポートはスタンダードプラン以上でご利用いただけます`（PLAN_FULL_TERMS.standard = `スタンダードプラン`）。テンプレート関数定義は `src/lib/domain/labels.ts` L304-L316 を参照
- 既存テスト `cloud-export-service.test.ts` L176 の `rejects.toThrow('スタンダードプラン以上')` は部分一致 assertion のため、文字列が一致する限り通過し続ける（実際 16 tests PASS）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（個別 gate 同等: biome / svelte-check / vitest / check-no-plan-literals 全 PASS）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし、import 1 行 + L145 1 行のみ）
- [x] 全 AC が実装済み（AC1-AC3 全完了）
- [x] Phase 分割した場合: Phase 2 C3 として PO 起票済 Issue #1928 を実装（C0 #1925 merged 済）
- [x] UI 変更時: 該当なし（refactor のみ、表示文字列 char-by-char 不変）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
