### PR TITLE
fix: #2097 B-1 — demo Lambda isDemo Pattern A (AUTH_MODE=anonymous fallback)

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -15,6 +15,7 @@ import {
 	DEMO_MODE_COOKIE_MAX_AGE,
 	DEMO_WRITE_ALLOWLIST,
 	DEMO_WRITE_METHODS,
+	isDemoLambda,
 	resolveDemoActive,
 } from '$lib/server/demo/demo-mode';
 import {
@@ -253,13 +254,20 @@ export const handle: Handle = ({ event, resolve }) =>
 			redirect(legacyEntry.status ?? 308, newUrl);
 		}
 
-		// 1) デモ実行モード判定（ADR-0039 / #1180）
+		// 1) デモ実行モード判定（ADR-0039 / #1180、ADR-0048 / #2097）
 		//
 		// `?mode=demo` クエリ → cookie `gq_demo=1` → `/demo/*` パス（Phase 1 backward compat）
 		// の順でデモ状態を解決。event.locals.isDemo を server-side SSOT として設定する。
 		// 本番ルートツリー上で同一コードパスを流すことで、
 		// `src/routes/demo/**` 別ツリー起因の乖離 (#296/#1129/#1147/#1180) を構造解消する。
 		// Phase 2 で /demo/* が削除されたら `fromLegacyPath` 経路も除去する。
+		//
+		// ADR-0048 Phase B-1 (#2097): Multi-Lambda demo deployment
+		// (demo.ganbari-quest.com) は AUTH_MODE=anonymous の Lambda 専用デプロイで、
+		// 上記 3 経路が必ずセットされない (素の `/admin` アクセス等)。フォールバックとして
+		// `isDemoLambda(env.AUTH_MODE)` を OR 合流させ、demo Lambda 上の全リクエストを
+		// `isDemo=true` として扱う。これにより 38 箇所の `data.isDemo` 分岐 UI が正しく
+		// demo として動作する (A-6 ISSUE-003 構造解消)。
 		//
 		// prerender 中は SvelteKit が url.searchParams へのアクセスを禁ずる
 		// （deterministic でなくなるため）。building 時はデモ判定をスキップして
@@ -287,7 +295,9 @@ export const handle: Handle = ({ event, resolve }) =>
 				});
 			}
 
-			event.locals.isDemo = demoActive;
+			// ADR-0048 Phase B-1 (#2097): AUTH_MODE=anonymous は demo Lambda 専用のため
+			// 強制的に isDemo=true とする。legacy 3 経路は backward compat のため保持。
+			event.locals.isDemo = demoActive || isDemoLambda(env.AUTH_MODE);
 		}
 
 		// ADR-0040 P2: 実行モードをリクエスト単位で解決。以降のガード／UI 出力は

--- a/src/lib/server/demo/demo-mode.ts
+++ b/src/lib/server/demo/demo-mode.ts
@@ -57,6 +57,22 @@ export function resolveDemoActive(
 }
 
 /**
+ * Multi-Lambda demo deployment (demo.ganbari-quest.com) の判定。
+ *
+ * ADR-0048 §Phase B-1 / Issue #2097: `AUTH_MODE=anonymous` の Lambda は demo Lambda
+ * 専用デプロイのため、リクエストのクエリ・cookie・パスに関係なく `isDemo=true` として
+ * 扱う必要がある。`resolveDemoActive()` の従来の 3 経路（query / cookie / `/demo/*`）の
+ * いずれもセットされない素のアクセス（例: `/admin`）で onboarding が表示される問題
+ * (A-6 ISSUE-003) の構造的解消。
+ *
+ * 既存の legacy 3 経路（cookie / `/demo/*`）は NUC local モード等の運用維持のため
+ * そのまま保持し、本関数は OR 演算でフォールバックとして合流させる。
+ */
+export function isDemoLambda(authMode: string | undefined): boolean {
+	return authMode === 'anonymous';
+}
+
+/**
  * 書き込みパスがガード例外に該当するか。
  */
 export function isDemoWriteAllowed(path: string): boolean {

--- a/src/routes/(parent)/admin/+page.svelte
+++ b/src/routes/(parent)/admin/+page.svelte
@@ -1,7 +1,16 @@
 <script lang="ts">
+import { page } from '$app/state';
 import AdminHome from '$lib/features/admin/components/AdminHome.svelte';
 
 let { data } = $props();
+
+// ADR-0048 Phase B-1 (#2097): demo Lambda (AUTH_MODE=anonymous) では
+// `(parent)/admin/+page.svelte` も isDemo=true として描画される。
+// hooks.server.ts が locals.isDemo=true をセットし、+layout.server.ts が
+// $page.data.isDemo に伝搬。本 page は AdminHome の `mode` prop に橋渡しすることで、
+// shared コンポーネントの `isDemo = mode === 'demo'` 派生を server-side SSOT と同期させる。
+// これにより onboarding ダイアログ等の本番専用 UI が demo Lambda 上で誤表示されない (A-6 ISSUE-003)。
+const adminMode = $derived<'live' | 'demo'>(page.data.isDemo ? 'demo' : 'live');
 </script>
 
 <AdminHome
@@ -9,7 +18,7 @@ let { data } = $props();
 	pointSettings={data.pointSettings}
 	tutorialStarted={data.tutorialStarted}
 	onboarding={data.onboarding}
-	mode="live"
+	mode={adminMode}
 	basePath="/admin"
 	monthlySummaries={data.monthlySummaries}
 	currentMonth={data.currentMonth}

--- a/tests/unit/demo/demo-mode.test.ts
+++ b/tests/unit/demo/demo-mode.test.ts
@@ -1,0 +1,90 @@
+// tests/unit/demo/demo-mode.test.ts
+// ADR-0048 Phase B-1 / Issue #2097: demo Lambda 判定の単体テスト
+//
+// 目的:
+// - `isDemoLambda(authMode)`: AUTH_MODE=anonymous 単独で isDemo=true となるか
+// - 既存 `resolveDemoActive()` legacy 3 経路 (query / cookie / `/demo/*`) との
+//   OR 合流が壊れていないか (NUC local モード等の backward compat)
+
+import { describe, expect, it } from 'vitest';
+import { isDemoLambda, resolveDemoActive } from '../../../src/lib/server/demo/demo-mode';
+
+describe('isDemoLambda (ADR-0048 Phase B-1 / #2097)', () => {
+	it('AUTH_MODE=anonymous → demo Lambda として判定 (Pattern A 中核)', () => {
+		// AC1: demo.ganbari-quest.com の素の /admin アクセス (cookie/query/path なし) でも
+		// AUTH_MODE=anonymous なら isDemo=true になることを保証する。
+		expect(isDemoLambda('anonymous')).toBe(true);
+	});
+
+	it('AUTH_MODE=cognito → demo Lambda ではない (production)', () => {
+		// AC2: 本番 ganbari-quest.com (cognito) は当然 demo 扱いしない。
+		expect(isDemoLambda('cognito')).toBe(false);
+	});
+
+	it('AUTH_MODE=local → demo Lambda ではない (NUC local モード)', () => {
+		// AC3 関連: NUC local 運用環境では isDemoLambda() は false を返し、
+		// resolveDemoActive() の cookie (gq_demo=1) 経路が backward compat で機能する。
+		expect(isDemoLambda('local')).toBe(false);
+	});
+
+	it('AUTH_MODE undefined → demo Lambda ではない', () => {
+		// 想定外の値や未設定でも false にフォールバックすることを保証 (デフォルト = local 扱い)。
+		expect(isDemoLambda(undefined)).toBe(false);
+	});
+
+	it('AUTH_MODE が想定外の文字列 → demo Lambda ではない', () => {
+		expect(isDemoLambda('foo')).toBe(false);
+		expect(isDemoLambda('')).toBe(false);
+	});
+});
+
+describe('resolveDemoActive (legacy 3 経路) + isDemoLambda OR 合流 (#2097)', () => {
+	it('legacy cookie 経路は単独で isDemo=true (NUC local + gq_demo=1)', () => {
+		// AC3: AUTH_MODE=local かつ gq_demo cookie がセットされている場合、
+		// legacy resolveDemoActive() 単独で isDemo=true となる (Pattern A 後も維持)。
+		const result = resolveDemoActive(null, '1', '/admin');
+		expect(result.isDemo).toBe(true);
+	});
+
+	it('legacy query 経路: ?mode=demo → isDemo=true', () => {
+		// 入口クエリは依然有効 (NUC local の検証 URL 等で使用)。
+		const result = resolveDemoActive('demo', undefined, '/admin');
+		expect(result.isDemo).toBe(true);
+		expect(result.fromQuery).toBe(true);
+	});
+
+	it('legacy path 経路: /demo/* → isDemo=true (Phase 1 backward compat)', () => {
+		const result = resolveDemoActive(null, undefined, '/demo/admin');
+		expect(result.isDemo).toBe(true);
+		expect(result.fromLegacyPath).toBe(true);
+	});
+
+	it('legacy 3 経路すべて未設定 → isDemo=false (= demo Lambda 外の通常 production)', () => {
+		// この場合 hooks.server.ts は `demoActive || isDemoLambda(env.AUTH_MODE)` で
+		// fallback して最終 isDemo を決める。
+		const result = resolveDemoActive(null, undefined, '/admin');
+		expect(result.isDemo).toBe(false);
+	});
+
+	it('hooks.server.ts OR 合流ロジックの再現: legacy=false かつ AUTH_MODE=anonymous → true', () => {
+		// hooks.server.ts の `event.locals.isDemo = demoActive || isDemoLambda(env.AUTH_MODE)`
+		// を最小再現。実 hooks 統合テスト (hooks-integration.test.ts) で詳細パス確認するが、
+		// 合流式の真偽値が意図通りであることをここで unit レベル保証。
+		const legacy = resolveDemoActive(null, undefined, '/admin');
+		const finalIsDemo = legacy.isDemo || isDemoLambda('anonymous');
+		expect(finalIsDemo).toBe(true);
+	});
+
+	it('hooks.server.ts OR 合流ロジックの再現: legacy=false かつ AUTH_MODE=cognito → false', () => {
+		const legacy = resolveDemoActive(null, undefined, '/admin');
+		const finalIsDemo = legacy.isDemo || isDemoLambda('cognito');
+		expect(finalIsDemo).toBe(false);
+	});
+
+	it('hooks.server.ts OR 合流ロジックの再現: legacy=true (cookie) かつ AUTH_MODE=local → true', () => {
+		// NUC local の cookie 経路は維持されることを再確認。
+		const legacy = resolveDemoActive(null, '1', '/admin');
+		const finalIsDemo = legacy.isDemo || isDemoLambda('local');
+		expect(finalIsDemo).toBe(true);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: デモ訪問者（demo.ganbari-quest.com の anonymous ユーザ）

**解決する課題**: demo Lambda (Multi-Lambda deployment、AUTH_MODE=anonymous) の素の `/admin` アクセスで「スタンダードへようこそ」onboarding ダイアログが anonymous ユーザに誤表示される。anonymous は本フローを完了できないため UX 破綻 (Phase A-2 audit ISSUE-003)。

**期待される効果**: 38 箇所の `data.isDemo` 分岐 UI が demo Lambda 上で正しく demo モードとして動作する。onboarding 誤表示が消え、anonymous ユーザはデモ向け UI のみを見る。

## 関連 Issue

closes #2097

(本 PR は #2097 ADR-0048 Phase B-1 のみを範囲とする。他 Phase は別 PR)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | AUTH_MODE='anonymous' → isDemo=true (cookie/query 不要) | `npx vitest run tests/unit/demo/demo-mode.test.ts` | `isDemoLambda('anonymous') === true` PASS |
| AC2 | AUTH_MODE='cognito' → isDemo=false (production 不変) | 同上 | `isDemoLambda('cognito') === false` PASS |
| AC3 | AUTH_MODE='local' + gq_demo cookie → isDemo=true (NUC backward compat) | 同上 | OR 合流テストで `resolveDemoActive(null, '1', '/admin').isDemo \|\| isDemoLambda('local') === true` PASS |
| AC4 | hooks.server.ts の既存 legacy 3 経路 (query / cookie / `/demo/*`) 不変 | `tests/unit/services/hooks-integration.test.ts` | 既存 83 tests PASS |
| AC5 | full vitest 回帰なし | `npx vitest run` | 252 files / 4708 tests PASS |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/`)
- [x] サービス層 (`$lib/server/services/`) — `$lib/server/demo/demo-mode.ts` (新規 helper 追加)
- [x] 設定・CI — `src/hooks.server.ts` (リクエスト境界の isDemo 解決)

**影響を受ける画面・機能**:
- demo Lambda (demo.ganbari-quest.com) の全ページ（特に `/admin` の onboarding 表示）
- 本番 ganbari-quest.com (cognito) は不変
- NUC local モードの cookie 経路は不変

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
  - biome / svelte-check (0 errors) / vitest (4708 PASS) / hardcoded-strings / check-no-plan-literals 全通過
- [x] 追加・変更したテストの概要:
  - `tests/unit/demo/demo-mode.test.ts` (新規、12 tests) — `isDemoLambda(authMode)` の真偽値全網羅 + legacy `resolveDemoActive` との OR 合流テスト
- [x] **新規 env / secret 追加時**: N/A（既存 `AUTH_MODE` enum に新値追加なし、`'anonymous'` は #2097 Phase A で既に追加済み）
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（priority:critical ラベルなし、refactor:internal-no-doc-impact 相当）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR の中核は `hooks.server.ts` 内部ロジックの変更（`event.locals.isDemo` を `AUTH_MODE === 'anonymous'` で OR 合流）。`src/routes/(parent)/admin/+page.svelte` も hardcoded `mode="live"` を `mode={data.isDemo ? 'demo' : 'live'}` に置換するのみで、UI 構造そのものは変更していない（既存の `AdminHome.svelte` 内 `isDemo` derived を server SSOT と同期させるだけ）。ADR-0003 §4 内部 refactor exempt 相当。

**SIDE EFFECT として demo Lambda 上の `/admin` UI が変化する**（onboarding が出なくなる）が、これは本 PR の目的そのものであり、機能変更ではなくバグ修正の意図された結果。本タスク指示書「Verification (post-merge)」に従い、merge 後の deploy が demo.ganbari-quest.com に反映された段階で AC を実機確認する運用設計（worktree 環境からは demo Lambda 実機への手動操作不可）。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A (バックエンドロジック変更) | N/A |
| **修正後** | N/A | N/A |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — `isDemoLambda()` は AUTH_MODE 単一引数の純粋関数。legacy `resolveDemoActive()` と責務分離
- [x] **DRY**: `mode === 'demo'` 文字列直書きを `+page.svelte` に追加せず、server SSOT (`data.isDemo`) 経由で AdminHome に伝播
- [x] **YAGNI**: helper function を 1 個追加するだけの最小変更。Pattern A の 3h 見積もり内
- [x] **Security**: N/A（既存 env 値の参照のみ、新 secret 露出なし）
- [x] **アクセシビリティ**: N/A（UI 構造変更なし）
- [x] **パフォーマンス**: hooks.server.ts の評価コスト変化なし（純粋関数 1 回呼び出し増）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版 — 本 PR は legacy `src/routes/demo/**` ツリー側を変更しない（ADR-0039 Phase 1 backward compat 経路は不変）。SSOT 化された本番ルートツリー (`(parent)/admin`) のみが対象で、demo route 側は副作用なし
- [x] N/A — 並行実装の影響範囲外（hooks 層の judgment ロジック変更が中核、UI 並行ペアの追従不要）

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:

- 中核は `src/hooks.server.ts` L256-291 の `event.locals.isDemo` 解決ロジック。Pattern A (auditor 推奨) を採用し、最小変更 (~3 files, ~3h 見積もり) で 38 箇所の `data.isDemo` 分岐 UI を一括是正する設計
- `src/routes/(parent)/admin/+page.svelte` の `mode` prop を `data.isDemo` 連動に変更。`AdminLayout` も `mode="live"` hardcoded だが、`onboarding` 誤表示の根本原因は `AdminHome` 側のため Phase B-1 scope では admin page のみ修正
- 後続 phase で AdminLayout / 残 admin sub-page も同様に server SSOT 連動化する余地あり（別 Issue で起票判断）

参照: Phase A-2 audit `docs/research/2097-demo-conditional-ui-audit.md` §A-6 ISSUE-003

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（既存 `AUTH_MODE` enum `'anonymous'` 値は #2097 Phase A で追加済み、本 PR では参照のみ）

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: Phase B-1 のみが本 PR scope。Phase A audit (`docs/research/2097-demo-conditional-ui-audit.md`) で PO 合意済み
- [x] UI 変更時: N/A（バックエンドロジック変更、SIDE EFFECT の UI 変化はデモ環境のみ）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
