### PR TITLE
fix: #2109 #2196 AdminLayout 赤バッジ撤去 + Checklist もどるボタン撤去 (ADR-0012)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4056,7 +4056,7 @@ export const CHILD_CHECKLIST_LABELS = {
 	emptyDesc: 'おやにおねがいしてね',
 	completedAll: '🎉 ぜんぶできた！',
 	checkForPoints: 'ぜんぶチェックしたら',
-	backButton: 'もどる',
+	// #2196: backButton 撤廃 — BottomNav と動線重複 + 他 child タブ (achievements / battle / history / status / shop) 統一性
 	completeTitle: 'ぜんぶできたよ！',
 	pointsSuffix: 'ポイント！',
 	completeMsg: 'わすれものなし！すごい！',

--- a/src/lib/features/admin/components/AdminLayout.svelte
+++ b/src/lib/features/admin/components/AdminLayout.svelte
@@ -593,7 +593,7 @@ function isItemActive(itemHref: string): boolean {
 	}
 	/* Page Guide help button */
 	.page-guide-btn {
-		/* #2109: position: relative は撤廃された .page-guide-badge の絶対配置用だったため不要化 */
+		/* #2109: position: relative removed (was only needed for now-deleted .page-guide-badge absolute positioning) */
 		width: 2rem;
 		height: 2rem;
 		display: flex;
@@ -610,6 +610,6 @@ function isItemActive(itemHref: string): boolean {
 		background: var(--color-action-primary, #3b82f6);
 		filter: brightness(1.1);
 	}
-	/* #2109: .page-guide-badge (赤 --color-danger 通知ドット) 撤廃
-	   ADR-0012 anti-engagement 整合 + 業界 prior art (Linear / Notion / GitHub / Stripe / Sentry) と一致 */
+	/* #2109: .page-guide-badge (red --color-danger notification dot) removed
+	   ADR-0012 anti-engagement + industry prior art (Linear / Notion / GitHub / Stripe / Sentry) */
 </style>

--- a/src/lib/features/admin/components/AdminLayout.svelte
+++ b/src/lib/features/admin/components/AdminLayout.svelte
@@ -7,7 +7,7 @@ import PageGuideOverlay from '$lib/ui/components/PageGuideOverlay.svelte';
 import TutorialOverlay from '$lib/ui/components/TutorialOverlay.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import { getPageGuide } from '$lib/ui/tutorial/page-guide-registry';
-import { isPageGuideCompleted, startPageGuide } from '$lib/ui/tutorial/page-guide-store.svelte';
+import { startPageGuide } from '$lib/ui/tutorial/page-guide-store.svelte';
 import { markTutorialStarted, startTutorialForPage } from '$lib/ui/tutorial/tutorial-store.svelte';
 
 interface NavItem {
@@ -46,20 +46,16 @@ async function handleStartTutorial() {
 }
 
 // ページガイド（v2）: 現在のページのガイドを起動
+// #2109: 赤バッジ (page-guide-badge) 撤廃 → pageGuideCompleted state 不要化 (ADR-0012 anti-engagement)
 let hasPageGuide = $state(false);
-let pageGuideCompleted = $state(false);
 
 $effect(() => {
 	const path = $page.url.pathname;
 	hasPageGuide = false;
-	pageGuideCompleted = false;
 
 	const adminPath = path.replace(basePath, '/admin');
 	getPageGuide(adminPath).then((guide) => {
 		hasPageGuide = guide !== null;
-		if (guide) {
-			pageGuideCompleted = isPageGuideCompleted(guide.pageId);
-		}
 	});
 });
 
@@ -218,9 +214,6 @@ function isItemActive(itemHref: string): boolean {
 						type="button"
 					>
 						❓
-						{#if !pageGuideCompleted}
-							<span class="page-guide-badge"></span>
-						{/if}
 					</button>
 				{:else if !isDemo}
 					<Button
@@ -600,7 +593,7 @@ function isItemActive(itemHref: string): boolean {
 	}
 	/* Page Guide help button */
 	.page-guide-btn {
-		position: relative;
+		/* #2109: position: relative は撤廃された .page-guide-badge の絶対配置用だったため不要化 */
 		width: 2rem;
 		height: 2rem;
 		display: flex;
@@ -617,14 +610,6 @@ function isItemActive(itemHref: string): boolean {
 		background: var(--color-action-primary, #3b82f6);
 		filter: brightness(1.1);
 	}
-	.page-guide-badge {
-		position: absolute;
-		top: -2px;
-		right: -2px;
-		width: 8px;
-		height: 8px;
-		border-radius: 9999px;
-		background: var(--color-danger, #ef4444);
-		border: 2px solid white;
-	}
+	/* #2109: .page-guide-badge (赤 --color-danger 通知ドット) 撤廃
+	   ADR-0012 anti-engagement 整合 + 業界 prior art (Linear / Notion / GitHub / Stripe / Sentry) と一致 */
 </style>

--- a/src/routes/(child)/checklist/+page.svelte
+++ b/src/routes/(child)/checklist/+page.svelte
@@ -174,15 +174,7 @@ const flatChecklists = $derived(data.checklists);
 		{/each}
 	{/if}
 
-	<!-- Back button -->
-	<div class="text-center mt-[var(--sp-md)]">
-		<a
-			href="/{data.uiMode}/home"
-			class="inline-block px-[var(--sp-lg)] py-[var(--sp-sm)] rounded-[var(--radius-md)] bg-[var(--color-surface-tertiary)] font-bold text-sm"
-		>
-			{CHILD_CHECKLIST_LABELS.backButton}
-		</a>
-	</div>
+	<!-- #2196: 「もどる」ボタン撤去 — BottomNav と動線重複 + 他 child タブ (achievements / battle / history / status / shop) 統一性 (ADR-0012 anti-engagement) -->
 </div>
 
 <!-- Complete overlay -->


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 子供

**解決する課題**:
- #2109: 管理画面ヘッダーのガイドアイコン (`❓`) に赤い通知ドット (`--color-danger`) が常時表示され、補助機能を「未対応事項」「重要な通知」と誤認させる (IT リテラシー低い親に false urgency)
- #2196: 子供画面の持ち物チェックリスト画面に独立「もどる」ボタンがあり、BottomNav と完全重複。他 child タブ (achievements / battle / history / status / shop) と統一性なし

**期待される効果**:
- ヘッダーガイドアイコンが業界 prior art (Linear / Notion / GitHub / Stripe / Sentry) と一致した subtle な見た目になり、親の「赤い印は何だろう？」という誤認・離脱要因を排除 (ADR-0012 anti-engagement / red dot blindness 防止)
- 子供画面のナビ動線統一性が向上し、認知負荷低減 + BottomNav 経由動線で同等機能維持
- いずれも Pre-PMF retention 寄与 (M3 Retention / V2MOM Q3)

## 関連 Issue

closes #2109
closes #2196

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| #2109 AC3 | `<span class="page-guide-badge"></span>` 削除 | `grep -E "page-guide-badge\|pageGuideCompleted.*<span" src/lib/features/admin/components/AdminLayout.svelte` | 0 件 (comment 3 件のみ残存) |
| #2109 AC4 | `.page-guide-badge` CSS 定義削除 | `grep -E "^\.page-guide-badge" src/lib/features/admin/components/AdminLayout.svelte` | 0 件 (CSS block 全削除) |
| #2109 AC5 | `pageGuideCompleted` state 撤廃判定 | `grep -E "pageGuideCompleted" src/` | バッジ専用使用と判明し state + isPageGuideCompleted import を撤廃。`isPageGuideCompleted` 関数自体は `page-guide-store.svelte.ts` に残存 (他用途で利用可能) |
| #2109 AC6 | DOM HTML に `.page-guide-badge` 不在 | `grep page-guide-badge tmp/screenshots/pr-2109-2196/demo-admin.dom.html` | 0 件 (capture 後 DOM 検証) |
| #2109 AC7 | ❓ ボタンクリックで PageGuide 起動回帰 | `handleStartPageGuide` 関数本体未変更、import / state 削減のみ | コードレビュー OK (関数 body line 62-68 維持) |
| #2109 AC1/AC2/AC8 | research file / 5 年齢モード SS 等 | research file (`tmp/research/04-...md`) が前段で存在せず本 PR 範囲外。SS は anonymous demo Lambda モード (`AUTH_MODE=anonymous` + `DATA_SOURCE=demo`) でキャプチャ済 (`/admin` AFTER × desktop/mobile) | <!-- ac-verification-skip: research file 前段不在のため別 Issue/補佐タスクに分離。SS は live 認証モードでの再現が cognito setup 必須のため代替ルートで検証 --> |
| #2196 AC1 | 本番 `+page.svelte` の Back button div 撤去 | `grep -nE "CHILD_CHECKLIST_LABELS\.backButton\|<!-- Back button -->" src/routes/\(child\)/checklist/+page.svelte` | 撤去確認、comment 1 件のみ (理由記録) |
| #2196 AC2 | デモ並行実装ペア撤去 | デモ並行実装は `#2097 PR-B3 #2188` で `src/routes/demo/` 全削除済 | N/A — 削除済対象。`ls src/routes/demo/` で No such file or directory |
| #2196 AC3 | `CHILD_CHECKLIST_LABELS.backButton` エントリ削除 + grep 確認 | `grep -rnE "CHILD_CHECKLIST_LABELS\.backButton" src/` | 0 件 (labels.ts / 本番 svelte 両方撤去) |
| #2196 AC4 | dogfood SS (BottomNav 経由動線維持) | mobile / desktop SS で BottomNav (ホーム / 持ち物チェック / ショップ / つよさ / かぞく) のみ表示。「もどる」ボタン unicode 0 件 | AFTER-checklist-mobile.png + DOM `grep もどる` = 0 件 |

## 変更タイプ

- [x] fix: バグ修正
- [x] design: デザイン・UI改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/`) — `src/routes/(child)/checklist/+page.svelte`
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`) — `src/lib/features/admin/components/AdminLayout.svelte`
- [x] ドメインモデル (`$lib/domain/`) — `src/lib/domain/labels.ts` (`CHILD_CHECKLIST_LABELS.backButton` 削除)

**影響を受ける画面・機能**:
- 親管理画面ヘッダー全画面 (AdminLayout 配下、`hasPageGuide=true` の場合の `❓` ボタン)
- 子供画面の持ち物チェックリスト (`/checklist`、全 5 年齢モード共通)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2109-2196` 全 Step PASS** — biome / svelte-check (型エラーは infra/ ファイル既知問題のみ、自分の変更ファイル 0 件) / pre-commit hook の sync-lp-fallback / generate-lp-labels --check PASS
- [x] 追加・変更したテストの概要: N/A (UI 削除のみ、既存 E2E への影響なし。`grep もどる tests/` で本件無関係の error-page / demo-guide spec のみ検出)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A (priority:medium)

## スクリーンショット / ビジュアルデモ

**#2196 持ち物チェックリスト画面 (本 PR の中心的 UI 変更)**:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | ![BEFORE-checklist-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2109-2196/BEFORE-checklist-mobile.png) | ![BEFORE-checklist-desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2109-2196/BEFORE-checklist-desktop.png) |
| **修正後** | ![AFTER-checklist-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2109-2196/AFTER-checklist-mobile.png) | ![AFTER-checklist-desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2109-2196/AFTER-checklist-desktop.png) |

注: capture-hp-screenshots は固定 viewport (390x844 / 1440x900) のため「もどる」ボタンは画面下部 (折り畳み外) に存在していた。DOM HTML inspection で BEFORE は `もどる` 1 件 / AFTER は 0 件を確認 (撮影後 grep 検証済)。

**#2109 管理画面ガイドアイコン (anonymous Lambda demo モードでの参考 SS)**:

修正後 (anonymous mode の `?` ghost button 表示、本 bug の live mode 条件 = `mode='live' && hasPageGuide && !pageGuideCompleted` は cognito setup 必須のため本 SS は参考):

| | モバイル | PC |
|---|---|---|
| **修正後 (anonymous demo)** | ![AFTER-admin-anonymous-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2109-2196/AFTER-admin-anonymous-mobile.png) | ![AFTER-admin-anonymous-desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2109-2196/AFTER-admin-anonymous-desktop.png) |

**主たる verification (#2109)**: コード diff で `.page-guide-badge` HTML 要素 / CSS block / state 変数 / import を物理的に削除。DOM HTML 確認で `page-guide-badge` 0 件。

**インタラクティブ状態**: N/A (UI 削除のみ、stateful なし)

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 OK (AdminLayout = layout 責務、状態減少 / Checklist = 表示責務、動線一本化)
- [x] **DRY**: BottomNav と「もどる」ボタンの重複動線を解消 (BottomNav に一本化)
- [x] **YAGNI**: 不要な state (`pageGuideCompleted`) と CSS (`.page-guide-badge`) を削除
- [x] **Security**: N/A (UI 表示のみ)
- [x] **アクセシビリティ**: focus stop 1 つ減 (BottomNav と機能重複の冗長 stop を削除、改善)
- [x] **パフォーマンス**: $effect 内処理が 1 行短縮、$state 1 つ削減 (微小改善)

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版 — デモ並行実装は `#2097 PR-B3 #2188` で `src/routes/demo/` 全削除済。新規 demo 追加禁止 (CLAUDE.md 更新済)。**本 PR 影響対象は本番のみで OK**
- [x] **LP ↔ アプリ双方向整合**: LP には backButton / page-guide-badge に該当する記載なし、不要
- [x] 全年齢モード 5 種: `/checklist` は uiMode パラメータで全モード共通動作 (page.svelte 内に分岐なし)。BottomNav 経由動線は 5 モード全共通
- [x] ナビゲーション 3 種: AdminLayout (admin header) + BottomNav (child) いずれも本 PR で同期更新。AdminMobileNav は別コンポーネントだが page-guide-badge / もどる は AdminMobileNav には元々存在せず影響なし
- [x] E2E / ユニットシード: `tests/e2e/global-setup.ts` 等の seed に backButton 依存なし、影響なし
- [x] **labels SSOT**: `CHILD_CHECKLIST_LABELS.backButton` エントリ削除 + 全 grep 0 件確認、SSOT 整合 OK
- [x] **設計書同期**: `docs/design/` に「page-guide-badge」「checklist back button」記述なし、影響なし
- [x] **並行 PR overlap**: 本 PR が変更する 3 ファイル (AdminLayout.svelte / checklist/+page.svelte / labels.ts) のうち labels.ts は他 PR と並行高頻度だが、本 PR 差分は CHILD_CHECKLIST_LABELS の 1 行削除のみで衝突リスク最小

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- #2109 の AC1/AC2 (research file commit/削除) は research source file (`tmp/research/04-research-help-icon-ui-pattern.md`) が前段で作成されていなかったため本 PR 範囲外。別 Issue / 補佐タスクで実行可能 (本 fix の実装本体 = AC3-7 は完遂)
- #2109 の visual verification (赤バッジ → なし) は live mode + page guide registered + uncompleted の 3 条件揃いが cognito setup 必須のため、本 PR では code diff + DOM HTML inspection で AC6 を物理担保。QA で cognito 環境がある場合は live `/admin` で目視確認推奨

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2109-2196` 全 Step PASS** をローカル確認した (pre-commit hook で SSOT companion 整合検査 PASS、biome / svelte-check 自分のファイル 0 エラー)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし、comment は AC trace 用に意図的に残存）
- [x] 全 AC が実装済み (#2109 AC3-AC7 + #2196 AC1/AC3/AC4。#2196 AC2 は #2188 で既消化。#2109 AC1/AC2/AC8 は本 PR 範囲外として上記レビュー依頼に記載)
- [x] Phase 分割した場合: N/A (両 Issue 同時クローズ)
- [x] UI 変更時: SS が GitHub 上で表示確認 (screenshots branch にコミット済) + DESIGN.md §9 禁忌 6 点を目視確認 (hex 直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / `<style>` 50 行超え いずれも違反なし)
- [x] 認証画面変更時: N/A (admin layout 変更だが認証ロジック非変更。anonymous demo Lambda で SS 取得)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
