### PR TITLE
feat: DynamoDB child-challenge-repo 本実装 (Phase 2B、#2824)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -89,6 +89,7 @@ certificatemanager
 chibi
 chukichi
 CHILDACT
+CHILDCHAL
 CKLOG
 CKOVER
 CKTPL

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -633,6 +633,28 @@ per-child チャレンジ instance。旧 `sibling_challenges` (family-wide + 別
 
 **インデックス:** (child_id, status), (start_date, end_date), source_template_id
 
+#### DynamoDB キー設計（single-table、#2824 / ADR-0055 Phase 2B）
+
+本番 cognito Lambda は `DATA_SOURCE=dynamodb` で稼働するため、SQLite と機能等価の DynamoDB 実装 (`src/lib/server/db/dynamodb/child-challenge-repo.ts`) を持つ。per-child instance は child partition 配下に置き、`findByChildId` を**追加 GSI なし**の単一 partition Query で完結させる（child_activities と同型、ADR-0055 §3.1）。
+
+| エンティティ | PK | SK | 補足 |
+|---|---|---|---|
+| child_challenge | `T#<tid>#CHILD#<childId>` | `CHILDCHAL#<paddedId>` | id は 8 桁 0 埋め。child_activities / activity_logs と同 partition に同居 |
+
+| アクセスパターン | 操作 | 条件 |
+|---|---|---|
+| `findByChildId(childId)` | Query | `PK = T#<tid>#CHILD#<childId> AND begins_with(SK, 'CHILDCHAL#')`。start_date 昇順は in-memory（SQLite SSOT と一致） |
+| `findActiveByChildId` / `findActiveOrUnclaimedByChildId` | Query + in-memory filter | isActive=1 / status / 期間 / 完成済未請求（#2488）を SQLite と同条件で適用 |
+| `findAllByTenant` | Scan（PK/SK filter） | challenge は child partition に分散するため admin 一覧は tenant 配下 Scan。created_at 昇順は in-memory |
+| `findById(id)` / mutation（`updateProgress` / `markCompleted` / `claimReward` / `update` / `deleteChallenge`） | Scan（SK 完全一致で PK/SK 解決）→ Update/Delete | interface が childId を受けず id 単独のため、id → PK/SK を Scan で解決。challenge instance は週次/月次で件数少なく低頻度のため GSI 不要（Pre-PMF / ADR-0010） |
+| `insert` / `insertBulk` | counter 採番 → PutItem | SQLite schema default（challenge_type='cooperative' / period_type='weekly' / status='active' / is_active=1 / current_value=0 等）を明示的に埋め、`.returning()` 等価の row を返す。取込時 per-child 配信の核心経路 |
+| `copyAcrossChildren` | Query（source）→ insertBulk（target） | 兄弟共通化（User §6）。source_template_id 維持 + 進捗 0 リセット |
+| `deleteByTenantId` | Scan（PK/SK projection）→ DeleteItem | テナント削除時 |
+
+新規 SK prefix `CHILDCHAL#` は既存テーブルにそのまま乗るため **CDK 変更不要**（追加 GSI なし）。helper 経由 stub の再混入は `scripts/check-dynamodb-stub-parity.mjs`（baseline ratchet）が CI で検出する。
+
+> **#2824 経緯**: 本 repo は #2362 PR-7 で導入され、#2263/#2280 hotfix で「read=空 / write=no-op + logger.warn」化されたまま有料本番で運用されていた。marketplace challenge-set 取込（顧客レビュー対象経路）が本番で永続せず UI が「N 件追加しました」と偽る CRITICAL の一部。本実装（Phase 2B）で根治する。
+
 ### sibling_cheers
 
 きょうだい間おうえんスタンプ。定型6種のスタンプを送り合う。

--- a/scripts/dynamodb-stub-baseline.json
+++ b/scripts/dynamodb-stub-baseline.json
@@ -33,22 +33,6 @@
 		"hasCertificate",
 		"issueCertificate"
 	],
-	"src/lib/server/db/dynamodb/child-challenge-repo.ts": [
-		"claimReward",
-		"copyAcrossChildren",
-		"delete",
-		"deleteByTenantId",
-		"findActiveByChildId",
-		"findActiveOrUnclaimedByChildId",
-		"findAllByTenant",
-		"findByChildId",
-		"findById",
-		"insert",
-		"insertBulk",
-		"markCompleted",
-		"update",
-		"updateProgress"
-	],
 	"src/lib/server/db/dynamodb/cloud-export-repo.ts": [
 		"countByTenant",
 		"deleteById",

--- a/src/lib/server/db/dynamodb/child-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/child-challenge-repo.ts
@@ -1,74 +1,142 @@
-// DynamoDB implementation of IChildChallengeRepo
+// src/lib/server/db/dynamodb/child-challenge-repo.ts
+// per-child challenge instance repository — DynamoDB 本実装 (ADR-0055、Phase 2B #2824)
 //
-// #2362 PR-7 / User §6: 旧 sibling-challenge-repo.dynamodb の per-child 後継。
-// #2263 hotfix pattern: Pre-PMF fallback (read = 空 / write = no-op + logger.warn)。
-// DynamoDB 本格対応は本番 PMF 後 (ADR-0010 Pre-PMF Bucket B)。
+// IChildChallengeRepo (child-challenge-repo.interface.ts) を SQLite 実装
+// (sqlite/child-challenge-repo.ts、挙動 SSOT) と機能等価に DynamoDB single-table で実装する。
+//
+// 経緯: #2362 PR-7 で導入された stub が #2263/#2280 hotfix で「read=空 / write=no-op +
+//   logger.warn」化されたまま有料本番 (AUTH_MODE=cognito + DATA_SOURCE=dynamodb) で運用されていた。
+//   marketplace challenge-set 取込 (顧客レビュー対象経路) が本番で永続せず、UI が「N 件追加しました」
+//   と偽る CRITICAL バグの一部。本実装で根治する (Phase 1 child-activity #2820 と同型)。
+//
+// key 設計 (keys.ts §childChallengeKey):
+//   PK = T#<tenantId>#CHILD#<childId>   (child partition、child_activities / activity_logs と同居)
+//   SK = CHILDCHAL#<paddedId>           (8 桁 0 埋め、辞書順)
+//   → findByChildId は単一 partition Query で完結し追加 GSI 不要 (ADR-0055 §3.1)。
+//
+// child-activity との差分: interface の mutation method (update / markCompleted / claimReward /
+//   deleteChallenge / findById) が childId を受け取らず id 単独のため、id → PK/SK 解決を
+//   tenant 配下 Scan (begins_with(SK, 'CHILDCHAL#') AND SK = :sk) で行う。challenge instance は
+//   1 child 当たり数件 (週次/月次) と低頻度なため Scan で十分 (ADR-0010 Pre-PMF、GSI 追加は過剰防衛)。
+//
+// 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/child-challenge-repo.ts (SSOT)
 
-import { logger } from '$lib/server/logger';
+import { DeleteCommand, PutCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type {
 	ChildChallenge,
 	InsertChildChallengeInput,
 	UpdateChildChallengeInput,
 } from '../types';
+import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
+import {
+	childChallengeKey,
+	childChallengePrefix,
+	childPK,
+	ENTITY_NAMES,
+	padId,
+	tenantPK,
+} from './keys';
+import { queryAllItems, stripKeys } from './repo-helpers';
 
-const SERVICE = 'child-challenge-repo.dynamodb';
+const PREFIX = childChallengePrefix();
 
-function warnRead(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] read fallback: returning empty (Pre-PMF stub, #2362)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
+/** DynamoDB item を ChildChallenge に正規化する (PK/SK を除去)。 */
+function toChildChallenge(item: Record<string, unknown>): ChildChallenge {
+	return stripKeys(item) as unknown as ChildChallenge;
 }
 
-function warnWrite(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] write fallback: no-op (Pre-PMF stub, #2362)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
-}
+// ============================================================
+// findByChildId — child 単位の全 challenge instance (child partition Query)
+// ============================================================
 
 export async function findByChildId(childId: number, tenantId: string): Promise<ChildChallenge[]> {
-	warnRead('findByChildId', { childId, tenantId });
-	return [];
+	const items = await queryAllItems(childPK(childId, tenantId), PREFIX);
+	const challenges = items.map(toChildChallenge);
+	// SQLite は ORDER BY start_date。in-memory で同順に揃える。
+	challenges.sort((a, b) => a.startDate.localeCompare(b.startDate));
+	return challenges;
 }
+
+// ============================================================
+// findActiveByChildId — status=active かつ today が start〜end 範囲内
+// ============================================================
 
 export async function findActiveByChildId(
 	childId: number,
 	today: string,
 	tenantId: string,
 ): Promise<ChildChallenge[]> {
-	warnRead('findActiveByChildId', { childId, today, tenantId });
-	return [];
+	const all = await findByChildId(childId, tenantId);
+	return all.filter(
+		(c) => c.isActive === 1 && c.status === 'active' && c.startDate <= today && c.endDate >= today,
+	);
 }
 
-/** #2488 (must-1 fix): Pre-PMF DynamoDB stub */
+// ============================================================
+// findActiveOrUnclaimedByChildId (#2488 must-1) — active + 完成済未請求
+// ============================================================
+
+/**
+ * status='active' に加え、status='completed' AND rewardClaimed=0 の instance も含める
+ * (markCompleted 直後に claim ボタンが消える regression 防止、SQLite SSOT と同条件)。
+ */
 export async function findActiveOrUnclaimedByChildId(
 	childId: number,
 	today: string,
 	tenantId: string,
 ): Promise<ChildChallenge[]> {
-	warnRead('findActiveOrUnclaimedByChildId', { childId, today, tenantId });
-	return [];
+	const all = await findByChildId(childId, tenantId);
+	return all.filter(
+		(c) =>
+			c.isActive === 1 &&
+			(c.status === 'active' || c.status === 'completed') &&
+			c.startDate <= today &&
+			c.endDate >= today &&
+			// status='completed' で rewardClaimed=1 (受取済) は除外
+			(c.status === 'active' || c.rewardClaimed === 0),
+	);
 }
+
+// ============================================================
+// findAllByTenant — tenant 全体 (admin 画面、child partition 横断 Scan)
+// ============================================================
 
 export async function findAllByTenant(tenantId: string): Promise<ChildChallenge[]> {
-	warnRead('findAllByTenant', { tenantId });
-	return [];
+	const items = await scanTenantChallenges(tenantId);
+	const challenges = items.map(toChildChallenge);
+	// SQLite は ORDER BY created_at。in-memory で同順に揃える。
+	challenges.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+	return challenges;
 }
+
+// ============================================================
+// findById — id 単独取得 (childId 不明のため tenant 配下 Scan)
+// ============================================================
 
 export async function findById(id: number, tenantId: string): Promise<ChildChallenge | undefined> {
-	warnRead('findById', { id, tenantId });
-	return undefined;
+	const items = await scanTenantChallenges(tenantId, { sk: `${PREFIX}${padId(id)}` });
+	const item = items[0];
+	return item ? toChildChallenge(item) : undefined;
 }
 
-export async function insert(
+// ============================================================
+// insert / insertBulk — per-child instance 新規作成
+// ============================================================
+
+/**
+ * 1 件の ChildChallenge を組み立てる。SQLite schema default
+ * (challengeType='cooperative' / periodType='weekly' / status='active' / isActive=1 /
+ * currentValue=0 / completed=0 / completedAt=null / rewardClaimed=0 / rewardClaimedAt=null)
+ * を明示的に埋め、insert の返り値が SQLite の `.returning()` と等価になるようにする。
+ */
+function buildChildChallenge(
+	id: number,
 	input: InsertChildChallengeInput,
-	tenantId: string,
-): Promise<ChildChallenge> {
-	warnWrite('insert', { childId: input.childId, title: input.title, tenantId });
-	const now = new Date().toISOString();
+	now: string,
+): ChildChallenge {
 	return {
-		id: 0,
+		id,
 		childId: input.childId,
 		title: input.title,
 		description: input.description ?? null,
@@ -92,11 +160,32 @@ export async function insert(
 	};
 }
 
+export async function insert(
+	input: InsertChildChallengeInput,
+	tenantId: string,
+): Promise<ChildChallenge> {
+	const id = await nextId(ENTITY_NAMES.childChallenge, tenantId);
+	const challenge = buildChildChallenge(id, input, new Date().toISOString());
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...childChallengeKey(input.childId, id, tenantId),
+				...challenge,
+			},
+		}),
+	);
+
+	return challenge;
+}
+
 export async function insertBulk(
 	inputs: readonly InsertChildChallengeInput[],
 	tenantId: string,
 ): Promise<ChildChallenge[]> {
-	warnWrite('insertBulk', { count: inputs.length, tenantId });
+	if (inputs.length === 0) return [];
+	// SQLite 実装と同じく直列 insert (id 採番が atomic counter のため順次 Put)。
 	const results: ChildChallenge[] = [];
 	for (const input of inputs) {
 		results.push(await insert(input, tenantId));
@@ -104,43 +193,216 @@ export async function insertBulk(
 	return results;
 }
 
+// ============================================================
+// updateProgress / markCompleted / claimReward / update / deleteChallenge
+// いずれも id 単独受領のため、tenant 配下 Scan で PK/SK を解決してから操作する。
+// ============================================================
+
 export async function updateProgress(
 	id: number,
 	currentValue: number,
 	tenantId: string,
 ): Promise<void> {
-	warnWrite('updateProgress', { id, currentValue, tenantId });
+	const key = await resolveKeyById(id, tenantId);
+	if (!key) return;
+	await getDocClient().send(
+		new UpdateCommand({
+			TableName: TABLE_NAME,
+			Key: key,
+			UpdateExpression: 'SET currentValue = :cv, updatedAt = :now',
+			ExpressionAttributeValues: { ':cv': currentValue, ':now': new Date().toISOString() },
+		}),
+	);
 }
 
 export async function markCompleted(id: number, tenantId: string): Promise<void> {
-	warnWrite('markCompleted', { id, tenantId });
+	const key = await resolveKeyById(id, tenantId);
+	if (!key) return;
+	const now = new Date().toISOString();
+	await getDocClient().send(
+		new UpdateCommand({
+			TableName: TABLE_NAME,
+			Key: key,
+			UpdateExpression:
+				'SET completed = :one, completedAt = :now, #status = :completed, updatedAt = :now',
+			ExpressionAttributeNames: { '#status': 'status' },
+			ExpressionAttributeValues: { ':one': 1, ':now': now, ':completed': 'completed' },
+		}),
+	);
 }
 
 export async function claimReward(id: number, tenantId: string): Promise<void> {
-	warnWrite('claimReward', { id, tenantId });
+	const key = await resolveKeyById(id, tenantId);
+	if (!key) return;
+	const now = new Date().toISOString();
+	await getDocClient().send(
+		new UpdateCommand({
+			TableName: TABLE_NAME,
+			Key: key,
+			UpdateExpression: 'SET rewardClaimed = :one, rewardClaimedAt = :now, updatedAt = :now',
+			ExpressionAttributeValues: { ':one': 1, ':now': now },
+		}),
+	);
 }
 
+/** UpdateChildChallengeInput で渡された field のみ更新する (SQLite .set({...}) 等価)。 */
 export async function update(
 	id: number,
-	_input: UpdateChildChallengeInput,
+	input: UpdateChildChallengeInput,
 	tenantId: string,
 ): Promise<void> {
-	warnWrite('update', { id, tenantId });
+	const key = await resolveKeyById(id, tenantId);
+	if (!key) return;
+
+	const fields = [
+		'title',
+		'description',
+		'periodType',
+		'startDate',
+		'endDate',
+		'targetConfig',
+		'rewardConfig',
+		'status',
+		'isActive',
+	] as const;
+
+	// status は予約語のため全 field を ExpressionAttributeNames 経由にする。
+	const sets: string[] = ['#updatedAt = :now'];
+	const names: Record<string, string> = { '#updatedAt': 'updatedAt' };
+	const values: Record<string, unknown> = { ':now': new Date().toISOString() };
+	for (const field of fields) {
+		if (input[field] !== undefined) {
+			const nameRef = `#${field}`;
+			sets.push(`${nameRef} = :${field}`);
+			names[nameRef] = field;
+			values[`:${field}`] = input[field];
+		}
+	}
+
+	await getDocClient().send(
+		new UpdateCommand({
+			TableName: TABLE_NAME,
+			Key: key,
+			UpdateExpression: `SET ${sets.join(', ')}`,
+			ExpressionAttributeNames: names,
+			ExpressionAttributeValues: values,
+		}),
+	);
 }
 
 export async function deleteChallenge(id: number, tenantId: string): Promise<void> {
-	warnWrite('delete', { id, tenantId });
+	const key = await resolveKeyById(id, tenantId);
+	if (!key) return;
+	await getDocClient().send(new DeleteCommand({ TableName: TABLE_NAME, Key: key }));
 }
 
+// ============================================================
+// copyAcrossChildren — 兄弟共通化 (User §6)
+// ============================================================
+
+/**
+ * source child の challenge 全件を target child に複製。
+ * sourceTemplateId を維持し、進捗は insert で currentValue=0 / completed=0 にリセット。
+ */
 export async function copyAcrossChildren(
 	sourceChildId: number,
 	targetChildId: number,
 	tenantId: string,
 ): Promise<ChildChallenge[]> {
-	warnWrite('copyAcrossChildren', { sourceChildId, targetChildId, tenantId });
-	return [];
+	const source = await findByChildId(sourceChildId, tenantId);
+	if (source.length === 0) return [];
+
+	const inputs: InsertChildChallengeInput[] = source.map((c) => ({
+		childId: targetChildId,
+		title: c.title,
+		description: c.description,
+		challengeType: c.challengeType,
+		periodType: c.periodType,
+		startDate: c.startDate,
+		endDate: c.endDate,
+		targetConfig: c.targetConfig,
+		rewardConfig: c.rewardConfig,
+		sourceTemplateId: c.sourceTemplateId,
+		targetValue: c.targetValue,
+	}));
+
+	return insertBulk(inputs, tenantId);
 }
 
+// ============================================================
+// deleteByTenantId — テナント削除時の全 child challenge 削除
+// ============================================================
+
 export async function deleteByTenantId(tenantId: string): Promise<void> {
-	warnWrite('deleteByTenantId', { tenantId });
+	const items = await scanTenantChallenges(tenantId, { projection: 'PK, SK' });
+	for (const item of items) {
+		await getDocClient().send(
+			new DeleteCommand({
+				TableName: TABLE_NAME,
+				Key: { PK: item.PK as string, SK: item.SK as string },
+			}),
+		);
+	}
+}
+
+// ============================================================
+// Scan helpers — child partition 横断検索
+// ============================================================
+//
+// child_challenges は child partition (PK=CHILD#<cId>) に分散するため、tenant 横断 read
+// (findAllByTenant / findById / deleteByTenantId) は GSI なしでは Scan が必要。challenge は
+// 週次/月次 instance で件数が少なく、これらは admin 表示 / id lookup / tenant 削除の低頻度経路
+// のため Pre-PMF (ADR-0010) では Scan + 属性フィルタで十分。GSI 追加は過剰防衛。
+
+/**
+ * tenant 配下の CHILDCHAL# item を Scan で収集する。
+ * @param opts.sk         SK 完全一致 (findById / resolveKeyById 用)
+ * @param opts.projection ProjectionExpression (PK/SK のみ取得したいとき)
+ */
+async function scanTenantChallenges(
+	tenantId: string,
+	opts?: { sk?: string; projection?: string },
+): Promise<Record<string, unknown>[]> {
+	const filters = ['begins_with(SK, :skPrefix)', 'begins_with(PK, :tenantPrefix)'];
+	const values: Record<string, unknown> = {
+		':skPrefix': PREFIX,
+		':tenantPrefix': tenantPK('CHILD#', tenantId),
+	};
+	if (opts?.sk) {
+		filters.push('SK = :sk');
+		values[':sk'] = opts.sk;
+	}
+
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await getDocClient().send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: filters.join(' AND '),
+				ExpressionAttributeValues: values,
+				ProjectionExpression: opts?.projection,
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) {
+			items.push(item);
+		}
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return items;
+}
+
+/** id から PK/SK を解決する (mutation method 用)。不在なら undefined。 */
+async function resolveKeyById(
+	id: number,
+	tenantId: string,
+): Promise<{ PK: string; SK: string } | undefined> {
+	const items = await scanTenantChallenges(tenantId, {
+		sk: `${PREFIX}${padId(id)}`,
+		projection: 'PK, SK',
+	});
+	const item = items[0];
+	if (!item) return undefined;
+	return { PK: item.PK as string, SK: item.SK as string };
 }

--- a/src/lib/server/db/dynamodb/keys.ts
+++ b/src/lib/server/db/dynamodb/keys.ts
@@ -117,6 +117,32 @@ export function childActivityPrefix(): string {
 	return 'CHILDACT#';
 }
 
+/**
+ * Child challenge instance (#2362 PR-7 / ADR-0055): PK=CHILD#<cId>, SK=CHILDCHAL#<id>
+ *
+ * per-child challenge instance を child partition 配下に配置する (child_activities /
+ * activity_logs 等と同じ child scope レイアウト)。これにより `findByChildId` は
+ * 単一 partition Query (begins_with(SK, 'CHILDCHAL#')) で完結し、GSI を追加せず
+ * cross-child access を構造的に防ぐ (ADR-0055 §3.1)。
+ *
+ * SQLite `child_challenges` table と機能等価。childActivityKey と同型 (Phase 1 #2820)。
+ */
+export function childChallengeKey(
+	childId: number,
+	challengeId: number,
+	tenantId: string,
+): DynamoKey {
+	return {
+		PK: tenantPK(`${PREFIX.CHILD}#${childId}`, tenantId),
+		SK: `CHILDCHAL#${padId(challengeId)}`,
+	};
+}
+
+/** Child challenge SK prefix for querying all challenges of a child */
+export function childChallengePrefix(): string {
+	return 'CHILDCHAL#';
+}
+
 /** Activity log: PK=CHILD#<cId>, SK=LOG#<date>#<id> */
 export function activityLogKey(
 	childId: number,
@@ -736,6 +762,7 @@ export const ENTITY_NAMES = {
 	category: 'category',
 	activity: 'activity',
 	childActivity: 'childActivity',
+	childChallenge: 'childChallenge',
 	activityLog: 'activityLog',
 	pointLedger: 'pointLedger',
 	status: 'status',

--- a/tests/unit/db/dynamodb-child-challenge-repo.test.ts
+++ b/tests/unit/db/dynamodb-child-challenge-repo.test.ts
@@ -1,0 +1,658 @@
+/**
+ * tests/unit/db/dynamodb-child-challenge-repo.test.ts
+ *
+ * #2824 / ADR-0055 Phase 2B: DynamoDB per-child child-challenge-repo 本実装の単体テスト。
+ *
+ * AWS SDK を vi.hoisted mock で置き換え、SQLite 実装 (sqlite/child-challenge-repo.ts、
+ * 挙動 SSOT) と機能等価であることを method ごとに検証する:
+ *   - 正しい Command + key で send する (child partition Query / tenant Scan)
+ *   - response を正しく型変換する (stripKeys)
+ *   - SQLite 機能等価 (active/期間 filter / 完成済未請求 filter / insert default 値 /
+ *     mutation の id→PK/SK 解決 / status 予約語ハンドリング / copy / tenant 削除)
+ *
+ * 背景: #2362 PR-7 で導入された stub が #2263/#2280 hotfix で read=空 / write=no-op 化され、
+ *   marketplace challenge-set 取込が本番 DynamoDB Lambda で永続せず「N 件追加しました」と
+ *   偽る CRITICAL バグの一因になった。本テストは本実装の機能等価性を回帰固定する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const {
+	mockSend,
+	MockGetCommand,
+	MockPutCommand,
+	MockQueryCommand,
+	MockUpdateCommand,
+	MockDeleteCommand,
+	MockScanCommand,
+} = vi.hoisted(() => {
+	const send = vi.fn();
+	class Cmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	return {
+		mockSend: send,
+		MockGetCommand: class extends Cmd {},
+		MockPutCommand: class extends Cmd {},
+		MockQueryCommand: class extends Cmd {},
+		MockUpdateCommand: class extends Cmd {},
+		MockDeleteCommand: class extends Cmd {},
+		MockScanCommand: class extends Cmd {},
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	GetCommand: MockGetCommand,
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	UpdateCommand: MockUpdateCommand,
+	DeleteCommand: MockDeleteCommand,
+	ScanCommand: MockScanCommand,
+}));
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/child-challenge-repo');
+}
+
+const TENANT = 'tenant-1';
+const CHILD_ID = 42;
+
+/** child partition の DynamoDB item を組み立てる (PK/SK + 属性)。 */
+function makeItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const id = (over.id as number) ?? 1;
+	const childId = (over.childId as number) ?? CHILD_ID;
+	return {
+		PK: `T#${TENANT}#CHILD#${childId}`,
+		SK: `CHILDCHAL#${String(id).padStart(8, '0')}`,
+		id,
+		childId,
+		title: 'なわとびチャレンジ',
+		description: null,
+		challengeType: 'cooperative',
+		periodType: 'weekly',
+		startDate: '2026-06-01',
+		endDate: '2026-06-07',
+		targetConfig: '{"metric":"count","baseTarget":5}',
+		rewardConfig: '{"points":50}',
+		status: 'active',
+		isActive: 1,
+		sourceTemplateId: null,
+		currentValue: 0,
+		targetValue: 5,
+		completed: 0,
+		completedAt: null,
+		rewardClaimed: 0,
+		rewardClaimedAt: null,
+		createdAt: '2026-06-01T00:00:00.000Z',
+		updatedAt: '2026-06-01T00:00:00.000Z',
+		...over,
+	};
+}
+
+const TODAY = '2026-06-04';
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// findByChildId
+// ============================================================
+
+describe('findByChildId', () => {
+	it('child partition を Query し startDate 昇順で返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 2, title: 'B', startDate: '2026-06-08' }),
+				makeItem({ id: 1, title: 'A', startDate: '2026-06-01' }),
+			],
+		});
+
+		const { findByChildId } = await loadRepo();
+		const result = await findByChildId(CHILD_ID, TENANT);
+
+		expect(result.map((c) => c.title)).toEqual(['A', 'B']);
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: {
+				KeyConditionExpression?: string;
+				ExpressionAttributeValues?: Record<string, string>;
+			};
+		};
+		expect(callArg.input.KeyConditionExpression).toContain('PK = :pk');
+		expect(callArg.input.ExpressionAttributeValues?.[':pk']).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(callArg.input.ExpressionAttributeValues?.[':prefix']).toBe('CHILDCHAL#');
+	});
+
+	it('LastEvaluatedKey でページングする', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [makeItem({ id: 1, title: 'p1' })],
+				LastEvaluatedKey: { PK: 'c', SK: 'c' },
+			})
+			.mockResolvedValueOnce({ Items: [makeItem({ id: 2, title: 'p2' })] });
+		const { findByChildId } = await loadRepo();
+		const result = await findByChildId(CHILD_ID, TENANT);
+		expect(result).toHaveLength(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+
+	it('0 件のときは空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findByChildId } = await loadRepo();
+		expect(await findByChildId(CHILD_ID, TENANT)).toEqual([]);
+	});
+});
+
+// ============================================================
+// findActiveByChildId
+// ============================================================
+
+describe('findActiveByChildId', () => {
+	it('isActive=1 / status=active / 期間内のみ返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({
+					id: 1,
+					title: 'active-in',
+					status: 'active',
+					startDate: '2026-06-01',
+					endDate: '2026-06-07',
+				}),
+				makeItem({ id: 2, title: 'completed', status: 'completed' }), // status≠active → 除外
+				makeItem({ id: 3, title: 'inactive', isActive: 0 }), // isActive=0 → 除外
+				makeItem({
+					id: 4,
+					title: 'past',
+					status: 'active',
+					startDate: '2026-05-01',
+					endDate: '2026-05-07',
+				}), // 期間外 → 除外
+			],
+		});
+		const { findActiveByChildId } = await loadRepo();
+		const result = await findActiveByChildId(CHILD_ID, TODAY, TENANT);
+		expect(result.map((c) => c.title)).toEqual(['active-in']);
+	});
+});
+
+// ============================================================
+// findActiveOrUnclaimedByChildId (#2488 must-1)
+// ============================================================
+
+describe('findActiveOrUnclaimedByChildId', () => {
+	it('active + 完成済かつ未請求を返し、受取済 completed を除外する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, title: 'active', status: 'active' }),
+				makeItem({ id: 2, title: 'completed-unclaimed', status: 'completed', rewardClaimed: 0 }),
+				makeItem({ id: 3, title: 'completed-claimed', status: 'completed', rewardClaimed: 1 }), // 受取済 → 除外
+				makeItem({ id: 4, title: 'expired', status: 'expired' }), // 対象外 status → 除外
+			],
+		});
+		const { findActiveOrUnclaimedByChildId } = await loadRepo();
+		const result = await findActiveOrUnclaimedByChildId(CHILD_ID, TODAY, TENANT);
+		expect(result.map((c) => c.title)).toEqual(['active', 'completed-unclaimed']);
+	});
+
+	it('期間外は active でも除外する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({
+					id: 1,
+					title: 'future',
+					status: 'active',
+					startDate: '2026-07-01',
+					endDate: '2026-07-07',
+				}),
+			],
+		});
+		const { findActiveOrUnclaimedByChildId } = await loadRepo();
+		expect(await findActiveOrUnclaimedByChildId(CHILD_ID, TODAY, TENANT)).toEqual([]);
+	});
+});
+
+// ============================================================
+// findAllByTenant
+// ============================================================
+
+describe('findAllByTenant', () => {
+	it('tenant 配下を Scan し createdAt 昇順で返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 2, title: 'B', createdAt: '2026-06-02T00:00:00.000Z' }),
+				makeItem({ id: 1, title: 'A', childId: 99, createdAt: '2026-06-01T00:00:00.000Z' }),
+			],
+		});
+		const { findAllByTenant } = await loadRepo();
+		const result = await findAllByTenant(TENANT);
+		expect(result.map((c) => c.title)).toEqual(['A', 'B']);
+		const scan = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scan.input.FilterExpression).toContain('begins_with(SK, :skPrefix)');
+		expect(scan.input.ExpressionAttributeValues?.[':skPrefix']).toBe('CHILDCHAL#');
+		expect(scan.input.ExpressionAttributeValues?.[':tenantPrefix']).toBe(`T#${TENANT}#CHILD#`);
+	});
+
+	it('Scan を LastEvaluatedKey でページングする', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [makeItem({ id: 1 })],
+				LastEvaluatedKey: { PK: 'x', SK: 'y' },
+			})
+			.mockResolvedValueOnce({ Items: [makeItem({ id: 2 })] });
+		const { findAllByTenant } = await loadRepo();
+		expect(await findAllByTenant(TENANT)).toHaveLength(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+});
+
+// ============================================================
+// findById
+// ============================================================
+
+describe('findById', () => {
+	it('SK 完全一致で Scan し 1 件返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [makeItem({ id: 7, title: 'X' })] });
+		const { findById } = await loadRepo();
+		const result = await findById(7, TENANT);
+		expect(result?.title).toBe('X');
+		const scan = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scan.input.FilterExpression).toContain('SK = :sk');
+		expect(scan.input.ExpressionAttributeValues?.[':sk']).toBe('CHILDCHAL#00000007');
+	});
+
+	it('不在のとき undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findById } = await loadRepo();
+		expect(await findById(7, TENANT)).toBeUndefined();
+	});
+});
+
+// ============================================================
+// insert / insertBulk
+// ============================================================
+
+describe('insert', () => {
+	it('counter 採番 → PutItem し SQLite default 値を埋めた row を返す', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 101 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insert } = await loadRepo();
+		const result = await insert(
+			{
+				childId: CHILD_ID,
+				title: 'すいえいチャレンジ',
+				startDate: '2026-06-01',
+				endDate: '2026-06-07',
+				targetConfig: '{"metric":"count"}',
+				rewardConfig: '{"points":30}',
+				targetValue: 3,
+			},
+			TENANT,
+		);
+
+		expect(result.id).toBe(101);
+		// SQLite schema default が埋まっている
+		expect(result).toMatchObject({
+			childId: CHILD_ID,
+			title: 'すいえいチャレンジ',
+			description: null,
+			challengeType: 'cooperative',
+			periodType: 'weekly',
+			status: 'active',
+			isActive: 1,
+			sourceTemplateId: null,
+			currentValue: 0,
+			targetValue: 3,
+			completed: 0,
+			completedAt: null,
+			rewardClaimed: 0,
+			rewardClaimedAt: null,
+		});
+
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(putCall.input.Item?.SK).toBe('CHILDCHAL#00000101');
+		expect(putCall.input.Item?.title).toBe('すいえいチャレンジ');
+		expect(putCall.input.Item?.status).toBe('active');
+	});
+
+	it('sourceTemplateId / description / periodType を反映する', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 5 } }).mockResolvedValueOnce({});
+		const { insert } = await loadRepo();
+		const result = await insert(
+			{
+				childId: CHILD_ID,
+				title: 'お手伝い',
+				description: '毎日のお手伝い',
+				periodType: 'monthly',
+				startDate: '2026-06-01',
+				endDate: '2026-06-30',
+				targetConfig: '{}',
+				rewardConfig: '{}',
+				sourceTemplateId: 'japan-annual-events',
+				targetValue: 20,
+			},
+			TENANT,
+		);
+		expect(result).toMatchObject({
+			description: '毎日のお手伝い',
+			periodType: 'monthly',
+			sourceTemplateId: 'japan-annual-events',
+			targetValue: 20,
+		});
+	});
+});
+
+describe('insertBulk', () => {
+	it('空配列は何も send せず空を返す', async () => {
+		const { insertBulk } = await loadRepo();
+		expect(await insertBulk([], TENANT)).toEqual([]);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it('複数 input を順次 insert し全 row を返す (取込永続の核心経路)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 1 } })
+			.mockResolvedValueOnce({})
+			.mockResolvedValueOnce({ Attributes: { counter: 2 } })
+			.mockResolvedValueOnce({});
+		const { insertBulk } = await loadRepo();
+		const base = {
+			childId: CHILD_ID,
+			startDate: '2026-06-01',
+			endDate: '2026-06-07',
+			targetConfig: '{}',
+			rewardConfig: '{}',
+			targetValue: 5,
+		};
+		const result = await insertBulk(
+			[
+				{ ...base, title: 'A' },
+				{ ...base, title: 'B' },
+			],
+			TENANT,
+		);
+		expect(result.map((c) => c.title)).toEqual(['A', 'B']);
+		expect(result.map((c) => c.id)).toEqual([1, 2]);
+		// 2 insert = 4 send (nextId + Put × 2)
+		expect(mockSend).toHaveBeenCalledTimes(4);
+	});
+});
+
+// ============================================================
+// updateProgress / markCompleted / claimReward
+// ============================================================
+
+describe('updateProgress', () => {
+	it('id を Scan で解決し currentValue を Update する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDCHAL#00000003' }],
+			}) // resolve
+			.mockResolvedValueOnce({}); // Update
+		const { updateProgress } = await loadRepo();
+		await updateProgress(3, 4, TENANT);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: {
+				Key?: { SK: string };
+				UpdateExpression?: string;
+				ExpressionAttributeValues?: Record<string, unknown>;
+			};
+		};
+		expect(upd.input.Key?.SK).toBe('CHILDCHAL#00000003');
+		expect(upd.input.UpdateExpression).toContain('currentValue = :cv');
+		expect(upd.input.ExpressionAttributeValues?.[':cv']).toBe(4);
+	});
+
+	it('id 不在のとき Update を発行しない (Scan のみ)', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { updateProgress } = await loadRepo();
+		await updateProgress(999, 1, TENANT);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('markCompleted', () => {
+	it('completed=1 / status=completed を予約語回避で Update する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDCHAL#00000001' }],
+			})
+			.mockResolvedValueOnce({});
+		const { markCompleted } = await loadRepo();
+		await markCompleted(1, TENANT);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: {
+				UpdateExpression?: string;
+				ExpressionAttributeNames?: Record<string, string>;
+				ExpressionAttributeValues?: Record<string, unknown>;
+			};
+		};
+		expect(upd.input.UpdateExpression).toContain('completed = :one');
+		expect(upd.input.UpdateExpression).toContain('#status = :completed');
+		expect(upd.input.ExpressionAttributeNames?.['#status']).toBe('status');
+		expect(upd.input.ExpressionAttributeValues?.[':completed']).toBe('completed');
+	});
+});
+
+describe('claimReward', () => {
+	it('rewardClaimed=1 を Update する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDCHAL#00000001' }],
+			})
+			.mockResolvedValueOnce({});
+		const { claimReward } = await loadRepo();
+		await claimReward(1, TENANT);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(upd.input.UpdateExpression).toContain('rewardClaimed = :one');
+		expect(upd.input.ExpressionAttributeValues?.[':one']).toBe(1);
+	});
+});
+
+// ============================================================
+// update (meta)
+// ============================================================
+
+describe('update', () => {
+	it('渡された field のみ UpdateExpression に含める (status 予約語回避)', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDCHAL#00000001' }],
+			})
+			.mockResolvedValueOnce({});
+		const { update } = await loadRepo();
+		await update(1, { title: 'updated', status: 'expired', isActive: 0 }, TENANT);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: {
+				UpdateExpression?: string;
+				ExpressionAttributeNames?: Record<string, string>;
+				ExpressionAttributeValues?: Record<string, unknown>;
+			};
+		};
+		expect(upd.input.UpdateExpression).toContain('#title = :title');
+		expect(upd.input.UpdateExpression).toContain('#status = :status');
+		expect(upd.input.UpdateExpression).toContain('#isActive = :isActive');
+		expect(upd.input.ExpressionAttributeNames?.['#status']).toBe('status');
+		expect(upd.input.ExpressionAttributeValues?.[':status']).toBe('expired');
+		expect(upd.input.ExpressionAttributeValues?.[':isActive']).toBe(0);
+		// 未指定 field は含まれない
+		expect(upd.input.UpdateExpression).not.toContain(':targetConfig');
+	});
+
+	it('field 0 件でも updatedAt のみ更新する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDCHAL#00000001' }],
+			})
+			.mockResolvedValueOnce({});
+		const { update } = await loadRepo();
+		await update(1, {}, TENANT);
+		const upd = mockSend.mock.calls[1]?.[0] as { input: { UpdateExpression?: string } };
+		expect(upd.input.UpdateExpression).toContain('#updatedAt = :now');
+	});
+
+	it('id 不在のとき Update を発行しない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { update } = await loadRepo();
+		await update(999, { title: 'x' }, TENANT);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ============================================================
+// deleteChallenge
+// ============================================================
+
+describe('deleteChallenge', () => {
+	it('id を Scan で解決し DeleteItem する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDCHAL#00000003' }],
+			})
+			.mockResolvedValueOnce({});
+		const { deleteChallenge } = await loadRepo();
+		await deleteChallenge(3, TENANT);
+		const del = mockSend.mock.calls[1]?.[0] as { input: { Key?: { SK: string } } };
+		expect(del.input.Key?.SK).toBe('CHILDCHAL#00000003');
+	});
+
+	it('id 不在のとき Delete を発行しない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { deleteChallenge } = await loadRepo();
+		await deleteChallenge(999, TENANT);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ============================================================
+// copyAcrossChildren
+// ============================================================
+
+describe('copyAcrossChildren', () => {
+	it('source の challenge を target child に複製し進捗をリセットする', async () => {
+		// 1) findByChildId(source) Query
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, title: 'A', currentValue: 3, completed: 1, sourceTemplateId: 'tpl-1' }),
+				makeItem({ id: 2, title: 'B', startDate: '2026-06-08' }),
+			],
+		});
+		// 2) insertBulk → nextId + Put × 2
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 10 } })
+			.mockResolvedValueOnce({})
+			.mockResolvedValueOnce({ Attributes: { counter: 11 } })
+			.mockResolvedValueOnce({});
+
+		const { copyAcrossChildren } = await loadRepo();
+		const result = await copyAcrossChildren(CHILD_ID, 99, TENANT);
+		expect(result.map((c) => c.title)).toEqual(['A', 'B']);
+		expect(result.every((c) => c.childId === 99)).toBe(true);
+		// 進捗リセット + sourceTemplateId 維持
+		expect(result[0]?.currentValue).toBe(0);
+		expect(result[0]?.completed).toBe(0);
+		expect(result[0]?.sourceTemplateId).toBe('tpl-1');
+	});
+
+	it('source 0 件のとき何も insert しない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { copyAcrossChildren } = await loadRepo();
+		expect(await copyAcrossChildren(CHILD_ID, 99, TENANT)).toEqual([]);
+		expect(mockSend).toHaveBeenCalledTimes(1); // Query のみ
+	});
+});
+
+// ============================================================
+// deleteByTenantId
+// ============================================================
+
+describe('deleteByTenantId', () => {
+	it('tenant 配下を Scan し全件 Delete する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				{ PK: `T#${TENANT}#CHILD#1`, SK: 'CHILDCHAL#00000001' },
+				{ PK: `T#${TENANT}#CHILD#2`, SK: 'CHILDCHAL#00000002' },
+			],
+		});
+		mockSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+		const { deleteByTenantId } = await loadRepo();
+		await deleteByTenantId(TENANT);
+		// 1 Scan + 2 Delete
+		expect(mockSend).toHaveBeenCalledTimes(3);
+		const del = mockSend.mock.calls[1]?.[0] as { input: { Key?: { PK: string } } };
+		expect(del.input.Key?.PK).toBe(`T#${TENANT}#CHILD#1`);
+	});
+});
+
+// ============================================================
+// interface 適合 (SQLite との機能等価性)
+// ============================================================
+
+describe('interface 適合 (IChildChallengeRepo)', () => {
+	it('全メソッドを export している (stub に後退していない)', async () => {
+		const repo = await loadRepo();
+		for (const m of [
+			'findByChildId',
+			'findActiveByChildId',
+			'findActiveOrUnclaimedByChildId',
+			'findAllByTenant',
+			'findById',
+			'insert',
+			'insertBulk',
+			'updateProgress',
+			'markCompleted',
+			'claimReward',
+			'update',
+			'deleteChallenge',
+			'copyAcrossChildren',
+			'deleteByTenantId',
+		]) {
+			expect(typeof (repo as Record<string, unknown>)[m]).toBe('function');
+		}
+	});
+
+	it('write method が no-op stub でない (insertBulk が実 send する)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		const { insertBulk } = await loadRepo();
+		const result = await insertBulk(
+			[
+				{
+					childId: CHILD_ID,
+					title: 'X',
+					startDate: '2026-06-01',
+					endDate: '2026-06-07',
+					targetConfig: '{}',
+					rewardConfig: '{}',
+					targetValue: 5,
+				},
+			],
+			TENANT,
+		);
+		// stub なら row.id=0 を返していた。本実装は採番された row を返す。
+		expect(result).toHaveLength(1);
+		expect(result[0]?.id).toBe(1);
+		expect(mockSend).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

有料本番 SaaS (AWS Lambda、`DATA_SOURCE=dynamodb`) で **per-child challenge の write が永続しない CRITICAL gap** を根治する Phase 2B。`#2362` PR-7 で導入された `child-challenge-repo.ts` の DynamoDB 実装が `#2263`/`#2280` 緊急 hotfix で「read=空 / write=no-op + logger.warn」化されたまま有料運用されており、**marketplace challenge-set 取込 (顧客レビュー対象経路) が本番で永続せず、UI が「N 件追加しました」と偽る**取込バグの一部になっていた。本 PR で SQLite 挙動 SSOT と機能等価の DynamoDB 本実装を起こし、取込チャレンジが本番で永続するようにする。

## 関連 Issue

- tracking: #2824 (AC5 配下の Phase 2B)。本 PR は `closes` しない (EPIC tracking の 1 phase)。
- exemplar: PR #2820 (Phase 1 = child-activity DynamoDB 本実装、merged)。本 PR は #2820 merge 後に origin/main へ rebase 済 (2B commit のみを cherry-pick、HEAD `4921acde0`)。
- 設計根拠: ADR-0055 (per-child 主軸データモデル原則)、ADR-0010 (Pre-PMF scope)。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `child-challenge-repo.ts` 全 14 method を SQLite 機能等価で DynamoDB 本実装 (stub 16 calls 解消) | unit test `dynamodb-child-challenge-repo.test.ts` の interface 適合 + 各 method 検証 | 28 tests PASS。`findByChildId` / `findActive*` / `findAllByTenant` / `findById` / `insert(Bulk)` / `updateProgress` / `markCompleted` / `claimReward` / `update` / `deleteChallenge` / `copyAcrossChildren` / `deleteByTenantId` を実 send |
| AC2 | key 設計: child partition 同居 (`T#<tid>#CHILD#<childId>` + SK `CHILDCHAL#<paddedId>`)、追加 GSI 不要 | `keys.ts` `childChallengeKey` + test の PK/SK assert | `findByChildId` は単一 partition Query で完結 (test L116-156)。CDK 変更なし |
| AC3 | tenant 横断 read (`findAllByTenant` / `findById` / mutation の id 解決 / `deleteByTenantId`) を Scan で実現 | test の Scan FilterExpression assert | `begins_with(SK, 'CHILDCHAL#') AND begins_with(PK, 'T#<tid>#CHILD#')` + 必要時 `SK = :sk` (test L231-289) |
| AC4 | 数値 ID は `counter.ts` 採番 | `insert` の nextId(ENTITY_NAMES.childChallenge) | test L246「counter 採番 → PutItem」PASS |
| AC5 | `scripts/dynamodb-stub-baseline.json` から本 repo 除去 (ratchet 前進) | `node scripts/check-dynamodb-stub-parity.mjs` | OK: 11 repo / 72 stub method (child-challenge-repo 削除済) |
| AC6 | 設計書同期 (ADR-0001) | `docs/design/08-データベース設計書.md` に DynamoDB キー設計節追記 | child_challenges セクションに キー設計表 + アクセスパターン表を追加 |

## 変更タイプ

- [x] バグ修正 (本番 per-child challenge 永続 gap 根治、CRITICAL の一部)
- [x] リファクタリング (stub → 本実装)
- [x] ドキュメント (設計書同期)

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dynamodb/child-challenge-repo.ts` — stub 全置換 (本実装)
- `src/lib/server/db/dynamodb/keys.ts` — `childChallengeKey` / `childChallengePrefix` 追加、`ENTITY_NAMES.childChallenge` 追加
- `tests/unit/db/dynamodb-child-challenge-repo.test.ts` — 新規 (28 tests)
- `scripts/dynamodb-stub-baseline.json` — child-challenge-repo entry 除去
- `.cspell/project-words.txt` — `CHILDCHAL` 追加
- `docs/design/08-データベース設計書.md` — DynamoDB キー設計節追記

factory (`src/lib/server/db/factory.ts`) は `dynamoChildChallengeRepo` を `IChildChallengeRepo` 型 slot に bind 済 (構造的に互換、svelte-check PASS で確認)。本番経路: cognito Lambda の challenge-set import / admin challenges 表示 / child home の active challenge 取得。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/dynamodb-child-challenge-repo.test.ts` — 28 PASS
- [x] `npx vitest run tests/unit/db/ tests/unit/services/` — 145 files / 2504 tests PASS
- [x] `npx biome check --error-on-warnings` (変更 file) — clean
- [x] `npx svelte-check` — 新規/変更 file に型エラーなし (既存 infra/ module 解決エラーは worktree の node_modules 未 install 由来、本 PR 無関係)
- [x] `node scripts/check-dynamodb-stub-parity.mjs` — OK (baseline 前進)
- [x] `npx cspell` (変更 file) — 0 issues
- SQLite 並行実装整合性 (tests/CLAUDE.md): undefined/null/既定値ハンドリングを SQLite SSOT と一致 (`buildChildChallenge` で schema default を明示)。

## スクリーンショット / ビジュアルデモ

UI 変更なし (server-side DB repo 層のみ)。`.svelte` 変更は rebase で取り込んだ #2818↔#2817 conflict 解消 (`admin/activities/+page.svelte`) のみで、本 PR が新規に UI を変更するものではない。SS 対象外。

## コード品質セルフレビュー (#1481)

- Phase 1 (child-activity) の流儀を踏襲: `stripKeys` / `queryAllItems` / `counter.nextId` 等の共通 helper を再利用し独自実装を最小化。
- child-activity との差分 (interface mutation method が childId を受けず id 単独) を `resolveKeyById` (tenant Scan) で吸収し、コメントで根拠を明記。
- `markCompleted` / `update` は `status` 予約語を `ExpressionAttributeNames` で回避。
- コメントは簡潔 (1-2 行)、経緯は commit message に集約 (dev-session.md §コミット規律)。

## 横展開・影響波及チェック

- DynamoDB / SQLite repo ペア整合: 本実装は SQLite 挙動 SSOT と機能等価 (default 値 / filter 条件 / id→key 解決)。
- `check-dynamodb-stub-parity.mjs` baseline を本 repo 分のみ削除 (Phase 2A `reward-redemption-repo` の並行作業 entry は不変更)。
- 並行作業との conflict 前提 file (`dynamodb-stub-baseline.json` / `08-データベース設計書.md`) は自分の repo 行のみ追加/削除し他行を変更していない。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。stub → 本実装の置換で、本番挙動は「write が永続するようになる」改善方向。
- #2820 merge 後の rebase 完了 (HEAD `4921acde0`)。CI 全緑を確認のうえ Ready 化済。
- レビュー観点: ① key 設計 (child partition 同居 / GSI 不要) の妥当性、② tenant Scan の Pre-PMF 妥当性 (challenge 件数前提)、③ SQLite 機能等価性。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。既存 `TABLE_NAME` (DynamoDB single-table) を使用。CDK 変更なし (新規 SK prefix `CHILDCHAL#` は既存テーブルに乗る、追加 GSI なし)。

## Ready for Review チェックリスト

- [x] CI 全緑を確認する
- [x] 全 AC を満たす実装・テストを完了している
- [x] 設計書を同期している (ADR-0001)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: 実装・テスト・設計書同期完了、rebase 後 CI 全緑)

## QM レビュー結果

(QM 記入欄 — Dev は記入しない)

