### PR TITLE
fix: #2097 DemoLambdaRole description ASCII-only (ADR-0048 deploy hotfix)

### DIFF
--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -326,7 +326,7 @@ export class ComputeStack extends cdk.Stack {
 				iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
 			],
 			description:
-				'Demo Lambda execution role — ADR-0048. CloudWatch Logs only. No DynamoDB/Cognito/Secrets/SES grants.',
+				'Demo Lambda execution role (ADR-0048). CloudWatch Logs only. No DynamoDB/Cognito/Secrets/SES grants.',
 		});
 
 		// 3. demo Fn: prod と同じ Docker image を共有しつつ env / role で隔離


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 (PO) + 将来の demo 利用者
**解決する課題**: PR #2124 マージ後の本番 cdk deploy が IAM Role description の不正文字で CREATE_FAILED 停止
**期待される効果**: deploy 完遂 → demo.ganbari-quest.com が稼働 → PO による本番同等 demo 確認が可能になる

## 関連 Issue

closes #2097 (ADR-0048 week 4 deploy 不全部分)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | em-dash の ASCII 化 | infra/lib/compute-stack.ts L328-329 diff | PASS - `(ADR-0048)` に置換 |
| AC2 | infra description 行 で AWS 許容文字外 0 件 | python regex scan で description: 行を全走査 | PASS - 0 violation |

## 変更タイプ
- [x] fix: バグ修正 (本番 deploy 修復)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] インフラ (`infra/`)

**影響を受ける画面・機能**: なし (IAM Role description 文字列のみ、デプロイ後の動作は不変)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready`**: 影響なし — 1 行リテラル変更のみ
- [x] 追加・変更したテスト: N/A — multi-lambda-cdk.test.ts は description 内容を assert しないため既存テスト不変
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A (priority:high 同等の本番 deploy 修復だが ADR-0002 priority:critical 5要件は適用範囲外)

## スクリーンショット / ビジュアルデモ

**該当なし (理由)**: インフラ IAM Role description の ASCII 化のみで UI 影響ゼロ

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A (1 行リテラル変更)
- [x] **DRY**: python scan で他 description 行に同類非許容文字なし確認済み
- [x] **YAGNI**: 最小変更
- [x] **Security**: N/A (description は機密情報を含まない)
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready`** ローカル確認: 1 行リテラル変更で影響なし
- [x] セルフレビュー済み (em-dash 1 箇所のみ変更)
- [x] 全 AC が実装済み
- [x] Phase 分割: N/A (緊急 hotfix)

## QM レビュー結果

<!-- QM 記入予定。merge 前に QA Agent が `docs/sessions/qa-session.md` Tier 2 手順 5 に従い記入。 -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
