### PR TITLE
fix: #2261 DemoBanner exitHref / signupHref を www. canonical に修正

### DIFF
--- a/site/shared-labels.js
+++ b/site/shared-labels.js
@@ -705,9 +705,9 @@
 			"heroButton": "無料で始める",
 			"midButton": "デモを見る",
 			"bottomButton": "無料で始める",
-			"heroHref": "https://ganbari-quest.com/auth/signup",
+			"heroHref": "https://www.ganbari-quest.com/auth/signup",
 			"midHref": "https://demo.ganbari-quest.com/",
-			"bottomHref": "https://ganbari-quest.com/auth/signup",
+			"bottomHref": "https://www.ganbari-quest.com/auth/signup",
 			"ariaLabelHero": "7 日間無料トライアルへのご案内",
 			"ariaLabelMid": "デモ画面で機能を体験",
 			"ariaLabelBottom": "無料トライアル開始のご案内"

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -1145,17 +1145,21 @@ export const DEMO_LABELS = {
 	/**
 	 * 退出先 (LP に戻す)。
 	 * #2097 Phase B Bug 3: demo Lambda には `/demo/exit` route が存在しないため
-	 * 本番 LP (https://ganbari-quest.com/) への absolute URL とする。
+	 * 本番 LP (https://www.ganbari-quest.com/) への absolute URL とする。
 	 * NUC 本番 (local mode) からも同じ absolute URL でアクセス可能。
+	 * #2261 (2026-05-19 PO 報告): apex (ganbari-quest.com) ではなく www. canonical
+	 * に統一。CloudFront / Route53 の canonical は www. のため、apex 経由だと
+	 * 301 リダイレクトが挟まり UX が劣化する。
 	 */
-	exitHref: 'https://ganbari-quest.com/',
+	exitHref: 'https://www.ganbari-quest.com/',
 	/**
 	 * サインアップ CTA 先 (本当に始める)。
 	 * #2097 Phase B Bug 2: demo Lambda では Cognito 未注入のため /auth/signup を
 	 * relative で叩くと中途半端な signup 画面 (失敗確定) が表示される。本番 (Cognito)
 	 * への absolute URL に固定する。
+	 * #2261 (2026-05-19 PO 報告): exitHref と同じく www. canonical に統一。
 	 */
-	signupHref: 'https://ganbari-quest.com/auth/signup',
+	signupHref: 'https://www.ganbari-quest.com/auth/signup',
 } as const;
 
 // ============================================================
@@ -6136,9 +6140,12 @@ export const LP_FLOATING_CTA_LABELS = {
 	midButton: 'デモを見る',
 	bottomButton: `${FREE_TERMS.tryFree}`,
 	// 各 phase の CTA href
-	heroHref: 'https://ganbari-quest.com/auth/signup',
+	// #2261 (2026-05-19 PO 報告): apex (ganbari-quest.com) ではなく www. canonical
+	// に統一。LP は www. で配信されているため apex 経由だと 301 リダイレクトが
+	// 挟まり UX 劣化（DemoBanner と同一 root cause、DEMO_LABELS.exitHref / signupHref 修正と同時対応）。
+	heroHref: 'https://www.ganbari-quest.com/auth/signup',
 	midHref: 'https://demo.ganbari-quest.com/',
-	bottomHref: 'https://ganbari-quest.com/auth/signup',
+	bottomHref: 'https://www.ganbari-quest.com/auth/signup',
 	// aria-label（読み上げ用）
 	// #1915 (TECH-F 中頻度 D-1): TRIAL_PERIOD_TERMS atom 経由
 	ariaLabelHero: `${TRIAL_PERIOD_TERMS.full}へのご案内`,

--- a/tests/unit/domain/demo-labels-2097.test.ts
+++ b/tests/unit/domain/demo-labels-2097.test.ts
@@ -1,5 +1,5 @@
 /**
- * tests/unit/domain/demo-labels-2097.test.ts (#2097 Phase B, PO 報告 2026-05-17)
+ * tests/unit/domain/demo-labels-2097.test.ts (#2097 Phase B, PO 報告 2026-05-17 / #2261 PO 報告 2026-05-19)
  *
  * `DEMO_LABELS` (DemoBanner SSOT) の 3 値が PO 修正指示に沿っていることを構造的に
  * 保証する回帰防止テスト。
@@ -14,10 +14,14 @@
  *     Bug 3: exitHref = '/demo/exit' (relative) — demo Lambda には /demo/exit route が無いため
  *            404。LP に戻す = https://ganbari-quest.com/ に変更
  *
- * AC マッピング (Issue #2097 Phase B):
+ *   2026-05-19 (#2261 PO 報告): exitHref / signupHref が apex (ganbari-quest.com) を指していたが、
+ *     LP canonical は www.ganbari-quest.com のため 301 リダイレクトが挟まり UX 劣化。
+ *     www. canonical に統一。
+ *
+ * AC マッピング (Issue #2097 Phase B + #2261 follow-up):
  *   - AC1: ctaStart = '本当に始める' (漢字)
- *   - AC2: signupHref = 'https://ganbari-quest.com/auth/signup' (absolute, 本番ドメイン)
- *   - AC3: exitHref = 'https://ganbari-quest.com/' (absolute, 本番 LP)
+ *   - AC2: signupHref = 'https://www.ganbari-quest.com/auth/signup' (absolute, www canonical)
+ *   - AC3: exitHref = 'https://www.ganbari-quest.com/' (absolute, www canonical)
  *   - AC4: 他フィールド (bannerTitle / bannerDescription / ctaExit) は変更されていない
  */
 
@@ -31,17 +35,21 @@ describe('DEMO_LABELS (#2097 Phase B: DemoBanner CTA / href SSOT)', () => {
 		expect(DEMO_LABELS.ctaStart).not.toContain('ほんとうに');
 	});
 
-	it('AC2: signupHref は本番 absolute URL (demo Lambda 上で /auth/signup を叩いて失敗するのを防ぐ)', () => {
-		expect(DEMO_LABELS.signupHref).toBe('https://ganbari-quest.com/auth/signup');
+	it('AC2: signupHref は www canonical absolute URL (apex 経由 301 リダイレクトを防ぐ、#2261)', () => {
+		expect(DEMO_LABELS.signupHref).toBe('https://www.ganbari-quest.com/auth/signup');
 		// relative path regression を検出
 		expect(DEMO_LABELS.signupHref.startsWith('http')).toBe(true);
+		// apex (no www.) regression を構造的に検出 (#2261)
+		expect(DEMO_LABELS.signupHref).toMatch(/^https:\/\/www\./);
 	});
 
-	it('AC3: exitHref は本番 LP absolute URL (/demo/exit は demo Lambda に存在しない → 404 を防ぐ)', () => {
-		expect(DEMO_LABELS.exitHref).toBe('https://ganbari-quest.com/');
+	it('AC3: exitHref は www canonical LP absolute URL (apex 経由 301 リダイレクト + /demo/exit 404 を防ぐ、#2261)', () => {
+		expect(DEMO_LABELS.exitHref).toBe('https://www.ganbari-quest.com/');
 		expect(DEMO_LABELS.exitHref.startsWith('http')).toBe(true);
 		// /demo/exit regression を構造的に検出
 		expect(DEMO_LABELS.exitHref).not.toContain('/demo/exit');
+		// apex (no www.) regression を構造的に検出 (#2261)
+		expect(DEMO_LABELS.exitHref).toMatch(/^https:\/\/www\./);
 	});
 
 	it('AC4: 他フィールド (bannerTitle / bannerDescription / ctaExit) は子供にも読める hiragana 維持', () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供 / 親（管理者）（demo.ganbari-quest.com 体験者全員）

**解決する課題**: `demo.ganbari-quest.com` の DemoBanner「おためしをやめる」/「無料登録して始める」リンクが apex (`https://ganbari-quest.com/`) を指していたが、LP canonical は `https://www.ganbari-quest.com/` のため 301 リダイレクトが挟まり、Cookie 切替・往復遅延で UX 劣化していた。PO 直接報告 2026-05-19。

**期待される効果**: demo → LP 遷移で 301 リダイレクトを排除し、Cookie scope 一致で認証状態の引き継ぎが破綻しない。SEO 観点でも canonical 一致により外部リンク評価が正しく集約される（ADR-0013 LP truth の URL 整合性も担保）。

## 関連 Issue

closes #2261

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `DEMO_LABELS.exitHref` が `https://www.ganbari-quest.com/` (www. canonical) | `grep -nE "exitHref.*www\\.ganbari-quest\\.com" src/lib/domain/labels.ts` | PASS: `exitHref: 'https://www.ganbari-quest.com/'` |
| AC2 | `DEMO_LABELS.signupHref` が `https://www.ganbari-quest.com/auth/signup` (www. canonical) | `grep -nE "signupHref.*www\\.ganbari-quest\\.com/auth/signup" src/lib/domain/labels.ts` | PASS: `signupHref: 'https://www.ganbari-quest.com/auth/signup'` |
| AC3 | unit test 期待値更新 + 全 PASS | `npx vitest run tests/unit/domain/demo-labels-2097.test.ts tests/unit/lp/demo-cta-href-migration-2097.test.ts` | PASS: 14 tests passed |
| AC4 | apex regression 検出 regex 追加 | `grep -nE "regression|apex" tests/unit/domain/demo-labels-2097.test.ts` | PASS: `^https://www\\.` 期待 regex 追加済 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [x] LP サイト (`site/`)（`shared-labels.js` 生成物のみ）
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- `demo.ganbari-quest.com` の DemoBanner「おためしをやめる」/「無料登録して始める」リンク
- LP `site/index.html` / `site/pricing.html` の FloatingCTA `hero` / `bottom` ボタン（同 root cause で apex hardcode していたものを www. canonical に統一）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2264` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/domain/demo-labels-2097.test.ts`: 期待値を `https://www.ganbari-quest.com/...` に更新 + apex regression 検出 regex (`^https://www\.`) を追加し再発防止
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority: high であり critical ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は `src/lib/domain/labels.ts` 内の URL 文字列 (`exitHref` / `signupHref` / `heroHref` / `bottomHref`) を apex → www. canonical に修正するのみ。**UI 視覚変化ゼロ**（ボタンラベル / レイアウト / 配色は不変、`<a href>` の値のみ変更）。`src/lib/**` 配下の internal data 修正で、`refactor:internal-no-doc-impact` label exempt (#2017 / ADR-0003 §4 内部 refactor exempt) 適用。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A (URL only change) | N/A (URL only change) |
| **修正後** | N/A (URL only change) | N/A (URL only change) |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（labels SSOT に集約、URL 直書き散在を回避）
- [x] **DRY**: `grep -rn "https://ganbari-quest.com"` で apex hardcode を全件監査済。本 PR scope: `DEMO_LABELS.{exitHref,signupHref}` + `LP_FLOATING_CTA_LABELS.{heroHref,bottomHref}` を同 root cause として一括修正。それ以外の apex hardcode は別 Issue 候補（下記「追加で監査した結果」参照、本 PR scope 外）
- [x] **YAGNI**: 該当箇所のみ修正、抽象化は追加せず
- [x] **Security（OSS 公開前提）**: URL 文字列のみ変更、秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A（リンク先 URL のみ変更、a11y attribute 不変）
- [x] **パフォーマンス**: 301 リダイレクト排除によりむしろ改善

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照）:

- [x] 本番アプリ + デモ版同期: 該当なし（DEMO_LABELS は demo 側専用、本番側に重複なし）
- [x] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: LP_FLOATING_CTA_LABELS の hero/bottomHref も同 root cause で apex → www. canonical に統一し、LP 全 9 ページとアプリ側 demo banner を整合
- [x] 全年齢モード 5 種: N/A（URL only change、年齢モード非依存）
- [x] ナビゲーション 3 種: N/A
- [x] E2E / ユニットシード + チュートリアル同期: N/A（demo data の URL 直書きなし）
- [x] **labels SSOT** (ADR-0009): `src/lib/domain/labels.ts` 経由 / `site/shared-labels.js` は `scripts/generate-lp-labels.mjs` で自動再生成
- [x] **設計書同期** (ADR-0001): URL 修正のため設計書影響なし
- [x] **並行 PR overlap** (#1200): `labels.ts` overlap PR なし（GitHub overlap-check 確認済）

**LP / 販促文言変更時** (ADR-0013 / #1314):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| `LP_FLOATING_CTA_LABELS.heroHref` / `bottomHref` URL | `src/lib/domain/labels.ts` (apex → www. canonical) | Committed (URL 修正のみ、新規訴求文言の追加なし) |
| `DEMO_LABELS.exitHref` / `signupHref` URL | 同上 | Committed |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**: 追加監査で apex hardcode を 30+ 件発見済（LP HTML 直書き / メール本文 / インフラ層）。本 PR scope 外として別 Issue 候補リストを下記に記載。QM 判断で別 Issue 起票を依頼。

### 追加で監査した結果 (本 PR scope 外、別 Issue 候補)

`grep -rn "https://ganbari-quest.com"` で apex hardcode を全件監査。**本 PR scope は labels.ts 経由のもの (DEMO_LABELS + LP_FLOATING_CTA_LABELS) のみ**、以下は別 Issue 候補:

**A. LP HTML href 直書き 30 件 (高優先)**: `site/*.html` 全 9 ページの `<a href="https://ganbari-quest.com/auth/signup">` 等。SSOT (labels.ts) に対応せず HTML 直書きのため `scripts/generate-lp-labels.mjs` での同期不可。LP HTML href の SSOT 化が必要。

**B. アプリ内通知 (`src/lib/server/services/*.ts`) 中優先**: `email-service.ts` (8 箇所) / `trial-notification-service.ts` (8 箇所) / `pmf-survey-service.ts` (1 箇所)。`env.APP_BASE_URL ?? 'https://ganbari-quest.com'` の default を www. canonical に統一。

**C. インフラ層 (低優先、別レイヤ判断)**: `infra/lib/compute-stack.ts` Cognito callback URL / `scripts/stripe-setup-portal.ts` / `playwright.{aws,production}.config.ts` 等。Cognito 登録済 callback URL は別管理。

**D. その他 (sitemap / 法務、別 ADR 候補)**: `src/routes/sitemap.xml/+server.ts` `SITE_ORIGIN` / `LP_LEGAL_SLA_LABELS.section1` SLA 適用範囲条文。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2264` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未着手のまま残っている AC がない）
- [x] Phase 分割した場合: 本 PR は Phase 分割なし、apex → www. canonical 修正の最小 PR
- [x] UI 変更時: N/A（URL only change、`refactor:internal-no-doc-impact` label exempt）
- [x] 認証画面変更時: N/A（リンク先 URL のみ変更、認証画面そのものは不変）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
