### PR TITLE
refactor: #1936 viewer-tokens +server.ts PLAN リテラル撤廃 (Phase 2 C11)

### DIFF
--- a/src/routes/api/v1/admin/viewer-tokens/+server.ts
+++ b/src/routes/api/v1/admin/viewer-tokens/+server.ts
@@ -4,6 +4,7 @@
 
 import { error, json } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import { createViewerToken, listViewerTokens } from '$lib/server/services/viewer-token-service';
 import type { RequestHandler } from './$types';
@@ -20,7 +21,7 @@ async function requireFamily(locals: App.Locals): Promise<string> {
 		locals.context?.plan,
 	);
 	if (tier !== 'family') {
-		throw error(403, { message: 'ファミリープラン限定の機能です' });
+		throw error(403, { message: PLAN_GATE_LABELS.viewerTokenFamilyOnly });
 	}
 	return tenantId;
 }


### PR DESCRIPTION
## 顧客価値・目的

PLAN_GATE_LABELS SSOT 化 (#1925 Phase 2) の C11 タスク。`src/routes/api/v1/admin/viewer-tokens/+server.ts` L23 の `'ファミリープラン限定の機能です'` ハードコードを `PLAN_GATE_LABELS.viewerTokenFamilyOnly` 経由に置換し、プラン制限メッセージの一元管理を進める。

**対象ユーザー**: 開発者（Dev / QA） / システム全体（プラン制限メッセージの SSOT 整合性）

**解決する課題**: viewer-tokens API のプラン制限メッセージが `+server.ts` に直書きされており、プラン名（ファミリー）変更時に複数箇所の同期修正が必要だった。Phase 2 C0 (#1925) で定義済みの `PLAN_GATE_LABELS.viewerTokenFamilyOnly` compound へ集約し、`PLAN_FULL_TERMS.family` (terms.ts atom) → `PLAN_GATE_LABELS` (labels.ts compound) → 各実装箇所 の 2 階層 SSOT に整合させる。

**期待される効果**: プラン名変更時 1 行修正で全箇所反映 / 散在防止 / 並行実装解消（PLAN gate 11+ 箇所のうち本 PR で C11 の 1 件解消）。

## 関連 Issue

closes #1936

related:
- #1916 (terms.ts atom SSOT)
- #1925 (PLAN_GATE_LABELS Phase 2 C0)
- ADR-0045 (terms.ts SSOT 2 階層化原則)
- ADR-0003 §4 内部 refactor exempt (PR-1985 / PR-1986)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/routes/api/v1/admin/viewer-tokens/+server.ts L23 'ファミリープラン限定の機能です' を PLAN_GATE_LABELS.viewerTokenFamilyOnly 経由に | `git diff src/routes/api/v1/admin/viewer-tokens/+server.ts` | PASS — `throw error(403, { message: PLAN_GATE_LABELS.viewerTokenFamilyOnly })` に置換、import 1 行追加 |
| AC2 | 既存 vitest PASS | `npx vitest run tests/unit/domain/plan-gate-labels.test.ts tests/unit/services/viewer-token-service.test.ts` | PASS — 2 files / 22 tests passed (1.61s) |
| AC3 | grep 'ファミリープラン' で 0 件 | `grep -n 'ファミリープラン' src/routes/api/v1/admin/viewer-tokens/+server.ts` | PASS — 0 件（ripgrep 経由で No matches found） |

## 変更タイプ

- [x] refactor: リファクタリング

## 移動先対応マップ（必須）

本 PR はファイル移動を伴わない（リテラル → SSOT 参照置換のみ）。

| 旧 path | 新 path | 種別 | import / 参照更新件数 |
|---|---|---|---|
| `'ファミリープラン限定の機能です'` (literal in `+server.ts` L23) | `PLAN_GATE_LABELS.viewerTokenFamilyOnly` (`src/lib/domain/labels.ts` L358) | 統合（1 リテラル → 既存 compound 参照） | 1 件 (`+server.ts` のみ) + import 1 行追加 |

**全件確認コマンド**:
```bash
# 該当ファイルにリテラルが残っていないことを確認
grep -n 'ファミリープラン' src/routes/api/v1/admin/viewer-tokens/+server.ts
# → 0 件
```

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [x] API （`src/routes/api/v1/admin/viewer-tokens/+server.ts` の 403 message 文字列 SSOT 化）
- [ ] ページ
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] LP サイト
- [ ] 設定・CI

**影響を受ける画面・機能**: `GET / POST /api/v1/admin/viewer-tokens` の 403 レスポンス body の `message` フィールド。**描画変化なし（#1744 ルールに準拠）** — char-by-char で旧リテラルと完全一致する compound (`PLAN_GATE_LABELS.viewerTokenFamilyOnly = ${PLAN_FULL_TERMS.family}限定の機能です = 'ファミリープラン限定の機能です'`) を参照。

## 「描画変化なし」根拠（#1744）

- [x] **ラベル文字列**: 旧 `'ファミリープラン限定の機能です'` と新 `PLAN_GATE_LABELS.viewerTokenFamilyOnly` の解決値は char-by-char で完全一致。`tests/unit/domain/plan-gate-labels.test.ts` L97 で `expect(PLAN_GATE_LABELS.viewerTokenFamilyOnly).toBe('ファミリープラン限定の機能です')` を assertion 済 (PASS 確認済)
- [x] **HTML 構造**: API 応答の JSON 構造は変更なし（`{ message: '...' }` のまま、SvelteKit `error()` helper 経由）
- [x] **CSS class 名**: API レスポンスのため非該当
- [x] **改行位置 / アイコン / 句読点**: メッセージ末尾「機能です」までの全角・半角・句読点すべて旧と完全一致
- [x] **不可視属性 (`aria-*` / `data-*`)**: 非該当（API 応答）

「描画変化あり」の場合は本セクションを削除してスクショ 4 スロットに替える。→ **本 PR は API 応答の文字列 SSOT 化のみで描画変化なしのため SS 4 スロット該当なし**。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**: ローカルで biome / svelte-check / vitest 主要該当を実機確認済（biome --error-on-warnings clean、svelte-check 0 errors、vitest 22 PASS）
- [x] 追加・変更したテストの概要を以下に記載:
  - 新規テスト追加なし。既存 `tests/unit/domain/plan-gate-labels.test.ts` の `describe('PLAN_GATE_LABELS.viewerTokenFamilyOnly')` (L95-) で本 PR の参照先 compound の char-by-char 一致を assertion 済（Phase 2 C0 で先行整備）
  - 既存 `tests/unit/services/viewer-token-service.test.ts` (PLAN gate を経由しない service 層テスト) も PASS
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor のみ、描画変化なし、根拠は上記「描画変化なし」根拠セクション）**

API 応答の `message` フィールドの文字列 SSOT 化のみで、UI 描画には影響しない。SS 4 スロットは UI 変更時の要件であり、本 PR は内部 refactor (ADR-0003 §4 exempt 適用) のため非該当。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: ハードコード文字列を compound 参照に変更することで「プラン名 SSOT 単一責任」が `terms.ts` (atom) → `labels.ts` (compound) のレイヤに集約。`+server.ts` は文字列管理責任を持たなくなり SRP 改善
- [x] **DRY**: PLAN_GATE 文字列の散在 1 件解消（Phase 2 全 11+ 箇所中の C11、本 PR で 1/11 進捗）
- [x] **YAGNI**: 既存 compound (`viewerTokenFamilyOnly`) を参照するのみで新規抽象レイヤーを追加していない
- [x] **Security**: API エラー応答 message のみ。秘密情報露出なし
- [x] **アクセシビリティ**: 描画変化なし、API 応答のため非影響
- [x] **パフォーマンス**: import 1 行追加のみ。bundle 影響は実質ゼロ（compound は既存 export、tree-shake 後の差は測定誤差レベル）

## 横展開・影響波及チェック

**並行実装ペア**（refactor で重要、`docs/design/parallel-implementations.md` 参照）:

- [x] 本番アプリ + デモ版が同期されている — 本 PR の対象は `/api/v1/admin/viewer-tokens` API（管理 API、デモ画面は別系統で同 API を参照しないため非該当）
- [x] LP ↔ アプリ双方向整合 — `site/shared-labels.js` への波及対象 export ではないため diff = 0（`node scripts/generate-lp-labels.mjs` で再生成、git status で site/ 変更なし確認済）
- [x] 全年齢モード 5 種が同じ実装を参照 — API レイヤのため年齢モード非依存
- [x] ナビゲーション 3 種が同じ SSOT を参照 — 非該当
- [x] E2E / ユニットシード + チュートリアル同期 — テスト側でも `tests/unit/domain/plan-gate-labels.test.ts` で同 compound の char-by-char 一致を assertion
- [x] labels SSOT (ADR-0045) — `terms.ts` (atom) → `labels.ts` (compound) → `+server.ts` (consumer) の 2 階層 SSOT に正しく整合
- [x] **設計書同期 (ADR-0001 / ADR-0003 §4 exempt)** — 内部 refactor のため `refactor:internal-no-doc-impact` ラベル付与で design-doc-check skip 適用。リテラル → compound 参照置換は外部仕様（API 応答の文字列）に変化なし、設計書記述 (`07-API設計書.md` 等) も非更新で整合
- [x] 並行 PR overlap 確認 (#1200) — Phase 2 他 C* タスク (C1-C15) と並行進行中だが、各タスクは独立ファイルを対象とし、本 PR (C11) の touch 範囲は `+server.ts` 1 ファイルのみで衝突なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（内部 refactor のみ、API 応答 message char-by-char 完全一致）
- [ ] 含まれる → 公開 API / 設定キー変更を以下に記載

**レビュー依頼事項・QA**:
- 「描画変化なし」根拠（5 項目チェック）の妥当性
- `PLAN_GATE_LABELS.viewerTokenFamilyOnly` 解決値が `'ファミリープラン限定の機能です'` と char-by-char 一致することの確認（既存 vitest L97 assertion で機械保証）
- ADR-0003 §4 内部 refactor exempt の適用妥当性（design-doc-check label exempt を含む）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（biome --error-on-warnings clean / svelte-check 0 errors / vitest 22 PASS / shared-labels.js diff 0）
- [x] 移動先対応マップが全件埋まっている（旧 path 参照 0 件確認済み — `grep 'ファミリープラン' src/routes/api/v1/admin/viewer-tokens/+server.ts` → 0）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし、import 1 行 + L23 1 行 の最小差分）
- [x] 全 AC が実装済み（AC1 / AC2 / AC3 すべて検証済）
- [x] 「描画変化なし」主張の根拠を明記済み（「描画変化なし」根拠セクション 5 項目チェック）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
