### PR TITLE
fix(marketplace): per-child 取込ダイアログ dead-end (確定後閉じない) を 3 type 横断 + bug1 main-red 修正

### DIFF
--- a/docs/design/marketplace-import-flow.md
+++ b/docs/design/marketplace-import-flow.md
@@ -161,6 +161,35 @@ POC #2693 EPIC #2724 Round 18 で「activity-pack 取込完了後に何のフィ
 
 **他 type への波及方針**: reward-set (`admin/rewards/importPresetToChildren`) も既に `x-sveltekit-action` header + ActionResult deserialize の同型実装。checklist / rule-preset / challenge-set の admin 動線で fetch ActionResult 経由を採用する場合、本 SSOT 3 件 (Toast + 2 重防御 + `x-sveltekit-action` header) を必ず複製すること。
 
+##### `?import=<presetId>` auto-open 後の dialog 再 open 防止 (consumed latch、#2773 後 bug1 spec 検出)
+
+`?import=<presetId>` で `ChildSelectionDialog` を auto-open する `$effect` は `data.importPresetId`
+(load 由来) を読む。confirm / cancel 後に **`await invalidateAll()` が `?import=` 残存 URL のまま
+load を再走させると `data.importPresetId` が依然 truthy** のため effect が再発火し dialog が
+即 再 open する (取込済なのに dialog が出続ける dead-end ループ)。これを防ぐため、auto-open する
+admin page (`?import=` を `await invalidateAll()` と併用する page) は **`consumedImportPresetId`
+ラッチ** を持ち、confirm / cancel 時に処理済 presetId を記録して同一 presetId の再 open を抑止する:
+
+```svelte
+let consumedImportPresetId = $state<string | null>(null);
+$effect(() => {
+	if (
+		data.importPresetId &&
+		data.importPresetId !== consumedImportPresetId && // 処理済 presetId は再 open しない
+		!showChildSelectionDialog &&
+		pendingImportPresetId === null
+	) {
+		pendingImportPresetId = data.importPresetId;
+		showChildSelectionDialog = true;
+	}
+});
+// confirm / cancel handler 冒頭: consumedImportPresetId = pendingImportPresetId;
+```
+
+実装位置: `src/routes/(parent)/admin/checklists/+page.svelte` (#2773 後 dead-end 再発を
+`tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts` の dialog close assert で検出)。`?import=` +
+`invalidateAll()` を併用する他 admin page (rewards 等) で同パターンが必要になった場合は本ラッチを複製する。
+
 ##### Round 18 Cluster H (#13/#16/#20/#25/#28) subset 取込 (2026-06-02)
 
 Round 18 Round 3 評価で「30 件一括取込で個別選択不可」「既存重複 activity の事前説明なし」「3 歳児親には 30 件は多すぎる」が 5 件 (Cluster H) 表面化した。これに対し、activity-pack 詳細での **subset 選択 UI + 既存重複 detection + 件数連動 CTA** を導入する (PR scope: activity-pack のみ、他 type は別 Issue)。

--- a/scripts/capture-specs/flows/import-dialog-reopen-2817.mjs
+++ b/scripts/capture-specs/flows/import-dialog-reopen-2817.mjs
@@ -1,0 +1,65 @@
+/**
+ * scripts/capture-specs/flows/import-dialog-reopen-2817.mjs
+ *
+ * PR #2817: per-child 取込 ChildSelectionDialog の確定後挙動 SS。
+ *
+ * 撮影目的:
+ *   - dialog-open: `?import=<presetId>` で ChildSelectionDialog auto-open した状態
+ *   - after-confirm: 確定 click 後の状態
+ *     - 修正前 (origin/main): dialog が再 open して開いたまま (dead-end)
+ *     - 修正後 (本 PR): dialog が閉じ「デモではお試し用です」message が表示される
+ *
+ * 使用例 (demo 環境 preview を別途起動してから):
+ *   MSYS_NO_PATHCONV=1 BASE_URL=http://localhost:5180 \
+ *     node scripts/capture.mjs \
+ *     --flow import-dialog-reopen-2817 \
+ *     --url /admin/activities?import=kinder-starter \
+ *     --actions scripts/capture-specs/flows/import-dialog-reopen-2817.mjs \
+ *     --presets mobile,desktop --pr 2817
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5180';
+const DOM_OUT_DIR = process.env.DOM_OUT_DIR || 'tmp/screenshots/pr-2817-dom';
+// before/after を SS ラベルで区別する (修正前 = origin/main build で SS_PHASE=before)
+const PHASE = process.env.SS_PHASE || 'after';
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	mkdirSync(DOM_OUT_DIR, { recursive: true });
+	const dumpDom = async (/** @type {string} */ label) => {
+		const html = await page.evaluate(() => document.documentElement.outerHTML);
+		writeFileSync(`${DOM_OUT_DIR}/${label}.dom.html`, html, 'utf-8');
+	};
+
+	const rafSettle = () =>
+		page.evaluate(
+			() =>
+				new Promise((resolve) =>
+					requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+				),
+		);
+
+	// --- 1) dialog auto-open 状態 ---
+	await page.goto(`${BASE_URL}/admin/activities?import=kinder-starter`);
+	const confirm = page.locator('[data-testid="child-selection-confirm"]');
+	await confirm.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+	await rafSettle();
+	await capture(`pr2817-${PHASE}-dialog-open`);
+	await dumpDom(`${PHASE}-dialog-open`);
+
+	// --- 2) 確定 click 後の状態 (修正前: dialog 開いたまま / 修正後: 閉じて demo message) ---
+	await confirm.click().catch(() => {});
+	// 結果が安定するまで feedback message or dialog 状態変化を待つ (両分岐を許容)
+	await page
+		.locator('text=デモではお試し用')
+		.waitFor({ state: 'visible', timeout: 10_000 })
+		.catch(() => {});
+	await rafSettle();
+	await capture(`pr2817-${PHASE}-after-confirm`);
+	await dumpDom(`${PHASE}-after-confirm`);
+};

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4170,6 +4170,7 @@ export const ADMIN_ACTIVITIES_PAGE_LABELS = {
 	// imported=0 (選んだ子に全て追加済み) — generic な「完了」で誤魔化さない
 	importAllDuplicates: `選んだ${CHILD_TERMS.honorific}にはすでに追加済みです`,
 	importFailed: '取込に失敗しました',
+	importDemo: 'デモではお試し用です（実際の追加は行われません）',
 	// Round 18 Cluster G (per-child scope badge): 英語内部語彙「per-child」UI 露出撤去 (ADR-0045 §9)
 	// 「お子さま別」= per-child scope (個別 child に紐付く activity) を親向けに明示する短い表示
 	scopeBadgePerChild: `${CHILD_TERMS.honorific}別`,

--- a/src/lib/ui/primitives/ChildSelectionDialog.stories.svelte
+++ b/src/lib/ui/primitives/ChildSelectionDialog.stories.svelte
@@ -24,7 +24,7 @@ import { defineMeta } from '@storybook/addon-svelte-csf';
 // `screen` (document.body 起点の Testing Library query) を使う。
 // 参考: Storybook docs "Interaction tests" + Ark UI Portal の仕様。
 import { expect, fn, screen, waitFor } from 'storybook/test';
-import { STORYBOOK_LABELS } from '$lib/domain/labels';
+import { CHILD_SELECTION_LABELS, STORYBOOK_LABELS } from '$lib/domain/labels';
 import ChildSelectionDialog from './ChildSelectionDialog.svelte';
 
 const L = STORYBOOK_LABELS.childSelectionDialog;
@@ -105,6 +105,30 @@ const { Story } = defineMeta({
 		await expect(args.onConfirm).toHaveBeenCalledTimes(1);
 		// 引数 shape: 'all' でなく number[]、選択 id を含む
 		await expect(args.onConfirm).toHaveBeenCalledWith([1, 2]);
+	}}
+/>
+
+<!--
+  Cancel: キャンセル click → onCancel 発火 / onConfirm は呼ばれない
+  (顧客指摘「キャンセルもできない」の component 層保証)。
+-->
+<Story
+	name="Cancel"
+	args={{
+		children: threeChildren,
+		open: true,
+		allowMultiple: false,
+		onConfirm: fn(),
+		onCancel: fn(),
+	}}
+	play={async ({ args }) => {
+		const cancel = await waitFor(() =>
+			screen.getByRole('button', { name: CHILD_SELECTION_LABELS.cancel }),
+		);
+		await expect(cancel).toBeVisible();
+		await cancel.click();
+		await expect(args.onCancel).toHaveBeenCalledTimes(1);
+		await expect(args.onConfirm).not.toHaveBeenCalled();
 	}}
 />
 

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -94,11 +94,17 @@ let copySourceChildId = $state<number | null>(null);
 // 「一括追加」dialog (manual create で複数 child 同時 create)
 let showBulkCreateDialog = $state(false);
 
-// `?import=<presetId>` で auto-open
+// `?import=<presetId>` で auto-open。presetId 単位の one-shot guard で、確定後に
+// effect が再走しても (data.importPresetId が残存) 再 open しないようにする。
+let consumedImportPresetId = $state<string | null>(null);
 $effect(() => {
-	if (data.importPresetId && !showChildSelectionDialog) {
-		pendingImportPresetId = data.importPresetId;
+	const pid = data.importPresetId;
+	if (pid && pid !== consumedImportPresetId) {
+		consumedImportPresetId = pid;
+		pendingImportPresetId = pid;
 		showChildSelectionDialog = true;
+	} else if (!pid) {
+		consumedImportPresetId = null;
 	}
 });
 
@@ -295,6 +301,15 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 		});
 		if (resp.ok) {
 			const result = deserialize(await resp.text());
+			// デモ環境 no-op (data.demo===true) は成功偽装せず明示 (reward / challenge と統一)。
+			if (
+				result.type === 'success' &&
+				(result.data as Record<string, unknown> | undefined)?.demo === true
+			) {
+				actionMessage = ADMIN_ACTIVITIES_PAGE_LABELS.importDemo;
+				showToast(ADMIN_ACTIVITIES_PAGE_LABELS.importDemo, undefined, 'info');
+				return;
+			}
 			const imported =
 				result.type === 'success' ? Number((result.data?.imported as number | undefined) ?? 0) : 0;
 			// #2745 fix Round 2 (CI artifact 解析根拠): Toast primitive (`role="alert"`) を

--- a/src/routes/(parent)/admin/challenges/+page.svelte
+++ b/src/routes/(parent)/admin/challenges/+page.svelte
@@ -44,11 +44,17 @@ const childOptions = $derived<ChildOption[]>(
 	})),
 );
 
-// #2774: `?import=<presetId>` で auto-open (server load で validation 済、5 type 統一)
+// #2774: `?import=<presetId>` で auto-open (5 type 統一)。presetId 単位の one-shot guard で、
+// 確定後に effect が再走しても (data.importPresetId が残存) 再 open しないようにする。
+let consumedImportPresetId = $state<string | null>(null);
 $effect(() => {
-	if (data.importPresetId && !showChildSelectionDialog) {
-		pendingImportPresetId = data.importPresetId;
+	const pid = data.importPresetId;
+	if (pid && pid !== consumedImportPresetId) {
+		consumedImportPresetId = pid;
+		pendingImportPresetId = pid;
 		showChildSelectionDialog = true;
+	} else if (!pid) {
+		consumedImportPresetId = null;
 	}
 });
 

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -247,8 +247,20 @@ const visibilityChildren = $derived<VisibilityChild[]>(
 );
 
 // `?import=<presetId>` で ChildSelectionDialog auto-open
+//
+// #2773 後 dead-end 再発防止 (bug1-import-dead-end.spec.ts で検出): confirm / cancel 後に
+// `await invalidateAll()` で load が再走すると、URL から `?import=` を除去する前に
+// `data.importPresetId` が依然 truthy のまま本 effect が再発火し dialog が再 open する
+// (取込済なのに dialog が出続ける dead-end ループ)。`consumedImportPresetId` で
+// 「処理済みの presetId」をラッチし、同一 presetId に対しては 1 回だけ auto-open する。
+let consumedImportPresetId = $state<string | null>(null);
 $effect(() => {
-	if (data.importPresetId && !showChildSelectionDialog && pendingImportPresetId === null) {
+	if (
+		data.importPresetId &&
+		data.importPresetId !== consumedImportPresetId &&
+		!showChildSelectionDialog &&
+		pendingImportPresetId === null
+	) {
 		pendingImportPresetId = data.importPresetId;
 		showChildSelectionDialog = true;
 	}
@@ -315,6 +327,9 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 		showChildSelectionDialog = false;
 		return;
 	}
+	// 取込確定した presetId をラッチし、invalidateAll 後の effect 再発火による
+	// dialog 再 open (dead-end ループ) を防ぐ (#2773 後 bug1 spec で検出)。
+	consumedImportPresetId = pendingImportPresetId;
 	const childIdsValue = result === 'all' ? 'all' : result.join(',');
 	const formData = new FormData();
 	formData.append('presetId', pendingImportPresetId);
@@ -390,6 +405,11 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 }
 
 function handleChildSelectionCancel() {
+	// cancel した presetId もラッチし、effect 再発火による dialog 再 open を防ぐ
+	// (#2773 後 bug1 spec で検出。cancel しても `data.importPresetId` は truthy のまま)。
+	if (pendingImportPresetId) {
+		consumedImportPresetId = pendingImportPresetId;
+	}
 	pendingImportPresetId = null;
 	showChildSelectionDialog = false;
 	if (typeof window !== 'undefined') {

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -74,11 +74,17 @@ let isImporting = $state(false);
 let showCopyFromChildDialog = $state(false);
 let copySourceChildId = $state<number | null>(null);
 
-// `?import=<presetId>` で auto-open (server load で validation 済)
+// `?import=<presetId>` で auto-open。presetId 単位の one-shot guard で、確定後に
+// effect が再走しても (data.importPresetId が残存) 再 open しないようにする。
+let consumedImportPresetId = $state<string | null>(null);
 $effect(() => {
-	if (data.importPresetId && !showChildSelectionDialog) {
-		pendingImportPresetId = data.importPresetId;
+	const pid = data.importPresetId;
+	if (pid && pid !== consumedImportPresetId) {
+		consumedImportPresetId = pid;
+		pendingImportPresetId = pid;
 		showChildSelectionDialog = true;
+	} else if (!pid) {
+		consumedImportPresetId = null;
 	}
 });
 

--- a/tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts
+++ b/tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts
@@ -1,65 +1,74 @@
 // tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts
 //
 // #2558 bug-1 (機能 dead-end、初顧客レビューで 1 分で発覚): demo Lambda 上で
-// marketplace 取込ダイアログの「追加」ボタンが無反応・dialog が閉じない回帰テスト。
+// marketplace 取込の「追加」ボタンが無反応・dialog が閉じない回帰テスト。
 //
 // 根本原因 (`src/lib/server/demo/demo-mode.ts` §buildDemoNoopResponseBody 導入前):
-//   - `?/importMarketplace*` form action は POST (`use:enhance`、x-sveltekit-action header 付き)
+//   - 取込 form action は POST (`x-sveltekit-action` header 付き fetch / use:enhance)
 //   - hooks.server.ts の `shouldReturnDemoNoop` が素の `{ ok: true, demo: true }` を返していた
-//   - SvelteKit `use:enhance` は deserialize 後 `result.type === undefined` となり、
-//     UI の `result.type === 'success'` 分岐 (onimported / onclose) が永久に発火しない
+//   - SvelteKit クライアントは `deserialize()` で `result.type === undefined` となり、
+//     UI の `result.type === 'success'` 分岐 (取込済 state 反映) が永久に発火しない
 //   - 結果: 追加ボタンを押しても dialog が閉じず feedback も出ない (= dead-end)
 //
 // 修正 (#2558):
 //   - form action リクエスト (`x-sveltekit-action: true`) には SvelteKit 認識可能な
-//     正規 ActionResult (`{ type: 'success', status: 200, data: devalue({demo:true}) }`) を返す
+//     正規 ActionResult (`{ type: 'success', status: 200, data: devalue({demo:true,...}) }`) を返す
 //   - UI は `d.demo === true` を検出し「デモではお試し用です」feedback + state 反映
 //
-// #2558 段階2 — 検証対象切替: admin/activities 内のマーケットプレイス風ブラウズ UI を撤去し
-//   /marketplace への画面遷移に一本化したため、本 spec の検証対象を、UnifiedImportHub の
-//   in-page browse UI を継続使用する `/admin/checklists` に振り替えた (同じ demo no-op response
-//   形式 + 同じ UnifiedImportHub component の dead-end を検証する。`marketplace-preset-import-*`
-//   testid は共通)。admin/activities の取込は marketplace 詳細 → ?import= → ChildSelectionDialog
-//   の正規経路に移行済 (admin-activities-per-child.spec.ts の goal 完遂テストで担保)。
+// #2773 段階3 — 検証対象切替 (marketplace 一本化、DESIGN.md §10):
+//   admin 内 in-page marketplace 風 browse UI (UnifiedImportHub の per-preset button) を
+//   全 5 admin page で撤去し、取込実行は marketplace 詳細 → `?import=<presetId>` →
+//   `ChildSelectionDialog` auto-open → 配信先確定 → `?/importPresetToChildren` POST の
+//   正規経路 (marketplace-import-flow.md §3.1) に一本化した。
+//   本 spec は旧 in-page UI (`marketplace-preset-import-*` button) を検証していたため、
+//   新 flow (`?import=` → ChildSelectionDialog → 確定) に検証対象を振り替える。dead-end
+//   回帰ガードの意図 (User 指摘 #2「動作しないインポート機能」検出) は維持し、demo no-op
+//   POST が SvelteKit action 形式で返り取込済 state に反映されることを引き続き検証する。
 //
 // 本 spec は demo Lambda 環境 (AUTH_MODE=anonymous + DATA_SOURCE=demo) 上で
-// (1) 取込 POST が SvelteKit action 形式 (type=success + demo flag) で返ること
-// (2) 実際の UI 操作で取込済 state に反映されること
+// (1) `?/importPresetToChildren` POST が SvelteKit action 形式 (type=success + demo flag) で返ること
+// (2) 実際の UI 操作 (?import= → dialog → 全員選択 → 確定) で取込済 state に反映されること
+// (3) dialog の cancel 経路が機能すること (旧 dead-end では cancel も無反応だった、bug-4)
 // を検証する。本番 cognito E2E では再現不可 (本番では実 import が走る) ため demo 専用 spec。
 
-import { expect, type Locator, type Page, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
-async function firstImportButton(page: Page): Promise<Locator> {
-	await page.goto('/admin/checklists', { waitUntil: 'domcontentloaded' });
-	await expect(page.getByTestId('marketplace-import-section')).toBeVisible({ timeout: 30_000 });
-	// #2558 fix: demo Lambda の checklist preset 一覧には event-pool / event-school-start が
-	// 既に pre-imported 状態 (CHECKLISTS_BY_CHILD: 903→'event-pool', 904→'event-school-start'、
-	// `src/lib/server/demo/demo-data.ts` §MARKETPLACE_CHECKLIST_TEMPLATES_BY_CHILD) として
-	// 配置されている。`alreadyImported = true` なら button は `disabled` でレンダリングされる
-	// (`UnifiedImportHub.svelte` L237) ため `.first()` (event-school-start) では click できない。
-	// 取込可能 (enabled = `:not([disabled])`) な最初の preset を選び、本テストの ACT
-	// (実際の import POST 発火 → UI 反映) を検証する。
-	const enabledPresetBtns = page.locator(
-		'[data-testid^="marketplace-preset-import-"]:not([disabled])',
-	);
-	await expect(enabledPresetBtns.first()).toBeVisible({ timeout: 15_000 });
-	await expect(enabledPresetBtns.first()).toBeEnabled({ timeout: 5_000 });
-	return enabledPresetBtns.first();
+// admin/checklists?import= で受け取る checklist preset。demo Lambda の checklist 一覧では
+// 一部 preset が pre-imported だが、ChildSelectionDialog 経由の取込は preset の取込済/未取込に
+// 関わらず実行され、結果メッセージ (imported / duplicate のいずれか) が必ず表示されるため、
+// dead-end 検出には十分。安定のため event-pool を使う。
+const IMPORT_PRESET_ID = 'event-pool';
+
+/**
+ * admin/checklists?import= で ChildSelectionDialog を auto-open させる。
+ *
+ * 本 spec は admin 側 demo no-op の挙動が検証対象のため、marketplace 詳細ページの CTA
+ * レンダリングは検証対象外。直接 `?import=` で dialog を開く (CTA → 遷移は
+ * marketplace-checklist-import.spec.ts が別途貫通検証している)。
+ */
+async function openImportDialog(page: Page) {
+	await page.goto(`/admin/checklists?import=${IMPORT_PRESET_ID}`, {
+		waitUntil: 'domcontentloaded',
+	});
+	const dialog = page.getByTestId('checklist-import-child-selection-dialog');
+	await expect(dialog).toBeVisible({ timeout: 30_000 });
+	return dialog;
 }
 
-test.describe('bug-1: marketplace 取込 dead-end (demo Lambda、#2558)', () => {
-	test('?/importMarketplaceChecklist POST は SvelteKit action 形式 (type=success + demo flag) で返る (素の {ok,demo} ではない)', async ({
+test.describe('bug-1: marketplace 取込 dead-end (demo Lambda、#2558 / #2773)', () => {
+	test('?/importPresetToChildren POST は SvelteKit action 形式 (type=success + demo flag) で返る (素の {ok,demo} ではない)', async ({
 		page,
 	}) => {
 		test.slow();
-		const importBtn = await firstImportButton(page);
+		await openImportDialog(page);
 
-		// ACT: import を実行し、form action レスポンスを捕捉する
+		// ACT: 全員選択 → 確定で import POST を発火し、form action レスポンスを捕捉する。
+		await page.getByTestId('child-selection-all').click();
 		const [resp] = await Promise.all([
 			page.waitForResponse(
-				(r) => /\?\/importMarketplace/.test(r.url()) && r.request().method() === 'POST',
+				(r) => /\?\/importPresetToChildren/.test(r.url()) && r.request().method() === 'POST',
 			),
-			importBtn.click(),
+			page.getByTestId('child-selection-confirm').click(),
 		]);
 
 		expect(resp.status()).toBe(200);
@@ -67,7 +76,7 @@ test.describe('bug-1: marketplace 取込 dead-end (demo Lambda、#2558)', () => 
 
 		// 修正の核心: SvelteKit が認識する ActionResult 形式であること (dead-end 回帰検出)。
 		// 旧 dead-end では body = `{ ok: true, demo: true }` (type 欠落) で
-		// use:enhance が result.type を解決できず onimported / state 反映が不発火だった。
+		// クライアントが result.type を解決できず取込済 state 反映が不発火だった。
 		expect(body).toMatchObject({ type: 'success', status: 200 });
 		// data は devalue stringified 文字列。demo フラグを含む (UI が feedback 表示に使う)。
 		expect(typeof body.data).toBe('string');
@@ -76,23 +85,38 @@ test.describe('bug-1: marketplace 取込 dead-end (demo Lambda、#2558)', () => 
 		expect(body).not.toMatchObject({ ok: true, demo: true });
 	});
 
-	test('import preset を click すると取込済 state に反映される (無反応 dead-end なら fail)', async ({
+	test('?import= → 全員選択 → 確定で取込済 state に反映される (無反応 dead-end なら fail)', async ({
 		page,
 	}) => {
 		test.slow();
-		const importBtn = await firstImportButton(page);
-		const presetTestid = (await importBtn.getAttribute('data-testid')) as string;
-		expect(presetTestid, 'preset import button testid が取得できること').toBeTruthy();
-		const itemId = presetTestid.replace('marketplace-preset-import-', '');
+		await openImportDialog(page);
 
-		await importBtn.click();
+		await page.getByTestId('child-selection-all').click();
+		await page.getByTestId('child-selection-confirm').click();
 
-		// 副作用: 取込成功 feedback (success result メッセージ) が表示されること。
+		// 副作用: 取込結果 feedback (action message banner) が表示されること。
 		// 旧 dead-end ではここで永久に無反応だった。demo no-op でも UI feedback は出る。
-		await expect(page.getByTestId('marketplace-admin-result-success')).toBeVisible({
+		await expect(page.getByTestId('checklists-action-message')).toBeVisible({
 			timeout: 30_000,
 		});
-		// preset 行自体は引き続き表示されている (dialog ではなく in-page section のため)
-		await expect(page.getByTestId(`marketplace-preset-import-${itemId}`)).toBeVisible();
+
+		// 確定後は dialog が閉じること (旧 dead-end では dialog が閉じなかった)。
+		await expect(page.getByTestId('checklist-import-child-selection-dialog')).toBeHidden({
+			timeout: 15_000,
+		});
+	});
+
+	test('取込 dialog の cancel で dialog が閉じる (無反応 cancel dead-end なら fail、bug-4)', async ({
+		page,
+	}) => {
+		test.slow();
+		const dialog = await openImportDialog(page);
+
+		// cancel ボタンで dialog を閉じる (旧 dead-end では cancel も無反応で閉じなかった)。
+		await page.getByRole('button', { name: 'キャンセル' }).click();
+
+		await expect(dialog).toBeHidden({ timeout: 15_000 });
+		// 取込は実行されていない (action message banner は出ない)。
+		await expect(page.getByTestId('checklists-action-message')).toHaveCount(0);
 	});
 });

--- a/tests/e2e/demo-lambda/per-child-import-dialog-reopen.spec.ts
+++ b/tests/e2e/demo-lambda/per-child-import-dialog-reopen.spec.ts
@@ -1,0 +1,91 @@
+// tests/e2e/demo-lambda/per-child-import-dialog-reopen.spec.ts
+//
+// per-child 取込 (?import=<presetId> → ChildSelectionDialog → 確定) の demo Lambda 回帰。
+// 顧客レビュー 2026-06-03 (AWS) で「確定後ダイアログが閉じない」を発見した経路。
+//
+// 根本原因: auto-open $effect の条件が `!showChildSelectionDialog` のみだったため、確定で
+// false になると effect が再走し、data.importPresetId が残存して即座に再 open していた。
+// presetId 単位の one-shot guard (consumedImportPresetId) で再 open を防ぐ。
+//
+// 検証 (3 per-child type 横断):
+//   (1) 確定後に dialog が閉じる (再 open しない = dead-end でない)
+//   (2) demo no-op は「デモではお試し用」を明示し、偽の成功件数を出さない
+//   (3) キャンセルで dialog が閉じる
+
+import { expect, type Page, test } from '@playwright/test';
+
+type Case = {
+	label: string;
+	adminPath: string;
+	importPreset: string;
+	dialogTestid: string;
+	/** demo で出てはいけない成功偽装文言 */
+	falseSuccess: RegExp;
+};
+
+const CASES: Case[] = [
+	{
+		label: 'activity-pack',
+		adminPath: '/admin/activities',
+		importPreset: 'kinder-starter',
+		dialogTestid: 'import-child-selection-dialog',
+		falseSuccess: /件の活動を追加しました/,
+	},
+	{
+		label: 'reward-set',
+		adminPath: '/admin/rewards',
+		importPreset: 'kinder-rewards',
+		dialogTestid: 'reward-import-child-selection-dialog',
+		falseSuccess: /件のごほうびを追加しました/,
+	},
+	{
+		label: 'challenge-set',
+		adminPath: '/admin/challenges',
+		importPreset: 'japan-annual-events',
+		dialogTestid: 'challenge-import-child-selection-dialog',
+		falseSuccess: /件のチャレンジを追加しました/,
+	},
+];
+
+async function openImportDialog(page: Page, c: Case) {
+	await page.goto(`${c.adminPath}?import=${c.importPreset}`, { waitUntil: 'domcontentloaded' });
+	const dialog = page.getByTestId(c.dialogTestid);
+	await expect(dialog, `${c.label}: ChildSelectionDialog auto-open`).toBeVisible({
+		timeout: 30_000,
+	});
+	return dialog;
+}
+
+for (const c of CASES) {
+	test.describe(`per-child import demo (${c.label})`, () => {
+		test(`${c.label}: 確定後に dialog が閉じる + demo no-op を正直に出す (偽の成功件数を出さない)`, async ({
+			page,
+		}) => {
+			test.slow();
+			const dialog = await openImportDialog(page, c);
+
+			// default selection='all' で confirm 可能
+			const confirm = dialog.getByTestId('child-selection-confirm');
+			await expect(confirm).toBeEnabled({ timeout: 10_000 });
+			await confirm.click();
+
+			// demo no-op honest: feedback「デモではお試し用」を待つ (settling 点 = effect 再走 window 経過)
+			const body = page.locator('body');
+			await expect(body, `${c.label}: demo 明示メッセージ`).toContainText(/デモではお試し用/, {
+				timeout: 15_000,
+			});
+			// 偽の成功件数を出さない
+			await expect(body, `${c.label}: 偽の成功件数を出さない`).not.toContainText(c.falseSuccess);
+
+			// dead-end でない: メッセージ表示後 (effect 再走後) も dialog は閉じたまま (旧 bug ではここで再 open)
+			await expect(dialog, `${c.label}: 確定後 dialog が閉じたまま (再 open しない)`).toBeHidden();
+		});
+
+		test(`${c.label}: キャンセルで dialog が閉じる`, async ({ page }) => {
+			test.slow();
+			const dialog = await openImportDialog(page, c);
+			await dialog.getByRole('button', { name: 'キャンセル' }).click();
+			await expect(dialog, `${c.label}: キャンセルで閉じる`).toBeHidden({ timeout: 10_000 });
+		});
+	});
+}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: 顧客レビュー (2026-06-03、AWS) で marketplace 取込の確定後にダイアログが閉じず・キャンセルも効かない dead-end が 2 分で露見した。取込が完了したのか分からず、操作が継続できない。

**期待される効果**: 取込確定後にダイアログが確実に閉じ、結果が正直に表示される（demo 環境では偽の成功件数を出さず「デモではお試し用」を明示）。activity / reward / challenge / checklist の 4 経路が同一ガード機構に統一され、経路ごとの挙動差が解消される。

## 関連 Issue

closes #2819

関連: #2558 (取込 dead-end 系列) / #2773 (marketplace 一本化、bug1 spec stale 化の起点) / #2774 (`?import=` 5 type 統一)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | activity / reward / challenge の取込確定後にダイアログが閉じ、再 open しない | `npx playwright test --config playwright.demo.config.ts tests/e2e/demo-lambda/per-child-import-dialog-reopen.spec.ts` | HEAD `4bc278a21` / 修正前 2 failed (再現) → 修正後 6 passed / CI `e2e-demo-lambda` pass |
| AC2 | demo 環境では偽の成功件数を出さず「デモではお試し用」を明示 (activity に demo 分岐追加、reward / challenge と統一) | 同 spec の `toContainText(/デモではお試し用/)` + `not.toContainText(/件の活動を追加しました/)` | HEAD `4bc278a21` / 6 passed / `src/routes/(parent)/admin/activities/+page.svelte` demo 分岐 + `labels.ts` `importDemo` 追加 |
| AC3 | キャンセルでダイアログが閉じる | 同 spec キャンセル test × 3 type + `ChildSelectionDialog.stories.svelte` Cancel play (`onCancel` 発火 / `onConfirm` 不発火) | HEAD `4bc278a21` / E2E 3 passed + CI `storybook-test` pass (1m29s) |
| AC4 | demo-lambda E2E 全 suite 回帰なし | `npx playwright test --config playwright.demo.config.ts --workers=1` (CI 同設定) | HEAD `4bc278a21` / **39 passed (27.0s)** / CI `e2e-demo-lambda` pass (1m50s) |
| AC5 | main red (bug1 spec の #2773 後 stale fail) を解消 | `tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts` (marketplace 一本化後の新 flow に改修、dead-end 回帰ガード意図維持) | HEAD `4bc278a21` / 3 passed / CI `e2e-demo-lambda` pass |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- `/admin/activities` / `/admin/rewards` / `/admin/challenges` / `/admin/checklists` の `?import=<presetId>` 取込ダイアログ (auto-open one-shot guard `consumedImportPresetId` に 4 経路統一)
- `ADMIN_ACTIVITIES_PAGE_LABELS.importDemo` 新設 (labels.ts)
- `ChildSelectionDialog.stories.svelte` Cancel play 追加
- `tests/e2e/demo-lambda/per-child-import-dialog-reopen.spec.ts` 新規 / `bug1-import-dead-end.spec.ts` 新 flow 化 / `docs/design/marketplace-import-flow.md` consumed-latch パターン追記
- `scripts/capture-specs/flows/import-dialog-reopen-2817.mjs` (本 PR SS 撮影 flow、再利用可能)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2817` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/e2e/demo-lambda/per-child-import-dialog-reopen.spec.ts` (新規): 3 per-child type × (確定後 dialog 閉鎖 + demo 正直表示 + 偽件数なし / キャンセル閉鎖) = 6 test
  - `tests/e2e/demo-lambda/bug1-import-dead-end.spec.ts`: marketplace 一本化後の新 flow (`?import=event-pool` → ChildSelectionDialog) に改修、ActionResult 形式 / 取込済 state 反映 / cancel 閉鎖の 3 assert で dead-end 回帰ガード意図を維持
  - `src/lib/ui/primitives/ChildSelectionDialog.stories.svelte`: Cancel play (onCancel 発火 / onConfirm 不発火)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（本 PR は frontend ガード + spec + labels のみ）
- [x] **Critical バグ修正の場合**（ADR-0002）: E2E 回帰 = demo-lambda 39 passed + CI 全 E2E pass / AC 全 5 項目検証済 (上表) / Issue #2819 提案 (one-shot guard) を全実装 / 対象画面は admin (親) 画面のため 5 年齢モード非該当 (子供画面変更なし)・demo-lambda visual-equality spec で回帰なし / 直近 30 日重複変更チェック済 (#2774 `?import=` 統一・#2632 loading・#2745 Toast と衝突なしを rebase + 全 suite で確認)

## スクリーンショット / ビジュアルデモ

**4 スロット添付**（#1740、確定クリック後の挙動対比 = 本 PR の修正点。DOM HTML スナップショットは screenshots branch `pr-2817/*.dom.html` に併置）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** (確定後も dialog 開いたまま = dead-end) | ![before-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2817/before-confirm-stuck.png) | ![before-pc](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2817/before-confirm-stuck-pc.png) |
| **修正後** (dialog 閉鎖 + demo 正直メッセージ) | ![after-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2817/after-confirm-closed.png) | ![after-pc](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2817/after-confirm-closed-pc.png) |

撮影: `scripts/capture-specs/flows/import-dialog-reopen-2817.mjs` (demo 環境 preview、修正前 = origin/main build / 修正後 = 本 PR build)。DESIGN.md §9 禁忌 6 点を目視確認済 (hex 直書きなし / primitives 使用 / 内部コード露出なし / labels.ts 経由 / インラインスタイルなし / style 50 行超なし)。

**インタラクティブ状態**: N/A（dialog open / closed の 2 状態は上表で網羅）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: one-shot guard は各 page の `$effect` 内に局所化 (単一責任)。ChildSelectionDialog primitive は無変更 (presentation 純化維持)
- [x] **DRY**: 4 経路 (activity / reward / challenge / checklist) で同名 `consumedImportPresetId` + 同型ガードに統一。`grep -rn "consumedImportPresetId" src/routes/` で 4 箇所一致を確認
- [x] **YAGNI**: 新規抽象 (shared composable 化) は今回見送り、最小ガードのみ
- [x] **Security（OSS 公開前提）**: 秘密情報なし / childIds は body 送信 (CWE-598 整合、URL 露出なし)
- [x] **アクセシビリティ**: dialog close で focus が page に戻る (Ark UI Dialog 既定)。CI `a11y` (axe WCAG 2.2 AA) pass (12m32s)
- [x] **パフォーマンス**: effect 1 本の条件変更のみ、N/A

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: LP 記載がアプリ実装と一致 / アプリの新規機能・用語が LP に未記載のままでない（Committed/Aspirational 確認）
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [ ] E2E / ユニットシード（`tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` / `src/lib/server/demo/demo-data.ts`）と チュートリアル (`tutorial-chapters.ts` / `demo-guide-state.svelte.ts`) を同期
- [x] **labels SSOT** (ADR-0009): `importDemo` を `ADMIN_ACTIVITIES_PAGE_LABELS` (labels.ts) 経由で追加、リテラル直書きなし
- [x] **設計書同期** (ADR-0001): `docs/design/marketplace-import-flow.md` に consumed-latch パターンを追記
- [x] **並行 PR overlap** (#1200): #2816 (bug1 単独修正) は本 PR が同一 commit を包含したため close 済。#2774 / #2632 の先行変更とは rebase で整合済
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- one-shot guard の解除条件 (`!pid` で reset) は「URL param クリア + load 再走後に同一 preset の再 import を許可する」ための分岐です。`?import=` を消さない page 遷移では guard が残存し再 open しない設計です
- demo-lambda spec の検証対象を in-page UnifiedImportHub (旧) → `?import=` ChildSelectionDialog (現行正規経路) に切替えています (bug1 spec、dead-end 回帰ガード意図は 3 assert で維持)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2817` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A（本 PR で完結）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: N/A（admin 画面は通常 dev 自動認証対象、login / signup / ops / プラン別 UI 変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
