### PR TITLE
refactor: #1961 PREMIUM_MODAL_LABELS 価格 atom を terms.ts 参照化 (Phase 7 H4)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4,7 +4,8 @@
 // #1304: baby=準備モード に表記変更済み（AGE_TIER_LABELS / AGE_TIER_SHORT_LABELS）
 
 // #1916: 用語集（atom）は terms.ts に集約。labels.ts は compound 専用とする SSOT 2 階層化基盤。
-import { PLAN_FULL_TERMS, PLAN_TERMS, TRIAL_TERMS } from './terms';
+// #1961 (Phase 7 H4): PRICE_TERMS を PREMIUM_MODAL_LABELS から参照
+import { PLAN_FULL_TERMS, PLAN_TERMS, PRICE_TERMS, TRIAL_TERMS } from './terms';
 import type { UiMode } from './validation/age-tier-types';
 // #980: age-tier-types.ts に型・正規化関数を集約し循環依存を解消
 import { normalizeUiMode } from './validation/age-tier-types';
@@ -558,6 +559,15 @@ export const TRIAL_LABELS = {
 // （「今すぐアップグレード」「失効します」等）を含めない中立的トーンとする。
 //
 // 親宛のみ送信されるため、敬語ベース（「ご利用ありがとうございます」「ご確認ください」）。
+//
+// #1961 (Phase 7 H4) atom 直書き監査:
+//   - planLabel は呼び出し側 (renewal-reminder service) から引数注入され、PLAN_LABELS / PLAN_FULL_TERMS
+//     経由で解決済みの compound を渡す設計のため本 namespace に直書きしない。
+//   - daysRemaining / days / expiresAt も全て引数注入で計算ロジック側の責務。
+//   - 件名・heading・本文は「次回更新予定日」「お元気でいらっしゃいますか」等の独自用語のみで
+//     構成され、プラン名・価格・トライアル日数・解約期間の atom には依存しない。
+//   - 検証: 範囲内に '無料' / 'スタンダード' / 'ファミリー' / '7日間' / '7 日間' / '¥\d+' /
+//     '無料プラン' / 'スタンダードプラン' / 'ファミリープラン' リテラル 0 件。
 // ============================================================
 
 export const LIFECYCLE_EMAIL_LABELS = {
@@ -729,7 +739,7 @@ export type PmfSurveyQ1 = keyof typeof PMF_SURVEY_LABELS.q1Options;
 export type PmfSurveyQ3 = keyof typeof PMF_SURVEY_LABELS.q3Options;
 
 // ============================================================
-// PremiumModal 用ラベル（#1166 labels.ts SSOT 化）
+// PremiumModal 用ラベル（#1166 labels.ts SSOT 化 / #1961 Phase 7 H4: 価格 atom を terms.ts 参照化）
 // ============================================================
 
 export const PREMIUM_MODAL_LABELS = {
@@ -748,8 +758,9 @@ export const PREMIUM_MODAL_LABELS = {
 		'✅ きょうだいの比較',
 		'✅ 年間サマリーレポート',
 	],
-	priceStandard: '¥500',
-	priceFamily: '¥780',
+	// #1961: 価格 atom は terms.ts (PRICE_TERMS) を SSOT として参照
+	priceStandard: `${PRICE_TERMS.standard}`,
+	priceFamily: `${PRICE_TERMS.family}`,
 	priceUnit: '/月〜',
 	ctaUpgrade: `${ACTION_LABELS.upgrade}する`,
 	ctaLater: ACTION_LABELS.later,
@@ -2020,6 +2031,14 @@ export function getCancellationCategoryLabel(category: CancellationCategory): st
 // GRADUATION_LABELS - 卒業フロー (#1603 / ADR-0023 §3.8 / §5 I10)
 // 解約フローで「卒業」を選んだ親向けの専用ページ。
 // Anti-engagement 原則 (ADR-0012): ポジティブだが煽らない。引き止め CTA 禁止。
+//
+// #1961 (Phase 7 H4) atom 直書き監査:
+//   - 卒業フローは「卒業」「ご利用期間」「事例公開」「ニックネーム」等の独自用語のみで構成され、
+//     プラン名 (PLAN_TERMS / PLAN_FULL_TERMS) / 価格 (PRICE_TERMS) / トライアル日数 (TRIAL_TERMS) /
+//     解約期間 (CANCEL_TERMS) / 無料訴求 (FREE_TERMS) の atom には依存しない。
+//   - yenAmount / days / current / max は全て引数注入で計算ロジック側の責務。
+//   - 検証: 範囲内に '無料' / 'スタンダード' / 'ファミリー' / '7日間' / '7 日間' / '¥\d+' /
+//     '無料プラン' / 'スタンダードプラン' / 'ファミリープラン' リテラル 0 件。
 // ============================================================
 
 export const GRADUATION_LABELS = {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者（labels.ts SSOT メンテナ）+ 親（管理者・PremiumModal 利用者）

**解決する課題**: PREMIUM_MODAL_LABELS の価格 atom (`'¥500'` / `'¥780'`) が直書きされており、プラン価格を変更する際 PRICE_TERMS（terms.ts）と PREMIUM_MODAL_LABELS（labels.ts）の 2 箇所修正が必要だった。GRADUATION_LABELS / LIFECYCLE_EMAIL_LABELS の atom 直書き有無も未監査だった。

**期待される効果**: PRICE_TERMS 1 行修正でプラン価格が PremiumModal にも自動伝播。GRADUATION / LIFECYCLE は監査済を明記し、将来 atom 直書きが混入しないことを構造的に保証（compound 専用ガード）。Issue #1916 で導入された 2 階層 SSOT (atom / compound) の Phase 7 整備の一環。

## 関連 Issue

closes #1961

- 親 Issue: #1916 (terms.ts 新設、Phase 1 基盤)
- blocked_by 解決済: #1917 (template literal parser、`scripts/generate-lp-labels.mjs` 対応)
- Phase: P1 後続 (Phase 7 H4)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | GRADUATION_LABELS の卒業 / プラン関連直書きを terms.ts 参照に | `node -e "..."` で範囲内 atom リテラル grep | **PASS**: 範囲 (`export const GRADUATION_LABELS` ～ `} as const satisfies Record<string, unknown>;`) に `'無料' / 'スタンダード' / 'ファミリー' / '7日間' / '7 日間' / '¥\d+' / '無料プラン' / 'スタンダードプラン' / 'ファミリープラン'` リテラル 0 件。元から atom 直書きが存在せず、卒業フローは独自用語（「卒業」「ご利用期間」「事例公開」「ニックネーム」等）のみで構成されているため**コード変更不要**、ヘッダコメントに監査結果と非依存の根拠を明記して可視化（diff 8 行追加）。 |
| AC2 | LIFECYCLE_EMAIL_LABELS の renewal / dormant / unsubscribe メール文言中のプラン / 期間直書きを terms.ts 参照に | 同上 grep | **PASS**: 範囲 (`export const LIFECYCLE_EMAIL_LABELS` ～ `} as const;`) に同 atom リテラル 0 件。`planLabel` / `daysRemaining` / `days` / `expiresAt` は全て呼び出し側 (`renewal-reminder` service) から引数注入される設計のため、本 namespace は atom に依存しない。ヘッダコメントに監査結果を明記（diff 9 行追加）。 |
| AC3 | PREMIUM_MODAL_LABELS のプラン関連直書きを terms.ts 参照に | `git diff src/lib/domain/labels.ts` + `node scripts/generate-lp-labels.mjs --check` exit 0 | **PASS**: `priceStandard: '¥500'` → `priceStandard: \`${PRICE_TERMS.standard}\`` / `priceFamily: '¥780'` → `priceFamily: \`${PRICE_TERMS.family}\`` に置換。import に `PRICE_TERMS` を追加。生成出力差分 0 (shared-labels.js は最新)。 |
| AC4 | 既存 vitest PASS | `npx vitest run` | **PASS**: 4414 tests / 231 files PASS（labels.test.ts 含む 33 tests labels SSOT 系も全 PASS）。 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- `PREMIUM_MODAL_LABELS` を消費する画面（PremiumDialog / PremiumModal 系コンポーネント）— 表示文字列の文字単位変化ゼロ（`'¥500'` / `'¥780'` を template literal 経由で同一文字列に展開）
- GRADUATION_LABELS / LIFECYCLE_EMAIL_LABELS は**コード変更なし**（コメント追加のみ）、UI / メール文言は変化なし

## テスト & 安全装置セルフチェック

- [N/A] **`npm run pre-ready -- --pr <num>` 全 Step PASS**: pre-ready は worktree から `origin/main` 比較が動かないため個別実行で代替（`npx biome check src/lib/domain/labels.ts` PASS / `npx svelte-check` 0 errors / `npx vitest run` 4414 tests PASS / `node scripts/generate-lp-labels.mjs --check` exit 0）
- [x] 追加・変更したテストの概要を以下に記載: **テスト追加なし**（atom リテラル → template literal 置換は既存 `labels.test.ts` の文字列一致テストで担保済、char-by-char 変化ゼロ）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 追加なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — DB 変更なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — 本 PR は priority:low の refactor

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: `src/lib/domain/labels.ts` の atom 直書き → `${PRICE_TERMS.x}` template literal 置換のみで、生成される表示文字列は char-by-char 同一（`'¥500'` → `\`${PRICE_TERMS.standard}\`` → `'¥500'` 展開）。`.svelte` / `.css` / `site/**` への変更は無いため UI 変化ゼロ。`refactor:internal-no-doc-impact` ラベル exempt 該当。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: PREMIUM_MODAL_LABELS は compound として PRICE_TERMS atom に依存する形に整理。SSOT 原則 (atom = terms.ts / compound = labels.ts) を遵守。
- [x] **DRY**: PRICE_TERMS.standard / .family は LP_HERO_PRICE_BAND_LABELS / LP_PRICING_LABELS 等で既に SSOT として参照されており、PREMIUM_MODAL_LABELS の置換で 2 箇所目の twin source 解消。
- [x] **YAGNI**: 現要件 (atom 直書き撤廃) のみに留め、新 atom 追加 / namespace 整理等の付随作業は scope 外として留保。
- [x] **Security（OSS 公開前提）**: 秘密情報なし。N/A
- [x] **アクセシビリティ**: 表示文字列変化ゼロ。N/A
- [x] **パフォーマンス**: import 追加 1 件のみ。bundle size 変化なし（PRICE_TERMS は既に他 namespace 経由で import 済み）。

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期: labels.ts 経由のため自動同期
- [x] LP ↔ アプリ双方向整合（ADR-0013）: shared-labels.js diff = 0 で確認
- [x] 全年齢モード 5 種に横展開: PREMIUM_MODAL_LABELS は年齢モード非依存
- [x] ナビゲーション 3 種に反映: N/A
- [x] E2E / ユニットシード + チュートリアルを同期: 文字列一致のため影響なし
- [x] labels SSOT (ADR-0009 → ADR-0045): atom / compound 階層を遵守
- [x] 設計書同期 (ADR-0001): `refactor:internal-no-doc-impact` 該当（実装内部のみ、表示文字列・API・DB スキーマすべて不変）
- [x] 並行 PR overlap 確認 (#1200): main worktree で並行作業中の PR が複数あるが、本 PR は `PREMIUM_MODAL_LABELS` の独立した 2 行 + ヘッダコメント 2 箇所のみで衝突可能性なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

N/A — LP 文言の変更なし、生成される文字列は char-by-char 同一

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- AC1 / AC2 を「コード変更なし + 監査コメント追加」で完了とした判断の妥当性を確認してほしい。Issue 本文には「卒業 / プラン関連直書きを terms.ts 参照に」とあるが、grep 監査の結果、対象 namespace に該当 atom リテラル 0 件であり、コードを変更する余地が物理的に無い。ヘッダコメントに監査結果と非依存の根拠を明記する形で SSOT を可視化した。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [N/A] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — pre-ready は worktree から動かないため個別実行で代替（biome / svelte-check / vitest / generate-lp-labels --check 全 PASS、上記「テスト & 安全装置セルフチェック」参照）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— diff は import 1 行 + コメントブロック 3 箇所 + 価格 atom 2 行のみ
- [x] 全 AC が実装済み — AC1-AC4 全 PASS（AC 検証マップ参照）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし、表示文字列 char-by-char 同一）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面に変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
