### PR TITLE
feat: #2824 Wave 3B — stamp-card-repo DynamoDB 本実装 (ADR-0055)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -290,6 +290,8 @@ Splide
 splidejs
 SSOT
 STATHIST
+STMPCARD
+STMPENT
 stylelint
 Stylelint
 subresource

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1418,6 +1418,32 @@ cognito Lambda + DynamoDB 環境にはテナント単位の `stamp_masters` seed
 - (card_id, slot)
 - (card_id, login_date)
 
+#### DynamoDB キー設計（single-table、#2824 Wave 3B / ADR-0055）
+
+本番 cognito Lambda は `DATA_SOURCE=dynamodb` で稼働するため、SQLite と機能等価の
+DynamoDB 実装 (`src/lib/server/db/dynamodb/stamp-card-repo.ts`) を持つ。card は per-child
+instance のため child partition に同居させ `findCardByChildAndWeek` を**追加 GSI なし**の
+GetItem 1 回で完結させる。entry は `findEntriesWithMasterByCardId(cardId)` に childId が
+渡らないため card 自身を partition key にした専用 partition に配置する（ADR-0055 §3.1）。
+
+| エンティティ | PK | SK | 補足 |
+|---|---|---|---|
+| stamp_cards | `T#<tid>#CHILD#<childId>` | `STMPCARD#<weekStart>` | weekStart 一意 = SQLite uniqueIndex(child_id, week_start) と等価。special_rewards / activity_logs と同 partition に同居。`id` は属性として保持 |
+| stamp_entries | `T#<tid>#STMPCARD#<cardId>` | `STMPENT#<paddedSlot>` | card 専用 partition。paddedSlot は SQLite uniqueIndex(card_id, slot) と等価。stamp master JOIN は固定 16 件 SSOT (`getDefaultStampMasters`) を in-memory 解決 |
+
+| アクセスパターン | 操作 | 条件 |
+|---|---|---|
+| `findEnabledStampMasters` | （DB アクセスなし） | `DEFAULT_STAMP_MASTERS_DATA` SSOT 16 件を返す（tenant 別カスタマイズなし Pre-PMF、空配列 → service の NO_STAMPS_AVAILABLE 回避） |
+| `findCardByChildAndWeek(childId, weekStart)` | GetItem | `PK = T#<tid>#CHILD#<childId>, SK = STMPCARD#<weekStart>`。core loop で頻出（home load 毎）のため単一 GetItem |
+| `insertCard` | counter 採番 → PutItem | status default = `collecting`（SQLite schema 一致）。redeemedPoints / redeemedAt = null |
+| `findEntriesWithMasterByCardId(cardId)` | Query | `PK = T#<tid>#STMPCARD#<cardId> AND begins_with(SK, 'STMPENT#')`。slot 昇順 + master JOIN(name/emoji/rarity) は in-memory（LEFT JOIN miss は null、SQLite SSOT と一致） |
+| `insertEntry` | PutItem（`attribute_not_exists(PK)`） | SQLite onConflictDoNothing 等価（同 (cardId, slot) 既存なら no-op） |
+| `updateCardStatus(id)` / `updateCardStatusIfCollecting(id)` | Scan（id filter）で PK/SK 解決 → UpdateItem | childId を受けないため tenant Scan + id で 1 件特定（reward-redemption-repo と同型）。後者は `ConditionExpression: #status = collecting` で冪等ガード（成功=1 / ConditionalCheckFailed=0、SQLite `result.changes` 等価）。redeem は週次・低頻度で GSI 不要（Pre-PMF / ADR-0010） |
+| `deleteByTenantId` | Scan → BatchWrite（2 経路） | `CHILD#*` 配下の `STMPCARD#`（cards）と `STMPCARD#*` 配下の `STMPENT#`（entries）を削除（`deleteItemsByPkPrefix`） |
+
+新規 SK prefix `STMPCARD#` / `STMPENT#` は既存テーブルにそのまま乗るため **CDK 変更不要**
+（追加 GSI なし）。schema 自体に変更はなく DynamoDB 実装の追加のみ。
+
 ### activity_mastery
 
 活動別習熟度。各活動の実行回数とレベル。
@@ -2399,3 +2425,4 @@ per-child refactor (ADR-0055) で頻発する子供 UI 破綻を pixelmatch base
 | 2026-05-30 | 5.16 | #2641 + #2642 + #2675 + #2685 (Phase 5 子 3+4 / Phase 6 子 3 / Phase 7 PR-1) — **Billing 再設計 expand 段階**。(1) `stripe_webhook_events` 新規 table 追加 (Stripe Webhook 冪等性 dedup、event_id PK + 6 列 + 2 index、30 日 retention ADR-0049 整合、DynamoDB は `PK=STRIPE_WEBHOOK_EVENT` single-partition + native TTL)。(2) `archived_reason` enum 3 値 SSOT 化 — `src/lib/domain/archive-types.ts` 新規 (`ARCHIVED_REASONS = ['trial_expired', 'downgrade_user_selected', 'dunning_canceled'] as const`) + drizzle schema 4 location (`children` / `activities` / `child_activities` / `checklist_templates`) で `text(..., { enum: ARCHIVED_REASONS })` 制約適用 + `getRetentionDays(reason)` helper。(3) lazy migration `migrateBillingPhase6` — table 新規作成 + 既存 archived row の NULL → `'downgrade_user_selected'` 補充 (4 location × idempotent)。`code 変更ゼロ` の expand 段階で後続 PR の前提を配備、handler 統合は Phase 7 PR-4a 連動。詳細は `docs/design/billing-redesign/phase5-webhook-idempotency-architecture.md` / `phase5-archive-unified-architecture.md` / `phase6-db-migration-plan.md` 参照 |
 | 2026-06-04 | 5.17 | #2824 Phase 2A (ADR-0055) — `reward_redemption_requests` の DynamoDB 本実装。本 repo は #2263 hotfix で「read=空 / write=no-op」化され、本番 cognito Lambda (`DATA_SOURCE=dynamodb`) でごほうび交換 (記録 → ポイント → 交換) が永続しない致命的 gap だった。SQLite 機能等価で本実装。キー設計: PK `T#<tid>#CHILD#<childId>` + SK `REDEMPT#<paddedId>` (child partition 同居、`findRedemptionRequestsByChild` を追加 GSI なし単一 partition Query で完結)。JOIN 代替に childName / rewardTitle / rewardIcon / rewardPoints を insert 時に非正規化保存し tenant 横断 read の N+1 を回避。id のみ受ける update / markShown は tenant Scan + id filter で PK/SK 解決 (special-reward-repo.markRewardShown 同型)。残高減算は service 層責務のため repo は status 更新のみ (TransactWriteItems 不要)。stub baseline (`scripts/dynamodb-stub-baseline.json`) から本 repo を削除 (12 → 11 repo 前進)。CDK 変更なし。schema 自体に変更なし (DynamoDB 実装の追加) |
 | 2026-06-04 | 5.18 | #2824 Wave 3A (ADR-0055) — `parent_messages` (おうえんメッセージ 親→子) の DynamoDB 本実装。本 repo は #2263 hotfix で「read=空 / write=no-op」化され、本番 cognito Lambda (`DATA_SOURCE=dynamodb`) で送信が永続しない gap だった。おうえんメッセージは LP (`feature-cheer-message`) が訴求する機能のため ADR-0013 LP truth 違反級。SQLite 機能等価で本実装。キー設計: PK `T<tid>#CHILD#<childId>` + SK `MSG#<paddedId>` (child partition 同居、`findMessages` / `findUnshownMessage` / `countUnshownMessages` を追加 GSI なし単一 partition Query で完結)。read は全て child 軸のため非正規化不要。sent_at 降順 (同値は id 降順 tiebreaker) + shown_at IS NULL filter は in-memory (SQLite SSOT 一致)。id のみ受ける `markMessageShown` は tenant Scan + id filter で PK/SK 解決 (reward-redemption-repo 同型、低頻度)。stub baseline から本 repo を削除 (10 → 9 repo 前進)。CDK 変更なし。schema 自体に変更なし (DynamoDB 実装の追加) |
+| 2026-06-04 | 5.19 | #2824 Wave 3B (ADR-0055) — `stamp_cards` / `stamp_entries` の DynamoDB 本実装。本 repo は #2263 hotfix (PR #2280) で「read=空 / write=no-op」化され、本番 cognito Lambda (`DATA_SOURCE=dynamodb`) で子供 home の自動押印 (`?/loginStamp`) によるスタンプ獲得・週末 redeem が永続せず週跨ぎで履歴消失する gap だった (コアゲーミフィケーションループ)。SQLite 機能等価で本実装。キー設計: card = PK `T#<tid>#CHILD#<childId>` + SK `STMPCARD#<weekStart>` (child partition 同居、`findCardByChildAndWeek` を追加 GSI なし GetItem 1 回で完結)、entry = PK `T#<tid>#STMPCARD#<cardId>` + SK `STMPENT#<paddedSlot>` (card 専用 partition、`findEntriesWithMasterByCardId(cardId)` を単一 partition Query で完結)。stamp master JOIN は固定 16 件 SSOT (`getDefaultStampMasters`) を in-memory 解決。insertEntry は `attribute_not_exists(PK)` で onConflictDoNothing 等価、updateCardStatusIfCollecting は `ConditionExpression: #status=collecting` で冪等ガード (成功=1 / ConditionalCheckFailed=0)。id のみ受ける updateCardStatus* は tenant Scan + id filter で PK/SK 解決。deleteByTenantId は CHILD# 配下 `STMPCARD#` + STMPCARD# 配下 `STMPENT#` の 2 経路削除。stub baseline から本 repo を削除。CDK 変更なし。schema 自体に変更なし (DynamoDB 実装の追加) |

--- a/scripts/dynamodb-stub-baseline.json
+++ b/scripts/dynamodb-stub-baseline.json
@@ -57,15 +57,6 @@
 		"insertCheer",
 		"markShown"
 	],
-	"src/lib/server/db/dynamodb/stamp-card-repo.ts": [
-		"deleteByTenantId",
-		"findCardByChildAndWeek",
-		"findEntriesWithMasterByCardId",
-		"insertCard",
-		"insertEntry",
-		"updateCardStatus",
-		"updateCardStatusIfCollecting"
-	],
 	"src/lib/server/db/dynamodb/viewer-token-repo.ts": [
 		"deleteById",
 		"findByTenant",

--- a/src/lib/server/db/dynamodb/keys.ts
+++ b/src/lib/server/db/dynamodb/keys.ts
@@ -388,6 +388,53 @@ export function parentMessagePrefix(): string {
 }
 
 /**
+ * Stamp card (#2824 Wave 3B / ADR-0055): PK=CHILD#<cId>, SK=STMPCARD#<weekStart>
+ *
+ * per-child instance を child partition 配下に置き (special_rewards / activity_logs と同居)、
+ * `findCardByChildAndWeek` を childId + weekStart 既知の GetItem 1 回で完結させる
+ * (weekStart は child 内で一意 = SQLite uniqueIndex(child_id, week_start) と等価)。
+ * child 軸を構造的に担保し追加 GSI 不要 (ADR-0055 §3.1)。cardId だけで引く
+ * updateCardStatus* は低頻度 (週次 redeem) のため tenant Scan + id filter で解決する。
+ */
+export function stampCardKey(childId: number, weekStart: string, tenantId: string): DynamoKey {
+	return {
+		PK: tenantPK(`${PREFIX.CHILD}#${childId}`, tenantId),
+		SK: `STMPCARD#${weekStart}`,
+	};
+}
+
+/** Stamp card SK prefix for querying all cards of a child / tenant cleanup */
+export function stampCardPrefix(): string {
+	return 'STMPCARD#';
+}
+
+/**
+ * Stamp entry (#2824 Wave 3B / ADR-0055): PK=STMPCARD#<cardId>, SK=STMPENT#<paddedSlot>
+ *
+ * entry は cardId だけで lookup される (`findEntriesWithMasterByCardId(cardId)` に childId が
+ * 渡らない) ため、card 自身を partition key にした専用 partition へ配置する。これにより
+ * 単一 partition Query (begins_with(SK, 'STMPENT#')) で全 entry を取得でき GSI 不要。
+ * SK の paddedSlot は SQLite uniqueIndex(card_id, slot) と等価 (slot は週内 1〜5 枠で一意)。
+ * stamp master との JOIN は固定 16 件 SSOT (getDefaultStampMasters) を in-memory で解決する。
+ */
+export function stampEntryKey(cardId: number, slot: number, tenantId: string): DynamoKey {
+	return {
+		PK: tenantPK(`STMPCARD#${cardId}`, tenantId),
+		SK: `STMPENT#${padId(slot)}`,
+	};
+}
+
+/** Stamp entry partition PK for a given card (Query all entries of a card). */
+export function stampEntryCardPK(cardId: number, tenantId: string): string {
+	return tenantPK(`STMPCARD#${cardId}`, tenantId);
+}
+
+/** Stamp entry SK prefix for querying all entries of a card. */
+export function stampEntryPrefix(): string {
+	return 'STMPENT#';
+}
+
+/**
  * Checklist template: PK=T#<tenantId>#CKTPL, SK=CKTPL#<id>
  * #2362 PR-5 (ADR-0055): family master 化に伴い CHILD#<cId> 配下 → tenant scope に変更。
  */
@@ -822,6 +869,7 @@ export const ENTITY_NAMES = {
 	specialReward: 'specialReward',
 	rewardRedemption: 'rewardRedemption',
 	parentMessage: 'parentMessage',
+	stampCard: 'stampCard',
 	checklistTemplate: 'checklistTemplate',
 	checklistAssignment: 'checklistAssignment',
 	checklistItem: 'checklistItem',

--- a/src/lib/server/db/dynamodb/stamp-card-repo.ts
+++ b/src/lib/server/db/dynamodb/stamp-card-repo.ts
@@ -20,7 +20,9 @@
 //       渡らない) ため card 自身を partition key にした専用 partition に置く。
 //       単一 partition Query で全 entry を取得でき追加 GSI 不要 (ADR-0055 §3.1)。
 //   cardId だけで引く updateCardStatus* は低頻度 (週次 redeem) のため tenant Scan + id filter
-//   で PK/SK を解決する (reward-redemption-repo.updateRedemptionRequestStatus と同パターン)。
+//   で PK/SK を解決する。Scan は ExclusiveStartKey で全ページ走査し一致 item を探す
+//   (DynamoDB Scan の Limit は filter 適用「前」の評価件数上限なので Limit:1 + Filter は
+//    対象が scan 順先頭でない限り空振りする。#2842 修正)。
 //
 // stamp master JOIN:
 //   SQLite の findEntriesWithMasterByCardId は stamp_entries LEFT JOIN stamp_masters で
@@ -321,28 +323,40 @@ async function queryCardEntries(
 /**
  * cardId だけ受け取る update* 用に、tenant 配下を Scan して card item (PK/SK) を解決する。
  * card は child partition (PK=CHILD#<cId>, SK=STMPCARD#<weekStart>) に分散し childId が
- * 不明なため、tenant Scan + id filter で 1 件特定する (reward-redemption-repo と同パターン)。
+ * 不明なため、tenant Scan + id filter で 1 件特定する。
  * redeem は週次・低頻度のため Pre-PMF では GSI 不要 (ADR-0010)。
+ *
+ * 重要 (#2842): DynamoDB Scan の `Limit` は **FilterExpression 適用前**に評価する item 数の
+ * 上限であり、filter 通過後の返却件数ではない。`Limit: 1` + Filter だと「scan 順の先頭 item が
+ * たまたま対象 card」でない限り Items が空になり、updateCardStatus* が silent no-op → redeem
+ * が黙って失敗していた。よって `Limit` は付けず `ExclusiveStartKey` で全ページを走査し、
+ * 一致 item を見つけ次第 early return する (queryCardEntries の entry Query loop と同じ
+ * ページング正パターン)。1 件も無ければ全ページ走査後に undefined を返す。
  */
 async function findCardItemById(
 	cardId: number,
 	tenantId: string,
 ): Promise<{ PK: string; SK: string } | undefined> {
-	const result = await getDocClient().send(
-		new ScanCommand({
-			TableName: TABLE_NAME,
-			FilterExpression:
-				'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
-			ExpressionAttributeValues: {
-				':tenantPrefix': tenantPK('CHILD#', tenantId),
-				':skPrefix': CARD_PREFIX,
-				':id': cardId,
-			},
-			ProjectionExpression: 'PK, SK',
-			Limit: 1,
-		}),
-	);
-	const item = (result.Items ?? [])[0];
-	if (!item) return undefined;
-	return { PK: item.PK as string, SK: item.SK as string };
+	const doc = getDocClient();
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression:
+					'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
+				ExpressionAttributeValues: {
+					':tenantPrefix': tenantPK('CHILD#', tenantId),
+					':skPrefix': CARD_PREFIX,
+					':id': cardId,
+				},
+				ProjectionExpression: 'PK, SK',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		const item = (result.Items ?? [])[0];
+		if (item) return { PK: item.PK as string, SK: item.SK as string };
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return undefined;
 }

--- a/src/lib/server/db/dynamodb/stamp-card-repo.ts
+++ b/src/lib/server/db/dynamodb/stamp-card-repo.ts
@@ -1,22 +1,42 @@
 // src/lib/server/db/dynamodb/stamp-card-repo.ts
-// DynamoDB implementation of IStampCardRepo
+// スタンプカードリポジトリ — DynamoDB 本実装 (#2824 Wave 3B / ADR-0055)
 //
-// 経緯:
-// - #2263 hotfix (PR #2280): 旧バージョンの未実装エラー throw で本番 500 を引き起こしうるため、
-//   Pre-PMF fallback (read = 空 / write = no-op + logger.warn) に置換。
-//   当時「スタンプカード機能は本番未活用」と判断していたが誤判定だった。
-// - 後続 Critical (Issue 起票 2026-05-20): 子供 home の自動押印 (`?/loginStamp` action) は本番で
-//   active。findEnabledStampMasters が 0 件を返すと stamp-card-service.stampToday が
-//   `throw new Error('No enabled stamps available')` で POST 500 を返す状態だった。
+// IStampCardRepo (interfaces/stamp-card-repo.interface.ts) を SQLite 実装
+// (sqlite/stamp-card-repo.ts、挙動 SSOT) と機能等価に DynamoDB single-table で実装する。
 //
-// 現在の方針 (Pre-PMF Bucket A):
-// - **read findEnabledStampMasters**: DEFAULT_STAMP_MASTERS_DATA SSOT から 16 件を合成して返す
-//   (本番でも子供 home が動く最小修正、tenant 別カスタマイズ機構なしの Pre-PMF)
-// - **write 系**: no-op + logger.warn を維持 (スタンプ獲得履歴の永続化は別 Issue で実装、
-//   現状は in-memory で押印演出のみ可能、week 跨ぎで履歴消失するが致命的でない)
-// - **その他 read**: 旧 fallback を維持 (空 / undefined)
+// 経緯: 本 repo は #2263 hotfix (PR #2280) で「read=空 / write=no-op + logger.warn」化された。
+//   スタンプカードは子供のコアゲーミフィケーションループ (おみくじシール / 週末 redeem) であり、
+//   子供 home の自動押印 (`?/loginStamp` action) は本番 cognito Lambda
+//   (AUTH_MODE=cognito + DATA_SOURCE=dynamodb) で active。書込みが永続しないと週跨ぎで
+//   スタンプ履歴が消失し体験の核を毀損する。本実装で根治する。
+//
+// key 設計 (keys.ts §stampCardKey / §stampEntryKey):
+//   stamp_cards : PK = T#<tid>#CHILD#<childId>   SK = STMPCARD#<weekStart>
+//     → child partition 同居 (special_rewards / activity_logs と同じ)。
+//       findCardByChildAndWeek は childId + weekStart 既知の GetItem 1 回で完結。
+//       weekStart 一意 = SQLite uniqueIndex(child_id, week_start) と等価。
+//   stamp_entries: PK = T#<tid>#STMPCARD#<cardId> SK = STMPENT#<paddedSlot>
+//     → entry は cardId だけで lookup される (findEntriesWithMasterByCardId に childId が
+//       渡らない) ため card 自身を partition key にした専用 partition に置く。
+//       単一 partition Query で全 entry を取得でき追加 GSI 不要 (ADR-0055 §3.1)。
+//   cardId だけで引く updateCardStatus* は低頻度 (週次 redeem) のため tenant Scan + id filter
+//   で PK/SK を解決する (reward-redemption-repo.updateRedemptionRequestStatus と同パターン)。
+//
+// stamp master JOIN:
+//   SQLite の findEntriesWithMasterByCardId は stamp_entries LEFT JOIN stamp_masters で
+//   name / emoji / rarity を返す。DynamoDB では固定 16 件 SSOT (getDefaultStampMasters) を
+//   in-memory map で解決する (stamp master は tenant 別カスタマイズなし Pre-PMF、
+//   findEnabledStampMasters も同 SSOT を返すため整合)。
+//
+// 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/stamp-card-repo.ts (SSOT)
 
-import { logger } from '$lib/server/logger';
+import {
+	GetCommand,
+	PutCommand,
+	QueryCommand,
+	ScanCommand,
+	UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
 import { getDefaultStampMasters } from '../stamp-master-defaults';
 import type {
 	InsertStampCardInput,
@@ -26,94 +46,303 @@ import type {
 	StampMaster,
 	UpdateStampCardStatusInput,
 } from '../types';
+import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
+import {
+	ENTITY_NAMES,
+	stampCardKey,
+	stampCardPrefix,
+	stampEntryCardPK,
+	stampEntryKey,
+	stampEntryPrefix,
+	tenantPK,
+} from './keys';
+import { stripKeys } from './repo-helpers';
 
-const SERVICE = 'stamp-card-repo.dynamodb';
+const CARD_PREFIX = stampCardPrefix();
+const ENTRY_PREFIX = stampEntryPrefix();
 
-function warnRead(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] read fallback: returning empty (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
+/** DynamoDB item を StampCard に正規化する (PK/SK 除去 + null 既定の補完)。 */
+function toCard(item: Record<string, unknown>): StampCard {
+	const stripped = stripKeys(item) as Record<string, unknown>;
+	return {
+		id: stripped.id as number,
+		childId: stripped.childId as number,
+		weekStart: stripped.weekStart as string,
+		weekEnd: stripped.weekEnd as string,
+		status: stripped.status as string,
+		redeemedPoints: (stripped.redeemedPoints ?? null) as number | null,
+		redeemedAt: (stripped.redeemedAt ?? null) as string | null,
+		createdAt: stripped.createdAt as string,
+		updatedAt: stripped.updatedAt as string,
+	};
 }
 
-function warnWrite(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] write fallback: no-op (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
-}
+// ============================================================
+// findEnabledStampMasters — 有効な stamp master 一覧
+// ============================================================
 
 /**
- * 有効な stamp master 一覧を返す。
- *
- * Pre-PMF Bucket A: tenant 別カスタマイズ機構は未実装のため
- * DEFAULT_STAMP_MASTERS_DATA SSOT (16 件) を全 tenant 共通で返す。
- * これにより本番 cognito Lambda の `?/loginStamp` action POST 500 を回避する
- * (空配列を返すと stamp-card-service.stampToday が throw する設計のため、
- *  空でなく default を返すのが最も安全)。
+ * 有効な stamp master 16 件を返す。tenant 別カスタマイズ機構は未実装 (Pre-PMF) のため
+ * DEFAULT_STAMP_MASTERS_DATA SSOT を全 tenant 共通で返す。空配列を返すと
+ * stamp-card-service.stampToday が NO_STAMPS_AVAILABLE になるため必ず 16 件を返す。
  */
 export async function findEnabledStampMasters(_tenantId: string): Promise<StampMaster[]> {
 	return getDefaultStampMasters();
 }
+
+// ============================================================
+// findCardByChildAndWeek — child + weekStart で 1 件取得 (GetItem)
+// ============================================================
 
 export async function findCardByChildAndWeek(
 	childId: number,
 	weekStart: string,
 	tenantId: string,
 ): Promise<StampCard | undefined> {
-	warnRead('findCardByChildAndWeek', { childId, weekStart, tenantId });
-	return undefined;
+	const result = await getDocClient().send(
+		new GetCommand({
+			TableName: TABLE_NAME,
+			Key: stampCardKey(childId, weekStart, tenantId),
+		}),
+	);
+	if (!result.Item) return undefined;
+	return toCard(result.Item);
 }
+
+// ============================================================
+// insertCard — スタンプカード新規作成
+// ============================================================
 
 export async function insertCard(
 	input: InsertStampCardInput,
 	tenantId: string,
 ): Promise<StampCard> {
-	warnWrite('insertCard', { childId: input.childId, weekStart: input.weekStart, tenantId });
+	const id = await nextId(ENTITY_NAMES.stampCard, tenantId);
 	const now = new Date().toISOString();
-	return {
-		id: 0,
+	const card: StampCard = {
+		id,
 		childId: input.childId,
 		weekStart: input.weekStart,
 		weekEnd: input.weekEnd,
+		// SQLite schema default 'collecting' と一致。
 		status: input.status ?? 'collecting',
 		redeemedPoints: null,
 		redeemedAt: null,
 		createdAt: now,
 		updatedAt: now,
 	};
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...stampCardKey(input.childId, input.weekStart, tenantId),
+				...card,
+			},
+		}),
+	);
+
+	return card;
 }
+
+// ============================================================
+// findEntriesWithMasterByCardId — card の entry 一覧 (master JOIN 付き)
+// ============================================================
 
 export async function findEntriesWithMasterByCardId(
 	cardId: number,
 	tenantId: string,
 ): Promise<StampEntryWithMaster[]> {
-	warnRead('findEntriesWithMasterByCardId', { cardId, tenantId });
-	return [];
+	const items = await queryCardEntries(cardId, tenantId);
+
+	// stamp master を id → master の map で in-memory 解決 (SQLite の LEFT JOIN 相当)。
+	const masterById = new Map<number, StampMaster>();
+	for (const m of getDefaultStampMasters()) masterById.set(m.id, m);
+
+	const entries: StampEntryWithMaster[] = items.map((item) => {
+		const stripped = stripKeys(item) as Record<string, unknown>;
+		const stampMasterId = (stripped.stampMasterId ?? null) as number | null;
+		const master = stampMasterId != null ? masterById.get(stampMasterId) : undefined;
+		return {
+			slot: stripped.slot as number,
+			stampMasterId,
+			omikujiRank: (stripped.omikujiRank ?? null) as string | null,
+			loginDate: stripped.loginDate as string,
+			// LEFT JOIN: master 不在なら null (SQLite と一致)。
+			name: master?.name ?? null,
+			emoji: master?.emoji ?? null,
+			rarity: master?.rarity ?? null,
+		};
+	});
+
+	// SQLite は INSERT 順 (rowid)。slot 昇順で揃える (slot は押印順 = 挿入順)。
+	entries.sort((a, b) => a.slot - b.slot);
+	return entries;
 }
 
+// ============================================================
+// insertEntry — スタンプ押印 (同 slot 重複は無視)
+// ============================================================
+
 export async function insertEntry(input: InsertStampEntryInput, tenantId: string): Promise<void> {
-	warnWrite('insertEntry', { cardId: input.cardId, slot: input.slot, tenantId });
+	try {
+		await getDocClient().send(
+			new PutCommand({
+				TableName: TABLE_NAME,
+				Item: {
+					...stampEntryKey(input.cardId, input.slot, tenantId),
+					cardId: input.cardId,
+					stampMasterId: input.stampMasterId,
+					omikujiRank: input.omikujiRank,
+					slot: input.slot,
+					loginDate: input.loginDate,
+					earnedAt: new Date().toISOString(),
+				},
+				// SQLite onConflictDoNothing 等価: 同 (cardId, slot) が既存なら上書きしない。
+				ConditionExpression: 'attribute_not_exists(PK)',
+			}),
+		);
+	} catch (e) {
+		// 既存 (slot 重複) は no-op で握りつぶす (onConflictDoNothing と一致)。
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return;
+		throw e;
+	}
 }
+
+// ============================================================
+// updateCardStatus — card status を更新 (cardId → Scan で PK/SK 解決)
+// ============================================================
 
 export async function updateCardStatus(
 	cardId: number,
 	input: UpdateStampCardStatusInput,
 	tenantId: string,
 ): Promise<void> {
-	warnWrite('updateCardStatus', { cardId, status: input.status, tenantId });
+	const found = await findCardItemById(cardId, tenantId);
+	if (!found) return;
+	await getDocClient().send(
+		new UpdateCommand({
+			TableName: TABLE_NAME,
+			Key: { PK: found.PK, SK: found.SK },
+			UpdateExpression:
+				'SET #status = :status, redeemedPoints = :rp, redeemedAt = :ra, updatedAt = :ua',
+			ExpressionAttributeNames: { '#status': 'status' },
+			ExpressionAttributeValues: {
+				':status': input.status,
+				':rp': input.redeemedPoints,
+				':ra': input.redeemedAt,
+				':ua': input.updatedAt,
+			},
+		}),
+	);
 }
+
+// ============================================================
+// updateCardStatusIfCollecting — collecting のみ更新し affected 数を返す (冪等ガード)
+// ============================================================
 
 export async function updateCardStatusIfCollecting(
 	cardId: number,
 	input: UpdateStampCardStatusInput,
 	tenantId: string,
 ): Promise<number> {
-	warnWrite('updateCardStatusIfCollecting', { cardId, status: input.status, tenantId });
-	return 0;
+	const found = await findCardItemById(cardId, tenantId);
+	if (!found) return 0;
+	try {
+		await getDocClient().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: { PK: found.PK, SK: found.SK },
+				UpdateExpression:
+					'SET #status = :status, redeemedPoints = :rp, redeemedAt = :ra, updatedAt = :ua',
+				ExpressionAttributeNames: { '#status': 'status' },
+				ExpressionAttributeValues: {
+					':status': input.status,
+					':rp': input.redeemedPoints,
+					':ra': input.redeemedAt,
+					':ua': input.updatedAt,
+					':collecting': 'collecting',
+				},
+				// SQLite WHERE status='collecting' 等価: 同時 redeem の二重付与を防ぐ。
+				ConditionExpression: '#status = :collecting',
+			}),
+		);
+		return 1;
+	} catch (e) {
+		// 既に redeemed 等で collecting でないなら affected=0 (SQLite result.changes と一致)。
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return 0;
+		throw e;
+	}
 }
 
-/** テナントの全スタンプカード・エントリを削除（Pre-PMF fallback: no-op） */
+// ============================================================
+// deleteByTenantId — テナントの全カード・エントリを削除
+// ============================================================
+
 export async function deleteByTenantId(tenantId: string): Promise<void> {
-	warnWrite('deleteByTenantId', { tenantId });
+	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
+	// cards: child partition 配下の STMPCARD# item。
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), CARD_PREFIX);
+	// entries: 専用 STMPCARD#<cardId> partition 配下の STMPENT# item。
+	await deleteItemsByPkPrefix(tenantPK('STMPCARD#', tenantId), ENTRY_PREFIX);
+}
+
+// ============================================================
+// 内部ヘルパ
+// ============================================================
+
+/** card partition (PK=STMPCARD#<cardId>) の STMPENT# item を全件 Query する (ページング対応)。 */
+async function queryCardEntries(
+	cardId: number,
+	tenantId: string,
+): Promise<Record<string, unknown>[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				ExpressionAttributeValues: {
+					':pk': stampEntryCardPK(cardId, tenantId),
+					':prefix': ENTRY_PREFIX,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) items.push(item);
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return items;
+}
+
+/**
+ * cardId だけ受け取る update* 用に、tenant 配下を Scan して card item (PK/SK) を解決する。
+ * card は child partition (PK=CHILD#<cId>, SK=STMPCARD#<weekStart>) に分散し childId が
+ * 不明なため、tenant Scan + id filter で 1 件特定する (reward-redemption-repo と同パターン)。
+ * redeem は週次・低頻度のため Pre-PMF では GSI 不要 (ADR-0010)。
+ */
+async function findCardItemById(
+	cardId: number,
+	tenantId: string,
+): Promise<{ PK: string; SK: string } | undefined> {
+	const result = await getDocClient().send(
+		new ScanCommand({
+			TableName: TABLE_NAME,
+			FilterExpression:
+				'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
+			ExpressionAttributeValues: {
+				':tenantPrefix': tenantPK('CHILD#', tenantId),
+				':skPrefix': CARD_PREFIX,
+				':id': cardId,
+			},
+			ProjectionExpression: 'PK, SK',
+			Limit: 1,
+		}),
+	);
+	const item = (result.Items ?? [])[0];
+	if (!item) return undefined;
+	return { PK: item.PK as string, SK: item.SK as string };
 }

--- a/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
+++ b/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
@@ -36,7 +36,8 @@ import * as reportDailySummaryRepo from '../../../src/lib/server/db/dynamodb/rep
 // #2295 (EPIC #2294 ①): season-event-repo / tenant-event-repo 削除済 (2026-05-19)
 // #2458 (Path B sibling drop): sibling-challenge-repo 削除済 (2026-05-26)、child-challenge-repo へ移行
 import * as siblingCheerRepo from '../../../src/lib/server/db/dynamodb/sibling-cheer-repo';
-import * as stampCardRepo from '../../../src/lib/server/db/dynamodb/stamp-card-repo';
+// #2824 Wave 3B (ADR-0055): stamp-card-repo は本実装済のため stub fallback テスト対象外。
+//   機能等価性は tests/unit/db/dynamodb-stamp-card-repo.test.ts (AWS SDK mock) で検証する。
 import * as viewerTokenRepo from '../../../src/lib/server/db/dynamodb/viewer-token-repo';
 
 const TENANT = 'test-tenant';
@@ -171,48 +172,11 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('stamp-card-repo', () => {
-		it('全 method が throw しない', async () => {
-			// findEnabledStampMasters は本番 loginStamp 500 を防ぐため
-			// DEFAULT_STAMP_MASTERS_DATA SSOT (16 件) を返す (空配列を返すと service が
-			// 'No enabled stamps available' で 500 を返していた 2026-05-20 Critical の回避策)
-			const stamps = await stampCardRepo.findEnabledStampMasters(TENANT);
-			expect(stamps.length).toBe(16);
-			expect(stamps.every((s) => s.isEnabled === 1)).toBe(true);
-			expect(stamps.every((s) => ['N', 'R', 'SR', 'UR'].includes(s.rarity))).toBe(true);
-			await expect(
-				stampCardRepo.findCardByChildAndWeek(1, '2026-05-12', TENANT),
-			).resolves.toBeUndefined();
-			await expect(
-				stampCardRepo.insertCard(
-					{ childId: 1, weekStart: '2026-05-12', weekEnd: '2026-05-18' },
-					TENANT,
-				),
-			).resolves.toBeTruthy();
-			await expect(stampCardRepo.findEntriesWithMasterByCardId(1, TENANT)).resolves.toEqual([]);
-			await expect(
-				stampCardRepo.insertEntry(
-					{ cardId: 1, stampMasterId: 1, omikujiRank: null, slot: 0, loginDate: TODAY },
-					TENANT,
-				),
-			).resolves.toBeUndefined();
-			await expect(
-				stampCardRepo.updateCardStatus(
-					1,
-					{ status: 'redeemed', redeemedPoints: 10, redeemedAt: TODAY, updatedAt: TODAY },
-					TENANT,
-				),
-			).resolves.toBeUndefined();
-			await expect(
-				stampCardRepo.updateCardStatusIfCollecting(
-					1,
-					{ status: 'completed', redeemedPoints: null, redeemedAt: null, updatedAt: TODAY },
-					TENANT,
-				),
-			).resolves.toBe(0);
-			await expect(stampCardRepo.deleteByTenantId(TENANT)).resolves.toBeUndefined();
-		});
-	});
+	// #2824 Wave 3B (ADR-0055): stamp-card-repo は本実装済 (stub 除外)。
+	//   子供 home 自動押印 (?/loginStamp) → スタンプ獲得 → 週末 redeem が本番 DynamoDB Lambda
+	//   で永続する。本実装の機能等価性テストは dynamodb-stamp-card-repo.test.ts に分離。ここで
+	//   stub 前提の assert を残すと「実装済なのに stub 期待」で誤った退行 gate になるため除外する
+	//   (他 repo の fallback assert は維持 = assertion 弱体化に該当しない)。
 
 	// #2295 (EPIC #2294 ①): tenant-event-repo describe 削除済 (2026-05-19、repo 自体撤去)
 
@@ -226,8 +190,8 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('regression guard: 全 7 repo の Promise.all で reject されない', () => {
-		it('SSR /preschool/home の典型的な 7 repo 並列呼び出しが全 fulfill する', async () => {
+	describe('regression guard: 全 6 repo の Promise.all で reject されない', () => {
+		it('SSR /preschool/home の典型的な 6 repo 並列呼び出しが全 fulfill する', async () => {
 			// #2295 (EPIC #2294 ①): seasonEventRepo / tenantEventRepo 削除済 (2026-05-19)、12 → 10 repo
 			// #2458 (Path B sibling drop): siblingChallengeRepo 削除済 (2026-05-26)、10 → 9 repo
 			// #2263 regression hotfix: childActivityRepo を stub fallback に置換 (9 → 10 repo)
@@ -237,13 +201,14 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 			//   (本実装は AWS SDK mock 必須 → dynamodb-reward-redemption-repo.test.ts で検証)。9 → 8 repo
 			// #2824 Wave 3A (ADR-0055): messageRepo を本実装化したため除外
 			//   (本実装は AWS SDK mock 必須 → dynamodb-message-repo.test.ts で検証)。8 → 7 repo
+			// #2824 Wave 3B (ADR-0055): stampCardRepo を本実装化したため除外
+			//   (本実装は AWS SDK mock 必須 → dynamodb-stamp-card-repo.test.ts で検証)。7 → 6 repo
 			const results = await Promise.allSettled([
 				autoChallengeRepo.findActiveByChild(1, TENANT),
 				battleRepo.findTodayBattle(1, TODAY, TENANT),
 				cloudExportRepo.findByTenant(TENANT),
 				reportDailySummaryRepo.findByChildAndDateRange(1, TODAY, TODAY, TENANT),
 				siblingCheerRepo.findUnshownCheers(1, TENANT),
-				stampCardRepo.findCardByChildAndWeek(1, '2026-05-12', TENANT),
 				viewerTokenRepo.findByTenant(TENANT),
 			]);
 

--- a/tests/unit/db/dynamodb-stamp-card-repo.test.ts
+++ b/tests/unit/db/dynamodb-stamp-card-repo.test.ts
@@ -1,0 +1,486 @@
+/**
+ * tests/unit/db/dynamodb-stamp-card-repo.test.ts
+ *
+ * #2824 Wave 3B / ADR-0055: DynamoDB stamp-card-repo 本実装の単体テスト。
+ *
+ * AWS SDK を vi.hoisted mock で置き換え、SQLite 実装 (sqlite/stamp-card-repo.ts、
+ * 挙動 SSOT) と機能等価であることを method ごとに検証する:
+ *   - 正しい Command + key で send する (child partition card / 専用 partition entry)
+ *   - response を正しく型変換する (stripKeys / master JOIN / null 既定補完)
+ *   - SQLite 機能等価 (findCardByChildAndWeek GetItem / insertCard default / entry の
+ *     onConflictDoNothing / updateCardStatusIfCollecting の冪等ガード / deleteByTenantId 2 経路)
+ *
+ * 背景: 本 repo は #2263 hotfix (PR #2280) で read=空 / write=no-op 化され、子供 home の
+ *   自動押印 (?/loginStamp) によるスタンプ獲得・週末 redeem が本番 DynamoDB Lambda で永続せず、
+ *   週跨ぎで履歴が消失する状態だった。本テストは本実装の機能等価性を回帰固定する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const {
+	mockSend,
+	MockGetCommand,
+	MockPutCommand,
+	MockQueryCommand,
+	MockUpdateCommand,
+	MockScanCommand,
+} = vi.hoisted(() => {
+	const send = vi.fn();
+	class Cmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	return {
+		mockSend: send,
+		MockGetCommand: class extends Cmd {},
+		MockPutCommand: class extends Cmd {},
+		MockQueryCommand: class extends Cmd {},
+		MockUpdateCommand: class extends Cmd {},
+		MockScanCommand: class extends Cmd {},
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	GetCommand: MockGetCommand,
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	UpdateCommand: MockUpdateCommand,
+	ScanCommand: MockScanCommand,
+	// bulk-delete.ts が import する Command。deleteByTenantId 経路で使用。
+	BatchWriteCommand: class {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	},
+}));
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/stamp-card-repo');
+}
+
+const TENANT = 'tenant-1';
+const CHILD_ID = 42;
+const WEEK_START = '2026-06-01';
+const WEEK_END = '2026-06-07';
+const CARD_ID = 7;
+
+/** child partition の stamp_card DynamoDB item を組み立てる。 */
+function makeCardItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const id = (over.id as number) ?? CARD_ID;
+	const weekStart = (over.weekStart as string) ?? WEEK_START;
+	return {
+		PK: `T#${TENANT}#CHILD#${CHILD_ID}`,
+		SK: `STMPCARD#${weekStart}`,
+		id,
+		childId: CHILD_ID,
+		weekStart,
+		weekEnd: WEEK_END,
+		status: 'collecting',
+		redeemedPoints: null,
+		redeemedAt: null,
+		createdAt: '2026-06-01T00:00:00.000Z',
+		updatedAt: '2026-06-01T00:00:00.000Z',
+		...over,
+	};
+}
+
+/** card partition の stamp_entry DynamoDB item を組み立てる。 */
+function makeEntryItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const slot = (over.slot as number) ?? 1;
+	return {
+		PK: `T#${TENANT}#STMPCARD#${CARD_ID}`,
+		SK: `STMPENT#${String(slot).padStart(8, '0')}`,
+		cardId: CARD_ID,
+		stampMasterId: 1,
+		omikujiRank: '大吉',
+		slot,
+		loginDate: '2026-06-01',
+		earnedAt: '2026-06-01T09:00:00.000Z',
+		...over,
+	};
+}
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// findEnabledStampMasters
+// ============================================================
+
+describe('findEnabledStampMasters', () => {
+	it('DEFAULT_STAMP_MASTERS_DATA SSOT 16 件を DB アクセスなしで返す', async () => {
+		const { findEnabledStampMasters } = await loadRepo();
+		const stamps = await findEnabledStampMasters(TENANT);
+		expect(stamps).toHaveLength(16);
+		expect(stamps.every((s) => s.isEnabled === 1)).toBe(true);
+		expect(stamps.every((s) => ['N', 'R', 'SR', 'UR'].includes(s.rarity))).toBe(true);
+		// DB を叩かない (空配列 → service の NO_STAMPS_AVAILABLE 回避)。
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+});
+
+// ============================================================
+// findCardByChildAndWeek
+// ============================================================
+
+describe('findCardByChildAndWeek', () => {
+	it('child + weekStart key で GetItem する', async () => {
+		mockSend.mockResolvedValueOnce({ Item: makeCardItem() });
+		const { findCardByChildAndWeek } = await loadRepo();
+		const card = await findCardByChildAndWeek(CHILD_ID, WEEK_START, TENANT);
+		expect(card?.id).toBe(CARD_ID);
+		expect(card?.weekStart).toBe(WEEK_START);
+		const callArg = mockSend.mock.calls[0]?.[0] as { input: { Key?: { PK: string; SK: string } } };
+		expect(callArg.input.Key?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(callArg.input.Key?.SK).toBe(`STMPCARD#${WEEK_START}`);
+	});
+
+	it('不在のとき undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Item: undefined });
+		const { findCardByChildAndWeek } = await loadRepo();
+		expect(await findCardByChildAndWeek(CHILD_ID, WEEK_START, TENANT)).toBeUndefined();
+	});
+
+	it('redeemedPoints / redeemedAt 欠落 item を null に補完する', async () => {
+		const item = makeCardItem({ status: 'redeemed' });
+		delete item.redeemedPoints;
+		delete item.redeemedAt;
+		mockSend.mockResolvedValueOnce({ Item: item });
+		const { findCardByChildAndWeek } = await loadRepo();
+		const card = await findCardByChildAndWeek(CHILD_ID, WEEK_START, TENANT);
+		expect(card?.redeemedPoints).toBeNull();
+		expect(card?.redeemedAt).toBeNull();
+	});
+});
+
+// ============================================================
+// insertCard
+// ============================================================
+
+describe('insertCard', () => {
+	it('counter 採番 → PutItem し SQLite default 値を埋めた card を返す', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 101 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insertCard } = await loadRepo();
+		const card = await insertCard(
+			{ childId: CHILD_ID, weekStart: WEEK_START, weekEnd: WEEK_END },
+			TENANT,
+		);
+
+		expect(card.id).toBe(101);
+		expect(card).toMatchObject({
+			childId: CHILD_ID,
+			weekStart: WEEK_START,
+			weekEnd: WEEK_END,
+			status: 'collecting', // schema default
+			redeemedPoints: null,
+			redeemedAt: null,
+		});
+
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(putCall.input.Item?.SK).toBe(`STMPCARD#${WEEK_START}`);
+		expect(putCall.input.Item?.status).toBe('collecting');
+	});
+
+	it('status 指定を反映する', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 5 } }).mockResolvedValueOnce({});
+		const { insertCard } = await loadRepo();
+		const card = await insertCard(
+			{ childId: CHILD_ID, weekStart: WEEK_START, weekEnd: WEEK_END, status: 'redeemable' },
+			TENANT,
+		);
+		expect(card.status).toBe('redeemable');
+	});
+});
+
+// ============================================================
+// findEntriesWithMasterByCardId
+// ============================================================
+
+describe('findEntriesWithMasterByCardId', () => {
+	it('card partition を Query し master JOIN 付きで slot 昇順に返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeEntryItem({ slot: 2, stampMasterId: 6 }), // R ロケット
+				makeEntryItem({ slot: 1, stampMasterId: 1 }), // N にこにこ
+			],
+		});
+		const { findEntriesWithMasterByCardId } = await loadRepo();
+		const entries = await findEntriesWithMasterByCardId(CARD_ID, TENANT);
+
+		expect(entries.map((e) => e.slot)).toEqual([1, 2]);
+		// master JOIN 解決 (getDefaultStampMasters SSOT)。
+		expect(entries[0]?.name).toBe('にこにこ');
+		expect(entries[0]?.emoji).toBe('😊');
+		expect(entries[0]?.rarity).toBe('N');
+		expect(entries[1]?.name).toBe('ロケット');
+		expect(entries[1]?.rarity).toBe('R');
+
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, string> };
+		};
+		expect(callArg.input.ExpressionAttributeValues?.[':pk']).toBe(
+			`T#${TENANT}#STMPCARD#${CARD_ID}`,
+		);
+		expect(callArg.input.ExpressionAttributeValues?.[':prefix']).toBe('STMPENT#');
+	});
+
+	it('stampMasterId が不在 (LEFT JOIN miss) のとき name/emoji/rarity は null', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeEntryItem({ slot: 1, stampMasterId: null })],
+		});
+		const { findEntriesWithMasterByCardId } = await loadRepo();
+		const entries = await findEntriesWithMasterByCardId(CARD_ID, TENANT);
+		expect(entries[0]?.stampMasterId).toBeNull();
+		expect(entries[0]?.name).toBeNull();
+		expect(entries[0]?.emoji).toBeNull();
+		expect(entries[0]?.rarity).toBeNull();
+		// omikujiRank は保持される。
+		expect(entries[0]?.omikujiRank).toBe('大吉');
+	});
+
+	it('LastEvaluatedKey でページングする', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [makeEntryItem({ slot: 1 })],
+				LastEvaluatedKey: { PK: 'c', SK: 'c' },
+			})
+			.mockResolvedValueOnce({ Items: [makeEntryItem({ slot: 2 })] });
+		const { findEntriesWithMasterByCardId } = await loadRepo();
+		const entries = await findEntriesWithMasterByCardId(CARD_ID, TENANT);
+		expect(entries).toHaveLength(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+
+	it('0 件のときは空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findEntriesWithMasterByCardId } = await loadRepo();
+		expect(await findEntriesWithMasterByCardId(CARD_ID, TENANT)).toEqual([]);
+	});
+});
+
+// ============================================================
+// insertEntry
+// ============================================================
+
+describe('insertEntry', () => {
+	it('card partition に PutItem し attribute_not_exists で slot 重複ガードする', async () => {
+		mockSend.mockResolvedValueOnce({});
+		const { insertEntry } = await loadRepo();
+		await insertEntry(
+			{ cardId: CARD_ID, stampMasterId: 3, omikujiRank: '中吉', slot: 2, loginDate: '2026-06-02' },
+			TENANT,
+		);
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: { Item?: Record<string, unknown>; ConditionExpression?: string };
+		};
+		expect(callArg.input.Item?.PK).toBe(`T#${TENANT}#STMPCARD#${CARD_ID}`);
+		expect(callArg.input.Item?.SK).toBe('STMPENT#00000002');
+		expect(callArg.input.Item?.stampMasterId).toBe(3);
+		expect(callArg.input.ConditionExpression).toBe('attribute_not_exists(PK)');
+	});
+
+	it('slot 重複 (ConditionalCheckFailed) は no-op で握りつぶす (onConflictDoNothing)', async () => {
+		const err = new Error('cond');
+		err.name = 'ConditionalCheckFailedException';
+		mockSend.mockRejectedValueOnce(err);
+		const { insertEntry } = await loadRepo();
+		await expect(
+			insertEntry(
+				{ cardId: CARD_ID, stampMasterId: 1, omikujiRank: null, slot: 1, loginDate: '2026-06-01' },
+				TENANT,
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it('ConditionalCheckFailed 以外の error は rethrow する', async () => {
+		mockSend.mockRejectedValueOnce(new Error('throughput exceeded'));
+		const { insertEntry } = await loadRepo();
+		await expect(
+			insertEntry(
+				{ cardId: CARD_ID, stampMasterId: 1, omikujiRank: null, slot: 1, loginDate: '2026-06-01' },
+				TENANT,
+			),
+		).rejects.toThrow('throughput exceeded');
+	});
+});
+
+// ============================================================
+// updateCardStatus
+// ============================================================
+
+describe('updateCardStatus', () => {
+	it('cardId を Scan で PK/SK 解決し status / redeem 系を更新する', async () => {
+		// 1) findCardItemById Scan
+		mockSend.mockResolvedValueOnce({
+			Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: `STMPCARD#${WEEK_START}` }],
+		});
+		// 2) UpdateCommand
+		mockSend.mockResolvedValueOnce({});
+
+		const { updateCardStatus } = await loadRepo();
+		await updateCardStatus(
+			CARD_ID,
+			{
+				status: 'redeemed',
+				redeemedPoints: 60,
+				redeemedAt: '2026-06-07T00:00:00Z',
+				updatedAt: '2026-06-07T00:00:00Z',
+			},
+			TENANT,
+		);
+
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const scan = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scan.input.FilterExpression).toContain('id = :id');
+		expect(scan.input.ExpressionAttributeValues?.[':id']).toBe(CARD_ID);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(upd.input.UpdateExpression).toContain('#status = :status');
+		expect(upd.input.ExpressionAttributeValues?.[':rp']).toBe(60);
+	});
+
+	it('card が見つからないとき Update せず no-op', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { updateCardStatus } = await loadRepo();
+		await updateCardStatus(
+			CARD_ID,
+			{ status: 'redeemed', redeemedPoints: 10, redeemedAt: 't', updatedAt: 't' },
+			TENANT,
+		);
+		// Scan のみ、Update 0 件。
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ============================================================
+// updateCardStatusIfCollecting
+// ============================================================
+
+describe('updateCardStatusIfCollecting', () => {
+	it('collecting の card を更新し 1 を返す (ConditionExpression 付き)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: `STMPCARD#${WEEK_START}` }],
+		});
+		mockSend.mockResolvedValueOnce({});
+		const { updateCardStatusIfCollecting } = await loadRepo();
+		const affected = await updateCardStatusIfCollecting(
+			CARD_ID,
+			{ status: 'redeemed', redeemedPoints: 50, redeemedAt: 't', updatedAt: 't' },
+			TENANT,
+		);
+		expect(affected).toBe(1);
+		const upd = mockSend.mock.calls[1]?.[0] as { input: { ConditionExpression?: string } };
+		expect(upd.input.ConditionExpression).toBe('#status = :collecting');
+	});
+
+	it('既に collecting でない (ConditionalCheckFailed) とき 0 を返す (冪等ガード)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: `STMPCARD#${WEEK_START}` }],
+		});
+		const err = new Error('cond');
+		err.name = 'ConditionalCheckFailedException';
+		mockSend.mockRejectedValueOnce(err);
+		const { updateCardStatusIfCollecting } = await loadRepo();
+		const affected = await updateCardStatusIfCollecting(
+			CARD_ID,
+			{ status: 'redeemed', redeemedPoints: 50, redeemedAt: 't', updatedAt: 't' },
+			TENANT,
+		);
+		expect(affected).toBe(0);
+	});
+
+	it('card 不在のとき 0 を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { updateCardStatusIfCollecting } = await loadRepo();
+		expect(
+			await updateCardStatusIfCollecting(
+				CARD_ID,
+				{ status: 'redeemed', redeemedPoints: 50, redeemedAt: 't', updatedAt: 't' },
+				TENANT,
+			),
+		).toBe(0);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ============================================================
+// deleteByTenantId
+// ============================================================
+
+describe('deleteByTenantId', () => {
+	it('cards (CHILD# 配下) と entries (STMPCARD# 配下) の 2 経路を Scan + 削除する', async () => {
+		// deleteItemsByPkPrefix は内部で Scan → BatchWrite。各経路 1 回 Scan (0 件返す)。
+		mockSend.mockResolvedValue({ Items: [] });
+		const { deleteByTenantId } = await loadRepo();
+		await deleteByTenantId(TENANT);
+		// 2 経路分の Scan が走る (cards prefix / entries prefix)。
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const scan1 = mockSend.mock.calls[0]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		const scan2 = mockSend.mock.calls[1]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		const pkPrefixes = [
+			scan1.input.ExpressionAttributeValues?.[':pkPrefix'],
+			scan2.input.ExpressionAttributeValues?.[':pkPrefix'],
+		];
+		expect(pkPrefixes).toContain(`T#${TENANT}#CHILD#`);
+		expect(pkPrefixes).toContain(`T#${TENANT}#STMPCARD#`);
+	});
+});
+
+// ============================================================
+// interface 適合 (SQLite との機能等価性)
+// ============================================================
+
+describe('interface 適合 (IStampCardRepo)', () => {
+	it('全メソッドを export している (stub に後退していない)', async () => {
+		const repo = await loadRepo();
+		for (const m of [
+			'findEnabledStampMasters',
+			'findCardByChildAndWeek',
+			'insertCard',
+			'findEntriesWithMasterByCardId',
+			'insertEntry',
+			'updateCardStatus',
+			'updateCardStatusIfCollecting',
+			'deleteByTenantId',
+		]) {
+			expect(typeof (repo as Record<string, unknown>)[m]).toBe('function');
+		}
+	});
+
+	it('write method が no-op stub でない (insertCard が実 send する)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		const { insertCard } = await loadRepo();
+		const card = await insertCard(
+			{ childId: CHILD_ID, weekStart: WEEK_START, weekEnd: WEEK_END },
+			TENANT,
+		);
+		// stub なら id=0 を返していた。本実装は counter 値を返す。
+		expect(card.id).toBe(1);
+		expect(mockSend).toHaveBeenCalled();
+	});
+});

--- a/tests/unit/db/dynamodb-stamp-card-repo.test.ts
+++ b/tests/unit/db/dynamodb-stamp-card-repo.test.ts
@@ -361,6 +361,7 @@ describe('updateCardStatus', () => {
 	});
 
 	it('card が見つからないとき Update せず no-op', async () => {
+		// 全ページ走査 (LastEvaluatedKey 無し) して 1 件も一致しない → undefined → no-op。
 		mockSend.mockResolvedValueOnce({ Items: [] });
 		const { updateCardStatus } = await loadRepo();
 		await updateCardStatus(
@@ -370,6 +371,60 @@ describe('updateCardStatus', () => {
 		);
 		// Scan のみ、Update 0 件。
 		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+
+	it('対象 card が 2 ページ目に来る Scan でも見つけて Update する (#2842 Limit:1+Filter 誤用回帰)', async () => {
+		// DynamoDB Scan の Limit は filter 適用「前」の評価上限。旧実装は Limit:1 のため
+		// 1 ページ目に対象が無いと空振りして silent no-op → redeem が黙って失敗していた。
+		// 本テストは「1 ページ目 = 非一致 (filter 落ち) で空 Items + LastEvaluatedKey、
+		// 2 ページ目 = 対象 card」を emulate し、pagination で必ず到達することを固定する。
+		mockSend
+			// 1) findCardItemById Scan page 1: filter で全部落ちて Items 空 + 続きあり
+			.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { PK: 'p1', SK: 'p1' } })
+			// 2) findCardItemById Scan page 2: 対象 card がここで一致
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: `STMPCARD#${WEEK_START}` }],
+			})
+			// 3) UpdateCommand
+			.mockResolvedValueOnce({});
+
+		const { updateCardStatus } = await loadRepo();
+		await updateCardStatus(
+			CARD_ID,
+			{
+				status: 'redeemed',
+				redeemedPoints: 60,
+				redeemedAt: '2026-06-07T00:00:00Z',
+				updatedAt: '2026-06-07T00:00:00Z',
+			},
+			TENANT,
+		);
+
+		// Scan 2 ページ + Update 1 回 = 3 send。Update に正しい PK/SK が渡る。
+		expect(mockSend).toHaveBeenCalledTimes(3);
+		const page1 = mockSend.mock.calls[0]?.[0] as { input: { ExclusiveStartKey?: unknown } };
+		const page2 = mockSend.mock.calls[1]?.[0] as { input: { ExclusiveStartKey?: unknown } };
+		// 旧実装は Limit:1 で 1 ページ目しか引かず、ExclusiveStartKey も渡していなかった。
+		expect(page1.input.ExclusiveStartKey).toBeUndefined();
+		expect(page2.input.ExclusiveStartKey).toEqual({ PK: 'p1', SK: 'p1' });
+		const upd = mockSend.mock.calls[2]?.[0] as { input: { Key?: { PK: string; SK: string } } };
+		expect(upd.input.Key?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(upd.input.Key?.SK).toBe(`STMPCARD#${WEEK_START}`);
+	});
+
+	it('Scan に Limit を付けない (filter 前評価上限による空振り防止、#2842)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: `STMPCARD#${WEEK_START}` }],
+		});
+		mockSend.mockResolvedValueOnce({});
+		const { updateCardStatus } = await loadRepo();
+		await updateCardStatus(
+			CARD_ID,
+			{ status: 'redeemed', redeemedPoints: 60, redeemedAt: 't', updatedAt: 't' },
+			TENANT,
+		);
+		const scan = mockSend.mock.calls[0]?.[0] as { input: { Limit?: number } };
+		expect(scan.input.Limit).toBeUndefined();
 	});
 });
 
@@ -421,6 +476,23 @@ describe('updateCardStatusIfCollecting', () => {
 			),
 		).toBe(0);
 		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+
+	it('対象 card が 2 ページ目に来る Scan でも見つけて 1 を返す (#2842 回帰)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { PK: 'p1', SK: 'p1' } })
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: `STMPCARD#${WEEK_START}` }],
+			})
+			.mockResolvedValueOnce({});
+		const { updateCardStatusIfCollecting } = await loadRepo();
+		const affected = await updateCardStatusIfCollecting(
+			CARD_ID,
+			{ status: 'redeemed', redeemedPoints: 50, redeemedAt: 't', updatedAt: 't' },
+			TENANT,
+		);
+		expect(affected).toBe(1);
+		expect(mockSend).toHaveBeenCalledTimes(3);
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

スタンプカード（おみくじシール / 達成スタンプ）は子供のコアゲーミフィケーションループの核。子供 home の自動押印 (`?/loginStamp` action) → スタンプ獲得 → 週末 redeem の体験が、本番 cognito Lambda (`DATA_SOURCE=dynamodb`) で**永続しない**致命的 gap を根治する。本 repo は #2263 hotfix (PR #2280) で「read=空 / write=no-op + logger.warn」化されており、週跨ぎでスタンプ履歴が消失する状態だった。SQLite 実装 (挙動 SSOT) と機能等価に DynamoDB single-table で本実装する。

## 関連 Issue

tracking #2824 (Wave 3B)。Phase 1 (#2820) / Phase 2A (#2826) / Phase 2B (#2825) は merged 済。本 PR は同 tracking の per-feature write 永続 gap 解消の Wave 3B。`closes` なし (tracking Issue は全 Wave 完遂後に PO 判断で close)。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `dynamodb/stamp-card-repo.ts` を SQLite 実装と機能等価に本実装 (stub 7 method 解消) | `dynamodb-stamp-card-repo.test.ts` 全 method の Command/key/型変換検証 | PASS (21 tests) |
| AC2 | 追加 GSI なしの key 設計 (child partition card + card 専用 partition entry) | key 設計表 (下記「影響範囲」) + svelte-check 型一致 | PASS — `STMPCARD#` / `STMPENT#` は既存テーブルに同居、CDK 変更不要 |
| AC3 | stub baseline (`scripts/dynamodb-stub-baseline.json`) から本 repo 削除 (ratchet 前進) | `node scripts/check-dynamodb-stub-parity.mjs` | PASS — `OK: 9 repo / 55 stub method`、`grep -c stamp-card-repo baseline = 0` |
| AC4 | fallback test から本 repo を除外、他 repo の fallback assert は維持 (ADR-0006 非弱体化) | `dynamodb-pre-pmf-fallback.test.ts` (regression guard 7 repo へ更新) | PASS (9 tests)、stamp-card describe 削除 + 機能等価テストへ移管コメント明記 |
| AC5 | 設計書同期 (`08-データベース設計書.md` DynamoDB キー設計節 + 変更履歴) | 設計書 diff | PASS — stamp_cards/stamp_entries キー設計表 + 5.18 changelog 追加 |

## 変更タイプ

- [x] バグ修正 (本番 write 永続 gap = データ消失) / 機能追加 (DynamoDB 本実装)
- [ ] UI 変更
- [x] 設計書更新
- [x] テスト追加

## 影響範囲・変更コンポーネント

DynamoDB key 設計 (追加 GSI 不要、ADR-0055 §3.1):

| エンティティ | PK | SK | query |
|---|---|---|---|
| stamp_cards | `T#<tid>#CHILD#<childId>` | `STMPCARD#<weekStart>` | `findCardByChildAndWeek` = GetItem (childId+weekStart 既知)。weekStart 一意 = SQLite uniqueIndex(child_id, week_start) 等価。core loop 頻出 (home load 毎) のため child partition 同居 |
| stamp_entries | `T#<tid>#STMPCARD#<cardId>` | `STMPENT#<paddedSlot>` | `findEntriesWithMasterByCardId(cardId)` = 単一 partition Query。entry は cardId のみで lookup される (childId 渡らない) ため card 専用 partition に配置。paddedSlot = SQLite uniqueIndex(card_id, slot) 等価 |

- `cardId` だけ受ける `updateCardStatus` / `updateCardStatusIfCollecting` は tenant Scan + id filter で PK/SK 解決 (reward-redemption-repo.updateRedemptionRequestStatus と同型、redeem は週次・低頻度で GSI 不要 = Pre-PMF / ADR-0010)。
- stamp master JOIN は固定 16 件 SSOT (`getDefaultStampMasters`) を in-memory map で解決 (tenant 別カスタマイズなし、LEFT JOIN miss は null)。
- `insertEntry` は `attribute_not_exists(PK)` で SQLite `onConflictDoNothing` 等価。`updateCardStatusIfCollecting` は `ConditionExpression: #status=collecting` で冪等ガード (成功=1 / ConditionalCheckFailed=0 = SQLite `result.changes` 等価)。
- 変更 file: `dynamodb/stamp-card-repo.ts` (本実装) / `dynamodb/keys.ts` (stampCardKey/stampEntryKey + ENTITY_NAMES.stampCard) / `scripts/dynamodb-stub-baseline.json` / `tests/unit/db/dynamodb-stamp-card-repo.test.ts` (新規) / `dynamodb-pre-pmf-fallback.test.ts` / `08-データベース設計書.md` / `.cspell/project-words.txt`。

## テスト & 安全装置セルフチェック

- [x] `dynamodb-stamp-card-repo.test.ts` 新規 21 tests (vi.hoisted AWS SDK mock、child-activity-repo 同型) — 全 method の Command/key/型変換/SQLite 機能等価
- [x] `dynamodb-pre-pmf-fallback.test.ts` 9 tests PASS (本 repo 除外、regression guard 8→7 repo)
- [x] `npx vitest run tests/unit/db/ tests/unit/services/` 全 PASS (146 files / 2442 tests)
- [x] `npx biome check` clean (changed files)
- [x] `npx svelte-check` 自 file 型エラー 0 (残 58 error は全て infra/aws-cdk-lib 未 install = worktree 固有、本 PR 無関係)
- [x] `node scripts/check-dynamodb-stub-parity.mjs` PASS
- [x] cspell PASS (STMPCARD / STMPENT を project-words 追加)

## スクリーンショット / ビジュアルデモ

N/A — サーバー側 DB repository 実装のみ。UI / `.svelte` 変更なし。挙動は既存スタンプカード UI (本番 SQLite で動作実績あり) を DynamoDB 環境でも同等に永続させるもので、画面の見た目に変化はない。

## コード品質セルフレビュー (#1481)

- SQLite 実装を挙動 SSOT として method ごとに対応付け、default 値 / null 補完 / sort 順 / 冪等ガードを一致させた。
- key builder は keys.ts に集約 (生 string 構築を repo に散らさない)。エラー判定は repo 全体の慣習 (`e instanceof Error && e.name === 'ConditionalCheckFailedException'`) に統一。
- exemplar (child-activity-repo / reward-redemption-repo) の vi.hoisted mock パターンを踏襲。

## 横展開・影響波及チェック

- 並行実装ペア (sqlite/stamp-card-repo.ts) と null/既定値ハンドリング一致を確認 (tests/CLAUDE.md「DynamoDB 並行実装の整合性」)。
- factory.ts は既存 `dynamoStampCardRepo` を参照済 (wiring 変更不要)。demo/stamp-card-repo.ts は別 impl で本 PR scope 外。
- Wave 3A (`feat/dynamodb-message-impl`) と baseline.json / 設計書 / keys.ts / cspell が共有編集対象。自 repo 行のみ追加/削除し他行不変。push 前に origin/main へ rebase 済 (conflict なし)。

## レビュー依頼事項・破壊的変更

破壊的変更なし。schema 自体に変更なし (DynamoDB 実装の追加のみ)、CDK 変更不要 (既存 single-table に新規 SK prefix が乗る)。レビュー観点: (1) updateCardStatus* の tenant Scan + id filter が週次低頻度前提で Pre-PMF 妥当か (2) entry を card 専用 partition に置く設計 (cardId のみで Query 完結) の妥当性。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。既存 `DATA_SOURCE=dynamodb` + `TABLE_NAME` (本番 Lambda 配備済) を使用。

## Ready for Review チェックリスト

- [x] `npm run pre-ready` 相当の検証 (biome / svelte-check / vitest / cspell / stub-parity) を local で実行し PASS
- [x] CI 全緑を確認してから Ready 化する
- [x] AC 検証マップ 4 列形式で全 AC を埋めた
- [x] 設計書同期完了 (08-DB設計書)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: 機能等価テスト 30 件 + parity gate で本実装を回帰固定。実機 DynamoDB は本番 Lambda 配備後に CUJ で担保)

## QM レビュー結果

(QM が記入)
