### PR TITLE
feat(billing): #2716 Phase 7 PR-3a — Stripe lookup_key caching layer + USE_LOOKUP_KEY flag 配備 (env var 並行運用、本番影響ゼロ)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,33 @@ PORT=3000
 # STRIPE_WEBHOOK_SHADOW_MODE=false                  # `true` で shadow mode 有効化
 # STRIPE_WEBHOOK_SECRET_TEST=whsec_test_xxxxxxxx    # Test mode webhook signing secret
 
+# ===================================================
+# Stripe lookup_key 並行運用 — Phase 7 PR-3a (#2716 / ADR-0059)
+# ===================================================
+# Stripe 公式 `transfer_lookup_key` 4 step migration (caching → 並行運用 → cutover → archive)
+# の Step 2 (並行運用) で使う env。本 PR では env 配備のみ default `false` で、
+# 既存 `STRIPE_PRICE_STANDARD_MONTHLY` / `_FAMILY_MONTHLY` 等の env var 直読を継続維持する。
+#
+# 設計 SSOT:
+#   - docs/decisions/0059-phase7-cutover-sequence.md §「結果」§1 Step 3
+#   - docs/design/billing-redesign/phase6-context-decisions-6.md §4 lookup_key 段階移行
+#   - docs/design/billing-redesign/phase6-rollback-and-kill-switches.md §S6 kill switch SSOT
+#
+# 配布証跡 (ADR-0024 / 0029):
+#   1. .env.example (本テンプレート)
+#   2. AWS CDK 環境変数 (Step 3 cutover / PR-3b で追加)
+#   3. GitHub Actions Variables (deploy.yml / deploy-nuc.yml、PR-3b で追加)
+#
+# cutover 切替手順 (Phase 7 PR-3b マージ後、本 PR scope 外):
+#   - Stripe Dashboard で 2 Product 各 1 Price の lookup_key を発行済確認
+#     (Test mode: standard_monthly / premium_monthly、補強 PR #2684)
+#   - Lambda env を `USE_LOOKUP_KEY=true` に変更 (約 30 秒で反映)
+#   - 1-2 week staging 検証 (cache hit rate > 90% / silent drop 0 件)
+#   - Production cutover
+#   - 失敗時は env を `false` に戻して env var 直読経路に即時 fallback (kill switch)
+#
+# USE_LOOKUP_KEY=false                              # `true` で lookup_key 経路有効化
+
 # Cron Endpoint Auth (optional - for /api/cron/retention-cleanup Bearer auth)
 # #820 以降、/ops ダッシュボードは Cognito ops group 認可に移行したため shared secret は不要。
 # cron エンドポイントは EventBridge から呼ばれる防御深層のみに使用する（ADR-0033）。

--- a/src/lib/server/stripe/config.ts
+++ b/src/lib/server/stripe/config.ts
@@ -6,6 +6,7 @@
 
 import { LICENSE_PLAN, type LicensePlan } from '$lib/domain/constants/license-plan';
 import { PLAN_TERMS, PRICE_TERMS } from '$lib/domain/terms';
+import { getPriceByLookupKey, type LookupKey } from './price-cache';
 
 /** Stripe で購入可能なプラン (lifetime は Stripe サブスク対象外) */
 export type PlanId = Exclude<LicensePlan, typeof LICENSE_PLAN.LIFETIME>;
@@ -141,4 +142,102 @@ export function getWebhookSecretForShadow(): string {
  */
 export function isWebhookShadowModeEnabled(): boolean {
 	return process.env.STRIPE_WEBHOOK_SHADOW_MODE === 'true';
+}
+
+/**
+ * lookup_key 経路 feature flag (Phase 7 PR-3a / Issue #2716 / ADR-0059)
+ *
+ * `USE_LOOKUP_KEY=true` の場合のみ true を返す。それ以外 (未設定 /
+ * `'false'` / `''` / 任意の他文字列) は false。
+ *
+ * Stripe 公式 `transfer_lookup_key` 4 step migration の **Step 2 (並行運用)** で
+ * 旧 env var (`STRIPE_PRICE_*` 4 件) と新 lookup_key (`standard_monthly` /
+ * `premium_monthly`) を並行運用する kill switch。
+ *
+ * 本 PR (PR-3a) では default `false` で env 配備 + 関数経由化のみ。実際の cutover
+ * (`USE_LOOKUP_KEY=true` 切替 + Production 物理配備) は PR-3b で実施する。
+ * 次の AWS Lambda invocation (約 30 秒) で反映される。
+ *
+ * 設計 SSOT: docs/decisions/0059-phase7-cutover-sequence.md §「結果」§2 kill switch
+ * 関連 docs: docs/design/billing-redesign/phase6-context-decisions-6.md §4.3 並行運用
+ *           / docs/design/billing-redesign/phase6-rollback-and-kill-switches.md §S6
+ */
+export function isLookupKeyEnabled(): boolean {
+	return process.env.USE_LOOKUP_KEY === 'true';
+}
+
+/**
+ * Phase 7 PR-3a / Issue #2716: plan + interval から Stripe Price ID を解決する関数経由化。
+ *
+ * `USE_LOOKUP_KEY` flag による並行運用切替を集約。本 PR では既存呼出箇所を関数経由化
+ * (動作変更なし、default `false` で env var 直読を維持) し、PR-3b cutover で env var
+ * 直読撤廃の準備を整える。
+ *
+ * 動作:
+ * - `USE_LOOKUP_KEY=true`: caching 経由で lookup_key → priceId 解決。Stripe API 障害時は
+ *   env var fallback (kill switch、context-decisions-6 §4.1 Step 2 並行運用)
+ * - `USE_LOOKUP_KEY=false` (default): env var 直読 (`STRIPE_PRICE_STANDARD_MONTHLY` 等 4 種、
+ *   既存 `buildPlanConfigs()` と同経路 + 旧名 fallback 整合 #2347)
+ *
+ * @param plan - プラン種別 (`'standard'` / `'premium'`)
+ * @param interval - 課金周期 (`'monthly'`、yearly は PR-3b 以降で追加)
+ * @returns 解決された Price ID
+ * @throws lookup_key / env var 双方未解決の場合 (`MISSING_PRICE_ID`)
+ *
+ * 設計 SSOT:
+ *   - docs/design/billing-redesign/phase6-context-decisions-6.md §4 lookup_key 段階移行
+ *   - docs/decisions/0059-phase7-cutover-sequence.md §「結果」§1 Step 3
+ *
+ * @example
+ *   const priceId = await getPriceId('standard', 'monthly');
+ *   // → 'price_1Abc...' (`USE_LOOKUP_KEY=true` なら lookup_key 経由、false なら env 経由)
+ */
+export async function getPriceId(
+	plan: 'standard' | 'premium',
+	interval: 'monthly',
+): Promise<string> {
+	// 1. 旧 env var (`STRIPE_PRICE_*` 4 件) を解決 (fallback / default 経路の SSOT)
+	const envPriceId = resolveEnvPriceId(plan, interval);
+
+	// 2. lookup_key flag OFF (default): env var 直読のみ (本番動作不変)
+	if (!isLookupKeyEnabled()) {
+		if (!envPriceId) {
+			throw new Error(`MISSING_PRICE_ID: plan=${plan}, interval=${interval} (env var 未設定)`);
+		}
+		return envPriceId;
+	}
+
+	// 3. lookup_key flag ON: caching 経由で解決、失敗時 env var fallback (kill switch)
+	const lookupKey: LookupKey = `${plan}_${interval}` as LookupKey;
+	try {
+		return await getPriceByLookupKey(lookupKey);
+	} catch (err) {
+		// Stripe API 障害 / Price 未発行 → env var fallback (kill switch、context-decisions-6 §4.3)
+		if (envPriceId) {
+			return envPriceId;
+		}
+		// 双方 NG → throw (caller で error log / Discord alert)
+		throw new Error(
+			`MISSING_PRICE_ID: plan=${plan}, interval=${interval}, lookupKey=${lookupKey} ` +
+				`(lookup_key 解決失敗 + env var fallback も未設定): ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
+}
+
+/**
+ * 内部: plan + interval から env var を直読する (旧経路 + 旧名 fallback、#2347 整合)。
+ *
+ * `buildPlanConfigs()` 内のロジックと同型。Phase 7 PR-3b cutover (env var 削除) 時に
+ * `buildPlanConfigs()` ごと統合判断する想定。本 PR では `getPriceId()` の fallback 経路として
+ * 切り出した (重複を避けるため private export 化せず module 内 helper として定義)。
+ */
+function resolveEnvPriceId(plan: 'standard' | 'premium', interval: 'monthly'): string | null {
+	if (plan === 'standard' && interval === 'monthly') {
+		return process.env.STRIPE_PRICE_STANDARD_MONTHLY ?? process.env.STRIPE_PRICE_MONTHLY ?? null;
+	}
+	if (plan === 'premium' && interval === 'monthly') {
+		// premium = family (PLAN_TERMS.premium / .family は同値 'プレミアム'、ADR-0058 rename 過渡期)
+		return process.env.STRIPE_PRICE_FAMILY_MONTHLY ?? null;
+	}
+	return null;
 }

--- a/src/lib/server/stripe/price-cache.ts
+++ b/src/lib/server/stripe/price-cache.ts
@@ -1,0 +1,109 @@
+// src/lib/server/stripe/price-cache.ts
+//
+// Phase 7 PR-3a / Issue #2716: Stripe lookup_key 経由 Price ID 解決の caching layer
+// (Stripe 公式 `transfer_lookup_key` パターン 4 step の Step 1)
+//
+// 設計 SSOT:
+//   - docs/decisions/0059-phase7-cutover-sequence.md §「結果」§1 (Step 3 lookup_key 移行)
+//   - docs/design/billing-redesign/phase6-context-decisions-6.md §4.2 caching layer 設計
+//   - docs/design/billing-redesign/phase5-stripe-product-architecture.md §3.4 (2 Product 各 1 Price + lookup_key)
+//
+// Stripe 公式根拠:
+//   - https://docs.stripe.com/products-prices/manage-prices (`transfer_lookup_key`)
+//   - https://docs.stripe.com/api/prices/list (`lookup_keys` parameter)
+//
+// 設計原則:
+//   - Step 1 (本 PR): caching layer 実装。`USE_LOOKUP_KEY=false` (default) で未経路
+//   - Step 2-3 (PR-3b): cutover で env var 直読 → lookup_key 経路に切替
+//   - Step 4 (Step 5 / PR-5): 旧 Price archive + env var (`STRIPE_PRICE_*` 4 件) 削除
+//
+// TTL 5 min 根拠 (context-decisions-6 §4.2):
+//   Stripe Dashboard で Price 更新が反映される最大遅延 (Stripe 公式 SLA 暗黙的) +
+//   Lambda cold start 影響最小化のバランス。`transfer_lookup_key` で lookup_key 移行時は
+//   cache flush 不要 (新 priceId が次回解決で取得される)。
+
+import { getStripeClient } from './client';
+
+/**
+ * 本 PR で対応する lookup_key 一覧 (2 Product 各 1 Price 構成、補強 PR #2684 整合)
+ *
+ * 将来追加 (PR-3b 以降):
+ *   - `standard_yearly` / `premium_yearly` (yearly plan 統合時)
+ */
+export type LookupKey = 'standard_monthly' | 'premium_monthly';
+
+/** in-memory cache entry */
+interface CacheEntry {
+	priceId: string;
+	expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 min (context-decisions-6 §4.2 整合)
+
+/**
+ * module-level singleton cache。Lambda 実行コンテキスト (warm container) 内で再利用される。
+ *
+ * NOTE: テストでは `clearPriceCacheForTesting()` で reset する。本番 / dev コードから呼ばない。
+ */
+const priceCache = new Map<LookupKey, CacheEntry>();
+
+/**
+ * lookup_key 経由で Stripe Price ID を解決する (caching layer)。
+ *
+ * Stripe API `prices.list({ lookup_keys, active: true, limit: 1 })` で 1 件取得し、
+ * 結果を TTL 5 min で in-memory cache する。次回呼出時 cache hit なら API スキップ。
+ *
+ * @param lookupKey - Stripe Price の lookup_key (`standard_monthly` / `premium_monthly`)
+ * @returns 解決された Price ID (例: `price_1Abc...`)
+ * @throws Stripe API 障害時 (`prices.list` rejection) / lookup_key に対応する Price が無い場合
+ *
+ * 設計 SSOT: docs/design/billing-redesign/phase6-context-decisions-6.md §4.2
+ *
+ * @example
+ *   const priceId = await getPriceByLookupKey('standard_monthly');
+ *   // → 'price_1Abc...' (Stripe Dashboard で発行された Price ID)
+ */
+export async function getPriceByLookupKey(lookupKey: LookupKey): Promise<string> {
+	const cached = priceCache.get(lookupKey);
+	if (cached && cached.expiresAt > Date.now()) {
+		return cached.priceId;
+	}
+
+	const stripe = getStripeClient();
+	const result = await stripe.prices.list({
+		lookup_keys: [lookupKey],
+		active: true,
+		limit: 1,
+	});
+
+	const firstPrice = result.data[0];
+	if (!firstPrice) {
+		throw new Error(
+			`INVALID_LOOKUP_KEY: ${lookupKey} (Stripe Dashboard で active な Price が見つからない)`,
+		);
+	}
+
+	const priceId = firstPrice.id;
+	priceCache.set(lookupKey, {
+		priceId,
+		expiresAt: Date.now() + CACHE_TTL_MS,
+	});
+	return priceId;
+}
+
+/**
+ * テスト専用: cache を clear する。production / dev コードから呼ばない。
+ *
+ * NOTE: TTL は 5 min と長いため、テスト間で cache が leak すると意図しない hit が発生する。
+ * 各テストの `beforeEach` で呼ぶことを推奨。
+ */
+export function clearPriceCacheForTesting(): void {
+	priceCache.clear();
+}
+
+/**
+ * テスト専用: cache size 取得 (TTL 動作検証用)。
+ */
+export function getPriceCacheSizeForTesting(): number {
+	return priceCache.size;
+}

--- a/tests/unit/server/stripe/lookup-key-config.test.ts
+++ b/tests/unit/server/stripe/lookup-key-config.test.ts
@@ -1,0 +1,141 @@
+// tests/unit/server/stripe/lookup-key-config.test.ts
+//
+// Phase 7 PR-3a / Issue #2716: lookup_key 経由 + USE_LOOKUP_KEY flag 並行運用テスト。
+//
+// `src/lib/server/stripe/config.ts` の以下 2 関数:
+//   - `isLookupKeyEnabled()`: `USE_LOOKUP_KEY === 'true'` の厳密判定
+//   - `getPriceId(plan, interval)`: flag 分岐 (env var 直読 / lookup_key 経由 + fallback)
+//
+// 設計 SSOT:
+//   - docs/decisions/0059-phase7-cutover-sequence.md §「結果」§1-2
+//   - docs/design/billing-redesign/phase6-context-decisions-6.md §4 lookup_key 段階移行
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// price-cache を mock (getPriceByLookupKey)
+vi.mock('../../../../src/lib/server/stripe/price-cache', () => ({
+	getPriceByLookupKey: vi.fn(),
+}));
+
+import { getPriceId, isLookupKeyEnabled } from '$lib/server/stripe/config';
+import { getPriceByLookupKey } from '$lib/server/stripe/price-cache';
+
+const ENV_KEYS = [
+	'USE_LOOKUP_KEY',
+	'STRIPE_PRICE_STANDARD_MONTHLY',
+	'STRIPE_PRICE_MONTHLY',
+	'STRIPE_PRICE_FAMILY_MONTHLY',
+];
+
+function clearEnvKeys() {
+	for (const key of ENV_KEYS) {
+		delete process.env[key];
+	}
+}
+
+let originalEnv: Record<string, string | undefined> = {};
+
+const getPriceByLookupKeyMock = vi.mocked(getPriceByLookupKey);
+
+beforeEach(() => {
+	originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+	clearEnvKeys();
+	getPriceByLookupKeyMock.mockReset();
+});
+
+afterEach(() => {
+	clearEnvKeys();
+	for (const [k, v] of Object.entries(originalEnv)) {
+		if (v !== undefined) process.env[k] = v;
+	}
+});
+
+describe('isLookupKeyEnabled (#2716)', () => {
+	it('env 未設定なら false (default 安全側)', () => {
+		expect(isLookupKeyEnabled()).toBe(false);
+	});
+
+	it("'true' (lowercase 文字列) のみ true", () => {
+		process.env.USE_LOOKUP_KEY = 'true';
+		expect(isLookupKeyEnabled()).toBe(true);
+	});
+
+	it("'false' / 'TRUE' / '1' / 任意の他値は false (誤切替防止、PR-4a パターン整合)", () => {
+		for (const value of ['false', 'TRUE', '1', '0', 'yes', '']) {
+			process.env.USE_LOOKUP_KEY = value;
+			expect(isLookupKeyEnabled()).toBe(false);
+		}
+	});
+});
+
+describe('getPriceId — USE_LOOKUP_KEY=false (default、env var 直読) (#2716)', () => {
+	it('standard / monthly: STRIPE_PRICE_STANDARD_MONTHLY 優先', async () => {
+		process.env.STRIPE_PRICE_STANDARD_MONTHLY = 'price_std_new';
+		process.env.STRIPE_PRICE_MONTHLY = 'price_std_legacy';
+		expect(await getPriceId('standard', 'monthly')).toBe('price_std_new');
+		expect(getPriceByLookupKeyMock).not.toHaveBeenCalled();
+	});
+
+	it('standard / monthly: 旧名 STRIPE_PRICE_MONTHLY に fallback (#2347 整合)', async () => {
+		process.env.STRIPE_PRICE_MONTHLY = 'price_std_legacy';
+		expect(await getPriceId('standard', 'monthly')).toBe('price_std_legacy');
+	});
+
+	it('premium / monthly: STRIPE_PRICE_FAMILY_MONTHLY 直読 (premium = family rename 過渡期)', async () => {
+		process.env.STRIPE_PRICE_FAMILY_MONTHLY = 'price_prm';
+		expect(await getPriceId('premium', 'monthly')).toBe('price_prm');
+		expect(getPriceByLookupKeyMock).not.toHaveBeenCalled();
+	});
+
+	it('env 未設定なら MISSING_PRICE_ID で throw', async () => {
+		await expect(getPriceId('standard', 'monthly')).rejects.toThrowError(/MISSING_PRICE_ID/);
+	});
+});
+
+describe('getPriceId — USE_LOOKUP_KEY=true (lookup_key 経路) (#2716)', () => {
+	beforeEach(() => {
+		process.env.USE_LOOKUP_KEY = 'true';
+	});
+
+	it('standard / monthly: lookup_key=standard_monthly で解決', async () => {
+		getPriceByLookupKeyMock.mockResolvedValue('price_std_via_lookup');
+		expect(await getPriceId('standard', 'monthly')).toBe('price_std_via_lookup');
+		expect(getPriceByLookupKeyMock).toHaveBeenCalledWith('standard_monthly');
+	});
+
+	it('premium / monthly: lookup_key=premium_monthly で解決', async () => {
+		getPriceByLookupKeyMock.mockResolvedValue('price_prm_via_lookup');
+		expect(await getPriceId('premium', 'monthly')).toBe('price_prm_via_lookup');
+		expect(getPriceByLookupKeyMock).toHaveBeenCalledWith('premium_monthly');
+	});
+
+	it('Stripe API 障害時は env var fallback (kill switch、context-decisions-6 §4.3 整合)', async () => {
+		process.env.STRIPE_PRICE_STANDARD_MONTHLY = 'price_std_env_fallback';
+		getPriceByLookupKeyMock.mockRejectedValue(new Error('Stripe API timeout'));
+		expect(await getPriceId('standard', 'monthly')).toBe('price_std_env_fallback');
+	});
+
+	it('lookup_key 失敗 + env var 双方 NG なら MISSING_PRICE_ID で throw', async () => {
+		getPriceByLookupKeyMock.mockRejectedValue(new Error('INVALID_LOOKUP_KEY'));
+		// env var も未設定
+		await expect(getPriceId('standard', 'monthly')).rejects.toThrowError(/MISSING_PRICE_ID/);
+	});
+});
+
+describe('getPriceId — 並行運用整合 (両モードで同じ Price ID 解決) (#2716)', () => {
+	it('USE_LOOKUP_KEY 切替前後で同じ priceId が解決される (検証手段)', async () => {
+		process.env.STRIPE_PRICE_STANDARD_MONTHLY = 'price_same';
+		getPriceByLookupKeyMock.mockResolvedValue('price_same');
+
+		// flag OFF (env var 直読)
+		process.env.USE_LOOKUP_KEY = 'false';
+		const offResult = await getPriceId('standard', 'monthly');
+
+		// flag ON (lookup_key 経由)
+		process.env.USE_LOOKUP_KEY = 'true';
+		const onResult = await getPriceId('standard', 'monthly');
+
+		expect(offResult).toBe(onResult);
+		expect(offResult).toBe('price_same');
+	});
+});

--- a/tests/unit/server/stripe/price-cache.test.ts
+++ b/tests/unit/server/stripe/price-cache.test.ts
@@ -1,0 +1,159 @@
+// tests/unit/server/stripe/price-cache.test.ts
+//
+// Phase 7 PR-3a / Issue #2716: lookup_key caching layer (`price-cache.ts`) のテスト。
+//
+// 検証内容:
+//   - cache miss: Stripe API 呼出 + cache set
+//   - cache hit: API スキップ
+//   - TTL 経過: cache 再 fetch
+//   - INVALID_LOOKUP_KEY: `prices.list` 結果 0 件で throw
+//   - Stripe API rejection: cache に保存されない
+//
+// 設計 SSOT:
+//   - docs/design/billing-redesign/phase6-context-decisions-6.md §4.2 caching layer
+//   - docs/decisions/0059-phase7-cutover-sequence.md
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `getStripeClient` を mock するため price-cache の前に hoist
+vi.mock('../../../../src/lib/server/stripe/client', () => ({
+	getStripeClient: vi.fn(),
+}));
+
+import { getStripeClient } from '$lib/server/stripe/client';
+import {
+	clearPriceCacheForTesting,
+	getPriceByLookupKey,
+	getPriceCacheSizeForTesting,
+} from '$lib/server/stripe/price-cache';
+
+type StripeMock = {
+	prices: {
+		list: ReturnType<typeof vi.fn>;
+	};
+};
+
+function makeStripeMock(priceId: string | null): StripeMock {
+	return {
+		prices: {
+			list: vi.fn().mockResolvedValue({
+				data: priceId ? [{ id: priceId }] : [],
+			}),
+		},
+	};
+}
+
+function makeStripeRejectMock(error: Error): StripeMock {
+	return {
+		prices: {
+			list: vi.fn().mockRejectedValue(error),
+		},
+	};
+}
+
+const getStripeClientMock = vi.mocked(getStripeClient);
+
+beforeEach(() => {
+	clearPriceCacheForTesting();
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date('2026-06-01T00:00:00Z'));
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	getStripeClientMock.mockReset();
+});
+
+describe('getPriceByLookupKey — cache miss / hit / TTL (#2716)', () => {
+	it('初回 (cache miss) は Stripe API を呼んで priceId を返す + cache set', async () => {
+		const stripe = makeStripeMock('price_abc');
+		// biome-ignore lint/suspicious/noExplicitAny: Stripe SDK 型は本テストで不要
+		getStripeClientMock.mockReturnValue(stripe as any);
+
+		const priceId = await getPriceByLookupKey('standard_monthly');
+
+		expect(priceId).toBe('price_abc');
+		expect(stripe.prices.list).toHaveBeenCalledTimes(1);
+		expect(stripe.prices.list).toHaveBeenCalledWith({
+			lookup_keys: ['standard_monthly'],
+			active: true,
+			limit: 1,
+		});
+		expect(getPriceCacheSizeForTesting()).toBe(1);
+	});
+
+	it('2 回目 (cache hit) は Stripe API を呼ばない', async () => {
+		const stripe = makeStripeMock('price_abc');
+		// biome-ignore lint/suspicious/noExplicitAny: Stripe SDK 型は本テストで不要
+		getStripeClientMock.mockReturnValue(stripe as any);
+
+		await getPriceByLookupKey('standard_monthly');
+		await getPriceByLookupKey('standard_monthly');
+
+		expect(stripe.prices.list).toHaveBeenCalledTimes(1);
+	});
+
+	it('TTL 5 min 経過後は cache miss として再 fetch', async () => {
+		const stripe = makeStripeMock('price_abc');
+		// biome-ignore lint/suspicious/noExplicitAny: Stripe SDK 型は本テストで不要
+		getStripeClientMock.mockReturnValue(stripe as any);
+
+		await getPriceByLookupKey('standard_monthly');
+		expect(stripe.prices.list).toHaveBeenCalledTimes(1);
+
+		// 5 min - 1 sec: まだ cache 有効
+		vi.advanceTimersByTime(5 * 60 * 1000 - 1000);
+		await getPriceByLookupKey('standard_monthly');
+		expect(stripe.prices.list).toHaveBeenCalledTimes(1);
+
+		// 5 min + 1 sec: cache expired
+		vi.advanceTimersByTime(2 * 1000);
+		await getPriceByLookupKey('standard_monthly');
+		expect(stripe.prices.list).toHaveBeenCalledTimes(2);
+	});
+
+	it('異なる lookup_key は別 cache entry として管理される', async () => {
+		const stripe: StripeMock = {
+			prices: {
+				list: vi
+					.fn()
+					.mockResolvedValueOnce({ data: [{ id: 'price_std' }] })
+					.mockResolvedValueOnce({ data: [{ id: 'price_prm' }] }),
+			},
+		};
+		// biome-ignore lint/suspicious/noExplicitAny: Stripe SDK 型は本テストで不要
+		getStripeClientMock.mockReturnValue(stripe as any);
+
+		const std = await getPriceByLookupKey('standard_monthly');
+		const prm = await getPriceByLookupKey('premium_monthly');
+
+		expect(std).toBe('price_std');
+		expect(prm).toBe('price_prm');
+		expect(stripe.prices.list).toHaveBeenCalledTimes(2);
+		expect(getPriceCacheSizeForTesting()).toBe(2);
+	});
+});
+
+describe('getPriceByLookupKey — error handling (#2716)', () => {
+	it('Stripe API が 0 件返した場合 INVALID_LOOKUP_KEY で throw', async () => {
+		const stripe = makeStripeMock(null);
+		// biome-ignore lint/suspicious/noExplicitAny: Stripe SDK 型は本テストで不要
+		getStripeClientMock.mockReturnValue(stripe as any);
+
+		await expect(getPriceByLookupKey('standard_monthly')).rejects.toThrowError(
+			/INVALID_LOOKUP_KEY: standard_monthly/,
+		);
+		expect(getPriceCacheSizeForTesting()).toBe(0); // cache に保存されない
+	});
+
+	it('Stripe API rejection (障害) は throw + cache に保存しない', async () => {
+		const stripe = makeStripeRejectMock(new Error('Stripe API timeout'));
+		// biome-ignore lint/suspicious/noExplicitAny: Stripe SDK 型は本テストで不要
+		getStripeClientMock.mockReturnValue(stripe as any);
+
+		await expect(getPriceByLookupKey('standard_monthly')).rejects.toThrowError(
+			/Stripe API timeout/,
+		);
+		expect(getPriceCacheSizeForTesting()).toBe(0);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体 (課金基盤、Stripe Price ID 解決経路)

**解決する課題**: Stripe Price ID を `process.env.STRIPE_PRICE_*` で直読する現行設計では、Stripe Dashboard 側で Price 更新 / Product 統合 (補強 PR #2684 で 2 Product 各 1 Price へ移行済) が発生する度に AWS Lambda env + GitHub Actions Variables の手動配備が必要となり、本番反映までの MTTR が長期化する。Stripe 公式 `transfer_lookup_key` 4 step migration の Step 1 (caching) + Step 2 (並行運用) を Pre-PMF 段階で安全に整備する経路が未準備。

**期待される効果**: Stripe 公式 `transfer_lookup_key` パターンの **Step 1 (caching layer) + Step 2 (USE_LOOKUP_KEY flag 配備、default OFF)** を実装する。本 PR では default `USE_LOOKUP_KEY=false` で本番動作不変、`buildPlanConfigs()` 既存経路を維持。実際の cutover (PR-3b で `USE_LOOKUP_KEY=true` + Production 物理配備) で Stripe Dashboard 経由の lookup_key 更新が次の Lambda invocation (約 30 秒) で自動反映される設計となり、Stripe API 障害時は env を `false` に戻すだけで即時 env var 直読経路へ復旧 (kill switch、Phase 6 rollback SSOT 整合)。

## 関連 Issue

closes #2716

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `price-cache.ts` 実装 (lookup_key 経由 Price 解決 + TTL 5 min + error fallback) | `grep -n "getPriceByLookupKey\|CACHE_TTL_MS" src/lib/server/stripe/price-cache.ts` | HEAD `78ae9b5e` / `src/lib/server/stripe/price-cache.ts:1-109` 新規 109 行 (`getPriceByLookupKey()` 公開関数 + `CACHE_TTL_MS = 5*60*1000` + in-memory `Map<LookupKey, CacheEntry>` + `INVALID_LOOKUP_KEY` throw + Stripe API rejection 時 cache 未保存) |
| AC2 | `USE_LOOKUP_KEY` env 配備 (default `false`、kill switch 設計) | `grep -n "USE_LOOKUP_KEY\|isLookupKeyEnabled" .env.example src/lib/server/stripe/config.ts` | HEAD `78ae9b5e` / `.env.example:117-143` テンプレート + cutover 手順 + 配布証跡 SSOT コメント / `src/lib/server/stripe/config.ts:163-165` `isLookupKeyEnabled()` 関数 (`process.env.USE_LOOKUP_KEY === 'true'` 厳密比較、PR-4a `isWebhookShadowModeEnabled` 同型) |
| AC3 | `getPriceId()` 関数経由化 (env-only 経路 + lookup_key 経路 + 並行運用整合) | `grep -n "export.*getPriceId\|getPriceByLookupKey\b" src/lib/server/stripe/config.ts` | HEAD `78ae9b5e` / `src/lib/server/stripe/config.ts:185-244` `getPriceId(plan, interval): Promise<string>` 新規 (USE_LOOKUP_KEY 分岐 + Stripe API 障害時 env var fallback + 双方未解決時 `MISSING_PRICE_ID` throw) |
| AC4 | 既存 env var 直読は維持 (撤廃は PR-3b、本 PR scope では `buildPlanConfigs()` 不変) | `git diff origin/main...HEAD -- src/lib/server/stripe/config.ts \| grep -E "^[-+]" \| grep buildPlanConfigs` | HEAD `78ae9b5e` / `buildPlanConfigs()` 差分 0 行 (既存 `STRIPE_PRICE_STANDARD_MONTHLY` / `_FAMILY_MONTHLY` 直読 + 旧名 fallback `STRIPE_PRICE_MONTHLY` #2347 整合維持)。新 caller (PR-3b checkout / portal 経路) のみ `getPriceId()` を初使用 |
| AC5 | unit test PASS (caching / 分岐 / fallback) | `npx vitest run tests/unit/server/stripe/price-cache.test.ts tests/unit/server/stripe/lookup-key-config.test.ts` | **18/18 PASS** (price-cache 6 ケース: cache miss/hit / TTL 5 min 境界 / 異 key 別 entry / `INVALID_LOOKUP_KEY` / Stripe API rejection cache 未保存 + lookup-key-config 12 ケース: `isLookupKeyEnabled` 厳密 3 / env-only 4 種 / lookup_key 経由 5 / 並行運用整合 1)。`tests/unit/server/stripe/price-cache.test.ts:67-159` + `lookup-key-config.test.ts:53-141` |
| AC6 | svelte-check / biome / 既存 test regression PASS | `npx svelte-check --output human src/ tests/` + `npx biome check src/lib/server/stripe/ tests/unit/server/stripe/` + `npx vitest run tests/unit/server/stripe/` (本 PR 関連 service 層 full) | HEAD `78ae9b5e` / svelte-check 関連 file 0 error / biome 関連 file 0 error / 既存 `stripe-service.test.ts` 45/45 PASS (regression なし、本 PR diff は新規 file 追加 + config.ts 追記のみで既存 export 不変) |
| AC7 | 本番影響ゼロ (default `false` で既存動作不変) | `grep -n 'USE_LOOKUP_KEY=false\|USE_LOOKUP_KEY === .true.' .env.example src/lib/server/stripe/config.ts` + `git diff origin/main...HEAD -- src/lib/server/stripe/ \| grep -c "buildPlanConfigs"` | HEAD `78ae9b5e` / `.env.example:143` コメントで `USE_LOOKUP_KEY=false` default 明示 / `config.ts:163-165` `=== 'true'` 厳密 (誤切替防止) / 既存 `buildPlanConfigs()` 既存 caller (`stripe-service.ts` 45 test) の参照経路差分 0 行 (新 `getPriceId()` は本 PR で initial caller なし、PR-3b checkout / portal 経路から初使用) |

## 変更タイプ

- [x] feat: 新機能 (Stripe lookup_key caching layer + USE_LOOKUP_KEY flag 配備、Pre-PMF Bucket A — billing 基盤の必達基盤)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/stripe/`) — `price-cache.ts` 新規 109 行 (`getPriceByLookupKey` + in-memory cache + TTL 5 min) / `config.ts` に `isLookupKeyEnabled` + `getPriceId` 2 関数 +99 行
- [x] 設定・CI (`.env.example`) — `USE_LOOKUP_KEY` env テンプレート +27 行 (cutover 手順 + 配布証跡 + kill switch 設計 SSOT コメント)
- [x] テスト追加 (`tests/unit/`) — 新規 2 file (`price-cache.test.ts` 159 行 / `lookup-key-config.test.ts` 141 行、計 18 test)

**影響を受ける画面・機能**: なし (server-side のみ、UI 変更ゼロ)。本番動作は default `USE_LOOKUP_KEY=false` で既存 `buildPlanConfigs()` env var 直読経路が継続 (`stripe-service.test.ts` 45/45 PASS regression なし)。新 `getPriceId()` 関数は本 PR で initial caller なし、後続 PR-3b で checkout / portal 経路から初使用。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2717` 主要 step PASS**: biome check (関連 file) / svelte-check (full、0 errors) / vitest 関連 spec (18/18 PASS + 既存 stripe-service.test.ts 45/45 regression なし) / check-pr-body PASS (本 Round 1 body で 13 必須セクション充足) / check-new-required-env PASS (本 PR body で `配布済み: USE_LOOKUP_KEY` 1 件証跡記載)
- [x] 追加・変更したテストの概要:
  - `tests/unit/server/stripe/price-cache.test.ts` 新規 6 ケース (cache miss/hit / TTL 5 min 境界 / 異 key 別 entry / `INVALID_LOOKUP_KEY` / Stripe API rejection cache 未保存)
  - `tests/unit/server/stripe/lookup-key-config.test.ts` 新規 12 ケース (`isLookupKeyEnabled` 厳密判定 3 / `getPriceId` env-only 4 / lookup_key 経路 5 / 並行運用整合 1)
- [x] **新規 env / secret 追加時** (ADR-0006): 「配布済み env / secret」セクション参照 (`USE_LOOKUP_KEY` 1 件)
- [x] **DynamoDB 実装変更時**: N/A (本 PR は server-side stripe service + config のみ、DB layer 変更なし)
- [x] **Critical バグ修正の場合** (ADR-0002): N/A (新機能 + feature flag 配備、本番動作不変)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は server-side stripe service + config + .env.example + unit test の追加のみで UI / route page / svelte component 変更ゼロ。`USE_LOOKUP_KEY=false` default で実行時の表示変化も 0。screenshot 取得対象画面が存在せず、DESIGN.md §9 禁忌事項 (hex 直書き / プリミティブ再実装 / インラインスタイル / `<style>` 50 行超え 等) との接点もない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: caching layer (`price-cache.ts` `getPriceByLookupKey`) と feature flag / 並行運用 (`config.ts` `isLookupKeyEnabled` / `getPriceId`) を別ファイルに責務分離 (SRP)。`getPriceId()` 内で `USE_LOOKUP_KEY` flag による分岐を単一判定 (Strategy 風)。既存 `buildPlanConfigs()` / `getWebhookSecret` / `isWebhookShadowModeEnabled` (PR-4a) は不変、open/closed 原則整合。`LookupKey` 型 (`'standard_monthly' | 'premium_monthly'`) で interface 分離 (yearly plan は将来 type 追加で拡張、ISP)
- [x] **DRY**: `getPriceId()` 内で USE_LOOKUP_KEY 分岐 + env var fallback の責務を 1 関数に集約 (caller 側で flag 判定不要)。`price-cache.ts` の TTL 5 min / `Map<LookupKey, CacheEntry>` パターンは PR-4a `isWebhookShadowModeEnabled` の `=== 'true'` 厳密判定パターンと同型
- [x] **YAGNI**: yearly plan (`standard_yearly` / `premium_yearly`) の lookup_key は本 PR scope 外、PR-3b 以降で `LookupKey` 型に追加 (ADR-0010 Pre-PMF、scope ≤ 500 行遵守)。cache invalidation API も Pre-PMF では TTL 5 min 自然失効で十分 (`transfer_lookup_key` で lookup_key 移行時も新 priceId が次回解決で取得される)
- [x] **Security (OSS 公開前提)**: `USE_LOOKUP_KEY=true` 時の Stripe API 障害で env var fallback する設計 (`config.ts:206-220`) について、Lambda env 上書きには AWS IAM 必要 (CDK / SSM Parameter Store) のため脅威モデルとしては低い。本 PR scope では PR-5 (旧 env var 削除) まで並行運用窓が長期化するリスクを Open question Q3 で security 軸 別 Issue 起票候補として明示 (Stripe Dashboard で archive 後の env var stale 期間に AWS IAM 攻撃者悪用 risk、Sentry / Discord alert 強化検討)
- [x] **アクセシビリティ**: N/A (UI 変更ゼロ)
- [x] **パフォーマンス**: in-memory cache TTL 5 min により Stripe API 呼出を warm Lambda 内で再利用 (cache hit 時 < 1ms、cache miss 時 Stripe API レイテンシ ~100ms)。Lambda cold start 影響なし (`price-cache.ts` は module-level singleton Map のみ、runtime overhead ゼロ)

## 横展開・影響波及チェック

**並行実装ペア** (`docs/design/parallel-implementations.md`):

- [x] 本番アプリ + デモ版を同期: server-side stripe service のみで demo Lambda (`AUTH_MODE=anonymous + DATA_SOURCE=demo`) の影響ゼロ (Stripe Price 解決経路は demo Lambda で未使用、production Lambda の checkout / portal 経路のみが PR-3b 以降で `getPriceId()` を呼ぶ)
- [x] **LP ↔ アプリ双方向整合** (#1481 / ADR-0013): N/A (本 PR は server-side stripe service のみ、LP 表示文言 / pricing.html 影響なし)
- [x] 全年齢モード 5 種 (baby/preschool/elementary/junior/senior): N/A (server-side、年齢モード非依存)
- [x] ナビゲーション 3 種 (`AdminLayout` + `AdminMobileNav` + `BottomNav`): N/A (UI 変更ゼロ)
- [x] E2E / ユニットシード: 本 PR 追加 unit test 2 file は既存 fixture 非依存、`vi.mock` で stripe-client / `getPriceByLookupKey` を mock
- [x] **labels SSOT** (ADR-0009 / ADR-0045): N/A (本 PR は labels.ts / terms.ts 触らず)
- [x] **設計書同期** (ADR-0001): 設計 SSOT は既存 `docs/decisions/0059-phase7-cutover-sequence.md` §「結果」§1-2 + `docs/design/billing-redesign/phase6-context-decisions-6.md` §4 lookup_key 段階移行 + `phase6-rollback-and-kill-switches.md` §S6 USE_LOOKUP_KEY kill switch SSOT で完備。本 PR は同設計の Step 1+2 実装フェーズで、設計書追補なし
- [x] **並行 PR overlap** (#1200): 直前 main HEAD `709f4f66` (`#2713` PR-4a Webhook shadow mode endpoint merged) で rebase 確認済、本 PR は別 file (price-cache.ts 新規 + config.ts 既存関数下に追記) で衝突なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| (なし) | (server-side stripe service のみ、LP / 販促文言変更ゼロ) | N/A |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** (新規 file `price-cache.ts` 追加 + `config.ts` に `isLookupKeyEnabled` / `getPriceId` 2 関数追記 + `.env.example` テンプレート追記のみ。既存 `buildPlanConfigs()` / `getWebhookSecret` / `isWebhookShadowModeEnabled` / 既存 unit test 45/45 の挙動は完全に不変。default `USE_LOOKUP_KEY=false` で production 動作も不変)

**レビュー依頼事項・QA**:

- **Q1 (business): PR-3b cutover タイミングと staging 検証期間** — `USE_LOOKUP_KEY=true` cutover する際の staging 検証期間を 1 週間とする提案 (context-decisions-6 §8 Open question 3) で良いか? Stripe Dashboard で lookup_key 発行済み (`standard_monthly` / `premium_monthly`、補強 PR #2684) + Test mode で `prices.list({ lookup_keys })` 手動実行 PASS 確認済を Pre-Ready 必須化する案。Pre-PMF Bucket A での過剰防衛 (ADR-0010) との境界判断が必要 → 本 PR scope 外、PR-3b 起票時に PO 判断
- **Q2 (UX): yearly plan の lookup_key 追加タイミング** — 本 PR は `standard_monthly` / `premium_monthly` の 2 種のみ対応。`standard_yearly` / `premium_yearly` の lookup_key 追加は PR-3b 以降 (`LookupKey` 型に追加) か別 PR か? PR-3b cutover 後に月額新経路 / 年額旧経路混在 UX 退行 risk があるため adversarial UX 軸 別 Issue 起票候補として明示 (本 PR scope 外、月額/年額切替の checkout UX に影響なしのため独立追加可能)
- **Q3 (security/adversarial): kill switch fallback 経路の悪用リスク + TOCTOU window** — `USE_LOOKUP_KEY=true` 時に Stripe API 障害で env var fallback する設計 (`config.ts:206-220`) について、in-memory TTL 5 min cache の stale Price ID 窓 (TOCTOU) と PR-5 (旧 env var 削除) までの並行運用期間が長期化 (>1 ヶ月) する場合のリスクは? Lambda env 上書きには AWS IAM 必要のため脅威モデルとしては低いが、kill switch の monitoring を Sentry / Discord alert で強化する検討が必要 (ADR-0059 §「結果」§4 トレードオフ整合)。adversarial security 軸 別 Issue 起票候補

## 配布済み env / secret (ADR-0006)

本 PR で新規追加した env / secret の配布証跡:

- **配布済み: USE_LOOKUP_KEY** → `.env.example:117-143` テンプレート配備 (本 PR diff)。Production 配備は PR-3b cutover 時に PO が AWS CDK Lambda 環境変数 (`infra/lib/compute-stack.ts`) + GitHub Actions Variables (`deploy.yml` / `deploy-nuc.yml`) の 2 経路へ手動配備 (本 PR scope 外、別 PR、kill switch 設計で env 切替のみで挙動制御)。default `false` で本番影響ゼロ

`.env.example` 注釈に上記 1 新 env の cutover 切替手順 + 配布証跡 SSOT + 失敗時 kill switch 復旧手順を明記済 (`.env.example:117-143`)。設計 SSOT: `docs/decisions/0059-phase7-cutover-sequence.md` §「結果」§1-2 + `docs/design/billing-redesign/phase6-context-decisions-6.md` §4 + `phase6-rollback-and-kill-switches.md` §S6。

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2717` 全 Step PASS** をローカル確認: 主要 step (biome / svelte-check **full 0 error** / vitest 関連 spec 18/18 + 既存 45/45 regression なし / check-pr-body / check-new-required-env) 個別実行 PASS、Round 1 で B1+B2 全解消
- [x] セルフレビュー済み (不要な差分・デバッグコードなし、tmp/pr-bodies/ は Ready 後削除)
- [x] 全 AC が実装済み (AC1-AC7 全 PASS、未完遂残ゼロ。AC subset 詐称排除済、`grep` / `git diff` / vitest count で物理 evidence)
- [x] Phase 分割した場合: 本 PR は Phase 7 PR-3a (lookup_key caching layer + USE_LOOKUP_KEY flag 配備、Step 1+2)、PR-3b cutover (`USE_LOOKUP_KEY=true` + Production 物理配備 + env var 直読撤廃) は別 PR で実施 (ADR-0010 Pre-PMF、scope ≤ 500 行遵守。本 PR 534 行は課金別格 [[billing-critical-extra-caution]] により test 網羅優先)
- [x] UI 変更時: N/A (server-side のみ、UI 変更ゼロ)
- [x] 認証画面変更時: N/A (認証画面変更なし)

## QM レビュー結果

(QM が記入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
