### PR TITLE
fix: #2078 cohort-analysis-service.test.ts Day 90 境界 flake 解消

### DIFF
--- a/tests/unit/services/cohort-analysis-service.test.ts
+++ b/tests/unit/services/cohort-analysis-service.test.ts
@@ -246,15 +246,17 @@ describe('getCohortAnalysis', () => {
 	});
 
 	it('リテンションが Day N ごとに返される', async () => {
+		// #2078: 120 日前のコホートを使い、Day 90 経過判定が確実に true になるよう余裕を持たせる。
+		// 旧実装は 100 日前を `monthDate(oldMonth)` (day=15) に丸めていたため、暦の組合せで
+		// 実際の経過日数が ~88 日になり Day 90 で eligibleTenants が空 → retention[90] = null になっていた。
 		const now = new Date();
-		// 90日以上前のコホート
-		const oldDate = new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000);
+		const oldDate = new Date(now.getTime() - 120 * 24 * 60 * 60 * 1000);
 		const oldMonth = `${oldDate.getFullYear()}-${String(oldDate.getMonth() + 1).padStart(2, '0')}`;
 
 		mockListAllTenants.mockResolvedValue([
 			makeTenant({
 				tenantId: 't1',
-				createdAt: monthDate(oldMonth),
+				createdAt: oldDate.toISOString(),
 				status: SUBSCRIPTION_STATUS.ACTIVE,
 			}),
 		]);
@@ -263,11 +265,10 @@ describe('getCohortAnalysis', () => {
 		const result = await getCohortAnalysis(6);
 
 		const oldCohort = result.cohorts.find((c) => c.month === oldMonth);
-		if (oldCohort) {
-			// 90日以上前なので全 Day N が計算されるはず
-			for (const dayN of RETENTION_DAYS) {
-				expect(oldCohort.retention[dayN]).not.toBeNull();
-			}
+		expect(oldCohort).toBeDefined();
+		// 120 日以上前なので全 Day N が計算されるはず (ADR-0006 assertion 強化、#2078)
+		for (const dayN of RETENTION_DAYS) {
+			expect(oldCohort?.retention[dayN]).not.toBeNull();
 		}
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

main HEAD で `tests/unit/services/cohort-analysis-service.test.ts > リテンションが Day N ごとに返される` が **2026-05-14 時点で常時 fail** していた flaky を解消する。本テストの fail により main 派生 PR の `unit-test (1)` / `unit-test-merge` job が軒並み fail し、CI 通過性を阻害していた。

**根本原因**: 旧実装は 100 日前を `monthDate(oldMonth)` (day=15 固定) に丸めていたため、暦の組合せ (例 today=2026-05-14 → 2026-02-15 = ~88 日経過) で Day 90 経過判定が境界をまたぎ、eligibleTenants が空 → retention[90] = null になっていた。

## 関連 Issue

closes #2078, closes #2080

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `npx vitest run tests/unit/services/cohort-analysis-service.test.ts` 全 PASS | ローカル実行 | PASS — Tests 15 passed (15) |
| AC2 | 暦組合せに依存しない (任意の今日に対し fail しない) | 120 日 + `toISOString()` で日数固定 | PASS — 120 > 90 + 暦変換非経由 |
| AC3 | ADR-0006 assertion 強化: 旧 `if (oldCohort) { ... }` 弱体化解消 | `expect(oldCohort).toBeDefined()` 追加 | PASS — oldCohort 不在で fail に変更 |
| AC4 | main 派生 PR の `unit-test (1)` / `unit-test-merge` 復活 | 本 PR merge 後 #2072 / #2073 / #2074 / #2076 / #2077 / #2079 / #2081 / #2082 で re-run | merge 後検証 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正 (flaky test 解消)
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] テストコード (`tests/unit/services/cohort-analysis-service.test.ts`)

**影響を受ける画面・機能**:
- 単体テストのみ。プロダクションコード (`src/lib/server/services/cohort-analysis-service.ts`) は無変更。
- 100 日 → 120 日に拡大 + `monthDate()` → `toISOString()` で暦組合せ非依存
- `if (oldCohort) { ... }` → `expect(oldCohort).toBeDefined()` で ADR-0006 assertion 強化

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/services/cohort-analysis-service.test.ts` PASS (15/15)
- [x] biome / svelte-check (テストのみ変更、ランタイム影響ゼロ)
- [x] ADR-0006 assertion 弱体化禁止に**順方向**(silently pass → 明示 fail)

## スクリーンショット / ビジュアルデモ

N/A — テスト修正のみ、UI 影響ゼロ。

## コード品質セルフレビュー (#1481)

- 修正理由を test 内コメントで明記 (#2078 教訓を local context として残存)
- ADR-0006 への参照を assertion 強化コメントに明記
- プロダクションコード無変更 (cohort-analysis-service.ts はビジネスロジックとしては正しい — 100 日経過判定は元から正常)

## 横展開・影響波及チェック

本 PR merge 後、main 派生の以下 PR で `unit-test (1)` / `unit-test-merge` re-run 必要:
- PR #2072 (#2068 LP CSP)
- PR #2074 (#2059 capture sha256 guard)
- PR #2076 (#2061 namespace 重複検査)
- PR #2077 (#2060 dev-open-pr skill gate)
- PR #2079 (#2069 SvelteKit DI POC)
- PR #2081 (#2075 biome labels)
- PR #2082 (#1914 5 ドメイン SSOT)

## レビュー依頼事項・破壊的変更

破壊的変更なし。テスト fixture の日数を 100 → 120 に拡大、`monthDate()` ヘルパー使用を直接 `toISOString()` に変更。`if (oldCohort)` 弱体化 assertion を `expect(oldCohort).toBeDefined()` に強化。

## 配布済み env / secret (ADR-0006)

N/A

## Ready for Review チェックリスト

- [x] CI 全緑見込 (本 PR の `unit-test (1)` PASS = AC1 完了)
- [x] PR 本文 13 必須セクション保持
- [x] SS N/A (テスト修正のみ)
- [x] ADR-0006 assertion 強化方向

## QM レビュー結果

(QM レビュー時記入)