### PR TITLE
infra: #1908 sitemap.xml 自動更新 + stale 解消 (TECH-C-1)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,6 +37,12 @@ jobs:
 
       - run: npm ci
 
+      - name: Regenerate sitemap.xml (#1908)
+        # main push 毎に site/*.html / site/help/*.html を走査し sitemap.xml を再生成。
+        # generate-sitemap.mjs は <lastmod> を git log から取得するため、過去ページも
+        # 直近の意味のある変更日に追従する (手動編集時代の stale 解消)。
+        run: node scripts/generate-sitemap.mjs
+
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v5

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -18,6 +18,7 @@
 | 認証・セキュリティ | `14-セキュリティ設計書.md` |
 | デザイン・ビジュアル | `15-ブランドガイドライン.md` |
 | LP IA (#1163) | `lp-content-map.md` |
+| LP sitemap.xml (#1908) | 自動生成: `scripts/generate-sitemap.mjs` (pages.yml main push 毎再生成、手動編集禁止) |
 
 **禁忌**: 会話で確定した仕様を反映せずに実装進行 / 「設計書は後で」と先送り / 設計書更新を別 Issue 切出しで本体 Done。アーキ図は drawio (`docs/design/diagrams/`)、ASCII 図禁止。
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
 		"generate:stamps:regenerate-all": "node scripts/regenerate-all-stamps.mjs",
 		"generate:image": "node scripts/generate-image.mjs",
 		"generate:coreloop-summary": "node scripts/generate-coreloop-summary.mjs",
+		"generate:sitemap": "node scripts/generate-sitemap.mjs",
+		"generate:sitemap:check": "node scripts/generate-sitemap.mjs --check",
 		"generate:stripe-product-images": "node scripts/generate-stripe-product-images.mjs",
 		"check:no-demo-route-dup": "node scripts/check-no-demo-route-duplication.mjs",
 		"check:cron-observability": "node scripts/check-cron-observability.mjs",

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -41,15 +41,41 @@ const BASE_URL = 'https://www.ganbari-quest.com';
 /**
  * URL prefix → priority/changefreq ルール表。
  * 配列順で最初に match した entry を採用する (top-down resolve)。
+ *
+ * @type {Array<{match: (url: string) => boolean, priority: string, changefreq: string}>}
  */
 const PRIORITY_RULES = [
-	{ match: (url) => url === '/', priority: '1.0', changefreq: 'weekly' },
-	{ match: (url) => url === '/pricing.html', priority: '0.9', changefreq: 'monthly' },
-	{ match: (url) => url === '/faq.html', priority: '0.8', changefreq: 'monthly' },
-	{ match: (url) => url === '/graduation.html', priority: '0.8', changefreq: 'monthly' },
-	{ match: (url) => url === '/pamphlet.html', priority: '0.7', changefreq: 'monthly' },
-	{ match: (url) => url === '/selfhost.html', priority: '0.6', changefreq: 'monthly' },
-	{ match: (url) => url.startsWith('/help/'), priority: '0.5', changefreq: 'monthly' },
+	{ match: (/** @type {string} */ url) => url === '/', priority: '1.0', changefreq: 'weekly' },
+	{
+		match: (/** @type {string} */ url) => url === '/pricing.html',
+		priority: '0.9',
+		changefreq: 'monthly',
+	},
+	{
+		match: (/** @type {string} */ url) => url === '/faq.html',
+		priority: '0.8',
+		changefreq: 'monthly',
+	},
+	{
+		match: (/** @type {string} */ url) => url === '/graduation.html',
+		priority: '0.8',
+		changefreq: 'monthly',
+	},
+	{
+		match: (/** @type {string} */ url) => url === '/pamphlet.html',
+		priority: '0.7',
+		changefreq: 'monthly',
+	},
+	{
+		match: (/** @type {string} */ url) => url === '/selfhost.html',
+		priority: '0.6',
+		changefreq: 'monthly',
+	},
+	{
+		match: (/** @type {string} */ url) => url.startsWith('/help/'),
+		priority: '0.5',
+		changefreq: 'monthly',
+	},
 	{ match: () => true, priority: '0.4', changefreq: 'yearly' }, // terms / privacy / tokushoho / sla 等
 ];
 
@@ -193,9 +219,10 @@ function main() {
 }
 
 // ESM の直接実行判定 (import 経由ではテスト時 main() を呼ばない)
+const entryArg = process.argv[1] ?? '';
 const isDirectRun =
-	import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}` ||
-	import.meta.url.endsWith(path.basename(process.argv[1] ?? ''));
+	import.meta.url === `file://${entryArg.replace(/\\/g, '/')}` ||
+	import.meta.url.endsWith(path.basename(entryArg));
 if (isDirectRun) {
 	main();
 }

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+/**
+ * scripts/generate-sitemap.mjs (#1908)
+ *
+ * LP `site/sitemap.xml` を `site/**.html` を走査して自動生成する。
+ *
+ * **背景** (#1908): 手動編集時代は `faq.html` / `graduation.html` / `help/license-key.html`
+ * が長期間欠落 (`<lastmod>` 2026-04-11 のまま) し、検索エンジンが新ページを
+ * クロールできなかった。pages.yml の build step に組み込み、main push 毎に
+ * 自動再生成することで stale を構造的に解消する。
+ *
+ * **設計方針** (Issue #1908):
+ *   - `site/*.html` + `site/help/*.html` を glob で網羅
+ *   - 各 HTML の `<lastmod>` は `git log -1 --format=%aI <path>` で取得
+ *   - `<priority>` / `<changefreq>` は path prefix からルール表で割当
+ *   - 出力は site/sitemap.xml を上書き (手動編集禁止コメント付き)
+ *
+ * **OSS 調査** (#1350 / ADR-0014):
+ *   - sitemap-generator-cli: Web スクレイピング型で http サーバ起動必要、Pre-PMF 過剰
+ *   - sitemap (npm 200KB): XML stream API。file 列挙ロジックは別途必要、利点薄い
+ *   - **採用: 独自実装** — fs.readdirSync + child_process(git log) で zero-dep
+ *
+ * **使用法**:
+ *   node scripts/generate-sitemap.mjs              # site/sitemap.xml 上書き
+ *   node scripts/generate-sitemap.mjs --check      # diff 検査 (CI/pre-ready 用)
+ *   node scripts/generate-sitemap.mjs --dry-run    # stdout 出力のみ (ファイル書出しなし)
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SITE_DIR = path.join(REPO_ROOT, 'site');
+const OUTPUT_PATH = path.join(SITE_DIR, 'sitemap.xml');
+const BASE_URL = 'https://www.ganbari-quest.com';
+
+/**
+ * URL prefix → priority/changefreq ルール表。
+ * 配列順で最初に match した entry を採用する (top-down resolve)。
+ */
+const PRIORITY_RULES = [
+	{ match: (url) => url === '/', priority: '1.0', changefreq: 'weekly' },
+	{ match: (url) => url === '/pricing.html', priority: '0.9', changefreq: 'monthly' },
+	{ match: (url) => url === '/faq.html', priority: '0.8', changefreq: 'monthly' },
+	{ match: (url) => url === '/graduation.html', priority: '0.8', changefreq: 'monthly' },
+	{ match: (url) => url === '/pamphlet.html', priority: '0.7', changefreq: 'monthly' },
+	{ match: (url) => url === '/selfhost.html', priority: '0.6', changefreq: 'monthly' },
+	{ match: (url) => url.startsWith('/help/'), priority: '0.5', changefreq: 'monthly' },
+	{ match: () => true, priority: '0.4', changefreq: 'yearly' }, // terms / privacy / tokushoho / sla 等
+];
+
+/**
+ * site/ 配下の HTML ファイルを再帰列挙し、URL path 配列を返す。
+ * `index.html` は `/` に正規化、subdir も含める。
+ *
+ * @param {string} dir 走査ルート (絶対パス)
+ * @param {string} prefix URL prefix (再帰用、通常は呼出側 '')
+ * @returns {string[]} URL path 配列 (例: ['/', '/faq.html', '/help/license-key.html'])
+ */
+export function collectHtmlFiles(dir, prefix = '') {
+	const result = [];
+	const entries = fs.readdirSync(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		const fullPath = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			// screenshots / assets 等の非 HTML ディレクトリは scan 対象だが HTML 以外しか含まない
+			result.push(...collectHtmlFiles(fullPath, `${prefix}/${entry.name}`));
+		} else if (entry.isFile() && entry.name.endsWith('.html')) {
+			if (entry.name === 'index.html' && prefix === '') {
+				result.push('/');
+			} else if (entry.name === 'index.html') {
+				result.push(`${prefix}/`);
+			} else {
+				result.push(`${prefix}/${entry.name}`);
+			}
+		}
+	}
+	return result.sort();
+}
+
+/**
+ * git log -1 --format=%aI <path> で最終変更日 ISO8601 を取得。
+ * git log が空 (未 commit ファイル) または失敗時は今日の YYYY-MM-DD を返す fallback。
+ *
+ * @param {string} absolutePath
+ * @returns {string} YYYY-MM-DD 形式
+ */
+export function getLastModDate(absolutePath) {
+	const result = spawnSync('git', ['log', '-1', '--format=%aI', absolutePath], {
+		cwd: REPO_ROOT,
+		encoding: 'utf8',
+	});
+	if (result.status !== 0 || !result.stdout.trim()) {
+		// 未 commit / git 外環境 fallback
+		return new Date().toISOString().slice(0, 10);
+	}
+	// '2026-05-09T18:30:17+09:00' → '2026-05-09'
+	return result.stdout.trim().slice(0, 10);
+}
+
+/**
+ * URL path → priority/changefreq の解決。PRIORITY_RULES を top-down で評価。
+ *
+ * @param {string} url
+ * @returns {{priority: string, changefreq: string}}
+ */
+export function resolvePriority(url) {
+	for (const rule of PRIORITY_RULES) {
+		if (rule.match(url)) {
+			return { priority: rule.priority, changefreq: rule.changefreq };
+		}
+	}
+	// 設計上 PRIORITY_RULES 末尾が catch-all だがフォールバック保証
+	return { priority: '0.4', changefreq: 'yearly' };
+}
+
+/**
+ * sitemap.xml 文字列を生成 (副作用なし、テスト容易性のため pure)。
+ *
+ * @param {Array<{url: string, lastmod: string, priority: string, changefreq: string}>} entries
+ * @returns {string}
+ */
+export function buildSitemapXml(entries) {
+	const lines = [
+		'<?xml version="1.0" encoding="UTF-8"?>',
+		'<!-- 自動生成: scripts/generate-sitemap.mjs (#1908)。手動編集禁止。pages.yml で main push 毎に再生成される。 -->',
+		'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+	];
+	for (const entry of entries) {
+		lines.push('  <url>');
+		lines.push(`    <loc>${BASE_URL}${entry.url}</loc>`);
+		lines.push(`    <lastmod>${entry.lastmod}</lastmod>`);
+		lines.push(`    <changefreq>${entry.changefreq}</changefreq>`);
+		lines.push(`    <priority>${entry.priority}</priority>`);
+		lines.push('  </url>');
+	}
+	lines.push('</urlset>');
+	lines.push('');
+	return lines.join('\n');
+}
+
+/**
+ * site/ 全 HTML を走査して sitemap entry 配列を構築 (副作用なし、テスト容易性のため pure)。
+ *
+ * @param {string} siteDir SITE_DIR を上書き可 (テスト用)
+ * @returns {Array<{url: string, lastmod: string, priority: string, changefreq: string}>}
+ */
+export function generateEntries(siteDir = SITE_DIR) {
+	const urls = collectHtmlFiles(siteDir);
+	return urls.map((url) => {
+		const relPath = url === '/' ? 'index.html' : url.replace(/^\//, '');
+		const absolutePath = path.join(siteDir, relPath);
+		const lastmod = getLastModDate(absolutePath);
+		const { priority, changefreq } = resolvePriority(url);
+		return { url, lastmod, priority, changefreq };
+	});
+}
+
+// ────────────── CLI ────────────── //
+
+function main() {
+	const argv = process.argv.slice(2);
+	const isCheck = argv.includes('--check');
+	const isDryRun = argv.includes('--dry-run');
+
+	const entries = generateEntries();
+	const xml = buildSitemapXml(entries);
+
+	if (isDryRun) {
+		process.stdout.write(xml);
+		return;
+	}
+
+	if (isCheck) {
+		const current = fs.existsSync(OUTPUT_PATH) ? fs.readFileSync(OUTPUT_PATH, 'utf8') : '';
+		if (current !== xml) {
+			console.error('[generate-sitemap] site/sitemap.xml is out of date.');
+			console.error('[generate-sitemap] Run: node scripts/generate-sitemap.mjs');
+			process.exit(1);
+		}
+		console.log('[generate-sitemap] site/sitemap.xml is up to date.');
+		return;
+	}
+
+	fs.writeFileSync(OUTPUT_PATH, xml);
+	console.log(
+		`[generate-sitemap] Wrote ${entries.length} URLs to ${path.relative(REPO_ROOT, OUTPUT_PATH)}`,
+	);
+}
+
+// ESM の直接実行判定 (import 経由ではテスト時 main() を呼ばない)
+const isDirectRun =
+	import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}` ||
+	import.meta.url.endsWith(path.basename(process.argv[1] ?? ''));
+if (isDirectRun) {
+	main();
+}

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,50 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- 自動生成: scripts/generate-sitemap.mjs (#1908)。手動編集禁止。pages.yml で main push 毎に再生成される。 -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.ganbari-quest.com/</loc>
-    <lastmod>2026-04-11</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://www.ganbari-quest.com/pricing.html</loc>
-    <lastmod>2026-04-11</lastmod>
+    <loc>https://www.ganbari-quest.com/faq.html</loc>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
+    <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.ganbari-quest.com/selfhost.html</loc>
-    <lastmod>2026-04-17</lastmod>
+    <loc>https://www.ganbari-quest.com/graduation.html</loc>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.ganbari-quest.com/help/license-key.html</loc>
+    <lastmod>2026-05-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>https://www.ganbari-quest.com/pamphlet.html</loc>
-    <lastmod>2026-04-11</lastmod>
+    <lastmod>2026-05-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.ganbari-quest.com/terms.html</loc>
-    <lastmod>2026-04-11</lastmod>
+    <loc>https://www.ganbari-quest.com/pricing.html</loc>
+    <lastmod>2026-05-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.ganbari-quest.com/privacy.html</loc>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
-    <loc>https://www.ganbari-quest.com/privacy.html</loc>
-    <lastmod>2026-04-11</lastmod>
+    <loc>https://www.ganbari-quest.com/selfhost.html</loc>
+    <lastmod>2026-05-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.ganbari-quest.com/sla.html</loc>
+    <lastmod>2026-05-07</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://www.ganbari-quest.com/terms.html</loc>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://www.ganbari-quest.com/tokushoho.html</loc>
-    <lastmod>2026-04-11</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.4</priority>
-  </url>
-  <url>
-    <loc>https://www.ganbari-quest.com/sla.html</loc>
-    <lastmod>2026-04-11</lastmod>
+    <lastmod>2026-05-07</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>

--- a/tests/unit/scripts/generate-sitemap.test.ts
+++ b/tests/unit/scripts/generate-sitemap.test.ts
@@ -1,0 +1,176 @@
+/**
+ * tests/unit/scripts/generate-sitemap.test.ts (#1908)
+ *
+ * scripts/generate-sitemap.mjs の純粋関数 (副作用なし) を検証する。
+ * git log / fs 書き出しは間接的に collectHtmlFiles 経由 + 一時ディレクトリで検証。
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+	buildSitemapXml,
+	collectHtmlFiles,
+	resolvePriority,
+} from '../../../scripts/generate-sitemap.mjs';
+
+describe('resolvePriority (#1908 AC3)', () => {
+	it('ルート / は priority 1.0 / weekly', () => {
+		expect(resolvePriority('/')).toEqual({ priority: '1.0', changefreq: 'weekly' });
+	});
+
+	it('pricing.html は priority 0.9 / monthly', () => {
+		expect(resolvePriority('/pricing.html')).toEqual({ priority: '0.9', changefreq: 'monthly' });
+	});
+
+	it('faq.html は priority 0.8 / monthly (#1908 AC4)', () => {
+		expect(resolvePriority('/faq.html')).toEqual({ priority: '0.8', changefreq: 'monthly' });
+	});
+
+	it('graduation.html は priority 0.8 / monthly (#1908 AC4)', () => {
+		expect(resolvePriority('/graduation.html')).toEqual({
+			priority: '0.8',
+			changefreq: 'monthly',
+		});
+	});
+
+	it('pamphlet.html は priority 0.7 / monthly', () => {
+		expect(resolvePriority('/pamphlet.html')).toEqual({ priority: '0.7', changefreq: 'monthly' });
+	});
+
+	it('selfhost.html は priority 0.6 / monthly', () => {
+		expect(resolvePriority('/selfhost.html')).toEqual({ priority: '0.6', changefreq: 'monthly' });
+	});
+
+	it('help/ 配下は priority 0.5 / monthly (#1908 AC4)', () => {
+		expect(resolvePriority('/help/license-key.html')).toEqual({
+			priority: '0.5',
+			changefreq: 'monthly',
+		});
+	});
+
+	it('terms / privacy / tokushoho / sla 等は catch-all で priority 0.4 / yearly', () => {
+		expect(resolvePriority('/terms.html')).toEqual({ priority: '0.4', changefreq: 'yearly' });
+		expect(resolvePriority('/privacy.html')).toEqual({ priority: '0.4', changefreq: 'yearly' });
+		expect(resolvePriority('/tokushoho.html')).toEqual({ priority: '0.4', changefreq: 'yearly' });
+		expect(resolvePriority('/sla.html')).toEqual({ priority: '0.4', changefreq: 'yearly' });
+	});
+
+	it('未知の path も catch-all で 0.4 / yearly を返す', () => {
+		expect(resolvePriority('/unknown-future.html')).toEqual({
+			priority: '0.4',
+			changefreq: 'yearly',
+		});
+	});
+});
+
+describe('buildSitemapXml (#1908 AC1)', () => {
+	it('XML 宣言と urlset / 自動生成コメントを含む', () => {
+		const xml = buildSitemapXml([]);
+		expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+		expect(xml).toContain('<!-- 自動生成: scripts/generate-sitemap.mjs (#1908)');
+		expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+		expect(xml).toContain('</urlset>');
+	});
+
+	it('entry 配列を <url> ブロックに変換する', () => {
+		const xml = buildSitemapXml([
+			{ url: '/', lastmod: '2026-05-09', priority: '1.0', changefreq: 'weekly' },
+			{ url: '/faq.html', lastmod: '2026-05-07', priority: '0.8', changefreq: 'monthly' },
+		]);
+		expect(xml).toContain('<loc>https://www.ganbari-quest.com/</loc>');
+		expect(xml).toContain('<loc>https://www.ganbari-quest.com/faq.html</loc>');
+		expect(xml).toContain('<lastmod>2026-05-09</lastmod>');
+		expect(xml).toContain('<lastmod>2026-05-07</lastmod>');
+		expect(xml).toContain('<priority>1.0</priority>');
+		expect(xml).toContain('<priority>0.8</priority>');
+	});
+
+	it('空配列でも valid XML を生成する', () => {
+		const xml = buildSitemapXml([]);
+		expect(xml).toMatch(/^<\?xml/);
+		expect(xml).toContain('</urlset>');
+		// <url> 要素は含まれない
+		expect(xml).not.toContain('<url>');
+	});
+});
+
+describe('collectHtmlFiles (#1908 AC1 / AC4)', () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gq-sitemap-test-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it('site 直下の index.html を / に正規化', () => {
+		fs.writeFileSync(path.join(tmpDir, 'index.html'), '<html></html>');
+		const result = collectHtmlFiles(tmpDir);
+		expect(result).toContain('/');
+	});
+
+	it('site 直下の HTML を /<name>.html として収集', () => {
+		fs.writeFileSync(path.join(tmpDir, 'index.html'), '<html></html>');
+		fs.writeFileSync(path.join(tmpDir, 'pricing.html'), '<html></html>');
+		fs.writeFileSync(path.join(tmpDir, 'faq.html'), '<html></html>');
+		const result = collectHtmlFiles(tmpDir);
+		expect(result).toEqual(['/', '/faq.html', '/pricing.html']);
+	});
+
+	it('subdir (例: help/) を再帰的に列挙し /help/<name>.html として収集 (#1908 AC4)', () => {
+		fs.writeFileSync(path.join(tmpDir, 'index.html'), '<html></html>');
+		fs.mkdirSync(path.join(tmpDir, 'help'));
+		fs.writeFileSync(path.join(tmpDir, 'help', 'license-key.html'), '<html></html>');
+		const result = collectHtmlFiles(tmpDir);
+		expect(result).toEqual(['/', '/help/license-key.html']);
+	});
+
+	it('非 HTML ファイル (sitemap.xml / robots.txt / .webp 等) は除外', () => {
+		fs.writeFileSync(path.join(tmpDir, 'index.html'), '<html></html>');
+		fs.writeFileSync(path.join(tmpDir, 'sitemap.xml'), '<?xml ?>');
+		fs.writeFileSync(path.join(tmpDir, 'robots.txt'), '');
+		fs.writeFileSync(path.join(tmpDir, 'image.webp'), '');
+		const result = collectHtmlFiles(tmpDir);
+		expect(result).toEqual(['/']);
+	});
+
+	it('list は alphabetical sort される (決定的出力)', () => {
+		fs.writeFileSync(path.join(tmpDir, 'zebra.html'), '<html></html>');
+		fs.writeFileSync(path.join(tmpDir, 'alpha.html'), '<html></html>');
+		fs.writeFileSync(path.join(tmpDir, 'mid.html'), '<html></html>');
+		const result = collectHtmlFiles(tmpDir);
+		expect(result).toEqual(['/alpha.html', '/mid.html', '/zebra.html']);
+	});
+});
+
+describe('full sitemap structure (#1908 AC4 / AC5 integration)', () => {
+	it('実際の site/ を走査した sitemap が faq / graduation / help/license-key を含む', () => {
+		// 実 repo の site/ をそのまま読む。Issue #1908 で stale 解消した 3 ページを必ず含むこと
+		const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../..');
+		const siteDir = path.join(repoRoot, 'site').replace(/^\\/, ''); // Windows 互換
+		const siteDirNormalized = fs.existsSync(siteDir) ? siteDir : path.resolve('site');
+		if (!fs.existsSync(siteDirNormalized)) {
+			// CI 等で site/ が無い環境では skip
+			return;
+		}
+		const urls = collectHtmlFiles(siteDirNormalized);
+		// AC4: faq / graduation / help/license-key の 3 ページが網羅されること
+		expect(urls).toContain('/faq.html');
+		expect(urls).toContain('/graduation.html');
+		expect(urls).toContain('/help/license-key.html');
+		// 既存の 8 ページも維持されていること
+		expect(urls).toContain('/');
+		expect(urls).toContain('/pricing.html');
+		expect(urls).toContain('/selfhost.html');
+		expect(urls).toContain('/pamphlet.html');
+		expect(urls).toContain('/terms.html');
+		expect(urls).toContain('/privacy.html');
+		expect(urls).toContain('/tokushoho.html');
+		expect(urls).toContain('/sla.html');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体 (LP 訪問者経由で全ユーザー)

**解決する課題**: `site/sitemap.xml` が手動編集に依存していたため、`faq.html` / `graduation.html` / `help/license-key.html` の 3 ページが長期間欠落 (`<lastmod>` 2026-04-11 のまま) し、検索エンジンが新ページをクロールできず SEO 訴求機会を失っていた。

**期待される効果**: `site/**.html` を自動列挙する `scripts/generate-sitemap.mjs` を `.github/workflows/pages.yml` の build 直前に組込み、main push 毎に自動再生成することで、新ページ追加時の手動更新漏れを構造的に解消する。`<lastmod>` も git log から取得するため stale が起こらない。

## 関連 Issue

closes #1908

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `scripts/generate-sitemap.mjs` 新規作成、`site/*.html` glob で網羅 | `git ls-files scripts/generate-sitemap.mjs` + `tests/unit/scripts/generate-sitemap.test.ts` `collectHtmlFiles` test 5 件 | PASS — 同 PR で 198 行新規、unit test 18/18 PASS |
| AC2 | `<lastmod>` が `git log -1 --format=%aI` から自動取得 | `scripts/generate-sitemap.mjs` `getLastModDate()` 関数 + `node scripts/generate-sitemap.mjs --dry-run` で `<lastmod>2026-05-09</lastmod>` 等が出力されること | PASS — dry-run 実行で 11 ページ全件が直近 commit 日時 (`2026-05-07`〜`2026-05-09`) に置換されることを確認 |
| AC3 | `pages.yml` の build 直前に sitemap regeneration step 追加 | `grep "generate-sitemap" .github/workflows/pages.yml` で 1 件、`Build app for preview` の前に配置 | PASS — `.github/workflows/pages.yml` L40-44 に `Regenerate sitemap.xml (#1908)` step 追加、build step 直前 |
| AC4 | 修正後 `site/sitemap.xml` に faq.html / graduation.html / help/license-key.html が含まれる | `grep -E "(faq|graduation|help/license-key)" site/sitemap.xml` で 3 件 | PASS — `site/sitemap.xml` に 3 ページ全て出現、`<priority>0.8/0.5</priority>` 設定 |
| AC5 | 修正後 `<lastmod>` が直近 main コミット日時 (2026-05-XX) になる | `grep "<lastmod>" site/sitemap.xml` 全 11 件が `2026-05-` 始まり | PASS — 全 entry が `2026-05-07` (faq/graduation 等) / `2026-05-09` (index/pricing/help 等) に更新済 |
| AC6 | visual diff (LP 画面) 変化なし | `site/index.html` 等の HTML 本体に diff なし、`sitemap.xml` のみ更新 | PASS — `git diff main --stat` の `site/` 範囲は `sitemap.xml` の 1 ファイルのみ |
| AC7 | no-touch-zones A-E 節 侵犯なし | `git diff main --name-only` で確認 | PASS — `src/` / `tests/e2e/` / DB schema / labels.ts 等への変更なし、scripts/ + workflows/ + sitemap.xml + docs/CLAUDE.md + package.json + tests/unit/ のみ |
| AC8 | `npm run pre-ready -- --pr <num>` PASS | 同 PR で実施 | PASS — biome / svelte-check / vitest 個別実行で全 green、PR push 後 pre-ready 全 Step PASS 確認済 |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- LP サイトマップのみ。アプリ本体 / 子供画面 / 親管理画面 / API への影響ゼロ。
- 検索エンジン (Google / Bing) のクロール挙動が改善される (新ページの早期 indexing)。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/scripts/generate-sitemap.test.ts` 新規 18 テスト
    - `resolvePriority`: 9 件 (ルート / pricing / faq / graduation / pamphlet / selfhost / help / catch-all / 未知 path)
    - `buildSitemapXml`: 3 件 (XML 宣言 / entry 配列変換 / 空配列)
    - `collectHtmlFiles`: 5 件 (index 正規化 / 直下 HTML / subdir / 非 HTML 除外 / sort)
    - integration: 1 件 (実 site/ で faq / graduation / help/license-key 全 3 ページ網羅)
- [x] **新規 env / secret 追加時**: N/A — env / secret 新規追加なし
- [x] **DynamoDB 実装変更時**: N/A — DB 触らず
- [x] **Critical バグ修正の場合**: N/A — `priority:medium` の infra 改善

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は `site/sitemap.xml` (XML metadata file) と CI workflow / 生成スクリプトのみの変更で、UI / レンダリング結果に影響なし。LP `index.html` / `pricing.html` 等の HTML / CSS は touch していない。`scripts/measure-lp-dimensions.mjs` の `mobileHeight` / `desktopHeight` も影響を受けない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 (`generate-sitemap.mjs` は sitemap 生成のみ) / 依存性逆転 (`generateEntries(siteDir)` は SITE_DIR を引数化、テスト容易) / インターフェース分離 (`collectHtmlFiles` / `resolvePriority` / `buildSitemapXml` を別関数化、副作用なし pure functions)
- [x] **DRY**: sitemap 生成ロジックは scripts/ 配下に他存在しないことを `grep "<urlset"` / `grep "sitemap.xml"` で確認済
- [x] **YAGNI**: 国際化 (hreflang) / image sitemap / video sitemap 等の拡張は実装せず。Issue #1908 AC8 範囲のみ
- [x] **Security（OSS 公開前提）**: 秘密情報なし / git log 出力 (commit timestamp) を使用するが日付のみで identifying info なし / N/A
- [x] **アクセシビリティ**: N/A — XML metadata file のみ
- [x] **パフォーマンス**: pages.yml 内で 11 ページ × git log 1 回 = 数秒で完了。CI 全体時間への影響無視可

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外（sitemap.xml は LP-only metadata で、本番アプリ / デモ版双方向の同期対象でない）

**LP / 販促文言変更時** (ADR-0013 / #1314):

N/A — 文言変更なし、metadata (URL list / lastmod / priority / changefreq) のみ。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- `.github/workflows/pages.yml` で sitemap 再生成 step を build step 直前に挿入したが、これにより workflow 全体時間が数秒延びる程度。preview server / Playwright 撮影への影響は無し
- `site/sitemap.xml` の `<lastmod>` が現状 `2026-05-09` (本 PR commit 時刻) に更新されるが、これは「sitemap.xml が再生成されたタイミング」ではなく「対象 HTML ファイルが最後に変更された commit 日時」が出力されることに注意 (例: faq.html → 2026-05-07)
- OSS 調査結果: `sitemap-generator-cli` (Web スクレイピング型、サーバ起動必要、過剰) / `sitemap` npm (Stream API、200KB、利点薄い) を比較し独自実装採用。詳細はスクリプトヘッダコメント参照

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（TODO / 「予定」のまま残っている AC がない）
- [x] Phase 分割した場合: N/A (Phase 分割なし)
- [x] UI 変更時: N/A (本 PR は UI 変更を含まない)
- [x] 認証画面変更時: N/A (本 PR は認証画面を触らない)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

