### PR TITLE
test: #1942 site/pricing.html hardcoded 用語 0 件回帰防止テスト (Phase 3 D2)

### DIFF
--- a/tests/unit/lp/pricing-html-no-hardcoded-1942.test.ts
+++ b/tests/unit/lp/pricing-html-no-hardcoded-1942.test.ts
@@ -1,0 +1,180 @@
+/**
+ * tests/unit/lp/pricing-html-no-hardcoded-1942.test.ts (#1942, Phase 3 D2)
+ *
+ * site/pricing.html の DOM AST 上で、`data-lp-key` 属性を持つ要素の
+ * 配下 (= LP_LABELS から注入される fallback テキスト) **以外** の
+ * テキストノードに hardcoded 用語が出現しないことを保証する回帰防止テスト。
+ *
+ * 設計背景:
+ *   Phase 3 D5 (#1945 sync-lp-fallback.mjs) で fallback テキストは labels.ts と
+ *   同期維持される。Phase 3 D7 (#1947) で LP_PRICING_LABELS / LP_PRICING_PHASEB_LABELS
+ *   / LP_PRICING_EXTRA_LABELS の atom (price / plan / trial / free) は terms.ts
+ *   参照に統一済。本テストは pricing.html 側で「data-lp-key を持たない要素に
+ *   hardcoded 用語が混入する」という再発を構造的に防止する。
+ *
+ * 検査範囲:
+ *   - 用語: 無料プラン / 7日間 / 7 日間 / スタンダードプラン / ファミリープラン /
+ *     クレジットカード登録不要 / 基本無料 / いつでも解約 / クレカ登録不要
+ *   - 検査対象: `<body>` 配下の text node。`<meta>` / `<title>` / `<script>` /
+ *     `<style>` / HTML コメントは除外（SEO meta は ADR-0009 例外）
+ *   - 許容: text node の祖先要素のいずれかに `data-lp-key` 属性がある場合
+ *     (= shared-labels.js 経由で labels.ts 値で上書きされる fallback)
+ *
+ * AC マッピング (Issue #1942):
+ *   - AC1: site/pricing.html 内の data-lp-key 経由でない hardcoded 用語を 0 件に
+ *   - AC2: grep 相当で fallback 内側除く直書き 0 件 (本テストが parse5 AST で構造的に検証)
+ *
+ * 参考:
+ *   - sibling Issue: #1941 (D1 site/index.html) / #1943 (D3 site/faq.html)
+ *   - blocked_by: #1916 (terms.ts) / #1917 (template literal parser) / #1925 (PLAN_GATE_LABELS)
+ *   - upstream merge: #1947 (Phase 3 D7) / #1945 (Phase 3 D5)
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { parse } from 'parse5';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const PRICING_HTML = path.join(REPO_ROOT, 'site/pricing.html');
+
+/**
+ * Issue #1942 で AC1 / AC2 が想定する hardcoded 用語の網羅リスト。
+ * sibling Issue #1941 (D1) の AC2 grep 表現と整合させる。
+ */
+const HARDCODED_TERMS = [
+	'無料プラン',
+	'7日間',
+	'7 日間',
+	'スタンダードプラン',
+	'ファミリープラン',
+	'クレジットカード登録不要',
+	'クレカ登録不要',
+	'基本無料',
+	'いつでも解約',
+] as const;
+
+const EXCLUDED_PARENT_TAGS: ReadonlySet<string> = new Set(['meta', 'title', 'script', 'style']);
+
+interface AstNode {
+	nodeName: string;
+	value?: string;
+	attrs?: Array<{ name: string; value: string }>;
+	parentNode?: AstNode | null;
+	childNodes?: AstNode[];
+	content?: AstNode;
+	sourceCodeLocation?: { startLine?: number };
+}
+
+interface Violation {
+	line: number | undefined;
+	parentTag: string;
+	term: string;
+	textSnippet: string;
+}
+
+/**
+ * parse5 AST node の祖先に `data-lp-key` 属性があるか判定。
+ * 子ノードから親へ遡り、いずれかの要素ノードが data-lp-key を持てば true。
+ */
+function hasLpKeyAncestor(node: AstNode | null | undefined): boolean {
+	let cur = node?.parentNode ?? null;
+	while (cur) {
+		if (cur.attrs?.some((a) => a.name === 'data-lp-key')) return true;
+		cur = cur.parentNode ?? null;
+	}
+	return false;
+}
+
+/**
+ * 単一 text node を hardcoded 用語と照合し、違反 (data-lp-key 配下でなく
+ * かつ除外 parent でない) があれば Violation 配列に push。
+ */
+function inspectTextNode(node: AstNode, violations: Violation[]): void {
+	if (!node.value) return;
+	const parentTag = node.parentNode?.nodeName ?? '?';
+	if (EXCLUDED_PARENT_TAGS.has(parentTag)) return;
+	if (hasLpKeyAncestor(node)) return;
+	for (const term of HARDCODED_TERMS) {
+		if (node.value.includes(term)) {
+			violations.push({
+				line: node.sourceCodeLocation?.startLine,
+				parentTag,
+				term,
+				textSnippet: node.value.trim().substring(0, 80),
+			});
+		}
+	}
+}
+
+/** AST 全体を再帰 walk して全 text node を inspectTextNode に流す。 */
+function walkAst(node: AstNode | null | undefined, violations: Violation[]): void {
+	if (!node) return;
+	if (node.nodeName === '#text') inspectTextNode(node, violations);
+	if (node.childNodes) for (const c of node.childNodes) walkAst(c, violations);
+	if (node.content) walkAst(node.content, violations);
+}
+
+function collectViolations(root: AstNode): Violation[] {
+	const violations: Violation[] = [];
+	walkAst(root, violations);
+	return violations;
+}
+
+/**
+ * data-lp-key 配下の text node に少なくとも 1 件の hardcoded 用語が
+ * 含まれているかを判定（sync-lp-fallback で labels.ts と同期維持される
+ * fallback テキストの存在前提を担保する補助 assertion）。
+ */
+function hasFallbackTermInsideLpKey(node: AstNode | null | undefined): boolean {
+	if (!node) return false;
+	if (node.nodeName === '#text' && node.value) {
+		const matched = HARDCODED_TERMS.some((t) => node.value?.includes(t));
+		if (matched && hasLpKeyAncestor(node)) return true;
+	}
+	if (node.childNodes) {
+		for (const c of node.childNodes) {
+			if (hasFallbackTermInsideLpKey(c)) return true;
+		}
+	}
+	if (node.content && hasFallbackTermInsideLpKey(node.content)) return true;
+	return false;
+}
+
+describe('site/pricing.html — hardcoded 用語撤廃 (#1942 Phase 3 D2)', () => {
+	it('AC1 / AC2: data-lp-key 経由でない hardcoded 用語が 0 件であること', () => {
+		const html = readFileSync(PRICING_HTML, 'utf8');
+		const doc = parse(html, { sourceCodeLocationInfo: true }) as unknown as AstNode;
+
+		const violations = collectViolations(doc);
+
+		// 違反内容を可視化（テスト失敗時の診断容易化のため詳細メッセージ生成）
+		if (violations.length > 0) {
+			const detail = violations
+				.map((v) => `  L${v.line ?? '?'} <${v.parentTag}> "${v.term}" — "${v.textSnippet}"`)
+				.join('\n');
+			throw new Error(
+				`[#1942 D2] data-lp-key を持たない位置に hardcoded 用語 ${violations.length} 件:\n${detail}\n\n` +
+					'対応方針: 該当要素に data-lp-key 属性を追加し、labels.ts の対応 namespace に値を登録する。\n' +
+					'fallback テキストは sync-lp-fallback.mjs 経由で labels.ts と同期される。',
+			);
+		}
+
+		expect(violations).toHaveLength(0);
+	});
+
+	it('AC1 補強: data-lp-key 配下の fallback テキストには hardcoded 用語が出現する (改修時の前提条件)', () => {
+		const html = readFileSync(PRICING_HTML, 'utf8');
+		const doc = parse(html, { sourceCodeLocationInfo: true }) as unknown as AstNode;
+
+		// data-lp-key 配下の fallback には hardcoded 用語が含まれている前提
+		// (sync-lp-fallback.mjs が labels.ts 値で上書きするため、ここに用語があるのは正常)
+		// 本 it は「fallback 配下に用語がある」ことを assert することで、
+		// 上の it (AC1 / AC2) の意義 (= 'fallback 内側を除く' 表現の保証) を担保する。
+		const found = hasFallbackTermInsideLpKey(doc);
+
+		// 多数の hardcoded 用語が data-lp-key 配下 fallback として残っているはず
+		// (Phase 3 D7 + D5 の運用結果として、labels.ts 経由で同期維持されている)
+		expect(found).toBe(true);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者（Dev / QA） / システム全体

**解決する課題**: `site/pricing.html` 内の hardcoded 用語（無料プラン / 7日間 / スタンダードプラン / ファミリープラン / クレジットカード登録不要 / 基本無料 / いつでも解約 等）が `data-lp-key` 経由でない位置に再混入することを構造的に防止する回帰防止テストを追加する。Phase 3 D7 (#1947) で `LP_PRICING_LABELS` / `LP_PRICING_PHASEB_LABELS` / `LP_PRICING_EXTRA_LABELS` の atom 化が完了し、Phase 3 D5 (#1945) で `sync-lp-fallback.mjs` による fallback 同期機構が運用中の現時点で、`site/pricing.html` 側に「真の hardcoded 用語（data-lp-key を持たない要素のテキスト）」が 0 件であることを parse5 AST で検証し、将来の改修で混入したら CI で即時検出する。

**期待される効果**: `terms.ts` の atom 修正だけで価格・プラン・トライアル文言が pricing.html まで伝播する SSOT 階層（terms.ts → labels.ts → shared-labels.js → site/pricing.html）の最終段で品質ゲートを設置。並行実装の温床（HTML 直書き）を構造的に排除し、表記揺れ起因の顧客混乱を防ぐ。

## 関連 Issue

closes #1942

related:
- #1947 (Phase 3 D7、上流 atomicization、merged)
- #1945 (Phase 3 D5、fallback 同期機構、merged)
- #1916 (terms.ts 新設、merged via PR #1966)
- #1941 (Phase 3 D1 sibling、site/index.html 同種 issue)
- #1943 (Phase 3 D3 sibling、site/faq.html 同種 issue)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | site/pricing.html 内の data-lp-key 経由でない hardcoded 用語を全て data-lp-key 経由に | `npx vitest run tests/unit/lp/pricing-html-no-hardcoded-1942.test.ts` の it("AC1 / AC2: data-lp-key 経由でない hardcoded 用語が 0 件であること") を parse5 AST で検証 | PASS — 違反 0 件（D7 + D5 merge により Issue 起票時想定の 50 件は既に全件 fallback 化済、本 PR は回帰防止テストで現状を pin） |
| AC2 | grep でリテラル直書き 0 件 (fallback 内側除く) | 同上 it（parse5 AST で `data-lp-key` 祖先有無を判定。grep より厳密な構造的検証） + 補助 it「fallback 配下に hardcoded 用語が出現する」で運用前提を担保 | PASS — text node レベルで data-lp-key 配下以外に対象用語 0 件、SEO meta (description / og:description) の 4 箇所は ADR-0009 例外として除外 |
| AC3 | visual diff で見た目変更ゼロ | `git diff main...HEAD -- site/pricing.html` で site 側の差分が無いこと（テスト追加のみで HTML / CSS / labels.ts いずれも未変更） | PASS — `site/pricing.html` 差分 0 byte（テスト追加 + tmp/pr-bodies/ 以外の変更なし） |
| AC4 | lp-metrics.yml ratchet PASS | `SKIP_SCREENSHOT_EXISTENCE_CHECK=1 node scripts/measure-lp-dimensions.mjs` ローカル実行 + CI lp-metrics.yml | PASS — `[OK] all LP metrics within thresholds`（mobileHeight / desktopHeight / forbiddenTerms / ctaVariants 等全閾値内、screenshots は CI 撮影で担保） |

## 変更タイプ

- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト (`site/`) — **コード未変更**
- [x] テスト (`tests/unit/lp/`)

**影響を受ける画面・機能**: 描画変化なし（テスト追加のみ）。LP `site/pricing.html` の構造は変更せず、parse5 AST レベルで「`data-lp-key` を祖先に持たない位置に hardcoded 用語が出現しないこと」を pin する unit test を 1 件追加。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**: 個別 step 実機検証
  - biome: `npx biome check tests/unit/lp/pricing-html-no-hardcoded-1942.test.ts` PASS（worktree 環境では `.` 引数が config の path resolution で ignore されるため対象ファイル直接指定で検証）
  - vitest: `npx vitest run tests/unit/lp/` 26 件 PASS
  - sync-lp-fallback: `node scripts/sync-lp-fallback.mjs --check` PASS（全 site/*.html 同期済み）
  - check-lp-ssot: `node scripts/check-lp-ssot.mjs` PASS（baseline 0 維持）
  - check-lp-inline-style: `node scripts/check-lp-inline-style.mjs` PASS（全 baseline 内）
  - measure-lp-dimensions: `SKIP_SCREENSHOT_EXISTENCE_CHECK=1 node scripts/measure-lp-dimensions.mjs` PASS
- [x] 追加・変更したテストの概要:
  - 新規: `tests/unit/lp/pricing-html-no-hardcoded-1942.test.ts` (2 件) — parse5 AST で site/pricing.html を解析し、HARDCODED_TERMS 9 種が `data-lp-key` 祖先を持たない text node に出現しないことを検証 + fallback 配下には用語が存在することを補助検証で担保
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（test 追加のみ、site/pricing.html / shared-labels.js 含む全 LP コードは未変更で描画変化ゼロ）**。

git diff で確認可能:
- `site/pricing.html`: 0 byte 差分
- `site/shared-labels.js`: 0 byte 差分
- `src/lib/domain/labels.ts` / `terms.ts`: 0 byte 差分

LP 描画への影響経路（labels.ts → generate-lp-labels.mjs → shared-labels.js → data-lp-key 注入）の全段で変更なし。テストは parse5 AST 上の構造を pin するのみで実行時の HTML 出力に影響しない。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — 1 ファイル 1 関心事（pricing.html の hardcoded 用語回帰防止のみ）。`hasLpKeyAncestor` / `inspectTextNode` / `walkAst` / `collectViolations` / `hasFallbackTermInsideLpKey` を細分し biome `noExcessiveCognitiveComplexity` (max 20) を満たす
- [x] **DRY**: HARDCODED_TERMS 配列を sibling Issue #1941 (D1) AC2 の grep 表現と整合させ、将来 site/index.html の同種テスト追加時に再利用可能な形にする（独立コピーで namespace 分離、`as const` で immutable）
- [x] **YAGNI**: parse5 は既存 dep（`sync-lp-fallback.mjs` で導入済、`scripts/__tests__/sync-lp-fallback.test.mjs` で先行採用）。新規 dep 追加なし、新 helper / class 追加なし
- [x] **Security**: 静的 HTML を読み込んで検証するのみ、外部 I/O なし、秘密情報なし
- [x] **アクセシビリティ**: 描画変化なしのため非影響
- [x] **パフォーマンス**: テスト 1 件あたり 50ms 以下（vitest 出力で確認）、CI 影響軽微

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照）:

- [x] **labels SSOT** (ADR-0045 → ADR-0009 supersede): site/pricing.html の fallback テキストは `sync-lp-fallback.mjs` 経由で labels.ts と同期維持されており、本テストはその運用結果（真の hardcoded 0 件）を pin する。labels.ts 側の atom (terms.ts) は #1947 で D7 完遂済
- [x] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: テスト追加のみのため文言追加・削除なし。LP_PRICING_*_LABELS の committed 文言は #1947 で確認済、本 PR は scope 外
- [N/A] 本番アプリ + デモ版同期（test 追加のみ）
- [N/A] 全年齢モード 5 種（LP_PRICING は年齢モード非依存）
- [N/A] ナビゲーション 3 種（test 追加のみ）
- [N/A] E2E / ユニットシード + チュートリアル同期（test 追加のみ）
- [x] **設計書同期** (ADR-0001): `docs/DESIGN.md` §6 は terms.ts → labels.ts 階層図が #1916 で反映済、ADR-0045 が #1968 で起票済。本 PR は構造を維持する内部テスト追加のため新規追記不要（`refactor:internal-no-doc-impact` ラベル相当の test version。`type:test` ラベル）
- [x] **並行 PR overlap** (#1200): 本 PR は `tests/unit/lp/pricing-html-no-hardcoded-1942.test.ts` 新規 1 ファイルのみ追加。既存 site/pricing.html / labels.ts / terms.ts いずれも touch しないため、進行中の他 PR と overlap しない

**LP / 販促文言変更時** (ADR-0013 / #1314):

N/A — 文言の追加・削除・変更なし（テスト追加のみ）。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（test 追加のみ、本番コード未変更）

**レビュー依頼事項・QA**:
- 「現状の `site/pricing.html` には Issue #1942 で想定された 50 件の hardcoded violation が既に 0 件に解消されている」という観察の妥当性確認（D7 #1947 + D5 #1945 merge 後の状態）
- parse5 AST ベースの判定ロジック（`hasLpKeyAncestor`）の正確性 — `data-lp-key` 祖先がいずれか 1 つでもあれば fallback 内側として許容する判定で良いか（grep ベースより厳密）
- HARDCODED_TERMS 9 種が Issue #1941 (D1) AC2 表現と整合しているか（site/pricing.html では「クレカ登録不要」「7 日間」（半角空白あり）含む全派生形カバー）
- AC2 の「fallback 内側を除く」表現を test 補助 it で「fallback 配下に hardcoded 用語が出現する」と双方向 assert することの是非

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（worktree 環境固有の path 解決問題で `pre-ready.mjs` 一括実行不可のため個別 step 実機検証 — biome / vitest / sync-lp-fallback / check-lp-ssot / check-lp-inline-style / measure-lp-dimensions 全 PASS）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1: violations 0 / AC2: parse5 AST 構造的検証 / AC3: site/pricing.html 差分 0 byte / AC4: lp-metrics PASS）
- [x] Phase 分割した場合: Phase 3 D2 単独 — 上流 D7 (#1947) / D5 (#1945) merge 後に着手、sibling D1 (#1941) / D3 (#1943) / D4 (#1944) は未着手のため独立完遂可能
- [N/A] UI 変更時: test 追加のみで描画変化なし
- [N/A] 認証画面変更時: 認証画面非変更

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
