### PR TITLE
fix: #2068 LP CSP の connect-src に jsdelivr を追加 (sourcemap CSP violation 解消)

### DIFF
--- a/docs/decisions/0029-lp-csp-and-cdn-sri-strategy.md
+++ b/docs/decisions/0029-lp-csp-and-cdn-sri-strategy.md
@@ -2,10 +2,10 @@
 
 | 項目 | 内容 |
 |------|------|
-| ステータス | **accepted (2026-05-01)** |
+| ステータス | **accepted (2026-05-01、2026-05-14 connect-src amendment #2068)** |
 | 日付 | 2026-05-01 |
 | 起票者 | PO |
-| 関連 Issue | #1719 / #1683 / #1701 / #1705 |
+| 関連 Issue | #1719 / #1683 / #1701 / #1705 / #2068 (connect-src amendment) |
 | 関連 ADR | ADR-0010 (Pre-PMF スコープ) / ADR-0024 (インフラ PR baseline) / ADR-0025 (LP SSOT 注入機構 + DOMPurify) |
 
 ## コンテキスト
@@ -70,7 +70,7 @@ GitHub Pages では HTTP レスポンスヘッダー（`Content-Security-Policy:
 CSP 内容（全 10 ファイル共通）:
 
 ```html
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 ```
 
 各指令の根拠:
@@ -82,7 +82,7 @@ CSP 内容（全 10 ファイル共通）:
 | `style-src` | `'self' 'unsafe-inline' https://cdn.jsdelivr.net` | `'unsafe-inline'`: 一部 inline `style="..."` 属性 (13 件 / 3 ファイル) と JSDOM 互換用。`https://cdn.jsdelivr.net`: splide-core CSS (index.html) |
 | `img-src` | `'self' data: blob:` | LP 内画像 + favicon (PNG) + OGP + 開発時の data: URI |
 | `font-src` | `'self'` | 外部フォント未使用（system-ui のみ） |
-| `connect-src` | `'self'` | 動的 fetch / XHR は無し（LP は完全静的） |
+| `connect-src` | `'self' https://cdn.jsdelivr.net` | 動的 fetch / XHR は無いが、ブラウザ DevTools が読み込んだ jsDelivr 配信 JS の sourcemap (`.map`) を connect-src 経由で取得しようとする (#2068)。`'self'` のみだと Chrome console に CSP violation 3 件 (splidejs / DOMPurify / budoux の sourcemap) が常時表示される。jsDelivr は既に `script-src` で許可済の origin なので sourcemap も同許可で揃える（OWASP CSP Cheat Sheet 整合）。実害となる動的 fetch / XHR は LP に無し、ホワイトリストは sourcemap 取得のみ |
 | `object-src` | `'none'` | プラグイン (`<object>` / `<embed>`) 一切禁止 |
 | `base-uri` | `'self'` | `<base>` 経由の URL 書き換え攻撃を防止 |
 | `form-action` | `'self'` | フォーム submit 先を同 origin に限定（contact form は `mailto:` なので `'self'` で問題なし、ブラウザ側で `mailto:` は除外扱い） |

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -227,7 +227,7 @@ HTTP レスポンスヘッダーで CSP を付与できないため、`<meta htt
 **CSP 内容**（全ページ共通）:
 
 ```html
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 ```
 
 **指令の根拠**:
@@ -239,7 +239,7 @@ HTTP レスポンスヘッダーで CSP を付与できないため、`<meta htt
 | `style-src` | `'self' 'unsafe-inline' https://cdn.jsdelivr.net` | splide-core CSS を allowlist。`'unsafe-inline'` は一部 inline `style="..."` 属性用 |
 | `img-src` | `'self' data: blob:` | 同 origin 画像 + favicon + OGP + データ URI |
 | `font-src` | `'self'` | 外部フォント未使用（system-ui） |
-| `connect-src` | `'self'` | LP は完全静的、外部 fetch 無し |
+| `connect-src` | `'self' https://cdn.jsdelivr.net` | LP の動的 fetch / XHR は無いが、ブラウザ DevTools が jsDelivr 配信 JS の sourcemap (`.map`) を `connect-src` 経由で取得する (#2068)。`'self'` のみだと Chrome console に CSP violation 3 件 (splidejs / DOMPurify / budoux sourcemap) が常時表示される。`script-src` で既に許可済の origin と揃える |
 | `object-src` | `'none'` | `<object>` / `<embed>` プラグイン禁止 |
 | `base-uri` | `'self'` | `<base>` 注入による URL 書き換え攻撃防止 |
 | `form-action` | `'self'` | フォーム送信先を同 origin に限定 |

--- a/site/faq.html
+++ b/site/faq.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- ADR-0029 (#1719): LP CSP 多層防御。DOMPurify サニタイズ (ADR-0025) と並ぶ第二層 -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 <title data-lp-key="faqB.k1">よくあるご質問 - がんばりクエスト</title>
 <meta name="description" content="がんばりクエストの保護者向けよくあるご質問。料金・トライアル・プライバシー・年齢・兄弟姉妹・データ管理について 24 項目にお答えします。">
 <meta property="og:title" content="よくあるご質問 - がんばりクエスト">

--- a/site/graduation.html
+++ b/site/graduation.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- ADR-0029 (#1719): LP CSP 多層防御。DOMPurify サニタイズ (ADR-0025) と並ぶ第二層 -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 <title data-lp-key="growthRoadmap.pageTitle">成長ロードマップ - がんばりクエスト</title>
 <meta name="description" content="がんばりクエストの成長ロードマップ。幼児（3-5歳）から高校生（16-18歳）、そして「卒業」まで、お子さまの成長に合わせて UI と機能が変化していく様子を実画面付きで紹介。">
 <meta property="og:title" content="成長ロードマップ - がんばりクエスト">

--- a/site/help/license-key.html
+++ b/site/help/license-key.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- ADR-0029 (#1719): LP CSP 多層防御。DOMPurify サニタイズ (ADR-0025) と並ぶ第二層 -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 <title data-lp-key="licenseKey.text1">ライセンスキーの使い方 - がんばりクエスト ヘルプ</title>
 <meta property="og:title" content="ライセンスキーの使い方 - がんばりクエスト">
 <meta property="og:type" content="website">

--- a/site/index.html
+++ b/site/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- ADR-0029 (#1719): LP CSP 多層防御。DOMPurify サニタイズ (ADR-0025) と並ぶ第二層。
      SRI / pin 戦略マトリクス: 特定 pin (splidejs) は SRI 必須、major pin (DOMPurify @3 / budoux @latest) は CSP allowlist 経由で守る -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 <title data-lp-key="indexB.k1">がんばりクエスト — 「やりなさい」を「やりたい！」に変える家族の冒険アプリ</title>
 <meta name="description" content="がんばりクエストは、お子さまの毎日のがんばりをRPG風の冒険に変える家庭向けWebアプリ。ポイント、レベルアップ、チャレンジで「自分から動く力」を育てます。3歳から18歳までのお子さまに対応（0〜2歳のお子さまは保護者向けの準備モードでご利用いただけます）。">
 <meta property="og:title" content="がんばりクエスト — 「やりなさい」を「やりたい！」に変える家族の冒険アプリ">

--- a/site/pamphlet.html
+++ b/site/pamphlet.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- ADR-0029 (#1719): LP CSP 多層防御。DOMPurify サニタイズ (ADR-0025) と並ぶ第二層 -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 <title data-lp-key="pamphletB.k1">がんばりクエスト パンフレット</title>
 <meta property="og:title" content="がんばりクエスト パンフレット">
 <meta property="og:type" content="website">

--- a/site/pricing.html
+++ b/site/pricing.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- ADR-0029 (#1719): LP CSP 多層防御。DOMPurify サニタイズ (ADR-0025) と並ぶ第二層 -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 <title data-lp-key="pricing.pageTitle">料金プラン - がんばりクエスト</title>
 <meta name="description" content="がんばりクエストの料金プラン。基本無料で始められます。スタンダード月額500円（税込）、ファミリー月額780円（税込）。すべての有料プランに 7 日間無料トライアル付き。">
 <meta property="og:title" content="料金プラン - がんばりクエスト">

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- ADR-0029 (#1719): LP CSP 多層防御。DOMPurify サニタイズ (ADR-0025) と並ぶ第二層 -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 <title>プライバシーポリシー - がんばりクエスト</title>
 <meta property="og:title" content="プライバシーポリシー - がんばりクエスト">
 <meta property="og:type" content="website">

--- a/site/selfhost.html
+++ b/site/selfhost.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- ADR-0029 (#1719): LP CSP 多層防御。DOMPurify サニタイズ (ADR-0025) と並ぶ第二層 -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 <title data-lp-key="selfhost.text1">セルフホスト版ガイド - がんばりクエスト</title>
 <meta name="description" content="がんばりクエストのセルフホスト版（OSS）のセットアップガイド。Docker で自宅サーバーや NAS に簡単にインストールできます。">
 <meta property="og:title" content="セルフホスト版ガイド - がんばりクエスト">

--- a/site/sla.html
+++ b/site/sla.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- ADR-0029 (#1719): LP CSP 多層防御。DOMPurify サニタイズ (ADR-0025) と並ぶ第二層 -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 <title>サービスレベル合意（SLA） - がんばりクエスト</title>
 <meta name="robots" content="noindex">
 <meta property="og:title" content="サービスレベル合意（SLA） - がんばりクエスト">

--- a/site/terms.html
+++ b/site/terms.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- ADR-0029 (#1719): LP CSP 多層防御。DOMPurify サニタイズ (ADR-0025) と並ぶ第二層 -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 <title>利用規約 - がんばりクエスト</title>
 <meta property="og:title" content="利用規約 - がんばりクエスト">
 <meta property="og:type" content="website">

--- a/site/tokushoho.html
+++ b/site/tokushoho.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!-- ADR-0029 (#1719): LP CSP 多層防御。DOMPurify サニタイズ (ADR-0025) と並ぶ第二層 -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; form-action 'self'">
 <title>特定商取引法に基づく表記 - がんばりクエスト</title>
 <meta name="robots" content="noindex">
 <meta property="og:title" content="特定商取引法に基づく表記 - がんばりクエスト">

--- a/tests/e2e/lp-csp.spec.ts
+++ b/tests/e2e/lp-csp.spec.ts
@@ -105,6 +105,11 @@ test.describe('#1719 / ADR-0029 LP CSP 多層防御', () => {
 			expect(cspContent, 'script-src に jsdelivr を allowlist').toMatch(
 				/script-src[^;]*https:\/\/cdn\.jsdelivr\.net/,
 			);
+			// #2068: connect-src にも jsdelivr を allowlist する必要がある
+			// (ブラウザ DevTools が jsdelivr 配信 JS の sourcemap を connect-src 経由で取得するため)
+			expect(cspContent, 'connect-src に jsdelivr を allowlist (#2068)').toMatch(
+				/connect-src[^;]*https:\/\/cdn\.jsdelivr\.net/,
+			);
 			expect(cspContent, 'style-src に self を含む').toMatch(/style-src[^;]*'self'/);
 			expect(cspContent, "object-src 'none' で <object>/<embed> 禁止").toMatch(
 				/object-src\s+'none'/,


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: LP 訪問者・サインアップ候補者 / 開発者・運営

**解決する課題**: LP (`https://www.ganbari-quest.com/index.html` 他全 11 ページ) を Chrome で開くと DevTools console に CSP violation が 3 件 (splidejs / DOMPurify / budoux の sourcemap.map) が常時表示されており、訪問した開発者・技術者からの「動作品質に問題があるサービス」という印象毀損リスクがある。

**期待される効果**: console 上の CSP violation を 0 件にし、開発者・サインアップ候補者が DevTools を開いた際の信頼性印象を保つ。実害なし機能の violation でも常時 3 件表示は「未整備感」を与えるため修正。

## 関連 Issue

closes #2068

関連: #2075 (main labels.ts biome formatting 退行、本 PR スコープ外で別 Issue) / #2078 (cohort-analysis date-dependent flaky test、本 PR スコープ外で別 Issue)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | LP 全 11 ページ (`site/*.html`) で `connect-src` に `https://cdn.jsdelivr.net` が含まれる | `git diff origin/main -- 'site/*.html' \| grep "connect-src 'self' https://cdn.jsdelivr.net"` で 11 件 | PASS (11 ファイル全件確認、`site/faq.html` / `graduation.html` / `help/license-key.html` / `index.html` / `pamphlet.html` / `pricing.html` / `privacy.html` / `selfhost.html` / `sla.html` / `terms.html` / `tokushoho.html`) |
| AC2 | `tests/e2e/lp-csp.spec.ts` に connect-src jsdelivr の assertion を追加 | `git diff origin/main -- tests/e2e/lp-csp.spec.ts` | PASS (line 105-109 に `expect(cspContent, 'connect-src に jsdelivr を allowlist (#2068)').toMatch(...)` 追加) |
| AC3 | ADR-0029 / セキュリティ設計書 §7.1.2 の `connect-src` 行を同期 | `git diff origin/main -- docs/decisions/0029-lp-csp-and-cdn-sri-strategy.md docs/design/14-セキュリティ設計書.md` | PASS (amendment 履歴 + connect-src 表行更新) |
| AC4 | LP メトリクス閾値違反なし | `SKIP_SCREENSHOT_EXISTENCE_CHECK=1 node scripts/measure-lp-dimensions.mjs` | PASS (`[OK] all LP metrics within thresholds`) |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [x] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: LP 全 11 ページ (`site/*.html`)。視覚的変化なし、Chrome DevTools console の CSP violation 3 件のみ消失。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2072` 全 Step PASS** — N/A（Step 1 (biome check) で main 起因の `src/lib/domain/labels.ts` formatting エラー (#2075) により停止。本 PR 変更とは無関係、別 Issue 起票済。代替検証: 個別 `npx biome check tests/e2e/lp-csp.spec.ts` PASS + `SKIP_SCREENSHOT_EXISTENCE_CHECK=1 node scripts/measure-lp-dimensions.mjs` PASS）
- [x] 追加・変更したテストの概要: `tests/e2e/lp-csp.spec.ts` に `connect-src に jsdelivr を allowlist (#2068)` の assertion を追加（既存の `script-src` 検証と同パターン）
- [x] **新規 env / secret 追加時**: N/A（HTML meta CSP のみの変更で env / secret は不変）
- [x] **DynamoDB 実装変更時**: N/A（DB 変更なし）
- [x] **Critical バグ修正の場合**: N/A（深刻度 low）

## スクリーンショット / ビジュアルデモ

**4 スロット添付**:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし（CSP meta 変更のみ） | 該当なし（CSP meta 変更のみ） |
| **修正後** | 該当なし（CSP meta 変更のみ） | 該当なし（CSP meta 変更のみ） |

**該当なし（理由）**: 本 PR は `<head>` 内の `<meta http-equiv="Content-Security-Policy">` の `connect-src` 値のみ変更しており、レンダリング結果に視覚的 diff は一切出ない。証跡は以下で代替:

- `tests/e2e/lp-csp.spec.ts` の `connect-src` allowlist 検証 assertion 追加（CI で全 10 ページに対し自動検証）
- 既存テスト `index.html ロード時に CSP violation が発生しない` (line 118-) が本変更後も PASS（sourcemap CSP violation 3 件が消失したことを間接検証）
- Chrome DevTools console での Before / After 比較は #2068 Issue body の image に `Refused to connect to ... .map` 3 件が記載されているため、修正後にこの 3 件が消えれば AC 達成

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: CSP meta tag 値の 1 行変更で責務分離・依存性逆転は不変
- [x] **DRY**: 11 LP ファイル全件に同じ変更を一括適用。`docs/decisions/0029` / `docs/design/14-セキュリティ設計書.md` に SSOT として記録、設計書と実装が乖離しない
- [x] **YAGNI**: `connect-src` の allowlist 追加は 1 origin (`https://cdn.jsdelivr.net`) のみ、過剰防衛にならない最小変更
- [x] **Security (OSS 公開前提)**: jsdelivr は既に `script-src` で許可済の origin。`connect-src` 拡張は sourcemap 取得 (`.map`) 経路のみで、XSS / IDOR 経路にならない。CSP の他指令 (object-src 'none' / base-uri 'self' / form-action 'self') は無変更で防御維持
- [x] **アクセシビリティ**: HTML meta タグ変更のみで A11y 影響なし
- [x] **パフォーマンス**: bundle size / runtime 影響ゼロ。sourcemap は元々 DevTools 開いた時のみ要求されるため通常訪問者には影響なし

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照）:

- [ ] 本番アプリ + デモ版を同期 — N/A（LP のみ、`/demo/**` 配下は SvelteKit `hooks.server.ts` 経由の独立 CSP）
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）— N/A（CSP は表示文言ではなく HTTP セキュリティ機構）
- [ ] 全年齢モード 5 種 — N/A（LP は年齢モード非依存）
- [ ] ナビゲーション 3 種 — N/A（CSP meta は `<head>` で navigation 構造に影響なし）
- [ ] E2E / ユニットシード / チュートリアル — N/A（tests/e2e/lp-csp.spec.ts のみ更新、seed / tutorial 影響なし）
- [ ] **labels SSOT** (ADR-0009 / ADR-0045) — N/A（CSP は ADR-0029 / セキュリティ設計書 SSOT）
- [x] **設計書同期** (ADR-0001): ADR-0029 + `docs/design/14-セキュリティ設計書.md §7.1.2` の `connect-src` 行を同 PR で更新
- [x] **並行 PR overlap** (#1200): `site/*.html` 11 ファイル全件を変更するため `pr-info.yml` overlap-check の警告は無視できる（本 PR 自体が 11 LP ファイル一括更新の正本）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A（CSP meta タグ変更のみ、ユーザー可視文言は無変更） | — | — |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**: 

1. ADR-0029 の `connect-src 'self'` から `'self' https://cdn.jsdelivr.net` への amendment が同 ADR §決定 1 (CSP 内容) / §決定 5 (SRI / pin マトリクス) と整合しているか確認
2. `tests/e2e/lp-csp.spec.ts` の新規 assertion が既存の `script-src` 検証と同パターンで実装されているか確認
3. CI fail (`lint-and-test` / `unit-test (1)` / `unit-test-merge`) は main 起因 (#2075 / #2078) のため本 PR の責務外。本 PR の `site-check` / `e2e-test` / `screenshot-check` 系が PASS していることを確認

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2072` 全 Step PASS** ローカル確認 — N/A（Step 1 で main 起因 #2075 により停止、本 PR scope 外。代替検証: 個別ファイル biome check / measure-lp-dimensions / E2E lp-csp.spec.ts 追加 assertion で AC 全件カバー）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了の AC は残っていない）
- [x] Phase 分割なし
- [x] UI 変更時 SS — 視覚的 diff 無しのため添付不要、E2E lp-csp.spec.ts で代替検証
- [x] 認証画面変更時 SS — N/A（認証画面は本 PR 影響範囲外）

### main 起因の既知 CI fail（本 PR スコープ外、Issue 起票済）

CI の `lint-and-test` / `unit-test (1)` / `unit-test-merge` ジョブが fail。原因は **main の既存退行 2 件**で、本 PR の CSP 変更とは無関係:

1. **#2075 — labels.ts biome formatting 退行**
   - `planFreeDesc` / `planStandardPersona` が 2 行 string 形式のまま残り、biome 2.4.10 の "1 行に収まる場合は 1 行に統合" ルールに違反
   - main の HEAD で `npx biome check src/lib/domain/labels.ts` を実行すると単独で再現
   - 影響: `lint-and-test` job fail
2. **#2078 — cohort-analysis-service.test.ts date-dependent flaky**
   - `Date.now() - 100 days` 基準テストが 2026-05-14 時点で retention[90]=null を返し fail
   - main の HEAD で `npx vitest run tests/unit/services/cohort-analysis-service.test.ts` を実行すると単独で再現
   - 影響: `unit-test (1)` + `unit-test-merge` job fail

**両 Issue を起票して別 PR で対応**（feedback_ci_failure_responsibility / feedback_root_cause_first_principle に従い、本 PR scope は CSP に限定）。本 PR 自身の CSP 変更による回帰は無し（追加した `tests/e2e/lp-csp.spec.ts` の `connect-src` assertion で検証）。Issue #2075 / #2078 が merge されれば本 PR の CI も自動的に green になる想定。

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
