### PR TITLE
fix: demo-lambda bug1 import dead-end spec を marketplace 一本化後の新 flow に修正 + dialog 再 open ループ根治

### DIFF
--- a/docs/design/marketplace-import-flow.md
+++ b/docs/design/marketplace-import-flow.md
@@ -161,6 +161,35 @@ POC #2693 EPIC #2724 Round 18 で「activity-pack 取込完了後に何のフィ
 
 **他 type への波及方針**: reward-set (`admin/rewards/importPresetToChildren`) も既に `x-sveltekit-action` header + ActionResult deserialize の同型実装。checklist / rule-preset / challenge-set の admin 動線で fetch ActionResult 経由を採用する場合、本 SSOT 3 件 (Toast + 2 重防御 + `x-sveltekit-action` header) を必ず複製すること。
 
+##### `?import=<presetId>` auto-open 後の dialog 再 open 防止 (consumed latch、#2773 後 bug1 spec 検出)
+
+`?import=<presetId>` で `ChildSelectionDialog` を auto-open する `$effect` は `data.importPresetId`
+(load 由来) を読む。confirm / cancel 後に **`await invalidateAll()` が `?import=` 残存 URL のまま
+load を再走させると `data.importPresetId` が依然 truthy** のため effect が再発火し dialog が
+即 再 open する (取込済なのに dialog が出続ける dead-end ループ)。これを防ぐため、auto-open する
+admin page (`?import=` を `await invalidateAll()` と併用する page) は **`consumedImportPresetId`
+ラッチ** を持ち、confirm / cancel 時に処理済 presetId を記録して同一 presetId の再 open を抑止する:
+
+```svelte
+let consumedImportPresetId = $state<string | null>(null);
+$effect(() => {
+	if (
+		data.importPresetId &&
+		data.importPresetId !== consumedImportPresetId && // 処理済 presetId は再 open しない
+		!showChildSelectionDialog &&
+		pendingImportPresetId === null
+	) {
+		pendingImportPresetId = data.importPresetId;
+		showChildSelectionDialog = true;
+	}
+});
+// confirm / cancel handler 冒頭: consumedImportPresetId = pendingImportPresetId;
+```
+
+実装位置: `src/routes/(parent)/admin/checklists/+page.svelte` (#2773 後 dead-end 再発を
+`tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts` の dialog close assert で検出)。`?import=` +
+`invalidateAll()` を併用する他 admin page (rewards 等) で同パターンが必要になった場合は本ラッチを複製する。
+
 ##### Round 18 Cluster H (#13/#16/#20/#25/#28) subset 取込 (2026-06-02)
 
 Round 18 Round 3 評価で「30 件一括取込で個別選択不可」「既存重複 activity の事前説明なし」「3 歳児親には 30 件は多すぎる」が 5 件 (Cluster H) 表面化した。これに対し、activity-pack 詳細での **subset 選択 UI + 既存重複 detection + 件数連動 CTA** を導入する (PR scope: activity-pack のみ、他 type は別 Issue)。

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -247,8 +247,20 @@ const visibilityChildren = $derived<VisibilityChild[]>(
 );
 
 // `?import=<presetId>` で ChildSelectionDialog auto-open
+//
+// #2773 後 dead-end 再発防止 (bug1-import-dead-end.spec.ts で検出): confirm / cancel 後に
+// `await invalidateAll()` で load が再走すると、URL から `?import=` を除去する前に
+// `data.importPresetId` が依然 truthy のまま本 effect が再発火し dialog が再 open する
+// (取込済なのに dialog が出続ける dead-end ループ)。`consumedImportPresetId` で
+// 「処理済みの presetId」をラッチし、同一 presetId に対しては 1 回だけ auto-open する。
+let consumedImportPresetId = $state<string | null>(null);
 $effect(() => {
-	if (data.importPresetId && !showChildSelectionDialog && pendingImportPresetId === null) {
+	if (
+		data.importPresetId &&
+		data.importPresetId !== consumedImportPresetId &&
+		!showChildSelectionDialog &&
+		pendingImportPresetId === null
+	) {
 		pendingImportPresetId = data.importPresetId;
 		showChildSelectionDialog = true;
 	}
@@ -315,6 +327,9 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 		showChildSelectionDialog = false;
 		return;
 	}
+	// 取込確定した presetId をラッチし、invalidateAll 後の effect 再発火による
+	// dialog 再 open (dead-end ループ) を防ぐ (#2773 後 bug1 spec で検出)。
+	consumedImportPresetId = pendingImportPresetId;
 	const childIdsValue = result === 'all' ? 'all' : result.join(',');
 	const formData = new FormData();
 	formData.append('presetId', pendingImportPresetId);
@@ -390,6 +405,11 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 }
 
 function handleChildSelectionCancel() {
+	// cancel した presetId もラッチし、effect 再発火による dialog 再 open を防ぐ
+	// (#2773 後 bug1 spec で検出。cancel しても `data.importPresetId` は truthy のまま)。
+	if (pendingImportPresetId) {
+		consumedImportPresetId = pendingImportPresetId;
+	}
 	pendingImportPresetId = null;
 	showChildSelectionDialog = false;
 	if (typeof window !== 'undefined') {

--- a/tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts
+++ b/tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts
@@ -1,65 +1,74 @@
 // tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts
 //
 // #2558 bug-1 (機能 dead-end、初顧客レビューで 1 分で発覚): demo Lambda 上で
-// marketplace 取込ダイアログの「追加」ボタンが無反応・dialog が閉じない回帰テスト。
+// marketplace 取込の「追加」ボタンが無反応・dialog が閉じない回帰テスト。
 //
 // 根本原因 (`src/lib/server/demo/demo-mode.ts` §buildDemoNoopResponseBody 導入前):
-//   - `?/importMarketplace*` form action は POST (`use:enhance`、x-sveltekit-action header 付き)
+//   - 取込 form action は POST (`x-sveltekit-action` header 付き fetch / use:enhance)
 //   - hooks.server.ts の `shouldReturnDemoNoop` が素の `{ ok: true, demo: true }` を返していた
-//   - SvelteKit `use:enhance` は deserialize 後 `result.type === undefined` となり、
-//     UI の `result.type === 'success'` 分岐 (onimported / onclose) が永久に発火しない
+//   - SvelteKit クライアントは `deserialize()` で `result.type === undefined` となり、
+//     UI の `result.type === 'success'` 分岐 (取込済 state 反映) が永久に発火しない
 //   - 結果: 追加ボタンを押しても dialog が閉じず feedback も出ない (= dead-end)
 //
 // 修正 (#2558):
 //   - form action リクエスト (`x-sveltekit-action: true`) には SvelteKit 認識可能な
-//     正規 ActionResult (`{ type: 'success', status: 200, data: devalue({demo:true}) }`) を返す
+//     正規 ActionResult (`{ type: 'success', status: 200, data: devalue({demo:true,...}) }`) を返す
 //   - UI は `d.demo === true` を検出し「デモではお試し用です」feedback + state 反映
 //
-// #2558 段階2 — 検証対象切替: admin/activities 内のマーケットプレイス風ブラウズ UI を撤去し
-//   /marketplace への画面遷移に一本化したため、本 spec の検証対象を、UnifiedImportHub の
-//   in-page browse UI を継続使用する `/admin/checklists` に振り替えた (同じ demo no-op response
-//   形式 + 同じ UnifiedImportHub component の dead-end を検証する。`marketplace-preset-import-*`
-//   testid は共通)。admin/activities の取込は marketplace 詳細 → ?import= → ChildSelectionDialog
-//   の正規経路に移行済 (admin-activities-per-child.spec.ts の goal 完遂テストで担保)。
+// #2773 段階3 — 検証対象切替 (marketplace 一本化、DESIGN.md §10):
+//   admin 内 in-page marketplace 風 browse UI (UnifiedImportHub の per-preset button) を
+//   全 5 admin page で撤去し、取込実行は marketplace 詳細 → `?import=<presetId>` →
+//   `ChildSelectionDialog` auto-open → 配信先確定 → `?/importPresetToChildren` POST の
+//   正規経路 (marketplace-import-flow.md §3.1) に一本化した。
+//   本 spec は旧 in-page UI (`marketplace-preset-import-*` button) を検証していたため、
+//   新 flow (`?import=` → ChildSelectionDialog → 確定) に検証対象を振り替える。dead-end
+//   回帰ガードの意図 (User 指摘 #2「動作しないインポート機能」検出) は維持し、demo no-op
+//   POST が SvelteKit action 形式で返り取込済 state に反映されることを引き続き検証する。
 //
 // 本 spec は demo Lambda 環境 (AUTH_MODE=anonymous + DATA_SOURCE=demo) 上で
-// (1) 取込 POST が SvelteKit action 形式 (type=success + demo flag) で返ること
-// (2) 実際の UI 操作で取込済 state に反映されること
+// (1) `?/importPresetToChildren` POST が SvelteKit action 形式 (type=success + demo flag) で返ること
+// (2) 実際の UI 操作 (?import= → dialog → 全員選択 → 確定) で取込済 state に反映されること
+// (3) dialog の cancel 経路が機能すること (旧 dead-end では cancel も無反応だった、bug-4)
 // を検証する。本番 cognito E2E では再現不可 (本番では実 import が走る) ため demo 専用 spec。
 
-import { expect, type Locator, type Page, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
-async function firstImportButton(page: Page): Promise<Locator> {
-	await page.goto('/admin/checklists', { waitUntil: 'domcontentloaded' });
-	await expect(page.getByTestId('marketplace-import-section')).toBeVisible({ timeout: 30_000 });
-	// #2558 fix: demo Lambda の checklist preset 一覧には event-pool / event-school-start が
-	// 既に pre-imported 状態 (CHECKLISTS_BY_CHILD: 903→'event-pool', 904→'event-school-start'、
-	// `src/lib/server/demo/demo-data.ts` §MARKETPLACE_CHECKLIST_TEMPLATES_BY_CHILD) として
-	// 配置されている。`alreadyImported = true` なら button は `disabled` でレンダリングされる
-	// (`UnifiedImportHub.svelte` L237) ため `.first()` (event-school-start) では click できない。
-	// 取込可能 (enabled = `:not([disabled])`) な最初の preset を選び、本テストの ACT
-	// (実際の import POST 発火 → UI 反映) を検証する。
-	const enabledPresetBtns = page.locator(
-		'[data-testid^="marketplace-preset-import-"]:not([disabled])',
-	);
-	await expect(enabledPresetBtns.first()).toBeVisible({ timeout: 15_000 });
-	await expect(enabledPresetBtns.first()).toBeEnabled({ timeout: 5_000 });
-	return enabledPresetBtns.first();
+// admin/checklists?import= で受け取る checklist preset。demo Lambda の checklist 一覧では
+// 一部 preset が pre-imported だが、ChildSelectionDialog 経由の取込は preset の取込済/未取込に
+// 関わらず実行され、結果メッセージ (imported / duplicate のいずれか) が必ず表示されるため、
+// dead-end 検出には十分。安定のため event-pool を使う。
+const IMPORT_PRESET_ID = 'event-pool';
+
+/**
+ * admin/checklists?import= で ChildSelectionDialog を auto-open させる。
+ *
+ * 本 spec は admin 側 demo no-op の挙動が検証対象のため、marketplace 詳細ページの CTA
+ * レンダリングは検証対象外。直接 `?import=` で dialog を開く (CTA → 遷移は
+ * marketplace-checklist-import.spec.ts が別途貫通検証している)。
+ */
+async function openImportDialog(page: Page) {
+	await page.goto(`/admin/checklists?import=${IMPORT_PRESET_ID}`, {
+		waitUntil: 'domcontentloaded',
+	});
+	const dialog = page.getByTestId('checklist-import-child-selection-dialog');
+	await expect(dialog).toBeVisible({ timeout: 30_000 });
+	return dialog;
 }
 
-test.describe('bug-1: marketplace 取込 dead-end (demo Lambda、#2558)', () => {
-	test('?/importMarketplaceChecklist POST は SvelteKit action 形式 (type=success + demo flag) で返る (素の {ok,demo} ではない)', async ({
+test.describe('bug-1: marketplace 取込 dead-end (demo Lambda、#2558 / #2773)', () => {
+	test('?/importPresetToChildren POST は SvelteKit action 形式 (type=success + demo flag) で返る (素の {ok,demo} ではない)', async ({
 		page,
 	}) => {
 		test.slow();
-		const importBtn = await firstImportButton(page);
+		await openImportDialog(page);
 
-		// ACT: import を実行し、form action レスポンスを捕捉する
+		// ACT: 全員選択 → 確定で import POST を発火し、form action レスポンスを捕捉する。
+		await page.getByTestId('child-selection-all').click();
 		const [resp] = await Promise.all([
 			page.waitForResponse(
-				(r) => /\?\/importMarketplace/.test(r.url()) && r.request().method() === 'POST',
+				(r) => /\?\/importPresetToChildren/.test(r.url()) && r.request().method() === 'POST',
 			),
-			importBtn.click(),
+			page.getByTestId('child-selection-confirm').click(),
 		]);
 
 		expect(resp.status()).toBe(200);
@@ -67,7 +76,7 @@ test.describe('bug-1: marketplace 取込 dead-end (demo Lambda、#2558)', () => 
 
 		// 修正の核心: SvelteKit が認識する ActionResult 形式であること (dead-end 回帰検出)。
 		// 旧 dead-end では body = `{ ok: true, demo: true }` (type 欠落) で
-		// use:enhance が result.type を解決できず onimported / state 反映が不発火だった。
+		// クライアントが result.type を解決できず取込済 state 反映が不発火だった。
 		expect(body).toMatchObject({ type: 'success', status: 200 });
 		// data は devalue stringified 文字列。demo フラグを含む (UI が feedback 表示に使う)。
 		expect(typeof body.data).toBe('string');
@@ -76,23 +85,38 @@ test.describe('bug-1: marketplace 取込 dead-end (demo Lambda、#2558)', () => 
 		expect(body).not.toMatchObject({ ok: true, demo: true });
 	});
 
-	test('import preset を click すると取込済 state に反映される (無反応 dead-end なら fail)', async ({
+	test('?import= → 全員選択 → 確定で取込済 state に反映される (無反応 dead-end なら fail)', async ({
 		page,
 	}) => {
 		test.slow();
-		const importBtn = await firstImportButton(page);
-		const presetTestid = (await importBtn.getAttribute('data-testid')) as string;
-		expect(presetTestid, 'preset import button testid が取得できること').toBeTruthy();
-		const itemId = presetTestid.replace('marketplace-preset-import-', '');
+		await openImportDialog(page);
 
-		await importBtn.click();
+		await page.getByTestId('child-selection-all').click();
+		await page.getByTestId('child-selection-confirm').click();
 
-		// 副作用: 取込成功 feedback (success result メッセージ) が表示されること。
+		// 副作用: 取込結果 feedback (action message banner) が表示されること。
 		// 旧 dead-end ではここで永久に無反応だった。demo no-op でも UI feedback は出る。
-		await expect(page.getByTestId('marketplace-admin-result-success')).toBeVisible({
+		await expect(page.getByTestId('checklists-action-message')).toBeVisible({
 			timeout: 30_000,
 		});
-		// preset 行自体は引き続き表示されている (dialog ではなく in-page section のため)
-		await expect(page.getByTestId(`marketplace-preset-import-${itemId}`)).toBeVisible();
+
+		// 確定後は dialog が閉じること (旧 dead-end では dialog が閉じなかった)。
+		await expect(page.getByTestId('checklist-import-child-selection-dialog')).toBeHidden({
+			timeout: 15_000,
+		});
+	});
+
+	test('取込 dialog の cancel で dialog が閉じる (無反応 cancel dead-end なら fail、bug-4)', async ({
+		page,
+	}) => {
+		test.slow();
+		const dialog = await openImportDialog(page);
+
+		// cancel ボタンで dialog を閉じる (旧 dead-end では cancel も無反応で閉じなかった)。
+		await page.getByRole('button', { name: 'キャンセル' }).click();
+
+		await expect(dialog).toBeHidden({ timeout: 15_000 });
+		// 取込は実行されていない (action message banner は出ない)。
+		await expect(page.getByTestId('checklists-action-message')).toHaveCount(0);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: main が red 状態 (e2e-demo-lambda job 3+ 連続 fail) で、User が顧客レビュー中の marketplace import 機能の dead-end 回帰ガード (`bug1-import-dead-end.spec.ts`) が壊れていた。さらに真因究明の過程で、実機 reproduce により `/admin/checklists` の marketplace 取込ダイアログが **取込確定 / cancel 後に即 再 open する dead-end ループ** (取込済なのに dialog が出続ける) を検出した。これは User 指摘 #2「動作しないインポート機能」と同種の顧客体験毀損。

**期待される効果**: (1) main の e2e-demo-lambda job が緑化し、CI が通常運用に戻る。(2) marketplace 取込が `?import=` deep link 経由で確定 / cancel した後、ダイアログが正しく閉じて取込済 state に反映される (再 open ループ解消)。

## 関連 Issue

<!-- main red を引き起こした #2773 (marketplace 一本化) の回帰修正。専用 Issue は未起票 (main red の即時 hotfix)。 -->
closes #

main red の root cause PR: #2773 (marketplace 一本化、in-page UnifiedImportHub 撤去)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | bug1-import-dead-end spec が新 flow で PASS (旧 in-page UI 依存撤去) | `npx playwright test --config playwright.demo.config.ts tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts --workers=1` | HEAD `56a2359` / 3 passed (7.9s) / tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts:59,88,109 |
| AC2 | demo no-op POST が SvelteKit ActionResult (type=success + demo flag) で返る (dead-end 回帰ガード意図維持) | 同 spec test:59 (`?/importPresetToChildren` POST response 捕捉 → `toMatchObject({type:'success'})` + `not.toMatchObject({ok:true,demo:true})`) | HEAD `56a2359` / test 1 PASS / spec L59-77 |
| AC3 | 確定後に取込済 state 反映 + dialog close (再 open ループ解消) | 同 spec test:88 (`checklists-action-message` visible + dialog `toBeHidden`) | HEAD `56a2359` / test 2 PASS / spec L88-107 |
| AC4 | cancel で dialog が閉じる (cancel dead-end 防止、bug-4 同種) | 同 spec test:109 (cancel click → dialog `toBeHidden` + action message `toHaveCount(0)`) | HEAD `56a2359` / test 3 PASS / spec L109-121 |
| AC5 | 他 demo-lambda spec に回帰なし | `set CI=1&& npx playwright test --config playwright.demo.config.ts --workers=1` | HEAD `56a2359` / 33 passed (22.8s) / 全 7 spec 緑 |
| AC6 | 型 / lint 健全性 | `npx svelte-check` / `npx biome check <changed>` | HEAD `56a2359` / svelte-check 0 ERRORS / biome No fixes (2 files) |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 親管理画面の持ち物チェックリスト (`/admin/checklists`) の marketplace 取込ダイアログ (`?import=<presetId>` deep link → ChildSelectionDialog auto-open)。demo Lambda 環境の bug1 回帰ガード spec。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  `tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts` を旧 in-page UI (`marketplace-preset-import-*` button) 依存から新 flow (`?import=` → ChildSelectionDialog → 全員選択 → 確定 → `?/importPresetToChildren` POST) に振り替え。dead-end 回帰ガードの 3 観点 (ActionResult 形式 / 取込済 state 反映 + dialog close / cancel で dialog close) を維持・強化。
- [x] **新規 env / secret 追加時**（ADR-0006）: 該当なし（N/A）
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:critical ラベルなし、main red 回帰 hotfix）

## スクリーンショット / ビジュアルデモ

**該当なし（UI 変更なし）**: 本 PR は `/admin/checklists` の `$effect` ラッチ追加 (dialog 再 open 抑止) + demo-lambda spec の振り替えのみで、**静的な画面の見た目に変化はない** (ダイアログのレイアウト・色・文言は一切不変)。修正対象は「取込確定 / cancel 後に dialog が即 再 open する」という**振る舞い (behavior)** であり、static SS では before/after の差分が出ない。振る舞いの修正は demo Lambda E2E (bug1 spec 3/3 PASS、dialog `toBeHidden` assert) で機械検証している。DESIGN.md §9 禁忌 6 点 (hex 直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / `<style>` 50 行超) の新規導入なし (追加は `let consumedImportPresetId = $state<string|null>(null)` + `$effect` 条件 1 行 + handler 各 1 行のみ)。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（dialog 再 open 抑止ロジックを `consumedImportPresetId` ラッチに局所化） / 既存 `$effect` パターンを破壊せず最小差分
- [x] **DRY**: 同種の `?import=` auto-open + `invalidateAll` 併用パターンを `grep` で確認 (rewards / activities)。rewards は replaceState を invalidateAll なしで実行するため再 open しないが、checklists は `await invalidateAll()` を併用するため再発した。本 PR でラッチ pattern を `marketplace-import-flow.md` に SSOT 化し、他 page で同パターン必要時の複製先を明記
- [x] **YAGNI**: 現要件 (checklists の再 open バグ) に限定。他 page への投機的横展開は行わず、SSOT ドキュメントで複製ガイドのみ残す
- [x] **Security（OSS 公開前提）**: 秘密情報 hardcode なし / `?import=` preset は既存の `getMarketplaceItem` validation 経路を維持 (CWE-598 child IDOR guard も `importPresetToChildren` action の既存実装を保持) / N/A
- [x] **アクセシビリティ**: ダイアログの ARIA / キーボード操作は既存 `ChildSelectionDialog` primitive のまま不変 / N/A
- [x] **パフォーマンス**: `$effect` 条件に文字列比較 1 つ追加のみ、N+1 なし / N/A

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: LP 文言変更なし
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード と チュートリアルを同期
- [ ] **labels SSOT** (ADR-0009): 新規ユーザー向け文言追加なし
- [x] **設計書同期** (ADR-0001): `docs/design/marketplace-import-flow.md` に `?import=` auto-open 後の dialog 再 open 防止 (consumed latch) パターンを SSOT 追記
- [x] **並行 PR overlap** (#1200): `/admin/checklists/+page.svelte` を同時期に変更する open PR は無し (origin/main 84c120c4 起点、衝突なし)
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**: 真因は #2773 (marketplace 一本化) が `/admin/checklists` の in-page UnifiedImportHub (`marketplace-preset-import-*` button) を撤去したが、demo-lambda の bug1 spec のみ旧 UI 依存のまま残っていた (#2773 は他の production spec は更新したが demo-lambda dir は未更新)。実機 reproduce で追加検出した dialog 再 open ループ (Case A 実 customer 破壊寄りの挙動) も同 PR で根治した。dialog 再 open の root cause は `handleChildSelectionConfirm` / `handleChildSelectionCancel` が `?import=` URL を除去する前に (or `await invalidateAll()` 経由で) load が再走し `data.importPresetId` が truthy のまま `$effect` が再発火する点。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（本 PR は単一スコープ完結、Phase 分割なし）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（該当なし＝静的画面の見た目変化なし、上記スクリーンショット欄に理由明記）
- [x] 認証画面変更時: 該当なし（認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
