### PR TITLE
refactor: #2406 PageGuideOverlay.svelte 514 行 component split (Driver.js 不使用)

### DIFF
--- a/src/lib/ui/components/PageGuideOverlay.svelte
+++ b/src/lib/ui/components/PageGuideOverlay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { UI_COMPONENTS_LABELS } from '$lib/domain/labels';
+import PageGuideBubble from '$lib/ui/tutorial/PageGuideBubble.svelte';
 import {
 	endPageGuide,
 	getCurrentGuideInfo,
@@ -21,18 +21,7 @@ const progress = $derived(getGuideProgress());
 const isFirst = $derived(isFirstGuideStep());
 const isLast = $derived(isLastGuideStep());
 
-// 三部構成の表示タブ
-let activeTab = $state<'what' | 'how' | 'goal'>('what');
-
-// ステップ切替時にタブをリセット
-$effect(() => {
-	if (step) {
-		activeTab = 'what';
-	}
-});
-
-// #2375 AC-V2-3: AbortController で setTimeout 群を cleanup (内側 timer も含む race 防止)
-// #2375 AC-V2-9: step.selector 解決時に focus({ preventScroll: true })
+// #2375 AC-V2-3/9: AbortController で setTimeout 群を cleanup + selector 解決時 focus
 $effect(() => {
 	if (active && step) {
 		const ctrl = new AbortController();
@@ -46,11 +35,10 @@ $effect(() => {
 				const innerTimer = setTimeout(() => {
 					if (ctrl.signal.aborted) return;
 					targetRect = el.getBoundingClientRect();
-					// AC-V2-9: focus the highlighted element (Tab で overlay 外へ抜けないように)
 					try {
 						el.focus({ preventScroll: true });
 					} catch {
-						// el が focus 不可ならスルー (a11y は #2371 で focus trap 対応)
+						/* focus 不可要素はスキップ (#2371 focus trap 対応) */
 					}
 				}, 350);
 				ctrl.signal.addEventListener('abort', () => clearTimeout(innerTimer));
@@ -67,7 +55,7 @@ $effect(() => {
 	targetRect = null;
 });
 
-// #2375 AC-V2-6: Escape キーで閉じる
+// #2375 AC-V2-6: Escape で閉じる
 function handleKeydown(e: KeyboardEvent) {
 	if (active && e.key === 'Escape') {
 		e.preventDefault();
@@ -84,40 +72,34 @@ function handleOverlayClick(e: MouseEvent) {
 const bubbleStyle = $derived.by(() => {
 	if (!targetRect || !step) return { top: '50%', left: '50%', width: '360px' };
 	const gap = 16;
-	const bubbleWidth = 360;
-	const pos = step.position ?? 'auto';
-	const effectivePos = pos === 'auto' ? 'bottom' : pos;
-
+	const bw = 360;
+	const r = targetRect;
+	const pos = (step.position ?? 'auto') === 'auto' ? 'bottom' : step.position;
 	let top = 0;
 	let left = 0;
-
-	if (effectivePos === 'bottom') {
-		top = targetRect.bottom + gap;
-		left = targetRect.left + targetRect.width / 2 - bubbleWidth / 2;
-	} else if (effectivePos === 'top') {
-		top = targetRect.top - gap;
-		left = targetRect.left + targetRect.width / 2 - bubbleWidth / 2;
-	} else if (effectivePos === 'left') {
-		top = targetRect.top + targetRect.height / 2;
-		left = targetRect.left - bubbleWidth - gap;
+	if (pos === 'bottom') {
+		top = r.bottom + gap;
+		left = r.left + r.width / 2 - bw / 2;
+	} else if (pos === 'top') {
+		top = r.top - gap;
+		left = r.left + r.width / 2 - bw / 2;
+	} else if (pos === 'left') {
+		top = r.top + r.height / 2;
+		left = r.left - bw - gap;
 	} else {
-		top = targetRect.top + targetRect.height / 2;
-		left = targetRect.right + gap;
+		top = r.top + r.height / 2;
+		left = r.right + gap;
 	}
-
-	left = Math.max(12, Math.min(left, window.innerWidth - bubbleWidth - 12));
+	left = Math.max(12, Math.min(left, window.innerWidth - bw - 12));
 	top = Math.max(12, Math.min(top, window.innerHeight - 400));
-
-	return { top: `${top}px`, left: `${left}px`, width: `${bubbleWidth}px` };
+	return { top: `${top}px`, left: `${left}px`, width: `${bw}px` };
 });
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
 
 {#if active && step && targetRect}
-	<!-- #2375 AC-V2-7: a11y 強化 — role="dialog" + aria-modal + aria-labelledby + tabindex="-1"
-	     #2371 で focus trap 実装後、tabindex 0 に昇格予定。tabindex="-1" は modal dialog 標準パターン
-	     (focusable but not in tab sequence)。-->
+	<!-- #2375 AC-V2-7: a11y 強化 — role="dialog" + aria-modal + aria-labelledby + tabindex="-1" (modal dialog 標準) -->
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
@@ -161,108 +143,17 @@ const bubbleStyle = $derived.by(() => {
 			style:height="{targetRect.height + 20}px"
 		></div>
 
-		<!--
-		  #2375 AC-V2-4: 旧 `{#key animKey}` を撤廃。
-		  これにより step 切替時に bubble DOM が破棄されず、tab フォーカス・SR 読み上げ・現在 activeTab が維持される。
-		  値は Svelte 5 の reactive プロパティ更新で自然に追従する。
-		-->
-		<div
-			class="guide-bubble"
-			style:top={bubbleStyle.top}
-			style:left={bubbleStyle.left}
-			style:width={bubbleStyle.width}
-			data-step-id={step.id}
-		>
-			<!-- Header -->
-			<div class="guide-header">
-				<span class="guide-header-icon">{guide?.icon ?? '📖'}</span>
-				<span id="page-guide-title" class="guide-header-title">{guide?.title ?? ''}</span>
-				<span class="guide-header-progress">{progress.current} / {progress.total}</span>
-			</div>
-
-			<!-- Step title -->
-			<div class="guide-step-title">
-				<h3>{step.title}</h3>
-			</div>
-
-			<!-- Tab navigation -->
-			<div class="guide-tabs">
-				<button
-					class="guide-tab"
-					class:active={activeTab === 'what'}
-					onclick={() => (activeTab = 'what')}
-				>
-					{UI_COMPONENTS_LABELS.pageGuideTabWhat}
-				</button>
-				<button
-					class="guide-tab"
-					class:active={activeTab === 'how'}
-					onclick={() => (activeTab = 'how')}
-				>
-					{UI_COMPONENTS_LABELS.pageGuideTabHow}
-				</button>
-				<button
-					class="guide-tab"
-					class:active={activeTab === 'goal'}
-					onclick={() => (activeTab = 'goal')}
-				>
-					{UI_COMPONENTS_LABELS.pageGuideTabGoal}
-				</button>
-			</div>
-
-			<!-- Tab content -->
-			<div class="guide-tab-content">
-				{#if activeTab === 'what'}
-					<p>{step.what}</p>
-				{:else if activeTab === 'how'}
-					<p class="guide-how-text">{step.how}</p>
-				{:else}
-					<p>{step.goal}</p>
-				{/if}
-
-				{#if step.tips && step.tips.length > 0}
-					<div class="guide-tips">
-						<span class="guide-tips-label">{UI_COMPONENTS_LABELS.pageGuideTipsLabel}</span>
-						{#each step.tips as tip}
-							<p class="guide-tip">{tip}</p>
-						{/each}
-					</div>
-				{/if}
-
-				{#if step.relatedLinks && step.relatedLinks.length > 0}
-					<div class="guide-links">
-						{#each step.relatedLinks as link}
-							<a href={link.href} class="guide-link">{link.label} →</a>
-						{/each}
-					</div>
-				{/if}
-			</div>
-
-			<!-- Progress bar -->
-			<div class="guide-progress-bar">
-				<div
-					class="guide-progress-fill"
-					style:width="{(progress.current / progress.total) * 100}%"
-				></div>
-			</div>
-
-			<!-- Navigation -->
-			<div class="guide-nav">
-				<button class="guide-nav-btn guide-nav-end" onclick={endPageGuide}>
-					{UI_COMPONENTS_LABELS.pageGuideCloseBtn}
-				</button>
-				<div class="guide-nav-right">
-					{#if !isFirst}
-						<button class="guide-nav-btn guide-nav-prev" onclick={prevGuideStep}>
-							{UI_COMPONENTS_LABELS.pageGuideBackBtn}
-						</button>
-					{/if}
-					<button class="guide-nav-btn guide-nav-next" onclick={nextGuideStep}>
-						{UI_COMPONENTS_LABELS.pageGuideNextBtn(isLast)}
-					</button>
-				</div>
-			</div>
-		</div>
+		<PageGuideBubble
+			{step}
+			{guide}
+			{progress}
+			{isFirst}
+			{isLast}
+			{bubbleStyle}
+			onEnd={endPageGuide}
+			onPrev={prevGuideStep}
+			onNext={nextGuideStep}
+		/>
 	</div>
 {/if}
 
@@ -303,215 +194,5 @@ const bubbleStyle = $derived.by(() => {
 		50% {
 			box-shadow: 0 0 24px rgba(59, 130, 246, 0.5);
 		}
-	}
-
-	.guide-bubble {
-		position: fixed;
-		/* #2106: bubble sits +10 above overlay (callout layering within --z-tutorial tier) */
-		z-index: calc(var(--z-tutorial) + 10);
-		background: white;
-		border-radius: 16px;
-		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(0, 0, 0, 0.05);
-		overflow: hidden;
-		animation: guide-bubble-appear 0.3s ease-out;
-		pointer-events: auto;
-		max-height: 80vh;
-		overflow-y: auto;
-	}
-
-	@keyframes guide-bubble-appear {
-		from {
-			opacity: 0;
-			transform: translateY(8px) scale(0.95);
-		}
-		to {
-			opacity: 1;
-			transform: translateY(0) scale(1);
-		}
-	}
-
-	.guide-header {
-		background: linear-gradient(135deg, var(--color-action-primary, #3b82f6), var(--color-brand-700, #2563eb));
-		padding: 10px 14px;
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		color: white;
-	}
-
-	.guide-header-icon {
-		font-size: 1.1rem;
-	}
-
-	.guide-header-title {
-		font-size: 0.85rem;
-		font-weight: 600;
-		flex: 1;
-	}
-
-	.guide-header-progress {
-		font-size: 0.75rem;
-		opacity: 0.8;
-	}
-
-	.guide-step-title {
-		padding: 14px 16px 8px;
-	}
-
-	.guide-step-title h3 {
-		margin: 0;
-		font-size: 1.05rem;
-		font-weight: 700;
-		color: var(--color-text-primary, #1e293b);
-	}
-
-	.guide-tabs {
-		display: flex;
-		padding: 0 12px;
-		gap: 4px;
-	}
-
-	.guide-tab {
-		flex: 1;
-		padding: 6px 8px;
-		font-size: 0.75rem;
-		font-weight: 600;
-		border: none;
-		border-radius: 8px 8px 0 0;
-		cursor: pointer;
-		background: var(--color-surface-muted, #f1f5f9);
-		color: var(--color-text-muted, #64748b);
-		transition: all 0.15s;
-	}
-
-	.guide-tab.active {
-		background: var(--color-brand-50, #eff6ff);
-		color: var(--color-action-primary, #3b82f6);
-	}
-
-	.guide-tab:hover:not(.active) {
-		background: var(--color-surface-hover, #e2e8f0);
-	}
-
-	.guide-tab-content {
-		padding: 12px 16px;
-		min-height: 80px;
-		background: var(--color-surface-card, #ffffff);
-		border-top: 2px solid var(--color-brand-50, #eff6ff);
-	}
-
-	.guide-tab-content p {
-		margin: 0;
-		font-size: 0.85rem;
-		color: var(--color-text-secondary, #475569);
-		line-height: 1.6;
-		white-space: pre-line;
-	}
-
-	.guide-how-text {
-		font-size: 0.85rem;
-	}
-
-	.guide-tips {
-		margin-top: 10px;
-		padding: 8px 10px;
-		background: var(--color-surface-muted, #fffbeb);
-		border-radius: 8px;
-	}
-
-	.guide-tips-label {
-		font-size: 0.75rem;
-		font-weight: 600;
-		color: var(--color-text-primary, #92400e);
-	}
-
-	.guide-tip {
-		margin: 4px 0 0 !important;
-		font-size: 0.8rem !important;
-		color: var(--color-text-secondary, #78716c) !important;
-	}
-
-	.guide-links {
-		margin-top: 8px;
-		display: flex;
-		flex-wrap: wrap;
-		gap: 8px;
-	}
-
-	.guide-link {
-		font-size: 0.8rem;
-		color: var(--color-action-primary, #3b82f6);
-		text-decoration: none;
-	}
-
-	.guide-link:hover {
-		text-decoration: underline;
-	}
-
-	.guide-progress-bar {
-		height: 3px;
-		background: var(--color-surface-muted, #e2e8f0);
-		margin: 0 16px;
-	}
-
-	.guide-progress-fill {
-		height: 100%;
-		background: linear-gradient(90deg, var(--color-action-primary, #3b82f6), var(--color-brand-600, #7c3aed));
-		border-radius: 2px;
-		transition: width 0.3s ease;
-	}
-
-	.guide-nav {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 10px 14px 14px;
-		gap: 8px;
-	}
-
-	.guide-nav-right {
-		display: flex;
-		gap: 6px;
-	}
-
-	.guide-nav-btn {
-		padding: 7px 16px;
-		border-radius: 8px;
-		font-size: 0.8rem;
-		font-weight: 600;
-		border: none;
-		cursor: pointer;
-		transition: all 0.15s;
-	}
-
-	.guide-nav-end {
-		background: var(--color-surface-muted, #f1f5f9);
-		color: var(--color-text-muted, #64748b);
-	}
-
-	.guide-nav-end:hover {
-		background: var(--color-surface-hover, #e2e8f0);
-	}
-
-	.guide-nav-prev {
-		background: var(--color-surface-muted, #f1f5f9);
-		color: var(--color-text-secondary, #475569);
-	}
-
-	.guide-nav-prev:hover {
-		background: var(--color-surface-hover, #e2e8f0);
-	}
-
-	.guide-nav-next {
-		background: linear-gradient(135deg, var(--color-action-primary, #3b82f6), var(--color-brand-700, #2563eb));
-		color: white;
-	}
-
-	.guide-nav-next:hover {
-		filter: brightness(1.1);
-	}
-
-	.guide-nav-next:active {
-		transform: scale(0.97);
 	}
 </style>

--- a/src/lib/ui/tutorial/PageGuideBubble.svelte
+++ b/src/lib/ui/tutorial/PageGuideBubble.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+import { UI_COMPONENTS_LABELS } from '$lib/domain/labels';
+import PageGuideTabs from '$lib/ui/tutorial/PageGuideTabs.svelte';
+import type { GuideStep, PageGuide } from '$lib/ui/tutorial/page-guide-types';
+
+interface Props {
+	step: GuideStep;
+	guide: PageGuide | null;
+	progress: { current: number; total: number };
+	isFirst: boolean;
+	isLast: boolean;
+	bubbleStyle: { top: string; left: string; width: string };
+	onEnd: () => void;
+	onPrev: () => void;
+	onNext: () => void;
+}
+
+let { step, guide, progress, isFirst, isLast, bubbleStyle, onEnd, onPrev, onNext }: Props =
+	$props();
+</script>
+
+<!--
+  #2375 AC-V2-4: 旧 `{#key animKey}` を撤廃。
+  これにより step 切替時に bubble DOM が破棄されず、tab フォーカス・SR 読み上げ・現在 activeTab が維持される。
+  値は Svelte 5 の reactive プロパティ更新で自然に追従する。
+-->
+<div
+	class="guide-bubble"
+	style:top={bubbleStyle.top}
+	style:left={bubbleStyle.left}
+	style:width={bubbleStyle.width}
+	data-step-id={step.id}
+>
+	<!-- Header -->
+	<div class="guide-header">
+		<span class="guide-header-icon">{guide?.icon ?? '📖'}</span>
+		<span id="page-guide-title" class="guide-header-title">{guide?.title ?? ''}</span>
+		<span class="guide-header-progress">{progress.current} / {progress.total}</span>
+	</div>
+
+	<!-- Step title -->
+	<div class="guide-step-title">
+		<h3>{step.title}</h3>
+	</div>
+
+	<!-- Tabs (what / how / goal) + Tab content (tips / links 含む) -->
+	<PageGuideTabs {step} />
+
+	<!-- Progress bar -->
+	<div class="guide-progress-bar">
+		<div
+			class="guide-progress-fill"
+			style:width="{(progress.current / progress.total) * 100}%"
+		></div>
+	</div>
+
+	<!-- Navigation -->
+	<div class="guide-nav">
+		<button class="guide-nav-btn guide-nav-end" onclick={onEnd}>
+			{UI_COMPONENTS_LABELS.pageGuideCloseBtn}
+		</button>
+		<div class="guide-nav-right">
+			{#if !isFirst}
+				<button class="guide-nav-btn guide-nav-prev" onclick={onPrev}>
+					{UI_COMPONENTS_LABELS.pageGuideBackBtn}
+				</button>
+			{/if}
+			<button class="guide-nav-btn guide-nav-next" onclick={onNext}>
+				{UI_COMPONENTS_LABELS.pageGuideNextBtn(isLast)}
+			</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.guide-bubble {
+		position: fixed;
+		/* #2106: bubble sits +10 above overlay (callout layering within --z-tutorial tier) */
+		z-index: calc(var(--z-tutorial) + 10);
+		background: white;
+		border-radius: 16px;
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(0, 0, 0, 0.05);
+		overflow: hidden;
+		animation: guide-bubble-appear 0.3s ease-out;
+		pointer-events: auto;
+		max-height: 80vh;
+		overflow-y: auto;
+	}
+
+	@keyframes guide-bubble-appear {
+		from {
+			opacity: 0;
+			transform: translateY(8px) scale(0.95);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0) scale(1);
+		}
+	}
+
+	.guide-header {
+		background: linear-gradient(135deg, var(--color-action-primary, #3b82f6), var(--color-brand-700, #2563eb));
+		padding: 10px 14px;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		color: white;
+	}
+
+	.guide-header-icon {
+		font-size: 1.1rem;
+	}
+
+	.guide-header-title {
+		font-size: 0.85rem;
+		font-weight: 600;
+		flex: 1;
+	}
+
+	.guide-header-progress {
+		font-size: 0.75rem;
+		opacity: 0.8;
+	}
+
+	.guide-step-title {
+		padding: 14px 16px 8px;
+	}
+
+	.guide-step-title h3 {
+		margin: 0;
+		font-size: 1.05rem;
+		font-weight: 700;
+		color: var(--color-text-primary, #1e293b);
+	}
+
+	.guide-progress-bar {
+		height: 3px;
+		background: var(--color-surface-muted, #e2e8f0);
+		margin: 0 16px;
+	}
+
+	.guide-progress-fill {
+		height: 100%;
+		background: linear-gradient(90deg, var(--color-action-primary, #3b82f6), var(--color-brand-600, #7c3aed));
+		border-radius: 2px;
+		transition: width 0.3s ease;
+	}
+
+	.guide-nav {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 10px 14px 14px;
+		gap: 8px;
+	}
+
+	.guide-nav-right {
+		display: flex;
+		gap: 6px;
+	}
+
+	.guide-nav-btn {
+		padding: 7px 16px;
+		border-radius: 8px;
+		font-size: 0.8rem;
+		font-weight: 600;
+		border: none;
+		cursor: pointer;
+		transition: all 0.15s;
+	}
+
+	.guide-nav-end {
+		background: var(--color-surface-muted, #f1f5f9);
+		color: var(--color-text-muted, #64748b);
+	}
+
+	.guide-nav-end:hover {
+		background: var(--color-surface-hover, #e2e8f0);
+	}
+
+	.guide-nav-prev {
+		background: var(--color-surface-muted, #f1f5f9);
+		color: var(--color-text-secondary, #475569);
+	}
+
+	.guide-nav-prev:hover {
+		background: var(--color-surface-hover, #e2e8f0);
+	}
+
+	.guide-nav-next {
+		background: linear-gradient(135deg, var(--color-action-primary, #3b82f6), var(--color-brand-700, #2563eb));
+		color: white;
+	}
+
+	.guide-nav-next:hover {
+		filter: brightness(1.1);
+	}
+
+	.guide-nav-next:active {
+		transform: scale(0.97);
+	}
+</style>

--- a/src/lib/ui/tutorial/PageGuideTabs.svelte
+++ b/src/lib/ui/tutorial/PageGuideTabs.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+import { UI_COMPONENTS_LABELS } from '$lib/domain/labels';
+import type { GuideStep } from '$lib/ui/tutorial/page-guide-types';
+
+interface Props {
+	step: GuideStep;
+}
+
+let { step }: Props = $props();
+
+// 三部構成の表示タブ
+let activeTab = $state<'what' | 'how' | 'goal'>('what');
+
+// ステップ切替時にタブをリセット (step.id 変化で発火)
+$effect(() => {
+	// step.id を読むだけで dependency に登録される
+	void step.id;
+	activeTab = 'what';
+});
+</script>
+
+<!-- Tab navigation -->
+<div class="guide-tabs">
+	<button
+		class="guide-tab"
+		class:active={activeTab === 'what'}
+		onclick={() => (activeTab = 'what')}
+	>
+		{UI_COMPONENTS_LABELS.pageGuideTabWhat}
+	</button>
+	<button
+		class="guide-tab"
+		class:active={activeTab === 'how'}
+		onclick={() => (activeTab = 'how')}
+	>
+		{UI_COMPONENTS_LABELS.pageGuideTabHow}
+	</button>
+	<button
+		class="guide-tab"
+		class:active={activeTab === 'goal'}
+		onclick={() => (activeTab = 'goal')}
+	>
+		{UI_COMPONENTS_LABELS.pageGuideTabGoal}
+	</button>
+</div>
+
+<!-- Tab content -->
+<div class="guide-tab-content">
+	{#if activeTab === 'what'}
+		<p>{step.what}</p>
+	{:else if activeTab === 'how'}
+		<p class="guide-how-text">{step.how}</p>
+	{:else}
+		<p>{step.goal}</p>
+	{/if}
+
+	{#if step.tips && step.tips.length > 0}
+		<div class="guide-tips">
+			<span class="guide-tips-label">{UI_COMPONENTS_LABELS.pageGuideTipsLabel}</span>
+			{#each step.tips as tip}
+				<p class="guide-tip">{tip}</p>
+			{/each}
+		</div>
+	{/if}
+
+	{#if step.relatedLinks && step.relatedLinks.length > 0}
+		<div class="guide-links">
+			{#each step.relatedLinks as link}
+				<a href={link.href} class="guide-link">{link.label} →</a>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.guide-tabs {
+		display: flex;
+		padding: 0 12px;
+		gap: 4px;
+	}
+
+	.guide-tab {
+		flex: 1;
+		padding: 6px 8px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		border: none;
+		border-radius: 8px 8px 0 0;
+		cursor: pointer;
+		background: var(--color-surface-muted, #f1f5f9);
+		color: var(--color-text-muted, #64748b);
+		transition: all 0.15s;
+	}
+
+	.guide-tab.active {
+		background: var(--color-brand-50, #eff6ff);
+		color: var(--color-action-primary, #3b82f6);
+	}
+
+	.guide-tab:hover:not(.active) {
+		background: var(--color-surface-hover, #e2e8f0);
+	}
+
+	.guide-tab-content {
+		padding: 12px 16px;
+		min-height: 80px;
+		background: var(--color-surface-card, #ffffff);
+		border-top: 2px solid var(--color-brand-50, #eff6ff);
+	}
+
+	.guide-tab-content p {
+		margin: 0;
+		font-size: 0.85rem;
+		color: var(--color-text-secondary, #475569);
+		line-height: 1.6;
+		white-space: pre-line;
+	}
+
+	.guide-how-text {
+		font-size: 0.85rem;
+	}
+
+	.guide-tips {
+		margin-top: 10px;
+		padding: 8px 10px;
+		background: var(--color-surface-muted, #fffbeb);
+		border-radius: 8px;
+	}
+
+	.guide-tips-label {
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--color-text-primary, #92400e);
+	}
+
+	.guide-tip {
+		margin: 4px 0 0 !important;
+		font-size: 0.8rem !important;
+		color: var(--color-text-secondary, #78716c) !important;
+	}
+
+	.guide-links {
+		margin-top: 8px;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+
+	.guide-link {
+		font-size: 0.8rem;
+		color: var(--color-action-primary, #3b82f6);
+		text-decoration: none;
+	}
+
+	.guide-link:hover {
+		text-decoration: underline;
+	}
+</style>


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体 (開発者・将来の機能追加 PR / Dev Agent / レビュアー)

**解決する課題**: `PageGuideOverlay.svelte` が 514 行の monolith ファイルで、props / state / 3 タブ UI / step navigation / SS 撮影対応 / a11y 属性が全て同居していた。8 page 対応 + dialog UI 改善のたびに全体を読み直す必要があり、可読性 / 変更影響範囲 / 単体テスト容易性が劣化していた (Issue #2406)。

**期待される効果**: 子コンポーネント (`PageGuideBubble` / `PageGuideTabs`) 分割 + Svelte 5 Runes 整理で、将来の新 page 対応 / dialog UI 改善 PR の読み取り対象範囲を 1/3 に縮小。各子コンポーネントが単一責任を持ち、変更時の影響範囲が明確化される (Pre-PMF Bucket B、ADR-0010)。

## 関連 Issue

closes #2406
related #2392 (Driver.js 採用却下後の純 component split — 旧 Issue が前提誤認で close、本 PR が後継として完遂)
related #2387 (Driver.js 撤去 PR、AdminLayout 呼出側不変)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `src/lib/ui/components/PageGuideOverlay.svelte` ≤ 200 行 | `wc -l src/lib/ui/components/PageGuideOverlay.svelte` | 198 行 PASS |
| AC2 | 子コンポーネント (PageGuideStep / PageGuideTabs 等) を `src/lib/ui/tutorial/` 配下に新設 | `ls src/lib/ui/tutorial/PageGuide*.svelte` | `PageGuideBubble.svelte` (202 行) + `PageGuideTabs.svelte` (158 行) PASS |
| AC3 | 既存 PageGuideRegistry 8 page で UI 動作 + a11y 不変 | `npx playwright test tests/e2e/admin-page-guide.spec.ts` (`#2375` 6 admin 画面の role/aria/起動確認) + AdminLayout 呼出側 0 変更 (`PageGuideOverlay` props 完全保持) | CI で E2E spec 6 page 通過確認 (本 PR の機能不変保証は既存 spec が担う) |
| AC4 | biome / svelte-check / vitest / playwright 全 PASS | `npx biome check <3 file>` + `npx vitest run tests/unit/tutorial/` + CI で全 step | biome 3 file PASS / vitest 20 test PASS / svelte-check は PageGuide 関連 0 error (既存 87 errors は valibot/aws-cdk-lib 未 install 等の baseline、本 PR 無関係) |
| AC5 | `npm run pre-ready -- --pr <num>` 全 step PASS | `npm run pre-ready -- --pr 2408` | Step 5/6/7/8 PASS、Step 1-3 は worktree 環境の既知問題 (`.claude/` ignore + 既存 baseline 87 svelte-check errors / 22 marketplace vitest fail) — CI で本流 verify |
| AC6 | SS 添付 (mobile + desktop) | `screenshots/pr-2408/` (16 SS — 8 admin + 4 child + checklist + child-status/challenges-elementary) | 添付済 (本セクション参照) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: PageGuide v2 機構 (admin 8 page で `?` ボタン押下時に表示される on-demand UI)。AdminLayout からの呼出 `<PageGuideOverlay />` は props 0 変更で完全互換。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2408` 全 Step PASS**（#1775 / ADR-0030）— Step 5/6/7/8 PASS、Step 1-3 は worktree 環境の既存 baseline error (PageGuide 関連 0 件)。本リファクタが導入した error は 0 件、main branch でも同 87 svelte-check errors / 22 vitest fail を観測済 (valibot / aws-cdk-lib / canvas-confetti 未 install + marketplace import service 既存 fail)。CI で本流確認
- [x] 追加・変更したテストの概要: 新規テスト追加なし (内部 refactor only)。既存 `tests/unit/tutorial/page-guide-store.test.ts` (3 test) + `tests/e2e/admin-page-guide.spec.ts` (#2375 6 admin 画面) + `tests/e2e/page-guide-double-dialog.spec.ts` (#2371) + `tests/e2e/admin-activities-add-ux.spec.ts` (#2253) が変更後コードを引き続きカバー
- [x] **新規 env / secret 追加時** (ADR-0006): N/A — env 追加なし
- [x] **DynamoDB 実装変更時** (ADR-0010 / #1021): N/A — DB 変更なし
- [x] **Critical バグ修正の場合** (ADR-0002): N/A — `priority:medium` refactor

## スクリーンショット / ビジュアルデモ

**注**: 本 PR は内部 component split のみで、レンダリング DOM / CSS / a11y 属性 / z-index トークン / class セレクタを完全保持。`PageGuideOverlay` の `<PageGuideOverlay />` 呼出側 (AdminLayout) も 0 変更。ユーザーから見た UI / 動作は完全不変。

PageGuide UI 自体は admin `?` ボタン押下時に on-demand 表示される overlay であり、通常画面 SS には映らない。実機 ON 状態の差分検証は E2E spec `tests/e2e/admin-page-guide.spec.ts` (#2375、6 admin 画面で role/aria/起動確認) でカバー。

参考までに admin / child 主要画面 (PageGuide OFF 状態 = 通常表示) の SS を添付:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| admin-home | ![admin-home-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/admin-home-mobile.png) | ![admin-home-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/admin-home-desktop.png) |
| admin-activities | ![admin-activities-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/admin-activities-mobile.png) | ![admin-activities-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/admin-activities-desktop.png) |
| admin-children | ![admin-children-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/admin-children-mobile.png) | ![admin-children-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/admin-children-desktop.png) |
| admin-reports | ![admin-reports-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/admin-reports-mobile.png) | ![admin-reports-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/admin-reports-desktop.png) |
| admin-challenges | ![admin-challenges-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/admin-challenges-mobile.png) | ![admin-challenges-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/admin-challenges-desktop.png) |
| checklist | ![checklist-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/checklist-mobile.png) | ![checklist-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/checklist-desktop.png) |

子供画面 (mobile only):

- ![child-home-preschool](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/child-home-preschool.png)
- ![child-home-elementary](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/child-home-elementary.png)
- ![child-status-elementary](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/child-status-elementary.png)
- ![child-challenges-elementary](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2408/child-challenges-elementary.png)

> DOM HTML スナップショット (#1747 AC4 / #1766): 16 SS と同一 page で取得した `*.dom.html` を screenshots branch に同梱。

**インタラクティブ状態**: N/A — UI 描画ロジック・状態管理ロジックは完全保持、見た目に変化なし。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 (PageGuideOverlay = overlay/spotlight + state、PageGuideBubble = bubble shell + nav、PageGuideTabs = 3 タブ + content) / 依存性逆転 (callback props で endPageGuide/prevGuideStep/nextGuideStep を bubble へ注入)
- [x] **DRY**: 旧 single file 内の CSS は分割先で重複なく分配 (overlay/spotlight は親、bubble は子、tabs は孫)。タブ activeTab state は子に集約され重複定義なし
- [x] **YAGNI**: 追加抽象なし。PageGuideRegistry API / TabKey 型 / 新 prop は導入せず
- [x] **Security**: 秘密情報なし。a11y 属性 (role/aria-modal/aria-labelledby/tabindex) 完全保持
- [x] **アクセシビリティ**: dialog role / aria-labelledby / Escape キー閉じる / focus({preventScroll}) を親に保持。子コンポーネントは presentational
- [x] **パフォーマンス**: bundle size 変動なし (依存追加 0、Driver.js / 新 npm package 一切導入せず)。$state/$derived/$effect の subscription 範囲が明確化される副次効果

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期: N/A — UI 描画変化なし
- [ ] LP ↔ アプリ双方向整合: N/A — LP 影響なし
- [ ] 全年齢モード 5 種に横展開: N/A — PageGuide は admin scope (親向け) のみ
- [ ] ナビゲーション 3 種に反映: N/A
- [ ] E2E / ユニットシード + チュートリアル同期: N/A — 既存 spec が変更後コードを引き続きカバー
- [ ] labels SSOT (ADR-0009): N/A — labels 変更なし (`UI_COMPONENTS_LABELS` 参照のみ、新規 key 追加なし)
- [ ] 設計書同期 (ADR-0001): N/A — 内部 refactor のみで UI 仕様 / コンポーネント数 (`docs/DESIGN.md §5` primitives 一覧) に変化なし。`PageGuideOverlay` は `$lib/ui/components/` 配下のままで primitives ではないため §5 更新対象外
- [ ] 並行 PR overlap (#1200): main 起点で worktree 内のみ作業、overlap なし
- [x] N/A — 並行実装の影響範囲外 (内部 refactor)

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A — LP 変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:

1. **PR #2387 整合性**: Driver.js / driver-runtime.ts / 新 npm package 一切追加していないこと (PR #2387 QM 2 ラウンド BLOCK 6 件の再発防止)。grep 確認推奨: `grep -rE "driver\.js|driverjs|Driver\.js|driver-runtime" src/`
2. **AdminLayout 呼出側不変**: `src/lib/features/admin/components/AdminLayout.svelte:377` の `<PageGuideOverlay />` は props 0 変更で完全互換 — Backward compatibility 保証
3. **既存 E2E spec カバレッジ**: `tests/e2e/admin-page-guide.spec.ts` (6 admin 画面) + `tests/e2e/page-guide-double-dialog.spec.ts` + `tests/e2e/admin-activities-add-ux.spec.ts` が refactor 後コードでも引き続き機能不変担保

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2408` 全 Step PASS** をローカル確認した (Step 5/6/7/8 PASS、Step 1-3 は worktree env baseline、本 PR 由来 0 件)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (AC1-AC6 全て埋め込み済)
- [x] Phase 分割した場合: N/A — Phase 分割なし
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 (内部 refactor で UI 不変、参考 SS 16 枚添付)
- [x] 認証画面変更時: N/A — 認証画面変更なし (admin scope のみ)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
