### PR TITLE
docs: #2788 Phase 3 license key 全廃反映 — phase3 UI 設計 4 file 整合 (naming rename ≠ license key 削除)

### DIFF
--- a/docs/design/billing-redesign/phase3-archived-resource-reactivation-ui-design.md
+++ b/docs/design/billing-redesign/phase3-archived-resource-reactivation-ui-design.md
@@ -8,6 +8,7 @@
 | Phase 2 整合 | [phase2-plan-change-journey.md](phase2-plan-change-journey.md) (#2549) ジャーニー B-7 (再アップで瞬時復元 = 最終山) / Pattern A (Notion 型) 採用根拠 / 文言 atom 拡張 (`PLAN_CHANGE_TERMS.protected` / `.resumeReady`) |
 | Phase 3 兄弟 | [phase3-admin-header-ui-design.md](phase3-admin-header-ui-design.md) (#2568 plan-badge) / [phase3-subscription-page-ui-design.md](phase3-subscription-page-ui-design.md) (#2567 `/admin/subscription` 純化) / [phase3-activity-limit-banner-ui-design.md](phase3-activity-limit-banner-ui-design.md) (#2569 ActivityLimitBanner) |
 | Phase 7 rename 方針 | `/admin/license` → `/admin/subscription` / `family` → `プレミアム` (atom 1 行) / 月額のみ (年額廃止)。本 docs 内では Phase 7 rename 後の名称を前提に記述、既存実装 reference (`SaasLicensePanel.svelte` 等) は現名維持 |
+| license key 全廃 / rename 整合 (#2788) | 本 docs の reactivation banner / archived listing は **license key UI を含まない**ため license key 全廃 (#2788、PR #2790) の影響なし。本文中の `license +page.server.ts` 等の `license` を含むパス・名称は **現名の既存実装 reference** で、Phase 7 で `/admin/subscription/` に rename される (naming rename)。naming rename と license key 概念削除 (全廃軸、`tenant.status=ACTIVE` が唯一の entitlement SSOT) は別軸 (Phase 5 補強 #2798 §2 原則 4 踏襲) |
 | 採用案 | Notion 型 Pattern A (Phase 2 #2549 既確定) + Calendly 型 「toggle-back restore」(One-click) を融合。read-only listing + 常時表示 reactivation banner |
 | `premium` 階層 signal 打消 | reactivation banner は **「データは保護されています」**を主訴求とし、「上位プランで restore」を副訴求にとどめる (上位プラン誘導を一次目的化しない)。LP コピー (`FREE_PLAN_TERMS.forever` 等) と連動して「無料が排除されている印象を与えない」設計を貫徹 (refs #2594 D-2) |
 

--- a/docs/design/billing-redesign/phase3-scheduled-downgrade-banner-ui-design.md
+++ b/docs/design/billing-redesign/phase3-scheduled-downgrade-banner-ui-design.md
@@ -7,6 +7,7 @@
 | 対応 Phase 1 要件 | [phase1-plan-change-requirements.md](phase1-plan-change-requirements.md) (#2535) §FR-4 / §Open question 4 |
 | 対応 Phase 2 ジャーニー | [phase2-plan-change-journey.md](phase2-plan-change-journey.md) (#2549) §「ダウン ジャーニー詳細 #5」/ §「Phase 3 申し送り 3」 |
 | ステータス | Phase 3 UI 設計 draft 2026-05-28 (deep-research: Notion / Kinde / Stripe 公式 + 既存実装 Explore: SaasLicensePanel.svelte + Alert primitive + MilestoneBanner) |
+| license key 全廃 / rename 整合 (#2788) | 本 banner は期末ダウン状態の表示専用で **license key UI を含まない** ため license key 全廃 (#2788、PR #2790) の影響なし。本文中の `SaasLicensePanel.svelte` は **既存実装 reference (現名維持)**。Phase 7 で `SaasSubscriptionPanel.svelte` に rename されるが、naming rename と license key 概念削除は別軸 (Phase 5 補強 #2798 §2 原則 4) |
 
 > **目的範囲**: 期末ダウン**確定後・期末到達まで**の親 admin 画面に表示する **1 件静的 banner** の UI 設計のみ。期末到達後の archived リソース UI は #2575 (別子 issue)、確認モーダル / proration 表示は #2549 Phase 2 / #2573 で別途扱う。
 

--- a/docs/design/billing-redesign/phase3-subscription-confirm-tokushoho-ui-design.md
+++ b/docs/design/billing-redesign/phase3-subscription-confirm-tokushoho-ui-design.md
@@ -7,6 +7,7 @@
 | Phase 1+2 整合 | Phase 1 #2541 法務 (FR-L1〜L7) / Phase 1 #2534 checkout (FR-1〜FR-8) / Phase 1 #2588 plan naming-pricing-axis (月額のみ確定) / Phase 2 #2548 checkout journey (谷⑤特商法最終確認) |
 | Phase 7 rename 方針 | `/admin/subscription/confirm` (新 URL、本画面の rename は無し、Phase 7 初出) / `family` atom 表示名は現状「ファミリー」を維持 (Phase 1 #2588 + Phase 3 #2609 SSOT 衝突解決で「プレミアム」表記は採用しない) |
 | 上位 #2567 採用案 C 整合 | 4 ページ分割の機能 3, 8 (proration 差額表示 + 特商法 6 項目) を本画面に分離。`SaasSubscriptionPanel.svelte` (旧 `SaasLicensePanel`) からの遷移先 |
+| license key 全廃 / rename 整合 (#2788) | 本画面は Stripe Subscription 開設の最終確認 (特商法 6 項目 + proration) 専用で **license key の入力・適用・表示要素を含まない** ため license key 全廃 (#2788、PR #2790) の影響なし。`SaasSubscriptionPanel.svelte` (旧 `SaasLicensePanel`) は namespace / component の naming rename であり、license key 概念削除 (全廃軸) とは別軸 (Phase 5 補強 #2798 §2 原則 4 踏襲) |
 | 作業姿勢 (#2525 critical) | 法令適合性最優先 / 全文言に設計意図 + 法的根拠 / Stripe vs 自社判断は deep-research primary source で裏付け / 個別法律解釈は法務確認必須 |
 | deep-research | (1) Stripe Checkout `custom_text` API 仕様 (4 field × 1200 文字 Markdown) / (2) JP 改正特商法第12条の6 6 項目 + 同意取得方法 / (3) Stripe Japan 公式特商法対応ガイド + Qiita 実装事例 / (4) Stripe 標準機能の限界 (定期購入各回代金 / 動的 proration / 解約手続詳細) |
 

--- a/docs/design/billing-redesign/phase3-subscription-page-ui-design.md
+++ b/docs/design/billing-redesign/phase3-subscription-page-ui-design.md
@@ -6,6 +6,7 @@
 | 親 | #2528 (Phase 3 UI) / Epic #2525 |
 | Phase 1+2 整合 | 補強 1 (#2583 URL) + 補強 2 (#2588 プラン命名 / 月額のみ / ROI framing) + Phase 2 補強 (#2585 URL / #2596 プラン命名) |
 | Phase 7 rename 方針 | `/admin/license` → `/admin/subscription` / `SaasLicensePanel` → `SaasSubscriptionPanel` / `family` → `プレミアム` (atom 1 行) / 月額のみ (年額 9 件削除) |
+| license key 全廃整合 (#2788) | Phase 1 補強 3 (`phase1-license-key-removal-final-requirements.md`、PR #2790 マージ済) で license key = SaaS / NUC 問わず**全廃**確定。本 UI 設計の「ライセンスキー適用 UI」section は **完全削除** (license key 概念消滅、SaaS 認可は `tenant.status=ACTIVE` が唯一 SSOT、NUC は信頼ベースで billing proof 不要)。**naming rename (`/admin/license` → `/admin/subscription`、`SaasLicensePanel` → `SaasSubscriptionPanel`) と license key 概念削除は別軸** (Phase 5 補強 #2798 §2 原則 4 整合)。rename は namespace / route 名の変更、license key 削除は機能の全廃で、rename 完了と license key 削除完了を同一視しない |
 | impact-analysis skill 適用 | L1 grep + L2 意味 (表示 vs 内部識別子) + L3 構造 + L4 派生 artifact 21 カテゴリ (docs のため該当なし) |
 | 採用案 | C: 4 ページ分割 (`/admin/subscription` + `/confirm` + `/admin/billing` + `/admin/billing/cancel`) |
 | `premium` 階層 signal 打消 | `premium` は機能本格度を示す signal であり、**無料プランへの exclusion 意図なし** (refs #2594 D-2)。本 UI 設計で「✓ お勧め」バッジを standard に付与することで「premium = 必須ではない上位選択肢」を視覚化、無料・standard・premium 3 段階で「無料が排除されている印象を与えない」設計を貫徹。LP コピー verification (`FREE_PLAN_TERMS.forever` / `FREE_TERMS.start` 併記) は Phase 4 移行 gate で別途確認 |
@@ -36,7 +37,7 @@
 | 7 | 超過リソース選択フロー | **維持** (#2575) | 既存 |
 | 8 | 特商法最終確認画面 | **削除** (→ `/admin/subscription/confirm`、#2573) | 別画面分離 |
 | 9 | Stripe Portal 遷移ボタン (642-650) | **削除** | `/admin/billing` 一本化 (二重実装解消) |
-| 10 | ライセンスキー適用 UI (385-544、170 行) | **削除** | ライセンスキー撤廃 (NUC は別画面 `NucSubscriptionPanel`) |
+| 10 | ライセンスキー適用 UI (385-544、170 行) | **完全削除** | license key 全廃 (#2788、概念消滅)。入力フォーム / 適用ボタン / ヘルプ全廃。NUC は信頼ベース (billing proof 不要、`NucSubscriptionPanel` は Edition badge / 全機能無制限ステータス表示のみ、license key 適用 UI は移設しない) |
 | 11 | 支払い履歴セクション (764-796) | **削除** | `/admin/billing` link のみ |
 
 → 削除 5 + 改善 4 + 維持 3 = 純化後 ~400 行 (Phase 7 実装見積)。
@@ -89,7 +90,7 @@ flowchart LR
     Old[現状 SaasLicensePanel<br/>763 行 7 セクション] --> Pure[/admin/subscription<br/>純化後 ~400 行]
     Old -- 削除 --> Conf[/admin/subscription/confirm<br/>特商法 = #2573]
     Old -- 削除 --> Bill[/admin/billing<br/>Portal / 履歴 SSOT 一本化]
-    Old -- 削除 --> Key[ライセンスキー UI 完全削除<br/>NUC は NucSubscriptionPanel]
+    Old -- 削除 --> Key[ライセンスキー UI 完全削除<br/>license key 全廃 #2788 概念消滅<br/>NUC も信頼ベースで billing proof 不要]
     Pure -- 新規追加 --> Cancel[/admin/billing/cancel<br/>解約導線 = 既存]
     style Old fill:#f8d7da
     style Pure fill:#d4edda
@@ -219,7 +220,8 @@ SUBSCRIPTION_PAGE_LABELS = {
 - `family` (英語、表示文): atom 経由 95 件 (Phase 7 atom 1 行修正)
 
 ### L2 意味 (型 / 同名異義)
-- 表示プラン名 (`PLAN_TERMS.family`) vs 内部識別子 (`'family'` enum / `family-tenant` / `LICENSE_KEY_STATUS` 等) の区別: Phase 1 補強 2 FR-5 で明文化済
+- 表示プラン名 (`PLAN_TERMS.family`) vs 内部識別子 (`'family'` enum / `family-tenant`) の区別: Phase 1 補強 2 FR-5 で明文化済
+- `LICENSE_KEY_STATUS` / `LICENSE_PLAN` enum + `licenseKey` 列は license key 全廃軸 (#2788 §3.8) で**物理削除**対象 (本 UI 設計と直交、Phase 7 実装 PR-L5 で対応)。本画面に license key の表示・入力要素は残さない
 
 ### L3 構造 (依存グラフ)
 - `SaasLicensePanel.svelte` 依存: 11 件 (削除候補ファイル特定済、Phase 7 実装で対応)
@@ -264,7 +266,7 @@ SUBSCRIPTION_PAGE_LABELS = {
 2. コンポーネント rename: `SaasLicensePanel.svelte` → `SaasSubscriptionPanel.svelte`
 3. ルート rename: `/admin/license/` → `/admin/subscription/`
 4. `LEGACY_URL_MAP` 永久エントリ追加
-5. 削除 5 セクション (Portal / 履歴 / 特商法 / ライセンスキー / 月年トグル) 実装
+5. 削除 5 セクション (Portal / 履歴 / 特商法 / ライセンスキー / 月年トグル) 実装。**ライセンスキー section 削除は license key 全廃軸 (#2788、naming rename とは別軸)** — 入力フォーム / 適用ボタン / ヘルプを完全撤去し、移設先 (NUC 含む) を作らない
 6. 改善 4 項目 (お勧めバッジ standard / 比較表差分強調 / cancel-anytime CTA / 解約導線) 実装
 7. Storybook + Playwright SS 撮影 + UX レビュー
 8. impact-analysis skill 4 layer 防御 + 21 カテゴリ checklist を PR body に記載
@@ -280,7 +282,8 @@ SUBSCRIPTION_PAGE_LABELS = {
 
 ## 根拠
 
-- Phase 1 補強 1 (#2583 naming-url-integrity)・補強 2 (#2588 plan-naming-pricing-axis)
+- Phase 1 補強 1 (#2583 naming-url-integrity)・補強 2 (#2588 plan-naming-pricing-axis)・補強 3 (#2788 / PR #2790 license-key-removal-final-requirements、license key 全廃 = naming rename と別軸)
+- Phase 5 補強 (#2798) §2 原則 4「naming rename ≠ license key 削除」を Phase 3 UI 設計でも踏襲
 - Phase 2 補強 (#2585 URL / #2596 プラン命名)
 - 既存実装: `SaasLicensePanel.svelte:165-763` (現名、Phase 7 で rename)
 - ADR-0012 (Anti-engagement) / ADR-0045 (terms.ts 2 階層) / ADR-0051 (NUC-SaaS Bifurcation)


### PR DESCRIPTION
## 顧客価値・目的

Epic #2525 (課金/プラン体系再設計) Phase 1 補強 3 (#2788、PR #2790 マージ済) で確定した **license key 完全全廃 (SaaS / NUC 問わず)** を、Phase 3 UI 設計 docs 4 file に反映する。Phase 2/4/5/6 補強 PR (#2794 / #2797 / #2798 / #2796) は既にマージ済で、本 PR は Phase 3 の整合を取る。

これにより、Phase 3 UI 設計が「Stripe Subscription 認可一本化 (`tenant.status=ACTIVE` が唯一の entitlement SSOT)」の前提で記述され、`/admin/subscription` ページから license key 入力 / 適用 / ヘルプ UI が完全に消える設計が docs SSOT に確定する。顧客が Stripe Subscription に移行したはずの課金画面で「ライセンスキー」を読まされる意味破綻状態を docs レベルで根治する。

## 関連 Issue

- Epic: #2525 / Phase 1 補強 3: #2788 (PR #2790 マージ済、license key 全廃 SSOT)
- 整合参照: Phase 5 補強 #2798 §2 原則 4「naming rename ≠ license key 削除」/ Phase 6 補強 #2796 (#2788 文脈判断)
- 補強対象: Phase 3 #2567 (subscription-page) / #2574 (downgrade-banner) / #2573 (confirm-tokushoho) / #2575 (archived-resource-reactivation)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC-1 | phase3 4 file の license key UI 言及を全廃方針に整合 | `git diff` 目視 + 4 file の license 言及行を全廃文脈に書換 | 完了。subscription-page (4 件) を完全削除方針に、他 3 file (各 1 件 header row) に license key 全廃整合行追加 |
| AC-2 | subscription-page で「ライセンスキー適用 UI」削除を明記 | L39 (table row 10) + L93 (mermaid 図 3) + L9 (header) + L269 (Phase 7 step 5) | 完了。「**完全削除** / 入力フォーム・適用ボタン・ヘルプ全廃 / 移設先 (NUC 含む) を作らない」を明記 |
| AC-3 | naming rename と license 概念削除を区別 (#2798 整合) | 4 file 全てに「naming rename ≠ license key 削除 (Phase 5 補強 #2798 §2 原則 4 踏襲)」を記載 | 完了。rename = namespace/route 名変更、license key 削除 = 機能全廃、別軸である旨を全 file で明示 |
| AC-4 | `grep "ライセンスキー" docs/design/billing-redesign/phase3*.md` で旧モデル前提 0 (全廃文脈のみ) | `grep -nH "ライセンスキー" docs/design/billing-redesign/phase3*.md` | 完了。5 件全て全廃文脈 (完全削除 / 概念消滅 / 周知不要)。license key を「現行/保持機能」として扱う旧モデル前提 0 件 |

## 変更タイプ

- [x] ドキュメント (設計書 / ADR / README)
- [ ] バグ修正 / [ ] 新機能 / [ ] リファクタ / [ ] インフラ / [ ] テスト

docs 設計書 4 file の整合のみ。実装コード / LP / DB schema / labels.ts 変更なし。

## 影響範囲・変更コンポーネント

| file | 変更内容 |
|---|---|
| `phase3-subscription-page-ui-design.md` | header に license key 全廃整合 row 追加 / table row 10「ライセンスキー適用 UI」を完全削除方針に / mermaid 図 3 Key node に概念消滅明記 / L2 意味層に enum・列 物理削除追記 / Phase 7 step 5 に全廃軸明示 / 根拠に #2788・#2798 追加 |
| `phase3-scheduled-downgrade-banner-ui-design.md` | header に license key 全廃整合 row 追加 (本 banner は license key UI 非含有、`SaasLicensePanel.svelte` は現名 reference) |
| `phase3-subscription-confirm-tokushoho-ui-design.md` | header に license key 全廃整合 row 追加 (特商法確認画面は license key 要素非含有、`SaasSubscriptionPanel.svelte` は naming rename) |
| `phase3-archived-resource-reactivation-ui-design.md` | header に license key 全廃整合 row 追加 (`license +page.server.ts` は現名 path reference、Phase 7 で `/admin/subscription/` rename) |

`docs/design/billing-redesign/README.md` 表は指示通り未変更。

## テスト & 安全装置セルフチェック

- [x] docs のみの変更で実行可能なテストなし (実装コード / labels.ts / LP 非変更)
- [x] `grep -nH "ライセンスキー" docs/design/billing-redesign/phase3*.md` で全廃文脈のみ確認 (5 件、旧モデル前提 0)
- [x] `git diff` 目視で機械的誤変換なし (textlint `--fix` 一括適用なし、手動編集のみ、#2243 整合)
- [x] 禁止語 grep を追加行に対し 0 件確認 (`scripts/check-pr-body.mjs` forbidden-terms 整合)

## スクリーンショット / ビジュアルデモ

UI 実装変更なし (設計書 docs のみ) のため SS 対象外。本 PR は Phase 3 UI 設計の文書整合であり、`.svelte` / LP HTML の描画変更を含まない。

## コード品質セルフレビュー (#1481)

- [x] 設計意図を各編集に明記 (license key 全廃軸と naming rename 軸の分離を全 file header / 該当行で記述)
- [x] 既存実装 reference (`SaasLicensePanel.svelte` / `license +page.server.ts` 等) は現名維持、Phase 7 rename 後名称と区別 (Phase 5 補強 #2798 確立パターン踏襲)
- [x] SSOT 整合: Phase 1 補強 3 (#2790 §2.1 / §3.1 / §3.3) + Phase 5 補強 (#2798 §2 原則 4) を一次 source として参照

## 横展開・影響波及チェック

- [x] Phase 1〜6 補強 PR との整合確認: Phase 1 (#2790) / Phase 2 (#2794) / Phase 4 (#2797) / Phase 5 (#2798) / Phase 6 (#2796) マージ済、本 PR で Phase 3 を整合
- [x] NUC 信頼ベース整合: `phase1-nuc-requirements.md` FR-1/FR-2 (billing proof 不要、DRM 作らない) と矛盾しない (NucSubscriptionPanel は Edition badge 表示のみ、license key 適用 UI 移設なし)
- [x] phase5-atom-ssot-architecture.md §2 原則 4 / §6.6 (`SUBSCRIPTION_PAGE_LABELS` 内 licenseKey* 27 key 削除) と方向性一致
- [x] README.md 表は別管理 (本 PR 未変更、指示遵守)

## レビュー依頼事項・破壊的変更

破壊的変更なし (docs 整合のみ)。Adversarial 3 軸 Open question:

- **business**: license key 全廃により campaign キー配布 (`ops/license/issue`) が Stripe Coupon 代替に移行 (#2790 OQ-2 確定済)。Phase 3 UI 設計には campaign 配布 UI が元々無いため本 PR の business 影響は中立。
- **UX**: NUC ユーザが `NucSubscriptionPanel` で license key 入力を期待する旧 UX 想定があった場合、本整合で「Edition badge / 全機能無制限ステータス表示のみ」に明確化。信頼ベース移行で NUC ユーザの入力操作がゼロになる UX 改善 (Pre-PMF 顧客ゼロ前提で移行コストなし)。
- **security**: `LICENSE_KEY_STATUS` / `LICENSE_PLAN` enum + `licenseKey` 列の物理削除 (#2788 §3.8) は本 docs と直交 (Phase 7 PR-L5 実装)。本 PR は docs 整合のみで認可経路を変更しないため security 退行なし。entitlement は `tenant.status=ACTIVE` が唯一 SSOT で license key 非経由。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。`AWS_LICENSE_SECRET` 等の env 撤去は #2788 §3.7 で Phase 7 PR-L5 (CDK) 担当、本 docs PR scope 外。

## Ready for Review チェックリスト

- [x] 全 AC を AC 検証マップで検証済 (4/4 完了)
- [x] 必須 13 セクション記載
- [x] `[x]` は文字通り達成された項目のみ
- [x] main 最新化 + push 直前 rebase 実施 (base: 061febfb)
- [x] 禁止語 (forbidden-terms) 追加行 0 件確認

## QM レビュー結果

(QM レビュー記入欄)
