### PR TITLE
refactor: #1957 LP_NAV / LP_COMMON / LP_FLOATING_CTA terms.ts 参照化 + LP_COMMON 価格 atom 削除 (Phase 3 D12)

### DIFF
--- a/site/shared-labels.js
+++ b/site/shared-labels.js
@@ -150,9 +150,6 @@
 			"trialPeriodLabel": "7 日間無料トライアル",
 			"trialPeriodShort": "7 日間無料",
 			"trialPeriodFull": "7 日間の無料トライアル",
-			"priceStandardMonthly": "月 ¥500",
-			"priceFamilyMonthly": "月 ¥780",
-			"priceMinFrom": "月 ¥500〜",
 			"noCreditCardNote": "クレジットカード登録不要",
 			"cancelAnytime": "いつでも解約 OK",
 			"bulletPoint": "・"

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4012,6 +4012,9 @@ export const DEMO_CHILD_ACHIEVEMENTS_LABELS = {
 // SSOT: site/*.html の <header> / <footer> 共通部分
 // ============================================================
 
+// #1957 (Phase 3 D12): signup を FREE_TERMS.tryFree atom 参照化。
+//                     他 key (hamburgerAriaLabel / logoAlt / home / marketplace / pricing / faq /
+//                     selfhost / login / features) は LP ナビ専用文言で terms.ts atom 該当なし。
 export const LP_NAV_LABELS = {
 	hamburgerAriaLabel: 'メニュー',
 	logoAlt: 'がんばりクエスト',
@@ -4020,11 +4023,15 @@ export const LP_NAV_LABELS = {
 	pricing: '料金プラン',
 	faq: 'よくあるご質問',
 	selfhost: '仕組みを公開（開発者向け）',
-	signup: '無料で始める',
+	signup: `${FREE_TERMS.tryFree}`,
 	login: 'ログイン',
 	features: 'できること',
 } as const;
 
+// #1957 (Phase 3 D12): atom 化対象ゼロをコメント注記で記録。
+//                     LP_FOOTER_LABELS はブランド名 / リンクラベル / コピーライト等
+//                     LP フッター専用文言で構成され、PLAN/PRICE/TRIAL/CANCEL/FREE/CTA いずれの
+//                     terms.ts atom にも該当しない。
 export const LP_FOOTER_LABELS = {
 	brandName: 'がんばりクエスト',
 	brandTagline: 'お子さまの「がんばり」を冒険に変える家庭向けWebアプリ',
@@ -4087,12 +4094,26 @@ export const LP_HERO_SPEC_BADGES_LABELS = {
 	setupSuffix: 'で初期設定',
 } as const;
 
-// LP CTA / 価格 / 期間表記 SSOT (#1616 R12)
+// LP CTA / 期間表記 SSOT (#1616 R12)
 // PM 優先 J 節裁定 2: 「無料で始める」（漢字統一）
 // site/ 配下では本定数を data-lp-key で参照し、表記揺れを排除する
+//
+// #1957 (Phase 3 D12): LP_COMMON_LABELS を縮小 + terms.ts 参照化。
+//   - 価格 atom (priceStandardMonthly / priceFamilyMonthly / priceMinFrom) を削除。
+//     これらは PRICE_TERMS atom (¥500 / ¥780) と「月 」prefix の連結で表現可能だが、
+//     site/*.html 内の data-lp-key=common.priceStandardMonthly 等の参照箇所はゼロであり、
+//     LP_HERO_PRICE_BAND_LABELS / LP_PRICING_LABELS 等の他 namespace が独自に terms.ts atom を
+//     直接参照しているため重複定義となっていた。本 PR で dead code として撤去し、
+//     価格 atom の SSOT を terms.ts (PRICE_TERMS) のみに統一する。
+//   - ctaSignup / noCreditCardNote / cancelAnytime を terms.ts atom 参照化。
+//   - trialPeriodLabel / trialPeriodShort / trialPeriodFull は TRIAL_TERMS.duration ('7日間'
+//     空白なし) と LP の表記 ('7 日間無料' 空白あり) で揺れがあるため、文字列差分ゼロ維持を
+//     優先しリテラル維持 (atom 化は別 Issue で表記統一後に再検討)。
+//   - bulletPoint / contactEmail / contactHint / ctaDemo / ctaPricing / ctaContact /
+//     ctaPricingDetail は LP 連結フレーズ / 連絡先で terms.ts atom 該当なし。
 export const LP_COMMON_LABELS = {
 	// CTA 動詞（site/ 全ページで本値に統一）
-	ctaSignup: '無料で始める',
+	ctaSignup: `${FREE_TERMS.tryFree}`,
 	ctaDemo: 'デモを見る',
 	ctaPricing: '料金プラン',
 	ctaContact: 'お問い合わせ',
@@ -4103,14 +4124,10 @@ export const LP_COMMON_LABELS = {
 	trialPeriodLabel: '7 日間無料トライアル',
 	trialPeriodShort: '7 日間無料',
 	trialPeriodFull: '7 日間の無料トライアル',
-	// 価格表記
-	priceStandardMonthly: '月 ¥500',
-	priceFamilyMonthly: '月 ¥780',
-	priceMinFrom: '月 ¥500〜',
 	// クレカ不要訴求
-	noCreditCardNote: 'クレジットカード登録不要',
+	noCreditCardNote: `${TRIAL_TERMS.noCreditCard}`,
 	// 解約訴求
-	cancelAnytime: 'いつでも解約 OK',
+	cancelAnytime: `${CANCEL_TERMS.anytimeOk}`,
 	bulletPoint: '・',
 } as const;
 
@@ -5419,6 +5436,10 @@ export const PUSH_NOTIFICATION_LABELS = {
 // LP Pages added dynamically
 // ============================================================
 
+// #1957 (Phase 3 D12): LP_LICENSEKEY_LABELS atom 化対象は text125 ('無料で始める') のみ。
+//                     既に `${FREE_TERMS.tryFree}` 参照済 (#1916/#1917 系)。他 text* は
+//                     ライセンスキー仕様 / FAQ / お問い合わせ連絡用文言で terms.ts atom 該当なし。
+//                     PLAN/PRICE/TRIAL/CANCEL/CTA いずれの atom にも合致するリテラルを含まない。
 export const LP_LICENSEKEY_LABELS = {
 	text1: 'ライセンスキーの使い方 - がんばりクエスト ヘルプ',
 	text2: 'ライセンスキーの使い方',
@@ -5634,6 +5655,10 @@ export const LP_FAQ_LABELS = {
 		'a href="mailto:ganbari.quest.support@gmail.com?subject=FAQページからのお問い合わせ" data-contact-context="FAQ bottom"',
 } as const;
 
+// #1957 (Phase 3 D12): LP_SELFHOST_LABELS は atom 化対象ゼロ。
+//                     セルフホスト版仕様 / Docker / 動作要件 / OSS コントリビュート関連の専用文言で
+//                     terms.ts atom (PLAN/PRICE/TRIAL/CANCEL/FREE/CTA) いずれにも該当しない。
+//                     text54 ('SaaS版を無料ではじめる') の「無料」も部分一致のため atom 化不可。
 export const LP_SELFHOST_LABELS = {
 	text1: 'セルフホスト版ガイド - がんばりクエスト',
 	text2: '&#x1F4E6; セルフホスト版ガイド',
@@ -5715,15 +5740,21 @@ export const LP_SELFHOST_LABELS = {
 // Anti-engagement (ADR-0012): 文言は「煽る」表現を避け、状況提示型 / 共感型 / 軽い再訴求 にとどめる。
 // 「今すぐ始める」「あと X 人」「タイムセール」などの urgency 演出は使わない。
 
+// #1957 (Phase 3 D12): heroButton / bottomButton を FREE_TERMS.tryFree atom 参照化。
+//                     midButton ('デモを見る') / heroText / midText / bottomText / *Href / aria* は
+//                     terms.ts atom と表記が異なる連結フレーズや URL/連絡用 aria 文のため atom 化対象外。
+//                     - heroText の「7 日間無料」「クレジットカード不要」(短縮形) は TRIAL_TERMS atom と表記揺れあり
+//                     - bottomText / ariaLabelHero の「7 日間無料」も同様
+//                     文字列差分ゼロ維持を優先しリテラル維持。
 export const LP_FLOATING_CTA_LABELS = {
 	// 各 phase の補強コピー（HTML 可、<small> + <strong> のみ想定）
 	heroText: '全機能を家族で試せる（7 日間無料）<small>クレジットカード不要</small>',
 	midText: 'コアループは 1 分で体験できます<small>サインアップ前に動きを確認</small>',
 	bottomText: 'ここまで読まれた方へ<small>7 日間無料・クレジットカード不要</small>',
 	// 各 phase の CTA ボタン文言（既存 ctaVariants 3 種の範囲内）
-	heroButton: '無料で始める',
+	heroButton: `${FREE_TERMS.tryFree}`,
 	midButton: 'デモを見る',
-	bottomButton: '無料で始める',
+	bottomButton: `${FREE_TERMS.tryFree}`,
 	// 各 phase の CTA href
 	heroHref: 'https://ganbari-quest.com/auth/signup',
 	midHref: 'https://ganbari-quest.com/demo',


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者・運営（システム全体）

**解決する課題**: LP_COMMON_LABELS に価格 atom (priceStandardMonthly / priceFamilyMonthly / priceMinFrom) が直書き重複しており、PRICE_TERMS atom (terms.ts) と二重定義になっていた。site/*.html 内の data-lp-key 経由でも参照されておらず実質 dead code。また LP_NAV_LABELS / LP_FLOATING_CTA_LABELS / LP_COMMON_LABELS 残部に「無料で始める」「クレジットカード登録不要」「いつでも解約 OK」等の atom リテラルが直書きされ、SSOT 2 階層化 (ADR-0045) の構造的負債が残っていた。

**期待される効果**: 価格 atom の SSOT を terms.ts (PRICE_TERMS) のみに統一し dead code を撤去。CTA 動詞 / トライアル訴求 / 解約訴求の atom 参照化により、用語変更時の修正箇所が terms.ts 1 行に集約される。LP の見た目・shared-labels.js 残部は char-by-char 一致（DIFF=ZERO）のため、ユーザー体験への影響なし。

## 関連 Issue

closes #1957

関連 ADR: ADR-0045 (terms.ts SSOT 2 階層化原則) / ADR-0009 (labels SSOT) / ADR-0013 (LP truth)
先行 PR: #2010 (D8) / #2009 (D10) / #2008 (D9) / #2007 (D6) / #2006 (D7) / #2005 (E5) / #2004 (E3) / #2003 (E1) / #2002 (E2) / #2001 (E4)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/lib/domain/labels.ts の LP_LICENSEKEY_LABELS / LP_SELFHOST_LABELS / LP_FLOATING_CTA_LABELS / LP_NAV_LABELS / LP_FOOTER_LABELS を terms.ts 参照に書換え | `grep -nE "FREE_TERMS\\.tryFree" src/lib/domain/labels.ts` で LP_NAV_LABELS.signup / LP_COMMON_LABELS.ctaSignup / LP_FLOATING_CTA_LABELS.heroButton / bottomButton 計 5 箇所が atom 参照化されていることを確認 | PASS — LP_NAV_LABELS.signup / LP_FLOATING_CTA_LABELS.heroButton / bottomButton / LP_COMMON_LABELS.ctaSignup / noCreditCardNote / cancelAnytime が `${FREE_TERMS.tryFree}` / `${TRIAL_TERMS.noCreditCard}` / `${CANCEL_TERMS.anytimeOk}` へ移行。LP_FOOTER_LABELS / LP_LICENSEKEY_LABELS / LP_SELFHOST_LABELS は atom 化対象ゼロをコメント注記で記録 (#1953 LP_HERO_SPEC_BADGES_LABELS / #1950 LP_LEGAL_SLA_LABELS と同パターン) |
| AC2 | LP_COMMON_LABELS を縮小、価格 atom (priceStandardMonthly / priceFamilyMonthly / priceMinFrom) は **削除** (terms.ts へ移管)、LP 連結フレーズ (bulletPoint 等) のみ残す | `grep -c "priceStandardMonthly\\|priceFamilyMonthly\\|priceMinFrom" src/lib/domain/labels.ts` (期待 0) + 削除 key の参照箇所が site/*.html / *.svelte / *.ts に存在しないことを確認 | PASS — 3 key を削除。`grep -rn "priceStandardMonthly\|priceFamilyMonthly\|priceMinFrom"` で labels.ts と (削除前) shared-labels.js のみが該当し外部参照ゼロを確認済（dead code）。bulletPoint / contactEmail / contactHint / ctaDemo / ctaPricing / ctaContact / ctaPricingDetail / trialPeriodLabel / trialPeriodShort / trialPeriodFull は据置き |
| AC3 | shared-labels.js 出力差分ゼロ（残った key の char-by-char 一致 + 意図的削除 3 行を除く） | `node scripts/generate-lp-labels.mjs --check` (再生成済 OK) + `diff /tmp/shared-labels-baseline.js site/shared-labels.js` で削除 3 行のみが diff として出ること | PASS — `✓ site/shared-labels.js は最新です`。diff 出力は `priceStandardMonthly / priceFamilyMonthly / priceMinFrom` の削除 3 行のみで、残った common.* / nav.* / footer.* / floatingCta.* / licenseKey.* / selfhost.* の値はすべて完全一致 |
| AC4 | visual diff で全 LP ページ見た目変更ゼロ | shared-labels.js 出力差分が「site/*.html から data-lp-key 経由で参照されていない 3 key (priceStandardMonthly / priceFamilyMonthly / priceMinFrom) の削除のみ」であることを `grep -rn "common\\.priceStandardMonthly\\|common\\.priceFamilyMonthly\\|common\\.priceMinFrom" site/` で確認（期待 0） | PASS — site/*.html 内に削除 3 key の data-lp-key 参照ゼロを機械検証。HTML レンダリング結果は変化しないため LP ページ見た目変更ゼロ |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [x] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
LP labels.ts SSOT のみ。実画面表示への影響ゼロ（shared-labels.js 残部 char-by-char 一致 + 削除 3 key は site/*.html 内の data-lp-key 参照ゼロの dead code）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome (`npx biome check src/`) / svelte-check (0 errors) / vitest (4429 tests passed) / lp-dimensions (`SKIP_SCREENSHOT_EXISTENCE_CHECK=1` で all within thresholds) / generate-lp-labels.mjs --check (最新) / check-ssot-parallel-impl.mjs (24 namespace 整合) / check-lp-inline-style.mjs (all within baseline) を個別実行で全 PASS 確認済。pre-ready は内部 refactor exempt label でスキップされる check も含むため個別実行で代替
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）: N/A — 内部 refactor (atom 参照化 + dead code 撤去) であり挙動変更なし。既存 4429 unit tests + generate-lp-labels.test.ts (7 tests) で template literal parser の正しさを担保
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret の追加なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — DynamoDB 影響なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — refactor

## スクリーンショット / ビジュアルデモ

**LP `site/index.html` を `--server-mode lp` (port 5280) で撮影 — 4 SS スロット添付（visual diff ゼロ確定、md5 hash 一致）**:

| | モバイル (375px) | デスクトップ (1440px) |
|---|---|---|
| **修正前 (origin/main)** | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2011/before-mobile.png) | ![before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2011/before-desktop.png) |
| **修正後 (HEAD)** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2011/after-mobile.png) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2011/after-desktop.png) |

**md5 hash 一致** (visual diff ゼロの決定的証跡):
- Desktop: before-desktop.png == after-desktop.png (md5: `3101dc68e361a6c5cd8e7ff6ae512236`)
- Mobile: before-mobile.png == after-mobile.png (md5: `962c6b5a801700c2d5e5e31c0de2a1e6`)

**撮影手順** (修正前 / 修正後それぞれ実行):
1. 修正前: `git checkout origin/main -- site/shared-labels.js src/lib/domain/labels.ts` → `MSYS_NO_PATHCONV=1 node scripts/capture.mjs --pr 2011 --server-mode lp --url /index.html --presets mobile,desktop`
2. 復元: `git checkout HEAD -- site/shared-labels.js src/lib/domain/labels.ts`
3. 修正後: 上記 capture.mjs を再実行

**visual diff ゼロ想定の根拠**:
- shared-labels.js diff = 削除 3 行のみ (`priceStandardMonthly` / `priceFamilyMonthly` / `priceMinFrom`)
- 削除 3 key は site/*.html の `data-lp-key` 経由で参照ゼロ (AC4 機械検証済) → HTML レンダリング結果に変化なし
- LP_NAV_LABELS.signup / LP_FLOATING_CTA_LABELS.heroButton / bottomButton / LP_COMMON_LABELS.ctaSignup / noCreditCardNote / cancelAnytime の atom 参照化は char-by-char 一致（resolve 後文字列が完全一致）

**インタラクティブ状態**: N/A — 上記 md5 一致により表示変更ゼロ確定

**DOM HTML スナップショット** (#1747 AC4 / #1766):
- [before-mobile.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2011/before-mobile.dom.html) / [before-desktop.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2011/before-desktop.dom.html)
- [after-mobile.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2011/after-mobile.dom.html) / [after-desktop.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2011/after-desktop.dom.html)


## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 (atom: terms.ts / compound: labels.ts) — ADR-0045 が定める 2 階層責務分離を 1 段階前進
- [x] **DRY**: priceStandardMonthly / priceFamilyMonthly / priceMinFrom の 3 key は PRICE_TERMS と LP_HERO_PRICE_BAND_LABELS / LP_PRICING_LABELS の atom 参照と二重定義になっていた。`grep -rn` で外部参照ゼロを確認のうえ削除
- [x] **YAGNI**: dead code (使われていない 3 key) を撤去。新規抽象化なし
- [x] **Security（OSS 公開前提）**: N/A — labels の atom 参照化のみで秘密情報なし
- [x] **アクセシビリティ**: N/A — テキスト変更ゼロ (char-by-char 一致)
- [x] **パフォーマンス**: N/A — bundle size に影響なし（atom 参照は string concatenation で resolve、generate 時に string literal に展開）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — N/A (LP labels のみ変更、デモ画面影響なし)
- [x] LP ↔ アプリ双方向整合（ADR-0013）— shared-labels.js 残部 char-by-char 一致 + 削除 3 key は site/ 内 data-lp-key 参照ゼロのため整合維持
- [x] 全年齢モード 5 種に横展開 — N/A (年齢モード非依存)
- [x] ナビゲーション 3 種に反映 — N/A (本 PR は LP_NAV_LABELS の signup atom 化のみ、表示文字列は完全一致)
- [x] E2E / ユニットシード + チュートリアルを同期 — N/A (内部 refactor)
- [x] labels SSOT (ADR-0009) — 本 PR が ADR-0045 (atom / compound 責務分離) 推進
- [x] 設計書同期 (ADR-0001) — N/A (内部 refactor、`refactor:internal-no-doc-impact` exempt)
- [x] 並行 PR overlap 確認 (#1200) — labels.ts は集中変更ファイルだが Phase 3 D6/D7/D8/D9/D10/D11 / Phase 4 E1-E5 が既に merge 済み、conflict なく rebase 可能
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A — 文言の変更なし（atom 参照化により char-by-char 一致を維持。削除 3 key は site/*.html 内参照ゼロの dead code 撤去のみ） |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- LP_COMMON_LABELS の 3 key 削除が本当に dead code か（`grep -rn "common\.priceStandardMonthly\|common\.priceFamilyMonthly\|common\.priceMinFrom" .` で外部参照ゼロを再確認願う）
- shared-labels.js diff が削除 3 行のみであること（`diff` 出力で確認）
- atom 化した key (LP_NAV.signup / LP_COMMON.ctaSignup / noCreditCardNote / cancelAnytime / LP_FLOATING_CTA.heroButton / bottomButton) の解決後文字列が一字も変わらないこと

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（個別実行で代替、テスト & 安全装置セルフチェック参照）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1-AC4 全て検証済、上記マップ参照）
- [x] UI 変更時: N/A — 表示変更ゼロ（char-by-char 一致 + 削除 3 key は dead code）。`refactor:internal-no-doc-impact` ラベル付与
- [x] 認証画面変更時: N/A — 認証画面影響なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

