### PR TITLE
infra: check-doc-code-references error message に修正手順例を追加 (#2577)

### DIFF
--- a/scripts/check-doc-code-references.mjs
+++ b/scripts/check-doc-code-references.mjs
@@ -415,8 +415,9 @@ function printNewViolationReport(newByFile) {
 	console.error(
 		'\n対応方針:\n' +
 			'  1. 実装側の現在のパスに参照を更新する (推奨)\n' +
+			'     (例: bare path 表記の代わりに Markdown link 形式 `[site/pricing.html L297-301](path/to/file)` に変換するとチェック対象外になります)\n' +
 			'  2. ドキュメント全体が陳腐化しているなら冒頭に `<!-- doc-status: deprecated -->` を追加\n' +
-			'  3. 意図的に違反を増やす場合は `node scripts/check-doc-code-references.mjs --update-baseline` で baseline 更新',
+			'  3. 意図的に新規参照を追加する場合のみ `node scripts/check-doc-code-references.mjs --update-baseline` を使って baseline を更新してください',
 	);
 }
 

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -220,7 +220,7 @@ function buildSteps(args, changedFiles) {
 	return [
 		{
 			name: 'biome',
-			label: 'Step /11: biome check (--error-on-warnings, CI と整合 — PR #2503 教訓)',
+			label: 'Step 1/11: biome check (--error-on-warnings, CI と整合 — PR #2503 教訓)',
 			skip: args.skipBiome,
 			// #2503 (Issue #2475 14 件目): pre-ready Step 1 は CI .github/workflows/ci.yml
 			// lint-and-test の `npx biome check --error-on-warnings .` と完全一致させる。
@@ -232,14 +232,14 @@ function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'svelte-check',
-			label: 'Step /11: svelte-check (TS strict)',
+			label: 'Step 2/11: svelte-check (TS strict)',
 			skip: args.skipSvelteCheck,
 			runner: () => run('svelte-check', ['npx', 'svelte-check', '--tsconfig', './tsconfig.json']),
 			fixHint: '  型エラー箇所を修正。`as any` / `// @ts-expect-error` の追加は禁止 (ADR-0006)。',
 		},
 		{
 			name: 'vitest',
-			label: 'Step /11: vitest run (unit test)',
+			label: 'Step 3/11: vitest run (unit test)',
 			skip: args.skipVitest,
 			runner: () => run('vitest', ['npx', 'vitest', 'run']),
 			fixHint:
@@ -248,7 +248,7 @@ function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'hardcoded-strings',
-			label: 'Step /11: check-hardcoded-strings.mjs (#1452 Phase A)',
+			label: 'Step 4/11: check-hardcoded-strings.mjs (#1452 Phase A)',
 			skip: args.skipHardcoded,
 			runner: () => run('check-hardcoded-strings', ['node', 'scripts/check-hardcoded-strings.mjs']),
 			fixHint:
@@ -257,7 +257,7 @@ function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'lp-dimensions',
-			label: `Step /11: measure-lp-dimensions.mjs (LP 変更検知: ${lpChanged ? 'YES' : 'NO — skip'})`,
+			label: `Step 5/11: measure-lp-dimensions.mjs (LP 変更検知: ${lpChanged ? 'YES' : 'NO — skip'})`,
 			skip: args.skipLpDimensions || !lpChanged,
 			runner: () => run('measure-lp-dimensions', ['node', 'scripts/measure-lp-dimensions.mjs']),
 			fixHint:
@@ -268,7 +268,7 @@ function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'lp-fallback',
-			label: `Step /11: sync-lp-fallback.mjs --check (LP / labels.ts 変更検知: ${lpFallbackTrigger ? 'YES' : 'NO — skip'})`,
+			label: `Step 6/11: sync-lp-fallback.mjs --check (LP / labels.ts 変更検知: ${lpFallbackTrigger ? 'YES' : 'NO — skip'})`,
 			skip: args.skipLpFallback || !lpFallbackTrigger,
 			runner: () => run('sync-lp-fallback', ['node', 'scripts/sync-lp-fallback.mjs', '--check']),
 			fixHint:
@@ -282,8 +282,8 @@ function buildSteps(args, changedFiles) {
 		{
 			name: 'plan-literals',
 			label: planLiteralsScriptExists
-				? 'Step /11: check-no-plan-literals.mjs (#972 / Phase 5 F1)'
-				: 'Step /11: check-no-plan-literals.mjs (script 未配備 — skip)',
+				? 'Step 7/11: check-no-plan-literals.mjs (#972 / Phase 5 F1)'
+				: 'Step 7/11: check-no-plan-literals.mjs (script 未配備 — skip)',
 			skip: args.skipPlanLiterals || !planLiteralsScriptExists,
 			runner: () => run('check-no-plan-literals', ['node', 'scripts/check-no-plan-literals.mjs']),
 			fixHint:
@@ -298,8 +298,8 @@ function buildSteps(args, changedFiles) {
 		{
 			name: 'lp-labels',
 			label: !lpLabelsScriptExists
-				? 'Step /11: generate-lp-labels --check (script 未配備 — skip)'
-				: `Step /11: generate-lp-labels --check (labels.ts / terms.ts / age-tier.ts 変更検知: ${lpLabelsTrigger ? 'YES' : 'NO — skip'})`,
+				? 'Step 8/11: generate-lp-labels --check (script 未配備 — skip)'
+				: `Step 8/11: generate-lp-labels --check (labels.ts / terms.ts / age-tier.ts 変更検知: ${lpLabelsTrigger ? 'YES' : 'NO — skip'})`,
 			skip: args.skipLpLabels || !lpLabelsScriptExists || !lpLabelsTrigger,
 			runner: () =>
 				run('generate-lp-labels --check', ['node', 'scripts/generate-lp-labels.mjs', '--check']),
@@ -323,7 +323,8 @@ function buildSteps(args, changedFiles) {
 			name: 'doc-code-references',
 			label: 'Step 10/11: check-doc-code-references.mjs (#2577)',
 			skip: args.skipDocCodeReferences,
-			runner: () => run('check-doc-code-references', ['node', 'scripts/check-doc-code-references.mjs']),
+			runner: () =>
+				run('check-doc-code-references', ['node', 'scripts/check-doc-code-references.mjs']),
 			fixHint:
 				'  ドキュメント内の実装コードパスが実在しません (デッドリンク)。\n' +
 				'  修正: bare path 表記を Markdown link 形式 `[site/pricing.html L297-301](path/to/file)` に変更するか、\n' +

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -58,6 +58,7 @@ const SKIP_FLAGS = {
 	'--skip-plan-literals': 'skipPlanLiterals',
 	'--skip-lp-labels': 'skipLpLabels',
 	'--skip-pr-body': 'skipPrBody',
+	'--skip-doc-code-references': 'skipDocCodeReferences',
 	'--skip-capture': 'skipCapture',
 };
 
@@ -73,6 +74,7 @@ function parseArgs(argv) {
 		skipPlanLiterals: false,
 		skipLpLabels: false,
 		skipPrBody: false,
+		skipDocCodeReferences: false,
 		skipCapture: false,
 		help: false,
 	};
@@ -97,7 +99,7 @@ pre-ready — Ready for Review 前のローカル一括セルフチェック (Is
 
 Usage:
   npm run pre-ready -- --pr <number>
-  npm run pre-ready                                # PR 未作成時 (Step 9/10 はスキップ)
+  npm run pre-ready                                # PR 未作成時 (Step 9/11 はスキップ)
 
 Options:
   --pr <num>             GitHub PR 番号 (Step 9 PR body / mergeable 検証用)
@@ -110,7 +112,8 @@ Options:
   --skip-plan-literals   Step 7 plan/status リテラル直書き検査をスキップ (#972 / Phase 5 F1)
   --skip-lp-labels       Step 8 LP labels 同期検査をスキップ (labels.ts / terms.ts / age-tier.ts 変更時のみ自動実行、Phase 1 B1)
   --skip-pr-body         Step 9 PR body 検査をスキップ
-  --skip-capture         Step 10 capture (UI 変更時のみ) をスキップ
+  --skip-doc-code-references Step 10 デッドリンク検査をスキップ
+  --skip-capture         Step 11 capture (UI 変更時のみ) をスキップ
   --help, -h             このヘルプ
 
 Steps:
@@ -123,7 +126,8 @@ Steps:
   7.  check-no-plan-literals.mjs  — プラン / ステータスリテラル直書き検査 (#972 / Phase 5 F1 / #1918)
   8.  generate-lp-labels --check  — site/shared-labels.js 同期検査 (labels.ts / terms.ts / age-tier.ts 変更時のみ、Phase 1 B1 / #1917)
   9.  check-pr-body.mjs           — PR body 必須セクション / 禁止語 / AC マップ / mergeable (PR 番号必須)
-  10. capture.mjs --pr            — UI 変更検知時のみ撮影 (現状は手動推奨。本 step は実行ガイダンスのみ)
+  10. check-doc-code-references.mjs — ドキュメントのデッドリンク検知 (#2577)
+  11. capture.mjs --pr            — UI 変更検知時のみ撮影 (現状は手動推奨。本 step は実行ガイダンスのみ)
 
 Exit codes:
   0 = 全 Step PASS
@@ -216,7 +220,7 @@ function buildSteps(args, changedFiles) {
 	return [
 		{
 			name: 'biome',
-			label: 'Step 1/10: biome check (--error-on-warnings, CI と整合 — PR #2503 教訓)',
+			label: 'Step /11: biome check (--error-on-warnings, CI と整合 — PR #2503 教訓)',
 			skip: args.skipBiome,
 			// #2503 (Issue #2475 14 件目): pre-ready Step 1 は CI .github/workflows/ci.yml
 			// lint-and-test の `npx biome check --error-on-warnings .` と完全一致させる。
@@ -228,14 +232,14 @@ function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'svelte-check',
-			label: 'Step 2/10: svelte-check (TS strict)',
+			label: 'Step /11: svelte-check (TS strict)',
 			skip: args.skipSvelteCheck,
 			runner: () => run('svelte-check', ['npx', 'svelte-check', '--tsconfig', './tsconfig.json']),
 			fixHint: '  型エラー箇所を修正。`as any` / `// @ts-expect-error` の追加は禁止 (ADR-0006)。',
 		},
 		{
 			name: 'vitest',
-			label: 'Step 3/10: vitest run (unit test)',
+			label: 'Step /11: vitest run (unit test)',
 			skip: args.skipVitest,
 			runner: () => run('vitest', ['npx', 'vitest', 'run']),
 			fixHint:
@@ -244,7 +248,7 @@ function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'hardcoded-strings',
-			label: 'Step 4/10: check-hardcoded-strings.mjs (#1452 Phase A)',
+			label: 'Step /11: check-hardcoded-strings.mjs (#1452 Phase A)',
 			skip: args.skipHardcoded,
 			runner: () => run('check-hardcoded-strings', ['node', 'scripts/check-hardcoded-strings.mjs']),
 			fixHint:
@@ -253,7 +257,7 @@ function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'lp-dimensions',
-			label: `Step 5/10: measure-lp-dimensions.mjs (LP 変更検知: ${lpChanged ? 'YES' : 'NO — skip'})`,
+			label: `Step /11: measure-lp-dimensions.mjs (LP 変更検知: ${lpChanged ? 'YES' : 'NO — skip'})`,
 			skip: args.skipLpDimensions || !lpChanged,
 			runner: () => run('measure-lp-dimensions', ['node', 'scripts/measure-lp-dimensions.mjs']),
 			fixHint:
@@ -264,7 +268,7 @@ function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'lp-fallback',
-			label: `Step 6/10: sync-lp-fallback.mjs --check (LP / labels.ts 変更検知: ${lpFallbackTrigger ? 'YES' : 'NO — skip'})`,
+			label: `Step /11: sync-lp-fallback.mjs --check (LP / labels.ts 変更検知: ${lpFallbackTrigger ? 'YES' : 'NO — skip'})`,
 			skip: args.skipLpFallback || !lpFallbackTrigger,
 			runner: () => run('sync-lp-fallback', ['node', 'scripts/sync-lp-fallback.mjs', '--check']),
 			fixHint:
@@ -278,8 +282,8 @@ function buildSteps(args, changedFiles) {
 		{
 			name: 'plan-literals',
 			label: planLiteralsScriptExists
-				? 'Step 7/10: check-no-plan-literals.mjs (#972 / Phase 5 F1)'
-				: 'Step 7/10: check-no-plan-literals.mjs (script 未配備 — skip)',
+				? 'Step /11: check-no-plan-literals.mjs (#972 / Phase 5 F1)'
+				: 'Step /11: check-no-plan-literals.mjs (script 未配備 — skip)',
 			skip: args.skipPlanLiterals || !planLiteralsScriptExists,
 			runner: () => run('check-no-plan-literals', ['node', 'scripts/check-no-plan-literals.mjs']),
 			fixHint:
@@ -294,8 +298,8 @@ function buildSteps(args, changedFiles) {
 		{
 			name: 'lp-labels',
 			label: !lpLabelsScriptExists
-				? 'Step 8/10: generate-lp-labels --check (script 未配備 — skip)'
-				: `Step 8/10: generate-lp-labels --check (labels.ts / terms.ts / age-tier.ts 変更検知: ${lpLabelsTrigger ? 'YES' : 'NO — skip'})`,
+				? 'Step /11: generate-lp-labels --check (script 未配備 — skip)'
+				: `Step /11: generate-lp-labels --check (labels.ts / terms.ts / age-tier.ts 変更検知: ${lpLabelsTrigger ? 'YES' : 'NO — skip'})`,
 			skip: args.skipLpLabels || !lpLabelsScriptExists || !lpLabelsTrigger,
 			runner: () =>
 				run('generate-lp-labels --check', ['node', 'scripts/generate-lp-labels.mjs', '--check']),
@@ -307,8 +311,8 @@ function buildSteps(args, changedFiles) {
 		{
 			name: 'pr-body',
 			label: args.pr
-				? `Step 9/10: check-pr-body.mjs --pr ${args.pr}`
-				: 'Step 9/10: check-pr-body.mjs (--pr 未指定 — skip)',
+				? `Step 9/11: check-pr-body.mjs --pr ${args.pr}`
+				: 'Step 9/11: check-pr-body.mjs (--pr 未指定 — skip)',
 			skip: args.skipPrBody || !args.pr,
 			runner: () => run('check-pr-body', ['node', 'scripts/check-pr-body.mjs', '--pr', args.pr]),
 			fixHint:
@@ -316,8 +320,18 @@ function buildSteps(args, changedFiles) {
 				'  詳細は scripts/check-pr-body.mjs --help を参照。',
 		},
 		{
+			name: 'doc-code-references',
+			label: 'Step 10/11: check-doc-code-references.mjs (#2577)',
+			skip: args.skipDocCodeReferences,
+			runner: () => run('check-doc-code-references', ['node', 'scripts/check-doc-code-references.mjs']),
+			fixHint:
+				'  ドキュメント内の実装コードパスが実在しません (デッドリンク)。\n' +
+				'  修正: bare path 表記を Markdown link 形式 `[site/pricing.html L297-301](path/to/file)` に変更するか、\n' +
+				'        意図的な追加なら `node scripts/check-doc-code-references.mjs --update-baseline` を実行してください。',
+		},
+		{
 			name: 'capture',
-			label: `Step 10/10: capture.mjs (UI 変更検知: ${uiChanged ? 'YES' : 'NO — skip'})`,
+			label: `Step 11/11: capture.mjs (UI 変更検知: ${uiChanged ? 'YES' : 'NO — skip'})`,
 			skip: args.skipCapture || !uiChanged || !args.pr,
 			runner: async () => {
 				console.log(


### PR DESCRIPTION
## 顧客価値・目的

`check-doc-code-references.mjs` がデッドリンクを検出した際の error message に **具体的な修正手順** を追加し、Dev が手探りで対処する時間を削減する。PR #2566 で発生した B-2 BLOCK (bare path 表記 → Markdown link 形式への移行) で Dev が「`--update-baseline` をすぐ実行すべきか / 修正すべきか」を判断できなかった UX 問題への構造的対応。

加えて `scripts/pre-ready.mjs` Step 10 として `check-doc-code-references` を統合し、`npm run pre-ready` 一括実行時に Dev が手動で個別に実行する手間を解消する。

## 関連 Issue

- closes #2577
- refs #2566 (発見事例、bare path → Markdown link 形式置換)

## AC 検証マップ (ADR-0004)

| AC | 内容 | 実装 file:line | 検証方法 |
|---|---|---|---|
| AC-1 | error message に Markdown link 形式の具体例を表示 | `scripts/check-doc-code-references.mjs` L418 (例: `[site/pricing.html L297-301](path/to/file)` を出力に含む) | `node scripts/check-doc-code-references.mjs` 違反時の console.error 出力を目視確認 |
| AC-2 | `--update-baseline` の判断基準を明示 (「意図的に新規参照を追加する場合のみ」) | `scripts/check-doc-code-references.mjs` L420 | 同上 |
| AC-3 | `npm run pre-ready` の Step 10 として統合 + エラー時に対応方針 hint 表示 | `scripts/pre-ready.mjs` L322-332 (新規 step `doc-code-references` 追加、`fixHint` で修正方針 console 出力) | `npm run pre-ready -- --pr 2580` 実行で Step 10 が走り、fail 時に hint が表示されることを目視 |

## 変更タイプ

- [x] type:infra (scripts/ 配下の error message + step 統合のみ)
- [ ] type:feat / type:fix / type:refactor / type:design / type:docs / type:marketing / type:test

## 影響範囲・変更コンポーネント

- `scripts/check-doc-code-references.mjs` — error message 文言追加 (3 行差分)
- `scripts/pre-ready.mjs` — Step 10 `doc-code-references` 追加 + Step 11 リナンバリング (capture)

UI / API / DB / LP / 認可 への影響なし。CLI tool の出力文言追加のみ。

## テスト & 安全装置セルフチェック

- [x] **biome check** PASS — `npx biome check --error-on-warnings scripts/check-doc-code-references.mjs scripts/pre-ready.mjs` で 0 error 0 warning (QM Re-Review 修正で format 違反 1 件解消)
- [x] **svelte-check** N/A — script 修正、Svelte UI 影響ゼロ
- [x] **vitest** N/A — script 修正、unit test 影響ゼロ (`scripts/` 配下の本変更は既存 vitest snapshot 影響なし)
- [x] **pre-ready Step 9 / 10**: 本 PR で Step 10 を追加。`check-doc-code-references.mjs` 単独実行は PASS (`baseline 内 77 件、44 ファイル。新規違反なし` 出力)
- [ ] e2e N/A — UI 変更なし

## スクリーンショット / ビジュアルデモ

N/A — script PR (UI 変更ゼロ)。`scripts/check-doc-code-references.mjs` の error message 変更は CLI console 出力のみで視覚的レイアウト変更を伴わない。

## コード品質セルフレビュー (#1481)

- biome format: PASS (auto-fix 適用、`runner: () =>` 改行スタイル準拠)
- import 整理: 追加 import なし、既存 import 順序維持
- 命名: `skipDocCodeReferences` skip flag は既存 9 個の `skip<StepName>` 命名規則に整合
- 13 13 セクション SSOT 整合: `.github/PR_TEMPLATE_SECTIONS.json` の 13 セクション全て本 PR body に存在

## 横展開・影響波及チェック

- 他 caller への影響: `npm run pre-ready` の caller (CLI 直接実行のみ) に互換性破壊なし — argv interface 変更なし、Step 10 追加は既存 Step 1-9 を変更しない
- 並行実装ペア: 該当なし (本 PR は script tool 文言変更、parallel-implementations.md 表に該当 file なし)
- 機能完成度 checklist 9 層: 該当なし (内部 infra script)

## レビュー依頼事項・破壊的変更

- 破壊的変更: なし (error message 表示文言追加 + step 統合のみ、CLI argv interface 不変)
- レビュー依頼: B-2 教訓に基づき **diff 目視レビュー** をお願いします (commit b63389c0 の Step 1-8 ラベル復元 12 件が正しく Step 1/11 ... Step 8/11 になっていることを確認)

## 配布済み env / secret (ADR-0006)

新規 env / secret 追加なし。`assert*Configured()` / `throw new Error('XXX is required')` パターン追加もなし (`scripts/check-new-required-env.mjs` 検出対象外)。

## Ready for Review チェックリスト

- [x] biome check PASS (`npx biome check --error-on-warnings scripts/check-doc-code-references.mjs scripts/pre-ready.mjs`)
- [x] svelte-check N/A (script PR)
- [x] vitest N/A (script PR、unit test 影響なし)
- [x] Step 9 PR body check honest 自己実行 (`node scripts/check-pr-body.mjs --pr 2580` 実行で PASS 確認済み)
- [x] Step 10 doc-code-references honest 自己実行 (`node scripts/check-doc-code-references.mjs` PASS 出力確認済み)
- [x] QA 承認・動作確認 — Dev 側からは N/A (QM Re-Review 担当者が approve 時点で確定。Dev 側で `[x]` できる項目は全完了)

## QM レビュー結果

QM Re-Review 待ち。

前回 QM Tier 2 Review (ad63eb247496c8475) 指摘 BLOCK 6 件全解消:

- **B-1 scope creep 除去**: `verify-backup-restore.cjs` (#2542) / 同 test を本 PR から完全除去。main から branch を作り直し、commit 81477479 (#2577 本来 commit) のみ cherry-pick。`git diff origin/main HEAD --stat` で 2 file のみ (`scripts/check-doc-code-references.mjs` + `scripts/pre-ready.mjs`) 残存を verify
- **B-2 Step 1-8 ラベル機械破壊復元**: 旧 commit 81477479 の `/10` → `/11` regex 一括置換事故により Step 1-8 が `Step /11` (番号欠落) に破壊されていたものを、`Step 1/11` ... `Step 8/11` と正しい番号に復元 (12 件)。#2225 の「機械生成ツール一括適用後は diff 全件目視レビュー」教訓を本 PR でも適用
- **B-3 PR body 必須セクション 13 件**: 本 PR body 全 13 セクション (`.github/PR_TEMPLATE_SECTIONS.json` SSOT) を埋め、`check-pr-body.mjs` 0 error を満たす
- **B-4 完了チェックリスト**: Dev 側自己項目 5 件 [x]、QA 承認・動作確認 1 件 [ ] (QM Re-Review で確定)
- **B-5 biome PASS**: `runner: () =>` 改行 format 違反 1 件を biome auto-fix で解消
- **B-6 AC map honest 化**: 「全 AC PASS」「pre-ready 確認済」claim を実 CI 結果に整合させ、Step 10 doc-code-references の baseline 内 77 件確認等の具体的実体根拠を AC 検証マップに記載
