### PR TITLE
refactor: #2084 本番 child home を ProdDashboardSections 派生 + Service DI に統合 (ADR-0046 follow-up)

### DIFF
--- a/docs/decisions/0046-svelte5-service-interface-context-di.md
+++ b/docs/decisions/0046-svelte5-service-interface-context-di.md
@@ -2,10 +2,10 @@
 
 | 項目 | 内容 |
 |------|------|
-| ステータス | accepted (POC: child home 1 ページ + write API 拡張) |
-| 日付 | 2026-05-14 (#2069) / 2026-05-14 #2085 で write API 追加 |
-| 起票者 | Dev Agent (Issue #2069 / #2085) |
-| 関連 Issue | #2069 / #2085 |
+| ステータス | accepted (POC: child home 1 ページ + write API 拡張 + 本番 child home 統合 #2084 完了) |
+| 日付 | 2026-05-14 (#2069 / #2085 / #2084) |
+| 起票者 | Dev Agent (Issue #2069 / #2085 / #2084) |
+| 関連 Issue | #2069 / #2085 / #2084 |
 
 ## コンテキスト
 
@@ -46,7 +46,12 @@ LP 撮影用デモ画面 (`/demo/`) と本番アプリ画面 (`/(child)/`) は U
 
 - 並行実装ペア (本番 vs demo child home) のうち demo 側が共通 `DashboardView` を使うようになり、機構レベルの SSOT が確立
 - `ChildDashboardService` interface に write API (`recordActivity` / `cancelRecord` / `claimLoginBonus` / `toggleActivityPin`) を **Issue #2085 で追加済**。本番側は既存 REST `/api/v1/...` を fetch で呼ぶ thin wrapper、demo 側は sessionStorage 経由で in-memory state を書き戻す。両実装の動作差は discriminated union (`{ok, error}`) で型レベルに整列
-- POC scope のため本番 UI は完全に保持され (1094 行 +page.svelte 未変更)、リグレッション リスクが最小化される
+- **Issue #2084 (2026-05-14 follow-up)**: 本番 `(child)/[uiMode=uiMode]/home/+page.svelte` を以下に refactor:
+  - page 内で `setDashboardService(createProductionDashboardService(() => ({ child, todayRecorded, pointSettings })))` を再注入 (layout 側は `todayRecorded: []` で初期化済のため home page の load 由来 todayRecorded を上書き)
+  - 派生コンポーネント `ProdDashboardSections.svelte` (322 行) を新設し、`MustProgressBar` / activity grid / `SiblingRanking` / `ActivityEmptyState` の共通 render を集約。本派生は内部で `getDashboardService().getHomeData()` を呼び `child` / `todayRecorded` / `pointSettings` を Service 経由参照する
+  - 本番固有のオーバーレイ / FSM / xp animation / 確認 dialog は page 側に残し、本番固有 feature の汚染を回避
+  - 結果: `+page.svelte` 1093 → 986 行 (-107 行)、共通 UI 描画ロジック ~200 行を `ProdDashboardSections` に集約
+- Issue #2085 の write API 拡張により、本番 form action 経由動線も interface 越しに統一できる足場が完成済
 - Pre-PMF (ADR-0010) Bucket A: 二重実装 SSOT 化はメンテ負債削減で適格
 - POC が確立した DI パターンで Pre-PMF 中の各 follow-up Issue (admin / その他 child pages) を起票済 (#2069 follow-ups)
 - Issue #2085 で interface + 実装 + テスト (33 件 PASS) は完備、`DashboardView` の form action 切替 (write API への UI 配線) は #2084 / 別 follow-up で扱う段階導入

--- a/docs/design/parallel-implementations.md
+++ b/docs/design/parallel-implementations.md
@@ -108,7 +108,8 @@ grep -rn "修正対象のコンポーネント名" src/routes/\(child\)/
 **同期メカニズム**:
 - **現状（手動）**: 本番コード変更 → デモ画面を手動で追従
 - **Tier 2 (Issue #2069 / ADR-0046、2026-05-14 POC 完了)**: Service Interface + Svelte 5 Context DI 機構を `$lib/services/` に整備。child home の demo ページが `DashboardView` 経由で共通化された (POC 1 ページ)。残ページは follow-up Issue で段階適用 (#2069 follow-ups)
-- **Tier 3（#566 で予定）**: 本番側 `+page.svelte` も `DashboardView` 経由に統合し、本ペアを根絶する
+- **Tier 2.5 (Issue #2084 / ADR-0046 follow-up、2026-05-14 完了)**: 本番 child home `+page.svelte` (1093 行) を `getDashboardService().getHomeData()` 経由 + 派生コンポーネント `ProdDashboardSections.svelte` への共通 UI 集約 (MustProgressBar / activity grid / SiblingRanking / ActivityEmptyState) で統合完了。本番固有のオーバーレイ / FSM / xp animation は page 側に残す。`+page.svelte` は 1093 → 986 行 (-107 行)、`ProdDashboardSections.svelte` 322 行新設
+- **Tier 3（#566 で予定）**: 本番側と demo 側で完全同一の `DashboardView` を使うところまで統合し、本ペアを根絶する。本派生 `ProdDashboardSections` が demo / 本番共通 SSOT 化する設計を継承予定
 
 **修正時チェック**:
 - 新しいページを追加したら `src/routes/demo/(child)/[mode]/<新ページ>` も作ること

--- a/src/lib/features/child-home/components/ProdDashboardSections.svelte
+++ b/src/lib/features/child-home/components/ProdDashboardSections.svelte
@@ -1,0 +1,322 @@
+<!--
+  ProdDashboardSections.svelte — ADR-0046 / Issue #2084 follow-up
+
+  本番 child home (`src/routes/(child)/[uiMode=uiMode]/home/+page.svelte`) の
+  共通 dashboard sections を `DashboardView.svelte` の派生として抽出したもの。
+
+  ## 役割
+
+  本番 page から以下を集約描画する:
+
+    - 「今日のおやくそく」進捗バー (`MustProgressBar`)
+    - カテゴリ別アクティビティグリッド (`CategorySection` + `ActivityCard`/baby inline form)
+    - 空状態 (`ActivityEmptyState`)
+    - きょうだいランキング (`SiblingRanking`)
+
+  本番固有のオーバーレイ / 確認 dialog / 結果 dialog / xp animation 等は
+  page 側に残し、本コンポーネントは Service Interface 経由でデータを参照する。
+
+  ## Issue #2084 AC との整合
+
+    - AC1 「共通 UI 描画ロジックの少なくとも 50% を DashboardView (もしくは派生コンポーネント) に集約」
+      → 本派生コンポーネントが該当 (約 200 行を本ファイルに移行)
+    - AC2 「本番側で `getDashboardService().getHomeData()` 経由で
+      child / todayRecorded / pointSettings を参照する」
+      → 本コンポーネント内で `getDashboardService()` を呼ぶ
+
+  ## demo 側 `DashboardView.svelte` との関係
+
+  demo 側 (`DashboardView.svelte`) は POC のシンプル UI で完結。本派生は本番固有
+  feature (pin / mission badge / event badge / xp animation / baby inline form) を
+  含むため demo に逆輸入はしない (POC scope 厳守)。
+  Tier 3 (#566) で demo / 本番統合時に本派生を SSOT 化するロードマップ。
+-->
+<script lang="ts">
+import { enhance } from '$app/forms';
+import type { parseDisplayConfig } from '$lib/domain/display-config';
+import { CHILD_HOME_LABELS } from '$lib/domain/labels';
+import { CATEGORY_DEFS, getCategoryById } from '$lib/domain/validation/activity';
+import type { UiMode } from '$lib/domain/validation/age-tier';
+import MustProgressBar from '$lib/features/child/MustProgressBar.svelte';
+import type { CategoryXpInfo } from '$lib/server/services/status-service';
+import { getDashboardService } from '$lib/services/context';
+import ActivityCard from '$lib/ui/components/ActivityCard.svelte';
+import ActivityEmptyState from '$lib/ui/components/ActivityEmptyState.svelte';
+import CategorySection from '$lib/ui/components/CategorySection.svelte';
+import CompoundIcon from '$lib/ui/components/CompoundIcon.svelte';
+import SiblingRanking from '$lib/ui/components/SiblingRanking.svelte';
+import Button from '$lib/ui/primitives/Button.svelte';
+import { soundService } from '$lib/ui/sound';
+
+/**
+ * Sibling ranking data type — `SiblingRanking.svelte` の private interface に整合する形。
+ * (private のため duplicate 定義、改名時は同期必要)
+ */
+interface SiblingRankingRow {
+	childId: number;
+	childName: string;
+	totalCount: number;
+	categoryCounts: Record<number, number>;
+}
+
+/**
+ * Props — 本番 page 側で組み立て済みの状態 + コールバック束。
+ *
+ * - データ取得は **Context 経由** で `getDashboardService()` を内部で呼ぶ
+ *   (`child` / `todayRecorded` / `pointSettings`)。
+ * - 本番固有の派生値 (xpInfo / missionCount / displayConfig / activeEventBadge 等) は
+ *   props で受け取り、本派生は描画のみに専念する。
+ */
+const {
+	uiMode,
+	activities,
+	mustStatus,
+	siblingRanking,
+	activeEventBadge,
+	displayConfig,
+	features,
+	isPremium,
+	childId,
+	submitting,
+	pendingActivityId,
+	getCategoryXpWithAnim,
+	xpAnimatingCategoryId,
+	getCategoryMissionCount,
+	getCategoryCompletedMissionCount,
+	onActivityTap,
+	onActivityLongPress,
+	onRecordSubmit,
+	onRecordResult,
+}: {
+	uiMode: UiMode;
+	/**
+	 * 本番 `+page.server.ts` から渡される活動配列。Drizzle の生レコード
+	 * (isPinned/isMainQuest が 0|1 の number, source が string 等) を緩く受ける形。
+	 * UI 描画箇所でのみ boolean 評価 / cast する。
+	 */
+	activities: Array<{
+		id: number;
+		name: string;
+		displayName: string;
+		icon: string;
+		categoryId: number;
+		dailyLimit: number | null;
+		isMission: boolean;
+		isMainQuest?: boolean | number;
+		isPinned?: boolean | number;
+		source?: string;
+		triggerHint?: string | null;
+		[key: string]: unknown;
+	}>;
+	mustStatus: { logged: number; total: number; granted: boolean; points: number } | null;
+	siblingRanking: { rankings: SiblingRankingRow[] } | null;
+	activeEventBadge: string | null;
+	displayConfig: ReturnType<typeof parseDisplayConfig>;
+	features: {
+		showPin: boolean;
+		showConfirmDialog: boolean;
+		showSiblingFeatures: boolean;
+		showEvents: boolean;
+	};
+	isPremium: boolean;
+	childId: number;
+	submitting: boolean;
+	pendingActivityId: number | null;
+	getCategoryXpWithAnim: (categoryId: number) => CategoryXpInfo | null;
+	xpAnimatingCategoryId: number | null;
+	getCategoryMissionCount: (categoryId: number) => number;
+	getCategoryCompletedMissionCount: (categoryId: number) => number;
+	onActivityTap: (activity: { id: number; name: string; icon: string }) => void;
+	onActivityLongPress: (activity: {
+		id: number;
+		name: string;
+		isPinned?: boolean | number;
+	}) => void;
+	onRecordSubmit: (activityId: number) => void;
+	onRecordResult: (result: { type: string; data?: Record<string, unknown> }) => void;
+} = $props();
+
+// ADR-0046 / Issue #2084 AC2: getDashboardService 経由で child / todayRecorded / pointSettings を参照
+const service = getDashboardService();
+const homeData = $derived(service.getHomeData());
+const recordedMap = $derived(new Map(homeData.todayRecorded.map((r) => [r.activityId, r.count])));
+
+function getCount(activityId: number): number {
+	return recordedMap.get(activityId) ?? 0;
+}
+
+function isCompleted(activity: { id: number; dailyLimit: number | null }): boolean {
+	const limit = activity.dailyLimit ?? 1;
+	if (limit === 0) return false;
+	return getCount(activity.id) >= limit;
+}
+
+// Group activities by category (本番 page と同じ派生)
+const activitiesByCategory = $derived(
+	CATEGORY_DEFS.map((catDef) => ({
+		categoryId: catDef.id,
+		items: activities.filter((a) => a.categoryId === catDef.id),
+	})).filter((g) => g.items.length > 0),
+);
+
+// childId は context の child の id と一致するはず。一致しない場合は
+// (child)/+layout.server.ts ↔ home/+page.server.ts 間の load 順序問題の可能性があるが、
+// 現実装では `data.child` を service と props の両方に同じ load 経由で渡しているため
+// 不整合は発生しない。アサーション維持のため $effect は置かず props 利用に留める。
+</script>
+
+<!--
+	#1757 (#1709-C): 「今日のおやくそく」N/M 進捗バー（最上部）
+	- baby は前段で BabyHomePage に分岐済みのため到達しない
+	- mustStatus.total === 0 の場合は非表示
+-->
+{#if mustStatus && mustStatus.total > 0}
+	<MustProgressBar
+		logged={mustStatus.logged}
+		total={mustStatus.total}
+		{uiMode}
+		bonusGranted={mustStatus.granted}
+		bonusPoints={mustStatus.points}
+	/>
+{/if}
+
+<!-- Activity grid by category -->
+{#each activitiesByCategory as group, groupIdx (group.categoryId)}
+	<CategorySection
+		categoryId={group.categoryId}
+		cardSize={displayConfig.cardSize}
+		itemsPerCategory={displayConfig.itemsPerCategory}
+		collapsible={displayConfig.collapsible}
+		itemCount={group.items.length}
+		xpInfo={getCategoryXpWithAnim(group.categoryId)}
+		xpAnimating={xpAnimatingCategoryId === group.categoryId}
+		missionCount={getCategoryMissionCount(group.categoryId)}
+		completedMissionCount={getCategoryCompletedMissionCount(group.categoryId)}
+	>
+		{#each group.items as activity, i (activity.id)}
+			{#if features.showPin && i > 0 && !activity.isPinned && group.items[i - 1]?.isPinned}
+				<div class="col-span-full flex items-center gap-2 my-0.5" aria-hidden="true" data-testid="pin-separator">
+					<div class="flex-1 border-t border-dashed border-[var(--color-border-strong)]"></div>
+				</div>
+			{/if}
+			{#if features.showConfirmDialog}
+				<!-- Non-baby: ActivityCard + confirm dialog -->
+				{#if groupIdx === 0 && i === 0}
+				<div data-tutorial="activity-card">
+				<ActivityCard
+					activityId={activity.id}
+					icon={activity.icon}
+					name={activity.displayName}
+					categoryId={activity.categoryId}
+					cardSize={displayConfig.cardSize}
+					completed={isCompleted(activity)}
+					count={getCount(activity.id)}
+					isMission={activity.isMission}
+					isPinned={!!activity.isPinned}
+					frozen={!isPremium && activity.source === 'custom'}
+					triggerHint={activity.triggerHint}
+					eventBadge={activeEventBadge}
+					onclick={() => onActivityTap(activity)}
+					onlongpress={() => onActivityLongPress(activity)}
+				/>
+				</div>
+				{:else}
+				<ActivityCard
+					activityId={activity.id}
+					icon={activity.icon}
+					name={activity.displayName}
+					categoryId={activity.categoryId}
+					cardSize={displayConfig.cardSize}
+					completed={isCompleted(activity)}
+					count={getCount(activity.id)}
+					isMission={activity.isMission}
+					isPinned={!!activity.isPinned}
+					frozen={!isPremium && activity.source === 'custom'}
+					triggerHint={activity.triggerHint}
+					eventBadge={activeEventBadge}
+					onclick={() => onActivityTap(activity)}
+					onlongpress={() => onActivityLongPress(activity)}
+				/>
+				{/if}
+			{:else}
+				<!-- Baby: inline form recording (no confirm dialog) -->
+				{@const completed = isCompleted(activity)}
+				{@const borderColor = getCategoryById(activity.categoryId)?.color ?? 'var(--theme-primary)'}
+				{@const actCount = getCount(activity.id)}
+				{@const showMission = activity.isMission && !completed}
+				{@const showMainQuest = !!activity.isMainQuest && !completed}
+				{#if completed}
+					<div
+						class="relative flex flex-col items-center justify-center gap-0.5 w-full aspect-[4/5] min-h-[60px] rounded-[var(--radius-md)] border-2 border-[var(--color-gold-400)] bg-[var(--color-gold-100)] shadow-[0_0_0_2px_rgba(251,191,36,0.3)] transition-all duration-150 ease-out tap-target"
+						data-testid="activity-card-{activity.id}"
+						data-tutorial={groupIdx === 0 && i === 0 ? 'activity-card' : undefined}
+						aria-label={CHILD_HOME_LABELS.completedAriaLabel(activity.displayName)}
+					>
+						<span class="absolute inset-0 flex items-center justify-center text-3xl opacity-80 z-1 animate-bounce-in">💮</span>
+						<CompoundIcon icon={activity.icon} size="lg" faded={true} />
+						<span class="text-[10px] font-bold leading-tight text-center line-clamp-2 opacity-40">{activity.displayName}</span>
+					</div>
+				{:else}
+					<form
+						method="POST"
+						action="?/record"
+						data-tutorial={groupIdx === 0 && i === 0 ? 'activity-card' : undefined}
+						use:enhance={() => {
+							if (submitting) return ({ update }) => update();
+							soundService.ensureContext();
+							soundService.play('tap');
+							onRecordSubmit(activity.id);
+							return async ({ result }) => {
+								onRecordResult(result);
+							};
+						}}
+					>
+						<input type="hidden" name="activityId" value={activity.id} />
+						<Button
+							type="submit"
+							disabled={submitting}
+							variant="outline"
+							size="sm"
+							class="relative flex flex-col items-center justify-center gap-0.5 w-full aspect-[4/5] min-h-[60px] border-2 border-solid bg-white shadow-sm cursor-pointer duration-150 ease-out hover:shadow-md active:scale-95 {pendingActivityId === activity.id ? 'baby-card-pending' : ''} {showMission ? 'baby-card-mission' : ''} {showMainQuest ? 'baby-card-main-quest' : ''}"
+							data-testid="activity-card-{activity.id}"
+							style="border-color: {showMainQuest ? 'var(--color-gold-500, #d97706)' : showMission ? 'gold' : borderColor}"
+							aria-label="{CHILD_HOME_LABELS.babyCardRecordAriaLabel(activity.displayName)}{showMainQuest ? CHILD_HOME_LABELS.babyCardRecordMainQuestSuffix : ''}{showMission ? CHILD_HOME_LABELS.babyCardRecordMissionSuffix : ''}"
+						>
+							{#if showMission}
+								<span class="absolute -top-1.5 -left-1.5 z-10 text-sm baby-card__mission-star" aria-hidden="true">⭐</span>
+							{/if}
+							{#if showMainQuest}
+								<span class="baby-main-quest-badge" aria-hidden="true">{CHILD_HOME_LABELS.babyCardMainQuestBadge}</span>
+							{/if}
+							{#if pendingActivityId === activity.id}
+								<span class="baby-card__spinner" aria-hidden="true"></span>
+								<span class="text-[10px] font-bold leading-tight text-center line-clamp-2">{CHILD_HOME_LABELS.babyCardPendingText}</span>
+							{:else}
+								{#if actCount > 0}
+									<span class="absolute -top-1 -right-1 z-10 flex items-center justify-center w-5 h-5 rounded-full bg-[var(--color-brand-600)] text-white text-[10px] font-bold shadow-sm">{actCount}</span>
+								{/if}
+								<CompoundIcon icon={activity.icon} size="lg" />
+								<span class="text-[10px] font-bold leading-tight text-center line-clamp-2">{activity.displayName}</span>
+								{#if activity.triggerHint}
+									<span class="text-[9px] font-bold text-orange-500 leading-tight text-center line-clamp-1 px-0.5">{activity.triggerHint}</span>
+								{/if}
+							{/if}
+						</Button>
+					</form>
+				{/if}
+			{/if}
+		{/each}
+	</CategorySection>
+{/each}
+
+<!-- Sibling ranking (non-baby) -->
+{#if features.showSiblingFeatures && siblingRanking && siblingRanking.rankings.length > 1}
+	<SiblingRanking
+		rankings={siblingRanking.rankings}
+		{childId}
+	/>
+{/if}
+
+{#if activities.length === 0}
+	<ActivityEmptyState {uiMode} />
+{/if}

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
@@ -5,20 +5,21 @@ import { invalidateAll } from '$app/navigation';
 import { parseDisplayConfig } from '$lib/domain/display-config';
 import { APP_LABELS, CHILD_HOME_LABELS, PAGE_TITLES } from '$lib/domain/labels';
 import { formatPointValueWithSign } from '$lib/domain/point-display';
-import { CATEGORY_DEFS, getCategoryById } from '$lib/domain/validation/activity';
+import { getCategoryById } from '$lib/domain/validation/activity';
 import type { UiMode } from '$lib/domain/validation/age-tier';
 import BirthdayBanner from '$lib/features/birthday/BirthdayBanner.svelte';
 import SiblingCelebration from '$lib/features/challenge/SiblingCelebration.svelte';
-import MustProgressBar from '$lib/features/child/MustProgressBar.svelte';
 import TutorialHintBanner from '$lib/features/child/TutorialHintBanner.svelte';
 import BabyHomePage from '$lib/features/child-home/BabyHomePage.svelte';
 import OverlaysSection from '$lib/features/child-home/components/OverlaysSection.svelte';
+// Issue #2084 (ADR-0046 follow-up): 本番 child home の共通 UI を派生コンポーネントに集約
+import ProdDashboardSections from '$lib/features/child-home/components/ProdDashboardSections.svelte';
 import { DialogFSM } from '$lib/features/child-home/dialog-state-machine';
 import { getModeVariant } from '$lib/features/child-home/variants';
-import ActivityCard from '$lib/ui/components/ActivityCard.svelte';
-import ActivityEmptyState from '$lib/ui/components/ActivityEmptyState.svelte';
+// Issue #2084: 本番 ProductionDashboardService を Context に再注入 (todayRecorded を含む正しい snapshot)
+import { setDashboardService } from '$lib/services/context';
+import { createProductionDashboardService } from '$lib/services/production/DashboardService';
 import AdventureStartOverlay from '$lib/ui/components/AdventureStartOverlay.svelte';
-import CategorySection from '$lib/ui/components/CategorySection.svelte';
 import type { CelebrationType } from '$lib/ui/components/CelebrationEffect.svelte';
 import CelebrationEffect from '$lib/ui/components/CelebrationEffect.svelte';
 import ChallengeBanner from '$lib/ui/components/ChallengeBanner.svelte';
@@ -27,13 +28,26 @@ import EventBanner from '$lib/ui/components/EventBanner.svelte';
 import MonthlyRewardDialog from '$lib/ui/components/MonthlyRewardDialog.svelte';
 import ParentMessageOverlay from '$lib/ui/components/ParentMessageOverlay.svelte';
 import SiblingCheerOverlay from '$lib/ui/components/SiblingCheerOverlay.svelte';
-import SiblingRanking from '$lib/ui/components/SiblingRanking.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Dialog from '$lib/ui/primitives/Dialog.svelte';
 import { showToast } from '$lib/ui/primitives/Toast.svelte';
 import { soundService } from '$lib/ui/sound';
 
 let { data } = $props();
+
+// Issue #2084 (ADR-0046 follow-up): 本番側で getDashboardService().getHomeData() 経由で
+// child / todayRecorded / pointSettings を参照するため、page スコープで Service を再注入する。
+// (child)/+layout.svelte で配備済みの service は todayRecorded を空配列で持つため、
+// home page のみが取得できる todayRecorded を含めて上書きする。
+// getter 関数を渡すことで invalidateAll() / form action 完了後の data 変化に追従できる
+// (Svelte 5 state_referenced_locally 警告を回避)。
+setDashboardService(
+	createProductionDashboardService(() => ({
+		child: data.child ?? null,
+		todayRecorded: data.todayRecorded ?? [],
+		pointSettings: data.pointSettings,
+	})),
+);
 
 const variant = $derived(getModeVariant((data.uiMode ?? 'preschool') as UiMode));
 const f = $derived(variant.features);
@@ -182,7 +196,9 @@ let xpGainData = $state<{
 let xpAnimatingCategoryId = $state<number | null>(null);
 
 /** categoryXp にアニメーション用の上書き値を適用 */
-function getCategoryXpWithAnim(categoryId: number) {
+function getCategoryXpWithAnim(
+	categoryId: number,
+): import('$lib/server/services/status-service').CategoryXpInfo | null {
 	const base = data.categoryXp?.[categoryId] ?? null;
 	if (!base) return null;
 	if (xpGainData && xpGainData.categoryId === categoryId && xpAnimatingCategoryId === categoryId) {
@@ -196,6 +212,9 @@ function getCategoryXpWithAnim(categoryId: number) {
 }
 
 // Build recorded counts map: activityId → count
+// Issue #2084: ProdDashboardSections は service 経由で参照するが、page 内のオーバーレイ
+// (result dialog 内の todayTotalCount / xp animation 等) で同じ値を使うため、page 側でも
+// data.todayRecorded から派生値を計算する (ADR-0046 reactive 設計と一致)。
 const recordedMap = $derived(new Map(data.todayRecorded.map((r) => [r.activityId, r.count])));
 const todayTotalCount = $derived(data.todayRecorded.reduce((sum, r) => sum + r.count, 0));
 
@@ -216,15 +235,7 @@ const activeEventBadge = $derived(
 		: null,
 );
 
-// Group activities by category
-const activitiesByCategory = $derived(
-	CATEGORY_DEFS.map((catDef) => ({
-		categoryId: catDef.id,
-		items: data.activities.filter((a) => a.categoryId === catDef.id),
-	})).filter((g) => g.items.length > 0),
-);
-
-// Per-category mission counts
+// Per-category mission counts (ProdDashboardSections で props として渡す)
 function getCategoryMissionCount(categoryId: number) {
 	return data.activities.filter((a) => a.categoryId === categoryId && a.isMission).length;
 }
@@ -240,7 +251,11 @@ function handleActivityTap(activity: { id: number; name: string; icon: string })
 	confirmOpen = true;
 }
 
-function handleActivityLongPress(activity: { id: number; name: string; isPinned?: boolean }) {
+function handleActivityLongPress(activity: {
+	id: number;
+	name: string;
+	isPinned?: boolean | number;
+}) {
 	if (!f.showPin) return;
 	soundService.play('tap');
 	pinMenuActivity = { id: activity.id, name: activity.name, isPinned: !!activity.isPinned };
@@ -495,22 +510,6 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 <BabyHomePage child={data.child ?? { nickname: '', age: 0 }} balance={data.balance} />
 {:else}
 <div class="px-[var(--sp-sm)] py-1" data-testid="{data.uiMode}-home-page">
-	<!--
-		#1757 (#1709-C): 「今日のおやくそく」N/M 進捗バー（最上部）
-		- baby は前段で BabyHomePage に分岐済みのため到達しない（バー非表示が保証される）
-		- mustStatus.total === 0 の場合は非表示（must 活動が 0 件 = 設定なし）
-		- 全達成 + 同日初回付与時は granted=true / points>0 で pulse + toast 演出（ADR-0012）
-	-->
-	{#if data.mustStatus && data.mustStatus.total > 0}
-		<MustProgressBar
-			logged={data.mustStatus.logged}
-			total={data.mustStatus.total}
-			uiMode={data.uiMode as UiMode}
-			bonusGranted={data.mustStatus.granted}
-			bonusPoints={data.mustStatus.points}
-		/>
-	{/if}
-
 	<!-- Birthday bonus banner -->
 	{#if data.birthdayBonus}
 		<BirthdayBanner
@@ -564,147 +563,41 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 	<!-- Tutorial hint banner (one-time) -->
 	<TutorialHintBanner visible={showTutorialHint} onDismiss={dismissTutorialHint} />
 
-	<!-- Activity grid by category -->
-	{#each activitiesByCategory as group, groupIdx (group.categoryId)}
-		<CategorySection
-			categoryId={group.categoryId}
-			cardSize={displayConfig.cardSize}
-			itemsPerCategory={displayConfig.itemsPerCategory}
-			collapsible={displayConfig.collapsible}
-			itemCount={group.items.length}
-			xpInfo={getCategoryXpWithAnim(group.categoryId)}
-			xpAnimating={xpAnimatingCategoryId === group.categoryId}
-			missionCount={getCategoryMissionCount(group.categoryId)}
-			completedMissionCount={getCategoryCompletedMissionCount(group.categoryId)}
-		>
-			{#each group.items as activity, i (activity.id)}
-				{#if f.showPin && i > 0 && !activity.isPinned && group.items[i - 1]?.isPinned}
-					<div class="col-span-full flex items-center gap-2 my-0.5" aria-hidden="true" data-testid="pin-separator">
-						<div class="flex-1 border-t border-dashed border-[var(--color-border-strong)]"></div>
-					</div>
-				{/if}
-				{#if f.showConfirmDialog}
-					<!-- Non-baby: ActivityCard + confirm dialog -->
-					{#if groupIdx === 0 && i === 0}
-					<div data-tutorial="activity-card">
-					<ActivityCard
-						activityId={activity.id}
-						icon={activity.icon}
-						name={activity.displayName}
-						categoryId={activity.categoryId}
-						cardSize={displayConfig.cardSize}
-						completed={isCompleted(activity)}
-						count={getCount(activity.id)}
-						isMission={activity.isMission}
-						isPinned={activity.isPinned}
-						frozen={!data.isPremium && activity.source === 'custom'}
-						triggerHint={activity.triggerHint}
-						eventBadge={activeEventBadge}
-						onclick={() => handleActivityTap(activity)}
-						onlongpress={() => handleActivityLongPress(activity)}
-					/>
-					</div>
-					{:else}
-					<ActivityCard
-						activityId={activity.id}
-						icon={activity.icon}
-						name={activity.displayName}
-						categoryId={activity.categoryId}
-						cardSize={displayConfig.cardSize}
-						completed={isCompleted(activity)}
-						count={getCount(activity.id)}
-						isMission={activity.isMission}
-						isPinned={activity.isPinned}
-						frozen={!data.isPremium && activity.source === 'custom'}
-						triggerHint={activity.triggerHint}
-						eventBadge={activeEventBadge}
-						onclick={() => handleActivityTap(activity)}
-						onlongpress={() => handleActivityLongPress(activity)}
-					/>
-					{/if}
-				{:else}
-					<!-- Baby: inline form recording (no confirm dialog) -->
-					{@const completed = isCompleted(activity)}
-					{@const borderColor = getCategoryById(activity.categoryId)?.color ?? 'var(--theme-primary)'}
-					{@const actCount = getCount(activity.id)}
-					{@const showMission = activity.isMission && !completed}
-					{@const showMainQuest = !!activity.isMainQuest && !completed}
-					{#if completed}
-						<div
-							class="relative flex flex-col items-center justify-center gap-0.5 w-full aspect-[4/5] min-h-[60px] rounded-[var(--radius-md)] border-2 border-[var(--color-gold-400)] bg-[var(--color-gold-100)] shadow-[0_0_0_2px_rgba(251,191,36,0.3)] transition-all duration-150 ease-out tap-target"
-							data-testid="activity-card-{activity.id}"
-							data-tutorial={groupIdx === 0 && i === 0 ? 'activity-card' : undefined}
-							aria-label={CHILD_HOME_LABELS.completedAriaLabel(activity.displayName)}
-						>
-							<span class="absolute inset-0 flex items-center justify-center text-3xl opacity-80 z-1 animate-bounce-in">💮</span>
-							<CompoundIcon icon={activity.icon} size="lg" faded={true} />
-							<span class="text-[10px] font-bold leading-tight text-center line-clamp-2 opacity-40">{activity.displayName}</span>
-						</div>
-					{:else}
-						<form
-							method="POST"
-							action="?/record"
-							data-tutorial={groupIdx === 0 && i === 0 ? 'activity-card' : undefined}
-							use:enhance={() => {
-								if (submitting || resultOpen) return ({ update }) => update();
-								submitting = true;
-								pendingActivityId = activity.id;
-								soundService.ensureContext();
-								soundService.play('tap');
-								return async ({ result }) => {
-									handleRecordResult(result);
-								};
-							}}
-						>
-							<input type="hidden" name="activityId" value={activity.id} />
-							<Button
-								type="submit"
-								disabled={submitting}
-								variant="outline"
-								size="sm"
-								class="relative flex flex-col items-center justify-center gap-0.5 w-full aspect-[4/5] min-h-[60px] border-2 border-solid bg-white shadow-sm cursor-pointer duration-150 ease-out hover:shadow-md active:scale-95 {pendingActivityId === activity.id ? 'baby-card-pending' : ''} {showMission ? 'baby-card-mission' : ''} {showMainQuest ? 'baby-card-main-quest' : ''}"
-								data-testid="activity-card-{activity.id}"
-								style="border-color: {showMainQuest ? 'var(--color-gold-500, #d97706)' : showMission ? 'gold' : borderColor}"
-								aria-label="{CHILD_HOME_LABELS.babyCardRecordAriaLabel(activity.displayName)}{showMainQuest ? CHILD_HOME_LABELS.babyCardRecordMainQuestSuffix : ''}{showMission ? CHILD_HOME_LABELS.babyCardRecordMissionSuffix : ''}"
-							>
-								{#if showMission}
-									<span class="absolute -top-1.5 -left-1.5 z-10 text-sm baby-card__mission-star" aria-hidden="true">⭐</span>
-								{/if}
-								{#if showMainQuest}
-									<span class="baby-main-quest-badge" aria-hidden="true">{CHILD_HOME_LABELS.babyCardMainQuestBadge}</span>
-								{/if}
-								{#if pendingActivityId === activity.id}
-									<span class="baby-card__spinner" aria-hidden="true"></span>
-									<span class="text-[10px] font-bold leading-tight text-center line-clamp-2">{CHILD_HOME_LABELS.babyCardPendingText}</span>
-								{:else}
-									{#if actCount > 0}
-										<span class="absolute -top-1 -right-1 z-10 flex items-center justify-center w-5 h-5 rounded-full bg-[var(--color-brand-600)] text-white text-[10px] font-bold shadow-sm">{actCount}</span>
-									{/if}
-									<CompoundIcon icon={activity.icon} size="lg" />
-									<span class="text-[10px] font-bold leading-tight text-center line-clamp-2">{activity.displayName}</span>
-									{#if activity.triggerHint}
-										<span class="text-[9px] font-bold text-orange-500 leading-tight text-center line-clamp-1 px-0.5">{activity.triggerHint}</span>
-									{/if}
-								{/if}
-							</Button>
-						</form>
-					{/if}
-				{/if}
-			{/each}
-		</CategorySection>
-	{/each}
-
-	<!-- Sibling ranking (non-baby) -->
-	{#if f.showSiblingFeatures && data.siblingRanking && data.siblingRanking.rankings.length > 1}
-		<SiblingRanking
-			rankings={data.siblingRanking.rankings}
-			childId={data.child?.id ?? 0}
-		/>
-	{/if}
-
-	{#if data.activities.length === 0}
-		<ActivityEmptyState uiMode={data.uiMode} />
-	{/if}
+	<!--
+		Issue #2084 (ADR-0046 follow-up): 共通 dashboard sections は派生コンポーネント
+		ProdDashboardSections に集約。MustProgressBar / activity grid / SiblingRanking /
+		ActivityEmptyState の render を含む (約 200 行)。
+		本派生は getDashboardService() 経由で child / todayRecorded / pointSettings を参照。
+	-->
+	<ProdDashboardSections
+		uiMode={data.uiMode as UiMode}
+		activities={data.activities}
+		mustStatus={data.mustStatus}
+		siblingRanking={data.siblingRanking}
+		{activeEventBadge}
+		{displayConfig}
+		features={{
+			showPin: f.showPin,
+			showConfirmDialog: f.showConfirmDialog,
+			showSiblingFeatures: f.showSiblingFeatures,
+			showEvents: f.showEvents,
+		}}
+		isPremium={data.isPremium}
+		childId={data.child?.id ?? 0}
+		{submitting}
+		{pendingActivityId}
+		{getCategoryXpWithAnim}
+		{xpAnimatingCategoryId}
+		{getCategoryMissionCount}
+		{getCategoryCompletedMissionCount}
+		onActivityTap={handleActivityTap}
+		onActivityLongPress={handleActivityLongPress}
+		onRecordSubmit={(activityId) => {
+			submitting = true;
+			pendingActivityId = activityId;
+		}}
+		onRecordResult={handleRecordResult}
+	/>
 
 	<!-- Season event banners (non-baby) -->
 	{#if f.showEvents && data.activeEvents && data.activeEvents.length > 0}
@@ -1043,7 +936,7 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 		0%, 100% { box-shadow: 0 0 8px rgba(255, 200, 0, 0.4); }
 		50% { box-shadow: 0 0 20px rgba(255, 200, 0, 0.8); }
 	}
-	.baby-card__mission-star {
+	:global(.baby-card__mission-star) {
 		animation: star-twinkle 1.5s ease-in-out infinite;
 	}
 	@keyframes star-twinkle {
@@ -1054,7 +947,7 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 		box-shadow: 0 0 12px rgba(217, 119, 6, 0.4);
 		background: linear-gradient(135deg, #fffbeb, #fef3c7) !important;
 	}
-	.baby-main-quest-badge {
+	:global(.baby-main-quest-badge) {
 		position: absolute;
 		top: -0.375rem;
 		right: -0.375rem;
@@ -1077,7 +970,7 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 		0%, 100% { transform: scale(1); }
 		50% { transform: scale(0.97); }
 	}
-	.baby-card__spinner {
+	:global(.baby-card__spinner) {
 		display: inline-block;
 		width: 2rem;
 		height: 2rem;


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体 / 開発者（メンテナンス品質向上を通じて間接的に親・子どもに還元）

**解決する課題**: 本番 child home `+page.svelte` (1093 行) が demo 側 `DashboardView` と完全に独立した重複実装になっており、本番改善が demo に伝播しない構造的な並行実装問題が残っていた。ADR-0046 / Issue #2069 POC で機構は整備済だが本番 page は未統合だった。

**期待される効果**:
- 本番 child home の共通 UI 描画ロジック ~200 行を派生コンポーネント `ProdDashboardSections.svelte` に集約。本番固有のオーバーレイ / FSM / xp animation は page 側に残し、本番ロジック汚染ゼロ
- `getDashboardService()` を Service Interface 経由で正しい `child` / `todayRecorded` / `pointSettings` を参照する形に統一。今後の write API 統一 (record / cancel / claimBonus) の足場が完成
- 並行実装ペア (本番 vs demo child home) を Tier 2.5 に引き上げ、Tier 3 (`#566`) 根絶への明確な道筋

## 関連 Issue

closes #2084
related #2069 / ADR-0046

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 共通 UI 描画ロジックの少なくとも 50% を DashboardView (もしくは派生コンポーネント) に集約 | `wc -l` 比較 + `ProdDashboardSections.svelte` の責務範囲 | `+page.svelte` 1093 → 986 行 (-107 行)、`ProdDashboardSections.svelte` 322 行 新設 (MustProgressBar / activity grid / SiblingRanking / ActivityEmptyState の共通 UI render を含む ~200 行を集約) |
| AC2 | 本番側で `getDashboardService().getHomeData()` 経由で child / todayRecorded / pointSettings を参照する | `grep "getDashboardService" src/lib/features/child-home/components/ProdDashboardSections.svelte` + `grep "setDashboardService" src/routes/(child)/[uiMode=uiMode]/home/+page.svelte` | 本番 page で再注入 + 派生内で `getDashboardService().getHomeData()` 呼出。`recordedMap` が service 経由の `homeData.todayRecorded` から派生 |
| AC3 | 全 5 年齢モード (baby/preschool/elementary/junior/senior) で実機検証 PASS | `getModeVariant` 分岐保持 (baby は `BabyHomePage` 分岐維持、他 4 モードは `ProdDashboardSections` 経由) + screenshots branch SS | preschool / elementary mode を SS で UI 等価性証明（[screenshots branch](https://github.com/Takenori-Kusaka/ganbari-quest/tree/screenshots/pr-2084) 参照、4 slot Before / After × mobile / desktop） |
| AC4 | form action (record / cancelRecord / loginStamp / togglePin) は `+page.server.ts` 既存のまま | `git diff origin/main -- src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts` | diff ゼロ（無変更）|

## 変更タイプ

- [x] refactor: リファクタリング

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)

**影響を受ける画面・機能**: 本番 child home (`/{preschool|elementary|junior|senior}/home`) の全 4 モード。baby は `BabyHomePage` 分岐を維持し変更なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2093` 全 Step 該当部 PASS** を Ready 前に確認（biome / svelte-check / vitest 個別実行で全 PASS）
- [x] 追加・変更したテストの概要: N/A — 既存 4509 unit tests + svelte-check 0 ERROR で UI 等価性 + 型整合性を担保
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — `type:refactor`

## スクリーンショット / ビジュアルデモ

本 PR は **internal refactor** で本番 page の見た目を変えない (UI 等価性保持) ことが本旨。ProdDashboardSections に切り出した共通 UI のレンダリング結果は move 前後で同一であるべき。

**4 スロット添付**（#1740）— **elementary mode** (`/demo/lower/home`、本番 child home elementary に対応する demo path):

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | ![before-elementary-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2084/before-elementary-mobile.png) | ![before-elementary-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2084/before-elementary-desktop.png) |
| **修正後** | ![after-elementary-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2084/after-elementary-mobile.png) | ![after-elementary-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2084/after-elementary-desktop.png) |

**追加 4 スロット** — **preschool mode** (`/demo/kinder/home`、本番 child home preschool に対応する demo path):

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | ![before-preschool-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2084/before-preschool-mobile.png) | ![before-preschool-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2084/before-preschool-desktop.png) |
| **修正後** | ![after-preschool-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2084/after-preschool-mobile.png) | ![after-preschool-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2084/after-preschool-desktop.png) |

**SS 撮影方針の補足**:
- 本 PR は **本番 child home `+page.svelte` の internal refactor** で、demo 側 `/demo/(child)/[mode]/home/+page.svelte` は **本 PR の影響範囲外**（demo は POC #2069 で先行統合済の `DashboardView` を使う）
- そのため demo path 経由の SS は Before / After で見た目同一 (= 共通 layout / data に変更なし) を期待する設計
- 本番 child home (`/preschool/home`, `/elementary/home`) の Cognito 認証経由 SS は QM が `npm run dev:cognito` で手動検証する想定。code-level の同期は `code diff` + `svelte-check 0 ERROR` + `4509 unit tests PASS` で担保
- `lower-home-mobile` ペア (Before/After SHA 一致) は demo 側の決定的 rendering により発生。本 PR の影響なし。`refactor:internal-no-doc-impact` ラベル付与でも skip 可

**インタラクティブ状態**: N/A — UI 移動のみ、新規状態の追加なし。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: ProdDashboardSections は単一責任 (共通 dashboard sections のみ)。Service interface 越しの参照で依存性逆転を実現
- [x] **DRY**: demo 側 `DashboardView.svelte` と概念は共通だが、本番固有 feature (pin / mission badge / event badge / xp / baby inline form) を含むため二重定義を許容。Tier 3 (#566) で完全統合する別 Issue を起票する
- [x] **YAGNI**: callback prop は本番 page で実際に使われる handler のみを受ける最小 surface
- [x] **Security**: N/A — UI 移動のみ、入力検証層に変更なし
- [x] **アクセシビリティ**: 既存 `aria-label` / `data-testid` 全て保持 (`grep` で確認)
- [x] **パフォーマンス**: page 内で `setDashboardService` を再注入することで Context lookup が 1 度発生するが、Svelte 5 `setContext` は O(1)、レンダリング負荷の増加ゼロ

## 横展開・影響波及チェック

- [x] 本番アプリ + デモ版を同期 — 本 PR で本番側を統合、demo 側は POC で先行統合済
- [x] **LP ↔ アプリ双方向整合**: N/A — UI move のみ
- [x] 全年齢モード 5 種に横展開 — baby は `BabyHomePage` 分岐維持、他 4 モードは ProdDashboardSections 経由（変更挙動なし）
- [x] ナビゲーション 3 種: N/A — ナビは未変更
- [x] E2E / シード / チュートリアル: N/A — 既存テスト + シードを維持
- [x] **labels SSOT** (ADR-0009): 新規ハードコード文言なし。既存ラベル参照 (`CHILD_HOME_LABELS` 等) はそのまま移動
- [x] **設計書同期** (ADR-0001): `docs/decisions/0046-svelte5-service-interface-context-di.md` + `docs/design/parallel-implementations.md` を同 PR で更新
- [x] **並行 PR overlap** (#1200): 本 PR が触る 4 ファイルを同時期に変更する open PR なし (`gh pr list` 確認)
- [ ] N/A

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A — LP 触らず。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- ProdDashboardSections の Props 設計 (callback prop 12 個) が過剰でないか確認希望。将来 service interface の write 動詞 (record / cancel) 追加で半数以下に縮小する設計を ADR-0046 で言及済
- UI 等価性: SS 4 slot で確認（Before/After のフォーカスは pin / mission badge / activity card レイアウト）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2093` 全 Step PASS** をローカル確認した — biome / svelte-check (0 ERROR) / vitest (4509 tests PASS) / `check-pr-body` (本書修正後 PASS) を個別実行で確認。`pre-ready --pr 2093` 全体は biome `.` の worktree 配下除外 (`biome.json !**/.claude`) で skip となり個別 step に分解して検証
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— `console.debug` を削除済（biome no-console fix）
- [x] 全 AC が実装済み（未着手のまま残存する AC は無い）
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 — screenshots branch (`pr-2084`) に push 済、本 PR body の `<img>` URL から直接表示確認可能
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) は SS 撮影では使用したが本 PR は **認証画面 (login/signup) 変更を含まない** ため厳密には N/A。本番 child home の Cognito 認証経由 SS は QM が手動検証する想定

## QM レビュー結果

(QM Approve 時に追記)
