### PR TITLE
refactor: #1956 LP_PAMPHLET / PAMPHLET_PHASEB / INDEX_EXTRA terms.ts 参照化 (Phase 3 D11)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -5738,6 +5738,11 @@ export const LP_FLOATING_CTA_LABELS = {
 // LP_INDEX_EXTRA_LABELS (#1465 SSOT Fixes)
 // ============================================================
 
+// #1956 (Phase 3 D11): terms.ts atom 参照化対象（PLAN_FULL_TERMS / PRICE_TERMS / TRIAL_TERMS /
+//   CANCEL_TERMS / FREE_TERMS / CTA_TERMS）。 char-by-char 一致厳守。
+//   '7 日間' (半角スペース有り) は TRIAL_TERMS.duration ('7日間' スペース無し) と一致しないため
+//   直書き継続（#2007 / #2008 / #2009 と同方針）。
+//   '&#165;' (HTML エンティティ) は PRICE_TERMS の '¥' (U+00A5) と一致しないため直書き継続。
 export const LP_INDEX_EXTRA_LABELS = {
 	k1: 'がんばりクエスト — 「やりなさい」を「やりたい！」に変える',
 	k2: '☰',
@@ -5745,9 +5750,9 @@ export const LP_INDEX_EXTRA_LABELS = {
 	k4: '「やりたい！」',
 	k5: ' に変える家族 RPG',
 	k6: '    3〜18 歳の毎日の習慣を、ポイント・シール・レベルで冒険に変える。声をかけなくても、自分から動きだす家族時間へ。',
-	k7: '無料で始める',
+	k7: `${FREE_TERMS.tryFree}`,
 	k8: 'デモを見る',
-	k9: '家族何人でも無料ではじめられます / クレジットカード登録不要',
+	k9: `家族何人でも無料ではじめられます / ${TRIAL_TERMS.noCreditCard}`,
 	k10: '子供のホーム画面 — 活動を記録してポイントゲット',
 	k11: 'お子さまの年齢で、画面とむずかしさが変わります',
 	k12: '3 歳から 18 歳まで、2 つの UI モードが対応。',
@@ -5799,14 +5804,18 @@ export const LP_INDEX_EXTRA_LABELS = {
 	k60: '設定の自由度',
 	k61: '活動の種類・ポイント配分・ごほうびは自由にカスタマイズ。お子さまに合わせて調整できます。',
 	k62: '料金プラン',
-	k63: '月 ¥500 から、家族全員が使える設計です。',
+	// #1956 (Phase 3 D11): k63 '月 ¥500' = monthlyPrefix + standard、k65 '基本無料' = FREE_TERMS.base、
+	//   k68 '無料体験' = CTA_TERMS.freeTrialNoun、k69 'いつでも解約 OK' = CANCEL_TERMS.anytimeOk、
+	//   k70 '無料プラン' = PLAN_FULL_TERMS.free。
+	//   k67 '月 &#165;500（税込）〜' は HTML エンティティのため char-by-char 一致せず直書き維持。
+	k63: `${PRICE_TERMS.monthlyPrefix}${PRICE_TERMS.standard} から、家族全員が使える設計です。`,
 	k64: '安心して始められる 4 つのお約束。',
-	k65: '基本無料',
+	k65: `${FREE_TERMS.base}`,
 	k66: '有料は',
 	k67: '月 &#165;500（税込）〜',
-	k68: '7 日間無料体験',
-	k69: 'いつでも解約 OK',
-	k70: 'お子さま 2 人までのご家庭なら、無料プランで冒険の仕組みをすべてお使いいただけます。',
+	k68: `7 日間${CTA_TERMS.freeTrialNoun}`,
+	k69: `${CANCEL_TERMS.anytimeOk}`,
+	k70: `お子さま 2 人までのご家庭なら、${PLAN_FULL_TERMS.free}で冒険の仕組みをすべてお使いいただけます。`,
 	k71: '3 人以上 / 長期履歴 / AI 自動提案は有料プランで。',
 	k72: '料金の詳細を見る &#8594;',
 	k73: 'お子さまのデータは、家族だけのものです',
@@ -5828,7 +5837,8 @@ export const LP_INDEX_EXTRA_LABELS = {
 	k89: 'FAQ 専用ページ（24 項目）',
 	k90: ' をご覧ください。',
 	k91: '無料トライアルにクレジットカードは必要ですか？',
-	k92: '不要です。メール認証だけで 7 日間すべての有料機能をお試しいただけます。期間終了時は自動で無料プランに戻るため、',
+	// #1956 (Phase 3 D11): '無料プラン' = PLAN_FULL_TERMS.free 参照化（'7 日間' は半角スペース有りで直書き継続）
+	k92: `不要です。メール認証だけで 7 日間すべての有料機能をお試しいただけます。期間終了時は自動で${PLAN_FULL_TERMS.free}に戻るため、`,
 	k93: '気付いたら課金されていた',
 	k94: 'ということはありません。',
 	k95: '子供が勝手に課金してしまう心配はありませんか？',
@@ -5841,20 +5851,28 @@ export const LP_INDEX_EXTRA_LABELS = {
 	k102: 'FAQ 専用ページ',
 	k103: ' へ。',
 	k104: '家族で全部使ってから、続けるか決める',
-	k105: '7 日間無料・クレジットカード登録不要 / いつでもキャンセル可能。',
+	// #1956 (Phase 3 D11): 'クレジットカード登録不要' = TRIAL_TERMS.noCreditCard 参照化、
+	//   '無料で始める' (k107 / k113) = FREE_TERMS.tryFree 参照化。
+	//   '7 日間' は半角スペース有りで直書き継続。
+	k105: `7 日間無料・${TRIAL_TERMS.noCreditCard} / いつでもキャンセル可能。`,
 	k106: '今日からお子さまの「やりたい！」を育てませんか？',
-	k107: '無料で始める',
+	k107: `${FREE_TERMS.tryFree}`,
 	k108: 'ご質問・ご要望は',
 	k109: 'メール',
 	k110: 'でお気軽にどうぞ',
 	k111: '全機能を家族で試せる（7 日間無料）',
 	k112: 'クレジットカード不要',
-	k113: '無料で始める',
+	k113: `${FREE_TERMS.tryFree}`,
 	k114: '&#10005;',
 } as const;
 
 // ============================================================
 // LP_PAMPHLET_LABELS (#1465 SSOT Fixes)
+//
+// #1956 (Phase 3 D11): terms.ts atom (PLAN_TERMS / PLAN_FULL_TERMS / FREE_TERMS / CTA_TERMS /
+//   TRIAL_TERMS) 参照化対象。char-by-char 一致厳守。
+//   '7 日間' (半角スペース有り) は TRIAL_TERMS.duration ('7日間' スペース無し) と一致しないため
+//   直書き継続（#2007 / #2008 / #2009 と同方針）。
 // ============================================================
 
 export const LP_PAMPHLET_LABELS = {
@@ -5882,7 +5900,8 @@ export const LP_PAMPHLET_LABELS = {
 	k22: '&#x1F476; 0〜2歳のお子様は「準備モード」でご登録いただけます',
 	k23: '小学生以上',
 	k24: '6&#x301C;18歳',
-	k25: '&#x1F3AE; まずは無料で始めよう！',
+	// #1956 (Phase 3 D11): 'まずは無料' = FREE_TERMS.start 部分参照化（PR-2008 ctaBottomDesc と同パターン）
+	k25: `&#x1F3AE; ${FREE_TERMS.start}で始めよう！`,
 	k26: '登録は1分。お子さまの名前と年齢を入れるだけで、今日から冒険が始まります。',
 	k27: '&#x1F310; アクセスはこちら',
 	k28: 'がんばりクエスト &#x2014; &#x6599;&#x91D1;&#x30D7;&#x30E9;&#x30F3; &amp; &#x59CB;&#x3081;&#x65B9;',
@@ -5899,9 +5918,11 @@ export const LP_PAMPHLET_LABELS = {
 	k38: '持ち物チェックリスト 3個/子まで',
 	k39: '90日間の履歴保持',
 	k40: '&#x2B50; おすすめ',
-	k41: 'スタンダード',
+	// #1956 (Phase 3 D11): 'スタンダード' = PLAN_TERMS.standard、
+	//   '7日間無料体験' = TRIAL_TERMS.duration + CTA_TERMS.freeTrialNoun
+	k41: `${PLAN_TERMS.standard}`,
 	k42: '/月（税込）',
-	k43: '7日間無料体験',
+	k43: `${TRIAL_TERMS.duration}${CTA_TERMS.freeTrialNoun}`,
 	k44: '子供の登録：無制限',
 	k45: 'オリジナル活動：無制限',
 	k46: '家族メンバー招待：4人まで',
@@ -5909,10 +5930,13 @@ export const LP_PAMPHLET_LABELS = {
 	k48: 'データのダウンロード',
 	k49: '1年間の履歴保持',
 	k50: 'メールサポート',
-	k51: 'ファミリー',
+	// #1956 (Phase 3 D11): 'ファミリー' = PLAN_TERMS.family、
+	//   '7日間無料体験' = TRIAL_TERMS.duration + CTA_TERMS.freeTrialNoun、
+	//   'スタンダードの全機能' = PLAN_TERMS.standard + 'の全機能'（#1947 LP_PRICING_EXTRA_LABELS k19 と同パターン）
+	k51: `${PLAN_TERMS.family}`,
 	k52: '/月（税込）',
-	k53: '7日間無料体験',
-	k54: 'スタンダードの全機能',
+	k53: `${TRIAL_TERMS.duration}${CTA_TERMS.freeTrialNoun}`,
+	k54: `${PLAN_TERMS.standard}の全機能`,
 	k55: '家族メンバー招待：無制限',
 	k56: 'AI 自動提案（活動・ごほうび・チェックリスト）',
 	k57: 'きょうだいランキング',
@@ -5932,7 +5956,9 @@ export const LP_PAMPHLET_LABELS = {
 	k71: 'ポイント獲得 &amp; レベルアップ！',
 	k72: '&#x2753; よくある質問',
 	k73: '料金はかかりますか？',
-	k74: '基本機能は無料でずっとお使いいただけます。有料プランはより多くのお子さまの登録や高度な分析機能が必要な場合にご検討ください。スタンダード・ファミリープランは 7 日間無料トライアル付きです。',
+	// #1956 (Phase 3 D11): 'スタンダード' = PLAN_TERMS.standard、'ファミリープラン' = PLAN_FULL_TERMS.family。
+	//   '7 日間' は半角スペース有りで TRIAL_TERMS.duration と一致しないため直書き継続。
+	k74: `基本機能は無料でずっとお使いいただけます。有料プランはより多くのお子さまの登録や高度な分析機能が必要な場合にご検討ください。${PLAN_TERMS.standard}・${PLAN_FULL_TERMS.family}は 7 日間無料トライアル付きです。`,
 	k75: '何歳から使えますか？',
 	k76: '3歳から18歳までのお子さま向けに設計しています。3歳からはお子さま自身がタップして記録、年齢に合わせて画面が自動で変わるので、きょうだいでも安心です。0〜2歳のお子さまは「準備モード」（保護者が記録するモード）で記録のみご利用いただけます（お子さま向けゲーミフィケーションは適用されません）。',
 	k77: '子供のデータは安全ですか？',
@@ -6594,6 +6620,11 @@ export const LP_FAQ_PHASEB_LABELS = {
 	k123: 'デモを見る',
 } as const;
 
+// #1956 (Phase 3 D11): terms.ts atom 参照化対象（PLAN_TERMS / PLAN_FULL_TERMS / FREE_TERMS）。
+//   char-by-char 一致厳守。
+//   '7 日間' (半角スペース有り) は TRIAL_TERMS.duration ('7日間' スペース無し) と一致しないため
+//   直書き継続。'&#xA5;500' / '&#xA5;780' (HTML エンティティ) は PRICE_TERMS.standard / family
+//   ('¥500' / '¥780', U+00A5) と char-by-char 一致しないため直書き継続（#2007 と同方針）。
 export const LP_PAMPHLET_PHASEB_LABELS = {
 	k1: 'がんばりクエスト パンフレット',
 	k2: '&#x1F5A8; 印刷 / PDF保存',
@@ -6615,7 +6646,8 @@ export const LP_PAMPHLET_PHASEB_LABELS = {
 	k18: '&#x1F476; 0〜2歳のお子さまは「準備モード」でご登録いただけます',
 	k19: '小学生以上',
 	k20: '6&#x301C;18歳',
-	k21: '&#x1F3AE; まずは無料で始めよう！',
+	// #1956 (Phase 3 D11): 'まずは無料' = FREE_TERMS.start 部分参照化
+	k21: `&#x1F3AE; ${FREE_TERMS.start}で始めよう！`,
 	k22: '登録は1分。お子さまの名前と年齢を入れるだけで、今日から冒険が始まります。',
 	k23: '&#x1F310; アクセスはこちら',
 	k24: 'がんばりクエスト &#x2014; &#x6599;&#x91D1;&#x30D7;&#x30E9;&#x30F3; &amp; &#x59CB;&#x3081;&#x65B9;',
@@ -6632,7 +6664,9 @@ export const LP_PAMPHLET_PHASEB_LABELS = {
 	k34: '<span class="check">&#x2713;</span>持ち物チェックリスト 3個/子まで',
 	k35: '<span class="check">&#x2713;</span>90日間の履歴保持',
 	k36: '&#x2B50; おすすめ',
-	k37: 'スタンダード',
+	// #1956 (Phase 3 D11): 'スタンダード' = PLAN_TERMS.standard 参照化。
+	//   '&#xA5;500' / '7 日間無料トライアル' は char-by-char 一致しないため直書き継続。
+	k37: `${PLAN_TERMS.standard}`,
 	k38: '&#xA5;500<small>/月（税込）</small>',
 	k39: '7 日間無料トライアル',
 	k40: '<span class="check">&#x2713;</span>子供の登録：無制限',
@@ -6642,10 +6676,13 @@ export const LP_PAMPHLET_PHASEB_LABELS = {
 	k44: '<span class="check">&#x2713;</span>データのダウンロード',
 	k45: '<span class="check">&#x2713;</span>1年間の履歴保持',
 	k46: '<span class="check">&#x2713;</span>メールサポート',
-	k47: 'ファミリー',
+	// #1956 (Phase 3 D11): 'ファミリー' = PLAN_TERMS.family、
+	//   'スタンダードの全機能' = PLAN_TERMS.standard + 'の全機能' 部分参照化。
+	//   '&#xA5;780' / '7 日間無料トライアル' は char-by-char 一致しないため直書き継続。
+	k47: `${PLAN_TERMS.family}`,
 	k48: '&#xA5;780<small>/月（税込）</small>',
 	k49: '7 日間無料トライアル',
-	k50: '<span class="check">&#x2713;</span>スタンダードの全機能',
+	k50: `<span class="check">&#x2713;</span>${PLAN_TERMS.standard}の全機能`,
 	k51: '<span class="check">&#x2713;</span>家族メンバー招待：無制限',
 	k52: '<span class="check">&#x2713;</span>AI 自動提案（活動・ごほうび・チェックリスト）',
 	k53: '<span class="check">&#x2713;</span>きょうだいランキング',
@@ -6662,7 +6699,9 @@ export const LP_PAMPHLET_PHASEB_LABELS = {
 	k64: '活動を記録するたびにポイント獲得 &amp; レベルアップ！',
 	k65: '&#x2753; よくある質問',
 	k66: '料金はかかりますか？',
-	k67: '基本機能は無料でずっとお使いいただけます。有料プランはより多くのお子さまの登録や高度な分析機能が必要な場合にご検討ください。スタンダード・ファミリープランは 7 日間無料トライアル付きです。',
+	// #1956 (Phase 3 D11): 'スタンダード' = PLAN_TERMS.standard、'ファミリープラン' = PLAN_FULL_TERMS.family。
+	//   '7 日間' は半角スペース有りで TRIAL_TERMS.duration と一致しないため直書き継続。
+	k67: `基本機能は無料でずっとお使いいただけます。有料プランはより多くのお子さまの登録や高度な分析機能が必要な場合にご検討ください。${PLAN_TERMS.standard}・${PLAN_FULL_TERMS.family}は 7 日間無料トライアル付きです。`,
 	k68: '何歳から使えますか？',
 	k69: '3歳から18歳までのお子さま向けに設計しています。3歳からはお子さま自身がタップして記録、年齢に合わせて画面が自動で変わるので、きょうだいでも安心です。0〜2歳のお子さまは「準備モード」（保護者が記録するモード）で記録のみご利用いただけます（お子さま向けゲーミフィケーションは適用されません）。',
 	k70: '子供のデータは安全ですか？',


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（labels.ts のメンテナを行う Dev / 将来の LP 文言改訂作業者）

**解決する課題**: SSOT 2 階層化 (Phase 1 #1916) を LP の `index.html` extra（hero〜footer 補完）/ `pamphlet.html` （既存 + Phase B）の 3 namespace に波及させる Phase 3 D11。LP_INDEX_EXTRA_LABELS は #1946 D6 の LP_INDEX_PHASEB_LABELS に対するペア namespace (旧版 + 補完用) として未着手だったもの。LP_PAMPHLET_LABELS / LP_PAMPHLET_PHASEB_LABELS は印刷用パンフレット (`site/pamphlet.html`) の SSOT で、料金プランカード・FAQ 文末など PLAN 名・トライアル動詞句が直書きされていた。

**期待される効果**: 将来 PLAN 名・価格・トライアル動詞句・解約・無料訴求の文言を改訂する際、terms.ts atom 1 行修正で全 LP・アプリ本体・法務文書に伝播するアーキテクチャを完成させる。誤って atom と不一致な直書き表現を追加してしまうリグレッションを構造的に防ぐ。

## 関連 Issue

closes #1956

- blocked_by: #1916 (terms.ts 基盤) / #1917 (template literal parser)
- 兄弟 PR: #2006 D7 (PRICING) / #2007 D6 (HERO_PRICE_BAND / INDEX_PHASEB) / #2008 D9 (VERSUS / CORELOOP) / #2009 D10 (FAQ) / #2010 D8 (CTA_TRUST_BADGES)
- ADR-0013 (LP truth) / ADR-0045 (terms.ts SSOT 2 階層化原則)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | src/lib/domain/labels.ts の以下 namespace を terms.ts 参照に書換え (LP_PAMPHLET_LABELS / LP_PAMPHLET_PHASEB_LABELS / LP_INDEX_EXTRA_LABELS) | char-by-char 突合の調査結果（atom 突合表は本 PR 本文「atom 突合表」を参照）+ template literal 化 + namespace ヘッダコメント追記 | PASS — `grep -c "Phase 3 D11" src/lib/domain/labels.ts` で 14 ヒット (3 namespace ヘッダ + 各箇所 inline コメント)。`grep -nE "FREE_TERMS\.tryFree\|FREE_TERMS\.base\|FREE_TERMS\.start\|TRIAL_TERMS\.noCreditCard\|CTA_TERMS\.freeTrialNoun\|PRICE_TERMS\.monthlyPrefix\|PRICE_TERMS\.standard\|CANCEL_TERMS\.anytimeOk\|PLAN_FULL_TERMS\.free\|PLAN_FULL_TERMS\.family\|PLAN_TERMS\.standard\|PLAN_TERMS\.family" src/lib/domain/labels.ts \| wc -l` で本 PR 該当箇所の参照増加を確認 |
| AC2 | shared-labels.js 出力差分ゼロ | `node scripts/generate-lp-labels.mjs` 実行後 `md5sum site/shared-labels.js` で HEAD と現在の md5 一致 | PASS — md5: `da2e6939e53383c7a12fff0e7417766c` (HEAD = main 最新と完全一致)。`git status site/shared-labels.js` 出力ゼロ |
| AC3 | visual diff で見た目変更ゼロ | site/index.html / site/pamphlet.html の data-lp-key fallback テキストと char-by-char 一致を維持 (visible 文字列変更なし) | PASS — `node scripts/sync-lp-fallback.mjs` で「全 site/*.html の fallback テキストは既に labels.ts と同期済みです」確認。`git status site/*.html` 出力ゼロ。template literal で組み立てられる文字列値が直書き値と char-by-char 一致 |

### atom 突合表（AC1 エビデンス）

#### LP_INDEX_EXTRA_LABELS (src/lib/domain/labels.ts:5746)

`site/index.html` 旧版用の 114 keys namespace。Phase B (LP_INDEX_PHASEB_LABELS, #1946 D6 で参照化済) と並行で残されており、tour-card / soft-features / pricing band / FAQ / floating CTA など多くの文言を含む。

**参照化箇所 (11 件)**:

| key | 元値 | 参照化後 | 使用 atom |
|---|---|---|---|
| k7 | `'無料で始める'` | `${FREE_TERMS.tryFree}` | FREE_TERMS.tryFree |
| k9 | `'家族何人でも無料ではじめられます / クレジットカード登録不要'` | `家族何人でも無料ではじめられます / ${TRIAL_TERMS.noCreditCard}` | TRIAL_TERMS.noCreditCard |
| k63 | `'月 ¥500 から、家族全員が使える設計です。'` | `${PRICE_TERMS.monthlyPrefix}${PRICE_TERMS.standard} から、家族全員が使える設計です。` | PRICE_TERMS.monthlyPrefix + standard |
| k65 | `'基本無料'` | `${FREE_TERMS.base}` | FREE_TERMS.base |
| k68 | `'7 日間無料体験'` | `7 日間${CTA_TERMS.freeTrialNoun}` | CTA_TERMS.freeTrialNoun |
| k69 | `'いつでも解約 OK'` | `${CANCEL_TERMS.anytimeOk}` | CANCEL_TERMS.anytimeOk |
| k70 | `'... 無料プラン で...'` | `... ${PLAN_FULL_TERMS.free} で...` | PLAN_FULL_TERMS.free |
| k92 | `'... 無料プラン に戻るため、'` | `... ${PLAN_FULL_TERMS.free} に戻るため、` | PLAN_FULL_TERMS.free |
| k105 | `'7 日間無料・クレジットカード登録不要 / いつでもキャンセル可能。'` | `7 日間無料・${TRIAL_TERMS.noCreditCard} / いつでもキャンセル可能。` | TRIAL_TERMS.noCreditCard |
| k107 | `'無料で始める'` | `${FREE_TERMS.tryFree}` | FREE_TERMS.tryFree |
| k113 | `'無料で始める'` | `${FREE_TERMS.tryFree}` | FREE_TERMS.tryFree |

**直書き継続 (char-by-char 不一致)**:

- k67 `'月 &#165;500（税込）〜'` — `&#165;` (HTML entity) は `PRICE_TERMS` の `'¥'` (U+00A5) と char-by-char 一致しないため直書き継続
- k68 / k105 / k111 等の `'7 日間'` (半角スペース有り) — TRIAL_TERMS.duration (`'7日間'` スペース無し) と一致しないため直書き継続（#2007 / #2008 / #2009 と同方針）
- k111 `'全機能を家族で試せる（7 日間無料）'` / k112 `'クレジットカード不要'` — atom 形と異なる訴求語（`'クレジットカード登録不要'` ではなく `'クレジットカード不要'`）のため直書き継続

#### LP_PAMPHLET_LABELS (src/lib/domain/labels.ts:5874)

`site/pamphlet.html` 印刷用パンフレットの 90 keys namespace。料金プランカード（フリー / スタンダード / ファミリー）と FAQ 文末を含む。

**参照化箇所 (7 件)**:

| key | 元値 | 参照化後 | 使用 atom |
|---|---|---|---|
| k25 | `'&#x1F3AE; まずは無料で始めよう！'` | `&#x1F3AE; ${FREE_TERMS.start}で始めよう！` | FREE_TERMS.start |
| k41 | `'スタンダード'` | `${PLAN_TERMS.standard}` | PLAN_TERMS.standard |
| k43 | `'7日間無料体験'` | `${TRIAL_TERMS.duration}${CTA_TERMS.freeTrialNoun}` | TRIAL_TERMS.duration + CTA_TERMS.freeTrialNoun |
| k51 | `'ファミリー'` | `${PLAN_TERMS.family}` | PLAN_TERMS.family |
| k53 | `'7日間無料体験'` | `${TRIAL_TERMS.duration}${CTA_TERMS.freeTrialNoun}` | TRIAL_TERMS.duration + CTA_TERMS.freeTrialNoun |
| k54 | `'スタンダードの全機能'` | `${PLAN_TERMS.standard}の全機能` | PLAN_TERMS.standard |
| k74 | `'... スタンダード・ファミリープランは 7 日間無料トライアル...'` | `... ${PLAN_TERMS.standard}・${PLAN_FULL_TERMS.family}は 7 日間無料トライアル...` | PLAN_TERMS.standard + PLAN_FULL_TERMS.family |

**直書き継続 (char-by-char 不一致)**:

- k32 `'ずっと無料'` / k74 `'7 日間'` — atom 未定義 / 半角スペース有りで直書き継続

#### LP_PAMPHLET_PHASEB_LABELS (src/lib/domain/labels.ts:6629)

Phase B で SSOT 化された `site/pamphlet.html` の 82 keys namespace。LP_PAMPHLET_LABELS と内容が重複する部分があり、HTML エンティティの違いで一致パターンが異なる。

**参照化箇所 (5 件)**:

| key | 元値 | 参照化後 | 使用 atom |
|---|---|---|---|
| k21 | `'&#x1F3AE; まずは無料で始めよう！'` | `&#x1F3AE; ${FREE_TERMS.start}で始めよう！` | FREE_TERMS.start |
| k37 | `'スタンダード'` | `${PLAN_TERMS.standard}` | PLAN_TERMS.standard |
| k47 | `'ファミリー'` | `${PLAN_TERMS.family}` | PLAN_TERMS.family |
| k50 | `'<span class="check">&#x2713;</span>スタンダードの全機能'` | `<span class="check">&#x2713;</span>${PLAN_TERMS.standard}の全機能` | PLAN_TERMS.standard |
| k67 | `'... スタンダード・ファミリープランは 7 日間無料トライアル...'` | `... ${PLAN_TERMS.standard}・${PLAN_FULL_TERMS.family}は 7 日間無料トライアル...` | PLAN_TERMS.standard + PLAN_FULL_TERMS.family |

**直書き継続 (char-by-char 不一致)**:

- k38 `'&#xA5;500<small>/月（税込）</small>'` / k48 `'&#xA5;780<small>/月（税込）</small>'` — `&#xA5;` (HTML entity) は PRICE_TERMS の `'¥'` (U+00A5) と char-by-char 不一致で直書き継続
- k39 / k49 `'7 日間無料トライアル'` — 半角スペース有り + `'無料トライアル'` は atom 未定義で直書き継続
- k28 `'ずっと無料'` — atom 未定義

**結論**: 3 namespace 合計 **23 件 atom 参照化** + namespace ヘッダ rationale コメント 3 件追加。

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- `src/lib/domain/labels.ts` の `LP_INDEX_EXTRA_LABELS` / `LP_PAMPHLET_LABELS` / `LP_PAMPHLET_PHASEB_LABELS` namespace（合計 62 行追加 / 23 行削除）
- 表示テキストへの影響なし（`site/index.html` / `site/pamphlet.html` の表示変更ゼロ）
- 実行時の挙動変更ゼロ（template literal の最終解決値は直書きと完全一致）
- shared-labels.js の md5 値が変化なし → CDN 経由の LP 配信値も完全一致

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
  - 注: pre-ready は worktree 環境で `origin/main` diff 取得失敗 + biome 0 file となる既存課題があるため、各 Step を個別実行で代替検証:
    - biome: `npx biome check src tests scripts` PASS (1253 files clean)
    - svelte-check: 0 errors (13 warnings は既存、本 PR と無関係)
    - vitest: `npx vitest run tests/unit/domain/labels.test.ts tests/unit/lp/` 全 PASS (37 tests / 2 files)
    - LP SSOT: `node scripts/check-lp-ssot.mjs` PASS (LEGAL-SSOT 54 keys, 0 missing)
    - LP fallback sync: `node scripts/sync-lp-fallback.mjs` 「全 site/*.html の fallback テキストは既に labels.ts と同期済みです」
    - LP inline-style baseline: `node scripts/check-lp-inline-style.mjs` 全 baseline 内
    - LP dimensions: `SKIP_SCREENSHOT_EXISTENCE_CHECK=1 node scripts/measure-lp-dimensions.mjs` all within thresholds
    - shared-labels.js diff: md5 `da2e6939e53383c7a12fff0e7417766c` (HEAD = 現在で完全一致)
- [x] 追加・変更したテストの概要: N/A（既存値の char-by-char 一致を維持する pure refactor のため、振る舞い変化なし → 既存 vitest 全件 PASS で担保）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は src/lib/domain/labels.ts の `*.ts` 1 ファイルのみの変更で、UI 関連ファイル（`*.svelte` / `*.svelte.ts` / `*.css` / `site/**`）の変更を一切含まない。

具体的には以下を全て満たす:
- 各 namespace の参照化された全 23 keys は template literal で組み立てられ、最終文字列は変更前後で char-by-char 完全一致
- `git diff site/shared-labels.js` 出力ゼロで CDN 配信値も完全一致（md5 `da2e6939e53383c7a12fff0e7417766c` 一致）
- `site/index.html` / `site/pamphlet.html` の `data-lp-key` fallback テキストとも char-by-char 一致
- `node scripts/sync-lp-fallback.mjs` で「全 site/*.html の fallback テキストは既に labels.ts と同期済みです」確認

このため `refactor:internal-no-doc-impact` ラベルでの screenshot 4 スロット exempt 対象（#1985 / ADR-0003 §4 改訂）。

**インタラクティブ状態**: N/A（UI 変更なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（terms.ts atom と labels.ts compound の責務分離を維持） / 依存性逆転（labels.ts が terms.ts を import する単方向依存） / インターフェース分離（namespace ごとに独立、相互参照なし）
- [x] **DRY**: `'無料で始める'` / `'基本無料'` / `'まずは無料'` / `'クレジットカード登録不要'` / `'いつでも解約 OK'` / `'無料体験'` / `'スタンダード'` / `'ファミリー'` / `'無料プラン'` / `'ファミリープラン'` / `'¥500'` / `'月 '` の各 atom リテラルを既存 atom 経由参照に統一。同 atom を参照する既存 namespace（#2006 / #2007 / #2008 / #2009 / #2010）と同方式
- [x] **YAGNI**: 不要な抽象化なし。新 atom 増設なし（CTA_TERMS / FREE_TERMS / PLAN_TERMS / PLAN_FULL_TERMS / PRICE_TERMS / TRIAL_TERMS / CANCEL_TERMS の既存 atom のみ使用）
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: N/A（template literal は build 時に解決、runtime オーバーヘッドなし）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — labels.ts は SSOT で本番 / デモ共用
- [x] LP ↔ アプリ双方向整合（ADR-0013） — shared-labels.js diff = 0 で LP 側 fallback と完全同期
- [x] 全年齢モード 5 種に横展開 — N/A（年齢モード非依存の LP / pamphlet ラベル）
- [x] ナビゲーション 3 種に反映 — N/A（ナビ非関連）
- [x] E2E / ユニットシード + チュートリアルを同期 — N/A（テストデータ非関連）
- [x] labels SSOT (ADR-0009 / ADR-0045 supersede) — terms.ts atom 経由の SSOT 階層を維持
- [x] 設計書同期 (ADR-0001) — 本 PR は労務的 refactor で設計書影響なし。`refactor:internal-no-doc-impact` ラベル exempt 対象 (#1985)
- [x] 並行 PR overlap 確認 (#1200) — Phase 3 D シリーズの兄弟 PR (#2006 / #2007 / #2008 / #2009 / #2010) と src/lib/domain/labels.ts を編集競合する可能性あり。本 PR は 5746 / 5874 / 6629 行付近の 3 namespace のみ編集で他 PR の編集領域 (LP_PRICING_LABELS / LP_HERO_PRICE_BAND / LP_VERSUS / LP_FAQ / LP_CTA_TRUST_BADGES) と非衝突
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A — 表示文言変更ゼロ（template literal で同一文字列を組み立てる pure refactor） | — | — |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- atom 突合表（AC1 エビデンス）の char-by-char 検証結果が妥当か（特に「'7 日間' は半角スペース有りで TRIAL_TERMS.duration ('7日間' スペース無し) と一致しない」「'&#xA5;' / '&#165;' は PRICE_TERMS の '¥' と一致しない」判断）
- `'まずは無料で始めよう！'` (k25 / k21) の `${FREE_TERMS.start}で始めよう！` への部分参照化が妥当か（PR-2008 ctaBottomDesc の `7 日間の${CTA_TERMS.freeTrialNoun}で...` と同パターン）
- `'スタンダードの全機能'` (k54 / k50) の `${PLAN_TERMS.standard}の全機能` への部分参照化が妥当か（#1947 LP_PRICING_EXTRA_LABELS k19 と同パターン）
- `refactor:internal-no-doc-impact` ラベル exempt 対象としての適格性（src/lib/domain/labels.ts の compound 構造リファクタで、site/*.html visible テキスト変更ゼロ + shared-labels.js md5 一致）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（worktree 環境の biome 0 file 課題のため個別 Step で代替検証、上記「テスト & 安全装置セルフチェック」参照）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [N/A] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — 本 PR は UI 変更ゼロ（labels.ts compound 構造 refactor のみ）
- [N/A] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — 認証画面非関連

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
