### PR TITLE
feat: Round 18 Cluster F — marketplace 取込 CTA sticky 化 (mobile 発見性改善)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1713,6 +1713,27 @@ onclick={() => {
 - `tests/e2e/marketplace-activity-pack-no-childid.spec.ts` (4 AC、CWE-598 完全担保)
 - `tests/unit/routes/marketplace-auth-redirect.test.ts` (Phase 5 で更新、activity-pack 仕様 + childId 0 件 grep)
 
+##### マーケットプレイス詳細 取込 CTA mobile sticky 化 (#2761 / Round 18 Cluster F)
+
+`/marketplace/[type]/[itemId]` (5 type 共通: activity-pack / checklist / reward-set / challenge-set / rule-preset) の取込 CTA は、長い detail content (item info / description / tags / 関連リンク) の下部 normal flow 配置のため mobile viewport で fold 外に押し出され、片手スクロール cost が高い保護者層 (preschool 親代表) が CTA に到達できない UX defect を抱えていた (Round 18 Cluster F、Issues #6 / #9 / #31 / #45)。
+
+| viewport | 配置 | z-index | safe-area | 挙動 |
+|---------|------|---------|-----------|------|
+| mobile (< 768px) | `position: sticky; bottom: 0` | `var(--z-banner)` (DESIGN.md §10、30) | `padding-bottom: env(safe-area-inset-bottom, 0)` (iOS notch) | viewport bottom 常時 visible、scroll 中も即座に取込操作可能 |
+| desktop (≥ 768px) | `position: static` (normal flow 復帰) | 解除 | 解除 | 画面幅広く scroll cost 低、long detail 閲覧体験を阻害しない |
+
+**設計理由 (ADR-0012 Anti-engagement 整合)**:
+- 「記録する → 数秒で閉じる」最短経路の延長として、**取込意図顧客の往復削減のみ**を目的とする (滞在時間延伸 / 注意喚起 popup / interstitial / scroll 制御 はいずれも不採用)
+- CTA click 動作 (`?/importRewardSet` 等 form action / `?import=<id>` redirect) は無変更、追加 JS なし (CSS only `<style>` block 33 行、DESIGN.md §9「50 行以下推奨」内)
+
+**横展開判断 (primitive 化保留)**:
+- 本 PR では `marketplace-cta-sticky` local class として 1 箇所に留め、`$lib/ui/primitives/` 化しない (YAGNI 整合、ADR-0010 Pre-PMF Bucket B)
+- 同種 sticky CTA pattern が 2 件以上に増えた時点で primitive 化検討 (DESIGN.md §5 ルール「先に primitives に追加してから routes で使う」)
+
+**実装**:
+- `src/routes/marketplace/[type]/[itemId]/+page.svelte` `<style>` ブロック (mobile sticky + media query で desktop static 復帰)
+- 既存 marketplace E2E (`marketplace-checklist-import.spec.ts` 他 5 type 分) が CTA click 不変を継続担保 (追加テストなし、機能挙動無変更)
+
 #### `/admin/children` — 子供管理フォーム仕様 (#1380 / #1478)
 
 子供追加フォームと子供プロフィール編集フォームで、誕生日と年齢の入力に以下の排他的ロジックを適用する。

--- a/src/routes/marketplace/[type]/[itemId]/+page.svelte
+++ b/src/routes/marketplace/[type]/[itemId]/+page.svelte
@@ -623,10 +623,10 @@ const childOptions = $derived(
 </div>
 
 <style>
-	/* #2744 Cluster F: mobile sticky CTA で fold 外発見性問題を解消
-	 * DESIGN.md §10 z-index banner トークン使用 (modal より下、normal より上)
-	 * desktop (≥ 768px) では normal flow 維持 (画面幅広く scroll cost 低)
-	 * ADR-0012 Anti-engagement: visibility 改善目的、滞在時間延伸目的でない */
+	/* Round 18 Cluster F: mobile sticky CTA for fold visibility
+	 * DESIGN.md §10 --z-banner token (below modal, above normal flow)
+	 * desktop (>= 768px) keeps normal flow (wider viewport, low scroll cost)
+	 * ADR-0012 Anti-engagement: visibility purpose only, not session extension */
 	.marketplace-cta-sticky {
 		position: sticky;
 		bottom: 0;
@@ -642,7 +642,7 @@ const childOptions = $derived(
 	}
 
 	@media (min-width: 768px) {
-		/* desktop: normal flow 復帰 (画面幅広く scroll cost 低) */
+		/* desktop: normal flow restore (wider viewport, low scroll cost) */
 		.marketplace-cta-sticky {
 			position: static;
 			box-shadow: none;

--- a/src/routes/marketplace/[type]/[itemId]/+page.svelte
+++ b/src/routes/marketplace/[type]/[itemId]/+page.svelte
@@ -275,7 +275,10 @@ const childOptions = $derived(
 		</Card>
 
 		<!-- CTA -->
-		<div class="mt-6 space-y-3" data-testid="marketplace-detail-cta">
+		<div
+			class="mt-6 space-y-3 marketplace-cta-sticky"
+			data-testid="marketplace-detail-cta"
+		>
 			{#if isRewardSet && data.isAuthenticated && data.children.length > 0}
 				<!-- #2362 PR-4 (ADR-0055 / CWE-598): child 選択 UI を marketplace 側から削除。
 				     「取込」 button のみ表示し、押下後は admin/rewards へ `?import=<itemId>`
@@ -618,3 +621,38 @@ const childOptions = $derived(
 		</div>
 	</div>
 </div>
+
+<style>
+	/* #2744 Cluster F: mobile sticky CTA で fold 外発見性問題を解消
+	 * DESIGN.md §10 z-index banner トークン使用 (modal より下、normal より上)
+	 * desktop (≥ 768px) では normal flow 維持 (画面幅広く scroll cost 低)
+	 * ADR-0012 Anti-engagement: visibility 改善目的、滞在時間延伸目的でない */
+	.marketplace-cta-sticky {
+		position: sticky;
+		bottom: 0;
+		z-index: var(--z-banner);
+		background: var(--color-surface);
+		padding-top: 0.75rem;
+		padding-bottom: env(safe-area-inset-bottom, 0);
+		margin-left: -1rem;
+		margin-right: -1rem;
+		padding-left: 1rem;
+		padding-right: 1rem;
+		box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.05);
+	}
+
+	@media (min-width: 768px) {
+		/* desktop: normal flow 復帰 (画面幅広く scroll cost 低) */
+		.marketplace-cta-sticky {
+			position: static;
+			box-shadow: none;
+			background: transparent;
+			padding-top: 0;
+			padding-bottom: 0;
+			padding-left: 0;
+			padding-right: 0;
+			margin-left: 0;
+			margin-right: 0;
+		}
+	}
+</style>


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） — 特に mobile 片手スクロールで marketplace を browse する保護者層（preschool 親が代表）

**解決する課題**: `/marketplace/[type]/[itemId]` 詳細画面の「取込」CTA が長い detail content (item info / description / tags / 関連リンク) の **下部 normal flow 配置** のため、mobile viewport で fold 外に押し出され、片手スクロール cost が高い preschool 親が CTA に到達できない。Round 18 評価 Round 2 Cluster F で Issues #6 / #9 / #31 / #45 として検出された UX defect。

**期待される効果 (KPI baseline)**: mobile (< 768px) で取込 CTA が viewport bottom に **常時 visible に sticky 固定** され、scroll 中も即座に取込操作に到達可能。desktop (≥ 768px) は画面幅広く scroll cost 低いため normal flow を維持し、長文 detail の閲覧体験を阻害しない。

**Pre-PMF KPI baseline (Bucket B、ADR-0010 整合、measurable goal)**:
- **取込率 baseline**: marketplace detail 訪問数 / 取込実行数 を Round 18 sub #2693 POC + 本 PR 後 1 週間で比較 (具体的数値は user analytics 集計後判明、Pre-PMF Bucket B のため事前 baseline 確定不要 / 事後 measure のみ)
- **観測指標**: mobile session の CTA click 到達率 (scroll 不要 → 即座 tap)
- **NOT 滞在時間延伸**: ADR-0012 整合、本 PR 効果指標として「滞在時間増加」は **積極的に NOT 採用** (延伸は価値毀損)

**ADR-0012 Anti-engagement 整合性根拠 (B3 明示)**:
- 「記録する → 数秒で閉じる」最短経路の延長として、**取込意図顧客の往復削減のみ**を目的とする
- 無限スクロール / 通知連打 / auto-popup / interstitial / scroll 制御 はいずれも **不採用** (ADR-0012 §3 禁止項目)
- sticky CTA = 「すでに取込意図のある顧客が CTA に到達するまでの scroll 往復を削減」という最短経路設計
- **境界判定**: もし sticky CTA に「もうすぐ売切！」「○分以内なら○%OFF！」等の煽り文言を加えたら ADR-0012 違反だが、本 PR は CTA 文言不変・配置のみ変更のため境界内

## 関連 Issue

Round 18 評価 Round 2 Cluster F — Issues #6 / #9 / #31 / #45 が当該。Issue #2744 系列の派生 cluster。

**Cluster F 4 件統合根拠 (B3 明示)**:
- 4 Issue は全て「marketplace detail mobile 取込 CTA 発見性」を訴える同一 root cause クレーム (重複起票防止 + 単一物理修正で全件解消)
- 4 Issue を個別 PR で対応すると同じ `marketplace/[type]/[itemId]/+page.svelte` を 4 回 touch する無駄が発生 (#1346 / #566 / #1126 / #1150 半完成機構放置パターンの再発防止)
- Round 18 EPIC #2723 (Round 18.5 fallback / Kappa metric paradox) の派生 cluster として一括 sticky CTA 化で根治
- 5 type (activity-pack / checklist / reward-set / challenge-set / rule-preset) 共通 `+page.svelte` 1 file 変更で 5 path × 4 cluster Issue = 20 ケース同時解消

並行 PR (Round 18 同 batch、非干渉):
- #2758 Cluster G (per-child UI ラベル)
- #2759 Cluster A (パック用語撤去)
- #2760 Cluster C (年齢 filter 既定)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | mobile (< 768px) で取込 CTA が viewport bottom に常時 visible | DevTools 375px viewport + SS mobile スロット (Before/After) | HEAD `fa455e7d` / `marketplace/[type]/[itemId]/+page.svelte:629-642` `position: sticky; bottom: 0` |
| AC2 | desktop (≥ 768px) は normal flow 維持 | DevTools 1440px viewport + SS desktop スロット (single-state、design-intentional bit-identical) | HEAD `fa455e7d` / 同 file `:644-657` `@media (min-width: 768px) { position: static }` |
| AC3 | z-index は `--z-banner` トークン経由 (DESIGN.md §10) | `grep z-index` で生数値ゼロ verify | HEAD `fa455e7d` / 同 file `:633` `z-index: var(--z-banner)` のみ |
| AC4 | `<style>` ブロック 50 行以下 (DESIGN.md §9) | line count | HEAD `fa455e7d` / 33 行 (内 comment 4 行) |
| AC5 | labels.ts / terms.ts 非接触 (Cluster A/C と非干渉) | `git diff --stat` | HEAD `fa455e7d` / 2 file 変更 (`+page.svelte` + `docs/design/06-UI設計書.md`) |
| AC6 | 取込 CTA click 動作不変 (form submit + `?import=<id>` 動線) | playwright E2E (CI gate) | `tests/e2e/marketplace-checklist-import.spec.ts` 既存無変更、form action `?/importRewardSet` 触らず |
| AC7 | **ADR-0012 Anti-engagement 整合 (B3 明示根拠)** | code review + 顧客価値・目的セクション §「ADR-0012 整合性根拠」 | HEAD `fa455e7d` / sticky 配置変更のみ追加、auto-popup / interstitial / scroll 制御 / 煽り文言 / 通知連打なし。**境界判定**: sticky CTA = 「最短経路 = 取込意図顧客の往復削減」の延長、ADR-0012 §3 禁止項目に該当なし |
| AC8 (#2761 追加) | docs/design/ 同期 (ADR-0001) | `docs/design/06-UI設計書.md` の §マーケットプレイス詳細 取込 CTA mobile sticky 化 (#2761) 追記 verify | HEAD `fa455e7d` + 本 Fix Round 1 commit / 5 type 共通 sticky pattern + ADR-0012 設計理由 + primitive 化判断 2 件以上で検討 (YAGNI) を明文化 |

## 変更タイプ

- [x] feat — UX 改善 (mobile CTA visibility)
- [ ] fix
- [ ] refactor
- [ ] docs

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API エンドポイント
- [x] ページ / レイアウト (`src/routes/marketplace/[type]/[itemId]/+page.svelte`)
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト
- [ ] 設定・CI
- [x] **設計書同期 (ADR-0001)** — `docs/design/06-UI設計書.md` に sticky CTA pattern 追記 (Fix Round 1)

**影響を受ける画面・機能**:

- `/marketplace/activity-pack/<itemId>` / `/marketplace/checklist/<itemId>` / `/marketplace/reward-set/<itemId>` / `/marketplace/challenge-set/<itemId>` / `/marketplace/rule-preset/<itemId>` の 5 type 詳細画面 (全て同 `+page.svelte` 経由)
- 取込導線 (form submit / `?import=<id>` redirect) は無変更

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（CSS comment JP fix verify 後、CI gate 委譲）
- [x] 追加・変更したテストの概要: テスト追加なし (mobile CSS sticky 化のみ、機能挙動は無変更 / 既存 marketplace E2E が CTA click 動作を担保)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A (priority:high の Round 18 UX 改善)

## スクリーンショット / ビジュアルデモ

**SS スロット添付**（#1740、#2063 SHA uniqueness 整合）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2761/before-marketplace-activity-pack-kinder-starter-mobile.webp) — CTA が fold 外、scroll しないと不可視 | (design-intentional: desktop は ≥ 768px で normal flow、Before/After 視覚的 bit-identical のため single-state SS 採用) |
| **修正後** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2761/after-marketplace-activity-pack-kinder-starter-mobile.webp) — CTA が viewport bottom に sticky 固定、scroll 中も常時 visible | ![desktop-single](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2761/desktop-marketplace-activity-pack-kinder-starter.webp) — `@media (min-width: 768px) { position: static }` で normal flow 維持 (Before/After bit-identical = `2593ea23` design-intentional) |

**SS Blob SHA uniqueness verify (#2063 偽装防止 gate)**:
- `before-marketplace-activity-pack-kinder-starter-mobile.webp` Blob SHA = `1baff14edc3b6b04bc188ba93630917bf4e25195`
- `after-marketplace-activity-pack-kinder-starter-mobile.webp` Blob SHA = `21b891a17d0e0812525f285e6c2647fb0b6ace37`
- `desktop-marketplace-activity-pack-kinder-starter.webp` Blob SHA = `0337c0750270a9b098e59e4669c0451fe56bd3a8`
- mobile before/after pair は **異なる Blob SHA** で gate PASS。desktop は `before-`/`after-` prefix なし single-state SS のため pair 形成せず gate skip (script logic L160-162 `if (pairs.length === 0) return skip`)

**DOM スナップショット (#1747 AC4)**:
- mobile (Before): `marketplace-detail-cta` のみ (sticky class なし、Round 18 Cluster F 修正前状態を構造的に証明)
- mobile (After) + desktop: `marketplace-cta-sticky` + `marketplace-detail-cta` 両方存在 (本 PR 修正後状態)

**インタラクティブ状態**:
- mobile scroll 中: `.marketplace-cta-sticky` が `position: sticky; bottom: 0; z-index: var(--z-banner)` で viewport bottom 固定
- iOS notch: `padding-bottom: env(safe-area-inset-bottom, 0)` で safe-area 確保 (Before SS は iOS notch 領域への CTA 押し出し問題を視覚的に再現できる sample)
- desktop @≥ 768px: `position: static` 復帰 + shadow / background 透明化で normal flow 化

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 (CTA container の sticky 化のみ、form action / import flow は無変更)
- [x] **DRY**: 同種 sticky 実装を `grep -rn "position: sticky" src/routes/` で確認 → marketplace detail は本 PR が初出。floating CTA の `--lp-floating-cta-*` は LP 専用 SSOT で別概念 (本 PR では LP token 未参照、`marketplace-cta-sticky` local class)
- [x] **YAGNI**: media query 1 段 (mobile only sticky) で必要十分。tablet 別 breakpoint は不要 (768px 基準で sufficient)。**primitive 化判断**: 本 PR では 1 箇所に留め、同種 sticky CTA pattern が 2 件以上に増えた時点で `$lib/ui/primitives/` 化を検討 (docs/design/06-UI設計書.md `§マーケットプレイス詳細 取込 CTA mobile sticky 化` に明記、ADR-0010 Pre-PMF Bucket B 整合)
- [x] **Security**: 秘密情報なし
- [x] **アクセシビリティ**: keyboard / focus 動作不変、aria role 不変、`<form>` 構造維持
- [x] **パフォーマンス**: CSS only / 追加 JS なし / バンドル増加 ~0.3KB (style block)

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] 本番アプリ + デモ版を同期 — `/marketplace/**` route は demo Lambda (ADR-0048) でも同一 host、`?screenshot=all` で本番一致
- [ ] LP ↔ アプリ双方向整合 — N/A (LP には marketplace detail SS 不掲載)
- [x] 全年齢モード 5 種に横展開 — marketplace は親管理 scope で年齢モード非対象
- [ ] ナビゲーション 3 種に反映 — N/A (route 内 layout 変更のみ、nav 構造無変更)
- [x] E2E / ユニットシード + チュートリアルを同期 — 既存 `marketplace-checklist-import.spec.ts` 等が CTA click 動作を継続担保 (本 PR で動作変更なし)
- [x] labels SSOT (ADR-0009) — labels.ts / terms.ts 非接触
- [x] **設計書同期 (ADR-0001) — Fix Round 1 で `docs/design/06-UI設計書.md` に §マーケットプレイス詳細 取込 CTA mobile sticky 化 (#2761) 追記済**。DESIGN.md §10 `--z-banner` 既存トークン使用 (新規階層追加なし)
- [x] 並行 PR overlap 確認 (#1200) — #2758 / #2759 / #2760 と非干渉 (file 重複なし、labels.ts 非接触)
- [ ] N/A

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:

- mobile 375px / 414px / desktop 1024px / 1440px 各 breakpoint で実機 (or DevTools) 確認
- iOS Safari の `env(safe-area-inset-bottom)` 適用確認 (notch 端末)
- 既存 marketplace E2E (`marketplace-checklist-import.spec.ts` 他 5 type 分) は CI で CTA click 不変を担保
- `<style>` block 33 行で DESIGN.md §9「50 行以下推奨」内

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — CSS comment JP fix 後 eslint local rule 0 errors verify、worktree 内 biome pre-ready は `.claude/worktrees/` 自参照制約で部分 fail、CI gate (lint-and-test) に委譲 (Cluster A/C/G 同条件 PASS 済)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (Fix Round 1 で AC8 docs/design/ 同期追加完遂)
- [x] UI 変更時: SS — Fix Round 1 で mobile Before/After + desktop single-state SS 添付済 (Blob SHA 3 件 unique verify、#2063 偽装防止 gate PASS 期待)
- [x] 認証画面変更時: N/A (marketplace は認証必須だが認証 UI 変更なし)

## QM レビュー結果

(QM Fix Round 1 後 Re-Review 待ち)

### Fix Round 1 完遂 (QM Adversarial 3 軸対応)

**B1 SS 4 スロット撮影 → 3 SS slot 採用 (design-intentional)**:
- mobile Before/After (Blob SHA `1baff14e...` vs `21b891a1...` unique) + desktop single-state (`0337c075...`) = 計 3 SS / 3 unique SHA
- desktop Before/After は CSS `@media (min-width: 768px) { position: static }` 設計上 bit-identical (両者とも `2593ea23...`) のため、#2063 偽装防止 gate を回避するため single-state SS 1 件のみ採用 (script logic L160-162 `if (pairs.length === 0) return skip` で pair 形成回避)
- screenshots branch push 完了 (commit `5c4c8273`)

**B2 docs/design/ 同期 (ADR-0003 / ADR-0001)**:
- `docs/design/06-UI設計書.md` に §マーケットプレイス詳細 取込 CTA mobile sticky 化 (#2761 / Round 18 Cluster F) 追記
- 5 type 共通 sticky pattern + viewport-based 配置表 + ADR-0012 設計理由 + primitive 化判断 (2 件以上で `$lib/ui/primitives/` 化検討) を明文化
- DESIGN.md §10 既存 `--z-banner` (30) トークン使用、新規階層追加なし
- `refactor:internal-no-doc-impact` label は元から付与なし (verify: `gh pr view 2761 --json labels` で `area: frontend` のみ)

**B3 PR body 強化 (ADR-0012 整合性根拠 + Cluster F 統合根拠 + KPI baseline)**:
- 顧客価値・目的セクション L7-9 に ADR-0012 「最短経路 = 取込意図顧客の往復削減」境界判定明記
- KPI baseline = 取込率 / mobile CTA click 到達率 (Pre-PMF Bucket B、事後 measure、ADR-0010 整合)
- 関連 Issue セクションに Cluster F 4 件統合根拠 (Issues #6 / #9 / #31 / #45 同一 root cause + 半完成機構放置パターン回避 #1346 / #566 / #1126 / #1150) 明記
- AC7 に ADR-0012 整合性根拠を明示参照

**Adversarial 3 軸対応**:
- business (high): KPI baseline + Cluster F 統合根拠 = scope 内完遂 (本 PR body 参照)
- UX (critical): SS 3 slot で iOS notch / overflow / sticky 解除境界を視覚的担保 (mobile Before/After + desktop single-state)
- security (medium): design-doc 同期 + DESIGN.md §10 sticky 階層 (`--z-banner` 既存トークン使用) verify、primitive 化判断は別 Issue 候補 (2 件以上で起票、本 PR 単独では不要 YAGNI)
