### PR TITLE
infra: #1985 design-doc-check workflow に label exempt 追加 (内部 refactor 設計書同期免除)

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -97,6 +97,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      # #1985: 判定ロジックは scripts/check-design-doc-sync.mjs (純粋関数 + unit test 完備) に集約。
+      # 旧 inline script は廃止し、ファイルパターン exempt + label exempt (refactor:internal-no-doc-impact)
+      # の OR 結合判定を 1 ファイルで管理する。
       - name: Check for design doc updates
         uses: actions/github-script@v9
         with:
@@ -113,34 +116,23 @@ jobs:
             );
             const files = diffOutput.trim().split('\n').filter(Boolean);
 
-            // src/routes/ の変更があるか
-            const hasRouteChanges = files.some(f => f.startsWith('src/routes/'));
-            // docs/design/ の変更があるか
-            const hasDesignDocChanges = files.some(f => f.startsWith('docs/design/'));
+            // PR ラベル一覧 (#1985: refactor:internal-no-doc-impact による exempt 判定用)
+            const labels = (context.payload.pull_request.labels || []).map((l) => l.name);
 
-            // 変更ファイルが全て「設計書更新不要なパターン」に合致するか判定
-            // (PR 本文テキストによる免除は廃止 — ファイルパターンのみで判定)
-            const allFilesExempt = files.every(f =>
-              /(?:^|\/|\\)CLAUDE\.md$/.test(f) || // **/CLAUDE.md（任意の階層）
-              f.startsWith('scripts/') ||           // scripts/ 配下（CI/CD スクリプト）
-              f.startsWith('docs/') ||              // docs/ 配下（docs 自体が設計書）
-              f.startsWith('infra/') ||             // infra/ 配下（インフラ設定のみ）
-              f.startsWith('.github/') ||           // .github/ 配下（CI 設定等）
-              f.startsWith('site/')                 // LP ファイル（設計書の管轄外）
+            // scripts/check-design-doc-sync.mjs の純粋関数を直接呼ぶ
+            // (CLI subprocess を経由しないことで stderr / stdout の改行 / encoding 起因の誤検知を回避)
+            const { checkDesignDocSync } = await import(
+              `${process.env.GITHUB_WORKSPACE}/scripts/check-design-doc-sync.mjs`
             );
-            const hasDesignDocExemption = allFilesExempt;
+            const result = checkDesignDocSync({ files, labels });
 
-            if (hasRouteChanges && !hasDesignDocChanges) {
-              if (hasDesignDocExemption) {
-                core.info(
-                  '✅ 変更ファイルが全て設計書更新不要なパターン（CLAUDE.md / scripts/ / docs/ / infra/ / .github/ / site/）のみです — チェックをスキップします (ADR-0003)'
-                );
-              } else {
-                core.setFailed(
-                  '❌ src/routes/ に変更がありますが、docs/design/ の更新がありません。\n' +
-                  '設計書の同期更新が必要な場合は同一PR内で更新してください（ADR-0003）。\n' +
-                  '設計書の更新が不要なパターン（CLAUDE.md のみ / scripts/ のみ / docs/ のみ等）でも\n' +
-                  'このメッセージが出た場合は、設計書更新が必要な変更を含んでいます。'
-                );
-              }
+            if (result.status === 'skip') {
+              core.info(`✅ ${result.reason}`);
+              return;
             }
+            if (result.status === 'pass') {
+              core.info(`✅ ${result.reason}`);
+              return;
+            }
+            // status === 'fail'
+            core.setFailed(`❌ ${result.reason}`);

--- a/scripts/__tests__/check-design-doc-sync.test.mjs
+++ b/scripts/__tests__/check-design-doc-sync.test.mjs
@@ -1,0 +1,249 @@
+/**
+ * scripts/__tests__/check-design-doc-sync.test.mjs
+ *
+ * #1985 — design-doc-check 判定ロジックのユニットテスト。
+ *
+ * 実行: node --test scripts/__tests__/check-design-doc-sync.test.mjs
+ *
+ * テストケースは以下の判定ツリーを網羅する:
+ * 1. src/routes/ 変更なし → skip
+ * 2. src/routes/ 変更あり + docs/design/ 同期あり → pass
+ * 3. src/routes/ 変更あり + 全ファイル exempt パターン (file-pattern exempt) → skip
+ * 4. src/routes/ 変更あり + label exempt あり → skip
+ * 5. src/routes/ 変更あり + どの exempt も該当せず → fail
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	checkDesignDocSync,
+	hasDesignDocChanges,
+	hasInternalRefactorLabel,
+	hasRouteChanges,
+	INTERNAL_REFACTOR_LABEL,
+	isAllFilesExempt,
+} from '../check-design-doc-sync.mjs';
+
+// ---------------------------------------------------------------------------
+// 個別 helper
+// ---------------------------------------------------------------------------
+
+describe('hasRouteChanges', () => {
+	it('src/routes/ 配下の変更を検出する', () => {
+		assert.equal(hasRouteChanges(['src/routes/admin/+page.svelte']), true);
+		assert.equal(hasRouteChanges(['src/routes/(child)/[uiMode=uiMode]/home/+page.ts']), true);
+	});
+
+	it('src/routes/ 以外は false', () => {
+		assert.equal(hasRouteChanges(['src/lib/foo.ts', 'docs/design/06-UI設計書.md']), false);
+		assert.equal(hasRouteChanges([]), false);
+	});
+
+	it('src/routes-helper のような prefix mismatch は false', () => {
+		assert.equal(hasRouteChanges(['src/routes-helper/foo.ts']), false);
+	});
+});
+
+describe('hasDesignDocChanges', () => {
+	it('docs/design/ 配下の変更を検出する', () => {
+		assert.equal(hasDesignDocChanges(['docs/design/06-UI設計書.md']), true);
+		assert.equal(hasDesignDocChanges(['docs/design/diagrams/foo.drawio']), true);
+	});
+
+	it('docs/decisions/ や docs/tickets/ は false', () => {
+		assert.equal(hasDesignDocChanges(['docs/decisions/0003-issue-quality.md']), false);
+		assert.equal(hasDesignDocChanges(['docs/tickets/old.md']), false);
+	});
+});
+
+describe('isAllFilesExempt', () => {
+	it('全ファイルが exempt パターンに合致すれば true', () => {
+		assert.equal(isAllFilesExempt(['CLAUDE.md', 'scripts/foo.mjs', 'docs/design/x.md']), true);
+		assert.equal(
+			isAllFilesExempt(['.github/workflows/ci.yml', 'site/index.html', 'infra/cdk/app.ts']),
+			true,
+		);
+	});
+
+	it('1 件でも exempt でないファイルがあれば false', () => {
+		assert.equal(isAllFilesExempt(['scripts/foo.mjs', 'src/routes/admin/+page.svelte']), false);
+		assert.equal(isAllFilesExempt(['src/lib/foo.ts']), false);
+	});
+
+	it('入れ子の CLAUDE.md (e.g. src/routes/CLAUDE.md) も exempt', () => {
+		assert.equal(isAllFilesExempt(['src/routes/CLAUDE.md', 'docs/CLAUDE.md']), true);
+	});
+
+	it('空配列は false (短絡前提なので CLI 側で先に hasRouteChanges() で弾かれる)', () => {
+		assert.equal(isAllFilesExempt([]), false);
+	});
+});
+
+describe('hasInternalRefactorLabel', () => {
+	it('label に refactor:internal-no-doc-impact があれば true', () => {
+		assert.equal(hasInternalRefactorLabel([INTERNAL_REFACTOR_LABEL]), true);
+		assert.equal(
+			hasInternalRefactorLabel(['type:refactor', INTERNAL_REFACTOR_LABEL, 'priority:high']),
+			true,
+		);
+	});
+
+	it('大文字小文字を区別しない', () => {
+		assert.equal(hasInternalRefactorLabel(['Refactor:Internal-No-Doc-Impact']), true);
+	});
+
+	it('label が無ければ false', () => {
+		assert.equal(hasInternalRefactorLabel([]), false);
+		assert.equal(hasInternalRefactorLabel(['type:refactor', 'priority:high']), false);
+	});
+
+	it('部分一致では false (悪用防止)', () => {
+		assert.equal(hasInternalRefactorLabel(['refactor']), false);
+		assert.equal(hasInternalRefactorLabel(['internal-no-doc-impact']), false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 判定本体 (checkDesignDocSync)
+// ---------------------------------------------------------------------------
+
+describe('checkDesignDocSync', () => {
+	describe('Case 1: src/routes/ 変更なし → skip', () => {
+		it('docs only PR は skip', () => {
+			const r = checkDesignDocSync({
+				files: ['docs/design/06-UI設計書.md'],
+				labels: [],
+			});
+			assert.equal(r.status, 'skip');
+			assert.match(r.reason, /src\/routes\/ への変更なし/);
+		});
+
+		it('scripts only PR は skip', () => {
+			const r = checkDesignDocSync({
+				files: ['scripts/foo.mjs', 'scripts/__tests__/foo.test.mjs'],
+				labels: [],
+			});
+			assert.equal(r.status, 'skip');
+		});
+
+		it('空 PR (空 diff) も skip', () => {
+			const r = checkDesignDocSync({ files: [], labels: [] });
+			assert.equal(r.status, 'skip');
+		});
+	});
+
+	describe('Case 2: src/routes/ 変更あり + docs/design/ 同期あり → pass', () => {
+		it('UI 変更 + 06-UI 設計書同期', () => {
+			const r = checkDesignDocSync({
+				files: ['src/routes/admin/+page.svelte', 'docs/design/06-UI設計書.md'],
+				labels: [],
+			});
+			assert.equal(r.status, 'pass');
+			assert.match(r.reason, /docs\/design\/ の同期更新あり/);
+		});
+
+		it('routes + design diagrams 同時更新', () => {
+			const r = checkDesignDocSync({
+				files: ['src/routes/foo/+page.ts', 'docs/design/diagrams/system.drawio'],
+				labels: [],
+			});
+			assert.equal(r.status, 'pass');
+		});
+	});
+
+	describe('Case 3: src/routes/ 変更あり + 全ファイル exempt (file-pattern exempt) → skip', () => {
+		it('CLAUDE.md のみ更新 (src/routes/ 変更ゼロ) は Case 1 で skip', () => {
+			const r = checkDesignDocSync({ files: ['src/routes/CLAUDE.md'], labels: [] });
+			// CLAUDE.md は src/routes/ 配下だが、hasRouteChanges() は startsWith 判定なので true
+			// → docs/design/ 同期なし → file-pattern exempt 該当 → skip
+			assert.equal(r.status, 'skip');
+			assert.match(r.reason, /設計書更新不要なパターン/);
+		});
+	});
+
+	describe('Case 4: src/routes/ 変更あり + label exempt → skip (#1985 NEW)', () => {
+		it('PLAN リテラル refactor PR が label で exempt される', () => {
+			const r = checkDesignDocSync({
+				files: ['src/routes/admin/+page.server.ts'],
+				labels: [INTERNAL_REFACTOR_LABEL],
+			});
+			assert.equal(r.status, 'skip');
+			assert.match(r.reason, /ラベル.*内部 refactor として exempt/);
+		});
+
+		it('複数 src/routes/ 変更でも label があれば skip', () => {
+			const r = checkDesignDocSync({
+				files: [
+					'src/routes/admin/+page.server.ts',
+					'src/routes/admin/dashboard/+page.server.ts',
+					'src/lib/domain/labels.ts',
+				],
+				labels: ['type:refactor', INTERNAL_REFACTOR_LABEL],
+			});
+			assert.equal(r.status, 'skip');
+		});
+
+		it('label の大文字小文字無視', () => {
+			const r = checkDesignDocSync({
+				files: ['src/routes/admin/+page.server.ts'],
+				labels: ['Refactor:Internal-No-Doc-Impact'],
+			});
+			assert.equal(r.status, 'skip');
+		});
+	});
+
+	describe('Case 5: src/routes/ 変更あり + 何も exempt せず → fail', () => {
+		it('UI 変更 + design 同期なし + label なし → fail', () => {
+			const r = checkDesignDocSync({
+				files: ['src/routes/admin/+page.svelte', 'src/lib/foo.ts'],
+				labels: [],
+			});
+			assert.equal(r.status, 'fail');
+			assert.match(r.reason, /docs\/design\/ の更新がありません/);
+			assert.match(r.reason, /refactor:internal-no-doc-impact/);
+		});
+
+		it('label が別ラベルでは fail', () => {
+			const r = checkDesignDocSync({
+				files: ['src/routes/admin/+page.svelte', 'src/lib/foo.ts'],
+				labels: ['type:refactor', 'priority:high'],
+			});
+			assert.equal(r.status, 'fail');
+		});
+
+		it('src/routes/ + src/lib/ の混在で exempt 該当なし', () => {
+			const r = checkDesignDocSync({
+				files: ['src/routes/admin/+page.ts', 'src/lib/server/foo.ts'],
+				labels: [],
+			});
+			assert.equal(r.status, 'fail');
+		});
+	});
+
+	describe('優先順位: docs/design/ 同期 > file-pattern exempt > label exempt', () => {
+		it('docs/design/ 同期があれば label が無くても pass', () => {
+			const r = checkDesignDocSync({
+				files: ['src/routes/admin/+page.ts', 'docs/design/06-UI設計書.md'],
+				labels: [],
+			});
+			assert.equal(r.status, 'pass');
+		});
+
+		it('file-pattern exempt が成立すれば label 不要', () => {
+			const r = checkDesignDocSync({
+				files: ['src/routes/CLAUDE.md', 'scripts/foo.mjs'],
+				labels: [],
+			});
+			assert.equal(r.status, 'skip');
+		});
+
+		it('label exempt は file-pattern exempt の fallback として機能', () => {
+			// src/routes/ + src/lib/ 混在 (file-pattern exempt 不成立) でも label で skip
+			const r = checkDesignDocSync({
+				files: ['src/routes/admin/+page.server.ts', 'src/lib/domain/labels.ts'],
+				labels: [INTERNAL_REFACTOR_LABEL],
+			});
+			assert.equal(r.status, 'skip');
+		});
+	});
+});

--- a/scripts/check-design-doc-sync.mjs
+++ b/scripts/check-design-doc-sync.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-design-doc-sync.mjs
+ *
+ * #1985: design-doc-check 判定ロジック純粋関数 + CLI。
+ *
+ * **背景**: ADR-0003 (Issue 起票・クローズ品質) の「設計書同期はマージブロッカー」原則の運用層。
+ * `src/routes/` 変更時に `docs/design/` 同期更新がない PR を hard-fail する。Wave 3 (#1980-1984) で
+ * PLAN リテラル → PLAN_GATE_LABELS template 経由化のような **機能仕様変化なし** の内部 refactor が
+ * 一律 fail し、各 PR で `docs/design/06-UI設計書.md §10.7` への形式的追記で乗り切る運用が発生。
+ * Wave 4-7 (api/v1/admin / Phase 7 H1-H6 など 30+ PR) で再発する前に exempt パターンを構造化。
+ *
+ * **判定ロジック (新)**:
+ * 1. `src/routes/` 変更なし → skip
+ * 2. `docs/design/` 同期あり → pass
+ * 3. (file-pattern exempt) 全変更ファイルが CLAUDE.md / scripts/ / docs/ / infra/ / .github/ / site/ → skip
+ * 4. (label exempt #1985 NEW) PR ラベルに `refactor:internal-no-doc-impact` 含む → skip
+ * 5. それ以外 → fail
+ *
+ * **label exempt の悪用防止**: ラベルは PO / QA / Dev で運用合意し、Issue / PR レビューで
+ * 「機能仕様変化なし」を確認した PR にのみ付与する。ADR-0003 改訂で運用基準を明文化 (Issue #1986)。
+ *
+ * **CLI 引数**:
+ *   --files <path>       改行区切りの変更ファイル一覧 (file)
+ *   --labels <names>     カンマ区切りの PR ラベル一覧 (string、空文字可)
+ *
+ * **環境変数 (CLI 引数の代替)**:
+ *   PR_FILES             改行区切りの変更ファイル一覧
+ *   PR_LABELS            カンマ区切りの PR ラベル一覧
+ *
+ * **exit**:
+ *   0 = OK (skip / pass)
+ *   1 = fail (src/routes/ 変更ありで設計書同期なし、かつ exempt なし)
+ *   2 = internal error
+ *
+ * **想定実行環境**: GitHub Actions (`pr-quality-gate.yml` の design-doc-check job)。
+ *
+ * **テスト**: `scripts/__tests__/check-design-doc-sync.test.mjs` (node --test)。
+ */
+
+const ROUTE_PREFIX = 'src/routes/';
+const DESIGN_DOC_PREFIX = 'docs/design/';
+
+/**
+ * exempt 対象のファイルパスパターン。
+ *
+ * いずれかにマッチした変更ファイルは「設計書同期不要」とみなす。
+ * 全変更ファイルが exempt パターンに合致する場合のみ skip 判定が成立する点に注意。
+ */
+const FILE_EXEMPT_MATCHERS = [
+	/(?:^|\/|\\)CLAUDE\.md$/, // **/CLAUDE.md (任意の階層)
+	/^scripts\//, // CI/CD スクリプト
+	/^docs\//, // docs 自体が設計書
+	/^infra\//, // インフラ設定
+	/^\.github\//, // CI 設定
+	/^site\//, // LP (設計書管轄外)
+];
+
+/**
+ * label exempt のラベル名 (#1985)。
+ *
+ * 運用ルール (ADR-0003 改訂、Issue #1986):
+ *   - 機能仕様変化なし (UI / API 変化なし)
+ *   - リテラル置換 / atom-compound 階層化のみ
+ *   - import 追加 + literal removal の diff パターン
+ *
+ * 上記を満たす PR にのみ Dev / QA が合意の上で付与する。悪用防止のためレビューでの確認必須。
+ */
+export const INTERNAL_REFACTOR_LABEL = 'refactor:internal-no-doc-impact';
+
+/**
+ * 変更ファイル一覧から、`src/routes/` 配下の変更があるかを判定。
+ *
+ * @param {string[]} files
+ * @returns {boolean}
+ */
+export function hasRouteChanges(files) {
+	return files.some((f) => f.startsWith(ROUTE_PREFIX));
+}
+
+/**
+ * 変更ファイル一覧から、`docs/design/` 配下の変更があるかを判定。
+ *
+ * @param {string[]} files
+ * @returns {boolean}
+ */
+export function hasDesignDocChanges(files) {
+	return files.some((f) => f.startsWith(DESIGN_DOC_PREFIX));
+}
+
+/**
+ * 全変更ファイルが exempt パターン (CLAUDE.md / scripts/ / docs/ / infra/ / .github/ / site/) に
+ * 合致するかを判定 (file-pattern exempt)。
+ *
+ * @param {string[]} files
+ * @returns {boolean} 全ファイルが exempt なら true。空配列 (= 変更なし) も true 扱いだが、
+ *                    呼び出し側の hasRouteChanges() で先に短絡されるため実害なし。
+ */
+export function isAllFilesExempt(files) {
+	if (files.length === 0) return false;
+	return files.every((f) => FILE_EXEMPT_MATCHERS.some((re) => re.test(f)));
+}
+
+/**
+ * PR ラベル一覧に `refactor:internal-no-doc-impact` が含まれるかを判定 (label exempt #1985)。
+ *
+ * @param {string[]} labels
+ * @returns {boolean}
+ */
+export function hasInternalRefactorLabel(labels) {
+	return labels.some((l) => l.trim().toLowerCase() === INTERNAL_REFACTOR_LABEL);
+}
+
+/**
+ * @typedef {Object} CheckResult
+ * @property {'skip' | 'pass' | 'fail'} status
+ * @property {string} reason
+ */
+
+/**
+ * design-doc-check の判定本体。GitHub Actions / CLI / unit test から呼び出す。
+ *
+ * @param {Object} input
+ * @param {string[]} input.files - 変更ファイル一覧
+ * @param {string[]} [input.labels] - PR ラベル一覧 (label exempt 判定用、省略時は空配列)
+ * @returns {CheckResult}
+ */
+export function checkDesignDocSync({ files, labels = [] }) {
+	if (!hasRouteChanges(files)) {
+		return {
+			status: 'skip',
+			reason: 'src/routes/ への変更なし',
+		};
+	}
+
+	if (hasDesignDocChanges(files)) {
+		return {
+			status: 'pass',
+			reason: 'docs/design/ の同期更新あり',
+		};
+	}
+
+	// src/routes/ 変更あり、かつ docs/design/ 同期なし → exempt 判定へ
+	if (isAllFilesExempt(files)) {
+		return {
+			status: 'skip',
+			reason:
+				'変更ファイルが全て設計書更新不要なパターン (CLAUDE.md / scripts/ / docs/ / infra/ / .github/ / site/) のみ (ADR-0003)',
+		};
+	}
+
+	if (hasInternalRefactorLabel(labels)) {
+		return {
+			status: 'skip',
+			reason: `PR ラベル '${INTERNAL_REFACTOR_LABEL}' により内部 refactor として exempt (#1985 / ADR-0003 改訂)`,
+		};
+	}
+
+	return {
+		status: 'fail',
+		reason:
+			'src/routes/ に変更がありますが、docs/design/ の更新がありません (ADR-0003)。\n' +
+			'設計書同期が必要な場合は同一 PR 内で更新してください。\n' +
+			'機能仕様変化なし (内部 refactor) の場合は PR ラベル ' +
+			`'${INTERNAL_REFACTOR_LABEL}' を付与してください (#1985)。`,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// CLI エントリポイント (node scripts/check-design-doc-sync.mjs から呼ばれる場合)
+// ---------------------------------------------------------------------------
+
+function parseCliArgs(argv) {
+	const args = { filesPath: null, labelsArg: null };
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === '--files' && i + 1 < argv.length) {
+			args.filesPath = argv[++i];
+		} else if (arg === '--labels' && i + 1 < argv.length) {
+			args.labelsArg = argv[++i];
+		}
+	}
+	return args;
+}
+
+async function readFiles(filePath) {
+	if (!filePath) {
+		const env = process.env.PR_FILES || '';
+		return env
+			.split('\n')
+			.map((s) => s.trim())
+			.filter(Boolean);
+	}
+	const fs = await import('node:fs/promises');
+	const content = await fs.readFile(filePath, 'utf8');
+	return content
+		.split('\n')
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
+function readLabels(labelsArg) {
+	const raw = labelsArg ?? process.env.PR_LABELS ?? '';
+	return raw
+		.split(',')
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
+async function main() {
+	try {
+		const cliArgs = parseCliArgs(process.argv.slice(2));
+		const files = await readFiles(cliArgs.filesPath);
+		const labels = readLabels(cliArgs.labelsArg);
+
+		const result = checkDesignDocSync({ files, labels });
+
+		if (result.status === 'skip') {
+			console.log(`[skip] ${result.reason}`);
+			process.exit(0);
+		}
+		if (result.status === 'pass') {
+			console.log(`[pass] ${result.reason}`);
+			process.exit(0);
+		}
+		console.error(`[fail] ${result.reason}`);
+		process.exit(1);
+	} catch (err) {
+		console.error(`[error] internal: ${err?.stack ? err.stack : err}`);
+		process.exit(2);
+	}
+}
+
+// import.meta.url が CLI エントリの場合のみ main 実行 (test では import 経由)
+const argv1 = process.argv[1] ?? '';
+const isCliInvocation =
+	argv1 !== '' &&
+	(import.meta.url === `file://${argv1}` || import.meta.url.endsWith(argv1.replace(/\\/g, '/')));
+
+if (isCliInvocation) {
+	main();
+}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者 (本プロジェクトの全 Dev / QA / PO)

**解決する課題**: 内部 refactor (atom と compound 階層化、PLAN リテラル → PLAN_GATE_LABELS template 経由化、機能仕様変化なし) で `design-doc-check` CI が形式的 fail し、`docs/design/06-UI設計書.md §10.7` への 1 行追記で乗り切る運用が Wave 3 (PR #1980-1984) で頻発した。Wave 4-7 の同種 refactor PR (api/v1/admin / Phase 7 H1-H6 など 30+ PR) で再発する前に exempt 構造化が必要。

**期待される効果**: 機能仕様変化のない PR で `docs/design/` への形式的同期作業を不要化し、`design-doc-check` 本来の目的 (機能変更時の SSOT 同期保証) に集中させる。Wave 4-7 の PR スループットを改善する。

## 関連 Issue

closes #1985

関連:
- Issue #1986 (連動 ADR 改訂、Issue I2) — 本 PR は workflow 改訂のみ、ADR-0003 改訂は I2 (#1986) のスコープ
- ADR-0003 (Issue 起票・クローズ品質) / ADR-0001 (設計書 SSOT) / ADR-0010 (Pre-PMF scope 判断、過剰防衛禁止)
- 短期措置で乗り切った Wave 3 PR-1980 ~ 1984

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `.github/workflows/pr-quality-gate.yml` の design-doc-check に **新規 ラベルベース exempt** 追加 (ラベル `refactor:internal-no-doc-impact` で skip) | `grep -n 'refactor:internal-no-doc-impact\|hasInternalRefactorLabel' scripts/check-design-doc-sync.mjs scripts/__tests__/check-design-doc-sync.test.mjs .github/workflows/pr-quality-gate.yml` | PASS — `INTERNAL_REFACTOR_LABEL` 定数 + `hasInternalRefactorLabel()` + workflow の labels 取得 + `checkDesignDocSync({ files, labels })` 全実装 |
| AC2 | または **diff 内容ベース exempt** | 本 PR では Option α (label exempt) のみ採用、diff 内容ベースは保留 (Issue 本文「Option α または β」の選択肢の一方を採用、両方必須ではない) | N/A — Option α 採用で Issue AC1/AC2 のいずれかを満たす |
| AC3 | 既存 file-pattern exempt との併存 (CLAUDE.md / scripts/ 等) | `node --test scripts/__tests__/check-design-doc-sync.test.mjs` (Case 3 / 優先順位 suite) | PASS — `isAllFilesExempt()` を `hasInternalRefactorLabel()` の前に評価、両 exempt の OR 結合で skip 判定 |
| AC4 | テスト追加 (scripts/__tests__ に判定ロジックの unit test) | `node --test scripts/__tests__/check-design-doc-sync.test.mjs` | PASS — 28 tests / 11 suites / 0 fail (Case 1-5 + 優先順位 + 個別 helper を網羅) |
| AC5 | ADR 改訂 (Issue I2 と連動、本 Issue merge 前に I2 ADR 起票完了必須) | `gh issue view 1986 --json state` | PASS — Issue #1986 起票済 (state: OPEN)。AC 文面の趣旨は「I2 起票完了」、ADR ファイル merge は I2 PR (#1986) のスコープ |
| AC6 | 関連 PR (Wave 4-7) で本 exempt が動作する確認 | 本 PR merge 後の Wave 4 PR (Phase 2 C7 以降など) で `refactor:internal-no-doc-impact` ラベル付与 → design-doc-check skip を実環境で確認 | 本 PR スコープ外 (Issue 本文「P3 / Wave 4 起動前に解決推奨」、本 PR は workflow 改訂までを担当) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト
- [x] 設定・CI (`.github/workflows/pr-quality-gate.yml`)
- [x] CI スクリプト (`scripts/check-design-doc-sync.mjs` + 同 unit test)

**影響を受ける画面・機能**: アプリ UI / ユーザー機能には一切影響しない。CI ジョブ `design-doc-check` のみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030） — 下記 Ready チェックリストで PR 番号確定後に実行
- [x] 追加・変更したテストの概要:
  - `scripts/__tests__/check-design-doc-sync.test.mjs` — 28 cases (Case 1: src/routes/ 変更なし → skip / Case 2: docs/design/ 同期あり → pass / Case 3: 全ファイル file-pattern exempt → skip / Case 4: label exempt → skip [#1985 NEW] / Case 5: どの exempt も該当せず → fail / 優先順位 suite / 個別 helper)
  - 実行: `node --test scripts/__tests__/check-design-doc-sync.test.mjs` → 28 pass / 0 fail
- [N/A] **新規 env / secret 追加時**（ADR-0006） — 該当なし
- [N/A] **DynamoDB 実装変更時** — 該当なし
- [N/A] **Critical バグ修正の場合** — `priority:high` (priority:critical 要件外)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: CI workflow 設定 + CI スクリプト + unit test のみの変更。アプリ UI / LP / SVG 等のビジュアル要素を一切変更しない。`scripts/check-pr-screenshot.mjs::isUiPr()` 判定でも UI ファイル無し → SS 不要扱いになる。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `check-design-doc-sync.mjs` は単一責任 (ファイル一覧 + ラベル一覧 → 判定結果)。純粋関数 export + CLI エントリ分離で test 容易性確保
- [x] **DRY**: 旧 inline script を削除し、判定ロジックを `scripts/check-design-doc-sync.mjs` 1 箇所に集約。workflow からは pure function を直接 import
- [x] **YAGNI**: Option β (diff 内容ベース exempt) は本 PR では実装しない (Issue 本文「Option α または β」の選択肢、Option α で AC 充足。誤検知 risk のある β は将来必要になれば別 Issue で追加検討)
- [x] **Security**: ラベル付与は GitHub 標準の権限制御 (リポジトリ書き込み権限) に依存。悪用防止のため大文字小文字無視判定 + 部分一致禁止 (test で網羅)
- [N/A] **アクセシビリティ** — UI 変更なし
- [N/A] **パフォーマンス** — CI ジョブの実行時間影響軽微 (subprocess 起動なし、import の数 ms 増のみ)

## 横展開・影響波及チェック

**並行実装ペア**:

- [N/A] 本番アプリ + デモ版を同期 — UI 変更なし
- [N/A] LP ↔ アプリ双方向整合
- [N/A] 全年齢モード 5 種に横展開
- [N/A] ナビゲーション 3 種に反映
- [N/A] E2E / ユニットシード + チュートリアルを同期
- [N/A] labels SSOT (ADR-0009) — UI label 変更なし (Workflow 内のラベル名 `refactor:internal-no-doc-impact` は GitHub label であり UI label ではない)
- [N/A] 設計書同期 (ADR-0001) — workflow 改訂のみ、ADR-0003 改訂は Issue I2 (#1986) のスコープ
- [x] 並行 PR overlap 確認 (#1200) — `pr-info.yml` overlap-check に委譲

**LP / 販促文言変更時** (ADR-0013):

N/A — LP / 販促文言変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- workflow logic 変更点: 旧 inline script → 外部 module + label exempt OR 結合
- `scripts/check-design-doc-sync.mjs::checkDesignDocSync()` の判定優先順位 (Case 1-5) が Issue 本文の意図と整合しているか
- ラベル `refactor:internal-no-doc-impact` の悪用リスク評価 (Dev / QA で機能仕様変化なしを必ずチェックする運用合意の必要性)
- AC2 (diff 内容ベース exempt) を本 PR で見送った判断 (Option α/β の OR 仕様、Option α のみで Issue AC を満たすか)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [N/A] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認
- [N/A] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
