### PR TITLE
refactor: #1934 admin/rewards/+page.server.ts PLAN リテラル撤廃 (Phase 2 C9)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1179,6 +1179,37 @@ AdminHome.svelte
         └─ onDismiss → fetch ?/dismissPremiumWelcome → welcomeVisible=false
 ```
 
+### 10.7 プラン制限メッセージ SSOT (#1925 / #1934 Phase 2 — ADR-0045 整合)
+
+`createPlanLimitError` / `FeatureGate buttonLabel` / 各 `+page.server.ts` action handler で
+無料プランのユーザーに返すアップグレード誘導メッセージは、**`PLAN_GATE_LABELS` (compound 層)** 経由で
+組み立てる。リテラル直書きは禁止 (ADR-0045: terms.ts atom → labels.ts compound 2 階層 SSOT)。
+
+| テンプレート関数 | 展開結果 | 代表的な使用箇所 |
+|---|---|---|
+| `PLAN_GATE_LABELS.standardOrAboveFor(feature)` | `${feature}はスタンダードプラン以上でご利用いただけます` | `admin/rewards/+page.server.ts` (特別なごほうび設定) / `admin/reports/+page.server.ts` (週次メールレポート) / `cloud-export-service.ts` (クラウドエクスポート) / `errors.ts` (AI 活動提案) / `api/v1/export/+server.ts` (エクスポート機能) |
+| `PLAN_GATE_LABELS.familyOnlyFor(feature)` | `${feature}はファミリープランでご利用いただけます` | `suggest-plan-gate.ts` (動的 featureLabel) |
+| `PLAN_GATE_LABELS.familyLimitedFor(feature)` | `${feature}はファミリープラン限定です` | `+page.server.ts` (家族メンバー / 招待機能) |
+| `PLAN_GATE_LABELS.standardOrAboveGenericWithUpgrade` | `この機能はスタンダードプラン以上でご利用いただけます。プランをアップグレードしてください。` | 汎用エラー画面 |
+
+**実装原則**:
+
+- routes / services から `'スタンダードプラン'` / `'ファミリープラン'` 直書き禁止 — `PLAN_GATE_LABELS` 経由で組み立てる
+- `PLAN_GATE_LABELS` は内部で `PLAN_FULL_TERMS.standard` / `PLAN_FULL_TERMS.family` (atom 層) を参照 — プラン名変更は terms.ts 1 行で全箇所伝播
+- char-by-char 一致は `tests/unit/domain/plan-gate-labels.test.ts` で機械保証 (Phase 2 C0 PR #1967 で導入)
+- 描画変化なし refactor: 既存リテラル → `PLAN_GATE_LABELS` 経由置換は ADR-0001 §「描画変化なし」原則に該当。設計書追記は本表のみで十分
+
+**Phase 2 集約進捗** (Issue #1925 親 → C1〜C15 子 Issue):
+
+| C# | 対象ファイル | Issue / PR |
+|---|---|---|
+| C0 | `labels.ts` PLAN_GATE_LABELS namespace 新設 | #1925 / PR #1967 |
+| C3 | `cloud-export-service.ts` | #1928 / PR #1972 |
+| C4 | `plan-limit-service.ts` (コメント参照化) | #1929 / PR #1976 |
+| C5 | `suggest-plan-gate.ts` | #1930 / PR #1977 |
+| C9 | `admin/rewards/+page.server.ts` | #1934 / PR #1981 |
+| 残 | `admin/reports/+page.server.ts` / `errors.ts` / `api/v1/export/+server.ts` 等 | C1 / C2 / C6 / C7 / C8 / C10〜C15 順次 |
+
 ---
 
 ## 11. 全ページ一覧

--- a/src/routes/(parent)/admin/rewards/+page.server.ts
+++ b/src/routes/(parent)/admin/rewards/+page.server.ts
@@ -4,6 +4,7 @@ import { fail } from '@sveltejs/kit';
 import { PRESET_REWARD_GROUPS } from '$lib/data/preset-rewards';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getAllChildren } from '$lib/server/services/child-service';
 import {
@@ -25,7 +26,7 @@ import {
 } from '$lib/server/services/special-reward-service';
 import type { Actions, PageServerLoad } from './$types';
 
-const UPGRADE_MESSAGE = '特別なごほうび設定はスタンダードプラン以上でご利用いただけます';
+const UPGRADE_MESSAGE = PLAN_GATE_LABELS.standardOrAboveFor('特別なごほうび設定');
 
 export const load: PageServerLoad = async ({ locals }) => {
 	const tenantId = requireTenantId(locals);


### PR DESCRIPTION
## 顧客価値・目的

`src/routes/(parent)/admin/rewards/+page.server.ts` L28 の `const UPGRADE_MESSAGE` リテラル
`'特別なごほうび設定はスタンダードプラン以上でご利用いただけます'` を `PLAN_GATE_LABELS.standardOrAboveFor('特別なごほうび設定')`
経由に置換し、Phase 2 C0 (#1925) で導入した compound 層 SSOT へ集約する。

**対象ユーザー**: 開発者（Dev / QA） / システム全体

**解決する課題**: プラン名 (`スタンダードプラン`) を直書きしているリテラルが残っており、
将来プラン名を変更した際の修正漏れリスクがある。

**期待される効果**: `PLAN_FULL_TERMS.standard` を更新するだけで全プラン制限メッセージが追従する。
本 PR は Phase 2 C9 として `+page.server.ts` 内 1 箇所を撤廃する。

## 関連 Issue

closes #1934

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/routes/(parent)/admin/rewards/+page.server.ts L28 const UPGRADE_MESSAGE = '特別なごほうび設定はスタンダードプラン以上でご利用いただけます' を PLAN_GATE_LABELS.standardOrAboveFor('特別なごほうび設定') 経由に | `git diff main -- "src/routes/(parent)/admin/rewards/+page.server.ts"` | PASS — L28 が `PLAN_GATE_LABELS.standardOrAboveFor('特別なごほうび設定')` 経由に置換され、`import { PLAN_GATE_LABELS } from '$lib/domain/labels';` が追加されたことを確認 |
| AC2 | 既存 vitest PASS | `npx vitest run tests/unit/domain/plan-gate-labels.test.ts tests/unit/routes/admin-rewards-actions.test.ts tests/unit/services/special-reward-service.test.ts tests/unit/services/reward-redemption-service.test.ts` | PASS — `Test Files 4 passed (4) / Tests 61 passed (61)` (plan-gate-labels 13 + admin-rewards-actions + special-reward-service + reward-redemption-service 計 48) |
| AC3 | grep 'スタンダードプラン' で 0 件 | `grep -n 'スタンダードプラン' "src/routes/(parent)/admin/rewards/+page.server.ts"` | PASS — `NO MATCH (good - 0 件)` |

## 変更タイプ

- [x] refactor: リファクタリング

## 移動先対応マップ（必須）

ファイル移動はなし。**リテラル → SSOT 経由の参照置換** のみ。

| 旧 (リテラル直書き) | 新 (SSOT 経由) | 種別 | import / 参照更新件数 |
|---|---|---|---|
| `'特別なごほうび設定はスタンダードプラン以上でご利用いただけます'` (L28) | `PLAN_GATE_LABELS.standardOrAboveFor('特別なごほうび設定')` | リテラル → compound 層参照 | import 1 件追加 / リテラル 1 箇所置換 |

**全件確認コマンド**:
```bash
# 当該ファイルに「スタンダードプラン」リテラルが残っていないことを確認
grep -n 'スタンダードプラン' "src/routes/(parent)/admin/rewards/+page.server.ts"
# → 0 件 (NO MATCH)
```

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API
- [x] ページ (`src/routes/(parent)/admin/rewards/+page.server.ts` のみ — server-side action handler)
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] LP サイト
- [ ] 設定・CI

**影響を受ける画面・機能**: 描画変化なし（#1744 ルールに準拠）。
`UPGRADE_MESSAGE` を参照する `grant` action / `addPreset` action の `createPlanLimitError` に渡す
メッセージは char-by-char 完全一致のため、無料プランの保護者が「特別なごほうび付与」/
「プリセット取り込み」を試みた際のエラー UI 文言は完全に同一。

## 「描画変化なし」根拠（#1744）

`PLAN_GATE_LABELS.standardOrAboveFor(feature)` は内部で
`` `${feature}は${PLAN_FULL_TERMS.standard}以上でご利用いただけます` `` に展開される。
`PLAN_FULL_TERMS.standard = 'スタンダードプラン'` のため、
`'特別なごほうび設定はスタンダードプラン以上でご利用いただけます'` と char-by-char 完全一致する。

- [x] **ラベル文字列**: 旧 `'特別なごほうび設定はスタンダードプラン以上でご利用いただけます'` ≡ 新展開後 (`PLAN_GATE_LABELS.standardOrAboveFor('特別なごほうび設定')` → `'特別なごほうび設定はスタンダードプラン以上でご利用いただけます'`) → tests/unit/domain/plan-gate-labels.test.ts でも同一 assertion が PASS
- [x] **HTML 構造**: server action の返却値内テキストのみの変更で DOM tree 不変
- [x] **CSS class 名**: 変更なし
- [x] **改行位置 / アイコン / 句読点**: 変更なし（同一文字列）
- [x] **不可視属性 (`aria-*` / `data-*`)**: 追加なし

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら理由明記）:
  追加なし。`tests/unit/domain/plan-gate-labels.test.ts` (Phase 2 C0 PR #1967 で導入) が
  `PLAN_GATE_LABELS.standardOrAboveFor` の char-by-char 一致を保証しており、本 PR は
  当該 SSOT の参照に置換するだけのため新規テスト不要。`tests/unit/routes/admin-rewards-actions.test.ts`
  の既存テスト (#728 / #787 プランゲート系) も全 PASS で機能リグレッションなしを担保。
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor のみ、描画変化なし、根拠は上記「描画変化なし」根拠セクション）**

本 PR の変更は server-side action handler 内の定数定義のみで、
- リテラル展開後の文字列が char-by-char 完全一致 (`PLAN_GATE_LABELS` 内部展開で保証)
- DOM 構造 / CSS / class 名 / aria 属性 すべて不変
- `*.svelte` / `*.css` / `site/**` のいずれも変更なし

`tests/unit/domain/plan-gate-labels.test.ts` 内の以下 assertion で機械的に保証:
```ts
expect(PLAN_GATE_LABELS.standardOrAboveFor('特別なごほうび設定'))
  .toBe('特別なごほうび設定はスタンダードプラン以上でご利用いただけます');
```

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: SRP — リテラル定義の所在を「ページ固有定数」から「ドメイン層 SSOT」へ移管。プラン制限メッセージのフォーマット責務が `PLAN_GATE_LABELS` に集約
- [x] **DRY**: Phase 2 C0 (#1925) で導入した compound 層への 9 箇所目の集約。重複定義 1 件を解消
- [x] **YAGNI**: 既存 `PLAN_GATE_LABELS.standardOrAboveFor()` を流用するのみで、新規抽象レイヤーは追加していない
- [x] **Security**: server-side action handler 内のメッセージ展開で、秘密情報露出はない
- [x] **アクセシビリティ**: 描画変化なし → アクセシビリティ非影響
- [x] **パフォーマンス**: server-side で関数呼び出しが 1 回増えるが、module-level evaluation で 1 度だけ実行されるためランタイム影響なし。bundle size 影響なし (server-side only)

## 横展開・影響波及チェック

**並行実装ペア** (`docs/design/parallel-implementations.md` / `feedback_review_lateral_spread`):

- [x] 本番アプリ + デモ版が同期されている — `src/routes/(parent)/admin/rewards/+page.server.ts` は本番 UI 専用（`/demo/admin/rewards` 配下に同等 server file は存在せず、UI ラベル経由ではないため同期対象外）
- [x] LP ↔ アプリ双方向整合 — `site/shared-labels.js` 再生成 diff = 0 (server-side 定数の変更で LP 直接参照なし)
- [x] 全年齢モード 5 種が同じ実装を参照 — 該当なし（プラン制限メッセージは年齢モードに依存しない server-side メッセージ）
- [x] ナビゲーション 3 種が同じ SSOT を参照 — 該当なし（ナビ変更なし）
- [x] E2E / ユニットシード + チュートリアル同期 — 該当なし（DB / seed 変更なし）
- [x] labels SSOT (ADR-0009 → ADR-0045 supersedes) — 本 PR が該当。`PLAN_GATE_LABELS` 経由参照に置換済み
- [x] 設計書同期 (ADR-0001) — `docs/DESIGN.md §6` の「terms.ts (atom) → labels.ts (compound) 2 階層 SSOT」原則に整合。設計書追記不要 (既に Phase 2 C0 で記載済み)
- [x] 並行 PR overlap 確認 (#1200) — Phase 2 C1〜C8 (PR #1968 / #1969 / #1972 / #1976 / #1977 等) は別ファイル対象。当該 +page.server.ts は本 PR 単独編集

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（内部 refactor のみ。リテラル → SSOT 経由参照で展開後文字列は char-by-char 同一）
- [ ] 含まれる → 公開 API / 設定キー変更を以下に記載

**レビュー依頼事項・QA**:
- 「移動先対応マップ」の置換 1 件が `PLAN_GATE_LABELS.standardOrAboveFor` の展開結果と char-by-char 一致しているか
- `tests/unit/domain/plan-gate-labels.test.ts` 13 件 PASS のうち
  `'特別なごほうび設定はスタンダードプラン以上でご利用いただけます'` を
  expected に持つテスト行 (line 41 付近) で本 PR の置換が機械的に保証されることの確認

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] 移動先対応マップが全件埋まっている（旧リテラル参照 0 件確認済み: `grep -n 'スタンダードプラン' src/routes/\(parent\)/admin/rewards/+page.server.ts` → 0 件）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし、import 1 行 + リテラル 1 箇所置換のみ）
- [x] 全 AC が実装済み（AC1 / AC2 / AC3 すべて検証マップで PASS）
- [x] 「描画変化なし」主張の根拠を明記済み（PLAN_GATE_LABELS char-by-char 完全一致を `plan-gate-labels.test.ts` で機械保証）
- [N/A] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — 本 PR は認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
