### PR TITLE
fix: #2494 Phase 1 — tenant isolation 意図的 no-op の SSOT 明文化 (docs + header 誤記述訂正)

### DIFF
--- a/docs/design/data-model-resource-scope.md
+++ b/docs/design/data-model-resource-scope.md
@@ -137,6 +137,19 @@ child_activities
 - ✅ regression test: `tests/unit/db/sqlite/activity-pref-repo.test.ts` (5 test) — AC-1 旧 activities table 空のまま child_activities 経由で集計成立 / AC-2 別 categoryId 除外 / AC-3 別 childId 除外 / AC-4 isPinned=0 除外 / AC-5 pin 0 件 fallback
 - ⏳ 18 caller migrate (PR-C-3) / seed.ts 変更 (PR-C-2) / DEMO_ACTIVITIES (PR-C-4) / 最終 drop (PR-C-5) は別 PR で順次実施
 
+#### tenant isolation の現状 SSOT（意図的 no-op、#2494 Phase 1）
+
+`child_activities` は **tenant_id 列を持たず childId scope** で運用する（§2.1 per-child 主軸と整合）。repo interface が受ける `tenantId` 引数の扱いは backend ごとに以下が現設計であり、**乖離ではなく意図的 no-op**:
+
+| backend | 現設計 | 根拠 |
+|---|---|---|
+| SQLite (`sqlite/child-activity-repo.ts`) | `_tenantId` 受領のみで filter しない（意図的 no-op） | SQLite が選ばれる process は認証 tenantId が `'local'`/`'demo'` 固定の **1 process = 1 DB = 1 tenant**（`auth/providers/local.ts` / `db/factory.ts`）。別 tenant の childId が入力される経路が構造的に存在せず、行レベル tenant filter は冗長 |
+| DynamoDB (`dynamodb/child-activity-repo.ts`) | **Pre-PMF stub**（read = `warnRead` + 空返却 / write = throw）。tenant filter 以前に実装自体を ADR-0055 per-child schema 本実装まで封鎖 | ADR-0010 Bucket B の構造的強制（同ファイル冒頭コメント参照） |
+
+- **SQLite を multi-tenant 共有 DB として使う構成は非想定**（SaaS は DynamoDB）。この前提が崩れる設計変更時は tenant_id 列追加が必須化する
+- child 越境（同一 tenant 内の child A→B）IDOR は `findActivityByIdForChild`（id + childId の 2 軸検証）で対処済み（#2524）
+- **Phase 2（tenant_id 列追加 + 全 query filter = interface contract と実装の完全一致）は #2828 で管理**。PO 基準: 「DB リポジトリ層の共通化のために有用であれば必須」— 有用性評価を先行し、有用なら実施する
+
 ### 4.2 checklist (PR-5 Phase 1 完了 / Phase 2 UX 化進行中)
 
 **実装状況** (2026-05-25 PR-5 Phase 1):

--- a/docs/design/data-model-resource-scope.md
+++ b/docs/design/data-model-resource-scope.md
@@ -139,12 +139,12 @@ child_activities
 
 #### tenant isolation の現状 SSOT（意図的 no-op、#2494 Phase 1）
 
-`child_activities` は **tenant_id 列を持たず childId scope** で運用する（§2.1 per-child 主軸と整合）。repo interface が受ける `tenantId` 引数の扱いは backend ごとに以下が現設計であり、**乖離ではなく意図的 no-op**:
+SQLite の `child_activities` は **tenant_id 列を持たず childId scope** で運用する（§2.1 per-child 主軸と整合）。repo interface が受ける `tenantId` 引数の扱いは backend ごとに以下が現設計（SQLite 側の no-op は乖離ではなく**意図的**）:
 
 | backend | 現設計 | 根拠 |
 |---|---|---|
 | SQLite (`sqlite/child-activity-repo.ts`) | `_tenantId` 受領のみで filter しない（意図的 no-op） | SQLite が選ばれる process は認証 tenantId が `'local'`/`'demo'` 固定の **1 process = 1 DB = 1 tenant**（`auth/providers/local.ts` / `db/factory.ts`）。別 tenant の childId が入力される経路が構造的に存在せず、行レベル tenant filter は冗長 |
-| DynamoDB (`dynamodb/child-activity-repo.ts`) | **Pre-PMF stub**（read = `warnRead` + 空返却 / write = throw）。tenant filter 以前に実装自体を ADR-0055 per-child schema 本実装まで封鎖 | ADR-0010 Bucket B の構造的強制（同ファイル冒頭コメント参照） |
+| DynamoDB (`dynamodb/child-activity-repo.ts`) | **本実装済み（#2820）**。`tenantId` は partition key（`PK = T#<tenantId>#CHILD#<childId>`）に組み込まれ、**tenant isolation が key 設計で構造的に強制**される | ADR-0055 per-child schema（child partition 同居、同ファイル冒頭コメント参照） |
 
 - **SQLite を multi-tenant 共有 DB として使う構成は非想定**（SaaS は DynamoDB）。この前提が崩れる設計変更時は tenant_id 列追加が必須化する
 - child 越境（同一 tenant 内の child A→B）IDOR は `findActivityByIdForChild`（id + childId の 2 軸検証）で対処済み（#2524）

--- a/src/lib/server/db/interfaces/child-activity-repo.interface.ts
+++ b/src/lib/server/db/interfaces/child-activity-repo.interface.ts
@@ -8,7 +8,8 @@
  *   - `childId` を必須引数化 (cross-child cross access を構造的に防ぐ)
  *   - `tenantId` 引数の現セマンティクス (#2494 Phase 1): SQLite 実装では**意図的 no-op**
  *     (1 process = 1 DB = 1 tenant で越境入力が構造的に不能)、DynamoDB 実装は
- *     Pre-PMF stub (ADR-0055 本実装まで封鎖)。filter 強制 (Phase 2) は #2828 で管理。
+ *     partition key (`T#<tenantId>#CHILD#<childId>`) で tenant isolation を構造的に
+ *     強制 (#2820 本実装)。SQLite 側の filter 化 (Phase 2) は #2828 で管理。
  *     SSOT: docs/design/data-model-resource-scope.md §4.1「tenant isolation の現状 SSOT」
  *   - 旧 `IActivityRepo` は PR-3 期間中は並存。完全切替時に削除
  *

--- a/src/lib/server/db/interfaces/child-activity-repo.interface.ts
+++ b/src/lib/server/db/interfaces/child-activity-repo.interface.ts
@@ -6,7 +6,10 @@
  *
  * 設計原則 (ADR-0055 §3.1):
  *   - `childId` を必須引数化 (cross-child cross access を構造的に防ぐ)
- *   - tenant isolation は `tenantId` で従来通り強制
+ *   - `tenantId` 引数の現セマンティクス (#2494 Phase 1): SQLite 実装では**意図的 no-op**
+ *     (1 process = 1 DB = 1 tenant で越境入力が構造的に不能)、DynamoDB 実装は
+ *     Pre-PMF stub (ADR-0055 本実装まで封鎖)。filter 強制 (Phase 2) は #2828 で管理。
+ *     SSOT: docs/design/data-model-resource-scope.md §4.1「tenant isolation の現状 SSOT」
  *   - 旧 `IActivityRepo` は PR-3 期間中は並存。完全切替時に削除
  *
  * 関連:

--- a/src/lib/server/db/sqlite/child-activity-repo.ts
+++ b/src/lib/server/db/sqlite/child-activity-repo.ts
@@ -2,7 +2,13 @@
 // per-child activity instance repository — SQLite 実装 (#2362 PR-3, ADR-0055)
 //
 // 旧 `activity-repo.ts` (family master + age filter) の後継。
-// `childId` 必須 + tenant isolation を強制し、cross-child access を構造的に防ぐ。
+// `childId` 必須で cross-child access を構造的に防ぐ。
+//
+// tenant isolation について (#2494 Phase 1):
+//   本実装の `_tenantId` 引数は意図的 no-op (SQLite は 1 process = 1 DB = 1 tenant で
+//   tenant 越境入力が構造的に不能なため)。SSOT は
+//   docs/design/data-model-resource-scope.md §4.1「tenant isolation の現状 SSOT」。
+//   tenant_id 列追加 + filter (Phase 2) は #2828 で管理 (repo 層共通化に有用なら必須)。
 //
 // 並存原則 (Phase 2 段階): 旧 activities table は drop しない。
 // Phase 6/7 で全 callsite 移行後に drop。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者（repo 層を読む Dev / QA / 将来の貢献者）

**解決する課題**: `child_activities` repo の `tenantId` 引数が SQLite 実装で no-op なのに、interface・実装 header・設計書のいずれにも「意図的である」ことが書かれておらず、interface contract と実装が乖離した SSOT 違反状態だった（ADR-0055 §3.1 との矛盾、#2494）。さらに header / interface には「tenant isolation を強制」という**実装と逆の記述**が残っていた。

**期待される効果**: 「意図的 no-op（SQLite は 1 process = 1 DB = 1 tenant で越境入力が構造的に不能）」を設計書 SSOT + コード 2 箇所の header に明文化し、誤読・誤修正（不要な filter 追加や、逆に本当に必要になる Phase 2 の見落とし）を構造的に防ぐ。Phase 2（列追加 + filter）は PO 基準付きで #2828 に分離。

**設計ポリシー確認**: PO 判断 2026-06-04（QA 表 Q3 = yes、deep research 2 周 + 敵対的レビューで security 反駁不成立を確認）。DynamoDB 側の実態は**時系列で変化**: 調査時点では Pre-PMF stub（issue 本文の「filter あり」前提は当時誤り）だったが、**QA merge #2820（`d7e59034`、2026-06-04）で本実装され、`tenantId` は partition key（`T#<tenantId>#CHILD#<childId>`）で構造的に強制**されるようになった。本 PR の docs はこの**最新実態**を記述している（rebase + 追従 commit `66e6deb8`）。

## 関連 Issue

closes #2494

- Phase 2 分離先: #2828（PO 基準「DB リポジトリ層の共通化に有用であれば必須」）
- 関連: ADR-0055 §3.1 / ADR-0010 / #2524（child 越境 IDOR fix）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `docs/design/data-model-resource-scope.md` §4.1 に「SQLite: tenant_id 列不要・`_tenantId` 意図的 no-op」を明記 | `grep -n "tenant isolation の現状 SSOT" docs/design/data-model-resource-scope.md` | PASS: §4.1 に新節（backend 別の現設計表 + 非想定条件 + #2828 pointer）。DynamoDB の実態（**#2820 本実装、PK 組込みで tenant isolation 構造強制**）も直接コード確認のうえ最新化済み |
| AC2 | `sqlite/child-activity-repo.ts` の `_tenantId` コメントを SSOT link で補強 | `grep -n "#2494 Phase 1" src/lib/server/db/sqlite/child-activity-repo.ts` | PASS: header L4-11 を訂正（「tenant isolation を強制し」という実装と矛盾する旧記述を削除し、意図的 no-op + SSOT pointer + #2828 を明記） |
| AC3 | interface の `tenantId` arg に「SQLite では未使用」JSDoc 追加 | `grep -n "意図的 no-op" src/lib/server/db/interfaces/child-activity-repo.interface.ts` | PASS: header 設計原則ブロックに一括明記（10 メソッド個別 JSDoc より DRY、L7-12 の「従来通り強制」という誤記述も同時訂正） |
| AC4 | schema.ts `childActivities` に `tenantId` 列追加 | — | **scope 外: #2828 へ分離（PO 判断 2026-06-04、有用性評価を先行）** |
| AC5 | migration script で既存 row backfill | — | **scope 外: #2828 へ分離（同上）** |
| AC6 | 全 query で tenantId filter 強制 | — | **scope 外: #2828 へ分離（同上）** |
| AC7 | interface `_tenantId` → `tenantId` rename | — | **scope 外: #2828 へ分離（同上、Phase 2 実装形に依存）** |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

<!-- fix: SSOT 乖離（interface contract と実装の矛盾記述）の訂正のため fix（Issue #2494 公式 label = type:fix と一致） -->

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — **コメント/JSDoc のみ**（schema・query・挙動の変更ゼロ）
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（docs 1 + コード comment 2 のみ、runtime 挙動不変）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2829` 全 Step PASS**（#1775 / ADR-0030）— Step1-8 PASS（biome / svelte-check / vitest〔#2820 の新規 DynamoDB テスト込み〕/ hardcoded-strings / no-plan-literals。LP 系 Step5/6/8 は非該当 skip）。rebase（#2820 取込）後に実行
- [x] 追加・変更したテストの概要: N/A（comment/docs のみ、runtime 挙動変更なし。既存 regression は `activity-legacy-table-write-zero*.test.ts` 群が維持）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（dynamodb 実装は不変。docs にその現状を記述したのみ）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし**（docs + コード comment のみ、UI 変更ゼロ）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A 相当（comment のみ）。SSOT pointer の一元化（docs §4.1 に集約、コードからは参照）で単一情報源を維持
- [x] **DRY**: interface への明記は 10 メソッド個別 JSDoc でなく header 1 箇所に集約。`grep -rn "tenant isolation を強制" src/` で同種の矛盾記述が他に無いことを確認（0 件）
- [x] **YAGNI**: Phase 2 実装に踏み込まず docs/comment に留めた（PO 基準どおり有用性評価を #2828 で先行）
- [x] **Security（OSS 公開前提）**: 秘密情報なし。security 評価（tenant 越境不能）は敵対的レビュー済みの内容を記述
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A（挙動不変）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 設計書同期 (ADR-0001) — 本 PR 自体が設計書 SSOT の追記 + コード側 pointer の同期
- [x] N/A — 上記以外の並行実装ペア（本番↔デモ / LP / 年齢モード / ナビ / labels / E2E シード）は影響範囲外（runtime 挙動・UI・用語の変更なし）
- [x] 並行 PR overlap 確認 (#1200) — 変更 3 ファイルを触る open PR なし

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- 調査 2 周（Round1/Round2）で残っていた矛盾「DynamoDB 側 tenant filter の有無」は**時系列**だったと確定: Round1 調査時点は stub（filter なしが正）、**#2820 merge 後は PK による tenant isolation 強制が正**。docs 記述は merge 後の最新実態に同期済み（#2828 にも同旨コメント済み）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2829` 全 Step PASS** をローカル確認した — Step1-8 PASS（rebase 後・#2820 取込済みの tree で実行、vitest 全件含む）。Step9 は本チェックリスト自身の自己参照
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— 3 file、`git diff --stat` で確認
- [x] 全 AC が実装済み — Phase 1 = AC1-3 全 PASS。AC4-7 は PO 判断で #2828 へ分離（上記 AC マップ）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

