### PR TITLE
refactor: #1927 server/errors.ts PLAN リテラル撤廃 (Phase 2 C2)

### DIFF
--- a/src/lib/server/errors.ts
+++ b/src/lib/server/errors.ts
@@ -1,4 +1,5 @@
 import { json } from '@sveltejs/kit';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { logger } from '$lib/server/logger';
 
 export type ErrorCode =
@@ -88,8 +89,7 @@ const ERROR_DEFINITIONS: Record<ErrorCode, ErrorDefinition> = {
 	},
 	PLAN_LIMIT_EXCEEDED: {
 		status: 403,
-		userMessage:
-			'この機能はスタンダードプラン以上でご利用いただけます。プランをアップグレードしてください。',
+		userMessage: PLAN_GATE_LABELS.standardOrAboveGenericWithUpgrade,
 		severity: 'info',
 		action: 'none',
 	},


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: プラン制限エラーメッセージ「この機能はスタンダードプラン以上でご利用いただけます。プランをアップグレードしてください。」が `src/lib/server/errors.ts` に文字列リテラル直書きされており、PLAN_FULL_TERMS 由来の SSOT を経由していない。プラン名（「スタンダード」「ファミリー」）を将来変更したとき、検索漏れによる文言不整合が発生する温床になる。

**期待される効果**: PLAN_GATE_LABELS namespace (PR #1967 Phase 2 C0 で導入済) 経由で PLAN_FULL_TERMS atom 由来の compound 値を参照する形に置換することで、プラン名の SSOT 化が server-side error メッセージにも完全適用される。char-by-char で既存メッセージと一致するため挙動変化はゼロ、ユーザー体感には影響しないが SSOT 整合性が改善される。

## 関連 Issue

closes #1927

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/lib/server/errors.ts L92 "この機能はスタンダードプラン以上でご利用いただけます。プランをアップグレードしてください。" を PLAN_GATE_LABELS.standardOrAboveGeneric + ACTION_LABELS.upgrade 経由に | `git diff main..HEAD -- src/lib/server/errors.ts` | userMessage が `PLAN_GATE_LABELS.standardOrAboveGenericWithUpgrade` (`PLAN_FULL_TERMS.standard` を内包する compound) に置換済。Issue 提案の 2 値合成より既存定義済 namespace 1 値参照の方が char-by-char 一致と将来保守性に優れるため後者を採用 |
| AC2 | 既存 vitest PASS | `npx vitest run tests/unit/domain/errors.test.ts tests/unit/domain/plan-gate-labels.test.ts` / `npm run pre-ready` | 31 件 PASS（errors 24件 + plan-gate-labels 7件）/ 全 vitest 4414 件 PASS |
| AC3 | grep 'スタンダードプラン' src/lib/server/errors.ts で 0 件 | `grep -c 'スタンダードプラン' src/lib/server/errors.ts` | 0 件（リテラル完全撤廃） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

注: `src/lib/server/errors.ts` は厳密にはサービス層直下ではないが server エラー定義モジュールであり、`$lib/domain/labels.ts` の compound (PLAN_GATE_LABELS) を import する形に変わったため上記 1 項目をチェック。

**影響を受ける画面・機能**: PLAN_LIMIT_EXCEEDED エラー (HTTP 403) を返す全 API エンドポイントの userMessage（プラン制限ヒット時の汎用フォールバックメッセージ）。char-by-char 一致のため挙動変化なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
  - biome check: src/lib/server/errors.ts 単体で `npx biome check` PASS（worktree 環境では `.` 指定で 0 ファイル扱いになるため Step 1 は file 単位で代替検証）
  - svelte-check: 4095 files 0 errors / 13 warnings (既存)
  - vitest run: 4414 件 PASS
  - check-hardcoded-strings: 0 violations (baseline 0、メイン worktree で実行)
  - measure-lp-dimensions: all metrics within thresholds
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）: N/A — char-by-char 一致のリテラル置換のため既存テストでカバーされる
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は server-side エラーメッセージ定義モジュール (`src/lib/server/errors.ts`) の文字列リテラルを `PLAN_GATE_LABELS.standardOrAboveGenericWithUpgrade` 経由参照に置換するリファクタのみ。`.svelte` / `site/**` / `*.css` の変更を一切含まず、出力される userMessage 文字列は char-by-char で既存と完全一致するため UI 上の見た目変化ゼロ。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし（UI 変更なし） | 該当なし（UI 変更なし） |
| **修正後** | 該当なし（UI 変更なし） | 該当なし（UI 変更なし） |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（PLAN_GATE_LABELS namespace の責務に従いプラン制限文言を集約） / 依存性逆転（labels.ts compound に依存、生リテラル依存ではなくなった） / インターフェース分離（必要最小限 1 値のみ import）
- [x] **DRY**: 既存リテラル "この機能はスタンダードプラン以上でご利用いただけます。プランをアップグレードしてください。" は `grep -r` で本ファイル 1 箇所のみと labels.ts の Doc-Comment 内記述のみであることを確認済。同 PR で 1 箇所完全撤廃
- [x] **YAGNI**: 既存定義済 PLAN_GATE_LABELS namespace を参照するのみで新規抽象化なし
- [x] **Security（OSS 公開前提）**: N/A — 文字列リテラル → 既存定数参照への置換のみ
- [x] **アクセシビリティ**: N/A — server-side エラー文字列、UI 描画ロジック変更なし
- [x] **パフォーマンス**: N/A — 起動時 1 回の static evaluation（既存 ERROR_DEFINITIONS と同 evaluation cost）

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期
- [x] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: shared-labels.js diff = 0（`npm run generate:lp-labels` 後 `git diff site/shared-labels.js` で確認）/ LP 側はこの文言を扱わないため波及なし
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [ ] E2E / ユニットシード（`tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` / `src/lib/server/demo/demo-data.ts`）と チュートリアル (`tutorial-chapters.ts` / `demo-guide-state.svelte.ts`) を同期
- [x] **labels SSOT** (ADR-0009): PLAN_GATE_LABELS.standardOrAboveGenericWithUpgrade 経由参照に置換完了 / リテラル直書きなし
- [x] **設計書同期** (ADR-0001): server エラー定義の SSOT 化のみ。`docs/design/06-UI設計書.md` / `07-API設計書.md` / `15-ブランドガイドライン.md` のいずれにも「PLAN_LIMIT_EXCEEDED userMessage」の構造的記述なし。labels.ts の PLAN_GATE_LABELS namespace は #1925 Phase 2 C0 で `docs/DESIGN.md` §6 に SSOT 階層として既反映済（PR #1967 で main 入り）
- [x] **並行 PR overlap** (#1200): `src/lib/server/errors.ts` を変更する他 open PR は無い
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A |

LP 文言の変更は無い（shared-labels.js diff = 0 で確認済）。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**:
- AC1 で Issue 提案は「PLAN_GATE_LABELS.standardOrAboveGeneric + ACTION_LABELS.upgrade 経由」だが、実装側では PR #1967 で導入済の `PLAN_GATE_LABELS.standardOrAboveGenericWithUpgrade` (1 値) を参照する形を採用した。理由: ① char-by-char 一致を機械的に保証できる（連結式の場合スペース有無等で zero-width 差異が起きやすい） ② Phase 2 C0 で本 errors.ts のメッセージを念頭にコメント (`server/errors.ts: 'この機能は...'`) 入りで `standardOrAboveGenericWithUpgrade` を意図的に定義済 ③ 結果として最終文字列も Issue 要求も同一。整合性に異論があれば指摘ください

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（worktree 起動の biome `.` 指定で 0 ファイル扱いとなる既知環境差は file 単位 `npx biome check src/lib/server/errors.ts` で代替検証、check-hardcoded-strings はメイン worktree で 0 violations 確認）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未着手・先送りの AC がない）
- [x] Phase 分割した場合: Phase 2 C2 として #1916 + #1925 を blocked_by 解除後に着手済（依存全 closed）
- [x] UI 変更時: N/A — UI 変更なし
- [x] 認証画面変更時: N/A — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
