### PR TITLE
refactor: #1959 BILLING_LABELS / CANCELLATION_LABELS の atom 直書き撤廃 (Phase 7 H2)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -1978,8 +1978,8 @@ export const CANCELLATION_LABELS = {
 	categoryPauseHint: '家庭事情・引っ越し・一時的に離れる（再開予定あり）',
 
 	// Plan-context messaging (free / standard / family 共通)
-	freePlanNotice:
-		'無料プランをご利用中です。解約後はアカウント自体を削除する必要がありますが、その前に理由をお聞かせください。',
+	// #1959: 無料プラン → PLAN_FULL_TERMS.free 参照化 (atom 直書き撤廃)
+	freePlanNotice: `${PLAN_FULL_TERMS.free}をご利用中です。解約後はアカウント自体を削除する必要がありますが、その前に理由をお聞かせください。`,
 	paidPlanNotice:
 		'解約手続きを進めると、Stripe の管理画面で決済停止を行います。次回の請求は発生しません。',
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） — 解約ページを利用する全プラン契約者

**解決する課題**: 用語変更（プラン名）が `labels.ts` の 1 namespace で完結せず、複数箇所で atom が直書きされていると、用語見直し時に散在修正が必要となり表記揺れの温床になる。本 PR は ADR-0045 (terms.ts SSOT 2 階層化) 原則に沿って `CANCELLATION_LABELS.freePlanNotice` 内の `無料プラン` atom 直書きを `PLAN_FULL_TERMS.free` 参照に置換する。

**期待される効果**: プラン名変更（例: 将来 `無料プラン` → `フリープラン` のような rename）が `terms.ts` 1 行修正で全 LP・アプリ本体・法務文書に伝播するようになり、表記揺れ起因の顧客混乱を構造的に防ぐ。

## 関連 Issue

closes #1959

- 関連 ADR: [ADR-0045 terms.ts SSOT 2 階層化](docs/decisions/0045-terms-ssot-2-layer.md)
- Phase 7 H2 (BILLING / CANCELLATION の atom 直書き撤廃)
- 上流: #1916 (terms.ts 新設) / #1917 (template literal parser) — terms.ts と generate-lp-labels.mjs は既に存在し本 PR の前提を満たす

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/lib/domain/labels.ts BILLING_LABELS (line 1882) 内の price / plan 関連直書きを terms.ts 参照に | `grep -nE '無料\|スタンダード\|ファミリー\|¥500\|¥780\|¥0\|7日間' src/lib/domain/labels.ts` の BILLING_LABELS 範囲 (line 1882-1935) で atom 該当 0 件を確認 | PASS — BILLING_LABELS scope に atom 直書きなし（`月額 / 年額プランの切り替え` `プラン管理` `プランを選択` 等は generic 語、atom ではない）。本 PR では BILLING_LABELS は変更不要として scope を確定 |
| AC2 | src/lib/domain/labels.ts CANCELLATION_LABELS (line 1959) 内の期間 / プラン関連直書きを terms.ts 参照に (cancelDisclaimer 整合性) | `git diff src/lib/domain/labels.ts` および `grep -n 'PLAN_FULL_TERMS' src/lib/domain/labels.ts` | PASS — `freePlanNotice: '無料プラン...'` → `` `${PLAN_FULL_TERMS.free}...` `` に置換。CANCELLATION_LABELS scope の他フィールド (期間/プラン関連) には atom 直書きなし |
| AC3 | 既存 vitest PASS | `npx vitest run --no-coverage` | PASS — 231 test files / 4414 tests 全 PASS |

**追加検証 (shared-labels.js diff = 0)**: `node scripts/generate-lp-labels.mjs --check` → `✓ site/shared-labels.js は最新です` 出力で template literal 解決後の文字列が完全一致を確認。

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`) — `src/lib/domain/labels.ts` のみ
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- 解約ページ (`/billing/cancel` 等で `CANCELLATION_LABELS.freePlanNotice` を表示する画面) — 表示文字列は char-by-char 完全一致のため UI 変更なし
- BILLING_LABELS 利用画面 (`/admin/billing` 等) — atom 該当なしのため未変更

**変更ファイル**:
- `src/lib/domain/labels.ts` (+2 / -2、`CANCELLATION_LABELS.freePlanNotice` 1 行のみ)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 個別 Step (biome / svelte-check / vitest / generate-lp-labels --check) を直接実行し全 PASS、refactor:internal-no-doc-impact label exempt 範囲
- [x] 追加・変更したテストの概要を以下に記載: N/A — 既存 4414 tests がそのまま PASS する内部 refactor。`freePlanNotice` の最終文字列は char-by-char 一致のため新規テスト不要
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — priority:medium、refactor

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: UI 変更を伴わない内部 refactor。`CANCELLATION_LABELS.freePlanNotice` の最終文字列は `` `${PLAN_FULL_TERMS.free}をご利用中です。...` `` = `'無料プランをご利用中です。...'` で char-by-char 完全一致 (PLAN_FULL_TERMS.free === '無料プラン')。`shared-labels.js` の diff も 0。SS 4 スロット撮影は exempt（`refactor:internal-no-doc-impact` label）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任を維持（labels.ts は表示文字列、terms.ts は atom）。ADR-0045 SSOT 2 階層化原則に沿う依存方向 (labels → terms)
- [x] **DRY**: `無料プラン` atom 直書きを `PLAN_FULL_TERMS.free` 参照に統一。表記揺れの温床を 1 箇所削減
- [x] **YAGNI**: 必要最小の変更（1 namespace の 1 フィールドのみ）。BILLING_LABELS は scope に atom がないと確認したため未変更
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし / N/A
- [x] **アクセシビリティ**: 表示文字列は完全一致、A11y 影響なし / N/A
- [x] **パフォーマンス**: template literal は build 時に静的評価され runtime コストなし

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — `labels.ts` は両方が import する SSOT
- [x] LP ↔ アプリ双方向整合（ADR-0013）— `shared-labels.js` diff = 0 で確認
- [x] 全年齢モード 5 種に横展開 — `freePlanNotice` は全年齢共通文言
- [x] ナビゲーション 3 種に反映 — N/A（解約ページ内文言）
- [x] E2E / ユニットシード + チュートリアルを同期 — N/A（atom 値は未変更）
- [x] labels SSOT (ADR-0009 / ADR-0045) — terms.ts 参照化の方針通り
- [x] 設計書同期 (ADR-0001) — `refactor:internal-no-doc-impact` label exempt（design doc 影響なしの内部 refactor）
- [x] 並行 PR overlap 確認 (#1200) — Phase 2 の各 PR は独立 namespace を扱い、本 PR の CANCELLATION_LABELS と衝突しない
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

N/A — LP 文言変更なし。`shared-labels.js` の最終出力 byte 一致で確認済 (`generate-lp-labels.mjs --check` PASS)。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** — `freePlanNotice` の表示文字列は char-by-char 完全一致
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- BILLING_LABELS scope に atom 直書きが本当にないかの確認 — `featurePlanSwitch: '月額 / 年額プランの切り替え'` `navLinkTitle: 'プラン管理'` 等は generic 語であり atom (PLAN_FULL_TERMS.free 等) には該当しないと判定（PR body AC1 参照）。この判定の妥当性をレビュー依頼

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — biome / vitest / generate-lp-labels --check 個別実行で全 PASS（refactor:internal-no-doc-impact label により 4 CI gate exempt 範囲、SS / docs sync 不要）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— `git diff` 確認済、変更 2 行のみ
- [x] 全 AC が実装済み — AC1 (BILLING scope 内 atom なし確認) / AC2 (freePlanNotice 置換) / AC3 (vitest PASS) 全完了
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A — 内部 refactor、UI 変更なし、char-by-char 一致
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
