### PR TITLE
refactor: #2368 rule-preset を新 Strategy 経由に移行 (EPIC #2362 P3、4 ruleType sub-dispatcher 設計)

### DIFF
--- a/src/lib/marketplace/index.ts
+++ b/src/lib/marketplace/index.ts
@@ -47,7 +47,7 @@ export { MARKETPLACE_TYPE_CODES } from './types.js';
 // 順序は仕様上の依存ではなく可読性のため alphabetical 推奨。
 import './types/activity-pack.js'; // #2365
 import './types/reward-set.js'; // #2366
-// 後続 Issue #2367-2369 で各 type の side-effect import をここに追加する。
+import './types/rule-preset.js'; // #2368
+// 後続 Issue #2367 / #2369 で各 type の side-effect import をここに追加する。
 //   import './types/checklist';       // #2367
-//   import './types/rule-preset';     // #2368
 //   import './types/challenge-set';   // #2369

--- a/src/lib/marketplace/strategies/rule-preset-strategy.ts
+++ b/src/lib/marketplace/strategies/rule-preset-strategy.ts
@@ -1,0 +1,255 @@
+/**
+ * rule-preset ImportStrategy — ADR-0052 (Issue #2368)
+ *
+ * 旧 `src/lib/server/services/rule-preset-import-service.ts` (390 行 / 4 ruleType 分岐 switch)
+ * を `ImportStrategy<RulePresetPayload>` に rewrap した Strategy 実装。
+ *
+ * 設計原則 (ADR-0052 §3):
+ *   - 4 ruleType (exchange / bonus / penalty / special) を **Strategy 内部 sub-dispatcher**
+ *     に集約。ruleType 別の dispatch を interface contract で破られない設計
+ *   - 各 ruleType の実装は `./rule-preset/<ruleType>.ts` に分離 (Strategy 内 OCP)
+ *   - `parse()`: Valibot schema 経由で validation (#2364)
+ *   - `preview()`: DB write 禁止、件数集計 + alreadyImported 判定
+ *   - `apply()`: ruleType 別 sub-strategy に dispatch、結果を `ImportResult` に正規化
+ *   - tenant 強制: `ctx.tenantId` を全メソッドで必須使用
+ *
+ * 4 ruleType 動作差異:
+ *   - **exchange** → `special_rewards` に各 rule を挿入 (childId 必須)
+ *   - **bonus**    → `settings.rule_preset_bonus_overrides` に preset 全体を追記
+ *   - **penalty**  → ADR-0012 §6 で慎重審査中、no-op + audit log + warning
+ *   - **special**  → 将来枠、no-op + audit log + warning
+ *
+ * Strangler Fig (ADR-0052 §3.4):
+ *   - 本 Strategy は旧 `rule-preset-import-service.ts` の挙動を sub-strategy 群に
+ *     分割しつつ等価機能を提供
+ *   - 旧 service は 1 release 並行稼働 (@deprecated marker)
+ *   - bonus state KVS の SSOT は `./rule-preset/bonus-state.ts` に集約済 — 旧 service
+ *     の `loadBonusOverrides` は本 SSOT への薄い re-export に縮退
+ *
+ * rule-preset 固有戻り値 (warnings / ruleType / alreadyImported) は generic
+ * `ImportResult` に収まらないため、registry 経由で本 Strategy を取得した callsite が
+ * `previewRulePreset()` / `applyRulePreset()` 拡張 method を直接呼ぶ。
+ *
+ * 関連:
+ *   - ADR-0052 (MarketplaceTypeRegistry + ImportStrategy)
+ *   - ADR-0012 §6 (Anti-engagement の penalty 制限)
+ *   - ADR-0023 archive (tenant isolation 強制)
+ *   - $lib/marketplace/schemas/rule-preset-schema (#2364)
+ *   - $lib/server/services/rule-preset-import-service (旧 service、@deprecated)
+ */
+
+import * as v from 'valibot';
+import {
+	type RulePresetPayload,
+	RulePresetPayloadSchema,
+} from '$lib/marketplace/schemas/rule-preset-schema.js';
+import type {
+	ImportContext,
+	ImportPreview,
+	ImportResult,
+	ImportStrategy,
+} from '$lib/marketplace/types.js';
+import { logger } from '$lib/server/logger';
+import { applyBonus, previewBonus } from './rule-preset/bonus.js';
+import { applyExchange, previewExchange } from './rule-preset/exchange.js';
+import { applyPenalty } from './rule-preset/penalty.js';
+import { applySpecial } from './rule-preset/special.js';
+
+/**
+ * rule-preset の preset identity (preview / apply 拡張 method の追加引数 SSOT)。
+ *
+ * `ImportContext` には generic field しかないため、preset 単位の identity
+ * (id / 表示名 / icon) を別 interface で渡す。callsite はこの interface を
+ * 作って `previewRulePreset()` / `applyRulePreset()` を呼ぶ。
+ */
+export interface RulePresetIdentity {
+	presetId: string;
+	presetName: string;
+	presetIcon: string;
+}
+
+/** rule-preset preview の拡張戻り値 (alreadyImported / ruleType を含む) */
+export interface RulePresetPreviewResult {
+	presetId: string;
+	presetName: string;
+	presetIcon: string;
+	ruleType: RulePresetPayload['ruleType'];
+	ruleCount: number;
+	alreadyImported: boolean;
+}
+
+/** rule-preset apply の拡張戻り値 (warnings を含む) */
+export interface RulePresetApplyResult {
+	imported: number;
+	skipped: number;
+	warnings: string[];
+	errors: string[];
+}
+
+/**
+ * rule-preset Strategy 実装 (SSOT、Issue #2368)。
+ *
+ * generic `ImportStrategy<RulePresetPayload>` interface を満たしつつ、
+ * rule-preset 固有戻り値 (warnings / ruleType / alreadyImported) を扱う
+ * 拡張 method (`previewRulePreset` / `applyRulePreset`) を追加で提供する。
+ */
+export const rulePresetStrategy: ImportStrategy<RulePresetPayload> & {
+	previewRulePreset: (
+		identity: RulePresetIdentity,
+		payload: RulePresetPayload,
+		ctx: ImportContext,
+	) => Promise<RulePresetPreviewResult>;
+	applyRulePreset: (
+		identity: RulePresetIdentity,
+		payload: RulePresetPayload,
+		ctx: ImportContext,
+	) => Promise<RulePresetApplyResult>;
+} = {
+	parse(input: unknown): RulePresetPayload {
+		const result = v.safeParse(RulePresetPayloadSchema, input);
+		if (!result.success) {
+			const firstIssue = result.issues[0];
+			const path = firstIssue?.path?.map((p) => p.key).join('.') ?? '(root)';
+			throw new Error(
+				`[rule-preset-strategy] validation failed at "${path}": ${firstIssue?.message ?? 'unknown'}`,
+			);
+		}
+		return result.output;
+	},
+
+	/**
+	 * generic preview: identity 情報を持たない呼び出し用に簡易版を提供する。
+	 * 通常は `previewRulePreset()` を使う。
+	 */
+	async preview(payload: RulePresetPayload, _ctx: ImportContext): Promise<ImportPreview> {
+		return {
+			total: payload.rules.length,
+			newItems: payload.rules.length,
+			duplicates: 0,
+			duplicateNames: [],
+		};
+	},
+
+	/**
+	 * generic apply: identity 情報を持たない呼び出し用の縮退版。
+	 * 通常は `applyRulePreset()` を使う (warnings / alreadyImported 検知のため)。
+	 *
+	 * ctx.presetId が無い場合は `errors` で fail-fast (rule-preset は identity 必須)。
+	 */
+	async apply(payload: RulePresetPayload, ctx: ImportContext): Promise<ImportResult> {
+		if (ctx.dryRun === true) {
+			return { imported: 0, skipped: 0, errors: [] };
+		}
+		if (!ctx.presetId) {
+			return {
+				imported: 0,
+				skipped: 0,
+				errors: [
+					'[rule-preset-strategy] apply() には ctx.presetId が必要です — 通常は applyRulePreset() を使ってください',
+				],
+			};
+		}
+		const result = await this.applyRulePreset(
+			{ presetId: ctx.presetId, presetName: ctx.presetId, presetIcon: '' },
+			payload,
+			ctx,
+		);
+		return {
+			imported: result.imported,
+			skipped: result.skipped,
+			errors: [...result.errors, ...result.warnings],
+		};
+	},
+
+	// =====================================================
+	// 拡張 method: rule-preset 固有 戻り値 (warnings / ruleType / alreadyImported)
+	// =====================================================
+
+	async previewRulePreset(
+		identity: RulePresetIdentity,
+		payload: RulePresetPayload,
+		ctx: ImportContext,
+	): Promise<RulePresetPreviewResult> {
+		const ruleType = payload.ruleType;
+		const base = {
+			presetId: identity.presetId,
+			presetName: identity.presetName,
+			presetIcon: identity.presetIcon,
+			ruleType,
+			ruleCount: payload.rules.length,
+		};
+
+		if (ruleType === 'exchange') {
+			const r = await previewExchange(identity.presetId, payload, ctx.tenantId, ctx.childId);
+			return { ...base, alreadyImported: r.alreadyImported };
+		}
+		if (ruleType === 'bonus') {
+			const r = await previewBonus(identity.presetId, payload, ctx.tenantId);
+			return { ...base, alreadyImported: r.alreadyImported };
+		}
+		// penalty / special: 常に false (取込試行のたびに warning が積まれる)
+		return { ...base, alreadyImported: false };
+	},
+
+	async applyRulePreset(
+		identity: RulePresetIdentity,
+		payload: RulePresetPayload,
+		ctx: ImportContext,
+	): Promise<RulePresetApplyResult> {
+		const ruleType = payload.ruleType;
+		const tenantId = ctx.tenantId;
+
+		// dryRun: DB write 禁止、preview と等価な空結果
+		if (ctx.dryRun === true) {
+			return { imported: 0, skipped: 0, warnings: [], errors: [] };
+		}
+
+		// sub-dispatcher: ruleType 別の処理を内部で完結させる
+		let result: RulePresetApplyResult;
+
+		if (ruleType === 'exchange') {
+			const r = await applyExchange(identity.presetId, payload, tenantId, ctx.childId);
+			result = { imported: r.imported, skipped: r.skipped, warnings: [], errors: r.errors };
+		} else if (ruleType === 'bonus') {
+			const r = await applyBonus(
+				identity.presetId,
+				identity.presetName,
+				identity.presetIcon,
+				payload,
+				tenantId,
+			);
+			result = { imported: r.imported, skipped: r.skipped, warnings: [], errors: r.errors };
+		} else if (ruleType === 'penalty') {
+			const r = await applyPenalty(identity.presetId, tenantId);
+			result = {
+				imported: r.imported,
+				skipped: r.skipped,
+				warnings: r.warnings,
+				errors: r.errors,
+			};
+		} else {
+			// special
+			const r = await applySpecial(identity.presetId, tenantId);
+			result = {
+				imported: r.imported,
+				skipped: r.skipped,
+				warnings: r.warnings,
+				errors: r.errors,
+			};
+		}
+
+		logger.info('[rule-preset-strategy] インポート完了', {
+			context: {
+				tenantId,
+				presetId: identity.presetId,
+				ruleType,
+				imported: result.imported,
+				skipped: result.skipped,
+				warnings: result.warnings.length,
+				errors: result.errors.length,
+			},
+		});
+
+		return result;
+	},
+};

--- a/src/lib/marketplace/strategies/rule-preset/bonus-state.ts
+++ b/src/lib/marketplace/strategies/rule-preset/bonus-state.ts
@@ -1,0 +1,120 @@
+/**
+ * bonus ruleType の settings KVS state SSOT (Issue #2368)
+ *
+ * 旧 `rule-preset-import-service.ts` の bonus overrides 部分を新 module に切り出した
+ * SSOT。`bonus-hook-service` および admin/settings/rules 配下の callsite から
+ * 本 module を直接参照する (旧 service への依存を撤去するため)。
+ *
+ * 設計原則:
+ *   - `settings.rule_preset_bonus_overrides` JSON の read/write のみを担当
+ *   - graceful degradation: settings repo 例外時は空 state を返却 (test 環境
+ *     で settings テーブル不在等を考慮)
+ *   - bonus 取込本体の sub-strategy (`./bonus.ts`) と分離: state I/O のみ
+ *
+ * 関連:
+ *   - ADR-0052 §3 (Strategy 内部の OCP: sub-strategy 群に分割)
+ *   - ADR-0023 archive (tenant isolation 強制)
+ */
+
+import { getSetting, setSetting } from '$lib/server/db/settings-repo';
+import { logger } from '$lib/server/logger';
+
+/** settings KVS キー (SSOT) */
+export const BONUS_OVERRIDES_KEY = 'rule_preset_bonus_overrides';
+
+/** bonus 取込状態 (settings KVS に JSON 直列化して格納) */
+export interface BonusOverridesState {
+	/** preset 単位の取込履歴 */
+	presets: BonusPresetEntry[];
+}
+
+export interface BonusPresetEntry {
+	/** preset itemId (例: 'streak-bonus' / 'early-bird') */
+	presetId: string;
+	/** preset 表示名 (UI 表示用キャッシュ) */
+	presetName: string;
+	/** preset icon (UI 表示用キャッシュ) */
+	presetIcon: string;
+	/** 親が ON/OFF できる。既定は true (有効) */
+	enabled: boolean;
+	/** preset の rules (bonus-hook-service で参照) */
+	rules: BonusRuleSpec[];
+	/** 取込日時 ISO */
+	importedAt: string;
+}
+
+export interface BonusRuleSpec {
+	title: string;
+	description: string;
+	icon: string;
+	/** bonus 額 (pointBonus が undefined / 0 のときも保持) */
+	pointBonus: number;
+}
+
+/**
+ * `settings.rule_preset_bonus_overrides` を JSON parse して返す。
+ *
+ * graceful degradation: 未設定 / 不正 JSON / settings テーブル不在では空 state。
+ */
+export async function loadBonusOverrides(tenantId: string): Promise<BonusOverridesState> {
+	let raw: string | null | undefined;
+	try {
+		raw = await getSetting(BONUS_OVERRIDES_KEY, tenantId);
+	} catch (e) {
+		logger.warn(
+			'[rule-preset-strategy] getSetting 失敗、bonus overrides を空 state にフォールバック',
+			{ context: { tenantId, error: String(e) } },
+		);
+		return { presets: [] };
+	}
+	if (!raw) return { presets: [] };
+	try {
+		const parsed = JSON.parse(raw) as BonusOverridesState;
+		if (!parsed || !Array.isArray(parsed.presets)) {
+			return { presets: [] };
+		}
+		return parsed;
+	} catch (e) {
+		logger.warn(
+			'[rule-preset-strategy] bonus overrides JSON parse 失敗、空 state にフォールバック',
+			{ context: { tenantId, error: String(e) } },
+		);
+		return { presets: [] };
+	}
+}
+
+/** state を JSON 直列化して `settings` テーブルに保存 */
+export async function saveBonusOverrides(
+	state: BonusOverridesState,
+	tenantId: string,
+): Promise<void> {
+	await setSetting(BONUS_OVERRIDES_KEY, JSON.stringify(state), tenantId);
+}
+
+/**
+ * 取込済 bonus preset の enabled フラグを切り替え (親管理画面の ON/OFF 用)。
+ * preset が存在しない場合は no-op。
+ */
+export async function setBonusPresetEnabled(
+	presetId: string,
+	enabled: boolean,
+	tenantId: string,
+): Promise<void> {
+	const state = await loadBonusOverrides(tenantId);
+	const preset = state.presets.find((p) => p.presetId === presetId);
+	if (!preset) return;
+	preset.enabled = enabled;
+	await saveBonusOverrides(state, tenantId);
+}
+
+/**
+ * 取込済 bonus preset を削除 (親管理画面の削除ボタン用)。
+ * preset が存在しない場合は no-op。
+ */
+export async function removeBonusPreset(presetId: string, tenantId: string): Promise<void> {
+	const state = await loadBonusOverrides(tenantId);
+	const before = state.presets.length;
+	state.presets = state.presets.filter((p) => p.presetId !== presetId);
+	if (state.presets.length === before) return;
+	await saveBonusOverrides(state, tenantId);
+}

--- a/src/lib/marketplace/strategies/rule-preset/bonus.ts
+++ b/src/lib/marketplace/strategies/rule-preset/bonus.ts
@@ -1,0 +1,87 @@
+/**
+ * rule-preset `bonus` sub-strategy (Issue #2368)
+ *
+ * `settings.rule_preset_bonus_overrides` JSON に preset 全体を追記する。
+ * 個別 rule は `bonus-hook-service` が読み出して活動記録時に適用する。
+ *
+ * 設計原則 (ADR-0052 §3 Strategy 内部 OCP):
+ *   - 1 ruleType = 1 sub-module。本 module は bonus のみを扱う
+ *   - settings KVS read/write helpers は `./bonus-state.ts` に分離 (state I/O のみ)
+ *
+ * ADR-0012 Anti-engagement 整合:
+ *   - bonus は streak / 早起き / カテゴリ達成等の **positive reinforcement** のみ
+ *   - 連続ガチャ / インフィニットスクロール等の anti-pattern を含まない
+ *   - 親管理画面で個別に ON/OFF 可能 (default true) — 通知連打にならない構造
+ *
+ * 関連:
+ *   - $lib/server/services/bonus-hook-service (本 sub-strategy 経由で state 取得)
+ *   - ADR-0023 archive (tenant isolation 強制)
+ */
+
+import type { RulePresetPayload } from '$lib/marketplace/schemas/rule-preset-schema.js';
+import { loadBonusOverrides, saveBonusOverrides } from './bonus-state.js';
+
+export interface BonusPreviewResult {
+	/** settings KVS に同 presetId が既存か */
+	alreadyImported: boolean;
+	/** payload 内の rule 総数 */
+	ruleCount: number;
+}
+
+export interface BonusApplyResult {
+	imported: number;
+	skipped: number;
+	errors: string[];
+}
+
+/** bonus preview: settings KVS の `rule_preset_bonus_overrides` に同 presetId が存在するか */
+export async function previewBonus(
+	presetId: string,
+	payload: RulePresetPayload,
+	tenantId: string,
+): Promise<BonusPreviewResult> {
+	const state = await loadBonusOverrides(tenantId);
+	const alreadyImported = state.presets.some((p) => p.presetId === presetId);
+	return { alreadyImported, ruleCount: payload.rules.length };
+}
+
+/**
+ * bonus apply: settings KVS に preset 全体を追記する。
+ * 同 presetId が既存なら skipped=1 で no-op。
+ */
+export async function applyBonus(
+	presetId: string,
+	presetName: string,
+	presetIcon: string,
+	payload: RulePresetPayload,
+	tenantId: string,
+): Promise<BonusApplyResult> {
+	const errors: string[] = [];
+	const state = await loadBonusOverrides(tenantId);
+
+	if (state.presets.some((p) => p.presetId === presetId)) {
+		return { imported: 0, skipped: 1, errors };
+	}
+
+	state.presets.push({
+		presetId,
+		presetName,
+		presetIcon,
+		enabled: true,
+		rules: payload.rules.map((r) => ({
+			title: r.title,
+			description: r.description,
+			icon: r.icon,
+			pointBonus: r.pointBonus ?? 0,
+		})),
+		importedAt: new Date().toISOString(),
+	});
+
+	try {
+		await saveBonusOverrides(state, tenantId);
+		return { imported: 1, skipped: 0, errors };
+	} catch (e) {
+		errors.push(`bonus preset 保存失敗: ${String(e)}`);
+		return { imported: 0, skipped: 0, errors };
+	}
+}

--- a/src/lib/marketplace/strategies/rule-preset/exchange.ts
+++ b/src/lib/marketplace/strategies/rule-preset/exchange.ts
@@ -1,0 +1,103 @@
+/**
+ * rule-preset `exchange` sub-strategy (Issue #2368)
+ *
+ * `special_rewards` テーブルに各 rule を挿入する (reward-set-import と同形)。
+ * `sourcePresetId` で重複検知を行う。
+ *
+ * 設計原則 (ADR-0052 §3 Strategy 内部 OCP):
+ *   - 1 ruleType = 1 sub-module。本 module は exchange のみを扱う
+ *   - childId は必須 (上位 dispatcher で事前検証)
+ *
+ * 関連:
+ *   - $lib/server/db/special-reward-repo
+ *   - ADR-0023 archive (tenant isolation 強制)
+ */
+
+import type { RulePresetPayload } from '$lib/marketplace/schemas/rule-preset-schema.js';
+import { findSpecialRewards, insertSpecialReward } from '$lib/server/db/special-reward-repo';
+
+export interface ExchangePreviewResult {
+	/** 既に同 sourcePresetId が special_rewards に存在するか */
+	alreadyImported: boolean;
+	/** payload 内の rule 総数 */
+	ruleCount: number;
+}
+
+export interface ExchangeApplyResult {
+	imported: number;
+	skipped: number;
+	errors: string[];
+}
+
+/**
+ * exchange preview: childId 必須、`special_rewards` に同 sourcePresetId 在処を確認。
+ */
+export async function previewExchange(
+	presetId: string,
+	payload: RulePresetPayload,
+	tenantId: string,
+	childId?: number,
+): Promise<ExchangePreviewResult> {
+	const ruleCount = payload.rules.length;
+	if (childId === undefined) {
+		return { alreadyImported: false, ruleCount };
+	}
+	const existing = await findSpecialRewards(childId, tenantId);
+	const alreadyImported = existing.some((r) => r.sourcePresetId === presetId);
+	return { alreadyImported, ruleCount };
+}
+
+/**
+ * exchange apply: 各 rule を `special_rewards` に挿入。
+ * childId 未指定は errors で fail (上位で事前検証する想定だが防御的に再確認)。
+ * 同 sourcePresetId + 同 title の既存 reward は skipped。
+ */
+export async function applyExchange(
+	presetId: string,
+	payload: RulePresetPayload,
+	tenantId: string,
+	childId: number | undefined,
+): Promise<ExchangeApplyResult> {
+	const errors: string[] = [];
+	let imported = 0;
+	let skipped = 0;
+
+	if (childId === undefined) {
+		errors.push('exchange ruleType の取込には childId が必要です');
+		return { imported, skipped, errors };
+	}
+
+	const existing = await findSpecialRewards(childId, tenantId);
+	const sameSourceTitles = new Set(
+		existing.filter((r) => r.sourcePresetId === presetId).map((r) => r.title),
+	);
+
+	for (const rule of payload.rules) {
+		if (sameSourceTitles.has(rule.title)) {
+			skipped++;
+			continue;
+		}
+		try {
+			await insertSpecialReward(
+				{
+					childId,
+					grantedBy: null,
+					title: rule.title,
+					description: rule.description,
+					// exchange は pointCost をポイントとして保存 (子供がポイントを使って交換)
+					points: rule.pointCost ?? 0,
+					icon: rule.icon,
+					category: 'rule-preset-exchange',
+					sourcePresetId: presetId,
+				},
+				tenantId,
+			);
+			imported++;
+			sameSourceTitles.add(rule.title);
+		} catch (e) {
+			errors.push(`「${rule.title}」: ${String(e)}`);
+		}
+	}
+
+	return { imported, skipped, errors };
+}

--- a/src/lib/marketplace/strategies/rule-preset/penalty.ts
+++ b/src/lib/marketplace/strategies/rule-preset/penalty.ts
@@ -1,0 +1,55 @@
+/**
+ * rule-preset `penalty` sub-strategy (Issue #2368)
+ *
+ * **ADR-0012 §6 細則による意図的 no-op**: penalty は Octalysis Drive 8 (black hat)
+ * 該当のため慎重審査中。インフラ (型定義 / 取込試行 audit log) のみ保持し、
+ * 実際の preset 投入は別 ADR 合意の上で個別に行う。
+ *
+ * 動作:
+ *   - imported=0, skipped=0 (試行は audit log に残す)
+ *   - warning 文字列を返却 (UI 側で親に提示)
+ *   - `settings.rule_preset_import_warnings` に audit log を記録
+ *
+ * 関連:
+ *   - ADR-0012 §6 (anti-engagement の penalty 制限)
+ *   - ADR-0052 §3 (Strategy 内部 sub-dispatcher の中で意図的 no-op を分離)
+ *   - ./warning-log.ts (audit log shared helper)
+ */
+
+import { recordRulePresetWarning } from './warning-log.js';
+
+export interface PenaltyApplyResult {
+	imported: 0;
+	skipped: 0;
+	warnings: string[];
+	errors: string[];
+}
+
+const PENALTY_REASON =
+	'penalty ruleType は ADR-0012 §6 細則で慎重審査中 (Octalysis Drive 8 black hat 該当)。実装インフラは保持、preset 投入は別 Issue で個別合意の上で行う';
+
+/**
+ * penalty apply: 意図的 no-op。warning を返却し audit log に記録する。
+ * `imported / skipped` は型レベルで 0 固定 (リテラル型) — interface 上で
+ * tenant isolation と合わせて契約を破られない設計。
+ */
+export async function applyPenalty(
+	presetId: string,
+	tenantId: string,
+): Promise<PenaltyApplyResult> {
+	await recordRulePresetWarning(
+		{
+			presetId,
+			ruleType: 'penalty',
+			reason: PENALTY_REASON,
+			timestamp: new Date().toISOString(),
+		},
+		tenantId,
+	);
+	return {
+		imported: 0,
+		skipped: 0,
+		warnings: [PENALTY_REASON],
+		errors: [],
+	};
+}

--- a/src/lib/marketplace/strategies/rule-preset/special.ts
+++ b/src/lib/marketplace/strategies/rule-preset/special.ts
@@ -1,0 +1,50 @@
+/**
+ * rule-preset `special` sub-strategy (Issue #2368)
+ *
+ * 将来枠、仕様未確定のため意図的 no-op。
+ * penalty 同様、取込試行を audit log に記録するのみ。
+ *
+ * 動作:
+ *   - imported=0, skipped=0
+ *   - warning 文字列を返却
+ *   - `settings.rule_preset_import_warnings` に audit log を記録
+ *
+ * 関連:
+ *   - ADR-0052 §3 (Strategy 内部 sub-dispatcher における将来枠の保留扱い)
+ *   - ./warning-log.ts (audit log shared helper)
+ */
+
+import { recordRulePresetWarning } from './warning-log.js';
+
+export interface SpecialApplyResult {
+	imported: 0;
+	skipped: 0;
+	warnings: string[];
+	errors: string[];
+}
+
+const SPECIAL_REASON = 'special ruleType は将来枠、仕様未確定のため本取込は no-op';
+
+/**
+ * special apply: 意図的 no-op。warning を返却し audit log に記録する。
+ */
+export async function applySpecial(
+	presetId: string,
+	tenantId: string,
+): Promise<SpecialApplyResult> {
+	await recordRulePresetWarning(
+		{
+			presetId,
+			ruleType: 'special',
+			reason: SPECIAL_REASON,
+			timestamp: new Date().toISOString(),
+		},
+		tenantId,
+	);
+	return {
+		imported: 0,
+		skipped: 0,
+		warnings: [SPECIAL_REASON],
+		errors: [],
+	};
+}

--- a/src/lib/marketplace/strategies/rule-preset/warning-log.ts
+++ b/src/lib/marketplace/strategies/rule-preset/warning-log.ts
@@ -1,0 +1,55 @@
+/**
+ * penalty / special 取込試行 warning の audit log helper (Issue #2368)
+ *
+ * 旧 `rule-preset-import-service.ts` の private `recordRulePresetWarning` を
+ * sub-strategy で共有するため新 module に切り出した SSOT。
+ *
+ * `settings.rule_preset_import_warnings` KVS に直近 100 件を JSON 配列で保持する。
+ *
+ * 関連:
+ *   - ADR-0012 §6 細則 (penalty unimplemented 状態の audit)
+ *   - ADR-0052 (Strategy 内部 sub-dispatcher における共有 helper)
+ */
+
+import { getSetting, setSetting } from '$lib/server/db/settings-repo';
+
+/** penalty / special 取込試行 warning */
+export interface RulePresetWarning {
+	presetId: string;
+	ruleType: 'penalty' | 'special';
+	/** ADR-0012 §6 細則表で penalty が unimplemented 状態であることの説明 */
+	reason: string;
+	timestamp: string;
+}
+
+/** penalty / special 取込時の warning 履歴: 取込試行を audit ログとして残す */
+export const RULE_PRESET_WARNINGS_KEY = 'rule_preset_import_warnings';
+
+/** 直近保持件数 (settings KVS 肥大化防止) */
+const MAX_WARNINGS = 100;
+
+/**
+ * penalty / special 取込試行を audit log として settings に記録する。
+ *
+ * 不正 JSON は破棄して新規 array で上書き (graceful degradation)。
+ */
+export async function recordRulePresetWarning(
+	warning: RulePresetWarning,
+	tenantId: string,
+): Promise<void> {
+	const raw = await getSetting(RULE_PRESET_WARNINGS_KEY, tenantId);
+	let warnings: RulePresetWarning[] = [];
+	if (raw) {
+		try {
+			const parsed = JSON.parse(raw);
+			if (Array.isArray(parsed)) warnings = parsed;
+		} catch {
+			// 不正 JSON は破棄
+		}
+	}
+	warnings.push(warning);
+	if (warnings.length > MAX_WARNINGS) {
+		warnings = warnings.slice(-MAX_WARNINGS);
+	}
+	await setSetting(RULE_PRESET_WARNINGS_KEY, JSON.stringify(warnings), tenantId);
+}

--- a/src/lib/marketplace/types/rule-preset.ts
+++ b/src/lib/marketplace/types/rule-preset.ts
@@ -1,0 +1,41 @@
+/**
+ * rule-preset MarketplaceTypeDescriptor 登録 — ADR-0052 (Issue #2368)
+ *
+ * `MarketplaceTypeRegistry` への rule-preset 登録 SSOT。
+ * `src/lib/marketplace/index.ts` の side-effect eager-load (`import './types/rule-preset'`)
+ * 経由で起動時に 1 度だけ実行される。
+ *
+ * 設計原則 (ADR-0052 §2.4):
+ *   - 1 type = 1 module。本 module の責務は Descriptor 組み立て + register() のみ
+ *   - Strategy 実装は `../strategies/rule-preset-strategy.ts` に分離 (sub-dispatcher)
+ *   - 4 ruleType 個別実装は `../strategies/rule-preset/*.ts` に分離
+ *   - Schema は `../schemas/rule-preset-schema.ts` (#2364)
+ *
+ * `requiresChildId`: false (exchange は childId 必須だが、bonus/penalty/special は不要なため
+ * Registry レベルでは false。callsite で payload.ruleType を見て個別判定する)。
+ *
+ * 関連:
+ *   - $lib/marketplace/registry (singleton marketplaceRegistry)
+ *   - $lib/marketplace/strategies/rule-preset-strategy
+ *   - $lib/marketplace/schemas/rule-preset-schema
+ */
+
+import { marketplaceRegistry } from '$lib/marketplace/registry.js';
+import type { RulePresetPayload } from '$lib/marketplace/schemas/rule-preset-schema.js';
+import { RulePresetPayloadSchema } from '$lib/marketplace/schemas/rule-preset-schema.js';
+import { rulePresetStrategy } from '$lib/marketplace/strategies/rule-preset-strategy.js';
+import type { MarketplaceTypeDescriptor } from '$lib/marketplace/types.js';
+
+/** rule-preset Descriptor (Registry に登録される本体) */
+export const rulePresetDescriptor: MarketplaceTypeDescriptor<'rule-preset', RulePresetPayload> = {
+	typeCode: 'rule-preset',
+	displayLabel: 'ルールセット',
+	description:
+		'マーケットプレイス公式のルールセット (例: ポイント交換 / 連続ボーナス、4 ruleType 対応)',
+	strategy: rulePresetStrategy,
+	requiresChildId: false,
+	schema: RulePresetPayloadSchema,
+};
+
+// side-effect: 起動時 1 度だけ Registry に登録
+marketplaceRegistry.register(rulePresetDescriptor);

--- a/src/lib/server/services/bonus-hook-service.ts
+++ b/src/lib/server/services/bonus-hook-service.ts
@@ -23,8 +23,10 @@
 // today categories count を使う形式とする。
 
 import { calcStreakBonus } from '$lib/domain/validation/activity';
+// #2368 (ADR-0052): bonus state SSOT は marketplace strategy 配下に移動済。
+// 本 import は新 SSOT を直接参照 (旧 rule-preset-import-service の re-export 経由を撤去)。
+import { loadBonusOverrides } from '$lib/marketplace/strategies/rule-preset/bonus-state';
 import { logger } from '$lib/server/logger';
-import { loadBonusOverrides } from '$lib/server/services/rule-preset-import-service';
 
 // ============================================================
 // 入力: 活動記録時のコンテキスト

--- a/src/lib/server/services/rule-preset-import-service.ts
+++ b/src/lib/server/services/rule-preset-import-service.ts
@@ -1,7 +1,14 @@
 // src/lib/server/services/rule-preset-import-service.ts
-// #2138 MP-3: rule-preset 4 ruleType 全対応 一括取込サービス
 //
-// 案 1「既存テーブル流用」採用 (Phase Marketplace research #2 軸 C):
+// @deprecated Issue #2368 / EPIC #2362 P3 / ADR-0052:
+//   本 service は新 `rulePresetStrategy` (`$lib/marketplace/strategies/rule-preset-strategy`)
+//   に置き換えられた。新 callsite は `marketplaceRegistry.get('rule-preset').strategy` 経由で
+//   呼ぶこと。本 service は Strangler Fig 期間 (1 release) の後方互換のみを目的とし、
+//   bonus state KVS の SSOT は `$lib/marketplace/strategies/rule-preset/bonus-state` に
+//   移動済 — 本 service の `loadBonusOverrides` / `saveBonusOverrides` /
+//   `setBonusPresetEnabled` / `removeBonusPreset` は新 SSOT への薄い re-export に縮退。
+//
+// 旧仕様メモ (#2138 MP-3 / Phase Marketplace research #2 軸 C):
 // - exchange → `special_rewards` 系へマッピング (reward-set-import-service と同形)
 // - bonus    → `settings.rule_preset_bonus_overrides` JSON 拡張で取込 (settings KVS)
 // - penalty  → 型定義保持 + 取込時に「未実装 ruleType」warning + import_warnings に記録
@@ -14,52 +21,45 @@
 // 重複検出: bonus / exchange 共通で sourcePresetId を利用 (#1254 G1)。
 
 import type { RulePresetPayload } from '$lib/domain/marketplace-item';
-import { getSetting, setSetting } from '$lib/server/db/settings-repo';
-import { findSpecialRewards, insertSpecialReward } from '$lib/server/db/special-reward-repo';
-import { logger } from '$lib/server/logger';
+import {
+	BONUS_OVERRIDES_KEY as BONUS_OVERRIDES_KEY_NEW,
+	type BonusOverridesState,
+	type BonusPresetEntry,
+	type BonusRuleSpec,
+	loadBonusOverrides as loadBonusOverridesNew,
+	removeBonusPreset as removeBonusPresetNew,
+	saveBonusOverrides as saveBonusOverridesNew,
+	setBonusPresetEnabled as setBonusPresetEnabledNew,
+} from '$lib/marketplace/strategies/rule-preset/bonus-state';
+import { RULE_PRESET_WARNINGS_KEY as RULE_PRESET_WARNINGS_KEY_NEW } from '$lib/marketplace/strategies/rule-preset/warning-log';
 
-// ============================================================
-// 設定 KVS キー (SSOT)
-// ============================================================
-
-/** bonus 取込状態: tenant スコープで取込済 preset の payload + 有効/無効を保持 */
-export const BONUS_OVERRIDES_KEY = 'rule_preset_bonus_overrides';
-
-/** penalty / special 取込時の warning 履歴: 取込試行を audit ログとして残す */
-export const RULE_PRESET_WARNINGS_KEY = 'rule_preset_import_warnings';
-
-// ============================================================
-// 型定義
-// ============================================================
-
-/** bonus 取込状態 (settings KVS に JSON 直列化して格納) */
-export interface BonusOverridesState {
-	/** preset 単位の取込履歴 */
-	presets: BonusPresetEntry[];
+/** @deprecated test ガード用、本番 import path は新 SSOT を使う */
+const DEPRECATION_WARNED = new Set<string>();
+function warnDeprecated(symbol: string): void {
+	if (DEPRECATION_WARNED.has(symbol)) return;
+	DEPRECATION_WARNED.add(symbol);
+	console.warn(
+		`[DEPRECATED #2368] rule-preset-import-service.${symbol} は @deprecated です。` +
+			'$lib/marketplace/strategies/rule-preset-strategy / $lib/marketplace/strategies/rule-preset/bonus-state 経由に移行してください。',
+	);
 }
 
-export interface BonusPresetEntry {
-	/** preset itemId (例: 'streak-bonus' / 'early-bird') */
-	presetId: string;
-	/** preset 表示名 (UI 表示用キャッシュ) */
-	presetName: string;
-	/** preset icon (UI 表示用キャッシュ) */
-	presetIcon: string;
-	/** 親が ON/OFF できる。既定は true (有効) */
-	enabled: boolean;
-	/** preset の rules (bonus-hook-service で参照) */
-	rules: BonusRuleSpec[];
-	/** 取込日時 ISO */
-	importedAt: string;
-}
+// ============================================================
+// 設定 KVS キー (SSOT は新 module、本 service は re-export のみ)
+// ============================================================
 
-export interface BonusRuleSpec {
-	title: string;
-	description: string;
-	icon: string;
-	/** bonus 額 (pointBonus が undefined / 0 のときも保持) */
-	pointBonus: number;
-}
+/** @deprecated #2368: `$lib/marketplace/strategies/rule-preset/bonus-state` に移動 */
+export const BONUS_OVERRIDES_KEY = BONUS_OVERRIDES_KEY_NEW;
+
+/** @deprecated #2368: `$lib/marketplace/strategies/rule-preset/warning-log` に移動 */
+export const RULE_PRESET_WARNINGS_KEY = RULE_PRESET_WARNINGS_KEY_NEW;
+
+// ============================================================
+// 型定義 (re-export only)
+// ============================================================
+
+/** @deprecated #2368: re-export from $lib/marketplace/strategies/rule-preset/bonus-state */
+export type { BonusOverridesState, BonusPresetEntry, BonusRuleSpec };
 
 /** penalty / special の取込試行 warning */
 export interface RulePresetWarning {
@@ -97,18 +97,15 @@ export interface RulePresetImportResult {
 }
 
 // ============================================================
-// preview
+// preview / import (@deprecated #2368: 内部は新 Strategy に委譲)
 // ============================================================
 
 /**
- * rule-preset 取込時の preview を返す。実際の DB 書込は行わない。
- *
- * 重複判定:
- * - exchange: `special_rewards.sourcePresetId === presetId` の存在で判定 (reward-set と同形)
- * - bonus: `settings.rule_preset_bonus_overrides` JSON 内の presets[].presetId で判定
- * - penalty / special: 常に alreadyImported=false (取込試行のたびに warning が積まれる)
+ * @deprecated Issue #2368: 新 callsite は
+ *   `marketplaceRegistry.get('rule-preset').strategy.previewRulePreset(...)`
+ *   を使う。本関数は Strangler Fig 期間の後方互換のため新 Strategy へ薄く委譲する。
  */
-// biome-ignore lint/complexity/useMaxParams: marketplace item の identity 3 つ (id/name/icon) + payload + tenantId + 任意 childId は SSOT 統合のため必須
+// biome-ignore lint/complexity/useMaxParams: 旧 API シグネチャ互換のため
 export async function previewRulePresetImport(
 	presetId: string,
 	presetName: string,
@@ -117,57 +114,27 @@ export async function previewRulePresetImport(
 	tenantId: string,
 	childId?: number,
 ): Promise<RulePresetImportPreview> {
-	const ruleType = payload.ruleType;
-	const ruleCount = payload.rules.length;
-
-	let alreadyImported = false;
-
-	if (ruleType === 'exchange' && childId !== undefined) {
-		// exchange: 既存 special_rewards テーブルに同 sourcePresetId が存在するか
-		const existing = await findSpecialRewards(childId, tenantId);
-		alreadyImported = existing.some((r) => r.sourcePresetId === presetId);
-	} else if (ruleType === 'bonus') {
-		// bonus: settings KVS の rule_preset_bonus_overrides JSON 内に同 presetId があるか
-		const state = await loadBonusOverrides(tenantId);
-		alreadyImported = state.presets.some((p) => p.presetId === presetId);
-	}
-	// penalty / special: 常に false
-
-	return {
-		presetId,
-		presetName,
-		presetIcon,
-		ruleType,
-		ruleCount,
-		alreadyImported,
-	};
+	warnDeprecated('previewRulePresetImport');
+	const { rulePresetStrategy } = await import(
+		'$lib/marketplace/strategies/rule-preset-strategy.js'
+	);
+	return rulePresetStrategy.previewRulePreset({ presetId, presetName, presetIcon }, payload, {
+		tenantId,
+		childId,
+	});
 }
 
-// ============================================================
-// import
-// ============================================================
-
 export interface ImportRulePresetOptions {
-	/**
-	 * exchange ruleType の取込先 子供 ID。bonus / penalty / special では使わない。
-	 */
+	/** exchange ruleType の取込先 子供 ID。bonus / penalty / special では使わない。 */
 	childId?: number;
 }
 
 /**
- * rule-preset を 4 ruleType 全てに分岐して一括取込する。
- *
- * - exchange → `special_rewards` に各 rule を挿入 (reward-set-import と同形、pointCost が
- *   コスト = points として書き込まれる)
- * - bonus → `settings.rule_preset_bonus_overrides` JSON に preset 全体を追記
- *   (個別 rule は bonus-hook-service が読み出して活動記録時に適用)
- * - penalty / special → 取込はせず warning を返却 (audit log として
- *   settings.rule_preset_import_warnings に記録)
- *
- * 重複: 同一 preset が既取込なら何もせず skipped=1 で返却。
+ * @deprecated Issue #2368: 新 callsite は
+ *   `marketplaceRegistry.get('rule-preset').strategy.applyRulePreset(...)` を使う。
+ *   本関数は Strangler Fig 期間の後方互換のため新 Strategy へ薄く委譲する。
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: 4 ruleType 分岐 + 例外処理を 1 ヶ所に集約するための必要複雑度
-// biome-ignore lint/complexity/useMaxParams: marketplace item の identity 3 つ (id/name/icon) + payload + tenantId + options 統合のため必須
+// biome-ignore lint/complexity/useMaxParams: 旧 API シグネチャ互換のため
 export async function importRulePreset(
 	presetId: string,
 	presetName: string,
@@ -176,214 +143,51 @@ export async function importRulePreset(
 	tenantId: string,
 	options?: ImportRulePresetOptions,
 ): Promise<RulePresetImportResult> {
-	const ruleType = payload.ruleType;
-	const warnings: string[] = [];
-	const errors: string[] = [];
-	let imported = 0;
-	let skipped = 0;
-
-	if (ruleType === 'exchange') {
-		const childId = options?.childId;
-		if (childId === undefined) {
-			errors.push('exchange ruleType の取込には childId が必要です');
-			return { imported: 0, skipped: 0, warnings, errors };
-		}
-
-		const existing = await findSpecialRewards(childId, tenantId);
-		const sameSourceTitles = new Set(
-			existing.filter((r) => r.sourcePresetId === presetId).map((r) => r.title),
-		);
-
-		for (const rule of payload.rules) {
-			if (sameSourceTitles.has(rule.title)) {
-				skipped++;
-				continue;
-			}
-			try {
-				await insertSpecialReward(
-					{
-						childId,
-						grantedBy: null,
-						title: rule.title,
-						description: rule.description,
-						// exchange は pointCost をポイントとして保存 (子供がポイントを使って交換)
-						// 未指定は 0 として扱う
-						points: rule.pointCost ?? 0,
-						icon: rule.icon,
-						category: 'rule-preset-exchange',
-						sourcePresetId: presetId,
-					},
-					tenantId,
-				);
-				imported++;
-				sameSourceTitles.add(rule.title);
-			} catch (e) {
-				errors.push(`「${rule.title}」: ${String(e)}`);
-			}
-		}
-	} else if (ruleType === 'bonus') {
-		const state = await loadBonusOverrides(tenantId);
-		if (state.presets.some((p) => p.presetId === presetId)) {
-			skipped = 1;
-		} else {
-			state.presets.push({
-				presetId,
-				presetName,
-				presetIcon,
-				enabled: true,
-				rules: payload.rules.map((r) => ({
-					title: r.title,
-					description: r.description,
-					icon: r.icon,
-					pointBonus: r.pointBonus ?? 0,
-				})),
-				importedAt: new Date().toISOString(),
-			});
-			try {
-				await saveBonusOverrides(state, tenantId);
-				imported = 1;
-			} catch (e) {
-				errors.push(`bonus preset 保存失敗: ${String(e)}`);
-			}
-		}
-	} else if (ruleType === 'penalty' || ruleType === 'special') {
-		// penalty: ADR-0012 §6 で「未実装 ruleType」として扱う (将来 ADR 合意後に解除)
-		// special: 将来枠、現状は仕様未確定
-		const reason =
-			ruleType === 'penalty'
-				? 'penalty ruleType は ADR-0012 §6 細則で慎重審査中 (Octalysis Drive 8 black hat 該当)。実装インフラは保持、preset 投入は別 Issue で個別合意の上で行う'
-				: 'special ruleType は将来枠、仕様未確定のため本取込は no-op';
-		warnings.push(reason);
-		await recordRulePresetWarning(
-			{
-				presetId,
-				ruleType,
-				reason,
-				timestamp: new Date().toISOString(),
-			},
-			tenantId,
-		);
-		// imported=0, skipped=0 (試行は audit log に残す)
-	}
-
-	logger.info('[rule-preset-import] インポート完了', {
-		context: {
-			tenantId,
-			presetId,
-			ruleType,
-			imported,
-			skipped,
-			warnings: warnings.length,
-			errors: errors.length,
-		},
+	warnDeprecated('importRulePreset');
+	const { rulePresetStrategy } = await import(
+		'$lib/marketplace/strategies/rule-preset-strategy.js'
+	);
+	return rulePresetStrategy.applyRulePreset({ presetId, presetName, presetIcon }, payload, {
+		tenantId,
+		childId: options?.childId,
 	});
-
-	return { imported, skipped, warnings, errors };
 }
 
 // ============================================================
-// bonus overrides KVS 読み書き (settings JSON SSOT)
+// bonus overrides KVS 読み書き
+// (@deprecated #2368: SSOT は $lib/marketplace/strategies/rule-preset/bonus-state)
 // ============================================================
 
-/**
- * `settings.rule_preset_bonus_overrides` を JSON parse して返す。
- * 未設定 / 不正 JSON / settings テーブル不在 (一部 integration test 環境) では空 state を返す。
- *
- * 公開 API: bonus-hook-service.ts が活動記録時の bonus 算出で参照する。
- * graceful degradation: settings repo が throw した場合も bonus 評価を no-op で進める
- * (regression なし、bonus 取込前と同じ挙動)。
- */
+/** @deprecated #2368: `$lib/marketplace/strategies/rule-preset/bonus-state.loadBonusOverrides` を使ってください */
 export async function loadBonusOverrides(tenantId: string): Promise<BonusOverridesState> {
-	let raw: string | null | undefined;
-	try {
-		raw = await getSetting(BONUS_OVERRIDES_KEY, tenantId);
-	} catch (e) {
-		// settings repo の例外 (test 環境で settings テーブル不在等) は graceful degradation
-		logger.warn(
-			'[rule-preset-import] getSetting 失敗、bonus overrides を空 state にフォールバック',
-			{
-				context: { tenantId, error: String(e) },
-			},
-		);
-		return { presets: [] };
-	}
-	if (!raw) return { presets: [] };
-	try {
-		const parsed = JSON.parse(raw) as BonusOverridesState;
-		if (!parsed || !Array.isArray(parsed.presets)) {
-			return { presets: [] };
-		}
-		return parsed;
-	} catch (e) {
-		logger.warn('[rule-preset-import] bonus overrides JSON parse 失敗、空 state にフォールバック', {
-			context: { tenantId, error: String(e) },
-		});
-		return { presets: [] };
-	}
+	warnDeprecated('loadBonusOverrides');
+	return loadBonusOverridesNew(tenantId);
 }
 
-/** state を JSON 直列化して `settings` テーブルに保存 */
+/** @deprecated #2368: `$lib/marketplace/strategies/rule-preset/bonus-state.saveBonusOverrides` を使ってください */
 export async function saveBonusOverrides(
 	state: BonusOverridesState,
 	tenantId: string,
 ): Promise<void> {
-	await setSetting(BONUS_OVERRIDES_KEY, JSON.stringify(state), tenantId);
+	warnDeprecated('saveBonusOverrides');
+	return saveBonusOverridesNew(state, tenantId);
 }
 
-/**
- * 取込済 bonus preset の enabled フラグを切り替え (親管理画面の ON/OFF 用)。
- * preset が存在しない場合は no-op。
- */
+/** @deprecated #2368: `$lib/marketplace/strategies/rule-preset/bonus-state.setBonusPresetEnabled` を使ってください */
 export async function setBonusPresetEnabled(
 	presetId: string,
 	enabled: boolean,
 	tenantId: string,
 ): Promise<void> {
-	const state = await loadBonusOverrides(tenantId);
-	const preset = state.presets.find((p) => p.presetId === presetId);
-	if (!preset) return;
-	preset.enabled = enabled;
-	await saveBonusOverrides(state, tenantId);
+	warnDeprecated('setBonusPresetEnabled');
+	return setBonusPresetEnabledNew(presetId, enabled, tenantId);
 }
 
-/**
- * 取込済 bonus preset を削除 (親管理画面の削除ボタン用)。
- * preset が存在しない場合は no-op。
- */
+/** @deprecated #2368: `$lib/marketplace/strategies/rule-preset/bonus-state.removeBonusPreset` を使ってください */
 export async function removeBonusPreset(presetId: string, tenantId: string): Promise<void> {
-	const state = await loadBonusOverrides(tenantId);
-	const before = state.presets.length;
-	state.presets = state.presets.filter((p) => p.presetId !== presetId);
-	if (state.presets.length === before) return;
-	await saveBonusOverrides(state, tenantId);
+	warnDeprecated('removeBonusPreset');
+	return removeBonusPresetNew(presetId, tenantId);
 }
 
-// ============================================================
-// penalty / special 取込 warning audit log
-// ============================================================
-
-/**
- * penalty / special 取込試行を audit log として settings に記録。
- * ADR-0012 §6 細則表で「インフラは保持、preset 投入は別 Issue」とした履歴を残す。
- */
-async function recordRulePresetWarning(
-	warning: RulePresetWarning,
-	tenantId: string,
-): Promise<void> {
-	const raw = await getSetting(RULE_PRESET_WARNINGS_KEY, tenantId);
-	let warnings: RulePresetWarning[] = [];
-	if (raw) {
-		try {
-			const parsed = JSON.parse(raw);
-			if (Array.isArray(parsed)) warnings = parsed;
-		} catch {
-			// 不正 JSON は破棄して新規 array で上書き
-		}
-	}
-	warnings.push(warning);
-	// 直近 100 件のみ保持 (settings KVS 肥大化防止)
-	if (warnings.length > 100) {
-		warnings = warnings.slice(-100);
-	}
-	await setSetting(RULE_PRESET_WARNINGS_KEY, JSON.stringify(warnings), tenantId);
-}
+// penalty / special audit log helper は
+// $lib/marketplace/strategies/rule-preset/warning-log に移動済。

--- a/src/routes/(parent)/admin/settings/rules/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/rules/+page.server.ts
@@ -9,13 +9,14 @@
 // (取込試行は audit log として settings.rule_preset_import_warnings に記録されるのみ)。
 
 import { fail } from '@sveltejs/kit';
-import { requireTenantId } from '$lib/server/auth/factory';
-import { logger } from '$lib/server/logger';
+// #2368 (ADR-0052): bonus state SSOT は marketplace strategy 配下に移動済。
 import {
 	loadBonusOverrides,
 	removeBonusPreset,
 	setBonusPresetEnabled,
-} from '$lib/server/services/rule-preset-import-service';
+} from '$lib/marketplace/strategies/rule-preset/bonus-state';
+import { requireTenantId } from '$lib/server/auth/factory';
+import { logger } from '$lib/server/logger';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {

--- a/src/routes/marketplace/[type]/[itemId]/+page.server.ts
+++ b/src/routes/marketplace/[type]/[itemId]/+page.server.ts
@@ -2,8 +2,11 @@ import { error, fail, redirect } from '@sveltejs/kit';
 import { getMarketplaceItem } from '$lib/data/marketplace';
 import type { MarketplaceItemType, RulePresetPayload } from '$lib/domain/marketplace-item';
 // #2366 (ADR-0052): reward-set を新 Strategy + dispatchImport 経由に移行。
-// `$lib/marketplace` の eager-load (`./types/reward-set`) で Registry 登録される。
-import { dispatchImport } from '$lib/marketplace';
+// `$lib/marketplace` の eager-load (`./types/reward-set` / `./types/rule-preset`) で Registry 登録される。
+// #2138 (MP-3) / #2368 (ADR-0052 P3): rule-preset 4 ruleType 全対応の一括取込
+// 新 SSOT: marketplaceRegistry.get('rule-preset').strategy 経由 (Strategy 内部 sub-dispatcher)
+import { dispatchImport, marketplaceRegistry } from '$lib/marketplace';
+import type { rulePresetStrategy } from '$lib/marketplace/strategies/rule-preset-strategy';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
 import {
@@ -11,11 +14,6 @@ import {
 	previewChecklistImport,
 } from '$lib/server/services/checklist-template-import-service';
 import { getAllChildren } from '$lib/server/services/child-service';
-// #2138 (MP-3): rule-preset 4 ruleType 全対応の一括取込
-import {
-	importRulePreset,
-	previewRulePresetImport,
-} from '$lib/server/services/rule-preset-import-service';
 import type { Actions, PageServerLoad } from './$types';
 
 const VALID_TYPES: MarketplaceItemType[] = [
@@ -223,14 +221,16 @@ export const actions: Actions = {
 		}
 
 		try {
-			const preview = await previewRulePresetImport(
-				item.itemId,
-				item.name,
-				item.icon,
-				payload,
-				tenantId,
-				childId,
-			);
+			// #2368: Strategy 経由 (Registry 経由で本番 / demo 環境とも同一動作)
+			const strategy = marketplaceRegistry.get('rule-preset').strategy as typeof rulePresetStrategy;
+			const identity = {
+				presetId: item.itemId,
+				presetName: item.name,
+				presetIcon: item.icon,
+			};
+			const ctx = { tenantId, childId };
+
+			const preview = await strategy.previewRulePreset(identity, payload, ctx);
 
 			if (preview.alreadyImported) {
 				return {
@@ -242,9 +242,7 @@ export const actions: Actions = {
 				};
 			}
 
-			const result = await importRulePreset(item.itemId, item.name, item.icon, payload, tenantId, {
-				childId,
-			});
+			const result = await strategy.applyRulePreset(identity, payload, ctx);
 			return {
 				ruleImport: {
 					alreadyImported: false,

--- a/src/routes/setup/rules/+page.server.ts
+++ b/src/routes/setup/rules/+page.server.ts
@@ -12,12 +12,11 @@
 import { redirect } from '@sveltejs/kit';
 import { getMarketplaceIndex, getMarketplaceItem } from '$lib/data/marketplace';
 import type { RulePresetPayload } from '$lib/domain/marketplace-item';
+// #2368 (ADR-0052 P3): Strategy 経由 (Registry 経由) で 4 ruleType sub-dispatcher を呼ぶ
+import { marketplaceRegistry } from '$lib/marketplace';
+import type { rulePresetStrategy } from '$lib/marketplace/strategies/rule-preset-strategy';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getAllChildren } from '$lib/server/services/child-service';
-import {
-	importRulePreset,
-	previewRulePresetImport,
-} from '$lib/server/services/rule-preset-import-service';
 import { trackSetupFunnel } from '$lib/server/services/setup-funnel-service';
 import type { Actions, PageServerLoad } from './$types';
 
@@ -110,27 +109,23 @@ export const actions: Actions = {
 					continue;
 				}
 
-				const preview = await previewRulePresetImport(
-					item.itemId,
-					item.name,
-					item.icon,
-					payload,
-					tenantId,
-					childId,
-				);
+				// #2368: Strategy 経由 (Registry 経由で本番 / demo 環境とも同一動作)
+				const strategy = marketplaceRegistry.get('rule-preset')
+					.strategy as typeof rulePresetStrategy;
+				const identity = {
+					presetId: item.itemId,
+					presetName: item.name,
+					presetIcon: item.icon,
+				};
+				const ctx = { tenantId, childId };
+
+				const preview = await strategy.previewRulePreset(identity, payload, ctx);
 				if (preview.alreadyImported) {
 					totalSkipped++;
 					continue;
 				}
 
-				const result = await importRulePreset(
-					item.itemId,
-					item.name,
-					item.icon,
-					payload,
-					tenantId,
-					{ childId },
-				);
+				const result = await strategy.applyRulePreset(identity, payload, ctx);
 				totalImported += result.imported;
 				totalSkipped += result.skipped;
 				allErrors.push(...result.errors);

--- a/tests/unit/marketplace/strategies/rule-preset-strategy.test.ts
+++ b/tests/unit/marketplace/strategies/rule-preset-strategy.test.ts
@@ -1,0 +1,339 @@
+/**
+ * tests/unit/marketplace/strategies/rule-preset-strategy.test.ts
+ *
+ * rule-preset ImportStrategy unit tests — Issue #2368 / ADR-0052 P3
+ *
+ * 検証 (Strategy 内部 sub-dispatcher 4 ruleType 全網羅):
+ *   - parse() の Valibot validation
+ *   - exchange:   special_rewards 挿入 + sourcePresetId 重複検知 + childId 必須
+ *   - bonus:      settings KVS state 追記 + 重複 presetId skip + bonus-hook 連動
+ *   - penalty:    ADR-0012 §6 意図的 no-op (imported=0 / warnings 1 件 / audit log 記録)
+ *   - special:    将来枠 no-op (imported=0 / warnings 1 件 / audit log 記録)
+ *   - tenant isolation: ctx.tenantId が全 sub-strategy に伝播
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------- Top-level mocks (settings repo + special-reward repo + logger) ----------
+
+const mockGetSetting = vi.fn();
+const mockSetSetting = vi.fn();
+const mockFindSpecialRewards = vi.fn();
+const mockInsertSpecialReward = vi.fn();
+
+vi.mock('$lib/server/db/settings-repo', () => ({
+	getSetting: (...args: unknown[]) => mockGetSetting(...args),
+	setSetting: (...args: unknown[]) => mockSetSetting(...args),
+}));
+
+vi.mock('$lib/server/db/special-reward-repo', () => ({
+	findSpecialRewards: (...args: unknown[]) => mockFindSpecialRewards(...args),
+	insertSpecialReward: (...args: unknown[]) => mockInsertSpecialReward(...args),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ---------- Import after mocks ----------
+
+import { loadBonusOverrides } from '../../../../src/lib/marketplace/strategies/rule-preset/bonus-state';
+import { rulePresetStrategy } from '../../../../src/lib/marketplace/strategies/rule-preset-strategy';
+
+const TENANT = 'test-tenant-001';
+const PRESET_ID = 'streak-bonus';
+const IDENTITY = {
+	presetId: PRESET_ID,
+	presetName: '連続ボーナス',
+	presetIcon: '🔥',
+};
+
+function makeBonusPayload(overrides: Record<string, unknown> = {}) {
+	return {
+		ruleType: 'bonus' as const,
+		rules: [
+			{
+				title: '3日連続ボーナス',
+				description: '3日連続で記録するとボーナス',
+				icon: '🔥',
+				pointBonus: 10,
+			},
+		],
+		...overrides,
+	};
+}
+
+function makeExchangePayload() {
+	return {
+		ruleType: 'exchange' as const,
+		rules: [
+			{
+				title: 'アイス交換',
+				description: 'アイスと交換',
+				icon: '🍦',
+				pointCost: 50,
+			},
+		],
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockGetSetting.mockResolvedValue(null);
+	mockSetSetting.mockResolvedValue(undefined);
+	mockFindSpecialRewards.mockResolvedValue([]);
+	mockInsertSpecialReward.mockResolvedValue({ id: 1 });
+});
+
+// =====================================================
+// parse()
+// =====================================================
+
+describe('rulePresetStrategy.parse', () => {
+	it('有効な bonus payload を parse して同等 object を返す', () => {
+		const input = makeBonusPayload();
+		const result = rulePresetStrategy.parse(input);
+		expect(result.ruleType).toBe('bonus');
+		expect(result.rules).toHaveLength(1);
+	});
+
+	it('ruleType が RULE_TYPES 外なら error throw', () => {
+		expect(() => rulePresetStrategy.parse({ ruleType: 'unknown', rules: [] })).toThrow(/ruleType/);
+	});
+
+	it('rules が空配列なら error throw', () => {
+		expect(() => rulePresetStrategy.parse({ ruleType: 'bonus', rules: [] })).toThrow(/rules/);
+	});
+
+	it('title が空文字なら error throw', () => {
+		const input = {
+			ruleType: 'bonus',
+			rules: [{ title: '', description: 'x', icon: '🔥', pointBonus: 5 }],
+		};
+		expect(() => rulePresetStrategy.parse(input)).toThrow();
+	});
+});
+
+// =====================================================
+// exchange ruleType
+// =====================================================
+
+describe('rulePresetStrategy.applyRulePreset — exchange', () => {
+	it('childId 必須: 未指定なら errors で fail-fast', async () => {
+		const result = await rulePresetStrategy.applyRulePreset(IDENTITY, makeExchangePayload(), {
+			tenantId: TENANT,
+		});
+		expect(result.imported).toBe(0);
+		expect(result.errors[0]).toMatch(/childId が必要/);
+	});
+
+	it('special_rewards に rule を挿入し imported=1 を返す', async () => {
+		const result = await rulePresetStrategy.applyRulePreset(IDENTITY, makeExchangePayload(), {
+			tenantId: TENANT,
+			childId: 42,
+		});
+		expect(result.imported).toBe(1);
+		expect(result.skipped).toBe(0);
+		expect(mockInsertSpecialReward).toHaveBeenCalledOnce();
+		const [insertedRow, tenantArg] = mockInsertSpecialReward.mock.calls[0]!;
+		expect(insertedRow.childId).toBe(42);
+		expect(insertedRow.points).toBe(50); // pointCost → points
+		expect(insertedRow.sourcePresetId).toBe(PRESET_ID);
+		expect(tenantArg).toBe(TENANT); // tenant isolation 伝播
+	});
+
+	it('同 sourcePresetId + 同 title が既存なら skipped++', async () => {
+		mockFindSpecialRewards.mockResolvedValue([
+			{ id: 1, title: 'アイス交換', sourcePresetId: PRESET_ID },
+		]);
+		const result = await rulePresetStrategy.applyRulePreset(IDENTITY, makeExchangePayload(), {
+			tenantId: TENANT,
+			childId: 42,
+		});
+		expect(result.imported).toBe(0);
+		expect(result.skipped).toBe(1);
+		expect(mockInsertSpecialReward).not.toHaveBeenCalled();
+	});
+});
+
+describe('rulePresetStrategy.previewRulePreset — exchange', () => {
+	it('alreadyImported=true: 同 sourcePresetId が存在する', async () => {
+		mockFindSpecialRewards.mockResolvedValue([{ id: 1, sourcePresetId: PRESET_ID }]);
+		const result = await rulePresetStrategy.previewRulePreset(IDENTITY, makeExchangePayload(), {
+			tenantId: TENANT,
+			childId: 42,
+		});
+		expect(result.alreadyImported).toBe(true);
+		expect(result.ruleType).toBe('exchange');
+	});
+
+	it('childId 未指定なら alreadyImported=false (preview のみは fail しない)', async () => {
+		const result = await rulePresetStrategy.previewRulePreset(IDENTITY, makeExchangePayload(), {
+			tenantId: TENANT,
+		});
+		expect(result.alreadyImported).toBe(false);
+	});
+});
+
+// =====================================================
+// bonus ruleType (+ bonus-hook-service 連動の確認)
+// =====================================================
+
+describe('rulePresetStrategy.applyRulePreset — bonus', () => {
+	it('settings KVS に preset を追記して imported=1', async () => {
+		const result = await rulePresetStrategy.applyRulePreset(IDENTITY, makeBonusPayload(), {
+			tenantId: TENANT,
+		});
+		expect(result.imported).toBe(1);
+		expect(result.skipped).toBe(0);
+		expect(mockSetSetting).toHaveBeenCalledOnce();
+		const [key, value, tenantArg] = mockSetSetting.mock.calls[0]!;
+		expect(key).toBe('rule_preset_bonus_overrides');
+		expect(tenantArg).toBe(TENANT);
+		const parsed = JSON.parse(value);
+		expect(parsed.presets[0].presetId).toBe(PRESET_ID);
+		expect(parsed.presets[0].enabled).toBe(true);
+		expect(parsed.presets[0].rules[0].pointBonus).toBe(10);
+	});
+
+	it('同 presetId が既存なら skipped=1 で no-op', async () => {
+		mockGetSetting.mockResolvedValue(
+			JSON.stringify({
+				presets: [
+					{
+						presetId: PRESET_ID,
+						presetName: '連続ボーナス',
+						presetIcon: '🔥',
+						enabled: true,
+						rules: [],
+						importedAt: '2026-01-01T00:00:00.000Z',
+					},
+				],
+			}),
+		);
+		const result = await rulePresetStrategy.applyRulePreset(IDENTITY, makeBonusPayload(), {
+			tenantId: TENANT,
+		});
+		expect(result.imported).toBe(0);
+		expect(result.skipped).toBe(1);
+		expect(mockSetSetting).not.toHaveBeenCalled();
+	});
+
+	it('保存後 loadBonusOverrides() で bonus-hook-service が読み出せる形になる', async () => {
+		// apply → setSetting に渡された JSON を mock storage として戻し、loadBonusOverrides で復元
+		await rulePresetStrategy.applyRulePreset(IDENTITY, makeBonusPayload(), {
+			tenantId: TENANT,
+		});
+		const savedJson = mockSetSetting.mock.calls[0]![1] as string;
+		mockGetSetting.mockResolvedValue(savedJson);
+
+		const state = await loadBonusOverrides(TENANT);
+		expect(state.presets).toHaveLength(1);
+		expect(state.presets[0]?.presetId).toBe(PRESET_ID);
+		expect(state.presets[0]?.rules[0]?.pointBonus).toBe(10);
+	});
+});
+
+describe('rulePresetStrategy.previewRulePreset — bonus', () => {
+	it('alreadyImported=true: settings KVS に同 presetId が存在する', async () => {
+		mockGetSetting.mockResolvedValue(
+			JSON.stringify({
+				presets: [
+					{
+						presetId: PRESET_ID,
+						presetName: '',
+						presetIcon: '',
+						enabled: true,
+						rules: [],
+						importedAt: '',
+					},
+				],
+			}),
+		);
+		const result = await rulePresetStrategy.previewRulePreset(IDENTITY, makeBonusPayload(), {
+			tenantId: TENANT,
+		});
+		expect(result.alreadyImported).toBe(true);
+	});
+});
+
+// =====================================================
+// penalty / special ruleType (ADR-0012 §6 意図的 no-op)
+// =====================================================
+
+describe('rulePresetStrategy.applyRulePreset — penalty (ADR-0012 §6 no-op)', () => {
+	const penaltyPayload = {
+		ruleType: 'penalty' as const,
+		rules: [{ title: '減点', description: 'x', icon: '⚠️' }],
+	};
+
+	it('imported=0 / skipped=0 / warnings 1 件 (黒帽 game design 規制)', async () => {
+		const result = await rulePresetStrategy.applyRulePreset(IDENTITY, penaltyPayload, {
+			tenantId: TENANT,
+		});
+		expect(result.imported).toBe(0);
+		expect(result.skipped).toBe(0);
+		expect(result.warnings).toHaveLength(1);
+		expect(result.warnings[0]).toMatch(/ADR-0012/);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it('settings.rule_preset_import_warnings に audit log を append', async () => {
+		await rulePresetStrategy.applyRulePreset(IDENTITY, penaltyPayload, { tenantId: TENANT });
+		const warningWrite = mockSetSetting.mock.calls.find(
+			(c) => c[0] === 'rule_preset_import_warnings',
+		);
+		expect(warningWrite).toBeDefined();
+		const [, value, tenantArg] = warningWrite!;
+		expect(tenantArg).toBe(TENANT);
+		const parsed = JSON.parse(value);
+		expect(parsed[0].ruleType).toBe('penalty');
+		expect(parsed[0].presetId).toBe(PRESET_ID);
+	});
+});
+
+describe('rulePresetStrategy.applyRulePreset — special (将来枠 no-op)', () => {
+	const specialPayload = {
+		ruleType: 'special' as const,
+		rules: [{ title: '将来枠', description: 'x', icon: '✨' }],
+	};
+
+	it('imported=0 / warnings 1 件 + audit log', async () => {
+		const result = await rulePresetStrategy.applyRulePreset(IDENTITY, specialPayload, {
+			tenantId: TENANT,
+		});
+		expect(result.imported).toBe(0);
+		expect(result.skipped).toBe(0);
+		expect(result.warnings[0]).toMatch(/将来枠/);
+
+		const warningWrite = mockSetSetting.mock.calls.find(
+			(c) => c[0] === 'rule_preset_import_warnings',
+		);
+		expect(warningWrite).toBeDefined();
+		const parsed = JSON.parse(warningWrite![1] as string);
+		expect(parsed[0].ruleType).toBe('special');
+	});
+});
+
+// =====================================================
+// dryRun 等価動作
+// =====================================================
+
+describe('rulePresetStrategy.applyRulePreset — dryRun', () => {
+	it('dryRun=true なら DB write せず空結果を返す (4 ruleType 全て)', async () => {
+		for (const ruleType of ['bonus', 'exchange', 'penalty', 'special'] as const) {
+			vi.clearAllMocks();
+			mockGetSetting.mockResolvedValue(null);
+			const payload = { ruleType, rules: [{ title: 't', description: 'd', icon: 'i' }] };
+			const result = await rulePresetStrategy.applyRulePreset(IDENTITY, payload, {
+				tenantId: TENANT,
+				childId: 42,
+				dryRun: true,
+			});
+			expect(result.imported).toBe(0);
+			expect(result.skipped).toBe(0);
+			expect(mockInsertSpecialReward).not.toHaveBeenCalled();
+			expect(mockSetSetting).not.toHaveBeenCalled();
+		}
+	});
+});

--- a/tests/unit/services/bonus-hook-service.test.ts
+++ b/tests/unit/services/bonus-hook-service.test.ts
@@ -10,7 +10,10 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockLoadBonusOverrides = vi.fn();
 
-vi.mock('$lib/server/services/rule-preset-import-service', () => ({
+// #2368 (ADR-0052 P3): bonus state SSOT が marketplace strategy 配下に移動したため新 path を mock。
+// bonus-hook-service.ts は `$lib/marketplace/strategies/rule-preset/bonus-state` から
+// loadBonusOverrides を import するため、ここで同じ specifier に対して mock を当てる。
+vi.mock('$lib/marketplace/strategies/rule-preset/bonus-state', () => ({
 	loadBonusOverrides: (...args: unknown[]) => mockLoadBonusOverrides(...args),
 }));
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（内部 refactor、運営 / 開発体験向上）

**解決する課題**: rule-preset の 4 ruleType (exchange / bonus / penalty / special) 分岐 switch が `rule-preset-import-service.ts` (390 行) に集約しており、新 ruleType 追加・ADR-0012 §6 penalty 制限の interface 強制が困難。EPIC #2362 (MarketplaceTypeRegistry + ImportStrategy) Phase 3 として、4 ruleType を Strategy 内部 sub-dispatcher に分割し、ADR-0012 §6 の penalty/special 意図的 no-op を **interface contract で破られない設計** にする。

**期待される効果**: 新 ruleType 追加が 1 ファイル増分で済む / ADR-0012 §6 penalty 制限が interface 強制で永続化 / bonus state KVS の SSOT 集約により bonus-hook-service の依存パスが明示化される。

## 関連 Issue

closes #2368

EPIC: #2362 / Blocked by: #2363 (merged) / #2364 (merged) / #2365 (merged) / Blocks: #8 / #10

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `/marketplace/rule-preset/<id>` → 4 ruleType 全てが新 Strategy 経由で動作 | `npx vitest run tests/unit/marketplace/strategies/rule-preset-strategy.test.ts` + 既存 E2E `tests/e2e/marketplace-rule-preset-import.spec.ts` の通過 | 17 PASS / E2E 既存 spec 等価動作 |
| AC2 | `penalty` / `special` 取込試行が ADR-0012 §6 規定通り warning + audit log 記録、imported=0 | unit test (`penalty (ADR-0012 §6 no-op)` / `special (将来枠 no-op)` describe) | imported=0 / warnings 1 件 / `settings.rule_preset_import_warnings` audit log 記録を検証 |
| AC3 | `bonus` の settings KVS 保存が `bonus-hook-service` から参照可能 | unit test「保存後 loadBonusOverrides で読み出せる形になる」 + `bonus-hook-service.test.ts` 既存 mock 更新後 PASS | bonus-hook-service が新 SSOT (`bonus-state.ts`) から `loadBonusOverrides` import、既存 14 件 streak/early-bird/weekend/category テスト PASS |
| AC4 | `exchange` の `special_rewards` 挿入が sourcePresetId 重複検知付きで動作 | unit test (`applyRulePreset — exchange` describe) | childId 必須 / 重複時 skipped++ / tenant 伝播 を検証 |
| AC5 | interface 上で tenant isolation を Strategy 単位で強制 | `ImportContext.tenantId` 型必須 + 全 sub-strategy 関数シグネチャで tenantId 必須引数 | コード review + unit test で tenantId argv が下流に渡ることを検証 |
| AC6 | biome check / svelte-check / vitest run 全 PASS | pre-ready Step 2/3 + 個別 biome check 実行 | svelte-check 0 errors / vitest 5368 PASS / biome check 0 errors (worktree 内 .claude ignore のため pre-ready Step 1 は worktree 制限で skip、個別 path 指定実行で確認) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`) — bonus-hook-service / rule-preset-import-service @deprecated 化
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`) — marketplace/[type]/[itemId] + setup/rules + admin/settings/rules の +page.server.ts
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`) — `src/lib/marketplace/strategies/rule-preset*` 新規 + `types/rule-preset.ts` Registry 登録
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- `/marketplace/rule-preset/<itemId>` 詳細ページの「一括追加」action (4 ruleType 全て)
- `/setup/rules` 初期セットアップでの bulk import
- `/admin/settings/rules` 取込済 bonus preset の ON/OFF・削除 (loadBonusOverrides 経由)
- 活動記録時の bonus 算出 (`bonus-hook-service.evaluateBonusHooks`、import path 切替のみで動作不変)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— svelte-check / vitest / hardcoded-strings / check-no-plan-literals / check-pr-body は PASS、Step 1 biome check は worktree (`.claude/worktrees/...`) 配下が biome.json の `!**/.claude` ignore に該当するため skip、個別 path 指定 (`npx biome check src/lib/marketplace/ ...`) で実行し 0 errors 確認済
- [x] 追加・変更したテストの概要:
  - `tests/unit/marketplace/strategies/rule-preset-strategy.test.ts` 新規 17 件 (parse / exchange childId 必須 + 重複 / bonus state SSOT + bonus-hook 連動 / penalty ADR-0012 no-op + audit log / special 将来枠 no-op + audit log / dryRun 4 ruleType 等価)
  - `tests/unit/services/bonus-hook-service.test.ts` mock specifier を `$lib/server/services/rule-preset-import-service` → `$lib/marketplace/strategies/rule-preset/bonus-state` に追従更新 (テスト内容変更なし、14 件 PASS 維持)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — DynamoDB 実装変更なし (rule-preset は SQLite + settings KVS のみ)
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — refactor のため Critical 修正ではない

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 内部 refactor のみで UI 変更なし。`/marketplace/rule-preset/<id>` 詳細ページ / `/setup/rules` / `/admin/settings/rules` の action callsite を Strategy 経由に置換しただけで、画面の見た目・遷移・form action 動作は不変。E2E `tests/e2e/marketplace-rule-preset-import.spec.ts` (既存 spec) で挙動等価性を担保。

**4 スロット添付**: N/A (UI 変更なし)

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 (1 ruleType = 1 sub-module) / 依存性逆転 (Strategy interface 経由) / インターフェース分離 (`ImportContext` は必要最小、`RulePresetIdentity` は preset 固有 identity を別 interface で分離)
- [x] **DRY**: bonus state I/O / penalty/special audit log を共有 helper (`bonus-state.ts` / `warning-log.ts`) に集約。旧 service `rule-preset-import-service.ts` は新 SSOT への薄い委譲に縮退済 (同等ロジックの 2 重定義なし、`grep` で確認)
- [x] **YAGNI**: 4 ruleType 全分岐は Issue で必須 AC のため過剰抽象化ではない。新 ruleType 追加は 1 sub-module 追加 + dispatcher 1 行で完結
- [x] **Security**: 秘密情報 hardcode なし / tenant isolation 強制 (全 sub-strategy が `tenantId` 必須引数で破られない契約) / OWASP は import flow に該当しない
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: N+1 なし / bundle size 影響なし (sub-module 群は eager-load されるが各 ruleType ロジックは旧 service 内 switch と等価)

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照）:

- [x] 本番アプリ + デモ版 — N/A: rule-preset import は本番 / demo Lambda 両方とも同じ `marketplaceRegistry.get('rule-preset').strategy` 経由で動作 (Registry / Strategy は環境非依存)
- [x] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: N/A — LP 文言・記載に影響なし
- [x] 全年齢モード 5 種: N/A — rule-preset import は親管理機能 (年齢モード非依存)
- [x] ナビゲーション 3 種: N/A — ナビ変更なし
- [x] E2E / ユニットシード: N/A — DB スキーマ・seed 変更なし
- [x] **labels SSOT** (ADR-0009): N/A — UI ラベル変更なし
- [x] **設計書同期** (ADR-0001): ADR-0052 (MarketplaceTypeRegistry + ImportStrategy) が既存。本 PR の 4 ruleType sub-dispatcher 設計は ADR-0052 §3 の「Strategy 内部 OCP」原則の Phase 3 適用であり、追加 ADR 不要 (PR 本文で言及)
- [x] **並行 PR overlap** (#1200): EPIC #2362 P4 (#2369 challenge-set) / P5 が同時並行する可能性あり。本 PR は rule-preset / bonus-hook-service / rule-preset-import-service / marketplace/[type]/[itemId] / setup/rules / admin/settings/rules に限定し、他 type には触れていない
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A — LP 文言変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

旧 `rule-preset-import-service.ts` の export (`importRulePreset` / `previewRulePresetImport` / `loadBonusOverrides` / `saveBonusOverrides` / `setBonusPresetEnabled` / `removeBonusPreset` / `BONUS_OVERRIDES_KEY` / `RULE_PRESET_WARNINGS_KEY` / `BonusOverridesState` 型 等) は **全て後方互換維持** (Strangler Fig 1 release 並行稼働)。内部実装が新 Strategy / 新 bonus-state SSOT への薄い委譲に変わるのみで、シグネチャ / 戻り値 / 動作は不変。

**レビュー依頼事項・QA**:
- (1) `rulePresetStrategy` の **拡張 method 設計**: rule-preset 固有戻り値 (warnings / ruleType / alreadyImported) は generic `ImportResult` に収まらないため、Strategy interface を満たす generic `apply()` に加えて `applyRulePreset(identity, payload, ctx)` / `previewRulePreset(identity, payload, ctx)` 拡張 method を追加した (`RulePresetIdentity` interface で preset identity を渡す)。activity-pack-strategy はこの拡張なしで通っていたが、4 ruleType それぞれの戻り値構造が異なる本 type では必要と判断。EPIC #2362 P4 (challenge-set) でも同様の拡張パターンを採用するか要検討。
- (2) Strangler Fig 期間 (1 release) の `console.warn` 通知が unit test 出力にも出る点 (実害なし、Strangler 期間中の許容)。
- (3) `MaxListenersExceededWarning` が vitest 出力に出ているが既存 issue (test suite 全体の listener leak、本 PR の変更とは無関係)。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (Step 1 biome は worktree 制限で skip、個別 path 指定で 0 errors 確認 / Step 2-9 全 PASS)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完成 AC は残っていない）
- [x] Phase 分割: 着手前に PO と合意し、子 Issue を起票済み (EPIC #2362 配下 P3)
- [x] UI 変更: N/A — UI 変更なし
- [x] 認証画面変更: N/A — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

