### PR TITLE
refactor: #1938 src/routes/api/v1/export/+server.ts PLAN リテラル撤廃 (Phase 2 C13)

### DIFF
--- a/src/routes/api/v1/export/+server.ts
+++ b/src/routes/api/v1/export/+server.ts
@@ -4,6 +4,7 @@ import { json } from '@sveltejs/kit';
 
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { todayDateJST } from '$lib/domain/date-utils';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { requireRole } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
@@ -27,10 +28,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan),
 	);
 	if (!limits.canExport) {
-		return apiError(
-			'PLAN_LIMIT_EXCEEDED',
-			'エクスポート機能はスタンダードプラン以上でご利用いただけます',
-		);
+		return apiError('PLAN_LIMIT_EXCEEDED', PLAN_GATE_LABELS.standardOrAboveFor('エクスポート機能'));
 	}
 
 	const childIdsParam = url.searchParams.get('childIds');


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者・standard / family プランで `/api/v1/export` を呼ぶ） / 開発者（labels SSOT 維持の保守性）

**解決する課題**: `src/routes/api/v1/export/+server.ts` L32 にエクスポート機能のプラン制限エラーメッセージが直書きされており、`PLAN_FULL_TERMS.standard = 'スタンダード'` を将来別語彙にリネームする際の修正漏れ点になっていた。Phase 2 C13 として `PLAN_GATE_LABELS.standardOrAboveFor()` compound 経由に統一する。

**期待される効果**: プラン名語彙を 1 行修正 (`terms.ts`) で全画面・全エラーパスに伝播できる SSOT 状態に近づく。ユーザー文言は char-by-char 完全一致で変化させない（UX 影響ゼロ）。

## 関連 Issue

closes #1938

- Phase 2 (Issue #1916: terms.ts SSOT 2 階層化) の C13 として位置付け
- 兄弟: #1925 (PLAN_GATE_LABELS 導入) / #1926 / #1927 / #1928 / #1929 / #1930 / #1935 (#1980 で merged main 取込済)
- ADR-0003 §4 (内部 refactor 設計書同期 exempt、PR-1987/PR-1988 で導入) の 4 条件全充足のため `refactor:internal-no-doc-impact` ラベルで `design-doc-check` skip 対象

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/routes/api/v1/export/+server.ts L32 'エクスポート機能はスタンダードプラン以上でご利用いただけます' を PLAN_GATE_LABELS.standardOrAboveFor 経由に | `grep -n 'PLAN_GATE_LABELS.standardOrAboveFor' src/routes/api/v1/export/+server.ts` | PASS — L31 で `PLAN_GATE_LABELS.standardOrAboveFor('エクスポート機能')` を呼出。展開結果は `'エクスポート機能' + 'は' + PLAN_FULL_TERMS.standard + '以上でご利用いただけます'` = `'エクスポート機能はスタンダードプラン以上でご利用いただけます'` で既存メッセージと char-by-char 完全一致 (tests/unit/domain/plan-gate-labels.test.ts L49-52 で同等値の assertion 既存) |
| AC2 | 既存 vitest PASS | `npx vitest run tests/unit/domain/plan-gate-labels.test.ts` | PASS — Test Files 1 passed (1) / Tests 13 passed (13) / Duration 1.75s |
| AC3 | grep 'スタンダードプラン' で 0 件 | `grep -c 'スタンダードプラン' src/routes/api/v1/export/+server.ts` | PASS — `0`（0 件） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- `/api/v1/export` GET endpoint のみ。free / preview プランで呼び出された際の `apiError('PLAN_LIMIT_EXCEEDED', ...)` レスポンス内 `error.message` 文字列のみ間接置換。表示文言は完全一致のため UI 上の見た目（client が message を表示する場合）は変化しない。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 部分実行（個別 step）で確認: biome --error-on-warnings PASS / svelte-check 0 errors / vitest plan-gate-labels 13 PASS / shared-labels.js diff = 0 / grep 'スタンダードプラン' 0 件
- [x] 追加・変更したテストの概要を以下に記載: N/A — 既存メッセージ char-by-char 一致のため新規テスト不要 (#1925〜#1935 の先行 C0-C10 でも同パターン採用、tests/unit/domain/plan-gate-labels.test.ts L49-52 で `PLAN_GATE_LABELS.standardOrAboveFor('エクスポート機能')` の値 assertion 既存)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — refactor 系、priority:high

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: server-side error message 文字列の参照経路のみ変更する refactor。表示文言は `PLAN_FULL_TERMS.standard = 'スタンダード'` 経由展開で既存メッセージと char-by-char 完全一致のため UI 上の見た目に変化なし。Svelte / CSS / HTML / 画像変更ゼロ（変更ファイルは `src/routes/api/v1/export/+server.ts` のみ）。

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A — UI 変更なし | N/A — UI 変更なし |
| **修正後** | N/A — UI 変更なし | N/A — UI 変更なし |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任維持（`+server.ts` の GET handler はそのまま、文字列源だけ compound 層に委譲）
- [x] **DRY**: `PLAN_GATE_LABELS.standardOrAboveFor` の callsite として `errors.ts` (AI 活動提案) / `cloud-export-service.ts` (クラウドエクスポート) / `admin/reports/+page.server.ts` (週次メールレポート) / `admin/rewards/+page.server.ts` (特別なごほうび設定) と並列に追加。`labels.ts` JSDoc コメント「カバー対象 (C1-C15 リテラル置換): - api/v1/export/+server.ts: 'エクスポート機能はスタンダードプラン以上でご利用いただけます'」が既記載 (#1925 で先行整備済) で実装と doc が同期している
- [x] **YAGNI**: 既存 compound テンプレを利用するのみ、新規抽象化なし
- [x] **Security（OSS 公開前提）**: 秘密情報なし / 内部 URL なし
- [x] **アクセシビリティ**: server-side 文字列のみ、ARIA / キーボード影響なし — N/A
- [x] **パフォーマンス**: テンプレート文字列の即時 concat 1 回のみ（render path に追加コストなし）— N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — `/api/v1/export` は本番 endpoint のみ（demo 版に同等 endpoint なし）。grep で `'エクスポート機能はスタンダードプラン以上でご利用いただけます'` リテラルが他ファイルに残っていないことを確認 (`src/routes/api/v1/export/+server.ts` のみ該当、置換後は 0 件)
- [x] LP ↔ アプリ双方向整合（ADR-0013）— LP には本文字列の出現なし。`shared-labels.js` regenerate diff = 0 で確認
- [x] 全年齢モード 5 種に横展開 — N/A（API endpoint、年齢モード非依存）
- [x] ナビゲーション 3 種に反映 — N/A
- [x] E2E / ユニットシード + チュートリアルを同期 — N/A（メッセージ文字列同一のため既存 E2E への影響なし、`tests/e2e` で `'スタンダードプラン以上'` を直 assert している箇所も grep で本ファイル経由は 0 件）
- [x] labels SSOT (ADR-0009 → ADR-0045 supersede) — `PLAN_GATE_LABELS.standardOrAboveFor` 経由で `terms.ts` の `PLAN_FULL_TERMS.standard` atom に到達。1 行修正で全画面伝播の要件を満たす
- [x] 設計書同期 (ADR-0001) — `docs/design/06-UI設計書.md` の compound テンプレ表（行: `PLAN_GATE_LABELS.standardOrAboveFor(feature) | ${feature}はスタンダードプラン以上でご利用いただけます | ... / api/v1/export/+server.ts (エクスポート機能) ...`）に当該 callsite が既記載 (#1925 で先行整備済) のため新規追記なし。本 PR は ADR-0003 §4 内部 refactor exempt の 4 条件全充足: (1) 機能仕様変化なし (2) atom と compound 階層化 (3) リテラル置換のみ (4) import 追加 + literal removal のみ → `refactor:internal-no-doc-impact` ラベルで `design-doc-check` skip 対象
- [x] 並行 PR overlap 確認 (#1200) — Phase 2 sibling PR (#1931 / #1932 / #1934 / #1980) は別 file のため衝突なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

N/A — LP / pricing への文言伝播なし。`shared-labels.js` diff = 0 確認済。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- 表示文字列が char-by-char 完全一致であること（`PLAN_GATE_LABELS.standardOrAboveFor('エクスポート機能')` の展開結果が旧リテラル `'エクスポート機能はスタンダードプラン以上でご利用いただけます'` と一致）の確認をお願いします。`PLAN_FULL_TERMS.standard = 'スタンダード'` を atom 経由参照しているため、将来 atom を変更すると UX 影響あり（=本リファクタの狙い通り）。
- biome formatter による 1 行整形（`apiError('PLAN_LIMIT_EXCEEDED', PLAN_GATE_LABELS.standardOrAboveFor('エクスポート機能'));` の単一行化）は `biome check --write` 結果。元の 5 行 → 1 行への整形による意図的変更です。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — biome --error-on-warnings / svelte-check / vitest plan-gate-labels / shared-labels.js diff = 0 / grep 'スタンダードプラン' 0 件 を個別 step で確認
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— `git diff` で 2 insertions, 4 deletions (import 1 行 + 引数整形 1 行 = char-by-char 一致) のみ確認
- [x] 全 AC が実装済み — AC1/AC2/AC3 全て PASS
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A — UI 変更なし（server-only refactor、文言は char-by-char 完全一致）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
