### PR TITLE
refactor: #1946 LP_HERO_PRICE_BAND_LABELS / LP_INDEX_PHASEB_LABELS の terms.ts 参照化 (Phase 3 D6)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -9,6 +9,7 @@
 // #1961 (Phase 7 H4): PRICE_TERMS を PREMIUM_MODAL_LABELS から参照
 // #1963 (Phase 7 H6): LICENSE_PAGE_LABELS で PRICE_TERMS を新規参照（plan / 期間 / 価格 atom 直書き撤廃）
 import {
+	CANCEL_TERMS,
 	CTA_TERMS,
 	FREE_TERMS,
 	PLAN_FULL_TERMS,
@@ -4046,12 +4047,16 @@ export const LP_FOOTER_LABELS = {
 
 // LP Hero 価格 anchor バンド (#1625 R21)
 // site/index.html hero 直下に配置する 1 行価格プロミスバンド
+// #1946 (Phase 3 D6): terms.ts 参照化。文字列差分ゼロを維持しつつ FREE_TERMS / PRICE_TERMS / CANCEL_TERMS 経由で atom SSOT に統一。
+//   - itemPriceLabel ('月') / itemTrial ('有料は 7 日間無料') は terms.ts atom と表記揺れ
+//     (PRICE_TERMS.monthlyPrefix が '月 ' 末尾空白あり / TRIAL_TERMS.duration が '7日間' 空白なし)
+//     のため、文字列差分ゼロを優先しリテラル維持 (atom 化は別 Issue で表記統一後に再検討)
 export const LP_HERO_PRICE_BAND_LABELS = {
-	itemFree: '基本無料',
+	itemFree: FREE_TERMS.base,
 	itemPriceLabel: '月',
-	itemPriceValue: '¥500〜',
+	itemPriceValue: `${PRICE_TERMS.standard}${PRICE_TERMS.fromSuffix}`,
 	itemTrial: '有料は 7 日間無料',
-	itemCancel: 'いつでも解約',
+	itemCancel: CANCEL_TERMS.anytime,
 } as const;
 
 // LP CTA 直下の不安解消 3 バッジ (#1626 R22)
@@ -6273,10 +6278,14 @@ export const LP_INDEX_PHASEB_LABELS = {
 	k45: '設定の自由度',
 	k46: '活動の種類・ポイント配分・ごほうびは自由にカスタマイズ。お子さまに合わせて調整できます。',
 	k47: '料金プラン',
-	k48: '月 ¥500 から、家族全員が使える設計です。安心して始められる 4 つのお約束。',
-	k49: '<strong>基本無料</strong>',
+	// #1946 (Phase 3 D6): k48/k49/k51 (price 系) を terms.ts (PRICE_TERMS / FREE_TERMS) 参照に。
+	//   k48 '月 ¥500' = monthlyPrefix + standard
+	//   k49 '基本無料' = FREE_TERMS.base
+	//   k51 '月 ¥500（税込）〜' = monthlyPrefix + standard + taxNote + fromSuffix
+	k48: `${PRICE_TERMS.monthlyPrefix}${PRICE_TERMS.standard} から、家族全員が使える設計です。安心して始められる 4 つのお約束。`,
+	k49: `<strong>${FREE_TERMS.base}</strong>`,
 	k50: '・',
-	k51: '有料は<strong>月 ¥500（税込）〜</strong>',
+	k51: `有料は<strong>${PRICE_TERMS.monthlyPrefix}${PRICE_TERMS.standard}${PRICE_TERMS.taxNote}${PRICE_TERMS.fromSuffix}</strong>`,
 	k52: '・',
 	k53: '<strong>7 日間無料トライアル</strong>',
 	k54: '・',


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者・将来の保守担当）

**解決する課題**: LP_HERO_PRICE_BAND_LABELS / LP_INDEX_PHASEB_LABELS の price 系 atom（`基本無料` / `¥500` / `〜` / `（税込）` / `いつでも解約`）が文字列リテラルとして直書きされており、`terms.ts` (FREE_TERMS / PRICE_TERMS / CANCEL_TERMS) と二重管理になっていた。価格・プラン名・解約用語を変更する際に `terms.ts` を直すだけで全 LP 表示が同期するという 2 階層 SSOT (ADR-0045) の前提が `LP_HERO_PRICE_BAND_LABELS` / `LP_INDEX_PHASEB_LABELS` で破れていた。

**期待される効果**: ADR-0045 Phase 3 D6 として SSOT 2 階層化を完遂。今後の価格変更（例: `¥500` → `¥600`）/ 無料訴求変更（例: `基本無料` → `ずっと無料` 等）で本 namespace の string literal を grep する手間が消え、`terms.ts` 1 行修正で hero / [06] pricing-promise の LP 表示が一括追従する。

## 関連 Issue

closes #1946

<!-- 関連: ADR-0045 (terms.ts SSOT 2 階層化) / Phase 3 D6 / blocked_by #1916 #1917 (両 closed) / supersede #1903 (価格バンド並べ替えは shared-labels.js diff=0 の制約から本 PR scope 外、別 Issue で文言変更時に同時実施) -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | LP_HERO_PRICE_BAND_LABELS の itemFree / itemPriceValue / itemCancel を terms.ts (FREE_TERMS / PRICE_TERMS / CANCEL_TERMS) 参照に書換え | `git diff main -- src/lib/domain/labels.ts` で `LP_HERO_PRICE_BAND_LABELS` の 3 行が `FREE_TERMS.base` / `${PRICE_TERMS.standard}${PRICE_TERMS.fromSuffix}` / `CANCEL_TERMS.anytime` に置換されていること | PASS — diff hunk `@@ -4046,12 +4047,16 @@ export const LP_FOOTER_LABELS = {` で 3 atom 参照化を確認。itemPriceLabel ('月') / itemTrial ('有料は 7 日間無料') は `PRICE_TERMS.monthlyPrefix` ('月 ' 末尾空白あり) / `TRIAL_TERMS.duration` ('7日間' 空白なし) と char 不一致のため AC2 (diff=0) を優先しリテラル維持（コメントで明記） |
| AC1 (cont.) | LP_INDEX_PHASEB_LABELS k48/k49/k51 (price 系) を terms.ts (PRICE_TERMS / FREE_TERMS) 参照に書換え | `git diff main -- src/lib/domain/labels.ts` で `LP_INDEX_PHASEB_LABELS` の k48 / k49 / k51 が template literal で `PRICE_TERMS.monthlyPrefix` / `PRICE_TERMS.standard` / `PRICE_TERMS.taxNote` / `PRICE_TERMS.fromSuffix` / `FREE_TERMS.base` を参照していること | PASS — diff hunk `@@ -6273,10 +6278,14 @@ export const LP_INDEX_PHASEB_LABELS = {` で k48/k49/k51 が template literal 参照化済 |
| AC2 | 既存 shared-labels.js 出力差分ゼロ (template literal 解決後の文字列が変わらないこと) | `cp site/shared-labels.js /tmp/before.js && node scripts/generate-lp-labels.mjs && md5sum /tmp/before.js site/shared-labels.js` | PASS — md5 一致 `da2e6939e53383c7a12fff0e7417766c`（before / after 同値、`diff -u` の出力行数 = 0） |
| AC3 | visual diff で LP 見た目変更ゼロ | `md5sum site/index.html site/pricing.html` が main HEAD と完全一致（labels.ts 経由でのみ参照されるため HTML ファイル自体は変更なし）+ `node scripts/measure-lp-dimensions.mjs` PASS | PASS — site/*.html は本 PR で未変更（git diff `--stat` で `src/lib/domain/labels.ts` のみ）/ `[OK] all LP metrics within thresholds` を確認 |
| AC1 補足 | §4.1 4 条件充足 (#1985 / ADR-0003 §4) | (1) 機能仕様変化なし: shared-labels.js md5 一致 / (2) 設計書記述変更なし: docs/design/ 未変更 / (3) labels.ts SSOT に整合: terms.ts atom 参照に統一 / (4) routes/ UI 変更なし: src/routes/ 未変更 | PASS — 全 4 条件充足、`refactor:internal-no-doc-impact` ラベル付与で design-doc-check workflow exempt |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（実行時表示文字列が char-by-char 一致のため）。理論上は LP `site/index.html` の hero 価格バンド (`LP_HERO_PRICE_BAND_LABELS` 参照箇所) と [06] pricing-promise セクション (`LP_INDEX_PHASEB_LABELS.k47-k55` 参照箇所) が atom 経由で表示されるが、shared-labels.js md5 完全一致のため LP 描画結果は変化なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証。詳細: ローカル実行ログ
  - biome (1303 files): clean
  - svelte-check (4096 files): 0 errors / 13 warnings (本 PR 無関係の `(parent)/admin/activities/[id]/edit/+page.svelte` 既存 warning)
  - vitest (232 test files / 4420 tests): all PASS
  - hardcoded-strings: baseline 0 件維持
  - lp-dimensions: `[OK] all LP metrics within thresholds`
  - sync-lp-fallback: `✓ 全 site/*.html の fallback テキストは labels.ts と同期済み`
- [x] 追加・変更したテストの概要を以下に記載: **N/A** — 本 PR は terms.ts atom 参照化の純 refactor で、既存 4420 ユニットテスト（labels.ts の文字列値を直接 / 間接 assert するテスト群）が回帰検出装置として機能する。既存テスト全 PASS = 文字列値が変化していない証跡。
- [x] **新規 env / secret 追加時**（ADR-0006）: **N/A** — 該当なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: **N/A** — 該当なし
- [x] **Critical バグ修正の場合**（ADR-0002）: **N/A** — 本 PR は `priority:high` の refactor

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**:

本 PR は `src/lib/domain/labels.ts` の terms.ts 参照化のみで、UI 描画結果は **char-by-char 完全一致**を保証している（AC2 で md5 = `da2e6939e53383c7a12fff0e7417766c` 一致を機械検証済）。`site/index.html` / `site/pricing.html` ファイル自体は本 PR で未変更（diff `--stat` 上 `src/lib/domain/labels.ts` の 1 ファイルのみ、+15 / -6 行）。

「修正前 / 修正後」 4 スロット SS は描画結果が同一であるため意味のある差分を提示できず、実機撮影は省略。代わりに以下を本 PR の visual identity 保証エビデンスとして提示:

| エビデンス | 値 / コマンド | 判定 |
|---|---|---|
| shared-labels.js md5 (before) | `da2e6939e53383c7a12fff0e7417766c` | — |
| shared-labels.js md5 (after, generate-lp-labels.mjs 再生成後) | `da2e6939e53383c7a12fff0e7417766c` | **一致 (PASS)** |
| `diff -u` before / after shared-labels.js | 出力 0 行 | **一致 (PASS)** |
| `git diff --stat main` | `src/lib/domain/labels.ts | 21 +++++++++++++++++--` (1 file changed, 15 insertions(+), 6 deletions(-)) | **site/ 未変更 (PASS)** |
| `node scripts/measure-lp-dimensions.mjs` | `[OK] all LP metrics within thresholds` | **PASS** |

**インタラクティブ状態**: N/A — UI 状態に依存しない labels 階層の atom 参照化のみ。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — labels.ts は表示文字列 SSOT のまま、terms.ts は atom SSOT のまま、責務境界は不変。依存性逆転 — labels.ts → terms.ts の片方向 import を維持（`CANCEL_TERMS` を新規追加）。インターフェース分離 — 必要な atom (`FREE_TERMS.base` / `PRICE_TERMS.standard` / `PRICE_TERMS.fromSuffix` / `PRICE_TERMS.monthlyPrefix` / `PRICE_TERMS.taxNote` / `CANCEL_TERMS.anytime`) のみ参照。
- [x] **DRY**: 価格・プラン・解約用語を「labels.ts に直書き + terms.ts に atom」と二重保持していた状態を解消。同一概念の単一表現を実現。`grep "基本無料\|¥500" src/lib/domain/labels.ts` で残存する直書き 4 箇所 (LP_HERO_PRICE_BAND_LABELS の itemPriceLabel / itemTrial、LP_INDEX_PHASEB_LABELS の k51 一部「7 日間無料トライアル」、LP_PRICING_LABELS heroPriceBand 内 '7 日間無料体験') は、いずれも terms.ts atom と char 揺れがあり diff=0 制約のため atom 化未済。コメントで根拠明記、別 Issue (atom 表記統一後の再 refactor) で対応。
- [x] **YAGNI**: 新規抽象化なし、純粋に既存 atom (`CANCEL_TERMS` は既に terms.ts に存在) 参照に切り替えただけ。
- [x] **Security（OSS 公開前提）**: N/A — 文字列リテラル → atom 参照の置換のみ、入出力境界・認可境界に影響なし。
- [x] **アクセシビリティ**: N/A — 表示文字列 char-by-char 一致のため ARIA / keyboard / contrast に変化なし。
- [x] **パフォーマンス**: N/A — TypeScript template literal は build 時に折り畳まれ、bundle size / runtime cost に有意な差異なし（`shared-labels.js` md5 一致が証跡）。

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外（`src/lib/domain/labels.ts` は SSOT 1 ファイル、デモ版・本番アプリ・LP すべてが本 SSOT を参照する設計）
- [x] **labels SSOT** (ADR-0009 archive → ADR-0045): terms.ts (atom) → labels.ts (compound) 2 階層 SSOT に整合
- [x] **設計書同期** (ADR-0001): docs/design/ への追記は不要（§4.1 4 条件充足 → `refactor:internal-no-doc-impact` ラベル exempt、ADR-0003 §4 / #1985 / #1986）。理由は AC1 補足参照
- [x] **並行 PR overlap** (#1200): 本 PR 変更ファイル `src/lib/domain/labels.ts` を同時期に変更する open PR の有無を `gh pr list --search "labels.ts"` で確認。LP_HERO_PRICE_BAND_LABELS / LP_INDEX_PHASEB_LABELS k47-k51 を変更する他 PR なし

**LP / 販促文言変更時** (ADR-0013): **N/A** — 本 PR は terms.ts 参照化のみで、shared-labels.js md5 完全一致により LP 表示文字列はすべて維持。Committed/Aspirational 区分の変更は伴わない。

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A — 本 PR は文言変更なし、atom 参照化のみ | — | — |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:

1. **shared-labels.js diff = 0 の機械検証**: AC2 evidence の md5 (`da2e6939e53383c7a12fff0e7417766c`) を CI 側で再現確認していただけると安心。検証コマンド: `cp site/shared-labels.js /tmp/before.js && node scripts/generate-lp-labels.mjs && diff /tmp/before.js site/shared-labels.js` で 0 行であること。
2. **#1903 価格バンド並べ替えとの関係**: Issue #1946 の supersede 注記に「価格バンド並べ替えは本 PR で同時実施可」とあるが、文言変更（「月 ¥500〜」→「基本無料、必要なら ¥500〜」）は shared-labels.js diff > 0 を必然的に伴うため、本 refactor PR の AC2 (diff=0) と相反する。**#1903 は本 PR scope 外**として別 Issue で文言変更を進める方針を採用（PR 説明セクション内でも明記）。supersede 解消は #1903 closer 時に判断。
3. **`refactor:internal-no-doc-impact` ラベル付与の妥当性**: AC1 補足の §4.1 4 条件充足を確認のうえラベル付与済。逸脱検出時はラベル除去を要請可（design-doc-check が再走 fail → 設計書同期要求）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / sync-lp-fallback すべて PASS、詳細はテスト & 安全装置セクション参照）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし、`git diff --stat` で `src/lib/domain/labels.ts` の 1 ファイル +15 / -6 行のみ）
- [x] 全 AC が実装済み（AC1 / AC2 / AC3 / AC1 補足の §4.1 4 条件すべて充足）
- [x] UI 変更時: **N/A** — 本 PR は labels.ts atom 参照化のみで shared-labels.js md5 完全一致、UI 描画結果に変化なし（4 スロット SS はスキーンショット セクションの「該当なし（理由）」参照）
- [x] 認証画面変更時: **N/A** — 認証画面 (`/auth/login` / `/auth/signup` / 管理画面 / ops / プラン別 UI) の変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
