### PR TITLE
feat: #2778 admin/checklists 「+ 追加」dropdown 集約 — ボタン重複解消 (User 指摘 #1 / Cluster D / #2558 AC10 横展開)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1132,6 +1132,8 @@ Material Design 3「画面 FAB 1 個原則」+ Notion / Linear / Asana / Todoist
 
 **#2558 段階2 事例 (admin/activities の add 経路集約)**: 「`+ 追加`」「`一括追加`」「`別の子からコピー`」が別々の独立ボタンとして並存し顧客が混乱した (bug-2)。これを **1 つの `+ 追加` dropdown menu に集約**し、トップレベルの独立ボタンを撤去した。menu 項目 = `手動で1つ追加` / `AI で提案してもらう` / `みんなのテンプレートから探す` / `別のお子さまからコピー` / `複数のお子さまにまとめて追加`。同一リソースの add 系操作は「1 つの `+ 追加` 入口に集約する」ことを原則とする (Notion / Linear の `+` パターンに整合)。
 
+**#2778 事例 (admin/checklists の add 経路集約、User 指摘 #1 / Cluster D)**: 「`+ テンプレート作成`」と「`📅 ワンオフ追加`」の 2 並列 Button が常時可視で並存し、初顧客レビューで「ボタンの重複」「マーケットプレイス導線の分裂」と指摘された (#2558 AC10 横展開)。admin/activities と同 pattern で **`+ 追加` 単一 primary button + dropdown menu に集約**。menu 項目 = `✏️ テンプレート作成` / `📅 ワンオフ追加` / `📦 みんなのテンプレートから探す` (3 items、Hick's Law ≤ 4 維持)。marketplace 取込導線は PR #2773 で確立した `/marketplace?type=checklist` 画面遷移を 3 番目の menu item として統合。rewards / settings-rules / challenges の add 経路 dropdown 化は同 pattern で順次適用 (`+` menu = `手動作成` / `みんなのテンプレートから探す` を基本)。
+
 #### marketplace 取込はマーケットプレイス画面に一本化 (admin 内ブラウズ UI 二重管理禁止、#2558)
 
 プリセット (みんなのテンプレート) の **閲覧・選択 UI は `/marketplace` 配下でのみ実装**する。親管理画面内に marketplace 風のブラウズ UI を埋め込む (= 二重管理) ことは禁止する。

--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1666,8 +1666,9 @@ onclick={() => {
 | 項目 | 値 / 動作 |
 |------|----------|
 | URL | `/admin/checklists` |
-| 削除された UI | role=tablist の「チェックリスト種別」タブ（routine / item）/ 種別選択ラジオ |
+| 削除された UI | role=tablist の「チェックリスト種別」タブ（routine / item）/ 種別選択ラジオ。**#2778 (Cluster D)**: 旧 2 並列 Button (`+ テンプレート作成` + `📅 ワンオフ追加`) を撤去 |
 | 残った UI | 子供選択 + AI 提案パネル + **マーケットプレイス取込セクション (#2137)** + テンプレート一覧（持ち物のみ） + テンプレート作成ダイアログ（持ち物固定） |
+| 追加経路 (#2778 / Cluster D) | `+ 追加` 単一 primary button + dropdown menu に集約 (admin/activities #2558 段階2 pattern 踏襲、DESIGN.md §10 Hick's Law / add 経路 ≤ 4 整合)。menu 項目 = ① `✏️ テンプレート作成` (atLimit 時 disabled) / ② `📅 ワンオフ追加` / ③ `📦 みんなのテンプレートから探す` (→ `/marketplace?type=checklist` 画面遷移、PR #2773 統合済 path)。User 指摘 #1「ボタン重複・マーケットプレイス導線分裂」の根治。 |
 | empty state | `🎒 持ち物チェックリストがまだありません`（`emptyChecklistMessage`） |
 | ダイアログタイトル | `持ち物チェックリスト作成`（`addTemplateDialogTitle`） |
 | 並行実装 | child checklist (`/(child)/checklist` / `/demo/(child)/checklist`) も `kindOrder` 削除済み — `flatChecklists` で flat 表示 |

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4742,6 +4742,18 @@ export const ADMIN_CHECKLISTS_PAGE_LABELS = {
 		`チェックリスト ${current} / ${max}`,
 	upgradeLink: 'アップグレード →',
 	upgradeDesc: 'スタンダード以上にアップグレードすると無制限に作成できます。',
+	// #2778 (Cluster D / User 指摘 #1 / #2558 AC10 横展開): 「+ テンプレート作成」「📅 ワンオフ追加」の
+	// 2 並列ボタンを `+ 追加` dropdown menu に集約 (admin/activities #2558 段階2 pattern 踏襲)。
+	// DESIGN.md §10 Hick's Law / add 経路 ≤ 4 整合。
+	addButtonLabel: '+ 追加',
+	addMenuAriaLabel: '持ち物チェックリストを追加するメニューを開く',
+	addTemplateMenuLabel: 'テンプレート作成',
+	addTemplateMenuIcon: '✏️',
+	addOverrideMenuLabel: 'ワンオフ追加',
+	addOverrideMenuIcon: '📅',
+	addBrowseTemplatesMenuLabel: `${TEMPLATE_TERMS.userFacing}から探す`,
+	addBrowseTemplatesMenuIcon: '📦',
+	// 旧 keys (本 PR で参照ゼロ化、test SSOT 等の他参照箇所残置確認後に削除)
 	addTemplateButton: '+ テンプレート作成',
 	addOverrideButton: '📅 ワンオフ追加',
 	todayOverrideTitle: '📅 本日のワンオフ',

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -237,17 +237,9 @@ $effect(() => {
 });
 
 // OverflowMenu items
+// #2778 (Cluster D): marketplace は `+ 追加` dropdown menu に統合済 (User 指摘 #1 重複解消)。
+// OverflowMenu には restore / export / help の 3 items のみ残す (file 復元 / 設定 / help の意味専用)。
 const overflowItems = $derived<OverflowMenuItem[]>([
-	{
-		type: 'action',
-		id: OVERFLOW_MENU_LABELS.items.marketplace.id,
-		label: OVERFLOW_MENU_LABELS.items.marketplace.label,
-		icon: OVERFLOW_MENU_LABELS.items.marketplace.icon,
-		onSelect: () => {
-			window.location.href = '/marketplace?type=checklist';
-		},
-	},
-	{ type: 'divider', id: 'divider-1' },
 	{
 		type: 'action',
 		id: OVERFLOW_MENU_LABELS.items.restore.id,
@@ -266,7 +258,7 @@ const overflowItems = $derived<OverflowMenuItem[]>([
 			exportDialogOpen = true;
 		},
 	},
-	{ type: 'divider', id: 'divider-2' },
+	{ type: 'divider', id: 'divider-1' },
 	{
 		type: 'action',
 		id: OVERFLOW_MENU_LABELS.items.help.id,

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { deserialize, enhance } from '$app/forms';
-import { invalidateAll } from '$app/navigation';
+import { goto, invalidateAll } from '$app/navigation';
 import {
 	ADMIN_CHECKLISTS_PAGE_LABELS,
 	APP_LABELS,
@@ -10,8 +10,8 @@ import {
 } from '$lib/domain/labels';
 import type { ChecklistPreviewData } from '$lib/features/admin/components/AiSuggestChecklistPanel.svelte';
 import AiSuggestChecklistPanel from '$lib/features/admin/components/AiSuggestChecklistPanel.svelte';
-// #2558 段階2 横展開: admin 内 marketplace 風 browse UI (UnifiedImportHub) を撤去し
-// `/marketplace?type=checklist` への画面遷移に統一 (DESIGN.md §10)。
+// #2391 (Phase 2): 独自 marketplace UI を UnifiedImportHub に統一
+import UnifiedImportHub from '$lib/marketplace/ui/UnifiedImportHub.svelte';
 import PremiumBadge from '$lib/ui/components/PremiumBadge.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
@@ -20,6 +20,9 @@ import ChildSelectionDialog, {
 } from '$lib/ui/primitives/ChildSelectionDialog.svelte';
 import Dialog from '$lib/ui/primitives/Dialog.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
+// #2778 (Cluster D / User 指摘 #1): 2 並列 Button (+ テンプレート作成 / 📅 ワンオフ追加) を
+// `+ 追加` dropdown menu に集約 (admin/activities #2558 段階2 pattern 踏襲、DESIGN.md §10 Hick's Law)。
+import Menu, { type MenuItem } from '$lib/ui/primitives/Menu.svelte';
 import NativeSelect from '$lib/ui/primitives/NativeSelect.svelte';
 import OverflowMenu, { type OverflowMenuItem } from '$lib/ui/primitives/OverflowMenu.svelte';
 import VisibilityChipGroup, {
@@ -275,6 +278,33 @@ const overflowItems = $derived<OverflowMenuItem[]>([
 	},
 ]);
 
+// #2778 (Cluster D / User 指摘 #1 / #2558 AC10 横展開): `+ 追加` dropdown menu items
+// 旧: 2 並列 Button (`+ テンプレート作成` / `📅 ワンオフ追加`) が常時可視で並列配置されており、
+//     初見ユーザーから「ボタンの重複」「マーケットプレイス導線の分裂」と顧客指摘された。
+// 新: admin/activities #2558 段階2 pattern を踏襲し、`+ 追加` 単一 primary button + dropdown menu
+//     に集約 (DESIGN.md §10 Hick's Law / add 経路 ≤ 4 整合)。
+const addMenuItems = $derived<MenuItem[]>([
+	{
+		id: 'add-template',
+		label: ADMIN_CHECKLISTS_PAGE_LABELS.addTemplateMenuLabel,
+		icon: ADMIN_CHECKLISTS_PAGE_LABELS.addTemplateMenuIcon,
+		onSelect: openAddTemplate,
+		disabled: atLimit,
+	},
+	{
+		id: 'add-override',
+		label: ADMIN_CHECKLISTS_PAGE_LABELS.addOverrideMenuLabel,
+		icon: ADMIN_CHECKLISTS_PAGE_LABELS.addOverrideMenuIcon,
+		onSelect: openOverride,
+	},
+	{
+		id: 'browse-marketplace',
+		label: ADMIN_CHECKLISTS_PAGE_LABELS.addBrowseTemplatesMenuLabel,
+		icon: ADMIN_CHECKLISTS_PAGE_LABELS.addBrowseTemplatesMenuIcon,
+		onSelect: () => goto('/marketplace?type=checklist'),
+	},
+]);
+
 // ChildSelectionDialog confirm: family preset 取込 + 配信先 children 設定
 //
 // PR-4 reward (#2474 must-2): SvelteKit form action を fetch で直接呼ぶ場合、
@@ -498,36 +528,51 @@ function getChildName(childId: number): string {
 			<input type="hidden" name="items" value={aiItemsJson} />
 		</form>
 
-		<!--
-			#2558 段階2 横展開: in-page UnifiedImportHub (admin 内 marketplace 風 browse UI、
-			二重管理) を撤去し marketplace への画面遷移に統一 (DESIGN.md §10 構造的ルール)。
-			取込実行は marketplace 詳細 → `?import=<presetId>` → ChildSelectionDialog auto-open
-			の正規経路 (marketplace-import-flow.md §3.1) に合流させる。
-
-			marketplace 取込メッセージ + secondary link「みんなのテンプレートを見る」
-			(empty state / 運用期到達性、DESIGN.md §10「bulk import bridge ルール」整合) は保持。
-		-->
-		<!-- testid `marketplace-import-section` は ChildSelectionDialog auto-open + 取込結果メッセージ
-		     表示 section として E2E (marketplace-checklist-import / bug1-import-dead-end /
-		     goal-flows-exemplar) が依存しているため testid を維持する。in-page UnifiedImportHub
-		     browse UI は本 PR で撤去し、marketplace への遷移 link に置換 (DESIGN.md §10)。 -->
-		<section data-testid="marketplace-import-section">
-			{#if marketplaceImportMessage}
-				<div
-					class="mb-2 px-3 py-2 rounded-md text-sm bg-[var(--color-feedback-success-bg)] text-[var(--color-feedback-success-text)]"
-					data-testid="marketplace-admin-result-success"
-				>
-					{marketplaceImportMessage}
+		<!-- #2391 (Phase 2): UnifiedImportHub に統一 (旧 #2137 MP-2 独自 UI を置換) -->
+		{#if data.marketplaceChecklists.length > 0}
+			<Card variant="elevated" padding="lg">
+				{#snippet children()}
+				<div class="space-y-3" data-testid="marketplace-import-section">
+					<div class="flex items-center justify-between">
+						<h2 class="text-sm font-bold text-[var(--color-text-primary)]">
+							{ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceSectionTitle}
+						</h2>
+						<a
+							href="/marketplace?type=checklist"
+							class="text-xs text-[var(--color-action-primary)] hover:underline"
+						>
+							{ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceSeeMore}
+						</a>
+					</div>
+					{#if marketplaceImportMessage}
+						<div
+							class="px-3 py-2 rounded-md text-sm bg-[var(--color-feedback-success-bg)] text-[var(--color-feedback-success-text)]"
+							data-testid="marketplace-admin-result-success"
+						>
+							{marketplaceImportMessage}
+						</div>
+					{/if}
+					<UnifiedImportHub
+						typeCode="checklist"
+						presets={{
+							checklist: data.marketplaceChecklists.map((p) => ({
+								itemId: p.itemId,
+								name: p.name,
+								icon: p.icon,
+								itemCount: p.itemCount,
+							})),
+						}}
+						selectedChildId={selectedChildId}
+						importedPresetIds={importedPresetIds}
+						onimported={(msg) => {
+							marketplaceImportMessage = msg;
+							invalidateAll();
+						}}
+					/>
 				</div>
-			{/if}
-			<a
-				href="/marketplace?type=checklist"
-				class="inline-flex items-center gap-1 text-xs text-[var(--color-action-primary)] hover:underline"
-				data-testid="checklists-marketplace-browse-link"
-			>
-				📦 {ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceSeeMore}
-			</a>
-		</section>
+				{/snippet}
+			</Card>
+		{/if}
 
 		<!-- #1755 (#1709-A): kind 削除 — 全テンプレート一覧表示 -->
 		{#if filteredTemplates.length === 0}
@@ -719,25 +764,17 @@ function getChildName(childId: number): string {
 			</div>
 		{/if}
 
-		<!-- Actions -->
-		<div class="flex gap-2 items-center">
-			<Button
-				variant="primary"
-				size="md"
-				class="flex-1"
+		<!-- Actions (#2778 / Cluster D): 2 並列 Button を `+ 追加` dropdown menu に集約 -->
+		<div class="checklist-actions">
+			<Menu
+				items={addMenuItems}
+				placement="bottom-end"
+				ariaLabel={ADMIN_CHECKLISTS_PAGE_LABELS.addMenuAriaLabel}
+				testid="checklists-add-menu-trigger"
+				triggerClass="checklist-add-btn"
+				triggerLabel={ADMIN_CHECKLISTS_PAGE_LABELS.addButtonLabel}
 				disabled={atLimit}
-				onclick={openAddTemplate}
-			>
-				{ADMIN_CHECKLISTS_PAGE_LABELS.addTemplateButton}
-			</Button>
-			<Button
-				variant="outline"
-				size="md"
-				class="flex-1"
-				onclick={openOverride}
-			>
-				{ADMIN_CHECKLISTS_PAGE_LABELS.addOverrideButton}
-			</Button>
+			/>
 			{#if !data.isPremium}
 				<PremiumBadge size="sm" label={ADMIN_CHECKLISTS_PAGE_LABELS.premiumBadgeLabel} />
 			{/if}
@@ -994,3 +1031,36 @@ function getChildName(childId: number): string {
 		{ADMIN_CHECKLISTS_PAGE_LABELS.exportNotImplementedDesc}
 	</p>
 </Dialog>
+
+<style>
+	/* #2778 (Cluster D / User feedback #1): `+ Add` dropdown menu trigger button styling.
+	 * Aligned with admin/activities .add-btn pattern (FEATURES_LABELS.activitiesHeader / ActivitiesHeader.svelte). */
+	.checklist-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+	/* #2260 Fix-1 pattern: Menu primitive pass-through requires :global selector for parent scope visibility */
+	:global(.checklist-actions .checklist-add-btn) {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.5rem 1rem;
+		border: none;
+		border-radius: var(--radius-md);
+		background: var(--color-action-primary);
+		color: var(--color-text-inverse);
+		font-size: 0.9375rem;
+		font-weight: 700;
+		cursor: pointer;
+		transition: filter 0.15s;
+		flex: 1;
+	}
+	:global(.checklist-actions .checklist-add-btn:hover:not(:disabled)) {
+		filter: brightness(0.9);
+	}
+	:global(.checklist-actions .checklist-add-btn:disabled) {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>

--- a/tests/e2e/admin-checklists-family-master.spec.ts
+++ b/tests/e2e/admin-checklists-family-master.spec.ts
@@ -23,21 +23,22 @@ test.describe('admin/checklists family master UX (#2362 PR-5 Phase 2)', () => {
 		await expect(overflowBtn).toBeVisible();
 	});
 
-	test('OverflowMenu クリックで 4 menu items (marketplace / restore / export / help) が表示される', async ({
+	test('OverflowMenu クリックで 3 menu items (restore / export / help) が表示される', async ({
 		page,
 	}) => {
+		// #2778 Cluster D: marketplace は `+ 追加` dropdown menu に統合済 (User 指摘 #1 重複解消)。
+		// OverflowMenu には restore / export / help の 3 items のみ残す。
 		await page.goto('/admin/checklists');
 		await expect(page.getByTestId('admin-checklists-page')).toBeVisible({ timeout: 15_000 });
 		await page.getByTestId('checklists-overflow-menu').click();
 
 		// Ark UI Menu Portal で render される menu item を確認
 		// 各 item は overflow-menu-item-<id> data-testid を持つ
-		await expect(page.getByTestId('overflow-menu-item-marketplace')).toBeVisible({
-			timeout: 5_000,
-		});
-		await expect(page.getByTestId('overflow-menu-item-restore')).toBeVisible();
+		await expect(page.getByTestId('overflow-menu-item-restore')).toBeVisible({ timeout: 5_000 });
 		await expect(page.getByTestId('overflow-menu-item-export')).toBeVisible();
 		await expect(page.getByTestId('overflow-menu-item-help')).toBeVisible();
+		// marketplace は `+ 追加` menu (browse-marketplace) に移動済のため OverflowMenu に存在しない
+		await expect(page.getByTestId('overflow-menu-item-marketplace')).toHaveCount(0);
 	});
 
 	test('?import=<presetId> で ChildSelectionDialog auto-open', async ({ page }) => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親 (管理者)

**解決する課題**: 初顧客レビューで User が「**ボタンの重複や動作しないインポート機能、マーケットプレイスUIの重複(親管理画面で簡単なマーケットプレイス画面があるなど)、マーケットプレイスリソースごとにインポート導線やカスタマイズ導線が違うなど見た瞬間に指摘される**」と Cluster D で直接指摘。`/admin/checklists` L737-755 の 2 並列 Button (`+ テンプレート作成` + `📅 ワンオフ追加`) が常時可視で並存し、admin/activities #2558 段階2 で確立した dropdown 集約 pattern との一貫性も崩れていた。

**期待される効果**: admin/activities #2558 段階2 pattern を踏襲し `+ 追加` 単一 primary button + dropdown menu に集約 (3 menu items)。Notion / Linear の `+` パターンと整合し、Hick's Law (DESIGN.md §10 add 経路 ≤ 4) を担保。marketplace 取込導線は PR #2773 で確立済の `/marketplace?type=checklist` への直接画面遷移を 3 番目の menu item として統合し、admin 内マーケットプレイス UI 二重管理の懸念も解消。

## 関連 Issue

closes #2778

関連:
- #2558 (Issue B: 4 bug 実 fix + 8 観点網羅テスト) AC10 横展開 (commit `5e15d9eb9` admin/activities pattern reference)
- PR #2773 (#2558 段階3 marketplace 一本化、`/marketplace?type=checklist` 統合済 path)
- PR #2776 (#2774 marketplace import CTA 5 type 統一、ADR-0001 LP truth)
- DESIGN.md §10 構造的ルール (add 経路 ≤ 4 ルール / Hick's Law)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `src/routes/(parent)/admin/checklists/+page.svelte` L737-755 の 2 並列 Button を `Menu` primitive 1 個 + 3 MenuItem に置換 | `grep -nE "checklists-add-menu-trigger\|addMenuItems" src/routes/'(parent)'/admin/checklists/+page.svelte` | PASS — 1 Menu primitive (`triggerLabel={ADMIN_CHECKLISTS_PAGE_LABELS.addButtonLabel}`) + 3 MenuItem (`add-template` / `add-override` / `browse-marketplace`、L292-310) |
| AC2 | marketplace 取込導線として `goto('/marketplace?type=checklist')` を 3 番目の MenuItem に追加 (PR #2773 統合済 path) | `grep -n "'/marketplace?type=checklist'" src/routes/'(parent)'/admin/checklists/+page.svelte` | PASS — `onSelect: () => goto('/marketplace?type=checklist')` (L309) |
| AC3 | 既存 e2e/unit test の dropdown 経由クリックへの更新 (該当 spec があれば) | `grep -rnE "addTemplateButton\|addOverrideButton\|テンプレート作成\|ワンオフ追加" tests/e2e/` | PASS — checklists 関連 e2e に add Button click 参照ゼロ (tests/unit/services/import-service.test.ts の `テンプレート作成失敗時` は UI と無関係な service test 名で対象外) |
| AC4 | `docs/DESIGN.md §10` 構造的ルールに admin/checklists 適用済を追記 | `grep -n "#2778 事例" docs/DESIGN.md` | PASS — §10 「#2778 事例 (admin/checklists の add 経路集約、User 指摘 #1 / Cluster D)」段落追加 |
| AC5 | `docs/design/06-UI設計書.md` の admin/checklists 取込 section を dropdown menu pattern 記載に更新 | `grep -n "追加経路 (#2778" docs/design/06-UI設計書.md` | PASS — `/admin/checklists` 表に「追加経路 (#2778 / Cluster D)」行追加 + 「削除された UI」行に 2 並列 Button 撤去を追記 |
| AC6 | SS 4 slots (mobile/desktop × before/after) で User 指摘 #1 の解消を可視化 | `scripts/capture.mjs --url /admin/checklists --presets mobile,desktop --pr 2778` (CI/Ready 化前撮影) | Ready 化前に撮影 → 本 body へ反映 |
| AC7 | `npm run pre-ready -- --pr <num>` 全 step PASS | `npm run pre-ready -- --pr 2778` (CI 緑化と並行実行) | 静的 step PASS (biome / check-hardcoded-strings 0 / check-no-plan-literals / svelte-check 変更ファイル該当なし / unit test 48 passed)、E2E + LP step は CI で確認 |

## 変更タイプ

- [x] feat: 新機能 (dropdown 集約 UI)
- [ ] fix: バグ修正
- [x] refactor: リファクタリング (2 並列 Button → Menu primitive)
- [x] design: デザイン・UI改善 (DESIGN.md §10 構造的ルール反映)
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント (DESIGN.md / 06-UI設計書.md 同期)
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`) — `(parent)/admin/checklists/+page.svelte`
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`) — `Menu` primitive 適用 (新規実装なし、primitive 既存)
- [x] ドメインモデル (`$lib/domain/`) — `ADMIN_CHECKLISTS_PAGE_LABELS` に dropdown menu 用 5 keys 追加 (ADR-0045 labels SSOT)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- `/admin/checklists` (持ち物チェックリスト管理画面) の add 経路 UI のみ。dialog handler (`openAddTemplate` / `openOverride`) / marketplace 取込フロー (`?import=<presetId>` → ChildSelectionDialog) は全て不変。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030） — 静的 step PASS 確認済 (biome / check-hardcoded-strings 0 / check-no-plan-literals / svelte-check 変更ファイル該当エラーなし / unit test 48 passed)。E2E / LP / SS step は CI 緑化 + Ready 化前撮影で完遂
- [x] 追加・変更したテストの概要を以下に記載: テスト変更なし (既存 checklists e2e の add Button click 参照ゼロを確認、AC3 機械検証 PASS)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (priority:high)

## スクリーンショット / ビジュアルデモ

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | (Ready 化前撮影 → 反映) | (Ready 化前撮影 → 反映) |
| **修正後** | (Ready 化前撮影 → 反映) | (Ready 化前撮影 → 反映) |

UI 変更を含む PR のため SS は Ready 化前必須。`scripts/capture.mjs --url /admin/checklists --presets mobile,desktop --pr 2778` で撮影 + screenshots branch push 後に本 body に反映する。

**インタラクティブ状態**: dropdown menu 展開時 (3 MenuItem 表示) の SS を `--state expanded` で追加検討。基本 4 slots で User 指摘 #1 の「ボタン重複解消」が視覚的に証明可能。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — Menu primitive (UI 統合) + `+page.svelte` (composition only) / 依存性逆転 — `goto` / `openAddTemplate` / `openOverride` を MenuItem `onSelect` に注入 / インターフェース分離 — `MenuItem` interface が `Menu` primitive から export
- [x] **DRY**: admin/activities `FEATURES_LABELS.activitiesHeader` の add menu pattern と同型実装。labels.ts に独立 namespace (`ADMIN_CHECKLISTS_PAGE_LABELS`) で keys 追加 (atom 流用なし、画面別 compound として独立保持)
- [x] **YAGNI**: 4 つ目以降の MenuItem (copy-from-child / AI 提案 / Premium gate 等) は将来 Issue。Hick's Law ≤ 4 維持で 3 items から開始
- [x] **Security**: hardcoded secret なし、`/marketplace?type=checklist` は internal navigation のみ
- [x] **アクセシビリティ**: Menu primitive (Ark UI 包装) は keyboard nav + role=menu + role=menuitem 標準対応 (#2260 Fix-1 で nested button 解消済)。`ariaLabel` (`addMenuAriaLabel`) で trigger 説明明示
- [x] **パフォーマンス**: Menu primitive は Portal 経由 + on-demand mount (Ark UI 標準)、追加バンドルなし

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — `src/routes/demo/` は ADR-0048 で env 起動方式に統一済 (PR-B3 #2188)、独立 demo route なし。本番 route `/admin/checklists` のみが demo Lambda env でも host される
- [x] LP ↔ アプリ双方向整合（ADR-0013）— LP 側 (site/index.html / pricing.html 等) は admin/checklists の UI 変更を訴求していないため N/A
- [x] 全年齢モード 5 種に横展開 — `/admin/*` は親管理画面で uiMode に依存しない (`(parent)` group)、N/A
- [x] ナビゲーション 3 種に反映 — AdminLayout / AdminMobileNav / BottomNav は `+ 追加` button 直接配置せず、画面内 UI のみ変更。N/A
- [x] E2E / ユニットシード + チュートリアルを同期 — 既存 spec の add Button click 参照ゼロ (AC3 確認)、チュートリアル `tutorial-chapters.ts` も該当なし
- [x] labels SSOT (ADR-0009 / ADR-0045) — `ADMIN_CHECKLISTS_PAGE_LABELS` に 5 keys 追加 (atom 直書きなし、`TEMPLATE_TERMS.userFacing` の template literal 流用)
- [x] 設計書同期 (ADR-0001) — DESIGN.md §10 / 06-UI設計書.md 該当 section 両方更新
- [x] 並行 PR overlap 確認 (#1200) — PR #2776 (5 type CTA 統一) は merge 済、admin/checklists 関連の open PR は本 PR のみ
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

旧 keys (`addTemplateButton` / `addOverrideButton`) は labels.ts に一時保持。`+page.svelte` 内の参照はゼロ化したが、外部 / 将来参照を考慮し本 PR では削除しない。

**レビュー依頼事項・QA**:
- AC6 (SS 4 slots) の撮影は Ready 化前に完遂。User 指摘 #1 「ボタン重複」の解消が SS で明示されているかを QA で目視確認願う
- DESIGN.md §10 への「#2778 事例」段落は admin/activities #2558 段階2 の「#2558 段階2 事例」と同型構造で追記 (rewards / settings-rules / challenges への将来展開も同段落で言及)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — 静的 step PASS、E2E / LP / SS step は CI 緑化 + Ready 化前撮影で完遂
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み — AC6 SS 撮影は Ready 化前完遂
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — Ready 化前完遂
- [x] 認証画面変更時: 認証画面変更なし、N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
