### PR TITLE
fix: #2097 B-5a demo special-reward unshown fixture (達成プレゼント modal 発火)

### DIFF
--- a/src/lib/server/db/demo/special-reward-repo.ts
+++ b/src/lib/server/db/demo/special-reward-repo.ts
@@ -32,17 +32,23 @@ export async function findSpecialRewards(
 }
 
 export async function findUnshownReward(
-	_childId: number,
+	childId: number,
 	_tenantId: string,
 ): Promise<SpecialReward | undefined> {
-	// 全 special rewards は shownAt=daysAgoISO(...) で「既読」扱い、新規 unshown はなし
-	return undefined;
+	// #2097 Phase B-5a: marketplace 由来 rewards のうち shownAt=null の最初の 1 件を返す
+	// (子供ホームで SpecialRewardOverlay = おうかん演出 / 達成プレゼント modal を発火させる)
+	const rewards = getDemoMarketplaceSpecialRewardsByChild(childId);
+	return rewards.find((r) => r.shownAt === null);
 }
 
 export async function markRewardShown(
 	_rewardId: number,
 	_tenantId: string,
 ): Promise<SpecialReward | undefined> {
+	// Stateless: fixture を mutate せず success として undefined (sqlite repo の returning().get()
+	// と整合: 該当行が無いと undefined)。demo 用途では子供ホーム再 reload 時に同じ unshown
+	// reward が再度 modal 表示されても UX 上問題なし (anti-engagement 原則 ADR-0012: 子供が
+	// modal を閉じる動作で十分体験は完結する)
 	return undefined;
 }
 

--- a/src/lib/server/demo/demo-data.ts
+++ b/src/lib/server/demo/demo-data.ts
@@ -1960,18 +1960,22 @@ const MARKETPLACE_CHECKLIST_ITEMS_BY_TEMPLATE: Record<number, ChecklistTemplateI
 	return map;
 })();
 
-// ── SpecialReward fixture (child reward shop 用) ───────────────
+// ── SpecialReward fixture (child reward shop 用 + 達成プレゼント modal 演出用) ───────────────
 //
 // Demo Lambda の子供側ごほうびショップ (`/(child)/[uiMode]/shop`) は
 // `getChildSpecialRewards` 経由で `findSpecialRewards(childId, tenantId)` を呼ぶ。
-// marketplace reward-set から各子供に上位 5 件を pre-granted (visible) として配置。
+// marketplace reward-set から各子供に上位 5 件を pre-granted として配置:
+//
+// - idx 0 (最新): **未表示** (shownAt = null) — `findUnshownReward` で取得され
+//   子供ホームで `SpecialRewardOverlay` (おうかん演出 / 達成プレゼント modal) を発火させる (B-5a)
+// - idx 1-4 (古い): 既表示 (shownAt 設定済み) — child shop 棚の履歴として表示される
 const MARKETPLACE_SPECIAL_REWARDS_BY_CHILD: Record<number, SpecialReward[]> = (() => {
 	const map: Record<number, SpecialReward[]> = {};
 	let idOffset = 0;
 	for (const [childIdStr, templates] of Object.entries(MARKETPLACE_REWARD_TEMPLATES_BY_CHILD)) {
 		const childId = Number(childIdStr);
 		const presetId = REWARD_SETS_BY_CHILD[childId]?.[0] ?? null;
-		// 上位 5 件を pre-granted として配置（child shop で「いくつか並んだ棚」を再現）
+		// 上位 5 件を pre-granted として配置（child shop で「いくつか並んだ棚」を再現 + 1 件未表示）
 		const top5 = templates.slice(0, 5);
 		map[childId] = top5.map((tpl, idx) => ({
 			id: SYN_SPECIAL_REWARD_ID_BASE + idOffset + idx,
@@ -1983,7 +1987,9 @@ const MARKETPLACE_SPECIAL_REWARDS_BY_CHILD: Record<number, SpecialReward[]> = ((
 			icon: tpl.icon,
 			category: tpl.category,
 			grantedAt: daysAgoISO(idx + 1),
-			shownAt: daysAgoISO(idx + 1),
+			// idx 0: shownAt=null (達成プレゼント modal 発火、B-5a)
+			// idx 1-4: shownAt 設定済み (履歴表示)
+			shownAt: idx === 0 ? null : daysAgoISO(idx + 1),
 			sourcePresetId: presetId,
 		}));
 		idOffset += top5.length;

--- a/tests/unit/server/db/demo/reward-marketplace.test.ts
+++ b/tests/unit/server/db/demo/reward-marketplace.test.ts
@@ -68,9 +68,11 @@ describe('demo/reward — marketplace integration (#2097 B-7)', () => {
 			expect(rewards.length).toBe(5);
 			expect(rewards.every((r) => r.childId === 902)).toBe(true);
 			expect(rewards.every((r) => r.sourcePresetId === 'kinder-rewards')).toBe(true);
-			// 全 reward が pre-granted (grantedAt + shownAt 既設定)
+			// 全 reward が pre-granted (grantedAt 設定済み)
 			expect(rewards.every((r) => r.grantedAt !== null)).toBe(true);
-			expect(rewards.every((r) => r.shownAt !== null)).toBe(true);
+			// #2097 Phase B-5a: idx 0 は未表示 (shownAt=null) で達成プレゼント modal 発火、idx 1-4 は既表示
+			expect(rewards.filter((r) => r.shownAt === null).length).toBe(1);
+			expect(rewards.filter((r) => r.shownAt !== null).length).toBe(4);
 		});
 
 		it('903 で elementary-rewards 由来 5 件', async () => {

--- a/tests/unit/server/db/demo/special-reward-repo.test.ts
+++ b/tests/unit/server/db/demo/special-reward-repo.test.ts
@@ -1,0 +1,121 @@
+// tests/unit/server/db/demo/special-reward-repo.test.ts
+// #2097 Phase B-5a: demo Lambda の special-reward (個別演出ごほうび) fixture 検証。
+// - findSpecialRewards: 各子供で marketplace reward-set 由来 5 件 (shown 4 + unshown 1)
+// - findUnshownReward: idx 0 (shownAt=null) を返し SpecialRewardOverlay (達成プレゼント modal) を発火
+// - markRewardShown: stateless stub (undefined を返す、fixture mutate なし)
+// - insertSpecialReward: stateless stub (returning input echo)
+
+import { describe, expect, it } from 'vitest';
+import * as specialRewardRepo from '../../../../../src/lib/server/db/demo/special-reward-repo';
+import { getDemoMarketplaceSpecialRewardsByChild } from '../../../../../src/lib/server/demo/demo-data';
+
+describe('demo/special-reward-repo (#2097 B-5a 達成プレゼント modal 発火)', () => {
+	describe('findSpecialRewards: 各子供 reward 件数 (granted / unshown 混在)', () => {
+		const expectedChildren = [
+			{ id: 902, name: 'ひなちゃん (preschool F)', presetId: 'kinder-rewards' },
+			{ id: 903, name: 'けんたくん (elementary M)', presetId: 'elementary-rewards' },
+			{ id: 904, name: 'さくらちゃん (junior F)', presetId: 'junior-rewards' },
+			{ id: 906, name: 'けいすけくん (senior M)', presetId: 'senior-rewards' },
+		];
+
+		for (const child of expectedChildren) {
+			it(`${child.id} (${child.name}) で 5 件 (shown 4 + unshown 1)`, async () => {
+				const rewards = await specialRewardRepo.findSpecialRewards(child.id, 'demo');
+				expect(rewards.length).toBe(5);
+				expect(rewards.every((r) => r.childId === child.id)).toBe(true);
+				expect(rewards.every((r) => r.sourcePresetId === child.presetId)).toBe(true);
+				expect(rewards.every((r) => r.grantedAt !== null)).toBe(true);
+				// idx 0 が未表示、idx 1-4 が既表示
+				expect(rewards.filter((r) => r.shownAt === null).length).toBe(1);
+				expect(rewards.filter((r) => r.shownAt !== null).length).toBe(4);
+			});
+		}
+
+		it('901 (たろうくん baby、marketplace 対象外) で 0 件', async () => {
+			expect(await specialRewardRepo.findSpecialRewards(901, 'demo')).toEqual([]);
+		});
+
+		it('存在しない childId (999) で 0 件', async () => {
+			expect(await specialRewardRepo.findSpecialRewards(999, 'demo')).toEqual([]);
+		});
+	});
+
+	describe('findUnshownReward: idx 0 (shownAt=null) を返し modal 発火', () => {
+		const expectedChildren = [902, 903, 904, 906];
+
+		for (const childId of expectedChildren) {
+			it(`${childId} で unshown reward を 1 件取得 (childId / shownAt=null 整合)`, async () => {
+				const unshown = await specialRewardRepo.findUnshownReward(childId, 'demo');
+				expect(unshown).toBeDefined();
+				expect(unshown?.childId).toBe(childId);
+				expect(unshown?.shownAt).toBeNull();
+				expect(unshown?.grantedAt).not.toBeNull();
+				expect(unshown?.title).toBeDefined();
+				expect(unshown?.points).toBeGreaterThan(0);
+			});
+		}
+
+		it('901 (baby、marketplace 対象外) で undefined (modal 発火なし)', async () => {
+			expect(await specialRewardRepo.findUnshownReward(901, 'demo')).toBeUndefined();
+		});
+
+		it('findUnshownReward と findSpecialRewards の整合 (idx 0 の id が一致)', async () => {
+			const all = await specialRewardRepo.findSpecialRewards(902, 'demo');
+			const unshown = await specialRewardRepo.findUnshownReward(902, 'demo');
+			expect(unshown?.id).toBe(all[0]?.id);
+		});
+	});
+
+	describe('markRewardShown: stateless stub (fixture mutate なし)', () => {
+		it('markRewardShown は undefined を返す (sqlite repo の returning().get() 整合)', async () => {
+			expect(await specialRewardRepo.markRewardShown(5000, 'demo')).toBeUndefined();
+		});
+
+		it('markRewardShown 呼出後も findUnshownReward は同じ unshown reward を返す (stateless)', async () => {
+			const before = await specialRewardRepo.findUnshownReward(902, 'demo');
+			await specialRewardRepo.markRewardShown(before?.id ?? 0, 'demo');
+			const after = await specialRewardRepo.findUnshownReward(902, 'demo');
+			expect(after?.id).toBe(before?.id);
+			expect(after?.shownAt).toBeNull();
+		});
+
+		it('markRewardShown 呼出後も fixture (MARKETPLACE_SPECIAL_REWARDS_BY_CHILD) 件数不変', async () => {
+			const before = getDemoMarketplaceSpecialRewardsByChild(902).length;
+			await specialRewardRepo.markRewardShown(5000, 'demo');
+			expect(getDemoMarketplaceSpecialRewardsByChild(902).length).toBe(before);
+		});
+	});
+
+	describe('insertSpecialReward: stateless stub (input echo)', () => {
+		it('insertSpecialReward は input を echo した SpecialReward を返す', async () => {
+			const input = {
+				childId: 902,
+				title: 'テスト報酬',
+				points: 50,
+				category: 'achievement',
+				icon: '🎁',
+			};
+			const result = await specialRewardRepo.insertSpecialReward(input, 'demo');
+			expect(result.childId).toBe(input.childId);
+			expect(result.title).toBe(input.title);
+			expect(result.points).toBe(input.points);
+			expect(result.icon).toBe(input.icon);
+			expect(result.shownAt).toBeNull();
+		});
+
+		it('insertSpecialReward 呼出後も fixture 件数不変', async () => {
+			const before = getDemoMarketplaceSpecialRewardsByChild(902).length;
+			await specialRewardRepo.insertSpecialReward(
+				{ childId: 902, title: 'x', points: 10, category: 'achievement' },
+				'demo',
+			);
+			expect(getDemoMarketplaceSpecialRewardsByChild(902).length).toBe(before);
+		});
+	});
+
+	describe('deleteByTenantId: no-op stub', () => {
+		it('deleteByTenantId は no-op (Promise<void>)', async () => {
+			await expect(specialRewardRepo.deleteByTenantId('demo')).resolves.toBeUndefined();
+		});
+	});
+});

--- a/tests/unit/server/db/demo/stub-repos.test.ts
+++ b/tests/unit/server/db/demo/stub-repos.test.ts
@@ -228,8 +228,15 @@ describe('demo/special-reward-repo', () => {
 		expect(await specialRewardRepo.findSpecialRewards(901, 'demo')).toEqual([]);
 	});
 
-	it('findUnshownReward は undefined (全 pre-granted は shownAt 既設定)', async () => {
-		expect(await specialRewardRepo.findUnshownReward(902, 'demo')).toBeUndefined();
+	it('findUnshownReward は marketplace 由来 idx 0 (shownAt=null) を返す (#2097 B-5a)', async () => {
+		const unshown = await specialRewardRepo.findUnshownReward(902, 'demo');
+		expect(unshown).toBeDefined();
+		expect(unshown?.childId).toBe(902);
+		expect(unshown?.shownAt).toBeNull();
+	});
+
+	it('findUnshownReward は 901 (baby、marketplace 対象外) で undefined', async () => {
+		expect(await specialRewardRepo.findUnshownReward(901, 'demo')).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供（demo Lambda の体験者全員）+ 親（演出を体感したい）

**解決する課題**: B-7 で marketplace 由来の special-reward (個別演出ごほうび) 5 件が各子供に配置されたが、全件 `shownAt` 既設定だったため `findUnshownReward` が常に undefined を返し、子供ホームで `SpecialRewardOverlay` (おうかん演出 / 達成プレゼント modal) が**永久に発火しなかった** (audit P1 #5)。demo Lambda の体験者は「がんばりクエストの主要な達成演出」を見ずに離脱する状態。

**期待される効果**: demo.ganbari-quest.com の子供ホーム (preschool / elementary / junior / senior) 初回 load で達成プレゼント modal が 1 回演出され、demo 体験者が「特別ごほうびがもらえる嬉しさ」を実感できる。本番 NUC ユーザの初日体験 (誕生日 / マイルストーン到達後の reward modal) と demo の見た目 parity を達成。

## 関連 Issue

related #2097 (Phase B-5a のみ。他 Phase B は別 PR)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 各子供 (902/903/904/906) で `findSpecialRewards` が 5 件返す (shown 4 + unshown 1) | `tests/unit/server/db/demo/special-reward-repo.test.ts` | PASS: 4 child × 5 件 + 各 1 件 unshown |
| AC2 | `findUnshownReward(childId)` が `shownAt=null` の 1 件を返す (idx 0) | 同上 | PASS: 4 child で unshown reward 取得確認、childId / shownAt=null 整合 |
| AC3 | 901 (baby、marketplace 対象外) で `findUnshownReward` が undefined | 同上 | PASS: modal 発火なし |
| AC4 | `markRewardShown` 呼出後も `findUnshownReward` は同じ reward を返す (stateless) | 同上 | PASS: stateless stub、fixture mutate なし |
| AC5 | `insertSpecialReward` / `deleteByTenantId` も stateless (fixture 件数不変) | 同上 | PASS |
| AC6 | `findUnshownReward` と `findSpecialRewards` の整合 (idx 0 の id が一致) | 同上 | PASS |
| AC7 | 既存テスト (reward-marketplace.test.ts / stub-repos.test.ts) も新動作で PASS | `npx vitest run tests/unit/server/db/demo/` | PASS: 153 件全 PASS |
| AC8 | production code paths (sqlite / dynamodb) 無変更 (demo-only) | `git diff --stat src/lib/server/db/sqlite/ src/lib/server/db/dynamodb/` | PASS: 0 行 diff |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — demo Repository のみ (sqlite/dynamodb 無変更)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- demo.ganbari-quest.com の `/preschool/home` (902) → `SpecialRewardOverlay` 1 回発火
- demo.ganbari-quest.com の `/elementary/home` (903) → 同上
- demo.ganbari-quest.com の `/junior/home` (904) → 同上
- demo.ganbari-quest.com の `/senior/home` (906) → 同上
- demo.ganbari-quest.com の `/{uiMode}/shop` (902/903/904/906) → 5 件 reward shop アイテム表示（B-7 で既稼働、本 PR で挙動変更なし）
- demo.ganbari-quest.com の `/baby/home` (901) → modal 発火なし (marketplace 対象外、想定動作)

本番 (ganbari-quest.com) は変更なし（demo Repository (`src/lib/server/db/demo/*`) + demo-data.ts のみ変更、production path 無変更）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— ローカル biome / vitest PASS、svelte-check の infra/ aws-cdk-lib エラーは pre-existing
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/server/db/demo/special-reward-repo.test.ts` (新規 19 件): B-5a 動作 — 各子供 (902/903/904/906) で reward 件数 / unshown 取得 / stateless stub / insert echo / deleteByTenantId 全網羅
  - `tests/unit/server/db/demo/reward-marketplace.test.ts` (修正): 「全 shown」assert を「shown 4 + unshown 1」に更新（B-5a 動作整合）
  - `tests/unit/server/db/demo/stub-repos.test.ts` (修正 + 新規 1 件): findUnshownReward の undefined assert を reward 取得に更新 + 901 baby の undefined ケース追加
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A (demo Repository のみ、sqlite/dynamodb 無変更)

## スクリーンショット / ビジュアルデモ

UI 直接変更なし (Repository fixture layer のみ)。本 PR は fixture-only のため SS N/A。実機検証は merge 後 demo Lambda デプロイで PO が確認:

- merge 後 `https://demo.ganbari-quest.com/preschool/home` 初回 load → 達成プレゼント modal が 1 回演出される
- 同 `/elementary/home` / `/junior/home` / `/senior/home` でも同等の演出を確認
- `/baby/home` では演出なし (marketplace 対象外、想定動作)

## コード品質セルフレビュー (#1481)

- [x] **OSS / 確立パターン先調査**（ADR-0014 / #1350）: 独自実装 0 — sqlite repo の `findUnshownReward` (`where shownAt is null limit 1`) と同じ semantics を `array.find((r) => r.shownAt === null)` で実装、新規 OSS 導入なし
- [x] **OOP / SOLID 原則**: Repository pattern (ADR-0048) 適合、demo Repository の Fake (read) + Stub (write) hybrid を維持。production path 無変更で OCP 適合
- [x] **複数箇所 SSOT 違反なし**: `MARKETPLACE_SPECIAL_REWARDS_BY_CHILD` builder の 1 行 (idx 0 unshown) のみで挙動制御、shown/unshown 判定が 1 箇所に集約
- [x] **既存 SSOT 準拠**: B-7 で導入された `getDemoMarketplaceSpecialRewardsByChild` 経由で参照、demo-data.ts の atom (MARKETPLACE_REWARD_TEMPLATES_BY_CHILD) を再利用
- [x] **コード臭**: builder の `shownAt: idx === 0 ? null : daysAgoISO(idx + 1)` 1 行差分、複雑度増加なし
- [x] **テスト品質**: 新規 test file は public Repository API ベース検証、実装ロジック再実装なし、assertion 弱体化なし (ADR-0006)

## 横展開・影響波及チェック

- [x] **demo / production 並行実装** (parallel-implementations.md): demo Repository のみ変更、production (sqlite / dynamodb) は B-7 と同じく無変更
- [x] **既存テスト影響**: 2 ファイル (reward-marketplace.test.ts / stub-repos.test.ts) を新動作に更新済、全 153 件 demo db テスト PASS
- [x] **legacy demo routes** (`src/routes/demo/`): 影響なし (B-5a は ADR-0048 demo Lambda の Repository chain のみ修正)
- [x] **anti-engagement 適合** (ADR-0012): modal 1 回演出のみ、stateless stub で `markRewardShown` 後も再演出される設計だが、子供が modal を閉じる動作で体験完結し連続演出にならない
- [x] **設計書同期**: `docs/research/2097-demo-fixture-gaps.md` P1 #5 で audit 済。本 PR で B-5a 完遂、追加対応なし

## レビュー依頼事項・破壊的変更

**重点レビュー観点**:
1. idx 0 を unshown にする方針が「子供ホーム初回 load 1 回演出」の anti-engagement 原則 (ADR-0012) と整合するか
2. `markRewardShown` を stateless stub のままにする判断 (子供が modal 閉じ → 再 reload で同じ reward 再演出)。代替案は MARKETPLACE_SPECIAL_REWARDS_BY_CHILD を runtime mutate だが ADR-0048 §2 stateless Fake/Stub 原則に違反するため不採用

**破壊的変更**: なし。Repository API signature / SpecialReward schema 変更なし、demo fixture 内 `shownAt` 値のみ 1 件変更。

## 配布済み env / secret (ADR-0006)

N/A (新規 env / secret 追加なし)

## Ready for Review チェックリスト

- [x] Issue の AC を全て満たすか自己確認 (AC 検証マップ 8 項目 PASS)
- [x] 設計書 / ADR を関連箇所で更新 (該当なし: docs/research/2097-demo-fixture-gaps.md が SSOT、本 PR で B-5a 完遂)
- [x] テストが安全装置として機能（assertion 弱体化なし、ADR-0006 適合）— 19 新規 + 2 修正 + 1 追加、demo db 全 153 件 PASS
- [x] biome / vitest ローカル PASS (svelte-check の infra/ aws-cdk-lib エラーは pre-existing、本 PR と無関係)

## QM レビュー結果

QM Agent が PR Ready 化後にレビュー実施する。本 PR は fixture-only の demo-only 変更のため、QM は (a) demo Repository 整合性 (b) production path 無変更 (c) anti-engagement 整合 (d) stateless 維持 を重点確認する。
