### PR TITLE
fix: Round 18 Cluster G — 「per-child」英語内部語彙 UI 露出撤去 (ADR-0045 §9)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4137,6 +4137,9 @@ export const ADMIN_ACTIVITIES_PAGE_LABELS = {
 	// imported=0 (選んだ子に全て追加済み) — generic な「完了」で誤魔化さない
 	importAllDuplicates: `選んだ${CHILD_TERMS.honorific}にはすでに追加済みです`,
 	importFailed: '取込に失敗しました',
+	// Round 18 Cluster G (per-child scope badge): 英語内部語彙「per-child」UI 露出撤去 (ADR-0045 §9)
+	// 「お子さま別」= per-child scope (個別 child に紐付く activity) を親向けに明示する短い表示
+	scopeBadgePerChild: `${CHILD_TERMS.honorific}別`,
 	// #2744 AC4 Delete UI (family scope): 一覧から活動を削除する確認 Dialog + 完了 Toast
 	// #2754 Fix Round 1 B2: undo 経路不在の business risk を文言で明示
 	// (ログ有 → 非表示で活動履歴は保全 / ログ無 → 物理削除でレコード復元不能)

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -526,7 +526,9 @@ function selectChild(childId: number) {
 					<span class="per-child-item__icon">{activity.icon}</span>
 					<span class="per-child-item__name">{activity.name}</span>
 					<span class="per-child-item__points">{activity.basePoints} pt</span>
-					<span class="per-child-item__scope-badge">per-child</span>
+					<span class="per-child-item__scope-badge"
+						>{ADMIN_ACTIVITIES_PAGE_LABELS.scopeBadgePerChild}</span
+					>
 				</div>
 			{/if}
 		{:else}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）— 特に preschool 親（3〜5 歳児保護者）

**解決する課題**: `/admin/activities` 一覧の per-child scope activity 行 badge に「per-child」という英語の内部実装語彙がそのまま表示されていた (`+page.svelte:529`)。一瞥して何を意味するか分からず、3 歳児保護者にとって認知負荷だった。docs/DESIGN.md §9「内部コード UI 露出禁止」/ ADR-0045 §9 違反。

**期待される効果**: 「お子さま別」と日本語親向け語彙で表示することで、その activity が個別 child に紐付くものであることが直感的に理解できる。同 UI に並ぶ他の文言と一貫した「お子さま」atom (`CHILD_TERMS.honorific`) を経由するため、SSOT (ADR-0045) も保たれる。

## 関連 Issue

Round 18 評価 Round 2 (Cluster G、persona_a 高 certainty 検出) の micro-fix。
Issue 番号なしのため `closes #` は付与せず、ADR-0045 §9 (内部コード露出禁止) に基づく直接是正として実施。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `+page.svelte:529` の literal `'per-child'` を撤去し labels.ts 経由参照に置換 | `grep -nE "scope-badge.*>per-child<" src/routes/(parent)/admin/activities/+page.svelte` で UI 文字列リテラル 0 件 | HEAD `fb00e7a6e` / 修正後 `+page.svelte:530-532` で `{ADMIN_ACTIVITIES_PAGE_LABELS.scopeBadgePerChild}` 参照 (class 名 / data-testid / comment 中の `per-child` 識別子は内部識別子のため非対象) |
| AC2 | `ADMIN_ACTIVITIES_PAGE_LABELS.scopeBadgePerChild` を `labels.ts` に追加 (`CHILD_TERMS.honorific` atom 経由、ADR-0045 整合) | `grep -n scopeBadgePerChild src/lib/domain/labels.ts` | HEAD `fb00e7a6e` / `labels.ts:4142` で `scopeBadgePerChild: \`${CHILD_TERMS.honorific}別\`` 定義 |
| AC3 | biome / svelte-check / vitest domain test PASS | `npx biome check` 該当 2 file / `npx svelte-check` 該当 +page.svelte に新規 error 0 / `npx vitest run tests/unit/domain/` | biome: Checked 2 files, No fixes applied / svelte-check: PR 編集箇所 (line 528-532) 新規 error 0 (line 62-63 の `state_referenced_locally` warning は pre-existing) / vitest domain: 813 PASS (Duration 67.54s) |
| AC4 | LP labels 同期維持 (shared-labels.js への波及なし、`scopeBadgePerChild` は admin 専用) | `node scripts/generate-lp-labels.mjs --check` | HEAD `fb00e7a6e` / 期待値: `✓ site/shared-labels.js は最新です` (admin 専用 label のため変更なし、`pre-ready` で再実行可能) |
| AC5 | SS 撮影で before/after の文言変化を視覚的に検証 (UI 変更のため必須) | `node scripts/capture.mjs --url '/admin/activities' --presets desktop,mobile --storage-state tmp/storage-state-owner-with-child.json` × 2 (main / PR HEAD) | 4 SS Blob SHA すべて unique (af2db05e / 394d4368 / 07afd2e2 / 448d6691)、本 PR body §「スクリーンショット」slot に 4 件添付済 |

## 変更タイプ

- [x] feat: 新機能 (label key 追加)
- [x] fix: バグ修正 (UI 内部語彙露出 = ADR-0045 §9 違反の是正)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/(parent)/admin/activities/+page.svelte`)
- [x] ドメインモデル (`$lib/domain/labels.ts`)

**影響を受ける画面・機能**:
- `/admin/activities` 一覧の per-child scope activity 行 badge (family 共通 activity には影響なし)

**影響を受けない**:
- LP / pricing / faq (admin 専用 label のため波及なし)
- 5 年齢モードの child 側 UI (本変更は admin 側のみ)
- Database schema / API / 認可

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — 主要 step ローカル実行済 (biome PASS / svelte-check PR 新規 error 0 / vitest domain 813 PASS / SS 撮影 4 件 Blob SHA unique)。Step 5 (LP dims) / 6 (LP fallback) / 8 (LP labels) は LP 非変更のため scope 外
- [x] 追加・変更したテストの概要: テスト追加なし (UI label rename のみ、`scopeBadgePerChild` 値は型システム + 既存 label tests baseline でカバー、tests/unit/domain/ 813 PASS で regression なし確認)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A (`priority:critical` ラベルなし、UX micro-fix)

## スクリーンショット / ビジュアルデモ

**4 スロット添付** (#1740):

| | モバイル (390×844) | PC (1440×900) |
|---|---|---|
| **修正前** (main d8c93181) | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2758/before-admin-activities-mobile.png) | ![before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2758/before-admin-activities-desktop.png) |
| **修正後** (PR HEAD fb00e7a6e) | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2758/after-admin-activities-mobile.png) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2758/after-admin-activities-desktop.png) |

**Blob SHA 4 件 unique 検証** (#2063 偽装防止):

```
af2db05e3813  205KB  before-admin-activities-mobile.png
394d436878c4  101KB  before-admin-activities-desktop.png
07afd2e2f411  207KB  after-admin-activities-mobile.png
448d669157a6  102KB  after-admin-activities-desktop.png
```

**DOM 文字列差分** (本 PR の主訴求 = scope-badge テキスト):

- 修正前: `<span class="per-child-item__scope-badge svelte-1hlzqwu">per-child</span>` (英語内部語彙)
- 修正後: `<span class="per-child-item__scope-badge svelte-1hlzqwu">お子さま別</span>` (日本語親向け、ADR-0045 atom 経由)

撮影環境: `npm run dev:cognito` (port 5174) + owner@example.com login + seed 子 1 + child_activities 2 (たろうくん / はみがき + おてつだい)、`tmp/seed-pr-2758.mjs` 経由。

**インタラクティブ状態**: N/A (badge 表示のみ、disabled / error / 空状態の派生表示なし)

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 (S) — `scopeBadgePerChild` は admin/activities ページ専用 label group `ADMIN_ACTIVITIES_PAGE_LABELS` 配下に配置、ドメイン分離維持
- [x] **DRY**: `'お子さま別'` 文字列リテラルが他箇所にないか `grep -rn 'お子さま別' src/` で確認 → 本 PR の 1 箇所 (labels.ts:4142) のみ、`CHILD_TERMS.honorific` atom 経由
- [x] **YAGNI**: 「お子さま個別」「お子さま専用」等の冗長な variant は追加せず、最短表記 `${CHILD_TERMS.honorific}別` 1 形のみ
- [x] **Security**: N/A (DOM 文字列のみ、attacker controlled 入力なし)
- [x] **アクセシビリティ**: badge は span text、`role` 付与なし (装飾用 inline tag)。日本語化により読み上げソフトでも親に意味通る (英語 "per-child" を screen reader が読むより認知負荷低)
- [x] **パフォーマンス**: bundle 増分 = label key 1 件 (約 20 byte)、N+1 / 大量描画なし

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期 — N/A (`src/routes/demo/**` は #2097 PR-B3 で削除済、demo Lambda は本番 route を `AUTH_MODE=anonymous` で起動)
- [ ] **LP ↔ アプリ双方向整合**: N/A (admin 専用 label、LP 訴求対象外)
- [ ] 全年齢モード 5 種に横展開 — N/A (admin 側のみ、5 年齢 child UI 非対象)
- [ ] ナビゲーション 3 種に反映 — N/A (badge 表示のみ、ナビ非変更)
- [ ] E2E / ユニットシード / チュートリアル同期 — N/A (新規 label のみ、シード変更不要)
- [x] **labels SSOT** (ADR-0045): atom `CHILD_TERMS.honorific` 経由で `labels.ts:4142` に compound `scopeBadgePerChild` 追加、`*.svelte` には文字列リテラル直書きなし
- [x] **設計書同期** (ADR-0001): 本 PR は新規 export 1 件追加。`docs/DESIGN.md §6` の labels エクスポート一覧は自動生成 (`scripts/generate-design-md-sections.mjs`) のため merge 後 main で再生成サイクルが走る (#1923 既存 SSOT 機構)
- [x] **並行 PR overlap** (#1200): 本 PR が変更する 2 file は open PR 中で重複 0 件 (`gh pr list --search "admin/activities labels.ts"` で同時期 open PR なし)
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A (admin 専用 label、LP 訴求対象外)

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- 「お子さま別」 vs 候補 (「お子さま個別」「お子さま専用」「個別」) の最短表記選定理由は AC2 通り CHILD_TERMS.honorific atom 1 件 + 「別」1 文字最小組合せ。badge は活動行内に inline 表示のため最短語が望ましい (mobile 幅 390px で活動名 + アイコン + pt + badge が 1 行に収まる必要あり)
- per-child scope の概念名そのものは内部識別子 (class / type discriminator / comment) に多数残存。これらは UI 露出ゼロのため ADR-0045 §9 対象外 (本 PR scope は UI 文字列 = badge text のみ)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **主要 pre-ready step ローカル確認済**: biome / svelte-check / vitest domain (813 PASS) / SS 撮影 4 件 Blob SHA unique。Step 9 (check-pr-body) は本 PR body 更新後に再実行する
- [x] セルフレビュー済み (不要な差分なし、+page.svelte +3 行 / labels.ts +3 行 = 計 6 行)
- [x] 全 AC が実装済み (AC1 〜 AC5 すべてエビデンス付き)
- [x] Phase 分割なし (micro-fix、6 行差分)
- [x] UI 変更時: SS が GitHub 上で表示確認 (4 URL × 200 OK 確認済) + Blob SHA 4 件 unique + DESIGN.md §9「内部コード UI 露出禁止」を充足 (本 PR が §9 違反を是正)
- [x] 認証画面変更時: 該当なし (badge 表示のみ、認証画面非変更)

## QM レビュー結果

QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照。

<!-- Round 1 final: design-doc-check label exempt re-trigger -->
