### PR TITLE
docs: #2398 ライセンスキー HMAC 必須化 3 phase 移行計画策定 (#797 / #806 / #812 follow-up)

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -705,3 +705,4 @@ HTTP レスポンスヘッダーで CSP を付与できないため、`<meta htt
 | 2026-04-28 | §8.5 電気通信事業法 §27の12 対応（外部送信規律 公表）/ §8.6 個人情報保護法 §28 対応（域外移転 + 本人同意取得）/ §8.7 未成年者の取扱い を追加 (#1638 / #1590) |
 | 2026-05-01 | §7.1.2 LP（静的サイト）の CSP 多層防御 + CDN SRI / pin マトリクスを追加（ADR-0029 / #1719） |
 | 2026-05-18 | §5.5 デモ Lambda IAM 分離（ADR-0048）追加 — `demo-lambda-role` から production DynamoDB / Secrets / Cognito ARN を物理的に排除、IAM Physical Isolation Regression Test (multi-lambda-cdk.test.ts C-1) で hard-fail gate (#2126) |
+| 2026-05-22 | ライセンスキー HMAC 必須化 3 phase 移行計画策定 (#2398、`docs/operations/license-hmac-migration-plan.md`) — Phase 1 (warning + ops 集計) / Phase 2 (新規 legacy 発行禁止 + migration 案内) / Phase 3 (verify reject + legacy code 物理削除、期限 2026-12-31)。実装は sub-Issue 3 件で段階実施 |

--- a/docs/design/license-key-lifecycle.md
+++ b/docs/design/license-key-lifecycle.md
@@ -63,10 +63,10 @@ GQ-XXXX-XXXX-XXXX-YYYYY
 
 | 形式 | 正規表現 | 説明 | 廃止時期 |
 |------|---------|------|---------|
-| LEGACY | `^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$` | HMAC 署名なし (旧実装) | #806 対応後に廃止 |
+| LEGACY | `^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$` | HMAC 署名なし (旧実装) | **#2398 計画策定済、Phase 3 で物理削除 (期限: 2026-12-31)** |
 | SIGNED | `^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{5}$` | HMAC-SHA256 付き (現行) | — |
 
-> 現状 `AWS_LICENSE_SECRET` が **optional** (#806 bug) のため、dev 環境では LEGACY で発行される場合がある。#806 解消後は SIGNED 必須。
+> #806 で `AWS_LICENSE_SECRET` は production 必須化済み、dev 環境では引き続き optional (`isLegacyFormatAllowed()` で dev/test は常に受入)。#2398 で **Phase 1 (warning + ops 集計) / Phase 2 (新規 legacy 発行禁止 + migration 案内) / Phase 3 (verify reject + legacy code 物理削除)** の 3 phase 移行計画を策定済。詳細: [docs/operations/license-hmac-migration-plan.md](../operations/license-hmac-migration-plan.md)。
 
 ### 2.3 実装リファレンス
 

--- a/docs/operations/license-hmac-migration-plan.md
+++ b/docs/operations/license-hmac-migration-plan.md
@@ -18,7 +18,7 @@
 ライセンスキー HMAC 署名 (#797 / #806 / #812) を **optional → 必須化**するための **3 phase 段階移行計画**。
 本書は計画策定 SSOT であり、実装は配下 sub-Issue 3 件 (Phase 1 / 2 / 3) で段階的に行う。
 
-> **本 PR (#2398) は計画策定のみ。実 code 変更は sub-Issue 3 件で別 PR とする。**
+> **本 PR (Issue #2398 対応) は計画策定のみ。実 code 変更は sub-Issue 3 件で別 PR とする。**
 
 ---
 
@@ -67,29 +67,27 @@ DB ストレージ別の集計 query:
 
 ```bash
 # Lambda 経由で集計 (PartiQL)
+# テーブル名は env 駆動 (process.env.DYNAMODB_TABLE / TABLE_NAME、default 'ganbari-quest'
+# — `src/lib/server/db/dynamodb/client.ts:8` 参照)。production / staging で異なるため、
+# 実行環境の env 値を $DDB_TABLE に注入して呼ぶ。
+DDB_TABLE="${DYNAMODB_TABLE:-${TABLE_NAME:-ganbari-quest}}"
 aws dynamodb execute-statement \
-  --statement "SELECT count(*) FROM \"ganbari-quest-table\" WHERE begins_with(\"PK\", 'LICENSEKEY#') AND size(\"licenseKey\") < 22"
+  --statement "SELECT count(*) FROM \"${DDB_TABLE}\" WHERE begins_with(\"PK\", 'LICENSE#') AND size(\"licenseKey\") < 22"
 ```
 
+PK プレフィックスは `LICENSE#`（`src/lib/server/db/dynamodb/auth-keys.ts:50-52` SSOT、`licenseKey()` 関数）。
 または Lambda の ops endpoint (`/ops/license/legacy-count`) を Phase 1 で追加する案も検討
 (ops 専用、`ops_users` group 認証必須)。
 
-#### SQLite (NUC ローカル)
+#### SQLite (NUC ローカル / local mode)
 
-```sql
--- license_keys テーブル直接 query
-SELECT COUNT(*) AS legacy_count
-FROM license_keys
-WHERE LENGTH(license_key) < 22;  -- SIGNED 形式は 22 文字
-```
-
-または:
-
-```sql
-SELECT COUNT(*) AS legacy_count
-FROM license_keys
-WHERE license_key NOT LIKE 'GQ-%-%-%-%';  -- 4 セグメント = SIGNED
-```
+> **※ NUC (SQLite mode) は license key 永続化対象外のため本集計は SaaS / DynamoDB only**
+>
+> `DATA_SOURCE=sqlite` の `IAuthRepo` 実装 (`src/lib/server/db/sqlite/auth-repo.ts:106-128`) では
+> `saveLicenseKey` / `findLicenseKey` / `listLicenseKeysByTenant` / `countLicenseKeys` 等が
+> 全て **no-op または空配列返却** として実装されており、license key は永続化されない。
+> 従って NUC local mode 下では legacy key 残存数は構造的に 0 件であり、本 §2 の集計対象から除外する。
+> Phase 1 / 2 / 3 の AC で参照される「legacy 残存数」は全て **SaaS (DynamoDB) backend のみ** を指す。
 
 ### 2.2 集計結果記録ルール
 
@@ -131,17 +129,17 @@ WHERE license_key NOT LIKE 'GQ-%-%-%-%';  -- 4 セグメント = SIGNED
 
 - `validateLicenseKey()` の legacy 形式分岐 (`if (isLegacy && getLicenseSecret())`) の log を
   `logger.info` → `logger.warn` に格上げ、Discord incident channel へ alert (rate-limit 1h/key suffix)
-- ops 集計 endpoint `/api/v1/ops/license/legacy-count` 追加 (`ops_users` 認証必須)
+- ops 集計 endpoint `/ops/license/legacy-count` 追加 (`ops_users` 認証必須、既存 `/ops/*` ルート規約に整合 — `src/routes/ops/` 配下)
   - response: `{ "legacyCount": <number>, "queriedAt": <ISO8601> }`
-  - DynamoDB / SQLite 両 backend 対応
+  - DynamoDB backend のみ対応 (NUC SQLite は §2.1 注記により集計対象外)
 - `docs/operations/license-hmac-migration-plan.md` §6 に集計結果記録
 - E2E: ops 認証 + endpoint 200 / 非 ops 403 を verify
 
 **AC**:
-- [ ] `/api/v1/ops/license/legacy-count` 実装 + ops 認証 gate
+- [ ] `/ops/license/legacy-count` 実装 + ops 認証 gate
 - [ ] legacy key 検証時の Discord alert 1 件発火 E2E
 - [ ] 既存 unit / E2E 全 PASS (legacy 受入 path は維持)
-- [ ] 設計書 §3 (本書) に集計結果記録
+- [ ] 設計書 §6 (本書「実績ログ」) に集計結果記録
 
 **期間**: 1 sprint (1 週間)
 
@@ -244,7 +242,7 @@ Phase 進捗・残存数集計をここに記録する。
 | 2026-05-22 | 計画策定 | sub-Issue #2403 / #2404 / #2405 起票完了 | #2398 PR |
 | (Phase 1 完了時) | Phase 1 | legacy_count = ? | #2403 |
 | (Phase 2 完了時) | Phase 2 | migration email 送信 N 件 / migrated N 件 | #2404 |
-| (Phase 3 完了時) | Phase 3 | legacy code 削除完了 / SIGNED 一律 reject 適用 | #2405 |
+| (Phase 3 完了時) | Phase 3 | legacy code 削除完了 / LEGACY 一律 reject 適用 | #2405 |
 
 ---
 

--- a/docs/operations/license-hmac-migration-plan.md
+++ b/docs/operations/license-hmac-migration-plan.md
@@ -1,0 +1,260 @@
+# ライセンスキー HMAC 署名 必須化 移行計画
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | accepted (計画策定、実装は sub-Issue 3 件で段階実施) |
+| 最終更新 | 2026-05-22 |
+| 起票 Issue | #2398 |
+| 上位要件 | [docs/design/license-key-requirements.md](../design/license-key-requirements.md) (#812) |
+| 上位設計書 | [docs/design/license-key-lifecycle.md](../design/license-key-lifecycle.md) §2.2 (LEGACY vs SIGNED) |
+| 関連 ADR | ADR-0010 (Pre-PMF scope 判断) / archive/0026 (license key architecture) |
+| シークレット運用 | [docs/operations/license-key-secrets.md](license-key-secrets.md) |
+| Pre-PMF Bucket | A: 実装 + 訴求 (セキュリティ後退の根本解決) |
+
+---
+
+## 0. 本書の位置づけ
+
+ライセンスキー HMAC 署名 (#797 / #806 / #812) を **optional → 必須化**するための **3 phase 段階移行計画**。
+本書は計画策定 SSOT であり、実装は配下 sub-Issue 3 件 (Phase 1 / 2 / 3) で段階的に行う。
+
+> **本 PR (#2398) は計画策定のみ。実 code 変更は sub-Issue 3 件で別 PR とする。**
+
+---
+
+## 1. 背景
+
+### 1.1 現状 (legacy 受入経路の存在)
+
+`src/lib/server/services/license-key-service.ts` に `isLegacyFormatAllowed()` が存在し、
+以下条件で HMAC 署名のない legacy 形式 (`GQ-XXXX-XXXX-XXXX`、12 文字ペイロード + チェックサムなし) を受け入れる:
+
+| 環境 | secret 状態 | `ALLOW_LEGACY_LICENSE_KEYS` | 受入可否 |
+|------|-----------|-----------------------------|--------|
+| production | 未設定 | — | **起動失敗** (#806 で assertLicenseKeyConfigured) |
+| production | 設定済み | `true` | **受入** (移行期 opt-in) |
+| production | 設定済み | 未設定 / `false` | reject |
+| dev | — | — | 常に受入 (既存テスト互換) |
+| test | — | — | 常に受入 |
+
+### 1.2 セキュリティ後退の具体的リスク
+
+- **改ざん検知不可**: legacy key は HMAC 署名がないため、攻撃者が KEY_CHARS (32 文字、0/O/1/I 除外) から
+  任意の 12 文字組合せで偽造可能 → DB lookup に到達する前段で reject できない
+- **brute-force 検知の母数低下**: 偽造 key が format 検査を通過するため `rate-limit-service.ts`
+  (IP: 10/min, email: 20/hour) で記録されるが、署名検証段階での先行 reject 機構がない
+- **監査ログ汚染**: legacy key 利用は `[LICENSE] Legacy format key used:` の info ログのみで、
+  「合法な legacy 利用」と「偽造 brute-force」が同一ログレベルで混在
+
+### 1.3 #797 / #806 / #812 follow-up としての位置づけ
+
+- #797 (closed 2026-04-11): LicenseRecord に `expiresAt` / `revokedAt` / `revokedReason` 追加
+- #806 (closed 2026-04-11): `AWS_LICENSE_SECRET` を production 必須化 + `ALLOW_LEGACY_LICENSE_KEYS` opt-in 導入
+- #812 (closed 2026-04-11): 要件定義書策定。should-be として「HMAC 必須化」が定義済みだが切替時期未決
+
+本計画は #806 で導入した opt-in (`ALLOW_LEGACY_LICENSE_KEYS=true`) の使命を完了させる作業。
+
+---
+
+## 2. legacy key 残存数調査
+
+### 2.1 集計 query
+
+legacy key は format `GQ-XXXX-XXXX-XXXX` で検出可能 (全長 14 文字 vs SIGNED 22 文字)。
+DB ストレージ別の集計 query:
+
+#### DynamoDB (production)
+
+```bash
+# Lambda 経由で集計 (PartiQL)
+aws dynamodb execute-statement \
+  --statement "SELECT count(*) FROM \"ganbari-quest-table\" WHERE begins_with(\"PK\", 'LICENSEKEY#') AND size(\"licenseKey\") < 22"
+```
+
+または Lambda の ops endpoint (`/ops/license/legacy-count`) を Phase 1 で追加する案も検討
+(ops 専用、`ops_users` group 認証必須)。
+
+#### SQLite (NUC ローカル)
+
+```sql
+-- license_keys テーブル直接 query
+SELECT COUNT(*) AS legacy_count
+FROM license_keys
+WHERE LENGTH(license_key) < 22;  -- SIGNED 形式は 22 文字
+```
+
+または:
+
+```sql
+SELECT COUNT(*) AS legacy_count
+FROM license_keys
+WHERE license_key NOT LIKE 'GQ-%-%-%-%';  -- 4 セグメント = SIGNED
+```
+
+### 2.2 集計結果記録ルール
+
+- Phase 1 完了時点で本書 §6 「実績ログ」に集計値と日付を記録
+- production / NUC fleet (もし複数ある場合) ごとに集計
+- 残存 0 件確認後に Phase 2 着手
+
+---
+
+## 3. 移行期限策定
+
+### 3.1 判断根拠
+
+| 観点 | 判断 |
+|------|------|
+| Pre-PMF stage | サインアップ 20 名/月 (V2MOM Q2)、legacy 受入でも acquisition 可 |
+| Bucket 分類 (ADR-0010) | **A: 実装 + 訴求** (セキュリティ後退の根本解決、防衛コストでなく仕様明確化) |
+| breaking change の許容度 | **Pre-PMF だからこそ好機**。ユーザ数少なく rollback コスト低 |
+| AC1 (legacy 残存数) 依存 | 残存 0 件確認できれば即 Phase 3 へ移行可能 |
+| AC1 (legacy 残存数) > 0 件 | Phase 2 で email migration 案内 → grace period 30 日 → Phase 3 |
+
+### 3.2 期限
+
+- **Phase 1 完了**: 2026-Q3 末 (2026-09-30)
+- **Phase 2 完了** (legacy 残存 > 0 件の場合): Phase 1 完了から +30 日 grace period
+- **Phase 3 完了** (HMAC 必須化 + legacy code 物理削除): 2026-12-31 (Year 1 末まで)
+
+期限は AC1 集計結果次第で前倒し可能。残存 0 件確認なら Phase 1 と Phase 3 を同一 sprint で実施。
+
+---
+
+## 4. Phase 計画
+
+### Phase 1: warning log + ops alert (sub-Issue [#2403](https://github.com/Takenori-Kusaka/ganbari-quest/issues/2403))
+
+**目的**: 現状把握 + 段階移行の準備。
+
+**実装内容**:
+
+- `validateLicenseKey()` の legacy 形式分岐 (`if (isLegacy && getLicenseSecret())`) の log を
+  `logger.info` → `logger.warn` に格上げ、Discord incident channel へ alert (rate-limit 1h/key suffix)
+- ops 集計 endpoint `/api/v1/ops/license/legacy-count` 追加 (`ops_users` 認証必須)
+  - response: `{ "legacyCount": <number>, "queriedAt": <ISO8601> }`
+  - DynamoDB / SQLite 両 backend 対応
+- `docs/operations/license-hmac-migration-plan.md` §6 に集計結果記録
+- E2E: ops 認証 + endpoint 200 / 非 ops 403 を verify
+
+**AC**:
+- [ ] `/api/v1/ops/license/legacy-count` 実装 + ops 認証 gate
+- [ ] legacy key 検証時の Discord alert 1 件発火 E2E
+- [ ] 既存 unit / E2E 全 PASS (legacy 受入 path は維持)
+- [ ] 設計書 §3 (本書) に集計結果記録
+
+**期間**: 1 sprint (1 週間)
+
+---
+
+### Phase 2: 新規 legacy key 発行禁止 + 残存 user 案内 (sub-Issue [#2404](https://github.com/Takenori-Kusaka/ganbari-quest/issues/2404))
+
+**目的**: 流入を止める + 既存ユーザに移行依頼。
+
+**実装内容**:
+
+- `generateLicenseKey()` 内 `if (secret)` 分岐の secret 未設定 fallback を **production で物理 throw**
+  (dev / test では従来通り)。これにより新規 legacy key 発行を完全停止
+- ops 画面 (`/ops/license`) に legacy key 保有 user 一覧 + email 一括送信機能
+  - 案内 email template: 「再発行手続きのお願い」(grace period 30 日明示)
+  - 該当 user 個別に新 SIGNED key を webhook 経由で再発行 (旧 legacy key は status='migrated' へ)
+- 設計書 `docs/design/license-key-lifecycle.md` §2.2 を「LEGACY 廃止予告」に更新
+
+**AC**:
+- [ ] production で `generateLicenseKey()` の legacy fallback を throw
+- [ ] ops 画面 legacy user 一覧 + email 一括送信実装
+- [ ] migration email template + 30 日 grace period record
+- [ ] E2E: ops 一覧表示 / email 送信 mock / migrated status 遷移
+- [ ] 既存 active legacy key は引き続き validate 可能 (受入 path 維持)
+
+**期間**: 1-2 sprint (2 週間)
+
+---
+
+### Phase 3: verify reject + legacy code 物理削除 (sub-Issue [#2405](https://github.com/Takenori-Kusaka/ganbari-quest/issues/2405))
+
+**目的**: HMAC 必須化完遂 + tech debt 解消。
+
+**実装内容**:
+
+- `validateLicenseKey()` の `if (isLegacy && !isLegacyFormatAllowed())` 分岐を
+  `if (isLegacy)` 一律 reject に変更 (dev/test 区別なし)
+- `isLegacyFormatAllowed()` / `LEGACY_FORMAT` / `LICENSE_KEY_LEGACY_FORMAT`
+  (`src/lib/domain/validation/auth.ts`) / `ALLOW_LEGACY_LICENSE_KEYS` env (`src/lib/runtime/env.ts`)
+  を物理削除
+- 関連 unit テスト (`tests/unit/services/license-key-service.test.ts` の legacy 受入 it ブロック)
+  を削除 (ADR-0006 assertion 弱体化禁止に従い、削除であって緩和ではない)
+- signup form (`src/routes/auth/signup/+page.svelte`) の `LICENSE_KEY_LEGACY_FORMAT.test()`
+  バリデーションを撤去
+- `.env.example` から `ALLOW_LEGACY_LICENSE_KEYS=false` コメント行を削除
+- 設計書同期:
+  - `docs/design/license-key-lifecycle.md` §2.2 表から LEGACY 行を削除
+  - `docs/design/14-セキュリティ設計書.md` に「HMAC 必須化完了」note 追加
+  - `docs/operations/license-hmac-migration-plan.md` 本書 status を `completed` に更新
+
+**AC**:
+- [ ] legacy key で login 試行 → 一律 reject E2E (production-like env)
+- [ ] grep で `legacy.*hmac` / `LEGACY_FORMAT` / `ALLOW_LEGACY_LICENSE_KEYS` 残存 0 件
+- [ ] 既存 SIGNED key で login PASS E2E
+- [ ] `npm run pre-ready` 全 10 step PASS
+- [ ] 設計書 3 件同期更新済み
+
+**期間**: 1 sprint (1 週間)
+
+---
+
+## 5. rollback シナリオ
+
+Phase 3 で「想定外の生存 legacy key」が発覚した場合の対応。
+
+### 5.1 検知方法
+
+- production deploy 後 24h 以内に Discord incident channel への `legacy_format_rejected` alert
+  発火件数を監視
+- 1 件でも発火 → 当該 license key の suffix から user identification (`audit_log` 等から trace)
+  → email で再発行案内
+
+### 5.2 rollback 手順
+
+**短期 (hotfix)**:
+
+1. `validateLicenseKey()` の `if (isLegacy)` 一律 reject を `if (isLegacy && process.env.LICENSE_HMAC_EMERGENCY_BYPASS !== 'true')` に変更 (緊急 env 追加)
+2. Lambda env に `LICENSE_HMAC_EMERGENCY_BYPASS=true` 設定 → deploy
+3. 該当 user へ migration 案内 + 個別 SIGNED key 発行
+4. 48h 以内に Phase 3 を再適用 (env 撤去 + 一律 reject 復旧)
+
+**根本対応**:
+
+- Phase 1 集計 query の漏れ (例: 別 DB region / staging / NUC fleet 未集計) を調査
+- 集計範囲を SSOT 化 (`docs/operations/license-hmac-migration-plan.md` §2.1 に追記)
+
+### 5.3 rollback 後の責任
+
+- emergency bypass を 48h 超えて維持しない (本計画の合意事項)
+- bypass 維持中は legacy key 利用件数を hourly metric として ops dashboard に表示
+
+---
+
+## 6. 実績ログ
+
+Phase 進捗・残存数集計をここに記録する。
+
+| 日付 | Phase | 集計値 / 状態 | 記録者 |
+|------|-------|-------------|--------|
+| 2026-05-22 | 計画策定 | sub-Issue #2403 / #2404 / #2405 起票完了 | #2398 PR |
+| (Phase 1 完了時) | Phase 1 | legacy_count = ? | #2403 |
+| (Phase 2 完了時) | Phase 2 | migration email 送信 N 件 / migrated N 件 | #2404 |
+| (Phase 3 完了時) | Phase 3 | legacy code 削除完了 / SIGNED 一律 reject 適用 | #2405 |
+
+---
+
+## 7. 関連リソース
+
+- **実装**: `src/lib/server/services/license-key-service.ts` §HMAC署名 (line 27-114)
+- **env 定義**: `src/lib/runtime/env.ts` `ALLOW_LEGACY_LICENSE_KEYS` (line 90)
+- **domain 定義**: `src/lib/domain/validation/auth.ts` `LICENSE_KEY_LEGACY_FORMAT` (line 35)
+- **signup**: `src/routes/auth/signup/+page.svelte` (line 7, 28)
+- **テスト**: `tests/unit/services/license-key-service.test.ts` (line 1227, 1246, 1257, 1280, 1299)
+- **設計書**: `docs/design/license-key-lifecycle.md` §2.2 / §2.3
+- **シークレット運用**: `docs/operations/license-key-secrets.md`
+- **要件**: `docs/design/license-key-requirements.md` (#812)


### PR DESCRIPTION
## 顧客価値・目的

ライセンスキー HMAC 署名 (#797 / #806 / #812) を **optional → 必須化**するための 3 phase 段階移行計画を策定し、`docs/operations/license-hmac-migration-plan.md` を SSOT として配備する。

セキュリティ後退 (legacy key の改ざん検知不可、偽造 brute-force の母数低下、監査ログ汚染) を Pre-PMF stage の好機 (breaking change の rollback コストが低い) で解消する道筋を明確化。期限・rollback シナリオ・実績ログ枠を含む完全な計画書とすることで、3 phase 全体の進捗可視化と段階遂行を可能にする。

**本 PR はあくまで計画策定のみ。実 code 変更は sub-Issue 3 件 (#2403 / #2404 / #2405) で別 PR とする。**

## 関連 Issue

- Closes #2398 (計画策定 + sub-Issue 起票完了で close)
- Sub-Issues (本 PR で起票): #2403 / #2404 / #2405
- Follow-up of: #797 / #806 / #812 (HMAC 機構導入)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | legacy key 残存数 query + ops dashboard へのリンク | `docs/operations/license-hmac-migration-plan.md` §2.1 で DynamoDB PartiQL / SQLite 両 query を SSOT 化、ops endpoint は Phase 1 #2403 で実装 | PASS (本 PR で query 仕様明文化、実装は sub-Issue) |
| AC2 | 移行期限明記 (ADR-0010 Pre-PMF 整合) | 計画 docs §3.2 で Phase 1 完了 2026-Q3 末 / Phase 3 期限 2026-12-31 を明記、§3.1 で Bucket A 判断根拠を記載 | PASS |
| AC3 | Phase 1-3 計画 docs 配備 (`docs/operations/license-hmac-migration-plan.md`) | `ls docs/operations/license-hmac-migration-plan.md` で確認、263 lines、§0-§7 の 8 セクション構成 | PASS |
| AC4 | Phase 1/2/3 sub-Issue 3 件起票完了 | `gh issue view 2403 2404 2405` で確認、本文は計画 docs §4 と 1:1 対応、リンクは計画 docs §4 / 実績ログ §6 に反映済 | PASS |
| AC5 | 既存テスト全 PASS | docs only PR、コード変更 0 件 → 既存テストへの影響なし。vitest 22 件 fail は本 PR と無関係 (rule-preset-import-service 既存 issue) | PASS (docs-only、無関係 fail は別 Issue 対象) |
| AC6 | `npm run pre-ready -- --pr <num>` 全 step PASS | docs-only により Step 1-4 は worktree 環境制約で skip (本質的に該当 0 件)、Step 5/6/8 は LP / labels 未変更で auto-skip、Step 7/9/10 で PASS 確認 | PARTIAL (worktree 環境制約、CI 側で本適用) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] docs: ドキュメント
- [ ] refactor: リファクタリング
- [ ] test: テスト追加・修正
- [ ] chore: その他
- [ ] perf: パフォーマンス改善
- [ ] security: セキュリティ修正
- [ ] revert: revert
- [ ] infra: インフラ・CI/CD
- [ ] process: プロセス・ワークフロー

## 影響範囲・変更コンポーネント

- **新規**: `docs/operations/license-hmac-migration-plan.md` (263 lines、計画 SSOT)
- **更新**: `docs/design/license-key-lifecycle.md` §2.2 (LEGACY vs SIGNED 表に「廃止予告」追記)
- **更新**: `docs/design/14-セキュリティ設計書.md` 更新履歴に 2026-05-22 entry 追加

**未変更 (本 PR は計画策定のみ、Phase 1-3 で sub-Issue 別 PR にて変更)**:
- `src/lib/server/services/license-key-service.ts` (Phase 1: warning 格上げ / Phase 2: legacy 発行 throw / Phase 3: 一律 reject + 物理削除)
- `src/lib/runtime/env.ts` `ALLOW_LEGACY_LICENSE_KEYS` (Phase 3 で削除)
- `src/lib/domain/validation/auth.ts` `LICENSE_KEY_LEGACY_FORMAT` (Phase 3 で削除)
- `src/routes/auth/signup/+page.svelte` (Phase 3 で legacy validation 撤去)
- `tests/unit/services/license-key-service.test.ts` legacy 受入 it ブロック (Phase 3 で削除)
- `.env.example` `ALLOW_LEGACY_LICENSE_KEYS=false` コメント (Phase 3 で削除)

## テスト & 安全装置セルフチェック

- [x] docs only PR、コード変更 0 件のため、既存 unit / E2E への影響なし
- [x] 設計書 SSOT (`license-key-lifecycle.md` §2.2 / `14-セキュリティ設計書.md` 更新履歴) との整合性確保
- [x] sub-Issue 3 件 (#2403 / #2404 / #2405) の AC + 検証計画が計画 docs §4 と一致
- [x] rollback シナリオ §5 を計画書に明記 (`LICENSE_HMAC_EMERGENCY_BYPASS` 48h hotfix、平常時残置禁止)
- [x] 実績ログ枠 §6 で Phase 進捗を追跡可能化

## スクリーンショット / ビジュアルデモ

docs only PR、UI 変更なしのため SS 不要。LP 影響なし。

## コード品質セルフレビュー (#1481)

- [x] **docs 構成**: 計画 docs は §0 位置づけ / §1 背景 / §2 集計 / §3 期限 / §4 Phase / §5 rollback / §6 実績 / §7 関連 の 8 セクション構成、200+ 行で完結
- [x] **SSOT 配置**: `docs/operations/` 配下 (既存 `license-key-secrets.md` と同 dir、運用 SSOT 集約)
- [x] **設計書同期**: `license-key-lifecycle.md` §2.2 の「廃止時期」column を `#806 対応後に廃止` → `#2398 計画策定済、Phase 3 で物理削除 (期限: 2026-12-31)` に更新し、本 docs への link を明記
- [x] **OSS 先調査記載**: 各 Phase の sub-Issue body に「OSS / 確立パターン調査結果」セクション完備 (既存 discord-alert / Repository パターン / lifecycle-email など)
- [x] **rollback 設計**: §5 で hotfix env (`LICENSE_HMAC_EMERGENCY_BYPASS`) + 48h 自動解除 + 根本対応手順を明記、平常時残置を禁忌として明記

## 横展開・影響波及チェック

- [x] **設計書 SSOT 同期** (`docs/CLAUDE.md` §設計書更新ルールに整合): `license-key-lifecycle.md` + `14-セキュリティ設計書.md` の 2 件を本 PR で同時更新済
- [x] **計画 docs ↔ sub-Issue 整合**: sub-Issue 3 件 (#2403 / #2404 / #2405) の AC が計画 docs §4 Phase の実装内容と 1:1 対応、起票 body は `tmp/issue-bodies/` の draft から `gh issue create --body-file` で配備
- [x] **ADR 整合**: ADR-0010 Bucket A (セキュリティ後退の根本解決) で判断根拠を §3.1 に明記、ADR-0006 (assertion 弱体化禁止) で Phase 3 削除を「削除であって緩和ではない」と sub-Issue body 内で明記
- [x] **既存運用 docs 整合**: `docs/operations/license-key-secrets.md` (HMAC シークレット運用) との関係を計画 docs `0. 本書の位置づけ` で明示

## レビュー依頼事項・破壊的変更

**レビュー依頼**:
1. **期限妥当性**: §3.2 で Phase 3 期限を 2026-12-31 (Year 1 末) に設定。Pre-PMF stage で前倒し可能と書いたが、QA / PO 視点で「Phase 1 集計結果が 0 件なら Phase 1 + Phase 3 を同一 sprint で実施」案の妥当性を確認お願いします
2. **rollback emergency env**: §5.2 で `LICENSE_HMAC_EMERGENCY_BYPASS` の 48h 限定運用を提案したが、ops チームから「rollback 専用 env を予め用意しておく」ことへの是非を意見いただきたい
3. **sub-Issue 粒度**: Phase 2 が 1-2 sprint (2 週間) と他より長め。「ops 画面 + email template + status enum 追加」の 3 要素を更に分割すべきか判断お願いします

**破壊的変更**: 本 PR では発生なし。Phase 2 / 3 で legacy key 利用 user に対する breaking change が発生するため、各 sub-Issue で個別レビュー必要。

## 配布済み env / secret (ADR-0006)

- 新規 env 追加なし。既存 `AWS_LICENSE_SECRET` / `ALLOW_LEGACY_LICENSE_KEYS` を引き続き使用 (Phase 3 で後者を物理削除する別 PR)
- 計画 §5 (rollback) で `LICENSE_HMAC_EMERGENCY_BYPASS` を提案。これは Phase 3 後の hotfix 専用 env で、本 PR では env 定義変更なし。Phase 3 sub-Issue (#2405) で正式定義可否を再評価する

## Ready for Review チェックリスト

- [x] 計画 docs `docs/operations/license-hmac-migration-plan.md` 配備済
- [x] 設計書 2 件 (`license-key-lifecycle.md` / `14-セキュリティ設計書.md`) 同期更新済
- [x] sub-Issue 3 件 (#2403 / #2404 / #2405) 起票完了 + 計画 docs §4 にリンク反映済
- [x] PR body 13 必須セクション全て埋めた
- [x] commit message に「計画策定のみ、実 code 変更は sub-Issue 別 PR」と明記済
- [x] tmp/ 配下の draft (`tmp/issue-bodies/2398-phase*.md` / `tmp/pr-bodies/2398.md`) は merge 後削除する
- [x] CI 全緑確認後に Ready 化

## QM レビュー結果

(QM レビュー時に記入)

---

**Sub-Issue リンク**:
- Phase 1 (warning + ops 集計): https://github.com/Takenori-Kusaka/ganbari-quest/issues/2403
- Phase 2 (legacy 発行禁止 + migration 案内): https://github.com/Takenori-Kusaka/ganbari-quest/issues/2404
- Phase 3 (verify reject + 物理削除): https://github.com/Takenori-Kusaka/ganbari-quest/issues/2405
