### PR TITLE
docs: [#2525 整合棚卸] Phase 1 内部 SSOT 不整合 3 件 (Product 構成 / 月額年額 / lifetime) docs 訂正 (#2789)

### DIFF
--- a/docs/design/billing-redesign/phase1-checkout-requirements.md
+++ b/docs/design/billing-redesign/phase1-checkout-requirements.md
@@ -25,8 +25,8 @@
 - NFR-2: webhook **署名検証必須** (construct_event)、未検証は reject
 - NFR-3: `checkout.session.async_payment_succeeded/failed` も購読 (将来の遅延決済対応)
 - NFR-4: サブスク状態を **アプリ DB にキャッシュ** (ログイン毎の Stripe API 照会回避)
-- NFR-5 (ADR-0012): 年額誘導は煽らず、トグルは中立操作可能
-- NFR-6 (ADR-0013): 「2ヶ月無料」は実価格 (16.7% off) と一致するため記載可
+- NFR-5 (ADR-0012): プラン選択は月額のみで提示し、年額誘導・期間トグルを設けない (年額廃止 #2588 補強2 / Anti-engagement 整合)
+- NFR-6 (ADR-0013): 「2ヶ月無料」等の年額割引訴求は廃止 (年額プラン非提供のため実価格と整合しない表記を出さない)
 
 ## ユーザーストーリー
 
@@ -43,11 +43,11 @@
 
 | # | 論点 | 推奨 | 状態 |
 |---|------|------|------|
-| 1 | 月/年トグルのデフォルト | **月額デフォルト** (年額は「2ヶ月おトク」併置) | ✅ PO 確定 2026-05-27 (Anti-engagement 整合) |
+| 1 | プラン選択 UI の課金期間 | **月額のみ** (期間トグルなし) | ✅ 年額廃止 (#2588 補強2) で確定。トグル論点は消失 (Anti-engagement 整合) |
 | 2 | 重複防止の実装方式 | Stripe built-in 自動 redirect | 推奨で確定 (UX 文言制御は Phase 3 で評価) |
 | 3 | success polling 上限 | webhook 10秒待ち後 polling、タイムアウト時「数分後に再読込」 | 実装詳細 (Phase 5-6) |
 | 4 | トライアル→有料化の動線文言 | standard も併置 (family 固定 trial 後のダウンセル経路) | トライアル要件と整合、確定 |
-| 5 | 年額の解約・日割り扱い | — | **解約孫 #2536 で確定** (Phase 1 早期に PO 判断要) |
+| 5 | 解約・日割り (proration) 扱い | 月額のみのため年額日割り論点は消失。月額の proration は Phase 5 #2640 (ダウン即時 + Stripe credit memo) で確定 | **解約孫 #2536 + Phase 5 #2640 で確定** |
 
 ## 関連 (2026-05-28 補強)
 
@@ -57,7 +57,8 @@
 
 | # | 既存実装 (file:line) | 本要件 | 扱い |
 |---|---|---|---|
-| 1 | createCheckoutSession (`src/lib/server/services/stripe-service.ts`:43-105) / webhook SSOT fulfillment (handleCheckoutCompleted `src/lib/server/services/stripe-service.ts`:245-303) / customer 紐づけ / 4 Price 構成 (`src/lib/server/stripe/config.ts`:39-70) | 維持 | ✅ 実装済み |
+| 1 | createCheckoutSession (`src/lib/server/services/stripe-service.ts`:43-105) / webhook SSOT fulfillment (handleCheckoutCompleted `src/lib/server/services/stripe-service.ts`:245-303) / customer 紐づけ | 維持 | ✅ 実装済み |
+| 1-b | 既存 4 Price 構成 (`src/lib/server/stripe/config.ts`:39-70、月額/年額 × standard/family) | **2 Product (standard / premium) 各 1 Price (月額のみ) + lookup_key** に再構成 (FR-1) | **変更** (Phase 5 #2639 代替案 D / 年額廃止 #2588 補強2、Phase 6/7 実装) |
 | 2 | priceId リテラル依存 (config.ts 環境変数直読) | lookup_key 参照 | **変更** (FR-1、Stripe Dashboard 設定も) |
 | 3 | success ページ「準備中」+ polling なし | 準備中表示 + session status polling | **新規実装** (FR-6、Phase 3 UI) |
 | 4 | `checkout.session.async_payment_succeeded/failed` 購読なし (現状 completed/invoice.paid/payment_failed のみ) | 購読追加 | **新規** (NFR-3) |
@@ -68,6 +69,6 @@
 ## 根拠 (primary source)
 
 - Stripe build-subscriptions / checkout/fulfillment / limit-subscriptions (Product/Price/lookup_key, webhook SSOT, processing gap polling, 重複防止 built-in)
-- 月額年額: innerTrends (16.7%=2ヶ月無料 標準) / Paddle (月換算併記)
+- 月額のみ採用根拠: Spotify Family 2026 年額廃止 / Netflix 月額のみ / SaaS 27% monthly-only (年額 sunk cost lock-in 回避、ADR-0012 整合。詳細は phase1-plan-naming-pricing-axis-requirements.md FR-2)
 - ADR-0012 (Anti-engagement) / ADR-0013 (LP truth)
 - 既存: src/lib/server/stripe/ / terms.ts (PRICE_TERMS / TRIAL_TERMS / PLAN_FULL_TERMS)

--- a/docs/design/billing-redesign/phase1-checkout-requirements.md
+++ b/docs/design/billing-redesign/phase1-checkout-requirements.md
@@ -10,9 +10,9 @@
 
 | ID | 要件 | 設計意図 + 根拠 |
 |----|------|----------------|
-| FR-1 | **1 Product (例: 「がんばりクエスト」) に standard/family × 月額/年額 = 4 Price** を Stripe に定義、アプリは **lookup_key 参照** | 価格改定時のコード変更ゼロ化。Stripe build-subscriptions 公式推奨。lifetime 廃止と整合。**同一 Product 別 Price 構成はプラン変更要件 ([plan-change](phase1-plan-change-requirements.md) §最重要制約 / FR-2) が要求する Portal 期末ダウングレード成立の前提** (別 Product だと Portal 期末ダウンが効かず credit proration 事故)。最終 Dashboard 構成の確認・再設計は Phase 5 へ申し送り (plan-change Open question 1) |
-| FR-2 | プラン選択 UI = **月額/年額トグル + プランカード 2 枚**、トグルで表示価格同期切替 | 業界収束パターン |
-| FR-3 | 年額カードに **月あたり換算 + 月額取り消し線 + 「2ヶ月分おトク」** 明示 | ユーザーに計算させない。両プラン 16.7% off = 2ヶ月無料 (業界ど真ん中) |
+| FR-1 | **2 Product (standard / family) に各 1 Price (月額のみ)** を Stripe に定義、アプリは **lookup_key 参照** | 価格改定時のコード変更ゼロ化。Stripe build-subscriptions 公式推奨。lifetime 廃止と整合。**Phase 5 アーキテクチャ再評価 (#2683 代替案 D) により、プラン変更は Portal ダウングレードを廃止し、自前で `subscription_schedules` を組む構成に変更したため、2 Product 構成が確定済。** |
+| FR-2 | プラン選択 UI = **プランカード 2 枚 (月額のみ)** | 年額廃止に伴いトグル撤去 (#2588 補強2) |
+| FR-3 | (削除) 年額廃止に伴い撤去 | 年額廃止 (#2588 補強2) に伴い関連UI撤去 |
 | FR-4 | Checkout Session 作成時に必ず **Customer object を渡す** | 重複検出 + 権限紐付けの前提。account-first で signup 時に Customer 確定済 |
 | FR-5 | **`checkout.session.completed` webhook で権限付与 (SSOT)**、success_url は UX 専用 | 公式の唯一信頼できる fulfillment 起点 (success_url 単独で付与禁止) |
 | FR-6 | success ページは **「準備中」表示 + session status polling で自動解禁** | processing gap の信頼毀損回避。Stripe は webhook を最大10秒待って redirect |
@@ -30,15 +30,14 @@
 
 ## ユーザーストーリー
 
-1. プランを選び (月/年トグル + カード)、年額のおトク額が一目で分かる
+1. プランを選び (カードから選択)、決済に進む
 2. 決済直後「準備中」を見た後、操作不要で自動的に有料機能が解禁
 3. すでに課金中なら二重課金されず契約管理画面に案内
 4. 無料/トライアルで feature gate に当たった時その場から checkout に進める
 
 ## 月額/年額の提示
 
-- 年額は両プラン **16.7% off = 2ヶ月無料** にぴったり一致 → **「2ヶ月分おトク」表現を推奨** (コンシューマ向けは % off より高転換)。年額選択時は月換算 (standard ¥417/月相当 / family ¥650/月相当) 併記
-- **デフォルト選択**: **月額デフォルト (PO 確定 2026-05-27)**。年額は「2ヶ月おトク」として併置。Anti-engagement 整合、Pre-PMF で始めやすさ優先
+- **年額プランは廃止 (月額のみ)**: Phase 1 補強 2 (#2588) の方針決定により、年額プランは提供しない。UI 上のトグルや「2ヶ月分おトク」の提示は撤去された。
 
 ## Open question
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発メンバー）

**解決する課題**: Epic #2525 の内部 SSOT (Phase 1 要件書) において、その後のフェーズの意思決定（2 Product 構成への変更・年額プランの廃止）が反映されず古い記述が残り、開発メンバーが誤情報に基づいて実装・設計を進めるリスクがあった。

**期待される効果**: `phase1-checkout-requirements.md` の記述が確定仕様（2 Product 各 1 Price・月額のみ）と整合し、後続 Phase の実装が正しい前提で進められる。

## 関連 Issue

closes #2789
- 関連: #2588 (月額のみ / 年額廃止), #2683 (代替案 D: 2 Product 各 1 Price), #2639 (Phase 5 Stripe Product 構成)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC-2789-1 | Product 構成の不整合解消 (FR-1 + delta 表) | `git grep -nE "2 Product\|4 ?Price" docs/design/billing-redesign/phase1-checkout-requirements.md` | HEAD `377352a4c` / FR-1 (L13)「2 Product 各 1 Price」/ delta #1-b (L61)「2 Product 各 1 Price + lookup_key に再構成」PASS |
| AC-2789-2 | 月額/年額の不整合解消 (FR-2/FR-3 + NFR-5/6 + Open Q#1/#5 + 根拠) | `git grep -nE "年額\|トグル\|2ヶ月無料" docs/design/billing-redesign/phase1-checkout-requirements.md` | HEAD `377352a4c` / 残存 hit は全て「年額廃止 / 月額のみ」文脈 (NFR-5 L28 / NFR-6 L29 / Open Q#1 L46 / Open Q#5 L50 / 根拠 L72) PASS |
| AC-2789-3 | lifetime 据置 (誤訂正していないこと) | `git grep -n "lifetime" docs/design/billing-redesign/phase1-checkout-requirements.md` | HEAD `377352a4c` / FR-1 内「lifetime 廃止と整合」据置 PASS |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（設計ドキュメント `docs/design/billing-redesign/phase1-checkout-requirements.md` のみ）。コード変更なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— docs-only 変更のため check-pr-body / hardcoded-strings 等の関連 Step を確認
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）: N/A（設計ドキュメントのみの訂正、テスト対象コードなし）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: docs-only PR（設計ドキュメント `phase1-checkout-requirements.md` の文言訂正のみ）で UI 変更を含まないため。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（ドキュメントのみ）
- [x] **DRY**: 兄弟 SSOT (`phase6-phase7-execution-ssot.md` 「2 Product 各 1 Price」/ `phase1-plan-naming-pricing-axis-requirements.md` FR-2「月額のみ・年額廃止」) を参照し、本ファイルの記述をそれらに整合させた
- [x] **YAGNI**: 訂正対象 6 箇所のみに限定し、不要な追記をしていない
- [x] **Security（OSS 公開前提）**: N/A（秘密情報・内部 URL の追記なし）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): 兄弟 SSOT (`phase6-phase7-execution-ssot.md` / `phase1-plan-naming-pricing-axis-requirements.md`) と矛盾しない記述に揃えた。本訂正は billing-redesign 内 SSOT 整合棚卸そのもの
- [x] **並行 PR overlap** (#1200): 本 PR が変更する単一ファイルを同時期に変更する open PR は無い
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A（LP / pricing / plan-features.ts の変更なし）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**:
- 訂正 6 箇所（NFR-5 / NFR-6 / Open question #1 / Open question #5 / delta 表 #1 / 根拠）が、確定仕様「2 Product 各 1 Price・月額のみ・年額廃止」と整合しているかご確認ください。
- `lifetime` 表記は FR-1 内で「lifetime 廃止と整合」のまま据置（誤訂正していない）です。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（残存タスクのない完遂状態。`lifetime` 表記は据置が正しい挙動）
- [x] Phase 分割した場合: N/A（単一ファイル訂正）
- [x] UI 変更時: N/A（docs-only）
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入。フォーマット・必須手順は docs/sessions/qa-session.md「Tier 2 手順 5」を参照。
     CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（ADR-0022）。 -->

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
