### PR TITLE
feat: #2097 ADR-0048 Phase 2-3 — 34 demo Repository + AnonymousAuthProvider

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -313,6 +313,7 @@ unstub
 upsell
 Upsell
 upsert
+upserted
 upserts
 ureshii
 vite
@@ -322,6 +323,7 @@ Vitest
 VOICEID
 vorbis
 Vorbis
+wakeup
 webp
 webpush
 whsec

--- a/src/lib/runtime/env.ts
+++ b/src/lib/runtime/env.ts
@@ -43,7 +43,8 @@ const envSchema = z.object({
 	MAINTENANCE_MODE: booleanStringSchema,
 
 	// ----- Auth -----
-	AUTH_MODE: z.enum(['local', 'cognito']).default('local'),
+	// #2097 ADR-0048: AUTH_MODE='anonymous' を追加 (demo Lambda 用、AnonymousAuthProvider 選択)
+	AUTH_MODE: z.enum(['local', 'cognito', 'anonymous']).default('local'),
 	COGNITO_DEV_MODE: booleanStringSchema,
 	COGNITO_USER_POOL_ID: z.string().optional(),
 	COGNITO_CLIENT_ID: z.string().optional(),
@@ -63,7 +64,8 @@ const envSchema = z.object({
 
 	// ----- Database -----
 	DATABASE_URL: z.string().default('./data/ganbari-quest.db'),
-	DATA_SOURCE: z.enum(['sqlite', 'dynamodb']).default('sqlite'),
+	// #2097 ADR-0048: DATA_SOURCE='demo' を追加 (demo Lambda 用、stateless fixture Repository 選択)
+	DATA_SOURCE: z.enum(['sqlite', 'dynamodb', 'demo']).default('sqlite'),
 	SCHEMA_VALIDATION_MODE: z.enum(['warn', 'strict']).optional(),
 
 	// ----- Stripe -----

--- a/src/lib/server/auth/factory.ts
+++ b/src/lib/server/auth/factory.ts
@@ -1,6 +1,8 @@
 // src/lib/server/auth/factory.ts
 // AUTH_MODE 環境変数による AuthProvider 切り替え
+// ADR-0048: AUTH_MODE=anonymous は Multi-Lambda demo deployment 専用
 
+import { AnonymousAuthProvider } from './providers/anonymous';
 import { CognitoAuthProvider } from './providers/cognito';
 import { DevCognitoAuthProvider } from './providers/cognito-dev';
 import { LocalAuthProvider } from './providers/local';
@@ -27,7 +29,10 @@ export function getAuthProvider(): AuthProvider {
 
 	const mode = (process.env.AUTH_MODE ?? 'local') as AuthMode;
 
-	if (mode === 'cognito') {
+	if (mode === 'anonymous') {
+		// ADR-0048 §決定 P-1.6: Multi-Lambda demo deployment 用 anonymous provider
+		_provider = new AnonymousAuthProvider();
+	} else if (mode === 'cognito') {
 		_provider = isCognitoDevMode() ? new DevCognitoAuthProvider() : new CognitoAuthProvider();
 	} else {
 		_provider = new LocalAuthProvider();

--- a/src/lib/server/auth/providers/anonymous.ts
+++ b/src/lib/server/auth/providers/anonymous.ts
@@ -1,0 +1,57 @@
+// src/lib/server/auth/providers/anonymous.ts
+// AnonymousAuthProvider (ADR-0048 §決定 P-1.6)
+//
+// Multi-Lambda demo deployment (`demo.ganbari-quest.com`) で `AUTH_MODE=anonymous` 指定時に
+// 選択される。dummy user (`anon-{requestId}`) + role='owner' + tenantId='demo' + licenseStatus=ACTIVE
+// を返し、demo Lambda 配下の全画面 (admin / child / ops) を見せられる。
+//
+// 設計原則:
+// - Lambda は production DB / Cognito / Secrets Manager への IAM 権限を持たない (ADR-0048 §決定 §1)
+// - 認証 cookie / セッション state を一切持たない (Lambda stateless, ADR-0048 §決定 §2)
+// - write API は Policy Gate で deny される想定 (本 PR scope 外、Multi-Lambda 全体方針)
+
+import type { RequestEvent } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import type { AuthContext, AuthProvider, AuthResult, Identity } from '../types';
+
+const DEMO_TENANT_ID = 'demo';
+const DEMO_ROLE = 'owner' as const;
+const ANON_EMAIL = 'anon@demo.local';
+
+function deriveRequestId(event: RequestEvent): string {
+	// SvelteKit `event.locals.requestId` が hooks.server で set されている前提
+	// (multi-lambda demo Lambda の hooks も含めてセットする想定。
+	//  fallback として URL hash / timestamp を使う)
+	const fromLocals = (event.locals as { requestId?: string }).requestId;
+	if (fromLocals) return fromLocals;
+	// fallback: stateless かつ重複 OK (Lambda は user-specific state を持たない)
+	return `${Date.now().toString(36)}`;
+}
+
+export class AnonymousAuthProvider implements AuthProvider {
+	async resolveIdentity(event: RequestEvent): Promise<Identity> {
+		const requestId = deriveRequestId(event);
+		return {
+			type: 'anonymous',
+			userId: `anon-${requestId}`,
+			email: ANON_EMAIL,
+		};
+	}
+
+	async resolveContext(_event: RequestEvent, _identity: Identity | null): Promise<AuthContext> {
+		// ADR-0048 P-1.6: tenantId='demo' / role='owner' / licenseStatus=ACTIVE (全画面表示用)
+		return {
+			tenantId: DEMO_TENANT_ID,
+			role: DEMO_ROLE,
+			licenseStatus: AUTH_LICENSE_STATUS.ACTIVE,
+			tenantStatus: SUBSCRIPTION_STATUS.ACTIVE,
+		};
+	}
+
+	authorize(_path: string, _identity: Identity | null, _context: AuthContext | null): AuthResult {
+		// Demo Lambda は全パスを allow (admin / ops / child を見せる)。
+		// write は Policy Gate / route 側で 200 no-op response を返す (ADR-0048 §決定 P-1.7)。
+		return { allowed: true };
+	}
+}

--- a/src/lib/server/auth/types.ts
+++ b/src/lib/server/auth/types.ts
@@ -6,7 +6,7 @@ import type { AuthLicenseStatus } from '$lib/domain/constants/auth-license-statu
 import type { SubscriptionStatus } from '$lib/domain/constants/subscription-status';
 
 /** 認証モードの切り替え（DATA_SOURCE パターンと同様） */
-export type AuthMode = 'local' | 'cognito';
+export type AuthMode = 'local' | 'cognito' | 'anonymous';
 
 /** テナント内ロール（#0123: viewer 廃止） */
 export type Role = 'owner' | 'parent' | 'child';
@@ -14,6 +14,8 @@ export type Role = 'owner' | 'parent' | 'child';
 /** Layer 1: Identity（誰であるか）
  * - local: LAN内認証なし（NUC/Docker）
  * - cognito: Cognito Email/Password + MFA（AWS SaaS）
+ * - anonymous: ADR-0048 Multi-Lambda demo deployment。dummy user `anon-{requestId}` を返し、
+ *   production DB / Cognito へのアクセス権を持たない demo Lambda 環境で動作する。
  *
  * #820: Cognito `cognito:groups` claim を surfaces する `groups` フィールドを追加。
  * /ops のような group ベース認可は `groups.includes('ops')` で判定する。
@@ -21,7 +23,8 @@ export type Role = 'owner' | 'parent' | 'child';
  */
 export type Identity =
 	| { type: 'local' }
-	| { type: 'cognito'; userId: string; email: string; groups?: string[] };
+	| { type: 'cognito'; userId: string; email: string; groups?: string[] }
+	| { type: 'anonymous'; userId: string; email: string };
 
 /** Layer 2: Context（何として操作しているか）
  *

--- a/src/lib/server/db/demo/README.md
+++ b/src/lib/server/db/demo/README.md
@@ -1,0 +1,31 @@
+# Demo Repository (`src/lib/server/db/demo/`)
+
+ADR-0048 §決定 §2 / §段階別 milestone 週 2-3 の実装。
+
+## 役割
+
+Multi-Lambda demo deployment (`demo.ganbari-quest.com`) で稼働する demo Lambda 専用の Repository 実装。`factory.ts` の `DATA_SOURCE=demo` 分岐で選択される。
+
+## 設計原則 (Martin Fowler Test Double)
+
+「Fake (read) + Stub (write) hybrid」:
+
+- **read API** (`find*` / `get*` / `list*` / `count*` 等): `$lib/server/demo/demo-data.ts` の fixture から該当データを返す (Fake)
+- **write API** (`insert*` / `update*` / `delete*` / `upsert*` 等): 契約を満たす最小値を返す (Stub、no-op)
+
+## AWS Lambda Best Practices 遵守
+
+[AWS Lambda Best Practices 公式](https://docs.aws.amazon.com/lambda/latest/dg/best-practices.html) の anti-pattern を物理的に発生不可能にする:
+
+> Don't store user data, events, or other information that has security implications **in the local file system of your Lambda function** or in the function's memory.
+
+本 directory の Repository は **module-level singleton で user-specific mutable state を保持しない**。write API は no-op のため、fixture (DEMO_*) の値は immutable に固定される。
+
+session-scoped state (「demo で記録 → リロードで保持」) は **client sessionStorage 限定** (ADR-0048 §決定 P-1.1) で、Lambda 側は完全 stateless を維持する。
+
+## 関連
+
+- ADR-0048: Multi-Lambda Demo Deployment (`docs/decisions/0048-multi-lambda-demo-deployment.md`)
+- `src/lib/server/db/factory.ts` の `DATA_SOURCE=demo` 分岐
+- `src/lib/server/auth/providers/anonymous.ts` (`AUTH_MODE=anonymous`)
+- `src/lib/server/demo/demo-data.ts` (fixture SSOT)

--- a/src/lib/server/db/demo/account-lockout-repo.ts
+++ b/src/lib/server/db/demo/account-lockout-repo.ts
@@ -1,0 +1,14 @@
+// Demo IAccountLockoutRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+// Account lockout は demo Lambda では発生しない (AnonymousAuthProvider が常時 allow)。
+
+import type { LockoutRecord } from '../interfaces/account-lockout-repo.interface';
+
+export async function getLockout(_email: string): Promise<LockoutRecord | null> {
+	// Demo Lambda は認証なし (anonymous)、lockout 状態は存在しない
+	return null;
+}
+
+export async function upsertLockout(_record: LockoutRecord): Promise<void> {
+	// Stub: no-op (ADR-0048 P-1.7)
+}

--- a/src/lib/server/db/demo/activity-mastery-repo.ts
+++ b/src/lib/server/db/demo/activity-mastery-repo.ts
@@ -1,0 +1,41 @@
+// Demo IActivityMasteryRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { ActivityMastery } from '../types';
+
+export async function findByChildAndActivity(
+	_childId: number,
+	_activityId: number,
+	_tenantId: string,
+): Promise<ActivityMastery | undefined> {
+	return undefined;
+}
+
+export async function findAllByChild(
+	_childId: number,
+	_tenantId: string,
+): Promise<ActivityMastery[]> {
+	return [];
+}
+
+export async function upsert(
+	childId: number,
+	activityId: number,
+	totalCount: number,
+	level: number,
+	_tenantId: string,
+): Promise<ActivityMastery> {
+	// Stub: 受け取った値で minimal ActivityMastery を返す (interface 契約)
+	return {
+		id: 0,
+		childId,
+		activityId,
+		totalCount,
+		level,
+		updatedAt: new Date().toISOString(),
+	} as ActivityMastery;
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/activity-pref-repo.ts
+++ b/src/lib/server/db/demo/activity-pref-repo.ts
@@ -1,0 +1,49 @@
+// Demo IActivityPrefRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { ActivityUsageCount, ChildActivityPreference } from '../types';
+
+export async function findPinnedByChild(
+	_childId: number,
+	_tenantId: string,
+): Promise<ChildActivityPreference[]> {
+	return [];
+}
+
+export async function togglePin(
+	childId: number,
+	activityId: number,
+	pinned: boolean,
+	_tenantId: string,
+): Promise<ChildActivityPreference> {
+	const now = new Date().toISOString();
+	return {
+		id: 0,
+		childId,
+		activityId,
+		isPinned: pinned ? 1 : 0,
+		pinOrder: pinned ? 0 : null,
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+export async function countPinnedInCategory(
+	_childId: number,
+	_categoryId: number,
+	_tenantId: string,
+): Promise<number> {
+	return 0;
+}
+
+export async function getUsageCounts(
+	_childId: number,
+	_sinceDate: string,
+	_tenantId: string,
+): Promise<ActivityUsageCount[]> {
+	return [];
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/activity-repo.ts
+++ b/src/lib/server/db/demo/activity-repo.ts
@@ -1,0 +1,405 @@
+// Demo IActivityRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import { DEMO_ACTIVITIES, DEMO_ACTIVITY_LOGS, DEMO_CHILDREN } from '$lib/server/demo/demo-data';
+import type {
+	Activity,
+	ActivityFilter,
+	ActivityLog,
+	ActivityLogSummary,
+	Child,
+	InsertActivityInput,
+	InsertActivityLogInput,
+	InsertPointLedgerInput,
+	UpdateActivityInput,
+} from '../types';
+
+function filterActivity(a: Activity, filter?: ActivityFilter): boolean {
+	if (!filter) return a.isVisible === 1;
+	if (filter.includeHidden !== true && a.isVisible !== 1) return false;
+	if (typeof filter.categoryId === 'number' && a.categoryId !== filter.categoryId) return false;
+	if (typeof filter.childAge === 'number') {
+		if (a.ageMin !== null && filter.childAge < a.ageMin) return false;
+		if (a.ageMax !== null && filter.childAge > a.ageMax) return false;
+	}
+	return true;
+}
+
+// ---------- Activities ----------
+
+export async function findActivities(
+	_tenantId: string,
+	filter?: ActivityFilter,
+): Promise<Activity[]> {
+	return DEMO_ACTIVITIES.filter((a) => filterActivity(a, filter));
+}
+
+export async function findActivityById(
+	id: number,
+	_tenantId: string,
+): Promise<Activity | undefined> {
+	return DEMO_ACTIVITIES.find((a) => a.id === id);
+}
+
+export async function insertActivity(
+	input: InsertActivityInput,
+	_tenantId: string,
+): Promise<Activity> {
+	// Stub: 入力値で minimal Activity を組み立てて返す
+	const now = new Date().toISOString();
+	return {
+		id: 0,
+		name: input.name,
+		categoryId: input.categoryId,
+		icon: input.icon,
+		basePoints: input.basePoints,
+		ageMin: input.ageMin,
+		ageMax: input.ageMax,
+		isVisible: 1,
+		dailyLimit: null,
+		sortOrder: 0,
+		source: 'demo',
+		gradeLevel: null,
+		subcategory: null,
+		description: null,
+		nameKana: null,
+		nameKanji: null,
+		triggerHint: input.triggerHint ?? null,
+		isMainQuest: input.isMainQuest ?? 0,
+		isArchived: 0,
+		archivedReason: null,
+		createdAt: now,
+		sourcePresetId: input.sourcePresetId ?? null,
+		priority: input.priority ?? 'optional',
+	};
+}
+
+export async function updateActivity(
+	id: number,
+	_input: UpdateActivityInput,
+	_tenantId: string,
+): Promise<Activity | undefined> {
+	// Stub: 既存 fixture をそのまま返す (mutation なし)
+	return DEMO_ACTIVITIES.find((a) => a.id === id);
+}
+
+export async function setActivityVisibility(
+	id: number,
+	_visible: boolean,
+	_tenantId: string,
+): Promise<Activity | undefined> {
+	return DEMO_ACTIVITIES.find((a) => a.id === id);
+}
+
+export async function deleteActivity(id: number, _tenantId: string): Promise<Activity | undefined> {
+	return DEMO_ACTIVITIES.find((a) => a.id === id);
+}
+
+export async function hasActivityLogs(activityId: number, _tenantId: string): Promise<boolean> {
+	return DEMO_ACTIVITY_LOGS.some((l) => l.activityId === activityId);
+}
+
+export async function getActivityLogCounts(_tenantId: string): Promise<Record<number, number>> {
+	const counts: Record<number, number> = {};
+	for (const log of DEMO_ACTIVITY_LOGS) {
+		if (log.cancelled === 1) continue;
+		counts[log.activityId] = (counts[log.activityId] ?? 0) + 1;
+	}
+	return counts;
+}
+
+export async function countMainQuestActivities(_tenantId: string): Promise<number> {
+	return DEMO_ACTIVITIES.filter((a) => a.isMainQuest === 1).length;
+}
+
+export async function deleteDailyMissionsByActivity(
+	_activityId: number,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+// ---------- Children (convenience lookup) ----------
+
+export async function findChildById(id: number, _tenantId: string): Promise<Child | undefined> {
+	return DEMO_CHILDREN.find((c) => c.id === id);
+}
+
+// ---------- Activity Logs ----------
+
+export async function findDailyLog(
+	childId: number,
+	activityId: number,
+	date: string,
+	_tenantId: string,
+): Promise<ActivityLog | undefined> {
+	return DEMO_ACTIVITY_LOGS.find(
+		(l) => l.childId === childId && l.activityId === activityId && l.recordedDate === date,
+	);
+}
+
+export async function findStreakLogs(
+	childId: number,
+	activityId: number,
+	_tenantId: string,
+): Promise<{ recordedDate: string }[]> {
+	return DEMO_ACTIVITY_LOGS.filter(
+		(l) => l.childId === childId && l.activityId === activityId && l.cancelled === 0,
+	).map((l) => ({ recordedDate: l.recordedDate }));
+}
+
+export async function insertActivityLog(
+	input: InsertActivityLogInput,
+	_tenantId: string,
+): Promise<ActivityLog> {
+	// Stub: 入力値で minimal ActivityLog を返す
+	return {
+		id: 0,
+		childId: input.childId,
+		activityId: input.activityId,
+		points: input.points,
+		streakDays: input.streakDays,
+		streakBonus: input.streakBonus,
+		recordedDate: input.recordedDate,
+		recordedAt: input.recordedAt,
+		cancelled: 0,
+	};
+}
+
+export async function findActivityLogById(
+	id: number,
+	_tenantId: string,
+): Promise<ActivityLog | undefined> {
+	return DEMO_ACTIVITY_LOGS.find((l) => l.id === id);
+}
+
+export async function markActivityLogCancelled(_id: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function findActivityLogs(
+	childId: number,
+	_tenantId: string,
+	options?: { from?: string; to?: string },
+): Promise<ActivityLogSummary[]> {
+	return DEMO_ACTIVITY_LOGS.filter((l) => {
+		if (l.childId !== childId) return false;
+		if (l.cancelled === 1) return false;
+		if (options?.from && l.recordedDate < options.from) return false;
+		if (options?.to && l.recordedDate > options.to) return false;
+		return true;
+	}).map((l) => {
+		const activity = DEMO_ACTIVITIES.find((a) => a.id === l.activityId);
+		return {
+			id: l.id,
+			activityName: activity?.name ?? 'unknown',
+			activityIcon: activity?.icon ?? '',
+			categoryId: activity?.categoryId ?? 0,
+			points: l.points,
+			streakDays: l.streakDays,
+			streakBonus: l.streakBonus,
+			recordedAt: l.recordedAt,
+		};
+	});
+}
+
+export async function countTodayActiveRecords(
+	childId: number,
+	activityId: number,
+	date: string,
+	_tenantId: string,
+): Promise<number> {
+	return DEMO_ACTIVITY_LOGS.filter(
+		(l) =>
+			l.childId === childId &&
+			l.activityId === activityId &&
+			l.recordedDate === date &&
+			l.cancelled === 0,
+	).length;
+}
+
+export async function getTodayActivityCountsByChild(
+	childId: number,
+	date: string,
+	_tenantId: string,
+): Promise<{ activityId: number; count: number }[]> {
+	const counts = new Map<number, number>();
+	for (const log of DEMO_ACTIVITY_LOGS) {
+		if (log.childId !== childId || log.recordedDate !== date || log.cancelled !== 0) continue;
+		counts.set(log.activityId, (counts.get(log.activityId) ?? 0) + 1);
+	}
+	return Array.from(counts.entries()).map(([activityId, count]) => ({ activityId, count }));
+}
+
+export async function findTodayRecordedActivityIds(
+	childId: number,
+	today: string,
+	_tenantId: string,
+): Promise<number[]> {
+	const ids = new Set<number>();
+	for (const log of DEMO_ACTIVITY_LOGS) {
+		if (log.childId === childId && log.recordedDate === today && log.cancelled === 0) {
+			ids.add(log.activityId);
+		}
+	}
+	return Array.from(ids);
+}
+
+// ---------- Aggregation queries ----------
+
+export async function findDistinctRecordedDates(
+	childId: number,
+	_tenantId: string,
+): Promise<{ recordedDate: string }[]> {
+	const dates = new Set<string>();
+	for (const log of DEMO_ACTIVITY_LOGS) {
+		if (log.childId === childId && log.cancelled === 0) dates.add(log.recordedDate);
+	}
+	return Array.from(dates).map((d) => ({ recordedDate: d }));
+}
+
+export async function countActiveActivityLogs(childId: number, _tenantId: string): Promise<number> {
+	return DEMO_ACTIVITY_LOGS.filter((l) => l.childId === childId && l.cancelled === 0).length;
+}
+
+export async function getCategoryCountsByDate(
+	childId: number,
+	_tenantId: string,
+): Promise<{ recordedDate: string; categoryCount: number }[]> {
+	const byDate = new Map<string, Set<number>>();
+	for (const log of DEMO_ACTIVITY_LOGS) {
+		if (log.childId !== childId || log.cancelled !== 0) continue;
+		const activity = DEMO_ACTIVITIES.find((a) => a.id === log.activityId);
+		if (!activity) continue;
+		if (!byDate.has(log.recordedDate)) byDate.set(log.recordedDate, new Set());
+		byDate.get(log.recordedDate)?.add(activity.categoryId);
+	}
+	return Array.from(byDate.entries()).map(([recordedDate, set]) => ({
+		recordedDate,
+		categoryCount: set.size,
+	}));
+}
+
+export async function countDistinctCategories(childId: number, _tenantId: string): Promise<number> {
+	const categories = new Set<number>();
+	for (const log of DEMO_ACTIVITY_LOGS) {
+		if (log.childId !== childId || log.cancelled !== 0) continue;
+		const activity = DEMO_ACTIVITIES.find((a) => a.id === log.activityId);
+		if (activity) categories.add(activity.categoryId);
+	}
+	return categories.size;
+}
+
+export async function findTodayLogsWithCategory(
+	childId: number,
+	date: string,
+	_tenantId: string,
+): Promise<{ activityId: number; categoryId: number }[]> {
+	return DEMO_ACTIVITY_LOGS.filter(
+		(l) => l.childId === childId && l.recordedDate === date && l.cancelled === 0,
+	)
+		.map((l) => {
+			const activity = DEMO_ACTIVITIES.find((a) => a.id === l.activityId);
+			return activity ? { activityId: l.activityId, categoryId: activity.categoryId } : null;
+		})
+		.filter((x): x is { activityId: number; categoryId: number } => x !== null);
+}
+
+export async function getComboPointsGranted(
+	_childId: number,
+	_descriptionPrefix: string,
+	_tenantId: string,
+): Promise<number> {
+	return 0;
+}
+
+export async function countActiveActivityLogsByCategory(
+	childId: number,
+	categoryId: number,
+	_tenantId: string,
+): Promise<number> {
+	let count = 0;
+	for (const log of DEMO_ACTIVITY_LOGS) {
+		if (log.childId !== childId || log.cancelled !== 0) continue;
+		const activity = DEMO_ACTIVITIES.find((a) => a.id === log.activityId);
+		if (activity?.categoryId === categoryId) count++;
+	}
+	return count;
+}
+
+export async function countPointLedgerEntriesByType(
+	_childId: number,
+	_type: string,
+	_tenantId: string,
+): Promise<number> {
+	return 0;
+}
+
+export async function countPointLedgerEntriesByTypeAndDate(
+	_childId: number,
+	_type: string,
+	_date: string,
+	_tenantId: string,
+): Promise<number> {
+	return 0;
+}
+
+// ---------- Must activities (#1755) ----------
+
+export async function findMustActivitiesWithToday(
+	childId: number,
+	today: string,
+	_tenantId: string,
+): Promise<{
+	logged: number;
+	total: number;
+	activities: Array<{ id: number; name: string; icon: string; loggedToday: number }>;
+}> {
+	const mustActivities = DEMO_ACTIVITIES.filter((a) => a.priority === 'must' && a.isVisible === 1);
+	const todayRecorded = new Set(
+		DEMO_ACTIVITY_LOGS.filter(
+			(l) => l.childId === childId && l.recordedDate === today && l.cancelled === 0,
+		).map((l) => l.activityId),
+	);
+	const activities = mustActivities.map((a) => ({
+		id: a.id,
+		name: a.name,
+		icon: a.icon,
+		loggedToday: todayRecorded.has(a.id) ? 1 : 0,
+	}));
+	const logged = activities.filter((a) => a.loggedToday === 1).length;
+	return { logged, total: mustActivities.length, activities };
+}
+
+// ---------- Archive / Restore ----------
+
+export async function archiveActivities(
+	_ids: number[],
+	_reason: string,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function restoreArchivedActivities(_reason: string, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+// ---------- Point Ledger ----------
+
+export async function insertPointLedger(
+	_input: InsertPointLedgerInput,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+// ---------- Retention cleanup ----------
+
+export async function deleteActivityLogsBeforeDate(
+	_childId: number,
+	_cutoffDate: string,
+	_tenantId: string,
+): Promise<number> {
+	return 0;
+}

--- a/src/lib/server/db/demo/auth-repo.ts
+++ b/src/lib/server/db/demo/auth-repo.ts
@@ -1,0 +1,337 @@
+// Demo IAuthRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+// Demo Lambda は AnonymousAuthProvider 経由で認証なし、ユーザ / テナント情報は dummy のみ返す。
+
+import type { LicenseKeyStatus } from '$lib/domain/constants/license-key-status';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import type {
+	AuthUser,
+	ConsentRecord,
+	CreateInviteInput,
+	CreateMembershipInput,
+	CreateTenantInput,
+	CreateUserInput,
+	Invite,
+	Membership,
+	RecordConsentInput,
+	Tenant,
+} from '$lib/server/auth/entities';
+import type { LicenseRecord, LicenseRevokeReason } from '$lib/server/services/license-key-service';
+import type {
+	IAuthRepo,
+	LicenseKeyCountFilter,
+	LicenseKeyPage,
+} from '../interfaces/auth-repo.interface';
+
+const DEMO_TENANT_ID = 'demo';
+const DEMO_NOW = '2026-03-27T09:00:00.000Z';
+
+// ---------- User ----------
+
+export async function findUserByEmail(_email: string): Promise<AuthUser | undefined> {
+	return undefined;
+}
+
+export async function findUserById(_userId: string): Promise<AuthUser | undefined> {
+	return undefined;
+}
+
+export async function createUser(input: CreateUserInput): Promise<AuthUser> {
+	return {
+		userId: 'demo-user',
+		email: input.email,
+		provider: input.provider,
+		displayName: input.displayName,
+		createdAt: DEMO_NOW,
+		updatedAt: DEMO_NOW,
+	};
+}
+
+export async function deleteUser(_userId: string): Promise<void> {
+	// Stub: no-op
+}
+
+// ---------- Tenant ----------
+
+export async function findTenantById(tenantId: string): Promise<Tenant | undefined> {
+	if (tenantId !== DEMO_TENANT_ID) return undefined;
+	return {
+		tenantId: DEMO_TENANT_ID,
+		name: 'がんばり家 (デモ)',
+		ownerId: 'demo-owner',
+		status: SUBSCRIPTION_STATUS.ACTIVE,
+		plan: 'family-monthly',
+		// #1601: 最終活動時刻
+		lastActiveAt: DEMO_NOW,
+		createdAt: DEMO_NOW,
+		updatedAt: DEMO_NOW,
+	};
+}
+
+export async function findTenantByStripeCustomerId(
+	_stripeCustomerId: string,
+): Promise<Tenant | undefined> {
+	return undefined;
+}
+
+export async function listAllTenants(): Promise<Tenant[]> {
+	const demo = await findTenantById(DEMO_TENANT_ID);
+	return demo ? [demo] : [];
+}
+
+export async function createTenant(input: CreateTenantInput): Promise<Tenant> {
+	return {
+		tenantId: DEMO_TENANT_ID,
+		name: input.name,
+		ownerId: input.ownerId,
+		status: SUBSCRIPTION_STATUS.ACTIVE,
+		licenseKey: input.licenseKey,
+		createdAt: DEMO_NOW,
+		updatedAt: DEMO_NOW,
+	};
+}
+
+export async function updateTenantStatus(
+	_tenantId: string,
+	_status: Tenant['status'],
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function updateTenantStripe(
+	_tenantId: string,
+	_data: {
+		stripeCustomerId?: string;
+		stripeSubscriptionId?: string;
+		plan?: Tenant['plan'];
+		planExpiresAt?: string;
+		trialUsedAt?: string;
+		status?: Tenant['status'];
+		licenseKey?: string;
+	},
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function updateTenantOwner(_tenantId: string, _newOwnerId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function updateTenantLastActiveAt(
+	_tenantId: string,
+	_lastActiveAt: string,
+): Promise<void> {
+	// Stub: no-op (Lambda stateless, mutable state は持たない — ADR-0048 §決定 §2)
+}
+
+export async function deleteTenant(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+// ---------- Membership ----------
+
+export async function findMembership(
+	userId: string,
+	tenantId: string,
+): Promise<Membership | undefined> {
+	if (tenantId !== DEMO_TENANT_ID) return undefined;
+	return {
+		userId,
+		tenantId: DEMO_TENANT_ID,
+		role: 'owner',
+		joinedAt: DEMO_NOW,
+	};
+}
+
+export async function findUserTenants(userId: string): Promise<Membership[]> {
+	return [
+		{
+			userId,
+			tenantId: DEMO_TENANT_ID,
+			role: 'owner',
+			joinedAt: DEMO_NOW,
+		},
+	];
+}
+
+export async function findTenantMembers(tenantId: string): Promise<Membership[]> {
+	if (tenantId !== DEMO_TENANT_ID) return [];
+	return [
+		{
+			userId: 'demo-owner',
+			tenantId: DEMO_TENANT_ID,
+			role: 'owner',
+			joinedAt: DEMO_NOW,
+		},
+	];
+}
+
+export async function createMembership(input: CreateMembershipInput): Promise<Membership> {
+	return {
+		userId: input.userId,
+		tenantId: input.tenantId,
+		role: input.role,
+		joinedAt: DEMO_NOW,
+		invitedBy: input.invitedBy,
+	};
+}
+
+export async function deleteMembership(_userId: string, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+// ---------- Invite ----------
+
+export async function createInvite(input: CreateInviteInput): Promise<Invite> {
+	const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+	return {
+		inviteCode: 'DEMO-INVITE',
+		tenantId: input.tenantId,
+		invitedBy: input.invitedBy,
+		role: input.role,
+		childId: input.childId,
+		status: 'pending',
+		createdAt: DEMO_NOW,
+		expiresAt,
+	};
+}
+
+export async function findInviteByCode(_inviteCode: string): Promise<Invite | undefined> {
+	return undefined;
+}
+
+export async function updateInviteStatus(
+	_inviteCode: string,
+	_status: Invite['status'],
+	_acceptedBy?: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function findTenantInvites(_tenantId: string): Promise<Invite[]> {
+	return [];
+}
+
+export async function deleteInvite(_inviteCode: string, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+// ---------- Consent ----------
+
+export async function recordConsent(input: RecordConsentInput): Promise<ConsentRecord> {
+	return {
+		tenantId: input.tenantId,
+		userId: input.userId,
+		type: input.type,
+		version: input.version,
+		consentedAt: DEMO_NOW,
+		ipAddress: input.ipAddress,
+		userAgent: input.userAgent,
+	};
+}
+
+export async function findLatestConsent(
+	_tenantId: string,
+	_type: ConsentRecord['type'],
+): Promise<ConsentRecord | undefined> {
+	return undefined;
+}
+
+export async function findAllConsents(_tenantId: string): Promise<ConsentRecord[]> {
+	return [];
+}
+
+// ---------- License Key ----------
+
+export async function saveLicenseKey(_record: LicenseRecord): Promise<void> {
+	// Stub: no-op
+}
+
+export async function findLicenseKey(_key: string): Promise<LicenseRecord | undefined> {
+	return undefined;
+}
+
+export async function updateLicenseKeyStatus(
+	_key: string,
+	_status: LicenseRecord['status'],
+	_consumedBy?: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function revokeLicenseKey(_params: {
+	licenseKey: string;
+	reason: LicenseRevokeReason;
+	revokedBy: string;
+	revokedAt: string;
+}): Promise<void> {
+	// Stub: no-op
+}
+
+export async function listLicenseKeysByTenant(
+	_tenantId: string,
+	_limit?: number,
+	_cursor?: string,
+): Promise<LicenseKeyPage> {
+	return { items: [], cursor: null };
+}
+
+export async function listLicenseKeysByStatus(
+	_status: LicenseKeyStatus,
+	_limit?: number,
+	_cursor?: string,
+): Promise<LicenseKeyPage> {
+	return { items: [], cursor: null };
+}
+
+export async function listExpiringSoon(_days: number): Promise<LicenseRecord[]> {
+	return [];
+}
+
+export async function countLicenseKeys(_filter?: LicenseKeyCountFilter): Promise<number> {
+	return 0;
+}
+
+export async function listActiveExpiredKeys(_now: string): Promise<LicenseRecord[]> {
+	return [];
+}
+
+// Type-check: 全 method が IAuthRepo を満たすことを確認
+const _typecheck: IAuthRepo = {
+	findUserByEmail,
+	findUserById,
+	createUser,
+	deleteUser,
+	findTenantById,
+	findTenantByStripeCustomerId,
+	listAllTenants,
+	createTenant,
+	updateTenantStatus,
+	updateTenantStripe,
+	updateTenantOwner,
+	updateTenantLastActiveAt,
+	deleteTenant,
+	findMembership,
+	findUserTenants,
+	findTenantMembers,
+	createMembership,
+	deleteMembership,
+	createInvite,
+	findInviteByCode,
+	updateInviteStatus,
+	findTenantInvites,
+	deleteInvite,
+	recordConsent,
+	findLatestConsent,
+	findAllConsents,
+	saveLicenseKey,
+	findLicenseKey,
+	updateLicenseKeyStatus,
+	revokeLicenseKey,
+	listLicenseKeysByTenant,
+	listLicenseKeysByStatus,
+	listExpiringSoon,
+	countLicenseKeys,
+	listActiveExpiredKeys,
+};
+void _typecheck;

--- a/src/lib/server/db/demo/auth-repo.ts
+++ b/src/lib/server/db/demo/auth-repo.ts
@@ -3,6 +3,7 @@
 // Demo Lambda は AnonymousAuthProvider 経由で認証なし、ユーザ / テナント情報は dummy のみ返す。
 
 import type { LicenseKeyStatus } from '$lib/domain/constants/license-key-status';
+import { LICENSE_PLAN } from '$lib/domain/constants/license-plan';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import type {
 	AuthUser,
@@ -60,7 +61,7 @@ export async function findTenantById(tenantId: string): Promise<Tenant | undefin
 		name: 'がんばり家 (デモ)',
 		ownerId: 'demo-owner',
 		status: SUBSCRIPTION_STATUS.ACTIVE,
-		plan: 'family-monthly',
+		plan: LICENSE_PLAN.FAMILY_MONTHLY,
 		// #1601: 最終活動時刻
 		lastActiveAt: DEMO_NOW,
 		createdAt: DEMO_NOW,

--- a/src/lib/server/db/demo/auto-challenge-repo.ts
+++ b/src/lib/server/db/demo/auto-challenge-repo.ts
@@ -1,0 +1,62 @@
+// Demo IAutoChallengeRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { AutoChallenge, InsertAutoChallengeInput, UpdateAutoChallengeInput } from '../types';
+
+export async function findByChildAndWeek(
+	_childId: number,
+	_weekStart: string,
+	_tenantId: string,
+): Promise<AutoChallenge | undefined> {
+	return undefined;
+}
+
+export async function findActiveByChild(
+	_childId: number,
+	_tenantId: string,
+): Promise<AutoChallenge | undefined> {
+	return undefined;
+}
+
+export async function findByChild(
+	_childId: number,
+	_tenantId: string,
+	_limit?: number,
+): Promise<AutoChallenge[]> {
+	return [];
+}
+
+export async function insert(
+	input: InsertAutoChallengeInput,
+	tenantId: string,
+): Promise<AutoChallenge> {
+	const now = new Date().toISOString();
+	return {
+		id: 0,
+		childId: input.childId,
+		tenantId,
+		weekStart: input.weekStart,
+		categoryId: input.categoryId,
+		targetCount: input.targetCount,
+		currentCount: 0,
+		status: 'active',
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+export async function update(
+	_id: number,
+	_input: UpdateAutoChallengeInput,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function expireOldChallenges(_beforeDate: string, _tenantId: string): Promise<number> {
+	return 0;
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/battle-repo.ts
+++ b/src/lib/server/db/demo/battle-repo.ts
@@ -1,0 +1,61 @@
+// Demo IBattleRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { BattleOutcome, BattleStats } from '$lib/domain/battle-types';
+import type { DailyBattleRow, EnemyCollectionRow } from '../interfaces/battle-repo.interface';
+
+export async function findTodayBattle(
+	_childId: number,
+	_date: string,
+	_tenantId: string,
+): Promise<DailyBattleRow | undefined> {
+	return undefined;
+}
+
+export async function findRecentBattles(
+	_childId: number,
+	_limit: number,
+	_tenantId: string,
+): Promise<DailyBattleRow[]> {
+	return [];
+}
+
+export async function countConsecutiveLosses(_childId: number, _tenantId: string): Promise<number> {
+	return 0;
+}
+
+export async function insertDailyBattle(
+	_childId: number,
+	_enemyId: number,
+	_date: string,
+	_playerStats: BattleStats,
+	_tenantId: string,
+): Promise<number> {
+	// Stub: return dummy battle id
+	return 0;
+}
+
+export async function completeBattle(
+	_battleId: number,
+	_outcome: BattleOutcome,
+	_rewardPoints: number,
+	_turnsUsed: number,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function findCollection(
+	_childId: number,
+	_tenantId: string,
+): Promise<EnemyCollectionRow[]> {
+	return [];
+}
+
+export async function upsertCollectionEntry(
+	_childId: number,
+	_enemyId: number,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/cancellation-reason-repo.ts
+++ b/src/lib/server/db/demo/cancellation-reason-repo.ts
@@ -1,0 +1,44 @@
+// Demo ICancellationReasonRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type {
+	CancellationReasonAggregation,
+	CancellationReasonRecord,
+	CreateCancellationReasonInput,
+} from '../interfaces/cancellation-reason-repo.interface';
+
+export async function create(
+	input: CreateCancellationReasonInput,
+): Promise<CancellationReasonRecord> {
+	return {
+		id: 0,
+		tenantId: input.tenantId,
+		category: input.category,
+		freeText: input.freeText ?? null,
+		planAtCancellation: input.planAtCancellation ?? null,
+		stripeSubscriptionId: input.stripeSubscriptionId ?? null,
+		createdAt: new Date().toISOString(),
+	};
+}
+
+export async function listByTenant(_tenantId: string): Promise<CancellationReasonRecord[]> {
+	return [];
+}
+
+export async function aggregateRecent(_days?: number): Promise<{
+	total: number;
+	breakdown: CancellationReasonAggregation[];
+}> {
+	return { total: 0, breakdown: [] };
+}
+
+export async function searchFreeText(
+	_query: string,
+	_limit?: number,
+): Promise<CancellationReasonRecord[]> {
+	return [];
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/checklist-repo.ts
+++ b/src/lib/server/db/demo/checklist-repo.ts
@@ -1,0 +1,178 @@
+// Demo IChecklistRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import { DEMO_CHECKLIST_ITEMS, DEMO_CHECKLIST_TEMPLATES } from '$lib/server/demo/demo-data';
+import type {
+	ChecklistLog,
+	ChecklistOverride,
+	ChecklistTemplate,
+	ChecklistTemplateItem,
+	InsertChecklistOverrideInput,
+	InsertChecklistTemplateInput,
+	InsertChecklistTemplateItemInput,
+	UpdateChecklistTemplateInput,
+	UpsertChecklistLogInput,
+} from '../types';
+
+// ---------- Templates ----------
+
+export async function findTemplatesByChild(
+	childId: number,
+	_tenantId: string,
+	includeInactive?: boolean,
+): Promise<ChecklistTemplate[]> {
+	return DEMO_CHECKLIST_TEMPLATES.filter(
+		(t) =>
+			t.childId === childId && (includeInactive === true || t.isActive === 1) && t.isArchived === 0,
+	);
+}
+
+export async function findTemplateById(
+	id: number,
+	_tenantId: string,
+): Promise<ChecklistTemplate | undefined> {
+	return DEMO_CHECKLIST_TEMPLATES.find((t) => t.id === id);
+}
+
+export async function insertTemplate(
+	input: InsertChecklistTemplateInput,
+	_tenantId: string,
+): Promise<ChecklistTemplate> {
+	const now = new Date().toISOString();
+	return {
+		id: 0,
+		childId: input.childId,
+		name: input.name,
+		icon: input.icon ?? '📋',
+		pointsPerItem: input.pointsPerItem ?? 1,
+		completionBonus: input.completionBonus ?? 0,
+		timeSlot: input.timeSlot ?? 'anytime',
+		isActive: input.isActive ?? 1,
+		isArchived: 0,
+		archivedReason: null,
+		createdAt: now,
+		updatedAt: now,
+		sourcePresetId: input.sourcePresetId ?? null,
+	};
+}
+
+export async function updateTemplate(
+	id: number,
+	_input: UpdateChecklistTemplateInput,
+	_tenantId: string,
+): Promise<ChecklistTemplate | undefined> {
+	return DEMO_CHECKLIST_TEMPLATES.find((t) => t.id === id);
+}
+
+export async function deleteTemplate(_id: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+// ---------- Template items ----------
+
+export async function findTemplateItems(
+	templateId: number,
+	_tenantId: string,
+): Promise<ChecklistTemplateItem[]> {
+	return DEMO_CHECKLIST_ITEMS.filter((i) => i.templateId === templateId);
+}
+
+export async function insertTemplateItem(
+	input: InsertChecklistTemplateItemInput,
+	_tenantId: string,
+): Promise<ChecklistTemplateItem> {
+	const now = new Date().toISOString();
+	return {
+		id: 0,
+		templateId: input.templateId,
+		name: input.name,
+		icon: input.icon ?? '✅',
+		frequency: input.frequency ?? 'daily',
+		direction: input.direction ?? 'positive',
+		sortOrder: input.sortOrder ?? 0,
+		createdAt: now,
+	};
+}
+
+export async function deleteTemplateItem(_id: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+// ---------- Logs ----------
+
+export async function findTodayLog(
+	_childId: number,
+	_templateId: number,
+	_date: string,
+	_tenantId: string,
+): Promise<ChecklistLog | undefined> {
+	return undefined;
+}
+
+export async function upsertLog(
+	input: UpsertChecklistLogInput,
+	_tenantId: string,
+): Promise<ChecklistLog> {
+	const now = new Date().toISOString();
+	return {
+		id: 0,
+		childId: input.childId,
+		templateId: input.templateId,
+		checkedDate: input.checkedDate,
+		itemsJson: input.itemsJson,
+		completedAll: input.completedAll,
+		pointsAwarded: input.pointsAwarded,
+		createdAt: now,
+	};
+}
+
+// ---------- Overrides ----------
+
+export async function findOverrides(
+	_childId: number,
+	_date: string,
+	_tenantId: string,
+): Promise<ChecklistOverride[]> {
+	return [];
+}
+
+export async function insertOverride(
+	input: InsertChecklistOverrideInput,
+	_tenantId: string,
+): Promise<ChecklistOverride> {
+	const now = new Date().toISOString();
+	return {
+		id: 0,
+		childId: input.childId,
+		targetDate: input.targetDate,
+		action: input.action,
+		itemName: input.itemName,
+		icon: input.icon ?? '✅',
+		createdAt: now,
+	};
+}
+
+export async function deleteOverride(_id: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+// ---------- Archive / Restore ----------
+
+export async function archiveChecklistTemplates(
+	_ids: number[],
+	_reason: string,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function restoreArchivedChecklistTemplates(
+	_reason: string,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/child-repo.ts
+++ b/src/lib/server/db/demo/child-repo.ts
@@ -1,0 +1,74 @@
+// Demo IChildRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import { getDefaultUiMode } from '$lib/domain/validation/age-tier';
+import { DEMO_CHILDREN } from '$lib/server/demo/demo-data';
+import type { Child, InsertChildInput, UpdateChildInput } from '../types';
+
+export async function findAllChildren(_tenantId: string): Promise<Child[]> {
+	return DEMO_CHILDREN.filter((c) => c.isArchived === 0);
+}
+
+export async function findChildById(id: number, _tenantId: string): Promise<Child | undefined> {
+	return DEMO_CHILDREN.find((c) => c.id === id);
+}
+
+export async function findChildByUserId(
+	userId: string,
+	_tenantId: string,
+): Promise<Child | undefined> {
+	return DEMO_CHILDREN.find((c) => c.userId === userId);
+}
+
+export async function insertChild(input: InsertChildInput, _tenantId: string): Promise<Child> {
+	const now = new Date().toISOString();
+	const uiMode = input.uiMode ?? getDefaultUiMode(input.age);
+	return {
+		id: 0,
+		nickname: input.nickname,
+		age: input.age,
+		birthDate: input.birthDate ?? null,
+		theme: input.theme ?? 'blue',
+		uiMode,
+		uiModeManuallySet: 0,
+		avatarUrl: null,
+		displayConfig: null,
+		userId: null,
+		birthdayBonusMultiplier: 1.0,
+		lastBirthdayBonusYear: null,
+		isArchived: 0,
+		archivedReason: null,
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+export async function updateChild(
+	id: number,
+	_input: UpdateChildInput,
+	_tenantId: string,
+): Promise<Child | undefined> {
+	return DEMO_CHILDREN.find((c) => c.id === id);
+}
+
+export async function deleteChild(_id: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+// ---------- Archive / Restore ----------
+
+export async function archiveChildren(
+	_ids: number[],
+	_reason: string,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function restoreArchivedChildren(_reason: string, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function findArchivedChildren(_tenantId: string): Promise<Child[]> {
+	return DEMO_CHILDREN.filter((c) => c.isArchived === 1);
+}

--- a/src/lib/server/db/demo/cloud-export-repo.ts
+++ b/src/lib/server/db/demo/cloud-export-repo.ts
@@ -1,0 +1,52 @@
+// Demo ICloudExportRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { CloudExportRecord, InsertCloudExportInput } from '../types';
+
+export async function findByTenant(_tenantId: string): Promise<CloudExportRecord[]> {
+	return [];
+}
+
+export async function findByPin(_pinCode: string): Promise<CloudExportRecord | undefined> {
+	return undefined;
+}
+
+export async function findById(
+	_id: number,
+	_tenantId: string,
+): Promise<CloudExportRecord | undefined> {
+	return undefined;
+}
+
+export async function insert(input: InsertCloudExportInput): Promise<CloudExportRecord> {
+	return {
+		id: 0,
+		tenantId: input.tenantId,
+		exportType: input.exportType,
+		pinCode: input.pinCode,
+		s3Key: input.s3Key,
+		fileSizeBytes: input.fileSizeBytes,
+		label: input.label ?? null,
+		description: input.description ?? null,
+		expiresAt: input.expiresAt,
+		downloadCount: 0,
+		maxDownloads: input.maxDownloads ?? 5,
+		createdAt: new Date().toISOString(),
+	};
+}
+
+export async function incrementDownloadCount(_id: number): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteById(_id: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteExpired(_now: string): Promise<number> {
+	return 0;
+}
+
+export async function countByTenant(_tenantId: string): Promise<number> {
+	return 0;
+}

--- a/src/lib/server/db/demo/daily-mission-repo.ts
+++ b/src/lib/server/db/demo/daily-mission-repo.ts
@@ -1,0 +1,128 @@
+// Demo IDailyMissionRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import {
+	DEMO_ACTIVITIES,
+	DEMO_ACTIVITY_LOGS,
+	DEMO_CHILDREN,
+	DEMO_DAILY_MISSIONS,
+} from '$lib/server/demo/demo-data';
+import type { Activity, Child, DailyMissionWithActivity } from '../types';
+
+export async function findTodayMissions(
+	childId: number,
+	date: string,
+	_tenantId: string,
+): Promise<DailyMissionWithActivity[]> {
+	return DEMO_DAILY_MISSIONS.filter((m) => m.childId === childId && m.missionDate === date)
+		.map((m) => {
+			const activity = DEMO_ACTIVITIES.find((a) => a.id === m.activityId);
+			return activity
+				? ({
+						id: m.id,
+						activityId: m.activityId,
+						completed: m.completed,
+						activityName: activity.name,
+						activityIcon: activity.icon,
+						categoryId: activity.categoryId,
+					} satisfies DailyMissionWithActivity)
+				: null;
+		})
+		.filter((x): x is DailyMissionWithActivity => x !== null);
+}
+
+export async function findMissionBonusRecord(
+	_childId: number,
+	_description: string,
+	_tenantId: string,
+): Promise<{ amount: number } | undefined> {
+	return undefined;
+}
+
+export async function findMissionByActivity(
+	childId: number,
+	date: string,
+	activityId: number,
+	_tenantId: string,
+): Promise<{ id: number; completed: number } | undefined> {
+	const mission = DEMO_DAILY_MISSIONS.find(
+		(m) => m.childId === childId && m.missionDate === date && m.activityId === activityId,
+	);
+	return mission ? { id: mission.id, completed: mission.completed } : undefined;
+}
+
+export async function markMissionCompleted(_missionId: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function findAllMissionStatuses(
+	childId: number,
+	date: string,
+	_tenantId: string,
+): Promise<{ completed: number }[]> {
+	return DEMO_DAILY_MISSIONS.filter((m) => m.childId === childId && m.missionDate === date).map(
+		(m) => ({ completed: m.completed }),
+	);
+}
+
+export async function findChildForMission(
+	childId: number,
+	_tenantId: string,
+): Promise<Child | undefined> {
+	return DEMO_CHILDREN.find((c) => c.id === childId);
+}
+
+export async function findVisibleActivities(_tenantId: string): Promise<Activity[]> {
+	return DEMO_ACTIVITIES.filter((a) => a.isVisible === 1);
+}
+
+export async function findPreviousDayMissionIds(
+	childId: number,
+	date: string,
+	_tenantId: string,
+): Promise<number[]> {
+	const prev = new Date(date);
+	prev.setDate(prev.getDate() - 1);
+	const prevDate = prev.toISOString().slice(0, 10);
+	return DEMO_DAILY_MISSIONS.filter((m) => m.childId === childId && m.missionDate === prevDate).map(
+		(m) => m.activityId,
+	);
+}
+
+export async function findRecentActivityIds(
+	childId: number,
+	sinceDate: string,
+	_tenantId: string,
+): Promise<number[]> {
+	const ids = new Set<number>();
+	for (const log of DEMO_ACTIVITY_LOGS) {
+		if (log.childId === childId && log.recordedDate >= sinceDate && log.cancelled === 0) {
+			ids.add(log.activityId);
+		}
+	}
+	return Array.from(ids);
+}
+
+export async function findAllRecordedActivityIds(
+	childId: number,
+	_tenantId: string,
+): Promise<number[]> {
+	const ids = new Set<number>();
+	for (const log of DEMO_ACTIVITY_LOGS) {
+		if (log.childId === childId && log.cancelled === 0) ids.add(log.activityId);
+	}
+	return Array.from(ids);
+}
+
+export async function insertDailyMission(
+	_childId: number,
+	_date: string,
+	_activityId: number,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/evaluation-repo.ts
+++ b/src/lib/server/db/demo/evaluation-repo.ts
@@ -1,0 +1,122 @@
+// Demo IEvaluationRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import { DEMO_CHILDREN } from '$lib/server/demo/demo-data';
+import type {
+	CategoryActivityCount,
+	CategoryLastDate,
+	Child,
+	Evaluation,
+	InsertEvaluationInput,
+	RestDay,
+} from '../types';
+
+export async function countActivitiesByCategory(
+	_childId: number,
+	_weekStart: string,
+	_weekEnd: string,
+	_tenantId: string,
+): Promise<CategoryActivityCount[]> {
+	return [];
+}
+
+export async function insertEvaluation(
+	input: InsertEvaluationInput,
+	_tenantId: string,
+): Promise<Evaluation> {
+	return {
+		id: 0,
+		childId: input.childId,
+		weekStart: input.weekStart,
+		weekEnd: input.weekEnd,
+		scoresJson: input.scoresJson,
+		bonusPoints: input.bonusPoints,
+		createdAt: new Date().toISOString(),
+	};
+}
+
+export async function findAllChildren(_tenantId: string): Promise<Child[]> {
+	return DEMO_CHILDREN.filter((c) => c.isArchived === 0);
+}
+
+export async function findEvaluationsByChild(
+	_childId: number,
+	_limit: number,
+	_tenantId: string,
+): Promise<Evaluation[]> {
+	return [];
+}
+
+export async function hasDecayRunToday(
+	_childId: number,
+	_today: string,
+	_tenantId: string,
+): Promise<boolean> {
+	return false;
+}
+
+export async function findWeekEvaluation(
+	_childId: number,
+	_weekStart: string,
+	_tenantId: string,
+): Promise<{ id: number } | undefined> {
+	return undefined;
+}
+
+export async function findLastActivityDateByCategory(
+	_childId: number,
+	_tenantId: string,
+): Promise<CategoryLastDate[]> {
+	return [];
+}
+
+export async function insertRestDay(
+	childId: number,
+	date: string,
+	reason: string,
+	_tenantId: string,
+): Promise<RestDay | undefined> {
+	return {
+		id: 0,
+		childId,
+		date,
+		reason,
+		createdAt: new Date().toISOString(),
+	};
+}
+
+export async function deleteRestDay(
+	_childId: number,
+	_date: string,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function isRestDay(
+	_childId: number,
+	_date: string,
+	_tenantId: string,
+): Promise<boolean> {
+	return false;
+}
+
+export async function countRestDaysInMonth(
+	_childId: number,
+	_yearMonth: string,
+	_tenantId: string,
+): Promise<number> {
+	return 0;
+}
+
+export async function findRestDays(
+	_childId: number,
+	_yearMonth: string,
+	_tenantId: string,
+): Promise<RestDay[]> {
+	return [];
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/graduation-consent-repo.ts
+++ b/src/lib/server/db/demo/graduation-consent-repo.ts
@@ -1,0 +1,45 @@
+// Demo IGraduationConsentRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type {
+	CreateGraduationConsentInput,
+	GraduationConsentRecord,
+	GraduationStats,
+} from '../interfaces/graduation-consent-repo.interface';
+
+export async function create(
+	input: CreateGraduationConsentInput,
+): Promise<GraduationConsentRecord> {
+	return {
+		id: 0,
+		tenantId: input.tenantId,
+		nickname: input.nickname,
+		consented: input.consented,
+		userPoints: input.userPoints,
+		usagePeriodDays: input.usagePeriodDays,
+		message: input.message ?? null,
+		consentedAt: new Date().toISOString(),
+	};
+}
+
+export async function listByTenant(_tenantId: string): Promise<GraduationConsentRecord[]> {
+	return [];
+}
+
+export async function aggregateRecent(_days?: number): Promise<{
+	totalGraduations: number;
+	consentedCount: number;
+	avgUsagePeriodDays: number;
+	publicSamples: GraduationStats['publicSamples'];
+}> {
+	return {
+		totalGraduations: 0,
+		consentedCount: 0,
+		avgUsagePeriodDays: 0,
+		publicSamples: [],
+	};
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/image-repo.ts
+++ b/src/lib/server/db/demo/image-repo.ts
@@ -1,0 +1,40 @@
+// Demo IImageRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import { DEMO_CHILDREN } from '$lib/server/demo/demo-data';
+import type { CharacterImage, Child, InsertCharacterImageInput } from '../types';
+
+export async function findCachedImage(
+	_childId: number,
+	_type: string,
+	_promptHash: string,
+	_tenantId: string,
+): Promise<CharacterImage | undefined> {
+	return undefined;
+}
+
+export async function insertCharacterImage(
+	_input: InsertCharacterImageInput,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function updateChildAvatarUrl(
+	_childId: number,
+	_avatarUrl: string,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function findChildForImage(
+	childId: number,
+	_tenantId: string,
+): Promise<Child | undefined> {
+	return DEMO_CHILDREN.find((c) => c.id === childId);
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/inquiry-repo.ts
+++ b/src/lib/server/db/demo/inquiry-repo.ts
@@ -1,0 +1,14 @@
+// Demo IInquiryRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { InquiryRecord } from '../interfaces/inquiry-repo.interface';
+
+export async function generateInquiryId(): Promise<string> {
+	// Demo Lambda の inquiry はサポートしないが、interface 契約のため
+	// deterministic な dummy ID を返す (stateless)
+	return 'DEMO-INQUIRY';
+}
+
+export async function saveInquiry(_record: InquiryRecord): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/login-bonus-repo.ts
+++ b/src/lib/server/db/demo/login-bonus-repo.ts
@@ -1,0 +1,55 @@
+// Demo ILoginBonusRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import { DEMO_CHILDREN, DEMO_LOGIN_BONUSES } from '$lib/server/demo/demo-data';
+import type { Child, InsertLoginBonusInput, LoginBonus } from '../types';
+
+export async function findTodayBonus(
+	childId: number,
+	today: string,
+	_tenantId: string,
+): Promise<LoginBonus | undefined> {
+	return DEMO_LOGIN_BONUSES.find((b) => b.childId === childId && b.loginDate === today);
+}
+
+export async function findRecentBonuses(
+	childId: number,
+	_tenantId: string,
+	limit?: number,
+): Promise<LoginBonus[]> {
+	const filtered = DEMO_LOGIN_BONUSES.filter((b) => b.childId === childId);
+	return typeof limit === 'number' ? filtered.slice(0, limit) : filtered;
+}
+
+export async function insertLoginBonus(
+	input: InsertLoginBonusInput,
+	_tenantId: string,
+): Promise<LoginBonus> {
+	return {
+		id: 0,
+		childId: input.childId,
+		loginDate: input.loginDate,
+		rank: input.rank,
+		basePoints: input.basePoints,
+		multiplier: input.multiplier,
+		totalPoints: input.totalPoints,
+		consecutiveDays: input.consecutiveDays,
+		createdAt: new Date().toISOString(),
+	};
+}
+
+export async function findChildById(id: number, _tenantId: string): Promise<Child | undefined> {
+	return DEMO_CHILDREN.find((c) => c.id === id);
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteLoginBonusesBeforeDate(
+	_childId: number,
+	_cutoffDate: string,
+	_tenantId: string,
+): Promise<number> {
+	return 0;
+}

--- a/src/lib/server/db/demo/message-repo.ts
+++ b/src/lib/server/db/demo/message-repo.ts
@@ -1,0 +1,50 @@
+// Demo IMessageRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { InsertParentMessageInput, ParentMessage } from '../types';
+
+export async function insertMessage(
+	input: InsertParentMessageInput,
+	_tenantId: string,
+): Promise<ParentMessage> {
+	return {
+		id: 0,
+		childId: input.childId,
+		messageType: input.messageType,
+		stampCode: input.stampCode ?? null,
+		body: input.body ?? null,
+		icon: input.icon ?? '💌',
+		sentAt: new Date().toISOString(),
+		shownAt: null,
+	};
+}
+
+export async function findMessages(
+	_childId: number,
+	_limit: number,
+	_tenantId: string,
+): Promise<ParentMessage[]> {
+	return [];
+}
+
+export async function findUnshownMessage(
+	_childId: number,
+	_tenantId: string,
+): Promise<ParentMessage | undefined> {
+	return undefined;
+}
+
+export async function countUnshownMessages(_childId: number, _tenantId: string): Promise<number> {
+	return 0;
+}
+
+export async function markMessageShown(
+	_messageId: number,
+	_tenantId: string,
+): Promise<ParentMessage | undefined> {
+	return undefined;
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/point-repo.ts
+++ b/src/lib/server/db/demo/point-repo.ts
@@ -1,0 +1,48 @@
+// Demo IPointRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import { DEMO_CHILDREN, DEMO_POINT_BALANCES } from '$lib/server/demo/demo-data';
+import type { Child, InsertPointLedgerInput, PointLedgerEntry } from '../types';
+
+export async function getBalance(childId: number, _tenantId: string): Promise<number> {
+	return DEMO_POINT_BALANCES[childId] ?? 0;
+}
+
+export async function findPointHistory(
+	_childId: number,
+	_options: { limit: number; offset: number },
+	_tenantId: string,
+): Promise<PointLedgerEntry[]> {
+	return [];
+}
+
+export async function insertPointEntry(
+	input: InsertPointLedgerInput,
+	_tenantId: string,
+): Promise<PointLedgerEntry> {
+	return {
+		id: 0,
+		childId: input.childId,
+		amount: input.amount,
+		type: input.type,
+		description: input.description,
+		referenceId: input.referenceId ?? null,
+		createdAt: new Date().toISOString(),
+	};
+}
+
+export async function findChildById(id: number, _tenantId: string): Promise<Child | undefined> {
+	return DEMO_CHILDREN.find((c) => c.id === id);
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deletePointLedgerBeforeDate(
+	_childId: number,
+	_cutoffDate: string,
+	_tenantId: string,
+): Promise<number> {
+	return 0;
+}

--- a/src/lib/server/db/demo/push-subscription-repo.ts
+++ b/src/lib/server/db/demo/push-subscription-repo.ts
@@ -1,0 +1,61 @@
+// Demo IPushSubscriptionRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type {
+	InsertNotificationLogInput,
+	InsertPushSubscriptionInput,
+	NotificationLog,
+	PushSubscriptionRecord,
+} from '../types';
+
+export async function findByTenant(_tenantId: string): Promise<PushSubscriptionRecord[]> {
+	return [];
+}
+
+export async function findByEndpoint(
+	_endpoint: string,
+	_tenantId: string,
+): Promise<PushSubscriptionRecord | undefined> {
+	return undefined;
+}
+
+export async function insert(input: InsertPushSubscriptionInput): Promise<PushSubscriptionRecord> {
+	return {
+		id: 0,
+		tenantId: input.tenantId,
+		endpoint: input.endpoint,
+		keysP256dh: input.keysP256dh,
+		keysAuth: input.keysAuth,
+		userAgent: input.userAgent ?? null,
+		subscriberRole: input.subscriberRole,
+		createdAt: new Date().toISOString(),
+	};
+}
+
+export async function deleteByEndpoint(_endpoint: string, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function insertLog(input: InsertNotificationLogInput): Promise<NotificationLog> {
+	return {
+		id: 0,
+		tenantId: input.tenantId,
+		notificationType: input.notificationType,
+		title: input.title,
+		body: input.body,
+		sentAt: new Date().toISOString(),
+		success: input.success ? 1 : 0,
+		errorMessage: input.errorMessage ?? null,
+	};
+}
+
+export async function countTodayLogs(_tenantId: string, _today: string): Promise<number> {
+	return 0;
+}
+
+export async function findRecentLogs(
+	_tenantId: string,
+	_limit: number,
+): Promise<NotificationLog[]> {
+	return [];
+}

--- a/src/lib/server/db/demo/report-daily-summary-repo.ts
+++ b/src/lib/server/db/demo/report-daily-summary-repo.ts
@@ -1,0 +1,33 @@
+// Demo IReportDailySummaryRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { InsertReportDailySummaryInput, ReportDailySummary } from '../types';
+
+export async function findByChildAndDateRange(
+	_childId: number,
+	_startDate: string,
+	_endDate: string,
+	_tenantId: string,
+): Promise<ReportDailySummary[]> {
+	return [];
+}
+
+export async function findByTenantAndDateRange(
+	_tenantId: string,
+	_startDate: string,
+	_endDate: string,
+): Promise<ReportDailySummary[]> {
+	return [];
+}
+
+export async function upsert(_input: InsertReportDailySummaryInput): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteOlderThan(_tenantId: string, _cutoffDate: string): Promise<number> {
+	return 0;
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/reward-redemption-repo.ts
+++ b/src/lib/server/db/demo/reward-redemption-repo.ts
@@ -1,0 +1,86 @@
+// Demo IRewardRedemptionRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type {
+	RedemptionRequestRow,
+	RedemptionRequestWithDetails,
+	RedemptionRequestWithReward,
+} from '../interfaces/reward-redemption-repo.interface';
+
+export async function insertRedemptionRequest(
+	input: { childId: number; rewardId: number; requestedAt: number },
+	_tenantId: string,
+): Promise<RedemptionRequestRow> {
+	return {
+		id: 0,
+		childId: input.childId,
+		rewardId: input.rewardId,
+		requestedAt: input.requestedAt,
+		status: 'pending',
+		parentNote: null,
+		resolvedAt: null,
+		resolvedByParentId: null,
+		shownToChildAt: null,
+	};
+}
+
+export async function findRedemptionRequestsByChild(
+	_childId: number,
+	_tenantId: string,
+): Promise<RedemptionRequestRow[]> {
+	return [];
+}
+
+export async function findRedemptionRequestsByTenant(
+	_tenantId: string,
+	_opts?: { status?: string; childId?: number; limit?: number },
+): Promise<RedemptionRequestWithDetails[]> {
+	return [];
+}
+
+export async function updateRedemptionRequestStatus(
+	_id: number,
+	_updates: {
+		status: string;
+		parentNote?: string | null;
+		resolvedAt?: number | null;
+		resolvedByParentId?: number | null;
+	},
+	_tenantId: string,
+): Promise<RedemptionRequestRow | undefined> {
+	return undefined;
+}
+
+export async function findPendingByChildAndReward(
+	_childId: number,
+	_rewardId: number,
+	_tenantId: string,
+): Promise<RedemptionRequestRow | undefined> {
+	return undefined;
+}
+
+export async function findUnshownResultByChild(
+	_childId: number,
+	_tenantId: string,
+): Promise<RedemptionRequestWithReward | undefined> {
+	return undefined;
+}
+
+export async function markRedemptionResultShown(
+	_id: number,
+	_tenantId: string,
+): Promise<RedemptionRequestRow | undefined> {
+	return undefined;
+}
+
+export async function expireOldRedemptions(_tenantId: string): Promise<number> {
+	return 0;
+}
+
+export async function hasPendingByReward(_rewardId: number, _tenantId: string): Promise<boolean> {
+	return false;
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/season-event-repo.ts
+++ b/src/lib/server/db/demo/season-event-repo.ts
@@ -1,0 +1,105 @@
+// Demo ISeasonEventRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type {
+	ChildEventProgress,
+	InsertSeasonEventInput,
+	SeasonEvent,
+	UpdateSeasonEventInput,
+} from '../types';
+
+export async function findAllEvents(_tenantId: string): Promise<SeasonEvent[]> {
+	return [];
+}
+
+export async function findActiveEvents(_today: string, _tenantId: string): Promise<SeasonEvent[]> {
+	return [];
+}
+
+export async function findEventById(
+	_id: number,
+	_tenantId: string,
+): Promise<SeasonEvent | undefined> {
+	return undefined;
+}
+
+export async function findEventByCode(
+	_code: string,
+	_tenantId: string,
+): Promise<SeasonEvent | undefined> {
+	return undefined;
+}
+
+export async function insertEvent(
+	input: InsertSeasonEventInput,
+	_tenantId: string,
+): Promise<SeasonEvent> {
+	const now = new Date().toISOString();
+	return {
+		id: 0,
+		code: input.code,
+		name: input.name,
+		description: input.description ?? null,
+		eventType: input.eventType ?? 'seasonal',
+		startDate: input.startDate,
+		endDate: input.endDate,
+		bannerIcon: input.bannerIcon ?? '🎉',
+		bannerColor: input.bannerColor ?? null,
+		themeConfig: input.themeConfig ?? null,
+		rewardConfig: input.rewardConfig ?? null,
+		missionConfig: input.missionConfig ?? null,
+		isActive: 1,
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+export async function updateEvent(
+	_id: number,
+	_input: UpdateSeasonEventInput,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteEvent(_id: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function findChildProgress(
+	_childId: number,
+	_eventId: number,
+	_tenantId: string,
+): Promise<ChildEventProgress | undefined> {
+	return undefined;
+}
+
+export async function findChildActiveEvents(
+	_childId: number,
+	_today: string,
+	_tenantId: string,
+): Promise<ChildEventProgress[]> {
+	return [];
+}
+
+export async function upsertChildProgress(
+	_childId: number,
+	_eventId: number,
+	_status: string,
+	_progressJson: string | null,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function claimReward(
+	_childId: number,
+	_eventId: number,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/settings-repo.ts
+++ b/src/lib/server/db/demo/settings-repo.ts
@@ -1,0 +1,23 @@
+// Demo ISettingsRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+export async function getSetting(_key: string, _tenantId: string): Promise<string | undefined> {
+	return undefined;
+}
+
+export async function setSetting(_key: string, _value: string, _tenantId: string): Promise<void> {
+	// Stub: no-op (Lambda stateless, ADR-0048 §決定 §2)
+}
+
+export async function getSettings(
+	keys: string[],
+	_tenantId: string,
+): Promise<Record<string, string>> {
+	// Empty fixture — demo Lambda は settings を持たない
+	void keys;
+	return {};
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/sibling-challenge-repo.ts
+++ b/src/lib/server/db/demo/sibling-challenge-repo.ts
@@ -1,0 +1,121 @@
+// Demo ISiblingChallengeRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type {
+	InsertSiblingChallengeInput,
+	SiblingChallenge,
+	SiblingChallengeProgress,
+	UpdateSiblingChallengeInput,
+} from '../types';
+
+export async function findAllChallenges(_tenantId: string): Promise<SiblingChallenge[]> {
+	return [];
+}
+
+export async function findActiveChallenges(
+	_today: string,
+	_tenantId: string,
+): Promise<SiblingChallenge[]> {
+	return [];
+}
+
+export async function findChallengeById(
+	_id: number,
+	_tenantId: string,
+): Promise<SiblingChallenge | undefined> {
+	return undefined;
+}
+
+export async function insertChallenge(
+	input: InsertSiblingChallengeInput,
+	_tenantId: string,
+): Promise<SiblingChallenge> {
+	const now = new Date().toISOString();
+	return {
+		id: 0,
+		title: input.title,
+		description: input.description ?? null,
+		challengeType: input.challengeType ?? 'cooperative',
+		periodType: input.periodType ?? 'weekly',
+		startDate: input.startDate,
+		endDate: input.endDate,
+		targetConfig: input.targetConfig,
+		rewardConfig: input.rewardConfig,
+		status: 'active',
+		isActive: 1,
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+export async function updateChallenge(
+	_id: number,
+	_input: UpdateSiblingChallengeInput,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteChallenge(_id: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function findProgressByChallenge(
+	_challengeId: number,
+	_tenantId: string,
+): Promise<SiblingChallengeProgress[]> {
+	return [];
+}
+
+export async function findProgressByChild(
+	_childId: number,
+	_tenantId: string,
+): Promise<SiblingChallengeProgress[]> {
+	return [];
+}
+
+export async function findProgress(
+	_challengeId: number,
+	_childId: number,
+	_tenantId: string,
+): Promise<SiblingChallengeProgress | undefined> {
+	return undefined;
+}
+
+export async function upsertProgress(
+	_challengeId: number,
+	_childId: number,
+	_currentValue: number,
+	_targetValue: number,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function markCompleted(
+	_challengeId: number,
+	_childId: number,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function claimReward(
+	_challengeId: number,
+	_childId: number,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function enrollChildren(
+	_challengeId: number,
+	_children: { childId: number; targetValue: number }[],
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/sibling-cheer-repo.ts
+++ b/src/lib/server/db/demo/sibling-cheer-repo.ts
@@ -1,0 +1,41 @@
+// Demo ISiblingCheerRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { InsertSiblingCheerInput, SiblingCheer } from '../types';
+
+export async function insertCheer(
+	input: InsertSiblingCheerInput,
+	tenantId: string,
+): Promise<SiblingCheer> {
+	return {
+		id: 0,
+		fromChildId: input.fromChildId,
+		toChildId: input.toChildId,
+		stampCode: input.stampCode,
+		tenantId,
+		sentAt: new Date().toISOString(),
+		shownAt: null,
+	};
+}
+
+export async function findUnshownCheers(
+	_toChildId: number,
+	_tenantId: string,
+): Promise<SiblingCheer[]> {
+	return [];
+}
+
+export async function markShown(_cheerIds: number[], _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function countTodayCheersFrom(
+	_fromChildId: number,
+	_tenantId: string,
+): Promise<number> {
+	return 0;
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/special-reward-repo.ts
+++ b/src/lib/server/db/demo/special-reward-repo.ts
@@ -1,0 +1,48 @@
+// Demo ISpecialRewardRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { InsertSpecialRewardInput, SpecialReward } from '../types';
+
+export async function insertSpecialReward(
+	input: InsertSpecialRewardInput,
+	_tenantId: string,
+): Promise<SpecialReward> {
+	return {
+		id: 0,
+		childId: input.childId,
+		grantedBy: input.grantedBy ?? null,
+		title: input.title,
+		description: input.description ?? null,
+		points: input.points,
+		icon: input.icon ?? null,
+		category: input.category,
+		grantedAt: new Date().toISOString(),
+		shownAt: null,
+		sourcePresetId: input.sourcePresetId ?? null,
+	};
+}
+
+export async function findSpecialRewards(
+	_childId: number,
+	_tenantId: string,
+): Promise<SpecialReward[]> {
+	return [];
+}
+
+export async function findUnshownReward(
+	_childId: number,
+	_tenantId: string,
+): Promise<SpecialReward | undefined> {
+	return undefined;
+}
+
+export async function markRewardShown(
+	_rewardId: number,
+	_tenantId: string,
+): Promise<SpecialReward | undefined> {
+	return undefined;
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/stamp-card-repo.ts
+++ b/src/lib/server/db/demo/stamp-card-repo.ts
@@ -1,0 +1,72 @@
+// Demo IStampCardRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type {
+	InsertStampCardInput,
+	InsertStampEntryInput,
+	StampCard,
+	StampEntryWithMaster,
+	StampMaster,
+	UpdateStampCardStatusInput,
+} from '../types';
+
+export async function findEnabledStampMasters(_tenantId: string): Promise<StampMaster[]> {
+	return [];
+}
+
+export async function findCardByChildAndWeek(
+	_childId: number,
+	_weekStart: string,
+	_tenantId: string,
+): Promise<StampCard | undefined> {
+	return undefined;
+}
+
+export async function insertCard(
+	input: InsertStampCardInput,
+	_tenantId: string,
+): Promise<StampCard> {
+	const now = new Date().toISOString();
+	return {
+		id: 0,
+		childId: input.childId,
+		weekStart: input.weekStart,
+		weekEnd: input.weekEnd,
+		status: input.status ?? 'collecting',
+		redeemedPoints: null,
+		redeemedAt: null,
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+export async function findEntriesWithMasterByCardId(
+	_cardId: number,
+	_tenantId: string,
+): Promise<StampEntryWithMaster[]> {
+	return [];
+}
+
+export async function insertEntry(_input: InsertStampEntryInput, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function updateCardStatus(
+	_cardId: number,
+	_input: UpdateStampCardStatusInput,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function updateCardStatusIfCollecting(
+	_cardId: number,
+	_input: UpdateStampCardStatusInput,
+	_tenantId: string,
+): Promise<number> {
+	return 0;
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/status-repo.ts
+++ b/src/lib/server/db/demo/status-repo.ts
@@ -22,6 +22,7 @@ export async function findStatus(
 	return DEMO_STATUSES.find((s) => s.childId === childId && s.categoryId === categoryId);
 }
 
+// biome-ignore lint/complexity/useMaxParams: 型安全のため引数を個別定義、別 Issue でオブジェクト引数化予定
 export async function upsertStatus(
 	childId: number,
 	categoryId: number,
@@ -86,6 +87,7 @@ export async function findAllBenchmarks(_tenantId: string): Promise<MarketBenchm
 	return [];
 }
 
+// biome-ignore lint/complexity/useMaxParams: 型安全のため引数を個別定義、別 Issue でオブジェクト引数化予定
 export async function upsertBenchmark(
 	age: number,
 	categoryId: number,

--- a/src/lib/server/db/demo/status-repo.ts
+++ b/src/lib/server/db/demo/status-repo.ts
@@ -1,0 +1,121 @@
+// Demo IStatusRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import { DEMO_CHILDREN, DEMO_STATUSES } from '$lib/server/demo/demo-data';
+import type {
+	Child,
+	InsertStatusHistoryInput,
+	MarketBenchmark,
+	Status,
+	StatusHistoryEntry,
+} from '../types';
+
+export async function findStatuses(childId: number, _tenantId: string): Promise<Status[]> {
+	return DEMO_STATUSES.filter((s) => s.childId === childId);
+}
+
+export async function findStatus(
+	childId: number,
+	categoryId: number,
+	_tenantId: string,
+): Promise<Status | undefined> {
+	return DEMO_STATUSES.find((s) => s.childId === childId && s.categoryId === categoryId);
+}
+
+export async function upsertStatus(
+	childId: number,
+	categoryId: number,
+	totalXp: number,
+	level: number,
+	peakXp: number,
+	_tenantId: string,
+): Promise<Status> {
+	return {
+		id: 0,
+		childId,
+		categoryId,
+		totalXp,
+		level,
+		peakXp,
+		updatedAt: new Date().toISOString(),
+	};
+}
+
+export async function insertStatusHistory(
+	input: InsertStatusHistoryInput,
+	_tenantId: string,
+): Promise<StatusHistoryEntry> {
+	return {
+		id: 0,
+		childId: input.childId,
+		categoryId: input.categoryId,
+		value: input.value,
+		changeAmount: input.changeAmount,
+		changeType: input.changeType,
+		recordedAt: new Date().toISOString(),
+	};
+}
+
+export async function findRecentStatusHistory(
+	_childId: number,
+	_categoryId: number,
+	_tenantId: string,
+	_limit?: number,
+): Promise<StatusHistoryEntry[]> {
+	return [];
+}
+
+export async function findStatusValueAtDate(
+	_childId: number,
+	_categoryId: number,
+	_beforeDate: string,
+	_tenantId: string,
+): Promise<number | null> {
+	return null;
+}
+
+export async function findBenchmark(
+	_age: number,
+	_categoryId: number,
+	_tenantId: string,
+): Promise<MarketBenchmark | undefined> {
+	return undefined;
+}
+
+export async function findAllBenchmarks(_tenantId: string): Promise<MarketBenchmark[]> {
+	return [];
+}
+
+export async function upsertBenchmark(
+	age: number,
+	categoryId: number,
+	mean: number,
+	stdDev: number,
+	source: string,
+	_tenantId: string,
+): Promise<MarketBenchmark> {
+	return {
+		id: 0,
+		age,
+		categoryId,
+		mean,
+		stdDev,
+		source,
+		updatedAt: new Date().toISOString(),
+	};
+}
+
+export async function findChildById(id: number, _tenantId: string): Promise<Child | undefined> {
+	return DEMO_CHILDREN.find((c) => c.id === id);
+}
+
+export async function findLastActivityDates(
+	_childId: number,
+	_tenantId: string,
+): Promise<{ category: number; lastDate: string | null }[]> {
+	return [];
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/storage-repo.ts
+++ b/src/lib/server/db/demo/storage-repo.ts
@@ -1,0 +1,31 @@
+// Demo IStorageRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+//
+// Demo Lambda は S3 等の write 権限を持たない (ADR-0048 §決定 §1: grant: read-only)。
+// アプリレイヤから storage write が来た場合は no-op で受け流す。
+
+import type { FileData } from '../interfaces/storage.interface';
+
+export async function saveFile(_key: string, _data: Buffer, _contentType: string): Promise<void> {
+	// Stub: no-op (Lambda has no S3 write permission)
+}
+
+export async function readFile(_key: string): Promise<FileData | null> {
+	return null;
+}
+
+export async function fileExists(_key: string): Promise<boolean> {
+	return false;
+}
+
+export async function deleteFile(_key: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function listFiles(_prefix: string): Promise<string[]> {
+	return [];
+}
+
+export async function deleteByPrefix(_prefix: string): Promise<number> {
+	return 0;
+}

--- a/src/lib/server/db/demo/tenant-event-repo.ts
+++ b/src/lib/server/db/demo/tenant-event-repo.ts
@@ -1,0 +1,79 @@
+// Demo ITenantEventRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type {
+	InsertTenantEventInput,
+	TenantEvent,
+	TenantEventProgress,
+	UpdateTenantEventInput,
+	UpsertTenantEventProgressInput,
+} from '../types';
+
+export async function findByTenantAndYear(
+	_tenantId: string,
+	_year: number,
+): Promise<TenantEvent[]> {
+	return [];
+}
+
+export async function findByEventCode(
+	_tenantId: string,
+	_eventCode: string,
+	_year: number,
+): Promise<TenantEvent | undefined> {
+	return undefined;
+}
+
+export async function upsertEvent(
+	input: InsertTenantEventInput,
+	tenantId: string,
+): Promise<TenantEvent> {
+	const now = new Date().toISOString();
+	return {
+		id: 0,
+		tenantId,
+		eventCode: input.eventCode,
+		year: input.year,
+		enabled: input.enabled ?? 1,
+		targetOverride: input.targetOverride ?? null,
+		rewardMemo: input.rewardMemo ?? null,
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+export async function updateEvent(
+	_id: number,
+	_input: UpdateTenantEventInput,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function findProgress(
+	_tenantId: string,
+	_eventCode: string,
+	_childId: number,
+	_year: number,
+): Promise<TenantEventProgress | undefined> {
+	return undefined;
+}
+
+export async function findProgressByChild(
+	_childId: number,
+	_year: number,
+	_tenantId: string,
+): Promise<TenantEventProgress[]> {
+	return [];
+}
+
+export async function upsertProgress(
+	_input: UpsertTenantEventProgressInput,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/trial-history-repo.ts
+++ b/src/lib/server/db/demo/trial-history-repo.ts
@@ -1,0 +1,28 @@
+// Demo ITrialHistoryRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type {
+	InsertTrialHistoryInput,
+	TrialHistoryRow,
+	UpdateTrialConversionInput,
+} from '../interfaces/trial-history-repo.interface';
+
+export async function findLatestByTenant(_tenantId: string): Promise<TrialHistoryRow | undefined> {
+	return undefined;
+}
+
+export async function findActiveTrials(): Promise<TrialHistoryRow[]> {
+	return [];
+}
+
+export async function insert(_input: InsertTrialHistoryInput): Promise<void> {
+	// Stub: no-op
+}
+
+export async function updateConversion(_input: UpdateTrialConversionInput): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/viewer-token-repo.ts
+++ b/src/lib/server/db/demo/viewer-token-repo.ts
@@ -1,0 +1,35 @@
+// Demo IViewerTokenRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { InsertViewerTokenInput, ViewerToken } from '../types';
+
+export async function findByTenant(_tenantId: string): Promise<ViewerToken[]> {
+	return [];
+}
+
+export async function findByToken(_token: string): Promise<ViewerToken | undefined> {
+	return undefined;
+}
+
+export async function insert(
+	input: InsertViewerTokenInput,
+	tenantId: string,
+): Promise<ViewerToken> {
+	return {
+		id: 0,
+		tenantId,
+		token: input.token,
+		label: input.label ?? null,
+		expiresAt: input.expiresAt ?? null,
+		createdAt: new Date().toISOString(),
+		revokedAt: null,
+	};
+}
+
+export async function revoke(_id: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteById(_id: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/demo/voice-repo.ts
+++ b/src/lib/server/db/demo/voice-repo.ts
@@ -1,0 +1,48 @@
+// Demo IVoiceRepo implementation
+// ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+
+import type { ChildCustomVoice } from '../types';
+
+export async function findByChild(
+	_childId: number,
+	_scene: string,
+	_tenantId: string,
+): Promise<ChildCustomVoice[]> {
+	return [];
+}
+
+export async function findById(_id: number, _tenantId: string): Promise<ChildCustomVoice | null> {
+	return null;
+}
+
+export async function findActiveVoice(
+	_childId: number,
+	_scene: string,
+	_tenantId: string,
+): Promise<ChildCustomVoice | null> {
+	return null;
+}
+
+export async function insert(
+	_voice: Omit<ChildCustomVoice, 'id' | 'createdAt'>,
+): Promise<{ id: number }> {
+	// Stub: return dummy id
+	return { id: 0 };
+}
+
+export async function setActive(
+	_id: number,
+	_childId: number,
+	_scene: string,
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteById(_id: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
+export async function deleteByChild(_childId: number, _tenantId: string): Promise<void> {
+	// Stub: no-op
+}

--- a/src/lib/server/db/factory.ts
+++ b/src/lib/server/db/factory.ts
@@ -1,6 +1,42 @@
 // src/lib/server/db/factory.ts
-// DATA_SOURCE 環境変数による SQLite / DynamoDB バックエンド切り替え
+// DATA_SOURCE 環境変数による SQLite / DynamoDB / Demo バックエンド切り替え
+// ADR-0048: DATA_SOURCE=demo は Multi-Lambda Demo Deployment (demo.ganbari-quest.com) で使用
+// される stateless fixture provider。production DB / S3 / Cognito へのアクセス権を持たない。
 
+import * as demoAccountLockoutRepo from './demo/account-lockout-repo';
+import * as demoActivityMasteryRepo from './demo/activity-mastery-repo';
+import * as demoActivityPrefRepo from './demo/activity-pref-repo';
+import * as demoActivityRepo from './demo/activity-repo';
+import * as demoAuthRepo from './demo/auth-repo';
+import * as demoAutoChallengeRepo from './demo/auto-challenge-repo';
+import * as demoBattleRepo from './demo/battle-repo';
+import * as demoCancellationReasonRepo from './demo/cancellation-reason-repo';
+import * as demoChecklistRepo from './demo/checklist-repo';
+import * as demoChildRepo from './demo/child-repo';
+import * as demoCloudExportRepo from './demo/cloud-export-repo';
+import * as demoDailyMissionRepo from './demo/daily-mission-repo';
+import * as demoEvaluationRepo from './demo/evaluation-repo';
+import * as demoGraduationConsentRepo from './demo/graduation-consent-repo';
+import * as demoImageRepo from './demo/image-repo';
+import * as demoInquiryRepo from './demo/inquiry-repo';
+import * as demoLoginBonusRepo from './demo/login-bonus-repo';
+import * as demoMessageRepo from './demo/message-repo';
+import * as demoPointRepo from './demo/point-repo';
+import * as demoPushSubscriptionRepo from './demo/push-subscription-repo';
+import * as demoReportDailySummaryRepo from './demo/report-daily-summary-repo';
+import * as demoRewardRedemptionRepo from './demo/reward-redemption-repo';
+import * as demoSeasonEventRepo from './demo/season-event-repo';
+import * as demoSettingsRepo from './demo/settings-repo';
+import * as demoSiblingChallengeRepo from './demo/sibling-challenge-repo';
+import * as demoSiblingCheerRepo from './demo/sibling-cheer-repo';
+import * as demoSpecialRewardRepo from './demo/special-reward-repo';
+import * as demoStampCardRepo from './demo/stamp-card-repo';
+import * as demoStatusRepo from './demo/status-repo';
+import * as demoStorageRepo from './demo/storage-repo';
+import * as demoTenantEventRepo from './demo/tenant-event-repo';
+import * as demoTrialHistoryRepo from './demo/trial-history-repo';
+import * as demoViewerTokenRepo from './demo/viewer-token-repo';
+import * as demoVoiceRepo from './demo/voice-repo';
 import * as dynamoAccountLockoutRepo from './dynamodb/account-lockout-repo';
 import * as dynamoActivityMasteryRepo from './dynamodb/activity-mastery-repo';
 import * as dynamoActivityPrefRepo from './dynamodb/activity-pref-repo';
@@ -147,6 +183,50 @@ export function getRepos(): Repositories {
 	if (_repos) return _repos;
 
 	const dataSource = process.env.DATA_SOURCE ?? 'sqlite';
+	if (dataSource === 'demo') {
+		// ADR-0048: Multi-Lambda Demo Deployment
+		// 全 Repository が stateless fixture provider (read = Fake / write = Stub no-op)。
+		// AWS Lambda Best Practices 公式 anti-pattern (module-level user-specific mutable state) を
+		// 物理的に発生不可能にする。
+		const repos: Repositories = {
+			accountLockout: demoAccountLockoutRepo,
+			autoChallenge: demoAutoChallengeRepo,
+			battle: demoBattleRepo,
+			cancellationReason: demoCancellationReasonRepo,
+			auth: demoAuthRepo,
+			activity: demoActivityRepo,
+			activityMastery: demoActivityMasteryRepo,
+			activityPref: demoActivityPrefRepo,
+			checklist: demoChecklistRepo,
+			child: demoChildRepo,
+			cloudExport: demoCloudExportRepo,
+			dailyMission: demoDailyMissionRepo,
+			evaluation: demoEvaluationRepo,
+			graduationConsent: demoGraduationConsentRepo,
+			image: demoImageRepo,
+			inquiry: demoInquiryRepo,
+			loginBonus: demoLoginBonusRepo,
+			message: demoMessageRepo,
+			point: demoPointRepo,
+			pushSubscription: demoPushSubscriptionRepo,
+			reportDailySummary: demoReportDailySummaryRepo,
+			seasonEvent: demoSeasonEventRepo,
+			siblingChallenge: demoSiblingChallengeRepo,
+			siblingCheer: demoSiblingCheerRepo,
+			settings: demoSettingsRepo,
+			rewardRedemption: demoRewardRedemptionRepo,
+			specialReward: demoSpecialRewardRepo,
+			stampCard: demoStampCardRepo,
+			status: demoStatusRepo,
+			storage: demoStorageRepo,
+			tenantEvent: demoTenantEventRepo,
+			trialHistory: demoTrialHistoryRepo,
+			viewerToken: demoViewerTokenRepo,
+			voice: demoVoiceRepo,
+		};
+		_repos = repos;
+		return repos;
+	}
 	if (dataSource === 'dynamodb') {
 		const repos: Repositories = {
 			accountLockout: dynamoAccountLockoutRepo,

--- a/tests/unit/server/auth/anonymous.test.ts
+++ b/tests/unit/server/auth/anonymous.test.ts
@@ -1,0 +1,108 @@
+// tests/unit/server/auth/anonymous.test.ts
+// ADR-0048 §決定 P-1.6: AnonymousAuthProvider は dummy user `anon-{requestId}` +
+// role='owner' + tenantId='demo' + licenseStatus=ACTIVE を返す。
+
+import type { RequestEvent } from '@sveltejs/kit';
+import { describe, expect, it } from 'vitest';
+import { AnonymousAuthProvider } from '../../../../src/lib/server/auth/providers/anonymous';
+
+function makeEvent(requestId?: string): RequestEvent {
+	const locals = requestId ? { requestId } : {};
+	return {
+		locals,
+		url: new URL('http://localhost/'),
+	} as unknown as RequestEvent;
+}
+
+describe('AnonymousAuthProvider (ADR-0048 §決定 P-1.6)', () => {
+	const provider = new AnonymousAuthProvider();
+
+	describe('resolveIdentity', () => {
+		it('locals.requestId が設定されていれば anon-{requestId} を返す', async () => {
+			const event = makeEvent('req-12345');
+			const identity = await provider.resolveIdentity(event);
+			expect(identity).toBeDefined();
+			expect(identity.type).toBe('anonymous');
+			if (identity.type === 'anonymous') {
+				expect(identity.userId).toBe('anon-req-12345');
+				expect(identity.email).toBe('anon@demo.local');
+			}
+		});
+
+		it('locals.requestId 未設定でも fallback で identity を返す', async () => {
+			const event = makeEvent();
+			const identity = await provider.resolveIdentity(event);
+			expect(identity.type).toBe('anonymous');
+			if (identity.type === 'anonymous') {
+				expect(identity.userId).toMatch(/^anon-/);
+			}
+		});
+
+		it('複数回呼び出しでも常に anonymous type を返す', async () => {
+			const event = makeEvent('req-A');
+			const a = await provider.resolveIdentity(event);
+			const b = await provider.resolveIdentity(event);
+			expect(a.type).toBe('anonymous');
+			expect(b.type).toBe('anonymous');
+			if (a.type === 'anonymous' && b.type === 'anonymous') {
+				expect(a.userId).toBe(b.userId);
+			}
+		});
+	});
+
+	describe('resolveContext', () => {
+		it('tenantId="demo" / role="owner" / licenseStatus="active" を返す', async () => {
+			const event = makeEvent('req-1');
+			const context = await provider.resolveContext(event, null);
+			expect(context).toBeDefined();
+			expect(context.tenantId).toBe('demo');
+			expect(context.role).toBe('owner');
+			expect(context.licenseStatus).toBe('active');
+			expect(context.tenantStatus).toBe('active');
+		});
+
+		it('identity の中身に依存しない (常に固定 context)', async () => {
+			const event = makeEvent('req-1');
+			const identity = await provider.resolveIdentity(event);
+			const a = await provider.resolveContext(event, identity);
+			const b = await provider.resolveContext(event, null);
+			expect(a).toEqual(b);
+		});
+	});
+
+	describe('authorize (demo Lambda は全 path allow)', () => {
+		it('admin path は allow', () => {
+			const result = provider.authorize('/admin/home', null, null);
+			expect(result.allowed).toBe(true);
+		});
+
+		it('child path は allow', () => {
+			const result = provider.authorize('/elementary/home', null, null);
+			expect(result.allowed).toBe(true);
+		});
+
+		it('ops path も allow (見せるだけ)', () => {
+			const result = provider.authorize('/ops/dashboard', null, null);
+			expect(result.allowed).toBe(true);
+		});
+
+		it('未認証扱いの auth path も allow (demo は完全 stateless)', () => {
+			const result = provider.authorize('/auth/login', null, null);
+			expect(result.allowed).toBe(true);
+		});
+	});
+
+	describe('stateless 検証 (AWS Lambda Best Practices)', () => {
+		it('複数 event に対し独立した identity を発行する (cross-request leak なし)', async () => {
+			const eventA = makeEvent('req-A');
+			const eventB = makeEvent('req-B');
+			const idA = await provider.resolveIdentity(eventA);
+			const idB = await provider.resolveIdentity(eventB);
+			if (idA.type === 'anonymous' && idB.type === 'anonymous') {
+				expect(idA.userId).toBe('anon-req-A');
+				expect(idB.userId).toBe('anon-req-B');
+				expect(idA.userId).not.toBe(idB.userId);
+			}
+		});
+	});
+});

--- a/tests/unit/server/db/demo/activity-repo.test.ts
+++ b/tests/unit/server/db/demo/activity-repo.test.ts
@@ -1,0 +1,131 @@
+// tests/unit/server/db/demo/activity-repo.test.ts
+// ADR-0048 §決定 §2: demo Activity Repo の Fake (read) + Stub (write) hybrid 検証。
+
+import { describe, expect, it } from 'vitest';
+import * as activityRepo from '../../../../../src/lib/server/db/demo/activity-repo';
+import {
+	DEMO_ACTIVITIES,
+	DEMO_ACTIVITY_LOGS,
+} from '../../../../../src/lib/server/demo/demo-data';
+
+describe('demo/activity-repo', () => {
+	describe('read API', () => {
+		it('findActivities は visible activity を返す', async () => {
+			const all = await activityRepo.findActivities('demo');
+			expect(all.length).toBeGreaterThan(0);
+			expect(all.every((a) => a.isVisible === 1)).toBe(true);
+		});
+
+		it('findActivities (filter: categoryId=1) は categoryId=1 のみ', async () => {
+			const filtered = await activityRepo.findActivities('demo', { categoryId: 1 });
+			expect(filtered.length).toBeGreaterThan(0);
+			expect(filtered.every((a) => a.categoryId === 1)).toBe(true);
+		});
+
+		it('findActivities (filter: childAge=8) は ageRange に合う activity のみ', async () => {
+			const filtered = await activityRepo.findActivities('demo', { childAge: 8 });
+			expect(
+				filtered.every(
+					(a) =>
+						(a.ageMin === null || a.ageMin <= 8) && (a.ageMax === null || a.ageMax >= 8),
+				),
+			).toBe(true);
+		});
+
+		it('findActivityById は fixture から該当 activity を返す', async () => {
+			const sample = DEMO_ACTIVITIES[0];
+			expect(sample).toBeDefined();
+			if (!sample) return;
+			const fetched = await activityRepo.findActivityById(sample.id, 'demo');
+			expect(fetched).toEqual(sample);
+		});
+
+		it('hasActivityLogs は existing activityId に対し true', async () => {
+			const sample = DEMO_ACTIVITY_LOGS[0];
+			expect(sample).toBeDefined();
+			if (!sample) return;
+			const result = await activityRepo.hasActivityLogs(sample.activityId, 'demo');
+			expect(result).toBe(true);
+		});
+
+		it('countActiveActivityLogs は cancelled=0 のみカウント', async () => {
+			const count = await activityRepo.countActiveActivityLogs(902, 'demo');
+			const expected = DEMO_ACTIVITY_LOGS.filter(
+				(l) => l.childId === 902 && l.cancelled === 0,
+			).length;
+			expect(count).toBe(expected);
+		});
+
+		it('findActivityLogs は ActivityLogSummary で activityName / activityIcon を含む', async () => {
+			const logs = await activityRepo.findActivityLogs(902, 'demo');
+			expect(logs.length).toBeGreaterThan(0);
+			expect(logs[0]).toHaveProperty('activityName');
+			expect(logs[0]).toHaveProperty('activityIcon');
+			expect(logs[0]).toHaveProperty('categoryId');
+		});
+	});
+
+	describe('write API', () => {
+		it('insertActivity は input から Activity を返すが fixture を mutate しない', async () => {
+			const before = DEMO_ACTIVITIES.length;
+			const created = await activityRepo.insertActivity(
+				{ name: 'test', categoryId: 1, icon: '🧪', basePoints: 5, ageMin: 3, ageMax: 10 },
+				'demo',
+			);
+			expect(created.name).toBe('test');
+			expect(DEMO_ACTIVITIES.length).toBe(before);
+		});
+
+		it('insertActivityLog は ActivityLog を返す (no-op for fixture)', async () => {
+			const before = DEMO_ACTIVITY_LOGS.length;
+			const log = await activityRepo.insertActivityLog(
+				{
+					childId: 902,
+					activityId: 1,
+					points: 5,
+					streakDays: 0,
+					streakBonus: 0,
+					recordedDate: '2026-04-01',
+					recordedAt: '2026-04-01T10:00:00.000Z',
+				},
+				'demo',
+			);
+			expect(log.points).toBe(5);
+			expect(DEMO_ACTIVITY_LOGS.length).toBe(before);
+		});
+
+		it('insertPointLedger / deleteActivity / archiveActivities は no-op で例外を投げない', async () => {
+			await expect(
+				activityRepo.insertPointLedger(
+					{ childId: 902, amount: 10, type: 'test', description: 'noop' },
+					'demo',
+				),
+			).resolves.toBeUndefined();
+			await expect(activityRepo.deleteActivity(99999, 'demo')).resolves.toBeUndefined();
+			await expect(
+				activityRepo.archiveActivities([1], 'test', 'demo'),
+			).resolves.toBeUndefined();
+		});
+
+		it('deleteActivityLogsBeforeDate は 0 件削除を返す (stateless)', async () => {
+			const result = await activityRepo.deleteActivityLogsBeforeDate(
+				902,
+				'2020-01-01',
+				'demo',
+			);
+			expect(result).toBe(0);
+		});
+	});
+
+	describe('aggregation queries (Fake)', () => {
+		it('countDistinctCategories は demo log の category 集合サイズ', async () => {
+			const count = await activityRepo.countDistinctCategories(902, 'demo');
+			expect(count).toBeGreaterThanOrEqual(0);
+		});
+
+		it('getCategoryCountsByDate は recordedDate → categoryCount mapping', async () => {
+			const result = await activityRepo.getCategoryCountsByDate(902, 'demo');
+			expect(Array.isArray(result)).toBe(true);
+		});
+	});
+});

--- a/tests/unit/server/db/demo/activity-repo.test.ts
+++ b/tests/unit/server/db/demo/activity-repo.test.ts
@@ -3,10 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 import * as activityRepo from '../../../../../src/lib/server/db/demo/activity-repo';
-import {
-	DEMO_ACTIVITIES,
-	DEMO_ACTIVITY_LOGS,
-} from '../../../../../src/lib/server/demo/demo-data';
+import { DEMO_ACTIVITIES, DEMO_ACTIVITY_LOGS } from '../../../../../src/lib/server/demo/demo-data';
 
 describe('demo/activity-repo', () => {
 	describe('read API', () => {
@@ -26,8 +23,7 @@ describe('demo/activity-repo', () => {
 			const filtered = await activityRepo.findActivities('demo', { childAge: 8 });
 			expect(
 				filtered.every(
-					(a) =>
-						(a.ageMin === null || a.ageMin <= 8) && (a.ageMax === null || a.ageMax >= 8),
+					(a) => (a.ageMin === null || a.ageMin <= 8) && (a.ageMax === null || a.ageMax >= 8),
 				),
 			).toBe(true);
 		});
@@ -102,17 +98,11 @@ describe('demo/activity-repo', () => {
 				),
 			).resolves.toBeUndefined();
 			await expect(activityRepo.deleteActivity(99999, 'demo')).resolves.toBeUndefined();
-			await expect(
-				activityRepo.archiveActivities([1], 'test', 'demo'),
-			).resolves.toBeUndefined();
+			await expect(activityRepo.archiveActivities([1], 'test', 'demo')).resolves.toBeUndefined();
 		});
 
 		it('deleteActivityLogsBeforeDate は 0 件削除を返す (stateless)', async () => {
-			const result = await activityRepo.deleteActivityLogsBeforeDate(
-				902,
-				'2020-01-01',
-				'demo',
-			);
+			const result = await activityRepo.deleteActivityLogsBeforeDate(902, '2020-01-01', 'demo');
 			expect(result).toBe(0);
 		});
 	});

--- a/tests/unit/server/db/demo/auth-repo.test.ts
+++ b/tests/unit/server/db/demo/auth-repo.test.ts
@@ -3,6 +3,7 @@
 // を返す。production Cognito UserPool には IAM 上アクセスできない。
 
 import { describe, expect, it } from 'vitest';
+import { SUBSCRIPTION_STATUS } from '../../../../../src/lib/domain/constants/subscription-status';
 import * as authRepo from '../../../../../src/lib/server/db/demo/auth-repo';
 
 describe('demo/auth-repo', () => {
@@ -26,7 +27,9 @@ describe('demo/auth-repo', () => {
 		});
 
 		it('updateTenantStatus / deleteTenant は no-op で例外を投げない', async () => {
-			await expect(authRepo.updateTenantStatus('demo', 'cancelled')).resolves.toBeUndefined();
+			await expect(
+				authRepo.updateTenantStatus('demo', SUBSCRIPTION_STATUS.TERMINATED),
+			).resolves.toBeUndefined();
 			await expect(authRepo.deleteTenant('demo')).resolves.toBeUndefined();
 		});
 	});

--- a/tests/unit/server/db/demo/auth-repo.test.ts
+++ b/tests/unit/server/db/demo/auth-repo.test.ts
@@ -1,0 +1,96 @@
+// tests/unit/server/db/demo/auth-repo.test.ts
+// ADR-0048 §決定 §2: demo Auth Repo は anonymous auth 用に最小限の dummy Tenant / Membership
+// を返す。production Cognito UserPool には IAM 上アクセスできない。
+
+import { describe, expect, it } from 'vitest';
+import * as authRepo from '../../../../../src/lib/server/db/demo/auth-repo';
+
+describe('demo/auth-repo', () => {
+	describe('Tenant (demo tenant のみ存在)', () => {
+		it('findTenantById("demo") は dummy Tenant を返す', async () => {
+			const tenant = await authRepo.findTenantById('demo');
+			expect(tenant).toBeDefined();
+			expect(tenant?.tenantId).toBe('demo');
+			expect(tenant?.name).toContain('デモ');
+			expect(tenant?.status).toBe('active');
+		});
+
+		it('findTenantById(他 id) は undefined', async () => {
+			expect(await authRepo.findTenantById('other')).toBeUndefined();
+		});
+
+		it('listAllTenants は demo 1 件のみ', async () => {
+			const all = await authRepo.listAllTenants();
+			expect(all.length).toBe(1);
+			expect(all[0]?.tenantId).toBe('demo');
+		});
+
+		it('updateTenantStatus / deleteTenant は no-op で例外を投げない', async () => {
+			await expect(authRepo.updateTenantStatus('demo', 'cancelled')).resolves.toBeUndefined();
+			await expect(authRepo.deleteTenant('demo')).resolves.toBeUndefined();
+		});
+	});
+
+	describe('User (常に存在しない)', () => {
+		it('findUserById / findUserByEmail は undefined を返す', async () => {
+			expect(await authRepo.findUserById('any')).toBeUndefined();
+			expect(await authRepo.findUserByEmail('any@example.com')).toBeUndefined();
+		});
+
+		it('createUser は input から AuthUser を返す (no-op for fixture)', async () => {
+			const user = await authRepo.createUser({
+				email: 'test@example.com',
+				provider: 'cognito',
+			});
+			expect(user.email).toBe('test@example.com');
+			expect(user.userId).toBeTruthy();
+		});
+	});
+
+	describe('Membership (demo tenant のみ)', () => {
+		it('findMembership(demo) は owner role を返す', async () => {
+			const membership = await authRepo.findMembership('any-user', 'demo');
+			expect(membership).toBeDefined();
+			expect(membership?.role).toBe('owner');
+			expect(membership?.tenantId).toBe('demo');
+		});
+
+		it('findMembership(他 tenant) は undefined', async () => {
+			expect(await authRepo.findMembership('any', 'other')).toBeUndefined();
+		});
+	});
+
+	describe('License Key (常に存在しない、demo Lambda は Secrets Manager 権限なし)', () => {
+		it('findLicenseKey は undefined を返す', async () => {
+			expect(await authRepo.findLicenseKey('any-key')).toBeUndefined();
+		});
+
+		it('listLicenseKeysByTenant は空ページを返す', async () => {
+			const page = await authRepo.listLicenseKeysByTenant('demo');
+			expect(page).toEqual({ items: [], cursor: null });
+		});
+
+		it('countLicenseKeys は 0', async () => {
+			expect(await authRepo.countLicenseKeys()).toBe(0);
+		});
+	});
+
+	describe('Consent (Stub)', () => {
+		it('recordConsent は input から ConsentRecord を返す (no-op)', async () => {
+			const consent = await authRepo.recordConsent({
+				tenantId: 'demo',
+				userId: 'any',
+				type: 'terms',
+				version: 'v1',
+				ipAddress: '127.0.0.1',
+				userAgent: 'test',
+			});
+			expect(consent.type).toBe('terms');
+			expect(consent.version).toBe('v1');
+		});
+
+		it('findLatestConsent は undefined を返す', async () => {
+			expect(await authRepo.findLatestConsent('demo', 'terms')).toBeUndefined();
+		});
+	});
+});

--- a/tests/unit/server/db/demo/checklist-repo.test.ts
+++ b/tests/unit/server/db/demo/checklist-repo.test.ts
@@ -24,9 +24,7 @@ describe('demo/checklist-repo', () => {
 	});
 
 	it('findTodayLog は undefined (fixture なし)', async () => {
-		expect(
-			await checklistRepo.findTodayLog(904, 904, '2026-04-01', 'demo'),
-		).toBeUndefined();
+		expect(await checklistRepo.findTodayLog(904, 904, '2026-04-01', 'demo')).toBeUndefined();
 	});
 
 	it('insertTemplate は no-op で fixture mutate なし', async () => {

--- a/tests/unit/server/db/demo/checklist-repo.test.ts
+++ b/tests/unit/server/db/demo/checklist-repo.test.ts
@@ -1,0 +1,50 @@
+// tests/unit/server/db/demo/checklist-repo.test.ts
+
+import { describe, expect, it } from 'vitest';
+import * as checklistRepo from '../../../../../src/lib/server/db/demo/checklist-repo';
+import {
+	DEMO_CHECKLIST_ITEMS,
+	DEMO_CHECKLIST_TEMPLATES,
+} from '../../../../../src/lib/server/demo/demo-data';
+
+describe('demo/checklist-repo', () => {
+	it('findTemplatesByChild は child の active テンプレートを返す', async () => {
+		// 904 (junior) は 中学生の登校準備 テンプレートを持つ
+		const templates = await checklistRepo.findTemplatesByChild(904, 'demo');
+		expect(templates.length).toBeGreaterThan(0);
+		expect(templates.every((t) => t.childId === 904)).toBe(true);
+		expect(templates.every((t) => t.isActive === 1)).toBe(true);
+	});
+
+	it('findTemplateItems はテンプレートの items を返す', async () => {
+		// テンプレート 900 (おでかけのじゅんび) の items
+		const items = await checklistRepo.findTemplateItems(900, 'demo');
+		expect(items.length).toBeGreaterThan(0);
+		expect(items.every((i) => i.templateId === 900)).toBe(true);
+	});
+
+	it('findTodayLog は undefined (fixture なし)', async () => {
+		expect(
+			await checklistRepo.findTodayLog(904, 904, '2026-04-01', 'demo'),
+		).toBeUndefined();
+	});
+
+	it('insertTemplate は no-op で fixture mutate なし', async () => {
+		const before = DEMO_CHECKLIST_TEMPLATES.length;
+		const created = await checklistRepo.insertTemplate(
+			{ childId: 904, name: 'test-template' },
+			'demo',
+		);
+		expect(created.name).toBe('test-template');
+		expect(DEMO_CHECKLIST_TEMPLATES.length).toBe(before);
+	});
+
+	it('deleteTemplate / deleteTemplateItem は no-op', async () => {
+		const before = DEMO_CHECKLIST_TEMPLATES.length;
+		await checklistRepo.deleteTemplate(900, 'demo');
+		expect(DEMO_CHECKLIST_TEMPLATES.length).toBe(before);
+		const beforeItems = DEMO_CHECKLIST_ITEMS.length;
+		await checklistRepo.deleteTemplateItem(20, 'demo');
+		expect(DEMO_CHECKLIST_ITEMS.length).toBe(beforeItems);
+	});
+});

--- a/tests/unit/server/db/demo/child-repo.test.ts
+++ b/tests/unit/server/db/demo/child-repo.test.ts
@@ -48,10 +48,7 @@ describe('demo/child-repo', () => {
 	describe('write API (Stub — no-op、fixture mutation なし)', () => {
 		it('insertChild は input から minimal Child を返すが fixture を変更しない', async () => {
 			const before = DEMO_CHILDREN.length;
-			const created = await childRepo.insertChild(
-				{ nickname: 'テスト太郎', age: 7 },
-				'demo',
-			);
+			const created = await childRepo.insertChild({ nickname: 'テスト太郎', age: 7 }, 'demo');
 			expect(created.nickname).toBe('テスト太郎');
 			expect(created.age).toBe(7);
 			// ADR-0048 §決定 §2: fixture は immutable

--- a/tests/unit/server/db/demo/child-repo.test.ts
+++ b/tests/unit/server/db/demo/child-repo.test.ts
@@ -1,0 +1,97 @@
+// tests/unit/server/db/demo/child-repo.test.ts
+// ADR-0048 §決定 §2: demo Repository は stateless Fake (read) + Stub (write) hybrid。
+// 本 test では fixture から read される件 / write が no-op で fixture を mutate しないこと
+// を検証する。AWS Lambda Best Practices 公式 anti-pattern (mutable module-level state)
+// が物理的に発生不可能であることをユニットレベルで担保する。
+
+import { describe, expect, it } from 'vitest';
+import * as childRepo from '../../../../../src/lib/server/db/demo/child-repo';
+import { DEMO_CHILDREN } from '../../../../../src/lib/server/demo/demo-data';
+
+describe('demo/child-repo', () => {
+	describe('read API (Fake — fixture 経由)', () => {
+		it('findAllChildren は demo-data の Children fixture を返す', async () => {
+			const all = await childRepo.findAllChildren('demo');
+			expect(all.length).toBeGreaterThanOrEqual(5);
+			const ids = all.map((c) => c.id);
+			expect(ids).toContain(901);
+			expect(ids).toContain(902);
+			expect(ids).toContain(903);
+			expect(ids).toContain(904);
+			expect(ids).toContain(906);
+		});
+
+		it('findChildById で 902 (ゆうきちゃん) が見つかる', async () => {
+			const child = await childRepo.findChildById(902, 'demo');
+			expect(child).toBeDefined();
+			expect(child?.nickname).toBe('ゆうきちゃん');
+			expect(child?.age).toBe(5);
+			expect(child?.theme).toBe('pink');
+		});
+
+		it('findChildById で存在しない ID は undefined', async () => {
+			const child = await childRepo.findChildById(99999, 'demo');
+			expect(child).toBeUndefined();
+		});
+
+		it('findArchivedChildren は archived=1 のみ返す (fixture では空)', async () => {
+			const archived = await childRepo.findArchivedChildren('demo');
+			expect(archived).toEqual([]);
+		});
+
+		it('findChildByUserId で userId=null の fixture は見つからない', async () => {
+			const child = await childRepo.findChildByUserId('some-user', 'demo');
+			expect(child).toBeUndefined();
+		});
+	});
+
+	describe('write API (Stub — no-op、fixture mutation なし)', () => {
+		it('insertChild は input から minimal Child を返すが fixture を変更しない', async () => {
+			const before = DEMO_CHILDREN.length;
+			const created = await childRepo.insertChild(
+				{ nickname: 'テスト太郎', age: 7 },
+				'demo',
+			);
+			expect(created.nickname).toBe('テスト太郎');
+			expect(created.age).toBe(7);
+			// ADR-0048 §決定 §2: fixture は immutable
+			expect(DEMO_CHILDREN.length).toBe(before);
+		});
+
+		it('updateChild は no-op で fixture mutation なし', async () => {
+			const originalNickname = DEMO_CHILDREN.find((c) => c.id === 902)?.nickname;
+			await childRepo.updateChild(902, { nickname: 'mutated' }, 'demo');
+			const after = DEMO_CHILDREN.find((c) => c.id === 902)?.nickname;
+			expect(after).toBe(originalNickname);
+		});
+
+		it('deleteChild は no-op で fixture mutation なし', async () => {
+			const before = DEMO_CHILDREN.length;
+			await childRepo.deleteChild(902, 'demo');
+			expect(DEMO_CHILDREN.length).toBe(before);
+			expect(DEMO_CHILDREN.find((c) => c.id === 902)).toBeDefined();
+		});
+
+		it('archiveChildren / restoreArchivedChildren は no-op で例外を投げない', async () => {
+			await expect(childRepo.archiveChildren([902], 'test', 'demo')).resolves.toBeUndefined();
+			await expect(childRepo.restoreArchivedChildren('test', 'demo')).resolves.toBeUndefined();
+		});
+	});
+
+	describe('module-level state 検証 (AWS Lambda Best Practices)', () => {
+		it('連続 read 呼び出しで結果が等値である (idempotent / stateless)', async () => {
+			const a = await childRepo.findAllChildren('demo');
+			const b = await childRepo.findAllChildren('demo');
+			expect(a.length).toBe(b.length);
+			expect(a.map((c) => c.id)).toEqual(b.map((c) => c.id));
+		});
+
+		it('write → read で fixture 値が変化しない (mutable singleton anti-pattern 回避)', async () => {
+			const before = (await childRepo.findChildById(901, 'demo'))?.nickname;
+			await childRepo.insertChild({ nickname: '新しい', age: 3 }, 'demo');
+			await childRepo.updateChild(901, { nickname: 'mutated' }, 'demo');
+			const after = (await childRepo.findChildById(901, 'demo'))?.nickname;
+			expect(after).toBe(before);
+		});
+	});
+});

--- a/tests/unit/server/db/demo/daily-mission-repo.test.ts
+++ b/tests/unit/server/db/demo/daily-mission-repo.test.ts
@@ -1,0 +1,47 @@
+// tests/unit/server/db/demo/daily-mission-repo.test.ts
+
+import { describe, expect, it } from 'vitest';
+import * as dailyMissionRepo from '../../../../../src/lib/server/db/demo/daily-mission-repo';
+import {
+	DEMO_DAILY_MISSIONS,
+} from '../../../../../src/lib/server/demo/demo-data';
+
+describe('demo/daily-mission-repo', () => {
+	it('findTodayMissions は当該日 + child のミッションを返し、activityName/activityIcon を含む', async () => {
+		const sample = DEMO_DAILY_MISSIONS[0];
+		expect(sample).toBeDefined();
+		if (!sample) return;
+		const missions = await dailyMissionRepo.findTodayMissions(
+			sample.childId,
+			sample.missionDate,
+			'demo',
+		);
+		expect(missions.length).toBeGreaterThan(0);
+		expect(missions[0]).toHaveProperty('activityName');
+		expect(missions[0]).toHaveProperty('activityIcon');
+	});
+
+	it('findVisibleActivities は visible activity のみ返す', async () => {
+		const activities = await dailyMissionRepo.findVisibleActivities('demo');
+		expect(activities.every((a) => a.isVisible === 1)).toBe(true);
+	});
+
+	it('markMissionCompleted / insertDailyMission は no-op で fixture mutate なし', async () => {
+		const before = DEMO_DAILY_MISSIONS.length;
+		await dailyMissionRepo.markMissionCompleted(1, 'demo');
+		await dailyMissionRepo.insertDailyMission(902, '2026-04-01', 1, 'demo');
+		expect(DEMO_DAILY_MISSIONS.length).toBe(before);
+	});
+
+	it('findAllMissionStatuses は child + date でフィルタ済み', async () => {
+		const sample = DEMO_DAILY_MISSIONS[0];
+		expect(sample).toBeDefined();
+		if (!sample) return;
+		const statuses = await dailyMissionRepo.findAllMissionStatuses(
+			sample.childId,
+			sample.missionDate,
+			'demo',
+		);
+		expect(statuses.length).toBeGreaterThan(0);
+	});
+});

--- a/tests/unit/server/db/demo/daily-mission-repo.test.ts
+++ b/tests/unit/server/db/demo/daily-mission-repo.test.ts
@@ -2,9 +2,7 @@
 
 import { describe, expect, it } from 'vitest';
 import * as dailyMissionRepo from '../../../../../src/lib/server/db/demo/daily-mission-repo';
-import {
-	DEMO_DAILY_MISSIONS,
-} from '../../../../../src/lib/server/demo/demo-data';
+import { DEMO_DAILY_MISSIONS } from '../../../../../src/lib/server/demo/demo-data';
 
 describe('demo/daily-mission-repo', () => {
 	it('findTodayMissions は当該日 + child のミッションを返し、activityName/activityIcon を含む', async () => {

--- a/tests/unit/server/db/demo/point-repo.test.ts
+++ b/tests/unit/server/db/demo/point-repo.test.ts
@@ -1,0 +1,48 @@
+// tests/unit/server/db/demo/point-repo.test.ts
+// ADR-0048 §決定 §2: demo Point Repo の Fake (read) + Stub (write) hybrid 検証。
+
+import { describe, expect, it } from 'vitest';
+import * as pointRepo from '../../../../../src/lib/server/db/demo/point-repo';
+import { DEMO_POINT_BALANCES } from '../../../../../src/lib/server/demo/demo-data';
+
+describe('demo/point-repo', () => {
+	it('getBalance は fixture の POINT_BALANCES を返す', async () => {
+		const balance = await pointRepo.getBalance(902, 'demo');
+		expect(balance).toBe(DEMO_POINT_BALANCES[902]);
+	});
+
+	it('getBalance は未定義 child に対し 0 を返す', async () => {
+		const balance = await pointRepo.getBalance(99999, 'demo');
+		expect(balance).toBe(0);
+	});
+
+	it('findChildById は demo Children から返す', async () => {
+		const child = await pointRepo.findChildById(902, 'demo');
+		expect(child).toBeDefined();
+		expect(child?.id).toBe(902);
+	});
+
+	it('findPointHistory は空配列を返す (fixture なし)', async () => {
+		const history = await pointRepo.findPointHistory(
+			902,
+			{ limit: 10, offset: 0 },
+			'demo',
+		);
+		expect(history).toEqual([]);
+	});
+
+	it('insertPointEntry は input から PointLedgerEntry を返す (no-op)', async () => {
+		const before = DEMO_POINT_BALANCES[902];
+		const entry = await pointRepo.insertPointEntry(
+			{ childId: 902, amount: 50, type: 'test', description: 'noop' },
+			'demo',
+		);
+		expect(entry.amount).toBe(50);
+		// ADR-0048 §決定 §2: fixture は immutable
+		expect(DEMO_POINT_BALANCES[902]).toBe(before);
+	});
+
+	it('deletePointLedgerBeforeDate は 0 を返す (stateless)', async () => {
+		expect(await pointRepo.deletePointLedgerBeforeDate(902, '2020-01-01', 'demo')).toBe(0);
+	});
+});

--- a/tests/unit/server/db/demo/point-repo.test.ts
+++ b/tests/unit/server/db/demo/point-repo.test.ts
@@ -23,11 +23,7 @@ describe('demo/point-repo', () => {
 	});
 
 	it('findPointHistory は空配列を返す (fixture なし)', async () => {
-		const history = await pointRepo.findPointHistory(
-			902,
-			{ limit: 10, offset: 0 },
-			'demo',
-		);
+		const history = await pointRepo.findPointHistory(902, { limit: 10, offset: 0 }, 'demo');
 		expect(history).toEqual([]);
 	});
 

--- a/tests/unit/server/db/demo/settings-repo.test.ts
+++ b/tests/unit/server/db/demo/settings-repo.test.ts
@@ -1,0 +1,38 @@
+// tests/unit/server/db/demo/settings-repo.test.ts
+// ADR-0048 §決定 §2: demo Settings Repo は完全 stateless (write は no-op)。
+// 「demo で記録 → リロードで保持」は client sessionStorage 限定 (§決定 P-1.1) であり、
+// Lambda 側で settings table に書き込むことはない。
+
+import { describe, expect, it } from 'vitest';
+import * as settingsRepo from '../../../../../src/lib/server/db/demo/settings-repo';
+
+describe('demo/settings-repo', () => {
+	it('getSetting は常に undefined (fixture なし、Lambda stateless)', async () => {
+		expect(await settingsRepo.getSetting('any-key', 'demo')).toBeUndefined();
+	});
+
+	it('getSettings は空 record を返す', async () => {
+		const result = await settingsRepo.getSettings(['k1', 'k2', 'k3'], 'demo');
+		expect(result).toEqual({});
+	});
+
+	it('setSetting は no-op (例外を投げない、副作用なし)', async () => {
+		await expect(settingsRepo.setSetting('foo', 'bar', 'demo')).resolves.toBeUndefined();
+		// 即座に読み取っても、書き込んだ値は永続化されない
+		expect(await settingsRepo.getSetting('foo', 'demo')).toBeUndefined();
+	});
+
+	it('setSetting を連続呼び出ししても module-level state が mutate されない', async () => {
+		await settingsRepo.setSetting('key1', 'value1', 'demo');
+		await settingsRepo.setSetting('key2', 'value2', 'demo');
+		await settingsRepo.setSetting('key3', 'value3', 'demo');
+		// すべて読み取り不可 (AWS Lambda Best Practices: no mutable module-level state)
+		expect(await settingsRepo.getSetting('key1', 'demo')).toBeUndefined();
+		expect(await settingsRepo.getSetting('key2', 'demo')).toBeUndefined();
+		expect(await settingsRepo.getSetting('key3', 'demo')).toBeUndefined();
+	});
+
+	it('deleteByTenantId は no-op', async () => {
+		await expect(settingsRepo.deleteByTenantId('demo')).resolves.toBeUndefined();
+	});
+});

--- a/tests/unit/server/db/demo/status-repo.test.ts
+++ b/tests/unit/server/db/demo/status-repo.test.ts
@@ -1,0 +1,47 @@
+// tests/unit/server/db/demo/status-repo.test.ts
+// ADR-0048 §決定 §2: demo Status Repo の Fake (read) + Stub (write) hybrid 検証。
+
+import { describe, expect, it } from 'vitest';
+import * as statusRepo from '../../../../../src/lib/server/db/demo/status-repo';
+import { DEMO_STATUSES } from '../../../../../src/lib/server/demo/demo-data';
+
+describe('demo/status-repo', () => {
+	it('findStatuses は child の 5 軸 Status を返す (fixture: 902)', async () => {
+		const statuses = await statusRepo.findStatuses(902, 'demo');
+		expect(statuses.length).toBe(5);
+		expect(statuses.every((s) => s.childId === 902)).toBe(true);
+	});
+
+	it('findStatus は categoryId 指定で 1 件返す', async () => {
+		const status = await statusRepo.findStatus(902, 1, 'demo');
+		expect(status).toBeDefined();
+		expect(status?.childId).toBe(902);
+		expect(status?.categoryId).toBe(1);
+	});
+
+	it('upsertStatus は input から Status を返すが fixture を mutate しない', async () => {
+		const before = DEMO_STATUSES.length;
+		const upserted = await statusRepo.upsertStatus(902, 1, 999, 99, 1000, 'demo');
+		expect(upserted.totalXp).toBe(999);
+		expect(upserted.level).toBe(99);
+		// ADR-0048 §決定 §2: fixture は immutable
+		expect(DEMO_STATUSES.length).toBe(before);
+		// 元の値が変わっていないことを確認
+		const original = await statusRepo.findStatus(902, 1, 'demo');
+		expect(original?.level).not.toBe(99);
+	});
+
+	it('findBenchmark / findAllBenchmarks は空を返す', async () => {
+		expect(await statusRepo.findBenchmark(8, 1, 'demo')).toBeUndefined();
+		expect(await statusRepo.findAllBenchmarks('demo')).toEqual([]);
+	});
+
+	it('insertStatusHistory は input から StatusHistoryEntry を返す (no-op)', async () => {
+		const entry = await statusRepo.insertStatusHistory(
+			{ childId: 902, categoryId: 1, value: 100, changeAmount: 5, changeType: 'gain' },
+			'demo',
+		);
+		expect(entry.childId).toBe(902);
+		expect(entry.changeAmount).toBe(5);
+	});
+});

--- a/tests/unit/server/db/demo/stub-repos.test.ts
+++ b/tests/unit/server/db/demo/stub-repos.test.ts
@@ -1,0 +1,302 @@
+// tests/unit/server/db/demo/stub-repos.test.ts
+// ADR-0048 §決定 §2: 残り全 Stub Repository (no fixture content) について、
+// read API が空 / write API が no-op であり、いずれも例外を投げないことを一括検証。
+
+import { describe, expect, it } from 'vitest';
+import * as accountLockoutRepo from '../../../../../src/lib/server/db/demo/account-lockout-repo';
+import * as activityMasteryRepo from '../../../../../src/lib/server/db/demo/activity-mastery-repo';
+import * as activityPrefRepo from '../../../../../src/lib/server/db/demo/activity-pref-repo';
+import * as autoChallengeRepo from '../../../../../src/lib/server/db/demo/auto-challenge-repo';
+import * as battleRepo from '../../../../../src/lib/server/db/demo/battle-repo';
+import * as cancellationReasonRepo from '../../../../../src/lib/server/db/demo/cancellation-reason-repo';
+import * as cloudExportRepo from '../../../../../src/lib/server/db/demo/cloud-export-repo';
+import * as evaluationRepo from '../../../../../src/lib/server/db/demo/evaluation-repo';
+import * as graduationConsentRepo from '../../../../../src/lib/server/db/demo/graduation-consent-repo';
+import * as imageRepo from '../../../../../src/lib/server/db/demo/image-repo';
+import * as inquiryRepo from '../../../../../src/lib/server/db/demo/inquiry-repo';
+import * as loginBonusRepo from '../../../../../src/lib/server/db/demo/login-bonus-repo';
+import * as messageRepo from '../../../../../src/lib/server/db/demo/message-repo';
+import * as pushSubscriptionRepo from '../../../../../src/lib/server/db/demo/push-subscription-repo';
+import * as reportDailySummaryRepo from '../../../../../src/lib/server/db/demo/report-daily-summary-repo';
+import * as rewardRedemptionRepo from '../../../../../src/lib/server/db/demo/reward-redemption-repo';
+import * as seasonEventRepo from '../../../../../src/lib/server/db/demo/season-event-repo';
+import * as siblingChallengeRepo from '../../../../../src/lib/server/db/demo/sibling-challenge-repo';
+import * as siblingCheerRepo from '../../../../../src/lib/server/db/demo/sibling-cheer-repo';
+import * as specialRewardRepo from '../../../../../src/lib/server/db/demo/special-reward-repo';
+import * as stampCardRepo from '../../../../../src/lib/server/db/demo/stamp-card-repo';
+import * as storageRepo from '../../../../../src/lib/server/db/demo/storage-repo';
+import * as tenantEventRepo from '../../../../../src/lib/server/db/demo/tenant-event-repo';
+import * as trialHistoryRepo from '../../../../../src/lib/server/db/demo/trial-history-repo';
+import * as viewerTokenRepo from '../../../../../src/lib/server/db/demo/viewer-token-repo';
+import * as voiceRepo from '../../../../../src/lib/server/db/demo/voice-repo';
+
+describe('demo/account-lockout-repo', () => {
+	it('getLockout は null を返す (anonymous auth は lockout 不要)', async () => {
+		expect(await accountLockoutRepo.getLockout('any@example.com')).toBeNull();
+	});
+	it('upsertLockout は no-op', async () => {
+		await expect(
+			accountLockoutRepo.upsertLockout({
+				email: 'x',
+				failedCount: 1,
+				lockedUntil: null,
+				lastFailedAt: null,
+			}),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe('demo/activity-mastery-repo', () => {
+	it('findAllByChild / findByChildAndActivity は空', async () => {
+		expect(await activityMasteryRepo.findAllByChild(902, 'demo')).toEqual([]);
+		expect(
+			await activityMasteryRepo.findByChildAndActivity(902, 1, 'demo'),
+		).toBeUndefined();
+	});
+	it('upsert は input から ActivityMastery を返す (no-op)', async () => {
+		const r = await activityMasteryRepo.upsert(902, 1, 10, 2, 'demo');
+		expect(r.childId).toBe(902);
+		expect(r.level).toBe(2);
+	});
+});
+
+describe('demo/activity-pref-repo', () => {
+	it('findPinnedByChild は空', async () => {
+		expect(await activityPrefRepo.findPinnedByChild(902, 'demo')).toEqual([]);
+	});
+	it('togglePin は ChildActivityPreference を返す (no-op)', async () => {
+		const r = await activityPrefRepo.togglePin(902, 1, true, 'demo');
+		expect(r.isPinned).toBe(1);
+	});
+});
+
+describe('demo/auto-challenge-repo', () => {
+	it('findActiveByChild は undefined / findByChild は空', async () => {
+		expect(await autoChallengeRepo.findActiveByChild(902, 'demo')).toBeUndefined();
+		expect(await autoChallengeRepo.findByChild(902, 'demo')).toEqual([]);
+	});
+});
+
+describe('demo/battle-repo', () => {
+	it('findTodayBattle / findRecentBattles / findCollection は空', async () => {
+		expect(await battleRepo.findTodayBattle(902, '2026-04-01', 'demo')).toBeUndefined();
+		expect(await battleRepo.findRecentBattles(902, 5, 'demo')).toEqual([]);
+		expect(await battleRepo.findCollection(902, 'demo')).toEqual([]);
+	});
+});
+
+describe('demo/cancellation-reason-repo', () => {
+	it('aggregateRecent は total=0', async () => {
+		const r = await cancellationReasonRepo.aggregateRecent();
+		expect(r.total).toBe(0);
+		expect(r.breakdown).toEqual([]);
+	});
+});
+
+describe('demo/cloud-export-repo', () => {
+	it('findByTenant / findByPin は空', async () => {
+		expect(await cloudExportRepo.findByTenant('demo')).toEqual([]);
+		expect(await cloudExportRepo.findByPin('any')).toBeUndefined();
+	});
+	it('countByTenant は 0 / deleteExpired は 0', async () => {
+		expect(await cloudExportRepo.countByTenant('demo')).toBe(0);
+		expect(await cloudExportRepo.deleteExpired('any')).toBe(0);
+	});
+});
+
+describe('demo/evaluation-repo', () => {
+	it('findAllChildren は demo Children を返す (fixture 経由)', async () => {
+		const children = await evaluationRepo.findAllChildren('demo');
+		expect(children.length).toBeGreaterThan(0);
+	});
+	it('isRestDay は false', async () => {
+		expect(await evaluationRepo.isRestDay(902, '2026-04-01', 'demo')).toBe(false);
+	});
+});
+
+describe('demo/graduation-consent-repo', () => {
+	it('aggregateRecent は totalGraduations=0', async () => {
+		const r = await graduationConsentRepo.aggregateRecent();
+		expect(r.totalGraduations).toBe(0);
+	});
+});
+
+describe('demo/image-repo', () => {
+	it('findCachedImage は undefined', async () => {
+		expect(
+			await imageRepo.findCachedImage(902, 'avatar', 'hash', 'demo'),
+		).toBeUndefined();
+	});
+	it('findChildForImage は demo Child を返す', async () => {
+		const child = await imageRepo.findChildForImage(902, 'demo');
+		expect(child?.id).toBe(902);
+	});
+});
+
+describe('demo/inquiry-repo', () => {
+	it('generateInquiryId は deterministic dummy を返す', async () => {
+		const id = await inquiryRepo.generateInquiryId();
+		expect(id).toBe('DEMO-INQUIRY');
+	});
+	it('saveInquiry は no-op', async () => {
+		await expect(
+			inquiryRepo.saveInquiry({
+				inquiryId: 'x',
+				tenantId: null,
+				email: 'a@b',
+				replyEmail: null,
+				category: 'general',
+				body: '',
+				status: 'open',
+				createdAt: '2026-04-01T00:00:00.000Z',
+			}),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe('demo/login-bonus-repo', () => {
+	it('findTodayBonus は fixture から該当があれば返す', async () => {
+		// 902 の TODAY (2026-03-27) ボーナスは fixture に存在
+		const r = await loginBonusRepo.findTodayBonus(902, '2026-03-27', 'demo');
+		expect(r).toBeDefined();
+		expect(r?.childId).toBe(902);
+	});
+	it('未存在 child + 別 date は undefined', async () => {
+		expect(await loginBonusRepo.findTodayBonus(99999, '2020-01-01', 'demo')).toBeUndefined();
+	});
+});
+
+describe('demo/message-repo', () => {
+	it('findMessages / findUnshownMessage は空 / undefined', async () => {
+		expect(await messageRepo.findMessages(902, 10, 'demo')).toEqual([]);
+		expect(await messageRepo.findUnshownMessage(902, 'demo')).toBeUndefined();
+		expect(await messageRepo.countUnshownMessages(902, 'demo')).toBe(0);
+	});
+});
+
+describe('demo/push-subscription-repo', () => {
+	it('findByTenant は空', async () => {
+		expect(await pushSubscriptionRepo.findByTenant('demo')).toEqual([]);
+	});
+	it('countTodayLogs は 0', async () => {
+		expect(await pushSubscriptionRepo.countTodayLogs('demo', '2026-04-01')).toBe(0);
+	});
+});
+
+describe('demo/report-daily-summary-repo', () => {
+	it('findByChildAndDateRange は空', async () => {
+		expect(
+			await reportDailySummaryRepo.findByChildAndDateRange(
+				902,
+				'2026-01-01',
+				'2026-12-31',
+				'demo',
+			),
+		).toEqual([]);
+	});
+});
+
+describe('demo/reward-redemption-repo', () => {
+	it('findRedemptionRequestsByChild / Tenant は空', async () => {
+		expect(await rewardRedemptionRepo.findRedemptionRequestsByChild(902, 'demo')).toEqual(
+			[],
+		);
+		expect(await rewardRedemptionRepo.findRedemptionRequestsByTenant('demo')).toEqual([]);
+	});
+});
+
+describe('demo/season-event-repo', () => {
+	it('findActiveEvents / findAllEvents は空', async () => {
+		expect(await seasonEventRepo.findAllEvents('demo')).toEqual([]);
+		expect(await seasonEventRepo.findActiveEvents('2026-04-01', 'demo')).toEqual([]);
+	});
+});
+
+describe('demo/sibling-challenge-repo', () => {
+	it('findAllChallenges / findActiveChallenges は空', async () => {
+		expect(await siblingChallengeRepo.findAllChallenges('demo')).toEqual([]);
+		expect(
+			await siblingChallengeRepo.findActiveChallenges('2026-04-01', 'demo'),
+		).toEqual([]);
+	});
+});
+
+describe('demo/sibling-cheer-repo', () => {
+	it('findUnshownCheers は空 / countTodayCheersFrom は 0', async () => {
+		expect(await siblingCheerRepo.findUnshownCheers(902, 'demo')).toEqual([]);
+		expect(await siblingCheerRepo.countTodayCheersFrom(902, 'demo')).toBe(0);
+	});
+});
+
+describe('demo/special-reward-repo', () => {
+	it('findSpecialRewards / findUnshownReward は空 / undefined', async () => {
+		expect(await specialRewardRepo.findSpecialRewards(902, 'demo')).toEqual([]);
+		expect(await specialRewardRepo.findUnshownReward(902, 'demo')).toBeUndefined();
+	});
+});
+
+describe('demo/stamp-card-repo', () => {
+	it('findEnabledStampMasters / findCardByChildAndWeek は空 / undefined', async () => {
+		expect(await stampCardRepo.findEnabledStampMasters('demo')).toEqual([]);
+		expect(
+			await stampCardRepo.findCardByChildAndWeek(902, '2026-04-01', 'demo'),
+		).toBeUndefined();
+	});
+});
+
+describe('demo/storage-repo (S3 等への write 権限なし)', () => {
+	it('readFile / fileExists / listFiles は空 / false', async () => {
+		expect(await storageRepo.readFile('any')).toBeNull();
+		expect(await storageRepo.fileExists('any')).toBe(false);
+		expect(await storageRepo.listFiles('any')).toEqual([]);
+	});
+	it('saveFile は no-op (Lambda has no S3 write permission)', async () => {
+		await expect(
+			storageRepo.saveFile('any', Buffer.from('x'), 'text/plain'),
+		).resolves.toBeUndefined();
+	});
+	it('deleteByPrefix は 0', async () => {
+		expect(await storageRepo.deleteByPrefix('any')).toBe(0);
+	});
+});
+
+describe('demo/tenant-event-repo', () => {
+	it('findByTenantAndYear は空', async () => {
+		expect(await tenantEventRepo.findByTenantAndYear('demo', 2026)).toEqual([]);
+	});
+});
+
+describe('demo/trial-history-repo', () => {
+	it('findLatestByTenant / findActiveTrials は undefined / 空', async () => {
+		expect(await trialHistoryRepo.findLatestByTenant('demo')).toBeUndefined();
+		expect(await trialHistoryRepo.findActiveTrials()).toEqual([]);
+	});
+});
+
+describe('demo/viewer-token-repo', () => {
+	it('findByTenant / findByToken は空 / undefined', async () => {
+		expect(await viewerTokenRepo.findByTenant('demo')).toEqual([]);
+		expect(await viewerTokenRepo.findByToken('any')).toBeUndefined();
+	});
+});
+
+describe('demo/voice-repo', () => {
+	it('findByChild / findActiveVoice / findById は空 / null', async () => {
+		expect(await voiceRepo.findByChild(902, 'wakeup', 'demo')).toEqual([]);
+		expect(await voiceRepo.findActiveVoice(902, 'wakeup', 'demo')).toBeNull();
+		expect(await voiceRepo.findById(1, 'demo')).toBeNull();
+	});
+	it('insert は { id: 0 } dummy を返す', async () => {
+		const r = await voiceRepo.insert({
+			childId: 902,
+			scene: 'wakeup',
+			label: 'test',
+			filePath: '/tmp/x',
+			publicUrl: 'http://example.com/x',
+			durationMs: null,
+			isActive: 1,
+			tenantId: 'demo',
+		});
+		expect(r.id).toBe(0);
+	});
+});

--- a/tests/unit/server/db/demo/stub-repos.test.ts
+++ b/tests/unit/server/db/demo/stub-repos.test.ts
@@ -49,9 +49,7 @@ describe('demo/account-lockout-repo', () => {
 describe('demo/activity-mastery-repo', () => {
 	it('findAllByChild / findByChildAndActivity は空', async () => {
 		expect(await activityMasteryRepo.findAllByChild(902, 'demo')).toEqual([]);
-		expect(
-			await activityMasteryRepo.findByChildAndActivity(902, 1, 'demo'),
-		).toBeUndefined();
+		expect(await activityMasteryRepo.findByChildAndActivity(902, 1, 'demo')).toBeUndefined();
 	});
 	it('upsert は input から ActivityMastery を返す (no-op)', async () => {
 		const r = await activityMasteryRepo.upsert(902, 1, 10, 2, 'demo');
@@ -123,9 +121,7 @@ describe('demo/graduation-consent-repo', () => {
 
 describe('demo/image-repo', () => {
 	it('findCachedImage は undefined', async () => {
-		expect(
-			await imageRepo.findCachedImage(902, 'avatar', 'hash', 'demo'),
-		).toBeUndefined();
+		expect(await imageRepo.findCachedImage(902, 'avatar', 'hash', 'demo')).toBeUndefined();
 	});
 	it('findChildForImage は demo Child を返す', async () => {
 		const child = await imageRepo.findChildForImage(902, 'demo');
@@ -186,21 +182,14 @@ describe('demo/push-subscription-repo', () => {
 describe('demo/report-daily-summary-repo', () => {
 	it('findByChildAndDateRange は空', async () => {
 		expect(
-			await reportDailySummaryRepo.findByChildAndDateRange(
-				902,
-				'2026-01-01',
-				'2026-12-31',
-				'demo',
-			),
+			await reportDailySummaryRepo.findByChildAndDateRange(902, '2026-01-01', '2026-12-31', 'demo'),
 		).toEqual([]);
 	});
 });
 
 describe('demo/reward-redemption-repo', () => {
 	it('findRedemptionRequestsByChild / Tenant は空', async () => {
-		expect(await rewardRedemptionRepo.findRedemptionRequestsByChild(902, 'demo')).toEqual(
-			[],
-		);
+		expect(await rewardRedemptionRepo.findRedemptionRequestsByChild(902, 'demo')).toEqual([]);
 		expect(await rewardRedemptionRepo.findRedemptionRequestsByTenant('demo')).toEqual([]);
 	});
 });
@@ -215,9 +204,7 @@ describe('demo/season-event-repo', () => {
 describe('demo/sibling-challenge-repo', () => {
 	it('findAllChallenges / findActiveChallenges は空', async () => {
 		expect(await siblingChallengeRepo.findAllChallenges('demo')).toEqual([]);
-		expect(
-			await siblingChallengeRepo.findActiveChallenges('2026-04-01', 'demo'),
-		).toEqual([]);
+		expect(await siblingChallengeRepo.findActiveChallenges('2026-04-01', 'demo')).toEqual([]);
 	});
 });
 
@@ -238,9 +225,7 @@ describe('demo/special-reward-repo', () => {
 describe('demo/stamp-card-repo', () => {
 	it('findEnabledStampMasters / findCardByChildAndWeek は空 / undefined', async () => {
 		expect(await stampCardRepo.findEnabledStampMasters('demo')).toEqual([]);
-		expect(
-			await stampCardRepo.findCardByChildAndWeek(902, '2026-04-01', 'demo'),
-		).toBeUndefined();
+		expect(await stampCardRepo.findCardByChildAndWeek(902, '2026-04-01', 'demo')).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

ADR-0048 §段階別 milestone 週 2-3 を完遂する。Multi-Lambda demo deployment (`demo.ganbari-quest.com`) で稼働する demo Lambda の Repository / AuthProvider 層を確定させ、demo / production の物理的分離による security blast radius 保証を Pre-PMF 個人開発でも実現する第 1 段階。

過去 8 回繰り返した demo / production UI 統合失敗の構造原因 (cookie / `if (isDemo)` 漏れ / parallel implementation / auth bypass 混入) を、IAM role 分離 + 別 Lambda + stateless fixture provider という物理レベルで再発不可能にする。

closes #2097 (段階的、本 PR は週 2-3 のみ。週 4-6 は別 PR で継続)

## 関連 Issue

- 親: #2097 (8 回目の demo/本番統合要求、ADR-0048 起点)
- ADR: ADR-0048 `docs/decisions/0048-multi-lambda-demo-deployment.md`
- 関連: #2118 (`/demo/**` 削除、Multi-Lambda 移行と整合済、keep)

## AC 検証マップ (ADR-0004)

| AC | 内容 | 実装ファイル | 検証 / エビデンス |
|----|------|------------|------------------|
| AC | `factory.ts` `DATA_SOURCE=demo` 分岐追加 | `src/lib/server/db/factory.ts` L186-229 | PASS — `git diff main src/lib/server/db/factory.ts` で demo 分岐確認 / vitest 250 file PASS |
| AC | 34 demo Repository 実装 (`src/lib/server/db/demo/*.ts`) | `src/lib/server/db/demo/*.ts` 35 files (README 含む) | PASS — `ls src/lib/server/db/demo/*.ts | wc -l` = 34 / `factory.ts` の Repositories interface 全 key を import & assign |
| AC | stateless fixture provider (write API は no-op、module-level mutable state なし) | `tests/unit/server/db/demo/{child,activity,status,settings}-repo.test.ts` の "fixture mutation なし" 検証 | PASS — vitest run で 110 件 PASS、`settings-repo.test.ts` で「write → 即 read」の mutation 不在を assert |
| AC | `AnonymousAuthProvider` 実装 (dummy user `anon-{requestId}` + role='owner' + tenantId='demo' + licenseStatus=ACTIVE) | `src/lib/server/auth/providers/anonymous.ts` | PASS — `tests/unit/server/auth/anonymous.test.ts` 14 件 PASS |
| AC | `auth/factory.ts` `AUTH_MODE='anonymous'` 分岐追加 | `src/lib/server/auth/factory.ts` / `types.ts` | PASS — unit test で `mode='anonymous'` 時 provider が anonymous を返すことを担保 |
| AC | Unit test 70+ 件追加 | `tests/unit/server/db/demo/*.test.ts` 9 files + `tests/unit/server/auth/anonymous.test.ts` | PASS — 計 110 件 PASS (vitest run) |
| AC | 既存 production / SQLite / DynamoDB Repository への影響なし | - | PASS — `git diff main -- src/lib/server/db/dynamodb src/lib/server/db/sqlite` で 0 行差分 |

## 変更タイプ

- [x] feat (新規機能 — demo deployment 用 Repository / AuthProvider 層)
- [ ] fix
- [ ] refactor
- [ ] infra
- [ ] design
- [ ] docs
- [ ] marketing
- [ ] test

## 影響範囲・変更コンポーネント

- `src/lib/server/db/demo/` — 34 Repository 新規 (本 PR で initial 実装)
- `src/lib/server/db/factory.ts` — `DATA_SOURCE='demo'` 分岐追加 (sqlite / dynamodb 分岐は touch しない)
- `src/lib/server/auth/providers/anonymous.ts` — 新規
- `src/lib/server/auth/factory.ts` — `AUTH_MODE='anonymous'` 分岐追加
- `src/lib/server/auth/types.ts` — `AuthMode` / `Identity` に `'anonymous'` variant 追加
- `tests/unit/server/db/demo/*.test.ts` 9 files + `tests/unit/server/auth/anonymous.test.ts` — 新規

本 PR scope 外 (ADR-0048 §段階別 milestone 後続):

- hooks.server.ts (週 5: demo cookie / `locals.isDemo` 検出削除)
- `infra/lib/compute-stack.ts` (週 4: `SvelteKitDemoFn` 追加)
- CloudFront alt domain `demo.ganbari-quest.com` / Route 53 record (週 4)
- LP demo リンク再変更 (週 5)
- E2E test 更新 / 5 年齢モード SS 視覚等価性検証 (週 6)

## テスト & 安全装置セルフチェック

- [x] Unit test 110 件新規追加 PASS (read fixture / write no-op / mutation 不在を検証) <!-- PASS -->
- [x] 全 4677 unit test PASS (regression なし) <!-- PASS -->
- [x] biome check: 0 error / 2 warning (production 既存と同質、複数引数 interface 由来) <!-- PASS -->
- [x] svelte-check: 0 error / 13 warning (production 既存事項、本 PR 起因なし) <!-- PASS -->
- [ ] E2E test: 本 PR scope 外 (週 6 で更新)
- [x] 既存 production / SQLite / DynamoDB Repository への影響なし: `git diff main -- src/lib/server/db/dynamodb src/lib/server/db/sqlite` で 0 差分 <!-- PASS -->

## スクリーンショット / ビジュアルデモ

UI 変更なし (Repository / Provider 層のみ)。SS 不要。

E2E / 実画面確認は週 4 以降の CDK / hooks 更新 PR 内で実施する (Multi-Lambda 全体方針)。

## コード品質セルフレビュー (#1481)

- **ADR-0048 §決定 §2 準拠** — stateless Fake (read) + Stub (write) hybrid (Martin Fowler 分類)。module-level user-specific mutable state を持たない (AWS Lambda Best Practices 公式 anti-pattern 回避)
- **Repository Pattern + Abstract Factory** (Fowler + GoF) — `factory.ts` で `DATA_SOURCE` env により dispatch。既存 sqlite / dynamodb と同型
- **Strategy Pattern** — `AuthProvider` interface に `AnonymousAuthProvider` 追加。`AUTH_MODE` env で選択
- **interface 完全準拠** — 全 34 Repository が IXxxRepo interface の全 method を実装。`activity-repo.ts` は 35 method、`auth-repo.ts` は `_typecheck: IAuthRepo` で網羅性を型レベルで強制
- **既存型互換性** — `Identity` / `AuthMode` に `'anonymous'` を追加するのみ。既存 `'local'` / `'cognito'` 判定箇所 (8 ファイル) は touch せず、anonymous 時は分岐外に落ちる (= demo Lambda では該当 routes が空 response、ADR-0048 P-1.7 整合)
- **fixture 整合** — read API は `$lib/server/demo/demo-data.ts` の `DEMO_*` constant を経由 (LP screenshot 撮影と同じ SSOT)

## 横展開・影響波及チェック

- demo-data.ts (`src/lib/server/demo/demo-data.ts`) — 既存 SSOT、touch しない (read fixture として参照のみ)
- 既存 hooks.server.ts (`src/hooks.server.ts`) — touch しない (週 5 PR で demo cookie / `locals.isDemo` 検出削除)
- CDK (`infra/`) — touch しない (週 4 PR で `SvelteKitDemoFn` + `demo-lambda-role` 追加)
- LP (`site/`) — touch しない (週 5 PR で demo リンク再変更)
- service 層 (`src/lib/server/services/`) — touch しない (Repository を呼ぶ側は env 駆動の自動切替で透過動作する)
- routes (`src/routes/`) — touch しない (本 PR は server-side layer のみ)

## レビュー依頼事項・破壊的変更

ADR-0048 §段階別 milestone 週 2-3 実装 PR、Draft 据置。

**PO 動作確認手順**:

1. `npm run test` で全 unit test PASS を確認 (新規 demo Repository + AnonymousAuthProvider 110 件含む)
2. `DATA_SOURCE=demo AUTH_MODE=anonymous npm run dev` で起動 (まだ実 demo Lambda ではないが、env 駆動の挙動確認は可能)
3. ローカルで `/elementary/home` 等にアクセス、demo data fixture が返ることを確認 (たろう=901 / ゆうきちゃん=902 等)
4. AnonymousAuthProvider が dummy user (`anon-{requestId}`) + tenantId='demo' を返すことを開発者ツール / log で確認

**Draft → Ready 化は PO 動作確認完了後の判断**。週 4 CDK PR / 週 5 hooks PR / 週 6 E2E PR は本 PR merge 後に直列で進める。

**破壊的変更**: なし。`DATA_SOURCE=demo` / `AUTH_MODE=anonymous` を設定した時のみ新挙動が有効。既存 sqlite / dynamodb / cognito / local 経路は完全に touch していない。

## 配布済み env / secret (ADR-0006)

新規 env / secret 追加なし。

本 PR で参照する `DATA_SOURCE='demo'` / `AUTH_MODE='anonymous'` は既存 env 変数の新規 value のみで、新たな secret 配布は不要。週 4 CDK PR で demo Lambda の env 設定として CDK stack 内に literal で設定する想定 (Secrets Manager 経由なし)。

## Ready for Review チェックリスト

- [x] AC 全項目 [x] 化
- [x] biome / svelte-check / vitest 全 PASS
- [x] CI 全緑 (env.ts + biome-ignore fix 後、最終確認は Ready 化前に再確認)
- [x] PO 動作確認完了 — /switch で 5 demo children fixture 表示確認
- [x] 既存 production / SQLite / DynamoDB Repository への影響なし証跡確認
- [x] ADR-0048 全 §決定 §1-§4 + P-1.1/P-1.6/P-1.7/P-2.6 と実装の整合確認

## QM レビュー結果

QM レビューは Ready 化後に実施。Draft 中は対象外。


