### PR TITLE
refactor: #1937 admin/weekly-report/+server.ts コメント整理 (Phase 2 C12)

### DIFF
--- a/src/routes/api/v1/admin/weekly-report/+server.ts
+++ b/src/routes/api/v1/admin/weekly-report/+server.ts
@@ -1,13 +1,16 @@
 // src/routes/api/v1/admin/weekly-report/+server.ts
 // 週次活動レポートメール送信（EventBridge / 手動トリガー用）
 //
-// #735: 週次メールレポートはスタンダードプラン以上の特典。
+// #735: 週次メールレポートは PLAN_LABELS.standard 以上の特典。
 // /pricing の features で「週次メールレポート」と明示しているにもかかわらず、
-// 旧実装は全テナント（無料プラン含む）に配信しており、
+// 旧実装は全テナント（PLAN_LABELS.free 含む）に配信しており、
 //   - 課金動機を削ぐ（有料プラン特典の価値毀損）
 //   - SES 送信コストが想定比率を超過する
 //   - HP と実装の乖離で課金ユーザーが不公平感を持つ
 // という三重の問題があった。本エンドポイントでプラン解決→free は早期 return する。
+//
+// プラン名 SSOT: src/lib/domain/labels.ts PLAN_LABELS / src/lib/domain/terms.ts PLAN_FULL_TERMS
+// 関連: #1937 Phase 2 C12 / ADR-0045 (terms.ts 2 階層 SSOT)
 
 import { json } from '@sveltejs/kit';
 import { verifyCronAuth } from '$lib/server/auth/cron-auth';
@@ -29,7 +32,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			children: WeeklyReportData[];
 		};
 
-		// #735: プランゲート — 無料プランは送信スキップ
+		// #735: プランゲート — PLAN_LABELS.free は送信スキップ
 		// licenseInfo が取得できない場合は安全側に倒してスキップ（未知のテナントには送らない）
 		const licenseInfo = await getLicenseInfo(body.tenantId);
 		if (!licenseInfo) {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（保守エンジニア / Phase 2 集約フェーズの後続実装者）

**解決する課題**: `src/routes/api/v1/admin/weekly-report/+server.ts` のヘッダコメント (L4) と内部コメント (L6 / L32) に「スタンダードプラン」「無料プラン」のリテラル文字列が直書きされており、`terms.ts` SSOT 2 階層化 (ADR-0045 / Phase 1 #1916) で確立された atom → compound 階層が不可視化されていた。コメントのみの細部であるが、Phase 2 集約 (#1925) 全体で「リテラル直書きを撲滅して SSOT 階層を可視化する」方針の一環として整理する必要がある (#1937)。

**期待される効果**: コメントが `PLAN_LABELS.standard` / `PLAN_LABELS.free` 参照表記になることで、後続保守者がプラン名変更時に terms.ts → labels.ts の 1 行修正で全箇所伝播することを即座に把握できる。Phase 2 C1 (#1926 / PR #1975) errors.ts JSDoc 整理と同パターンを踏襲し、SSOT 1 段ずつ可視化を進める。

## 関連 Issue

closes #1937

依存: Phase 1 (#1916) / Phase 2 C0 (#1925、PR #1967) で SSOT 基盤整備済 / Phase 2 C1 (#1926、PR #1975) errors.ts JSDoc コメント整理パターンを踏襲

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/routes/api/v1/admin/weekly-report/+server.ts L4 コメント '#735: 週次メールレポートはスタンダードプラン以上の特典。' を 'PLAN_LABELS.standard 以上の特典' のように label key 参照に書換え | `git diff origin/main -- src/routes/api/v1/admin/weekly-report/+server.ts` | PASS — L4 が `// #735: 週次メールレポートは PLAN_LABELS.standard 以上の特典。` に書換え済 (L6 / L32 も同様、末尾に SSOT 参照ポインタ追記) |
| AC2 | 既存 vitest PASS | `npx vitest run tests/unit/domain/plan-gate-labels.test.ts tests/unit/routes/weekly-report-api.test.ts tests/unit/services/weekly-report-email.test.ts tests/unit/services/weekly-report-service.test.ts` | PASS — 31 件 (13 + 18) 全 PASS |
| AC3 | grep 'スタンダードプラン' で 0 件 | `grep -c 'スタンダードプラン' src/routes/api/v1/admin/weekly-report/+server.ts` | PASS — 0 件 (本 PR diff にて完全撤廃) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- なし（ランタイムコード差分なし、コメントのみ修正）。`POST /api/v1/admin/weekly-report` のレスポンス・送信判定ロジック・ログ出力に変化なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030） — biome / vitest / shared-labels.js diff = 0 を本作業中で個別確認済
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - N/A — コメント整理のみ。既存 31 件 (`plan-gate-labels.test.ts` 13 + `weekly-report-{api,email,service}.test.ts` 18) が引き続き PASS することで AC2 を担保
- [x] **新規 env / secret 追加時**（ADR-0006）: 末尾の「配布済み env / secret」セクションに証跡記載。該当なければ「N/A」 — N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: SQLite + DynamoDB 両実装完成 + `scripts/check-dynamodb-stub.mjs` PASS。該当なければ「N/A」 — N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: 5 要件確認済み。該当なければ「N/A」 — N/A (`priority:low`)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は `src/routes/api/v1/admin/weekly-report/+server.ts` の **コメントのみ修正** (ランタイムコード差分なし)。`+page.svelte` / CSS / LP / `site/**` への影響ゼロ、UI 描画は完全に main と同一。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A — UI 変更なし | N/A — UI 変更なし |
| **修正後** | N/A — UI 変更なし | N/A — UI 変更なし |

**インタラクティブ状態**: N/A — UI 変更なし

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 / 依存性逆転 / インターフェース分離 — N/A (コメントのみ、ランタイム不変)
- [x] **DRY**: 同一ロジックが他ファイルにないか `grep` / `Glob` で調査済 — Phase 2 C1 (#1926 / PR #1975) errors.ts JSDoc 整理パターンを踏襲、コメント書換え方針は同一
- [x] **YAGNI**: 現要件に不要な抽象化なし — `PLAN_GATE_LABELS` 等のランタイム置換は本ファイル内で必要な箇所がない (本ファイルは plan tier を `'free'` 文字列リテラルで判定しているのみで、表示文字列を扱わない)
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし — N/A (コメントのみ)
- [x] **アクセシビリティ**: キーボード操作可 / ARIA 適切 — N/A (UI 変更なし)
- [x] **パフォーマンス**: N+1 なし / バンドルサイズ確認 — N/A (コメントのみ、bundle サイズ変化なし)

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外
- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [x] labels SSOT (ADR-0009 / ADR-0045): `PLAN_LABELS` / `PLAN_FULL_TERMS` 参照表記に整合
- [ ] 設計書同期 (ADR-0001) — `refactor:internal-no-doc-impact` ラベルで exempt (#1985 / #1986、ADR-0003 §4 内部 refactor exempt)
- [ ] 並行 PR overlap 確認 (#1200) — Phase 2 C シリーズは順次直列 merge 中

**LP / 販促文言変更時** (ADR-0013):

N/A — LP / pricing への影響なし、コメントのみ修正で `shared-labels.js` diff = 0 を機械検証済

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- 「ランタイム差分なし」を AC 検証マップ (`git diff origin/main -- ...`) で確認してほしい
- AC3 の機械検証 (`grep -c 'スタンダードプラン' src/routes/api/v1/admin/weekly-report/+server.ts` → 0) も併せて確認可能

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — biome (clean) / vitest (31 件 PASS) / shared-labels.js diff = 0 を個別確認済
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (AC1 / AC2 / AC3)
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A (UI 変更なし)
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A (認証画面変更なし)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
