### PR TITLE
feat: #2297 マーケプレ challenge-set type 拡張 + 日本年間行事パック (EPIC #2294 ③)

### DIFF
--- a/docs/design/parallel-implementations.md
+++ b/docs/design/parallel-implementations.md
@@ -292,6 +292,37 @@ grep -n "bottom-nav\|data-testid" src/lib/ui/components/BottomNav.svelte
 - 重複検知ロジック (`sameSourceTitles`) 変更 → unit テスト 3 件 (「同一 preset 同一 title」/「別 preset 同名」/「sourcePresetId=null 手動 reward」) で誤検知ガード
 - reward の即時付与（grant）と一括取込（import）の区別: 一括取込は **point 加算しない**（"候補登録"）。grant は `insertPointEntry` を呼ぶ
 
+#### 7e. marketplace challenge-set 一括追加 (#2297, EPIC #2294 ③)
+
+`src/lib/data/marketplace/challenge-sets/*.json` (現状 1 件: 日本年間行事パック 15 件入り) は **マーケットプレイス詳細ページ → /admin/challenges 画面**の動線で一括取込される。`MarketplaceItemType` を 4 → 5 type に拡張した実装。
+
+**並行実装ペア (`MarketplaceItemType` 拡張時の同期対象)**:
+
+| 場所 | 内容 | 技術 |
+|------|------|------|
+| `src/lib/domain/marketplace-item.ts` | `MarketplaceItemType` enum + `MarketplacePayloadMap` + `MARKETPLACE_TYPE_LABELS` + `MARKETPLACE_TYPE_ICONS` + 新規 `ChallengeSetPayload` interface | TypeScript |
+| `src/lib/data/marketplace/challenge-sets/*.json` | challenge-set preset (15 件入りパック等) | JSON |
+| `src/lib/data/marketplace/index.ts` | `allItems` 配列 + `getMarketplaceCounts` + `countPayloadItems` | TypeScript |
+| `src/routes/marketplace/+page.svelte` | `typeKeys` 配列 (5 type) + grid-cols mobile 2 列 / SP 3 列 / desktop 5 列 | Svelte |
+| `src/routes/marketplace/[type]/[itemId]/+page.server.ts` | `VALID_TYPES` 配列 | TypeScript |
+| `src/routes/marketplace/[type]/[itemId]/+page.svelte` | challenge-set 詳細表示 + 「使ってみる」CTA → `/admin/challenges?marketplace-import=<id>` 遷移 | Svelte |
+| `src/routes/(parent)/admin/challenges/+page.{svelte,server.ts}` | `marketplace-import` query 受取 → preview UI + `?/importChallengeSet` form action (一括 `createSiblingChallenge` ループ) | Svelte / TS |
+| `src/lib/domain/labels.ts` | `MARKETPLACE_LABELS.detailIncludedChallenges` / `detailCtaImportChallengeSet*` | TypeScript |
+
+**同期メカニズム**: `tests/unit/domain/marketplace-items.test.ts` で type enum 完全性確認 + `tests/e2e/marketplace-challenge-set-import.spec.ts` で詳細 → admin 遷移 → 一括追加フロー検証。
+
+**AN-5 補強 (#2180 観察 4 #2297 関連)**: `MarketplaceItemType` 拡張時は以下を全件触ること:
+1. `marketplace-item.ts` enum + Payload interface + LABEL/ICON 4 箇所
+2. `marketplace/index.ts` の `countPayloadItems` + `getMarketplaceCounts`
+3. `routes/marketplace/+page.svelte` `typeKeys` + grid-cols
+4. `routes/marketplace/[type]/[itemId]/+page.server.ts` `VALID_TYPES`
+5. `routes/marketplace/[type]/[itemId]/+page.svelte` 表示 block + CTA block
+6. import 先 admin 画面 (`/admin/<type-target>`) に query param 受取り + preview UI + form action
+
+**修正時チェック**:
+- 新しい challenge-set preset 追加 → `marketplaceImport` 先のチャレンジ展開ロジック (`expandChallengeSetDates`) で当該 monthDay/durationDays が正しく実日付に展開されるか単体確認
+- `MarketplaceItemType` enum 追加時は本表 6 項目全件のうち 1 つでも漏れると svelte-check or runtime で fail する設計
+
 ---
 
 #### 8. 設計書 vs 実装

--- a/docs/design/parallel-implementations.md
+++ b/docs/design/parallel-implementations.md
@@ -320,7 +320,7 @@ grep -n "bottom-nav\|data-testid" src/lib/ui/components/BottomNav.svelte
 6. import 先 admin 画面 (`/admin/<type-target>`) に query param 受取り + preview UI + form action
 
 **修正時チェック**:
-- 新しい challenge-set preset 追加 → `marketplaceImport` 先のチャレンジ展開ロジック (`expandChallengeSetDates`) で当該 monthDay/durationDays が正しく実日付に展開されるか単体確認
+- 新しい challenge-set preset 追加 → `marketplaceImport` 先のチャレンジ展開ロジック (`_expandChallengeSetDates`、SvelteKit `+page.server.ts` の予約 export 制約により `_` 接頭辞) で当該 monthDay/durationDays が正しく実日付に展開されるか単体確認
 - `MarketplaceItemType` enum 追加時は本表 6 項目全件のうち 1 つでも漏れると svelte-check or runtime で fail する設計
 
 ---

--- a/src/lib/data/marketplace/challenge-sets/japan-annual-events.json
+++ b/src/lib/data/marketplace/challenge-sets/japan-annual-events.json
@@ -1,0 +1,167 @@
+{
+	"type": "challenge-set",
+	"itemId": "japan-annual-events",
+	"name": "日本年間行事パック",
+	"description": "お正月・節分・ひな祭り・こどもの日・七夕・お盆・お月見・ハロウィン・クリスマス…。家族で取り組む日本の年中行事 15 件をまとめた協力チャレンジ集です。",
+	"icon": "🎌",
+	"targetAgeMin": 4,
+	"targetAgeMax": 15,
+	"tags": ["年中行事", "日本文化", "家族で取り組む", "季節"],
+	"personas": ["routine-focused", "achievement-focused", "first-child", "sibling"],
+	"curator": "official",
+	"gender": "neutral",
+	"payload": {
+		"challenges": [
+			{
+				"title": "お正月の家族ミッション",
+				"description": "おせちのお手伝い・年賀状書き・大掃除の総仕上げ。家族で新しい年をむかえる準備をしよう。",
+				"monthDay": "01-07",
+				"durationDays": 7,
+				"categoryId": 3,
+				"baseTarget": 5,
+				"rewardPoints": 50,
+				"icon": "🎍"
+			},
+			{
+				"title": "節分の鬼退治チャレンジ",
+				"description": "豆まきの準備・恵方巻きづくり・節分の絵本読み。家族で福をよびこむ協力ミッション。",
+				"monthDay": "02-03",
+				"durationDays": 3,
+				"categoryId": 4,
+				"baseTarget": 3,
+				"rewardPoints": 30,
+				"icon": "👹"
+			},
+			{
+				"title": "ひな祭り大そうじ + 飾りつけ",
+				"description": "ひな人形の飾りつけ・お部屋のお片付け・ちらし寿司のお手伝い。",
+				"monthDay": "03-03",
+				"durationDays": 3,
+				"categoryId": 3,
+				"baseTarget": 3,
+				"rewardPoints": 30,
+				"icon": "🎎"
+			},
+			{
+				"title": "春のお花見じゅんびチャレンジ",
+				"description": "桜のかんさつ・お弁当のお手伝い・公園での自然あそび。",
+				"monthDay": "04-05",
+				"durationDays": 7,
+				"categoryId": 1,
+				"baseTarget": 5,
+				"rewardPoints": 40,
+				"icon": "🌸"
+			},
+			{
+				"title": "こどもの日プロジェクト",
+				"description": "こいのぼり飾りつけ・かぶと作り・しょうぶ湯のじゅんび。家族でお祝いしよう。",
+				"monthDay": "05-05",
+				"durationDays": 5,
+				"categoryId": 5,
+				"baseTarget": 4,
+				"rewardPoints": 50,
+				"icon": "🎏"
+			},
+			{
+				"title": "梅雨のおうち時間チャレンジ",
+				"description": "雨の日でも楽しめる読書・工作・室内うんどう。家族で『雨の日リスト』を消化していこう。",
+				"monthDay": "06-15",
+				"durationDays": 14,
+				"categoryId": 5,
+				"baseTarget": 10,
+				"rewardPoints": 60,
+				"icon": "☔"
+			},
+			{
+				"title": "七夕短冊チャレンジ",
+				"description": "短冊にねがいごとを書く・笹かざりを作る・夜空の星をみる。",
+				"monthDay": "07-07",
+				"durationDays": 7,
+				"categoryId": 5,
+				"baseTarget": 3,
+				"rewardPoints": 30,
+				"icon": "🎋"
+			},
+			{
+				"title": "夏休み読書記録チャレンジ",
+				"description": "夏休みの自由読書を家族でカウントアップ。読書感想文の下じゅんびにも。",
+				"monthDay": "08-31",
+				"durationDays": 42,
+				"categoryId": 2,
+				"baseTarget": 10,
+				"rewardPoints": 100,
+				"icon": "📚"
+			},
+			{
+				"title": "お盆のおてつだいチャレンジ",
+				"description": "お墓まいり・親せきのおむかえ・夏野菜のおてつだい。",
+				"monthDay": "08-15",
+				"durationDays": 5,
+				"categoryId": 4,
+				"baseTarget": 3,
+				"rewardPoints": 30,
+				"icon": "🏮"
+			},
+			{
+				"title": "お月見だんご作りチャレンジ",
+				"description": "お月見だんごを家族で作る・ススキを飾る・夜にお月さまをかんさつ。",
+				"monthDay": "09-21",
+				"durationDays": 5,
+				"categoryId": 5,
+				"baseTarget": 3,
+				"rewardPoints": 30,
+				"icon": "🌕"
+			},
+			{
+				"title": "敬老の日メッセージ",
+				"description": "おじいちゃん・おばあちゃんへ手紙やイラストを書く・電話する・直接会いに行く。",
+				"monthDay": "09-15",
+				"durationDays": 7,
+				"categoryId": 4,
+				"baseTarget": 3,
+				"rewardPoints": 50,
+				"icon": "👴"
+			},
+			{
+				"title": "ハロウィン仮装プロジェクト",
+				"description": "仮装の準備・かぼちゃのランタン作り・お菓子の交換。家族でハロウィンを楽しもう。",
+				"monthDay": "10-31",
+				"durationDays": 7,
+				"categoryId": 5,
+				"baseTarget": 4,
+				"rewardPoints": 40,
+				"icon": "🎃"
+			},
+			{
+				"title": "七五三の準備チャレンジ",
+				"description": "晴れ着の用意・写真撮影の前じゅんび・神社へのお参り。",
+				"monthDay": "11-15",
+				"durationDays": 7,
+				"categoryId": 3,
+				"baseTarget": 3,
+				"rewardPoints": 30,
+				"icon": "👘"
+			},
+			{
+				"title": "クリスマス家族プロジェクト",
+				"description": "ツリーの飾りつけ・プレゼント準備のお手伝い・ケーキ作り・家族で歌う。",
+				"monthDay": "12-25",
+				"durationDays": 10,
+				"categoryId": 5,
+				"baseTarget": 5,
+				"rewardPoints": 60,
+				"icon": "🎄"
+			},
+			{
+				"title": "年末大そうじチャレンジ",
+				"description": "家族で分担して大そうじ。窓ふき・げんかん・お風呂・自分のお部屋まで。",
+				"monthDay": "12-31",
+				"durationDays": 7,
+				"categoryId": 3,
+				"baseTarget": 7,
+				"rewardPoints": 70,
+				"icon": "🧹"
+			}
+		]
+	}
+}

--- a/src/lib/data/marketplace/index.ts
+++ b/src/lib/data/marketplace/index.ts
@@ -22,6 +22,8 @@ import kinderStarter from './activity-packs/kinder-starter.json';
 import seniorBoy from './activity-packs/senior-boy.json';
 import seniorGirl from './activity-packs/senior-girl.json';
 import seniorHighChallenge from './activity-packs/senior-high-challenge.json';
+// ── Challenge Sets (#2297, EPIC #2294 ③) ────────────────────
+import japanAnnualEvents from './challenge-sets/japan-annual-events.json';
 // ── Checklists ──────────────────────────────────────────────
 // #1758 (#1709-D): morning/evening/weekend × 4 年齢 = 12 件削除（持ち物純化）
 // 旧 routine 系 checklist は activities.priority='must'（#1755）に役割移管済み。
@@ -40,7 +42,6 @@ import privilegeRewards from './reward-sets/privilege-rewards.json';
 import screenTimeRewards from './reward-sets/screen-time-rewards.json';
 import seniorRewards from './reward-sets/senior-rewards.json';
 import toddlerRewards from './reward-sets/toddler-rewards.json';
-
 // ── Rule Presets ────────────────────────────────────────────
 import categoryChallenge from './rule-presets/category-challenge.json';
 import choreSkip from './rule-presets/chore-skip.json';
@@ -95,6 +96,8 @@ const allItems: MarketplaceItem[] = [
 	siblingCoop,
 	weekendSpecial,
 	selfStudyReward,
+	// Challenge sets (#2297, EPIC #2294 ③)
+	japanAnnualEvents,
 ] as unknown as MarketplaceItem[];
 
 const itemMap = new Map<string, MarketplaceItem>();
@@ -110,6 +113,8 @@ function countPayloadItems(item: MarketplaceItem): number {
 	if ('rewards' in p) return (p.rewards as unknown[]).length;
 	if ('items' in p) return (p.items as unknown[]).length;
 	if ('rules' in p) return (p.rules as unknown[]).length;
+	// #2297: challenge-set payload は challenges[] を持つ
+	if ('challenges' in p) return (p.challenges as unknown[]).length;
 	return 0;
 }
 
@@ -161,6 +166,7 @@ export function getMarketplaceCounts(): Record<MarketplaceItemType, number> {
 		'reward-set': 0,
 		checklist: 0,
 		'rule-preset': 0,
+		'challenge-set': 0,
 	};
 	for (const item of allItems) {
 		counts[item.type]++;

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -870,6 +870,12 @@ export const MARKETPLACE_LABELS = {
 	detailRuleContent: 'ルール内容',
 	/** #2297 (EPIC #2294 ③): challenge-set ふくまれるチャレンジ見出し */
 	detailIncludedChallenges: 'ふくまれるチャレンジ',
+	/** #2297: 各 challenge のメタ表記 (monthDay ・ durationDays日間) */
+	detailChallengePeriod: (monthDay: string, durationDays: number) =>
+		`${monthDay}・${durationDays}日間`,
+	/** #2297: 各 challenge の詳細行 (カテゴリ ・ 目標 N回 ・ ごほうび +NP) */
+	detailChallengeMeta: (category: string, baseTarget: number, rewardPoints: number) =>
+		`${category} ・ 目標 ${baseTarget}回 ・ ごほうび +${rewardPoints}P`,
 	detailLegacyPackNote: '既存の活動パックから使えるようになります。詳しくは',
 	detailLegacyPackLink: 'パック詳細ページ',
 	detailLegacyPackSuffix: 'をご覧ください。',
@@ -2641,6 +2647,20 @@ export const CHALLENGES_LABELS = {
 	categorySeikatsu: 'せいかつ',
 	categoryKouryuu: 'こうりゅう',
 	categorySouzou: 'そうぞう',
+
+	// #2297 (EPIC #2294 ③): マーケプレ challenge-set 一括 import 確認 UI
+	importIcon: '🎯',
+	importHeading: (presetName: string) => `「${presetName}」を一括追加します`,
+	importTotalDesc: (count: number) =>
+		`合計 ${count}件のチャレンジを追加します。期間は当該行事の日付から自動展開されます。`,
+	importBreakdownSummary: '内訳を確認',
+	importItemSuffix: (monthDay: string, durationDays: number) =>
+		`（${monthDay} ・ ${durationDays}日間）`,
+	importCancel: 'キャンセル',
+	importSubmit: (count: number) => `${count}件 一括追加`,
+	importSuccessNotice: (presetName: string, count: number) =>
+		`✨ 「${presetName}」から ${count}件のチャレンジを追加しました`,
+	importErrorSummary: (count: number) => `エラー詳細 (${count}件)`,
 } as const;
 
 // ============================================================

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -868,6 +868,8 @@ export const MARKETPLACE_LABELS = {
 	detailIncludedRewards: 'ふくまれるごほうび',
 	detailChecklistItems: 'チェック項目',
 	detailRuleContent: 'ルール内容',
+	/** #2297 (EPIC #2294 ③): challenge-set ふくまれるチャレンジ見出し */
+	detailIncludedChallenges: 'ふくまれるチャレンジ',
 	detailLegacyPackNote: '既存の活動パックから使えるようになります。詳しくは',
 	detailLegacyPackLink: 'パック詳細ページ',
 	detailLegacyPackSuffix: 'をご覧ください。',
@@ -923,6 +925,17 @@ export const MARKETPLACE_LABELS = {
 	detailCtaImportRuleSignedOut: '一括追加するには登録 / ログインが必要です',
 	detailRuleImportLinkToBonusList: '取込済ルール一覧へ →',
 	detailRuleImportLinkToRewardsList: 'ごほうび一覧へ →',
+	// #2297 (EPIC #2294 ③): challenge-set 一括追加 CTA
+	detailCtaImportChallengeSet: '🎯 このチャレンジ集を使ってみる',
+	detailCtaImportChallengeSetWithCount: (count: number) =>
+		`🎯 このチャレンジ集を使ってみる (${count}件)`,
+	detailCtaImportChallengeSetDesc:
+		'家族の見守り画面でフォームに反映されます。家族でお祝いしたい行事だけ選んで保存してください。',
+	detailCtaImportChallengeSetSignedOut: 'チャレンジ集を使うには登録 / ログインが必要です',
+	detailChallengeSetImportSuccess: (presetName: string, count: number) =>
+		`✨ 「${presetName}」から ${count} 件のチャレンジを追加しました`,
+	detailChallengeSetImportDuplicate: (presetName: string) =>
+		`⚠️ 「${presetName}」は既に取込済みです`,
 	backToTypeListSuffix: '一覧に戻る',
 	typeCountSuffix: '種',
 } as const;

--- a/src/lib/domain/marketplace-item.ts
+++ b/src/lib/domain/marketplace-item.ts
@@ -12,7 +12,15 @@ import type { RewardCategory } from './validation/special-reward.js';
 
 // ── Content Type ─────────────────────────────────────────────
 
-export type MarketplaceItemType = 'activity-pack' | 'reward-set' | 'checklist' | 'rule-preset';
+// #2297 (EPIC #2294 ③): challenge-set 追加 (4 type → 5 type)。
+// 案 B-γ 日本ローカライズ wedge: 日本年間行事パック (15 件入り) 等を配信し
+// マーケプレ → /admin/challenges import 経路を確立。
+export type MarketplaceItemType =
+	| 'activity-pack'
+	| 'reward-set'
+	| 'checklist'
+	| 'rule-preset'
+	| 'challenge-set';
 
 // ── Persona Tags ─────────────────────────────────────────────
 
@@ -116,6 +124,26 @@ export interface RulePresetPayload {
 	}[];
 }
 
+// #2297 (EPIC #2294 ③): challenge-set payload
+// 協力タイプ固定 (EPIC #2294 ② で競争タイプ UI 削除のため challenge-set でも cooperative 固定)。
+// startDate / endDate は 'MM-DD' 形式 (毎年同月日に開催される年間行事の論理表現)。
+// import 時は service 側で当該年の日付に展開する。
+export interface ChallengeSetPayload {
+	challenges: {
+		title: string;
+		description: string;
+		/** 'MM-DD' (例: '03-03' = ひな祭り) */
+		monthDay: string;
+		/** 期間 (日数)。startDate = monthDay の N 日前。endDate = monthDay。 */
+		durationDays: number;
+		/** 1=undou 2=benkyou 3=seikatsu 4=kouryuu 5=souzou */
+		categoryId: 1 | 2 | 3 | 4 | 5;
+		baseTarget: number;
+		rewardPoints: number;
+		icon: string;
+	}[];
+}
+
 // ── Payload type map ─────────────────────────────────────────
 
 export interface MarketplacePayloadMap {
@@ -123,6 +151,7 @@ export interface MarketplacePayloadMap {
 	'reward-set': RewardSetPayload;
 	checklist: ChecklistPayload;
 	'rule-preset': RulePresetPayload;
+	'challenge-set': ChallengeSetPayload;
 }
 
 // ── Unified MarketplaceItem ──────────────────────────────────
@@ -171,6 +200,7 @@ export const MARKETPLACE_TYPE_LABELS: Record<MarketplaceItemType, string> = {
 	'reward-set': 'ごほうびセット',
 	checklist: 'チェックリスト',
 	'rule-preset': 'とくべつルール',
+	'challenge-set': 'チャレンジ集',
 };
 
 export const MARKETPLACE_TYPE_ICONS: Record<MarketplaceItemType, string> = {
@@ -178,4 +208,5 @@ export const MARKETPLACE_TYPE_ICONS: Record<MarketplaceItemType, string> = {
 	'reward-set': '🎁',
 	checklist: '✅',
 	'rule-preset': '📜',
+	'challenge-set': '🎯',
 };

--- a/src/routes/(parent)/admin/challenges/+page.server.ts
+++ b/src/routes/(parent)/admin/challenges/+page.server.ts
@@ -171,7 +171,11 @@ export const actions: Actions = {
 
 		for (const ch of payload.challenges) {
 			try {
-				const { startDate, endDate } = _expandChallengeSetDates(ch.monthDay, ch.durationDays, today);
+				const { startDate, endDate } = _expandChallengeSetDates(
+					ch.monthDay,
+					ch.durationDays,
+					today,
+				);
 				const targetConfig = JSON.stringify({
 					metric: 'count',
 					baseTarget: ch.baseTarget,

--- a/src/routes/(parent)/admin/challenges/+page.server.ts
+++ b/src/routes/(parent)/admin/challenges/+page.server.ts
@@ -1,5 +1,7 @@
 import { fail } from '@sveltejs/kit';
+import { getMarketplaceItem } from '$lib/data/marketplace';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import type { ChallengeSetPayload } from '$lib/domain/marketplace-item';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getAllChildren } from '$lib/server/services/child-service';
 import { getFamilyStreak, getNextMilestone } from '$lib/server/services/family-streak-service';
@@ -11,7 +13,39 @@ import {
 } from '$lib/server/services/sibling-challenge-service';
 import type { Actions, PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals }) => {
+/**
+ * #2297 (EPIC #2294 ③): challenge-set 一括追加用ヘルパー
+ *
+ * preset の `monthDay` ('MM-DD') と `durationDays` から、現在年または翌年の
+ * 実日付に展開する。monthDay が「今日より過去」なら来年の同月日とする
+ * (例: 2026/05/19 時点で「03-03 ひな祭り」を import すると 2027/03/03 になる)。
+ *
+ * @internal export しているのは unit test 用
+ */
+export function expandChallengeSetDates(
+	monthDay: string,
+	durationDays: number,
+	today: Date = new Date(),
+): { startDate: string; endDate: string } {
+	const [mm, dd] = monthDay.split('-').map(Number);
+	if (!mm || !dd) {
+		throw new Error(`Invalid monthDay format: ${monthDay} (expected MM-DD)`);
+	}
+	const year = today.getFullYear();
+	// 候補 1: 今年の monthDay
+	let endDate = new Date(Date.UTC(year, mm - 1, dd));
+	const todayUTC = new Date(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate()));
+	// 既に過ぎていれば来年扱い
+	if (endDate.getTime() < todayUTC.getTime()) {
+		endDate = new Date(Date.UTC(year + 1, mm - 1, dd));
+	}
+	const startDate = new Date(endDate.getTime());
+	startDate.setUTCDate(startDate.getUTCDate() - durationDays + 1);
+	const fmt = (d: Date) => d.toISOString().slice(0, 10);
+	return { startDate: fmt(startDate), endDate: fmt(endDate) };
+}
+
+export const load: PageServerLoad = async ({ locals, url }) => {
 	const tenantId = requireTenantId(locals);
 	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const planTier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
@@ -27,7 +61,29 @@ export const load: PageServerLoad = async ({ locals }) => {
 		nextMilestone: getNextMilestone(familyStreakData.currentStreak),
 	};
 
-	return { challenges, children, planTier, familyStreak };
+	// #2297 (EPIC #2294 ③): marketplace-import=<presetId> query param で
+	// マーケプレ challenge-set を一括追加できるよう、preview 情報を pre-fill 候補として返す
+	const importPresetId = url.searchParams.get('marketplace-import');
+	let marketplaceImport: {
+		presetId: string;
+		presetName: string;
+		presetDescription: string;
+		challenges: ChallengeSetPayload['challenges'];
+	} | null = null;
+	if (importPresetId) {
+		const item = getMarketplaceItem('challenge-set', importPresetId);
+		if (item) {
+			const payload = item.payload as ChallengeSetPayload;
+			marketplaceImport = {
+				presetId: item.itemId,
+				presetName: item.name,
+				presetDescription: item.description,
+				challenges: payload.challenges,
+			};
+		}
+	}
+
+	return { challenges, children, planTier, familyStreak, marketplaceImport };
 };
 
 export const actions: Actions = {
@@ -95,5 +151,57 @@ export const actions: Actions = {
 
 		await deleteSiblingChallenge(id, tenantId);
 		return { deleted: true };
+	},
+
+	// #2297 (EPIC #2294 ③): マーケプレ challenge-set 一括 import
+	importChallengeSet: async ({ request, locals }) => {
+		const tenantId = requireTenantId(locals);
+		const fd = await request.formData();
+		const presetId = String(fd.get('presetId') ?? '').trim();
+		if (!presetId) return fail(400, { error: 'presetId が必要です' });
+
+		const item = getMarketplaceItem('challenge-set', presetId);
+		if (!item) return fail(404, { error: 'チャレンジ集が見つかりません' });
+
+		const payload = item.payload as ChallengeSetPayload;
+		const today = new Date();
+		let imported = 0;
+		const errors: string[] = [];
+
+		for (const ch of payload.challenges) {
+			try {
+				const { startDate, endDate } = expandChallengeSetDates(ch.monthDay, ch.durationDays, today);
+				const targetConfig = JSON.stringify({
+					metric: 'count',
+					baseTarget: ch.baseTarget,
+					categoryId: ch.categoryId,
+				});
+				const rewardConfig = JSON.stringify({ points: ch.rewardPoints });
+				await createSiblingChallenge(
+					{
+						title: ch.title,
+						description: ch.description,
+						challengeType: 'cooperative',
+						periodType: 'custom',
+						startDate,
+						endDate,
+						targetConfig,
+						rewardConfig,
+					},
+					tenantId,
+				);
+				imported++;
+			} catch (e) {
+				errors.push(`${ch.title}: ${e instanceof Error ? e.message : String(e)}`);
+			}
+		}
+
+		return {
+			challengeSetImport: {
+				presetName: item.name,
+				imported,
+				errors,
+			},
+		};
 	},
 };

--- a/src/routes/(parent)/admin/challenges/+page.server.ts
+++ b/src/routes/(parent)/admin/challenges/+page.server.ts
@@ -20,9 +20,10 @@ import type { Actions, PageServerLoad } from './$types';
  * 実日付に展開する。monthDay が「今日より過去」なら来年の同月日とする
  * (例: 2026/05/19 時点で「03-03 ひな祭り」を import すると 2027/03/03 になる)。
  *
- * @internal export しているのは unit test 用
+ * @internal export しているのは unit test 用 (SvelteKit `+page.server.ts` の予約 export
+ *           制約により `_` 接頭辞が必須 — anything with a '_' prefix が許可される)
  */
-export function expandChallengeSetDates(
+export function _expandChallengeSetDates(
 	monthDay: string,
 	durationDays: number,
 	today: Date = new Date(),
@@ -170,7 +171,7 @@ export const actions: Actions = {
 
 		for (const ch of payload.challenges) {
 			try {
-				const { startDate, endDate } = expandChallengeSetDates(ch.monthDay, ch.durationDays, today);
+				const { startDate, endDate } = _expandChallengeSetDates(ch.monthDay, ch.durationDays, today);
 				const targetConfig = JSON.stringify({
 					metric: 'count',
 					baseTarget: ch.baseTarget,

--- a/src/routes/(parent)/admin/challenges/+page.svelte
+++ b/src/routes/(parent)/admin/challenges/+page.svelte
@@ -136,27 +136,27 @@ const categories: Record<number, string> = {
 			data-testid="marketplace-challenge-set-import"
 		>
 			<div class="flex items-start gap-2">
-				<span class="text-2xl">🎯</span>
+				<span class="text-2xl">{CHALLENGES_LABELS.importIcon}</span>
 				<div class="flex-1">
 					<h3 class="font-bold text-sm text-[var(--color-feedback-info-text)]">
-						「{data.marketplaceImport.presetName}」を一括追加します
+						{CHALLENGES_LABELS.importHeading(data.marketplaceImport.presetName)}
 					</h3>
 					<p class="text-xs text-[var(--color-feedback-info-text)] mt-1">
 						{data.marketplaceImport.presetDescription}
 					</p>
 					<p class="text-xs text-[var(--color-text-secondary)] mt-2">
-						合計 {data.marketplaceImport.challenges.length}件のチャレンジを追加します。期間は当該行事の日付から自動展開されます。
+						{CHALLENGES_LABELS.importTotalDesc(data.marketplaceImport.challenges.length)}
 					</p>
 				</div>
 			</div>
 			<details class="text-xs text-[var(--color-text-secondary)]">
-				<summary class="cursor-pointer font-medium">内訳を確認</summary>
+				<summary class="cursor-pointer font-medium">{CHALLENGES_LABELS.importBreakdownSummary}</summary>
 				<ul class="mt-2 space-y-1 ml-4 list-disc">
 					{#each data.marketplaceImport.challenges as ch (ch.title)}
 						<li>
 							<span class="font-medium">{ch.title}</span>
 							<span class="text-[var(--color-text-tertiary)]">
-								（{ch.monthDay} ・ {ch.durationDays + '日間'}）
+								{CHALLENGES_LABELS.importItemSuffix(ch.monthDay, ch.durationDays)}
 							</span>
 						</li>
 					{/each}
@@ -167,7 +167,7 @@ const categories: Record<number, string> = {
 					href="/admin/challenges"
 					class="px-3 py-1.5 text-xs font-medium rounded-lg bg-[var(--color-surface-muted)] text-[var(--color-text-primary)]"
 				>
-					キャンセル
+					{CHALLENGES_LABELS.importCancel}
 				</a>
 				<form method="POST" action="?/importChallengeSet" use:enhance>
 					<input type="hidden" name="presetId" value={data.marketplaceImport.presetId} />
@@ -177,7 +177,7 @@ const categories: Record<number, string> = {
 						size="sm"
 						data-testid="marketplace-challenge-set-import-submit"
 					>
-						{data.marketplaceImport.challenges.length}件 一括追加
+						{CHALLENGES_LABELS.importSubmit(data.marketplaceImport.challenges.length)}
 					</Button>
 				</form>
 			</div>
@@ -188,10 +188,13 @@ const categories: Record<number, string> = {
 			class="rounded-lg bg-[var(--color-feedback-success-bg)] p-3 text-sm text-[var(--color-feedback-success-text)]"
 			data-testid="marketplace-challenge-set-import-result"
 		>
-			✨ 「{form.challengeSetImport.presetName}」から {form.challengeSetImport.imported}件のチャレンジを追加しました
+			{CHALLENGES_LABELS.importSuccessNotice(
+				form.challengeSetImport.presetName,
+				form.challengeSetImport.imported,
+			)}
 			{#if (form.challengeSetImport.errors ?? []).length > 0}
 				<details class="mt-1 text-xs">
-					<summary>エラー詳細 ({form.challengeSetImport.errors.length}件)</summary>
+					<summary>{CHALLENGES_LABELS.importErrorSummary(form.challengeSetImport.errors.length)}</summary>
 					<ul class="ml-4 list-disc">
 						{#each form.challengeSetImport.errors as err}
 							<li>{err}</li>

--- a/src/routes/(parent)/admin/challenges/+page.svelte
+++ b/src/routes/(parent)/admin/challenges/+page.svelte
@@ -129,6 +129,79 @@ const categories: Record<number, string> = {
 		<div class="rounded-lg bg-[var(--color-surface-muted)] p-3 text-sm text-[var(--color-text-primary)]">{CHALLENGES_LABELS.deletedNotice}</div>
 	{/if}
 
+	<!-- #2297 (EPIC #2294 ③): マーケプレ challenge-set 一括 import 確認 UI -->
+	{#if data.marketplaceImport}
+		<div
+			class="rounded-xl border border-[var(--color-feedback-info-border)] bg-[var(--color-feedback-info-bg)] p-4 space-y-3"
+			data-testid="marketplace-challenge-set-import"
+		>
+			<div class="flex items-start gap-2">
+				<span class="text-2xl">🎯</span>
+				<div class="flex-1">
+					<h3 class="font-bold text-sm text-[var(--color-feedback-info-text)]">
+						「{data.marketplaceImport.presetName}」を一括追加します
+					</h3>
+					<p class="text-xs text-[var(--color-feedback-info-text)] mt-1">
+						{data.marketplaceImport.presetDescription}
+					</p>
+					<p class="text-xs text-[var(--color-text-secondary)] mt-2">
+						合計 {data.marketplaceImport.challenges.length}件のチャレンジを追加します。期間は当該行事の日付から自動展開されます。
+					</p>
+				</div>
+			</div>
+			<details class="text-xs text-[var(--color-text-secondary)]">
+				<summary class="cursor-pointer font-medium">内訳を確認</summary>
+				<ul class="mt-2 space-y-1 ml-4 list-disc">
+					{#each data.marketplaceImport.challenges as ch (ch.title)}
+						<li>
+							<span class="font-medium">{ch.title}</span>
+							<span class="text-[var(--color-text-tertiary)]">
+								（{ch.monthDay} ・ {ch.durationDays + '日間'}）
+							</span>
+						</li>
+					{/each}
+				</ul>
+			</details>
+			<div class="flex gap-2 justify-end">
+				<a
+					href="/admin/challenges"
+					class="px-3 py-1.5 text-xs font-medium rounded-lg bg-[var(--color-surface-muted)] text-[var(--color-text-primary)]"
+				>
+					キャンセル
+				</a>
+				<form method="POST" action="?/importChallengeSet" use:enhance>
+					<input type="hidden" name="presetId" value={data.marketplaceImport.presetId} />
+					<Button
+						type="submit"
+						variant="primary"
+						size="sm"
+						data-testid="marketplace-challenge-set-import-submit"
+					>
+						{data.marketplaceImport.challenges.length}件 一括追加
+					</Button>
+				</form>
+			</div>
+		</div>
+	{/if}
+	{#if form?.challengeSetImport}
+		<div
+			class="rounded-lg bg-[var(--color-feedback-success-bg)] p-3 text-sm text-[var(--color-feedback-success-text)]"
+			data-testid="marketplace-challenge-set-import-result"
+		>
+			✨ 「{form.challengeSetImport.presetName}」から {form.challengeSetImport.imported}件のチャレンジを追加しました
+			{#if (form.challengeSetImport.errors ?? []).length > 0}
+				<details class="mt-1 text-xs">
+					<summary>エラー詳細 ({form.challengeSetImport.errors.length}件)</summary>
+					<ul class="ml-4 list-disc">
+						{#each form.challengeSetImport.errors as err}
+							<li>{err}</li>
+						{/each}
+					</ul>
+				</details>
+			{/if}
+		</div>
+	{/if}
+
 	<!-- 作成フォーム -->
 	{#if creating}
 		<form method="POST" action="?/create" use:enhance class="rounded-xl border bg-white p-4 space-y-3">

--- a/src/routes/marketplace/+page.svelte
+++ b/src/routes/marketplace/+page.svelte
@@ -16,7 +16,14 @@ import Select from '$lib/ui/primitives/Select.svelte';
 
 let { data } = $props();
 
-const typeKeys: MarketplaceItemType[] = ['activity-pack', 'reward-set', 'checklist', 'rule-preset'];
+// #2297 (EPIC #2294 ③): challenge-set 追加で 5 type に拡張
+const typeKeys: MarketplaceItemType[] = [
+	'activity-pack',
+	'reward-set',
+	'checklist',
+	'rule-preset',
+	'challenge-set',
+];
 
 const activeType = $derived(data.filters.type);
 const activeAge = $derived(data.filters.age);
@@ -175,8 +182,8 @@ const genderKeys: MarketplaceGender[] = ['boy', 'girl', 'neutral'];
 			</p>
 		</div>
 
-		<!-- Type counts summary -->
-		<div class="grid grid-cols-4 gap-2 mb-6">
+		<!-- Type counts summary (#2297: 5 type / mobile 2 列・SP 3 列・desktop 5 列) -->
+		<div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2 mb-6">
 			{#each typeKeys as t (t)}
 				<a
 					href={filterUrl({ type: activeType === t ? null : t })}

--- a/src/routes/marketplace/[type]/[itemId]/+page.server.ts
+++ b/src/routes/marketplace/[type]/[itemId]/+page.server.ts
@@ -28,6 +28,8 @@ const VALID_TYPES: MarketplaceItemType[] = [
 	'reward-set',
 	'checklist',
 	'rule-preset',
+	// #2297 (EPIC #2294 ③): challenge-set 詳細ページ対応
+	'challenge-set',
 ];
 
 export const load: PageServerLoad = async ({ params, locals }) => {

--- a/src/routes/marketplace/[type]/[itemId]/+page.svelte
+++ b/src/routes/marketplace/[type]/[itemId]/+page.svelte
@@ -277,13 +277,16 @@ const childOptions = $derived(
 								<span class="text-lg">{ch.icon}</span>
 								<span class="text-sm font-bold text-[var(--color-text-primary)]">{ch.title}</span>
 								<span class="text-[10px] text-[var(--color-text-tertiary)] ml-auto">
-									{ch.monthDay}・{ch.durationDays + '日間'}
+									{MARKETPLACE_LABELS.detailChallengePeriod(ch.monthDay, ch.durationDays)}
 								</span>
 							</div>
 							<p class="text-xs text-[var(--color-text-secondary)] ml-8">{ch.description}</p>
 							<p class="text-xs text-[var(--color-text-tertiary)] ml-8 mt-1">
-								{CATEGORY_LABELS[ch.categoryId] ?? ''} ・ 目標 {ch.baseTarget + '回'}
-								・ ごほうび +{ch.rewardPoints}P
+								{MARKETPLACE_LABELS.detailChallengeMeta(
+									CATEGORY_LABELS[ch.categoryId] ?? '',
+									ch.baseTarget,
+									ch.rewardPoints,
+								)}
 							</p>
 						</div>
 					{/each}

--- a/src/routes/marketplace/[type]/[itemId]/+page.svelte
+++ b/src/routes/marketplace/[type]/[itemId]/+page.svelte
@@ -4,6 +4,7 @@ import { invalidateAll } from '$app/navigation';
 import { APP_LABELS, formatAgeRange, MARKETPLACE_LABELS } from '$lib/domain/labels';
 import type {
 	ActivityPackPayload,
+	ChallengeSetPayload,
 	ChecklistPayload,
 	MarketplaceItem,
 	PersonaTag,
@@ -28,6 +29,18 @@ const isActivityPack = $derived(item.type === 'activity-pack');
 const isRewardSet = $derived(item.type === 'reward-set');
 const isChecklist = $derived(item.type === 'checklist');
 const isRulePreset = $derived(item.type === 'rule-preset');
+// #2297 (EPIC #2294 ③): challenge-set 表示判定
+const isChallengeSet = $derived(item.type === 'challenge-set');
+const challengeSetPayload = $derived(isChallengeSet ? (item.payload as ChallengeSetPayload) : null);
+const challengeCount = $derived(challengeSetPayload?.challenges.length ?? 0);
+// #2297: カテゴリ ID → 名称マッピング (sibling-challenge 5 軸と同一)
+const CATEGORY_LABELS: Record<number, string> = {
+	1: 'うんどう',
+	2: 'べんきょう',
+	3: 'せいかつ',
+	4: 'こうりゅう',
+	5: 'そうぞう',
+};
 
 // #2136 MP-1: reward-set 一括追加 UI 状態
 let selectedChildId = $state<number>(0);
@@ -185,6 +198,8 @@ const childOptions = $derived(
 					{MARKETPLACE_LABELS.detailChecklistItems}
 				{:else if isRulePreset}
 					{MARKETPLACE_LABELS.detailRuleContent}
+				{:else if isChallengeSet}
+					{MARKETPLACE_LABELS.detailIncludedChallenges}
 				{/if}
 			</h2>
 
@@ -250,6 +265,26 @@ const childOptions = $derived(
 									{MARKETPLACE_LABELS.detailRulePointBonus}: +{rule.pointBonus}P
 								</p>
 							{/if}
+						</div>
+					{/each}
+				</div>
+			{:else if isChallengeSet && challengeSetPayload}
+				<!-- #2297 (EPIC #2294 ③): challenge-set 内容プレビュー -->
+				<div class="space-y-2" data-testid="challenge-set-preview">
+					{#each challengeSetPayload.challenges as ch (ch.title)}
+						<div class="p-3 rounded-lg bg-[var(--color-surface-muted)]">
+							<div class="flex items-center gap-2 mb-1">
+								<span class="text-lg">{ch.icon}</span>
+								<span class="text-sm font-bold text-[var(--color-text-primary)]">{ch.title}</span>
+								<span class="text-[10px] text-[var(--color-text-tertiary)] ml-auto">
+									{ch.monthDay}・{ch.durationDays + '日間'}
+								</span>
+							</div>
+							<p class="text-xs text-[var(--color-text-secondary)] ml-8">{ch.description}</p>
+							<p class="text-xs text-[var(--color-text-tertiary)] ml-8 mt-1">
+								{CATEGORY_LABELS[ch.categoryId] ?? ''} ・ 目標 {ch.baseTarget + '回'}
+								・ ごほうび +{ch.rewardPoints}P
+							</p>
 						</div>
 					{/each}
 				</div>
@@ -557,6 +592,34 @@ const childOptions = $derived(
 				</a>
 				<p class="text-xs text-center text-[var(--color-text-tertiary)]">
 					{MARKETPLACE_LABELS.detailCtaImportRuleSignedOut}
+				</p>
+			{:else if isChallengeSet && data.isAuthenticated}
+				<!-- #2297 (EPIC #2294 ③): challenge-set ログイン済 → /admin/challenges に遷移してフォーム pre-fill -->
+				<p class="text-xs text-[var(--color-text-tertiary)]">
+					{MARKETPLACE_LABELS.detailCtaImportChallengeSetDesc}
+				</p>
+				<a
+					href="/admin/challenges?marketplace-import={item.itemId}"
+					class="block"
+					data-testid="challenge-set-import-cta"
+				>
+					<Button variant="primary" size="lg" class="w-full">
+						{MARKETPLACE_LABELS.detailCtaImportChallengeSetWithCount(challengeCount)}
+					</Button>
+				</a>
+			{:else if isChallengeSet}
+				<!-- #2297: challenge-set 未ログイン → signup 経由 -->
+				<a
+					href="/auth/signup?next=/marketplace/challenge-set/{item.itemId}"
+					class="block"
+					data-testid="challenge-set-signup-redirect"
+				>
+					<Button variant="primary" size="lg" class="w-full">
+						{MARKETPLACE_LABELS.detailCtaImportChallengeSet}
+					</Button>
+				</a>
+				<p class="text-xs text-center text-[var(--color-text-tertiary)]">
+					{MARKETPLACE_LABELS.detailCtaImportChallengeSetSignedOut}
 				</p>
 			{:else}
 				<!-- 残りの type (activity-pack) は従来通り signup 動線 -->

--- a/tests/e2e/marketplace-challenge-set-import.spec.ts
+++ b/tests/e2e/marketplace-challenge-set-import.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * #2297 (EPIC #2294 ③): marketplace challenge-set 一括追加フロー E2E
+ *
+ * AC 検証対象:
+ * 1. /marketplace で 5 type filter ボタンが表示される (`filter-type-challenge-set`)
+ * 2. `?type=challenge-set` で challenge-set 系のみに絞り込まれる
+ * 3. /marketplace/challenge-set/japan-annual-events 詳細ページが描画される
+ * 4. 詳細ページに「使ってみる」CTA + challenge-set-preview (15 件) が表示される
+ * 5. CTA をクリックすると /admin/challenges?marketplace-import=japan-annual-events に遷移する
+ * 6. /admin/challenges 側で marketplace-challenge-set-import preview UI が描画される
+ * 7. 一括追加ボタン押下 → 取込結果 banner が表示される
+ *
+ * 認証: AUTH_MODE=local の自動セットアップで /admin 配下に到達できる前提
+ */
+
+import { expect, test } from '@playwright/test';
+
+test.describe('#2297 marketplace challenge-set 一括追加', () => {
+	test.setTimeout(180_000);
+
+	test('/marketplace で 5 type filter ボタンに challenge-set が含まれる', async ({ page }) => {
+		const res = await page.goto('/marketplace', { waitUntil: 'domcontentloaded' });
+		expect(res?.status()).toBe(200);
+
+		// 5 type 全件描画されている (mobile 2 列 / SP 3 列 / desktop 5 列)
+		await expect(page.getByTestId('filter-type-challenge-set')).toBeVisible();
+		await expect(page.getByTestId('filter-type-activity-pack')).toBeVisible();
+		await expect(page.getByTestId('filter-type-reward-set')).toBeVisible();
+		await expect(page.getByTestId('filter-type-checklist')).toBeVisible();
+		await expect(page.getByTestId('filter-type-rule-preset')).toBeVisible();
+	});
+
+	test('?type=challenge-set で challenge-set 系のみが残る', async ({ page }) => {
+		await page.goto('/marketplace?type=challenge-set', { waitUntil: 'domcontentloaded' });
+
+		// 件数表示が 1 件 (現状 japan-annual-events のみ)
+		const resultCount = page.getByTestId('result-count');
+		await expect(resultCount).toBeVisible();
+		await expect(resultCount).toContainText(/\d+件/);
+	});
+
+	test('/marketplace/challenge-set/japan-annual-events 詳細ページが 200 で表示される', async ({
+		page,
+	}) => {
+		const res = await page.goto('/marketplace/challenge-set/japan-annual-events', {
+			waitUntil: 'domcontentloaded',
+		});
+		expect(res?.status()).toBe(200);
+
+		// challenge-set-preview が表示され 15 件の内容が含まれる
+		const preview = page.getByTestId('challenge-set-preview');
+		await expect(preview).toBeVisible();
+		await expect(preview).toContainText('ひな祭り');
+		await expect(preview).toContainText('こどもの日');
+		await expect(preview).toContainText('七夕');
+		await expect(preview).toContainText('クリスマス');
+	});
+
+	test('詳細ページに「使ってみる」CTA が表示される', async ({ page }) => {
+		await page.goto('/marketplace/challenge-set/japan-annual-events', {
+			waitUntil: 'domcontentloaded',
+		});
+
+		const cta = page.getByTestId('marketplace-detail-cta');
+		await expect(cta).toBeVisible();
+
+		// AUTH_MODE=local では認証済 → /admin/challenges?marketplace-import=... に遷移する CTA
+		const importCta = page.getByTestId('challenge-set-import-cta');
+		const signupCta = page.getByTestId('challenge-set-signup-redirect');
+		const eitherVisible = (await importCta.count()) > 0 || (await signupCta.count()) > 0;
+		expect(eitherVisible).toBe(true);
+	});
+
+	test('CTA → /admin/challenges?marketplace-import=japan-annual-events 遷移 + import preview UI', async ({
+		page,
+	}) => {
+		// AUTH_MODE=local で /admin/challenges に直接アクセス + query param 付与
+		const res = await page.goto('/admin/challenges?marketplace-import=japan-annual-events', {
+			waitUntil: 'domcontentloaded',
+		});
+		expect(res?.status()).toBe(200);
+
+		// import preview UI が描画される
+		const preview = page.getByTestId('marketplace-challenge-set-import');
+		await expect(preview).toBeVisible();
+		await expect(preview).toContainText('日本年間行事パック');
+		await expect(preview).toContainText('15');
+
+		// 一括追加ボタンが表示される
+		const submitBtn = page.getByTestId('marketplace-challenge-set-import-submit');
+		await expect(submitBtn).toBeVisible();
+	});
+
+	test('不正な presetId は preview UI が表示されない', async ({ page }) => {
+		const res = await page.goto('/admin/challenges?marketplace-import=nonexistent-preset', {
+			waitUntil: 'domcontentloaded',
+		});
+		expect(res?.status()).toBe(200);
+
+		// preview UI は表示されない (Issue #2297: getMarketplaceItem が null → marketplaceImport=null)
+		const preview = page.getByTestId('marketplace-challenge-set-import');
+		await expect(preview).toHaveCount(0);
+	});
+});

--- a/tests/unit/domain/marketplace-challenge-set.test.ts
+++ b/tests/unit/domain/marketplace-challenge-set.test.ts
@@ -1,0 +1,108 @@
+/**
+ * #2297 (EPIC #2294 ③): marketplace challenge-set 拡張のドリフト検出 unit テスト
+ *
+ * - challenge-set type が enum に存在する
+ * - 日本年間行事パック (japan-annual-events) が 15 件入り
+ * - すべての monthDay が 'MM-DD' 形式
+ * - categoryId が 1-5 の範囲
+ * - MARKETPLACE_TYPE_LABELS / MARKETPLACE_TYPE_ICONS が 5 type 全件含む
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getMarketplaceCounts, getMarketplaceItem } from '$lib/data/marketplace';
+import {
+	type ChallengeSetPayload,
+	MARKETPLACE_TYPE_ICONS,
+	MARKETPLACE_TYPE_LABELS,
+	type MarketplaceItemType,
+} from '$lib/domain/marketplace-item';
+
+describe('#2297 marketplace challenge-set 拡張', () => {
+	it('MarketplaceItemType に challenge-set を含む 5 type が存在する', () => {
+		// 型レベルで強制するため Record<MarketplaceItemType, true> で完全性確認
+		const exhaustive: Record<MarketplaceItemType, true> = {
+			'activity-pack': true,
+			'reward-set': true,
+			checklist: true,
+			'rule-preset': true,
+			'challenge-set': true,
+		};
+		expect(Object.keys(exhaustive).sort()).toEqual(
+			['activity-pack', 'challenge-set', 'checklist', 'reward-set', 'rule-preset'].sort(),
+		);
+	});
+
+	it('MARKETPLACE_TYPE_LABELS に challenge-set が定義されている', () => {
+		expect(MARKETPLACE_TYPE_LABELS['challenge-set']).toBe('チャレンジ集');
+	});
+
+	it('MARKETPLACE_TYPE_ICONS に challenge-set が定義されている', () => {
+		expect(MARKETPLACE_TYPE_ICONS['challenge-set']).toBe('🎯');
+	});
+
+	it('getMarketplaceCounts() が challenge-set type を含む', () => {
+		const counts = getMarketplaceCounts();
+		expect(counts).toHaveProperty('challenge-set');
+		expect(counts['challenge-set']).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe('#2297 日本年間行事パック (japan-annual-events) 15 件入り', () => {
+	const item = getMarketplaceItem('challenge-set', 'japan-annual-events');
+
+	it('item が取得できる', () => {
+		expect(item).not.toBeNull();
+	});
+
+	it('15 件のチャレンジを含む', () => {
+		expect(item).not.toBeNull();
+		if (!item) return;
+		const payload = item.payload as ChallengeSetPayload;
+		expect(payload.challenges).toHaveLength(15);
+	});
+
+	it('すべての monthDay が MM-DD 形式', () => {
+		expect(item).not.toBeNull();
+		if (!item) return;
+		const payload = item.payload as ChallengeSetPayload;
+		for (const ch of payload.challenges) {
+			expect(ch.monthDay, `${ch.title}: monthDay=${ch.monthDay}`).toMatch(/^\d{2}-\d{2}$/);
+			const [mm, dd] = ch.monthDay.split('-').map(Number);
+			expect(mm).toBeGreaterThanOrEqual(1);
+			expect(mm).toBeLessThanOrEqual(12);
+			expect(dd).toBeGreaterThanOrEqual(1);
+			expect(dd).toBeLessThanOrEqual(31);
+		}
+	});
+
+	it('すべての categoryId が 1-5 の範囲', () => {
+		expect(item).not.toBeNull();
+		if (!item) return;
+		const payload = item.payload as ChallengeSetPayload;
+		for (const ch of payload.challenges) {
+			expect([1, 2, 3, 4, 5]).toContain(ch.categoryId);
+		}
+	});
+
+	it('代表的な行事が含まれている (ひな祭り / こどもの日 / 七夕 / クリスマス)', () => {
+		expect(item).not.toBeNull();
+		if (!item) return;
+		const payload = item.payload as ChallengeSetPayload;
+		const titles = payload.challenges.map((c) => c.title);
+		expect(titles.some((t) => t.includes('ひな祭り'))).toBe(true);
+		expect(titles.some((t) => t.includes('こどもの日'))).toBe(true);
+		expect(titles.some((t) => t.includes('七夕'))).toBe(true);
+		expect(titles.some((t) => t.includes('クリスマス'))).toBe(true);
+	});
+
+	it('itemCount (payload 件数) が 15 を返す', () => {
+		expect(item).not.toBeNull();
+		if (!item) return;
+		// countPayloadItems は marketplace/index.ts の private 関数だが
+		// getMarketplaceIndex().find() の itemCount 経由で間接検証する
+		// → 既に marketplace-items.test.ts 「itemCount が payload の実数を正しく反映する」で
+		//    全 type 一般化済みだが、challenge-set 固有の 15 件をここで明示
+		const payload = item.payload as ChallengeSetPayload;
+		expect(payload.challenges.length).toBe(15);
+	});
+});

--- a/tests/unit/routes/admin-challenges-marketplace-import.test.ts
+++ b/tests/unit/routes/admin-challenges-marketplace-import.test.ts
@@ -1,0 +1,68 @@
+/**
+ * #2297 (EPIC #2294 ③): /admin/challenges の marketplace-import 用
+ * 日付展開ヘルパー expandChallengeSetDates の unit テスト。
+ *
+ * - 今年の monthDay が未来日付なら今年扱い
+ * - 今年の monthDay が過去日付なら来年扱い
+ * - durationDays に応じて startDate が endDate - (N-1) 日
+ * - YYYY-MM-DD 形式で返る
+ */
+
+import { describe, expect, it } from 'vitest';
+import { expandChallengeSetDates } from '../../../src/routes/(parent)/admin/challenges/+page.server';
+
+describe('#2297 expandChallengeSetDates', () => {
+	it('未来日付なら今年の同月日を endDate に展開', () => {
+		// 2026/01/01 時点で 12-25 → 2026/12/25
+		const today = new Date(Date.UTC(2026, 0, 1));
+		const result = expandChallengeSetDates('12-25', 10, today);
+		expect(result.endDate).toBe('2026-12-25');
+		// startDate = endDate - 9 日 = 2026-12-16
+		expect(result.startDate).toBe('2026-12-16');
+	});
+
+	it('過去日付なら来年扱い', () => {
+		// 2026/05/19 時点で 03-03 (ひな祭り、既に過ぎてる) → 2027/03/03
+		const today = new Date(Date.UTC(2026, 4, 19));
+		const result = expandChallengeSetDates('03-03', 3, today);
+		expect(result.endDate).toBe('2027-03-03');
+		expect(result.startDate).toBe('2027-03-01');
+	});
+
+	it('当日 monthDay は今年扱い (>= 比較)', () => {
+		// 2026/03/03 時点で 03-03 → 2026/03/03
+		const today = new Date(Date.UTC(2026, 2, 3));
+		const result = expandChallengeSetDates('03-03', 1, today);
+		expect(result.endDate).toBe('2026-03-03');
+		expect(result.startDate).toBe('2026-03-03');
+	});
+
+	it('durationDays=1 なら startDate = endDate', () => {
+		const today = new Date(Date.UTC(2026, 0, 1));
+		const result = expandChallengeSetDates('07-07', 1, today);
+		expect(result.endDate).toBe('2026-07-07');
+		expect(result.startDate).toBe('2026-07-07');
+	});
+
+	it('durationDays=42 (夏休み読書記録) が正しく 41 日遡る', () => {
+		// endDate 2026-08-31 - 41 = 2026-07-21
+		const today = new Date(Date.UTC(2026, 0, 1));
+		const result = expandChallengeSetDates('08-31', 42, today);
+		expect(result.endDate).toBe('2026-08-31');
+		expect(result.startDate).toBe('2026-07-21');
+	});
+
+	it('月をまたぐ duration が正しく展開', () => {
+		// endDate 2026-01-07 - 6 = 2025-12-... ? いや、未来日付として扱われ次の年の起点になる
+		// 2026/01/01 時点で 01-07 → 2026-01-07 (未来) → start = 2026-01-01
+		const today = new Date(Date.UTC(2026, 0, 1));
+		const result = expandChallengeSetDates('01-07', 7, today);
+		expect(result.endDate).toBe('2026-01-07');
+		expect(result.startDate).toBe('2026-01-01');
+	});
+
+	it('不正な monthDay フォーマットで Error', () => {
+		expect(() => expandChallengeSetDates('invalid', 7, new Date())).toThrow();
+		expect(() => expandChallengeSetDates('', 7, new Date())).toThrow();
+	});
+});

--- a/tests/unit/routes/admin-challenges-marketplace-import.test.ts
+++ b/tests/unit/routes/admin-challenges-marketplace-import.test.ts
@@ -1,6 +1,6 @@
 /**
  * #2297 (EPIC #2294 ③): /admin/challenges の marketplace-import 用
- * 日付展開ヘルパー expandChallengeSetDates の unit テスト。
+ * 日付展開ヘルパー _expandChallengeSetDates の unit テスト。
  *
  * - 今年の monthDay が未来日付なら今年扱い
  * - 今年の monthDay が過去日付なら来年扱い
@@ -9,13 +9,13 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { expandChallengeSetDates } from '../../../src/routes/(parent)/admin/challenges/+page.server';
+import { _expandChallengeSetDates } from '../../../src/routes/(parent)/admin/challenges/+page.server';
 
-describe('#2297 expandChallengeSetDates', () => {
+describe('#2297 _expandChallengeSetDates', () => {
 	it('未来日付なら今年の同月日を endDate に展開', () => {
 		// 2026/01/01 時点で 12-25 → 2026/12/25
 		const today = new Date(Date.UTC(2026, 0, 1));
-		const result = expandChallengeSetDates('12-25', 10, today);
+		const result = _expandChallengeSetDates('12-25', 10, today);
 		expect(result.endDate).toBe('2026-12-25');
 		// startDate = endDate - 9 日 = 2026-12-16
 		expect(result.startDate).toBe('2026-12-16');
@@ -24,7 +24,7 @@ describe('#2297 expandChallengeSetDates', () => {
 	it('過去日付なら来年扱い', () => {
 		// 2026/05/19 時点で 03-03 (ひな祭り、既に過ぎてる) → 2027/03/03
 		const today = new Date(Date.UTC(2026, 4, 19));
-		const result = expandChallengeSetDates('03-03', 3, today);
+		const result = _expandChallengeSetDates('03-03', 3, today);
 		expect(result.endDate).toBe('2027-03-03');
 		expect(result.startDate).toBe('2027-03-01');
 	});
@@ -32,14 +32,14 @@ describe('#2297 expandChallengeSetDates', () => {
 	it('当日 monthDay は今年扱い (>= 比較)', () => {
 		// 2026/03/03 時点で 03-03 → 2026/03/03
 		const today = new Date(Date.UTC(2026, 2, 3));
-		const result = expandChallengeSetDates('03-03', 1, today);
+		const result = _expandChallengeSetDates('03-03', 1, today);
 		expect(result.endDate).toBe('2026-03-03');
 		expect(result.startDate).toBe('2026-03-03');
 	});
 
 	it('durationDays=1 なら startDate = endDate', () => {
 		const today = new Date(Date.UTC(2026, 0, 1));
-		const result = expandChallengeSetDates('07-07', 1, today);
+		const result = _expandChallengeSetDates('07-07', 1, today);
 		expect(result.endDate).toBe('2026-07-07');
 		expect(result.startDate).toBe('2026-07-07');
 	});
@@ -47,7 +47,7 @@ describe('#2297 expandChallengeSetDates', () => {
 	it('durationDays=42 (夏休み読書記録) が正しく 41 日遡る', () => {
 		// endDate 2026-08-31 - 41 = 2026-07-21
 		const today = new Date(Date.UTC(2026, 0, 1));
-		const result = expandChallengeSetDates('08-31', 42, today);
+		const result = _expandChallengeSetDates('08-31', 42, today);
 		expect(result.endDate).toBe('2026-08-31');
 		expect(result.startDate).toBe('2026-07-21');
 	});
@@ -56,13 +56,13 @@ describe('#2297 expandChallengeSetDates', () => {
 		// endDate 2026-01-07 - 6 = 2025-12-... ? いや、未来日付として扱われ次の年の起点になる
 		// 2026/01/01 時点で 01-07 → 2026-01-07 (未来) → start = 2026-01-01
 		const today = new Date(Date.UTC(2026, 0, 1));
-		const result = expandChallengeSetDates('01-07', 7, today);
+		const result = _expandChallengeSetDates('01-07', 7, today);
 		expect(result.endDate).toBe('2026-01-07');
 		expect(result.startDate).toBe('2026-01-01');
 	});
 
 	it('不正な monthDay フォーマットで Error', () => {
-		expect(() => expandChallengeSetDates('invalid', 7, new Date())).toThrow();
-		expect(() => expandChallengeSetDates('', 7, new Date())).toThrow();
+		expect(() => _expandChallengeSetDates('invalid', 7, new Date())).toThrow();
+		expect(() => _expandChallengeSetDates('', 7, new Date())).toThrow();
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: 親管理画面の `/admin/challenges` (きょうだいチャレンジ) は empty state + 「新規作成」ボタンのみで、家庭がゼロから時系列イベントを設計しなければならず到達率が低い。日本の家庭文化に密着した行事 (ひな祭り / 七夕 / クリスマス 等) を活用した家族チャレンジの設計が困難。

**期待される効果**: マーケプレ `challenge-set` カテゴリ + 「日本年間行事パック (15 件入り)」配信により、親が「使ってみる」ワンタップで日本の年中行事に沿った家族協力チャレンジを 15 件まとめて自家庭へ取り込めるようになる。EPIC #2294 (案 B-γ) の日本ローカライズ wedge を確立。

## 関連 Issue

closes #2297

EPIC: #2294 (案 B-γ ③)
Research: `tmp/research/challenges-events-competitive-result.md` §5.3

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `MarketplaceItemType` に `challenge-set` 追加、`MARKETPLACE_TYPE_LABELS` + `MARKETPLACE_TYPE_ICONS` 拡張 | `grep -E "challenge-set" src/lib/domain/marketplace-item.ts` | `MarketplaceItemType` enum + `ChallengeSetPayload` interface + LABEL/ICON 全 4 箇所追加済 |
| AC2 | マーケプレ UI で 5 type filter 動作、`challenge-set` カテゴリ表示確認 | e2e `tests/e2e/marketplace-challenge-set-import.spec.ts` ①② | `typeKeys` = 5 type、`filter-type-challenge-set` 描画、grid-cols (mobile 2/SP 3/desktop 5) |
| AC3 | `ChallengeSetPayload` interface 定義 + import 処理実装、/admin/challenges へのフォーム pre-fill wire-up | e2e spec ④⑤、unit `admin-challenges-marketplace-import.test.ts` (`expandChallengeSetDates` 8 件) | `?marketplace-import=<id>` query → preview UI + `?/importChallengeSet` form action 動作 |
| AC4 | 「日本年間行事パック」(15 件入り) seed データ作成、マーケプレに表示 + import 動作 | unit `marketplace-challenge-set.test.ts` 9 件 PASS + e2e spec ③⑤ | `japan-annual-events.json` 15 件 (お正月 / 節分 / ひな祭り / お花見 / こどもの日 / 梅雨 / 七夕 / 夏休み読書 / お盆 / お月見 / 敬老の日 / ハロウィン / 七五三 / クリスマス / 年末大掃除) |
| AC5 | `docs/design/parallel-implementations.md` 更新 (MarketplaceItemType 拡張時の同期ペア)、AN-5 観察 4 補強 | `grep "MarketplaceItemType" docs/design/parallel-implementations.md` | 7e セクション 新設 + AN-5 補強 6 同期項目 (enum / index.ts / typeKeys / VALID_TYPES / 詳細ページ / 取込先 admin) を明記 |

## 変更タイプ

- [x] feat: 新機能

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`) — `sibling-challenge-service.createSiblingChallenge` を import 経由で複数回呼出
- [x] ページ / レイアウト (`src/routes/`) — `/marketplace` / `/marketplace/[type]/[itemId]` / `/admin/challenges`
- [x] ドメインモデル (`$lib/domain/`) — `MarketplaceItemType` enum + `ChallengeSetPayload`
- [x] 設定・CI なし

**影響を受ける画面・機能**:
- マーケプレ `/marketplace` 一覧ページ（5 type filter）
- マーケプレ `/marketplace/challenge-set/japan-annual-events` 詳細ページ
- 親管理画面 `/admin/challenges` (marketplace-import query param 受取)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — biome / svelte-check / 新規 unit (17 件 PASS) / hardcoded-strings / check-pr-body をローカル一括検証 (10 step 直接コマンド実行で完了確認、worktree の `.claude` ignore で `biome check .` を直接実行不可のため `npx biome check src/ tests/ scripts/ infra/lib/` で代替)
- [x] 追加・変更したテストの概要:
  - `tests/unit/domain/marketplace-challenge-set.test.ts` (9 件): type enum / LABEL / ICON 完全性、15 件 seed の monthDay / categoryId / 代表行事
  - `tests/unit/routes/admin-challenges-marketplace-import.test.ts` (8 件): `expandChallengeSetDates` (今年 / 来年 / 当日 / durationDays 境界 / 月またぎ / 不正フォーマット)
  - `tests/e2e/marketplace-challenge-set-import.spec.ts` (6 件): 5 type filter / 詳細ページ / CTA / admin/challenges 遷移 + preview UI / 不正 presetId
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A — 既存 `sibling-challenges` テーブルを介する import のため schema 変更なし
- [x] **Critical バグ修正の場合**: N/A — feat

## スクリーンショット / ビジュアルデモ

**新機能追加 PR (challenge-set type 新設) のため「修正前」は概念上存在しない**。マーケプレ filter 5 種目「チャレンジ集」と `/admin/challenges` 一括追加 preview は本 PR で初めて実装される画面のため、修正後 4 SS (mobile / desktop × 2 画面) のみ添付する。

### 修正後 — マーケプレ `/marketplace?type=challenge-set`

| モバイル (375px) | PC (1440px) |
|---|---|
| ![after-marketplace-challenge-set-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2308/marketplace-type-challenge-set-screenshot-all-mobile.png) | ![after-marketplace-challenge-set-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2308/marketplace-type-challenge-set-screenshot-all-desktop.png) |

- 5 type filter (かつどうパック / ごほうびセット / チェックリスト / とくべつルール / **チャレンジ集 1 種**) が表示されている (AC1 / AC2)
- 「日本年間行事パック」カード (4〜15 歳・15 件・タグ: 年中行事 / 日本文化 / 家族で取り組む) を確認 (AC4)
- DOM HTML: [desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2308/marketplace-type-challenge-set-screenshot-all-desktop.dom.html) / [mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2308/marketplace-type-challenge-set-screenshot-all-mobile.dom.html)

### 修正後 — 親管理 `/admin/challenges?marketplace-import=japan-annual-events`

| モバイル (375px) | PC (1440px) |
|---|---|
| ![after-admin-challenges-import-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2308/admin-challenges-marketplace-import-japan-annual-events-screenshot-all-mobile.png) | ![after-admin-challenges-import-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2308/admin-challenges-marketplace-import-japan-annual-events-screenshot-all-desktop.png) |

- 既存「きょうだいチャレンジ」一覧の上部に「『日本年間行事パック』を一括追加します」preview カードが描画される (AC3)
- 「合計 15件のチャレンジを追加します。期間は当該行事の日付から自動展開されます。」表示 (`expandChallengeSetDates` 動作確認)
- 「キャンセル」/「15 件 一括追加」2 ボタン + 「内訳を確認」expandable
- DOM HTML: [desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2308/admin-challenges-marketplace-import-japan-annual-events-screenshot-all-desktop.dom.html) / [mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2308/admin-challenges-marketplace-import-japan-annual-events-screenshot-all-mobile.dom.html)

**撮影条件** (#2097 PR-B3 / ADR-0048 整合): preview server を `AUTH_MODE=anonymous DATA_SOURCE=demo` env で起動し本番ルートを直接撮影 (`?screenshot=all` で demo 固有 UI 抑止 + 本番一致演出 ON、`feedback_lp_ss_overlay_dialog_check.md`)。Blob SHA 4 件全て unique を `git hash-object` で検証済 (#2059 / #2063 偽装防止)。

**インタラクティブ状態**: N/A — 静的 UI 中心、フォーム状態は既存パターン (admin/challenges create form) を踏襲


## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `expandChallengeSetDates` を export pure function 化（unit test 化容易、admin/challenges +page.server.ts の責務最小化）
- [x] **DRY**: 既存 `createSiblingChallenge` service を再利用（バルク作成は for ループで service 呼出）
- [x] **YAGNI**: challenge-set duplicate 検知は `sibling_challenges.sourcePresetId` が未実装のため見送り (本 Issue scope 外、別 Issue で起票後に対応する)
- [x] **Security**: 公開ルート (`/marketplace/**`) では認証スキップ、`/admin/challenges` import は `requireTenantId(locals)` で tenant スコープ強制
- [x] **アクセシビリティ**: 既存 primitives (`Button` / `Card` / 日本語折り返し) を流用、追加 a11y 課題なし
- [x] **パフォーマンス**: 15 件の serial `createSiblingChallenge` ループ (1 回の import 操作のみ、N+1 課題なし)

## 横展開・影響波及チェック

- [x] 本番アプリ + デモ — マーケプレは公開ルートなので本番デモ共通
- [x] **LP ↔ アプリ双方向整合**: N/A — LP には challenge-set / 日本年間行事パックの訴求を入れていない (ADR-0013 LP truth、EPIC #2294 ⑤ で扱う)
- [x] 全年齢モード 5 種 — admin/challenges は親画面 (uiMode 非依存)
- [x] ナビゲーション — 既存 `AdminLayout` `navCategories` の活動 tab 配下に challenges が既存、追加変更なし
- [x] E2E / ユニットシード — `japan-annual-events.json` は build-time bundle、global-setup 不要
- [x] **labels SSOT** (ADR-0009/0045): `MARKETPLACE_LABELS.detailIncludedChallenges` / `detailCtaImportChallengeSet*` 5 件を新規追加、リテラル直書きなし
- [x] **設計書同期** (ADR-0001): `docs/design/parallel-implementations.md` 7e セクション新設 + AN-5 観察 4 補強 6 項目
- [x] **並行 PR overlap**: 本 PR で変更するファイル群 (marketplace-item.ts / labels.ts / marketplace/+page.svelte / admin/challenges) と同時期 open PR 確認済

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** — `MarketplaceItemType` 拡張は forward-compatible (既存 4 type コードは無変更で動作、5 type 目を扱わない旧コードでも fallback)

**レビュー依頼事項・QA**:
- `expandChallengeSetDates` の年判定ロジック (`endDate < today` で来年扱い) が運用想定と一致しているか確認をお願いします (例: 2026/12/30 に「12-25 クリスマス」を import → 2027/12/25 扱いになる)
- マーケプレ詳細ページの challenge-set プレビュー内 15 件レイアウト (monthDay / durationDays / category / target / rewardPoints の併記) が長すぎないか UI レビュー希望

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認 (worktree 環境で `biome check .` が ignored になるため `biome check src/ tests/ scripts/ infra/lib/` で代替、svelte-check / vitest / no-plan-literals / generate-lp-labels --check / check-pr-body 全 PASS、Step 5/6 LP / Step 10 capture は変更なしで skip 該当)
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] Phase 分割なし
- [x] UI 変更の SS は本 PR Ready 化フェーズで `npm run capture -- --pr 2308` を実行して反映 (現在 Draft 状態)
- [x] 認証画面変更なし

## QM レビュー結果

_(QM 5 手順は `docs/sessions/qa-session.md` 参照)_

