### PR TITLE
feat: #2519 data 保全 gate — backup restore 検証 + runtime data orphan 自動 gate (Closes #2519)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ PORT=3000
 # BACKUP_DIR=./data/backups
 # BACKUP_RETENTION=10
 # BACKUP_POST_HOOK=node scripts/hooks/gdrive-upload.cjs
+# #2519: docker compose --profile backup の cron は backup-db.cjs の後に
+#   verify-backup-restore.cjs を実行し、restore 可能性 (integrity_check /
+#   foreign_key_check / row count) を毎日検証する。失敗時は DISCORD_ALERT_WEBHOOK_URL
+#   宛に alert を送る。ALLOW_EMPTY=1 で「空 backup」を PASS にできる (初回検証 / CI smoke 用)。
 
 # Google Drive Backup hook (optional, used with BACKUP_POST_HOOK)
 # GDRIVE_CLIENT_ID=your_client_id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,14 +31,19 @@ services:
 
   # Scheduled backup service (runs daily at 3:00 AM JST)
   # Enable: docker compose --profile backup up -d
+  #
+  # #2519: backup → restore 検証を chain する。backup の「存在」だけでなく
+  # 「restore 可能 + 中身が壊れていない」を毎日確認し、verify 失敗時は
+  # verify-backup-restore.cjs が Discord alert を送る (DISCORD_ALERT_WEBHOOK_URL)。
+  # GDrive アップロードは BACKUP_POST_HOOK (.env) 経由で backup-db.cjs が実行する。
   backup:
     build: .
     entrypoint: /bin/sh
     command:
       - -c
       - |
-        echo "0 3 * * * cd /app && node scripts/backup-to-gdrive.cjs >> /proc/1/fd/1 2>&1" | crontab -
-        echo "[Backup] Cron scheduled: daily 3:00 AM JST (local + GDrive)"
+        echo "0 3 * * * cd /app && node scripts/backup-db.cjs >> /proc/1/fd/1 2>&1 && node scripts/verify-backup-restore.cjs >> /proc/1/fd/1 2>&1" | crontab -
+        echo "[Backup] Cron scheduled: daily 3:00 AM JST (backup + restore verification)"
         crond -f
     volumes:
       - ./data:/app/data

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -2126,6 +2126,36 @@ dim 4 漏れによる data orphan が発生した場合の復旧手順は [docs/
 
 Issue #2510 / #2507 のフォローアップで `scripts/check-schema-migration-completeness.mjs` を実装予定 (**本 PR scope 外**)。schema.ts 差分から破壊的変更 (DROP COLUMN / FK target 切替 / NOT NULL 変更 / cross-table flip) を検出し、create-tables.ts + lazy-startup-migrations.ts (structural + data copy) 双方の差分有無を CI gate 化。dim 4 の **実装** (本 PR #2513) と dim 4 漏れの **機械検出** (将来) は別レイヤである点に注意。
 
+### 8.7 data 保全 gate — runtime orphan 自動 gate + backup restore 検証 (#2519 / #2518 KPT)
+
+§8.6 の 4 dimension SSOT は「schema 破壊変更 PR が同期更新すべき file」を定める **予防策**。一方、予防が漏れた場合 (PR #2487 = dim 4 漏れ) を **実行時に検出する 2 つの gate** を #2519 で追加した。「検証を増やす」のではなく、**既存 gate の盲点 2 点を埋める最小十分対応** (ADR-0010 Bucket A: data 消失 = 親離脱の最重要 failure class)。
+
+#### gate 1: runtime data orphan 自動 gate
+
+| 項目 | 内容 |
+|---|---|
+| 実体 | `src/lib/server/db/migration/data-integrity-guards.ts` `assertNoDataOrphans(sqlite)` |
+| 呼出点 | `client.ts` の startup sequence、`applyLazyStartupMigrations()` + `SQL_CREATE_TABLES` + `validateAndMigrate()` の **後** (= migration 完了後) |
+| 監視対象 | core 4 table (`activity_logs` / `daily_missions` / `activity_mastery` / `child_activity_preferences`) の `activity_id → child_activities(id)` orphan。全 table 全 FK の毎起動チェックは過剰のため不採用 (cross-table flip 爆心地に限定) |
+| 検出時の挙動 | 常に `console.error` + (本番/dev) Discord alert (`emitOrphanAlert` DI 経由、fire-and-forget) + (test/CI) throw で fail-loud。**起動は止めない** (復旧 script は app 経由で実行するため、起動 block すると復旧不能になる) |
+| 盲点埋め | 既存 `scripts/check-orphan-tables.mjs` は static schema dead table を見るが runtime data orphan (FK 切れ row) を見ない = #2510 を捕捉できなかった構造的理由 |
+| 回帰テスト | `tests/integration/db/data-orphan-gate.test.ts` (legacy schema 自動修復で orphan=0 / 直接 orphan を throw で検出 / 健全 DB は throw せず / onOrphan callback) |
+
+#### gate 2: backup restore + integrity 検証
+
+| 項目 | 内容 |
+|---|---|
+| 実体 | `scripts/verify-backup-restore.cjs` |
+| 検証内容 | 最新 backup を一時 file に restore → `PRAGMA integrity_check`=ok + `PRAGMA foreign_key_check`=空 + 主要 table (`children` / `child_activities` / `activity_logs` / `point_ledger`) row count > 0 を assert。全 PASS で exit 0、1 つでも fail で exit 1 |
+| cron 組込 | `docker-compose.yml` の `backup` profile が daily 03:00 JST に `backup-db.cjs` → `verify-backup-restore.cjs` を chain 実行。verify 失敗時は `DISCORD_ALERT_WEBHOOK_URL` 宛に Discord alert (cron は `.cjs` のため SvelteKit module を import せず、最小 fetch を script 内に持つ) |
+| backup-db.cjs 格上げ | `backup-db.cjs` の backup 直後 integrity チェックを「table 数 > 0」から `integrity_check`=ok + `foreign_key_check`=空 に格上げ。WAL-safe な `db.backup()` は維持 |
+| 盲点埋め | 従来の `backup-db.cjs` は「table 数 > 0」しか確認せず「backup の存在 ≠ restore 可能」(GitLab 2017 postmortem 教訓) を満たさなかった。NUC は単一 SQLite で冗長性ゼロのため backup の restore 可能性が最後の砦 |
+
+#### scope 外 (ADR-0010 過剰防衛却下)
+
+- Litestream フル / 多重 backup 冗長 → 単一家庭 NUC では cron + `.backup()` + restore 検証で十分
+- candidate 1 (`migrateActivitiesLegacyDataCopy` data copy migration) は **PR #2513 で実装済** (§8.6 実装ステータス参照)、#2519 対象外
+
 ---
 
 ## 9. 更新履歴
@@ -2172,3 +2202,4 @@ Issue #2510 / #2507 のフォローアップで `scripts/check-schema-migration-
 | 2026-04-30 | 5.11 | #1755 (#1709-A umbrella) **破壊的 schema 変更** — `checklist_templates.kind` 列削除（持ち物純化）+ `activities.priority TEXT NOT NULL DEFAULT 'optional'` 列追加（'must' = 「今日のおやくそく」 / 'optional' = ふつうの活動）。旧ルーチン枠レコードは migration で drop し、ルーティン的な役割は `activities.priority='must'` に移管。ADR-0010 Pre-PMF 利用者ゼロ前提。後続 sub-issue (#1709-B/C) で親 admin UI（must トグル）/ 子供 UI（「今日のおやくそく」セクション + 達成率ボーナス preschool/elementary +5 / junior/senior +3 / baby 0）を実装。DynamoDB 側 (`activity-repo.ts`) も priority 属性を取扱う本実装（stub 禁止 #1021）。詳細は §activities §checklist_templates 参照 |
 | 2026-04-30 | 5.12 | #1711 (R3-D / ADR-0027) — 設計書の retroactive 同期。06-UI / 08-DB / lp-content-map / marketplace-preset-checklist-audit 全件で旧ルーチン枠語彙の表記揺れ排除。「kind 概念は活動 priority='must' に統合済」の記述を維持し、現役仕様としての旧ルーチン枠記述が 0 件となる状態を確立。schema 自体に変更なし（5.11 の状態を確認するメタ修正） |
 | 2026-05-27 | 5.13 | #2510 §8.6「Schema 変更時の SSOT 4 dimension」追加。NUC activities data 完全消失 (PR #2487 起因) + NUC startup blocking (PR #2480 起因 / #2508-#2509) 連続発生の構造的教訓として、schema 変更 PR が同期更新すべき 4 file (schema.ts / create-tables.ts / lazy-startup-migrations.ts structural / lazy-startup-migrations.ts data copy) を SSOT 化。dim 4 (data copy migration) は cross-table semantic flip 時の row 移動責務として dim 3 (structural) と独立に扱う。緊急復旧 runbook: `docs/runbooks/activities-data-recovery.md` |
+| 2026-05-27 | 5.14 | #2519 §8.7「data 保全 gate」追加。§8.6 (予防) の盲点を実行時に埋める 2 gate を実装: (1) runtime data orphan 自動 gate (`data-integrity-guards.ts` `assertNoDataOrphans`、startup で core 4 table の FK orphan 検出 + Discord alert + test throw)、(2) backup restore + integrity 検証 (`verify-backup-restore.cjs`、最新 backup を restore して integrity_check / foreign_key_check / row count > 0 を assert、NUC cron 組込 + 失敗時 alert)。`backup-db.cjs` の integrity を table 数 → integrity_check/foreign_key_check に格上げ |

--- a/scripts/backup-db.cjs
+++ b/scripts/backup-db.cjs
@@ -78,14 +78,37 @@ async function main() {
 	}
 	db.close();
 
-	// Verify integrity
+	// Verify integrity (#2519: table count → PRAGMA integrity_check + foreign_key_check に格上げ)
+	// table 数 > 0 は「file が開ける」程度の確認に過ぎず、page 構造の破損 / FK orphan を
+	// 見逃す。GitLab 2017 教訓 (backup の存在 ≠ restore 可能) に従い、backup 直後に
+	// integrity_check=ok + foreign_key_check=空 を確認する。
 	try {
 		const bdb = new Database(backupPath, { readonly: true });
-		const result = bdb
-			.prepare("SELECT COUNT(*) as cnt FROM sqlite_master WHERE type='table'")
-			.get();
-		bdb.close();
-		console.log(`[Backup] Integrity check: OK (${result.cnt} tables)`);
+		try {
+			const tableCount = bdb
+				.prepare("SELECT COUNT(*) as cnt FROM sqlite_master WHERE type='table'")
+				.get().cnt;
+
+			const integrity = bdb.pragma('integrity_check');
+			const integrityOk =
+				Array.isArray(integrity) && integrity.length === 1 && integrity[0].integrity_check === 'ok';
+			if (!integrityOk) {
+				throw new Error(`integrity_check failed: ${JSON.stringify(integrity)}`);
+			}
+
+			const fkViolations = bdb.pragma('foreign_key_check');
+			if (!Array.isArray(fkViolations) || fkViolations.length > 0) {
+				throw new Error(
+					`foreign_key_check found ${fkViolations.length} violation(s): ${JSON.stringify(fkViolations.slice(0, 5))}`,
+				);
+			}
+
+			console.log(
+				`[Backup] Integrity check: OK (${tableCount} tables, integrity_check=ok, foreign_key_check=clean)`,
+			);
+		} finally {
+			bdb.close();
+		}
 	} catch (err) {
 		console.error('[Backup] Integrity check FAILED:', err);
 		process.exit(1);

--- a/scripts/verify-backup-restore.cjs
+++ b/scripts/verify-backup-restore.cjs
@@ -1,0 +1,237 @@
+// scripts/verify-backup-restore.cjs — backup restore + integrity 検証 (#2519)
+//
+// Usage:
+//   node scripts/verify-backup-restore.cjs
+//
+// 最新 backup file を一時 file に restore (copy) し、以下を assert する:
+//   1. PRAGMA integrity_check  = 'ok'        (B-tree / page 構造の健全性)
+//   2. PRAGMA foreign_key_check = 空          (FK orphan が無い)
+//   3. 主要 table の row count  > 0           (空の backup = 復旧不能を検出)
+//
+// すべて PASS で exit 0、1 つでも fail で exit 1。
+//
+// ## 設計背景 (GitLab 2017 postmortem 教訓 — #2519 / research §7)
+//
+// 既存 `backup-db.cjs` は backup 後に「table 数 > 0」しか確認しない。これは
+// 「backup file が存在する」ことの確認に過ぎず、「その backup から実際に restore
+// できる / restore した DB が壊れていない / 中身が空でない」ことを保証しない。
+// GitLab 2017 の data loss incident は **backup が存在したのに restore できず**
+// 6 時間分の data を失った典型例。NUC は単一 SQLite で冗長性ゼロのため、backup の
+// restore 可能性検証が最後の砦になる (ADR-0010 Bucket A: data 保全 = 親離脱直結)。
+//
+// ## 検証対象 table
+//
+// data 消失が即 = 親離脱に直結する core data を持つ table:
+//   - children            (子供 = アカウントの中核)
+//   - child_activities    (各 child の活動 = Issue #2510 の orphan 爆心地)
+//   - activity_logs       (活動記録 = 貯めたポイントの履歴)
+//   - point_ledger        (ポイント残高明細)
+// いずれも「空 backup」は復旧不能 (= data 喪失) を意味するため row > 0 を要求する。
+// ただし backup が「真に空の新規 DB」である可能性 (初回起動直後 backup) を許容する
+// ため、ALLOW_EMPTY=1 で空 DB を PASS にできる (CI smoke / 初回検証用)。
+
+const Database = require('better-sqlite3');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+// .env 読込 (backup-db.cjs と同パターン)
+const envPath = path.join(__dirname, '..', '.env');
+if (fs.existsSync(envPath)) {
+	const envContent = fs.readFileSync(envPath, 'utf-8');
+	for (const line of envContent.split('\n')) {
+		const trimmed = line.trim();
+		if (trimmed && !trimmed.startsWith('#')) {
+			const eqIdx = trimmed.indexOf('=');
+			if (eqIdx > 0) {
+				const key = trimmed.slice(0, eqIdx).trim();
+				const val = trimmed.slice(eqIdx + 1).trim();
+				if (!process.env[key]) process.env[key] = val;
+			}
+		}
+	}
+}
+
+const DB_PATH = process.env.DATABASE_URL
+	? path.resolve(process.env.DATABASE_URL)
+	: path.join(__dirname, '..', 'data', 'ganbari-quest.db');
+const BACKUP_DIR = process.env.BACKUP_DIR
+	? path.resolve(process.env.BACKUP_DIR)
+	: path.join(path.dirname(DB_PATH), 'backups');
+const ALLOW_EMPTY = process.env.ALLOW_EMPTY === '1';
+// 明示 backup file 指定 (test / 単発検証用)。未指定なら BACKUP_DIR の最新を使う。
+const EXPLICIT_BACKUP = process.env.VERIFY_BACKUP_FILE
+	? path.resolve(process.env.VERIFY_BACKUP_FILE)
+	: '';
+
+// row > 0 を要求する core table (空 backup = 復旧不能の検出)
+const REQUIRED_NONEMPTY_TABLES = ['children', 'child_activities', 'activity_logs', 'point_ledger'];
+
+// 失敗時の Discord alert webhook (任意)。`src/lib/server/discord-alert.ts` と同 env を参照。
+// .cjs (cron) からは SvelteKit module を import できないため、ここで最小限の fetch を行う。
+const DISCORD_WEBHOOK =
+	process.env.DISCORD_ALERT_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_INCIDENT || '';
+
+/**
+ * 検証失敗を Discord に通知 (#2519 AC2)。webhook 未設定なら no-op。
+ * cron 経路で fail-loud にするための最小実装。
+ */
+async function notifyFailure(backupPath, failures) {
+	if (!DISCORD_WEBHOOK) return;
+	const embed = {
+		title: '🚨 [CRITICAL] backup restore 検証 失敗',
+		description: 'NUC backup が安全に restore できません。data 保全リスク。',
+		color: 10038562,
+		fields: [
+			{ name: 'Backup', value: `\`${backupPath}\``, inline: false },
+			{ name: 'Failures', value: `\`\`\`${failures.join('\n').slice(0, 800)}\`\`\`` },
+			{
+				name: '対応',
+				value: 'docs/runbooks/activities-data-recovery.md / backup cron を確認',
+			},
+		],
+		timestamp: new Date().toISOString(),
+		footer: { text: 'がんばりクエスト backup verification' },
+	};
+	try {
+		await fetch(DISCORD_WEBHOOK, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: '@everyone', embeds: [embed] }),
+		});
+		console.log('[verify] Discord alert sent');
+	} catch (err) {
+		console.error('[verify] Discord alert failed (non-fatal):', err.message);
+	}
+}
+
+/** BACKUP_DIR から最新の backup file path を返す (無ければ null)。 */
+function findLatestBackup() {
+	if (!fs.existsSync(BACKUP_DIR)) return null;
+	const files = fs
+		.readdirSync(BACKUP_DIR)
+		.filter((f) => f.startsWith('ganbari-quest-') && f.endsWith('.db'))
+		.sort()
+		.reverse();
+	return files.length > 0 ? path.join(BACKUP_DIR, files[0]) : null;
+}
+
+/** table が存在するか (PRAGMA / sqlite_master)。 */
+function tableExists(db, name) {
+	return !!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?").get(name);
+}
+
+/**
+ * 復元済 backup に対し integrity_check / foreign_key_check / row count を検査。
+ * @returns { ok: boolean, failures: string[] }
+ */
+function verifyRestoredDb(restoredPath) {
+	const failures = [];
+	const db = new Database(restoredPath, { readonly: true });
+	try {
+		// 1. integrity_check
+		const integrity = db.pragma('integrity_check');
+		const integrityOk =
+			Array.isArray(integrity) && integrity.length === 1 && integrity[0].integrity_check === 'ok';
+		if (integrityOk) {
+			console.log('[verify] PRAGMA integrity_check: ok');
+		} else {
+			failures.push(`integrity_check failed: ${JSON.stringify(integrity)}`);
+		}
+
+		// 2. foreign_key_check (空配列 = orphan なし)
+		const fkViolations = db.pragma('foreign_key_check');
+		if (Array.isArray(fkViolations) && fkViolations.length === 0) {
+			console.log('[verify] PRAGMA foreign_key_check: clean (0 violations)');
+		} else {
+			failures.push(
+				`foreign_key_check found ${fkViolations.length} violation(s): ${JSON.stringify(fkViolations.slice(0, 5))}`,
+			);
+		}
+
+		// 3. 主要 table row count > 0
+		const counts = [];
+		let totalRows = 0;
+		for (const table of REQUIRED_NONEMPTY_TABLES) {
+			if (!tableExists(db, table)) {
+				failures.push(`required table missing: ${table}`);
+				continue;
+			}
+			const c = db.prepare(`SELECT COUNT(*) AS c FROM ${table}`).get().c;
+			counts.push(`${table}=${c}`);
+			totalRows += c;
+		}
+		console.log(`[verify] row counts: ${counts.join(' ')}`);
+
+		// ALLOW_EMPTY=1 のとき「全 table 0 行」は PASS (初回起動直後 backup を許容)。
+		// そうでなければ各 table > 0 を要求する。
+		if (totalRows === 0 && ALLOW_EMPTY) {
+			console.log('[verify] all required tables empty but ALLOW_EMPTY=1 → treated as PASS');
+		} else {
+			for (const table of REQUIRED_NONEMPTY_TABLES) {
+				if (!tableExists(db, table)) continue;
+				const c = db.prepare(`SELECT COUNT(*) AS c FROM ${table}`).get().c;
+				if (c === 0) {
+					failures.push(`required table empty (data loss risk): ${table}`);
+				}
+			}
+		}
+	} finally {
+		db.close();
+	}
+	return { ok: failures.length === 0, failures };
+}
+
+async function main() {
+	console.log('=== Ganbari Quest Backup Restore Verification (#2519) ===');
+	console.log(`Time: ${new Date().toISOString()}`);
+
+	const backupPath = EXPLICIT_BACKUP || findLatestBackup();
+	if (!backupPath) {
+		console.error(`[verify] FAILED: no backup found in ${BACKUP_DIR}`);
+		console.error('[verify] backup が 1 件も無い = 復旧手段ゼロ。backup cron を確認してください。');
+		await notifyFailure(BACKUP_DIR, ['no backup found — backup cron が動いていない可能性']);
+		process.exit(1);
+	}
+	if (!fs.existsSync(backupPath)) {
+		console.error(`[verify] FAILED: backup file not found: ${backupPath}`);
+		await notifyFailure(backupPath, ['backup file not found']);
+		process.exit(1);
+	}
+	console.log(`Backup: ${backupPath}`);
+
+	// 一時 file に restore (本 backup を read-only で直接開かず copy して検証する。
+	// WAL / lock 干渉を避け、検証中に元 backup を変更しないため)。
+	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gq-verify-'));
+	const restoredPath = path.join(tmpDir, 'restored.db');
+	let result;
+	try {
+		fs.copyFileSync(backupPath, restoredPath);
+		console.log(`[verify] restored to temp: ${restoredPath}`);
+		result = verifyRestoredDb(restoredPath);
+	} finally {
+		// 一時 file は必ず削除
+		try {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		} catch (err) {
+			console.warn('[verify] temp cleanup failed (non-fatal):', err.message);
+		}
+	}
+
+	if (result.ok) {
+		console.log('[verify] PASS — backup is restorable and intact');
+		console.log('=== Verification complete ===');
+		process.exit(0);
+	}
+	console.error('[verify] FAILED — backup is NOT safely restorable:');
+	for (const f of result.failures) {
+		console.error(`  ✗ ${f}`);
+	}
+	await notifyFailure(backupPath, result.failures);
+	process.exit(1);
+}
+
+main().catch((err) => {
+	console.error('[verify] Fatal error:', err);
+	process.exit(1);
+});

--- a/src/lib/server/db/client.ts
+++ b/src/lib/server/db/client.ts
@@ -4,11 +4,35 @@
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { SQL_CREATE_TABLES } from './create-tables';
+import { assertNoDataOrphans, type OrphanReport } from './migration/data-integrity-guards';
 import { applyLazyStartupMigrations } from './migration/lazy-startup-migrations';
 import * as schema from './schema';
 import { validateAndMigrate } from './schema-validator';
 
 const DATABASE_URL = process.env.DATABASE_URL ?? './data/ganbari-quest.db';
+
+/**
+ * data orphan 検出時の Discord alert 送出 (#2519)。fire-and-forget。
+ * `discord-alert.ts` を **dynamic import** して startup module が
+ * `$env/dynamic/private` を eager load しないようにする。webhook 未設定環境
+ * (dev / CI) では `sendDiscordAlert` 側が no-op で抜ける。
+ */
+function emitOrphanAlert(report: OrphanReport): void {
+	const detail = Object.entries(report.counts)
+		.map(([table, count]) => `${table}=${count}`)
+		.join(' ');
+	import('../discord-alert')
+		.then(({ sendDiscordAlert }) =>
+			sendDiscordAlert({
+				level: 'critical',
+				message: `DATA ORPHAN 検出: core 4 table が child_activities(id) を参照できません (合計 ${report.total} 行)`,
+				errorSummary: `${detail}\n復旧: docs/runbooks/activities-data-recovery.md`,
+			}),
+		)
+		.catch((err) => {
+			console.error('[data-integrity-guard #2519] Discord alert 送出失敗', err);
+		});
+}
 
 const sqlite = new Database(DATABASE_URL);
 
@@ -59,6 +83,13 @@ if ((process.env.DATA_SOURCE ?? 'sqlite') === 'sqlite') {
 			process.exit(1);
 		}
 	}
+
+	// 4. runtime data orphan gate (#2519)。dim 4 (data copy migration) の漏れ /
+	//    別 backend からの誤った backfill 等で core 4 table が child_activities に
+	//    存在しない activity_id を指す orphan 状態 (= UI 表示 0 / history 消失、
+	//    Issue #2510 と同型) を startup で必ず検出する。orphan を検出しても起動は
+	//    止めず (復旧 script は app 経由で実行するため)、Discord alert で気付かせる。
+	assertNoDataOrphans(sqlite, { onOrphan: emitOrphanAlert });
 }
 
 export const db = drizzle(sqlite, { schema });

--- a/src/lib/server/db/migration/data-integrity-guards.ts
+++ b/src/lib/server/db/migration/data-integrity-guards.ts
@@ -1,0 +1,191 @@
+// src/lib/server/db/migration/data-integrity-guards.ts
+//
+// startup 時 (`client.ts`) に **`applyLazyStartupMigrations()` の後** に走る
+// runtime data orphan 検出 gate (Issue #2519 / #2518 KPT umbrella)。
+//
+// ## 設計背景 (Issue #2510 NUC activities data 完全消失 — 検出できなかった構造的理由)
+//
+// 既存の `scripts/check-orphan-tables.mjs` は **static schema の dead table**
+// (どの import からも参照されない table 定義) を検出するが、**runtime data の
+// orphan row (FK 切れの実 row)** を見ない。このため PR #2487 で
+// `activities` → `child_activities` cross-table flip 時に data copy migration
+// (4 dimension SSOT の dim 4) が漏れ、4 table の全 row が `child_activities` に
+// 存在しない `activity_id` を指す orphan 状態 (= UI 表示 0 + history 完全消失) に
+// なっても、CI / startup のどの gate も鳴らなかった (Issue #2510)。
+//
+// 本 file は **startup ごと** に core 4 table の FK orphan を count し、1 件でも
+// 検出すれば fail-loud にする最小十分 gate。dim 4 migration の漏れ / 不完全 copy /
+// 別 backend (DynamoDB) からの誤った backfill 等が **「黙って data が消える」前に
+// 必ず鳴る** ようにする。
+//
+// ## 監視対象 (core 4 table 限定、AC6)
+//
+// `migrateActivityFkSwitchover` (dim 3) で FK target を `child_activities` に
+// 切替えた 4 table のみ:
+//
+//   - activity_logs            (活動記録 = ポイント履歴の事実)
+//   - daily_missions           (今日のミッション)
+//   - activity_mastery         (熟練度)
+//   - child_activity_preferences (ピン留め設定)
+//
+// **全 table の全 FK を毎起動チェックするのは過剰** (起動が遅くなる + 検出対象が
+// 散漫になる) ため採用しない (AC6)。cross-table semantic flip が起きたのは
+// `activity_id → child_activities(id)` の 4 table であり、ここが #2510 の爆心地。
+// 将来別 table で同型 flip が起きたら本 file の `CORE_ORPHAN_CHECKS` に追加する。
+//
+// ## 失敗時の挙動
+//
+// - **常に** `console.error` で orphan 件数を出力 (NUC docker log / CloudWatch に残る)
+// - **test 環境** (`NODE_ENV=test` or `VITEST`): throw (CI / unit test で fail-loud)
+// - **本番/dev 起動時**: process は止めない (orphan があっても app は起動させ、
+//   UI から「見えないだけ」の状態で運用を継続させつつ alert で気付けるようにする)。
+//   呼び出し元 (`client.ts`) が `onOrphan` callback 経由で Discord alert を送る。
+//
+// startup を `process.exit(1)` で止めない理由: orphan は「data が物理削除された」
+// のではなく「FK 参照先が無く UI から見えない」状態であり、起動を止めると復旧
+// (`scripts/recover-activities-data.mjs` 実行 = app 経由) すらできなくなる。
+// alert で人間に気付かせ、runbook で復旧する方針 (ADR-0010 Bucket A、最小十分)。
+//
+// ## SSOT 注記
+//
+// orphan 判定 SQL は `docs/runbooks/activities-data-recovery.md` §3.1 /
+// `scripts/recover-activities-data.mjs` `ORPHAN_QUERIES` /
+// `lazy-startup-migrations.ts` `countOrphans` と同一 (NOT EXISTS で
+// `child_activities(id)` を参照しない row を数える)。runtime が異なるため
+// import 共有はできないが、判定ロジックを変える際は 3 箇所を同期させること。
+// 詳細: docs/design/08-データベース設計書.md §8.6。
+
+import type Database from 'better-sqlite3';
+
+/** orphan 検査対象の 1 table 定義 (core 4 table、AC6)。 */
+interface OrphanCheck {
+	/** orphan を数える子 table 名 */
+	table: string;
+	/** 子 table が指す親 table (本 gate では全て child_activities) */
+	parentTable: string;
+	/** 子 table 側の FK 列 (本 gate では全て activity_id) */
+	fkColumn: string;
+}
+
+/**
+ * core 4 table の orphan 検査定義 (#2510 cross-table flip 爆心地)。
+ * いずれも `activity_id` が `child_activities(id)` を参照する。
+ */
+const CORE_ORPHAN_CHECKS: readonly OrphanCheck[] = [
+	{ table: 'activity_logs', parentTable: 'child_activities', fkColumn: 'activity_id' },
+	{ table: 'daily_missions', parentTable: 'child_activities', fkColumn: 'activity_id' },
+	{ table: 'activity_mastery', parentTable: 'child_activities', fkColumn: 'activity_id' },
+	{
+		table: 'child_activity_preferences',
+		parentTable: 'child_activities',
+		fkColumn: 'activity_id',
+	},
+];
+
+export interface OrphanReport {
+	/** table 名 → orphan row 件数 */
+	counts: Record<string, number>;
+	/** orphan 合計件数 (全 table 合算) */
+	total: number;
+}
+
+function tableExists(db: Database.Database, name: string): boolean {
+	return !!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?").get(name);
+}
+
+/**
+ * 1 table の orphan (parent に存在しない FK 値を持つ row) 件数を返す。
+ * 子 table / 親 table いずれかが不在なら 0 (新規 DB / 旧 schema 互換)。
+ */
+function countOrphanRows(db: Database.Database, check: OrphanCheck): number {
+	if (!tableExists(db, check.table) || !tableExists(db, check.parentTable)) {
+		return 0;
+	}
+	const row = db
+		.prepare(
+			`SELECT COUNT(*) AS c FROM ${check.table} t
+			 WHERE NOT EXISTS (
+			   SELECT 1 FROM ${check.parentTable} p WHERE p.id = t.${check.fkColumn}
+			 )`,
+		)
+		.get() as { c: number };
+	return row.c;
+}
+
+/**
+ * core 4 table の orphan 件数を集計して返す (副作用なし、純関数)。
+ * test / 呼び出し元での assert に使う。
+ */
+export function collectDataOrphans(db: Database.Database): OrphanReport {
+	const counts: Record<string, number> = {};
+	let total = 0;
+	for (const check of CORE_ORPHAN_CHECKS) {
+		const c = countOrphanRows(db, check);
+		counts[check.table] = c;
+		total += c;
+	}
+	return { counts, total };
+}
+
+export interface AssertNoDataOrphansOptions {
+	/**
+	 * orphan 検出時に呼ばれる callback (本番/dev 起動経路で Discord alert を送るため)。
+	 * `data-integrity-guards.ts` が `discord-alert.ts` を直接 import しない (=
+	 * startup module が `$env/dynamic/private` を eager load しない) ための DI hook。
+	 * fire-and-forget で良い (本関数は callback の完了を待たない)。
+	 */
+	onOrphan?: (report: OrphanReport) => void;
+	/**
+	 * true なら orphan 検出時に throw する (test / CI 用)。
+	 * 未指定時は `NODE_ENV === 'test'` または `VITEST` env で自動 true。
+	 */
+	throwOnOrphan?: boolean;
+}
+
+function isTestEnv(): boolean {
+	return process.env.NODE_ENV === 'test' || process.env.VITEST === 'true';
+}
+
+/**
+ * core 4 table の runtime data orphan を検査する startup gate (#2519 AC4)。
+ *
+ * - orphan 0 件 → 何もしない (正常起動)
+ * - orphan 1 件以上 →
+ *   1. **常に** `console.error` で件数を出力 (log に必ず残す)
+ *   2. `onOrphan` callback があれば呼ぶ (本番/dev で Discord alert)
+ *   3. test 環境 (or `throwOnOrphan: true`) なら Error を throw (CI fail-loud)
+ *
+ * @returns orphan レポート (件数 0 でも返す)
+ */
+export function assertNoDataOrphans(
+	db: Database.Database,
+	options: AssertNoDataOrphansOptions = {},
+): OrphanReport {
+	const report = collectDataOrphans(db);
+	if (report.total === 0) return report;
+
+	const detail = CORE_ORPHAN_CHECKS.map((c) => `${c.table}=${report.counts[c.table] ?? 0}`).join(
+		' ',
+	);
+	const message = `[data-integrity-guard #2519] DATA ORPHAN detected — ${report.total} row(s) reference a missing child_activities(id): ${detail}. See docs/runbooks/activities-data-recovery.md`;
+
+	// 1. 常に console.error (NUC docker log / CloudWatch / app-YYYY-MM-DD.log)
+	console.error(message);
+
+	// 2. 本番/dev alert (DI 経由、fire-and-forget)
+	if (options.onOrphan) {
+		try {
+			options.onOrphan(report);
+		} catch (err) {
+			console.error('[data-integrity-guard #2519] onOrphan callback failed', err);
+		}
+	}
+
+	// 3. test / CI では throw (fail-loud)
+	const shouldThrow = options.throwOnOrphan ?? isTestEnv();
+	if (shouldThrow) {
+		throw new Error(message);
+	}
+
+	return report;
+}

--- a/src/lib/server/db/migration/data-integrity-guards.ts
+++ b/src/lib/server/db/migration/data-integrity-guards.ts
@@ -56,6 +56,7 @@
 // 詳細: docs/design/08-データベース設計書.md §8.6。
 
 import type Database from 'better-sqlite3';
+import { getEnv } from '$lib/runtime/env';
 
 /** orphan 検査対象の 1 table 定義 (core 4 table、AC6)。 */
 interface OrphanCheck {
@@ -143,7 +144,10 @@ export interface AssertNoDataOrphansOptions {
 }
 
 function isTestEnv(): boolean {
-	return process.env.NODE_ENV === 'test' || process.env.VITEST === 'true';
+	// env 直接参照禁止 (ADR-0040) のため $lib/runtime/env 経由。vitest は起動時に
+	// VITEST='true' を設定するため、CI / unit test では throwOnOrphan 既定 true。
+	const env = getEnv();
+	return env.NODE_ENV === 'test' || env.VITEST === 'true';
 }
 
 /**

--- a/tests/integration/db/data-orphan-gate.test.ts
+++ b/tests/integration/db/data-orphan-gate.test.ts
@@ -1,0 +1,264 @@
+// tests/integration/db/data-orphan-gate.test.ts
+//
+// Issue #2519 (#2518 KPT umbrella) runtime data orphan gate の回帰テスト。
+//
+// 検証する不変条件:
+//   1. legacy production schema (FK→activities) を seed → startup full sequence
+//      (applyLazyStartupMigrations → SQL_CREATE_TABLES → validateAndMigrate →
+//       assertNoDataOrphans) を通すと orphan = 0 (dim 4 data copy が自動修復し
+//      gate が PASS する)
+//   2. dim 4 が走れない壊れた DB (activities source 不在で orphan が残る) では
+//      assertNoDataOrphans が orphan を検出して throw する (= Issue #2510 のような
+//      「黙って data が見えなくなる」状態を startup で必ず fail-loud にする)
+//   3. orphan の無い健全な DB では throw しない
+//   4. onOrphan callback が orphan 検出時に呼ばれる (Discord alert DI hook)
+//
+// 本 gate が無かったため #2510 (NUC activities 全件 orphan) はどの CI / startup
+// チェックでも鳴らなかった。本テストはその構造的盲点が再発しないことを保証する。
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SQL_CREATE_TABLES } from '../../../src/lib/server/db/create-tables';
+import {
+	assertNoDataOrphans,
+	collectDataOrphans,
+} from '../../../src/lib/server/db/migration/data-integrity-guards';
+import { applyLazyStartupMigrations } from '../../../src/lib/server/db/migration/lazy-startup-migrations';
+import { validateAndMigrate } from '../../../src/lib/server/db/schema-validator';
+
+/**
+ * NUC production (#2508 / #2510 発生時点) の旧 schema を再現する seed。
+ * activity 系 4 table は FK target = activities (旧)、child_activities は空。
+ * startup-upgrade-path.test.ts の seedLegacyProductionDb と同形 (FK target 旧)。
+ */
+function seedLegacyProductionDb(db: Database.Database): void {
+	db.pragma('foreign_keys = OFF');
+	db.exec(`
+		CREATE TABLE children (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			nickname TEXT NOT NULL,
+			age INTEGER NOT NULL DEFAULT 5,
+			theme TEXT NOT NULL DEFAULT 'pink',
+			ui_mode TEXT NOT NULL DEFAULT 'preschool',
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			is_archived INTEGER NOT NULL DEFAULT 0,
+			archived_reason TEXT
+		);
+		CREATE TABLE categories (
+			id INTEGER PRIMARY KEY,
+			code TEXT NOT NULL UNIQUE,
+			name TEXT NOT NULL,
+			icon TEXT,
+			color TEXT
+		);
+		CREATE TABLE activities (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			category_id INTEGER REFERENCES categories(id),
+			icon TEXT NOT NULL DEFAULT '⭐',
+			base_points INTEGER NOT NULL DEFAULT 5,
+			is_visible INTEGER NOT NULL DEFAULT 1,
+			sort_order INTEGER NOT NULL DEFAULT 0,
+			source TEXT NOT NULL DEFAULT 'seed',
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			is_archived INTEGER NOT NULL DEFAULT 0,
+			archived_reason TEXT,
+			priority TEXT NOT NULL DEFAULT 'optional'
+		);
+		CREATE TABLE child_activities (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			name TEXT NOT NULL,
+			category_id INTEGER REFERENCES categories(id),
+			icon TEXT NOT NULL DEFAULT '⭐',
+			base_points INTEGER NOT NULL DEFAULT 5,
+			is_visible INTEGER NOT NULL DEFAULT 1,
+			sort_order INTEGER NOT NULL DEFAULT 0,
+			source TEXT NOT NULL DEFAULT 'seed',
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			is_archived INTEGER NOT NULL DEFAULT 0,
+			archived_reason TEXT,
+			priority TEXT NOT NULL DEFAULT 'optional'
+		);
+		CREATE TABLE activity_logs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			activity_id INTEGER NOT NULL REFERENCES activities(id),
+			points INTEGER NOT NULL,
+			streak_days INTEGER NOT NULL DEFAULT 1,
+			streak_bonus INTEGER NOT NULL DEFAULT 0,
+			recorded_date TEXT NOT NULL,
+			recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			cancelled INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE daily_missions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			mission_date TEXT NOT NULL,
+			activity_id INTEGER NOT NULL REFERENCES activities(id),
+			completed INTEGER NOT NULL DEFAULT 0,
+			completed_at TEXT
+		);
+		CREATE TABLE activity_mastery (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id),
+			activity_id INTEGER NOT NULL REFERENCES activities(id),
+			total_count INTEGER NOT NULL DEFAULT 0,
+			level INTEGER NOT NULL DEFAULT 1,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE child_activity_preferences (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			child_id INTEGER NOT NULL REFERENCES children(id) ON DELETE CASCADE,
+			activity_id INTEGER NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
+			is_pinned INTEGER NOT NULL DEFAULT 0,
+			pin_order INTEGER,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+	`);
+	db.pragma('foreign_keys = ON');
+}
+
+/** legacy DB に child + 旧 activities + 各 4 table の参照 row を投入 (#2510 再現素材)。 */
+function seedLegacyDataWithReferences(db: Database.Database): void {
+	db.pragma('foreign_keys = OFF');
+	db.prepare("INSERT INTO children (id, nickname, age) VALUES (1, 'A', 5)").run();
+	db.prepare("INSERT INTO activities (id, name) VALUES (10, 'walk')").run();
+	db.prepare("INSERT INTO activities (id, name) VALUES (11, 'study')").run();
+	// 4 table に旧 activity_id を参照する row を入れる (この時点では child_activities が空)
+	db.prepare(
+		"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (1, 10, 5, '2026-05-01')",
+	).run();
+	db.prepare(
+		"INSERT INTO daily_missions (child_id, mission_date, activity_id) VALUES (1, '2026-05-01', 11)",
+	).run();
+	db.prepare(
+		'INSERT INTO activity_mastery (child_id, activity_id, total_count) VALUES (1, 10, 3)',
+	).run();
+	db.prepare(
+		'INSERT INTO child_activity_preferences (child_id, activity_id, is_pinned) VALUES (1, 11, 1)',
+	).run();
+	db.pragma('foreign_keys = ON');
+}
+
+describe('runtime data orphan gate (#2519)', () => {
+	const prevNodeEnv = process.env.NODE_ENV;
+	const prevVitest = process.env.VITEST;
+
+	beforeEach(() => {
+		// test 環境では assertNoDataOrphans が自動 throw する (NODE_ENV=test or VITEST)
+		process.env.VITEST = 'true';
+	});
+	afterEach(() => {
+		process.env.NODE_ENV = prevNodeEnv;
+		process.env.VITEST = prevVitest;
+		vi.restoreAllMocks();
+	});
+
+	it('legacy schema + 参照 row を startup full sequence で通すと orphan=0 (dim 4 が自動修復) → gate PASS', () => {
+		const db = new Database(':memory:');
+		db.pragma('foreign_keys = ON');
+		try {
+			seedLegacyProductionDb(db);
+			seedLegacyDataWithReferences(db);
+
+			// === client.ts と同 sequence ===
+			expect(() => applyLazyStartupMigrations(db)).not.toThrow();
+			expect(() => db.exec(SQL_CREATE_TABLES)).not.toThrow();
+			const result = validateAndMigrate(db);
+			expect(result.errors, `unexpected errors: ${JSON.stringify(result.errors)}`).toEqual([]);
+
+			// === gate: dim 4 data copy が orphan を解消済 → throw しない ===
+			expect(() => assertNoDataOrphans(db, { throwOnOrphan: true })).not.toThrow();
+
+			// child_activities に row が copy され、4 table が全て解消されていること
+			const report = collectDataOrphans(db);
+			expect(report.total).toBe(0);
+			const childActCount = (
+				db.prepare('SELECT COUNT(*) AS c FROM child_activities').get() as { c: number }
+			).c;
+			expect(childActCount).toBeGreaterThan(0);
+		} finally {
+			db.close();
+		}
+	});
+
+	it('child_activities に存在しない activity_id を指す orphan row を検出して throw する', () => {
+		const db = new Database(':memory:');
+		db.pragma('foreign_keys = OFF'); // orphan を意図的に作るため FK OFF
+		try {
+			// 新 schema (FK→child_activities) を直接作成。child_activities は空のまま
+			// orphan な activity_logs row を 2 件挿入 (#2510 と同型の「参照先が無い」状態)
+			db.exec(SQL_CREATE_TABLES);
+			db.prepare("INSERT INTO children (id, nickname, age) VALUES (1, 'A', 5)").run();
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (1, 999, 5, '2026-05-01')",
+			).run();
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (1, 998, 3, '2026-05-02')",
+			).run();
+			db.prepare(
+				'INSERT INTO activity_mastery (child_id, activity_id, total_count) VALUES (1, 997, 1)',
+			).run();
+
+			const report = collectDataOrphans(db);
+			expect(report.counts.activity_logs).toBe(2);
+			expect(report.counts.activity_mastery).toBe(1);
+			expect(report.total).toBe(3);
+
+			// gate は throw する (test 環境)
+			expect(() => assertNoDataOrphans(db)).toThrowError(/DATA ORPHAN detected/);
+		} finally {
+			db.close();
+		}
+	});
+
+	it('orphan の無い健全な DB では throw しない & total=0', () => {
+		const db = new Database(':memory:');
+		db.pragma('foreign_keys = ON');
+		try {
+			db.exec(SQL_CREATE_TABLES);
+			db.prepare("INSERT INTO children (id, nickname, age) VALUES (1, 'A', 5)").run();
+			db.prepare(
+				"INSERT OR IGNORE INTO categories (id, code, name) VALUES (1, 'undou', 'うんどう')",
+			).run();
+			db.prepare(
+				"INSERT INTO child_activities (id, child_id, name, category_id, icon) VALUES (50, 1, 'walk', 1, '⭐')",
+			).run();
+			db.prepare(
+				"INSERT INTO activity_logs (child_id, activity_id, points, recorded_date) VALUES (1, 50, 5, '2026-05-01')",
+			).run();
+
+			let report = collectDataOrphans(db);
+			expect(report.total).toBe(0);
+			report = assertNoDataOrphans(db, { throwOnOrphan: true });
+			expect(report.total).toBe(0);
+		} finally {
+			db.close();
+		}
+	});
+
+	it('onOrphan callback が orphan 検出時に呼ばれる (Discord alert DI hook)', () => {
+		const db = new Database(':memory:');
+		db.pragma('foreign_keys = OFF');
+		try {
+			db.exec(SQL_CREATE_TABLES);
+			db.prepare("INSERT INTO children (id, nickname, age) VALUES (1, 'A', 5)").run();
+			db.prepare(
+				"INSERT INTO daily_missions (child_id, mission_date, activity_id) VALUES (1, '2026-05-01', 12345)",
+			).run();
+
+			const onOrphan = vi.fn();
+			// throwOnOrphan: false で callback だけ確認 (本番起動経路相当)
+			const report = assertNoDataOrphans(db, { onOrphan, throwOnOrphan: false });
+
+			expect(report.counts.daily_missions).toBe(1);
+			expect(onOrphan).toHaveBeenCalledTimes(1);
+			expect(onOrphan).toHaveBeenCalledWith(expect.objectContaining({ total: 1 }));
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/tests/integration/db/data-orphan-gate.test.ts
+++ b/tests/integration/db/data-orphan-gate.test.ts
@@ -17,7 +17,7 @@
 // チェックでも鳴らなかった。本テストはその構造的盲点が再発しないことを保証する。
 
 import Database from 'better-sqlite3';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SQL_CREATE_TABLES } from '../../../src/lib/server/db/create-tables';
 import {
 	assertNoDataOrphans,
@@ -144,16 +144,9 @@ function seedLegacyDataWithReferences(db: Database.Database): void {
 }
 
 describe('runtime data orphan gate (#2519)', () => {
-	const prevNodeEnv = process.env.NODE_ENV;
-	const prevVitest = process.env.VITEST;
-
-	beforeEach(() => {
-		// test 環境では assertNoDataOrphans が自動 throw する (NODE_ENV=test or VITEST)
-		process.env.VITEST = 'true';
-	});
+	// 注: vitest は起動時に VITEST='true' を設定するため、$lib/runtime/env 経由の
+	// isTestEnv() は本テスト runtime で true。throwOnOrphan を明示しない呼出は throw する。
 	afterEach(() => {
-		process.env.NODE_ENV = prevNodeEnv;
-		process.env.VITEST = prevVitest;
 		vi.restoreAllMocks();
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 実家庭（子供 + 親）/ システム全体

**解決する課題**: data 消失は親離脱の最重要 failure class。Issue #2510 (NUC activities 全件 orphan = 子供が貯めたポイント/履歴が UI から完全に見えなくなった事故) は、既存の static schema チェック (`check-orphan-tables.mjs`) も backup チェック (`backup-db.cjs` の「table 数 > 0」) も捕捉できなかった。「runtime data の orphan row を見ていない」「backup の存在 ≠ restore 可能を確認していない」という既存 gate の 2 つの盲点が原因。

**期待される効果**: 検証を増やすのではなく既存 gate の盲点を埋める最小十分対応として、(1) startup ごとに core 4 table の FK orphan を自動検出し alert する gate、(2) backup の restore 可能性 + integrity を毎日検証する gate、の 2 つを追加。dim 4 migration の漏れや別 backend からの誤った backfill で「黙って data が消える」前に必ず鳴るようにし、初顧客レビュー前に data 保全の最後の砦を確立する。

## 関連 Issue

closes #2519
Related: #2518 (KPT umbrella)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `scripts/verify-backup-restore.cjs` — 最新 backup を一時 file に restore → integrity_check=ok + foreign_key_check=空 + 主要 table row > 0 を assert | ローカル実証: 健全 backup で PASS / FK violation + 空 table で fail を確認 | 健全→exit 0、orphan/空→exit 1、no backup→exit 1、空+ALLOW_EMPTY=1→exit 0 (本文「テスト」参照) |
| AC2 | NUC cron 組込 + 失敗時 Discord alert | `docker-compose.yml` `backup` profile が daily 03:00 JST に `backup-db.cjs` → `verify-backup-restore.cjs` を chain。verify 失敗時 `DISCORD_ALERT_WEBHOOK_URL` 宛 alert | `docker-compose.yml` backup service / `verify-backup-restore.cjs` `notifyFailure()` |
| AC3 | `backup-db.cjs` の `db.backup()` (WAL-safe) 維持、integrity を table count → integrity_check/foreign_key_check に格上げ | `scripts/backup-db.cjs` の integrity check ブロック | `[Backup] Integrity check: OK (N tables, integrity_check=ok, foreign_key_check=clean)` をローカル確認 |
| AC4 | `assertNoDataOrphans(sqlite)` を新規 file に実装、core 4 table の FK orphan を count、>0 で console.error + (本番 alert / test throw)。`client.ts` で `applyLazyStartupMigrations()` の後に呼ぶ | `src/lib/server/db/migration/data-integrity-guards.ts` + `src/lib/server/db/client.ts` (validateAndMigrate の後に呼出) | 新規 file 作成 / client.ts に `emitOrphanAlert` DI で alert 配線 |
| AC5 | CI integration test「旧 schema fixture → startup → orphan=0」1 本 | `tests/integration/db/data-orphan-gate.test.ts` (4 ケース) | `npx vitest run tests/integration/db/data-orphan-gate.test.ts` → 4 passed |
| AC6 | core 4 table 限定 (全 table 全 FK 毎起動チェックは過剰、却下) | `CORE_ORPHAN_CHECKS` は activity_logs / daily_missions / activity_mastery / child_activity_preferences の 4 件のみ | `data-integrity-guards.ts` 冒頭コメント + 定数 |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — migration guard 追加（schema 自体は不変）
- [ ] サービス層
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [x] インフラ (`docker-compose.yml` backup cron)
- [ ] LP サイト
- [x] 設定・CI (`scripts/`, `.env.example`)

**影響を受ける画面・機能**: なし（UI 変更なし）。startup 経路 (`client.ts`) + NUC backup cron + 検証スクリプトのみ。schema 自体は不変で、gate を追加するのみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/integration/db/data-orphan-gate.test.ts` を新規追加（4 ケース: ① legacy schema + 参照 row を startup full sequence で通すと dim 4 が自動修復し orphan=0 → gate PASS / ② child_activities に存在しない activity_id を指す orphan を検出して throw / ③ 健全 DB は throw せず total=0 / ④ onOrphan callback が orphan 検出時に呼ばれる）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（新規 *必須* env なし。`verify-backup-restore.cjs` は既存 `DATABASE_URL` / `BACKUP_DIR` / `DISCORD_ALERT_WEBHOOK_URL` を再利用、optional な `ALLOW_EMPTY` / `VERIFY_BACKUP_FILE` のみ追加）
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（gate は SQLite (NUC) のみ。`client.ts` の `DATA_SOURCE === 'sqlite'` ブロック内に配置）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high feat。data 保全 gate の予防的追加）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: backend-only 変更。UI / .svelte の変更を含まない（startup migration guard + 検証スクリプト + cron 定義 + 設計書のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `data-integrity-guards.ts` は orphan 検出の単一責任。Discord alert は `onOrphan` callback DI で注入し、guard module 自体は `discord-alert.ts` / `$env/dynamic/private` を import しない（依存性逆転）
- [x] **DRY**: orphan 判定 SQL は `lazy-startup-migrations.ts` `countOrphans` / `recover-activities-data.mjs` `ORPHAN_QUERIES` / runbook §3.1 と同一ロジック。runtime が異なり import 共有不可のため SQL を同期する旨を 3 箇所すべてに明記（既存 #2513 の 2 箇所同期と同じ方針）
- [x] **YAGNI**: 全 table 全 FK の毎起動チェックは過剰として却下（AC6）。Litestream / 多重 backup 冗長も ADR-0010 過剰防衛として不採用
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。Discord webhook は env 経由。SQL は固定 table 名定数のみで動的補間に外部入力を含まない
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: orphan count は core 4 table の `COUNT(*) ... NOT EXISTS` のみ（起動時 1 回）。verify は一時 file に copy して read-only 検証し本番 DB をロックしない

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版 — N/A（UI 変更なし）
- [ ] LP ↔ アプリ双方向整合 — N/A
- [ ] 全年齢モード 5 種 — N/A
- [ ] ナビゲーション 3 種 — N/A
- [ ] E2E / ユニットシード — N/A（既存 seed 不変。新規テストは in-memory DB を自前 seed）
- [ ] labels SSOT — N/A（ユーザー向け文言なし、内部ログのみ）
- [x] **設計書同期** (ADR-0001): `docs/design/08-データベース設計書.md` §8.7「data 保全 gate」を新規追加 + 更新履歴 5.14 を追記
- [x] **並行 PR overlap** (#1200): **PR #2515 (#2513) が `lazy-startup-migrations.ts` を変更中**のため、本 PR は同 file を編集せず新規 file `data-integrity-guards.ts` に実装し `client.ts` から後段で呼ぶ方針で conflict を回避。`client.ts` は本 PR でのみ編集
- [ ] N/A

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（schema 不変。orphan 検出時も startup は止めず alert + log のみ。test 環境でのみ throw）

**レビュー依頼事項・QA**:
- `client.ts` の orphan gate は起動を `process.exit` で止めない設計（復旧 script は app 経由で実行するため、起動 block すると復旧不能になる）。orphan を許容して起動 → alert で気付かせ runbook で復旧する方針（ADR-0010 Bucket A 最小十分）。この trade-off の妥当性を確認いただきたい。
- `verify-backup-restore.cjs` の `notifyFailure` は cron (.cjs) から SvelteKit module を import できないため最小 fetch を script 内に持つ（`discord-alert.ts` の throttle/embed 機構は流用せず）。SSOT 重複の許容範囲かレビューいただきたい。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 *必須* env / secret の追加なし（既存 env 再利用 + optional flag のみ）

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1〜AC6 すべて実装 + 検証済み、未完の項目なし）
- [x] Phase 分割なし（1 PR で全 AC 完遂）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

<!-- QM が記入。CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（ADR-0022）。 -->

(QM レビュー待ち)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
