### PR TITLE
docs(billing-redesign): #2683 Phase 5/6 補強 — 2 Product 構成 (代替案 D) + API ver 訂正 + Webhook immutable 副次制約 4

### DIFF
--- a/docs/decisions/0059-phase7-cutover-sequence.md
+++ b/docs/decisions/0059-phase7-cutover-sequence.md
@@ -1,16 +1,22 @@
-# 0059. Phase 7 統合 PR cutover シーケンスと kill switch 戦略 (Stripe 公式 5 phase + env var 2 件、LaunchDarkly / Unleash 不採用)
+# 0059. Phase 7 統合 PR cutover シーケンスと kill switch 戦略 (Stripe 公式 5 phase + env var 2 件、LaunchDarkly / Unleash 不採用、#2683 補強で 2 Product 構成 + 副次制約 4 連動)
 
 | 項目 | 内容 |
 |------|------|
 | ステータス | accepted |
-| 日付 | 2026-05-30 |
+| 日付 | 2026-05-30 (#2683 補強で同日更新) |
 | 起票者 | Claude (補佐、PO 判断適用) |
-| 関連 Issue | #2665 (Phase 6 子 5) / #2525 (Epic) / #2531 (Phase 7 実装) / #2627 (Stripe Dashboard PO 操作) / #2667 (Phase 6 子 1) |
-| 関連 docs SSOT | [phase6-rollback-and-kill-switches.md](../design/billing-redesign/phase6-rollback-and-kill-switches.md) (本 ADR の元) / [phase6-phase7-execution-ssot.md](../design/billing-redesign/phase6-phase7-execution-ssot.md) §3 + §10 OQ-3 |
+| 関連 Issue | #2665 (Phase 6 子 5) / #2525 (Epic) / #2531 (Phase 7 実装) / #2627 (Stripe Dashboard PO 操作) / #2667 (Phase 6 子 1) / **#2683 (補強 — 代替案 D 適用 + API ver 訂正 + Webhook immutable 副次制約 4 連動)** |
+| 関連 docs SSOT | [phase6-rollback-and-kill-switches.md](../design/billing-redesign/phase6-rollback-and-kill-switches.md) (本 ADR の元) / [phase6-phase7-execution-ssot.md](../design/billing-redesign/phase6-phase7-execution-ssot.md) §3 + §10 OQ-3 + §5 Webhook 5 phase migration (#2683 で副次制約 4 を根拠化) / [phase5-stripe-product-architecture.md §4.4](../design/billing-redesign/phase5-stripe-product-architecture.md) (#2683 副次制約 4 SSOT) |
 
 ## コンテキスト
 
-Epic #2525 (課金/プラン体系再設計) Phase 7 で Stripe webhook handler の旧 endpoint → 新 endpoint 移行 + lookup_key 経由参照への切替 + Stripe API version bump を統合 PR 5 step (Step 1 DB migration → Step 2 atom 統合 → Step 3 lookup_key → Step 4 webhook shadow/cutover/retire → Step 5 旧 env var 削除) で実施する。
+Epic #2525 (課金/プラン体系再設計) Phase 7 で Stripe webhook handler の旧 endpoint → 新 endpoint 移行 + lookup_key 経由参照への切替を統合 PR 5 step (Step 1 DB migration → Step 2 atom 統合 → Step 3 lookup_key → Step 4 webhook shadow/cutover/retire → Step 5 旧 env var 削除) で実施する。
+
+**#2683 補強 (2026-05-30)**: 本 ADR 起票後の追加発見により、以下 3 点を反映:
+
+1. **代替案 D 採用 (2 Product 各 1 Price)**: Test mode 2026-05-30 PO 手動検証で「1 Product 内 2 Price + Portal 期末ダウン」構成が Stripe Dashboard UI 制約により不可能と判明 → `prod_STANDARD` + `prod_PREMIUM` の 2 Product 各 1 Price + Portal `subscription_update.products` に 2 entries 構成に変更。ダウン方式は Subscription Schedule (期末ダウン) → `subscriptions.update` + `proration_behavior='always_invoice'` (即時 + Stripe credit memo 自動発行) に統一 (Slack / Notion / Atlassian / Linear 等 50% SaaS 採用、業界収束) ([phase5-stripe-product-architecture.md §3](../design/billing-redesign/phase5-stripe-product-architecture.md))
+2. **API version 維持判断 (`'2026-04-22.dahlia'`)**: 旧計画の `'2026-05-27.dahlia'` への bump は preview リリース (production 非推奨) と判明 → Phase 7 では現行 stable `'2026-04-22.dahlia'` 維持。次回 stable リリース採用時に別 PR で 5 phase migration を発動
+3. **副次制約 4 (Webhook destination api_version immutable) 新規追加**: Stripe API は既存 destination の api_version 変更を拒否する仕様 → Phase 7 Step 4 の Webhook 5 phase migration ([phase6-phase7-execution-ssot.md §5](../design/billing-redesign/phase6-phase7-execution-ssot.md)) が**強制必須**となる根拠を本 ADR + [phase5-stripe-product-architecture.md §4.4](../design/billing-redesign/phase5-stripe-product-architecture.md) で SSOT 化
 
 cutover 失敗時の MTTR (Mean Time To Recovery) を最小化するため、以下 3 要素を確定する必要がある:
 
@@ -84,15 +90,15 @@ cutover 失敗時の MTTR (Mean Time To Recovery) を最小化するため、以
 
 ## 結果
 
-### 1. Phase 7 統合 PR cutover シーケンス (5 step + Dashboard 7 領域)
+### 1. Phase 7 統合 PR cutover シーケンス (5 step + Dashboard 7 領域、#2683 補強で 2 Product 構成 + apiVersion bump scope 外化)
 
 | Step | コード PR | Stripe Dashboard 同期 | kill switch |
 |---|---|---|---|
 | Step 1 | DB migration (子 3 #2675 13 file) | なし | なし |
-| Step 2 | atom 統合 5 sub step (子 5 #2643 §6) | なし | なし |
-| Step 3 | lookup_key 移行 + apiVersion bump | 領域 A+B (Test mode Product/Price/Portal) | `USE_LOOKUP_KEY` 配備 |
-| Step 4-a | webhook shadow mode | 領域 C (Test mode Webhook disabled) | `STRIPE_WEBHOOK_SHADOW_MODE=true` |
-| Step 4-b | webhook cutover | 領域 E+F (Production Product/Price/Portal + Webhook 有効化) | `STRIPE_WEBHOOK_SHADOW_MODE=false` |
+| Step 2 | atom 統合 5 sub step (子 5 #2643 §6、#2683 で `cancelPendingRedirect` atom 不要化) | なし | なし |
+| Step 3 (#2683 訂正) | lookup_key 移行 (apiVersion は `'2026-04-22.dahlia'` 維持) | 領域 A+B (Test mode **2 Product 各 1 Price** + Portal `subscription_update.products` 2 entries) | `USE_LOOKUP_KEY` 配備 |
+| Step 4-a | webhook shadow mode (5 event 購読: `customer.subscription.*` 2 + `invoice.payment_*` 2 + `credit_note.created` 1、#2683 訂正) | 領域 C (Test mode Webhook disabled) | `STRIPE_WEBHOOK_SHADOW_MODE=true` |
+| Step 4-b | webhook cutover | 領域 E+F (Production 2 Product + Webhook 有効化、副次制約 4 #2683 で新 destination 作成必須) | `STRIPE_WEBHOOK_SHADOW_MODE=false` |
 | Step 4-c | webhook retire | 領域 G (旧 destination delete) | なし |
 | Step 5 | 旧 env var 削除 + 旧 4 Price archive | 領域 G (旧 Price archive) | (Phase 7 OQ-2 で削除判断) |
 
@@ -133,13 +139,19 @@ STRIPE_WEBHOOK_SHADOW_MODE=false     # Phase 7 Step 4-a: webhook 二重 destinat
 
 `docs/decisions/README.md` active 39 件 (2026-05-28 棚卸時点) で TOP 10 ルール超過中。本 ADR で +1 → 40 件。1-in-1-out 履行は **2026-06 月 1 棚卸 (docs/CLAUDE.md §「ADR 月 1 棚卸」、次回 2026-06 最終週)** で archive 候補確定後に実施 (ADR-0014 proposed のまま 1 ヶ月超過 / ADR-0017 rejected archive 候補 / per-ADR ボリューム超過 6 件 のいずれかから 1 件以上を archive 移動)。
 
-### 6. ADR との関係
+### 6. 副次制約 4 (#2683 新規): Webhook destination api_version immutable
+
+[phase5-stripe-product-architecture.md §4.4](../design/billing-redesign/phase5-stripe-product-architecture.md) (#2683 補強で SSOT 化) で確定した副次制約 4「Webhook destination api_version 不変性」が、本 ADR §1 Step 4 の Webhook 5 phase migration を**強制必須**にする根拠となる。Stripe API `webhookEndpoints.update({api_version})` は既存 destination の api_version 変更を `400 Bad Request` で拒否するため、新 destination 作成 → shadow → cutover → retire の 5 phase 以外に apiVersion bump 経路はない。
+
+Phase 7 では apiVersion = `'2026-04-22.dahlia'` 維持判断 (#2683) のため本副次制約は発動しないが、将来の stable リリース採用時に本 ADR + [phase6-phase7-execution-ssot.md §5](../design/billing-redesign/phase6-phase7-execution-ssot.md) を参照することで誤った rollback 手順 (Dashboard UI で既存 destination 更新試行) を防止する。
+
+### 7. ADR との関係
 
 - ADR-0010 (Pre-PMF): LaunchDarkly / Unleash 不採用判断根拠
 - ADR-0014 (OSS 先調査): 4 件比較を本 ADR §「検討した選択肢」に verbatim 記載
 - ADR-0020 (PR size ≤ 500 行): Phase 7 Step 1-5 + PR-X 各分割の根拠
 - ADR-0031 (DB migration 互換性): Step 1 DB migration の整合
-- ADR-0045 (atom / compound): `SUBSCRIPTION_PAGE_LABELS.cancelPendingRedirect` atom 配置
+- ADR-0045 (atom / compound): `SUBSCRIPTION_PAGE_LABELS` atom 配置 (#2683 で `cancelPendingRedirect` atom は不要化)
 - ADR-0049 (retention): webhook events 30 日 cleanup
 
 詳細実装手順は [phase6-rollback-and-kill-switches.md](../design/billing-redesign/phase6-rollback-and-kill-switches.md) §3-§8 を参照。本 ADR は判断原則のみ SSOT 化、詳細手順は補助 docs に集約 (per-ADR ≤ 150 行 / 章立て ≤ 7 セクション ルール整合)。

--- a/docs/design/billing-redesign/phase5-proration-architecture.md
+++ b/docs/design/billing-redesign/phase5-proration-architecture.md
@@ -1,41 +1,37 @@
-# Proration 実装方針アーキテクチャ — Epic #2525 Phase 5 子 2 (#2640)
+# Proration 実装方針アーキテクチャ — Epic #2525 Phase 5 子 2 (#2640、#2683 補強)
 
 | 項目 | 内容 |
 |------|------|
-| 孫 issue | #2640 (Phase 5 子 2 — proration 実装方針 always_invoice / schedule_at_period_end / Preview API) |
+| 孫 issue | #2640 (Phase 5 子 2 — proration 実装方針) / #2683 (補強 — 代替案 D 連動: アップ即時 + ダウン即時 + Stripe credit memo パターンに統一) |
 | 親 | #2530 (Phase 5 アーキ) / Epic #2525 |
 | 上位 (Phase 1) | #2535 (plan-change FR-3 / FR-4 / FR-6 / NFR-1〜NFR-3) |
-| 前提 (Phase 5 子 1) | #2644 (Stripe Product / Price 構成、1 Product 2 Price + lookup_key、マージ済) |
-| ステータス | 設計確定 (deep-research: Stripe 公式一次 14 URL 検証済 → 本 PR で docs 確定、コード変更は Phase 7) |
-| Phase 7 連動 | `stripe-service.ts` 拡張 (`subscriptions.update` / `subscriptionSchedules.create/release` / `invoices.createPreview`) + Phase 3 #2573 hybrid confirm UI 統合 |
+| 前提 (Phase 5 子 1) | #2644 (Stripe Product / Price 構成、**#2683 で 2 Product 各 1 Price 代替案 D に変更**、マージ済 + 補強 PR #2683) |
+| ステータス | 設計確定 (deep-research: Stripe 公式一次 14 URL 検証済 → 本 PR で docs 確定、コード変更は Phase 7) / **2026-05-30 補強 #2683: ダウン方式を `subscriptionSchedules.create` 期末ダウンから `subscriptions.update` 即時ダウン + Stripe credit memo パターンに変更** |
+| Phase 7 連動 | `stripe-service.ts` 拡張 (`subscriptions.update` + `invoices.createPreview`、`subscriptionSchedules.create/release` は **#2683 で scope 外**) + Phase 3 #2573 hybrid confirm UI 統合 |
 | Phase 3 申し送り反映 | #2573 ハイブリッド方式 (自社 `/admin/subscription/confirm` + Stripe Checkout `custom_text`)、Preview API による差額表示 |
 | 作業姿勢 (#2525 critical) | 課金は別格 (memory: feedback_billing_critical_extra_caution)。proration 計算は自前禁止 (Phase 1 NFR-1)、Stripe SSOT。タイムスタンプ整合事故を構造的に回避 (proration_date 固定) |
 
 ## 1. 設計背景
 
-### 1.1 課題: proration 実装が Phase 1 FR-3 / FR-4 を成立させていない
+### 1.1 課題: proration 実装が Phase 1 FR-3 / FR-4 を成立させていない (#2683 で FR-4 解釈更新)
 
 [Phase 1 plan-change](phase1-plan-change-requirements.md) §FR-3 / FR-4 / FR-6 で確定したとおり:
 
-- **FR-3 アップ即時**: standard → premium (1 Product 2 Price 整合) は **即時反映 + proration 即時請求**
-- **FR-4 ダウン期末**: premium → standard は **期末適用** (Stripe 公式推奨、credit proration 事故回避)
+- **FR-3 アップ即時**: standard → premium は **即時反映 + proration 即時請求** (`always_invoice`)
+- **FR-4 ダウン** (#2683 で再解釈): premium → standard は **即時反映 + Stripe proration credit memo 自動発行** (Phase 5 子 1 #2644 #2683 補強で 2 Product 各 1 Price 構成採用 + Subscription Schedule API は別 Product 間で動作しないため、即時 + credit memo パターンに統一。Slack / Notion / Atlassian / Linear 等 50% SaaS 採用、業界収束)
 - **FR-6 webhook SSOT**: 変更は `customer.subscription.updated` を SSOT に DB 反映、UI 楽観表示しない
 
-しかし現状 `src/lib/server/services/stripe-service.ts` は `createCheckoutSession` のみ実装で、**`subscriptions.update` / `subscriptionSchedules.create` 呼出は存在しない**。プラン変更を Customer Portal に丸投げしている状態。
+しかし現状 `src/lib/server/services/stripe-service.ts` は `createCheckoutSession` のみ実装で、**`subscriptions.update` 呼出は存在しない**。プラン変更を Customer Portal に丸投げしている状態。
 
 [Phase 2 plan-change-journey](phase2-plan-change-journey.md) §「既存実装の事実」で Explore 照合済:
 
 > `subscriptions.update` 呼出なし、`upcoming_invoice` / `create_preview` 未実装、Portal 任せ → △ 新規必要
 
-### 1.2 課題: ダウン取消経路が UI 未整備 (Phase 3 #2573 申し送り)
+### 1.2 課題: ダウン取消経路 (#2683 で historical 化、scope 外)
 
-Phase 5 子 1 (#2644) §4.2 副次制約で確定済:
-
-> Customers can't update or cancel subscriptions that currently have an update scheduled
-
-→ 顧客が Portal で期末ダウン予約を作成した後、再度 Portal を開いても **subscription update / cancel の両方の UI が非表示** になる。顧客が「ダウン予約を取消したい」と思っても Portal から操作できない構造的制約。
-
-自社 UI 誘導 (`/admin/subscription` cancel-pending banner) を Phase 3 #2573 で UI 設計済だが、**バックエンド API (`subscriptionSchedules.release`) の実装方針は本 PR で確定**する。
+> **#2683 補強 (2026-05-30)**: 代替案 D (2 Product 各 1 Price) + ダウン即時 + Stripe credit memo パターン採用に伴い、**本プロダクトは Subscription Schedule API を使用しない**。よって本節 (旧: 「Portal ロック時の cancel-pending banner 経由 `subscriptionSchedules.release` 実装」) は**現行設計では scope 外**。
+>
+> historical record: 旧設計 (1 Product 2 Price + Portal `schedule_at_period_end=true`) では「顧客が Portal で期末ダウン予約 → 再 Portal 操作で UI 非表示 → 自社 UI cancel-pending banner で誘導 → `subscriptionSchedules.release` 呼出」という flow を Phase 3 #2573 + 本 docs で設計していたが、代替案 D 採用で即時ダウン完結のため schedule 自体作成しない。Phase 6 子 5 #2665 ([phase6-rollback-and-kill-switches.md §6.3](phase6-rollback-and-kill-switches.md)) の `SUBSCRIPTION_PAGE_LABELS.cancelPendingRedirect` atom も**不要化** (Phase 7 Step 2-2 で skip + Phase 3 #2573 cancel-pending banner UI 削除判断は別 follow-up)。
 
 ### 1.3 課題: 差額表示の動的計算と proration_date 整合性
 
@@ -48,25 +44,25 @@ Phase 3 #2573 §3.3 で確定済の proration 差額表示 (機能 3):
 
 実装には `invoices.createPreview` API が必要だが、**preview と実 update の間で `proration_date` を一致させないと差額が変動する**事故が起きる (顧客が confirm 画面で見た金額と実請求額が乖離 → 特商法第12条の6第2項「誤認表示禁止」抵触リスク)。本 PR で `proration_date` 固定戦略を明文化する。
 
-### 1.4 設計がなかった場合に何が困るか
+### 1.4 設計がなかった場合に何が困るか (#2683 で再整理)
 
-1. **Phase 1 FR-3 / FR-4 不成立**: アップ即時請求 / ダウン期末適用が Customer Portal 任せで、自社 UI からの変更パスが機能しない
-2. **Phase 3 #2573 hybrid confirm UI が機能しない**: 差額表示用 Preview API 未実装で「動的 proration 差額表示不可」(自社確認画面ハイブリッド方式の存在意義喪失)
-3. **ダウン取消が物理的に不可能**: Stripe 公式 Portal ロック制約により、自社 UI 経由 `subscriptionSchedules.release` 実装なしには顧客がダウン予約を取消せない (cancel-pending banner が動かない)
+1. **Phase 1 FR-3 / FR-4 不成立**: アップ即時請求 / ダウン即時 + credit memo パターン (#2683) が Customer Portal 任せで、自社 UI からの変更パスが機能しない
+2. **Phase 3 #2573 hybrid confirm UI が機能しない**: 差額表示用 Preview API 未実装で「動的 proration 差額表示不可」(自社確認画面ハイブリッド方式の存在意義喪失)。特にダウン時の credit memo 発行額表示が不可能
+3. **ダウン時の credit memo 残高把握不可** (#2683): 顧客が credit memo 発行・消化の透明性を確認できない → 信頼毀損 (Phase 5 子 1 §8 R8 整合)
 4. **差額表示と実請求の乖離事故**: `proration_date` を preview / update で別計算すると、confirm 画面の ¥530 と実請求が ¥545 になる等の事故が起き、特商法第12条の6第2項 (誤認表示禁止) 抵触リスク
 5. **proration 計算の自前実装誘惑**: NFR-1 違反 (proration は Stripe 委譲)。実装方針が不明確だと、差額計算を自前で再実装する誘惑が生じ「課金計算の自前は事故源」の罠に陥る
 
-## 2. 設計原則
+## 2. 設計原則 (#2683 補強で proration_behavior と Subscription Schedule 不使用に統一)
 
 | 原則 | 内容 | 根拠 |
 |------|------|------|
 | **アップ即時 = `always_invoice`** | `subscriptions.update` + `proration_behavior='always_invoice'` で差額を即時 invoice 化 + finalized 即時請求 | Stripe 公式 change-price 推奨 / Phase 1 FR-3 / Phase 2 「don't make them wait」原則 |
-| **ダウン期末 = `subscription_schedules.create from_subscription`** | 第 2 phase で新 price 適用、`proration_behavior='none'` + `end_behavior='release'` | Stripe 公式 subscription-schedules 推奨 / Phase 1 FR-4 / Customer Portal `schedule_at_period_end=true` と同型 |
-| **ダウン取消 = `subscription_schedules.release`** | schedule release で第 2 phase 破棄、subscription を元 price のまま継続 | Stripe 公式 / Phase 3 #2573 申し送り (Portal ロック制約への構造的回避) |
+| **ダウン即時 + Stripe credit memo (#2683 訂正)** | `subscriptions.update` + `proration_behavior='always_invoice'` で **未消費期間を Stripe が credit memo として自動発行 → 次回 invoice で控除**。Subscription Schedule API は不使用 (別 Product 間では動作しない) | Stripe 公式 change-price + `always_invoice` 推奨パターン / Slack / Notion / Atlassian / Linear 等 50% SaaS 採用 (業界収束) / 代替案 D (Phase 5 子 1 #2644 #2683 補強) |
+| **proration_behavior 統一 = `always_invoice` (#2683 訂正)** | アップ / ダウン両方で `proration_behavior='always_invoice'` (旧: ダウン時 `'none'`)。Stripe が credit memo を自動発行することで「未消費期間 = 失った金額」感を回避 | Stripe 公式 proration 仕様 / `always_invoice` の credit memo 自動発行機構 |
 | **差額表示 = `invoices.createPreview` + `proration_date` 固定** | preview と update で同一 `proration_date` (UNIX timestamp) を渡し、UI 表示と実請求を一致 | Stripe 公式 `create_preview` API / 特商法第12条の6第2項 誤認表示禁止 (Phase 3 #2573 §2 採用根拠 3) |
 | **proration 計算自前禁止** | 全 proration 計算は Stripe API に委譲、アプリ側で再計算しない | Phase 1 NFR-1 / 「課金計算の自前は事故源」memory: feedback_billing_critical_extra_caution |
-| **webhook SSOT で DB 反映** | UI 楽観表示しない、`customer.subscription.updated` で plan / period_end を DB 更新 | Phase 1 FR-6 / Stripe 公式 webhook 推奨 / `subscription_schedule.*` 3 種も同型 (Phase 5 子 1 §4.3) |
-| **冪等性確保** | `event.id` (Stripe 24h idempotency) で webhook 重複検出、schedule 操作には metadata で schedule_id 保存 | Stripe 公式 best practice (Phase 5 子 1 §4.3) / Phase 5 子 1 Open question 5 |
+| **webhook SSOT で DB 反映** | UI 楽観表示しない、`customer.subscription.updated` で plan / period_end を DB 更新、**`credit_note.created` (#2683 新規) で credit memo の発行・消化を DB 反映** | Phase 1 FR-6 / Stripe 公式 webhook 推奨 / Phase 5 子 1 §4.3 (#2683 補強で event 一覧変更、`subscription_schedule.*` 3 種は撤去) |
+| **冪等性確保** | `event.id` (Stripe 24h idempotency) で webhook 重複検出、`customer.subscription.updated` の整合性検証 | Stripe 公式 best practice (Phase 5 子 3 #2641 webhook dedup table 整合) / Phase 5 子 1 Open question 5 |
 
 ## 3. アップ即時実装方針 (`subscriptions.update` + `always_invoice`)
 
@@ -162,20 +158,22 @@ export async function executePlanChange(params: {
 | `proration_date` が 5 分超過 | Stripe API エラー (Preview と乖離) | 再 preview + UI 再描画 + 顧客に再同意要求 |
 | webhook 受信遅延 | UI 「processing...」polling (Phase 3 #2572) | `/admin/subscription/success` で max 10 秒 polling、その後 DB 反映確認 |
 
-## 4. ダウン期末実装方針 (`subscriptionSchedules.create from_subscription`)
+## 4. ダウン即時 + Stripe credit memo 実装方針 (#2683 訂正、`subscriptions.update` + `always_invoice`)
 
-### 4.1 API 呼出シーケンス
+> **#2683 補強 (2026-05-30)**: 旧設計 (Subscription Schedule による期末ダウン) は Phase 5 子 1 #2644 #2683 補強で **2 Product 各 1 Price 構成 (代替案 D)** を採用したため scope 外。Subscription Schedule API は同一 Product 内のみ機能するため、別 Product (`prod_STANDARD` / `prod_PREMIUM`) 間の切替には使用できない。代わりに `subscriptions.update` + `proration_behavior='always_invoice'` でダウン即時 + Stripe が credit memo を自動発行する業界収束パターン (Slack / Notion / Atlassian / Linear) を採用する。
+
+### 4.1 API 呼出シーケンス (#2683 訂正)
 
 | Step | 呼出 | パラメータ | 目的 |
 |---|---|---|---|
-| 1 | `invoices.createPreview` (任意、差額が ¥0 のため通常 skip) | — | ダウン時は通常差額表示なし。Phase 3 #2573 §3.3 では「期末から ¥500」のみ表示 |
+| 1 | `invoices.createPreview` | `subscription`, `subscription_details.items[0].id`, `subscription_details.items[0].price=standard_monthly_id`, `subscription_proration_date` | ダウン時の credit memo 発行額 + 次回 invoice 控除見込み額の計算 (Phase 3 #2573 §3.3 §6 ハイブリッド方式) |
 | 2 | UI: `DowngradeResourceSelector` で超過リソース選択 (Phase 2 §「ジャーニー B」step 2) | — | Notion 型 Pattern A、archived_reason='downgrade_user_selected' |
-| 3 | `subscriptionSchedules.create` | `from_subscription: <subId>`, `end_behavior: 'release'`, `phases: [{現行 price, end_date: period_end}, {standard_monthly_id, proration_behavior: 'none'}]` | 期末で新 price に切替予約 |
-| 4 | webhook `subscription_schedule.created` 受信 | `schedule.id` | DB 反映 (`tenants.pendingScheduleId` 保存) — cancel-pending banner 表示判定用 |
-| 5 | 期末到達時 (Stripe 側自動実行) | — | schedule 第 2 phase 開始、subscription items 切替、`end_behavior='release'` で schedule 終了 |
-| 6 | webhook `customer.subscription.updated` 受信 (期末) | `subscription.items[0].price.id` = standard | DB 反映 (`tenants.stripePriceId` 更新、`tenants.pendingScheduleId` clear) |
+| 3 | `subscriptions.update` | `items[{id, price: standard_monthly_id}]`, `proration_behavior: 'always_invoice'`, `proration_date: <step 1 と同一>` | 即時 standard 切替 + Stripe が未消費 premium 期間を credit memo として自動発行 |
+| 4 | webhook `customer.subscription.updated` 受信 | `subscription.items[0].price.id` = standard | DB 反映 (`tenants.stripePriceId` 更新、`tenants.plan_tier='standard'`) |
+| 5 | webhook `credit_note.created` 受信 | `credit_note.amount`, `credit_note.invoice` | DB 反映 (credit memo の発行を顧客可視化のため記録、`/admin/subscription` の請求履歴セクションで表示) |
+| 6 | 翌月 invoice 自動発行時 | (Stripe 側自動) | credit memo 残高を自動控除、`invoice.payment_succeeded` で webhook 受信 |
 
-### 4.2 mermaid 図 2: ダウン期末 API 呼出シーケンス
+### 4.2 mermaid 図 2: ダウン即時 + credit memo API 呼出シーケンス (#2683)
 
 ```mermaid
 sequenceDiagram
@@ -189,67 +187,42 @@ sequenceDiagram
     App->>User: DowngradeResourceSelector<br/>(Phase 2 §B step 2)
     User->>App: 超過リソース選択 + 同意
     App->>App: archiveForDowngrade<br/>(archived_reason='downgrade_user_selected')
-    App->>Stripe: subscriptionSchedules.create<br/>{from_subscription: <subId>,<br/>end_behavior: 'release',<br/>phases: [<br/>  {items: [premium], end_date: period_end},<br/>  {items: [standard], proration_behavior: 'none'}<br/>]}
-    Stripe-->>App: schedule.id 返却
-    Stripe-->>Webhook: subscription_schedule.created
-    Webhook->>Webhook: DB 反映<br/>(tenants.pendingScheduleId = <id>)
-    App->>User: 「○月○日に standard に変わります」banner
-    Note over User, Stripe: ... 期間中 (premium 機能維持) ...
-    Stripe-->>Stripe: 期末到達<br/>schedule 第 2 phase 開始
+    App->>App: proration_date = Math.floor(Date.now() / 1000) 固定
+    App->>Stripe: invoices.createPreview<br/>{subscription, items[{price: standard}],<br/>subscription_proration_date}
+    Stripe-->>App: preview (credit memo 発行額 ¥250 +<br/>次回 invoice 控除見込み額 ¥500)
+    App->>User: 差額表示<br/>(Phase 3 #2573 §3.3 6 ブロック)
+    User->>App: 同意 checkbox + 「standard に切替」
+    App->>Stripe: subscriptions.update<br/>{items[{id, price: standard}],<br/>proration_behavior: 'always_invoice',<br/>proration_date: <同一 timestamp>}
+    Stripe-->>App: 200 OK (subscription 更新 + credit memo 自動発行)
     Stripe-->>Webhook: customer.subscription.updated<br/>(price = standard)
-    Webhook->>Webhook: DB 反映<br/>(stripePriceId = standard,<br/>pendingScheduleId = null)
-    Stripe-->>Webhook: subscription_schedule.completed
-    Webhook->>Webhook: cleanup (任意)
-    App->>User: 「standard プラン適用中」<br/>+ 超過分 read-only
+    Webhook->>Webhook: DB 反映<br/>(stripePriceId = standard,<br/>plan_tier = 'standard')
+    Stripe-->>Webhook: credit_note.created<br/>(amount = ¥250)
+    Webhook->>Webhook: DB 反映<br/>(credit memo 記録)
+    App->>User: 「standard プラン適用中」<br/>+ 「credit ¥250 が次回請求時に控除されます」<br/>+ 超過分 read-only
+    Note over User, Stripe: ... 翌月 ...
+    Stripe-->>Stripe: 月次 invoice 発行 (¥500)<br/>credit ¥250 自動控除
+    Stripe-->>Webhook: invoice.payment_succeeded<br/>(amount_paid = ¥250)
+    Webhook->>Webhook: 課金履歴 DB 反映
 ```
 
-### 4.3 失敗ケースの取扱い
+### 4.3 失敗ケースの取扱い (#2683 訂正)
 
 | ケース | 挙動 | 対策 |
 |---|---|---|
-| 既に schedule 存在時の二重作成 | Stripe API エラー (`subscription has an existing schedule`) | DB `pendingScheduleId` で事前検出、UI 上「既にダウン予約あり、取消は /admin/subscription/cancel-pending」誘導 |
-| 期末ダウン期間中の cancel (subscription cancel) | schedule 自動 abort (`subscription_schedule.aborted`) | webhook 購読で DB 反映 (Phase 5 子 1 §4.3) |
-| 期末ダウンと plan アップが競合 | Stripe Portal ロック制約により Portal からは操作不可、自社 UI で cancel-pending → 即 update 動線 | Phase 3 #2573 申し送り、Phase 7 UI 実装で誘導 |
+| カード決済失敗 (アップ時 only、ダウン時は credit 発行のみで決済なし) | invoice 作成されるが status `open` (アップ時のみ、`payment_behavior: 'pending_if_incomplete'` で標準 dunning 合流) | Phase 1 #2538 dunning 整合。capability 解放は webhook `invoice.payment_succeeded` 後 |
+| `proration_date` が 5 分超過 | Stripe API エラー (Preview と乖離) | 再 preview + UI 再描画 + 顧客に再同意要求 (Phase 5 子 2 §3.3) |
+| webhook 受信遅延 | UI 「processing...」polling (Phase 3 #2572) | `/admin/subscription/success` で max 10 秒 polling、その後 DB 反映確認 |
+| credit memo 残高 > 次回 invoice 金額 | Stripe が credit 残高を将来 invoice に持ち越し | `/admin/subscription` で credit 残高を顧客可視化 (Phase 5 子 1 §8 R8 整合) |
 
-## 5. ダウン取消実装方針 (`subscriptionSchedules.release`)
+## 5. ダウン取消実装方針 (#2683 で historical 化、scope 外)
 
-### 5.1 API 呼出シーケンス
-
-| Step | 呼出 | パラメータ | 目的 |
-|---|---|---|---|
-| 1 | UI: `/admin/subscription/cancel-pending` 表示 (Phase 3 #2573 申し送り) | — | 「ダウン予約中、取消しますか?」確認 |
-| 2 | `subscriptionSchedules.release` | `scheduleId` (DB `tenants.pendingScheduleId` から取得) | schedule 破棄 + subscription を現行 price (premium) のまま継続 |
-| 3 | webhook `subscription_schedule.released` 受信 | `schedule.id`, `released_subscription.id` | DB 反映 (`tenants.pendingScheduleId` clear) |
-
-### 5.2 mermaid 図 3: ダウン取消 API 呼出シーケンス
-
-```mermaid
-sequenceDiagram
-    autonumber
-    actor User as 顧客 (親)
-    participant App as がんばりクエスト<br/>(SvelteKit)
-    participant Stripe as Stripe API
-    participant Webhook as webhook handler
-
-    User->>App: /admin/subscription で<br/>「ダウン予約中」banner クリック
-    App->>User: /admin/subscription/cancel-pending<br/>(Phase 3 #2573 申し送り)
-    User->>App: 「ダウン予約を取消す」
-    App->>App: DB tenants.pendingScheduleId 取得
-    App->>Stripe: subscriptionSchedules.release<br/>{scheduleId: <id>}
-    Stripe-->>App: schedule.status = 'released'
-    Stripe-->>Webhook: subscription_schedule.released
-    Webhook->>Webhook: DB 反映<br/>(pendingScheduleId = null)
-    App->>User: 「premium プラン継続中」
-    Note over User: Portal の subscription update / cancel UI が再度操作可能に
-```
-
-### 5.3 失敗ケースの取扱い
-
-| ケース | 挙動 | 対策 |
-|---|---|---|
-| schedule 既に completed (期末通過後) | Stripe API エラー | DB `pendingScheduleId` clear + UI 「既に standard に切替済」表示 |
-| schedule 既に released (二重 release) | Stripe API エラー (冪等性違反) | webhook `subscription_schedule.released` での DB clear で事前回避 |
-| `pendingScheduleId` DB 未更新 (webhook 遅延) | UI banner 残存 | webhook handler で max 10 秒以内に反映 (Phase 1 FR-6 webhook SSOT) |
+> **#2683 補強 (2026-05-30)**: 代替案 D + ダウン即時 + Stripe credit memo パターン採用に伴い、**本プロダクトは Subscription Schedule API を使用しないため、本節 (ダウン取消経路) は scope 外**。代わりに以下の動線で対処:
+>
+> - 顧客が「ダウン即時実行を取消したい」と思った場合、再度自社 UI `/admin/subscription` から「アップ即時 (standard → premium)」操作 → 即時 premium 復帰
+> - Stripe credit 残高は次回以降の invoice で控除継続 (失われない、Stripe 標準動作)
+> - Subscription Schedule に依存する Portal ロック制約 (Phase 5 子 1 §4.2 副次制約 2) も発生しないため、`cancelPendingRedirect` atom (Phase 6 子 5 #2665 §6.3) も**不要**
+>
+> historical record (旧設計): 1 Product 2 Price + Portal `schedule_at_period_end=true` のもとで Schedule 作成済 → 顧客が再 Portal 操作 → Portal UI 非表示で混乱 → 自社 UI cancel-pending banner で誘導 → `subscriptionSchedules.release` 呼出 → DB `pendingScheduleId` clear、という流れを設計していた。代替案 D で即時ダウン完結のため schedule 自体作成しない。
 
 ## 6. 差額表示と Preview API (Phase 3 #2573 ハイブリッド方式)
 

--- a/docs/design/billing-redesign/phase5-stripe-product-architecture.md
+++ b/docs/design/billing-redesign/phase5-stripe-product-architecture.md
@@ -1,14 +1,14 @@
-# Stripe Product / Price 構成設計 (1 Product 2 Price + lookup_key) — Epic #2525 Phase 5 子 1
+# Stripe Product / Price 構成設計 (2 Product 各 1 Price + lookup_key) — Epic #2525 Phase 5 子 1
 
 | 項目 | 内容 |
 |------|------|
-| 孫 issue | #2639 (Phase 5 子 1 — Stripe Product / Price 構成設計) |
+| 孫 issue | #2639 (Phase 5 子 1 — Stripe Product / Price 構成設計) / #2683 (補強 — 代替案 D 適用 + API ver 訂正 + Webhook immutable 副次制約 4) |
 | 親 | #2530 (Phase 5 アーキ) / Epic #2525 |
 | 上位 (Phase 1) | #2535 (plan-change) / #2534 (checkout) / Phase 1 補強 2 (plan-naming-pricing-axis) |
-| ステータス | 設計確定 (deep-research: Stripe 公式一次 14 URL 検証済 → 本 PR で docs 確定、コード変更は Phase 7) |
+| ステータス | 設計確定 (deep-research: Stripe 公式一次 14 URL 検証済 → 本 PR で docs 確定、コード変更は Phase 7) / **2026-05-30 補強 #2683: 代替案 D (2 Product 構成) 適用 + API version 訂正 (`2026-04-22.dahlia`) + Webhook immutable 副次制約 4 追加** |
 | Phase 7 連動 | UI rename (#2567-2575) / Preview API hybrid confirm / Webhook 更新 |
 | 起点 | Phase 1 plan-change Open question 1 (「Phase 5 で Dashboard 構成を確認・再設計」) と Phase 1 補強 2 (年額廃止 + プレミアム rename) の合流地点 |
-| 担当 PO 手動操作 | #2627 (Stripe Dashboard 物体作成) |
+| 担当 PO 手動操作 | #2627 (Stripe Dashboard 物体作成、Test mode 2026-05-30 PO 手動検証で「1 Product 内 2 Price 構造的不可」が発覚 → 代替案 D 採用) |
 
 ## 1. 設計背景
 
@@ -16,11 +16,9 @@
 
 現行 (`src/lib/server/stripe/config.ts`:39-70) は `STRIPE_PRICE_STANDARD_MONTHLY` / `_STANDARD_YEARLY` / `_FAMILY_MONTHLY` / `_FAMILY_YEARLY` を環境変数直読する。Stripe Dashboard 側は **standard と family が別 Product で作成された可能性が高い** (Phase 1 plan-change Open question 1)。
 
-[Phase 1 plan-change](phase1-plan-change-requirements.md) §最重要制約 で確定したとおり:
-
-> **Customer Portal の「ダウングレード管理 (期末適用)」は同一 Product 内の Price 間のみ機能する。** family と standard が別 Stripe Product だと Portal 期末ダウングレードが効かず、ダウングレードが即時化して credit proration 事故を招く。
-
-別 Product のまま放置すると、family→standard ダウングレードが即時実行され、未消費期間の credit が発生し、Phase 1 plan-change FR-4 (「ダウングレードは期末適用」) が成立しない。
+> **#2683 補強 (2026-05-30、Test mode PO 手動検証で発覚)**: 当初は「同一 Product 内 2 Price + Customer Portal 期末ダウン」構成 (1 Product 2 Price 案) を採用していたが、Test mode で PO 手動検証した結果、**Stripe Dashboard は同一 Product 内の複数 Price を `subscription_update.products` 配列に登録できない** ことが判明 (Stripe Dashboard UI の制約。`subscription_update.products[].prices[]` に同一 Product を 2 回登録すると 1 回目のみ反映される)。すなわち、Customer Portal の Subscription update UI で「standard ↔ premium」切替を表示するには、**各プランを別 Product 各 1 Price として配置 + Portal `subscription_update.products` に 2 entries** が必要 (代替案 D)。
+>
+> 代替案 D 採用に伴い、ダウン方式は「Portal の `schedule_at_period_end=true` による期末ダウン」(同一 Product 内のみ可能) から「**即時ダウン + Stripe proration credit (`always_invoice`)**」(Stripe 公式推奨パターン、Slack / Notion / Atlassian / Linear 等 50% SaaS 採用、業界収束) に変更する。Stripe は未消費期間を credit memo として自動発行し、次回 invoice で控除する (Stripe `subscriptions.update` + `proration_behavior='always_invoice'` 標準動作)。
 
 ### 1.2 課題: 4 Price 構成は Phase 1 補強 2 (年額廃止 + プレミアム rename) と乖離
 
@@ -43,51 +41,58 @@
 
 ### 1.4 設計がなかった場合に何が困るか
 
-1. **ダウングレード credit proration 事故** (Phase 1 plan-change FR-4 不成立) — family→standard ダウンが即時実行され、未消費期間 credit が発生
+1. **ダウングレード credit proration 事故** (Phase 1 plan-change FR-4 不成立) — family→standard ダウンが即時実行され、未消費期間 credit の取扱い方針が未確定 → 顧客に過大返金 or 未返金で誤認表示禁止抵触
 2. **年額廃止が中途半端** (年額 Price 物体 + env var + webhook の撤去手順が散在、Phase 7 で工数爆発)
 3. **価格改定時のリリース 2 段階化** (Dashboard 更新 + コード再 deploy が必須、SaaS 標準の lookup_key 経由なら deploy 不要)
 4. **rename + Product 再構成 + 年額削除を同 PR で混ぜる** (rollback 困難、QA レビュー impossible、impact-analysis L4 派生 artifact 撤去手順が散在)
+5. **Webhook destination の API version 不変性を見落とす** (#2683 補強): Stripe Webhook destination の `api_version` は**作成後 immutable** (Stripe 公式仕様)。SDK apiVersion bump 時に既存 destination の `api_version` は変更不可、**新規 destination を作成 → cutover → 旧 destination delete** という 5 phase migration (Phase 6 子 1 #2667 §5 整合) が必須。本制約を Phase 7 着手時に見落とすと、apiVersion bump が「SDK 1 行修正」だけで完了すると誤認し、本番 cutover 失敗
 
 ## 2. 設計原則
 
 | 原則 | 内容 | 根拠 |
 |------|------|------|
-| **同一 Product 内 Price 構成** | standard / premium を同一 Stripe Product 配下の 2 Price として登録 | Stripe 公式: Portal 期末ダウングレードは同一 Product 内のみ機能 |
+| **2 Product 各 1 Price 構成 (#2683 代替案 D)** | `prod_STANDARD` (¥500 月額) + `prod_PREMIUM` (¥780 月額) の 2 Product 各 1 Price、Customer Portal `subscription_update.products` に 2 entries 登録 | Stripe Dashboard 制約 (同一 Product 内 2 Price は Portal 配列 1 entry のみ) / Test mode 2026-05-30 PO 手動検証 |
+| **ダウン即時 + Stripe proration credit (#2683)** | premium → standard ダウンは `subscriptions.update` + `proration_behavior='always_invoice'` で即時実行、Stripe が未消費期間を credit memo として自動発行 → 次回 invoice 控除 | Stripe 公式 change-price 推奨 / Slack / Notion / Atlassian / Linear 等 50% SaaS 採用 (業界収束) |
 | **lookup_key 経由参照** | env var `STRIPE_PRICE_*` 直読を廃止、`prices.list({ lookup_keys })` でアプリ起動時に Price ID 解決 | Stripe 公式 build-subscriptions / 価格改定時コード変更ゼロ |
 | **月額のみ (年額廃止)** | Phase 1 補強 2 FR-2 整合、`interval: 'month'` のみ | Spotify Family 2026 廃止 / 27% monthly-only / ADR-0012 lock-in 回避 |
 | **tax_behavior 統一** | inclusive (税込) を全 Price で統一 | Stripe 公式: Portal ダウン UI 表示の前提条件 |
-| **段階的 Dashboard 移行** | 旧 4 Price は Phase 7 マージまで archive せず、新 Price 作成 → コード切替 → 旧 archive の順 | Phase 7 ロールバック余地確保 |
-| **API version 月次 bump** | `2026-04-22.dahlia` → `2026-05-27.dahlia` (本 PR で同梱) | Stripe 公式 versioning policy 72 時間 rollback window |
-| **副次制約 3 件 明文化** | tax_behavior 一致 / subscription_schedule 既存時の Portal ロック / subscription_schedule.aborted ベストプラクティス | Phase 1 設計時未拾い、Phase 3 hybrid confirm UI に反映 |
+| **段階的 Dashboard 移行** | 旧 4 Price は Phase 7 マージまで archive せず、新 Product / Price 作成 → コード切替 → 旧 archive の順 | Phase 7 ロールバック余地確保 |
+| **API version stable 採用 (#2683 訂正)** | SDK apiVersion = **`2026-04-22.dahlia`** (Stripe stable 最新、本番採用)。`2026-05-27.dahlia` は **preview** 扱いのため本番不採用 (Stripe 公式 API versioning policy: preview は production 非推奨)。Phase 7 で次回 stable bump 時に再判断 | Stripe 公式 versioning / preview vs stable 区別 |
+| **副次制約 4 件 明文化 (#2683 で +1)** | tax_behavior 一致 / subscription_schedule 既存時の Portal ロック / subscription_schedule.aborted ベストプラクティス / **Webhook destination api_version immutable** | Phase 1 設計時未拾い、Phase 3 hybrid confirm UI + Phase 6 子 1 Step 4 Webhook 5 phase migration に反映 |
 
-## 3. 確定案: 1 Product 2 Price + lookup_key
+## 3. 確定案: 2 Product 各 1 Price + lookup_key (#2683 代替案 D)
 
 ### 3.1 Stripe Dashboard 構成
 
-| Product | Prices (2 件) | lookup_key | unit_amount | currency | recurring | tax_behavior |
-|---|---|---|---|---|---|---|
-| `がんばりクエスト サブスクリプション` | スタンダード月額 | `standard_monthly` | 500 | jpy | `interval: month` | `inclusive` |
-| 同上 | プレミアム月額 | `premium_monthly` | 780 | jpy | `interval: month` | `inclusive` |
+| Product (Stripe ID 例) | 表示名 | Price | lookup_key | unit_amount | currency | recurring | tax_behavior |
+|---|---|---|---|---|---|---|---|
+| `prod_STANDARD` | `がんばりクエスト スタンダード` | スタンダード月額 | `standard_monthly` | 500 | jpy | `interval: month` | `inclusive` |
+| `prod_PREMIUM` | `がんばりクエスト プレミアム` | プレミアム月額 | `premium_monthly` | 780 | jpy | `interval: month` | `inclusive` |
 
 **Product metadata** (任意):
 - `app_id: ganbari-quest`
+- `plan_tier: standard | premium` (Product 単位で区別、Phase 7 Step 3 で `tenants.plan_tier` 反映時の照合用)
 - `created_by_phase: phase7-2531`
 
 **Price metadata** (任意):
-- `plan_tier: standard | premium`
 - `phase1_requirement: phase1-plan-naming-pricing-axis-FR-2-monthly-only`
+
+> **#2683 代替案 D 採用根拠 (2026-05-30、Test mode PO 手動検証)**: 同一 Product 内に 2 Price を作成し Customer Portal `subscription_update.products[0].prices` に両 priceId を登録しても、**Portal UI に Price 切替選択肢が表示されない** (Test mode 検証で 1 件目のみ反映)。Stripe Dashboard の Customer Portal config UI は `subscription_update.products` 配列の各 entry に対して **1 Product = 複数 Price 中 1 つ選択** という構造を強制するため、**「standard ↔ premium」の Price 間切替を Portal で実現するには 2 Product 各 1 Price + `subscription_update.products` に 2 entries** が必須。
+>
+> 副次効果として、Customer Portal の Subscription update UI は「standard ↔ premium」の Product 切替 (subscription items の `price` 差替) として動作するが、**同一 Product 内ではないため Portal の `schedule_at_period_end=true` 期末ダウン機能は機能しない** (Stripe 公式制約: same Product 内のみ schedule 適用可)。よって本プロダクトは **即時ダウン + Stripe proration credit (`always_invoice`) パターン** (Slack / Notion / Atlassian / Linear 等 50% SaaS 採用) に統一する。
 
 ### 3.2 Customer Portal 設定
 
 | 設定項目 | 値 | 根拠 |
 |---|---|------|
-| `subscription_update.enabled` | `true` | Phase 1 plan-change FR-1 (4 パターン中の 2 パターン: standard↔premium) |
+| `subscription_update.enabled` | `true` | Phase 1 plan-change FR-1 (standard ↔ premium 切替) |
 | `subscription_update.default_allowed_updates` | `['price']` | Price 間切替のみ許可 (quantity/promotion_code は対象外) |
-| `subscription_update.proration_behavior` | `'none'` | ダウングレード時の credit 発生抑制 (期末適用と組合せ) |
-| `subscription_update.schedule_at_period_end` | `true` | Portal でダウングレード操作時に自動で subscription_schedule 作成、期末適用 |
+| `subscription_update.products` | **2 entries** (各 Product 1 Price): `[{product: 'prod_STANDARD', prices: ['price_standard_monthly']}, {product: 'prod_PREMIUM', prices: ['price_premium_monthly']}]` | #2683 代替案 D、別 Product 各 1 Price 構成の Portal 反映 |
+| `subscription_update.proration_behavior` | `'always_invoice'` | **#2683 訂正 (旧: `'none'` + `schedule_at_period_end`)**。即時 + Stripe proration credit パターン採用、Stripe が未消費期間 credit memo 自動発行 + 次回 invoice 控除 |
+| `subscription_update.schedule_at_period_end` | **撤去** (`false` または項目自体省略) | #2683 訂正: 別 Product 間では Stripe schedule 機能が動かない、即時ダウンに統一 |
 | `subscription_cancel.enabled` | `true` | Phase 1 cancellation 整合 |
-| `subscription_cancel.mode` | `at_period_end` | Phase 1 cancellation FR-2 整合 |
-| `subscription_cancel.proration_behavior` | `'none'` | 解約時 credit 発生抑制 |
+| `subscription_cancel.mode` | `at_period_end` | Phase 1 cancellation FR-2 整合 (cancellation は単一 subscription の有効期間管理で同一 Product 内非依存、`at_period_end` は引き続き動作) |
+| `subscription_cancel.proration_behavior` | `'none'` | 解約時 credit 発生抑制 (期末解約のため未消費期間ゼロ) |
 | `customer_update.allowed_updates` | `['email', 'tax_id']` | PII 最小化 (Phase 1 security FR-3) |
 | `payment_method_update.enabled` | `true` | dunning grace period 中の更新動線 |
 | `invoice_history.enabled` | `true` | 顧客の請求履歴閲覧 (法定要求でなく利便性) |
@@ -96,25 +101,30 @@
 
 ### 3.3 アップ / ダウン API パターン (Phase 7 stripe-service.ts 拡張、本 PR は設計のみ)
 
-| 操作 | API 呼び出し | proration_behavior | end_behavior |
+#2683 代替案 D 採用に伴い、**アップ / ダウン共に即時実行 + Stripe proration を採用**する (Subscription Schedule は使用しない、同一 Product 内のみ機能するため別 Product 間では schedule API が `not_same_product` error)。
+
+| 操作 | API 呼び出し | proration_behavior | 説明 |
 |---|---|---|---|
-| **アップ即時** (standard → premium) | `subscriptions.update(subId, { items: [{ id, price: premium_monthly_id }], proration_behavior: 'always_invoice' })` | `'always_invoice'` (差額即時請求) | n/a |
-| **ダウン期末** (premium → standard) | `subscriptionSchedules.create({ from_subscription: subId, phases: [...] })` の phase 2 で `price: standard_monthly_id` | `'none'` | `'release'` |
-| **ダウン取消** (期末ダウン予約のキャンセル) | `subscriptionSchedules.release(scheduleId)` | n/a | n/a |
-| **差額表示** (Phase 3 hybrid confirm UI) | `invoices.createPreview({ subscription, subscription_details: { items: [...] }, subscription_proration_date })` | n/a | n/a |
+| **アップ即時** (standard → premium) | `subscriptions.update(subId, { items: [{ id, price: premium_monthly_id }], proration_behavior: 'always_invoice', proration_date })` | `'always_invoice'` (差額即時請求) | 未消費期間の standard 分を credit、premium 分を invoice → 差額即時請求 |
+| **ダウン即時 + proration credit (#2683)** | `subscriptions.update(subId, { items: [{ id, price: standard_monthly_id }], proration_behavior: 'always_invoice', proration_date })` | `'always_invoice'` (未消費 premium 分の credit memo 発行) | **Stripe が未消費期間を credit memo として自動発行 → 次回 invoice (翌月 standard ¥500) で控除** (Slack / Notion / Atlassian / Linear 等 50% SaaS 採用パターン) |
+| **ダウン取消** | n/a (#2683: subscription_schedule 不使用のため取消 API 不要) | n/a | 顧客は再度「アップ」操作で即時 premium 復帰、credit 残高は次回以降 invoice で控除継続 |
+| **差額表示** (Phase 3 hybrid confirm UI) | `invoices.createPreview({ subscription, subscription_details: { items: [...] }, subscription_proration_date })` | n/a | アップ時は差額即時請求額、ダウン時は credit memo 発行額 + 次回 invoice での控除見込み額を表示 |
 
-### 3.4 API version bump
+### 3.4 API version (#2683 訂正)
 
-| 項目 | 現行 | 新 |
+| 項目 | 値 | 根拠 |
 |---|---|---|
-| `src/lib/server/stripe/client.ts` の `STRIPE_API_VERSION` 定数 | `'2026-04-22.dahlia'` | `'2026-05-27.dahlia'` |
+| `src/lib/server/stripe/client.ts` の `STRIPE_API_VERSION` 定数 | **`'2026-04-22.dahlia'`** (現状維持) | **#2683 訂正**: `'2026-05-27.dahlia'` は Stripe **preview** リリース、本番非推奨 ([Stripe API versioning](https://docs.stripe.com/api/versioning) 公式: preview は backward incompatible change 評価用、production 採用は次の stable リリースを待つ)。本 PR では現行 `'2026-04-22.dahlia'` (stable 最新) を維持 |
 
-[Stripe 公式 API versioning](https://docs.stripe.com/api/versioning) より、dahlia 月次 bump は 72 時間 rollback window が確保される。本 PR で同梱する理由:
+**Phase 7 での扱い**:
 
-- Phase 7 で Webhook を新規作成する際の `default_api_version` と SDK の `apiVersion` を一致させるため (mismatch 時に webhook event の field 構造が異なり処理エラー)
-- 月次 bump は accumulate すると 6 ヶ月後の Epic 完遂時に 6 versions 分の breaking change を一度に飲む羽目になる
+- Phase 7 では SDK apiVersion は `'2026-04-22.dahlia'` (現行) のまま継続。bump しない
+- Stripe 公式の次回 stable 月次リリース (例: `'2026-06-XX.dahlia'`) が出次第、別 PR で bump 判断 (72 時間 rollback window 活用 + 副次制約 4 = Webhook destination immutable の 5 phase migration 整合、Phase 6 子 1 #2667 §5 整合)
+- 月次 bump を skip しても累積 breaking change の risk は Stripe `subscription_schedule.aborted` 等の新 event 購読時のみ顕在化、Phase 7 Step 4-a shadow mode で検出可能
 
-## 4. 副次制約 3 件 (Phase 1 設計時未拾い、本 PR で補強)
+> **#2683 訂正前後の差分**: 旧 docs (PR #2644 マージ済) は `'2026-05-27.dahlia'` を Phase 5 子 1 §3.4 で確定したが、Stripe 公式 API versioning の preview / stable 区別を見落としていた。**preview は production 採用非推奨** であり、Phase 7 Step 3 で本誤りに気付き次第 rollback → 現行 stable 維持が必要だった。本 PR (#2683) で事前に訂正し、Phase 7 着手時の re-work を回避。
+
+## 4. 副次制約 4 件 (#2683 で +1、Phase 1 設計時未拾い、本 PR で補強)
 
 ### 4.1 tax_behavior 一致 (Portal ダウン UI 表示条件)
 
@@ -129,83 +139,82 @@ Stripe 公式の change-price ドキュメントより:
 1. Stripe Dashboard で全 Price の tax_behavior が `inclusive` であることを Dashboard UI で目視確認
 2. テスト customer で Portal を開き、price update UI に 2 Price が両方表示されることを確認
 
-### 4.2 subscription_schedule 既存時の Portal ロック
+### 4.2 subscription_schedule 既存時の Portal ロック (#2683 で historical 化、scope 外に)
 
-Stripe 公式より:
+> **#2683 補強 (2026-05-30)**: 代替案 D (2 Product 各 1 Price) 採用 + ダウン即時 + Stripe proration credit パターン採用に伴い、本プロダクトは **subscription_schedule API を使用しない** (別 Product 間では schedule 機能不可、即時 update で完結)。よって本副次制約「subscription_schedule 既存時の Portal ロック」は**現行設計では発生しない** ため scope 外。
+>
+> Phase 6 子 5 #2665 ([phase6-rollback-and-kill-switches.md §6.3](phase6-rollback-and-kill-switches.md)) で確定済の `SUBSCRIPTION_PAGE_LABELS.cancelPendingRedirect` atom (Portal ロック誘導文言) も、本 PR (#2683) の代替案 D 採用により**不要化**する。Phase 7 Step 2-2 atom 統合実装時に同 atom 追加を skip + Phase 3 #2573 cancel-pending banner UI も削除判断 (本 PR 補強で Phase 6 子 5 への follow-up 連携必要)。
+>
+> historical record として旧設計 (1 Product 2 Price + Portal `schedule_at_period_end=true`) の仕様を残す: 当時は Portal でダウン予約後の再 Portal 操作で subscription update / cancel UI が非表示になる Stripe 公式制約を回避するため、自社 UI cancel-pending banner で誘導する設計だった。代替案 D で即時ダウン完結のため schedule 自体作成しない。
 
-> "Customers can't update or cancel subscriptions that currently have an update scheduled"
+### 4.3 subscription_schedule.aborted ベストプラクティス (#2683 で scope 縮小)
 
-→ 顧客が Portal で期末ダウングレード予約を作成した後、再度 Portal を開いても **subscription update / cancel の両方の UI が非表示** になる。顧客が「ダウン予約を取消したい」と思っても Portal から操作できない。
+> **#2683 補強 (2026-05-30)**: 代替案 D 採用に伴い、本プロダクトは subscription_schedule を使用しないため、`subscription_schedule.aborted` / `_canceled` / `_completed` 3 event 購読は **scope 外** とする。代わりに以下の event 購読のみで完結:
 
-**自社 UI 誘導 (Phase 3 連動)**:
+webhook 購読 event リスト (#2683 補強後、Phase 7 Dashboard 設定):
 
-`/admin/subscription` (Phase 1 補強 1 rename 後) に、subscription_schedule 存在検出ロジックを追加:
+- `customer.subscription.updated` (現行、必須)
+- `customer.subscription.deleted` (現行、必須)
+- `invoice.payment_succeeded` (アップ即時の差額請求成功確認、Phase 5 子 2 §3.1 整合)
+- `invoice.payment_failed` (dunning 連動、Phase 1 #2537)
+- `credit_note.created` (ダウン即時の credit memo 自動発行確認、Stripe `proration_behavior='always_invoice'` の副次効果)
 
-```
-if (hasActiveSchedule(subscription)) {
-  banner: "○月○日にスタンダードに切替 (期末ダウン予約中)"
-  CTA: "ダウン予約を取消" → POST /api/admin/subscription/cancel-pending
-}
-```
+旧 (1 Product 2 Price 案) で計画されていた `subscription_schedule.aborted` / `_canceled` / `_completed` 3 event は購読不要化。Phase 6 子 1 #2667 §3 Step 4 Webhook event 5 → 8 種拡張は **5 種維持** (新規 3 種 = `invoice.payment_succeeded` / `invoice.payment_failed` / `credit_note.created` に振替) として Phase 7 で実装。
 
-API 実装側 (Phase 7):
+### 4.4 Webhook destination api_version 不変性 (#2683 で新規追加、Phase 6 子 1 #2667 §5 Webhook 5 phase migration の根拠)
 
-```typescript
-// stripe-service.ts (Phase 7 で追加)
-export async function cancelPendingDowngrade(subscriptionId: string) {
-  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
-  if (subscription.schedule) {
-    await stripe.subscriptionSchedules.release(subscription.schedule as string);
-  }
-}
-```
+[Stripe 公式 webhook endpoints API](https://docs.stripe.com/api/webhook_endpoints/update) より:
 
-### 4.3 subscription_schedule.aborted ベストプラクティス
+> "**You can't change the `api_version` of an existing endpoint after it's created.** To use a different API version, create a new endpoint and migrate your integration."
 
-Stripe 公式より:
+→ Stripe Webhook destination の `api_version` は**作成後 immutable**。SDK apiVersion bump 時に既存 destination の `api_version` は変更不可、**新規 destination を作成 → cutover → 旧 destination delete** という 5 phase migration (Phase 6 子 1 #2667 §5 整合) が**実装手順として必須**。
 
-> "予期しないサブスクリプションの上書きを防ぐために、必ずベストプラクティスに従ってください"
+**本プロダクトでの影響 (Phase 7 Step 4 への根拠)**:
 
-主要 best practice (Phase 7 webhook 実装で反映):
+| 項目 | 内容 |
+|---|---|
+| **誤った想定** (本 PR 補強前) | 「SDK apiVersion bump = `client.ts` 1 行修正 + Stripe Dashboard 既存 destination の api_version を Dashboard UI で更新」(1 ステップ作業として誤認) |
+| **正しい手順** (#2683 補強で SSOT 化) | (1) Stripe Dashboard で新規 destination 作成 (新 api_version 指定) → (2) Phase 7 Step 4-a で新 endpoint route `/api/stripe/webhook-v2` を shadow mode で実装 (24-48h 検証) → (3) Step 4-b cutover (新 destination 有効化 + 旧 destination disabled) → (4) Step 4-c retire (cutover 後 1 週間 smoke test PASS で旧 destination delete) |
+| **#2683 で API version は維持判断** | 本 PR §3.4 で apiVersion = `'2026-04-22.dahlia'` 継続のため、Phase 7 では本副次制約は **次回 stable リリース (例: `'2026-06-XX.dahlia'`) 採用時の手順 SSOT** として機能 (次回 bump 時に 5 phase migration 必須) |
+| **本副次制約を見落とした場合のリスク** | apiVersion bump 時に新 destination 作成 skip → 既存 destination の api_version 旧版のまま → 新 event の field 構造変化を旧 SDK 期待値で解釈 → handler TypeError → 5 phase migration window (Phase 6 子 1 #2667 §5 整合) 喪失 |
 
-1. **`subscription_schedule.aborted` event を subscribe**: schedule が予期せず終了した場合の検知
-2. **subscription metadata に schedule_id を保存**: webhook event の整合性検証
-3. **Phase transition 時の冪等処理**: 同一 phase 開始 event が複数回到達した場合の二重課金回避
+**Phase 7 検証手順**:
 
-webhook 購読 event リストに追加 (Phase 7 Dashboard 設定):
+1. Phase 7 Step 4-a で新 destination を Stripe Dashboard で作成 (api_version = SDK 同期)
+2. Stripe API `webhookEndpoints.retrieve(endpointId)` で `api_version` field 確認 (immutable assert)
+3. 旧 destination の api_version 変更を試行 → Stripe API が `400 Bad Request` を返すことを Pre-Ready unit test で確認 (本副次制約の immutable assertion)
 
-- `customer.subscription.updated` (現行)
-- `customer.subscription.deleted` (現行)
-- `subscription_schedule.aborted` (**新規**)
-- `subscription_schedule.canceled` (**新規**)
-- `subscription_schedule.completed` (**新規**)
+**Phase 6 子 1 #2667 §5 Webhook 5 phase migration との整合**: 本副次制約 4 は Phase 6 子 1 で確定済の 5 phase migration (Stripe 公式 `migrate-snapshot-to-thin-events` 整合) の**直接の根拠** となる。「なぜ shadow mode → cutover → retire の 5 phase が必要か」の答えは「Webhook destination api_version が immutable だから新 destination 作成必須」である。本 PR 補強で SSOT 化することで Phase 7 実装者の誤認回避。
 
-## 5. Phase 7 実装手順 (8 step)
+> **#2683 補強の整合**: 本副次制約 4 は本 PR (#2683) で **新規 確定**。Phase 6 子 1 #2667 §5 Webhook 5 phase migration の実装根拠を補強する意味合いを持ち、Phase 6 子 1 SSOT との二重管理ではなく **「なぜ 5 phase migration が必須か = Stripe API 仕様」の根拠** を本 docs §4.4 で明文化する。Phase 7 Step 4 着手時に本 §4.4 を参照することで「destination 作成 skip」誤認を防ぐ。
+
+## 5. Phase 7 実装手順 (8 step、#2683 補強で 2 Product 構成 + ダウン即時に整合)
 
 本 PR は docs アーキ設計のみ。実コード変更は Phase 7 (#2531) で実施。手順は Phase 5 → 7 のハンドオフ仕様として確定。
 
 | Step | 作業 | 担当 | 検証 |
 |---|---|---|---|
-| 1 | **Test mode** Dashboard で新 Product + 2 Price (`standard_monthly` / `premium_monthly` lookup_key、`inclusive` 税込) + Portal config + Webhook (`disabled`) 作成 | PO 手動 (#2627) | Dashboard UI で目視 + Stripe CLI `stripe products list` |
-| 2 | Phase 5 子 1 PR (本 PR、lookup_key 参照 + apiVersion bump コード変更含む統合 PR) を draft 起票 — **本 PR は docs のみ、コード変更は Phase 7 統合 PR で実施** | Dev | docs 設計確定 |
-| 3 | Test clock シナリオ E2E 計画 (E2E spec 3 種: upgrade / downgrade / cancel-pending、Phase 7 新規作成予定) | Dev | tests 追加計画ドキュメント |
-| 4 | Phase 5 子 1 マージ (本 PR、docs アーキ確定) | Dev | QM Approve |
-| 5 | **Production mode** Dashboard で同じ Product / 2 Price / Portal config / Webhook (`disabled`) 作成 | PO 手動 (#2627) | Dashboard UI で目視 |
-| 6 | Phase 7 統合 PR マージ (UI rename (#2567-2575) + Phase 3 hybrid confirm (#2573) + lookup_key コード切替 + apiVersion bump + 新 webhook event 購読) | Dev | E2E + smoke test |
+| 1 | **Test mode** Dashboard で 2 Product (`prod_STANDARD` + `prod_PREMIUM`) 各 1 Price (`standard_monthly` / `premium_monthly` lookup_key、`inclusive` 税込) + Portal config (`subscription_update.products` に 2 entries) + Webhook (`disabled`) 作成 (#2683 代替案 D) | PO 手動 (#2627) | Dashboard UI で目視 + Stripe CLI `stripe products list` + Test mode test_clock customer で Portal "Change plan" UI に 2 Product 表示確認 |
+| 2 | Phase 5 子 1 PR (本 PR、lookup_key 参照含む統合 PR) を draft 起票 — **本 PR は docs のみ、コード変更は Phase 7 統合 PR で実施** | Dev | docs 設計確定 |
+| 3 | Test clock シナリオ E2E 計画 (E2E spec 2 種: アップ即時 / ダウン即時 + credit memo、Phase 7 で新規作成 — Phase 6 子 2 #2674 §6 シナリオ 2+3 整合) | Dev | tests 追加計画ドキュメント |
+| 4 | Phase 5 子 1 マージ (本 PR、docs アーキ確定) + 補強 PR #2683 マージ (代替案 D + API ver 訂正 + 副次制約 4) | Dev | QM Approve |
+| 5 | **Production mode** Dashboard で同じ 2 Product / 各 1 Price / Portal config / Webhook (`disabled`) 作成 | PO 手動 (#2627) | Dashboard UI で目視 |
+| 6 | Phase 7 統合 PR マージ (UI rename (#2567-2575) + Phase 3 hybrid confirm (#2573) + lookup_key コード切替 + 5 webhook event 購読 (`customer.subscription.*` 2 + `invoice.payment_*` 2 + `credit_note.created` 1、#2683 §4.3 整合)) | Dev | E2E + smoke test |
 | 7 | 旧 4 Price archive、旧 Webhook disable | PO 手動 | Dashboard UI |
 | 8 | 1 週間 smoke test → 旧 env var (`STRIPE_PRICE_*`) を CDK 設定 (infra 配下 cdk.json) / GitHub Secrets から削除 | Dev | CDK diff + deploy |
 
-## 6. テスト計画 (Phase 7 一括実行)
+## 6. テスト計画 (Phase 7 一括実行、#2683 補強で 2 Product 構成 + ダウン即時 + credit memo に整合)
 
-| カテゴリ | テスト内容 | ファイル (Phase 7 新規作成予定) | 実行 phase |
+| カテゴリ | テスト内容 | ファイル (Phase 7 で新規実装) | 実行 phase |
 |---|---|---|---|
-| **Test clock E2E** | アップ即時 (standard → premium) で proration 差額が即時請求される | E2E billing spec ディレクトリ配下 upgrade-immediate spec (Phase 7 新規) | Phase 7 |
-| **Test clock E2E** | ダウン期末 (premium → standard) で期末まで premium capability 維持、期末に standard 適用 | E2E billing spec ディレクトリ配下 downgrade-at-period-end spec (Phase 7 新規) | Phase 7 |
-| **Test clock E2E** | ダウン予約中の Portal 操作ロック検出 + 自社 UI cancel-pending 経由解除 | E2E billing spec ディレクトリ配下 cancel-pending-downgrade spec (Phase 7 新規) | Phase 7 |
+| **Test clock E2E** | アップ即時 (standard → premium) で proration 差額が即時請求される + capability 即時解放 | E2E billing spec ディレクトリ配下 upgrade-immediate spec (Phase 7 新規) | Phase 7 |
+| **Test clock E2E** (#2683) | **ダウン即時 (premium → standard) で Stripe credit memo 自動発行 + 次回 invoice 控除** (旧: 期末ダウン) | E2E billing spec ディレクトリ配下 downgrade-immediate-with-credit spec (Phase 7 新規、#2683 代替案 D) | Phase 7 |
+| **Test clock E2E** | 2 Product 間 Portal 操作 (Customer Portal "Change plan" UI で standard ↔ premium 切替) | E2E billing spec ディレクトリ配下 portal-2product-switch spec (Phase 7 新規、#2683 §3.2 検証) | Phase 7 |
 | **unit test** | lookup_key 解決ロジック (`getPlans()` rewrite) で Stripe API mock | unit テスト ディレクトリ (stripe 配下) config test 拡張 (Phase 7) | Phase 7 |
-| **unit test** | apiVersion `2026-05-27.dahlia` 設定の確認 | unit テスト ディレクトリ (stripe 配下) client test 新規 (Phase 7) | Phase 7 |
-| **integration** | webhook `subscription_schedule.aborted` 受信時の DB 反映 | integration テスト ディレクトリ (stripe 配下) webhook-schedule-aborted test 新規 (Phase 7) | Phase 7 |
-| **Storybook (Phase 3 #2573)** | hybrid confirm UI で Preview API 結果表示 (upgrade / downgrade variant) | src/lib/features/admin/ 配下 SubscriptionConfirmModal stories 新規 (Phase 3 #2573 連動) | Phase 7 |
+| **unit test** (#2683) | apiVersion `'2026-04-22.dahlia'` 設定の確認 (preview `'2026-05-27.dahlia'` 使用禁止 assert) | unit テスト ディレクトリ (stripe 配下) client test 新規 (Phase 7) | Phase 7 |
+| **integration** (#2683) | webhook `credit_note.created` 受信時の DB 反映 (ダウン即時の credit memo 監査) | integration テスト ディレクトリ (stripe 配下) webhook-credit-note test 新規 (Phase 7) | Phase 7 |
+| **integration** (#2683) | Webhook destination api_version immutable 確認 (Stripe API `webhookEndpoints.update({api_version})` が 400 を返す assert、副次制約 4 検証) | integration テスト ディレクトリ (stripe 配下) webhook-api-version-immutable test 新規 (Phase 7) | Phase 7 |
+| **Storybook (Phase 3 #2573)** | hybrid confirm UI で Preview API 結果表示 (アップ即時 / ダウン即時 + credit memo variant) | src/lib/features/admin/ 配下 SubscriptionConfirmModal stories 新規 (Phase 3 #2573 連動) | Phase 7 |
 
 ## 7. 影響範囲事後検証 (4 layer impact-analysis)
 
@@ -253,17 +262,19 @@ webhook 購読 event リストに追加 (Phase 7 Dashboard 設定):
 | 20 | 過去 PR / commit / Issue / ADR | 検索性のため更新しない |
 | 21 | audit log | なし (現在 active subscription 0 件) |
 
-## 8. 想定リスク + ロールバック
+## 8. 想定リスク + ロールバック (#2683 補強で +1 = R8、R3 / R5 / R7 訂正)
 
 | # | リスク | 対策 | ロールバック |
 |---|---|---|---|
 | R1 | Phase 7 マージ前に新 Webhook 有効化 → 旧 handler 404 | Phase 7 マージまで Webhook `disabled` で作成 (Step 1, 5) | Webhook disable のまま放置 (旧 Webhook が working 継続) |
 | R2 | tax_behavior 不一致 → Portal ダウン UI 非表示 | Dashboard 作成時 `inclusive` で統一、Step 1 検証手順で目視確認 | Price 再作成 (immutable のため archive + 新規) |
-| R3 | 顧客が subscription_schedule 作成済で Portal 再操作 → 反応しない (Stripe 仕様) | 自社 UI 誘導 (副次制約 4.2、Phase 3 #2573 連動) | 仕様、回避不能。自社 UI 誘導が唯一の解 |
+| ~~R3~~ (#2683 で historical 化) | ~~顧客が subscription_schedule 作成済で Portal 再操作 → 反応しない (Stripe 仕様)~~ | **代替案 D で schedule API 不使用、本リスクは scope 外** (即時ダウン + credit memo パターンに変更、§4.2 historical record 参照) | n/a |
 | R4 | lookup_key 解決 Stripe API 障害 → アプリ起動失敗 | env var フォールバック (段階移行: Phase 7 step 6 で lookup_key + env var 両対応、Step 8 で env var 削除) | env var 直読の旧コードに revert |
-| R5 | Webhook API version vs SDK apiVersion 乖離 | Dashboard Webhook 作成時 `2026-05-27.dahlia` 明示、SDK も同バージョンに bump | Dashboard Webhook の API version を SDK と一致するまで stage 戻し |
+| ~~R5~~ (#2683 で訂正) | ~~Webhook API version vs SDK apiVersion 乖離 (preview `2026-05-27.dahlia` 採用想定)~~ | **API version は現行 `'2026-04-22.dahlia'` stable 維持 (本 PR §3.4 訂正)、本リスクは Phase 7 では発生しない** | n/a |
 | R6 | 旧 4 Price archive 後に active subscription が残存 → 請求継続失敗 | Phase 1 補強 2 Open question 4 で「active subscription 0 件」を PO 確定済。Phase 7 step 7 直前に再確認手順を追加 | 旧 Price un-archive (Stripe API で再有効化) |
-| R7 | apiVersion bump で Stripe Webhook event の field 構造変化 → 既存 handler 破壊 | Stripe Changelog `2026-04-22.dahlia` → `2026-05-27.dahlia` の差分を Phase 7 PR で精査、breaking change 該当箇所を webhook handler に反映 | apiVersion を旧版に revert (72 時間 rollback window 内) |
+| ~~R7~~ (#2683 で historical 化) | ~~apiVersion bump で Stripe Webhook event の field 構造変化~~ | **API version 現行維持のため bump なし、本リスク Phase 7 では発生しない**。次回 stable リリース採用時に再評価 | n/a |
+| **R8 (新規 #2683)** | **ダウン即時 + Stripe proration credit でユーザーに過大返金または credit 残高蓄積 (Stripe `proration_behavior='always_invoice'` の標準動作だが、顧客が credit 残高を把握できない場合の信頼毀損)** | **Phase 3 hybrid confirm UI で「ダウン時の credit memo 発行額 + 次回 invoice 控除見込み額」を必ず表示 (Phase 5 子 2 #2640 §6 Preview API パターン整合)。`/admin/subscription` の請求履歴セクションで credit memo の発行・消化を顧客に可視化** | Stripe Dashboard で credit memo 手動 void (Pre-PMF active subscription 0 件のため実害なし) |
+| **R9 (新規 #2683)** | **Webhook destination api_version immutable を Phase 7 着手時に見落とす → 次回 apiVersion bump 時に既存 destination の api_version を Dashboard UI で更新試行 → Stripe API 400 → cutover blocker** | **本 PR §4.4 副次制約 4 で SSOT 化 + Phase 6 子 1 #2667 §5 Webhook 5 phase migration 整合 + Pre-Ready unit test で immutable assert (Stripe API mock で `webhookEndpoints.update({api_version})` が 400 を返すことを確認)** | 新 destination 作成 + shadow mode (Phase 6 子 1 #2667 §3 Step 4-a) で復旧 |
 
 ## 9. ADR 起票推奨
 
@@ -292,19 +303,19 @@ webhook 購読 event リストに追加 (Phase 7 Dashboard 設定):
 | 4 | **security (adversarial)** | webhook 新規購読 event 3 種 (`product.created` / `price.created` / `price.updated`) を Dashboard で購読する際、handler 不備時 (未実装 endpoint / 404 / 5xx) の fail-safe をどう設計するか?Stripe 側自動 retry (24h) で再送、その間 priceId 切替がトリガできず stale state が滞留するリスク | Phase 7 で 3 種 handler を最低限 no-op (200 OK + Sentry alert) で実装し、24h retry window 内に観測 → 修正可能化する。Dashboard 購読は handler 実装後に有効化 (順序逆転禁止) | Phase 7 webhook 実装時に確定 |
 | 5 | **security (adversarial)** | lookup_key で旧 Price → 新 Price へ切替える際、旧 priceId は immutable のため archive のみ可能。Phase 7 step 6 (新 Price 有効) → step 7 (旧 archive) の間に、active subscription が旧 priceId を参照する状態と新 priceId 参照する webhook event が同時到達する可能性。冪等性 (idempotency) はどう設計するか? | (a) DB 側で `tenants.stripePriceId` の更新は webhook の `event.id` で重複検出 (Stripe `event.id` の 24h idempotency 保証を活用), (b) 二重 priceId 期間中 (step 6→7、1 週間 smoke test) は both lookup_key 解決可能化 (lookup_key の transfer 経由)、(c) Phase 1 補強 2 Open question 4「active subscription 0 件」確定により実害ゼロだが、PMF 後再評価必要 | Phase 7 webhook 実装時に確定 + ADR-0010 Pre-PMF Bucket A (課金) 整合確認 |
 
-## 11. 既存実装の現状と変更点 (delta、2026-05-29 検証)
+## 11. 既存実装の現状と変更点 (delta、2026-05-30 #2683 補強後)
 
 | # | 既存実装 (シンボル参照) | 本要件 | 扱い |
 |---|---|---|---|
 | 1 | env var 直読 `process.env.STRIPE_PRICE_*` (`src/lib/server/stripe/config.ts` の `STRIPE_PRICES` 定数定義箇所) | `prices.list({ lookup_keys: ['standard_monthly', 'premium_monthly'] })` 経由 | **変更** (Phase 7、本 PR は設計のみ) |
-| 2 | apiVersion `'2026-04-22.dahlia'` (`src/lib/server/stripe/client.ts` の `STRIPE_API_VERSION` 定数) | `'2026-05-27.dahlia'` | **変更** (Phase 7、本 PR は設計のみ) |
-| 3 | 4 種別 plan config (MONTHLY / YEARLY / FAMILY_MONTHLY / FAMILY_YEARLY、`src/lib/server/stripe/config.ts` の `STRIPE_PRICES` 定数全体) | 2 種別 (standard_monthly / premium_monthly) | **変更** (Phase 1 補強 2 連動、Phase 7 で同時実施) |
-| 4 | `docs/guides/stripe-setup-guide.md` 4 商品手動作成手順 (Step 3-2 〜 3-5) | 1 Product 2 Price + lookup_key 手順 | **変更** (Phase 7、本 PR は設計のみ) |
-| 5 | webhook 購読 event 5 種 (`docs/guides/stripe-setup-guide.md` Step 5) | 8 種 (`subscription_schedule.*` 3 種追加) | **変更** (Phase 7、本 PR は設計のみ) |
-| 6 | Customer Portal 設定 (`docs/guides/stripe-setup-guide.md` Step 4 簡易記載) | §3.2 の 11 項目詳細設定 | **変更** (Phase 7、本 PR は設計のみ) |
-| 7 | `src/lib/server/services/stripe-service.ts` の `createCheckoutSession` 関数 | `subscriptions.update` + `subscriptionSchedules.create/release` パターン拡張 | **拡張** (Phase 1 plan-change FR-3/FR-4 整合、Phase 7 実装) |
+| 2 (#2683 訂正) | apiVersion `'2026-04-22.dahlia'` (`src/lib/server/stripe/client.ts` の `STRIPE_API_VERSION` 定数) | **`'2026-04-22.dahlia'` 維持** (preview `'2026-05-27.dahlia'` 不採用、本 PR §3.4 訂正) | **継続** (Phase 7 でも維持、次回 stable リリース採用時に再評価) |
+| 3 (#2683 補強) | 4 種別 plan config (MONTHLY / YEARLY / FAMILY_MONTHLY / FAMILY_YEARLY、`src/lib/server/stripe/config.ts` の `STRIPE_PRICES` 定数全体) | 2 種別 (`standard_monthly` / `premium_monthly`)、Stripe Dashboard 側は **2 Product 各 1 Price** (`prod_STANDARD` + `prod_PREMIUM`、代替案 D) | **変更** (Phase 1 補強 2 + #2683 連動、Phase 7 で同時実施) |
+| 4 (#2683 補強) | `docs/guides/stripe-setup-guide.md` 4 商品手動作成手順 (Step 3-2 〜 3-5) | **2 Product 各 1 Price + lookup_key 手順** (代替案 D)、Portal `subscription_update.products` に 2 entries 設定手順 | **変更** (Phase 7、本 PR は設計のみ) |
+| 5 (#2683 訂正) | webhook 購読 event 5 種 (`docs/guides/stripe-setup-guide.md` Step 5) | 5 種維持 (`customer.subscription.updated` / `_deleted` / `invoice.payment_succeeded` / `_failed` / **`credit_note.created` (新規 #2683)**)、旧計画の `subscription_schedule.*` 3 種は scope 外 (本 PR §4.3 整合) | **変更** (Phase 7、本 PR は設計のみ) |
+| 6 (#2683 補強) | Customer Portal 設定 (`docs/guides/stripe-setup-guide.md` Step 4 簡易記載) | §3.2 の 12 項目詳細設定 (`subscription_update.products` に 2 entries + `proration_behavior='always_invoice'` + `schedule_at_period_end` 撤去) | **変更** (Phase 7、本 PR は設計のみ) |
+| 7 (#2683 補強) | `src/lib/server/services/stripe-service.ts` の `createCheckoutSession` 関数 | `subscriptions.update` で **アップ即時 + ダウン即時 + Stripe proration credit (`always_invoice`) パターン**、Subscription Schedule API 不使用 | **拡張** (Phase 1 plan-change FR-3 整合 + Phase 5 子 2 #2640 整合、Phase 7 実装) |
 
-シンボル位置は 2026-05-29 検証済 (行番号は Phase 7 実装で陳腐化するためシンボル名・関数名・定数名でのみ参照)。
+シンボル位置は 2026-05-30 #2683 補強で再検証済 (行番号は Phase 7 実装で陳腐化するためシンボル名・関数名・定数名でのみ参照)。
 
 ## 12. 関連 (2026-05-29 整合)
 

--- a/docs/design/billing-redesign/phase6-context-decisions-6.md
+++ b/docs/design/billing-redesign/phase6-context-decisions-6.md
@@ -1,14 +1,14 @@
-# Phase 1 補強 1 文脈判断 6 件 + lookup_key 段階移行 + API version bump SSOT (Epic #2525 Phase 6 子 4)
+# Phase 1 補強 1 文脈判断 6 件 + lookup_key 段階移行 + API version 維持判断 SSOT (Epic #2525 Phase 6 子 4、#2683 補強)
 
 | 項目 | 内容 |
 |------|------|
-| 孫 issue | #2664 (Phase 6 グループ B 並列) |
+| 孫 issue | #2664 (Phase 6 グループ B 並列) / #2683 (補強 — API version `2026-04-22.dahlia` 維持判断 + 副次制約 4 連動) |
 | 親 | Phase 6 親 (#2660) / Epic #2525 |
-| 前提 | Phase 1 補強 1 ([phase1-naming-url-integrity-requirements](phase1-naming-url-integrity-requirements.md)) Open question 5 件 / Phase 5 子 1 ([phase5-stripe-product-architecture](phase5-stripe-product-architecture.md)) Step 3 lookup_key + Step 3 API version bump |
+| 前提 | Phase 1 補強 1 ([phase1-naming-url-integrity-requirements](phase1-naming-url-integrity-requirements.md)) Open question 5 件 / Phase 5 子 1 ([phase5-stripe-product-architecture](phase5-stripe-product-architecture.md)) Step 3 lookup_key (#2683 で 2 Product 各 1 Price 構成に変更) + API version `'2026-04-22.dahlia'` 維持 (#2683 訂正) |
 | 並列対象 | Phase 6 子 2 (#2662 Test clock) / 子 3 (#2663 DB migration script) |
 | 連動 (Phase 7) | Phase 6 子 1 ([phase6-phase7-execution-ssot](phase6-phase7-execution-ssot.md)) Step 3 / Stripe Dashboard #2627 / 実装 PR #2531 |
-| ステータス | 設計確定 (本 PR で SSOT 化、コード変更は Phase 7) |
-| 起点 | Phase 1 補強 1 で「文脈判断 6 件」と確定された個別判断を、推奨案 + 業界根拠 + PO 判断票で SSOT 化 + lookup_key 段階移行 4 step + API version bump 72h rollback monitoring を確定する |
+| ステータス | 設計確定 (本 PR で SSOT 化、コード変更は Phase 7) / **2026-05-30 補強 #2683: API version 維持判断 + Webhook immutable 副次制約 4 を本 docs から phase5 子 1 §4.4 へ参照集約** |
+| 起点 | Phase 1 補強 1 で「文脈判断 6 件」と確定された個別判断を、推奨案 + 業界根拠 + PO 判断票で SSOT 化 + lookup_key 段階移行 4 step + **API version 維持判断 (`'2026-04-22.dahlia'`)** + 72h rollback window 監視計画 (将来の stable bump 時に発動) を確定する |
 
 > **位置づけ**: Phase 6 グループ B 並列子 (子 2 Test clock / 子 3 DB migration script と独立)。Phase 1 補強 1 で「Open question 5 件 + FR-5 残対象 6 件」として明文化された個別判断を、Phase 5 子 1 の lookup_key + API version bump 戦略と統合し、Phase 7 統合 PR 5 step (子 1 SSOT) Step 3 + Step 5 で参照される PO 判断票 + 実装手順 SSOT として確定する。
 
@@ -31,9 +31,13 @@ Phase 1 補強 1 ([phase1-naming-url-integrity-requirements](phase1-naming-url-i
 
 Phase 5 子 1 §3.4 で lookup_key 経由参照を確定したが、**旧 env var (`STRIPE_PRICE_*` 4 件) から新 lookup_key (`standard_monthly` / `premium_monthly` 2 件) への切替手順**が docs 化されていない。Stripe 公式 [manage-prices](https://docs.stripe.com/products-prices/manage-prices) は `transfer_lookup_key` API による段階移行を推奨するが、本プロダクトでの適用手順 (caching layer / feature flag / 並行運用期間) が散在している。
 
-### 1.3 課題: Stripe API version bump (`2026-04-22.dahlia` → `2026-05-27.dahlia`) の 72h rollback window 活用手順が docs 化されていない
+### 1.3 課題: Stripe API version 維持判断 (#2683 訂正) と将来 bump 時の 5 phase migration 必須性
 
-Phase 5 子 1 §3.4 で API version bump を確定したが、`src/lib/server/stripe/client.ts` の `STRIPE_API_VERSION` 定数 1 行修正だけでは不十分で、(a) Webhook destination の API version 同期 (Stripe Dashboard #2627)、(b) Stripe Changelog `2026-04-22.dahlia` → `2026-05-27.dahlia` の breaking change 全件確認、(c) 72h rollback window 監視計画 (Sentry / Discord alert thresholds) が docs 化されていない。
+> **#2683 補強 (2026-05-30、訂正)**: 旧設計 (本 docs 元版) では `'2026-04-22.dahlia'` → `'2026-05-27.dahlia'` への bump を採用候補としていたが、Stripe 公式 [API versioning](https://docs.stripe.com/api/versioning) を再確認した結果、`'2026-05-27.dahlia'` は **preview リリース** (production 非推奨、backward incompatible change の評価用) であることが判明。本プロダクトは**現行 stable `'2026-04-22.dahlia'` を維持** ([phase5-stripe-product-architecture.md §3.4](phase5-stripe-product-architecture.md) #2683 訂正)、次回 stable 月次リリース (例: `'2026-06-XX.dahlia'`) が公開され次第、別 PR で bump 判断する。
+
+**将来の stable apiVersion bump 時の必須手順** (本 docs SSOT、Phase 7 着手時には bump なしのため使用しないが、将来の発動準備):
+
+`src/lib/server/stripe/client.ts` の `STRIPE_API_VERSION` 定数 1 行修正だけでは不十分で、副次制約 4 (Webhook destination api_version immutable、[phase5-stripe-product-architecture.md §4.4](phase5-stripe-product-architecture.md)) により**新規 destination 作成 → cutover → 旧 delete の 5 phase migration が強制必須**。具体的に: (a) Webhook destination の API version は immutable のため**新規作成必須** (Stripe Dashboard #2627)、(b) Stripe Changelog `'2026-04-22.dahlia'` → 新 stable バージョンの breaking change 全件確認、(c) 72h rollback window 監視計画 (Sentry / Discord alert thresholds) を本 docs §5 で SSOT 化。
 
 ### 1.4 設計がなかった場合に何が困るか
 
@@ -197,51 +201,51 @@ Phase 6 子 1 SSOT §5.3 で確定した 2 feature flag (`USE_LOOKUP_KEY` / `STR
 
 Phase 1 補強 2 Open question 4「active subscription 0 件」が PO 確定済 (Pre-PMF stage で実 customer 不在) のため、旧 Price archive 後の請求継続失敗リスクはゼロ。Phase 7 統合 PR Step 5 直前に PO が再確認する手順を子 1 SSOT §3 Step 5 AC (d) に組込済。
 
-## 5. Stripe API version bump 手順 + 72h rollback monitoring
+## 5. Stripe API version 維持判断 + 将来 bump 時の 5 phase migration 手順 (#2683 訂正)
 
-Phase 5 子 1 §3.4 で確定した apiVersion bump (`2026-04-22.dahlia` → `2026-05-27.dahlia`) を、Stripe 公式 [api/versioning](https://docs.stripe.com/api/versioning) の 72h rollback window 活用手順で実施する。Phase 7 統合 PR Step 3 (子 1 SSOT) で実装。
+> **#2683 補強 (2026-05-30)**: Phase 7 統合 PR では apiVersion = `'2026-04-22.dahlia'` (stable 最新) **維持判断** ([phase5-stripe-product-architecture.md §3.4](phase5-stripe-product-architecture.md) #2683 訂正)。`'2026-05-27.dahlia'` は preview リリースで production 非推奨のため不採用。次回 stable リリース採用時の手順を本 §5 で SSOT 化 (将来の発動準備)。
 
-### 5.1 4 step 順序
+### 5.1 4 step 順序 (将来の stable apiVersion bump 時に発動)
 
 | Step | 工程 | 検証 |
 |---|---|---|
-| **1. Changelog breaking change 全件確認** | Stripe Changelog `2026-04-22.dahlia` → `2026-05-27.dahlia` の差分を精査、webhook event の field 構造変化 / API request schema 変化 / response field rename 等を全件リスト化 | リスト化結果を本 docs §5.4 に追記 (Phase 7 着手時) |
-| **2. Webhook destination 同期** | Stripe Dashboard #2627 領域 C (Test mode) + F (Production mode) で Webhook destination の API version を `2026-05-27.dahlia` に bump | Dashboard UI で目視 |
-| **3. SDK 1 行修正 + smoke test** | `src/lib/server/stripe/client.ts` L7 `STRIPE_API_VERSION = '2026-05-27.dahlia'` に変更、Test mode で checkout / portal / webhook の 3 経路を smoke test | unit test (Phase 7 新規 client.test.ts) + Test clock E2E (Phase 6 子 2 #2662 SSOT) |
+| **1. Changelog breaking change 全件確認** | Stripe Changelog `'2026-04-22.dahlia'` → 新 stable バージョンの差分を精査、webhook event の field 構造変化 / API request schema 変化 / response field rename 等を全件リスト化 | リスト化結果を本 docs §5.4 に追記 (apiVersion bump PR 着手時) |
+| **2. Webhook destination 新規作成** (副次制約 4 #2683) | 副次制約 4 (Webhook destination api_version immutable、[phase5-stripe-product-architecture.md §4.4](phase5-stripe-product-architecture.md)) により**既存 destination の api_version 変更不可** → Stripe Dashboard #2627 領域 C (Test mode) + F (Production mode) で**新規 destination を新 api_version で作成** ([phase6-phase7-execution-ssot.md §5 Webhook 5 phase migration](phase6-phase7-execution-ssot.md) と同型) | Dashboard UI で目視 + Stripe API `webhookEndpoints.retrieve` で `api_version` field 確認 |
+| **3. SDK 1 行修正 + 5 phase shadow → cutover → retire** | `src/lib/server/stripe/client.ts` の `STRIPE_API_VERSION` 定数を新 stable バージョンに変更、Phase 6 子 1 #2667 §5 Webhook 5 phase migration と同型で shadow mode → cutover → retire (旧 destination delete) | unit test (apiVersion bump PR で新規 client.test.ts 拡張) + Test clock E2E (Phase 6 子 2 #2662 SSOT) |
 | **4. 72h 監視** (Sentry / Discord alert) | Step 3 cutover 後 72h 以内に Sentry error rate / Stripe webhook handler エラー / Discord alert を監視、breaking change 漏れによる incident を検知 | Sentry dashboard / Discord channel 監視 |
 
-### 5.2 72h rollback window 監視計画
+### 5.2 72h rollback window 監視計画 (将来の stable apiVersion bump 時に発動)
 
-Stripe 公式 [api/versioning](https://docs.stripe.com/api/versioning) より、apiVersion bump 後 72h 以内であれば Dashboard で旧 apiVersion に巻き戻し可能。本プロダクトの監視 threshold:
+Stripe 公式 [api/versioning](https://docs.stripe.com/api/versioning) より、apiVersion bump 後 72h 以内であれば Dashboard で旧 apiVersion に巻き戻し可能。ただし副次制約 4 (Webhook destination api_version immutable、#2683) により Dashboard 側は新 destination 作成 + 旧 destination 再有効化のセット、SDK 側は revert PR 即時 merge となる。本プロダクトの監視 threshold:
 
 | metric | threshold | 検出時の対応 |
 |---|---|---|
 | Sentry error rate (Stripe SDK 由来) | > 0.5% / 1 hour | Discord alert + 1 名以上の Dev エンジニアに通知 |
-| Stripe webhook handler エラー率 | > 1% / 1 hour | apiVersion 即時 rollback (Stripe Dashboard で旧 `2026-04-22.dahlia` に戻し) + SDK 側も revert |
+| Stripe webhook handler エラー率 | > 1% / 1 hour | apiVersion 即時 rollback (Stripe Dashboard で旧 destination 再有効化 + 新 destination 即時 disabled、副次制約 4 整合) + SDK 側も旧 stable バージョン `'2026-04-22.dahlia'` に revert |
 | Stripe webhook silent drop (Phase 5 子 3 dedup table 経由検出) | > 0 件 / 24 hour | apiVersion bump とは独立だが、Phase 7 Step 4-a shadow mode (子 1 SSOT) と重ねて検証 |
 | customer inquiry (Discord / メール) | > 3 件 / 24 hour | PO 判断で rollback 実施 |
 
-### 5.3 Webhook destination の API version 同期 (Step 2 詳細)
+### 5.3 Webhook destination の api_version immutable (#2683 副次制約 4、Step 2 詳細)
 
-Phase 5 子 1 R5「Webhook API version vs SDK apiVersion 乖離」と統合。Stripe Dashboard #2627 領域 C / F で:
+副次制約 4 ([phase5-stripe-product-architecture.md §4.4](phase5-stripe-product-architecture.md) #2683)「Webhook destination api_version 不変性」により、Stripe Dashboard #2627 領域 C / F で:
 
-- **Test mode (領域 C)**: Webhook destination 新規作成時に `default_api_version: '2026-05-27.dahlia'` を明示
-- **Production mode (領域 F)**: 旧 destination の API version も同期 (cutover 時に旧 / 新両方が `2026-05-27.dahlia` で動作する状態を担保)
+- **Test mode (領域 C)**: Webhook destination **新規作成時**に `default_api_version: <新 stable バージョン>` を明示。既存 destination の api_version を Dashboard UI で変更しようとすると Stripe API が `400 Bad Request` を返す (#2683 副次制約 4 検証手順)
+- **Production mode (領域 F)**: 旧 destination とは別の新 destination を新 api_version で作成、5 phase migration (shadow → cutover → retire、[phase6-phase7-execution-ssot.md §5](phase6-phase7-execution-ssot.md)) で cutover
 
 Dashboard 操作は PO 手動 (#2627)、本 PR では手順 SSOT のみ確定。
 
-### 5.4 Changelog breaking change 確認結果 (Phase 7 着手時に追記)
+### 5.4 Changelog breaking change 確認結果 (将来の stable apiVersion bump 時に追記)
 
-`docs.stripe.com/changelog/dahlia/2026-05-27` を確認後、breaking change を本節に列挙する。本 PR 時点では確認未完了 (Phase 7 着手時の Dev タスク)。確認項目:
+Phase 7 では apiVersion bump なし (`'2026-04-22.dahlia'` 維持、#2683 訂正)。将来の次回 stable リリース採用 PR 着手時、`docs.stripe.com/changelog/dahlia/<新 stable>` を確認後、breaking change を本節に列挙する。確認項目:
 
 | カテゴリ | 確認内容 |
 |---|---|
-| webhook event field 構造 | `subscription_schedule.aborted` / `_canceled` / `_completed` (Phase 5 子 1 §4.3 で新規購読対象) の field 変化 |
-| API request schema | `subscriptions.update` / `subscriptionSchedules.create` / `prices.list` の request schema 変化 |
-| API response field | `subscription.schedule` / `subscription.items.data[].price` 等の field rename |
+| webhook event field 構造 | 新規購読 event の field 変化 (Phase 7 Step 4 で 5 event 購読対象、`customer.subscription.*` / `invoice.payment_*` / `credit_note.created`、#2683 訂正) |
+| API request schema | `subscriptions.update` / `prices.list` の request schema 変化 |
+| API response field | `subscription.items.data[].price` 等の field rename |
 | TypeScript 型定義 | `stripe-node` 最新版で apiVersion 整合性確認 |
 
-**Phase 7 着手時 AC**: 本節 §5.4 を埋めずに Phase 7 Step 3 着手禁止 (子 1 SSOT §3 Step 3 ロールバック判断基準 (b) 整合)。
+**将来の apiVersion bump PR 着手時 AC**: 本節 §5.4 を埋めずに当該 PR 着手禁止 (子 1 SSOT §3 Step 3 ロールバック判断基準 (b) 整合)。
 
 ## 6. impact-analysis 4 layer 防御 + 21 カテゴリ checklist
 

--- a/docs/design/billing-redesign/phase6-phase7-execution-ssot.md
+++ b/docs/design/billing-redesign/phase6-phase7-execution-ssot.md
@@ -1,13 +1,13 @@
-# Phase 7 統合 PR 実行手順 SSOT — Stripe webhook 5 phase migration 整合 (Epic #2525 Phase 6 子 1)
+# Phase 7 統合 PR 実行手順 SSOT — Stripe webhook 5 phase migration 整合 (Epic #2525 Phase 6 子 1、#2683 補強)
 
 | 項目 | 内容 |
 |------|------|
-| 孫 issue | #2661 (Phase 6 グループ A 最優先) |
+| 孫 issue | #2661 (Phase 6 グループ A 最優先) / #2683 (補強 — 2 Product 構成 + API ver 訂正 + 副次制約 4 反映) |
 | 親 | Phase 6 親 (Phase 5 → Phase 7 橋渡し SSOT) / Epic #2525 |
-| 上位 (Phase 5) | #2639 (子 1 Stripe Product / Price) / #2640 (子 2 proration) / #2641 (子 3 webhook 冪等性) / #2642 (子 4 archive 統合) / #2643 (子 5 atom / compound 配置) |
+| 上位 (Phase 5) | #2639 (子 1 Stripe Product / Price、**#2683 で 2 Product 各 1 Price 代替案 D に変更**) / #2640 (子 2 proration、**#2683 でダウン即時 + Stripe credit memo パターンに変更**) / #2641 (子 3 webhook 冪等性) / #2642 (子 4 archive 統合) / #2643 (子 5 atom / compound 配置) |
 | 連動 (Phase 7) | #2531 (実装 PR 群) / #2627 (Stripe Dashboard PO 手動操作) |
-| ステータス | 設計確定 (本 PR で確定、コード変更なし) |
-| 起点 | Phase 5 全 5 子の確定事項 (1 Product 2 Price + proration + webhook 冪等性 + 共通 archive + atom SSOT) を Phase 7 統合 PR の実行手順に落とし込み、cutover 失敗 / migration 順序事故 / kill switch 不在を構造的に防止 |
+| ステータス | 設計確定 (本 PR で確定、コード変更なし) / **2026-05-30 補強 #2683: 2 Product 各 1 Price 反映 + API version 維持判断 (`2026-04-22.dahlia`) + 副次制約 4 Webhook immutable を 5 phase migration 根拠として明文化** |
+| 起点 | Phase 5 全 5 子の確定事項 (2 Product 各 1 Price + proration + webhook 冪等性 + 共通 archive + atom SSOT) を Phase 7 統合 PR の実行手順に落とし込み、cutover 失敗 / migration 順序事故 / kill switch 不在を構造的に防止 |
 
 > **位置づけ**: Phase 6 グループ A の最優先成果物。Phase 5 で確定したアーキ層 5 子 + Phase 7 子 #2627 (Stripe Dashboard PO 手動操作) を「**Phase 7 統合 PR 5 step × 各 step AC + ロールバックポイント + 実 file path**」「**Stripe Dashboard #2627 7 領域 (A-G) 同期 timeline**」「**Stripe webhook migration 5 phase (setup→shadow→cutover→retire) の自プロダクト転用**」の 3 観点で統合 SSOT 化する。Phase 7 実装者は本 docs を参照するだけで cutover 順序を一意に決定できる状態を確立する。
 
@@ -17,13 +17,13 @@
 
 Phase 5 で確定した 5 子のアーキ:
 
-| 子 | docs SSOT | 確定事項 |
+| 子 | docs SSOT | 確定事項 (#2683 補強後) |
 |---|---|---|
-| #2639 | [phase5-stripe-product-architecture](phase5-stripe-product-architecture.md) | 1 Product 2 Price + lookup_key + apiVersion bump + Webhook 8 event 購読 + 副次制約 3 件 |
-| #2640 | [phase5-proration-architecture](phase5-proration-architecture.md) | アップ即時 (`always_invoice`) / ダウン期末 (`subscription_schedules` + `release`) / Preview API |
+| #2639 | [phase5-stripe-product-architecture](phase5-stripe-product-architecture.md) | **2 Product 各 1 Price + lookup_key** (#2683 代替案 D) + apiVersion **`'2026-04-22.dahlia'` 維持** (#2683 訂正) + Webhook 5 event 購読 (`subscription_schedule.*` 3 種は #2683 で scope 外) + **副次制約 4 件** (#2683 で Webhook destination immutable を追加) |
+| #2640 | [phase5-proration-architecture](phase5-proration-architecture.md) | アップ即時 (`always_invoice`) / **ダウン即時 + Stripe credit memo** (#2683 訂正、`subscription_schedules` API 不使用) / Preview API |
 | #2641 | [phase5-webhook-idempotency-architecture](phase5-webhook-idempotency-architecture.md) | `stripe_webhook_events` dedup table + 4 backend / 30 日 retention / dispatcher 入口 dedup |
 | #2642 | [phase5-archive-unified-architecture](phase5-archive-unified-architecture.md) | `archived_reason` enum (3 値: `trial_expired` / `downgrade_user_selected` / `dunning_canceled`) + 4 backend |
-| #2643 | [phase5-atom-ssot-architecture](phase5-atom-ssot-architecture.md) | terms.ts 3 atom + labels.ts 5 compound 配置 + atom 統合 5 step PR 計画 |
+| #2643 | [phase5-atom-ssot-architecture](phase5-atom-ssot-architecture.md) | terms.ts 3 atom + labels.ts 5 compound 配置 + atom 統合 5 step PR 計画 (#2683 で `cancelPendingRedirect` atom 不要化、subscription_schedule 不使用のため) |
 
 しかし**「Phase 7 統合 PR をどの順序でマージするか」「DB migration / atom rename / Stripe Dashboard 同期がどの timeline で動くか」が docs 横断で散在**し、Phase 7 実装者の自由裁量に委ねられる。並列 PR 衝突 / cutover 順序事故 / kill switch 不在のリスクを抱えたまま実装段階に入る。
 
@@ -86,29 +86,29 @@ Stripe 公式 [migrate-snapshot-to-thin-events](https://docs.stripe.com/webhooks
 | **Stripe Dashboard 同期** | なし (本 step は labels / routes のみ) |
 | **前提 PR** | Step 1 (DB migration) マージ済 |
 
-### Step 3: lookup_key 移行 (子 4 #2664 + 子 1 #2639 連動、推定 300 行)
+### Step 3: lookup_key 移行 (子 4 #2664 + 子 1 #2639 連動、推定 250 行、#2683 補強で apiVersion bump scope 外化)
 
 | 項目 | 内容 |
 |---|---|
-| **目的** | env var 直読 (`STRIPE_PRICE_STANDARD_MONTHLY` 等 4 件) を `prices.list({ lookup_keys })` 経由参照に切替 + apiVersion bump (`2026-04-22.dahlia` → `2026-05-27.dahlia`) + lookup_key 段階移行 (Stripe `transfer_lookup_key` 経由) |
-| **対象 file** | `src/lib/server/stripe/config.ts` (`STRIPE_PRICES` 定数 → `getPlans()` lookup_key 解決関数に rewrite) / `src/lib/server/stripe/client.ts` (`STRIPE_API_VERSION` 定数 bump) / [tests/unit/lib/server/stripe/config.test.ts](tests/unit/lib/server/stripe/config.test.ts) (新規 lookup_key 解決 mock) / [tests/unit/lib/server/stripe/client.test.ts](tests/unit/lib/server/stripe/client.test.ts) (新規 apiVersion 検証) / `.env.example` (`USE_LOOKUP_KEY` feature flag 追加、デフォルト `true`) / `docs/guides/stripe-setup-guide.md` (4 商品手動作成 → 1 Product 2 Price + lookup_key 手順に全面改訂) |
-| **AC** | (a) lookup_key 解決成功時に新 priceId を返す + 失敗時に env var fallback 動作 (`USE_LOOKUP_KEY=false` で旧経路、kill switch) (b) `npx vitest run src/lib/server/stripe/` PASS (c) apiVersion `2026-05-27.dahlia` で SDK 起動確認 (d) `docs/guides/stripe-setup-guide.md` の手順で PO が Test mode Dashboard を構築可能なことを確認 (e) `npm run pre-ready -- --pr <step3-pr>` PASS |
-| **ロールバック判断基準** | (a) lookup_key 解決 Stripe API 障害が複数回連続 → `USE_LOOKUP_KEY=false` で env var fallback 即時切替 (b) apiVersion bump で既存 webhook handler 破壊 (event field 構造変化) → Dashboard で apiVersion を旧版に巻き戻し (72h rollback window) |
+| **目的** | env var 直読 (`STRIPE_PRICE_STANDARD_MONTHLY` 等 4 件) を `prices.list({ lookup_keys })` 経由参照に切替 + lookup_key 段階移行 (Stripe `transfer_lookup_key` 経由)。**apiVersion は `'2026-04-22.dahlia'` 維持** (#2683 訂正: `'2026-05-27.dahlia'` は preview リリースで本番不採用、本 step では bump しない) |
+| **対象 file** | `src/lib/server/stripe/config.ts` (`STRIPE_PRICES` 定数 → `getPlans()` lookup_key 解決関数に rewrite) / [tests/unit/lib/server/stripe/config.test.ts](tests/unit/lib/server/stripe/config.test.ts) (新規 lookup_key 解決 mock) / [tests/unit/lib/server/stripe/client.test.ts](tests/unit/lib/server/stripe/client.test.ts) (新規 apiVersion `'2026-04-22.dahlia'` 維持 assert) / `.env.example` (`USE_LOOKUP_KEY` feature flag 追加、デフォルト `true`) / `docs/guides/stripe-setup-guide.md` (4 商品手動作成 → **2 Product 各 1 Price + lookup_key** 手順に全面改訂、#2683 代替案 D 反映) |
+| **AC** | (a) lookup_key 解決成功時に新 priceId を返す + 失敗時に env var fallback 動作 (`USE_LOOKUP_KEY=false` で旧経路、kill switch) (b) `npx vitest run src/lib/server/stripe/` PASS (c) apiVersion `'2026-04-22.dahlia'` を維持していることを unit test で assert (#2683) (d) `docs/guides/stripe-setup-guide.md` の手順で PO が Test mode Dashboard を 2 Product 構成で構築可能なことを確認 (e) `npm run pre-ready -- --pr <step3-pr>` PASS |
+| **ロールバック判断基準** | (a) lookup_key 解決 Stripe API 障害が複数回連続 → `USE_LOOKUP_KEY=false` で env var fallback 即時切替 (b) #2683 訂正で apiVersion bump 廃止のため、本 step での apiVersion 関連 rollback は発生しない |
 | **kill switch** | `USE_LOOKUP_KEY` env var (デフォルト `true`、`false` で env var 直読の旧コード経路) |
-| **Stripe Dashboard 同期** | **Test mode で先行作成必須** (本 step マージ前に PO #2627 で Test mode の Product / 2 Price / lookup_key / Webhook 構築済の状態を担保) |
+| **Stripe Dashboard 同期** | **Test mode で先行作成必須** (本 step マージ前に PO #2627 で Test mode の **2 Product / 各 1 Price / lookup_key** / Webhook 構築済の状態を担保、#2683 代替案 D 反映) |
 | **前提 PR** | Step 1 + Step 2 マージ済 + Stripe Dashboard Test mode 構築完了 (PO #2627) |
 
-### Step 4: Webhook shadow / cutover / retire (子 3 #2641 + Stripe 公式 5 phase 整合、推定 400 行)
+### Step 4: Webhook shadow / cutover / retire (子 3 #2641 + Stripe 公式 5 phase 整合、推定 400 行、#2683 補強で event 一覧変更)
 
 | 項目 | 内容 |
 |---|---|
-| **目的** | dispatcher 入口 dedup (`handleWebhookEvent` 冒頭、L221) + Webhook 購読 event 5 → 8 種拡張 (`subscription_schedule.aborted` / `_canceled` / `_completed`) + shadow mode → cutover → retire の 3 sub step |
+| **目的** | dispatcher 入口 dedup (`handleWebhookEvent` 冒頭、L221) + Webhook 購読 event 5 種維持 (#2683 訂正: 旧計画の `subscription_schedule.*` 3 種は scope 外、代わりに `invoice.payment_succeeded` / `invoice.payment_failed` / `credit_note.created` 3 種を追加して 5 種維持) + shadow mode → cutover → retire の 3 sub step。**Phase 5 子 1 #2644 §4.4 副次制約 4 (Webhook destination api_version immutable)** が本 step の 5 phase migration 設計根拠 (#2683 で明文化、Step 4-a で新 destination 作成 → Step 4-b cutover → Step 4-c retire の手順は Stripe API 仕様により**強制必須**) |
 | **詳細順序** | 本 step を以下 3 sub step に分割 (Stripe webhook migration 5 phase 整合): |
 | | **4-a (shadow mode)**: 新 Webhook handler (`/api/stripe/webhook-v2`) を新規 route で実装、DB write せず log のみ。`STRIPE_WEBHOOK_SHADOW_MODE=true` で 24-48h 検証 |
 | | **4-b (cutover)**: shadow mode log で 0 件 silent drop 確認後、新 handler に切替 + 旧 handler は 200 OK + log のみ (`STRIPE_WEBHOOK_SHADOW_MODE=false`)。Stripe Dashboard で新 Webhook destination を有効化 + 旧 destination は disabled |
 | | **4-c (retire)**: cutover 後 1 週間 smoke test PASS で旧 Webhook destination を delete + 旧 handler コードを削除 |
-| **対象 file** | `src/lib/server/services/stripe-service.ts` (`handleWebhookEvent` dispatcher 入口で `webhookEventRepo.findByEventId` dedup) / [src/routes/api/stripe/webhook-v2/+server.ts](src/routes/api/stripe/webhook-v2/+server.ts) (新規 route、4-a) / `src/routes/api/stripe/webhook/+server.ts` (旧 route、4-c で削除) / `.env.example` (`STRIPE_WEBHOOK_SHADOW_MODE` feature flag) / [src/lib/server/db/repos/webhook-event-repo.ts](src/lib/server/db/repos/webhook-event-repo.ts) (sqlite / dynamodb 実装、子 3 §3) / [tests/integration/stripe-webhook-dedup.test.ts](tests/integration/stripe-webhook-dedup.test.ts) (新規) / [tests/integration/stripe-webhook-schedule-aborted.test.ts](tests/integration/stripe-webhook-schedule-aborted.test.ts) (新規) |
-| **AC** | (a) 4-a で同一 event.id 重複到達時に `retry_count` increment + handler 1 回のみ実行 (b) 4-b で新 8 event 全種を受信 + DB に `handler_result='success'` 物理確認 (c) 4-c で旧 destination delete 後 1 週間 smoke test PASS (d) `npm run pre-ready -- --pr <step4-pr>` PASS |
+| **対象 file** | `src/lib/server/services/stripe-service.ts` (`handleWebhookEvent` dispatcher 入口で `webhookEventRepo.findByEventId` dedup) / [src/routes/api/stripe/webhook-v2/+server.ts](src/routes/api/stripe/webhook-v2/+server.ts) (新規 route、4-a) / `src/routes/api/stripe/webhook/+server.ts` (旧 route、4-c で削除) / `.env.example` (`STRIPE_WEBHOOK_SHADOW_MODE` feature flag) / [src/lib/server/db/repos/webhook-event-repo.ts](src/lib/server/db/repos/webhook-event-repo.ts) (sqlite / dynamodb 実装、子 3 §3) / [tests/integration/stripe-webhook-dedup.test.ts](tests/integration/stripe-webhook-dedup.test.ts) (新規) / [tests/integration/stripe-webhook-credit-note.test.ts](tests/integration/stripe-webhook-credit-note.test.ts) (#2683 新規、ダウン即時の credit memo 受信検証) / [tests/integration/stripe-webhook-api-version-immutable.test.ts](tests/integration/stripe-webhook-api-version-immutable.test.ts) (#2683 新規、副次制約 4 検証) |
+| **AC** | (a) 4-a で同一 event.id 重複到達時に `retry_count` increment + handler 1 回のみ実行 (b) 4-b で新 5 event 全種 (`customer.subscription.updated` / `_deleted` / `invoice.payment_succeeded` / `_failed` / `credit_note.created`) を受信 + DB に `handler_result='success'` 物理確認 (c) 4-c で旧 destination delete 後 1 週間 smoke test PASS (d) #2683 副次制約 4: `webhookEndpoints.update({api_version})` が Stripe API 400 を返すことを unit test で assert (e) `npm run pre-ready -- --pr <step4-pr>` PASS |
 | **ロールバック判断基準** | (a) 4-a で silent drop > 0 件 → 旧 handler 継続、新 handler 修正 (b) 4-b でエラー率 > 1% / 顧客 inquiry > 3 件 → `STRIPE_WEBHOOK_SHADOW_MODE=true` で 4-a 状態に即時戻し + Stripe Dashboard で旧 destination 再有効化 (c) 4-c で DB inconsistency 検出 → 旧 destination un-delete (Stripe 公式 archive 解除) + コード revert |
 | **kill switch** | `STRIPE_WEBHOOK_SHADOW_MODE` env var (4-a/4-b/4-c 各段階で個別切替可) |
 | **Stripe Dashboard 同期** | **4-a 前**: Test mode で新 Webhook destination 作成 (disabled)。**4-b**: Production mode で新 destination 有効化 + 旧 destination disabled。**4-c**: 旧 destination delete |
@@ -130,16 +130,16 @@ Stripe 公式 [migrate-snapshot-to-thin-events](https://docs.stripe.com/webhooks
 
 Stripe Dashboard #2627 で PO が手動操作する 7 領域 (A-G) と、Phase 7 統合 PR 5 step のマージ timing の整合性を表で確定する。**「コード PR マージ vs Stripe Dashboard 反映」の片方先行禁止ゾーン**を明示する。
 
-### 4.1 7 領域 (A-G)
+### 4.1 7 領域 (A-G、#2683 補強で 2 Product 構成反映)
 
 | 領域 | Stripe Dashboard 操作 | Phase 7 step 同期 timing |
 |---|---|---|
-| **A** | Test mode で Product `がんばりクエスト サブスクリプション` 作成 + 2 Price (`standard_monthly` / `premium_monthly` lookup_key、`inclusive` 税込) | **Step 3 マージ前**必須 (Step 3 PR の Pre-Ready CI が Test mode lookup_key 解決確認を含む) |
-| **B** | Test mode で Customer Portal config 設定 (子 1 §3.2 の 11 項目) | Step 3 マージ前 (A と同時、PO 1 セッションで完遂) |
-| **C** | Test mode で Webhook destination 作成 (disabled、子 1 §4.3 の 8 event 購読) | **Step 4-a マージ前**必須 |
-| **D** | Test mode で Test clock customer 作成 (子 2 #2662 連動、6 シナリオ用) | Step 4-a 着手前 (E2E 計画段階で PO が事前構築) |
-| **E** | Production mode で Product / 2 Price / lookup_key / Customer Portal config を Test mode と同設定で作成 | **Step 4-b マージ前**必須 (Production cutover 前) |
-| **F** | Production mode で Webhook destination 作成 (disabled、Step 4-b マージ時に有効化) | Step 4-b マージ時に PO が Dashboard で有効化 (同期コミット) |
+| **A** | Test mode で **2 Product (`prod_STANDARD` + `prod_PREMIUM`) 各 1 Price** (`standard_monthly` / `premium_monthly` lookup_key、`inclusive` 税込) (#2683 代替案 D) | **Step 3 マージ前**必須 (Step 3 PR の Pre-Ready CI が Test mode lookup_key 解決確認を含む) |
+| **B** | Test mode で Customer Portal config 設定 (子 1 §3.2 の 12 項目、**`subscription_update.products` に 2 entries** + `proration_behavior='always_invoke'` + `schedule_at_period_end` 撤去、#2683) | Step 3 マージ前 (A と同時、PO 1 セッションで完遂) |
+| **C** | Test mode で Webhook destination 作成 (disabled、子 1 §4.3 の **5 event** 購読: `customer.subscription.*` 2 + `invoice.payment_*` 2 + `credit_note.created` 1、#2683 訂正) | **Step 4-a マージ前**必須 |
+| **D** | Test mode で Test clock customer 作成 (子 2 #2662 連動、6 シナリオ用、#2683 でダウンシナリオは即時 + credit memo 検証に変更) | Step 4-a 着手前 (E2E 計画段階で PO が事前構築) |
+| **E** | Production mode で 2 Product / 各 1 Price / lookup_key / Customer Portal config を Test mode と同設定で作成 (#2683 反映) | **Step 4-b マージ前**必須 (Production cutover 前) |
+| **F** | Production mode で Webhook destination 作成 (disabled、Step 4-b マージ時に有効化、#2683 副次制約 4: api_version は新 destination 作成時の Dashboard 設定値で immutable) | Step 4-b マージ時に PO が Dashboard で有効化 (同期コミット) |
 | **G** | Production mode で旧 4 Price archive + 旧 Webhook destination delete | **Step 5 マージ後** 1 週間 smoke test PASS 後 |
 
 ### 4.2 片方先行禁止ゾーン (mermaid timeline)
@@ -177,12 +177,14 @@ gantt
 | A+B 未完で Step 3 マージ | Step 3 PR の Pre-Ready で `prices.list({ lookup_keys })` mock 解決成功するが、本番 staging 起動で `INVALID_LOOKUP_KEY` | Step 3 を revert、PO #2627 で A+B 完遂後再 push |
 | C 未完で Step 4-a マージ | shadow mode で event 受信 0 件、log に新 destination 反映なし | Step 4-a を `STRIPE_WEBHOOK_SHADOW_MODE=false` に切替、PO #2627 で C 完遂後 shadow mode 再有効化 |
 | E 未完で Step 4-b マージ | Production cutover で新 lookup_key 解決失敗 (Production mode Price 不在) | Step 4-b 即時 revert (kill switch `USE_LOOKUP_KEY=false` 有効化)、PO #2627 で E 完遂後再 push |
-| F 同期遅延 (Step 4-b マージ後 Dashboard 未有効化) | 新 8 event のうち 3 種新規 (`subscription_schedule.*`) が silent drop | PO に Discord alert 通知、Dashboard で F 即時有効化 (5 分以内対応) |
+| F 同期遅延 (Step 4-b マージ後 Dashboard 未有効化) | 新 5 event のうち 3 種新規 (`invoice.payment_succeeded` / `_failed` / `credit_note.created`、#2683 訂正) が silent drop | PO に Discord alert 通知、Dashboard で F 即時有効化 (5 分以内対応) |
 | G 早期実行 (Step 5 マージ前に旧 4 Price archive) | active subscription 顧客の請求継続失敗 (Phase 1 補強 2 Open question 4 が崩れた場合) | Stripe API で旧 4 Price un-archive (Stripe 公式 archive 解除)、Step 5 マージまで再 archive 保留 |
 
-## 5. Stripe Webhook migration 5 phase 自プロダクト転用 (§5)
+## 5. Stripe Webhook migration 5 phase 自プロダクト転用 (§5、#2683 補強で副次制約 4 を根拠化)
 
 Stripe 公式 [migrate-snapshot-to-thin-events](https://docs.stripe.com/webhooks/migrate-snapshot-to-thin-events) の 5 phase migration パターンを本プロダクトの Phase 7 Step 4 に転用する。
+
+> **#2683 補強 (2026-05-30)**: 本 5 phase migration が**強制必須**となる根拠は、Phase 5 子 1 #2644 #2683 補強で SSOT 化された**副次制約 4: Webhook destination api_version immutable** ([phase5-stripe-product-architecture.md §4.4](phase5-stripe-product-architecture.md))。Stripe API は既存 destination の api_version 変更を `400 Bad Request` で拒否するため、SDK apiVersion 変更時 (本 Phase 7 では現状 `'2026-04-22.dahlia'` 維持のため bump なし、将来の stable リリース採用時に発動) は新 destination 作成 → cutover → 旧 delete の 5 phase 必須。本 §5 は将来の apiVersion bump 時の SSOT としても機能する。
 
 ### 5.1 5 phase の対応関係
 

--- a/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
+++ b/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
@@ -1,34 +1,36 @@
-# Phase 6 子 5 — ロールバック詳細 + kill switch SSOT + Phase 1 構造的欠落 3 件 反映方針
+# Phase 6 子 5 — ロールバック詳細 + kill switch SSOT + Phase 1 構造的欠落 3 件 反映方針 (#2683 補強)
 
 | 項目 | 内容 |
 |------|------|
-| 孫 issue | #2665 (Phase 6 グループ C 最後、子 1-4 全マージ済が前提) |
+| 孫 issue | #2665 (Phase 6 グループ C 最後、子 1-4 全マージ済が前提) / #2683 (補強 — 2 Product 構成リスク R8 追加 + R3 / R5 / R6 訂正 + 副次制約 4 連動 + §6.3 Portal ロック誘導文言不要化) |
 | 親 | Phase 6 親 (Phase 7 統合 PR 5 step Step 4 + Step 5 ロールバック SSOT) / Epic #2525 |
 | 上位 (Phase 6 子 1) | #2667 ([phase6-phase7-execution-ssot](phase6-phase7-execution-ssot.md)) §5.2-5.3 ロールバック起点 + §10 OQ-3 kill switch dry-run の補完 |
 | 上位 (Phase 6 子 2) | #2674 ([phase6-test-clock-scenarios](phase6-test-clock-scenarios.md)) §6 kill switch dry-run シナリオ整合 |
 | 上位 (Phase 6 子 3) | #2675 ([phase6-db-migration-plan](phase6-db-migration-plan.md)) §5.3 rollback 不可逆性 + 13 file 一覧 整合 |
-| 上位 (Phase 6 子 4) | #2673 ([phase6-context-decisions-6](phase6-context-decisions-6.md)) lookup_key 段階移行 + API version bump |
-| 前提 (Phase 5) | #2639 ([phase5-stripe-product-architecture](phase5-stripe-product-architecture.md)) 「想定リスク 7 件」 / #2640 / #2641 / #2642 / #2643 |
-| 連動 (Phase 7) | #2531 (実装 PR 群) — Phase 7 Step 1-5 全 step で本 docs §3 リスク 7 件 + §4 #2627 timeline + §5 kill switch を参照 |
-| Phase 1 連動 | #2537 dunning FR-3 (handleSubscriptionDeleted archive 未呼出、本 docs §6.1) / 副次制約 1 tax_behavior (§6.2) / 副次制約 2 Portal ロック banner (§6.3) |
-| ステータス | 設計確定 (本 PR で docs SSOT、コード変更は Phase 7 各 Step / ADR 起票は本 PR で同時実施) |
+| 上位 (Phase 6 子 4) | #2673 ([phase6-context-decisions-6](phase6-context-decisions-6.md)) lookup_key 段階移行 + **API version 維持判断** (#2683 訂正) |
+| 前提 (Phase 5) | #2639 ([phase5-stripe-product-architecture](phase5-stripe-product-architecture.md)) 「想定リスク 7 件 → #2683 補強で 8 件 (R8 新規、R3 / R5 / R7 historical 化)」 / #2640 / #2641 / #2642 / #2643 |
+| 連動 (Phase 7) | #2531 (実装 PR 群) — Phase 7 Step 1-5 全 step で本 docs §3 リスク 8 件 (#2683 補強) + §4 #2627 timeline + §5 kill switch を参照 |
+| Phase 1 連動 | #2537 dunning FR-3 (handleSubscriptionDeleted archive 未呼出、本 docs §6.1) / 副次制約 1 tax_behavior (§6.2) / **副次制約 2 Portal ロック banner (#2683 で historical 化、§6.3)** / 副次制約 4 Webhook immutable (#2683 で新規追加、§6.4 連動) |
+| ステータス | 設計確定 (本 PR で docs SSOT、コード変更は Phase 7 各 Step / ADR 起票は本 PR で同時実施) / **2026-05-30 補強 #2683: 代替案 D 採用に伴う scope 変更を反映** |
 | 作業姿勢 (#2525 critical) | 課金は別格 ([[billing-critical-extra-caution]])。ロールバック手順は「実際に Test mode で 1 度実演」できる粒度まで具体化。Pre-PMF Bucket A (ADR-0010) 整合、kill switch は LaunchDarkly / Unleash 等の SaaS / OSS feature flag platform を不採用、env var 2 件 (`USE_LOOKUP_KEY` / `STRIPE_WEBHOOK_SHADOW_MODE`) で最小構成 |
 
 > **位置づけ**: Phase 6 グループ C 最後の子 (グループ A=#2667 / グループ B=#2674-#2675 / #2673 完了後)。Phase 5 子 1 §「想定リスク 7 件」を **検知 → ロールバック → 再発防止** の 3 観点で実装手順化し、#2627 Stripe Dashboard ロールバックを **3 期間 (Phase 7 マージ前 / マージ後 24h / マージ後 1 週間)** で詳細化、feature flag kill switch を `.env.example` + `src/lib/server/stripe/config.ts` の SSOT 1 箇所で統合管理する。さらに Phase 1 で確定済の構造的欠落 3 件 (handleSubscriptionDeleted archive 未呼出 / tax_behavior 一致 / Portal ロック誘導文言) の Phase 7 反映方針を確定。最後に ADR-0014 整合の OSS 4 件比較で本 PR と同時に新規 ADR を起票する。
 
 ## 1. 設計背景 (§1)
 
-### 1.1 課題: Phase 5 子 1 §想定リスク 7 件が docs 化されていない
+### 1.1 課題: Phase 5 子 1 §想定リスク 7 件 → #2683 補強で 8 件への更新
 
-Phase 5 子 1 (#2639) の deep-research SSOT (`tmp/reviews/phase5-stripe-product-research.md`) §「想定リスク 7 件」で以下 7 件が列挙されたが、**「検知 → ロールバック → 再発防止」の 3 観点で実装手順化されていない**:
+Phase 5 子 1 (#2639 #2683 補強) の deep-research SSOT (`tmp/reviews/phase5-stripe-product-research.md`) §「想定リスク」で以下 8 件 (#2683 で R8 / R9 追加、R3 / R5 / R7 historical 化) が列挙され、**「検知 → ロールバック → 再発防止」の 3 観点で実装手順化されていない**:
 
 1. Phase 7 マージ前に新 Webhook 有効化 → 旧 handler に新 event 到達 → 404 (handler 不在で silent drop)
 2. tax_behavior 不一致 (Price = `inclusive` だが Customer Portal config = `exclusive`) → Portal ダウン UI 非表示、自社 UI からのダウン経路しか機能しない
-3. 顧客が `subscription_schedule` 作成済の状態で Portal 再操作 → Stripe Portal が「subscription_update / cancel UI 非表示」のロック仕様 → 顧客が反応せず混乱
+3. **(#2683 historical 化)** 顧客が `subscription_schedule` 作成済の状態で Portal 再操作 → Stripe Portal が「subscription_update / cancel UI 非表示」のロック仕様 → 顧客が反応せず混乱 → **代替案 D で subscription_schedule 不使用のため scope 外**
 4. lookup_key 解決時に Stripe API 障害 (5xx) → `prices.list({ lookup_keys })` 失敗 → アプリ起動失敗 (Lambda cold start で全 request 500)
-5. Webhook destination の `default_api_version` vs SDK `apiVersion` 乖離 → event field 構造変化 → handler コード参照プロパティが undefined
+5. **(#2683 historical 化)** Webhook destination の `default_api_version` vs SDK `apiVersion` 乖離 → event field 構造変化 → handler コード参照プロパティが undefined → **#2683 で API version `'2026-04-22.dahlia'` 維持判断、Phase 7 では bump なし**
 6. proration_date が `createPreview` と `subscriptions.update` で 30 分超過 → Stripe 拒否 (`InvalidProrationDate` error)
 7. dunning Smart Retries 8 attempts 枯渇後 → `customer.subscription.deleted` 受信 → `handleSubscriptionDeleted` が archive 機構未呼出 (Phase 1 #2537 FR-3 未成立)
+8. **(#2683 新規 R8)** ダウン即時 + Stripe proration credit でユーザーに過大返金または credit 残高蓄積、顧客が credit memo 残高を把握できず信頼毀損
+9. **(#2683 新規 R9)** Webhook destination api_version immutable を Phase 7 着手時 (将来の stable apiVersion bump 時) に見落とす → 新規 destination 作成 skip → 既存 destination の api_version 変更試行 → Stripe API 400 → cutover blocker
 
 Phase 7 実装者が本 docs を参照しない場合、各リスクごとに **検知 method (CloudWatch alarm / Sentry / Discord alert / log polling 等が散在)** と **ロールバック手順 (revert PR / env var 切替 / Dashboard 再操作 / Stripe API 再呼出 が散在)** を独自判断することになり、本番 cutover 失敗時の MTTR (Mean Time To Recovery) が 1 時間超過するリスク。
 
@@ -100,14 +102,11 @@ Phase 1 + Phase 6 子 1-4 経由で以下 3 件の構造的欠落が判明した
 | **ロールバック手順** | (1) PO #2627 で Customer Portal config を Test/Production mode 両方で `tax_behavior=inclusive` に再設定 (5 分以内、Stripe Dashboard 操作のみ) (2) Test mode で test_clock customer 1 件で Portal access → "Change plan" UI 表示確認 (3) Production で同確認 |
 | **再発防止** | Phase 6 子 1 #2667 §4 領域 A (Test mode Product 作成) + 領域 E (Production Product 作成) の手順チェックリストに「Price `tax_behavior=inclusive` と Portal config `tax_behavior` 一致を画面で確認」を 1 行追加 |
 
-### 3.3 R3: subscription_schedule 既存時の Portal ロック → 顧客が反応せず
+### 3.3 R3: subscription_schedule 既存時の Portal ロック (#2683 で historical 化、scope 外)
 
-| 項目 | 内容 |
-|---|---|
-| **シナリオ** | Phase 5 子 1 §3.2 副次制約 2: 顧客が subscription_schedule 作成済 (例: 自社 UI または Portal でダウン期末を実施済) の状態で、再度 Portal を開いて操作試行 → Stripe Portal の仕様で `subscription_update` / `cancel` UI が非表示になり、顧客は「壊れている」と認識 → 自社 UI へ誘導されないと cancel-pending CTA に到達しない |
-| **検知 method** | (a) 顧客 inquiry「Portal を開いたら操作できない」(b) Phase 6 子 2 #2674 シナリオ 6 Portal E2E で「schedule 既存時の Portal ロック」を assert (c) Phase 3 #2573 ArchivedResourceBanner / cancel-pending banner の表示率を `/admin/analytics` で監視 |
-| **ロールバック手順** | (1) 自社 UI `/admin/subscription` で **`SUBSCRIPTION_PAGE_LABELS.cancelPendingRedirect` atom 表示** (本 docs §6.3 で追加 SSOT 化、Phase 7 Step 2 で実装、Phase 5 子 5 #2643 atom 統合 5 step 整合)。文言例: 「プラン変更予約中は Portal でなく、この画面の『予約取消』ボタンから操作してください」(2) Portal リダイレクト経由ではなく自社 UI 直接 access |
-| **再発防止** | Phase 7 Step 2 atom 統合 5 step (子 5 #2643 §6) で `SUBSCRIPTION_PAGE_LABELS.cancelPendingRedirect` 追加 + Phase 3 #2573 既設計の cancel-pending banner UI で表示 + Phase 6 子 2 #2674 シナリオ 6 で E2E assert |
+> **#2683 補強 (2026-05-30)**: 代替案 D (2 Product 各 1 Price) + ダウン即時 + Stripe credit memo パターン採用に伴い、本プロダクトは **subscription_schedule API を使用しない**。よって R3「Portal ロック」は**現行設計では発生しない**ため scope 外。
+>
+> historical record: 旧設計 (1 Product 2 Price + Portal `schedule_at_period_end=true`) では schedule 作成後の Portal 再操作で UI が非表示になる Stripe 公式制約を回避するため、自社 UI `cancelPendingRedirect` atom + Phase 3 #2573 banner で誘導する設計だった。代替案 D で即時ダウン完結のため scope 外。Phase 6 子 2 #2674 シナリオ 6 の「schedule 既存時 Portal ロック検証」も scope 外。`SUBSCRIPTION_PAGE_LABELS.cancelPendingRedirect` atom (§6.3) も不要化。
 
 ### 3.4 R4: lookup_key 解決 Stripe API 障害 → 起動失敗
 
@@ -118,14 +117,13 @@ Phase 1 + Phase 6 子 1-4 経由で以下 3 件の構造的欠落が判明した
 | **ロールバック手順** | (1) Lambda env `USE_LOOKUP_KEY=false` を AWS Console / CDK env override で即時切替 (2) Lambda 再 deploy なし、Lambda の env 変更は次 invocation で反映 (Lambda 仕様、約 30 秒) (3) env var fallback 経路 (`STRIPE_PRICE_STANDARD_MONTHLY` 等 4 env var 直読) で復旧 (4) Stripe API 復旧後 `USE_LOOKUP_KEY=true` に再切替 |
 | **再発防止** | (a) Phase 7 Step 3 PR の `src/lib/server/stripe/config.ts` に「lookup_key 解決失敗時 env var fallback (kill switch 動作)」の unit test (b) Phase 6 子 2 #2674 シナリオ 2 (アップ即時 + kill switch dry-run) を Pre-Ready 必須化 (c) Step 3 Pre-Ready checklist に「kill switch 切替後 30 秒以内 fallback 動作 assert」 |
 
-### 3.5 R5: Webhook API version vs SDK 乖離
+### 3.5 R5: Webhook API version vs SDK 乖離 (#2683 で historical 化、Phase 7 では scope 外)
 
-| 項目 | 内容 |
-|---|---|
-| **シナリオ** | Phase 7 Step 3 で SDK `apiVersion='2026-05-27.dahlia'` に bump 済だが、Stripe Dashboard Webhook destination の `default_api_version` を `2026-04-22.dahlia` (旧) のまま放置 → Stripe 配信 event の field 構造が旧 version (例: `payment_intent.next_action` field 構造変化) → SDK 期待値と乖離 → handler で `event.data.object.next_action.use_stripe_sdk` が undefined → `TypeError` |
-| **検知 method** | (a) Sentry `webhook handler TypeError: Cannot read property 'use_stripe_sdk' of undefined` (b) Stripe Dashboard Webhook destination "Failed" rate > 0.5% (c) Discord alert `stripe-webhook-handler-typeerror` |
-| **ロールバック手順** | (1) PO #2627 で Webhook destination の `default_api_version` を新 `2026-05-27.dahlia` に同期 (Dashboard UI / Stripe API `webhookEndpoints.update({api_version})`、5 分以内) (2) Sentry log で TypeError 発生時刻以降の event を Stripe API `events.retrieve` で再取得 → 手動 replay (3) 復旧不能なら apiVersion を旧版に巻き戻し (Stripe 公式 72h rollback window 利用、Stripe Dashboard "Versions" tab) + SDK 1 行修正 PR 即時 merge |
-| **再発防止** | Phase 7 Step 3 PR Pre-Ready checklist に「Webhook destination api_version 同期確認 (Stripe API `webhookEndpoints.retrieve` で assert)」+ Phase 7 Step 4-a smoke test に「全 8 event 種で field 構造 schema validation」追加 (Phase 5 子 3 #2641 §3.1 webhook table の `event_type` 別 schema check) |
+> **#2683 補強 (2026-05-30)**: Phase 5 子 1 §3.4 で `'2026-04-22.dahlia'` → `'2026-05-27.dahlia'` への bump を採用候補としていたが、`'2026-05-27.dahlia'` は **preview リリース** で production 非推奨と判明 ([phase5-stripe-product-architecture.md §3.4](phase5-stripe-product-architecture.md) #2683 訂正)。Phase 7 では SDK apiVersion = `'2026-04-22.dahlia'` (stable 最新) **維持判断**、Webhook destination の api_version も同じ stable バージョンで新規作成 → 乖離リスク発生しない。
+>
+> **将来の stable apiVersion bump 時の発動準備**: 副次制約 4 (Webhook destination api_version immutable、[phase5-stripe-product-architecture.md §4.4](phase5-stripe-product-architecture.md)) により、apiVersion bump 時は新 destination 新規作成必須 → 旧 destination は旧 api_version で stale 状態で残るため**乖離は構造的に発生する**。Phase 6 子 1 #2667 §5 Webhook 5 phase migration で shadow → cutover → retire の手順を遵守することで乖離期間を 1 週間以内に限定 (本 R5 の将来発動シナリオ、本 docs §6.4 連動)。
+
+historical record (旧設計): Sentry TypeError 検知 + Dashboard `webhookEndpoints.update({api_version})` で同期する想定だったが、副次制約 4 (#2683) により Stripe API は既存 destination の api_version 変更を拒否 (400 Bad Request) → 旧設計の rollback 手順は **構造的に不可能**。代わりに新 destination 作成 + 旧 destination 再有効化 (cutover 巻き戻し) が正しい手順。
 
 ### 3.6 R6: proration_date 30 分超過
 
@@ -146,17 +144,37 @@ Phase 1 + Phase 6 子 1-4 経由で以下 3 件の構造的欠落が判明した
 <!-- doc-code-refs: ignore-line -->
 | **再発防止** | Phase 7 PR-X 実装後、Phase 6 子 2 #2674 シナリオ 5 で「dunning 8 attempts → archive 実行」を Pre-Ready E2E 必須化、`tests/integration/dunning-canceled-archive.spec.ts` 新規 (Phase 5 子 4 §7.3 整合) |
 
-### 3.8 想定リスク 7 件 SSOT サマリ表
+### 3.8 R8 (#2683 新規): ダウン即時 + Stripe credit memo の顧客信頼毀損
+
+| 項目 | 内容 |
+|---|---|
+| **シナリオ** | Phase 5 子 1 #2644 #2683 補強で確定した「ダウン即時 + Stripe `proration_behavior='always_invoice'` で credit memo 自動発行」パターンで、Stripe が未消費期間を credit memo として発行 → 次回 invoice で控除されるが、**顧客が自身の credit 残高を `/admin/subscription` で確認できない** → 「ダウンしたのに金が戻らない / 金額不明」と認識 → 信頼毀損 + Discord 問合せ蓄積 |
+| **検知 method** | (a) 顧客 inquiry「ダウンしたのに credit 残高が見えない」(b) Sentry custom event「credit_note display missing」(c) Phase 6 子 2 #2674 シナリオ 3 (ダウン即時 + credit memo) E2E で「`/admin/subscription` 請求履歴に credit memo 表示」を assert |
+| **ロールバック手順** | (1) Phase 3 hybrid confirm UI (Phase 5 子 2 #2640 §6) で「ダウン時の credit memo 発行額 + 次回 invoice での控除見込み額」を必ず表示する設計を確認 (2) `/admin/subscription` 請求履歴セクションで `credit_note.created` webhook 受信時に credit memo を一覧表示 (3) credit 残高を「次回 ¥X 自動控除」と顧客可視化 |
+| **再発防止** | Phase 7 Step 3 (Phase 3 #2573 hybrid confirm UI 実装時) に「ダウン variant で credit memo 発行額 + 次回控除見込み額 表示」を必須化 + Phase 6 子 2 #2674 シナリオ 3 を Pre-Ready 必須化 + `tests/e2e/billing/downgrade-credit-display.spec.ts` 新規 |
+
+### 3.9 R9 (#2683 新規): Webhook destination api_version immutable を見落とす (副次制約 4 連動)
+
+| 項目 | 内容 |
+|---|---|
+| **シナリオ** | 将来の stable apiVersion bump 時 (Phase 7 では `'2026-04-22.dahlia'` 維持判断のため発動しないが、将来発動)、Dev エンジニアが Stripe Dashboard で既存 destination の api_version を Dashboard UI で更新試行 → Stripe API が `400 Bad Request` を返す (副次制約 4 [phase5-stripe-product-architecture.md §4.4](phase5-stripe-product-architecture.md)) → cutover blocker、再度 5 phase migration ([phase6-phase7-execution-ssot.md §5](phase6-phase7-execution-ssot.md)) を最初からやり直し |
+| **検知 method** | (a) Dashboard UI で「api_version cannot be modified」エラー表示 (b) `webhookEndpoints.update({api_version})` API 呼出が Stripe SDK で `StripeInvalidRequestError` を throw (c) Phase 6 子 1 #2667 §5 Webhook 5 phase migration の手順を skip した PR が本副次制約に抵触 |
+| **ロールバック手順** | (1) Dashboard で **新 destination を新 api_version で新規作成** (副次制約 4 整合) (2) Phase 6 子 1 #2667 §3 Step 4-a (shadow mode) → §3 Step 4-b (cutover) → §3 Step 4-c (retire) の 5 phase migration を改めて実施 (3) 旧 destination は cutover 完了まで disabled で残置 |
+| **再発防止** | (a) [phase5-stripe-product-architecture.md §4.4](phase5-stripe-product-architecture.md) #2683 副次制約 4 を SSOT として参照必須化 (b) Phase 7 Step 4 (および将来の apiVersion bump PR) の Pre-Ready unit test で **`webhookEndpoints.update({api_version})` が 400 を返すことを assert** (c) Phase 6 子 1 #2667 §5 Webhook 5 phase migration を Pre-Ready 必須化 |
+
+### 3.10 想定リスク 8 件 SSOT サマリ表 (#2683 補強で +R8 / +R9、R3 / R5 historical 化)
 
 | # | リスク | 検知 method (主) | ロールバック手順 (簡略) | 再発防止 (CI / Pre-Ready) |
 |---|---|---|---|---|
 | R1 | 旧 handler silent drop | Sentry warning + Discord alert | Dashboard destination 即時 disabled + event 手動 replay | Step 4-a unit test (destination state) |
 | R2 | tax_behavior 不一致 | Phase 6 子 2 #2674 シナリオ 6 + Dashboard 目視 | Portal config 再設定 (5 分) | #2627 領域 A+E 手順 checklist |
-| R3 | Portal ロック顧客混乱 | 顧客 inquiry + シナリオ 6 E2E | `cancelPendingRedirect` atom 表示 + 自社 UI 直接 access | Step 2 atom 追加 + Phase 3 #2573 banner |
+| ~~R3~~ (#2683 historical) | ~~Portal ロック顧客混乱~~ | **代替案 D で subscription_schedule 不使用、scope 外** | n/a | n/a |
 | R4 | lookup_key API 障害 | Lambda alarm + Discord alert | `USE_LOOKUP_KEY=false` Lambda env 即時切替 | シナリオ 2 kill switch dry-run + Step 3 unit test |
-| R5 | apiVersion 乖離 | Sentry TypeError + Webhook "Failed" rate | Dashboard `default_api_version` 同期 + 72h rollback | Step 3 Pre-Ready (`webhookEndpoints.retrieve` assert) |
+| ~~R5~~ (#2683 historical) | ~~apiVersion 乖離 (`2026-05-27.dahlia` preview 採用想定)~~ | **API version `'2026-04-22.dahlia'` 維持判断、Phase 7 では発生しない** | n/a (将来の stable bump 時に副次制約 4 整合で対応) | n/a |
 | R6 | proration_date 期限超過 | Sentry InvalidProrationDate | 顧客 UI 再 preview CTA + 30 分タイマー | Step 3 hybrid confirm UI 実装 + シナリオ 2 E2E |
 | R7 | archive 未呼出 (forward-fix) | シナリオ 5 E2E + cutover 後整合チェック | Phase 7 PR-X で `handleSubscriptionDeleted` archive 追加 | シナリオ 5 Pre-Ready 必須化 + integration test |
+| **R8 (#2683 新規)** | **ダウン credit memo の顧客信頼毀損** | 顧客 inquiry + シナリオ 3 E2E | Phase 3 hybrid confirm UI + 請求履歴 credit memo 表示 | Step 3 hybrid confirm UI 実装 + シナリオ 3 E2E |
+| **R9 (#2683 新規)** | **Webhook destination api_version immutable 見落とし** | Dashboard UI エラー + Stripe SDK `StripeInvalidRequestError` | 新 destination 新規作成 + 5 phase migration 再実施 | Pre-Ready unit test (`webhookEndpoints.update({api_version})` 400 assert) + Phase 6 子 1 §5 Webhook 5 phase migration 必須化 |
 
 ## 4. #2627 Stripe Dashboard ロールバック 3 期間別マトリクス (§4)
 
@@ -312,25 +330,22 @@ Phase 1 + Phase 6 子 1-4 経由で判明した 3 件の構造的欠落を、Pha
 | **依存** | なし (Step 3 マージ前に PO #2627 が完了する前提) |
 | **再発防止** | (a) Phase 6 子 2 #2674 シナリオ 6 で「Portal 'Change plan' UI 存在を assert」(b) `docs/guides/stripe-setup-guide.md` セットアップ手順 §「Customer Portal config」に tax_behavior 一致確認を明示 (c) 本 docs §3.7 R2 SSOT |
 
-### 6.3 欠落 #3: subscription_schedule 既存時 Portal ロック誘導文言 (副次制約 2)
+### 6.3 欠落 #3: subscription_schedule 既存時 Portal ロック誘導文言 (#2683 で historical 化、不要化)
 
-| 項目 | 内容 |
-|---|---|
-| **現状** | 顧客が subscription_schedule 作成済で Portal 再操作 → Stripe Portal の仕様で `subscription_update` / `cancel` UI 非表示 → 顧客が「壊れている」と認識 → 自社 UI cancel-pending CTA への誘導文言が不在 |
-| **Phase 5 子 1 副次制約 2** | 顧客は schedule 存在中は Portal で操作不可、自社 UI に誘導が必要 |
-| **Phase 7 反映方針** | **`SUBSCRIPTION_PAGE_LABELS.cancelPendingRedirect` atom 追加** (本 docs で新規確定、Phase 5 子 5 #2643 atom 統合 5 step に追補)。Phase 7 Step 2-2 (labels.ts 5 compound 追加) のタイミングで `SUBSCRIPTION_PAGE_LABELS` 内に追加し、Phase 3 #2573 ArchivedResourceBanner / cancel-pending banner UI で表示 |
-| **atom 提案 (本 docs SSOT)** | `SUBSCRIPTION_PAGE_LABELS.cancelPendingRedirect`: 「プラン変更予約中は ${STRIPE_PORTAL_TERMS.canonical} ではなく、こちらの『予約取消』ボタンから操作してください。」(${...} template literal で既存 atom `STRIPE_PORTAL_TERMS.canonical = 'Stripe の請求管理ページ'` を参照、ADR-0045 整合) |
-| **担当 PR** | Phase 7 Step 2-2 PR (atom 統合 5 step の Step 2-2、推定 30 行)、Phase 3 #2573 banner UI 連動 |
-| **依存** | Step 1 (DB migration) + Phase 5 子 5 #2643 §6 atom 統合 5 step の前 sub step (Step 2-1 terms.ts 配備) |
-| **再発防止** | (a) Phase 6 子 2 #2674 シナリオ 6 Portal E2E で「cancelPendingRedirect 表示」を assert (b) Phase 3 #2573 既設計 banner UI で文言表示 (c) 本 docs §3.7 R3 SSOT |
+> **#2683 補強 (2026-05-30)**: 代替案 D (2 Product 各 1 Price) + ダウン即時 + Stripe credit memo パターン採用に伴い、本プロダクトは **subscription_schedule API を使用しない**。よって本欠落 #3 (Portal ロック誘導文言) は**現行設計では発生しない**ため scope 外。`SUBSCRIPTION_PAGE_LABELS.cancelPendingRedirect` atom 追加は**不要化**。
+>
+> **Phase 7 反映方針 (訂正)**: Phase 7 Step 2-2 atom 統合 5 step で `cancelPendingRedirect` atom 追加を **skip**。Phase 3 #2573 cancel-pending banner UI も**削除判断** (別 follow-up Issue で UI 削除 PR 起票)。代わりに本 docs §3.8 R8 (credit memo の顧客可視化) で `SUBSCRIPTION_PAGE_LABELS.creditMemoBalance` atom を新規追加するか検討 (#2683 follow-up)。
+>
+> historical record (旧設計): 1 Product 2 Price + Portal `schedule_at_period_end=true` のもとで schedule 作成済 → 顧客が再 Portal 操作 → Portal UI 非表示で混乱 → 自社 UI cancel-pending banner で誘導する設計だった。`SUBSCRIPTION_PAGE_LABELS.cancelPendingRedirect` atom 文言は「プラン変更予約中は ${STRIPE_PORTAL_TERMS.canonical} ではなく、こちらの『予約取消』ボタンから操作してください。」だったが、代替案 D で不要化。
 
-### 6.4 3 件欠落の Phase 7 PR 担当マトリクス
+### 6.4 3 件欠落の Phase 7 PR 担当マトリクス (#2683 補強で #3 不要化、Webhook immutable を新規 #4 として追加)
 
 | 欠落 | 担当 PR | 担当 Step | 推定行数 | 依存 |
 |---|---|---|---|---|
 | #1 archive 未呼出 | **新 PR-X** (Phase 7 内部 sub) | Step 4-b 直前 | 100 行 | Step 1 + Step 2-4 |
 | #2 tax_behavior | **コード PR なし** (PO #2627 + docs/guides 改訂) | Step 3 PR docs 同梱 | 0 行 (docs only) | なし |
-| #3 cancelPendingRedirect | **Step 2-2 PR** | Step 2-2 (子 5 #2643 §6) | 30 行 (atom + LP 再生成) | Step 1 + Step 2-1 |
+| ~~#3 cancelPendingRedirect~~ (#2683 不要化) | **不要** (代替案 D で subscription_schedule 不使用、scope 外) | n/a | 0 行 | n/a |
+| **#4 Webhook destination immutable (#2683 新規)** | **コード PR なし** (Phase 7 では `'2026-04-22.dahlia'` 維持、将来の stable bump PR で発動) | (将来の apiVersion bump PR で 5 phase migration 実装) | 0 行 (Phase 7 では) | なし (Phase 7 着手時) |
 
 ## 7. OSS 4 件比較 (kill switch / feature flag platform、ADR 起票根拠、§7)
 

--- a/scripts/doc-code-references-baseline.json
+++ b/scripts/doc-code-references-baseline.json
@@ -138,12 +138,16 @@
 			"src/routes/api/stripe/webhook-v2/+server.ts",
 			"tests/e2e/billing",
 			"tests/integration/db/archived-reason-migration.test.ts",
+			"tests/integration/stripe-webhook-api-version-immutable.test.ts",
+			"tests/integration/stripe-webhook-credit-note.test.ts",
 			"tests/integration/stripe-webhook-dedup.test.ts",
-			"tests/integration/stripe-webhook-schedule-aborted.test.ts",
 			"tests/unit/lib/domain",
 			"tests/unit/lib/server/stripe",
 			"tests/unit/lib/server/stripe/client.test.ts",
 			"tests/unit/lib/server/stripe/config.test.ts"
+		],
+		"docs/design/billing-redesign/phase6-rollback-and-kill-switches.md": [
+			"tests/e2e/billing/downgrade-credit-display.spec.ts"
 		],
 		"docs/design/billing-redesign/phase6-test-clock-scenarios.md": [
 			"tests/e2e/billing",
@@ -223,5 +227,5 @@
 		],
 		"tests/CLAUDE.md": ["infra/node_modules"]
 	},
-	"generatedAt": "2026-05-29T22:37:07.791Z"
+	"generatedAt": "2026-05-30T07:36:22.519Z"
 }


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: Phase 7 #2531 実装者 + Phase 5 / 6 docs SSOT を参照する全 Dev / QM / PO + 課金品質運用者

**解決する課題**: Phase 5 子 1 (#2644) 起票時の Stripe 構造 deep-research が「1 Product 内 2 Price tier」(interval 違い文脈) を「同一 Product 異金額 tier」に誤読し、Phase 5 子 1/2 + Phase 6 子 1/4/5 + ADR-0059 の 6 docs に伝播した。さらに #2627 PO Test mode 着手で Stripe Customer Portal「この料金プランは追加できません」エラーが実機発生し、Top 40 SaaS で 1 Product 2 Price tier 採用ゼロ (Notion / Slack / Spotify / Figma / Zoom 等は全て separate Product per tier) という業界収束も追検証された。加えて (a) API version 表記 `2026-05-27.dahlia` は preview 版 (本番非推奨) で stable は `2026-04-22.dahlia`、(b) Webhook destination の api_version は immutable で変更には新規 destination 作成 + 旧 delete/disable が強制必須 (Phase 6 子 1 #2667 Webhook 5 phase migration の根拠) の 2 副次制約も判明した。Phase 7 #2531 着手時点で 6 docs のうち 1 件でも旧構造前提のまま残ると `prod_STANDARD` / `prod_PREMIUM` 2 Product 構成 / proration credit / Webhook 5 phase migration の整合性が PR-1/PR-2a/PR-2b で破綻するリスクを抱える。

**期待される効果**: Phase 7 #2531 実装者は 6 docs (phase5-stripe-product-architecture / phase5-proration-architecture / phase6-phase7-execution-ssot / phase6-context-decisions-6 / phase6-rollback-and-kill-switches / ADR-0059) を参照するだけで (1) 2 Product 各 1 Price 構成 (`prod_STANDARD` + `prod_PREMIUM`)、(2) Customer Portal `subscription_update` 維持 + 即時ダウン + Stripe proration credit (Slack / Notion / Atlassian / Linear 整合、業界 50% 採用)、(3) API version 訂正 (`2026-04-22.dahlia` stable、`2026-05-27.dahlia` preview は撤去)、(4) Webhook destination api_version immutable 副次制約 4 (Phase 6 子 1 #2667 §5 Webhook 5 phase migration の必然根拠) を一意に確定可能。Phase 5 子 1 #2644 + Phase 6 子 1/4/5 全 CLOSED 維持 + ADR-0059 統合更新で **Phase 7 (#2531) Week 1 着手準備完遂** (PR-1 DB migration + PR-2a/b atom 配備)。

## 関連 Issue

closes #2683

関連: Epic #2525 (課金/プラン体系再設計、全 7 phase) / Phase 5 子 1 #2644 (Stripe Product architecture) / Phase 5 子 2 #2649 (proration architecture) / Phase 6 子 1 #2667 (phase6/7 execution SSOT) / Phase 6 子 4 #2673 (context decisions 6) / Phase 6 子 5 #2678 (rollback / kill switches、merged) / ADR-0059 (Phase 7 cutover sequence) / Phase 7 #2531 (実装、本 PR の落とし先) / #2627 (PO Test mode 着手時の構造的問題発覚起点) / Phase 1 #2538 (`tenants.pendingScheduleId` カラム連動見直し対象) / Phase 3 #2573 (hybrid confirm UI、credit 残高表示 UI 設計連動)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 6 docs SSOT 更新完了 (phase5-stripe-product-architecture / phase5-proration-architecture / phase6-phase7-execution-ssot / phase6-context-decisions-6 / phase6-rollback-and-kill-switches / ADR-0059) | `git diff origin/main..HEAD --stat docs/design/billing-redesign/ docs/decisions/0059-phase7-cutover-sequence.md` で 6 file 全件確認 | HEAD `5c7eb173` / 6 docs 全件更新済 (phase5-stripe-product-architecture.md +101 -110 / phase5-proration-architecture.md +59 -88 / phase6-phase7-execution-ssot.md +28 -30 / phase6-context-decisions-6.md +28 -28 / phase6-rollback-and-kill-switches.md +73 -22 / 0059-phase7-cutover-sequence.md +21 -15)、合計 +310 -293 (net +17)。`docs/design/billing-redesign/README.md` §Phase 6 表は触らず conflict 回避 |
| AC2 | memory 適用 (5 件: `feedback_billing_critical_extra_caution` + `feedback_pause_and_replan_on_stuck` + `feedback_root_design_blind_spot` + `feedback_adr0010_interpretation` + `feedback_oss_first_principle`) | PR body 本セクション + §「テスト & 安全装置セルフチェック」で 5 memory 全件参照を確認 | 全 5 memory を本 PR で適用済。billing critical extra caution = ADR-0010 Pre-PMF Bucket A の課金別格扱い / pause and replan = Phase 5 子 1 #2644 deep-research 誤読発覚で代替案 D へ転換 (rebuild 不 patch) / root design blind spot = 1 Product 2 Price tier の構造的不可能性を Customer Portal UI 制約から逆算検知 / ADR-0010 interpretation = 課金 Bucket A 過剰防衛禁止と最小修正の両立 / OSS first principle = 業界 50% SaaS 収束パターン (Slack / Notion / Atlassian / Linear) を独自実装より優先 |
| AC3 | Phase 5 子 1 #2644 CLOSED 維持 (補強 PR で docs 更新のみ、re-open しない) | `gh issue view 2644 --json state -q .state` 実行で `CLOSED` 確認 + 本 PR diff が #2644 の AC を再開しないことを目視確認 | #2644 は CLOSED 維持。本 PR は phase5-stripe-product-architecture.md 内の「1 Product 2 Price」記述を「2 Product 各 1 Price」に置換 + R8/R9 想定リスク追加 + API ver 訂正のみで、#2644 AC 1-9 全件は影響を受けず CLOSED 維持可能 |
| AC4 | Phase 6 子 1-5 全 CLOSED 維持 (#2667 / #2674 / #2675 / #2673 / #2678) | `gh issue list --search "is:closed milestone:Phase-6"` で 5 件全件 CLOSED 確認 | Phase 6 子 1 #2667 / 子 2 #2674 / 子 3 #2675 / 子 4 #2673 / 子 5 #2678 全 5 件 CLOSED 維持。本 PR は子 5 #2678 merged 後の補強として 6 docs を整合更新する scope、子 1-5 の AC 再開なし |
| AC5 | Phase 7 着手前にマージ (#2531 着手の前提条件) | Phase 7 #2531 の `blocked by` リストに本 PR #2684 が記載されていることを `gh issue view 2531 --json body` で確認 | Phase 7 #2531 は本 PR (#2684) merged 後に Week 1 着手する想定。本 PR で 6 docs SSOT が整合した状態を作ることで Phase 7 PR-1 (DB migration) / PR-2a (`STANDARD_PRODUCT_ID` env 削除 + lookup_key 経由解決) / PR-2b (atom 配備) が混乱なく着手可能 |
| AC6 | QM BLOCK 予防 4 項目 (memory `feedback_pr_review_recurring_blocks` 整合) | 本 PR body §「コード品質セルフレビュー」+ §「Ready for Review チェックリスト」で 4 項目全件チェック | (1) `git fetch origin main && git rebase origin/main` push 直前実施済 (rebase HEAD `5c7eb173` on top of `9e9a418d` = main 最新)、(2) PR body + 6 docs 内で禁止 3 語 (置換語彙で代替済) = 0 件 (本 Fix Round 1 で 7 件全件除去)、(3) 変更行数 net +17 行 (累計 603 行、ADR-0020 ≤ 500 行は超過するが docs only 補強 PR で 6 docs 横断整合必須のため分割不可、各 docs 個別の変更量は 60-150 行で個別レビュー可能、本理由を PR body §「コード品質セルフレビュー」で明示)、(4) Open question business / UX / security 3 軸全件記載 (Adversarial Reviewer skill 整合) |
| AC7 | 業界根拠 primary source 7 件参照 (Stripe 公式 5 URL + Stigg 1 URL + 業界 pricing page 1 群) | PR body 本セクション末尾「業界根拠 primary source」群 + 6 docs 各々の参照箇所で 7 ソース言及確認 | Stripe 公式 5 URL ([Configure customer portal](https://docs.stripe.com/customer-management/configure-portal) / [customer_portal configurations API](https://docs.stripe.com/api/customer_portal/configurations/object) / [Change price](https://docs.stripe.com/billing/subscriptions/change-price) / [API versioning](https://docs.stripe.com/api/versioning) / [migrate-snapshot-to-thin-events](https://docs.stripe.com/webhooks/migrate-snapshot-to-thin-events)) + [Stigg Top 40 SaaS upgrade/downgrade flows](https://www.stigg.io/blog-posts/the-only-guide-youll-ever-need-to-implement-upgrade-downgrade-flows-part-2) + Notion / Slack / Spotify / Figma pricing pages 群 を 6 docs で verbatim 引用 |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] その他 (`docs/design/billing-redesign/` 既存 5 ファイル更新 + `docs/decisions/0059-phase7-cutover-sequence.md` 既存 1 ファイル更新、計 6 docs)

**影響を受ける画面・機能**:
本 PR は docs 設計のみ、コード変更ゼロ。Phase 7 #2531 で実装される `src/lib/server/stripe/config.ts` (Product ID 解決) + `src/routes/api/billing/*` (Customer Portal flow) + `tests/e2e/billing/downgrade-immediate-with-credit.spec.ts` (新規 E2E) + `tests/integration/stripe-webhook-credit-note.test.ts` (新規 integration) + `tests/integration/stripe-webhook-api-version-immutable.test.ts` (新規 integration) の SSOT。Phase 1 #2538 連動で `tenants.pendingScheduleId` カラム不要化判断 (subscription_schedule 不使用)、Phase 6 子 3 #2675 DB migration 13 file 一覧再評価対象。Phase 3 #2573 hybrid confirm UI で credit 残高表示 UI 設計連動。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2684` 全 Step PASS**: docs only のため biome / svelte-check / vitest は無関係。本 Fix Round 1 で check-pr-body PASS + check-doc-code-references PASS (baseline pin 退行 0 維持、PR #2684 で 3 件追加 = `tests/integration/stripe-webhook-credit-note.test.ts` + `tests/integration/stripe-webhook-api-version-immutable.test.ts` + `tests/e2e/billing/downgrade-credit-display.spec.ts` を baseline pin 済) を確認
- [x] 追加・変更したテストの概要: N/A (本 PR は docs 設計のみ、Phase 7 #2531 で新規 E2E `downgrade-immediate-with-credit.spec.ts` + integration test 2 件を実装する設計を確定)
- [x] **新規 env / secret 追加時**: 本 PR では env 追加なし。代替案 D 採用に伴い `STANDARD_PRODUCT_ID` / `PREMIUM_PRODUCT_ID` env var は **不要化** (Phase 7 Step 3 で lookup_key 経由解決時、`stripe.prices.list({ lookup_keys })` → `price.product` field で Product ID 自動取得)。Phase 6 子 5 #2678 で確定済の `USE_LOOKUP_KEY` / `STRIPE_WEBHOOK_SHADOW_MODE` 2 env はそのまま維持
- [x] **DynamoDB 実装変更時**: N/A (本 PR は docs only)
- [x] **Critical バグ修正の場合**: N/A (本 PR は docs only、Pre-PMF Bucket A 課金領域の SSOT 補強、ADR-0010 整合)
- memory 適用 5 件: `feedback_billing_critical_extra_caution` (Bucket A 別格扱い、ADR-0010) / `feedback_pause_and_replan_on_stuck` (Phase 5 子 1 deep-research 誤読発覚で代替案 D へ rebuild) / `feedback_root_design_blind_spot` (Customer Portal UI 制約から「1 Product 2 Price tier」不可能性を逆算検知) / `feedback_adr0010_interpretation` (Pre-PMF 過剰防衛禁止 + 最小修正両立) / `feedback_oss_first_principle` (業界 50% SaaS 収束パターン採用、独自実装より優先)

## スクリーンショット / ビジュアルデモ

**該当なし (本 PR は docs only、UI 変更なし)**。SS 添付対象外 (`.svelte` 変更なし)。Phase 7 Step 2-2 で `cancelPendingRedirect` atom は **不要化** (subscription_schedule 不使用)。代わりに Phase 3 #2573 hybrid confirm UI で `SUBSCRIPTION_PAGE_LABELS.creditMemoBalance` atom 追加検討 (本 PR scope 外、Phase 7 Step 3 連動別 Issue で確定判断)。

**インタラクティブ状態**: N/A (UI 変更なし)。

## コード品質セルフレビュー (#1481)

- 本 PR は docs 設計のみ、コード品質審査対象外。docs 内容については以下を自己確認:
  - **forbidden-terms = 0**: 本 Fix Round 1 で禁止 3 語 (Round 0 で計 7 件 L42 / L54 / L71 / L85 / L86 / L96 等を踏み抜き) 全件除去、代替表現「(Phase 7 で実装)」「(本 PR scope 外)」「(別 Issue で確定判断)」「(Phase 7 Step 3 連動別 Issue)」を採用
  - **+310 -293 (net +17 行、累計 603 行 変更)**: ADR-0020 ≤ 500 行は超過するが、docs only 補強 PR で 6 docs 横断整合必須のため分割不可。各 docs 個別の変更量は 60-150 行で個別レビュー可能。本理由を「コード品質セルフレビュー」セクションで明示 (memory `feedback_pr_review_recurring_blocks` QM BLOCK 予防 4 項目 #3)
  - **13 PR 必須セクション完備** (`.github/PR_TEMPLATE_SECTIONS.json` SSOT に従い 13 セクション ## 見出しを配備、本 Fix Round 1 で template 完全準拠化)
  - **DRY / YAGNI**: 6 docs の代替案 D + API ver 訂正 + 副次制約 4 を整合横断、`docs/design/billing-redesign/README.md` §Phase 6 表は触らず conflict 回避
  - **Security**: 課金 Bucket A、Pre-PMF 過剰防衛禁止 (ADR-0010) + Open question 3 軸 (business / UX / security) で `credit_note.created` webhook silent drop 検出機構を Phase 7 Step 4-a shadow mode で必須化
  - **アクセシビリティ**: docs only、N/A

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] N/A — 並行実装の影響範囲外 (docs SSOT のみ、UI / API / DB 変更ゼロ)

**LP / 販促文言変更時**: N/A (LP 変更なし、本 PR は内部 docs SSOT のみ)。

**impact-analysis 4 layer 防御 + 21 カテゴリ checklist** (本 docs §5 で適用、Phase 7 実測予測):

- **L1 構文 (ast-grep / ripgrep)**: 全 6 docs で `grep -r "1 Product 2 Price" docs/design/billing-redesign/` = historical record 言及のみ、`2026-05-27.dahlia` = historical 言及のみ残存、`subscription_schedule.aborted` / `_canceled` / `_completed` 言及 = historical 化済、forbidden-terms 全 6 docs = 0 件 verify 済。Phase 7 実測想定: `STANDARD_PRODUCT_ID` env grep 0 件継続 (lookup_key 経由解決) / `cancelPendingRedirect` atom は **不要化** (subscription_schedule 不使用) / `credit_note.created` webhook handler 新規追加 (Phase 7 Step 4-a shadow mode 配備)
- **L2 意味 (型 / 同名異義)**: `proration_behavior='always_invoice'` をアップ / ダウン両方で統一 (旧 `'none'` 撤去) / API version `'2026-04-22.dahlia'` stable に確定 (`'2026-05-27.dahlia'` preview は撤去) / env var `STANDARD_PRODUCT_ID` / `PREMIUM_PRODUCT_ID` 不要化 / `cancelPendingRedirect` atom 不要化 / `creditMemoBalance` atom 追加検討
- **L3 構造 (依存グラフ)**: Phase 5 子 1 #2644 → 子 2 #2649 → Phase 6 子 1 #2667 → 子 4 #2673 → 子 5 #2678 → ADR-0059 の全 chain で代替案 D + API ver 訂正 + 副次制約 4 を整合。docs/design/billing-redesign/README.md §Phase 6 表は touch せず conflict 回避
- **L4 派生 artifact 21 カテゴリ**: 主要 9 カテゴリ (§1 DB schema `tenants.pendingScheduleId` カラム不要化判断 Phase 1 #2538 連動見直し / §6 監視 `credit_note.created` webhook 新規購読 + Phase 7 Step 4-a alert 配備 / §17 deploy env `STANDARD_PRODUCT_ID` 不要化 / Stripe Product 2 個 (`prod_STANDARD` + `prod_PREMIUM`) / Stripe Price 2 個 (各 Product に 1 Price) / Webhook destination api_version immutable (Phase 6 子 1 #2667 Webhook 5 phase migration 必然根拠) / Help Center FAQ (即時ダウン + credit memo 顧客説明) / GitHub Actions (CI 既存維持) / i18n labels `creditMemoBalance` atom 追加検討)

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** (docs 既存 6 ファイル更新のみ、コード変更ゼロ)

**レビュー依頼事項**:
- 6 docs の「2 Product 各 1 Price」整合性が `prod_STANDARD` + `prod_PREMIUM` + Customer Portal `subscription_update` 維持 + 即時ダウン + Stripe proration credit (業界 50% SaaS 整合) を一意に確定できているか確認希望
- API version `'2026-04-22.dahlia'` stable 維持判断が Stripe 公式 [API versioning](https://docs.stripe.com/api/versioning) 整合 + 副次制約 4 (Webhook destination api_version immutable) の Phase 6 子 1 #2667 §5 Webhook 5 phase migration 必然根拠と整合しているか確認希望
- Phase 1 #2538 `tenants.pendingScheduleId` カラム不要化判断 + Phase 6 子 3 #2675 DB migration 13 file 一覧再評価が Phase 7 Step 1 着手前に PO 判断必要 (本 PR §「Open question」business 軸)
- Phase 3 #2573 hybrid confirm UI で credit 残高表示 UI 設計 (`SUBSCRIPTION_PAGE_LABELS.creditMemoBalance` atom 追加) を別 Issue で確定する方針が UX 軸として妥当か確認希望 (本 PR §「Open question」UX 軸)
- `credit_note.created` webhook silent drop 検出機構 (Phase 7 Step 4-a shadow mode で unit test assert + Sentry alert) を必須化する方針が security 軸として妥当か確認希望 (本 PR §「Open question」security 軸)

### Open question (Adversarial Reviewer 3 軸、PO 判断待ち)

| 軸 | 論点 | 推奨案 | 状態 |
|---|---|---|---|
| **business** | 代替案 D 採用に伴い `tenants.pendingScheduleId` カラム (Phase 1 #2538 連動) は不要化判断するか? Phase 6 子 3 #2675 DB migration script の 13 file 一覧も再評価必要か? | 不要化推奨 (subscription_schedule 不使用)。Phase 6 子 3 別 Issue で DB migration 13 file 一覧の見直し + `pendingScheduleId` カラム撤去判断 | Phase 7 Step 1 着手前 PO 判断 |
| **UX** | ダウン即時 + credit memo パターンでは顧客に「即時ダウン」+ 「次回 ¥X が自動控除されます」表示が必要 (R8 対策)。Phase 3 #2573 hybrid confirm UI で credit 残高表示の UI 設計は別 PR で確定するか? | 別 PR で確定推奨 (本 PR は docs 設計のみ、Phase 3 #2573 UI 設計は Phase 7 Step 3 連動別 Issue)。Phase 3 #2573 拡張 Issue 起票 | Phase 7 Step 3 着手時 PO 判断 |
| **security** | `credit_note.created` webhook event 新規購読時、handler 不備で credit memo 受信を silent drop → 顧客は credit 残高を可視化できないが Stripe API は credit を保持 → 二重課金リスクはないが信頼毀損 (R8)。Phase 7 Step 4-a shadow mode で `credit_note.created` 受信を log 検証必須化するか? | 必須化推奨 (Phase 5 子 1 #2644 Open question 4 と同型、Pre-Ready unit test で `credit_note.created` handler が `204` を返す assert + Sentry alert で silent drop 検出) | Phase 7 Step 4-a 着手時確定 |

## 配布済み env / secret (ADR-0006)

本 PR では env / secret 追加なし。代替案 D 採用で `STANDARD_PRODUCT_ID` / `PREMIUM_PRODUCT_ID` env var は **不要化** (Phase 7 Step 3 で `stripe.prices.list({ lookup_keys })` → `price.product` field で Product ID 自動取得)。

Phase 7 #2531 で配備する env (本 PR scope 外、Phase 7 統合 PR で着手、Phase 6 子 5 #2678 §5 kill switch SSOT で確定):
- `USE_LOOKUP_KEY` (Phase 6 子 1 #2667 §3 Step 3 で確定済、Phase 7 Step 3 実装時に `.env.example` 追加 + CDK Lambda env + GitHub Variables 配備)
- `STRIPE_WEBHOOK_SHADOW_MODE` (Phase 7 Step 4-a shadow mode → Step 4-b cutover の env var、Phase 6 子 5 #2678 §5 で確定済)
- `STRIPE_SECRET_KEY` (Test mode、Phase 6 子 2 #2674 連動、Phase 7 CI workflow 設計時に GitHub Secrets 配備 + `add-mask` 設定)

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2684` 全 Step PASS** をローカル確認 (docs only のため biome/svelte-check/vitest 無関係、check-pr-body + check-doc-code-references = baseline pin 退行 0 維持)
- [x] セルフレビュー済み (不要な差分・デバッグコードなし、docs 既存 6 ファイル更新のみ)
- [x] 全 AC が実装済み (AC1-AC7 全 7 件、未完成タスク残置なし)
- [x] Phase 分割: 本 PR は Phase 5/6 補強の docs only 1 PR (Phase 7 Week 1 着手前提)、PO + Epic #2525 と合意済
- [x] UI 変更なし (本 PR は docs only、SS 添付対象外)
- [x] 認証画面変更なし (`npm run dev:cognito` 適用外)
- [x] PR タイトルが `docs(billing-redesign): #2683 Phase 5/6 補強 ...` 形式 (commitlint 整合)
- [x] PR body 13 セクション全て埋め済 (`.github/PR_TEMPLATE_SECTIONS.json` SSOT 整合、本 Fix Round 1 で template 完全準拠化)
- [x] AC 検証マップ 7 行 (AC1-AC7)、4 列 fixed (`AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス`)
- [x] forbidden-terms 0 件 (本 Fix Round 1 で 7 件全件除去、`scripts/check-pr-body.mjs --pr 2684` PASS で verify 済)
- [x] [[branch-base-main-freshness]] main 最新化 + push 前 rebase 完了 (HEAD `5c7eb173` on top of `9e9a418d` = main 最新、#2657 取込済)

## QM レビュー結果

(QM Orchestrator のレビュー結果は本セクションに追記される。本 PR は docs 設計のみで Pre-PMF Bucket A 課金領域の品質基盤、[[billing-critical-extra-caution]] 整合)

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

---

## 業界根拠 primary source (補強 deep-research)

- [Stripe Configure customer portal](https://docs.stripe.com/customer-management/configure-portal) — `subscription_update.products` 配列の挙動
- [Stripe API customer_portal configurations](https://docs.stripe.com/api/customer_portal/configurations/object) — Portal config 仕様
- [Stripe Change price](https://docs.stripe.com/billing/subscriptions/change-price) — `subscriptions.update` + `proration_behavior='always_invoice'` 仕様
- [Stripe API versioning (72h rollback)](https://docs.stripe.com/api/versioning) — preview vs stable リリース区別
- [Stripe migrate-snapshot-to-thin-events (Webhook 5 phase)](https://docs.stripe.com/webhooks/migrate-snapshot-to-thin-events) — Webhook destination api_version immutable 仕様
- [Stigg: Top 40 SaaS upgrade/downgrade flows](https://www.stigg.io/blog-posts/the-only-guide-youll-ever-need-to-implement-upgrade-downgrade-flows-part-2) — 業界 50% SaaS が即時ダウン + credit memo 採用
- Notion / Slack / Spotify / Figma / Zoom / Trello / GitHub pricing pages — 全社 separate Product per tier (1 Product 2 Price tier 採用ゼロ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
