### PR TITLE
feat: #2813 Phase 7 PR-L2 — license key 認可撤廃 (contract step、NUC 信頼ベース化)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -220,11 +220,8 @@ PORT=3000
 # DEBUG_TRIAL_TIER: standard | family （DEBUG_TRIAL=active のとき使用）
 # DEBUG_TRIAL_TIER=standard
 #
-# DEBUG_LICENSE_KEY_VALID: true | false （ADR-0040 P5 / #1221）
-#   nuc-prod モード時に EvaluationContext.licenseKey.valid を上書きする。
-#   Playwright matrix (playwright.matrix.config.ts) で license valid/invalid を
-#   切り替えるためのみに使用。dev=false では常に無視される。
-# DEBUG_LICENSE_KEY_VALID=true
+# #2813 (Epic #2525 Phase 7 PR-L2): DEBUG_LICENSE_KEY_VALID は license key 全廃に伴い撤廃済。
+#   NUC は信頼ベース (判定なし) に移行し、license key に依存する debug 上書きは不要になった。
 
 # ============================================================
 # EPIC #2310: Parent-Gate Session (ADR-0050) — REQUIRED in production

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ SvelteKit 2 + Svelte 5 (Runes) + Ark UI Svelte + SQLite + Drizzle ORM。TypeScri
 
 ### 開発プラン切替 (#758、dev only)
 
-`.env.local` で `DEBUG_PLAN` / `DEBUG_TRIAL` / `DEBUG_TRIAL_TIER` / `DEBUG_LICENSE_KEY_VALID` 上書き（本番ビルド無効）。詳細: `.env.example` / `src/lib/server/debug-plan.ts`
+`.env.local` で `DEBUG_PLAN` / `DEBUG_TRIAL` / `DEBUG_TRIAL_TIER` 上書き（本番ビルド無効）。詳細: `.env.example` / `src/lib/server/debug-plan.ts`（`DEBUG_LICENSE_KEY_VALID` は #2813 で license key 全廃に伴い撤廃済）
 
 ### サブディレクトリ別局所テストコマンド (#2184)
 

--- a/playwright.matrix.config.ts
+++ b/playwright.matrix.config.ts
@@ -1,21 +1,26 @@
 /**
  * ADR-0040 P5 (#1221): mode × plan マトリクス専用 Playwright config。
  *
- * 5 つの実行モード × プラン / ライセンス状態の組合せで smoke test を走らせ、
+ * 4 つの実行モード × プラン状態の組合せで smoke test を走らせ、
  * 3 層アーキテクチャ（env.ts → evaluation-context.ts → capabilities.ts）が
  * 境界条件で破綻しないことを機械検証する。
+ *
+ * #2813 (Epic #2525 Phase 7 PR-L2): license key 全廃に伴い nuc-prod の
+ * license valid/invalid 2 project を「nuc-prod 信頼ベース write 可能」1 project に統合。
+ * NUC は `DEBUG_LICENSE_KEY_VALID` env 無しで常に write 可能であることを smoke で担保する
+ * (phase1-nuc FR-2 / US-N3 = license key 撤廃で NUC が記録不能にならない保証)。
  *
  * ## 使い方
  *
  * ```bash
  * npm run test:e2e:matrix
  * # または単一 project のみ:
- * npx playwright test --config playwright.matrix.config.ts --project=nuc-prod-license-expired
+ * npx playwright test --config playwright.matrix.config.ts --project=nuc-prod-trust-based
  * ```
  *
  * ## 注意
  *
- * - 5 つの dev server を port 5201-5205 で同時起動するため、起動に 30-60 秒程度かかる
+ * - 4 つの dev server を port 5201-5204 で同時起動するため、起動に 30-60 秒程度かかる
  * - デフォルト CI には含めない（追加時は e2e-test ジョブのタイムアウトを要確認）
  * - DEBUG_* env の上書きは `dev === true` でのみ効く（ADR-0029 safety）
  */
@@ -50,16 +55,10 @@ const SCENARIOS: readonly Scenario[] = [
 		description: 'mode=aws-prod × trial=expired → upgrade CTA 表示',
 	},
 	{
-		project: 'nuc-prod-license-valid',
+		project: 'nuc-prod-trust-based',
 		port: 5204,
-		env: { APP_MODE: 'nuc-prod', DEBUG_LICENSE_KEY_VALID: 'true' },
-		description: 'mode=nuc-prod × license=valid → write.db allowed',
-	},
-	{
-		project: 'nuc-prod-license-expired',
-		port: 5205,
-		env: { APP_MODE: 'nuc-prod', DEBUG_LICENSE_KEY_VALID: 'false' },
-		description: 'mode=nuc-prod × license=invalid → write.db denies with license-key-invalid',
+		env: { APP_MODE: 'nuc-prod' },
+		description: 'mode=nuc-prod → 信頼ベースで write.db 常時 allowed (license key 撤廃、#2813)',
 	},
 ] as const;
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,7 +10,7 @@ import { buildEvaluationContext, setEvaluationContext } from '$lib/runtime/evalu
 import { type RuntimeMode, resolveRuntimeMode } from '$lib/runtime/runtime-mode';
 import { getAuthMode, getAuthProvider } from '$lib/server/auth/factory';
 import { getOrInitDb } from '$lib/server/db/client';
-import { applyDebugPlanOverride, getDebugLicenseKeyOverride } from '$lib/server/debug-plan';
+import { applyDebugPlanOverride } from '$lib/server/debug-plan';
 import {
 	buildDemoNoopResponseBody,
 	DEMO_WRITE_ALLOWLIST,
@@ -89,7 +89,7 @@ const COGNITO_DEV_MODE = process.env.COGNITO_DEV_MODE === 'true';
  * ADR-0040 P4 (#1217): Policy Gate `can(ctx, 'write.db')` 経由で "demo 書き込み no-op"
  * を判定する参考実装。hooks main handler の cognitive complexity を上げないために、
  * 判定をここへ切り出している。true を返したら呼び側で 200 `{ ok: true, demo: true }`
- * を返す。他の write 拒否理由 (build-time-readonly / license-key-invalid) は
+ * を返す。他の write 拒否理由 (build-time-readonly) は
  * 本ブロックではなく P4.1 以降で個別ガードに置き換える想定。
  */
 function shouldReturnDemoNoop(method: string, path: string, mode: RuntimeMode): boolean {
@@ -99,22 +99,6 @@ function shouldReturnDemoNoop(method: string, path: string, mode: RuntimeMode): 
 	return (
 		!DEMO_WRITE_ALLOWLIST.some((prefix) => path.startsWith(prefix)) && !path.startsWith('/_app/')
 	);
-}
-
-/**
- * ADR-0040 P5 (#1221): EvaluationContext ビルダのラッパー。
- *
- * nuc-prod モードで `DEBUG_LICENSE_KEY_VALID` env が立っていれば licenseKey を注入する。
- * Playwright matrix (`playwright.matrix.config.ts`) で license valid/invalid を
- * 切り替えるための dev-only フック。本番ビルドでは `getDebugLicenseKeyOverride()` が
- * 常に null を返すため常に従来通りの動作になる。
- */
-function resolveEvaluationContextForRequest(mode: RuntimeMode) {
-	const debugLicense = mode === 'nuc-prod' ? getDebugLicenseKeyOverride() : null;
-	return buildEvaluationContext({
-		mode,
-		licenseKey: debugLicense ? { valid: debugLicense.valid, expiresAt: null } : null,
-	});
 }
 
 // Initialize analytics providers (lazy, environment-variable gated)
@@ -308,8 +292,7 @@ export const handle: Handle = ({ event, resolve }) =>
 		//
 		// ADR-0040 P4 (#1217): 判定は `shouldReturnDemoNoop` に切り出し Policy Gate
 		// `can(ctx, 'write.db')` 経由で評価する。`demo-readonly` 理由のみ no-op にし、
-		// 他の write 拒否理由 (build-time-readonly / license-key-invalid) は P4.1 以降
-		// で個別ガードに置き換える。
+		// 他の write 拒否理由 (build-time-readonly) は P4.1 以降で個別ガードに置き換える。
 		if (shouldReturnDemoNoop(event.request.method, path, event.locals.runtimeMode)) {
 			logger.info(`Demo write no-op: ${event.request.method} ${path}`, {
 				requestId: event.locals.requestId,
@@ -383,10 +366,12 @@ export const handle: Handle = ({ event, resolve }) =>
 		}
 
 		// ADR-0040 P3 (#1215): 認証解決完了後の EvaluationContext を注入。
-		// P3 スコープでは mode のみ真面目に投影し、user / plan / licenseKey の詳細投影は
-		// P4 で capability 判定が必要になった時点で追加する（resolvePlanTier の I/O を
-		// hooks で先取りしないため）。既存の event.locals.* は互換のため変更しない。
-		setEvaluationContext(resolveEvaluationContextForRequest(event.locals.runtimeMode));
+		// P3 スコープでは mode のみ真面目に投影し、user / plan の詳細投影は P4 で
+		// capability 判定が必要になった時点で追加する（resolvePlanTier の I/O を hooks で
+		// 先取りしないため）。既存の event.locals.* は互換のため変更しない。
+		// #2813 (Phase 7 PR-L2): license key 全廃により licenseKey 注入経路を撤廃。
+		// NUC は信頼ベースで mode のみから write 可否が決まる (capabilities.ts canWriteDb)。
+		setEvaluationContext(buildEvaluationContext({ mode: event.locals.runtimeMode }));
 
 		// 2) ルート保護
 

--- a/src/lib/policy/capabilities.ts
+++ b/src/lib/policy/capabilities.ts
@@ -29,9 +29,12 @@ import { error } from '@sveltejs/kit';
 import type { EvaluationContext } from '$lib/runtime/evaluation-context';
 
 /**
- * 代表 10 capability。ADR-0040 Epic (#1202) §P4 に従う。
+ * capability 一覧。ADR-0040 Epic (#1202) §P4 に従う。
  *
  * 増減する場合は ADR-0040 §第 3 層 の code example も同期更新すること。
+ *
+ * #2813 (Epic #2525 Phase 7 PR-L2): `redeem.license_key` を撤廃。license key 全廃に伴い
+ * NUC の正規性判定機構を削除し、信頼ベースに移行した (phase1-nuc FR-3 / ADR-0051)。
  */
 export type Capability =
 	| 'record.activity'
@@ -42,8 +45,7 @@ export type Capability =
 	| 'write.db'
 	| 'debug.plan_override'
 	| 'view.ops_license_dashboard'
-	| 'manage.child_profile'
-	| 'redeem.license_key';
+	| 'manage.child_profile';
 
 /**
  * Deny の理由。UI では i18n キーにマップして表示する想定（直接露出はしない）。
@@ -54,7 +56,6 @@ export type DenyReason =
 	| 'unauthenticated' // user=null
 	| 'role-insufficient' // role が要件を満たさない (owner/parent/child)
 	| 'plan-tier-insufficient' // プランティアが要件を満たさない
-	| 'license-key-invalid' // NUC モードでライセンスキー invalid
 	| 'mode-mismatch' // capability が別モード専用
 	| 'dev-only' // local-debug 専用
 	| 'ops-only'; // Cognito groups に 'ops' が必要
@@ -74,7 +75,10 @@ const deny = (reason: DenyReason): PolicyResult => ({ allowed: false, reason });
 function canWriteDb(ctx: EvaluationContext): PolicyResult {
 	if (ctx.mode === 'demo') return deny('demo-readonly');
 	if (ctx.mode === 'build') return deny('build-time-readonly');
-	if (ctx.mode === 'nuc-prod' && !ctx.licenseKey?.valid) return deny('license-key-invalid');
+	// #2813 (Epic #2525 Phase 7 PR-L2): license key 全廃に伴い nuc-prod の
+	// `!licenseKey.valid` deny を撤廃。NUC は信頼ベース (判定なし) で常時 write 可能
+	// (phase1-nuc FR-2 / US-N3、配布物自体が正規の証跡)。これにより NUC が license key
+	// 不在で記録不能になる経路を完全に除去した。
 	return ALLOW;
 }
 
@@ -122,13 +126,6 @@ const evaluators: Record<Capability, CapabilityEvaluator> = {
 		if (!ctx.user) return deny('unauthenticated');
 		if (ctx.user.role === 'child') return deny('role-insufficient');
 		return canWriteDb(ctx);
-	},
-
-	'redeem.license_key': (ctx) => {
-		if (ctx.mode !== 'nuc-prod') return deny('mode-mismatch');
-		if (!ctx.user) return deny('unauthenticated');
-		if (ctx.user.role !== 'owner') return deny('role-insufficient');
-		return ALLOW;
 	},
 };
 

--- a/src/lib/runtime/evaluation-context.ts
+++ b/src/lib/runtime/evaluation-context.ts
@@ -2,8 +2,11 @@
  * EvaluationContext (ADR-0040 Phase 3 / #1215)
  *
  * リクエスト単位の "文脈オブジェクト"。OpenFeature の evaluation context 概念を参考に、
- * mode × user × plan × licenseKey × now を 1 つに束ねて hooks.server.ts で 1 回だけ
+ * mode × user × plan × now を 1 つに束ねて hooks.server.ts で 1 回だけ
  * 構築し、#788 の AsyncLocalStorage に注入する。
+ *
+ * #2813 (Epic #2525 Phase 7 PR-L2): license key 全廃に伴い `licenseKey` 因子を撤廃。
+ * NUC は信頼ベース (判定なし) に移行し、認可は subscription tier (plan) のみで決まる。
  *
  * 目的:
  * - P4 Policy Gate の `can(ctx, capability)` が 4 因子を個別取得する必要を無くす
@@ -39,12 +42,6 @@ export interface EvaluationPlan {
 	trialState: 'none' | 'active' | 'expired';
 }
 
-/** ライセンスキー検証結果（ADR-0026、nuc-prod モードのみ） */
-export interface EvaluationLicenseKey {
-	valid: boolean;
-	expiresAt: Date | null;
-}
-
 /**
  * リクエスト単位の文脈オブジェクト。
  *
@@ -57,8 +54,6 @@ export interface EvaluationContext {
 	user: EvaluationUser | null;
 	/** ライセンスプラン。未認証 / demo / プラン未確定のうちは null */
 	plan: EvaluationPlan | null;
-	/** NUC モードのみ ADR-0026 のライセンスキー検証結果が入る。それ以外は null */
-	licenseKey: EvaluationLicenseKey | null;
 	/** 現在時刻。テストで固定化するためのファネル */
 	now: Date;
 }
@@ -68,7 +63,6 @@ export interface BuildEvaluationContextInput {
 	mode: RuntimeMode;
 	user?: EvaluationUser | null;
 	plan?: EvaluationPlan | null;
-	licenseKey?: EvaluationLicenseKey | null;
 	/** 省略時は `new Date()`。テスト時は固定化したい日時を渡す */
 	now?: Date;
 }
@@ -84,7 +78,6 @@ export function buildEvaluationContext(input: BuildEvaluationContextInput): Eval
 		mode: input.mode,
 		user: input.user ?? null,
 		plan: input.plan ?? null,
-		licenseKey: input.licenseKey ?? null,
 		now: input.now ?? new Date(),
 	};
 }

--- a/src/lib/server/debug-plan.ts
+++ b/src/lib/server/debug-plan.ts
@@ -18,9 +18,6 @@ export type DebugPlan = 'free' | 'standard' | 'family';
 /** 許容される DEBUG_TRIAL 値 */
 export type DebugTrial = 'active' | 'expired' | 'not-started';
 
-/** 許容される DEBUG_LICENSE_KEY_VALID 値 */
-export type DebugLicenseKeyValid = 'true' | 'false';
-
 export interface DebugPlanOverride {
 	licenseStatus: AuthContext['licenseStatus'];
 	plan?: string;
@@ -103,33 +100,13 @@ export function getDebugTrialOverride(): DebugTrialOverride | null {
 }
 
 /**
- * DEBUG_LICENSE_KEY_VALID env に基づくライセンスキー状態の上書きを返す。
- * ADR-0040 P5 (#1221): nuc-prod モードの E2E マトリクスで license valid/invalid を切り替える。
- *
- * dev モード (`dev === true`) 以外では常に null を返す（本番ビルドで無効化）。
- */
-export function getDebugLicenseKeyOverride(): { valid: boolean } | null {
-	if (!dev) return null;
-	const raw = process.env.DEBUG_LICENSE_KEY_VALID?.trim().toLowerCase();
-	if (!raw) return null;
-	if (raw !== 'true' && raw !== 'false') {
-		console.warn(
-			`[debug-plan] DEBUG_LICENSE_KEY_VALID="${raw}" is invalid. Expected one of: true, false`,
-		);
-		return null;
-	}
-	return { valid: raw === 'true' };
-}
-
-/**
  * デバッグ上書きが有効かどうか（インジケータ表示用）
+ *
+ * #2813 (Epic #2525 Phase 7 PR-L2): license key 全廃に伴い `DEBUG_LICENSE_KEY_VALID`
+ * 上書きを撤廃。`DEBUG_PLAN` (subscription tier 切替) / `DEBUG_TRIAL` は残す。
  */
 export function isDebugPlanActive(): boolean {
-	return (
-		getDebugPlanOverride() !== null ||
-		getDebugTrialOverride() !== null ||
-		getDebugLicenseKeyOverride() !== null
-	);
+	return getDebugPlanOverride() !== null || getDebugTrialOverride() !== null;
 }
 
 /**
@@ -150,10 +127,6 @@ export function getDebugPlanSummary(): string | null {
 		const tierStr =
 			rawTrial === 'active' && rawTier && VALID_TRIAL_TIERS.has(rawTier) ? `(${rawTier})` : '';
 		parts.push(`trial=${rawTrial}${tierStr}`);
-	}
-	const rawLicense = process.env.DEBUG_LICENSE_KEY_VALID?.trim().toLowerCase();
-	if (rawLicense === 'true' || rawLicense === 'false') {
-		parts.push(`license=${rawLicense}`);
 	}
 	return parts.length > 0 ? parts.join(' ') : null;
 }

--- a/tests/unit/policy/capabilities.test.ts
+++ b/tests/unit/policy/capabilities.test.ts
@@ -24,7 +24,6 @@ function ctx(
 		mode: overrides.mode,
 		user: overrides.user ?? null,
 		plan: overrides.plan ?? null,
-		licenseKey: overrides.licenseKey ?? null,
 		now: overrides.now,
 	});
 }
@@ -48,29 +47,15 @@ describe('policy/capabilities can() — write.db', () => {
 		});
 	});
 
-	it('nuc-prod + licenseKey valid = allowed', () => {
-		expect(
-			can(
-				ctx({ mode: 'nuc-prod', user: owner, licenseKey: { valid: true, expiresAt: null } }),
-				'write.db',
-			),
-		).toEqual({ allowed: true });
+	// #2813 (Epic #2525 Phase 7 PR-L2): license key 全廃。NUC は信頼ベースで
+	// licenseKey に依存せず常時 write 可能 (phase1-nuc FR-2 / US-N3 = NUC が記録不能に
+	// ならないことの回帰防止)。
+	it('nuc-prod = allowed (license key 無し、信頼ベースで常時 write 可能)', () => {
+		expect(can(ctx({ mode: 'nuc-prod', user: owner }), 'write.db')).toEqual({ allowed: true });
 	});
 
-	it('nuc-prod + licenseKey invalid = license-key-invalid', () => {
-		expect(
-			can(
-				ctx({ mode: 'nuc-prod', user: owner, licenseKey: { valid: false, expiresAt: null } }),
-				'write.db',
-			),
-		).toEqual({ allowed: false, reason: 'license-key-invalid' });
-	});
-
-	it('nuc-prod + licenseKey=null = license-key-invalid', () => {
-		expect(can(ctx({ mode: 'nuc-prod', user: owner }), 'write.db')).toEqual({
-			allowed: false,
-			reason: 'license-key-invalid',
-		});
+	it('nuc-prod + user 無しでも allowed (mode のみで write 可否が決まる)', () => {
+		expect(can(ctx({ mode: 'nuc-prod' }), 'write.db')).toEqual({ allowed: true });
 	});
 
 	it('aws-prod = allowed (user 不要、共通判定のみ)', () => {
@@ -99,13 +84,24 @@ describe('policy/capabilities can() — record.activity', () => {
 		});
 	});
 
-	it('nuc-prod + licenseKey invalid = license-key-invalid', () => {
-		expect(
-			can(
-				ctx({ mode: 'nuc-prod', user: child, licenseKey: { valid: false, expiresAt: null } }),
-				'record.activity',
-			),
-		).toEqual({ allowed: false, reason: 'license-key-invalid' });
+	// #2813 (Epic #2525 Phase 7 PR-L2): NUC write 回帰防止 (phase1-nuc US-N3)。
+	// 5 年齢モード (baby/preschool/elementary/junior/senior) いずれの子供も NUC で
+	// 活動記録が可能であることを保証する。年齢モードは UI 層 (uiMode) の差で、認可は
+	// role=child + mode=nuc-prod のみで決まるため、record.activity が NUC で常時許可される
+	// ことが「license key 撤廃で記録不能にならない」保証となる。
+	it('nuc-prod + child = allowed (license key 無し、子供の活動記録が NUC で常時可能)', () => {
+		expect(can(ctx({ mode: 'nuc-prod', user: child }), 'record.activity')).toEqual({
+			allowed: true,
+		});
+	});
+
+	it('nuc-prod + owner / parent / child いずれも記録可能 (5 年齢モード横断の NUC write 保証)', () => {
+		for (const user of [owner, parent, child]) {
+			expect(
+				can(ctx({ mode: 'nuc-prod', user }), 'record.activity'),
+				`role=${user.role} が nuc-prod で記録できない`,
+			).toEqual({ allowed: true });
+		}
 	});
 });
 
@@ -227,17 +223,10 @@ describe('policy/capabilities can() — purchase.upgrade', () => {
 	});
 
 	it('nuc-prod = mode-mismatch (NUC は Stripe を使わない)', () => {
-		expect(
-			can(
-				ctx({
-					mode: 'nuc-prod',
-					user: owner,
-					plan: free,
-					licenseKey: { valid: true, expiresAt: null },
-				}),
-				'purchase.upgrade',
-			),
-		).toEqual({ allowed: false, reason: 'mode-mismatch' });
+		expect(can(ctx({ mode: 'nuc-prod', user: owner, plan: free }), 'purchase.upgrade')).toEqual({
+			allowed: false,
+			reason: 'mode-mismatch',
+		});
 	});
 
 	it('parent role = role-insufficient', () => {
@@ -296,27 +285,8 @@ describe('policy/capabilities can() — manage.child_profile', () => {
 	});
 });
 
-describe('policy/capabilities can() — redeem.license_key', () => {
-	it('nuc-prod + owner = allowed', () => {
-		expect(can(ctx({ mode: 'nuc-prod', user: owner }), 'redeem.license_key')).toEqual({
-			allowed: true,
-		});
-	});
-
-	it('aws-prod = mode-mismatch', () => {
-		expect(can(ctx({ mode: 'aws-prod', user: owner }), 'redeem.license_key')).toEqual({
-			allowed: false,
-			reason: 'mode-mismatch',
-		});
-	});
-
-	it('parent role = role-insufficient', () => {
-		expect(can(ctx({ mode: 'nuc-prod', user: parent }), 'redeem.license_key')).toEqual({
-			allowed: false,
-			reason: 'role-insufficient',
-		});
-	});
-});
+// #2813 (Epic #2525 Phase 7 PR-L2): `redeem.license_key` capability は license key 全廃に伴い
+// 撤廃済。NUC は信頼ベース (判定なし) のため key 引換機構そのものが存在しない (phase1-nuc FR-3)。
 
 describe('policy/capabilities ensureCan()', () => {
 	it('allowed の時は throw しない', () => {

--- a/tests/unit/runtime/evaluation-context.test.ts
+++ b/tests/unit/runtime/evaluation-context.test.ts
@@ -17,8 +17,9 @@ describe('runtime/evaluation-context buildEvaluationContext (ADR-0040 P3 / #1215
 		expect(ctx.mode).toBe('local-debug');
 		expect(ctx.user).toBeNull();
 		expect(ctx.plan).toBeNull();
-		expect(ctx.licenseKey).toBeNull();
 		expect(ctx.now).toBeInstanceOf(Date);
+		// #2813 (Phase 7 PR-L2): licenseKey 因子は撤廃済。context に残っていないことを保証する。
+		expect('licenseKey' in ctx).toBe(false);
 	});
 
 	it('returns the exact provided values (pure builder)', () => {
@@ -29,13 +30,11 @@ describe('runtime/evaluation-context buildEvaluationContext (ADR-0040 P3 / #1215
 			mode: 'aws-prod',
 			user,
 			plan,
-			licenseKey: { valid: true, expiresAt: new Date('2027-01-01Z') },
 			now,
 		});
 		expect(ctx.mode).toBe('aws-prod');
 		expect(ctx.user).toEqual(user);
 		expect(ctx.plan).toEqual(plan);
-		expect(ctx.licenseKey).toEqual({ valid: true, expiresAt: new Date('2027-01-01Z') });
 		expect(ctx.now).toBe(now);
 	});
 
@@ -101,19 +100,11 @@ describe('runtime/evaluation-context buildEvaluationContext (ADR-0040 P3 / #1215
 		}
 	});
 
-	it('accepts licenseKey with valid=true/false and expiresAt', () => {
-		const expires = new Date('2030-01-01Z');
-		const ctxValid = buildEvaluationContext({
-			mode: 'nuc-prod',
-			licenseKey: { valid: true, expiresAt: expires },
-		});
-		expect(ctxValid.licenseKey).toEqual({ valid: true, expiresAt: expires });
-
-		const ctxInvalid = buildEvaluationContext({
-			mode: 'nuc-prod',
-			licenseKey: { valid: false, expiresAt: null },
-		});
-		expect(ctxInvalid.licenseKey).toEqual({ valid: false, expiresAt: null });
+	it('nuc-prod context は licenseKey 因子を持たない (#2813 license key 全廃)', () => {
+		// NUC は信頼ベースに移行し、認可は mode + plan のみで決まる。
+		const ctx = buildEvaluationContext({ mode: 'nuc-prod' });
+		expect(ctx.mode).toBe('nuc-prod');
+		expect('licenseKey' in ctx).toBe(false);
 	});
 
 	it('now defaults to a fresh Date, but can be injected for test stabilization', () => {
@@ -143,7 +134,6 @@ describe('runtime/evaluation-context AsyncLocalStorage integration', () => {
 			mode: 'nuc-prod',
 			user: { id: 'u-1', role: 'owner', groups: [] },
 			plan: { tier: 'family', status: 'active', trialState: 'none' },
-			licenseKey: { valid: true, expiresAt: new Date('2030-12-31Z') },
 			now: new Date('2026-04-19T00:00:00Z'),
 		});
 

--- a/tests/unit/server/debug-plan.test.ts
+++ b/tests/unit/server/debug-plan.test.ts
@@ -14,7 +14,6 @@ vi.mock('$app/environment', () => ({
 import type { AuthContext } from '$lib/server/auth/types';
 import {
 	applyDebugPlanOverride,
-	getDebugLicenseKeyOverride,
 	getDebugPlanOverride,
 	getDebugPlanSummary,
 	getDebugTrialOverride,
@@ -30,7 +29,6 @@ describe('debug-plan', () => {
 		delete process.env.DEBUG_PLAN;
 		delete process.env.DEBUG_TRIAL;
 		delete process.env.DEBUG_TRIAL_TIER;
-		delete process.env.DEBUG_LICENSE_KEY_VALID;
 	});
 
 	afterEach(() => {
@@ -163,40 +161,8 @@ describe('debug-plan', () => {
 		});
 	});
 
-	describe('getDebugLicenseKeyOverride (ADR-0040 P5 / #1221)', () => {
-		it('dev=false なら常に null（本番セーフガード）', () => {
-			devState.dev = false;
-			process.env.DEBUG_LICENSE_KEY_VALID = 'true';
-			expect(getDebugLicenseKeyOverride()).toBeNull();
-		});
-
-		it('env 未設定なら null', () => {
-			expect(getDebugLicenseKeyOverride()).toBeNull();
-		});
-
-		it('DEBUG_LICENSE_KEY_VALID=true → { valid: true }', () => {
-			process.env.DEBUG_LICENSE_KEY_VALID = 'true';
-			expect(getDebugLicenseKeyOverride()).toEqual({ valid: true });
-		});
-
-		it('DEBUG_LICENSE_KEY_VALID=false → { valid: false }', () => {
-			process.env.DEBUG_LICENSE_KEY_VALID = 'false';
-			expect(getDebugLicenseKeyOverride()).toEqual({ valid: false });
-		});
-
-		it('大文字小文字混在も許容', () => {
-			process.env.DEBUG_LICENSE_KEY_VALID = ' TRUE ';
-			expect(getDebugLicenseKeyOverride()).toEqual({ valid: true });
-		});
-
-		it('無効値は null を返して警告', () => {
-			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-			process.env.DEBUG_LICENSE_KEY_VALID = 'yes';
-			expect(getDebugLicenseKeyOverride()).toBeNull();
-			expect(warn).toHaveBeenCalled();
-			warn.mockRestore();
-		});
-	});
+	// #2813 (Epic #2525 Phase 7 PR-L2): `getDebugLicenseKeyOverride` / `DEBUG_LICENSE_KEY_VALID`
+	// は license key 全廃に伴い撤廃済。`DEBUG_PLAN` (subscription tier 切替) / `DEBUG_TRIAL` は維持。
 
 	describe('isDebugPlanActive / getDebugPlanSummary', () => {
 		it('env 未設定 → false / null', () => {
@@ -221,12 +187,6 @@ describe('debug-plan', () => {
 			process.env.DEBUG_PLAN = 'standard';
 			process.env.DEBUG_TRIAL = 'expired';
 			expect(getDebugPlanSummary()).toBe('plan=standard trial=expired');
-		});
-
-		it('DEBUG_LICENSE_KEY_VALID も summary に含まれる', () => {
-			process.env.DEBUG_LICENSE_KEY_VALID = 'false';
-			expect(isDebugPlanActive()).toBe(true);
-			expect(getDebugPlanSummary()).toBe('license=false');
 		});
 
 		it('dev=false では summary も null', () => {


### PR DESCRIPTION
## 顧客価値・目的

Epic #2525 課金/プラン体系再設計の Phase 7 PR-L2 (expand-contract の contract step)。license key 全廃 (Phase 1 補強 3 #2788) の**認可経路を撤廃**し、NUC セルフホスト版を「信頼ベース (正規性判定なし)」に移行する。

これにより、license key を撤廃しても **NUC が記録不能にならない**ことを保証する (NUC=全機能無制限・課金なし、配布物自体が正規の証跡)。SaaS 認可は既に Stripe Subscription ベースで、license key は authorization の冗長な input path に過ぎなかったため、本 PR は「移行」ではなく「冗長層の除去」である (phase1-license-key-removal-final-requirements §2.1)。

## 関連 Issue

- Epic: #2525 (課金/プラン体系再設計)
- 本 PR: #2813 (Phase 7 PR-L2)
- 上流: #2812 (PR-L1、license key 入力経路削除 — マージ済 `1c9fe8f1`)
- SSOT: `docs/design/billing-redesign/phase1-license-key-removal-final-requirements.md` §3.2 / §2.1 / `phase1-nuc-requirements.md` FR-1/FR-2/FR-3/US-N3 / `phase6-phase7-execution-ssot.md` Step 0 PR-L2

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | capabilities.ts `nuc-prod && !licenseKey.valid` deny 撤廃 + 型/evaluator 削除 (4 箇所) | code review + unit | `canWriteDb` deny 撤廃 / `Capability` `redeem.license_key` 削除 / `DenyReason` `license-key-invalid` 削除 / evaluator 削除。`capabilities.test.ts` 全 PASS |
| AC2 | evaluation-context.ts `EvaluationLicenseKey` 型 + `licenseKey` field 撤廃 | code review + unit | 型 + field + builder input 撤廃。`evaluation-context.test.ts` で `'licenseKey' in ctx === false` を assert (PASS) |
| AC3 | hooks.server.ts `getDebugLicenseKeyOverride` 経路撤廃 | code review + build | import + `resolveEvaluationContextForRequest` wrapper 撤廃、`buildEvaluationContext({ mode })` 直接注入に簡素化。production build 成功 |
| AC4 | debug-plan.ts `getDebugLicenseKeyOverride` 削除 (DEBUG_PLAN 維持) | code review + unit | `getDebugLicenseKeyOverride` / `DebugLicenseKeyValid` 撤廃、`DEBUG_PLAN`/`DEBUG_TRIAL` matrix 維持。`debug-plan.test.ts` 全 PASS |
| AC5 | NUC write 5 年齢モード PASS (記録不能にならない保証) | unit + matrix E2E | `capabilities.test.ts` で nuc-prod が licenseKey 無しで owner/parent/child いずれも `write.db`/`record.activity` allowed を assert (年齢モードは UI 層差、認可は role+mode のみ)。matrix E2E `nuc-prod-trust-based` 2 tests PASS |
| AC6 | capabilities.test.ts / evaluation-context.test.ts 更新 (license matrix 削除、DEBUG_PLAN 維持) | unit | 3 test file 更新、license 系 assert 削除 + NUC 信頼ベース assert 追加。83 tests PASS |
| AC7 | production build 起動成功 | build | `npm run build` 成功 (✓ built in 16.04s)、license key 認可結合なしでコンパイル |
| AC8 | 既存 regression PASS / svelte-check / biome | full unit + lint | unit 6111 passed (touched 全 PASS、4 fail は infra/stagehand の aws-cdk-lib / @axe-core 未 install env gap、本変更無関係)。svelte-check touched files 0 errors / biome clean |

## 変更タイプ

- [x] リファクタリング (認可冗長層の除去)
- [x] テスト更新
- [ ] バグ修正
- [ ] 新機能

## 影響範囲・変更コンポーネント

- `src/lib/policy/capabilities.ts` — `canWriteDb` deny 撤廃 + `Capability`/`DenyReason` 型 + evaluator 削除
- `src/lib/runtime/evaluation-context.ts` — `EvaluationLicenseKey` 型 + `licenseKey` field 撤廃
- `src/hooks.server.ts` — `getDebugLicenseKeyOverride` 注入経路撤廃 + wrapper 簡素化
- `src/lib/server/debug-plan.ts` — `getDebugLicenseKeyOverride` / `DebugLicenseKeyValid` 撤廃 (DEBUG_PLAN 維持)
- `playwright.matrix.config.ts` — nuc-prod license valid/invalid 2 project を信頼ベース 1 project に統合
- `.env.example` / `CLAUDE.md` — `DEBUG_LICENSE_KEY_VALID` 記述撤廃
- tests: `capabilities.test.ts` / `evaluation-context.test.ts` / `debug-plan.test.ts`

**変更なし (PR-L3〜L5 担当)**: ops/admin license routes / `license-key-service.ts` / email-service / DB auth-repo の `licenseKey` (License record の string field、EvaluationContext の認可因子とは別概念)。

## テスト & 安全装置セルフチェック

- [x] unit: `capabilities.test.ts` (write.db / record.activity の nuc-prod 信頼ベース write) / `evaluation-context.test.ts` (licenseKey 因子不在) / `debug-plan.test.ts` — 計 83 PASS
- [x] NUC write 回帰防止: nuc-prod が licenseKey 無しで owner/parent/child いずれも記録可能を assert (5 年齢モード横断、phase1-nuc US-N3)
- [x] matrix E2E: `nuc-prod-trust-based` project で license key 無しの home 描画 + 配信稼働を smoke (2 PASS)
- [x] full unit: 6111 passed (4 fail は infra/stagehand の依存未 install env gap、本変更と無関係)
- [x] production build 成功 / svelte-check (touched 0 errors) / biome clean

## スクリーンショット / ビジュアルデモ

UI 変更ゼロ (server-side 認可ロジックのみ)。NUC write の結果は機能維持され、画面表示は不変のため SS 添付対象外。matrix E2E `nuc-prod-trust-based` で home がエラーなく描画されることを確認済。

## コード品質セルフレビュー (#1481)

- [x] 削除中心の diff (216 deletions / 80 insertions)。認可の冗長層を除去し `canWriteDb` を mode のみで判定する単純構造に収斂
- [x] 撤廃箇所には `#2813` コメントで根拠 (phase1-nuc FR-2/FR-3 / US-N3) を明記
- [x] `DEBUG_PLAN` (subscription tier 切替) は誤削除せず維持。`LICENSE_PLAN`/`AUTH_LICENSE_STATUS` import も DEBUG_PLAN が使うため残存
- [x] biome / svelte-check で touched files clean

## 横展開・影響波及チェック

impact-analysis 4 layer で検証:

- **L1 (構文 grep)**: `licenseKey` / `EvaluationLicenseKey` / `redeem.license_key` / `license-key-invalid` / `getDebugLicenseKeyOverride` / `DEBUG_LICENSE_KEY_VALID` を src/tests 全件 grep。EvaluationContext の認可因子としての `licenseKey` は 4 file から完全除去。残存は License record の string field (PR-L3〜L5 scope) のみ
- **L3 (構造依存グラフ)**: capabilities → hooks → debug-plan の依存を辿り、`getDebugLicenseKeyOverride` の唯一の caller (hooks.server.ts) を撤去。`canWriteDb` 撤廃で予期しない deny が他経路に波及しないことを確認 (demo/build deny は不変、aws-prod/local-debug/nuc-prod は ALLOW)
- **L4 (派生 artifact)**: `.env.example` / root `CLAUDE.md` の `DEBUG_LICENSE_KEY_VALID` 記述を同 PR で同期更新。`14-セキュリティ設計書` の認可境界は subscription tier ベースで不変 (license key は冗長層だったため認可境界に実質変化なし)

## レビュー依頼事項・破壊的変更

- 破壊的変更: なし (license key は SaaS で常に null、nuc-prod でも撤廃前は deny の input でしかなく、撤廃で NUC は write 可能化 = 機能向上方向)
- Adversarial 3 軸 Open question:
  - **business**: NUC 信頼ベース化で正規性判定が消えるが、ADR-0051 (NUC=Edition 配布形態、買い切り SKU でない) + ADR-0010 (Pre-PMF 過剰防衛禁止) + 業界 4/5 信頼ベースで妥当。収益は SaaS 側
  - **UX**: NUC 利用者が license key 入力を求められなくなる (US-N2 整合)。記録機能は維持され体験毀損なし
  - **security**: 認可境界は subscription tier ベースで不変。license key は冗長 input だったため攻撃面は減少 (DRM 機構そのものが消滅)。NUC は家庭内 offline 機器で攻撃面極小

## 配布済み env / secret (ADR-0006)

新規 env なし。`DEBUG_LICENSE_KEY_VALID` (dev-only debug env) を撤廃。`AWS_LICENSE_SECRET` 等の本番 env 撤去は PR-L5 担当のため本 PR scope 外。

## Ready for Review チェックリスト

- [x] AC 検証マップ全 AC に証跡
- [x] 13 必須セクション記載
- [x] `[x]` は実証跡あり
- [x] SS スロット (UI 変更ゼロのため対象外を明記)

## QM レビュー結果

(QM 記入欄)
