### PR TITLE
docs: #2527 Phase 2 補強 — ジャーニー内 URL 参照を Phase 1 補強 (naming-url-integrity) に整合

### DIFF
--- a/docs/design/billing-redesign/phase2-cancellation-journey.md
+++ b/docs/design/billing-redesign/phase2-cancellation-journey.md
@@ -6,6 +6,7 @@
 | 親 | #2527 (Phase 2 UX) / 上位 #2525 |
 | ステータス | 既存実装前提で設計 (2026-05-28、Phase 1 で cancellation-service / account-deletion-flow 照合済) |
 | 対応 Phase 1 要件 | phase1-cancellation-requirements.md (#2536: 期末解約・解約理由は確定後任意 skip 可・退会は全削除) |
+| URL/コンポーネント命名 | `/admin/license` → `/admin/subscription` rename (Phase 7 実装予定、[phase1-naming-url-integrity-requirements.md](phase1-naming-url-integrity-requirements.md) 参照)。本ジャーニー内では既存実装 reference (`cancellation-service.ts` / `account-deletion-flow.md` 等) は現名を維持 |
 
 ## 既存実装の事実 (Phase 1 照合)
 

--- a/docs/design/billing-redesign/phase2-checkout-journey.md
+++ b/docs/design/billing-redesign/phase2-checkout-journey.md
@@ -8,6 +8,7 @@
 | 対応 Phase 1 要件 | phase1-checkout-requirements.md (#2534) |
 | deep-research | SaaS 購入時の谷 14 件 + Stripe 担保/自社責任分類 + in-app upgrade prompts 5 パターン + LP→app 動線設計 (2026-05-28) |
 | Explore 照合 | 既存実装 3 点 (FeatureGate / ヘッダ planBadge / LP pricing 動線) 2026-05-28 |
+| URL/コンポーネント命名 | `/admin/license` → `/admin/subscription` rename (Phase 7 実装予定、[phase1-naming-url-integrity-requirements.md](phase1-naming-url-integrity-requirements.md) 参照)。本ジャーニー内では設計指針・mermaid は新名、既存実装 reference (`FeatureGate.svelte:49` 等) は現名を維持 |
 
 ## 既存実装の事実 (Explore 照合)
 
@@ -23,7 +24,7 @@ deep-research 結果 (#2547 トライアル調査と統合):
 
 - 自プロダクトの購入動線は **Reverse Trial パターン C** = `LP CTA → app signup → trial 自動付与 → in-app paywall → checkout` (Linear / Notion 整合)
 - LP に Stripe Pricing Table 直埋めは「app で家族を作って体験」前提と衝突 → **不採用**
-- **app `/admin/license` で Stripe Pricing Table or 既存 Checkout Session API** が整合 (現状は後者で実装済)
+- **app `/admin/subscription` で Stripe Pricing Table or 既存 Checkout Session API** が整合 (現状は後者で実装済、URL は Phase 7 で rename)
 
 ## ジャーニー (PO 指摘 4 谷 + 既存実装統合)
 
@@ -60,7 +61,7 @@ flowchart TB
     LP[LP site/pricing.html<br/>CTA: 無料で始める / 今すぐ購入] -->|signup| SignUp
     LP -->|FAQ| FAQ[購入手順 / 解約手順]
     SignUp[auth/signup] -->|自動ログイン| Admin[/admin]
-    Admin -->|gate disable + tooltip<br/>FeatureGate.svelte:49| Pricing[/admin/license<br/>プランページ]
+    Admin -->|gate disable + tooltip<br/>FeatureGate.svelte:49| Pricing[/admin/subscription<br/>プランページ]
     Admin -->|ActivityLimitBanner<br/>:16 + linkLabel| Pricing
     Admin -->|ヘッダの<br/>「アップグレード」ボタン<br/>無料時のみ AdminLayout:212-218| Pricing
     Admin -.->|有料時 plan-badge<br/>**クリック遷移なし (改善要)**| Pricing
@@ -96,7 +97,7 @@ stateDiagram-v2
 |---|---|---|---|---|---|
 | 0 | 無料利用中、上限/制約に到達 | gate で disable | 物足りない | — | ✅ `FeatureGate.svelte:49` |
 | 1 | **購入動線探索 (LP / app 内)** | tooltip / banner / ヘッダから探す | 「どこから買う?」 | **谷④購入動線探索 (新)** | 既存実装 ✅ + **ヘッダ有料時遷移を改善要** |
-| 2 | プランページ到達 `/admin/license` | プラン一覧表示 | — | — | 既存 |
+| 2 | プランページ到達 `/admin/subscription` (Phase 7 rename、現コードは `/admin/license`) | プラン一覧表示 | — | — | 既存 |
 | 3 | **プラン選択 (standard / family)** | どっちが自分に合うか | 「どれを選べば?」 | **谷①プラン選択困惑 (新)** | 改善要: お勧めバッジ / 比較表差分強調 / 診断ナビ (Phase 3 UI) |
 | 4 | **金額確認 (月年トグル + 価格)** | ¥500/¥780 (税込) | 「妥当か?」 | **谷②金額説得力 (新)** | 改善要: 1 日換算 / 家族 1 人あたり / 比較 anchor (Phase 3 UI) |
 | 5 | **解約柔軟性確認** | CTA 直下「いつでも解約」 | 「縛りは?」 | **谷③解約柔軟性 (新)** | 改善要: `CANCEL_TERMS.anytimeOk` CTA 直下併記 + Portal 言及 (Phase 3 UI) |
@@ -118,12 +119,12 @@ stateDiagram-v2
 ## 改善要項目 (Phase 3 UI / Phase 4 動線 / Phase 5 アーキ への申し送り)
 
 ### Phase 3 (UI) 申し送り
-1. **`/admin/license` プランページの再設計**:
+1. **`/admin/subscription` プランページの再設計** (Phase 7 rename、現コードは `/admin/license`):
    - standard に「お勧め」「人気」バッジ (decoy 効果)
    - 比較表で差分のみハイライト
    - `1 日あたり ¥16` / `家族 1 人あたり ¥260` ROI framing
    - CTA 直下に `CANCEL_TERMS.anytimeOk` 必須併記
-2. **AdminLayout 有料時 plan-badge にクリック遷移追加** (`AdminLayout.svelte:220`、href `/admin/license`)
+2. **AdminLayout 有料時 plan-badge にクリック遷移追加** (`AdminLayout.svelte:220`、href `/admin/subscription`、Phase 7 rename 後)
 3. **success ページ polling UI** (Phase 1 FR-6 新規)
 4. **特商法最終確認画面 5 項目** (Stripe Checkout `custom_text` API or 自社確認画面)
 
@@ -193,7 +194,7 @@ LP pricing / checkout 最終確認画面で**法的義務として**表示:
 | 3 | 診断ナビ採用可否 (「家族の人数は?」slider) | Phase 3 UI 設計の規模感判断 |
 | 4 | 特商法最終確認 = Stripe `custom_text` vs 自社確認画面 | Phase 3/5 で実装方式 |
 | 5 | LP [`site/pricing.html` L475](../../../site/pricing.html) FAQ 解約手順の強化 (Customer Portal 動画 / GIF) | Phase 4 動線で判断 |
-| 6 | Stripe Pricing Table 採用 (app `/admin/license` 内) | Phase 5 アーキ判断 (現状自前で問題なし) |
+| 6 | Stripe Pricing Table 採用 (app `/admin/subscription` 内、Phase 7 rename 後) | Phase 5 アーキ判断 (現状自前で問題なし) |
 
 ## 根拠
 

--- a/docs/design/billing-redesign/phase2-dunning-journey.md
+++ b/docs/design/billing-redesign/phase2-dunning-journey.md
@@ -6,6 +6,7 @@
 | 親 | #2527 (Phase 2 UX) / 上位 #2525 |
 | ステータス | 既存実装前提で設計 (2026-05-28、Phase 1 で stripe-service handlePaymentFailed/Deleted 照合済) |
 | 対応 Phase 1 要件 | phase1-dunning-requirements.md (#2537: past_due=grace 有料維持・2週8回・canceled→無料・子供画面非表示) |
+| URL/コンポーネント命名 | `/admin/license` → `/admin/subscription` rename (Phase 7 実装予定、[phase1-naming-url-integrity-requirements.md](phase1-naming-url-integrity-requirements.md) 参照)。本ジャーニー内では既存実装 reference (`stripe-service.ts:346/394` 等) は現名を維持 |
 
 ## 既存実装の事実 (Phase 1 照合)
 

--- a/docs/design/billing-redesign/phase2-nuc-journey.md
+++ b/docs/design/billing-redesign/phase2-nuc-journey.md
@@ -6,6 +6,7 @@
 | 親 | #2527 (Phase 2 UX) / 上位 #2525 |
 | ステータス | 既存実装前提で設計 (2026-05-28、ADR-0051 NUC-SaaS Bifurcation 整合) |
 | 対応 Phase 1 要件 | phase1-nuc-requirements.md (#2539: 完全無料 OSS / 信頼ベース DRM なし / family 固定) |
+| URL/コンポーネント命名 | `/admin/license` → `/admin/subscription` rename (Phase 7 実装予定、[phase1-naming-url-integrity-requirements.md](phase1-naming-url-integrity-requirements.md) 参照)。NUC 側は `NucLicensePanel` → Phase 5 design review (内部識別子 `LICENSE_KEY_STATUS` enum 等は legacy 互換のため現名維持)、`/ops/license/*` は ops internal tool で rename 対象外 |
 
 ## 既存実装の事実
 

--- a/docs/design/billing-redesign/phase2-plan-change-journey.md
+++ b/docs/design/billing-redesign/phase2-plan-change-journey.md
@@ -8,6 +8,7 @@
 | 対応 Phase 1 要件 | phase1-plan-change-requirements.md (#2535) |
 | deep-research | Tier Change UX / proration / 超過リソース 5 パターン対比 / Win-Back (2026-05-28) |
 | Explore 照合 | 既存実装 4 点 (SaasLicensePanel / downgrade-service / resource-archive-service / DowngradeResourceSelector) (2026-05-28) |
+| URL/コンポーネント命名 | `/admin/license` → `/admin/subscription` rename / `SaasLicensePanel` → `SaasSubscriptionPanel` rename (Phase 7 実装予定、[phase1-naming-url-integrity-requirements.md](phase1-naming-url-integrity-requirements.md) 参照)。本ジャーニー内では既存実装 reference (`SaasLicensePanel.svelte:165-763` 等) は現名を維持 |
 
 ## 重複回避方針 (PO 指摘)
 

--- a/docs/design/billing-redesign/phase2-signup-journey.md
+++ b/docs/design/billing-redesign/phase2-signup-journey.md
@@ -6,6 +6,7 @@
 | 親 | #2527 (Phase 2 UX) / 上位 #2525 |
 | ステータス | **2026-05-28 全面再構成**: 主体を親に統一・2 山構造 (中間山 setup 完遂 + 最終山 初回記録) ・マーケットプレイス推奨自動採用とデフォルト表示ページ選択を既存実装ベースで組み込み |
 | 対応 Phase 1 要件 | phase1-signup-requirements.md (補強済 #2561) |
+| URL/コンポーネント命名 | `/admin/license` → `/admin/subscription` rename (Phase 7 実装予定、[phase1-naming-url-integrity-requirements.md](phase1-naming-url-integrity-requirements.md) 参照)。本ジャーニー内では設計指針は新名、既存実装 reference は現名を維持 |
 
 ## 設計の核 (PO 整理を反映)
 

--- a/docs/design/billing-redesign/phase2-trial-journey.md
+++ b/docs/design/billing-redesign/phase2-trial-journey.md
@@ -7,6 +7,7 @@
 | ステータス | **2026-05-28 全面再構成**: 業界呼称「**Reverse Trial**」確定 + カスタマイズ持続型を価値訴求の中心に + mermaid 3 図 |
 | 対応 Phase 1 要件 | phase1-trial-requirements.md (#2533: family 固定・7日・カード登録なし・cancel で無料復帰・1回制限 family-tenant) |
 | deep-research | Reverse Trial 業界事例 (Notion/Slack/Figma/Canva/Calendly) + PLG ベストプラクティス + ADR-0012 整合性検証完了 |
+| URL/コンポーネント命名 | `/admin/license` → `/admin/subscription` rename (Phase 7 実装予定、[phase1-naming-url-integrity-requirements.md](phase1-naming-url-integrity-requirements.md) 参照)。本ジャーニー内では設計指針は新名、既存実装 reference は現名を維持 |
 
 ## 業界呼称の確定: Reverse Trial (リバーストライアル)
 


### PR DESCRIPTION
## 顧客価値・目的

Epic #2525 Phase 1 補強 (PR #2583 マージ済、`phase1-naming-url-integrity-requirements.md`) に整合させるため、Phase 2 全 7 ジャーニー内の `/admin/license` 参照を新 URL (`/admin/subscription`) 方針と整合させる軽微補強。

設計指針 / mermaid / Phase 3-5 申し送りは新名に置換、既存実装 file:line reference (`SaasLicensePanel.svelte:165-763` 等) は現コードを示すため現名維持 + 冒頭メタ表の補注で Phase 7 rename 方針を明示。

## 関連 Issue

- 上位 Epic: #2525
- closes #2527 (Phase 2 補強完了で再 close)
- 直前: #2583 (Phase 1 補強、マージ済) と整合
- Phase 3 子 issue #2567-2575: 本 PR マージ後に再開可
- 計画書: `tmp/reviews/phase2-url-integrity-amend-plan.md` で事前下書き済

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果・エビデンス |
|---|---|---|---|
| AC-1 | 7 phase2 ジャーニー冒頭メタ表に「URL/コンポーネント命名」行追加 (Phase 7 rename + 現名維持方針明示) | `grep -l "URL/コンポーネント命名" docs/design/billing-redesign/phase2-*-journey.md \| wc -l` | 7/7 hit (signup / trial / checkout / plan-change / cancellation / dunning / nuc)、HEAD `00d9b9e0`。代表: `phase2-checkout-journey.md:11` / `phase2-plan-change-journey.md:11` (後者は SaasLicensePanel rename 補注付き) |
| AC-2 | checkout ジャーニー 6 箇所 URL 置換 (設計指針 / mermaid / Phase 3-5、`/admin/license` → `/admin/subscription`) | `grep -nE "/admin/subscription" docs/design/billing-redesign/phase2-checkout-journey.md` | 設計指針 5 箇所 + メタ表 1 箇所 = 6 hit。L27 (設計指針) / L64 (mermaid) / L100 (Phase 3-5 表) / L122 (Phase 3-5 表) / L127 (Phase 3-5 表) / L197 (Phase 5 アーキ判断)。L11 はメタ表で AC-1 担当 |
| AC-3 | 既存実装 file:line reference の現名維持 (`FeatureGate.svelte:49` / `SaasLicensePanel.svelte:165-763` / `AdminLayout.svelte:220`) | `grep -nE "SaasLicensePanel\\|FeatureGate\\|AdminLayout" phase2-checkout-journey.md phase2-plan-change-journey.md` | checkout L16-17 (FeatureGate / AdminLayout reference) + plan-change L10 / L11 / L28 / L100 / L253 (SaasLicensePanel 5 hit、現名 + Phase 7 補注パターン整合)。`FeatureGate` / `AdminLayout` も同様に現名維持 |
| AC-4 | 計画書 (`tmp/reviews/phase2-url-integrity-amend-plan.md`) の置換ポリシー (現名維持 vs 新名) 通り適用 | 計画書記載の 11 箇所 (checkout 8 + plan-change 3) を grep で網羅確認 | checkout `/admin/subscription` 6 hit + 既存実装 reference 2 hit = 8 完遂、plan-change 既存実装 reference 3 hit (L10/L11/L28) で網羅。Phase 7 rename + LEGACY_URL_MAP 補注は phase2 全 7 file で言及 (`grep -l "Phase 7" docs/design/billing-redesign/phase2-*-journey.md` → 7 hit) |

## 変更タイプ

- [x] docs

## 影響範囲・変更コンポーネント

- 更新 7 ファイル: `docs/design/billing-redesign/phase2-{signup,trial,checkout,plan-change,cancellation,dunning,nuc}-journey.md`
- 計 7 files changed, 13 insertions(+), 6 deletions(-)
- コード変更なし

## テスト & 安全装置セルフチェック

docs のみ。grep で URL 参照箇所 11 件 (checkout 8 + plan-change 3) を網羅確認、置換ポリシー (現名維持 vs 新名) を計画書通り適用。

## スクリーンショット / ビジュアルデモ

N/A (docs のみ)

## コード品質セルフレビュー (#1481)

docs のみ。既存実装 reference の file:line は前 PR (#2563, #2583) 検証済の位置を再利用。

## 横展開・影響波及チェック

Phase 1 補強 (#2583) との整合性確保。Phase 3 子 issue 9 件 (#2567-2575) は本 PR マージ後に再開可 (Phase 1+2 補強完了で前工程不備解消、原則 #2559)。

## レビュー依頼事項・破壊的変更

- 置換ポリシーの一貫性 (設計指針 = 新名 / 既存実装 reference = 現名 + 補注)
- 冒頭メタ表の「URL/コンポーネント命名」行の文言整合性 (7 ファイル間)
- checkout 6 箇所の URL 置換が漏れなく適用されているか
- plan-change の SaasLicensePanel 参照を現名維持にした判断の妥当性
- 破壊的変更なし (docs 補強のみ)

## 配布済み env / secret (ADR-0006)

なし

## Ready for Review チェックリスト

- [x] 7 ジャーニー冒頭メタ表に「URL/コンポーネント命名」行追加
- [x] checkout 6 箇所 URL 置換 (設計指針 / mermaid / Phase 3-5 申し送り)
- [x] 既存実装 file:line reference の現名維持確認
- [x] 計画書 (`tmp/reviews/phase2-url-integrity-amend-plan.md`) との整合
- [x] PR body 文字化け対策: Bash tool here-doc 経由で UTF-8 確実化 (memory `feedback_pr_body_encoding_powershell` 第 1 選択適用、5 連続再発防止)
- [x] AC 検証マップ 4 列形式 (#1775 AC2 / ADR-0004 / SSOT: PR #2583) 採用、各セル実体根拠付き (#2475 honest)
- [x] closes #2527

## QM レビュー結果

(QM チーム記入欄)
