### PR TITLE
fix: NUC startup failure — checklist_templates lazy migration (Closes #2508) [HOTFIX]

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -46,6 +46,51 @@ src/lib/server/db/
 - **WAL モード**: 読み書き並行性を向上
 - **バックアップ**: 日次で git push（DBファイルのコピー）
 
+### Schema 変更時の lazy migration 必須 SSOT (#2508 / 3 dimension SSOT)
+
+**背景**: PR #2480 (#2362 PR-5 Phase 1) で `checklist_templates` を per-child instance
+(`child_id NOT NULL`) から family master (`tenant_id NOT NULL`) に flip した際、
+`schema.ts` / `create-tables.ts` は更新したが、既存 production DB を新 schema に上げる
+**shadow-table recreation migration** が `client.ts` startup から呼ばれていなかったため、
+NUC startup が `no such column: tenant_id` (SQL_CREATE_TABLES 内の `CREATE INDEX`) で完全に
+block された (2026-05-27 NUC down)。
+
+**SSOT**: schema 変更 PR では **3 file の同期更新を必須** とする。
+
+| # | ファイル | 役割 |
+|---|---|---|
+| 1 | `src/lib/server/db/schema.ts` | drizzle table 定義 (TypeScript 型 SSOT) |
+| 2 | `src/lib/server/db/create-tables.ts` | `CREATE TABLE/INDEX IF NOT EXISTS` 群 (新規 DB / dev / CI 用) |
+| 3 | **`src/lib/server/db/migration/lazy-startup-migrations.ts`** | 既存 production DB を新 schema にアップグレードする shadow-table recreation / DROP COLUMN / FK target switch |
+
+(1) と (2) を更新しただけでは既存 production DB は壊れる。本 file の更新漏れは
+**NUC startup blocking** という形で爆発するため、以下に該当する schema 変更 PR は
+必ず (3) へ migration を追加すること:
+
+- `ALTER TABLE DROP COLUMN` (SQLite 3.35+ で限定対応、shadow recreation 推奨)
+- FK target 変更 (SQLite 直接サポートなし、shadow recreation 必須)
+- NOT NULL 制約変更 (同上)
+- 既存 row への DEFAULT 値 backfill 含むカラム追加
+
+なお、**個別カラム追加 (`ALTER TABLE ADD COLUMN ... DEFAULT ...`) は `schema-validator.ts`
+の `validateAndMigrate` が drizzle schema 差分から自動適用する**ため、shadow recreation
+対象外。
+
+**startup 実行順序** (`src/lib/server/db/client.ts`):
+
+```
+1. applyLazyStartupMigrations(sqlite)  ← 旧 schema を新 schema 互換に揃える
+2. sqlite.exec(SQL_CREATE_TABLES)      ← 新規 table / index を idempotent に作成
+3. validateAndMigrate(sqlite)          ← drizzle 差分検出 + 個別 ALTER ADD COLUMN
+```
+
+**冪等性**: 各 migration block は `tableExists` / `hasColumn` / `hasFkToActivities`
+guard で「既に新形式なら skip」を保証。startup ごとに毎回呼ばれても no-op。
+
+**再発防止 CI gate**: 別 Issue で `scripts/check-schema-migration-completeness.mjs`
+(schema.ts 差分 ↔ create-tables.ts ↔ lazy-startup-migrations.ts の同期検証) を将来追加予定。
+現状はコードレビューと本 SSOT の周知で運用。
+
 ---
 
 ## 2. ER図

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -87,8 +87,8 @@ block された (2026-05-27 NUC down)。
 **冪等性**: 各 migration block は `tableExists` / `hasColumn` / `hasFkToActivities`
 guard で「既に新形式なら skip」を保証。startup ごとに毎回呼ばれても no-op。
 
-**再発防止 CI gate**: 別 Issue で `scripts/check-schema-migration-completeness.mjs`
-(schema.ts 差分 ↔ create-tables.ts ↔ lazy-startup-migrations.ts の同期検証) を将来追加予定。
+**再発防止 CI gate**: 別 Issue #2507 で機械検証 script
+(schema.ts 差分 ↔ create-tables.ts ↔ lazy-startup-migrations.ts の同期検証) を別 PR で実装する。
 現状はコードレビューと本 SSOT の周知で運用。
 
 ---

--- a/scripts/migrate-local.ts
+++ b/scripts/migrate-local.ts
@@ -1,9 +1,28 @@
 // Temporary migration script for local DB schema alignment
+//
+// NOTE (#2508 / 3 dimension SSOT):
+//   shadow-table recreation 系 migration
+//   (checklist_templates.kind drop / #2362 PR-3 FK switchover / PR-5 family flip)
+//   は `src/lib/server/db/migration/lazy-startup-migrations.ts` に集約済み。
+//   本 script は (a) lazy helper を明示的に呼ぶ + (b) `validateAndMigrate` に
+//   拾われない or 拾われる前に backfill が必要な軽量 ALTER のみを実行する。
+//
+//   startup 経路 (`client.ts`) と本 script の両方で同じ helper を共有することで、
+//   「migrate-local.ts は最新だが startup は古い」という乖離を構造的に防ぐ。
+//
+// 実行: `npx tsx scripts/migrate-local.ts` (NUC は startup 時に自動適用されるため通常不要)
+
 import Database from 'better-sqlite3';
 import { SQL_CREATE_TABLES } from '../src/lib/server/db/create-tables';
+import { applyLazyStartupMigrations } from '../src/lib/server/db/migration/lazy-startup-migrations';
 
 const db = new Database('./data/ganbari-quest.db');
 db.pragma('foreign_keys = OFF');
+
+console.log(
+	'Applying lazy startup migrations (shadow-table recreation / DROP COLUMN / FK switch)...',
+);
+applyLazyStartupMigrations(db);
 
 console.log('Running CREATE TABLE IF NOT EXISTS...');
 db.exec(SQL_CREATE_TABLES);
@@ -12,6 +31,9 @@ db.exec(SQL_CREATE_TABLES);
 // In-place column additions (ADR-0031 NULL 混在防止対応)
 // CREATE TABLE IF NOT EXISTS は既存テーブルを変更しないため、
 // 既存 DB に新カラムを追加する場合はここで個別に ALTER TABLE する。
+//
+// 注: NOT NULL DEFAULT 'literal' の単純追加は `validateAndMigrate` (schema-validator.ts)
+//     でも自動適用されるが、本 script は startup 経路を経由しないため明示的に列挙する。
 // ============================================================
 
 interface ColumnInfo {
@@ -38,10 +60,10 @@ if (
 	console.log('  → done');
 }
 
-// #1755 (#1709-A): activities.priority カラム追加 + checklist_templates.kind 列削除
+// #1755 (#1709-A): activities.priority カラム追加
 //   - 'must' = 今日のおやくそく / 'optional' = ふつうの活動（既定）
-//   - kind 列削除は破壊的変更（ADR-0010 Pre-PMF 利用者ゼロ前提）
-//   - 既存 kind='routine' レコードは drop（持ち物純化、旧 routine は priority='must' に役割移管）
+//   - 注: checklist_templates.kind 列削除 + 'routine' レコード drop は
+//     `migration/lazy-startup-migrations.ts` の `migrateChecklistTemplatesDropKind` に集約済み。
 if (
 	db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='activities'").get() &&
 	!tableHasColumn('activities', 'priority')
@@ -52,23 +74,6 @@ if (
 		UPDATE activities SET priority = 'optional' WHERE priority IS NULL OR priority = '';
 	`);
 	console.log('  → done (existing rows backfilled to optional)');
-}
-
-if (
-	db
-		.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='checklist_templates'")
-		.get() &&
-	tableHasColumn('checklist_templates', 'kind')
-) {
-	console.log('Dropping checklist_templates.kind column (#1755 / #1709-A)…');
-	// 旧 kind='routine' のテンプレートを先に削除（持ち物純化）
-	const droppedRoutines = db
-		.prepare("DELETE FROM checklist_templates WHERE kind = 'routine'")
-		.run();
-	console.log(`  → deleted ${droppedRoutines.changes} legacy 'routine' templates`);
-	// SQLite 3.35+ は ALTER TABLE DROP COLUMN を直接サポート
-	db.exec('ALTER TABLE checklist_templates DROP COLUMN kind;');
-	console.log('  → kind column dropped');
 }
 
 // #2267 (EPIC #2266): parent_messages に bonus_points / reward_category カラム追加
@@ -96,230 +101,14 @@ if (
 	console.log('  → done (existing rows remain NULL = no category)');
 }
 
-// #2362 PR-3 (Phase 7b-2a): activity 系 FK 切替 (旧 activities → child_activities)
-//   - activity_logs / daily_missions / activity_mastery / child_activity_preferences の 4 件
-//   - 旧 activities table は drop しない (#2458 別 PR)、並存維持
-//   - SQLite 制約により FK 単独 ALTER は不可。shadow table 再作成 pattern を使う
-//   - 冪等性: PRAGMA foreign_key_list で FK target を確認し、'activities' なら切替実行
-//   - 設計 SSOT: docs/design/08-データベース設計書.md / docs/design/data-model-resource-scope.md §4.1
-interface ForeignKeyInfo {
-	id: number;
-	seq: number;
-	table: string;
-	from: string;
-	to: string;
-	on_update: string;
-	on_delete: string;
-	match: string;
-}
-
-function tableHasFkToActivities(table: string): boolean {
-	if (!db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='${table}'`).get()) {
-		return false;
-	}
-	const fks = db.prepare(`PRAGMA foreign_key_list(${table})`).all() as ForeignKeyInfo[];
-	return fks.some((fk) => fk.from === 'activity_id' && fk.table === 'activities');
-}
-
-if (
-	tableHasFkToActivities('activity_logs') ||
-	tableHasFkToActivities('daily_missions') ||
-	tableHasFkToActivities('activity_mastery') ||
-	tableHasFkToActivities('child_activity_preferences')
-) {
-	console.log(
-		'Switching activity_id FK target: activities → child_activities (#2362 PR-3 Phase 7b-2a)…',
-	);
-	db.exec('PRAGMA foreign_keys = OFF');
-
-	// 1. activity_logs
-	if (tableHasFkToActivities('activity_logs')) {
-		console.log('  → activity_logs');
-		db.exec(`
-			CREATE TABLE activity_logs_new (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				child_id INTEGER NOT NULL REFERENCES children(id),
-				activity_id INTEGER NOT NULL REFERENCES child_activities(id),
-				points INTEGER NOT NULL,
-				streak_days INTEGER NOT NULL DEFAULT 1,
-				streak_bonus INTEGER NOT NULL DEFAULT 0,
-				recorded_date TEXT NOT NULL,
-				recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-				cancelled INTEGER NOT NULL DEFAULT 0
-			);
-			INSERT INTO activity_logs_new (id, child_id, activity_id, points, streak_days, streak_bonus, recorded_date, recorded_at, cancelled)
-				SELECT id, child_id, activity_id, points, streak_days, streak_bonus, recorded_date, recorded_at, cancelled FROM activity_logs;
-			DROP TABLE activity_logs;
-			ALTER TABLE activity_logs_new RENAME TO activity_logs;
-			CREATE INDEX idx_activity_logs_daily ON activity_logs(child_id, activity_id, recorded_date);
-			CREATE INDEX idx_activity_logs_child_date ON activity_logs(child_id, recorded_date);
-			CREATE INDEX idx_activity_logs_activity ON activity_logs(activity_id);
-			CREATE INDEX idx_activity_logs_streak ON activity_logs(child_id, activity_id, recorded_date);
-		`);
-	}
-
-	// 2. daily_missions
-	if (tableHasFkToActivities('daily_missions')) {
-		console.log('  → daily_missions');
-		db.exec(`
-			CREATE TABLE daily_missions_new (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				child_id INTEGER NOT NULL REFERENCES children(id),
-				mission_date TEXT NOT NULL,
-				activity_id INTEGER NOT NULL REFERENCES child_activities(id),
-				completed INTEGER NOT NULL DEFAULT 0,
-				completed_at TEXT
-			);
-			INSERT INTO daily_missions_new (id, child_id, mission_date, activity_id, completed, completed_at)
-				SELECT id, child_id, mission_date, activity_id, completed, completed_at FROM daily_missions;
-			DROP TABLE daily_missions;
-			ALTER TABLE daily_missions_new RENAME TO daily_missions;
-			CREATE UNIQUE INDEX idx_daily_missions_unique ON daily_missions(child_id, mission_date, activity_id);
-			CREATE INDEX idx_daily_missions_child_date ON daily_missions(child_id, mission_date);
-		`);
-	}
-
-	// 3. activity_mastery
-	if (tableHasFkToActivities('activity_mastery')) {
-		console.log('  → activity_mastery');
-		db.exec(`
-			CREATE TABLE activity_mastery_new (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				child_id INTEGER NOT NULL REFERENCES children(id),
-				activity_id INTEGER NOT NULL REFERENCES child_activities(id),
-				total_count INTEGER NOT NULL DEFAULT 0,
-				level INTEGER NOT NULL DEFAULT 1,
-				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-			);
-			INSERT INTO activity_mastery_new (id, child_id, activity_id, total_count, level, updated_at)
-				SELECT id, child_id, activity_id, total_count, level, updated_at FROM activity_mastery;
-			DROP TABLE activity_mastery;
-			ALTER TABLE activity_mastery_new RENAME TO activity_mastery;
-			CREATE UNIQUE INDEX idx_activity_mastery_child_activity ON activity_mastery(child_id, activity_id);
-		`);
-	}
-
-	// 4. child_activity_preferences (ON DELETE CASCADE 維持)
-	if (tableHasFkToActivities('child_activity_preferences')) {
-		console.log('  → child_activity_preferences');
-		db.exec(`
-			CREATE TABLE child_activity_preferences_new (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				child_id INTEGER NOT NULL REFERENCES children(id) ON DELETE CASCADE,
-				activity_id INTEGER NOT NULL REFERENCES child_activities(id) ON DELETE CASCADE,
-				is_pinned INTEGER NOT NULL DEFAULT 0,
-				pin_order INTEGER,
-				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-			);
-			INSERT INTO child_activity_preferences_new (id, child_id, activity_id, is_pinned, pin_order, created_at, updated_at)
-				SELECT id, child_id, activity_id, is_pinned, pin_order, created_at, updated_at FROM child_activity_preferences;
-			DROP TABLE child_activity_preferences;
-			ALTER TABLE child_activity_preferences_new RENAME TO child_activity_preferences;
-			CREATE UNIQUE INDEX idx_child_activity_prefs_unique ON child_activity_preferences(child_id, activity_id);
-			CREATE INDEX idx_child_activity_prefs_child ON child_activity_preferences(child_id);
-			CREATE INDEX idx_child_activity_prefs_pinned ON child_activity_preferences(child_id, is_pinned);
-		`);
-	}
-
-	db.exec('PRAGMA foreign_keys = ON');
-	console.log('  → activity FK switchover complete');
-}
-
-// #2362 PR-5 (Phase 1): checklist_templates family master 化
-//   - 旧: checklist_templates.child_id NOT NULL (per-child instance)
-//   - 新: checklist_templates に tenant_id 列追加 + child_id 列削除
-//         + checklist_template_assignments 新規 (template ↔ child N:M binding)
-//   - 既存 per-child template は配信先 1 件の family master + assignment 1 行に変換
-//   - 既存 checklist_logs / checklist_overrides の child_id は維持 (per-child progress / override の事実履歴)
-//   - 冪等性: PRAGMA table_info で child_id 列の有無を確認し、既に新形式なら skip
-//   - SQLite 制約: DROP COLUMN は 3.35+、shadow table 再作成 pattern を併用 (FK 維持)
-//   - SSOT: docs/design/data-model-resource-scope.md §4.2
-if (
-	db
-		.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='checklist_templates'")
-		.get() &&
-	tableHasColumn('checklist_templates', 'child_id')
-) {
-	console.log(
-		'Switching checklist_templates: per-child instance → family master (#2362 PR-5 Phase 1)…',
-	);
-	db.exec('PRAGMA foreign_keys = OFF');
-
-	const hasTenantId = tableHasColumn('checklist_templates', 'tenant_id');
-
-	// 1. checklist_templates: tenant_id 追加 (なければ) + child_id 削除 + shadow table 再作成
-	db.exec(`
-		CREATE TABLE checklist_templates_new (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			tenant_id TEXT NOT NULL DEFAULT 'default',
-			name TEXT NOT NULL,
-			icon TEXT NOT NULL DEFAULT '📋',
-			points_per_item INTEGER NOT NULL DEFAULT 2,
-			completion_bonus INTEGER NOT NULL DEFAULT 5,
-			time_slot TEXT NOT NULL DEFAULT 'anytime',
-			is_active INTEGER NOT NULL DEFAULT 1,
-			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			is_archived INTEGER NOT NULL DEFAULT 0,
-			archived_reason TEXT,
-			source_preset_id TEXT
-		);
-	`);
-
-	// 2. 既存 row を新 schema に移行。tenant_id は (a) 既に列があればその値、(b) なければ 'default'。
-	if (hasTenantId) {
-		db.exec(`
-			INSERT INTO checklist_templates_new
-				(id, tenant_id, name, icon, points_per_item, completion_bonus, time_slot, is_active,
-				 created_at, updated_at, is_archived, archived_reason, source_preset_id)
-				SELECT id, COALESCE(tenant_id, 'default'), name, icon, points_per_item, completion_bonus, time_slot, is_active,
-				 created_at, updated_at, is_archived, COALESCE(archived_reason, NULL), COALESCE(source_preset_id, NULL)
-				 FROM checklist_templates;
-		`);
-	} else {
-		db.exec(`
-			INSERT INTO checklist_templates_new
-				(id, tenant_id, name, icon, points_per_item, completion_bonus, time_slot, is_active,
-				 created_at, updated_at, is_archived, archived_reason, source_preset_id)
-				SELECT id, 'default', name, icon, points_per_item, completion_bonus, time_slot, is_active,
-				 created_at, updated_at, is_archived, COALESCE(archived_reason, NULL), COALESCE(source_preset_id, NULL)
-				 FROM checklist_templates;
-		`);
-	}
-
-	// 3. 新規 assignments table (旧 per-child template の child_id を 1 row ずつ移行)
-	db.exec(`
-		CREATE TABLE IF NOT EXISTS checklist_template_assignments (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			template_id INTEGER NOT NULL REFERENCES checklist_templates(id),
-			child_id INTEGER NOT NULL REFERENCES children(id),
-			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-		);
-		CREATE UNIQUE INDEX IF NOT EXISTS idx_checklist_template_assignments_unique
-			ON checklist_template_assignments(template_id, child_id);
-		CREATE INDEX IF NOT EXISTS idx_checklist_template_assignments_child
-			ON checklist_template_assignments(child_id);
-		INSERT INTO checklist_template_assignments (template_id, child_id, created_at)
-			SELECT id, child_id, created_at FROM checklist_templates;
-	`);
-
-	const assignmentCount = (
-		db.prepare('SELECT COUNT(*) AS c FROM checklist_template_assignments').get() as { c: number }
-	).c;
-	console.log(`  → migrated ${assignmentCount} per-child rows to template_assignments`);
-
-	// 4. 旧 table を drop して new を rename
-	db.exec(`
-		DROP TABLE checklist_templates;
-		ALTER TABLE checklist_templates_new RENAME TO checklist_templates;
-		CREATE INDEX IF NOT EXISTS idx_checklist_templates_tenant_archived
-			ON checklist_templates(tenant_id, is_archived);
-	`);
-
-	db.exec('PRAGMA foreign_keys = ON');
-	console.log('  → checklist family master flip complete');
-}
+// ============================================================
+// 注: 以下の shadow-table recreation 系は本 script から削除済み
+// (`migration/lazy-startup-migrations.ts` に集約):
+//   - #1755 checklist_templates.kind 列削除 + 'routine' レコード drop
+//   - #2362 PR-3 activity FK switchover (activities → child_activities)
+//   - #2362 PR-5 checklist_templates family master flip
+//     (child_id → tenant_id + checklist_template_assignments 作成)
+// ============================================================
 
 const tables = db
 	.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")

--- a/src/lib/server/db/client.ts
+++ b/src/lib/server/db/client.ts
@@ -4,6 +4,7 @@
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { SQL_CREATE_TABLES } from './create-tables';
+import { applyLazyStartupMigrations } from './migration/lazy-startup-migrations';
 import * as schema from './schema';
 import { validateAndMigrate } from './schema-validator';
 
@@ -26,9 +27,17 @@ sqlite.pragma('synchronous = NORMAL');
 // All statements use CREATE TABLE/INDEX IF NOT EXISTS, so this is idempotent.
 // Ensures new tables are always available after code updates (NUC Docker, Lambda, dev).
 if ((process.env.DATA_SOURCE ?? 'sqlite') === 'sqlite') {
+	// 1. shadow-table recreation / DROP COLUMN / FK target switchover を最初に実行。
+	//    既存 production DB の旧 schema を新 schema 互換に揃え、後続の
+	//    `SQL_CREATE_TABLES` の `CREATE INDEX ... ON <new_column>` 等が
+	//    `no such column` で fail しないようにする。
+	//    詳細: src/lib/server/db/migration/lazy-startup-migrations.ts 冒頭コメント
+	applyLazyStartupMigrations(sqlite);
+
+	// 2. 新規 table / index を idempotent に作成
 	sqlite.exec(SQL_CREATE_TABLES);
 
-	// スキーマバリデーション + 安全な自動マイグレーション（カラム追加）
+	// 3. スキーマバリデーション + 安全な自動マイグレーション（カラム追加）
 	const schemaResult = validateAndMigrate(sqlite);
 
 	if (schemaResult.applied.length > 0) {

--- a/src/lib/server/db/migration/lazy-startup-migrations.ts
+++ b/src/lib/server/db/migration/lazy-startup-migrations.ts
@@ -99,11 +99,11 @@ function migrateChecklistTemplatesDropKind(db: Database.Database): void {
 		return;
 	}
 	const dropped = db.prepare("DELETE FROM checklist_templates WHERE kind = 'routine'").run();
-	console.log(
+	console.info(
 		`[lazy-migrate #1755] deleted ${dropped.changes} legacy 'routine' rows from checklist_templates`,
 	);
 	db.exec('ALTER TABLE checklist_templates DROP COLUMN kind;');
-	console.log('[lazy-migrate #1755] dropped checklist_templates.kind column');
+	console.info('[lazy-migrate #1755] dropped checklist_templates.kind column');
 }
 
 /**
@@ -123,7 +123,7 @@ function migrateActivityFkSwitchover(db: Database.Database): void {
 		hasFkToActivities(db, 'child_activity_preferences');
 	if (!needs) return;
 
-	console.log(
+	console.info(
 		'[lazy-migrate #2362-PR3] switching activity_id FK target: activities → child_activities',
 	);
 
@@ -149,7 +149,7 @@ function migrateActivityFkSwitchover(db: Database.Database): void {
 			CREATE INDEX idx_activity_logs_activity ON activity_logs(activity_id);
 			CREATE INDEX idx_activity_logs_streak ON activity_logs(child_id, activity_id, recorded_date);
 		`);
-		console.log('[lazy-migrate #2362-PR3]   → activity_logs done');
+		console.info('[lazy-migrate #2362-PR3]   → activity_logs done');
 	}
 
 	if (hasFkToActivities(db, 'daily_missions')) {
@@ -169,7 +169,7 @@ function migrateActivityFkSwitchover(db: Database.Database): void {
 			CREATE UNIQUE INDEX idx_daily_missions_unique ON daily_missions(child_id, mission_date, activity_id);
 			CREATE INDEX idx_daily_missions_child_date ON daily_missions(child_id, mission_date);
 		`);
-		console.log('[lazy-migrate #2362-PR3]   → daily_missions done');
+		console.info('[lazy-migrate #2362-PR3]   → daily_missions done');
 	}
 
 	if (hasFkToActivities(db, 'activity_mastery')) {
@@ -188,7 +188,7 @@ function migrateActivityFkSwitchover(db: Database.Database): void {
 			ALTER TABLE activity_mastery_new RENAME TO activity_mastery;
 			CREATE UNIQUE INDEX idx_activity_mastery_child_activity ON activity_mastery(child_id, activity_id);
 		`);
-		console.log('[lazy-migrate #2362-PR3]   → activity_mastery done');
+		console.info('[lazy-migrate #2362-PR3]   → activity_mastery done');
 	}
 
 	if (hasFkToActivities(db, 'child_activity_preferences')) {
@@ -210,7 +210,7 @@ function migrateActivityFkSwitchover(db: Database.Database): void {
 			CREATE INDEX idx_child_activity_prefs_child ON child_activity_preferences(child_id);
 			CREATE INDEX idx_child_activity_prefs_pinned ON child_activity_preferences(child_id, is_pinned);
 		`);
-		console.log('[lazy-migrate #2362-PR3]   → child_activity_preferences done');
+		console.info('[lazy-migrate #2362-PR3]   → child_activity_preferences done');
 	}
 }
 
@@ -235,7 +235,7 @@ function migrateChecklistTemplatesFamilyFlip(db: Database.Database): void {
 		return;
 	}
 
-	console.log('[lazy-migrate #2362-PR5] flipping checklist_templates: per-child → family master');
+	console.info('[lazy-migrate #2362-PR5] flipping checklist_templates: per-child → family master');
 
 	const hasTenantId = hasColumn(db, 'checklist_templates', 'tenant_id');
 
@@ -299,7 +299,7 @@ function migrateChecklistTemplatesFamilyFlip(db: Database.Database): void {
 	const assignmentCount = (
 		db.prepare('SELECT COUNT(*) AS c FROM checklist_template_assignments').get() as { c: number }
 	).c;
-	console.log(
+	console.info(
 		`[lazy-migrate #2362-PR5]   migrated ${assignmentCount} per-child rows to template_assignments`,
 	);
 
@@ -310,7 +310,7 @@ function migrateChecklistTemplatesFamilyFlip(db: Database.Database): void {
 		CREATE INDEX IF NOT EXISTS idx_checklist_templates_tenant_archived
 			ON checklist_templates(tenant_id, is_archived);
 	`);
-	console.log('[lazy-migrate #2362-PR5]   → flip complete');
+	console.info('[lazy-migrate #2362-PR5]   → flip complete');
 }
 
 /**

--- a/src/lib/server/db/migration/lazy-startup-migrations.ts
+++ b/src/lib/server/db/migration/lazy-startup-migrations.ts
@@ -93,17 +93,24 @@ function hasFkToActivities(db: Database.Database, table: string): boolean {
 /**
  * #1755 (#1709-A) 後半: `checklist_templates.kind` 列削除 + 旧 'routine' レコード drop。
  * 持ち物純化 (旧 routine は `activities.priority='must'` に役割移管)。
+ *
+ * #2509 fix: DELETE + DROP COLUMN を transaction で囲み、片方だけ成功して
+ * 不整合 (routine 行は消えたが kind 列が残っている等) を残さない。
  */
 function migrateChecklistTemplatesDropKind(db: Database.Database): void {
+	// guard (read-only): tx 外で OK
 	if (!tableExists(db, 'checklist_templates') || !hasColumn(db, 'checklist_templates', 'kind')) {
 		return;
 	}
-	const dropped = db.prepare("DELETE FROM checklist_templates WHERE kind = 'routine'").run();
-	console.info(
-		`[lazy-migrate #1755] deleted ${dropped.changes} legacy 'routine' rows from checklist_templates`,
-	);
-	db.exec('ALTER TABLE checklist_templates DROP COLUMN kind;');
-	console.info('[lazy-migrate #1755] dropped checklist_templates.kind column');
+	const run = db.transaction(() => {
+		const dropped = db.prepare("DELETE FROM checklist_templates WHERE kind = 'routine'").run();
+		console.info(
+			`[lazy-migrate #1755] deleted ${dropped.changes} legacy 'routine' rows from checklist_templates`,
+		);
+		db.exec('ALTER TABLE checklist_templates DROP COLUMN kind;');
+		console.info('[lazy-migrate #1755] dropped checklist_templates.kind column');
+	});
+	run();
 }
 
 /**
@@ -114,6 +121,13 @@ function migrateChecklistTemplatesDropKind(db: Database.Database): void {
  * `child_activity_preferences` のみ ON DELETE CASCADE を維持。
  *
  * 対象: activity_logs / daily_missions / activity_mastery / child_activity_preferences
+ *
+ * #2509 fix: 各 sub-table の shadow-table recreation を transaction で囲み、
+ * 例えば INSERT 中に fail した場合に `*_new` だけ残って旧 table と二重存在
+ * (次回起動で `CREATE INDEX ... ON activity_logs(...)` が `no such table` で
+ * fail する等) する不整合を防ぐ。各 sub-table は独立 tx (1 つ失敗しても他は
+ * 既に commit 済み or skip)、tx 内で例外が起きると better-sqlite3 は自動 ROLLBACK
+ * する。
  */
 function migrateActivityFkSwitchover(db: Database.Database): void {
 	const needs =
@@ -128,88 +142,100 @@ function migrateActivityFkSwitchover(db: Database.Database): void {
 	);
 
 	if (hasFkToActivities(db, 'activity_logs')) {
-		db.exec(`
-			CREATE TABLE activity_logs_new (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				child_id INTEGER NOT NULL REFERENCES children(id),
-				activity_id INTEGER NOT NULL REFERENCES child_activities(id),
-				points INTEGER NOT NULL,
-				streak_days INTEGER NOT NULL DEFAULT 1,
-				streak_bonus INTEGER NOT NULL DEFAULT 0,
-				recorded_date TEXT NOT NULL,
-				recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-				cancelled INTEGER NOT NULL DEFAULT 0
-			);
-			INSERT INTO activity_logs_new (id, child_id, activity_id, points, streak_days, streak_bonus, recorded_date, recorded_at, cancelled)
-				SELECT id, child_id, activity_id, points, streak_days, streak_bonus, recorded_date, recorded_at, cancelled FROM activity_logs;
-			DROP TABLE activity_logs;
-			ALTER TABLE activity_logs_new RENAME TO activity_logs;
-			CREATE INDEX idx_activity_logs_daily ON activity_logs(child_id, activity_id, recorded_date);
-			CREATE INDEX idx_activity_logs_child_date ON activity_logs(child_id, recorded_date);
-			CREATE INDEX idx_activity_logs_activity ON activity_logs(activity_id);
-			CREATE INDEX idx_activity_logs_streak ON activity_logs(child_id, activity_id, recorded_date);
-		`);
+		const run = db.transaction(() => {
+			db.exec(`
+				CREATE TABLE activity_logs_new (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_id INTEGER NOT NULL REFERENCES children(id),
+					activity_id INTEGER NOT NULL REFERENCES child_activities(id),
+					points INTEGER NOT NULL,
+					streak_days INTEGER NOT NULL DEFAULT 1,
+					streak_bonus INTEGER NOT NULL DEFAULT 0,
+					recorded_date TEXT NOT NULL,
+					recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					cancelled INTEGER NOT NULL DEFAULT 0
+				);
+				INSERT INTO activity_logs_new (id, child_id, activity_id, points, streak_days, streak_bonus, recorded_date, recorded_at, cancelled)
+					SELECT id, child_id, activity_id, points, streak_days, streak_bonus, recorded_date, recorded_at, cancelled FROM activity_logs;
+				DROP TABLE activity_logs;
+				ALTER TABLE activity_logs_new RENAME TO activity_logs;
+				CREATE INDEX idx_activity_logs_daily ON activity_logs(child_id, activity_id, recorded_date);
+				CREATE INDEX idx_activity_logs_child_date ON activity_logs(child_id, recorded_date);
+				CREATE INDEX idx_activity_logs_activity ON activity_logs(activity_id);
+				CREATE INDEX idx_activity_logs_streak ON activity_logs(child_id, activity_id, recorded_date);
+			`);
+		});
+		run();
 		console.info('[lazy-migrate #2362-PR3]   → activity_logs done');
 	}
 
 	if (hasFkToActivities(db, 'daily_missions')) {
-		db.exec(`
-			CREATE TABLE daily_missions_new (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				child_id INTEGER NOT NULL REFERENCES children(id),
-				mission_date TEXT NOT NULL,
-				activity_id INTEGER NOT NULL REFERENCES child_activities(id),
-				completed INTEGER NOT NULL DEFAULT 0,
-				completed_at TEXT
-			);
-			INSERT INTO daily_missions_new (id, child_id, mission_date, activity_id, completed, completed_at)
-				SELECT id, child_id, mission_date, activity_id, completed, completed_at FROM daily_missions;
-			DROP TABLE daily_missions;
-			ALTER TABLE daily_missions_new RENAME TO daily_missions;
-			CREATE UNIQUE INDEX idx_daily_missions_unique ON daily_missions(child_id, mission_date, activity_id);
-			CREATE INDEX idx_daily_missions_child_date ON daily_missions(child_id, mission_date);
-		`);
+		const run = db.transaction(() => {
+			db.exec(`
+				CREATE TABLE daily_missions_new (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_id INTEGER NOT NULL REFERENCES children(id),
+					mission_date TEXT NOT NULL,
+					activity_id INTEGER NOT NULL REFERENCES child_activities(id),
+					completed INTEGER NOT NULL DEFAULT 0,
+					completed_at TEXT
+				);
+				INSERT INTO daily_missions_new (id, child_id, mission_date, activity_id, completed, completed_at)
+					SELECT id, child_id, mission_date, activity_id, completed, completed_at FROM daily_missions;
+				DROP TABLE daily_missions;
+				ALTER TABLE daily_missions_new RENAME TO daily_missions;
+				CREATE UNIQUE INDEX idx_daily_missions_unique ON daily_missions(child_id, mission_date, activity_id);
+				CREATE INDEX idx_daily_missions_child_date ON daily_missions(child_id, mission_date);
+			`);
+		});
+		run();
 		console.info('[lazy-migrate #2362-PR3]   → daily_missions done');
 	}
 
 	if (hasFkToActivities(db, 'activity_mastery')) {
-		db.exec(`
-			CREATE TABLE activity_mastery_new (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				child_id INTEGER NOT NULL REFERENCES children(id),
-				activity_id INTEGER NOT NULL REFERENCES child_activities(id),
-				total_count INTEGER NOT NULL DEFAULT 0,
-				level INTEGER NOT NULL DEFAULT 1,
-				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-			);
-			INSERT INTO activity_mastery_new (id, child_id, activity_id, total_count, level, updated_at)
-				SELECT id, child_id, activity_id, total_count, level, updated_at FROM activity_mastery;
-			DROP TABLE activity_mastery;
-			ALTER TABLE activity_mastery_new RENAME TO activity_mastery;
-			CREATE UNIQUE INDEX idx_activity_mastery_child_activity ON activity_mastery(child_id, activity_id);
-		`);
+		const run = db.transaction(() => {
+			db.exec(`
+				CREATE TABLE activity_mastery_new (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_id INTEGER NOT NULL REFERENCES children(id),
+					activity_id INTEGER NOT NULL REFERENCES child_activities(id),
+					total_count INTEGER NOT NULL DEFAULT 0,
+					level INTEGER NOT NULL DEFAULT 1,
+					updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+				);
+				INSERT INTO activity_mastery_new (id, child_id, activity_id, total_count, level, updated_at)
+					SELECT id, child_id, activity_id, total_count, level, updated_at FROM activity_mastery;
+				DROP TABLE activity_mastery;
+				ALTER TABLE activity_mastery_new RENAME TO activity_mastery;
+				CREATE UNIQUE INDEX idx_activity_mastery_child_activity ON activity_mastery(child_id, activity_id);
+			`);
+		});
+		run();
 		console.info('[lazy-migrate #2362-PR3]   → activity_mastery done');
 	}
 
 	if (hasFkToActivities(db, 'child_activity_preferences')) {
-		db.exec(`
-			CREATE TABLE child_activity_preferences_new (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				child_id INTEGER NOT NULL REFERENCES children(id) ON DELETE CASCADE,
-				activity_id INTEGER NOT NULL REFERENCES child_activities(id) ON DELETE CASCADE,
-				is_pinned INTEGER NOT NULL DEFAULT 0,
-				pin_order INTEGER,
-				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-			);
-			INSERT INTO child_activity_preferences_new (id, child_id, activity_id, is_pinned, pin_order, created_at, updated_at)
-				SELECT id, child_id, activity_id, is_pinned, pin_order, created_at, updated_at FROM child_activity_preferences;
-			DROP TABLE child_activity_preferences;
-			ALTER TABLE child_activity_preferences_new RENAME TO child_activity_preferences;
-			CREATE UNIQUE INDEX idx_child_activity_prefs_unique ON child_activity_preferences(child_id, activity_id);
-			CREATE INDEX idx_child_activity_prefs_child ON child_activity_preferences(child_id);
-			CREATE INDEX idx_child_activity_prefs_pinned ON child_activity_preferences(child_id, is_pinned);
-		`);
+		const run = db.transaction(() => {
+			db.exec(`
+				CREATE TABLE child_activity_preferences_new (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_id INTEGER NOT NULL REFERENCES children(id) ON DELETE CASCADE,
+					activity_id INTEGER NOT NULL REFERENCES child_activities(id) ON DELETE CASCADE,
+					is_pinned INTEGER NOT NULL DEFAULT 0,
+					pin_order INTEGER,
+					created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+				);
+				INSERT INTO child_activity_preferences_new (id, child_id, activity_id, is_pinned, pin_order, created_at, updated_at)
+					SELECT id, child_id, activity_id, is_pinned, pin_order, created_at, updated_at FROM child_activity_preferences;
+				DROP TABLE child_activity_preferences;
+				ALTER TABLE child_activity_preferences_new RENAME TO child_activity_preferences;
+				CREATE UNIQUE INDEX idx_child_activity_prefs_unique ON child_activity_preferences(child_id, activity_id);
+				CREATE INDEX idx_child_activity_prefs_child ON child_activity_preferences(child_id);
+				CREATE INDEX idx_child_activity_prefs_pinned ON child_activity_preferences(child_id, is_pinned);
+			`);
+		});
+		run();
 		console.info('[lazy-migrate #2362-PR3]   → child_activity_preferences done');
 	}
 }
@@ -228,6 +254,7 @@ function migrateActivityFkSwitchover(db: Database.Database): void {
  * SSOT: docs/design/data-model-resource-scope.md §4.2
  */
 function migrateChecklistTemplatesFamilyFlip(db: Database.Database): void {
+	// guard (read-only): tx 外で OK
 	if (
 		!tableExists(db, 'checklist_templates') ||
 		!hasColumn(db, 'checklist_templates', 'child_id')
@@ -239,77 +266,87 @@ function migrateChecklistTemplatesFamilyFlip(db: Database.Database): void {
 
 	const hasTenantId = hasColumn(db, 'checklist_templates', 'tenant_id');
 
-	// 1. 新 schema の shadow table を作成 (create-tables.ts と同一形状)
-	db.exec(`
-		CREATE TABLE checklist_templates_new (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			tenant_id TEXT NOT NULL DEFAULT 'default',
-			name TEXT NOT NULL,
-			icon TEXT NOT NULL DEFAULT '📋',
-			points_per_item INTEGER NOT NULL DEFAULT 2,
-			completion_bonus INTEGER NOT NULL DEFAULT 5,
-			time_slot TEXT NOT NULL DEFAULT 'anytime',
-			is_active INTEGER NOT NULL DEFAULT 1,
-			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			is_archived INTEGER NOT NULL DEFAULT 0,
-			archived_reason TEXT,
-			source_preset_id TEXT
-		);
-	`);
-
-	// 2. 既存 row を移行。tenant_id 既存値 or 'default'。
-	//    time_slot / is_archived は旧 schema で nullable だった可能性があるので COALESCE で補完。
-	if (hasTenantId) {
+	// #2509 fix: 4 step (shadow CREATE → INSERT → assignments + populate → DROP/RENAME) を
+	// 単一 tx で囲む。step 2/3 で fail した場合に shadow table (`*_new`) や中途半端な
+	// assignments が残ると、次回起動時の guard (`hasColumn('child_id')`) は false に
+	// なり migration skip するが、`SQL_CREATE_TABLES` 内の `CREATE INDEX ... ON
+	// checklist_templates(tenant_id, ...)` が「shadow rename されておらず tenant_id 列
+	// 不在」で fail し永続的 startup loop (Issue #2508 と同型) に陥る。tx で全 step 失敗
+	// 時に ROLLBACK させ、再起動時にも旧 schema から再度 migrate 試行可能な状態を保つ。
+	const run = db.transaction(() => {
+		// 1. 新 schema の shadow table を作成 (create-tables.ts と同一形状)
 		db.exec(`
-			INSERT INTO checklist_templates_new
-				(id, tenant_id, name, icon, points_per_item, completion_bonus, time_slot, is_active,
-				 created_at, updated_at, is_archived, archived_reason, source_preset_id)
-			SELECT id, COALESCE(tenant_id, 'default'), name, icon, points_per_item, completion_bonus,
-				COALESCE(time_slot, 'anytime'), is_active, created_at, updated_at,
-				COALESCE(is_archived, 0), archived_reason, source_preset_id FROM checklist_templates;
+			CREATE TABLE checklist_templates_new (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				tenant_id TEXT NOT NULL DEFAULT 'default',
+				name TEXT NOT NULL,
+				icon TEXT NOT NULL DEFAULT '📋',
+				points_per_item INTEGER NOT NULL DEFAULT 2,
+				completion_bonus INTEGER NOT NULL DEFAULT 5,
+				time_slot TEXT NOT NULL DEFAULT 'anytime',
+				is_active INTEGER NOT NULL DEFAULT 1,
+				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				is_archived INTEGER NOT NULL DEFAULT 0,
+				archived_reason TEXT,
+				source_preset_id TEXT
+			);
 		`);
-	} else {
+
+		// 2. 既存 row を移行。tenant_id 既存値 or 'default'。
+		//    time_slot / is_archived は旧 schema で nullable だった可能性があるので COALESCE で補完。
+		if (hasTenantId) {
+			db.exec(`
+				INSERT INTO checklist_templates_new
+					(id, tenant_id, name, icon, points_per_item, completion_bonus, time_slot, is_active,
+					 created_at, updated_at, is_archived, archived_reason, source_preset_id)
+				SELECT id, COALESCE(tenant_id, 'default'), name, icon, points_per_item, completion_bonus,
+					COALESCE(time_slot, 'anytime'), is_active, created_at, updated_at,
+					COALESCE(is_archived, 0), archived_reason, source_preset_id FROM checklist_templates;
+			`);
+		} else {
+			db.exec(`
+				INSERT INTO checklist_templates_new
+					(id, tenant_id, name, icon, points_per_item, completion_bonus, time_slot, is_active,
+					 created_at, updated_at, is_archived, archived_reason, source_preset_id)
+				SELECT id, 'default', name, icon, points_per_item, completion_bonus,
+					COALESCE(time_slot, 'anytime'), is_active, created_at, updated_at,
+					COALESCE(is_archived, 0), archived_reason, source_preset_id FROM checklist_templates;
+			`);
+		}
+
+		// 3. 旧 per-child template の child_id 値を assignments 1 row に移行
 		db.exec(`
-			INSERT INTO checklist_templates_new
-				(id, tenant_id, name, icon, points_per_item, completion_bonus, time_slot, is_active,
-				 created_at, updated_at, is_archived, archived_reason, source_preset_id)
-			SELECT id, 'default', name, icon, points_per_item, completion_bonus,
-				COALESCE(time_slot, 'anytime'), is_active, created_at, updated_at,
-				COALESCE(is_archived, 0), archived_reason, source_preset_id FROM checklist_templates;
+			CREATE TABLE IF NOT EXISTS checklist_template_assignments (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				template_id INTEGER NOT NULL REFERENCES checklist_templates(id),
+				child_id INTEGER NOT NULL REFERENCES children(id),
+				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+			);
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_checklist_template_assignments_unique
+				ON checklist_template_assignments(template_id, child_id);
+			CREATE INDEX IF NOT EXISTS idx_checklist_template_assignments_child
+				ON checklist_template_assignments(child_id);
+			INSERT INTO checklist_template_assignments (template_id, child_id, created_at)
+				SELECT id, child_id, created_at FROM checklist_templates;
 		`);
-	}
 
-	// 3. 旧 per-child template の child_id 値を assignments 1 row に移行
-	db.exec(`
-		CREATE TABLE IF NOT EXISTS checklist_template_assignments (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			template_id INTEGER NOT NULL REFERENCES checklist_templates(id),
-			child_id INTEGER NOT NULL REFERENCES children(id),
-			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		const assignmentCount = (
+			db.prepare('SELECT COUNT(*) AS c FROM checklist_template_assignments').get() as { c: number }
+		).c;
+		console.info(
+			`[lazy-migrate #2362-PR5]   migrated ${assignmentCount} per-child rows to template_assignments`,
 		);
-		CREATE UNIQUE INDEX IF NOT EXISTS idx_checklist_template_assignments_unique
-			ON checklist_template_assignments(template_id, child_id);
-		CREATE INDEX IF NOT EXISTS idx_checklist_template_assignments_child
-			ON checklist_template_assignments(child_id);
-		INSERT INTO checklist_template_assignments (template_id, child_id, created_at)
-			SELECT id, child_id, created_at FROM checklist_templates;
-	`);
 
-	const assignmentCount = (
-		db.prepare('SELECT COUNT(*) AS c FROM checklist_template_assignments').get() as { c: number }
-	).c;
-	console.info(
-		`[lazy-migrate #2362-PR5]   migrated ${assignmentCount} per-child rows to template_assignments`,
-	);
-
-	// 4. 旧 table を drop + new を rename + index 再作成
-	db.exec(`
-		DROP TABLE checklist_templates;
-		ALTER TABLE checklist_templates_new RENAME TO checklist_templates;
-		CREATE INDEX IF NOT EXISTS idx_checklist_templates_tenant_archived
-			ON checklist_templates(tenant_id, is_archived);
-	`);
+		// 4. 旧 table を drop + new を rename + index 再作成
+		db.exec(`
+			DROP TABLE checklist_templates;
+			ALTER TABLE checklist_templates_new RENAME TO checklist_templates;
+			CREATE INDEX IF NOT EXISTS idx_checklist_templates_tenant_archived
+				ON checklist_templates(tenant_id, is_archived);
+		`);
+	});
+	run();
 	console.info('[lazy-migrate #2362-PR5]   → flip complete');
 }
 
@@ -317,11 +354,17 @@ function migrateChecklistTemplatesFamilyFlip(db: Database.Database): void {
  * startup 時に `SQL_CREATE_TABLES` 実行より **前** に呼ぶ。
  *
  * - 各 migration は冪等 (既に新形式なら skip)
+ * - 各 migration block は内部で **transaction (BEGIN ... COMMIT)** を張る (#2509)。
+ *   ALTER TABLE / DROP TABLE / RENAME / INSERT が途中で fail した場合は SQLite が
+ *   自動 ROLLBACK し、partial state を残さない。partial state が残ると次回起動時
+ *   guard 判定が破れて startup loop に陥る (Issue #2508 と同型のリスク) ため、
+ *   atomic 化は必須。
  * - 全 migration を `foreign_keys = OFF` 下で実行 (shadow table 再作成中の
  *   FK 整合性 trip を回避)
  * - 終了時に `foreign_keys = ON` に必ず戻す
  * - エラー時は呼び出し元 (`client.ts`) に伝播し、`SCHEMA_VALIDATION_MODE`
- *   分岐で process.exit するか継続するかを判断する
+ *   分岐で process.exit するか継続するかを判断する。fail-fast 原則: partial state
+ *   で app を起動させない。
  *
  * 注: 本 helper は単一 SQLite ファイル (NUC / local dev) を前提。
  *     DynamoDB バックエンドでは呼ばない。
@@ -333,6 +376,12 @@ export function applyLazyStartupMigrations(db: Database.Database): void {
 		migrateChecklistTemplatesDropKind(db);
 		migrateActivityFkSwitchover(db);
 		migrateChecklistTemplatesFamilyFlip(db);
+	} catch (err) {
+		// #2509: tx 内で失敗した場合 better-sqlite3 が自動 ROLLBACK 済。partial state
+		// は残らないが、後続の `SQL_CREATE_TABLES` / `validateAndMigrate` 実行は危険
+		// (整合性が確定しないため) なので呼び出し元に再 throw し fail-fast させる。
+		console.error('[lazy-migrate] migration failed and rolled back; aborting startup', err);
+		throw err;
 	} finally {
 		// shadow-table recreation 中の FK 制約 trip を防ぐため OFF にしたが、
 		// 終了時に必ず元 (通常 ON) に戻す。

--- a/src/lib/server/db/migration/lazy-startup-migrations.ts
+++ b/src/lib/server/db/migration/lazy-startup-migrations.ts
@@ -1,0 +1,341 @@
+// src/lib/server/db/migration/lazy-startup-migrations.ts
+//
+// startup 時に **`SQL_CREATE_TABLES` (create-tables.ts) より前** に実行する
+// shadow-table recreation 系 / DROP COLUMN 系の lazy migration 集約 SSOT。
+//
+// ## 設計背景 (NUC startup failure 2026-05-27)
+//
+// `schema-validator.ts` (`validateAndMigrate`) は **個別カラム追加**
+// (`ALTER TABLE ADD COLUMN`) のみ対応する (SQLite ADR-0031)。一方、
+// SQLite では以下の operation はサポートされない / 制約がある:
+//
+// - `ALTER TABLE DROP COLUMN` (SQLite 3.35+ で限定対応、複雑な制約あり)
+// - `ALTER TABLE` で FK target 変更 (不可能)
+// - `ALTER TABLE` で NOT NULL 制約変更 (不可能)
+//
+// これらは **shadow table recreation pattern** (旧 table の隣に新 schema の
+// `*_new` を作って `INSERT ... SELECT` → `DROP old` → `RENAME new` → re-create
+// indexes) で対応する必要がある。
+//
+// PR #2480 (#2362 PR-5 Phase 1) で `checklist_templates` を
+// per-child instance (child_id NOT NULL) から family master (tenant_id NOT NULL)
+// に flip した際、本来 startup の `SQL_CREATE_TABLES` より **前** にこの
+// shadow-table recreation を実行する必要があったが、scripts/migrate-local.ts
+// にしか実装されておらず NUC startup から呼ばれていなかった。結果、
+// `SQL_CREATE_TABLES` 内の `CREATE INDEX ... ON checklist_templates(tenant_id, ...)`
+// が `no such column: tenant_id` で失敗し、`validateAndMigrate` に到達せず
+// app 起動が完全に block された。
+//
+// ## 責務分離 (3 dimension SSOT、再発防止 Issue)
+//
+// schema 変更 PR では以下 **3 file** を必ず同期更新する:
+//
+// 1. `src/lib/server/db/schema.ts` — drizzle table 定義 (TypeScript 型 SSOT)
+// 2. `src/lib/server/db/create-tables.ts` — `CREATE TABLE/INDEX IF NOT EXISTS`
+//    群 (新規 DB / dev / CI 用の素朴 init)
+// 3. **`src/lib/server/db/migration/lazy-startup-migrations.ts` (本 file)** —
+//    既存 production DB を新 schema にアップグレードする shadow-table
+//    recreation / DROP COLUMN 系 migration
+//
+// (1) と (2) を更新しただけでは既存 production DB は壊れる。本 file の更新
+// 漏れは NUC startup blocking という形で爆発するため、schema 破壊変更 PR は
+// 必ず本 file へ migration を追加すること。
+//
+// ## 実行順序
+//
+// `client.ts` で SQLite mode 時に以下の順序で実行:
+//
+// 1. `applyLazyStartupMigrations(sqlite)` ← **本 file**
+//    既存 production DB の旧 schema を新 schema 互換に揃える
+// 2. `sqlite.exec(SQL_CREATE_TABLES)`
+//    新規 table / index を idempotent に作成
+// 3. `validateAndMigrate(sqlite)`
+//    drizzle schema との差分検出 + 安全な `ALTER TABLE ADD COLUMN` 自動適用
+//
+// ## 冪等性
+//
+// 各 migration block は `tableExists` / `hasColumn` / `hasFkToActivities`
+// 等の guard で「既に新形式なら skip」を保証する。複数回呼んでも no-op。
+
+import type Database from 'better-sqlite3';
+
+interface ColumnInfo {
+	name: string;
+}
+
+interface ForeignKeyInfo {
+	id: number;
+	seq: number;
+	table: string;
+	from: string;
+	to: string;
+	on_update: string;
+	on_delete: string;
+	match: string;
+}
+
+function tableExists(db: Database.Database, name: string): boolean {
+	return !!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?").get(name);
+}
+
+function hasColumn(db: Database.Database, table: string, column: string): boolean {
+	if (!tableExists(db, table)) return false;
+	const cols = db.prepare(`PRAGMA table_info(${table})`).all() as ColumnInfo[];
+	return cols.some((c) => c.name === column);
+}
+
+function hasFkToActivities(db: Database.Database, table: string): boolean {
+	if (!tableExists(db, table)) return false;
+	const fks = db.prepare(`PRAGMA foreign_key_list(${table})`).all() as ForeignKeyInfo[];
+	return fks.some((fk) => fk.from === 'activity_id' && fk.table === 'activities');
+}
+
+/**
+ * #1755 (#1709-A) 後半: `checklist_templates.kind` 列削除 + 旧 'routine' レコード drop。
+ * 持ち物純化 (旧 routine は `activities.priority='must'` に役割移管)。
+ */
+function migrateChecklistTemplatesDropKind(db: Database.Database): void {
+	if (!tableExists(db, 'checklist_templates') || !hasColumn(db, 'checklist_templates', 'kind')) {
+		return;
+	}
+	const dropped = db.prepare("DELETE FROM checklist_templates WHERE kind = 'routine'").run();
+	console.log(
+		`[lazy-migrate #1755] deleted ${dropped.changes} legacy 'routine' rows from checklist_templates`,
+	);
+	db.exec('ALTER TABLE checklist_templates DROP COLUMN kind;');
+	console.log('[lazy-migrate #1755] dropped checklist_templates.kind column');
+}
+
+/**
+ * #2362 PR-3 (Phase 7b-2a): activity 系テーブルの FK target を
+ * 旧 `activities` から `child_activities` に切替。
+ *
+ * SQLite は FK target 変更を直接サポートしないため shadow table 再作成 pattern。
+ * `child_activity_preferences` のみ ON DELETE CASCADE を維持。
+ *
+ * 対象: activity_logs / daily_missions / activity_mastery / child_activity_preferences
+ */
+function migrateActivityFkSwitchover(db: Database.Database): void {
+	const needs =
+		hasFkToActivities(db, 'activity_logs') ||
+		hasFkToActivities(db, 'daily_missions') ||
+		hasFkToActivities(db, 'activity_mastery') ||
+		hasFkToActivities(db, 'child_activity_preferences');
+	if (!needs) return;
+
+	console.log(
+		'[lazy-migrate #2362-PR3] switching activity_id FK target: activities → child_activities',
+	);
+
+	if (hasFkToActivities(db, 'activity_logs')) {
+		db.exec(`
+			CREATE TABLE activity_logs_new (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				child_id INTEGER NOT NULL REFERENCES children(id),
+				activity_id INTEGER NOT NULL REFERENCES child_activities(id),
+				points INTEGER NOT NULL,
+				streak_days INTEGER NOT NULL DEFAULT 1,
+				streak_bonus INTEGER NOT NULL DEFAULT 0,
+				recorded_date TEXT NOT NULL,
+				recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				cancelled INTEGER NOT NULL DEFAULT 0
+			);
+			INSERT INTO activity_logs_new (id, child_id, activity_id, points, streak_days, streak_bonus, recorded_date, recorded_at, cancelled)
+				SELECT id, child_id, activity_id, points, streak_days, streak_bonus, recorded_date, recorded_at, cancelled FROM activity_logs;
+			DROP TABLE activity_logs;
+			ALTER TABLE activity_logs_new RENAME TO activity_logs;
+			CREATE INDEX idx_activity_logs_daily ON activity_logs(child_id, activity_id, recorded_date);
+			CREATE INDEX idx_activity_logs_child_date ON activity_logs(child_id, recorded_date);
+			CREATE INDEX idx_activity_logs_activity ON activity_logs(activity_id);
+			CREATE INDEX idx_activity_logs_streak ON activity_logs(child_id, activity_id, recorded_date);
+		`);
+		console.log('[lazy-migrate #2362-PR3]   → activity_logs done');
+	}
+
+	if (hasFkToActivities(db, 'daily_missions')) {
+		db.exec(`
+			CREATE TABLE daily_missions_new (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				child_id INTEGER NOT NULL REFERENCES children(id),
+				mission_date TEXT NOT NULL,
+				activity_id INTEGER NOT NULL REFERENCES child_activities(id),
+				completed INTEGER NOT NULL DEFAULT 0,
+				completed_at TEXT
+			);
+			INSERT INTO daily_missions_new (id, child_id, mission_date, activity_id, completed, completed_at)
+				SELECT id, child_id, mission_date, activity_id, completed, completed_at FROM daily_missions;
+			DROP TABLE daily_missions;
+			ALTER TABLE daily_missions_new RENAME TO daily_missions;
+			CREATE UNIQUE INDEX idx_daily_missions_unique ON daily_missions(child_id, mission_date, activity_id);
+			CREATE INDEX idx_daily_missions_child_date ON daily_missions(child_id, mission_date);
+		`);
+		console.log('[lazy-migrate #2362-PR3]   → daily_missions done');
+	}
+
+	if (hasFkToActivities(db, 'activity_mastery')) {
+		db.exec(`
+			CREATE TABLE activity_mastery_new (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				child_id INTEGER NOT NULL REFERENCES children(id),
+				activity_id INTEGER NOT NULL REFERENCES child_activities(id),
+				total_count INTEGER NOT NULL DEFAULT 0,
+				level INTEGER NOT NULL DEFAULT 1,
+				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+			);
+			INSERT INTO activity_mastery_new (id, child_id, activity_id, total_count, level, updated_at)
+				SELECT id, child_id, activity_id, total_count, level, updated_at FROM activity_mastery;
+			DROP TABLE activity_mastery;
+			ALTER TABLE activity_mastery_new RENAME TO activity_mastery;
+			CREATE UNIQUE INDEX idx_activity_mastery_child_activity ON activity_mastery(child_id, activity_id);
+		`);
+		console.log('[lazy-migrate #2362-PR3]   → activity_mastery done');
+	}
+
+	if (hasFkToActivities(db, 'child_activity_preferences')) {
+		db.exec(`
+			CREATE TABLE child_activity_preferences_new (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				child_id INTEGER NOT NULL REFERENCES children(id) ON DELETE CASCADE,
+				activity_id INTEGER NOT NULL REFERENCES child_activities(id) ON DELETE CASCADE,
+				is_pinned INTEGER NOT NULL DEFAULT 0,
+				pin_order INTEGER,
+				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+			);
+			INSERT INTO child_activity_preferences_new (id, child_id, activity_id, is_pinned, pin_order, created_at, updated_at)
+				SELECT id, child_id, activity_id, is_pinned, pin_order, created_at, updated_at FROM child_activity_preferences;
+			DROP TABLE child_activity_preferences;
+			ALTER TABLE child_activity_preferences_new RENAME TO child_activity_preferences;
+			CREATE UNIQUE INDEX idx_child_activity_prefs_unique ON child_activity_preferences(child_id, activity_id);
+			CREATE INDEX idx_child_activity_prefs_child ON child_activity_preferences(child_id);
+			CREATE INDEX idx_child_activity_prefs_pinned ON child_activity_preferences(child_id, is_pinned);
+		`);
+		console.log('[lazy-migrate #2362-PR3]   → child_activity_preferences done');
+	}
+}
+
+/**
+ * #2362 PR-5 (Phase 1): `checklist_templates` flip
+ *
+ * - 旧: `checklist_templates.child_id NOT NULL` (per-child instance)
+ * - 新: `tenant_id NOT NULL` 列追加 + `child_id` 列削除
+ *   + `checklist_template_assignments` 新規 (template ↔ child N:M binding)
+ *
+ * 既存 per-child template は family master + assignment 1 行に変換。
+ * `checklist_logs` / `checklist_overrides` の `child_id` は維持 (per-child
+ * progress / override の事実履歴)。
+ *
+ * SSOT: docs/design/data-model-resource-scope.md §4.2
+ */
+function migrateChecklistTemplatesFamilyFlip(db: Database.Database): void {
+	if (
+		!tableExists(db, 'checklist_templates') ||
+		!hasColumn(db, 'checklist_templates', 'child_id')
+	) {
+		return;
+	}
+
+	console.log('[lazy-migrate #2362-PR5] flipping checklist_templates: per-child → family master');
+
+	const hasTenantId = hasColumn(db, 'checklist_templates', 'tenant_id');
+
+	// 1. 新 schema の shadow table を作成 (create-tables.ts と同一形状)
+	db.exec(`
+		CREATE TABLE checklist_templates_new (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			tenant_id TEXT NOT NULL DEFAULT 'default',
+			name TEXT NOT NULL,
+			icon TEXT NOT NULL DEFAULT '📋',
+			points_per_item INTEGER NOT NULL DEFAULT 2,
+			completion_bonus INTEGER NOT NULL DEFAULT 5,
+			time_slot TEXT NOT NULL DEFAULT 'anytime',
+			is_active INTEGER NOT NULL DEFAULT 1,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			is_archived INTEGER NOT NULL DEFAULT 0,
+			archived_reason TEXT,
+			source_preset_id TEXT
+		);
+	`);
+
+	// 2. 既存 row を移行。tenant_id 既存値 or 'default'。
+	//    time_slot / is_archived は旧 schema で nullable だった可能性があるので COALESCE で補完。
+	if (hasTenantId) {
+		db.exec(`
+			INSERT INTO checklist_templates_new
+				(id, tenant_id, name, icon, points_per_item, completion_bonus, time_slot, is_active,
+				 created_at, updated_at, is_archived, archived_reason, source_preset_id)
+			SELECT id, COALESCE(tenant_id, 'default'), name, icon, points_per_item, completion_bonus,
+				COALESCE(time_slot, 'anytime'), is_active, created_at, updated_at,
+				COALESCE(is_archived, 0), archived_reason, source_preset_id FROM checklist_templates;
+		`);
+	} else {
+		db.exec(`
+			INSERT INTO checklist_templates_new
+				(id, tenant_id, name, icon, points_per_item, completion_bonus, time_slot, is_active,
+				 created_at, updated_at, is_archived, archived_reason, source_preset_id)
+			SELECT id, 'default', name, icon, points_per_item, completion_bonus,
+				COALESCE(time_slot, 'anytime'), is_active, created_at, updated_at,
+				COALESCE(is_archived, 0), archived_reason, source_preset_id FROM checklist_templates;
+		`);
+	}
+
+	// 3. 旧 per-child template の child_id 値を assignments 1 row に移行
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS checklist_template_assignments (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			template_id INTEGER NOT NULL REFERENCES checklist_templates(id),
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_checklist_template_assignments_unique
+			ON checklist_template_assignments(template_id, child_id);
+		CREATE INDEX IF NOT EXISTS idx_checklist_template_assignments_child
+			ON checklist_template_assignments(child_id);
+		INSERT INTO checklist_template_assignments (template_id, child_id, created_at)
+			SELECT id, child_id, created_at FROM checklist_templates;
+	`);
+
+	const assignmentCount = (
+		db.prepare('SELECT COUNT(*) AS c FROM checklist_template_assignments').get() as { c: number }
+	).c;
+	console.log(
+		`[lazy-migrate #2362-PR5]   migrated ${assignmentCount} per-child rows to template_assignments`,
+	);
+
+	// 4. 旧 table を drop + new を rename + index 再作成
+	db.exec(`
+		DROP TABLE checklist_templates;
+		ALTER TABLE checklist_templates_new RENAME TO checklist_templates;
+		CREATE INDEX IF NOT EXISTS idx_checklist_templates_tenant_archived
+			ON checklist_templates(tenant_id, is_archived);
+	`);
+	console.log('[lazy-migrate #2362-PR5]   → flip complete');
+}
+
+/**
+ * startup 時に `SQL_CREATE_TABLES` 実行より **前** に呼ぶ。
+ *
+ * - 各 migration は冪等 (既に新形式なら skip)
+ * - 全 migration を `foreign_keys = OFF` 下で実行 (shadow table 再作成中の
+ *   FK 整合性 trip を回避)
+ * - 終了時に `foreign_keys = ON` に必ず戻す
+ * - エラー時は呼び出し元 (`client.ts`) に伝播し、`SCHEMA_VALIDATION_MODE`
+ *   分岐で process.exit するか継続するかを判断する
+ *
+ * 注: 本 helper は単一 SQLite ファイル (NUC / local dev) を前提。
+ *     DynamoDB バックエンドでは呼ばない。
+ */
+export function applyLazyStartupMigrations(db: Database.Database): void {
+	const fkBefore = db.pragma('foreign_keys', { simple: true }) as number;
+	db.pragma('foreign_keys = OFF');
+	try {
+		migrateChecklistTemplatesDropKind(db);
+		migrateActivityFkSwitchover(db);
+		migrateChecklistTemplatesFamilyFlip(db);
+	} finally {
+		// shadow-table recreation 中の FK 制約 trip を防ぐため OFF にしたが、
+		// 終了時に必ず元 (通常 ON) に戻す。
+		db.pragma(`foreign_keys = ${fkBefore ? 'ON' : 'OFF'}`);
+	}
+}

--- a/tests/integration/db/startup-upgrade-path.test.ts
+++ b/tests/integration/db/startup-upgrade-path.test.ts
@@ -1,0 +1,278 @@
+// tests/integration/db/startup-upgrade-path.test.ts
+//
+// startup 経路 (`client.ts` と同 sequence) を full reproduction し、
+// legacy production schema → 新 schema へ no-error で upgrade されることを
+// 検証する。Issue #2508 (NUC startup failure 2026-05-27) の回帰テスト。
+//
+// reproduction:
+//   1. legacy production schema (child_id NOT NULL / kind 列あり / FK→activities) を seed
+//   2. applyLazyStartupMigrations(db)     ← 本 hotfix で追加した step
+//   3. db.exec(SQL_CREATE_TABLES)         ← `no such column: tenant_id` で fail していた step
+//   4. validateAndMigrate(db)             ← schema-validator による drizzle 差分追加
+//   → 3 全 step が no-error で完了し、最終 schema が正しい状態であることを assert
+//
+// 本 hotfix 前: step 3 が `SqliteError: no such column: tenant_id` で fail → app crash
+
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { SQL_CREATE_TABLES } from '../../../src/lib/server/db/create-tables';
+import { applyLazyStartupMigrations } from '../../../src/lib/server/db/migration/lazy-startup-migrations';
+import { validateAndMigrate } from '../../../src/lib/server/db/schema-validator';
+
+interface ColumnInfo {
+	name: string;
+	type: string;
+	notnull: number;
+}
+interface FkInfo {
+	table: string;
+	from: string;
+	to: string;
+}
+
+function getColumns(db: Database.Database, table: string): ColumnInfo[] {
+	return db.prepare(`PRAGMA table_info(${table})`).all() as ColumnInfo[];
+}
+function tableExists(db: Database.Database, name: string): boolean {
+	return !!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?").get(name);
+}
+function fkTargets(db: Database.Database, table: string): FkInfo[] {
+	return db.prepare(`PRAGMA foreign_key_list(${table})`).all() as FkInfo[];
+}
+
+/**
+ * NUC production (#2508 発生時点 2026-05-27) の旧 schema を再現する seed。
+ * children / categories / activities / child_activities は production NUC で
+ * 既に新 schema を満たすため `CREATE TABLE IF NOT EXISTS` 後の `CREATE INDEX`
+ * (is_archived 等) が成功する状態を再現する。
+ */
+function seedLegacyProductionDb(db: Database.Database): void {
+	db.pragma('foreign_keys = OFF');
+	db.exec(`
+		CREATE TABLE children (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			nickname TEXT NOT NULL,
+			age INTEGER NOT NULL DEFAULT 5,
+			birth_date TEXT,
+			theme TEXT NOT NULL DEFAULT 'pink',
+			ui_mode TEXT NOT NULL DEFAULT 'preschool',
+			avatar_url TEXT,
+			display_config TEXT,
+			user_id TEXT,
+			birthday_bonus_multiplier REAL NOT NULL DEFAULT 1.0,
+			last_birthday_bonus_year INTEGER,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			is_archived INTEGER NOT NULL DEFAULT 0,
+			archived_reason TEXT
+		);
+		-- SQL_CREATE_TABLES の categories と同形 (5 列、INSERT OR IGNORE と整合)
+		CREATE TABLE categories (
+			id INTEGER PRIMARY KEY,
+			code TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			icon TEXT,
+			color TEXT
+		);
+		CREATE TABLE activities (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			category_id INTEGER REFERENCES categories(id),
+			icon TEXT NOT NULL DEFAULT '⭐',
+			base_points INTEGER NOT NULL DEFAULT 5,
+			is_visible INTEGER NOT NULL DEFAULT 1,
+			sort_order INTEGER NOT NULL DEFAULT 0,
+			source TEXT NOT NULL DEFAULT 'seed',
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			is_archived INTEGER NOT NULL DEFAULT 0,
+			archived_reason TEXT,
+			priority TEXT NOT NULL DEFAULT 'optional'
+		);
+		CREATE TABLE child_activities (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			name TEXT NOT NULL,
+			category_id INTEGER REFERENCES categories(id),
+			icon TEXT NOT NULL DEFAULT '⭐',
+			base_points INTEGER NOT NULL DEFAULT 5,
+			is_visible INTEGER NOT NULL DEFAULT 1,
+			sort_order INTEGER NOT NULL DEFAULT 0,
+			source TEXT NOT NULL DEFAULT 'seed',
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			is_archived INTEGER NOT NULL DEFAULT 0,
+			archived_reason TEXT,
+			priority TEXT NOT NULL DEFAULT 'optional'
+		);
+		-- 旧 schema (#2508 発生時点と一致): child_id NOT NULL + kind 列あり + tenant_id なし
+		CREATE TABLE checklist_templates (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			name TEXT NOT NULL,
+			icon TEXT NOT NULL DEFAULT '📋',
+			points_per_item INTEGER NOT NULL DEFAULT 2,
+			completion_bonus INTEGER NOT NULL DEFAULT 5,
+			time_slot TEXT,
+			is_active INTEGER NOT NULL DEFAULT 1,
+			is_archived INTEGER,
+			archived_reason TEXT,
+			source_preset_id TEXT,
+			kind TEXT NOT NULL DEFAULT 'routine',
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE activity_logs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			activity_id INTEGER NOT NULL REFERENCES activities(id),
+			points INTEGER NOT NULL,
+			streak_days INTEGER NOT NULL DEFAULT 1,
+			streak_bonus INTEGER NOT NULL DEFAULT 0,
+			recorded_date TEXT NOT NULL,
+			recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			cancelled INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE daily_missions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			mission_date TEXT NOT NULL,
+			activity_id INTEGER NOT NULL REFERENCES activities(id),
+			completed INTEGER NOT NULL DEFAULT 0,
+			completed_at TEXT
+		);
+		CREATE TABLE activity_mastery (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			activity_id INTEGER NOT NULL REFERENCES activities(id),
+			total_count INTEGER NOT NULL DEFAULT 0,
+			level INTEGER NOT NULL DEFAULT 1,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE child_activity_preferences (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id) ON DELETE CASCADE,
+			activity_id INTEGER NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
+			is_pinned INTEGER NOT NULL DEFAULT 0,
+			pin_order INTEGER,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+	`);
+	db.pragma('foreign_keys = ON');
+}
+
+describe('startup upgrade path (legacy NUC production DB → new schema)', () => {
+	it('client.ts と同 sequence (lazy → SQL_CREATE_TABLES → validateAndMigrate) で no-error 完了する', () => {
+		const db = new Database(':memory:');
+		db.pragma('foreign_keys = ON');
+
+		try {
+			seedLegacyProductionDb(db);
+
+			// === step 1: shadow-table recreation 系 (本 hotfix で追加された step) ===
+			expect(() => applyLazyStartupMigrations(db)).not.toThrow();
+
+			// === step 2: SQL_CREATE_TABLES (本 hotfix 前はここで `no such column: tenant_id` fail) ===
+			expect(() => db.exec(SQL_CREATE_TABLES)).not.toThrow();
+
+			// === step 3: drizzle validateAndMigrate (個別 ALTER ADD COLUMN) ===
+			// validateAndMigrate は schema 差分を warn として残すが throw はしない。
+			// extraColumns 警告は legacy schema との差分由来なので無視できる。
+			const result = validateAndMigrate(db);
+			expect(result.errors, `unexpected errors: ${JSON.stringify(result.errors)}`).toEqual([]);
+
+			// === 最終 schema 検証 ===
+			// checklist_templates: kind 列なし / tenant_id NOT NULL / child_id 列なし
+			const ctCols = getColumns(db, 'checklist_templates');
+			expect(ctCols.some((c) => c.name === 'kind')).toBe(false);
+			expect(ctCols.some((c) => c.name === 'child_id')).toBe(false);
+			const tenantIdCol = ctCols.find((c) => c.name === 'tenant_id');
+			expect(tenantIdCol?.notnull).toBe(1);
+
+			// checklist_template_assignments table 作成
+			expect(tableExists(db, 'checklist_template_assignments')).toBe(true);
+
+			// activity_* FK target = child_activities
+			for (const table of [
+				'activity_logs',
+				'daily_missions',
+				'activity_mastery',
+				'child_activity_preferences',
+			]) {
+				const fks = fkTargets(db, table);
+				const activityFk = fks.find((fk) => fk.from === 'activity_id');
+				expect(activityFk?.table, `${table}.activity_id FK target`).toBe('child_activities');
+			}
+		} finally {
+			db.close();
+		}
+	});
+
+	it('legacy schema + 既存データ (per-child template 2 件 + activity_logs 3 件) を保全する', () => {
+		const db = new Database(':memory:');
+		db.pragma('foreign_keys = ON');
+
+		try {
+			seedLegacyProductionDb(db);
+			db.prepare("INSERT INTO children (nickname, age) VALUES ('A', 5)").run();
+			db.prepare("INSERT INTO children (nickname, age) VALUES ('B', 7)").run();
+			db.prepare("INSERT INTO activities (name) VALUES ('walk')").run();
+			db.prepare("INSERT INTO child_activities (child_id, name) VALUES (1, 'walk-A')").run();
+			db.prepare(
+				"INSERT INTO checklist_templates (child_id, name, kind) VALUES (1, 'morning', 'belongings')",
+			).run();
+			db.prepare(
+				"INSERT INTO checklist_templates (child_id, name, kind) VALUES (2, 'evening', 'belongings')",
+			).run();
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (1, 1, 10, '2026-05-27')",
+			).run();
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (1, 1, 5, '2026-05-26')",
+			).run();
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (2, 1, 8, '2026-05-26')",
+			).run();
+
+			applyLazyStartupMigrations(db);
+			db.exec(SQL_CREATE_TABLES);
+			validateAndMigrate(db);
+
+			// templates 2 件 (family master) + assignments 2 件 (旧 per-child child_id)
+			const tplCnt = db.prepare('SELECT COUNT(*) AS c FROM checklist_templates').get() as {
+				c: number;
+			};
+			expect(tplCnt.c).toBe(2);
+			const assignCnt = db
+				.prepare('SELECT COUNT(*) AS c FROM checklist_template_assignments')
+				.get() as { c: number };
+			expect(assignCnt.c).toBe(2);
+
+			// activity_logs 3 件保全
+			const logCnt = db.prepare('SELECT COUNT(*) AS c FROM activity_logs').get() as { c: number };
+			expect(logCnt.c).toBe(3);
+		} finally {
+			db.close();
+		}
+	});
+
+	it('既に新 schema 状態の DB に対して再起動シーケンスを流しても no-error (冪等)', () => {
+		const db = new Database(':memory:');
+		db.pragma('foreign_keys = ON');
+
+		try {
+			// 1 回目
+			seedLegacyProductionDb(db);
+			applyLazyStartupMigrations(db);
+			db.exec(SQL_CREATE_TABLES);
+			validateAndMigrate(db);
+
+			// 2 回目 (再起動相当): 全 step が no-error で skip
+			expect(() => applyLazyStartupMigrations(db)).not.toThrow();
+			expect(() => db.exec(SQL_CREATE_TABLES)).not.toThrow();
+			const result = validateAndMigrate(db);
+			expect(result.errors).toEqual([]);
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/tests/unit/db/lazy-startup-migrations.test.ts
+++ b/tests/unit/db/lazy-startup-migrations.test.ts
@@ -268,6 +268,61 @@ describe('applyLazyStartupMigrations', () => {
 		});
 	});
 
+	describe('transaction rollback on mid-failure (#2509)', () => {
+		// 各 migration block は内部で transaction を張るため、ALTER / INSERT / DROP の
+		// 途中で fail した場合は SQLite が自動 ROLLBACK し partial state は残らない。
+		// partial state が残ると次回起動時 guard 判定 (hasColumn / hasFkToActivities)
+		// が破れて永続的 startup loop に陥るため、atomic 化は #2508 の構造的再発防止
+		// の核心。本ケースでは「shadow table 作成 → INSERT 途中で table 不在 error」
+		// を強制し、ROLLBACK が機能して旧 schema が完全に残ることを検証する。
+
+		it('shadow table が既存と衝突して family flip が fail した場合、旧 schema (child_id 列) が完全に残る', () => {
+			seedLegacyProductionSchema(db);
+			db.prepare("INSERT INTO children (nickname, age) VALUES ('A', 5)").run();
+			db.prepare(
+				"INSERT INTO checklist_templates (child_id, name, kind) VALUES (1, 'morning', 'belongings')",
+			).run();
+
+			// 強制 fail: shadow table と同名の table を先に作っておき、
+			// `CREATE TABLE checklist_templates_new (...)` が SQLITE_ERROR で落ちるようにする。
+			// これは family flip の step 1 で必ず最初に投げられる DDL なので、
+			// tx 内の全 step (INSERT / assignments 作成 / DROP / RENAME) がまだ実行されない
+			// ことが確認できる。tx wrap がなければ migrateChecklistTemplatesDropKind の DELETE+
+			// DROP COLUMN は既に commit されてしまい、`kind` 列の削除と family flip 部分実装
+			// の二重不整合が残る (#2508 と同型の startup loop リスク)。
+			db.exec('CREATE TABLE checklist_templates_new (placeholder TEXT);');
+
+			let caught: Error | undefined;
+			try {
+				applyLazyStartupMigrations(db);
+			} catch (err) {
+				caught = err as Error;
+			}
+
+			// 例外は呼び出し元に伝播されている (fail-fast)
+			expect(caught).toBeDefined();
+			expect(caught?.message).toMatch(/already exists|checklist_templates_new/);
+
+			// migrateChecklistTemplatesDropKind 自体は family flip の前に走る tx なので
+			// 成功して commit 済 (kind 列削除 + 'routine' 行削除)。それは想定挙動。
+			expect(hasColumn(db, 'checklist_templates', 'kind')).toBe(false);
+
+			// **核心 assertion**: family flip の tx が ROLLBACK されたため、
+			// checklist_templates は旧 schema のまま (child_id 列が残り、tenant_id 不在)、
+			// checklist_template_assignments table も作成されていない。
+			// partial state (例: assignments 作成済 + 旧 templates もそのまま) は残らない。
+			expect(hasColumn(db, 'checklist_templates', 'child_id')).toBe(true);
+			expect(hasColumn(db, 'checklist_templates', 'tenant_id')).toBe(false);
+			expect(tableExists(db, 'checklist_template_assignments')).toBe(false);
+
+			// 旧 row 数も保全
+			const remaining = (
+				db.prepare('SELECT COUNT(*) AS c FROM checklist_templates').get() as { c: number }
+			).c;
+			expect(remaining).toBe(1);
+		});
+	});
+
 	describe('foreign_keys pragma 状態の保全', () => {
 		it('呼び出し前後で foreign_keys=ON の状態が維持される', () => {
 			seedLegacyProductionSchema(db);

--- a/tests/unit/db/lazy-startup-migrations.test.ts
+++ b/tests/unit/db/lazy-startup-migrations.test.ts
@@ -1,0 +1,293 @@
+// tests/unit/db/lazy-startup-migrations.test.ts
+//
+// applyLazyStartupMigrations の冪等性 + shadow-table recreation
+// 動作検証。NUC startup failure (Issue #2508) の回帰テスト。
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { applyLazyStartupMigrations } from '$lib/server/db/migration/lazy-startup-migrations';
+
+interface ColumnInfo {
+	name: string;
+	type: string;
+	notnull: number;
+	dflt_value: string | null;
+}
+interface FkInfo {
+	table: string;
+	from: string;
+	to: string;
+}
+
+function getColumns(db: Database.Database, table: string): ColumnInfo[] {
+	return db.prepare(`PRAGMA table_info(${table})`).all() as ColumnInfo[];
+}
+function hasColumn(db: Database.Database, table: string, column: string): boolean {
+	return getColumns(db, table).some((c) => c.name === column);
+}
+function tableExists(db: Database.Database, name: string): boolean {
+	return !!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?").get(name);
+}
+function fkTargets(db: Database.Database, table: string): FkInfo[] {
+	return db.prepare(`PRAGMA foreign_key_list(${table})`).all() as FkInfo[];
+}
+
+/**
+ * production NUC の旧 schema をそのまま再現した fixture を作成する。
+ * - checklist_templates: child_id NOT NULL, tenant_id 列なし, kind 列あり
+ * - activity_logs / daily_missions / activity_mastery / child_activity_preferences:
+ *   FK target = activities (旧 target)
+ * - children / activities / child_activities table も最低限作成
+ */
+function seedLegacyProductionSchema(db: Database.Database): void {
+	db.pragma('foreign_keys = OFF');
+	db.exec(`
+		CREATE TABLE children (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			nickname TEXT NOT NULL,
+			age INTEGER NOT NULL DEFAULT 5
+		);
+		CREATE TABLE activities (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL
+		);
+		CREATE TABLE child_activities (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			name TEXT NOT NULL
+		);
+
+		-- 旧 schema (NUC production と一致): child_id NOT NULL + tenant_id なし + kind あり
+		CREATE TABLE checklist_templates (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			name TEXT NOT NULL,
+			icon TEXT NOT NULL DEFAULT '📋',
+			points_per_item INTEGER NOT NULL DEFAULT 2,
+			completion_bonus INTEGER NOT NULL DEFAULT 5,
+			time_slot TEXT,
+			is_active INTEGER NOT NULL DEFAULT 1,
+			is_archived INTEGER,
+			archived_reason TEXT,
+			source_preset_id TEXT,
+			kind TEXT NOT NULL DEFAULT 'routine',
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+
+		-- 旧 FK target: activities
+		CREATE TABLE activity_logs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			activity_id INTEGER NOT NULL REFERENCES activities(id),
+			points INTEGER NOT NULL,
+			streak_days INTEGER NOT NULL DEFAULT 1,
+			streak_bonus INTEGER NOT NULL DEFAULT 0,
+			recorded_date TEXT NOT NULL,
+			recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			cancelled INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE daily_missions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			mission_date TEXT NOT NULL,
+			activity_id INTEGER NOT NULL REFERENCES activities(id),
+			completed INTEGER NOT NULL DEFAULT 0,
+			completed_at TEXT
+		);
+		CREATE TABLE activity_mastery (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			activity_id INTEGER NOT NULL REFERENCES activities(id),
+			total_count INTEGER NOT NULL DEFAULT 0,
+			level INTEGER NOT NULL DEFAULT 1,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE child_activity_preferences (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id) ON DELETE CASCADE,
+			activity_id INTEGER NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
+			is_pinned INTEGER NOT NULL DEFAULT 0,
+			pin_order INTEGER,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+	`);
+	db.pragma('foreign_keys = ON');
+}
+
+describe('applyLazyStartupMigrations', () => {
+	let db: Database.Database;
+
+	beforeEach(() => {
+		db = new Database(':memory:');
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe('legacy production schema → new schema upgrade', () => {
+		beforeEach(() => {
+			seedLegacyProductionSchema(db);
+		});
+
+		it('checklist_templates.kind 列を drop して routine レコードを削除する (#1755)', () => {
+			db.prepare("INSERT INTO children (nickname, age) VALUES ('A', 5)").run();
+			db.prepare(
+				"INSERT INTO checklist_templates (child_id, name, kind) VALUES (1, 'routine-template', 'routine')",
+			).run();
+			db.prepare(
+				"INSERT INTO checklist_templates (child_id, name, kind) VALUES (1, 'belongings-template', 'belongings')",
+			).run();
+
+			applyLazyStartupMigrations(db);
+
+			expect(hasColumn(db, 'checklist_templates', 'kind')).toBe(false);
+			// 'routine' 1 件は削除、'belongings' 1 件は family flip で生き残る
+			const remaining = db.prepare('SELECT name FROM checklist_templates ORDER BY id').all() as {
+				name: string;
+			}[];
+			expect(remaining.map((r) => r.name)).toEqual(['belongings-template']);
+		});
+
+		it('checklist_templates を child_id (NOT NULL) → tenant_id (NOT NULL) に flip し assignments に migrate する (#2362 PR-5)', () => {
+			db.prepare("INSERT INTO children (nickname, age) VALUES ('A', 5)").run();
+			db.prepare("INSERT INTO children (nickname, age) VALUES ('B', 7)").run();
+			db.prepare(
+				"INSERT INTO checklist_templates (child_id, name, kind) VALUES (1, 'morning', 'belongings')",
+			).run();
+			db.prepare(
+				"INSERT INTO checklist_templates (child_id, name, kind) VALUES (2, 'evening', 'belongings')",
+			).run();
+
+			applyLazyStartupMigrations(db);
+
+			// checklist_templates: tenant_id NOT NULL 列が存在、child_id 列なし
+			const cols = getColumns(db, 'checklist_templates');
+			const tenantIdCol = cols.find((c) => c.name === 'tenant_id');
+			expect(tenantIdCol).toBeDefined();
+			expect(tenantIdCol?.notnull).toBe(1);
+			expect(cols.some((c) => c.name === 'child_id')).toBe(false);
+
+			// assignments table 存在 + 旧 per-child の child_id 値 2 件が assignments に移っている
+			expect(tableExists(db, 'checklist_template_assignments')).toBe(true);
+			const assignments = db
+				.prepare('SELECT template_id, child_id FROM checklist_template_assignments ORDER BY id')
+				.all();
+			expect(assignments).toEqual([
+				{ template_id: 1, child_id: 1 },
+				{ template_id: 2, child_id: 2 },
+			]);
+
+			// templates 自体は family master として 2 件残る (tenant_id='default')
+			const templates = db
+				.prepare('SELECT id, tenant_id, name FROM checklist_templates ORDER BY id')
+				.all();
+			expect(templates).toEqual([
+				{ id: 1, tenant_id: 'default', name: 'morning' },
+				{ id: 2, tenant_id: 'default', name: 'evening' },
+			]);
+		});
+
+		it('activity_logs / daily_missions / activity_mastery / child_activity_preferences の FK target を activities → child_activities に切替える (#2362 PR-3)', () => {
+			applyLazyStartupMigrations(db);
+
+			for (const table of [
+				'activity_logs',
+				'daily_missions',
+				'activity_mastery',
+				'child_activity_preferences',
+			]) {
+				const fks = fkTargets(db, table);
+				const activityFk = fks.find((fk) => fk.from === 'activity_id');
+				expect(activityFk, `${table}.activity_id FK target`).toBeDefined();
+				expect(activityFk?.table, `${table}.activity_id FK target`).toBe('child_activities');
+			}
+		});
+
+		it('既存データを失わずに FK target を切替える (activity_logs の row 数保全)', () => {
+			db.prepare("INSERT INTO children (nickname, age) VALUES ('A', 5)").run();
+			db.prepare("INSERT INTO activities (name) VALUES ('walk')").run();
+			db.prepare("INSERT INTO child_activities (child_id, name) VALUES (1, 'walk-personal')").run();
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (1, 1, 10, '2026-05-27')",
+			).run();
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (1, 1, 5, '2026-05-26')",
+			).run();
+
+			applyLazyStartupMigrations(db);
+
+			const cnt = db.prepare('SELECT COUNT(*) AS c FROM activity_logs').get() as { c: number };
+			expect(cnt.c).toBe(2);
+		});
+	});
+
+	describe('冪等性 — 同じ DB に複数回適用しても no-op (or no-error)', () => {
+		it('legacy → new に上げた後、もう一度呼んでも success / 全制約が維持される', () => {
+			seedLegacyProductionSchema(db);
+			applyLazyStartupMigrations(db);
+			// 2 回目: 既に新形式なので全 migration block は guard で skip される
+			expect(() => applyLazyStartupMigrations(db)).not.toThrow();
+
+			// 確認: kind 列なし / tenant_id NOT NULL / assignments table / FK target = child_activities
+			expect(hasColumn(db, 'checklist_templates', 'kind')).toBe(false);
+			expect(hasColumn(db, 'checklist_templates', 'tenant_id')).toBe(true);
+			expect(tableExists(db, 'checklist_template_assignments')).toBe(true);
+
+			const fks = fkTargets(db, 'activity_logs');
+			expect(fks.find((fk) => fk.from === 'activity_id')?.table).toBe('child_activities');
+		});
+
+		it('新規 (empty) DB に対しても no-error で skip する', () => {
+			// 何も seed しない (テーブル 0 件)
+			expect(() => applyLazyStartupMigrations(db)).not.toThrow();
+		});
+
+		it('既に新 schema のみ (kind なし + tenant_id NOT NULL + assignments あり) でも no-op', () => {
+			db.pragma('foreign_keys = OFF');
+			db.exec(`
+				CREATE TABLE children (id INTEGER PRIMARY KEY, nickname TEXT NOT NULL);
+				CREATE TABLE checklist_templates (
+					id INTEGER PRIMARY KEY,
+					tenant_id TEXT NOT NULL DEFAULT 'default',
+					name TEXT NOT NULL
+				);
+				CREATE TABLE checklist_template_assignments (
+					id INTEGER PRIMARY KEY,
+					template_id INTEGER NOT NULL REFERENCES checklist_templates(id),
+					child_id INTEGER NOT NULL REFERENCES children(id)
+				);
+			`);
+			db.pragma('foreign_keys = ON');
+
+			expect(() => applyLazyStartupMigrations(db)).not.toThrow();
+			// tenant_id 列が壊れていない
+			expect(hasColumn(db, 'checklist_templates', 'tenant_id')).toBe(true);
+		});
+	});
+
+	describe('foreign_keys pragma 状態の保全', () => {
+		it('呼び出し前後で foreign_keys=ON の状態が維持される', () => {
+			seedLegacyProductionSchema(db);
+			db.pragma('foreign_keys = ON');
+			expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+
+			applyLazyStartupMigrations(db);
+
+			// migration 実行中は OFF にするが、終了時には呼び出し時の状態 (ON) に戻す
+			expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+		});
+
+		it('呼び出し前 foreign_keys=OFF だった場合はそれを維持する', () => {
+			seedLegacyProductionSchema(db);
+			db.pragma('foreign_keys = OFF');
+			expect(db.pragma('foreign_keys', { simple: true })).toBe(0);
+
+			applyLazyStartupMigrations(db);
+
+			expect(db.pragma('foreign_keys', { simple: true })).toBe(0);
+		});
+	});
+});


### PR DESCRIPTION
[HOTFIX] NUC startup failure 緊急復旧 + 構造的再発防止 (3 dimension SSOT 確立)

## 顧客価値・目的

NUC production app が 2026-05-27 に `SqliteError: no such column: tenant_id` で
起動完全失敗 (HTTP 接続不能、container restart loop、約 6 分間 access 0)。
本 PR で **緊急復旧 (実施済) + 構造的再発防止**を完遂。

NUC self-host 利用ユーザは「セルフホスト = 信頼性 commitment」のもと選択している
ため、startup blocking は Pre-PMF 段階でも信頼性毀損が大きい。ADR-0001 設計書 SSOT
の 3 dimension 化 (schema.ts ↔ create-tables.ts ↔ lazy-startup-migrations.ts) で
PR #2480 で発生した「2 file 同期したが migration helper 漏れ」を構造的に防ぐ。

## 関連 Issue

closes #2508

- Related #2507 (再発防止 CI gate `check-schema-migration-completeness.mjs`、別 PR で実装)
- 原因 PR: #2480 (#2362 PR-5 Phase 1 — checklist_templates flip)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | NUC 復旧 — `/api/health` 200 OK | `curl http://localhost:3000/api/health` (NUC SSH) | `{"status":"ok","schemaValid":true,...}` / 復旧時刻 2026-05-27 07:24 (停止 07:18 から 6 分) |
| AC2 | 復旧前 / 後 schema diff 記録 | NUC container 内 `PRAGMA table_info(checklist_templates)` 比較 | Before: `child_id NOT NULL` + `kind` 列 / After: `tenant_id NOT NULL`、`child_id` / `kind` 列削除、`checklist_template_assignments` table 作成 |
| AC3 | lazy helper 新規作成 | `src/lib/server/db/migration/lazy-startup-migrations.ts` | 3 migration 集約 (kind drop / FK switch / family flip) + 冪等性 guard |
| AC4 | client.ts 修正 | `src/lib/server/db/client.ts` | `applyLazyStartupMigrations(sqlite)` を `SQL_CREATE_TABLES` より前に呼ぶ順序へ |
| AC5 | migrate-local.ts DRY 化 | `scripts/migrate-local.ts` | 重複 shadow-table recreation 削除、lazy helper に delegate |
| AC6 | unit test 追加 | `npx vitest run tests/unit/db/lazy-startup-migrations.test.ts` | 9 / 9 PASS (旧 → 新 schema 変換 / データ保全 / 冪等性 / FK pragma 状態保全) |
| AC7 | integration test 追加 | `npx vitest run tests/integration/db/startup-upgrade-path.test.ts` | 3 / 3 PASS (client.ts sequence reproduction で旧 schema → 新 schema no-error 完了) |
| AC8 | 設計書更新 | `docs/design/08-データベース設計書.md` §「Schema 変更時の lazy migration 必須 SSOT」 | 3 dimension SSOT (schema.ts / create-tables.ts / lazy-startup-migrations.ts) を明文化 |
| AC9 | 再発防止 Issue 起票 | https://github.com/Takenori-Kusaka/ganbari-quest/issues/2507 | #2507 起票完了 (CI gate 設計 + AC1-AC5) |

### ADR-0002 Critical 5 要件

- **E2E 回帰**: `tests/integration/db/startup-upgrade-path.test.ts` で旧 schema fixture + client.ts 同 sequence reproduction → 3 / 3 PASS
- **AC 全完了**: 上記 AC1-AC9 全 [x]
- **提案全実装**: analyst (root-cause-analyst Agent a0c6bcdaa82066bef) の hotfix 設計を全実装
- **5 年齢モード検証**: schema 変更は age-tier 無関係、復旧後 health check で全 API 経路 schema OK を smoke 確認
- **直近 30 日重複変更チェック**: PR #2480 (2026-05-21 merge) が同 file 触ったことを認識、本 hotfix は補完位置付け

## 変更タイプ

- [x] バグ修正 (fix) — production downtime hotfix
- [x] 仕様変更 (refactor) — migration logic を `migration/lazy-startup-migrations.ts` に集約
- [x] テスト追加 (test) — unit 9 + integration 3
- [x] ドキュメント (docs) — `docs/design/08-データベース設計書.md` 3 dimension SSOT 追加

## 影響範囲・変更コンポーネント

- **`src/lib/server/db/`** — `client.ts` startup 順序変更 + `migration/lazy-startup-migrations.ts` 新規
- **`scripts/migrate-local.ts`** — 重複 logic 削除 + lazy helper への delegate
- **`tests/unit/db/`** — `lazy-startup-migrations.test.ts` 新規 (9 tests)
- **`tests/integration/db/`** — `startup-upgrade-path.test.ts` 新規 (3 tests、新規 dir)
- **`docs/design/08-データベース設計書.md`** — §「Schema 変更時の lazy migration 必須 SSOT」追加

## テスト & 安全装置セルフチェック

- [x] vitest unit + integration: 5784 / 5784 PASS (本 PR worktree で実行確認)
- [x] biome check: 0 errors (10 warnings は `console.log` Remove 提案で migration 進捗出力上意図的に残す)
- [x] svelte-check: 0 errors on hotfix-relevant files (54 infra errors は worktree `infra/node_modules/` 未 install 由来の既知問題で本 hotfix 無関係)
- [x] 冪等性 test: 2 回連続呼出で no-error (`lazy-startup-migrations.test.ts` §「冪等性」3 tests)
- [x] FK pragma 状態保全 test: ON / OFF 両方とも呼び出し前後で保全 (同 §「foreign_keys pragma 状態の保全」2 tests)
- [x] NUC 実機 smoke: 復旧後 `/api/health` 200 OK + `schemaValid:true`

## スクリーンショット / ビジュアルデモ

UI 変更なしのため SS 撮影対象外。NUC startup log smoke (復旧後):

```
ganbari-quest-app-1   ganbari-quest-app   "/docker-entrypoint.…"   app
Up 10 seconds (health: starting)   0.0.0.0:3000->3000/tcp, [::]:3000->3000/tcp

app-1  | [SCHEMA] children.active_title_id は DB に存在しますがスキーマ定義にありません（レガシーカラム）
app-1  | [SCHEMA] statuses.value は DB に存在しますがスキーマ定義にありません（レガシーカラム）
app-1  | Listening on http://0.0.0.0:3000
```

API health:

```
$ curl http://localhost:3000/api/health
{"status":"ok","timestamp":"2026-05-26T22:23:25.145Z","version":"v1.20260526.0",
 "dataSource":"sqlite","region":"local","uptime":24,
 "schema":{"schemaValid":true,"migrationsApplied":0,"schemaWarnings":2}}
```

## コード品質セルフレビュー (#1481)

- [x] **3 dimension SSOT 確立**: schema 変更 PR で更新必須な 3 file を設計書 §「Schema 変更時の lazy migration 必須 SSOT」で明示。再発防止 Issue #2507 で CI gate 化を別 PR で実装
- [x] **冪等性**: 各 migration block は guard で「既に新形式なら skip」を保証。複数 startup でも no-op
- [x] **transaction-less 安全性**: shadow-table recreation は `foreign_keys = OFF` 下で実行、エラー時 client.ts SCHEMA_VALIDATION_MODE 分岐で process.exit 制御 (中途半端 schema は SCHEMA_VALIDATION_MODE != 'warn' で startup 拒否)
- [x] **pragma 状態保全**: try / finally で呼び出し前の foreign_keys 状態に必ず戻す
- [x] **DRY 化**: 重複 logic を集約、`migrate-local.ts` は helper に delegate

## 横展開・影響波及チェック

- [x] **scripts/migrate-local.ts** — 同期 (重複削除 + delegate)
- [x] **schema-validator.ts (validateAndMigrate)** — 既存挙動維持 (個別 ALTER ADD COLUMN は本 helper 対象外、補完関係)
- [x] **demo / dynamodb 並行実装** — schema 変更なし、本 hotfix 無関係
- [x] **tests/e2e/global-setup.ts / tests/helpers/test-db.ts / src/lib/server/demo/demo-data.ts** — 既に新 schema (PR #2480 で同期済) のため本 hotfix で追加変更不要
- [x] **Lambda (production)** — Cold start で `client.ts` を経由、本 hotfix で同 startup シーケンスが適用される (NUC + Lambda 両方で恩恵)
- [x] **冪等性確認**: Lambda が複数 cold start で本 helper を実行しても shadow recreation guard で no-op

## レビュー依頼事項・破壊的変更

- **破壊的変更なし**: 既に新 schema の DB に対しては全 migration block が guard で skip
- **production data 損失リスク**: NUC 復旧時に 1 transaction (`BEGIN ... COMMIT`) で実行済、データ保全確認済 (rollback で worst case 旧 schema 維持)
- **レビュー focus**: ① `client.ts` の startup 順序が `applyLazyStartupMigrations → SQL_CREATE_TABLES → validateAndMigrate` で正しいか / ② 設計書 §「Schema 変更時の lazy migration 必須 SSOT」の 3 file 同期ルールが将来の schema 変更 PR で守れる粒度か

## 配布済み env / secret (ADR-0006)

新規 env / secret 追加なし。

## Ready for Review チェックリスト

- [x] CI 全緑確認 (本 PR push 後の CI 結果を確認してから Ready 化)
- [x] AC 全 [x] 検証マップ作成済
- [x] biome / svelte-check / vitest 全 PASS (worktree で確認、CI で再検証)
- [x] 設計書同期 (`docs/design/08-データベース設計書.md`)
- [x] 再発防止 Issue #2507 起票済
- [x] NUC 緊急復旧完了 (production access 復元済)

## QM レビュー結果

(QM チームのレビュー後に記入)
