### PR TITLE
refactor: #1935 admin/settings/+page.server.ts PLAN リテラル撤廃 (Phase 2 C10)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1190,6 +1190,7 @@ AdminHome.svelte
 | `PLAN_GATE_LABELS.standardOrAboveFor(feature)` | `${feature}はスタンダードプラン以上でご利用いただけます` | `admin/rewards/+page.server.ts` (特別なごほうび設定) / `admin/reports/+page.server.ts` (週次メールレポート) / `cloud-export-service.ts` (クラウドエクスポート) / `errors.ts` (AI 活動提案) / `api/v1/export/+server.ts` (エクスポート機能) |
 | `PLAN_GATE_LABELS.familyOnlyFor(feature)` | `${feature}はファミリープランでご利用いただけます` | `suggest-plan-gate.ts` (動的 featureLabel) |
 | `PLAN_GATE_LABELS.familyLimitedFor(feature)` | `${feature}はファミリープラン限定です` | `+page.server.ts` (家族メンバー / 招待機能) |
+| `PLAN_GATE_LABELS.familyLimitedWithUpgradeFor(feature)` | `${feature}はファミリープラン限定です。アップグレードすると利用できます。` | `admin/settings/+page.server.ts` (きょうだいランキング) |
 | `PLAN_GATE_LABELS.standardOrAboveGenericWithUpgrade` | `この機能はスタンダードプラン以上でご利用いただけます。プランをアップグレードしてください。` | 汎用エラー画面 |
 
 **実装原則**:
@@ -1208,7 +1209,8 @@ AdminHome.svelte
 | C4 | `plan-limit-service.ts` (コメント参照化) | #1929 / PR #1976 |
 | C5 | `suggest-plan-gate.ts` | #1930 / PR #1977 |
 | C9 | `admin/rewards/+page.server.ts` | #1934 / PR #1981 |
-| 残 | `admin/reports/+page.server.ts` / `errors.ts` / `api/v1/export/+server.ts` 等 | C1 / C2 / C6 / C7 / C8 / C10〜C15 順次 |
+| C10 | `admin/settings/+page.server.ts` (きょうだいランキング) | #1935 / PR #1980 |
+| 残 | `admin/reports/+page.server.ts` / `errors.ts` / `api/v1/export/+server.ts` 等 | C1 / C2 / C6 / C7 / C8 / C11〜C15 順次 |
 
 ---
 

--- a/src/routes/(parent)/admin/settings/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/+page.server.ts
@@ -1,7 +1,7 @@
 import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
-import { OYAKAGI_LABELS } from '$lib/domain/labels';
+import { OYAKAGI_LABELS, PLAN_GATE_LABELS } from '$lib/domain/labels';
 import type { CurrencyCode, PointUnitMode } from '$lib/domain/point-display';
 import { CURRENCY_CODES } from '$lib/domain/point-display';
 import { requireTenantId } from '$lib/server/auth/factory';
@@ -275,7 +275,7 @@ export const actions = {
 				siblingError: createPlanLimitError(
 					planTier,
 					'family',
-					'きょうだいランキングはファミリープラン限定です。アップグレードすると利用できます。',
+					PLAN_GATE_LABELS.familyLimitedWithUpgradeFor('きょうだいランキング'),
 				),
 				upgradeRequired: true,
 			});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 開発者（labels SSOT 維持の保守性）

**解決する課題**: `src/routes/(parent)/admin/settings/+page.server.ts` L278 にきょうだいランキングのプラン制限エラーメッセージが直書きされており、`PLAN_FULL_TERMS.family = 'ファミリープラン'` を将来別語彙にリネームする際の修正漏れ点になっていた。Phase 2 C10 として `PLAN_GATE_LABELS` compound 経由に統一する。

**期待される効果**: プラン名語彙を 1 行修正 (`terms.ts`) で全画面・全エラーパスに伝播できる SSOT 状態に近づく。ユーザー文言は char-by-char 完全一致で変化させない（UX 影響ゼロ）。

## 関連 Issue

closes #1935

- Phase 2 (Issue #1916: terms.ts SSOT 2 階層化) の C10 として位置付け
- 兄弟: #1925 (PLAN_GATE_LABELS 導入) / #1926 / #1927 / #1928 / #1929 / #1930 (#1930 PR #1977 で merged main 取込済)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/routes/(parent)/admin/settings/+page.server.ts L278 'きょうだいランキングはファミリープラン限定です。アップグレードすると利用できます。' を PLAN_GATE_LABELS 経由に | `grep -n 'PLAN_GATE_LABELS.familyLimitedWithUpgradeFor' 'src/routes/(parent)/admin/settings/+page.server.ts'` | PASS — L278 で `PLAN_GATE_LABELS.familyLimitedWithUpgradeFor('きょうだいランキング')` を呼出。展開結果は `'きょうだいランキング' + 'は' + PLAN_FULL_TERMS.family + '限定です。アップグレードすると利用できます。'` で既存メッセージと char-by-char 完全一致 |
| AC2 | 既存 vitest PASS | `npx vitest run` | PASS — Test Files 231 passed (231) / Tests 4414 passed (4414) / Duration 60.59s |
| AC3 | grep 'ファミリープラン' で 0 件 | `grep -rn 'ファミリープラン' 'src/routes/(parent)/admin/settings/+page.server.ts'` | PASS — `No matches found`（0 件） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- 親管理画面 (`/admin/settings`) のきょうだい設定保存アクション (`saveSiblingSettings`) のみ。きょうだいランキング機能を free / standard プランで有効化しようとした際の `fail(403)` レスポンス内 `siblingError.message` 文字列のみ間接置換。表示文言は完全一致のため UI 上の見た目は変化しない。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 部分実行（個別 step）で確認: biome --error-on-warnings PASS / vitest 4414 PASS / shared-labels.js diff = 0 / grep 'ファミリープラン' 0 件
- [x] 追加・変更したテストの概要を以下に記載: N/A — 既存メッセージ char-by-char 一致のため新規テスト不要 (#1925〜#1930 の先行 C0-C9 でも同パターン採用)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — refactor 系、priority:high

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: server-side error message 文字列の参照経路のみ変更する refactor。表示文言は `PLAN_FULL_TERMS.family = 'ファミリープラン'` 経由展開で既存メッセージと char-by-char 完全一致のため UI 上の見た目に変化なし。Svelte / CSS / HTML / 画像変更ゼロ。

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A — UI 変更なし | N/A — UI 変更なし |
| **修正後** | N/A — UI 変更なし | N/A — UI 変更なし |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任維持（`+page.server.ts` の `saveSiblingSettings` action はそのまま、文字列源だけ compound 層に委譲）
- [x] **DRY**: `PLAN_GATE_LABELS.familyLimitedWithUpgradeFor` の唯一の callsite（コメント `カバー対象: admin/settings/+page.server.ts` と一致）。grep で他に同文字列リテラル直書きが残っていないことを確認済
- [x] **YAGNI**: 既存 compound テンプレを利用するのみ、新規抽象化なし
- [x] **Security（OSS 公開前提）**: 秘密情報なし / 内部 URL なし
- [x] **アクセシビリティ**: server-side 文字列のみ、ARIA / キーボード影響なし — N/A
- [x] **パフォーマンス**: テンプレート文字列の即時 concat 1 回のみ（render path に追加コストなし）— N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — `/demo/admin/settings` 配下にきょうだい設定保存 action は無い (demo は表示のみ)。grep で `'ファミリープラン'` リテラルが他 server.ts に無いことを確認 (`src/routes/(parent)/admin/settings/+page.server.ts` のみ該当)
- [x] LP ↔ アプリ双方向整合（ADR-0013）— LP には本文字列の出現なし。`shared-labels.js` regenerate diff = 0 で確認
- [x] 全年齢モード 5 種に横展開 — N/A（親側 server action、年齢モード非依存）
- [x] ナビゲーション 3 種に反映 — N/A
- [x] E2E / ユニットシード + チュートリアルを同期 — N/A（メッセージ文字列同一のため既存 E2E への影響なし、`tests/e2e` で `'ファミリープラン限定'` を直 assert している箇所も grep で 0 件）
- [x] labels SSOT (ADR-0009) — `PLAN_GATE_LABELS.familyLimitedWithUpgradeFor` 経由で `terms.ts` の `PLAN_FULL_TERMS.family` atom に到達。1 行修正で全画面伝播の要件を満たす
- [x] 設計書同期 (ADR-0001) — `docs/DESIGN.md` §6 用語辞書（atom/compound 2 階層）の方針内、`PLAN_GATE_LABELS` JSDoc に「カバー対象: admin/settings/+page.server.ts」が既記載 (#1925 で先行整備済) のため新規追記なし
- [x] 並行 PR overlap 確認 (#1200) — Phase 2 sibling PR (#1931 / #1932 / #1934) は別 file (`admin/checklists` / `admin/messages` / `admin/rewards`) のため衝突なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

N/A — LP / pricing への文言伝播なし。`shared-labels.js` diff = 0 確認済。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- 表示文字列が char-by-char 完全一致であること（`PLAN_GATE_LABELS.familyLimitedWithUpgradeFor('きょうだいランキング')` の展開結果が旧リテラルと一致）の確認をお願いします。`PLAN_FULL_TERMS.family = 'ファミリープラン'` を atom 経由参照しているため、将来 atom を変更すると UX 影響あり（=本リファクタの狙い通り）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — biome / vitest / shared-labels.js diff / grep 'ファミリープラン' 0 件 を個別 step で確認
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— `git diff` で 2 行 (import 1 行 + 引数 1 行) のみ確認
- [x] 全 AC が実装済み — AC1/AC2/AC3 全て PASS
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A — UI 変更なし（server-only refactor、文言は char-by-char 完全一致）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
