### PR TITLE
refactor: #1930 suggest-plan-gate.ts PLAN リテラル撤廃 (Phase 2 C5)

### DIFF
--- a/src/lib/server/api/suggest-plan-gate.ts
+++ b/src/lib/server/api/suggest-plan-gate.ts
@@ -3,6 +3,7 @@
 
 import { error } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { apiError } from '$lib/server/errors';
 import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 
@@ -41,10 +42,7 @@ export async function validateSuggestRequest(
 	if (tier !== 'family') {
 		return {
 			ok: false,
-			response: apiError(
-				'PLAN_LIMIT_EXCEEDED',
-				`${featureLabel}はファミリープランでご利用いただけます`,
-			),
+			response: apiError('PLAN_LIMIT_EXCEEDED', PLAN_GATE_LABELS.familyOnlyFor(featureLabel)),
 		};
 	}
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（Dev / 設計書同期）

**解決する課題**: `src/lib/server/api/suggest-plan-gate.ts` L46 のテンプレートリテラル `${featureLabel}はファミリープランでご利用いただけます` がアプリ本体に直書きされており、`PLAN_FULL_TERMS.family` の用語変更（terms.ts atom 層）が伝播しない。`#1925` Phase 2 C0 で `PLAN_GATE_LABELS.familyOnlyFor()` compound 層が導入されたため、本ファイルを SSOT 経由に統一する。

**期待される効果**: ADR-0045（terms.ts SSOT 2 階層化）と ADR-0009（labels.ts SSOT）の整合が前進。「ファミリープラン」用語を将来変更する場合 `terms.ts` 1 行修正で本ファイルに自動反映される。Phase 2 C1-C15 の完遂に向けた小ステップ進捗。

## 関連 Issue

closes #1930

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | L46 リテラルを `PLAN_GATE_LABELS.familyOnlyFor(featureLabel)` 経由に置換 | `git diff src/lib/server/api/suggest-plan-gate.ts` | PASS — `apiError('PLAN_LIMIT_EXCEEDED', PLAN_GATE_LABELS.familyOnlyFor(featureLabel))` に置換、`PLAN_GATE_LABELS` を `$lib/domain/labels` から import |
| AC2 | 既存 vitest 全 PASS | `npx vitest run` | PASS — `Test Files 231 passed (231) / Tests 4414 passed (4414)`（`tests/unit/domain/plan-gate-labels.test.ts` line 63-68 の "動的 featureLabel (suggest-plan-gate.ts) の既存メッセージと一致する" assertion を含む） |
| AC3 | `grep 'ファミリープラン' src/lib/server/api/suggest-plan-gate.ts` で 0 件 | `Grep pattern='ファミリープラン' path=src/lib/server/api/suggest-plan-gate.ts` | PASS — "No matches found" |

## 変更タイプ

- [x] refactor: リファクタリング

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`) — `suggest-plan-gate.ts` は server-side AI 提案エンドポイント共通プランゲート
- [x] ドメインモデル (`$lib/domain/`) — `PLAN_GATE_LABELS` (compound) を import

**影響を受ける画面・機能**:
AI 活動提案 / AI チェックリスト提案など `validateSuggestRequest()` を呼ぶ全エンドポイント（`/api/ai/suggest-*` 系）のプラン制限エラーメッセージ。char-by-char 一致（`${feature}はファミリープランでご利用いただけます`）のため UI / API レスポンス文字列に変化なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest をローカル一括検証（worktree 環境では `biome.json` の `!**/.claude` ignore により `.` パス展開が空になるため、個別実行: `npx biome check src/ tests/ scripts/ --error-on-warnings` PASS / `npx svelte-check` 0 errors / `npx vitest run` 4414 / 4414 PASS）
- [x] 追加・変更したテストの概要を以下に記載:
  - N/A — Phase 2 C0 (#1967) で `tests/unit/domain/plan-gate-labels.test.ts` line 63-68 が既に "動的 featureLabel (suggest-plan-gate.ts) の既存メッセージと一致する" assertion を提供しており、本 PR は import 切替のみのため新規テスト不要
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — `priority:high` refactor

## スクリーンショット / ビジュアルデモ

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし（理由: server-side only、UI 非表示） | 該当なし（同左） |
| **修正後** | 該当なし（同左） | 該当なし（同左） |

UI 変更を含まない PR (refactor のみ、`src/lib/server/api/suggest-plan-gate.ts` のみ修正) のため **該当なし（理由: server-side AI 提案エンドポイント共通プランゲート、`apiError` 経由 JSON レスポンスのみ。エラーメッセージ文字列は char-by-char 一致のため UI 表示にも変化なし）**。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（S）— compound 層 SSOT (`PLAN_GATE_LABELS.familyOnlyFor`) への集約は責任分離を強化（プラン制限メッセージ生成は labels.ts に集中、各呼び出し箇所はテンプレート展開を委譲）
- [x] **DRY**: 同一ロジックが他ファイル (`admin/checklists/+page.server.ts` 他) にもあり、Phase 2 C1-C15 で順次集約予定（本 PR は C5 のみ）。Issue #1925 で全体管理
- [x] **YAGNI**: 必要最小の import 追加 + 1 箇所の置換のみ
- [x] **Security（OSS 公開前提）**: N/A（メッセージ文字列の改変なし）
- [x] **アクセシビリティ**: N/A（server-side のため）
- [x] **パフォーマンス**: N/A（template literal → function call、negligible）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] **labels SSOT** (ADR-0009 / ADR-0045): 用語は `src/lib/domain/labels.ts::PLAN_GATE_LABELS` (compound) → `terms.ts::PLAN_FULL_TERMS.family` (atom) 経由。リテラル直書きなし
- [x] **設計書同期** (ADR-0001): `docs/DESIGN.md` §6 SSOT 2 階層化と整合（`PLAN_GATE_LABELS` namespace 既掲載 #1925）。本 PR で設計書追加更新は不要
- [x] **並行 PR overlap** (#1200): `src/lib/server/api/suggest-plan-gate.ts` を同時期に変更する open PR を `gh search prs` で確認 — overlap なし
- [x] N/A — 子供 UI / 全年齢モード / ナビゲーション / E2E seed への影響なし（server-side のみ）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A（site/ 未変更、`shared-labels.js` diff = 0）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- char-by-char 一致確認: `PLAN_GATE_LABELS.familyOnlyFor('AI 提案')` → `'AI 提案はファミリープランでご利用いただけます'`（`tests/unit/domain/plan-gate-labels.test.ts` line 63-68 で既保証）
- worktree 環境制約: `npm run pre-ready` の `biome check .` ステップは `biome.json::files.includes` の `!**/.claude` ignore により worktree (`/.claude/worktrees/.../`) で `.` 展開が空になり fail。これは worktree のみの制約で、PR 本体ブランチを CI 上で main に対し走らせる際は通常 `.` で動作する（CI の `ci.yml` が SSOT）。代替として `npx biome check src/ tests/ scripts/ --error-on-warnings` を実行し PASS

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（worktree 制約で biome 一括は個別実行に分割）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1 / AC2 / AC3 全充足）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（Phase 2 C5 = Issue #1930、親 Issue #1925）
- [x] UI 変更時: N/A（server-side only）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

<!-- QM 記入欄: Tier 2 手順 5（Issue 照合 / SS 実視認 / SS 欠落検知 / CI 確認 / 承認判断）の結果を本セクションに追記してください。CI 緑 = approve ではありません（ADR-0022）。 -->
