### PR TITLE
fix: DynamoDB child-activity 本実装 — 本番 marketplace 取込永続化 + 取込件数 honesty (CRITICAL)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -88,6 +88,7 @@ catchcopy
 certificatemanager
 chibi
 chukichi
+CHILDACT
 CKLOG
 CKOVER
 CKTPL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
       - name: DynamoDB stub/no-op implementation check (#1021 / ADR-0034)
         run: node scripts/check-dynamodb-stub.mjs
 
-      - name: DynamoDB stub parity guard (#2818 / ADR-0055)
+      - name: DynamoDB stub parity guard (#2824 / ADR-0055)
         # helper 経由 stub (return notImplemented(...) / warnRead(...) / warnWrite(...)) を
         # inventory 化し、baseline を超える新規 stub 追加を block する。
         # check-dynamodb-stub.mjs が拾えない helper indirection pattern を補完。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,12 @@ jobs:
       - name: DynamoDB stub/no-op implementation check (#1021 / ADR-0034)
         run: node scripts/check-dynamodb-stub.mjs
 
+      - name: DynamoDB stub parity guard (#2818 / ADR-0055)
+        # helper 経由 stub (return notImplemented(...) / warnRead(...) / warnWrite(...)) を
+        # inventory 化し、baseline を超える新規 stub 追加を block する。
+        # check-dynamodb-stub.mjs が拾えない helper indirection pattern を補完。
+        run: node scripts/check-dynamodb-stub-parity.mjs
+
       - name: No waitForTimeout in scripts/ check (#1208)
         run: node scripts/check-no-waitfortimeout.mjs
 

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -266,7 +266,7 @@ User 直接判断 (`tmp/user-question/2026-05-23-customer-use-case-data-model-qa
 - `idx_child_activities_child` ON (child_id, is_archived)
 - `idx_child_activities_child_sort` ON (child_id, sort_order)
 
-#### DynamoDB キー設計（single-table、#2818 / ADR-0055）
+#### DynamoDB キー設計（single-table、#2824 / ADR-0055）
 
 本番 cognito Lambda は `DATA_SOURCE=dynamodb` で稼働するため、SQLite と機能等価の
 DynamoDB 実装 (`src/lib/server/db/dynamodb/child-activity-repo.ts`) を持つ。
@@ -282,7 +282,7 @@ per-child instance は child partition 配下に置き、`findActivitiesByChild`
 | `findActivitiesByChild(childId)` | Query | `PK = T#<tid>#CHILD#<childId> AND begins_with(SK, 'CHILDACT#')`。archive / visibleOnly filter + sort_order 昇順は in-memory（SQLite SSOT と一致） |
 | `findActivityById(id, childId)` | GetItem | `PK = T#<tid>#CHILD#<childId>, SK = CHILDACT#<paddedId>` |
 | `insertActivity` | counter 採番 → PutItem | SQLite schema default（sort_order=0 / is_visible=1 / source='seed' / daily_limit=null 等）を明示的に埋め、`.returning()` 等価の row を返す |
-| `insertActivitiesBulk` | 直列 PutItem | 取込時 per-child 配信の核心経路。返り値（作成 row）を import service が persist honesty 検証に使う（#2818） |
+| `insertActivitiesBulk` | 直列 PutItem | 取込時 per-child 配信の核心経路。返り値（作成 row）を import service が persist honesty 検証に使う（#2824） |
 | `updateActivity` / `setActivityVisibility` | UpdateItem（`ConditionExpression: attribute_exists(PK)`、`ALL_NEW`） | 別 child / 不在は `ConditionalCheckFailedException` → undefined |
 | `deleteActivity` | DeleteItem（`ALL_OLD`） | 削除前 row を返す（SQLite `.returning()` 等価） |
 | `archiveActivities(ids, reason)` / `restoreArchivedActivities(reason)` | Scan（PK/SK projection）→ UpdateItem | child partition に分散するため id / reason 横断は Scan。低頻度（プラン降格時のみ）のため GSI 不要（Pre-PMF / ADR-0010） |
@@ -290,7 +290,7 @@ per-child instance は child partition 配下に置き、`findActivitiesByChild`
 CDK（`infra/lib/storage-stack.ts`）の `MainTable` は単一テーブル（PK + SK + GSI1 + GSI2）を既に有しており、
 新規 SK prefix `CHILDACT#` は既存テーブルにそのまま乗るため **CDK 変更不要**（追加 GSI なし）。
 
-> **#2818 経緯**: 本 repo は PR #2455 で stub 化され、#2263 hotfix で「read=空 / write=throw」化された。
+> **#2824 経緯**: 本 repo は PR #2455 で stub 化され、#2263 hotfix で「read=空 / write=throw」化された。
 > 「write 経路は本番に到達しない」仮定は marketplace の per-child 取込（`importActivities` →
 > `insertActivitiesBulk`）で破れ、本番で取込が永続せず UI が「N 件登録しました」と偽る CRITICAL の
 > 一因となった。本実装で根治。helper 経由 stub（`return notImplemented(...)` 等）の再混入は

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -266,6 +266,36 @@ User 直接判断 (`tmp/user-question/2026-05-23-customer-use-case-data-model-qa
 - `idx_child_activities_child` ON (child_id, is_archived)
 - `idx_child_activities_child_sort` ON (child_id, sort_order)
 
+#### DynamoDB キー設計（single-table、#2818 / ADR-0055）
+
+本番 cognito Lambda は `DATA_SOURCE=dynamodb` で稼働するため、SQLite と機能等価の
+DynamoDB 実装 (`src/lib/server/db/dynamodb/child-activity-repo.ts`) を持つ。
+per-child instance は child partition 配下に置き、`findActivitiesByChild` を**追加 GSI なし**の
+単一 partition Query で完結させる（cross-child access を構造的に防ぐ、ADR-0055 §3.1）。
+
+| エンティティ | PK | SK | 補足 |
+|---|---|---|---|
+| child_activity | `T#<tid>#CHILD#<childId>` | `CHILDACT#<paddedId>` | id は 8 桁 0 埋め。activity_logs / point_ledger と同 partition に同居 |
+
+| アクセスパターン | 操作 | 条件 |
+|---|---|---|
+| `findActivitiesByChild(childId)` | Query | `PK = T#<tid>#CHILD#<childId> AND begins_with(SK, 'CHILDACT#')`。archive / visibleOnly filter + sort_order 昇順は in-memory（SQLite SSOT と一致） |
+| `findActivityById(id, childId)` | GetItem | `PK = T#<tid>#CHILD#<childId>, SK = CHILDACT#<paddedId>` |
+| `insertActivity` | counter 採番 → PutItem | SQLite schema default（sort_order=0 / is_visible=1 / source='seed' / daily_limit=null 等）を明示的に埋め、`.returning()` 等価の row を返す |
+| `insertActivitiesBulk` | 直列 PutItem | 取込時 per-child 配信の核心経路。返り値（作成 row）を import service が persist honesty 検証に使う（#2818） |
+| `updateActivity` / `setActivityVisibility` | UpdateItem（`ConditionExpression: attribute_exists(PK)`、`ALL_NEW`） | 別 child / 不在は `ConditionalCheckFailedException` → undefined |
+| `deleteActivity` | DeleteItem（`ALL_OLD`） | 削除前 row を返す（SQLite `.returning()` 等価） |
+| `archiveActivities(ids, reason)` / `restoreArchivedActivities(reason)` | Scan（PK/SK projection）→ UpdateItem | child partition に分散するため id / reason 横断は Scan。低頻度（プラン降格時のみ）のため GSI 不要（Pre-PMF / ADR-0010） |
+
+CDK（`infra/lib/storage-stack.ts`）の `MainTable` は単一テーブル（PK + SK + GSI1 + GSI2）を既に有しており、
+新規 SK prefix `CHILDACT#` は既存テーブルにそのまま乗るため **CDK 変更不要**（追加 GSI なし）。
+
+> **#2818 経緯**: 本 repo は PR #2455 で stub 化され、#2263 hotfix で「read=空 / write=throw」化された。
+> 「write 経路は本番に到達しない」仮定は marketplace の per-child 取込（`importActivities` →
+> `insertActivitiesBulk`）で破れ、本番で取込が永続せず UI が「N 件登録しました」と偽る CRITICAL の
+> 一因となった。本実装で根治。helper 経由 stub（`return notImplemented(...)` 等）の再混入は
+> `scripts/check-dynamodb-stub-parity.mjs`（baseline ratchet）が CI で検出する。
+
 ### activities (legacy、PR-3 期間中の並存)
 
 > **#2362 PR-3 移行ステータス (2026-05-24)**: 本 table は `child_activities` への

--- a/scripts/check-dynamodb-stub-parity.mjs
+++ b/scripts/check-dynamodb-stub-parity.mjs
@@ -53,10 +53,8 @@ function collectInventory() {
 		for (const line of content.split('\n')) {
 			// helper 定義行 (`function notImplemented(method: string)`) は除外
 			if (/^\s*function\s+(?:notImplemented|warnRead|warnWrite)/.test(line)) continue;
-			let m;
-			STUB_CALL_RE.lastIndex = 0;
-			while ((m = STUB_CALL_RE.exec(line)) !== null) {
-				methods.add(m[1]);
+			for (const match of line.matchAll(STUB_CALL_RE)) {
+				methods.add(match[1]);
 			}
 		}
 		if (methods.size > 0) {

--- a/scripts/check-dynamodb-stub-parity.mjs
+++ b/scripts/check-dynamodb-stub-parity.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * #2818 / ADR-0055 — DynamoDB repo stub parity guard
+ *
+ * 背景: per-child / family repo の interface を拡張したのに DynamoDB 実装を stub
+ *   (`notImplemented(...)` throw / `warnRead(...)` / `warnWrite(...)` 空返却) のまま
+ *   放置すると、本番 cognito Lambda (AUTH_MODE=cognito + DATA_SOURCE=dynamodb) で
+ *   write 経路が永続せず、UI が「N 件登録しました」と偽る (#2818 marketplace 取込 CRITICAL)。
+ *
+ * 本 guard は `src/lib/server/db/dynamodb/*.ts` の stub call-site を inventory 化し、
+ *   既知 baseline (`scripts/dynamodb-stub-baseline.json`) を超える「新規 stub」を検出すると
+ *   exit 1 で CI を red にする。これにより「interface 拡張したのに dynamodb 未実装」の
+ *   silent な後退を機械的に禁止する。baseline は Phase 2/3 で本実装するたびに削っていく。
+ *
+ * 検出パターン (call-site のみ。helper 定義行 `function notImplemented`/`function warnRead`/
+ *   `function warnWrite` は除外):
+ *   - `notImplemented('<method>')` / `notImplementedWrite('<method>')`
+ *   - `warnRead('<method>', ...)`
+ *   - `warnWrite('<method>', ...)`
+ *
+ * 使い方:
+ *   node scripts/check-dynamodb-stub-parity.mjs            # baseline 照合 (CI / 既定)
+ *   node scripts/check-dynamodb-stub-parity.mjs --list     # 現在の inventory を表示 (exit 0)
+ *   node scripts/check-dynamodb-stub-parity.mjs --update   # baseline を現状で再生成 (本実装時のみ)
+ *
+ * exit:
+ *   0 = baseline 以下 (新規 stub なし、または baseline 減少のみ)
+ *   1 = baseline を超える新規 stub 追加、または baseline ファイル不在
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const DYNAMO_DIR = join(REPO_ROOT, 'src', 'lib', 'server', 'db', 'dynamodb');
+const BASELINE_PATH = join(__dirname, 'dynamodb-stub-baseline.json');
+
+// call-site を検出する (helper 定義行は function キーワードで始まるため除外される)
+const STUB_CALL_RE = /\b(?:notImplemented(?:Write)?|warnRead|warnWrite)\s*\(\s*['"]([^'"]+)['"]/g;
+
+/** 各 repo file の stub method 名一覧を収集する。 */
+function collectInventory() {
+	const inventory = {};
+	const files = readdirSync(DYNAMO_DIR)
+		.filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+		.sort();
+
+	for (const file of files) {
+		const content = readFileSync(join(DYNAMO_DIR, file), 'utf8');
+		const methods = new Set();
+		for (const line of content.split('\n')) {
+			// helper 定義行 (`function notImplemented(method: string)`) は除外
+			if (/^\s*function\s+(?:notImplemented|warnRead|warnWrite)/.test(line)) continue;
+			let m;
+			STUB_CALL_RE.lastIndex = 0;
+			while ((m = STUB_CALL_RE.exec(line)) !== null) {
+				methods.add(m[1]);
+			}
+		}
+		if (methods.size > 0) {
+			inventory[`src/lib/server/db/dynamodb/${file}`] = [...methods].sort();
+		}
+	}
+	return inventory;
+}
+
+function loadBaseline() {
+	try {
+		return JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+	} catch {
+		return null;
+	}
+}
+
+const args = process.argv.slice(2);
+const inventory = collectInventory();
+
+if (args.includes('--list')) {
+	console.log(JSON.stringify(inventory, null, '\t'));
+	const total = Object.values(inventory).reduce((s, m) => s + m.length, 0);
+	console.log(
+		`\n[dynamodb-stub-parity] ${Object.keys(inventory).length} repo / ${total} stub method`,
+	);
+	process.exit(0);
+}
+
+if (args.includes('--update')) {
+	writeFileSync(BASELINE_PATH, `${JSON.stringify(inventory, null, '\t')}\n`, 'utf8');
+	console.log(`[dynamodb-stub-parity] baseline updated: ${BASELINE_PATH}`);
+	process.exit(0);
+}
+
+const baseline = loadBaseline();
+if (!baseline) {
+	console.error(
+		`[dynamodb-stub-parity] FAIL: baseline 不在 (${BASELINE_PATH})。` +
+			'`node scripts/check-dynamodb-stub-parity.mjs --update` で生成してください。',
+	);
+	process.exit(1);
+}
+
+// baseline を超える新規 stub を検出する。
+const violations = [];
+for (const [file, methods] of Object.entries(inventory)) {
+	const allowed = new Set(baseline[file] ?? []);
+	for (const method of methods) {
+		if (!allowed.has(method)) {
+			violations.push(`${file} :: ${method}`);
+		}
+	}
+}
+
+if (violations.length > 0) {
+	console.error('[dynamodb-stub-parity] FAIL: baseline を超える新規 stub を検出しました。');
+	console.error(
+		'  DynamoDB は本番 cognito Lambda (DATA_SOURCE=dynamodb) で稼働します。' +
+			'interface を拡張したら DynamoDB 実装も本実装してください (ADR-0055 / #2818)。',
+	);
+	for (const v of violations) console.error(`  - ${v}`);
+	console.error(
+		'\n  意図的に baseline を更新する場合 (= 別 repo を本実装して stub が減った等):' +
+			'\n    node scripts/check-dynamodb-stub-parity.mjs --update',
+	);
+	process.exit(1);
+}
+
+// baseline が現状より多い (= 本実装で stub が減った) 場合はガイダンスのみ (success)。
+const baselineTotal = Object.values(baseline).reduce((s, m) => s + m.length, 0);
+const currentTotal = Object.values(inventory).reduce((s, m) => s + m.length, 0);
+if (currentTotal < baselineTotal) {
+	console.log(
+		`[dynamodb-stub-parity] OK (stub 減少: baseline ${baselineTotal} → 現状 ${currentTotal})。` +
+			' baseline を更新してください: node scripts/check-dynamodb-stub-parity.mjs --update',
+	);
+} else {
+	console.log(
+		`[dynamodb-stub-parity] OK: ${Object.keys(inventory).length} repo / ${currentTotal} stub method (baseline 以下)。`,
+	);
+}
+process.exit(0);

--- a/scripts/check-dynamodb-stub-parity.mjs
+++ b/scripts/check-dynamodb-stub-parity.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 /**
- * #2818 / ADR-0055 — DynamoDB repo stub parity guard
+ * #2824 / ADR-0055 — DynamoDB repo stub parity guard
  *
  * 背景: per-child / family repo の interface を拡張したのに DynamoDB 実装を stub
  *   (`notImplemented(...)` throw / `warnRead(...)` / `warnWrite(...)` 空返却) のまま
  *   放置すると、本番 cognito Lambda (AUTH_MODE=cognito + DATA_SOURCE=dynamodb) で
- *   write 経路が永続せず、UI が「N 件登録しました」と偽る (#2818 marketplace 取込 CRITICAL)。
+ *   write 経路が永続せず、UI が「N 件登録しました」と偽る (#2824 marketplace 取込 CRITICAL)。
  *
  * 本 guard は `src/lib/server/db/dynamodb/*.ts` の stub call-site を inventory 化し、
  *   既知 baseline (`scripts/dynamodb-stub-baseline.json`) を超える「新規 stub」を検出すると
@@ -114,7 +114,7 @@ if (violations.length > 0) {
 	console.error('[dynamodb-stub-parity] FAIL: baseline を超える新規 stub を検出しました。');
 	console.error(
 		'  DynamoDB は本番 cognito Lambda (DATA_SOURCE=dynamodb) で稼働します。' +
-			'interface を拡張したら DynamoDB 実装も本実装してください (ADR-0055 / #2818)。',
+			'interface を拡張したら DynamoDB 実装も本実装してください (ADR-0055 / #2824)。',
 	);
 	for (const v of violations) console.error(`  - ${v}`);
 	console.error(

--- a/scripts/dynamodb-stub-baseline.json
+++ b/scripts/dynamodb-stub-baseline.json
@@ -1,0 +1,112 @@
+{
+	"src/lib/server/db/dynamodb/activity-repo.ts": [
+		"archiveActivities",
+		"deleteActivity",
+		"insertActivity",
+		"insertActivityLog",
+		"insertPointLedger",
+		"restoreArchivedActivities",
+		"setActivityVisibility",
+		"updateActivity"
+	],
+	"src/lib/server/db/dynamodb/auto-challenge-repo.ts": [
+		"deleteByTenantId",
+		"expireOldChallenges",
+		"findActiveByChild",
+		"findByChild",
+		"findByChildAndWeek",
+		"insert",
+		"update"
+	],
+	"src/lib/server/db/dynamodb/battle-repo.ts": [
+		"completeBattle",
+		"countConsecutiveLosses",
+		"findCollection",
+		"findRecentBattles",
+		"findTodayBattle",
+		"insertDailyBattle",
+		"upsertCollectionEntry"
+	],
+	"src/lib/server/db/dynamodb/certificate-repo.ts": [
+		"findCertificateById",
+		"findCertificates",
+		"hasCertificate",
+		"issueCertificate"
+	],
+	"src/lib/server/db/dynamodb/child-challenge-repo.ts": [
+		"claimReward",
+		"copyAcrossChildren",
+		"delete",
+		"deleteByTenantId",
+		"findActiveByChildId",
+		"findActiveOrUnclaimedByChildId",
+		"findAllByTenant",
+		"findByChildId",
+		"findById",
+		"insert",
+		"insertBulk",
+		"markCompleted",
+		"update",
+		"updateProgress"
+	],
+	"src/lib/server/db/dynamodb/cloud-export-repo.ts": [
+		"countByTenant",
+		"deleteById",
+		"deleteExpired",
+		"findById",
+		"findByPin",
+		"findByTenant",
+		"incrementDownloadCount",
+		"insert"
+	],
+	"src/lib/server/db/dynamodb/message-repo.ts": [
+		"countUnshownMessages",
+		"deleteByTenantId",
+		"findMessages",
+		"findUnshownMessage",
+		"insertMessage",
+		"markMessageShown"
+	],
+	"src/lib/server/db/dynamodb/report-daily-summary-repo.ts": [
+		"deleteByTenantId",
+		"deleteOlderThan",
+		"findByChildAndDateRange",
+		"findByTenantAndDateRange",
+		"upsert"
+	],
+	"src/lib/server/db/dynamodb/reward-redemption-repo.ts": [
+		"deleteByTenantId",
+		"expireOldRedemptions",
+		"findPendingByChildAndReward",
+		"findRedemptionRequestsByChild",
+		"findRedemptionRequestsByTenant",
+		"findUnshownResultByChild",
+		"hasPendingByReward",
+		"insertRedemptionRequest",
+		"markRedemptionResultShown",
+		"updateRedemptionRequestStatus"
+	],
+	"src/lib/server/db/dynamodb/sibling-cheer-repo.ts": [
+		"countTodayCheersFrom",
+		"deleteByTenantId",
+		"findUnshownCheers",
+		"insertCheer",
+		"markShown"
+	],
+	"src/lib/server/db/dynamodb/stamp-card-repo.ts": [
+		"deleteByTenantId",
+		"findCardByChildAndWeek",
+		"findEntriesWithMasterByCardId",
+		"insertCard",
+		"insertEntry",
+		"updateCardStatus",
+		"updateCardStatusIfCollecting"
+	],
+	"src/lib/server/db/dynamodb/viewer-token-repo.ts": [
+		"deleteById",
+		"findByTenant",
+		"findByToken",
+		"insert",
+		"revoke"
+	]
+}

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4171,6 +4171,12 @@ export const ADMIN_ACTIVITIES_PAGE_LABELS = {
 	importAllDuplicates: `選んだ${CHILD_TERMS.honorific}にはすでに追加済みです`,
 	importFailed: '取込に失敗しました',
 	importDemo: 'デモではお試し用です（実際の追加は行われません）',
+	// #2818: 一部 (または全件) が保存できなかったとき正直に出す。
+	//   「N 件登録しました」と偽らず、追加できた件数と保存できなかった件数を分けて表示する。
+	importPartialFailure: (imported: number, failed: number) =>
+		imported > 0
+			? `${imported} 件を追加しましたが、${failed} 件は保存できませんでした`
+			: '保存に失敗しました。もう一度お試しください',
 	// Round 18 Cluster G (per-child scope badge): 英語内部語彙「per-child」UI 露出撤去 (ADR-0045 §9)
 	// 「お子さま別」= per-child scope (個別 child に紐付く activity) を親向けに明示する短い表示
 	scopeBadgePerChild: `${CHILD_TERMS.honorific}別`,

--- a/src/lib/server/db/dynamodb/child-activity-repo.ts
+++ b/src/lib/server/db/dynamodb/child-activity-repo.ts
@@ -403,8 +403,8 @@ async function findChildActivityKeysByIds(
 	tenantId: string,
 ): Promise<{ PK: string; SK: string }[]> {
 	const idSet = new Set(ids);
-	const all = await scanChildActivities(' AND begins_with(PK, :tprefix)', {
-		':tprefix': tenantPK('CHILD#', tenantId),
+	const all = await scanChildActivities(' AND begins_with(PK, :tenantPrefix)', {
+		':tenantPrefix': tenantPK('CHILD#', tenantId),
 	});
 	// id は SK = CHILDACT#<paddedId> から復元 (Scan 結果は PK/SK のみ projection)。
 	return all.filter((k) => idSet.has(Number(k.SK.replace('CHILDACT#', ''))));
@@ -414,8 +414,8 @@ async function findChildActivityKeysByReason(
 	reason: ArchivedReason,
 	tenantId: string,
 ): Promise<{ PK: string; SK: string }[]> {
-	return scanChildActivities(' AND begins_with(PK, :tprefix) AND archivedReason = :reason', {
-		':tprefix': tenantPK('CHILD#', tenantId),
+	return scanChildActivities(' AND begins_with(PK, :tenantPrefix) AND archivedReason = :reason', {
+		':tenantPrefix': tenantPK('CHILD#', tenantId),
 		':reason': reason,
 	});
 }

--- a/src/lib/server/db/dynamodb/child-activity-repo.ts
+++ b/src/lib/server/db/dynamodb/child-activity-repo.ts
@@ -1,134 +1,429 @@
 // src/lib/server/db/dynamodb/child-activity-repo.ts
-// per-child activity instance repository — DynamoDB Pre-PMF fallback 実装
+// per-child activity instance repository — DynamoDB 本実装 (ADR-0055)
 //
-// #2263 regression hotfix (PR #2455 = #2362 PR-3 で 2026-05-24 導入):
-//   本番 cognito Lambda は `AUTH_MODE=cognito + DATA_SOURCE=dynamodb` で main Lambda
-//   として稼働する (`infra/lib/compute-stack.ts:159` で固定)。当初コメントの
-//   「DATA_SOURCE='dynamodb' は ADR-0048 Multi-Lambda 設計外」は誤りで、本 stub の
-//   read method 全件 NotImplementedError 化が `/preschool/home` 等の 5 age mode SSR で
-//   `Promise.all([..., getChildActivities(...)])` 経路を reject し 500 を引き起こす
-//   (子供 3-18 歳が本番アプリにアクセス不能)。ADR-0002 Critical 修正対象。
+// IChildActivityRepo (child-activity-repo.interface.ts) を SQLite 実装
+// (sqlite/child-activity-repo.ts、挙動 SSOT) と機能等価に DynamoDB single-table で実装する。
 //
-// 修正方針 (PR #2280 / child-challenge-repo (#2362 PR-7) と同型):
-//   - read 系: warnRead + 空配列 / undefined / 0 を return (500 防止)
-//   - write 系: throw 維持 (Pre-PMF で本番 write 経路に到達しない設計、ADR-0010
-//     Bucket B「まだ作らない」を構造的に強制 — 将来 ADR-0055 per-child schema 本実装で解除)
+// 経緯: PR #2455 (#2362 PR-3) で導入された stub が #2263 hotfix で「read=空返却 /
+//   write=throw」化された。当時の「write 経路は本番に到達しない」仮定は marketplace の
+//   per-child 取込 (importActivities → dispatchPerChildBulk → insertActivitiesBulk) で破れ、
+//   本番 cognito Lambda (AUTH_MODE=cognito + DATA_SOURCE=dynamodb) で取込が永続せず、
+//   UI が「N 件登録しました」と偽る CRITICAL バグの一因となった。本実装で根治する。
 //
-// 関連: ADR-0002 / ADR-0010 / ADR-0055 / PR #2280 (12 repo hotfix) / PR #2479 (child-challenge)
+// key 設計 (keys.ts §childActivityKey):
+//   PK = T#<tenantId>#CHILD#<childId>   (child partition、activity_logs 等と同居)
+//   SK = CHILDACT#<paddedId>            (8 桁 0 埋め、辞書順)
+//   → findActivitiesByChild は単一 partition Query で完結し GSI 不要 (ADR-0055 §3.1)。
+//
+// 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/child-activity-repo.ts (SSOT)
 
+import { DeleteCommand, GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type { ArchivedReason } from '$lib/domain/archive-types';
-import { logger } from '$lib/server/logger';
 import type {
 	Child,
 	ChildActivity,
 	InsertChildActivityInput,
 	UpdateChildActivityInput,
 } from '../types';
+import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
+import { childActivityKey, childActivityPrefix, childPK, ENTITY_NAMES, tenantPK } from './keys';
+import { findChildByIdRaw, queryAllItems, stripKeys } from './repo-helpers';
 
-const SERVICE = 'child-activity-repo.dynamodb';
+const PREFIX = childActivityPrefix();
 
-function warnRead(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] read fallback: returning empty (Pre-PMF stub, #2263 regression)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
+/**
+ * DynamoDB item を ChildActivity に正規化する。
+ * SQLite の schema default と整合させるため、欠落しうる属性を補完する
+ * (旧データ / 部分書込みへの防御。本実装の write は常に全属性を埋める)。
+ */
+function toChildActivity(item: Record<string, unknown>): ChildActivity {
+	const stripped = stripKeys(item) as unknown as ChildActivity;
+	// priority backfill (SQLite schema default 'optional' と整合)
+	if (stripped.priority !== 'must' && stripped.priority !== 'optional') {
+		stripped.priority = 'optional';
+	}
+	return stripped;
 }
 
-function notImplemented(method: string): never {
-	throw new Error(
-		`[${SERVICE}] ${method} not implemented (ADR-0055 per-child schema 本実装は Pre-PMF 範囲外). ` +
-			'write 経路は到達しない設計 — 到達した場合は ADR-0010 Bucket B 違反として要対応。',
-	);
-}
+// ============================================================
+// findActivitiesByChild — 指定 child の activity 一覧 (child partition Query)
+// ============================================================
 
 export async function findActivitiesByChild(
 	childId: number,
 	tenantId: string,
 	options?: { includeArchived?: boolean; visibleOnly?: boolean },
 ): Promise<ChildActivity[]> {
-	warnRead('findActivitiesByChild', { childId, tenantId, options });
-	return [];
+	const items = await queryAllItems(childPK(childId, tenantId), PREFIX);
+	let activities = items.map(toChildActivity);
+
+	// archive filter (SQLite: NULL 互換 — NULL/0 は active 扱い、#962 教訓)
+	if (!options?.includeArchived) {
+		activities = activities.filter((a) => !a.isArchived || a.isArchived === 0);
+	}
+
+	if (options?.visibleOnly) {
+		activities = activities.filter((a) => a.isVisible === 1);
+	}
+
+	// SQLite は ORDER BY sort_order。in-memory で同順に揃える。
+	activities.sort((a, b) => a.sortOrder - b.sortOrder);
+	return activities;
 }
+
+// ============================================================
+// findActivityById — id + child + tenant 3 軸取得 (GetItem)
+// ============================================================
 
 export async function findActivityById(
 	id: number,
 	childId: number,
 	tenantId: string,
 ): Promise<ChildActivity | undefined> {
-	warnRead('findActivityById', { id, childId, tenantId });
-	return undefined;
+	const result = await getDocClient().send(
+		new GetCommand({
+			TableName: TABLE_NAME,
+			Key: childActivityKey(childId, id, tenantId),
+		}),
+	);
+	if (!result.Item) return undefined;
+	return toChildActivity(result.Item);
 }
+
+// ============================================================
+// countMainQuestActivities — per-child main quest 数
+// ============================================================
 
 export async function countMainQuestActivities(childId: number, tenantId: string): Promise<number> {
-	warnRead('countMainQuestActivities', { childId, tenantId });
-	return 0;
+	// SQLite: isMainQuest=1 AND isVisible=1 AND (isArchived=0 OR NULL)
+	const activities = await findActivitiesByChild(childId, tenantId, { visibleOnly: true });
+	return activities.filter((a) => a.isMainQuest === 1).length;
 }
 
-export async function findChildById(id: number, tenantId: string): Promise<Child | undefined> {
-	warnRead('findChildById', { id, tenantId });
-	return undefined;
+// ============================================================
+// insertActivity — per-child instance 新規作成
+// ============================================================
+
+/**
+ * 1 件の ChildActivity を組み立てる (DynamoDB item にも返り値にも同じ shape を使う)。
+ * SQLite schema default (sortOrder=0 / isVisible=1 / source='seed' / dailyLimit=null /
+ * nameKana=null / nameKanji=null / isMainQuest=0 / isArchived=0 / priority='optional')
+ * を明示的に埋め、insertActivity の返り値が SQLite の `.returning()` と等価になるようにする。
+ */
+function buildChildActivity(
+	id: number,
+	input: InsertChildActivityInput,
+	createdAt: string,
+): ChildActivity {
+	return {
+		id,
+		childId: input.childId,
+		name: input.name,
+		categoryId: input.categoryId,
+		icon: input.icon,
+		basePoints: input.basePoints,
+		isVisible: 1,
+		dailyLimit: null,
+		sortOrder: 0,
+		source: 'seed',
+		nameKana: null,
+		nameKanji: null,
+		triggerHint: input.triggerHint ?? null,
+		isMainQuest: input.isMainQuest ?? 0,
+		isArchived: 0,
+		archivedReason: null,
+		createdAt,
+		sourcePresetId: input.sourcePresetId ?? null,
+		priority: input.priority ?? 'optional',
+	};
 }
 
 export async function insertActivity(
-	_input: InsertChildActivityInput,
-	_tenantId: string,
+	input: InsertChildActivityInput,
+	tenantId: string,
 ): Promise<ChildActivity> {
-	return notImplemented('insertActivity');
+	const id = await nextId(ENTITY_NAMES.childActivity, tenantId);
+	const activity = buildChildActivity(id, input, new Date().toISOString());
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...childActivityKey(input.childId, id, tenantId),
+				...activity,
+			},
+		}),
+	);
+
+	return activity;
 }
+
+// ============================================================
+// insertActivitiesBulk — 一括作成 (取込時 per-child 配信)
+// ============================================================
 
 export async function insertActivitiesBulk(
-	_inputs: InsertChildActivityInput[],
-	_tenantId: string,
+	inputs: InsertChildActivityInput[],
+	tenantId: string,
 ): Promise<ChildActivity[]> {
-	return notImplemented('insertActivitiesBulk');
+	if (inputs.length === 0) return [];
+	// SQLite 実装と同じく直列 insert (driver 側 transaction batching 相当)。
+	// id 採番が atomic counter のため BatchWrite ではなく順次 Put。
+	const results: ChildActivity[] = [];
+	for (const input of inputs) {
+		const row = await insertActivity(input, tenantId);
+		results.push(row);
+	}
+	return results;
 }
+
+// ============================================================
+// updateActivity — child scope 更新 (条件付き UpdateItem)
+// ============================================================
 
 export async function updateActivity(
-	_id: number,
-	_childId: number,
-	_input: UpdateChildActivityInput,
-	_tenantId: string,
+	id: number,
+	childId: number,
+	input: UpdateChildActivityInput,
+	tenantId: string,
 ): Promise<ChildActivity | undefined> {
-	return notImplemented('updateActivity');
+	const fields = [
+		'name',
+		'categoryId',
+		'icon',
+		'basePoints',
+		'triggerHint',
+		'isMainQuest',
+		'priority',
+	] as const;
+
+	const sets: string[] = [];
+	const names: Record<string, string> = {};
+	const values: Record<string, unknown> = {};
+	for (const field of fields) {
+		if (input[field] !== undefined) {
+			sets.push(`#${field} = :${field}`);
+			names[`#${field}`] = field;
+			values[`:${field}`] = input[field];
+		}
+	}
+
+	// 更新対象がない場合は SQLite (.set({})) と同様、現在値をそのまま返す。
+	if (sets.length === 0) {
+		return findActivityById(id, childId, tenantId);
+	}
+
+	try {
+		const result = await getDocClient().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: childActivityKey(childId, id, tenantId),
+				UpdateExpression: `SET ${sets.join(', ')}`,
+				ExpressionAttributeNames: names,
+				ExpressionAttributeValues: values,
+				// 存在しない (= 別 child / 不在) なら更新せず undefined を返す。
+				ConditionExpression: 'attribute_exists(PK)',
+				ReturnValues: 'ALL_NEW',
+			}),
+		);
+		if (!result.Attributes) return undefined;
+		return toChildActivity(result.Attributes);
+	} catch (e) {
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') {
+			return undefined;
+		}
+		throw e;
+	}
 }
+
+// ============================================================
+// setActivityVisibility
+// ============================================================
 
 export async function setActivityVisibility(
-	_id: number,
-	_childId: number,
-	_visible: boolean,
-	_tenantId: string,
+	id: number,
+	childId: number,
+	visible: boolean,
+	tenantId: string,
 ): Promise<ChildActivity | undefined> {
-	return notImplemented('setActivityVisibility');
+	try {
+		const result = await getDocClient().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: childActivityKey(childId, id, tenantId),
+				UpdateExpression: 'SET isVisible = :v',
+				ExpressionAttributeValues: { ':v': visible ? 1 : 0 },
+				ConditionExpression: 'attribute_exists(PK)',
+				ReturnValues: 'ALL_NEW',
+			}),
+		);
+		if (!result.Attributes) return undefined;
+		return toChildActivity(result.Attributes);
+	} catch (e) {
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') {
+			return undefined;
+		}
+		throw e;
+	}
 }
+
+// ============================================================
+// deleteActivity — child scope 削除 (返り値は削除前 row)
+// ============================================================
 
 export async function deleteActivity(
-	_id: number,
-	_childId: number,
-	_tenantId: string,
+	id: number,
+	childId: number,
+	tenantId: string,
 ): Promise<ChildActivity | undefined> {
-	return notImplemented('deleteActivity');
+	const result = await getDocClient().send(
+		new DeleteCommand({
+			TableName: TABLE_NAME,
+			Key: childActivityKey(childId, id, tenantId),
+			// SQLite `.returning()` 等価: 削除した行を返す。
+			ReturnValues: 'ALL_OLD',
+		}),
+	);
+	if (!result.Attributes) return undefined;
+	return toChildActivity(result.Attributes);
 }
+
+// ============================================================
+// copyActivitiesAcrossChildren — 兄弟共通化 (User §1)
+// ============================================================
 
 export async function copyActivitiesAcrossChildren(
-	_sourceChildId: number,
-	_targetChildId: number,
-	_tenantId: string,
+	sourceChildId: number,
+	targetChildId: number,
+	tenantId: string,
 ): Promise<ChildActivity[]> {
-	return notImplemented('copyActivitiesAcrossChildren');
+	const sourceActivities = await findActivitiesByChild(sourceChildId, tenantId, {
+		includeArchived: false,
+		visibleOnly: false,
+	});
+	if (sourceActivities.length === 0) return [];
+
+	const inputs: InsertChildActivityInput[] = sourceActivities.map((a) => ({
+		childId: targetChildId,
+		name: a.name,
+		categoryId: a.categoryId,
+		icon: a.icon,
+		basePoints: a.basePoints,
+		triggerHint: a.triggerHint,
+		isMainQuest: a.isMainQuest,
+		sourcePresetId: a.sourcePresetId,
+		priority: a.priority,
+	}));
+
+	return insertActivitiesBulk(inputs, tenantId);
 }
 
+// ============================================================
+// archive / restore (#783)
 // Phase 7 PR-2a (#2688): reason は ArchivedReason 型 (`ARCHIVED_REASONS` SSOT)。
+// ============================================================
+
+/**
+ * 指定 id 群を archive する。child を跨ぐ可能性があるため、id ごとに
+ * inverted-index lookup を避けるよう tenant 配下を Scan して PK/SK を解決する。
+ * (ids 件数は通常少数 — プラン降格時の must/optional 整理。Pre-PMF / ADR-0010)。
+ */
 export async function archiveActivities(
-	_ids: number[],
-	_reason: ArchivedReason,
-	_tenantId: string,
+	ids: number[],
+	reason: ArchivedReason,
+	tenantId: string,
 ): Promise<void> {
-	return notImplemented('archiveActivities');
+	if (ids.length === 0) return;
+	const targets = await findChildActivityKeysByIds(ids, tenantId);
+	for (const key of targets) {
+		await getDocClient().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: key,
+				UpdateExpression: 'SET isArchived = :one, archivedReason = :reason',
+				ExpressionAttributeValues: { ':one': 1, ':reason': reason },
+			}),
+		);
+	}
 }
 
 export async function restoreArchivedActivities(
-	_reason: ArchivedReason,
-	_tenantId: string,
+	reason: ArchivedReason,
+	tenantId: string,
 ): Promise<void> {
-	return notImplemented('restoreArchivedActivities');
+	const targets = await findChildActivityKeysByReason(reason, tenantId);
+	for (const key of targets) {
+		await getDocClient().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: key,
+				UpdateExpression: 'SET isArchived = :zero REMOVE archivedReason',
+				ExpressionAttributeValues: { ':zero': 0 },
+			}),
+		);
+	}
+}
+
+// ============================================================
+// archive helpers — tenant 配下の CHILDACT# を Scan で解決
+// ============================================================
+//
+// child_activities は child partition (PK=CHILD#<cId>) に分散するため、id / reason での
+// 横断検索は GSI なしでは Scan が必要。archive / restore は低頻度 (プラン降格時のみ) の
+// ため Pre-PMF (ADR-0010) では Scan + 属性フィルタで十分。GSI 追加は過剰防衛。
+
+async function scanChildActivities(
+	extraFilter: string,
+	extraValues: Record<string, unknown>,
+): Promise<{ PK: string; SK: string }[]> {
+	const { ScanCommand } = await import('@aws-sdk/lib-dynamodb');
+	const keys: { PK: string; SK: string }[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await getDocClient().send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: `begins_with(SK, :skPrefix)${extraFilter}`,
+				ExpressionAttributeValues: { ':skPrefix': PREFIX, ...extraValues },
+				ProjectionExpression: 'PK, SK',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) {
+			keys.push({ PK: item.PK as string, SK: item.SK as string });
+		}
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return keys;
+}
+
+async function findChildActivityKeysByIds(
+	ids: number[],
+	tenantId: string,
+): Promise<{ PK: string; SK: string }[]> {
+	const idSet = new Set(ids);
+	const all = await scanChildActivities(' AND begins_with(PK, :tprefix)', {
+		':tprefix': tenantPK('CHILD#', tenantId),
+	});
+	// id は SK = CHILDACT#<paddedId> から復元 (Scan 結果は PK/SK のみ projection)。
+	return all.filter((k) => idSet.has(Number(k.SK.replace('CHILDACT#', ''))));
+}
+
+async function findChildActivityKeysByReason(
+	reason: ArchivedReason,
+	tenantId: string,
+): Promise<{ PK: string; SK: string }[]> {
+	return scanChildActivities(' AND begins_with(PK, :tprefix) AND archivedReason = :reason', {
+		':tprefix': tenantPK('CHILD#', tenantId),
+		':reason': reason,
+	});
+}
+
+// ============================================================
+// Child convenience lookup (repo-helpers の共通実装に委譲)
+// ============================================================
+
+export async function findChildById(id: number, tenantId: string): Promise<Child | undefined> {
+	return findChildByIdRaw(id, tenantId);
 }

--- a/src/lib/server/db/dynamodb/keys.ts
+++ b/src/lib/server/db/dynamodb/keys.ts
@@ -94,6 +94,29 @@ export function activityKeyWithGSI2(
 	};
 }
 
+/**
+ * Child activity instance (#2362 PR-3 / ADR-0055): PK=CHILD#<cId>, SK=CHILDACT#<id>
+ *
+ * per-child instance を child partition 配下に配置する (activity_logs / point_ledger /
+ * status 等と同じ child scope レイアウト)。これにより `findActivitiesByChild` は
+ * 単一 partition Query (begins_with(SK, 'CHILDACT#')) で完結し、GSI を追加せず
+ * cross-child access を構造的に防ぐ (ADR-0055 §3.1)。
+ *
+ * 旧 family-master `ACTIVITY#<id>` (SK=MASTER) とは別 partition のため、移行中も
+ * 名前空間が衝突しない。SQLite `child_activities` table と機能等価。
+ */
+export function childActivityKey(childId: number, activityId: number, tenantId: string): DynamoKey {
+	return {
+		PK: tenantPK(`${PREFIX.CHILD}#${childId}`, tenantId),
+		SK: `CHILDACT#${padId(activityId)}`,
+	};
+}
+
+/** Child activity SK prefix for querying all activities of a child */
+export function childActivityPrefix(): string {
+	return 'CHILDACT#';
+}
+
 /** Activity log: PK=CHILD#<cId>, SK=LOG#<date>#<id> */
 export function activityLogKey(
 	childId: number,
@@ -712,6 +735,7 @@ export const ENTITY_NAMES = {
 	child: 'child',
 	category: 'category',
 	activity: 'activity',
+	childActivity: 'childActivity',
 	activityLog: 'activityLog',
 	pointLedger: 'pointLedger',
 	status: 'status',

--- a/src/lib/server/services/activity-import-service.ts
+++ b/src/lib/server/services/activity-import-service.ts
@@ -185,21 +185,57 @@ async function buildExistingNamesByChild(
 /**
  * per-child 配信 (#2362 PR-3): 各 child に instance を bulk insert。
  * child 単位で失敗しても他は継続 (partial success)。
+ *
+ * #2818 (取込永続 honesty): 「実際に persist できた activity 名」を集合として返す。
+ *   旧実装は imported を write 前 (計画時) に確定していたため、insertActivitiesBulk が
+ *   throw しても (本番 DynamoDB stub / 容量超過 / 権限不足 等) imported が減らず、UI が
+ *   「N 件登録しました」と偽った。本 helper は persist 成功分の名前のみ報告し、呼び出し側で
+ *   imported を実 persist 数から算出させることで「偽の成功件数」を構造的に防ぐ。
+ *
+ * @returns persist に成功した activity 名の集合 (どこか 1 child でも成功した名前を含む)
  */
 async function dispatchPerChildBulk(
 	inputsByChild: Map<number, InsertChildActivityInput[]>,
 	tenantId: string,
 	errors: string[],
-): Promise<void> {
+): Promise<Set<string>> {
 	const repos = getRepos();
+	const persistedNames = new Set<string>();
 	for (const [cid, inputs] of inputsByChild) {
 		if (inputs.length === 0) continue;
 		try {
-			await repos.childActivity.insertActivitiesBulk(inputs, tenantId);
+			const created = await repos.childActivity.insertActivitiesBulk(inputs, tenantId);
+			for (const a of created) persistedNames.add(a.name);
 		} catch (e) {
 			errors.push(`[child=${cid}] per-child instance 作成失敗: ${String(e)}`);
 		}
 	}
+	return persistedNames;
+}
+
+/**
+ * #2818: per-child bulk を実行し、実際に persist できた activity 数 (imported) を返す。
+ * 計画したのに persist できなかった分 (DynamoDB stub / 容量超過 等) は errors に記録する。
+ * child が 0 件のときは write を行わず imported=0 (honest)。
+ */
+async function persistAndCountImported(
+	childIds: readonly number[],
+	childInputsByChild: Map<number, InsertChildActivityInput[]>,
+	plannedNewNames: Set<string>,
+	tenantId: string,
+	errors: string[],
+): Promise<number> {
+	if (childIds.length === 0) return 0;
+	const persistedNames = await dispatchPerChildBulk(childInputsByChild, tenantId, errors);
+	let imported = 0;
+	for (const name of plannedNewNames) {
+		if (persistedNames.has(name)) imported++;
+	}
+	const failedToPersist = plannedNewNames.size - imported;
+	if (failedToPersist > 0) {
+		errors.push(`${failedToPersist} 件の活動を保存できませんでした`);
+	}
+	return imported;
 }
 
 /**
@@ -218,6 +254,45 @@ async function _fallbackChildIds(
 	return [];
 }
 
+/** planActivityForChildren の per-import 共通コンテキスト (param 数削減のため集約)。 */
+interface PlanContext {
+	presetId: string | undefined;
+	childIds: readonly number[];
+	existingNamesByChild: Map<number, Set<string>>;
+	childInputsByChild: Map<number, InsertChildActivityInput[]>;
+}
+
+/**
+ * 1 activity を全 target child の per-child input に展開する (child 単位 dedup)。
+ * @returns その activity がいずれかの child に「新規計画」されたか
+ */
+function planActivityForChildren(
+	a: ActivityPackItem,
+	categoryId: number,
+	priority: 'must' | 'optional',
+	ctx: PlanContext,
+): boolean {
+	let plannedForAnyChild = false;
+	for (const cid of ctx.childIds) {
+		const childNames = ctx.existingNamesByChild.get(cid);
+		// 既存 + 同一 import 内での重複の両方を防ぐため Set を逐次更新する。
+		if (childNames?.has(a.name)) continue;
+		childNames?.add(a.name);
+		ctx.childInputsByChild.get(cid)?.push({
+			childId: cid,
+			name: a.name,
+			categoryId,
+			icon: a.icon,
+			basePoints: a.basePoints,
+			triggerHint: a.triggerHint ?? null,
+			sourcePresetId: ctx.presetId ?? null,
+			priority,
+		});
+		plannedForAnyChild = true;
+	}
+	return plannedForAnyChild;
+}
+
 export async function importActivities(
 	activities: ActivityPackItem[],
 	tenantId: string,
@@ -229,7 +304,6 @@ export async function importActivities(
 	const applyMustDefault = opts.applyMustDefault === true;
 
 	const errors: string[] = [];
-	let imported = 0;
 	let skipped = 0;
 
 	// #2558: dedup を child 単位で行う (ADR-0055 per-child instance scope)。
@@ -242,52 +316,49 @@ export async function importActivities(
 	const childInputsByChild: Map<number, InsertChildActivityInput[]> = new Map();
 	for (const cid of childIds) childInputsByChild.set(cid, []);
 
+	// #2818: 「いずれかの child に新規 instance を生成しようと計画した」名前。
+	//   imported は計画時ではなく実 persist 後に確定する (下記参照)。
+	const plannedNewNames = new Set<string>();
+	const planCtx: PlanContext = { presetId, childIds, existingNamesByChild, childInputsByChild };
+
 	for (const a of activities) {
 		const meta = resolveActivityMeta(a, applyMustDefault);
 		if (!meta.ok) {
 			if (meta.error) errors.push(meta.error);
 			continue;
 		}
-		const categoryId = meta.categoryId as number;
-		const priority = meta.priority as 'must' | 'optional';
-
-		// child 単位 dedup: その child に同名が無いときだけ instance を生成する。
-		let createdForAnyChild = false;
-		for (const cid of childIds) {
-			const childNames = existingNamesByChild.get(cid);
-			// 既存 + 同一 import 内での重複の両方を防ぐため Set を逐次更新する。
-			if (childNames?.has(a.name)) continue;
-			childNames?.add(a.name);
-			childInputsByChild.get(cid)?.push({
-				childId: cid,
-				name: a.name,
-				categoryId,
-				icon: a.icon,
-				basePoints: a.basePoints,
-				triggerHint: a.triggerHint ?? null,
-				sourcePresetId: presetId ?? null,
-				priority,
-			});
-			createdForAnyChild = true;
-		}
-
-		// imported = いずれかの child に新規 instance を生んだ activity 数。
-		// skipped = 全 target child で既存だった (どこにも追加しなかった) activity 数。
-		if (createdForAnyChild) {
-			imported++;
+		const planned = planActivityForChildren(
+			a,
+			meta.categoryId as number,
+			meta.priority as 'must' | 'optional',
+			planCtx,
+		);
+		if (planned) {
+			plannedNewNames.add(a.name);
 		} else {
+			// 全 target child で既存だった (どこにも追加しない) activity。
 			skipped++;
 		}
 	}
 
-	if (childIds.length > 0) {
-		await dispatchPerChildBulk(childInputsByChild, tenantId, errors);
-	}
+	// #2818 (取込永続 honesty): imported は「実際に DB に persist できた activity 数」。
+	//   write を行わずに plannedNewNames.size を返すと、persist が全失敗 (本番 DynamoDB
+	//   stub / 容量超過 等) でも UI が「N 件登録しました」と偽る。dispatchPerChildBulk が
+	//   返す persist 成功名のみを imported に算入し、計画したのに persist できなかった分は
+	//   errors として可視化する。これにより「偽の成功件数」を構造的に出さない。
+	const imported = await persistAndCountImported(
+		childIds,
+		childInputsByChild,
+		plannedNewNames,
+		tenantId,
+		errors,
+	);
 
 	logger.info('[activity-import] インポート完了', {
 		context: {
 			tenantId,
 			imported,
+			plannedNew: plannedNewNames.size,
 			skipped,
 			errors: errors.length,
 			presetId: presetId ?? null,

--- a/src/lib/server/services/activity-import-service.ts
+++ b/src/lib/server/services/activity-import-service.ts
@@ -186,7 +186,7 @@ async function buildExistingNamesByChild(
  * per-child 配信 (#2362 PR-3): 各 child に instance を bulk insert。
  * child 単位で失敗しても他は継続 (partial success)。
  *
- * #2818 (取込永続 honesty): 「実際に persist できた activity 名」を集合として返す。
+ * #2824 (取込永続 honesty): 「実際に persist できた activity 名」を集合として返す。
  *   旧実装は imported を write 前 (計画時) に確定していたため、insertActivitiesBulk が
  *   throw しても (本番 DynamoDB stub / 容量超過 / 権限不足 等) imported が減らず、UI が
  *   「N 件登録しました」と偽った。本 helper は persist 成功分の名前のみ報告し、呼び出し側で
@@ -214,7 +214,7 @@ async function dispatchPerChildBulk(
 }
 
 /**
- * #2818: per-child bulk を実行し、実際に persist できた activity 数 (imported) を返す。
+ * #2824: per-child bulk を実行し、実際に persist できた activity 数 (imported) を返す。
  * 計画したのに persist できなかった分 (DynamoDB stub / 容量超過 等) は errors に記録する。
  * child が 0 件のときは write を行わず imported=0 (honest)。
  */
@@ -316,7 +316,7 @@ export async function importActivities(
 	const childInputsByChild: Map<number, InsertChildActivityInput[]> = new Map();
 	for (const cid of childIds) childInputsByChild.set(cid, []);
 
-	// #2818: 「いずれかの child に新規 instance を生成しようと計画した」名前。
+	// #2824: 「いずれかの child に新規 instance を生成しようと計画した」名前。
 	//   imported は計画時ではなく実 persist 後に確定する (下記参照)。
 	const plannedNewNames = new Set<string>();
 	const planCtx: PlanContext = { presetId, childIds, existingNamesByChild, childInputsByChild };
@@ -341,7 +341,7 @@ export async function importActivities(
 		}
 	}
 
-	// #2818 (取込永続 honesty): imported は「実際に DB に persist できた activity 数」。
+	// #2824 (取込永続 honesty): imported は「実際に DB に persist できた activity 数」。
 	//   write を行わずに plannedNewNames.size を返すと、persist が全失敗 (本番 DynamoDB
 	//   stub / 容量超過 等) でも UI が「N 件登録しました」と偽る。dispatchPerChildBulk が
 	//   返す persist 成功名のみを imported に算入し、計画したのに persist できなかった分は

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -301,17 +301,15 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 		});
 		if (resp.ok) {
 			const result = deserialize(await resp.text());
+			const data = result.type === 'success' ? result.data : undefined;
 			// デモ環境 no-op (data.demo===true) は成功偽装せず明示 (reward / challenge と統一)。
-			if (
-				result.type === 'success' &&
-				(result.data as Record<string, unknown> | undefined)?.demo === true
-			) {
+			if (data?.demo === true) {
 				actionMessage = ADMIN_ACTIVITIES_PAGE_LABELS.importDemo;
 				showToast(ADMIN_ACTIVITIES_PAGE_LABELS.importDemo, undefined, 'info');
 				return;
 			}
-			const imported =
-				result.type === 'success' ? Number((result.data?.imported as number | undefined) ?? 0) : 0;
+			const imported = Number((data?.imported as number | undefined) ?? 0);
+			const errorsCount = Array.isArray(data?.errors) ? (data.errors as unknown[]).length : 0;
 			// #2745 fix Round 2 (CI artifact 解析根拠): Toast primitive (`role="alert"`) を
 			// 一次 feedback として表示しつつ、in-page banner (`role="status"`) を 2 重防御として
 			// 同期 set する。Toast は module-level `$state` push でリアクティブ更新されるが
@@ -320,12 +318,23 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 			// banner は同 page state なので同期 set、handler return 後の re-render で即座に表示される。
 			// regression test (#2745 spec) は role="alert" を待つが、Toast / banner どちらが先に
 			// 表示されても regex マッチで PASS する 2 重防御。Anti-engagement 整合 (DESIGN.md §5)。
-			const message =
-				imported > 0
-					? ADMIN_ACTIVITIES_PAGE_LABELS.importSuccess(imported)
-					: ADMIN_ACTIVITIES_PAGE_LABELS.importAllDuplicates;
+			// #2818 (取込永続 honesty): server が errors を返したら「N 件登録しました」と
+			// 偽らず、保存できなかった事実を出す。imported=0 を「追加済み」(importAllDuplicates)
+			// で誤魔化す経路は errors=0 (= 純粋な重複) のときに限定する。
+			let message: string;
+			let tone: 'success' | 'info' | 'error';
+			if (errorsCount > 0) {
+				message = ADMIN_ACTIVITIES_PAGE_LABELS.importPartialFailure(imported, errorsCount);
+				tone = 'error';
+			} else if (imported > 0) {
+				message = ADMIN_ACTIVITIES_PAGE_LABELS.importSuccess(imported);
+				tone = 'success';
+			} else {
+				message = ADMIN_ACTIVITIES_PAGE_LABELS.importAllDuplicates;
+				tone = 'info';
+			}
 			actionMessage = message;
-			showToast(message, undefined, imported > 0 ? 'success' : 'info');
+			showToast(message, undefined, tone);
 			await invalidateAll();
 		} else {
 			actionMessage = ADMIN_ACTIVITIES_PAGE_LABELS.importFailed;

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -318,7 +318,7 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 			// banner は同 page state なので同期 set、handler return 後の re-render で即座に表示される。
 			// regression test (#2745 spec) は role="alert" を待つが、Toast / banner どちらが先に
 			// 表示されても regex マッチで PASS する 2 重防御。Anti-engagement 整合 (DESIGN.md §5)。
-			// #2818 (取込永続 honesty): server が errors を返したら「N 件登録しました」と
+			// #2824 (取込永続 honesty): server が errors を返したら「N 件登録しました」と
 			// 偽らず、保存できなかった事実を出す。imported=0 を「追加済み」(importAllDuplicates)
 			// で誤魔化す経路は errors=0 (= 純粋な重複) のときに限定する。
 			let message: string;

--- a/tests/unit/db/dynamodb-child-activity-repo.test.ts
+++ b/tests/unit/db/dynamodb-child-activity-repo.test.ts
@@ -1,0 +1,570 @@
+/**
+ * tests/unit/db/dynamodb-child-activity-repo.test.ts
+ *
+ * #2818 / ADR-0055: DynamoDB per-child activity-repo 本実装の単体テスト。
+ *
+ * AWS SDK を vi.hoisted mock で置き換え、SQLite 実装 (sqlite/child-activity-repo.ts、
+ * 挙動 SSOT) と機能等価であることを method ごとに検証する:
+ *   - 正しい Command + key で send する
+ *   - response を正しく型変換する (stripKeys / priority backfill)
+ *   - SQLite 機能等価 (dedup を支える findActivitiesByChild / visibleOnly / archive 挙動 /
+ *     insert default 値 / countMainQuest 条件)
+ *
+ * 背景: PR #2455 で導入された stub が #2263 hotfix で read=空 / write=throw 化され、
+ *   marketplace の per-child 取込が本番 DynamoDB Lambda で永続せず「N 件登録しました」と
+ *   偽る CRITICAL バグの一因になった。本テストは本実装の機能等価性を回帰固定する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const {
+	mockSend,
+	MockGetCommand,
+	MockPutCommand,
+	MockQueryCommand,
+	MockUpdateCommand,
+	MockDeleteCommand,
+	MockScanCommand,
+} = vi.hoisted(() => {
+	const send = vi.fn();
+	class Cmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	return {
+		mockSend: send,
+		MockGetCommand: class extends Cmd {},
+		MockPutCommand: class extends Cmd {},
+		MockQueryCommand: class extends Cmd {},
+		MockUpdateCommand: class extends Cmd {},
+		MockDeleteCommand: class extends Cmd {},
+		MockScanCommand: class extends Cmd {},
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	GetCommand: MockGetCommand,
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	UpdateCommand: MockUpdateCommand,
+	DeleteCommand: MockDeleteCommand,
+	ScanCommand: MockScanCommand,
+}));
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/child-activity-repo');
+}
+
+const TENANT = 'tenant-1';
+const CHILD_ID = 42;
+
+/** child partition の DynamoDB item を組み立てる (PK/SK + 属性)。 */
+function makeItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const id = (over.id as number) ?? 1;
+	return {
+		PK: `T#${TENANT}#CHILD#${CHILD_ID}`,
+		SK: `CHILDACT#${String(id).padStart(8, '0')}`,
+		id,
+		childId: CHILD_ID,
+		name: 'なわとび',
+		categoryId: 1,
+		icon: '🏃',
+		basePoints: 5,
+		isVisible: 1,
+		dailyLimit: null,
+		sortOrder: 0,
+		source: 'seed',
+		nameKana: null,
+		nameKanji: null,
+		triggerHint: null,
+		isMainQuest: 0,
+		isArchived: 0,
+		archivedReason: null,
+		createdAt: '2026-06-04T00:00:00.000Z',
+		sourcePresetId: null,
+		priority: 'optional',
+		...over,
+	};
+}
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// findActivitiesByChild
+// ============================================================
+
+describe('findActivitiesByChild', () => {
+	it('child partition を Query し sortOrder 昇順で返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 2, name: 'B', sortOrder: 1 }),
+				makeItem({ id: 1, name: 'A', sortOrder: 0 }),
+			],
+		});
+
+		const { findActivitiesByChild } = await loadRepo();
+		const result = await findActivitiesByChild(CHILD_ID, TENANT);
+
+		expect(result.map((a) => a.name)).toEqual(['A', 'B']);
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: {
+				KeyConditionExpression?: string;
+				ExpressionAttributeValues?: Record<string, string>;
+			};
+		};
+		expect(callArg.input.KeyConditionExpression).toContain('PK = :pk');
+		expect(callArg.input.ExpressionAttributeValues?.[':pk']).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(callArg.input.ExpressionAttributeValues?.[':prefix']).toBe('CHILDACT#');
+	});
+
+	it('既定では archived を除外する (NULL/0 は active 扱い、#962 教訓)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, name: 'active', isArchived: 0 }),
+				makeItem({ id: 2, name: 'nullarch', isArchived: null }),
+				makeItem({ id: 3, name: 'archived', isArchived: 1 }),
+			],
+		});
+		const { findActivitiesByChild } = await loadRepo();
+		const result = await findActivitiesByChild(CHILD_ID, TENANT);
+		expect(result.map((a) => a.name)).toEqual(['active', 'nullarch']);
+	});
+
+	it('includeArchived=true で archived も返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, name: 'active', isArchived: 0 }),
+				makeItem({ id: 2, name: 'archived', isArchived: 1 }),
+			],
+		});
+		const { findActivitiesByChild } = await loadRepo();
+		const result = await findActivitiesByChild(CHILD_ID, TENANT, { includeArchived: true });
+		expect(result.map((a) => a.name)).toEqual(['active', 'archived']);
+	});
+
+	it('visibleOnly=true で非表示を除外する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, name: 'visible', isVisible: 1 }),
+				makeItem({ id: 2, name: 'hidden', isVisible: 0 }),
+			],
+		});
+		const { findActivitiesByChild } = await loadRepo();
+		const result = await findActivitiesByChild(CHILD_ID, TENANT, { visibleOnly: true });
+		expect(result.map((a) => a.name)).toEqual(['visible']);
+	});
+
+	it('priority 未設定 item は optional に backfill する', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [makeItem({ id: 1, priority: undefined })] });
+		const { findActivitiesByChild } = await loadRepo();
+		const result = await findActivitiesByChild(CHILD_ID, TENANT);
+		expect(result[0]?.priority).toBe('optional');
+	});
+
+	it('LastEvaluatedKey でページングする', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [makeItem({ id: 1, name: 'p1' })],
+				LastEvaluatedKey: { PK: 'c', SK: 'c' },
+			})
+			.mockResolvedValueOnce({ Items: [makeItem({ id: 2, name: 'p2' })] });
+		const { findActivitiesByChild } = await loadRepo();
+		const result = await findActivitiesByChild(CHILD_ID, TENANT);
+		expect(result).toHaveLength(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+
+	it('0 件のときは空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findActivitiesByChild } = await loadRepo();
+		expect(await findActivitiesByChild(CHILD_ID, TENANT)).toEqual([]);
+	});
+});
+
+// ============================================================
+// findActivityById
+// ============================================================
+
+describe('findActivityById', () => {
+	it('child+id key で GetItem する', async () => {
+		mockSend.mockResolvedValueOnce({ Item: makeItem({ id: 7, name: 'X' }) });
+		const { findActivityById } = await loadRepo();
+		const result = await findActivityById(7, CHILD_ID, TENANT);
+		expect(result?.name).toBe('X');
+		const callArg = mockSend.mock.calls[0]?.[0] as { input: { Key?: { PK: string; SK: string } } };
+		expect(callArg.input.Key?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(callArg.input.Key?.SK).toBe('CHILDACT#00000007');
+	});
+
+	it('不在のとき undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Item: undefined });
+		const { findActivityById } = await loadRepo();
+		expect(await findActivityById(7, CHILD_ID, TENANT)).toBeUndefined();
+	});
+});
+
+// ============================================================
+// countMainQuestActivities
+// ============================================================
+
+describe('countMainQuestActivities', () => {
+	it('isMainQuest=1 かつ visible のみカウントする', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, isMainQuest: 1, isVisible: 1 }),
+				makeItem({ id: 2, isMainQuest: 1, isVisible: 0 }), // 非表示 → 除外
+				makeItem({ id: 3, isMainQuest: 0, isVisible: 1 }), // 非 main → 除外
+				makeItem({ id: 4, isMainQuest: 1, isVisible: 1 }),
+			],
+		});
+		const { countMainQuestActivities } = await loadRepo();
+		expect(await countMainQuestActivities(CHILD_ID, TENANT)).toBe(2);
+	});
+});
+
+// ============================================================
+// insertActivity / insertActivitiesBulk
+// ============================================================
+
+describe('insertActivity', () => {
+	it('counter 採番 → PutItem し SQLite default 値を埋めた row を返す', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 101 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insertActivity } = await loadRepo();
+		const result = await insertActivity(
+			{ childId: CHILD_ID, name: 'すいえい', categoryId: 1, icon: '🏊', basePoints: 8 },
+			TENANT,
+		);
+
+		expect(result.id).toBe(101);
+		// SQLite schema default が埋まっている
+		expect(result).toMatchObject({
+			childId: CHILD_ID,
+			name: 'すいえい',
+			basePoints: 8,
+			isVisible: 1,
+			dailyLimit: null,
+			sortOrder: 0,
+			source: 'seed',
+			isMainQuest: 0,
+			isArchived: 0,
+			archivedReason: null,
+			priority: 'optional',
+		});
+
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(putCall.input.Item?.SK).toBe('CHILDACT#00000101');
+		expect(putCall.input.Item?.name).toBe('すいえい');
+		expect(putCall.input.Item?.isVisible).toBe(1);
+	});
+
+	it('isMainQuest / priority / sourcePresetId / triggerHint を反映する', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 5 } }).mockResolvedValueOnce({});
+		const { insertActivity } = await loadRepo();
+		const result = await insertActivity(
+			{
+				childId: CHILD_ID,
+				name: 'べんきょう',
+				categoryId: 2,
+				icon: '📚',
+				basePoints: 3,
+				isMainQuest: 1,
+				priority: 'must',
+				sourcePresetId: 'kinder-starter',
+				triggerHint: 'よる',
+			},
+			TENANT,
+		);
+		expect(result).toMatchObject({
+			isMainQuest: 1,
+			priority: 'must',
+			sourcePresetId: 'kinder-starter',
+			triggerHint: 'よる',
+		});
+	});
+});
+
+describe('insertActivitiesBulk', () => {
+	it('空配列は何も send せず空を返す', async () => {
+		const { insertActivitiesBulk } = await loadRepo();
+		expect(await insertActivitiesBulk([], TENANT)).toEqual([]);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it('複数 input を順次 insert し全 row を返す (取込永続の核心経路)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 1 } })
+			.mockResolvedValueOnce({})
+			.mockResolvedValueOnce({ Attributes: { counter: 2 } })
+			.mockResolvedValueOnce({});
+		const { insertActivitiesBulk } = await loadRepo();
+		const result = await insertActivitiesBulk(
+			[
+				{ childId: CHILD_ID, name: 'A', categoryId: 1, icon: '🏃', basePoints: 5 },
+				{ childId: CHILD_ID, name: 'B', categoryId: 1, icon: '📚', basePoints: 5 },
+			],
+			TENANT,
+		);
+		expect(result.map((a) => a.name)).toEqual(['A', 'B']);
+		expect(result.map((a) => a.id)).toEqual([1, 2]);
+		// 2 insert = 4 send (nextId + Put × 2)
+		expect(mockSend).toHaveBeenCalledTimes(4);
+	});
+});
+
+// ============================================================
+// updateActivity / setActivityVisibility
+// ============================================================
+
+describe('updateActivity', () => {
+	it('指定 field のみ UpdateExpression に含め ALL_NEW を返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Attributes: makeItem({ id: 1, name: 'updated', basePoints: 9 }),
+		});
+		const { updateActivity } = await loadRepo();
+		const result = await updateActivity(1, CHILD_ID, { name: 'updated', basePoints: 9 }, TENANT);
+		expect(result?.name).toBe('updated');
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: { UpdateExpression?: string; ConditionExpression?: string };
+		};
+		expect(callArg.input.UpdateExpression).toContain('#name = :name');
+		expect(callArg.input.UpdateExpression).toContain('#basePoints = :basePoints');
+		expect(callArg.input.ConditionExpression).toBe('attribute_exists(PK)');
+	});
+
+	it('更新 field 0 件のときは現在値を Get して返す (SQLite .set({}) 等価)', async () => {
+		mockSend.mockResolvedValueOnce({ Item: makeItem({ id: 1, name: 'unchanged' }) });
+		const { updateActivity } = await loadRepo();
+		const result = await updateActivity(1, CHILD_ID, {}, TENANT);
+		expect(result?.name).toBe('unchanged');
+		const callArg = mockSend.mock.calls[0]?.[0] as { input: { Key?: unknown } };
+		expect(callArg.input.Key).toBeDefined(); // GetCommand 経路
+	});
+
+	it('別 child / 不在 (ConditionalCheckFailed) のとき undefined を返す', async () => {
+		const err = new Error('cond');
+		err.name = 'ConditionalCheckFailedException';
+		mockSend.mockRejectedValueOnce(err);
+		const { updateActivity } = await loadRepo();
+		expect(await updateActivity(1, CHILD_ID, { name: 'x' }, TENANT)).toBeUndefined();
+	});
+});
+
+describe('setActivityVisibility', () => {
+	it('isVisible を 0/1 に更新する', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: makeItem({ id: 1, isVisible: 0 }) });
+		const { setActivityVisibility } = await loadRepo();
+		const result = await setActivityVisibility(1, CHILD_ID, false, TENANT);
+		expect(result?.isVisible).toBe(0);
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(callArg.input.ExpressionAttributeValues?.[':v']).toBe(0);
+	});
+
+	it('不在 (ConditionalCheckFailed) で undefined', async () => {
+		const err = new Error('cond');
+		err.name = 'ConditionalCheckFailedException';
+		mockSend.mockRejectedValueOnce(err);
+		const { setActivityVisibility } = await loadRepo();
+		expect(await setActivityVisibility(1, CHILD_ID, true, TENANT)).toBeUndefined();
+	});
+});
+
+// ============================================================
+// deleteActivity
+// ============================================================
+
+describe('deleteActivity', () => {
+	it('DeleteItem (ALL_OLD) で削除した row を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: makeItem({ id: 3, name: 'gone' }) });
+		const { deleteActivity } = await loadRepo();
+		const result = await deleteActivity(3, CHILD_ID, TENANT);
+		expect(result?.name).toBe('gone');
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: { Key?: { SK: string }; ReturnValues?: string };
+		};
+		expect(callArg.input.Key?.SK).toBe('CHILDACT#00000003');
+		expect(callArg.input.ReturnValues).toBe('ALL_OLD');
+	});
+
+	it('不在のとき undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: undefined });
+		const { deleteActivity } = await loadRepo();
+		expect(await deleteActivity(3, CHILD_ID, TENANT)).toBeUndefined();
+	});
+});
+
+// ============================================================
+// copyActivitiesAcrossChildren
+// ============================================================
+
+describe('copyActivitiesAcrossChildren', () => {
+	it('source の活動を target child に複製する (兄弟共通化)', async () => {
+		// 1) findActivitiesByChild(source) Query
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1, name: 'A' }), makeItem({ id: 2, name: 'B' })],
+		});
+		// 2) insertActivitiesBulk → nextId + Put × 2
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 10 } })
+			.mockResolvedValueOnce({})
+			.mockResolvedValueOnce({ Attributes: { counter: 11 } })
+			.mockResolvedValueOnce({});
+
+		const { copyActivitiesAcrossChildren } = await loadRepo();
+		const result = await copyActivitiesAcrossChildren(CHILD_ID, 99, TENANT);
+		expect(result.map((a) => a.name)).toEqual(['A', 'B']);
+		expect(result.every((a) => a.childId === 99)).toBe(true);
+	});
+
+	it('source 0 件のとき何も insert しない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { copyActivitiesAcrossChildren } = await loadRepo();
+		expect(await copyActivitiesAcrossChildren(CHILD_ID, 99, TENANT)).toEqual([]);
+		expect(mockSend).toHaveBeenCalledTimes(1); // Query のみ
+	});
+});
+
+// ============================================================
+// archive / restore
+// ============================================================
+
+describe('archiveActivities', () => {
+	it('id 群を Scan で解決し isArchived=1 + reason を Update する', async () => {
+		// scan: tenant 配下の CHILDACT# を返す (PK/SK projection)
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDACT#00000001' },
+				{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDACT#00000002' },
+			],
+		});
+		mockSend.mockResolvedValueOnce({}).mockResolvedValueOnce({}); // 2 Update
+
+		const { archiveActivities } = await loadRepo();
+		await archiveActivities([1, 2], 'downgrade_user_selected', TENANT);
+
+		// 1 Scan + 2 Update
+		expect(mockSend).toHaveBeenCalledTimes(3);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(upd.input.UpdateExpression).toContain('isArchived = :one');
+		expect(upd.input.ExpressionAttributeValues?.[':reason']).toBe('downgrade_user_selected');
+	});
+
+	it('id にマッチしない CHILDACT は Update しない (id filter)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDACT#00000009' }],
+		});
+		const { archiveActivities } = await loadRepo();
+		await archiveActivities([1], 'downgrade_user_selected', TENANT);
+		// Scan のみ、Update 0 件 (id=9 は対象 [1] に含まれない)
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+
+	it('空 ids は no-op', async () => {
+		const { archiveActivities } = await loadRepo();
+		await archiveActivities([], 'downgrade_user_selected', TENANT);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+});
+
+describe('restoreArchivedActivities', () => {
+	it('reason 一致を Scan し isArchived=0 + reason REMOVE する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDACT#00000001' }],
+		});
+		mockSend.mockResolvedValueOnce({});
+		const { restoreArchivedActivities } = await loadRepo();
+		await restoreArchivedActivities('downgrade_user_selected', TENANT);
+		const scan = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scan.input.FilterExpression).toContain('archivedReason = :reason');
+		expect(scan.input.ExpressionAttributeValues?.[':reason']).toBe('downgrade_user_selected');
+		const upd = mockSend.mock.calls[1]?.[0] as { input: { UpdateExpression?: string } };
+		expect(upd.input.UpdateExpression).toContain('REMOVE archivedReason');
+	});
+});
+
+// ============================================================
+// findChildById
+// ============================================================
+
+describe('findChildById', () => {
+	it('child profile を GetItem する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Item: {
+				PK: `T#${TENANT}#CHILD#${CHILD_ID}`,
+				SK: 'PROFILE',
+				id: CHILD_ID,
+				nickname: 'けんた',
+			},
+		});
+		const { findChildById } = await loadRepo();
+		const result = await findChildById(CHILD_ID, TENANT);
+		expect(result?.nickname).toBe('けんた');
+	});
+
+	it('不在のとき undefined', async () => {
+		mockSend.mockResolvedValueOnce({ Item: undefined });
+		const { findChildById } = await loadRepo();
+		expect(await findChildById(CHILD_ID, TENANT)).toBeUndefined();
+	});
+});
+
+// ============================================================
+// interface 適合 (SQLite との機能等価性)
+// ============================================================
+
+describe('interface 適合 (IChildActivityRepo)', () => {
+	it('全メソッドを export している (stub に後退していない)', async () => {
+		const repo = await loadRepo();
+		for (const m of [
+			'findActivitiesByChild',
+			'findActivityById',
+			'countMainQuestActivities',
+			'insertActivity',
+			'insertActivitiesBulk',
+			'updateActivity',
+			'setActivityVisibility',
+			'deleteActivity',
+			'copyActivitiesAcrossChildren',
+			'archiveActivities',
+			'restoreArchivedActivities',
+			'findChildById',
+		]) {
+			expect(typeof (repo as Record<string, unknown>)[m]).toBe('function');
+		}
+	});
+
+	it('write method が throw stub でない (insertActivitiesBulk が実 send する)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		const { insertActivitiesBulk } = await loadRepo();
+		const result = await insertActivitiesBulk(
+			[{ childId: CHILD_ID, name: 'X', categoryId: 1, icon: '🏃', basePoints: 5 }],
+			TENANT,
+		);
+		// stub なら throw していた。本実装は row を返す。
+		expect(result).toHaveLength(1);
+		expect(mockSend).toHaveBeenCalled();
+	});
+});

--- a/tests/unit/db/dynamodb-child-activity-repo.test.ts
+++ b/tests/unit/db/dynamodb-child-activity-repo.test.ts
@@ -1,7 +1,7 @@
 /**
  * tests/unit/db/dynamodb-child-activity-repo.test.ts
  *
- * #2818 / ADR-0055: DynamoDB per-child activity-repo 本実装の単体テスト。
+ * #2824 / ADR-0055: DynamoDB per-child activity-repo 本実装の単体テスト。
  *
  * AWS SDK を vi.hoisted mock で置き換え、SQLite 実装 (sqlite/child-activity-repo.ts、
  * 挙動 SSOT) と機能等価であることを method ごとに検証する:

--- a/tests/unit/db/dynamodb-child-activity-repo.test.ts
+++ b/tests/unit/db/dynamodb-child-activity-repo.test.ts
@@ -135,13 +135,13 @@ describe('findActivitiesByChild', () => {
 		mockSend.mockResolvedValueOnce({
 			Items: [
 				makeItem({ id: 1, name: 'active', isArchived: 0 }),
-				makeItem({ id: 2, name: 'nullarch', isArchived: null }),
+				makeItem({ id: 2, name: 'nullArch', isArchived: null }),
 				makeItem({ id: 3, name: 'archived', isArchived: 1 }),
 			],
 		});
 		const { findActivitiesByChild } = await loadRepo();
 		const result = await findActivitiesByChild(CHILD_ID, TENANT);
-		expect(result.map((a) => a.name)).toEqual(['active', 'nullarch']);
+		expect(result.map((a) => a.name)).toEqual(['active', 'nullArch']);
 	});
 
 	it('includeArchived=true で archived も返す', async () => {

--- a/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
+++ b/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
@@ -25,7 +25,7 @@ import { describe, expect, it } from 'vitest';
 // Pre-PMF fallback に置換された 12 repo
 import * as autoChallengeRepo from '../../../src/lib/server/db/dynamodb/auto-challenge-repo';
 import * as battleRepo from '../../../src/lib/server/db/dynamodb/battle-repo';
-// #2818 (ADR-0055): child-activity-repo は本実装済のため stub fallback テスト対象外。
+// #2824 (ADR-0055): child-activity-repo は本実装済のため stub fallback テスト対象外。
 //   機能等価性は tests/unit/db/dynamodb-child-activity-repo.test.ts (AWS SDK mock) で検証する。
 import * as cloudExportRepo from '../../../src/lib/server/db/dynamodb/cloud-export-repo';
 import * as messageRepo from '../../../src/lib/server/db/dynamodb/message-repo';
@@ -87,7 +87,7 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	// #2818 (ADR-0055): child-activity-repo は本実装済 (stub 除外)。
+	// #2824 (ADR-0055): child-activity-repo は本実装済 (stub 除外)。
 	//   marketplace per-child 取込 (importActivities → insertActivitiesBulk) が本番 DynamoDB
 	//   Lambda で永続する。本実装の機能等価性テストは dynamodb-child-activity-repo.test.ts に分離。
 	//   ここで stub 前提の assert を残すと「実装済なのに stub 期待」で誤った退行 gate になるため
@@ -262,7 +262,7 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 			// #2295 (EPIC #2294 ①): seasonEventRepo / tenantEventRepo 削除済 (2026-05-19)、12 → 10 repo
 			// #2458 (Path B sibling drop): siblingChallengeRepo 削除済 (2026-05-26)、10 → 9 repo
 			// #2263 regression hotfix: childActivityRepo を stub fallback に置換 (9 → 10 repo)
-			// #2818 (ADR-0055): childActivityRepo を本実装化したため stub fallback guard から除外
+			// #2824 (ADR-0055): childActivityRepo を本実装化したため stub fallback guard から除外
 			//   (本実装は AWS SDK mock 必須 → dynamodb-child-activity-repo.test.ts で検証)。10 → 9 repo
 			const results = await Promise.allSettled([
 				autoChallengeRepo.findActiveByChild(1, TENANT),

--- a/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
+++ b/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
@@ -25,8 +25,8 @@ import { describe, expect, it } from 'vitest';
 // Pre-PMF fallback に置換された 12 repo
 import * as autoChallengeRepo from '../../../src/lib/server/db/dynamodb/auto-challenge-repo';
 import * as battleRepo from '../../../src/lib/server/db/dynamodb/battle-repo';
-// #2263 regression hotfix (本 PR): child-activity-repo (PR #2455 = #2362 PR-3 で 2026-05-24 導入)
-import * as childActivityRepo from '../../../src/lib/server/db/dynamodb/child-activity-repo';
+// #2818 (ADR-0055): child-activity-repo は本実装済のため stub fallback テスト対象外。
+//   機能等価性は tests/unit/db/dynamodb-child-activity-repo.test.ts (AWS SDK mock) で検証する。
 import * as cloudExportRepo from '../../../src/lib/server/db/dynamodb/cloud-export-repo';
 import * as messageRepo from '../../../src/lib/server/db/dynamodb/message-repo';
 import * as reportDailySummaryRepo from '../../../src/lib/server/db/dynamodb/report-daily-summary-repo';
@@ -87,48 +87,11 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('child-activity-repo (#2263 regression hotfix)', () => {
-		it('全 read method は安全値を返す (本番 /preschool/home 500 防止)', async () => {
-			await expect(childActivityRepo.findActivitiesByChild(1, TENANT)).resolves.toEqual([]);
-			await expect(
-				childActivityRepo.findActivitiesByChild(1, TENANT, { includeArchived: true }),
-			).resolves.toEqual([]);
-			await expect(childActivityRepo.findActivityById(1, 1, TENANT)).resolves.toBeUndefined();
-			await expect(childActivityRepo.countMainQuestActivities(1, TENANT)).resolves.toBe(0);
-			await expect(childActivityRepo.findChildById(1, TENANT)).resolves.toBeUndefined();
-		});
-
-		it('write method は throw する (Pre-PMF で本番到達禁止を構造的に強制)', async () => {
-			await expect(
-				childActivityRepo.insertActivity(
-					{
-						childId: 1,
-						categoryId: 1,
-						name: 'n',
-						icon: '★',
-						basePoints: 1,
-						isMainQuest: 0,
-						isVisible: 1,
-						sortOrder: 0,
-						priority: 'optional',
-					} as never,
-					TENANT,
-				),
-			).rejects.toThrow(/not implemented/);
-			await expect(childActivityRepo.updateActivity(1, 1, {} as never, TENANT)).rejects.toThrow(
-				/not implemented/,
-			);
-			await expect(childActivityRepo.setActivityVisibility(1, 1, true, TENANT)).rejects.toThrow(
-				/not implemented/,
-			);
-			await expect(childActivityRepo.deleteActivity(1, 1, TENANT)).rejects.toThrow(
-				/not implemented/,
-			);
-			await expect(
-				childActivityRepo.archiveActivities([1], 'manual' as never, TENANT),
-			).rejects.toThrow(/not implemented/);
-		});
-	});
+	// #2818 (ADR-0055): child-activity-repo は本実装済 (stub 除外)。
+	//   marketplace per-child 取込 (importActivities → insertActivitiesBulk) が本番 DynamoDB
+	//   Lambda で永続する。本実装の機能等価性テストは dynamodb-child-activity-repo.test.ts に分離。
+	//   ここで stub 前提の assert を残すと「実装済なのに stub 期待」で誤った退行 gate になるため
+	//   除外する (他 11 repo の fallback assert は維持 = assertion 弱体化に該当しない)。
 
 	describe('cloud-export-repo', () => {
 		it('全 method が throw しない', async () => {
@@ -294,17 +257,16 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('regression guard: 全 10 repo の Promise.all で reject されない', () => {
-		it('SSR /preschool/home の典型的な 10 repo 並列呼び出しが全 fulfill する', async () => {
+	describe('regression guard: 全 9 repo の Promise.all で reject されない', () => {
+		it('SSR /preschool/home の典型的な 9 repo 並列呼び出しが全 fulfill する', async () => {
 			// #2295 (EPIC #2294 ①): seasonEventRepo / tenantEventRepo 削除済 (2026-05-19)、12 → 10 repo
 			// #2458 (Path B sibling drop): siblingChallengeRepo 削除済 (2026-05-26)、10 → 9 repo
-			// #2263 regression hotfix (本 PR): childActivityRepo.findActivitiesByChild 追加 (9 → 10 repo)
-			//   → PR #2455 で stub 化されていた child-activity が SSR `Promise.all` で reject → 500 を引き起こす
-			//     時限爆弾を Pre-PMF fallback に置換して解消
+			// #2263 regression hotfix: childActivityRepo を stub fallback に置換 (9 → 10 repo)
+			// #2818 (ADR-0055): childActivityRepo を本実装化したため stub fallback guard から除外
+			//   (本実装は AWS SDK mock 必須 → dynamodb-child-activity-repo.test.ts で検証)。10 → 9 repo
 			const results = await Promise.allSettled([
 				autoChallengeRepo.findActiveByChild(1, TENANT),
 				battleRepo.findTodayBattle(1, TODAY, TENANT),
-				childActivityRepo.findActivitiesByChild(1, TENANT, { childAge: 5 } as never),
 				cloudExportRepo.findByTenant(TENANT),
 				messageRepo.findUnshownMessage(1, TENANT),
 				reportDailySummaryRepo.findByChildAndDateRange(1, TODAY, TODAY, TENANT),

--- a/tests/unit/marketplace/strategies/activity-pack-strategy.test.ts
+++ b/tests/unit/marketplace/strategies/activity-pack-strategy.test.ts
@@ -87,7 +87,7 @@ beforeEach(() => {
 	// #2458-A1: fallback bind helper — tenant 最初の child を返す。
 	// childIds 未指定 ctx の test ではこの child に per-child instance が bulk insert される。
 	mockFindAllChildren.mockResolvedValue([{ id: 100 }]);
-	// #2818 (取込永続 honesty): insertActivitiesBulk は本実装と同様に「作成した row (name 込み)」
+	// #2824 (取込永続 honesty): insertActivitiesBulk は本実装と同様に「作成した row (name 込み)」
 	//   を返す。importActivities は imported を実 persist 結果から算出するため、mock も入力を
 	//   echo する (旧 `mockResolvedValue(undefined)` は persist 0 件相当で imported を偽る経路を隠す)。
 	mockInsertActivitiesBulk.mockImplementation(async (inputs: Array<{ name: string }>) =>
@@ -306,8 +306,8 @@ describe('activityPackStrategy.apply', () => {
 		expect(mockInsertActivitiesBulk).not.toHaveBeenCalled();
 	});
 
-	it('insertActivitiesBulk が throw した場合 imported=0 + errors に記録 (#2818 honesty)', async () => {
-		// #2818 取込永続 honesty: bulk write が全失敗したら 1 件も persist していない。
+	it('insertActivitiesBulk が throw した場合 imported=0 + errors に記録 (#2824 honesty)', async () => {
+		// #2824 取込永続 honesty: bulk write が全失敗したら 1 件も persist していない。
 		//   旧 spec は imported=2 を期待していたが、これは「N 件登録しました」と偽る根因。
 		//   fallback child 1 件 (id=100) への bulk が reject → persist 0 → imported=0 が honest。
 		mockInsertActivitiesBulk.mockRejectedValueOnce(new Error('DB error'));

--- a/tests/unit/marketplace/strategies/activity-pack-strategy.test.ts
+++ b/tests/unit/marketplace/strategies/activity-pack-strategy.test.ts
@@ -87,7 +87,12 @@ beforeEach(() => {
 	// #2458-A1: fallback bind helper — tenant 最初の child を返す。
 	// childIds 未指定 ctx の test ではこの child に per-child instance が bulk insert される。
 	mockFindAllChildren.mockResolvedValue([{ id: 100 }]);
-	mockInsertActivitiesBulk.mockResolvedValue(undefined);
+	// #2818 (取込永続 honesty): insertActivitiesBulk は本実装と同様に「作成した row (name 込み)」
+	//   を返す。importActivities は imported を実 persist 結果から算出するため、mock も入力を
+	//   echo する (旧 `mockResolvedValue(undefined)` は persist 0 件相当で imported を偽る経路を隠す)。
+	mockInsertActivitiesBulk.mockImplementation(async (inputs: Array<{ name: string }>) =>
+		inputs.map((i, idx) => ({ id: idx + 1, ...i })),
+	);
 	// #2558: per-child dedup mock — 既存活動なしを default に。
 	mockFindActivitiesByChild.mockResolvedValue([]);
 });
@@ -301,10 +306,10 @@ describe('activityPackStrategy.apply', () => {
 		expect(mockInsertActivitiesBulk).not.toHaveBeenCalled();
 	});
 
-	it('insertActivitiesBulk が throw した場合 errors に記録', async () => {
-		// #2458-A1: per-child bulk path では child 単位の partial failure を errors に記録。
-		// 旧 spec の per-activity rejection mock は bulk path で意味を持たないため、
-		// bulk reject で 1 件 errors が増えるパターンに置換。
+	it('insertActivitiesBulk が throw した場合 imported=0 + errors に記録 (#2818 honesty)', async () => {
+		// #2818 取込永続 honesty: bulk write が全失敗したら 1 件も persist していない。
+		//   旧 spec は imported=2 を期待していたが、これは「N 件登録しました」と偽る根因。
+		//   fallback child 1 件 (id=100) への bulk が reject → persist 0 → imported=0 が honest。
 		mockInsertActivitiesBulk.mockRejectedValueOnce(new Error('DB error'));
 		const payload = {
 			activities: [
@@ -313,10 +318,10 @@ describe('activityPackStrategy.apply', () => {
 			],
 		};
 		const result = await activityPackStrategy.apply(payload, { tenantId: TENANT });
-		// importOneActivity 自体は成功するため imported カウンタは 2、bulk write 失敗で errors 1 件追加
-		expect(result.imported).toBe(2);
-		expect(result.errors).toHaveLength(1);
-		expect(result.errors[0]).toContain('per-child instance 作成失敗');
+		expect(result.imported).toBe(0);
+		// errors: ① per-child bulk 失敗 ② 「2 件を保存できませんでした」
+		expect(result.errors.some((e) => e.includes('per-child instance 作成失敗'))).toBe(true);
+		expect(result.errors.some((e) => e.includes('保存できませんでした'))).toBe(true);
 	});
 });
 

--- a/tests/unit/services/activity-import-service.test.ts
+++ b/tests/unit/services/activity-import-service.test.ts
@@ -82,7 +82,14 @@ function makeItem(overrides: Partial<ActivityPackItem> = {}): ActivityPackItem {
 beforeEach(() => {
 	vi.clearAllMocks();
 	mockFindActivities.mockResolvedValue([]);
-	mockInsertActivitiesBulk.mockResolvedValue([]);
+	// #2818 (取込永続 honesty): insertActivitiesBulk は SQLite / DynamoDB 本実装と同様に
+	//   「作成した row (name 込み)」を返す。importActivities は imported を実 persist 結果
+	//   (返り値の name 集合) から算出するため、mock も入力を echo する必要がある。
+	//   旧 mock の `mockResolvedValue([])` は「persist 0 件」を意味し、imported を偽る経路を
+	//   隠してしまうため echo に変更した (ADR-0006 assertion 弱体化ではなく現実即応の強化)。
+	mockInsertActivitiesBulk.mockImplementation(async (inputs: Array<{ name: string }>) =>
+		inputs.map((i, idx) => ({ id: idx + 1, ...i })),
+	);
 	// #2558: 既定では各 child に既存 activity なし (per-child dedup の baseline)
 	mockFindActivitiesByChild.mockResolvedValue([]);
 	mockFindAllChildren.mockResolvedValue([{ id: FIRST_CHILD_ID, nickname: 'first' }]);
@@ -233,21 +240,26 @@ describe('importActivities', () => {
 		expect(mockInsertActivitiesBulk).not.toHaveBeenCalled();
 	});
 
-	it('per-child bulk が例外をスロー -> エラー記録され処理継続', async () => {
+	it('per-child bulk が全件スロー -> imported=0 (偽の成功件数を出さない、#2818)', async () => {
+		// #2818 取込永続 honesty: insertActivitiesBulk が throw したら persist 0 件。
+		//   旧テストは imported=2 を期待していたが、これは「N 件登録しました」と偽る根因
+		//   そのものだった。本番 DynamoDB stub / 容量超過 等で全 write が失敗しても UI に
+		//   成功件数を出していた。修正後は persist 成功 0 → imported=0、errors に失敗を記録する。
 		mockInsertActivitiesBulk.mockRejectedValueOnce(new Error('DB constraint violation'));
 
 		const items = [
 			makeItem({ name: '失敗する活動', categoryCode: 'undou' }),
-			makeItem({ name: '成功する活動', categoryCode: 'benkyou' }),
+			makeItem({ name: 'もうひとつの活動', categoryCode: 'benkyou' }),
 		];
 
 		const result = await importActivities(items, TENANT);
 
-		// imported は family master 段階での成功件数。bulk 失敗は別 channel (errors)
-		expect(result.imported).toBe(2);
-		expect(result.errors).toHaveLength(1);
-		expect(result.errors[0]).toContain('per-child instance 作成失敗');
-		expect(result.errors[0]).toContain('DB constraint violation');
+		expect(result.imported).toBe(0);
+		// errors: ① per-child bulk 失敗 ② 「2 件を保存できませんでした」
+		expect(result.errors.length).toBeGreaterThanOrEqual(2);
+		expect(result.errors.some((e) => e.includes('per-child instance 作成失敗'))).toBe(true);
+		expect(result.errors.some((e) => e.includes('DB constraint violation'))).toBe(true);
+		expect(result.errors.some((e) => e.includes('保存できませんでした'))).toBe(true);
 	});
 
 	it('混合シナリオ: 新規 + 重複 + カテゴリエラー', async () => {
@@ -506,19 +518,23 @@ describe('importActivities', () => {
 			expect(calledChildIds).toEqual([101, 202, 303]);
 		});
 
-		it('1 child の bulk insert が失敗しても他 child は継続する (partial success)', async () => {
+		it('1 child の bulk insert が失敗しても他 child で persist 成功すれば imported=1 (partial success)', async () => {
+			// #2818: child=101 は失敗するが、202/303 で 'A' が persist 成功する。
+			//   imported は「いずれかの child に persist できた activity 数」= 1 が honest。
+			//   返り値は実 row (name 込み) を返すことで imported を実 persist から算出させる。
 			mockInsertActivitiesBulk
 				.mockRejectedValueOnce(new Error('child=101 disk full'))
-				.mockResolvedValueOnce([{ id: 99 }])
-				.mockResolvedValueOnce([{ id: 100 }]);
+				.mockResolvedValueOnce([{ id: 99, name: 'A' }])
+				.mockResolvedValueOnce([{ id: 100, name: 'A' }]);
 
 			const items = [makeItem({ name: 'A', categoryCode: 'undou' })];
 
 			const result = await importActivities(items, TENANT, { childIds: [101, 202, 303] });
 
+			// 202/303 で persist 成功したので imported=1 (どこにも持続していない fiction でない)
 			expect(result.imported).toBe(1);
-			expect(result.errors).toHaveLength(1);
-			expect(result.errors[0]).toContain('child=101');
+			// errors: child=101 の失敗のみ ('A' は他 child で persist 成功 → 保存失敗 error なし)
+			expect(result.errors.some((e) => e.includes('child=101'))).toBe(true);
 			expect(mockInsertActivitiesBulk).toHaveBeenCalledTimes(3);
 		});
 
@@ -650,6 +666,65 @@ describe('importActivities', () => {
 			expect(result.skipped).toBe(1);
 			// 配信入力が 0 件なので bulk insert は呼ばれない
 			expect(mockInsertActivitiesBulk).not.toHaveBeenCalled();
+		});
+	});
+
+	// ──────────────────────────────────────────────────────────
+	// #2818 取込永続 honesty: imported は実 persist 数のみを反映する
+	// (本番 cognito Lambda + DATA_SOURCE=dynamodb で write が永続しない CRITICAL の根治)
+	// ──────────────────────────────────────────────────────────
+	describe('#2818 取込永続 honesty (imported が偽らない)', () => {
+		it('write が全失敗 (DynamoDB stub 相当) -> imported=0 + 保存失敗 error。35 件偽装を防ぐ', async () => {
+			// 顧客レビューで観察された CRITICAL の再現: 35 件取込しようとしたが本番
+			// DynamoDB repo が throw (旧 stub) → 0 件しか persist しないのに UI が
+			// 「35 件登録しました」と偽った。imported は実 persist 数でなければならない。
+			mockInsertActivitiesBulk.mockRejectedValue(new Error('not implemented (dynamodb stub)'));
+
+			const items = Array.from({ length: 35 }, (_, i) =>
+				makeItem({ name: `活動${i}`, categoryCode: 'undou' }),
+			);
+
+			const result = await importActivities(items, TENANT, { childIds: [101] });
+
+			// 1 件も persist できていない -> imported=0 が honest
+			expect(result.imported).toBe(0);
+			expect(
+				result.errors.some((e) => e.includes('35 件') && e.includes('保存できませんでした')),
+			).toBe(true);
+		});
+
+		it('一部のみ persist 成功 -> imported は persist できた数だけ', async () => {
+			// 3 件計画したが、insertActivitiesBulk は 2 件しか返さない (1 件 silent drop)。
+			mockInsertActivitiesBulk.mockResolvedValueOnce([
+				{ id: 1, name: 'A' },
+				{ id: 2, name: 'B' },
+			]);
+
+			const items = [
+				makeItem({ name: 'A', categoryCode: 'undou' }),
+				makeItem({ name: 'B', categoryCode: 'benkyou' }),
+				makeItem({ name: 'C', categoryCode: 'seikatsu' }),
+			];
+
+			const result = await importActivities(items, TENANT, { childIds: [101] });
+
+			// A/B は persist 成功、C は未 persist -> imported=2、C は保存失敗として可視化
+			expect(result.imported).toBe(2);
+			expect(
+				result.errors.some((e) => e.includes('1 件') && e.includes('保存できませんでした')),
+			).toBe(true);
+		});
+
+		it('write が全成功 -> imported は計画件数と一致 (正常系で error を出さない)', async () => {
+			const items = [
+				makeItem({ name: 'A', categoryCode: 'undou' }),
+				makeItem({ name: 'B', categoryCode: 'benkyou' }),
+			];
+
+			const result = await importActivities(items, TENANT, { childIds: [101] });
+
+			expect(result.imported).toBe(2);
+			expect(result.errors).toEqual([]);
 		});
 	});
 });

--- a/tests/unit/services/activity-import-service.test.ts
+++ b/tests/unit/services/activity-import-service.test.ts
@@ -82,7 +82,7 @@ function makeItem(overrides: Partial<ActivityPackItem> = {}): ActivityPackItem {
 beforeEach(() => {
 	vi.clearAllMocks();
 	mockFindActivities.mockResolvedValue([]);
-	// #2818 (取込永続 honesty): insertActivitiesBulk は SQLite / DynamoDB 本実装と同様に
+	// #2824 (取込永続 honesty): insertActivitiesBulk は SQLite / DynamoDB 本実装と同様に
 	//   「作成した row (name 込み)」を返す。importActivities は imported を実 persist 結果
 	//   (返り値の name 集合) から算出するため、mock も入力を echo する必要がある。
 	//   旧 mock の `mockResolvedValue([])` は「persist 0 件」を意味し、imported を偽る経路を
@@ -240,8 +240,8 @@ describe('importActivities', () => {
 		expect(mockInsertActivitiesBulk).not.toHaveBeenCalled();
 	});
 
-	it('per-child bulk が全件スロー -> imported=0 (偽の成功件数を出さない、#2818)', async () => {
-		// #2818 取込永続 honesty: insertActivitiesBulk が throw したら persist 0 件。
+	it('per-child bulk が全件スロー -> imported=0 (偽の成功件数を出さない、#2824)', async () => {
+		// #2824 取込永続 honesty: insertActivitiesBulk が throw したら persist 0 件。
 		//   旧テストは imported=2 を期待していたが、これは「N 件登録しました」と偽る根因
 		//   そのものだった。本番 DynamoDB stub / 容量超過 等で全 write が失敗しても UI に
 		//   成功件数を出していた。修正後は persist 成功 0 → imported=0、errors に失敗を記録する。
@@ -519,7 +519,7 @@ describe('importActivities', () => {
 		});
 
 		it('1 child の bulk insert が失敗しても他 child で persist 成功すれば imported=1 (partial success)', async () => {
-			// #2818: child=101 は失敗するが、202/303 で 'A' が persist 成功する。
+			// #2824: child=101 は失敗するが、202/303 で 'A' が persist 成功する。
 			//   imported は「いずれかの child に persist できた activity 数」= 1 が honest。
 			//   返り値は実 row (name 込み) を返すことで imported を実 persist から算出させる。
 			mockInsertActivitiesBulk
@@ -670,10 +670,10 @@ describe('importActivities', () => {
 	});
 
 	// ──────────────────────────────────────────────────────────
-	// #2818 取込永続 honesty: imported は実 persist 数のみを反映する
+	// #2824 取込永続 honesty: imported は実 persist 数のみを反映する
 	// (本番 cognito Lambda + DATA_SOURCE=dynamodb で write が永続しない CRITICAL の根治)
 	// ──────────────────────────────────────────────────────────
-	describe('#2818 取込永続 honesty (imported が偽らない)', () => {
+	describe('#2824 取込永続 honesty (imported が偽らない)', () => {
 		it('write が全失敗 (DynamoDB stub 相当) -> imported=0 + 保存失敗 error。35 件偽装を防ぐ', async () => {
 			// 顧客レビューで観察された CRITICAL の再現: 35 件取込しようとしたが本番
 			// DynamoDB repo が throw (旧 stub) → 0 件しか persist しないのに UI が


### PR DESCRIPTION
## 顧客価値・目的

有料本番 SaaS (AWS Lambda, `DATA_SOURCE=dynamodb`) で **marketplace 取込が永続せず「35件登録しました」と表示されるのに実際は 0 件**という CRITICAL バグを根治する。子供向け活動を親が marketplace から取り込んでも本番で消えるため、課金顧客の中核体験が壊れていた (顧客レビュー 2026-06-03 で発覚、User/PO 直接方針 2026-06-04)。

真因: `dynamodb/child-activity-repo.ts` が PR #2455 で stub 化され #2263 hotfix で「read=空 / write=throw」化された。「write 経路は本番に到達しない」仮定が marketplace の per-child 取込 (`importActivities → dispatchPerChildBulk → insertActivitiesBulk`) で破れていた。

## 関連 Issue

- 関連: #2701 (read-side CRITICAL = 5 age mode home 500、本 PR は同 repo の write-side 根治)
- 関連: #2746 (per-child binding 整合性、ADR-0055)
- 関連: ADR-0055 (Per-child 主軸データモデル原則) の完遂
- closes #2824 (本 PR の正式 tracking Issue。実装中に仮置きした番号が license 系 #2818 と衝突していたため、#2824 を起票しコード/設計書/CI の全参照を 29cd0d08a で訂正済)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `dynamodb/child-activity-repo.ts` 全 method を SQLite 実装と機能等価に本実装 | `tests/unit/db/dynamodb-child-activity-repo.test.ts` (vi.hoisted AWS SDK mock) | PASS (31 tests)。read 4 + write 8 + findChildById を網羅 |
| AC2 | marketplace per-child 取込が本番 DynamoDB で永続する | `insertActivitiesBulk` 本実装 + interface 適合テスト「write が throw stub でない」 | PASS。`insertActivitiesBulk` が実 PutItem を send |
| AC3 | imported は実 persist 数のみ反映 (偽の成功件数を出さない) | `activity-import-service.test.ts` #2824 honesty describe (35件偽装防止 / 一部 persist / 全成功) | PASS。write 全失敗→imported=0 + errors |
| AC4 | UI が persist 失敗を正直に表示 | admin/activities `+page.svelte` errors 有無で `importPartialFailure` 出し分け | svelte-check PASS。errorsCount>0 で error tone |
| AC5 | 構造ガードで「interface 拡張したのに dynamodb 未実装」を機械検出 | `scripts/check-dynamodb-stub-parity.mjs` + baseline + CI 組込 | PASS。baseline 12 repo / 86 method、新規 stub で exit 1 |
| AC6 | DB 設計書同期 (ADR-0001) | `08-データベース設計書.md` に DynamoDB key 設計追記 | 反映済 (PK/SK 表 + アクセスパターン表) |

## 変更タイプ

- [x] fix (CRITICAL バグ修正)
- [x] feat (DynamoDB 本実装)
- [x] test
- [x] infra/ci (構造ガード)
- [x] docs (設計書同期)

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dynamodb/child-activity-repo.ts` — stub → 本実装 (全 method)
- `src/lib/server/db/dynamodb/keys.ts` — `childActivityKey` / `childActivityPrefix` / `ENTITY_NAMES.childActivity` 追加
- `src/lib/server/services/activity-import-service.ts` — imported を実 persist 数から算出 (honesty hardening)
- `src/lib/domain/labels.ts` — `importPartialFailure` ラベル追加
- `src/routes/(parent)/admin/activities/+page.svelte` — errors 有無で feedback 出し分け
- `scripts/check-dynamodb-stub-parity.mjs` + `scripts/dynamodb-stub-baseline.json` + `.github/workflows/ci.yml` — 構造ガード
- tests 4 件 + `docs/design/08-データベース設計書.md`

### DynamoDB key 設計 (レビューの核心)

| エンティティ | PK | SK |
|---|---|---|
| child_activity | `T#<tid>#CHILD#<childId>` | `CHILDACT#<paddedId>` (8 桁 0 埋め) |

| アクセスパターン | 操作 | 条件 |
|---|---|---|
| findActivitiesByChild | Query | `PK = T#<tid>#CHILD#<childId> AND begins_with(SK, 'CHILDACT#')` (archive/visible/sort は in-memory、SQLite SSOT 一致) |
| findActivityById | GetItem | `PK=.., SK=CHILDACT#<paddedId>` |
| insertActivity / Bulk | counter 採番 → PutItem | schema default を明示充填、`.returning()` 等価 row 返却 |
| updateActivity / setVisibility | UpdateItem (`attribute_exists(PK)` / `ALL_NEW`) | 別 child / 不在 → `ConditionalCheckFailedException` → undefined |
| deleteActivity | DeleteItem (`ALL_OLD`) | 削除前 row 返却 |
| archive / restore | Scan (PK/SK projection) → UpdateItem | child partition 分散のため横断は Scan。低頻度のため GSI 不要 (Pre-PMF / ADR-0010) |

### GSI 要否判断

**追加 GSI 不要。CDK 変更なし。** child partition (`PK=CHILD#<id>`) 配下に置くことで `findActivitiesByChild` (最頻アクセス) は単一 partition Query で完結。横断アクセス (archive/restore by id/reason) は低頻度のため Scan で対応 (既存 push_subscription / cancellation_reason と同方針)。

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/db/ tests/unit/services/ tests/unit/marketplace/` → 160 files / 2732 tests PASS
- 直接影響 4 spec → 96 tests PASS
- `npx biome check --error-on-warnings` (変更ファイル) → clean (cognitive complexity / useMaxParams 解消済)
- `npx svelte-check` → 変更ファイルに型エラー 0 (残 58 errors は infra/node_modules 未install の既知環境ノイズ、CI で解消)
- `node scripts/check-dynamodb-stub-parity.mjs` → OK / `node scripts/check-dynamodb-stub.mjs` → OK
- `node scripts/check-no-plan-literals.mjs` / `check-internal-terms.mjs` / `generate-lp-labels.mjs --check` → PASS

ADR-0006: 既存テストの assertion は弱体化していない。`imported=2` 期待だった failure-case テストはバグそのものを encode していたため `imported=0` に**是正** (弱体化でなく現実即応の強化、各テストにコメントで明記)。

## スクリーンショット / ビジュアルデモ

admin/activities 取込結果 feedback の文言出し分けのみ変更 (成功 path のレイアウト・文言は不変)。取込画面の実機 SS (demo fixture data、`AUTH_MODE=anonymous` + `DATA_SOURCE=demo`):

### Desktop
![admin-activities-desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2820/admin-activities-desktop.png)

### Mobile
![admin-activities-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2820/admin-activities-mobile.png)

> 本 PR の UI 変更は persist 失敗時の error message 1 分岐追加 (#2824 honesty)。成功 path の `importSuccess` 文言・レイアウトは不変のため、上記は取込画面の現行表示。persist 失敗 state は本 PR が解消する本番 DynamoDB stub 起因のため再現条件が消滅する (unit test `activity-import-service.test.ts` で挙動を回帰固定)。

## コード品質セルフレビュー (#1481)

- **OSS 先調査**: 新規機構なし。DynamoDB single-table key パターンは既存 `keys.ts` / `checklist-repo.ts` / `push-subscription-repo.ts` の確立パターンを踏襲 (独自実装 0)。`stripKeys` / `queryAllItems` / `findChildByIdRaw` は `repo-helpers.ts` の共通実装を再利用。
- **複雑度**: `importActivities` を `planActivityForChildren` + `persistAndCountImported` に分解し cognitive complexity 27→20 以下に。`PlanContext` で param 数を 5 以下に。
- **SQLite ⇄ DynamoDB 並行実装整合**: insert default 値 (sortOrder=0 / isVisible=1 / source='seed' / dailyLimit=null 等) を両実装で一致 (tests/CLAUDE.md §DynamoDB 並行実装整合)。
- **NULL 互換**: archive filter は `!isArchived || isArchived===0` で NULL/0 を active 扱い (#962 教訓、SQLite と一致)。

## 横展開・影響波及チェック

- `docs/design/parallel-implementations.md` DB スキーマ: child_activities の DynamoDB 実装追加。SQLite (挙動 SSOT) / demo / dynamodb の 3 backend で write 等価に。
- 構造ガード `check-dynamodb-stub-parity.mjs` が **残 11 同型 stub repo** (battle / reward-redemption / auto-challenge / child-challenge 等) を baseline で固定する。これらは同根 (write 永続なし) のため、interface 拡張時に dynamodb 未実装が混入すれば gate が exit 1 で検出する。本 PR の child-activity 本実装はこの baseline から 1 repo 削減した形であり、残 repo の本実装可否は QM/PO が優先度判断する。
- `activity-import-service` の honesty 修正は reward-set / checklist / challenge import にも同型問題がある可能性。本 PR は activity-pack のみ。横展開は別 Issue で評価 (PO 判断)。

## レビュー依頼事項・破壊的変更

- **破壊的変更なし**。stub → 本実装で挙動が「壊れていた→正しく動く」方向。
- tracking Issue は #2824 で確定済 (衝突は解消、全参照訂正済)。
- **レビュー核心**: DynamoDB key 設計 (上表) と honesty hardening の貫通 (service → +page.svelte)。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。`DYNAMODB_TABLE` 等は既存。

## Ready for Review チェックリスト

- [x] CI 全通過を確認した (push 後 CI 緑化を確認のうえ Ready 化)
- [x] AC 検証マップを全 AC 分記入した
- [x] 設計書を同期した (08-データベース設計書.md)
- [x] テストを追加した (新規 spec + 回帰固定)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: 全 step PASS、QA review 可能状態)

## QM レビュー結果

(QM 記入)



