### PR TITLE
docs: #2815 D-2 不採用判断の SSOT 化 + C-3 post-mortem 禁忌新設 (self-report 信頼性仕上げ)

### DIFF
--- a/docs/operations/self-review-agent.md
+++ b/docs/operations/self-review-agent.md
@@ -74,6 +74,17 @@ Dev Self-Review で「PASS」と自己宣言したが QM Re-Review で実態 FAI
 
 verdict table には「false PASS 主張ゼロを目視確認済」を明記する。QA team が merge 前に加えた fix の頻出パターンは [../sessions/dev-process/qa-fix-patterns.md](../sessions/dev-process/qa-fix-patterns.md) を参照し、事前回避する。
 
+### §2.4-2 機械 gate 対応表 + 観点一括 CLI 不採用判断（#2815 D-2）
+
+17 観点の機械検証は **既存 4 層 gate**（pre-ready 12 step / `.husky/pre-push` verify chain / CI lint-and-test / check-pr-body）が担う。**観点一括実行の専用 CLI（run-self-review.mjs）は新設しない**（PO 指示の deep research 判断: 機械化可能観点は既存 gate で充足済みで、新 CLI は pre-ready のサブセット再実装 = 二重管理 #1442 / ADR-0010 Bucket C。証跡なき `[x]` の検出は check-pr-body の `self-review-evidence-missing` gate が担う）。
+
+| 観点群 | 機械化 | 担う既存 gate |
+|---|---|---|
+| #1 破綻なし / #4 Storybook / #8 場当たり禁止 / #9 AC マップ / #10 必須セクション / #11 禁止語 | 完全機械化（充足済み） | pre-ready Step1-3 + CI lint-and-test / `test:storybook` CI / stylelint + `check-no-plan-literals.mjs` + `check-hardcoded-strings.mjs` / `check-pr-body.mjs`（pre-ready Step9・pre-push・CI gate の 3 層） |
+| #6 docs SSOT（履歴メタ 0 件） | 機械化可・未 gate | grep 手動（gate 化は #2440 棚卸 Phase 4 で ratchet 化判断） |
+| #2 テスト十分性 / #5 過去指摘 / #12 label / #13 並行実装 / #15 セキュリティ / #16 リーク / #17 性能 | 半機械（候補抽出のみ機械） | `check-test-antipatterns` + coverage ratchet / `lint:parallel` / pr-info type-label 等 — **要否・妥当性の最終判断は人/LLM**（§2.4 の証跡必須が適用される） |
+| #3 SS 期待 UX / #7 SOLID / #14 Research 適合 | 機械化不可 | 人/LLM 判断必須（証跡コマンド添付は §2.4 で強制） |
+
 ---
 
 ## §3 Agent spawn テンプレート

--- a/docs/sessions/qa-session.md
+++ b/docs/sessions/qa-session.md
@@ -223,6 +223,7 @@ Orchestrator が Tier 2 Review Agent / CI Fix Agent を spawn する際の定型
 詳細は ADR-0022 / ADR-0026。要点:
 
 - **CI 緑 = approve**（#1197 / #1198）/ SS 未視認で approve / Issue を開かず approve / 「見ました」だけの所見
+- **Dev の self-report（pre-ready `[x]` / 完遂宣言）を独立検証なしに信用して approve**（#2815 post-mortem 事例: pre-ready 自己申告と CI の乖離 = PR #2503 / Self-Review false PASS 3 連発 = #2475 / Fix Agent「全件解消」が実 60% = #2690 / approve 宣言のみで tool call せず exit = #2756）。Re-Review 手順 4 の物理 verification（grep 件数突合）と CI 実結果を必ず照合する
 - 1 Agent で複数 PR / 独自フォーマットの approve body / `--admin` bypass（ADR-0022 完全禁止）
 - CI 失敗のゼロベーストラブルシュート（KB 参照 → Fix Agent spawn が標準）
 - **`ganbariquestsupport-lab` で PR を作成**（QA レビュー専用、PR 作成は Takenori-Kusaka — #1728 / ADR-0022 amendment）。本禁忌は **3 層機械強制機構** で abort される:


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者・QM（self-report 信頼性基盤の完成）

**解決する課題**: (D-2) 「17 観点一括 CLI を作るか」が未判断のまま残ると、将来の開発者が pre-ready と重複する第 2 CLI を善意で新設し二重管理（#1442）に陥るリスクがある。(C-3) QM の禁忌集に「Dev self-report の盲信 approve」が無く、#2503/#2475/#2690/#2756 の post-mortem が運用 SSOT に未接続だった。

**期待される効果**: (D-2) 機械 gate 対応表により「どの観点がどの既存 gate で守られているか」が 1 表で分かり、CLI 新設の再検討コストと二重管理リスクを構造的に排除。(C-3) QM が self-report 盲信で approve する経路に禁忌 + 事例リンクが立ち、Re-Review 手順 4（物理 verification）への導線が閉じる。

**設計ポリシー確認**: D-2 は PO 指示（QA 表 Q11 = 「他 script との競合性 + git hook 効果性を deep research し、あるべき開発基盤を設計実装」）の deep research 結論。17 観点 × 4 層 gate の対応表で機械化可能分の充足を確認し、新 CLI 不採用（pre-ready のサブセット再実装 = 二重管理 / ADR-0010 Bucket C、反証 3 シナリオも B 案・D-1 精緻化に収束し不採用判断は頑健）。

## 関連 Issue

refs #2815（Track D-2 / C-3 の完遂。これで #2815 の残りは C-1 self-dogfood / C-2 再発 monitor の運用 verify のみ）

- 関連: #1442（使い捨て script 禁止）/ #2511（C-3 の post-mortem 起源、「現状あり」前提の錯誤を本 PR で訂正）/ PR #2834（D-1 gate）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| D-2-1 | run-self-review.mjs の可否を deep research で判断 | 調査 spec（17 観点 × 既存 4 層 gate 対応表、pre-ready 12 step の CI 搭載状況） | PASS: **不採用**。機械化可能 7 観点（#1/4/6/8/9/10/11）のうち #6 以外は既存 gate で 100% 充足、半機械 7 + 判断必須 3 は CLI 化不能。新 CLI の純増自動化は #6（grep 1 行）のみで CLI 規模に達しない |
| D-2-2 | 判断結果の SSOT 化 | `grep -n "§2.4-2" docs/operations/self-review-agent.md` | PASS: §2.4-2 新設（機械 gate 対応表 + 不採用根拠。#6 の gate 化は #2440 Phase 4 へ接続） |
| C-3 | post-mortem リンクを qa-session.md 禁忌に追記 | `grep -n "self-report" docs/sessions/qa-session.md` | PASS: 「QM が絶対にやってはいけないこと」に self-report 盲信 approve の禁忌 + 事例 4 件（PR #2503 / #2475 / #2690 / #2756）+ Re-Review 手順 4 への導線を新設（#2511 が「現状あり」とした項は実在せず、本 PR で新設） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — プロセス SSOT docs 2 ファイルのみ（コード変更ゼロ）

**影響を受ける画面・機能**: なし（runtime 不変）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2843` 全 Step PASS**（#1775 / ADR-0030）— Step1-8 PASS（biome / svelte-check / vitest 全件 / hardcoded-strings / no-plan-literals。LP 系 Step5/6/8 は非該当 skip）
- [x] 追加・変更したテストの概要: N/A（docs のみ。`check-doc-code-references.mjs` 新規違反なし = `✓ baseline 内` を実測）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし**（docs のみ、UI 変更ゼロ）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A 相当（docs）。判断の SSOT は self-review-agent.md 1 箇所に集約し、qa-session.md からは事例リンクのみ
- [x] **DRY**: 新 CLI 不採用の判断自体が DRY（pre-ready との二重管理回避）。`grep -rn "run-self-review" docs/ scripts/` で他箇所に判断の重複記述なし（0 件）
- [x] **YAGNI**: #6 の gate 化は必要性実証まで保留（#2440 Phase 4 接続のみ明記）
- [x] **Security（OSS 公開前提）**: 秘密情報なし
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 設計書同期 (ADR-0001) — 本 PR 自体がプロセス SSOT の追記
- [x] 並行 PR overlap 確認 (#1200) — 重複 open PR なし
- [x] N/A — 本番↔デモ / LP / 年齢モード / ナビ / labels / E2E シードは影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- D-2 の詳細な調査 spec（4 層 map / 17 観点仕分け / 3 案比較 / 反証）は #2815 のコメントに全文掲載。本 PR はその結論の SSOT 化。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2843` 全 Step PASS** をローカル確認した — Step1-8 PASS。Step9 は本チェックリスト自身の自己参照
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— 2 file、`git diff --stat` で確認
- [x] 全 AC が実装済み — D-2-1/D-2-2/C-3 全 PASS（上記 AC マップ）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

