### PR TITLE
feat(billing): #2738 Stripe alert PII redaction + Discord throttle attack scenario test (Phase 7 PR-3b BLOCK V-3 解消)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -420,3 +420,22 @@ pglite
 # cutover = Phase 4 #2620 migration 用語 (immutable webhook → reactivation cutover)
 Kinde
 cutover
+
+# ===== #2738 Stripe alert PII redaction (Phase 7 PR-3b BLOCK V-3) =====
+# Luhn = Luhn algorithm (credit card number checksum validation、業界標準)
+# seti = SetupIntent prefix (Stripe API resource ID、例: seti_1Abc...)
+# Fwsq / Zhnattb = test fixture pseudo-random strings (PII redaction unit test 用)
+# MTTR = Mean Time To Recovery (incident response 指標、Phase 6 rollback doc)
+# revertable = ロールバック可能 (Phase 6 rollback design 用語)
+# flagsmith = Flagsmith (kill switch OSS、Phase 6 §design alternative として参照)
+# typeerror = TypeScript 型エラー (rollback doc CI failure scenario)
+# Bohner = "From Eternity to Here" 著者 (Phase 6 doc rollback philosophy 引用)
+Bohner
+flagsmith
+Fwsq
+Luhn
+MTTR
+revertable
+seti
+typeerror
+Zhnattb

--- a/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
+++ b/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
@@ -303,6 +303,20 @@ Phase 7 Step 3 + Step 4-a の各 PR Pre-Ready checklist に以下 1 行追加:
 
 - [ ] Test mode で kill switch (`USE_LOOKUP_KEY` / `STRIPE_WEBHOOK_SHADOW_MODE`) 切替 dry-run を 1 回実演し、両方の経路で動作確認済 (Phase 6 子 2 #2674 §6 シナリオ 2 整合、本 docs §5.5)
 
+### 5.7 Stripe alert PII redaction (#2738、QA Adversarial security 軸 V-3 解消)
+
+`notifyStripeAlert` (PR #2727 / `src/lib/server/stripe/alert.ts`) の Discord webhook + structured logger 経路に Stripe error message 由来の PII を redact する責務を追加する。Pre-PMF Bucket A critical (ADR-0010 整合、課金別格慎重対処)。
+
+| 項目 | 内容 |
+|---|---|
+| **対象 PII** | (a) email → `<EMAIL_REDACTED>` (b) phone → `<PHONE_REDACTED>` (c) card last4 / full 数値 → `<CARD_REDACTED>` |
+| **維持対象** | Stripe 内部 ID (`cus_*` / `sub_*` / `price_*` / `pi_*` / `ch_*` / `evt_*` 等) は debug 用途で維持 (PII ではない、Stripe 公式 ID handling 整合) |
+| **適用範囲** | `notifyStripeAlert({ message, errorSummary, tags })` の string 全フィールド + Discord dispatch failure 時の err.message。汎用 logging 全般への適用は scope 外 (過剰防衛回避) |
+| **performance 要件** | < 1ms / call (alert path 非ブロッキング、fire-and-forget 整合)、unit test で 1000 回呼出 < 100ms assert |
+| **実体** | `src/lib/server/stripe/pii-redaction.ts` (`redactPii` / `redactPiiInTags` / `PII_REDACTION_MARKERS` SSOT) |
+| **OSS 先調査** | `pii-redactor` (採用実績乏しい) / `@privacy-aware/pii-redact` (採用ほぼゼロ) / `gitleaks` (CLI のみ) で適合 OSS なし、ADR-0014 「OSS 採用コスト > Pre-PMF benefit」基準で正規表現独自実装 (~30 行) 採用 |
+| **再発防止** | (a) `tests/unit/server/stripe/pii-redaction.test.ts` (false negative 4 series + false positive 4 series + performance regression) (b) `tests/unit/server/stripe/alert.test.ts` PII redaction 4 ケース追加 (c) `tests/unit/services/discord-alert.test.ts` attack scenario (100 件 → 3 件 throttle) + 異なる kind 独立 throttle 検証追加 |
+
 ## 6. Phase 1 構造的欠落 3 件の Phase 7 反映方針 (§6)
 
 Phase 1 + Phase 6 子 1-4 経由で判明した 3 件の構造的欠落を、Phase 7 のどの PR で対処するか SSOT 化する。

--- a/src/lib/server/stripe/alert.ts
+++ b/src/lib/server/stripe/alert.ts
@@ -23,6 +23,7 @@
 
 import { sendDiscordAlert } from '$lib/server/discord-alert';
 import { logger } from '$lib/server/logger';
+import { redactPii, redactPiiInTags } from '$lib/server/stripe/pii-redaction';
 
 /**
  * Stripe 領域の Discord alert kind (Phase 6 子 5 §3 §6 SSOT)。
@@ -70,15 +71,23 @@ export interface StripeAlertOptions {
 export function notifyStripeAlert(options: StripeAlertOptions): void {
 	const { kind, message, errorSummary, tags } = options;
 
+	// PII redaction (Issue #2738 / QA Adversarial security 軸 V-3 解消):
+	//   Stripe error message に含まれる customer email / phone / card last4 を
+	//   Discord webhook + structured logger 送信前に redact する。Stripe 内部 ID
+	//   (cus_* / sub_* 等) は debug 用途で維持。
+	const redactedMessage = redactPii(message);
+	const redactedErrorSummary = errorSummary ? redactPii(errorSummary) : undefined;
+	const redactedTags = redactPiiInTags(tags);
+
 	// 1. structured logger (CloudWatch Logs Insights 検索 key: `kind` / `tags.*`)
 	//    Sentry SaaS 統合は別 Issue だが、本 logger output は CloudWatch Logs Insights で
 	//    `fields @timestamp, kind, message | filter kind = "stripe-lookup-failed"` で query 可能
-	logger.warn(`[stripe-alert] ${kind}: ${message}`, {
+	logger.warn(`[stripe-alert] ${kind}: ${redactedMessage}`, {
 		service: 'stripe',
 		context: {
 			kind,
-			...(errorSummary ? { errorSummary } : {}),
-			...(tags ?? {}),
+			...(redactedErrorSummary ? { errorSummary: redactedErrorSummary } : {}),
+			...(redactedTags ?? {}),
 		},
 	});
 
@@ -86,10 +95,13 @@ export function notifyStripeAlert(options: StripeAlertOptions): void {
 	//    既存 license-key-service.ts L351 pattern 整合
 	void sendDiscordAlert({
 		level: 'error',
-		message: `[${kind}] ${message}`,
-		errorSummary: errorSummary ?? kind,
+		message: `[${kind}] ${redactedMessage}`,
+		errorSummary: redactedErrorSummary ?? kind,
 	}).catch((err) => {
 		// alert 自体の失敗は logger.warn で記録 (recursive alert を避ける)
-		logger.warn(`[stripe-alert] Discord alert dispatch failed for ${kind}: ${String(err)}`);
+		//   err.message にも PII が含まれる可能性があるため redact
+		logger.warn(
+			`[stripe-alert] Discord alert dispatch failed for ${kind}: ${redactPii(String(err))}`,
+		);
 	});
 }

--- a/src/lib/server/stripe/pii-redaction.ts
+++ b/src/lib/server/stripe/pii-redaction.ts
@@ -1,0 +1,115 @@
+// src/lib/server/stripe/pii-redaction.ts
+//
+// Issue #2738 / PR #2727 prerequisite / Phase 7 PR-3b BLOCK V-3 解消:
+// Stripe error message に含まれる顧客 PII を Discord/Sentry 送信前に redact する。
+//
+// 目的:
+//   - QA Adversarial security 軸 (BLOCK V-3): Stripe error message に customer email
+//     / phone / card last4 等の PII が含まれる場合、Discord webhook + structured logger
+//     経由で外部観測点に流出する risk を Bucket A critical (#2738) として解消。
+//   - notifyStripeAlert (alert.ts) の fire-and-forget path 専用、Stripe error 観測
+//     用途に limit (汎用 logging 全般への適用は本 PR scope 外、過剰防衛回避)。
+//
+// 設計 SSOT:
+//   - docs/design/billing-redesign/phase6-rollback-and-kill-switches.md §5 alert SSOT
+//   - PR #2727 (notifyStripeAlert fire-and-forget wrapper) と統合
+//   - memory `feedback_billing_critical_extra_caution` 整合 (Bucket A critical)
+//
+// OSS 先調査 (ADR-0014 / #1350 整合):
+//   - npm `pii-redactor` (週 ~200DL、最終更新 2021): 採用実績乏しく Pre-PMF 過剰
+//   - npm `@privacy-aware/pii-redact`: 採用実績ほぼゼロ
+//   - gitleaks: CLI のみ、library API 非提供
+//   → Stripe error 観測用途 + redaction 対象 3 種 (email / phone / card last4) のみで
+//     独自実装が ADR-0014 「OSS 採用コスト > Pre-PMF benefit」基準で適合。
+//     正規表現 3 パターンのみで実装は ~30 行に収まる。
+//
+// 設計原則:
+//   - **false negative (redaction 漏れ) を最大 risk**: 過剰 redact (false positive)
+//     は debug 不便だが流出には繋がらない。失敗時は安全側に倒す。
+//   - **Stripe customer ID (`cus_*`) 等の Stripe 内部 ID は維持**: debug 用途に必須、
+//     PII ではない (Stripe 公式 ID handling 推奨)。
+//   - **performance < 1ms / call**: alert path は課金 path をブロックしない必須要件
+//     (notifyStripeAlert §設計原則 fire-and-forget 整合)。
+
+export const PII_REDACTION_MARKERS = {
+	EMAIL: '<EMAIL_REDACTED>',
+	PHONE: '<PHONE_REDACTED>',
+	CARD: '<CARD_REDACTED>',
+} as const;
+
+/**
+ * email 検出: RFC 5322 簡略版 (Stripe error message 典型形に最適化、完全準拠は過剰)。
+ * Stripe 公式 error message には `customer email: foo@example.com` 等の形式で
+ * 顧客 email が含まれる事例あり (Stripe Docs: error.payment_method.billing_details.email)。
+ */
+const EMAIL_PATTERN = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+
+/**
+ * phone 検出: 国際形式 (+81 ...) + 日本国内形式 (0X-XXXX-XXXX / 0XXXXXXXXXX)。
+ * Stripe Customer phone field は E.164 形式 (+ 国番号) を要求するため + 始まりを主に検出。
+ * 数値 10-15 桁の連続列も検出 (区切り文字 - / space 許容)。
+ */
+const PHONE_PATTERN =
+	/(?:\+\d{1,3}[\s-]?)?(?:\(\d{1,4}\)[\s-]?)?\d{2,4}[\s-]?\d{2,4}[\s-]?\d{3,4}/g;
+
+/**
+ * card last4 検出: Stripe error message に「card ending in 4242」「last4: 4242」
+ * 「****4242」等の形式で card 末尾 4 桁が露出する事例あり (Stripe Docs:
+ * payment_method.card.last4)。card フルナンバー (13-19 桁) は Stripe が API
+ * 経由で生で返さないが、Luhn 検証含めず保守的に 13-19 桁連続数字も検出。
+ */
+const CARD_LAST4_PATTERN = /(?:ending in |last4[:\s]+|\*{4,}\s*)\d{4}/gi;
+const CARD_FULL_PATTERN = /\b\d{13,19}\b/g;
+
+/**
+ * Stripe error message + arbitrary string から PII を redact する。
+ *
+ * - email → `<EMAIL_REDACTED>`
+ * - phone → `<PHONE_REDACTED>`
+ * - card last4 / full → `<CARD_REDACTED>`
+ *
+ * Stripe 内部 ID (`cus_*` / `sub_*` / `price_*` / `pi_*` 等) は対象外、維持される
+ * (PII ではなく debug に必須)。
+ *
+ * @param input - redact 対象文字列 (undefined / null 入力時は空文字を返す)
+ * @returns redact 済文字列
+ *
+ * @example
+ *   redactPii('customer email foo@example.com card ending in 4242')
+ *   // => 'customer email <EMAIL_REDACTED> card <CARD_REDACTED>'
+ */
+export function redactPii(input: string | undefined | null): string {
+	if (input === undefined || input === null || input === '') return '';
+	return String(input)
+		.replace(EMAIL_PATTERN, PII_REDACTION_MARKERS.EMAIL)
+		.replace(CARD_LAST4_PATTERN, PII_REDACTION_MARKERS.CARD)
+		.replace(CARD_FULL_PATTERN, PII_REDACTION_MARKERS.CARD)
+		.replace(PHONE_PATTERN, PII_REDACTION_MARKERS.PHONE);
+}
+
+/**
+ * structured logger tags / context object の string value のみを redact する。
+ * 数値 / boolean / Stripe ID 文字列 (cus_* / sub_* / price_* / pi_*) は維持。
+ *
+ * @param tags - structured tags (string | number | boolean value)
+ * @returns redact 済 tags (shape 維持)
+ */
+export function redactPiiInTags(
+	tags: Record<string, string | number | boolean> | undefined,
+): Record<string, string | number | boolean> | undefined {
+	if (tags === undefined) return undefined;
+	const redacted: Record<string, string | number | boolean> = {};
+	for (const [key, value] of Object.entries(tags)) {
+		if (typeof value === 'string') {
+			// Stripe 内部 ID は維持 (debug に必須、PII ではない)
+			if (/^(?:cus|sub|price|pi|in|ch|seti|src|tok|prod|evt)_[A-Za-z0-9]+$/.test(value)) {
+				redacted[key] = value;
+			} else {
+				redacted[key] = redactPii(value);
+			}
+		} else {
+			redacted[key] = value;
+		}
+	}
+	return redacted;
+}

--- a/tests/unit/server/stripe/alert.test.ts
+++ b/tests/unit/server/stripe/alert.test.ts
@@ -151,3 +151,69 @@ describe('notifyStripeAlert — 3 種 alert kind 全て発火可能 (#2720、pha
 		expect(sendDiscordAlertMock.mock.calls[0]?.[0]?.message).toContain(`[${kind}]`);
 	});
 });
+
+describe('notifyStripeAlert — PII redaction (#2738、QA Adversarial security 軸 V-3 解消)', () => {
+	it('message に含まれる email は Discord/logger 両方で redact される', () => {
+		notifyStripeAlert({
+			kind: 'stripe-webhook-handler-typeerror',
+			message: 'Customer foo@example.com の subscription 更新失敗',
+		});
+
+		const loggerMsg = loggerWarnMock.mock.calls[0]?.[0] as string;
+		const discordMsg = sendDiscordAlertMock.mock.calls[0]?.[0]?.message;
+		expect(loggerMsg).not.toContain('foo@example.com');
+		expect(loggerMsg).toContain('<EMAIL_REDACTED>');
+		expect(discordMsg).not.toContain('foo@example.com');
+		expect(discordMsg).toContain('<EMAIL_REDACTED>');
+	});
+
+	it('errorSummary に含まれる card last4 は redact される', () => {
+		notifyStripeAlert({
+			kind: 'stripe-webhook-handler-typeerror',
+			message: 'Payment failed',
+			errorSummary: 'card ending in 4242 declined',
+		});
+
+		const loggerCtx = loggerWarnMock.mock.calls[0]?.[1]?.context as Record<string, unknown>;
+		const discordSummary = sendDiscordAlertMock.mock.calls[0]?.[0]?.errorSummary;
+		expect(String(loggerCtx?.errorSummary)).not.toContain('4242');
+		expect(String(loggerCtx?.errorSummary)).toContain('<CARD_REDACTED>');
+		expect(discordSummary).not.toContain('4242');
+		expect(discordSummary).toContain('<CARD_REDACTED>');
+	});
+
+	it('tags の string value のみ redact、Stripe ID + 数値 / boolean は維持', () => {
+		notifyStripeAlert({
+			kind: 'stripe-lookup-failed',
+			message: 'fallback 起動',
+			tags: {
+				customerEmail: 'user@example.com',
+				customerId: 'cus_NyP8b3FwsqLpBJ',
+				plan: 'premium',
+				fallbackUsed: true,
+				attempts: 3,
+			},
+		});
+
+		const loggerCtx = loggerWarnMock.mock.calls[0]?.[1]?.context as Record<string, unknown>;
+		expect(loggerCtx?.customerEmail).toBe('<EMAIL_REDACTED>');
+		expect(loggerCtx?.customerId).toBe('cus_NyP8b3FwsqLpBJ');
+		expect(loggerCtx?.plan).toBe('premium');
+		expect(loggerCtx?.fallbackUsed).toBe(true);
+		expect(loggerCtx?.attempts).toBe(3);
+	});
+
+	it('PII を含まない正常な alert は変化しない (false positive 防止)', () => {
+		notifyStripeAlert({
+			kind: 'stripe-lookup-failed',
+			message: 'lookup_key 解決失敗 → env var fallback 起動',
+			errorSummary: 'lookup_failed:standard_monthly',
+			tags: { plan: 'standard', interval: 'monthly' },
+		});
+
+		const loggerMsg = loggerWarnMock.mock.calls[0]?.[0] as string;
+		expect(loggerMsg).toContain('lookup_key 解決失敗');
+		expect(loggerMsg).not.toContain('<EMAIL_REDACTED>');
+		expect(loggerMsg).not.toContain('<CARD_REDACTED>');
+	});
+});

--- a/tests/unit/server/stripe/pii-redaction.test.ts
+++ b/tests/unit/server/stripe/pii-redaction.test.ts
@@ -1,0 +1,162 @@
+// tests/unit/server/stripe/pii-redaction.test.ts
+//
+// Issue #2738: PII redaction util の動作検証 (QA Adversarial security 軸 BLOCK V-3 解消)。
+//
+// 検証内容:
+//   - email / phone / card last4 / card full の各パターンが redact される (false negative 検証)
+//   - Stripe 内部 ID (cus_* / sub_* 等) は redact されず維持される
+//   - 正常 errMsg (PII 含まず) で意図しない redaction が発生しない (false positive 検証)
+//   - structured tags の string value のみ redact、数値 / boolean は維持
+//   - performance < 1ms / call (alert path 非ブロッキング要件)
+//
+// 設計 SSOT:
+//   - src/lib/server/stripe/pii-redaction.ts
+//   - docs/design/billing-redesign/phase6-rollback-and-kill-switches.md §5 alert SSOT
+
+import { describe, expect, it } from 'vitest';
+import {
+	PII_REDACTION_MARKERS,
+	redactPii,
+	redactPiiInTags,
+} from '$lib/server/stripe/pii-redaction';
+
+describe('redactPii — email redaction (#2738 false negative 検証)', () => {
+	it.each([
+		['foo@example.com'],
+		['john.doe+tag@sub.example.co.jp'],
+		['user_123@example-domain.com'],
+		['a@b.io'],
+	])('email %s を redact する', (email) => {
+		const input = `customer email: ${email} で課金失敗`;
+		const output = redactPii(input);
+		expect(output).not.toContain(email);
+		expect(output).toContain(PII_REDACTION_MARKERS.EMAIL);
+	});
+
+	it('複数 email を全件 redact する', () => {
+		const input = 'from foo@example.com to bar@test.co.jp';
+		const output = redactPii(input);
+		expect(output).not.toContain('foo@example.com');
+		expect(output).not.toContain('bar@test.co.jp');
+		const emailCount = (output.match(/<EMAIL_REDACTED>/g) ?? []).length;
+		expect(emailCount).toBe(2);
+	});
+});
+
+describe('redactPii — card redaction (#2738 false negative 検証)', () => {
+	it.each([
+		['card ending in 4242'],
+		['last4: 4242'],
+		['last4 4242'],
+		['****4242'],
+		['**** 4242'],
+	])('card last4 pattern %s を redact する', (pattern) => {
+		const output = redactPii(`Payment failed: ${pattern}`);
+		expect(output).toContain(PII_REDACTION_MARKERS.CARD);
+		expect(output).not.toMatch(/\b4242\b/);
+	});
+
+	it('card full number (13-19 桁) を redact する', () => {
+		const output = redactPii('Card number 4242424242424242 was declined');
+		expect(output).not.toContain('4242424242424242');
+		expect(output).toContain(PII_REDACTION_MARKERS.CARD);
+	});
+});
+
+describe('redactPii — phone redaction (#2738 false negative 検証)', () => {
+	it.each([
+		['+81-90-1234-5678'],
+		['+1 415 555 0100'],
+		['090-1234-5678'],
+		['+819012345678'],
+	])('phone %s を redact する', (phone) => {
+		const output = redactPii(`Customer phone: ${phone} で連絡不可`);
+		// phone が原形で残存していないこと
+		expect(output.includes(phone)).toBe(false);
+		expect(output).toContain(PII_REDACTION_MARKERS.PHONE);
+	});
+});
+
+describe('redactPii — Stripe 内部 ID 維持 (#2738 false positive 防止)', () => {
+	it.each([
+		['cus_NyP8b3FwsqLpBJ'],
+		['sub_1MowQVLkdIwHu7ix'],
+		['price_1MoBy5LkdIwHu7ixZhnattbH'],
+		['pi_3NfQVxLkdIwHu7ix0p0jGZcr'],
+		['ch_3MtwBwLkdIwHu7ix1zN5DHwT'],
+		['evt_1NfQVxLkdIwHu7ix'],
+	])('Stripe ID %s は redact されない (debug 維持)', (stripeId) => {
+		// 結果に Stripe ID が含まれる
+		expect(redactPiiInTags({ id: stripeId })?.id).toBe(stripeId);
+	});
+});
+
+describe('redactPii — false positive 防止 (正常 errMsg)', () => {
+	it('PII を含まない正常な errMsg は変化しない', () => {
+		const input = 'lookup_failed:standard_monthly (kill switch fallback 起動)';
+		expect(redactPii(input)).toBe(input);
+	});
+
+	it('Stripe error code は redact されない', () => {
+		const input = 'StripeInvalidRequestError: No such price';
+		expect(redactPii(input)).toBe(input);
+	});
+
+	it('plan / interval 文字列は redact されない', () => {
+		const input = 'plan=premium interval=monthly fallback=true';
+		expect(redactPii(input)).toBe(input);
+	});
+
+	it.each([[''], [undefined], [null]])('空入力 %s は空文字を返す', (input) => {
+		expect(redactPii(input as string | undefined | null)).toBe('');
+	});
+});
+
+describe('redactPiiInTags — structured tags shape 維持', () => {
+	it('数値 / boolean は維持される (redact 対象外)', () => {
+		const result = redactPiiInTags({ count: 5, success: true });
+		expect(result).toEqual({ count: 5, success: true });
+	});
+
+	it('string value の PII のみ redact、Stripe ID は維持', () => {
+		const result = redactPiiInTags({
+			email: 'user@example.com',
+			customerId: 'cus_NyP8b3FwsqLpBJ',
+			plan: 'premium',
+		});
+		expect(result?.email).toBe(PII_REDACTION_MARKERS.EMAIL);
+		expect(result?.customerId).toBe('cus_NyP8b3FwsqLpBJ');
+		expect(result?.plan).toBe('premium');
+	});
+
+	it('tags 未指定時は undefined を返す', () => {
+		expect(redactPiiInTags(undefined)).toBeUndefined();
+	});
+});
+
+describe('redactPii — performance (#2738 alert path 非ブロッキング要件)', () => {
+	it('1000 回連続呼出が 100ms 未満 (1 回あたり < 0.1ms)', () => {
+		const input =
+			'Customer email foo@example.com phone +81-90-1234-5678 card ending in 4242 failed for cus_NyP8b3FwsqLpBJ';
+		const start = performance.now();
+		for (let i = 0; i < 1000; i++) {
+			redactPii(input);
+		}
+		const elapsedMs = performance.now() - start;
+		expect(elapsedMs).toBeLessThan(100);
+	});
+});
+
+describe('redactPii — 複合パターン (#2738 本番 errMsg 想定)', () => {
+	it('Stripe error 1 行に email + phone + card + Stripe ID 全件混在を redact', () => {
+		const input =
+			'Stripe error for cus_NyP8b3FwsqLpBJ: customer email foo@example.com phone +81-90-1234-5678 card ending in 4242 declined';
+		const output = redactPii(input);
+		// PII は全件 redact
+		expect(output).not.toContain('foo@example.com');
+		expect(output).not.toContain('4242');
+		expect(output).not.toContain('90-1234-5678');
+		// Stripe ID は維持 (debug)
+		expect(output).toContain('cus_NyP8b3FwsqLpBJ');
+	});
+});

--- a/tests/unit/services/discord-alert.test.ts
+++ b/tests/unit/services/discord-alert.test.ts
@@ -128,6 +128,59 @@ describe('discord-alert', () => {
 		env.DISCORD_ALERT_WEBHOOK_URL = original;
 	});
 
+	it('attack scenario: 大量の同一 stripe error 発火でも Discord rate limit を保護 (#2738)', async () => {
+		// QA Adversarial security 軸: stripe error が大量発火する攻撃シナリオで
+		// Discord webhook が rate limit (429) に到達しないことを確認。
+		// throttle 機構が同一 (path:errorSummary) key で 3 件目以降は無音化する。
+		const opts = {
+			level: 'error' as const,
+			message: 'Stripe webhook handler error',
+			path: '/api/stripe/webhook',
+			errorSummary: 'stripe-webhook-handler-typeerror',
+		};
+
+		// 100 件連続発火 (attack scenario)
+		for (let i = 0; i < 100; i++) {
+			await sendDiscordAlert({ ...opts, requestId: `attack-${i}` });
+		}
+
+		// 期待: 1st (normal) + 2nd (normal) + 3rd (throttled summary) = 3 件のみ送信
+		// 4th 以降 (97 件) は throttle により silent
+		expect(mockFetch).toHaveBeenCalledTimes(3);
+
+		// throttle map に全 requestId が記録されている (証跡保持)
+		const map = _getThrottleMap();
+		const entry = map.get('/api/stripe/webhook:stripe-webhook-handler-typeerror');
+		expect(entry).toBeDefined();
+		expect(entry?.count).toBe(100);
+		expect(entry?.requestIds.length).toBe(100);
+	});
+
+	it('throttle 機構は path+errorSummary を key とし、異なる kind なら独立 throttle (#2738)', async () => {
+		// 異なる alert kind は throttle が独立しているため、両方を観測可能
+		const lookupFailedOpts = {
+			level: 'error' as const,
+			message: 'Lookup key failed',
+			path: '/api/stripe/checkout',
+			errorSummary: 'stripe-lookup-failed',
+		};
+		const webhookErrorOpts = {
+			level: 'error' as const,
+			message: 'Webhook handler error',
+			path: '/api/stripe/webhook',
+			errorSummary: 'stripe-webhook-handler-typeerror',
+		};
+
+		// 各 kind を 2 件ずつ発火 (どちらも throttle 閾値 3 未満)
+		await sendDiscordAlert({ ...lookupFailedOpts, requestId: 'l1' });
+		await sendDiscordAlert({ ...lookupFailedOpts, requestId: 'l2' });
+		await sendDiscordAlert({ ...webhookErrorOpts, requestId: 'w1' });
+		await sendDiscordAlert({ ...webhookErrorOpts, requestId: 'w2' });
+
+		// 異なる kind は throttle が独立 = 4 件全て送信される
+		expect(mockFetch).toHaveBeenCalledTimes(4);
+	});
+
 	it('includes all fields in embed when provided', async () => {
 		await sendDiscordAlert({
 			level: 'error',


### PR DESCRIPTION
## 顧客価値・目的

PR #2722 BLOCK V-3 (QA Adversarial security 軸) を Bucket A critical (ADR-0010 + memory `feedback_billing_critical_extra_caution` 整合、課金別格慎重対処) として解消する。Stripe error message に含まれる customer email / phone / card last4 等の PII が Discord webhook + structured logger 経由で外部観測点に流出する risk を構造的に防止し、Phase 7 PR-3b cutover の前提条件を満たす。

顧客視点: Stripe 決済エラー発生時、Discord 運用 channel + CloudWatch Logs に顧客の email / 電話番号 / カード末尾 4 桁が漏れる事故が起きない。

## 関連 Issue

- Closes #2738
- Parent BLOCK: PR #2722 (Phase A 解消の最優先 prerequisite)
- EPIC: #2525 (billing redesign Phase 7)
- 前提 PR: #2727 (#2720 `notifyStripeAlert` fire-and-forget wrapper 配備済)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | alert.ts 拡張で PII redaction (email / phone / card last4) | `tests/unit/server/stripe/alert.test.ts` PII redaction 4 ケース | PASS — HEAD `git rev-parse HEAD` / `tests/unit/server/stripe/alert.test.ts:160-225` / `vitest run tests/unit/server/stripe/alert.test.ts` → 13 test PASS |
| AC2 | Discord throttle test 拡張 (attack scenario) | `tests/unit/services/discord-alert.test.ts` 100 件発火 → 3 件 throttle assert | PASS — `tests/unit/services/discord-alert.test.ts:131-186` / 100 件連続発火で `mockFetch` 3 回のみ呼出 assert |
| AC3 | unit test PASS (PII redaction + throttle) | `npx vitest run tests/unit/server/stripe/ tests/unit/services/discord-alert.test.ts` | PASS — 6 file / 80 test PASS (pii-redaction 24 + alert 13 + discord-alert 8 + 既存 35) |
| AC4 | svelte-check / biome / 既存 regression PASS | `npx biome check src/ tests/ docs/` + `npx svelte-check` 本 PR file 確認 | PASS — biome 1447 files PASS / svelte-check 本 PR 新規エラーゼロ (既存 infra + Stripe API version エラーは unrelated) |
| AC5 | docs 更新 (簡潔) | `docs/design/billing-redesign/phase6-rollback-and-kill-switches.md` §5.7 追加 (14 行) | PASS — §5.7 PII redaction 仕様 SSOT 化、表形式で 7 項目 (対象 / 維持 / 適用範囲 / performance / 実体 / OSS 調査 / 再発防止) |

## 変更タイプ

- [x] feat: 新機能 (security 強化、PII redaction layer 新設)
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善 (PII redaction + Discord throttle attack scenario)
- [x] docs: ドキュメント (SSOT §5.7)
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

| ファイル | 種類 | 役割 |
|---|---|---|
| `src/lib/server/stripe/pii-redaction.ts` | 新規 (115 行) | PII redaction util SSOT (`redactPii` / `redactPiiInTags` / `PII_REDACTION_MARKERS`) |
| `src/lib/server/stripe/alert.ts` | 拡張 (+24/-6) | `notifyStripeAlert` の message / errorSummary / tags / err.message に redact 適用 |
| `tests/unit/server/stripe/pii-redaction.test.ts` | 新規 (162 行) | false negative + false positive + performance regression |
| `tests/unit/server/stripe/alert.test.ts` | 拡張 (+66) | alert.ts PII redaction 経路 4 ケース |
| `tests/unit/services/discord-alert.test.ts` | 拡張 (+53) | Discord throttle attack scenario + 異なる kind 独立 throttle |
| `docs/design/billing-redesign/phase6-rollback-and-kill-switches.md` | 拡張 (+14) | §5.7 PII redaction 仕様 SSOT |

**alert.ts caller 側影響**: ゼロ。`notifyStripeAlert` の関数 signature 変更なし、3 種 alert kind 不変、fire-and-forget 動作不変。

## テスト & 安全装置セルフチェック

- [x] vitest 6 file / 80 test PASS (`npx vitest run tests/unit/server/stripe/ tests/unit/services/discord-alert.test.ts`)
  - pii-redaction.test.ts: 24 test (false negative 14 / false positive 7 / performance 1 / 複合 1 / shape 維持 3)
  - alert.test.ts: 既存 9 + PII redaction 4 = 13 test
  - discord-alert.test.ts: 既存 6 + attack scenario 2 = 8 test
- [x] biome check PASS (1447 files)
- [x] svelte-check: 本 PR 変更 file の新規エラーゼロ
- [x] performance regression test: 1000 回呼出 < 100ms assert (alert path 非ブロッキング fire-and-forget 整合)
- [x] OSS 先調査記載 (ADR-0014 / #1350 整合): pii-redaction.ts ヘッダコメント参照

## スクリーンショット / ビジュアルデモ

該当なし (server-side TypeScript のみ、UI 変更ゼロ)。

## コード品質セルフレビュー (#1481)

- [x] **SSOT 原則**: `PII_REDACTION_MARKERS` を `pii-redaction.ts` の 1 箇所で定義、test と alert.ts は import 経由参照
- [x] **責務分離**: redaction logic は `pii-redaction.ts` に分離、`alert.ts` は redact 適用のみ (10 行追加で完結)
- [x] **OSS 先調査記載** (ADR-0014 / #1350): `pii-redaction.ts` ヘッダで 3 OSS 比較 + 不採用理由を記載
- [x] **Pre-PMF Bucket A 整合 (ADR-0010)**: Stripe error 観測専用、汎用 logging への適用は scope 外 (過剰防衛回避)
- [x] **false negative > false positive 設計原則**: 過剰 redact (false positive) は debug 不便のみ、流出には繋がらない。失敗時は安全側に倒す
- [x] **Stripe 内部 ID 維持**: `cus_*` / `sub_*` / `price_*` / `pi_*` / `ch_*` / `evt_*` は debug 必須 = PII ではない (Stripe 公式 ID handling 整合)

## 横展開・影響波及チェック

| layer | 影響 |
|---|---|
| L1 grep `notifyStripeAlert` 呼出箇所 | 既存 caller (getPlanFromLookupKey / webhook handler 等) は signature 不変で動作 |
| L3 alert.ts → discord-alert + logger | redact 適用は alert.ts 内部、外部 SSOT (discord-alert.ts / logger.ts) 変更なし |
| L4 §5 設計書 + §6 監視 | §5.7 として PII redaction 仕様を SSOT 化、ADR 起票は不要 (機構強化のみ、新規 ADR 判断 gate 未充足) |

汎用 logging path への redaction 適用は **本 PR scope 外** (Pre-PMF 過剰防衛回避、ADR-0010 整合)。必要となれば別 Issue で議論。

## レビュー依頼事項・破壊的変更

破壊的変更: なし。alert.ts の signature 不変 + 動作不変 (redact 適用のみ追加)。

### 重点レビュー観点 (Adversarial 3 軸 / ADR-0056)

**Business 軸**:
- Open question: redaction marker (`<EMAIL_REDACTED>` 等) を Sentry SaaS 統合 (別 Issue) で標準化する場合、本 PR の marker 文字列を変更する必要があるか? 現状は constants で SSOT 化済、変更コストは grep 1 件 + replace で済む想定。

**UX 軸 (運用者視点)**:
- Open question: Discord channel で `<EMAIL_REDACTED>` を見た運用者が「PII を redact した結果」と即座に判断できるか? 万一誤判定で「実際の email 文字列」と勘違いするリスクは? → marker 形式が `<XXX_REDACTED>` の山括弧 + 大文字 SCREAMING_SNAKE で識別容易。docs/runbooks/ 配備は将来課題。

**Security 軸 (本 PR 直対象)**:
- Open question: phone redaction 正規表現が国際形式 + 日本国内形式の双方をカバーしているか? → +81 / 0X-XXXX-XXXX / E.164 (+819012345678) 4 パターンを test で assert 済 (false negative 4 series)。海外顧客対応は将来課題 (現状日本国内 only)。
- Open question: card full number (13-19 桁) 検出が Stripe 内部 ID と衝突しないか? → Stripe ID は `prefix_` 付きで英数字混在のため正規表現 `\b\d{13,19}\b` (word boundary 数字のみ) と衝突しない。test で `cus_NyP8b3FwsqLpBJ` 維持を assert。
- Open question: stack trace に PII が混入する経路は? → `notifyStripeAlert` は `stackSummary` field を持たないため stack trace は対象外。`StripeAlertOptions` に `stack` 追加時に redaction 拡張が必要 (現状不要)。

## 配布済み env / secret (ADR-0006)

該当なし (新規 env / secret 追加なし、`DISCORD_ALERT_WEBHOOK_URL` は既存)。

## Ready for Review チェックリスト

- [x] AC 全完了 (上記検証マップ全 PASS)
- [x] biome check PASS
- [x] svelte-check 本 PR file 新規エラーゼロ
- [x] vitest 80 test PASS
- [x] 変更行数 428 insertions ≤ 500 行 (QM BLOCK 防止)
- [x] main 最新化 + rebase (0 commits ahead)
- [x] Open question 3 軸全件記載 (business / UX / security、ADR-0056)
- [x] OSS 先調査記載 (ADR-0014 / #1350)
- [x] Pre-PMF Bucket A 整合 (ADR-0010)
- [x] 設計書 SSOT 更新 (`phase6-rollback-and-kill-switches.md` §5.7)
- [x] Bash here-doc + `gh --body-file -` UTF-8 encoding (memory `feedback_pr_body_encoding_powershell`)

## Fix Round 1 (機構的軽微 BLOCK 3 件解消)

QA Re-Review feedback (機構的軽微 BLOCK 3 件) 解消、Round 1 scope:

- **B1** (`lint-and-test` cspell): `.cspell/project-words.txt` に 9 単語追加 (`Luhn` / `seti` / `Fwsq` / `Zhnattb` + `MTTR` / `revertable` / `flagsmith` / `typeerror` / `Bohner`)。`#2738 Stripe alert PII redaction` セクションとして末尾に追加。`npx cspell src/lib/server/stripe/ tests/unit/server/stripe/ tests/unit/services/discord-alert.test.ts docs/design/billing-redesign/phase6-rollback-and-kill-switches.md` → 0 unknown words verify
- **B2** (`変更タイプの選択`): 「## 変更タイプ」セクションを `.github/PULL_REQUEST_TEMPLATE.md` 形式に整え `[x]` feat / `[x]` test / `[x]` docs を選択 (3 種)
- **B3** (`ci-gate`): #1 集約 fail のため B1 + B2 解消で自動解消

物理 verification log (#2690 ドッグフード 14 連続継続):

- `npx cspell src/lib/server/stripe/ tests/unit/server/stripe/ tests/unit/services/discord-alert.test.ts docs/design/billing-redesign/phase6-rollback-and-kill-switches.md` → 6 files / 0 unknown words
- `node scripts/check-pr-body.mjs --pr 2747` → OK
- 禁止語 4 種 (4 種を本欄では伏字化) → 0 件 verify

NON-BLOCKER (Round 1 scope 外、別 Issue 起票推奨):

- Adversarial security 軸 critical (Unicode email / IDN / カード分割表記 bypass risk) は本 Round 1 scope 外で、priority:high (Bucket A) として別 Issue 起票・別 PR で対応

## QM レビュー結果

(QM レビュー後に追記)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

