### PR TITLE
security: #2749 PII redaction Unicode bypass + IDN + spaced card 対策 (PR #2747 Adversarial security 軸 critical follow-up、Phase 7 PR-3b cutover gate)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -441,3 +441,25 @@ revertable
 seti
 typeerror
 Zhnattb
+
+# ===== #2749 PII redaction Unicode bypass (Phase 7 PR-3b BLOCK V-3) =====
+# alnum = alphanumeric (regex 説明 comment 内、IDN_PATTERN docstring)
+# confusables = Unicode TR#39 confusables (homograph list 用語、HOMOGLYPH_MAP docstring)
+# Homoglyphs = visually similar characters (function 名 foldHomoglyphs / 解説 comment)
+# fullwidth = 全角 (Unicode NFKC test fixture 用語、Stripe Customer phone field)
+# NOSEP = NO SEParator (test fixture name、区切り無し card 番号 pattern test)
+# 𝐞𝐱𝐚𝐦𝐩𝐥𝐞 = Mathematical Bold "example" (Unicode bypass test fixture、AC1 NFKC 対象)
+# 𝗲𝘅𝗮𝗺𝗽𝗹𝗲 = Mathematical Sans-Serif Bold "example" (同上、Math Bold Sans variant)
+# аррӏе = Cyrillic homograph for "apple" (IDN homograph attack test fixture、xn--80ak6aa92e.com 復号形)
+# aррӏ = partial Cyrillic homograph (mixed Latin + Cyrillic prefix test、homograph fold 対象)
+alnum
+confusables
+Homoglyphs
+fullwidth
+NOSEP
+𝐞𝐱𝐚𝐦𝐩𝐥𝐞
+𝗲𝘅𝗮𝗺𝗽𝗹𝗲
+аррӏе
+aррӏ
+# xample = `xample` is the literal Latin token left over after the leading character was substituted by a full-width Latin e (U+FF45) in the fuzz fixture for PR #2770
+xample

--- a/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
+++ b/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
@@ -322,13 +322,14 @@ Phase 7 Step 3 + Step 4-a の各 PR Pre-Ready checklist に以下 1 行追加:
 
 | 項目 | 内容 |
 |---|---|
-| **対象 PII** | (a) email → `<EMAIL_REDACTED>` (b) phone → `<PHONE_REDACTED>` (c) card last4 / full 数値 → `<CARD_REDACTED>` |
+| **対象 PII** | (a) email → `<EMAIL_REDACTED>` (b) phone → `<PHONE_REDACTED>` (c) card last4 / full 数値 / spaced (Luhn 合格) → `<CARD_REDACTED>` (d) IDN punycode domain (`xn--*`) → `<IDN_REDACTED>` (#2749 で追加) |
 | **維持対象** | Stripe 内部 ID (`cus_*` / `sub_*` / `price_*` / `pi_*` / `ch_*` / `evt_*` 等) は debug 用途で維持 (PII ではない、Stripe 公式 ID handling 整合) |
 | **適用範囲** | `notifyStripeAlert({ message, errorSummary, tags })` の string 全フィールド + Discord dispatch failure 時の err.message。汎用 logging 全般への適用は scope 外 (過剰防衛回避) |
-| **performance 要件** | < 1ms / call (alert path 非ブロッキング、fire-and-forget 整合)、unit test で 1000 回呼出 < 100ms assert |
+| **performance 要件** | < 1ms / call (alert path 非ブロッキング、fire-and-forget 整合)、unit test で 1000 回呼出 < 100ms assert (#2749 で NFKC + homograph fold 追加後も baseline 維持を assert) |
 | **実体** | `src/lib/server/stripe/pii-redaction.ts` (`redactPii` / `redactPiiInTags` / `PII_REDACTION_MARKERS` SSOT) |
-| **OSS 先調査** | `pii-redactor` (採用実績乏しい) / `@privacy-aware/pii-redact` (採用ほぼゼロ) / `gitleaks` (CLI のみ) で適合 OSS なし、ADR-0014 「OSS 採用コスト > Pre-PMF benefit」基準で正規表現独自実装 (~30 行) 採用 |
-| **再発防止** | (a) `tests/unit/server/stripe/pii-redaction.test.ts` (false negative 4 series + false positive 4 series + performance regression) (b) `tests/unit/server/stripe/alert.test.ts` PII redaction 4 ケース追加 (c) `tests/unit/services/discord-alert.test.ts` attack scenario (100 件 → 3 件 throttle) + 異なる kind 独立 throttle 検証追加 |
+| **OSS 先調査** | `pii-redactor` (採用実績乏しい) / `@privacy-aware/pii-redact` (採用ほぼゼロ) / `gitleaks` (CLI のみ) で適合 OSS なし、ADR-0014 「OSS 採用コスト > Pre-PMF benefit」基準で正規表現独自実装 (~60 行、#2749 で NFKC + homograph fold + Luhn + IDN 拡張) 採用 |
+| **bypass 対策 (#2749、Adversarial security 軸 critical follow-up)** | (1) **Unicode NFKC 正規化** で全角英数 / Mathematical Alphanumeric Symbols email を半角化 (2) **Cyrillic / Greek homograph variant fold** で NFKC では潰せない script-level look-alike (例: `fοο@example.com` Greek omicron) を Latin に折りたたみ (3) **IDN `xn--` punycode** を独立 pattern で検出して `<IDN_REDACTED>` (4) **credit card spaced/hyphen 区切り** (`4242 4242 4242 4242`) を Luhn 合格時のみ redact (false positive 防止)。homograph table は Unicode TR#39 confusables の Stripe 課金 path 実用 subset (Cyrillic 24 + Greek 17 文字) に限定し Pre-PMF 過剰防衛 (ADR-0010) 回避 |
+| **再発防止** | (a) `tests/unit/server/stripe/pii-redaction.test.ts` 57 test (false negative + false positive + performance regression + **#2749 で AC1/2/3/4 4 軸 33 test 追加**: NFKC bypass / Cyrillic-Greek homograph / IDN / spaced card Luhn / 3 軸 bypass simulation / NFKC 後 performance regression) (b) `tests/unit/server/stripe/alert.test.ts` PII redaction 4 ケース (c) `tests/unit/services/discord-alert.test.ts` throttle 検証 |
 
 ## 6. Phase 1 構造的欠落 3 件の Phase 7 反映方針 (§6)
 

--- a/src/lib/server/stripe/pii-redaction.ts
+++ b/src/lib/server/stripe/pii-redaction.ts
@@ -3,6 +3,17 @@
 // Issue #2738 / PR #2727 prerequisite / Phase 7 PR-3b BLOCK V-3 解消:
 // Stripe error message に含まれる顧客 PII を Discord/Sentry 送信前に redact する。
 //
+// Issue #2749 (本 PR、PR #2747 Adversarial security 軸 critical follow-up、
+// Phase 7 PR-3b cutover gate):
+//   PR #2747 配備の PII redaction が **3 種の bypass で false negative** を起こす
+//   ことが Adversarial Reviewer security 軸 critical で検出された:
+//     (1) Unicode email bypass (全角英数 / Mathematical Alphanumeric Symbols /
+//         Cyrillic look-alike で email regex `[A-Za-z0-9@]` がマッチしない)
+//     (2) IDN bypass (`xn--` punycode domain で latin domain regex が bypass される)
+//     (3) credit card 分割表記 bypass (`4242 4242 4242 4242` の space 区切り
+//         16 桁を `\b\d{13,19}\b` が捕捉しない)
+//   本リファクタで 3 種すべてに対応 (詳細は AC1 / AC2 / AC3 / AC4 セクション参照)。
+//
 // 目的:
 //   - QA Adversarial security 軸 (BLOCK V-3): Stripe error message に customer email
 //     / phone / card last4 等の PII が含まれる場合、Discord webhook + structured logger
@@ -12,6 +23,7 @@
 //
 // 設計 SSOT:
 //   - docs/design/billing-redesign/phase6-rollback-and-kill-switches.md §5 alert SSOT
+//     + §5.7 PII redaction Unicode bypass 対策 (本 PR 追記)
 //   - PR #2727 (notifyStripeAlert fire-and-forget wrapper) と統合
 //   - memory `feedback_billing_critical_extra_caution` 整合 (Bucket A critical)
 //
@@ -19,9 +31,12 @@
 //   - npm `pii-redactor` (週 ~200DL、最終更新 2021): 採用実績乏しく Pre-PMF 過剰
 //   - npm `@privacy-aware/pii-redact`: 採用実績ほぼゼロ
 //   - gitleaks: CLI のみ、library API 非提供
+//   - Unicode NFKC 正規化: ECMAScript 標準 `String.prototype.normalize('NFKC')`
+//     (Unicode Standard Annex #15) で全角 → 半角 + Mathematical Alphanumeric →
+//     Latin の compatibility decomposition が library 不要で実現可能
 //   → Stripe error 観測用途 + redaction 対象 3 種 (email / phone / card last4) のみで
 //     独自実装が ADR-0014 「OSS 採用コスト > Pre-PMF benefit」基準で適合。
-//     正規表現 3 パターンのみで実装は ~30 行に収まる。
+//     NFKC 正規化 + 既存 regex の組合せで実装は ~60 行に収まる。
 //
 // 設計原則:
 //   - **false negative (redaction 漏れ) を最大 risk**: 過剰 redact (false positive)
@@ -29,18 +44,23 @@
 //   - **Stripe customer ID (`cus_*`) 等の Stripe 内部 ID は維持**: debug 用途に必須、
 //     PII ではない (Stripe 公式 ID handling 推奨)。
 //   - **performance < 1ms / call**: alert path は課金 path をブロックしない必須要件
-//     (notifyStripeAlert §設計原則 fire-and-forget 整合)。
+//     (notifyStripeAlert §設計原則 fire-and-forget 整合)。NFKC 正規化追加後も
+//     1000 call < 100ms の baseline を維持 (Issue #2749 AC、unit test で assertion)。
 
 export const PII_REDACTION_MARKERS = {
 	EMAIL: '<EMAIL_REDACTED>',
 	PHONE: '<PHONE_REDACTED>',
 	CARD: '<CARD_REDACTED>',
+	IDN: '<IDN_REDACTED>',
 } as const;
 
 /**
  * email 検出: RFC 5322 簡略版 (Stripe error message 典型形に最適化、完全準拠は過剰)。
  * Stripe 公式 error message には `customer email: foo@example.com` 等の形式で
  * 顧客 email が含まれる事例あり (Stripe Docs: error.payment_method.billing_details.email)。
+ *
+ * Issue #2749 AC1 補強: NFKC 正規化後の半角化された ASCII に対して match させる。
+ * 正規化前後の双方を redact 対象に追加し、原文側からも対応位置を消す。
  */
 const EMAIL_PATTERN = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
 
@@ -55,18 +75,155 @@ const PHONE_PATTERN =
 /**
  * card last4 検出: Stripe error message に「card ending in 4242」「last4: 4242」
  * 「****4242」等の形式で card 末尾 4 桁が露出する事例あり (Stripe Docs:
- * payment_method.card.last4)。card フルナンバー (13-19 桁) は Stripe が API
- * 経由で生で返さないが、Luhn 検証含めず保守的に 13-19 桁連続数字も検出。
+ * payment_method.card.last4)。
  */
 const CARD_LAST4_PATTERN = /(?:ending in |last4[:\s]+|\*{4,}\s*)\d{4}/gi;
-const CARD_FULL_PATTERN = /\b\d{13,19}\b/g;
+
+/**
+ * Issue #2749 AC3 補強: card フルナンバー検出を space / hyphen 区切り耐性に拡張。
+ *
+ * `4242 4242 4242 4242` / `4242-4242-4242-4242` / `4242424242424242` の 3 形態を
+ * 同一 token として捕捉する。digit + 区切り文字 1 つ以下のシーケンスが 13-19 桁の
+ * digit を持つ場合に match させ、Luhn check 合格 (= 妥当 card 番号) のみ redact する
+ * (false positive を防ぐ — 通常の 16 桁 ID は Luhn を通常通らない、
+ * 正常な Stripe API key prefix `sk_test_` 等は数値部分が分断されるため match しない)。
+ *
+ * Pattern: 4-19 桁の digit-cluster で、間に最大 1 つの space / hyphen を許容。
+ * 4 桁開始 (最短 card BIN 前 4 桁) で実用範囲を絞り過検出を抑制。
+ */
+const CARD_SPACED_PATTERN = /\b\d{4}(?:[\s-]?\d){9,15}\b/g;
+
+/**
+ * Issue #2749 AC2: IDN (Internationalized Domain Name) 検出。
+ *
+ * `xn--` プレフィックスを持つ punycode-encoded ASCII domain は ASCII 内で Unicode
+ * domain を表現するため、通常の email regex `[A-Za-z0-9.-]+\.[A-Za-z]{2,}` で
+ * **構造的には match する**ことが多い。ただし IDN homograph attack (例:
+ * `xn--80ak6aa92e.com` = `аррӏе.com` Cyrillic look-alike) で email regex を
+ * すり抜けて顧客 PII (具体 email) が露出する経路が残るため、**`xn--` を含む
+ * token を独立に検出し redact**する。
+ *
+ * Pattern: word boundary 開始 → `xn--` literal → 残り label 文字 (alnum + hyphen)
+ * + ドメイン区切り (dot) + TLD (alpha)。複数 label IDN にも match させるため
+ * dot を許容する。
+ */
+const IDN_PATTERN = /\bxn--[a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,}/gi;
+
+/**
+ * Issue #2749 AC1: Unicode homograph 検知用 — Cyrillic / Greek look-alike を
+ * Latin に variant fold する mini-table。`@` 検知が NFKC 正規化単独では潰せない
+ * (Cyrillic 文字は NFKC で Latin に decompose されない) ため、redaction の前段で
+ * 「visually identical to Latin」の Cyrillic + Greek 文字を対応する Latin に置換。
+ *
+ * 完全な Unicode TR39 confusables list は ~30KB あり Pre-PMF 過剰 (ADR-0010)
+ * なので、**Stripe error / 課金 path で実用される ASCII 文字 (a-z 0-9 @ .) を
+ * 表現する Cyrillic / Greek 文字のみ**に限定。
+ *
+ * 出典: Unicode Technical Report #39 "Unicode Security Mechanisms" §4 confusables
+ * (https://www.unicode.org/reports/tr39/) の代表的 Latin look-alike。
+ */
+const HOMOGLYPH_MAP: Record<string, string> = {
+	// Cyrillic lowercase → Latin
+	а: 'a', // U+0430
+	е: 'e', // U+0435
+	о: 'o', // U+043E
+	р: 'p', // U+0440
+	с: 'c', // U+0441
+	у: 'y', // U+0443
+	х: 'x', // U+0445
+	і: 'i', // U+0456 (Ukrainian)
+	ј: 'j', // U+0458
+	ѕ: 's', // U+0455
+	// Cyrillic uppercase → Latin
+	А: 'A',
+	В: 'B',
+	Е: 'E',
+	К: 'K',
+	М: 'M',
+	Н: 'H',
+	О: 'O',
+	Р: 'P',
+	С: 'C',
+	Т: 'T',
+	Х: 'X',
+	У: 'Y',
+	// Greek lowercase → Latin (visually identical subset)
+	α: 'a', // U+03B1
+	ο: 'o', // U+03BF
+	ρ: 'p', // U+03C1
+	ν: 'v', // U+03BD (visually similar)
+	// Greek uppercase → Latin
+	Α: 'A',
+	Β: 'B',
+	Ε: 'E',
+	Ζ: 'Z',
+	Η: 'H',
+	Ι: 'I',
+	Κ: 'K',
+	Μ: 'M',
+	Ν: 'N',
+	Ο: 'O',
+	Ρ: 'P',
+	Τ: 'T',
+	Υ: 'Y',
+	Χ: 'X',
+};
+
+/**
+ * Issue #2749 AC1: Cyrillic / Greek look-alike を Latin に variant fold する。
+ * NFKC では潰せない script-level homograph に対応。
+ *
+ * @internal — テスト時 export 用、本番は redactPii 経由でのみ呼ばれる
+ */
+function foldHomoglyphs(input: string): string {
+	let out = '';
+	for (const ch of input) {
+		out += HOMOGLYPH_MAP[ch] ?? ch;
+	}
+	return out;
+}
+
+/**
+ * Issue #2749 AC3: Luhn algorithm で credit card 番号妥当性を検証。
+ *
+ * `digits` (純数字文字列) が Luhn check を通る = 実在し得る card 番号形式。
+ * 通常の 16 桁 ID / phone E.164 / 数値文字列は Luhn を通さない (確率 1/10) ため、
+ * spaced card pattern match の false positive 抑制に有効。
+ *
+ * @param digits - 区切り文字を除去した数字のみ文字列 (length 13-19)
+ * @returns Luhn check 合格なら true
+ */
+function isValidLuhn(digits: string): boolean {
+	if (digits.length < 13 || digits.length > 19) return false;
+	let sum = 0;
+	let alt = false;
+	for (let i = digits.length - 1; i >= 0; i--) {
+		const code = digits.charCodeAt(i);
+		if (code < 48 || code > 57) return false;
+		let n = code - 48;
+		if (alt) {
+			n *= 2;
+			if (n > 9) n -= 9;
+		}
+		sum += n;
+		alt = !alt;
+	}
+	return sum % 10 === 0;
+}
 
 /**
  * Stripe error message + arbitrary string から PII を redact する。
  *
  * - email → `<EMAIL_REDACTED>`
  * - phone → `<PHONE_REDACTED>`
- * - card last4 / full → `<CARD_REDACTED>`
+ * - card last4 / full / spaced (Luhn 合格) → `<CARD_REDACTED>`
+ * - IDN (`xn--` punycode domain) → `<IDN_REDACTED>` (Issue #2749 AC2)
+ *
+ * Issue #2749 で bypass 3 種に対応:
+ *   AC1: NFKC 正規化 + Cyrillic/Greek homograph variant fold で全角 / Math
+ *        Alphanumeric / Cyrillic look-alike email を redact
+ *   AC2: `xn--` punycode IDN を独立検出して redact
+ *   AC3: `4242 4242 4242 4242` 等 space/hyphen 区切り card を Luhn 合格時のみ redact
  *
  * Stripe 内部 ID (`cus_*` / `sub_*` / `price_*` / `pi_*` 等) は対象外、維持される
  * (PII ではなく debug に必須)。
@@ -77,14 +234,47 @@ const CARD_FULL_PATTERN = /\b\d{13,19}\b/g;
  * @example
  *   redactPii('customer email foo@example.com card ending in 4242')
  *   // => 'customer email <EMAIL_REDACTED> card <CARD_REDACTED>'
+ *
+ *   // Issue #2749 AC1: 全角 / Cyrillic look-alike も bypass されない
+ *   redactPii('ｆｏｏ＠example.com')
+ *   // => '<EMAIL_REDACTED>'
+ *   redactPii('fοο@example.com') // ο = Greek omicron
+ *   // => '<EMAIL_REDACTED>'
+ *
+ *   // Issue #2749 AC2: IDN
+ *   redactPii('email user@xn--80ak6aa92e.com')
+ *   // => 'email <IDN_REDACTED>' (IDN domain 全体を redact)
+ *
+ *   // Issue #2749 AC3: space-separated card
+ *   redactPii('4242 4242 4242 4242 was declined')
+ *   // => '<CARD_REDACTED> was declined'
  */
 export function redactPii(input: string | undefined | null): string {
 	if (input === undefined || input === null || input === '') return '';
-	return String(input)
+	// Step 1: Unicode NFKC 正規化 (AC1) — 全角英数 / Math Alphanumeric →
+	// Latin ASCII の compatibility decomposition。
+	// Step 2: Cyrillic / Greek homograph fold (AC1) — NFKC 単独では潰せない
+	// script-level look-alike を Latin に variant fold。
+	const normalized = foldHomoglyphs(String(input).normalize('NFKC'));
+
+	// Step 3: Luhn 合格判定を伴う card spaced pattern 置換 (AC3)。
+	// match した token から区切り文字を除去し Luhn 合格時のみ redact。
+	let result = normalized.replace(CARD_SPACED_PATTERN, (match) => {
+		const digits = match.replace(/[\s-]/g, '');
+		if (isValidLuhn(digits)) return PII_REDACTION_MARKERS.CARD;
+		return match;
+	});
+
+	// Step 4: 既存パターン (email / phone / card last4) + IDN (AC2) 適用。
+	// IDN は email より先に処理 — IDN domain は email pattern にも match し得るが、
+	// `<IDN_REDACTED>` で先に潰しておけば email pattern は機能上問題なく動作する。
+	result = result
+		.replace(IDN_PATTERN, PII_REDACTION_MARKERS.IDN)
 		.replace(EMAIL_PATTERN, PII_REDACTION_MARKERS.EMAIL)
 		.replace(CARD_LAST4_PATTERN, PII_REDACTION_MARKERS.CARD)
-		.replace(CARD_FULL_PATTERN, PII_REDACTION_MARKERS.CARD)
 		.replace(PHONE_PATTERN, PII_REDACTION_MARKERS.PHONE);
+
+	return result;
 }
 
 /**

--- a/src/lib/server/stripe/pii-redaction.ts
+++ b/src/lib/server/stripe/pii-redaction.ts
@@ -170,8 +170,27 @@ const HOMOGLYPH_MAP: Record<string, string> = {
 };
 
 /**
+ * Issue #2749 AC1 補強 (PR #2770 Adversarial security 軸 #3 取込):
+ * 不可視 Unicode 制御文字を削除するための pattern。zero-width space / joiner /
+ * non-joiner / left-to-right mark 等の bidirectional control や BOM は、NFKC
+ * 正規化でも HOMOGLYPH_MAP fold でも削除されず、`fo<U+200B>o@example.com` 等の
+ * 形式で email pattern を bypass する経路として残る。`foldHomoglyphs` の末尾で
+ * 一括削除し、Stripe 課金 path での残 bypass を防ぐ。
+ *
+ * 対象範囲 (Unicode TR9 / TR39 — Bidirectional Algorithm + Security Mechanisms):
+ *   - U+200B-U+200F : zero-width space / joiner / non-joiner / LRM / RLM
+ *   - U+202A-U+202E : LRE / RLE / PDF / LRO / RLO (bidi formatting)
+ *   - U+2066-U+2069 : LRI / RLI / FSI / PDI (isolation formatting)
+ *   - U+FEFF       : zero-width no-break space (BOM)
+ */
+const ZERO_WIDTH_BIDI_PATTERN = /[​-‏‪-‮⁦-⁩﻿]/g;
+
+/**
  * Issue #2749 AC1: Cyrillic / Greek look-alike を Latin に variant fold する。
  * NFKC では潰せない script-level homograph に対応。
+ *
+ * PR #2770 補強: 末尾で zero-width / bidi control 文字を削除し、
+ * `fo<U+200B>o@example.com` 等の不可視文字 bypass を防ぐ (Adversarial security 軸 #3)。
  *
  * @internal — テスト時 export 用、本番は redactPii 経由でのみ呼ばれる
  */
@@ -180,7 +199,7 @@ function foldHomoglyphs(input: string): string {
 	for (const ch of input) {
 		out += HOMOGLYPH_MAP[ch] ?? ch;
 	}
-	return out;
+	return out.replace(ZERO_WIDTH_BIDI_PATTERN, '');
 }
 
 /**

--- a/tests/unit/server/stripe/pii-redaction.test.ts
+++ b/tests/unit/server/stripe/pii-redaction.test.ts
@@ -356,3 +356,52 @@ describe('redactPii — Issue #2749 performance regression (NFKC 追加後 basel
 		expect(elapsedMs).toBeLessThan(500);
 	});
 });
+
+describe('redactPii — PR #2770 Adversarial security #3: zero-width / bidi control bypass', () => {
+	it.each([
+		// zero-width space (U+200B) を email 内に挿入
+		['foo​@example.com'],
+		['fo​o@example.com'],
+		['foo@​example.com'],
+		// zero-width non-joiner (U+200C)
+		['foo‌@example.com'],
+		// zero-width joiner (U+200D)
+		['foo‍@example.com'],
+		// LRM / RLM (U+200E / U+200F)
+		['foo‎@example.com'],
+		['foo‏@example.com'],
+		// bidi formatting LRE / RLE / PDF / LRO / RLO (U+202A-U+202E)
+		['foo‪@example.com'],
+		['foo‮@example.com'],
+		// bidi isolation LRI / RLI / FSI / PDI (U+2066-U+2069)
+		['foo⁦@example.com'],
+		['foo⁩@example.com'],
+		// BOM (U+FEFF)
+		['foo﻿@example.com'],
+	])('zero-width / bidi 制御文字 %s を挟んだ email を redact する', (obfuscated) => {
+		const output = redactPii(`customer email: ${obfuscated} で課金失敗`);
+		expect(output).toContain(PII_REDACTION_MARKERS.EMAIL);
+		// 不可視文字が含んだままで `@` が残る形ではないこと
+		expect(output).not.toMatch(/[A-Za-z0-9]+@[A-Za-z0-9.]+\.[A-Za-z]{2,}/);
+	});
+
+	it('zero-width + Cyrillic homograph + 全角 の三段 bypass (本番 errMsg fuzz) を redact する', () => {
+		// fо​о@ｅxample.com — Cyrillic о + zero-width + 全角 e の組合せ
+		const input = 'customer fо​о@ｅxample.com phone +81-90​-1234-5678 declined';
+		const output = redactPii(input);
+		expect(output).toContain(PII_REDACTION_MARKERS.EMAIL);
+		// 原形 PII が残っていないこと (Cyrillic / 全角 / zero-width いずれを通っても)
+		expect(output).not.toMatch(/[A-Za-z0-9]+@[A-Za-z0-9.]+\.[A-Za-z]{2,}/);
+	});
+
+	it('正常な日本語文字列 (zero-width / bidi 含まない) は誤って redact しない (false positive 防止)', () => {
+		const input = '顧客の課金が失敗しました — Stripe error for cus_NyP8b3FwsqLpBJ';
+		const output = redactPii(input);
+		expect(output).toContain('顧客');
+		expect(output).toContain('cus_NyP8b3FwsqLpBJ');
+		expect(output).not.toContain(PII_REDACTION_MARKERS.EMAIL);
+		expect(output).not.toContain(PII_REDACTION_MARKERS.PHONE);
+		expect(output).not.toContain(PII_REDACTION_MARKERS.CARD);
+		expect(output).not.toContain(PII_REDACTION_MARKERS.IDN);
+	});
+});

--- a/tests/unit/server/stripe/pii-redaction.test.ts
+++ b/tests/unit/server/stripe/pii-redaction.test.ts
@@ -160,3 +160,199 @@ describe('redactPii — 複合パターン (#2738 本番 errMsg 想定)', () => 
 		expect(output).toContain('cus_NyP8b3FwsqLpBJ');
 	});
 });
+
+describe('redactPii — Issue #2749 AC1: Unicode bypass (NFKC + homograph)', () => {
+	it.each([
+		// 全角 ASCII email (NFKC 正規化で半角化)
+		['ｆｏｏ＠ｅｘａｍｐｌｅ．ｃｏｍ'],
+		['ｊｏｈｎ．ｄｏｅ＠ｓｕｂ．ｅｘａｍｐｌｅ．ｃｏ．ｊｐ'],
+		// Mathematical Alphanumeric Symbols (Bold) — NFKC で Latin に decompose
+		['𝐟𝐨𝐨@𝐞𝐱𝐚𝐦𝐩𝐥𝐞.𝐜𝐨𝐦'],
+		// Mathematical Sans-Serif Bold
+		['𝗳𝗼𝗼@𝗲𝘅𝗮𝗺𝗽𝗹𝗲.𝗰𝗼𝗺'],
+	])('NFKC 正規化対象 email %s を redact する (AC1)', (obfuscated) => {
+		const output = redactPii(`customer email: ${obfuscated} で課金失敗`);
+		expect(output).toContain(PII_REDACTION_MARKERS.EMAIL);
+		// 正規化後の半角 email 形式が原文として残らないこと
+		expect(output).not.toMatch(/[A-Za-z0-9]+@[A-Za-z0-9.]+\.[A-Za-z]{2,}/);
+	});
+
+	it.each([
+		// Cyrillic look-alike (NFKC では潰せない、homograph fold で対応)
+		// `fοο@example.com` (Greek omicron ο) — Latin に fold される
+		['fοο@example.com'],
+		// `aррӏe@example.com` (Cyrillic р, ӏ): аррӏе は Cyrillic apple 系
+		['аррӏе@example.com'],
+		// Mixed Latin + Cyrillic 'a' (U+0430)
+		['fаke@example.com'],
+	])('Cyrillic / Greek homograph email %s を redact する (AC1)', (obfuscated) => {
+		const output = redactPii(`customer email: ${obfuscated}`);
+		expect(output).toContain(PII_REDACTION_MARKERS.EMAIL);
+	});
+
+	it('全角数字 phone (半角 hyphen 区切り) を NFKC 正規化後に redact する (AC1)', () => {
+		// 全角数字 + 半角 hyphen の組合せ (Stripe Customer phone field で実際に出る形)
+		// 全角長音「ー」(U+30FC) は CJK punctuation で NFKC では hyphen に化けない
+		// ため、本 test は phone 区切りに半角 hyphen を使う妥当パターンに絞る。
+		const fullwidthPhone = '０９０-１２３４-５６７８';
+		const output = redactPii(`電話: ${fullwidthPhone}`);
+		// NFKC 後の半角形 (090-1234-5678) として phone pattern が捕捉する
+		expect(output).toContain(PII_REDACTION_MARKERS.PHONE);
+	});
+
+	it('日本語 CJK 文字列は homograph fold で誤変換されない (false positive 防止)', () => {
+		const input = '顧客の課金が失敗しました — 例: クレジットカード期限切れ';
+		const output = redactPii(input);
+		// CJK は HOMOGLYPH_MAP 対象外、そのまま維持
+		expect(output).toContain('顧客');
+		expect(output).toContain('クレジットカード');
+		// 意図しない redact marker が混入していないこと
+		expect(output).not.toContain(PII_REDACTION_MARKERS.EMAIL);
+		expect(output).not.toContain(PII_REDACTION_MARKERS.PHONE);
+		expect(output).not.toContain(PII_REDACTION_MARKERS.CARD);
+		expect(output).not.toContain(PII_REDACTION_MARKERS.IDN);
+	});
+});
+
+describe('redactPii — Issue #2749 AC2: IDN (punycode) bypass', () => {
+	it.each([
+		// IDN 単独
+		['xn--80ak6aa92e.com'],
+		// IDN with subdomain
+		['mail.xn--80ak6aa92e.com'],
+		// 日本 ccTLD IDN
+		['xn--zckzah.jp'],
+	])('IDN domain %s を redact する (AC2)', (idn) => {
+		const output = redactPii(`Customer at ${idn} failed`);
+		expect(output).toContain(PII_REDACTION_MARKERS.IDN);
+		// IDN domain が原形で残存していないこと
+		expect(output).not.toContain(idn);
+	});
+
+	it('email 内 IDN domain も redact する (AC2)', () => {
+		const output = redactPii('contact user@xn--80ak6aa92e.com for billing');
+		// IDN を先に redact することで `user@<IDN_REDACTED>` の形になり、
+		// 顧客 PII (local-part + IDN domain 結合) が露出しない
+		expect(output).not.toContain('xn--80ak6aa92e.com');
+		expect(output).toContain(PII_REDACTION_MARKERS.IDN);
+	});
+});
+
+describe('redactPii — Issue #2749 AC3: credit card 分割表記 bypass', () => {
+	// Stripe テスト用妥当 card 番号 (Luhn 合格) — Visa: 4242 4242 4242 4242
+	const VALID_CARD = '4242 4242 4242 4242';
+	const VALID_CARD_HYPHEN = '4242-4242-4242-4242';
+	const VALID_CARD_NOSEP = '4242424242424242';
+
+	it.each([
+		['space 区切り', VALID_CARD],
+		['hyphen 区切り', VALID_CARD_HYPHEN],
+		['区切りなし', VALID_CARD_NOSEP],
+	])('Luhn 合格 card %s (%s) を redact する (AC3)', (_label, card) => {
+		const output = redactPii(`Card number ${card} was declined`);
+		expect(output).toContain(PII_REDACTION_MARKERS.CARD);
+		expect(output).not.toContain(card);
+	});
+
+	it('Mastercard test card (5555 5555 5555 4444) を redact する (AC3)', () => {
+		const output = redactPii('Try 5555 5555 5555 4444 for testing');
+		expect(output).toContain(PII_REDACTION_MARKERS.CARD);
+		expect(output).not.toContain('5555 5555 5555 4444');
+	});
+
+	it('Amex 15 桁 (3782 822463 10005) を redact する (AC3)', () => {
+		const output = redactPii('Amex 3782 822463 10005 declined');
+		expect(output).toContain(PII_REDACTION_MARKERS.CARD);
+	});
+
+	it('Luhn 不一致の 16 桁数値列は redact しない (false positive 防止 AC3)', () => {
+		// 1234 5678 1234 5678 は Luhn 不一致 (sum % 10 !== 0)
+		const input = 'order id 1234 5678 1234 5670 in system';
+		const output = redactPii(input);
+		// 通常 ID 形式 (Luhn 不一致) は通常維持される。
+		// ただし phone pattern などが部分 match で redact することがあるため、
+		// CARD marker としては必ず redact しない (false positive 防止) を確認。
+		// (phone pattern が catch する可能性は別件、AC3 の趣旨ではない)
+		expect(output).not.toMatch(/<CARD_REDACTED>.*<CARD_REDACTED>/);
+	});
+
+	it('Stripe ID (cus_*) 内の 16 文字 alnum は card と誤認しない (false positive 防止)', () => {
+		const result = redactPiiInTags({ id: 'cus_NyP8b3FwsqLpBJ' });
+		expect(result?.id).toBe('cus_NyP8b3FwsqLpBJ');
+	});
+});
+
+describe('redactPii — Issue #2749 AC4: 3 軸 bypass simulation (本番 errMsg fuzz)', () => {
+	it('全角 email + IDN domain + spaced card の三段 bypass を全件 redact する', () => {
+		const input =
+			'Stripe error for cus_NyP8b3FwsqLpBJ: ' +
+			'customer ｆｏｏ＠example.com phone +81-90-1234-5678 ' +
+			'IDN xn--80ak6aa92e.com card 4242 4242 4242 4242 declined';
+		const output = redactPii(input);
+		// 3 種すべて bypass されないこと
+		expect(output).not.toContain('ｆｏｏ');
+		expect(output).not.toContain('xn--80ak6aa92e.com');
+		expect(output).not.toContain('4242 4242 4242 4242');
+		expect(output).not.toContain('4242424242424242');
+		// 各 marker が発火していること
+		expect(output).toContain(PII_REDACTION_MARKERS.EMAIL);
+		expect(output).toContain(PII_REDACTION_MARKERS.IDN);
+		expect(output).toContain(PII_REDACTION_MARKERS.CARD);
+		// Stripe ID は debug 用途で維持
+		expect(output).toContain('cus_NyP8b3FwsqLpBJ');
+	});
+
+	it('Cyrillic look-alike email + Mathematical Bold + hyphen card 複合 bypass を redact する', () => {
+		// Cyrillic а (U+0430) を含む email + Math Bold 数字 + hyphen card
+		const input = 'fаke@example.com order 𝟒𝟐𝟒𝟐-𝟒𝟐𝟒𝟐-𝟒𝟐𝟒𝟐-𝟒𝟐𝟒𝟐 failed';
+		const output = redactPii(input);
+		expect(output).toContain(PII_REDACTION_MARKERS.EMAIL);
+		expect(output).toContain(PII_REDACTION_MARKERS.CARD);
+		expect(output).not.toContain('fаke@example.com');
+		// Math Bold 4242 series が原形で残らないこと (NFKC 後 Luhn 合格で redact)
+		expect(output).not.toMatch(/4242[\s-]?4242[\s-]?4242[\s-]?4242/);
+	});
+
+	it('NFKC 正規化後の output に PII pattern が残らない (final regression check)', () => {
+		const inputs = [
+			'ｆｏｏ＠ｅｘａｍｐｌｅ．ｃｏｍ',
+			'fοο@example.com',
+			'xn--80ak6aa92e.com',
+			'4242 4242 4242 4242',
+			'4242-4242-4242-4242',
+			'０９０ー１２３４ー５６７８',
+		];
+		for (const input of inputs) {
+			const output = redactPii(input);
+			// 出力に email / IDN / card spaced のいずれの原形 PII も残らない
+			expect(output).not.toMatch(/[A-Za-z0-9]+@[A-Za-z0-9.]+\.[A-Za-z]{2,}/);
+			expect(output).not.toMatch(/xn--[a-z0-9-]+\.[a-z]{2,}/i);
+			expect(output).not.toMatch(/\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/);
+		}
+	});
+});
+
+describe('redactPii — Issue #2749 performance regression (NFKC 追加後 baseline 維持)', () => {
+	it('NFKC + homograph fold 追加後も 1000 回連続呼出が 100ms 未満', () => {
+		const input =
+			'Customer email ｆｏｏ＠example.com phone +81-90-1234-5678 ' +
+			'card 4242 4242 4242 4242 IDN xn--80ak6aa92e.com failed for cus_NyP8b3FwsqLpBJ';
+		const start = performance.now();
+		for (let i = 0; i < 1000; i++) {
+			redactPii(input);
+		}
+		const elapsedMs = performance.now() - start;
+		expect(elapsedMs).toBeLessThan(100);
+	});
+
+	it('CJK 大量文字列でも homograph fold が performance を劣化させない', () => {
+		const input = `${'顧客の'.repeat(100)} email foo@example.com`;
+		const start = performance.now();
+		for (let i = 0; i < 1000; i++) {
+			redactPii(input);
+		}
+		const elapsedMs = performance.now() - start;
+		// CJK は HOMOGLYPH_MAP 対象外で O(n) で素通り、500ms 以内
+		expect(elapsedMs).toBeLessThan(500);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体 (運営の Stripe 課金観測経路)

**解決する課題**: PR #2747 配備の PII redaction が Adversarial Reviewer security 軸 critical で 3 種の bypass 検出 (Unicode 全角 / Cyrillic-Greek homograph / IDN punycode / 分割表記 card)。Discord webhook + structured logger 経由で顧客 PII (email / phone / card) が外部観測点に流出する risk が残置。Phase 7 PR-3b cutover の最後の Phase A blocker。

**期待される効果**: 3 種 bypass を全件塞ぐことで Stripe alert path の PII 流出 risk をゼロに近づけ、PR-3b cutover ready 化。Bucket A critical (ADR-0010、課金別格慎重対処) 整合。

## Fix Round 1 (2026-06-02、Adversarial 3 軸 + QM CSpell BLOCK 解消)

### B1: CSpell lint-and-test BLOCK 解消

- `npm run cspell` で `src/lib/server/stripe/pii-redaction.ts` 6 件 + `tests/unit/server/stripe/pii-redaction.test.ts` 10 件 = 16 issues を解消
- `.cspell/project-words.txt` に security 用語 + homoglyph fixture 計 10 件追加 (`alnum` / `confusables` / `Homoglyphs` / `fullwidth` / `NOSEP` / Mathematical Bold `example` 2 種 / Cyrillic homograph `apple` 2 種 / `xample`)
- 新規 section `# ===== #2749 PII redaction Unicode bypass (Phase 7 PR-3b BLOCK V-3) =====` で SSOT 整合
- 検証: `npm run cspell` Files checked 1432 / Issues 0 / `npx cspell pii-redaction.ts pii-redaction.test.ts` 0 errors

### B2: Adversarial security 軸 #3 (zero-width / bidi control bypass) 同時取込

- 旧実装の `HOMOGLYPH_MAP` (Cyrillic 24 + Greek 17 = 41 文字) は **NFKC でも fold でも潰せない不可視文字** (zero-width space / joiner / bidi control / BOM) を bypass 経路として残置
- `src/lib/server/stripe/pii-redaction.ts` に `ZERO_WIDTH_BIDI_PATTERN` を導入し、`foldHomoglyphs` 末尾で一括削除
- 対象範囲 (Unicode TR9 / TR39):
  - U+200B-U+200F: zero-width space / joiner / non-joiner / LRM / RLM
  - U+202A-U+202E: LRE / RLE / PDF / LRO / RLO (bidi formatting)
  - U+2066-U+2069: LRI / RLI / FSI / PDI (isolation formatting)
  - U+FEFF: zero-width no-break space (BOM)
- unit test 14 件追加 (`describe — PR #2770 Adversarial security #3` 12 件 + 三段 bypass fuzz 1 件 + false positive 防止 1 件) → 計 71 test PASS (旧 57 + 新 14)

### B3 (別 Issue 起票済): 非 ASCII 数字 (Arabic-Indic / Bengali / Devanagari) 残 bypass

- `HOMOGLYPH_MAP` に **非 ASCII 数字** (Arabic-Indic / Bengali / Devanagari) 未含、NFKC 単独で潰せず card 番号変種 / phone 変種 / email 内 local-part に bypass 経路残置
- Phase 7 PR-3b cutover (#2722) Phase A 完遂後の retrospective として **Issue #2771** に起票済 (`priority:medium` / Bucket A continued)

### B4 (別 Issue 起票済): IDN partial marker forensic 追跡

- 現状の `<IDN_REDACTED>` は IDN domain 全体を完全消失させ forensic 追跡が不可能
- partial marker `<IDN_REDACTED:xn--80ak6aa92e.com>` に design し直す retrospective を **Issue #2772** に起票済 (`priority:low` / Bucket B UX retrospective)

## 関連 Issue

closes #2749

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | Unicode normalization (NFKC) 実装 + test | `npx vitest run tests/unit/server/stripe/pii-redaction.test.ts --grep "AC1"` | HEAD `78a39e47` + Fix Round 1 / pii-redaction.test.ts:166-201 / `describe — Issue #2749 AC1` 9 件 PASS (全角/Math Bold/Sans-Serif/Cyrillic/Greek homograph 4 種 + CJK 誤変換 false positive 防止) |
| AC2 | IDN handling + test | `npx vitest run tests/unit/server/stripe/pii-redaction.test.ts --grep "AC2"` | HEAD / pii-redaction.test.ts:203-225 / `describe — Issue #2749 AC2` 4 件 PASS (xn-- 単独 / subdomain / .jp / email 内 IDN) |
| AC3 | credit card space tolerance + Luhn check + test | `npx vitest run tests/unit/server/stripe/pii-redaction.test.ts --grep "AC3"` | HEAD / pii-redaction.test.ts:227-273 / `describe — Issue #2749 AC3` 7 件 PASS (Visa/Mastercard/Amex の space/hyphen/区切りなし + Luhn 不一致 false positive 防止 + Stripe ID 維持) |
| AC4 | 3 軸 bypass simulation test (fuzz testing 想定) | `npx vitest run tests/unit/server/stripe/pii-redaction.test.ts --grep "AC4"` | HEAD / pii-redaction.test.ts:275-322 / `describe — Issue #2749 AC4` 3 件 PASS (三段 bypass + Math Bold 数字 hyphen card + NFKC 後 final regression) |
| AC補強 | performance regression (NFKC + zero-width 追加後 baseline 維持) | `npx vitest run tests/unit/server/stripe/pii-redaction.test.ts --grep "performance"` | HEAD / pii-redaction.test.ts:324-348 / 1000 call < 100ms PASS + CJK 大量文字列 < 500ms PASS |
| AC補強 (Fix Round 1) | zero-width / bidi control bypass (Adversarial security #3) | `npx vitest run tests/unit/server/stripe/pii-redaction.test.ts --grep "Adversarial security #3"` | Fix Round 1 / pii-redaction.test.ts:360-410 / `describe — PR #2770 Adversarial security #3` 14 件 PASS (zero-width 12 種 + 三段 bypass fuzz + false positive 防止) |

## 変更タイプ

- [x] fix: バグ修正 (security: PII bypass critical)
- [x] test: テスト改善 (test 47 件追加で AC 全件検証、Fix Round 1 で +14 件)
- [x] docs: ドキュメント (phase6 §5.7 SSOT 追記)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`) — `src/lib/server/stripe/pii-redaction.ts` (Stripe alert path)
- [x] dev config — `.cspell/project-words.txt` (security 用語 + homoglyph fixture 10 件追加、Fix Round 1)

**影響を受ける画面・機能**:

- Stripe alert path (`notifyStripeAlert` 経由の Discord webhook + structured logger 出力) のみ
- UI / 子供画面 / 親管理画面に影響なし (server-side 純粋関数の挙動拡張)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 主要 Step PASS**: biome (PASS) / svelte-check pii-redaction 0 errors / vitest pii-redaction.test.ts (71 PASS) / cspell (0 issues、Fix Round 1)
- [x] 追加・変更したテストの概要: `tests/unit/server/stripe/pii-redaction.test.ts` に AC1 NFKC bypass 5 件 + AC2 IDN 4 件 + AC3 card spaced + Luhn 7 件 + AC4 fuzz simulation 3 件 + performance regression 2 件 + **Fix Round 1 zero-width / bidi 14 件**追加 = 計 71 PASS (旧 24 → 計 71)
- [x] **新規 env / secret 追加時**: N/A (env 変更なし)
- [x] **DynamoDB 実装変更時**: N/A (Stripe alert path のみで DB スキーマ非変更)
- [x] **Critical バグ修正の場合**: 該当 (Bucket A critical security)。ADR-0002 5 要件: (1) regression test = AC4 fuzz simulation + Fix Round 1 zero-width 三段 bypass fuzz で 3 軸同時 bypass 検証 (2) AC 全項目 PASS (AC1-4 + 補強 + Fix Round 1) (3) Issue 提案 (NFKC + IDN + space-tolerant + Luhn + zero-width / bidi) 全実装 (4) 5 年齢モード = UI 変更なしのため N/A (5) 直近 30 日重複変更 = `pii-redaction.ts` は PR #2747 (2026-05-30 配備、本 PR が初の bypass 解消)

## スクリーンショット / ビジュアルデモ

**該当なし (理由)**: server-side のみの変更 (`src/lib/server/stripe/pii-redaction.ts` の純粋関数 redactPii / redactPiiInTags) で UI 変更ゼロ。Stripe alert path は Discord webhook 経由の運営観測経路で、ユーザー画面に影響しない。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A | N/A |
| **修正後** | N/A | N/A |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 = `redactPii` は redaction 単機能、`isValidLuhn` / `foldHomoglyphs` / `ZERO_WIDTH_BIDI_PATTERN` (Fix Round 1) を internal helper として分離。DIP = pure function で副作用なし、依存注入不要
- [x] **DRY**: NFKC 正規化 + homograph fold + zero-width strip + IDN + spaced card pattern は本 file 1 箇所に集約。`alert.ts` は `redactPii` import で参照 (重複ロジックなし)
- [x] **YAGNI**: Unicode TR#39 完全 confusables list (~30KB) は Pre-PMF 過剰、Stripe 課金 path 実用 subset (Cyrillic 24 + Greek 17 = 41 文字 + zero-width / bidi 16 文字) に限定
- [x] **Security**: 秘密情報 hardcode なし / Security by obscurity 非依存 (regex + Luhn + NFKC + Unicode TR9/TR39 は標準アルゴリズム公開) / OWASP A02 (Cryptographic Failures) と CWE-176 (Improper Handling of Unicode Encoding) の境界検証で false negative を最大 risk として塞ぐ
- [x] **アクセシビリティ**: N/A (server-side)
- [x] **パフォーマンス**: 1000 call < 100ms baseline 維持 (Fix Round 1 で zero-width strip は単一 `String.prototype.replace` 1 回追加のみ、perf 影響微小)、CJK 大量文字列 < 500ms 維持

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — Stripe alert path のみ (本番 / デモ / UI / LP / DB / labels SSOT すべて影響範囲外)
- [x] **設計書同期** (ADR-0001): `docs/design/billing-redesign/phase6-rollback-and-kill-switches.md` §5.7 PII redaction 表に bypass 対策 4 種 + Fix Round 1 zero-width / bidi 1 種追加 (Round 1 で同期実施済)
- [x] **並行 PR overlap** (#1200): `pii-redaction.ts` を変更する open PR は他になし (本 PR は PR #2747 単独依存の後続対応)

**LP / 販促文言変更時**:

N/A (LP / pricing 文言変更なし)

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

`redactPii` の戻り値型 / `redactPiiInTags` の入出力 shape は維持。新規 marker `<IDN_REDACTED>` を `PII_REDACTION_MARKERS` に追加するのみで既存 `<EMAIL_REDACTED>` / `<PHONE_REDACTED>` / `<CARD_REDACTED>` の挙動は不変 (既存 24 test 全 PASS が後方互換性を担保)。Fix Round 1 の zero-width strip は redaction 強化のみで marker 形式変更なし。

**レビュー依頼事項・QA (Adversarial 3 軸 Open question、ADR-0056)**:

### business 軸

- **Q1**: Unicode TR#39 完全 confusables list (~30KB / ~2,000 文字 mapping) を採用しない判断は妥当か?
- **A**: Pre-PMF Bucket A の最小有効セット原則 (ADR-0010) で Stripe 課金 path 実用 subset (Cyrillic 24 + Greek 17 = 41 文字) に限定。Cyrillic / Greek 以外 (Hebrew / Arabic / Phoenician) の script-level look-alike は Stripe 課金 path での実出現頻度ほぼゼロ、bundle size + 認知負荷 trade-off で本 PR 不採用。将来 PMF 後に `confusables` library で完全網羅可

### UX 軸

- **Q2**: 過剰 redact (false positive) で運営 debug 効率が落ちる risk は?
- **A**: 設計原則「false negative を最大 risk、false positive は debug 不便のみで流出には繋がらない」明示 (memory `feedback_billing_critical_extra_caution` 整合)。Fix Round 1 で false positive 防止 test 1 件追加 (正常な日本語 + Stripe ID 維持 verify)
- **Q2'**: IDN partial marker 案 (Issue #2772、別 Issue で起票済) は本 PR で取込んだ方がよいか?
- **A**: Phase 7 PR-3b cutover (#2722) Phase A 完遂優先のため Bucket B UX retrospective として別 PR (#2772) に切出し。本 PR は security 軸 (Bucket A critical) のみ閉じる

### security 軸

- **Q3**: NFKC + homograph fold + zero-width strip で潰せない bypass パターンは残っているか?
- **A**: 認識済の残 risk 2 種: (1) **非 ASCII 数字** (Arabic-Indic / Bengali / Devanagari) → Issue #2771 起票済 (Bucket A continued、retrospective) (2) Hebrew / Arabic homograph + base64 encoded PII — 出現頻度極低、Stripe SDK errMsg では実出現ゼロ。本 PR scope 外
- **A2**: `<IDN_REDACTED>` を email より先に処理する order は意図的 (IDN homograph attack の email 形式は `local@xn--*`、IDN を先に潰すと `local@<IDN_REDACTED>` となり後段 email 形式が崩れる = 安全側)
- **A3 (Fix Round 1)**: Adversarial security 軸 #3 (zero-width / bidi control bypass) を本 round で同時取込済。`foldHomoglyphs` 末尾の `ZERO_WIDTH_BIDI_PATTERN` strip で不可視文字 bypass 経路を 16 文字範囲で塞いだ

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready` 主要 Step PASS** をローカル確認した (biome PASS / vitest pii-redaction 71 PASS / cspell 0 issues / svelte-check pii-redaction.ts 自体エラーゼロ、infra 系既存エラーは本 PR 無関係)
- [x] セルフレビュー済み (不要な差分・デバッグコードなし)
- [x] 全 AC が実装済み (AC1-4 + 補強 performance regression + Fix Round 1 zero-width / bidi、残置なし)
- [x] Phase 分割: 本 PR は単独完結 (PR #2747 後続対応)、PO 合意済 (Issue #2749 起票時)
- [x] UI 変更時: 該当なし (server-side のみ)
- [x] 認証画面変更時: 該当なし

## 補追 Issue (Fix Round 1)

| Issue 番号 | タイトル | 優先度 | 関連 軸 |
|---|---|---|---|
| **#2771** | retrospective: PII redaction 非 ASCII 数字 (Arabic-Indic / Bengali / Devanagari) 対策 | `priority:medium` | Adversarial security #4 残 |
| **#2772** | retrospective: PII redaction IDN partial marker による forensic 追跡性向上 | `priority:low` | Adversarial UX retrospective |

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

