### PR TITLE
refactor: #2490 Sub-B1 LICENSE_KEY_STATUS.MIGRATED enum + 3 経路 reject (HMAC Phase 2 Sub-B 5 段階分割の最初)

### DIFF
--- a/docs/design/license-key-lifecycle.md
+++ b/docs/design/license-key-lifecycle.md
@@ -39,6 +39,7 @@ stateDiagram-v2
 | **active** | 発行済み・未消費 | `'active'` |
 | **consumed** | ユーザーが consume 済み | `'consumed'` |
 | **revoked** | Ops 手動 / 漏洩 / 期限切れで失効 | `'revoked'` |
+| **migrated** | **#2490 Phase 2 Sub-B1**: HMAC migration により再発行された旧 legacy key (validate/consume/revoke 全経路で reject、監査用に record 残置) | `'migrated'` |
 | **expired** (論理状態) | 90 日経過だがバッチ未実行 | `'active'` + `createdAt + 90d < now()` |
 
 ---
@@ -102,7 +103,7 @@ GQ-XXXX-XXXX-XXXX-YYYYY
 | `kind` | enum | △ | **#801**: `'purchase' \| 'gift' \| 'campaign'`。未設定（legacy）は `'purchase'` として扱う |
 | `issuedBy` | string | △ | **#801**: 発行 actor。`kind='gift' \| 'campaign'` では必須（監査要件）。`purchase` では `stripe:<sessionId>` |
 | `stripeSessionId` | string | — | Stripe Checkout Session ID (発行元) |
-| `status` | enum | ○ | `'active' \| 'consumed' \| 'revoked'` |
+| `status` | enum | ○ | `'active' \| 'consumed' \| 'revoked' \| 'migrated'` (#2490 Phase 2 Sub-B1 で MIGRATED 追加) |
 | `consumedBy` | string | — | 消費したユーザー ID (consume 後) |
 | `consumedAt` | string (ISO8601) | — | 消費日時 |
 | `revokedReason` | string | — | 失効理由 (`expired` / `leaked` / `ops-manual` / `refund`) |

--- a/src/lib/domain/constants/license-key-status.ts
+++ b/src/lib/domain/constants/license-key-status.ts
@@ -13,6 +13,13 @@ export const LICENSE_KEY_STATUS = {
 	CONSUMED: 'consumed',
 	/** revokeLicenseKey で失効された (返金 / 漏洩 / 期限切れ等) */
 	REVOKED: 'revoked',
+	/**
+	 * #2490 Phase 2 Sub-B1: HMAC migration により旧 legacy key が SIGNED 再発行され無効化された状態。
+	 * - validate / consume / revoke 全経路で reject される (validateLicenseKey は invalid を返す)
+	 * - 監査ログ用に元 record は残置 (status のみ migrated に遷移)
+	 * - 詳細: docs/operations/license-hmac-migration-plan.md §4 Phase 2 / docs/design/license-key-lifecycle.md §3.1
+	 */
+	MIGRATED: 'migrated',
 } as const;
 
 export type LicenseKeyStatus = (typeof LICENSE_KEY_STATUS)[keyof typeof LICENSE_KEY_STATUS];
@@ -21,6 +28,7 @@ export const ALL_LICENSE_KEY_STATUSES: readonly LicenseKeyStatus[] = [
 	LICENSE_KEY_STATUS.ACTIVE,
 	LICENSE_KEY_STATUS.CONSUMED,
 	LICENSE_KEY_STATUS.REVOKED,
+	LICENSE_KEY_STATUS.MIGRATED,
 ] as const;
 
 export function isLicenseKeyActive(status: LicenseKeyStatus): boolean {
@@ -33,4 +41,8 @@ export function isLicenseKeyConsumed(status: LicenseKeyStatus): boolean {
 
 export function isLicenseKeyRevoked(status: LicenseKeyStatus): boolean {
 	return status === LICENSE_KEY_STATUS.REVOKED;
+}
+
+export function isLicenseKeyMigrated(status: LicenseKeyStatus): boolean {
+	return status === LICENSE_KEY_STATUS.MIGRATED;
 }

--- a/src/lib/server/services/license-key-service.ts
+++ b/src/lib/server/services/license-key-service.ts
@@ -381,6 +381,15 @@ export async function validateLicenseKey(
 		return { valid: false, reason: 'このライセンスキーは無効化されています' };
 	}
 
+	// #2490 Phase 2 Sub-B1: migrated status は HMAC migration により再発行された旧 key
+	if (record.status === LICENSE_KEY_STATUS.MIGRATED) {
+		await recordFailure('migrated', { useFullKey: true });
+		return {
+			valid: false,
+			reason: 'このライセンスキーは再発行のため無効化されています',
+		};
+	}
+
 	// #797: 有効期限チェック。active でも expiresAt を過ぎていたら reject する。
 	// expiresAt が未設定の legacy レコードは期限チェックをスキップ（後方互換）。
 	if (isLicenseExpired(record)) {
@@ -471,6 +480,11 @@ export async function consumeLicenseKey(
 	if (record.status === LICENSE_KEY_STATUS.REVOKED) {
 		await recordFailure('revoked', { revokedReason: record.revokedReason ?? null });
 		return { ok: false, reason: 'このライセンスキーは無効化されています' };
+	}
+	// #2490 Phase 2 Sub-B1: migrated status は HMAC migration により再発行された旧 key
+	if (record.status === LICENSE_KEY_STATUS.MIGRATED) {
+		await recordFailure('migrated');
+		return { ok: false, reason: 'このライセンスキーは再発行のため無効化されています' };
 	}
 	if (record.status !== LICENSE_KEY_STATUS.ACTIVE) {
 		await recordFailure('not_active', { status: record.status });
@@ -576,6 +590,11 @@ export async function revokeLicenseKey(params: {
 	if (record.status === LICENSE_KEY_STATUS.CONSUMED) {
 		// consumed キーも監査目的で revoke 可能だが、現状ユースケースがないため拒否
 		return { ok: false, reason: 'このライセンスキーは既に使用されています' };
+	}
+
+	// #2490 Phase 2 Sub-B1: migrated key は既に再発行で無効化済、revoke 不要
+	if (record.status === LICENSE_KEY_STATUS.MIGRATED) {
+		return { ok: false, reason: 'このライセンスキーは再発行のため既に無効化されています' };
 	}
 
 	const revokedAt = new Date().toISOString();

--- a/tests/unit/domain/license-key-status-constants.test.ts
+++ b/tests/unit/domain/license-key-status-constants.test.ts
@@ -6,6 +6,7 @@ import {
 	ALL_LICENSE_KEY_STATUSES,
 	isLicenseKeyActive,
 	isLicenseKeyConsumed,
+	isLicenseKeyMigrated,
 	isLicenseKeyRevoked,
 	LICENSE_KEY_STATUS,
 } from '../../../src/lib/domain/constants/license-key-status';
@@ -15,10 +16,11 @@ describe('LICENSE_KEY_STATUS 定数', () => {
 		expect(LICENSE_KEY_STATUS.ACTIVE).toBe('active');
 		expect(LICENSE_KEY_STATUS.CONSUMED).toBe('consumed');
 		expect(LICENSE_KEY_STATUS.REVOKED).toBe('revoked');
+		expect(LICENSE_KEY_STATUS.MIGRATED).toBe('migrated'); // #2490 Phase 2 Sub-B1
 	});
 
 	it('ALL_LICENSE_KEY_STATUSES は全 status を含む (重複なし)', () => {
-		expect(ALL_LICENSE_KEY_STATUSES).toHaveLength(3);
+		expect(ALL_LICENSE_KEY_STATUSES).toHaveLength(4); // active / consumed / revoked / migrated (#2490)
 		expect(new Set(ALL_LICENSE_KEY_STATUSES).size).toBe(ALL_LICENSE_KEY_STATUSES.length);
 	});
 
@@ -34,18 +36,28 @@ describe('ヘルパ関数 (相互排他)', () => {
 		expect(isLicenseKeyActive(LICENSE_KEY_STATUS.ACTIVE)).toBe(true);
 		expect(isLicenseKeyActive(LICENSE_KEY_STATUS.CONSUMED)).toBe(false);
 		expect(isLicenseKeyActive(LICENSE_KEY_STATUS.REVOKED)).toBe(false);
+		expect(isLicenseKeyActive(LICENSE_KEY_STATUS.MIGRATED)).toBe(false);
 	});
 
 	it('CONSUMED のみ isLicenseKeyConsumed === true', () => {
 		expect(isLicenseKeyConsumed(LICENSE_KEY_STATUS.CONSUMED)).toBe(true);
 		expect(isLicenseKeyConsumed(LICENSE_KEY_STATUS.ACTIVE)).toBe(false);
 		expect(isLicenseKeyConsumed(LICENSE_KEY_STATUS.REVOKED)).toBe(false);
+		expect(isLicenseKeyConsumed(LICENSE_KEY_STATUS.MIGRATED)).toBe(false);
 	});
 
 	it('REVOKED のみ isLicenseKeyRevoked === true', () => {
 		expect(isLicenseKeyRevoked(LICENSE_KEY_STATUS.REVOKED)).toBe(true);
 		expect(isLicenseKeyRevoked(LICENSE_KEY_STATUS.ACTIVE)).toBe(false);
 		expect(isLicenseKeyRevoked(LICENSE_KEY_STATUS.CONSUMED)).toBe(false);
+		expect(isLicenseKeyRevoked(LICENSE_KEY_STATUS.MIGRATED)).toBe(false);
+	});
+
+	it('MIGRATED のみ isLicenseKeyMigrated === true (#2490 Phase 2 Sub-B1)', () => {
+		expect(isLicenseKeyMigrated(LICENSE_KEY_STATUS.MIGRATED)).toBe(true);
+		expect(isLicenseKeyMigrated(LICENSE_KEY_STATUS.ACTIVE)).toBe(false);
+		expect(isLicenseKeyMigrated(LICENSE_KEY_STATUS.CONSUMED)).toBe(false);
+		expect(isLicenseKeyMigrated(LICENSE_KEY_STATUS.REVOKED)).toBe(false);
 	});
 
 	it('各 status はちょうど 1 つのヘルパで true になる (partition)', () => {
@@ -54,6 +66,7 @@ describe('ヘルパ関数 (相互排他)', () => {
 				isLicenseKeyActive(s),
 				isLicenseKeyConsumed(s),
 				isLicenseKeyRevoked(s),
+				isLicenseKeyMigrated(s),
 			].filter(Boolean).length;
 			expect(trueCount).toBe(1);
 		}

--- a/tests/unit/services/license-key-service.test.ts
+++ b/tests/unit/services/license-key-service.test.ts
@@ -728,6 +728,24 @@ describe('validateLicenseKey', () => {
 		}
 	});
 
+	it('#2490 Phase 2 Sub-B1: ステータスが migrated のキーは invalid (再発行 reject) を返す', async () => {
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-ABCD-EFGH-JKLM',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'migrated',
+			createdAt: '2026-01-01T00:00:00Z',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await validateLicenseKey('GQ-ABCD-EFGH-JKLM');
+
+		expect(result.valid).toBe(false);
+		if (!result.valid) {
+			expect(result.reason).toBe('このライセンスキーは再発行のため無効化されています');
+		}
+	});
+
 	it('ステータスが active のキーは valid を返し、レコードを含む', async () => {
 		const record: LicenseRecord = {
 			licenseKey: 'GQ-ABCD-EFGH-JKLM',
@@ -1033,6 +1051,26 @@ describe('consumeLicenseKey', () => {
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
 			expect(result.reason).toBe('このライセンスキーは無効化されています');
+		}
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+		expect(mockUpdateLicenseKeyStatus).not.toHaveBeenCalled();
+	});
+
+	it('#2490 Phase 2 Sub-B1: ステータスが migrated のキーは {ok:false} を返し何も更新しない', async () => {
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-ABCD-EFGH-JKLM',
+			tenantId: 'tenant-issuer',
+			plan: 'monthly',
+			status: 'migrated',
+			createdAt: '2026-01-01T00:00:00Z',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await consumeLicenseKey('GQ-ABCD-EFGH-JKLM', 'tenant-issuer');
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toBe('このライセンスキーは再発行のため無効化されています');
 		}
 		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
 		expect(mockUpdateLicenseKeyStatus).not.toHaveBeenCalled();
@@ -1535,6 +1573,29 @@ describe('revokeLicenseKey (#797)', () => {
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
 			expect(result.reason).toContain('使用');
+		}
+		expect(mockRevokeLicenseKey).not.toHaveBeenCalled();
+	});
+
+	it('#2490 Phase 2 Sub-B1: migrated 状態の key は revoke 試行で {ok:false} を返す', async () => {
+		const record: LicenseRecord = {
+			licenseKey: 'GQ-MIGR-MIGR-MIGR',
+			tenantId: 'tenant-1',
+			plan: 'monthly',
+			status: 'migrated',
+			createdAt: '2026-01-01T00:00:00Z',
+		};
+		mockFindLicenseKey.mockResolvedValue(record);
+
+		const result = await revokeLicenseKey({
+			licenseKey: 'GQ-MIGR-MIGR-MIGR',
+			reason: 'ops-manual',
+			revokedBy: 'ops:admin-1',
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toBe('このライセンスキーは再発行のため既に無効化されています');
 		}
 		expect(mockRevokeLicenseKey).not.toHaveBeenCalled();
 	});

--- a/tests/unit/services/license-key-service.test.ts
+++ b/tests/unit/services/license-key-service.test.ts
@@ -1579,7 +1579,7 @@ describe('revokeLicenseKey (#797)', () => {
 
 	it('#2490 Phase 2 Sub-B1: migrated 状態の key は revoke 試行で {ok:false} を返す', async () => {
 		const record: LicenseRecord = {
-			licenseKey: 'GQ-MIGR-MIGR-MIGR',
+			licenseKey: 'GQ-2334-2334-2334',
 			tenantId: 'tenant-1',
 			plan: 'monthly',
 			status: 'migrated',
@@ -1588,7 +1588,7 @@ describe('revokeLicenseKey (#797)', () => {
 		mockFindLicenseKey.mockResolvedValue(record);
 
 		const result = await revokeLicenseKey({
-			licenseKey: 'GQ-MIGR-MIGR-MIGR',
+			licenseKey: 'GQ-2334-2334-2334',
 			reason: 'ops-manual',
 			revokedBy: 'ops:admin-1',
 		});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者 + 保護者 (license validate / consume / revoke のセキュリティ強化、Phase 2 Sub-B 着手の最小単位)

**解決する課題**: HMAC 必須化計画 (#2398) Phase 2 Sub-B の 5 段階分割実装の **Sub-B1 (enum + reject、最小独立 scope)**。`LICENSE_KEY_STATUS.MIGRATED` enum を追加し、validate / consume / revoke の 3 経路で reject 動作を確立する。

**期待される効果**: HMAC migration により再発行される旧 legacy key の reject 動作を構造的に提供。Sub-B4 / B5 の ops UI 機能と組み合わせて Phase 2 完了 → Phase 3 (#2405、verify reject + 物理削除) への構造的前進。

## 関連 Issue

closes #2490 (Sub-B1 部分のみ、Sub-B2 / B3 / B4 / B5 は別 PR で順次)

関連:
- 親 EPIC: #2398 (HMAC 必須化計画策定)
- 上流: #2404 (Phase 2 Sub-A) PR #2489 merged
- 下流 blocks: #2405 (Phase 3)
- 計画 docs: `docs/operations/license-hmac-migration-plan.md` §4 Phase 2

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `LICENSE_KEY_STATUS.MIGRATED: 'migrated'` enum 追加 + `ALL_LICENSE_KEY_STATUSES` + `isLicenseKeyMigrated()` helper | `grep -n "MIGRATED\|isLicenseKeyMigrated" src/lib/domain/constants/license-key-status.ts` | ✅ commit `9e18ef95` で `MIGRATED: 'migrated'` 追加、ALL 配列に追加、helper 追加 |
| AC2 | `validateLicenseKey()` で MIGRATED は invalid 返却 (「このライセンスキーは再発行のため無効化されています」) | `npx vitest run tests/unit/services/license-key-service.test.ts -t "migrated のキーは invalid"` | ✅ 新規 test 追加で 1/1 PASS |
| AC3 | `consumeLicenseKey()` で MIGRATED は `{ok:false}` 返却 (mockUpdate 系呼出なし) | 同 test ファイル `-t "migrated のキーは {ok:false}"` | ✅ 新規 test 追加で 1/1 PASS |
| AC4 | `revokeLicenseKey()` で MIGRATED は `{ok:false}` 返却 (revoke 不要、record 残置) | 同 test ファイル `-t "migrated 状態の key は revoke 試行で"` | ✅ 新規 test 追加で 1/1 PASS |
| AC5 | `docs/design/license-key-lifecycle.md` §1 状態表 + §3.1 status enum 値リストに `migrated` 追加 | `grep -n "migrated" docs/design/license-key-lifecycle.md` | ✅ §1 line 42 + §3.1 line 105 に追加 |
| AC6 | `npm run pre-ready` 全 step PASS | コマンド実行 | ⏳ 本 commit 後実行 |
| AC7 | AC 検証マップ全行埋め (ADR-0004) | 本表の各 cell 確認 | ✅ AC1〜5 すべて 検証手段 + エビデンス埋め (AC6 は pre-ready 実行検証) |

### 本 PR scope 外 (Sub-B2-B5 別 PR 起票)

- Sub-B2: `listLicenseKeysByStatus()` format filter 拡張 (DynamoDB 実装 + interface)
- Sub-B3: `sendLicenseKeyMigrationEmail()` email template + labels.ts SSOT
- Sub-B4: ops UI legacy section (`/ops/license/+page.svelte` + form action)
- Sub-B5: E2E (`tests/e2e/ops-license-migration.spec.ts`) + docs/operations §6 統合

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング (enum 拡張 + reject 経路追加)
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ — status カラム string type のため schema migration 不要
- [x] サービス層 (`$lib/server/services/`) — `license-key-service.ts` の 3 経路 reject 追加
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [x] ドメインモデル (`$lib/domain/`) — `LICENSE_KEY_STATUS` enum 拡張
- [ ] インフラ
- [ ] LP サイト
- [ ] 設定・CI
- [x] テストコード — 新規 3 件追加
- [x] ドキュメント (`docs/design/license-key-lifecycle.md` §1 + §3.1 同期)

**影響を受ける画面・機能**: なし (MIGRATED 状態の key は現状 DB に存在しないため、本 PR は将来動作の追加のみ。active/consumed/revoked は既存挙動不変)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030） — 本 PR Ready 化前に実行
- [x] 追加・変更したテストの概要: 3 件追加 (validate / consume / revoke が migrated を reject)。104/104 PASS
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A (status カラム string type、schema migration 不要、DB 実装変更なし)
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A
- [x] **ADR-0006 assertion 弱体化禁止整合**: 本 PR は reject 経路追加で assertion 強化方向、ADR-0006 整合

## スクリーンショット / ビジュアルデモ

**該当なし**: 本 PR は server-side service 層 + enum 追加 + docs のみで UI 表示変化なし。「描画変化なし」を明示 (#1744)。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A (UI 変更なし) | N/A (UI 変更なし) |
| **修正後** | N/A (UI 変更なし) | N/A (UI 変更なし) |

## コード品質セルフレビュー (#1481)

- [x] **SOLID (OCP)**: enum 拡張 + helper 追加で既存 active/consumed/revoked の挙動を変更せず新状態を導入。Open/Closed 整合
- [x] **DRY**: 3 経路の reject pattern (status check + return) は既存 active/consumed/revoked と同 pattern 踏襲、独自実装なし
- [x] **YAGNI**: Sub-B2-B5 は別 PR、本 PR は最小 scope (enum + reject + docs) のみ
- [x] **Security**: MIGRATED 状態の key を validate / consume / revoke で reject = HMAC migration の構造的整合性確保
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: enum 値追加のみ、判定 cost は既存 active/consumed/revoked と同等

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] N/A — 並行実装の影響範囲外 (本番 ↔ デモ / LP ↔ アプリ / 5 年齢モード / labels SSOT いずれにも波及しない)

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** (MIGRATED 状態の key は DB に未存在のため、本 PR は将来動作の追加のみ)

**レビュー依頼事項・QA**:

1. **5 段階分割の最初の PR**: Sub-B1 単独で機能完成 (enum + 3 経路 reject + docs)。後続 Sub-B2 (list filter) / Sub-B3 (email) / Sub-B4 (ops UI) / Sub-B5 (E2E) は独立 PR で順次。各 Sub の独立性は deep-research (Issue #2490 rewrite trigger) で検証済
2. **MIGRATED 文言の統一**: 3 経路すべて「再発行のため無効化されています」表現で統一 (validate「再発行のため無効化」/ consume「再発行のため無効化」/ revoke「再発行のため既に無効化」)。user-facing 説明として一貫
3. **DB schema 変更不要根拠**: `dynamodb/auth-repo.ts:798` で `status as LicenseRecord['status']` の string キャストパターン、SQLite も同様 string カラム。enum 値追加だけで DB schema は不変
4. **設計書同期範囲**: 本 PR は §1 状態表 + §3.1 status enum 表のみ更新。MIGRATE 遷移トリガ (Sub-B4 で実装) と migration email template (Sub-B3) は別 PR で docs §3 / §4 拡張

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (Sub-B1 範囲、Sub-B2-B5 は別 PR)
- [x] UI 変更時: 該当なし
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
