### PR TITLE
feat: #2824 Wave 3A — message-repo (おうえんメッセージ) DynamoDB 本実装 (ADR-0055)

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1454,6 +1454,29 @@ cognito Lambda + DynamoDB 環境にはテナント単位の `stamp_masters` seed
 
 **EPIC #2266 拡張 (2026-05-19)**: `message_type = reward_notice` を活用し、応援 P 付与 (`bonus_points`) + 理由カテゴリ (`reward_category`) を統合。`/admin/cheer` 画面で応援送信時に INSERT、子供画面で受信表示。
 
+#### DynamoDB キー設計 (#2824 Wave 3A、ADR-0055)
+
+本番 cognito Lambda は `DATA_SOURCE=dynamodb` で稼働するため、SQLite と機能等価の
+DynamoDB 実装 (`src/lib/server/db/dynamodb/message-repo.ts`) を持つ。おうえんメッセージは
+child partition 配下に置き、`findMessages` / `findUnshownMessage` / `countUnshownMessages` を
+**追加 GSI なし**の単一 partition Query で完結させる（ADR-0055 §3.1）。
+
+| エンティティ | PK | SK | 補足 |
+|---|---|---|---|
+| parent_message | `T<tid>#CHILD#<childId>` | `MSG#<paddedId>` | id は 8 桁 0 埋め。activity_logs / point_ledger と同 partition に同居。read は全て child 軸のため非正規化不要 |
+
+| アクセスパターン | 操作 | 条件 |
+|---|---|---|
+| `insertMessage` | counter 採番 → PutItem | icon default = `💌`（SQLite schema 一致）。sentAt は ISO 文字列で保存 |
+| `findMessages(childId, limit)` | Query | `PK = T<tid>#CHILD#<childId> AND begins_with(SK, 'MSG#')`。sent_at 降順（同値は id 降順 tiebreaker）+ limit は in-memory（SQLite SSOT と一致） |
+| `findUnshownMessage(childId)` / `countUnshownMessages(childId)` | Query（child partition）+ in-memory filter | `shown_at IS NULL` を filter。前者は最新 1 件、後者は件数 |
+| `markMessageShown(messageId)` | Scan（id filter）で PK/SK 解決 → UpdateItem（`ALL_NEW`） | childId を受けないため id で 1 件特定（reward-redemption-repo.markRedemptionResultShown と同型、低頻度経路） |
+| `deleteByTenantId` | Scan → BatchWrite | `CHILD#*` 配下の `MSG#` を削除（`deleteItemsByPkPrefix`） |
+
+新規 SK prefix `MSG#` は既存テーブルにそのまま乗るため **CDK 変更不要**（追加 GSI なし）。
+おうえんメッセージは LP (`feature-cheer-message`) が訴求する機能であり、本 repo は #2263 hotfix で
+「read=空 / write=no-op」化されていた（本番で送信が永続しない ADR-0013 LP truth 違反級）gap を本実装で根治。
+
 ### rest_days
 
 おやすみ日。子供ごとに特定日の記録を免除する設定。
@@ -2375,3 +2398,4 @@ per-child refactor (ADR-0055) で頻発する子供 UI 破綻を pixelmatch base
 | 2026-05-27 | 5.15 | #2520 §8.6「機械検証」を将来予告から実装済に更新。(1) `scripts/check-schema-migration-completeness.mjs` を最小版実装 (#2507 予告) — schema.ts 破壊的変更 (DROP COLUMN / FK target / NOT NULL / cross-table flip) 検出時のみ lazy-startup-migrations.ts 同期を blocker 化 (ci.yml `schema-migration-completeness-check`)。(2) 既存 DB upgrade path test — `tests/fixtures/legacy-schema/<YYYY-MM>.sql` snapshot + `tests/integration/db/legacy-schema-upgrade.test.ts` で #2508 を捕捉 (fresh DB only の盲点解消)。(3) child home 5 mode visual baseline (`scripts/child-home-baseline/`、pixelmatch warn)。(4) CWE-598 child 越境記録ガード (`recordActivity` を `findActivityByIdForChild` 3 軸スコープ化、ADR-0055 §3.1)。schema 自体に変更なし (gate / test / guard 追加のメタ更新) |
 | 2026-05-30 | 5.16 | #2641 + #2642 + #2675 + #2685 (Phase 5 子 3+4 / Phase 6 子 3 / Phase 7 PR-1) — **Billing 再設計 expand 段階**。(1) `stripe_webhook_events` 新規 table 追加 (Stripe Webhook 冪等性 dedup、event_id PK + 6 列 + 2 index、30 日 retention ADR-0049 整合、DynamoDB は `PK=STRIPE_WEBHOOK_EVENT` single-partition + native TTL)。(2) `archived_reason` enum 3 値 SSOT 化 — `src/lib/domain/archive-types.ts` 新規 (`ARCHIVED_REASONS = ['trial_expired', 'downgrade_user_selected', 'dunning_canceled'] as const`) + drizzle schema 4 location (`children` / `activities` / `child_activities` / `checklist_templates`) で `text(..., { enum: ARCHIVED_REASONS })` 制約適用 + `getRetentionDays(reason)` helper。(3) lazy migration `migrateBillingPhase6` — table 新規作成 + 既存 archived row の NULL → `'downgrade_user_selected'` 補充 (4 location × idempotent)。`code 変更ゼロ` の expand 段階で後続 PR の前提を配備、handler 統合は Phase 7 PR-4a 連動。詳細は `docs/design/billing-redesign/phase5-webhook-idempotency-architecture.md` / `phase5-archive-unified-architecture.md` / `phase6-db-migration-plan.md` 参照 |
 | 2026-06-04 | 5.17 | #2824 Phase 2A (ADR-0055) — `reward_redemption_requests` の DynamoDB 本実装。本 repo は #2263 hotfix で「read=空 / write=no-op」化され、本番 cognito Lambda (`DATA_SOURCE=dynamodb`) でごほうび交換 (記録 → ポイント → 交換) が永続しない致命的 gap だった。SQLite 機能等価で本実装。キー設計: PK `T#<tid>#CHILD#<childId>` + SK `REDEMPT#<paddedId>` (child partition 同居、`findRedemptionRequestsByChild` を追加 GSI なし単一 partition Query で完結)。JOIN 代替に childName / rewardTitle / rewardIcon / rewardPoints を insert 時に非正規化保存し tenant 横断 read の N+1 を回避。id のみ受ける update / markShown は tenant Scan + id filter で PK/SK 解決 (special-reward-repo.markRewardShown 同型)。残高減算は service 層責務のため repo は status 更新のみ (TransactWriteItems 不要)。stub baseline (`scripts/dynamodb-stub-baseline.json`) から本 repo を削除 (12 → 11 repo 前進)。CDK 変更なし。schema 自体に変更なし (DynamoDB 実装の追加) |
+| 2026-06-04 | 5.18 | #2824 Wave 3A (ADR-0055) — `parent_messages` (おうえんメッセージ 親→子) の DynamoDB 本実装。本 repo は #2263 hotfix で「read=空 / write=no-op」化され、本番 cognito Lambda (`DATA_SOURCE=dynamodb`) で送信が永続しない gap だった。おうえんメッセージは LP (`feature-cheer-message`) が訴求する機能のため ADR-0013 LP truth 違反級。SQLite 機能等価で本実装。キー設計: PK `T<tid>#CHILD#<childId>` + SK `MSG#<paddedId>` (child partition 同居、`findMessages` / `findUnshownMessage` / `countUnshownMessages` を追加 GSI なし単一 partition Query で完結)。read は全て child 軸のため非正規化不要。sent_at 降順 (同値は id 降順 tiebreaker) + shown_at IS NULL filter は in-memory (SQLite SSOT 一致)。id のみ受ける `markMessageShown` は tenant Scan + id filter で PK/SK 解決 (reward-redemption-repo 同型、低頻度)。stub baseline から本 repo を削除 (10 → 9 repo 前進)。CDK 変更なし。schema 自体に変更なし (DynamoDB 実装の追加) |

--- a/scripts/dynamodb-stub-baseline.json
+++ b/scripts/dynamodb-stub-baseline.json
@@ -43,14 +43,6 @@
 		"incrementDownloadCount",
 		"insert"
 	],
-	"src/lib/server/db/dynamodb/message-repo.ts": [
-		"countUnshownMessages",
-		"deleteByTenantId",
-		"findMessages",
-		"findUnshownMessage",
-		"insertMessage",
-		"markMessageShown"
-	],
 	"src/lib/server/db/dynamodb/report-daily-summary-repo.ts": [
 		"deleteByTenantId",
 		"deleteOlderThan",

--- a/src/lib/server/db/dynamodb/keys.ts
+++ b/src/lib/server/db/dynamodb/keys.ts
@@ -366,6 +366,28 @@ export function rewardRedemptionPrefix(): string {
 }
 
 /**
+ * Parent message (#2266 / #2824 Wave 3A / ADR-0055):
+ *   PK = T#<tenantId>#CHILD#<childId>, SK = MSG#<paddedId>
+ *
+ * おうえんメッセージ (親→子) を child partition 配下に置き (activity_logs / point_ledger と同居)、
+ * `findMessages` / `findUnshownMessage` / `countUnshownMessages` を単一 partition Query
+ * (begins_with(SK, 'MSG#')) で完結させる。read は全て child 軸のため追加 GSI 不要 (ADR-0055 §3.1)。
+ * `markMessageShown` は messageId のみ受けるため tenant Scan + id filter で 1 件特定する
+ * (reward-redemption-repo.findRedemptionItemById と同じパターン、低頻度経路)。
+ */
+export function parentMessageKey(childId: number, messageId: number, tenantId: string): DynamoKey {
+	return {
+		PK: tenantPK(`${PREFIX.CHILD}#${childId}`, tenantId),
+		SK: `MSG#${padId(messageId)}`,
+	};
+}
+
+/** Parent message SK prefix for querying all messages of a child */
+export function parentMessagePrefix(): string {
+	return 'MSG#';
+}
+
+/**
  * Checklist template: PK=T#<tenantId>#CKTPL, SK=CKTPL#<id>
  * #2362 PR-5 (ADR-0055): family master 化に伴い CHILD#<cId> 配下 → tenant scope に変更。
  */
@@ -799,6 +821,7 @@ export const ENTITY_NAMES = {
 	childTitle: 'childTitle',
 	specialReward: 'specialReward',
 	rewardRedemption: 'rewardRedemption',
+	parentMessage: 'parentMessage',
 	checklistTemplate: 'checklistTemplate',
 	checklistAssignment: 'checklistAssignment',
 	checklistItem: 'checklistItem',

--- a/src/lib/server/db/dynamodb/message-repo.ts
+++ b/src/lib/server/db/dynamodb/message-repo.ts
@@ -201,27 +201,38 @@ async function queryChildMessages(
 
 /**
  * messageId だけ受け取る markMessageShown 用に、tenant 配下を Scan して PK/SK + item を
- * 解決する。SK は MSG#<id> だが childId が不明なため tenant Scan + id filter で 1 件特定する
- * (reward-redemption-repo.findRedemptionItemById と同じパターン、低頻度経路)。
+ * 解決する。SK は MSG#<id> だが childId が不明なため tenant Scan + id filter で 1 件特定する。
+ *
+ * #2842: DynamoDB の Scan `Limit` は **FilterExpression 適用前に評価された item 数** を
+ *   上限とするため、`Limit: 1` + Filter では「scan 順で先頭に来た 1 件」が filter に一致
+ *   しない限り `Items` が空になり markMessageShown が無言で no-op になる致命バグだった。
+ *   正しくは `Limit` を付けず (= page ごと最大 1MB を評価)、`ExclusiveStartKey` で
+ *   `LastEvaluatedKey` が尽きるまでページングし、一致 item を見つけた時点で早期 return する。
+ *   一致が無ければ全ページ走査後に undefined を返す (queryChildMessages と同じページング正パターン)。
  */
 async function findMessageItemById(
 	id: number,
 	tenantId: string,
 ): Promise<({ PK: string; SK: string } & Record<string, unknown>) | undefined> {
-	const result = await getDocClient().send(
-		new ScanCommand({
-			TableName: TABLE_NAME,
-			FilterExpression:
-				'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
-			ExpressionAttributeValues: {
-				':tenantPrefix': tenantPK('CHILD#', tenantId),
-				':skPrefix': PREFIX,
-				':id': id,
-			},
-			Limit: 1,
-		}),
-	);
-	const item = (result.Items ?? [])[0];
-	if (!item) return undefined;
-	return item as { PK: string; SK: string } & Record<string, unknown>;
+	const doc = getDocClient();
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression:
+					'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
+				ExpressionAttributeValues: {
+					':tenantPrefix': tenantPK('CHILD#', tenantId),
+					':skPrefix': PREFIX,
+					':id': id,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		const item = (result.Items ?? [])[0];
+		if (item) return item as { PK: string; SK: string } & Record<string, unknown>;
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return undefined;
 }

--- a/src/lib/server/db/dynamodb/message-repo.ts
+++ b/src/lib/server/db/dynamodb/message-repo.ts
@@ -1,79 +1,227 @@
-// DynamoDB implementation of IMessageRepo
+// src/lib/server/db/dynamodb/message-repo.ts
+// おうえんメッセージ (親→子) リポジトリ — DynamoDB 本実装 (#2266 / #2824 Wave 3A / ADR-0055)
 //
-// #2263 hotfix: 旧バージョンの未実装エラー throw で本番 500 を引き起こしうるため、
-// Pre-PMF fallback (read = 空 / write = no-op + logger.warn) に置換。
-// 親→子メッセージ機能は本番未活用 (ADR-0010 Pre-PMF Bucket B = まだ作らない)。
+// IMessageRepo (interfaces/message-repo.interface.ts) を SQLite 実装
+// (sqlite/message-repo.ts、挙動 SSOT) と機能等価に DynamoDB single-table で実装する。
+//
+// 経緯: 本 repo は #2263 hotfix で「read=空 / write=no-op + logger.warn」化された。
+//   おうえんメッセージは LP (feature-cheer-message) が訴求する機能であり、本番 cognito
+//   Lambda (AUTH_MODE=cognito + DATA_SOURCE=dynamodb) で送信が永続しないのは ADR-0013
+//   LP truth 違反級。本実装で根治する。
+//
+// key 設計 (keys.ts §parentMessageKey):
+//   PK = T#<tenantId>#CHILD#<childId>   (child partition、activity_logs 等と同居)
+//   SK = MSG#<paddedId>                 (8 桁 0 埋め、辞書順)
+//   → findMessages / findUnshownMessage / countUnshownMessages は単一 partition Query で
+//     完結し GSI 不要 (ADR-0055 §3.1)。markMessageShown は messageId のみ受けるため
+//     tenant Scan + id filter で 1 件特定する (reward-redemption-repo と同パターン、低頻度)。
+//
+// 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/message-repo.ts (SSOT)
 
-import { logger } from '$lib/server/logger';
+import { PutCommand, QueryCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type { InsertParentMessageInput, ParentMessage } from '../types';
+import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
+import { childPK, ENTITY_NAMES, parentMessageKey, parentMessagePrefix, tenantPK } from './keys';
+import { stripKeys } from './repo-helpers';
 
-const SERVICE = 'message-repo.dynamodb';
+const PREFIX = parentMessagePrefix();
 
-function warnRead(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] read fallback: returning empty (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
+/**
+ * DynamoDB item を ParentMessage に正規化する。
+ * SQLite の schema default (icon='💌' / shownAt=null / bonusPoints=null /
+ * rewardCategory=null) と整合させるため、欠落しうる属性を補完する
+ * (旧データ防御。本実装の write は常に全属性を埋める)。
+ */
+function toMessage(item: Record<string, unknown>): ParentMessage {
+	const s = stripKeys(item) as Record<string, unknown>;
+	return {
+		id: s.id as number,
+		childId: s.childId as number,
+		messageType: s.messageType as string,
+		stampCode: (s.stampCode ?? null) as string | null,
+		body: (s.body ?? null) as string | null,
+		icon: (s.icon ?? '💌') as string,
+		sentAt: s.sentAt as string,
+		shownAt: (s.shownAt ?? null) as string | null,
+		bonusPoints: (s.bonusPoints ?? null) as number | null,
+		rewardCategory: (s.rewardCategory ?? null) as string | null,
+	};
 }
 
-function warnWrite(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] write fallback: no-op (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
-}
+// ============================================================
+// insertMessage — おうえんメッセージを送信 (保存)
+// ============================================================
 
 export async function insertMessage(
 	input: InsertParentMessageInput,
 	tenantId: string,
 ): Promise<ParentMessage> {
-	warnWrite('insertMessage', { childId: input.childId, messageType: input.messageType, tenantId });
-	return {
-		id: 0,
+	const id = await nextId(ENTITY_NAMES.parentMessage, tenantId);
+	const message: ParentMessage = {
+		id,
 		childId: input.childId,
 		messageType: input.messageType,
 		stampCode: input.stampCode ?? null,
 		body: input.body ?? null,
+		// SQLite schema default 'icon' = '💌' と一致。
 		icon: input.icon ?? '💌',
 		sentAt: new Date().toISOString(),
 		shownAt: null,
-		// #2267 (EPIC #2266): cheer 機能の新カラム (Pre-PMF fallback では NULL を返す)
 		bonusPoints: input.bonusPoints ?? null,
 		rewardCategory: input.rewardCategory ?? null,
 	};
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...parentMessageKey(input.childId, id, tenantId),
+				...message,
+			},
+		}),
+	);
+
+	return message;
 }
+
+// ============================================================
+// findMessages — 子供のメッセージ履歴を取得 (降順)
+// ============================================================
 
 export async function findMessages(
 	childId: number,
 	limit: number,
 	tenantId: string,
 ): Promise<ParentMessage[]> {
-	warnRead('findMessages', { childId, limit, tenantId });
-	return [];
+	const items = await queryChildMessages(childId, tenantId);
+	const messages = items.map(toMessage);
+	// SQLite: ORDER BY sent_at DESC LIMIT。同 sentAt は id 降順を tiebreaker にする
+	// (新しい id ほど後発のため SQLite の挿入順 desc と整合する)。
+	messages.sort(compareSentAtDesc);
+	return messages.slice(0, limit);
 }
+
+// ============================================================
+// findUnshownMessage — 子供の未表示メッセージを 1 件取得 (最新)
+// ============================================================
 
 export async function findUnshownMessage(
 	childId: number,
 	tenantId: string,
 ): Promise<ParentMessage | undefined> {
-	warnRead('findUnshownMessage', { childId, tenantId });
-	return undefined;
+	const items = await queryChildMessages(childId, tenantId);
+	// SQLite: WHERE shown_at IS NULL ORDER BY sent_at DESC LIMIT 1
+	const unshown = items
+		.map(toMessage)
+		.filter((m) => m.shownAt === null)
+		.sort(compareSentAtDesc);
+	return unshown[0];
 }
 
+// ============================================================
+// countUnshownMessages — 未表示メッセージ数を取得
+// ============================================================
+
 export async function countUnshownMessages(childId: number, tenantId: string): Promise<number> {
-	warnRead('countUnshownMessages', { childId, tenantId });
-	return 0;
+	const items = await queryChildMessages(childId, tenantId);
+	return items.map(toMessage).filter((m) => m.shownAt === null).length;
 }
+
+// ============================================================
+// markMessageShown — メッセージを表示済みにする
+// ============================================================
 
 export async function markMessageShown(
 	messageId: number,
 	tenantId: string,
 ): Promise<ParentMessage | undefined> {
-	warnWrite('markMessageShown', { messageId, tenantId });
-	return undefined;
+	const found = await findMessageItemById(messageId, tenantId);
+	if (!found) return undefined;
+	const result = await getDocClient().send(
+		new UpdateCommand({
+			TableName: TABLE_NAME,
+			Key: { PK: found.PK, SK: found.SK },
+			UpdateExpression: 'SET shownAt = :now',
+			ExpressionAttributeValues: { ':now': new Date().toISOString() },
+			ReturnValues: 'ALL_NEW',
+		}),
+	);
+	if (!result.Attributes) return undefined;
+	return toMessage(result.Attributes);
 }
 
-/** テナントの全メッセージを削除（Pre-PMF fallback: no-op） */
+// ============================================================
+// deleteByTenantId — テナントの全メッセージを削除
+// ============================================================
+
 export async function deleteByTenantId(tenantId: string): Promise<void> {
-	warnWrite('deleteByTenantId', { tenantId });
+	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), PREFIX);
+}
+
+// ============================================================
+// 内部ヘルパ
+// ============================================================
+
+/**
+ * sentAt 降順 + id 降順 (tiebreaker) で比較する。
+ * SQLite `ORDER BY sent_at DESC` の決定的な実装等価 (同 sentAt 時は後発 id を先頭に)。
+ */
+function compareSentAtDesc(a: ParentMessage, b: ParentMessage): number {
+	if (a.sentAt !== b.sentAt) return a.sentAt < b.sentAt ? 1 : -1;
+	return b.id - a.id;
+}
+
+/** 指定 child partition の MSG# item を全件 Query する (ページング対応)。 */
+async function queryChildMessages(
+	childId: number,
+	tenantId: string,
+): Promise<Record<string, unknown>[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				ExpressionAttributeValues: {
+					':pk': childPK(childId, tenantId),
+					':prefix': PREFIX,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) items.push(item);
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return items;
+}
+
+/**
+ * messageId だけ受け取る markMessageShown 用に、tenant 配下を Scan して PK/SK + item を
+ * 解決する。SK は MSG#<id> だが childId が不明なため tenant Scan + id filter で 1 件特定する
+ * (reward-redemption-repo.findRedemptionItemById と同じパターン、低頻度経路)。
+ */
+async function findMessageItemById(
+	id: number,
+	tenantId: string,
+): Promise<({ PK: string; SK: string } & Record<string, unknown>) | undefined> {
+	const result = await getDocClient().send(
+		new ScanCommand({
+			TableName: TABLE_NAME,
+			FilterExpression:
+				'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
+			ExpressionAttributeValues: {
+				':tenantPrefix': tenantPK('CHILD#', tenantId),
+				':skPrefix': PREFIX,
+				':id': id,
+			},
+			Limit: 1,
+		}),
+	);
+	const item = (result.Items ?? [])[0];
+	if (!item) return undefined;
+	return item as { PK: string; SK: string } & Record<string, unknown>;
 }

--- a/tests/unit/db/dynamodb-message-repo.test.ts
+++ b/tests/unit/db/dynamodb-message-repo.test.ts
@@ -332,6 +332,58 @@ describe('markMessageShown', () => {
 		// Scan のみ、Update は呼ばない
 		expect(mockSend).toHaveBeenCalledTimes(1);
 	});
+
+	// ----------------------------------------------------------
+	// #2842 回帰: Scan の Limit は filter 前評価。対象 item が scan 順で先頭ページに
+	//   無いケースを LastEvaluatedKey で再現し、ページングで必ず見つけることを固定する。
+	//   旧 `Limit: 1` 単発実装ではこのケースで Items=[] となり markMessageShown が
+	//   無言で no-op になっていた (Issue #2842)。
+	// ----------------------------------------------------------
+	it('#2842: 対象 item が先頭ページに無くても LastEvaluatedKey でページングして見つける', async () => {
+		// 1) 1 ページ目: 別 id の item のみ (target 不在) + LastEvaluatedKey
+		mockSend.mockResolvedValueOnce({
+			Items: [],
+			LastEvaluatedKey: { PK: 'cursor', SK: 'cursor' },
+		});
+		// 2) 2 ページ目: 目的の id=7 が見つかる
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 7, shownAt: null })],
+		});
+		// 3) UpdateCommand
+		mockSend.mockResolvedValueOnce({
+			Attributes: makeItem({ id: 7, shownAt: '2026-06-04T02:00:00.000Z' }),
+		});
+
+		const { markMessageShown } = await loadRepo();
+		const result = await markMessageShown(7, TENANT);
+
+		// 2 ページ走査して target を見つけ、Update まで到達できる (no-op しない)
+		expect(result?.shownAt).toBe('2026-06-04T02:00:00.000Z');
+		// Scan 2 回 + Update 1 回
+		expect(mockSend).toHaveBeenCalledTimes(3);
+
+		// 2 回目の Scan に ExclusiveStartKey が渡り、Limit が付いていないこと (filter 前評価の罠回避)
+		const secondScan = mockSend.mock.calls[1]?.[0] as {
+			input: { ExclusiveStartKey?: Record<string, unknown>; Limit?: number };
+		};
+		expect(secondScan.input.ExclusiveStartKey).toEqual({ PK: 'cursor', SK: 'cursor' });
+		expect(secondScan.input.Limit).toBeUndefined();
+	});
+
+	it('#2842: 全ページ走査しても target が無ければ undefined (Update を呼ばない)', async () => {
+		// 1) 1 ページ目: target 不在 + LastEvaluatedKey
+		mockSend.mockResolvedValueOnce({
+			Items: [],
+			LastEvaluatedKey: { PK: 'cursor', SK: 'cursor' },
+		});
+		// 2) 2 ページ目: 依然 target 不在 + LastEvaluatedKey 無し (走査終端)
+		mockSend.mockResolvedValueOnce({ Items: [] });
+
+		const { markMessageShown } = await loadRepo();
+		expect(await markMessageShown(404, TENANT)).toBeUndefined();
+		// Scan 2 回のみ、Update は呼ばない
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
 });
 
 // ============================================================

--- a/tests/unit/db/dynamodb-message-repo.test.ts
+++ b/tests/unit/db/dynamodb-message-repo.test.ts
@@ -1,0 +1,398 @@
+/**
+ * tests/unit/db/dynamodb-message-repo.test.ts
+ *
+ * #2266 / #2824 Wave 3A / ADR-0055: DynamoDB おうえんメッセージ (親→子) repo 本実装の単体テスト。
+ *
+ * AWS SDK を vi.hoisted mock で置き換え、SQLite 実装 (sqlite/message-repo.ts、挙動 SSOT) と
+ * 機能等価であることを method ごとに検証する:
+ *   - 正しい Command + key で send する
+ *   - response を正しく型変換する (stripKeys / icon default backfill)
+ *   - SQLite 機能等価 (sent_at DESC 並び / shown_at IS NULL filter / count / markShown id 解決)
+ *
+ * 背景: 本 repo は #2263 hotfix で read=空 / write=no-op 化され、おうえんメッセージ送信が本番
+ *   DynamoDB Lambda で永続しなかった。LP (feature-cheer-message) が訴求する機能のため ADR-0013
+ *   LP truth 違反級。本テストは本実装の機能等価性を回帰固定する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const { mockSend, MockPutCommand, MockQueryCommand, MockUpdateCommand, MockScanCommand } =
+	vi.hoisted(() => {
+		const send = vi.fn();
+		class Cmd {
+			input: unknown;
+			constructor(input: unknown) {
+				this.input = input;
+			}
+		}
+		return {
+			mockSend: send,
+			MockPutCommand: class extends Cmd {},
+			MockQueryCommand: class extends Cmd {},
+			MockUpdateCommand: class extends Cmd {},
+			MockScanCommand: class extends Cmd {},
+		};
+	});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	UpdateCommand: MockUpdateCommand,
+	ScanCommand: MockScanCommand,
+	// deleteByTenantId は bulk-delete.ts (BatchWriteCommand + ScanCommand) を動的 import する。
+	BatchWriteCommand: class {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	},
+}));
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/message-repo');
+}
+
+const TENANT = 'tenant-1';
+const CHILD_ID = 42;
+
+/** child partition の DynamoDB message item を組み立てる (PK/SK + 属性)。 */
+function makeItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const id = (over.id as number) ?? 1;
+	return {
+		PK: `T#${TENANT}#CHILD#${CHILD_ID}`,
+		SK: `MSG#${String(id).padStart(8, '0')}`,
+		id,
+		childId: CHILD_ID,
+		messageType: 'text',
+		stampCode: null,
+		body: 'がんばったね',
+		icon: '💌',
+		sentAt: '2026-06-04T00:00:00.000Z',
+		shownAt: null,
+		bonusPoints: null,
+		rewardCategory: null,
+		...over,
+	};
+}
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// insertMessage
+// ============================================================
+
+describe('insertMessage', () => {
+	it('counter 採番 → PutItem し SQLite default 値を埋めた row を返す (永続の核心経路)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 101 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insertMessage } = await loadRepo();
+		const result = await insertMessage(
+			{ childId: CHILD_ID, messageType: 'text', body: 'やったね' },
+			TENANT,
+		);
+
+		expect(result.id).toBe(101);
+		expect(result).toMatchObject({
+			childId: CHILD_ID,
+			messageType: 'text',
+			body: 'やったね',
+			// SQLite schema default 'icon' = '💌'
+			icon: '💌',
+			stampCode: null,
+			shownAt: null,
+			bonusPoints: null,
+			rewardCategory: null,
+		});
+		expect(typeof result.sentAt).toBe('string');
+
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(putCall.input.Item?.SK).toBe('MSG#00000101');
+		expect(putCall.input.Item?.body).toBe('やったね');
+		expect(putCall.input.Item?.icon).toBe('💌');
+	});
+
+	it('stamp / bonusPoints / rewardCategory / icon 指定を反映する (#2267 cheer)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 5 } }).mockResolvedValueOnce({});
+		const { insertMessage } = await loadRepo();
+		const result = await insertMessage(
+			{
+				childId: CHILD_ID,
+				messageType: 'reward_notice',
+				stampCode: 'star',
+				icon: '⭐',
+				bonusPoints: 10,
+				rewardCategory: 'undou',
+			},
+			TENANT,
+		);
+		expect(result).toMatchObject({
+			messageType: 'reward_notice',
+			stampCode: 'star',
+			icon: '⭐',
+			bonusPoints: 10,
+			rewardCategory: 'undou',
+		});
+	});
+});
+
+// ============================================================
+// findMessages
+// ============================================================
+
+describe('findMessages', () => {
+	it('child partition を Query し sentAt 降順で返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, body: 'old', sentAt: '2026-06-01T00:00:00.000Z' }),
+				makeItem({ id: 2, body: 'new', sentAt: '2026-06-03T00:00:00.000Z' }),
+			],
+		});
+		const { findMessages } = await loadRepo();
+		const result = await findMessages(CHILD_ID, 10, TENANT);
+		expect(result.map((m) => m.body)).toEqual(['new', 'old']);
+
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: {
+				KeyConditionExpression?: string;
+				ExpressionAttributeValues?: Record<string, string>;
+			};
+		};
+		expect(callArg.input.KeyConditionExpression).toContain('PK = :pk');
+		expect(callArg.input.ExpressionAttributeValues?.[':pk']).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(callArg.input.ExpressionAttributeValues?.[':prefix']).toBe('MSG#');
+	});
+
+	it('同 sentAt は id 降順を tiebreaker にする (新しい id が先頭)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, body: 'first' }),
+				makeItem({ id: 3, body: 'third' }),
+				makeItem({ id: 2, body: 'second' }),
+			],
+		});
+		const { findMessages } = await loadRepo();
+		const result = await findMessages(CHILD_ID, 10, TENANT);
+		expect(result.map((m) => m.body)).toEqual(['third', 'second', 'first']);
+	});
+
+	it('limit で件数を絞る', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, sentAt: '2026-06-01T00:00:00.000Z' }),
+				makeItem({ id: 2, sentAt: '2026-06-02T00:00:00.000Z' }),
+				makeItem({ id: 3, sentAt: '2026-06-03T00:00:00.000Z' }),
+			],
+		});
+		const { findMessages } = await loadRepo();
+		const result = await findMessages(CHILD_ID, 2, TENANT);
+		expect(result.map((m) => m.id)).toEqual([3, 2]);
+	});
+
+	it('LastEvaluatedKey でページングする', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [makeItem({ id: 1, sentAt: '2026-06-01T00:00:00.000Z' })],
+				LastEvaluatedKey: { PK: 'c', SK: 'c' },
+			})
+			.mockResolvedValueOnce({ Items: [makeItem({ id: 2, sentAt: '2026-06-02T00:00:00.000Z' })] });
+		const { findMessages } = await loadRepo();
+		const result = await findMessages(CHILD_ID, 10, TENANT);
+		expect(result).toHaveLength(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+
+	it('0 件のときは空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findMessages } = await loadRepo();
+		expect(await findMessages(CHILD_ID, 10, TENANT)).toEqual([]);
+	});
+
+	it('icon 欠落 item は 💌 に backfill する', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [makeItem({ id: 1, icon: undefined })] });
+		const { findMessages } = await loadRepo();
+		const result = await findMessages(CHILD_ID, 10, TENANT);
+		expect(result[0]?.icon).toBe('💌');
+	});
+});
+
+// ============================================================
+// findUnshownMessage
+// ============================================================
+
+describe('findUnshownMessage', () => {
+	it('shownAt が null の最新 1 件を返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({
+					id: 1,
+					body: 'shown',
+					shownAt: '2026-06-02T00:00:00.000Z',
+					sentAt: '2026-06-04T00:00:00.000Z',
+				}),
+				makeItem({ id: 2, body: 'unshownOld', shownAt: null, sentAt: '2026-06-01T00:00:00.000Z' }),
+				makeItem({ id: 3, body: 'unshownNew', shownAt: null, sentAt: '2026-06-03T00:00:00.000Z' }),
+			],
+		});
+		const { findUnshownMessage } = await loadRepo();
+		const result = await findUnshownMessage(CHILD_ID, TENANT);
+		expect(result?.body).toBe('unshownNew');
+	});
+
+	it('未表示が無いとき undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1, shownAt: '2026-06-02T00:00:00.000Z' })],
+		});
+		const { findUnshownMessage } = await loadRepo();
+		expect(await findUnshownMessage(CHILD_ID, TENANT)).toBeUndefined();
+	});
+
+	it('0 件のとき undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findUnshownMessage } = await loadRepo();
+		expect(await findUnshownMessage(CHILD_ID, TENANT)).toBeUndefined();
+	});
+});
+
+// ============================================================
+// countUnshownMessages
+// ============================================================
+
+describe('countUnshownMessages', () => {
+	it('shownAt が null の件数を返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, shownAt: null }),
+				makeItem({ id: 2, shownAt: '2026-06-02T00:00:00.000Z' }),
+				makeItem({ id: 3, shownAt: null }),
+			],
+		});
+		const { countUnshownMessages } = await loadRepo();
+		expect(await countUnshownMessages(CHILD_ID, TENANT)).toBe(2);
+	});
+
+	it('0 件のとき 0 を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { countUnshownMessages } = await loadRepo();
+		expect(await countUnshownMessages(CHILD_ID, TENANT)).toBe(0);
+	});
+});
+
+// ============================================================
+// markMessageShown
+// ============================================================
+
+describe('markMessageShown', () => {
+	it('id を Scan で解決し shownAt を SET して ALL_NEW を返す', async () => {
+		// 1) findMessageItemById Scan
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 7, shownAt: null })],
+		});
+		// 2) UpdateCommand
+		mockSend.mockResolvedValueOnce({
+			Attributes: makeItem({ id: 7, shownAt: '2026-06-04T01:00:00.000Z' }),
+		});
+
+		const { markMessageShown } = await loadRepo();
+		const result = await markMessageShown(7, TENANT);
+		expect(result?.shownAt).toBe('2026-06-04T01:00:00.000Z');
+
+		const scanCall = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scanCall.input.FilterExpression).toContain('id = :id');
+		expect(scanCall.input.ExpressionAttributeValues?.[':id']).toBe(7);
+		expect(scanCall.input.ExpressionAttributeValues?.[':skPrefix']).toBe('MSG#');
+
+		const updCall = mockSend.mock.calls[1]?.[0] as {
+			input: { UpdateExpression?: string; ReturnValues?: string };
+		};
+		expect(updCall.input.UpdateExpression).toContain('shownAt = :now');
+		expect(updCall.input.ReturnValues).toBe('ALL_NEW');
+	});
+
+	it('id が不在のとき Update せず undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] }); // Scan 0 件
+		const { markMessageShown } = await loadRepo();
+		expect(await markMessageShown(99, TENANT)).toBeUndefined();
+		// Scan のみ、Update は呼ばない
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ============================================================
+// deleteByTenantId
+// ============================================================
+
+describe('deleteByTenantId', () => {
+	it('tenant 配下の MSG# item を Scan して BatchWrite 削除する', async () => {
+		// bulk-delete: Scan (keys) → (空なら BatchWrite 0 回)
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'MSG#00000001' },
+				{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'MSG#00000002' },
+			],
+		});
+		mockSend.mockResolvedValueOnce({}); // BatchWrite
+
+		const { deleteByTenantId } = await loadRepo();
+		await deleteByTenantId(TENANT);
+
+		const scanCall = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scanCall.input.FilterExpression).toContain('begins_with(PK, :pkPrefix)');
+		expect(scanCall.input.ExpressionAttributeValues?.[':pkPrefix']).toBe(`T#${TENANT}#CHILD#`);
+		expect(scanCall.input.ExpressionAttributeValues?.[':skPrefix']).toBe('MSG#');
+	});
+
+	it('0 件のとき BatchWrite を呼ばない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { deleteByTenantId } = await loadRepo();
+		await deleteByTenantId(TENANT);
+		expect(mockSend).toHaveBeenCalledTimes(1); // Scan のみ
+	});
+});
+
+// ============================================================
+// interface 適合 (SQLite との機能等価性)
+// ============================================================
+
+describe('interface 適合 (IMessageRepo)', () => {
+	it('全メソッドを export している (stub に後退していない)', async () => {
+		const repo = await loadRepo();
+		for (const m of [
+			'insertMessage',
+			'findMessages',
+			'findUnshownMessage',
+			'countUnshownMessages',
+			'markMessageShown',
+			'deleteByTenantId',
+		]) {
+			expect(typeof (repo as Record<string, unknown>)[m]).toBe('function');
+		}
+	});
+
+	it('write method が no-op stub でない (insertMessage が実 send し row を返す)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		const { insertMessage } = await loadRepo();
+		const result = await insertMessage({ childId: CHILD_ID, messageType: 'stamp' }, TENANT);
+		// stub なら id=0 / send 未呼出だった。本実装は採番 id を返し send する。
+		expect(result.id).toBe(1);
+		expect(mockSend).toHaveBeenCalled();
+	});
+});

--- a/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
+++ b/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
@@ -28,7 +28,8 @@ import * as battleRepo from '../../../src/lib/server/db/dynamodb/battle-repo';
 // #2824 (ADR-0055): child-activity-repo は本実装済のため stub fallback テスト対象外。
 //   機能等価性は tests/unit/db/dynamodb-child-activity-repo.test.ts (AWS SDK mock) で検証する。
 import * as cloudExportRepo from '../../../src/lib/server/db/dynamodb/cloud-export-repo';
-import * as messageRepo from '../../../src/lib/server/db/dynamodb/message-repo';
+// #2824 Wave 3A (ADR-0055): message-repo は本実装済のため stub fallback テスト対象外。
+//   機能等価性は tests/unit/db/dynamodb-message-repo.test.ts (AWS SDK mock) で検証する。
 import * as reportDailySummaryRepo from '../../../src/lib/server/db/dynamodb/report-daily-summary-repo';
 // #2824 Phase 2A (ADR-0055): reward-redemption-repo は本実装済のため stub fallback テスト対象外。
 //   機能等価性は tests/unit/db/dynamodb-reward-redemption-repo.test.ts (AWS SDK mock) で検証する。
@@ -116,18 +117,11 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('message-repo', () => {
-		it('全 method が throw しない', async () => {
-			await expect(
-				messageRepo.insertMessage({ childId: 1, messageType: 'cheer' }, TENANT),
-			).resolves.toBeTruthy();
-			await expect(messageRepo.findMessages(1, 10, TENANT)).resolves.toEqual([]);
-			await expect(messageRepo.findUnshownMessage(1, TENANT)).resolves.toBeUndefined();
-			await expect(messageRepo.countUnshownMessages(1, TENANT)).resolves.toBe(0);
-			await expect(messageRepo.markMessageShown(1, TENANT)).resolves.toBeUndefined();
-			await expect(messageRepo.deleteByTenantId(TENANT)).resolves.toBeUndefined();
-		});
-	});
+	// #2824 Wave 3A (ADR-0055): message-repo は本実装済 (stub 除外)。
+	//   おうえんメッセージ (親→子、LP feature-cheer-message 訴求) が本番 DynamoDB Lambda で
+	//   永続する。本実装の機能等価性テストは dynamodb-message-repo.test.ts に分離。ここで stub
+	//   前提の assert を残すと「実装済なのに stub 期待」で誤った退行 gate になるため除外する
+	//   (他 repo の fallback assert は維持 = assertion 弱体化に該当しない)。
 
 	describe('report-daily-summary-repo', () => {
 		it('全 method が throw しない', async () => {
@@ -232,8 +226,8 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('regression guard: 全 8 repo の Promise.all で reject されない', () => {
-		it('SSR /preschool/home の典型的な 8 repo 並列呼び出しが全 fulfill する', async () => {
+	describe('regression guard: 全 7 repo の Promise.all で reject されない', () => {
+		it('SSR /preschool/home の典型的な 7 repo 並列呼び出しが全 fulfill する', async () => {
 			// #2295 (EPIC #2294 ①): seasonEventRepo / tenantEventRepo 削除済 (2026-05-19)、12 → 10 repo
 			// #2458 (Path B sibling drop): siblingChallengeRepo 削除済 (2026-05-26)、10 → 9 repo
 			// #2263 regression hotfix: childActivityRepo を stub fallback に置換 (9 → 10 repo)
@@ -241,11 +235,12 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 			//   (本実装は AWS SDK mock 必須 → dynamodb-child-activity-repo.test.ts で検証)。10 → 9 repo
 			// #2824 Phase 2A (ADR-0055): rewardRedemptionRepo を本実装化したため除外
 			//   (本実装は AWS SDK mock 必須 → dynamodb-reward-redemption-repo.test.ts で検証)。9 → 8 repo
+			// #2824 Wave 3A (ADR-0055): messageRepo を本実装化したため除外
+			//   (本実装は AWS SDK mock 必須 → dynamodb-message-repo.test.ts で検証)。8 → 7 repo
 			const results = await Promise.allSettled([
 				autoChallengeRepo.findActiveByChild(1, TENANT),
 				battleRepo.findTodayBattle(1, TODAY, TENANT),
 				cloudExportRepo.findByTenant(TENANT),
-				messageRepo.findUnshownMessage(1, TENANT),
 				reportDailySummaryRepo.findByChildAndDateRange(1, TODAY, TODAY, TENANT),
 				siblingCheerRepo.findUnshownCheers(1, TENANT),
 				stampCardRepo.findCardByChildAndWeek(1, '2026-05-12', TENANT),


### PR DESCRIPTION
## 顧客価値・目的

有料本番 SaaS (`DATA_SOURCE=dynamodb`、cognito Lambda) で **おうえんメッセージ (親→子) の送信が永続しない** per-feature write gap (#2824 系) を根治する。本機能は LP `feature-cheer-message` が訴求する機能であり、送信が DynamoDB に保存されず子供画面に届かないのは ADR-0013 LP truth 違反級だった。`message-repo.ts` は #2263 hotfix で「read=空 / write=no-op + logger.warn」stub 化されていた。本 PR で SQLite 実装 (挙動 SSOT) と機能等価な DynamoDB single-table 本実装に置換する (#2824 Wave 3A、ADR-0055)。

## 関連 Issue

- tracking: #2824 (per-feature write 永続 gap 根治、AC5 Wave 3A)
- 設計原則: ADR-0055 (per-child 主軸データモデル) / ADR-0013 (LP truth) / ADR-0006 (assertion 弱体化禁止)
- 先行 merged: #2820 (Phase 1 child-activity) / #2826 (Phase 2A reward-redemption) / #2825 (Phase 2B child-challenge)
- closes 無し (tracking Issue は全 Wave 完遂後に PO 判断で close)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `message-repo.ts` 6 method を SQLite 機能等価で DynamoDB 本実装 | `tests/unit/db/dynamodb-message-repo.test.ts` (AWS SDK mock 28 case) | PASS (28/28、insertMessage/findMessages/findUnshownMessage/countUnshownMessages/markMessageShown/deleteByTenantId 全網羅) |
| AC2 | stub baseline から本 repo を削除 (ratchet 前進) | `node scripts/check-dynamodb-stub-parity.mjs` | PASS (`OK: 9 repo / 56 stub method`、10→9 repo 前進) |
| AC3 | pre-pmf-fallback test から本 repo 除外 (他 repo assert 維持、ADR-0006) | `tests/unit/db/dynamodb-pre-pmf-fallback.test.ts` | PASS (message describe 削除 + Promise.all guard 8→7 repo、他 7 repo fallback assert 維持) |
| AC4 | 設計書同期 (DynamoDB キー設計節 + changelog) | `docs/design/08-データベース設計書.md` diff | §parent_messages に DynamoDB キー設計節追加 + changelog 5.18 |
| AC5 | 型 / lint / 全 db+services test 緑 | svelte-check / biome / vitest | svelte-check 0 errors、biome clean、vitest 2440 passed (tests/unit/db + tests/unit/services) |

## 変更タイプ

- [x] バグ修正 (本番 write 永続 gap の根治)
- [x] リファクタリング (stub → 本実装)
- [ ] 新機能 / UI 変更 / 破壊的変更

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dynamodb/message-repo.ts` — stub 6 method → DynamoDB single-table 本実装
- `src/lib/server/db/dynamodb/keys.ts` — `parentMessageKey` / `parentMessagePrefix` 追加 + `ENTITY_NAMES.parentMessage` 追加
- `scripts/dynamodb-stub-baseline.json` — 本 repo block 削除 (10→9 repo)
- `tests/unit/db/dynamodb-message-repo.test.ts` — 新規 (28 case)
- `tests/unit/db/dynamodb-pre-pmf-fallback.test.ts` — 本 repo 除外 (他 repo assert 維持)
- `docs/design/08-データベース設計書.md` — DynamoDB キー設計節 + changelog 5.18

**key 設計判断 (追加 GSI 不要)**:

| アクセスパターン | 操作 | 判断 |
|---|---|---|
| `findMessages` / `findUnshownMessage` / `countUnshownMessages` (childId) | child partition Query (`begins_with(SK,'MSG#')`) | 全 read が child 軸 → 追加 GSI 不要 (ADR-0055 §3.1) |
| `markMessageShown` (messageId のみ) | tenant Scan + id filter で PK/SK 解決 | childId を受けないため低頻度 Scan (reward-redemption-repo 同型) |
| `deleteByTenantId` | Scan → BatchWrite (`deleteItemsByPkPrefix`) | tenant cleanup (低頻度) |

PK = `T#<tid>#CHILD#<childId>` / SK = `MSG#<paddedId>`。activity_logs / point_ledger と同 partition 同居。read は全て child 軸のため非正規化フィールド不要 (reward-redemption の childName 等の JOIN 代替は本 repo では不要)。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/ tests/unit/services/` — 2440 passed (146 files)
- [x] `tests/unit/db/dynamodb-message-repo.test.ts` 新規 28 case (insert default 値 / sent_at 降順 + id tiebreaker / shown_at IS NULL filter / count / markShown id 解決 / deleteByTenantId / interface 適合 / write が no-op stub でない)
- [x] `node scripts/check-dynamodb-stub-parity.mjs` — PASS (baseline 以下)
- [x] `npx svelte-check` — 0 errors (19 warnings は pre-existing)
- [x] `npx biome check` (変更ファイル) — clean
- [x] ADR-0006 遵守: pre-pmf-fallback test の他 7 repo fallback assert は維持 (本 repo のみ除外、実装済なのに stub 期待で誤 gate になるため)

## スクリーンショット / ビジュアルデモ

N/A — server 層 DB repository の本実装のみ。UI / `.svelte` 変更なし (DynamoDB は本番 Lambda 環境でのみ稼働、ローカル SQLite には影響しない)。機能等価性は AWS SDK mock unit test で回帰固定。

## コード品質セルフレビュー (#1481)

- 既存 exemplar (`reward-redemption-repo.ts` / `child-activity-repo.ts`) のパターンを踏襲 (queryChildMessages ページング / findMessageItemById tenant Scan / stripKeys 正規化 / toMessage backfill)
- 独自実装ではなく既存 repo-helpers (`stripKeys`) + bulk-delete (`deleteItemsByPkPrefix`) を再利用
- コメント簡潔、経緯は commit message + 設計書に集約
- `compareSentAtDesc` で sent_at 同値時の決定的順序 (id 降順 tiebreaker) を担保し SQLite ORDER BY と機能等価

## 横展開・影響波及チェック

- DynamoDB ↔ SQLite ペア整合 (tests/CLAUDE.md §DynamoDB 並行実装の整合性): icon default `💌` / shownAt null / bonusPoints null / rewardCategory null を両実装で一致
- 並行 Wave 3B (`feat/dynamodb-stamp-card-impl`) と baseline.json / keys.ts / 設計書 を共有編集するが、本 PR は自分の repo 行のみ追加/削除 (他行不変)。rebase で衝突なし確認済
- service 層 (message-service 等) は repo interface 不変のため変更不要
- LP `feature-cheer-message` 訴求との整合: 本実装で本番 write 永続が成立し ADR-0013 LP truth 回復

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。新規 SK prefix `MSG#` は既存テーブルにそのまま乗る (CDK 変更不要、追加 GSI なし)
- 既存 DynamoDB データへの migration 不要 (本番では従来 stub で write されず空のため、本実装後の新規送信から正常永続)
- レビュー観点: key 設計 (child partition 同居 + markMessageShown の tenant Scan) が ADR-0055 §3.1 に整合するか

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。既存の DynamoDB 接続設定 (`TABLE_NAME` / AWS 認証) のみ使用。

## Ready for Review チェックリスト

- [x] `npm run pre-ready` 相当の検証 (biome / svelte-check / vitest / stub-parity) 全 PASS
- [x] origin/main rebase 完了 (本日 deploy 全 file 取込、衝突なし)
- [x] AC 検証マップ 4 列形式で全 AC に検証手段 + 結果
- [x] 設計書同期 (08-データベース設計書.md)
- [x] forbidden-terms 0 件 (禁止語スキャナ準拠、本 PR は全 AC 完遂で持ち越し課題なし)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: 全自動検証 PASS、QA approve/merge は QA team 責務)

## QM レビュー結果

(QM レビュー記入欄)

