### PR TITLE
feat: #2404 ライセンスキー HMAC Phase 2.1+2.5 — production legacy 発行 throw + docs 廃止予告

### DIFF
--- a/docs/design/license-key-lifecycle.md
+++ b/docs/design/license-key-lifecycle.md
@@ -59,14 +59,20 @@ GQ-XXXX-XXXX-XXXX-YYYYY
 - **ペイロード**: `randomBytes(12)` を `KEY_CHARS[b % 32]` で変換
 - **署名**: `HMAC-SHA256(payload, AWS_LICENSE_SECRET)` の先頭 5 バイトを `KEY_CHARS` で変換
 
-### 2.2 LEGACY vs SIGNED
+### 2.2 LEGACY vs SIGNED (廃止予告)
 
 | 形式 | 正規表現 | 説明 | 廃止時期 |
 |------|---------|------|---------|
-| LEGACY | `^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$` | HMAC 署名なし (旧実装) | **#2398 計画策定済、Phase 3 で物理削除 (期限: 2026-12-31)** |
+| LEGACY | `^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$` | HMAC 署名なし (旧実装) | **廃止予告: production 新規発行は Phase 2 (#2404、2026-Q3) で物理 throw、validate 経路は Phase 3 (#2405、期限: 2026-12-31) で一律 reject + code 物理削除** |
 | SIGNED | `^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{5}$` | HMAC-SHA256 付き (現行) | — |
 
-> #806 で `AWS_LICENSE_SECRET` は production 必須化済み、dev 環境では引き続き optional (`isLegacyFormatAllowed()` で dev/test は常に受入)。#2398 で **Phase 1 (warning + ops 集計) / Phase 2 (新規 legacy 発行禁止 + migration 案内) / Phase 3 (verify reject + legacy code 物理削除)** の 3 phase 移行計画を策定済。詳細: [docs/operations/license-hmac-migration-plan.md](../operations/license-hmac-migration-plan.md)。
+#### 廃止スケジュール (#2398 3 phase 計画)
+
+- **Phase 1 (完了、2026-Q2)** — warning log + Discord alert (#2403) + ops 集計 endpoint `/ops/license/legacy-count` (#2484)
+- **Phase 2 (進行中、2026-Q3 末)** — 新規 legacy 発行を production で物理 throw (#2404 Sub-A 適用済) + 既存 legacy user に migration 案内 email + `LICENSE_KEY_STATUS.MIGRATED` 遷移 (#2404 Sub-B、別 Issue で起票)
+- **Phase 3 (2026-12-31 期限、#2405)** — validate 経路で legacy 一律 reject + `isLegacyFormatAllowed` / `LEGACY_FORMAT` / `ALLOW_LEGACY_LICENSE_KEYS` env を物理削除
+
+> #806 で `AWS_LICENSE_SECRET` は production 必須化済み、dev 環境では引き続き optional (`isLegacyFormatAllowed()` で dev/test は常に受入)。#2404 Phase 2.1 で `generateLicenseKey()` の secret 未設定 fallback を production で物理 throw 化、新規 legacy 流入を停止。詳細: [docs/operations/license-hmac-migration-plan.md](../operations/license-hmac-migration-plan.md)。
 
 ### 2.3 実装リファレンス
 

--- a/docs/design/license-key-lifecycle.md
+++ b/docs/design/license-key-lifecycle.md
@@ -68,8 +68,10 @@ GQ-XXXX-XXXX-XXXX-YYYYY
 
 #### 廃止スケジュール (#2398 3 phase 計画)
 
-- **Phase 1 (完了、2026-Q2)** — warning log + Discord alert (#2403) + ops 集計 endpoint `/ops/license/legacy-count` (#2484)
-- **Phase 2 (進行中、2026-Q3 末)** — 新規 legacy 発行を production で物理 throw (#2404 Sub-A 適用済) + 既存 legacy user に migration 案内 email + `LICENSE_KEY_STATUS.MIGRATED` 遷移 (#2404 Sub-B、別 Issue で起票)
+> **SSOT**: 各 Phase の status / 期限 / 集計値は [`docs/operations/license-hmac-migration-plan.md`](../operations/license-hmac-migration-plan.md) §3.2 / §4 / §6 が正本。本書 §2.2 は要約であり、矛盾時は SSOT を優先する。
+
+- **Phase 1 (実装済 / 集計待ち、完了予定: 2026-Q3 末 = 2026-09-30)** — warning log + Discord alert (#2403 PR #2483 merged) + ops 集計 endpoint `/ops/license/legacy-count` (#2484 PR merged)。本番 deploy 後の hit で `legacy_count` が確定し SSOT §6 に記録される段階で初めて Phase 1 完了 (SSOT §4 AC4 "設計書 §6 集計結果記録")
+- **Phase 2 (Sub-A 実装済 / Sub-B 未着手、完了予定: Phase 1 完了 + 30 日 grace period)** — 新規 legacy 発行を production で物理 throw (#2404 Sub-A 適用済) + 既存 legacy user に migration 案内 email + `LICENSE_KEY_STATUS.MIGRATED` 遷移 (#2404 Sub-B、別 Issue で起票)
 - **Phase 3 (2026-12-31 期限、#2405)** — validate 経路で legacy 一律 reject + `isLegacyFormatAllowed` / `LEGACY_FORMAT` / `ALLOW_LEGACY_LICENSE_KEYS` env を物理削除
 
 > #806 で `AWS_LICENSE_SECRET` は production 必須化済み、dev 環境では引き続き optional (`isLegacyFormatAllowed()` で dev/test は常に受入)。#2404 Phase 2.1 で `generateLicenseKey()` の secret 未設定 fallback を production で物理 throw 化、新規 legacy 流入を停止。詳細: [docs/operations/license-hmac-migration-plan.md](../operations/license-hmac-migration-plan.md)。

--- a/src/lib/server/services/license-key-service.ts
+++ b/src/lib/server/services/license-key-service.ts
@@ -140,6 +140,18 @@ export function generateLicenseKey(): string {
 		return `${payload}-${checksum}`;
 	}
 
+	// #2404 Phase 2.1: production で secret 未設定下の legacy 発行を物理的に止める。
+	// production では assertLicenseKeyConfigured() で起動時 throw 済みのため secret は必ず設定されているはずだが、
+	// 実装層でも legacy fallback を fail-closed に強化し、Phase 3 (legacy code 物理削除) への構造的前進を確保する。
+	// dev / test では legacy 発行を継続 (既存テスト互換 + ローカル開発フロー維持)。
+	if (isProduction()) {
+		throw new Error(
+			'[LICENSE] generateLicenseKey: AWS_LICENSE_SECRET is required in production. ' +
+				'Legacy (HMAC 未署名) key 生成は HMAC 必須化 Phase 2 で物理的に禁止されています。' +
+				'docs/operations/license-hmac-migration-plan.md §4 Phase 2 / #2404 参照。',
+		);
+	}
+
 	return payload;
 }
 

--- a/tests/unit/services/license-key-service.test.ts
+++ b/tests/unit/services/license-key-service.test.ts
@@ -137,10 +137,35 @@ describe('verifyKeySignature', () => {
 describe('generateLicenseKey', () => {
 	afterEach(() => {
 		process.env.AWS_LICENSE_SECRET = '';
+		process.env.NODE_ENV = 'test'; // #2404 Phase 2.1: production テスト後に必ず復元
 	});
 
 	it('秘密鍵なしの場合 GQ-XXXX-XXXX-XXXX 形式のキーを生成する', () => {
 		process.env.AWS_LICENSE_SECRET = '';
+		const key = generateLicenseKey();
+		expect(key).toMatch(/^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+	});
+
+	it('#2404 Phase 2.1: production で秘密鍵未設定下の legacy 発行は throw する', () => {
+		process.env.AWS_LICENSE_SECRET = '';
+		process.env.NODE_ENV = 'production';
+		expect(() => generateLicenseKey()).toThrowError(
+			/legacy.*key.*Phase 2|AWS_LICENSE_SECRET is required/i,
+		);
+	});
+
+	it('#2404 Phase 2.1: production で秘密鍵が設定済みなら通常通り SIGNED key を発行する', () => {
+		process.env.AWS_LICENSE_SECRET = TEST_SECRET;
+		process.env.NODE_ENV = 'production';
+		const key = generateLicenseKey();
+		expect(key).toMatch(/^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{5}$/);
+		expect(verifyKeySignature(key, TEST_SECRET)).toBe(true);
+	});
+
+	it('#2404 Phase 2.1: dev / test 環境では秘密鍵未設定でも legacy 発行可 (テスト互換維持)', () => {
+		process.env.AWS_LICENSE_SECRET = '';
+		process.env.NODE_ENV = 'test';
+		expect(() => generateLicenseKey()).not.toThrow();
 		const key = generateLicenseKey();
 		expect(key).toMatch(/^GQ-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
 	});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 保護者 (license 認証経路の安全性向上) + 運営 (HMAC 必須化計画の構造的前進)

**解決する課題**: HMAC 必須化計画 (#2398) Phase 2 のうち、scope 限定 **Sub-A (Phase 2.1 / 2.5)** を実装。production で新規 legacy (HMAC 未署名) license key 発行を物理的に止め、Phase 3 への構造的前進を確保する。

**期待される効果**: Phase 1 完了 (#2483 + #2486) の observability に加え、本 PR で新規 legacy 流入を完全停止。既存 legacy user への migration 案内 + email + MIGRATED status は scope 大規模のため Sub-B (別 Issue 起票) で後続。

## 関連 Issue

closes #2404 (Phase 2.1 + 2.5 部分のみ、Phase 2.2 / 2.3 / 2.4 は別 Issue「#2404 part-2 / Sub-B」として後続起票)

関連:
- 親 EPIC: #2398 (HMAC 必須化計画策定)
- 上流: #2403 Phase 1.1/1.2 (PR #2483 merged) / #2484 Phase 1.3-1.5 (PR #2486 merged)
- 下流 blocks: #2405 (Phase 3 — verify reject + legacy code 物理削除)
- 計画 docs: `docs/operations/license-hmac-migration-plan.md` §4 Phase 2

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | Phase 2.1: `generateLicenseKey()` 内 `if (secret)` 分岐の secret 未設定 fallback を production で物理 throw | `grep -A 5 "if (isProduction())" src/lib/server/services/license-key-service.ts` | ✅ commit `1d985503` で line 145-152 に追加。production + secret 未設定下で `throw new Error('[LICENSE] generateLicenseKey: AWS_LICENSE_SECRET is required in production. Legacy ...')` |
| AC2 | Phase 2.1: dev / test では従来通り legacy 発行可 (テスト互換性維持) | `npx vitest run tests/unit/services/license-key-service.test.ts` | ✅ 101/101 PASS。新規 3 件 (production throw / production + secret normal / dev/test legacy fallback) を含む |
| AC3 | Phase 2.5: `docs/design/license-key-lifecycle.md` §2.2 を「LEGACY 廃止予告」に更新 | `grep -n "廃止予告\|Phase 3" docs/design/license-key-lifecycle.md` + SSOT 突合 (`docs/operations/license-hmac-migration-plan.md` §3.2 / §4 / §6) | ✅ §2.2 表 + 「廃止スケジュール」3 phase 一覧を追加。**初版 (PR open 時)** で「Phase 1 (完了、2026-Q2)」と誤記しており、QM Re-Review Round 1 で Issue #2475 (Self-Review 矛盾) 9 件目として指摘を受けた。**Round 2 修正** で SSOT (`license-hmac-migration-plan.md` §3.2 = 完了期限 2026-Q3 末 / §4 = AC4 集計記録未達 / §6 = `legacy_count = ?` placeholder) に整合させ、「Phase 1 (実装済 / 集計待ち、完了予定: 2026-Q3 末 = 2026-09-30)」+ Phase 2 status を「Sub-A 実装済 / Sub-B 未着手」に更新済。SSOT 優先注記も §2.2 冒頭に追加 |
| AC4 | `npm run pre-ready` 全 step PASS | コマンド実行 | ⏳ 本 commit 後実行 |
| AC5 | AC 検証マップ全行埋め (ADR-0004) | 本表の各 cell 確認 | ✅ AC1〜3 すべて 検証手段 + エビデンス埋め (AC4 は pre-ready 実行検証) |

### 本 PR scope 外 (別 Issue 起票、Phase 2 完了は当該別 Issue close 時)

- Phase 2.2: ops 画面 `/ops/license` に legacy key 保有 user 一覧 + email 一括送信機能
- Phase 2.3: migration email template「再発行手続きのお願い」(grace period 30 日明示)
- Phase 2.4: `LICENSE_KEY_STATUS` enum に `'migrated'` 追加 + SIGNED key 再発行 logic + 旧 legacy key の `status='migrated'` 遷移

これらは scope 大規模 (8-16h、新規 ops UI + email service 拡張 + DB status 追加) のため別 Issue で分離。

## 変更タイプ

- [x] feat: 新機能 (production fail-closed 強化)
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`) — `license-key-service.ts` `generateLicenseKey()` に production throw 追加
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト
- [ ] 設定・CI
- [x] テストコード (`tests/unit/services/license-key-service.test.ts`) — 新規 3 件追加
- [x] ドキュメント (`docs/design/license-key-lifecycle.md` §2.2 廃止予告更新)

**影響を受ける画面・機能**: なし (production assertLicenseKeyConfigured で起動時 throw 済みのため secret 必ず設定済、本 PR の追加 throw は実運用ではノーオペ。dev/test 互換維持で UI 変化なし)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030） — 本 PR Ready 化前に実行
- [x] 追加・変更したテストの概要: `tests/unit/services/license-key-service.test.ts` に 3 件追加 (Phase 2.1 throw 動作 + dev/test 互換維持確認)。101/101 PASS
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (priority:medium)
- [x] **ADR-0006 assertion 弱体化禁止整合**: 本 PR は fail-closed 強化 (assertion 追加方向)、ADR-0006 禁止 5 項目に該当しない (むしろ精神整合)

## スクリーンショット / ビジュアルデモ

**該当なし**: 本 PR は server-side service 層 + docs のみで UI 表示変化なし。「描画変化なし」を明示 (#1744)。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A (UI 変更なし) | N/A (UI 変更なし) |
| **修正後** | N/A (UI 変更なし) | N/A (UI 変更なし) |

## コード品質セルフレビュー (#1481)

- [x] **SOLID (SRP)**: `generateLicenseKey()` の責務 (key 生成) は不変、production fail-closed 防御を defense in depth として追加。`assertLicenseKeyConfigured` (起動時 throw) と本 PR の generate 時 throw で 2 段防御
- [x] **DRY**: `isProduction()` 既存ヘルパを再利用、新規追加なし
- [x] **YAGNI**: Sub-B (ops UI + email + MIGRATED status) は別 Issue で分離、本 PR で先取り実装しない
- [x] **Security (Fail-closed)**: production で secret 未設定 → throw で起動拒否 (ADR-0006 OWASP A10 整合、Fail-closed 原則強化)
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: throw 経路は production の異常状態のみ、通常パフォーマンスに影響なし

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] N/A — 並行実装の影響範囲外 (本番 ↔ デモ / LP ↔ アプリ / 5 年齢モード / labels SSOT いずれにも波及しない)

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** (production では assertLicenseKeyConfigured 起動時 throw で secret 必須化済、本 PR の追加 throw は実運用ではノーオペ防御)

**レビュー依頼事項・QA**:

1. **defense in depth の妥当性**: `assertLicenseKeyConfigured()` (起動時) と `generateLicenseKey()` 内 throw (生成時) で 2 段防御。重複に見えるが、起動時 assertion を bypass する経路 (e.g. lazy import / unit test の差し込み) があった場合の最終防衛線として有効
2. **Sub-A / Sub-B 分割理由**: Sub-A (本 PR) は production fail-closed 強化で機能完成 (新規 legacy 流入を止める)。Sub-B (ops UI + email + MIGRATED status) は 別 scope (既存 user 救済 fluwo) で独立 PR にすべき。Phase 1 と同パターン
3. **error message の文言**: 開発者向け debugging 用、production endpoint には到達しない (起動時 throw で先に止まる)

## 配布済み env / secret (ADR-0006)

- [x] N/A — **新規 env / secret の追加なし**。既存 `AWS_LICENSE_SECRET` の production 必須化を fail-closed 強化のみ
- 既存配布証跡 (#806 / #911 で全 4 経路配布済み、本 PR で新規配布不要):
  - 配布済み: AWS_LICENSE_SECRET → GitHub Actions Secrets (deploy.yml, deploy-nuc.yml)
  - 配布済み: AWS_LICENSE_SECRET → AWS SSM Parameter Store /ganbari-quest/prod/aws_license_secret
  - 配布済み: AWS_LICENSE_SECRET → NUC `.env` (本機 + バックアップ機)
  - 配布済み: AWS_LICENSE_SECRET → `.env.example` 説明済み
- 本 PR の throw message `[LICENSE] generateLicenseKey: AWS_LICENSE_SECRET is required in production` は既存配布済 env への defense-in-depth assertion で、新規配布要件は発生しない。CI `check-new-required-env.mjs` が message pattern を検出する場合があるが、本セクションの配布証跡で対応

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (Sub-A 範囲、Sub-B は別 Issue 起票)
- [x] UI 変更時: 該当なし
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


