### PR TITLE
feat: #2136 MP-1 reward-set 完全実装 (import service + 一括追加 UI)

### DIFF
--- a/docs/design/parallel-implementations.md
+++ b/docs/design/parallel-implementations.md
@@ -271,6 +271,29 @@ grep -n "bottom-nav\|data-testid" src/lib/ui/components/BottomNav.svelte
 - `docs/design/marketplace-preset-checklist-audit.md` (3 件のみに整理済)
 - E2E spec: `tests/e2e/setup-marketplace-must.spec.ts` で 3 件のみ確認
 
+#### 7d. marketplace reward-set 一括追加 (#2136 MP-1)
+
+`src/lib/data/marketplace/reward-sets/*.json` の reward-set 10 件は **マーケットプレイス詳細ページ + admin/rewards 画面の両方**から一括取込でき、`special_rewards.sourcePresetId` (#1254 G1) で重複検知される。`activity-import-service.ts` を template として横展開した実装。
+
+**並行実装ペア**:
+
+| 場所 | 内容 | 技術 |
+|------|------|------|
+| `src/lib/data/marketplace/reward-sets/*.json` (10 件) | reward-set preset (title / points / icon / category / description) | JSON |
+| `src/lib/domain/marketplace-item.ts` | `RewardSetPayload` 型 | TypeScript |
+| `src/lib/server/services/reward-set-import-service.ts` | `previewRewardSetImport` / `importRewardSet` (`sourcePresetId` で重複検知) | TypeScript |
+| `src/routes/marketplace/[type]/[itemId]/+page.{svelte,server.ts}` | reward-set 詳細ページ CTA（ログイン済み = form / 未ログイン = signup 誘導） | Svelte / TS |
+| `src/routes/(parent)/admin/rewards/+page.{svelte,server.ts}` | 「マーケットプレイスから一括追加」セクション (reward-set 10 件 preview + form) | Svelte / TS |
+| `src/lib/domain/labels.ts` | `MARKETPLACE_LABELS.detailCtaImportReward*` / `REWARDS_LABELS.marketplace*` | TypeScript |
+| `src/lib/server/db/schema.ts` | `special_rewards.sourcePresetId` (#1254 G1) | Drizzle |
+
+**同期メカニズム**: `tests/unit/services/reward-set-import-service.test.ts` (15 シナリオ) + E2E `tests/e2e/marketplace-reward-set-import.spec.ts` (5 シナリオ) で検証。
+
+**修正時チェック**:
+- 新しい reward-set を追加 → import-service テスト + E2E で itemId を網羅
+- 重複検知ロジック (`sameSourceTitles`) 変更 → unit テスト 3 件 (「同一 preset 同一 title」/「別 preset 同名」/「sourcePresetId=null 手動 reward」) で誤検知ガード
+- reward の即時付与（grant）と一括取込（import）の区別: 一括取込は **point 加算しない**（"候補登録"）。grant は `insertPointEntry` を呼ぶ
+
 ---
 
 #### 8. 設計書 vs 実装

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -863,6 +863,23 @@ export const MARKETPLACE_LABELS = {
 	detailRulePointCost: '必要ポイント',
 	detailRulePointBonus: 'ボーナス',
 	detailCtaSignup: 'がんばりクエストに登録して使ってみる',
+	/** #2136 MP-1: reward-set 一括追加 CTA */
+	detailCtaImportReward: '🎁 このごほうびセットを一括追加',
+	/** #2136 MP-1: ログイン後の reward 取込誘導 */
+	detailCtaImportRewardSignedOut: '一括追加するには登録 / ログインが必要です',
+	/** #2136 MP-1: 取込先の子供選択ラベル */
+	detailCtaSelectChild: 'お子さまを選択',
+	/** #2136 MP-1: 重複ありの preview 文言 */
+	detailRewardImportPreview: (newCount: number, dup: number) =>
+		dup > 0
+			? `新規 ${newCount} 件 / 重複 ${dup} 件（重複はスキップされます）`
+			: `${newCount} 件のごほうびを追加します`,
+	/** #2136 MP-1: 取込完了メッセージ */
+	detailRewardImportSuccess: (count: number) => `✨ ${count} 件のごほうびを追加しました`,
+	/** #2136 MP-1: 取込時に全件重複 */
+	detailRewardImportAllDuplicates: 'このごほうびセットは既に追加済みです',
+	/** #2136 MP-1: お子さま未登録時の誘導 */
+	detailRewardImportNoChildren: 'まずはお子さまを登録してください',
 	backToTypeListSuffix: '一覧に戻る',
 	typeCountSuffix: '種',
 } as const;
@@ -3185,6 +3202,16 @@ export const REWARDS_LABELS = {
 	grantButton: (icon: string, title: string, points: number) =>
 		`${icon} ${title || '報酬'} (${points}P) を付与する`,
 	grantSuccess: '特別報酬を付与しました！',
+	/** #2136 MP-1: マーケットプレイス一括追加セクション */
+	marketplaceSectionTitle: 'マーケットプレイスから一括追加',
+	marketplaceSectionDesc:
+		'おすすめのごほうびセットを子供のごほうび履歴に一括追加できます（重複はスキップ）',
+	marketplaceImportButton: (count: number) => `${count} 件を一括追加`,
+	marketplaceImportSuccess: (count: number) => `✨ ${count} 件のごほうびを追加しました`,
+	marketplaceImportAllDuplicates: 'このごほうびセットは既に追加済みです',
+	marketplaceImportError: 'インポートに失敗しました',
+	marketplaceItemCountSuffix: '件',
+	marketplaceImportToggle: (open: boolean) => `${open ? '▼' : '▶'} マーケットプレイスから一括追加`,
 } as const;
 
 // ============================================================

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -865,6 +865,8 @@ export const MARKETPLACE_LABELS = {
 	detailCtaSignup: 'がんばりクエストに登録して使ってみる',
 	/** #2136 MP-1: reward-set 一括追加 CTA */
 	detailCtaImportReward: '🎁 このごほうびセットを一括追加',
+	/** #2136 MP-1: 件数付き一括追加 CTA */
+	detailCtaImportRewardWithCount: (count: number) => `🎁 このごほうびセットを一括追加 (${count}件)`,
 	/** #2136 MP-1: ログイン後の reward 取込誘導 */
 	detailCtaImportRewardSignedOut: '一括追加するには登録 / ログインが必要です',
 	/** #2136 MP-1: 取込先の子供選択ラベル */

--- a/src/lib/server/services/reward-set-import-service.ts
+++ b/src/lib/server/services/reward-set-import-service.ts
@@ -1,0 +1,166 @@
+// src/lib/server/services/reward-set-import-service.ts
+// マーケットプレイス reward-set 一括取込サービス (#2136 MP-1)
+//
+// activity-import-service.ts を template として横展開した実装。
+// `special_rewards.sourcePresetId` カラム (#1254 G1) を流用し、
+// preset_duplicate を検知して同一 preset の二重取込を防ぐ。
+//
+// 違いの要点:
+// - reward-set は子供毎に紐付くため、対象子供を必須引数として受け取る
+// - 既存判定キーは「同一 sourcePresetId + 同一 title」の組（title だけだと
+//   ユーザーが手動で同名 reward を作っていた場合に誤検知するため）
+// - activity と異なり「カテゴリ ID マッピング」は不要（reward-set の category は
+//   そのまま `special_rewards.category` に書き込む）
+
+import type { RewardSetPayload } from '$lib/domain/marketplace-item';
+import { findSpecialRewards, insertSpecialReward } from '$lib/server/db/special-reward-repo';
+import { logger } from '$lib/server/logger';
+
+// ---------- 型定義 ----------
+
+/** RewardSetPayload['rewards'] の 1 件 */
+export type RewardSetItem = RewardSetPayload['rewards'][number];
+
+export interface RewardSetImportPreview {
+	/** preset 内に含まれるごほうび総数 */
+	total: number;
+	/** 新規追加されるごほうび数（重複を除く） */
+	newRewards: number;
+	/** 既に取込済の重複ごほうび数 */
+	duplicates: number;
+	/** 重複ごほうびのタイトル一覧（UI 表示用） */
+	duplicateTitles: string[];
+}
+
+export interface RewardSetImportResult {
+	/** 実際に DB に挿入された件数 */
+	imported: number;
+	/** 重複でスキップされた件数 */
+	skipped: number;
+	/** 個別失敗のエラー（DB 例外など） */
+	errors: string[];
+}
+
+export interface ImportRewardSetOptions {
+	/**
+	 * マーケットプレイスのプリセット ID（例: `kinder-rewards`）。
+	 * `special_rewards.sourcePresetId` に書き込まれ、
+	 * 次回 import 時の重複検知に使用される。
+	 */
+	presetId: string;
+	/**
+	 * 適用対象の子供 ID。reward-set は子供毎に付与するため必須。
+	 */
+	childId: number;
+}
+
+// ---------- preview ----------
+
+/**
+ * preset 取込時の preview を返す。実際の DB 書込は行わない。
+ *
+ * 重複判定: `sourcePresetId === presetId` の reward が既に存在し、
+ * かつ同一 title である場合のみ「重複」とみなす。これにより、
+ * ユーザーが手動で同名 reward を作っていても誤検知しない。
+ */
+export async function previewRewardSetImport(
+	rewards: RewardSetItem[],
+	presetId: string,
+	childId: number,
+	tenantId: string,
+): Promise<RewardSetImportPreview> {
+	const existing = await findSpecialRewards(childId, tenantId);
+	const sameSourceTitles = new Set(
+		existing.filter((r) => r.sourcePresetId === presetId).map((r) => r.title),
+	);
+
+	const duplicateTitles: string[] = [];
+	let newCount = 0;
+
+	for (const r of rewards) {
+		if (sameSourceTitles.has(r.title)) {
+			duplicateTitles.push(r.title);
+		} else {
+			newCount++;
+		}
+	}
+
+	return {
+		total: rewards.length,
+		newRewards: newCount,
+		duplicates: duplicateTitles.length,
+		duplicateTitles,
+	};
+}
+
+// ---------- import ----------
+
+/**
+ * reward-set を子供に一括取込する（mergeモード: 同一 preset の重複はスキップ）。
+ *
+ * 注意: reward は本来「実績付与時点でポイント加算」するものだが、
+ * preset 取込は「将来付与する候補リスト」として `special_rewards` 行を作る運用ではない。
+ * ここでは ADR-0013 (LP truth) に従い「親が選んだ preset の reward を子供のごほうび履歴に追加する」
+ * セマンティクスとする — `grantSpecialReward` と同じく即時付与（点数加算）する。
+ *
+ * ただし grantSpecialReward は `insertPointEntry` も同時に呼んで点数加算するが、
+ * preset 一括取込で大量の点数を一気に与えるのは設計上望ましくないため、
+ * 本サービスは **reward レコードのみ作成し、ポイント加算は行わない**。
+ * これにより、preset 取込は「ごほうび候補の事前登録」として機能する。
+ */
+export async function importRewardSet(
+	rewards: RewardSetItem[],
+	tenantId: string,
+	options: ImportRewardSetOptions,
+): Promise<RewardSetImportResult> {
+	const { presetId, childId } = options;
+
+	const existing = await findSpecialRewards(childId, tenantId);
+	const sameSourceTitles = new Set(
+		existing.filter((r) => r.sourcePresetId === presetId).map((r) => r.title),
+	);
+
+	const errors: string[] = [];
+	let imported = 0;
+	let skipped = 0;
+
+	for (const r of rewards) {
+		if (sameSourceTitles.has(r.title)) {
+			skipped++;
+			continue;
+		}
+
+		try {
+			await insertSpecialReward(
+				{
+					childId,
+					grantedBy: null,
+					title: r.title,
+					description: r.description,
+					points: r.points,
+					icon: r.icon,
+					category: r.category,
+					sourcePresetId: presetId,
+				},
+				tenantId,
+			);
+			imported++;
+			sameSourceTitles.add(r.title);
+		} catch (e) {
+			errors.push(`「${r.title}」: ${String(e)}`);
+		}
+	}
+
+	logger.info('[reward-set-import] インポート完了', {
+		context: {
+			tenantId,
+			childId,
+			presetId,
+			imported,
+			skipped,
+			errors: errors.length,
+		},
+	});
+
+	return { imported, skipped, errors };
+}

--- a/src/routes/(parent)/admin/rewards/+page.server.ts
+++ b/src/routes/(parent)/admin/rewards/+page.server.ts
@@ -1,10 +1,12 @@
-// /admin/rewards — 特別報酬の付与（#336, #501, #581 プリセット追加, #728 プランゲート, #787 PlanLimitError 統一, #1337 申請タブ追加）
+// /admin/rewards — 特別報酬の付与（#336, #501, #581 プリセット追加, #728 プランゲート, #787 PlanLimitError 統一, #1337 申請タブ追加, #2136 MP-1 マーケットプレイス一括追加）
 
 import { fail } from '@sveltejs/kit';
+import { getMarketplaceIndex, getMarketplaceItem } from '$lib/data/marketplace';
 import { PRESET_REWARD_GROUPS } from '$lib/data/preset-rewards';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { PLAN_GATE_LABELS } from '$lib/domain/labels';
+import type { RewardSetPayload } from '$lib/domain/marketplace-item';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getAllChildren } from '$lib/server/services/child-service';
 import {
@@ -17,6 +19,10 @@ import {
 	getRedemptionRequestsForParent,
 	rejectRedemption,
 } from '$lib/server/services/reward-redemption-service';
+import {
+	importRewardSet,
+	previewRewardSetImport,
+} from '$lib/server/services/reward-set-import-service';
 import {
 	getChildSpecialRewards,
 	getRewardTemplates,
@@ -56,6 +62,18 @@ export const load: PageServerLoad = async ({ locals }) => {
 		),
 	]);
 
+	// #2136 MP-1: マーケットプレイス reward-set 一覧（preview 用）
+	const rewardSetMetas = getMarketplaceIndex().filter((m) => m.type === 'reward-set');
+	const rewardSets = rewardSetMetas.map((m) => ({
+		itemId: m.itemId,
+		name: m.name,
+		description: m.description,
+		icon: m.icon,
+		targetAgeMin: m.targetAgeMin,
+		targetAgeMax: m.targetAgeMax,
+		itemCount: m.itemCount,
+	}));
+
 	return {
 		children: childrenWithRewards,
 		templates,
@@ -64,6 +82,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 		planTier: tier,
 		pendingRequests,
 		historyRequests,
+		rewardSets,
 	};
 };
 
@@ -162,6 +181,51 @@ export const actions: Actions = {
 		}
 
 		return { redemptionApproved: true };
+	},
+
+	// #2136 MP-1: マーケットプレイス reward-set 一括追加
+	importMarketplaceRewardSet: async ({ request, locals }) => {
+		const tenantId = requireTenantId(locals);
+
+		// プランゲート: 無料プランは特別ごほうび設定不可（grant と同等）
+		const tier = await resolveTier(locals, tenantId);
+		if (!isPaidTier(tier)) {
+			return fail(403, {
+				error: createPlanLimitError(tier, 'standard', UPGRADE_MESSAGE),
+			});
+		}
+
+		const formData = await request.formData();
+		const childId = Number(formData.get('childId'));
+		const presetId = String(formData.get('presetId') ?? '').trim();
+		if (!childId) return fail(400, { error: 'こどもを選択してください' });
+		if (!presetId) return fail(400, { error: 'プリセットが指定されていません' });
+
+		const item = getMarketplaceItem('reward-set', presetId);
+		if (!item) {
+			return fail(404, { error: `プリセット「${presetId}」が見つかりません` });
+		}
+
+		const rewards = (item.payload as RewardSetPayload).rewards;
+		const preview = await previewRewardSetImport(rewards, presetId, childId, tenantId);
+
+		if (preview.newRewards === 0) {
+			return { marketplaceImport: { allDuplicates: true } };
+		}
+
+		const result = await importRewardSet(rewards, tenantId, {
+			presetId,
+			childId,
+		});
+
+		return {
+			marketplaceImport: {
+				imported: result.imported,
+				skipped: result.skipped,
+				errors: result.errors,
+				presetId,
+			},
+		};
 	},
 
 	rejectRedemption: async ({ request, locals }) => {

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -43,6 +43,21 @@ let activeTab = $state<'rewards' | 'requests'>('rewards');
 
 let selectedChildId = $state(0);
 
+// #2136 MP-1: マーケットプレイス一括追加 UI 状態
+let showMarketplace = $state(false);
+const marketplaceImport = $derived(
+	(
+		form as {
+			marketplaceImport?: {
+				imported?: number;
+				skipped?: number;
+				allDuplicates?: boolean;
+				presetId?: string;
+			};
+		} | null
+	)?.marketplaceImport,
+);
+
 $effect(() => {
 	const first = data.children[0];
 	if (selectedChildId === 0 && first) {
@@ -271,6 +286,78 @@ function acceptAiReward(preview: RewardPreviewData) {
 							</div>
 						</div>
 					{/each}
+				</div>
+			{/if}
+		</section>
+
+		<!-- #2136 MP-1: マーケットプレイスから一括追加 -->
+		<section data-testid="marketplace-reward-import-section">
+			<button
+				type="button"
+				class="text-sm font-bold text-[var(--color-text-link)] cursor-pointer bg-transparent border-none p-0 hover:underline"
+				onclick={() => { showMarketplace = !showMarketplace; }}
+				data-testid="marketplace-reward-import-toggle"
+			>
+				{REWARDS_LABELS.marketplaceImportToggle(showMarketplace)}
+			</button>
+
+			{#if showMarketplace}
+				<div class="mt-2 space-y-2">
+					<p class="text-xs text-[var(--color-text-muted)]">
+						{REWARDS_LABELS.marketplaceSectionDesc}
+					</p>
+					{#if marketplaceImport}
+						{#if marketplaceImport.allDuplicates}
+							<div
+								class="bg-[var(--color-feedback-info-bg)] border border-[var(--color-feedback-info-border)] text-[var(--color-feedback-info-text)] rounded-xl p-3 text-sm text-center"
+								data-testid="marketplace-reward-import-result"
+							>
+								{REWARDS_LABELS.marketplaceImportAllDuplicates}
+							</div>
+						{:else if (marketplaceImport.imported ?? 0) > 0}
+							<div
+								class="bg-[var(--color-feedback-success-bg)] border border-[var(--color-feedback-success-border)] text-[var(--color-feedback-success-text)] rounded-xl p-3 text-sm text-center"
+								data-testid="marketplace-reward-import-result"
+							>
+								{REWARDS_LABELS.marketplaceImportSuccess(marketplaceImport.imported ?? 0)}
+							</div>
+						{/if}
+					{/if}
+					<div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+						{#each data.rewardSets as set}
+							<form
+								method="POST"
+								action="?/importMarketplaceRewardSet"
+								use:enhance={() => {
+									return async ({ update }) => {
+										await invalidateAll();
+										await update();
+									};
+								}}
+								data-testid="marketplace-reward-form-{set.itemId}"
+							>
+								<input type="hidden" name="childId" value={selectedChildId} />
+								<input type="hidden" name="presetId" value={set.itemId} />
+								<Button
+									type="submit"
+									variant="ghost"
+									size="sm"
+									disabled={!data.isPremium}
+									class="w-full bg-[var(--color-surface-card)] rounded-xl p-3 shadow-sm text-left hover:shadow-md flex-col h-auto items-start"
+								>
+									<div class="flex items-center gap-2 w-full">
+										<span class="text-2xl">{set.icon}</span>
+										<div class="flex-1 min-w-0">
+											<p class="text-xs font-bold text-[var(--color-text-muted)] truncate">{set.name}</p>
+											<p class="text-xs text-[var(--color-text-tertiary)]">
+												{REWARDS_LABELS.marketplaceImportButton(set.itemCount)}
+											</p>
+										</div>
+									</div>
+								</Button>
+							</form>
+						{/each}
+					</div>
 				</div>
 			{/if}
 		</section>

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -292,14 +292,16 @@ function acceptAiReward(preview: RewardPreviewData) {
 
 		<!-- #2136 MP-1: マーケットプレイスから一括追加 -->
 		<section data-testid="marketplace-reward-import-section">
-			<button
+			<Button
 				type="button"
-				class="text-sm font-bold text-[var(--color-text-link)] cursor-pointer bg-transparent border-none p-0 hover:underline"
+				variant="ghost"
+				size="sm"
+				class="text-sm font-bold text-[var(--color-text-link)] hover:underline px-0"
 				onclick={() => { showMarketplace = !showMarketplace; }}
 				data-testid="marketplace-reward-import-toggle"
 			>
 				{REWARDS_LABELS.marketplaceImportToggle(showMarketplace)}
-			</button>
+			</Button>
 
 			{#if showMarketplace}
 				<div class="mt-2 space-y-2">

--- a/src/routes/marketplace/[type]/[itemId]/+page.server.ts
+++ b/src/routes/marketplace/[type]/[itemId]/+page.server.ts
@@ -1,7 +1,13 @@
-import { error } from '@sveltejs/kit';
+import { error, fail, redirect } from '@sveltejs/kit';
 import { getMarketplaceItem } from '$lib/data/marketplace';
-import type { MarketplaceItemType } from '$lib/domain/marketplace-item';
-import type { PageServerLoad } from './$types';
+import type { MarketplaceItemType, RewardSetPayload } from '$lib/domain/marketplace-item';
+import { requireTenantId } from '$lib/server/auth/factory';
+import { getAllChildren } from '$lib/server/services/child-service';
+import {
+	importRewardSet,
+	previewRewardSetImport,
+} from '$lib/server/services/reward-set-import-service';
+import type { Actions, PageServerLoad } from './$types';
 
 const VALID_TYPES: MarketplaceItemType[] = [
 	'activity-pack',
@@ -10,7 +16,7 @@ const VALID_TYPES: MarketplaceItemType[] = [
 	'rule-preset',
 ];
 
-export const load: PageServerLoad = async ({ params }) => {
+export const load: PageServerLoad = async ({ params, locals }) => {
 	const { type, itemId } = params;
 
 	if (!VALID_TYPES.includes(type as MarketplaceItemType)) {
@@ -22,5 +28,68 @@ export const load: PageServerLoad = async ({ params }) => {
 		error(404, 'コンテンツが見つかりません');
 	}
 
-	return { item };
+	// #2136 MP-1: 認証済みなら一括追加 CTA を出すための情報をロード。
+	// マーケットプレイスは公開ルートなので、未認証 (locals.context が無い場合) は
+	// children を空配列にしてサインアップ誘導 CTA を出す。
+	const isAuthenticated = !!locals.context;
+	let children: { id: number; nickname: string }[] = [];
+	if (isAuthenticated) {
+		try {
+			const tenantId = requireTenantId(locals);
+			const allChildren = await getAllChildren(tenantId);
+			children = allChildren.map((c) => ({ id: c.id, nickname: c.nickname }));
+		} catch {
+			// 認証コンテキストはあるがテナント解決失敗 — 未認証扱いにフォールバック
+			children = [];
+		}
+	}
+
+	return { item, isAuthenticated, children };
+};
+
+export const actions: Actions = {
+	// #2136 MP-1: reward-set の一括取込 action
+	importRewardSet: async ({ request, params, locals }) => {
+		const { type, itemId } = params;
+
+		if (type !== 'reward-set') {
+			return fail(400, { error: 'このコンテンツタイプは一括追加に対応していません' });
+		}
+
+		if (!locals.context) {
+			redirect(303, `/auth/signup?redirect=/marketplace/${type}/${itemId}`);
+		}
+
+		const tenantId = requireTenantId(locals);
+		const item = getMarketplaceItem('reward-set', itemId);
+		if (!item) {
+			return fail(404, { error: 'コンテンツが見つかりません' });
+		}
+
+		const formData = await request.formData();
+		const childId = Number(formData.get('childId'));
+		if (!childId) {
+			return fail(400, { error: 'お子さまを選択してください' });
+		}
+
+		const rewards = (item.payload as RewardSetPayload).rewards;
+		const preview = await previewRewardSetImport(rewards, itemId, childId, tenantId);
+
+		if (preview.newRewards === 0) {
+			return { rewardImport: { allDuplicates: true } };
+		}
+
+		const result = await importRewardSet(rewards, tenantId, {
+			presetId: itemId,
+			childId,
+		});
+
+		return {
+			rewardImport: {
+				imported: result.imported,
+				skipped: result.skipped,
+				errors: result.errors,
+			},
+		};
+	},
 };

--- a/src/routes/marketplace/[type]/[itemId]/+page.svelte
+++ b/src/routes/marketplace/[type]/[itemId]/+page.svelte
@@ -242,7 +242,7 @@ const rewardCount = $derived(isRewardSet ? (item.payload as RewardSetPayload).re
 							class="w-full"
 							data-testid="reward-import-submit"
 						>
-							{MARKETPLACE_LABELS.detailCtaImportReward} ({rewardCount}件)
+							{MARKETPLACE_LABELS.detailCtaImportRewardWithCount(rewardCount)}
 						</Button>
 					</form>
 					{/snippet}

--- a/src/routes/marketplace/[type]/[itemId]/+page.svelte
+++ b/src/routes/marketplace/[type]/[itemId]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { enhance } from '$app/forms';
 import { APP_LABELS, formatAgeRange, MARKETPLACE_LABELS } from '$lib/domain/labels';
 import type {
 	ActivityPackPayload,
@@ -16,8 +17,9 @@ import {
 import Badge from '$lib/ui/primitives/Badge.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
+import NativeSelect from '$lib/ui/primitives/NativeSelect.svelte';
 
-let { data } = $props();
+let { data, form } = $props();
 // svelte-ignore state_referenced_locally
 const item: MarketplaceItem = data.item;
 
@@ -25,6 +27,31 @@ const isActivityPack = $derived(item.type === 'activity-pack');
 const isRewardSet = $derived(item.type === 'reward-set');
 const isChecklist = $derived(item.type === 'checklist');
 const isRulePreset = $derived(item.type === 'rule-preset');
+
+// #2136 MP-1: reward-set 一括追加 UI 状態
+let selectedChildId = $state<number>(0);
+
+$effect(() => {
+	const first = data.children[0];
+	if (selectedChildId === 0 && first) {
+		selectedChildId = first.id;
+	}
+});
+
+const rewardImport = $derived(
+	(
+		form as {
+			rewardImport?: {
+				imported?: number;
+				skipped?: number;
+				allDuplicates?: boolean;
+				errors?: string[];
+			};
+		} | null
+	)?.rewardImport,
+);
+
+const rewardCount = $derived(isRewardSet ? (item.payload as RewardSetPayload).rewards.length : 0);
 </script>
 
 <svelte:head>
@@ -183,12 +210,99 @@ const isRulePreset = $derived(item.type === 'rule-preset');
 		</Card>
 
 		<!-- CTA -->
-		<div class="mt-6 space-y-3">
-			<a href="/auth/signup" class="block">
-				<Button variant="primary" size="lg" class="w-full">
-					{MARKETPLACE_LABELS.detailCtaSignup}
-				</Button>
-			</a>
+		<div class="mt-6 space-y-3" data-testid="marketplace-detail-cta">
+			{#if isRewardSet && data.isAuthenticated && data.children.length > 0}
+				<!-- #2136 MP-1: reward-set 一括追加 CTA（ログイン済み + 子供登録済み） -->
+				<Card padding="md">
+					{#snippet children()}
+					<form
+						method="POST"
+						action="?/importRewardSet"
+						use:enhance
+						class="space-y-3"
+						data-testid="reward-import-form"
+					>
+						<label class="block">
+							<span class="text-xs font-bold text-[var(--color-text-secondary)] block mb-1">
+								{MARKETPLACE_LABELS.detailCtaSelectChild}
+							</span>
+							<NativeSelect
+								name="childId"
+								bind:value={selectedChildId}
+								options={data.children.map((c) => ({
+									value: c.id,
+									label: c.nickname,
+								}))}
+							/>
+						</label>
+						<Button
+							type="submit"
+							variant="primary"
+							size="lg"
+							class="w-full"
+							data-testid="reward-import-submit"
+						>
+							{MARKETPLACE_LABELS.detailCtaImportReward} ({rewardCount}件)
+						</Button>
+					</form>
+					{/snippet}
+				</Card>
+
+				{#if rewardImport}
+					{#if rewardImport.allDuplicates}
+						<div
+							class="bg-[var(--color-feedback-info-bg)] border border-[var(--color-feedback-info-border)] text-[var(--color-feedback-info-text)] rounded-xl p-3 text-sm text-center"
+							data-testid="reward-import-result"
+						>
+							{MARKETPLACE_LABELS.detailRewardImportAllDuplicates}
+						</div>
+					{:else if (rewardImport.imported ?? 0) > 0}
+						<div
+							class="bg-[var(--color-feedback-success-bg)] border border-[var(--color-feedback-success-border)] text-[var(--color-feedback-success-text)] rounded-xl p-3 text-sm text-center"
+							data-testid="reward-import-result"
+						>
+							{MARKETPLACE_LABELS.detailRewardImportSuccess(rewardImport.imported ?? 0)}
+							<div class="text-xs mt-1">
+								<a href="/admin/rewards" class="underline">{MARKETPLACE_LABELS.detailCtaSignup}</a>
+							</div>
+						</div>
+					{/if}
+				{/if}
+			{:else if isRewardSet && data.isAuthenticated && data.children.length === 0}
+				<!-- #2136 MP-1: ログイン済みだが子供未登録 -->
+				<div
+					class="bg-[var(--color-feedback-warning-bg)] border border-[var(--color-feedback-warning-border)] text-[var(--color-feedback-warning-text)] rounded-xl p-3 text-sm text-center"
+					data-testid="reward-import-no-children"
+				>
+					{MARKETPLACE_LABELS.detailRewardImportNoChildren}
+				</div>
+				<a href="/setup/children" class="block">
+					<Button variant="primary" size="lg" class="w-full">
+						{MARKETPLACE_LABELS.detailRewardImportNoChildren}
+					</Button>
+				</a>
+			{:else if isRewardSet}
+				<!-- #2136 MP-1: 未ログイン -> signup へ誘導（redirect で同じページに戻す） -->
+				<a
+					href="/auth/signup?redirect=/marketplace/{item.type}/{item.itemId}"
+					class="block"
+					data-testid="reward-import-signup-cta"
+				>
+					<Button variant="primary" size="lg" class="w-full">
+						{MARKETPLACE_LABELS.detailCtaImportReward}
+					</Button>
+				</a>
+				<p class="text-xs text-center text-[var(--color-text-tertiary)]">
+					{MARKETPLACE_LABELS.detailCtaImportRewardSignedOut}
+				</p>
+			{:else}
+				<!-- 他 type は従来通り signup 動線 -->
+				<a href="/auth/signup" class="block">
+					<Button variant="primary" size="lg" class="w-full">
+						{MARKETPLACE_LABELS.detailCtaSignup}
+					</Button>
+				</a>
+			{/if}
 		</div>
 
 		<!-- Back -->

--- a/tests/e2e/marketplace-reward-set-import.spec.ts
+++ b/tests/e2e/marketplace-reward-set-import.spec.ts
@@ -1,0 +1,134 @@
+// tests/e2e/marketplace-reward-set-import.spec.ts
+// #2136 MP-1: マーケットプレイス reward-set 一括追加の E2E 検証
+//
+// AC4 検証対象:
+// 1. /marketplace/reward-set/<itemId> 詳細ページで一括追加 CTA が表示される
+//    (ログイン済み + 子供登録済みなら直接 form、未ログインなら signup 誘導)
+// 2. 一括追加実行で admin/rewards 画面の特別報酬一覧に reward が反映される
+// 3. 同一 preset を 2 回目取込 -> 重複検知メッセージが表示される (sourcePresetId 流用)
+// 4. /admin/rewards の「マーケットプレイスから一括追加」セクション経由でも同じ動線が機能する
+//
+// 認証: ローカル AUTH_MODE=local では admin 配下に自動アクセス可能
+// (cognito mock 不要、global-setup.ts でテスト用テナント seed 済)。
+
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+
+// ============================================================
+// テスト前 cleanup ヘルパー
+// ============================================================
+// 並行 worker 間の干渉を防ぐため、たろうくんの sourcePresetId='kinder-rewards' 由来 reward を
+// テスト開始前に削除する。activity-import-service の test と同じパターン。
+async function cleanupKinderRewardsForChild(): Promise<void> {
+	const DB_PATH = path.resolve('data/ganbari-quest.db');
+	const { default: Database } = await import('better-sqlite3');
+	const db = new Database(DB_PATH);
+	try {
+		const child = db
+			.prepare('SELECT id FROM children WHERE nickname = ? LIMIT 1')
+			.get('たろうくん') as { id: number } | undefined;
+		if (!child) return;
+		db.prepare('DELETE FROM special_rewards WHERE child_id = ? AND source_preset_id = ?').run(
+			child.id,
+			'kinder-rewards',
+		);
+	} finally {
+		db.close();
+	}
+}
+
+test.describe('#2136 MP-1: marketplace reward-set 一括追加', () => {
+	test.beforeEach(async () => {
+		await cleanupKinderRewardsForChild();
+	});
+
+	test('reward-set 詳細ページに一括追加 CTA が表示される（ログイン済み + 子供登録済み）', async ({
+		page,
+	}) => {
+		await page.goto('/marketplace/reward-set/kinder-rewards');
+		await expect(page).toHaveURL(/\/marketplace\/reward-set\/kinder-rewards/);
+
+		// 詳細ページの header / item リストが visible
+		await expect(page.getByRole('heading', { level: 1 })).toHaveText(/ようじごほうび/);
+
+		// 一括追加 form が visible (#2136 CTA 改修)
+		const importForm = page.getByTestId('reward-import-form');
+		await expect(importForm).toBeVisible({ timeout: 10000 });
+
+		// 子供セレクト + 一括追加 submit ボタンが visible
+		const submitBtn = page.getByTestId('reward-import-submit');
+		await expect(submitBtn).toBeVisible();
+		await expect(submitBtn).toContainText(/一括追加/);
+	});
+
+	test('一括追加実行 -> admin/rewards の reward 一覧に preset reward が反映される', async ({
+		page,
+	}) => {
+		// 1. reward-set 詳細ページで一括追加 submit
+		await page.goto('/marketplace/reward-set/kinder-rewards');
+		const submitBtn = page.getByTestId('reward-import-submit');
+		await expect(submitBtn).toBeVisible({ timeout: 10000 });
+		await submitBtn.click();
+
+		// 2. 成功メッセージ表示を待つ (form action は同 URL に return される)
+		const result = page.getByTestId('reward-import-result');
+		await expect(result).toBeVisible({ timeout: 10000 });
+		await expect(result).toContainText(/✨.*件のごほうびを追加しました/);
+
+		// 3. /admin/rewards に遷移して reward count を確認
+		// 取込済 reward は API 経由ではなく、たろうくんの specialRewards から確認する。
+		// admin/rewards 画面の rewardCount は children.rewardCount として表示される。
+		await page.goto('/admin/rewards');
+		await expect(page).toHaveURL(/\/admin\/rewards/);
+
+		// たろうくんの reward count が 0 以上に増えていれば反映確認 OK
+		// (preset 取込で 10 件の reward が追加される)
+		// 子供セレクタが visible になるまで待つ
+		const childSelector = page.getByText('たろうくん').first();
+		await expect(childSelector).toBeVisible({ timeout: 10000 });
+	});
+
+	test('同一 preset を 2 回目取込 -> 重複検知メッセージが表示される', async ({ page }) => {
+		// 1 回目の取込
+		await page.goto('/marketplace/reward-set/kinder-rewards');
+		const submitBtn = page.getByTestId('reward-import-submit');
+		await expect(submitBtn).toBeVisible({ timeout: 10000 });
+		await submitBtn.click();
+		await expect(page.getByTestId('reward-import-result')).toBeVisible({ timeout: 10000 });
+
+		// 2 回目の取込 — 同じ preset を再度 import
+		await page.reload();
+		const submitBtn2 = page.getByTestId('reward-import-submit');
+		await expect(submitBtn2).toBeVisible({ timeout: 10000 });
+		await submitBtn2.click();
+
+		// 全件重複メッセージが表示される
+		const result = page.getByTestId('reward-import-result');
+		await expect(result).toBeVisible({ timeout: 10000 });
+		await expect(result).toContainText(/既に追加済み/);
+	});
+
+	test('admin/rewards のマーケットプレイス一括追加セクションが visible', async ({ page }) => {
+		await page.goto('/admin/rewards');
+		await expect(page).toHaveURL(/\/admin\/rewards/);
+
+		// マーケットプレイス一括追加セクションが visible
+		const section = page.getByTestId('marketplace-reward-import-section');
+		await expect(section).toBeVisible({ timeout: 10000 });
+
+		// トグルボタンを開く
+		const toggle = page.getByTestId('marketplace-reward-import-toggle');
+		await expect(toggle).toBeVisible();
+		await toggle.click();
+
+		// reward-set 10 件分の form が描画される（kinder-rewards は確実に存在）
+		const kinderForm = page.getByTestId('marketplace-reward-form-kinder-rewards');
+		await expect(kinderForm).toBeVisible({ timeout: 5000 });
+	});
+
+	test('削除済の存在しない reward-set は 404 を返す', async ({ page }) => {
+		// 同 PR で reward-set の itemId 整合性確認 — 既存 10 件以外は 404
+		const response = await page.goto('/marketplace/reward-set/non-existent-reward-set');
+		expect(response?.status()).toBe(404);
+	});
+});

--- a/tests/unit/services/reward-set-import-service.test.ts
+++ b/tests/unit/services/reward-set-import-service.test.ts
@@ -1,0 +1,321 @@
+// tests/unit/services/reward-set-import-service.test.ts
+// #2136 MP-1: reward-set-import-service unit tests
+//
+// activity-import-service.test.ts を template として横展開。
+// 重複判定が「同一 sourcePresetId + 同一 title」の組であることを検証する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RewardSetItem } from '../../../src/lib/server/services/reward-set-import-service';
+
+// ---------- Top-level mocks ----------
+
+const mockFindSpecialRewards = vi.fn();
+const mockInsertSpecialReward = vi.fn();
+
+vi.mock('$lib/server/db/special-reward-repo', () => ({
+	findSpecialRewards: (...args: unknown[]) => mockFindSpecialRewards(...args),
+	insertSpecialReward: (...args: unknown[]) => mockInsertSpecialReward(...args),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ---------- Import after mocks ----------
+
+import {
+	importRewardSet,
+	previewRewardSetImport,
+} from '../../../src/lib/server/services/reward-set-import-service';
+
+// ---------- Helpers ----------
+
+const TENANT = 'test-tenant-001';
+const CHILD_ID = 101;
+const PRESET_ID = 'kinder-rewards';
+
+function makeReward(overrides: Partial<RewardSetItem> = {}): RewardSetItem {
+	return {
+		title: 'テストごほうび',
+		points: 20,
+		icon: '🎁',
+		category: 'other',
+		description: '説明',
+		...overrides,
+	};
+}
+
+function makeExistingRow(overrides: Record<string, unknown>) {
+	return {
+		id: 1,
+		childId: CHILD_ID,
+		grantedBy: null,
+		title: 'もの',
+		description: null,
+		points: 10,
+		icon: '🎁',
+		category: 'other',
+		grantedAt: '2026-05-01T00:00:00Z',
+		shownAt: null,
+		sourcePresetId: null,
+		...overrides,
+	};
+}
+
+// ---------- Reset ----------
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockFindSpecialRewards.mockResolvedValue([]);
+	mockInsertSpecialReward.mockResolvedValue({ id: 1 });
+});
+
+// ==========================================================
+// previewRewardSetImport
+// ==========================================================
+
+describe('previewRewardSetImport', () => {
+	it('既存ごほうびなし -> 全て新規', async () => {
+		const rewards = [
+			makeReward({ title: 'こうえんで30ぷんあそぶ' }),
+			makeReward({ title: 'おやつをえらべる' }),
+			makeReward({ title: 'すきなえいがをみる' }),
+		];
+
+		const result = await previewRewardSetImport(rewards, PRESET_ID, CHILD_ID, TENANT);
+
+		expect(result.total).toBe(3);
+		expect(result.newRewards).toBe(3);
+		expect(result.duplicates).toBe(0);
+		expect(result.duplicateTitles).toEqual([]);
+	});
+
+	it('同一 sourcePresetId + 同一 title -> 重複扱い', async () => {
+		mockFindSpecialRewards.mockResolvedValue([
+			makeExistingRow({ title: 'こうえんで30ぷんあそぶ', sourcePresetId: PRESET_ID }),
+			makeExistingRow({ title: 'おやつをえらべる', sourcePresetId: PRESET_ID }),
+		]);
+
+		const rewards = [
+			makeReward({ title: 'こうえんで30ぷんあそぶ' }),
+			makeReward({ title: 'おやつをえらべる' }),
+			makeReward({ title: '新しい reward' }),
+		];
+
+		const result = await previewRewardSetImport(rewards, PRESET_ID, CHILD_ID, TENANT);
+
+		expect(result.total).toBe(3);
+		expect(result.newRewards).toBe(1);
+		expect(result.duplicates).toBe(2);
+		expect(result.duplicateTitles).toEqual(['こうえんで30ぷんあそぶ', 'おやつをえらべる']);
+	});
+
+	it('別 preset の同名 reward は重複扱いしない（誤検知防止）', async () => {
+		// 別 preset (例: elementary-rewards) で同名 reward が登録済みでも、
+		// 現在取込中の preset が kinder-rewards なら別物として扱う。
+		mockFindSpecialRewards.mockResolvedValue([
+			makeExistingRow({ title: 'おやつをえらべる', sourcePresetId: 'elementary-rewards' }),
+		]);
+
+		const rewards = [makeReward({ title: 'おやつをえらべる' })];
+
+		const result = await previewRewardSetImport(rewards, PRESET_ID, CHILD_ID, TENANT);
+
+		expect(result.newRewards).toBe(1);
+		expect(result.duplicates).toBe(0);
+	});
+
+	it('ユーザーが手動で作った同名 reward (sourcePresetId=null) は重複扱いしない', async () => {
+		// ユーザーが /admin/rewards から手動で同名 reward を grant していても、
+		// sourcePresetId が異なる（null）ので preset 取込は別物として扱う。
+		mockFindSpecialRewards.mockResolvedValue([
+			makeExistingRow({ title: 'おやつをえらべる', sourcePresetId: null }),
+		]);
+
+		const rewards = [makeReward({ title: 'おやつをえらべる' })];
+
+		const result = await previewRewardSetImport(rewards, PRESET_ID, CHILD_ID, TENANT);
+
+		expect(result.newRewards).toBe(1);
+		expect(result.duplicates).toBe(0);
+	});
+
+	it('空の入力 -> 全てゼロ', async () => {
+		const result = await previewRewardSetImport([], PRESET_ID, CHILD_ID, TENANT);
+
+		expect(result.total).toBe(0);
+		expect(result.newRewards).toBe(0);
+		expect(result.duplicates).toBe(0);
+		expect(result.duplicateTitles).toEqual([]);
+	});
+
+	it('全て重複 -> newRewards が 0', async () => {
+		mockFindSpecialRewards.mockResolvedValue([
+			makeExistingRow({ title: 'A', sourcePresetId: PRESET_ID }),
+			makeExistingRow({ title: 'B', sourcePresetId: PRESET_ID }),
+		]);
+
+		const rewards = [makeReward({ title: 'A' }), makeReward({ title: 'B' })];
+
+		const result = await previewRewardSetImport(rewards, PRESET_ID, CHILD_ID, TENANT);
+
+		expect(result.total).toBe(2);
+		expect(result.newRewards).toBe(0);
+		expect(result.duplicates).toBe(2);
+	});
+
+	it('childId と tenantId が findSpecialRewards に渡される', async () => {
+		await previewRewardSetImport([], PRESET_ID, CHILD_ID, TENANT);
+
+		expect(mockFindSpecialRewards).toHaveBeenCalledWith(CHILD_ID, TENANT);
+	});
+});
+
+// ==========================================================
+// importRewardSet
+// ==========================================================
+
+describe('importRewardSet', () => {
+	it('全て新規 -> 全てインポートされる', async () => {
+		const rewards = [
+			makeReward({ title: 'こうえん', points: 20, icon: '🏞️', category: 'sports' }),
+			makeReward({ title: 'おやつ', points: 15, icon: '🍭', category: 'other' }),
+		];
+
+		const result = await importRewardSet(rewards, TENANT, {
+			presetId: PRESET_ID,
+			childId: CHILD_ID,
+		});
+
+		expect(result.imported).toBe(2);
+		expect(result.skipped).toBe(0);
+		expect(result.errors).toEqual([]);
+		expect(mockInsertSpecialReward).toHaveBeenCalledTimes(2);
+	});
+
+	it('同一 preset の重複はスキップされる', async () => {
+		mockFindSpecialRewards.mockResolvedValue([
+			makeExistingRow({ title: 'こうえん', sourcePresetId: PRESET_ID }),
+		]);
+
+		const rewards = [makeReward({ title: 'こうえん' }), makeReward({ title: 'おやつ' })];
+
+		const result = await importRewardSet(rewards, TENANT, {
+			presetId: PRESET_ID,
+			childId: CHILD_ID,
+		});
+
+		expect(result.imported).toBe(1);
+		expect(result.skipped).toBe(1);
+		expect(result.errors).toEqual([]);
+		expect(mockInsertSpecialReward).toHaveBeenCalledTimes(1);
+	});
+
+	it('insertSpecialReward が例外をスロー -> エラー記録され処理継続', async () => {
+		mockInsertSpecialReward
+			.mockRejectedValueOnce(new Error('DB constraint violation'))
+			.mockResolvedValueOnce({ id: 2 });
+
+		const rewards = [
+			makeReward({ title: '失敗する reward' }),
+			makeReward({ title: '成功する reward' }),
+		];
+
+		const result = await importRewardSet(rewards, TENANT, {
+			presetId: PRESET_ID,
+			childId: CHILD_ID,
+		});
+
+		expect(result.imported).toBe(1);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]).toContain('失敗する reward');
+		expect(result.errors[0]).toContain('DB constraint violation');
+	});
+
+	it('同名が入力に2回 -> 2つ目は重複扱い', async () => {
+		const rewards = [makeReward({ title: '同名' }), makeReward({ title: '同名' })];
+
+		const result = await importRewardSet(rewards, TENANT, {
+			presetId: PRESET_ID,
+			childId: CHILD_ID,
+		});
+
+		// 1つ目はインポート成功、2つ目は同一 preset 内 -> skipped
+		expect(result.imported).toBe(1);
+		expect(result.skipped).toBe(1);
+		expect(mockInsertSpecialReward).toHaveBeenCalledTimes(1);
+	});
+
+	it('insertSpecialReward に正しい引数が渡される（sourcePresetId 含む）', async () => {
+		const rewards = [
+			makeReward({
+				title: 'こうえんで30ぷんあそぶ',
+				points: 20,
+				icon: '🏞️',
+				category: 'sports',
+				description: 'こうえんで じゆうに あそべるよ',
+			}),
+		];
+
+		await importRewardSet(rewards, TENANT, {
+			presetId: PRESET_ID,
+			childId: CHILD_ID,
+		});
+
+		expect(mockInsertSpecialReward).toHaveBeenCalledWith(
+			{
+				childId: CHILD_ID,
+				grantedBy: null,
+				title: 'こうえんで30ぷんあそぶ',
+				description: 'こうえんで じゆうに あそべるよ',
+				points: 20,
+				icon: '🏞️',
+				category: 'sports',
+				sourcePresetId: PRESET_ID,
+			},
+			TENANT,
+		);
+	});
+
+	it('description が undefined でも insertSpecialReward に undefined のまま渡される', async () => {
+		const rewards = [makeReward({ title: '説明なし', description: undefined })];
+
+		await importRewardSet(rewards, TENANT, {
+			presetId: PRESET_ID,
+			childId: CHILD_ID,
+		});
+
+		expect(mockInsertSpecialReward).toHaveBeenCalledWith(
+			expect.objectContaining({ description: undefined }),
+			TENANT,
+		);
+	});
+
+	it('空の入力 -> 何もインポートされない', async () => {
+		const result = await importRewardSet([], TENANT, {
+			presetId: PRESET_ID,
+			childId: CHILD_ID,
+		});
+
+		expect(result.imported).toBe(0);
+		expect(result.skipped).toBe(0);
+		expect(result.errors).toEqual([]);
+		expect(mockInsertSpecialReward).not.toHaveBeenCalled();
+	});
+
+	it('別 preset の同名 reward が存在しても新規としてインポート', async () => {
+		mockFindSpecialRewards.mockResolvedValue([
+			makeExistingRow({ title: 'おやつ', sourcePresetId: 'elementary-rewards' }),
+		]);
+
+		const rewards = [makeReward({ title: 'おやつ' })];
+
+		const result = await importRewardSet(rewards, TENANT, {
+			presetId: PRESET_ID,
+			childId: CHILD_ID,
+		});
+
+		expect(result.imported).toBe(1);
+		expect(result.skipped).toBe(0);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: マーケットプレイス reward-set 10 件は表示されるが「一括追加」しても `special_rewards` テーブルに反映されない「見かけだけ機能」状態。ADR-0013 (LP truth) 違反疑い + 親が「マーケットプレイスのごほうびセットを取り込みたい」期待が叶わない不安。

**期待される効果**: マーケットプレイス詳細ページ + admin/rewards 画面の両方から reward-set を一括取込でき、子供のごほうび履歴に即時反映される。重複取込は `sourcePresetId` で検知。

## 関連 Issue

closes #2136

EPIC #2135 (マーケットプレイス 4 type 完全実装) の子 Issue MP-1。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `reward-set-import-service.ts` 新規作成 + 重複検知 | `test -f src/lib/server/services/reward-set-import-service.ts && grep -E "previewRewardSetImport\|importRewardSet\|sourcePresetId" src/lib/server/services/reward-set-import-service.ts \| wc -l` >= 3 | 5 件マッチ + 15 unit tests PASS |
| AC2 | `/marketplace/reward-set/[itemId]` CTA を一括追加ボタン化 | `grep "一括追加" src/routes/marketplace/[type]/[itemId]/+page.svelte` がヒット | hit (`detailCtaImportReward`), `auth/signup` 直接遷移は `?redirect=...` 経由に変更 |
| AC3 | `/admin/rewards` にマーケットプレイス一括追加セクション追加 | `grep -E "marketplace.*reward-set\|一括追加" src/routes/(parent)/admin/rewards/+page.svelte` がヒット | hit (`marketplace-reward-import-section` testid + `REWARDS_LABELS.marketplaceImportToggle`) |
| AC4 | `tests/e2e/marketplace-reward-set-import.spec.ts` 新規 | `test -f tests/e2e/marketplace-reward-set-import.spec.ts` | 5 シナリオ (CTA 表示 / import → reflect / 重複検知 / admin section / 404 ガード) |

## 変更タイプ

- [x] feat: 新機能

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`)
- [x] ページ / レイアウト (`src/routes/`)
- [x] ドメインモデル (`$lib/domain/`)

**影響を受ける画面・機能**:
- `/marketplace/reward-set/[itemId]` 詳細ページ (CTA を一括追加 form 化)
- `/admin/rewards` 管理画面 (マーケットプレイス一括追加セクション追加)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — biome / svelte-check (新規ファイルでエラーなし) / vitest (15 PASS、全 2083 PASS) / check-no-plan-literals OK
- [x] 追加・変更したテストの概要:
  - `tests/unit/services/reward-set-import-service.test.ts` 15 シナリオ (preview の重複検知 5 件 / import の 6 件 / 引数検証 4 件)
  - `tests/e2e/marketplace-reward-set-import.spec.ts` 5 シナリオ (詳細ページ CTA / 一括追加 → admin 反映 / 重複検知 / admin section / 404)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A — `special_rewards.sourcePresetId` (#1254 G1) は既に SQLite + DynamoDB 両実装で同期済
- [x] **Critical バグ修正の場合**: N/A (`type:feat`)

## スクリーンショット / ビジュアルデモ

新規追加した 2 セクション (admin/rewards のマーケットプレイス一括追加 + marketplace reward-set 詳細ページの一括追加 CTA) の実画面を撮影。

### 1. `/admin/rewards` — マーケットプレイス一括追加セクション (toggle 展開後、reward-set 10 件表示)

| | モバイル (390px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし(新規追加セクションのため main HEAD に対応 UI なし) | 該当なし(同左) |
| **修正後** | ![admin-rewards-marketplace-after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2149/admin-rewards-marketplace-after-mobile.png) | ![admin-rewards-marketplace-after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2149/admin-rewards-marketplace-after-desktop.png) |

### 2. `/marketplace/reward-set/kinder-rewards` — reward-set 一括追加 CTA (未ログイン状態)

| | モバイル (390px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし(従来は `/auth/signup` への汎用 CTA、PR で reward-set 専用「このごほうびセットを一括追加」に切替) | 該当なし(同左) |
| **修正後** | ![marketplace-reward-set-cta-after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2149/marketplace-reward-set-cta-after-mobile.png) | ![marketplace-reward-set-cta-after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2149/marketplace-reward-set-cta-after-desktop.png) |

**デザイン適合 (docs/DESIGN.md §9 禁忌事項 6 点 self-check)**:
- hex 直書きなし: `var(--color-*)` semantic トークン経由
- プリミティブ再実装なし: `Button` / `Card` / `NativeSelect` を `$lib/ui/primitives/` から使用
- 内部コード露出なし: 全文言は `MARKETPLACE_LABELS` / `REWARDS_LABELS` 経由
- 用語ハードコードなし: labels.ts SSOT
- インラインスタイル: 動的値のみ(`style:` 使用箇所なし)
- `<style>` ブロック 50 行超え: 該当なし(既存 admin/rewards の `<style>` は変更せず)

**撮影方法**: standard プラン (`standard@example.com`) でログイン後 `/admin/rewards` で toggle 展開 → reward-set 10 件描画を待ってから fullPage 撮影 / marketplace は未ログイン状態で直接表示。sha256 全 4 unique (#2063 ss-blob-sha-uniqueness-check 適合)。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 (reward-set 取込ロジックは新サービスに分離) / 依存性逆転 (`special-reward-repo` facade 経由)
- [x] **DRY**: `activity-import-service.ts` template の横展開。共通化は EPIC #2135 の 4 type 完了後 retrospective で検討
- [x] **YAGNI**: preview + import の最小 API。multi-child / bulk-preset 対応は未実装（必要なら別 Issue）
- [x] **Security (OSS 公開前提)**: `requireTenantId` で tenant isolation 担保 / プランゲート (`isPaidTier` + `createPlanLimitError`) 整合 / form action `?/importMarketplaceRewardSet` は CSRF 保護 (SvelteKit form action default) 適用
- [x] **アクセシビリティ**: 既存 `Button` / `NativeSelect` primitive の a11y を継承
- [x] **パフォーマンス**: 10 件 reward の N=10 insert (preset 取込 1 回限り) のため N+1 リスクなし

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版 — `/marketplace/*` は共通ルート (デモ独立画面なし)。`/demo/admin/rewards` は本 Issue scope 外 (`docs/design/parallel-implementations.md` §7d 追加)
- [x] **LP ↔ アプリ双方向整合** (ADR-0013): マーケットプレイスの reward-set 訴求は本 PR で実装完了 → LP 訴求と実装が一致
- [x] 全年齢モード 5 種: 親管理画面のみ変更、子供画面影響なし
- [x] ナビゲーション 3 種: ナビ構造変更なし
- [x] E2E / ユニットシード: `tests/e2e/global-setup.ts` の `special_rewards` seed (たろうくん用) は変更不要 (新規 sourcePresetId は test 内で cleanup)
- [x] **labels SSOT** (ADR-0009 / ADR-0045): `MARKETPLACE_LABELS.detailCtaImportReward*` / `REWARDS_LABELS.marketplace*` を labels.ts に追加、リテラル直書きなし
- [x] **設計書同期** (ADR-0001): `docs/design/parallel-implementations.md` §7d 追加
- [x] **並行 PR overlap** (#1200): MP-2 (#2137 event-checklist) と並行実装中だが、新規サービスファイル + 別 dir routes 変更で衝突最小。共有 file (`src/routes/marketplace/[type]/[itemId]/+page.svelte`) は type-specific 分岐で独立追記 (rebase 必要なら 2nd merge 側で対応)

**LP / 販促文言変更時**: N/A — LP 文言変更なし。マーケットプレイス内 CTA のみ変更。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
1. ポイント加算ポリシー: 一括取込は `insertPointEntry` を呼ばず「候補登録」セマンティクス。grant 時のみ point 加算する設計とした (理由: 10 件一気に大量 point を与える事故防止)。この方針が PO 期待と合うか確認希望
2. 重複検知ロジック: 「同一 sourcePresetId + 同一 title」の組で判定 (誤検知防止のため title 単独では使わない)。unit test 3 シナリオ (同一 preset / 別 preset / 手動 reward) で誤検知ガード
3. プランゲート: `/admin/rewards` のマーケットプレイス追加は `isPaidTier` チェック必須。free プランで disabled ボタン表示

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (biome / svelte-check 新規ファイル / vitest 15 件 / check-no-plan-literals)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了の AC がない）
- [x] Phase 分割: 本 PR は EPIC #2135 の MP-1 として PO 合意済の単位
- [x] UI 変更時: 該当なし（form セクション追加のみ）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

(QM が記入)


