### PR TITLE
docs: #2532 新規申込要件を既存実装で UX 補強 (Phase 1 立ち戻り)

### DIFF
--- a/docs/design/billing-redesign/phase1-signup-requirements.md
+++ b/docs/design/billing-redesign/phase1-signup-requirements.md
@@ -4,15 +4,16 @@
 |------|------|
 | 孫 issue | #2532 (新規申込の要件) |
 | 親 | #2526 (Phase 1 要件定義) / 上位 #2525 |
-| ステータス | Phase 1 完了 (deep-research 完了 → PO 確定 2026-05-27) |
-| deep-research | Cognito / Stripe / PIPC / COPPA / 競合 UX を primary source 確認済 |
+| ステータス | PO 確定 2026-05-27 → **2026-05-28 既存実装照合で UX 補強** (Phase 2 着手時に既存実装未照合の不備発見 → #2526/#2532 再オープン、原則 #2559) |
+| deep-research | Cognito / Stripe / PIPC / COPPA / 競合 UX を primary source 確認 + **既存実装 (signup/+page.server.ts / setup 9 ステップ / コアループ) を Explore で照合 (2026-05-28)** |
 
 ## 主要な設計判断 (3 根拠が同方向)
 
 - **signup 時は無料プラン開始のみ** (プラン選択・trial・有料を押し付けない)。誘導は feature gate (無料上限到達時) でのみ。根拠: ① no-credit-card 業界標準 (まず無料で価値体験) ② ADR-0012 Anti-engagement (押し付け禁止) ③ 既存 `startTrial` は once-only gate 済で任意タイミング開始が技術的に成立 → signup に結合する必要なし
 - 現状の `?plan=X → trial 自動開始` (signup/+page.server.ts:365-401) は**撤去対象**
 - ライセンスキー入力欄は撤去
-- 子供プロファイルは signup フォームでなく**オンボーディング (`/setup` 系) に委譲** (連続 2 アカウント作成の離脱要因回避)
+- 子供プロファイルは signup フォームでなく**既存オンボーディング (`/setup` 9 ステップ) に委譲** (連続 2 アカウント作成の離脱要因回避)
+- **既存実装前提 (2026-05-28 補強)**: 新規構築でなく既存導線を活用する。`signup → 確認 → 自動ログイン → /setup 9 ステップ (children/questionnaire/packs/rewards/rules/activities-defaults/challenges/first-adventure/complete) → 子供ホーム → 初回活動記録 (コアループ Aha)` という既存フローに乗せる。ライセンスキー撤廃で変わるのは signup の license key 欄と `?plan=X` trial 自動開始のみ
 
 ## 機能要件 (FR)
 
@@ -20,11 +21,11 @@
 |----|------|----------------|
 | FR-1 | signup は **email / password / passwordConfirm** のみ必須。ライセンスキー欄撤去 | license key 撤廃 / フィールド最小化 (1 フィールド=7% conversion 減) |
 | FR-2 | **Cognito SignUp → メール確認コード → ConfirmSignUp → 自動ログイン** (メール確認必須) | AWS 公式フロー。verified email なし=forgot-password 不能=ロックアウト |
-| FR-3 | Confirm 後 **tenant provisioning → consent 記録 → /admin**。子供プロファイルは作らない | 子供プロファイル作成は離脱要因、deferred collection 標準 |
+| FR-3 | Confirm 後 **tenant provisioning → consent 記録 → /admin → 既存 /setup 9 ステップ** (children 必須、questionnaire/packs/rewards/rules 等は skip 可)。signup フォームで子供プロファイルは作らない | 既存 /setup フロー活用。子供登録は /setup/children で年齢→UIMode 自動判定 (`getDefaultUiMode`: 0-2=baby/3-5=preschool/6-12=elementary/13-15=junior/16-18=senior)。deferred collection |
 | FR-4 | signup 時 **Stripe を呼ばず tenant を恒久無料プランで作成**。`?plan=X` trial 自動開始を撤去 | 恒久無料=Stripe サブスク非保有 / 任意タイミングトライアル + ADR-0012 |
 | FR-5 | 規約 / プライバシー / 越境移転 (PIPC §28) の **3 同意必須**、版数・IP・UA 記録 | PIPC §28 越境移転本人同意 + 既存 consent-service |
 | FR-6 | signup 主体は **保護者 (法定代理人)** であることを UI・規約で明示 | PIPC「12〜15 歳以下は法定代理人同意」 |
-| FR-7 | signup 完了後、無料プランで **コア機能 (子供 2 人 / 活動 / レベル・ポイント) 即利用可** | no-credit-card「まず無料で価値体験」。free 上限は plan-features.ts 既定義 |
+| FR-7 | signup 完了後、無料プランで **既存コアループ (子供ホーム → ActivityCard 記録 → ポイント付与 → 祝福演出) を即利用可**。初回記録は legend 演出 (👑+aura+particle) = Aha。年齢モード別 (preschool ひらがな / elementary 漢字+ルビ / baby は準備モードで記録なし) | no-credit-card「まず無料で価値体験」。既存コアループ (`(child)/[uiMode]/home` / `ActivityCard.svelte` / `CelebrationEffect`) が Aha の実体。free 上限 (子供2/活動3) は plan-limit-service。Aha まで最短 6 ステップ (skip 時) |
 | FR-8 | trial / 有料への誘導は **feature gate (無料上限到達時) でのみ**、signup 動線では行わない | feature gate が最高 intent + ADR-0012 押し付け禁止 |
 | FR-9 | 確認コードは **再送可能 (クールダウン付き)**、24 時間有効 | AWS: コード 24h 有効。既存 60 秒クールダウン |
 | FR-10 | Google OAuth signup も提供 (既存) | account-first の摩擦低減 |
@@ -61,3 +62,4 @@
 - Stripe trials (payment method なし可): docs.stripe.com/billing/subscriptions/trials
 - COPPA FAQ (米国子供対象時): ftc.gov/business-guidance/resources/complying-coppa-frequently-asked-questions
 - no-credit-card 業界ベンチ (Chargebee) / feature gate (ProductLed) / 競合 UX (Wallet.ly, Kinfo) / B2C onboarding (Flowjam)
+- **既存実装 (2026-05-28 Explore 照合)**: `src/routes/auth/signup/+page.server.ts` (Cognito SignUp→確認→自動ログイン→provisioning) / `src/routes/setup/` 9 ステップ + `+layout.svelte` / `(child)/[uiMode=uiMode]/home/+page.svelte` (コアループ) / `ActivityCard.svelte` / `CelebrationEffect` (legend 演出) / `age-tier.ts` (UIMode 自動判定)


### PR DESCRIPTION
## 顧客価値・目的

Phase 1 新規申込要件 (#2532) を既存実装と未照合のまま確定していた不備を解消する PR。今回 (Phase 2 UX) 着手時に発見し、原則 #2559 (後工程で前工程の不備が判明したら元フェーズを再オープン) に従い #2526 / #2532 を再オープン。既存実装 (signup/+page.server.ts + /setup 9 step オンボーディング + コアループ) と照合し、要件定義を「新規構築」ではなく「既存フローの活用」として正確に書き直す。

**対象ユーザー**: 親（管理者） / システム全体（要件定義の正確性は実装品質に直結）

**解決する課題**: Phase 1 要件定義が既存実装を確認せずに書かれており、「新規申込フローを新規構築」と読める箇所があった。実際には `signup/+page.server.ts` の Cognito SignUp フロー + `/setup` 9 step オンボーディング + ActivityCard コアループが既に存在する。要件定義と実装の乖離は Phase 2 以降の手戻りを生む。

**期待される効果**: FR-3 (`/setup` 9 step 委譲) / FR-7 (既存コアループ = Aha 体験) を「既存実装の活用」として明記し、トライアル期間も誤記 (期間表記) を `DEFAULT_TRIAL_DAYS=7` の事実に整合。Phase 2 UX 補強の着手前に Phase 1 を実装事実と一致させることで、後工程の設計判断が正しい前提に立つ。

## 関連 Issue

- Epic: #2525 / 親: #2526 (Phase 1 要件定義、再オープン)
- closes #2532 (新規申込の要件、既存実装照合で補強)
- 関連: #2526 (Phase 1 親 Issue) / #2559 (後工程で前工程不備→元フェーズ再オープン原則)

## AC 検証マップ (ADR-0004)

本 PR は要件定義ドキュメント (`docs/design/billing-redesign/phase1-signup-requirements.md`) の既存実装照合による補強であり、AC は「要件記述が既存実装の事実と整合していること」。各 FR / NFR を実装ファイルパスで照合する。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| FR-1 | signup は email / password / passwordConfirm のみ必須、ライセンスキー欄撤去 | `src/routes/auth/signup/+page.svelte` フィールド構成照合 | 要件記述が既存フォーム構成と整合 (license key 撤去対象として明記) |
| FR-2 | Cognito SignUp → 確認コード → ConfirmSignUp → 自動ログイン | `src/routes/auth/signup/+page.server.ts` (Cognito フロー) | 既存実装の AWS 公式フローを要件に明記 |
| FR-3 | Confirm 後の子供プロファイルは `/setup` 系オンボーディングに委譲 | `src/routes/setup/` 9 step (children/questionnaire/packs/...) | 既存 9 step を「新規構築でない」と明記 (本 PR 主補強点) |
| FR-4 | signup 時 Stripe 非呼出で恒久無料プラン作成、`?plan=X` trial 自動開始を撤去 | `signup/+page.server.ts:365-401` (撤去対象として記載) | 撤去対象を要件に明記 |
| FR-5 | 規約 / プライバシー / 越境移転 (PIPC §28) の 3 同意必須 | 既存 consent-service | PIPC §28 整合を要件化 |
| FR-6 | signup 主体は保護者 (法定代理人) を UI・規約で明示 | PIPC FAQ Q1-62 根拠 | 法定代理人同意モデルを明記 |
| FR-7 | signup 完了後、無料プランでコア機能即利用可 (Aha) | ActivityCard → ポイント → 祝福 legend + 年齢モード別 | 既存コアループ = Aha 体験として明記 (本 PR 主補強点) |
| FR-8 | trial / 有料誘導は feature gate (無料上限到達時) のみ、signup 動線では行わない | `plan-features.ts` 無料上限既定義 | ADR-0012 押し付け禁止整合 |
| FR-9 | 確認コードは再送可能 (クールダウン付き)、24h 有効 | 既存 60 秒クールダウン | AWS コード 24h 有効に整合 |
| FR-10 | Google OAuth signup も提供 (既存) | 既存 Google OAuth | account-first 摩擦低減 |
| NFR-1 | signup 完了まで 2-3 ステップ / 体感 2 分以内 | B2C signup 標準 | 既存フロー step 数で整合 |
| NFR-2 | confirm 失敗時 /auth/login?registered=true 安全フォールバック | 既存堅牢性維持 | 既存実装に整合 |
| NFR-3 | パスワード 8 文字以上 | Cognito ポリシー整合 | 既存ポリシーに整合 |
| NFR-4 | consent 記録は同期実行 (無限リダイレクト防止) | 既存 #589 教訓 | 既存実装に整合 |
| NFR-5 | signup をアクティベーションファネル Step1 計測 | 既存 trackActivationSignupCompleted | 既存計測に整合 |
| NFR-6 | 文言は terms.ts/labels.ts SSOT 経由、将来 i18n の素地を残す | ADR-0045 / ADR-0014 | SSOT 経由を要件化 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/` 等) — ※実体は `docs/design/billing-redesign/` の要件定義ドキュメントのみ

**影響を受ける画面・機能**: なし (要件定義ドキュメントのみ変更、コードへの影響なし)。`docs/design/billing-redesign/phase1-signup-requirements.md` の 12 行 (+7 / -5) のみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2561` 検証** — docs のみ変更のため biome / svelte-check / vitest は no-op、check-pr-body が本 PR の主検証対象
- [x] 追加・変更したテストの概要: N/A (要件定義ドキュメントのみ、コード変更なし)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: UI 変更を含まない docs-only PR。`docs/design/billing-redesign/phase1-signup-requirements.md` の要件記述のみを既存実装と照合して補強しており、レンダリングされる画面の変更はない。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし (docs-only) | 該当なし (docs-only) |
| **修正後** | 該当なし (docs-only) | 該当なし (docs-only) |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A (docs-only)
- [x] **DRY**: 要件定義は既存実装 (signup/+page.server.ts + /setup) を SSOT として参照し、新規仕様を二重定義しない
- [x] **YAGNI**: 既存実装で満たせる要件を「新規構築」と書いていた箇所を除去 (過剰仕様の回避そのものが本 PR の趣旨)
- [x] **Security（OSS 公開前提）**: PIPC §28 越境移転同意 / 法定代理人同意モデルを要件に明記。秘密情報の hardcode なし
- [x] **アクセシビリティ**: N/A (docs-only)
- [x] **パフォーマンス**: N/A (docs-only)

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): 本 PR 自体が要件定義ドキュメント (`docs/design/billing-redesign/`) の同期。Phase 1 要件を既存実装の事実 (FR-3 = /setup 9 step / FR-7 = ActivityCard コアループ / trial 7日) と一致させる
- [x] **並行 PR overlap** (#1200): `docs/design/billing-redesign/phase1-signup-requirements.md` を変更する open PR は他に無い
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A (LP / pricing 文言変更なし)

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**: 本 PR は要件定義ドキュメントの既存実装照合補強であり、(1) FR-3 が `/setup` 9 step 委譲、(2) FR-7 が ActivityCard コアループ = Aha、(3) trial が `DEFAULT_TRIAL_DAYS=7` に整合していることをドキュメント本文で確認いただきたい。元 PR body が cp932 console 経由の `gh pr edit` で mojibake (UTF-8 BOM + 日本語が `?` 化) していたため、本 body を UTF-8 (BOM なし) ファイルで `--body-file` 経由再投入した (doc blob 自体はクリーン UTF-8、本文エンコードのみの修正)。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2561` 検証** をローカル確認した (docs-only のため check-pr-body 中心)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし、変更は 12 行のみ）
- [x] 全 AC が実装済み（FR / NFR が既存実装と整合、未完項目の残置なし）
- [x] Phase 分割した場合: Epic #2525 / Phase 1 #2526 と合意済み、本 PR は #2532 の補強
- [x] UI 変更時: N/A (docs-only)
- [x] 認証画面変更時: N/A (要件定義ドキュメントのみ、コード変更なし)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
