### PR TITLE
feat(billing): #2721 Phase 7 PR-3b — lookup_key Production cutover + apiVersion 物理 bump (#2627 同期)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,11 +122,14 @@ PORT=3000
 # STRIPE_WEBHOOK_SECRET_TEST=whsec_test_xxxxxxxx    # Test mode webhook signing secret
 
 # ===================================================
-# Stripe lookup_key 並行運用 — Phase 7 PR-3a (#2716 / ADR-0059)
+# Stripe lookup_key Production cutover — Phase 7 PR-3b (#2721 / ADR-0059)
 # ===================================================
-# Stripe 公式 `transfer_lookup_key` 4 step migration (caching → 並行運用 → cutover → archive)
-# の Step 2 (並行運用) で使う env。本 PR では env 配備のみ default `false` で、
-# 既存 `STRIPE_PRICE_STANDARD_MONTHLY` / `_FAMILY_MONTHLY` 等の env var 直読を継続維持する。
+# Stripe 公式 `transfer_lookup_key` 4 step migration の **Step 3 (cutover) 完了済**。
+# Production Stripe Dashboard に 2 Product 各 1 Price + lookup_key 発行済 (#2627、
+# 2026-05-31 PO 同期完了)。CDK default `true` で lookup_key 経路を本番有効化。
+#
+# default 値: `true` (cutover 後、CDK SSOT)
+# kill switch: Lambda env を `USE_LOOKUP_KEY=false` に変更 → 約 30 秒で env var 直読に巻き戻し
 #
 # 設計 SSOT:
 #   - docs/decisions/0059-phase7-cutover-sequence.md §「結果」§1 Step 3
@@ -134,19 +137,18 @@ PORT=3000
 #   - docs/design/billing-redesign/phase6-rollback-and-kill-switches.md §S6 kill switch SSOT
 #
 # 配布証跡 (ADR-0024 / 0029):
-#   1. .env.example (本テンプレート)
-#   2. AWS CDK 環境変数 (Step 3 cutover / PR-3b で追加)
-#   3. GitHub Actions Variables (deploy.yml / deploy-nuc.yml、PR-3b で追加)
+#   1. .env.example (本テンプレート、cutover 完了後の default 表記)
+#   2. AWS CDK 環境変数 (PR-3b で配備、infra/lib/compute-stack.ts useLookupKey)
+#   3. GitHub Actions Variables (PR-3b で配備、deploy.yml `-c useLookupKey=${{ vars.USE_LOOKUP_KEY || 'true' }}`)
 #
-# cutover 切替手順 (Phase 7 PR-3b マージ後、本 PR scope 外):
-#   - Stripe Dashboard で 2 Product 各 1 Price の lookup_key を発行済確認
-#     (Test mode: standard_monthly / premium_monthly、補強 PR #2684)
-#   - Lambda env を `USE_LOOKUP_KEY=true` に変更 (約 30 秒で反映)
-#   - 1-2 week staging 検証 (cache hit rate > 90% / silent drop 0 件)
-#   - Production cutover
-#   - 失敗時は env を `false` に戻して env var 直読経路に即時 fallback (kill switch)
+# ロールバック手順 (Phase 6 子 5 #2678 §S2 整合):
+#   - PR-3b マージ前: revert 可
+#   - マージ後 24h 以内: GitHub Actions Variables に `USE_LOOKUP_KEY=false` 設定 + CDK redeploy
+#   - 1 週間後: forward-fix のみ (旧 env var は PR-5 cleanup で削除)
 #
-# USE_LOOKUP_KEY=false                              # `true` で lookup_key 経路有効化
+# 1-2 week smoke test PASS 後の PR-5 で旧 env var (`STRIPE_PRICE_STANDARD_MONTHLY` 等 4 件) 削除。
+#
+# USE_LOOKUP_KEY=true                               # cutover 完了、default `true`
 
 # Cron Endpoint Auth (optional - for /api/cron/retention-cleanup Bearer auth)
 # #820 以降、/ops ダッシュボードは Cognito ops group 認可に移行したため shared secret は不要。

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -217,6 +217,9 @@ jobs:
             -c stripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET }} \
             -c stripePriceStandardMonthly=${{ vars.STRIPE_PRICE_STANDARD_MONTHLY }} \
             -c stripePriceFamilyMonthly=${{ vars.STRIPE_PRICE_FAMILY_MONTHLY }} \
+            -c useLookupKey=${{ vars.USE_LOOKUP_KEY || 'true' }} \
+            -c stripeWebhookShadowMode=${{ vars.STRIPE_WEBHOOK_SHADOW_MODE || 'false' }} \
+            -c stripeWebhookSecretTest=${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }} \
             -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }} \
             -c cronSecret=${{ secrets.CRON_SECRET }} \
             -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
@@ -240,6 +243,9 @@ jobs:
           -c stripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET }}
           -c stripePriceStandardMonthly=${{ vars.STRIPE_PRICE_STANDARD_MONTHLY }}
           -c stripePriceFamilyMonthly=${{ vars.STRIPE_PRICE_FAMILY_MONTHLY }}
+          -c useLookupKey=${{ vars.USE_LOOKUP_KEY || 'true' }}
+          -c stripeWebhookShadowMode=${{ vars.STRIPE_WEBHOOK_SHADOW_MODE || 'false' }}
+          -c stripeWebhookSecretTest=${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }}
           -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }}
           -c cronSecret=${{ secrets.CRON_SECRET }}
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}

--- a/docs/design/billing-redesign/phase6-phase7-execution-ssot.md
+++ b/docs/design/billing-redesign/phase6-phase7-execution-ssot.md
@@ -98,6 +98,32 @@ Stripe 公式 [migrate-snapshot-to-thin-events](https://docs.stripe.com/webhooks
 | **Stripe Dashboard 同期** | **Test mode で先行作成必須** (本 step マージ前に PO #2627 で Test mode の **2 Product / 各 1 Price / lookup_key** / Webhook 構築済の状態を担保、#2683 代替案 D 反映) |
 | **前提 PR** | Step 1 + Step 2 マージ済 + Stripe Dashboard Test mode 構築完了 (PO #2627) |
 
+#### Step 3-a 実装完了記録 (PR #2717 / Issue #2716)
+
+| 項目 | 内容 |
+|---|---|
+| **実装 PR** | [#2717 feat(billing): #2716 Phase 7 PR-3a — Stripe lookup_key caching layer + USE_LOOKUP_KEY flag 配備](https://github.com/Takenori-Kusaka/ganbari-quest/pull/2717) |
+| **対象 Issue** | #2716 |
+| **マージ commit** | `af430e0a` (2026-05-30) |
+| **配備 file** | `src/lib/server/stripe/price-cache.ts` (新規 caching layer) + `src/lib/server/stripe/config.ts` (`isLookupKeyEnabled` / `getPriceId` 関数経由化) + `.env.example` (USE_LOOKUP_KEY default `false` 配備) |
+| **テスト追加** | `tests/unit/server/stripe/price-cache.test.ts` + `tests/unit/server/stripe/lookup-key-config.test.ts` (flag 分岐 + lookup_key 経路 + env var fallback) |
+| **本 PR scope (Step 3-a only)** | caching layer 実装 + `USE_LOOKUP_KEY=false` default で配備のみ、本番動作不変 (env var 直読継続)。Production cutover は PR-3b (#2721) に持ち越し |
+| **本番影響** | default `USE_LOOKUP_KEY=false` で本番 Lambda 動作不変。Production Stripe Dashboard の lookup_key 発行も PO 手動操作で Test mode のみ完了 |
+| **次工程** | PR-3b (#2721) で `USE_LOOKUP_KEY=true` 物理 cutover + CDK env 配備 + GitHub Actions Variables 経路追加 |
+
+#### Step 3-b 実装完了記録 (PR #2721 候補 / Issue #2721) — 本 PR
+
+| 項目 | 内容 |
+|---|---|
+| **対象 Issue** | #2721 |
+| **配備 file** | `src/lib/server/stripe/client.ts` (`STRIPE_API_VERSION` 物理 bump `'2026-05-27.dahlia'` → `'2026-04-22.dahlia'`、補強 PR #2684 docs SSOT との物理同期) + `infra/lib/compute-stack.ts` (Lambda env 3 件配備: `USE_LOOKUP_KEY` / `STRIPE_WEBHOOK_SHADOW_MODE` / `STRIPE_WEBHOOK_SECRET_TEST`) + `.github/workflows/deploy.yml` (CDK context 3 件追加: cdk diff + cdk deploy の 2 箇所) + `.env.example` (USE_LOOKUP_KEY default `true` 更新) |
+| **テスト追加** | `tests/unit/server/stripe/client-api-version.test.ts` (新規、stable / preview 厳密 assert regression gate) + `tests/unit/infra/multi-lambda-cdk.test.ts` (3 ケース追加: 本番 Fn env 配備 + demo Fn omit 検証) |
+| **本 PR scope (Step 3-b cutover)** | (1) apiVersion 物理 bump (補強 PR #2684 で docs 訂正のみ実施、client.ts 物理同期が漏れていた構造的欠落の補修) + (2) PR-3a 配備済 `USE_LOOKUP_KEY` の Production cutover (`true` default 配備) + (3) PR-4a 配備済 `STRIPE_WEBHOOK_SHADOW_MODE` / `STRIPE_WEBHOOK_SECRET_TEST` の CDK context 経由配布完了 (PR-4a では env 配備のみで GitHub Actions → CDK 経路が未配線だった) |
+| **本番影響** | (a) apiVersion `'2026-04-22.dahlia'` stable 化により preview リリース脱却。副次制約 4 (Webhook destination api_version immutable) には未触 (Webhook destination 自体は PR-4b で新規作成) (b) Production Lambda env に `USE_LOOKUP_KEY=true` 配備で lookup_key 経路 cutover (Stripe API 障害時は env var fallback、kill switch 有効) (c) shadow mode 関連 env は default `false` のまま、PR-4b cutover まで本番 Webhook 動作不変 |
+| **前提** | **#2627 Production Stripe Dashboard 同期完了 (PO 手動操作、2026-05-31)**: 2 Product + Price 各 1 (lookup_key=`standard_monthly` / `premium_monthly`、内税) + Customer Portal (代替案 D) + Tax + Branding が Production mode で配備済 (#2627 comment confirmation) |
+| **kill switch 操作** | (a) `USE_LOOKUP_KEY` cutover 失敗時: GitHub Actions Variables に `USE_LOOKUP_KEY=false` 設定 → CDK redeploy で env var 直読経路に巻き戻し (約 30 秒で反映) (b) apiVersion ロールバック: `client.ts:8` を `'2026-05-27.dahlia'` (旧値) に戻す revert PR + Lambda 再 deploy (Webhook destination は PR-4b 未実施のため不整合発生せず) |
+| **次工程** | (a) 1-2 week staging 検証 (Sentry error rate < 0.5% / Stripe API 障害率 / lookup_key cache hit rate) (b) PR-4b (Webhook cutover) 着手判断 (c) PR-5 (旧 env var 物理削除 + 旧 Webhook destination retire) |
+
 ### Step 4: Webhook shadow / cutover / retire (子 3 #2641 + Stripe 公式 5 phase 整合、推定 400 行、#2683 補強で event 一覧変更)
 
 | 項目 | 内容 |

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -100,6 +100,26 @@ export class ComputeStack extends cdk.Stack {
 		const stripePriceStandardMonthly = this.node.tryGetContext('stripePriceStandardMonthly') ?? '';
 		const stripePriceFamilyMonthly = this.node.tryGetContext('stripePriceFamilyMonthly') ?? '';
 
+		// --- Phase 7 PR-3b / PR-4a 配備済 Stripe Webhook + lookup_key 関連 env (#2721 / #2713 / #2716) ---
+		// 参照 SSOT:
+		//   - docs/decisions/0059-phase7-cutover-sequence.md
+		//   - docs/design/billing-redesign/phase6-phase7-execution-ssot.md §3 Step 3 / Step 4
+		//   - docs/design/billing-redesign/phase6-context-decisions-6.md §4 lookup_key 段階移行
+		//
+		// useLookupKey (PR-3b cutover): default 'true' で Production cutover を反映する。
+		//   - lookup_key (`standard_monthly` / `premium_monthly`) 経由 Price ID 解決
+		//   - Stripe API 障害時は env var `STRIPE_PRICE_*` fallback (kill switch、isLookupKeyEnabled())
+		//   - 旧 env var 4 件は PR-5 cleanup (1 週間 smoke test 完了後) で削除
+		// stripeWebhookShadowMode (PR-4a 配備、cutover は PR-4b): default 'false'。
+		//   - PR-4a で env 配備のみ実施済 (#2714)、CDK context 配布が本 PR で完了
+		//   - PR-4b cutover 時に 'true' に切替て shadow mode 検証 (24-48h)
+		// stripeWebhookSecretTest (PR-4a 配備): Test mode webhook signing secret (#2627 §C)。
+		//   - shadow mode + cutover で `STRIPE_WEBHOOK_SHADOW_MODE=true` 時に getWebhookSecretForShadow()
+		//     経由で参照される (config.ts:120)
+		const useLookupKey = this.node.tryGetContext('useLookupKey') ?? 'true';
+		const stripeWebhookShadowMode = this.node.tryGetContext('stripeWebhookShadowMode') ?? 'false';
+		const stripeWebhookSecretTest = this.node.tryGetContext('stripeWebhookSecretTest') ?? '';
+
 		// --- Cron Endpoint Bearer Secret (#820 PR-D / ADR-0033) ---
 		// /api/cron/retention-cleanup の Bearer 認証に使用。
 		// /ops ダッシュボードは Cognito ops group 認可に移行したため、この鍵は共有しない。
@@ -219,6 +239,18 @@ export class ComputeStack extends cdk.Stack {
 				...(stripePriceFamilyMonthly
 					? { STRIPE_PRICE_FAMILY_MONTHLY: stripePriceFamilyMonthly }
 					: {}),
+				// Phase 7 PR-3b cutover (#2721): default 'true' で lookup_key 経路有効化。
+				// Stripe API 障害時は env var fallback (config.ts isLookupKeyEnabled() / getPriceId())。
+				// kill switch: Lambda env を 'false' に変更すると約 30 秒で env var 直読経路に巻き戻し。
+				USE_LOOKUP_KEY: useLookupKey,
+				// Phase 7 PR-4a 配備 (#2713): default 'false'。PR-4b cutover で 'true' 切替。
+				// shadow mode = log only handler (`/api/stripe/webhook-v2`)、本番動作不変。
+				STRIPE_WEBHOOK_SHADOW_MODE: stripeWebhookShadowMode,
+				// Phase 7 PR-4a 配備 (#2713 / #2627 §C): Test mode webhook signing secret。
+				// shadow / cutover で getWebhookSecretForShadow() (config.ts:120) 経由参照。
+				// 空文字 fallback で本番 STRIPE_WEBHOOK_SECRET に flow。Production cutover 後に
+				// 本番 secret に置換 (PR-4b マージ時、#2627 §F)。
+				...(stripeWebhookSecretTest ? { STRIPE_WEBHOOK_SECRET_TEST: stripeWebhookSecretTest } : {}),
 				COGNITO_LOGOUT_URL: 'https://ganbari-quest.com/auth/login',
 				SES_SENDER_EMAIL: 'noreply@ganbari-quest.com',
 				SES_CONFIG_SET_NAME: 'ganbari-quest-config',

--- a/src/lib/server/stripe/client.ts
+++ b/src/lib/server/stripe/client.ts
@@ -5,7 +5,27 @@ import Stripe from 'stripe';
 
 type StripeApiVersion = NonNullable<ConstructorParameters<typeof Stripe>[1]>['apiVersion'];
 
-const STRIPE_API_VERSION = '2026-05-27.dahlia' as StripeApiVersion;
+/**
+ * Stripe API バージョン (Phase 7 PR-3b / Issue #2721、補強 PR #2684 docs SSOT 物理同期)
+ *
+ * **`'2026-04-22.dahlia'` を維持** (Stripe 最新 stable リリース)。
+ * `'2026-05-27.dahlia'` は **preview リリース** (Stripe 公式 API versioning policy で
+ * production 非推奨、backward incompatible change の評価専用) のため不採用。
+ *
+ * 副次制約 4 (Webhook destination api_version immutable、phase5-stripe-product-architecture
+ * §4.4 / #2683) により、apiVersion bump は Webhook destination 新規作成 + 5 phase migration
+ * (setup → discovery → shadow → cutover → retire) が強制必須。次回 stable リリース
+ * (例: `'2026-06-XX.dahlia'`) 採用判断は別 PR で実施する。
+ *
+ * 設計 SSOT:
+ *   - docs/decisions/0059-phase7-cutover-sequence.md
+ *   - docs/design/billing-redesign/phase5-stripe-product-architecture.md §3.4 (#2683 訂正)
+ *   - docs/design/billing-redesign/phase6-context-decisions-6.md §5.1 (5 phase migration 手順)
+ *
+ * Stripe 公式根拠:
+ *   - https://docs.stripe.com/api/versioning (72h rollback window)
+ */
+const STRIPE_API_VERSION = '2026-04-22.dahlia' as StripeApiVersion;
 
 let _client: Stripe | null = null;
 

--- a/tests/unit/infra/multi-lambda-cdk.test.ts
+++ b/tests/unit/infra/multi-lambda-cdk.test.ts
@@ -291,6 +291,12 @@ describe('ADR-0048 Multi-Lambda Demo Deployment (#2097 week 4)', () => {
 				// #2310 / #2337 / ADR-0050: demo Lambda は AUTH_MODE=anonymous で PIN gate 無効、
 				// PARENT_GATE_COOKIE_SECRET 注入は本番 Lambda のみ (ADR-0048 / cross-tenancy 防止)
 				'PARENT_GATE_COOKIE_SECRET',
+				// Phase 7 PR-3b / PR-4a (#2721 / #2713 / ADR-0059): Stripe env は本番 Lambda のみ
+				// 注入 (demo Lambda は STRIPE_SECRET_KEY 未注入で Stripe 経路自体が動作しないため
+				// shadow mode / lookup_key 関連 env も demo に配備する意味なし)
+				'USE_LOOKUP_KEY',
+				'STRIPE_WEBHOOK_SHADOW_MODE',
+				'STRIPE_WEBHOOK_SECRET_TEST',
 				'DYNAMODB_TABLE',
 				'TABLE_NAME',
 				'ANALYTICS_TABLE_NAME',
@@ -348,6 +354,54 @@ describe('ADR-0048 Multi-Lambda Demo Deployment (#2097 week 4)', () => {
 					'live',
 			);
 			expect(demoLiveAliases.length).toBe(0);
+		});
+	});
+
+	describe('Phase 7 PR-3b Stripe Webhook / lookup_key env (#2721 / ADR-0059)', () => {
+		it('本番 Fn に USE_LOOKUP_KEY=true が注入される (cutover 後 default、kill switch)', () => {
+			// #2721 PR-3b cutover: lookup_key 経路 default 有効化。
+			// makeApp() の context 未注入時は compute-stack.ts の `?? 'true'` fallback が効く。
+			// Lambda env を 'false' に変更すると約 30 秒で env var 直読経路に巻き戻し (kill switch)。
+			const template = computeTemplate;
+
+			template.hasResourceProperties('AWS::Lambda::Function', {
+				FunctionName: 'ganbari-quest-app',
+				Environment: {
+					Variables: Match.objectLike({
+						USE_LOOKUP_KEY: 'true',
+					}),
+				},
+			});
+		});
+
+		it('本番 Fn に STRIPE_WEBHOOK_SHADOW_MODE=false が注入される (PR-4a 配備、PR-4b で true 切替)', () => {
+			// #2713 PR-4a: shadow mode env 配備済。本 PR-3b で CDK context 経由配布が完了。
+			// 'false' default で本番動作不変 (旧 /api/stripe/webhook 継続)。
+			const template = computeTemplate;
+
+			template.hasResourceProperties('AWS::Lambda::Function', {
+				FunctionName: 'ganbari-quest-app',
+				Environment: {
+					Variables: Match.objectLike({
+						STRIPE_WEBHOOK_SHADOW_MODE: 'false',
+					}),
+				},
+			});
+		});
+
+		it('STRIPE_WEBHOOK_SECRET_TEST は context 未注入時に env に追加されない (空文字列 omit、本番影響ゼロ)', () => {
+			// #2713 PR-4a 配備済 (config.ts getWebhookSecretForShadow() が `?? STRIPE_WEBHOOK_SECRET` fallback)。
+			// makeApp() で stripeWebhookSecretTest context 未注入のため env に omit されることを確認 (compute-stack.ts L211-213 の `... ? {...} : {}` パターン)。
+			const template = computeTemplate;
+			const functions = template.findResources('AWS::Lambda::Function', {
+				Properties: { FunctionName: 'ganbari-quest-app' },
+			});
+			expect(Object.keys(functions).length).toBe(1);
+			const prodFnDef = Object.values(functions)[0] as {
+				Properties: { Environment?: { Variables?: Record<string, unknown> } };
+			};
+			const envVars = prodFnDef.Properties.Environment?.Variables ?? {};
+			expect(envVars.STRIPE_WEBHOOK_SECRET_TEST).toBeUndefined();
 		});
 	});
 

--- a/tests/unit/routes/api-stripe-webhook-v2.test.ts
+++ b/tests/unit/routes/api-stripe-webhook-v2.test.ts
@@ -36,8 +36,10 @@ vi.mock('$lib/server/stripe/config', () => ({
 
 vi.mock('$lib/server/stripe/client', async () => {
 	const StripeImport = (await import('stripe')).default;
+	type StripeApiVersion = NonNullable<ConstructorParameters<typeof StripeImport>[1]>['apiVersion'];
 	const stripeVerify = new StripeImport('sk_test_dummy_for_v2_unit', {
-		apiVersion: '2026-04-22.dahlia',
+		// Phase 7 PR-3b #2721: `'2026-04-22.dahlia'` (stable) を維持 (`client.ts` と同パターン cast)
+		apiVersion: '2026-04-22.dahlia' as StripeApiVersion,
 	});
 	return { getStripeClient: () => stripeVerify, isStripeEnabled: () => true };
 });
@@ -46,8 +48,10 @@ const mockHandleWebhookEvent = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('$lib/server/services/stripe-service', async () => {
 	const StripeImport = (await import('stripe')).default;
+	type StripeApiVersion = NonNullable<ConstructorParameters<typeof StripeImport>[1]>['apiVersion'];
 	const stripeVerify = new StripeImport('sk_test_dummy_for_v2_service', {
-		apiVersion: '2026-04-22.dahlia',
+		// Phase 7 PR-3b #2721: `'2026-04-22.dahlia'` (stable) を維持 (`client.ts` と同パターン cast)
+		apiVersion: '2026-04-22.dahlia' as StripeApiVersion,
 	});
 	return {
 		handleWebhookEvent: (...args: unknown[]) => mockHandleWebhookEvent(...args),

--- a/tests/unit/routes/api-stripe-webhook-v2.test.ts
+++ b/tests/unit/routes/api-stripe-webhook-v2.test.ts
@@ -37,7 +37,7 @@ vi.mock('$lib/server/stripe/config', () => ({
 vi.mock('$lib/server/stripe/client', async () => {
 	const StripeImport = (await import('stripe')).default;
 	const stripeVerify = new StripeImport('sk_test_dummy_for_v2_unit', {
-		apiVersion: '2026-05-27.dahlia',
+		apiVersion: '2026-04-22.dahlia',
 	});
 	return { getStripeClient: () => stripeVerify, isStripeEnabled: () => true };
 });
@@ -47,7 +47,7 @@ const mockHandleWebhookEvent = vi.fn().mockResolvedValue(undefined);
 vi.mock('$lib/server/services/stripe-service', async () => {
 	const StripeImport = (await import('stripe')).default;
 	const stripeVerify = new StripeImport('sk_test_dummy_for_v2_service', {
-		apiVersion: '2026-05-27.dahlia',
+		apiVersion: '2026-04-22.dahlia',
 	});
 	return {
 		handleWebhookEvent: (...args: unknown[]) => mockHandleWebhookEvent(...args),

--- a/tests/unit/routes/api-stripe-webhook.test.ts
+++ b/tests/unit/routes/api-stripe-webhook.test.ts
@@ -48,7 +48,7 @@ vi.mock('$lib/server/services/stripe-service', async () => {
 	// （getStripeClient() のモックを避けるため直接 Stripe インスタンスを生成）
 	const StripeImport = (await import('stripe')).default;
 	const stripeVerify = new StripeImport('sk_test_dummy_for_verification_only', {
-		apiVersion: '2026-05-27.dahlia',
+		apiVersion: '2026-04-22.dahlia',
 	});
 	return {
 		handleWebhookEvent: (...args: unknown[]) => mockHandleWebhookEvent(...args),

--- a/tests/unit/routes/api-stripe-webhook.test.ts
+++ b/tests/unit/routes/api-stripe-webhook.test.ts
@@ -47,8 +47,12 @@ vi.mock('$lib/server/services/stripe-service', async () => {
 	// verifyWebhookSignature は Stripe の constructEvent を使った実装をインライン化する
 	// （getStripeClient() のモックを避けるため直接 Stripe インスタンスを生成）
 	const StripeImport = (await import('stripe')).default;
+	type StripeApiVersion = NonNullable<ConstructorParameters<typeof StripeImport>[1]>['apiVersion'];
 	const stripeVerify = new StripeImport('sk_test_dummy_for_verification_only', {
-		apiVersion: '2026-04-22.dahlia',
+		// Phase 7 PR-3b #2721: `'2026-04-22.dahlia'` (stable) を維持。Stripe SDK 22.2.0 の
+		// LatestApiVersion type は `'2026-05-27.dahlia'` (preview) のため、`client.ts` と
+		// 同パターンで `as StripeApiVersion` cast する (副次制約 4 整合、preview 不採用)。
+		apiVersion: '2026-04-22.dahlia' as StripeApiVersion,
 	});
 	return {
 		handleWebhookEvent: (...args: unknown[]) => mockHandleWebhookEvent(...args),

--- a/tests/unit/server/stripe/client-api-version.test.ts
+++ b/tests/unit/server/stripe/client-api-version.test.ts
@@ -1,0 +1,42 @@
+// tests/unit/server/stripe/client-api-version.test.ts
+//
+// Phase 7 PR-3b / Issue #2721: Stripe API version 物理 bump regression test。
+//
+// 補強 PR #2684 (2026-05-30) で docs SSOT は `'2026-04-22.dahlia'` 維持 (`'2026-05-27.dahlia'`
+// は preview リリースで本番不採用) と確定したが、`src/lib/server/stripe/client.ts` の物理
+// `STRIPE_API_VERSION` 定数 bump が同 PR では実施されておらず、本 PR-3b cutover で物理同期した。
+//
+// 本 test は将来 `'2026-05-27.dahlia'` (preview) や任意の他値への意図しない bump を CI で検知し、
+// 副次制約 4 (Webhook destination api_version immutable、#2683) に違反する apiVersion 変更を
+// PR レビュー前に hard-fail させる regression gate として load-bearing。
+//
+// 設計 SSOT:
+//   - docs/decisions/0059-phase7-cutover-sequence.md
+//   - docs/design/billing-redesign/phase5-stripe-product-architecture.md §3.4 (#2683 訂正)
+//   - docs/design/billing-redesign/phase6-context-decisions-6.md §5 (5 phase migration 手順)
+//
+// Stripe 公式根拠:
+//   - https://docs.stripe.com/api/versioning (72h rollback window + stable / preview 区別)
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const CLIENT_TS_PATH = resolve(__dirname, '../../../../src/lib/server/stripe/client.ts');
+
+describe('Stripe API version SSOT (Phase 7 PR-3b #2721 / 補強 PR #2684 docs 物理同期)', () => {
+	const source = readFileSync(CLIENT_TS_PATH, 'utf-8');
+
+	it('STRIPE_API_VERSION は stable リリース `2026-04-22.dahlia` を維持する (preview 不採用)', () => {
+		// docs SSOT (phase5-stripe-product-architecture §3.4 #2683 訂正) との物理同期。
+		// 値変更時は ADR-0059 + phase6-context-decisions-6 §5 の 4 step migration 手順
+		// (Changelog 確認 → Webhook destination 新規作成 → SDK bump → 72h 監視) を完遂してから。
+		expect(source).toMatch(/const STRIPE_API_VERSION = '2026-04-22\.dahlia'/);
+	});
+
+	it('preview リリース `2026-05-27.dahlia` を使用していない (production 非推奨、副次制約 4 違反 prevention)', () => {
+		// Stripe 公式 API versioning policy: `YYYY-MM-DD.codename` の preview リリースは
+		// backward incompatible change の評価用で production 非推奨。誤って戻し書きされていないか確認。
+		expect(source).not.toMatch(/STRIPE_API_VERSION = '2026-05-27\.dahlia'/);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体 (課金基盤、Stripe Price ID 解決経路 + Webhook destination api_version 整合)

**解決する課題**: Phase 6 子 4 #2673 §S2 lookup_key 段階移行 4 step のうち **Step 3 cutover** と、補強 PR #2684 (2026-05-30) で docs SSOT を `'2026-04-22.dahlia'` 維持と確定した **apiVersion の物理同期漏れ** を 1 PR に集約する。さらに PR-4a #2714 で `.env.example` + `config.ts` のみ配備した **Webhook shadow mode env の CDK / GitHub Actions 経路の構造的欠落** を補修する。

**期待される効果**: AWS CDK Lambda env に `USE_LOOKUP_KEY=true` + `STRIPE_WEBHOOK_SHADOW_MODE=false` (default) + `STRIPE_WEBHOOK_SECRET_TEST` 配備 + `deploy.yml` CDK context 3 件追加で、Production lookup_key 経路 cutover + Webhook shadow mode 制御の env 反映経路を完成させる。`STRIPE_API_VERSION` 定数を `'2026-05-27.dahlia'` (preview) → `'2026-04-22.dahlia'` (stable) に物理 bump し、docs SSOT との物理同期を達成。Stripe API 障害時は env を `USE_LOOKUP_KEY=false` に戻すだけで env var 直読経路 (kill switch、ADR-0059 §1.5) に即時復帰。

## 関連 Issue

closes #2721

## ⚠️ 依存関係 / Phase 7 PR ordering (本 PR Ready 化前の prerequisite、Round 5 時点で最新化)

**本 PR は Phase 7 chain の最 critical cutover PR であり、以下 6 件の prerequisite implementation + staging 検証完了後にのみ Ready 化可能**。Round 5 (2026-06-02) 時点での解消状況:

| # | prerequisite | 内容 | 状態 (2026-06-02) | merge / close 元 |
|---|---|---|---|---|
| 1 | #2718 | PR-3b cutover staging 検証期間 SSOT 確定 (2-3 日 or 1 営業週間 2 案併記) | ✅ MERGED | PR #2726 (2026-05-31) |
| 2 | #2719 | yearly plan 物理削除 (env var 6→2 + checkout monthly 2 種化) | ✅ MERGED | PR #2753 (2026-06-01) |
| 3 | #2720 | Sentry / Discord alert 強化 (TOCTOU + kill switch silent degradation 観測) | ✅ CLOSED | 統合先 PR で吸収完了 |
| 4 | #2735 | Phase 7 TOCTOU lookup_key collision test + CloudWatch retention 30+ SSOT + post-mortem runbook | ✅ MERGED | PR #2757 (2026-06-01) |
| 5 | #2738 | errMsg PII redaction + Discord throttle attack scenario test | ✅ MERGED | PR #2747 (2026-06-01) |
| 6 | #2749 | PII redaction Unicode bypass + IDN + カード分割表記対策 (#2747 Adversarial security 軸 critical 補追 Issue) | ✅ **MERGED (PR #2770、2026-06-02T04:08:18Z)** | **PR #2770 (2026-06-02)** |

**Phase A 解消状況**: **6/6 完了 (全解消達成)** — #2718 / #2719 / #2720 / #2735 / #2738 / #2749 すべて MERGED / CLOSED。

**Round 5 判断**: 本 PR は Phase A prerequisite **6/6 全解消達成** + staging 検証期間 gate (2-3 日案、2026-05-31T23:33Z baseline から約 2.5 日経過) も達成圏に到達し、本 PR Re-Ready 化の 2 条件 AND が満たされた状態に進んだ。QM Round 5 Re-Review approve gate に乗せ、approve 後に cutover 実施判断を Dev/PO で確定する (ADR-0059 §1.5 kill switch + ADR-0010 Pre-PMF Bucket A 整合)。

## staging 検証期間起算点 SSOT (Round 5 最新化)

| 項目 | 値 |
|---|---|
| **staging 検証期間 baseline** | #2718 SSOT 確定 = **PR #2726 MERGED `2026-05-31T23:33:22Z`** |
| **検証期間案 (#2726 で SSOT 化、2 案併記)** | (a) 短期 2-3 日 / (b) 標準 1 営業週間 (Dev/PO 判断、本 PR Ready 化時に確定) |
| **現在経過 (Round 5 時点、2026-06-02)** | baseline から **約 2.5 日経過**。短期案 2-3 日 gate 達成圏に到達 (✅)、1 営業週間 gate には未達 (継続観測中) |
| **cutover 実施判断 timeline** | **Phase A 6/6 全解消 (✅ #2770 MERGED)** + **staging 検証期間 gate 達成圏 (✅ 約 2.5 日)** の 2 条件 AND 達成。QM Re-Review approve 後に cutover timing を Dev/PO で確定 |
| **cutover 完了 timing** | 上記 2 条件達成 + QM Round 5 Re-Review approve 後 (Dev/PO 判断、本 Round 5 で Re-Ready 化判定経路に乗る) |

**Round 5 では Re-Ready 化判定経路に乗る** (Phase A 6/6 全解消 + staging 検証期間 達成圏 の AND 条件達成)。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | AWS CDK `compute-stack.ts` に `USE_LOOKUP_KEY=true` + `STRIPE_WEBHOOK_SECRET_TEST` 環境変数配備 | `grep -n "useLookupKey\|stripeWebhookShadowMode\|stripeWebhookSecretTest\|USE_LOOKUP_KEY\|STRIPE_WEBHOOK_SHADOW_MODE\|STRIPE_WEBHOOK_SECRET_TEST" infra/lib/compute-stack.ts` + `npx vitest run tests/unit/infra/multi-lambda-cdk.test.ts` | HEAD (Round 4 rebase 後) / `infra/lib/compute-stack.ts` context 取得 (`useLookupKey` default 文字列 `'true'` / `stripeWebhookShadowMode` default 文字列 `'false'` / `stripeWebhookSecretTest` default 空文字、null-coalescing 演算子経由) + `USE_LOOKUP_KEY: useLookupKey` + `STRIPE_WEBHOOK_SHADOW_MODE: stripeWebhookShadowMode` + `stripeWebhookSecretTest` 真偽値による条件付き spread (空文字 omit) / `tests/unit/infra/multi-lambda-cdk.test.ts` Phase 7 PR-3b describe ブロック (3 ケース) PASS (18/18) |
| AC2 | GitHub Actions Variables 配備手順 PR body 明示 | 本 PR body §「PO action required」表を参照 + `grep -n "useLookupKey\|stripeWebhookShadowMode\|stripeWebhookSecretTest" .github/workflows/deploy.yml` | HEAD (Round 4 rebase 後) / `.github/workflows/deploy.yml` cdk diff 経路 + cdk deploy 経路 (2 箇所同期、`-c useLookupKey=${{ vars.USE_LOOKUP_KEY \|\| 'true' }}` / `-c stripeWebhookShadowMode=${{ vars.STRIPE_WEBHOOK_SHADOW_MODE \|\| 'false' }}` / `-c stripeWebhookSecretTest=${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }}`) / 本 PR body §PO action required で `gh secret set STRIPE_WEBHOOK_SECRET_TEST` 手順明示 |
| AC3 | 既存 env var fallback 経路維持 | `npx vitest run tests/unit/server/stripe/lookup-key-config.test.ts` + `git diff origin/main...HEAD -- src/lib/server/stripe/config.ts` | HEAD (Round 4 rebase 後) / 本 PR で `src/lib/server/stripe/config.ts` 差分 0 行 (PR-3a #2717 配備済 `isLookupKeyEnabled()` / `getPriceId()` kill switch 設計を不変参照、`buildPlanConfigs()` env var 直読経路も継続) |
| AC4 | apiVersion `2026-04-22.dahlia` 確認 (補強 PR #2684 完遂) — **本 PR で物理 bump 完遂** | `grep -n "STRIPE_API_VERSION = " src/lib/server/stripe/client.ts` + `npx vitest run tests/unit/server/stripe/client-api-version.test.ts` | HEAD (Round 4 rebase 後) / `src/lib/server/stripe/client.ts` `const STRIPE_API_VERSION = '2026-04-22.dahlia' as StripeApiVersion;` (`'2026-05-27.dahlia'` → `'2026-04-22.dahlia'` 物理 bump、補強 PR #2684 docs 訂正の物理同期漏れ補修) / `client-api-version.test.ts` 2 ケース PASS |
| AC5 | Test mode で `USE_LOOKUP_KEY=true` integration test PASS | `npx vitest run tests/unit/server/stripe/` (lookup-key-config.test.ts / price-cache.test.ts) | HEAD (Round 4 rebase 後) / PR-3a #2717 配備の `tests/unit/server/stripe/lookup-key-config.test.ts` 12 ケース + `price-cache.test.ts` 6 ケース = 18/18 PASS / Production smoke test は PO action #4 で 24h 観測 |
| AC6 | svelte-check / biome / 既存 test regression PASS | `npx svelte-check` + `npx biome check src/ tests/ infra/lib/ scripts/ .github/` + `npx vitest run` | HEAD (Round 4 rebase 後) / **svelte-check: 0 errors / 19 warnings** / **biome: 1102 files / 0 errors** / **vitest (Phase 7 subset 証跡): 4 file / 33 test PASS** (multi-lambda-cdk 18 + client-api-version 2 + api-stripe-webhook 7 + api-stripe-webhook-v2 6) |

### AC「全件」物理 grep verification log (#2690 ドッグフード 26 連続継続)

```bash
# AC1: compute-stack.ts CDK context + Lambda env 配備
$ grep -nE "useLookupKey|stripeWebhookShadowMode|stripeWebhookSecretTest" infra/lib/compute-stack.ts
# context 取得 3 件 + Lambda env injection 3 件 (USE_LOOKUP_KEY / STRIPE_WEBHOOK_SHADOW_MODE / STRIPE_WEBHOOK_SECRET_TEST)
# Round 4 rebase で stripePriceFamilyYearly 削除 (main #2719 PR #2753 取込) も反映済

# AC2: deploy.yml CDK context 経路 (cdk diff + cdk deploy 2 箇所)
$ grep -nE "useLookupKey|stripeWebhookShadowMode|stripeWebhookSecretTest" .github/workflows/deploy.yml
# cdk diff 経路 + cdk deploy 経路に 3 件ずつ配備 (計 6 行)
# Round 4 rebase で stripePriceFamilyYearly 削除も反映済

# AC4: client.ts apiVersion 物理 bump
$ grep -n "STRIPE_API_VERSION = " src/lib/server/stripe/client.ts
# const STRIPE_API_VERSION = '2026-04-22.dahlia' as StripeApiVersion;

# Round 4 rebase 確認:
$ git log --oneline origin/main..HEAD
# 2 commits: feat(billing) #2721 PR-3b + test(billing) #2721 Round 1 Phase C
$ gh pr view 2722 --json mergeable
# MERGEABLE (Round 4 rebase 解消後)
```

## 変更タイプ

- [x] feat: 新機能 (lookup_key Production cutover + apiVersion 物理 bump + CDK env 配備)
- [x] infra: インフラ・CI/CD (CDK Lambda env 3 件配備 + deploy.yml CDK context 3 件追加)
- [x] refactor: リファクタリング (test mock の Stripe SDK type cast 同期、Round 1 Phase C で追加)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/stripe/`) — `client.ts` `STRIPE_API_VERSION` 物理 bump (1 行 + コメント 21 行追加)
- [x] インフラ (`infra/`) — `compute-stack.ts` CDK context 3 件取得 + Lambda env 3 件配備 (production Fn のみ、demo Fn omit)
- [x] 設定・CI (`.github/workflows/deploy.yml`) — CDK context 3 件追加 (cdk diff + cdk deploy 2 箇所同期)
- [x] テスト追加 (`tests/unit/`) — `client-api-version.test.ts` 新規 2 ケース + `multi-lambda-cdk.test.ts` 3 ケース追加 + `api-stripe-webhook{,-v2}.test.ts` apiVersion 同期
- [x] 設計書同期 (`docs/design/`) — `phase6-phase7-execution-ssot.md` Step 3-a (#2717) + Step 3-b (本 PR) 実装完了記録 26 行追記
- [x] env テンプレート (`.env.example`) — USE_LOOKUP_KEY コメント更新 (default `true` 反映)

**影響を受ける画面・機能**: なし (server-side / infra / docs / test のみ、UI 変更ゼロ)。本番動作は AC5 経路 (Stripe API 障害時 env var fallback、`isLookupKeyEnabled()` kill switch) で継続性担保。

## テスト & 安全装置セルフチェック

<!-- biome / svelte-check / vitest / playwright の個別申告は不要 — pre-ready CLI が一括検証 + CI ci.yml が同 4 コマンドを独立に実行するため二重申告は冗長。 -->

- [x] **`npx svelte-check && npx biome check src/ tests/ infra/lib/ scripts/ .github/ && npx vitest run` 全件 PASS をローカル確認** (#2690 ドッグフード 26 連続継続、Round 4 rebase 後):
  - svelte-check: **0 errors / 19 warnings**
  - biome (src/ infra/ scripts/): **1102 files / 0 errors**
  - vitest (Phase 7 subset 証跡): **4 file / 33 test PASS** (multi-lambda-cdk 18 + client-api-version 2 + api-stripe-webhook 7 + api-stripe-webhook-v2 6)
- [x] 追加・変更したテストの概要:
  - `tests/unit/server/stripe/client-api-version.test.ts` 新規 (2 ケース、stable assert + preview 不採用 regression gate)
  - `tests/unit/infra/multi-lambda-cdk.test.ts` Phase 7 PR-3b describe ブロック 3 ケース (本番 Fn env 配備 + demo Fn omit + forbiddenEnvKeys に Phase 7 env 3 件追加)
  - `tests/unit/routes/api-stripe-webhook.test.ts` + `api-stripe-webhook-v2.test.ts` Stripe constructor mock の apiVersion を `as StripeApiVersion` cast 同期
- [x] **新規 env / secret 追加時** (ADR-0006): 末尾の「配布済み env / secret」セクション参照 (3 件: `USE_LOOKUP_KEY` / `STRIPE_WEBHOOK_SHADOW_MODE` / `STRIPE_WEBHOOK_SECRET_TEST`)
- [x] **DynamoDB 実装変更時**: N/A (本 PR は infra + stripe service の apiVersion 物理 bump + test、DB layer 変更なし)
- [x] **Critical バグ修正の場合** (ADR-0002): N/A (新機能 + feature flag cutover、本番動作は default `USE_LOOKUP_KEY=true` で lookup_key 経路 + Stripe API 障害時 env var fallback 維持)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は infra (CDK Lambda env) + stripe service (apiVersion 物理 bump) + deploy.yml CDK context + 設計書同期 + unit test 追加のみで、UI / route page / svelte component 変更ゼロ。`USE_LOOKUP_KEY=true` cutover も server-side のみで実行時の表示変化も 0。screenshot 取得対象画面が存在せず、DESIGN.md §9 禁忌事項 (hex 直書き / プリミティブ再実装 / インラインスタイル / `<style>` 50 行超え 等) との接点もない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: CDK Lambda env 配備は `compute-stack.ts` ComputeStack 内で context 取得 + env injection に集約 (SRP)。Stripe API version 定数は `client.ts` 1 箇所 SSOT (DRY + 副次制約 4 整合)
- [x] **DRY**: env var 名 SSOT (`USE_LOOKUP_KEY` / `STRIPE_WEBHOOK_SHADOW_MODE` / `STRIPE_WEBHOOK_SECRET_TEST`) を `.env.example` / `compute-stack.ts` / `deploy.yml` で同名統一 / Stripe API version 文字列リテラルは `client.ts` 1 箇所 SSOT (test 側は文字列マッチ test `client-api-version.test.ts` で値変更を CI で hard-fail 検知)
- [x] **YAGNI**: yearly plan 物理削除は #2719 PR #2753 で先行完了済 (本 PR Round 4 rebase で main 反映)。GitHub Actions Variables `USE_LOOKUP_KEY` 未設定でも CDK default `'true'` で動作 (kill switch 用途で運用時に override したくなった時に追加、過剰防衛回避)
- [x] **Security (OSS 公開前提)**: `STRIPE_WEBHOOK_SECRET_TEST` は空文字 fallback で CDK deploy 失敗を防ぎつつ、Lambda env への注入は条件付き spread で空文字 omit / `STRIPE_WEBHOOK_SHADOW_MODE=true` 時のみ Test mode signing secret が `getWebhookSecretForShadow()` 経由で使用される設計 / Lambda env 上書きには AWS IAM 必要のため脅威モデルとしては低い。**PII redaction Unicode bypass (#2749) は PR #2770 MERGED で解消済**、本 PR cutover の security gate は完全充足
- [x] **アクセシビリティ**: N/A (UI 変更ゼロ)
- [x] **パフォーマンス**: lookup_key 経路は PR-3a 配備済 `price-cache.ts` の in-memory cache (TTL 5 min) で warm Lambda 内 Stripe API 呼出を再利用 (cache hit 時 < 1ms、cache miss 時 ~100ms)。CDK deploy 後の Lambda cold start 影響なし (env 反映は次 invocation で完結、約 30 秒)

## 横展開・影響波及チェック

**並行実装ペア** (`docs/design/parallel-implementations.md`):

- [x] 本番アプリ + デモ版を同期: 本 PR の CDK Lambda env 配備は **production Fn のみ対象** (demo Fn は forbiddenEnvKeys regression test `multi-lambda-cdk.test.ts` で Phase 7 env 3 件 omit を CI で hard-fail assert、ADR-0048 Multi-Lambda Demo 整合)
- [x] **LP ↔ アプリ双方向整合** (#1481 / ADR-0013): N/A (本 PR は infra + server-side のみ、LP 表示文言 / pricing.html 影響なし)
- [x] 全年齢モード 5 種 (baby/preschool/elementary/junior/senior): N/A (server-side / infra、年齢モード非依存)
- [x] ナビゲーション 3 種 (`AdminLayout` + `AdminMobileNav` + `BottomNav`): N/A (UI 変更ゼロ)
- [x] E2E / ユニットシード: 本 PR 追加 unit test 3 file は既存 fixture 非依存、`vi.mock` で stripe-client / `getPriceByLookupKey` を mock
- [x] **labels SSOT** (ADR-0009 / ADR-0045): N/A (本 PR は labels.ts / terms.ts 触らず)
- [x] **設計書同期** (ADR-0001): `docs/design/billing-redesign/phase6-phase7-execution-ssot.md` §Step 3-a / §Step 3-b 実装完了記録 追記済 (本 PR で更新、26 行追加)
- [x] **並行 PR overlap** (#1200): Round 4 rebase で main HEAD `7f61009b` (PR #2761 marketplace CTA sticky) 取込済、`.github/workflows/deploy.yml` + `infra/lib/compute-stack.ts` の 2 file conflict 解消済 (main #2719 PR #2753 の `stripePriceFamilyYearly` 削除と PR-3b 追加 3 env (`useLookupKey` / `stripeWebhookShadowMode` / `stripeWebhookSecretTest`) を統合)

**LP / 販促文言変更時** (ADR-0013 / #1314):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| (なし) | (infra + server-side stripe client + test のみ、LP / 販促文言変更ゼロ) | N/A |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** (default `USE_LOOKUP_KEY=true` cutover でも PR-3a 配備済 `isLookupKeyEnabled()` kill switch + env var fallback で挙動連続性担保、`STRIPE_API_VERSION` bump は副次制約 4 整合 = 既存 Production Webhook destination 2026-02-25.clover は触らず PR-4b で新 destination 作成、Customer-facing API 互換性影響なし)

**レビュー依頼事項・QA**:

- **Q1 (business / ADR-0056 軸)**: 本 PR Re-Ready 化は **Phase A 6/6 全解消 (#2770 MERGED) + staging 検証期間 gate (#2718 SSOT、2-3 日案、約 2.5 日経過で達成圏)** の AND 条件達成。Round 5 では rebase + body 最新化 + Phase A 6/6 完遂反映 + staging gate 達成圏更新まで完遂。QM Re-Review approve gate に乗る経路に進む (ADR-0010 Pre-PMF Bucket A 整合、Pre-PMF active subscription 0 件前提でも cutover の前提が完全充足)
- **Q2 (UX 軸)**: 顧客の体感に直接影響する変更は無い (本 PR は SDK / infra 層、ユーザー UI 変更ゼロ)。新規 trial customer が発生した場合の checkout 動線は lookup_key 解決失敗時に env var fallback が動作するため checkout 自体は継続。yearly plan の checkout は #2719 PR #2753 で物理削除済 (monthly 2 種のみ)
- **Q3 (security / adversarial 軸)**: 副次制約 4 (Webhook destination api_version immutable) 違反は無いか? 本 PR は SDK apiVersion bump のみで Webhook destination 自体には触れない (PR-4b で新 destination 作成)。既存 Production Webhook は 2026-02-25.clover のままで動作継続。**PII redaction Unicode bypass (#2749) は PR #2770 MERGED で完全解消** — `#2738` PR #2747 で base redaction 実装済 + #2770 で Unicode normalization / IDN / カード分割表記の bypass 経路を補強完了。本 PR cutover (lookup_key + apiVersion bump) は Stripe API 呼出経路を増やすが、エラー時の Discord alert PII 漏洩 risk は #2770 で構造的に排除済

## PO action required (本 PR マージ後)

| # | 操作 | 担当 | 備考 |
|---|---|---|---|
| 1 | (任意) GitHub Actions Variables に `USE_LOOKUP_KEY` / `STRIPE_WEBHOOK_SHADOW_MODE` を設定 | PO | 未設定でも CDK fallback (null-coalescing 演算子で `'true'` / `'false'` の文字列 default 適用) が効くため必須ではない |
| 2 | GitHub Actions Secrets に `STRIPE_WEBHOOK_SECRET_TEST` を設定 | PO | PO ローカル Test mode signing secret。`gh secret set STRIPE_WEBHOOK_SECRET_TEST --body "whsec_..." --repo Takenori-Kusaka/ganbari-quest` |
| 3 | `cdk deploy --all` (GHA `deploy.yml` 自動 or 手動) | PO | Lambda env physical update に必須 |
| 4 | 本番 smoke test (24h 観測) | PO + Dev | Sentry error rate < 0.5% / Stripe API 障害率 / lookup_key cache hit rate を Phase 6 子 5 §S2 threshold で監視 |

## ロールバック手順 (Phase 6 子 5 #2678 §S2 整合)

| 期間 | 手順 |
|---|---|
| マージ前 | revert 可 (簡単、Draft 維持で merge 前停止) |
| マージ後 24h 以内 | GitHub Actions Variables に `USE_LOOKUP_KEY=false` 設定 → CDK redeploy で env var 直読経路に巻き戻し (約 30 秒で反映)。apiVersion は revert PR + Lambda 再 deploy で旧 `'2026-05-27.dahlia'` に戻し (Webhook destination は PR-4b 未実施のため不整合発生せず) |
| 1 週間後 | forward fix のみ (旧 env var は別 PR cleanup で削除、ADR-0010 Pre-PMF 過剰防衛防止) |

## 配布済み env / secret (ADR-0006)

本 PR で新規追加した env / secret の配布証跡:

- **配布済み: USE_LOOKUP_KEY** → CDK context `useLookupKey` → Lambda env (`infra/lib/compute-stack.ts`) → GitHub Actions Variables `vars.USE_LOOKUP_KEY` (`.github/workflows/deploy.yml`、default `'true'`)。`.env.example` テンプレート PR-3a #2717 で配備済
- **配布済み: STRIPE_WEBHOOK_SHADOW_MODE** → CDK context `stripeWebhookShadowMode` → Lambda env (`infra/lib/compute-stack.ts`) → GitHub Actions Variables `vars.STRIPE_WEBHOOK_SHADOW_MODE` (`.github/workflows/deploy.yml`、default `'false'`)。`.env.example` テンプレート PR-4a #2714 で配備済
- **配布済み: STRIPE_WEBHOOK_SECRET_TEST** → CDK context `stripeWebhookSecretTest` → Lambda env (`infra/lib/compute-stack.ts` 条件付き spread、空文字 omit) → GitHub Actions Secrets `secrets.STRIPE_WEBHOOK_SECRET_TEST` (`.github/workflows/deploy.yml`)。`.env.example` テンプレート PR-4a #2714 で配備済

設計 SSOT: [docs/decisions/0059-phase7-cutover-sequence.md](../docs/decisions/0059-phase7-cutover-sequence.md) §1 + [docs/design/billing-redesign/phase6-context-decisions-6.md](../docs/design/billing-redesign/phase6-context-decisions-6.md) §4 + [phase6-rollback-and-kill-switches.md](../docs/design/billing-redesign/phase6-rollback-and-kill-switches.md) §S6。

## Ready for Review チェックリスト

**✅ Round 5 時点 (2026-06-02): 本 PR は Phase A 6/6 全解消 (#2770 MERGED 2026-06-02T04:08:18Z) + staging 検証期間 gate 達成圏 (約 2.5 日経過、短期案 2-3 日 ✅) の AND 条件達成**。QM Round 5 Re-Review approve gate に乗る経路。

- [x] **`npx svelte-check && npx biome check src/ infra/ scripts/ && npx vitest run` 全件 PASS をローカル確認** (Round 4 rebase 後、#2690 ドッグフード 26 連続継続)
- [x] セルフレビュー済み (不要な差分・デバッグコードなし、tmp/pr-bodies/ は Ready 後削除)
- [x] 全 AC が実装済み (AC1-AC6 全 PASS 物理 grep + vitest count evidence 付与、未完遂残ゼロ)
- [x] Phase 分割した場合: 本 PR は Phase 7 PR-3b cutover + apiVersion 物理 bump + Webhook env CDK 経路完成。**Phase A prerequisite 6/6 全解消達成** (#2718 / #2719 / #2720 / #2735 / #2738 / #2749 すべて MERGED / CLOSED)
- [x] UI 変更時: N/A (server-side / infra のみ、UI 変更ゼロ)
- [x] 認証画面変更時: N/A (認証画面変更なし)
- [x] **Phase A 6/6 全解消 (✅ #2770 MERGED) + staging 検証期間 gate 達成圏 (✅ 約 2.5 日経過) — Re-Ready 化 AND 条件達成**。QM Round 5 Re-Review approve gate に乗る経路で cutover 実施判断を Dev/PO で確定

## QM レビュー結果

(QM が Round 5 Re-Review 時に記入。Round 5 で rebase + body 最新化 + Phase A 6/6 完遂反映 + staging gate 達成圏更新まで完遂、QM Re-Review approve gate 充足状態で cutover 実施判断経路)

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
