### PR TITLE
fix: #2513 activities data copy を lazy-startup-migrations に組込 (dim 4 durable fix、Closes #2513)

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -2091,14 +2091,14 @@ NUC startup blocking (Issue #2508 / PR #2509) + NUC activities data 完全消失
 両者は同 file 内に並んで実装されるが、責務は明確に異なる:
 
 - **dim 3 (structural)**: schema 形状を旧→新に合わせる (列 / FK / 制約の整合)。例: `migrateActivityFkSwitchover` (`activities` → `child_activities` への FK target 切替)
-- **dim 4 (data copy)**: データ自体を旧 table 群から新 table 群へ意味的に意味のある形で再配置する。例: `migrateActivitiesLegacyDataCopy` (旧 `activities` 191 行を per-child `child_activities` に copy + 4 table の FK remap)
+- **dim 4 (data copy)**: データ自体を旧 table 群から新 table 群へ意味的に意味のある形で再配置する。例: `migrateActivitiesLegacyDataCopy` (旧 `activities` 行を per-child `child_activities` に copy + 4 table の FK remap)。**PR #2513 で `lazy-startup-migrations.ts` に実装済** (startup 時 `migrateActivityFkSwitchover` の直後に自動実行、新規 NUC / dev / CI でも適用)。手動緊急復旧版は `scripts/recover-activities-data.mjs` に同 logic を維持 (NUC container 単発実行用、SQL logic を同期)
 
 #### 事例集
 
 | PR | dim 充足 | 結果 |
 |---|---|---|
 | PR #2480 (checklist_templates per-child → family master flip) | 1, 2, 3, 4 (PR #2509 で `migrateChecklistTemplatesFamilyFlip` 内に data copy も含めて完遂) | per-child template → assignments 1 row 移行込で完全復旧 |
-| PR #2487 (activities → child_activities flip) | 1, 2, 3 のみ | dim 4 漏れ → NUC user data 完全消失 (history 全件 orphan、UI 表示 0)。Issue #2510 で recovery + 恒久 fix |
+| PR #2487 (activities → child_activities flip) | 1, 2, 3 のみ | dim 4 漏れ → NUC user data 完全消失 (history 全件 orphan、UI 表示 0)。Issue #2510 で緊急 recovery (`scripts/recover-activities-data.mjs`、PR #2512) → **PR #2513 で `migrateActivitiesLegacyDataCopy` を lazy-startup-migrations.ts に組込み恒久 fix 完遂** (dim 4 をコードで補完) |
 | PR #2491 (#2458-A2 demo + dynamodb 同期) | 別 backend | sqlite 影響なし (DynamoDB 側は別途 backfill 必要) |
 
 #### Self-Review チェック (schema 破壊変更 PR で必須)
@@ -2118,9 +2118,13 @@ git diff main -- src/lib/server/db/migration/lazy-startup-migrations.ts | \
 
 dim 4 漏れによる data orphan が発生した場合の復旧手順は [docs/runbooks/activities-data-recovery.md](../runbooks/activities-data-recovery.md) に集約 (NUC + DynamoDB 同型問題用)。
 
+#### 実装ステータス (#2513)
+
+- **dim 4 data copy migration**: **実装済** (PR #2513)。`src/lib/server/db/migration/lazy-startup-migrations.ts` の `migrateActivitiesLegacyDataCopy()` が startup 時 (`migrateActivityFkSwitchover` 直後) に自動実行され、旧 `activities` 行を per-child `child_activities` に copy + 4 table remap + orphan = 0 assert する。新規 NUC / dev / CI でも自動適用。回帰テスト: `tests/unit/db/lazy-startup-migrations.test.ts` (data copy 5 ケース) + `tests/integration/db/startup-upgrade-path.test.ts` (startup full path で UI 一覧 + 履歴成立)。
+
 #### 機械検証 (将来)
 
-Issue #2510 のフォローアップで `scripts/check-schema-migration-completeness.mjs` を実装予定。schema.ts 差分から破壊的変更 (DROP COLUMN / FK target 切替 / NOT NULL 変更 / cross-table flip) を検出し、create-tables.ts + lazy-startup-migrations.ts (structural + data copy) 双方の差分有無を CI gate 化。
+Issue #2510 / #2507 のフォローアップで `scripts/check-schema-migration-completeness.mjs` を実装予定 (**本 PR scope 外**)。schema.ts 差分から破壊的変更 (DROP COLUMN / FK target 切替 / NOT NULL 変更 / cross-table flip) を検出し、create-tables.ts + lazy-startup-migrations.ts (structural + data copy) 双方の差分有無を CI gate 化。dim 4 の **実装** (本 PR #2513) と dim 4 漏れの **機械検出** (将来) は別レイヤである点に注意。
 
 ---
 

--- a/docs/runbooks/activities-data-recovery.md
+++ b/docs/runbooks/activities-data-recovery.md
@@ -176,14 +176,19 @@ ssh kusaka-server@192.168.68.79 "docker start ganbari-quest-app-1"
 
 ---
 
-## 6. 恒久 fix (本 runbook の前提)
+## 6. 恒久 fix (実装済 — PR #2513)
 
-本 runbook は **緊急対応** のみを扱う。再発防止のための **恒久 fix** は #2510 で実施:
+本 runbook は **緊急対応** のみを扱う。再発防止のための **恒久 fix** は **PR #2513 で実装完遂済**:
 
-- `src/lib/server/db/migration/lazy-startup-migrations.ts` に `migrateActivitiesLegacyDataCopy()` 関数を append (PR #2509 マージ後)
-- 同 file の `applyLazyStartupMigrations()` 呼出順を `migrateActivityFkSwitchover` の直後に挿入
-- 新規 NUC environment / dev / CI でも自動適用される
-- 本 runbook はリカバリ手順として残存 (DynamoDB 等別 backend で同型問題が起きた際に利用)
+- ✅ `src/lib/server/db/migration/lazy-startup-migrations.ts` に `migrateActivitiesLegacyDataCopy()` 関数を実装
+- ✅ 同 file の `applyLazyStartupMigrations()` 呼出順を `migrateActivityFkSwitchover` の **直後** に挿入 (FK target 切替後でないと remap が整合しないため順序固定)
+- ✅ guards (冪等): `activities`/`child_activities`/`children` 不在 OR `child_activities` 非空 OR 4 table orphan ゼロ で skip
+- ✅ source/target 双方に存在する column のみ copy (古い schema の column 欠落に耐える) + age 列無し旧 schema では referenced のみ copy
+- ✅ orphan = 0 post-condition を transaction 内 assert (残れば throw → ROLLBACK)
+- ✅ 新規 NUC environment / dev / CI でも startup 時に自動適用される
+- ✅ 回帰テスト: `tests/unit/db/lazy-startup-migrations.test.ts` (data copy 5 ケース: referenced ∪ age 適合 / 5 年齢モード分岐 / 冪等 / orphan ゼロ skip / age 列無し) + `tests/integration/db/startup-upgrade-path.test.ts` (startup full path で UI 一覧 + 履歴 JOIN 成立)
+
+**通常運用では本 runbook の手動実行は不要** (startup migration が自動修復)。本 runbook はリカバリ参照手順として残存 (DynamoDB 等別 backend で同型問題が起きた際 / NUC で明示再実行したい際に利用)。`scripts/recover-activities-data.mjs` は同 logic の NUC container 単発実行版として維持 (runtime 都合で `.ts` helper を import 共有できないため SQL logic を 2 箇所同期、#2513)。
 
 ---
 
@@ -209,8 +214,9 @@ PR #2480 (checklist_templates flip) は **PR #2509 で per-child → assignments
 ## 8. 関連リソース
 
 - 緊急復旧 script: `scripts/recover-activities-data.mjs`
-- 関連 Issue: [#2510](https://github.com/Takenori-Kusaka/ganbari-quest/issues/2510)
-- in-flight 関連 PR: [#2509](https://github.com/Takenori-Kusaka/ganbari-quest/pull/2509) (lazy-startup-migrations.ts 枠組)
+- 恒久 fix 実装: `src/lib/server/db/migration/lazy-startup-migrations.ts` `migrateActivitiesLegacyDataCopy()` (PR #2513)
+- 関連 Issue: [#2510](https://github.com/Takenori-Kusaka/ganbari-quest/issues/2510) (umbrella) / [#2513](https://github.com/Takenori-Kusaka/ganbari-quest/issues/2513) (恒久 fix)
+- 関連 PR: [#2509](https://github.com/Takenori-Kusaka/ganbari-quest/pull/2509) (lazy-startup-migrations.ts 枠組) / [#2512](https://github.com/Takenori-Kusaka/ganbari-quest/pull/2512) (緊急 recovery script + runbook)
 - 原因 PR: [#2487](https://github.com/Takenori-Kusaka/ganbari-quest/pull/2487) (activity-repo facade rewrite)
 - 同型対応 ref PR: [#2509](https://github.com/Takenori-Kusaka/ganbari-quest/pull/2509) (checklist_templates flip data copy)
 - ADR: [ADR-0002](../decisions/0002-critical-fix-quality-gate.md) (Critical 5 要件)、[ADR-0031](../decisions/archive/0031-schema-change-compat-testing.md) (SQLite ADD COLUMN only)、[ADR-0010](../decisions/0010-pre-pmf-scope-judgment.md) (Bucket A)

--- a/scripts/doc-code-references-baseline.json
+++ b/scripts/doc-code-references-baseline.json
@@ -32,8 +32,7 @@
 		],
 		"docs/design/08-データベース設計書.md": [
 			"scripts/check-schema-migration-completeness.mjs",
-			"src/lib/features/admin/components/ArchiveBanner.svelte",
-			"src/lib/server/db/migration/lazy-startup-migrations.ts"
+			"src/lib/features/admin/components/ArchiveBanner.svelte"
 		],
 		"docs/design/09-テスト設計書.md": ["tests/unit/services/decay-service.test.ts"],
 		"docs/design/10-SaaS展開ロードマップ.md": ["infra/cdk"],
@@ -120,13 +119,9 @@
 			"scripts/check-no-escape-language.mjs",
 			"src/lib/services/PhotoBrowser.ts"
 		],
-		"docs/runbooks/activities-data-recovery.md": [
-			"src/lib/server/db/migration/lazy-startup-migrations.ts"
-		],
 		"docs/security/security-code-review-2026-03.md": [
 			"src/lib/server/services/email-otp-service.ts"
-		],
-		"tests/CLAUDE.md": ["infra/node_modules"]
+		]
 	},
-	"generatedAt": "2026-05-26T23:47:39.907Z"
+	"generatedAt": "2026-05-27T02:58:51.027Z"
 }

--- a/scripts/recover-activities-data.mjs
+++ b/scripts/recover-activities-data.mjs
@@ -30,12 +30,76 @@
  *   - foreign_keys = OFF (shadow operation 中の FK trip 回避)
  *   - 終了時に foreign_keys = ON に戻す
  *   - orphan assert 失敗時は ROLLBACK
+ *
+ * ## SSOT 関係 (#2513)
+ *
+ * 本 script は **NUC container で TS toolchain 無しに単発実行する緊急復旧版**。
+ * 同一 logic は startup 自動 migration として
+ * `src/lib/server/db/migration/lazy-startup-migrations.ts` の
+ * `migrateActivitiesLegacyDataCopy()` に実装されており、そちらが **恒久 SSOT**
+ * (新規 NUC / dev / CI でも startup 時に自動適用)。
+ *
+ * 両者は runtime が異なり (standalone `node` vs SvelteKit build) import による
+ * code 共有が不可能なため、**SQL logic を 2 箇所で維持** する。どちらかを変更する
+ * 際は他方も同期させること。挙動は同一に保つ:
+ *   - child_activities INSERT は source/target 双方に存在する column のみ対象
+ *     (古い schema で column を欠く DB でも `no such column` で fail しない)
+ *   - referenced ∪ age 適合 の和集合を copy、age 列が無い旧 schema では referenced のみ
+ *   - 4 table remap 後 orphan = 0 を assert
+ *
+ * 通常運用では本 script の手動実行は不要 (startup migration が自動修復)。本 script は
+ * DynamoDB 等別 backend で同型問題が起きた際の参照実装 / NUC での明示再実行用に残す。
+ * 詳細: docs/runbooks/activities-data-recovery.md / docs/design/08-データベース設計書.md §8.6。
  */
 
 import Database from 'better-sqlite3';
 
 const DB_PATH = process.env.DB_PATH ?? '/app/data/ganbari-quest.db';
 const DRY_RUN = process.env.DRY_RUN === '1';
+
+/** table が存在するか */
+function tableExists(db, name) {
+	return !!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?").get(name);
+}
+
+/** table に column が存在するか */
+function hasColumn(db, table, column) {
+	if (!tableExists(db, table)) return false;
+	return db
+		.prepare(`PRAGMA table_info(${table})`)
+		.all()
+		.some((c) => c.name === column);
+}
+
+/**
+ * source (`activities`) と target (`child_activities`) の双方に存在する copy 対象
+ * column のみ返す (片方にしか無い列を SELECT/INSERT すると `no such column` で fail)。
+ * lazy-startup-migrations.ts の detectCopyableActivityColumns と同一ロジック (#2513 SSOT 同期)。
+ */
+function detectCopyableActivityColumns(db) {
+	const candidate = [
+		'name',
+		'category_id',
+		'icon',
+		'base_points',
+		'is_visible',
+		'daily_limit',
+		'sort_order',
+		'source',
+		'name_kana',
+		'name_kanji',
+		'trigger_hint',
+		'is_main_quest',
+		'created_at',
+		'is_archived',
+		'archived_reason',
+		'source_preset_id',
+		'priority',
+	];
+	return candidate.filter(
+		(col) => hasColumn(db, 'activities', col) && hasColumn(db, 'child_activities', col),
+	);
+}
 
 const ORPHAN_QUERIES = {
 	logs: `SELECT COUNT(*) AS c FROM activity_logs al
@@ -77,10 +141,11 @@ function remapTable(db, tableName, mapping) {
 
 /**
  * 1 child について copy 対象 activity を child_activities に INSERT し、mapping に登録する。
+ * ageFitStmt は age 列が無い旧 schema では null (referenced のみで copy)。
  */
 function copyActivitiesForChild(child, insertStmt, referencedStmt, ageFitStmt, mapping) {
 	const referencedRows = referencedStmt.all(child.id, child.id, child.id, child.id);
-	const ageFitRows = ageFitStmt.all(child.age, child.age);
+	const ageFitRows = ageFitStmt && child.age != null ? ageFitStmt.all(child.age, child.age) : [];
 
 	const activityIdSet = new Set();
 	for (const r of referencedRows) activityIdSet.add(r.activity_id);
@@ -107,20 +172,14 @@ function copyActivitiesForChild(child, insertStmt, referencedStmt, ageFitStmt, m
  * 失敗時は throw で ROLLBACK。
  */
 function runRecoveryTransaction(db, children) {
-	const insertStmt = db.prepare(`
-		INSERT INTO child_activities (
-			child_id, name, category_id, icon, base_points, is_visible, daily_limit,
-			sort_order, source, name_kana, name_kanji, trigger_hint, is_main_quest,
-			created_at, is_archived, archived_reason, source_preset_id, priority
-		)
-		SELECT
-			? AS child_id, a.name, a.category_id, a.icon, a.base_points, a.is_visible, a.daily_limit,
-			a.sort_order, a.source, a.name_kana, a.name_kanji, a.trigger_hint,
-			COALESCE(a.is_main_quest, 0), a.created_at,
-			COALESCE(a.is_archived, 0), a.archived_reason, a.source_preset_id, a.priority
-		FROM activities a
-		WHERE a.id = ?
-	`);
+	// source/target 双方に存在する column のみ INSERT (古い schema の column 欠落に耐える)
+	const copyableCols = detectCopyableActivityColumns(db);
+	const insertCols = ['child_id', ...copyableCols];
+	const selectCols = copyableCols.map((c) => `a.${c}`).join(', ');
+	const insertStmt = db.prepare(
+		`INSERT INTO child_activities (${insertCols.join(', ')})
+		 SELECT ?${selectCols ? `, ${selectCols}` : ''} FROM activities a WHERE a.id = ?`,
+	);
 
 	const referencedStmt = db.prepare(`
 		SELECT DISTINCT activity_id FROM (
@@ -134,13 +193,20 @@ function runRecoveryTransaction(db, children) {
 		)
 	`);
 
-	const ageFitStmt = db.prepare(`
-		SELECT id FROM activities
-		WHERE
-			(age_min IS NULL OR age_min <= ?)
-			AND (age_max IS NULL OR age_max >= ?)
-			AND COALESCE(is_archived, 0) = 0
-	`);
+	// age 列が無い旧 schema では age 適合 copy を skip (referenced のみ)。
+	const hasAge =
+		hasColumn(db, 'children', 'age') &&
+		hasColumn(db, 'activities', 'age_min') &&
+		hasColumn(db, 'activities', 'age_max');
+	const ageFitStmt = hasAge
+		? db.prepare(`
+			SELECT id FROM activities
+			WHERE
+				(age_min IS NULL OR age_min <= ?)
+				AND (age_max IS NULL OR age_max >= ?)
+				AND COALESCE(is_archived, 0) = 0
+		`)
+		: null;
 
 	const mapping = new Map();
 	let totalCopied = 0;

--- a/src/lib/server/db/migration/lazy-startup-migrations.ts
+++ b/src/lib/server/db/migration/lazy-startup-migrations.ts
@@ -26,20 +26,28 @@
 // が `no such column: tenant_id` で失敗し、`validateAndMigrate` に到達せず
 // app 起動が完全に block された。
 //
-// ## 責務分離 (3 dimension SSOT、再発防止 Issue)
+// ## 責務分離 (4 dimension SSOT、再発防止 Issue #2508 / #2510)
 //
-// schema 変更 PR では以下 **3 file** を必ず同期更新する:
+// schema 変更 PR では以下 **4 dimension** を必ず同期更新する (詳細:
+// docs/design/08-データベース設計書.md §8.6):
 //
 // 1. `src/lib/server/db/schema.ts` — drizzle table 定義 (TypeScript 型 SSOT)
 // 2. `src/lib/server/db/create-tables.ts` — `CREATE TABLE/INDEX IF NOT EXISTS`
 //    群 (新規 DB / dev / CI 用の素朴 init)
-// 3. **`src/lib/server/db/migration/lazy-startup-migrations.ts` (本 file)** —
-//    既存 production DB を新 schema にアップグレードする shadow-table
-//    recreation / DROP COLUMN 系 migration
+// 3. **`src/lib/server/db/migration/lazy-startup-migrations.ts` (本 file、structural)** —
+//    既存 production DB の schema 形状を新 schema に合わせる shadow-table
+//    recreation / DROP COLUMN / FK target switch / NOT NULL 変更
+//    (例: `migrateActivityFkSwitchover`)
+// 4. **`src/lib/server/db/migration/lazy-startup-migrations.ts` (本 file、data copy)** —
+//    cross-table semantic flip 時に row 自体を旧 table 群から新 table 群へ
+//    再配置する data migration (例: `migrateActivitiesLegacyDataCopy`、
+//    旧 per-table `activities` → per-child `child_activities`)
 //
-// (1) と (2) を更新しただけでは既存 production DB は壊れる。本 file の更新
-// 漏れは NUC startup blocking という形で爆発するため、schema 破壊変更 PR は
-// 必ず本 file へ migration を追加すること。
+// (1)(2) を更新しただけでは既存 production DB は壊れる。dim 3 の漏れは NUC
+// startup blocking (Issue #2508 / PR #2480)、dim 4 の漏れは既存 data の orphan 化
+// = user history 完全消失 (Issue #2510 / PR #2487) という形で爆発するため、
+// schema 破壊変更 PR は必ず本 file へ structural + (cross-table flip 時は) data copy
+// migration を追加すること。
 //
 // ## 実行順序
 //
@@ -241,6 +249,353 @@ function migrateActivityFkSwitchover(db: Database.Database): void {
 }
 
 /**
+ * 旧 `activities` table が持つ column のうち `child_activities` へ copy 可能な
+ * ものを実 DB から検出して返す (startup 時 schema 検証より **前** に走るため、
+ * 旧 production DB の `activities` / `child_activities` が一部 column を欠く場合に備える)。
+ *
+ * **source (`activities`) と target (`child_activities`) の両方に存在する** column
+ * のみを対象にする (片方にしか無い列を SELECT/INSERT すると `no such column` で fail)。
+ */
+function detectCopyableActivityColumns(db: Database.Database): string[] {
+	// child_activities へ copy する候補 (child_id は固定で別途指定するため除外)。
+	const candidate = [
+		'name',
+		'category_id',
+		'icon',
+		'base_points',
+		'is_visible',
+		'daily_limit',
+		'sort_order',
+		'source',
+		'name_kana',
+		'name_kanji',
+		'trigger_hint',
+		'is_main_quest',
+		'created_at',
+		'is_archived',
+		'archived_reason',
+		'source_preset_id',
+		'priority',
+	];
+	return candidate.filter(
+		(col) => hasColumn(db, 'activities', col) && hasColumn(db, 'child_activities', col),
+	);
+}
+
+/**
+ * #2487 (#2458-A1) follow-up / Issue #2510 / #2513: legacy `activities` rows を
+ * per-child `child_activities` に copy する **data copy migration** (4 dimension
+ * SSOT の dim 4)。
+ *
+ * ## 背景
+ *
+ * PR #2487 で activity-repo facade を旧 per-table `activities` から per-child
+ * `child_activities` に flip した際、**既存 production DB の `activities` 行を
+ * `child_activities` へ copy する data migration が完全に漏れていた**。結果 NUC で:
+ *
+ * - `activities`: 191 行 (旧 table、read 経路なし)
+ * - `child_activities`: 0 行 (新 SSOT、空)
+ * - `activity_logs` / `daily_missions` / `activity_mastery`
+ *   / `child_activity_preferences`: FK target は `child_activities` だが
+ *   参照先 row が存在せず全件 orphan → UI 表示 0 + history 完全消失
+ *
+ * `migrateActivityFkSwitchover` (dim 3 / structural) は FK target を切替える
+ * **だけ** で、row 自体の移動は行わない。本関数は **switchover の後** に走り、
+ * 旧 `activities` の row を各 child の `child_activities` に複製してから 4 table の
+ * `activity_id` を remap する。
+ *
+ * ## 復旧方針 (RCA Phase B' Option C / `scripts/recover-activities-data.mjs` と同一)
+ *
+ * 各 child について以下 2 集合の和を `child_activities` に copy する:
+ *   (a) referenced — 既往 `activity_logs` / `daily_missions` / `activity_mastery`
+ *       / `child_activity_preferences` で参照されている activity (**history 保全**)
+ *   (b) age 適合 — `age_min ≤ child.age ≤ age_max` かつ未 archive の activity
+ *       (UI 一覧表示用)。`activities` に age 列が無い古い schema では全件 (a) のみ
+ *
+ * その後 `(old activity_id, child_id) → new child_activity_id` mapping を構築し、
+ * 4 table の `activity_id` を remap。最後に orphan = 0 を assert (throw で
+ * DB 整合性を保護)。
+ *
+ * ## guards (冪等性)
+ *
+ * - `activities` / `child_activities` / `children` のいずれかが不在 → skip
+ * - `child_activities` が非空 (既 copy 済) → skip
+ * - 4 table いずれにも orphan が無い → skip (copy 不要)
+ *
+ * ## SSOT 注記
+ *
+ * 本関数は SvelteKit startup 経路 (`client.ts`) の **恒久 data copy SSOT**。
+ * NUC container で TS toolchain 無しに単発実行する緊急復旧版は
+ * `scripts/recover-activities-data.mjs` に存在する (runtime が異なるため import 共有
+ * 不可、SQL logic を同期させること)。詳細: docs/runbooks/activities-data-recovery.md /
+ * docs/design/08-データベース設計書.md §8.6。
+ */
+function migrateActivitiesLegacyDataCopy(db: Database.Database): void {
+	// --- guard 1: 必要 table が揃っていない (新規 DB / 旧 table 未作成) → skip ---
+	if (
+		!tableExists(db, 'activities') ||
+		!tableExists(db, 'child_activities') ||
+		!tableExists(db, 'children')
+	) {
+		return;
+	}
+
+	// --- guard 2: child_activities が既に非空 (= 既 copy 済 or 新規 seed 済) → skip ---
+	const childActivitiesCount = (
+		db.prepare('SELECT COUNT(*) AS c FROM child_activities').get() as { c: number }
+	).c;
+	if (childActivitiesCount > 0) return;
+
+	// --- guard 3: 旧 activities が空 → copy 元なし → skip ---
+	const activitiesCount = (
+		db.prepare('SELECT COUNT(*) AS c FROM activities').get() as { c: number }
+	).c;
+	if (activitiesCount === 0) return;
+
+	// --- guard 4: 4 table に orphan が 1 件も無ければ data copy 不要 → skip ---
+	// (FK switchover 済だが参照対象が無い = orphan。orphan ゼロなら移行不要)
+	const hasLogTable = tableExists(db, 'activity_logs');
+	const hasMissionTable = tableExists(db, 'daily_missions');
+	const hasMasteryTable = tableExists(db, 'activity_mastery');
+	const hasPrefTable = tableExists(db, 'child_activity_preferences');
+
+	const orphanBefore = countOrphans(db, {
+		hasLogTable,
+		hasMissionTable,
+		hasMasteryTable,
+		hasPrefTable,
+	});
+	if (
+		orphanBefore.logs === 0 &&
+		orphanBefore.missions === 0 &&
+		orphanBefore.mastery === 0 &&
+		orphanBefore.prefs === 0
+	) {
+		return;
+	}
+
+	const presence: OrphanTablePresence = {
+		hasLogTable,
+		hasMissionTable,
+		hasMasteryTable,
+		hasPrefTable,
+	};
+
+	console.info(
+		`[lazy-migrate #2510] copying legacy activities → child_activities ` +
+			`(activities=${activitiesCount}, orphans: logs=${orphanBefore.logs} ` +
+			`missions=${orphanBefore.missions} mastery=${orphanBefore.mastery} prefs=${orphanBefore.prefs})`,
+	);
+
+	const run = db.transaction(() => {
+		const mapping = copyAllChildActivities(db, presence);
+
+		// 4 table の activity_id を (child_id, old activity_id) → new child_activity id に remap
+		for (const [tableName, present] of [
+			['activity_logs', hasLogTable],
+			['daily_missions', hasMissionTable],
+			['activity_mastery', hasMasteryTable],
+			['child_activity_preferences', hasPrefTable],
+		] as const) {
+			if (present) remapActivityIdColumn(db, tableName, mapping);
+		}
+
+		// post-condition: orphan = 0 を assert。残れば throw → tx ROLLBACK (整合性保護)。
+		assertNoOrphansRemain(db, presence);
+	});
+	run();
+	console.info('[lazy-migrate #2510]   → activities data copy complete (orphan = 0)');
+}
+
+/**
+ * 全 child について copy 対象 activity を `child_activities` に INSERT し、
+ * `(childId:oldActivityId) → new child_activity id` の mapping を返す。
+ */
+function copyAllChildActivities(
+	db: Database.Database,
+	presence: OrphanTablePresence,
+): Map<string, number | bigint> {
+	const { hasLogTable, hasMissionTable, hasMasteryTable, hasPrefTable } = presence;
+	const copyableCols = detectCopyableActivityColumns(db);
+	const hasAge =
+		hasColumn(db, 'children', 'age') &&
+		hasColumn(db, 'activities', 'age_min') &&
+		hasColumn(db, 'activities', 'age_max');
+
+	// child_activities への INSERT (検出した column のみ、child_id は固定で先頭指定)。
+	const insertCols = ['child_id', ...copyableCols];
+	const selectCols = copyableCols.map((c) => `a.${c}`).join(', ');
+	const insertStmt = db.prepare(
+		`INSERT INTO child_activities (${insertCols.join(', ')})
+		 SELECT ?${selectCols ? `, ${selectCols}` : ''} FROM activities a WHERE a.id = ?`,
+	);
+
+	// referenced: 既往 4 table で参照されている activity_id (history 保全)。
+	// table 不在は `SELECT NULL WHERE 0` で空集合化し、placeholder の余分引数も無害。
+	const referencedStmt = db.prepare(`
+		SELECT DISTINCT activity_id FROM (
+			${hasLogTable ? 'SELECT activity_id FROM activity_logs WHERE child_id = ? UNION' : 'SELECT NULL AS activity_id WHERE 0 UNION'}
+			${hasMissionTable ? 'SELECT activity_id FROM daily_missions WHERE child_id = ? UNION' : 'SELECT NULL WHERE 0 UNION'}
+			${hasMasteryTable ? 'SELECT activity_id FROM activity_mastery WHERE child_id = ? UNION' : 'SELECT NULL WHERE 0 UNION'}
+			${hasPrefTable ? 'SELECT activity_id FROM child_activity_preferences WHERE child_id = ?' : 'SELECT NULL WHERE 0'}
+		) WHERE activity_id IS NOT NULL
+	`);
+
+	// age 適合 activity (UI 一覧用)。age 列が無い旧 schema では null (referenced のみ)。
+	const ageFitStmt = hasAge
+		? db.prepare(`
+			SELECT id FROM activities
+			WHERE (age_min IS NULL OR age_min <= ?)
+				AND (age_max IS NULL OR age_max >= ?)
+				AND COALESCE(is_archived, 0) = 0
+		`)
+		: null;
+
+	const children = db
+		.prepare('SELECT id, age FROM children WHERE COALESCE(is_archived, 0) = 0')
+		.all() as { id: number; age: number | null }[];
+
+	const mapping = new Map<string, number | bigint>();
+	let totalCopied = 0;
+	for (const child of children) {
+		totalCopied += copyChildActivities(child, presence, {
+			insertStmt,
+			referencedStmt,
+			ageFitStmt,
+			mapping,
+		});
+	}
+	console.info(
+		`[lazy-migrate #2510]   inserted ${totalCopied} child_activities rows (mapping size: ${mapping.size})`,
+	);
+	return mapping;
+}
+
+interface CopyStatements {
+	insertStmt: Database.Statement;
+	referencedStmt: Database.Statement;
+	ageFitStmt: Database.Statement | null;
+	mapping: Map<string, number | bigint>;
+}
+
+/**
+ * 1 child について referenced ∪ age 適合 の activity 集合を `child_activities` に
+ * INSERT し mapping に登録。copy 件数を返す。
+ */
+function copyChildActivities(
+	child: { id: number; age: number | null },
+	presence: OrphanTablePresence,
+	stmts: CopyStatements,
+): number {
+	const { insertStmt, referencedStmt, ageFitStmt, mapping } = stmts;
+	const activityIdSet = new Set<number>();
+
+	// referenced (存在 table 分だけ child.id を bind)
+	const refArgs: number[] = [];
+	if (presence.hasLogTable) refArgs.push(child.id);
+	if (presence.hasMissionTable) refArgs.push(child.id);
+	if (presence.hasMasteryTable) refArgs.push(child.id);
+	if (presence.hasPrefTable) refArgs.push(child.id);
+	for (const r of referencedStmt.all(...refArgs) as { activity_id: number }[]) {
+		activityIdSet.add(r.activity_id);
+	}
+
+	// age 適合
+	if (ageFitStmt && child.age != null) {
+		for (const r of ageFitStmt.all(child.age, child.age) as { id: number }[]) {
+			activityIdSet.add(r.id);
+		}
+	}
+
+	let copied = 0;
+	for (const oldActivityId of activityIdSet) {
+		const result = insertStmt.run(child.id, oldActivityId);
+		if (result.changes > 0) {
+			mapping.set(`${child.id}:${oldActivityId}`, result.lastInsertRowid);
+			copied++;
+		}
+	}
+	return copied;
+}
+
+/**
+ * data copy 後 4 table に orphan が残っていれば throw (tx ROLLBACK で整合性保護)。
+ */
+function assertNoOrphansRemain(db: Database.Database, presence: OrphanTablePresence): void {
+	const orphanAfter = countOrphans(db, presence);
+	if (
+		orphanAfter.logs > 0 ||
+		orphanAfter.missions > 0 ||
+		orphanAfter.mastery > 0 ||
+		orphanAfter.prefs > 0
+	) {
+		throw new Error(
+			`[lazy-migrate #2510] ORPHAN remains after data copy — ROLLBACK. ` +
+				`logs=${orphanAfter.logs} missions=${orphanAfter.missions} ` +
+				`mastery=${orphanAfter.mastery} prefs=${orphanAfter.prefs}`,
+		);
+	}
+}
+
+/**
+ * 1 つの table の `activity_id` を `(child_id, old activity_id) → new child_activity id`
+ * mapping で remap する。mapping に無い行は触らない (既に新 id か、対象外)。
+ */
+function remapActivityIdColumn(
+	db: Database.Database,
+	tableName: 'activity_logs' | 'daily_missions' | 'activity_mastery' | 'child_activity_preferences',
+	mapping: Map<string, number | bigint>,
+): void {
+	const update = db.prepare(`UPDATE ${tableName} SET activity_id = ? WHERE id = ?`);
+	const rows = db.prepare(`SELECT id, child_id, activity_id FROM ${tableName}`).all() as {
+		id: number;
+		child_id: number;
+		activity_id: number;
+	}[];
+	let remapped = 0;
+	for (const row of rows) {
+		const newId = mapping.get(`${row.child_id}:${row.activity_id}`);
+		if (newId !== undefined) {
+			update.run(newId, row.id);
+			remapped++;
+		}
+	}
+	console.info(`[lazy-migrate #2510]   ${tableName} remapped: ${remapped} / ${rows.length}`);
+}
+
+interface OrphanTablePresence {
+	hasLogTable: boolean;
+	hasMissionTable: boolean;
+	hasMasteryTable: boolean;
+	hasPrefTable: boolean;
+}
+
+/**
+ * 4 table それぞれについて `child_activities` に存在しない `activity_id` を持つ
+ * 行 (= orphan) 件数を返す。table 不在時は 0。
+ */
+function countOrphans(
+	db: Database.Database,
+	presence: OrphanTablePresence,
+): { logs: number; missions: number; mastery: number; prefs: number } {
+	const orphanCount = (table: string): number =>
+		(
+			db
+				.prepare(
+					`SELECT COUNT(*) AS c FROM ${table} t
+					 WHERE NOT EXISTS (SELECT 1 FROM child_activities ca WHERE ca.id = t.activity_id)`,
+				)
+				.get() as { c: number }
+		).c;
+	return {
+		logs: presence.hasLogTable ? orphanCount('activity_logs') : 0,
+		missions: presence.hasMissionTable ? orphanCount('daily_missions') : 0,
+		mastery: presence.hasMasteryTable ? orphanCount('activity_mastery') : 0,
+		prefs: presence.hasPrefTable ? orphanCount('child_activity_preferences') : 0,
+	};
+}
+
+/**
  * #2362 PR-5 (Phase 1): `checklist_templates` flip
  *
  * - 旧: `checklist_templates.child_id NOT NULL` (per-child instance)
@@ -375,6 +730,9 @@ export function applyLazyStartupMigrations(db: Database.Database): void {
 	try {
 		migrateChecklistTemplatesDropKind(db);
 		migrateActivityFkSwitchover(db);
+		// #2510 / #2513: FK switchover (dim 3) の **後** に data copy (dim 4) を実行。
+		// FK target が child_activities になった後でないと remap が整合しないため順序固定。
+		migrateActivitiesLegacyDataCopy(db);
 		migrateChecklistTemplatesFamilyFlip(db);
 	} catch (err) {
 		// #2509: tx 内で失敗した場合 better-sqlite3 が自動 ROLLBACK 済。partial state

--- a/tests/integration/db/startup-upgrade-path.test.ts
+++ b/tests/integration/db/startup-upgrade-path.test.ts
@@ -255,6 +255,92 @@ describe('startup upgrade path (legacy NUC production DB → new schema)', () =>
 		}
 	});
 
+	it('PR #2487 起因の activities data 消失 (orphan) を startup で復旧し UI 一覧 + 履歴が成立する (#2510 / #2513)', () => {
+		const db = new Database(':memory:');
+		db.pragma('foreign_keys = ON');
+
+		try {
+			seedLegacyProductionDb(db);
+
+			// --- PR #2487 後の NUC 状態を再現 ---
+			// children / activities (旧 per-table) に実データ。child_activities は空。
+			// activity_logs 等は FK target = activities (switchover 前) → switchover で
+			// child_activities に切替わるが参照先が無く全件 orphan 化する。
+			db.prepare("INSERT INTO children (nickname, age) VALUES ('elementary-A', 9)").run();
+			db.prepare("INSERT INTO children (nickname, age) VALUES ('teen-B', 15)").run();
+			db.prepare("INSERT INTO activities (name) VALUES ('walk')").run(); // id=1
+			db.prepare("INSERT INTO activities (name) VALUES ('study')").run(); // id=2
+			// 履歴 (activity_logs): child A が walk を 2 回、child B が study を 1 回
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (1, 1, 10, '2026-05-27')",
+			).run();
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (1, 1, 5, '2026-05-26')",
+			).run();
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (2, 2, 8, '2026-05-26')",
+			).run();
+			db.prepare(
+				"INSERT INTO daily_missions (child_id, mission_date, activity_id) VALUES (1, '2026-05-27', 1)",
+			).run();
+			db.prepare(
+				'INSERT INTO activity_mastery (child_id, activity_id, total_count) VALUES (1, 1, 2)',
+			).run();
+
+			// === startup シーケンス (client.ts と同順) ===
+			expect(() => applyLazyStartupMigrations(db)).not.toThrow();
+			expect(() => db.exec(SQL_CREATE_TABLES)).not.toThrow();
+			expect(validateAndMigrate(db).errors).toEqual([]);
+
+			// --- UI 一覧表示が成立: 各 child に child_activities が生成された ---
+			const childAActivities = (
+				db.prepare('SELECT COUNT(*) AS c FROM child_activities WHERE child_id = 1').get() as {
+					c: number;
+				}
+			).c;
+			expect(childAActivities).toBeGreaterThan(0);
+
+			// --- 履歴が成立: activity_logs が orphan ゼロ (= child_activities を正しく参照) ---
+			const orphanLogs = (
+				db
+					.prepare(
+						`SELECT COUNT(*) AS c FROM activity_logs al
+						 WHERE NOT EXISTS (SELECT 1 FROM child_activities ca WHERE ca.id = al.activity_id)`,
+					)
+					.get() as { c: number }
+			).c;
+			expect(orphanLogs).toBe(0);
+
+			// --- 履歴が child ごとに正しく辿れる (UI の活動別履歴表示が成立) ---
+			// child A の walk 履歴 2 件が child A の child_activities 経由で JOIN できる
+			const childAWalkLogs = (
+				db
+					.prepare(
+						`SELECT COUNT(*) AS c FROM activity_logs al
+						 JOIN child_activities ca ON ca.id = al.activity_id
+						 WHERE al.child_id = 1 AND ca.child_id = 1 AND ca.name = 'walk'`,
+					)
+					.get() as { c: number }
+			).c;
+			expect(childAWalkLogs).toBe(2);
+
+			// daily_missions / activity_mastery も orphan ゼロ
+			for (const table of ['daily_missions', 'activity_mastery']) {
+				const orphan = (
+					db
+						.prepare(
+							`SELECT COUNT(*) AS c FROM ${table} t
+							 WHERE NOT EXISTS (SELECT 1 FROM child_activities ca WHERE ca.id = t.activity_id)`,
+						)
+						.get() as { c: number }
+				).c;
+				expect(orphan, `${table} orphan`).toBe(0);
+			}
+		} finally {
+			db.close();
+		}
+	});
+
 	it('既に新 schema 状態の DB に対して再起動シーケンスを流しても no-error (冪等)', () => {
 		const db = new Database(':memory:');
 		db.pragma('foreign_keys = ON');

--- a/tests/unit/db/lazy-startup-migrations.test.ts
+++ b/tests/unit/db/lazy-startup-migrations.test.ts
@@ -323,6 +323,357 @@ describe('applyLazyStartupMigrations', () => {
 		});
 	});
 
+	describe('activities → child_activities data copy (#2510 / #2513 dim 4)', () => {
+		/**
+		 * PR #2487 後の NUC production を再現する fixture:
+		 * - `activities`: 旧 per-table、age_min/age_max + 全 child_activities 互換 column
+		 * - `child_activities`: 新 SSOT、空 (= data copy 漏れ状態)
+		 * - `activity_logs` 等: FK target は **既に child_activities** (switchover 済) だが
+		 *   参照先が空のため全件 orphan
+		 *
+		 * 本 fixture は switchover 済前提なので、FK target を最初から child_activities に
+		 * 設定する (migrateActivityFkSwitchover が no-op になり、data copy だけが走る)。
+		 */
+		function seedActivitiesDataLossSchema(db: Database.Database): void {
+			db.pragma('foreign_keys = OFF');
+			db.exec(`
+				CREATE TABLE children (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					nickname TEXT NOT NULL,
+					age INTEGER NOT NULL DEFAULT 5,
+					is_archived INTEGER NOT NULL DEFAULT 0
+				);
+				CREATE TABLE categories (
+					id INTEGER PRIMARY KEY,
+					code TEXT NOT NULL UNIQUE,
+					name TEXT NOT NULL
+				);
+				-- 旧 per-table activities (age_min / age_max + 全 copy 対象 column)
+				CREATE TABLE activities (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					name TEXT NOT NULL,
+					category_id INTEGER REFERENCES categories(id),
+					icon TEXT NOT NULL DEFAULT '⭐',
+					base_points INTEGER NOT NULL DEFAULT 5,
+					is_visible INTEGER NOT NULL DEFAULT 1,
+					daily_limit INTEGER,
+					sort_order INTEGER NOT NULL DEFAULT 0,
+					source TEXT NOT NULL DEFAULT 'seed',
+					name_kana TEXT,
+					name_kanji TEXT,
+					trigger_hint TEXT,
+					is_main_quest INTEGER NOT NULL DEFAULT 0,
+					created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					is_archived INTEGER NOT NULL DEFAULT 0,
+					archived_reason TEXT,
+					source_preset_id TEXT,
+					priority TEXT NOT NULL DEFAULT 'optional',
+					age_min INTEGER,
+					age_max INTEGER
+				);
+				-- 新 SSOT child_activities (create-tables.ts と同形)、空
+				CREATE TABLE child_activities (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_id INTEGER NOT NULL REFERENCES children(id),
+					name TEXT NOT NULL,
+					category_id INTEGER REFERENCES categories(id),
+					icon TEXT NOT NULL DEFAULT '⭐',
+					base_points INTEGER NOT NULL DEFAULT 5,
+					is_visible INTEGER NOT NULL DEFAULT 1,
+					daily_limit INTEGER,
+					sort_order INTEGER NOT NULL DEFAULT 0,
+					source TEXT NOT NULL DEFAULT 'seed',
+					name_kana TEXT,
+					name_kanji TEXT,
+					trigger_hint TEXT,
+					is_main_quest INTEGER NOT NULL DEFAULT 0,
+					created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					is_archived INTEGER NOT NULL DEFAULT 0,
+					archived_reason TEXT,
+					source_preset_id TEXT,
+					priority TEXT NOT NULL DEFAULT 'optional'
+				);
+				-- FK target は既に child_activities (switchover 済)。checklist_templates は
+				-- 新 schema にしておき (kind 無し / tenant_id NOT NULL)、他 migration を no-op 化。
+				CREATE TABLE checklist_templates (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					tenant_id TEXT NOT NULL DEFAULT 'default',
+					name TEXT NOT NULL
+				);
+				CREATE TABLE activity_logs (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_id INTEGER NOT NULL REFERENCES children(id),
+					activity_id INTEGER NOT NULL REFERENCES child_activities(id),
+					points INTEGER NOT NULL,
+					streak_days INTEGER NOT NULL DEFAULT 1,
+					streak_bonus INTEGER NOT NULL DEFAULT 0,
+					recorded_date TEXT NOT NULL,
+					recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					cancelled INTEGER NOT NULL DEFAULT 0
+				);
+				CREATE TABLE daily_missions (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_id INTEGER NOT NULL REFERENCES children(id),
+					mission_date TEXT NOT NULL,
+					activity_id INTEGER NOT NULL REFERENCES child_activities(id),
+					completed INTEGER NOT NULL DEFAULT 0,
+					completed_at TEXT
+				);
+				CREATE TABLE activity_mastery (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_id INTEGER NOT NULL REFERENCES children(id),
+					activity_id INTEGER NOT NULL REFERENCES child_activities(id),
+					total_count INTEGER NOT NULL DEFAULT 0,
+					level INTEGER NOT NULL DEFAULT 1,
+					updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+				);
+				CREATE TABLE child_activity_preferences (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_id INTEGER NOT NULL REFERENCES children(id) ON DELETE CASCADE,
+					activity_id INTEGER NOT NULL REFERENCES child_activities(id) ON DELETE CASCADE,
+					is_pinned INTEGER NOT NULL DEFAULT 0,
+					pin_order INTEGER,
+					created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+				);
+			`);
+			db.pragma('foreign_keys = ON');
+		}
+
+		function orphanCount(db: Database.Database, table: string): number {
+			return (
+				db
+					.prepare(
+						`SELECT COUNT(*) AS c FROM ${table} t
+						 WHERE NOT EXISTS (SELECT 1 FROM child_activities ca WHERE ca.id = t.activity_id)`,
+					)
+					.get() as { c: number }
+			).c;
+		}
+
+		/**
+		 * orphan 行 (child_activities に存在しない activity_id を持つ行) を seed する。
+		 * NUC では FK switchover (dim 3) で FK target が child_activities に切替わった後、
+		 * data copy (dim 4) が漏れたため既存行が全件 orphan 化した状態を再現する。
+		 * SQLite は table 再作成時の既存行に FK を再検証しないが、本テストは
+		 * `:memory:` で新規 INSERT するため `foreign_keys = OFF` で投入して同状態を作る。
+		 */
+		function insertOrphanRows(db: Database.Database, fn: () => void): void {
+			const before = db.pragma('foreign_keys', { simple: true });
+			db.pragma('foreign_keys = OFF');
+			try {
+				fn();
+			} finally {
+				db.pragma(`foreign_keys = ${before ? 'ON' : 'OFF'}`);
+			}
+		}
+
+		/**
+		 * 5 年齢モード (baby=1 / preschool=4 / elementary=9 / junior=14 / senior=17) の
+		 * child + age 帯の異なる activities 5 件 + in-age/out-of-age 混在 logs 10 件を seed。
+		 * (per-child instance のため、年齢ごとに age 適合 copy が分岐することを検証)
+		 */
+		function seedFiveAgeModeFixture(db: Database.Database): void {
+			db.prepare("INSERT INTO categories (id, code, name) VALUES (1, 'undou', '運動')").run();
+			// 5 年齢モード代表 child
+			const childAges = [
+				{ nickname: 'baby', age: 1 },
+				{ nickname: 'preschool', age: 4 },
+				{ nickname: 'elementary', age: 9 },
+				{ nickname: 'junior', age: 14 },
+				{ nickname: 'senior', age: 17 },
+			];
+			for (const c of childAges) {
+				db.prepare('INSERT INTO children (nickname, age) VALUES (?, ?)').run(c.nickname, c.age);
+			}
+			// age 帯の異なる activities 5 件 (age_min/age_max を散らす)
+			const acts = [
+				{ name: 'all-ages', min: 0, max: 18 },
+				{ name: 'preschool-only', min: 3, max: 5 },
+				{ name: 'elementary-only', min: 6, max: 12 },
+				{ name: 'teen-only', min: 13, max: 18 },
+				{ name: 'archived-act', min: 0, max: 18, archived: 1 },
+			];
+			for (const a of acts) {
+				db.prepare(
+					'INSERT INTO activities (name, category_id, age_min, age_max, is_archived) VALUES (?, 1, ?, ?, ?)',
+				).run(a.name, a.min, a.max, a.archived ?? 0);
+			}
+		}
+
+		it('referenced (history) ∪ age 適合 activity を child_activities に copy し 4 table を remap する', () => {
+			seedActivitiesDataLossSchema(db);
+			seedFiveAgeModeFixture(db);
+
+			// elementary child (id=3, age 9) の history を作る: 'elementary-only' (id=3) を参照
+			insertOrphanRows(db, () => {
+				db.prepare(
+					"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (3, 3, 10, '2026-05-27')",
+				).run();
+				db.prepare(
+					"INSERT INTO daily_missions (child_id, mission_date, activity_id) VALUES (3, '2026-05-27', 3)",
+				).run();
+				db.prepare(
+					'INSERT INTO activity_mastery (child_id, activity_id, total_count) VALUES (3, 3, 5)',
+				).run();
+				db.prepare(
+					'INSERT INTO child_activity_preferences (child_id, activity_id, is_pinned) VALUES (3, 3, 1)',
+				).run();
+				// teen child (id=4, age 14) は 'teen-only' (id=4) の log を持つが age 適合は別途
+				db.prepare(
+					"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (4, 4, 7, '2026-05-26')",
+				).run();
+			});
+
+			// 全 4 table が orphan 状態であることを前提確認
+			expect(orphanCount(db, 'activity_logs')).toBeGreaterThan(0);
+
+			applyLazyStartupMigrations(db);
+
+			// child_activities が生成された
+			const caCount = (
+				db.prepare('SELECT COUNT(*) AS c FROM child_activities').get() as { c: number }
+			).c;
+			expect(caCount).toBeGreaterThan(0);
+
+			// 4 table の orphan = 0
+			expect(orphanCount(db, 'activity_logs')).toBe(0);
+			expect(orphanCount(db, 'daily_missions')).toBe(0);
+			expect(orphanCount(db, 'activity_mastery')).toBe(0);
+			expect(orphanCount(db, 'child_activity_preferences')).toBe(0);
+
+			// elementary child (id=3) は referenced 'elementary-only' + age 適合 (all-ages,
+			// elementary-only) を持つ。'teen-only' (age 13-18) は age 不適合のため含まれない。
+			const elemActs = db
+				.prepare(`SELECT ca.name FROM child_activities ca WHERE ca.child_id = 3 ORDER BY ca.name`)
+				.all() as { name: string }[];
+			const elemNames = elemActs.map((r) => r.name);
+			expect(elemNames).toContain('elementary-only'); // referenced + age 適合
+			expect(elemNames).toContain('all-ages'); // age 適合
+			expect(elemNames).not.toContain('teen-only'); // age 不適合 + 未参照
+			expect(elemNames).not.toContain('archived-act'); // archived は age 適合から除外
+
+			// teen child (id=4) は referenced 'teen-only' (age 適合でもある) を必ず持つ (history 保全)
+			const teenNames = (
+				db.prepare(`SELECT name FROM child_activities WHERE child_id = 4`).all() as {
+					name: string;
+				}[]
+			).map((r) => r.name);
+			expect(teenNames).toContain('teen-only');
+		});
+
+		it('5 年齢モードそれぞれで age 適合した activity 数が age 帯に応じて分岐する', () => {
+			seedActivitiesDataLossSchema(db);
+			seedFiveAgeModeFixture(db);
+			// 各 child に 1 件ずつ all-ages (id=1) の log を入れ orphan 状態を作る
+			insertOrphanRows(db, () => {
+				for (let childId = 1; childId <= 5; childId++) {
+					db.prepare(
+						"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (?, 1, 5, '2026-05-27')",
+					).run(childId);
+				}
+			});
+
+			applyLazyStartupMigrations(db);
+
+			const countFor = (childId: number) =>
+				(
+					db
+						.prepare('SELECT COUNT(*) AS c FROM child_activities WHERE child_id = ?')
+						.get(childId) as { c: number }
+				).c;
+
+			// preschool (age 4): all-ages + preschool-only = 2
+			expect(countFor(2)).toBe(2);
+			// elementary (age 9): all-ages + elementary-only = 2
+			expect(countFor(3)).toBe(2);
+			// junior (age 14): all-ages + teen-only = 2
+			expect(countFor(4)).toBe(2);
+			// senior (age 17): all-ages + teen-only = 2
+			expect(countFor(5)).toBe(2);
+			// baby (age 1): all-ages のみ = 1 (preschool-only は age_min 3 で不適合)
+			expect(countFor(1)).toBe(1);
+		});
+
+		it('冪等性: 2 回実行で child_activities が重複生成されない (no-op)', () => {
+			seedActivitiesDataLossSchema(db);
+			seedFiveAgeModeFixture(db);
+			insertOrphanRows(db, () => {
+				db.prepare(
+					"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (3, 3, 10, '2026-05-27')",
+				).run();
+			});
+
+			applyLazyStartupMigrations(db);
+			const after1 = (
+				db.prepare('SELECT COUNT(*) AS c FROM child_activities').get() as { c: number }
+			).c;
+			expect(after1).toBeGreaterThan(0);
+
+			// 2 回目: child_activities 非空 guard で skip → 重複生成なし
+			expect(() => applyLazyStartupMigrations(db)).not.toThrow();
+			const after2 = (
+				db.prepare('SELECT COUNT(*) AS c FROM child_activities').get() as { c: number }
+			).c;
+			expect(after2).toBe(after1);
+			// orphan も維持 (0)
+			expect(orphanCount(db, 'activity_logs')).toBe(0);
+		});
+
+		it('orphan が 1 件も無い場合は data copy を skip する (既正常 DB)', () => {
+			seedActivitiesDataLossSchema(db);
+			seedFiveAgeModeFixture(db);
+			// child_activities を 1 件手動投入し、log もその新 id を指す (orphan ゼロ)
+			db.prepare(
+				"INSERT INTO child_activities (id, child_id, name, category_id) VALUES (100, 3, 'existing', 1)",
+			).run();
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (3, 100, 10, '2026-05-27')",
+			).run();
+
+			applyLazyStartupMigrations(db);
+
+			// child_activities 非空 guard で skip。手動投入の 1 件のみ。
+			const caCount = (
+				db.prepare('SELECT COUNT(*) AS c FROM child_activities').get() as { c: number }
+			).c;
+			expect(caCount).toBe(1);
+		});
+
+		it('age 列が無い旧 activities schema でも referenced のみで copy + orphan 解消する', () => {
+			// age_min/age_max 無しの activities table を再構築
+			db.pragma('foreign_keys = OFF');
+			db.exec(`
+				CREATE TABLE children (id INTEGER PRIMARY KEY AUTOINCREMENT, nickname TEXT NOT NULL, age INTEGER NOT NULL DEFAULT 5, is_archived INTEGER NOT NULL DEFAULT 0);
+				CREATE TABLE activities (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, is_archived INTEGER NOT NULL DEFAULT 0);
+				CREATE TABLE child_activities (id INTEGER PRIMARY KEY AUTOINCREMENT, child_id INTEGER NOT NULL REFERENCES children(id), name TEXT NOT NULL);
+				CREATE TABLE checklist_templates (id INTEGER PRIMARY KEY, tenant_id TEXT NOT NULL DEFAULT 'default', name TEXT NOT NULL);
+				CREATE TABLE activity_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, child_id INTEGER NOT NULL REFERENCES children(id), activity_id INTEGER NOT NULL REFERENCES child_activities(id), points INTEGER NOT NULL, recorded_date TEXT NOT NULL);
+			`);
+			db.pragma('foreign_keys = ON');
+			db.prepare("INSERT INTO children (nickname, age) VALUES ('A', 8)").run();
+			db.prepare("INSERT INTO activities (name) VALUES ('walk')").run();
+			db.prepare("INSERT INTO activities (name) VALUES ('study')").run();
+			insertOrphanRows(db, () => {
+				db.prepare(
+					"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (1, 1, 10, '2026-05-27')",
+				).run();
+			});
+
+			expect(orphanCount(db, 'activity_logs')).toBe(1);
+			applyLazyStartupMigrations(db);
+
+			// referenced 'walk' (id=1) のみ copy。age 列無しなので age 適合 'study' は copy されない。
+			const names = (
+				db.prepare('SELECT name FROM child_activities WHERE child_id = 1').all() as {
+					name: string;
+				}[]
+			).map((r) => r.name);
+			expect(names).toEqual(['walk']);
+			expect(orphanCount(db, 'activity_logs')).toBe(0);
+		});
+	});
+
 	describe('foreign_keys pragma 状態の保全', () => {
 		it('呼び出し前後で foreign_keys=ON の状態が維持される', () => {
 			seedLegacyProductionSchema(db);


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 子供 / システム全体（特に既存 NUC セルフホストユーザー）

**解決する課題**: PR #2487 (#2458-A1) で activity-repo facade を旧 per-table `activities` から per-child `child_activities` に flip した際、既存 production DB の `activities` 行を `child_activities` へ copy する data migration が完全に漏れていた。結果 NUC ユーザーで活動履歴が全件 orphan 化し、UI の活動一覧・履歴表示が 0 件になる data 完全消失が発生した (Issue #2510)。緊急復旧 script (PR #2512) は手動実行を要するため、**startup 自動 migration による恒久 fix が未実装**だった。

**期待される効果**: アプリ起動時に旧 `activities` を per-child `child_activities` へ自動 copy + 4 table の FK remap を行い、過去 NUC のような data 消失を **新規 NUC / dev / CI 全環境で自動的に再発防止**する。手動復旧オペレーションを不要にし、既存ユーザーの活動履歴を恒久的に保全する。

## 関連 Issue

closes #2513
Related: #2510 (activities data 完全消失 umbrella)

<!-- 本 PR は #2509 (lazy-startup-migrations.ts 枠組、main 済 f77e150f1) + #2512 (緊急 recovery script + runbook + §8.6、main 済 cd3080296) の成果に dim 4 をコードで上乗せして完成させる。
     依存状態: #2509 / #2512 ともに main マージ済。本 PR は新 main に rebase 済で single-commit (cherry-pick 包含は解消)。mergeable=MERGEABLE。-->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | migrateActivitiesLegacyDataCopy(db) を lazy-startup-migrations.ts に追加 (guards / copy logic / orphan assert / 呼出順) | `git diff main -- src/lib/server/db/migration/lazy-startup-migrations.ts` | 関数実装 + applyLazyStartupMigrations 内 migrateActivityFkSwitchover の直後に挿入 (FK switch 完了を前提に remap が整合するため順序固定) |
| AC1-guards | activities/child_activities/children 不在 OR child_activities 非空 OR 4 table orphan ゼロ で skip | unit test「orphan が 1 件も無い場合は skip」「冪等性 2 回実行 no-op」 | PASS |
| AC1-copy | 各 child について referenced ∪ age 適合 ∪ is_archived=0 を copy + 4 table FK remap | unit test「referenced ∪ age 適合 を copy し 4 table を remap」 | PASS (elementary child = referenced + age 適合、teen-only は age 不適合で除外、archived は除外) |
| AC1-assert | orphan = 0 を throw で保証 | unit test 4 table orphan = 0 検証 + 実装の assertNoOrphansRemain throw | PASS |
| AC2-unit | 旧 schema fixture (activities 5 + children 5 + logs in/out-age 混在) で copy / age 分岐 / 冪等 / remap 検証 | `npx vitest run tests/unit/db/lazy-startup-migrations.test.ts` | 15 tests PASS (data copy 5 ケース追加) |
| AC2-integration | 旧 activities data + 新 code startup で activity 一覧 + 履歴表示成立を end-to-end 検証 | `npx vitest run tests/integration/db/startup-upgrade-path.test.ts` | 4 tests PASS (UI 一覧 child_activities > 0 + 履歴 JOIN 成立 + orphan 0) |
| AC3-section86 | docs/design/08-データベース設計書.md §8.6 を「data copy migration コード組込済」状態に更新 | docs/design/08-データベース設計書.md §8.6「実装ステータス (#2513)」 | dim 4 を「実装済 (PR #2513)」に更新、事例集 PR #2487 行を恒久 fix 完遂に更新 |
| AC3-runbook | docs/runbooks/activities-data-recovery.md §6 を「実装済」に更新 | docs/runbooks/activities-data-recovery.md §6 / §8 | 恒久 fix 5 項目を実装済に更新 + 関連 PR #2513 追記 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — migration ロジック追加 (table 定義変更なし)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`scripts/recover-activities-data.mjs` 同期 / `scripts/doc-code-references-baseline.json`)

**影響を受ける画面・機能**: startup 時の lazy migration (NUC / dev / CI)。間接的に全年齢モードの子供活動一覧・活動履歴・デイリーミッション・activity mastery・ピン留め (orphan 化していた 4 table の表示が復旧)。スキーマ定義 (schema.ts / create-tables.ts) は不変。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / check-no-plan-literals / doc-code-references / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要:
  - tests/unit/db/lazy-startup-migrations.test.ts: data copy 5 ケース追加（referenced ∪ age 適合 / 5 年齢モード age 分岐 / 冪等性 2 回実行 no-op / orphan ゼロ skip / age 列無し旧 schema）
  - tests/integration/db/startup-upgrade-path.test.ts: PR #2487 起因 orphan を startup full path (lazy → SQL_CREATE_TABLES → validateAndMigrate) で復旧し UI 一覧 + 履歴 JOIN 成立を end-to-end 検証
  - 計 19 tests PASS（unit 15 + integration 4）。全体 vitest 326 files / 5806 tests PASS
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（env 追加なし）
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（本 migration は単一 SQLite ファイル前提。DynamoDB backend は別 backfill が必要な旨を runbook に明記済）
- [x] **Critical バグ修正の場合**（ADR-0002）: 5 要件確認済み（下記「レビュー依頼事項」に詳細）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は DB startup migration ロジック + テスト + 設計書同期のみで UI コンポーネント (`.svelte`) を一切変更しない。間接的に活動一覧の表示が復旧するが、その復旧は tests/integration/db/startup-upgrade-path.test.ts で child_activities > 0 + 履歴 JOIN 成立として検証済み。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — migrateActivitiesLegacyDataCopy を copyAllChildActivities / copyChildActivities / assertNoOrphansRemain / detectCopyableActivityColumns / countOrphans / remapActivityIdColumn に分割（cognitive complexity 52 → max 20 以下）。
- [x] **DRY**: 緊急復旧 scripts/recover-activities-data.mjs と SQL logic を同期（runtime 都合で .ts helper を .mjs から import 共有できないため SQL を 2 箇所維持する旨を両ファイルにコメント明記）。column intersection / age 条件分岐ロジックを両者で一致させた。
- [x] **YAGNI**: copy 対象は referenced ∪ age 適合のみ（過剰な全件 copy を避ける）。古い schema の column 欠落耐性は実害（NUC で startup migration が schema 検証前に走る）に基づく必要最小の防御。
- [x] **Security（OSS 公開前提）**: 秘密情報なし。SQL は table 名固定 + parameterized bind（activity_id は内部 INTEGER）。N/A 寄り。
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: startup 1 回のみ実行 + child_activities 非空 guard で 2 回目以降 skip。child × activity ループは O(children × age-fit activities)、NUC 規模（数 child × 数百 activity）で許容。

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期 — N/A（startup migration は env 非依存、demo Lambda でも同一適用）
- [ ] **LP ↔ アプリ双方向整合** — N/A（LP 文言変更なし）
- [x] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開 — unit test「5 年齢モードそれぞれで age 適合した activity 数が age 帯に応じて分岐する」で baby=1 / preschool/elementary/junior/senior=2 を検証（ADR-0002 要件 4）
- [ ] ナビゲーション 3 種 — N/A
- [x] E2E / ユニットシード + チュートリアル同期 — schema 定義変更なしのため seed 変更不要。test fixture は本 PR test 内に自己完結
- [ ] **labels SSOT** (ADR-0009) — N/A（ユーザー向け文言変更なし）
- [x] **設計書同期** (ADR-0001): docs/design/08-データベース設計書.md §8.6 + docs/runbooks/activities-data-recovery.md §6/§8 を同 PR で更新
- [x] **並行 PR overlap** (#1200): #2512 が main マージ済 (cd3080296)。本 PR は新 main へ rebase 済で single-commit、overlap なし (recover-activities-data.mjs / runbook / §8.6 は #2512 の成果に dim 4 を上乗せ修正)
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（既存 data を保全する復旧 migration。schema 定義は不変）

**レビュー依頼事項・QA**:

ADR-0002 Critical 5 要件:
1. **E2E 回帰**: tests/integration/db/startup-upgrade-path.test.ts に PR #2487 起因 orphan の startup 復旧で UI 一覧 + 履歴 JOIN 成立を end-to-end 追加。既存 E2E / unit 全 PASS（5806 tests）
2. **AC 全完了**: AC1-AC3 全て実装・検証（上記 AC 検証マップ全行に結果記載）
3. **提案全実装**: migrateActivitiesLegacyDataCopy + recover script DRY 同期 + unit/integration test + 設計書/runbook 更新
4. **5 年齢モード検証**: unit test で baby/preschool/elementary/junior/senior の age 帯別 copy 件数分岐を検証
5. **直近 30 日重複変更チェック**: 同領域 PR #2487 (原因) / #2491 (demo+dynamodb) / #2509 (lazy-startup 枠組、main 済) / #2512 (緊急 recovery、open) を全認識。本 PR は dim 4 をコードで補完する補完 PR

設計判断で迷った点（要レビュー）:
- **DRY 限界**: recover-activities-data.mjs (NUC container 単発実行、TS toolchain 無し) と .ts helper は runtime が異なり import 共有不可。SQL logic を 2 箇所維持する方針を採った（両ファイルに SSOT 関係コメント明記）。ビルド成果物を container に配る案は Pre-PMF 過剰として不採用。
- **#2512 マージ後 rebase 済**: 実装中に #2512 が main マージされたため、当初 cherry-pick で取り込んでいた #2512 の 2 commit を drop し新 main へ rebase。現在は dim 4 実装の single-commit のみ (mergeable=MERGEABLE 確認済)。stacked PR (base != main で CI skip、#1808 教訓) は回避。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（本 PR は #2510 umbrella の Phase 3-4 として #2513 で起票済）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


