### PR TITLE
fix: #2356 deploy-nuc.yml actor ガード リスト拡張 (PO + QA account 許可、EPIC #2354 ②)

### DIFF
--- a/.github/workflows/deploy-nuc.yml
+++ b/.github/workflows/deploy-nuc.yml
@@ -24,8 +24,16 @@ concurrency:
 jobs:
   deploy-nuc:
     runs-on: [self-hosted, Windows, X64]
-    # Public repository guard: only trusted actors can trigger this workflow on the
-    # self-hosted NUC runner. fork PR からの未承認 push 実行を防ぐ。
+    # Self-hosted runner actor guard: restrict self-hosted NUC runner execution to
+    # trusted actors performing main push / workflow_dispatch.
+    #
+    # 本 workflow の trigger は `push: branches=[main]` + `workflow_dispatch` のみで、
+    # fork PR からの直接 push は GitHub の保護により発生しない (upstream main への push
+    # 権限が fork 側にないため)。workflow_dispatch も upstream リポジトリの権限がある
+    # actor からしか発火しない。したがって本 actor allowlist の目的は「fork PR 防御」
+    # ではなく、**self-hosted NUC runner 上で実行できる actor を ADR-0022 体制で
+    # 想定済みの 2 account に絞り込み、想定外の actor (誤って付与された collaborator /
+    # 将来の admin bypass 等) による NUC 本番マシン上での任意コード実行を防ぐ**こと。
     #
     # 許可リスト (ADR-0022 QA merge 体制 + Issue #2356 / EPIC #2354):
     #   - Takenori-Kusaka       : PO (リポジトリ owner)。手動 dispatch / 自身 commit の main 経由 push
@@ -34,7 +42,6 @@ jobs:
     #                                ここを許可しないと QA merge 後の main push で NUC deploy が
     #                                全件 skip され、本番 / NUC 環境が長期間古い build に固定される。
     #
-    # fork PR からの実行は actor が両 account 外となるため skip される (防御維持)。
     # 信頼 account 追加時は本リストに追記するだけで対応可。
     if: contains(fromJSON('["Takenori-Kusaka", "ganbariquestsupport-lab"]'), github.actor)
     defaults:

--- a/.github/workflows/deploy-nuc.yml
+++ b/.github/workflows/deploy-nuc.yml
@@ -24,9 +24,19 @@ concurrency:
 jobs:
   deploy-nuc:
     runs-on: [self-hosted, Windows, X64]
-    # Public repository guard: only the repo owner can trigger this workflow.
-    # Prevents unauthorized fork PRs from executing commands on the self-hosted runner.
-    if: github.actor == 'Takenori-Kusaka'
+    # Public repository guard: only trusted actors can trigger this workflow on the
+    # self-hosted NUC runner. fork PR からの未承認 push 実行を防ぐ。
+    #
+    # 許可リスト (ADR-0022 QA merge 体制 + Issue #2356 / EPIC #2354):
+    #   - Takenori-Kusaka       : PO (リポジトリ owner)。手動 dispatch / 自身 commit の main 経由 push
+    #   - ganbariquestsupport-lab : QA セッション専用 account。ADR-0022 で確立した
+    #                                "QA approve + squash merge" 体制での merge actor。
+    #                                ここを許可しないと QA merge 後の main push で NUC deploy が
+    #                                全件 skip され、本番 / NUC 環境が長期間古い build に固定される。
+    #
+    # fork PR からの実行は actor が両 account 外となるため skip される (防御維持)。
+    # 信頼 account 追加時は本リストに追記するだけで対応可。
+    if: contains(fromJSON('["Takenori-Kusaka", "ganbariquestsupport-lab"]'), github.actor)
     defaults:
       run:
         shell: powershell

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -401,6 +401,10 @@ export function resolveDemoActive(env: Pick<TypedEnv, 'AUTH_MODE' | 'DATA_SOURCE
 - バージョニング: Git tag (`v*.*.*`) でセマンティックバージョン管理、main push は dev ビルド
 - 自動更新: Dependabot（GitHub Actions + npm + infra npm の3エコシステム週次更新）
 
+### 4.1 NUC self-hosted runner actor ガード (Issue #2356 / EPIC #2354)
+
+`deploy-nuc.yml` は public repo の self-hosted runner で動作するため、fork PR 防御として **actor 許可リスト**で限定する (`if: contains(fromJSON('["Takenori-Kusaka", "ganbariquestsupport-lab"]'), github.actor)`)。許可は (1) **Takenori-Kusaka** (PO / repo owner) と (2) **ganbariquestsupport-lab** (ADR-0022 QA merge 体制の squash merge actor) の 2 account のみ。fork PR や任意の bot は両 account 外となるため skip され、self-hosted runner 上での未承認 command 実行を防ぐ (信頼境界維持)。AWS Lambda 側 `deploy.yml` は GitHub-hosted runner + OIDC で動くため本 gate は不要。新たな信頼 account を追加する場合は本リストに 1 行追記すれば足り、構造変更は伴わない。
+
 ## 5. セキュリティ（WAFなし構成）
 
 | 対策 | 実装 | コスト |

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -403,7 +403,7 @@ export function resolveDemoActive(env: Pick<TypedEnv, 'AUTH_MODE' | 'DATA_SOURCE
 
 ### 4.1 NUC self-hosted runner actor ガード (Issue #2356 / EPIC #2354)
 
-`deploy-nuc.yml` は public repo の self-hosted runner で動作するため、fork PR 防御として **actor 許可リスト**で限定する (`if: contains(fromJSON('["Takenori-Kusaka", "ganbariquestsupport-lab"]'), github.actor)`)。許可は (1) **Takenori-Kusaka** (PO / repo owner) と (2) **ganbariquestsupport-lab** (ADR-0022 QA merge 体制の squash merge actor) の 2 account のみ。fork PR や任意の bot は両 account 外となるため skip され、self-hosted runner 上での未承認 command 実行を防ぐ (信頼境界維持)。AWS Lambda 側 `deploy.yml` は GitHub-hosted runner + OIDC で動くため本 gate は不要。新たな信頼 account を追加する場合は本リストに 1 行追記すれば足り、構造変更は伴わない。
+`deploy-nuc.yml` は public repo の self-hosted runner で動作するため、**self-hosted NUC runner 上で実行できる actor を ADR-0022 体制で想定済みの actor に限定する** ために actor 許可リストで gate する (`if: contains(fromJSON('["Takenori-Kusaka", "ganbariquestsupport-lab"]'), github.actor)`)。本 workflow の trigger は `push: branches=[main]` + `workflow_dispatch` のみであり、fork PR からの直接 push は GitHub の保護 (fork 側に upstream main への push 権限がない) により発生せず、`workflow_dispatch` も upstream リポジトリの権限がある actor からしか発火しない。したがって本 gate の目的は「fork PR 防御」ではなく、**想定外の actor (誤って付与された collaborator / 将来の admin bypass / bot 等) による NUC 本番マシン上での任意コード実行を防ぐ**こと。許可は (1) **Takenori-Kusaka** (PO / repo owner) と (2) **ganbariquestsupport-lab** (ADR-0022 QA merge 体制の squash merge actor) の 2 account のみ。AWS Lambda 側 `deploy.yml` は GitHub-hosted runner + OIDC で動くため本 gate は不要。新たな信頼 account を追加する場合は本リストに 1 行追記すれば足り、構造変更は伴わない。
 
 ## 5. セキュリティ（WAFなし構成）
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（最終的には NUC ローカル親管理画面を使う家族にも波及）

**解決する課題**: `deploy-nuc.yml` actor ガード `if: github.actor == 'Takenori-Kusaka'` が、ADR-0022 で確立した QA merge 体制 (`ganbariquestsupport-lab` account による squash merge) と構造的に不整合。QA merge 後の main push では `github.actor=ganbariquestsupport-lab` となり、actor ガードに引っかかって NUC deploy job が**全件 skipped** になっていた。結果 NUC 環境がコミット `dbebd732` (Parent-Gate 時点) で停止し、本セッション merge 済の PR 5 件が NUC 環境に未反映 → ユーザ NUC ローカル親管理画面の表示デグレ (5 タブのはずが 4 タブ表示で「家族」タブが無い)。

**期待される効果**: QA merge 後の NUC deploy 自動 trigger が成功するようになり、QA 体制 (ADR-0022) と NUC deploy パイプラインが整合する。fork PR 防御 (信頼 actor リスト外は skip) は維持。EPIC #2354 ② として表示デグレの構造的解消 (子①/③/④と相補的)。

## 関連 Issue

closes #2356

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `.github/workflows/deploy-nuc.yml` line 29 を `contains(fromJSON([...]), github.actor)` に変更 | `grep "contains.fromJSON" .github/workflows/deploy-nuc.yml` | PASS (許可リスト `["Takenori-Kusaka", "ganbariquestsupport-lab"]` を line 37 に配置) |
| AC2 | 本 PR 自身が dogfood: QA merge 後の NUC deploy 自動 trigger 成功 | merge 後 `gh run list --workflow=deploy-nuc.yml --limit=1 --json conclusion` で success 確認 | merge 後 QA team が dogfood として検証 (本 PR 自身が QA merge されて初めて検証可能なため、AC2 は merge 時点でのみ充足判定可) |
| AC3 | PR description に変更前後の actor ガード比較 + セキュリティ考慮表 + dogfood run id 記載 | 本 PR body 下部参照 | PASS (下記「変更前後 + セキュリティ考慮」セクション、dogfood run id は AC2 と同じく merge 後追記) |
| AC4 | `docs/decisions/0022-*.md` または関連設計書に「actor ガード調整経緯」を補足追記 | `grep "actor ガード" docs/design/13-AWSサーバレスアーキテクチャ設計書.md` | PASS (§4.1 として 1 段落追記。ADR-0022 への注記は子 Issue #2354 ④ で完成) |

### 変更前後 + セキュリティ考慮 (AC3 補足)

`if` 式の変更内容:

```diff
- if: github.actor == 'Takenori-Kusaka'
+ if: contains(fromJSON('["Takenori-Kusaka", "ganbariquestsupport-lab"]'), github.actor)
```

セキュリティ評価 (4 観点):

- **fork PR 防御**: 維持。許可リスト外 actor は skip され、self-hosted runner 上での command 実行不可
- **QA account 信頼性**: ADR-0022 で確立した QA approve + squash merge 体制下にあり、PR review 必須化 + `bypass_actors:[]` で信頼境界内
- **self-hosted runner 悪用リスク**: 低。両 account とも `bypass_actors:[]` 体制で bypass 不可
- **将来の actor 追加**: リスト 1 行追記で柔軟対応可、構造変更不要

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [x] インフラ (`.github/workflows/deploy-nuc.yml`)
- [ ] LP サイト
- [x] 設定・CI (workflow ファイル変更)

**影響を受ける画面・機能**: NUC self-hosted runner 上で実行される deploy パイプライン (画面・UI 直接影響なし。merge 後の deploy 成功で NUC ローカル親管理画面 5 タブ表示が同期復旧することが期待される波及効果)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2356` 全 Step PASS**（次セクション参照） — biome / svelte-check / vitest / hardcoded-strings / check-pr-body
- [x] 追加・変更したテストの概要: **N/A** — workflow `if` 式変更 + 設計書 1 段落追記のみ。GitHub Actions の `contains(fromJSON([...]), <var>)` は公式関数で挙動安定、ユニット test 対象外。dogfood 検証 (AC2) で実機 trigger 確認
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A (priority:high で critical 未指定。EPIC #2354 ② 子 Issue として起票)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: workflow `if` 式変更 + AWS 設計書 1 段落追記のみで UI 変更なし。NUC ローカル親管理画面の表示デグレ自体は本 PR scope 外 (EPIC #2354 の他子 Issue で扱う)。本 PR は「QA merge 後の deploy が trigger される」構造修正のみ。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 (actor ガード判定のみ修正) / 既存依存関係に変更なし
- [x] **DRY**: `github.actor` 参照を全 workflow で `grep` 確認。`dependabot-auto-merge.yml` の `dependabot[bot]` は別目的、`pr-*-gate.yml` の `!= dependabot[bot]` も除外条件で別目的。本 PR で同期修正不要
- [x] **YAGNI**: 許可リストに 2 account のみ追加、追加の actor は将来必要時に追記
- [x] **Security**: fork PR 防御は actor 許可リストで維持。許可 account は両者ともリポジトリ信頼境界内 (PO + QA 専用) で `bypass_actors:[]` 体制 (ADR-0022) 下にある
- [x] **アクセシビリティ**: N/A (UI 非該当)
- [x] **パフォーマンス**: N/A (workflow trigger 1 回の if 評価のみ)

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版 — 影響なし (workflow のみ)
- [ ] LP ↔ アプリ双方向整合 — 影響なし
- [ ] 全年齢モード 5 種 — 非依存
- [ ] ナビゲーション 3 種 — 影響なし
- [ ] E2E / ユニットシード + チュートリアル — 影響なし
- [ ] labels SSOT — 影響なし
- [x] **設計書同期** (ADR-0001): `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §4.1 に NUC actor ガード方針節を追記
- [ ] 並行 PR overlap (#1200) — 本 PR が変更する `.github/workflows/deploy-nuc.yml` を変更する open PR なし（同時起票なし）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- AC2 (dogfood) は本 PR 自身が QA merge されて初めて検証可能。merge 後 `gh run list --workflow=deploy-nuc.yml --limit=1` で `conclusion=success` を確認できれば AC2 PASS
- 許可リスト 2 account の正当性: PO (Takenori-Kusaka) は repo owner、QA (ganbariquestsupport-lab) は ADR-0022 で確立した squash merge 専用 account。両者とも `bypass_actors:[]` 体制下で、self-hosted runner 上での command 実行を信頼できる
- workflow 内の他 actor 参照は除外条件 (dependabot bot) または表示用のみで本 PR scope 外

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2356` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC2 のみ merge 後の dogfood 検証、それ以外は本 PR 内で完結）
- [x] Phase 分割した場合: EPIC #2354 子② として起票済み、他子 Issue (子①/③/④) と独立並行可
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入。フォーマット・必須手順は docs/sessions/qa-session.md「Tier 2 手順 5」を参照。
     CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（ADR-0022）。 -->

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
