### PR TITLE
refactor: #1926 errors.ts JSDoc の PLAN リテラル撤廃 (Phase 2 C1)

### DIFF
--- a/src/lib/domain/errors.ts
+++ b/src/lib/domain/errors.ts
@@ -15,11 +15,14 @@ import type { PlanTier } from '$lib/server/services/plan-limit-service';
  *
  * ## レスポンス例
  *
+ * `message` は `PLAN_GATE_LABELS.standardOrAboveFor('AI 活動提案')` 等で組み立てる
+ * （プラン名直書き禁止、SSOT は `src/lib/domain/labels.ts` PLAN_GATE_LABELS / #1925 / #1926）。
+ *
  * ```json
  * {
  *   "error": {
  *     "code": "PLAN_LIMIT_EXCEEDED",
- *     "message": "AI 活動提案はスタンダードプラン以上でご利用いただけます",
+ *     "message": "<PLAN_GATE_LABELS.standardOrAboveFor('AI 活動提案') の戻り値>",
  *     "currentTier": "free",
  *     "requiredTier": "standard",
  *     "upgradeUrl": "/admin/license"
@@ -39,6 +42,7 @@ import type { PlanTier } from '$lib/server/services/plan-limit-service';
  *
  * @see docs/design/07-API設計書.md §4.2 プラン制限エラー
  * @see ADR-0024 plan-tier-resolution-pattern
+ * @see PLAN_GATE_LABELS in src/lib/domain/labels.ts (プラン制限メッセージ SSOT)
  */
 export interface PlanLimitError {
 	/** 常に 'PLAN_LIMIT_EXCEEDED' */
@@ -59,10 +63,21 @@ export type PlanLimitErrorBody = PlanLimitError;
 /**
  * PlanLimitError を組み立てるヘルパー。
  *
+ * `message` は `PLAN_GATE_LABELS` のテンプレートメソッド経由で組み立てること
+ * （プラン名直書き禁止、SSOT は `src/lib/domain/labels.ts` PLAN_GATE_LABELS / #1925 / #1926）。
+ *
  * @example
  * ```ts
+ * import { PLAN_GATE_LABELS } from '$lib/domain/labels';
+ *
  * return json(
- *   { error: createPlanLimitError('free', 'standard', 'AI 活動提案はスタンダードプラン以上でご利用いただけます') },
+ *   {
+ *     error: createPlanLimitError(
+ *       'free',
+ *       'standard',
+ *       PLAN_GATE_LABELS.standardOrAboveFor('AI 活動提案'),
+ *     ),
+ *   },
  *   { status: 403 },
  * );
  * ```


### PR DESCRIPTION
## 顧客価値・目的

SSOT 化 / labels.ts 集約を伴う refactor PR。`src/lib/domain/errors.ts` の JSDoc コメント内に直書きされていた「AI 活動提案はスタンダードプラン以上でご利用いただけます」リテラルを撤廃し、Phase 2 C0 (#1925、PR #1967) で導入された `PLAN_GATE_LABELS.standardOrAboveFor` 経由の構築指針に書き換える。

**対象ユーザー**: 開発者（Dev / QA） / システム全体

**解決する課題**: プラン名 (「スタンダードプラン」「ファミリープラン」) が JSDoc 例にハードコードされていると、PLAN_FULL_TERMS atom (terms.ts) を変更したときに JSDoc 上の例だけ古い表記が残り、SSOT 2 階層化原則 (ADR-0045) と乖離する。grep で「ファミリープラン」「スタンダードプラン」リテラル検索が JSDoc 内のノイズで埋もれ、本来の追跡対象 (リテラル直書き残骸) が検出しにくくなる。

**期待される効果**: terms.ts → labels.ts → PLAN_GATE_LABELS の 1 階層 SSOT 経路に errors.ts JSDoc も整列。grep `スタンダードプラン|ファミリープラン src/lib/domain/errors.ts` が 0 件になり、後続 C2-C15 リテラル置換時の grep 信号対雑音比が向上。`@see PLAN_GATE_LABELS in src/lib/domain/labels.ts` 行も追加し、JSDoc 読者を SSOT へ誘導。

## 関連 Issue

closes #1926

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/lib/domain/errors.ts L22 (JSDoc) と L65 (createPlanLimitError 例) の "AI 活動提案はスタンダードプラン以上でご利用いただけます" を PLAN_GATE_LABELS.standardOrAboveFor 経由に | `git diff src/lib/domain/errors.ts` で旧リテラル削除 + `@example` 内に `PLAN_GATE_LABELS.standardOrAboveFor('AI 活動提案')` 呼び出しが入った構築指針記載を確認 | **PASS** — レスポンス例 message を `<PLAN_GATE_LABELS.standardOrAboveFor('AI 活動提案') の戻り値>` プレースホルダーに変更、`@example` ブロックを `import { PLAN_GATE_LABELS } from '$lib/domain/labels';` + `PLAN_GATE_LABELS.standardOrAboveFor('AI 活動提案')` 呼び出し形式に再構成 |
| AC2 | 既存 vitest PASS | `npx vitest run` (worktree) | **PASS** — 4402 tests / 230 files PASS。tests/unit/domain/plan-gate-labels.test.ts (13 tests) も継続 PASS。1 file (downgrade-service.test.ts) は並列 worker の sqlite I/O 競合で fail したが単独 `npx vitest run tests/unit/services/downgrade-service.test.ts` は PASS、本 PR 差分とは無関係 |
| AC3 | grep -E '"スタンダードプラン"\|"ファミリープラン"' src/lib/domain/errors.ts で 0 件 | `grep -E '"スタンダードプラン"\|"ファミリープラン"' src/lib/domain/errors.ts` + `grep -nE 'スタンダードプラン\|ファミリープラン' src/lib/domain/errors.ts` 両方実行 | **PASS** — 両 grep 共に 0 件 (exit 1)。クォートあり版だけでなくリテラル全体 (JSDoc 内含む) も完全撤廃 |

## 変更タイプ

- [x] refactor: リファクタリング

## 移動先対応マップ（必須）

JSDoc 内のテキスト書き換えのみで、ファイル移動・SSOT 統合元削除は無し。**「リテラル → テンプレート参照」 の置換であり、SSOT は Phase 2 C0 (PR #1967) で既に確立済み**。

| 旧 path | 新 path | 種別 | import / 参照更新件数 |
|---|---|---|---|
| `src/lib/domain/errors.ts` JSDoc 内の `"AI 活動提案はスタンダードプラン以上でご利用いただけます"` リテラル直書き (2 箇所、L22 / L65) | `PLAN_GATE_LABELS.standardOrAboveFor('AI 活動提案')` 経由構築 (説明 + `@example` 内呼び出し) | リテラル → SSOT 参照置換 | errors.ts 1 ファイル / 実コード行 0 (JSDoc コメントのみ) |

**全件確認コマンド**:
```bash
# 旧リテラル参照が JSDoc にも残っていないことを確認
grep -E '"スタンダードプラン"|"ファミリープラン"' src/lib/domain/errors.ts
# → 0 件 (exit 1) PASS

# 念のため grep ワード単体（JSDoc 内含む）も 0 件であること
grep -nE 'スタンダードプラン|ファミリープラン' src/lib/domain/errors.ts
# → 0 件 (exit 1) PASS

# 他ファイル（C2-C15 対象）の残リテラル件数確認 — 本 PR では errors.ts のみ範囲外確認
grep -rE 'スタンダードプラン|ファミリープラン' src/lib/server/ src/routes/ --include="*.ts"
# → C2-C15 対象として #1925 series 内で個別 PR で順次撤廃
```

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ドメインモデル (`$lib/domain/errors.ts` JSDoc コメントのみ)

実コード差分はゼロ (JSDoc コメント / `@example` ブロックのみ修正)。実 UI / 実 LP / 実 API レスポンスは一切変化しない。

**影響を受ける画面・機能**: 描画変化なし（#1744 ルールに準拠）。errors.ts は型定義 + ヘルパー関数 (`createPlanLimitError` / `isPlanLimitError` / `getErrorMessage`) のみ export し、JSDoc 修正は実行コードに影響しない。`shared-labels.js` 再生成 diff = 0 で確認済み。

## 「描画変化なし」根拠（#1744）

- [x] **ラベル文字列**: 実コードに表示されるラベルは一切変更していない (JSDoc コメントのみ修正)。`createPlanLimitError(...)` の出力 `message` プロパティは引数で受けた string をそのまま返すため、呼び出し側 (server / +page.server.ts) のメッセージ文字列も無変化。`shared-labels.js` 再生成 diff = 0 で LP 側も無影響を確認
- [x] **HTML 構造**: 本 PR では HTML / Svelte コンポーネントを 1 行も触らないため、DOM tree は完全に同一
- [x] **CSS class 名**: CSS / Tailwind / class 名の変更なし
- [x] **改行位置 / アイコン / 句読点**: 表示される文字列に変更なし (JSDoc 内のみ修正)
- [x] **不可視属性 (`aria-*` / `data-*`)**: 追加なし

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — Step 1 (biome) / 2 (svelte-check) / 3 (vitest) / 4 (hardcoded-strings) / 5 (lp-dimensions) を個別ローカル PASS 確認済 (下記証跡)。Step 6/7 (PR body / mergeable) は本 PR 作成直後に `--pr <num>` 付き再実行で検証する
  - biome: `npx biome check --error-on-warnings src/lib/domain/errors.ts` → `Checked 1 file in 222ms. No fixes applied.` PASS (warning 0 件)
  - svelte-check: `0 errors / 13 warnings` PASS (warnings は本 PR と無関係の既存項目)
  - vitest: 4402 tests PASS (1 file は並列 sqlite I/O 競合、単独実行で PASS、本 PR と無関係)
  - check-no-plan-literals: `[check-no-plan-literals] OK — リテラル直書きなし` PASS
  - shared-labels.js diff: 0 行 PASS (`node scripts/generate-lp-labels.mjs` 実行後)
- [x] 追加・変更したテストの概要: 新規テスト追加なし（既存 `tests/unit/domain/plan-gate-labels.test.ts` 13 tests が PLAN_GATE_LABELS の char-by-char 一致を保証しており、本 PR の JSDoc 内例文の正しさは Phase 2 C0 のテストで間接担保される。errors.ts は JSDoc 修正のみで実コードゼロ変更のため新規 unit test を追加する対象がない）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor のみ、描画変化ゼロ、根拠は上記「描画変化なし」根拠セクション）**

理由:
- 本 PR は `src/lib/domain/errors.ts` の **JSDoc コメントブロックのみ** を変更 (実行コード差分ゼロ、`git diff --stat` で +17 / -2 行のうち全行 JSDoc 内)
- LP `site/shared-labels.js` 再生成 diff = 0 で LP 側にも無影響
- `createPlanLimitError(...)` のシグネチャ・戻り値も無変化 (TypeScript 型 / 関数本体 / `as` キャスト無し)
- どの画面 (`/admin/*` / `/demo/*` / LP) を撮影しても 1px の差分も発生しない

`tests/unit/domain/plan-gate-labels.test.ts` の 13 件テストが PLAN_GATE_LABELS の char-by-char 一致を保証しているため、ユーザー可視メッセージの一貫性も間接的に担保される。

### 4 スロット: 代表 SS (LP `/index.html`、visual baseline 確認用)

JSDoc 内変更により実 UI / LP に1pxの差も出ないことを示す代表 SS を 2 ビューポート × 1 ページで添付。修正前 / 修正後を別撮りしても完全同一になるため、本 PR では「修正後」のみを baseline として添付し、修正前 = 修正後の主張を読み手に視認可能にする。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | (= 修正後と完全同一、`shared-labels.js` diff = 0 で証明) | (= 修正後と完全同一、`shared-labels.js` diff = 0 で証明) |
| **修正後** | ![index-html-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-1975/index-html-mobile.png) | ![index-html-desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-1975/index-html-desktop.png) |

DOM HTML スナップショット (#1747 / #1766):
- [index-html-desktop.dom.html](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-1975/index-html-desktop.dom.html)
- [index-html-mobile.dom.html](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-1975/index-html-mobile.dom.html)

**インタラクティブ状態**: N/A（実行コード差分ゼロ）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任が改善されている。errors.ts は型定義 + ヘルパーに専念し、メッセージ文字列構築の責務を `PLAN_GATE_LABELS` (labels.ts) に明示的に委譲することを JSDoc で表明
- [x] **DRY**: ハードコードリテラル 2 箇所 (L22 / L65) を撤廃。後続 C2-C15 で他ファイルに波及する `PLAN_GATE_LABELS.standardOrAboveFor` 経由パターンの第一例として位置付け
- [x] **YAGNI**: 不要な抽象レイヤーを追加していない (JSDoc コメント書換えのみ、実コード行追加ゼロ)
- [x] **Security**: 移動・統合により秘密情報が露出していない (公開 API 仕様の JSDoc コメントのみ修正)
- [x] **アクセシビリティ**: 描画変化なし、アクセシビリティ非影響
- [x] **パフォーマンス**: 実行コード差分ゼロのためバンドルサイズ増減なし。JSDoc コメントは Vite ビルドで除去される

## 横展開・影響波及チェック

**並行実装ペア**（refactor で重要、`docs/design/parallel-implementations.md` 参照）:

- [x] 本番アプリ + デモ版が同期されている — 実コード差分ゼロのため両者で同じ動作を維持
- [x] LP ↔ アプリ双方向整合 — `shared-labels.js` 再生成 diff = 0 で LP に無影響を確認、ADR-0013 LP truth 違反なし
- [x] 全年齢モード 5 種が同じ実装を参照 — errors.ts は年齢モード非依存のドメイン共通モジュール
- [x] ナビゲーション 3 種が同じ SSOT を参照 — errors.ts はナビゲーション層と非結合
- [x] E2E / ユニットシード + チュートリアル同期 — DB スキーマ変更なし、シード非影響
- [x] labels SSOT (ADR-0045 supersedes ADR-0009) — 本 PR は ADR-0045 (terms.ts atom → labels.ts compound) の運用例として PLAN_GATE_LABELS 経由で SSOT に整列
- [x] 設計書同期 (ADR-0001) — 設計書側 (`docs/design/07-API設計書.md` §4.2) は実 API レスポンスの仕様を記載しており、本 PR は JSDoc コメントのみ修正で API 仕様自体は無変化のため設計書更新不要
- [x] 並行 PR overlap 確認 (#1200) — `src/lib/domain/errors.ts` を同時期に変更する open PR は無し (Phase 2 C0 の PR #1967 は merged 済み、Phase 2 C2-C15 はまだ未着手)

**LP / 販促文言変更時** (ADR-0013 / #1314): 該当なし (LP / pricing / `plan-features.ts` 変更なし)

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（内部 refactor のみ、JSDoc コメント書換えのみで公開 API シグネチャ・戻り値・型定義に diff 無し）

**レビュー依頼事項・QA**:
- (a) JSDoc 内 `<PLAN_GATE_LABELS.standardOrAboveFor('AI 活動提案') の戻り値>` プレースホルダー記法が読み手に伝わるか（API 設計書に正規 message を載せる方針なら、JSDoc は具体例ではなくテンプレ参照記法で十分という判断）
- (b) `@example` ブロックの `import { PLAN_GATE_LABELS } from '$lib/domain/labels';` が他 ESM / SvelteKit `$lib` 規約と整合しているか
- (c) Phase 2 C2-C15 (server/errors.ts / cloud-export-service.ts / suggest-plan-gate.ts / admin/checklists 等 11 箇所、`tests/unit/domain/plan-gate-labels.test.ts` L8-L19 列挙) は別 PR で順次撤廃する方針で OK か（本 PR は #1926 errors.ts JSDoc 範囲のみ）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (Step 1-5 個別 PASS、Step 6/7 は PR 作成直後の再実行で検証)
- [x] 移動先対応マップが全件埋まっている（旧リテラル 2 箇所 → PLAN_GATE_LABELS.standardOrAboveFor 経由参照、grep 0 件確認済み）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし、`git diff --stat` で 1 file / +17 / -2 のみ）
- [x] 全 AC が実装済み（AC1-AC3 全て検証エビデンス記載済み）
- [x] 「描画変化なし」主張の根拠を明記済み（JSDoc コメントのみ修正、実コード差分ゼロ、shared-labels.js diff = 0）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
