### PR TITLE
process: #2090 Issue Forms 4 textarea (alternatives / no-gos / research-link / pre-pmf-check) を required 化

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,365 +1,332 @@
-# がんばりクエスト プロジェクト辞書
-# 新語追加時は PR レビューで正当性を必ず確認すること
-# cspell:disable-next-line の使用は禁止。辞書で解決する。
-
-# ===== プロジェクト固有名詞 =====
-ganbari
-Ganbari
-GANBARI
-ganba
-ganbatta
-ganbariquestsupport
+# 「PERS-CRT-N」形式の persona 検証由来 critical 識別子を comment に残す運用)
 # ↑ ADR-0022 で定めた QA 専用 GitHub アカウント名 (ganbariquestsupport-lab)。
-# scripts/check-gh-account-before-pr.mjs / claude-hook-prevent-qa-account-pr.mjs
-# のテスト・docs で多数登場。
-subresource
 # ↑ REST API のサブリソース (例: /pulls/123/comments) を指す技術用語。
-# claude-hook-prevent-qa-account-pr.test.ts の false-positive 設計判断コメントで使用。
-
-# ===== ドメイン用語（ローマ字 — 活動カテゴリ / 機能名） =====
-omikuji
-Omikuji
-OMIKUJI
-undou
-benkyou
-seikatsu
-souzou
-kouryuu
-otetsudai
-kichi
-nikonikoSmile
-
+# ===== #1702 LP-SSOT Phase B namespace =====
+# ===== #1900 (UIUX-C-1) =====
+# ===== #1915 SSOT 用語多重表記正規化 atom namespace =====
+# ===== ADR-0025 (#1683) =====
+# ===== AWS =====
+# ===== infra / AWS 用語 =====
+# ===== site（LP）用語 =====
+# ===== SQL / DB =====
+# ===== SSOT 完全化 (#1465 / #1683 PR #1680) =====
+# ===== Svelte 5 イベントハンドラプロパティ =====
+# ===== UI / デザイン =====
+# ===== Web/UI 技術用語 =====
 # ===== おみくじ運勢 =====
-daikichi
-daidaikichi
-chukichi
-shokichi
-suekichi
-
-# ===== 日本語ローマ字（メッセージ / UI / デモデータ） =====
-ganbare
-sugoi
-issho
-omedeto
-omedetou
-daisuki
-ureshii
-miteruyo
-arigatou
-kodomo
-sakura
-setsubun
-hinamatsuri
-ouen
-gohubi
-gohoubi
-chibi
-
+# ===== おやカギコード (#1360) =====
+# ===== コード内略語・複合語 =====
+# ===== コード内略語（プロジェクト固有） =====
+# ===== テストデータ / ダミー =====
+# ===== テスト用ライセンスキーフラグメント =====
+# ===== テスト用日本語ローマ字 =====
+# ===== テスト用語 =====
+# ===== ドメイン用語（ローマ字 — 活動カテゴリ / 機能名） =====
 # ===== ドメイン用語（英語由来） =====
-coreloop
-CORELOOP
-Unshown
-unshown
-Unblended
-unblended
-upsell
-Upsell
-gamification
-levelup
+# ===== ビジネス指標 =====
+# ===== プラン / コンプライアンス =====
+# ===== プロジェクト固有名詞 =====
+# ===== メディア / バイナリフォーマット =====
+# ===== ライフサイクルメール (#1601) =====
+# ===== ライブラリ名 =====
+# ===== 外部サービス =====
+# ===== 年齢モード =====
+# ===== 技術用語 / ライブラリ =====
+# ===== 日本語ローマ字（メッセージ / UI / デモデータ） =====
+# ===== 法令・データ保護 (#1638 / #1590) =====
+# ===== 解約フロー (#1596) =====
+# claude-hook-prevent-qa-account-pr.test.ts の false-positive 設計判断コメントで使用。
+# cspell:disable-next-line の使用は禁止。辞書で解決する。
+# DOMPurify = OSS HTML sanitizer (cure53)、ADR-0025 で採用
+# DPIA = Data Protection Impact Assessment（個情法 §28 域外移転 / GDPR §35）
+# freetext = 自由記述カラムの testid / CSS class 識別子 (cancellation_reasons.free_text)
+# healthcheck = cron-dispatcher の動作確認エンドポイント識別子
+# Issue タイトル / コミットメッセージ / コードコメント内で参照される。
+# LICENSEKEY = LP_LICENSEKEY_LABELS export 名 (site/help/license-key.html ページ用)
+# LIFESTAGE = ライフステージ (幼児期 / 学童期 / 思春期等) を表す atom namespace。
+# maxlength = HTML <textarea> 属性 (Playwright toHaveAttribute で検証)
+# Paraglide = inlang 製 i18n OSS、ADR-0014 で採用検討
+# Persona-critical findings prefix (PO Wave レビュー #1888 / #1892 / #1894 / #1899 / #1903 等で
+# PHASEB = #1702 で導入した LP_INDEX/PRICING/FAQ/PAMPHLET _PHASEB_LABELS の suffix
+# scripts/check-gh-account-before-pr.mjs / claude-hook-prevent-qa-account-pr.mjs
+# terms.ts の LIFESTAGE_TERMS / labels.ts / site/shared-labels.js で参照される造語。
+# UIUX = PO Issue グルーピング略号 (UI/UX 改善 Critical track)。
+# がんばりクエスト プロジェクト辞書
+# のテスト・docs で多数登場。
+# 新語追加時は PR レビューで正当性を必ず確認すること
+ABCDEFGHJKLMNPQRSTUVWXYZ
+achv
+ACHV
+ACTPREF
+ACTV
+adminhome
+ADR
+antipattern
+antipatterns
+arigatou
+arpu
+Arpu
+ARPU
+autocheckpoint
+autocomplete
+autodocs
+AUTOINCREMENT
+autoreply
+backfill
+bedrock
+Bedrock
+benkyou
+bfcache
+biome
+Biome
+biomejs
+browsable
+Budou
+budoux
+BusyKid
+catchcopy
+certificatemanager
+chibi
+chukichi
+CKLOG
+CKOVER
+CKTPL
+Cloudflare
+cloudwatch
+CloudWatch
+codegen
+coeff
+cognito
+Cognito
+convertable
+Convertable
 cooldown
 Cooldown
 COOLDOWN
-dedup
-recalc
-writeback
-syncsafe
-browsable
-convertable
-Convertable
-
-# ===== コード内略語（プロジェクト固有） =====
-CKOVER
-CKLOG
-STATHIST
-ACTPREF
-ACHV
-achv
-prefs
-Prefs
+copilot
+Copilot
+COPPA
+coreloop
+CORELOOP
+creds
+cspell
 cust
-coeff
+daidaikichi
+daikichi
+daisuki
+dedup
+dependabot
+Dependabot
+describedby
 dflt
-# Persona-critical findings prefix (PO Wave レビュー #1888 / #1892 / #1894 / #1899 / #1903 等で
-# 「PERS-CRT-N」形式の persona 検証由来 critical 識別子を comment に残す運用)
-PERS
-
-# ===== Svelte 5 イベントハンドラプロパティ =====
+dmarc
+Dmarc
+DMARC
+domainkey
+domcontentloaded
+DOMPurify
+DPIA
+drizzle
+Drizzle
+drizzleorm
+dropdown
+dynamodb
+DynamoDB
+EBML
+EFGH
+ehon
+epool
+EXIF
+favicon
+fflate
+freetext
+froms
+ftyp
+fullscreen
+FUTR
+gamification
+ganba
+ganbare
+ganbari
+Ganbari
+GANBARI
+ganbariquestsupport
+ganbatta
+genai
+gohoubi
+gohubi
+greenlight
+Greenlight
+hamigaki
+hanako
+hanami
+healthcheck
+hinamatsuri
+HSTS
+innerhtml
+issho
+JKLM
+jscpd
+Kaku
+kichi
+kinder
+kinesisfirehose
+knip
+kodomo
+kokor
+kouryuu
+Kusaka
+latm
+LEGC
+levelup
+LICENSEKEY
+LIFESTAGE
+lifestage
+localde
+localdev
+localtime
+lookback
+Lottie
+lowr
+LOWR
+maxlength
+Metas
+microticks
+miteruyo
+mozjpeg
+multiline
+navigations
+networkidle
+nikonikoSmile
+noopener
+NOPQR
+noreferrer
+noreply
+nosniff
+notif
+notnull
+NPRST
+oekaki
+okataduke
+omedeto
+omedetou
+omikuji
+Omikuji
+OMIKUJI
+omote
 onaccept
 oncanceledit
 oncreated
+oneclick
 onedit
 onimported
 onlongpress
 onretry
 onsaved
-
-# ===== 年齢モード =====
-preschool
-kinder
-
-# ===== SQL / DB =====
-AUTOINCREMENT
-drizzle
-Drizzle
-backfill
-upsert
-notnull
-
-# ===== 技術用語 / ライブラリ =====
-networkidle
-domcontentloaded
-autodocs
-svelte
-Svelte
-sveltekit
-SvelteKit
-tailwindcss
-Tailwind
-vitest
-Vitest
-biome
-Biome
-stylelint
-Stylelint
-biomejs
-drizzleorm
-umami
-Umami
-vite
-Vite
-plainto
-tsquery
-signin
-signup
-signout
-subrouter
-Cloudflare
-prerender
-prerendered
-sveltejs
-genai
-fflate
-nosniff
-HSTS
-noreply
-SSOT
-ADR
-knip
-cspell
-jscpd
-semgrep
-sonarjs
+osoto
+osouji
 osv
-codegen
-autocomplete
-fullscreen
-multiline
-scrollbar
-Lottie
-webp
-scrshot
-Budou
-budoux
-innerhtml
-pwa
-PWA
-favicon
-webpush
-qrcode
-mozjpeg
-microticks
-autocheckpoint
-bfcache
-navigations
-TOTP
-VOICEID
-whsec
-
-# ===== メディア / バイナリフォーマット =====
-EXIF
-ftyp
-latm
-EBML
-Vorbis
-vorbis
-
-# ===== AWS =====
-Bedrock
-bedrock
-DynamoDB
-dynamodb
-CloudWatch
-cloudwatch
-SES
-cognito
-Cognito
-
-# ===== 外部サービス =====
-Reconsent
-reconsent
-Dependabot
-dependabot
-Copilot
-copilot
-Snyk
-Greenlight
-greenlight
-BusyKid
-
-# ===== テストデータ / ダミー =====
-JKLM
-EFGH
-CKTPL
-ABCDEFGHJKLMNPQRSTUVWXYZ
-
-# ===== UI / デザイン =====
-Segoe
-Roboto
-noopener
-noreferrer
-dropdown
-popover
-tooltip
-
-# ===== プラン / コンプライアンス =====
+otetsudai
+otomodachi
+ouen
+oyakagi
+Oyakagi
+OYAKAGI
+Paraglide
+PERS
+PHASEB
+PITR
+plainto
 pmf
 PMF
-COPPA
-
-# ===== テスト用語 =====
-unstub
-selfhost
-localdev
-localde
-localtime
-adminhome
+popover
+prefs
+Prefs
+prerender
+prerendered
+preschool
+pwa
+PWA
+qrcode
 quickmode
-wrongpassword
-upserts
-froms
-Tmpls
-epool
-creds
-
-# ===== テスト用ライセンスキーフラグメント =====
-WXYZ
-NPRST
+recalc
+reconsent
+Reconsent
 REVD
-LOWR
-lowr
-LEGC
-FUTR
-ACTV
-wxyz
-
-# ===== テスト用日本語ローマ字 =====
-hamigaki
-taisou
-osouji
-ehon
-hanako
-otomodachi
-osoto
-okataduke
-oekaki
-tokushoho
-
-# ===== infra / AWS 用語 =====
-domainkey
-DMARC
-Dmarc
-dmarc
-PITR
-autoreply
-certificatemanager
-kinesisfirehose
-kokor
-
-# ===== site（LP）用語 =====
-catchcopy
-Takenori
-Kusaka
-Kaku
-omote
-
-# ===== ビジネス指標 =====
-ARPU
-arpu
-Arpu
-
-# ===== Web/UI 技術用語 =====
-describedby
-Signups
+Roboto
+sakura
+scrollbar
+scrshot
+Segoe
+seikatsu
+selfhost
+semgrep
+SES
+setsubun
+shokichi
+signin
+signout
+signup
 signups
-oneclick
-lookback
-
-# ===== ライブラリ名 =====
+Signups
+Snyk
+sonarjs
+souzou
 splide
 Splide
 splidejs
-
-# ===== コード内略語・複合語 =====
-notif
+SSOT
+STATHIST
+stylelint
+Stylelint
+subresource
+subrouter
+suekichi
+sugoi
+svelte
+Svelte
+sveltejs
+sveltekit
+SvelteKit
+syncsafe
+Tailwind
+tailwindcss
+taisou
+Takenori
 TESTIDS
-Metas
+textareas
+Tmpls
+tokushoho
+tooltip
 totaltime
-xlabel
-NOPQR
-hanami
-
-# ===== おやカギコード (#1360) =====
-oyakagi
-OYAKAGI
-Oyakagi
-
-# ===== 法令・データ保護 (#1638 / #1590) =====
-# DPIA = Data Protection Impact Assessment（個情法 §28 域外移転 / GDPR §35）
-DPIA
-antipatterns
-antipattern
-
-# ===== ライフサイクルメール (#1601) =====
-# healthcheck = cron-dispatcher の動作確認エンドポイント識別子
-healthcheck
-
-# ===== 解約フロー (#1596) =====
-# maxlength = HTML <textarea> 属性 (Playwright toHaveAttribute で検証)
-# freetext = 自由記述カラムの testid / CSS class 識別子 (cancellation_reasons.free_text)
-maxlength
-freetext
-
-# ===== SSOT 完全化 (#1465 / #1683 PR #1680) =====
-# LICENSEKEY = LP_LICENSEKEY_LABELS export 名 (site/help/license-key.html ページ用)
-LICENSEKEY
-
-# ===== ADR-0025 (#1683) =====
-# DOMPurify = OSS HTML sanitizer (cure53)、ADR-0025 で採用
-# Paraglide = inlang 製 i18n OSS、ADR-0014 で採用検討
-DOMPurify
-Paraglide
-
-# ===== #1702 LP-SSOT Phase B namespace =====
-# PHASEB = #1702 で導入した LP_INDEX/PRICING/FAQ/PAMPHLET _PHASEB_LABELS の suffix
-PHASEB
-
-# ===== #1900 (UIUX-C-1) =====
-# UIUX = PO Issue グルーピング略号 (UI/UX 改善 Critical track)。
-# Issue タイトル / コミットメッセージ / コードコメント内で参照される。
+TOTP
+tsquery
 UIUX
-
-# ===== #1915 SSOT 用語多重表記正規化 atom namespace =====
-# LIFESTAGE = ライフステージ (幼児期 / 学童期 / 思春期等) を表す atom namespace。
-# terms.ts の LIFESTAGE_TERMS / labels.ts / site/shared-labels.js で参照される造語。
-LIFESTAGE
-lifestage
+umami
+Umami
+unblended
+Unblended
+undou
+unshown
+Unshown
+unstub
+upsell
+Upsell
+upsert
+upserts
+ureshii
+vite
+Vite
+vitest
+Vitest
+VOICEID
+vorbis
+Vorbis
+webp
+webpush
+whsec
+writeback
+wrongpassword
+wxyz
+WXYZ
+xlabel

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -15,6 +15,7 @@ Issue 起票手順 SSOT → [Skill: issue-triage](../.claude/skills/issue-triage
 
 最低限の絶対ルール (詳細は SKILL.md):
 - 根本原因特定 / 同一領域の過去 Issue 確認 / 解決策は 1 つに絞る / AC に全境界条件列挙 / 再発問題はスクラップ&ビルド前提
+- **4 textarea (alternatives / no-gos / research-link / pre-pmf-check) 必須化** — Issue Forms (`*.yml`) で `required: true` 機構強制（#2090、Rust RFC + Shape Up + ADR-0010 §3）。補佐の `gh issue create --body-file` 経由起票も同 4 見出しを markdown body に含める
 
 ## 依存関係 3 分割と工程区分（#1261）
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,12 +31,12 @@ body:
     validations:
       required: true
 
-  - type: dropdown
+  - type: textarea
     id: environment
     attributes:
       label: 環境
-      description: アプリをどの環境で実行していますか?
-      options:
+      description: |
+        どの環境で実行していますか? 以下のいずれかを記載（dropdown 既知不具合回避のため textarea 化 #2090）:
         - AWS Lambda 本番 (ganbari-quest.com)
         - Docker (NUC / セルフホスト)
         - ローカル開発 (npm run dev)
@@ -50,34 +50,27 @@ body:
       description: "例: Chrome 120 / iPhone Safari / iPad"
       placeholder: "Chrome 120 (Android)"
 
-  - type: dropdown
+  - type: textarea
     id: screen
     attributes:
       label: 発生画面
-      description: どの画面で発生しましたか?
-      options:
-        - "子供画面 (baby: 0-2歳)"
-        - "子供画面 (preschool: 3-5歳)"
-        - "子供画面 (elementary: 6-9歳)"
-        - "子供画面 (junior: 10-12歳)"
-        - "子供画面 (senior: 13-15歳)"
-        - "親 管理画面"
-        - "デモ画面"
-        - "LP / マーケティングサイト"
-        - "その他"
+      description: |
+        どの画面で発生しましたか? 以下のいずれかを記載（dropdown 既知不具合回避のため textarea 化 #2090）:
+        - 子供画面 (baby/preschool/elementary/junior/senior)
+        - 親 管理画面 / デモ画面 / LP / マーケティングサイト / その他
     validations:
       required: true
 
-  - type: dropdown
+  - type: textarea
     id: priority
     attributes:
       label: 深刻度
-      description: ユーザーへの影響度
-      options:
-        - "critical: アプリが使えない / データ消失"
-        - "high: 主要機能が使えない"
-        - "medium: 回避策あり"
-        - "low: 見た目の問題 / 軽微"
+      description: |
+        ユーザーへの影響度（dropdown 既知不具合回避のため textarea 化 #2090）:
+        - critical: アプリが使えない / データ消失
+        - high: 主要機能が使えない
+        - medium: 回避策あり
+        - low: 見た目の問題 / 軽微
     validations:
       required: true
 
@@ -111,21 +104,91 @@ body:
       description: "関連するが依存関係を持たない Issue / ADR / 過去インシデントを列挙"
       placeholder: "#234 (類似バグ)"
 
-  - type: dropdown
+  - type: textarea
     id: phase
     attributes:
       label: 工程区分（P0-P7 / N/A）
-      description: "バグ修正は通常 P7 だが、ポリシーや仕様の見直しが必要な場合は該当工程を選択"
-      options:
-        - "P0: インフラ・プロセス更改"
-        - "P1: ポリシー・判断基準 (ADR)"
-        - "P2: プロダクト定義・顧客範囲（企画）"
-        - "P3: アーキテクチャ・技術選定 (ADR)"
-        - "P4: 戦略・構造設計"
-        - "P5: 実装・コンテンツ"
-        - "P6: 機能実装"
-        - "P7: バグ修正・クリーンアップ"
-        - "N/A（独立タスク）"
+      description: |
+        バグ修正は通常 P7 だが、ポリシーや仕様の見直しが必要な場合は該当工程を選択（dropdown 既知不具合回避のため textarea 化 #2090）:
+        - P0: インフラ・プロセス更改
+        - P1: ポリシー・判断基準 (ADR)
+        - P2: プロダクト定義・顧客範囲（企画）
+        - P3: アーキテクチャ・技術選定 (ADR)
+        - P4: 戦略・構造設計
+        - P5: 実装・コンテンツ
+        - P6: 機能実装
+        - P7: バグ修正・クリーンアップ
+        - N/A（独立タスク）
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives + Prior art（Rust RFC 抜粋、#2090）
+      description: |
+        検討した他案 + 不採用理由を列挙。Prior art (採用 OSS / 競合の同等機能) を含めること。
+        該当が無い場合は「探した範囲」を書く（どのキーワードで探し、なぜ該当がなかったか）。
+      value: |
+        <!-- 例:
+        - 案 A: 既存 fallback 経路の再利用 — メリット: 0 行追加 / デメリット: 副作用増（不採用）
+        - 案 B: 新規 error boundary 追加 — メリット: 単一責務 / デメリット: 工数 +1h（採用）
+        - Prior art: react-error-boundary / sentry hook パターン
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: no-gos
+    attributes:
+      label: No-gos / 今回スコープ外（Shape Up 抜粋、#2090）
+      description: |
+        今回意図的にスコープ外とする範囲を明示する（YAGNI 適用 / 将来 Issue 候補）。
+        該当が無い場合は「特になし」と明記すること（空欄不可）。
+      value: |
+        <!-- 例:
+        - 過去発生済 incident への retroactive 再現テスト（新規のみ）
+        - 同類似 bug の横展開修正（別 Issue 起票）
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: research-link
+    attributes:
+      label: research-link（Deep Research 結果リンク、#2090）
+      description: |
+        `docs/reference/NN-research-*.md` への link を貼る、または "N/A" を明記。
+        OSS 比較 / 競合調査 / 学術参照などの調査記録のリンク先。
+      value: |
+        <!-- 例:
+        - docs/reference/NN-research-error-boundary-patterns.md
+        - または: N/A（既存 fix パターン適用のため新規調査不要）
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: pre-pmf-check
+    attributes:
+      label: Pre-PMF check（ADR-0010 §3、#2090）
+      description: |
+        Pre-PMF 段階での起票バイアスを防ぐため、ADR-0010 §3 の 5 質問に回答する。
+        `priority:critical` bug fix / 法務・セキュリティ対応はチェック不要（その旨明記）。
+      value: |
+        <!--
+        Q1: どのペルソナ (P1/P2) のどの課題を解決するか？
+        →
+        Q2: V2MOM Method (M1〜M4) のどれに紐づくか？
+        →
+        Q3: このバグ修正なしで Pre-PMF サインアップ 20 名/月 (V2MOM Q2) に到達できるか？ (可能→medium 以下 / 不可能→high 以上 + 根拠)
+        →
+        Q4: 直近に Growth / Marketing / Onboarding 系 Issue を 1 本以上起票したか？
+        →
+        Q5: 工数と Year 1 KPI (MAU 500 / MRR ¥12,000) への寄与が釣り合っているか？
+        →
+        または: 免除 (priority:critical bug fix / 法務 / セキュリティ)
+        -->
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/dev_ticket.yml
+++ b/.github/ISSUE_TEMPLATE/dev_ticket.yml
@@ -102,6 +102,76 @@ body:
         - 決定: A（標準）/ Pre-PMF コスト (ADR-0010): +14KB 許容
 
   - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives + Prior art（Rust RFC 抜粋、#2090）
+      description: |
+        検討した他案 + 不採用理由を列挙。Prior art (採用 OSS / 競合の同等機能) を含めること。
+        該当が無い場合は「探した範囲」を書く（どのキーワードで探し、なぜ該当がなかったか）。
+      value: |
+        <!-- 例:
+        - 案 A: 既存 hook を拡張 — メリット: 0 行追加 / デメリット: 副作用増（不採用）
+        - 案 B: 新規 service 層 — メリット: 単一責務 / デメリット: 工数 +2h（採用）
+        - Prior art: kubernetes/kube-aggregator の同等パターン
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: no-gos
+    attributes:
+      label: No-gos / 今回スコープ外（Shape Up 抜粋、#2090）
+      description: |
+        今回意図的にスコープ外とする範囲を明示する（YAGNI 適用 / 将来 Issue 候補）。
+        該当が無い場合は「特になし」と明記すること（空欄不可）。
+      value: |
+        <!-- 例:
+        - 既存 open Issue への retroactive 適用（新規のみ）
+        - i18n 対応（別 Issue 候補）
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: research-link
+    attributes:
+      label: research-link（Deep Research 結果リンク、#2090）
+      description: |
+        `docs/reference/NN-research-*.md` への link を貼る、または "N/A" を明記。
+        OSS 比較 / 競合調査 / 学術参照などの調査記録のリンク先。
+      value: |
+        <!-- 例:
+        - docs/reference/01-research-issue-templating-and-doc-consolidation.md §2.1
+        - または: N/A（既存パターン適用のため新規調査不要）
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: pre-pmf-check
+    attributes:
+      label: Pre-PMF check（ADR-0010 §3、#2090）
+      description: |
+        Pre-PMF 段階での起票バイアスを防ぐため、ADR-0010 §3 の 5 質問に回答する。
+        `priority:critical` bug fix / 法務・セキュリティ対応はチェック不要（その旨明記）。
+      value: |
+        <!--
+        Q1: どのペルソナ (P1/P2) のどの課題を解決するか？
+        →
+        Q2: V2MOM Method (M1〜M4) のどれに紐づくか？
+        →
+        Q3: この機能なしで Pre-PMF サインアップ 20 名/月 (V2MOM Q2) に到達できるか？ (可能→medium 以下 / 不可能→high 以上 + 根拠)
+        →
+        Q4: 直近に Growth / Marketing / Onboarding 系 Issue を 1 本以上起票したか？
+        →
+        Q5: 工数と Year 1 KPI (MAU 500 / MRR ¥12,000) への寄与が釣り合っているか？
+        →
+        または: 免除 (priority:critical bug fix / 法務 / セキュリティ)
+        -->
+    validations:
+      required: true
+
+  - type: textarea
     id: technical
     attributes:
       label: 技術メモ

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -147,8 +147,73 @@ body:
   - type: textarea
     id: alternatives
     attributes:
-      label: 検討した代替案
-      description: 他の解決策やワークアラウンドを検討しましたか?
+      label: Alternatives + Prior art（Rust RFC 抜粋、#2090）
+      description: |
+        検討した他案 + 不採用理由を列挙。Prior art (採用 OSS / 競合の同等機能) を含めること。
+        該当が無い場合は「探した範囲」を書く（どのキーワードで探し、なぜ該当がなかったか）。
+      value: |
+        <!-- 例:
+        - 案 A: 既存設定画面に option 追加 — メリット: 既存統合 / デメリット: 既存 UI 圧迫（不採用）
+        - 案 B: 新規 dedicated 画面 — メリット: 単一責務 / デメリット: 工数 +4h（採用）
+        - Prior art: 競合 Bedrock の同等機能 / iOS Screen Time 設定パターン
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: no-gos
+    attributes:
+      label: No-gos / 今回スコープ外（Shape Up 抜粋、#2090）
+      description: |
+        今回意図的にスコープ外とする範囲を明示する（YAGNI 適用 / 将来 Issue 候補）。
+        該当が無い場合は「特になし」と明記すること（空欄不可）。
+      value: |
+        <!-- 例:
+        - i18n 対応（別 Issue 候補）
+        - mobile 横向き対応（usage 1% 未満のため別 Issue）
+        - PMF 後 A/B test 実装（Pre-PMF では不要）
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: research-link
+    attributes:
+      label: research-link（Deep Research 結果リンク、#2090）
+      description: |
+        `docs/reference/NN-research-*.md` への link を貼る、または "N/A" を明記。
+        OSS 比較 / 競合調査 / 学術参照などの調査記録のリンク先。
+      value: |
+        <!-- 例:
+        - docs/reference/NN-research-feature-name.md
+        - または: N/A（既存パターン適用のため新規調査不要）
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: pre-pmf-check
+    attributes:
+      label: Pre-PMF check（ADR-0010 §3 自由記述、#2090）
+      description: |
+        上記 checkboxes 版に加え、ADR-0010 §3 の 5 質問への具体回答を自由記述で残す。
+        checkboxes は機械的チェック、textarea は根拠記述用（2 段階防御）。
+      value: |
+        <!--
+        Q1: どのペルソナ (P1/P2) のどの課題を解決するか？
+        →
+        Q2: V2MOM Method (M1〜M4) のどれに紐づくか？
+        →
+        Q3: この機能なしで Pre-PMF サインアップ 20 名/月 (V2MOM Q2) に到達できるか？ (可能→medium 以下 / 不可能→high 以上 + 根拠)
+        →
+        Q4: 直近に Growth / Marketing / Onboarding 系 Issue を 1 本以上起票したか？
+        →
+        Q5: 工数と Year 1 KPI (MAU 500 / MRR ¥12,000) への寄与が釣り合っているか？
+        →
+        または: 免除 (priority:critical bug fix / 法務 / セキュリティ)
+        -->
+    validations:
+      required: true
 
   - type: textarea
     id: blocked_by

--- a/.github/ISSUE_TEMPLATE/process_ticket.yml
+++ b/.github/ISSUE_TEMPLATE/process_ticket.yml
@@ -74,6 +74,76 @@ body:
       description: 10 行超独自実装は 2 件以上比較必須。lp-content / marketing / docs では N/A 可。
 
   - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives + Prior art（Rust RFC 抜粋、#2090）
+      description: |
+        検討した他案 + 不採用理由を列挙。Prior art (採用 OSS / 競合の同等機能) を含めること。
+        該当が無い場合は「探した範囲」を書く（どのキーワードで探し、なぜ該当がなかったか）。
+      value: |
+        <!-- 例:
+        - 案 A: SSOT を docs/CLAUDE.md に追加 — メリット: 既存集約 / デメリット: 散在継続（不採用）
+        - 案 B: 専用 ADR 起票 — メリット: 横断ポリシー化 / デメリット: 10 枠圧迫（採用）
+        - Prior art: kubernetes/community KEP テンプレ
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: no-gos
+    attributes:
+      label: No-gos / 今回スコープ外（Shape Up 抜粋、#2090）
+      description: |
+        今回意図的にスコープ外とする範囲を明示する（YAGNI 適用 / 将来 Issue 候補）。
+        該当が無い場合は「特になし」と明記すること（空欄不可）。
+      value: |
+        <!-- 例:
+        - 既存 open Issue への retroactive 適用（新規のみ）
+        - CI 自動 lint（本 Issue では Manual 検証、future work）
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: research-link
+    attributes:
+      label: research-link（Deep Research 結果リンク、#2090）
+      description: |
+        `docs/reference/NN-research-*.md` への link を貼る、または "N/A" を明記。
+        OSS 比較 / 競合調査 / 学術参照などの調査記録のリンク先。
+      value: |
+        <!-- 例:
+        - docs/reference/01-research-issue-templating-and-doc-consolidation.md §2.1
+        - または: N/A（既存パターン適用のため新規調査不要）
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: pre-pmf-check
+    attributes:
+      label: Pre-PMF check（ADR-0010 §3、#2090）
+      description: |
+        Pre-PMF 段階での起票バイアスを防ぐため、ADR-0010 §3 の 5 質問に回答する。
+        `priority:critical` bug fix / 法務・セキュリティ対応はチェック不要（その旨明記）。
+      value: |
+        <!--
+        Q1: どのペルソナ (P1/P2) のどの課題を解決するか？
+        →
+        Q2: V2MOM Method (M1〜M4) のどれに紐づくか？
+        →
+        Q3: この変更なしで Pre-PMF サインアップ 20 名/月 (V2MOM Q2) に到達できるか？ (可能→medium 以下 / 不可能→high 以上 + 根拠)
+        →
+        Q4: 直近に Growth / Marketing / Onboarding 系 Issue を 1 本以上起票したか？
+        →
+        Q5: 工数と Year 1 KPI (MAU 500 / MRR ¥12,000) への寄与が釣り合っているか？
+        →
+        または: 免除 (priority:critical bug fix / 法務 / セキュリティ / process: プロセス改善で機構強制)
+        -->
+    validations:
+      required: true
+
+  - type: textarea
     id: goals
     attributes:
       label: ゴール（Acceptance Criteria）

--- a/tests/unit/github/issue-template-required-textareas.test.ts
+++ b/tests/unit/github/issue-template-required-textareas.test.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * GitHub Issue Forms required textareas validation (#2090).
+ *
+ * Issue Forms (`.github/ISSUE_TEMPLATE/*.yml`) で起票時に以下 4 textarea が
+ * `validations.required: true` で必須化されていることを検証する:
+ *
+ * 1. alternatives (Rust RFC 抜粋 — 検討した他案 + 不採用理由)
+ * 2. no-gos (Shape Up 抜粋 — 今回スコープ外)
+ * 3. research-link (Deep Research 結果リンク)
+ * 4. pre-pmf-check (ADR-0010 §3 4 質問への回答)
+ *
+ * dropdown の既知不具合 (default 値選択で起票通過、community discussion #45084 /
+ * #75372) を回避するため textarea のみで強制効果を担保する設計。
+ *
+ * 依存追加を避けるため YAML parser を使わず regex で検査する (Issue Forms YAML は
+ * 単純構造のため regex で十分な validation 強度を担保できる)。
+ */
+
+const TEMPLATE_DIR = resolve(process.cwd(), '.github/ISSUE_TEMPLATE');
+
+const TARGET_TEMPLATES = [
+	'dev_ticket.yml',
+	'process_ticket.yml',
+	'bug_report.yml',
+	'feature_request.yml',
+];
+
+const REQUIRED_TEXTAREA_IDS = ['alternatives', 'no-gos', 'research-link', 'pre-pmf-check'];
+
+function loadTemplate(filename: string): string {
+	return readFileSync(resolve(TEMPLATE_DIR, filename), 'utf8');
+}
+
+/**
+ * 指定 ID の field block を抽出する。
+ * Issue Forms YAML の field block は `  - type: <type>` で始まり、
+ * 次の `  - type:` または EOF までを 1 block とする。
+ */
+function extractFieldBlock(content: string, id: string): string | null {
+	// 各 - type: ... ブロックを切り出す
+	const blocks = content.split(/\n(?= {2}- type: )/);
+	for (const block of blocks) {
+		const idMatch = block.match(/^\s+id:\s+(\S+)/m);
+		if (idMatch && idMatch[1] === id) {
+			return block;
+		}
+	}
+	return null;
+}
+
+function getFieldType(block: string): string | null {
+	const m = block.match(/^\s*-?\s*type:\s+(\S+)/m);
+	return m && m[1] ? m[1] : null;
+}
+
+function hasRequiredTrue(block: string): boolean {
+	// validations:\n      required: true パターン
+	return /validations:\s*\n\s+required:\s+true/.test(block);
+}
+
+function countTypeDropdown(content: string): number {
+	const matches = content.match(/^\s*-\s*type:\s+dropdown/gm);
+	return matches ? matches.length : 0;
+}
+
+describe('GitHub Issue Forms — required textareas (#2090)', () => {
+	describe.each(TARGET_TEMPLATES)('%s', (filename) => {
+		const content = loadTemplate(filename);
+
+		it('contains body field blocks (sanity check)', () => {
+			expect(content).toMatch(/^body:/m);
+			expect(content).toMatch(/-\s+type:\s+/);
+		});
+
+		describe.each(REQUIRED_TEXTAREA_IDS)('%s field', (id) => {
+			it('exists with type=textarea', () => {
+				const block = extractFieldBlock(content, id);
+				expect(block, `${filename} に id: ${id} の field が存在しない`).not.toBe(null);
+				expect(getFieldType(block as string)).toBe('textarea');
+			});
+
+			it('has validations.required: true', () => {
+				const block = extractFieldBlock(content, id);
+				expect(block).not.toBe(null);
+				expect(
+					hasRequiredTrue(block as string),
+					`${filename} の id: ${id} に validations.required: true が付与されていない`,
+				).toBe(true);
+			});
+		});
+	});
+
+	describe('bug_report.yml — dropdown 既知不具合回避 (AC3)', () => {
+		it('contains zero `type: dropdown` items (textarea のみで強制、#2090)', () => {
+			const content = loadTemplate('bug_report.yml');
+			expect(countTypeDropdown(content)).toBe(0);
+		});
+	});
+
+	describe('AC4 — 既存 dropdown 維持', () => {
+		it('dev_ticket.yml の priority dropdown は維持', () => {
+			const content = loadTemplate('dev_ticket.yml');
+			const block = extractFieldBlock(content, 'priority');
+			expect(block).not.toBe(null);
+			expect(getFieldType(block as string)).toBe('dropdown');
+			expect(hasRequiredTrue(block as string)).toBe(true);
+		});
+
+		it('process_ticket.yml の kind dropdown は維持', () => {
+			const content = loadTemplate('process_ticket.yml');
+			const block = extractFieldBlock(content, 'kind');
+			expect(block).not.toBe(null);
+			expect(getFieldType(block as string)).toBe('dropdown');
+			expect(hasRequiredTrue(block as string)).toBe(true);
+		});
+	});
+
+	describe('.github/CLAUDE.md — Issue 起票ルール記載 (AC6)', () => {
+		const claudeMd = readFileSync(resolve(process.cwd(), '.github/CLAUDE.md'), 'utf8');
+
+		it('4 textarea 必須化の言及あり', () => {
+			expect(claudeMd).toMatch(
+				/4 textarea \(alternatives \/ no-gos \/ research-link \/ pre-pmf-check\) 必須化/,
+			);
+		});
+
+		it('#2090 への参照あり', () => {
+			expect(claudeMd).toContain('#2090');
+		});
+	});
+});

--- a/tests/unit/github/issue-template-required-textareas.test.ts
+++ b/tests/unit/github/issue-template-required-textareas.test.ts
@@ -54,7 +54,7 @@ function extractFieldBlock(content: string, id: string): string | null {
 
 function getFieldType(block: string): string | null {
 	const m = block.match(/^\s*-?\s*type:\s+(\S+)/m);
-	return m && m[1] ? m[1] : null;
+	return m?.[1] ?? null;
 }
 
 function hasRequiredTrue(block: string): boolean {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: PO / PO 補佐 (Claude Code) / 開発チーム / Issue を起票する全ユーザー

**解決する課題**: GitHub Issue Forms は dropdown の既知不具合 (default 値選択で起票通過、community discussion #45084 / #75372) があり、`required: true` の機構強制が完全に機能しない。また Pre-PMF バイアス防止 (ADR-0010 §3) や OSS 先調査 (ADR-0014 / #1350) の責務が markdown body 運用に依存しており、起票時に網羅性を取りこぼす構造リスクがあった (4-5 月 LP レビュー失敗の根本原因 = 補佐の調査責務未定義)。

**期待される効果**: Issue Forms native `required: true` 機構で web UI 起票時に Rust RFC (Alternatives + Prior art) + Shape Up (No-gos) + Deep Research link + ADR-0010 §3 (Pre-PMF check) の 4 textarea を強制し、機構レベルで起票品質を担保する。「機構が先、文書は後」原則 (memory `feedback_principle_enforcement_via_ci.md`) に整合し、Issue B (S-2 文書統廃合) と並列で機構強制を担当する。

## 関連 Issue

closes #2090

Related: #2088 (S-1: po-session.md 調査責務追加、Blocked by) / #2089 (S-2: 文書統廃合、並列) / ADR-0010 (Pre-PMF) / ADR-0014 (OSS 先調査)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 4 yml 全てに `id: alternatives` / `id: no-gos` / `id: research-link` の 3 textarea が `required: true` で存在 | `for f in .github/ISSUE_TEMPLATE/{dev,process,bug_report,feature_request}.yml; do c=$(grep -cE "id: (alternatives\|no-gos\|research-link)" $f); [ "$c" -eq 3 ] \|\| exit 1; done` | PASS (全 4 ファイル c=3) |
| AC2 | 全 yml に `id: pre-pmf-check` textarea が required:true + ADR-0010 §3 質問が pre-fill | `grep -A 10 "id: pre-pmf-check" *.yml \| grep -E "required: true\|サインアップ 20 名/月"` | PASS (4 ファイル全てに pre-fill 確認) |
| AC3 | `bug_report.yml` の dropdown 全廃 | `grep "type: dropdown" .github/ISSUE_TEMPLATE/bug_report.yml \| wc -l` == 0 | PASS (0 件) |
| AC4 | 既存 dropdown (dev_ticket priority / process_ticket kind) は維持、`yamllint .github/ISSUE_TEMPLATE/*.yml` PASS | `node tmp/validate-yaml.mjs` (依存追加避けるため js-yaml で parse 検証) | PASS (5 yml 全 parse 成功) |
| AC5 | GitHub web UI 起票 Manual テスト: 4 必須 textarea 空欄で submit → block | Manual テスト (PR merge 後、PO が web UI から実機検証) | 本 PR scope 外: PR merge 後の web UI Manual テストは PO が実施 (CI 自動化は別 Issue、Issue 本文 No-gos §で明記済) |
| AC6 | `.github/CLAUDE.md` Issue 起票ルールに 4 textarea 必須化を 1 行追記 | `grep -E "alternatives.*no-gos\|4 textarea 必須化" .github/CLAUDE.md` | PASS (line 19) |
| AC7 | Issue A の研究レポート (#2088) への link 記載 | 本 PR description で `docs/reference/01-research-issue-templating-and-doc-consolidation.md` を参照 | PASS (本 description 上記 §2.1 参照) |

参照: `docs/reference/01-research-issue-templating-and-doc-consolidation.md` §2.1 軸 A (Issue B / S-1 で commit される運用)

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`.github/ISSUE_TEMPLATE/*.yml` + `.github/CLAUDE.md`)

**影響を受ける画面・機能**: GitHub Issue 起票画面 (web UI + `gh issue create --body-file`)。今後の全 Issue 起票で 4 textarea 必須化。既存 open Issue への retroactive 適用なし (新規起票のみ、PO 判断 #4)。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest 個別実行で PASS 確認済み
- [x] 追加したテスト: `tests/unit/github/issue-template-required-textareas.test.ts` (41 tests)。4 yml × 4 textarea ID × (exists + required:true) + bug_report dropdown 0 件 + dev/process 既存 dropdown 維持 + CLAUDE.md 記載検証
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は `.github/ISSUE_TEMPLATE/*.yml` (Issue Forms) と `.github/CLAUDE.md` (Markdown) の変更のみで、アプリ本体 UI / LP には一切影響しない。`.svelte` ファイル変更ゼロのため `refactor:internal-no-doc-impact` 相当の N/A。GitHub Issue web UI での実際の見た目検証は AC5 を PO Manual テストで担保で実施。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A (YAML template + 1 markdown 追記のみ、新規ロジック実装ゼロ)
- [x] **DRY**: 4 yml で同等な 4 textarea を追加するが、各 template の文脈に応じて example placeholder を微調整 (dev: 一般実装 / process: SSOT 整理 / bug: error boundary 例 / feature: UI 設定例)。完全コピペは避け、文脈最適化
- [x] **YAGNI**: ADR-0010 §3 質問は本 yml で pre-fill するが、Issue 本文の 5 質問 (P/V2MOM/サインアップ 20 名/月/Growth 連続/工数⇔KPI) のみで過剰質問追加なし
- [x] **Security**: N/A (公開 Issue template、機密データ無し)
- [x] **アクセシビリティ**: N/A (GitHub native form rendering)
- [x] **パフォーマンス**: N/A (form 1 つ追加のみ、render 影響皆無)

## 横展開・影響波及チェック

- 並行実装ペア (`docs/design/parallel-implementations.md`) との関係: Issue Template は SSOT 単一、並行実装なし
- 本番 / デモ: N/A (Issue Forms はリポジトリ唯一の SSOT)
- 設計書更新: `.github/CLAUDE.md` に 1 行追記 (AC6)、`docs/sessions/po-session.md` への波及は #2088 (S-1) の scope
- 設計書 (`docs/design/`): UI / DB / API 仕様非該当のため更新不要
- 横展開 grep: `grep -nR "id: alternatives" .github/ISSUE_TEMPLATE/*.yml` で 4 ファイル全件追加確認済み
- `docs/troubleshoot/github_actions.md` / その他知見更新: 該当なし

## レビュー依頼事項・破壊的変更

**破壊的変更**: 既存 open Issue への retroactive 適用なし (新規起票のみ。Issue 本文 No-gos 明記)。既存 Issue body へ 4 見出しを後付け要求しない。

**レビュー観点**:
1. AC3 (bug_report の dropdown 全廃) と AC4 (dev/process の dropdown 維持) の整合: bug_report.yml は environment / screen / priority / phase 4 dropdown を全て textarea 化、dev_ticket priority / process_ticket kind は dropdown 維持を選択。Issue 本文「`bug_report.yml` の `type` dropdown → textarea 化」の文字通りでない解釈について PO 確認希望 (`id: type` dropdown は dev_ticket にのみ存在し、bug_report に存在しないため、bug_report の dropdown を全廃する PO 意図と解釈)
2. ADR-0010 §3 は 5 質問だが Issue 本文では「4 質問」と記載: pre-pmf-check textarea は ADR の最新版 (5 質問) を pre-fill。AC2 grep の期待文字列「サインアップ 20 名/月」は Q3 内に確実に存在
3. dogfood 観察期間: PR merge 後 1 ヶ月、5-10 件の Issue 起票で「Alternatives field の充足率 / 空欄頻度」を retrospective (PO 判断)

## 配布済み env / secret (ADR-0006)

N/A — env / secret 追加なし

## Ready for Review チェックリスト

- [x] AC 検証マップ全件埋まり
- [x] PR body 必須 13 セクション存在 (`.github/PR_TEMPLATE_SECTIONS.json` 整合)
- [x] `[x]` 完了マーキング 1 件以上
- [x] スクリーンショット 4 スロット (UI 変更非該当のため N/A 明記、本 PR は `.github/` のみ)
- [x] 関連 Issue 番号 (`closes #2090`)
- [x] biome / svelte-check / vitest ローカル PASS
- [x] CI 全緑後に Draft → Ready 移行

## QM レビュー結果

<!-- QA / QM が記入 (本 PR Dev 側では未記入、ADR-0022 通り) -->
