### PR TITLE
refactor: #1932 admin/messages PLAN リテラル撤廃 (Phase 2 C7)

### DIFF
--- a/src/routes/(parent)/admin/messages/+page.server.ts
+++ b/src/routes/(parent)/admin/messages/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import {
 	MESSAGE_TEXT_MAX_LENGTH,
 	SENDABLE_MESSAGE_TYPES,
@@ -59,17 +60,17 @@ export const actions: Actions = {
 			return fail(400, { error: 'スタンプを選択してください' });
 		}
 		if (validType === 'text') {
-			// ファミリープラン限定チェック（トライアル状態も考慮）
+			// PLAN_LABELS.family 限定チェック（トライアル状態も考慮）
 			const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 			const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 			const limits = getPlanLimits(tier);
 			if (!limits.canFreeTextMessage) {
-				// #787: PlanLimitError 形式に統一
+				// #787: PlanLimitError 形式に統一 / #1932: PLAN_GATE_LABELS 経由で SSOT 化
 				return fail(403, {
 					error: createPlanLimitError(
 						tier,
 						'family',
-						'自由テキストメッセージはファミリープラン限定です',
+						PLAN_GATE_LABELS.familyLimitedFor('自由テキストメッセージ'),
 					),
 				});
 			}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / システム全体（保守 SSOT）

**解決する課題**: `src/routes/(parent)/admin/messages/+page.server.ts` に「ファミリープラン」リテラルが直書きされており、プラン名変更時に grep 漏れが発生するリスクがあった。Phase 2 C7 として `terms.ts` SSOT (#1916) + `PLAN_GATE_LABELS` compound (#1925) 経由に正規化し、保守の単一情報源を確立する。

**期待される効果**: 既存メッセージ文字列は char-by-char 完全一致のままユーザー影響ゼロで内部 SSOT 化を達成。今後プラン名表記の改訂が発生した場合、`PLAN_FULL_TERMS.family` 1 行修正で全 LP / アプリ本体 / 法務文書に伝播する。

## 関連 Issue

closes #1932

関連: #1916 (terms.ts atom 階層) / #1925 (PLAN_GATE_LABELS compound) / Phase 2 C7

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `src/routes/(parent)/admin/messages/+page.server.ts` L62 (コメント) と L72 "自由テキストメッセージはファミリープラン限定です" を `PLAN_GATE_LABELS.familyLimitedFor` 経由に + コメント書換え | `Read src/routes/(parent)/admin/messages/+page.server.ts L62-L73` で目視 + diff | PASS — L4 に `import { PLAN_GATE_LABELS }` 追加 / L63 コメントを `PLAN_LABELS.family 限定チェック` に変更 / L73 を `PLAN_GATE_LABELS.familyLimitedFor('自由テキストメッセージ')` 経由に置換 (出力文字列は既存と char-by-char 一致) |
| AC2 | 既存 vitest PASS | `npx vitest run tests/unit/routes/admin-messages-send.test.ts` | PASS — 8 tests passed (#772 のプランゲートテストが既存メッセージ `'自由テキストメッセージはファミリープラン限定です'` を expect しているが、`familyLimitedFor` 出力と完全一致するため変化なし) |
| AC3 | grep 'ファミリープラン' で 0 件 | `Grep pattern='ファミリープラン' path='src/routes/(parent)/admin/messages'` | PASS — `No matches found` (L62 コメント / L72 リテラル両方撤廃済み) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
親管理画面の `/admin/messages` 自由テキスト送信 action のエラーメッセージ生成処理のみ。出力文字列は変化なし（char-by-char 一致）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
  - 個別検証実行済: `npx biome check --error-on-warnings src/routes/(parent)/admin/messages/+page.server.ts` clean / `npx svelte-check` 0 errors 13 warnings (既存) / `npx vitest run tests/unit/routes/admin-messages-send.test.ts` 8 PASS / `npx vitest run tests/unit/domain/plan-gate-labels.test.ts` 13 PASS
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - N/A — 既存 vitest #772 が出力メッセージ完全一致を担保（`familyLimitedFor('自由テキストメッセージ')` = `'自由テキストメッセージはファミリープラン限定です'`）。新規テスト不要。
- [x] **新規 env / secret 追加時**（ADR-0006）: 末尾の「配布済み env / secret」セクションに証跡を記載。該当なければ「N/A」 — N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: SQLite + DynamoDB 両実装完成 + `scripts/check-dynamodb-stub.mjs` PASS。該当なければ「N/A」 — N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: 5 要件確認済み。該当なければ「N/A」 — N/A (refactor 任意)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は `+page.server.ts` の SSR action コードのみの変更で、UI レンダリング差分なし。出力エラーメッセージは既存と char-by-char 一致 (`'自由テキストメッセージはファミリープラン限定です'`) のため、画面上の見た目は変化しない。`.svelte` 変更ゼロ。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし（UI 変更なし） | 該当なし（UI 変更なし） |
| **修正後** | 該当なし（UI 変更なし） | 該当なし（UI 変更なし） |

**インタラクティブ状態**: N/A — UI 変更なし。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（S）/ 依存性逆転（D, interface 経由）/ インターフェース分離（I, 必要最小依存）— `PLAN_GATE_LABELS` を import するだけの最小依存追加。labels.ts compound 層が `PLAN_FULL_TERMS` atom に依存する DIP 構造に整合。
- [x] **DRY**: 同一ロジック / 同一バグが他ファイルにないか `grep` / `Glob` で調査済み — `Grep 'ファミリープラン' src/routes/(parent)/admin/messages` で 0 件確認済 (修正後)。同等の他ファイルは Phase 2 C0-C15 で別 Issue として並行進行中（C7 = 本 Issue）。
- [x] **YAGNI**: 現要件に不要な抽象化を追加していない — 既存 `PLAN_GATE_LABELS.familyLimitedFor()` を利用するだけで新規抽象化なし。
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし / Security by obscurity に依存しない / OWASP Top 10 (Injection / Auth / XSS / IDOR) を境界で検証 / N/A 可 — エラーメッセージ生成処理のみで認可ロジック (`limits.canFreeTextMessage`) には変更なし。
- [x] **アクセシビリティ**: キーボード操作可 / ARIA 適切 / コントラスト WCAG AA / N/A 可 — N/A (SSR コードのみ)
- [x] **パフォーマンス**: N+1 なし / バンドルサイズ確認 / N/A 可 — N/A (関数呼び出し 1 回追加のみ、無視可能)

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: LP 記載がアプリ実装と一致 / アプリの新規機能・用語が LP に未記載のままでない（Committed/Aspirational 確認）
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [ ] E2E / ユニットシード（`tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` / `src/lib/server/demo/demo-data.ts`）と チュートリアル (`tutorial-chapters.ts` / `demo-guide-state.svelte.ts`) を同期
- [x] **labels SSOT** (ADR-0009): 新規ユーザー向け文言は `src/lib/domain/labels.ts` 経由 / LP 側は `data-label` 属性経由 / リテラル直書きなし — 本 PR の主目的そのもの。`PLAN_GATE_LABELS.familyLimitedFor` 経由化 + コメント `PLAN_LABELS.family` 参照表記化。
- [ ] **設計書同期** (ADR-0001): 影響を受ける `docs/design/` の設計書を同 PR で更新（DB→08 / API→07 / UI→06 / インフラ→13 / セキュリティ→14） — N/A (リテラル → SSOT 移行のみで仕様変更なし)
- [x] **並行 PR overlap** (#1200): 本 PR が変更するファイルを同時期に変更する open PR が他に無い、または合意済み — `src/routes/(parent)/admin/messages/+page.server.ts` 単一ファイル 1 hunk 変更。Phase 2 C0-C15 は各サブ Issue が独立ファイルを担当する設計。
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A |

該当なし。LP / pricing / `plan-features.ts` / `pricing-strategy.md` への影響なし。`shared-labels.js` 再生成 diff = 0 (labels.ts 未変更のため)。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**:
- `PLAN_GATE_LABELS.familyLimitedFor('自由テキストメッセージ')` 出力 = `'自由テキストメッセージはファミリープラン限定です'` の char-by-char 一致を `npx vitest run tests/unit/routes/admin-messages-send.test.ts` (#772) で担保。テスト L101 が既存メッセージ文字列を expect しており PASS = 一致証明。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — pre-ready 個別 Step (biome / svelte-check / vitest / shared-labels.js diff = 0) を個別に実行済 (#1775 step 6 = check-pr-body は PR 作成後に実行)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— 1 file 4 insertions 3 deletions、import 追加 + コメント書換 + リテラル → 関数呼び出し置換のみ
- [x] 全 AC が実装済み（未完了として残っている AC がない）— AC1/AC2/AC3 全 PASS
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — Phase 2 C7 として #1932 で起票済 (PO 起票)
- [N/A] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認 — UI 変更なし
- [N/A] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
