### PR TITLE
refactor: #1954 LP_VERSUS / LP_GROWTH_ROADMAP / LP_CORELOOP terms.ts 参照化 (Phase 3 D9)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4426,6 +4426,19 @@ export const ONBOARDING_LABELS = {
 // SSOT: site/index.html [02] セクション用ラベル
 // 親 P1 が「シール帳・ホワイトボードでも続けばよいのでは」と離脱する直前の優位訴求
 // ============================================================
+// #1954 (Phase 3 D9): terms.ts atom 参照化対象ゼロの恒久記録。
+//   本 namespace は「シール帳・ホワイトボード（紙）」と「がんばりクエスト（デジタル）」を
+//   並べる比較表のため、PLAN 名 (PLAN_TERMS / PLAN_FULL_TERMS) / 価格 (PRICE_TERMS) /
+//   トライアル期間 (TRIAL_TERMS) / 解約 (CANCEL_TERMS) / 無料訴求 (FREE_TERMS) /
+//   CTA 動詞句 (CTA_TERMS) のいずれの atom にも触れない構造で意図的に組まれている。
+//   訴求軸は「自動集計 / 年齢継続 / 卒業 / 端末非依存」の 4 観点であり、料金・期間・解約条件
+//   といった具体的な terms に依存しない普遍的な優位性を提示する設計。
+//   このため char-by-char 突合の結果、参照化対象は **0 件**。
+//   将来 PLAN 名・価格・期間表現等が現れた場合は terms.ts 経由で参照化すること（#1916 SSOT 階層）。
+//   検証: 本 namespace 範囲内に '無料' / 'スタンダード' / 'ファミリー' / '7日間' / '7 日間' /
+//         '¥500' / '¥780' / '¥0' / '無料プラン' / 'スタンダードプラン' / 'ファミリープラン' /
+//         'いつでも解約' / 'クレジットカード登録不要' / '基本無料' / 'まずは無料' /
+//         '無料で始める' / '無料体験' / '無料で試す' / '無料で試せます' リテラル 0 件。
 
 export const LP_VERSUS_LABELS = {
 	// #1844 (PO-N-2): タイトルの投げかけ撤去 + 4 行 Desc を「体言止め」へ完全統一
@@ -4468,6 +4481,18 @@ export const LP_VERSUS_LABELS = {
 // #1712 R5: 5 stage の H3 を「親主語ベネフィット」にリフレーム + 親視点 / 子供視点 1 行併記。
 //   開発者目線の「○○の特徴」型 → 保護者が観測できる行動変化（「○○が要らなくなる」「○○を聞かなくても」）
 //   へ書き換え、購入後の体験イメージを具体化する。
+// #1954 (Phase 3 D9): terms.ts atom 参照化スコープ。
+//   本 namespace は 5 ステージ（幼児 / 小学生 / 中学生 / 高校生 / 卒業）の長期成長物語を
+//   提示する設計。年齢区分文字列（'幼児' / '小学生' / '中学生' / '高校生'）は AGE_TIER_TERMS
+//   atom が terms.ts に未定義のため Phase 3 では参照化対象外（将来 atom 化時に再走査）。
+//   PLAN 名 / 価格 / 解約 / 無料訴求等は本セクションが「成長過程の語り」を主眼とするため
+//   原則登場せず、ctaBottomDesc 1 件のみが「無料体験」atom (CTA_TERMS.freeTrialNoun) と
+//   char-by-char 一致するため参照化する。
+//   トライアル期間表現 '7 日間' は半角スペース有り、TRIAL_TERMS.duration ('7日間' スペース無し)
+//   と char-by-char 一致しないため文字列差分ゼロ厳守原則により直書き継続（#2004 / #1950 と同方針）。
+//   検証: 本 namespace 範囲内に PLAN_TERMS / PLAN_FULL_TERMS / PRICE_TERMS / CANCEL_TERMS /
+//         FREE_TERMS / CTA_TERMS.freeTrialVerb / freeTrialDesc の atom と char-by-char 一致する
+//         直書きは ctaBottomDesc の '無料体験' (CTA_TERMS.freeTrialNoun) のみ。
 export const LP_GROWTH_ROADMAP_LABELS = {
 	sectionTitle: '3 歳から 18 歳まで、そして「卒業」へ',
 	sectionDesc:
@@ -4483,7 +4508,9 @@ export const LP_GROWTH_ROADMAP_LABELS = {
 	breadcrumbHome: 'ホーム',
 	breadcrumbCurrent: '成長ロードマップ',
 	ctaBottomTitle: '家族で全部使ってから、続けるか決める',
-	ctaBottomDesc: '7 日間の無料体験で、お子さまに合うかを家族でゆっくり試せます。',
+	// #1954 (Phase 3 D9): '無料体験' atom を CTA_TERMS.freeTrialNoun 参照化。
+	//   '7 日間' は半角スペース有りで TRIAL_TERMS.duration ('7日間') と一致しないため直書き継続。
+	ctaBottomDesc: `7 日間の${CTA_TERMS.freeTrialNoun}で、お子さまに合うかを家族でゆっくり試せます。`,
 	// #1793: 「親が観測できること」(計測・実験用語 / 監視連想で permission marketing 毀損) を
 	//   文脈別語彙に刷新。growth-roadmap 5 stages は親子の長期成長物語のため
 	//   「家族で実感できること」(家族主体・実感ベース) に統一する。
@@ -4547,6 +4574,18 @@ export const LP_GROWTH_ROADMAP_LABELS = {
 //   既存 keys は SSOT 整合のため一部空文字保持で再混入を CI 検出可能に。
 // #1788 (P-MAJ-3): 「プリセット活動で設定は 2 分」(parentPerspectiveDesc) と
 //   「プリセット活動がそのまま使える」(l1Step1Desc) を honest 表現へ刷新（候補から選ぶ運用を明示）。
+// #1954 (Phase 3 D9): terms.ts atom 参照化対象ゼロの恒久記録。
+//   本 namespace は「活動 → 習慣 → ごほうび」の 3 つの仕組み（コアループ）を説明する構造。
+//   訴求軸が「ループ全体の動詞句」（記録する / 続ける / 交換する / 計画する）にあり、
+//   PLAN 名 (PLAN_TERMS / PLAN_FULL_TERMS) / 価格 (PRICE_TERMS) / トライアル期間 (TRIAL_TERMS) /
+//   解約 (CANCEL_TERMS) / 無料訴求 (FREE_TERMS) / CTA 動詞句 (CTA_TERMS) のいずれの atom にも
+//   触れない構造で意図的に組まれている。料金や期間に依存しない普遍的な仕組み説明として設計。
+//   このため char-by-char 突合の結果、参照化対象は **0 件**。
+//   将来 PLAN 名・価格・期間表現等が現れた場合は terms.ts 経由で参照化すること（#1916 SSOT 階層）。
+//   検証: 本 namespace 範囲内に '無料' / 'スタンダード' / 'ファミリー' / '7日間' / '7 日間' /
+//         '¥500' / '¥780' / '¥0' / '無料プラン' / 'スタンダードプラン' / 'ファミリープラン' /
+//         'いつでも解約' / 'クレジットカード登録不要' / '基本無料' / 'まずは無料' /
+//         '無料で始める' / '無料体験' / '無料で試す' / '無料で試せます' リテラル 0 件。
 export const LP_CORELOOP_LABELS = {
 	sectionTitle: '3 つの仕組みで、毎日のがんばりが本物の報酬になる',
 	sectionDesc:


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（labels.ts のメンテナを行う Dev / 将来の LP 文言改訂作業者）

**解決する課題**: SSOT 2 階層化 (Phase 1 #1916) を LP の比較セクション / 成長ロードマップ / コアループ namespace へ波及させる Phase 3 D9。Issue 本文では「プラン名 / 価格 / 年齢区分 / coreloop 用語の terms.ts 参照化」が指示されたが、実装の char-by-char 突合の結果、対象 3 namespace のうち 2 件 (LP_VERSUS / LP_CORELOOP) で terms.ts atom と一致する直書き 0 件、1 件 (LP_GROWTH_ROADMAP) で 1 atom (`CTA_TERMS.freeTrialNoun`) のみ一致を確認。本 PR は (a) 1 件参照化 + (b) 2 件のゼロ件記録を rationale コメントとして labels.ts に恒久記録する。

**期待される効果**: 将来 LP の比較訴求 / 成長ロードマップ / コアループを改訂する Dev がコメントを読むだけで「PLAN 名・価格・期間表現・無料訴求・CTA 動詞句が現れた場合は terms.ts 経由で参照化する」というメンテナンス指針を即座に把握できる。誤って atom と一致する文字列を直書きで追加してしまうリグレッションを構造的に防ぐ。

## 関連 Issue

closes #1954

- blocked_by: #1916 (terms.ts 基盤) / #1917 (template literal parser)
- 兄弟 Issue: #2004 LP_LEGAL_SLA_LABELS Phase 4 E3（同じ「対象ゼロ記録」パターンの先例） / #2005 LP_LEGAL_DISCLAIMER_LABELS Phase 4 E5
- ADR-0013 (LP truth) / ADR-0045 (terms.ts SSOT 2 階層化原則) / ADR-0042 (LP CSS Spacing/Layout 3 層トークン)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/lib/domain/labels.ts の以下 namespace を terms.ts 参照に書換え (LP_VERSUS_LABELS / LP_GROWTH_ROADMAP_LABELS / LP_CORELOOP_LABELS) | char-by-char 突合の調査結果（atom 突合表は本 PR 本文「atom 突合表」を参照）+ namespace ヘッダコメント追記で恒久記録 + LP_GROWTH_ROADMAP_LABELS.ctaBottomDesc を CTA_TERMS.freeTrialNoun 参照化 | PASS — `grep -n "Phase 3 D9" src/lib/domain/labels.ts` で 4 件ヒット (3 namespace ヘッダ + 1 ctaBottomDesc コメント)。`grep -n "CTA_TERMS.freeTrialNoun" src/lib/domain/labels.ts` の LP_GROWTH_ROADMAP_LABELS 内 1 件追加確認 |
| AC2 | shared-labels.js 出力差分ゼロ | `node scripts/generate-lp-labels.mjs` 実行後 `git diff site/shared-labels.js` 出力ゼロ | PASS — `git diff site/shared-labels.js` 出力ゼロ。template literal で組み立てられる文字列値が直書き値と char-by-char 一致 (`'7 日間の無料体験で、お子さまに合うかを家族でゆっくり試せます。'`) |
| AC3 | visual diff で見た目変更ゼロ | site/index.html (versus / coreloop) / site/graduation.html (growth-roadmap CTA bottom) の data-lp-key fallback テキストと char-by-char 一致を維持 (visible 文字列変更なし) | PASS — site/graduation.html:192 `<p data-lp-key="growthRoadmap.ctaBottomDesc">7 日間の無料体験で、お子さまに合うかを家族でゆっくり試せます。</p>` と shared-labels.js:205 `"ctaBottomDesc": "7 日間の無料体験で、お子さまに合うかを家族でゆっくり試せます。"` が完全一致。LP_VERSUS / LP_CORELOOP は値変更ゼロ (コメントのみ追加) のため自動成立 |

### atom 突合表（AC1 エビデンス）

#### LP_VERSUS_LABELS (src/lib/domain/labels.ts:4430)

「シール帳・ホワイトボード（紙）」と「がんばりクエスト（デジタル）」を並べる比較表。訴求軸は「自動集計 / 年齢継続 / 卒業 / 端末非依存」の 4 観点であり、料金・期間・解約条件といった具体的な terms に依存しない普遍的な優位性を提示する設計。

- `PLAN_TERMS.free / standard / family` ("無料" / "スタンダード" / "ファミリー") — 出現なし
- `PLAN_FULL_TERMS.free / standard / family` ("無料プラン" / "スタンダードプラン" / "ファミリープラン") — 出現なし
- `PRICE_TERMS.*` (¥500 / ¥780 / ¥0 / 月 / 〜 / 税込) — 全 atom 出現なし
- `TRIAL_TERMS.duration` ("7日間") / `noCreditCard` / `noCreditCardShort` / `noCreditCardMid` — 出現なし
- `CANCEL_TERMS.anytime / anytimeOk` ("いつでも解約" / "いつでも解約 OK") — 出現なし
- `FREE_TERMS.base / start / tryFree` ("基本無料" / "まずは無料" / "無料で始める") — 出現なし
- `CTA_TERMS.freeTrialNoun / Verb / Desc` ("無料体験" / "無料で試す" / "無料で試せます") — 出現なし

**結論**: 参照化対象 **0 件**。

#### LP_GROWTH_ROADMAP_LABELS (src/lib/domain/labels.ts:4471)

5 ステージ（幼児 / 小学生 / 中学生 / 高校生 / 卒業）の長期成長物語を提示する設計。

- `PLAN_TERMS.*` / `PLAN_FULL_TERMS.*` / `PRICE_TERMS.*` / `CANCEL_TERMS.*` / `FREE_TERMS.*` — 出現なし
- 年齢区分文字列 ('幼児' / '小学生' / '中学生' / '高校生') — terms.ts に AGE_TIER_TERMS atom が未定義のため Phase 3 では参照化対象外（将来 atom 化時に再走査）
- `TRIAL_TERMS.duration` ("7日間") — `ctaBottomDesc` の '7 日間' は半角スペース有りで char-by-char 一致しない（文字列差分ゼロ厳守原則により直書き継続、#2004 / #1950 と同方針）
- `CTA_TERMS.freeTrialNoun` ("無料体験") — `ctaBottomDesc` の '無料体験' と char-by-char 完全一致 → **template literal 参照化** (#1954 唯一の値変更箇所)
- `CTA_TERMS.freeTrialVerb` ("無料で試す") / `freeTrialDesc` ("無料で試せます") — 出現なし

**結論**: 参照化対象 **1 件** (`ctaBottomDesc` の `${CTA_TERMS.freeTrialNoun}`)。

#### LP_CORELOOP_LABELS (src/lib/domain/labels.ts:4550)

「活動 → 習慣 → ごほうび」の 3 つの仕組み（コアループ）を説明する構造。訴求軸が「ループ全体の動詞句」（記録する / 続ける / 交換する / 計画する）にあり、料金や期間に依存しない普遍的な仕組み説明として設計。

- `PLAN_TERMS.*` / `PLAN_FULL_TERMS.*` / `PRICE_TERMS.*` / `TRIAL_TERMS.*` / `CANCEL_TERMS.*` / `FREE_TERMS.*` / `CTA_TERMS.*` — 全 atom 出現なし

**結論**: 参照化対象 **0 件**。

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- `src/lib/domain/labels.ts` の `LP_VERSUS_LABELS` / `LP_GROWTH_ROADMAP_LABELS` / `LP_CORELOOP_LABELS` namespace ヘッダコメント（合計 36 行追加）
- `LP_GROWTH_ROADMAP_LABELS.ctaBottomDesc` を template literal 化（`'無料体験'` → `${CTA_TERMS.freeTrialNoun}`）。最終文字列は char-by-char 一致を維持
- 表示テキストへの影響なし（`site/index.html` LP_VERSUS / LP_CORELOOP セクション、`site/graduation.html` ctaBottomDesc 表示変更ゼロ）
- 実行時の挙動変更ゼロ（template literal の最終解決値は直書きと完全一致）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
  - 注: pre-ready は worktree 環境で `origin/main` diff 取得失敗 + biome 0 file となる既存課題があるため、各 Step を個別実行で代替検証:
    - biome: `npx biome check --error-on-warnings src/lib/domain/labels.ts` PASS
    - svelte-check: 0 errors (13 warnings は既存、本 PR と無関係)
    - vitest: `npx vitest run tests/unit/domain/ tests/unit/lp/` 全 PASS (725 tests / 34 files)
    - LP SSOT: `node scripts/check-lp-ssot.mjs` PASS (LEGAL-SSOT 54 keys, 0 missing)
    - shared-labels.js diff: `git diff site/shared-labels.js` 出力ゼロ
- [x] 追加・変更したテストの概要: N/A（既存値の char-by-char 一致を維持する pure refactor のため、振る舞い変化なし → 既存 vitest 全件 PASS で担保）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は src/lib/domain/labels.ts の `*.ts` 1 ファイルのみの変更で、UI 関連ファイル（`*.svelte` / `*.svelte.ts` / `*.css` / `site/**`）の変更を一切含まない。

具体的には以下を全て満たす:
- `LP_GROWTH_ROADMAP_LABELS.ctaBottomDesc` の値は template literal `\`7 日間の${CTA_TERMS.freeTrialNoun}で、お子さまに合うかを家族でゆっくり試せます。\`` で組み立てられ、最終文字列 `'7 日間の無料体験で、お子さまに合うかを家族でゆっくり試せます。'` は変更前後で char-by-char 完全一致
- `LP_VERSUS_LABELS` / `LP_CORELOOP_LABELS` は値変更ゼロ（namespace ヘッダコメントのみ追加）
- `git diff site/shared-labels.js` 出力ゼロで CDN 配信値も完全一致
- `site/graduation.html` の `data-lp-key="growthRoadmap.ctaBottomDesc"` fallback テキストとも char-by-char 一致

このため `refactor:internal-no-doc-impact` ラベルでの screenshot 4 スロット exempt 対象（#1985 / ADR-0003 §4 改訂）。

**インタラクティブ状態**: N/A（UI 変更なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（terms.ts atom と labels.ts compound の責務分離を維持） / 依存性逆転（labels.ts が terms.ts を import する単方向依存） / インターフェース分離（namespace ごとに独立、相互参照なし）
- [x] **DRY**: `'無料体験'` リテラルを `CTA_TERMS.freeTrialNoun` 経由に統一。同 atom を参照する既存 namespace（ACTION_LABELS:521 `freeTrial: CTA_TERMS.freeTrialNoun`）と同方式。`grep "CTA_TERMS.freeTrialNoun" src/lib/domain/labels.ts` で 2 件参照に増加
- [x] **YAGNI**: 不要な抽象化なし。AGE_TIER_TERMS や SETUP_TERMS 等の新 atom 増設は本 PR scope 外として明示的に排除
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: N/A（template literal は build 時に解決、runtime オーバーヘッドなし）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — labels.ts は SSOT で本番 / デモ共用
- [x] LP ↔ アプリ双方向整合（ADR-0013） — shared-labels.js diff = 0 で LP 側 fallback と完全同期
- [x] 全年齢モード 5 種に横展開 — N/A（年齢モード非依存の LP セクションラベル）
- [x] ナビゲーション 3 種に反映 — N/A（ナビ非関連）
- [x] E2E / ユニットシード + チュートリアルを同期 — N/A（テストデータ非関連）
- [x] labels SSOT (ADR-0009 / ADR-0045 supersede) — terms.ts atom 経由の SSOT 階層を維持
- [x] 設計書同期 (ADR-0001) — 本 PR は労務的 refactor で設計書影響なし。`refactor:internal-no-doc-impact` ラベル exempt 対象 (#1985)
- [x] 並行 PR overlap 確認 (#1200) — Phase 3 D シリーズの兄弟 PR (#1946 / #1947 / #1953 等) と src/lib/domain/labels.ts を編集競合する可能性あり。本 PR は 4430 / 4471 / 4550 行付近のみ編集で他 PR の編集領域と非衝突
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A — 表示文言変更ゼロ（template literal で同一文字列を組み立てる pure refactor） | — | — |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- atom 突合表（AC1 エビデンス）の char-by-char 検証結果が妥当か（特に「'7 日間' は半角スペース有りで TRIAL_TERMS.duration ('7日間' スペース無し) と一致しない」判断）
- LP_VERSUS / LP_CORELOOP のゼロ件記録が、将来の LP 改訂時に有用な rationale として機能するか（先例: #2004 LP_LEGAL_SLA_LABELS、#2005 LP_LEGAL_DISCLAIMER_LABELS）
- `refactor:internal-no-doc-impact` ラベル exempt 対象としての適格性（src/lib/domain/labels.ts の compound 構造リファクタで、site/*.html visible テキスト変更ゼロ + shared-labels.js diff 0）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（worktree 環境の biome 0 file 課題のため個別 Step で代替検証、上記「テスト & 安全装置セルフチェック」参照）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [N/A] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — 本 PR は UI 変更ゼロ（labels.ts compound 構造 refactor のみ）
- [N/A] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — 認証画面非関連

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
