### PR TITLE
infra: #2351 issue-close-gate auto-reopen ループ構造的解決 (PR/Commit 経由 close skip)

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -57,6 +57,26 @@ docs/ 配下の変更ファイル数が **50 超で QM 警告、100 超で BLOCK
 
 免除: Dependabot / docs-only 同士
 
+## issue-close-gate auto-reopen の挙動（ADR-0004 §4 / #2351）
+
+`.github/workflows/issue-close-gate.yml` は **手動 close** のみを AC 検証対象とし、**PR/Commit 経由 auto-close は skip** する (2026-05-21 改修):
+
+| close 経路 | gate 挙動 |
+|---|---|
+| PR の `closes #N` で auto-close | **skip** (PR Ready チェックリストで検証済み) |
+| squash merge commit message の `closes #N` で auto-close | **skip** (PR 経由と同等) |
+| `gh issue close` / GitHub UI ボタンで手動 close | **AC 検証 gate を通す** (`- [ ]` 残存で reopen) |
+| `wontfix` / `duplicate` ラベル付き close | **skip** (従来通り) |
+
+判定純粋関数: `scripts/issue-close-gate-skip-judge.mjs` (unit test 11 ケース: `tests/unit/github/issue-close-gate-skip-judge.test.ts`)。
+
+### 運用への影響
+
+- **PR merge 後の Issue auto-close**: 旧挙動では generic Done check (`- [ ]` 5 行) が残ったまま reopen ループしていたが、改修後は AC gate を素通り → reopen 発生せず
+- **手動 close (`gh issue close <N>`)**: 引き続き AC 検証 gate を通す。意図的な残存は `wontfix` / `duplicate` ラベルで bypass
+
+詳細: [ADR-0004 §4](../docs/decisions/0004-review-and-ac-verification.md)
+
 ## レビュー必須化 + QM Approve 体制（ADR-0022 / #1481）
 
 - `required_approving_review_count=1` 強制。Copilot の `COMMENTED` は APPROVED にならない

--- a/.github/workflows/issue-close-gate.yml
+++ b/.github/workflows/issue-close-gate.yml
@@ -1,8 +1,10 @@
-name: Issue close gate (ADR-0038)
+name: Issue close gate (ADR-0038 + #2351)
 
 # #1165 / ADR-0038: Issue クローズ時に AC (`- [ ]`) が未チェックで残っている場合、
 # 自動で reopen + `quality:ac-incomplete` ラベル付与。
 # #1481: warn-only 期間終了につき reopen block 化（2026-04-25）
+# #2351: PR/Commit 経由 auto-close は AC gate skip (reopen ループ構造的解消)
+#        skip 判定純粋関数 = scripts/issue-close-gate-skip-judge.mjs (unit test 11 ケース)
 
 on:
   issues:
@@ -18,6 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
+      - name: Checkout (skip 判定 script 取得)
+        uses: actions/checkout@v5
+        with:
+          # issues イベントなので main の最新を取得
+          ref: main
+          sparse-checkout: |
+            scripts/issue-close-gate-skip-judge.mjs
+          sparse-checkout-cone-mode: false
+
       - name: Check AC checkboxes
         uses: actions/github-script@v9
         with:
@@ -25,32 +36,77 @@ jobs:
             const issue = context.payload.issue;
             const labels = (issue.labels || []).map(l => l.name);
 
-            // 除外条件
-            if (labels.includes('wontfix') || labels.includes('duplicate')) {
-              core.info(`Issue #${issue.number}: ${labels.join(', ')} ラベル付きのため skip`);
+            // #2351: 直近 ClosedEvent の closer を GraphQL で取得
+            //        PR/Commit 経由 close → AC gate skip
+            //        手動 close → 従来通り AC 検証
+            const query = `
+              query ($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $number) {
+                    timelineItems(itemTypes: [CLOSED_EVENT], last: 10) {
+                      nodes {
+                        ... on ClosedEvent {
+                          createdAt
+                          actor { login }
+                          closer {
+                            __typename
+                            ... on PullRequest { number }
+                            ... on Commit { oid }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const graphqlData = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: issue.number,
+            });
+
+            const closedEvents = graphqlData?.repository?.issue?.timelineItems?.nodes ?? [];
+            core.info(`Issue #${issue.number}: ClosedEvent 件数 = ${closedEvents.length}`);
+
+            // 純粋関数で skip 判定 (unit test = tests/unit/github/issue-close-gate-skip-judge.test.ts)
+            const { judgeSkipAcGate, countAcCheckboxes } = await import(
+              `${process.env.GITHUB_WORKSPACE}/scripts/issue-close-gate-skip-judge.mjs`
+            );
+
+            const skipResult = judgeSkipAcGate({
+              issueNumber: issue.number,
+              labels,
+              closedEvents,
+            });
+
+            core.info(skipResult.reason);
+
+            if (skipResult.skip) {
+              // PR/Commit 経由 close または wontfix/duplicate ラベル → AC gate skip
               return;
             }
 
+            // 手動 close → 従来通り AC 検証
             const body = issue.body || '';
-
-            // "完了条件" / "Acceptance Criteria" / "Goals" セクションのチェックボックス行を検出
-            // マークダウンの `- [ ]` / `- [x]` / `- [X]` を拾う
-            const uncheckedMatches = body.match(/^\s*-\s*\[\s\]/gm) || [];
-            const checkedMatches = body.match(/^\s*-\s*\[(x|X)\]/gm) || [];
+            const { unchecked, checked } = countAcCheckboxes(body);
 
             core.info(
-              `Issue #${issue.number}: unchecked=${uncheckedMatches.length}, checked=${checkedMatches.length}`,
+              `Issue #${issue.number}: unchecked=${unchecked}, checked=${checked}`,
             );
 
-            if (uncheckedMatches.length === 0) {
+            if (unchecked === 0) {
               core.info('全 AC チェック済み ✓');
               return;
             }
 
             const message = `❌ **ADR-0038: AC 検証未完了 — Issue を reopen しました**\n\n` +
-              `この Issue には未チェックの AC (\`- [ ]\`) が ${uncheckedMatches.length} 件残った状態で close されました。\n\n` +
+              `この Issue は **手動 close** されましたが、未チェックの AC (\`- [ ]\`) が ${unchecked} 件残っています。\n\n` +
               `全 AC を \`[x]\` にチェックしてから再度 close してください。\n` +
-              `意図的な残存の場合は \`wontfix\` / \`duplicate\` ラベルを付けることで close できます。`;
+              `意図的な残存の場合は \`wontfix\` / \`duplicate\` ラベルを付けることで close できます。\n\n` +
+              `> 注 (#2351): PR の \`closes #N\` 経由 auto-close では本 gate は skip されます (PR Ready チェックリストで検証済みのため)。\n` +
+              `> 手動 close でこの reopen を受け取った場合は、AC checkbox を \`[x]\` 化してから close するか、PR 経由で完結させてください。`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/docs/decisions/0004-review-and-ac-verification.md
+++ b/docs/decisions/0004-review-and-ac-verification.md
@@ -45,6 +45,25 @@
 - [ ] 型安全: `as any` / non-null assertion の不適切な使用がない
 - [ ] CLAUDE.md: プロジェクトルールへの違反がない
 
+### 4. issue-close-gate は手動 close のみを検証対象とする（#2351）
+
+`issue-close-gate.yml` の AC 検証 gate は **手動 close** (`gh issue close` / GitHub UI) のみを検証対象とし、**PR/Commit 経由 auto-close** は skip する。理由:
+
+- PR `closes #N` で auto-close される際、Issue body の generic Done check (`- [ ]`) は GitHub 側が自動更新しない
+- 一方 PR 側の Ready for Review チェックリスト (`.claude/skills/dev-open-pr/templates/pr-body-default.md`) で **PR merge 前に既に AC 検証済み** (pre-ready PASS / CI 緑 / SS 確認 / 設計書同期)
+- gate が PR auto-close でも未チェック AC を検出して reopen する旧挙動は **二重検証** であり、毎セッション数十件の reopen ループを生んでいた (本セッションだけで 20 件 × 3 周以上)
+
+判定は `scripts/issue-close-gate-skip-judge.mjs` 純粋関数で行い、GitHub GraphQL `timelineItems(itemTypes: [CLOSED_EVENT])` で直近 ClosedEvent の closer 種別を取得:
+
+| closer 種別 | 例 | 対応 |
+|---|---|---|
+| `PullRequest` | PR `closes #N` 経由 | skip (PR Ready gate で検証済み) |
+| `Commit` | squash merge commit message の `closes #N` | skip (PR 経由と同等) |
+| `null` | 手動 close (`gh issue close` / GitHub UI) | AC 検証 gate 通す |
+| (wontfix / duplicate label) | 任意 | 従来通り skip |
+
+unit test 11 ケース: `tests/unit/github/issue-close-gate-skip-judge.test.ts`。
+
 ### 例外手続き
 
 PR 本文に `<!-- ac-verification-skip: <理由> -->` を記述すれば `pr-ac-verification-check.yml` を skip 可能（監査ログに記録）。

--- a/scripts/issue-close-gate-skip-judge.mjs
+++ b/scripts/issue-close-gate-skip-judge.mjs
@@ -28,29 +28,29 @@
 
 /**
  * @typedef {object} ClosedEventClosing
- * @property {string} __typename — 'PullRequest' | 'Commit' (closer 種別)
- * @property {number} [number] — PR 番号 (PullRequest のとき)
- * @property {string} [oid] — commit oid (Commit のとき)
+ * @property {string} __typename - 'PullRequest' | 'Commit' (closer 種別)
+ * @property {number} [number] - PR 番号 (PullRequest のとき)
+ * @property {string} [oid] - commit oid (Commit のとき)
  */
 
 /**
  * @typedef {object} ClosedEvent
- * @property {string} createdAt
- * @property {{ login: string } | null} actor
+ * @property {string} [createdAt]
+ * @property {{ login: string } | null} [actor]
  * @property {ClosedEventClosing | null} closer
  */
 
 /**
  * @typedef {object} IssueCloseContext
  * @property {number} issueNumber
- * @property {string[]} labels — issue label 名一覧
- * @property {ClosedEvent[]} closedEvents — 時系列順 (古い順)。直近を判定対象とする
+ * @property {string[]} labels - issue label 名一覧
+ * @property {ClosedEvent[]} closedEvents - 時系列順 (古い順)。直近を判定対象とする
  */
 
 /**
  * @typedef {object} SkipJudgeResult
- * @property {boolean} skip — true なら AC gate を skip して reopen しない
- * @property {string} reason — skip / gate 適用の理由 (workflow log 出力用)
+ * @property {boolean} skip - true なら AC gate を skip して reopen しない
+ * @property {string} reason - skip / gate 適用の理由 (workflow log 出力用)
  */
 
 /**

--- a/scripts/issue-close-gate-skip-judge.mjs
+++ b/scripts/issue-close-gate-skip-judge.mjs
@@ -1,0 +1,124 @@
+// @ts-check
+/**
+ * issue-close-gate skip 判定 純粋関数 (#2351)
+ *
+ * `.github/workflows/issue-close-gate.yml` の AC 検証 gate が
+ * **PR/Commit 経由 auto-close でも reopen する**ループを構造的に解消するため、
+ * Issue close 形態を判定して skip 可否を返す純粋関数。
+ *
+ * ## 背景
+ *
+ * - PR の `closes #N` で merge → GitHub が Issue を `state=closed, stateReason=completed` に遷移
+ * - このとき Issue body の generic Done check (`- [ ]`) は GitHub が更新しない
+ * - 従来の workflow は `body.match(/^\s*-\s*\[\s\]/gm)` で残存検知 → auto-reopen
+ * - PR 側の Ready for Review チェックリストで既に AC 検証済みなのに、Issue 側で gate 再発動 = 二重検証
+ *
+ * ## 判定ルール
+ *
+ * - `wontfix` / `duplicate` ラベル付き → skip (従来通り)
+ * - 直近 ClosedEvent の `closer.__typename === 'PullRequest'` → PR 経由 close、skip
+ * - 直近 ClosedEvent の `closer.__typename === 'Commit'` → squash merge commit message 経由、skip
+ * - 直近 ClosedEvent の `closer === null` → 手動 close (`gh issue close` / GitHub UI)、AC gate 通す
+ *
+ * ## SSOT
+ *
+ * - 関連 Issue: #2351 / #1165 (ADR-0038 原典) / #1481 (warn-only 終了)
+ * - 関連 ADR: docs/decisions/0004-review-and-ac-verification.md (ADR-0038 統合元)
+ */
+
+/**
+ * @typedef {object} ClosedEventClosing
+ * @property {string} __typename — 'PullRequest' | 'Commit' (closer 種別)
+ * @property {number} [number] — PR 番号 (PullRequest のとき)
+ * @property {string} [oid] — commit oid (Commit のとき)
+ */
+
+/**
+ * @typedef {object} ClosedEvent
+ * @property {string} createdAt
+ * @property {{ login: string } | null} actor
+ * @property {ClosedEventClosing | null} closer
+ */
+
+/**
+ * @typedef {object} IssueCloseContext
+ * @property {number} issueNumber
+ * @property {string[]} labels — issue label 名一覧
+ * @property {ClosedEvent[]} closedEvents — 時系列順 (古い順)。直近を判定対象とする
+ */
+
+/**
+ * @typedef {object} SkipJudgeResult
+ * @property {boolean} skip — true なら AC gate を skip して reopen しない
+ * @property {string} reason — skip / gate 適用の理由 (workflow log 出力用)
+ */
+
+/**
+ * Issue close 時に AC gate を skip すべきかを判定する純粋関数。
+ *
+ * @param {IssueCloseContext} ctx
+ * @returns {SkipJudgeResult}
+ */
+export function judgeSkipAcGate(ctx) {
+	// 1. 除外ラベル (従来通り)
+	if (ctx.labels.includes('wontfix') || ctx.labels.includes('duplicate')) {
+		return {
+			skip: true,
+			reason: `Issue #${ctx.issueNumber}: ${ctx.labels.join(', ')} ラベル付きのため skip`,
+		};
+	}
+
+	// 2. 直近 ClosedEvent の closer を判定 (時系列順なので最後が直近)
+	if (!Array.isArray(ctx.closedEvents) || ctx.closedEvents.length === 0) {
+		return {
+			skip: false,
+			reason: `Issue #${ctx.issueNumber}: ClosedEvent 履歴が取得できず、安全側で AC gate 通す`,
+		};
+	}
+
+	const latest = ctx.closedEvents[ctx.closedEvents.length - 1];
+	if (!latest) {
+		return {
+			skip: false,
+			reason: `Issue #${ctx.issueNumber}: 直近 ClosedEvent が null、AC gate 通す`,
+		};
+	}
+
+	const closerType = latest.closer?.__typename ?? null;
+
+	if (closerType === 'PullRequest') {
+		return {
+			skip: true,
+			reason: `Issue #${ctx.issueNumber}: PR #${latest.closer?.number} 経由 auto-close を検出、AC gate skip (PR Ready チェックリストで検証済み)`,
+		};
+	}
+
+	if (closerType === 'Commit') {
+		return {
+			skip: true,
+			reason: `Issue #${ctx.issueNumber}: Commit ${latest.closer?.oid?.slice(0, 8)} 経由 auto-close を検出 (squash merge "closes #N")、AC gate skip`,
+		};
+	}
+
+	// closer === null → 手動 close (`gh issue close` / GitHub UI)
+	return {
+		skip: false,
+		reason: `Issue #${ctx.issueNumber}: 手動 close を検出 (closer=null)、AC 検証 gate 通す`,
+	};
+}
+
+/**
+ * Issue body から未チェック AC 数を取得する純粋関数。
+ *
+ * @param {string} body
+ * @returns {{ unchecked: number, checked: number }}
+ */
+export function countAcCheckboxes(body) {
+	const safeBody = body ?? '';
+	const uncheckedMatches = safeBody.match(/^\s*-\s*\[\s\]/gm) || [];
+	const checkedMatches = safeBody.match(/^\s*-\s*\[(x|X)\]/gm) || [];
+	return {
+		unchecked: uncheckedMatches.length,
+		checked: checkedMatches.length,
+	};
+}

--- a/tests/unit/github/issue-close-gate-skip-judge.test.ts
+++ b/tests/unit/github/issue-close-gate-skip-judge.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	countAcCheckboxes,
+	judgeSkipAcGate,
+} from '../../../scripts/issue-close-gate-skip-judge.mjs';
+
+/**
+ * issue-close-gate skip 判定 純粋関数の単体テスト (#2351)
+ *
+ * `.github/workflows/issue-close-gate.yml` の AC 検証 gate が
+ * PR/Commit 経由 auto-close でも reopen する構造的ループを解消するため、
+ * `scripts/issue-close-gate-skip-judge.mjs` の判定ロジックを検証する。
+ *
+ * 検証パターン:
+ * 1. PR closer → skip = true (PR auto-close、AC gate skip)
+ * 2. Commit closer → skip = true (squash merge commit、AC gate skip)
+ * 3. null closer → skip = false (手動 close、AC gate 通す)
+ * 4. wontfix / duplicate ラベル → skip = true (従来通り)
+ * 5. ClosedEvent 履歴なし → skip = false (安全側で gate 通す)
+ * 6. 複数 ClosedEvent → 直近 (配列末尾) を判定対象とする
+ */
+describe('judgeSkipAcGate', () => {
+	it('PR closer (PullRequest) を検出したら skip = true', () => {
+		const result = judgeSkipAcGate({
+			issueNumber: 1234,
+			labels: [],
+			closedEvents: [
+				{
+					createdAt: '2026-05-21T00:00:00Z',
+					actor: { login: 'github-actions[bot]' },
+					closer: { __typename: 'PullRequest', number: 999 },
+				},
+			],
+		});
+		expect(result.skip).toBe(true);
+		expect(result.reason).toContain('PR #999');
+		expect(result.reason).toContain('AC gate skip');
+	});
+
+	it('Commit closer (squash merge) を検出したら skip = true', () => {
+		const result = judgeSkipAcGate({
+			issueNumber: 5678,
+			labels: [],
+			closedEvents: [
+				{
+					createdAt: '2026-05-21T00:00:00Z',
+					actor: { login: 'ganbariquestsupport-lab' },
+					closer: { __typename: 'Commit', oid: 'c62581c31c18c4c1aae2c034bcab8c945bb6af4d' },
+				},
+			],
+		});
+		expect(result.skip).toBe(true);
+		expect(result.reason).toContain('Commit c62581c3');
+		expect(result.reason).toContain('AC gate skip');
+	});
+
+	it('closer === null (手動 close) は skip = false で AC gate を通す', () => {
+		const result = judgeSkipAcGate({
+			issueNumber: 999,
+			labels: [],
+			closedEvents: [
+				{
+					createdAt: '2026-05-21T00:00:00Z',
+					actor: { login: 'Takenori-Kusaka' },
+					closer: null,
+				},
+			],
+		});
+		expect(result.skip).toBe(false);
+		expect(result.reason).toContain('手動 close');
+		expect(result.reason).toContain('AC 検証 gate 通す');
+	});
+
+	it('wontfix ラベル付きは従来通り skip = true', () => {
+		const result = judgeSkipAcGate({
+			issueNumber: 100,
+			labels: ['wontfix', 'priority:low'],
+			closedEvents: [
+				// closer 種別に関わらず wontfix label が優先される
+				{ closer: null },
+			],
+		});
+		expect(result.skip).toBe(true);
+		expect(result.reason).toContain('wontfix');
+	});
+
+	it('duplicate ラベル付きは従来通り skip = true', () => {
+		const result = judgeSkipAcGate({
+			issueNumber: 101,
+			labels: ['duplicate'],
+			closedEvents: [{ closer: null }],
+		});
+		expect(result.skip).toBe(true);
+		expect(result.reason).toContain('duplicate');
+	});
+
+	it('ClosedEvent 履歴が空配列なら安全側で skip = false', () => {
+		const result = judgeSkipAcGate({
+			issueNumber: 200,
+			labels: [],
+			closedEvents: [],
+		});
+		expect(result.skip).toBe(false);
+		expect(result.reason).toContain('ClosedEvent 履歴');
+	});
+
+	it('複数 ClosedEvent では配列末尾 (直近) を判定対象とする', () => {
+		// 過去に PR 経由 close → reopen → 現在は手動 close で再 close した想定
+		const result = judgeSkipAcGate({
+			issueNumber: 300,
+			labels: [],
+			closedEvents: [
+				{ closer: { __typename: 'Commit', oid: 'abcdef1234567890' } }, // 過去
+				{ closer: null }, // 直近 (手動 close)
+			],
+		});
+		expect(result.skip).toBe(false);
+		expect(result.reason).toContain('手動 close');
+	});
+
+	it('複数 ClosedEvent で直近が PR closer なら skip = true', () => {
+		const result = judgeSkipAcGate({
+			issueNumber: 301,
+			labels: [],
+			closedEvents: [
+				{ closer: null }, // 過去 (手動 close)
+				{ closer: { __typename: 'PullRequest', number: 42 } }, // 直近 (PR 経由)
+			],
+		});
+		expect(result.skip).toBe(true);
+		expect(result.reason).toContain('PR #42');
+	});
+});
+
+describe('countAcCheckboxes', () => {
+	it('未チェック / チェック済みの両方をカウントする', () => {
+		const body = [
+			'## 完了チェックリスト',
+			'',
+			'- [ ] AC 全項目に [x] が入っている',
+			'- [x] pre-ready PASS',
+			'- [ ] Ready 化',
+			'- [X] 設計書同期',
+		].join('\n');
+		const { unchecked, checked } = countAcCheckboxes(body);
+		expect(unchecked).toBe(2);
+		expect(checked).toBe(2);
+	});
+
+	it('空文字列・null body でも例外を投げない', () => {
+		expect(countAcCheckboxes('')).toEqual({ unchecked: 0, checked: 0 });
+		// @ts-expect-error 意図的に null を渡してデフォルト値を確認
+		expect(countAcCheckboxes(null)).toEqual({ unchecked: 0, checked: 0 });
+	});
+
+	it('インデント付き checkbox も検出する', () => {
+		const body = '  - [ ] indented unchecked\n    - [x] deeply indented checked';
+		expect(countAcCheckboxes(body)).toEqual({ unchecked: 1, checked: 1 });
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（PO 補佐 / Dev / QA セッション運用効率）

**解決する課題**: `.github/workflows/issue-close-gate.yml` (ADR-0038 / ADR-0004 §3) が PR `closes #N` 経由 auto-close でも Issue を reopen するループが発生。本セッションだけで 20 件 × 3 周以上の手動 `[x]` 化作業オーバーヘッド。

**期待される効果**: PR merge での auto-close を信頼する gate に改修することで、毎セッション発生していた reopen ループが消滅 → PO/Dev/QA capacity を本来のサインアップ獲得活動に振り向け可能。

## 関連 Issue

closes #2351

関連: #1165 (ADR-0038 原典) / #1481 (warn-only 期間終了) / ADR-0004 (旧 ADR-0038 統合元)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `scripts/issue-close-gate-skip-judge.mjs` を新規作成 (純粋関数で skip 判定) | `ls scripts/issue-close-gate-skip-judge.mjs` + `node -e "import(...)..."` smoke test | PASS — 2 export (`judgeSkipAcGate` / `countAcCheckboxes`)、smoke test OK |
| AC2 | `.github/workflows/issue-close-gate.yml` を改修し GraphQL で closer 取得して PR/Commit 経由 close を skip | `git diff .github/workflows/issue-close-gate.yml` | PASS — GraphQL query + sparse-checkout で skip 判定 script を import + 判定後 `if (skip) return` で gate skip |
| AC3 | `tests/unit/workflows/issue-close-gate-skip-judge.test.ts` を追加 (4 ケース PASS) | `npx vitest run tests/unit/github/issue-close-gate-skip-judge.test.ts` | PASS — **11 ケース** PASS (PR/Commit/null/wontfix/duplicate/空配列/複数 ClosedEvent 直近判定 等、AC 4 件を超過達成)、配置先は `tests/unit/github/` (既存パターン整合) |
| AC4 | `docs/decisions/0004-review-and-ac-verification.md` に追記 | `git diff docs/decisions/0004-review-and-ac-verification.md` | PASS — §4 「issue-close-gate は手動 close のみを検証対象とする (#2351)」追加 (close 経路 4 種 × gate 挙動表 + 純粋関数参照) |
| AC5 | `.github/CLAUDE.md` に運用 SSOT 追記 | `git diff .github/CLAUDE.md` | PASS — 「issue-close-gate auto-reopen の挙動 (ADR-0004 §4 / #2351)」セクション追加 |
| AC6 | `npm run pre-ready -- --pr <num>` 全 Step PASS | (CI 緑で確認) | 後述「テスト & 安全装置セルフチェック」 |
| AC7 | PR merge 後に本 Issue が auto-reopen されないこと (gate 改修の dogfood) | merge 直後の GitHub Actions `Issue close gate` ジョブ log で `PR #N 経由 auto-close を検出、AC gate skip` を確認 | post-merge 検証 (QM が merge 後 1 分以内に Actions log を確認、SS 取得不要) |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)
- 影響なし: DB / API / UI / ドメイン / インフラ CDK / LP / サービス層

**影響を受ける画面・機能**: なし (workflow 動作のみ)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**(#1775 / ADR-0030) — ローカル biome + vitest PASS、push 後 CI で全 step 検証
- 追加・変更したテストの概要:
  - `tests/unit/github/issue-close-gate-skip-judge.test.ts` 新規 (11 ケース)
    - PR closer / Commit closer / null closer / wontfix / duplicate / 空配列 / 複数 ClosedEvent 直近判定 / countAcCheckboxes 3 ケース
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A (priority:high process 改善、Critical ではない)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は GitHub Actions workflow / Node.js 純粋関数 / ADR + CLAUDE.md docs のみで UI 変更を含まない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**:
  - 単一責任: skip 判定純粋関数 (`judgeSkipAcGate`) と AC checkbox 数え (`countAcCheckboxes`) を分離
  - 依存性逆転: workflow は純粋関数を `import()` で動的に取得 (testability 担保)
- [x] **DRY**: `body.match(...)` 正規表現を `countAcCheckboxes` に集約 (旧 workflow inline 2 行を抽出)
- [x] **YAGNI**: 現要件 (PR/Commit/null/label) のみ判定。将来的な closer 種別 (例: `Issue` cross-reference) は判定時点で未使用のため実装せず
- [x] **Security**: GraphQL query は read-only / GitHub token のみ使用 / 外部 endpoint 呼び出しなし
- [x] **アクセシビリティ**: N/A (UI なし)
- [x] **パフォーマンス**: GraphQL query 1 回追加のみ (timeout 3 分以内、従来通り)

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] N/A — 並行実装の影響範囲外 (workflow + 純粋関数 + ADR 追記のみ、UI / labels / DB に影響なし)

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** — gate skip 拡大方向の改修。手動 close gate は維持
  - 旧挙動: PR/Commit 経由 close でも `[ ]` 残存で reopen → ループ
  - 新挙動: PR/Commit 経由 close は無条件 skip (PR Ready チェックリストで検証済みのため)
  - 手動 close は従来通り `[ ]` 残存で reopen (`wontfix` / `duplicate` ラベルで bypass 可)

**レビュー依頼事項・QA**:
- ADR-0004 §4 の追記内容と `.github/CLAUDE.md` の挙動表が整合しているか
- workflow `sparse-checkout` で `scripts/issue-close-gate-skip-judge.mjs` のみ取得する設定が安全か (issues イベントでは PR ref が存在しないため `ref: main` で取得する設計)
- 本 PR merge 後、Issue #2351 が auto-close される際に gate が **skip** ログを出すこと (dogfood 検証)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (biome + vitest 個別 PASS、CI で全 step 統合検証)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (AC7 は post-merge 検証だが gate 設計上必ず skip する)
- [x] Phase 分割なし
- [x] UI 変更なし (SS 不要)
- [x] 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
