### PR TITLE
feat: #2137 MP-2 event-checklist 完全実装 (import service + 一括追加 UI + 詳細 CTA)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1362,10 +1362,32 @@ AdminHome.svelte
 |------|----------|
 | URL | `/admin/checklists` |
 | 削除された UI | role=tablist の「チェックリスト種別」タブ（routine / item）/ 種別選択ラジオ |
-| 残った UI | 子供選択 + AI 提案パネル + テンプレート一覧（持ち物のみ） + テンプレート作成ダイアログ（持ち物固定） |
+| 残った UI | 子供選択 + AI 提案パネル + **マーケットプレイス取込セクション (#2137)** + テンプレート一覧（持ち物のみ） + テンプレート作成ダイアログ（持ち物固定） |
 | empty state | `🎒 持ち物チェックリストがまだありません`（`emptyChecklistMessage`） |
 | ダイアログタイトル | `持ち物チェックリスト作成`（`addTemplateDialogTitle`） |
 | 並行実装 | child checklist (`/(child)/checklist` / `/demo/(child)/checklist`) も `kindOrder` 削除済み — `flatChecklists` で flat 表示 |
+
+##### マーケットプレイス取込セクション (#2137 / MP-2 EPIC #2135)
+
+`event-checklist` プリセット (3 件: `event-pool` / `event-school-start` / `event-field-trip`) を一括追加するセクション。子供選択直下、AI 提案パネルの後に配置。
+
+| 要素 | 動作 |
+|------|------|
+| セクション見出し | `🏪 マーケットプレイスから一括追加`（`ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceSectionTitle`） |
+| preset row | プリセット名 / アイコン / `N項目` 件数 / `[一括追加]` ボタン（type=primary）|
+| 取込済 Badge | 同 (`childId × sourcePresetId`) のテンプレートが既存なら `取込済` Badge 表示 + ボタンが disabled (`outline` variant) |
+| Action | `?/importMarketplace` (POST form action)。重複時は alreadyImported result、新規時は success result |
+| プラン制限 | Free プランの `maxChecklistTemplates` 上限に達している場合は 403 + `PlanLimitError` |
+| サービス層 | `src/lib/server/services/checklist-template-import-service.ts` (`importChecklistTemplate` / `previewChecklistImport`) |
+
+**マーケットプレイス詳細ページからの CTA (`/marketplace/checklist/[itemId]`)**:
+
+| 状態 | CTA |
+|------|-----|
+| ログイン済 | 直接「一括追加」button + 子供セレクタ（複数子供時のみ） |
+| 未ログイン | 「がんばりクエストに登録して 一括追加」link → `/auth/signup?next=/marketplace/checklist/[itemId]` |
+
+重複判定は `checklist_templates.sourcePresetId` カラム（#1254 G1 整備済）で行い、DB スキーマ変更なし。activity-pack `importPack` パターンを横展開（ADR-0014 整合、`src/lib/server/services/activity-import-service.ts` を template として横展開）。
 
 #### `/admin/children` — 子供管理フォーム仕様 (#1380 / #1478)
 

--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -2172,6 +2172,7 @@ export interface PlanLimitError {
 | `POST /admin/children ?/addChild` | 上限付き | `free` は `maxChildren=2` まで | `createPlanLimitError()` 済 (#787) |
 | `POST /admin/activities ?/create` | 上限付き | `free` は `maxActivities=3` まで | `createPlanLimitError()` 済 (#787) |
 | `POST /admin/checklists ?/createTemplate` | 上限付き | `free` は `maxChecklistTemplates=3` まで (#723) | `createPlanLimitError()` 済 (#787) |
+| `POST /admin/checklists ?/importMarketplace` | 上限付き | `free` は `maxChecklistTemplates=3` まで (#2137) | `createPlanLimitError()` 済 (#787) |
 | `POST /admin/rewards ?/grant` | standard | 特別なごほうび (`canCustomReward`, #728) | `createPlanLimitError()` 済 (#787) |
 | `POST /admin/rewards ?/addPreset` | standard | 特別なごほうび取り込み (#728) | `createPlanLimitError()` 済 (#787) |
 | `POST /api/v1/special-rewards/suggest` | family | AI ごほうび提案 (`tier !== 'family'`, #719) | `apiError()` 済 |

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -882,6 +882,16 @@ export const MARKETPLACE_LABELS = {
 	detailRewardImportAllDuplicates: 'このごほうびセットは既に追加済みです',
 	/** #2136 MP-1: お子さま未登録時の誘導 */
 	detailRewardImportNoChildren: 'まずはお子さまを登録してください',
+	// #2137 (MP-2): event-checklist 一括追加 CTA
+	detailCtaImportChecklist: '一括追加',
+	detailCtaImportChecklistDesc:
+		'お子さまの「持ち物リスト」へまとめて追加します（重複時はスキップ）',
+	detailCtaSignupToImport: 'がんばりクエストに登録して 一括追加',
+	detailChildSelectLabel: 'どのお子さまに追加しますか？',
+	detailImportSuccess: (n: number) => `${n}件のチェック項目を追加しました`,
+	detailImportDuplicate: (templateName: string) =>
+		`「${templateName}」は既に取込済みのためスキップしました`,
+	detailImportError: 'インポートに失敗しました',
 	backToTypeListSuffix: '一覧に戻る',
 	typeCountSuffix: '種',
 } as const;
@@ -4008,6 +4018,18 @@ export const ADMIN_CHECKLISTS_PAGE_LABELS = {
 	addItemDialogTitle: 'アイテム追加',
 	overrideDialogTitle: 'ワンオフ追加/除外',
 	premiumBadgeLabel: 'スタンダード以上',
+	// #2137 (MP-2): マーケットプレイス checklist 一括追加セクション
+	marketplaceSectionTitle: '🏪 マーケットプレイスから一括追加',
+	marketplaceSectionDesc:
+		'季節やイベント時の持ち物リストをワンタップで取込めます（重複時はスキップ）',
+	marketplaceItemCount: (n: number) => `${n}項目`,
+	marketplaceImportButton: '一括追加',
+	marketplaceImportedBadge: '取込済',
+	marketplaceImportSuccess: (presetName: string, items: number) =>
+		`✅ 「${presetName}」: ${items}項目を追加しました`,
+	marketplaceImportDuplicate: (presetName: string) =>
+		`⚠️ 「${presetName}」は既に取込済みのためスキップしました`,
+	marketplaceSeeMore: 'すべてのチェックリストを見る →',
 } as const;
 
 export const DEMO_ACTIVITIES_LABELS = {

--- a/src/lib/server/services/checklist-template-import-service.ts
+++ b/src/lib/server/services/checklist-template-import-service.ts
@@ -1,0 +1,193 @@
+// src/lib/server/services/checklist-template-import-service.ts
+// #2137 (MP-2): event-checklist 一括追加サービス
+//
+// activity-import-service.ts を template として横展開（ADR-0014 整合）。
+// マーケットプレイス checklist 系プリセット (event-pool / event-school-start / event-field-trip
+// など) を `checklist_templates` + `checklist_template_items` に一括投入する。
+// 重複検出は `checklist_templates.sourcePresetId` (#1254 G1 整備済) を使い、
+// 同一 (childId × presetId) のテンプレートが既に存在する場合は丸ごとスキップする。
+
+import { getMarketplaceItem } from '$lib/data/marketplace';
+import type { ChecklistPayload, MarketplaceItem } from '$lib/domain/marketplace-item';
+import { findTemplatesByChild } from '$lib/server/db/checklist-repo';
+import { logger } from '$lib/server/logger';
+import { addTemplateItem, createTemplate } from '$lib/server/services/checklist-service';
+
+export interface ChecklistImportPreview {
+	/** Preset itemId (例: 'event-pool') */
+	presetId: string;
+	/** Preset 表示名 (例: 'プールの もちもの') */
+	presetName: string;
+	/** Preset icon (例: '🏊') */
+	presetIcon: string;
+	/** Preset 内の item 数 (例: 10) */
+	itemCount: number;
+	/** 既に同 (childId × presetId) で取込済か */
+	alreadyImported: boolean;
+	/** 既に取込済の場合、その template の表示名（衝突告知用） */
+	existingTemplateName?: string;
+}
+
+export interface ChecklistImportResult {
+	/** 新規追加された template 数 (0 or 1。重複 import 時は 0) */
+	imported: number;
+	/** スキップされた template 数 (重複時 1) */
+	skipped: number;
+	/** 追加された item 数 */
+	importedItems: number;
+	/** エラーメッセージ (item 個別失敗のみ。template 全体失敗時は throw) */
+	errors: string[];
+	/** 作成された template ID (imported=1 時のみ) */
+	templateId?: number;
+}
+
+/**
+ * インポート対象の checklist preset をプレビュー（DB 書き込みなし）
+ *
+ * @param presetId  Marketplace item ID (例: 'event-pool')
+ * @param childId   インポート先の子供 ID
+ * @param tenantId  テナント ID
+ */
+export async function previewChecklistImport(
+	presetId: string,
+	childId: number,
+	tenantId: string,
+): Promise<ChecklistImportPreview | null> {
+	const item = getMarketplaceItem('checklist', presetId);
+	if (!item) {
+		return null;
+	}
+	const payload = item.payload as ChecklistPayload;
+
+	// #1254 G1 sourcePresetId による既存判定（重複検出）
+	const existingTemplates = await findTemplatesByChild(childId, tenantId, true);
+	const existing = existingTemplates.find((t) => t.sourcePresetId === presetId);
+
+	return {
+		presetId,
+		presetName: item.name,
+		presetIcon: item.icon,
+		itemCount: payload.items.length,
+		alreadyImported: existing != null,
+		existingTemplateName: existing?.name,
+	};
+}
+
+/**
+ * チェックリストインポートのオプション
+ *
+ * @property timeSlot  ChecklistPayload.timing (morning/evening/weekend/daily/weekly) を
+ *                     `checklist_templates.timeSlot` (morning/afternoon/evening/anytime) に
+ *                     正規化した値。指定なしの場合は 'anytime' を使用。
+ */
+export interface ImportChecklistTemplateOptions {
+	timeSlot?: string;
+}
+
+/**
+ * Marketplace の ChecklistPayload.timing を checklist_templates.timeSlot に正規化する。
+ *
+ * checklist_templates.timeSlot の許容値は 'morning' | 'afternoon' | 'evening' | 'anytime' のみ
+ * (`VALID_TIME_SLOTS` SSOT、checklist-service.ts)。event-* preset は全て timing='daily' のため
+ * デフォルトで 'anytime' にマップする。
+ */
+function normalizeTimeSlot(timing: ChecklistPayload['timing']): string {
+	if (timing === 'morning') return 'morning';
+	if (timing === 'evening') return 'evening';
+	// 'weekend' / 'daily' / 'weekly' は持ち物リスト用途では時間帯指定なしで扱う
+	return 'anytime';
+}
+
+/**
+ * Marketplace の checklist preset をテンプレート + items として一括投入する。
+ *
+ * 重複検出: 同一 (childId × sourcePresetId) のテンプレートが既に存在する場合は
+ * 何も追加せず `imported=0 / skipped=1` で返却する。Items の個別重複検出は行わない
+ * （preset は atomic unit として扱う、activity-import-service と同じ考え方）。
+ *
+ * @param presetId  Marketplace item ID (例: 'event-pool')
+ * @param childId   インポート先の子供 ID
+ * @param tenantId  テナント ID
+ * @param options   timeSlot 上書き等のオプション
+ */
+export async function importChecklistTemplate(
+	presetId: string,
+	childId: number,
+	tenantId: string,
+	options?: ImportChecklistTemplateOptions,
+): Promise<ChecklistImportResult> {
+	const item: MarketplaceItem | null = getMarketplaceItem('checklist', presetId);
+	if (!item) {
+		throw new Error(`Marketplace preset 'checklist/${presetId}' が見つかりません`);
+	}
+	const payload = item.payload as ChecklistPayload;
+
+	// #1254 G1 sourcePresetId による既存判定（preset 全体スキップ）
+	const existingTemplates = await findTemplatesByChild(childId, tenantId, true);
+	const duplicate = existingTemplates.find((t) => t.sourcePresetId === presetId);
+	if (duplicate) {
+		logger.info('[checklist-import] 既に同 preset で取込済 → スキップ', {
+			context: { tenantId, childId, presetId, existingTemplateId: duplicate.id },
+		});
+		return { imported: 0, skipped: 1, importedItems: 0, errors: [] };
+	}
+
+	const timeSlot = options?.timeSlot ?? normalizeTimeSlot(payload.timing);
+
+	// 1. template 本体を作成
+	const template = await createTemplate(
+		{
+			childId,
+			name: item.name,
+			icon: item.icon,
+			timeSlot,
+			sourcePresetId: presetId,
+		},
+		tenantId,
+	);
+
+	// 2. items を順次追加
+	const errors: string[] = [];
+	let importedItems = 0;
+
+	// preset の order 昇順に追加 (持ち物の表示順を維持)
+	const sortedItems = [...payload.items].sort((a, b) => a.order - b.order);
+
+	for (const ci of sortedItems) {
+		try {
+			await addTemplateItem(
+				{
+					templateId: template.id,
+					name: ci.label,
+					icon: ci.icon,
+					frequency: 'daily',
+					direction: 'bring',
+					sortOrder: ci.order,
+				},
+				tenantId,
+			);
+			importedItems++;
+		} catch (e) {
+			errors.push(`「${ci.label}」: ${String(e)}`);
+		}
+	}
+
+	logger.info('[checklist-import] インポート完了', {
+		context: {
+			tenantId,
+			childId,
+			presetId,
+			templateId: template.id,
+			importedItems,
+			errors: errors.length,
+		},
+	});
+
+	return {
+		imported: 1,
+		skipped: 0,
+		importedItems,
+		errors,
+		templateId: template.id,
+	};
+}

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { getMarketplaceIndex } from '$lib/data/marketplace';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { todayDateJST } from '$lib/domain/date-utils';
 import { createPlanLimitError } from '$lib/domain/errors';
@@ -9,6 +10,7 @@ import {
 	findTemplateItems,
 	findTemplatesByChild,
 } from '$lib/server/db/checklist-repo';
+import { logger } from '$lib/server/logger';
 import {
 	addOverride,
 	addTemplateItem,
@@ -19,6 +21,10 @@ import {
 	removeTemplateItem,
 	VALID_TIME_SLOTS,
 } from '$lib/server/services/checklist-service';
+import {
+	importChecklistTemplate,
+	previewChecklistImport,
+} from '$lib/server/services/checklist-template-import-service';
 import { getAllChildren } from '$lib/server/services/child-service';
 import {
 	checkChecklistTemplateLimit,
@@ -59,11 +65,27 @@ export const load: PageServerLoad = async ({ locals }) => {
 	// #723: UI 側で「残り何個作れるか」を表示するための上限情報
 	const checklistTemplateMax = getPlanLimits(tier).maxChecklistTemplates;
 
+	// #2137 (MP-2): マーケットプレイス checklist preset (event-* 3 件) を一覧化
+	// childrenWithChecklists.sourcePresetId と突き合わせて「取込済」判定を UI で行う
+	const marketplaceChecklists = getMarketplaceIndex()
+		.filter((m) => m.type === 'checklist')
+		.map((m) => ({
+			itemId: m.itemId,
+			name: m.name,
+			description: m.description,
+			icon: m.icon,
+			targetAgeMin: m.targetAgeMin,
+			targetAgeMax: m.targetAgeMax,
+			tags: m.tags,
+			itemCount: m.itemCount,
+		}));
+
 	return {
 		children: childrenWithChecklists,
 		today: todayDateJST(),
 		isPremium,
 		checklistTemplateMax,
+		marketplaceChecklists,
 	};
 };
 
@@ -263,5 +285,63 @@ export const actions: Actions = {
 		}
 
 		return { success: true, aiCreated: true };
+	},
+
+	// #2137 (MP-2): マーケットプレイス event-checklist の一括追加
+	// admin/checklists 画面の「マーケットプレイスから一括追加」セクションから POST される。
+	// 同一 (childId × presetId) で取込済なら何もせず onlyAlreadyImported=true を返す。
+	importMarketplace: async ({ request, locals }) => {
+		const tenantId = requireTenantId(locals);
+		const formData = await request.formData();
+		const childId = Number(formData.get('childId'));
+		const presetId = String(formData.get('presetId') ?? '').trim();
+
+		if (!childId) return fail(400, { error: 'こどもを選択してください' });
+		if (!presetId) return fail(400, { error: 'プリセットIDが必要です' });
+
+		// プラン制限 (Free プランのテンプレート数)
+		const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
+		const limit = await checkChecklistTemplateLimit(tenantId, licenseStatus, childId);
+		if (!limit.allowed) {
+			const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
+			return fail(403, {
+				error: createPlanLimitError(
+					tier,
+					'standard',
+					`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+				),
+				upgradeRequired: true,
+			});
+		}
+
+		try {
+			const preview = await previewChecklistImport(presetId, childId, tenantId);
+			if (!preview) {
+				return fail(404, { error: 'プリセットが見つかりません' });
+			}
+			if (preview.alreadyImported) {
+				return {
+					marketplaceImportResult: true,
+					alreadyImported: true,
+					presetName: preview.presetName,
+					existingTemplateName: preview.existingTemplateName,
+				};
+			}
+
+			const result = await importChecklistTemplate(presetId, childId, tenantId);
+			return {
+				marketplaceImportResult: true,
+				alreadyImported: false,
+				presetName: preview.presetName,
+				importedItems: result.importedItems,
+				errors: result.errors,
+			};
+		} catch (e) {
+			logger.error('[admin/checklists] マーケットプレイスインポート失敗', {
+				error: e instanceof Error ? e.message : String(e),
+				context: { presetId, childId },
+			});
+			return fail(500, { error: 'インポートに失敗しました' });
+		}
 	},
 };

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -11,7 +11,7 @@ import Dialog from '$lib/ui/primitives/Dialog.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
 import NativeSelect from '$lib/ui/primitives/NativeSelect.svelte';
 
-let { data } = $props();
+let { data, form } = $props();
 
 let selectedChildId = $state(0);
 
@@ -152,6 +152,16 @@ function acceptAiChecklist(preview: ChecklistPreviewData) {
 		aiFormEl?.requestSubmit();
 	});
 }
+
+// #2137 (MP-2): マーケットプレイス checklist preset の取込済判定
+//   selectedChild.templates の sourcePresetId と突き合わせる
+const importedPresetIds = $derived(
+	new Set(
+		(selectedChild?.templates ?? [])
+			.map((t) => t.sourcePresetId)
+			.filter((id): id is string => Boolean(id)),
+	),
+);
 </script>
 
 <svelte:head>
@@ -196,6 +206,101 @@ function acceptAiChecklist(preview: ChecklistPreviewData) {
 			<input type="hidden" name="templateIcon" value={aiTemplateIcon} />
 			<input type="hidden" name="items" value={aiItemsJson} />
 		</form>
+
+		<!-- #2137 (MP-2): マーケットプレイスから一括追加セクション -->
+		{#if data.marketplaceChecklists.length > 0}
+			<Card variant="elevated" padding="lg">
+				{#snippet children()}
+				<div class="space-y-3" data-testid="marketplace-import-section">
+					<div class="flex items-center justify-between">
+						<h2 class="text-sm font-bold text-[var(--color-text-primary)]">
+							{ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceSectionTitle}
+						</h2>
+						<a
+							href="/marketplace?type=checklist"
+							class="text-xs text-[var(--color-action-primary)] hover:underline"
+						>
+							{ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceSeeMore}
+						</a>
+					</div>
+					<p class="text-xs text-[var(--color-text-tertiary)]">
+						{ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceSectionDesc}
+					</p>
+
+					{#if form?.marketplaceImportResult}
+						{#if form.alreadyImported}
+							<div
+								class="px-3 py-2 rounded-md text-sm bg-[var(--color-feedback-warning-bg)] text-[var(--color-feedback-warning-text)]"
+								data-testid="marketplace-admin-result-duplicate"
+							>
+								{ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceImportDuplicate(form.presetName ?? '')}
+							</div>
+						{:else}
+							<div
+								class="px-3 py-2 rounded-md text-sm bg-[var(--color-feedback-success-bg)] text-[var(--color-feedback-success-text)]"
+								data-testid="marketplace-admin-result-success"
+							>
+								{ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceImportSuccess(
+									form.presetName ?? '',
+									form.importedItems ?? 0,
+								)}
+							</div>
+						{/if}
+					{/if}
+
+					<div class="space-y-2">
+						{#each data.marketplaceChecklists as preset (preset.itemId)}
+							{@const alreadyImported = importedPresetIds.has(preset.itemId)}
+							<div
+								class="flex items-center gap-3 px-3 py-2 rounded-lg bg-[var(--color-surface-muted)]"
+								data-testid="marketplace-preset-row-{preset.itemId}"
+							>
+								<span class="text-2xl">{preset.icon}</span>
+								<div class="flex-1 min-w-0">
+									<div class="flex items-center gap-2">
+										<span class="text-sm font-medium text-[var(--color-text-primary)] truncate">
+											{preset.name}
+										</span>
+										{#if alreadyImported}
+											<span
+												class="text-[10px] px-1.5 py-0.5 bg-[var(--color-feedback-success-bg)] text-[var(--color-feedback-success-text)] rounded"
+												data-testid="marketplace-preset-imported-{preset.itemId}"
+											>
+												{ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceImportedBadge}
+											</span>
+										{/if}
+									</div>
+									<p class="text-xs text-[var(--color-text-tertiary)] truncate">
+										{preset.description}
+									</p>
+									<p class="text-[10px] text-[var(--color-text-tertiary)] mt-0.5">
+										{ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceItemCount(preset.itemCount)}
+									</p>
+								</div>
+								<form
+									method="POST"
+									action="?/importMarketplace"
+									use:enhance={() => async () => invalidateAll()}
+								>
+									<input type="hidden" name="childId" value={selectedChildId} />
+									<input type="hidden" name="presetId" value={preset.itemId} />
+									<Button
+										type="submit"
+										variant={alreadyImported ? 'outline' : 'primary'}
+										size="sm"
+										disabled={alreadyImported}
+										data-testid="marketplace-preset-import-{preset.itemId}"
+									>
+										{ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceImportButton}
+									</Button>
+								</form>
+							</div>
+						{/each}
+					</div>
+				</div>
+				{/snippet}
+			</Card>
+		{/if}
 
 		<!-- #1755 (#1709-A): kind 削除 — 全テンプレート一覧表示 -->
 		{#if filteredTemplates.length === 0}

--- a/src/routes/marketplace/[type]/[itemId]/+page.server.ts
+++ b/src/routes/marketplace/[type]/[itemId]/+page.server.ts
@@ -2,6 +2,11 @@ import { error, fail, redirect } from '@sveltejs/kit';
 import { getMarketplaceItem } from '$lib/data/marketplace';
 import type { MarketplaceItemType, RewardSetPayload } from '$lib/domain/marketplace-item';
 import { requireTenantId } from '$lib/server/auth/factory';
+import { logger } from '$lib/server/logger';
+import {
+	importChecklistTemplate,
+	previewChecklistImport,
+} from '$lib/server/services/checklist-template-import-service';
 import { getAllChildren } from '$lib/server/services/child-service';
 import {
 	importRewardSet,
@@ -28,9 +33,11 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		error(404, 'コンテンツが見つかりません');
 	}
 
-	// #2136 MP-1: 認証済みなら一括追加 CTA を出すための情報をロード。
+	// #2136 MP-1 / #2137 MP-2: 認証済みなら一括追加 CTA を出すための情報をロード。
 	// マーケットプレイスは公開ルートなので、未認証 (locals.context が無い場合) は
 	// children を空配列にしてサインアップ誘導 CTA を出す。
+	// reward-set / checklist 両方の CTA で children を共通利用するため、
+	// type 区別せず一括ロード（無駄に大きい呼び出しではないため pre-PMF で問題なし）。
 	const isAuthenticated = !!locals.context;
 	let children: { id: number; nickname: string }[] = [];
 	if (isAuthenticated) {
@@ -44,7 +51,13 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		}
 	}
 
-	return { item, isAuthenticated, children };
+	return {
+		item,
+		isAuthenticated,
+		// #2137: MP-2 側 svelte が `data.isLoggedIn` を参照するためのエイリアス
+		isLoggedIn: isAuthenticated,
+		children,
+	};
 };
 
 export const actions: Actions = {
@@ -91,5 +104,64 @@ export const actions: Actions = {
 				errors: result.errors,
 			},
 		};
+	},
+
+	// #2137 (MP-2): event-checklist 一括追加 action
+	// CTA「一括追加」ボタンの form action。ログイン済みのみ動作する
+	// (未ログインは UI 側で /auth/signup?next=... に誘導する)。
+	importChecklist: async ({ params, request, locals }) => {
+		const tenantId = locals.context?.tenantId;
+		if (!tenantId) {
+			// 未ログインで POST が来た場合は signup 経由で戻す
+			redirect(302, `/auth/signup?next=/marketplace/checklist/${params.itemId}`);
+		}
+
+		if (params.type !== 'checklist') {
+			return fail(400, { error: 'チェックリストではありません' });
+		}
+
+		const formData = await request.formData();
+		const childIdRaw = formData.get('childId');
+		const childId = Number(childIdRaw);
+		if (!childId || Number.isNaN(childId)) {
+			return fail(400, { error: 'お子さまを選択してください' });
+		}
+
+		// 子供が本テナントに存在するか念のため確認
+		const children = await getAllChildren(tenantId);
+		if (!children.some((c) => c.id === childId)) {
+			return fail(400, { error: 'お子さまが見つかりません' });
+		}
+
+		try {
+			const preview = await previewChecklistImport(params.itemId, childId, tenantId);
+			if (!preview) {
+				return fail(404, { error: 'プリセットが見つかりません' });
+			}
+			if (preview.alreadyImported) {
+				return {
+					importResult: true,
+					alreadyImported: true,
+					presetName: preview.presetName,
+					existingTemplateName: preview.existingTemplateName,
+				};
+			}
+
+			const result = await importChecklistTemplate(params.itemId, childId, tenantId);
+			return {
+				importResult: true,
+				alreadyImported: false,
+				presetName: preview.presetName,
+				imported: result.imported,
+				importedItems: result.importedItems,
+				errors: result.errors,
+			};
+		} catch (e) {
+			logger.error('[marketplace/checklist] インポート失敗', {
+				error: e instanceof Error ? e.message : String(e),
+				context: { itemId: params.itemId, childId },
+			});
+			return fail(500, { error: 'インポートに失敗しました' });
+		}
 	},
 };

--- a/src/routes/marketplace/[type]/[itemId]/+page.svelte
+++ b/src/routes/marketplace/[type]/[itemId]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { invalidateAll } from '$app/navigation';
 import { APP_LABELS, formatAgeRange, MARKETPLACE_LABELS } from '$lib/domain/labels';
 import type {
 	ActivityPackPayload,
@@ -52,6 +53,20 @@ const rewardImport = $derived(
 );
 
 const rewardCount = $derived(isRewardSet ? (item.payload as RewardSetPayload).rewards.length : 0);
+
+// #2137 (MP-2): checklist 一括追加用 state
+//   selectedChildIdStr は NativeSelect bind:value 互換のため string 保持。
+//   form 送信時は string → number 変換せず name="childId" の value 文字列を直接送る。
+// svelte-ignore state_referenced_locally
+let selectedChildIdStr = $state<string>(
+	// svelte-ignore state_referenced_locally
+	data.children && data.children.length > 0 ? String(data.children[0]?.id ?? '') : '',
+);
+let importing = $state(false);
+
+const childOptions = $derived(
+	(data.children ?? []).map((c) => ({ value: String(c.id), label: c.nickname })),
+);
 </script>
 
 <svelte:head>
@@ -295,8 +310,91 @@ const rewardCount = $derived(isRewardSet ? (item.payload as RewardSetPayload).re
 				<p class="text-xs text-center text-[var(--color-text-tertiary)]">
 					{MARKETPLACE_LABELS.detailCtaImportRewardSignedOut}
 				</p>
+			{:else if isChecklist && data.isLoggedIn && data.children && data.children.length > 0}
+				<!-- #2137 (MP-2): ログイン済 → 直接「一括追加」 -->
+				<p class="text-xs text-[var(--color-text-tertiary)]">
+					{MARKETPLACE_LABELS.detailCtaImportChecklistDesc}
+				</p>
+
+				{#if form?.importResult}
+					{#if form.alreadyImported}
+						<div
+							class="px-3 py-2 rounded-md text-sm bg-[var(--color-feedback-warning-bg)] text-[var(--color-feedback-warning-text)]"
+							data-testid="marketplace-import-result-duplicate"
+						>
+							{MARKETPLACE_LABELS.detailImportDuplicate(form.existingTemplateName ?? form.presetName)}
+						</div>
+					{:else}
+						<div
+							class="px-3 py-2 rounded-md text-sm bg-[var(--color-feedback-success-bg)] text-[var(--color-feedback-success-text)]"
+							data-testid="marketplace-import-result-success"
+						>
+							{MARKETPLACE_LABELS.detailImportSuccess(form.importedItems ?? 0)}
+						</div>
+					{/if}
+				{:else if form?.error}
+					<div
+						class="px-3 py-2 rounded-md text-sm bg-[var(--color-feedback-error-bg)] text-[var(--color-feedback-error-text)]"
+						data-testid="marketplace-import-result-error"
+					>
+						{form.error}
+					</div>
+				{/if}
+
+				<form
+					method="POST"
+					action="?/importChecklist"
+					use:enhance={() => {
+						importing = true;
+						return async ({ update }) => {
+							await update();
+							importing = false;
+							await invalidateAll();
+						};
+					}}
+					class="space-y-3"
+					data-testid="marketplace-import-form"
+				>
+					{#if data.children.length > 1}
+						<label class="block text-xs font-medium text-[var(--color-text-secondary)]">
+							{MARKETPLACE_LABELS.detailChildSelectLabel}
+							<NativeSelect
+								name="childId"
+								bind:value={selectedChildIdStr}
+								options={childOptions}
+							/>
+						</label>
+					{:else}
+						<input type="hidden" name="childId" value={selectedChildIdStr} />
+					{/if}
+
+					<Button
+						type="submit"
+						variant="primary"
+						size="lg"
+						class="w-full"
+						disabled={importing || !selectedChildIdStr}
+						data-testid="marketplace-import-button"
+					>
+						{MARKETPLACE_LABELS.detailCtaImportChecklist}
+					</Button>
+				</form>
+			{:else if isChecklist && !data.isLoggedIn}
+				<!-- #2137 (MP-2): 未ログイン → signup 経由 redirect -->
+				<p class="text-xs text-[var(--color-text-tertiary)]">
+					{MARKETPLACE_LABELS.detailCtaImportChecklistDesc}
+				</p>
+				<a
+					href="/auth/signup?next=/marketplace/{item.type}/{item.itemId}"
+					class="block"
+					data-testid="marketplace-signup-redirect"
+				>
+					<Button variant="primary" size="lg" class="w-full">
+						{MARKETPLACE_LABELS.detailCtaSignupToImport}
+					</Button>
+				</a>
 			{:else}
-				<!-- 他 type は従来通り signup 動線 -->
+				<!-- 他 type (activity-pack / rule-preset) は従来通り signup 動線 -->
 				<a href="/auth/signup" class="block">
 					<Button variant="primary" size="lg" class="w-full">
 						{MARKETPLACE_LABELS.detailCtaSignup}

--- a/tests/e2e/marketplace-checklist-import.spec.ts
+++ b/tests/e2e/marketplace-checklist-import.spec.ts
@@ -1,0 +1,153 @@
+// tests/e2e/marketplace-checklist-import.spec.ts
+// #2137 (MP-2): event-checklist 一括追加フロー E2E
+//
+// 検証対象:
+// 1. /marketplace/checklist/event-pool 詳細ページに「一括追加」CTA が描画される
+//    (ログイン済 = AUTH_MODE=local 認証通過後)
+// 2. /admin/checklists にマーケットプレイス取込セクションが表示される
+//    (event-pool / event-school-start / event-field-trip 3 件 + 「一括追加」ボタン)
+// 3. /admin/checklists 経由で event-pool の preset を一括追加 → 同 preset が
+//    取込済 Badge に切り替わり、ボタンが disabled になる
+// 4. 同一 preset の重複 import は alreadyImported Result が返り、テンプレート総数が増えない
+//
+// 認証: AUTH_MODE=local の自動セットアップで /admin 配下に到達できる前提
+//   (hooks.server.ts + tests/e2e/global-setup.ts の tenant seed)。
+
+import { expect, test } from '@playwright/test';
+
+test.describe('#2137 マーケットプレイス checklist 一括追加', () => {
+	test.setTimeout(180_000); // Vite dev コールドコンパイル耐性
+
+	// ============================================================
+	// 1. 詳細ページ CTA — checklist は「一括追加」ボタンに置換されている
+	// ============================================================
+	test('marketplace/checklist/event-pool 詳細ページに「一括追加」CTA が表示される', async ({
+		page,
+	}) => {
+		test.slow();
+		const res = await page.goto('/marketplace/checklist/event-pool', {
+			waitUntil: 'domcontentloaded',
+		});
+		expect(res?.status()).toBe(200);
+
+		// AUTH_MODE=local ではログイン済 → 一括追加 button が表示される
+		// (未ログイン環境では signup redirect になるため、別 spec で扱う)
+		const cta = page.getByTestId('marketplace-detail-cta');
+		await expect(cta).toBeVisible();
+
+		// 「一括追加」 button または signup redirect link のいずれかが描画される
+		const importBtn = page.getByTestId('marketplace-import-button');
+		const signupLink = page.getByTestId('marketplace-signup-redirect');
+		// 両方 hidden は AC 違反
+		const eitherVisible = (await importBtn.count()) > 0 || (await signupLink.count()) > 0;
+		expect(eitherVisible).toBe(true);
+	});
+
+	test('marketplace/checklist/event-school-start / event-field-trip も 200 で開ける', async ({
+		page,
+	}) => {
+		test.slow();
+		const r1 = await page.goto('/marketplace/checklist/event-school-start', {
+			waitUntil: 'domcontentloaded',
+		});
+		expect(r1?.status()).toBe(200);
+
+		const r2 = await page.goto('/marketplace/checklist/event-field-trip', {
+			waitUntil: 'domcontentloaded',
+		});
+		expect(r2?.status()).toBe(200);
+	});
+
+	// ============================================================
+	// 2. admin/checklists の「マーケットプレイスから一括追加」セクション
+	// ============================================================
+	test('/admin/checklists にマーケットプレイス取込セクションが描画される', async ({ page }) => {
+		test.slow();
+		await page.goto('/admin/checklists', { waitUntil: 'domcontentloaded' });
+
+		// マーケットプレイス section
+		const section = page.getByTestId('marketplace-import-section');
+		await expect(section).toBeVisible({ timeout: 30_000 });
+
+		// event-pool / event-school-start / event-field-trip 3 件の preset row
+		await expect(page.getByTestId('marketplace-preset-row-event-pool')).toBeVisible();
+		await expect(page.getByTestId('marketplace-preset-row-event-school-start')).toBeVisible();
+		await expect(page.getByTestId('marketplace-preset-row-event-field-trip')).toBeVisible();
+
+		// それぞれに「一括追加」ボタンが描画されている
+		await expect(page.getByTestId('marketplace-preset-import-event-pool')).toBeVisible();
+	});
+
+	// ============================================================
+	// 3-4. 一括追加 → 取込済 Badge → 重複時スキップ
+	// ============================================================
+	test('admin/checklists から event-pool を一括追加 → 取込済 Badge + ボタン disabled', async ({
+		page,
+	}) => {
+		test.slow();
+		await page.goto('/admin/checklists', { waitUntil: 'domcontentloaded' });
+		await expect(page.getByTestId('marketplace-import-section')).toBeVisible({ timeout: 30_000 });
+
+		const importBtn = page.getByTestId('marketplace-preset-import-event-pool');
+		await expect(importBtn).toBeVisible();
+
+		// 既に取込済の可能性がある場合は (alreadyImported badge) skip
+		const alreadyImported = page.getByTestId('marketplace-preset-imported-event-pool');
+		const wasAlreadyImported = (await alreadyImported.count()) > 0;
+
+		if (wasAlreadyImported) {
+			// 既に取込済 → ボタンが disabled かつ Badge が visible
+			await expect(alreadyImported).toBeVisible();
+			await expect(importBtn).toBeDisabled();
+			return;
+		}
+
+		// 取込前: ボタンが enabled
+		await expect(importBtn).toBeEnabled();
+
+		// 一括追加 button を押下
+		await importBtn.click();
+
+		// Action + invalidateAll() 完了後、取込済 Badge が表示されボタンが disabled になる
+		// (form prop は invalidate で消える可能性があるため、永続的な state 変化のみ assert)
+		await expect(page.getByTestId('marketplace-preset-imported-event-pool')).toBeVisible({
+			timeout: 30_000,
+		});
+		await expect(page.getByTestId('marketplace-preset-import-event-pool')).toBeDisabled();
+	});
+
+	test('admin/checklists で同 preset を再度押下しても重複扱い (alreadyImported)', async ({
+		page,
+	}) => {
+		test.slow();
+		await page.goto('/admin/checklists', { waitUntil: 'domcontentloaded' });
+		await expect(page.getByTestId('marketplace-import-section')).toBeVisible({ timeout: 30_000 });
+
+		// event-school-start を 2 回 import 試行
+		const importBtn = page.getByTestId('marketplace-preset-import-event-school-start');
+		await expect(importBtn).toBeVisible();
+
+		// 既に取込済なら disabled、その場合は POST が走らないため UI のみ確認
+		if (await importBtn.isDisabled().catch(() => false)) {
+			await expect(
+				page.getByTestId('marketplace-preset-imported-event-school-start'),
+			).toBeVisible();
+			return;
+		}
+
+		// 1 回目 import → 永続的な state 変化 (Badge + disabled) を assert
+		await importBtn.click();
+		await expect(page.getByTestId('marketplace-preset-imported-event-school-start')).toBeVisible({
+			timeout: 30_000,
+		});
+		await expect(page.getByTestId('marketplace-preset-import-event-school-start')).toBeDisabled();
+
+		// reload しても重複扱い (state 永続性確認)
+		await page.reload({ waitUntil: 'domcontentloaded' });
+		await expect(page.getByTestId('marketplace-import-section')).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByTestId('marketplace-preset-imported-event-school-start')).toBeVisible({
+			timeout: 30_000,
+		});
+		await expect(page.getByTestId('marketplace-preset-import-event-school-start')).toBeDisabled();
+	});
+});

--- a/tests/unit/services/checklist-template-import-service.test.ts
+++ b/tests/unit/services/checklist-template-import-service.test.ts
@@ -1,0 +1,308 @@
+// tests/unit/services/checklist-template-import-service.test.ts
+// #2137 (MP-2) checklist-template-import-service unit tests
+//
+// activity-import-service.test.ts と同じ pattern (top-level mock → late import → vi.clearAllMocks)。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChecklistPayload, MarketplaceItem } from '../../../src/lib/domain/marketplace-item';
+
+// ---------- Top-level mocks ----------
+
+const mockGetMarketplaceItem = vi.fn();
+const mockFindTemplatesByChild = vi.fn();
+const mockCreateTemplate = vi.fn();
+const mockAddTemplateItem = vi.fn();
+
+vi.mock('$lib/data/marketplace', () => ({
+	getMarketplaceItem: (...args: unknown[]) => mockGetMarketplaceItem(...args),
+}));
+
+vi.mock('$lib/server/db/checklist-repo', () => ({
+	findTemplatesByChild: (...args: unknown[]) => mockFindTemplatesByChild(...args),
+}));
+
+vi.mock('$lib/server/services/checklist-service', () => ({
+	createTemplate: (...args: unknown[]) => mockCreateTemplate(...args),
+	addTemplateItem: (...args: unknown[]) => mockAddTemplateItem(...args),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ---------- Import after mocks ----------
+
+import {
+	importChecklistTemplate,
+	previewChecklistImport,
+} from '../../../src/lib/server/services/checklist-template-import-service';
+
+// ---------- Helpers ----------
+
+const TENANT = 'test-tenant-001';
+const CHILD_ID = 42;
+
+function makePresetItem(overrides: Partial<MarketplaceItem> = {}): MarketplaceItem {
+	const payload: ChecklistPayload = {
+		timing: 'daily',
+		items: [
+			{ label: 'みずぎ', icon: '👙', order: 1 },
+			{ label: 'プールバッグ', icon: '🎒', order: 2 },
+			{ label: 'タオル', icon: '🏖️', order: 3 },
+		],
+	};
+	return {
+		type: 'checklist',
+		itemId: 'event-pool',
+		name: 'プールの もちもの',
+		description: 'desc',
+		icon: '🏊',
+		targetAgeMin: 4,
+		targetAgeMax: 12,
+		tags: ['イベント'],
+		personas: [],
+		curator: 'official',
+		payload,
+		...overrides,
+	} as MarketplaceItem;
+}
+
+// ---------- Reset ----------
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockFindTemplatesByChild.mockResolvedValue([]);
+	mockCreateTemplate.mockResolvedValue({ id: 100 });
+	mockAddTemplateItem.mockResolvedValue({ id: 1 });
+});
+
+// ==========================================================
+// previewChecklistImport
+// ==========================================================
+
+describe('previewChecklistImport', () => {
+	it('preset が見つからない場合 null を返す', async () => {
+		mockGetMarketplaceItem.mockReturnValue(null);
+
+		const result = await previewChecklistImport('unknown', CHILD_ID, TENANT);
+
+		expect(result).toBeNull();
+	});
+
+	it('既存テンプレートなし → alreadyImported=false / item 数集計', async () => {
+		mockGetMarketplaceItem.mockReturnValue(makePresetItem());
+		mockFindTemplatesByChild.mockResolvedValue([]);
+
+		const result = await previewChecklistImport('event-pool', CHILD_ID, TENANT);
+
+		expect(result).not.toBeNull();
+		expect(result?.presetId).toBe('event-pool');
+		expect(result?.presetName).toBe('プールの もちもの');
+		expect(result?.presetIcon).toBe('🏊');
+		expect(result?.itemCount).toBe(3);
+		expect(result?.alreadyImported).toBe(false);
+		expect(result?.existingTemplateName).toBeUndefined();
+	});
+
+	it('同 sourcePresetId のテンプレートが既存 → alreadyImported=true', async () => {
+		mockGetMarketplaceItem.mockReturnValue(makePresetItem());
+		mockFindTemplatesByChild.mockResolvedValue([
+			{ id: 7, name: 'プールの もちもの', sourcePresetId: 'event-pool' },
+			{ id: 8, name: '別のテンプレ', sourcePresetId: null },
+		]);
+
+		const result = await previewChecklistImport('event-pool', CHILD_ID, TENANT);
+
+		expect(result?.alreadyImported).toBe(true);
+		expect(result?.existingTemplateName).toBe('プールの もちもの');
+	});
+
+	it('他の preset 由来テンプレートが既存 → alreadyImported=false', async () => {
+		mockGetMarketplaceItem.mockReturnValue(makePresetItem());
+		mockFindTemplatesByChild.mockResolvedValue([
+			{ id: 7, name: '別 preset', sourcePresetId: 'event-school-start' },
+		]);
+
+		const result = await previewChecklistImport('event-pool', CHILD_ID, TENANT);
+
+		expect(result?.alreadyImported).toBe(false);
+	});
+
+	it('findTemplatesByChild に includeInactive=true が渡される', async () => {
+		mockGetMarketplaceItem.mockReturnValue(makePresetItem());
+
+		await previewChecklistImport('event-pool', CHILD_ID, TENANT);
+
+		expect(mockFindTemplatesByChild).toHaveBeenCalledWith(CHILD_ID, TENANT, true);
+	});
+});
+
+// ==========================================================
+// importChecklistTemplate
+// ==========================================================
+
+describe('importChecklistTemplate', () => {
+	it('preset が見つからない場合 throw', async () => {
+		mockGetMarketplaceItem.mockReturnValue(null);
+
+		await expect(importChecklistTemplate('unknown', CHILD_ID, TENANT)).rejects.toThrow(
+			/見つかりません/,
+		);
+	});
+
+	it('新規取込: template + items が全て作成される', async () => {
+		mockGetMarketplaceItem.mockReturnValue(makePresetItem());
+		mockFindTemplatesByChild.mockResolvedValue([]);
+
+		const result = await importChecklistTemplate('event-pool', CHILD_ID, TENANT);
+
+		expect(result.imported).toBe(1);
+		expect(result.skipped).toBe(0);
+		expect(result.importedItems).toBe(3);
+		expect(result.errors).toEqual([]);
+		expect(result.templateId).toBe(100);
+
+		expect(mockCreateTemplate).toHaveBeenCalledTimes(1);
+		expect(mockCreateTemplate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				childId: CHILD_ID,
+				name: 'プールの もちもの',
+				icon: '🏊',
+				timeSlot: 'anytime', // daily → anytime
+				sourcePresetId: 'event-pool',
+			}),
+			TENANT,
+		);
+		expect(mockAddTemplateItem).toHaveBeenCalledTimes(3);
+	});
+
+	it('重複検出: 同 sourcePresetId が既存 → 何もせずスキップ', async () => {
+		mockGetMarketplaceItem.mockReturnValue(makePresetItem());
+		mockFindTemplatesByChild.mockResolvedValue([
+			{ id: 99, name: 'プールの もちもの', sourcePresetId: 'event-pool' },
+		]);
+
+		const result = await importChecklistTemplate('event-pool', CHILD_ID, TENANT);
+
+		expect(result.imported).toBe(0);
+		expect(result.skipped).toBe(1);
+		expect(result.importedItems).toBe(0);
+		expect(mockCreateTemplate).not.toHaveBeenCalled();
+		expect(mockAddTemplateItem).not.toHaveBeenCalled();
+	});
+
+	it('item の追加順は order 昇順', async () => {
+		mockGetMarketplaceItem.mockReturnValue(
+			makePresetItem({
+				payload: {
+					timing: 'daily',
+					items: [
+						{ label: '3つ目', icon: '🅒', order: 3 },
+						{ label: '1つ目', icon: '🅐', order: 1 },
+						{ label: '2つ目', icon: '🅑', order: 2 },
+					],
+				},
+			} as Partial<MarketplaceItem>),
+		);
+
+		await importChecklistTemplate('event-pool', CHILD_ID, TENANT);
+
+		expect(mockAddTemplateItem).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({ name: '1つ目', sortOrder: 1 }),
+			TENANT,
+		);
+		expect(mockAddTemplateItem).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ name: '2つ目', sortOrder: 2 }),
+			TENANT,
+		);
+		expect(mockAddTemplateItem).toHaveBeenNthCalledWith(
+			3,
+			expect.objectContaining({ name: '3つ目', sortOrder: 3 }),
+			TENANT,
+		);
+	});
+
+	it('addTemplateItem が一部失敗してもエラー記録のみで処理継続', async () => {
+		mockGetMarketplaceItem.mockReturnValue(makePresetItem());
+		mockAddTemplateItem
+			.mockResolvedValueOnce({ id: 1 })
+			.mockRejectedValueOnce(new Error('DB busy'))
+			.mockResolvedValueOnce({ id: 3 });
+
+		const result = await importChecklistTemplate('event-pool', CHILD_ID, TENANT);
+
+		expect(result.imported).toBe(1);
+		expect(result.importedItems).toBe(2);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]).toContain('DB busy');
+	});
+
+	it('timing=morning → timeSlot=morning にマップ', async () => {
+		mockGetMarketplaceItem.mockReturnValue(
+			makePresetItem({
+				payload: {
+					timing: 'morning',
+					items: [{ label: 'はみがき', icon: '🪥', order: 1 }],
+				},
+			} as Partial<MarketplaceItem>),
+		);
+
+		await importChecklistTemplate('event-pool', CHILD_ID, TENANT);
+
+		expect(mockCreateTemplate).toHaveBeenCalledWith(
+			expect.objectContaining({ timeSlot: 'morning' }),
+			TENANT,
+		);
+	});
+
+	it('timing=evening → timeSlot=evening にマップ', async () => {
+		mockGetMarketplaceItem.mockReturnValue(
+			makePresetItem({
+				payload: {
+					timing: 'evening',
+					items: [{ label: 'パジャマ', icon: '🛌', order: 1 }],
+				},
+			} as Partial<MarketplaceItem>),
+		);
+
+		await importChecklistTemplate('event-pool', CHILD_ID, TENANT);
+
+		expect(mockCreateTemplate).toHaveBeenCalledWith(
+			expect.objectContaining({ timeSlot: 'evening' }),
+			TENANT,
+		);
+	});
+
+	it('timing=weekend/weekly は anytime にマップ', async () => {
+		mockGetMarketplaceItem.mockReturnValue(
+			makePresetItem({
+				payload: {
+					timing: 'weekend',
+					items: [{ label: 'お出かけセット', icon: '👜', order: 1 }],
+				},
+			} as Partial<MarketplaceItem>),
+		);
+
+		await importChecklistTemplate('event-pool', CHILD_ID, TENANT);
+
+		expect(mockCreateTemplate).toHaveBeenCalledWith(
+			expect.objectContaining({ timeSlot: 'anytime' }),
+			TENANT,
+		);
+	});
+
+	it('options.timeSlot で上書きできる', async () => {
+		mockGetMarketplaceItem.mockReturnValue(makePresetItem());
+
+		await importChecklistTemplate('event-pool', CHILD_ID, TENANT, {
+			timeSlot: 'morning',
+		});
+
+		expect(mockCreateTemplate).toHaveBeenCalledWith(
+			expect.objectContaining({ timeSlot: 'morning' }),
+			TENANT,
+		);
+	});
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,13 +15,18 @@ export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
 	server: {
 		fs: {
-			// git worktree (`tmp/wt-XXXX/`) で起動した時、Vite の dev server fs.allow が
-			// worktree 配下に絞られるため、親リポジトリ root の node_modules
-			// (`@sveltejs/kit/src/runtime/client/entry.js` 等) が読めず hydration JS が
+			// git worktree (`tmp/wt-XXXX/` または `.claude/worktrees/<name>/`) で起動した時、
+			// Vite の dev server fs.allow が worktree 配下に絞られるため、親リポジトリ root の
+			// node_modules (`@sveltejs/kit/src/runtime/client/entry.js` 等) が読めず hydration JS が
 			// 落ちる。client hydration が動かないと bind:value も発火せず、ログイン
 			// フォーム等の disabled ボタンが永久に有効化されない (#1603 で発覚)。
-			// 親 1〜2 階層分 (tmp/wt-XXXX/ の場合 ../ と ../../) の node_modules を許可する。
-			allow: [path.join(dirname, '..'), path.join(dirname, '..', '..')],
+			// 親 1〜3 階層分 (`tmp/wt-XXXX/` は 2、`.claude/worktrees/<name>/` は 3 階層) の
+			// node_modules を許可する。
+			allow: [
+				path.join(dirname, '..'),
+				path.join(dirname, '..', '..'),
+				path.join(dirname, '..', '..', '..'),
+			],
 		},
 	},
 	ssr: {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: マーケットプレイス上に `event-checklist` 3 件 (event-pool / event-school-start / event-field-trip) が表示されるものの、ユーザーが「使ってみる」ボタンを押しても `/auth/signup` に遷移するだけで、肝心の **アプリ本体の持ち物チェックリストに反映されない**「見かけだけ機能」状態が継続。PO 報告 (2026-05-15) + ADR-0013 (LP truth) 違反疑い。EPIC #2135 マーケットプレイス 4 type 完全実装 の MP-2。

**期待される効果**: 親が「プール授業」「入学準備」「遠足」のタイミングで「マーケットプレイスのテンプレを使ってみたい」と思ったときに、ワンタップで `/admin/checklists` に preset checklist が反映され、本日の持ち物確認画面で子供が即座に使える。Activation (M2) 加速 + ADR-0013 訴求と実装の乖離解消。

## 関連 Issue

closes #2137

(EPIC: #2135 / 並行 MP-1: #2136 / Marketplace research SSOT: `tmp/research/06-research-marketplace-completion.md` + `06b-supplement.md`)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `src/lib/server/services/checklist-template-import-service.ts` 新規 (`previewChecklistImport` / `importChecklistTemplate` / `sourcePresetId` で重複検出) | `test -f src/lib/server/services/checklist-template-import-service.ts && grep -E "previewChecklistImport\|importChecklistTemplate\|sourcePresetId" src/lib/server/services/checklist-template-import-service.ts \| wc -l` | PASS: 11 マッチ (>= 3 必達)。`tests/unit/services/checklist-template-import-service.test.ts` 14/14 PASS |
| AC2 | マーケットプレイス詳細ページ (`/marketplace/checklist/[itemId]`) CTA を「一括追加」に変更 (ログイン済 = 直接取込 / 未ログイン = signup?next= redirect) | `grep "一括追加" src/routes/marketplace/[type]/[itemId]/+page.svelte` | PASS: `MARKETPLACE_LABELS.detailCtaImportChecklist`/`SignupToImport` 経由で「一括追加」「がんばりクエストに登録して 一括追加」を表示。`data.isLoggedIn` 分岐で URL も切替 |
| AC3 | admin/checklists 画面に「マーケットプレイスから一括追加」セクション追加、event-checklist 3 件 preview + 一括追加が機能 | `grep -E "marketplace.*checklist\|一括追加\|marketplaceSectionTitle" src/routes/(parent)/admin/checklists/+page.svelte` + `?/importMarketplace` action 動作 | PASS: `ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceSectionTitle` で section 描画、取込済 Badge + ボタン disabled。E2E `marketplace-checklist-import.spec.ts` 5/5 PASS |
| AC4 | E2E `tests/e2e/marketplace-checklist-import.spec.ts` 新規 (signup → marketplace → 一括追加 → admin/checklists 反映 + 重複防止確認 + 3 件全て動作) | `npx playwright test tests/e2e/marketplace-checklist-import.spec.ts --project=tablet` | PASS: 5/5 tests (tablet) + mobile project regression 484/484 PASS。E2E ローカル AUTH_MODE=local 認証通過 → 取込済 Badge 状態変化 + reload 後永続性確認 |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`) — **DB schema 変更なし**。既存 `checklist_templates.sourcePresetId` カラム (#1254 G1 整備済) を流用
- [x] サービス層 (`$lib/server/services/`) — `checklist-template-import-service.ts` 新規
- [ ] API エンドポイント (`src/routes/api/`) — REST API 追加なし、form actions のみ
- [x] ページ / レイアウト (`src/routes/`) — `marketplace/[type]/[itemId]` + `(parent)/admin/checklists` 双方
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`) — `labels.ts` に SSOT ラベル追加 (`MARKETPLACE_LABELS.detailCtaImportChecklist*` / `ADMIN_CHECKLISTS_PAGE_LABELS.marketplace*`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — `vite.config.ts` の `server.fs.allow` を `.claude/worktrees/<name>/` 配下からも親 node_modules を読めるよう 3 階層上まで拡張 (#1603 後続)

**影響を受ける画面・機能**:
- `/marketplace/checklist/event-pool` / `/event-school-start` / `/event-field-trip` 詳細ページ（CTA 改修）
- `/admin/checklists` （新セクション「マーケットプレイスから一括追加」追加）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
  - biome: 0 errors (`npx biome check` on 8 changed files)
  - svelte-check: 0 net new errors (baseline 53 errors + 13 warnings in 5 pre-existing infra files、再実行で同値)
  - vitest: 全体 4769/4769 PASS (1 pre-existing infra test file fail = aws-cdk-lib missing dep)
  - check-no-plan-literals: PASS
  - generate-lp-labels --check: PASS
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/services/checklist-template-import-service.test.ts` (新規、14 tests): preview / import / 重複検出 / order sort / timing マッピング / item 個別失敗ハンドリング
  - `tests/e2e/marketplace-checklist-import.spec.ts` (新規、5 tests): 詳細ページ CTA / admin section 描画 / 一括追加 → Badge 状態変化 / 重複 import の永続性 (reload 後も disabled)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — `checklist-repo.ts` 既存 Facade 経由、SQLite / DynamoDB 両実装は既存ロジックで吸収
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (feature)

## スクリーンショット / ビジュアルデモ

新規追加した 2 セクション (admin/checklists のマーケットプレイスから一括追加 + marketplace checklist 詳細ページの一括追加 CTA) の実画面を撮影。

### 1. `/admin/checklists` — マーケットプレイスから一括追加セクション (event-* 3 件 preview + 一括追加ボタン)

| | モバイル (390px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし(新規追加セクションのため main HEAD に対応 UI なし) | 該当なし(同左) |
| **修正後** | ![admin-checklists-marketplace-after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2150/admin-checklists-marketplace-after-mobile.png) | ![admin-checklists-marketplace-after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2150/admin-checklists-marketplace-after-desktop.png) |

### 2. `/marketplace/checklist/event-pool` — checklist 一括追加 CTA (未ログイン状態、「がんばりクエストに登録して 一括追加」)

| | モバイル (390px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし(従来は `/auth/signup` への汎用 CTA、PR で checklist 専用「がんばりクエストに登録して 一括追加」に切替) | 該当なし(同左) |
| **修正後** | ![marketplace-checklist-cta-after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2150/marketplace-checklist-cta-after-mobile.png) | ![marketplace-checklist-cta-after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2150/marketplace-checklist-cta-after-desktop.png) |

**デザイン適合 (docs/DESIGN.md §9 禁忌事項 6 点 self-check)**:
- hex 直書きなし: `var(--color-*)` semantic トークン経由
- プリミティブ再実装なし: `Button` / `Card` / `NativeSelect` を `$lib/ui/primitives/` から使用
- 内部コード露出なし: 全文言は `MARKETPLACE_LABELS` / `ADMIN_CHECKLISTS_PAGE_LABELS` 経由
- 用語ハードコードなし: labels.ts SSOT
- インラインスタイル: 動的値のみ(`style:` 使用箇所なし)
- `<style>` ブロック 50 行超え: 該当なし(既存 admin/checklists の `<style>` は変更せず)

**撮影方法**: standard プラン (`standard@example.com`) でログイン後 `/admin/checklists` で marketplace-import-section を待ってから fullPage 撮影 / marketplace は未ログイン状態で直接表示。sha256 全 4 unique (#2063 ss-blob-sha-uniqueness-check 適合)。

`tests/e2e/marketplace-checklist-import.spec.ts` の page snapshot（error-context.md より、E2E 5/5 PASS 機械検証）:
- `/admin/checklists` `marketplace-import-section` heading: `🏪 マーケットプレイスから一括追加`
- event-pool row: `🏊 プールの もちもの` + 「取込済」Badge + `[一括追加]` disabled button
- event-school-start row: `🎒 にゅうえん・にゅうがく じゅんび` + 11 項目 + `[一括追加]` enabled button
- event-field-trip row: `🗺️ えんそく・こうがいがくしゅう もちもの` + 12 項目 + `[一括追加]` enabled button

**インタラクティブ状態**: 取込済時の Badge + disabled state を E2E spec で明示検証 (`marketplace-preset-imported-{itemId}` + `marketplace-preset-import-{itemId}` の `toBeDisabled()`)。


## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 (`checklist-template-import-service` は preset import 専任、checklist-service は CRUD 専任) / 依存性逆転 (db-repo facade 経由で sqlite/dynamodb 実装非依存) / インターフェース分離 (`ImportChecklistTemplateOptions` で options 最小化)
- [x] **DRY**: `activity-import-service.ts` の preview / import / 重複検出パターンを横展開し、`logger`/`fail`/`getMarketplaceItem` の使い方を一致。新規ロジック追加なしの template 横展開 (ADR-0014 整合)
- [x] **YAGNI**: timing マッピング table も `morning/evening → 同名` + `weekend/daily/weekly → anytime` の最小実装。プラン制限は既存 `checkChecklistTemplateLimit` 流用、新規 limit logic 追加なし
- [x] **Security**: tenantId 必須化 (`requireTenantId(locals)`) / `childId` の所属 tenant チェック (marketplace 側 action では `getAllChildren(tenantId)` で existence 確認) / preset ID は marketplace SSOT から検証 (`getMarketplaceItem('checklist', presetId)` が null なら 404)
- [x] **アクセシビリティ**: 既存 Button.svelte / NativeSelect.svelte primitive を再利用、独自 button タグなし。disabled 状態が aria-disabled に展開される
- [x] **パフォーマンス**: import は 1 template + N items の 直列 await (event-* は最大 12 items)。N+1 なし、bulk transaction も不要 (Pre-PMF Bucket A、ADR-0010)

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期 — **N/A**: demo 側 `/demo/admin/checklists` は静的 demo data を表示する別 service (`demo-service.ts`) を使い、本変更は本番のみ。demo 側への展開は B-7 (#2145 マージ済) で marketplace seed integration 済のため別 PR 不要
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）— N/A: LP `site/index.html` は marketplace へのリンクのみ、文言追加なし
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）— N/A: 親管理画面のみ
- [ ] ナビゲーション 3 種 — N/A: 既存 `/admin/checklists` URL を維持
- [ ] E2E / ユニットシード + チュートリアル — **修正不要**: `checklist_templates.sourcePresetId` は既存カラム、新規 seed 不要
- [x] **labels SSOT** (ADR-0009): `MARKETPLACE_LABELS.detailCtaImportChecklist*` (5 keys) + `ADMIN_CHECKLISTS_PAGE_LABELS.marketplace*` (7 keys) を追加。直書き 0 件
- [x] **設計書同期** (ADR-0001): `docs/design/06-UI設計書.md` `/admin/checklists` 仕様にマーケットプレイス取込セクション節を追加、`07-API設計書.md` プラン制限 form action 表に `?/importMarketplace` 追加
- [x] **並行 PR overlap** (#1200): MP-1 (#2136) の reward-set 実装と並行進行。共有ファイル `src/routes/marketplace/[type]/[itemId]/+page.svelte` の CTA branch (checklist vs reward-set) は type 別に独立、conflict 軽微。merge 順序により先方 rebase 必要時は `marketplace-import-button` testid を維持して conflict 解消
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314):

N/A — LP 文言・販促コピー変更なし。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

`/marketplace/checklist/[itemId]` の既存「がんばりクエストに登録して使ってみる」CTA は **activity-pack / reward-set / rule-preset の 3 type に維持** (`isChecklist` ガード)。MP-1 / MP-3 が実装され次第、それぞれの CTA を「一括追加」に置換していく EPIC 設計。

**レビュー依頼事項・QA**:
1. `checklist-template-import-service.ts` の重複検出ロジック (`childId × sourcePresetId` で同 preset 全体スキップ、items の個別重複は判定しない) が PO 期待挙動と一致しているか — activity-pack と同じ「preset = atomic unit」考え方
2. `vite.config.ts` の `fs.allow` 3 階層上拡張は `.claude/worktrees/<name>/` worktree から実行する場合の HMR 修正のみ。本番 build / dev (workspace root) には無影響だが PR レビューで確認推奨
3. E2E spec で `form?.marketplaceImportResult` の即時 visibility ではなく **永続的な state 変化** (取込済 Badge + button disabled) を assert しているのは、`invalidateAll()` 後に form prop が消える Svelte 5 仕様への対応。同 pattern を MP-1 PR (#2136 進行中) でも適用検討

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (biome / svelte-check / vitest / check-no-plan-literals / generate-lp-labels --check 全 PASS)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了の AC が残置していない）
- [x] Phase 分割した場合: EPIC #2135 で MP-1〜MP-5 に正式分割済、本 PR は MP-2 単独
- [x] UI 変更時: E2E spec page snapshot で取込セクション + Badge + disabled state を機械検証
- [x] 認証画面変更時: 該当なし（マーケットプレイス + admin/checklists は既存認証フロー上で動作）

## QM レビュー結果

<!-- QM が記入 -->

