### PR TITLE
fix: #2353 [CRITICAL Phase A] PIN gate banner 残存 bug + 初期 PIN 5086 modal 露出削除

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -170,6 +170,26 @@ Layer 2: Context（署名付きトークン）
 
 子供 UI 側に PIN 通知バナーは出さない (engagement 寄与しない / 子供への余計な学習回避)。modal は親操作起点 (`/switch` のリンク click) のみで開く。
 
+#### 初期 PIN ヒント表示ポリシー (Issue #2353 Phase A、2026-05-21)
+
+業界 PIN 採用 4 サービス調査 (Apple Screen Time / Nintendo / Roblox / BusyKid) で「初期 PIN ヒントは setup 時のみ、認証 modal では非表示」が prior art 100%。これに整合し、本プロダクトも以下を遵守する:
+
+| 表示文脈 | 初期 PIN ヒント `OYAKAGI_LABELS.defaultValueHint` (= `'初期値は 5086（がんばり）です'`) | 理由 |
+|---|---|---|
+| `/setup/complete/+page.svelte` (初期 setup 完了画面) | **表示** | 親が初期 setup を完了した直後の文脈、適切 |
+| `/admin/settings/account/+page.svelte` (PIN 変更画面) | **表示** | 親が自ら PIN 変更を試みる文脈、適切 |
+| `/switch` PIN modal (`Dialog`) | **非表示** | 子供画面と同じ端末で表示される → 子供が見て即入れる脆弱性 |
+
+`OYAKAGI_LABELS.gateDefaultHint` (PIN modal 専用 atom) は #2353 Phase A で **削除**。再追加禁止 (子供脆弱性、業界 prior art ゼロ)。
+
+#### banner 残存 bug 対策 (Issue #2353 Phase A、2026-05-21)
+
+`/switch?pinRequired=1` 再アクセス時に banner だけ残って modal が出ない bug を構造的に修正:
+
+- 根本原因: `$state` 初期化が初回 mount のみで、`data.pinRequired` query 再到達時に追従しない
+- 修正: `src/routes/switch/+page.svelte` に `$effect(() => { if (data.pinRequired) { pinModalOpen = true; ... } })` で query 変化を watch
+- 業界調査 (Wave 28-A Research): 8 サービス全てで「banner + modal は同時表示 or modal 単独」、「banner だけ + modal 出ない」設計は prior art ゼロ
+
 ---
 
 ## 5. 認可

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -1226,7 +1226,8 @@ export const OYAKAGI_LABELS = {
 	gateLockoutNotice: (sec: number) => `連続で間違えたため、${sec}秒後に再度お試しください`,
 	gateFormatNotice: 'おやカギコードは4〜6桁の数字です',
 	gateGenericError: 'おやカギコードの確認に失敗しました。もう一度お試しください',
-	gateDefaultHint: '初期値は 5086（がんばり）です',
+	// Issue #2353 Fix 5 (Phase A): gateDefaultHint (= '初期値は 5086（がんばり）です') は子供が見て即入れる脆弱性のため modal 用 atom を削除
+	// setup フローでの初期値伝達は OYAKAGI_LABELS.defaultValueHint で継続 (適切な文脈 = 親が初期 setup 完了画面で見る)
 	gatePinRequiredBanner: 'ご家族の見守り画面に入るにはおやカギコードが必要です',
 } as const;
 

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -21,6 +21,19 @@ let pinSubmitting = $state<boolean>(false);
 // PinInput remount 用 key (失敗時に入力欄を確実にリセット)
 let pinInputKey = $state<number>(0);
 
+// Issue #2353 Fix 1 (Phase A): pinRequired query 再到達時 modal 自動 open 保証
+// 子供画面から戻って `/switch?pinRequired=1` 再アクセス時、banner だけ残って modal が出ない bug の構造的修正。
+// $state は初期化のみで data.pinRequired の変化に追従しないため、$effect で同期する。
+// Research 結論 (Wave 28-A): 業界 8 サービス調査で「banner だけ + modal 出さない」設計は prior art ゼロ = 構造的 bug 確定。
+$effect(() => {
+	if (data.pinRequired) {
+		pinModalOpen = true;
+		// 過去の error / lockout / 入力残骸をクリアして再入力できる状態に揃える
+		pinError = '';
+		pinInputKey += 1;
+	}
+});
+
 const lockedNow = $derived(lockoutUntil !== null && Date.now() < (lockoutUntil ?? 0));
 
 async function handleAdminLinkClick(e: MouseEvent) {
@@ -160,7 +173,9 @@ async function handlePinComplete(details: { valueAsString: string }) {
 	{#key pinInputKey}
 		<PinInput length={4} mask onComplete={handlePinComplete} />
 	{/key}
-	<p class="text-xs text-[var(--color-text-muted)] text-center mt-3">{OYAKAGI_LABELS.gateDefaultHint}</p>
+	<!-- Issue #2353 Fix 5 (Phase A): 初期 PIN 5086 ヒントを modal から削除 (子供脆弱性) -->
+	<!-- 業界 PIN 採用 4 サービス全てで初期値ヒントは setup 時のみ、modal では非表示 (Apple / Nintendo / Roblox / BusyKid) -->
+	<!-- setup/complete/+page.svelte の OYAKAGI_LABELS.defaultValueHint は適切な文脈 (初期 setup 完了時) なので維持 -->
 	{#if pinError}
 		<div class="mt-3" data-testid="parent-gate-error">
 			<Alert variant="danger">{pinError}</Alert>

--- a/tests/e2e/parent-gate.spec.ts
+++ b/tests/e2e/parent-gate.spec.ts
@@ -85,5 +85,43 @@ function registerParentGateTests(): void {
 			await page.goto('/admin', { waitUntil: 'domcontentloaded' });
 			await expect(page).toHaveURL(/\/switch\?.*pinRequired=1/);
 		});
+
+		// Issue #2353 Fix 1 (Phase A): banner 残存 + modal 出ない回帰検証
+		// 子供画面から `/switch?pinRequired=1` に再アクセスした際に banner だけでなく modal も自動 open する。
+		// Research 結論 (Wave 28-A): 業界 8 サービス調査で「banner だけ + modal 出さない」は prior art ゼロ。
+		test('Fix 1: /switch?pinRequired=1 再アクセス時に banner + modal の両方が表示される (banner 残存 bug 回帰)', async ({
+			page,
+		}) => {
+			// 1. まず child home に到達 (前段)
+			await page.goto('/switch', { waitUntil: 'domcontentloaded' });
+			const firstChildButton = page.locator('[data-testid^="child-select-"]').first();
+			await firstChildButton.click();
+			await page.waitForURL(/\/(preschool|elementary|junior|senior|baby)\/home/, {
+				timeout: 15_000,
+			});
+
+			// 2. 子供画面から /switch?pinRequired=1 に再アクセス (banner 残存 bug の再現条件)
+			await page.goto('/switch?pinRequired=1', { waitUntil: 'domcontentloaded' });
+
+			// 3. banner と modal の両方が同時に表示されること (Fix 1 修正前は modal が出ない bug)
+			await expect(page.getByTestId('parent-gate-required-banner')).toBeVisible();
+			await expect(page.getByTestId('parent-gate-modal')).toBeVisible();
+		});
+
+		// Issue #2353 Fix 5 (Phase A): 初期 PIN 5086 ヒント modal 非表示回帰検証
+		// PIN modal に「初期値は 5086（がんばり）です」が表示されないこと (子供脆弱性対策)。
+		// Research 結論: Apple / Nintendo / Roblox / BusyKid 全て modal では初期 PIN ヒント非表示。
+		test('Fix 5: PIN modal に初期 PIN 5086 ヒントが表示されない (子供脆弱性回帰)', async ({
+			page,
+		}) => {
+			await page.goto('/switch?pinRequired=1', { waitUntil: 'domcontentloaded' });
+			await expect(page.getByTestId('parent-gate-modal')).toBeVisible();
+
+			// modal 内に 5086 / "初期値" / "がんばり" 文字が含まれないこと
+			const modal = page.getByTestId('parent-gate-modal');
+			await expect(modal).not.toContainText('5086');
+			await expect(modal).not.toContainText('初期値');
+			await expect(modal).not.toContainText('がんばり');
+		});
 	});
 }


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）+ 全 family member

**解決する課題**: Issue #2353 (PR #2325 / EPIC #2310 派生) で PO から直接指摘された PIN gate 6 設計欠陥のうち、本番ユーザー UX 詰まりと子供セキュリティ脆弱性に直結する **Critical 2 件** を 24h SLA で hotfix。Phase B-E (SSOT 違反 / ひらがな漢字化 / PIN reset 導線 / 初心者導線) は別 PR で並行進行。

**期待される効果**:
- Fix 1: `/switch?pinRequired=1` 再アクセス時に banner だけ残って PIN modal が出ない bug を解消。親が画面更新せずに即 PIN 入力可能に。
- Fix 5: PIN modal から「初期値は 5086（がんばり）です」表示を削除。子供が見て即入れる脆弱性を解消。

## 関連 Issue

Related #2353 (Phase A scope のみ部分対応、Phase B-E は別 PR で完遂)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC2 | 設計欠陥 1 (エラー banner 残存) の cookie / state 管理 bug を修正、`/switch` 再アクセスで PIN modal 自動表示 (画面更新不要)、E2E spec で回帰検証 | `tests/e2e/parent-gate.spec.ts` `Fix 1: /switch?pinRequired=1 再アクセス時に banner + modal の両方が表示される` | E2E spec 追加 PASS (PARENT_GATE_FORCE_ACTIVE=true 起動時) + `src/routes/switch/+page.svelte` `$effect` 同期実装 |
| AC6 | 設計欠陥 5 初期 PIN 5086 ヒント表示削除 — `OYAKAGI_LABELS.defaultValueHint` を PIN modal から除去、setup フロー completion 画面でのみ表示 (子供が見える文脈に出さない) | `tests/e2e/parent-gate.spec.ts` `Fix 5: PIN modal に初期 PIN 5086 ヒントが表示されない` + SS 目視 (mobile / desktop) | E2E spec 追加 PASS + SS で「初期値」「5086」「がんばり」非表示確認 + `OYAKAGI_LABELS.gateDefaultHint` atom 削除 |
| AC1/3/4/5/7/8/9/10 | <!-- ac-verification-skip: Phase A scope 外 (Phase B-E 別 PR で対応) --> | — | 別 PR で対応 (Research / SSOT 違反 / ひらがな化 / PIN reset / 初心者導線 / ADR-0050 §7 / E2E 拡充 / 設計書同期) |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/`) — `src/routes/switch/+page.svelte`
- [x] ドメインモデル (`$lib/domain/`) — `src/lib/domain/labels.ts` (`OYAKAGI_LABELS.gateDefaultHint` 削除)

**影響を受ける画面・機能**: `/switch` PIN gate modal (全 user 共通、cognito production / PARENT_GATE_FORCE_ACTIVE=true 起動時)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**: pre-commit hook (biome / generate-lp-labels / sync-lp-fallback) PASS、svelte-check 既存 unrelated エラー 2 件 (`cookie-signature` / `canvas-confetti`、本 PR 範囲外) のみ、vitest 786 件 PASS
- [x] 追加・変更したテストの概要:
  - `tests/e2e/parent-gate.spec.ts` に 2 件追加
    - `Fix 1: /switch?pinRequired=1 再アクセス時に banner + modal の両方が表示される (banner 残存 bug 回帰)`
    - `Fix 5: PIN modal に初期 PIN 5086 ヒントが表示されない (子供脆弱性回帰)`
- [x] 新規 env / secret 追加なし — N/A
- [x] DynamoDB 実装変更なし — N/A
- [x] **Critical バグ修正 (ADR-0002) 5 要件**:
  1. E2E 回帰: `tests/e2e/parent-gate.spec.ts` に Fix 1 / Fix 5 各 1 件追加
  2. AC 全完了: AC2 + AC6 のみ部分対応 (Phase A scope 限定、AC1/3/4/5/7/8/9/10 は別 PR、Issue 本文に明記)
  3. 提案全実装: Phase A 提案 (Fix 1 + Fix 5) 全実装
  4. 5 年齢モード検証: PIN gate は親側機構で年齢モード非依存、mobile/desktop SS で UI 確認
  5. 直近 30 日重複変更チェック: PR #2325 (EPIC #2310 / 2026-05-20 merge) 派生 = 同一機構の改修 (本 PR は #2325 直接の派生 hotfix)

## スクリーンショット / ビジュアルデモ

**SS 撮影方法**: `AUTH_MODE=cognito COGNITO_DEV_MODE=true PARENT_GATE_FORCE_ACTIVE=true npx vite dev --port 5194 --strictPort --host 127.0.0.1` 起動 + `MSYS_NO_PATHCONV=1 node scripts/capture.mjs --flow pin-gate-banner-2353 --url /auth/login --actions scripts/capture-specs/flows/pin-gate-banner-2353.mjs --base-url http://127.0.0.1:5194 --presets mobile,desktop --pr 2359 --format webp`。BEFORE 撮影は別 worktree (`git worktree add ../gq-main-before origin/main`) で `+page.svelte` / `labels.ts` を main HEAD 状態に差し替えて再撮影 (#2059 sha256 偽装 gate 整合 — 4 SS distinct SHA256 確認済)。

**4 スロット添付**:

| | モバイル (375×844) | PC (1280×800) |
|---|---|---|
| **修正前** (main HEAD = `c64dab3a`) — PIN modal に「初期値は 5086（がんばり）です」5086 ヒント表示 = 子供脆弱性 | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2359/parent-gate-2353-before-flow.webp) | ![before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2359/parent-gate-2353-before-desktop-flow.webp) |
| **修正後** (PR HEAD = `32ff8465`) — 5086 ヒント完全削除 + `$effect` で `/switch?pinRequired=1` 再到達時の modal 自動 open 保証 | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2359/parent-gate-2353-after-flow.webp) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2359/parent-gate-2353-after-desktop-flow.webp) |

**観察ポイント**:
- BEFORE モバイル / デスクトップ: PIN modal 下端に「初期値は 5086（がんばり）です」ヒントが表示されており、子供がこの画面を見ると即座に PIN を入力できてしまう脆弱性 (Fix 5 対象)
- AFTER モバイル / デスクトップ: 同じ位置のヒントが完全に削除され、ヒントなしの 4 桁 PIN 入力フィールドのみ。setup フロー完了画面 (`OYAKAGI_LABELS.defaultValueHint`) では文脈通り表示継続 = 親が初期 setup 時に伝達された PIN を覚える運用

**インタラクティブ状態**: modal initial (空入力) のみで Fix 5 視覚差分は十分検出可能。typing / invalid PIN / lockout は既存 `parent-gate-2310` flow が PR #2325 で網羅済のため重複撮影 skip (Anti-engagement / SS 数最小化、ADR-0012 整合)。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `$effect` で URL query → state 同期は単一責任、modal 内 hint 削除は `OYAKAGI_LABELS` SSOT 削減で DI 拡張不要
- [x] **DRY**: `OYAKAGI_LABELS.gateDefaultHint` の grep 全件確認済 (modal 専用、他参照なし)、`OYAKAGI_LABELS.defaultValueHint` は setup/complete で継続使用
- [x] **YAGNI**: 抽象化追加なし、最小修正 (`$effect` 1 ブロック + label 1 行削除 + 表示行削除)
- [x] **Security**: 初期 PIN 5086 ヒント modal 露出を削除 → 子供脆弱性解消 (本 PR の主目的の 1 つ)
- [x] **アクセシビリティ**: 既存 Dialog / PinInput primitive 構造維持、追加要素なし
- [x] **パフォーマンス**: `$effect` は cheap な比較のみ、N+1 影響なし

## 横展開・影響波及チェック

- [x] **labels SSOT** (ADR-0009 / 0045): `OYAKAGI_LABELS.gateDefaultHint` 削除、`gateDefaultHint` を参照していたのは `src/routes/switch/+page.svelte` のみ (grep 確認済)。`OYAKAGI_LABELS.defaultValueHint` は setup/complete で継続使用 (適切な文脈)
- [x] **設計書同期** (ADR-0001): `docs/design/14-セキュリティ設計書.md` §4.3 に追記 (初期 PIN ヒント表示ポリシー table 3 文脈別 + banner 残存 bug 対策)
- [x] **並行 PR overlap** (#1200): 本 PR が変更する `src/routes/switch/+page.svelte` / `src/lib/domain/labels.ts` を同時期に変更する Wave 28-C (Phase B-E) PR と labels.ts / switch route conflict 可能性あり → 早期 merge 推奨 (Phase B-E が後から rebase)
- [ ] 本番アプリ + デモ版同期 — PIN gate は cognito production / PARENT_GATE_FORCE_ACTIVE=true のみ動作、demo Lambda (`AUTH_MODE=anonymous`) では無効 → 同期不要
- [ ] 全年齢モード 5 種 — PIN gate は親側機構で年齢モード非依存
- [ ] ナビゲーション 3 種 — `/switch` のみ影響、ナビ非該当
- [ ] E2E / ユニットシード + チュートリアル — `tests/e2e/parent-gate.spec.ts` 追加のみ、seed / tutorial 変更なし
- [x] **LP ↔ アプリ双方向整合** (#1481 / ADR-0013): LP は PIN gate を訴求していない (家庭内軽ロック、marketing 対象外) → 整合維持

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A — LP / pricing / plan-features 文言変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** — `OYAKAGI_LABELS.gateDefaultHint` atom 削除は modal 表示の internal SSOT で、外部 API / DB スキーマ / cookie / 認証フロー変更なし

**レビュー依頼事項・QA**:
- Fix 1 `$effect` の二重発火 (data.pinRequired 真偽値同値再代入時) は意図的: 過去 error / lockout / pinInputKey をリセットすることで「銀行 ATM 風」の毎回クリーンスレート挙動を保証
- Fix 5 削除した atom (`OYAKAGI_LABELS.gateDefaultHint`) は modal 専用で他参照なし (grep 確認)、再追加禁止を設計書にも明記済 (docs/design/14-セキュリティ設計書.md §4.3 「初期 PIN ヒント表示ポリシー」)
- Wave 28-C (Phase B-E) と labels.ts / switch route conflict 可能性あり、本 PR 早期 merge 推奨

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし (既存 `PARENT_GATE_COOKIE_SECRET` / `PARENT_GATE_FORCE_ACTIVE` を継続使用)

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 相当 ローカル確認**: pre-commit hook PASS + biome / svelte-check (unrelated 既存 2 件のみ) / vitest 786 件 PASS / check-no-plan-literals OK / generate-lp-labels --check OK / sync-lp-fallback --check OK
- [x] セルフレビュー済み (デバッグコードなし、最小差分)
- [x] AC2 + AC6 のみ実装 (Phase A scope 限定、他 AC は Issue 本文で別 PR 進行明記)
- [x] Phase 分割: PO 指示 (Wave 28-A Research → Phase A 緊急 + Phase B-E 並行) に従い分割済み、Issue #2353 が親
- [x] UI 変更時 SS: screenshots branch `pr-2359/` に 4 SS push 済 (before-mobile / before-desktop / after-mobile / after-desktop、distinct SHA256)、本 PR body §「スクリーンショット」に raw.githubusercontent.com URL で添付
- [x] 認証画面変更時 `npm run dev:cognito` (#1026) 経由で撮影済 (port 5194、PARENT_GATE_FORCE_ACTIVE=true)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

