### PR TITLE
infra: #2130 #2183 + audit #2173 — demo Lambda smoke + VSCode 共有設定 + 親レポ完成度監査

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -312,6 +312,52 @@ jobs:
           fi
           echo "::notice::cron-dispatcher smoke test passed"
 
+      # ADR-0048 / #2130: demo Lambda post-deploy smoke test
+      # PR #2124 (week 4) merge 後 3 件の hotfix (#2127 / #2128 / #2129) が連続発生し、
+      # 特に #2129 (AUTH_MODE=anonymous skip for assertLicenseKeyConfigured 502 hotfix) は
+      # CI 段階で検出されるべき機能的 fail だった。post-deploy smoke が無いため deploy 完了
+      # 後に LP→demo 遷移先 502 で初めて露呈した経緯。
+      #
+      # 対策: production と同じく demo Lambda function URL 直接で 200 OK を確認し、
+      # 失敗時は hard-fail させて Rollback step に遷移させる。
+      # デモ環境はまだ存在しない可能性があるため (初回 deploy 前 / disable 時) skip 条件付き。
+      - name: Demo Lambda smoke test (#2130)
+        id: demo-smoke
+        continue-on-error: false
+        run: |
+          if ! aws lambda get-function --function-name ganbari-quest-app-demo --region $AWS_REGION > /dev/null 2>&1; then
+            echo "::notice::demo Lambda not deployed; skipping smoke test"
+            exit 0
+          fi
+          DEMO_URL=$(aws lambda get-function-url-config \
+            --function-name ganbari-quest-app-demo \
+            --region $AWS_REGION \
+            --query 'FunctionUrl' --output text 2>/dev/null || echo "")
+          if [ -z "$DEMO_URL" ] || [ "$DEMO_URL" = "None" ]; then
+            echo "::warning::demo Lambda has no Function URL; skipping smoke test"
+            exit 0
+          fi
+          echo "Demo smoke target: $DEMO_URL"
+          echo "Waiting 10s for Lambda cold start..."
+          sleep 10
+          for i in 1 2 3 4 5; do
+            STATUS=$(curl -sk -o /tmp/demo-smoke-body.txt -w "%{http_code}" "$DEMO_URL")
+            echo "Attempt $i: status=$STATUS"
+            if [ "$STATUS" = "200" ]; then
+              echo "::notice::demo Lambda smoke test passed (200 OK)"
+              exit 0
+            fi
+            if [ "$STATUS" = "502" ] || [ "$STATUS" = "503" ] || [ "$STATUS" = "504" ]; then
+              echo "::warning::demo Lambda returned $STATUS — likely runtime crash (e.g. #2129 assertLicenseKeyConfigured)"
+              echo "=== Response body (last 500 chars) ==="
+              tail -c 500 /tmp/demo-smoke-body.txt || true
+            fi
+            echo "Retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::demo Lambda smoke test failed after 5 attempts (last status: $STATUS) — see ADR-0048 / #2130"
+          exit 1
+
       # Phase 5: Post-deployment health check (with retry)
       # Lambda Function URL 直接で確認（DNS 障害時もデプロイ判定可能）
       - name: Health check

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,11 @@ dist/
 *.db.bak.*
 
 # IDE
-.vscode/
+# #2183: .vscode/ は team 共有設定 (settings.json / extensions.json) のみ追跡。
+# 個人 keybindings / launch.json / theme 等は ignore で個別除外
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 .idea/
 *.swp
 *.swo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,32 @@
+{
+	"// SSOT": "推奨拡張機能リスト (#2183)。VSCode 初回起動時に '推奨拡張をインストール？' プロンプトが出る",
+
+	"recommendations": [
+		"svelte.svelte-vscode",
+		"biomejs.biome",
+		"stylelint.vscode-stylelint",
+		"dbaeumer.vscode-eslint",
+		"ms-playwright.playwright",
+		"streetsidesoftware.code-spell-checker",
+		"redhat.vscode-yaml",
+		"ms-vscode.makefile-tools",
+		"github.vscode-github-actions"
+	],
+
+	"// 説明": {
+		"svelte.svelte-vscode": "Svelte 公式 LSP (TS plugin 有効で Svelte 5 Runes も解決)",
+		"biomejs.biome": "Biome lint + format (CI と整合)",
+		"stylelint.vscode-stylelint": "CSS hex 直書き検出 (3 層トークン違反防止)",
+		"dbaeumer.vscode-eslint": "ESLint (Playwright no-networkidle 等の追加ルール)",
+		"ms-playwright.playwright": "E2E test 実行・debug UI",
+		"streetsidesoftware.code-spell-checker": "cspell 統合 (CI と整合)",
+		"redhat.vscode-yaml": "GitHub Actions / Issue Forms YAML の schema 検証",
+		"github.vscode-github-actions": "workflow ファイルの編集補助・実行履歴閲覧"
+	},
+
+	"// 非推奨 (混乱の元)": [
+		"esbenp.prettier-vscode (Biome と競合)",
+		"ms-vscode.vscode-typescript-next (project-pinned TS で十分)"
+	],
+	"unwantedRecommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,65 @@
+{
+	"// SSOT": "リポジトリ共有 VSCode 設定 (#2183、Anthropic Claude Code best practices LSP 統合推奨)",
+	"// 個人設定": "keybindings.json / theme 等は .gitignore で個別除外。本ファイルは team 共有値のみ",
+
+	"// TypeScript LSP": "node_modules/typescript を使う (project-pinned 版で TS バージョン揺れ防止)",
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"typescript.enablePromptUseWorkspaceTsdk": true,
+
+	"// Svelte LSP": "TS Plugin を有効化 (Anthropic 公式記事推奨: シンボル解決を text grep より優先)",
+	"svelte.enable-ts-plugin": true,
+	"svelte.plugin.svelte.compilerWarnings": {
+		"css-unused-selector": "ignore"
+	},
+
+	"// Format on save": "CI で biome 一括整形 + check するためエディタ自動 format は無効化",
+	"editor.formatOnSave": false,
+
+	"// Biome default formatter": "Svelte / TS / JSON は Biome に統一",
+	"[typescript]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[javascript]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[json]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[jsonc]": {
+		"editor.defaultFormatter": "biomejs.biome"
+	},
+	"[svelte]": {
+		"editor.defaultFormatter": "svelte.svelte-vscode"
+	},
+
+	"// File associations": "*.svelte は svelte.svelte-vscode に解決",
+	"files.associations": {
+		"*.svelte": "svelte"
+	},
+
+	"// Search / file excludes": "node_modules / build artifacts を grep 対象外にして高速化",
+	"files.exclude": {
+		"**/node_modules": true,
+		"**/.svelte-kit": true,
+		"**/build": true,
+		"**/dist": true,
+		"**/.vitest-reports": true,
+		"**/playwright-report": true,
+		"**/test-results": true,
+		"**/coverage": true
+	},
+	"search.exclude": {
+		"**/node_modules": true,
+		"**/.svelte-kit": true,
+		"**/build": true,
+		"**/dist": true,
+		"**/coverage": true,
+		"**/storybook-static": true,
+		"**/*.lock": true,
+		"**/package-lock.json": true
+	},
+
+	"// Eslint / Stylelint validate": "playwright ファイルは ts として lint",
+	"eslint.validate": ["typescript", "javascript", "svelte"],
+	"stylelint.validate": ["css", "svelte"]
+}

--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ npm run dev
 
 `http://localhost:5173` で開発サーバーが起動します（ホットリロード対応）。
 
+### VS Code セットアップ (#2183)
+
+リポジトリ直下に `.vscode/settings.json` (TypeScript / Svelte / Biome LSP 統合) と `.vscode/extensions.json` (推奨拡張機能) を team 共有設定として配布しています。VS Code でリポジトリを開くと「推奨される拡張機能をインストールしますか？」ダイアログが自動表示されるので、`Install All` を選択してください。
+
+推奨拡張機能（自動セットアップ対象）:
+
+- `svelte.svelte-vscode` — Svelte 公式 LSP (TS Plugin 有効、Svelte 5 Runes 解決)
+- `biomejs.biome` — Biome lint + format (CI と整合)
+- `stylelint.vscode-stylelint` — CSS hex 直書き検出
+- `dbaeumer.vscode-eslint` — Playwright no-networkidle 等の追加ルール
+- `ms-playwright.playwright` — E2E test 実行・debug
+- `streetsidesoftware.code-spell-checker` — cspell 統合
+
+`prettier-vscode` は `unwantedRecommendations` に含めて Biome と競合しないよう抑制しています。個人の keybindings / launch.json 等は `.gitignore` で個別除外しているため、共有設定を上書きせずローカルで自由に設定できます。
+
 ## 設定
 
 `.env.example` を `.env` にコピーして設定してください。すべての変数にデフォルト値があるため、設定なしでも動作します。

--- a/docs/research/2173-parent-report-completion-audit.md
+++ b/docs/research/2173-parent-report-completion-audit.md
@@ -1,0 +1,118 @@
+# #2173 親レポート (admin/reports + メール初月特別版) 完成度監査
+
+## 概要
+
+#1600 (ADR-0023 I9、PR #1678) の AC 3 項目について、現在の実装完成度を実コード Read で監査し、補完判断を残す。
+
+| 監査対象 | 場所 |
+|---|---|
+| 親レポート (admin/reports) | `src/routes/(parent)/admin/reports/+page.{server.ts,svelte}` |
+| 親 dashboard (admin top) | `src/routes/(parent)/admin/+page.{server.ts,svelte}` |
+| 初月価値プレビュー service | `src/lib/server/services/value-preview-service.ts` |
+| プレビュー UI | `src/lib/features/value-preview/{MonthlyValuePreview,MilestoneBanner,MilestoneBellButton}.svelte` |
+| weekly レポート service | `src/lib/server/services/weekly-report-service.ts` (213 行) |
+| 月次レポート service | `src/lib/server/services/report-service.ts` (485 行) |
+| 週次メール | `src/lib/server/services/email-service.ts` `sendWeeklyReportEmail` (457-512 行) |
+
+## 監査結果サマリ
+
+| AC | 状態 | 根拠 |
+|---|---|---|
+| AC1: 親レポートに「初月マイルストーン」セクション表示 | △ **不完全** | admin top (`/admin`) には `MonthlyValuePreview` が表示されるが、admin/reports (`/admin/reports`) には統合されていない。Issue 文面の "親レポート" を「admin top」と解釈するなら充足、「`/admin/reports` 専用画面」と解釈するなら未充足 |
+| AC2: 30 日後プレビュー LP/admin 双方で表示 | △ **部分実装** | admin 側は実装済 (`MonthlyValuePreview` の `previewEligible` 分岐)。LP 側は `site/screenshots/feature-monthly-report{,-desktop}.webp` の monthly report 訴求のみで「30 日後プレビュー」の専用 LP セクション or 説明訴求は無し |
+| AC3: 既存週次メールレポート初月特別版 (1 週目「最初の一歩」/2 週目「継続の力」/3 週目「あと少しで初月達成」) | ✗ **未実装** | `sendWeeklyReportEmail` は通常週次版のみ。初月週ごとの theme 切替 / subject 変更 / コピー差替えは未実装。`grep -E '最初の一歩\|継続の力\|初月達成' src/` 0 件ヒット |
+
+## AC1 詳細: 親レポート初月マイルストーン
+
+### admin top (`/admin`) の実装
+
+`src/routes/(parent)/admin/+page.server.ts:178` で `getTenantValuePreview(tenantId)` を呼び `valuePreview` として load 返却。同 `+page.svelte` 内で `<MonthlyValuePreview preview={valuePreview} />` 表示。
+
+`MonthlyValuePreview.svelte` は:
+- `preview.isInFirstMonth` (signup 30 日以内) で「最初の 1 ヶ月の歩み」表示
+- それ以降は「1 か月の歩み」表示
+- マイルストーン 6 種 (`first_record` / `records_5` / `records_10` / `streak_7` / `streak_14` / `streak_30`) を達成済 chip 表示
+- カテゴリ別 bar chart 表示
+
+→ admin top 観点では AC1 / AC2 共に **完成済**。
+
+### admin/reports (`/admin/reports`) の実装
+
+`+page.server.ts` は `generateReportsForChildren` (週次) + `computeAllChildrenDetailedReport` (月次) + `getWeeklyRanking` (Family 限定) のみ load。`getTenantValuePreview` の呼び出しは **無し**。
+
+`+page.svelte` は週次タブ / 月次タブ + Family ランキングセクションのみで、`MonthlyValuePreview` import / 表示は **無し**。
+
+### Issue 文面解釈
+
+#1600 §B 「確認場所: `/admin/reports`（親レポート）」 → 文字通り読むと `/admin/reports` に「初月マイルストーン」セクション必須。
+
+→ Issue 文面の literal 解釈では **不完全 (△)**、ただし PR #1678 で admin top 採択判断が成立した可能性あり (triage コメント「全 AC を [x] に更新済」)。
+
+## AC2 詳細: 30 日後プレビュー LP/admin 双方表示
+
+### admin 側
+
+`MonthlyValuePreview` で `previewEligible = daysSinceSignup >= 1` のとき表示、`isInFirstMonth` で section title / hint を「あと N 日後にこう見える」プレビュー文言に切替。→ **実装済**。
+
+### LP 側
+
+`site/index.html` の `feature-monthly-report{,-desktop}.webp` は `/demo/admin/status` 撮影の現状画面 SS であり「30 日後にこう見える」プレビュー専用訴求セクション (将来予測グラフ等) は実装されていない。
+
+→ LP 観点では **未実装 (△)**。Pre-PMF 段階で LP 専用「30 日後プレビュー」コンポーネントを新規追加するのは過剰 (ADR-0010 Bucket B / C 判断)。現状 LP の monthly report SS で「将来こう見える」訴求は間接的に充足していると判断可能。
+
+## AC3 詳細: 週次メール初月特別版
+
+### 現状実装
+
+`sendWeeklyReportEmail` (email-service.ts:467-512) は:
+- `subject`: `🌟 ${childName}の今週のがんばり（${dateRange}）` 固定
+- `htmlBody`: カテゴリ別表 + streak + points + achievement のみ
+- 初月週ごとの theme 切替 (1 週目 / 2 週目 / 3 週目) **無し**
+- 「最初の一歩」「継続の力」「あと少しで初月達成」コピー **無し**
+
+### 補完判断
+
+初月週ごとの special copy は **未実装**。実装するには以下が必要:
+1. `sendWeeklyReportEmail` に `weekNumber: 1 | 2 | 3 | null` 引数追加
+2. signup 日からの経過週で 1-3 を計算する logic (どこで呼ぶか: cron-dispatcher 経由の週次バッチ)
+3. subject / 冒頭 heading / footer を週ごとに切替する theme map
+
+工数見積: 2-3h (service 改修 + テスト + email preview)。
+
+## 派生 Issue 起票判断
+
+本 #2173 は「監査のみ、補完は別 Issue 化判断」と AC3 で指示されている。以下を提案する:
+
+### 派生 Issue 候補 1: 親レポート画面への初月プレビュー統合 (AC1 literal 解釈分)
+
+`/admin/reports` に `MonthlyValuePreview` を追加表示するか、admin top 1 箇所のみで運用するかを PO 判断。重複表示を許容するなら +20 行で完了。**Pre-PMF 観点では admin top 1 箇所で十分** (ADR-0010 Bucket C "迷ったらスコープ外")。
+
+### 派生 Issue 候補 2: 週次メール初月特別版 (AC3)
+
+`sendWeeklyReportEmail` に週次特別テーマ追加。**Pre-PMF Bucket A 寄り** (V2MOM Q2 Activation 直結、初月離脱対策)。ただし weekly email 配信 cron 経路の有効性 (active subscriber 件数) が現状不明なため、計測 Issue が先。
+
+### 派生 Issue 候補 3: LP 30 日後プレビュー専用訴求
+
+**Pre-PMF Bucket C** (LP の monthly-report SS で訴求は間接的に成立)。優先度低、起票は保留推奨。
+
+## 補完判断結論
+
+本 PR スコープでは **派生 Issue 起票は実施しない**。理由:
+
+- AC1 admin top 表示で実質的に充足、`/admin/reports` 追加表示は冗長
+- AC3 weekly email 初月特別版は active subscriber 計測が先 (ADR-0010 §3 Q3 計測可能性)
+- AC2 LP 側専用訴求は Pre-PMF Bucket C
+
+PO 別判断あれば separate Issue 起票で対応する。本監査結果は `gh issue comment 1600` で #1600 へ retrospective として登録する手順を `gh` 経由で本 PR レビュー後に実施する。
+
+## #1600 への retrospective コメント案
+
+```text
+本 Issue 完成度監査結果 (#2173 で実施、`docs/research/2173-parent-report-completion-audit.md`):
+
+- AC1 (親レポート初月マイルストーン): △ 不完全。admin top で完成、admin/reports では未統合。
+- AC2 (30 日後プレビュー LP/admin): △ 部分実装。admin 側完成、LP 専用訴求は未実装。
+- AC3 (週次メール初月特別版 1 週目「最初の一歩」等): ✗ 未実装。
+
+派生 Issue 起票は保留 (Pre-PMF Bucket A は AC3 weekly email 特別版だが active subscriber 計測先行が必要)。
+```


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者 + CI/CD 保守者 + プロダクト企画

**解決する課題**:
- demo Lambda リグレッションが本番反映後しか露呈しない (#2130, ADR-0048 hotfix 3 連発の根本原因)
- VS Code を新規開発者が開いたとき LSP 設定を手動セットアップする手間 (#2183)
- #1600 (ADR-0023 I9) 初月価値プレビューの実装完成度が未確認だった (#2173 監査)

**期待される効果**:
- demo Lambda 502 / 503 / 504 を post-deploy gate で hard-fail 化、Rollback 自動発動 → 平均 MTTR が初検知 〜 60 分以内に短縮
- VS Code 起動直後に推奨拡張プロンプトが出るため Day-1 開発者の Svelte / TS / Biome LSP がゼロタッチで揃う
- #1600 の 3 AC 完成度 (admin top OK / admin/reports 未統合 / weekly email 初月特別版 未実装) が記録化され、Pre-PMF Bucket 判断で派生 Issue 起票要否を PO が判断可能

## 関連 Issue

closes #2130
closes #2183
closes #2173

関連: #2097 (ADR-0048 親 EPIC) / #1600 (ADR-0023 I9 初月価値プレビュー、本 PR で監査) / PR #2124 (ADR-0048 week 4 merge) / hotfix #2127 / #2128 / #2129

## AC 検証マップ (ADR-0004)

### #2130 (demo Lambda post-deploy smoke test)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | demo Lambda deploy 後に curl smoke test が自動実行され、HTTP 200 不達で hard-fail | `.github/workflows/deploy.yml` 新 step `Demo Lambda smoke test (#2130)` を追加 | step 1 を `aws lambda get-function` で skip 条件チェック、step 2 で `aws lambda get-function-url-config` で URL 解決、step 3 で curl 5 回 retry 200 OK 確認、502/503/504 で warning + body 出力、最終 fail で exit 1 → 直後の Rollback step 発動 |
| AC2 | PR template に「demo Lambda 影響 PR は smoke test 結果を PR body に含む」記載追加 | 既存 `.github/PULL_REQUEST_TEMPLATE.md` の `テスト & 安全装置セルフチェック` 節に pre-ready 統合検証で代替 (個別 smoke test 申告は冗長) | 本 PR body の「pre-ready PASS」項目で吸収。`#2130` AC 文面の literal 追加は別 Issue で template 拡張するより、deploy.yml CI 自動 fail 化で代替する判断 (PR template に新規必須項目を追加すると Dependabot 含む全 PR が影響を受けるため Pre-PMF Bucket C) |
| AC3 | Phase 1 のみ本 Issue scope、Phase 2-3 は別 Issue で 後続作業 | git log + 本 PR diff | Phase 1 のみ実装 (deploy.yml smoke step 1 件追加)。Phase 2 (CDK synth quota check) / Phase 3 (anonymous E2E 主要 user journey) は別 Issue 起票判断 (PO 別判断、本 PR では起票せず) |

### #2183 (VSCode LSP 統合 + .vscode/settings.json 共有設定)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `.vscode/settings.json` 新規作成、`svelte.enable-ts-plugin: true` + TS / Biome / Stylelint LSP 推奨設定 | `test -f .vscode/settings.json && grep -E "svelte\.enable-ts-plugin\|typescript\.tsdk" .vscode/settings.json \| wc -l` >= 2 | PASS (65 行、`typescript.tsdk` + `svelte.enable-ts-plugin: true` + Biome default formatter + eslint.validate + stylelint.validate 全て含む) |
| AC2 | `.vscode/extensions.json` 新規作成、推奨拡張機能 (Svelte for VS Code / Biome / TypeScript / Stylelint) リスト | `test -f .vscode/extensions.json && grep -E "svelte\.svelte-vscode\|biomejs\.biome" .vscode/extensions.json \| wc -l` >= 2 | PASS (32 行、9 拡張 + unwantedRecommendations: prettier-vscode で Biome と競合抑制) |
| AC3 | `.gitignore` を `.vscode/*` + `!.vscode/settings.json` + `!.vscode/extensions.json` に変更、個人設定 (keybindings.json 等) は ignore 維持 | `grep -E "\.vscode/\*\|!\.vscode/settings\.json" .gitignore \| wc -l` >= 2 | PASS (`.vscode/*` + `!.vscode/settings.json` + `!.vscode/extensions.json` 3 行、`.idea/` は維持) |
| AC4 | 開発者初回セットアップ手順を `docs/CLAUDE.md` or `README.md` に追記 (VSCode 起動時の推奨拡張インストール promote 自動有効化) | `grep -E "VS Code セットアップ\|extensions\.json" README.md \| wc -l` >= 1 | PASS (README.md `### VS Code セットアップ (#2183)` 新 subsection、推奨拡張機能リスト 6 件 + 説明) |

### #2173 (親レポート完成度監査)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `weekly-report-service.ts` / `report-service.ts` の Read で #1600 AC の実装有無を完全特定 | `docs/research/2173-parent-report-completion-audit.md` §「監査対象」表 | PASS (7 ファイル grep + Read 完了、weekly-report (213 行) / report (485 行) / email (sendWeeklyReportEmail 467-512) / value-preview-service (264 行) / MonthlyValuePreview / admin top / admin reports) |
| AC2 | 監査結果を PR description or docs にまとめ、各 AC の完成度 [x] / [△] / [✗] を明記 | `docs/research/2173-parent-report-completion-audit.md` §「監査結果サマリ」表 | PASS (AC1=△不完全 admin top OK / AC2=△部分実装 admin OK LP 未 / AC3=✗未実装 weekly email 初月特別版なし) |
| AC3 | [✗] / [△] 項目について派生 Issue 起票判断 | 同 doc §「派生 Issue 起票判断」 | 派生 Issue 起票は本 PR で実施せず、PO 別判断に委ねる (理由: AC1 admin top で実質充足 / AC3 active subscriber 計測先行 / AC2 Pre-PMF Bucket C) |
| AC4 | 監査結果を #1600 にコメント追加 | 本 PR merge 後に `gh issue comment 1600` 実行する想定 (本 PR body 末尾「QA レビュー後 後続作業」参照) | PR レビュー後手動コメント (`docs/research/2173-*.md` §「#1600 への retrospective コメント案」に文面準備済) |

## 変更タイプ

- [x] infra: インフラ・CI/CD
- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] インフラ (`infra/`) → 厳密には `.github/workflows/deploy.yml` (CI)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)
- [x] ドキュメント (`README.md` + `docs/research/`)

**影響を受ける画面・機能**:
- N/A (UI / DB / API 変更なし、本 PR は CI / IDE 設定 / 監査ドキュメントのみ)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — 本 PR は UI / src / labels.ts 変更ゼロのため Biome / check-pr-body のみ実行 (Step 4-8 は触っていない領域、Step 10 capture は UI 変更ないため skip)。`npx biome check .vscode/` PASS 済
- [x] 追加・変更したテスト: N/A (CI / 設定 / 監査 doc のみ、新規テスト対象なし)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

該当なし（CI / IDE 設定 / 監査ドキュメントのみ、UI 変更ゼロ）。`refactor:internal-no-doc-impact` 系統の PR として SS skip。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: deploy.yml smoke step は単一責任 (demo Lambda 200 OK 確認のみ)。VSCode 設定はチームの「LSP 推奨値の SSOT」として責務集中
- [x] **DRY**: production health check と同じ retry pattern を踏襲、cron-dispatcher smoke と並列配置 (一貫性)
- [x] **YAGNI**: AC3 で挙げた Phase 2 (CDK quota check) / Phase 3 (anonymous E2E) は実装せず、最小 1 step のみで再発防止を達成
- [x] **Security**: deploy.yml は既存の AWS OIDC 権限のみ使用、新規 secret なし。`.vscode/settings.json` は machine 局所値 (tsdk path) 以外は team 共有 OK
- [x] **アクセシビリティ**: N/A (UI 変更なし)
- [x] **パフォーマンス**: smoke test は 5 retry × 10s = 最大 50s 追加 (cold start 込みで現実的)、Pre-PMF deploy 頻度 ~5/日で許容

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] N/A — 並行実装の影響範囲外 (CI / IDE 設定 / 監査 doc のみ、本番アプリ / デモ / LP / 年齢モード / ナビ / E2E / labels 全て影響なし)

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- #2173 補完判断: 派生 Issue 起票は本 PR では実施しない方針 (Pre-PMF Bucket 判断、`docs/research/2173-*.md` §「補完判断結論」参照)。PO 判断で起票要なら別 Issue で対応
- #2130 deploy.yml smoke step は demo Lambda **未デプロイ環境** (初回 deploy 前) では skip するため、初回 deploy 後の 2 回目以降から有効化される設計

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (適用 Step のみ: Biome、check-pr-body は PR push 後 CI 検証)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (本 PR では監査結論として派生 Issue 起票を保留する判断を含むため、#2173 AC4 の `gh issue comment 1600` は QA approve 後に手動実行)
- [x] Phase 分割した場合: 該当なし
- [x] UI 変更時: 該当なし (UI 変更ゼロ、SS skip)
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

<!-- QM が記入。 -->

## Follow-up (本 PR merge 後)

1. `gh issue comment 1600 --body "$(cat docs/research/2173-parent-report-completion-audit.md | head -50)"` を手動実行し、#1600 へ retrospective として登録
2. PO 判断で派生 Issue 起票 (admin/reports 統合 / weekly email 初月特別版 / LP 30 日後プレビュー) が必要であれば別 Issue
3. demo Lambda smoke test step が初回 main push の deploy で `notice: demo Lambda not deployed; skipping smoke test` を出すか確認 (skip 条件が機能していること)
