### PR TITLE
fix: #2282 e2e-demo-lambda 2 spec 誤期待を実装の事実に整合 (AC11-5 + bug4 POST observation)

### DIFF
--- a/tests/e2e/demo-lambda/anonymous-no-mode-param.spec.ts
+++ b/tests/e2e/demo-lambda/anonymous-no-mode-param.spec.ts
@@ -73,13 +73,42 @@ test.describe('#2097 AC11: demo Lambda は `?mode=demo` 不要で動作', () => 
 		await expect(page.getByTestId('child-select-902')).toBeVisible();
 	});
 
-	test('AC11-5: /elementary/home に直接アクセスしても認証 challenge なしで描画される', async ({
+	test('AC11-5: /elementary/home 直アクセスで認証 challenge (= /auth/login redirect) が発生しない', async ({
+		context,
 		page,
 	}) => {
-		// AUTH_MODE=anonymous により AnonymousAuthProvider が常に allowed=true を返す。
-		// 本番 cognito では /auth/login へ 302 redirect だが、demo Lambda では直アクセス OK。
-		const res = await page.goto('/elementary/home');
-		expect(res?.status() ?? 200).toBeLessThan(400);
+		// AUTH_MODE=anonymous により AnonymousAuthProvider.authorize() が常に allowed=true を返す。
+		// 本番 cognito では未認証時に /auth/login へ 302 redirect されるが、demo Lambda ではそれが
+		// 起きないことが本 AC の真意 (= "認証 challenge なしで描画される")。
+		//
+		// ただし `/(child)/+layout.server.ts` は selectedChildId cookie が無い場合 `/switch` に
+		// redirect する UX 仕様 (子供選択画面、認証とは独立)。これは demo / 本番 cognito で同じ
+		// 挙動であり「認証 challenge」ではない。本 spec では以下 2 ケースを assert する:
+		//
+		//   case (a): cookie 未設定で /elementary/home に直アクセス
+		//     → 認証 challenge ではなく /switch (子供選択) に redirect される (auth/login へは行かない)
+		//   case (b): selectedChildId=903 (elementary fixture けんた) cookie pre-set で直アクセス
+		//     → /elementary/home が直接描画される (capture-hp-screenshots と同じ pattern)
+
+		// case (a): cookie 未設定 → /switch (子供選択) に着地、/auth/login には行かない
+		await context.clearCookies();
+		const resNoCookie = await page.goto('/elementary/home');
+		expect(resNoCookie?.status() ?? 200).toBeLessThan(400);
+		await expect(page).not.toHaveURL(/\/auth\/login/);
+		// 子供選択画面 (/switch) または home (直描画) のどちらかに着地していれば demo Lambda 仕様準拠
+		await expect(page).toHaveURL(/\/(switch|elementary\/home)/);
+
+		// case (b): cookie pre-set → home が直接描画される (capture-hp-screenshots SSOT pattern)
+		await context.clearCookies();
+		await context.addCookies([
+			{
+				name: 'selectedChildId',
+				value: '903', // demo fixture けんた (elementary、src/lib/server/demo/demo-data.ts SSOT)
+				url: page.url() || 'http://localhost:5180',
+			},
+		]);
+		const resWithCookie = await page.goto('/elementary/home');
+		expect(resWithCookie?.status() ?? 200).toBeLessThan(400);
 		await expect(page).toHaveURL(/\/elementary\/home/);
 	});
 });

--- a/tests/e2e/demo-lambda/bug4-switch-click.spec.ts
+++ b/tests/e2e/demo-lambda/bug4-switch-click.spec.ts
@@ -77,15 +77,24 @@ test.describe('Bug 4: /switch クリックで子供選択が動作する (demo L
 		await expect(page).toHaveURL(/\/baby\/home/, { timeout: 10_000 });
 	});
 
-	test('/switch POST レスポンスが redirect になっている (no-op 化されていない)', async ({
+	test('/switch POST レスポンスが SvelteKit action redirect で返る (demo no-op 化されていない)', async ({
 		page,
 	}) => {
 		await page.goto('/switch');
 
-		// form submission の POST response を観測する
-		// SvelteKit 2 の form action では redirect 時は 303 + Location header を返す
-		// (use:enhance enabled でも redirect は raw HTTP 303、本番準拠)。
-		// もし demo no-op 化されていれば 200 + `{ ok: true, demo: true }` JSON が返る。
+		// SvelteKit 2 の form action は `use:enhance` 有効時、redirect を以下の形式で返す
+		// (src/routes/switch/+page.svelte は <form use:enhance> + redirect(303, ...) を発火):
+		//
+		//   HTTP 200 + Content-Type: application/json
+		//   body: `{ type: 'redirect', status: 303, location: '/preschool/home' }`
+		//
+		// クライアント側 use:enhance が JSON を消費し goto(location) で実際の遷移を行う。
+		// raw HTTP 303 は use:enhance OFF 時 (full page submit) のみ。
+		//
+		// 一方 demo no-op 化されていた場合 (Bug 4 再発時) は:
+		//   HTTP 200 + body `{ ok: true, demo: true }` (DEMO_WRITE_METHODS で no-op)
+		//
+		// 本 spec は body 解析で「SvelteKit action redirect 形式」と「demo no-op 形式」を弁別する。
 		const responsePromise = page.waitForResponse(
 			(res) => res.url().includes('/switch') && res.request().method() === 'POST',
 		);
@@ -93,10 +102,16 @@ test.describe('Bug 4: /switch クリックで子供選択が動作する (demo L
 		await page.getByTestId('child-select-902').click();
 		const res = await responsePromise;
 
-		// redirect response であること (303 status + Location ヘッダ)
-		// no-op 化されていれば 200 になる。
-		expect(res.status()).toBe(303);
-		const location = res.headers().location ?? '';
-		expect(location).toMatch(/\/preschool\/home/);
+		// status は 200 (use:enhance 経由)、demo no-op も 200 を返すため弁別は body で行う
+		expect(res.status()).toBe(200);
+
+		const body = await res.json();
+		// SvelteKit action redirect 形式であること = demo no-op 化されていない証拠
+		expect(body).toMatchObject({
+			type: 'redirect',
+			location: expect.stringMatching(/\/preschool\/home/),
+		});
+		// no-op 形式 `{ ok: true, demo: true }` ではないこと (回帰検出)
+		expect(body).not.toMatchObject({ demo: true });
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体 (内部品質)

**解決する課題**: main branch + 全 PR で `e2e-demo-lambda` ジョブが 2 spec (anonymous-no-mode-param AC11-5 / bug4-switch-click POST observation) で連続 fail し、`ci-gate` も連鎖 fail。本番 deploy 安定性 / 他 PR Ready 化判断に影響していた。

**期待される効果**: e2e-demo-lambda ジョブ green 化により ci-gate 緑復帰。本 PR の merge 後、すべての PR が demo Lambda gate を正しく評価できる。なお visual-equality.spec.ts と demo-marketplace-seed.spec.ts の連続 fail は AC スコープ外 (別 Issue 起票推奨)。

## 関連 Issue

closes #2282

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | root cause 特定 (demo Lambda の `/elementary/home` 直アクセスで `/switch` redirect する hook / load の特定) | `(child)/+layout.server.ts` L52-54 の `if (!childIdStr) redirect(302, '/switch')` (selectedChildId cookie 不在時の子供選択 UX redirect) を特定。**認証 challenge ではない** | `src/routes/(child)/+layout.server.ts` 該当箇所コード参照 |
| AC2 | 2 spec が PASS する修正 (どちらかが期待する動作 = spec / 実装を整合) | spec 側を実装の事実 (ADR-0013 LP truth) に整合させる方向で修正 (実装側変更なし)。1) AC11-5: 「認証 challenge 無し」を `not.toHaveURL(/auth/login)` で直接 assert + cookie pre-set 時の直描画を 2 ケース構成で assert。2) bug4 POST: SvelteKit `use:enhance` の action redirect 形式 (`HTTP 200 + body {type: 'redirect', location}`) を body parse で弁別、demo no-op (`{demo: true}`) との 2 way 識別 | `tests/e2e/demo-lambda/anonymous-no-mode-param.spec.ts:76-110` / `tests/e2e/demo-lambda/bug4-switch-click.spec.ts:80-117` |
| AC3 | main / 本 PR で `e2e-demo-lambda` が PASS | ローカル `playwright.demo.config.ts` で 11 ケース全 PASS、CI 結果は PR push 後の e2e-demo-lambda ジョブ参照 | `npx playwright test tests/e2e/demo-lambda/anonymous-no-mode-param.spec.ts tests/e2e/demo-lambda/bug4-switch-click.spec.ts --config=playwright.demo.config.ts` → `11 passed (13.1s)` |
| AC4 | pre-ready PASS | `npm run pre-ready -- --pr <num>` 全 10 step PASS | 後述「テスト & 安全装置セルフチェック」参照 |

## 変更タイプ

- [x] test: テスト改善 (spec 期待値修正)
- [x] fix: バグ修正 (CI gate の偽陽性解消)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] テストのみ (`tests/e2e/demo-lambda/`)

**影響を受ける画面・機能**:
- 影響なし (実装側変更なし、テスト spec のみ修正)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— PR 番号確定後 push 前に実行確認
- [x] 追加・変更したテストの概要:
  - `tests/e2e/demo-lambda/anonymous-no-mode-param.spec.ts` AC11-5 を 2 ケース構成に書換 (case a: cookie 未設定で `/auth/login` redirect しない / case b: cookie pre-set で home 直描画)
  - `tests/e2e/demo-lambda/bug4-switch-click.spec.ts` POST observation を SvelteKit action redirect 形式の body parse assertion に書換 (status 303 → status 200 + body `{type: 'redirect'}` 検証 + demo no-op `{demo: true}` 不在検証)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: priority:high (priority:critical 未指定、ADR-0002 5 要件は対象外)

## スクリーンショット / ビジュアルデモ

**該当なし**: テスト spec のみ修正、UI 変更なし (`.svelte` / `.css` / `site/**` 一切変更なし)。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A (UI 変更なし) | N/A (UI 変更なし) |
| **修正後** | N/A (UI 変更なし) | N/A (UI 変更なし) |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: spec の役割 (実装挙動の不変条件 assertion) を保持しつつ、実装の事実に整合する形に refactor のみ
- [x] **DRY**: 5 click 個別テストと POST observation が重複していたため、observation は body 形式弁別に絞り込み (click テストと役割分離)
- [x] **YAGNI**: cookie pre-set ケースは capture-hp-screenshots.mjs と同じ pattern を採用、独自 helper は追加せず
- [x] **Security**: N/A (テスト spec のみ)
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A (spec 実行時間ほぼ変化なし、11 ケース 13.1s)

## 横展開・影響波及チェック

- [x] N/A — テスト spec のみ修正、並行実装 / 設計書 / labels に影響なし
- [x] **設計書同期** (ADR-0001): 該当なし (テスト spec のみ)
- [x] **並行 PR overlap** (#1200): 同 spec を変更する open PR を確認、衝突なし

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:

1. **AC11-5 の旧期待 (直描画) を放棄した妥当性**: `(child)/+layout.server.ts` の selectedChildId cookie 必須仕様は demo / 本番 cognito 共通の UX 仕様 (子供選択画面)。これを「認証 challenge」と誤認していた旧 spec の前提を否定する判断について、QA レビューで本記述に同意いただきたい
2. **bug4 POST の body parse 方式**: SvelteKit `use:enhance` 経由 form action は `HTTP 200 + body {type:'redirect', location}` を返す ([SvelteKit 公式実装](https://github.com/sveltejs/kit/blob/main/packages/kit/src/runtime/server/page/actions.js) `action_json_redirect()` 関数 SSOT)。raw HTTP 303 を期待した旧 spec は SvelteKit 仕様と不整合。body 形式弁別による「demo no-op 化 (`{demo: true}`) 検出」も維持されているので Bug 4 回帰検出は劣化していない
3. **scope 外 fail の扱い**: 同 e2e-demo-lambda ジョブで visual-equality.spec.ts (5 ケース) + demo-marketplace-seed.spec.ts (1 ケース) も連続 fail しているが本 Issue #2282 の AC スコープ外。前者は AC11-5 と同根 (cookie 不在 → /switch redirect)、後者は marketplace seed timing/event-pool 連携の別問題。本 PR merge 後、PO 判断で別 Issue 起票を依頼

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み (不要な差分・デバッグコードなし、diff 59 insertions / 15 deletions の最小範囲)
- [x] 全 AC が実装済み (AC1-4 すべて検証マップに記入)
- [x] Phase 分割なし
- [x] UI 変更なし
- [x] 認証画面変更なし

## QM レビュー結果

<!-- QM が記入 -->
