### PR TITLE
refactor: #2458-C-1 activity-pref-repo:countPinnedInCategory を child_activities JOIN に migrate

### DIFF
--- a/docs/design/data-model-resource-scope.md
+++ b/docs/design/data-model-resource-scope.md
@@ -115,6 +115,13 @@ child_activities
 - ✅ schema 不変 (本 PR は backend rewrite のみ、`schema.ts` / `create-tables.ts` / `interfaces/activity-repo.interface.ts` 変更なし。interface.ts は comment 更新のみ)
 - ⏳ physical drop (#2458-C): 3 backend (sqlite / demo / dynamodb) で旧 `activities` table / partition への write 0 化完遂 → main merge + 1 release 経過後に旧 `activities` table / `IActivityRepo` interface / 残 read 経路を schema / dynamodb partition から削除
 
+**実装状況 PR-C-1 (2026-05-26、#2458 Path B 第 1 弾)**:
+
+- ✅ `src/lib/server/db/sqlite/activity-pref-repo.ts` `countPinnedInCategory` を `child_activities` JOIN に migrate — 旧 JOIN は `childActivityPreferences.activityId` (FK target は PR-3 Phase 7b-2a で `child_activities.id` に切替済) を `activities.id` と突合する integrity bug 状態だった。本 PR で正しい FK target との JOIN に修正
+- ✅ caller `activity-pin-service.ts:50` は `categoryId` を渡すのみで internal JOIN target に依存しないため signature 不変 (透過 migrate)
+- ✅ regression test: `tests/unit/db/sqlite/activity-pref-repo.test.ts` (5 test) — AC-1 旧 activities table 空のまま child_activities 経由で集計成立 / AC-2 別 categoryId 除外 / AC-3 別 childId 除外 / AC-4 isPinned=0 除外 / AC-5 pin 0 件 fallback
+- ⏳ 18 caller migrate (PR-C-3) / seed.ts 変更 (PR-C-2) / DEMO_ACTIVITIES (PR-C-4) / 最終 drop (PR-C-5) は別 PR で順次実施
+
 ### 4.2 checklist (PR-5 Phase 1 完了 / Phase 2 UX 化進行中)
 
 **実装状況** (2026-05-25 PR-5 Phase 1):

--- a/src/lib/server/db/sqlite/activity-pref-repo.ts
+++ b/src/lib/server/db/sqlite/activity-pref-repo.ts
@@ -1,9 +1,27 @@
 // src/lib/server/db/sqlite/activity-pref-repo.ts
 // 子供×活動ピン留め設定リポジトリ（SQLite実装）
+//
+// #2458-C-1 (2026-05-26): countPinnedInCategory を旧 `activities` table JOIN から
+// `child_activities` JOIN に migrate。これにより本 file は旧 `activities` table を
+// 完全に参照しなくなり、#2458-C (旧 table physical drop) の制約条件を 1 件満たす。
+//
+// 設計:
+//   - `childActivityPreferences.activityId` FK target は PR-3 (Phase 7b-2a) で既に
+//     `childActivities.id` に切替済 (schema.ts L564-566)。旧 JOIN は活動 id を
+//     `activities.id` と突合する integrity bug 状態だった。本 PR で正しい FK target
+//     (`childActivities`) との JOIN に修正する。
+//   - signature 不変 (caller `activity-pin-service.ts:50` は categoryId を渡すのみで
+//     internal JOIN target に依存しない)。
+//
+// 関連:
+//   - #2458 EPIC (旧 activities table drop)
+//   - PR #2487 (#2458-A1 sqlite facade rewrite — write 0 化)
+//   - ADR-0055 §3.1 per-child primary data model
+//   - docs/design/data-model-resource-scope.md §4.1
 
 import { and, count, eq, gte, sql } from 'drizzle-orm';
 import { db } from '../client';
-import { activities, activityLogs, childActivityPreferences } from '../schema';
+import { activityLogs, childActivities, childActivityPreferences } from '../schema';
 import type { ActivityUsageCount, ChildActivityPreference } from '../types';
 
 export async function findPinnedByChild(
@@ -109,15 +127,19 @@ export async function countPinnedInCategory(
 	categoryId: number,
 	_tenantId: string,
 ): Promise<number> {
+	// #2458-C-1: childActivityPreferences.activityId は child_activities.id を参照する
+	// (schema.ts L564-566、PR-3 Phase 7b-2a で FK target 切替済)。旧 JOIN は
+	// `activities.id` 突合だったが、現状の FK semantics と integrity bug 状態を解消し、
+	// 正しく child_activities と JOIN する。
 	const result = db
 		.select({ count: count() })
 		.from(childActivityPreferences)
-		.innerJoin(activities, eq(childActivityPreferences.activityId, activities.id))
+		.innerJoin(childActivities, eq(childActivityPreferences.activityId, childActivities.id))
 		.where(
 			and(
 				eq(childActivityPreferences.childId, childId),
 				eq(childActivityPreferences.isPinned, 1),
-				eq(activities.categoryId, categoryId),
+				eq(childActivities.categoryId, categoryId),
 			),
 		)
 		.get();

--- a/tests/unit/db/sqlite/activity-pref-repo.test.ts
+++ b/tests/unit/db/sqlite/activity-pref-repo.test.ts
@@ -1,0 +1,231 @@
+// tests/unit/db/sqlite/activity-pref-repo.test.ts
+//
+// #2458-C-1 regression test: activity-pref-repo.countPinnedInCategory が
+// `child_activities` JOIN に migrate されたことを保証する。
+//
+// 旧実装は legacy `activities` table と JOIN していたが、`childActivityPreferences.activityId`
+// の FK target は PR-3 で `childActivities.id` に切替済 (schema.ts L564-566)。本 test は
+// 1. 旧 `activities` table が空でも categoryId 集計が成立する (= 旧 table への JOIN なし)
+// 2. `child_activities` の categoryId が集計対象になる (正しい JOIN target)
+// 3. 別 childId / 別 categoryId / isPinned=0 は除外される
+// を assert する。これにより #2458-C (旧 table physical drop) ready 状態に 1 段近づく。
+//
+// 参照:
+//   - PR #2458-C-1 / Issue #2458
+//   - PR #2487 (#2458-A1 sqlite facade rewrite — write 0 化)
+//   - ADR-0055 §3.1 per-child primary data model
+//   - docs/design/data-model-resource-scope.md §4.1
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { closeDb, createTestDb, resetDb, type TestSqlite } from '../../helpers/test-db';
+
+// vitest 全体で共有される client.db を test DB に差し替える
+const dbHolder: { sqlite: TestSqlite | null; db: ReturnType<typeof createTestDb>['db'] | null } = {
+	sqlite: null,
+	db: null,
+};
+
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		if (!dbHolder.db) throw new Error('test db not initialized');
+		return dbHolder.db;
+	},
+}));
+
+const TENANT = 't-2458-c1';
+
+// import after mock
+import {
+	childActivities as childActivitiesTable,
+	children as childrenTable,
+	childActivityPreferences as prefsTable,
+} from '$lib/server/db/schema';
+import { countPinnedInCategory } from '$lib/server/db/sqlite/activity-pref-repo';
+
+function countLegacyActivitiesTable(sqlite: TestSqlite): number {
+	const row = sqlite.prepare('SELECT COUNT(*) as cnt FROM activities').get() as { cnt: number };
+	return row.cnt;
+}
+
+describe('#2458-C-1: countPinnedInCategory は child_activities JOIN 経由', () => {
+	let testChildId: number;
+	let otherChildId: number;
+
+	beforeEach(() => {
+		const { sqlite, db } = createTestDb();
+		dbHolder.sqlite = sqlite;
+		dbHolder.db = db;
+
+		// child 2 件 seed
+		const child1 = db
+			.insert(childrenTable)
+			.values({
+				nickname: 'けんた',
+				age: 8,
+				theme: 'default',
+				uiMode: 'elementary',
+				userId: TENANT,
+			})
+			.returning()
+			.get();
+		testChildId = child1.id;
+
+		const child2 = db
+			.insert(childrenTable)
+			.values({
+				nickname: 'さくら',
+				age: 6,
+				theme: 'default',
+				uiMode: 'elementary',
+				userId: TENANT,
+			})
+			.returning()
+			.get();
+		otherChildId = child2.id;
+	});
+
+	afterEach(() => {
+		if (dbHolder.sqlite) {
+			resetDb(dbHolder.sqlite);
+			closeDb(dbHolder.sqlite);
+		}
+		dbHolder.sqlite = null;
+		dbHolder.db = null;
+	});
+
+	it('AC-1: 旧 activities table が空でも child_activities の categoryId 集計が成立する', async () => {
+		if (!dbHolder.sqlite || !dbHolder.db) throw new Error('db not initialized');
+		const db = dbHolder.db;
+
+		// 旧 activities table は空のまま (PR-A1 で write 0 化済)
+		expect(countLegacyActivitiesTable(dbHolder.sqlite)).toBe(0);
+
+		// child_activities に categoryId=1 を 3 件 seed
+		const inserted = db
+			.insert(childActivitiesTable)
+			.values([
+				{ childId: testChildId, name: '体操', categoryId: 1, icon: '🤸', basePoints: 5 },
+				{ childId: testChildId, name: 'マラソン', categoryId: 1, icon: '🏃', basePoints: 5 },
+				{ childId: testChildId, name: '縄跳び', categoryId: 1, icon: '🪢', basePoints: 5 },
+			])
+			.returning()
+			.all();
+
+		// 3 件全てを pin
+		for (const [idx, act] of inserted.entries()) {
+			db.insert(prefsTable)
+				.values({
+					childId: testChildId,
+					activityId: act.id,
+					isPinned: 1,
+					pinOrder: idx + 1,
+				})
+				.run();
+		}
+
+		const result = await countPinnedInCategory(testChildId, 1, TENANT);
+		expect(result).toBe(3);
+
+		// 旧 activities table への write 一切なし (1 段 ready)
+		expect(countLegacyActivitiesTable(dbHolder.sqlite)).toBe(0);
+	});
+
+	it('AC-2: 異なる categoryId は集計対象外', async () => {
+		if (!dbHolder.sqlite || !dbHolder.db) throw new Error('db not initialized');
+		const db = dbHolder.db;
+
+		const inserted = db
+			.insert(childActivitiesTable)
+			.values([
+				{ childId: testChildId, name: '体操', categoryId: 1, icon: '🤸', basePoints: 5 },
+				{ childId: testChildId, name: '読書', categoryId: 2, icon: '📖', basePoints: 5 },
+				{ childId: testChildId, name: '勉強', categoryId: 2, icon: '📚', basePoints: 5 },
+			])
+			.returning()
+			.all();
+
+		for (const [idx, act] of inserted.entries()) {
+			db.insert(prefsTable)
+				.values({
+					childId: testChildId,
+					activityId: act.id,
+					isPinned: 1,
+					pinOrder: idx + 1,
+				})
+				.run();
+		}
+
+		// categoryId=1 は 1 件のみ (体操)
+		expect(await countPinnedInCategory(testChildId, 1, TENANT)).toBe(1);
+		// categoryId=2 は 2 件 (読書 + 勉強)
+		expect(await countPinnedInCategory(testChildId, 2, TENANT)).toBe(2);
+		// 存在しない categoryId は 0
+		expect(await countPinnedInCategory(testChildId, 99, TENANT)).toBe(0);
+	});
+
+	it('AC-3: 別 childId の pin は集計対象外', async () => {
+		if (!dbHolder.sqlite || !dbHolder.db) throw new Error('db not initialized');
+		const db = dbHolder.db;
+
+		const myActivity = db
+			.insert(childActivitiesTable)
+			.values({ childId: testChildId, name: '体操', categoryId: 1, icon: '🤸', basePoints: 5 })
+			.returning()
+			.get();
+		const otherActivity = db
+			.insert(childActivitiesTable)
+			.values({ childId: otherChildId, name: 'マラソン', categoryId: 1, icon: '🏃', basePoints: 5 })
+			.returning()
+			.get();
+
+		db.insert(prefsTable)
+			.values({ childId: testChildId, activityId: myActivity.id, isPinned: 1, pinOrder: 1 })
+			.run();
+		db.insert(prefsTable)
+			.values({ childId: otherChildId, activityId: otherActivity.id, isPinned: 1, pinOrder: 1 })
+			.run();
+
+		// 自分の child の pin のみ (1 件)
+		expect(await countPinnedInCategory(testChildId, 1, TENANT)).toBe(1);
+		expect(await countPinnedInCategory(otherChildId, 1, TENANT)).toBe(1);
+	});
+
+	it('AC-4: isPinned=0 は集計対象外', async () => {
+		if (!dbHolder.sqlite || !dbHolder.db) throw new Error('db not initialized');
+		const db = dbHolder.db;
+
+		const acts = db
+			.insert(childActivitiesTable)
+			.values([
+				{ childId: testChildId, name: '体操', categoryId: 1, icon: '🤸', basePoints: 5 },
+				{ childId: testChildId, name: 'マラソン', categoryId: 1, icon: '🏃', basePoints: 5 },
+			])
+			.returning()
+			.all();
+
+		// 1 件目は pin、2 件目は unpin
+		const [a1, a2] = acts;
+		if (!a1 || !a2) throw new Error('seed failed');
+
+		db.insert(prefsTable)
+			.values({ childId: testChildId, activityId: a1.id, isPinned: 1, pinOrder: 1 })
+			.run();
+		db.insert(prefsTable)
+			.values({ childId: testChildId, activityId: a2.id, isPinned: 0, pinOrder: null })
+			.run();
+
+		expect(await countPinnedInCategory(testChildId, 1, TENANT)).toBe(1);
+	});
+
+	it('AC-5: pin 0 件 のとき 0 を返す (entries 不在ケース)', async () => {
+		if (!dbHolder.sqlite || !dbHolder.db) throw new Error('db not initialized');
+		const db = dbHolder.db;
+
+		db.insert(childActivitiesTable)
+			.values({ childId: testChildId, name: '体操', categoryId: 1, icon: '🤸', basePoints: 5 })
+			.run();
+		// pin 未作成
+
+		expect(await countPinnedInCategory(testChildId, 1, TENANT)).toBe(0);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

User 採択 Path B (5 activities sub-PR) 第 1 弾。`activity-pref-repo.ts:countPinnedInCategory` が legacy `activities` table を JOIN している integrity bug を解消し、**旧 `activities` table 物理 drop ready 状態に 1 段近づく**。

`childActivityPreferences.activityId` FK target は PR-3 (Phase 7b-2a) で `child_activities.id` に切替済 (schema.ts L564-566) だったが、本関数の JOIN は依然として旧 `activities.id` を突合していた。`child_activities` ⇔ `activities` で id 空間が乖離する state では `categoryId` 集計が壊れる integrity bug。本 PR で正しい FK target との JOIN に修正。

User 「やりきり = 申し送り禁止、scope 分割は OK」原則整合 (#2458 Path B 分割計画)。

## 関連 Issue

Related: #2458

(上流 merged: PR #2487 (#2458-A1 sqlite facade rewrite — write 0 化))

## AC 検証マップ (ADR-0004)

| # | AC | 検証方法 | 結果 |
|---|---|---|---|
| 1 | countPinnedInCategory が `child_activities` JOIN 経由で集計する | `tests/unit/db/sqlite/activity-pref-repo.test.ts` AC-1 (旧 `activities` 空のまま `child_activities` 経由で 3 件集計成立) | ✅ pass |
| 2 | 旧 `activities` table への JOIN が削除されている | grep + diff: import 行 `activities` 撤去 / JOIN 句 `childActivities` に置換 | ✅ 確認済 |
| 3 | caller `activity-pin-service.ts:50` signature 不変 | `tests/unit/services/activity-pin-service.test.ts` 11 件 pass | ✅ pass |
| 4 | 別 categoryId / 別 childId / isPinned=0 が集計対象外 | `activity-pref-repo.test.ts` AC-2, AC-3, AC-4 | ✅ pass |
| 5 | pin 0 件 fallback で 0 を返す | AC-5 | ✅ pass |
| 6 | 設計書 `data-model-resource-scope.md` §4.1 同期 | PR-C-1 実装状況追記 | ✅ 同期済 |

## 変更タイプ

- [x] refactor (機能変更なし、internal JOIN target rewrite + integrity bug 解消)
- [x] test 追加
- [x] docs (設計書同期)

## 影響範囲・変更コンポーネント

| ファイル | 変更内容 |
|---|---|
| `src/lib/server/db/sqlite/activity-pref-repo.ts` | `countPinnedInCategory` の JOIN target を `activities` → `child_activities` に切替 (5 行差分) |
| `tests/unit/db/sqlite/activity-pref-repo.test.ts` | 新規 (5 test = AC-1..AC-5) |
| `docs/design/data-model-resource-scope.md` | §4.1 に PR-C-1 実装状況追記 (現状の正解のみ) |

**caller 影響**: `activity-pin-service.ts:50` (`countPinnedInCategory(childId, activity.categoryId, tenantId)`) は signature 不変で透過。internal JOIN target に依存しないため修正不要。

**他 backend 影響**: 本 PR は `sqlite` 実装のみ。`dynamodb/activity-pref-repo.ts` は別構造 (partition key + scan)、`demo/activity-pref-repo.ts` は in-memory map 操作で JOIN 概念なし、いずれも本変更の影響を受けない。

## テスト & 安全装置セルフチェック

| 項目 | 結果 |
|---|---|
| `npx vitest run tests/unit/db/sqlite/activity-pref-repo.test.ts` | ✅ 5 test pass (Duration 2.64s) |
| `npx vitest run tests/unit/services/activity-pin-service.test.ts` | ✅ 11 test pass (caller 透過性確認) |
| `npx vitest run tests/unit/services/activity-legacy-table-write-zero.test.ts` | ✅ 8 test pass (PR-A1 維持) |
| `npx biome check src/lib/server/db/sqlite/activity-pref-repo.ts tests/unit/db/sqlite/activity-pref-repo.test.ts` | ✅ PASS |
| `npx svelte-check` (本 PR file) | ✅ 本 PR file には error なし |
| カバレッジ閾値 (ADR-0005) | ✅ 引下げなし (test 追加のみ) |
| assertion 弱体化 (ADR-0006) | ✅ なし (新規 test のみ) |

**svelte-check note**: 全体実行で `infra/` 関連 error が出るが、worktree 環境で `infra/node_modules` 未 install による既知問題 (`tests/CLAUDE.md` §テスト環境セットアップ #2476)。本 PR 変更 file の svelte-check は clean。

## スクリーンショット / ビジュアルデモ

UI 変更なし (DB 層 internal JOIN rewrite + test + docs)。SS 対象外。

## コード品質セルフレビュー (#1481)

| 観点 | self check |
|---|---|
| 重複コード | ✅ なし。`countPinnedInCategory` は 1 関数の internal JOIN 修正のみ |
| 命名 | ✅ `childActivities` は schema.ts 命名と整合 |
| 関数規模 | ✅ 関数長 16 行 (変更前後とも) |
| early return | ✅ `result?.count ?? 0` で null safe |
| エラーハンドリング | ✅ Drizzle ORM のクエリエラーは上位伝播 (caller side で catch) |
| comment 設計理由 | ✅ JOIN target 切替の理由を 4 行 inline comment + file 冒頭 SSOT block で説明 |
| signature 不変 | ✅ caller (`activity-pin-service.ts`) 修正ゼロ |

## 横展開・影響波及チェック

並行実装 (`docs/design/parallel-implementations.md`) と #2458 Path B 分割計画照合:

| 領域 | 本 PR の対応 | 後続 PR |
|---|---|---|
| `sqlite/activity-pref-repo.ts` countPinnedInCategory | ✅ 本 PR で `child_activities` JOIN に切替 | — |
| `dynamodb/activity-pref-repo.ts` | scope 外 (DynamoDB は production 未使用 + scan ベースで JOIN 概念なし) | — |
| `demo/activity-pref-repo.ts` | scope 外 (in-memory map で JOIN 概念なし、demo fixture 整合は本 PR 対象外) | PR-C-4 (DEMO_ACTIVITIES) |
| 18 caller migrate | scope 外 (caller は `findActivityById` 経由で透過、本 PR の signature 不変保証で対応) | PR-C-3 |
| seed.ts 旧 activities 削除 | scope 外 | PR-C-2 |
| 最終 drop (schema.ts `activities` table) | scope 外 (本 PR で sqlite/activity-pref-repo の旧 table 参照 0 化を達成、PR-C-5 で table 自体を drop) | PR-C-5 / #2458 EPIC |

## レビュー依頼事項・破壊的変更

- 破壊的変更: なし (signature 不変、caller 修正ゼロ)
- レビュー focus:
  1. JOIN target 切替の semantics 等価性 (`childActivityPreferences.activityId` FK target が `child_activities.id` であることを schema.ts L564-566 で確認済)
  2. test 5 件の AC カバレッジ (旧 `activities` table 空状態での集計成立 / 別 categoryId/childId/isPinned 除外 / empty fallback)

## 配布済み env / secret (ADR-0006)

新規 env / secret 追加なし。証跡欠落リスクなし。

## Ready for Review チェックリスト

- [x] PR 必須 13 セクション充足
- [x] AC 検証マップ全項目 ✅
- [x] 全テスト pass (24 関連 test)
- [x] biome / svelte-check clean (本 PR file 対象)
- [x] 設計書 (`data-model-resource-scope.md` §4.1) 同期
- [x] caller (`activity-pin-service.ts`) signature 不変確認
- [x] worktree 内完結 / remote SHA verify 済 (2078b311ca55ca360c4cd284e956445244c133dd)
- [x] Self-Review HONESTY: 17 観点機械検証完遂、APPROVE

## QM レビュー結果

(QM team が記入)
