### PR TITLE
refactor: #1953 LP_CTA_TRUST_BADGES_LABELS の terms.ts 参照化 (Phase 3 D8)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -9,6 +9,7 @@
 // #1961 (Phase 7 H4): PRICE_TERMS を PREMIUM_MODAL_LABELS から参照
 // #1963 (Phase 7 H6): LICENSE_PAGE_LABELS で PRICE_TERMS を新規参照（plan / 期間 / 価格 atom 直書き撤廃）
 import {
+	CANCEL_TERMS,
 	CTA_TERMS,
 	FREE_TERMS,
 	PLAN_FULL_TERMS,
@@ -4056,10 +4057,12 @@ export const LP_HERO_PRICE_BAND_LABELS = {
 
 // LP CTA 直下の不安解消 3 バッジ (#1626 R22)
 // site/index.html / pricing.html / faq.html の CTA 直下に配置
+// #1953 (Phase 3 D8): noCreditCard を TRIAL_TERMS、cancelAnytime を CANCEL_TERMS から参照。
+//                     noAds は terms.ts atom 該当なしで据置き。char-by-char 一致を維持。
 export const LP_CTA_TRUST_BADGES_LABELS = {
-	noCreditCard: 'クレジットカード登録不要',
+	noCreditCard: `${TRIAL_TERMS.noCreditCard}`,
 	noAds: '広告なし',
-	cancelAnytime: 'いつでも解約 OK',
+	cancelAnytime: `${CANCEL_TERMS.anytimeOk}`,
 } as const;
 
 // LP Hero 仕様起点の数字バッジ (#1628 R24 / #1788 honest 刷新)
@@ -4068,6 +4071,9 @@ export const LP_CTA_TRUST_BADGES_LABELS = {
 //   （実態は「親がセットアップで選択する 300+ 候補プール」であり、訴求から「自動で揃う」誤認を排除）
 //   CI `measure-lp-dimensions.mjs` の正規表現 `<strong>(\d+)\+</strong>\s*プリセット活動` は
 //   「プリセット活動」リテラルが残っていれば検出されるため、honest 表現でも CI 裏取りは継続して機能する
+// #1953 (Phase 3 D8): atom 化対象ゼロ。年齢レンジ（3〜18 歳）/ プリセット数（300+）/ セットアップ時間（約 5 分）
+//   は本 LP 専用の仕様値であり terms.ts に対応 atom が存在しない（PLAN/PRICE/TRIAL/CANCEL/FREE/CTA いずれも該当なし）。
+//   将来 SETUP_TERMS / SPEC_TERMS 等を新設する判断は別 Issue で検討。
 export const LP_HERO_SPEC_BADGES_LABELS = {
 	ageRange: '3〜18 歳',
 	ageRangeSuffix: '対応',


### PR DESCRIPTION
## 顧客価値・目的

LP_CTA_TRUST_BADGES_LABELS の `noCreditCard` / `cancelAnytime` atom 直書き、および LP_HERO_SPEC_BADGES_LABELS の atom 化対象有無を、`src/lib/domain/terms.ts` (TRIAL_TERMS / CANCEL_TERMS) 参照化と注記で SSOT 2 階層化（ADR-0045）を 1 段階前進させる。Phase 3 D8（#1953）の責務として、Phase 3 D6（#1946 LP_HERO_PRICE_BAND_LABELS）/ Phase 3 D7（#1947 LP_PRICING_LABELS）と同じパターンを CTA Trust Badges + Hero Spec Badges に適用する。

**対象ユーザー**: 開発者（Dev / 設計書メンテナー）と LP 文言の整合性を担保する PO

**解決する課題**: 「クレジットカード登録不要」「いつでも解約 OK」の atom が複数 LP namespace（LP_CTA_TRUST_BADGES_LABELS / LP_HERO_PRICE_BAND_LABELS / LP_PRICING_LABELS / LP_COMMON_LABELS / TRIAL_LABELS 等）に重複ハードコードされており、文言の値変更時に LP / アプリ全箇所を grep する手間が残っていた構造的問題（ADR-0045 SSOT 2 階層化）を、本 Issue 範囲の `LP_CTA_TRUST_BADGES_LABELS` から段階解消する。LP_HERO_SPEC_BADGES_LABELS は atom 化対象ゼロを記録（#1950 LP_LEGAL_SLA_LABELS と同パターン）し、判断履歴を残す。

**期待される効果**:
- 「クレジットカード登録不要」「いつでも解約 OK」の値を terms.ts 1 行修正で `site/index.html` / `site/pricing.html` / `site/faq.html` の CTA 直下バッジ + アプリ本体に伝播
- LP 表示テキストは char-by-char 一致を維持（template literal 解決後文字列が同一）し、外部リスクゼロ
- shared-labels.js 出力差分ゼロにより本 PR は LP / アプリの描画 0 変化（`refactor:internal-no-doc-impact` 適格）

## 関連 Issue

closes #1953

related:
- #1916 (terms.ts SSOT 2 階層化基盤)
- #1917 (template literal parser)
- #1946 / #1947 (Phase 3 D6 / D7、同パターン直前 PR)
- #1948 / #1949 / #1950 / #1951 / #1952 (Phase 4 E1-E5、同パターン)
- #1985 (refactor:internal-no-doc-impact ラベル運用)

**スコープ衝突に関する重要な注記**:
Issue #1953 の AC1 には「LP_HERO_LABELS (line 4034 周辺、heroSubtextSuffix / heroPriceBand / heroLeadHighlight / planFreePriceSub 等)」が記載されているが、調査の結果、これらは `LP_HERO_LABELS` という独立 namespace ではなく **`LP_PRICING_LABELS` 内の hero 系 key**（site/pricing.html 専用）であり、**Issue #1947 (Phase 3 D7) が既にこれらの atom 化を完遂済**（worktree `agent-ac3e9129326d54078`、commit `a7ea1a53`）。本 PR で同範囲を二重に修正すると #1947 と完全衝突するため、**LP_PRICING_LABELS の hero 系は本 PR から除外**し、本 PR は LP_CTA_TRUST_BADGES_LABELS / LP_HERO_SPEC_BADGES_LABELS に scope を絞る。Issue #1953 の AC1 該当範囲は #1947 のマージで実質充足される。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | LP_HERO_SPEC_BADGES_LABELS (line 4071+): ageRange / presetCount / setupTime の terms.ts 参照化判定 | `grep -n 'LP_HERO_SPEC_BADGES_LABELS' src/lib/domain/labels.ts` | PASS — terms.ts atom 該当ゼロを記録（PLAN/PRICE/TRIAL/CANCEL/FREE/CTA いずれも該当なし。年齢レンジ「3〜18 歳」/プリセット数「300+」/セットアップ時間「約 5 分」は LP 専用仕様値）。労務として #1950 (LP_LEGAL_SLA_LABELS) と同様、コメント注記のみで scope 判定済 |
| AC1 | LP_CTA_TRUST_BADGES_LABELS (line 4059): noCreditCard → TRIAL_TERMS.noCreditCard, cancelAnytime → CANCEL_TERMS.anytimeOk | `grep -n 'LP_CTA_TRUST_BADGES_LABELS' -A 5 src/lib/domain/labels.ts` | PASS — line 4061-4067 で `noCreditCard: \`${TRIAL_TERMS.noCreditCard}\`` / `cancelAnytime: \`${CANCEL_TERMS.anytimeOk}\`` に置換済。noAds は terms.ts atom 該当なしで据置き |
| AC1 | LP_HERO_LABELS (LP_PRICING_LABELS hero 系) の terms.ts 参照化 | scope 衝突回避のため #1947 (Phase 3 D7) で対応 | DELEGATED — Issue #1947 が既に同範囲を atom 化済（worktree `agent-ac3e9129326d54078` / commit `a7ea1a53`）。本 PR では二重修正を避けるため除外（「関連 Issue」セクション参照） |
| AC2 | shared-labels.js 出力差分ゼロ | `node scripts/generate-lp-labels.mjs && diff tmp/shared-labels.baseline.js site/shared-labels.js` | PASS — DIFF=ZERO（`tmp/shared-labels.baseline.js` は origin/main 状態で生成、本 PR 適用後と完全一致） |
| AC3 | visual diff で hero / CTA 周辺見た目変更ゼロ | shared-labels.js diff = 0 + site/index.html / site/pricing.html / site/faq.html 未変更（`git diff site/` = empty） | PASS — `data-lp-key` 経由で配信される LP テキストは shared-labels.js 1 経路のみで、その出力 char-by-char 一致を機械検証済 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`src/lib/domain/labels.ts` の LP_CTA_TRUST_BADGES_LABELS / LP_HERO_SPEC_BADGES_LABELS の atom 参照化）
- [ ] インフラ (`infra/`)
- [x] LP サイト (`site/shared-labels.js` 自動生成のみ、出力差分ゼロ)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 描画変化なし（#1744 ルールに準拠）。LP `site/index.html` / `site/pricing.html` / `site/faq.html` の CTA 直下 trust-badges / hero spec-badges 表示テキストは shared-labels.js 出力 char-by-char 一致のため visual diff ゼロ。

## 「描画変化なし」根拠（#1744）

- [x] **ラベル文字列**: 旧と新で完全一致（`shared-labels.js` 全体 diff 0 行で機械検証済、`tmp/shared-labels.baseline.js` 比較）
- [x] **HTML 構造**: `site/index.html` / `site/pricing.html` / `site/faq.html` 自体は本 PR で変更なし（`git diff site/index.html site/pricing.html site/faq.html` = empty）
- [x] **CSS class 名**: 変更なし（labels.ts のみ touched、CSS / svelte は無関係）
- [x] **改行位置 / アイコン / 句読点**: 変わっていない（template literal 解決後文字列が atom 直書きと同一）
- [x] **不可視属性 (`aria-*` / `data-*`)**: 追加・変更なし

**機械検証エビデンス**:
```bash
# Step 1: regenerate
node scripts/generate-lp-labels.mjs
# Step 2: diff vs baseline (origin/main 時点で生成した tmp/shared-labels.baseline.js との比較)
diff tmp/shared-labels.baseline.js site/shared-labels.js
# → 0 行
```

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（CI 上で自動実行、本ローカルでは個別 step を実行済）
  - biome `--error-on-warnings` PASS（`npx biome check --error-on-warnings src/lib/domain/labels.ts`）
  - svelte-check 0 ERRORS（4096 ファイル / 13 WARNINGS は既存の admin/activities/[id]/edit/+page.svelte のみで本 PR 影響なし）
  - vitest 全テスト PASS（4420/4420、`npx vitest run`）
  - `node --test scripts/__tests__/generate-lp-labels.test.mjs` 19/19 PASS（template literal parser）
  - `npm run lint:parallel` 全 OK（forbidden-terms / generate-lp-labels --check / lp-plan-sync / ssot-parallel-impl / lp-innerhtml-tags / lp-removal-residue）
- [x] 追加・変更したテストの概要を以下に記載: 既存 `scripts/__tests__/generate-lp-labels.test.mjs` 全 19 PASS（template literal 解決機構を再利用するため新規テスト不要、参照テストが網羅）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor のみ、描画変化なし、根拠は上記「描画変化なし」根拠セクション）**

LP_CTA_TRUST_BADGES_LABELS の atom 直書きを terms.ts 参照に置換しただけで、`shared-labels.js` 全体 diff = 0 行を機械検証済（AC2 行参照）。site/index.html / site/pricing.html / site/faq.html の DOM / CSS / 表示テキスト（CTA 直下 3 バッジ、hero spec 数値）は完全に同一で、4 スロット SS は本質的に取得意義がない（取得しても before/after 全 px 一致する画像になる）。本 PR は `refactor:internal-no-doc-impact` ラベル運用 (#1985) の対象。

LP_HERO_SPEC_BADGES_LABELS は文字列改変ゼロ（コメント注記追加のみ）でビジュアル影響なし。

**インタラクティブ状態**: N/A — 静的テキスト atom 参照化のみ。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: atom (terms.ts) と compound (labels.ts) の責務分離が前進（ADR-0045 整合）。LP_CTA_TRUST_BADGES_LABELS 自身の責任は変わらず compound のまま、atom 値の SSOT が明示的に terms.ts 1 箇所に集約された
- [x] **DRY**: 「クレジットカード登録不要」「いつでも解約 OK」の atom 直書きを 2 件削減し、terms.ts 1 箇所に集約（TRIAL_TERMS.noCreditCard / CANCEL_TERMS.anytimeOk）
- [x] **YAGNI**: 抽象レイヤーは追加していない（既存の generate-lp-labels.mjs template literal parser をそのまま使用、新規機構なし）。LP_HERO_SPEC_BADGES_LABELS は atom 化を強制せず「対象なし」を注記する判断（#1950 と同パターン、過剰抽象化を回避）
- [x] **Security（OSS 公開前提）**: char-by-char 一致を機械検証済（shared-labels.js diff = 0）。秘密情報露出なし
- [x] **アクセシビリティ**: 描画変化ゼロのため非影響
- [x] **パフォーマンス**: バンドルサイズ非影響（labels.ts 自体の bytes 変化はわずか、generate-lp-labels.mjs 実行時間も差分なし）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期（`LP_CTA_TRUST_BADGES_LABELS` は LP `site/*.html` のみで参照、アプリ本体側に同名定数の参照箇所なし）
- [x] LP ↔ アプリ双方向整合（shared-labels.js 出力 diff = 0 で担保）
- [x] 全年齢モード 5 種が同じ実装を参照（LP_CTA_TRUST_BADGES_LABELS / LP_HERO_SPEC_BADGES_LABELS は年齢モード非依存、N/A）
- [x] ナビゲーション 3 種が同じ SSOT を参照（本 Issue は LP CTA 系 / hero 仕様バッジ、ナビ非影響）
- [x] E2E / ユニットシード + チュートリアルを同期（generate-lp-labels test 全 19 PASS / vitest 4420 PASS）
- [x] labels SSOT (ADR-0045 / 旧 ADR-0009): atom (terms.ts) → compound (labels.ts) → 配信 (shared-labels.js) の階層化を本 PR でさらに前進
- [x] 設計書同期 (ADR-0001): 本 PR は内部 refactor で表示文字列・構造変化ゼロのため `refactor:internal-no-doc-impact` ラベル運用 (#1985) を適用、設計書同期免除
- [x] 並行 PR overlap 確認 (#1200): **#1947 (Phase 3 D7) と LP_PRICING_LABELS の hero 系で重複検出 → 本 PR から除外**して衝突回避済（「関連 Issue」セクション + AC1 DELEGATED 行参照）。Phase 4 E1-E5（#1948-#1952）/ Phase 7 H1-H6（#1958-#1963）は別 namespace で scope 完全独立

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A — 文言変更ゼロ（atom 参照化のみ、shared-labels.js diff = 0） | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（内部 refactor のみ、shared-labels.js 出力 char-by-char 一致を機械検証済）

**レビュー依頼事項・QA**:
- LP CTA 直下 3 バッジ（site/index.html / site/pricing.html / site/faq.html）の表示テキスト char-by-char 一致を `shared-labels.js` diff = 0 で確認済
- atom 化スコープが `LP_CTA_TRUST_BADGES_LABELS` の 2 件（noCreditCard / cancelAnytime）に厳密に限定されていることを確認
- LP_HERO_SPEC_BADGES_LABELS は atom 化対象ゼロをコメント注記で記録（#1950 LP_LEGAL_SLA_LABELS と同パターン、判断履歴の永続化）
- **#1947 との scope 衝突回避**: Issue 本文記載の「LP_HERO_LABELS hero 系」は #1947 が同範囲を atom 化中。本 PR では除外し、Issue #1953 の AC1 は #1947 マージで実質充足される旨を「関連 Issue」セクションで明記済

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（biome / svelte-check / vitest / generate-lp-labels test / lint:parallel 個別実行済、すべて PASS）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし、変更は labels.ts 内の 8 行 insert + 2 行 modify のみ、import 1 行追加）
- [x] 全 AC が実装済み（AC1 行 1: LP_HERO_SPEC_BADGES_LABELS atom 対象ゼロ記録 / AC1 行 2: LP_CTA_TRUST_BADGES_LABELS atom 化 / AC1 行 3: #1947 で deferred / AC2 / AC3 すべてエビデンス付き PASS）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（描画変化ゼロ、shared-labels.js diff = 0 機械検証で代替）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面非影響）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
