### PR TITLE
chore: add .claudeignore (session 初期スキャンのノイズ除外、Claude Code 大規模リポジトリ運用ベストプラクティス) [PR-1]

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,38 @@
+# Claude Code session ignore (PO 承認 2026-05-17、Phase Claude-Code-Best-Practices-Adoption PR-1)
+# Reference: https://claude.com/blog/how-claude-code-works-in-large-codebases-best-practices-and-where-to-start
+# 大規模リポジトリで session 初期スキャン時の context 消費を削減し、不要ノイズを除外
+
+# Build artifacts (再生成可能、Claude が読む必要なし)
+node_modules/
+.svelte-kit/
+build/
+dist/
+.cache/
+
+# Generated screenshots (LP 配信 / Playwright 撮影、コード理解と無関係)
+docs/screenshots/
+docs/screenshots-*/
+site/screenshots/
+
+# Temp & local working files (補佐セッションの中間生成物)
+tmp/
+.claude/worktrees/
+.claude/scheduled_tasks.lock
+.playwright-mcp/
+
+# Test outputs (実行毎に再生成)
+playwright-report/
+test-results/
+coverage/
+
+# Database files (binary、grep 不可)
+*.db
+*.db-journal
+*.db-shm
+*.db-wal
+*.db.bak.*
+
+# Lock files (大規模 JSON、シンボル参照不要)
+package-lock.json
+yarn.lock
+pnpm-lock.yaml


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者 / AI エージェント（Claude Code 利用者全員）

**解決する課題**: Claude Code session 起動時の初期スキャンで `tmp/` / `docs/screenshots*/` / `playwright-report/` / `*.db` / lock file 等のノイズが context window を圧迫し、初手から context 消費が大きく DX が悪化していた。Anthropic 公式記事「How Claude Code works in large codebases」で推奨される `.claudeignore` が本プロジェクトには未設置だった。

**期待される効果**: session 初期スキャン高速化 + context 消費削減で、開発・QM レビュー・Fix 作業のすべてで AI エージェント応答品質と速度が向上する。ユーザー価値とは独立した DX 改善 (Pre-PMF Bucket A)。

## 関連 Issue

closes #2195

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `.claudeignore` がリポジトリルートに存在 | `git ls-files .claudeignore` | PASS (1 件 hit、本 PR 差分で追加) |
| AC2 | 除外パターンが build artifact / generated assets / temp / test output / db / lock のみで構成 (ソースコード・設計書・テストコードは含まない) | `.claudeignore` 内容目視 | PASS (`src/` / `docs/design/` / `tests/` 等は除外対象外) |
| AC3 | 既存 `.gitignore` と矛盾しない (重複は許容、目的が異なる) | 両ファイル diff 目視 | PASS (重複あり、矛盾なし) |
| AC4 | Claude Code 新規 session で除外対象ファイルがスキャンされないこと | 新規 session 起動 + context size 観察 | 手動確認 (本 PR merge 後の次 session で確認) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — `.claudeignore` 新規追加のみ

**影響を受ける画面・機能**: なし。アプリ動作・CI 動作に影響なし。Claude Code session スキャン挙動のみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2182` 全 Step PASS** — 設定ファイル 1 件のみのため biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body すべて該当範囲外で PASS
- [x] 追加・変更したテストの概要: **N/A** (設定ファイル 1 件追加のみ、テスト追加対象外)
- [x] **新規 env / secret 追加時** (ADR-0006): **N/A** (env 追加なし)
- [x] **DynamoDB 実装変更時** (ADR-0010 / #1021): **N/A** (DB 変更なし)
- [x] **Critical バグ修正の場合** (ADR-0002): **N/A** (bug fix ではない、infra chore)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 設定ファイル 1 件 (`.claudeignore`) 追加のみで UI 変更なし。アプリ画面・LP・管理画面いずれにも影響なし。Claude Code session スキャン挙動のみが変化する内部 DX 改善のため、視覚的成果物は存在しない。

**インタラクティブ状態**: N/A (UI 変更なし)

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A (設定ファイル、ロジック含まず)
- [x] **DRY**: `.gitignore` と内容重複は許容 (目的が異なる: git tracking vs Claude session scan)。意図的な重複であることを Issue #2195 本文に明記
- [x] **YAGNI**: 38 行に絞り、現時点で確実にノイズと判別できるパスのみ列挙。将来想定の予防的 entry は追加せず
- [x] **Security (OSS 公開前提)**: 秘密情報・内部 URL hardcode なし。`.claudeignore` は除外パターン定義のみで認証情報を含まない
- [x] **アクセシビリティ**: N/A (UI なし)
- [x] **パフォーマンス**: Claude Code session 初期スキャン速度向上が主目的。本変更自体がパフォーマンス改善

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合** (#1481 / ADR-0013)
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアル同期
- [ ] **labels SSOT** (ADR-0009)
- [ ] **設計書同期** (ADR-0001): `.claudeignore` の運用方針は将来 docs/ 配下に追記検討 (本 PR scope 外、必要なら follow-up Issue)
- [x] **並行 PR overlap** (#1200): `.claudeignore` を同時期に変更する open PR は存在しない (新規ファイル追加のため overlap 構造的に発生不可)
- [x] N/A — 並行実装の影響範囲外 (Claude Code session 設定のみ)

**LP / 販促文言変更時** (ADR-0013 / #1314): **N/A** (LP / pricing / plan-features 変更なし)

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**: `.claudeignore` の除外パターンに「除外しすぎ」がないか軽く目視確認をお願いします。特に `*.db` (test fixture も全除外) と `package-lock.json` (依存解決時に Claude が参照したい場合あり) は判断に迷ったため、QM 観点で問題なしか確認希望。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2182` 全 Step PASS** をローカル確認した (設定ファイル 1 件、該当検証ステップは全て trivial PASS)
- [x] セルフレビュー済み (不要な差分・デバッグコードなし)
- [x] 全 AC が実装済み (AC1-3 は本 PR で達成、AC4 は merge 後の次 session で確認可能な性質)
- [x] Phase 分割した場合: Phase Claude-Code-Best-Practices-Adoption の PR-1 として PO 承認済み (本セッション 11 番目)
- [x] UI 変更時: N/A (UI 変更なし)
- [x] 認証画面変更時: N/A (認証画面変更なし)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
