### PR TITLE
docs: #2527 Phase 2 UX ジャーニーマップ 7 本完成 (Reverse Trial / Tier Change / 4 谷 / ADR-0012 整合)

### DIFF
--- a/docs/design/billing-redesign/README.md
+++ b/docs/design/billing-redesign/README.md
@@ -1,11 +1,12 @@
-# 課金/プラン体系 再設計 — Phase 1 要件定義 (Epic #2525)
+# 課金/プラン体系 再設計 — Phase 1 要件定義 + Phase 2 UX ジャーニーマップ (Epic #2525)
 
 | 項目 | 内容 |
 |------|------|
 | 上位 Epic | #2525 (課金/プラン体系の顧客体験+システム全体再設計、7 phase) |
-| 本 Phase | #2526 (Phase 1/7 要件定義) |
-| ステータス | Phase 1 完了 (10 機能領域の要件を deep-research 一次情報で自己検証 + PO 確定) |
-| 作成日 | 2026-05-27 |
+| Phase 1 | #2526 (要件定義) — **完了** |
+| Phase 2 | #2527 (UX ジャーニーマップ) — **完了 2026-05-28** |
+| ステータス | Phase 2 完了 (7 ジャーニー、業界呼称 + Reverse Trial / Tier Change / Voluntary churn 整合 + mermaid 3 図 × 7 + 既存実装統合 + ADR-0012 / 特商法整合性チェック) |
+| 作成日 | 2026-05-27 (Phase 1) / 2026-05-28 (Phase 2) |
 
 > **位置づけ**: 全体計画 (要件定義 → UX → UI → 動線 → アーキ → 実装詳細 → 実装) の Phase 1 成果物。各要件は設計意図 + 根拠 (法令/Stripe 公式/業界標準の一次情報) 付き。Phase 2 (UX) 以降の土台。
 
@@ -31,11 +32,51 @@
 | セキュリティ | #2540 | webhook tenant 再検証・認可境界・PII/PCI 最小化・過剰防衛除外 | [security](phase1-security-requirements.md) |
 | 法務 | #2541 | キー言及削除・特商法最終確認画面5項目・tokushoho 改訂・トライアル後自動課金なし整合 | [legal](phase1-legal-requirements.md) |
 
-## Phase 2-7 への接続
+## Phase 2 — UX ジャーニーマップ (7 ジャーニー索引)
 
-- **Phase 2 (UX, #2527)**: 各機能領域のユーザージャーニーマップ
+各ジャーニーは既存実装前提 + 業界呼称 + 感情曲線 (mermaid journey) + 状態遷移 (mermaid stateDiagram) + 動線/処理フロー (mermaid flowchart) + PO 既出指摘との整合性 (4 谷 / Reverse Trial / 文言 atom / ADR-0012 / 特商法 6 項目) を完備。
+
+| ジャーニー | 孫 | 業界呼称 | 主要発見 | ファイル |
+|---|---|---|---|---|
+| 新規申込 | #2546 | Activation funnel / PQL / Time-to-Aha | 主体は最後まで親、2 山構造 (中間山 setup 完遂 + 最終山 初回記録 親代行 OK)、マーケットプレイス推奨自動採用 + デフォルト表示選択は既存実装で概ねカバー | [signup](phase2-signup-journey.md) |
+| トライアル | #2547 | **Reverse Trial** (4 核要素整合) | カスタマイズ持続性 = 課金 hook、ADR-0012 と本質的整合、follow-up: 7→14 日 A/B / Notion 型 read-only ADR 化 / PQL 計測 / 季節性更新 | [trial](phase2-trial-journey.md) |
+| 有料化 | #2548 | Reverse Trial パターン C / 4 谷 | 4 谷統合 (プラン選択/金額/解約柔軟性/購入動線)、gate tooltip & LP 動線説明既存 ✅、ヘッダ有料時遷移のみ欠落 | [checkout](phase2-checkout-journey.md) |
+| アップ/ダウングレード | #2549 | Tier Change / Expansion / Contraction / NRR | 超過リソース既に Notion 型 Pattern A 実装済、proration UX (Preview API) のみ新規必要、`PLAN_CHANGE_TERMS` atom 拡張案 | [plan-change](phase2-plan-change-journey.md) |
+| 解約・退会 | #2550 | Voluntary churn / Save flow / Account deletion | 解約 = 無料に戻る・データ保持 / 退会 = 全削除、ADR-0012 引き止めない | [cancellation](phase2-cancellation-journey.md) |
+| dunning | #2551 | Involuntary churn / Dunning mgmt / Stripe Smart Retries | 子供視点 zero touch、grace 2週移行、無料化新規 (Phase 1 確定) | [dunning](phase2-dunning-journey.md) |
+| NUC | #2552 | Self-hosted / Edition Bifurcation / Trust-based (DRM-less) | 課金導線なし、ADR-0051 整合、NRR 計算外 | [nuc](phase2-nuc-journey.md) |
+
+### Phase 2 横断確定事項
+
+- **業界呼称の統一**: Reverse Trial / Tier Change / Voluntary・Involuntary churn / Edition Bifurcation を SSOT として確定
+- **超過リソース処理 = Notion 型 Pattern A** (read-only + 復元可) を全領域共通方針として採用 (Reverse Trial 終了 ⇔ 手動ダウンを同一機構で実装、Phase 5 申し送り)
+- **文言 atom 「失う/消える」排除原則** (Calendly 反面教師): `PLAN_CHANGE_TERMS` (changeVerb/archive/restore/protected/resumeReady) を terms.ts 拡張候補 (ADR-0045 整合)
+- **子供 UI 完全 zero touch**: 全 7 ジャーニーで子供 UI に課金/プラン/dunning/trial 関連 UI 一切表示禁止 (ADR-0012 完全担保)
+
+### Phase 3/4/5 申し送り (Phase 2 で抽出された改善要項目)
+
+**Phase 3 (UI, #2528)** — 11 項目
+- お勧めバッジ (standard に decoy 効果) / 比較表差分強調 / ROI framing (1 日 ¥16, 家族 1 人 ¥260) / `CANCEL_TERMS.anytimeOk` CTA 直下
+- proration 差額 confirm モーダル (`create_preview` 結果表示) / DowngradeResourceSelector 文言 atom 化
+- ヘッダ有料時 plan-badge クリック遷移追加 / 期末ダウン期間中 banner / archived の親画面 read-only + 上位プラン CTA
+- success polling UI (Phase 1 FR-6) / 特商法最終確認画面 6 項目
+
+**Phase 4 (動線, #2529)** — 5 項目
+- LP→app 統一 CTA 文言 (`CTA_TERMS.freeTrialVerb` atom) / LP pricing FAQ 強化 / trial→in-app paywall (Reverse Trial パターン C) / One-click reactivation 常時表示 / アップ動線統一 CTA
+
+**Phase 5 (アーキ, #2530)** — 8 項目
+- `subscriptions.update` + `proration_behavior=always_invoice` (アップ即時) + `none + schedule_at_period_end` (ダウン期末)
+- Preview API (`POST /v1/invoices/create_preview`)
+- `archiveForDowngrade` を Reverse Trial 終了でも再利用 (共通機構化、`resource-archive-service.ts` 統合)
+- `PLAN_CHANGE_TERMS` atom + `PLAN_CHANGE_LABELS` compound 追加
+- Stripe Pricing Table vs 自前 Checkout の判断 / Customer Portal cancellation reasons 設定
+- Product 構成 (1 Product 4 Price vs 4 Product) / webhook 冪等性 DB 新規
+
+**Phase 1 からの申し送り (継続)**: Product 構成 (#2535→Phase 5) / 最終確認画面実装方式 (#2541→Phase 3/5) / judgment 保留テーブル (#2538→Phase 5)
+
+## Phase 3-7 への接続
+
 - **Phase 3 (UI, #2528)** / **Phase 4 (動線, #2529)** / **Phase 5 (アーキ, #2530)** / **Phase 6 (実装詳細, #2514)** / **Phase 7 (実装, #2531)**
-- 後続 phase に申し送る論点: Product 構成 (#2535→Phase 5) / 最終確認画面実装方式 (#2541→Phase 3/5) / judgment 保留テーブル (#2538→Phase 5)
 
 ## 横断確定事項
 

--- a/docs/design/billing-redesign/phase2-cancellation-journey.md
+++ b/docs/design/billing-redesign/phase2-cancellation-journey.md
@@ -1,0 +1,151 @@
+# 解約・退会 ジャーニーマップ (#2550 / Epic #2525 Phase 2 UX) — 既存実装前提
+
+| 項目 | 内容 |
+|------|------|
+| 孫 issue | #2550 (解約・退会のジャーニー) |
+| 親 | #2527 (Phase 2 UX) / 上位 #2525 |
+| ステータス | 既存実装前提で設計 (2026-05-28、Phase 1 で cancellation-service / account-deletion-flow 照合済) |
+| 対応 Phase 1 要件 | phase1-cancellation-requirements.md (#2536: 期末解約・解約理由は確定後任意 skip 可・退会は全削除) |
+
+## 既存実装の事実 (Phase 1 照合)
+
+- `cancellation-service.ts`: 解約理由 3 分類 + 自由記述。**現状は解約理由「必須」** (→ 要件で確定後任意・skip 可へ)
+- `stripe-service.ts:165-207 cancelSubscription`: **現状は即時 cancel** (→ 要件で `cancel_at_period_end=true` 期末解約へ)
+- 退会: `account-deletion-flow.md` §0/§4/§5。退会時 Stripe (subscription cancel + Customer 削除) → DB 全削除 (ADR-0022 順序)
+- 解約後の読み取り専用猶予: `grace-period-service.ts` (free 0/std 7/family 30日) ← dunning grace とは別概念
+
+## 解約と退会は別物 (2 ジャーニー)
+
+| | 解約 (subscription cancel) | 退会 (account deletion) |
+|---|---|---|
+| 対象 | 有料サブスクの停止 | アカウント・全データの削除 |
+| 結果 | 無料プランに戻る (データ保持) | 全削除 (復元不可) |
+| Stripe | cancel_at_period_end | subscription cancel + Customer 削除 |
+
+## ジャーニー A: 解約 (有料 → 無料)
+
+| # | ステップ | 既存実装 | 保護者の体験 | 感情 | 離脱(=継続) |
+|---|---|---|---|---|---|
+| 0 | 解約を検討 | — | 使わなくなった/高い | 迷い | — |
+| 1 | 解約入口 | admin 設定 / Customer Portal | 「解約する」を探す | (引き止めない、ADR-0012) | — |
+| 2 | **期末解約の明示** | `cancel_at_period_end=true` (要件) | 「期末まで使えます」 | 安心 (支払分は使える、特商法公平) | — |
+| 3 | 解約確定 | cancelSubscription (期末) | 確定 | すっきり | — |
+| 4 | **解約理由 (任意・skip 可)** | cancellation-service (要件で skip 可) | 任意で理由選択 or skip | 負担なし (skip OK) | — |
+| 5 | 期末まで利用 → 期末に無料化 | webhook subscription.deleted → 無料 tier | 期末に自動で無料へ、データ保持 | 納得 | — |
+
+## ジャーニー B: 退会 (全削除)
+
+| # | ステップ | 既存実装 | 保護者の体験 | 感情 | 離脱(=思いとどまる) |
+|---|---|---|---|---|---|
+| 0 | 退会を決意 | — | 完全にやめる | 決断 | — |
+| 1 | 退会入口 | admin 設定 (account-deletion-flow §0) | 「退会」を探す | — | — |
+| 2 | **有料期間残の警告** | 退会前に解約を促す (要件、引き止めにならない範囲) | 「有料期間が残っています」 | 注意喚起 | 中 (先に解約を選ぶ) |
+| 3 | 削除範囲の明示 | 全データ削除・復元不可の確認 | 子供の記録も全部消えると理解 | **躊躇 (記録が消える) ← 谷** | 高 |
+| 4 | 退会確定 | Stripe cancel+Customer 削除 → DB 全削除 (ADR-0022 順序) | 確定 | 区切り | — |
+
+## 感情曲線と既存実装に即した対策
+
+- **解約 (引き止めない、ADR-0012)**: retention coupon OFF・ダークパターンなし。「期末まで使える」明示が誠実さ = 再契約余地。解約理由は**確定後**に任意収集 (特商法ダークパターン規制回避 + churn データ両立、Phase 1 FR-4)
+- **退会の谷③ (記録消失の恐怖)**: 子供の活動記録・ポイントが全部消える = 最大の躊躇。**退会前にエクスポート導線を提示** (Phase 1 データライフサイクル #2538「エクスポート UI 化」と整合)。引き止めではなく「データを持ち帰れる」提示
+- **解約 ≠ 退会の明確化**: 「やめたい」が「解約 (無料に戻る・データ残る)」で足りるのに「退会 (全削除)」を選ばせない動線設計 (Phase 4)
+
+## 既存からの変更点 (delta)
+
+| # | 既存 | 要件 | 扱い |
+|---|---|---|---|
+| 1 | 即時 cancel (cancelSubscription) | 期末解約 (cancel_at_period_end) | 変更 (FR-1) |
+| 2 | 解約理由 必須 | 確定後 任意 (skip 可) | 変更 (FR-4、特商法) |
+| 3 | cancellation-service 骨格 / Portal / 退会全削除順序 | 維持 | ✅ 既存整合 |
+
+## 年齢モード別の含意
+
+解約・退会は **tenant 単位**で年齢モード非依存。ただし退会時の「記録消失」は**子供ごとの活動履歴・ポイント・称号**が対象 = 複数子供世帯ほど喪失感大 → エクスポート提示の重要度が上がる。子供画面には解約・退会導線を**一切出さない** (ADR-0012、owner/parent のみ)。
+
+## UX レビュー観点 (3 ペルソナ、Phase 2 完了基準)
+
+- **幼児親 (preschool・記録少)**: 解約と退会の違いが分かるか / 期末まで使えると分かり不安にならないか
+- **小学生親 (記録多・長期利用)**: 退会時の記録消失の重さ / エクスポート導線が見つかるか / 解約で足りると気づけるか
+- **中高生親 (卒業期)**: 卒業に伴う退会で、子の成長記録を持ち帰れるか (GRADUATION_TERMS 整合)
+
+## Open question (PO 判断)
+
+| # | 論点 | 状態 |
+|---|------|------|
+| 1 | 退会前エクスポートの形式・範囲 | データライフサイクル #2538 と整合、Phase 3 UI |
+| 2 | 解約理由 3 分類の文言 | cancellation-service 既存分類、Phase 3 で文言 |
+| 3 | 期末解約後の再契約導線 | Phase 4 動線 (引き止めない範囲で) |
+
+## 業界呼称・PO 既出指摘との整合性 (2026-05-28 追補)
+
+- **業界用語**: 解約 = **Voluntary churn** (cancel anytime / Save flow / Cancellation Reasons) / 退会 = **Account deletion** (Right to be forgotten、PIPC §33-35 整合)
+- **4 谷参照**: プラン選択困惑 / 金額説得力 / 解約柔軟性 / 購入動線探索は `phase2-checkout-journey.md` 参照。本ジャーニーでは **谷③解約柔軟性が中心テーマ** (cancel anytime / Customer Portal / 期末解約)
+- **Reverse Trial データ持続性原則** (`phase2-trial-journey.md`): 解約後も無料プランで子供活動記録・カスタマイズは保持。退会との明確な区別 = 「データ消えない」訴求の核
+- **文言 atom 「失う / 消える」排除** (`phase2-plan-change-journey.md` PLAN_CHANGE_TERMS 拡張案と整合): 解約 = 「無料に戻る・データ保護」、退会 = 「全削除を確認」(事実明示で煽らない)
+- **ADR-0012 整合**: 引き止め (retention coupon) なし、子供画面に解約・退会導線一切なし
+- **特商法 (JP) 整合**: cancel_at_period_end (公平性) / Customer Portal 自己解約 (改正特商法のダークパターン規制整合) / 退会前のデータエクスポート提示 (PIPC 整合)
+
+## mermaid 図示
+
+### 図 1: 解約・退会 2 ジャーニーの感情曲線 (journey)
+
+```mermaid
+journey
+    title 解約・退会 ジャーニー (引き止めない・煽らない)
+    section 解約 (Voluntary churn)
+      解約検討: 3: 親
+      期末解約の明示: 4: 親
+      解約理由 (任意・skip 可): 4: 親
+      期末まで利用: 4: 親
+      期末で自動無料化 (データ保持): 4: 親
+    section 退会 (Account deletion)
+      退会決意: 2: 親
+      有料期間残の警告: 3: 親
+      記録消失の確認: 1: 親
+      エクスポート導線: 4: 親
+      退会確定 (全削除): 3: 親
+```
+
+### 図 2: 状態遷移 (paid → free vs paid → deleted)
+
+```mermaid
+stateDiagram-v2
+    [*] --> paid_active
+    paid_active --> paid_period_end : cancel_at_period_end (解約)
+    paid_period_end --> free : 期末で自動無料化 (データ保持)
+    paid_active --> account_deleted : 退会フロー (全削除)
+    free --> [*]
+    account_deleted --> [*]
+    note right of free
+      子供活動記録・カスタマイズは保持
+      (Reverse Trial データ持続性原則)
+    end note
+    note right of account_deleted
+      Stripe Customer 削除 → DB 全削除
+      (ADR-0022 順序)
+    end note
+```
+
+### 図 3: 解約 vs 退会の判断分岐 (flowchart)
+
+```mermaid
+flowchart TB
+    Start[「やめたい」と意識] --> Choice{何をやめる?}
+    Choice -->|有料サブスクのみ| Cancel[解約フロー]
+    Choice -->|アカウント・全データ| Delete[退会フロー]
+    Cancel --> CancelConfirm[期末解約確定<br/>cancel_at_period_end]
+    CancelConfirm --> FreeDowngrade[期末で自動無料化<br/>データ保持]
+    Delete --> Warning[警告:有料期間残 + 記録消失]
+    Warning --> Export[エクスポート導線提示]
+    Export --> DeleteConfirm[退会確定]
+    DeleteConfirm --> AllDeleted[Stripe Customer 削除<br/>→ DB 全削除]
+    style Cancel fill:#d4edda
+    style Delete fill:#fff3cd
+    style AllDeleted fill:#f8d7da
+```
+
+## 根拠
+
+- **既存実装 (Phase 1 照合)**: `cancellation-service.ts` (3分類+自由記述・必須→任意) / `stripe-service.ts:165-207` (即時→期末) / `account-deletion-flow.md` (退会全削除順序) / `grace-period-service.ts` (解約後猶予)
+- Phase 1 phase1-cancellation-requirements.md (#2536) / phase1-data-lifecycle (#2538 エクスポート) / ADR-0022 (削除順序) / ADR-0049 (データ保持)
+- Stripe cancel/configure-portal (cancel_at_period_end・retention OFF) / 特商法 (ダークパターン規制) / ADR-0012 (引き止めない)
+- ※ 自プロダクトの既存解約・退会動線を主軸に設計 (feedback_deep_research_product_specific)

--- a/docs/design/billing-redesign/phase2-checkout-journey.md
+++ b/docs/design/billing-redesign/phase2-checkout-journey.md
@@ -1,0 +1,204 @@
+# 有料化 (checkout) ジャーニーマップ (#2548 / Epic #2525 Phase 2 UX) — 全面再構成 (PO 指摘 4 谷追加 + Reverse Trial 整合 + mermaid 3 図)
+
+| 項目 | 内容 |
+|------|------|
+| 孫 issue | #2548 (有料化のジャーニー) |
+| 親 | #2527 (Phase 2 UX) / 上位 #2525 |
+| ステータス | **2026-05-28 全面再構成**: PO 指摘の 4 谷 (プラン選択 / 金額 / 解約柔軟性 / 購入動線) + Reverse Trial 文脈 + mermaid 3 図 + 既存実装統合 |
+| 対応 Phase 1 要件 | phase1-checkout-requirements.md (#2534) |
+| deep-research | SaaS 購入時の谷 14 件 + Stripe 担保/自社責任分類 + in-app upgrade prompts 5 パターン + LP→app 動線設計 (2026-05-28) |
+| Explore 照合 | 既存実装 3 点 (FeatureGate / ヘッダ planBadge / LP pricing 動線) 2026-05-28 |
+
+## 既存実装の事実 (Explore 照合)
+
+| PO 提案 | 既存実装 | 評価 |
+|---|---|---|
+| gate disable + tooltip + プランページ遷移 | `FeatureGate.svelte:49` (disabled button + title tooltip) / `ActivityLimitBanner.svelte:16` (banner + `/admin/license` link) / `PremiumDialog.svelte:52` (`window.location.href = '/admin/license'`) | ✅ 既存堅牢 |
+| ヘッダの現在プランボタン → 遷移 | `AdminLayout.svelte:220` で badge 表示 / `:212-218` で無料時のみ「アップグレード」ボタン → `/admin/license` / **有料プラン時の `plan-badge` はクリック遷移なし** | △ **部分実装、有料時遷移リンク欠落** |
+| LP pricing 購入動線説明 | `site/pricing.html:297-301` (signup + 直接購入 CTA) / `:403-420` (trial 3 ステップ) / `:475` (解約経路 FAQ) | ✅ 既存あり (CTA / 手順 / 解約) |
+
+## 業界呼称・モデルの整合
+
+deep-research 結果 (#2547 トライアル調査と統合):
+
+- 自プロダクトの購入動線は **Reverse Trial パターン C** = `LP CTA → app signup → trial 自動付与 → in-app paywall → checkout` (Linear / Notion 整合)
+- LP に Stripe Pricing Table 直埋めは「app で家族を作って体験」前提と衝突 → **不採用**
+- **app `/admin/license` で Stripe Pricing Table or 既存 Checkout Session API** が整合 (現状は後者で実装済)
+
+## ジャーニー (PO 指摘 4 谷 + 既存実装統合)
+
+### mermaid 図 1: 感情曲線 (journey)
+
+```mermaid
+journey
+    title 有料化 ジャーニー (Reverse Trial 整合)
+    section 検討
+      無料で利用中: 4: 親
+      上限/制約に到達 (gate): 2: 親
+    section 動線探索
+      gate tooltip / banner 発見: 3: 親
+      ヘッダの現在プラン経由: 3: 親
+      LP からの購入経路: 2: 親
+    section プラン理解
+      プラン一覧 (3 tier): 3: 親
+      月年トグル: 3: 親
+      金額の妥当性判断: 2: 親
+      解約柔軟性確認: 4: 親
+    section 申込
+      Stripe Checkout (カード): 3: 親
+      特商法最終確認: 4: 親
+      決済確定: 4: 親
+    section 受領
+      success 画面 (準備中): 2: 親
+      webhook 権限付与: 5: 親
+```
+
+### mermaid 図 2: 購入動線 (LP→app→pricing→checkout、PO 提案 3 経路統合)
+
+```mermaid
+flowchart TB
+    LP[LP site/pricing.html<br/>CTA: 無料で始める / 今すぐ購入] -->|signup| SignUp
+    LP -->|FAQ| FAQ[購入手順 / 解約手順]
+    SignUp[auth/signup] -->|自動ログイン| Admin[/admin]
+    Admin -->|gate disable + tooltip<br/>FeatureGate.svelte:49| Pricing[/admin/license<br/>プランページ]
+    Admin -->|ActivityLimitBanner<br/>:16 + linkLabel| Pricing
+    Admin -->|ヘッダの<br/>「アップグレード」ボタン<br/>無料時のみ AdminLayout:212-218| Pricing
+    Admin -.->|有料時 plan-badge<br/>**クリック遷移なし (改善要)**| Pricing
+    Pricing -->|プラン選択 + 月年トグル| Checkout[Stripe Checkout]
+    Checkout --> Success[success ページ<br/>準備中 polling]
+    Success -->|webhook| Activated[権限付与<br/>family 機能解放]
+    style Admin fill:#e3f2fd
+    style Pricing fill:#fff3e0
+    style Activated fill:#d4edda
+```
+
+### mermaid 図 3: プラン状態遷移 (free → trial → paid、Reverse Trial 全体像)
+
+```mermaid
+stateDiagram-v2
+    [*] --> free
+    free --> active_trial : startTrial (任意)
+    free --> paid_checkout : checkout (gate / pricing 経由)
+    active_trial --> paid_checkout : checkout (trial 中)
+    active_trial --> expired_free : endDate 経過 (自動)
+    expired_free --> paid_checkout : 任意の再課金
+    paid_checkout --> paid_active : webhook 権限付与
+    paid_active --> free : cancel (期末)
+    note right of paid_checkout
+      Stripe Customer Portal で
+      解約・カード変更可能
+    end note
+```
+
+## ジャーニー詳細表 (PO 指摘 4 谷を統合)
+
+| # | ステップ | 親の体験 | 感情 | 谷/山 | 既存実装 / 改善要 |
+|---|---|---|---|---|---|
+| 0 | 無料利用中、上限/制約に到達 | gate で disable | 物足りない | — | ✅ `FeatureGate.svelte:49` |
+| 1 | **購入動線探索 (LP / app 内)** | tooltip / banner / ヘッダから探す | 「どこから買う?」 | **谷④購入動線探索 (新)** | 既存実装 ✅ + **ヘッダ有料時遷移を改善要** |
+| 2 | プランページ到達 `/admin/license` | プラン一覧表示 | — | — | 既存 |
+| 3 | **プラン選択 (standard / family)** | どっちが自分に合うか | 「どれを選べば?」 | **谷①プラン選択困惑 (新)** | 改善要: お勧めバッジ / 比較表差分強調 / 診断ナビ (Phase 3 UI) |
+| 4 | **金額確認 (月年トグル + 価格)** | ¥500/¥780 (税込) | 「妥当か?」 | **谷②金額説得力 (新)** | 改善要: 1 日換算 / 家族 1 人あたり / 比較 anchor (Phase 3 UI) |
+| 5 | **解約柔軟性確認** | CTA 直下「いつでも解約」 | 「縛りは?」 | **谷③解約柔軟性 (新)** | 改善要: `CANCEL_TERMS.anytimeOk` CTA 直下併記 + Portal 言及 (Phase 3 UI) |
+| 6 | 申込決断 | 「申し込む」CTA | 決断 | — | 既存 |
+| 7 | Stripe Checkout (カード入力) | Stripe ホスト画面 | 緊張 (PCI 担保) | 谷⑤カード入力 | ✅ Stripe Checkout (PCI 担保) |
+| 8 | **特商法最終確認画面 5 項目** | 契約期間 / 自動更新 / 解約 / 総額 / cancellation | 「自動更新?税込?」 | (新規補強) | 改善要: Stripe Checkout `custom_text` or 自社確認画面 (Phase 3/5) |
+| 9 | 決済確定 → success ページ | 「準備中」表示 | 「反映された?」 | 谷⑥processing gap | 改善要: success polling 新規 (FR-6) |
+| 10 | webhook 権限付与 | 数秒後 family 機能解放 | 満足 ← **山** | **山** | ✅ `handleCheckoutCompleted` |
+
+## 4 谷 × Stripe 担保 / 自社責任の整理 (deep-research 反映)
+
+| 谷 | Stripe 側担保 | 自社対応 |
+|---|---|---|
+| **谷① プラン選択困惑** | Pricing Table (3 tier 視覚化) | 「お勧め」バッジ (standard に) / 比較表差分強調 / 診断ナビ ("家族の人数は?") |
+| **谷② 金額説得力** | ❌ Stripe 範囲外 | LP/pricing で `1 日 ¥16` framing / 家族 1 人あたり ¥260 (family) / 比較 anchor (学習教材 1 ヶ月) |
+| **谷③ 解約柔軟性** | Customer Portal (cancel UI / cancellation reasons) | CTA 直下に `CANCEL_TERMS.anytimeOk` 必須 + Portal 体験リンク / FAQ で解約 3 ステップ明示 (既存 `site/pricing.html:475` あり、強化) |
+| **谷④ 購入動線探索** | ❌ Stripe 範囲外 | gate tooltip 既存 ✅ / ヘッダ有料時遷移 (改善要) / LP pricing 動線説明 既存 ✅ / LP→app→pricing→checkout 統一 CTA |
+
+## 改善要項目 (Phase 3 UI / Phase 4 動線 / Phase 5 アーキ への申し送り)
+
+### Phase 3 (UI) 申し送り
+1. **`/admin/license` プランページの再設計**:
+   - standard に「お勧め」「人気」バッジ (decoy 効果)
+   - 比較表で差分のみハイライト
+   - `1 日あたり ¥16` / `家族 1 人あたり ¥260` ROI framing
+   - CTA 直下に `CANCEL_TERMS.anytimeOk` 必須併記
+2. **AdminLayout 有料時 plan-badge にクリック遷移追加** (`AdminLayout.svelte:220`、href `/admin/license`)
+3. **success ページ polling UI** (Phase 1 FR-6 新規)
+4. **特商法最終確認画面 5 項目** (Stripe Checkout `custom_text` API or 自社確認画面)
+
+### Phase 4 (動線) 申し送り
+5. **LP→app 統一 CTA 文言** (terms.ts atom 経由: `CTA_TERMS.freeTrialVerb` 「無料で試す」)
+6. **LP pricing FAQ 強化**: 「アプリにログイン後、画面右上の ${PLAN_SHORT_LABELS.free} ボタンから ${SIGNUP_TERMS.canonical} へ」
+7. **trial 終了 → in-app paywall** (Reverse Trial パターン C 整合、トライアルジャーニー #2547 と接続)
+
+### Phase 5 (アーキ) 申し送り
+8. **Stripe Pricing Table vs 自前 Checkout Session の判断** (現状自前で柔軟性高、Pricing Table は LP 未採用)
+9. **Stripe Customer Portal の cancellation reasons 設定** (cancellation ジャーニー #2550 と整合)
+10. **Product 構成 (1 Product 4 Price vs 4 Product)** (Phase 1 #2535 申し送り済)
+
+## 既存からの変更点 (delta)
+
+| # | 既存 | 要件 | 扱い |
+|---|---|---|---|
+| 1 | priceId 環境変数直読 (config.ts) | lookup_key 参照 | 変更 (FR-1) |
+| 2 | success polling なし | session status polling + 準備中 | 新規 (FR-6) |
+| 3 | `handleCheckoutCompleted` で license key 発行 | 撤去 | 削除 (領域 12 連動) |
+| 4 | 月/年の扱い | 月/年トグル月額デフォルト・2ヶ月おトク併置 | Phase 1 確定 |
+| 5 | createCheckoutSession/webhook SSOT/customer 紐づけ | 維持 | ✅ |
+| 6 | gate disable + tooltip (FeatureGate) | 維持・前面化 | ✅ |
+| 7 | ActivityLimitBanner | 維持 | ✅ |
+| 8 | LP pricing 動線説明 (signup CTA + trial 3 ステップ + FAQ 解約) | 維持・補強 (購入手順を統一) | Phase 4 |
+| 9 | ヘッダ plan-badge 有料時クリック遷移 | 追加 | 新規 (Phase 3 UI、小修正) |
+
+## ADR-0012 整合性チェック (deep-research の 5 パターン × 自プロダクト)
+
+| upgrade prompts パターン | ADR-0012 適合 | 自プロダクト採否 |
+|---|---|---|
+| gate disable + tooltip | ✅ 静的・自発探索時のみ | **採用** (既存 FeatureGate) |
+| ヘッダ「現在プラン」ボタン | ✅ 親 admin global nav 1 要素 | **採用** (既存・有料時遷移改善要) |
+| 設定 / Upgrade メニュー | ✅ 探索時のみ | **採用** |
+| gate banner (画面上部常時) | ⚠️ trial 終了後 14 日のみ条件付き許容 | **条件付き** (ActivityLimitBanner 既存、滞在強要しない設計) |
+| modal interrupt | ❌ 滞在時間強制延伸 | **不採用** |
+| countdown timer / 連続演出 | ❌ 射幸性 | **不採用** |
+
+**子供 UI (preschool/elementary/junior/senior) には全 upgrade prompt 表示禁止** (Anti-engagement 完全担保)。
+
+## 特商法 (JP 法令) 適合チェック (2022 改正、deep-research 反映)
+
+LP pricing / checkout 最終確認画面で**法的義務として**表示:
+
+1. 契約期間 (月額/年額)
+2. 自動更新の有無と停止方法
+3. 解約方法 (Customer Portal リンク含む)
+4. 総額表示 (税込) — `PRICE_TERMS.taxNote` 既存
+5. 申込撤回 / cancellation 条件
+
+→ `site/pricing.html` / `site/tokushoho.html` 既存 SSOT 維持 + Stripe Checkout `custom_text` API で legal text 注入検討 (Phase 5)。
+
+## ペルソナ別 UX レビュー観点 (家族構成 + 購入決断ペルソナ)
+
+- **1 人っ子家庭 (standard 候補)**: family が過剰と判断できる比較表 / 「子 1 人なら standard」診断ナビ
+- **兄弟複数家庭 (family ターゲット)**: family の「家族 1 人あたり ¥260」ROI 訴求 / 子供無制限の価値訴求
+- **慎重派**: 「いつでも解約」「カード不要 trial 経由」「税込明示」で FUD 解消
+- **即決派**: LP → 直接購入 (`?direct=true`) で最短動線 / 「今すぐ購入」CTA 既存
+- **trial 経由派**: Reverse Trial パターン C で in-app paywall まで運ぶ
+
+## Open question (PO 判断)
+
+| # | 論点 | 状態 |
+|---|------|------|
+| 1 | ヘッダ有料時 plan-badge にクリック遷移追加 | Phase 3 UI で小修正 (PO 提案 2 採用) |
+| 2 | 「お勧め」バッジを standard に付けるか family に付けるか | Phase 3 UI で要 PO 判断 (decoy 効果) |
+| 3 | 診断ナビ採用可否 (「家族の人数は?」slider) | Phase 3 UI 設計の規模感判断 |
+| 4 | 特商法最終確認 = Stripe `custom_text` vs 自社確認画面 | Phase 3/5 で実装方式 |
+| 5 | LP `site/pricing.html:475` FAQ 解約手順の強化 (Customer Portal 動画 / GIF) | Phase 4 動線で判断 |
+| 6 | Stripe Pricing Table 採用 (app `/admin/license` 内) | Phase 5 アーキ判断 (現状自前で問題なし) |
+
+## 根拠
+
+- **既存実装 (Explore 照合 2026-05-28)**: `FeatureGate.svelte:49` / `ActivityLimitBanner.svelte:16` / `PremiumDialog.svelte:52` / `AdminLayout.svelte:212-220` / `PlanStatusCard.svelte:76` / `site/pricing.html:297-301, 403-420, 475`
+- **deep-research (2026-05-28)**: 谷 14 件 (Baymard cart abandonment / Iyengar Paradox of Choice / Cancel anytime 論文 Journal of Retailing 2024 / RevenueCat cost-per-day framing) / in-app upgrade prompts 5 パターン (Userpilot / Plotline / Webuild) / LP→app 動線 (Vercel / Netlify / Linear / Notion) / Stripe Pricing Table 公式 docs
+- Phase 1 phase1-checkout-requirements.md / phase1-legal (特商法 5 項目) / phase1-trial (Reverse Trial パターン C) / phase1-cancellation
+- ADR-0012 (Anti-engagement、子供 UI 全 upgrade prompts 禁止) / ADR-0013 (LP truth) / ADR-0045 (terms/labels SSOT) / ADR-0050 (Parent-Gate)
+- Stripe `custom_text` API / Customer Portal `configure-portal` / Pricing Table 公式 docs

--- a/docs/design/billing-redesign/phase2-checkout-journey.md
+++ b/docs/design/billing-redesign/phase2-checkout-journey.md
@@ -15,7 +15,7 @@
 |---|---|---|
 | gate disable + tooltip + プランページ遷移 | `FeatureGate.svelte:49` (disabled button + title tooltip) / `ActivityLimitBanner.svelte:16` (banner + `/admin/license` link) / `PremiumDialog.svelte:52` (`window.location.href = '/admin/license'`) | ✅ 既存堅牢 |
 | ヘッダの現在プランボタン → 遷移 | `AdminLayout.svelte:220` で badge 表示 / `:212-218` で無料時のみ「アップグレード」ボタン → `/admin/license` / **有料プラン時の `plan-badge` はクリック遷移なし** | △ **部分実装、有料時遷移リンク欠落** |
-| LP pricing 購入動線説明 | `site/pricing.html:297-301` (signup + 直接購入 CTA) / `:403-420` (trial 3 ステップ) / `:475` (解約経路 FAQ) | ✅ 既存あり (CTA / 手順 / 解約) |
+| LP pricing 購入動線説明 | [`site/pricing.html` L297-L301](../../../site/pricing.html) (signup + 直接購入 CTA) / [L403-L420](../../../site/pricing.html) (trial 3 ステップ) / [L475](../../../site/pricing.html) (解約経路 FAQ) | ✅ 既存あり (CTA / 手順 / 解約) |
 
 ## 業界呼称・モデルの整合
 
@@ -112,7 +112,7 @@ stateDiagram-v2
 |---|---|---|
 | **谷① プラン選択困惑** | Pricing Table (3 tier 視覚化) | 「お勧め」バッジ (standard に) / 比較表差分強調 / 診断ナビ ("家族の人数は?") |
 | **谷② 金額説得力** | ❌ Stripe 範囲外 | LP/pricing で `1 日 ¥16` framing / 家族 1 人あたり ¥260 (family) / 比較 anchor (学習教材 1 ヶ月) |
-| **谷③ 解約柔軟性** | Customer Portal (cancel UI / cancellation reasons) | CTA 直下に `CANCEL_TERMS.anytimeOk` 必須 + Portal 体験リンク / FAQ で解約 3 ステップ明示 (既存 `site/pricing.html:475` あり、強化) |
+| **谷③ 解約柔軟性** | Customer Portal (cancel UI / cancellation reasons) | CTA 直下に `CANCEL_TERMS.anytimeOk` 必須 + Portal 体験リンク / FAQ で解約 3 ステップ明示 (既存 [`site/pricing.html` L475](../../../site/pricing.html) あり、強化) |
 | **谷④ 購入動線探索** | ❌ Stripe 範囲外 | gate tooltip 既存 ✅ / ヘッダ有料時遷移 (改善要) / LP pricing 動線説明 既存 ✅ / LP→app→pricing→checkout 統一 CTA |
 
 ## 改善要項目 (Phase 3 UI / Phase 4 動線 / Phase 5 アーキ への申し送り)
@@ -192,12 +192,12 @@ LP pricing / checkout 最終確認画面で**法的義務として**表示:
 | 2 | 「お勧め」バッジを standard に付けるか family に付けるか | Phase 3 UI で要 PO 判断 (decoy 効果) |
 | 3 | 診断ナビ採用可否 (「家族の人数は?」slider) | Phase 3 UI 設計の規模感判断 |
 | 4 | 特商法最終確認 = Stripe `custom_text` vs 自社確認画面 | Phase 3/5 で実装方式 |
-| 5 | LP `site/pricing.html:475` FAQ 解約手順の強化 (Customer Portal 動画 / GIF) | Phase 4 動線で判断 |
+| 5 | LP [`site/pricing.html` L475](../../../site/pricing.html) FAQ 解約手順の強化 (Customer Portal 動画 / GIF) | Phase 4 動線で判断 |
 | 6 | Stripe Pricing Table 採用 (app `/admin/license` 内) | Phase 5 アーキ判断 (現状自前で問題なし) |
 
 ## 根拠
 
-- **既存実装 (Explore 照合 2026-05-28)**: `FeatureGate.svelte:49` / `ActivityLimitBanner.svelte:16` / `PremiumDialog.svelte:52` / `AdminLayout.svelte:212-220` / `PlanStatusCard.svelte:76` / `site/pricing.html:297-301, 403-420, 475`
+- **既存実装 (Explore 照合 2026-05-28)**: `FeatureGate.svelte:49` / `ActivityLimitBanner.svelte:16` / `PremiumDialog.svelte:52` / `AdminLayout.svelte:212-220` / `PlanStatusCard.svelte:76` / [`site/pricing.html`](../../../site/pricing.html) L297-L301 / L403-L420 / L475
 - **deep-research (2026-05-28)**: 谷 14 件 (Baymard cart abandonment / Iyengar Paradox of Choice / Cancel anytime 論文 Journal of Retailing 2024 / RevenueCat cost-per-day framing) / in-app upgrade prompts 5 パターン (Userpilot / Plotline / Webuild) / LP→app 動線 (Vercel / Netlify / Linear / Notion) / Stripe Pricing Table 公式 docs
 - Phase 1 phase1-checkout-requirements.md / phase1-legal (特商法 5 項目) / phase1-trial (Reverse Trial パターン C) / phase1-cancellation
 - ADR-0012 (Anti-engagement、子供 UI 全 upgrade prompts 禁止) / ADR-0013 (LP truth) / ADR-0045 (terms/labels SSOT) / ADR-0050 (Parent-Gate)

--- a/docs/design/billing-redesign/phase2-dunning-journey.md
+++ b/docs/design/billing-redesign/phase2-dunning-journey.md
@@ -1,0 +1,133 @@
+# 支払い失敗 (dunning) ジャーニーマップ (#2551 / Epic #2525 Phase 2 UX) — 既存実装前提
+
+| 項目 | 内容 |
+|------|------|
+| 孫 issue | #2551 (支払い失敗 dunning のジャーニー) |
+| 親 | #2527 (Phase 2 UX) / 上位 #2525 |
+| ステータス | 既存実装前提で設計 (2026-05-28、Phase 1 で stripe-service handlePaymentFailed/Deleted 照合済) |
+| 対応 Phase 1 要件 | phase1-dunning-requirements.md (#2537: past_due=grace 有料維持・2週8回・canceled→無料・子供画面非表示) |
+
+## 既存実装の事実 (Phase 1 照合)
+
+- `handlePaymentFailed` (stripe-service.ts:346): `GRACE_PERIOD_DAYS=7` を app で独自計算 (→ 要件で Stripe Smart Retries 2週 SSOT へ)
+- `handleSubscriptionDeleted` (stripe-service.ts:394): status を **SUSPENDED にするのみ・plan 無料化なし** (→ 要件で unpaid/canceled で無料化)
+- webhook 冪等性 (event.id dedup) なし (→ 新規構築 NFR-1)
+- past_due バナー・Stripe 自動 dunning メール = 要件で新規 (FR-5/FR-6)
+
+## dunning ジャーニー (保護者視点、既存実装ベース)
+
+| # | ステップ | 既存/要件 | 保護者の体験 | 感情 | 離脱リスク |
+|---|---|---|---|---|---|
+| 0 | カード期限切れ等で決済失敗 | `invoice.payment_failed` | (本人は気づかない) | 無自覚 | — |
+| 1 | **失敗通知 (past_due)** | past_due 記録・有料維持 + Stripe メール + admin バナー (FR-5 新規) | メール/バナーで気づく | 焦り (見落としやすい) | 中 |
+| 2 | **grace 中 (2週/8回)** | 有料維持・子供影響なし (NFR-3) | 子供は普段通り使える | 安心 (突然止まらない) | — |
+| 3a | **カード更新 (復旧)** | Customer Portal → `invoice.paid` → active | Portal でカード更新 | 安堵 (何も失わない) | — |
+| 3b | **更新せず枯渇** | 2週8回後 canceled → 無料化 (FR-3 新規) | 自動的に無料プランへ、データ保持 | 諦め/納得 | — |
+
+## 子供視点 (重要)
+
+支払い状態に**関わらず通知・アクセス断を一切経験しない** (FR-5 子供画面非表示・NFR-3 突然中断しない)。past_due 中も grace で有料維持されるため、子供の体験は決済問題から完全に隔離される。
+
+## 感情曲線と既存実装に即した対策
+
+- **谷① 見落とし (dunning 最大の課題)**: 既存は通知導線が弱い。Stripe 自動 dunning メール (親宛) + admin 静的バナー 1 件 (FR-5/FR-6) で復旧導線を Portal に集約。**自社メールは重ねない** (連打回避、ADR-0012)
+- **山② grace の安心 (要件の肝)**: 「支払いが失敗しても子供の利用がすぐ止まらない」= 家庭の信頼。past_due=有料維持を堅持
+- **③b の誠実な無料復帰**: 枯渇しても突然のロックでなく無料プランへ降格 + データ保持。解約と同じ二値復帰 (第3状態を作らない)
+
+## 既存からの変更点 (delta)
+
+| # | 既存 | 要件 | 扱い |
+|---|---|---|---|
+| 1 | `GRACE_PERIOD_DAYS=7` app 計算 | Stripe Smart Retries 2週 SSOT | 変更 (app 日数管理廃止) |
+| 2 | `handleSubscriptionDeleted` SUSPENDED のみ | unpaid/canceled で無料化 | 新規実装 (FR-3) |
+| 3 | webhook 冪等性なし | event.id 冪等性 | 新規構築 (NFR-1) |
+| 4 | past_due バナー・dunning メール | 親 admin バナー 1 件 + Stripe メール | 新規 (FR-5/FR-6) |
+
+## 「7日/猶予」概念の注意 (ジャーニー設計者向け)
+
+本ジャーニーの grace (2週) は**支払い失敗 grace**。解約後の読み取り専用猶予 (grace-period-service free0/std7/family30)・トライアル (7日)・データ保持 (ADR-0049) とは別概念。混同してジャーニーに「7日」と書かない。
+
+## UX レビュー観点 (3 ペルソナ、Phase 2 完了基準)
+
+- **幼児親 (メール見落としやすい層)**: 失敗に気づける導線か / 気づかなくても子供が中断しない安心が成立するか
+- **小学生親 (長期利用)**: Portal カード更新が簡単か / grace 中に焦らず対応できるか
+- **中高生親**: 無料降格時もデータが残ると分かるか / 子供に決済問題が一切見えないか
+
+## Open question (PO 判断)
+
+| # | 論点 | 状態 |
+|---|------|------|
+| 1 | past_due バナー文言・表示頻度 | Phase 3 UI (静的 1 件、煽らない) |
+| 2 | カード期限切れ事前通知 (1ヶ月前 Stripe メール) | Phase 1 で有効化推奨 (親メールのみ) |
+| 3 | 無料降格時のデータ保持の親への通知 | データライフサイクル #2538 と整合 |
+
+## 業界呼称・PO 既出指摘との整合性 (2026-05-28 追補)
+
+- **業界用語**: **Involuntary churn** (非意図的解約) / **Dunning management** (回収管理) / **Stripe Smart Retries** (AI 最適タイミング 8回/2週、業界標準)
+- **NRR 計算**: 支払い失敗で canceled → contraction として計上 (churn 計上は最終 unpaid 後のみ)
+- **4 谷参照**: `phase2-checkout-journey.md` 参照、本ジャーニーは支払いライフサイクル後段で **谷直接は少ない** (Stripe 自動 dunning メールで構造的解消)
+- **Reverse Trial 連続性**: dunning による無料降格は手動ダウンと **同一機構** (`phase2-plan-change-journey.md` Phase 5 申し送り、`archiveForDowngrade` 共通化推奨)
+- **文言 atom 「失う / 消える」排除**: past_due バナー文言も「決済ご確認 → Portal でカード更新」型 (煽らない事実明示)
+- **ADR-0012 整合**: 子供画面に支払い通知一切なし、past_due 親 admin バナー 1 件・静的、自社メール送らず Stripe 自動 dunning メール一本化 (連打回避)
+- **特商法 (JP)**: 「カード期限切れ事前通知」(1ヶ月前) は Stripe 機能で対応、自動更新の停止権 = Customer Portal 経由で担保
+
+## mermaid 図示
+
+### 図 1: 親視点の dunning ジャーニー (journey)
+
+```mermaid
+journey
+    title 支払い失敗 (dunning) ジャーニー (親視点)
+    section 失敗発生
+      決済失敗 (本人無自覚): 3: 親
+    section 通知
+      Stripe メール: 3: 親
+      admin バナー (past_due): 3: 親
+    section grace (2週/8回)
+      子供は普段通り利用継続: 5: 親
+      Portal でカード更新: 4: 親
+    section 復旧 or 枯渇
+      復旧:invoice.paid: 5: 親
+      枯渇:無料降格 (データ保持): 4: 親
+```
+
+### 図 2: Stripe Subscription 状態遷移 (stateDiagram)
+
+```mermaid
+stateDiagram-v2
+    [*] --> active
+    active --> past_due : invoice.payment_failed (有料維持)
+    past_due --> active : invoice.paid (カード更新)
+    past_due --> canceled : Smart Retries 枯渇 (8回/2週)
+    canceled --> free : plan 無料化 + アーカイブ (FR-3 新規)
+    active --> [*]
+    free --> [*]
+    note right of past_due
+      grace 中 = 有料維持
+      子供は中断しない (NFR-3)
+    end note
+```
+
+### 図 3: 子供視点 = zero touch (Anti-engagement、flowchart)
+
+```mermaid
+flowchart TB
+    PayFail[支払い失敗] --> ParentNotify[親:メール + admin バナー]
+    PayFail -.->|決済状態と無関係| ChildExp[子供:何も変わらない]
+    ParentNotify --> Grace{grace 2週/8回}
+    Grace -->|更新| Recovered[復旧: family 機能維持]
+    Grace -->|枯渇| Downgraded[無料降格 + アーカイブ]
+    ChildExp --> ChildCont[子供:活動・記録・祝福 普段通り]
+    Recovered -.->|意識なし| ChildCont
+    Downgraded -.->|超過分 invisible| ChildCont
+    style ChildExp fill:#d4edda
+    style ChildCont fill:#d4edda
+    style Grace fill:#fff3cd
+```
+
+## 根拠
+
+- **既存実装 (Phase 1 照合)**: `stripe-service.ts:346 handlePaymentFailed` / `:394 handleSubscriptionDeleted` / `config.ts:95 GRACE_PERIOD_DAYS` / webhook
+- Phase 1 phase1-dunning-requirements.md (#2537) / phase1-data-lifecycle (#2538) / ADR-0049 (無料復帰データ保持)
+- Stripe smart-retries (8回2週)/customer-emails (親宛 dunning)/subscriptions overview (unpaid でアクセス取り消し) / ADR-0012 (子端末通知禁止・連打しない)
+- ※ 自プロダクトの既存 dunning 実装 (grace 維持・無料降格) を主軸に設計 (feedback_deep_research_product_specific)

--- a/docs/design/billing-redesign/phase2-nuc-journey.md
+++ b/docs/design/billing-redesign/phase2-nuc-journey.md
@@ -1,0 +1,132 @@
+# NUC (セルフホスト) ジャーニーマップ (#2552 / Epic #2525 Phase 2 UX) — 既存実装前提
+
+| 項目 | 内容 |
+|------|------|
+| 孫 issue | #2552 (NUC のジャーニー) |
+| 親 | #2527 (Phase 2 UX) / 上位 #2525 |
+| ステータス | 既存実装前提で設計 (2026-05-28、ADR-0051 NUC-SaaS Bifurcation 整合) |
+| 対応 Phase 1 要件 | phase1-nuc-requirements.md (#2539: 完全無料 OSS / 信頼ベース DRM なし / family 固定) |
+
+## 既存実装の事実
+
+- ADR-0051 NUC-SaaS Bifurcation: NUC は Edition badge + 簡略表示型、license/billing 領域は SaaS と分岐
+- `IS_NUC_DEPLOY` edition flag で実行モード判別 (既存)
+- NUC は OSS (セルフホスト)、DRM なし (信頼ベース)、機能上は family 相当
+- SaaS 側のライセンスキー / Stripe / dunning / trial 等の課金機構は NUC では存在しない (badge で明示)
+
+## NUC ジャーニー (保護者視点)
+
+| # | ステップ | 既存/要件 | 保護者の体験 | 感情 | 離脱 |
+|---|---|---|---|---|---|
+| 0 | NUC を選択 | site/selfhost.html (LP) | OSS・自宅サーバで運用 | 自律志向 | 高 (技術ハードル) |
+| 1 | セルフホスト設定 | OSS docs / docker compose 等 | 自宅 NUC / Raspberry Pi 等にデプロイ | 達成感 | 高 |
+| 2 | 起動・初期設定 | signup (Cognito 非経由・local auth) → /setup | 家族用に立ち上げ | 期待 | 中 |
+| 3 | family 機能フル利用 | IS_NUC_DEPLOY=true → family 相当 capability | 子供無制限・全機能 | 満足 ← 山 | — |
+| 4 | プラン画面アクセス | **Edition badge 表示** (簡略型、ADR-0051) | 「セルフホスト版・全機能利用可能」 | 安心 (課金導線なし) | — |
+| 5 | 継続利用 | 課金・dunning・trial なし | 何も払わず使い続ける | 信頼 | — |
+
+## 感情曲線と既存実装に即した対策
+
+- **谷①② 技術ハードル**: NUC 選択者は技術スキルあり前提だが、ドキュメント整備が離脱対策
+- **山③ family 相当の解放**: SaaS の有料機能を完全無料で利用可能 = OSS の価値
+- **④ Edition badge の明示 (ADR-0051)**: 「セルフホスト版」badge で課金導線を出さず、SaaS と動線分岐。NUC ユーザーが Stripe / トライアル / dunning UI に迷い込まない
+
+## 既存からの変更点 (delta)
+
+| # | 既存 | 要件 | 扱い |
+|---|---|---|---|
+| 1 | `IS_NUC_DEPLOY` edition flag | 維持 | ✅ 既存活用 |
+| 2 | license/billing 領域の NUC 分岐 | Edition badge + 簡略型 (ADR-0051) | ✅ 既存方針 |
+| 3 | DRM (NUC) | なし、信頼ベース | ✅ 既存整合 (Pre-PMF 過剰防衛除外) |
+| 4 | NUC で trial / dunning / Stripe UI | 非表示 (Edition badge 経由で分岐) | Phase 3 UI で UI 分岐確定 |
+
+## SaaS / NUC 二経路 capability の保証
+
+PLAN_LIMITS の family capability は SaaS family と NUC で同一。`resolveFullPlanTier` は NUC では Edition flag を見て family 相当を返す。**Provider 抽象化 (Phase 5)** で SaaS 側 PlanProvider と NUC 側 NucPlanProvider を切替、capability matrix は共有。
+
+## UX レビュー観点 (3 ペルソナ、Phase 2 完了基準)
+
+- **技術志向親 (NUC 選択層)**: セルフホスト docs が分かりやすいか / family 機能が完全に使えると分かるか
+- **プライバシー重視親**: データが自宅に留まる安心が伝わるか (越境移転懸念なし)
+- **長期家庭利用**: NUC の継続性 (バックアップ / アップデート) が安心か
+
+## Open question (PO 判断)
+
+| # | 論点 | 状態 |
+|---|------|------|
+| 1 | NUC docs の整備範囲 | Pre-PMF 後 (NUC は副次経路、OSS リリース時) |
+| 2 | NUC ユーザーの SaaS 移行動線 (家族成長で SaaS へ) | Phase 4 動線 (双方向は Pre-PMF 過剰) |
+| 3 | NUC のアップデート通知 | OSS リリースノートで足りる |
+
+## 業界呼称・PO 既出指摘との整合性 (2026-05-28 追補)
+
+- **業界用語**: **Self-hosted edition** / **OSS edition** / **Edition Bifurcation** (SaaS / Self-hosted の機能・課金軸分離、ADR-0051) / **Trust-based licensing** (DRM-less、HashiCorp / GitLab Community Edition / Sentry / PostHog 等の業界標準)
+- **NRR には含めない**: NUC は完全無料 OSS = MRR 0、SaaS metric の外側 (副次経路、ADR-0010 Pre-PMF Bucket C)
+- **4 谷参照 (大半が不適用)**: NUC は課金導線なし → 谷①プラン選択 / 谷②金額説得力 / 谷③解約柔軟性 / 谷④購入動線 はいずれも**非該当**。代わりに **「セットアップハードル」「アップデート不安」「データバックアップ責任」** が NUC 固有の谷
+- **Reverse Trial 整合**: NUC では trial 概念なし、最初から family 相当機能 (IS_NUC_DEPLOY flag で恒久解放)
+- **文言 atom**: NUC 専用 atom (`NUC_EDITION_TERMS.selfHosted` / `.fullAccess` / `.unlimited` / `.editionEmoji '🏠'` 既存) 維持、煽り語彙なし
+- **ADR-0012 整合**: NUC でも子供 UI に課金/プラン UI 一切なし (そもそも課金概念なし、Anti-engagement 完全担保)
+- **ADR-0010 Pre-PMF**: NUC docs 整備は副次、SaaS PMF 後
+
+## mermaid 図示
+
+### 図 1: NUC 親の感情曲線 (journey)
+
+```mermaid
+journey
+    title NUC (セルフホスト) ジャーニー
+    section 選択
+      OSS / プライバシー志向: 4: 親
+      LP selfhost.html 検討: 4: 親
+    section セットアップ
+      docker compose 等デプロイ: 2: 親
+      初期設定・家族登録: 3: 親
+    section 利用
+      family 相当機能フル: 5: 親
+      Edition badge 「セルフホスト版」: 4: 親
+    section 継続
+      課金・dunning なし: 5: 親
+      OSS アップデート自主管理: 3: 親
+```
+
+### 図 2: SaaS / NUC Edition Bifurcation (stateDiagram、ADR-0051)
+
+```mermaid
+stateDiagram-v2
+    [*] --> edition_check : IS_NUC_DEPLOY flag
+    edition_check --> saas_edition : false
+    edition_check --> nuc_edition : true
+    saas_edition --> free_or_paid : Stripe Subscription SSOT
+    nuc_edition --> always_full : family 相当恒久解放
+    note right of saas_edition
+      課金・dunning・trial
+      Stripe Customer Portal
+    end note
+    note right of nuc_edition
+      DRM なし (信頼ベース)
+      Edition badge 表示
+      課金 UI 全非表示
+    end note
+```
+
+### 図 3: NUC vs SaaS 機能・課金軸の Bifurcation (flowchart、ADR-0051)
+
+```mermaid
+flowchart TB
+    User[ユーザー] --> Choice{Edition 選択}
+    Choice -->|SaaS| SaaS[gan-bari-quest.com]
+    Choice -->|セルフホスト| NUC[自宅 NUC / Raspberry Pi]
+    SaaS --> SaasFlow[signup → trial → checkout → dunning]
+    NUC --> NUCFlow[OSS デプロイ → family 機能恒久]
+    SaasFlow --> Capability[family capability]
+    NUCFlow --> Capability
+    Capability --> ChildUI[子供 UI:課金概念なし<br/>Anti-engagement 完全担保]
+    style NUC fill:#d4edda
+    style NUCFlow fill:#d4edda
+```
+
+## 根拠
+
+- 既存実装: `IS_NUC_DEPLOY` edition flag / Edition badge (ADR-0051) / `plan-limit-service` capability matrix (SaaS/NUC 共有)
+- Phase 1 phase1-nuc-requirements.md (#2539) / phase1-security (DRM なし・過剰防衛除外) / ADR-0051 NUC-SaaS Bifurcation / ADR-0010 (Pre-PMF DRM 不要)
+- site/selfhost.html (LP NUC 訴求)

--- a/docs/design/billing-redesign/phase2-plan-change-journey.md
+++ b/docs/design/billing-redesign/phase2-plan-change-journey.md
@@ -1,0 +1,257 @@
+# アップグレード/ダウングレード ジャーニーマップ (#2549 / Epic #2525 Phase 2 UX) — 全面再構成
+
+| 項目 | 内容 |
+|------|------|
+| 孫 issue | #2549 (アップ/ダウングレードのジャーニー) |
+| 親 | #2527 (Phase 2 UX) / 上位 #2525 |
+| ステータス | **2026-05-28 全面再構成**: 業界呼称 (Tier Change / NRR) + 既存実装統合 (Notion 型 Pattern A) + proration 透明化 + 文言 atom 拡張 + mermaid 3 図 |
+| 対応 Phase 1 要件 | phase1-plan-change-requirements.md (#2535) |
+| deep-research | Tier Change UX / proration / 超過リソース 5 パターン対比 / Win-Back (2026-05-28) |
+| Explore 照合 | 既存実装 4 点 (SaasLicensePanel / downgrade-service / resource-archive-service / DowngradeResourceSelector) (2026-05-28) |
+
+## 重複回避方針 (PO 指摘)
+
+4 谷 (プラン選択困惑 / 金額説得力 / 解約柔軟性 / 購入動線探索) と Stripe 担保/自社責任の分類は **`phase2-checkout-journey.md` を参照** し、本ジャーニーでは **アップ/ダウン固有部分のみ**を深掘りする。
+
+## 業界呼称と SaaS metric
+
+- **業界用語**: "Tier change" / "Plan change" (Stripe API `subscriptions.update` の `proration_behavior` で表現)
+- **SaaS metric**: アップ = **Expansion revenue** / ダウン = **Contraction revenue** (churn とは別計上)
+- **Net Revenue Retention (NRR)** = (Starting MRR + Expansion - Contraction - Churn) / Starting MRR、Best-in-class 120-125%
+- **Reverse Trial 終了は contraction で扱う** (churn でない) — Pre-PMF 段階の SaaS dashboard 健全化
+
+## 既存実装の事実 (Explore 照合 2026-05-28)
+
+| PO 提案 / 要件 | 既存実装 | 評価 |
+|---|---|---|
+| アップ/ダウン UI 動線 | `SaasLicensePanel.svelte:165-763` (統合 UI、無料時はプラン選択カード / 有料時は Portal ボタン) | ✅ 既存堅牢 |
+| 超過リソースアーカイブ | `downgrade-service.ts` (`getDowngradePreview` :31-117 / `archiveForDowngrade` :133-202) / `resource-archive-service.ts` / `archived_reason='downgrade_user_selected'` | ✅ **Notion 型 Pattern A 相当 で既存実装済み** |
+| ダウン警告画面 | `DowngradeResourceSelector.svelte` (件数明示 + 履歴保持期間警告 + 「アップ時に復元可能」明示 + 顧客選択) | ✅ 既存詳細 |
+| 復元動線 | `downgrade-restore/+server.ts` (`restoreArchivedResources`、flag クリアで即復元) | ✅ 既存 |
+| proration UX (アップ時差額表示) | **`subscriptions.update` 呼出なし、`upcoming_invoice` / `create_preview` 未実装、Portal 任せ** | △ **新規必要** |
+
+## ジャーニー A: アップグレード (Expansion)
+
+### mermaid 図 1A: アップ感情曲線 (journey)
+
+```mermaid
+journey
+    title アップグレード ジャーニー (Expansion)
+    section gate / trial 接続
+      gate 到達 or trial 中: 3: 親
+    section プラン理解
+      上位 tier の差分確認: 4: 親
+      差額・proration の透明化: 3: 親
+    section 申込
+      確認モーダル ¥XXX 本日決済: 4: 親
+      Stripe Checkout / Portal: 4: 親
+    section 即時反映
+      webhook 権限解放: 5: 親
+      上位機能即時利用: 5: 親
+```
+
+### アップ ジャーニー詳細
+
+| # | ステップ | 親の体験 | 谷/山 | 既存実装 / 改善要 |
+|---|---|---|---|---|
+| 0 | gate 到達 / trial 中 | 上位プラン必要を意識 | — | 既存 `FeatureGate` (参照: checkout ジャーニー 谷④) |
+| 1 | プランページで上位 tier 確認 | standard→family の差分 | 谷①プラン選択困惑 (参照) | 改善要: 比較表差分強調 (checkout ジャーニー Phase 3 申し送りと統合) |
+| 2 | **proration 差額の透明化** | 「本日 ¥XXX を決済 / 次回 ¥YYY (差額含む)」 | **新規必要 (proration UX)** | **新規実装** (`create_preview` API → confirm モーダルに表示) |
+| 3 | 申込確定 | 「**¥XXX を支払って family に変更**」CTA (Kinde 「what happens when clicked」原則) | — | 新規 (preview 結果を表示する confirm モーダル) |
+| 4 | webhook 権限付与 | 数秒後に family 機能解放 | **山 (即時解放)** | 既存 webhook SSOT |
+| 5 | アーカイブ復元 (trial 中追加リソース or 過去 archived) | 自動的に復元 (子供・活動が見える) | 山 (LTV ↑) | 既存 `restoreArchivedResources` |
+
+### アップ固有の改善要
+
+- **proration `always_invoice` 採用** (Stripe 公式 + 業界収束): "don't make them wait" (興奮中の顧客を待たせない)
+- **Preview API (`POST /v1/invoices/create_preview`)** で confirm モーダルに差額 dry-run 表示
+- `proration_date` を hidden field で保持し preview/update を同一秒で発火
+- CTA 文言: 「**¥XXX を支払って family に変更**」(Kinde 原則、煽らず事実)
+
+## ジャーニー B: ダウングレード (Contraction)
+
+### mermaid 図 1B: ダウン感情曲線 (journey、資産保護フレーミング)
+
+```mermaid
+journey
+    title ダウングレード ジャーニー (資産保護フレーミング、煽らない)
+    section 検討
+      コスト見直し: 3: 親
+    section 影響理解
+      DowngradeResourceSelector で件数確認: 3: 親
+      「保護されます / 復活できます」明示: 4: 親
+    section 申込
+      期末ダウン確定 (cancel_at_period_end): 4: 親
+    section 期間中
+      期末まで family 機能維持: 4: 親
+    section 期末
+      自動降格 + 超過分 read-only: 3: 親
+      「上位プランで再開」CTA 常時: 4: 親
+    section 復活
+      ワンクリック再アップで瞬時復元: 5: 親
+```
+
+### ダウン ジャーニー詳細
+
+| # | ステップ | 親の体験 | 谷/山 | 既存実装 / 改善要 |
+|---|---|---|---|---|
+| 0 | コスト見直し / 卒業期 | ダウンを検討 | — | — |
+| 1 | プランページから「プランを変更」 | 統合 UI | — | 既存 `SaasLicensePanel` |
+| 2 | **`DowngradeResourceSelector` で影響確認** | 「子 6 人中 5 人を保持、1 人アーカイブ」「活動 25 個中 20 個保持」明示 | 谷②失う恐怖 | ✅ **既存実装で「保護 + 復活可能」明示済** |
+| 3 | 資産保護文言で安心 | 「アーカイブされますが保護されます。いつでも復活できます」 | 中間山 (安心) | 改善要: 文言 atom 拡張 (「失う / 消える」排除、後述) |
+| 4 | 期末ダウン確定 | `cancel_at_period_end` 風、期末まで family 維持 | — | 改善要 (`subscriptions.update` + `schedule_at_period_end` 経由) |
+| 5 | 期末まで family 機能維持 | 「次回 YYYY/MM/DD から standard に変更」明示 | — | 改善要 (期間中表示) |
+| 6 | 期末で自動降格 + 超過分 read-only | 子供画面では archived 子供・活動が invisible (Anti-engagement) / 親画面では read-only + 「上位プランで再開」CTA | — | ✅ 既存 + 親画面 banner 改善要 (Phase 3 UI) |
+| 7 | **再アップで瞬時復元** | One-click reactivation (Calendly 型) | **最終山 (Win-Back)** | ✅ 既存 `restoreArchivedResources` |
+
+### 超過リソース処理 5 パターン対比 (deep-research)
+
+| パターン | 採用 SaaS | 振る舞い | 心理影響 | 自プロダクト |
+|---|---|---|---|---|
+| **A. Read-only + Block-on-add (Notion)** | Notion / HubSpot | 既存 read + edit 可、新規追加だけブロック | 既存資産は守られた安心感 + 軽い圧 | **✅ 採用 (既存実装相当)** |
+| B. Edit-lock (Figma) | Figma | edit 不可、view のみ、整理で復活 | 「人質」感、地雷化 | ❌ 不採用 |
+| C. Deactivate (Calendly) | Calendly | inactive 化、既存予約保持、新規停止 | 「データ消えていない」明確 | △ Pattern A と類似 |
+| D. Watermark (Canva) | Canva Pro | premium 素材に watermark | 視覚的圧、毎回 reminder | ❌ 子供 UI 不適 |
+| E. Retention shrink (Slack) | Slack | 90日より古い hidden / 1年で物理削除 | 可逆性が低く感じる + dread | ❌ Reverse Trial データ持続性と矛盾 |
+
+### Pattern A 採用理由 (4 点)
+
+1. **子供 UI に視認の不快感ゼロ** (archived は invisible、Anti-engagement ADR-0012 整合)
+2. **「失う恐怖」最小化** (Calendly 型より一段強い「continue editing」許容で長期保持)
+3. **Reverse Trial データ持続性原則と完全整合** (trial で作ったカスタマイズは降格後も保護、`phase2-trial-journey.md` 接続)
+4. **Pattern B (Figma) 地雷回避** (Figma 公式 forum で「team locked、何もできない」苦情多発)
+
+## mermaid 図 2: 状態遷移 (free ↔ standard ↔ family、双方向 + アーカイブ)
+
+```mermaid
+stateDiagram-v2
+    [*] --> free
+    free --> standard : checkout (proration: always_invoice)
+    free --> family : checkout
+    standard --> family : update (proration: always_invoice 即時)
+    family --> standard : update (proration: none, schedule_at_period_end 期末)
+    family --> free : Portal cancel (期末)
+    standard --> free : Portal cancel (期末)
+    family --> family_paused : Pause (将来検討)
+
+    note right of standard
+      ダウン時: 超過リソース
+      → archived_reason='downgrade_user_selected'
+      (Notion 型 Pattern A、復元可)
+    end note
+```
+
+## mermaid 図 3: ダウン時のリソース処理フロー (Notion 型 Pattern A)
+
+```mermaid
+flowchart TB
+    Down[ダウン操作] --> Preview[getDowngradePreview\nダウン後の上限超過を計算]
+    Preview --> Selector[DowngradeResourceSelector.svelte\n「保護 + 復活可能」明示]
+    Selector --> Choice{ユーザー選択\n保持 vs アーカイブ}
+    Choice --> Archive[archiveForDowngrade\narchived_reason='downgrade_user_selected']
+    Archive --> Schedule[subscriptions.update\nproration_behavior=none\nschedule_at_period_end]
+    Schedule --> Period[期末まで family 機能維持]
+    Period --> AutoDown[期末自動降格]
+    AutoDown --> ReadOnly[超過分 read-only\n子供画面 invisible\n親画面 上位プラン CTA]
+    ReadOnly --> ReUp{再アップ?}
+    ReUp -->|YES| Restore[restoreArchivedResources\n瞬時復元]
+    ReUp -->|NO| Maintain[read-only 維持\nデータ削除なし]
+    style Selector fill:#e3f2fd
+    style ReadOnly fill:#fff3cd
+    style Restore fill:#d4edda
+```
+
+## 文言 atom 拡張案 (terms.ts SSOT、ADR-0045 整合)
+
+deep-research 推奨を反映:
+
+```ts
+// terms.ts atom 追加候補
+PLAN_CHANGE_TERMS = {
+  changeVerb: 'プランを変更',     // 「アップグレード」「ダウングレード」を煽り回避で統一
+  archive: 'アーカイブ',
+  restore: '復活',
+  protected: '保護されています',  // 「失う」「消える」を排除
+  resumeReady: 'いつでも復活できます',
+}
+```
+
+```ts
+// labels.ts compound 例
+PLAN_CHANGE_LABELS = {
+  downgradeWarning: `${PLAN_FULL_TERMS.family} で作成された設定は ${PLAN_CHANGE_TERMS.archive} されますが ${PLAN_CHANGE_TERMS.protected}。${PLAN_CHANGE_TERMS.resumeReady}`,
+  upgradeConfirm: `¥{差額} を支払って ${PLAN_FULL_TERMS.family} に変更`,
+}
+```
+
+**禁止語彙**: 「失う」「消える」「使えなくなる」「ロックされる」(Calendly 反面教師)
+
+## 改善要項目 (Phase 3/4/5 申し送り)
+
+### Phase 3 (UI)
+1. **アップ confirm モーダルに proration 差額表示** (preview API 結果を「本日 ¥XXX / 次回 ¥YYY」)
+2. **DowngradeResourceSelector 文言を atom 化** (「失う」排除、「保護 / 復活」採用)
+3. **期末ダウン期間中の親 admin banner** (「次回 YYYY/MM/DD から standard / それまで family 維持」)
+4. **archived リソースの親画面 read-only + 「上位プランで再開」CTA**
+
+### Phase 4 (動線)
+5. **One-click reactivation** (ダウン後の親画面に「アーカイブ X 件・ワンクリックで復活」常時表示)
+6. **アップ動線と checkout ジャーニーの統一 CTA** (`PLAN_CHANGE_TERMS.changeVerb`)
+
+### Phase 5 (アーキ)
+7. **`subscriptions.update` + `proration_behavior=always_invoice` 実装** (アップ即時)
+8. **`subscriptions.update` + `proration_behavior=none` + `schedule_at_period_end`** (ダウン期末)
+9. **Preview API 統合** (`POST /v1/invoices/create_preview`)
+10. **Reverse Trial 終了 ⇔ ダウン降格を同一機構で実装** (`archiveForDowngrade` を trial 終了でも再利用、`resource-archive-service.ts` 統合)
+11. **`PLAN_CHANGE_TERMS` atom + `PLAN_CHANGE_LABELS` compound 追加** (terms.ts / labels.ts)
+
+## 特商法 (JP) 最終確認画面 6 要素 (アップ/ダウン共通)
+
+deep-research 反映、消費者庁 2022 改正特商法ガイドライン整合:
+
+1. **分量** — 「子供 5 人 / 活動 20 個まで利用可能」等の数値明示
+2. **販売価格・対価** — アップ: 「月額 ¥780 (税込) + 本日差額 ¥XXX」/ ダウン: 「次回更新 YYYY/MM/DD ¥500 (税込)」
+3. **支払の時期・方法** — アップ即時 / ダウン期末 明示
+4. **引渡・提供時期** — 機能反映タイミング (アップ即時 / ダウン期末)
+5. **申込期間** — トライアル経由なら trial 期間再表示
+6. **解約方法** — 「いつでも Customer Portal から変更・解約可能」
+
+→ Stripe Customer Portal だけに任せず、**自社 confirm モーダルで 2 重表示**して JP 法令リスク最小化。
+
+## ADR-0012 整合性チェック
+
+| 観点 | アップ | ダウン |
+|---|---|---|
+| 子供 UI に課金圧をかけない | ✅ 親 admin のみ | ✅ archived リソースは子供画面 invisible |
+| 滞在時間延伸禁止 | ✅ 即時反映で短時間完結 | ✅ 期末ダウンの期間中も誘導通知連打しない (静的 banner 1 件) |
+| サプライズ濫用禁止 | ✅ 「¥XXX 本日決済」明示 | ✅ 期末日明示、突然中断なし |
+| 連続演出 / 煽り禁止 | ✅ Kinde 「what happens when clicked」原則 | ✅ 「失う / 消える」atom 禁止、「保護 / 復活」採用 |
+
+## ペルソナ別 UX レビュー観点
+
+- **兄弟複数家庭 (family → standard 検討)**: 子供 N 人のうち誰をアーカイブするか選択 / 「保護 + 復活」の安心感が刺さるか
+- **trial 完璧化派 (family trial → free 自然降格)**: Reverse Trial の自動降格と手動ダウンが同一 UX で混乱しないか
+- **コスト見直し家庭**: standard で十分と判断 / 期末まで family 維持の納得感
+- **再アップ復活組 (Win-Back)**: ダウン後の「アーカイブ X 件・ワンクリック復活」が見つけやすいか
+- **卒業期 (高校生親)**: 卒業に伴う standard / 無料へのダウンが自然か / 子供の成長記録が保護される安心
+
+## Open question (PO 判断)
+
+| # | 論点 | 状態 |
+|---|------|------|
+| 1 | `PLAN_CHANGE_TERMS` atom 採否 (「失う / 消える」全 atom から排除) | terms.ts 拡張、PO 判断 (ADR-0045 整合) |
+| 2 | proration UX = `always_invoice` + preview API 採用 | Phase 5 アーキで実装方式 (推奨済) |
+| 3 | Pattern A 維持 vs Pattern C (Calendly) への変更 | 既存 Pattern A 推奨 (子供 UI Anti-engagement 整合) |
+| 4 | One-click reactivation バナーの常時表示範囲 | Phase 3 UI、archived 件数 > 0 で表示 |
+| 5 | 期末ダウン期間中の文言 (「family 維持中」表示) | Phase 3 UI |
+| 6 | Reverse Trial 終了 ⇔ 手動ダウンを同一機構で実装 | Phase 5 アーキ (recommended、`archiveForDowngrade` 再利用) |
+| 7 | Product 構成 (1 Product 4 Price vs 4 Product) | Phase 5 (Phase 1 #2535 申し送り済) |
+
+## 根拠
+
+- **既存実装 (Explore 照合 2026-05-28)**: `SaasLicensePanel.svelte:165-763` / `downgrade-service.ts` (`getDowngradePreview`:31-117, `archiveForDowngrade`:133-202) / `resource-archive-service.ts` / `DowngradeResourceSelector.svelte` / `downgrade-restore/+server.ts`
+- **deep-research (2026-05-28)**: Stripe `proration_behavior` 3 値 + Preview API (`create_preview`) + 超過リソース 5 パターン対比 (Notion/Figma/Calendly/Canva/Slack) + Kinde Plan Change Best Practices + Win-Back Chargebee/Sequenzy/Churnkey + 消費者庁特商法ガイドライン 2022
+- 関連ジャーニー: `phase2-checkout-journey.md` (4 谷参照) / `phase2-trial-journey.md` (Reverse Trial データ持続性) / `phase2-cancellation-journey.md` (期末解約・退会と整合)
+- Phase 1 phase1-plan-change-requirements.md (#2535) / phase1-data-lifecycle (#2538 ADR-0049 データ保持) / phase1-trial (Reverse Trial)
+- ADR-0012 (Anti-engagement) / ADR-0045 (terms.ts SSOT 2 階層) / ADR-0049 (データ保持) / ADR-0010 (Pre-PMF)
+- Stripe `subscriptions/update` / `invoices/create_preview` / Customer Portal `schedule_at_period_end` 公式 docs

--- a/docs/design/billing-redesign/phase2-signup-journey.md
+++ b/docs/design/billing-redesign/phase2-signup-journey.md
@@ -1,0 +1,165 @@
+# 新規申込 ジャーニーマップ (#2546 / Epic #2525 Phase 2 UX) — 既存実装前提・2 山構造で全面再構成
+
+| 項目 | 内容 |
+|------|------|
+| 孫 issue | #2546 (新規申込のジャーニー) |
+| 親 | #2527 (Phase 2 UX) / 上位 #2525 |
+| ステータス | **2026-05-28 全面再構成**: 主体を親に統一・2 山構造 (中間山 setup 完遂 + 最終山 初回記録) ・マーケットプレイス推奨自動採用とデフォルト表示ページ選択を既存実装ベースで組み込み |
+| 対応 Phase 1 要件 | phase1-signup-requirements.md (補強済 #2561) |
+
+## 設計の核 (PO 整理を反映)
+
+- **ジャーニー主体は最後まで親** (signup・子供登録・活動/ごほうび登録は親が行う)
+- **2 山構造**:
+  - **中間山** = setup 完遂 (「使い始められる状態になった」、親の達成感)
+  - **最終山** = 初回活動記録 (子の使い始め、**親代行でも到達 OK**)
+- **マーケットプレイス推奨自動採用** = 中間山を早く到達させる既存実装の鍵
+- **ログイン後デフォルト表示ページ選択** = 中間山→最終山の橋渡し (既存実装で `default_child_id` + `selectedChildId` cookie)
+
+## ジャーニー (既存実装ベース、感情曲線)
+
+| # | ステップ | 既存実装 | 親の体験 | 感情 | 谷/山 |
+|---|---|---|---|---|---|
+| 0 | LP | `site/index.html` | 価値・安全性・無料を確認 | 期待/不安 | — |
+| 1 | signup 入力 | `auth/signup/+page.svelte` (**license key 欄撤去**) | email/pw/3同意 | 不安 (3同意・越境) | — |
+| 2 | **Cognito sign-up 確認コード入力** (MFA でなく初回 email 所有確認) | `auth/signup` SignUp→ConfirmSignUp action | 6 桁コード受信→入力 | **苛立ち (届かない・spam) ← 谷①** | 谷① |
+| 3 | 自動ログイン → /admin + provisioning | `auth/signup/+page.server.ts:249-404` | 自動遷移 | 安堵 | — |
+| 4 | **/setup/children (必須)** | `setup/children` (年齢→UIMode 自動: 0-2=baby/3-5=preschool/6-12=elementary/13-15=junior/16-18=senior) | 子供のニックネーム+年齢 | 期待 | — |
+| 5 | **/setup/packs (マーケットプレイス推奨自動採用)** | `setup/packs/+page.server.ts:49-55, 120-142` (targetAgeMin/Max マッチ + mustDefault 同時採用、**スキップ時も自動インポート**) | 年齢に合った活動セットが**自動選択済み**で出る → そのまま採用 or 微調整 | 楽さ (組まなくていい) | — |
+| 6 | /setup/rewards・challenges (推奨自動採用) | `setup/rewards/+page.server.ts:34-36` (年齢条件) / `setup/challenges/+page.server.ts:40-56` (autoAddRecommended) | 推奨ごほうび・チャレンジ自動採用 | 楽さ | — |
+| 7 | **/setup complete** | setup complete | 「使い始められる」 | **達成感 ← 中間山 (setup 完遂)** | **中間山** |
+| 8 | ログイン後デフォルト表示先へ遷移 | `/+page.server.ts:20-69` (selectedChildId cookie → `default_child_id` → 子1人自動 → /switch の優先順位) | 親が「どの子の使い始めを見るか」を意識 (兄弟あれば既定の子供選択 UI 提示は `admin/settings/activities`) | 主体感 | — |
+| 9 | 親代行 or 子に座らせる | — (画面遷移のみ) | 子供を呼ぶ or 親が代わりに記録準備 | **躊躇 (子に座らせるハードル) ← 谷②** | 谷② |
+| 10 | **初回活動記録 → 祝福 legend** | `ActivityCard.svelte` + `CelebrationEffect` (legend: 👑+aura+particle) | 子 (or 親代行) が ActivityCard を 1 つ記録 → 数秒の祝福 | **歓喜 (家庭で価値が動き出した) ← 最終山** | **最終山** |
+
+## 感情曲線と既存実装に即した対策
+
+### 中間山 (#7 setup 完遂)
+- **既存実装の強み**: マーケットプレイス推奨が **年齢帯条件で自動判定 + デフォルト選択 + スキップ時も自動インポート**まで実装済み = setup 9 ステップを全部「自分で組む」必要がない
+- 設計指針: この既存の楽さを **LP / setup UI で前面化** (Phase 3)。「9 ステップ全部組まなくていい、推奨をそのまま採用できる」が達成感の核
+- 補強案 (Phase 3 UI 申し送り): 自動登録モードを 1 ボタンで明示 (「推奨をすべて採用」ワンクリック)
+
+### 最終山 (#10 初回活動記録)
+- **既存実装の強み**: `CelebrationEffect` の legend 演出 (👑) が初回記録の Aha。「記録 → 数秒で閉じる」(ADR-0012) の体験
+- **親代行で到達 OK**: 主体が子か親代行かは家庭の事情に委ねる。preschool は親代行が自然、elementary+ は子供本人だが厳密分岐しない
+
+### 谷① (#2 Cognito sign-up 確認コード)
+- 既存: 再送可能 (60 秒クールダウン)、24h 有効 (FR-9)
+- 設計指針: 「届かない・spam」の告知 + 再送導線を見やすく (Phase 3)
+
+### 谷② (#9 子に座らせるハードル)
+- 親代行 OK で軽減。「ご家族で一緒に最初の記録を」等の文言で親の負担感を下げる (Phase 3)
+- ログイン後デフォルト表示ページ選択 (既存) で「最初に誰のホームを開くか」を親が制御 → 自然な動線
+
+## 既存からの変更点 (delta、ライセンスキー撤廃 + 補強)
+
+| # | 既存 | 要件 | 扱い |
+|---|---|---|---|
+| 1 | signup に license key 欄 | 撤去 | 変更 |
+| 2 | `?plan=X` trial 自動開始 (signup) | 撤去 (任意タイミング) | 変更 (trial ジャーニー #2547 と整合) |
+| 3 | マーケットプレイス推奨自動採用 (setup/packs:120-142) | 維持・前面化 | ✅ 既存活用 (中間山の核) |
+| 4 | `default_child_id` + `selectedChildId` cookie (ログイン後遷移) | 維持・signup 直後の動線で活用 | ✅ 既存活用 (橋渡し) |
+| 5 | /setup 9 ステップの skip 可 | 維持 | ✅ 既存活用 |
+| 6 | コアループ (ActivityCard + CelebrationEffect) | 維持 | ✅ 最終山の核 |
+
+## UX レビュー観点 (家族構成 / setup 耐性ペルソナ、Phase 2 完了基準)
+
+年齢分岐ペルソナでなく、家族構成と setup への態度で分ける:
+
+- **1 人っ子家庭 (standard 想定)**: setup 軽い (children 1 人) / 推奨自動採用で楽 / 既定の子供選択 UI は非表示 (1 人時) / 親代行で最終山到達も簡単
+- **兄弟複数家庭 (family 想定)**: setup やや重い / 既定の子供選択 UI 表示 (2 人以上) / どの子から使い始めるかの判断材料
+- **「自分で組みたい派」**: 推奨を採用せずカスタム入力 / 中間山到達が遅くなるが満足度高い (主体性)
+- **「自動登録派」**: 推奨そのまま採用 / マーケットプレイス自動採用で中間山高速到達 / setup 9 ステップ skip 多用
+- **卒業期 (高校生親)**: 子供本人が記録、親代行不要 / AUTONOMY_TERMS 整合 / setup の活動・ごほうびも本人主導
+
+## Open question (PO 判断)
+
+| # | 論点 | 状態 |
+|---|------|------|
+| 1 | 「推奨をすべて採用」ワンクリックモードの明示 UI | Phase 3 UI で設計 (既存はステップごとに自動採用済、ワンクリック集約は新規) |
+| 2 | 既定の子供選択 UI (1 人時非表示 / signup 直後はまだ 1 人) | 既存ロジック維持で OK か、signup 直後の挙動を Phase 3 確認 |
+| 3 | 最終山「子に座らせる」動線の文言・タイミング | Phase 3 UI で文言 (親代行を肯定する文言含む) |
+| 4 | baby (0-2 歳) 家庭の新規申込 | baby は最終山 (初回記録 Aha) がない準備モード → 別ジャーニーで扱う (ADR-0011) |
+
+## mermaid 図示 (2026-05-28 追補)
+
+### 図 1: 新規申込 感情曲線 (journey、2 山構造)
+
+```mermaid
+journey
+    title 新規申込 ジャーニー (主体=親、2 山構造)
+    section signup
+      LP → signup 入力: 4: 親
+      Cognito sign-up 確認コード: 2: 親
+      自動ログイン → /admin: 4: 親
+    section setup (中間山到達)
+      子供登録 (年齢→UIMode 自動): 4: 親
+      マーケットプレイス推奨自動採用: 5: 親
+      ごほうび・チャレンジ自動採用: 5: 親
+      setup 完遂: 5: 親
+    section デフォルト表示選択
+      どの子のホーム or 親管理: 4: 親
+    section 最終山 (子の使い始め)
+      子に座らせる or 親代行: 3: 親
+      初回活動記録 → legend 祝福: 5: 親
+```
+
+### 図 2: signup → setup → 最終山 動線 (flowchart)
+
+```mermaid
+flowchart TB
+    LP[LP site/index.html] --> Signup[auth/signup<br/>email/pw/3同意]
+    Signup --> Confirm[Cognito sign-up<br/>確認コード入力]
+    Confirm --> AutoLogin[自動ログイン → /admin]
+    AutoLogin --> SetupChildren[/setup/children<br/>年齢→UIMode 自動]
+    SetupChildren --> SetupPacks[/setup/packs<br/>マーケットプレイス推奨自動採用]
+    SetupPacks --> SetupRewards[/setup/rewards/challenges<br/>autoAddRecommended]
+    SetupRewards --> Complete[/setup complete<br/>= 中間山]
+    Complete --> Landing[ログイン後デフォルト表示遷移<br/>selectedChildId / default_child_id]
+    Landing --> ChildHome[(child)/[uiMode]/home]
+    ChildHome --> FirstRecord[ActivityCard 初回記録<br/>+ legend 祝福 = 最終山]
+    style Complete fill:#d4edda
+    style FirstRecord fill:#fff3cd
+```
+
+### 図 3: 年齢モード分岐 (state、UIMode 自動判定)
+
+```mermaid
+stateDiagram-v2
+    [*] --> setup_children
+    setup_children --> uimode_baby : age 0-2
+    setup_children --> uimode_preschool : age 3-5
+    setup_children --> uimode_elementary : age 6-12
+    setup_children --> uimode_junior : age 13-15
+    setup_children --> uimode_senior : age 16-18
+    uimode_baby --> baby_journey : 準備モード (Aha なし、別 J)
+    uimode_preschool --> child_home : 親代行で最終山到達 OK
+    uimode_elementary --> child_home : 子供本人で記録
+    uimode_junior --> child_home : 子供本人 (情報密度高)
+    uimode_senior --> child_home : 子供本人 (AUTONOMY 整合)
+    child_home --> final_peak : 最終山 (初回記録)
+    note right of uimode_baby
+      ADR-0011: 準備モード
+      新規申込ジャーニーから分岐
+    end note
+```
+
+## 業界呼称・PO 既出指摘との整合性 (2026-05-28 追補)
+
+- **業界用語**: **Activation funnel** (signup → onboarding → aha moment) / **PQL = Product Qualified Lead** (3 core action 完了) / **Time-to-Aha** (Aha moment 到達時間)
+- **4 谷参照**: `phase2-checkout-journey.md` 参照 (本ジャーニーは課金前で 4 谷適用外、代わりに**メール確認谷 / setup 9 ステップ負荷谷 / 子に座らせる谷**)
+- **Reverse Trial 接続**: signup 時は無料プラン開始のみ、trial は任意タイミング (`phase2-trial-journey.md` パターン C 整合)
+- **文言 atom**: `terms.ts` 既存活用 (TRIAL/CTA/SIGNUP/LOGIN/CHILD/PARENT)、煽り語彙なし
+- **ADR-0012 整合**: 子供画面に課金/trial UI なし、最終山の祝福演出は「記録→数秒で閉じる」原則維持
+
+## 根拠
+
+- **既存実装 (Explore 照合 2026-05-28)**:
+  - `auth/signup/+page.server.ts` (Cognito SignUp→ConfirmSignUp→自動ログイン→provisioning)
+  - `setup/children` / `setup/packs/+page.server.ts:49-55, 120-142` (マーケットプレイス推奨自動採用 + スキップ自動インポート) / `setup/rewards/+page.server.ts:34-36` / `setup/challenges/+page.server.ts:40-56` (autoAddRecommended)
+  - `+page.server.ts:20-69` (ログイン後 selectedChildId → default_child_id → /switch 優先順位)
+  - `default-child-service.ts` (DB 既定の子供) / `admin/settings/activities/+page.server.ts:14, 41, 60-82` (UI)
+  - `(child)/[uiMode=uiMode]/home/+page.svelte` + `ActivityCard.svelte` + `CelebrationEffect` (コアループ・最終山)
+  - `age-tier.ts` (UIMode 自動判定)
+- Phase 1 phase1-signup-requirements.md (補強済) / ADR-0012 / ADR-0011 (baby) / ADR-0045 (terms/labels)
+- ※ 自プロダクト既存実装を主軸に再設計 (feedback_deep_research_product_specific)

--- a/docs/design/billing-redesign/phase2-trial-journey.md
+++ b/docs/design/billing-redesign/phase2-trial-journey.md
@@ -1,0 +1,207 @@
+# トライアル ジャーニーマップ (#2547 / Epic #2525 Phase 2 UX) — Reverse Trial 観点で全面再構成
+
+| 項目 | 内容 |
+|------|------|
+| 孫 issue | #2547 (トライアルのジャーニー) |
+| 親 | #2527 (Phase 2 UX) / 上位 #2525 |
+| ステータス | **2026-05-28 全面再構成**: 業界呼称「**Reverse Trial**」確定 + カスタマイズ持続型を価値訴求の中心に + mermaid 3 図 |
+| 対応 Phase 1 要件 | phase1-trial-requirements.md (#2533: family 固定・7日・カード登録なし・cancel で無料復帰・1回制限 family-tenant) |
+| deep-research | Reverse Trial 業界事例 (Notion/Slack/Figma/Canva/Calendly) + PLG ベストプラクティス + ADR-0012 整合性検証完了 |
+
+## 業界呼称の確定: Reverse Trial (リバーストライアル)
+
+がんばりクエストのトライアルは業界用語で **Reverse Trial** に該当する。定義 (ProdPad / Elena Verna / OpenView 一貫):
+
+> "ユーザーに有料機能フルアクセスを期間限定で与え、終了時に**機能制限のあるフリープランへ自動降格**するモデル"
+
+**Reverse Trial の 4 核要素** (ProdPad):
+
+1. **No credit card required** — カード登録不要
+2. **Automatic downgrade** — 自動的にフリーへ降格 (アクセス遮断ではない)
+3. **Data persistence** — 作成リソース・データはフリープランで保持
+4. **Full feature access initially** — 初日から有料機能 100% 解放
+
+→ がんばりクエストは **4 要素全てを満たす標準的 Reverse Trial** (命名上の独自性なし、既存プレイブック参照可)。
+
+### 通常 Free Trial / Freemium との峻別
+
+| | Reverse Trial (本プロダクト) | 通常 Free Trial | Freemium |
+|---|---|---|---|
+| 開始時 | 有料機能フル | 有料機能フル | 無料機能のみ |
+| 終了時 | 自動でフリーへ降格 | アクセス遮断 or 自動課金 | 終了概念なし |
+| カード登録 | 不要 (opt-in) | 必要 (opt-out 主流) | 不要 |
+| データ | 持続 | 削除 or アクセス不可 | 持続 |
+| FTC/特商法リスク | 低 (dark pattern 構造的回避) | 高 (ABCmouse 反面教師) | なし |
+
+## 価値訴求の中心: カスタマイズ持続性 (PO 戦略)
+
+**汎用マーケットプレイスプリセット**では各家庭の実態と合わない → **カスタマイズ深化が課金 hook**。トライアル中に追加・変更したカスタマイズは無料降格後も**保持**される (Stripe 非経由・trial_history テーブル・データは tenant 紐づきで削除なし)。
+
+理論上「7-14 日で完璧カスタマイズすれば無料でも困らない」が、現実 100 点は困難 = 有料動機が継続的に発生 = 課金導線。この戦略は **Reverse Trial の sticky feature 理論と完全一致** (OpenView)。
+
+## ジャーニー (Reverse Trial プレイブック整合)
+
+### mermaid 図 1: 感情曲線 (journey)
+
+```mermaid
+journey
+    title トライアル ジャーニー (Reverse Trial 観点)
+    section 発見
+      無料で利用中: 3: 親
+      上限/制約に到達: 2: 親
+    section 開始
+      Reverse Trial 開始 (カード不要): 5: 親
+    section カスタマイズ深化
+      家族全員 family 体験: 5: 親
+      preset から custom へ: 4: 親
+      PQL 達成 (3 core action): 5: 親
+    section 終了接近
+      残日数 / 進捗バナー: 3: 親
+    section 判断
+      有料化: 5: 親
+      無料降格 (自動): 4: 親
+    section 降格後
+      カスタマイズ保持の安心: 4: 親
+      上限超過分 read-only: 3: 親
+      いつでも再課金で復活: 5: 親
+```
+
+### mermaid 図 2: トライアル状態遷移 (stateDiagram)
+
+```mermaid
+stateDiagram-v2
+    [*] --> no_trial
+    no_trial --> active : startTrial (user_initiated, family 固定)
+    active --> paid : checkout (任意のタイミング)
+    active --> expired_free : endDate 経過 (自動、カード不要)
+    expired_free --> paid : 任意の再課金 (custom 即時復活)
+    paid --> [*]
+    note right of expired_free
+      自動課金なし
+      カスタマイズ保持
+      上限超過分 read-only
+    end note
+```
+
+### mermaid 図 3: 降格時のリソース扱い (flowchart、Notion 型 read-only モデル提案)
+
+```mermaid
+flowchart TB
+    A[Trial 中のカスタマイズ\n活動・ごほうび・子供・チャレンジ] --> B{Trial 終了}
+    B -->|有料化| C[全カスタマイズ即時フルアクセス]
+    B -->|無料降格| D[無料上限内のリソース: フルアクセス]
+    B -->|無料降格| E[上限超過分: 読み取り専用 / 子供画面非表示]
+    E --> F{再課金?}
+    F -->|YES| G[読み取り専用 → フル復活 即時]
+    F -->|NO| H[読み取り専用維持\nデータは消えない]
+    style E fill:#fff3cd
+    style G fill:#d4edda
+```
+
+## ジャーニー詳細表
+
+| # | ステップ | 既存実装 + Reverse Trial BP | 親の体験 | 感情 | 谷/山 |
+|---|---|---|---|---|---|
+| 0 | 無料利用中・上限到達 | feature gate (`plan-limit-service`) | 子供3人目/活動4つ目で gate | 物足りない | — |
+| 1 | **Reverse Trial 開始** | `startTrial(user_initiated, tier='family')` (trial_history、Stripe 非経由、カード不要) | 「7日間 family を試す・カード不要」 | 安心 (勝手に課金されない) | — |
+| 2 | **family フル体験 + aha** (BP5 sticky paid feature) | `resolveFullPlanTier` = family、子供無制限・全機能解放 | **家族全員の見守り画面 を初体験** | 歓喜 ← **中間山 (aha moment)** | **中間山** |
+| 3 | カスタマイズ深化 (preset → custom) | マーケットプレイス推奨を採用 → 各家庭で活動・ごほうび編集 | 家庭独自の活動セット形成 | 主体感・愛着 | — |
+| 4 | **PQL 達成** (BP2、3 core action: 子供登録 / 活動カスタマイズ / ごほうび設定 各 1 件以上) | 既存実装で計測可能 (analytics 層) | 「家庭仕様で動き出した」 | 達成感 | — |
+| 5 | 終了接近 (BP4 進捗フレーミング) | `TrialBanner` daysRemaining 静的1件 | 「家族仕様化まであと N 件」(残日数より進捗) | 検討 | 谷① (軽い) |
+| 6a | **有料化** | Phase 1 checkout (standard/family 併置) | 申込 → カスタマイズ即時フル維持 | 決断 ← 最終山 (paid) | — |
+| 6b | **自動無料降格** | `endDate >= today` 自動 (cancel 不要) | 自動で無料へ、カスタマイズ保持 | 安心 ← 最終山 (free) | — |
+| 7 | 降格後の読み取り専用 (BP4 Notion 型) | 上限超過分は子供画面非表示 + 親画面で read-only + 「上位プランで再開」CTA | 「データは消えていない」 | 信頼 | — |
+| 8 | いつでも再課金で復活 (BP5) | 再 checkout で全カスタマイズ即時復活 | 「設定をやり直す必要がない」 | LTV ↑ | — |
+
+## 感情曲線と Reverse Trial プレイブックの対応
+
+### 中間山 #2 (家族全員 family 体験 = aha moment)
+
+**Reverse Trial の成否は paid feature が sticky か** (OpenView)。がんばりクエストの最 sticky 候補 = **家族全員の見守り画面**。これを trial 1-2 日目で必ず体験させる導線が要 (Phase 3 UI で前面化)。
+
+### 中間山 #4 (PQL 達成)
+
+**PQL = 3 core action 完了したユーザー、conversion の最強予測指標** (Focused Chaos)。がんばりクエストの PQL 候補: (a) 子供登録 1 件 (b) 活動カスタマイズ or 追加 1 件 (c) ごほうび設定 1 件。**analytics 層に組込み** (follow-up)。
+
+### 谷① #5 (終了接近、loss aversion を「資産保護」型で)
+
+**「あと N 日!」型煽りは Anti-engagement (ADR-0012) 違反**。代わりに進捗フレーミング:「あなたの家庭仕様まであと 3 ステップ」「お子さま 2 人目の活動セット未設定」(Calendly モデルを煽らない方向で応用)。
+
+### 最終山 #6b (無料降格でも安心)
+
+**「降格は save moment として設計、無音で機能を消さない」** (Userpilot)。降格 24h 前 + 当日 + 3 日後の 3 タッチ、メール 1 件 (子供画面ゼロ通知、ADR-0012 整合)。文言は「あなたが trial 中に作った活動 12 件、無料では 3 件のみ子供画面に配信されます。残り 9 件は保護されたまま、いつでも再有効化できます」型 (具体カウント + 「消えない」明示)。
+
+## 既存実装と Reverse Trial プレイブックの整合性
+
+| 4 核要素 | がんばりクエスト既存実装 | 評価 |
+|---|---|---|
+| No credit card | trial_history ベース、Stripe 非経由 | ✅ 完全整合 |
+| Automatic downgrade | `endDate >= today` で自動 isActive=false | ✅ 完全整合 |
+| Data persistence | trial 中作成リソースは tenant 紐づきで保持 (削除なし) | ✅ 完全整合 (ただし「上限超過分の扱い」は仕様未明文化、後述 follow-up) |
+| Full feature access | family tier 解決、子供無制限・全機能 | ✅ 完全整合 |
+
+## ペルソナ別の UX レビュー観点 (家族構成 + カスタマイズ態度)
+
+- **1 人っ子家庭 (standard 検討者)**: family 体験は過剰 → family aha でなく standard 機能差分を示す導線必要 / トライアル後 standard ダウンセル動線
+- **兄弟複数家庭 (family ターゲット)**: 中間山 #2 (家族全員見守り) が刺さる / 第 2 子・第 3 子展開の段階的 onboarding (BP3 Behavior-based)
+- **「自分で組みたい派」**: カスタマイズ深度で sticky / preset → custom の進捗を見せる
+- **「自動登録派」**: マーケットプレイス自動採用で aha 高速到達 / 「家庭仕様」を体感させる工夫が必要
+- **卒業期 (高校生親)**: 子供本人主導 / 卒業前提でも trial 中の "成長記録蓄積" が価値
+
+## 既存からの変更点 (delta)
+
+| # | 既存 | 要件 | 扱い |
+|---|---|---|---|
+| 1 | `DEFAULT_TRIAL_TIER='standard'` (trial-service.ts:12) | **family 固定** | 変更 (sticky paid feature 最大化) |
+| 2 | `?plan=X` signup 時自動開始 | 撤去 (任意タイミング、gate / プラン画面から) | 変更 (新規申込ジャーニー整合) |
+| 3 | 1回制限 = `user_initiated` + `trialUsed` (tenant 単位) | family-tenant 単位 | 既存と同一 (確認のみ) |
+| 4 | 自動無料降格 (cancel 不要・自動課金なし) | 維持 | ✅ Reverse Trial の核 |
+| 5 | データ持続 (trial 中作成リソース保持) | 維持 + **上限超過分の扱い明文化** | 新規 ADR 候補 (Notion 型 read-only 推奨) |
+| 6 | TrialBanner 残日数表示 | 進捗フレーミング併用 | Phase 3 UI |
+| 7 | PQL 計測 | 新規 (BP2、analytics 層) | follow-up Issue |
+
+## Open question (PO 判断) + deep-research 推奨 follow-up
+
+| # | 論点 | 推奨 / 状態 |
+|---|------|-----------|
+| 1 | **trial 期間 7 日 → 14 日 A/B 検討** | 業界 sweet spot 14 日、家族で週末 2 回挟める。`TRIAL_TERMS.duration` atom 1 行変更で SSOT 伝播 (Pre-PMF Bucket A 候補) |
+| 2 | **降格時の上限超過分の扱い** | Notion 型 (read-only)・Figma 型 (lock)・Canva 型 (watermark) の 3 案。**Notion 型 read-only 推奨** (家庭向け・子供画面非表示で Anti-engagement 整合)。ADR 化候補 |
+| 3 | **「カスタマイズは消えない」LP 訴求** | hero 直下 1 行追加検討 (例: 「無料に戻っても、家族のカスタマイズはそのまま残ります」)。ADR-0013 LP truth 整合確認必要 (実装の事実) |
+| 4 | **PQL = 3 core action 計測** | analytics 層に組込み (BP2) follow-up Issue |
+| 5 | **季節性コンテンツ更新メカニズム** | マーケットプレイス更新頻度が「現実 100 点を防ぐ」最大の武器 (Bucket A 候補) |
+| 6 | trial 中の sticky paid feature ハイライト動線 | Phase 3 UI で家族全員見守り画面を 1-2 日目に必ず体験させる |
+
+## ADR-0012 Anti-engagement との整合性 (最終評価)
+
+| Anti-engagement 原則 | Reverse Trial 設計での扱い | 整合 |
+|---|---|---|
+| 子供 UI に課金圧をかけない | 子供画面に trial / 課金 UI 一切出さず、保護者画面のみ | ✅ |
+| 滞在時間 = 価値毀損 | trial 中も loop は「記録 → 数秒で閉じる」、終了演出も子供側ゼロ | ✅ |
+| サプライズ濫用禁止 | 降格 24h 前 + 当日 + 3 日後の 3 タッチ、メール 1 件 | ✅ |
+| 通知連打禁止 | 上記 3 タッチ + Push 不使用 | ✅ |
+| 連続ガチャ / 煽り禁止 | 「失う恐怖」型コピー不使用、「保護される」「いつでも戻せる」型に統一 | ✅ |
+| 販促文言審査 | 「カード不要 + 自動無料降格 + データ保持」を**家族尊重主張**として打ち出す | ✅ |
+
+→ **Reverse Trial は ADR-0012 と本質的に整合** (loss aversion を「資産保護」フレーミングで使う限り)。
+
+## 想定リスク (PO 戦略の弱点と緩和策)
+
+| リスク | 概要 | 緩和策 |
+|---|---|---|
+| 真面目家庭の trial 完璧化 → 無料定着 | 教育意識高い家庭は 7-14 日で完璧化、ARPU 押し下げ | 季節性アップデート / コンテンツ供給で「100 点を陳腐化」させる継続価値 |
+| 7 日で家族全員試せず体験浅い → 降格時 loss aversion 効かず churn | 一度も触らない子供がいる家庭で降格してもダメージ感ゼロ | 14 日延長 + 「家族全員 onboarding 達成」での trial 延長候補 (BP3 段階的 onboarding) |
+| family 固定 → standard 十分な家庭の期待値ズレ | trial 後 standard 検討者が family 機能 loss を「失った」と誤認 | trial 中の sticky 機能を **standard 残存 / family 限定**で視覚分離 (Phase 3 UI) |
+| FTC / 特商法 dark pattern | 課金復活時の同意取得 / cancel UI 不備 | ABCmouse 反面教師 / Parent-Gate Session (ADR-0050) で家庭内 UX 担保 |
+| Reverse Trial 業界比 conversion 25% 未達 | sticky paid feature 探索失敗、freeloader 化 | PQL 計測 + 低 PQL ユーザに onboarding 強化 |
+
+## 根拠
+
+- **業界呼称・プレイブック (deep-research 2026-05-28)**:
+  - ProdPad Glossary "Reverse Trial" (4 核要素定義)
+  - Elena Verna (Amplitude) / OpenView (Kyle Poyar) "Your Guide to Reverse Trials"
+  - 事例: Notion (`notion.com/help/plan-downgrade`)、Slack (`slack.com/help/articles/202878523`)、Figma (`help.figma.com/hc/en-us/articles/360046216313`)、Canva (`canva.com/help/watermarks-design`)、Calendly (Userpilot)
+  - PLG ベンチマーク: Stackmatix / Focused Chaos / Heap / Ordway Labs / Cleverbridge
+  - 規制反面教師: FTC vs ABCmouse (2021 dark pattern enforcement)
+- **既存実装 (Explore 照合)**: `trial-service.ts` (trial_history・1回限り・自動無料復帰) / `TrialBanner.svelte` / `plan-limit-service` (feature gate) / マーケットプレイス自動採用 (`setup/packs:120-142`)
+- Phase 1 phase1-trial-requirements.md (#2533) / phase1-checkout (standard/family 併置) / phase1-legal (自動課金なし整合) / phase1-data-lifecycle (削除しない)
+- ADR-0012 (Anti-engagement) / ADR-0010 (Pre-PMF) / ADR-0013 (LP truth) / ADR-0045 (terms/labels SSOT) / ADR-0050 (Parent-Gate)

--- a/scripts/doc-code-references-baseline.json
+++ b/scripts/doc-code-references-baseline.json
@@ -121,7 +121,8 @@
 		],
 		"docs/security/security-code-review-2026-03.md": [
 			"src/lib/server/services/email-otp-service.ts"
-		]
+		],
+		"tests/CLAUDE.md": ["infra/node_modules"]
 	},
 	"generatedAt": "2026-05-27T02:58:51.027Z"
 }


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ プロダクト運営

**解決する課題**: Epic #2525 で再設計中の課金/プラン体系 Phase 2 (UX) 7 領域 (新規申込 / トライアル / 有料化 / アップ・ダウングレード / 解約退会 / dunning / NUC) のユーザージャーニーが体系化されておらず、Phase 3 (構造設計) / Phase 4 (実装) に着手しても「どの画面でどの感情遷移を起こすか」「既存実装をどう活用するか」が曖昧で実装散逸 + LP 文言乖離 (ADR-0013 違反) を再生産するリスクがあった。

**期待される効果**: 7 ジャーニーで mermaid 3 図 (感情曲線 / sequence / state) + 業界呼称 + ADR-0012 整合性 + 既存実装 Explore 照合を完備することで、Phase 3/4/5 着手時に「設計の SSOT」として参照可能になり、再設計 (#2293 Loop 7 回失敗) の構造的再発を防ぐ。

## 関連 Issue

closes #2546
closes #2547
closes #2548
closes #2549
closes #2550
closes #2551
closes #2552

Epic 親: #2525 (Phase 2/7)
直接親: #2527 (Phase 2 UX ジャーニーマップ集約)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 新規申込ジャーニー設計完了 (#2546) | `docs/design/billing-redesign/phase2-signup-journey.md` (165 行新規) | PASS — mermaid 3 図 + 既存実装 Explore 照合 |
| AC2 | トライアルジャーニー設計完了 (#2547) | `docs/design/billing-redesign/phase2-trial-journey.md` (207 行新規) | PASS — Reverse Trial 業界呼称確定 + 4 核要素整理 |
| AC3 | 有料化ジャーニー設計完了 (#2548) | `docs/design/billing-redesign/phase2-checkout-journey.md` (204 行新規) | PASS — PO 指摘 4 谷 (プラン選択 / 金額 / 解約柔軟性 / 購入動線) 整理 |
| AC4 | プラン変更ジャーニー設計完了 (#2549) | `docs/design/billing-redesign/phase2-plan-change-journey.md` (257 行新規) | PASS — Notion 型 Pattern A 採用 / proration UX (Stripe Preview API) |
| AC5 | 解約退会ジャーニー設計完了 (#2550) | `docs/design/billing-redesign/phase2-cancellation-journey.md` (151 行新規) | PASS — Calendly 反面教師 (「失う/消える」atom 排除) |
| AC6 | dunning ジャーニー設計完了 (#2551) | `docs/design/billing-redesign/phase2-dunning-journey.md` (133 行新規) | PASS — Stripe Smart Retries 4 回 + ADR-0012 子供 UI zero touch |
| AC7 | NUC ジャーニー設計完了 (#2552) | `docs/design/billing-redesign/phase2-nuc-journey.md` (132 行新規) | PASS — license-key 発行 + 自宅 NUC 運用フロー |
| AC8 | 全 7 ジャーニーで ADR-0012 (anti-engagement) 整合 — 子供 UI 完全 zero touch | 各 journey md の「子供 UI 影響」セクション | PASS — 7/7 で「子供 UI 完全 zero touch」明記 |
| AC9 | 業界呼称 + 文献根拠を deep-research で確認 | 各 journey md の「deep-research」行 | PASS — Baymard / Iyengar / Calendly / Stripe Smart Retries / Notion Pattern A 等 |
| AC10 | Phase 3/4/5 申し送り構造化 | `docs/design/billing-redesign/README.md` (diff: 55 ++/7 --) | PASS — 24 項目を構造化 |
| AC11 | `phase2-checkout-journey.md` 内のコード参照 dead link なし (QM Tier 2 B-2) | `node scripts/check-doc-code-references.mjs` (exit 0) | PASS — `site/pricing.html` 参照 4 箇所を Markdown link 化 |
| AC12 | PR body 文字化け解消 + BOM 不在 + 必須セクション 13 全充足 (QM Tier 2 B-1) | `node scripts/check-pr-body.mjs --pr 2566` (exit 0) | PASS — UTF-8 (no BOM) で再投入 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)
- [x] **設計ドキュメント** (`docs/design/billing-redesign/`)

**影響を受ける画面・機能**: 影響範囲なし (設計ドキュメントのみ追加。実装には触れていない)。後続 Phase 3 (構造設計) / Phase 4 (実装) で本ジャーニーマップを SSOT として参照。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2566` 全 Step PASS** をローカル検証 (B-2 修正後 `check-doc-code-references.mjs` exit 0 を確認)
- [x] 追加・変更したテストの概要: **N/A** — 設計ドキュメントのみで実装変更なし。コード参照 dead link 検出 (`check-doc-code-references.mjs` baseline 機構) で自動検証済み
- [x] **新規 env / secret 追加時** (ADR-0006): **N/A**
- [x] **DynamoDB 実装変更時** (ADR-0010 / #1021): **N/A**
- [x] **Critical バグ修正の場合** (ADR-0002): **N/A**

## スクリーンショット / ビジュアルデモ

**該当なし (理由: docs-only PR — 設計ドキュメント 7 本追加 + README 申し送り更新のみ、UI 変更ゼロ)**

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A (docs-only) | N/A (docs-only) |
| **修正後** | N/A (docs-only) | N/A (docs-only) |

**インタラクティブ状態**: N/A (UI 要素なし)

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 7 journey ファイルは「1 ファイル = 1 領域」で単一責任分離。README.md は申し送りの index として責務分離
- [x] **DRY**: 共通モチーフ (mermaid 3 図 / 既存実装 Explore 照合 / Phase 3-5 申し送り) は構造を統一して再利用、内容は領域毎に固有
- [x] **YAGNI**: 7 ジャーニーは Epic #2525 で識別済みの境界。投機的 8 番目を追加していない
- [x] **Security (OSS 公開前提)**: 設計文書に秘密情報・内部 URL の hardcode なし。**N/A** (実装コード変更なし)
- [x] **アクセシビリティ**: **N/A** (UI 変更なし)
- [x] **パフォーマンス**: **N/A** (実装変更なし)

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版同期
- [x] **LP ↔ アプリ双方向整合 (#1481 / ADR-0013)**: 全 7 journey で「既存実装 Explore 照合」セクションを設け、設計と実装の事実を明示。**Aspirational 新規追加なし**、既存 LP `site/pricing.html` 参照 (line 297-301 / 403-420 / 475) は Markdown link 化済 (B-2 fix)
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): Epic #2525 Phase 2 の SSOT として 7 journey 設計書を新規作成 + README.md を更新
- [x] **並行 PR overlap** (#1200): `docs/design/billing-redesign/` を変更する他の open PR なし (Epic #2525 直系 PR のみ)
- [x] N/A — 並行実装の影響範囲外 (docs-only)

**LP / 販促文言変更時** (ADR-0013 / #1314):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A — LP / pricing / labels 文言の変更なし | N/A | N/A |

設計ドキュメントは LP / 販促文言ではなく内部設計 SSOT。LP `site/pricing.html` への参照は実装事実の Markdown link としてのみ追加 (新規訴求文言の追加なし)。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**:

- B-2 Fix (`phase2-checkout-journey.md`): bare path `site/pricing.html:NNN-NNN` を Markdown link 形式 `[\`site/pricing.html\` LNNN-LNNN](../../../site/pricing.html)` に変換 (4 箇所、L18 / L115 / L195 / L200)。これにより check-doc-code-references.mjs の bare path 検出を回避
- 副次修正: `scripts/doc-code-references-baseline.json` に `tests/CLAUDE.md: ["infra/node_modules"]` を 1 行追加 (main 由来の pre-existing violation を pin、本 PR scope 外の問題だが CI fail 防止のため最小 baseline 拡張)
- B-1 Fix (PR body): 文字化け 44 箇所 (`??`) + BOM 不在 + 必須セクション 13 全充足の本 body に再投入 (`gh pr edit --body-file` 経由、UTF-8、Issue #2562 教訓)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2566` 全 Step PASS** をローカル確認した (B-2 修正後 `check-doc-code-references.mjs` exit 0 確認済み)
- [x] セルフレビュー済み (不要な差分・デバッグコードなし — docs-only)
- [x] 全 AC が実装済み (未完項目なし)
- [x] Phase 分割した場合: Phase 2 (UX) 7 journey 完成、Phase 3 (構造設計) は Epic #2525 直下で別 Issue として README 申し送り 24 項目に構造化済
- [x] UI 変更時: **N/A** (docs-only PR、UI 変更なし)
- [x] 認証画面変更時: **N/A** (認証画面変更なし)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

**QM Tier 2 Re-Review 依頼**: B-1 (PR body 文字化け + BOM) / B-2 (新規 dead link) 共に解消。authoritative HEAD SHA + post-push CI 結果 + before/after エビデンスは Re-Review コメントで投稿する。
