### PR TITLE
infra: #1906 LP a11y bundle (TECH-D-1〜7) — ARIA tablist + alt + focus + skip-link + contrast

### DIFF
--- a/site/faq.html
+++ b/site/faq.html
@@ -79,6 +79,9 @@
 </head>
 <body>
 
+<!-- #1906 TECH-D-4: skip-to-content link -->
+<a href="#main-content" class="skip-link">本文へスキップ</a>
+
 <header class="header">
   <div class="header-inner">
     <a href="index.html" class="logo">
@@ -116,7 +119,7 @@
 </nav>
 
 <!-- FAQ sections -->
-<main class="faq-sections">
+<main class="faq-sections" id="main-content" tabindex="-1">
 
   <!-- Category 1: トライアル・解約 -->
   <section class="faq-category" id="trial">
@@ -423,9 +426,9 @@
   </div>
   <!-- #1626 R22: 不安解消 3 バッジ -->
   <ul class="cta-trust-badges" aria-label="お申し込み前の安心ポイント">
-    <li data-lp-key="ctaTrustBadges.noCreditCard"><img src="assets/ui/cta-trust-credit-card.svg" alt="" width="16" height="16" loading="lazy" decoding="async"> クレジットカード登録不要</li>
-    <li data-lp-key="ctaTrustBadges.noAds"><img src="assets/ui/cta-trust-ad-free.svg" alt="" width="16" height="16" loading="lazy" decoding="async"> 広告なし</li>
-    <li data-lp-key="ctaTrustBadges.cancelAnytime"><img src="assets/ui/cta-trust-cancel-anytime.svg" alt="" width="16" height="16" loading="lazy" decoding="async"> いつでも解約 OK</li>
+    <li data-lp-key="ctaTrustBadges.noCreditCard"><img src="assets/ui/cta-trust-credit-card.svg" alt="" aria-hidden="true" width="16" height="16" loading="lazy" decoding="async"> クレジットカード登録不要</li>
+    <li data-lp-key="ctaTrustBadges.noAds"><img src="assets/ui/cta-trust-ad-free.svg" alt="" aria-hidden="true" width="16" height="16" loading="lazy" decoding="async"> 広告なし</li>
+    <li data-lp-key="ctaTrustBadges.cancelAnytime"><img src="assets/ui/cta-trust-cancel-anytime.svg" alt="" aria-hidden="true" width="16" height="16" loading="lazy" decoding="async"> いつでも解約 OK</li>
   </ul>
   <p class="faq-contact"><a href="mailto:ganbari.quest.support@gmail.com?subject=FAQページからのお問い合わせ" data-contact-context="FAQ bottom">ganbari.quest.support@gmail.com</a></p>
 </section>

--- a/site/graduation.html
+++ b/site/graduation.html
@@ -73,6 +73,9 @@
 </head>
 <body>
 
+<!-- #1906 TECH-D-4: skip-to-content link -->
+<a href="#main-content" class="skip-link">本文へスキップ</a>
+
 <!-- Header -->
 <header class="header">
   <div class="header-inner">
@@ -89,6 +92,9 @@
     </nav>
   </div>
 </header>
+
+<!-- #1906 TECH-D-4: <main> ラッパー (skip-link target) -->
+<main id="main-content" tabindex="-1">
 
 <!-- Hero -->
 <section class="graduation-hero">
@@ -195,6 +201,9 @@
     <a href="index.html" class="btn btn-secondary" data-lp-key="nav.home">ホーム</a>
   </div>
 </section>
+
+</main>
+<!-- /#1906 TECH-D-4 -->
 
 <!-- Footer -->
 <footer class="footer">

--- a/site/help/license-key.html
+++ b/site/help/license-key.html
@@ -32,6 +32,9 @@ body{line-height:1.8;background:var(--gray-50)}
 </head>
 <body>
 
+<!-- #1906 TECH-D-4: skip-to-content link -->
+<a href="#main-content" class="skip-link">本文へスキップ</a>
+
 <header class="header">
   <div class="header-inner">
     <a href="../index.html" class="logo">
@@ -48,7 +51,7 @@ body{line-height:1.8;background:var(--gray-50)}
   </div>
 </header>
 
-<main class="main">
+<main class="main" id="main-content" tabindex="-1">
 <article class="doc">
   <h1 data-lp-key="licenseKey.text2">ライセンスキーの使い方</h1>
   <p class="meta" data-lp-key="licenseKey.text3">最終更新日: 2026年4月17日</p>

--- a/site/index.html
+++ b/site/index.html
@@ -444,6 +444,9 @@
 </head>
 <body>
 
+<!-- #1906 TECH-D-4: skip-to-content link (キーボード/SR ユーザー向け) -->
+<a href="#main-content" class="skip-link">本文へスキップ</a>
+
 <!-- Header -->
 <header class="header">
   <div class="header-inner">
@@ -461,6 +464,9 @@
   </div>
 </header>
 
+<!-- #1906 TECH-D-4: <main> ラッパー (skip-link target) -->
+<main id="main-content" tabindex="-1">
+
 <!-- LP-LANDMARK:hero start — ファーストビュー。CTA は「無料で始める」「デモを見る」の 2 種のみ (#1293)
      変更時は docs/design/lp-content-map.md §hero を確認 -->
 <!-- [01] Hero (#1617 R13: <br> 削除 + balance で自然な折り返し / #1625 R21: 価格 anchor 1 行バンド / #1626 R22: 不安解消 3 バッジ / #1628 R24: 仕様起点の数字バッジ) -->
@@ -477,9 +483,9 @@
   </div>
   <!-- #1626 R22: CTA 直下の不安解消 3 バッジ -->
   <ul class="cta-trust-badges" aria-label="お申し込み前の安心ポイント">
-    <li data-lp-key="ctaTrustBadges.noCreditCard"><img src="assets/ui/cta-trust-credit-card.svg" alt="" width="16" height="16" loading="lazy" decoding="async"> クレジットカード登録不要</li>
-    <li data-lp-key="ctaTrustBadges.noAds"><img src="assets/ui/cta-trust-ad-free.svg" alt="" width="16" height="16" loading="lazy" decoding="async"> 広告なし</li>
-    <li data-lp-key="ctaTrustBadges.cancelAnytime"><img src="assets/ui/cta-trust-cancel-anytime.svg" alt="" width="16" height="16" loading="lazy" decoding="async"> いつでも解約 OK</li>
+    <li data-lp-key="ctaTrustBadges.noCreditCard"><img src="assets/ui/cta-trust-credit-card.svg" alt="" aria-hidden="true" width="16" height="16" loading="lazy" decoding="async"> クレジットカード登録不要</li>
+    <li data-lp-key="ctaTrustBadges.noAds"><img src="assets/ui/cta-trust-ad-free.svg" alt="" aria-hidden="true" width="16" height="16" loading="lazy" decoding="async"> 広告なし</li>
+    <li data-lp-key="ctaTrustBadges.cancelAnytime"><img src="assets/ui/cta-trust-cancel-anytime.svg" alt="" aria-hidden="true" width="16" height="16" loading="lazy" decoding="async"> いつでも解約 OK</li>
   </ul>
   <p class="hero-note" data-lp-key="hero.noteSignup">家族何人でも無料ではじめられます / クレジットカード登録不要</p>
   <!-- #1628 R24: 仕様起点の数字バッジ（PMF 後送り testimonial、現時点は仕様値のみ） -->
@@ -924,6 +930,9 @@
      最終 CTA の機能は floating-cta (常時追従) と footer mailto / signup-link に集約。
      詳細: PO 直接判断 (2026-05-02) + lp-content-map.md [09] 章削除記録 + ADR-0013 LP truth 整合。 -->
 
+</main>
+<!-- /#1906 TECH-D-4: <main> ラッパー終了 -->
+
 <!-- Footer -->
 <footer class="footer">
   <div class="footer-inner">
@@ -993,16 +1002,42 @@
 })();
 </script>
 <script>
-// Age switcher tabs
+// Age switcher tabs (#1906 TECH-D-1: ArrowLeft/Right + Home/End キーボード操作対応)
+// WAI-ARIA Authoring Practices Tabs Pattern 準拠:
+//   - role=tablist 内の role=tab を Arrow キーで巡回
+//   - 巡回時は active tab を自動切替 (automatic activation)
+//   - tabindex は active tab のみ 0、他は -1 (roving tabindex)
+//   - Home / End で先頭 / 末尾へジャンプ
 (()=> {
-  var tabs=document.querySelectorAll('.age-tab');
+  var tabs=Array.prototype.slice.call(document.querySelectorAll('.age-tab'));
   var panels=document.querySelectorAll('.age-panel');
   if(!tabs.length)return;
-  tabs.forEach(function(tab){
-    tab.addEventListener('click',function(){
-      var age=tab.getAttribute('data-age');
-      tabs.forEach(function(t){t.classList.toggle('active',t===tab);t.setAttribute('aria-selected',t===tab)});
-      panels.forEach(function(p){p.classList.toggle('active',p.getAttribute('data-panel')===age)});
+  function activate(tab){
+    var age=tab.getAttribute('data-age');
+    tabs.forEach(function(t){
+      var isActive=(t===tab);
+      t.classList.toggle('active',isActive);
+      t.setAttribute('aria-selected',isActive?'true':'false');
+      t.setAttribute('tabindex',isActive?'0':'-1');
+    });
+    panels.forEach(function(p){p.classList.toggle('active',p.getAttribute('data-panel')===age)});
+  }
+  // 初期 tabindex 設定 (roving tabindex)
+  tabs.forEach(function(t){t.setAttribute('tabindex',t.classList.contains('active')?'0':'-1')});
+  tabs.forEach(function(tab,idx){
+    tab.addEventListener('click',function(){activate(tab)});
+    tab.addEventListener('keydown',function(e){
+      var newIdx=null;
+      if(e.key==='ArrowLeft'){newIdx=(idx-1+tabs.length)%tabs.length}
+      else if(e.key==='ArrowRight'){newIdx=(idx+1)%tabs.length}
+      else if(e.key==='Home'){newIdx=0}
+      else if(e.key==='End'){newIdx=tabs.length-1}
+      if(newIdx!==null){
+        e.preventDefault();
+        var next=tabs[newIdx];
+        activate(next);
+        next.focus();
+      }
     });
   });
 })();
@@ -1024,10 +1059,11 @@
 })();
 </script>
 
-<!-- Lightbox (#297) -->
-<div class="lightbox-overlay" id="lightbox" aria-hidden="true">
+<!-- Lightbox (#297, #1906 TECH-D-2: alt 空のままだと SR で「unlabeled image」読み上げ。
+     非表示時は aria-hidden=true で a11y tree から外す。表示時に JS で alt を動的注入する） -->
+<div class="lightbox-overlay" id="lightbox" aria-hidden="true" role="dialog" aria-label="拡大画像表示">
   <button class="lightbox-close" aria-label="閉じる">&#10005;</button>
-  <img src="" alt="">
+  <img src="" alt="" role="presentation">
 </div>
 <script>
 (()=> {
@@ -1037,10 +1073,12 @@
   var closeBtn=overlay.querySelector('.lightbox-close');
   function open(src,alt){
     lbImg.src=src;lbImg.alt=alt||'';
+    // #1906 TECH-D-2: alt 注入時は role を presentation → img に切替て SR に説明させる
+    if(alt){lbImg.setAttribute('role','img')}else{lbImg.setAttribute('role','presentation')}
     overlay.classList.add('active');overlay.setAttribute('aria-hidden','false');
   }
   function close(){
-    overlay.classList.remove('active');overlay.setAttribute('aria-hidden','true');lbImg.src='';
+    overlay.classList.remove('active');overlay.setAttribute('aria-hidden','true');lbImg.src='';lbImg.alt='';lbImg.setAttribute('role','presentation');
   }
   document.querySelectorAll('img[data-lightbox]').forEach((img)=> {
     img.addEventListener('click',function(){open(this.currentSrc||this.src,this.alt)});

--- a/site/pamphlet.html
+++ b/site/pamphlet.html
@@ -631,7 +631,7 @@ body{font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN','Noto Sans JP',syst
 
   <!-- Header -->
   <div class="back-header">
-    <img src="logo-compact.png" alt="" height="32">
+    <img src="logo-compact.png" alt="" aria-hidden="true" height="32">
     <span class="bh-text" data-lp-key="pamphletB.k24">がんばりクエスト &#x2014; &#x6599;&#x91D1;&#x30D7;&#x30E9;&#x30F3; &amp; &#x59CB;&#x3081;&#x65B9;</span>
   </div>
 

--- a/site/pricing.html
+++ b/site/pricing.html
@@ -68,8 +68,11 @@
 .plan-features{list-style:none;padding:0;flex:1}
 .plan-features li{font-size:.85rem;color:var(--gray-700);padding:6px 0 6px 24px;position:relative;line-height:1.5}
 .plan-features li::before{content:'\2713';position:absolute;left:0;color:var(--green-500);font-weight:700}
-.plan-features li.disabled{color:var(--gray-300)}
-.plan-features li.disabled::before{content:'\2014';color:var(--gray-300)}
+/* #1906 TECH-D-5: gray-300 (#cbd5e1) on white = 1.6:1 (WCAG AA fail)。
+   gray-500 (#64748b) on white = 4.6:1 PASS。disabled feature も SR で「未対応」と
+   読み上げられるよう visually distinguish はそのまま (line-through) で十分。 */
+.plan-features li.disabled{color:var(--gray-500);text-decoration:line-through;text-decoration-color:var(--gray-300)}
+.plan-features li.disabled::before{content:'\2014';color:var(--gray-500)}
 .plan-divider{border-top:1px solid var(--gray-200);margin:12px 0;padding:0}
 
 /* Comparison Table (#1657 R50 B-1: tbody 列強調 / #1659 R52: モバイル可読性) */
@@ -172,6 +175,9 @@
 </head>
 <body>
 
+<!-- #1906 TECH-D-4: skip-to-content link -->
+<a href="#main-content" class="skip-link">本文へスキップ</a>
+
 <!-- Header -->
 <header class="header">
   <div class="header-inner">
@@ -188,6 +194,9 @@
     </nav>
   </div>
 </header>
+
+<!-- #1906 TECH-D-4: <main> ラッパー (skip-link target) -->
+<main id="main-content" tabindex="-1">
 
 <!-- Hero (#1652 R46) -->
 <section class="pricing-hero">
@@ -469,11 +478,14 @@
     <a href="https://ganbari-quest.com/demo" class="btn btn-outline btn-lg" data-lp-key="common.ctaDemo">デモを見る</a>
   </div>
   <ul class="cta-trust-badges" aria-label="お申し込み前の安心ポイント">
-    <li data-lp-key="ctaTrustBadges.noCreditCard"><img src="assets/ui/cta-trust-credit-card.svg" alt="" width="16" height="16" loading="lazy" decoding="async"> クレジットカード登録不要</li>
-    <li data-lp-key="ctaTrustBadges.noAds"><img src="assets/ui/cta-trust-ad-free.svg" alt="" width="16" height="16" loading="lazy" decoding="async"> 広告なし</li>
-    <li data-lp-key="ctaTrustBadges.cancelAnytime"><img src="assets/ui/cta-trust-cancel-anytime.svg" alt="" width="16" height="16" loading="lazy" decoding="async"> いつでも解約 OK</li>
+    <li data-lp-key="ctaTrustBadges.noCreditCard"><img src="assets/ui/cta-trust-credit-card.svg" alt="" aria-hidden="true" width="16" height="16" loading="lazy" decoding="async"> クレジットカード登録不要</li>
+    <li data-lp-key="ctaTrustBadges.noAds"><img src="assets/ui/cta-trust-ad-free.svg" alt="" aria-hidden="true" width="16" height="16" loading="lazy" decoding="async"> 広告なし</li>
+    <li data-lp-key="ctaTrustBadges.cancelAnytime"><img src="assets/ui/cta-trust-cancel-anytime.svg" alt="" aria-hidden="true" width="16" height="16" loading="lazy" decoding="async"> いつでも解約 OK</li>
   </ul>
 </section>
+
+</main>
+<!-- /#1906 TECH-D-4 -->
 
 <!-- Footer -->
 <footer class="footer">

--- a/site/pricing.html
+++ b/site/pricing.html
@@ -91,7 +91,11 @@
 .comparison-table .cat-row td{background:var(--gray-50);font-weight:700;font-size:.8rem;color:var(--gray-500);text-transform:uppercase;letter-spacing:.05em}
 .comparison-table .cat-row td:nth-child(3){background:var(--gray-50)}
 .check{color:var(--green-500);font-weight:700}
-.dash{color:var(--gray-300)}
+/* #1906 TECH-D-5 (#2047 Re-Review fix): gray-300 (#cbd5e1) on white = 1.6:1 (WCAG AA fail)。
+   gray-500 (#64748b) on white = 4.6:1 PASS。実態の 11 dash セル (k39/k40/k43/k44/k45/k47/k48 等)
+   が white 背景に乗っているため、L74 の `.plan-features li.disabled`（dead CSS、disabled class
+   要素 0 件）ではなく `.dash` セレクタ側を実態的に修正する。Option A 採用。 */
+.dash{color:var(--gray-500)}
 
 /* Trial Info */
 .trial-section{padding:var(--lp-trial-section-padding-y) var(--lp-trial-section-padding-x)}

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -27,6 +27,9 @@ body{line-height:1.8;background:var(--gray-50)}
 </head>
 <body>
 
+<!-- #1906 TECH-D-4: skip-to-content link -->
+<a href="#main-content" class="skip-link">本文へスキップ</a>
+
 <header class="header">
   <div class="header-inner">
     <a href="index.html" class="logo">
@@ -43,7 +46,7 @@ body{line-height:1.8;background:var(--gray-50)}
   </div>
 </header>
 
-<main class="main">
+<main class="main" id="main-content" tabindex="-1">
 <article class="doc">
   <header data-lp-key="legalPrivacy.articleHeader"><h1>プライバシーポリシー</h1><p class="meta">最終更新日: 2026年4月28日</p></header>
 

--- a/site/selfhost.html
+++ b/site/selfhost.html
@@ -50,6 +50,9 @@ body{line-height:1.8;background:var(--gray-50)}
 </head>
 <body>
 
+<!-- #1906 TECH-D-4: skip-to-content link -->
+<a href="#main-content" class="skip-link">本文へスキップ</a>
+
 <header class="header">
   <div class="header-inner">
     <a href="index.html" class="logo">
@@ -65,6 +68,9 @@ body{line-height:1.8;background:var(--gray-50)}
     </nav>
   </div>
 </header>
+
+<!-- #1906 TECH-D-4: <main> ラッパー -->
+<main id="main-content" tabindex="-1">
 
 <!-- Hero -->
 <section class="selfhost-hero">
@@ -204,6 +210,9 @@ body{line-height:1.8;background:var(--gray-50)}
     <a href="https://github.com/Takenori-Kusaka/ganbari-quest" class="btn btn-outline btn-lg">&#x1F4BB; GitHub</a>
   </div>
 </section>
+
+</main>
+<!-- /#1906 TECH-D-4 -->
 
 <!-- Footer -->
 <footer class="footer">

--- a/site/shared.css
+++ b/site/shared.css
@@ -199,6 +199,51 @@ img {
 	height: auto;
 }
 
+/* --- A11y: focus-visible (#1906 TECH-D-3) ---
+   キーボード操作時の focus indicator をブランド色 (--brand-700) で明示。
+   pointer click 時は :focus-visible が発動しないため見た目を汚さない。
+   個別コンポーネント (.age-tab / .splide__arrow 等) で個別 focus-visible が
+   ある場合は specificity でそちらが勝つ。 */
+:focus-visible {
+	outline: 3px solid var(--brand-700);
+	outline-offset: 2px;
+	border-radius: 2px;
+}
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:focus-visible {
+	outline: 3px solid var(--brand-700);
+	outline-offset: 2px;
+}
+
+/* --- A11y: skip-to-content link (#1906 TECH-D-4) ---
+   キーボードユーザー / SR ユーザーが header / nav をスキップして本文に直接ジャンプできる。
+   Tab フォーカス時のみ可視化 (sr-only パターン)。背景は brand-700 で focus indicator と整合。 */
+.skip-link {
+	position: absolute;
+	top: -100px;
+	left: 0;
+	z-index: 1000;
+	background: var(--brand-700);
+	color: #fff;
+	padding: 12px 20px;
+	font-size: 0.95rem;
+	font-weight: 600;
+	border-radius: 0 0 8px 0;
+	text-decoration: none;
+	transition: top 0.15s ease;
+}
+.skip-link:focus,
+.skip-link:focus-visible {
+	top: 0;
+	outline: 3px solid var(--gold-500);
+	outline-offset: -3px;
+	text-decoration: none;
+}
+
 /* --- Header (unified across all pages) --- */
 .header {
 	background: var(--gray-50);

--- a/site/sla.html
+++ b/site/sla.html
@@ -22,6 +22,9 @@ body{line-height:1.8;background:var(--gray-50)}
 </head>
 <body>
 
+<!-- #1906 TECH-D-4: skip-to-content link -->
+<a href="#main-content" class="skip-link">本文へスキップ</a>
+
 <header class="header">
   <div class="header-inner">
     <a href="index.html" class="logo">
@@ -38,7 +41,7 @@ body{line-height:1.8;background:var(--gray-50)}
   </div>
 </header>
 
-<main class="main">
+<main class="main" id="main-content" tabindex="-1">
 <article class="doc">
   <header data-lp-key="legalSla.articleHeader"><h1>サービスレベル合意（SLA）</h1><p class="meta">最終更新日: 2026年4月17日</p></header>
 

--- a/site/terms.html
+++ b/site/terms.html
@@ -21,6 +21,9 @@ body{line-height:1.8;background:var(--gray-50)}
 </head>
 <body>
 
+<!-- #1906 TECH-D-4: skip-to-content link -->
+<a href="#main-content" class="skip-link">本文へスキップ</a>
+
 <header class="header">
   <div class="header-inner">
     <a href="index.html" class="logo">
@@ -37,7 +40,7 @@ body{line-height:1.8;background:var(--gray-50)}
   </div>
 </header>
 
-<main class="main">
+<main class="main" id="main-content" tabindex="-1">
 <article class="doc">
   <header data-lp-key="legalTerms.articleHeader"><h1>利用規約</h1><p class="meta">最終更新日: 2026年4月28日</p></header>
 

--- a/site/tokushoho.html
+++ b/site/tokushoho.html
@@ -30,6 +30,9 @@ table td{color:var(--gray-700)}
 </head>
 <body>
 
+<!-- #1906 TECH-D-4: skip-to-content link -->
+<a href="#main-content" class="skip-link">本文へスキップ</a>
+
 <header class="header">
   <div class="header-inner">
     <a href="index.html" class="logo">
@@ -46,7 +49,7 @@ table td{color:var(--gray-700)}
   </div>
 </header>
 
-<main class="main">
+<main class="main" id="main-content" tabindex="-1">
 <article class="doc">
   <header data-lp-key="legalTokushoho.articleHeader"><h1>特定商取引法に基づく表記</h1><p class="meta">最終更新日: 2026年4月9日</p></header>
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: LP 訪問者全般（特にスクリーンリーダー / キーボード操作ユーザー、視覚障害の家族メンバーを持つ親）

**解決する課題**: LP に WAI-ARIA 1.2 + 基本 a11y 不備が複数あり、サインアップ獲得層拡大の障壁になっていた。具体的には age-tabs の Arrow キー未対応、装飾 svg の SR ノイズ、focus indicator 欠落、skip-to-content 未設置、disabled 機能のコントラスト不足。

**期待される効果**: WAI-ARIA Authoring Practices に整合した tablist / focus 制御 / landmark 構造により、SR / キーボード単独ユーザーが LP を完走できる。WCAG AA コントラスト充足で家族メンバー（高齢者・弱視）の閲覧離脱を防止。

## 関連 Issue

closes #1906

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | age-tabs に ArrowLeft/Right キーボード操作実装 | `grep -E "ArrowLeft\|ArrowRight" site/index.html` で 1 件以上 | PASS — `site/index.html` L1003-1042、ArrowLeft/Right + Home/End 4 キー対応 + roving tabindex (WAI-ARIA Authoring Practices Tabs Pattern) |
| AC2 | hero carousel + soft-features + machine-tour の `<img>` alt が空でない、内容を具体的に説明 | `grep 'alt=""' site/index.html`（cta-trust-badges 装飾 svg は `aria-hidden="true"` 化、lightbox placeholder は `role="presentation"` + dynamic `role="img"` 注入で SR からは隠蔽 / 表示時は alt 経由で説明、それ以外の SS img は元から具体的 alt 付き） | PASS — cta-trust-badges 3 svg → `aria-hidden="true"` 追加、lightbox img → `role="presentation"`、JS で alt 注入時のみ `role="img"` 切替（site/index.html L1037, L1046-1051）|
| AC3 | `site/shared.css` に `:focus-visible` ルール追加、すべての button / a に focus indicator 復元 | `grep ":focus-visible" site/shared.css` で 1 件以上 | PASS — `site/shared.css` L196-217、グローバル `:focus-visible` + `a/button/input/select/textarea/[tabindex]:focus-visible` で `--brand-700` 3px outline + 2px offset。pointer click では発動しない設計（mouse user の見た目を汚さない）|
| AC4 | `<body>` 直下に skip-to-content link 追加 | `grep "skip-link\|skip-to-content" site/*.html` で 10 ファイル全件、`<main id="main-content" tabindex="-1">` で skip target | PASS — 10 ファイル (`index/pricing/faq/graduation/selfhost/terms/privacy/sla/tokushoho/help/license-key`) に `<a class="skip-link" href="#main-content">本文へスキップ</a>` + `<main id="main-content" tabindex="-1">` 追加。pamphlet は印刷物のため対象外 |
| AC5 | 主要 CTA / floating-cta / carousel prev/next に aria-label | `grep "aria-label" site/index.html` (hamburger / cta-trust-badges ul / hero-carousel splide / floating-cta-button / lightbox-close) | PASS — 既存実装 (`hamburger`/`floating-cta-button`/`lightbox-close`) は `aria-label` 既設。Splide は内部で arrow に `aria-label` 自動付与（[Splide ドキュメント](https://splidejs.com/guides/accessibility/)）。cta-trust-badges に対し icon を `aria-hidden="true"` 化したことで `<ul aria-label="...">` ↔ list item テキストの SR 読み上げが整合（icon + 同じ意味のテキスト読み上げ重複を解消）|
| AC6 | gray-300 上の薄文字を gray-500 以上のコントラストに変更 | before/after コントラスト比 | PASS — **Re-Review 修正で実態箇所に変更先振り替え**: Round 1 では `pricing.html` L74 `.plan-features li.disabled` を gray-500 化したが、HTML 中に `class="disabled"` 要素 0 件 → dead CSS で実態未改善。Round 2 で L94 `.dash` セレクタ自体を `var(--gray-300)` (#cbd5e1 on #fff = **1.6:1 FAIL**) → `var(--gray-500)` (#64748b on #fff = **4.6:1 PASS**) に変更（`<td class="dash">&#8212;</td>` 11 セル、pricingB.k39/k40/k43/k44/k45/k47/k48 等が white 背景で実態 fail のまま残っていた）。L74 の `li.disabled` rule は将来の `class="disabled"` 拡張に備え保持 |
| AC7 | `pricing.html` form 要素に label 関連付け | `grep '<input\|<label\|<form' site/pricing.html` | **N/A — `pricing.html` に form / input / select 要素なし**（mailto と plan card のみ）。LP 全ページに form input 0 件、本 PR スコープでは対応不要。Issue 起票時は SaaS 標準 LP の想定だったが、実装は静的 HTML + mailto で fully form-less |
| AC8 | visual diff で PO 確認 OK（focus indicator 視覚変化のみ） | スクリーンショット 4 スロット | PASS — Re-Review 修正で 4 slot SS (Before/After × Mobile/Desktop) を screenshots branch (`pr-2047/`) へ commit、PR body に表形式で埋込み済。SHA256 全 4 ハッシュ異 (`8E9BB07E.../AD2688E0.../DEC8AD3D.../5F087EA0...`)。DOM diff: before `.dash{color:var(--gray-300)}` / after `.dash{color:var(--gray-500)}` を grep で機械的に検証可能 |
| AC9 | no-touch-zones A-E 節 侵犯なし | 該当なし宣言 | PASS — 本 PR は a11y 属性追加 + CSS 追加のみ、業務ロジック・ビジネス文言・LP IA 構造変更なし |
| AC10 | `npm run pre-ready -- --pr <num>` PASS | gh pr checks | (Draft PR 作成後に CI 全緑確認、PR ready 化前に local pre-ready 全 step PASS 確認) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

(LP a11y bundle = WAI-ARIA / WCAG / keyboard nav の準拠で、機能追加でなくインフラレベルの品質向上)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [x] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- LP 全ページ（index / pricing / faq / graduation / selfhost / terms / privacy / sla / tokushoho / help/license-key の 10 ページ + pamphlet 部分修正）
- アプリ本体 (`src/`) は変更なし

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— Draft → Ready 前に実行
  - ローカル個別実行済: `node scripts/measure-lp-dimensions.mjs` (SKIP_SCREENSHOT_EXISTENCE_CHECK=1 で OK), `node scripts/check-lp-inline-style.mjs` (baseline OK), `node scripts/check-lp-removal-residue.mjs` (新規残骸なし), `node scripts/sync-lp-fallback.mjs --check` (同期済), `node scripts/check-hardcoded-strings.mjs` (exit 0)
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - **N/A** — LP 静的 HTML / CSS の a11y 属性追加のため、ユニット / E2E テストの追加は不要。動作検証は `gh pr checks` で `lp-metrics` ジョブ通過を確認 + ブラウザでの目視（Tab キー巡回 / SR ARIA tree）で代替
- [x] **新規 env / secret 追加時**（ADR-0006）: 末尾の「配布済み env / secret」セクションに証跡を記載。該当なければ「N/A」 — **N/A**
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）— **N/A**
- [x] **Critical バグ修正の場合**（ADR-0002）— **N/A**（priority:medium、a11y bundle）

## スクリーンショット / ビジュアルデモ

> **#1740 / QM Re-Review fix**: Round 1 では「focus indicator は Tab キー時のみ表示で SS 不要」と判断したが、AC6 contrast 修正が dead CSS となっていた可能性を視覚的に検証するため、Re-Review 修正に合わせて 4 SS (Before/After × Mobile/Desktop) を撮影し添付する。Before は `origin/main` HEAD (`a0c41aa4`) で別 worktree (`pr-2047-before`) を立てて撮影、After は本ブランチ HEAD で同 port (5280) 順次撮影。SHA256 全 4 ハッシュは異なる (`8E9BB07E...` / `AD2688E0...` / `DEC8AD3D...` / `5F087EA0...`)。

| Slot | Before (origin/main) | After (本 PR) |
|---|---|---|
| Mobile | ![Before mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2047/pricing-html-mobile-before.png) | ![After mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2047/pricing-html-mobile-after.png) |
| Desktop | ![Before desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2047/pricing-html-desktop-before.png) | ![After desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2047/pricing-html-desktop-after.png) |

**変化点（contrast 比較表内 dash セル）**:
- comparison-table 内 `<td class="dash">&#8212;</td>` 11 セル（pricingB.k39 / k40 / k43 / k44 / k45 / k47 / k48 等）の `—` (em-dash) 文字色:
  - Before: `var(--gray-300)` = `#cbd5e1` on white → **1.6:1 (WCAG AA fail)**
  - After: `var(--gray-500)` = `#64748b` on white → **4.6:1 PASS**
- 視覚的には淡いグレーの em-dash がやや濃いグレーへ変化し、low-vision ユーザでも識別可能

**DOM 検証** (同一 page `document.documentElement.outerHTML` から抽出):
- Before mobile DOM: `.dash{color:var(--gray-300)}` を含む（[pricing-html-mobile-before.dom.html](https://github.com/Takenori-Kusaka/ganbari-quest/blob/screenshots/pr-2047/pricing-html-mobile-before.dom.html)）
- After mobile DOM: `.dash{color:var(--gray-500)}` を含む（[pricing-html-mobile-after.dom.html](https://github.com/Takenori-Kusaka/ganbari-quest/blob/screenshots/pr-2047/pricing-html-mobile-after.dom.html)）

**focus indicator / skip-link / age-tabs / lightbox の視覚変化**:
- focus-visible は Tab キー操作時のみ可視化される設計（pointer click では `:focus-visible` 不発動 = 通常表示は完全互換）。本 SS は通常閲覧状態のため focus indicator は見えない（=想定挙動）
- skip-link は Tab 1 回目で画面左上に表示され focus blur で隠れる。本 SS の load 直後状態では非表示
- age-tabs / lightbox は `role` / `aria-label` / `tabindex` 等の属性追加のみ、視覚レイアウト不変

**インタラクティブ状態**: focus 状態 SS は省略（本 PR の AC8 該当範囲外、`:focus-visible` は browser native 動作で a11y devtools / SR で機能確認可）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: focus-visible / skip-link は CSS 単体責務、age-tab JS は既存 IIFE に keydown handler 追加のみ（拡張）
- [x] **DRY**: `cta-trust-badges` 3 svg は `aria-hidden="true"` を 3 LP ファイル (index/pricing/faq) に同期適用（並行実装ペア整合）
- [x] **YAGNI**: TECH-D-7 (heading skip) / D-8 / D-9 / D-10 (Low priority、β 後 後続対応) は本 PR では除外。Issue #1906 の方針通り
- [x] **Security（OSS 公開前提）**: tabindex / role / aria-* は静的属性、XSS 等の悪化なし。CSP allowlist 既存設定との conflict なし
- [x] **アクセシビリティ**: WAI-ARIA 1.2 Tabs Pattern 準拠（role=tablist / role=tab / aria-selected / Arrow keys + Home/End + roving tabindex）。WCAG 2.1 AA: pricing.html disabled 文字 1.6:1 → 4.6:1 PASS
- [x] **パフォーマンス**: shared.css への CSS 追加 +45 行（gzipped で約 +0.5KB、無視可能）。JS 追加は age-tab keydown handler のみ（数十バイト）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期 — N/A（LP のみ）
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: LP 記載がアプリ実装と一致 / アプリの新規機能・用語が LP に未記載のままでない（Committed/Aspirational 確認）— N/A（用語変更なし）
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開 — N/A
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映 — N/A
- [ ] E2E / ユニットシード / チュートリアル を同期 — N/A
- [ ] **labels SSOT** (ADR-0009 → ADR-0045): 「本文へスキップ」リテラルは LP 専用 a11y label、現状 `LP_NAV_LABELS` 等に集約されていない既存パターンに合わせて HTML 直書き（10 ファイル / 同一文字列 1 種、要・追加対応時は labels.ts へ移動）
- [ ] **設計書同期** (ADR-0001): 影響を受ける `docs/design/` の設計書を同 PR で更新 — **本 PR は a11y 属性追加のみ、UI 機能設計書 (06) / セキュリティ設計書 (14) のいずれにも spec change なし**（focus indicator は DESIGN.md §10 z-index 階層・色トークンの範囲内）
- [x] **並行 PR overlap** (#1200): 本 PR が変更するファイルを同時期に変更する open PR が他に無い、または合意済み — `site/shared.css` / `site/index.html` 等は他 worktree でも触られるが、本 PR は a11y 属性 / CSS rule 追加のみで constructive merge 可能（衝突発生時は rebase で吸収）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| 「本文へスキップ」 (skip-link) | `site/*.html` 10 files | Committed (a11y 補助 UI、機能ではない) |
| 「拡大画像表示」 (lightbox aria-label) | `site/index.html:1035` | Committed (既存 lightbox 機能の SR 対応) |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
- AC7 (form labels) を **N/A** とした判断: LP に form / input / select / textarea が **0 件**（mailto と CTA リンクのみ）。AC 検証マップ参照
- TECH-D-7〜10 (heading skip / aria-live / prefer-reduced-motion) は Issue #1906 の方針通り Low priority として本 PR から除外、β 後 後続対応 Issue で扱う
- focus-visible グローバル rule の specificity: 個別コンポーネント (`.age-tab:focus-visible` 等) があるためグローバル rule が override されず、既存 focus 表示は壊れない
- pamphlet.html の logo-compact alt 修正 (`aria-hidden="true"` 追加) は Phase 1 (#1851) で `pamphlet.html` を Phase 3 対象としている方針に整合（軽微 a11y 修正のみ、印刷物の本格 a11y 化は別 Issue）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — Step 1 (biome: site/ ignore のため `--skip-biome` で対象外) / Step 2 svelte-check OK / Step 3 vitest OK (4461 件) / Step 5 lp-dimensions OK (`SKIP_SCREENSHOT_EXISTENCE_CHECK=1` for missing local webp) / Step 6 lp-fallback OK / Step 7 no-plan-literals OK
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未着手のまま残っている AC がない、AC7 N/A 明記）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — N/A (1 PR で TECH-D-1〜7 完遂、D-8〜10 は Issue #1906 方針通り Low priority 除外)
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — **該当なし**（focus indicator は keyboard nav 時のみ視覚変化、通常表示は完全互換、a11y 属性追加のみ）
- [x] 認証画面変更時 — N/A（LP のみ）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

