### PR TITLE
refactor: Round 18 Cluster A — 「パック」用語 UI 露出 10 箇所撤去 (TEMPLATE_TERMS SSOT 整合、ADR-0045)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -110,7 +110,8 @@ export const PAGE_TITLES = {
 	certificates: 'がんばり証明書',
 	license: 'プラン・お支払い',
 	statusBenchmark: 'ベンチマーク管理',
-	packs: '活動パック',
+	// #2276 / Round 18 Cluster A (ADR-0045): 活動パック → TEMPLATE_TERMS atom 経由化
+	packs: TEMPLATE_TERMS.userFacing,
 	// 認証
 	login: `${LOGIN_TERMS.canonical}`,
 	signup: `${SIGNUP_TERMS.canonical}`,
@@ -153,7 +154,8 @@ export const PAGE_TITLES = {
 	setupComplete: 'ぼうけんのはじまり！',
 	setupChildren: '子供登録',
 	setupFirstAdventure: 'はじめてのぼうけん',
-	setupPacks: '活動パック選択',
+	// Round 18 Cluster A (ADR-0045): 活動パック → TEMPLATE_TERMS atom 経由
+	setupPacks: `${TEMPLATE_TERMS.userFacing}を選ぶ`,
 	// #2140 MP-5: setup wizard β 採用
 	setupRewards: 'ごほうびセット選択',
 	setupRules: 'おうちのルール選択',
@@ -876,8 +878,8 @@ export const MARKETPLACE_LABELS = {
 	pageTitle: TEMPLATE_TERMS.userFacing,
 	navShort: TEMPLATE_TERMS.short,
 	pageDescription: 'お子さまの年齢にぴったりの活動・ごほうび・チェックリストを見つけよう',
-	metaDescription:
-		'活動パック・ごほうびセット・チェックリスト・特別ルールを探そう。がんばりクエストの公式テンプレート集です。',
+	// Round 18 Cluster A (ADR-0045): 活動パック → TEMPLATE_TERMS atom 経由
+	metaDescription: `${TEMPLATE_TERMS.userFacing} — 活動・ごほうび・チェックリスト・特別ルールを探そう。がんばりクエストの公式${TEMPLATE_TERMS.short}集です。`,
 	filterClear: 'フィルタをクリア',
 	emptyState: '条件に合うコンテンツがありません',
 	ctaHeading: `${TEMPLATE_TERMS.short}を使うには`,
@@ -886,7 +888,8 @@ export const MARKETPLACE_LABELS = {
 	backToHome: 'トップページへ',
 	backToDemo: 'デモを体験',
 	breadcrumbRoot: TEMPLATE_TERMS.short,
-	recommendedSection: 'おすすめパック',
+	// Round 18 Cluster A (ADR-0045): おすすめパック → TEMPLATE_TERMS atom 経由
+	recommendedSection: `おすすめ${TEMPLATE_TERMS.short}`,
 	importCta: '使ってみる',
 	questsBadge: 'クエスト集',
 	tabs: {
@@ -4436,7 +4439,8 @@ export const CERTIFICATES_PAGE_LABELS = {
 } as const;
 
 export const PACKS_PAGE_LABELS = {
-	pageTitle: '活動パック',
+	// Round 18 Cluster A (ADR-0045): 活動パック → TEMPLATE_TERMS atom 経由
+	pageTitle: TEMPLATE_TERMS.userFacing,
 	pageDesc:
 		'年齢に合わせた活動セットをインポートできます。同じ名前の活動は自動的にスキップされます。',
 	recommendedBadge: 'おすすめ',
@@ -4530,10 +4534,11 @@ export const DEMO_LAYOUT_LABELS = {
 } as const;
 
 export const SETUP_PACKS_LABELS = {
-	pageTitle: 'かつどうパックをえらぼう',
+	// Round 18 Cluster A (ADR-0045): かつどうパック → TEMPLATE_TERMS atom 経由
+	pageTitle: `${TEMPLATE_TERMS.userFacing}をえらぼう`,
 	pageDesc: 'お子さまの年齢にあわせた活動セットを選んでください。あとから追加・変更できます。',
 	recommendedBadge: 'おすすめ',
-	autoAddOption: 'おすすめパックを自動で追加してすすむ',
+	autoAddOption: `おすすめ${TEMPLATE_TERMS.short}を自動で追加してすすむ`,
 	backButton: 'もどる',
 	importingLabel: 'インポート中...',
 	addPacksButton: (count: number) => `${count}件のパックを追加`,

--- a/src/lib/domain/marketplace-item.ts
+++ b/src/lib/domain/marketplace-item.ts
@@ -6,6 +6,7 @@
  */
 
 import { AGE_TIER_LABELS } from './labels.js';
+import { TEMPLATE_TERMS } from './terms.js';
 import type { CategoryCode, GradeLevel } from './validation/activity.js';
 import type { UiMode } from './validation/age-tier-types.js';
 import type { RewardCategory } from './validation/special-reward.js';
@@ -195,8 +196,12 @@ export interface MarketplaceItemMeta {
 
 // ── Type labels ──────────────────────────────────────────────
 
+// Round 18 Cluster A (ADR-0045): かつどうパック → TEMPLATE_TERMS atom 経由化。
+// type label は同 marketplace 内で type 識別子として並ぶため、TEMPLATE_TERMS.userFacing
+// 単独では情報量不足。サブ識別子 (活動 / ごほうび / 持ち物 等) を添えて「みんなの
+// テンプレート (活動)」形式で統一する。
 export const MARKETPLACE_TYPE_LABELS: Record<MarketplaceItemType, string> = {
-	'activity-pack': 'かつどうパック',
+	'activity-pack': `${TEMPLATE_TERMS.userFacing}（活動）`,
 	'reward-set': 'ごほうびセット',
 	checklist: 'チェックリスト',
 	'rule-preset': 'とくべつルール',

--- a/src/lib/features/admin/components/OnboardingChecklist.stories.svelte
+++ b/src/lib/features/admin/components/OnboardingChecklist.stories.svelte
@@ -1,5 +1,6 @@
 <script module>
 import { defineMeta } from '@storybook/addon-svelte-csf';
+import { PAGE_TITLES } from '$lib/domain/labels';
 import OnboardingChecklist from './OnboardingChecklist.svelte';
 
 const basePath = '/admin';
@@ -14,7 +15,8 @@ const allItems = [
 	},
 	{
 		key: 'activities',
-		label: '活動パックを選ぶ',
+		// Round 18 Cluster A (ADR-0045): 活動パック → labels.ts SSOT 経由 (TEMPLATE_TERMS atom 由来)
+		label: PAGE_TITLES.setupPacks,
 		completed: false,
 		href: `${basePath}/activities`,
 		required: true,

--- a/src/lib/server/services/onboarding-service.ts
+++ b/src/lib/server/services/onboarding-service.ts
@@ -1,7 +1,7 @@
 // src/lib/server/services/onboarding-service.ts
 // オンボーディングチェックリスト — 自動完了検知
 
-import { OYAKAGI_LABELS } from '$lib/domain/labels';
+import { OYAKAGI_LABELS, PAGE_TITLES } from '$lib/domain/labels';
 import { findTemplatesByChild } from '$lib/server/db/checklist-repo';
 import { getSetting, setSetting } from '$lib/server/db/settings-repo';
 import { getActivities } from '$lib/server/services/activity-service';
@@ -63,7 +63,8 @@ export async function getOnboardingProgress(
 		},
 		{
 			key: 'activities',
-			label: '活動パックを選ぶ',
+			// Round 18 Cluster A (ADR-0045): 活動パック → labels.ts SSOT 経由 (TEMPLATE_TERMS atom 由来)
+			label: PAGE_TITLES.setupPacks,
 			completed: activities.length > 0,
 			href: `${basePath}/activities`,
 			required: true,

--- a/tests/unit/services/onboarding-service.test.ts
+++ b/tests/unit/services/onboarding-service.test.ts
@@ -323,7 +323,9 @@ describe('onboarding-service', () => {
 			expect(result.items[0]?.key).toBe('children');
 			expect(result.items[0]?.label).toBe('子供を登録する');
 			expect(result.items[1]?.key).toBe('activities');
-			expect(result.items[1]?.label).toBe('活動パックを選ぶ');
+			// Round 18 Cluster A (ADR-0045): 「活動パックを選ぶ」→「みんなのテンプレートを選ぶ」
+			// onboarding-service.ts が PAGE_TITLES.setupPacks (TEMPLATE_TERMS atom 由来) を参照する
+			expect(result.items[1]?.label).toBe('みんなのテンプレートを選ぶ');
 			expect(result.items[2]?.key).toBe('rewards');
 			expect(result.items[2]?.label).toBe('ごほうびプリセットを選ぶ');
 			expect(result.items[3]?.key).toBe('pin');


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 子供

**解決する課題**: アプリ全体で「みんなのテンプレート」（user-facing canonical）と「活動パック / かつどうパック / おすすめパック」（旧呼称・内部実装語彙）が UI 上に混在し、顧客が「テンプレート」と「パック」を別概念として誤認する状態だった。Round 18 評価 Round 2 (`tmp/round18-eval-round2-2026-06-01.md`) で複数 reviewer agent から 1.00 certainty で TEMPLATE_TERMS SSOT 違反として検出された。

**期待される効果**: アプリ全体で「みんなのテンプレート」「テンプレート」の 2 表記に統一され、用語の見た目混在が消滅。今後「テンプレート」呼称を見直す際に terms.ts atom 1 行修正だけで全 UI / LP / 法務文書に伝播する SSOT 構造を回復。

## 関連 Issue

<!-- closes #123 で自動クローズ。複数の場合は全て列挙。Issue がない場合は理由を明記 -->
<!-- Round 18 評価 Round 2 で検出された cluster A の品質改善 PR。新規 Issue として起票されていない (Round 18 EPIC #2723 の supplementary fix) ため closes 対象なし。Round 18 評価結果は tmp/round18-eval-round2-2026-06-01.md を SSOT として参照。 -->

関連: Round 18 EPIC #2723 / ADR-0045 (terms.ts SSOT 2 階層化原則)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | labels.ts で 7 箇所の atom 文字列リテラル直書きが `${TEMPLATE_TERMS.userFacing}` / `${TEMPLATE_TERMS.short}` template literal 経由に置換されている | `git diff origin/main -- src/lib/domain/labels.ts \| grep "TEMPLATE_TERMS"` | HEAD `88af8b38` / labels.ts L113-114, 157-158, 880-881, 891-892, 4441-4442, 4537-4538, 4541 で 7 件すべて template literal 経由化を確認 |
| AC2 | marketplace-item.ts の `MARKETPLACE_TYPE_LABELS['activity-pack']` が atom 経由化 (`${TEMPLATE_TERMS.userFacing}（活動）`) | `git diff origin/main -- src/lib/domain/marketplace-item.ts` | HEAD `88af8b38` / marketplace-item.ts L199-204 で `${TEMPLATE_TERMS.userFacing}（活動）` に置換、`import { TEMPLATE_TERMS }` を terms.js から追加 |
| AC3 | onboarding-service.ts の `activities` item label が labels.ts SSOT (PAGE_TITLES.setupPacks) 経由化 | `grep -n "PAGE_TITLES.setupPacks\|活動パック" src/lib/server/services/onboarding-service.ts` | HEAD `88af8b38` / onboarding-service.ts L4 で `PAGE_TITLES` import、L67 で `label: PAGE_TITLES.setupPacks` 参照 |
| AC4 | OnboardingChecklist.stories.svelte の activities item label が labels.ts SSOT (PAGE_TITLES.setupPacks) 経由化 | `grep -n "PAGE_TITLES.setupPacks\|活動パック" src/lib/features/admin/components/OnboardingChecklist.stories.svelte` | HEAD `88af8b38` / stories.svelte L3 で `PAGE_TITLES` import、L19 で `label: PAGE_TITLES.setupPacks` 参照 |
| AC5 | check-no-plan-literals.mjs が PASS (atom 文字列リテラル直書き 0 件維持) | `node scripts/check-no-plan-literals.mjs` | HEAD `88af8b38` / `[check-no-plan-literals] OK — リテラル直書きなし` (本 PR commit log 参照) |
| AC6 | LP labels (`site/shared-labels.js`) が labels.ts と同期、generate-lp-labels --check PASS | `node scripts/generate-lp-labels.mjs --check` | HEAD `88af8b38` / `✓ site/shared-labels.js は最新です` (本 PR commit log 参照) |
| AC7 | biome / svelte-check 修正 file 関連 error 0 件 / vitest domain tests 全 PASS | `npx biome check ...`, `npx svelte-check`, `npx vitest run tests/unit/domain/` | HEAD `88af8b38` / biome (5 file PASS) / svelte-check (修正 file 関連 error 0、infra/ は pre-existing で worktree 環境固有の `infra/node_modules` 未配置由来) / vitest (41 file 813 test PASS) |
| AC8 | onboarding-service.test.ts の SSOT 整合追従 (atom 値直書き assert → atom 経由化値 assert に更新、ADR-0006 適合: 弱体化でなく SSOT 強化) | `npx vitest run tests/unit/services/onboarding-service.test.ts` | HEAD `88af8b38` / 30 test 全 PASS / tests/unit/services/onboarding-service.test.ts L326-329 で「みんなのテンプレートを選ぶ」を assert |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:

- `/marketplace` トップ (MARKETPLACE_LABELS.metaDescription / recommendedSection / breadcrumbRoot)
- `/marketplace/activity-pack` (MARKETPLACE_TYPE_LABELS['activity-pack'])
- `/setup/packs` (SETUP_PACKS_LABELS.pageTitle / autoAddOption)
- `/admin/packs` (PACKS_PAGE_LABELS.pageTitle)
- AdminLayout sidebar (PAGE_TITLES.packs / setupPacks)
- OnboardingChecklist (`activities` item label)
- Storybook (OnboardingChecklist stories)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル一括検証 — biome / svelte-check / vitest / check-no-plan-literals / generate-lp-labels --check / sync-lp-fallback --check / commit hook (companion 整合検査) 全 PASS
- [x] 追加・変更したテストの概要を以下に記載: `tests/unit/services/onboarding-service.test.ts` L326 の assertion 値を atom 直書き「活動パックを選ぶ」から atom 経由化後の SSOT 値「みんなのテンプレートを選ぶ」に更新 (ADR-0006 適合の SSOT 強化、弱体化ではない)。30 test 全 PASS。既存 tests/unit/domain 41 file 813 test 全 PASS で SSOT 整合維持を確認
- [x] **新規 env / secret 追加時** (ADR-0006): 該当なし。N/A
- [x] **DynamoDB 実装変更時** (ADR-0010 / #1021): 該当なし。N/A
- [x] **Critical バグ修正の場合** (ADR-0002): 該当なし。N/A (本 PR は refactor / 用語 SSOT 整合)

## スクリーンショット / ビジュアルデモ

**添付ルール（要約）**:
- URL は GitHub 上で表示可能なもの
- ローカル相対パス禁止
- DOM HTML スナップショット併記必須

**4 スロット添付**（#1740）:

本 PR は **UI 文言 (labels.ts compound) の SSOT 整合 refactor で視覚レイアウトは無変更** のため、SS 4 スロットは **該当なし** とし、文字列 diff の grep 証跡を AC エビデンス列で代替する。差分は label 表示文字列のみ:

| 修正箇所 | 修正前 | 修正後 |
|---|---|---|
| `/admin/packs` page タイトル | 「活動パック」 | 「みんなのテンプレート」 |
| `/setup/packs` page タイトル | 「かつどうパックをえらぼう」 | 「みんなのテンプレートをえらぼう」 |
| `/marketplace` recommendedSection | 「おすすめパック」 | 「おすすめテンプレート」 |
| `/marketplace/activity-pack` (および activity-pack カード type label) | 「かつどうパック」 | 「みんなのテンプレート（活動）」 |
| AdminLayout sidebar (PAGE_TITLES.packs) | 「活動パック」 | 「みんなのテンプレート」 |
| OnboardingChecklist (`activities` item label) | 「活動パックを選ぶ」 | 「みんなのテンプレートを選ぶ」 |
| SETUP_PACKS_LABELS.autoAddOption | 「おすすめパックを自動で追加してすすむ」 | 「おすすめテンプレートを自動で追加してすすむ」 |
| MARKETPLACE_LABELS.metaDescription | 「活動パック・ごほうびセット・チェックリスト・特別ルールを探そう。…」 | 「みんなのテンプレート — 活動・ごほうび・チェックリスト・特別ルールを探そう。…」 |

**SS 不要の根拠** (DESIGN.md §9 禁忌 6 点目視確認結果):
- hex 直書きなし / プリミティブ再実装なし / 内部コード露出なし / 用語ハードコード**撤去**（本 PR の目的） / インラインスタイル変更なし / `<style>` ブロック変更なし
- 文言差し替えは既存 layout / a11y / コントラスト / キーボード挙動を維持し、視覚的 regression は発生しない

**インタラクティブ状態**: N/A (label 表示文字列のみの変更で disabled / readonly / エラー / 空状態の挙動変更なし)。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — `TEMPLATE_TERMS` atom を 1 箇所 (`terms.ts`) で定義し、各 compound (`labels.ts`) は template literal 経由で参照する責務分離 (ADR-0045)
- [x] **DRY**: 同一 atom 値の文字列リテラル直書き複製を 10 箇所撤去、全て `${TEMPLATE_TERMS.userFacing}` / `${TEMPLATE_TERMS.short}` 参照に統一。grep で全件確認済 (残「活動パック」は code comment / DB seed data / legacy-url-map の reason 内のみ、UI 露出なし)
- [x] **YAGNI**: 新規抽象化なし。既存 `TEMPLATE_TERMS` atom (`#2276` 由来) の参照を増やすのみ
- [x] **Security (OSS 公開前提)**: 秘密情報・内部 URL の hardcode なし / N/A
- [x] **アクセシビリティ**: 文言変更のみで aria / コントラスト / キーボード挙動変更なし / N/A
- [x] **パフォーマンス**: bundle size 影響なし / N/A

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] 本番アプリ + デモ版を同期 — `src/routes/demo/**` は #2097 PR-B3 で全削除済 (ADR-0048)、本 PR は本番ルートのみ修正で demo Lambda にも env (AUTH_MODE=anonymous + DATA_SOURCE=demo) 経由で本番ルートが提供されるため自動同期
- [x] **LP ↔ アプリ双方向整合** (#1481 / ADR-0013): LP 側 `site/shared-labels.js` は `scripts/generate-lp-labels.mjs --check` で同期確認済 (TEMPLATE_TERMS atom 変更なし、compound 経由のため LP fallback への影響なし)
- [x] 全年齢モード 5 種 (baby/preschool/elementary/junior/senior) に横展開 — 文言変更のみ、年齢モード分岐ロジック未変更で全モード一律反映
- [x] ナビゲーション 3 種 (`AdminLayout` + `AdminMobileNav` + `BottomNav`) に反映 — `PAGE_TITLES.packs` 経由のため自動反映
- [x] E2E / ユニットシード / チュートリアル を同期 — DB seed の「季節活動パック」code comment は scope 外 (UI 露出なし)。tutorial-chapters.ts は別 cluster (Round 18 Cluster B-G 候補) で扱う
- [x] **labels SSOT** (ADR-0045): 新規ユーザー向け文言は `terms.ts` atom → `labels.ts` compound で SSOT、リテラル直書きなし
- [x] **設計書同期** (ADR-0001): 用語辞書 (`docs/DESIGN.md §6`) は generate-design-md-sections.mjs で自動同期される機構の範囲内。TEMPLATE_TERMS atom 自体は変更なし (`#2276` で導入済)、本 PR は参照箇所の SSOT 整合化のみ
- [x] **並行 PR overlap** (#1200): 本 PR が変更する 4 file (labels.ts / marketplace-item.ts / onboarding-service.ts / OnboardingChecklist.stories.svelte) を同時期に変更する open PR は未確認 (capture --pr <N> 後 overlap-check 自動確認に委ねる)

**LP / 販促文言変更時** (ADR-0013 / #1314):

N/A (本 PR は LP `site/**` / pricing page / `plan-features.ts` / `pricing-strategy.md` を変更しない。アプリ内 `/marketplace` の `metaDescription` 文字列は LP `site/shared-labels.js` には乗らない compound)。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:

- 本 PR は Round 18 評価 Round 2 で複数 agent 1.00 certainty 検出された Cluster A (TEMPLATE_TERMS SSOT 違反 10 箇所) の集中 fix。Cluster B-G は別 PR で扱う scope narrow。
- `marketplace-item.ts` の `MARKETPLACE_TYPE_LABELS['activity-pack']` の日本語表記は「みんなのテンプレート（活動）」とした。他 type (`reward-set` / `checklist` / `rule-preset` / `challenge-set`) は引き続き「ごほうびセット」「チェックリスト」等の固有名詞のまま (これらは別 atom 候補で、Cluster A scope 外)。表記の妥当性のみ確認願いたい。
- SS は本 PR では 4 スロット未添付 (上記「SS 不要の根拠」セクション参照)。文字列 diff の grep / 行番号証跡で代替し、AC エビデンス列にすべて記載済。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — biome / svelte-check / vitest tests/unit/domain / check-no-plan-literals / generate-lp-labels --check / sync-lp-fallback --check すべて PASS
- [x] セルフレビュー済み (4 file 修正、不要な差分・デバッグコードなし、コメントで Round 18 Cluster A の修正根拠を明記)
- [x] 全 AC が実装済み (AC1-AC7 全件、未完了の AC は残っていない)
- [x] Phase 分割 — 着手前に本 prompt で Cluster A scope を確定済み、Cluster B-G は別 PR (起票時に PO 合意の上で進める)
- [x] UI 変更時: SS 4 スロット該当なし (本 PR は label 文字列のみの SSOT 整合 refactor、視覚レイアウト無変更、DESIGN.md §9 禁忌 6 点目視確認済、上記「SS 不要の根拠」セクション参照)
- [x] 認証画面変更時: 該当なし (本 PR は認証画面に文言変更なし)

## QM レビュー結果

(QM が記入)

