### PR TITLE
refactor: #1929 plan-limit-service コメントの PLAN_LABELS.family 参照化 (Phase 2 C4)

### DIFF
--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -15,9 +15,9 @@ export interface PlanLimits {
 	maxFamilyMembers: number | null; // null = 無制限, 招待によるメンバー上限（owner含む） (#1111)
 	historyRetentionDays: number | null;
 	canExport: boolean;
-	canFreeTextMessage: boolean; // 自由テキストメッセージ（ファミリープラン限定）
+	canFreeTextMessage: boolean; // 自由テキストメッセージ（PLAN_LABELS.family 限定）
 	canCustomReward: boolean; // 特別なごほうび設定（スタンダード以上） #728
-	canSiblingRanking: boolean; // きょうだいランキング（ファミリープラン限定） #782
+	canSiblingRanking: boolean; // きょうだいランキング（PLAN_LABELS.family 限定） #782
 	maxCloudExports: number; // クラウド保管の同時保管数上限
 }
 
@@ -57,7 +57,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		maxChildren: null,
 		maxActivities: null,
 		maxChecklistTemplates: null,
-		// #1111: ファミリープランは無制限
+		// #1111: PLAN_LABELS.family は無制限
 		maxFamilyMembers: null,
 		historyRetentionDays: null,
 		canExport: true,


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者向け、SSOT 整合性）

**解決する課題**: `src/lib/server/services/plan-limit-service.ts` の interface コメント / 実装コメントに「ファミリープラン」という表示文字列リテラルがハードコードされていた。プラン名は `PLAN_TERMS` (atom) → `PLAN_LABELS` (compound) に SSOT 化されており (ADR-0045 / #1916)、コメントも atom key を参照する表記に揃えるべき。

**期待される効果**: 将来「ファミリープラン」の表示名を変更する際、コード grep で抜け漏れが起きにくくなる。実装コードと用語 SSOT の方向が一致する。表示文字列 = 0 影響、ユーザー体験に変更なし。

## 関連 Issue

closes #1929

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | L18 / L20 / L60 のコメント中「ファミリープラン限定」「ファミリープランは無制限」を「PLAN_LABELS.family 限定」のように label key 参照に書換え | `git diff src/lib/server/services/plan-limit-service.ts` | PASS — 3 箇所 (L18 / L20 / L60) を `PLAN_LABELS.family` 参照表記に置換済み |
| AC2 | 既存 vitest PASS | `npx vitest run plan-limit` / `npx vitest run tests/unit/services` | PASS — plan-limit 関連 70 件 / services 全 2035 件 |
| AC3 | grep 'ファミリープラン' src/lib/server/services/plan-limit-service.ts で 0 件 | `Grep "ファミリープラン" path=plan-limit-service.ts` | PASS — 0 件（「ファミリー」単体でも 0 件） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし — interface / 実装コメントのみの変更で、表示文字列・ロジック・型定義に変更なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome check (個別ファイル指定で PASS、worktree から `.` パス指定は `**/.claude` exclude のため不可) / svelte-check (0 ERRORS, 13 既存 WARNINGS) / vitest plan-limit + services 全 PASS / hardcoded-strings (本 PR 影響なし) / lp-dimensions (本 PR は `site/` 無変更、CI で `SKIP_SCREENSHOT_EXISTENCE_CHECK=1` 経由検証)
- [x] 追加・変更したテストの概要: N/A (コメント変更のみ、既存テスト網羅で担保)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (`priority:low`、コメント整理)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: コメント整理のみで `.svelte` / 表示文字列の変更ゼロ。実行時 UI に何の変更もない (interface / 実装コメントの 3 行のみ)。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A — UI 変更なし | N/A — UI 変更なし |
| **修正後** | N/A — UI 変更なし | N/A — UI 変更なし |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: コメントのみの変更で責務 / 依存関係に影響なし
- [x] **DRY**: 同一ハードコード「ファミリープラン」を grep で確認、`plan-limit-service.ts` 内 0 件達成
- [x] **YAGNI**: 余分な抽象化追加なし
- [x] **Security**: N/A — 表示文字列・ロジック変更なし
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: N/A — 実行時挙動変化なし

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] **labels SSOT** (ADR-0009 → ADR-0045 supersede): 本 PR 自体が atom (PLAN_TERMS / PLAN_LABELS.family) 参照に SSOT 整合させる作業。コード上の表示文字列リテラルは追加していない
- [ ] **設計書同期** (ADR-0001): N/A — interface / コメントの内部参照表記変更のみで、設計書記載対象に影響なし
- [ ] **並行 PR overlap** (#1200): `src/lib/server/services/plan-limit-service.ts` を変更する他 open PR は確認済み、overlap なし
- [x] N/A — コメントのみ変更、実装の並行実装ペアは無関係

**LP / 販促文言変更時**: N/A — `site/**` 変更なし、`plan-features.ts` 等の販促ファイル変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
- 変更は 3 行（interface コメント 2 行 + PLAN_LIMITS.family 内コメント 1 行）のみ。表示文字列 / 型定義 / ロジックに変更なし。
- 「PLAN_LABELS.family」は `src/lib/domain/labels.ts` に既存の atom 参照キー。コメントから参照することで、将来の用語変更時 grep が容易になる。
- worktree (`.claude/worktrees/...`) からの `npm run pre-ready` は biome.json の `**/.claude` exclude により `.` パス指定が「No files processed」になる。個別ファイル指定 `npx biome check src/lib/server/services/plan-limit-service.ts` は PASS。CI 側 (メイン worktree 等) で正常実行される想定。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready` 主要 Step PASS** をローカル確認した（biome 個別 / svelte-check / vitest）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし、3 行変更のみ）
- [x] 全 AC が実装済み（AC1/AC2/AC3 全充足）
- [x] Phase 分割: N/A
- [x] UI 変更時: N/A — UI 変更なし
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
