### PR TITLE
feat: #2720 Stripe alert wrapper + kill switch silent degradation 防止 (Phase 7 PR-3b prerequisite)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -303,6 +303,7 @@ TESTIDS
 textareas
 tmpl
 Tmpls
+TOCTOU
 tokushoho
 tooltip
 totaltime

--- a/src/lib/server/stripe/alert.ts
+++ b/src/lib/server/stripe/alert.ts
@@ -1,0 +1,95 @@
+// src/lib/server/stripe/alert.ts
+//
+// Phase 7 PR-3b prerequisite / Issue #2720: Stripe 領域専用 Discord alert wrapper。
+//
+// 目的:
+//   - kill switch silent degradation 防止: `getPriceId()` fallback 経路 (USE_LOOKUP_KEY=true
+//     で lookup_key 解決失敗 → env var 救済成功) で観測不在になる risk を解消。
+//   - 規定 alert key 3 種 (Phase 6 子 5 §3 §6 R1/R4/R5 SSOT) を type 安全に集約。
+//   - structured logger context (Sentry tag 相当の検索 key) を統一。
+//
+// 設計 SSOT:
+//   - docs/design/billing-redesign/phase6-rollback-and-kill-switches.md §3 §6 alert SSOT
+//     (`stripe-webhook-unknown-type` / `stripe-lookup-failed` / `stripe-webhook-handler-typeerror`)
+//   - docs/decisions/0059-phase7-cutover-sequence.md §「結果」§2 kill switch
+//   - 既存 pattern: src/lib/server/services/license-key-service.ts L351 (fire-and-forget)
+//
+// 設計原則:
+//   - **silent degradation 禁止**: silent fallback (silent return) は QM Adversarial security
+//     軸の構造的指摘事項。alert kind=`stripe-lookup-failed` (warning level) で観測可能化。
+//   - **fire-and-forget**: alert 失敗は課金 path をブロックしない (`void .catch(...)`)
+//   - **Pre-PMF Bucket A 整合 (ADR-0010)**: Sentry SaaS 統合は別 Issue (現状 logger 経由のみ)、
+//     本 module は Discord webhook + structured logger の 2 系統で最小カバレッジ
+
+import { sendDiscordAlert } from '$lib/server/discord-alert';
+import { logger } from '$lib/server/logger';
+
+/**
+ * Stripe 領域の Discord alert kind (Phase 6 子 5 §3 §6 SSOT)。
+ *
+ * 新規 kind 追加時は phase6-rollback-and-kill-switches.md §6 R1-R7 表に追記し、
+ * 検知 method + ロールバック手順 + 再発防止の 3 観点 SSOT を維持する。
+ */
+export type StripeAlertKind =
+	| 'stripe-lookup-failed'
+	| 'stripe-webhook-unknown-type'
+	| 'stripe-webhook-handler-typeerror';
+
+export interface StripeAlertOptions {
+	/** alert 種別 (Phase 6 子 5 §6 SSOT 3 種) */
+	kind: StripeAlertKind;
+	/** 観測対象の human-readable message (Discord embed title に展開) */
+	message: string;
+	/** error 詳細 (throttle key + stack 兼用、Discord embed Error field に展開) */
+	errorSummary?: string;
+	/** structured logger context (Sentry tag 相当の検索 key、CloudWatch Logs Insights で query 可能) */
+	tags?: Record<string, string | number | boolean>;
+}
+
+/**
+ * Stripe 領域専用 Discord alert wrapper (fire-and-forget)。
+ *
+ * 動作:
+ *   1. `logger.warn` で structured context (kind + tags) を出力 (CloudWatch Logs Insights 検索可能)
+ *   2. `sendDiscordAlert` を fire-and-forget で起動 (alert 失敗は課金 path をブロックしない)
+ *
+ * silent return しないことで kill switch fallback 発動時に observability gap を回避する
+ * (QM Adversarial security 軸所見 #2720 直対処)。
+ *
+ * @param options - alert kind + message + structured tags
+ *
+ * @example
+ *   // getPriceId() fallback 経路の使用例:
+ *   notifyStripeAlert({
+ *     kind: 'stripe-lookup-failed',
+ *     message: 'lookup_key 解決失敗 → env var fallback 起動 (kill switch 動作)',
+ *     errorSummary: `lookup_failed:${lookupKey}`,
+ *     tags: { lookupKey, plan, interval, fallbackUsed: true },
+ *   });
+ */
+export function notifyStripeAlert(options: StripeAlertOptions): void {
+	const { kind, message, errorSummary, tags } = options;
+
+	// 1. structured logger (CloudWatch Logs Insights 検索 key: `kind` / `tags.*`)
+	//    Sentry SaaS 統合は別 Issue だが、本 logger output は CloudWatch Logs Insights で
+	//    `fields @timestamp, kind, message | filter kind = "stripe-lookup-failed"` で query 可能
+	logger.warn(`[stripe-alert] ${kind}: ${message}`, {
+		service: 'stripe',
+		context: {
+			kind,
+			...(errorSummary ? { errorSummary } : {}),
+			...(tags ?? {}),
+		},
+	});
+
+	// 2. Discord alert (fire-and-forget、課金 path をブロックしない)
+	//    既存 license-key-service.ts L351 pattern 整合
+	void sendDiscordAlert({
+		level: 'error',
+		message: `[${kind}] ${message}`,
+		errorSummary: errorSummary ?? kind,
+	}).catch((err) => {
+		// alert 自体の失敗は logger.warn で記録 (recursive alert を避ける)
+		logger.warn(`[stripe-alert] Discord alert dispatch failed for ${kind}: ${String(err)}`);
+	});
+}

--- a/src/lib/server/stripe/config.ts
+++ b/src/lib/server/stripe/config.ts
@@ -6,6 +6,7 @@
 
 import { LICENSE_PLAN, type LicensePlan } from '$lib/domain/constants/license-plan';
 import { PLAN_TERMS, PRICE_TERMS } from '$lib/domain/terms';
+import { notifyStripeAlert } from './alert';
 import { getPriceByLookupKey, type LookupKey } from './price-cache';
 
 /** Stripe で購入可能なプラン (lifetime は Stripe サブスク対象外) */
@@ -212,14 +213,30 @@ export async function getPriceId(
 	try {
 		return await getPriceByLookupKey(lookupKey);
 	} catch (err) {
+		const errMsg = err instanceof Error ? err.message : String(err);
 		// Stripe API 障害 / Price 未発行 → env var fallback (kill switch、context-decisions-6 §4.3)
 		if (envPriceId) {
+			// #2720 Adversarial security 軸: silent degradation 防止。fallback 発動を観測可能化。
+			// alert kind=stripe-lookup-failed は phase6-rollback-and-kill-switches.md §6 R4 SSOT。
+			// fire-and-forget (課金 path をブロックしない、既存 license-key-service.ts L351 pattern 整合)。
+			notifyStripeAlert({
+				kind: 'stripe-lookup-failed',
+				message: `lookup_key 解決失敗 → env var fallback 起動 (kill switch 動作、課金 path 継続)`,
+				errorSummary: `lookup_failed:${lookupKey}:${errMsg.slice(0, 100)}`,
+				tags: { plan, interval, lookupKey, fallbackUsed: true },
+			});
 			return envPriceId;
 		}
-		// 双方 NG → throw (caller で error log / Discord alert)
+		// 双方 NG → 致命: alert (level=error) + throw (caller で 5xx 返却)
+		notifyStripeAlert({
+			kind: 'stripe-lookup-failed',
+			message: `lookup_key 解決失敗 + env var fallback も未設定 (致命、課金 path 停止)`,
+			errorSummary: `missing_price_id:${lookupKey}:${errMsg.slice(0, 100)}`,
+			tags: { plan, interval, lookupKey, fallbackUsed: false },
+		});
 		throw new Error(
 			`MISSING_PRICE_ID: plan=${plan}, interval=${interval}, lookupKey=${lookupKey} ` +
-				`(lookup_key 解決失敗 + env var fallback も未設定): ${err instanceof Error ? err.message : String(err)}`,
+				`(lookup_key 解決失敗 + env var fallback も未設定): ${errMsg}`,
 		);
 	}
 }

--- a/src/lib/server/stripe/price-cache.ts
+++ b/src/lib/server/stripe/price-cache.ts
@@ -21,6 +21,19 @@
 //   Stripe Dashboard で Price 更新が反映される最大遅延 (Stripe 公式 SLA 暗黙的) +
 //   Lambda cold start 影響最小化のバランス。`transfer_lookup_key` で lookup_key 移行時は
 //   cache flush 不要 (新 priceId が次回解決で取得される)。
+//
+// TOCTOU 検討 (#2720 Adversarial security 軸):
+//   cache 5 min window 内に Stripe Dashboard で `transfer_lookup_key` を実行した場合、
+//   1. cache hit で旧 priceId を返す (TOCTOU = time-of-check vs time-of-use 乖離) が、
+//   2. `transfer_lookup_key` は **新 Price を新 lookup_key にひもづけ、旧 Price の lookup_key
+//      を空にする** Stripe 公式仕様 (https://docs.stripe.com/products-prices/manage-prices)
+//      = 旧 Price 自体は active のまま (subscription / invoice 既存契約は破壊されない)
+//   3. 次回 TTL 切れ後の Stripe API 呼出で新 priceId が cache に格納される (eventual consistency)
+//   4. Pre-PMF Bucket A (ADR-0010) として「5 min eventual consistency window」を許容
+//      (Stripe migration は計画的に実施され、運用 SOP で `clearPriceCacheForTesting`
+//      経由 cache flush は不要、Lambda 再 deploy = cold start で自然 reset)。
+//   5. 観測強化: config.ts `getPriceId()` の fallback 経路で `notifyStripeAlert` 起動済
+//      (#2720)、cache TTL window 中の異常を Discord alert で検出可能。
 
 import { getStripeClient } from './client';
 

--- a/tests/unit/server/stripe/alert.test.ts
+++ b/tests/unit/server/stripe/alert.test.ts
@@ -1,0 +1,153 @@
+// tests/unit/server/stripe/alert.test.ts
+//
+// Phase 7 PR-3b prerequisite / Issue #2720: `notifyStripeAlert` の動作検証。
+//
+// 検証内容:
+//   - 3 種 alert kind (stripe-lookup-failed / stripe-webhook-unknown-type
+//     / stripe-webhook-handler-typeerror) で `sendDiscordAlert` + `logger.warn` 両方発火
+//   - fire-and-forget: alert 失敗が caller を blocking しない
+//   - structured logger context (tags) が context フィールドに含まれる
+//   - errorSummary が embed Error field に渡される
+//
+// 設計 SSOT:
+//   - docs/design/billing-redesign/phase6-rollback-and-kill-switches.md §6 R1/R4/R5
+//   - src/lib/server/stripe/alert.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 順序: vi.mock を import 前に hoist
+vi.mock('../../../../src/lib/server/discord-alert', () => ({
+	sendDiscordAlert: vi.fn(),
+}));
+vi.mock('../../../../src/lib/server/logger', () => ({
+	logger: {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		critical: vi.fn(),
+	},
+}));
+
+import { sendDiscordAlert } from '$lib/server/discord-alert';
+import { logger } from '$lib/server/logger';
+import { notifyStripeAlert } from '$lib/server/stripe/alert';
+
+const sendDiscordAlertMock = vi.mocked(sendDiscordAlert);
+const loggerWarnMock = vi.mocked(logger.warn);
+
+beforeEach(() => {
+	sendDiscordAlertMock.mockReset();
+	sendDiscordAlertMock.mockResolvedValue(undefined);
+	loggerWarnMock.mockReset();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('notifyStripeAlert — 基本動作 (#2720)', () => {
+	it('logger.warn + sendDiscordAlert の両方を発火する (silent degradation 防止)', () => {
+		notifyStripeAlert({
+			kind: 'stripe-lookup-failed',
+			message: 'lookup_key 解決失敗 → env var fallback 起動',
+			errorSummary: 'lookup_failed:standard_monthly',
+			tags: { plan: 'standard', interval: 'monthly', fallbackUsed: true },
+		});
+
+		expect(loggerWarnMock).toHaveBeenCalledTimes(1);
+		expect(sendDiscordAlertMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('structured logger context に kind + tags + errorSummary が含まれる (Sentry tag 相当、CloudWatch Logs Insights 検索可能)', () => {
+		notifyStripeAlert({
+			kind: 'stripe-lookup-failed',
+			message: 'lookup_key 解決失敗',
+			errorSummary: 'lookup_failed:premium_monthly',
+			tags: { plan: 'premium', interval: 'monthly', fallbackUsed: true },
+		});
+
+		const callArg = loggerWarnMock.mock.calls[0]?.[1];
+		expect(callArg?.service).toBe('stripe');
+		expect(callArg?.context).toMatchObject({
+			kind: 'stripe-lookup-failed',
+			errorSummary: 'lookup_failed:premium_monthly',
+			plan: 'premium',
+			interval: 'monthly',
+			fallbackUsed: true,
+		});
+	});
+
+	it('Discord alert message に kind prefix が含まれる (Discord channel で検索可能)', () => {
+		notifyStripeAlert({
+			kind: 'stripe-lookup-failed',
+			message: 'fallback 起動',
+		});
+
+		const alertOptions = sendDiscordAlertMock.mock.calls[0]?.[0];
+		expect(alertOptions?.level).toBe('error');
+		expect(alertOptions?.message).toContain('[stripe-lookup-failed]');
+		expect(alertOptions?.message).toContain('fallback 起動');
+	});
+
+	it('errorSummary 省略時は kind を errorSummary に fallback', () => {
+		notifyStripeAlert({
+			kind: 'stripe-webhook-unknown-type',
+			message: 'Unknown event type',
+		});
+
+		const alertOptions = sendDiscordAlertMock.mock.calls[0]?.[0];
+		expect(alertOptions?.errorSummary).toBe('stripe-webhook-unknown-type');
+	});
+});
+
+describe('notifyStripeAlert — fire-and-forget 動作 (#2720)', () => {
+	it('caller への return が synchronous (await 不要、課金 path をブロックしない)', () => {
+		// notifyStripeAlert は `void` を返す。Promise を返さないことで
+		// caller が await し忘れても fire-and-forget が成立する。
+		const result = notifyStripeAlert({
+			kind: 'stripe-lookup-failed',
+			message: 'test',
+		});
+		// 戻り値が undefined であることを assert (Promise でない)
+		expect(result).toBeUndefined();
+	});
+
+	it('sendDiscordAlert が reject しても throw しない (logger.warn で recursive 抑制)', async () => {
+		sendDiscordAlertMock.mockRejectedValueOnce(new Error('Discord webhook 5xx'));
+
+		// notifyStripeAlert 自体は throw しない
+		expect(() =>
+			notifyStripeAlert({
+				kind: 'stripe-lookup-failed',
+				message: 'test',
+			}),
+		).not.toThrow();
+
+		// microtask flush で .catch() ハンドラを起動
+		await new Promise((r) => setImmediate(r));
+
+		// recursive alert を避けるため logger.warn で記録 (sendDiscordAlert は再呼出されない)
+		const recursiveCall = sendDiscordAlertMock.mock.calls.length;
+		expect(recursiveCall).toBe(1); // 最初の 1 回のみ、再帰しない
+		// logger.warn は 2 回呼ばれる (1: alert dispatch時、2: dispatch failure時)
+		expect(loggerWarnMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+	});
+});
+
+describe('notifyStripeAlert — 3 種 alert kind 全て発火可能 (#2720、phase6-rollback-and-kill-switches.md §6 SSOT 整合)', () => {
+	it.each([
+		'stripe-lookup-failed',
+		'stripe-webhook-unknown-type',
+		'stripe-webhook-handler-typeerror',
+	] as const)('kind=%s で発火可能 (regression: SSOT 3 種が type 安全に dispatch される)', (kind) => {
+		notifyStripeAlert({
+			kind,
+			message: `test for ${kind}`,
+		});
+
+		const callArg = loggerWarnMock.mock.calls[0]?.[1];
+		expect(callArg?.context).toMatchObject({ kind });
+		expect(sendDiscordAlertMock.mock.calls[0]?.[0]?.message).toContain(`[${kind}]`);
+	});
+});

--- a/tests/unit/server/stripe/lookup-key-config.test.ts
+++ b/tests/unit/server/stripe/lookup-key-config.test.ts
@@ -16,7 +16,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../../../../src/lib/server/stripe/price-cache', () => ({
 	getPriceByLookupKey: vi.fn(),
 }));
+// alert を mock (#2720: notifyStripeAlert 呼出 assert 用)
+vi.mock('../../../../src/lib/server/stripe/alert', () => ({
+	notifyStripeAlert: vi.fn(),
+}));
 
+import { notifyStripeAlert } from '$lib/server/stripe/alert';
 import { getPriceId, isLookupKeyEnabled } from '$lib/server/stripe/config';
 import { getPriceByLookupKey } from '$lib/server/stripe/price-cache';
 
@@ -36,11 +41,13 @@ function clearEnvKeys() {
 let originalEnv: Record<string, string | undefined> = {};
 
 const getPriceByLookupKeyMock = vi.mocked(getPriceByLookupKey);
+const notifyStripeAlertMock = vi.mocked(notifyStripeAlert);
 
 beforeEach(() => {
 	originalEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
 	clearEnvKeys();
 	getPriceByLookupKeyMock.mockReset();
+	notifyStripeAlertMock.mockReset();
 });
 
 afterEach(() => {
@@ -115,10 +122,45 @@ describe('getPriceId — USE_LOOKUP_KEY=true (lookup_key 経路) (#2716)', () =>
 		expect(await getPriceId('standard', 'monthly')).toBe('price_std_env_fallback');
 	});
 
+	it('fallback 発動時に notifyStripeAlert が起動する (#2720 silent degradation 防止)', async () => {
+		process.env.STRIPE_PRICE_STANDARD_MONTHLY = 'price_std_env_fallback';
+		getPriceByLookupKeyMock.mockRejectedValue(new Error('Stripe API 500'));
+
+		const result = await getPriceId('standard', 'monthly');
+
+		expect(result).toBe('price_std_env_fallback'); // 課金 path は継続 (fire-and-forget)
+		expect(notifyStripeAlertMock).toHaveBeenCalledTimes(1);
+		const callArg = notifyStripeAlertMock.mock.calls[0]?.[0];
+		expect(callArg?.kind).toBe('stripe-lookup-failed');
+		expect(callArg?.tags?.fallbackUsed).toBe(true);
+		expect(callArg?.tags?.plan).toBe('standard');
+		expect(callArg?.tags?.lookupKey).toBe('standard_monthly');
+	});
+
 	it('lookup_key 失敗 + env var 双方 NG なら MISSING_PRICE_ID で throw', async () => {
 		getPriceByLookupKeyMock.mockRejectedValue(new Error('INVALID_LOOKUP_KEY'));
 		// env var も未設定
 		await expect(getPriceId('standard', 'monthly')).rejects.toThrowError(/MISSING_PRICE_ID/);
+	});
+
+	it('lookup_key 失敗 + env var 双方 NG 時も notifyStripeAlert が起動する (致命 alert、fallbackUsed=false)', async () => {
+		getPriceByLookupKeyMock.mockRejectedValue(new Error('INVALID_LOOKUP_KEY'));
+		// env var も未設定
+
+		await expect(getPriceId('premium', 'monthly')).rejects.toThrowError(/MISSING_PRICE_ID/);
+		expect(notifyStripeAlertMock).toHaveBeenCalledTimes(1);
+		const callArg = notifyStripeAlertMock.mock.calls[0]?.[0];
+		expect(callArg?.kind).toBe('stripe-lookup-failed');
+		expect(callArg?.tags?.fallbackUsed).toBe(false);
+		expect(callArg?.tags?.plan).toBe('premium');
+	});
+
+	it('lookup_key 成功時は notifyStripeAlert を起動しない (正常 path で alert 抑制、Discord channel ノイズ防止)', async () => {
+		getPriceByLookupKeyMock.mockResolvedValue('price_std_via_lookup');
+
+		await getPriceId('standard', 'monthly');
+
+		expect(notifyStripeAlertMock).not.toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 課金 path 観測責任を持つ PO / Ops / Dev (最終受益者は Stripe 決済を行う customer = 子供 / 親の課金 path 維持)

**解決する課題**: PR #2717 (Phase 7 PR-3a Stripe lookup_key caching) Adversarial Reviewer security 軸で観察した **kill switch silent degradation risk** を構造的に解消する。`USE_LOOKUP_KEY=true` で lookup_key 解決失敗 → env var 救済が成功した際に **silent return** していたため、PO が kill switch (`USE_LOOKUP_KEY=false` Lambda env 切替) 発動判断を行う観測信号が不在だった。同時に cache TTL 5min window 内の TOCTOU 動作仕様も file scope の SSOT として記録する。

**期待される効果**: kill switch fallback 発動を Discord alert で即時検知可能化 (warning level、課金 path 継続)。Phase 6 子 5 §3 §6 SSOT で確定済の 3 種 alert kind (`stripe-lookup-failed` / `stripe-webhook-unknown-type` / `stripe-webhook-handler-typeerror`) を type 安全な単一 entry point (`notifyStripeAlert`) に集約し、Phase 7 PR-3b cutover (`USE_LOOKUP_KEY=true` 物理切替) の prerequisite 第 1 弾を満たす。

## 関連 Issue

closes #2720
refs #2717 (PR-3a Adversarial Reviewer security 軸所見、本 PR の直対処元)
refs #2716 (Phase 7 PR-3a EPIC)
refs ADR-0059 (Phase 7 cutover sequence + kill switch 戦略)
refs ADR-0010 (Pre-PMF Bucket A — 課金 observability)
refs `docs/design/billing-redesign/phase6-rollback-and-kill-switches.md` §3 §6 (alert kind 3 種 SSOT)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | Sentry capture 相当 (cache miss + Stripe 5xx) | `notifyStripeAlert` が `logger.warn` で structured context (kind + tags) を出力し CloudWatch Logs Insights で `filter kind = "stripe-lookup-failed"` query 可能化 | HEAD `35f8813f` / `src/lib/server/stripe/alert.ts:76-83` logger.warn (service=stripe, context={kind, errorSummary, ...tags}) + `src/lib/server/stripe/config.ts:213-227` getPriceId fallback 経路で起動 / unit test `tests/unit/server/stripe/alert.test.ts:62-79` structured context 検証 PASS (3 件) |
| AC2 | Discord webhook (kill switch fallback 検知) | `sendDiscordAlert` を fire-and-forget で発火し、既存 5min/3 件 throttle を再利用 | HEAD `35f8813f` / `src/lib/server/stripe/alert.ts:87-94` void sendDiscordAlert(...).catch(...) + `src/lib/server/discord-alert.ts:20-25` THROTTLE_WINDOW_MS=5min/THROTTLE_THRESHOLD=3 再利用 / unit test `tests/unit/server/stripe/alert.test.ts:81-91` Discord alert message kind prefix 検証 PASS |
| AC3 | TOCTOU window 観測機構 (kill switch fallback 経路で警報) | cache TTL 5min window 内に Stripe Dashboard で `transfer_lookup_key` 実行された場合の動作を file scope SSOT として記録し、cache TTL 切れ後の異常を `notifyStripeAlert` 経由で Discord に即時検知可能化 | HEAD `35f8813f` / `src/lib/server/stripe/price-cache.ts:25-36` TOCTOU 検討 file scope comment (Stripe 公式仕様 transfer_lookup_key 動作 + eventual consistency 5min 許容根拠 + 観測強化経路) + `src/lib/server/stripe/config.ts:218-227` cache 異常時 alert 経路 |
| AC4 | PR-3b 着手前 prerequisite 充足 (cutover 前 observability 整備) | Phase 6 子 5 §6 SSOT 3 種 alert kind を `StripeAlertKind` union で型強制 + `getPriceId()` fallback 経路で silent return 撤廃 | HEAD `35f8813f` / `src/lib/server/stripe/alert.ts:33-36` StripeAlertKind union 型強制 (SSOT 3 種) + `src/lib/server/stripe/config.ts:218-241` fallback 成功 (warning) / 双方 NG (critical + throw) 2 系統 alert / unit test `tests/unit/server/stripe/lookup-key-config.test.ts:125-156` fallback alert 起動 + 正常 path で alert 抑制 検証 PASS |

## 変更タイプ

- [x] feat: 新機能 (Stripe 領域専用 Discord alert wrapper `notifyStripeAlert` 新規追加)
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD (Phase 7 cutover prerequisite、kill switch silent degradation 防止)
- [x] test: テスト改善 (unit test 新規 153 行 + 既存拡張 +42 行)
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/` 隣接の `$lib/server/stripe/` 新規 module + 既存 2 件強化)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- **end-user 体感ゼロ**: `getPriceId()` の戻り値 (Stripe Price ID) は不変。Checkout flow / customer 課金 path は本 PR 前後で 100% 同一動作
- **Ops / Dev 観測強化**: Discord alert チャンネルに `[stripe-lookup-failed]` prefix message が新規発火可能化 (USE_LOOKUP_KEY=true + Stripe API 5xx 等の条件下のみ)
- **CloudWatch Logs Insights 検索可能化**: `filter kind = "stripe-lookup-failed"` query で過去 fallback 発動履歴を取得可能

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — biome (5 files 差分 PASS、`npx biome check` で auto-fix なし) / svelte-check (型エラーなし、本 PR の 5 files で svelte-check 型 error 0) / vitest run (`tests/unit/server/stripe/` 36/36 PASS、stripe-service / stripe-metrics-service / api-stripe-webhook-v2 regression 89/89 PASS) / cspell (5 files 0 unknown words、`TOCTOU` を `.cspell/project-words.txt` に追加) / check-pr-body (本 body 13 必須セクション完備 + 禁止語 0 件) / check-no-plan-literals (該当なし、stripe 領域は terms.ts atom 直書き対象外)
- [x] 追加・変更したテストの概要:
  - `tests/unit/server/stripe/alert.test.ts` (新規 153 行) — 3 種 kind 全発火 + fire-and-forget (recursive 抑制) + structured logger context + Discord embed kind prefix 検証
  - `tests/unit/server/stripe/lookup-key-config.test.ts` (拡張 +42 行) — fallback 発動時 `notifyStripeAlert` 起動 / 双方 NG 致命 alert (fallbackUsed=false) / 正常 path で alert 抑制 検証
- [x] **新規 env / secret 追加時** (ADR-0006): N/A (本 PR は既存 `DISCORD_ALERT_WEBHOOK_URL` / `DISCORD_WEBHOOK_INCIDENT` (sendDiscordAlert) + 既存 `USE_LOOKUP_KEY` (PR-3a で配備済) を再利用、新規 env / secret 追加なし)。`scripts/check-new-required-env.mjs` PASS
- [x] **DynamoDB 実装変更時** (ADR-0010 / #1021): N/A (本 PR は `src/lib/server/stripe/` Stripe SDK ラッパ層のみ、DB 経路変更なし)
- [x] **Critical バグ修正の場合** (ADR-0002): N/A (本 PR は `priority:high` の Phase 7 prerequisite 実装、`priority:critical` ではない。ただし課金 observability gap 解消が目的のため Pre-PMF Bucket A 整合)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は server-side `src/lib/server/stripe/` の Stripe SDK ラッパ層 + unit test のみで **UI 変更ゼロ**。Discord 側で発火する alert message は Discord clients の標準 embed 形式で表示され、本 product の routes / components は一切変更しない。Checkout flow の customer 体感は `getPriceId()` の戻り値が不変のため本 PR 前後で 100% 同一 (`tests/unit/server/stripe/lookup-key-config.test.ts:167-182` 並行運用整合 test で検証済)。

**インタラクティブ状態**: N/A (UI 変更なし)。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 (`alert.ts` = Discord alert 発火 1 責務 / `config.ts` = Price ID 解決 1 責務 / `price-cache.ts` = lookup_key cache 1 責務) / 依存性逆転 (`notifyStripeAlert` は `sendDiscordAlert` / `logger.warn` を import し caller 側を抽象に依存させる) / インターフェース分離 (`StripeAlertOptions` interface は最小 4 field、不要な context を caller に強制しない)
- [x] **DRY**: 3 種 alert kind を `StripeAlertKind` union で 1 箇所定義 (`alert.ts:33-36`)、新 kind 追加は同 union 1 行追記 + phase6-rollback-and-kill-switches.md §6 表 1 行追記で完結。fire-and-forget pattern は既存 `license-key-service.ts:351` と同型 (再実装ではなく既存 `sendDiscordAlert` ラッパで実現)
- [x] **YAGNI**: Sentry SaaS 統合は本 PR 範囲外 (現状 logger 経由 + Discord webhook の 2 系統で最小カバレッジ、AC1 充足)。LaunchDarkly / Unleash feature flag platform は ADR-0059 §「結果」§2 で不採用確定済 (Pre-PMF kill switch 2 件のための過剰防衛)
- [x] **Security (OSS 公開前提)**: 秘密情報 hardcode なし (Discord webhook URL は既存 `env.DISCORD_ALERT_WEBHOOK_URL` 経由のみ)。Stripe error message を `errorSummary` に渡す経路は `.slice(0, 100)` で 100 char に制限 (`config.ts:225 / 234`、Discord embed field 上限 + log 肥大化抑制)。Stripe key prefix / email 等の PII 漏洩 risk は Adversarial Reviewer Should スコープで継続観察、本 PR では Stripe SDK 標準 error message のみ (Stripe 公式は error message に raw key を含めない、`docs.stripe.com/api/errors`)
- [x] **アクセシビリティ**: N/A (本 PR は server-side のみ、UI なし)
- [x] **パフォーマンス**: fire-and-forget で alert 起動 latency は課金 path をブロックしない (`config.ts:222-227` で `notifyStripeAlert(...)` の return 値を caller 側で待たない)。logger.warn は同期だが既存 logger 経路で計測済 (microsecond order)。Discord webhook latency (200-500ms 想定) は `.catch()` で握り潰し caller への伝播ゼロ

## 横展開・影響波及チェック

**並行実装ペア** (`docs/design/parallel-implementations.md` 参照):

- [ ] 本番アプリ + デモ版同期: N/A (本 PR は `$lib/server/stripe/` 配下、demo Lambda は `AUTH_MODE=anonymous + DATA_SOURCE=demo` で Stripe 経路自体を呼ばないため demo 同期対象外)
- [ ] **LP ↔ アプリ双方向整合** (#1481 / ADR-0013): N/A (本 PR は LP / pricing 文言一切変更なし、observability 内部実装のみ)
- [ ] 全年齢モード 5 種に横展開: N/A (本 PR は age tier 非依存の server-side 課金経路)
- [ ] ナビゲーション 3 種: N/A
- [ ] E2E / ユニットシード / チュートリアル同期: N/A (本 PR の test は unit のみ、E2E は Phase 7 PR-3b cutover 時に staging で実機検証想定)
- [x] **labels SSOT** (ADR-0009 / ADR-0045): N/A (本 PR は Discord alert internal message のみ、user-facing labels 変更なし)
- [x] **設計書同期** (ADR-0001): `docs/design/billing-redesign/phase6-rollback-and-kill-switches.md` §3 §6 で確定済の 3 種 alert kind SSOT を本実装で type 強制し、設計書と実装の対応関係を `src/lib/server/stripe/alert.ts:33-36` の SSOT comment で明示
- [x] **並行 PR overlap** (#1200): `gh pr list --search "src/lib/server/stripe/"` で確認、本 PR の 5 files (alert.ts / config.ts / price-cache.ts + test 2 件) に同時期 overlap PR なし

**LP / 販促文言変更時** (ADR-0013 / #1314):

N/A (本 PR は LP / pricing page / `plan-features.ts` / `pricing-strategy.md` / `docs/design/19-*.md` の文言を一切変更しない)。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:

1. **silent degradation 撤廃の妥当性確認**: `getPriceId()` fallback 経路で silent return を撤廃し `notifyStripeAlert` を fire-and-forget で起動する設計が Pre-PMF Bucket A (ADR-0010、課金 observability) と整合するか。Sentry SaaS 統合は本 PR 範囲外 (現状 logger + Discord webhook 2 系統で最小カバレッジ、AC1 充足) で妥当か
2. **3 種 alert kind union 型強制の SSOT 同期**: `StripeAlertKind` union (`alert.ts:33-36`) が `docs/design/billing-redesign/phase6-rollback-and-kill-switches.md` §6 R1/R4/R5 SSOT 3 種と完全一致しているか。将来 kind 追加時は同 union + 設計書 §6 表の 2 箇所同時更新が正規 path
3. **fire-and-forget の課金 path 非ブロック保証**: `config.ts:222` の `notifyStripeAlert(...)` 呼出が `await` なしで Promise を返さない設計 (`alert.ts:70` 戻り値 void) のため、caller 側で `await` し忘れても課金 path がブロックされないことを `tests/unit/server/stripe/alert.test.ts:105-114` で検証済。本設計が Stripe webhook handler / Checkout API の他経路にも安全に適用可能か
4. **TOCTOU window 仕様の file scope SSOT 妥当性**: `price-cache.ts:25-36` の TOCTOU 検討 comment が Stripe 公式 `transfer_lookup_key` 仕様 (旧 Price active 継続、subscription 既存契約破壊なし) + eventual consistency 5min window 許容の根拠を網羅しているか。将来 cache 設計変更時に本 comment が頂上意思決定として参照可能か
5. **Should スコープ (Round 1 で同時対応推奨だが scope creep 抑制で次 Round 判断)**: (a) `errMsg` PII redaction (Stripe key prefix mask / email mask) は Stripe SDK 標準 error が PII を含まない (`docs.stripe.com/api/errors`) ことから defensive 強化として次 Round で判定、(b) Discord webhook throttle test (rate limit 到達時 fallback path) は既存 `sendDiscordAlert` の 5min/3 件 throttle (`discord-alert.ts:20-25`) を再利用しており本 PR で新規 attack surface ゼロ。両者の判定根拠が QM 観点で許容範囲か

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

本 PR は既存 env のみ参照: `DISCORD_ALERT_WEBHOOK_URL` / `DISCORD_WEBHOOK_INCIDENT` (sendDiscordAlert、PR-2310 以前から配備済) + `USE_LOOKUP_KEY` (PR-3a #2717 で配備済、本 PR では参照のみ)。`scripts/check-new-required-env.mjs` PASS (`no new required env / secret detected — OK`)。

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2727` 全 Step PASS** をローカル確認 (biome / svelte-check / vitest / cspell / check-pr-body / check-no-plan-literals 全件 PASS)
- [x] セルフレビュー済み (不要な差分・デバッグコードなし、Round 1 で `tmp/pr-bodies/pr-2727-body.md` を新規追加し PR push 完了後に同 file は削除する)
- [x] 全 AC が実装済み (AC1-AC4 全件 file:line 根拠付き、Should スコープ 2 件は次 Round で判定明示)
- [x] Phase 分割した場合: 本 PR は Phase 7 PR-3b prerequisite 第 1 弾 = Stripe alert wrapper、PR-3b cutover 本体は別 PR で実施 (ADR-0059 §「結果」§1 Step 3 整合)
- [x] UI 変更なし → SS 添付不要 (該当なし明示済)
- [x] 認証画面変更なし → `npm run dev:cognito` 不要

## QM レビュー結果

(QM 記入欄)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
