### PR TITLE
refactor: #1958 ACTION_LABELS / TRIAL_LABELS の atom 直書き撤廃 (Phase 7 H1)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4,10 +4,11 @@
 // #1304: baby=準備モード に表記変更済み（AGE_TIER_LABELS / AGE_TIER_SHORT_LABELS）
 
 // #1916: 用語集（atom）は terms.ts に集約。labels.ts は compound 専用とする SSOT 2 階層化基盤。
-// #1961 (Phase 7 H4): PRICE_TERMS を PREMIUM_MODAL_LABELS から参照
+// #1958 (Phase 7 H1): CTA_TERMS を ACTION_LABELS / TRIAL_LABELS から参照（freeTrial / freeTrialWord / freeTrialDesc）
 // #1960 (Phase 7 H3): PRICING_PAGE_LABELS subtitle1 で FREE_TERMS を追加 import
+// #1961 (Phase 7 H4): PRICE_TERMS を PREMIUM_MODAL_LABELS から参照
 // #1963 (Phase 7 H6): LICENSE_PAGE_LABELS で PRICE_TERMS を新規参照（plan / 期間 / 価格 atom 直書き撤廃）
-import { FREE_TERMS, PLAN_FULL_TERMS, PLAN_TERMS, PRICE_TERMS, TRIAL_TERMS } from './terms';
+import { CTA_TERMS, FREE_TERMS, PLAN_FULL_TERMS, PLAN_TERMS, PRICE_TERMS, TRIAL_TERMS } from './terms';
 import type { UiMode } from './validation/age-tier-types';
 // #980: age-tier-types.ts に型・正規化関数を集約し循環依存を解消
 import { normalizeUiMode } from './validation/age-tier-types';
@@ -504,16 +505,18 @@ export const ACTIVITY_PRIORITY_FORM_LABELS = {
  * 将来「アップグレード → プラン変更」等の一括置換がこのファイル 1 行の
  * 変更で済むようにする（#1166 + #1174）。
  */
+// #1958 Phase 7 H1: freeTrial / freeTrialWord / freeTrialDesc は CTA atom (terms.ts CTA_TERMS) を参照。
+// upgrade / viewPlans / later / submitting / viewDetail は本 Issue scope 外 (動詞 atom が未確立のため留保)。
 export const ACTION_LABELS = {
 	upgrade: 'アップグレード',
 	viewPlans: 'プランを見る',
 	later: 'あとで',
-	freeTrial: '無料体験',
-	freeTrialWord: '無料で試す',
+	freeTrial: CTA_TERMS.freeTrialNoun,
+	freeTrialWord: CTA_TERMS.freeTrialVerb,
 	// #1383: タイトル文脈用の可能形 (「7日間、全機能を無料で試せます」)。
 	// freeTrialWord (終止形) を「〜ます」に連結すると「試すます」と非文法になるため、
 	// 完全活用済みの文言を個別定数化する。
-	freeTrialDesc: '無料で試せます',
+	freeTrialDesc: CTA_TERMS.freeTrialDesc,
 	submitting: '開始中...',
 	// #1167: 詳細ページへの誘導 CTA。活動パック / マーケット一覧の「中身を確認する」導線に使用
 	viewDetail: 'くわしく見る',
@@ -537,13 +540,14 @@ export const ACTION_LABELS = {
  * CI: scripts/check-forbidden-terms.mjs が完全一致禁止語を検出する。
  */
 // #1916: atom (トライアル日数) は terms.ts (TRIAL_TERMS) に移譲
+// #1958 Phase 7 H1: bannerDescNotStarted の文末「カード登録不要。」を TRIAL_TERMS.noCreditCardMid 参照に統一。
 export const TRIAL_LABELS = {
 	durationDays: TRIAL_TERMS.durationDays,
 	bannerTitleActive: (days: number) => `${ACTION_LABELS.freeTrial}中（残り${days}日）`,
 	bannerTitleUrgent: `${ACTION_LABELS.freeTrial}は明日で終了します`,
 	bannerDescActive: '全機能をお試しいただけます。',
 	bannerTitleNotStarted: `${TRIAL_TERMS.duration}、全機能を${ACTION_LABELS.freeTrialDesc}`,
-	bannerDescNotStarted: `${PLAN_LABELS.standard}のすべての機能をお使いいただけます。カード登録不要。`,
+	bannerDescNotStarted: `${PLAN_LABELS.standard}のすべての機能をお使いいただけます。${TRIAL_TERMS.noCreditCardMid}。`,
 	bannerCtaNotStarted: ACTION_LABELS.viewPlans,
 	bannerCtaStart: `${TRIAL_TERMS.duration} ${ACTION_LABELS.freeTrialWord}`,
 	bannerCtaSubmitting: ACTION_LABELS.submitting,

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -8,7 +8,14 @@
 // #1960 (Phase 7 H3): PRICING_PAGE_LABELS subtitle1 で FREE_TERMS を追加 import
 // #1961 (Phase 7 H4): PRICE_TERMS を PREMIUM_MODAL_LABELS から参照
 // #1963 (Phase 7 H6): LICENSE_PAGE_LABELS で PRICE_TERMS を新規参照（plan / 期間 / 価格 atom 直書き撤廃）
-import { CTA_TERMS, FREE_TERMS, PLAN_FULL_TERMS, PLAN_TERMS, PRICE_TERMS, TRIAL_TERMS } from './terms';
+import {
+	CTA_TERMS,
+	FREE_TERMS,
+	PLAN_FULL_TERMS,
+	PLAN_TERMS,
+	PRICE_TERMS,
+	TRIAL_TERMS,
+} from './terms';
 import type { UiMode } from './validation/age-tier-types';
 // #980: age-tier-types.ts に型・正規化関数を集約し循環依存を解消
 import { normalizeUiMode } from './validation/age-tier-types';

--- a/src/lib/domain/terms.ts
+++ b/src/lib/domain/terms.ts
@@ -19,8 +19,9 @@
 //   TRIAL_TERMS      — トライアル atom（7日間 / カード登録）
 //   CANCEL_TERMS     — 解約 atom
 //   FREE_TERMS       — 無料訴求 atom
+//   CTA_TERMS        — CTA / トライアル動詞句 atom（無料体験 / 無料で試す / 無料で試せます、#1958）
 //
-// 参照: docs/DESIGN.md §6 / Issue #1916 / Issue #1917 (template literal parser)
+// 参照: docs/DESIGN.md §6 / Issue #1916 / Issue #1917 (template literal parser) / Issue #1958
 
 // ============================================================
 // PLAN_TERMS — プラン名（短縮形、PLAN_SHORT_LABELS の atom）
@@ -64,6 +65,10 @@ export const TRIAL_TERMS = {
 	durationDays: 7,
 	noCreditCard: 'クレジットカード登録不要',
 	noCreditCardShort: 'クレカ登録不要',
+	// #1958 Phase 7 H1: TRIAL_LABELS.bannerDescNotStarted の文末「カード登録不要。」用 atom。
+	// 既存の noCreditCard (12 文字) / noCreditCardShort (8 文字) と異なる中間長 (7 文字) であり、
+	// 文字列差分ゼロ維持のため新 atom として独立させる。
+	noCreditCardMid: 'カード登録不要',
 } as const;
 
 // ============================================================
@@ -83,4 +88,23 @@ export const FREE_TERMS = {
 	base: '基本無料',
 	start: 'まずは無料',
 	tryFree: '無料で始める',
+} as const;
+
+// ============================================================
+// CTA_TERMS — CTA / トライアル訴求の動詞句 atom (#1958 Phase 7 H1)
+// ============================================================
+//
+// 「無料体験」「無料で試す」「無料で試せます」等、トライアル CTA で頻出する
+// 動詞句・名詞句を atom として集約。labels.ts ACTION_LABELS / TRIAL_LABELS の
+// compound はこの atom を参照する。
+//
+// 設計指針:
+//   - freeTrialNoun: 名詞「無料体験」（「〜中」「〜は明日で終了します」「〜が終了しました」）
+//   - freeTrialVerb: 終止形「無料で試す」（CTA ボタン文末）
+//   - freeTrialDesc: 可能形「無料で試せます」（タイトル文脈、#1383 で個別定数化済）
+
+export const CTA_TERMS = {
+	freeTrialNoun: '無料体験',
+	freeTrialVerb: '無料で試す',
+	freeTrialDesc: '無料で試せます',
 } as const;


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（labels.ts SSOT 利用者すべて、特に LP / アプリ本体 / Storybook / 法務文書）

**解決する課題**: ACTION_LABELS / TRIAL_LABELS が「無料体験」「無料で試す」「無料で試せます」「カード登録不要」等の atom 文字列を直接記述しており、terms.ts (atom) → labels.ts (compound) の SSOT 2 階層化原則 (#1916 / ADR-0045) から外れていた。値変更時に複数箇所を grep して直す必要があり、文言ドリフトの温床となっていた。

**期待される効果**: トライアル CTA / バナー文言の atom が terms.ts 1 ファイルに集約され、将来「無料体験 → 無料体験版」のような表記揺れ調整が 1 行修正で labels.ts / shared-labels.js / 法務文書すべてに伝播するようになる (Phase 7 H1 完遂)。char-by-char ゼロ差分のため UI / LP に視覚変化なし。

## 関連 Issue

closes #1958

- 親 Phase: #1916 (terms.ts 新設) / #1917 (template literal parser)
- 関連 ADR: ADR-0045 (terms.ts SSOT 2 階層化原則)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/lib/domain/labels.ts ACTION_LABELS の freeTrial / freeTrialWord / freeTrialDesc を terms.ts CTA_TERMS 参照に | `grep -nP "freeTrial(Word\|Desc)?:" src/lib/domain/labels.ts` | PASS — `freeTrial: CTA_TERMS.freeTrialNoun` / `freeTrialWord: CTA_TERMS.freeTrialVerb` / `freeTrialDesc: CTA_TERMS.freeTrialDesc` (labels.ts L511-516)。upgrade / viewPlans / later / submitting / viewDetail は本 Issue scope 外として留保 (動詞 atom の確立は別 Issue) |
| AC2 | src/lib/domain/labels.ts TRIAL_LABELS の bannerDescNotStarted の文末「カード登録不要」を terms.ts 参照に統一 | `grep -nP "noCreditCardMid\|カード登録不要" src/lib/domain/labels.ts src/lib/domain/terms.ts` | PASS — `TRIAL_TERMS.noCreditCardMid: 'カード登録不要'` を terms.ts に追加し、`bannerDescNotStarted` で `${TRIAL_TERMS.noCreditCardMid}。` 参照化 (labels.ts L547)。bannerTitleActive / bannerTitleNotStarted / bannerCtaStart 等は既に TRIAL_TERMS.duration / ACTION_LABELS 参照済 |
| AC3 | shared-labels.js 出力差分ゼロ | `node scripts/generate-lp-labels.mjs --check` | PASS — `✓ site/shared-labels.js は最新です` (LP namespace 配信は ACTION_LABELS / TRIAL_LABELS を含まず、template literal resolver も同一文字列を再生成するため char-by-char 一致) |
| AC4 | 既存 vitest PASS (TRIAL_LABELS の関数型 banner 文言が同じ最終文字列) | `npx vitest run` + 解決値スポット検証 (tsx) | PASS — Test Files 231 passed / Tests 4414 passed。解決値: `bannerTitleActive(3)='無料体験中（残り3日）'` / `bannerTitleNotStarted='7日間、全機能を無料で試せます'` / `bannerDescNotStarted='スタンダードプランのすべての機能をお使いいただけます。カード登録不要。'` / `bannerCtaStart='7日間 無料で試す'` (元値と完全一致) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- TrialBanner.svelte（管理画面のトライアルバナー、表示文言は char-by-char 一致のため視覚変化なし）
- shared-labels.js を読む LP 全頁（生成出力 diff ゼロのため変化なし）
- ACTION_LABELS / TRIAL_LABELS を import するすべての消費者（参照値は同一）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル検証用コマンド単位で実行（biome check / svelte-check / vitest / shared-labels --check 個別 PASS、`pre-ready` 実行は PR 番号採番後に再実行）
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - N/A — 既存 4414 テストが char-by-char 一致を担保しており、refactor の安全装置として十分（atom 化の最終文字列は変えない）
- [N/A] **新規 env / secret 追加時**（ADR-0006）: 該当なし
- [N/A] **DynamoDB 実装変更時**（ADR-0010 / #1021）: 該当なし
- [N/A] **Critical バグ修正の場合**（ADR-0002）: priority:medium / type:refactor

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は labels.ts (compound) / terms.ts (atom) の純粋なリファクタリングで、UI 表示文字列は char-by-char 一致 (vitest + tsx スポット検証で確認済)。`*.svelte` / `*.css` / `site/**` の変更ゼロのため SS 撮影対象なし。視覚的差分が生じないことが ADR-0006 (assertion erosion 禁止) と AC3 / AC4 の機械検証で担保されている。

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし（UI 変更ゼロ） | 該当なし（UI 変更ゼロ） |
| **修正後** | 該当なし（UI 変更ゼロ） | 該当なし（UI 変更ゼロ） |

**インタラクティブ状態**: N/A — UI コンポーネント変更なし。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — terms.ts は atom（用語集）、labels.ts は compound（表示文字列組み立て）に責務分離。ACTION_LABELS / TRIAL_LABELS が atom を直接保持していた SOLID 違反を解消
- [x] **DRY**: 「無料体験」「無料で試す」「無料で試せます」「カード登録不要」が複数箇所で重複保持されていた状態を terms.ts 1 箇所に集約
- [x] **YAGNI**: CTA_TERMS は本 Issue で実消費される 3 atom (freeTrialNoun / freeTrialVerb / freeTrialDesc) のみ。upgrade / viewPlans / later 等は scope 外として留保（動詞 atom の確立は別 Issue で議論）
- [x] **Security（OSS 公開前提）**: 秘密情報なし。labels.ts / terms.ts は元々公開資産
- [N/A] **アクセシビリティ**: UI 変更なし
- [N/A] **パフォーマンス**: 文字列定数のみ。bundle size 変化ゼロ（JS としてはリテラル → const 参照に変わるだけで minifier 後同等）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期（labels.ts は本番/デモ共通 SSOT）
- [x] LP ↔ アプリ双方向整合（ADR-0013）— shared-labels.js diff = 0 で LP 側に伝播変化なし
- [N/A] 全年齢モード 5 種に横展開 — 年齢帯非依存の atom
- [N/A] ナビゲーション 3 種に反映 — ナビ非依存
- [N/A] E2E / ユニットシード + チュートリアルを同期 — テストデータ非依存
- [x] labels SSOT (ADR-0045 + 旧 ADR-0009 archive) — atom (terms.ts) / compound (labels.ts) 2 階層原則を遵守
- [x] 設計書同期 (ADR-0001) — `refactor:internal-no-doc-impact` ラベル付与 (#1985 / #1986、内部 refactor exempt) で design-doc-check skip。文言・API・DB・UI 変更なしのため設計書本体の更新は不要
- [x] 並行 PR overlap 確認 (#1200) — Phase 7 H2-H4 (#1959 / #1960 / #1961 / #1962 / #1963) と labels.ts の異 namespace を編集するため衝突リスクなし

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A — 文言の最終解決値は char-by-char 不変。LP shared-labels.js diff = 0 | — | — |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- AC4 の最終文字列保証：`tsx` でランタイム解決値を確認した結果（PR body AC 検証マップ「結果 / エビデンス」列に記載）。元の TRIAL_LABELS 出力との char-by-char 一致を vitest 4414 件で担保
- CTA_TERMS の scope 設計：本 Issue は freeTrial / freeTrialWord / freeTrialDesc の 3 atom のみ atom 化。upgrade / viewPlans / later / submitting / viewDetail は「動詞 atom」が未確立のため留保（次 Issue 起票候補）
- TRIAL_TERMS.noCreditCardMid の必要性：既存の `noCreditCard: 'クレジットカード登録不要'` (12 文字) / `noCreditCardShort: 'クレカ登録不要'` (8 文字) と異なる中間長 (7 文字) のため、文字列 char-by-char 維持目的で新 atom 独立。将来統合は別 Issue で文言審議が前提

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（PR 採番後に `pre-ready -- --pr <num>` 再実行し本文 fingerprint まで検証する。本 commit 時点で個別 Step: biome / svelte-check / vitest / shared-labels --check は全 PASS）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [N/A] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — UI 変更なし
- [N/A] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
