### PR TITLE
infra: #2495 PR title 接頭辞→type:* label 自動付与 (観察1)

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -108,6 +108,14 @@ AC 検証マップ (`pr-ac-verification-check.yml`) も hard-fail。
 
 セットアップ: Branch Ruleset の `required_status_checks` に 5 ジョブ追加（管理者作業）。
 
+### type:* label 自動付与 — title 接頭辞が SSOT（#2495）
+
+`type:*` label は **PR title 接頭辞を SSOT** とし `pr-info.yml` の `type-label` job が自動付与する（`feat`/`fix`/`refactor`/`design`/`infra`/`test`/`docs`/`marketing` の 8 種）。`## 変更タイプ` checkbox は人間可読の補助で label の source ではない（title と乖離時は title が正）。`area:*` は `labeler.yml`（file-glob, actions/labeler）が担い、両者は責務分離。
+
+- title 接頭辞が 8 種いずれにも一致しない場合（`build`/`chore`/`ci` 等の label 不在 type を含む）は無干渉（既存 label を保持）
+- 既存の異なる `type:*` を 1 回 remove してから付与するため、title を変更すれば label も追従する（idempotent）
+- Dependabot / Renovate は exempt（actor 判定で skip）
+
 ## 新規 env / secret 追加時（ADR-0006）
 
 `scripts/check-new-required-env.mjs` が以下を検出: `assert*Configured()` / `throw new Error('XXX is required')` / `process.env.X || (() => { throw })()`。

--- a/.github/workflows/pr-info.yml
+++ b/.github/workflows/pr-info.yml
@@ -152,3 +152,39 @@ jobs:
             if (existing) {
               await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
             }
+
+  # #2495 観察1: PR title 接頭辞を SSOT として type:* label を自動付与。
+  # actions/labeler (labeler.yml) は area:* file-glob のみで PR title を見ないため、
+  # title→type:* 機構を本 job が補完する (責務分離: title→type / file-glob→area)。
+  type-label:
+    name: title 接頭辞から type:* label 付与
+    runs-on: ubuntu-latest
+    if: "github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'"
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            // PR title 接頭辞 (Conventional Commits 風) を SSOT とし type:* label を derive する。
+            // type 集合は PULL_REQUEST_TEMPLATE.md「## 変更タイプ」8 件 + gh label list の
+            // type:* 8 件と一致 (feat/fix/refactor/design/infra/test/docs/marketing)。
+            // build/chore/ci/perf/style 等は label 不在のため map しない。
+            const title = context.payload.pull_request.title || '';
+            const m = title.match(/^(feat|fix|refactor|design|infra|test|docs|marketing)(\(.+\))?!?:/i);
+            if (!m) {
+              core.info(`title 接頭辞が type:* 対象外のため無干渉: "${title}"`);
+              return;
+            }
+            const want = `type:${m[1].toLowerCase()}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const cur = context.payload.pull_request.labels.map((l) => l.name);
+            // 既存の異なる type:* を 1 回 remove (手動上書きとの二重化防止、idempotent)
+            for (const l of cur.filter((n) => n.startsWith('type:') && n !== want)) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: l }).catch(() => {});
+            }
+            if (!cur.includes(want)) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [want] });
+              core.info(`付与: ${want}`);
+            } else {
+              core.info(`既付与のためスキップ: ${want}`);
+            }


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（ラベル運用の一貫性に依存する QM / ops / Issue triage）

**解決する課題**: PR の `type:*` label は手動付与に依存しており、付与漏れ・title と乖離した label が散見されていた。`pr-template-gate.yml` Job5 (`type:docs` で test 結果チェックを skip) や Issue triage / ops 集計が label を消費するため、label hygiene の欠落は下流の自動化精度を毀損する。真因調査の結果、`.github/labeler.yml` は `actions/labeler@v6` 用の **area:* file-glob のみ**で PR title を見ない仕様であり、title→type:* 機構が **一度も実装されていなかった**（「config 同期 lag」という当初仮説は誤認）。

**期待される効果**: PR title 接頭辞を権威 SSOT として `type:*` label が機械的に自動付与される。手動付与漏れ・title 乖離が構造的に解消し、label を消費する下流 gate / triage / ops 集計の精度が安定する。

## 関連 Issue

closes #2495

関連: #2525 (ライセンスキー廃止 EPIC、観察2 の re-home 先) / ADR-0014 (OSS 先調査ルール)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `.github/labeler.yml` (or 該当 workflow) を調査 | `.github/labeler.yml` を Read し、area:* file-glob のみ(`changed-files`)で PR title 参照 0 件を確認 | PASS: labeler.yml は `area: frontend/backend/database/infra/tests/docs/config` の 7 glob 定義のみ。`title` キーワード不在 = title→type 機構は未実装と確定 |
| AC2 | PR タイトル接頭辞 → type:* label 自動付与が機能しているか確認 | 既存 workflow (`labeler.yml` / `pr-info.yml` / `pr-template-gate.yml`) を grep し title→type label 付与ロジックの不在を確認 | PASS: 不在を確認（真因確定）。actions/labeler は file-glob 専用で title 非対応 |
| AC3 | 機能していない場合は config 修正 + 動作確認 | `pr-info.yml` に `type-label` job (github-script) を add-only で追加。正規表現を 8 接頭辞 + scope/breaking variant + 未知接頭辞で `node -e` 試験 | PASS: HEAD `5d7b4b27` / 8 接頭辞すべて `type:<name>` に map、`feat(auth):` / `fix!:` / `feat(api)!:` / `FEAT:` も正解、`build`/`chore`/`ci`/`perf`/`style`/非接頭辞は無干渉（下記「OSS / 確立パターン調査結果」+「正規表現動作確認」参照） |
| AC4 | PR テンプレの「変更タイプ」checkbox と label 自動付与の関係を `.github/CLAUDE.md` に明記 | `.github/CLAUDE.md` §「type:* label 自動付与 — title 接頭辞が SSOT（#2495）」を追加（PR テンプレ必須ゲート section 直後） | PASS: HEAD `5d7b4b27` / `.github/CLAUDE.md` に「title が SSOT、checkbox は補助、area:* は labeler.yml が担い責務分離」を明記 |
| AC5 | `/ops/license/legacy-count` response の `backend` field を 3 値返却に変更 | — | **scope 外: EPIC #2525 へ re-home（PO 判断 2026-06-03）**。観察2 は ops/license backend のため license-key 廃止 EPIC に帰属し独立していない。observability 要件は #2525 配下で確定後に対応 |
| AC6 | interface `LicenseKeyCountResponse` の backend field を narrow | — | **scope 外: EPIC #2525 へ re-home（PO 判断 2026-06-03）** |
| AC7 | unit test 追加 (3 backend 各値) | — | **scope 外: EPIC #2525 へ re-home（PO 判断 2026-06-03）** |
| AC8 | migration plan §6 実績ログテーブル ヘッダ更新 | — | **scope 外: EPIC #2525 へ re-home（PO 判断 2026-06-03）** |

### OSS / 確立パターン調査結果 (ADR-0014 / #1350)

title→type:* label 機構の実装にあたり、新規 3rd-party action 導入を含め以下を比較した。

| 選択肢 | 概要 | 判定 | 理由 |
|--------|------|------|------|
| **自前 github-script step**（採用） | 既存 `pr-info.yml`（`permissions: pull-requests: write` 保持）に github-script の job を約 15 行で add-only | **採用** | labeler.yml を一切触らず area:* の責務を侵さない。pin version も既存慣習 `actions/github-script@v9` を踏襲。bundle / 学習コストゼロ |
| srvaroa/labeler | title / branch / 複合条件で label 付与可能な OSS labeler | 不採用 | `.github/labeler.yml` を奪い既存 area:* glob 全面移行が必要 = Issue no-gos「labeler 大改修」に直撃。Pre-PMF 過剰コスト (ADR-0010) |
| bcoe/conventional-release-labels 等 | Conventional Commits 接頭辞で label 付与する action | 不採用 | 最終更新 4 年 stale。保守リスク高 |
| actions/labeler (既存) | file-glob ベースの公式 labeler | 不採用（title 用途として） | **PR title を見ない仕様**（本 Issue の真因そのもの）。area:* 用途では引き続き使用、責務分離 |

確立パターン: GitHub Actions の「軽量 1 回限りの label 操作は github-script + REST API で完結」という慣習に整合（既存 `pr-info.yml` の size-check / overlap-check も同パターン）。

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

<!-- 本 PR は CI workflow の追加であり infra に分類。Issue label は当初 type:fix だが、
     実体は .github/workflows/ への CI job 追加のため infra が正（PULL_REQUEST_TEMPLATE.md 変更タイプ準拠）。
     本 PR の type-label job が稼働すれば title 接頭辞 "infra:" から type:infra が自動付与される（ドッグフーディング）。 -->

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: CI workflow `pr-info.yml`（PR open/synchronize/reopen 時に type:* label を自動付与）。アプリ本体・UI への影響なし。`labeler.yml`（area:*）は不変。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）: 本 PR は `.github/` のみの変更（src / site / labels.ts いずれも不変）のため pre-ready の対象 step (biome/svelte-check/vitest/hardcoded-strings/lp-dimensions/check-no-plan-literals 等) に該当差分なし。YAML 妥当性は `python yaml.safe_load` で PARSE OK + 3 job 認識を確認、正規表現は `node -e` で 8 接頭辞 + 未知接頭辞を試験（下記）
- [x] 追加・変更したテストの概要: N/A（CI workflow の追加であり、ロジック検証は github-script script の正規表現を `node -e` で全 8 接頭辞 + variant + 未知接頭辞について手動試験。workflow job 自体の E2E は GitHub Actions 実環境での稼働で確認される）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（`secrets.GITHUB_TOKEN` は既存、新規 env なし）
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:low）

### 正規表現 動作確認

`node -e` で `/^(feat|fix|refactor|design|infra|test|docs|marketing)(\(.+\))?!?:/i` を検証:

```
type:feat          <- "feat: 新機能"
type:fix           <- "fix: バグ修正"
type:refactor      <- "refactor: リファクタ"
type:design        <- "design: UI改善"
type:infra         <- "infra: #2495 PR title 接頭辞→type:* label 自動付与 (観察1)"
type:test          <- "test: テスト改善"
type:docs          <- "docs: ドキュメント"
type:marketing     <- "marketing: LP更新"
type:feat          <- "feat(auth): scope付き"
type:fix           <- "fix!: breaking change"
type:feat          <- "feat(api)!: scope + breaking"
type:feat          <- "FEAT: 大文字"
(無干渉)            <- "build: ビルド (未知)"
(無干渉)            <- "chore: 雑務 (未知)"
(無干渉)            <- "ci: CI (未知)"
(無干渉)            <- "perf: 高速化 (未知)"
(無干渉)            <- "style: スタイル (未知)"
(無干渉)            <- "WIP feat: 接頭辞でない"
(無干渉)            <- "ランダムタイトル"
```

8 接頭辞 + scope/breaking variant + 大文字を正しく map、label 不在 type (build/chore/ci/perf/style) と非接頭辞は無干渉（job を落とさない）。

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は CI workflow (`.github/workflows/pr-info.yml`) と `.github/CLAUDE.md` のみの変更で、UI / 画面描画への影響は一切ない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（type-label job は title→type 付与のみ）。area:* (labeler.yml) と責務分離
- [x] **DRY**: 既存 `pr-info.yml` の size-check / overlap-check と同じ github-script パターンを踏襲。新規依存なし
- [x] **YAGNI**: 乖離検出 / release-notes 等の付加機能は追加せず（ADR-0010 過剰防衛回避）。最小 15 行ロジックのみ
- [x] **Security（OSS 公開前提）**: 秘密情報 hardcode なし。`secrets.GITHUB_TOKEN` の既定権限 (`pull-requests: write`) のみ使用。fork PR ではないため `pull_request`（`pull_request_target` 不使用）
- [x] **アクセシビリティ**: N/A（CI workflow）
- [x] **パフォーマンス**: N/A（PR ごとに 1 回の軽量 REST 呼び出し）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001): `.github/CLAUDE.md` に type:* label 自動付与ルールを明記（PR 運用ドキュメント = 本変更の SSOT）
- [x] 並行 PR overlap 確認 (#1200): `.github/workflows/pr-info.yml` + `.github/CLAUDE.md` のみ変更、overlap リスク低
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- `labeler.yml`（area:*）は一切変更していない点（責務分離）を確認願います。
- 観察2 (AC5-8、ops/license backend 3 値化) は本 PR scope 外。EPIC #2525 へ re-home 済（Issue #2495 にコメント投稿、PO 判断 2026-06-03）。観察2 を本 PR で実装していないことは意図的です。
- 本 PR の type-label job が初回稼働すると、本 PR 自身の title `infra:` から `type:infra` が自動付与される想定（ドッグフーディング）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2808` 全 Step PASS** をローカル確認した — Step1-8 PASS（biome clean / svelte-check 0 errors / vitest / check-hardcoded-strings / check-no-plan-literals）。LP系 Step5/6/8 は非 LP 変更で skip。環境は `npm ci` + `cd infra && npm ci` で同期後に実行
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— 2 file（`.github/workflows/pr-info.yml` add-only job / `.github/CLAUDE.md` 追記）、`git diff --stat` で確認
- [x] 全 AC が実装済み — 観察1 AC（type:* 自動付与）全 PASS。観察2 は EPIC #2525 へ re-home（scope 外、PO 判断 2026-06-03）
- [x] UI 変更時: N/A（UI 変更なし、workflow + docs のみ）
- [x] 認証画面変更時: N/A（認証画面変更なし）

<!-- 本 PR は Draft。Ready 化は QM 判断後。Ready チェックリストは Ready 化時にチェックする。 -->

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


