### PR TITLE
refactor: #2403 ライセンスキー HMAC 必須化 Phase 1.1/1.2 — warning log 格上げ + Discord alert

### DIFF
--- a/src/lib/server/services/license-key-service.ts
+++ b/src/lib/server/services/license-key-service.ts
@@ -10,6 +10,7 @@ import { type LicensePlan, planDurationDays } from '$lib/domain/constants/licens
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { MS_PER_DAY } from '$lib/domain/constants/time';
 import { getRepos } from '$lib/server/db/factory';
+import { sendDiscordAlert } from '$lib/server/discord-alert';
 import { logger } from '$lib/server/logger';
 
 // ============================================================
@@ -325,9 +326,23 @@ export async function validateLicenseKey(
 		}
 	}
 
-	// 旧形式キーの場合: 秘密鍵があればログ出力（将来的に非推奨化の追跡用）
+	// 旧形式キーの場合: 秘密鍵があれば警告ログ + Discord alert (HMAC 必須化 Phase 1、#2403)
+	// 既存 discord-alert.ts の 5 分窓 × 3 件 throttle 機構で同一 key prefix の連続通知を抑制 (key suffix を
+	// message 内に含めることで throttle key として動作、Issue #2403 「key suffix で同一 user 連続通知抑制」整合)。
+	// Phase 2 で legacy 発行禁止、Phase 3 で verify reject + 物理削除 (docs/operations/license-hmac-migration-plan.md)。
 	if (isLegacy && getLicenseSecret()) {
-		logger.info(`[LICENSE] Legacy format key used: ${normalized.slice(0, 7)}...`);
+		const keyPrefix = normalized.slice(0, 7);
+		logger.warn(
+			`[LICENSE] Legacy format key used (HMAC 未署名、Phase 2/3 で reject 予告): ${keyPrefix}...`,
+		);
+		// fire-and-forget — alert 失敗は本処理を止めない (await しない、未処理例外は logger 内で catch される設計)
+		void sendDiscordAlert({
+			level: 'error',
+			message: `Legacy license key used: ${keyPrefix}... (HMAC 未署名、要 Phase 2 migration 通知)`,
+			errorSummary: `legacy_key_used:${keyPrefix}`,
+		}).catch((err) => {
+			logger.warn(`[LICENSE] Discord alert failed for legacy key ${keyPrefix}: ${String(err)}`);
+		});
 	}
 
 	const repos = getRepos();

--- a/tests/unit/services/license-key-service.test.ts
+++ b/tests/unit/services/license-key-service.test.ts
@@ -33,6 +33,11 @@ vi.mock('$lib/server/logger', () => ({
 	},
 }));
 
+const mockSendDiscordAlert = vi.fn();
+vi.mock('$lib/server/discord-alert', () => ({
+	sendDiscordAlert: (...args: unknown[]) => mockSendDiscordAlert(...args),
+}));
+
 import {
 	assertLicenseKeyConfigured,
 	consumeLicenseKey,
@@ -510,6 +515,61 @@ describe('validateLicenseKey', () => {
 		const result = await validateLicenseKey('GQ-ABCD-EFGH-JKLM');
 
 		expect(result.valid).toBe(true);
+	});
+
+	it('#2403 Phase 1.1/1.2: legacy 形式 + AWS_LICENSE_SECRET 設定下で logger.warn + Discord alert が発火する', async () => {
+		// Arrange — AWS_LICENSE_SECRET 設定 (Phase 1.1 の `if (isLegacy && getLicenseSecret())` 分岐に入る条件)
+		process.env.AWS_LICENSE_SECRET = TEST_SECRET;
+		const { logger } = await import('$lib/server/logger');
+		mockSendDiscordAlert.mockResolvedValue(undefined);
+
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-ABCD-EFGH-JKLM',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: '2026-01-01T00:00:00Z',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		// Act
+		const result = await validateLicenseKey('GQ-ABCD-EFGH-JKLM');
+
+		// Assert — validation 自体は成功 (legacy 受け入れ維持、Phase 2 で初めて reject)
+		expect(result.valid).toBe(true);
+
+		// Assert — Phase 1.1: logger.warn が「Legacy format key used」で発火
+		expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Legacy format key used'));
+		expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('GQ-ABCD'));
+
+		// Assert — Phase 1.2: sendDiscordAlert が level: 'error' + errorSummary: legacy_key_used:<prefix> で発火
+		expect(mockSendDiscordAlert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				level: 'error',
+				errorSummary: expect.stringContaining('legacy_key_used:GQ-ABCD'),
+			}),
+		);
+	});
+
+	it('#2403 Phase 1.2: Discord alert 失敗は本処理を止めない (fire-and-forget)', async () => {
+		process.env.AWS_LICENSE_SECRET = TEST_SECRET;
+		mockSendDiscordAlert.mockRejectedValue(new Error('Discord webhook unreachable'));
+
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-ABCD-EFGH-JKLM',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'active',
+			createdAt: '2026-01-01T00:00:00Z',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		// Act — Discord alert が reject しても validateLicenseKey は通常通り完了する
+		const result = await validateLicenseKey('GQ-ABCD-EFGH-JKLM');
+
+		// Assert — validation 結果は alert 失敗の影響を受けない
+		expect(result.valid).toBe(true);
+		expect(mockSendDiscordAlert).toHaveBeenCalled();
 	});
 
 	it('署名付きキーの署名が正しい場合はDBを参照する', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 保護者 (license 認証経路の安全性) + 運営 (observability)

**解決する課題**: ライセンスキー HMAC 必須化の 3 phase 移行計画 (#2398) の Phase 1.1 / 1.2 を実装し、HMAC 未署名 (legacy 形式) key が production で使用されていることを観測 + Discord alert 可能にする。Phase 2/3 の reject 実装の前提情報を整備する。

**期待される効果**: legacy key 利用の検知 + 通知により、Phase 2 (新規 legacy 発行禁止) + Phase 3 (verify reject + 物理削除) への移行判断材料を取得。ops チームが legacy 残存数を能動的に観測可能になる。

## 関連 Issue

closes #2403 (Phase 1.1 / 1.2 部分のみ、Phase 1.3-1.5 は別 Issue「#2403 パート 2」として後続起票)

関連:
- 親 Issue: #2398 (HMAC 必須化計画策定)
- 計画 docs: `docs/operations/license-hmac-migration-plan.md` §4 Phase 1
- 関連: #797 / #806 / #812 (HMAC 機構導入)
- ADR-0006 (assertion 弱体化禁止整合 — band-aid なし、warn 格上げのみ)
- ADR-0014 (OSS 先調査整合 — 既存 discord-alert.ts を流用、新規 OSS 導入なし)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | Phase 1.1: `validateLicenseKey()` の legacy 形式利用時 (`if (isLegacy && getLicenseSecret())` 分岐) のログを `logger.info` → `logger.warn` に格上げ | `grep -n "logger.warn" src/lib/server/services/license-key-service.ts` で legacy 警告ログ確認 | ✅ commit `99796770` で line 329-335 の logger.info を logger.warn に格上げ、Phase 2/3 reject 予告メッセージを含める |
| AC2 | Phase 1.2: Discord incident channel への alert 連携 | `grep -n sendDiscordAlert src/lib/server/services/license-key-service.ts` 確認 | ✅ commit `99796770` で `sendDiscordAlert({ level: 'error', errorSummary: \`legacy_key_used:${keyPrefix}\` })` 追加。既存 5 分窓 × 3 件 throttle 機構が key prefix 単位で連続通知を抑制 (Issue 本文「rate-limit 1h/key suffix」は同等の意図を既存機構で達成、PR scope 拡大せず) |
| AC3 | テスト追加: warn / Discord alert 発火を検証 | `npx vitest run tests/unit/services/license-key-service.test.ts` | ✅ 98 / 98 PASS。新規 2 件: 「#2403 Phase 1.1/1.2: legacy 形式 + AWS_LICENSE_SECRET 設定下で logger.warn + Discord alert が発火する」「#2403 Phase 1.2: Discord alert 失敗は本処理を止めない (fire-and-forget)」 |
| AC4 | `npm run pre-ready` 全 step PASS | コマンド実行 | ⏳ 本 commit 後実行 |
| AC5 | AC 検証マップ全行埋め (ADR-0004) | 本表の各 cell 確認 | ✅ AC1〜3 すべて 検証手段 + エビデンス埋め (AC4 は pre-ready 実行待ち) |

### 本 PR scope 外 (別 Issue 起票、Phase 1 完了は当該別 Issue close 時)

- Phase 1.3: ops endpoint `/api/v1/ops/license/legacy-count` (auth-repo interface 拡張 + DynamoDB 実装 + SQLite no-op + ops 認証 gate)
- Phase 1.4: E2E (ops 認証 200 + 非 ops 403)
- Phase 1.5: docs/operations/license-hmac-migration-plan.md §6 実績ログ追記 (Phase 1.3 endpoint 実装後、集計値取得時点)

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`) — `license-key-service.ts` の legacy 警告ロジック更新
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)
- [x] テストコード (`tests/unit/services/license-key-service.test.ts`) — 新規 2 件追加

**影響を受ける画面・機能**: なし (license 認証経路の挙動は不変、observability 層の強化のみ)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030） — 本 PR Ready 化前に実行
- [x] 追加・変更したテストの概要: `tests/unit/services/license-key-service.test.ts` に 2 件追加 (Phase 1.1/1.2 発火確認 + fire-and-forget 例外処理確認)。98/98 PASS
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A (既存 `AWS_LICENSE_SECRET` / `DISCORD_ALERT_WEBHOOK_URL` を流用、新規追加なし)
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A (Phase 1.3 で別 PR、本 PR では Repository 触らず)
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (priority:medium)
- [x] **ADR-0006 assertion 弱体化禁止整合**: 本 PR は band-aid (timeout / retry / skip) を一切含まない。legacy 受入は維持しつつ observability のみ強化、Phase 2/3 で root reject へ段階移行

## スクリーンショット / ビジュアルデモ

**該当なし**: 本 PR は service 層の observability 強化 (logger.warn 格上げ + Discord alert 連携) のみで UI 表示変化なし。「描画変化なし」を明示 (#1744)。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A (UI 変更なし) | N/A (UI 変更なし) |
| **修正後** | N/A (UI 変更なし) | N/A (UI 変更なし) |

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 既存 `sendDiscordAlert` API を流用 (Dependency Inversion 維持)、license-key-service の責務不変
- [x] **DRY**: Discord alert 機構は既存 `discord-alert.ts` を再利用、新規 throttle 機構を独自実装せず
- [x] **YAGNI**: Phase 1.1/1.2 のみで完結。Phase 1.3 (endpoint) は別 Issue で起票、本 PR で先取り実装しない
- [x] **Security**: legacy key prefix の 7 文字のみ log / alert に含める (full key 漏洩防止、既存パターン踏襲)
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: Discord alert は fire-and-forget (await しない)、validation 経路の latency に影響しない

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] N/A — 並行実装の影響範囲外 (本番 ↔ デモ / LP ↔ アプリ / 5 年齢モード / labels SSOT いずれにも波及しない)

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- legacy key 受入は維持 (Phase 2 で初めて reject)、validate 結果は不変

**レビュー依頼事項・QA**:

1. **Issue 本文「rate-limit 1h/key suffix」と既存 discord-alert.ts 機構 (5 分窓 × 3 件 throttle) の差異**: 既存機構は key prefix を `errorSummary` に含めることで key prefix 単位の throttle key 化を達成。意図 (「同一 user 連続通知抑制」) は満たすが時間窓は 5 分。Issue 本文の「1h」は migration plan §4 起草時の概算値で、既存実装の 5 分窓で機能要件は満たすと判断。新規 throttle 機構導入は Pre-PMF 過剰防衛として棄却 (ADR-0014 OSS 先調査整合)
2. **Phase 1.1/1.2 と 1.3 の PR 分割理由**: user 判断 (2026-05-25) で Phase 1.3 (ops endpoint) は別 Issue 起票。本 PR は warn + Discord alert で self-contained (機能完成、band-aid なし)。Phase 1.3 は auth-repo interface 拡張 + DynamoDB 実装 + ops 認証 gate を伴うため独立 scope として整理
3. **Stacked PR**: 本 PR の base は `infra/2476-dx-setup-silent-fail` (#2477) で stacked。#2477 merge 後に base 自動更新 (GitHub native) で main 直 base に切替。`fileParallelism: false` の恩恵を即時享受するため

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし (既存 `AWS_LICENSE_SECRET` / `DISCORD_ALERT_WEBHOOK_URL` 流用)

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (Phase 1.1/1.2 範囲、1.3 以降は別 Issue 起票)
- [x] UI 変更時: 該当なし
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
