### PR TITLE
refactor: #2097 Phase 2 — Production toViewModel() + DashboardView ViewModel 経路 (ADR-0047)

### DIFF
--- a/src/lib/features/child-home/components/DashboardView.svelte
+++ b/src/lib/features/child-home/components/DashboardView.svelte
@@ -1,44 +1,126 @@
 <!--
-  DashboardView.svelte — ADR-0046 / Issue #2069 POC
+  DashboardView.svelte — ADR-0046 / ADR-0047 Phase 2
 
   Child Home の共通 UI コンポーネント。
 
-  POC scope:
-    - demo (`/demo/(child)/[mode]/home/+page.svelte`) から呼び出される。
-    - データ取得は **Context 経由** で注入された ChildDashboardService から行う。
-    - 表示要素は demo 側 `+page.svelte` (移行前) と同等 (UI 等価性証明のため)。
+  ## Phase 2 構造 (ADR-0047)
 
-  follow-up scope (Issue #2069 残り):
-    - 本番側 `+page.svelte` (1094 行) を順次本 View に集約。
-    - 完了 / 確認 dialog の write 動詞 (record / cancel / claimBonus) を
-      service interface に追加し、demo / 本番のどちらでも同じ form を使う。
+  本コンポーネントは **`ChildHomeViewModel` 入力経路** をメインに昇格した。
+  Phase 2 では UI 等価性 (本番 degrade なし) を最優先とし、本番固有 feature
+  (pin / mission badge / event badge / baby inline form / xp animation /
+  sibling ranking / frozen activity / triggerHint / mainQuest) を全て render する。
+
+  ### 入力経路
+
+  1. **`viewModel` 経路 (本番、ADR-0047)**:
+     - `viewModel: ChildHomeViewModel` を main contract として受け取る
+     - 本番固有 feature の表示判定は `viewModel.features.*` フラグで行う
+     - 本番固有の Drizzle 詳細フィールド (displayName / frozen / triggerHint /
+       isMainQuest 等) は ChildHomeViewModel に含まれないため、互換ブリッジとして
+       `auxiliaryActivities` 補助 props で受け取る。Phase 4 以降で `ChildHomeActivity`
+       を拡張して補助 props を削減予定。
+
+  2. **`pageData` 経路 (demo、Phase 3 で廃止)**:
+     - 旧 demo 側 `+page.svelte` からそのまま `pageData` を受け取る互換 path
+     - Phase 3 で `DemoDashboardService.toViewModel()` 実装後、本 path は削除
+
+  ### 旧 `ProdDashboardSections.svelte` との関係
+
+  ProdDashboardSections.svelte は Phase 2 完了時点で `+page.svelte` から呼ばれなくなる
+  (孤児コンポーネント)。Phase 3 で demo 側を ViewModel 化する PR にて `git rm` される。
 -->
 <script lang="ts">
 import { enhance } from '$app/forms';
-import { DEMO_CHILD_HOME_LABELS, formatStreak } from '$lib/domain/labels';
+import type { parseDisplayConfig } from '$lib/domain/display-config';
+import { CHILD_HOME_LABELS, DEMO_CHILD_HOME_LABELS, formatStreak } from '$lib/domain/labels';
 import { formatPointValueWithSign } from '$lib/domain/point-display';
-import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
+import { CATEGORY_DEFS, getCategoryById } from '$lib/domain/validation/activity';
 import type { UiMode } from '$lib/domain/validation/age-tier';
 import MustProgressBar from '$lib/features/child/MustProgressBar.svelte';
+import type { CategoryXpInfo } from '$lib/server/services/status-service';
 import { getDashboardService } from '$lib/services/context';
+import type { ChildHomeViewModel } from '$lib/services/types';
 import ActivityCard from '$lib/ui/components/ActivityCard.svelte';
+import ActivityEmptyState from '$lib/ui/components/ActivityEmptyState.svelte';
 import CategorySection from '$lib/ui/components/CategorySection.svelte';
+import CompoundIcon from '$lib/ui/components/CompoundIcon.svelte';
+import SiblingRanking from '$lib/ui/components/SiblingRanking.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Dialog from '$lib/ui/primitives/Dialog.svelte';
+import { soundService } from '$lib/ui/sound';
 
 /**
- * Props
+ * Sibling ranking row 型 (`SiblingRanking.svelte` private interface に整合)。
+ */
+interface SiblingRankingRow {
+	childId: number;
+	childName: string;
+	totalCount: number;
+	categoryCounts: Record<number, number>;
+}
+
+/**
+ * 本番互換ブリッジ用 auxiliary activity 型 (Phase 4 で `ChildHomeActivity` に統合予定)。
  *
- * - `pageData`: SvelteKit `+page.server.ts` の load 戻り値そのまま。
- *   demo 側で form action 結果や mustStatus / checklist など Context に
- *   含まない既存スキーマフィールドを引き続き使えるよう、原形を維持する。
- *   POC では Service interface (`getDashboardService`) が
- *   `todayRecorded` / `pointSettings` / `child` を提供する。
+ * `+page.server.ts` から渡される Drizzle 生レコードのうち、ViewModel に含まれない
+ * UI 描画必須フィールド (displayName / frozen / triggerHint / isMainQuest) を保持する。
+ * `id` で `viewModel.activities[i]` と紐付け。
+ */
+interface AuxiliaryActivity {
+	id: number;
+	displayName: string;
+	frozen: boolean;
+	triggerHint?: string | null;
+	isMainQuest?: boolean | number;
+}
+
+/**
+ * Props — `viewModel` 経路 (本番) / `pageData` 経路 (demo) の hybrid。
  */
 const {
-	pageData,
+	// ---- viewModel 経路 (本番、ADR-0047) ----
+	viewModel = undefined,
+	auxiliaryActivities = [],
+	mustStatus = null,
+	siblingRanking = null,
+	displayConfig = null,
+	childId = 0,
+	submitting = false,
+	pendingActivityId = null,
+	getCategoryXpWithAnim = undefined,
+	xpAnimatingCategoryId = null,
+	getCategoryMissionCount = undefined,
+	getCategoryCompletedMissionCount = undefined,
+	activeEventBadge = null,
+	onActivityTap = undefined,
+	onActivityLongPress = undefined,
+	onRecordSubmit = undefined,
+	onRecordResult = undefined,
+	// ---- pageData 経路 (demo、Phase 3 で廃止) ----
+	pageData = undefined,
 }: {
-	pageData: {
+	viewModel?: ChildHomeViewModel;
+	auxiliaryActivities?: readonly AuxiliaryActivity[];
+	mustStatus?: { logged: number; total: number; granted: boolean; points: number } | null;
+	siblingRanking?: { rankings: SiblingRankingRow[] } | null;
+	displayConfig?: ReturnType<typeof parseDisplayConfig> | null;
+	childId?: number;
+	submitting?: boolean;
+	pendingActivityId?: number | null;
+	getCategoryXpWithAnim?: (categoryId: number) => CategoryXpInfo | null;
+	xpAnimatingCategoryId?: number | null;
+	getCategoryMissionCount?: (categoryId: number) => number;
+	getCategoryCompletedMissionCount?: (categoryId: number) => number;
+	activeEventBadge?: string | null;
+	onActivityTap?: (activity: { id: number; name: string; icon: string }) => void;
+	onActivityLongPress?: (activity: {
+		id: number;
+		name: string;
+		isPinned?: boolean | number;
+	}) => void;
+	onRecordSubmit?: (activityId: number) => void;
+	onRecordResult?: (result: { type: string; data?: Record<string, unknown> }) => void;
+	pageData?: {
 		activities: {
 			id: number;
 			name: string;
@@ -61,12 +143,32 @@ const {
 	};
 } = $props();
 
+// ADR-0046: getDashboardService は viewModel 経路でも todayRecorded を共有するため使う
 const service = getDashboardService();
 const homeData = $derived(service.getHomeData());
 
+// auxiliary activity を id で参照しやすくするマップ
+const auxMap = $derived(new Map(auxiliaryActivities.map((a) => [a.id, a])));
+
+// =============================================================================
+// viewModel 経路 (本番、ADR-0047) — activities by category
+// =============================================================================
+
+const vmActivitiesByCategory = $derived(
+	viewModel
+		? CATEGORY_DEFS.map((catDef) => ({
+				categoryId: catDef.id,
+				items: viewModel.activities.filter((a) => a.categoryId === catDef.id),
+			})).filter((g) => g.items.length > 0)
+		: [],
+);
+
+// =============================================================================
+// pageData 経路 (demo 互換、Phase 3 で削除予定)
+// =============================================================================
+
 const ps = $derived(homeData.pointSettings);
 const fmtPts = (pts: number) => formatPointValueWithSign(pts, ps.mode, ps.currency, ps.rate);
-
 const recordedMap = $derived(new Map(homeData.todayRecorded.map((r) => [r.activityId, r.count])));
 
 function getCount(activityId: number): number {
@@ -79,14 +181,16 @@ function isCompleted(activity: { id: number; dailyLimit: number | null }): boole
 	return getCount(activity.id) >= limit;
 }
 
-const activitiesByCategory = $derived(
-	CATEGORY_DEFS.map((catDef) => ({
-		categoryId: catDef.id,
-		items: pageData.activities.filter((a) => a.categoryId === catDef.id),
-	})).filter((g) => g.items.length > 0),
+const demoActivitiesByCategory = $derived(
+	pageData
+		? CATEGORY_DEFS.map((catDef) => ({
+				categoryId: catDef.id,
+				items: pageData.activities.filter((a) => a.categoryId === catDef.id),
+			})).filter((g) => g.items.length > 0)
+		: [],
 );
 
-// Confirm / result dialog state
+// Confirm / result dialog state (pageData 経路で使う)
 let confirmOpen = $state(false);
 let selectedActivity = $state<{
 	id: number;
@@ -94,7 +198,7 @@ let selectedActivity = $state<{
 	displayName?: string;
 	icon: string;
 } | null>(null);
-let submitting = $state(false);
+let demoSubmitting = $state(false);
 let resultOpen = $state(false);
 let resultData = $state<{ activityName: string; totalPoints: number; streakDays: number } | null>(
 	null,
@@ -102,13 +206,13 @@ let resultData = $state<{ activityName: string; totalPoints: number; streakDays:
 
 const anyDialogOpen = $derived(confirmOpen || resultOpen);
 
-function handleActivityTap(activity: {
+function handleDemoActivityTap(activity: {
 	id: number;
 	name: string;
 	displayName?: string;
 	icon: string;
 }) {
-	if (anyDialogOpen || submitting) return;
+	if (anyDialogOpen || demoSubmitting) return;
 	selectedActivity = activity;
 	confirmOpen = true;
 }
@@ -124,157 +228,315 @@ function handleResultClose() {
 }
 </script>
 
-<div class="px-[var(--sp-sm)] py-1">
-	{#if pageData.mustStatus && pageData.mustStatus.total > 0 && pageData.uiMode !== 'baby'}
+{#if viewModel}
+	<!-- ====================================================================
+	     本番経路 (ADR-0047 Phase 2): ViewModel ベース dashboard sections
+	     本番固有 feature (pin / mission / event badge / baby inline form /
+	     sibling ranking / frozen / triggerHint / mainQuest) を render する。
+	     ==================================================================== -->
+	{#if mustStatus && mustStatus.total > 0}
 		<MustProgressBar
-			logged={pageData.mustStatus.logged}
-			total={pageData.mustStatus.total}
-			uiMode={pageData.uiMode as UiMode}
-			bonusGranted={pageData.mustStatus.granted}
-			bonusPoints={pageData.mustStatus.points}
+			logged={mustStatus.logged}
+			total={mustStatus.total}
+			uiMode={viewModel.uiMode as UiMode}
+			bonusGranted={mustStatus.granted}
+			bonusPoints={mustStatus.points}
 		/>
 	{/if}
 
-	{#if pageData.hasChecklists}
-		<div
-			class="flex items-center justify-between w-full px-[var(--sp-md)] py-[var(--sp-sm)] mb-[var(--sp-sm)] rounded-[var(--radius-lg)] bg-white shadow-sm border border-[var(--color-border)]"
+	{#each vmActivitiesByCategory as group, groupIdx (group.categoryId)}
+		<CategorySection
+			categoryId={group.categoryId}
+			cardSize={displayConfig?.cardSize}
+			itemsPerCategory={displayConfig?.itemsPerCategory}
+			collapsible={displayConfig?.collapsible}
+			itemCount={group.items.length}
+			xpInfo={getCategoryXpWithAnim ? getCategoryXpWithAnim(group.categoryId) : null}
+			xpAnimating={xpAnimatingCategoryId === group.categoryId}
+			missionCount={getCategoryMissionCount ? getCategoryMissionCount(group.categoryId) : 0}
+			completedMissionCount={getCategoryCompletedMissionCount ? getCategoryCompletedMissionCount(group.categoryId) : 0}
 		>
-			<div class="flex items-center gap-[var(--sp-sm)]">
-				<span class="text-2xl">📋</span>
-				<span class="font-bold">{DEMO_CHILD_HOME_LABELS.checklistTitle}</span>
-			</div>
-			{#if pageData.checklistProgress}
-				<div class="flex items-center gap-[var(--sp-xs)]">
-					{#if pageData.checklistProgress.allDone}
-						<span class="text-sm font-bold text-[var(--theme-accent)]">{DEMO_CHILD_HOME_LABELS.checklistDone}</span>
-					{:else}
-						<span class="text-sm text-[var(--color-text-muted)]">
-							{pageData.checklistProgress.checkedCount}/{pageData.checklistProgress.totalCount}
-						</span>
-					{/if}
-				</div>
-			{/if}
-		</div>
-	{/if}
-
-	{#if pageData.dailyMissions && pageData.dailyMissions.missions.length > 0}
-		<div class="mb-[var(--sp-sm)] rounded-[var(--radius-lg)] bg-white shadow-sm border border-[var(--color-border)] overflow-hidden">
-			<div class="flex items-center gap-[var(--sp-xs)] px-[var(--sp-md)] pt-[var(--sp-sm)] pb-1">
-				<span class="text-lg">🎯</span>
-				<span class="font-bold text-sm">{DEMO_CHILD_HOME_LABELS.dailyMissionTitle}</span>
-				<span class="text-xs text-[var(--color-text-muted)] ml-auto">
-					{pageData.dailyMissions.completedCount}/{pageData.dailyMissions.missions.length}
-				</span>
-			</div>
-			<div class="px-[var(--sp-md)] pb-[var(--sp-sm)]">
-				{#each pageData.dailyMissions.missions as mission (mission.id)}
-					<div class="flex items-center gap-[var(--sp-sm)] py-1">
-						<span class="text-lg w-6 text-center">{mission.completed ? '✅' : '⬜'}</span>
-						<span class="text-lg">{mission.activityIcon}</span>
-						<span class="text-sm {mission.completed ? 'line-through text-[var(--color-text-muted)]' : 'font-bold'}">
-							{mission.activityName}
-						</span>
-					</div>
-				{/each}
-				{#if pageData.dailyMissions.allComplete}
-					<div class="text-center mt-1 py-1 rounded-[var(--radius-md)] bg-[var(--theme-bg)]">
-						<span class="text-sm font-bold text-[var(--theme-accent)]">{DEMO_CHILD_HOME_LABELS.missionComplete(fmtPts(pageData.dailyMissions.bonusAwarded))}</span>
+			{#each group.items as activity, i (activity.id)}
+				{@const aux = auxMap.get(activity.id)}
+				{@const displayName = aux?.displayName ?? activity.name}
+				{@const completed = activity.todayRecorded >= 1}
+				{#if viewModel.features.showPinButton && i > 0 && !activity.isPinned && group.items[i - 1]?.isPinned}
+					<div class="col-span-full flex items-center gap-2 my-0.5" aria-hidden="true" data-testid="pin-separator">
+						<div class="flex-1 border-t border-dashed border-[var(--color-border-strong)]"></div>
 					</div>
 				{/if}
-			</div>
-		</div>
-	{/if}
-
-	{#each activitiesByCategory as group (group.categoryId)}
-		<CategorySection categoryId={group.categoryId} itemCount={group.items.length}>
-			{#each group.items as activity (activity.id)}
-				<ActivityCard
-					activityId={activity.id}
-					icon={activity.icon}
-					name={activity.displayName}
-					categoryId={activity.categoryId}
-					completed={isCompleted(activity)}
-					count={getCount(activity.id)}
-					isMission={activity.isMission}
-					onclick={() => handleActivityTap(activity)}
-				/>
+				{#if !viewModel.ageContext.isBabyParentMode}
+					<!-- Non-baby: ActivityCard + confirm dialog (handled by page) -->
+					{#if groupIdx === 0 && i === 0}
+						<div data-tutorial="activity-card">
+							<ActivityCard
+								activityId={activity.id}
+								icon={activity.icon}
+								name={displayName}
+								categoryId={activity.categoryId}
+								cardSize={displayConfig?.cardSize}
+								{completed}
+								count={activity.todayRecorded}
+								isMission={activity.isMust}
+								isPinned={activity.isPinned}
+								frozen={aux?.frozen ?? false}
+								triggerHint={aux?.triggerHint}
+								eventBadge={activeEventBadge}
+								onclick={() => onActivityTap?.({ id: activity.id, name: displayName, icon: activity.icon })}
+								onlongpress={() => onActivityLongPress?.({ id: activity.id, name: displayName, isPinned: activity.isPinned })}
+							/>
+						</div>
+					{:else}
+						<ActivityCard
+							activityId={activity.id}
+							icon={activity.icon}
+							name={displayName}
+							categoryId={activity.categoryId}
+							cardSize={displayConfig?.cardSize}
+							{completed}
+							count={activity.todayRecorded}
+							isMission={activity.isMust}
+							isPinned={activity.isPinned}
+							frozen={aux?.frozen ?? false}
+							triggerHint={aux?.triggerHint}
+							eventBadge={activeEventBadge}
+							onclick={() => onActivityTap?.({ id: activity.id, name: displayName, icon: activity.icon })}
+							onlongpress={() => onActivityLongPress?.({ id: activity.id, name: displayName, isPinned: activity.isPinned })}
+						/>
+					{/if}
+				{:else}
+					<!-- Baby inline form recording (no confirm dialog) -->
+					{@const borderColor = getCategoryById(activity.categoryId)?.color ?? 'var(--theme-primary)'}
+					{@const actCount = activity.todayRecorded}
+					{@const showMission = activity.isMust && !completed}
+					{@const showMainQuest = !!aux?.isMainQuest && !completed}
+					{#if completed}
+						<div
+							class="relative flex flex-col items-center justify-center gap-0.5 w-full aspect-[4/5] min-h-[60px] rounded-[var(--radius-md)] border-2 border-[var(--color-gold-400)] bg-[var(--color-gold-100)] shadow-[0_0_0_2px_rgba(251,191,36,0.3)] transition-all duration-150 ease-out tap-target"
+							data-testid="activity-card-{activity.id}"
+							data-tutorial={groupIdx === 0 && i === 0 ? 'activity-card' : undefined}
+							aria-label={CHILD_HOME_LABELS.completedAriaLabel(displayName)}
+						>
+							<span class="absolute inset-0 flex items-center justify-center text-3xl opacity-80 z-1 animate-bounce-in">💮</span>
+							<CompoundIcon icon={activity.icon} size="lg" faded={true} />
+							<span class="text-[10px] font-bold leading-tight text-center line-clamp-2 opacity-40">{displayName}</span>
+						</div>
+					{:else}
+						<form
+							method="POST"
+							action="?/record"
+							data-tutorial={groupIdx === 0 && i === 0 ? 'activity-card' : undefined}
+							use:enhance={() => {
+								if (submitting) return ({ update }) => update();
+								soundService.ensureContext();
+								soundService.play('tap');
+								onRecordSubmit?.(activity.id);
+								return async ({ result }) => {
+									onRecordResult?.(result);
+								};
+							}}
+						>
+							<input type="hidden" name="activityId" value={activity.id} />
+							<Button
+								type="submit"
+								disabled={submitting}
+								variant="outline"
+								size="sm"
+								class="relative flex flex-col items-center justify-center gap-0.5 w-full aspect-[4/5] min-h-[60px] border-2 border-solid bg-white shadow-sm cursor-pointer duration-150 ease-out hover:shadow-md active:scale-95 {pendingActivityId === activity.id ? 'baby-card-pending' : ''} {showMission ? 'baby-card-mission' : ''} {showMainQuest ? 'baby-card-main-quest' : ''}"
+								data-testid="activity-card-{activity.id}"
+								style="border-color: {showMainQuest ? 'var(--color-gold-500, #d97706)' : showMission ? 'gold' : borderColor}"
+								aria-label="{CHILD_HOME_LABELS.babyCardRecordAriaLabel(displayName)}{showMainQuest ? CHILD_HOME_LABELS.babyCardRecordMainQuestSuffix : ''}{showMission ? CHILD_HOME_LABELS.babyCardRecordMissionSuffix : ''}"
+							>
+								{#if showMission}
+									<span class="absolute -top-1.5 -left-1.5 z-10 text-sm baby-card__mission-star" aria-hidden="true">⭐</span>
+								{/if}
+								{#if showMainQuest}
+									<span class="baby-main-quest-badge" aria-hidden="true">{CHILD_HOME_LABELS.babyCardMainQuestBadge}</span>
+								{/if}
+								{#if pendingActivityId === activity.id}
+									<span class="baby-card__spinner" aria-hidden="true"></span>
+									<span class="text-[10px] font-bold leading-tight text-center line-clamp-2">{CHILD_HOME_LABELS.babyCardPendingText}</span>
+								{:else}
+									{#if actCount > 0}
+										<span class="absolute -top-1 -right-1 z-10 flex items-center justify-center w-5 h-5 rounded-full bg-[var(--color-brand-600)] text-white text-[10px] font-bold shadow-sm">{actCount}</span>
+									{/if}
+									<CompoundIcon icon={activity.icon} size="lg" />
+									<span class="text-[10px] font-bold leading-tight text-center line-clamp-2">{displayName}</span>
+									{#if aux?.triggerHint}
+										<span class="text-[9px] font-bold text-orange-500 leading-tight text-center line-clamp-1 px-0.5">{aux.triggerHint}</span>
+									{/if}
+								{/if}
+							</Button>
+						</form>
+					{/if}
+				{/if}
 			{/each}
 		</CategorySection>
 	{/each}
 
-	{#if pageData.activities.length === 0}
-		<div class="flex flex-col items-center justify-center py-[var(--sp-2xl)] text-[var(--color-text-muted)]">
-			<span class="text-4xl mb-[var(--sp-md)]">📋</span>
-			<p class="text-[var(--font-md)]">{DEMO_CHILD_HOME_LABELS.activitiesEmpty}</p>
-		</div>
+	{#if viewModel.features.showSiblingRanking && siblingRanking && siblingRanking.rankings.length > 1}
+		<SiblingRanking rankings={siblingRanking.rankings} {childId} />
 	{/if}
-</div>
 
-<!-- Confirm dialog -->
-<Dialog bind:open={confirmOpen} title="きろくする？" onOpenChange={({ open }) => { if (!open) handleConfirmClose(); }}>
-	{#if selectedActivity}
-		<div class="text-center py-4">
-			<span class="text-5xl block mb-3">{selectedActivity.icon}</span>
-			<p class="text-lg font-bold mb-4">{selectedActivity.displayName ?? selectedActivity.name}</p>
-			<form
-				method="POST"
-				action="?/record"
-				use:enhance={() => {
-					submitting = true;
-					return async ({ result }) => {
-						submitting = false;
-						confirmOpen = false;
-						if (result.type === 'success' && result.data) {
-							const d = result.data as { activityName: string; totalPoints: number; streakDays: number };
-							resultData = d;
-							resultOpen = true;
-						}
-					};
-				}}
+	{#if viewModel.activities.length === 0}
+		<ActivityEmptyState uiMode={viewModel.uiMode as UiMode} />
+	{/if}
+{:else if pageData}
+	<!-- ====================================================================
+	     demo 互換経路 (Phase 3 で削除): 旧 pageData ベース
+	     ==================================================================== -->
+	<div class="px-[var(--sp-sm)] py-1">
+		{#if pageData.mustStatus && pageData.mustStatus.total > 0 && pageData.uiMode !== 'baby'}
+			<MustProgressBar
+				logged={pageData.mustStatus.logged}
+				total={pageData.mustStatus.total}
+				uiMode={pageData.uiMode as UiMode}
+				bonusGranted={pageData.mustStatus.granted}
+				bonusPoints={pageData.mustStatus.points}
+			/>
+		{/if}
+
+		{#if pageData.hasChecklists}
+			<div
+				class="flex items-center justify-between w-full px-[var(--sp-md)] py-[var(--sp-sm)] mb-[var(--sp-sm)] rounded-[var(--radius-lg)] bg-white shadow-sm border border-[var(--color-border)]"
 			>
-				<input type="hidden" name="activityId" value={selectedActivity.id} />
-				<Button
-					type="submit"
-					variant="primary"
-					size="lg"
-					disabled={submitting}
-					class="w-full bg-[var(--theme-accent)] disabled:opacity-50"
+				<div class="flex items-center gap-[var(--sp-sm)]">
+					<span class="text-2xl">📋</span>
+					<span class="font-bold">{DEMO_CHILD_HOME_LABELS.checklistTitle}</span>
+				</div>
+				{#if pageData.checklistProgress}
+					<div class="flex items-center gap-[var(--sp-xs)]">
+						{#if pageData.checklistProgress.allDone}
+							<span class="text-sm font-bold text-[var(--theme-accent)]">{DEMO_CHILD_HOME_LABELS.checklistDone}</span>
+						{:else}
+							<span class="text-sm text-[var(--color-text-muted)]">
+								{pageData.checklistProgress.checkedCount}/{pageData.checklistProgress.totalCount}
+							</span>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		{/if}
+
+		{#if pageData.dailyMissions && pageData.dailyMissions.missions.length > 0}
+			<div class="mb-[var(--sp-sm)] rounded-[var(--radius-lg)] bg-white shadow-sm border border-[var(--color-border)] overflow-hidden">
+				<div class="flex items-center gap-[var(--sp-xs)] px-[var(--sp-md)] pt-[var(--sp-sm)] pb-1">
+					<span class="text-lg">🎯</span>
+					<span class="font-bold text-sm">{DEMO_CHILD_HOME_LABELS.dailyMissionTitle}</span>
+					<span class="text-xs text-[var(--color-text-muted)] ml-auto">
+						{pageData.dailyMissions.completedCount}/{pageData.dailyMissions.missions.length}
+					</span>
+				</div>
+				<div class="px-[var(--sp-md)] pb-[var(--sp-sm)]">
+					{#each pageData.dailyMissions.missions as mission (mission.id)}
+						<div class="flex items-center gap-[var(--sp-sm)] py-1">
+							<span class="text-lg w-6 text-center">{mission.completed ? '✅' : '⬜'}</span>
+							<span class="text-lg">{mission.activityIcon}</span>
+							<span class="text-sm {mission.completed ? 'line-through text-[var(--color-text-muted)]' : 'font-bold'}">
+								{mission.activityName}
+							</span>
+						</div>
+					{/each}
+					{#if pageData.dailyMissions.allComplete}
+						<div class="text-center mt-1 py-1 rounded-[var(--radius-md)] bg-[var(--theme-bg)]">
+							<span class="text-sm font-bold text-[var(--theme-accent)]">{DEMO_CHILD_HOME_LABELS.missionComplete(fmtPts(pageData.dailyMissions.bonusAwarded))}</span>
+						</div>
+					{/if}
+				</div>
+			</div>
+		{/if}
+
+		{#each demoActivitiesByCategory as group (group.categoryId)}
+			<CategorySection categoryId={group.categoryId} itemCount={group.items.length}>
+				{#each group.items as activity (activity.id)}
+					<ActivityCard
+						activityId={activity.id}
+						icon={activity.icon}
+						name={activity.displayName}
+						categoryId={activity.categoryId}
+						completed={isCompleted(activity)}
+						count={getCount(activity.id)}
+						isMission={activity.isMission}
+						onclick={() => handleDemoActivityTap(activity)}
+					/>
+				{/each}
+			</CategorySection>
+		{/each}
+
+		{#if pageData.activities.length === 0}
+			<div class="flex flex-col items-center justify-center py-[var(--sp-2xl)] text-[var(--color-text-muted)]">
+				<span class="text-4xl mb-[var(--sp-md)]">📋</span>
+				<p class="text-[var(--font-md)]">{DEMO_CHILD_HOME_LABELS.activitiesEmpty}</p>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Confirm dialog -->
+	<Dialog bind:open={confirmOpen} title="きろくする？" onOpenChange={({ open }) => { if (!open) handleConfirmClose(); }}>
+		{#if selectedActivity}
+			<div class="text-center py-4">
+				<span class="text-5xl block mb-3">{selectedActivity.icon}</span>
+				<p class="text-lg font-bold mb-4">{selectedActivity.displayName ?? selectedActivity.name}</p>
+				<form
+					method="POST"
+					action="?/record"
+					use:enhance={() => {
+						demoSubmitting = true;
+						return async ({ result }) => {
+							demoSubmitting = false;
+							confirmOpen = false;
+							if (result.type === 'success' && result.data) {
+								const d = result.data as { activityName: string; totalPoints: number; streakDays: number };
+								resultData = d;
+								resultOpen = true;
+							}
+						};
+					}}
 				>
-					{submitting ? DEMO_CHILD_HOME_LABELS.recordingLabel : DEMO_CHILD_HOME_LABELS.recordButton}
-				</Button>
-			</form>
-		</div>
-	{/if}
-</Dialog>
+					<input type="hidden" name="activityId" value={selectedActivity.id} />
+					<Button
+						type="submit"
+						variant="primary"
+						size="lg"
+						disabled={demoSubmitting}
+						class="w-full bg-[var(--theme-accent)] disabled:opacity-50"
+					>
+						{demoSubmitting ? DEMO_CHILD_HOME_LABELS.recordingLabel : DEMO_CHILD_HOME_LABELS.recordButton}
+					</Button>
+				</form>
+			</div>
+		{/if}
+	</Dialog>
 
-<!-- Result dialog -->
-<Dialog bind:open={resultOpen} title="きろくしたよ！" onOpenChange={({ open }) => { if (!open) handleResultClose(); }}>
-	{#if resultData}
-		<div class="text-center py-4">
-			<p class="text-3xl font-bold text-[var(--color-point)] mb-2">
-				{fmtPts(resultData.totalPoints)}
-			</p>
-			<p class="text-sm text-[var(--color-text-muted)]">
-				{formatStreak(resultData.streakDays)}{DEMO_CHILD_HOME_LABELS.resultStreakSuffix}
-			</p>
-			<p class="text-xs text-[var(--color-text-muted)] mt-1">{DEMO_CHILD_HOME_LABELS.resultTodayPrefix} {homeData.todayRecorded.reduce((sum, r) => sum + r.count, 0) + 1}{DEMO_CHILD_HOME_LABELS.resultTodaySuffix}</p>
-			<p class="text-xs text-[var(--color-feedback-warning-text)] mt-3">
-				{DEMO_CHILD_HOME_LABELS.demoDataNote}
-			</p>
-			<a
-				href="/demo/signup"
-				class="mt-3 block w-full py-2.5 bg-gradient-to-r from-amber-500 to-orange-500 text-white font-bold rounded-[var(--radius-lg)] text-center text-sm"
-			>
-				{DEMO_CHILD_HOME_LABELS.signupCta}
-			</a>
-			<Button
-				variant="primary"
-				size="md"
-				class="mt-2 w-full bg-[var(--theme-accent)]"
-				onclick={handleResultClose}
-			>
-				{DEMO_CHILD_HOME_LABELS.closeButton}
-			</Button>
-		</div>
-	{/if}
-</Dialog>
+	<!-- Result dialog -->
+	<Dialog bind:open={resultOpen} title="きろくしたよ！" onOpenChange={({ open }) => { if (!open) handleResultClose(); }}>
+		{#if resultData}
+			<div class="text-center py-4">
+				<p class="text-3xl font-bold text-[var(--color-point)] mb-2">
+					{fmtPts(resultData.totalPoints)}
+				</p>
+				<p class="text-sm text-[var(--color-text-muted)]">
+					{formatStreak(resultData.streakDays)}{DEMO_CHILD_HOME_LABELS.resultStreakSuffix}
+				</p>
+				<p class="text-xs text-[var(--color-text-muted)] mt-1">{DEMO_CHILD_HOME_LABELS.resultTodayPrefix} {homeData.todayRecorded.reduce((sum, r) => sum + r.count, 0) + 1}{DEMO_CHILD_HOME_LABELS.resultTodaySuffix}</p>
+				<p class="text-xs text-[var(--color-feedback-warning-text)] mt-3">
+					{DEMO_CHILD_HOME_LABELS.demoDataNote}
+				</p>
+				<a
+					href="/demo/signup"
+					class="mt-3 block w-full py-2.5 bg-gradient-to-r from-amber-500 to-orange-500 text-white font-bold rounded-[var(--radius-lg)] text-center text-sm"
+				>
+					{DEMO_CHILD_HOME_LABELS.signupCta}
+				</a>
+				<Button
+					variant="primary"
+					size="md"
+					class="mt-2 w-full bg-[var(--theme-accent)]"
+					onclick={handleResultClose}
+				>
+					{DEMO_CHILD_HOME_LABELS.closeButton}
+				</Button>
+			</div>
+		{/if}
+	</Dialog>
+{/if}

--- a/src/lib/services/production/DashboardService.ts
+++ b/src/lib/services/production/DashboardService.ts
@@ -32,11 +32,20 @@ import type {
 	CancelRecordResult,
 	ChildDashboardHomeData,
 	ChildDashboardService,
+	ChildHomeActivity,
+	ChildHomeAgeContext,
+	ChildHomeChild,
+	ChildHomeCurrency,
+	ChildHomeFeatureFlags,
+	ChildHomeProgressDisplay,
+	ChildHomeViewModel,
 	ClaimLoginBonusResult,
 	RecordActivityInput,
 	RecordActivityWriteResult,
 	ToggleActivityPinInput,
 	ToggleActivityPinResult,
+	ToViewModelCapable,
+	ToViewModelContext,
 } from '../types';
 
 /**
@@ -46,7 +55,7 @@ import type {
  */
 export type FetchFn = typeof fetch;
 
-export class ProductionDashboardService implements ChildDashboardService {
+export class ProductionDashboardService implements ChildDashboardService, ToViewModelCapable {
 	readonly kind = 'production' as const;
 
 	readonly #getHomeData: () => ChildDashboardHomeData;
@@ -165,6 +174,189 @@ export class ProductionDashboardService implements ChildDashboardService {
 		} catch {
 			return { ok: false, error: 'NETWORK' };
 		}
+	}
+
+	/**
+	 * UI Contract `ChildHomeViewModel` を構築する (ADR-0047 Phase 2)。
+	 *
+	 * 設計原則:
+	 *   - DashboardView (UI コンポーネント) は本メソッドの戻り値のみを受け取る。
+	 *     Drizzle 生レコード型 (`as never` キャスト) は一切露出しない。
+	 *   - `progressDisplay.type` は **コンテキスト法則** で切替わる:
+	 *     `baby` / `preschool` / `free` プラン → `today-missions` (mustStatus / dailyMissions ベース)
+	 *     `elementary` 以上 + `standard` 以上 → `category-level` (categoryXp ベース)
+	 *     identity (demo / production の固定) で切替えない (ADR-0047 §決定 + 深層調査 §5 案 B 失敗回避)
+	 *   - `features` は production の plan / age 状態から導出。demo (Phase 3) は別ロジックで同じ shape を返す。
+	 *   - `currency` は production の `pointSettings.mode` を反映 (currency mode 時のみ ¥ + JPY)
+	 *
+	 * @param ctx `+page.server.ts` load 結果から抽出した補助 context (activities / mustStatus 等)
+	 * @returns DashboardView が直接受け取る UI Contract
+	 */
+	toViewModel(ctx: ToViewModelContext): ChildHomeViewModel {
+		const home = this.#getHomeData();
+		const child = this.#buildChild(home, ctx);
+		const currency = this.#buildCurrency(home);
+		const progressDisplay = this.#buildProgressDisplay(ctx);
+		const activities = this.#buildActivities(home, ctx);
+		const features = this.#buildFeatures(ctx);
+		const ageContext = this.#buildAgeContext(ctx);
+
+		return {
+			child,
+			currency,
+			progressDisplay,
+			activities,
+			features,
+			uiMode: ctx.uiMode,
+			ageContext,
+		};
+	}
+
+	/**
+	 * `ChildHomeChild` を構築。
+	 *
+	 * 注意: Drizzle の `Child` 型は `level` / `xpToNextLevel` / `xpInLevel` / `streakDays` を
+	 * 持たない (これらは別 service / layout で計算される)。Phase 2 段階では、本 service が直接
+	 * 把握しているのは `home.child` (Drizzle Child) のみのため、不足 field は 0 fallback とする
+	 * (本番 page 側で overall level を直接 UI 表示する箇所がないため degrade 影響なし。
+	 * カテゴリ別 level / XP は `progressDisplay.type === 'category-level'` 経路で表現される)。
+	 */
+	#buildChild(home: ChildDashboardHomeData, ctx: ToViewModelContext): ChildHomeChild {
+		const c = home.child;
+		if (!c) {
+			// SSR 初期 / 子供未選択時の fallback (UI 層で child null 判定がないことを ViewModel で吸収)
+			return {
+				id: 0,
+				nickname: '',
+				pointBalance: 0,
+				level: 1,
+				xpToNextLevel: 0,
+				xpInLevel: 0,
+				streakDays: 0,
+				uiMode: ctx.uiMode,
+			};
+		}
+		return {
+			id: c.id,
+			nickname: c.nickname,
+			pointBalance: 0, // layout 経由で balance を持つ。Phase 2 では ViewModel 直接表示なし
+			level: 1, // overall level は廃止 (status-service §38-43 deprecated)
+			xpToNextLevel: 0,
+			xpInLevel: 0,
+			streakDays: 0,
+			uiMode: ctx.uiMode,
+		};
+	}
+
+	/** `pointSettings.mode` を反映した currency contract */
+	#buildCurrency(home: ChildDashboardHomeData): ChildHomeCurrency {
+		const ps = home.pointSettings;
+		if (ps.mode === 'currency') {
+			// 通貨モードでは JPY のみを公式サポート (point-display.ts CURRENCY_DEFS)
+			// 他通貨は表記 symbol だけ替わるが ViewModel code としては 'JPY' 一本化
+			return { symbol: '¥', code: 'JPY' };
+		}
+		return { symbol: 'P', code: 'POINTS' };
+	}
+
+	/**
+	 * `progressDisplay` type union 判定 (ADR-0047 核心ロジック)。
+	 *
+	 * コンテキスト法則:
+	 *   - baby / preschool: `today-missions` (年齢が低いほどミッション中心 UX)
+	 *   - free プラン: `today-missions` (free プランは categoryXp 表示なし)
+	 *   - elementary 以上 + standard / family: `category-level`
+	 */
+	#buildProgressDisplay(ctx: ToViewModelContext): ChildHomeProgressDisplay {
+		const useToday = ctx.uiMode === 'baby' || ctx.uiMode === 'preschool' || ctx.planTier === 'free';
+
+		if (useToday) {
+			return {
+				type: 'today-missions',
+				mustStatus: {
+					completed: ctx.mustStatus?.logged ?? 0,
+					total: ctx.mustStatus?.total ?? 0,
+				},
+				dailyMissions: {
+					completed: ctx.dailyMissions?.completedCount ?? 0,
+					total: ctx.dailyMissions?.missions.length ?? 0,
+				},
+			};
+		}
+
+		// category-level: categoryXp を 5 カテゴリ分マップ
+		const categories: { id: number; name: string; level: number; xpPercent: number }[] = [];
+		if (ctx.categoryXp) {
+			for (const [idStr, info] of Object.entries(ctx.categoryXp)) {
+				categories.push({
+					id: Number(idStr),
+					name: info.levelTitle,
+					level: info.level,
+					xpPercent: info.progressPct,
+				});
+			}
+		}
+		return { type: 'category-level', categories };
+	}
+
+	/** Activity grid 用 ViewModel field を構築 */
+	#buildActivities(
+		home: ChildDashboardHomeData,
+		ctx: ToViewModelContext,
+	): readonly ChildHomeActivity[] {
+		const recordedMap = new Map(home.todayRecorded.map((r) => [r.activityId, r.count]));
+		return ctx.activities.map((a) => ({
+			id: a.id,
+			name: a.name,
+			icon: a.icon,
+			categoryId: a.categoryId,
+			categoryName: '', // category 名は UI 層 (CategorySection) が CATEGORY_DEFS から解決
+			pointReward: a.basePoints ?? 0,
+			streakBonus: 0, // record 結果から導出 (UI 側 result dialog で扱う)
+			isPinned: !!a.isPinned,
+			todayRecorded: recordedMap.get(a.id) ?? 0,
+			isMust: !!a.isMission,
+		}));
+	}
+
+	/**
+	 * 9 feature flag を production の plan / age 状態から導出。
+	 *
+	 * - `showShopTab`: production では always true (有料プラン / 無料プラン両方で shop タブ表示)
+	 * - `showXpAnimation` / `showMissionBadge` / `showPinButton` 等: baby は ADR-0011 で抑制
+	 * - `showSiblingRanking`: family プランのみ (production の plan-limit-service と一致)
+	 * - `showBirthdayBonus` / `showMonthlyReward` / `showStampCard` / `showEventBadge`:
+	 *   premium 限定 or season-event 在否で表示判定 (本 Phase では feature flag のみ。UI 配線は page 側)
+	 */
+	#buildFeatures(ctx: ToViewModelContext): ChildHomeFeatureFlags {
+		const isBaby = ctx.uiMode === 'baby';
+		return {
+			showShopTab: true, // production: shop タブは常時表示 (free / standard / family 共通)
+			showXpAnimation: !isBaby,
+			showMissionBadge: !isBaby,
+			showPinButton: !isBaby,
+			showEventBadge: !isBaby && ctx.activeEventBadge !== null,
+			showSiblingRanking: !isBaby && ctx.planTier === 'family',
+			showBirthdayBonus: !isBaby,
+			showMonthlyReward: !isBaby && ctx.isPremium,
+			showStampCard: !isBaby,
+		};
+	}
+
+	/**
+	 * 年齢 / プラン状態コンテキストを構築 (UI 層が age tier を再判定しないように)。
+	 *
+	 * `isBabyParentMode`: baby は ADR-0011 で「親の準備モード」として扱う。
+	 * 本番 page 側で `data.uiMode === 'baby'` を判定して `BabyHomePage` に分岐済みのため、
+	 * 本 field は ViewModel 経由で同じ判定を提供するインフラ (Phase 3 demo 側でも同じ法則を適用)。
+	 */
+	#buildAgeContext(ctx: ToViewModelContext): ChildHomeAgeContext {
+		return {
+			isBabyParentMode: ctx.uiMode === 'baby',
+			ageTier: ctx.uiMode,
+			planTier: ctx.planTier,
+			isTrialActive: ctx.isTrialActive,
+		};
 	}
 
 	async toggleActivityPin(input: ToggleActivityPinInput): Promise<ToggleActivityPinResult> {

--- a/src/lib/services/types.ts
+++ b/src/lib/services/types.ts
@@ -477,3 +477,88 @@ export interface ParentAdminReadonlySettings {
 	cheerMessage: string;
 	autoSleepEnabled: boolean;
 }
+
+// ============================================================================
+// ADR-0047 Phase 2: toViewModel() 用補助型
+// ============================================================================
+
+/**
+ * Production Dashboard Service `toViewModel()` に渡す追加 context。
+ *
+ * `ChildDashboardHomeData` (child / todayRecorded / pointSettings) だけでは
+ * UI 描画に必要な情報 (activities / mustStatus / siblingRanking 等) が不足するため、
+ * SvelteKit の `+page.server.ts` load 結果から抽出した補助情報をここに集約する。
+ *
+ * - production: `+page.svelte` の `data` 経由で読み取って渡す
+ * - demo (Phase 3): `getDemoHomeData()` の seed 結果から組み立てて渡す
+ *
+ * 設計原則 (ADR-0047 §決定):
+ *   - UI 描画に必要な情報を field 単位で contract 化 (ViewModel 構築の責務を service に集中)
+ *   - production / demo の divergence は本 context の値で吸収 (ViewModel field の有無で表現)
+ */
+export interface ToViewModelContext {
+	/** 現在の UI mode (5 年齢モード) */
+	uiMode: 'baby' | 'preschool' | 'elementary' | 'junior' | 'senior';
+	/** プランティア (production: 実値 / demo: 'standard' 固定) */
+	planTier: 'free' | 'standard' | 'family';
+	/** trial 中フラグ (demo: false 固定) */
+	isTrialActive: boolean;
+	/** premium プラン (paid tier) フラグ */
+	isPremium: boolean;
+	/**
+	 * 活動一覧 (`+page.server.ts` の activities load 結果)。
+	 * Drizzle 生レコード型を緩く受け入れ、ViewModel 構築側で正規化する。
+	 */
+	activities: ReadonlyArray<{
+		id: number;
+		name: string;
+		displayName?: string;
+		icon: string;
+		categoryId: number;
+		dailyLimit: number | null;
+		isMission?: boolean;
+		isMainQuest?: boolean | number;
+		isPinned?: boolean | number;
+		basePoints?: number;
+	}>;
+	/** must status (#1757 「今日のおやくそく」) */
+	mustStatus: {
+		logged: number;
+		total: number;
+		granted: boolean;
+		points: number;
+	} | null;
+	/** daily missions (子供向け day-target) */
+	dailyMissions: {
+		missions: { id: number; activityIcon: string; activityName: string; completed: boolean }[];
+		completedCount: number;
+		allComplete: boolean;
+		bonusAwarded: number;
+	} | null;
+	/** category XP (status-service) */
+	categoryXp: Record<
+		number,
+		{ value: number; level: number; levelTitle: string; progressPct: number; maxValue: number }
+	> | null;
+	/** 現在アクティブな season event の bannerIcon (1 件目のみ) */
+	activeEventBadge: string | null;
+}
+
+/**
+ * Production Dashboard Service の拡張契約 (Phase 2)。
+ *
+ * 基本 (read/write) は `ChildDashboardService` で SSOT 化済みだが、
+ * `toViewModel()` で `ChildHomeViewModel` を構築する責務を追加する。
+ *
+ * Phase 2 では Production 側のみ実装する。demo 側は Phase 3 で実装。
+ */
+export interface ToViewModelCapable {
+	/**
+	 * UI Contract である `ChildHomeViewModel` を構築する。
+	 *
+	 * - 引数 `ctx` は `+page.server.ts` から渡される追加情報
+	 * - 戻り値 `ChildHomeViewModel` は DashboardView 等の UI コンポーネントが直接受け取る
+	 * - production / demo 両 service が同じ shape を返すことが ADR-0047 §決定 の SSOT 核心
+	 */
+	toViewModel(ctx: ToViewModelContext): ChildHomeViewModel;
+}

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
@@ -11,12 +11,12 @@ import BirthdayBanner from '$lib/features/birthday/BirthdayBanner.svelte';
 import SiblingCelebration from '$lib/features/challenge/SiblingCelebration.svelte';
 import TutorialHintBanner from '$lib/features/child/TutorialHintBanner.svelte';
 import BabyHomePage from '$lib/features/child-home/BabyHomePage.svelte';
+// Issue #2097 Phase 2 (ADR-0047): DashboardView を ViewModel 経路で呼ぶ (ProdDashboardSections を孤児化)
+import DashboardView from '$lib/features/child-home/components/DashboardView.svelte';
 import OverlaysSection from '$lib/features/child-home/components/OverlaysSection.svelte';
-// Issue #2084 (ADR-0046 follow-up): 本番 child home の共通 UI を派生コンポーネントに集約
-import ProdDashboardSections from '$lib/features/child-home/components/ProdDashboardSections.svelte';
 import { DialogFSM } from '$lib/features/child-home/dialog-state-machine';
 import { getModeVariant } from '$lib/features/child-home/variants';
-// Issue #2084: 本番 ProductionDashboardService を Context に再注入 (todayRecorded を含む正しい snapshot)
+// Issue #2097 Phase 2: 本番 ProductionDashboardService を Context に再注入 (todayRecorded を含む正しい snapshot)
 import { setDashboardService } from '$lib/services/context';
 import { createProductionDashboardService } from '$lib/services/production/DashboardService';
 import AdventureStartOverlay from '$lib/ui/components/AdventureStartOverlay.svelte';
@@ -35,19 +35,17 @@ import { soundService } from '$lib/ui/sound';
 
 let { data } = $props();
 
-// Issue #2084 (ADR-0046 follow-up): 本番側で getDashboardService().getHomeData() 経由で
-// child / todayRecorded / pointSettings を参照するため、page スコープで Service を再注入する。
+// Issue #2097 Phase 2 (ADR-0047): 本番 ProductionDashboardService を Context に再注入。
 // (child)/+layout.svelte で配備済みの service は todayRecorded を空配列で持つため、
 // home page のみが取得できる todayRecorded を含めて上書きする。
 // getter 関数を渡すことで invalidateAll() / form action 完了後の data 変化に追従できる
 // (Svelte 5 state_referenced_locally 警告を回避)。
-setDashboardService(
-	createProductionDashboardService(() => ({
-		child: data.child ?? null,
-		todayRecorded: data.todayRecorded ?? [],
-		pointSettings: data.pointSettings,
-	})),
-);
+const dashboardService = createProductionDashboardService(() => ({
+	child: data.child ?? null,
+	todayRecorded: data.todayRecorded ?? [],
+	pointSettings: data.pointSettings,
+}));
+setDashboardService(dashboardService);
 
 const variant = $derived(getModeVariant((data.uiMode ?? 'preschool') as UiMode));
 const f = $derived(variant.features);
@@ -212,7 +210,7 @@ function getCategoryXpWithAnim(
 }
 
 // Build recorded counts map: activityId → count
-// Issue #2084: ProdDashboardSections は service 経由で参照するが、page 内のオーバーレイ
+// Issue #2097 Phase 2: DashboardView は service 経由で参照するが、page 内のオーバーレイ
 // (result dialog 内の todayTotalCount / xp animation 等) で同じ値を使うため、page 側でも
 // data.todayRecorded から派生値を計算する (ADR-0046 reactive 設計と一致)。
 const recordedMap = $derived(new Map(data.todayRecorded.map((r) => [r.activityId, r.count])));
@@ -235,7 +233,29 @@ const activeEventBadge = $derived(
 		: null,
 );
 
-// Per-category mission counts (ProdDashboardSections で props として渡す)
+// Issue #2097 Phase 2 (ADR-0047): toViewModel() で ChildHomeViewModel を構築。
+// DashboardView は本 ViewModel + page-local callbacks を受け取り、
+// ProdDashboardSections と同等の dashboard sections を render する。
+const viewModel = $derived(
+	dashboardService.toViewModel({
+		uiMode: (data.uiMode ?? 'preschool') as
+			| 'baby'
+			| 'preschool'
+			| 'elementary'
+			| 'junior'
+			| 'senior',
+		planTier: (data.planTier ?? 'free') as 'free' | 'standard' | 'family',
+		isTrialActive: false,
+		isPremium: data.isPremium ?? false,
+		activities: data.activities,
+		mustStatus: data.mustStatus,
+		dailyMissions: data.dailyMissions,
+		categoryXp: data.categoryXp,
+		activeEventBadge,
+	}),
+);
+
+// Per-category mission counts (DashboardView で props として渡す)
 function getCategoryMissionCount(categoryId: number) {
 	return data.activities.filter((a) => a.categoryId === categoryId && a.isMission).length;
 }
@@ -564,25 +584,24 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 	<TutorialHintBanner visible={showTutorialHint} onDismiss={dismissTutorialHint} />
 
 	<!--
-		Issue #2084 (ADR-0046 follow-up): 共通 dashboard sections は派生コンポーネント
-		ProdDashboardSections に集約。MustProgressBar / activity grid / SiblingRanking /
-		ActivityEmptyState の render を含む (約 200 行)。
-		本派生は getDashboardService() 経由で child / todayRecorded / pointSettings を参照。
+		Issue #2097 Phase 2 (ADR-0047): DashboardView を ViewModel 経路で呼ぶ。
+		`viewModel` が ChildHomeViewModel SSOT (型強制)、`auxiliaryActivities` は
+		Drizzle 詳細 (displayName / frozen / triggerHint / isMainQuest) を一時的に
+		補助 props として渡す互換ブリッジ (Phase 4 で ChildHomeActivity に統合予定)。
+		ProdDashboardSections.svelte は本 Phase で呼ばれなくなり孤児化 (Phase 3 で git rm)。
 	-->
-	<ProdDashboardSections
-		uiMode={data.uiMode as UiMode}
-		activities={data.activities}
+	<DashboardView
+		{viewModel}
+		auxiliaryActivities={data.activities.map((a: { id: number; displayName: string; source?: string; triggerHint?: string | null; isMainQuest?: boolean | number }) => ({
+			id: a.id,
+			displayName: a.displayName,
+			frozen: !data.isPremium && a.source === 'custom',
+			triggerHint: a.triggerHint ?? null,
+			isMainQuest: a.isMainQuest ?? 0,
+		}))}
 		mustStatus={data.mustStatus}
 		siblingRanking={data.siblingRanking}
-		{activeEventBadge}
 		{displayConfig}
-		features={{
-			showPin: f.showPin,
-			showConfirmDialog: f.showConfirmDialog,
-			showSiblingFeatures: f.showSiblingFeatures,
-			showEvents: f.showEvents,
-		}}
-		isPremium={data.isPremium}
 		childId={data.child?.id ?? 0}
 		{submitting}
 		{pendingActivityId}
@@ -590,6 +609,7 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 		{xpAnimatingCategoryId}
 		{getCategoryMissionCount}
 		{getCategoryCompletedMissionCount}
+		{activeEventBadge}
 		onActivityTap={handleActivityTap}
 		onActivityLongPress={handleActivityLongPress}
 		onRecordSubmit={(activityId) => {

--- a/tests/unit/services/production-dashboard-service.test.ts
+++ b/tests/unit/services/production-dashboard-service.test.ts
@@ -1,0 +1,290 @@
+/**
+ * ProductionDashboardService.toViewModel() unit tests — ADR-0047 Phase 2
+ *
+ * UI Contract `ChildHomeViewModel` 構築の核心 logic を検証する:
+ *   - `progressDisplay.type` のコンテキスト法則切替 (baby/preschool/free → today-missions、
+ *     elementary 以上 + standard 以上 → category-level)
+ *   - `currency` の pointSettings.mode 反映 (point → 'P'/POINTS、currency → '¥'/JPY)
+ *   - `features.*` の plan / age 状態からの導出
+ *   - `activities` の todayRecorded merge
+ *   - `ageContext.isBabyParentMode` の baby 判定 (ADR-0011)
+ */
+import { describe, expect, it } from 'vitest';
+import type { Child } from '$lib/server/db/types/index.js';
+import { ProductionDashboardService } from '$lib/services/production/DashboardService';
+import type { ChildDashboardHomeData, ToViewModelContext } from '$lib/services/types';
+
+function makeChild(overrides: Partial<Child> = {}): Child {
+	return {
+		id: 1,
+		nickname: 'たろう',
+		age: 7,
+		birthDate: '2018-01-01',
+		theme: 'pink',
+		uiMode: 'elementary',
+		uiModeManuallySet: 0,
+		avatarUrl: null,
+		displayConfig: null,
+		userId: null,
+		birthdayBonusMultiplier: 1,
+		lastBirthdayBonusYear: null,
+		isArchived: 0,
+		archivedReason: null,
+		createdAt: '2026-01-01T00:00:00Z',
+		updatedAt: '2026-01-01T00:00:00Z',
+		...overrides,
+	};
+}
+
+function makeHomeData(overrides: Partial<ChildDashboardHomeData> = {}): ChildDashboardHomeData {
+	return {
+		child: makeChild(),
+		todayRecorded: [],
+		pointSettings: { mode: 'point', currency: 'JPY', rate: 1 },
+		...overrides,
+	};
+}
+
+function makeCtx(overrides: Partial<ToViewModelContext> = {}): ToViewModelContext {
+	return {
+		uiMode: 'elementary',
+		planTier: 'standard',
+		isTrialActive: false,
+		isPremium: true,
+		activities: [],
+		mustStatus: null,
+		dailyMissions: null,
+		categoryXp: null,
+		activeEventBadge: null,
+		...overrides,
+	};
+}
+
+describe('ProductionDashboardService.toViewModel()', () => {
+	describe('currency contract (Q4)', () => {
+		it('returns P/POINTS when pointSettings.mode is point', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(makeCtx());
+			expect(vm.currency).toEqual({ symbol: 'P', code: 'POINTS' });
+		});
+
+		it('returns ¥/JPY when pointSettings.mode is currency', () => {
+			const svc = new ProductionDashboardService(() =>
+				makeHomeData({ pointSettings: { mode: 'currency', currency: 'JPY', rate: 1 } }),
+			);
+			const vm = svc.toViewModel(makeCtx());
+			expect(vm.currency).toEqual({ symbol: '¥', code: 'JPY' });
+		});
+	});
+
+	describe('progressDisplay context law (deep research §5 案 B core)', () => {
+		it('baby uiMode → today-missions', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(
+				makeCtx({
+					uiMode: 'baby',
+					mustStatus: { logged: 1, total: 3, granted: false, points: 0 },
+				}),
+			);
+			expect(vm.progressDisplay.type).toBe('today-missions');
+			if (vm.progressDisplay.type === 'today-missions') {
+				expect(vm.progressDisplay.mustStatus).toEqual({ completed: 1, total: 3 });
+			}
+		});
+
+		it('preschool uiMode → today-missions', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(makeCtx({ uiMode: 'preschool' }));
+			expect(vm.progressDisplay.type).toBe('today-missions');
+		});
+
+		it('free plan → today-missions regardless of age', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(makeCtx({ uiMode: 'elementary', planTier: 'free' }));
+			expect(vm.progressDisplay.type).toBe('today-missions');
+		});
+
+		it('elementary + standard plan → category-level', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(
+				makeCtx({
+					uiMode: 'elementary',
+					planTier: 'standard',
+					categoryXp: {
+						1: { value: 10, level: 2, levelTitle: '初心', progressPct: 50, maxValue: 100 },
+					},
+				}),
+			);
+			expect(vm.progressDisplay.type).toBe('category-level');
+			if (vm.progressDisplay.type === 'category-level') {
+				expect(vm.progressDisplay.categories).toHaveLength(1);
+				expect(vm.progressDisplay.categories[0]).toEqual({
+					id: 1,
+					name: '初心',
+					level: 2,
+					xpPercent: 50,
+				});
+			}
+		});
+
+		it('junior + family plan → category-level', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(makeCtx({ uiMode: 'junior', planTier: 'family' }));
+			expect(vm.progressDisplay.type).toBe('category-level');
+		});
+
+		it('senior + standard plan → category-level', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(makeCtx({ uiMode: 'senior', planTier: 'standard' }));
+			expect(vm.progressDisplay.type).toBe('category-level');
+		});
+	});
+
+	describe('features contract (9 flags)', () => {
+		it('baby suppresses gamification features (ADR-0011)', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(makeCtx({ uiMode: 'baby' }));
+			expect(vm.features.showXpAnimation).toBe(false);
+			expect(vm.features.showMissionBadge).toBe(false);
+			expect(vm.features.showPinButton).toBe(false);
+			expect(vm.features.showSiblingRanking).toBe(false);
+			expect(vm.features.showBirthdayBonus).toBe(false);
+			expect(vm.features.showMonthlyReward).toBe(false);
+			expect(vm.features.showStampCard).toBe(false);
+			// shop タブは year-round 表示 (Q5 = B)
+			expect(vm.features.showShopTab).toBe(true);
+		});
+
+		it('elementary + family enables all features', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(makeCtx({ uiMode: 'elementary', planTier: 'family' }));
+			expect(vm.features.showXpAnimation).toBe(true);
+			expect(vm.features.showMissionBadge).toBe(true);
+			expect(vm.features.showPinButton).toBe(true);
+			expect(vm.features.showSiblingRanking).toBe(true);
+			expect(vm.features.showStampCard).toBe(true);
+		});
+
+		it('standard plan does not enable sibling ranking (family only)', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(makeCtx({ planTier: 'standard' }));
+			expect(vm.features.showSiblingRanking).toBe(false);
+		});
+
+		it('non-premium suppresses monthly reward', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(makeCtx({ isPremium: false }));
+			expect(vm.features.showMonthlyReward).toBe(false);
+		});
+
+		it('showEventBadge requires non-null activeEventBadge', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vmNoEvent = svc.toViewModel(makeCtx({ activeEventBadge: null }));
+			expect(vmNoEvent.features.showEventBadge).toBe(false);
+			const vmEvent = svc.toViewModel(makeCtx({ activeEventBadge: '🎉' }));
+			expect(vmEvent.features.showEventBadge).toBe(true);
+		});
+	});
+
+	describe('activities merge with todayRecorded', () => {
+		it('attaches todayRecorded count to each activity', () => {
+			const svc = new ProductionDashboardService(() =>
+				makeHomeData({
+					todayRecorded: [
+						{ activityId: 1, count: 2 },
+						{ activityId: 3, count: 1 },
+					],
+				}),
+			);
+			const vm = svc.toViewModel(
+				makeCtx({
+					activities: [
+						{ id: 1, name: 'うんどう', icon: '🏃', categoryId: 1, dailyLimit: 3, basePoints: 5 },
+						{ id: 2, name: 'べんきょう', icon: '📚', categoryId: 2, dailyLimit: 2, basePoints: 5 },
+						{ id: 3, name: 'おてつだい', icon: '🧹', categoryId: 3, dailyLimit: 1, basePoints: 5 },
+					],
+				}),
+			);
+			expect(vm.activities).toHaveLength(3);
+			expect(vm.activities[0]).toMatchObject({ id: 1, todayRecorded: 2, pointReward: 5 });
+			expect(vm.activities[1]).toMatchObject({ id: 2, todayRecorded: 0 });
+			expect(vm.activities[2]).toMatchObject({ id: 3, todayRecorded: 1 });
+		});
+
+		it('treats activities with isMission true as must (mission badge)', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(
+				makeCtx({
+					activities: [
+						{ id: 1, name: 'a', icon: '', categoryId: 1, dailyLimit: 1, isMission: true },
+						{ id: 2, name: 'b', icon: '', categoryId: 1, dailyLimit: 1, isMission: false },
+					],
+				}),
+			);
+			expect(vm.activities[0]?.isMust).toBe(true);
+			expect(vm.activities[1]?.isMust).toBe(false);
+		});
+
+		it('coerces isPinned number 1 to true', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(
+				makeCtx({
+					activities: [{ id: 1, name: 'a', icon: '', categoryId: 1, dailyLimit: 1, isPinned: 1 }],
+				}),
+			);
+			expect(vm.activities[0]?.isPinned).toBe(true);
+		});
+	});
+
+	describe('ageContext (ADR-0011 baby parent mode)', () => {
+		it('marks isBabyParentMode true when uiMode is baby', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(makeCtx({ uiMode: 'baby' }));
+			expect(vm.ageContext.isBabyParentMode).toBe(true);
+			expect(vm.ageContext.ageTier).toBe('baby');
+		});
+
+		it('marks isBabyParentMode false for preschool and above', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			for (const uiMode of ['preschool', 'elementary', 'junior', 'senior'] as const) {
+				const vm = svc.toViewModel(makeCtx({ uiMode }));
+				expect(vm.ageContext.isBabyParentMode).toBe(false);
+				expect(vm.ageContext.ageTier).toBe(uiMode);
+			}
+		});
+
+		it('propagates planTier and isTrialActive from context', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			const vm = svc.toViewModel(makeCtx({ planTier: 'family', isTrialActive: true }));
+			expect(vm.ageContext.planTier).toBe('family');
+			expect(vm.ageContext.isTrialActive).toBe(true);
+		});
+	});
+
+	describe('child fallback when null', () => {
+		it('returns sentinel child when home.child is null (SSR initial)', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData({ child: null }));
+			const vm = svc.toViewModel(makeCtx({ uiMode: 'elementary' }));
+			expect(vm.child).toEqual({
+				id: 0,
+				nickname: '',
+				pointBalance: 0,
+				level: 1,
+				xpToNextLevel: 0,
+				xpInLevel: 0,
+				streakDays: 0,
+				uiMode: 'elementary',
+			});
+		});
+	});
+
+	describe('uiMode passthrough', () => {
+		it('reflects ctx.uiMode in viewModel.uiMode', () => {
+			const svc = new ProductionDashboardService(() => makeHomeData());
+			for (const uiMode of ['baby', 'preschool', 'elementary', 'junior', 'senior'] as const) {
+				const vm = svc.toViewModel(makeCtx({ uiMode }));
+				expect(vm.uiMode).toBe(uiMode);
+			}
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者 + 将来の機能拡張 + 子供 / 親 UI 全機能）

**解決する課題**: 過去 7 回 (#531 / #561 / #562 / #563 / #566 / #2069 / PR #2099) で demo / 本番 UI 統合が「shim 完了報告」に終わり構造的に解消されてこなかった。原因は **UI Contract が型として存在せず、divergence を field 単位で表現できなかった** こと (ADR-0047 §コンテキスト)。

**期待される効果**: 本番 child home の DashboardView が `ChildHomeViewModel` のみを契約として受け取るようになり、Phase 3-5 で demo 側を同 ViewModel に揃えることで「型レベル SSOT」が初めて成立する。これにより `if (service.kind === 'demo')` 分岐や `as never` キャストが構造的に書けなくなり、demo / 本番の機能 divergence を構造的に阻止できる。

## 関連 Issue

closes #2097 (Phase 2 / 5 phase 計画の 2/5)

依存:
- ADR-0046 (Service Interface + Context DI) — 本 PR が直接乗る基盤
- ADR-0047 (Demo / 本番 UI Contract SSOT) — Phase 1 で確定した型 SSOT を実装に配線
- 禁止語 SSOT (`docs/decisions/forbidden-escape-language.md`) — Phase 1 で文書化

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `ProductionDashboardService.toViewModel()` 実装 | `tests/unit/services/production-dashboard-service.test.ts` で 21 cases | 21 PASS (`npx vitest run`) |
| AC2 | DashboardView が `ChildHomeViewModel` を main contract として受け取る | `git diff src/lib/features/child-home/components/DashboardView.svelte` で `viewModel: ChildHomeViewModel` prop が main path | `viewModel` ブロックが新規追加、pageData 経路は demo 互換のため Phase 3 (Issue #2097) で削除 |
| AC3 | 本番 page (`+page.svelte`) で `toViewModel()` 経由で DashboardView を呼ぶ | `grep "viewModel\|DashboardView" src/routes/(child)/[uiMode=uiMode]/home/+page.svelte` | `const viewModel = $derived(dashboardService.toViewModel({...}))` + `<DashboardView {viewModel} ... />` |
| AC4 | ProdDashboardSections.svelte が呼ばれない孤児コンポーネントに | `grep ProdDashboardSections src/routes/(child)/[uiMode=uiMode]/home/+page.svelte` | import 削除済、参照 0 件 |
| AC5 | 5 年齢モード (baby/preschool/elementary/junior/senior) で本番 UI が degrade しない | unit test + svelte-check + 既存 E2E が機能網羅検証 | unit 4567+21 PASS / svelte-check 0 error / E2E は CI で確認 |
| AC6 | `progressDisplay.type` がコンテキスト法則で切替わる (identity 固定 NG) | `tests/unit/services/production-dashboard-service.test.ts` §progressDisplay context law | baby/preschool/free → today-missions、elementary+ → category-level の 6 cases PASS |
| AC7 | `features` 9 flags が plan / age 状態から導出 | 同上 §features contract | baby 抑制 / family ranking / non-premium reward 等 5 cases PASS |
| AC8 | 禁止語 (12 語) を PR body / commit message で使用しない | 視認チェック + Phase 5 で機械検証起動 (Issue #2097 §5 phase 計画) | 12 語いずれも未使用 (commit message + 本 body 確認済) |

## 変更タイプ

- [x] refactor: リファクタリング

## 影響範囲・変更コンポーネント

**変更レイヤー**:

- [x] サービス層 (`src/lib/services/production/DashboardService.ts` — toViewModel() 実装)
- [x] UI コンポーネント (`src/lib/features/child-home/components/DashboardView.svelte` — ViewModel 経路追加)
- [x] ページ / レイアウト (`src/routes/(child)/[uiMode=uiMode]/home/+page.svelte` — DashboardView 呼出に切替)
- [x] ドメインモデル (`src/lib/services/types.ts` — `ToViewModelContext` / `ToViewModelCapable` 追加)

**影響を受ける画面・機能**:

- 本番 child home (`/(child)/[uiMode]/home`) 全 5 年齢モード
  - DashboardView (ViewModel 経路) が ProdDashboardSections と同等を render
- demo child home (`/demo/(child)/[mode]/home`) — 本 PR で**触らない**
  - DashboardView の旧 `pageData` 経路は demo 互換のため残置 (Phase 3 で削除)
- ProdDashboardSections.svelte は孤児化 (`grep` で参照 0 件、Phase 3 で `git rm`)

## テスト & 安全装置セルフチェック

- [x] `npx biome check src` — 844 files 0 errors
- [x] `npx svelte-check` — 0 errors / 0 warnings on touched files
- [x] `npx vitest run` — 240 + 1 = 241 test files / 4567 + 21 = 4588 tests PASS
- [x] `node scripts/check-no-plan-literals.mjs` — OK リテラル直書きなし
- [x] 追加テスト:
  - `tests/unit/services/production-dashboard-service.test.ts` 新規 21 cases
    - progressDisplay コンテキスト法則 6 cases (baby/preschool/free → today-missions、elementary+ → category-level)
    - currency 2 cases (point / currency mode)
    - features 9 flags 5 cases (baby 抑制、family ranking、non-premium 等)
    - activities merge 3 cases (todayRecorded merge、isMission、isPinned coercion)
    - ageContext 3 cases (baby parent mode、planTier propagation)
    - child fallback / uiMode passthrough 2 cases

## スクリーンショット / ビジュアルデモ

**本 PR の SS 撮影状況**:

本 PR は本番 child home の内部実装 refactor (ProdDashboardSections → DashboardView + ViewModel) であり、**UI 表示は ProdDashboardSections と同等を保つよう設計**。本 PR の機能等価性は以下で担保:

1. **構造的同一性**: DashboardView の ViewModel 経路は ProdDashboardSections.svelte の構造 (MustProgressBar / CategorySection 内 ActivityCard + baby inline form / SiblingRanking / ActivityEmptyState) を 1:1 で踏襲。git diff で render 順序 / props 渡し / event handler 配線が同一であることが確認できる。
2. **unit test (21 cases) PASS**: progressDisplay / currency / features / activities merge / ageContext すべて contract レベルで検証済。
3. **既存 E2E test の網羅**: `tests/e2e/` 配下の child home flow (activity record / cancel / mission / pin / level up 等) が本番 page 全機能を網羅。CI で全 PASS 確認。

**5 年齢モード × mobile/desktop SS 実機撮影**: Issue #2097 5 phase 計画 (ADR-0047 §決定) で **「Phase 2 PO レビュー観点 = 本番 degrade ないか」** と確定しており、PO 動作確認手順でローカル `npm run dev:cognito` 経由の実機検証を依頼する (下記 §レビュー依頼事項 参照)。

## コード品質セルフレビュー (#1481)

- [x] **重複コード**: ProdDashboardSections.svelte 全 322 行を DashboardView 内に再実装する形となるが、Phase 3 で ProdDashboardSections を削除するため一時的並走。**Phase 3 (Issue #2097 §5 phase 計画) 完了時に重複解消される**
- [x] **抽象度**: `ChildHomeViewModel` (UI Contract) と `ToViewModelContext` (構築用 context) を responsibility 分離。前者は UI 描画 SSOT、後者は service 構築時の補助情報
- [x] **型安全**: `viewModel: ChildHomeViewModel` を main path として型強制。`as never` キャストは新規導入なし
- [x] **インラインスタイル**: 動的 border-color のみ (既存実装と同じ)、Tailwind arbitrary hex 不使用
- [x] **未使用 import**: 自動修正 (`biome check --write`) で clean
- [x] **可読性**: `toViewModel()` 内部を 6 つの private helper method (`#buildChild` / `#buildCurrency` / `#buildProgressDisplay` / `#buildActivities` / `#buildFeatures` / `#buildAgeContext`) に責務分離。各 method の JSDoc に判定法則を記載

## 横展開・影響波及チェック

- [x] **demo 側 (`/demo/(child)/**`)**: 本 PR で**一切触らない** (ADR-0047 §5 phase で Phase 3 担当)
  - 旧 demo 側 `+page.svelte` は依然 DashboardView を `pageData` prop で呼ぶ → DashboardView 内の `{:else if pageData}` ブロックで互換維持
- [x] **`+layout.svelte` 配下 (子供 status / shop / checklist 等)**: 触らない。Context DI (ADR-0046) で配備済みの service を依然参照する
- [x] **並行実装**: `docs/design/parallel-implementations.md` の child home エントリは「ProdDashboardSections と DashboardView の 2 ファイル並走」状態だったが、本 PR で本番 page が DashboardView を呼ぶようになり並走解消への前進。完全解消は Phase 3 で ProdDashboardSections.svelte を git rm 時
- [x] **CI gate**: SS Blob SHA uniqueness check (#2063) は本 PR で SS 添付なしのため対象外
- [x] **設計書同期**: ADR-0047 §5 phase 計画 / ADR-0046 が SSOT。本 PR は Phase 2 完了 (Issue #2097 §5 phase 計画 Phase 2 行を本 PR merge 時に [x] 化)

## レビュー依頼事項・破壊的変更

**Phase 2 (production refactor) PR、Draft 据置**。

### PO 動作確認手順

1. ローカル `npm run dev:cognito` (port 5174) 起動
2. 各 DEV_USER でログイン → 全 5 年齢モード (baby/preschool/elementary/junior/senior) で以下を確認:
   - **活動記録**: activity card タップ → confirm dialog → record → result dialog → ポイント加算
   - **キャンセル**: result dialog 内 cancel button → 5 秒以内なら取消可能
   - **mission badge / star**: must 活動の星マーク表示、bonus 付与
   - **ピン留め**: long press → pin context menu → 状態切替
   - **レベルアップ演出**: XP gain → level up overlay 表示
   - **きょうだいランキング**: family プランで複数 child の ranking 表示
   - **birthday banner**: 誕生日子供にバナー表示
   - **monthly reward**: premium かつ月初に reward modal
   - **tutorial overlay**: 初回訪問時に tutorial 表示
3. 修正前 (`git stash` で `main` HEAD) と修正後で UI が degrade していないことを目視確認

### 破壊的変更

- なし。ProductionDashboardService は既存 `ChildDashboardService` interface に **追加で** `ToViewModelCapable` を実装するのみ。既存 read/write API は維持。

### 残作業 (Phase 3-5、別 PR で扱う)

- Phase 3 (Issue #2097): `DemoDashboardService.toViewModel()` 実装 + ProdDashboardSections.svelte 削除 + DashboardView の `pageData` 経路削除 + 5 年齢モード demo SS が本番 SS と機能等価
- Phase 4 (Issue #2097): `ParentAdminViewModel` 実装 + demo /(parent) layout に notice バナー
- Phase 5 (Issue #2097): `scripts/check-no-escape-language.mjs` 起動 + CI 組込 + demo shop 配線

Draft → Ready 化は PO 判断 (動作確認完了後)。Dev / Reviewer Agent は本 PR で自律的に `gh pr ready` / `gh pr merge` を実行しない (feedback_no_autonomous_qa_merge / ADR-0022)。

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret 追加なし。

## Ready for Review チェックリスト

- [x] commit が AC 全項目を網羅 (上記 AC 検証マップ AC1-AC8)
- [x] biome / svelte-check / vitest 全 PASS
- [x] 禁止語 SSOT (`docs/decisions/forbidden-escape-language.md`) の 12 語を本 PR body / commit message で使用していない
- [x] ADR-0047 §決定の UI Contract を完全実装 (`ChildHomeViewModel` 7 fields)
- [x] Issue #2097 §更新 2026-05-14 §5 phase 計画 Phase 2 行を完了状態にする
- [x] PO 動作確認完了 → Draft → Ready 化 (Dev Agent は実行しない) — N/A: Draft 据置なので PO 確認後に PO 自身が Ready 化する

## QM レビュー結果

未実施 (Draft 据置)。PO 動作確認 → Ready 化 → QM レビュー → merge の順を遵守。
