### PR TITLE
fix: #2827 — schema migration gate に検出漏れ 2 経路追加 (新規 table 同期漏れ / 新規 NOT NULL no-default 列)

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -87,9 +87,13 @@ block された (2026-05-27 NUC down)。
 **冪等性**: 各 migration block は `tableExists` / `hasColumn` / `hasFkToActivities`
 guard で「既に新形式なら skip」を保証。startup ごとに毎回呼ばれても no-op。
 
-**再発防止 CI gate**: 別 Issue #2507 で機械検証 script
-(schema.ts 差分 ↔ create-tables.ts ↔ lazy-startup-migrations.ts の同期検証) を別 PR で実装する。
-現状はコードレビューと本 SSOT の周知で運用。
+**再発防止 CI gate**: `scripts/check-schema-migration-completeness.mjs` が `schema.ts` 差分から
+NUC 起動 block 級の変更を検出し、既存 DB upgrade 経路の同期漏れを blocker 化する
+(CI `ci.yml` job `schema-migration-completeness-check`)。検出対象は (1) DROP COLUMN /
+(2) FK target 変更 / (3) NOT NULL 反転 / (4) cross-table flip / (5) 新規 table 追加
+(create-tables.ts または lazy-startup-migrations.ts への同期がなければ blocker) /
+(6) 新規 NOT NULL かつ DEFAULT なし列追加 (`validateAndMigrate` が自動 ALTER 不能で exit 1 する境界)。
+非破壊の ADD COLUMN (nullable / DEFAULT 付き) は `validateAndMigrate` が自動適用するため対象外。
 
 ---
 

--- a/scripts/check-schema-migration-completeness.mjs
+++ b/scripts/check-schema-migration-completeness.mjs
@@ -130,7 +130,8 @@ function getSyncedTableNames() {
 			if (!line.startsWith('+') && !line.startsWith('-')) continue;
 			// snake_case 識別子 + クォート内文字列の両方をトークンとして拾う
 			for (const m of line.matchAll(/['"]?\b([a-z][a-z0-9_]+)\b['"]?/g)) {
-				synced.add(m[1]);
+				const token = m[1];
+				if (token) synced.add(token);
 			}
 		}
 	}
@@ -158,9 +159,10 @@ function collectColumnsInAddedTables(added, addedTables, removedTables) {
 	for (const line of added) {
 		const tableStart = line.match(TABLE_START_RE);
 		if (tableStart) {
-			const name = tableStart[1];
+			const name = tableStart[1] ?? '';
 			// 真の新規 table (追加側のみ) のときだけ追跡開始。rename / 行移動は対象外。
-			currentNewTable = addedTables.has(name) && !removedTables.has(name) ? name : null;
+			currentNewTable =
+				name !== '' && addedTables.has(name) && !removedTables.has(name) ? name : null;
 			continue;
 		}
 		// table ブロック終端 (drizzle 定義の閉じ `}` / `});`) で追跡解除
@@ -311,10 +313,14 @@ export function detectBreakingChanges(diff, options = {}) {
 	const TABLE_RE = /sqliteTable\(\s*['"]([\w]+)['"]/g;
 	/** @type {Set<string>} */
 	const removedTables = new Set();
-	for (const m of removedText.matchAll(TABLE_RE)) removedTables.add(m[1]);
+	for (const m of removedText.matchAll(TABLE_RE)) {
+		if (m[1]) removedTables.add(m[1]);
+	}
 	/** @type {Set<string>} */
 	const addedTables = new Set();
-	for (const m of addedText.matchAll(TABLE_RE)) addedTables.add(m[1]);
+	for (const m of addedText.matchAll(TABLE_RE)) {
+		if (m[1]) addedTables.add(m[1]);
+	}
 	for (const tableName of addedTables) {
 		if (removedTables.has(tableName)) continue; // rename / 行移動は新規ではない
 		if (syncedTableNames.has(tableName)) continue; // create-tables / lazy に同期済

--- a/scripts/check-schema-migration-completeness.mjs
+++ b/scripts/check-schema-migration-completeness.mjs
@@ -8,17 +8,31 @@
  *   既存 production DB を upgrade する `lazy-startup-migrations.ts` への追加が漏れ、
  *   NUC 起動が `no such column: tenant_id` で block した (NUC down ~6 分)。
  *
- * 本 gate (最小版):
- *   `src/lib/server/db/schema.ts` の diff が **破壊的変更**
- *   (DROP COLUMN / FK target 変更 / NOT NULL 追加・削除 / cross-table flip) を含むときだけ、
- *   `src/lib/server/db/migration/lazy-startup-migrations.ts` に diff があるかを検証する。
+ * 本 gate:
+ *   `src/lib/server/db/schema.ts` の diff が **NUC 起動 block 級の変更**
+ *   を含むときだけ、既存 production DB を upgrade する経路に同期 diff があるかを検証する。
  *   無ければ exit 1 (blocker)。
  *
- *   通常の **ADD COLUMN** (列追加のみ) は破壊的でないため warn 止まり (既存
- *   `check-schema-change-tests.mjs` の責務、本 script は exit 0)。
+ *   検出する変更 (`schema-validator.ts` / `client.ts` が exit 1 する境界と一致):
+ *     (1) DROP COLUMN
+ *     (2) FK target 変更
+ *     (3) NOT NULL 追加・削除 (既存列の反転)
+ *     (4) cross-table flip (child_id ⇔ tenant_id)
+ *     (5) 新規 table 追加 + create-tables.ts / lazy-startup-migrations.ts 同期漏れ (#2827)
+ *         — `schema-validator.ts:181-188` の missing table → valid=false → client.ts exit 1
+ *     (6) 新規 NOT NULL かつ DEFAULT なし列の追加 (#2827)
+ *         — `validateAndMigrate:195-243` の notNull && !hasDefault 列は自動 ALTER 不能 → exit 1
  *
- *   完全な SQL parser は不要 (AC7)。正規表現で破壊的キーワードを検出し、該当時に
- *   lazy-startup-migrations.ts 差分の有無を確認する、で十分。
+ *   (1)-(4) は lazy-startup-migrations.ts への同期 diff で blocker 解除。
+ *   (5) は新規 table 名が create-tables.ts または lazy-startup-migrations.ts の同 PR diff に
+ *   出現すれば解除 (#2827)。
+ *   (6) は新規列に DEFAULT を付与する (= schema.ts の修正) ことで解除する境界違反のため、
+ *   blocker を立てた時点で schema 側の是正を促す。
+ *
+ *   通常の **非破壊 ADD COLUMN** (nullable / DEFAULT 付き列追加のみ) は `validateAndMigrate`
+ *   が自動適用するため warn 止まり (既存 `check-schema-change-tests.mjs` の責務、本 script は exit 0)。
+ *
+ *   完全な SQL parser は不要 (AC7)。正規表現で破壊的キーワード / 新規 table / 新規列を検出する。
  *
  * #2507 / #2519 との棲み分け:
  *   - #2507  = 3 dimension (schema / create-tables / lazy) 完全同期 gate (将来の full 版)
@@ -52,6 +66,7 @@ const SKIP_MARKER = '[skip-schema-migration-check]';
 
 const SCHEMA_FILE = 'src/lib/server/db/schema.ts';
 const LAZY_MIGRATION_FILE = 'src/lib/server/db/migration/lazy-startup-migrations.ts';
+const CREATE_TABLES_FILE = 'src/lib/server/db/create-tables.ts';
 
 let baseRef = process.env.BASE_REF || BASE_REF_DEFAULT;
 for (const arg of process.argv.slice(2)) {
@@ -87,13 +102,92 @@ function getSchemaDiff() {
 }
 
 /**
+ * 指定ファイルの diff (同 PR の差分全体) を取得する。
+ * 検出 (5) の「create-tables.ts / lazy-startup-migrations.ts への対応同期」判定に使う。
+ * @param {string} file
+ * @returns {string}
+ */
+function getFileDiff(file) {
+	return runGit(['diff', `${baseRef}...HEAD`, '--', file]);
+}
+
+/**
+ * create-tables.ts / lazy-startup-migrations.ts の同 PR diff から「同期済みと見なせる table 名」を集める。
+ * 該当 table 名がどちらかの diff に出現していれば、新規 table 追加の対応がなされたと判定する (#2827 検出 5)。
+ * @returns {Set<string>}
+ */
+function getSyncedTableNames() {
+	/** @type {Set<string>} */
+	const synced = new Set();
+	// table 名は create-tables.ts では `CREATE TABLE IF NOT EXISTS <name>`、
+	// lazy-startup-migrations.ts では `tableExists(db, '<name>')` / `CREATE TABLE '<name>'` 等で出現する。
+	// いずれも diff テキストに table 名が文字列として現れるため、追加/変更行から
+	// 識別子・クォート文字列トークンを広く収集し、後段で「新規 table 名」と突合する。
+	for (const file of [CREATE_TABLES_FILE, LAZY_MIGRATION_FILE]) {
+		const diff = getFileDiff(file);
+		for (const line of diff.split('\n')) {
+			if (line.startsWith('---') || line.startsWith('+++')) continue;
+			if (!line.startsWith('+') && !line.startsWith('-')) continue;
+			// snake_case 識別子 + クォート内文字列の両方をトークンとして拾う
+			for (const m of line.matchAll(/['"]?\b([a-z][a-z0-9_]+)\b['"]?/g)) {
+				synced.add(m[1]);
+			}
+		}
+	}
+	return synced;
+}
+
+/**
+ * 追加行 (added) を順に走査し、「新規追加された table 定義ブロック配下の列名 (dbColumn)」を集める。
+ * unified=0 diff では table 定義開始 `sqliteTable('<name>', {` と続く列定義行が同じ追加 hunk に
+ * 連続して並ぶため、`sqliteTable('<newtable>'` 行以降・table ブロック終端 (`});` / 次の sqliteTable)
+ * までの列を新規 table 配下と見なす。検出 (6) で新規 table のカラムを除外するために使う (#2827)。
+ *
+ * @param {string[]} added         追加行 (先頭の '+' を除去済み)
+ * @param {Set<string>} addedTables  追加側に出現した table 名
+ * @param {Set<string>} removedTables  削除側に出現した table 名 (rename は新規ではない)
+ * @returns {Set<string>}  新規 table 配下に定義された dbColumn の集合
+ */
+function collectColumnsInAddedTables(added, addedTables, removedTables) {
+	const TABLE_START_RE = /sqliteTable\(\s*['"]([\w]+)['"]/;
+	const COL_RE = /^\s*(\w+)\s*:\s*(integer|text|real|blob)\s*\(\s*['"]([\w]+)['"]/;
+	/** @type {Set<string>} */
+	const cols = new Set();
+	/** @type {string | null} */
+	let currentNewTable = null;
+	for (const line of added) {
+		const tableStart = line.match(TABLE_START_RE);
+		if (tableStart) {
+			const name = tableStart[1];
+			// 真の新規 table (追加側のみ) のときだけ追跡開始。rename / 行移動は対象外。
+			currentNewTable = addedTables.has(name) && !removedTables.has(name) ? name : null;
+			continue;
+		}
+		// table ブロック終端 (drizzle 定義の閉じ `}` / `});`) で追跡解除
+		if (currentNewTable && /^\s*\}/.test(line)) {
+			currentNewTable = null;
+			continue;
+		}
+		if (currentNewTable) {
+			const col = line.match(COL_RE);
+			if (col?.[3]) cols.add(col[3]);
+		}
+	}
+	return cols;
+}
+
+/**
  * schema.ts の diff から破壊的変更を検出する。
  * 完全 parser でなく、drizzle column 定義行の正規表現で実用的に判定する (AC7)。
  *
  * @param {string} diff  `git diff --unified=0` の出力
+ * @param {{ syncedTableNames?: Set<string> }} [options]
+ *   `syncedTableNames`: create-tables.ts / lazy-startup-migrations.ts の同 PR diff に出現した
+ *   table 名の集合。検出 (5) の同期判定に使う。未指定なら新規 table は常に未同期扱い (blocker)。
  * @returns {{ reason: string, line: string }[]}  検出された破壊的変更の一覧
  */
-export function detectBreakingChanges(diff) {
+export function detectBreakingChanges(diff, options = {}) {
+	const syncedTableNames = options.syncedTableNames ?? new Set();
 	/** @type {{ reason: string, line: string }[]} */
 	const breaking = [];
 	const lines = diff.split('\n');
@@ -208,6 +302,52 @@ export function detectBreakingChanges(diff) {
 		});
 	}
 
+	// (5) 新規 table 追加 + create-tables.ts / lazy-startup-migrations.ts 同期漏れ (#2827)
+	//     schema.ts diff に `sqliteTable('<name>', ...)` が **追加された** が、
+	//     削除側に同名 table が無い (= 真の新規 table) ものを抽出する。
+	//     根拠: schema-validator.ts:181-188 が missing table を valid=false → client.ts exit 1
+	//     (= NUC 起動停止)。新規 table 名が create-tables.ts / lazy-startup-migrations.ts の
+	//     同 PR diff に出現していなければ、新規 DB / 既存 DB 両方で table が作られず起動 block。
+	const TABLE_RE = /sqliteTable\(\s*['"]([\w]+)['"]/g;
+	/** @type {Set<string>} */
+	const removedTables = new Set();
+	for (const m of removedText.matchAll(TABLE_RE)) removedTables.add(m[1]);
+	/** @type {Set<string>} */
+	const addedTables = new Set();
+	for (const m of addedText.matchAll(TABLE_RE)) addedTables.add(m[1]);
+	for (const tableName of addedTables) {
+		if (removedTables.has(tableName)) continue; // rename / 行移動は新規ではない
+		if (syncedTableNames.has(tableName)) continue; // create-tables / lazy に同期済
+		breaking.push({
+			reason: `新規 table 追加 (table '${tableName}' が schema.ts に追加されたが create-tables.ts / lazy-startup-migrations.ts に未同期)`,
+			line: `sqliteTable('${tableName}', …)`,
+		});
+	}
+
+	// (6) 新規 NOT NULL かつ DEFAULT なし列の追加 (#2827)
+	//     既存 table に追加された新規列が notNull かつ .default() なしのケースを検出する。
+	//     根拠: validateAndMigrate:195-243 は notNull && !hasDefault の不足列を自動 ALTER 不能とし
+	//     valid=false → client.ts exit 1 (= NUC 起動停止、手動マイグレーション必須)。
+	//
+	//     除外条件:
+	//       - removedCols に同名 dbColumn がある列 = 既存列の反転 → (3) の責務
+	//       - 新規 table 配下の列 = その table は CREATE TABLE で丸ごと作られるため、
+	//         ALTER ADD COLUMN 経路に乗らず exit 1 にならない (missing-table 判定が先行)。
+	//         → 新規 table のカラムは (6) の対象外。
+	const dbColsInNewTables = collectColumnsInAddedTables(added, addedTables, removedTables);
+	for (const [dbCol, info] of addedCols) {
+		if (removedCols.has(dbCol)) continue; // 既存列の変更は (3) の責務
+		if (dbColsInNewTables.has(dbCol)) continue; // 新規 table 配下の列は CREATE TABLE 経路
+		const isNotNull = /\.notNull\(\)/.test(info.line);
+		const hasDefault = /\.default\(/.test(info.line);
+		if (isNotNull && !hasDefault) {
+			breaking.push({
+				reason: `新規 NOT NULL no-default 列追加 (列 '${dbCol}': notNull かつ DEFAULT なし → 既存 DB で自動 ALTER 不能)`,
+				line: info.line,
+			});
+		}
+	}
+
 	return breaking;
 }
 
@@ -224,24 +364,52 @@ function main() {
 	}
 
 	const diff = getSchemaDiff();
-	const breaking = detectBreakingChanges(diff);
+	// 検出 (5): create-tables.ts / lazy-startup-migrations.ts の同 PR diff から
+	// 「同期済みと見なせる table 名」を集めて新規 table の同期判定に使う。
+	const syncedTableNames = getSyncedTableNames();
+	const breaking = detectBreakingChanges(diff, { syncedTableNames });
 
 	if (breaking.length === 0) {
 		console.log(
-			'[check-schema-migration-completeness] schema.ts changed but no breaking change detected (ADD COLUMN 等は warn 対象、本 gate は OK).',
+			'[check-schema-migration-completeness] schema.ts changed but no breaking change detected (非破壊 ADD COLUMN 等は warn 対象、本 gate は OK).',
 		);
 		return;
 	}
 
 	const lazyChanged = changed.includes(LAZY_MIGRATION_FILE);
 
+	// 検出 (6) 新規 NOT NULL no-default 列は、lazy-startup-migrations.ts を触っても解決しない
+	// (schema.ts 側で DEFAULT 付与 / nullable 化が必要)。lazyChanged では bypass させない。
+	const schemaFixRequired = breaking.filter((b) =>
+		b.reason.includes('新規 NOT NULL no-default 列追加'),
+	);
+
 	console.log('');
-	console.log('[check-schema-migration-completeness] 破壊的 schema 変更を検出:');
+	console.log('[check-schema-migration-completeness] NUC 起動 block 級の schema 変更を検出:');
 	for (const b of breaking) {
 		console.log(`  - ${b.reason}`);
 		console.log(`      ${b.line}`);
 	}
 	console.log('');
+
+	if (schemaFixRequired.length > 0) {
+		console.error(
+			'❌ [check-schema-migration-completeness] BLOCKER (検出 6: 新規 NOT NULL no-default 列)',
+		);
+		console.error('');
+		console.error('  追加された NOT NULL かつ DEFAULT なしの列は、既存 production DB に対し');
+		console.error('  `validateAndMigrate` (schema-validator.ts:195-243) が自動 ALTER できず');
+		console.error('  valid=false → client.ts で exit 1 (NUC 起動停止) を引き起こします。');
+		console.error('');
+		console.error('  schema.ts 側で当該列に `.default(...)` を付与するか nullable 化してください');
+		console.error('  (lazy-startup-migrations.ts への追加では解決しません)。');
+		console.error('');
+		console.error(
+			'  参照: docs/design/08-データベース設計書.md §1 lazy migration 必須 SSOT / Issue #2827',
+		);
+		console.error('');
+		process.exit(1);
+	}
 
 	if (lazyChanged) {
 		console.log(
@@ -253,9 +421,11 @@ function main() {
 	console.error('❌ [check-schema-migration-completeness] BLOCKER');
 	console.error('');
 	console.error(
-		'  破壊的 schema 変更 (DROP COLUMN / FK target 変更 / NOT NULL 変更 / cross-table flip) を',
+		'  NUC 起動 block 級の schema 変更 (DROP COLUMN / FK target 変更 / NOT NULL 変更 /',
 	);
-	console.error('  含むのに、既存 production DB を upgrade する');
+	console.error(
+		'  cross-table flip / 新規 table 追加) を含むのに、既存 production DB を upgrade する',
+	);
 	console.error(`  ${LAZY_MIGRATION_FILE} に diff がありません。`);
 	console.error('');
 	console.error(
@@ -263,12 +433,15 @@ function main() {
 	);
 	console.error('  起動 block」を再発させます。lazy-startup-migrations.ts に shadow-table');
 	console.error('  recreation / ALTER 等の upgrade step を追加してください。');
+	console.error('  新規 table 追加の場合は create-tables.ts への CREATE TABLE 追加も必須です。');
 	console.error('');
 	console.error(
 		`  純フォーマット変更など意図的に skip する場合は PR 本文に "${SKIP_MARKER}" を含めてください。`,
 	);
 	console.error('');
-	console.error('  参照: docs/design/08-データベース設計書.md §8.6 / Issue #2507 / #2508');
+	console.error(
+		'  参照: docs/design/08-データベース設計書.md §1 lazy migration 必須 SSOT / Issue #2507 / #2508 / #2827',
+	);
 	console.error('');
 	process.exit(1);
 }

--- a/tests/unit/scripts/check-schema-migration-completeness.test.ts
+++ b/tests/unit/scripts/check-schema-migration-completeness.test.ts
@@ -109,4 +109,93 @@ describe('detectBreakingChanges (#2520 AC6/AC7)', () => {
 			expect(result.some((b) => b.reason.includes('cross-table flip'))).toBe(true);
 		});
 	});
+
+	// ---- #2827: 検出漏れ 2 経路 (新規 table 追加同期漏れ / 新規 NOT NULL no-default 列) ----
+
+	describe('(5) 新規 table 追加同期漏れ (#2827 穴A)', () => {
+		const newTableDiff = [
+			'@@ -200,0 +201,4 @@',
+			"+export const familyEvents = sqliteTable('family_events', {",
+			"+	id: integer('id').primaryKey({ autoIncrement: true }),",
+			"+	tenantId: text('tenant_id').notNull().default(''),",
+			'+});',
+		].join('\n');
+
+		it('新規 table が追加され create-tables / lazy に同期が無い → 破壊 (blocker)', () => {
+			// syncedTableNames を渡さない = 同期なし扱い
+			const result = detectBreakingChanges(newTableDiff);
+			expect(
+				result.some(
+					(b) => b.reason.includes('新規 table 追加') && b.reason.includes('family_events'),
+				),
+			).toBe(true);
+		});
+
+		it('新規 table だが create-tables / lazy の同 PR diff に該当 table 名が出現 → 非検出', () => {
+			// 境界ケース: create-tables.ts または lazy-startup-migrations.ts に 'family_events' が出現
+			const result = detectBreakingChanges(newTableDiff, {
+				syncedTableNames: new Set(['family_events']),
+			});
+			expect(result.some((b) => b.reason.includes('新規 table 追加'))).toBe(false);
+		});
+
+		it('table の rename (削除側にも同名 sqliteTable) は新規扱いしない', () => {
+			// 削除側と追加側の両方に同名 table → 行移動 / rename であり新規ではない
+			const diff = [
+				"-export const familyEvents = sqliteTable('family_events', {",
+				"+export const familyEvents = sqliteTable('family_events', {",
+			].join('\n');
+			const result = detectBreakingChanges(diff);
+			expect(result.some((b) => b.reason.includes('新規 table 追加'))).toBe(false);
+		});
+	});
+
+	describe('(6) 新規 NOT NULL no-default 列追加 (#2827 穴B)', () => {
+		it('既存 table に notNull かつ DEFAULT なし列を新規追加 → 破壊 (blocker)', () => {
+			const diff = ["+	ownerId: text('owner_id').notNull(),"].join('\n');
+			const result = detectBreakingChanges(diff);
+			expect(
+				result.some(
+					(b) =>
+						b.reason.includes('新規 NOT NULL no-default 列追加') && b.reason.includes('owner_id'),
+				),
+			).toBe(true);
+		});
+
+		it('境界ケース: 新規 notNull 列でも .default() があれば非検出', () => {
+			const diff = ["+	ownerId: text('owner_id').notNull().default(''),"].join('\n');
+			const result = detectBreakingChanges(diff);
+			expect(result.some((b) => b.reason.includes('新規 NOT NULL no-default 列追加'))).toBe(false);
+		});
+
+		it('境界ケース: 新規列でも nullable (notNull なし) なら非検出', () => {
+			const diff = ["+	memo: text('memo'),"].join('\n');
+			const result = detectBreakingChanges(diff);
+			expect(result.some((b) => b.reason.includes('新規 NOT NULL no-default 列追加'))).toBe(false);
+		});
+
+		it('境界ケース: 新規 table 配下の notNull no-default 列は (6) の対象外 (CREATE TABLE 経路)', () => {
+			// 新規 table 丸ごと追加時、その配下の notNull no-default 列は validateAndMigrate の
+			// missing-table 判定が先行し ALTER ADD COLUMN 経路に乗らないため (6) では flag しない。
+			// (table 自体は (5) で同期検証される)
+			const diff = [
+				"+export const familyEvents = sqliteTable('family_events', {",
+				"+	id: integer('id').primaryKey({ autoIncrement: true }),",
+				"+	label: text('label').notNull(),",
+				'+});',
+			].join('\n');
+			const result = detectBreakingChanges(diff, {
+				syncedTableNames: new Set(['family_events']),
+			});
+			expect(result.some((b) => b.reason.includes('新規 NOT NULL no-default 列追加'))).toBe(false);
+		});
+
+		it('既存列の notNull 反転 (両側に存在) は (3) の責務で (6) では検出しない', () => {
+			const diff = ["-	memo: text('memo'),", "+	memo: text('memo').notNull(),"].join('\n');
+			const result = detectBreakingChanges(diff);
+			// (3) NOT NULL 変更で検出されるが、(6) では検出しない
+			expect(result.some((b) => b.reason.includes('NOT NULL 変更'))).toBe(true);
+			expect(result.some((b) => b.reason.includes('新規 NOT NULL no-default 列追加'))).toBe(false);
+		});
+	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（NUC セルフホスト版を起動する運営・利用者）

**解決する課題**: `scripts/check-schema-migration-completeness.mjs` の最小版 (PR #2524) は破壊的 schema 変更 4 種 (DROP COLUMN / FK target 変更 / NOT NULL 反転 / cross-table flip) のみを blocker 化していたが、敵対的レビューで「`validateAndMigrate` (`schema-validator.ts`) が exit 1 = NUC 起動停止に到達するのに gate が素通りする」経路が 2 つ実在することが判明した。穴A (新規 table 追加 + create-tables.ts / lazy-startup-migrations.ts 同期漏れ) / 穴B (新規 NOT NULL かつ DEFAULT なし列追加) がそれにあたる。

**期待される効果**: gate の検出境界を `validateAndMigrate` / `client.ts` が exit 1 する境界と一致させることで、#2508 (NUC startup failure) と同型の「既存 / 新規 DB を新 schema に上げられず起動 block」を PR 段階の CI で機械的に止める。NUC 本番の起動 block 再発を構造的に予防する (Pre-PMF Bucket A、ADR-0010 整合)。

## 関連 Issue

closes #2827

<!-- 上流: #2507 (scope 再定義済) / 起因: #2508 (NUC startup failure) / 実装元: PR #2524 -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `detectBreakingChanges` に「(5) 新規 table 追加」検出を追加（create-tables.ts / lazy-startup-migrations.ts への対応同期がない場合 blocker） | `npx vitest run tests/unit/scripts/check-schema-migration-completeness.test.ts` | HEAD `1e77a04` / 19 passed / `scripts/check-schema-migration-completeness.mjs:305-325` (検出5 ループ) + `tests/unit/scripts/check-schema-migration-completeness.test.ts:117-160` (穴A 再現 + 境界 3 ケース PASS) |
| AC2 | 「(6) 新規 NOT NULL no-default 列追加」検出を追加（`validateAndMigrate` が exit 1 する境界と gate の検出境界を一致させる） | `npx vitest run tests/unit/scripts/check-schema-migration-completeness.test.ts` | HEAD `1e77a04` / 19 passed / `scripts/check-schema-migration-completeness.mjs:327-350` (検出6 ループ) + `main()` で lazy 変更による bypass を禁止 (`:348-361`) + test `:162-209` (穴B 再現 + 境界 4 ケース PASS) |
| AC3 | unit test に穴A/穴B の再現ケースを追加（`tests/unit/scripts/check-schema-migration-completeness.test.ts`） | `npx vitest run tests/unit/scripts/check-schema-migration-completeness.test.ts` | HEAD `1e77a04` / Test Files 1 passed / Tests 19 passed (既存 12 + 新規 7。穴A 同期済→非検出 / table rename→非検出 / 穴B default あり→非検出 / nullable→非検出 / 新規 table 配下列→非検出 / 既存列反転は(3)責務) |
| AC4 | `08-データベース設計書.md` の stale 記述（§lazy migration 必須 SSOT 末尾 L90-92 付近「#2507 は別 PR で実装する（現状未実装）」）を実装済みの記述に修正 | `git show HEAD -- "docs/design/08-データベース設計書.md"` | HEAD `1e77a04` / 「別 Issue #2507 で機械検証 script を別 PR で実装する。現状はコードレビューと本 SSOT の周知で運用」を削除し、`check-schema-migration-completeness.mjs` 実装済 + 検出 6 種 (新規 table / 新規 NOT NULL no-default 列を含む) の記述に置換 (`docs/design/08-データベース設計書.md:90-97`) |
| AC5 | `npm run pre-ready -- --pr <num>` 全 step PASS | `npm run pre-ready -- --pr 2837`（全 12 step） | PASS: HEAD `f1357808` で **全 12 step 完全通過**（Step10 doc-refs / Step11 terminology 含む）。経緯の正直な記録: 初版 `1e77a04` は agent の部分検証（biome/dogfood/doc-refs のみ）で svelte-check 未実行 → pre-ready Step2 が **TS strict nullability 6 件**を検出 → guard 修正 commit 後に全 step PASS（D-4 検証 scope 漏れの実例として記録） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: CI gate `scripts/check-schema-migration-completeness.mjs`（PR 時の static schema diff 検証のみ。アプリ実行時挙動・UI への影響なし）。本 gate は `ci.yml` job `schema-migration-completeness-check` から呼ばれ、schema.ts 変更 PR の lazy migration 同期漏れを blocker 化する。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2837` 全 Step PASS**（#1775 / ADR-0030）— HEAD `f1357808` で全 12 step PASS（svelte-check は初版の nullability 6 件を検出 → guard 修正済み）
- [x] 追加・変更したテストの概要を以下に記載: `tests/unit/scripts/check-schema-migration-completeness.test.ts` に検出(5)穴A 4 ケース（同期漏れ→blocker / 同期済→非検出 / rename→非検出）+ 検出(6)穴B 5 ケース（notNull no-default→blocker / default あり→非検出 / nullable→非検出 / 新規 table 配下列→非検出 / 既存列反転は(3)責務）を追加。計 19 passed
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret の追加なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — DB 実装変更なし（CI gate script のみ）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — `priority:high`（critical ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（fix: CI 検証 script の変更のみ。UI 変更を一切含まない）**

**4 スロット添付**（#1740）: 該当なし（UI 変更なし）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 既存 `detectBreakingChanges` の単一責任（schema diff → 破壊的変更一覧）を維持。新規 table 配下列の attribution は純粋関数 `collectColumnsInAddedTables` に分離（単一責任）。同期判定情報は `options.syncedTableNames` で注入（依存性逆転、テスト時にモック可）
- [x] **DRY**: 新規 table 名抽出 (`sqliteTable('<name>'`) / 列定義抽出は既存の正規表現パターンを踏襲。独自 SQL parser の再発明はしない（AC7 既存方針継承）
- [x] **YAGNI**: `validateAndMigrate` が exit 1 する 2 経路のみを検出。非破壊 ADD COLUMN（自動 ALTER 可能）への blocker 拡大はしない（過剰防衛回避、Issue no-gos 整合）
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A（CI script、UI なし）
- [x] **パフォーマンス**: N/A（PR 単位の static diff 解析、軽量正規表現のみ）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001): `docs/design/08-データベース設計書.md` §lazy migration 必須 SSOT の stale 記述を実装済み記述に更新（gate 検出 6 種を明記）
- [x] 並行 PR overlap 確認 (#1200): `scripts/check-schema-migration-completeness.mjs` / 同 test / `08-データベース設計書.md` を変更する他 open PR なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**: 検出(6) の境界判断について確認をお願いしたい。新規 table 丸ごと追加時、その配下の `notNull` no-default 列は `validateAndMigrate` の missing-table 判定が先行し ALTER ADD COLUMN 経路に乗らない（exit 1 にならない）ため、検出(6)では flag しない設計とした（純粋関数 `collectColumnsInAddedTables` で新規 table 配下列を除外）。table 自体は検出(5) で同期検証される。`detectBreakingChanges` の第 2 引数 `options.syncedTableNames` は後方互換（省略時は新規 table 常に未同期扱い）のため既存 4 検出の単一引数呼び出しは無変更。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

<!-- 本 PR は Draft で起票し Ready 化しない（指示）。下記は Draft 完遂時点の Dev 自己確認。 -->

- [x] **`npm run pre-ready -- --pr 2837` 全 Step PASS** をローカル確認した — HEAD `f1357808` で全 12 step 完全通過（初版の svelte-check 6 errors は修正済み、上記 AC5 に経緯記録）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1-AC5 すべて実装 + 検証エビデンス記載）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 → N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 → N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

