### PR TITLE
refactor: #1933 admin/reports PLAN リテラル撤廃 (Phase 2 C8)

### DIFF
--- a/src/routes/(parent)/admin/reports/+page.server.ts
+++ b/src/routes/(parent)/admin/reports/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getSettings, setSetting } from '$lib/server/db/settings-repo';
 import { logger } from '$lib/server/logger';
@@ -31,7 +32,7 @@ export const load: PageServerLoad = async ({ locals, url, parent }) => {
 
 	const childList = children.map((c) => ({ id: c.id, nickname: c.nickname }));
 
-	// ランキングデータ取得（ファミリープラン用、#373）
+	// ランキングデータ取得（PLAN_LABELS.family 用、#373）
 	const parentData = await parent();
 	const isFamily = parentData.planTier === 'family';
 	// #735: 週次メールレポートは standard+ 特典。free はプレビューのみ、設定不可
@@ -138,7 +139,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					planTier,
 					'standard',
-					'週次メールレポートはスタンダードプラン以上でご利用いただけます',
+					PLAN_GATE_LABELS.standardOrAboveFor('週次メールレポート'),
 				),
 			});
 		}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（Dev / 設計書同期）

**解決する課題**: `src/routes/(parent)/admin/reports/+page.server.ts` L141 のリテラル `'週次メールレポートはスタンダードプラン以上でご利用いただけます'` がアプリ本体に直書きされており、`PLAN_FULL_TERMS.standard`（terms.ts atom 層）の用語変更が伝播しない。同様に L34 のコメント `ファミリープラン用` も atom 参照になっておらず、用語変更時に grep の網に掛からない。`#1925` Phase 2 C0 で `PLAN_GATE_LABELS.standardOrAboveFor()` compound 層が導入されたため、本ファイルを SSOT 経由に統一する。

**期待される効果**: ADR-0045（terms.ts SSOT 2 階層化）と ADR-0009 archive（labels.ts SSOT）の整合が前進。「スタンダードプラン」「ファミリープラン」用語を将来変更する場合 `terms.ts` 1 行修正で本ファイルに自動反映される。Phase 2 C1-C15 完遂に向けた小ステップ進捗（C8）。

## 関連 Issue

closes #1933

Phase 2 C8（親 Issue #1925 / blocked_by #1916, #1925、依存機構は既に main マージ済）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/routes/(parent)/admin/reports/+page.server.ts L34 (コメント) と L141 "週次メールレポートはスタンダードプラン以上でご利用いただけます" を PLAN_GATE_LABELS.standardOrAboveFor 経由に + コメント書換え | `git diff src/routes/(parent)/admin/reports/+page.server.ts` | PASS — L4 に `import { PLAN_GATE_LABELS } from '$lib/domain/labels';` 追加、L34 コメントを `// ランキングデータ取得（PLAN_LABELS.family 用、#373）` に変更、L142 を `PLAN_GATE_LABELS.standardOrAboveFor('週次メールレポート')` に置換 |
| AC2 | 既存 vitest PASS | `npx vitest run` | PASS — `Test Files 231 passed (231) / Tests 4414 passed (4414)`（`tests/unit/domain/plan-gate-labels.test.ts` line 37-41 の "週次メールレポート (admin/reports) の既存メッセージと一致する" assertion を含む） |
| AC3 | grep 'スタンダードプラン\|ファミリープラン' で 0 件 | `grep -nE 'スタンダードプラン\|ファミリープラン' 'src/routes/(parent)/admin/reports/+page.server.ts'` | PASS — "NONE — AC3 PASS"（grep 結果 0 件） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`) — `src/routes/(parent)/admin/reports/+page.server.ts` の load + actions.updateSettings
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`) — `PLAN_GATE_LABELS` (compound) を import
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
親管理画面のレポートタブ（`/admin/reports`）の `updateSettings` action — free プランで週次メールレポート設定を変更しようとした際の 403 エラーメッセージ。`PLAN_GATE_LABELS.standardOrAboveFor('週次メールレポート')` は `'週次メールレポートはスタンダードプラン以上でご利用いただけます'` と char-by-char 一致（`tests/unit/domain/plan-gate-labels.test.ts` line 37-41 で既保証）のため UI / API レスポンス文字列に変化なし（描画変化なし、#1744）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest をローカル一括検証（worktree 環境では `biome.json` の `!**/.claude` ignore により `.` パス展開が空になるため、個別実行: `npx biome check src/ tests/ scripts/ --error-on-warnings` PASS / `npx svelte-check` 0 errors / `npx vitest run` 4414 / 4414 PASS / `node scripts/check-no-plan-literals.mjs` PASS）
- [x] 追加・変更したテストの概要を以下に記載:
  - N/A — Phase 2 C0 (#1967) で `tests/unit/domain/plan-gate-labels.test.ts` line 37-41 が既に "週次メールレポート (admin/reports) の既存メッセージと一致する" char-by-char assertion を提供しており、本 PR は import 切替とコメント書き換えのみのため新規テスト不要
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — `priority:high` refactor

## スクリーンショット / ビジュアルデモ

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし（理由: server-side actions only、UI 非表示） | 該当なし（同左） |
| **修正後** | 該当なし（同左） | 該当なし（同左） |

UI 変更を含まない PR (refactor のみ、`src/routes/(parent)/admin/reports/+page.server.ts` のみ修正) のため **該当なし（理由: server-side `updateSettings` action のみ。`fail(403, { error: createPlanLimitError(..., message) })` のメッセージ文字列を SSOT compound 経由に切り替えただけで、生成される文字列は char-by-char 一致のため UI 表示にも変化なし。`+page.svelte` 側は変更なし）**。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（S）— compound 層 SSOT (`PLAN_GATE_LABELS.standardOrAboveFor`) への集約は責任分離を強化（プラン制限メッセージ生成は labels.ts に集中、各呼び出し箇所はテンプレート展開を委譲）
- [x] **DRY**: 同一リテラルが他ファイル（`src/lib/server/services/cloud-export-service.ts` 等、Phase 2 C3 で C0 完遂）にもあったが、本 PR で C8（admin/reports）も SSOT に統合。Phase 2 全体の進捗管理は Issue #1925
- [x] **YAGNI**: 必要最小の import 追加 + 1 箇所の置換 + 1 行コメントのみ
- [x] **Security（OSS 公開前提）**: N/A（メッセージ文字列の改変なし、エラーレスポンス構造も同一）
- [x] **アクセシビリティ**: N/A（server-side のため）
- [x] **パフォーマンス**: N/A（template literal → function call、negligible）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — `src/routes/demo/admin/reports/` 側にはこの updateSettings アクション分岐がない（demo はサーバ side actions を使わない）ため対象外
- [x] LP ↔ アプリ双方向整合（ADR-0013）— `npm run generate:lp-labels` 実行後 `git status site/shared-labels.js` = no diff（terms.ts atom 経由のため LP 側生成物に変化なし）
- [x] 全年齢モード 5 種に横展開 — N/A（`/admin/reports` は parent 専用、年齢モード非依存）
- [x] ナビゲーション 3 種に反映 — N/A（リテラル置換のみ、ナビ非影響）
- [x] E2E / ユニットシード + チュートリアルを同期 — N/A（テストデータ非影響）
- [x] **labels SSOT** (ADR-0009 archive / ADR-0045): 用語は `src/lib/domain/labels.ts::PLAN_GATE_LABELS` (compound) → `terms.ts::PLAN_FULL_TERMS.standard` (atom) 経由。リテラル直書きなし
- [x] **設計書同期** (ADR-0001): `docs/DESIGN.md` §6 SSOT 2 階層化と整合（`PLAN_GATE_LABELS` namespace 既掲載 #1925）。本 PR で設計書追加更新は不要
- [x] 並行 PR overlap 確認 (#1200) — `gh pr list --search 'admin/reports/+page.server.ts'` で同時期に同ファイルを変更する open PR なし

**LP / 販促文言変更時** (ADR-0013):

N/A — site/ 未変更、`shared-labels.js` diff = 0、LP / pricing 訴求文言なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- char-by-char 一致確認: `PLAN_GATE_LABELS.standardOrAboveFor('週次メールレポート')` → `'週次メールレポートはスタンダードプラン以上でご利用いただけます'`（`tests/unit/domain/plan-gate-labels.test.ts` line 37-41 で既保証、本 PR で追加 assertion 不要）
- worktree 環境制約: `npm run pre-ready` の `biome check .` ステップは `biome.json::files.includes` の `!**/.claude` ignore により worktree (`/.claude/worktrees/.../`) で `.` 展開が空になり fail。これは worktree のみの制約で、PR 本体ブランチを CI 上で main に対し走らせる際は通常 `.` で動作する（CI の `ci.yml` が SSOT）。代替として `npx biome check src/ tests/ scripts/ --error-on-warnings` を実行し PASS

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（worktree 制約で biome 一括は個別実行に分割、内訳は「テスト & 安全装置セルフチェック」セクション参照）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし、diff は import 1 行追加 + コメント 1 行書換 + リテラル 1 行置換のみ）
- [x] 全 AC が実装済み（AC1 / AC2 / AC3 全充足）
- [N/A] UI 変更時: server-side only のため SS 該当なし
- [N/A] 認証画面変更時: server-side only のため `dev:cognito` 検証該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

<!-- QM 記入欄: Tier 2 手順 5（Issue 照合 / SS 実視認 / SS 欠落検知 / CI 確認 / 承認判断）の結果を本セクションに追記してください。CI 緑 = approve ではありません（ADR-0022）。 -->
