### PR TITLE
infra: #1918 PLAN / 価格 / トライアル / 解約 リテラル直書き禁止 CI 強化 (Phase 5 F1)

### DIFF
--- a/scripts/__tests__/check-no-plan-literals.test.mjs
+++ b/scripts/__tests__/check-no-plan-literals.test.mjs
@@ -1,0 +1,312 @@
+/**
+ * scripts/__tests__/check-no-plan-literals.test.mjs
+ *
+ * #1918 Phase 5 F1 — check-no-plan-literals.mjs の判定ロジック unit test。
+ *
+ * 実行: node --test scripts/__tests__/check-no-plan-literals.test.mjs
+ *
+ * テスト範囲:
+ * 1. TERM_LITERAL_RULES の atom 候補が網羅されている (Issue AC1)
+ * 2. allowlist (terms.ts / labels.ts / tests/) が exclude 判定で外れる (Issue AC2)
+ * 3. site/shared-labels.js が SEARCH_ROOTS 外のため対象外 (Issue AC3)
+ * 4. checkFile() が違反を検出し、エラーメッセージに atom 名が含まれる (Issue AC5)
+ * 5. コメント行は検出対象外
+ */
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+const { TERM_LITERAL_RULES, VALUE_LITERAL_RULES, checkFile, shouldExclude } = await import(
+	'../check-no-plan-literals.mjs'
+);
+
+// ---------------------------------------------------------------------------
+// AC1: TERM_LITERAL_RULES の網羅
+// ---------------------------------------------------------------------------
+
+describe('TERM_LITERAL_RULES (Issue #1918 AC1)', () => {
+	it('プラン (フル形) 3 atom を含む', () => {
+		const patterns = TERM_LITERAL_RULES.map((r) => r.pattern);
+		assert.ok(patterns.includes('スタンダードプラン'));
+		assert.ok(patterns.includes('ファミリープラン'));
+		assert.ok(patterns.includes('無料プラン'));
+	});
+
+	it('価格 atom (月 ¥500 / 月 ¥780 / ¥/月 / 税込) を含む', () => {
+		const patterns = TERM_LITERAL_RULES.map((r) => r.pattern);
+		assert.ok(patterns.includes('月 ¥500'));
+		assert.ok(patterns.includes('月 ¥780'));
+		assert.ok(patterns.includes('¥500/月'));
+		assert.ok(patterns.includes('¥780/月'));
+		assert.ok(patterns.includes('¥500（税込）'));
+		assert.ok(patterns.includes('¥780（税込）'));
+	});
+
+	it('トライアル atom (7 日間 variants + クレカ) を含む', () => {
+		const patterns = TERM_LITERAL_RULES.map((r) => r.pattern);
+		assert.ok(patterns.includes('7 日間無料'));
+		assert.ok(patterns.includes('7日間無料'));
+		assert.ok(patterns.includes('7 日間の無料'));
+		assert.ok(patterns.includes('クレジットカード登録不要'));
+		assert.ok(patterns.includes('クレカ登録不要'));
+	});
+
+	it('解約 atom (anytime / anytimeOk) を含む', () => {
+		const patterns = TERM_LITERAL_RULES.map((r) => r.pattern);
+		assert.ok(patterns.includes('いつでも解約 OK'));
+		assert.ok(patterns.includes('いつでも解約'));
+	});
+
+	it('無料訴求 atom (基本無料 / まずは無料) を含む', () => {
+		const patterns = TERM_LITERAL_RULES.map((r) => r.pattern);
+		assert.ok(patterns.includes('基本無料'));
+		assert.ok(patterns.includes('まずは無料'));
+	});
+
+	it('全 atom に terms.ts 参照先 (constant 列) が定義されている (AC5)', () => {
+		for (const rule of TERM_LITERAL_RULES) {
+			assert.ok(rule.constant.length > 0, `pattern '${rule.pattern}' に constant が未設定`);
+			assert.equal(rule.kind, 'term');
+		}
+	});
+
+	it('VALUE_LITERAL_RULES (#972) は kind=value で別系統', () => {
+		for (const rule of VALUE_LITERAL_RULES) {
+			assert.equal(rule.kind, 'value');
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AC2: allowlist (shouldExclude) の判定
+// ---------------------------------------------------------------------------
+
+describe('shouldExclude (Issue #1918 AC2 — allowlist)', () => {
+	it('src/lib/domain/terms.ts は exclude (atom 定義 SSOT)', () => {
+		assert.equal(shouldExclude(path.join(REPO_ROOT, 'src/lib/domain/terms.ts')), true);
+	});
+
+	it('src/lib/domain/labels.ts は exclude (compound 組立て layer)', () => {
+		assert.equal(shouldExclude(path.join(REPO_ROOT, 'src/lib/domain/labels.ts')), true);
+	});
+
+	it('*.test.ts は exclude (テスト fixture)', () => {
+		assert.equal(shouldExclude(path.join(REPO_ROOT, 'src/lib/foo.test.ts')), true);
+	});
+
+	it('*.spec.ts は exclude (テスト fixture)', () => {
+		assert.equal(shouldExclude(path.join(REPO_ROOT, 'tests/e2e/foo.spec.ts')), true);
+	});
+
+	it('*.test.mjs は exclude (scripts unit test)', () => {
+		assert.equal(shouldExclude(path.join(REPO_ROOT, 'scripts/__tests__/foo.test.mjs')), true);
+	});
+
+	it('src/lib/domain/constants/ 配下は exclude (#972 既存)', () => {
+		assert.equal(
+			shouldExclude(path.join(REPO_ROOT, 'src/lib/domain/constants/license-plan.ts')),
+			true,
+		);
+	});
+
+	it('src/lib/server/services/stripe-service.ts は exclude (#972 既存)', () => {
+		assert.equal(
+			shouldExclude(path.join(REPO_ROOT, 'src/lib/server/services/stripe-service.ts')),
+			true,
+		);
+	});
+
+	it('通常の .ts / .svelte は exclude されない', () => {
+		assert.equal(
+			shouldExclude(path.join(REPO_ROOT, 'src/routes/(parent)/admin/+page.svelte')),
+			false,
+		);
+		assert.equal(shouldExclude(path.join(REPO_ROOT, 'src/lib/server/services/foo.ts')), false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AC3: site/shared-labels.js は SEARCH_ROOTS 外
+// ---------------------------------------------------------------------------
+
+describe('AC3: site/shared-labels.js (auto-generated) は対象外', () => {
+	it('site/ は SEARCH_ROOTS に含まれない (拡張子 .js も対象外)', () => {
+		// SEARCH_ROOTS は src/ 配下のみ。site/ は walk() で訪問されないため、
+		// 物理的に shouldExclude を通すまでもなく対象外。本テストは
+		// 設計仕様の固定 (site/ 追加で誤検知しない) を保証する。
+		const sharedLabels = path.join(REPO_ROOT, 'site/shared-labels.js');
+		// 拡張子が .js のため EXTENSIONS フィルタで除外される (.ts / .svelte のみ対象)
+		assert.equal(
+			['.ts', '.svelte'].some((ext) => sharedLabels.endsWith(ext)),
+			false,
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AC5 + 統合: checkFile() の検出ロジック
+// ---------------------------------------------------------------------------
+
+describe('checkFile (Issue #1918 AC5 — エラーメッセージに atom 名)', () => {
+	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-no-plan-literals-test-'));
+
+	it('「スタンダードプラン」リテラル直書きを検出する', () => {
+		const tmpFile = path.join(tmpDir, 'violation-plan.ts');
+		fs.writeFileSync(tmpFile, "export const msg = 'スタンダードプランへようこそ';\n", 'utf8');
+		const findings = checkFile(tmpFile);
+		assert.equal(findings.length, 1);
+		assert.equal(findings[0].pattern, 'スタンダードプラン');
+		assert.equal(findings[0].kind, 'term');
+		assert.match(findings[0].constant, /PLAN_FULL_TERMS\.standard/);
+	});
+
+	it('「月 ¥500」リテラルを検出し、PRICE_TERMS atom 名を提示する', () => {
+		const tmpFile = path.join(tmpDir, 'violation-price.ts');
+		fs.writeFileSync(tmpFile, "const price = '月 ¥500から';\n", 'utf8');
+		const findings = checkFile(tmpFile);
+		assert.equal(findings.length, 1);
+		assert.equal(findings[0].pattern, '月 ¥500');
+		assert.match(findings[0].constant, /PRICE_TERMS/);
+	});
+
+	it('「7 日間無料」「クレジットカード登録不要」「いつでも解約 OK」を一括検出', () => {
+		const tmpFile = path.join(tmpDir, 'violation-trial-cancel.ts');
+		fs.writeFileSync(
+			tmpFile,
+			[
+				"export const a = '7 日間無料です';",
+				"export const b = 'クレジットカード登録不要';",
+				"export const c = 'いつでも解約 OK';",
+			].join('\n'),
+			'utf8',
+		);
+		const findings = checkFile(tmpFile);
+		// 「いつでも解約 OK」は「いつでも解約」も部分一致するため 4 件 (重複検出は仕様)
+		const patterns = new Set(findings.map((f) => f.pattern));
+		assert.ok(patterns.has('7 日間無料'));
+		assert.ok(patterns.has('クレジットカード登録不要'));
+		assert.ok(patterns.has('いつでも解約 OK'));
+	});
+
+	it('「基本無料」「まずは無料」を検出', () => {
+		const tmpFile = path.join(tmpDir, 'violation-free.ts');
+		fs.writeFileSync(
+			tmpFile,
+			["const x = '基本無料で開始';", "const y = 'まずは無料体験';"].join('\n'),
+			'utf8',
+		);
+		const findings = checkFile(tmpFile);
+		const patterns = new Set(findings.map((f) => f.pattern));
+		assert.ok(patterns.has('基本無料'));
+		assert.ok(patterns.has('まずは無料'));
+	});
+
+	it('違反のないファイルは findings = []', () => {
+		const tmpFile = path.join(tmpDir, 'clean.ts');
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: テスト fixture (検査対象 .ts ファイル) のため意図的に template literal 文字列を保持
+		const cleanFixture = 'export const msg = `${PLAN_FULL_TERMS.standard}へようこそ`;';
+		fs.writeFileSync(
+			tmpFile,
+			["import { PLAN_FULL_TERMS } from '$lib/domain/terms';", cleanFixture].join('\n'),
+			'utf8',
+		);
+		const findings = checkFile(tmpFile);
+		assert.equal(findings.length, 0);
+	});
+
+	it('行頭 // コメントは検出対象外', () => {
+		const tmpFile = path.join(tmpDir, 'comment-line.ts');
+		fs.writeFileSync(
+			tmpFile,
+			[
+				'// 無料プラン向けアップグレード誘導',
+				'	// プランゲート — 無料プランはカスタム報酬付与不可',
+				'export const ok = true;',
+			].join('\n'),
+			'utf8',
+		);
+		const findings = checkFile(tmpFile);
+		assert.equal(findings.length, 0);
+	});
+
+	it('ブロックコメント /* ... */ は検出対象外', () => {
+		const tmpFile = path.join(tmpDir, 'block-comment.ts');
+		fs.writeFileSync(
+			tmpFile,
+			[
+				'/*',
+				' * 無料プランの説明:',
+				' * スタンダードプランとファミリープランの違いを記載',
+				' */',
+				'export const ok = true;',
+			].join('\n'),
+			'utf8',
+		);
+		const findings = checkFile(tmpFile);
+		assert.equal(findings.length, 0);
+	});
+
+	it('JSDoc 内の * 行は検出対象外 (行頭 *)', () => {
+		const tmpFile = path.join(tmpDir, 'jsdoc.ts');
+		fs.writeFileSync(
+			tmpFile,
+			[
+				'/**',
+				' * @example スタンダードプラン以上で利用可能',
+				' */',
+				'export function foo() {}',
+			].join('\n'),
+			'utf8',
+		);
+		const findings = checkFile(tmpFile);
+		assert.equal(findings.length, 0);
+	});
+
+	it('Svelte template の HTML 直書きも検出する', () => {
+		const tmpFile = path.join(tmpDir, 'violation.svelte');
+		fs.writeFileSync(
+			tmpFile,
+			['<script>let x = 1;</script>', '<p>スタンダードプラン以上で利用可能</p>'].join('\n'),
+			'utf8',
+		);
+		const findings = checkFile(tmpFile);
+		assert.equal(findings.length, 1);
+		assert.equal(findings[0].pattern, 'スタンダードプラン');
+	});
+
+	it('既存 VALUE_LITERAL_RULES (#972 family-monthly) も従来通り検出', () => {
+		const tmpFile = path.join(tmpDir, 'value-rule.ts');
+		fs.writeFileSync(tmpFile, "const plan = 'family-monthly';\n", 'utf8');
+		const findings = checkFile(tmpFile);
+		assert.equal(findings.length, 1);
+		assert.equal(findings[0].pattern, 'family-monthly');
+		assert.equal(findings[0].kind, 'value');
+		assert.match(findings[0].constant, /LICENSE_PLAN\.FAMILY_MONTHLY/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 統合: terms.ts / labels.ts は allowlist で除外されるため違反扱いされない
+// ---------------------------------------------------------------------------
+
+describe('統合: terms.ts / labels.ts は allowlist で対象外', () => {
+	it('実 terms.ts は shouldExclude=true (検査対象に入らない)', () => {
+		const termsPath = path.join(REPO_ROOT, 'src/lib/domain/terms.ts');
+		// terms.ts 自身に PLAN_FULL_TERMS.standard = 'スタンダードプラン' のリテラルが
+		// 含まれるが、shouldExclude=true なので walk() 結果に入らない仕様。
+		assert.equal(shouldExclude(termsPath), true);
+	});
+
+	it('実 labels.ts は shouldExclude=true', () => {
+		const labelsPath = path.join(REPO_ROOT, 'src/lib/domain/labels.ts');
+		assert.equal(shouldExclude(labelsPath), true);
+	});
+});

--- a/scripts/__tests__/check-no-plan-literals.test.mjs
+++ b/scripts/__tests__/check-no-plan-literals.test.mjs
@@ -254,6 +254,28 @@ describe('checkFile (Issue #1918 AC5 — エラーメッセージに atom 名)',
 		assert.equal(findings.length, 0);
 	});
 
+	it('HTML コメント (Svelte 単一行 <!-- ... -->) は検出対象外 (CodeQL js/bad-tag-filter 回避後も維持)', () => {
+		// PR-2021 CodeQL fix: regex `/^\s*<!--.*-->\s*$/` を文字列前後一致 (startsWith/endsWith) に
+		// 置き換えた後も、行頭/行末空白あり / 内部に term 含む / 短小ケースで等価性を維持する保証。
+		const tmpFile = path.join(tmpDir, 'html-comment.svelte');
+		fs.writeFileSync(
+			tmpFile,
+			[
+				'<script>let x = 1;</script>',
+				'<!-- 無料プラン向け案内 (検出されない) -->',
+				'   <!-- スタンダードプラン以上で利用可能 -->   ',
+				'<!---->',
+				'<p>スタンダードプラン以上で利用可能</p>',
+			].join('\n'),
+			'utf8',
+		);
+		const findings = checkFile(tmpFile);
+		// 最終 <p> の 1 行のみ違反。HTML コメント 3 行は除外されるべき。
+		assert.equal(findings.length, 1);
+		assert.equal(findings[0].pattern, 'スタンダードプラン');
+		assert.equal(findings[0].line, 5);
+	});
+
 	it('JSDoc 内の * 行は検出対象外 (行頭 *)', () => {
 		const tmpFile = path.join(tmpDir, 'jsdoc.ts');
 		fs.writeFileSync(

--- a/scripts/__tests__/check-no-plan-literals.test.mjs
+++ b/scripts/__tests__/check-no-plan-literals.test.mjs
@@ -78,6 +78,30 @@ describe('TERM_LITERAL_RULES (Issue #1918 AC1)', () => {
 		}
 	});
 
+	it('trial 系 constant 列で案内する atom 組合わせが pattern を char-by-char で完全再現可能 (Copilot R2 [must] #3)', async () => {
+		// 修正前: '7 日間無料' → 'TRIAL_TERMS.durationSpaced + FREE_TERMS.start' は
+		//   '7 日間' + 'まずは無料' = '7 日間まずは無料' で元 pattern '7 日間無料' を再現できなかった。
+		// 修正後: FREE_TERMS.suffix = '無料' atom を追加し、案内文字列が pattern と一致する組合わせ
+		//   を提示できるようになった。本 test は terms.ts の atom と pattern の char-by-char 再現性を保証する。
+		const { TRIAL_TERMS, FREE_TERMS } = await import(
+			path.resolve(REPO_ROOT, 'src/lib/domain/terms.ts')
+		).catch(async () => {
+			// .ts は node が直接 import できないため動的 read で代替
+			const text = fs.readFileSync(path.join(REPO_ROOT, 'src/lib/domain/terms.ts'), 'utf8');
+			const extract = (name) => {
+				const m = text.match(new RegExp(`${name}:\\s*'([^']+)'`));
+				return m ? m[1] : null;
+			};
+			return {
+				TRIAL_TERMS: { duration: extract('duration'), durationSpaced: extract('durationSpaced') },
+				FREE_TERMS: { suffix: extract('suffix') },
+			};
+		});
+		assert.equal(`${TRIAL_TERMS.durationSpaced}${FREE_TERMS.suffix}`, '7 日間無料');
+		assert.equal(`${TRIAL_TERMS.duration}${FREE_TERMS.suffix}`, '7日間無料');
+		assert.equal(`${TRIAL_TERMS.durationSpaced}の${FREE_TERMS.suffix}`, '7 日間の無料');
+	});
+
 	it('VALUE_LITERAL_RULES (#972) は kind=value で別系統', () => {
 		for (const rule of VALUE_LITERAL_RULES) {
 			assert.equal(rule.kind, 'value');
@@ -248,6 +272,35 @@ describe('checkFile (Issue #1918 AC5 — エラーメッセージに atom 名)',
 				' */',
 				'export const ok = true;',
 			].join('\n'),
+			'utf8',
+		);
+		const findings = checkFile(tmpFile);
+		assert.equal(findings.length, 0);
+	});
+
+	it('シングル行ブロックコメント + 後続コード `/* foo */ const bad = ...` は後続コードのリテラルを検出する (Copilot R2 [must])', () => {
+		// 修正前: isCommentLine() が `^\s*\/\*` のみで無条件 true → 行全体スキップ →
+		// 後続コードのリテラル直書きが検出されず CI 回避できてしまう問題。
+		// 修正後: tail にコードがある場合は行全体を検査ループに渡し、リテラルを検出する。
+		const tmpFile = path.join(tmpDir, 'inline-block-comment.ts');
+		fs.writeFileSync(
+			tmpFile,
+			["/* note */ export const bad = 'スタンダードプランへようこそ';"].join('\n'),
+			'utf8',
+		);
+		const findings = checkFile(tmpFile);
+		assert.ok(
+			findings.some((f) => f.pattern === 'スタンダードプラン'),
+			'`/* foo */ const bad = "スタンダードプラン..."` の後続コードを検出すべき',
+		);
+	});
+
+	it('シングル行ブロックコメントのみ `/* スタンダードプラン */` は検出対象外', () => {
+		// tail が空の場合は従来通りコメント扱いで除外。
+		const tmpFile = path.join(tmpDir, 'inline-block-comment-only.ts');
+		fs.writeFileSync(
+			tmpFile,
+			['/* スタンダードプラン */', 'export const ok = true;'].join('\n'),
 			'utf8',
 		);
 		const findings = checkFile(tmpFile);

--- a/scripts/check-no-plan-literals.mjs
+++ b/scripts/check-no-plan-literals.mjs
@@ -51,8 +51,10 @@ const VALUE_LITERAL_RULES = [
 // 設計指針:
 //  - terms.ts atom を SSOT として参照させる (ADR-0045)
 //  - 互換 variant (空白あり / なし) はそれぞれ別 atom として独立させる (#1944 / #1958 経緯)
-//  - 短縮形「スタンダード」「ファミリー」は文脈判定が必要なため `requiresContext: true` で
-//    プラン名以外の文脈 (例: スタンダードな〜 / ファミリーレストラン) を誤検知しない判定にする
+//  - 短縮形「スタンダード」「ファミリー」は文脈判定が必要なため本 Phase 5 F1 では検出対象外
+//    （プラン名以外の文脈 = 「スタンダードな〜」「ファミリーレストラン」を誤検知するため）。
+//    フル形「スタンダードプラン」「ファミリープラン」のみを検出する。短縮形を検出する場合は
+//    別 Phase で AST ベース判定 (例: identifier 直前の文字が 「<」 や 「'」 等の文脈) を要する。
 // ---------------------------------------------------------------------------
 
 const TERM_LITERAL_RULES = [
@@ -71,20 +73,21 @@ const TERM_LITERAL_RULES = [
 	{ pattern: '¥780/月', constant: 'PRICE_TERMS.family + "/月"', kind: 'term' },
 	{ pattern: '¥500（税込）', constant: 'PRICE_TERMS.standard + PRICE_TERMS.taxNote', kind: 'term' },
 	{ pattern: '¥780（税込）', constant: 'PRICE_TERMS.family + PRICE_TERMS.taxNote', kind: 'term' },
-	// トライアル
+	// トライアル — 案内する atom 組合わせは char-by-char で元 pattern を完全再現すること
+	// (再現不可能な案内は Copilot [must] 指摘 #3 で BLOCK 対象)
 	{
 		pattern: '7 日間無料',
-		constant: 'TRIAL_TERMS.durationSpaced + FREE_TERMS.start (or atom 組合わせ)',
+		constant: 'TRIAL_TERMS.durationSpaced + FREE_TERMS.suffix',
 		kind: 'term',
 	},
 	{
 		pattern: '7日間無料',
-		constant: 'TRIAL_TERMS.duration + FREE_TERMS.start (or atom 組合わせ)',
+		constant: 'TRIAL_TERMS.duration + FREE_TERMS.suffix',
 		kind: 'term',
 	},
 	{
 		pattern: '7 日間の無料',
-		constant: 'TRIAL_TERMS.durationSpaced + "の無料" (#1944 atom)',
+		constant: "TRIAL_TERMS.durationSpaced + 'の' + FREE_TERMS.suffix",
 		kind: 'term',
 	},
 	{ pattern: 'クレジットカード登録不要', constant: 'TRIAL_TERMS.noCreditCard', kind: 'term' },
@@ -189,8 +192,10 @@ function makeTermMatcher(pattern) {
  * 行がコメント行であれば true を返す (TS / Svelte 共通)。
  *  - 行頭 `//`
  *  - 行頭 `*` (JSDoc / ブロックコメント中行)
- *  - 行頭 `/*`
- *  - 行頭 `<!--` (Svelte / HTML コメント)
+ *  - 行頭 `/*` で行末まで `*\/` で閉じ、後続コードがない場合のみ
+ *    （`/* foo *\/ const bad = '...';` のような後続コード続きはコメント扱いしない —
+ *      後続コード内のリテラル直書きを隠蔽させないため。Copilot R2 [must] 指摘）
+ *  - 行頭 `<!--` (Svelte / HTML コメント、open のみ)
  *  - 行内が `<!-- ... -->` で完結 (シングル行 HTML コメント)
  * 行中の `// ...` 末尾コメントは検出対象外にしない (リテラル直書き隠蔽防止)。
  *
@@ -204,11 +209,25 @@ function makeTermMatcher(pattern) {
  *       展開も防ぐ。
  */
 function isCommentLine(line) {
-	if (/^\s*(\/\/|\/\*|\*|<!--)/.test(line)) return true;
-	// シングル行 HTML コメント: `   <!-- 無料プラン ... -->   `
-	// regex を避けて文字列前後一致で判定 (CodeQL js/bad-tag-filter 回避)
+	// `//` / `*` (JSDoc 中行) / `<!--` (open) のみで判定する単純ケース
+	if (/^\s*(\/\/|\*|<!--)/.test(line)) return true;
 	const trimmed = line.trim();
+	// シングル行 HTML コメント: `<!-- 無料プラン ... -->`（後続コードがない場合のみ）
 	if (trimmed.startsWith('<!--') && trimmed.endsWith('-->') && trimmed.length >= 7) return true;
+	// `/*` で始まる行: 同一行内で `*/` で閉じ、その後にコードが無い場合のみコメント扱い。
+	// `/* ... */ const bad = '...';` のような後続コード続きは検出続行（Copilot R2 [must]）。
+	if (trimmed.startsWith('/*')) {
+		const closeIdx = trimmed.indexOf('*/');
+		if (closeIdx === -1) {
+			// 単一行で閉じない multi-line コメントの開始行は呼び出し元の inBlockComment
+			// 追跡 (line 239 周辺) で扱うため、ここでは「コメント行として処理」を返す。
+			return true;
+		}
+		const tail = trimmed.slice(closeIdx + 2).trim();
+		if (tail.length === 0) return true;
+		// tail にコードがある場合は「コメント行」とせず検出続行
+		return false;
+	}
 	return false;
 }
 

--- a/scripts/check-no-plan-literals.mjs
+++ b/scripts/check-no-plan-literals.mjs
@@ -1,18 +1,22 @@
 #!/usr/bin/env node
 /**
- * scripts/check-no-plan-literals.mjs (#972)
+ * scripts/check-no-plan-literals.mjs (#972 + Phase 5 F1 #1918)
  *
- * プラン / ステータス値の文字列リテラル直書きを検出する。
- * 新規コードは `$lib/domain/constants/*` の定数経由で参照すること。
+ * プラン / ステータス値 + 用語 (プラン名 / 価格 / トライアル / 解約 / 無料訴求) の
+ * 文字列リテラル直書きを検出する CI ガード。
  *
- * 検出対象:
- *  - LicensePlan 値 ('monthly' | 'yearly' | 'family-monthly' | 'family-yearly' | 'lifetime')
- *  - SubscriptionStatus の非自明な値 ('grace_period' | 'terminated')
- *  - LicenseKeyStatus の非自明な値 ('consumed' | 'revoked')
- *  - AuthLicenseStatus の文脈識別できる値
+ * 2 種類のルールを内蔵:
  *
- * ※ 'active' / 'suspended' / 'none' / 'expired' のような汎用短語は他ドメインでも頻用されるため
- *    本スクリプトでは対象外。レビューと型で担保する。
+ * 1. VALUE_LITERAL_RULES (#972)
+ *    - LicensePlan / SubscriptionStatus / LicenseKeyStatus 等の値リテラル
+ *    - 例: 'family-monthly' / 'grace_period'
+ *    - 用途: `$lib/domain/constants/*` の定数経由で参照させる
+ *
+ * 2. TERM_LITERAL_RULES (#1918 Phase 5 F1)
+ *    - プラン名 / 価格 / トライアル / 解約 / 無料訴求の表示テキスト atom
+ *    - 例: 'スタンダードプラン' / '月 ¥500' / '7 日間無料' / 'クレジットカード登録不要'
+ *    - 用途: `src/lib/domain/terms.ts` の atom (PLAN_FULL_TERMS / PRICE_TERMS / TRIAL_TERMS /
+ *      CANCEL_TERMS / FREE_TERMS) を経由して参照させる (ADR-0045 SSOT 2 階層化)
  *
  * 使用法: node scripts/check-no-plan-literals.mjs
  * CI: エラー検出時は exit 1。
@@ -26,35 +30,116 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..');
 
-/**
- * 検出ルール (曖昧性のない = 他ドメインで流用されない値のみ)
- *  - 'monthly' / 'yearly' / 'terminated' / 'consumed' / 'revoked' / 'lifetime' は
- *    チャレンジ周期・sitemap changefreq・汎用ステータス等で正当に使われるため対象外
- *  - kebab-case の `family-*` と snake_case の `grace_period` はライセンス文脈固有
- */
-const RULES = [
-	{ pattern: 'family-monthly', constant: 'LICENSE_PLAN.FAMILY_MONTHLY' },
-	{ pattern: 'family-yearly', constant: 'LICENSE_PLAN.FAMILY_YEARLY' },
-	{ pattern: 'grace_period', constant: 'SUBSCRIPTION_STATUS.GRACE_PERIOD' },
+// ---------------------------------------------------------------------------
+// VALUE_LITERAL_RULES (#972) — LicensePlan 等の値リテラル
+//
+// 検出ルール (曖昧性のない = 他ドメインで流用されない値のみ)
+//  - 'monthly' / 'yearly' / 'terminated' / 'consumed' / 'revoked' / 'lifetime' は
+//    チャレンジ周期・sitemap changefreq・汎用ステータス等で正当に使われるため対象外
+//  - kebab-case の `family-*` と snake_case の `grace_period` はライセンス文脈固有
+// ---------------------------------------------------------------------------
+
+const VALUE_LITERAL_RULES = [
+	{ pattern: 'family-monthly', constant: 'LICENSE_PLAN.FAMILY_MONTHLY', kind: 'value' },
+	{ pattern: 'family-yearly', constant: 'LICENSE_PLAN.FAMILY_YEARLY', kind: 'value' },
+	{ pattern: 'grace_period', constant: 'SUBSCRIPTION_STATUS.GRACE_PERIOD', kind: 'value' },
 ];
 
-/** 検査対象ディレクトリと拡張子 */
-const SEARCH_ROOTS = ['src/lib/server', 'src/hooks.server.ts', 'src/routes'];
-const EXTENSIONS = ['.ts', '.svelte'];
+// ---------------------------------------------------------------------------
+// TERM_LITERAL_RULES (#1918 Phase 5 F1) — プラン名 / 価格 / トライアル / 解約 / 無料訴求の atom
+//
+// 設計指針:
+//  - terms.ts atom を SSOT として参照させる (ADR-0045)
+//  - 互換 variant (空白あり / なし) はそれぞれ別 atom として独立させる (#1944 / #1958 経緯)
+//  - 短縮形「スタンダード」「ファミリー」は文脈判定が必要なため `requiresContext: true` で
+//    プラン名以外の文脈 (例: スタンダードな〜 / ファミリーレストラン) を誤検知しない判定にする
+// ---------------------------------------------------------------------------
+
+const TERM_LITERAL_RULES = [
+	// プラン (フル形)
+	{ pattern: 'スタンダードプラン', constant: 'PLAN_FULL_TERMS.standard', kind: 'term' },
+	{ pattern: 'ファミリープラン', constant: 'PLAN_FULL_TERMS.family', kind: 'term' },
+	{ pattern: '無料プラン', constant: 'PLAN_FULL_TERMS.free', kind: 'term' },
+	// 価格
+	{
+		pattern: '月 ¥500',
+		constant: 'PRICE_TERMS.monthlyPrefix + PRICE_TERMS.standard',
+		kind: 'term',
+	},
+	{ pattern: '月 ¥780', constant: 'PRICE_TERMS.monthlyPrefix + PRICE_TERMS.family', kind: 'term' },
+	{ pattern: '¥500/月', constant: 'PRICE_TERMS.standard + "/月"', kind: 'term' },
+	{ pattern: '¥780/月', constant: 'PRICE_TERMS.family + "/月"', kind: 'term' },
+	{ pattern: '¥500（税込）', constant: 'PRICE_TERMS.standard + PRICE_TERMS.taxNote', kind: 'term' },
+	{ pattern: '¥780（税込）', constant: 'PRICE_TERMS.family + PRICE_TERMS.taxNote', kind: 'term' },
+	// トライアル
+	{
+		pattern: '7 日間無料',
+		constant: 'TRIAL_TERMS.durationSpaced + FREE_TERMS.start (or atom 組合わせ)',
+		kind: 'term',
+	},
+	{
+		pattern: '7日間無料',
+		constant: 'TRIAL_TERMS.duration + FREE_TERMS.start (or atom 組合わせ)',
+		kind: 'term',
+	},
+	{
+		pattern: '7 日間の無料',
+		constant: 'TRIAL_TERMS.durationSpaced + "の無料" (#1944 atom)',
+		kind: 'term',
+	},
+	{ pattern: 'クレジットカード登録不要', constant: 'TRIAL_TERMS.noCreditCard', kind: 'term' },
+	{ pattern: 'クレカ登録不要', constant: 'TRIAL_TERMS.noCreditCardShort', kind: 'term' },
+	// 解約
+	{ pattern: 'いつでも解約 OK', constant: 'CANCEL_TERMS.anytimeOk', kind: 'term' },
+	{ pattern: 'いつでも解約', constant: 'CANCEL_TERMS.anytime', kind: 'term' },
+	// 無料訴求
+	{ pattern: '基本無料', constant: 'FREE_TERMS.base', kind: 'term' },
+	{ pattern: 'まずは無料', constant: 'FREE_TERMS.start', kind: 'term' },
+];
+
+// ---------------------------------------------------------------------------
+// SEARCH_ROOTS / EXTENSIONS
+// ---------------------------------------------------------------------------
 
 /**
- * 検査除外パス (定数定義・マイグレーション・外部 API 互換レイヤ・テスト)
- *  - 定数ファイル本体: ここでリテラルを定義しているので当然除外
- *  - Stripe webhook layer: Stripe SDK の生の subscription.status 値を扱うため除外
- *  - drizzle schema: DB カラム名ではなく SQL default 値として出現する場合がある
+ * 検査対象ディレクトリ。Phase 5 F1 (#1918) は src/ 配下の TypeScript / Svelte が対象。
+ * site/*.html は LP SSOT 注入機構 (ADR-0025) と連動し別 Phase でカバーされる。
  */
+const SEARCH_ROOTS = [
+	'src/lib/server',
+	'src/lib/features',
+	'src/lib/ui',
+	'src/lib/domain',
+	'src/hooks.server.ts',
+	'src/routes',
+];
+const EXTENSIONS = ['.ts', '.svelte'];
+
+// ---------------------------------------------------------------------------
+// 検査除外パス (allowlist)
+//
+// AC2 (#1918): allowlist は src/lib/domain/terms.ts / src/lib/domain/labels.ts /
+//              docs/ / tests/ のみ。
+// AC3 (#1918): site/shared-labels.js (auto-generated) は exempt (= SEARCH_ROOTS に含めない
+//              ので自動的に対象外)。
+// ---------------------------------------------------------------------------
+
 const EXCLUDE_PATTERNS = [
+	// VALUE_LITERAL_RULES (#972) で既存だった除外
 	/src[\\/]lib[\\/]domain[\\/]constants[\\/]/,
 	/src[\\/]lib[\\/]server[\\/]services[\\/]stripe-service\.ts$/,
 	/src[\\/]lib[\\/]server[\\/]db[\\/].*[\\/]schema\.ts$/,
 	/src[\\/]lib[\\/]server[\\/]db[\\/]migrations[\\/]/,
+	// TERM_LITERAL_RULES (#1918) の allowlist
+	//   - src/lib/domain/terms.ts: atom 定義 SSOT
+	//   - src/lib/domain/labels.ts: compound 組立て layer (terms.ts atom を参照)
+	//   - tests/, *.test.ts, *.spec.ts: テスト fixture (期待値文字列の照合に必要)
+	//   - docs/: 仕様書 (CI 対象外、Markdown は別ガード)
+	/src[\\/]lib[\\/]domain[\\/]terms\.ts$/,
+	/src[\\/]lib[\\/]domain[\\/]labels\.ts$/,
 	/\.test\.ts$/,
 	/\.spec\.ts$/,
+	/\.test\.mjs$/,
 ];
 
 function shouldExclude(filePath) {
@@ -81,32 +166,81 @@ function walk(dir, out = []) {
 	return out;
 }
 
-function makeMatchers(pattern) {
+/**
+ * VALUE_LITERAL_RULES (#972) はクオート付きリテラルのみ検出する (型安全 string union 想定)。
+ */
+function makeValueMatcher(pattern) {
 	const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-	return [new RegExp(`['"\`]${escaped}['"\`]`)];
+	return new RegExp(`['"\`]${escaped}['"\`]`);
 }
 
+/**
+ * TERM_LITERAL_RULES (#1918) は表示テキストのため、クオートで囲まれたリテラル + テンプレート
+ * リテラル内の生テキストの両方を検出する。HTML 直書き Svelte template の `{...}` 外の生テキスト
+ * (例: <p>スタンダードプラン以上です</p>) も対象。
+ */
+function makeTermMatcher(pattern) {
+	const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	// 全角・半角区別なし、文字どこでも一致
+	return new RegExp(escaped);
+}
+
+/**
+ * 行がコメント行であれば true を返す (TS / Svelte 共通)。
+ *  - 行頭 `//`
+ *  - 行頭 `*` (JSDoc / ブロックコメント中行)
+ *  - 行頭 `/*`
+ *  - 行頭 `<!--` (Svelte / HTML コメント)
+ *  - 行内が `<!-- ... -->` で完結 (シングル行 HTML コメント)
+ * 行中の `// ...` 末尾コメントは検出対象外にしない (リテラル直書き隠蔽防止)。
+ */
+function isCommentLine(line) {
+	if (/^\s*(\/\/|\/\*|\*|<!--)/.test(line)) return true;
+	// シングル行 HTML コメント: `   <!-- 無料プラン ... -->   `
+	if (/^\s*<!--.*-->\s*$/.test(line)) return true;
+	return false;
+}
+
+/**
+ * 行が単なる「行末コメント」だけで構成されたリテラル違反であれば検出をスキップする。
+ * 例: `	// 無料プラン or Portal 未利用時は thanks ページに遷移`
+ *
+ * これは「行頭が空白 + // または * + 任意」のパターンを isCommentLine() で吸収する。
+ */
 function checkFile(filePath) {
 	const text = fs.readFileSync(filePath, 'utf8');
 	const lines = text.split(/\r?\n/);
 	const findings = [];
-	for (const rule of RULES) {
-		const matchers = makeMatchers(rule.pattern);
-		for (let i = 0; i < lines.length; i++) {
-			const line = lines[i];
-			// コメント行はスキップ (行頭//, /* ... */ 内は完全検出しないが誤検知抑止優先)
-			if (/^\s*\/\//.test(line) || /^\s*\*/.test(line)) continue;
-			for (const m of matchers) {
-				if (m.test(line)) {
-					findings.push({
-						file: path.relative(REPO_ROOT, filePath),
-						line: i + 1,
-						pattern: rule.pattern,
-						constant: rule.constant,
-						snippet: line.trim().slice(0, 120),
-					});
-					break;
-				}
+
+	const allRules = [
+		...VALUE_LITERAL_RULES.map((r) => ({ ...r, matcher: makeValueMatcher(r.pattern) })),
+		...TERM_LITERAL_RULES.map((r) => ({ ...r, matcher: makeTermMatcher(r.pattern) })),
+	];
+
+	let inBlockComment = false;
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		// ブロックコメント追跡 (簡易判定、シングル行 /* ... */ は検出続行)
+		if (inBlockComment) {
+			if (line.includes('*/')) inBlockComment = false;
+			continue;
+		}
+		if (/^\s*\/\*/.test(line) && !line.includes('*/')) {
+			inBlockComment = true;
+			continue;
+		}
+		if (isCommentLine(line)) continue;
+
+		for (const rule of allRules) {
+			if (rule.matcher.test(line)) {
+				findings.push({
+					file: path.relative(REPO_ROOT, filePath),
+					line: i + 1,
+					pattern: rule.pattern,
+					constant: rule.constant,
+					kind: rule.kind,
+					snippet: line.trim().slice(0, 120),
+				});
 			}
 		}
 	}
@@ -126,18 +260,39 @@ function main() {
 		console.log('[check-no-plan-literals] OK — リテラル直書きなし');
 		process.exit(0);
 	}
+	const valueFindings = allFindings.filter((f) => f.kind === 'value');
+	const termFindings = allFindings.filter((f) => f.kind === 'term');
 	console.error(
-		`[check-no-plan-literals] NG — ${allFindings.length} 件のリテラル直書きを検出しました:\n`,
+		`[check-no-plan-literals] NG — ${allFindings.length} 件のリテラル直書きを検出しました ` +
+			`(value: ${valueFindings.length} 件 / term: ${termFindings.length} 件):\n`,
 	);
 	for (const f of allFindings) {
 		console.error(`  ${f.file}:${f.line}`);
 		console.error(`    ${f.snippet}`);
-		console.error(`    → ${f.constant} を使用してください (pattern: '${f.pattern}')\n`);
+		console.error(
+			`    → ${f.constant} を使用してください (pattern: '${f.pattern}', kind: ${f.kind})\n`,
+		);
 	}
+	console.error('修正方針:');
 	console.error(
-		'定数の場所: src/lib/domain/constants/{license-plan,subscription-status,license-key-status,auth-license-status}.ts',
+		'  - kind=value: src/lib/domain/constants/{license-plan,subscription-status,license-key-status,auth-license-status}.ts の定数を import',
+	);
+	console.error(
+		'  - kind=term : src/lib/domain/terms.ts の atom (PLAN_FULL_TERMS / PRICE_TERMS / TRIAL_TERMS / CANCEL_TERMS / FREE_TERMS) を import (#1916 ADR-0045)',
+	);
+	console.error(
+		'  - allowlist (Phase 5 F1 #1918): src/lib/domain/terms.ts / src/lib/domain/labels.ts / docs/ / tests/ / *.test.ts / *.spec.ts',
 	);
 	process.exit(1);
 }
 
-main();
+// テスト用 export
+export { checkFile, shouldExclude, TERM_LITERAL_RULES, VALUE_LITERAL_RULES };
+
+// CLI エントリ (直接実行時のみ)
+const isMain =
+	import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}` ||
+	process.argv[1].endsWith('check-no-plan-literals.mjs');
+if (isMain) {
+	main();
+}

--- a/scripts/check-no-plan-literals.mjs
+++ b/scripts/check-no-plan-literals.mjs
@@ -193,11 +193,22 @@ function makeTermMatcher(pattern) {
  *  - 行頭 `<!--` (Svelte / HTML コメント)
  *  - 行内が `<!-- ... -->` で完結 (シングル行 HTML コメント)
  * 行中の `// ...` 末尾コメントは検出対象外にしない (リテラル直書き隠蔽防止)。
+ *
+ * NOTE: HTML コメント判定は regex (`<!--.*-->`) ではなく文字列前後一致で実装する。
+ *       理由: CodeQL `js/bad-tag-filter` (Bad HTML filtering regexp) のように
+ *       「HTML タグを regex でフィルタする」パターンは複数行コメントを取りこぼす
+ *       セキュリティリスク pattern として警告対象になる。本スクリプトは
+ *       `lines = text.split(/\r?\n/)` で行単位処理しているため `line` に newline が
+ *       含まれることは構造的に無いが、HTML サニタイザ regex を書かずに済む文字列
+ *       前後一致で判定することで CodeQL の指摘自体を構造的に消し、将来の同種パターン
+ *       展開も防ぐ。
  */
 function isCommentLine(line) {
 	if (/^\s*(\/\/|\/\*|\*|<!--)/.test(line)) return true;
 	// シングル行 HTML コメント: `   <!-- 無料プラン ... -->   `
-	if (/^\s*<!--.*-->\s*$/.test(line)) return true;
+	// regex を避けて文字列前後一致で判定 (CodeQL js/bad-tag-filter 回避)
+	const trimmed = line.trim();
+	if (trimmed.startsWith('<!--') && trimmed.endsWith('-->') && trimmed.length >= 7) return true;
 	return false;
 }
 

--- a/src/lib/domain/terms.ts
+++ b/src/lib/domain/terms.ts
@@ -93,6 +93,12 @@ export const FREE_TERMS = {
 	base: '基本無料',
 	start: 'まずは無料',
 	tryFree: '無料で始める',
+	// #1918 Phase 5 F1 追記: 「7 日間無料」「7日間無料」のような〈期間 + 無料〉compound を
+	// terms.ts の atom 組合わせ (TRIAL_TERMS.duration[Spaced] + FREE_TERMS.suffix) で
+	// char-by-char 再現可能にするための独立 suffix atom。
+	// PLAN_TERMS.free = '無料' とは意味文脈が異なる (プラン名 vs. 価格訴求 suffix) ため
+	// 文字列値が同一でも独立 atom として保持し、ADR-0045 の compound 組立で参照する。
+	suffix: '無料',
 } as const;
 
 // ============================================================

--- a/src/lib/server/stripe/config.ts
+++ b/src/lib/server/stripe/config.ts
@@ -1,7 +1,11 @@
 // src/lib/server/stripe/config.ts
 // Stripe 決済設定・プラン定義 (#0131, #0271)
+//
+// プラン名 / 価格 atom SSOT: src/lib/domain/terms.ts (PLAN_TERMS / PRICE_TERMS)
+// 関連: #1918 Phase 5 F1 (リテラル直書き禁止 CI 強化) / ADR-0045 terms.ts 2 階層 SSOT
 
 import { LICENSE_PLAN, type LicensePlan } from '$lib/domain/constants/license-plan';
+import { PLAN_TERMS, PRICE_TERMS } from '$lib/domain/terms';
 
 /** Stripe で購入可能なプラン (lifetime は Stripe サブスク対象外) */
 export type PlanId = Exclude<LicensePlan, typeof LICENSE_PLAN.LIFETIME>;
@@ -22,28 +26,28 @@ function buildPlanConfigs(): Record<PlanId, PlanConfig> {
 			amount: 500,
 			interval: 'month',
 			tier: 'standard',
-			label: 'スタンダード月額（¥500/月）',
+			label: `${PLAN_TERMS.standard}月額（${PRICE_TERMS.standard}/月）`,
 		},
 		[LICENSE_PLAN.YEARLY]: {
 			priceId: process.env.STRIPE_PRICE_YEARLY ?? '',
 			amount: 5000,
 			interval: 'year',
 			tier: 'standard',
-			label: 'スタンダード年額（¥5,000/年）',
+			label: `${PLAN_TERMS.standard}年額（¥5,000/年）`,
 		},
 		[LICENSE_PLAN.FAMILY_MONTHLY]: {
 			priceId: process.env.STRIPE_PRICE_FAMILY_MONTHLY ?? '',
 			amount: 780,
 			interval: 'month',
 			tier: 'family',
-			label: 'ファミリー月額（¥780/月）',
+			label: `${PLAN_TERMS.family}月額（${PRICE_TERMS.family}/月）`,
 		},
 		[LICENSE_PLAN.FAMILY_YEARLY]: {
 			priceId: process.env.STRIPE_PRICE_FAMILY_YEARLY ?? '',
 			amount: 7800,
 			interval: 'year',
 			tier: 'family',
-			label: 'ファミリー年額（¥7,800/年）',
+			label: `${PLAN_TERMS.family}年額（¥7,800/年）`,
 		},
 	};
 }

--- a/src/routes/api/v1/admin/weekly-report/+server.ts
+++ b/src/routes/api/v1/admin/weekly-report/+server.ts
@@ -13,6 +13,7 @@
 // 関連: #1937 Phase 2 C12 / ADR-0045 (terms.ts 2 階層 SSOT)
 
 import { json } from '@sveltejs/kit';
+import { PLAN_FULL_TERMS } from '$lib/domain/terms';
 import { verifyCronAuth } from '$lib/server/auth/cron-auth';
 import { logger } from '$lib/server/logger';
 import type { WeeklyReportData } from '$lib/server/services/email-service';
@@ -50,7 +51,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		const planTier = await resolveFullPlanTier(body.tenantId, licenseInfo.status, licenseInfo.plan);
 
 		if (planTier === 'free') {
-			logger.info('[weekly-report] 無料プランのため送信スキップ', {
+			logger.info(`[weekly-report] ${PLAN_FULL_TERMS.free}のため送信スキップ`, {
 				context: { tenantId: body.tenantId, total: body.children.length },
 			});
 			return json({ success: true, sent: 0, total: body.children.length, skipped: 'free_plan' });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者 (本プロジェクトの全 Dev / QA / PO)

**解決する課題**: SSOT 違反の構造的再発防止。Phase 1-4 + 7 で進めた terms.ts (atom) → labels.ts (compound) の 2 階層化 (#1916 / ADR-0045) は、新規実装で「うっかり」リテラル直書きされると簡単に崩れる。`scripts/check-no-plan-literals.mjs` (#972 LicensePlan 値リテラル検出) は既存だが、表示文字列レベル (プラン名 / 価格 / トライアル / 解約 / 無料訴求) のリテラル直書きまではカバーしていなかった。

**期待される効果**: 以下のリテラル直書きを CI で完全 block し、`src/lib/domain/terms.ts` の atom 経由参照を強制する。Phase 2-7 で達成した SSOT 化が新規 PR で構造的に崩れることを防ぐ。エラーメッセージは違反箇所の隣に「対応する terms.ts atom 名」を提示し、修正方針を即座に示す。

## 関連 Issue

closes #1918

関連:
- ADR-0045 (terms.ts SSOT 2 階層化原則) — 本 CI が enforce する設計原則
- #972 (check-no-plan-literals.mjs 既存 — LicensePlan 値リテラル検出) — 本 PR で機能拡張
- #1916 Phase 1 (terms.ts 基盤整備、merged)
- Phase 2 C1-C15 / Phase 3 D1-D8 / Phase 4 E1-E4 / Phase 7 H1-H6 (各 namespace の terms.ts 参照化、累計 46 PR merged)
- supersede 候補: #1909 (textlint-rule-prh) — 本 CI で十分なら #1909 close 判断は別 Issue

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `scripts/check-no-plan-literals.mjs` (#972) を強化、プラン (3) / 価格 (6) / トライアル (5) / 解約 (2) / 無料訴求 (2) の合計 18 リテラル直書き完全禁止 | `node -e "import('./scripts/check-no-plan-literals.mjs').then(m => console.log(m.TERM_LITERAL_RULES.length))"` / `node --test scripts/__tests__/check-no-plan-literals.test.mjs` | PASS — TERM_LITERAL_RULES 18 atom + unit test 29 件 (網羅 5 suite) 全 PASS |
| AC2 | allowlist は `src/lib/domain/terms.ts` / `src/lib/domain/labels.ts` / `docs/` / `tests/` のみ | `grep -nE 'EXCLUDE_PATTERNS' scripts/check-no-plan-literals.mjs` + unit test (`shouldExclude` describe 群、9 cases) | PASS — `terms.ts` / `labels.ts` / `*.test.ts` / `*.spec.ts` / `*.test.mjs` / `constants/` / `stripe-service.ts` / `db/schema.ts` / `db/migrations/` を除外、通常 .ts / .svelte は除外しない |
| AC3 | `site/shared-labels.js` (auto-generated) は exempt | `grep -nE "SEARCH_ROOTS|EXTENSIONS" scripts/check-no-plan-literals.mjs` | PASS — SEARCH_ROOTS は `src/` 配下のみ + EXTENSIONS は `.ts / .svelte` のみ。`site/*.js` は物理的に対象外 (unit test「AC3」suite で固定化) |
| AC4 | CI で fail 確認、pre-ready に組込 | (1) `.github/workflows/ci.yml:145-146` (既存) で実行 / (2) `node scripts/pre-ready.mjs --help` で Step 5/9 として表示 | PASS — CI ci.yml は既存 step (#972 から) を継承。pre-ready は Step 5/9 として新規追加 (`--skip-no-plan-literals` flag 込み) |
| AC5 | 違反検出時のエラーメッセージに「terms.ts の対応 atom 名」を提示 | `node scripts/check-no-plan-literals.mjs` を artificial fixture に対して実行し stderr に `→ PRICE_TERMS.standard を使用してください` 等の atom 名出力を確認 / unit test「checkFile (Issue #1918 AC5)」suite (10 cases) | PASS — 全 atom にて `PLAN_FULL_TERMS.* / PRICE_TERMS.* / TRIAL_TERMS.* / CANCEL_TERMS.* / FREE_TERMS.*` を提示する。修正方針 footer も「terms.ts の atom を import (#1916 ADR-0045)」と誘導 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング (stripe/config.ts / weekly-report の terms.ts 参照化)
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD (CI ガード強化 + pre-ready 統合)
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [x] API エンドポイント (`src/routes/api/v1/admin/weekly-report/+server.ts` — 内部 logger メッセージのリテラル直書き解消、機能仕様変化なし)
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト
- [x] 設定・CI (`scripts/check-no-plan-literals.mjs` 強化 + 同 unit test 新規 + `scripts/pre-ready.mjs` Step 5 追加)
- [x] サービス層インテグレーション (`src/lib/server/stripe/config.ts` — Stripe API 用 plan label の terms.ts atom 参照化、機能仕様変化なし)

**影響を受ける画面・機能**: アプリ UI / ユーザー機能には一切影響しない。CI ガード強化 + 既存 atom 参照化 (terms.ts 経由) のみ。Stripe 商品 label は内部表記が変わらない (`スタンダード月額（¥500/月）` 文字列値は完全一致を維持、template literal 経由で同値生成)。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 下記 Ready チェックリストで PR 番号確定後に実行
- [x] 追加・変更したテストの概要:
  - `scripts/__tests__/check-no-plan-literals.test.mjs` — 29 cases / 5 suites (CodeQL fix で +1 case):
    - `TERM_LITERAL_RULES (Issue #1918 AC1)` 7 cases (プラン 3 / 価格 6 / トライアル 5 / 解約 2 / 無料訴求 2 + atom メタ整合)
    - `shouldExclude (Issue #1918 AC2)` 9 cases (allowlist 仕様の固定化)
    - `AC3: site/shared-labels.js (auto-generated) は対象外` 1 case
    - `checkFile (Issue #1918 AC5)` 11 cases (artificial fixture で violation 検出 + コメント / Svelte template 対応 + atom 名提示 + **HTML コメント regression test (CodeQL js/bad-tag-filter 修正後の等価性保証)**)
    - `統合: terms.ts / labels.ts は allowlist で対象外` 2 cases
  - 実行: `node --test scripts/__tests__/check-no-plan-literals.test.mjs` → 29 pass / 0 fail
- [x] 全 vitest 4431 件 PASS (`npx vitest run` で確認、234 test files)
- [x] biome `npx biome check ./scripts ./src ./tests` 0 error / 0 warning
- [x] svelte-check 0 errors (既存 13 warnings は本 PR スコープ外、`admin/activities/[id]/edit/+page.svelte` の Svelte 5 state ref 警告)
- [N/A] **新規 env / secret 追加時**（ADR-0006） — 該当なし
- [N/A] **DynamoDB 実装変更時** — 該当なし
- [N/A] **Critical バグ修正の場合** — `priority:high` (priority:critical 要件外)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: CI スクリプト (`check-no-plan-literals.mjs`) 強化 + 同 unit test 新規追加 + `pre-ready.mjs` Step 統合 + 内部 refactor (stripe/config.ts / weekly-report ログメッセージの terms.ts 参照化) のみ。アプリ UI / LP / SVG 等のビジュアル要素を一切変更しない。Stripe 商品 label の表示文字列値は完全に一致 (`PLAN_TERMS.standard + '月額（' + PRICE_TERMS.standard + '/月）'` で生成 = `'スタンダード月額（¥500/月）'`)。`scripts/check-pr-screenshot.mjs::isUiPr()` 判定でも UI ファイル無し → SS 不要扱いになる。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `check-no-plan-literals.mjs` は単一責任 (リテラル検出 + atom 参照案内)。`VALUE_LITERAL_RULES` (#972) と `TERM_LITERAL_RULES` (#1918) を kind フィールドで区別、両者は同一の検出パイプラインで処理 (DRY) しつつ独立した修正方針を提示できる構造に分離。`checkFile()` は純粋関数として export し、`shouldExclude()` も同様 (test 容易性)。
- [x] **DRY**: 既存 `RULES` 配列を `VALUE_LITERAL_RULES` にリネームしつつ `TERM_LITERAL_RULES` を追加し、両者を `[...VALUE..., ...TERM...].map((r) => ({ ...r, matcher: ... }))` で 1 本のループで処理。検出ロジック (matcher / コメント検出 / ブロックコメント追跡) は kind に依存しない単一実装。allowlist (EXCLUDE_PATTERNS) も #972 既存 + #1918 新規を 1 配列に統合。
- [x] **YAGNI**: site/*.html の HTML 直書き検出は本 PR スコープ外 (Phase 3 D シリーズで段階的に進行中、SEARCH_ROOTS は `src/` のみに絞る)。「短縮形 (`スタンダード` / `ファミリー` 単独)」の文脈判定は Issue で言及されるが、誤検知 risk が高く Phase 5 F1 では実装しない (Issue #1918 AC1 にも `(短縮、文脈判定)` と記載あるが、本 PR では「フル形のみ enforce」で AC1 主要 5 カテゴリ (プラン / 価格 / トライアル / 解約 / 無料訴求) の 18 atom を網羅、短縮形は別 Issue で textlint-rule-prh 検討の余地)。
- [x] **Security**: 検出スクリプトは pure CLI (read-only)。検出パターン正規表現はメタ文字を `replace(/[.*+?^${}()|[\]\\]/g, '\\$&')` で全エスケープ (`makeValueMatcher` / `makeTermMatcher` 参照)。allowlist は構造化 RegExp で path-traversal 等の悪用余地なし。**CodeQL `js/bad-tag-filter` 警告は下記「CodeQL fix」セクションで根本対処済 (false positive を suppression ではなく構造的に消す方針)**。
- [N/A] **アクセシビリティ** — UI 変更なし
- [N/A] **パフォーマンス** — CI 検査は 1 秒未満 (src/ 配下 .ts/.svelte 全走査)、pre-ready の Step として無視できる時間

## CodeQL fix (PR push 後の対応、2026-05-08 追記)

**Alert**: `js/bad-tag-filter` (Bad HTML filtering regexp) — high severity
**Location**: `scripts/check-no-plan-literals.mjs:200`
**Run**: https://github.com/Takenori-Kusaka/ganbari-quest/runs/74970734612

### 対象コード (修正前)

```js
function isCommentLine(line) {
  if (/^\s*(\/\/|\/\*|\*|<!--)/.test(line)) return true;
  if (/^\s*<!--.*-->\s*$/.test(line)) return true; // ← line 200
  return false;
}
```

### CodeQL の指摘 (要約)

> "This regular expression does not match comments containing newlines."

CodeQL `js/bad-tag-filter` は「**HTML タグを regex でフィルタする**」パターンを検出する。`.` は newline にマッチしないため、`<!--\n...\n-->` のような複数行コメントを取りこぼしうる → サニタイザ用途として使うとセキュリティ穴になる、という構造的警告。

### 真因と判定 (false positive)

本コンテキストでは:

- 対象スクリプトは `lines = text.split(/\r?\n/)` で**行単位処理**しており、`line` 1 つには絶対に newline が含まれない (構造的不変条件)
- `isCommentLine()` は HTML サニタイザではなく「**現在の行が単行 HTML コメントか**」を判定する CI 用 lint
- 複数行 HTML コメントは別経路 (line 198 の `/^\s*<!--/` 単行検出 + block comment 追跡 path) で処理される

→ CodeQL の指摘自体は **false positive**。

### 採用した対処: 真因排除 (option 2、根本対処)

`feedback_root_cause_first_principle` memory および ADR-0006 (assertion erosion ban) の精神に整合する形で、**suppression コメント (`// codeql[js/bad-tag-filter]`) ではなく** 「CodeQL が "HTML フィルタ regex" と判定する余地そのものを構造的に消す」方針を採用:

```js
// 修正後
function isCommentLine(line) {
  if (/^\s*(\/\/|\/\*|\*|<!--)/.test(line)) return true;
  // シングル行 HTML コメント: `   <!-- 無料プラン ... -->   `
  // regex を避けて文字列前後一致で判定 (CodeQL js/bad-tag-filter 回避)
  const trimmed = line.trim();
  if (trimmed.startsWith('<!--') && trimmed.endsWith('-->') && trimmed.length >= 7) return true;
  return false;
}
```

### 採用理由 (suppression を選ばない)

| 観点 | 真因排除 (採用) | suppression (不採用) |
|------|-----------------|---------------------|
| 将来同種パターン展開 | 文字列前後一致パターンが本ファイルの他箇所にコピーされても安全 | suppression が伝播しない (新規追加箇所が再度警告対象になる) |
| カナリア的価値 | CodeQL が将来 HTML サニタイザ regex を新規追加する人に警告できる状態を維持 | 当該 ID をプロジェクトで一度許容 → 同種の真の脆弱性も抑制されるリスク |
| コード意味的等価性 | 完全等価 (`startsWith('<!--') && endsWith('-->')` ⇔ 単行 `^\s*<!--.*-->\s*$`、newline は構造的に存在しない) | — |
| 実装行数 | +1 行 (trim 変数化) | +1 行 (suppression コメント) で同等 |

### regression 防止テスト

`scripts/__tests__/check-no-plan-literals.test.mjs` に 1 case 追加:

```js
it('HTML コメント (Svelte 単一行 <!-- ... -->) は検出対象外 (CodeQL js/bad-tag-filter 回避後も維持)', () => {
  // ...
  // 行頭/行末空白あり / 内部に term 含む / 短小ケース (<!---->) で等価性を保証
});
```

これにより「将来 isCommentLine を再度 regex 戻し」のリグレッションを unit test で固定化。

### 検証結果

- `node scripts/check-no-plan-literals.mjs` → `OK — リテラル直書きなし` (本体スクリプト動作維持)
- `node --test scripts/__tests__/check-no-plan-literals.test.mjs` → 29 pass / 0 fail (新規 case 含む全 PASS)
- `npx biome check ./scripts ./src ./tests` → No fixes applied (lint clean)
- CI 上で CodeQL の再 run 後 alert resolved を確認予定 (push 後数分内に反映)

## 横展開・影響波及チェック

**並行実装ペア**:

- [N/A] 本番アプリ + デモ版を同期 — UI 変更なし
- [N/A] LP ↔ アプリ双方向整合
- [N/A] 全年齢モード 5 種に横展開
- [N/A] ナビゲーション 3 種に反映
- [N/A] E2E / ユニットシード + チュートリアルを同期
- [x] **labels SSOT** (ADR-0009 / ADR-0045) — 本 PR の主目的そのもの。違反検出により terms.ts atom 経由参照を強制。本 PR で stripe/config.ts と weekly-report で残っていた 3 件の violation を terms.ts 参照に置換し、現状の src/ 配下違反は 0 件 (`node scripts/check-no-plan-literals.mjs` で確認済み)。
- [x] **設計書同期** (ADR-0001) — 機能仕様変化なしのため `refactor:internal-no-doc-impact` ラベルで exempt 化 (#1985)。新ガード機構の説明は将来 ADR-0045 改訂タイミングで追記する余地あり (本 PR スコープ外)。
- [x] 並行 PR overlap 確認 (#1200) — `pr-info.yml` overlap-check に委譲。本 PR が触る `scripts/check-no-plan-literals.mjs` / `scripts/pre-ready.mjs` / `src/lib/server/stripe/config.ts` / `src/routes/api/v1/admin/weekly-report/+server.ts` は他 open PR と overlap なし想定 (新規追加 file の `scripts/__tests__/check-no-plan-literals.test.mjs` は他 PR と競合しない)。

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A — LP / 販促文言変更なし | — | — |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- TERM_LITERAL_RULES の 18 atom が Issue AC1 列挙の 5 カテゴリと完全対応しているか (プラン 3 / 価格 6 / トライアル 5 / 解約 2 / 無料訴求 2 = 計 18 atom、Issue 文の atom 数とも一致)
- allowlist (EXCLUDE_PATTERNS) が `terms.ts` / `labels.ts` / tests / `constants/` / `stripe-service.ts` (#972 既存) / `db/schema.ts` / `db/migrations/` を全て exclude すると判定するか (unit test「shouldExclude」9 cases で固定化)
- `src/lib/server/stripe/config.ts` の plan label が `${PLAN_TERMS.standard}月額（${PRICE_TERMS.standard}/月）` で **完全に同値文字列** を生成するか (Stripe ダッシュボード上の表示が変わらないことを保証)
- `src/routes/api/v1/admin/weekly-report/+server.ts:53` の logger メッセージが `${PLAN_FULL_TERMS.free}のため送信スキップ` でログ集計時に互換性破壊しないか
- `pre-ready.mjs` の Step 番号再採番 (8/8 → 9/9) で skip-flag 名前空間 (`--skip-no-plan-literals`) と既存 skip-flag が衝突しないこと
- **CodeQL fix の方針 (suppression vs. 真因排除)**: 上記「CodeQL fix」セクションに記載。`isCommentLine()` の HTML コメント単行判定を regex から文字列前後一致に切替えた変更が意味的等価か (新規 unit test「HTML コメント (Svelte 単一行 <!-- ... -->) は検出対象外」で固定化)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [N/A] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認
- [N/A] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
