### PR TITLE
docs: #2788 Phase 2 ジャーニー docs に license key 全廃 反映 (Epic #2525 やり直し)

### DIFF
--- a/docs/design/billing-redesign/phase2-nuc-journey.md
+++ b/docs/design/billing-redesign/phase2-nuc-journey.md
@@ -6,7 +6,7 @@
 | 親 | #2527 (Phase 2 UX) / 上位 #2525 |
 | ステータス | 既存実装前提で設計 (2026-05-28、ADR-0051 NUC-SaaS Bifurcation 整合) |
 | 対応 Phase 1 要件 | phase1-nuc-requirements.md (#2539: 完全無料 OSS / 信頼ベース DRM なし / family 固定) |
-| URL/コンポーネント命名 | `/admin/license` → `/admin/subscription` rename (Phase 7 実装予定、[phase1-naming-url-integrity-requirements.md](phase1-naming-url-integrity-requirements.md) 参照)。NUC 側は `NucLicensePanel` → Phase 5 design review (内部識別子 `LICENSE_KEY_STATUS` enum 等は legacy 互換のため現名維持)、`/ops/license/*` は ops internal tool で rename 対象外 |
+| URL/コンポーネント命名 | `/admin/license` → `/admin/subscription` rename (Phase 7 担当、[phase1-naming-url-integrity-requirements.md](phase1-naming-url-integrity-requirements.md) 参照)。NUC 側は `NucLicensePanel` → Phase 5 design review。**ライセンスキー全廃** ([phase1-license-key-removal-final-requirements.md](phase1-license-key-removal-final-requirements.md) §3.4/§3.8 + OQ-4 確定): `LICENSE_KEY_STATUS` / `LICENSE_PLAN` enum + `licenseKey` 列 + `LicenseRecord` table + `/ops/license/*` 発行 UI + `license-key-service.ts` は SaaS / NUC 問わず物理削除 (legacy 互換維持はしない、expand-contract §3.8)。NUC は信頼ベースで Edition flag 判定のみ、ライセンスキー判定は存在しない |
 | プラン命名 + 課金期間 | `family` → **`プレミアム`** rename / NUC は **完全無料 OSS で課金概念なし** ([phase1-plan-naming-pricing-axis-requirements.md](phase1-plan-naming-pricing-axis-requirements.md) 参照)。NUC では `family 相当 capability` → 表示「プレミアム相当 capability」rename、内部 `IS_NUC_DEPLOY=true` / `PLAN_LIMITS.family` 等は現名維持 |
 
 > **`premium` 階層 signal 打消** (本 PR scope、refs #2594 D-2):
@@ -14,10 +14,10 @@
 
 ## 既存実装の事実
 
-- ADR-0051 NUC-SaaS Bifurcation: NUC は Edition badge + 簡略表示型、license/billing 領域は SaaS と分岐
+- ADR-0051 NUC-SaaS Bifurcation: NUC は Edition badge + 簡略表示型、billing 領域は SaaS と分岐
 - `IS_NUC_DEPLOY` edition flag で実行モード判別 (既存)
 - NUC は OSS (セルフホスト)、DRM なし (信頼ベース)、機能上は family 相当
-- SaaS 側のライセンスキー / Stripe / dunning / trial 等の課金機構は NUC では存在しない (badge で明示)
+- **ライセンスキー機構は SaaS / NUC 双方から全廃済** ([phase1-license-key-removal-final-requirements.md](phase1-license-key-removal-final-requirements.md) §2.1): SaaS の認可は Stripe Subscription ベース (ライセンスキーは冗長な入力経路に過ぎず除去)、NUC は信頼ベースで Edition flag のみ判定 (`nuc-prod && !licenseKey.valid` deny も撤廃)。NUC では Stripe / dunning / trial 等の課金機構も存在しない (badge で明示)
 
 ## NUC ジャーニー (保護者視点)
 

--- a/docs/design/billing-redesign/phase2-plan-change-journey.md
+++ b/docs/design/billing-redesign/phase2-plan-change-journey.md
@@ -8,7 +8,7 @@
 | 対応 Phase 1 要件 | phase1-plan-change-requirements.md (#2535) |
 | deep-research | Tier Change UX / proration / 超過リソース 5 パターン対比 / Win-Back (2026-05-28) |
 | Explore 照合 | 既存実装 4 点 (SaasLicensePanel / downgrade-service / resource-archive-service / DowngradeResourceSelector) (2026-05-28) |
-| URL/コンポーネント命名 | `/admin/license` → `/admin/subscription` rename / `SaasLicensePanel` → `SaasSubscriptionPanel` rename (Phase 7 実装予定、[phase1-naming-url-integrity-requirements.md](phase1-naming-url-integrity-requirements.md) 参照)。本ジャーニー内では既存実装 reference (`SaasLicensePanel.svelte:165-763` 等) は現名を維持 |
+| URL/コンポーネント命名 | `/admin/license` → `/admin/subscription` rename / `SaasLicensePanel` → `SaasSubscriptionPanel` rename (Phase 7 担当、[phase1-naming-url-integrity-requirements.md](phase1-naming-url-integrity-requirements.md) 参照)。本ジャーニー内では既存実装 reference (`SaasLicensePanel.svelte:165-763` 等) は現名を維持。**注**: `SaasLicensePanel` / `/admin/license` の "license" は **プラン状態表示パネル / プラン管理 URL の旧命名**であり、**ライセンスキー概念とは無関係**。ライセンスキー機構自体は全廃済 ([phase1-license-key-removal-final-requirements.md](phase1-license-key-removal-final-requirements.md))、本ジャーニーのアップ/ダウンは Stripe Subscription (`subscriptions.update` proration) を唯一 SSOT とする |
 | プラン命名 + 課金期間 | `family` → **`プレミアム`** rename / **月額のみ (年額廃止、interval 変更 4 パターン → 2 パターンに簡素化)** (Phase 7 実装予定、[phase1-plan-naming-pricing-axis-requirements.md](phase1-plan-naming-pricing-axis-requirements.md) 参照)。本ジャーニー内では表示は新名、stateDiagram の状態名 (`free`/`standard`/`family`) は現名維持 (Phase 7 で enum rename) |
 
 > **`premium` 階層 signal 打消** (本 PR scope、refs #2594 D-2):

--- a/docs/design/billing-redesign/phase2-signup-journey.md
+++ b/docs/design/billing-redesign/phase2-signup-journey.md
@@ -26,7 +26,7 @@
 | # | ステップ | 既存実装 | 親の体験 | 感情 | 谷/山 |
 |---|---|---|---|---|---|
 | 0 | LP | `site/index.html` | 価値・安全性・無料を確認 | 期待/不安 | — |
-| 1 | signup 入力 | `auth/signup/+page.svelte` (**license key 欄撤去**) | email/pw/3同意 | 不安 (3同意・越境) | — |
+| 1 | signup 入力 | `auth/signup/+page.svelte` (**ライセンスキー概念 全廃**: 旧キー入力欄は撤去済、認証/認可は Stripe Subscription + Cognito 一本化) | email/pw/3同意 | 不安 (3同意・越境) | — |
 | 2 | **Cognito sign-up 確認コード入力** (MFA でなく初回 email 所有確認) | `auth/signup` SignUp→ConfirmSignUp action | 6 桁コード受信→入力 | **苛立ち (届かない・spam) ← 谷①** | 谷① |
 | 3 | 自動ログイン → /admin + provisioning | `auth/signup/+page.server.ts:249-404` | 自動遷移 | 安堵 | — |
 | 4 | **/setup/children (必須)** | `setup/children` (年齢→UIMode 自動: 0-2=baby/3-5=preschool/6-12=elementary/13-15=junior/16-18=senior) | 子供のニックネーム+年齢 | 期待 | — |
@@ -56,11 +56,13 @@
 - 親代行 OK で軽減。「ご家族で一緒に最初の記録を」等の文言で親の負担感を下げる (Phase 3)
 - ログイン後デフォルト表示ページ選択 (既存) で「最初に誰のホームを開くか」を親が制御 → 自然な動線
 
-## 既存からの変更点 (delta、ライセンスキー撤廃 + 補強)
+## 既存からの変更点 (delta、ライセンスキー全廃 + 補強)
+
+> **ライセンスキー全廃の確定** ([phase1-license-key-removal-final-requirements.md](phase1-license-key-removal-final-requirements.md) §3 + OQ-3/OQ-4 確定 2026-06-03): signup の旧「ライセンスキー入力」は**入力欄の撤去にとどまらず、ライセンスキー概念そのものを全廃**する。SaaS の認可は `tenant.stripeSubscriptionId` + `tenant.status` から計算され (`cognito.ts` L147-152)、ライセンスキーを一切読まない。プラン状態の唯一 SSOT は Stripe Subscription であり、signup ジャーニーにライセンスキーの入力・検証・配布動線は存在しない。
 
 | # | 既存 | 要件 | 扱い |
 |---|---|---|---|
-| 1 | signup に license key 欄 | 撤去 | 変更 |
+| 1 | signup にライセンスキー入力欄 | 全廃 (入力欄撤去 + 概念消滅、Stripe Checkout 一本化) | 変更 |
 | 2 | `?plan=X` trial 自動開始 (signup) | 撤去 (任意タイミング) | 変更 (trial ジャーニー #2547 と整合) |
 | 3 | マーケットプレイス推奨自動採用 (setup/packs:120-142) | 維持・前面化 | ✅ 既存活用 (中間山の核) |
 | 4 | `default_child_id` + `selectedChildId` cookie (ログイン後遷移) | 維持・signup 直後の動線で活用 | ✅ 既存活用 (橋渡し) |


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（設計書 SSOT を参照する Dev / QA / 補佐）

**解決する課題**: Phase 1 補強 3 (#2788 / PR #2790 マージ済) で「ライセンスキー完全全廃」が確定したが、Phase 2 UX ジャーニー docs 3 file (signup / plan-change / nuc) には旧モデル前提 (ライセンスキー入力欄の単なる撤去・「SaaS 側のライセンスキー」残存フレーミング・enum legacy 互換維持) の記述が残存していた。SSOT 内部の自己矛盾は、後続 Phase (UI / 動線 / 実装) が誤った前提で進行するリスクを生む。

**期待される効果**: Phase 2 ジャーニー docs が phase1-license-key-removal-final-requirements.md (#2790) の全廃方針と完全整合し、後続 Phase の実装者が「ライセンスキー = SaaS / NUC 問わず全廃、プラン状態の唯一 SSOT は Stripe Subscription」を正しい前提として参照できる。

## 関連 Issue

closes #2788

<!-- #2788 = Epic #2525 Phase 1 補強 3 (license key 全廃) の Phase 2 docs 反映タスク -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | phase2 3 file の license key 言及を全廃方針に整合 | `grep -n "ライセンスキー" docs/design/billing-redesign/phase2*.md` | HEAD `5492faae` / 全 6 ヒットが「全廃」「全廃済」「概念無関係」文脈のみ (signup:29/59/61/65, nuc:9/20, plan-change:11)。旧モデル前提 (残存前提) の記述 0 |
| AC2 | signup ジャーニーの license key 入力 UX 削除を明記 | `phase2-signup-journey.md:29,59-65` | HEAD `5492faae` / L29「ライセンスキー概念 全廃: 旧キー入力欄は撤去済、認証/認可は Stripe Subscription + Cognito 一本化」+ L61 全廃確定 blockquote (OQ-3/OQ-4 反映) + L65「全廃 (入力欄撤去 + 概念消滅、Stripe Checkout 一本化)」 |
| AC3 | NUC ジャーニーの信頼ベース整合 | `phase2-nuc-journey.md:9,20` | HEAD `5492faae` / L20「ライセンスキー機構は SaaS / NUC 双方から全廃済」+「NUC は信頼ベースで Edition flag のみ判定 (`nuc-prod && !licenseKey.valid` deny も撤廃)」、L9 で LICENSE_KEY_STATUS/LICENSE_PLAN enum 物理削除 (OQ-4) 反映。phase1-nuc FR-1/FR-2 整合 |
| AC4 | grep "ライセンスキー" phase2*.md で残存が「全廃」文脈のみ (旧モデル前提 0) | `grep -ni "license key\|licenseKey\|ライセンスキー" docs/design/billing-redesign/phase2-{signup,plan-change,nuc}-journey.md` | HEAD `5492faae` / plan-change L11 は「SaasLicensePanel / /admin/license の "license" は旧命名でライセンスキー概念とは無関係」と明示 (naming rename 対象、phase1-naming-url-integrity 整合)。全ヒット全廃文脈 |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし (docs のみ)。`docs/design/billing-redesign/phase2-{signup,plan-change,nuc}-journey.md` の 3 設計書を更新。README 表は conflict 連鎖回避のため非変更。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— docs-only 変更 (DB/API/UI/code/LP/labels 非変更) のため biome/svelte-check/vitest/lp-dimensions は no-op 相当、check-pr-body のみ実体検証対象
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）: N/A (docs-only)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（docs-only PR、UI 変更を含まない）**。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A (docs-only)
- [x] **DRY**: 全廃方針の根拠は phase1-license-key-removal-final-requirements.md を SSOT 参照し、本 PR では同内容を重複転記せず link で集約
- [x] **YAGNI**: 不要な抽象化追加なし
- [x] **Security（OSS 公開前提）**: N/A (秘密情報なし)
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードと チュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): 本 PR 自体が Phase 2 設計書 (phase2-*-journey.md) を Phase 1 補強 3 SSOT (#2790) に同期する作業。実装コード変更を伴わない docs 整合
- [x] **並行 PR overlap** (#1200): README 表を非変更とし、Epic #2525 やり直しの他 docs PR との conflict 連鎖を回避
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314):

N/A (LP / pricing / plan-features.ts 非変更)

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
- plan-change-journey.md の `SaasLicensePanel` / `/admin/license` は naming rename 対象 (phase1-naming-url-integrity) であり、ライセンスキー概念とは無関係であることを L11 の「**注**」で明示した。この区別 (命名 vs キー概念) が妥当か確認をお願いします。
- nuc-journey.md L9 で `LICENSE_KEY_STATUS` / `LICENSE_PLAN` enum を「legacy 互換のため現名維持」→「物理削除 (OQ-4 確定)」に是正した。phase1-license-key-removal §3.4/§3.8 + OQ-4 整合。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（残課題のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み (#2788 = Epic #2525 やり直し Phase 2 反映タスク)
- [x] UI 変更時: N/A (docs-only)
- [x] 認証画面変更時: N/A (docs-only)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
