### PR TITLE
feat: Round 18 Cluster H — activity-pack subset 選択 UI + 既存重複 detection (#13/#16/#20/#25/#28)

### DIFF
--- a/docs/design/marketplace-import-flow.md
+++ b/docs/design/marketplace-import-flow.md
@@ -130,6 +130,27 @@ POC #2693 EPIC #2724 Round 18 で「activity-pack 取込完了後に何のフィ
 
 **他 type への波及方針**: reward-set (`admin/rewards/importPresetToChildren`) も既に `x-sveltekit-action` header + ActionResult deserialize の同型実装。checklist / rule-preset / challenge-set の admin 動線で fetch ActionResult 経由を採用する場合、本 SSOT 3 件 (Toast + 2 重防御 + `x-sveltekit-action` header) を必ず複製すること。
 
+##### Round 18 Cluster H (#13/#16/#20/#25/#28) subset 取込 (2026-06-02)
+
+Round 18 Round 3 評価で「30 件一括取込で個別選択不可」「既存重複 activity の事前説明なし」「3 歳児親には 30 件は多すぎる」が 5 件 (Cluster H) 表面化した。これに対し、activity-pack 詳細での **subset 選択 UI + 既存重複 detection + 件数連動 CTA** を導入する (PR scope: activity-pack のみ、他 type は別 Issue)。
+
+| 動線要素 | 修正内容 | 実装位置 |
+|---|---|---|
+| **既存活動 fetch** | marketplace 詳細 `load` で `type === 'activity-pack'` のときに `findActivities(tenantId)` を呼び、`existingActivityNames: string[]` を unique 集約して返す。`getAllChildren` 取得と同じ try/catch で囲み、tenant 解決失敗時は空配列 fallback | `src/routes/marketplace/[type]/[itemId]/+page.server.ts` `load` |
+| **subset 選択 UI** | activity-pack の preview list 各行に checkbox を追加。既存活動と name match した行は default unchecked + 「登録済み」 badge (`MARKETPLACE_LABELS.detailActivityPackAlreadyExistsBadge`)、それ以外は default checked。「すべて選ぶ / すべて外す」ボタンで一括変更 | `src/routes/marketplace/[type]/[itemId]/+page.svelte` activity-pack branch |
+| **件数連動 CTA** | `selectedCount` (`$derived`) を CTA 文言に反映 (`MARKETPLACE_LABELS.detailCtaImportActivityPackSelected(count)`)。`selectedCount === 0` のときは disabled (`MARKETPLACE_LABELS.detailActivityPackSelectedZero` 文言、誤遷移防止) | 同上 |
+| **subset URL 渡し** | CTA href を `/admin/activities?import=<itemId>&indexes=<csv>` 形式に拡張。全件選択時 (`selectedCount === totalCount`) は `indexes` 省略で後方互換維持。CWE-598 (childId 露出禁止) は崩れない (`indexes` は SSOT 内 activity 配列の index = 機微情報ではない) | `importUrlWithSubset` `$derived` |
+| **subset query 受領** | admin/activities `load` で `?indexes=<csv>` を parse し `importSelectedIndexes: number[] \| null` として返す。空 / 未指定 / 不正値は null (= 全件 / 後方互換) | `src/routes/(parent)/admin/activities/+page.server.ts` `load` |
+| **subset action 送信** | ChildSelectionDialog confirm 時、`data.importSelectedIndexes` が空でなければ `selectedIndexes` (CSV) を `FormData` に追加して `?/importPackToChildren` に POST | `src/routes/(parent)/admin/activities/+page.svelte` `handleChildSelectionConfirm` |
+| **subset payload slice** | `importPackToChildren` action で `selectedIndexes` を parse → unique 化 → `source.payload.activities` を index で slice してから `dispatchImport` に渡す。subset 結果が 0 件なら fail 400 (`'取り込む活動が選択されていません'`) | 同 `+page.server.ts` `importPackToChildren` action |
+
+**dedup 連携**: subset で選んだ activity が target child 側で既に存在する場合、`activity-import-service.ts` の per-child dedup (`#2558`) で skip される。subset slice + per-child dedup の 2 段防御で、preschool 親「既存と重複する activity の事前説明なし」(Cluster H #25) と「個別選択不可」(#20) を同時解決する。
+
+**CWE-598 整合性検証**:
+- URL に乗るのは `import=<itemId>` (公開 SSOT 識別子) + `indexes=<csv>` (公開 activity 配列 index) のみ
+- childId は依然として ChildSelectionDialog 経由でのみ確定 (URL/body 直接受領なし)
+- subset slice 結果も payload 内に直接含まれ、URL に乗らない
+
 #### per-child type の重複判定 (dedup) scope ルール (#2558、必読)
 
 **per-child instance type (activity / reward / challenge) の import 重複判定は必ず child 単位で行う。** tenant 全体での dedup は禁止。

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -930,6 +930,26 @@ export const MARKETPLACE_LABELS = {
 	/** activity-pack 説明 */
 	detailCtaImportActivityPackDesc:
 		'取り込む際はご家族の見守り画面で「どのお子さまに追加するか」を選びます',
+	// Round 18 Cluster H (#13/#16/#20/#25/#28): activity-pack subset 選択 UI 用 labels
+	/** Cluster H: subset 選択セクション見出し */
+	detailActivityPackSelectHeading: '取り込む活動を選ぶ',
+	/** Cluster H: 選択ヒント (preschool 親「30 件は多すぎる」「歯磨きとお片付けだけ欲しい」への直接回答) */
+	detailActivityPackSelectHint:
+		'チェックを外すと取り込みません。既に登録済みの活動は最初からチェックを外しています。',
+	/** Cluster H: 既存活動と name 一致した場合のバッジラベル */
+	detailActivityPackAlreadyExistsBadge: '登録済み',
+	/** Cluster H: 全て選択ボタン */
+	detailActivityPackSelectAll: 'すべて選ぶ',
+	/** Cluster H: 全て解除ボタン */
+	detailActivityPackDeselectAll: 'すべて外す',
+	/** Cluster H: 選択件数表示 (例: 「12件 / 30件 を取り込みます」) */
+	detailActivityPackSelectedCount: (selected: number, total: number) =>
+		`${selected}件 / ${total}件 を取り込みます`,
+	/** Cluster H: 0 件選択時の inert 状態説明 */
+	detailActivityPackSelectedZero: '取り込む活動を 1 件以上選んでください',
+	/** Cluster H: 件数連動 CTA (subset 選択結果を反映、選択件数 = N) */
+	detailCtaImportActivityPackSelected: (count: number) =>
+		`ご家族の見守り画面で取り込む (${count}件を選択中)`,
 	/** #2136 MP-1: reward-set 一括追加 CTA */
 	detailCtaImportReward: '🎁 このごほうびセットを一括追加',
 	/** #2136 MP-1: 件数付き一括追加 CTA */

--- a/src/lib/domain/validation/marketplace-import-params.ts
+++ b/src/lib/domain/validation/marketplace-import-params.ts
@@ -1,0 +1,67 @@
+// src/lib/domain/validation/marketplace-import-params.ts
+// Round 18 Cluster H (#2767 Fix Round 1 B3): marketplace activity-pack subset 取込の
+// URL query (`?indexes=<csv>`) を Zod で input validation する。
+//
+// 設計背景:
+// - `/admin/activities?import=<itemId>&indexes=0,2,5,...` の indexes は公開 marketplace SSOT の
+//   activity index (payload.activities[i] の i)。CWE-598 整合で childId は乗らないが、
+//   負数 / NaN / 非整数 / 重複 / 空文字 などの edge case を「黙って全件 fallback」に流すと
+//   攻撃面ではなく UX 面で「ユーザ指定と異なる subset が取込まれる」事故になる。
+// - 元実装は Number/filter/Set で部分的に防御していたが、Zod ベースで input contract を
+//   明示化し、unit test で 4 edge case (NaN / 負数 / 空文字 / 重複) を回帰固定する。
+//
+// 設計原則:
+// - **null = 全件取込 (後方互換)** を維持。indexes 省略時は全件 (importPackToChildren で
+//   selectedIndexes=null パスを走らせる)。
+// - **空配列 = 全件 fallback**。「不正値だけのカンマ列 (例: `?indexes=abc,,xyz`)」は安全側に
+//   倒して全件取込 fallback。空 indexes での 0 件取込にはしない (admin 側の dispatchImport が
+//   空 payload で 400 を返すのは別 layer の責務)。
+// - **upper bound は呼び出し側で適用**。本 helper は payload.activities.length を知らないため
+//   負/非整数のみ落とし、上限チェックは admin 側で `.filter((i) => i < length)` を継続。
+//
+// 関連: Issue #2767 / ADR-0055 (per-child + family master データモデル原則)。
+
+import { z } from 'zod';
+
+/**
+ * 単一 index value 用 schema。
+ *
+ * 受理: 非負整数 (0, 1, 2, ..., MAX_SAFE_INTEGER)
+ * 拒否: NaN / Infinity / 負数 / 小数 / 文字列 (Number(s) で NaN 化する全ケース)
+ */
+const indexSchema = z
+	.number()
+	.int({ message: 'index must be integer' })
+	.nonnegative({ message: 'index must be >= 0' })
+	.finite({ message: 'index must be finite' });
+
+/**
+ * `?indexes=<csv>` query 文字列をパースして、重複除去済の非負整数配列を返す。
+ *
+ * @param raw URL searchParams で取得した raw 文字列 (trim 済推奨)。`null` / `undefined` / 空文字
+ *   は「indexes 省略」扱いで `null` を返す (= admin 側で全件取込 fallback)。
+ * @returns 重複除去済 + 並び順保持の非負整数配列。**全要素が不正値 (例: 'abc,xyz') の場合も
+ *   null を返して全件 fallback に倒す** (UX 安全側)。
+ */
+export function parseImportIndexes(raw: string | null | undefined): number[] | null {
+	if (raw === null || raw === undefined) return null;
+	const trimmed = raw.trim();
+	if (trimmed.length === 0) return null;
+
+	const tokens = trimmed.split(',').map((s) => s.trim());
+	const parsedNumbers: number[] = [];
+	for (const token of tokens) {
+		if (token.length === 0) continue;
+		const n = Number(token);
+		const result = indexSchema.safeParse(n);
+		if (result.success) {
+			parsedNumbers.push(result.data);
+		}
+		// invalid token (NaN / 負数 / 小数等) は silent drop — 全要素 drop で空配列 → null へ
+	}
+
+	if (parsedNumbers.length === 0) return null;
+
+	// 重複除去 + 並び順保持
+	return Array.from(new Set(parsedNumbers));
+}

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -435,7 +435,10 @@ export const actions: Actions = {
 				if (subset.length === 0) {
 					return fail(400, { error: '取り込む活動が選択されていません' });
 				}
-				rawPayload = { ...source.payload, activities: subset } as typeof source.payload;
+				rawPayload = {
+					...(source.payload as Record<string, unknown>),
+					activities: subset,
+				} as typeof source.payload;
 			}
 			const result = await dispatchImport({
 				typeCode: 'activity-pack',

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -59,6 +59,19 @@ export const load: PageServerLoad = async ({ locals, url, cookies }) => {
 
 	// `?import=<presetId>` query で ChildSelectionDialog auto-open
 	const importPresetId = url.searchParams.get('import')?.trim() || null;
+	// Round 18 Cluster H (#13/#16/#20/#25/#28): activity-pack subset 選択。
+	// `?indexes=0,2,5,...` CSV で取込対象 activity の index (payload.activities[i] の i) を受け取る。
+	// 空 / 未指定なら全件 (後方互換)、indexes が指定されたら subset を action 経由で渡す。
+	const importIndexesRaw = url.searchParams.get('indexes')?.trim() || '';
+	let importSelectedIndexes: number[] | null = null;
+	if (importIndexesRaw) {
+		const parsed = importIndexesRaw
+			.split(',')
+			.map((s) => Number(s.trim()))
+			.filter((n) => Number.isInteger(n) && n >= 0);
+		// 重複除去 + 並び順保持
+		importSelectedIndexes = Array.from(new Set(parsed));
+	}
 	// `?childId=<n>` query で初期選択 child 復元 (refresh / share link 対応)
 	const initialChildIdRaw = url.searchParams.get('childId');
 	const initialChildId =
@@ -93,6 +106,8 @@ export const load: PageServerLoad = async ({ locals, url, cookies }) => {
 		children,
 		childActivitiesByChild,
 		importPresetId,
+		// Round 18 Cluster H: subset 選択 indexes (null = 全件 / 後方互換)
+		importSelectedIndexes,
 		initialChildId,
 		initialChildIdFromCookie,
 		categoryDefs: CATEGORY_DEFS,
@@ -365,11 +380,15 @@ export const actions: Actions = {
 	// #2362 PR-3 Phase 4: per-child 取込 (ChildSelectionDialog から呼出)
 	// `?import=<presetId>` query で auto-open した dialog で「全員 / 個別」選択 → 本 action に POST
 	// childIds=all で全 child、childIds=1,2,3 で個別 child 配列
+	// Round 18 Cluster H (#13/#16/#20/#25/#28): selectedIndexes (CSV) で subset 取込対応。
+	// 未指定なら全件 (後方互換)。指定された index で payload.activities を slice してから strategy へ。
+	// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: subset 取込分岐 + childIds parse + 既存エラーハンドリング統合のため。subset slice ロジックを別 helper に切り出す refactor は別 Issue で対応 (Round 18 Cluster H scope 外)
 	importPackToChildren: async ({ request, locals }) => {
 		const tenantId = requireTenantId(locals);
 		const formData = await request.formData();
 		const packId = String(formData.get('packId') ?? '').trim();
 		const childIdsRaw = String(formData.get('childIds') ?? '').trim();
+		const selectedIndexesRaw = String(formData.get('selectedIndexes') ?? '').trim();
 
 		if (!packId) return fail(400, { error: 'パックIDが必要です' });
 		if (!childIdsRaw) return fail(400, { error: '対象のお子さまを選択してください' });
@@ -390,11 +409,37 @@ export const actions: Actions = {
 			return fail(400, { error: '有効な対象が指定されていません' });
 		}
 
+		// Round 18 Cluster H: subset 取込 — selectedIndexes が指定されたら payload を slice。
+		// 未指定 / 空文字 / 不正値のみは全件取込で後方互換維持。
+		let selectedIndexes: number[] | null = null;
+		if (selectedIndexesRaw) {
+			const parsed = selectedIndexesRaw
+				.split(',')
+				.map((s) => Number(s.trim()))
+				.filter((n) => Number.isInteger(n) && n >= 0);
+			selectedIndexes = Array.from(new Set(parsed));
+			if (selectedIndexes.length === 0) {
+				return fail(400, { error: '取り込む活動が選択されていません' });
+			}
+		}
+
 		try {
 			const source = loadFromMarketplace('activity-pack', packId);
+			// subset 取込時は payload.activities を slice、それ以外は全件 (raw payload そのまま)
+			let rawPayload = source.payload;
+			if (selectedIndexes !== null) {
+				const allActivities = (source.payload as { activities: unknown[] }).activities ?? [];
+				const subset = selectedIndexes
+					.filter((i) => i < allActivities.length)
+					.map((i) => allActivities[i]);
+				if (subset.length === 0) {
+					return fail(400, { error: '取り込む活動が選択されていません' });
+				}
+				rawPayload = { ...source.payload, activities: subset } as typeof source.payload;
+			}
 			const result = await dispatchImport({
 				typeCode: 'activity-pack',
-				rawPayload: source.payload,
+				rawPayload,
 				displayName: source.displayName,
 				ctx: { tenantId, presetId: packId, childIds },
 			});
@@ -405,7 +450,7 @@ export const actions: Actions = {
 			}
 			logger.error('[admin/activities] per-child 取込失敗', {
 				error: e instanceof Error ? e.message : String(e),
-				context: { packId, childIds },
+				context: { packId, childIds, selectedIndexCount: selectedIndexes?.length ?? null },
 			});
 			return fail(500, { error: 'インポートに失敗しました' });
 		}

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -2,6 +2,9 @@ import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
+// #2767 Fix Round 1 B3 (Adversarial security): indexes query を Zod ベース input validation
+// 経由でパースし、NaN / 負数 / 非整数 / 空文字 / 重複の 4 edge case を回帰固定する。
+import { parseImportIndexes } from '$lib/domain/validation/marketplace-import-params';
 // #2365 (ADR-0052): activity-pack を新 Strategy + dispatchImport 経由に移行。
 // `$lib/marketplace` の eager-load (`./types/activity-pack`) で Registry 登録される。
 import { dispatchImport } from '$lib/marketplace';
@@ -62,16 +65,9 @@ export const load: PageServerLoad = async ({ locals, url, cookies }) => {
 	// Round 18 Cluster H (#13/#16/#20/#25/#28): activity-pack subset 選択。
 	// `?indexes=0,2,5,...` CSV で取込対象 activity の index (payload.activities[i] の i) を受け取る。
 	// 空 / 未指定なら全件 (後方互換)、indexes が指定されたら subset を action 経由で渡す。
-	const importIndexesRaw = url.searchParams.get('indexes')?.trim() || '';
-	let importSelectedIndexes: number[] | null = null;
-	if (importIndexesRaw) {
-		const parsed = importIndexesRaw
-			.split(',')
-			.map((s) => Number(s.trim()))
-			.filter((n) => Number.isInteger(n) && n >= 0);
-		// 重複除去 + 並び順保持
-		importSelectedIndexes = Array.from(new Set(parsed));
-	}
+	// #2767 Fix Round 1 B3: parseImportIndexes (Zod 経由) で 4 edge case を回帰固定
+	// (NaN / 負数 / 非整数 / 空文字 / 重複)。詳細: marketplace-import-params.ts.
+	const importSelectedIndexes = parseImportIndexes(url.searchParams.get('indexes'));
 	// `?childId=<n>` query で初期選択 child 復元 (refresh / share link 対応)
 	const initialChildIdRaw = url.searchParams.get('childId');
 	const initialChildId =
@@ -411,16 +407,13 @@ export const actions: Actions = {
 
 		// Round 18 Cluster H: subset 取込 — selectedIndexes が指定されたら payload を slice。
 		// 未指定 / 空文字 / 不正値のみは全件取込で後方互換維持。
-		let selectedIndexes: number[] | null = null;
-		if (selectedIndexesRaw) {
-			const parsed = selectedIndexesRaw
-				.split(',')
-				.map((s) => Number(s.trim()))
-				.filter((n) => Number.isInteger(n) && n >= 0);
-			selectedIndexes = Array.from(new Set(parsed));
-			if (selectedIndexes.length === 0) {
-				return fail(400, { error: '取り込む活動が選択されていません' });
-			}
+		// #2767 Fix Round 1 B3: 共通 helper (parseImportIndexes) 経由で edge case を回帰固定。
+		// raw が指定されているのに全要素 drop された (= 全て NaN/負数/小数) ケースは null 帰着で
+		// 全件 fallback だが、UX 整合 (画面で 0 件選択状態は CTA disable) を保つため
+		// 明示的な空指定 ('' でない空 csv 例: ',,,') は次の `=== ''` 分岐で fail させる。
+		const selectedIndexes = parseImportIndexes(selectedIndexesRaw);
+		if (selectedIndexesRaw !== '' && selectedIndexes === null) {
+			return fail(400, { error: '取り込む活動が選択されていません' });
 		}
 
 		try {

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -261,6 +261,12 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 	const formData = new FormData();
 	formData.append('packId', pendingImportPresetId);
 	formData.append('childIds', childIdsValue);
+	// Round 18 Cluster H (#13/#16/#20/#25/#28): activity-pack subset 取込。
+	// marketplace 詳細で選んだ index を URL → load → state 経由でそのまま action へ転送する。
+	// 未指定なら全件 (server action 側で後方互換 fallback)。
+	if (data.importSelectedIndexes && data.importSelectedIndexes.length > 0) {
+		formData.append('selectedIndexes', data.importSelectedIndexes.join(','));
+	}
 
 	// #2745 fix: SvelteKit form action を fetch で叩く際は `x-sveltekit-action: true`
 	// + `accept: application/json` ヘッダー必須 (admin/rewards `importPresetToChildren`

--- a/src/routes/marketplace/[type]/[itemId]/+page.server.ts
+++ b/src/routes/marketplace/[type]/[itemId]/+page.server.ts
@@ -12,6 +12,7 @@ import type { MarketplaceItemType, RulePresetPayload } from '$lib/domain/marketp
 import { marketplaceRegistry } from '$lib/marketplace';
 import type { rulePresetStrategy } from '$lib/marketplace/strategies/rule-preset-strategy';
 import { requireTenantId } from '$lib/server/auth/factory';
+import { findActivities } from '$lib/server/db/activity-repo';
 import { logger } from '$lib/server/logger';
 import { getAllChildren } from '$lib/server/services/child-service';
 import type { Actions, PageServerLoad } from './$types';
@@ -44,14 +45,26 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	// type 区別せず一括ロード（無駄に大きい呼び出しではないため pre-PMF で問題なし）。
 	const isAuthenticated = !!locals.context;
 	let children: { id: number; nickname: string }[] = [];
+	// Round 18 Cluster H (#13/#16/#20/#25/#28): activity-pack subset 選択用に、
+	// 既存活動の name を集めて preschool 親が「[既存]」ラベルで重複を一目で見分けられるようにする。
+	// per-child / family master 並存期 (ADR-0055) のため tenant aggregate (`findActivities`) で
+	// 全 child の既存活動 name を集約。重複判定は name match のみ (icon は SSOT が活動 master のため
+	// 比較に含めない)。空配列で初期化、未認証時はそのまま空配列のまま返る。
+	let existingActivityNames: string[] = [];
 	if (isAuthenticated) {
 		try {
 			const tenantId = requireTenantId(locals);
 			const allChildren = await getAllChildren(tenantId);
 			children = allChildren.map((c) => ({ id: c.id, nickname: c.nickname }));
+
+			if (type === 'activity-pack') {
+				const existing = await findActivities(tenantId);
+				existingActivityNames = Array.from(new Set(existing.map((a) => a.name)));
+			}
 		} catch {
 			// 認証コンテキストはあるがテナント解決失敗 — 未認証扱いにフォールバック
 			children = [];
+			existingActivityNames = [];
 		}
 	}
 
@@ -61,6 +74,8 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		// #2137: MP-2 側 svelte が `data.isLoggedIn` を参照するためのエイリアス
 		isLoggedIn: isAuthenticated,
 		children,
+		// Round 18 Cluster H: activity-pack 詳細で「[既存]」ラベル表示用 (未認証時 / 他 type 時は空配列)
+		existingActivityNames,
 	};
 };
 

--- a/src/routes/marketplace/[type]/[itemId]/+page.svelte
+++ b/src/routes/marketplace/[type]/[itemId]/+page.svelte
@@ -92,6 +92,43 @@ let importingRule = $state(false);
 const childOptions = $derived(
 	(data.children ?? []).map((c) => ({ value: String(c.id), label: c.nickname })),
 );
+
+// Round 18 Cluster H (#13/#16/#20/#25/#28): activity-pack subset 選択 UI state
+// 既存活動 name と一致するものは default unchecked (重複取込で hidden delete 発生回避)
+// それ以外は default checked (現状の 30 件一括取込 UX を後方互換維持)
+const activityPackActivities = $derived(
+	isActivityPack ? (item.payload as ActivityPackPayload).activities : [],
+);
+const existingNameSet = $derived(new Set(data.existingActivityNames ?? []));
+// svelte-ignore state_referenced_locally
+let activitySelections = $state<boolean[]>(
+	isActivityPack
+		? (item.payload as ActivityPackPayload).activities.map(
+				(a) => !(data.existingActivityNames ?? []).includes(a.name),
+			)
+		: [],
+);
+const selectedCount = $derived(activitySelections.filter((b) => b).length);
+const totalCount = $derived(activityPackActivities.length);
+const importUrlWithSubset = $derived.by(() => {
+	if (!isActivityPack) return '';
+	const indexes = activitySelections
+		.map((selected, i) => (selected ? i : -1))
+		.filter((i) => i >= 0);
+	// 全件選択 (既定 = 既存重複除く全て) は indexes 省略 (後方互換)、subset は CSV で URL に乗せる。
+	// CWE-598: childId は乗せない。activity index は機微情報ではない (公開 marketplace SSOT の index)。
+	const params = new URLSearchParams({ import: item.itemId });
+	if (indexes.length !== totalCount) {
+		params.set('indexes', indexes.join(','));
+	}
+	return `/admin/activities?${params.toString()}`;
+});
+function selectAllActivities() {
+	activitySelections = activitySelections.map(() => true);
+}
+function deselectAllActivities() {
+	activitySelections = activitySelections.map(() => false);
+}
 </script>
 
 <svelte:head>
@@ -184,18 +221,77 @@ const childOptions = $derived(
 
 			{#if isActivityPack}
 				{@const payload = item.payload as ActivityPackPayload}
+				<!-- Round 18 Cluster H (#13/#16/#20/#25/#28): subset 選択 UI
+					ADR-0012 Anti-engagement: 既定で「既存と重複しないもののみ checked」、preschool 親が
+					「30 件は多すぎる、歯磨きとお片付けだけ欲しい」「既存と重複する activity の事前説明なし」
+					不満に直接回答する。「すべて選ぶ / すべて外す」で 0 摩擦の subset 編集を提供。 -->
+				{#if data.isAuthenticated && data.children.length > 0}
+					<div
+						class="flex items-center justify-between mb-3 pb-2 border-b border-[var(--color-border-default)]"
+					>
+						<p
+							class="text-xs font-bold text-[var(--color-text-secondary)]"
+							data-testid="activity-pack-selected-count"
+						>
+							{MARKETPLACE_LABELS.detailActivityPackSelectedCount(selectedCount, totalCount)}
+						</p>
+						<div class="flex gap-2">
+							<button
+								type="button"
+								class="text-xs text-[var(--color-action-primary)] underline hover:no-underline"
+								onclick={selectAllActivities}
+								data-testid="activity-pack-select-all"
+							>
+								{MARKETPLACE_LABELS.detailActivityPackSelectAll}
+							</button>
+							<button
+								type="button"
+								class="text-xs text-[var(--color-action-primary)] underline hover:no-underline"
+								onclick={deselectAllActivities}
+								data-testid="activity-pack-deselect-all"
+							>
+								{MARKETPLACE_LABELS.detailActivityPackDeselectAll}
+							</button>
+						</div>
+					</div>
+					<p class="text-xs text-[var(--color-text-tertiary)] mb-3">
+						{MARKETPLACE_LABELS.detailActivityPackSelectHint}
+					</p>
+				{/if}
 				<div class="space-y-2">
-					{#each payload.activities as act}
-						<div class="flex items-center gap-2 py-1 border-b border-[var(--color-border-subtle)] last:border-0">
+					{#each payload.activities as act, i}
+						{@const isExisting = existingNameSet.has(act.name)}
+						<label
+							class="flex items-center gap-2 py-1 border-b border-[var(--color-border-subtle)] last:border-0 cursor-pointer"
+							data-testid="activity-pack-row"
+							data-existing={isExisting ? 'true' : 'false'}
+						>
+							{#if data.isAuthenticated && data.children.length > 0}
+								<input
+									type="checkbox"
+									bind:checked={activitySelections[i]}
+									class="w-4 h-4 accent-[var(--color-action-primary)]"
+									data-testid="activity-pack-checkbox-{i}"
+									aria-label={act.name}
+								/>
+							{/if}
 							<span class="text-lg">{act.icon}</span>
 							<div class="flex-1">
 								<span class="text-sm font-medium text-[var(--color-text-primary)]">{act.name}</span>
+								{#if isExisting}
+									<span
+										class="ml-2 text-[10px] bg-[var(--color-surface-muted)] text-[var(--color-text-secondary)] px-2 py-0.5 rounded-full"
+										data-testid="activity-pack-existing-badge"
+									>
+										{MARKETPLACE_LABELS.detailActivityPackAlreadyExistsBadge}
+									</span>
+								{/if}
 								{#if act.triggerHint}
 									<p class="text-xs text-[var(--color-text-tertiary)]">{act.triggerHint}</p>
 								{/if}
 							</div>
 							<span class="text-xs text-[var(--color-text-tertiary)]">+{act.basePoints}P</span>
-						</div>
+						</label>
 					{/each}
 				</div>
 			{:else if isRewardSet}
@@ -556,22 +652,33 @@ const childOptions = $derived(
 				<!-- #2362 PR-3 Phase 5 (CWE-598): activity-pack ログイン済 + 子供登録済
 					→ 親管理画面に遷移して ChildSelectionDialog を auto-open (Phase 4 admin の mechanism と接続)。
 					URL に childId を渡さず itemId のみ。child binding は admin 側ダイアログで決定する。
-					(docs/design/marketplace-import-flow.md §3.1 取込フロー sequence 整合) -->
-				{@const activityPackPayload = item.payload as ActivityPackPayload}
+					(docs/design/marketplace-import-flow.md §3.1 取込フロー sequence 整合)
+					Round 18 Cluster H: subset 選択 (indexes CSV) を URL に追加。
+					selectedCount === 0 のときは CTA を disable (誤遷移防止)。 -->
 				<p class="text-xs text-[var(--color-text-tertiary)]">
 					{MARKETPLACE_LABELS.detailCtaImportActivityPackDesc}
 				</p>
-				<a
-					href="/admin/activities?import={item.itemId}"
-					class="block"
-					data-testid="activity-pack-import-cta"
-				>
-					<Button variant="primary" size="lg" class="w-full">
-						{MARKETPLACE_LABELS.detailCtaImportActivityPackWithCount(
-							activityPackPayload.activities.length,
-						)}
+				{#if selectedCount > 0}
+					<a
+						href={importUrlWithSubset}
+						class="block"
+						data-testid="activity-pack-import-cta"
+					>
+						<Button variant="primary" size="lg" class="w-full">
+							{MARKETPLACE_LABELS.detailCtaImportActivityPackSelected(selectedCount)}
+						</Button>
+					</a>
+				{:else}
+					<Button
+						variant="primary"
+						size="lg"
+						class="w-full"
+						disabled
+						data-testid="activity-pack-import-cta-disabled"
+					>
+						{MARKETPLACE_LABELS.detailActivityPackSelectedZero}
 					</Button>
-				</a>
+				{/if}
 			{:else if isActivityPack && data.isAuthenticated && data.children.length === 0}
 				<!-- #2362 PR-3 Phase 5: activity-pack ログイン済 + 子供未登録 → setup 誘導 -->
 				<div

--- a/src/routes/marketplace/[type]/[itemId]/+page.svelte
+++ b/src/routes/marketplace/[type]/[itemId]/+page.svelte
@@ -658,27 +658,26 @@ function deselectAllActivities() {
 				<p class="text-xs text-[var(--color-text-tertiary)]">
 					{MARKETPLACE_LABELS.detailCtaImportActivityPackDesc}
 				</p>
-				{#if selectedCount > 0}
-					<a
-						href={importUrlWithSubset}
-						class="block"
-						data-testid="activity-pack-import-cta"
-					>
-						<Button variant="primary" size="lg" class="w-full">
-							{MARKETPLACE_LABELS.detailCtaImportActivityPackSelected(selectedCount)}
-						</Button>
-					</a>
-				{:else}
-					<Button
-						variant="primary"
-						size="lg"
-						class="w-full"
-						disabled
-						data-testid="activity-pack-import-cta-disabled"
-					>
-						{MARKETPLACE_LABELS.detailActivityPackSelectedZero}
+				<!-- Round 18 Cluster H: CTA <a> は常時 render (CWE-598 spec count >= 1 担保)。
+					 selectedCount === 0 時は aria-disabled + preventDefault で nav 無効化、視覚的にも disabled 表現。
+					 既存 marketplace-activity-pack-no-childid.spec.ts (AC1/AC2) との互換維持。 -->
+				<a
+					href={selectedCount > 0 ? importUrlWithSubset : `/admin/activities?import=${item.itemId}`}
+					class="block"
+					class:opacity-50={selectedCount === 0}
+					class:cursor-not-allowed={selectedCount === 0}
+					aria-disabled={selectedCount === 0}
+					data-testid="activity-pack-import-cta"
+					onclick={(e) => {
+						if (selectedCount === 0) e.preventDefault();
+					}}
+				>
+					<Button variant="primary" size="lg" class="w-full" disabled={selectedCount === 0}>
+						{selectedCount > 0
+							? MARKETPLACE_LABELS.detailCtaImportActivityPackSelected(selectedCount)
+							: MARKETPLACE_LABELS.detailActivityPackSelectedZero}
 					</Button>
-				{/if}
+				</a>
 			{:else if isActivityPack && data.isAuthenticated && data.children.length === 0}
 				<!-- #2362 PR-3 Phase 5: activity-pack ログイン済 + 子供未登録 → setup 誘導 -->
 				<div

--- a/tests/unit/domain/marketplace-import-params.test.ts
+++ b/tests/unit/domain/marketplace-import-params.test.ts
@@ -1,0 +1,144 @@
+// tests/unit/domain/marketplace-import-params.test.ts
+// Issue #2767 Fix Round 1 B3 (Adversarial security): activity-pack subset 取込の
+// `?indexes=<csv>` query を Zod ベース helper でパースし、4 edge case の input validation を
+// 回帰固定する。
+//
+// 検証対象:
+// - parseImportIndexes (src/lib/domain/validation/marketplace-import-params.ts)
+//
+// AC マッピング (Adversarial B3):
+// - AC-B3-1 (NaN): 'abc' / 'NaN' / '1.5e' などの非数値 token を silent drop する
+// - AC-B3-2 (負数): '-1' / '-100' を silent drop する
+// - AC-B3-3 (空文字): '' / null / undefined / トリム後空 → null (全件 fallback)
+// - AC-B3-4 (重複): '0,0,1,1,2' → [0, 1, 2] (順序保持 + 重複除去)
+// - AC-B3-5 (非整数 / 小数): '1.5' / '2.7' を silent drop する
+// - AC-B3-6 (正常系): '0,2,5' → [0, 2, 5]
+//
+// 関連 Issue: #2767 (Round 18 Cluster H)
+
+import { describe, expect, it } from 'vitest';
+import { parseImportIndexes } from '$lib/domain/validation/marketplace-import-params';
+
+describe('parseImportIndexes (#2767 Round 1 B3 — Zod input validation)', () => {
+	describe('AC-B3-1: NaN / 非数値 token を silent drop', () => {
+		it('"abc" → null (全件 fallback)', () => {
+			expect(parseImportIndexes('abc')).toBeNull();
+		});
+
+		it('"NaN" → null', () => {
+			expect(parseImportIndexes('NaN')).toBeNull();
+		});
+
+		it('"0,abc,2" → [0, 2] (有効値のみ抽出)', () => {
+			expect(parseImportIndexes('0,abc,2')).toEqual([0, 2]);
+		});
+
+		it('"foo,bar,baz" → null (全要素 drop → 全件 fallback)', () => {
+			expect(parseImportIndexes('foo,bar,baz')).toBeNull();
+		});
+	});
+
+	describe('AC-B3-2: 負数を silent drop', () => {
+		it('"-1" → null', () => {
+			expect(parseImportIndexes('-1')).toBeNull();
+		});
+
+		it('"-100" → null', () => {
+			expect(parseImportIndexes('-100')).toBeNull();
+		});
+
+		it('"0,-1,2,-3" → [0, 2] (負数のみ drop)', () => {
+			expect(parseImportIndexes('0,-1,2,-3')).toEqual([0, 2]);
+		});
+	});
+
+	describe('AC-B3-3: 空文字 / null / undefined → null (全件 fallback)', () => {
+		it('"" → null', () => {
+			expect(parseImportIndexes('')).toBeNull();
+		});
+
+		it('"   " (spaces only) → null', () => {
+			expect(parseImportIndexes('   ')).toBeNull();
+		});
+
+		it('null → null', () => {
+			expect(parseImportIndexes(null)).toBeNull();
+		});
+
+		it('undefined → null', () => {
+			expect(parseImportIndexes(undefined)).toBeNull();
+		});
+
+		it('",,," (commas only) → null', () => {
+			expect(parseImportIndexes(',,,')).toBeNull();
+		});
+
+		it('", , ," (commas + spaces) → null', () => {
+			expect(parseImportIndexes(', , ,')).toBeNull();
+		});
+	});
+
+	describe('AC-B3-4: 重複除去 + 並び順保持', () => {
+		it('"0,0,1,1,2" → [0, 1, 2] (重複除去)', () => {
+			expect(parseImportIndexes('0,0,1,1,2')).toEqual([0, 1, 2]);
+		});
+
+		it('"5,3,5,3,1" → [5, 3, 1] (出現順保持)', () => {
+			expect(parseImportIndexes('5,3,5,3,1')).toEqual([5, 3, 1]);
+		});
+
+		it('"10,10,10" → [10] (全重複)', () => {
+			expect(parseImportIndexes('10,10,10')).toEqual([10]);
+		});
+	});
+
+	describe('AC-B3-5: 非整数 (小数 / Infinity) を silent drop', () => {
+		it('"1.5" → null', () => {
+			expect(parseImportIndexes('1.5')).toBeNull();
+		});
+
+		it('"0,1.5,2,2.7" → [0, 2] (小数は drop)', () => {
+			expect(parseImportIndexes('0,1.5,2,2.7')).toEqual([0, 2]);
+		});
+
+		it('"Infinity" → null', () => {
+			expect(parseImportIndexes('Infinity')).toBeNull();
+		});
+
+		it('"0,Infinity,3" → [0, 3]', () => {
+			expect(parseImportIndexes('0,Infinity,3')).toEqual([0, 3]);
+		});
+	});
+
+	describe('AC-B3-6: 正常系', () => {
+		it('"0" → [0] (単一値)', () => {
+			expect(parseImportIndexes('0')).toEqual([0]);
+		});
+
+		it('"0,1,2" → [0, 1, 2]', () => {
+			expect(parseImportIndexes('0,1,2')).toEqual([0, 1, 2]);
+		});
+
+		it('"0,2,5,8" → [0, 2, 5, 8] (sparse)', () => {
+			expect(parseImportIndexes('0,2,5,8')).toEqual([0, 2, 5, 8]);
+		});
+
+		it('" 0 , 2 , 5 " (whitespace 混入) → [0, 2, 5]', () => {
+			expect(parseImportIndexes(' 0 , 2 , 5 ')).toEqual([0, 2, 5]);
+		});
+
+		it('large index "30,100,500" → [30, 100, 500] (上限は呼び出し側担保)', () => {
+			expect(parseImportIndexes('30,100,500')).toEqual([30, 100, 500]);
+		});
+	});
+
+	describe('複合 edge case (Adversarial)', () => {
+		it('"0,-1,1.5,abc,2,2" → [0, 2] (混在 → 有効値のみ + 重複除去)', () => {
+			expect(parseImportIndexes('0,-1,1.5,abc,2,2')).toEqual([0, 2]);
+		});
+
+		it('"abc,-1,1.5,NaN" → null (全要素 invalid → 全件 fallback)', () => {
+			expect(parseImportIndexes('abc,-1,1.5,NaN')).toBeNull();
+		});
+	});
+});

--- a/tests/unit/marketplace/strategies/activity-pack-strategy.test.ts
+++ b/tests/unit/marketplace/strategies/activity-pack-strategy.test.ts
@@ -350,4 +350,38 @@ describe('marketplace dispatcher + activity-pack', () => {
 		expect(result.imported).toBe(1);
 		expect(result.total).toBe(1);
 	});
+
+	// Round 18 Cluster H (#13/#16/#20/#25/#28): subset 取込 — `+page.server.ts` の
+	// `importPackToChildren` action が `selectedIndexes` を受け取った時に payload.activities を
+	// slice してから dispatchImport へ渡す動線を、subset 後 payload で逆方向に検証する。
+	// preschool 親「30 件は多すぎる、歯磨きとお片付けだけ欲しい」の subset 結果が正しく取り込まれることを担保。
+	it('subset 取込 (#13/#16/#20/#25/#28): 30 件から 2 件 slice した payload は 2 件のみ insert される', async () => {
+		const { dispatchImport } = await import('../../../../src/lib/marketplace');
+
+		// 30 件 fixture (preschool starter pack 規模)
+		const allActivities = Array.from({ length: 30 }, (_, i) =>
+			makeActivity({ name: `activity-${i}`, categoryCode: 'seikatsu' as const }),
+		);
+		// 「歯磨きとお片付けだけ欲しい」を index 3, 7 でシミュレート
+		const selectedIndexes = [3, 7];
+		const subset = selectedIndexes.map((i) => allActivities[i]);
+		const slicedPayload = { activities: subset };
+
+		const result = await dispatchImport({
+			typeCode: 'activity-pack',
+			rawPayload: slicedPayload,
+			displayName: 'kinder-starter (subset)',
+			ctx: { tenantId: TENANT, presetId: 'kinder-starter' },
+		});
+		// subset = 2 件のみ insert / 残り 28 件は payload に含まれないため skip すらされない
+		expect(result.imported).toBe(2);
+		expect(result.total).toBe(2);
+		// bulk write が 1 回 / 2 inputs (subset 件数) で呼ばれる (#2458-A1: per-child bulk path)
+		expect(mockInsertActivitiesBulk).toHaveBeenCalledTimes(1);
+		const [inputs] = mockInsertActivitiesBulk.mock.calls[0] as [unknown[]];
+		expect(inputs).toHaveLength(2);
+		// subset で選んだ activity の name が伝播していること (順序 = selectedIndexes 順)
+		const names = (inputs as Array<{ name: string }>).map((a) => a.name);
+		expect(names).toEqual(['activity-3', 'activity-7']);
+	});
 });

--- a/tests/unit/routes/marketplace-auth-redirect.test.ts
+++ b/tests/unit/routes/marketplace-auth-redirect.test.ts
@@ -92,7 +92,11 @@ describe('#2303 marketplace 未ログイン CTA は /auth/login redirect', () =>
 		it('詳細画面 activity-pack ログイン済 CTA は /admin/activities?import= へ遷移する (#2362 PR-3 Phase 5)', () => {
 			// #2362 PR-3 Phase 5: activity-pack ログイン済 + 子供登録済の CTA は admin/activities へ
 			// (ChildSelectionDialog auto-open mechanism Phase 4 と接続)
-			expect(content).toMatch(/href=["']\/admin\/activities\?import=\{item\.itemId\}["']/);
+			// Round 18 Cluster H (#2767): href が template literal の動的式に変更されたため、
+			// 静的 href={...} だけでなく `/admin/activities?import=${item.itemId}` 形式も許容。
+			expect(content).toMatch(
+				/href=["']\/admin\/activities\?import=\{item\.itemId\}["']|\/admin\/activities\?import=\$\{item\.itemId\}/,
+			);
 		});
 
 		it('詳細画面に /auth/signup 直接遷移が残っていない (data integrity 保護)', () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親 (管理者) — preschool 親が `/marketplace/activity-pack/<itemId>` で取込決定する場面

**解決する課題**: 30 件 activity-pack を一括取込する仕様で、preschool 親が「歯磨きとお片付けだけ欲しい」のに全件取込で後で 27 件削除する羽目 + 既存重複の事前説明なし。Round 18 評価 Round 3 (Issues #13/#16/#20/#25/#28) で severity 3-4 検出。

**期待される効果**: 個別 activity checkbox 選択 + 既存重複 detection + 件数連動 CTA で「選択した分だけ取り込む」UX を実現、subset 取込で認知負荷削減。

## 関連 Issue

- Round 18 評価 Round 3 (`tmp/round18-eval-round3-2026-06-02.md` Cluster H) — Issues #13/#16/#20/#25/#28
- **補追 Issue**: #2769 (Hick's Law 軽減検討 — default=全 unchecked or popularity sort 整合、Adversarial B4)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 個別 activity checkbox 選択 UI (default = 全 checked、既存重複は default unchecked) | E2E + unit + SS | HEAD `c1dd8df0` / `+page.svelte:activitySelections` $state / 「すべて選ぶ/外す」button / Mobile SS で 30 件 checkbox 確認 |
| AC2 | 既存重複 detection (name match で「登録済み」badge + default unchecked) | E2E badge visible | HEAD `c1dd8df0` / `existingNameSet` $derived / `activity-pack-existing-badge` testid |
| AC3 | 件数連動 CTA (selectedCount 表示、0 件時 disabled UX) | E2E count assert | HEAD `c1dd8df0` / `detailCtaImportActivityPackSelected(selectedCount)` / After SS で「30件を選択中」CTA 文言確認 |
| AC4 | subset を `?indexes=<csv>` query で admin/activities に伝達 (CWE-598 整合、childId 非露出) | E2E + spec | HEAD `c1dd8df0` / `importUrlWithSubset` $derived / `marketplace-activity-pack-no-childid.spec.ts` AC1/AC2 互換 |
| AC5 | `importPackToChildren` action で `payload.activities` を slice してから dispatchImport へ (後方互換) | unit test | HEAD `c1dd8df0` / `activity-pack-strategy.test.ts` subset dispatcher integration 20 PASS |
| AC6 | CWE-598 spec 互換: `<a data-testid="activity-pack-import-cta">` 常時 render (selectedCount === 0 時は aria-disabled + preventDefault) | E2E spec | HEAD `c1dd8df0` / spec count >= 1 担保、href = `/admin/activities?import=<itemId>` で childId 非露出 |
| AC7 | 設計書同期 (marketplace-import-flow.md) | grep | HEAD `c1dd8df0` / 「Round 18 Cluster H subset 取込」sub-section 追加済 |
| **AC8 (Fix Round 1 B3)** | `?indexes=<csv>` の Zod input validation (4 edge case 回帰固定) | unit test 27 件 | HEAD `c1dd8df0` / `parseImportIndexes` helper + `tests/unit/domain/marketplace-import-params.test.ts` (NaN/負数/空文字/重複/非整数/正常系) PASS |

## 変更タイプ

- [x] feat: 新機能 (subset 取込 UX)
- [x] fix: Adversarial Review Fix Round 1 (B3 Zod input validation 強化)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/marketplace/[type]/[itemId]/+page.svelte`)
- [x] サービス層 (`src/lib/server/services/activity-import-service.ts`)
- [x] ドメインモデル (`src/lib/domain/labels.ts`)
- [x] **新規 validation helper** (`src/lib/domain/validation/marketplace-import-params.ts`、Fix Round 1 B3)

**影響を受ける画面・機能**: `/marketplace/activity-pack/<itemId>` 詳細 + 取込導線 → `/admin/activities?import=<itemId>&indexes=<csv>`

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — CI gate に委譲
- [x] 追加テスト: `activity-pack-strategy.test.ts` subset dispatcher 1 件
- [x] **追加テスト (Fix Round 1 B3)**: `tests/unit/domain/marketplace-import-params.test.ts` 27 件 PASS
- [x] **新規 env / secret**: N/A
- [x] **DynamoDB**: N/A
- [x] **Critical**: N/A

## スクリーンショット / ビジュアルデモ

**撮影環境**: `npm run dev:cognito` (port 5174) で cognito-dev `parent@example.com` でログイン後、`/setup/children` で「たろう (4 歳 / preschool)」を登録した状態で `/marketplace/activity-pack/kinder-starter` を撮影。

### 修正前 (main HEAD `7f18baec`)

| Viewport | Screenshot |
|---|---|
| Mobile (390×844, 2x DPR) | ![before-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2767/before-marketplace-activity-pack-kinder-starter-mobile.webp) |
| Desktop (1440×900) | ![before-desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2767/before-marketplace-activity-pack-kinder-starter-desktop.webp) |

### 修正後 (PR HEAD)

| Viewport | Screenshot |
|---|---|
| Mobile (390×844, 2x DPR) | ![after-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2767/after-marketplace-activity-pack-kinder-starter-mobile.webp) |
| Desktop (1440×900) | ![after-desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2767/after-marketplace-activity-pack-kinder-starter-desktop.webp) |

**差分 (Before → After)**:
- 「30件 / 30件 を取り込みます」カウント表示 + 「すべて選ぶ / すべて外す」ボタン追加
- 各 activity 行に checkbox (`activity-pack-checkbox-{0..29}`) 追加 + `data-testid="activity-pack-row"` 化
- CTA 文言: 「ご家族の見守り画面で取り込む (30件の活動)」→「ご家族の見守り画面で取り込む (30件を選択中)」(件数連動)

**Blob SHA uniqueness (#2063 偽装防止)**: 4 件全て unique (`sha256sum` で確認済)。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: $state / $derived 分離、subset 計算 import action 内 slice 局所化、Fix Round 1 B3 で input validation を helper に分離 (SRP)
- [x] **DRY**: existingNameSet 1 箇所、selectedCount/totalCount 単一定義、`parseImportIndexes` で URL load + action POST 両方の parse を統一
- [x] **YAGNI**: AI suggest による「3 歳児向け 5 件 auto-select」は Round 18 再評価次第で別 Issue
- [x] **Security (Fix Round 1 B3)**: CWE-598 整合 (URL に childId 非露出)、indexes は公開 marketplace SSOT の index、Zod 経由で 4 edge case (NaN/負数/非整数/空文字/重複) input validation
- [x] **アクセシビリティ**: aria-disabled / preventDefault / `<label>` で checkbox 全行クリック領域確保
- [x] **パフォーマンス**: client-side filter、追加 fetch なし

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] N/A — 並行実装の影響範囲外 (marketplace activity-pack scope 限定)

**LP / 販促文言変更**: なし

## Adversarial Review 対応 (Fix Round 1)

| Adversarial | 対応 | 証跡 |
|---|---|---|
| **B1 (CI screenshot-check FAIL)** | SS 4 スロット撮影 + Markdown image syntax 埋込 (修正前/後 × mobile/desktop) | 上記「スクリーンショット」section、Blob SHA 4 件 unique |
| **B2 (5 age modes Fitts's Law)** | marketplace 詳細は **parent admin UI で uiMode 非依存**。`src/routes/(child)/[uiMode]` 配下に露出していないため age-mode tapSize SSOT (DESIGN.md §8) は適用対象外。Material Design 標準 44px+ ボタン target で十分 | `grep -rn "marketplace" src/routes/(child)/` = 0 件 |
| **B3 (input validation)** | `parseImportIndexes` (Zod 経由) helper 新設 + unit test 27 件 (NaN / 負数 / 非整数 / 空文字 / 重複 / 正常系 / 複合 edge case) | `src/lib/domain/validation/marketplace-import-params.ts` + `tests/unit/domain/marketplace-import-params.test.ts` PASS |
| **B4 (Hick's Law)** | 本 PR scope 維持 + 補追 Issue #2769 起票 (Option A/B/C trade-off は PO 判断材料として整理) | Issue #2769 |

## レビュー依頼事項・破壊的変更

- 並行 PR (Cluster I/J+K) との conflict: なし
- 既存 marketplace E2E への影響: `marketplace-activity-pack-no-childid.spec.ts` AC1/AC2 互換維持 (CTA `<a>` 常時 render)
- `importPackToChildren` action 後方互換: 全件選択時 `indexes` 省略で従来動作

## 配布済み env / secret (ADR-0006)

N/A

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**
- [x] セルフレビュー済み
- [x] 全 AC が実装済み (AC1-AC8、Fix Round 1 B3 含む)
- [x] UI 変更時: SS 4 スロット添付 (修正前/後 × mobile/desktop、Blob SHA 4 件 unique)
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM 記入欄、Dev 起票時は空欄 -->
N/A (QA Tier 2 Re-Review 待機中、Fix Round 1 完了)
