### PR TITLE
feat: #2824 Phase 2A — reward-redemption-repo DynamoDB 本実装 (ADR-0055)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -116,6 +116,7 @@ daidaikichi
 daikichi
 daisuki
 dedup
+Denorm
 dependabot
 Dependabot
 Deque
@@ -261,6 +262,7 @@ quickmode
 recalc
 reconsent
 Reconsent
+REDEMPT
 REVD
 Roboto
 sakura

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1150,6 +1150,31 @@ pending_parent_approval
 **ポイント減算タイミング:** `approved` への遷移時のみ `point_ledger` に記録（type: `'reward_redemption'`）。  
 `requested_at` 時点ではポイントを保留しない（シンプルさ優先）。
 
+#### DynamoDB キー設計（single-table、#2824 Phase 2A / ADR-0055）
+
+本番 cognito Lambda は `DATA_SOURCE=dynamodb` で稼働するため、SQLite と機能等価の
+DynamoDB 実装 (`src/lib/server/db/dynamodb/reward-redemption-repo.ts`) を持つ。per-child
+instance を child partition 配下に置き、`findRedemptionRequestsByChild` を**追加 GSI なし**の
+単一 partition Query で完結させる（ADR-0055 §3.1）。
+
+| エンティティ | PK | SK | 補足 |
+|---|---|---|---|
+| reward_redemption_request | `T#<tid>#CHILD#<childId>` | `REDEMPT#<paddedId>` | id は 8 桁 0 埋め。special_rewards / activity_logs と同 partition に同居。JOIN 代替に `childName` / `rewardTitle` / `rewardIcon` / `rewardPoints` を insert 時に非正規化保存 |
+
+| アクセスパターン | 操作 | 条件 |
+|---|---|---|
+| `findRedemptionRequestsByChild(childId)` | Query | `PK = T#<tid>#CHILD#<childId> AND begins_with(SK, 'REDEMPT#')`。requested_at 降順は in-memory（SQLite SSOT と一致） |
+| `insertRedemptionRequest` | counter 採番 → child / reward 解決 → PutItem | status default = `pending_parent_approval`（SQLite schema 一致）。childName / reward fields を非正規化保存し tenant 横断 read の N+1 を回避 |
+| `findRedemptionRequestsByTenant` / `expireOldRedemptions` / `hasPendingByReward` | Scan（`begins_with(PK, T#<tid>#CHILD#)` + `begins_with(SK, REDEMPT#)`） | child partition に分散するため tenant 横断は Scan。親確認 / cron / 削除（低頻度）のみで GSI 不要（Pre-PMF / ADR-0010）。status / childId / limit は in-memory filter |
+| `updateRedemptionRequestStatus(id)` / `markRedemptionResultShown(id)` | Scan（id filter）で PK/SK 解決 → UpdateItem（`ALL_NEW`） | childId を受けないため id で 1 件特定（special-reward-repo.markRewardShown と同型）。undefined はスキップ / null は明示 SET（SQLite `.set({...})` 等価） |
+| `findPendingByChildAndReward` / `findUnshownResultByChild` | Query（child partition）+ in-memory filter | 二重申請 / 未表示通知。後者は reward 結合フィールドを露出 |
+| `deleteByTenantId` | Scan → BatchWrite | `CHILD#*` 配下の `REDEMPT#` を削除（`deleteItemsByPkPrefix`） |
+
+**残高整合:** ポイント減算は service 層（`reward-redemption-service.approveRedemption`）が
+`insertPointEntry` で別途行う（SQLite と同じ責務分割）。本 repo は status 更新のみ担い残高に
+触れないため TransactWriteItems は不要。新規 SK prefix `REDEMPT#` は既存テーブルにそのまま
+乗るため **CDK 変更不要**（追加 GSI なし）。
+
 ### checklist_templates
 
 #### 設計背景（#2362 PR-5 / ADR-0055: family master 化）
@@ -2322,3 +2347,4 @@ per-child refactor (ADR-0055) で頻発する子供 UI 破綻を pixelmatch base
 | 2026-05-27 | 5.14 | #2519 §8.7「data 保全 gate」追加。§8.6 (予防) の盲点を実行時に埋める 2 gate を実装: (1) runtime data orphan 自動 gate (`data-integrity-guards.ts` `assertNoDataOrphans`、startup で core 4 table の FK orphan 検出 + Discord alert + test throw)、(2) backup restore + integrity 検証 (`verify-backup-restore.cjs`、最新 backup を restore して integrity_check / foreign_key_check / row count > 0 を assert、NUC cron 組込 + 失敗時 alert)。`backup-db.cjs` の integrity を table 数 → integrity_check/foreign_key_check に格上げ |
 | 2026-05-27 | 5.15 | #2520 §8.6「機械検証」を将来予告から実装済に更新。(1) `scripts/check-schema-migration-completeness.mjs` を最小版実装 (#2507 予告) — schema.ts 破壊的変更 (DROP COLUMN / FK target / NOT NULL / cross-table flip) 検出時のみ lazy-startup-migrations.ts 同期を blocker 化 (ci.yml `schema-migration-completeness-check`)。(2) 既存 DB upgrade path test — `tests/fixtures/legacy-schema/<YYYY-MM>.sql` snapshot + `tests/integration/db/legacy-schema-upgrade.test.ts` で #2508 を捕捉 (fresh DB only の盲点解消)。(3) child home 5 mode visual baseline (`scripts/child-home-baseline/`、pixelmatch warn)。(4) CWE-598 child 越境記録ガード (`recordActivity` を `findActivityByIdForChild` 3 軸スコープ化、ADR-0055 §3.1)。schema 自体に変更なし (gate / test / guard 追加のメタ更新) |
 | 2026-05-30 | 5.16 | #2641 + #2642 + #2675 + #2685 (Phase 5 子 3+4 / Phase 6 子 3 / Phase 7 PR-1) — **Billing 再設計 expand 段階**。(1) `stripe_webhook_events` 新規 table 追加 (Stripe Webhook 冪等性 dedup、event_id PK + 6 列 + 2 index、30 日 retention ADR-0049 整合、DynamoDB は `PK=STRIPE_WEBHOOK_EVENT` single-partition + native TTL)。(2) `archived_reason` enum 3 値 SSOT 化 — `src/lib/domain/archive-types.ts` 新規 (`ARCHIVED_REASONS = ['trial_expired', 'downgrade_user_selected', 'dunning_canceled'] as const`) + drizzle schema 4 location (`children` / `activities` / `child_activities` / `checklist_templates`) で `text(..., { enum: ARCHIVED_REASONS })` 制約適用 + `getRetentionDays(reason)` helper。(3) lazy migration `migrateBillingPhase6` — table 新規作成 + 既存 archived row の NULL → `'downgrade_user_selected'` 補充 (4 location × idempotent)。`code 変更ゼロ` の expand 段階で後続 PR の前提を配備、handler 統合は Phase 7 PR-4a 連動。詳細は `docs/design/billing-redesign/phase5-webhook-idempotency-architecture.md` / `phase5-archive-unified-architecture.md` / `phase6-db-migration-plan.md` 参照 |
+| 2026-06-04 | 5.17 | #2824 Phase 2A (ADR-0055) — `reward_redemption_requests` の DynamoDB 本実装。本 repo は #2263 hotfix で「read=空 / write=no-op」化され、本番 cognito Lambda (`DATA_SOURCE=dynamodb`) でごほうび交換 (記録 → ポイント → 交換) が永続しない致命的 gap だった。SQLite 機能等価で本実装。キー設計: PK `T#<tid>#CHILD#<childId>` + SK `REDEMPT#<paddedId>` (child partition 同居、`findRedemptionRequestsByChild` を追加 GSI なし単一 partition Query で完結)。JOIN 代替に childName / rewardTitle / rewardIcon / rewardPoints を insert 時に非正規化保存し tenant 横断 read の N+1 を回避。id のみ受ける update / markShown は tenant Scan + id filter で PK/SK 解決 (special-reward-repo.markRewardShown 同型)。残高減算は service 層責務のため repo は status 更新のみ (TransactWriteItems 不要)。stub baseline (`scripts/dynamodb-stub-baseline.json`) から本 repo を削除 (12 → 11 repo 前進)。CDK 変更なし。schema 自体に変更なし (DynamoDB 実装の追加) |

--- a/scripts/dynamodb-stub-baseline.json
+++ b/scripts/dynamodb-stub-baseline.json
@@ -74,18 +74,6 @@
 		"findByTenantAndDateRange",
 		"upsert"
 	],
-	"src/lib/server/db/dynamodb/reward-redemption-repo.ts": [
-		"deleteByTenantId",
-		"expireOldRedemptions",
-		"findPendingByChildAndReward",
-		"findRedemptionRequestsByChild",
-		"findRedemptionRequestsByTenant",
-		"findUnshownResultByChild",
-		"hasPendingByReward",
-		"insertRedemptionRequest",
-		"markRedemptionResultShown",
-		"updateRedemptionRequestStatus"
-	],
 	"src/lib/server/db/dynamodb/sibling-cheer-repo.ts": [
 		"countTodayCheersFrom",
 		"deleteByTenantId",

--- a/src/lib/server/db/dynamodb/keys.ts
+++ b/src/lib/server/db/dynamodb/keys.ts
@@ -316,6 +316,30 @@ export function specialRewardPrefix(): string {
 }
 
 /**
+ * Reward redemption request (#1337 / #2824 Phase 2A / ADR-0055):
+ *   PK = T#<tenantId>#CHILD#<childId>, SK = REDEMPT#<paddedId>
+ *
+ * per-child instance を child partition 配下に置き (special_rewards / activity_logs と同居)、
+ * `findRedemptionRequestsByChild` を単一 partition Query (begins_with(SK, 'REDEMPT#')) で
+ * 完結させる。child 軸を構造的に担保し追加 GSI 不要 (ADR-0055 §3.1)。
+ */
+export function rewardRedemptionKey(
+	childId: number,
+	requestId: number,
+	tenantId: string,
+): DynamoKey {
+	return {
+		PK: tenantPK(`${PREFIX.CHILD}#${childId}`, tenantId),
+		SK: `REDEMPT#${padId(requestId)}`,
+	};
+}
+
+/** Reward redemption SK prefix for querying all requests of a child */
+export function rewardRedemptionPrefix(): string {
+	return 'REDEMPT#';
+}
+
+/**
  * Checklist template: PK=T#<tenantId>#CKTPL, SK=CKTPL#<id>
  * #2362 PR-5 (ADR-0055): family master 化に伴い CHILD#<cId> 配下 → tenant scope に変更。
  */
@@ -747,6 +771,7 @@ export const ENTITY_NAMES = {
 	title: 'title',
 	childTitle: 'childTitle',
 	specialReward: 'specialReward',
+	rewardRedemption: 'rewardRedemption',
 	checklistTemplate: 'checklistTemplate',
 	checklistAssignment: 'checklistAssignment',
 	checklistItem: 'checklistItem',

--- a/src/lib/server/db/dynamodb/reward-redemption-repo.ts
+++ b/src/lib/server/db/dynamodb/reward-redemption-repo.ts
@@ -1,113 +1,444 @@
 // src/lib/server/db/dynamodb/reward-redemption-repo.ts
-// DynamoDB implementation of IRewardRedemptionRepo
+// ごほうびショップ交換申請リポジトリ — DynamoDB 本実装 (#1337 / #2824 Phase 2A / ADR-0055)
 //
-// #2263 hotfix: 旧バージョンの未実装エラー throw で本番 500 を引き起こしうるため、
-// Pre-PMF fallback (read = 空 / write = no-op + logger.warn) に置換。
-// ごほうび交換機能は本番未活用 (ADR-0010 Pre-PMF Bucket B = まだ作らない)。
+// IRewardRedemptionRepo を SQLite 実装 (sqlite/reward-redemption-repo.ts、挙動 SSOT) と
+// 機能等価に DynamoDB single-table で実装する。
+//
+// 経緯: 本 repo は #2263 hotfix で「read=空 / write=no-op + logger.warn」化された。
+//   ごほうび交換は子供のコアループ (記録 → ポイント → 交換) の終端であり、本番 cognito
+//   Lambda (AUTH_MODE=cognito + DATA_SOURCE=dynamodb) で交換申請が永続しないのは致命的。
+//   本実装で根治する。
+//
+// key 設計 (keys.ts §rewardRedemptionKey):
+//   PK = T#<tenantId>#CHILD#<childId>   (child partition、special_rewards 等と同居)
+//   SK = REDEMPT#<paddedId>             (8 桁 0 埋め、辞書順)
+//   → findRedemptionRequestsByChild は単一 partition Query で完結し GSI 不要 (ADR-0055 §3.1)。
+//
+// 結合フィールドの非正規化:
+//   SQLite の findRedemptionRequestsByTenant / findUnshownResultByChild は children +
+//   special_rewards を JOIN して childName / rewardTitle / rewardIcon / rewardPoints を返す。
+//   DynamoDB では tenant 横断クエリ時の N+1 を避けるため、insert 時に上記を解決して item に
+//   非正規化保存する (RedemptionRequestRow 返り値には含めず、With* 型でのみ露出)。
+//
+// 残高整合: ポイント減算は service 層 (reward-redemption-service.approveRedemption) が
+//   insertPointEntry で別途行う (SQLite と同じ責務分割)。本 repo は status 更新のみ担い、
+//   残高に触れないため TransactWriteItems は不要。
+//
+// 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/reward-redemption-repo.ts (SSOT)
 
-import { logger } from '$lib/server/logger';
+import { PutCommand, QueryCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type {
 	IRewardRedemptionRepo,
 	RedemptionRequestRow,
 	RedemptionRequestWithDetails,
 	RedemptionRequestWithReward,
 } from '../interfaces/reward-redemption-repo.interface';
+import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
+import {
+	childPK,
+	ENTITY_NAMES,
+	rewardRedemptionKey,
+	rewardRedemptionPrefix,
+	specialRewardPrefix,
+	tenantPK,
+} from './keys';
+import { findChildByIdRaw, stripKeys } from './repo-helpers';
 
-const SERVICE = 'reward-redemption-repo.dynamodb';
+const PREFIX = rewardRedemptionPrefix();
+const THIRTY_DAYS_SECONDS = 30 * 24 * 60 * 60;
 
-function warnRead(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] read fallback: returning empty (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
+// item に保存する非正規化フィールド (JOIN 代替)。RedemptionRequestRow には含めない。
+interface DenormFields {
+	childName: string;
+	rewardTitle: string;
+	rewardIcon: string | null;
+	rewardPoints: number;
 }
 
-function warnWrite(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] write fallback: no-op (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
+// DynamoDB item から PK/SK + 非正規化フィールドを除いた RedemptionRequestRow を作る。
+function toRow(item: Record<string, unknown>): RedemptionRequestRow {
+	const stripped = stripKeys(item) as Record<string, unknown>;
+	return {
+		id: stripped.id as number,
+		childId: stripped.childId as number,
+		rewardId: stripped.rewardId as number,
+		requestedAt: stripped.requestedAt as number,
+		status: stripped.status as string,
+		parentNote: (stripped.parentNote ?? null) as string | null,
+		resolvedAt: (stripped.resolvedAt ?? null) as number | null,
+		resolvedByParentId: (stripped.resolvedByParentId ?? null) as number | null,
+		shownToChildAt: (stripped.shownToChildAt ?? null) as number | null,
+	};
 }
+
+// 非正規化フィールドを取り出す (旧データ防御で欠落時は既定値)。
+function extractDenorm(item: Record<string, unknown>): DenormFields {
+	return {
+		childName: (item.childName ?? '') as string,
+		rewardTitle: (item.rewardTitle ?? '') as string,
+		rewardIcon: (item.rewardIcon ?? null) as string | null,
+		rewardPoints: (item.rewardPoints ?? 0) as number,
+	};
+}
+
+/**
+ * child partition から指定 special reward (id) を解決する。
+ * SQLite の JOIN special_rewards 相当。SK は REWARD#<ts>#<id> のため child の REWARD# を
+ * Query し id 一致を探す (service の findSpecialRewards と同じパターン)。
+ */
+async function findRewardFields(
+	childId: number,
+	rewardId: number,
+	tenantId: string,
+): Promise<{ title: string; icon: string | null; points: number } | undefined> {
+	const result = await getDocClient().send(
+		new QueryCommand({
+			TableName: TABLE_NAME,
+			KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+			FilterExpression: 'id = :rid',
+			ExpressionAttributeValues: {
+				':pk': childPK(childId, tenantId),
+				':prefix': specialRewardPrefix(),
+				':rid': rewardId,
+			},
+		}),
+	);
+	const item = (result.Items ?? [])[0];
+	if (!item) return undefined;
+	return {
+		title: (item.title ?? '') as string,
+		icon: (item.icon ?? null) as string | null,
+		points: (item.points ?? 0) as number,
+	};
+}
+
+// ============================================================
+// insertRedemptionRequest — 交換申請を作成
+// ============================================================
 
 export const insertRedemptionRequest: IRewardRedemptionRepo['insertRedemptionRequest'] = async (
 	input,
 	tenantId,
 ): Promise<RedemptionRequestRow> => {
-	warnWrite('insertRedemptionRequest', {
-		childId: input.childId,
-		rewardId: input.rewardId,
-		tenantId,
-	});
-	return {
-		id: 0,
+	const id = await nextId(ENTITY_NAMES.rewardRedemption, tenantId);
+
+	// JOIN 代替: childName / reward fields を解決し item に非正規化保存。
+	const child = await findChildByIdRaw(input.childId, tenantId);
+	const reward = await findRewardFields(input.childId, input.rewardId, tenantId);
+
+	const row: RedemptionRequestRow = {
+		id,
 		childId: input.childId,
 		rewardId: input.rewardId,
 		requestedAt: input.requestedAt,
-		status: 'pending',
+		// SQLite schema default と一致 (#1337)。
+		status: 'pending_parent_approval',
 		parentNote: null,
 		resolvedAt: null,
 		resolvedByParentId: null,
 		shownToChildAt: null,
 	};
+
+	const denorm: DenormFields = {
+		childName: child?.nickname ?? '',
+		rewardTitle: reward?.title ?? '',
+		rewardIcon: reward?.icon ?? null,
+		rewardPoints: reward?.points ?? 0,
+	};
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...rewardRedemptionKey(input.childId, id, tenantId),
+				...row,
+				...denorm,
+			},
+		}),
+	);
+
+	return row;
 };
+
+// ============================================================
+// findRedemptionRequestsByChild — 子供の申請一覧 (最新順)
+// ============================================================
 
 export const findRedemptionRequestsByChild: IRewardRedemptionRepo['findRedemptionRequestsByChild'] =
 	async (childId, tenantId): Promise<RedemptionRequestRow[]> => {
-		warnRead('findRedemptionRequestsByChild', { childId, tenantId });
-		return [];
+		const items = await queryChildRedemptions(childId, tenantId);
+		// SQLite: ORDER BY requested_at DESC。in-memory で同順に揃える。
+		const rows = items.map(toRow);
+		rows.sort((a, b) => b.requestedAt - a.requestedAt);
+		return rows;
 	};
+
+// ============================================================
+// findRedemptionRequestsByTenant — 親向け一覧 (childName / reward 結合付き)
+// ============================================================
 
 export const findRedemptionRequestsByTenant: IRewardRedemptionRepo['findRedemptionRequestsByTenant'] =
 	async (tenantId, opts): Promise<RedemptionRequestWithDetails[]> => {
-		warnRead('findRedemptionRequestsByTenant', { tenantId, opts });
-		return [];
+		// child partition に分散するため tenant 配下を Scan (低頻度: 親が見守り画面で確認時のみ)。
+		const items = await scanTenantRedemptions(tenantId);
+
+		let rows: RedemptionRequestWithDetails[] = items.map((item) => ({
+			...toRow(item),
+			...extractDenorm(item),
+		}));
+
+		// SQLite の WHERE 相当 (status / childId filter)。
+		if (opts?.status) {
+			rows = rows.filter((r) => r.status === opts.status);
+		}
+		if (opts?.childId) {
+			rows = rows.filter((r) => r.childId === opts.childId);
+		}
+
+		// ORDER BY requested_at DESC + LIMIT。
+		rows.sort((a, b) => b.requestedAt - a.requestedAt);
+		return rows.slice(0, opts?.limit ?? 50);
 	};
+
+// ============================================================
+// updateRedemptionRequestStatus — 申請状態を更新
+// ============================================================
 
 export const updateRedemptionRequestStatus: IRewardRedemptionRepo['updateRedemptionRequestStatus'] =
 	async (id, updates, tenantId): Promise<RedemptionRequestRow | undefined> => {
-		warnWrite('updateRedemptionRequestStatus', { id, status: updates.status, tenantId });
-		return undefined;
+		const found = await findRedemptionItemById(id, tenantId);
+		if (!found) return undefined;
+
+		const sets: string[] = ['#status = :status'];
+		const names: Record<string, string> = { '#status': 'status' };
+		const values: Record<string, unknown> = { ':status': updates.status };
+
+		// undefined はスキップ、null は明示的に SET (SQLite .set({...}) と一致)。
+		if (updates.parentNote !== undefined) {
+			sets.push('parentNote = :parentNote');
+			values[':parentNote'] = updates.parentNote;
+		}
+		if (updates.resolvedAt !== undefined) {
+			sets.push('resolvedAt = :resolvedAt');
+			values[':resolvedAt'] = updates.resolvedAt;
+		}
+		if (updates.resolvedByParentId !== undefined) {
+			sets.push('resolvedByParentId = :resolvedByParentId');
+			values[':resolvedByParentId'] = updates.resolvedByParentId;
+		}
+
+		const result = await getDocClient().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: { PK: found.PK, SK: found.SK },
+				UpdateExpression: `SET ${sets.join(', ')}`,
+				ExpressionAttributeNames: names,
+				ExpressionAttributeValues: values,
+				ReturnValues: 'ALL_NEW',
+			}),
+		);
+		if (!result.Attributes) return undefined;
+		return toRow(result.Attributes);
 	};
+
+// ============================================================
+// findPendingByChildAndReward — 二重申請チェック
+// ============================================================
 
 export const findPendingByChildAndReward: IRewardRedemptionRepo['findPendingByChildAndReward'] =
 	async (childId, rewardId, tenantId): Promise<RedemptionRequestRow | undefined> => {
-		warnRead('findPendingByChildAndReward', { childId, rewardId, tenantId });
-		return undefined;
+		const items = await queryChildRedemptions(childId, tenantId);
+		const match = items.find(
+			(item) => item.rewardId === rewardId && item.status === 'pending_parent_approval',
+		);
+		return match ? toRow(match) : undefined;
 	};
+
+// ============================================================
+// findUnshownResultByChild — 子供の未表示の承認/却下通知 (reward 結合付き)
+// ============================================================
 
 export const findUnshownResultByChild: IRewardRedemptionRepo['findUnshownResultByChild'] = async (
 	childId,
 	tenantId,
 ): Promise<RedemptionRequestWithReward | undefined> => {
-	warnRead('findUnshownResultByChild', { childId, tenantId });
-	return undefined;
+	const items = await queryChildRedemptions(childId, tenantId);
+	// SQLite: status IN (approved, rejected) AND shown_to_child_at IS NULL
+	//   ORDER BY resolved_at DESC LIMIT 1
+	const candidates = items
+		.filter(
+			(item) =>
+				(item.status === 'approved' || item.status === 'rejected') &&
+				(item.shownToChildAt === null || item.shownToChildAt === undefined),
+		)
+		.sort((a, b) => ((b.resolvedAt as number) ?? 0) - ((a.resolvedAt as number) ?? 0));
+
+	const top = candidates[0];
+	if (!top) return undefined;
+	const denorm = extractDenorm(top);
+	return {
+		...toRow(top),
+		rewardTitle: denorm.rewardTitle,
+		rewardIcon: denorm.rewardIcon,
+	};
 };
+
+// ============================================================
+// markRedemptionResultShown — 未表示通知を表示済みにする
+// ============================================================
 
 export const markRedemptionResultShown: IRewardRedemptionRepo['markRedemptionResultShown'] = async (
 	id,
 	tenantId,
 ): Promise<RedemptionRequestRow | undefined> => {
-	warnWrite('markRedemptionResultShown', { id, tenantId });
-	return undefined;
+	const found = await findRedemptionItemById(id, tenantId);
+	if (!found) return undefined;
+	const now = Math.floor(Date.now() / 1000);
+	const result = await getDocClient().send(
+		new UpdateCommand({
+			TableName: TABLE_NAME,
+			Key: { PK: found.PK, SK: found.SK },
+			UpdateExpression: 'SET shownToChildAt = :now',
+			ExpressionAttributeValues: { ':now': now },
+			ReturnValues: 'ALL_NEW',
+		}),
+	);
+	if (!result.Attributes) return undefined;
+	return toRow(result.Attributes);
 };
+
+// ============================================================
+// expireOldRedemptions — 30 日以上 pending を expired に移行 (cron)
+// ============================================================
 
 export const expireOldRedemptions: IRewardRedemptionRepo['expireOldRedemptions'] = async (
 	tenantId,
 ): Promise<number> => {
-	warnWrite('expireOldRedemptions', { tenantId });
-	return 0;
+	const cutoff = Math.floor(Date.now() / 1000) - THIRTY_DAYS_SECONDS;
+	const items = await scanTenantRedemptions(tenantId);
+	const targets = items.filter(
+		(item) => item.status === 'pending_parent_approval' && (item.requestedAt as number) < cutoff,
+	);
+	for (const item of targets) {
+		await getDocClient().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: { PK: item.PK as string, SK: item.SK as string },
+				UpdateExpression: 'SET #status = :expired',
+				ExpressionAttributeNames: { '#status': 'status' },
+				ExpressionAttributeValues: { ':expired': 'expired' },
+			}),
+		);
+	}
+	return targets.length;
 };
+
+// ============================================================
+// hasPendingByReward — 報酬削除前の pending チェック
+// ============================================================
 
 export const hasPendingByReward: IRewardRedemptionRepo['hasPendingByReward'] = async (
 	rewardId,
 	tenantId,
 ): Promise<boolean> => {
-	warnRead('hasPendingByReward', { rewardId, tenantId });
-	return false;
+	const items = await scanTenantRedemptions(tenantId);
+	return items.some(
+		(item) => item.rewardId === rewardId && item.status === 'pending_parent_approval',
+	);
 };
+
+// ============================================================
+// deleteByTenantId — テナントの全申請を削除
+// ============================================================
 
 export const deleteByTenantId: IRewardRedemptionRepo['deleteByTenantId'] = async (
 	tenantId,
 ): Promise<void> => {
-	warnWrite('deleteByTenantId', { tenantId });
+	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), PREFIX);
 };
+
+// ============================================================
+// 内部ヘルパ
+// ============================================================
+
+/** 指定 child partition の REDEMPT# item を全件 Query する (ページング対応)。 */
+async function queryChildRedemptions(
+	childId: number,
+	tenantId: string,
+): Promise<Record<string, unknown>[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				ExpressionAttributeValues: {
+					':pk': childPK(childId, tenantId),
+					':prefix': PREFIX,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) items.push(item);
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return items;
+}
+
+/**
+ * tenant 配下の REDEMPT# item を Scan する。
+ * redemption は child partition (PK=CHILD#<cId>) に分散するため tenant 横断は Scan が必要。
+ * 親の確認 / cron / 削除 (低頻度) のみに使われるため Pre-PMF では GSI 不要 (ADR-0010)。
+ */
+async function scanTenantRedemptions(tenantId: string): Promise<Record<string, unknown>[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: 'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix)',
+				ExpressionAttributeValues: {
+					':tenantPrefix': tenantPK('CHILD#', tenantId),
+					':skPrefix': PREFIX,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) items.push(item);
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return items;
+}
+
+/**
+ * id だけ受け取る update / markShown 用に、tenant 配下を Scan して PK/SK + item を解決する。
+ * SK は REDEMPT#<id> だが childId が不明なため tenant Scan + id filter で 1 件特定する
+ * (special-reward-repo.markRewardShown と同じパターン)。
+ */
+async function findRedemptionItemById(
+	id: number,
+	tenantId: string,
+): Promise<({ PK: string; SK: string } & Record<string, unknown>) | undefined> {
+	const result = await getDocClient().send(
+		new ScanCommand({
+			TableName: TABLE_NAME,
+			FilterExpression:
+				'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
+			ExpressionAttributeValues: {
+				':tenantPrefix': tenantPK('CHILD#', tenantId),
+				':skPrefix': PREFIX,
+				':id': id,
+			},
+			Limit: 1,
+		}),
+	);
+	const item = (result.Items ?? [])[0];
+	if (!item) return undefined;
+	return item as { PK: string; SK: string } & Record<string, unknown>;
+}

--- a/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
+++ b/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
@@ -30,7 +30,8 @@ import * as battleRepo from '../../../src/lib/server/db/dynamodb/battle-repo';
 import * as cloudExportRepo from '../../../src/lib/server/db/dynamodb/cloud-export-repo';
 import * as messageRepo from '../../../src/lib/server/db/dynamodb/message-repo';
 import * as reportDailySummaryRepo from '../../../src/lib/server/db/dynamodb/report-daily-summary-repo';
-import * as rewardRedemptionRepo from '../../../src/lib/server/db/dynamodb/reward-redemption-repo';
+// #2824 Phase 2A (ADR-0055): reward-redemption-repo は本実装済のため stub fallback テスト対象外。
+//   機能等価性は tests/unit/db/dynamodb-reward-redemption-repo.test.ts (AWS SDK mock) で検証する。
 // #2295 (EPIC #2294 ①): season-event-repo / tenant-event-repo 削除済 (2026-05-19)
 // #2458 (Path B sibling drop): sibling-challenge-repo 削除済 (2026-05-26)、child-challenge-repo へ移行
 import * as siblingCheerRepo from '../../../src/lib/server/db/dynamodb/sibling-cheer-repo';
@@ -155,37 +156,11 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('reward-redemption-repo', () => {
-		it('全 method が throw しない', async () => {
-			await expect(
-				rewardRedemptionRepo.insertRedemptionRequest(
-					{ childId: 1, rewardId: 1, requestedAt: Date.now() },
-					TENANT,
-				),
-			).resolves.toBeTruthy();
-			await expect(rewardRedemptionRepo.findRedemptionRequestsByChild(1, TENANT)).resolves.toEqual(
-				[],
-			);
-			await expect(rewardRedemptionRepo.findRedemptionRequestsByTenant(TENANT)).resolves.toEqual(
-				[],
-			);
-			await expect(
-				rewardRedemptionRepo.updateRedemptionRequestStatus(1, { status: 'approved' }, TENANT),
-			).resolves.toBeUndefined();
-			await expect(
-				rewardRedemptionRepo.findPendingByChildAndReward(1, 1, TENANT),
-			).resolves.toBeUndefined();
-			await expect(
-				rewardRedemptionRepo.findUnshownResultByChild(1, TENANT),
-			).resolves.toBeUndefined();
-			await expect(
-				rewardRedemptionRepo.markRedemptionResultShown(1, TENANT),
-			).resolves.toBeUndefined();
-			await expect(rewardRedemptionRepo.expireOldRedemptions(TENANT)).resolves.toBe(0);
-			await expect(rewardRedemptionRepo.hasPendingByReward(1, TENANT)).resolves.toBe(false);
-			await expect(rewardRedemptionRepo.deleteByTenantId(TENANT)).resolves.toBeUndefined();
-		});
-	});
+	// #2824 Phase 2A (ADR-0055): reward-redemption-repo は本実装済 (stub 除外)。
+	//   ごほうび交換 (記録 → ポイント → 交換) が本番 DynamoDB Lambda で永続する。本実装の
+	//   機能等価性テストは dynamodb-reward-redemption-repo.test.ts に分離。ここで stub 前提の
+	//   assert を残すと「実装済なのに stub 期待」で誤った退行 gate になるため除外する
+	//   (他 repo の fallback assert は維持 = assertion 弱体化に該当しない)。
 
 	// #2458 (Path B sibling drop): sibling-challenge-repo describe 削除済 (2026-05-26)、
 	// repo / table 物理 drop 済。per-child child-challenge-repo に移行 (ADR-0055 / User §6)。
@@ -257,20 +232,21 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('regression guard: 全 9 repo の Promise.all で reject されない', () => {
-		it('SSR /preschool/home の典型的な 9 repo 並列呼び出しが全 fulfill する', async () => {
+	describe('regression guard: 全 8 repo の Promise.all で reject されない', () => {
+		it('SSR /preschool/home の典型的な 8 repo 並列呼び出しが全 fulfill する', async () => {
 			// #2295 (EPIC #2294 ①): seasonEventRepo / tenantEventRepo 削除済 (2026-05-19)、12 → 10 repo
 			// #2458 (Path B sibling drop): siblingChallengeRepo 削除済 (2026-05-26)、10 → 9 repo
 			// #2263 regression hotfix: childActivityRepo を stub fallback に置換 (9 → 10 repo)
 			// #2824 (ADR-0055): childActivityRepo を本実装化したため stub fallback guard から除外
 			//   (本実装は AWS SDK mock 必須 → dynamodb-child-activity-repo.test.ts で検証)。10 → 9 repo
+			// #2824 Phase 2A (ADR-0055): rewardRedemptionRepo を本実装化したため除外
+			//   (本実装は AWS SDK mock 必須 → dynamodb-reward-redemption-repo.test.ts で検証)。9 → 8 repo
 			const results = await Promise.allSettled([
 				autoChallengeRepo.findActiveByChild(1, TENANT),
 				battleRepo.findTodayBattle(1, TODAY, TENANT),
 				cloudExportRepo.findByTenant(TENANT),
 				messageRepo.findUnshownMessage(1, TENANT),
 				reportDailySummaryRepo.findByChildAndDateRange(1, TODAY, TODAY, TENANT),
-				rewardRedemptionRepo.findUnshownResultByChild(1, TENANT),
 				siblingCheerRepo.findUnshownCheers(1, TENANT),
 				stampCardRepo.findCardByChildAndWeek(1, '2026-05-12', TENANT),
 				viewerTokenRepo.findByTenant(TENANT),

--- a/tests/unit/db/dynamodb-reward-redemption-repo.test.ts
+++ b/tests/unit/db/dynamodb-reward-redemption-repo.test.ts
@@ -1,0 +1,534 @@
+/**
+ * tests/unit/db/dynamodb-reward-redemption-repo.test.ts
+ *
+ * #2824 Phase 2A / ADR-0055: DynamoDB reward-redemption-repo 本実装の単体テスト。
+ *
+ * AWS SDK を vi.hoisted mock で置き換え、SQLite 実装 (sqlite/reward-redemption-repo.ts、
+ * 挙動 SSOT) と機能等価であることを method ごとに検証する:
+ *   - 正しい Command + key で send する (child partition Query / tenant Scan / by-id 解決)
+ *   - response を正しく型変換する (toRow / 非正規化フィールド露出)
+ *   - SQLite 機能等価 (status default / 最新順 sort / filter / 二重申請 / 期限切れ / 残高非干渉)
+ *
+ * 背景: 本 repo は #2263 hotfix で read=空 / write=no-op 化され、本番 DynamoDB Lambda で
+ *   ごほうび交換 (記録 → ポイント → 交換) が永続しない致命的 gap になっていた。本テストは
+ *   本実装の機能等価性を回帰固定する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const {
+	mockSend,
+	MockGetCommand,
+	MockPutCommand,
+	MockQueryCommand,
+	MockUpdateCommand,
+	MockScanCommand,
+} = vi.hoisted(() => {
+	const send = vi.fn();
+	class Cmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	return {
+		mockSend: send,
+		MockGetCommand: class extends Cmd {},
+		MockPutCommand: class extends Cmd {},
+		MockQueryCommand: class extends Cmd {},
+		MockUpdateCommand: class extends Cmd {},
+		MockScanCommand: class extends Cmd {},
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	GetCommand: MockGetCommand,
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	UpdateCommand: MockUpdateCommand,
+	ScanCommand: MockScanCommand,
+	BatchWriteCommand: class {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	},
+}));
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/reward-redemption-repo');
+}
+
+const TENANT = 'tenant-1';
+const CHILD_ID = 42;
+
+/** child partition の redemption DynamoDB item を組み立てる (PK/SK + 属性 + 非正規化)。 */
+function makeItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const id = (over.id as number) ?? 1;
+	const childId = (over.childId as number) ?? CHILD_ID;
+	return {
+		PK: `T#${TENANT}#CHILD#${childId}`,
+		SK: `REDEMPT#${String(id).padStart(8, '0')}`,
+		id,
+		childId,
+		rewardId: 7,
+		requestedAt: 1700000000,
+		status: 'pending_parent_approval',
+		parentNote: null,
+		resolvedAt: null,
+		resolvedByParentId: null,
+		shownToChildAt: null,
+		// 非正規化 (JOIN 代替)
+		childName: 'けんた',
+		rewardTitle: 'アイスクリーム',
+		rewardIcon: '🍦',
+		rewardPoints: 100,
+		...over,
+	};
+}
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// insertRedemptionRequest
+// ============================================================
+
+describe('insertRedemptionRequest', () => {
+	it('counter 採番 → child/reward を解決 → PutItem し pending_parent_approval row を返す', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 11 } }) // nextId
+			.mockResolvedValueOnce({ Item: { PK: 'p', SK: 'PROFILE', id: CHILD_ID, nickname: 'けんた' } }) // findChildByIdRaw (GetItem)
+			.mockResolvedValueOnce({
+				Items: [{ id: 7, title: 'アイスクリーム', icon: '🍦', points: 100 }],
+			}) // reward Query
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insertRedemptionRequest } = await loadRepo();
+		const row = await insertRedemptionRequest(
+			{ childId: CHILD_ID, rewardId: 7, requestedAt: 1700000000 },
+			TENANT,
+		);
+
+		expect(row).toMatchObject({
+			id: 11,
+			childId: CHILD_ID,
+			rewardId: 7,
+			requestedAt: 1700000000,
+			status: 'pending_parent_approval',
+			parentNote: null,
+			resolvedAt: null,
+			shownToChildAt: null,
+		});
+
+		const putCall = mockSend.mock.calls[3]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(putCall.input.Item?.SK).toBe('REDEMPT#00000011');
+		// 非正規化フィールドが item に保存される (JOIN 代替)
+		expect(putCall.input.Item?.childName).toBe('けんた');
+		expect(putCall.input.Item?.rewardTitle).toBe('アイスクリーム');
+		expect(putCall.input.Item?.rewardIcon).toBe('🍦');
+		expect(putCall.input.Item?.rewardPoints).toBe(100);
+	});
+
+	it('child / reward が不在でも throw せず空文字 / 0 で非正規化する', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 1 } })
+			.mockResolvedValueOnce({ Item: undefined }) // child 不在
+			.mockResolvedValueOnce({ Items: [] }) // reward 不在
+			.mockResolvedValueOnce({});
+		const { insertRedemptionRequest } = await loadRepo();
+		const row = await insertRedemptionRequest(
+			{ childId: CHILD_ID, rewardId: 7, requestedAt: 1 },
+			TENANT,
+		);
+		expect(row.id).toBe(1);
+		const putCall = mockSend.mock.calls[3]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.childName).toBe('');
+		expect(putCall.input.Item?.rewardPoints).toBe(0);
+	});
+});
+
+// ============================================================
+// findRedemptionRequestsByChild
+// ============================================================
+
+describe('findRedemptionRequestsByChild', () => {
+	it('child partition を Query し requestedAt 降順で row を返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, requestedAt: 100 }),
+				makeItem({ id: 2, requestedAt: 300 }),
+				makeItem({ id: 3, requestedAt: 200 }),
+			],
+		});
+		const { findRedemptionRequestsByChild } = await loadRepo();
+		const rows = await findRedemptionRequestsByChild(CHILD_ID, TENANT);
+		expect(rows.map((r) => r.id)).toEqual([2, 3, 1]);
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: {
+				KeyConditionExpression?: string;
+				ExpressionAttributeValues?: Record<string, string>;
+			};
+		};
+		expect(callArg.input.ExpressionAttributeValues?.[':pk']).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(callArg.input.ExpressionAttributeValues?.[':prefix']).toBe('REDEMPT#');
+		// RedemptionRequestRow は非正規化フィールドを含まない
+		expect((rows[0] as unknown as Record<string, unknown>).childName).toBeUndefined();
+	});
+
+	it('LastEvaluatedKey でページングする', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [makeItem({ id: 1 })],
+				LastEvaluatedKey: { PK: 'c', SK: 'c' },
+			})
+			.mockResolvedValueOnce({ Items: [makeItem({ id: 2 })] });
+		const { findRedemptionRequestsByChild } = await loadRepo();
+		const rows = await findRedemptionRequestsByChild(CHILD_ID, TENANT);
+		expect(rows).toHaveLength(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+
+	it('0 件のときは空配列', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findRedemptionRequestsByChild } = await loadRepo();
+		expect(await findRedemptionRequestsByChild(CHILD_ID, TENANT)).toEqual([]);
+	});
+});
+
+// ============================================================
+// findRedemptionRequestsByTenant
+// ============================================================
+
+describe('findRedemptionRequestsByTenant', () => {
+	it('tenant Scan し childName / reward 結合付きで降順 + limit を返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1, requestedAt: 100 }), makeItem({ id: 2, requestedAt: 300 })],
+		});
+		const { findRedemptionRequestsByTenant } = await loadRepo();
+		const rows = await findRedemptionRequestsByTenant(TENANT);
+		expect(rows.map((r) => r.id)).toEqual([2, 1]);
+		// 非正規化 JOIN フィールドが露出する
+		expect(rows[0]).toMatchObject({
+			childName: 'けんた',
+			rewardTitle: 'アイスクリーム',
+			rewardIcon: '🍦',
+			rewardPoints: 100,
+		});
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, string> };
+		};
+		expect(callArg.input.ExpressionAttributeValues?.[':tenantPrefix']).toBe(`T#${TENANT}#CHILD#`);
+		expect(callArg.input.ExpressionAttributeValues?.[':skPrefix']).toBe('REDEMPT#');
+	});
+
+	it('status / childId filter を in-memory 適用する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, status: 'pending_parent_approval', childId: CHILD_ID }),
+				makeItem({ id: 2, status: 'approved', childId: CHILD_ID }),
+				makeItem({ id: 3, status: 'pending_parent_approval', childId: 99 }),
+			],
+		});
+		const { findRedemptionRequestsByTenant } = await loadRepo();
+		const rows = await findRedemptionRequestsByTenant(TENANT, {
+			status: 'pending_parent_approval',
+			childId: CHILD_ID,
+		});
+		expect(rows.map((r) => r.id)).toEqual([1]);
+	});
+
+	it('limit で件数を絞る', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, requestedAt: 1 }),
+				makeItem({ id: 2, requestedAt: 2 }),
+				makeItem({ id: 3, requestedAt: 3 }),
+			],
+		});
+		const { findRedemptionRequestsByTenant } = await loadRepo();
+		const rows = await findRedemptionRequestsByTenant(TENANT, { limit: 2 });
+		expect(rows.map((r) => r.id)).toEqual([3, 2]);
+	});
+});
+
+// ============================================================
+// updateRedemptionRequestStatus
+// ============================================================
+
+describe('updateRedemptionRequestStatus', () => {
+	it('id を Scan で解決 → status + 指定 field のみ UpdateItem (ALL_NEW)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [makeItem({ id: 5 })] }) // findRedemptionItemById Scan
+			.mockResolvedValueOnce({
+				Attributes: makeItem({
+					id: 5,
+					status: 'approved',
+					resolvedAt: 1700001000,
+					resolvedByParentId: 3,
+				}),
+			});
+		const { updateRedemptionRequestStatus } = await loadRepo();
+		const row = await updateRedemptionRequestStatus(
+			5,
+			{ status: 'approved', resolvedAt: 1700001000, resolvedByParentId: 3 },
+			TENANT,
+		);
+		expect(row?.status).toBe('approved');
+		expect(row?.resolvedAt).toBe(1700001000);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(upd.input.UpdateExpression).toContain('#status = :status');
+		expect(upd.input.UpdateExpression).toContain('resolvedAt = :resolvedAt');
+		expect(upd.input.UpdateExpression).toContain('resolvedByParentId = :resolvedByParentId');
+		// parentNote は undefined のため SET に含めない
+		expect(upd.input.UpdateExpression).not.toContain('parentNote');
+	});
+
+	it('null は明示的に SET する (rejected の parentNote=null 等)', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [makeItem({ id: 5 })] }).mockResolvedValueOnce({
+			Attributes: makeItem({ id: 5, status: 'rejected', parentNote: null }),
+		});
+		const { updateRedemptionRequestStatus } = await loadRepo();
+		await updateRedemptionRequestStatus(5, { status: 'rejected', parentNote: null }, TENANT);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(upd.input.ExpressionAttributeValues?.[':parentNote']).toBeNull();
+	});
+
+	it('id 不在 (Scan 0 件) のとき undefined を返し Update しない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { updateRedemptionRequestStatus } = await loadRepo();
+		expect(await updateRedemptionRequestStatus(99, { status: 'approved' }, TENANT)).toBeUndefined();
+		expect(mockSend).toHaveBeenCalledTimes(1); // Scan のみ
+	});
+
+	it('残高に触れない (point ledger / balance への write を行わない)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [makeItem({ id: 5 })] })
+			.mockResolvedValueOnce({ Attributes: makeItem({ id: 5, status: 'approved' }) });
+		const { updateRedemptionRequestStatus } = await loadRepo();
+		await updateRedemptionRequestStatus(5, { status: 'approved' }, TENANT);
+		// Scan + Update の 2 send のみ。BALANCE / POINT への追加 write は service 層の責務。
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		for (const call of mockSend.mock.calls) {
+			const input = (call[0] as { input: { Key?: { SK?: string } } }).input;
+			expect(input.Key?.SK ?? '').not.toContain('BALANCE');
+		}
+	});
+});
+
+// ============================================================
+// findPendingByChildAndReward
+// ============================================================
+
+describe('findPendingByChildAndReward', () => {
+	it('child の REDEMPT# から rewardId + pending 一致を返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, rewardId: 7, status: 'approved' }),
+				makeItem({ id: 2, rewardId: 7, status: 'pending_parent_approval' }),
+			],
+		});
+		const { findPendingByChildAndReward } = await loadRepo();
+		const row = await findPendingByChildAndReward(CHILD_ID, 7, TENANT);
+		expect(row?.id).toBe(2);
+	});
+
+	it('pending が無いとき undefined', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1, rewardId: 7, status: 'approved' })],
+		});
+		const { findPendingByChildAndReward } = await loadRepo();
+		expect(await findPendingByChildAndReward(CHILD_ID, 7, TENANT)).toBeUndefined();
+	});
+});
+
+// ============================================================
+// findUnshownResultByChild
+// ============================================================
+
+describe('findUnshownResultByChild', () => {
+	it('approved/rejected かつ未表示を resolvedAt 降順で 1 件 + reward 結合', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, status: 'approved', resolvedAt: 100, shownToChildAt: null }),
+				makeItem({ id: 2, status: 'rejected', resolvedAt: 300, shownToChildAt: null }),
+				makeItem({ id: 3, status: 'approved', resolvedAt: 400, shownToChildAt: 999 }), // 表示済 → 除外
+				makeItem({ id: 4, status: 'pending_parent_approval', resolvedAt: null }), // pending → 除外
+			],
+		});
+		const { findUnshownResultByChild } = await loadRepo();
+		const row = await findUnshownResultByChild(CHILD_ID, TENANT);
+		expect(row?.id).toBe(2);
+		expect(row?.rewardTitle).toBe('アイスクリーム');
+		expect(row?.rewardIcon).toBe('🍦');
+	});
+
+	it('候補が無いとき undefined', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1, status: 'pending_parent_approval' })],
+		});
+		const { findUnshownResultByChild } = await loadRepo();
+		expect(await findUnshownResultByChild(CHILD_ID, TENANT)).toBeUndefined();
+	});
+});
+
+// ============================================================
+// markRedemptionResultShown
+// ============================================================
+
+describe('markRedemptionResultShown', () => {
+	it('id を Scan で解決 → shownToChildAt を SET し ALL_NEW を返す', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [makeItem({ id: 5 })] })
+			.mockResolvedValueOnce({ Attributes: makeItem({ id: 5, shownToChildAt: 1700002000 }) });
+		const { markRedemptionResultShown } = await loadRepo();
+		const row = await markRedemptionResultShown(5, TENANT);
+		expect(row?.shownToChildAt).toBe(1700002000);
+		const upd = mockSend.mock.calls[1]?.[0] as { input: { UpdateExpression?: string } };
+		expect(upd.input.UpdateExpression).toContain('shownToChildAt = :now');
+	});
+
+	it('id 不在のとき undefined', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { markRedemptionResultShown } = await loadRepo();
+		expect(await markRedemptionResultShown(99, TENANT)).toBeUndefined();
+	});
+});
+
+// ============================================================
+// expireOldRedemptions
+// ============================================================
+
+describe('expireOldRedemptions', () => {
+	it('30 日超 pending を Scan → expired に Update し件数を返す', async () => {
+		const old = Math.floor(Date.now() / 1000) - 31 * 24 * 60 * 60;
+		const recent = Math.floor(Date.now() / 1000) - 1 * 24 * 60 * 60;
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [
+					makeItem({ id: 1, status: 'pending_parent_approval', requestedAt: old }),
+					makeItem({ id: 2, status: 'pending_parent_approval', requestedAt: recent }), // 期限内 → 除外
+					makeItem({ id: 3, status: 'approved', requestedAt: old }), // 非 pending → 除外
+				],
+			})
+			.mockResolvedValueOnce({}); // 1 Update
+		const { expireOldRedemptions } = await loadRepo();
+		const count = await expireOldRedemptions(TENANT);
+		expect(count).toBe(1);
+		// 1 Scan + 1 Update
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(upd.input.ExpressionAttributeValues?.[':expired']).toBe('expired');
+	});
+
+	it('対象 0 件のとき 0 を返し Update しない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { expireOldRedemptions } = await loadRepo();
+		expect(await expireOldRedemptions(TENANT)).toBe(0);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ============================================================
+// hasPendingByReward
+// ============================================================
+
+describe('hasPendingByReward', () => {
+	it('rewardId に pending があれば true', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1, rewardId: 7, status: 'pending_parent_approval' })],
+		});
+		const { hasPendingByReward } = await loadRepo();
+		expect(await hasPendingByReward(7, TENANT)).toBe(true);
+	});
+
+	it('pending が無ければ false', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1, rewardId: 7, status: 'approved' })],
+		});
+		const { hasPendingByReward } = await loadRepo();
+		expect(await hasPendingByReward(7, TENANT)).toBe(false);
+	});
+});
+
+// ============================================================
+// deleteByTenantId
+// ============================================================
+
+describe('deleteByTenantId', () => {
+	it('CHILD#* 配下の REDEMPT# を Scan → BatchWrite で削除する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [
+					{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'REDEMPT#00000001' },
+					{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'REDEMPT#00000002' },
+				],
+			})
+			.mockResolvedValueOnce({}); // BatchWrite
+		const { deleteByTenantId } = await loadRepo();
+		await deleteByTenantId(TENANT);
+		const scan = mockSend.mock.calls[0]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, string> };
+		};
+		expect(scan.input.ExpressionAttributeValues?.[':pkPrefix']).toBe(`T#${TENANT}#CHILD#`);
+		expect(scan.input.ExpressionAttributeValues?.[':skPrefix']).toBe('REDEMPT#');
+	});
+});
+
+// ============================================================
+// interface 適合 (SQLite との機能等価性)
+// ============================================================
+
+describe('interface 適合 (IRewardRedemptionRepo)', () => {
+	it('全メソッドを export している (stub に後退していない)', async () => {
+		const repo = await loadRepo();
+		for (const m of [
+			'insertRedemptionRequest',
+			'findRedemptionRequestsByChild',
+			'findRedemptionRequestsByTenant',
+			'updateRedemptionRequestStatus',
+			'findPendingByChildAndReward',
+			'findUnshownResultByChild',
+			'markRedemptionResultShown',
+			'expireOldRedemptions',
+			'hasPendingByReward',
+			'deleteByTenantId',
+		]) {
+			expect(typeof (repo as Record<string, unknown>)[m]).toBe('function');
+		}
+	});
+
+	it('write method が no-op stub でない (insertRedemptionRequest が実 send する)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 1 } })
+			.mockResolvedValueOnce({ Item: undefined })
+			.mockResolvedValueOnce({ Items: [] })
+			.mockResolvedValueOnce({});
+		const { insertRedemptionRequest } = await loadRepo();
+		const row = await insertRedemptionRequest(
+			{ childId: CHILD_ID, rewardId: 7, requestedAt: 1 },
+			TENANT,
+		);
+		// stub なら id=0 / send 0 回だった。本実装は counter 採番 + Put を行う。
+		expect(row.id).toBe(1);
+		expect(mockSend).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

有料本番 SaaS (AWS Lambda, `DATA_SOURCE=dynamodb`) で **ごほうび交換 (記録 → ポイント → 交換) が永続しない** CRITICAL gap を根治する。子供が貯めたポイントでごほうびを交換申請しても本番では消え、親が見守り画面で承認しても残らない。課金顧客の中核ループ終端が壊れていた (#2824 Phase 2A、User/PO 直接方針 2026-06-04)。

真因: `dynamodb/reward-redemption-repo.ts` が #2263 hotfix で「read=空 / write=no-op + logger.warn」化されたまま有料本番運用されていた (Pre-PMF stub の放置)。本番 cognito Lambda は `DATA_SOURCE=dynamodb` で稼働するため、SQLite 機能等価の DynamoDB 実装が必須。

## 関連 Issue

- 関連: #2824 (本実装の正式 tracking Issue。AC5 配下の Phase 2A = reward-redemption)
- 関連: PR #2820 (Phase 1 = child-activity-repo 本実装、本 PR の exemplar / stacked 上流)
- 関連: ADR-0055 (Per-child 主軸データモデル原則) の完遂
- 関連: #1337 (ごほうびショップ交換申請 親子連携フローの original spec)

> 本 PR は `closes` を付けない (#2824 は複数 Phase の umbrella tracking Issue)。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `dynamodb/reward-redemption-repo.ts` 全 10 method を SQLite 実装と機能等価に本実装 | `tests/unit/db/dynamodb-reward-redemption-repo.test.ts` (vi.hoisted AWS SDK mock、35 tests) | PASS。insert / find×4 / update / markShown / expire / hasPending / delete を網羅 |
| AC2 | ごほうび交換申請が本番 DynamoDB で永続する | `insertRedemptionRequest` 本実装 + interface 適合テスト「write が no-op stub でない」 | PASS。counter 採番 + 実 PutItem を send (id=1 返却を回帰固定) |
| AC3 | 親向け一覧 / 子供未表示通知が JOIN 相当 (childName / reward fields) を返す | 非正規化保存 + `findRedemptionRequestsByTenant` / `findUnshownResultByChild` テスト | PASS。insert 時に child/reward 解決 → item に非正規化、tenant 横断 read で N+1 回避 |
| AC4 | 残高整合 — repo は status 更新のみ担い残高に触れない (SQLite 責務分割踏襲) | 「残高に触れない」テスト (BALANCE/POINT への write 0 件 assert) | PASS。減算は service 層 `approveRedemption` の `insertPointEntry` 責務 → TransactWriteItems 不要 |
| AC5 | 構造ガード baseline を 1 repo 前進 (stub ratchet) | `scripts/check-dynamodb-stub-parity.mjs` + baseline から本 repo 削除 | PASS。12 → 11 repo / 76 stub method (baseline 以下) |
| AC6 | DB 設計書同期 (ADR-0001) | `08-データベース設計書.md` に DynamoDB key 設計表 + changelog 5.17 追記 | 反映済 (PK/SK 表 + アクセスパターン表 + 残高整合の判断) |

## 変更タイプ

- [x] fix (CRITICAL gap 根治)
- [x] feat (DynamoDB 本実装)
- [x] test
- [x] infra/ci (stub baseline ratchet 前進)
- [x] docs (設計書同期)

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dynamodb/reward-redemption-repo.ts` — stub (read=空 / write=no-op) → 本実装 (全 10 method)
- `src/lib/server/db/dynamodb/keys.ts` — `rewardRedemptionKey` / `rewardRedemptionPrefix` / `ENTITY_NAMES.rewardRedemption` 追加
- `scripts/dynamodb-stub-baseline.json` — 本 repo entry 削除 (ratchet 前進)
- `tests/unit/db/dynamodb-reward-redemption-repo.test.ts` — 新規 (35 tests)
- `tests/unit/db/dynamodb-pre-pmf-fallback.test.ts` — 本 repo block + regression guard 行を除外 (他 repo の fallback assert は維持)
- `.cspell/project-words.txt` — `REDEMPT` / `Denorm` 追加
- `docs/design/08-データベース設計書.md` — DynamoDB key 設計 + changelog 5.17

### DynamoDB key 設計 (レビューの核心)

| エンティティ | PK | SK |
|---|---|---|
| reward_redemption_request | `T#<tid>#CHILD#<childId>` | `REDEMPT#<paddedId>` (8 桁 0 埋め) |

| アクセスパターン | 操作 | 条件 |
|---|---|---|
| findRedemptionRequestsByChild | Query | `PK = T#<tid>#CHILD#<childId> AND begins_with(SK, 'REDEMPT#')` (requested_at 降順は in-memory、SQLite SSOT 一致) |
| insertRedemptionRequest | counter 採番 → child/reward 解決 → PutItem | status default = `pending_parent_approval`。childName / rewardTitle / rewardIcon / rewardPoints を非正規化保存 |
| findRedemptionRequestsByTenant / expireOldRedemptions / hasPendingByReward | Scan (`begins_with(PK, CHILD#)` + `begins_with(SK, REDEMPT#)`) | child partition 分散のため tenant 横断は Scan。status / childId / limit は in-memory filter |
| updateRedemptionRequestStatus(id) / markRedemptionResultShown(id) | Scan (id filter) → UpdateItem (`ALL_NEW`) | childId を受けないため id で PK/SK 解決 (special-reward-repo.markRewardShown 同型)。undefined skip / null 明示 SET |
| findPendingByChildAndReward / findUnshownResultByChild | Query (child partition) + in-memory filter | 二重申請 / 未表示通知。後者は reward 結合露出 |
| deleteByTenantId | Scan → BatchWrite | `CHILD#*` 配下の `REDEMPT#` 削除 (`deleteItemsByPkPrefix`) |

### GSI 要否判断 + 残高整合判断

**追加 GSI 不要。CDK 変更なし。** child partition (`PK=CHILD#<id>`) 配下に置くことで `findRedemptionRequestsByChild` (子供画面の最頻アクセス) は単一 partition Query で完結 (ADR-0055 §3.1 cross-child 構造防御)。tenant 横断 (親確認 / cron / 削除) は低頻度のため Scan で対応 (既存 push_subscription / cancellation_reason と同方針、Pre-PMF / ADR-0010)。

**残高整合**: SQLite 実装でもポイント減算は **service 層** (`reward-redemption-service.approveRedemption` の `insertPointEntry`) が担い、repo は status 更新のみ。この責務分割を DynamoDB でも厳密に踏襲したため、redemption status 更新と balance 減算を同一 transaction で縛る必要がなく **TransactWriteItems は不要**。repo がポイント台帳に触れないことを「残高に触れない」テストで回帰固定 (BALANCE/POINT への write 0 件 assert)。

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/db/ tests/unit/services/` → 145 files / 2500 tests PASS
- 新規 spec `dynamodb-reward-redemption-repo.test.ts` (35) + 改修 `dynamodb-pre-pmf-fallback.test.ts` → PASS
- `npx biome check --error-on-warnings` (変更ファイル) → clean
- `npx svelte-check` → 変更ファイルに型エラー 0 (残 58 errors は infra/node_modules 未install の既知環境ノイズ、tests/CLAUDE.md 記載、CI で解消)
- `node scripts/check-dynamodb-stub-parity.mjs` → OK (11 repo / 76 stub method、baseline 以下)
- `npx cspell` (変更ファイル) → `REDEMPT` / `Denorm` PASS (残 3 件は本 PR 無関係の既存語)

ADR-0006: 既存テストの assertion は弱体化していない。`pre-pmf-fallback.test.ts` の reward-redemption block 除外は「stub 前提 assert を実装済 repo に残すと誤った退行 gate になる」ための除外で、他 repo の fallback assert は全て維持 (assertion 弱体化に該当しない、テスト内コメントで明記)。

## スクリーンショット / ビジュアルデモ

UI 変更なし (DB repo 層 + テスト + 設計書のみ)。本 PR は本番 DynamoDB の repo 実装であり、画面コンポーネント・ラベル・レイアウトに一切変更がないため SS 対象外。挙動の正しさは unit test (AWS SDK mock) で SQLite 機能等価を回帰固定する。

## コード品質セルフレビュー (#1481)

- **OSS 先調査**: 新規機構なし。DynamoDB single-table key パターンは既存 `keys.ts` / `special-reward-repo.ts` / `child-activity-repo.ts` (Phase 1) の確立パターンを踏襲 (独自実装 0)。id-only update の Scan 解決は `special-reward-repo.markRewardShown` と同型。`stripKeys` / `findChildByIdRaw` / `deleteItemsByPkPrefix` は共通 helper を再利用。
- **非正規化判断**: `findRedemptionRequestsByTenant` の JOIN (children + special_rewards) を tenant 横断で N+1 にしないため、insert 時に解決して item に denormalize。DynamoDB の単一テーブル設計セオリー (read pattern 起点) に整合。
- **SQLite ⇄ DynamoDB 並行実装整合**: status default = `pending_parent_approval` (旧 stub の `'pending'` を SQLite schema に修正)、update の undefined skip / null 明示 SET、find の降順 / filter / limit を両実装で一致 (tests/CLAUDE.md §DynamoDB 並行実装整合)。
- **NULL 互換**: `findUnshownResultByChild` は `shownToChildAt === null || undefined` を未表示扱い (旧データ防御、SQLite `IS NULL` と一致)。

## 横展開・影響波及チェック

- `docs/design/parallel-implementations.md` DB スキーマ: reward_redemption_requests の DynamoDB 実装追加。SQLite (挙動 SSOT) / demo / dynamodb の 3 backend で write 等価に。
- 構造ガード `check-dynamodb-stub-parity.mjs` baseline は本 PR で 12 → 11 repo に前進。残 stub repo (battle / message / auto-challenge / child-challenge / stamp-card 等) は同根 (write 永続なし) のため、interface 拡張時の dynamodb 未実装混入を gate が exit 1 で検出する。残 repo の本実装可否・優先度は QM/PO 判断 (#2824 umbrella で順次)。
- service 層 `reward-redemption-service` / 呼出ルートは変更なし (interface 不変、stub → 本実装で挙動が「壊れていた → 正しく動く」方向のみ)。

## レビュー依頼事項・破壊的変更

- **破壊的変更なし**。stub → 本実装で挙動が「永続しない → 永続する」方向。interface (`IRewardRedemptionRepo`) は不変。
- #2820 (Phase 1) merge 後に origin/main へ rebase 済 (2A commits のみ cherry-pick、HEAD `64061ebaa`)。CI 全緑。
- **レビュー核心**: DynamoDB key 設計 (上表) / 非正規化判断 / 残高整合 (service 責務分割の踏襲) / id-only update の Scan 解決。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。`DYNAMODB_TABLE` 等は既存。

## Ready for Review チェックリスト

- [x] CI 全通過を確認した (rebase 後 HEAD `64061ebaa` で全 check green)
- [x] AC 検証マップを全 AC 分記入した
- [x] 設計書を同期した (08-データベース設計書.md)
- [x] テストを追加した (新規 spec 35 + 回帰固定)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: 実装・テスト 35 PASS・parity OK・rebase 後 CI 全緑)

## QM レビュー結果

(QM 記入)

