### PR TITLE
fix: #1906 LP a11y contrast broader audit follow-up (.cross / .sep / .hpb-dot / .pp-dot)

### DIFF
--- a/site/graduation.html
+++ b/site/graduation.html
@@ -25,7 +25,10 @@
 .graduation-breadcrumb{max-width:1080px;margin:0 auto;padding:14px 16px;font-size:.85rem;color:var(--gray-500)}
 .graduation-breadcrumb a{color:var(--brand-700);text-decoration:none}
 .graduation-breadcrumb a:hover{text-decoration:underline}
-.graduation-breadcrumb .sep{margin:0 8px;color:var(--gray-300)}
+/* #1906 a11y bundle (Re-Review broader audit): gray-300 (#cbd5e1) on white = 1.6:1 fail。
+   "›" は breadcrumb の階層関係を示す情報付き graphic で、WCAG 1.4.11 (非テキスト 3:1) を満たすべき。
+   gray-500 (#64748b) = 4.6:1 PASS に統一。*/
+.graduation-breadcrumb .sep{margin:0 8px;color:var(--gray-500)}
 
 /* 成長ステージ詳細 (#1848: LP から graduation.html へ移管 / #1895: 「5 ステージ」表現リフレーム済。
    gr-shot は LP 本体の max-height:96px から専用ページの 240px に拡張。

--- a/site/index.html
+++ b/site/index.html
@@ -108,7 +108,9 @@
 /* #1625 R21: 価格 anchor 1 行バンド */
 .hero-price-band{display:flex;flex-wrap:wrap;justify-content:center;align-items:center;gap:6px 12px;max-width:680px;margin:0 auto 20px;padding:10px 16px;font-size:.95rem;color:var(--gray-800);background:rgba(255,255,255,.65);border:1px solid var(--gray-300);border-radius:999px;line-height:1.4}
 .hero-price-band .hpb-item strong{color:var(--brand-700);font-weight:700}
-.hero-price-band .hpb-dot{color:var(--gray-400)}
+/* #1906 a11y bundle (Re-Review broader audit): gray-400 (#94a3b8) on white = 2.8:1 fail (WCAG 1.4.11 3:1)。
+   `・` 区切り字は price-band の項目分割を視覚的に伝える機能を持つため gray-500 (4.6:1 PASS) に統一。*/
+.hero-price-band .hpb-dot{color:var(--gray-500)}
 @media(max-width:640px){.hero-price-band{font-size:.88rem;border-radius:14px;padding:10px 14px;gap:4px 10px}.hero-price-band .hpb-dot{display:none}}
 /* #1626 R22: CTA 直下の不安解消 3 バッジ */
 /* #1824: 絵文字 (💳🚫🔄) を SVG 化 (OS 依存解消、16×16 表示、line-height 内に収めるよう vertical-align:middle) */
@@ -274,7 +276,8 @@
 .pp-band{display:flex;flex-wrap:wrap;justify-content:center;align-items:center;gap:8px 14px;padding:var(--lp-pp-band-padding-y) var(--lp-pp-band-padding-x);background:linear-gradient(135deg,#f5f3ff,#eff6ff);border:1px solid var(--gray-300);border-radius:var(--radius);margin:0 auto 20px;font-size:1.05rem;color:var(--gray-900);line-height:1.6}
 .pp-item{display:inline-flex;align-items:center}
 .pp-item strong{color:#8b5cf6;font-size:1.1rem}
-.pp-dot{color:var(--gray-400);font-weight:400}
+/* #1906 a11y bundle (Re-Review broader audit): gray-400 → gray-500 (.hpb-dot と同種、price promise band 区切り) */
+.pp-dot{color:var(--gray-500);font-weight:400}
 .pp-footnote{font-size:.9rem;color:var(--gray-600);line-height:1.7;margin:0 auto 22px;max-width:560px}
 .pp-cta{text-align:center;margin-top:8px}
 .pp-cta .btn{min-width:220px}

--- a/site/pamphlet.html
+++ b/site/pamphlet.html
@@ -364,11 +364,11 @@ body{font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN','Noto Sans JP',syst
   line-height:1.4;
 }
 .plan-features li .check{color:var(--green-500);flex-shrink:0;font-size:.75rem}
-/* #1906 a11y bundle (Re-Review broader audit): gray-300 (#cbd5e1) on white = 1.6:1 (WCAG 1.4.11
-   non-text contrast 3:1 fail)。"✕" は「機能未対応」を示す essential graphics で、視認できないと
-   feature 比較表として機能不全になる。gray-500 (#64748b) on white = 4.6:1 PASS に統一。
-   `.dash` (pricing.html L98) と同種の修正。*/
-.plan-features li .cross{color:var(--gray-500);flex-shrink:0;font-size:.75rem}
+/* #1906 Re-Review #2: `.cross` セレクタは pamphlet.html 全体で実利用ゼロ (`class="cross"` HTML 要素 0 件)。
+   plan-features は `<span class="check">✓</span>` のみで構成されるプラン別「利用可能機能リスト」構造で、
+   機能未対応マーク (✕) を表示する設計ではないため、本セレクタは dead CSS。
+   PR #2047 の `.disabled` (pricing.html L74) と同様に保持するが、a11y 修正対象から除外する。*/
+.plan-features li .cross{color:var(--gray-300);flex-shrink:0;font-size:.75rem}
 
 /* -- Back: Steps -- */
 .back-steps{

--- a/site/pamphlet.html
+++ b/site/pamphlet.html
@@ -364,7 +364,11 @@ body{font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN','Noto Sans JP',syst
   line-height:1.4;
 }
 .plan-features li .check{color:var(--green-500);flex-shrink:0;font-size:.75rem}
-.plan-features li .cross{color:var(--gray-300);flex-shrink:0;font-size:.75rem}
+/* #1906 a11y bundle (Re-Review broader audit): gray-300 (#cbd5e1) on white = 1.6:1 (WCAG 1.4.11
+   non-text contrast 3:1 fail)。"✕" は「機能未対応」を示す essential graphics で、視認できないと
+   feature 比較表として機能不全になる。gray-500 (#64748b) on white = 4.6:1 PASS に統一。
+   `.dash` (pricing.html L98) と同種の修正。*/
+.plan-features li .cross{color:var(--gray-500);flex-shrink:0;font-size:.75rem}
 
 /* -- Back: Steps -- */
 .back-steps{


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: LP 訪問者全般（特に低視野・色覚特性ユーザー、視覚障害の家族メンバーを持つ親）

**解決する課題**: PR #2047 (#1906 LP a11y bundle) は QM Re-Review で `.dash` セレクタ実態修正 + 4 SS 添付で merge 完了したが、QM レビュー時の指示「全 LP HTML を grep + 自動 audit (axe-core/lighthouse) で発見」の broader audit までは scope 外として残っていた。本 PR で残箇所を `.dash` と同種パターンで一括修正する。

**期待される効果**: WCAG 1.4.11 (非テキスト 3:1) を全 LP UI 区切り字で達成。視認できない区切り字 / breadcrumb 階層字による「breadcrumb 階層が読み取れない」「price band 項目区切りが消失」状態を解消し、低視野 / 色覚特性ユーザの離脱を防止。

## 関連 Issue

closes #1906

> #1906 LP a11y bundle の merge 後 follow-up。PR #2047 で AC6 contrast の **BLOCKING 該当範囲**（`.dash` 11 セル）は修正完了したが、QM 指示の broader audit は scope 外として残存。これらは独立した essential graphics で、WCAG 1.4.11 fail のため本 PR で完遂する。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (#1906 AC6 補完) | gray-300/400 上の薄文字 / 機能 graphics を gray-500 以上のコントラストに変更 | grep + 手計算コントラスト比 + DOM verify | PASS — **3 箇所統一**: `.sep` (graduation.html:31) / `.hpb-dot` (index.html:113) / `.pp-dot` (index.html:280) を全て `var(--gray-500)` (#64748b on white = 4.6:1 PASS) に変更 |
| AC2 | LP metrics ratchet 不変 | `node scripts/measure-lp-dimensions.mjs` | PASS — mobile/desktop 寸法・forbiddenTerms 影響なし |
| AC3 | inline-style baseline 不変 | `node scripts/check-lp-inline-style.mjs` | PASS — 全ファイル baseline と同等 |
| AC4 | LP removal residue 新規違反 0 | `node scripts/check-lp-removal-residue.mjs` | PASS — 新規残骸なし |
| AC5 | broader audit 完遂 (gray-300/400 残箇所 0、または不変判定理由明記) | grep `color:\s*var\(--gray-(300\|400)\)` | PASS — 残 3 件は不変判定済 (詳細下記) |
| AC6 (Re-Review #2 追加) | dead CSS を a11y 修正対象から除外 + 構造的判定根拠を commit に明記 | `class="cross"` HTML grep | PASS — pamphlet.html `.cross` 修正撤回 (commit 3e3eaf43) |

### Broader audit 結果

#### 修正対象 (3 箇所、gray-300/400 → gray-500 に統一、4.6:1 PASS)

| File:Line | Selector | Before | After | コントラスト比 | 機能 / 修正理由 |
|---|---|---|---|---|---|
| `graduation.html:31` | `.graduation-breadcrumb .sep` | `var(--gray-300)` | `var(--gray-500)` | 1.6:1 → 4.6:1 | "›" breadcrumb 階層区切り (情報付き graphic、WCAG 1.4.11 適用) |
| `index.html:113` | `.hero-price-band .hpb-dot` | `var(--gray-400)` | `var(--gray-500)` | 2.8:1 → 4.6:1 | "・" hero 価格バンド項目区切り (desktop only、mobile では `display:none`) |
| `index.html:280` | `.pp-dot` | `var(--gray-400)` | `var(--gray-500)` | 2.8:1 → 4.6:1 | "・" pricing-promise バンド項目区切り |

#### 不変判定 (3 件)

| File:Line | Selector | 不変理由 |
|---|---|---|
| `index.html:382` | `.floating-cta-text small` | dark BG (`--gray-900` #1e293b) 上で gray-300 = 11.6:1 PASS (WCAG AAA、既存 #1800 U-MIN-5 で意図的に gray-300 化) |
| `pricing.html:74` | `.plan-features li.disabled` `text-decoration-color` | line-through 装飾色のみ (本文色は既に gray-500 PASS)。dead CSS (`class="disabled"` 要素 0 件) のため実害なし、将来の拡張用途で保持 |
| `pamphlet.html:371` | `.plan-features li .cross` | **(Re-Review #2 で修正撤回 commit 3e3eaf43)** dead CSS。`class="cross"` HTML 要素 0 件 + plan-features は `<span class="check">` のみで構成される「プラン別利用可能機能リスト」(L652-691) 構造で、機能未対応マーク (✕) 表示設計を持たない。pricing.html `.dash` のような実機能未対応マーク表示構造とは異なる |

## 変更タイプ

- [x] fix: バグ修正 (a11y contrast WCAG 1.4.11 fail 修正)
- [x] refactor:internal-no-doc-impact (Re-Review #2 で `.cross` dead CSS 修正撤回、設計書更新不要)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] LP サイト (`site/`)

**影響を受ける画面・機能**:
- LP 3 ファイル (`site/index.html` / `site/graduation.html` / `site/pamphlet.html`)
  - graduation.html: `.sep` 色変更 (実機表示変化あり)
  - index.html: `.hpb-dot` / `.pp-dot` 色変更 (実機表示変化あり)
  - pamphlet.html: `.cross` 修正撤回 (実機表示変化なし、dead CSS)
- アプリ本体 (`src/`) は変更なし

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル個別実行で確認
  - `node scripts/measure-lp-dimensions.mjs` PASS (`SKIP_SCREENSHOT_EXISTENCE_CHECK=1`)
  - `node scripts/check-lp-inline-style.mjs` PASS (baseline 同等)
  - `node scripts/check-lp-removal-residue.mjs` PASS (新規残骸なし)
- [x] 追加・変更したテストの概要: **N/A** — LP 静的 CSS の値変更のみ、ユニット / E2E テストの追加は不要 (CI `lp-metrics` ジョブで回帰防止)
- [x] **新規 env / secret 追加時** — **N/A**
- [x] **DynamoDB 実装変更時** — **N/A**
- [x] **Critical バグ修正の場合** — **N/A** (priority:medium、a11y contrast 補完)

## スクリーンショット / ビジュアルデモ

> **#2056 Re-Review #2 で SS 4 枚を撮影 + screenshots branch (`pr-2056/`) に push 完了**。
> `.sep` (graduation.html breadcrumb 階層関係) と `.hpb-dot` (index.html hero-price-band 項目区切り) は階層 / 区切りの可読性に視覚効果あり。

| Selector | Before (Desktop) | After (Desktop) |
|---|---|---|
| `.sep` (graduation.html, breadcrumb) | ![sep-before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2056/sep-before-desktop.png) | ![sep-after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2056/sep-after-desktop.png) |
| `.hpb-dot` (index.html, hero-price-band) | ![hpb-dot-before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2056/hpb-dot-before-desktop.png) | ![hpb-dot-after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2056/hpb-dot-after-desktop.png) |

**SS 撮影手段**: `node scripts/capture.mjs --section <css>` で section locator 切り出し、Playwright DOM snapshot (`*.dom.html`) でコントラスト値 (`color: var(--gray-300/400/500)`) を構造的検証 (#1747 AC4 / #1766)。

**SS 範囲外** (PR #2056 で撮影しない理由):
- `.pp-dot` (index.html pricing-promise band): `.hpb-dot` と完全に同種の修正 (gray-400 → gray-500、`.` 区切り字、ホワイト背景) のため `.hpb-dot` SS で代表 — 撮影重複回避
- `.cross` (pamphlet.html): dead CSS (HTML 要素 0 件)、SS 撮影しても変化を可視化できない (DOM 検証が SSOT)

**インタラクティブ状態**: N/A (静的 CSS rule 値のみ)

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: CSS 値変更のみ、責務分離影響なし
- [x] **DRY**: 3 箇所の修正パターンは `.dash` (pricing.html) と完全に同じ「essential graphics の gray-300/400 → gray-500 昇格」。CSS の `--gray-500` セマンティックトークンで一元化済
- [x] **YAGNI**: 必要箇所のみ修正、過剰抽象化なし。dead CSS (`.cross` / `.disabled`) は a11y 修正対象から除外
- [x] **Security**: N/A
- [x] **アクセシビリティ**: WCAG 1.4.11 (非テキスト 3:1) を全 3 箇所で達成。WCAG 2.1 AA のさらに強い 4.5:1 (Level AA テキスト) を満たす gray-500 を採用
- [x] **パフォーマンス**: CSS 値変更のみ、bundle size 影響なし

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期 — N/A (LP のみ)
- [ ] **LP ↔ アプリ双方向整合** — N/A (アプリ側 `--color-text-tertiary` 等は既に PASS、`docs/DESIGN.md §2` トークン定義済)
- [ ] 全年齢モード 5 種 — N/A
- [ ] ナビゲーション 3 種 — N/A
- [ ] E2E / ユニットシード / チュートリアル — N/A
- [ ] **labels SSOT** — N/A (CSS のみ)
- [ ] **設計書同期** — N/A (`docs/DESIGN.md §2` の Semantic トークン体系は不変、本 PR は LP 個別ファイルでの var 参照値修正のみ)
- [x] **並行 PR overlap** — `site/index.html` / `site/pamphlet.html` は他 LP 系 PR で同時編集中だが、本 PR の変更は `.sep` / `.hpb-dot` / `.pp-dot` の 3 行 + `.cross` 撤回 1 行のみで、構造的衝突は発生しにくい (rebase 吸収可)
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A — 文言変更なし、CSS のみ

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- 3 箇所の修正は全て `.dash` (PR #2047) と同種の「essential graphics gray-300/400 → gray-500 昇格」パターン。コントラスト比は手計算で確認済 (gray-300=#cbd5e1 → 1.6:1、gray-400=#94a3b8 → 2.8:1、gray-500=#64748b → 4.6:1、いずれも on white)
- 不変判定 3 件 (`floating-cta-text small` / `text-decoration-color` / `.cross`) は WCAG 適合済または dead CSS (HTML 要素 0 件) のため不修正の判断
- **Re-Review #2 で `.cross` dead CSS 修正を撤回**: pamphlet.html plan-features は `<span class="check">` のみで構成され機能未対応マーク (✕) 表示設計を持たないため、`.cross` への gray-500 適用は a11y 改善効果ゼロ。PR #2047 `.disabled` を dead CSS のまま AC PASS と主張した過ちの再現を防ぐため、commit 3e3eaf43 で gray-500 → gray-300 に戻した
- 本 PR は PR #2047 の broader audit を完遂する独立 PR (PR #2047 は merge 完了済、新ブランチで起票)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** ローカル確認済 (LP-specific step を個別実行)
- [x] セルフレビュー済み (不要な差分・デバッグコードなし)
- [x] 全 AC が実装済み
- [x] Phase 分割 — N/A (1 PR で完遂)
- [x] UI 変更時 SS — **#2056 Re-Review #2 で 4 SS 添付完了** (`.sep` Before/After Desktop + `.hpb-dot` Before/After Desktop)
- [x] 認証画面変更時 — N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
