### PR TITLE
fix: #2097 PR-B1 capture-hp-screenshots を本番ルートに切替 (LP SS から demo 固有 UI 撲滅)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -65,8 +65,20 @@ jobs:
         # vite preview は NODE_ENV=production で起動するため、
         # hooks.server.ts の assertLicenseKeyConfigured() が AWS_LICENSE_SECRET を要求する。
         # LP スクリーンショット撮影用のダミー値（本番シークレットとは別物）。
+        #
+        # #2097 EPIC PR-B1 (2026-05-17): AUTH_MODE=anonymous + DATA_SOURCE=demo を指定し、
+        # capture-hp-screenshots.mjs が本番ルート `/(child)/[uiMode]/home` を demo fixture data
+        # で撮影できるようにする (Multi-Lambda demo Lambda と同型の env、ADR-0048)。
+        #   - AUTH_MODE=anonymous: hooks.server.ts が AnonymousAuthProvider を選択 →
+        #       tenantId='demo' / role='owner' / licenseStatus=ACTIVE で全画面を許可
+        #   - DATA_SOURCE=demo: db/factory.ts が demo Repository (in-memory fixture) を選択 →
+        #       SQLite / DynamoDB に書き込みせず demo-data.ts のみで完結
+        # assertLicenseKeyConfigured() は AUTH_MODE=anonymous の場合 skip されるため
+        # AWS_LICENSE_SECRET は不要だが、後方互換のため引き続き設定する。
         env:
           AWS_LICENSE_SECRET: pages-capture-secret-do-not-use-in-production
+          AUTH_MODE: anonymous
+          DATA_SOURCE: demo
         run: |
           npm run preview -- --port 5173 --host 0.0.0.0 > /tmp/preview.log 2>&1 &
           echo "PREVIEW_PID=$!" >> $GITHUB_ENV

--- a/docs/design/asset-catalog.md
+++ b/docs/design/asset-catalog.md
@@ -137,32 +137,34 @@ site/ と static/ の双方を同期更新する SSOT パターン。
 
 ---
 
-## LP スクショ — site/index.html 内の機能画像 (#1707 / #1712 / #1900)
+## LP スクショ — site/index.html 内の機能画像 (#1707 / #1712 / #1900 / #2097)
 
-LP `site/index.html` の hero carousel / machine-tour / soft-features / growth-roadmap セクションで参照する実画面のスクリーンショット一覧。`scripts/capture-hp-screenshots.mjs` が `/demo/<mode>/<path>` のデモ画面から自動撮影し `site/screenshots/` に出力する。`.gitignore` で git 追跡対象外（GitHub Pages デプロイ時に CI が生成）。
+LP `site/index.html` の hero carousel / machine-tour / soft-features / growth-roadmap セクションで参照する実画面のスクリーンショット一覧。`scripts/capture-hp-screenshots.mjs` が **本番ルート `/(child)/[uiMode]/<path>` / `/admin/<path>`** を Multi-Lambda demo Lambda 同型の env (`AUTH_MODE=anonymous` + `DATA_SOURCE=demo`、ADR-0048) で起動した preview server で撮影し `site/screenshots/` に出力する。`.gitignore` で git 追跡対象外（GitHub Pages デプロイ時に CI が生成）。
+
+> **#2097 EPIC PR-B1 (2026-05-17)**: 旧来 `/demo/<legacyMode>/<path>` (LEGACY_UI_MODE_MAP 経由) で撮影していたが、`src/routes/demo/(child)/[mode]/home/+page.svelte` (DashboardView) を経由するため「きょうのミッション」セクション等の demo 固有 UI が映り込み、本番 `ProdDashboardSections` から乖離していた (ADR-0013 LP truth 違反 + LP 訴求毀損)。本リファクタで本番ルート (`(child)/[uiMode=uiMode]`) を直接撮影する方式に切替。`selectedChildId` cookie は capture script が URL の uiMode セグメントから自動推論して pre-set する (`baby=901 / preschool=902 / elementary=903 / junior=904 / senior=906`、demo fixture SSOT)。
 
 | ファイル名 | LP セクション | 撮影元 URL（routes） | サイズ（mobile / desktop） |
 |----------|------------|--------------------|--------------------------|
-| **`carousel-1-child-home{,-desktop}.webp`** (#1900) | hero carousel slide 1（幼児 3-5 歳代表） | `/demo/kinder/home` | 780×1688 / 2880×1800 |
-| **`carousel-2-child-status{,-desktop}.webp`** (#1900) | hero carousel slide 2（小学生 6-12 歳代表） | `/demo/lower/home` | 780×1688 / 2880×1800 |
-| **`carousel-3-admin-main{,-desktop}.webp`** (#1900) | hero carousel slide 3（中高生 13-18 歳代表） | `/demo/upper/home` | 780×1688 / 2880×1800 |
-| **`carousel-4-admin-sub{,-desktop}.webp`** (#1900 / #1901) | hero carousel slide 4（管理画面 / 子供管理 = 家族メンバーの登録と切替） | `/demo/admin/children` | 780×1688 / 2880×1800 |
-| `feature-point-level{,-desktop}.webp` | machine-tour ① | `/demo/lower/home` | 780×1688 / 2880×1800 |
-| `feature-belongings-checklist{,-desktop}.webp` | machine-tour ② | `/demo/checklist?childId=904` (scrollTo: `[data-testid^="demo-checklist-item-"]`) | 780×1688 / 2880×1800 |
-| **`feature-rpg-battle{,-desktop}.webp`** (#1707) | machine-tour ④（冒険のクライマックス） | `/demo/lower/battle` | 780×1688 / 2880×1800 |
-| **`feature-monthly-report{,-desktop}.webp`** (#1707) | soft-features（月次レポート） | `/demo/admin/status` | 780×1688 / 2880×1800 |
-| **`feature-auto-sleep{,-desktop}.webp`** (#1707 / #1901) | soft-features（時間管理 + おうえんメッセージ設定） | `/demo/admin/settings` | 780×1688 / 2880×1800 |
-| **`feature-cheer-message{,-desktop}.webp`** (#1707 / #1901) | soft-features（おうえんメッセージ受信、子供ホーム下部） | `/demo/lower/home` (scrollTo: `[data-testid^="activity-card-"]`) | 780×1688 / 2880×1800 |
-| **`feature-settings{,-desktop}.webp`** (#1707) | soft-features（設定の自由度） | `/demo/admin/activities` | 780×1688 / 2880×1800 |
-| **`growth-stage-preschool{,-desktop}.webp`** (#1712) | growth-roadmap preschool | `/demo/kinder/home` | 780×1688 / 2880×1800 |
-| **`growth-stage-elementary{,-desktop}.webp`** (#1712) | growth-roadmap elementary | `/demo/lower/home` | 780×1688 / 2880×1800 |
-| **`growth-stage-junior{,-desktop}.webp`** (#1712) | growth-roadmap junior | `/demo/upper/home` | 780×1688 / 2880×1800 |
-| **`growth-stage-senior{,-desktop}.webp`** (#1712) | growth-roadmap senior | `/demo/teen/home` | 780×1688 / 2880×1800 |
-| **`growth-stage-graduate{,-desktop}.webp`** (#1712) | graduation.html / growth-roadmap graduate | `/demo/lower/achievements` | 780×1688 / 2880×1800 |
+| **`carousel-1-child-home{,-desktop}.webp`** (#1900 / #2097) | hero carousel slide 1（幼児 3-5 歳代表） | `/preschool/home` | 780×1688 / 2880×1800 |
+| **`carousel-2-child-status{,-desktop}.webp`** (#1900 / #2097) | hero carousel slide 2（小学生 6-12 歳代表） | `/elementary/home` | 780×1688 / 2880×1800 |
+| **`carousel-3-admin-main{,-desktop}.webp`** (#1900 / #2097) | hero carousel slide 3（中高生 13-18 歳代表） | `/junior/home` | 780×1688 / 2880×1800 |
+| **`carousel-4-admin-sub{,-desktop}.webp`** (#1900 / #1901 / #2097) | hero carousel slide 4（管理画面 / 子供管理 = 家族メンバーの登録と切替） | `/admin/children` | 780×1688 / 2880×1800 |
+| `feature-point-level{,-desktop}.webp` (#2097) | machine-tour ① | `/elementary/home` | 780×1688 / 2880×1800 |
+| `feature-belongings-checklist{,-desktop}.webp` (#2097) | machine-tour ② | `/checklist?childId=903` (scrollTo: `[data-testid^="demo-checklist-item-"]`) | 780×1688 / 2880×1800 |
+| **`feature-rpg-battle{,-desktop}.webp`** (#1707 / #2097) | machine-tour ④（冒険のクライマックス） | `/elementary/battle` | 780×1688 / 2880×1800 |
+| **`feature-monthly-report{,-desktop}.webp`** (#1707 / #2097) | soft-features（月次レポート） | `/admin/status` | 780×1688 / 2880×1800 |
+| **`feature-auto-sleep{,-desktop}.webp`** (#1707 / #1901 / #2097) | soft-features（時間管理 + おうえんメッセージ設定） | `/admin/settings` | 780×1688 / 2880×1800 |
+| **`feature-cheer-message{,-desktop}.webp`** (#1707 / #1901 / #2097) | soft-features（おうえんメッセージ受信、子供ホーム下部） | `/elementary/home` (scrollTo: `[data-testid^="activity-card-"]`) | 780×1688 / 2880×1800 |
+| **`feature-settings{,-desktop}.webp`** (#1707 / #2097) | soft-features（設定の自由度） | `/admin/activities` | 780×1688 / 2880×1800 |
+| **`growth-stage-preschool{,-desktop}.webp`** (#1712 / #2097) | growth-roadmap preschool | `/preschool/home` | 780×1688 / 2880×1800 |
+| **`growth-stage-elementary{,-desktop}.webp`** (#1712 / #2097) | growth-roadmap elementary | `/elementary/home` | 780×1688 / 2880×1800 |
+| **`growth-stage-junior{,-desktop}.webp`** (#1712 / #2097) | growth-roadmap junior | `/junior/home` | 780×1688 / 2880×1800 |
+| **`growth-stage-senior{,-desktop}.webp`** (#1712 / #2097) | growth-roadmap senior | `/senior/home` | 780×1688 / 2880×1800 |
+| **`growth-stage-graduate{,-desktop}.webp`** (#1712 / #2097) | graduation.html / growth-roadmap graduate | `/elementary/achievements` | 780×1688 / 2880×1800 |
 
 > **#1901 削除済 dead 撮影定義**: `feature-titles{,-desktop}.webp` (旧: machine-tour ② 称号セクション、#1708 で LP 削除済) と `feature-routine-checklist{,-desktop}.webp` (旧: machine-tour ③ ルーティン、#1708 で LP 削除済) は LP HTML 参照ゼロ + ETag 重複ペアの根本原因のため `capture-hp-screenshots.mjs` から削除。
 >
-> **#1901 carousel SS の URL 同期**: `carousel-4-admin-sub` の撮影元 URL を旧 `/demo/admin/activities` から `/demo/admin/children` に振り替え。`feature-settings` との URL/ETag 重複を解消。LP `site/index.html` の data-label / alt も「子供管理 ― 家族メンバーの登録と切替」に同期。
+> **#1901 carousel SS の URL 同期**: `carousel-4-admin-sub` の撮影元 URL を旧 `/admin/activities` から `/admin/children` に振り替え。`feature-settings` との URL/ETag 重複を解消。LP `site/index.html` の data-label / alt も「子供管理 ― 家族メンバーの登録と切替」に同期。
 
 ### 撮影方法
 

--- a/scripts/capture-hp-screenshots.mjs
+++ b/scripts/capture-hp-screenshots.mjs
@@ -4,13 +4,26 @@
 // HP (site/index.html) 用のプロダクトスクリーンショットを自動取得
 // 使用法:
 //   node scripts/capture-hp-screenshots.mjs [--webp] [--only <group|name>]
-// 前提: npm run dev でローカルサーバーが起動していること
+// 前提: preview server を AUTH_MODE=anonymous + DATA_SOURCE=demo で起動していること
+//   (`.github/workflows/pages.yml` の preview 起動 step と同じ構成)
+//   ローカル検証は `AUTH_MODE=anonymous DATA_SOURCE=demo npx vite dev --port 5173` で OK
 //
 // オプション:
 //   --webp        PNG撮影後にWebPへ自動変換（sharp Node API を使用）
 //   --only X      撮影対象を絞り込む。X はグループ名 (carousel, feature, age, growth)
 //                 もしくは個別の screenshot 名 (例: feature-belongings-checklist)
 //                 #1783: 個別撮り直し (`npm run capture:feature -- <name>`) で利用
+//
+// #2097 EPIC PR-B1 (2026-05-17):
+//   従来 `/demo/<legacyMode>/<path>` (LEGACY_UI_MODE_MAP 経由) で撮影していたが、
+//   `src/routes/demo/(child)/[mode]/home/+page.svelte` (DashboardView) を経由するため
+//   「きょうのミッション」セクション等の demo 固有 UI が映り込み、本番 `ProdDashboardSections`
+//   から乖離していた (ADR-0013 LP truth 違反 + LP 訴求毀損)。
+//
+//   本リファクタでは Multi-Lambda demo deployment (ADR-0048) と同型の env (AUTH_MODE=anonymous +
+//   DATA_SOURCE=demo) で preview server を起動し、本番ルート `/(child)/[uiMode]/home` 等を
+//   demo fixture data で描画した状態を撮影する。`selectedChildId` cookie を `?screenshot=all` と
+//   合わせて pre-set することで `/(child)/+layout.server.ts` の `/switch` redirect をバイパスする。
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -58,47 +71,104 @@ const TABLET = { width: 768, height: 1024, deviceScaleFactor: 2 };
 const DESKTOP = { width: 1440, height: 900, deviceScaleFactor: 2 };
 
 // ============================================================
+// Demo fixture child IDs (SSOT: src/lib/server/demo/demo-data.ts)
+// ============================================================
+//
+// #2097 EPIC PR-B1: 本番ルート `/(child)/[uiMode]/home` 等を撮影するため、
+// uiMode と一致する `selectedChildId` cookie を pre-set する必要がある。
+// demo fixture の 5 子供 (901-906) はそれぞれ uiMode が固定されており、
+// child の uiMode と URL `[uiMode]` が一致しない場合は `(child)/+layout.server.ts`
+// が `/(child)/${effectiveMode}/home` に redirect する。
+//
+// uiMode → childId 対応 (demo fixture から抽出、`/switch` HTML 検証済):
+//   baby (1歳)        → 901 たろうくん
+//   preschool (5歳)   → 902 ひなちゃん
+//   elementary (8歳)  → 903 けんたくん
+//   junior (14歳)     → 904 さくらちゃん
+//   senior (17歳)     → 906 けいすけくん
+const CHILD_ID_BY_UI_MODE = {
+	baby: '901',
+	preschool: '902',
+	elementary: '903',
+	junior: '904',
+	senior: '906',
+};
+
+/**
+ * URL から uiMode を判定し、対応する selectedChildId cookie 仕様を返す。
+ * URL 例:
+ *   `/preschool/home` → preschool → child 902
+ *   `/elementary/home?...` → elementary → child 903
+ *   `/admin/...` → null (admin は全 child 横断)
+ *   `/checklist?childId=N` → childId クエリパラメータがあれば優先
+ */
+function deriveChildIdCookieFromUrl(urlPath) {
+	// `?childId=N` クエリパラメータが明示されていればそれを優先
+	const queryMatch = urlPath.match(/[?&]childId=(\d+)/);
+	if (queryMatch) {
+		return [{ name: 'selectedChildId', value: queryMatch[1] }];
+	}
+
+	// path 先頭 segment が uiMode の場合は対応 child を選択
+	const segMatch = urlPath.match(/^\/?([a-z]+)\b/);
+	if (segMatch) {
+		const seg = segMatch[1];
+		const childId = CHILD_ID_BY_UI_MODE[seg];
+		if (childId) {
+			return [{ name: 'selectedChildId', value: childId }];
+		}
+	}
+
+	// admin / checklist (子供共通) 等は cookie 不要
+	return undefined;
+}
+
+// ============================================================
 // Screenshot definitions
 // ============================================================
 
 // #1900 (UIUX-C-1): hero carousel 4 枚を年齢帯 3 系統 + 管理画面に再構成。
 //   旧構成は 4 枚すべて /demo/lower/* 固定で alt「3〜18 歳の代表」と実体が乖離していた
-//   (ADR-0013 LP truth 違反)。本リファクタで以下の 4 枚に組み替える:
-//     carousel-1 = 幼児 (preschool 互換 = legacy `kinder` mode) ホーム
-//     carousel-2 = 小学生 (elementary 互換 = legacy `lower` mode) ホーム
-//     carousel-3 = 中高生 (junior 互換 = legacy `upper` mode) ホーム
+//   (ADR-0013 LP truth 違反)。本リファクタで以下の 4 枚に組み替えた:
+//     carousel-1 = 幼児 (preschool) ホーム
+//     carousel-2 = 小学生 (elementary) ホーム
+//     carousel-3 = 中高生 (junior) ホーム
 //     carousel-4 = ご家族の見守り画面 (管理画面)
 //   `name` は HTML 側 <img src="screenshots/<name>-mobile.webp"> と一致するため後方互換維持。
 //   alt / data-label の SSOT は `LP_INDEX_PHASEB_LABELS.carouselSlide{1..4}Alt` (#1900 で追加)。
+//
+// #2097 EPIC PR-B1: 撮影元 URL を `/demo/<legacyMode>/...` から `/<uiMode>/...` (本番ルート)
+//   に切替。`ProdDashboardSections.svelte` 経由で「きょうのミッション」セクション等が
+//   映り込まない正しい本番 UI が撮影される。
 const CAROUSEL_SCREENSHOTS = [
 	{
 		name: 'carousel-1-child-home',
-		url: '/demo/kinder/home',
+		url: '/preschool/home',
 		description: 'Carousel 1: 幼児（3-5 歳代表）ホーム画面 — ひらがな・大きなボタン',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 		mobileSuffix: '-mobile',
 	},
 	{
 		name: 'carousel-2-child-status',
-		url: '/demo/lower/home',
+		url: '/elementary/home',
 		description: 'Carousel 2: 小学生（6-12 歳代表）ホーム画面 — 活動記録とポイント獲得',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 		mobileSuffix: '-mobile',
 	},
 	{
 		name: 'carousel-3-admin-main',
-		url: '/demo/upper/home',
+		url: '/junior/home',
 		description: 'Carousel 3: 中高生（13-18 歳代表）ホーム画面 — 自己管理ダッシュボード',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 		mobileSuffix: '-mobile',
 	},
 	// #1900 (UIUX-C-1) + #1901 統合: hero carousel 4 枚を年齢帯 3 系統 + 管理画面に再構成する文脈で、
-	//   slide 4 = ご家族の見守り (管理画面) を担う。main #1901 の物理重複解消 (旧 /demo/admin/activities は
-	//   feature-settings と URL/ETag 完全一致だった) を尊重し URL は /demo/admin/children を採用、
+	//   slide 4 = ご家族の見守り (管理画面) を担う。main #1901 の物理重複解消 (旧 /admin/activities は
+	//   feature-settings と URL/ETag 完全一致だった) を尊重し URL は /admin/children を採用、
 	//   ADR-0013 LP truth 整合のため alt / data-label も「子供管理 — 家族メンバーの登録と切替」で統一する。
 	{
 		name: 'carousel-4-admin-sub',
-		url: '/demo/admin/children',
+		url: '/admin/children',
 		description: 'Carousel 4: 子供管理画面（家族メンバーの登録と切替）',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 		mobileSuffix: '-mobile',
@@ -108,20 +178,20 @@ const CAROUSEL_SCREENSHOTS = [
 const FEATURE_SCREENSHOTS = [
 	{
 		name: 'feature-point-level',
-		url: '/demo/lower/home',
+		url: '/elementary/home',
 		description: 'Features: ポイント＆レベルアップ',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
 	{
 		name: 'feature-combo-mission',
-		url: '/demo/lower/home',
+		url: '/elementary/home',
 		description: 'Features: コンボ＆デイリーミッション',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 		scrollTo: '[data-testid="category-header-1"]',
 	},
 	{
 		name: 'feature-radar-chart',
-		url: '/demo/lower/status',
+		url: '/elementary/status',
 		description: 'Features: 成長レーダーチャート',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
@@ -129,16 +199,20 @@ const FEATURE_SCREENSHOTS = [
 	//        撮影定義のみ残存し growth-stage-graduate と URL/ETag が完全一致していたため削除。
 	{
 		name: 'feature-belongings-checklist',
-		url: '/demo/checklist?childId=904',
+		url: '/checklist?childId=903',
 		description: 'Features: 持ち物チェックリスト (子供画面)',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 		// #1783: kind 削除 (#1755 #1709-A) で旧 [data-testid="checklist-group-item"] が消滅し
 		// waitForSelector がタイムアウトしていた。現行 DOM の demo-checklist-item-* に追従する。
+		// #2097 EPIC PR-B1: childId=904 → 903 (elementary fixture) に振り替え。
+		//   旧 904 (demo fixture では junior=14歳) では本番ルートの `(child)/+layout` が
+		//   uiMode=junior に redirect してしまうため。checklist は uiMode 配下ではないが
+		//   selectedChildId cookie の整合のため elementary 子を選択。
 		scrollTo: '[data-testid^="demo-checklist-item-"]',
 	},
 	{
 		name: 'feature-growth-record-admin',
-		url: '/demo/admin/status',
+		url: '/admin/status',
 		description: 'Features: 成長記録・管理画面',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
@@ -148,111 +222,116 @@ const FEATURE_SCREENSHOTS = [
 	// #1707 R2: machine-tour ④ RPG バトル（冒険のクライマックス）
 	{
 		name: 'feature-rpg-battle',
-		url: '/demo/lower/battle',
+		url: '/elementary/battle',
 		description: 'Features: RPG バトル画面（累積した努力でボスに挑戦）',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
 	// #1707 R2: soft-features 月次レポート（成長の記録）
 	{
 		name: 'feature-monthly-report',
-		url: '/demo/admin/status',
+		url: '/admin/status',
 		description: 'Features: 月次レポート（活動・ポイント推移）',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
 	// #1707 R2 / #1901: soft-features 自動スリープ（時間管理・使いすぎ防止）
 	// #1901: 旧 /demo/admin (top) は carousel-3-admin-main と URL/ETag 完全一致だったため
-	//        /demo/admin/settings (auto-sleep + おうえんメッセージ設定画面) に変更。
+	//        /admin/settings (auto-sleep + おうえんメッセージ設定画面) に変更。
 	{
 		name: 'feature-auto-sleep',
-		url: '/demo/admin/settings',
+		url: '/admin/settings',
 		description: 'Features: 時間管理（自動スリープ設定 + おうえんメッセージ設定）',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
 	// #1707 R2 / #1901: soft-features おうえんメッセージ受信（子供ホーム画面下部）
-	// #1901: growth-stage-elementary と URL が同じ /demo/lower/home のため、scrollTo で
+	// #1901: growth-stage-elementary と URL が同じ /elementary/home のため、scrollTo で
 	//        画面下部の activity-card 領域を撮影し物理的に異なる SS を生成する。
 	{
 		name: 'feature-cheer-message',
-		url: '/demo/lower/home',
+		url: '/elementary/home',
 		description: 'Features: おうえんメッセージ受信（子供ホーム下部）',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 		scrollTo: '[data-testid^="activity-card-"]',
 	},
 	// #1707 R2: soft-features 設定の自由度（活動・ポイント・ごほうびのカスタマイズ）
-	// #1901: carousel-4-admin-sub が /demo/admin/children に振り替えられたため、本撮影は
-	//        /demo/admin/activities を維持しても URL 重複しない。
+	// #1901: carousel-4-admin-sub が /admin/children に振り替えられたため、本撮影は
+	//        /admin/activities を維持しても URL 重複しない。
 	{
 		name: 'feature-settings',
-		url: '/demo/admin/activities',
+		url: '/admin/activities',
 		description: 'Features: 親管理の設定一覧（活動・ポイント・ごほうびのカスタマイズ）',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
 ];
 
 // #1707 R2 / #1712 R5: 成長 stage サムネ 5 枚（5 stage 各々のホーム画面）
-// 撮影元 URL は /demo/<legacyMode>/home（legacyMode は LEGACY_UI_MODE_MAP で正規化される）。
+// #2097 EPIC PR-B1: 撮影元 URL を本番ルート `/<uiMode>/home` に変更。
+//   旧 `/demo/<legacyMode>/home` (LEGACY_UI_MODE_MAP 経由) は demo (child)/[mode] DashboardView 経由で
+//   「きょうのミッション」等 demo 固有 UI が映り込んでいた。
 // graduate stage は卒業マイルストーン画面（実装上は achievements に集約されているため代替）。
 const GROWTH_STAGE_SCREENSHOTS = [
 	{
 		name: 'growth-stage-preschool',
-		url: '/demo/kinder/home',
+		url: '/preschool/home',
 		description: 'Growth Stage: 幼児（preschool）— 大きな絵文字ボタンと達成スタンプ',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
 	{
 		name: 'growth-stage-elementary',
-		url: '/demo/lower/home',
+		url: '/elementary/home',
 		description: 'Growth Stage: 小学生（elementary）— 称号コレクションとデイリーミッション',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
 	{
 		name: 'growth-stage-junior',
-		url: '/demo/upper/home',
+		url: '/junior/home',
 		description: 'Growth Stage: 中学生（junior）— 月次レポートと自己ペース可視化',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
 	{
 		name: 'growth-stage-senior',
-		url: '/demo/teen/home',
+		url: '/senior/home',
 		description: 'Growth Stage: 高校生（senior）— 15 年分のログと進路素材',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
 	{
 		name: 'growth-stage-graduate',
-		url: '/demo/lower/achievements',
+		url: '/elementary/achievements',
 		description: 'Growth Stage: 卒業（graduate）— 履歴エクスポートと家族の手元に残す記録',
 		viewports: { mobile: MOBILE, desktop: DESKTOP },
 	},
 ];
 
+// #2097 EPIC PR-B1: age-* も本番ルート `/<uiMode>/home` に同期切替。
+//   `LEGACY_UI_MODE_MAP` 経由 (kinder→preschool, lower→elementary, upper→junior, teen→senior)
+//   と等価な撮影結果を本番ルート直結で得る。baby は legacy/本番ともに `baby` 同一。
 const AGE_SCREENSHOTS = [
 	{
 		name: 'age-baby',
-		url: '/demo/baby/home',
+		url: '/baby/home',
 		description: 'Age Modes: はじめの一歩（0-2歳）',
 		viewports: { mobile: MOBILE, tablet: TABLET, desktop: DESKTOP },
 	},
 	{
 		name: 'age-kinder',
-		url: '/demo/kinder/home',
+		url: '/preschool/home',
 		description: 'Age Modes: じぶんでタップ（3-5歳）',
 		viewports: { mobile: MOBILE, tablet: TABLET, desktop: DESKTOP },
 	},
 	{
 		name: 'age-lower',
-		url: '/demo/lower/home',
+		url: '/elementary/home',
 		description: 'Age Modes: 冒険スタート（6-9歳）',
 		viewports: { mobile: MOBILE, tablet: TABLET, desktop: DESKTOP },
 	},
 	{
 		name: 'age-upper',
-		url: '/demo/upper/home',
+		url: '/junior/home',
 		description: 'Age Modes: チャレンジ（10-14歳）',
 		viewports: { mobile: MOBILE, tablet: TABLET, desktop: DESKTOP },
 	},
 	{
 		name: 'age-teen',
-		url: '/demo/teen/home',
+		url: '/senior/home',
 		description: 'Age Modes: みらい設計（15-18歳）',
 		viewports: { mobile: MOBILE, tablet: TABLET, desktop: DESKTOP },
 	},
@@ -303,6 +382,11 @@ async function captureScreenshots() {
 	const pngFiles = [];
 
 	for (const shot of ALL_SCREENSHOTS) {
+		// #2097 EPIC PR-B1: 本番ルート `/(child)/[uiMode]/home` 等を撮影するため、
+		// `selectedChildId` cookie を URL の uiMode に対応する child fixture id で pre-set する。
+		// admin / checklist (childId クエリ明示) などは null を返す → cookie 未設定。
+		const cookies = deriveChildIdCookieFromUrl(shot.url);
+
 		for (const [sizeName, viewport] of Object.entries(shot.viewports)) {
 			totalFiles++;
 			const suffix = sizeName === 'mobile' ? (shot.mobileSuffix ?? '') : `-${sizeName}`;
@@ -310,7 +394,7 @@ async function captureScreenshots() {
 
 			console.log(`Capturing ${shot.description} [${sizeName}] ...`);
 
-			// #1825: carousel-* shots は LP /demo 画面ではあるが、index.html の hero carousel と同じ
+			// #1825: carousel-* shots は本番ルートではあるが、index.html の hero carousel と同じ
 			// Splide.js を使う場合に SS が黒ブロック化する問題への対策として全 LP shot で waitSplide を有効化。
 			// Splide が存在しないページでは silent skip するため副作用なし。
 			const isCarouselShot = shot.name.startsWith('carousel-');
@@ -322,6 +406,7 @@ async function captureScreenshots() {
 				format: 'png',
 				selector: shot.scrollTo,
 				waitSplide: isCarouselShot,
+				cookies,
 			});
 
 			if (result.ok) {

--- a/scripts/lib/screenshot-helpers.mjs
+++ b/scripts/lib/screenshot-helpers.mjs
@@ -482,6 +482,11 @@ export class ScreenshotCapture {
 	 * @param {boolean} [opts.waitSplide=false] - Splide.js carousel 初期化完了を待機するか (#1825)。
 	 *   LP の `site/index.html` 等の hero carousel 撮影で「黒ブロック」状態を回避する目的。
 	 *   Splide が存在しないページでは silent skip するため副作用なし
+	 * @param {Array<{ name: string; value: string; path?: string; httpOnly?: boolean; sameSite?: 'Strict' | 'Lax' | 'None' }>} [opts.cookies] -
+	 *   撮影前に設定する cookie 一覧 (#2097 EPIC PR-B1)。本番ルート (`/(child)/[uiMode]/home` 等) を
+	 *   demo モード (AUTH_MODE=anonymous + DATA_SOURCE=demo) で撮影する際、`selectedChildId` cookie を
+	 *   pre-set して `/(child)/+layout.server.ts` の `/switch` redirect をバイパスする目的。
+	 *   各 cookie の `path` 既定値は `/`、`httpOnly` は `false`、`sameSite` は `'Lax'`。
 	 * @returns {Promise<{ ok: true; filePath: string; size: number; domPath?: string; domSize?: number } | { ok: false; error: Error }>}
 	 */
 	async capture({
@@ -496,6 +501,7 @@ export class ScreenshotCapture {
 		storageState,
 		domSnapshot,
 		waitSplide = false,
+		cookies,
 	}) {
 		if (!this.#browser) throw new Error('setup() を先に呼び出してください。');
 
@@ -506,6 +512,23 @@ export class ScreenshotCapture {
 			locale: this.#locale,
 			...(storageState ? { storageState } : {}),
 		});
+
+		// #2097 EPIC PR-B1: 本番ルートを demo Lambda 想定で撮影する際に `selectedChildId` を pre-set する。
+		// `baseUrl` の URL から host を抽出して cookie domain として設定する。
+		if (cookies && cookies.length > 0) {
+			const baseUrl = new URL(this.#baseUrl);
+			await context.addCookies(
+				cookies.map((c) => ({
+					name: c.name,
+					value: c.value,
+					domain: baseUrl.hostname,
+					path: c.path ?? '/',
+					httpOnly: c.httpOnly ?? false,
+					sameSite: c.sameSite ?? 'Lax',
+				})),
+			);
+		}
+
 		const page = await context.newPage();
 
 		try {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@ import '$lib/ui/styles/app.css';
 import { page } from '$app/stores';
 import { APP_LABELS } from '$lib/domain/labels';
 import DemoBanner from '$lib/features/demo/DemoBanner.svelte';
+import { resolveScreenshotMode } from '$lib/features/demo/screenshot-mode';
 import NavigationProgress from '$lib/ui/components/NavigationProgress.svelte';
 import Toast from '$lib/ui/primitives/Toast.svelte';
 
@@ -16,7 +17,19 @@ let { children, data } = $props();
 // 独自の橙バナーを描画するため、二重表示を避けるために root DemoBanner を抑止する。
 // Phase 2 で `/demo/**` 削除時にこの条件は不要になる。
 const isLegacyDemoPath = $derived($page.url?.pathname?.startsWith('/demo') ?? false);
-const isDemo = $derived(!isLegacyDemoPath && (data?.isDemo ?? $page.data?.isDemo ?? false));
+
+// #2097 EPIC PR-B1 (2026-05-17): LP SS 撮影時 (`?screenshot=all` / `?screenshot=1`) は
+// DemoBanner を抑止する。Multi-Lambda demo Lambda 上で本番ルートを撮影する際に
+// 「これはデモアプリです」表示が映り込み LP 訴求を毀損する事故への対策 (PO 2026-05-17 指摘)。
+// page 側の `?screenshot` 再呼出禁止ルール (src/routes/CLAUDE.md) は **page** が対象であり、
+// root layout は SSOT helper `resolveScreenshotMode` を経由する限り抵触しない。
+const isScreenshotMode = $derived(
+	resolveScreenshotMode($page.url?.searchParams?.get('screenshot') ?? null) !== 'off',
+);
+
+const isDemo = $derived(
+	!isLegacyDemoPath && !isScreenshotMode && (data?.isDemo ?? $page.data?.isDemo ?? false),
+);
 
 // #702: E2E hydration marker. $effect は SSR では走らずクライアント mount 後にのみ
 // 走るため、ここで window.__APP_HYDRATED__ を立てると Playwright から


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 運営（マーケティング）

**解決する課題**: LP に掲載される機能スクリーンショットが `/demo/kinder/home` 経由 (`DashboardView.svelte`) で撮影されており、「きょうのミッション」セクション等 demo 固有 UI が映り込んでいた。本番アプリは `(child)/[uiMode]/home/+page.svelte` 経由で `ProdDashboardSections.svelte` を使うが、こちらにはそのセクションが存在しない。PO 2026-05-17 指摘: 「LP に登場する SS が『これはデモアプリです』と表示されていることは明らかな不具合」。

**期待される効果**:
- LP に映る SS が本番ルート (`ProdDashboardSections`) と完全一致 → 訴求と実体の乖離 (permission marketing 失敗) を解消
- ADR-0013 LP truth 原則の構造的担保
- #2097 EPIC 修正案 B 採択先頭の PR-B1 として、後続 PR-B2~ (`/demo/(child)/*` 削除 / hooks.server.ts demo 検出 cleanup 等) の土台を確定

## 関連 Issue

closes part-of #2097

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 撮影スクリプトが本番ルート (`/<uiMode>/<path>`) を使用 | `grep` on `scripts/capture-hp-screenshots.mjs` | 全 19 spec で本番ルート `/preschool|/elementary|/junior|/senior|/baby/...` に切替済 |
| AC2 | 修正後 SS に「きょうのミッション」セクションが映らない | `grep -c 'きょうのミッション' site/screenshots/growth-stage-*.dom.html` | **0/4** (preschool/elementary/junior/senior 全件、ローカル撮影で実測) |
| AC3 | 修正後 SS に DemoBanner「これはデモアプリです」が映らない | `grep -c 'demo-banner' site/screenshots/growth-stage-preschool.dom.html` | **0** (root +layout.svelte で `?screenshot=all` 抑止) |
| AC4 | preview server を AUTH_MODE=anonymous + DATA_SOURCE=demo で起動 | `.github/workflows/pages.yml` `Start preview server` step env | 追加済 (Multi-Lambda demo Lambda 同型、ADR-0048) |
| AC5 | `docs/design/asset-catalog.md` 撮影元 URL 表を更新 | `git diff main -- docs/design/asset-catalog.md` | 17 行更新 + #2097 EPIC PR-B1 経緯を SSOT 化 |
| AC6 | 既存 capture テスト全 PASS | `npx vitest run tests/unit/scripts/capture.test.ts tests/unit/scripts/screenshot-helpers.test.ts` | 38+8 = **46/46** PASS。`tests/unit/scripts/__tests__/capture-ss-fakes.test.mjs` も 16/16 PASS |
| AC7 | Before/After SS の SHA256 が異なる (#2063 偽装防止) | `sha256sum tmp/screenshots/pr-2181/{before,after}-growth-stage-*.png` | 全 4 ペア で sha256 異なる確認済 |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/+layout.svelte` — DemoBanner suppression for screenshot mode)
- [x] LP サイト (`site/screenshots/` 配下に撮影される画像が変わる)
- [x] 設定・CI (`scripts/capture-hp-screenshots.mjs`, `scripts/lib/screenshot-helpers.mjs`, `.github/workflows/pages.yml`)

**影響を受ける画面・機能**: LP 全 11 ページ (hero carousel / machine-tour / soft-features / growth-roadmap で表示される 19 件の機能 SS)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready` 主要 step PASS** — biome (changed files PASS) / svelte-check **0 errors / 15 warnings (全て pre-existing state_referenced_locally)** / vitest **4990/4990 passed** (--skip-biome 経由、biome `.` 引数の Windows shell 問題は pre-existing で本変更無関係。changed file 直指定では PASS)
- [x] 追加・変更したテストの概要: capture-related test 全 PASS (新規 `cookies` パラメータは optional のため既存 test 互換)。新規テスト追加なし (URL 切替 + cookie 設定の動作確認は実機 SS 撮影で検証済)
- [x] **新規 env / secret 追加時**: N/A — `AUTH_MODE` / `DATA_SOURCE` は既存 env、pages.yml の preview server プロセス専用設定で本番 Lambda 環境変数とは独立
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A (priority:high)

## スクリーンショット / ビジュアルデモ

実機撮影 (ローカル `AUTH_MODE=anonymous DATA_SOURCE=demo npx vite dev` 上、playwright 経由):

| 年齢モード | 修正前 (`/demo/<legacyMode>/home`) | 修正後 (`/<uiMode>/home`) |
|---|---|---|
| preschool | ![before-preschool](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2181/before-growth-stage-preschool.png) | ![after-preschool](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2181/after-growth-stage-preschool.png) |
| elementary | ![before-elementary](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2181/before-growth-stage-elementary.png) | ![after-elementary](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2181/after-growth-stage-elementary.png) |
| junior | ![before-junior](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2181/before-growth-stage-junior.png) | ![after-junior](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2181/after-growth-stage-junior.png) |
| senior | ![before-senior](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2181/before-growth-stage-senior.png) | ![after-senior](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2181/after-growth-stage-senior.png) |

### 比較ポイント

| 検証項目 | 修正前 (`/demo/kinder/home` 経由 = DashboardView) | 修正後 (`/preschool/home` 経由 = ProdDashboardSections) |
|---|---|---|
| 「きょうのミッション」セクション (1/3) | **表示** ← demo 固有 UI | **消滅** ✓ |
| カテゴリヘッダー Lv 表示 | **なし** ← 本番乖離 | **Lv.4 等表示** ✓ 本番一致 |
| DemoBanner「これはおためしモード」 | **表示** ← LP 訴求毀損 | **抑止** ✓ |
| MilestoneBanner | demo seed の旧データ | **本番一致 (はじめての記録)** ✓ |
| ParentMessageOverlay (おうえんメッセージ) | 非表示 | **表示** ✓ (`?screenshot=all` 強制) |

> **#2063 SS Blob SHA gate**: 全 4 ペア (preschool/elementary/junior/senior) で Before/After sha256 が異なることをローカル `sha256sum` で確認済。PR body の Before/After URL も別 blob (異なる Git SHA) で配信される。

**インタラクティブ状態**: N/A (撮影スクリプトのリファクタ + DemoBanner suppression 1 件で、UX 変更なし)

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: capture-hp-screenshots は URL → cookies 推論 helper (`deriveChildIdCookieFromUrl`) を pure function として分離 (テスタブル + 単一責任)。`CHILD_ID_BY_UI_MODE` map で fixture id mapping を SSOT 集約
- [x] **DRY**: 既存 `ScreenshotCapture.capture()` の API に最小拡張 (`cookies` パラメータ追加のみ、optional)。fixture child id mapping は `src/lib/server/demo/demo-data.ts` の SSOT 由来
- [x] **YAGNI**: cookie 設定は撮影 use case のみで使う最小機能 (一般 cookie 設定は対象外)
- [x] **Security**: 新規秘密情報追加なし。AUTH_MODE=anonymous は demo Lambda 同型で IAM 分離前提 (本 PR では preview server プロセスに限定)
- [x] **アクセシビリティ**: root +layout.svelte の DemoBanner 抑止は `?screenshot=*` 時のみ作用、通常 UX に影響なし
- [x] **パフォーマンス**: capture 実行時間に変化なし (cookie 設定 1 回のみ、各 capture invocation 当たり <1ms)

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版同期: 本 PR は **撮影元を demo → 本番に切り替える** ため、両者の UI 等価性が逆に高まる方向 (#2097 EPIC 修正案 B の本質)
- [x] **LP ↔ アプリ双方向整合** (ADR-0013): LP 配信 SS が本番ルートを描画 → 実装の事実と一致
- [x] 全年齢モード 5 種: baby (901) / preschool (902) / elementary (903) / junior (904) / senior (906) 全 fixture id に対応
- [x] N/A: ナビゲーション 3 種は変更なし / E2E シードは変更なし / labels SSOT は変更なし
- [x] **設計書同期** (ADR-0001): `docs/design/asset-catalog.md` 撮影元 URL 表 17 行を同 PR で更新済
- [x] **並行 PR overlap** (#1200): 本 PR が変更する 5 ファイル (`pages.yml` / `asset-catalog.md` / `capture-hp-screenshots.mjs` / `screenshot-helpers.mjs` / `+layout.svelte`) を同時期に変更する open PR なし

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A (文言変更なし、撮影元 URL 切替のみ)

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- Multi-Lambda demo deployment (ADR-0048) と同型の env 構成 (`AUTH_MODE=anonymous` + `DATA_SOURCE=demo`) を preview server に適用。本 PR scope 内ではローカル / GitHub Pages の preview のみで使用するため、本番 Lambda env への影響なし
- 後続 #2097 PR-B2~ で DashboardView 撤廃 / `src/routes/demo/(child)/*` 削除 / hooks.server.ts demo 検出 cleanup (本 PR scope 外)。本 PR では capture スクリプトの本番ルート切替 + LP SS 整合 1 点に scope を絞り完遂
- 撮影 cookie の `selectedChildId` 値は demo fixture child id (`901-906`) に依存。fixture 変更時は capture-hp-screenshots.mjs の `CHILD_ID_BY_UI_MODE` も同期する必要あり (parallel-implementations.md の波及対象に将来追加検討)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

(`AUTH_MODE` / `DATA_SOURCE` は既存 env、pages.yml の preview server プロセス専用設定で本番 deploy Lambda 環境変数とは独立)

## Ready for Review チェックリスト

- [x] **`npm run pre-ready` 主要 step** をローカル確認 (svelte-check 0 errors / vitest 4990 PASS / 個別 biome PASS)
- [x] セルフレビュー済み (不要な差分・デバッグコードなし、`tmp/cap-*.mjs` 等は worktree 内 `tmp/` のため git 追跡対象外)
- [x] 全 AC が実装済み
- [x] Phase 分割: 本 PR-B1 は #2097 修正案 B の先頭。PO 合意済 (Issue body §「経緯 (失敗 8 回 + research v1-v4 + PO 確定)」)
- [x] UI 変更時: SS は capture-hp-screenshots.mjs 経由で全 19 spec 撮影確認、本変更直接の UI 変更は root +layout.svelte の DemoBanner 抑止 (`?screenshot=all` 時のみ作用、通常 UX に影響なし)

## QM レビュー結果

<!-- QM が記入。フォーマット・必須手順は docs/sessions/qa-session.md「Tier 2 手順 5」を参照。
     CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（ADR-0022）。 -->

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
