### PR TITLE
refactor: #1940 admin license/members HTML コメント PLAN リテラル → label key (Phase 2 C15)

### DIFF
--- a/src/routes/(parent)/admin/license/+page.svelte
+++ b/src/routes/(parent)/admin/license/+page.svelte
@@ -654,7 +654,7 @@ async function openPortal() {
 					</button>
 				</div>
 
-				<!-- スタンダードプラン -->
+				<!-- PLAN_LABELS.standard -->
 				<div
 					class="plan-card"
 					class:selected={selectedTier === 'standard'}
@@ -682,7 +682,7 @@ async function openPortal() {
 					</ul>
 				</div>
 
-				<!-- ファミリープラン -->
+				<!-- PLAN_LABELS.family -->
 				<div
 					class="plan-card"
 					class:selected={selectedTier === 'family'}

--- a/src/routes/(parent)/admin/members/+page.svelte
+++ b/src/routes/(parent)/admin/members/+page.svelte
@@ -400,7 +400,7 @@ const roleLabel = (role: string) => {
 		</Card>
 	{/if}
 
-	<!-- 閲覧リンク（ファミリープラン限定） -->
+	<!-- 閲覧リンク（PLAN_LABELS.family 限定） -->
 	{#if data.isFamily}
 		<Card variant="default" padding="md">
 			{#snippet children()}

--- a/src/routes/demo/(parent)/admin/license/+page.svelte
+++ b/src/routes/demo/(parent)/admin/license/+page.svelte
@@ -342,7 +342,7 @@ function handleMockApply() {
 					</button>
 				</div>
 
-				<!-- スタンダードプラン -->
+				<!-- PLAN_LABELS.standard -->
 				<div
 					class="plan-card"
 					class:selected={selectedTier === 'standard'}
@@ -373,7 +373,7 @@ function handleMockApply() {
 					</ul>
 				</div>
 
-				<!-- ファミリープラン -->
+				<!-- PLAN_LABELS.family -->
 				<div
 					class="plan-card recommended"
 					class:selected={selectedTier === 'family'}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者 (本プロジェクトの全 Dev / QA / PO)

**解決する課題**: `src/routes/(parent)/admin/license/+page.svelte` 等 5 ファイルの HTML コメントに「スタンダードプラン」「ファミリープラン」が日本語リテラル直書きで残っており、`PLAN_LABELS` 定義値変更時に grep 漏れの起点となる構造リスクを抱えていた。

**期待される効果**: コメント表記を `PLAN_LABELS.standard` / `PLAN_LABELS.family` の label key 参照形式に統一することで、以下を実現する。

1. 将来 `PLAN_LABELS.standard` の表示文言を改名する際に、コメント追従の grep 漏れが構造的に発生しなくなる
2. `grep 'PLAN_LABELS\.' src/` で「どのコンポーネントが PLAN_LABELS に依存しているか」がコメントレベルでも辿れる
3. ADR-0009 (labels.ts SSOT 化原則) / Issue #1916 (terms / labels 2 階層化) で進めている構造化と整合する

機能仕様 / DOM / 表示テキスト / `labels.ts` 値は一切変更しない (HTML コメントのみ)。

## 関連 Issue

closes #1940

関連:
- #1916 (terms.ts SSOT 2 階層化、blocks #1940)
- ADR-0009 (labels.ts SSOT 化原則 — archive 落ちの旧 ADR、現行は ADR-0045 に supersede)
- ADR-0045 (terms.ts SSOT 2 階層化原則 atom / compound 責務分離)
- Phase 2 C シリーズ: C10 (#1980) / C15 (本 PR、#1940) — 内部 refactor で機能仕様変化なし

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 5 ファイルの HTML コメント中の PLAN リテラルを label key 参照表記に書換え (license L657 / L685、members L403、demo/license L345 / L376) | `git diff --stat` および `git diff "src/routes/(parent)/admin/license/+page.svelte" "src/routes/(parent)/admin/members/+page.svelte" "src/routes/demo/(parent)/admin/license/+page.svelte"` | PASS — 3 ファイル / 5 insertions / 5 deletions、全 5 コメント (`<!-- スタンダードプラン -->` × 2 → `<!-- PLAN_LABELS.standard -->`、`<!-- ファミリープラン -->` × 2 → `<!-- PLAN_LABELS.family -->`、`<!-- 閲覧リンク（ファミリープラン限定） -->` → `<!-- 閲覧リンク（PLAN_LABELS.family 限定） -->`) を確認 |
| AC2 | 既存 vitest / E2E PASS | `npm run pre-ready -- --pr 1991` (Step 3 vitest 含む)。E2E は CI 側 `playwright-e2e` job に委譲 | PASS — pre-ready 全 Step PASS をローカル確認 (詳細 Ready チェックリスト参照)。コメントのみ変更で実行ロジック未変更につき既存テスト互換 |
| AC3 | `grep 'スタンダードプラン\|ファミリープラン'` で本 PR 対象 5 ファイル全て 0 件 | `grep -nE 'スタンダードプラン\|ファミリープラン' "src/routes/(parent)/admin/license/+page.svelte" "src/routes/(parent)/admin/members/+page.svelte" "src/routes/demo/(parent)/admin/license/+page.svelte"` | PASS — 全 0 件。リポジトリ全体としては `site/shared-labels.js` (LP 用 FAQ 文言、固有名詞表示) に残るが本 Issue の scope 対象外 (Issue 文面でも 5 ファイルのみ列挙) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`) — 3 ファイルの HTML コメント文字列のみ
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 一切影響しない。HTML コメントのみの変更で DOM / 表示テキスト / 動作ロジック / labels.ts 値は無変更。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 1991` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載: N/A — HTML コメントのみの変更で実行ロジック未変更、既存テストで充分カバー (新規テスト追加なし)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — env / secret 追加なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — DB 変更なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — `priority:low` (Critical 要件外)

## スクリーンショット / ビジュアルデモ

**変更性質**: HTML コメント (`<!-- ... -->`) のみの変更で DOM / 表示テキスト / レンダリング結果が一切変わらない (SvelteKit SSR は HTML コメントを output に含めず、`grep "PLAN_LABELS.standard" SSR-output` 結果は両 branch とも 0 件)。`scripts/check-pr-screenshot.mjs::isUiPr()` は `.svelte` 変更ありで UI PR と判定するため、形式上の 4 スロット添付を行う。**visual diff ゼロ想定**を以下の構造的証跡で示す。

**visual diff ゼロ証跡**:

- 撮影手順: `git checkout origin/main -- <3 files>` で main 状態に切替 → before SS 撮影 → `git checkout HEAD -- <3 files>` で復元 → after SS 撮影 (同じ dev server / 同じ URL `/demo/admin/license`)
- **PNG md5 完全一致** (撮影プロセスは独立、ファイルバイナリも同一):
  - mobile:  `682a04f6e26d01447abb800e7ab4e34e` (before / after 双方)
  - desktop: `5c72f2479492745d816f9383ba12f90a` (before / after 双方)
- **DOM HTML diff** (`*.dom.html`): SSR `requestId` UUID (毎回 generate) のみ差分、HTML コメントの変更分は SSR output に一切現れない (HTML コメントは Svelte コンパイラ段階で SSR から削除される)

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1991/before-mobile.png) | ![before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1991/before-desktop.png) |
| **修正後** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1991/after-mobile.png) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1991/after-desktop.png) |

**DOM HTML スナップショット** (#1747 AC4 / #1766):

- [before-mobile.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1991/before-mobile.dom.html)
- [before-desktop.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1991/before-desktop.dom.html)
- [after-mobile.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1991/after-mobile.dom.html)
- [after-desktop.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1991/after-desktop.dom.html)

**インタラクティブ状態**: N/A — HTML コメントのみで DOM 不変、対話状態の差分は構造的に発生し得ない。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A — 5 行のコメント文字列変更のみで構造変化なし
- [x] **DRY**: コメント表記を `PLAN_LABELS.standard` / `PLAN_LABELS.family` の label key 参照形式に統一し、将来の文言変更時に grep 起点の一貫性を確保
- [x] **YAGNI**: コメントのみで過剰抽象化なし
- [x] **Security（OSS 公開前提）**: N/A — コメントのみ
- [x] **アクセシビリティ**: N/A — DOM 不変
- [x] **パフォーマンス**: N/A — bundle サイズ 0 byte 変化 (コメントは production build 時に minify で除去)

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] 本番アプリ (`src/routes/(parent)/`) + デモ版 (`src/routes/demo/(parent)/`) を同期 — admin/license の 2 ファイルで同じコメント形式に揃えた (本番 L657/L685、demo L345/L376)
- [N/A] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）— LP / pricing 文言変更なし
- [N/A] 全年齢モード 5 種に横展開 — admin 画面 (年齢モード非依存)
- [N/A] ナビゲーション 3 種に反映 — ナビ変更なし
- [N/A] E2E / ユニットシード + チュートリアルを同期 — シード / チュートリアル変更なし
- [x] **labels SSOT** (ADR-0009 → ADR-0045): コメントを `PLAN_LABELS.<key>` 参照表記に統一することで、`labels.ts` SSOT との整合がコメントレベルでも担保される
- [x] **設計書同期** (ADR-0001): N/A — `refactor:internal-no-doc-impact` ラベル exempt 対象 (#1985 / #1986 で導入された内部 refactor exempt)、機能仕様変化なし
- [x] **並行 PR overlap** (#1200): 本 PR が変更する 3 ファイルを同時期に変更する open PR は確認時点で無し
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A |

該当なし。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- HTML コメントのみの変更で機能仕様 / DOM / 表示テキスト / labels.ts 値は一切無変更
- AC3 (grep 0 件) は本 PR 対象 5 ファイルでのみ要求。LP 側 `site/shared-labels.js` の固有名詞 (FAQ 文言等) は Issue 範囲外
- `refactor:internal-no-doc-impact` ラベル付与で `design-doc-check` skip を期待 (#1985 / #1986)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 1991` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (未着手の AC が残っていない)
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — Phase 2 C15 として既存 #1940 を完遂、子分割なし
- [N/A] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認 — DOM 不変
- [N/A] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — DOM 不変

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

