### PR TITLE
refactor: #2490 Sub-B2 listLicenseKeysByStatus format filter 拡張 (HMAC Phase 2 Sub-B 5 段階分割 #2)

### DIFF
--- a/src/lib/server/db/demo/auth-repo.ts
+++ b/src/lib/server/db/demo/auth-repo.ts
@@ -279,8 +279,7 @@ export async function listLicenseKeysByTenant(
 
 export async function listLicenseKeysByStatus(
 	_status: LicenseKeyStatus,
-	_limit?: number,
-	_cursor?: string,
+	_options?: { format?: 'legacy' | 'signed'; limit?: number; cursor?: string },
 ): Promise<LicenseKeyPage> {
 	return { items: [], cursor: null };
 }

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -840,26 +840,37 @@ export const listLicenseKeysByTenant: IAuthRepo['listLicenseKeysByTenant'] = asy
 
 export const listLicenseKeysByStatus: IAuthRepo['listLicenseKeysByStatus'] = async (
 	status,
-	limit = DEFAULT_PAGE_SIZE,
-	cursor,
+	options,
 ) => {
 	// DynamoDB の LICENSE# パーティションは status でインデックスされていないため、
 	// Scan + FilterExpression を使用。Pre-PMF 段階ではキー数が限定的。
 	// 本番スケール時は GSI 追加を検討（ADR-0034 準拠で過剰設計を避ける）。
+	const limit = options?.limit ?? DEFAULT_PAGE_SIZE;
+	const cursor = options?.cursor;
+	const format = options?.format;
 	const items: LicenseRecord[] = [];
 	let lastKey = cursor ? decodeCursor(cursor) : undefined;
 	let scannedCount = 0;
+
+	// #2490 Sub-B2: format filter 追加 (countLicenseKeys と同 size(licenseKey) パターン)
+	const filterParts = ['begins_with(PK, :prefix)', '#status = :status'];
+	const valuesExtra: Record<string, string | number> = {};
+	if (format) {
+		filterParts.push('size(licenseKey) = :formatLen');
+		valuesExtra[':formatLen'] = getLicenseFormatLength(format);
+	}
 
 	// Scan は FilterExpression 適用前の Limit なので、十分な件数が集まるまでループする
 	while (items.length < limit) {
 		const result = await doc().send(
 			new ScanCommand({
 				TableName: TABLE_NAME,
-				FilterExpression: 'begins_with(PK, :prefix) AND #status = :status',
+				FilterExpression: filterParts.join(' AND '),
 				ExpressionAttributeNames: { '#status': 'status' },
 				ExpressionAttributeValues: {
 					':prefix': 'LICENSE#',
 					':status': status,
+					...valuesExtra,
 				},
 				ExclusiveStartKey: lastKey,
 				// 多めにスキャンしてフィルタで絞る

--- a/src/lib/server/db/interfaces/auth-repo.interface.ts
+++ b/src/lib/server/db/interfaces/auth-repo.interface.ts
@@ -131,11 +131,16 @@ export interface IAuthRepo {
 		cursor?: string,
 	): Promise<LicenseKeyPage>;
 
-	/** ステータス別のライセンスキー一覧（ページネーション対応） */
+	/**
+	 * ステータス別のライセンスキー一覧（ページネーション対応）。
+	 *
+	 * #2490 Phase 2 Sub-B2: format filter 拡張 (`countLicenseKeys` と同パターン、OCP 整合)。
+	 * - `options.format: 'legacy' | 'signed'` で key 形式絞込み (`size(licenseKey)` で判定、schema 変更不要)
+	 * - migration plan §4 line 90 整合: SQLite no-op (空配列返却、SaaS DynamoDB のみ実集計)
+	 */
 	listLicenseKeysByStatus(
 		status: LicenseKeyStatus,
-		limit?: number,
-		cursor?: string,
+		options?: { format?: 'legacy' | 'signed'; limit?: number; cursor?: string },
 	): Promise<LicenseKeyPage>;
 
 	/** N 日以内に有効期限が切れるアクティブなキー一覧 */

--- a/tests/unit/services/license-key-search.test.ts
+++ b/tests/unit/services/license-key-search.test.ts
@@ -235,6 +235,38 @@ describe('DynamoDB auth-repo — license key search (#816)', () => {
 			expect(result.items).toHaveLength(1);
 			expect(result.items[0]?.revokedReason).toBe('ops-manual');
 		});
+
+		it('#2490 Sub-B2: format: "legacy" filter で size(licenseKey)=17 FilterExpression を含む', async () => {
+			mockSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			await mod.listLicenseKeysByStatus(LICENSE_KEY_STATUS.ACTIVE, { format: 'legacy' });
+
+			const command = mockSend.mock.calls[0]?.[0];
+			expect(command?.input?.FilterExpression).toContain('size(licenseKey) = :formatLen');
+			expect(command?.input?.ExpressionAttributeValues?.[':formatLen']).toBe(17);
+		});
+
+		it('#2490 Sub-B2: format: "signed" filter で size(licenseKey)=23 を含む', async () => {
+			mockSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			await mod.listLicenseKeysByStatus(LICENSE_KEY_STATUS.ACTIVE, { format: 'signed' });
+
+			const command = mockSend.mock.calls[0]?.[0];
+			expect(command?.input?.ExpressionAttributeValues?.[':formatLen']).toBe(23);
+		});
+
+		it('#2490 Sub-B2: format 未指定なら size filter は付与されない (backward-compat)', async () => {
+			mockSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+
+			const mod = await import('$lib/server/db/dynamodb/auth-repo');
+			await mod.listLicenseKeysByStatus(LICENSE_KEY_STATUS.ACTIVE);
+
+			const command = mockSend.mock.calls[0]?.[0];
+			expect(command?.input?.FilterExpression).not.toContain('size(licenseKey)');
+			expect(command?.input?.ExpressionAttributeValues?.[':formatLen']).toBeUndefined();
+		});
 	});
 
 	describe('listExpiringSoon', () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者 (Sub-B4 で ops UI が legacy LicenseRecord 一覧を取得する API 基盤)

**解決する課題**: HMAC 必須化計画 (#2398) Phase 2 Sub-B の 5 段階分割実装 **Sub-B2 (list filter 拡張、独立)**。`listLicenseKeysByStatus()` に `format?: 'legacy' | 'signed'` filter を追加し、後続 Sub-B4 で ops UI が legacy 形式の LicenseRecord 一覧を絞込みできる API 基盤を提供する。

**期待される効果**: Sub-B4 (ops UI) で `listLicenseKeysByStatus('active', { format: 'legacy' })` で legacy key 保有 tenant 一覧を取得可能化。Sub-B1 (PR #2496 merged) の `MIGRATED` enum と組み合わせて Phase 2 完了の構造的前進。

## 関連 Issue

closes #2490 (Sub-B2 部分のみ、Sub-B3 / B4 / B5 は別 PR で順次)

関連:
- 親 EPIC: #2398 (HMAC 必須化計画策定)
- 上流: #2496 Sub-B1 (enum + reject、merged) / #2486 Phase 1.3 (countLicenseKeys format filter、merged)
- 下流 blocks: Sub-B4 (ops UI、本 PR + Sub-B3 完了で着手可)
- 計画 docs: `docs/operations/license-hmac-migration-plan.md` §4 Phase 2

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `auth-repo.interface.ts` `listLicenseKeysByStatus` を options 引数化 (`{ format?, limit?, cursor? }`) | `grep -A 3 "listLicenseKeysByStatus" src/lib/server/db/interfaces/auth-repo.interface.ts` | ✅ interface line 141-144 で options 形に変更 + JSDoc に Sub-B2 由来明記 |
| AC2 | DynamoDB 実装 `size(licenseKey) = :formatLen` FilterExpression 追加 | `grep -A 5 "format" src/lib/server/db/dynamodb/auth-repo.ts:841-` | ✅ `getLicenseFormatLength(format)` (既存 PR #2486 helper) 再利用 + filterParts に動的追加 |
| AC3 | SQLite / demo backend signature 透過対応 | `grep -A 3 "listLicenseKeysByStatus" src/lib/server/db/sqlite/auth-repo.ts src/lib/server/db/demo/auth-repo.ts` | ✅ SQLite は既存 no-op (`() => ({ items: [], cursor: null })`) で透過、demo は options 引数に signature 同期 |
| AC4 | unit test 3 件 (format: legacy / signed / unfiltered backward-compat) | `npx vitest run tests/unit/services/license-key-search.test.ts` | ✅ 21/21 PASS (既存 18 + 新規 3) |
| AC5 | `npm run pre-ready` 全 step PASS | コマンド実行 | ⏳ 本 commit 後実行 |
| AC6 | AC 検証マップ全行埋め (ADR-0004) | 本表の各 cell 確認 | ✅ AC1〜4 すべて 検証手段 + エビデンス埋め (AC5 は pre-ready 実行検証) |

### 本 PR scope 外 (Sub-B3-B5 別 PR 起票)

- Sub-B3: `sendLicenseKeyMigrationEmail()` email template + labels.ts SSOT
- Sub-B4: ops UI legacy section (本 PR + Sub-B3 完了後着手)
- Sub-B5: E2E + docs/operations 同期

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング (interface 拡張 + DynamoDB filter 追加)
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — interface + 3 backend 実装 (DynamoDB 機能拡張 / SQLite + demo は signature 同期のみ)
- [ ] サービス層
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト
- [ ] 設定・CI
- [x] テストコード — 新規 3 件追加 (`tests/unit/services/license-key-search.test.ts`)
- [ ] ドキュメント

**影響を受ける画面・機能**: なし (filter 未指定の既存呼出は behavior 不変、新規 format filter のみ追加)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030） — 本 PR Ready 化前に実行
- [x] 追加・変更したテストの概要: 3 件追加 (format: legacy / signed / 未指定の backward-compat)。21/21 PASS
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: 既存 `getLicenseFormatLength()` (PR #2486 で導入) helper 再利用、新規 stub なし。SQLite + demo は既存 no-op で透過対応、両 backend 完成
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A
- [x] **ADR-0006 assertion 弱体化禁止整合**: 本 PR は filter 拡張 (新機能)、ADR-0006 禁止 5 項目に該当しない

## スクリーンショット / ビジュアルデモ

**該当なし**: 本 PR は DB layer 拡張のみで UI 表示変化なし。「描画変化なし」を明示 (#1744)。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A (UI 変更なし) | N/A (UI 変更なし) |
| **修正後** | N/A (UI 変更なし) | N/A (UI 変更なし) |

## コード品質セルフレビュー (#1481)

- [x] **SOLID (OCP)**: 既存 listLicenseKeysByStatus に options optional 引数追加で OCP 整合。signature 変更だが旧 caller (filter 未指定) は backward-compat 維持
- [x] **DRY**: `getLicenseFormatLength()` (PR #2486 で導入) を再利用、size filter 組立 logic を独自実装しない
- [x] **YAGNI**: format 値は `'legacy' | 'signed'` の 2 値のみ、将来 format 追加は extension point として残置
- [x] **Security**: filter は ops 限定 endpoint (Sub-B4 で gate) で使用、認証境界は既存 `/ops/+layout.server.ts` の `isOpsMember` で適用
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: 既存 Scan + FilterExpression パターンに 1 行追加、scan 全体オーバーヘッドは無視可能 (status filter 同パターン)

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** (interface signature 拡張は optional options なので旧 caller 互換)
- 既存 caller 0 件確認済 (`grep -rn listLicenseKeysByStatus src/routes src/lib/server/services` で 0 hit)

**レビュー依頼事項・QA**:

1. **signature 変更の互換性**: `(status, limit?, cursor?)` → `(status, options?)` への変更。Pre-PMF で既存 caller 0 件のため安全だが、将来 caller 追加時は options 形に準拠する必要あり
2. **`size(licenseKey)` 判定の確定性**: AWS DynamoDB `size()` operator は String 属性に対し UTF-8 byte 長を返す。本 license key は ASCII のみ (KEY_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789') で文字数一致が確定
3. **5 段階分割の 2 番目 PR**: Sub-B1 (#2496 merged) + 本 Sub-B2 で API 基盤完成。Sub-B3 (email) と Sub-B4 (ops UI) はこの API を呼ぶ

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (Sub-B2 範囲、Sub-B3-B5 は別 PR)
- [x] UI 変更時: 該当なし
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
