### PR TITLE
fix: #2097 Phase B-2 — demo stamp card fixture (16 masters + 4 子供 × 当週/前週カード)

### DIFF
--- a/src/lib/server/db/demo/stamp-card-repo.ts
+++ b/src/lib/server/db/demo/stamp-card-repo.ts
@@ -1,6 +1,12 @@
 // Demo IStampCardRepo implementation
 // ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
+// #2097 Phase B-2: 当週 active card + 前週 redeemed card の fixture を返す。
 
+import {
+	DEMO_STAMP_CARDS,
+	DEMO_STAMP_ENTRIES,
+	DEMO_STAMP_MASTERS,
+} from '$lib/server/demo/demo-data';
 import type {
 	InsertStampCardInput,
 	InsertStampEntryInput,
@@ -11,15 +17,15 @@ import type {
 } from '../types';
 
 export async function findEnabledStampMasters(_tenantId: string): Promise<StampMaster[]> {
-	return [];
+	return DEMO_STAMP_MASTERS.filter((m) => m.isEnabled === 1);
 }
 
 export async function findCardByChildAndWeek(
-	_childId: number,
-	_weekStart: string,
+	childId: number,
+	weekStart: string,
 	_tenantId: string,
 ): Promise<StampCard | undefined> {
-	return undefined;
+	return DEMO_STAMP_CARDS.find((c) => c.childId === childId && c.weekStart === weekStart);
 }
 
 export async function insertCard(
@@ -41,10 +47,22 @@ export async function insertCard(
 }
 
 export async function findEntriesWithMasterByCardId(
-	_cardId: number,
+	cardId: number,
 	_tenantId: string,
 ): Promise<StampEntryWithMaster[]> {
-	return [];
+	const entries = DEMO_STAMP_ENTRIES.filter((e) => e.cardId === cardId);
+	return entries.map((e) => {
+		const master = DEMO_STAMP_MASTERS.find((m) => m.id === e.stampMasterId);
+		return {
+			slot: e.slot,
+			stampMasterId: e.stampMasterId,
+			omikujiRank: e.omikujiRank,
+			loginDate: e.loginDate,
+			name: master?.name ?? null,
+			emoji: master?.emoji ?? null,
+			rarity: master?.rarity ?? null,
+		};
+	});
 }
 
 export async function insertEntry(_input: InsertStampEntryInput, _tenantId: string): Promise<void> {

--- a/src/lib/server/demo/demo-data.ts
+++ b/src/lib/server/demo/demo-data.ts
@@ -49,6 +49,9 @@ import type {
 	SiblingChallengeProgress,
 	SiblingCheer,
 	SpecialReward,
+	StampCard,
+	StampEntry,
+	StampMaster,
 	Status,
 } from '$lib/server/db/types/index.js';
 
@@ -3073,6 +3076,614 @@ export function getDemoMarketplaceChecklistItemsByTemplate(
 export function getDemoMarketplaceSpecialRewardsByChild(childId: number): SpecialReward[] {
 	return MARKETPLACE_SPECIAL_REWARDS_BY_CHILD[childId] ?? [];
 }
+
+// ============================================================
+// Stamp Cards (#2097 Phase B-2)
+// ============================================================
+// production seed (src/lib/server/db/seed.ts) と同じ 16 種を fixture 化。
+// rarity 別出現確率: N 60% / R 25% / SR 12% / UR 3% (stamp-card-service.ts §RARITY_WEIGHTS)
+//
+// baby (901) は ADR-0011 によりスタンプカード非表示。
+// preschool/elementary/junior/senior の 4 子供に対し、
+// - 当週 (weekStart=2026-03-23, demo TODAY=2026-03-27 Fri):
+//   active "collecting" card + 子供の活動レベルに応じた filled stamp 2-4 個
+// - 前週 (weekStart=2026-03-16): 5/5 filled + status='redeemed' の完了カード
+//
+// 当週カード ID = 7xx, 前週カード ID = 8xx, entry ID = card_id * 10 + slot
+// child 別 fillCount (当週): 902=2, 903=3, 904=4, 906=4 (年齢/活発度に応じて段階)
+
+export const DEMO_STAMP_MASTERS: StampMaster[] = [
+	// Normal (5)
+	{
+		id: 1,
+		name: 'にこにこ',
+		emoji: '😊',
+		rarity: 'N',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 2,
+		name: 'グッジョブ',
+		emoji: '👍',
+		rarity: 'N',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 3,
+		name: 'スター',
+		emoji: '⭐',
+		rarity: 'N',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 4,
+		name: 'ハート',
+		emoji: '❤️',
+		rarity: 'N',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 5,
+		name: 'がんばった',
+		emoji: '💪',
+		rarity: 'N',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	// Rare (5)
+	{
+		id: 6,
+		name: 'ロケット',
+		emoji: '🚀',
+		rarity: 'R',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 7,
+		name: 'おうかん',
+		emoji: '👑',
+		rarity: 'R',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 8,
+		name: 'トロフィー',
+		emoji: '🏆',
+		rarity: 'R',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 9,
+		name: 'にじ',
+		emoji: '🌈',
+		rarity: 'R',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 10,
+		name: 'たいよう',
+		emoji: '☀️',
+		rarity: 'R',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	// Super Rare (4)
+	{
+		id: 11,
+		name: 'ドラゴン',
+		emoji: '🐉',
+		rarity: 'SR',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 12,
+		name: 'ユニコーン',
+		emoji: '🦄',
+		rarity: 'SR',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 13,
+		name: 'たからばこ',
+		emoji: '📦',
+		rarity: 'SR',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 14,
+		name: 'まほうのつえ',
+		emoji: '🪄',
+		rarity: 'SR',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	// Ultra Rare (2)
+	{
+		id: 15,
+		name: 'でんせつのけん',
+		emoji: '⚔️',
+		rarity: 'UR',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+	{
+		id: 16,
+		name: 'きせきのほし',
+		emoji: '🌟',
+		rarity: 'UR',
+		isDefault: 1,
+		isEnabled: 1,
+		createdAt: NOW,
+		updatedAt: NOW,
+	},
+];
+
+// 週境界: demo TODAY=2026-03-27 (Fri) → weekStart=2026-03-23 / weekEnd=2026-03-29
+// 前週: weekStart=2026-03-16 / weekEnd=2026-03-22
+const CURRENT_WEEK_START = '2026-03-23';
+const CURRENT_WEEK_END = '2026-03-29';
+const PREV_WEEK_START = '2026-03-16';
+const PREV_WEEK_END = '2026-03-22';
+
+// 当週 active "collecting" card: card.id = 7xx (子供ごと固定)
+// 前週 5/5 完了 "redeemed" card: card.id = 8xx
+export const DEMO_STAMP_CARDS: StampCard[] = [
+	// 902 ひなちゃん (preschool) — 当週 2 枚 (月火)
+	{
+		id: 702,
+		childId: 902,
+		weekStart: CURRENT_WEEK_START,
+		weekEnd: CURRENT_WEEK_END,
+		status: 'collecting',
+		redeemedPoints: null,
+		redeemedAt: null,
+		createdAt: daysAgoISO(4),
+		updatedAt: daysAgoISO(3),
+	},
+	{
+		id: 802,
+		childId: 902,
+		weekStart: PREV_WEEK_START,
+		weekEnd: PREV_WEEK_END,
+		status: 'redeemed',
+		redeemedPoints: 100, // 5*10 + 50 complete bonus
+		redeemedAt: daysAgoISO(5),
+		createdAt: daysAgoISO(11),
+		updatedAt: daysAgoISO(5),
+	},
+	// 903 けんたくん (elementary) — 当週 3 枚 (月火水)
+	{
+		id: 703,
+		childId: 903,
+		weekStart: CURRENT_WEEK_START,
+		weekEnd: CURRENT_WEEK_END,
+		status: 'collecting',
+		redeemedPoints: null,
+		redeemedAt: null,
+		createdAt: daysAgoISO(4),
+		updatedAt: daysAgoISO(2),
+	},
+	{
+		id: 803,
+		childId: 903,
+		weekStart: PREV_WEEK_START,
+		weekEnd: PREV_WEEK_END,
+		status: 'redeemed',
+		redeemedPoints: 100,
+		redeemedAt: daysAgoISO(5),
+		createdAt: daysAgoISO(11),
+		updatedAt: daysAgoISO(5),
+	},
+	// 904 さくらちゃん (junior) — 当週 4 枚 (月火水木)
+	{
+		id: 704,
+		childId: 904,
+		weekStart: CURRENT_WEEK_START,
+		weekEnd: CURRENT_WEEK_END,
+		status: 'collecting',
+		redeemedPoints: null,
+		redeemedAt: null,
+		createdAt: daysAgoISO(4),
+		updatedAt: daysAgoISO(1),
+	},
+	{
+		id: 804,
+		childId: 904,
+		weekStart: PREV_WEEK_START,
+		weekEnd: PREV_WEEK_END,
+		status: 'redeemed',
+		redeemedPoints: 100,
+		redeemedAt: daysAgoISO(5),
+		createdAt: daysAgoISO(11),
+		updatedAt: daysAgoISO(5),
+	},
+	// 906 けいすけくん (senior) — 当週 4 枚 (月火水木)
+	{
+		id: 706,
+		childId: 906,
+		weekStart: CURRENT_WEEK_START,
+		weekEnd: CURRENT_WEEK_END,
+		status: 'collecting',
+		redeemedPoints: null,
+		redeemedAt: null,
+		createdAt: daysAgoISO(4),
+		updatedAt: daysAgoISO(1),
+	},
+	{
+		id: 806,
+		childId: 906,
+		weekStart: PREV_WEEK_START,
+		weekEnd: PREV_WEEK_END,
+		status: 'redeemed',
+		redeemedPoints: 100,
+		redeemedAt: daysAgoISO(5),
+		createdAt: daysAgoISO(11),
+		updatedAt: daysAgoISO(5),
+	},
+];
+
+// stamp_entries: cardId * 10 + slot
+// loginDate は当週: weekStart 起点 (Mon=2026-03-23) で slot-1 日後
+//                  前週: weekStart 起点 (Mon=2026-03-16) で slot-1 日後
+function currentWeekDate(slot: number): string {
+	const d = new Date(`${CURRENT_WEEK_START}T00:00:00Z`);
+	d.setUTCDate(d.getUTCDate() + (slot - 1));
+	return d.toISOString().slice(0, 10);
+}
+function prevWeekDate(slot: number): string {
+	const d = new Date(`${PREV_WEEK_START}T00:00:00Z`);
+	d.setUTCDate(d.getUTCDate() + (slot - 1));
+	return d.toISOString().slice(0, 10);
+}
+
+export const DEMO_STAMP_ENTRIES: StampEntry[] = [
+	// === 902 ひな 当週 (cardId=702) — slot 1-2, masters 1(N)+3(N) ===
+	{
+		id: 7021,
+		cardId: 702,
+		stampMasterId: 1,
+		omikujiRank: 'sho-kichi',
+		slot: 1,
+		loginDate: currentWeekDate(1),
+		earnedAt: daysAgoISO(4),
+	},
+	{
+		id: 7022,
+		cardId: 702,
+		stampMasterId: 3,
+		omikujiRank: 'kichi',
+		slot: 2,
+		loginDate: currentWeekDate(2),
+		earnedAt: daysAgoISO(3),
+	},
+	// === 902 ひな 前週 (cardId=802) — 5/5 完了, N×3 + R×1 + SR×1 ===
+	{
+		id: 8021,
+		cardId: 802,
+		stampMasterId: 1,
+		omikujiRank: 'sho-kichi',
+		slot: 1,
+		loginDate: prevWeekDate(1),
+		earnedAt: daysAgoISO(11),
+	},
+	{
+		id: 8022,
+		cardId: 802,
+		stampMasterId: 4,
+		omikujiRank: 'sho-kichi',
+		slot: 2,
+		loginDate: prevWeekDate(2),
+		earnedAt: daysAgoISO(10),
+	},
+	{
+		id: 8023,
+		cardId: 802,
+		stampMasterId: 5,
+		omikujiRank: 'kichi',
+		slot: 3,
+		loginDate: prevWeekDate(3),
+		earnedAt: daysAgoISO(9),
+	},
+	{
+		id: 8024,
+		cardId: 802,
+		stampMasterId: 9,
+		omikujiRank: 'chu-kichi',
+		slot: 4,
+		loginDate: prevWeekDate(4),
+		earnedAt: daysAgoISO(8),
+	},
+	{
+		id: 8025,
+		cardId: 802,
+		stampMasterId: 12,
+		omikujiRank: 'dai-kichi',
+		slot: 5,
+		loginDate: prevWeekDate(5),
+		earnedAt: daysAgoISO(7),
+	},
+	// === 903 けんた 当週 (cardId=703) — 3 個, N+N+R ===
+	{
+		id: 7031,
+		cardId: 703,
+		stampMasterId: 2,
+		omikujiRank: 'sho-kichi',
+		slot: 1,
+		loginDate: currentWeekDate(1),
+		earnedAt: daysAgoISO(4),
+	},
+	{
+		id: 7032,
+		cardId: 703,
+		stampMasterId: 5,
+		omikujiRank: 'kichi',
+		slot: 2,
+		loginDate: currentWeekDate(2),
+		earnedAt: daysAgoISO(3),
+	},
+	{
+		id: 7033,
+		cardId: 703,
+		stampMasterId: 8,
+		omikujiRank: 'chu-kichi',
+		slot: 3,
+		loginDate: currentWeekDate(3),
+		earnedAt: daysAgoISO(2),
+	},
+	// === 903 けんた 前週 (cardId=803) — 5/5 完了, N×2 + R×2 + SR×1 ===
+	{
+		id: 8031,
+		cardId: 803,
+		stampMasterId: 1,
+		omikujiRank: 'sho-kichi',
+		slot: 1,
+		loginDate: prevWeekDate(1),
+		earnedAt: daysAgoISO(11),
+	},
+	{
+		id: 8032,
+		cardId: 803,
+		stampMasterId: 5,
+		omikujiRank: 'kichi',
+		slot: 2,
+		loginDate: prevWeekDate(2),
+		earnedAt: daysAgoISO(10),
+	},
+	{
+		id: 8033,
+		cardId: 803,
+		stampMasterId: 6,
+		omikujiRank: 'chu-kichi',
+		slot: 3,
+		loginDate: prevWeekDate(3),
+		earnedAt: daysAgoISO(9),
+	},
+	{
+		id: 8034,
+		cardId: 803,
+		stampMasterId: 7,
+		omikujiRank: 'chu-kichi',
+		slot: 4,
+		loginDate: prevWeekDate(4),
+		earnedAt: daysAgoISO(8),
+	},
+	{
+		id: 8035,
+		cardId: 803,
+		stampMasterId: 13,
+		omikujiRank: 'dai-kichi',
+		slot: 5,
+		loginDate: prevWeekDate(5),
+		earnedAt: daysAgoISO(7),
+	},
+	// === 904 さくら 当週 (cardId=704) — 4 個, N+R+SR+R ===
+	{
+		id: 7041,
+		cardId: 704,
+		stampMasterId: 3,
+		omikujiRank: 'sho-kichi',
+		slot: 1,
+		loginDate: currentWeekDate(1),
+		earnedAt: daysAgoISO(4),
+	},
+	{
+		id: 7042,
+		cardId: 704,
+		stampMasterId: 8,
+		omikujiRank: 'chu-kichi',
+		slot: 2,
+		loginDate: currentWeekDate(2),
+		earnedAt: daysAgoISO(3),
+	},
+	{
+		id: 7043,
+		cardId: 704,
+		stampMasterId: 11,
+		omikujiRank: 'dai-kichi',
+		slot: 3,
+		loginDate: currentWeekDate(3),
+		earnedAt: daysAgoISO(2),
+	},
+	{
+		id: 7044,
+		cardId: 704,
+		stampMasterId: 9,
+		omikujiRank: 'chu-kichi',
+		slot: 4,
+		loginDate: currentWeekDate(4),
+		earnedAt: daysAgoISO(1),
+	},
+	// === 904 さくら 前週 (cardId=804) — 5/5 完了, R×2 + SR×2 + UR×1 ===
+	{
+		id: 8041,
+		cardId: 804,
+		stampMasterId: 6,
+		omikujiRank: 'chu-kichi',
+		slot: 1,
+		loginDate: prevWeekDate(1),
+		earnedAt: daysAgoISO(11),
+	},
+	{
+		id: 8042,
+		cardId: 804,
+		stampMasterId: 10,
+		omikujiRank: 'chu-kichi',
+		slot: 2,
+		loginDate: prevWeekDate(2),
+		earnedAt: daysAgoISO(10),
+	},
+	{
+		id: 8043,
+		cardId: 804,
+		stampMasterId: 11,
+		omikujiRank: 'dai-kichi',
+		slot: 3,
+		loginDate: prevWeekDate(3),
+		earnedAt: daysAgoISO(9),
+	},
+	{
+		id: 8044,
+		cardId: 804,
+		stampMasterId: 14,
+		omikujiRank: 'dai-kichi',
+		slot: 4,
+		loginDate: prevWeekDate(4),
+		earnedAt: daysAgoISO(8),
+	},
+	{
+		id: 8045,
+		cardId: 804,
+		stampMasterId: 16,
+		omikujiRank: 'dai-kichi',
+		slot: 5,
+		loginDate: prevWeekDate(5),
+		earnedAt: daysAgoISO(7),
+	},
+	// === 906 けいすけ 当週 (cardId=706) — 4 個, R+SR+R+SR ===
+	{
+		id: 7061,
+		cardId: 706,
+		stampMasterId: 7,
+		omikujiRank: 'chu-kichi',
+		slot: 1,
+		loginDate: currentWeekDate(1),
+		earnedAt: daysAgoISO(4),
+	},
+	{
+		id: 7062,
+		cardId: 706,
+		stampMasterId: 12,
+		omikujiRank: 'dai-kichi',
+		slot: 2,
+		loginDate: currentWeekDate(2),
+		earnedAt: daysAgoISO(3),
+	},
+	{
+		id: 7063,
+		cardId: 706,
+		stampMasterId: 10,
+		omikujiRank: 'chu-kichi',
+		slot: 3,
+		loginDate: currentWeekDate(3),
+		earnedAt: daysAgoISO(2),
+	},
+	{
+		id: 7064,
+		cardId: 706,
+		stampMasterId: 13,
+		omikujiRank: 'dai-kichi',
+		slot: 4,
+		loginDate: currentWeekDate(4),
+		earnedAt: daysAgoISO(1),
+	},
+	// === 906 けいすけ 前週 (cardId=806) — 5/5 完了, R×1 + SR×2 + UR×2 ===
+	{
+		id: 8061,
+		cardId: 806,
+		stampMasterId: 8,
+		omikujiRank: 'chu-kichi',
+		slot: 1,
+		loginDate: prevWeekDate(1),
+		earnedAt: daysAgoISO(11),
+	},
+	{
+		id: 8062,
+		cardId: 806,
+		stampMasterId: 12,
+		omikujiRank: 'dai-kichi',
+		slot: 2,
+		loginDate: prevWeekDate(2),
+		earnedAt: daysAgoISO(10),
+	},
+	{
+		id: 8063,
+		cardId: 806,
+		stampMasterId: 14,
+		omikujiRank: 'dai-kichi',
+		slot: 3,
+		loginDate: prevWeekDate(3),
+		earnedAt: daysAgoISO(9),
+	},
+	{
+		id: 8064,
+		cardId: 806,
+		stampMasterId: 15,
+		omikujiRank: 'dai-kichi',
+		slot: 4,
+		loginDate: prevWeekDate(4),
+		earnedAt: daysAgoISO(8),
+	},
+	{
+		id: 8065,
+		cardId: 806,
+		stampMasterId: 16,
+		omikujiRank: 'dai-kichi',
+		slot: 5,
+		loginDate: prevWeekDate(5),
+		earnedAt: daysAgoISO(7),
+	},
+];
 
 // ============================================================
 // Helper: Get demo data for a specific child

--- a/tests/unit/server/db/demo/stamp-card-repo.test.ts
+++ b/tests/unit/server/db/demo/stamp-card-repo.test.ts
@@ -1,0 +1,234 @@
+// tests/unit/server/db/demo/stamp-card-repo.test.ts
+// #2097 Phase B-2: demo Stamp Card Repo の Fake (read) + Stub (write) hybrid 検証。
+// production seed と同じ 16 種マスタを返し、4 子供 (902/903/904/906) に当週 + 前週カードを供給する。
+
+import { describe, expect, it } from 'vitest';
+import * as stampCardRepo from '../../../../../src/lib/server/db/demo/stamp-card-repo';
+import {
+	DEMO_STAMP_CARDS,
+	DEMO_STAMP_ENTRIES,
+	DEMO_STAMP_MASTERS,
+} from '../../../../../src/lib/server/demo/demo-data';
+
+const CURRENT_WEEK_START = '2026-03-23';
+const PREV_WEEK_START = '2026-03-16';
+
+describe('demo/stamp-card-repo (#2097 Phase B-2)', () => {
+	describe('findEnabledStampMasters', () => {
+		it('production seed と同じ 16 種を返す', async () => {
+			const masters = await stampCardRepo.findEnabledStampMasters('demo');
+			expect(masters.length).toBe(16);
+			expect(masters.length).toBe(DEMO_STAMP_MASTERS.length);
+		});
+
+		it('全マスタが isEnabled=1', async () => {
+			const masters = await stampCardRepo.findEnabledStampMasters('demo');
+			expect(masters.every((m) => m.isEnabled === 1)).toBe(true);
+		});
+
+		it('全 4 レアリティ (N / R / SR / UR) を含む', async () => {
+			const masters = await stampCardRepo.findEnabledStampMasters('demo');
+			const rarities = new Set(masters.map((m) => m.rarity));
+			expect(rarities).toEqual(new Set(['N', 'R', 'SR', 'UR']));
+		});
+
+		it('レアリティ比率: N=5, R=5, SR=4, UR=2', async () => {
+			const masters = await stampCardRepo.findEnabledStampMasters('demo');
+			const byRarity = masters.reduce<Record<string, number>>((acc, m) => {
+				acc[m.rarity] = (acc[m.rarity] ?? 0) + 1;
+				return acc;
+			}, {});
+			expect(byRarity).toEqual({ N: 5, R: 5, SR: 4, UR: 2 });
+		});
+	});
+
+	describe('findCardByChildAndWeek', () => {
+		// 4 子供 (902 ひな / 903 けんた / 904 さくら / 906 けいすけ) × 当週 / 前週
+		// 901 たろう (baby) は ADR-0011 によりスタンプカード非表示 → fixture 対象外
+
+		it.each([902, 903, 904, 906])('childId=%i: 当週 active card が取れる', async (childId) => {
+			const card = await stampCardRepo.findCardByChildAndWeek(childId, CURRENT_WEEK_START, 'demo');
+			expect(card).toBeDefined();
+			expect(card?.childId).toBe(childId);
+			expect(card?.weekStart).toBe(CURRENT_WEEK_START);
+			expect(card?.status).toBe('collecting');
+			expect(card?.redeemedPoints).toBeNull();
+		});
+
+		it.each([902, 903, 904, 906])('childId=%i: 前週 redeemed card が取れる', async (childId) => {
+			const card = await stampCardRepo.findCardByChildAndWeek(childId, PREV_WEEK_START, 'demo');
+			expect(card).toBeDefined();
+			expect(card?.childId).toBe(childId);
+			expect(card?.weekStart).toBe(PREV_WEEK_START);
+			expect(card?.status).toBe('redeemed');
+			expect(card?.redeemedPoints).toBe(100); // 5*10 + 50 complete bonus
+		});
+
+		it('baby (childId=901) はカード未登録 → undefined', async () => {
+			const card = await stampCardRepo.findCardByChildAndWeek(901, CURRENT_WEEK_START, 'demo');
+			expect(card).toBeUndefined();
+		});
+
+		it('未登録の週 (2 週前) は undefined', async () => {
+			const card = await stampCardRepo.findCardByChildAndWeek(902, '2026-03-09', 'demo');
+			expect(card).toBeUndefined();
+		});
+	});
+
+	describe('findEntriesWithMasterByCardId', () => {
+		it('902 当週カード (cardId=702): 2 件、master 情報付き', async () => {
+			const entries = await stampCardRepo.findEntriesWithMasterByCardId(702, 'demo');
+			expect(entries.length).toBe(2);
+			expect(entries[0]?.name).toBeTruthy();
+			expect(entries[0]?.emoji).toBeTruthy();
+			expect(entries[0]?.rarity).toBeTruthy();
+			expect(entries[0]?.slot).toBe(1);
+			expect(entries[1]?.slot).toBe(2);
+		});
+
+		it('902 前週カード (cardId=802): 5/5 完了', async () => {
+			const entries = await stampCardRepo.findEntriesWithMasterByCardId(802, 'demo');
+			expect(entries.length).toBe(5);
+			expect(entries.map((e) => e.slot)).toEqual([1, 2, 3, 4, 5]);
+		});
+
+		it.each([
+			[703, 3], // 903 当週
+			[704, 4], // 904 当週
+			[706, 4], // 906 当週
+		])('cardId=%i: %i 件のエントリ', async (cardId, expected) => {
+			const entries = await stampCardRepo.findEntriesWithMasterByCardId(cardId, 'demo');
+			expect(entries.length).toBe(expected);
+		});
+
+		it.each([803, 804, 806])('前週 cardId=%i は 5/5 完了 (redeemable な状態)', async (cardId) => {
+			const entries = await stampCardRepo.findEntriesWithMasterByCardId(cardId, 'demo');
+			expect(entries.length).toBe(5);
+		});
+
+		it('未登録 cardId は空配列', async () => {
+			const entries = await stampCardRepo.findEntriesWithMasterByCardId(99999, 'demo');
+			expect(entries).toEqual([]);
+		});
+
+		it('entries の master join: rarity が N / R / SR / UR のいずれか', async () => {
+			const entries = await stampCardRepo.findEntriesWithMasterByCardId(806, 'demo');
+			for (const e of entries) {
+				expect(['N', 'R', 'SR', 'UR']).toContain(e.rarity);
+			}
+		});
+	});
+
+	describe('fixture 整合性 (DEMO_STAMP_CARDS / DEMO_STAMP_ENTRIES)', () => {
+		it('全 entry が DEMO_STAMP_CARDS の card に紐づく', () => {
+			const cardIds = new Set(DEMO_STAMP_CARDS.map((c) => c.id));
+			for (const entry of DEMO_STAMP_ENTRIES) {
+				expect(cardIds.has(entry.cardId)).toBe(true);
+			}
+		});
+
+		it('全 entry の stampMasterId が DEMO_STAMP_MASTERS に存在', () => {
+			const masterIds = new Set(DEMO_STAMP_MASTERS.map((m) => m.id));
+			for (const entry of DEMO_STAMP_ENTRIES) {
+				if (entry.stampMasterId !== null) {
+					expect(masterIds.has(entry.stampMasterId)).toBe(true);
+				}
+			}
+		});
+
+		it('全 card の childId が demo 4 子供 (902/903/904/906) のいずれか', () => {
+			const validChildIds = new Set([902, 903, 904, 906]);
+			for (const card of DEMO_STAMP_CARDS) {
+				expect(validChildIds.has(card.childId)).toBe(true);
+			}
+		});
+
+		it('当週 (2026-03-23) card は 4 子供分すべて collecting', () => {
+			const currentWeekCards = DEMO_STAMP_CARDS.filter((c) => c.weekStart === CURRENT_WEEK_START);
+			expect(currentWeekCards.length).toBe(4);
+			expect(currentWeekCards.every((c) => c.status === 'collecting')).toBe(true);
+		});
+
+		it('前週 (2026-03-16) card は 4 子供分すべて redeemed', () => {
+			const prevWeekCards = DEMO_STAMP_CARDS.filter((c) => c.weekStart === PREV_WEEK_START);
+			expect(prevWeekCards.length).toBe(4);
+			expect(prevWeekCards.every((c) => c.status === 'redeemed')).toBe(true);
+			expect(prevWeekCards.every((c) => c.redeemedPoints === 100)).toBe(true);
+		});
+
+		it('各 card の slot は 1 から連番', () => {
+			for (const card of DEMO_STAMP_CARDS) {
+				const slots = DEMO_STAMP_ENTRIES.filter((e) => e.cardId === card.id)
+					.map((e) => e.slot)
+					.sort((a, b) => a - b);
+				// 連番 (1, 2, 3, ...) であること
+				slots.forEach((slot, idx) => {
+					expect(slot).toBe(idx + 1);
+				});
+			}
+		});
+	});
+
+	describe('Stub write API は no-op (DB 変更しない)', () => {
+		it('insertCard は input をそのまま返す', async () => {
+			const card = await stampCardRepo.insertCard(
+				{
+					childId: 902,
+					weekStart: '2026-04-13',
+					weekEnd: '2026-04-19',
+					status: 'collecting',
+				},
+				'demo',
+			);
+			expect(card.id).toBe(0);
+			expect(card.childId).toBe(902);
+		});
+
+		it('insertEntry は no-op', async () => {
+			await expect(
+				stampCardRepo.insertEntry(
+					{
+						cardId: 702,
+						stampMasterId: 1,
+						omikujiRank: 'kichi',
+						slot: 3,
+						loginDate: '2026-03-25',
+					},
+					'demo',
+				),
+			).resolves.toBeUndefined();
+		});
+
+		it('updateCardStatus / updateCardStatusIfCollecting は no-op / 0', async () => {
+			await expect(
+				stampCardRepo.updateCardStatus(
+					702,
+					{
+						status: 'redeemed',
+						redeemedPoints: 50,
+						redeemedAt: '2026-03-29T00:00:00.000Z',
+						updatedAt: '2026-03-29T00:00:00.000Z',
+					},
+					'demo',
+				),
+			).resolves.toBeUndefined();
+
+			expect(
+				await stampCardRepo.updateCardStatusIfCollecting(
+					702,
+					{
+						status: 'redeemed',
+						redeemedPoints: 50,
+						redeemedAt: '2026-03-29T00:00:00.000Z',
+						updatedAt: '2026-03-29T00:00:00.000Z',
+					},
+					'demo',
+				),
+			).toBe(0);
+		});
+
+		it('deleteByTenantId は no-op', async () => {
+			await expect(stampCardRepo.deleteByTenantId('demo')).resolves.toBeUndefined();
+		});
+	});
+});

--- a/tests/unit/server/db/demo/stub-repos.test.ts
+++ b/tests/unit/server/db/demo/stub-repos.test.ts
@@ -22,7 +22,6 @@ import * as seasonEventRepo from '../../../../../src/lib/server/db/demo/season-e
 import * as siblingChallengeRepo from '../../../../../src/lib/server/db/demo/sibling-challenge-repo';
 import * as siblingCheerRepo from '../../../../../src/lib/server/db/demo/sibling-cheer-repo';
 import * as specialRewardRepo from '../../../../../src/lib/server/db/demo/special-reward-repo';
-import * as stampCardRepo from '../../../../../src/lib/server/db/demo/stamp-card-repo';
 import * as storageRepo from '../../../../../src/lib/server/db/demo/storage-repo';
 import * as tenantEventRepo from '../../../../../src/lib/server/db/demo/tenant-event-repo';
 import * as trialHistoryRepo from '../../../../../src/lib/server/db/demo/trial-history-repo';
@@ -253,12 +252,8 @@ describe('demo/special-reward-repo', () => {
 	});
 });
 
-describe('demo/stamp-card-repo', () => {
-	it('findEnabledStampMasters / findCardByChildAndWeek は空 / undefined', async () => {
-		expect(await stampCardRepo.findEnabledStampMasters('demo')).toEqual([]);
-		expect(await stampCardRepo.findCardByChildAndWeek(902, '2026-04-01', 'demo')).toBeUndefined();
-	});
-});
+// NOTE: demo/stamp-card-repo は #2097 Phase B-2 で fixture 化したため、
+// 固有テストを tests/unit/server/db/demo/stamp-card-repo.test.ts に移管。
 
 describe('demo/storage-repo (S3 等への write 権限なし)', () => {
 	it('readFile / fileExists / listFiles は空 / false', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: demo Lambda で動作確認する POC ユーザ / プロダクト体験を試す見込み客

**解決する課題**: demo Lambda の週間スタンプカード演出が完全空白 — `findEnabledStampMasters()` が `[]`、`findCardByChildAndWeek()` が `undefined` を返すため child home の週間エンゲージメント機能が一切表示されない（`docs/research/2097-demo-fixture-gaps.md` P0 #1）。

**期待される効果**: preschool/elementary/junior/senior の 4 子供で当週 active card + 前週 redeemed card が表示され、demo を触ったユーザに「習慣化を支える週間サイクル」を視覚的に体験させる。

## 関連 Issue

closes #2097 の Phase B-2 sub-task（Issue #2097 全体は EPIC のため別 sub-PR 群との直列）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | demo `findEnabledStampMasters()` が production seed と同じ 16 種を返す | `tests/unit/server/db/demo/stamp-card-repo.test.ts` `findEnabledStampMasters` describe (4 ケース) | PASS (167 demo tests) |
| AC2 | 4 子供 (902/903/904/906) で当週 + 前週カードが取れる | 同テスト `findCardByChildAndWeek` describe (10 ケース、it.each で 4 子供 × 2 週) | PASS |
| AC3 | カードに紐づく entry が master 情報付きで取れる (LEFT JOIN 相当) | 同テスト `findEntriesWithMasterByCardId` describe (8 ケース) | PASS |
| AC4 | baby (901) は ADR-0011 により対象外 → undefined | 同テスト `baby (childId=901) はカード未登録 → undefined` | PASS |
| AC5 | write 系は no-op を維持 (SQLite/DynamoDB 影響ゼロ) | 同テスト `Stub write API は no-op` describe (4 ケース) | PASS |
| AC6 | fixture 整合性 (entry → card → master の参照整合性、slot 連番) | 同テスト `fixture 整合性` describe (6 ケース) | PASS |

## 変更タイプ

- [x] fix: バグ修正 (demo Lambda の機能空白を解消)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/db/demo/stamp-card-repo.ts`) — demo Repository のみ拡張
- [x] ドメインモデル (`$lib/server/demo/demo-data.ts`) — fixture data 追加

**影響を受ける画面・機能**:
- demo Lambda 配下の child home (`/demo/{kinder,lower,upper,teen}/home`) の週間スタンプカード演出
- demo Lambda 配下の admin reports（stamp card 集計を参照する場合）

**本番影響**: SQLite (`src/lib/server/db/sqlite/stamp-card-repo.ts`) / DynamoDB 実装ファイルは変更ゼロ。production tenant の挙動は無変更。

## テスト & 安全装置セルフチェック

- [x] biome check src/ tests/ PASS (1260 files)
- [x] svelte-check (本 PR 起因の新規エラー 0、main の既存 infra/CDK エラーのみ残存)
- [x] vitest run tests/unit/server/db/demo/ → 167 passed
- [ ] 追加・変更したテストの概要:
  - 新規 `tests/unit/server/db/demo/stamp-card-repo.test.ts` (34 ケース、5 describe ブロック)
  - 変更 `tests/unit/server/db/demo/stub-repos.test.ts` — stamp-card-repo describe を専用ファイルに移管
- [x] **新規 env / secret 追加時**: N/A — env 追加なし
- [x] **DynamoDB 実装変更時**: N/A — demo Repository のみ拡張、SQLite/DynamoDB は無変更
- [x] **Critical バグ修正の場合**: N/A — priority:medium (demo UX 改善)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は **demo Lambda 用の fixture data 追加** であり、Svelte component / route / CSS の変更を含まない。実画面表示変化は demo Lambda にデプロイされてから確認可能になる（worktree ローカルの SvelteKit dev server は本番用 SQLite Repository を呼ぶため、demo Repository fixture は反映されない）。

**post-merge 検証フロー**:
1. main マージ後、`pages.yml` または demo Lambda デプロイ workflow が自動で demo Lambda を更新
2. POREVIEWER / QA が `https://gambari-quest-demo.example.com/demo/kinder/home` 等で実画面確認
3. 当週カード 2 stamp 表示 + 前週カード 5/5 redeemed 表示を目視

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし (UI 構造変更なし) | 該当なし |
| **修正後** | 該当なし (UI 構造変更なし) | 該当なし |

**インタラクティブ状態**: N/A — UI 構造の変更を含まない

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: demo Repository は ISP (`IStampCardRepo` interface を実装)、SQLite/DynamoDB と入れ替え可能 (DIP)
- [x] **DRY**: production seed (`src/lib/server/db/seed.ts:3242-3258` の 16 stamp 定義) と同じデータを fixture に複製。これは demo Lambda が seed.ts を実行しないアーキ上の必然 (ADR-0048 stateless Fake)、ハードコード必須
- [x] **YAGNI**: fixture は 4 子供 × 2 週分 (8 cards / 32 entries) に限定。3 週前カードは追加しない (visualization 上不要)
- [x] **Security**: N/A — public domain emoji + stamp 名のみ
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: fixture は module-load 1 回評価 + `Array.find` / `Array.filter` で O(n)。n=8 (cards) / 32 (entries) で十分軽量

## 横展開・影響波及チェック

- [x] 本番アプリ + デモ版 — 本 PR は demo 専用 fixture。本番側は SQLite seed.ts で既に 16 stamp が seed 済み
- [x] **LP ↔ アプリ双方向整合**: LP の `feature-cheer-message.webp` 等の SS 撮影元 `/demo/lower/home` で本 fixture が反映される（post-merge）
- [x] 全年齢モード 5 種: baby (901) は ADR-0011 でスタンプカード非対象 → 意図的に fixture 未追加。preschool/elementary/junior/senior の 4 子供は全て fixture あり
- [x] ナビゲーション 3 種: N/A — ナビ変更なし
- [x] E2E / ユニットシード: `src/lib/server/demo/demo-data.ts` を更新 (該当 SSOT)。`tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` は本番 SQLite seed 経路のため更新不要
- [x] **labels SSOT**: stamp 名 16 種は `src/lib/server/db/seed.ts` の defaultStamps と完全一致。ハードコード重複の発生源は seed.ts と本 fixture の 2 箇所のみ (ADR-0048 上避けられない構造)
- [x] **設計書同期**: 本 PR は fixture data 追加のみで UI 仕様 / API / DB スキーマ変更なし → `docs/design/` 更新不要
- [x] **並行 PR overlap**: `src/lib/server/demo/demo-data.ts` を変更する open PR を確認、現状 #2097 EPIC の他 sub-PR が並行中。本 PR は専用セクション末尾追加のため merge conflict リスク低
- [ ] N/A

**LP / 販促文言変更時** (ADR-0013): 該当なし — LP/pricing 文言は変更していない

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- fixture の rarity 配分が production の RARITY_WEIGHTS (N 60% / R 25% / SR 12% / UR 3%) と乖離していないか観点
  - 902 (preschool 2 stamps): N×2
  - 903 (elementary 3 stamps): N×2 + R×1
  - 904 (junior 4 stamps): N×1 + R×2 + SR×1
  - 906 (senior 4 stamps): R×2 + SR×2
  - 前週カード 4 子供 5/5: 年齢が上がるほど高 rarity を多く配置
- `_currentWeekDate` / `_prevWeekDate` の underscore prefix は biome の `noUnusedFunctionParameters` 対策ではない（実際に使われている）。混乱避けるためリネームすべきか？ → リネーム済み (currentWeekDate / prevWeekDate)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] biome / svelte-check / vitest run をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（fixture 追加 + Repository read 拡張 + 34 ケース test、未完了項目なし）
- [x] Phase 分割: 本 PR は EPIC #2097 Phase B の sub-task。research doc (`docs/research/2097-demo-fixture-gaps.md`) で P0 8 領域の最初の 1 件を着手
- [x] UI 変更時: 該当なし
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
