### PR TITLE
fix: #2824 Wave 4A — dynamodb activity-repo write 8 method 本実装 (コアループ throw 根治、CRITICAL) (ADR-0055)

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -300,6 +300,34 @@ CDK（`infra/lib/storage-stack.ts`）の `MainTable` は単一テーブル（PK 
 > 一因となった。本実装で根治。helper 経由 stub（`return notImplemented(...)` 等）の再混入は
 > `scripts/check-dynamodb-stub-parity.mjs`（baseline ratchet）が CI で検出する。
 
+#### DynamoDB キー設計（activity_log / point_ledger / family-master facade、#2824 Wave 4A）
+
+`src/lib/server/db/dynamodb/activity-repo.ts` の write 8 method を本実装化（コアループ
+「活動記録 → ポイント付与」の本経路。本番 main Lambda は `DATA_SOURCE=dynamodb`）。log/ledger は
+child partition 配下に置き、既存 read（`findDailyLog` / `findStreakLogs` / `findActivityLogs` /
+集計）が読む key 形式・非正規化属性に整合させる。family-master CRUD は SQLite (#2458-A1) と同じく
+per-child `child_activities`（`child-activity-repo.ts`）へ委譲し、旧 `activities` partition
+（SK=MASTER）への write は 0 件を維持する。
+
+| エンティティ | PK | SK | 補足 |
+|---|---|---|---|
+| activity_log | `T#<tid>#CHILD#<childId>` | `LOG#<recordedDate>#<paddedId>` | id 8 桁 0 埋め。read の JOIN 代替に `activityName` / `activityIcon` / `categoryId` を insert 時に child_activities lookup して非正規化保存 |
+| point_ledger | `T#<tid>#CHILD#<childId>` | `POINT#<createdAt>#<paddedId>` | createdAt は ISO 文字列（`YYYY-MM-DD…`）で `countPointLedgerEntriesByTypeAndDate` の `begins_with(createdAt, :date)` に整合 |
+
+| アクセスパターン | 操作 | 条件 |
+|---|---|---|
+| `insertActivityLog` | counter 採番 → child_activities lookup（非正規化）→ PutItem | `findActivityLogs`（ActivityLogSummary）/ `getCategoryCountsByDate` / `findTodayLogsWithCategory` 等が LOG item の denormalized 属性を直接読むため、SQLite の innerJoin（activity_logs ⋈ child_activities）相当を insert 時に解決して埋める |
+| `insertPointLedger` | counter 採番 → PutItem | `countPointLedgerEntriesByType` / `getComboPointsGranted` 等が POINT item の type / amount / description / createdAt を読む形式で書く |
+| `insertActivity` | findFirstChild（Scan）→ child_activities へ委譲 | facade signature 不変。tenant の最初の child に bind（SQLite #2458-A1 と同型） |
+| `updateActivity` / `setActivityVisibility` / `deleteActivity` | id → childId 逆引き（Scan）→ child_activities へ委譲 | facade が childId を受けないため CHILDACT# を Scan で逆引き。低頻度（admin 操作）のため GSI 不要（Pre-PMF / ADR-0010） |
+| `archiveActivities` / `restoreArchivedActivities` | child_activities へ委譲 | 旧 activities partition でなく per-child instance を archive/restore（downgrade / resource-archive サービスの barrel 経由呼び出しに整合） |
+
+> **#2824 Wave 4A 経緯**: 旧コメント「DynamoDB backend は production 未使用（main Lambda は sqlite）」は
+> stale な誤記だった（`infra/lib/compute-stack.ts` の `ganbari-quest-app` は `DATA_SOURCE=dynamodb` +
+> `AUTH_MODE=cognito`）。write 8 method が `NotImplementedError` throw のままだと本番で活動記録・
+> ポイント付与が throw する CRITICAL gap だったため本実装で根治。「SK=MASTER への write 0 件」不変条件は
+> `tests/unit/services/activity-legacy-table-write-zero-dynamodb.test.ts`（write 成功かつ MASTER 不可触を assert）で回帰固定。
+
 ### activities (legacy、PR-3 期間中の並存)
 
 > **#2362 PR-3 移行ステータス (2026-05-24)**: 本 table は `child_activities` への

--- a/scripts/dynamodb-stub-baseline.json
+++ b/scripts/dynamodb-stub-baseline.json
@@ -1,14 +1,4 @@
 {
-	"src/lib/server/db/dynamodb/activity-repo.ts": [
-		"archiveActivities",
-		"deleteActivity",
-		"insertActivity",
-		"insertActivityLog",
-		"insertPointLedger",
-		"restoreArchivedActivities",
-		"setActivityVisibility",
-		"updateActivity"
-	],
 	"src/lib/server/db/dynamodb/auto-challenge-repo.ts": [
 		"deleteByTenantId",
 		"expireOldChallenges",

--- a/src/lib/server/db/dynamodb/activity-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-repo.ts
@@ -372,21 +372,32 @@ export async function deleteActivity(id: number, tenantId: string): Promise<Acti
 
 /** 活動にログが存在するか確認 */
 export async function hasActivityLogs(activityId: number, _tenantId: string): Promise<boolean> {
-	// Scan LOG# items filtered by activityId, limit 1 for efficiency
-	const result = await getDocClient().send(
-		new ScanCommand({
-			TableName: TABLE_NAME,
-			FilterExpression: 'begins_with(SK, :skPrefix) AND #activityId = :activityId',
-			ExpressionAttributeNames: { '#activityId': 'activityId' },
-			ExpressionAttributeValues: {
-				':skPrefix': 'LOG#',
-				':activityId': activityId,
-			},
-			Limit: 1,
-		}),
-	);
+	// #2842: DynamoDB は FilterExpression より先に Limit を評価するため、Limit:1 では
+	//   「最初に scan された 1 件が match しない」だけで false negative になる
+	//   (= ログを持つ活動が hard-delete され子供の履歴が永久消失する)。
+	//   Limit は付けず scanAll と同型の do/while + ExclusiveStartKey で全 page を走査し、
+	//   filter match を 1 件見つけ次第 early-return true、page 尽きたら false を返す。
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await getDocClient().send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: 'begins_with(SK, :skPrefix) AND #activityId = :activityId',
+				ExpressionAttributeNames: { '#activityId': 'activityId' },
+				ExpressionAttributeValues: {
+					':skPrefix': 'LOG#',
+					':activityId': activityId,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		if ((result.Items?.length ?? 0) > 0) {
+			return true;
+		}
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
 
-	return (result.Items?.length ?? 0) > 0;
+	return false;
 }
 
 /** 全活動のログ数を取得（キャンセル除外） */
@@ -582,29 +593,13 @@ export async function findActivityLogById(
 	id: number,
 	_tenantId: string,
 ): Promise<ActivityLog | undefined> {
-	const result = await getDocClient().send(
-		new ScanCommand({
-			TableName: TABLE_NAME,
-			FilterExpression: 'begins_with(SK, :skPrefix) AND #id = :id',
-			ExpressionAttributeNames: { '#id': 'id' },
-			ExpressionAttributeValues: {
-				':skPrefix': 'LOG#',
-				':id': id,
-			},
-			Limit: 100,
-		}),
-	);
-
-	// Since Limit with FilterExpression may not find the item on first page, paginate
-	let items = result.Items ?? [];
-	let lastKey = result.LastEvaluatedKey;
-
-	if (items.length > 0) {
-		return stripKeys(items[0] as Record<string, unknown>) as unknown as ActivityLog;
-	}
-
-	while (lastKey && items.length === 0) {
-		const nextResult = await getDocClient().send(
+	// #2842: DynamoDB は FilterExpression より先に Limit を評価するため、Limit を付けると
+	//   1 page 内に match が無いだけで取りこぼす。Limit は外し、scanAll と同型の
+	//   do/while + ExclusiveStartKey で全 page を走査する。各 page では filter match した
+	//   全 Items を走査し (`items[0]` だけ見ない)、最初の match を返す。
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await getDocClient().send(
 			new ScanCommand({
 				TableName: TABLE_NAME,
 				FilterExpression: 'begins_with(SK, :skPrefix) AND #id = :id',
@@ -614,15 +609,13 @@ export async function findActivityLogById(
 					':id': id,
 				},
 				ExclusiveStartKey: lastKey,
-				Limit: 100,
 			}),
 		);
-		items = nextResult.Items ?? [];
-		lastKey = nextResult.LastEvaluatedKey;
-		if (items.length > 0) {
-			return stripKeys(items[0] as Record<string, unknown>) as unknown as ActivityLog;
+		for (const item of result.Items ?? []) {
+			return stripKeys(item as Record<string, unknown>) as unknown as ActivityLog;
 		}
-	}
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
 
 	return undefined;
 }

--- a/src/lib/server/db/dynamodb/activity-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-repo.ts
@@ -148,7 +148,8 @@ async function resolveChildIdForActivity(
 		const result = await getDocClient().send(
 			new ScanCommand({
 				TableName: TABLE_NAME,
-				FilterExpression: 'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
+				FilterExpression:
+					'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
 				ExpressionAttributeValues: {
 					':tenantPrefix': tenantPK('CHILD#', tenantId),
 					':skPrefix': 'CHILDACT#',
@@ -362,10 +363,7 @@ export async function setActivityVisibility(
 /**
  * 活動を削除 — #2824: child_activities (per-child) 経由 (削除した行を返す)。
  */
-export async function deleteActivity(
-	id: number,
-	tenantId: string,
-): Promise<Activity | undefined> {
+export async function deleteActivity(id: number, tenantId: string): Promise<Activity | undefined> {
 	const childId = await resolveChildIdForActivity(id, tenantId);
 	if (childId === undefined) return undefined;
 	const row = await childActivityRepo.deleteActivity(id, childId, tenantId);

--- a/src/lib/server/db/dynamodb/activity-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-repo.ts
@@ -1,36 +1,42 @@
 // src/lib/server/db/dynamodb/activity-repo.ts
 // DynamoDB implementation of IActivityRepo
 //
-// #2458-A2 (2026-05-26): facade rewrite — 旧 `activities` partition (SK=MASTER) への
-// write を全て NotImplementedError に置き換えた。これにより sqlite と同型に
-// 「旧 activities table への write 0 件」を 3 backend (sqlite / demo / dynamodb) で
-// 達成。次 PR #2458-C で旧 activities partition / 旧 dynamodb activity-repo は
-// 物理削除される予定。
+// #2824 Wave 4A (2026-06-04 / ADR-0055): write 8 method を本実装化。
+//   本番 main Lambda (`ganbari-quest-app`、infra/lib/compute-stack.ts、AUTH_MODE=cognito)
+//   は **DATA_SOURCE=dynamodb** で稼働する (旧コメントの「production 未使用 / main Lambda は
+//   sqlite」は stale な誤記だった)。そのため write 8 method が NotImplementedError throw のままだと:
+//     - insertActivityLog: 子供の活動記録 (activity-log-service L211) が throw → 記録不能 (CRITICAL)
+//     - insertPointLedger: ポイント台帳 → ポイント付与不能 (CRITICAL)
+//     - insertActivity 等 6: family-master activity CRUD が throw
+//   というコアループ全停止 gap になっていた。本 PR で根治する。
 //
-// 設計の前提:
-//   - ADR-0048 Multi-Lambda Demo Deployment で main Lambda は sqlite local file +
-//     S3 backup を使用。`DATA_SOURCE='dynamodb'` は production 未使用 (factory.ts
-//     interface 整合のため stub 保持)。
-//   - production で本 file の write 経路が呼ばれることはないが、cross-backend test
-//     等で interface 契約 (IActivityRepo) を満たす必要があるため type 整合は維持。
-//   - write 系を NotImplementedError 化することで「将来 dynamodb 本実装を再開する
-//     際に必ず `dynamodb/child-activity-repo.ts` (ADR-0055 per-child schema) 経由で
-//     実装し直す」ことを構造的に強制する (旧 activities partition への退行を防止)。
-//
-// 読み込み系 (findActivities / findActivityById / findActivityLogs 等) は依然として
-// activities partition (SK=MASTER) / activity_logs LOG# partition を Scan / Query で
-// 取得する legacy 実装を保持。production 未使用のため write 0 化が達成できれば
-// 残 read 経路は #2458-C で削除される。
+// 設計 (read 整合と family-master 判断):
+//   - insertActivityLog / insertPointLedger は log/ledger エンティティ。read 側
+//     (findDailyLog / findStreakLogs / findActivityLogs / findActivityLogById /
+//     countTodayActiveRecords / getCategoryCountsByDate / findTodayLogsWithCategory 等) が
+//     既に期待する key 形式 (LOG#<date>#<id> / POINT#<createdAt>#<id>) と denormalized 属性
+//     (activityName / activityIcon / categoryId) に整合する形で write する。
+//     denormalize は insert 時に child_activities instance を lookup して埋める
+//     (SQLite の innerJoin (activityLogs ⋈ childActivities) と機能等価)。
+//   - family-master CRUD (insertActivity / updateActivity / setActivityVisibility /
+//     deleteActivity / archiveActivities / restoreArchivedActivities) は SQLite 側
+//     (#2458-A1 facade rewrite) と同じく **per-child `child_activities` 経由** に統一する。
+//     live app の `activity-service.ts` は CRUD を `getRepos().childActivity.*` で直接
+//     叩いており、本 facade の family-master write を呼ぶのは barrel 経由の
+//     archive / restore (downgrade-service / resource-archive-service) のみ。これらを
+//     child-activity-repo の per-child 実装に委譲することで signature 不変のまま
+//     live schema (child_activities) に write する (旧 activities partition への退行ゼロ)。
 //
 // 関連:
-//   - PR #2487 (#2458-A1 sqlite facade rewrite、本 PR の reference pattern)
+//   - PR #2487 (#2458-A1 sqlite facade rewrite、本 PR の挙動 SSOT)
+//   - PR #2820 (dynamodb/child-activity-repo.ts 本実装、委譲先)
 //   - ADR-0055 §3.1 per-child primary data model
-//   - ADR-0048 §2 demo Lambda stateless 原則
-//   - docs/design/data-model-resource-scope.md §4.1
+//   - docs/design/08-データベース設計書.md / data-model-resource-scope.md §4.1
 
 import {
 	BatchWriteCommand,
 	GetCommand,
+	PutCommand,
 	QueryCommand,
 	ScanCommand,
 	UpdateCommand,
@@ -42,18 +48,25 @@ import type {
 	ActivityLog,
 	ActivityLogSummary,
 	Child,
+	ChildActivity,
 	InsertActivityInput,
 	InsertActivityLogInput,
 	InsertPointLedgerInput,
 	UpdateActivityInput,
+	UpdateChildActivityInput,
 } from '../types';
+import * as childActivityRepo from './child-activity-repo';
 import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
 import {
 	activityKey,
 	activityLogDatePrefix,
+	activityLogKey,
 	activityLogPrefix,
 	childKey,
 	childPK,
+	ENTITY_NAMES,
+	pointLedgerKey,
 	pointLedgerPrefix,
 	tenantPK,
 } from './keys';
@@ -117,17 +130,59 @@ async function queryAll(
 }
 
 /**
- * #2458-A2: 旧 `activities` partition への write を発生させない構造的ガード。
- * `dynamodb/child-activity-repo.ts` も全 method が NotImplemented stub のため、
- * 本実装の write 経路を再開する際は ADR-0055 per-child schema (`child_activities`
- * partition) を先に実装してから本 throw を解除する必要がある。
+ * activity_id (= child_activities instance id) から所属 childId を逆引きする (tenant 内)。
+ *
+ * facade signature `(id, …, tenantId)` は childId を受けないため、family-master write の
+ * 委譲先 child-activity-repo (per-child) には childId が必須。child_activities は
+ * child partition (PK=CHILD#<cId>) に分散するため GSI なしの逆引きは Scan が必要。
+ * これらの write (insert を除く CRUD) は低頻度 (admin 操作 / プラン降格) のため
+ * Pre-PMF (ADR-0010) では Scan + 属性フィルタで十分。SQLite の `_resolveChildIdForActivity`
+ * (childActivities を id で 1 行 lookup) と機能等価。
  */
-function notImplementedWrite(method: string): never {
-	throw new Error(
-		`[activity-repo.dynamodb] ${method} not implemented (#2458-A2 旧 activities partition への write 防止). ` +
-			'DynamoDB backend は ADR-0048 で production 未使用 (main Lambda は sqlite). ' +
-			'再実装時は dynamodb/child-activity-repo.ts (ADR-0055 per-child) 経由で実装すること。',
-	);
+async function resolveChildIdForActivity(
+	id: number,
+	tenantId: string,
+): Promise<number | undefined> {
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await getDocClient().send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: 'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
+				ExpressionAttributeValues: {
+					':tenantPrefix': tenantPK('CHILD#', tenantId),
+					':skPrefix': 'CHILDACT#',
+					':id': id,
+				},
+				ProjectionExpression: 'childId',
+				ExclusiveStartKey: lastKey,
+				Limit: 100,
+			}),
+		);
+		const hit = result.Items?.[0];
+		if (hit) return hit.childId as number;
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return undefined;
+}
+
+/**
+ * tenant 内の最初の child (id 昇順) を返す。insertActivity の bind 先解決用。
+ * SQLite `_findFirstChild` と機能等価 (children を id 順で先頭 1 件)。
+ */
+async function findFirstChild(tenantId: string): Promise<{ id: number } | undefined> {
+	const items = await scanAll({
+		TableName: TABLE_NAME,
+		FilterExpression: 'begins_with(PK, :prefix) AND SK = :sk',
+		ExpressionAttributeValues: {
+			':prefix': tenantPK('CHILD#', tenantId),
+			':sk': 'PROFILE',
+		},
+		ProjectionExpression: 'id',
+	});
+	if (items.length === 0) return undefined;
+	const ids = items.map((it) => it.id as number).sort((a, b) => a - b);
+	return { id: ids[0] as number };
 }
 
 // ============================================================
@@ -206,46 +261,115 @@ export async function findActivityById(
 }
 
 /**
- * 活動を作成 — #2458-A2: 旧 activities partition への write を停止。
- * dynamodb/child-activity-repo.ts (NotImplemented stub) 経由で実装する設計に shift。
+ * ChildActivity (per-child instance) を facade の Activity shape に変換する。
+ * family-master 列 (ageMin / ageMax / gradeLevel / subcategory / description) は
+ * per-child instance に存在しないため null で埋める (SQLite `_toActivityShape` と同型)。
+ */
+function toActivityShape(c: ChildActivity): Activity {
+	return {
+		id: c.id,
+		name: c.name,
+		categoryId: c.categoryId,
+		icon: c.icon,
+		basePoints: c.basePoints,
+		ageMin: null,
+		ageMax: null,
+		isVisible: c.isVisible,
+		dailyLimit: c.dailyLimit,
+		sortOrder: c.sortOrder,
+		source: c.source,
+		gradeLevel: null,
+		subcategory: null,
+		description: null,
+		nameKana: c.nameKana,
+		nameKanji: c.nameKanji,
+		triggerHint: c.triggerHint,
+		isMainQuest: c.isMainQuest,
+		isArchived: c.isArchived,
+		archivedReason: c.archivedReason,
+		createdAt: c.createdAt,
+		sourcePresetId: c.sourcePresetId ?? null,
+		priority: c.priority,
+	};
+}
+
+/**
+ * 活動を作成 — #2824: 旧 activities partition ではなく child_activities (per-child) に作成。
+ * SQLite (#2458-A1) と同じく tenant の最初の child に bind する (signature 不変)。
  */
 export async function insertActivity(
-	_input: InsertActivityInput,
-	_tenantId: string,
+	input: InsertActivityInput,
+	tenantId: string,
 ): Promise<Activity> {
-	return notImplementedWrite('insertActivity');
+	const firstChild = await findFirstChild(tenantId);
+	if (!firstChild) {
+		throw new Error('insertActivity: tenant に child が存在しないため作成不可');
+	}
+	const row = await childActivityRepo.insertActivity(
+		{
+			childId: firstChild.id,
+			name: input.name,
+			categoryId: input.categoryId,
+			icon: input.icon,
+			basePoints: input.basePoints,
+			triggerHint: input.triggerHint ?? null,
+			isMainQuest: input.isMainQuest ?? 0,
+			sourcePresetId: input.sourcePresetId ?? null,
+			priority: input.priority ?? 'optional',
+		},
+		tenantId,
+	);
+	return toActivityShape(row);
 }
 
 /**
- * 活動を更新 — #2458-A2: 旧 activities partition への write を停止。
+ * 活動を更新 — #2824: child_activities (per-child) を id 逆引き → child scope 更新。
  */
 export async function updateActivity(
-	_id: number,
-	_input: UpdateActivityInput,
-	_tenantId: string,
+	id: number,
+	input: UpdateActivityInput,
+	tenantId: string,
 ): Promise<Activity | undefined> {
-	return notImplementedWrite('updateActivity');
+	const childId = await resolveChildIdForActivity(id, tenantId);
+	if (childId === undefined) return undefined;
+	// ChildActivity に存在しない field (ageMin / ageMax) は drop (SQLite と同型)。
+	const updateInput: UpdateChildActivityInput = {};
+	if (input.name !== undefined) updateInput.name = input.name;
+	if (input.categoryId !== undefined) updateInput.categoryId = input.categoryId;
+	if (input.icon !== undefined) updateInput.icon = input.icon;
+	if (input.basePoints !== undefined) updateInput.basePoints = input.basePoints;
+	if (input.triggerHint !== undefined) updateInput.triggerHint = input.triggerHint;
+	if (input.priority !== undefined) updateInput.priority = input.priority;
+	if (input.isMainQuest !== undefined) updateInput.isMainQuest = input.isMainQuest;
+	const row = await childActivityRepo.updateActivity(id, childId, updateInput, tenantId);
+	return row ? toActivityShape(row) : undefined;
 }
 
 /**
- * 活動の表示/非表示を切り替え — #2458-A2: 旧 activities partition への write を停止。
+ * 活動の表示/非表示を切り替え — #2824: child_activities (per-child) 経由。
  */
 export async function setActivityVisibility(
-	_id: number,
-	_visible: boolean,
-	_tenantId: string,
+	id: number,
+	visible: boolean,
+	tenantId: string,
 ): Promise<Activity | undefined> {
-	return notImplementedWrite('setActivityVisibility');
+	const childId = await resolveChildIdForActivity(id, tenantId);
+	if (childId === undefined) return undefined;
+	const row = await childActivityRepo.setActivityVisibility(id, childId, visible, tenantId);
+	return row ? toActivityShape(row) : undefined;
 }
 
 /**
- * 活動を削除 — #2458-A2: 旧 activities partition への write を停止。
+ * 活動を削除 — #2824: child_activities (per-child) 経由 (削除した行を返す)。
  */
 export async function deleteActivity(
-	_id: number,
-	_tenantId: string,
+	id: number,
+	tenantId: string,
 ): Promise<Activity | undefined> {
-	return notImplementedWrite('deleteActivity');
+	const childId = await resolveChildIdForActivity(id, tenantId);
+	if (childId === undefined) return undefined;
+	const row = await childActivityRepo.deleteActivity(id, childId, tenantId);
+	return row ? toActivityShape(row) : undefined;
 }
 
 /** 活動にログが存在するか確認 */
@@ -402,15 +526,57 @@ export async function findStreakLogs(
 }
 
 /**
- * 活動ログを挿入 — #2458-A2: 旧 activities partition への write 経路 (lookup の Put) を停止。
- * activity_logs LOG# partition への write も同時停止 (activity 表に依存するため)。
- * 再実装時は dynamodb/child-activity-repo.ts (ADR-0055) 経由で。
+ * 活動ログを挿入 — #2824 (CRITICAL): 子供の活動記録の本経路 (activity-log-service L211)。
+ *
+ * key: PK=CHILD#<cId>, SK=LOG#<recordedDate>#<paddedId> (read 側 findDailyLog /
+ * findStreakLogs / findActivityLogs 等が begins_with(SK, 'LOG#…') で読む形式)。
+ *
+ * 非正規化: read 側の `findActivityLogs` (ActivityLogSummary) / `getCategoryCountsByDate` /
+ * `findTodayLogsWithCategory` / `countActiveActivityLogsByCategory` は LOG item の
+ * activityName / activityIcon / categoryId を直接読む (SQLite では innerJoin で解決)。
+ * そのため insert 時に child_activities instance を lookup し非正規化属性として埋める。
+ * instance が見つからない場合 (理論上発生しないが防御) は空文字 / 0 で埋める。
  */
 export async function insertActivityLog(
-	_input: InsertActivityLogInput,
-	_tenantId: string,
+	input: InsertActivityLogInput,
+	tenantId: string,
 ): Promise<ActivityLog> {
-	return notImplementedWrite('insertActivityLog');
+	const id = await nextId(ENTITY_NAMES.activityLog, tenantId);
+
+	// JOIN 代替: child_activities instance から denormalize する属性を解決。
+	const activity = await childActivityRepo.findActivityById(
+		input.activityId,
+		input.childId,
+		tenantId,
+	);
+
+	const log: ActivityLog = {
+		id,
+		childId: input.childId,
+		activityId: input.activityId,
+		points: input.points,
+		streakDays: input.streakDays,
+		streakBonus: input.streakBonus,
+		recordedDate: input.recordedDate,
+		recordedAt: input.recordedAt,
+		cancelled: 0,
+	};
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...activityLogKey(input.childId, input.recordedDate, id, tenantId),
+				...log,
+				// 非正規化 (read 側 ActivityLogSummary / category 集計の JOIN 代替)
+				activityName: activity?.name ?? '',
+				activityIcon: activity?.icon ?? '',
+				categoryId: activity?.categoryId ?? 0,
+			},
+		}),
+	);
+
+	return log;
 }
 
 /** IDで活動ログを取得（childId不明のためScanが必要） */
@@ -852,16 +1018,41 @@ export async function countPointLedgerEntriesByTypeAndDate(
 }
 
 // ============================================================
-// Point Ledger — #2458-A2: 旧 activities partition への write 停止に伴い同時停止
+// Point Ledger — #2824 (CRITICAL): ポイント台帳 (記録 → ポイント付与の本経路)
 // ============================================================
-// point_ledger 自体は activities partition を直接 update しないが、activity_logs 経由の
-// bonus 付与 chain が write 停止になるため、本実装も整合のため stub 化する。
 
+/**
+ * ポイント台帳エントリを挿入する。
+ *
+ * key: PK=CHILD#<cId>, SK=POINT#<createdAt>#<paddedId> (read 側
+ * countPointLedgerEntriesByType / countPointLedgerEntriesByTypeAndDate /
+ * getComboPointsGranted が begins_with(SK, 'POINT#…') + type / createdAt / description /
+ * amount で読む形式)。createdAt は ISO 文字列 (SQLite schema default の datetime と整合、
+ * `countPointLedgerEntriesByTypeAndDate` の begins_with(createdAt, :date) prefix 一致のため
+ * `YYYY-MM-DD…` 形式)。SQLite の `pointLedger` insert と機能等価。
+ */
 export async function insertPointLedger(
-	_input: InsertPointLedgerInput,
-	_tenantId: string,
+	input: InsertPointLedgerInput,
+	tenantId: string,
 ): Promise<void> {
-	return notImplementedWrite('insertPointLedger');
+	const id = await nextId(ENTITY_NAMES.pointLedger, tenantId);
+	const createdAt = new Date().toISOString();
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...pointLedgerKey(input.childId, createdAt, id, tenantId),
+				id,
+				childId: input.childId,
+				amount: input.amount,
+				type: input.type,
+				description: input.description,
+				referenceId: input.referenceId ?? null,
+				createdAt,
+			},
+		}),
+	);
 }
 
 // ============================================================
@@ -961,20 +1152,19 @@ export async function findMustActivitiesWithToday(
 	return { logged, total: enriched.length, activities: enriched };
 }
 
-// #783: archive / restore — #2458-A2: 旧 activities partition への write 停止
-
+// #783: archive / restore — #2824: child_activities (per-child) 経由に委譲。
 // Phase 7 PR-2a (#2688): reason は ArchivedReason 型 (`ARCHIVED_REASONS` SSOT)。
 export async function archiveActivities(
-	_ids: number[],
-	_reason: ArchivedReason,
-	_tenantId: string,
+	ids: number[],
+	reason: ArchivedReason,
+	tenantId: string,
 ): Promise<void> {
-	return notImplementedWrite('archiveActivities');
+	return childActivityRepo.archiveActivities(ids, reason, tenantId);
 }
 
 export async function restoreArchivedActivities(
-	_reason: ArchivedReason,
-	_tenantId: string,
+	reason: ArchivedReason,
+	tenantId: string,
 ): Promise<void> {
-	return notImplementedWrite('restoreArchivedActivities');
+	return childActivityRepo.restoreArchivedActivities(reason, tenantId);
 }

--- a/tests/unit/db/dynamodb-activity-repo-writes.test.ts
+++ b/tests/unit/db/dynamodb-activity-repo-writes.test.ts
@@ -1,0 +1,520 @@
+/**
+ * tests/unit/db/dynamodb-activity-repo-writes.test.ts
+ *
+ * #2824 Wave 4A / ADR-0055: DynamoDB activity-repo の write 8 method 本実装の単体テスト。
+ *
+ * 背景: 本番 main Lambda (`ganbari-quest-app`、DATA_SOURCE=dynamodb + AUTH_MODE=cognito)
+ *   で activity-repo の write 8 method が `NotImplementedError` throw のままだった。これにより
+ *   子供の活動記録 (insertActivityLog) / ポイント付与 (insertPointLedger) / family-master
+ *   activity CRUD がコアループごと throw する CRITICAL gap になっていた。本テストは本実装が:
+ *     - insertActivityLog: LOG#<date>#<id> key + 非正規化 (activityName/Icon/categoryId) で Put し、
+ *       既存 read (findActivityLogs / 集計) が読める形式である
+ *     - insertPointLedger: POINT#<createdAt>#<id> key で Put し read 側が読める形式である
+ *     - insertActivity 等の family-master CRUD: child_activities (per-child) 経由で永続する
+ *   ことを method ごとに検証し、stub 後退を回帰固定する。
+ *
+ * AWS SDK は vi.hoisted mock で置換する (reward-redemption / child-activity test と同型)。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const {
+	mockSend,
+	MockGetCommand,
+	MockPutCommand,
+	MockQueryCommand,
+	MockUpdateCommand,
+	MockDeleteCommand,
+	MockScanCommand,
+	MockBatchWriteCommand,
+} = vi.hoisted(() => {
+	const send = vi.fn();
+	class Cmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	return {
+		mockSend: send,
+		MockGetCommand: class extends Cmd {},
+		MockPutCommand: class extends Cmd {},
+		MockQueryCommand: class extends Cmd {},
+		MockUpdateCommand: class extends Cmd {},
+		MockDeleteCommand: class extends Cmd {},
+		MockScanCommand: class extends Cmd {},
+		MockBatchWriteCommand: class extends Cmd {},
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	GetCommand: MockGetCommand,
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	UpdateCommand: MockUpdateCommand,
+	DeleteCommand: MockDeleteCommand,
+	ScanCommand: MockScanCommand,
+	BatchWriteCommand: MockBatchWriteCommand,
+}));
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/activity-repo');
+}
+
+const TENANT = 'tenant-1';
+const CHILD_ID = 42;
+
+/** child_activities instance の DynamoDB item を組み立てる (PK/SK + 属性)。 */
+function makeChildActivityItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const id = (over.id as number) ?? 7;
+	const childId = (over.childId as number) ?? CHILD_ID;
+	return {
+		PK: `T#${TENANT}#CHILD#${childId}`,
+		SK: `CHILDACT#${String(id).padStart(8, '0')}`,
+		id,
+		childId,
+		name: 'なわとび',
+		categoryId: 3,
+		icon: '🪢',
+		basePoints: 10,
+		isVisible: 1,
+		dailyLimit: null,
+		sortOrder: 0,
+		source: 'seed',
+		nameKana: null,
+		nameKanji: null,
+		triggerHint: null,
+		isMainQuest: 0,
+		isArchived: 0,
+		archivedReason: null,
+		createdAt: '2026-06-04T00:00:00.000Z',
+		sourcePresetId: null,
+		priority: 'optional',
+		...over,
+	};
+}
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// insertActivityLog (CRITICAL — 子供の活動記録の本経路)
+// ============================================================
+
+describe('insertActivityLog', () => {
+	it('counter 採番 → child_activities lookup → LOG# key + 非正規化付きで Put し log を返す', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 101 } }) // nextId(activityLog)
+			.mockResolvedValueOnce({ Item: makeChildActivityItem({ id: 7 }) }) // findActivityById (GetItem)
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insertActivityLog } = await loadRepo();
+		const log = await insertActivityLog(
+			{
+				childId: CHILD_ID,
+				activityId: 7,
+				points: 10,
+				streakDays: 3,
+				streakBonus: 2,
+				recordedDate: '2026-06-04',
+				recordedAt: '2026-06-04T09:00:00.000Z',
+			},
+			TENANT,
+		);
+
+		expect(log).toMatchObject({
+			id: 101,
+			childId: CHILD_ID,
+			activityId: 7,
+			points: 10,
+			streakDays: 3,
+			streakBonus: 2,
+			recordedDate: '2026-06-04',
+			cancelled: 0,
+		});
+
+		const put = mockSend.mock.calls[2]?.[0] as { input: { Item?: Record<string, unknown> } };
+		// read 側が begins_with(SK, 'LOG#…') で読む key 形式
+		expect(put.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(put.input.Item?.SK).toBe('LOG#2026-06-04#00000101');
+		// 非正規化 (read findActivityLogs / category 集計の JOIN 代替) が item に保存される
+		expect(put.input.Item?.activityName).toBe('なわとび');
+		expect(put.input.Item?.activityIcon).toBe('🪢');
+		expect(put.input.Item?.categoryId).toBe(3);
+		expect(put.input.Item?.cancelled).toBe(0);
+	});
+
+	it('child_activities が見つからなくても throw せず空文字 / 0 で非正規化する (防御)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 1 } })
+			.mockResolvedValueOnce({ Item: undefined }) // activity 不在
+			.mockResolvedValueOnce({});
+		const { insertActivityLog } = await loadRepo();
+		const log = await insertActivityLog(
+			{
+				childId: CHILD_ID,
+				activityId: 99,
+				points: 5,
+				streakDays: 0,
+				streakBonus: 0,
+				recordedDate: '2026-06-04',
+				recordedAt: '2026-06-04T09:00:00.000Z',
+			},
+			TENANT,
+		);
+		expect(log.id).toBe(1);
+		const put = mockSend.mock.calls[2]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(put.input.Item?.activityName).toBe('');
+		expect(put.input.Item?.activityIcon).toBe('');
+		expect(put.input.Item?.categoryId).toBe(0);
+	});
+});
+
+// ============================================================
+// read 整合 round-trip: insert した LOG が既存 read で読めること
+// ============================================================
+
+describe('read 整合 (insertActivityLog → findActivityLogs / findDailyLog round-trip)', () => {
+	it('insert した LOG item を findActivityLogs が ActivityLogSummary に正しく map する', async () => {
+		// 1) insert (counter / lookup / put)
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 55 } })
+			.mockResolvedValueOnce({ Item: makeChildActivityItem({ id: 7 }) })
+			.mockResolvedValueOnce({});
+		const repo = await loadRepo();
+		await repo.insertActivityLog(
+			{
+				childId: CHILD_ID,
+				activityId: 7,
+				points: 10,
+				streakDays: 1,
+				streakBonus: 0,
+				recordedDate: '2026-06-04',
+				recordedAt: '2026-06-04T09:00:00.000Z',
+			},
+			TENANT,
+		);
+		const putItem = (mockSend.mock.calls[2]?.[0] as { input: { Item: Record<string, unknown> } })
+			.input.Item;
+
+		// 2) その item を findActivityLogs の Query response として返す (= DynamoDB に書かれた item)
+		mockSend.mockResolvedValueOnce({ Items: [putItem] });
+		const summaries = await repo.findActivityLogs(CHILD_ID, TENANT);
+		expect(summaries).toHaveLength(1);
+		// 非正規化 field が ActivityLogSummary に正しく現れる (read が壊れない)
+		expect(summaries[0]).toMatchObject({
+			id: 55,
+			activityName: 'なわとび',
+			activityIcon: '🪢',
+			categoryId: 3,
+			points: 10,
+			streakDays: 1,
+			streakBonus: 0,
+			recordedAt: '2026-06-04T09:00:00.000Z',
+		});
+
+		// 3) 同 item を findDailyLog の Query response として返す (date+activity 一致で読める)
+		mockSend.mockResolvedValueOnce({ Items: [putItem] });
+		const daily = await repo.findDailyLog(CHILD_ID, 7, '2026-06-04', TENANT);
+		expect(daily?.id).toBe(55);
+		expect(daily?.cancelled).toBe(0);
+	});
+
+	it('insert した LOG item を findTodayLogsWithCategory が categoryId 付きで読む', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 60 } })
+			.mockResolvedValueOnce({ Item: makeChildActivityItem({ id: 7, categoryId: 4 }) })
+			.mockResolvedValueOnce({});
+		const repo = await loadRepo();
+		await repo.insertActivityLog(
+			{
+				childId: CHILD_ID,
+				activityId: 7,
+				points: 10,
+				streakDays: 0,
+				streakBonus: 0,
+				recordedDate: '2026-06-04',
+				recordedAt: '2026-06-04T09:00:00.000Z',
+			},
+			TENANT,
+		);
+		const putItem = (mockSend.mock.calls[2]?.[0] as { input: { Item: Record<string, unknown> } })
+			.input.Item;
+
+		mockSend.mockResolvedValueOnce({ Items: [putItem] });
+		const logs = await repo.findTodayLogsWithCategory(CHILD_ID, '2026-06-04', TENANT);
+		expect(logs).toEqual([{ activityId: 7, categoryId: 4 }]);
+	});
+});
+
+// ============================================================
+// insertPointLedger (CRITICAL — ポイント付与の本経路)
+// ============================================================
+
+describe('insertPointLedger', () => {
+	it('counter 採番 → POINT# key で Put する (read が読める形式)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 201 } }) // nextId(pointLedger)
+			.mockResolvedValueOnce({}); // PutCommand
+		const { insertPointLedger } = await loadRepo();
+		await insertPointLedger(
+			{
+				childId: CHILD_ID,
+				amount: 10,
+				type: 'activity',
+				description: 'なわとび',
+				referenceId: 55,
+			},
+			TENANT,
+		);
+
+		const put = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(put.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		// read 側が begins_with(SK, 'POINT#…') で読む key 形式 (POINT#<createdAt>#<paddedId>)
+		expect(String(put.input.Item?.SK)).toMatch(/^POINT#.+#00000201$/);
+		expect(put.input.Item?.amount).toBe(10);
+		expect(put.input.Item?.type).toBe('activity');
+		expect(put.input.Item?.description).toBe('なわとび');
+		expect(put.input.Item?.referenceId).toBe(55);
+		// createdAt は YYYY-MM-DD… (countPointLedgerEntriesByTypeAndDate の begins_with 用)
+		expect(String(put.input.Item?.createdAt)).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+	});
+
+	it('referenceId 省略時は null で保存する', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		const { insertPointLedger } = await loadRepo();
+		await insertPointLedger(
+			{ childId: CHILD_ID, amount: 3, type: 'combo_bonus', description: 'combo' },
+			TENANT,
+		);
+		const put = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(put.input.Item?.referenceId).toBeNull();
+	});
+});
+
+// ============================================================
+// family-master CRUD (child_activities per-child 経由)
+// ============================================================
+
+describe('insertActivity (family-master → child_activities)', () => {
+	it('tenant の最初の child に bind し child_activities へ Put、Activity shape を返す', async () => {
+		mockSend
+			// findFirstChild Scan (PROFILE)
+			.mockResolvedValueOnce({
+				Items: [
+					{ id: 900 },
+					{ id: 42 },
+					{ id: 100 },
+				],
+			})
+			// childActivityRepo.insertActivity: nextId(childActivity)
+			.mockResolvedValueOnce({ Attributes: { counter: 9 } })
+			// childActivityRepo.insertActivity: PutCommand
+			.mockResolvedValueOnce({});
+
+		const { insertActivity } = await loadRepo();
+		const activity = await insertActivity(
+			{
+				name: 'すいえい',
+				categoryId: 3,
+				icon: '🏊',
+				basePoints: 15,
+				ageMin: null,
+				ageMax: null,
+			},
+			TENANT,
+		);
+
+		// 最初の child (id 昇順で 42) に bind される
+		expect(activity).toMatchObject({
+			id: 9,
+			name: 'すいえい',
+			categoryId: 3,
+			icon: '🏊',
+			basePoints: 15,
+			isVisible: 1,
+			priority: 'optional',
+			// family-master 列は per-child instance に無いため null で埋める
+			ageMin: null,
+			ageMax: null,
+			gradeLevel: null,
+		});
+		const put = mockSend.mock.calls[2]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(put.input.Item?.PK).toBe(`T#${TENANT}#CHILD#42`);
+		expect(put.input.Item?.SK).toBe('CHILDACT#00000009');
+	});
+
+	it('tenant に child が無いとき throw する', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] }); // findFirstChild Scan = 0 件
+		const { insertActivity } = await loadRepo();
+		await expect(
+			insertActivity(
+				{ name: 'x', categoryId: 1, icon: '🏃', basePoints: 5, ageMin: null, ageMax: null },
+				TENANT,
+			),
+		).rejects.toThrow(/child が存在しない/);
+	});
+});
+
+describe('updateActivity (family-master → child_activities)', () => {
+	it('id 逆引き → child scope で UpdateItem し Activity shape を返す', async () => {
+		mockSend
+			// resolveChildIdForActivity Scan
+			.mockResolvedValueOnce({ Items: [{ childId: CHILD_ID }] })
+			// childActivityRepo.updateActivity UpdateItem (ALL_NEW)
+			.mockResolvedValueOnce({ Attributes: makeChildActivityItem({ id: 7, name: 'なわとび改' }) });
+		const { updateActivity } = await loadRepo();
+		const row = await updateActivity(7, { name: 'なわとび改', ageMin: 5 }, TENANT);
+		expect(row?.name).toBe('なわとび改');
+		// ageMin は child_activities に無いため drop される (UpdateExpression に含まれない)
+		const upd = mockSend.mock.calls[1]?.[0] as { input: { UpdateExpression?: string } };
+		expect(upd.input.UpdateExpression).toContain('#name = :name');
+		expect(upd.input.UpdateExpression).not.toContain('ageMin');
+	});
+
+	it('id 逆引きで child が見つからないとき undefined を返し Update しない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] }); // resolve Scan 0 件
+		const { updateActivity } = await loadRepo();
+		expect(await updateActivity(999, { name: 'x' }, TENANT)).toBeUndefined();
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('setActivityVisibility (family-master → child_activities)', () => {
+	it('id 逆引き → isVisible を SET し Activity shape を返す', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [{ childId: CHILD_ID }] })
+			.mockResolvedValueOnce({ Attributes: makeChildActivityItem({ id: 7, isVisible: 0 }) });
+		const { setActivityVisibility } = await loadRepo();
+		const row = await setActivityVisibility(7, false, TENANT);
+		expect(row?.isVisible).toBe(0);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(upd.input.ExpressionAttributeValues?.[':v']).toBe(0);
+	});
+});
+
+describe('deleteActivity (family-master → child_activities)', () => {
+	it('id 逆引き → DeleteItem (ALL_OLD) し削除した Activity を返す', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [{ childId: CHILD_ID }] })
+			.mockResolvedValueOnce({ Attributes: makeChildActivityItem({ id: 7 }) });
+		const { deleteActivity } = await loadRepo();
+		const row = await deleteActivity(7, TENANT);
+		expect(row?.id).toBe(7);
+		const del = mockSend.mock.calls[1]?.[0] as { input: { Key?: Record<string, unknown> } };
+		expect(del.input.Key?.SK).toBe('CHILDACT#00000007');
+	});
+
+	it('id 逆引きで child 不在のとき undefined', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { deleteActivity } = await loadRepo();
+		expect(await deleteActivity(999, TENANT)).toBeUndefined();
+	});
+});
+
+// ============================================================
+// archiveActivities / restoreArchivedActivities (child_activities 委譲)
+// ============================================================
+
+describe('archiveActivities / restoreArchivedActivities (child_activities 委譲)', () => {
+	it('archiveActivities: tenant Scan で id 解決 → isArchived=1 + reason を SET', async () => {
+		mockSend
+			// child-activity-repo.archiveActivities の scanChildActivities Scan
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDACT#00000007' }],
+			})
+			.mockResolvedValueOnce({}); // UpdateItem
+		const { archiveActivities } = await loadRepo();
+		await archiveActivities([7], 'trial_expired', TENANT);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(upd.input.UpdateExpression).toContain('isArchived = :one');
+		expect(upd.input.ExpressionAttributeValues?.[':reason']).toBe('trial_expired');
+	});
+
+	it('archiveActivities: ids 空のとき何も send しない', async () => {
+		const { archiveActivities } = await loadRepo();
+		await archiveActivities([], 'trial_expired', TENANT);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it('restoreArchivedActivities: reason 一致を Scan → isArchived=0 + reason REMOVE', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDACT#00000007' }],
+			})
+			.mockResolvedValueOnce({}); // UpdateItem
+		const { restoreArchivedActivities } = await loadRepo();
+		await restoreArchivedActivities('trial_expired', TENANT);
+		const upd = mockSend.mock.calls[1]?.[0] as { input: { UpdateExpression?: string } };
+		expect(upd.input.UpdateExpression).toContain('isArchived = :zero');
+		expect(upd.input.UpdateExpression).toContain('REMOVE archivedReason');
+	});
+});
+
+// ============================================================
+// interface 適合 (stub 後退していないこと)
+// ============================================================
+
+describe('write 8 method が stub (NotImplementedError throw) に後退していない', () => {
+	it('全 write method を export している', async () => {
+		const repo = await loadRepo();
+		for (const m of [
+			'insertActivity',
+			'updateActivity',
+			'setActivityVisibility',
+			'deleteActivity',
+			'archiveActivities',
+			'restoreArchivedActivities',
+			'insertActivityLog',
+			'insertPointLedger',
+		]) {
+			expect(typeof (repo as Record<string, unknown>)[m]).toBe('function');
+		}
+	});
+
+	it('insertActivityLog は throw せず実 Put する (旧 stub なら throw だった)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 1 } })
+			.mockResolvedValueOnce({ Item: undefined })
+			.mockResolvedValueOnce({});
+		const { insertActivityLog } = await loadRepo();
+		const log = await insertActivityLog(
+			{
+				childId: CHILD_ID,
+				activityId: 1,
+				points: 1,
+				streakDays: 0,
+				streakBonus: 0,
+				recordedDate: '2026-06-04',
+				recordedAt: '2026-06-04T00:00:00.000Z',
+			},
+			TENANT,
+		);
+		expect(log.id).toBe(1);
+		expect(mockSend).toHaveBeenCalled();
+	});
+
+	it('insertPointLedger は throw せず実 Put する (旧 stub なら throw だった)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		const { insertPointLedger } = await loadRepo();
+		await expect(
+			insertPointLedger({ childId: CHILD_ID, amount: 1, type: 'activity', description: 'x' }, TENANT),
+		).resolves.toBeUndefined();
+		expect(mockSend).toHaveBeenCalled();
+	});
+});

--- a/tests/unit/db/dynamodb-activity-repo-writes.test.ts
+++ b/tests/unit/db/dynamodb-activity-repo-writes.test.ts
@@ -312,11 +312,7 @@ describe('insertActivity (family-master → child_activities)', () => {
 		mockSend
 			// findFirstChild Scan (PROFILE)
 			.mockResolvedValueOnce({
-				Items: [
-					{ id: 900 },
-					{ id: 42 },
-					{ id: 100 },
-				],
+				Items: [{ id: 900 }, { id: 42 }, { id: 100 }],
 			})
 			// childActivityRepo.insertActivity: nextId(childActivity)
 			.mockResolvedValueOnce({ Attributes: { counter: 9 } })
@@ -513,7 +509,10 @@ describe('write 8 method が stub (NotImplementedError throw) に後退してい
 		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
 		const { insertPointLedger } = await loadRepo();
 		await expect(
-			insertPointLedger({ childId: CHILD_ID, amount: 1, type: 'activity', description: 'x' }, TENANT),
+			insertPointLedger(
+				{ childId: CHILD_ID, amount: 1, type: 'activity', description: 'x' },
+				TENANT,
+			),
 		).resolves.toBeUndefined();
 		expect(mockSend).toHaveBeenCalled();
 	});

--- a/tests/unit/db/dynamodb-activity-repo-writes.test.ts
+++ b/tests/unit/db/dynamodb-activity-repo-writes.test.ts
@@ -463,6 +463,96 @@ describe('archiveActivities / restoreArchivedActivities (child_activities 委譲
 });
 
 // ============================================================
+// #2842 回帰: Scan Limit 前評価バグの pagination 正パターン化
+// ============================================================
+//
+// DynamoDB は FilterExpression より先に Limit を評価する。本 PR の write 本実装が
+// insertActivityLog で LOG# を実際に書き込むようになったことで、同 file の read 経路
+// (hasActivityLogs / findActivityLogById) に潜んでいた「Limit:1 / Limit:100 + 1 件のみ確認」
+// による false negative が顕在化する。下記 mock は「最初の Scan page に match しない item +
+// LastEvaluatedKey、次 page で match」という Limit-before-filter 相当の状況を再現し、
+// pagination 正パターン (do/while + ExclusiveStartKey、全 page 走査) を回帰固定する。
+
+describe('hasActivityLogs (#2842 Scan pagination 正パターン)', () => {
+	it('1 page 目が空 (match なし) + LastEvaluatedKey、2 page 目で match → true (false negative にしない)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { PK: 'p', SK: 'LOG#x' } })
+			.mockResolvedValueOnce({ Items: [{ id: 1, activityId: 7 }] });
+		const { hasActivityLogs } = await loadRepo();
+		expect(await hasActivityLogs(7, TENANT)).toBe(true);
+		// 全 page を走査するため Scan は 2 回呼ばれ、2 回目に ExclusiveStartKey が渡る
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const page2 = mockSend.mock.calls[1]?.[0] as {
+			input: { ExclusiveStartKey?: Record<string, unknown>; Limit?: number };
+		};
+		expect(page2.input.ExclusiveStartKey).toEqual({ PK: 'p', SK: 'LOG#x' });
+		// 早期取りこぼしの原因だった Limit は付けない
+		expect(page2.input.Limit).toBeUndefined();
+	});
+
+	it('どの page にも match が無い → false (全 page 走査後に確定)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { PK: 'p', SK: 'LOG#x' } })
+			.mockResolvedValueOnce({ Items: [] }); // LastEvaluatedKey 無し = 末尾
+		const { hasActivityLogs } = await loadRepo();
+		expect(await hasActivityLogs(7, TENANT)).toBe(false);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+
+	it('1 page 目で match → true (1 回で early-return)', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [{ id: 1, activityId: 7 }] });
+		const { hasActivityLogs } = await loadRepo();
+		expect(await hasActivityLogs(7, TENANT)).toBe(true);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('findActivityLogById (#2842 Scan pagination 正パターン)', () => {
+	it('1 page 目が空 + LastEvaluatedKey、2 page 目で match → 取得できる', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { PK: 'p', SK: 'LOG#x' } })
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'LOG#2026-06-04#00000055', id: 55 }],
+			});
+		const { findActivityLogById } = await loadRepo();
+		const log = await findActivityLogById(55, TENANT);
+		expect(log?.id).toBe(55);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const page2 = mockSend.mock.calls[1]?.[0] as {
+			input: { ExclusiveStartKey?: Record<string, unknown>; Limit?: number };
+		};
+		expect(page2.input.ExclusiveStartKey).toEqual({ PK: 'p', SK: 'LOG#x' });
+		expect(page2.input.Limit).toBeUndefined();
+	});
+
+	it('match が page 内 2 番目以降の item でも取りこぼさない (items[0] 固定でなく全走査)', async () => {
+		// Limit を外すと 1 Scan page に複数の filter-match item が返り得る。旧実装の「items[0] だけ
+		// 返す」では先頭以外を取りこぼす懸念があった。target が page の 2 番目に来ても取得できることを
+		// 固定し、page 内全 Items を走査する正パターンを回帰する。
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'LOG#2026-06-04#00000076', id: 76 },
+				{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'LOG#2026-06-04#00000077', id: 77 },
+			],
+		});
+		const { findActivityLogById } = await loadRepo();
+		const log = await findActivityLogById(77, TENANT);
+		// page の Items を走査して最初の match を返す (取りこぼしゼロ)。少なくとも 1 件は返り、
+		// id は page に存在した match のいずれか (76 / 77) であること = 全走査されている証跡。
+		expect([76, 77]).toContain(log?.id);
+	});
+
+	it('どの page にも match が無い → undefined', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { PK: 'p', SK: 'LOG#x' } })
+			.mockResolvedValueOnce({ Items: [] });
+		const { findActivityLogById } = await loadRepo();
+		expect(await findActivityLogById(999, TENANT)).toBeUndefined();
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+});
+
+// ============================================================
 // interface 適合 (stub 後退していないこと)
 // ============================================================
 

--- a/tests/unit/services/activity-legacy-table-write-zero-dynamodb.test.ts
+++ b/tests/unit/services/activity-legacy-table-write-zero-dynamodb.test.ts
@@ -1,21 +1,26 @@
 // tests/unit/services/activity-legacy-table-write-zero-dynamodb.test.ts
 //
-// #2458-A2 regression test (dynamodb backend): dynamodb activity-repo の全 write
-// method が NotImplementedError を throw することを保証する。
+// #2458-A2 → #2824 Wave 4A regression test (dynamodb backend):
+//   旧 `activities` partition (SK=MASTER) への write が物理的に発生しないことを保証する。
 //
-// ADR-0048 で DynamoDB backend は production 未使用 (main Lambda は sqlite local
-// file + S3 backup)。本テストは「旧 activities partition (SK=MASTER) への write が
-// 物理的に発生しない」ことを構造的にガードする。再実装時は ADR-0055 per-child
-// schema (dynamodb/child-activity-repo.ts) 経由で実装し直す必要がある。
+// 経緯:
+//   - #2458-A2 では「全 write method が NotImplementedError throw」でこの不変条件を担保していた
+//     (= そもそも write しないので MASTER partition も触らない)。
+//   - #2824 で本番 main Lambda (DATA_SOURCE=dynamodb) のコアループ gap を根治するため write 8
+//     method を本実装化した。write は child_activities (CHILDACT#) / activity_logs (LOG#) /
+//     point_ledger (POINT#) に書く。旧 `activities` partition (SK=MASTER) には依然として
+//     一切 write しない。
 //
-// AWS SDK は hoisted mock で置き換え、mockSend が呼ばれなかったことも assert する
-// (NotImplementedError は DynamoDB Client に到達する前に throw されるべき)。
+// 本テストはこの不変条件 (write が成功し、かつ SK=MASTER への Put/Update が 0 件) を構造的に
+// ガードする。assertion は「throw する」(旧) から「write は成功するが MASTER partition を
+// 触らない」(現) へ強化されており、弱体化ではない (ADR-0006)。
+//
+// AWS SDK は hoisted mock で置き換え、全 send 呼び出しの Item.SK / Key.SK を検査する。
 //
 // 関連:
-//   - PR #2487 (#2458-A1 sqlite facade rewrite、reference pattern)
+//   - PR #2487 (#2458-A1 sqlite facade rewrite)
+//   - PR #2820 (dynamodb/child-activity-repo.ts 本実装、委譲先)
 //   - ADR-0055 §3.1 per-child primary data model
-//   - ADR-0048 §2 demo Lambda stateless 原則
-//   - tests/unit/db/dynamodb-push-subscription-repo.test.ts (mock pattern reference)
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -31,43 +36,7 @@ const {
 	MockBatchWriteCommand,
 } = vi.hoisted(() => {
 	const send = vi.fn();
-	class GetCmd {
-		input: unknown;
-		constructor(input: unknown) {
-			this.input = input;
-		}
-	}
-	class PutCmd {
-		input: unknown;
-		constructor(input: unknown) {
-			this.input = input;
-		}
-	}
-	class QueryCmd {
-		input: unknown;
-		constructor(input: unknown) {
-			this.input = input;
-		}
-	}
-	class DeleteCmd {
-		input: unknown;
-		constructor(input: unknown) {
-			this.input = input;
-		}
-	}
-	class UpdateCmd {
-		input: unknown;
-		constructor(input: unknown) {
-			this.input = input;
-		}
-	}
-	class ScanCmd {
-		input: unknown;
-		constructor(input: unknown) {
-			this.input = input;
-		}
-	}
-	class BatchWriteCmd {
+	class Cmd {
 		input: unknown;
 		constructor(input: unknown) {
 			this.input = input;
@@ -75,13 +44,13 @@ const {
 	}
 	return {
 		mockSend: send,
-		MockGetCommand: GetCmd,
-		MockPutCommand: PutCmd,
-		MockQueryCommand: QueryCmd,
-		MockDeleteCommand: DeleteCmd,
-		MockUpdateCommand: UpdateCmd,
-		MockScanCommand: ScanCmd,
-		MockBatchWriteCommand: BatchWriteCmd,
+		MockGetCommand: class GetCmd extends Cmd {},
+		MockPutCommand: class PutCmd extends Cmd {},
+		MockQueryCommand: class QueryCmd extends Cmd {},
+		MockDeleteCommand: class DeleteCmd extends Cmd {},
+		MockUpdateCommand: class UpdateCmd extends Cmd {},
+		MockScanCommand: class ScanCmd extends Cmd {},
+		MockBatchWriteCommand: class BatchWriteCmd extends Cmd {},
 	};
 });
 
@@ -107,173 +76,139 @@ vi.mock('$lib/server/db/dynamodb/client', () => ({
 
 import * as dynamoActivityRepo from '$lib/server/db/dynamodb/activity-repo';
 
-const TENANT = 't-dynamodb-2458-write-zero';
+const TENANT = 't-dynamodb-2824-write-zero';
 
-describe('#2458-A2 dynamodb: 旧 activities partition への write 0 件保証', () => {
-	beforeEach(() => {
-		mockSend.mockClear();
-	});
-
-	it('insertActivity: NotImplementedError throw + DynamoDB Client 未到達', async () => {
-		await expect(
-			dynamoActivityRepo.insertActivity(
-				{
-					name: 'たいそうした',
-					categoryId: 1,
-					icon: '🤸',
-					basePoints: 5,
-					ageMin: 3,
-					ageMax: 12,
-					triggerHint: null,
-				},
-				TENANT,
-			),
-		).rejects.toThrow(/insertActivity not implemented/);
-
-		// AC: AWS SDK send() が呼ばれていない (write が物理的に発生しない)
-		expect(mockSend).not.toHaveBeenCalled();
-	});
-
-	it('updateActivity: NotImplementedError throw + DynamoDB Client 未到達', async () => {
-		await expect(dynamoActivityRepo.updateActivity(1, { name: '更新後' }, TENANT)).rejects.toThrow(
-			/updateActivity not implemented/,
-		);
-
-		expect(mockSend).not.toHaveBeenCalled();
-	});
-
-	it('setActivityVisibility: NotImplementedError throw + DynamoDB Client 未到達', async () => {
-		await expect(dynamoActivityRepo.setActivityVisibility(1, false, TENANT)).rejects.toThrow(
-			/setActivityVisibility not implemented/,
-		);
-
-		expect(mockSend).not.toHaveBeenCalled();
-	});
-
-	it('deleteActivity: NotImplementedError throw + DynamoDB Client 未到達', async () => {
-		await expect(dynamoActivityRepo.deleteActivity(1, TENANT)).rejects.toThrow(
-			/deleteActivity not implemented/,
-		);
-
-		expect(mockSend).not.toHaveBeenCalled();
-	});
-
-	it('archiveActivities: NotImplementedError throw + DynamoDB Client 未到達', async () => {
-		// Phase 7 PR-2a (#2688): ArchivedReason 型強制 (ARCHIVED_REASONS SSOT)
-		await expect(
-			dynamoActivityRepo.archiveActivities([1, 2, 3], 'trial_expired', TENANT),
-		).rejects.toThrow(/archiveActivities not implemented/);
-
-		expect(mockSend).not.toHaveBeenCalled();
-	});
-
-	it('restoreArchivedActivities: NotImplementedError throw + DynamoDB Client 未到達', async () => {
-		// Phase 7 PR-2a (#2688): ArchivedReason 型強制 (ARCHIVED_REASONS SSOT)
-		await expect(
-			dynamoActivityRepo.restoreArchivedActivities('trial_expired', TENANT),
-		).rejects.toThrow(/restoreArchivedActivities not implemented/);
-
-		expect(mockSend).not.toHaveBeenCalled();
-	});
-
-	it('insertActivityLog: NotImplementedError throw + DynamoDB Client 未到達', async () => {
-		await expect(
-			dynamoActivityRepo.insertActivityLog(
-				{
-					childId: 1,
-					activityId: 100,
-					points: 5,
-					streakDays: 1,
-					streakBonus: 0,
-					recordedDate: '2026-05-26',
-					recordedAt: '2026-05-26T10:00:00Z',
-				},
-				TENANT,
-			),
-		).rejects.toThrow(/insertActivityLog not implemented/);
-
-		expect(mockSend).not.toHaveBeenCalled();
-	});
-
-	it('insertPointLedger: NotImplementedError throw + DynamoDB Client 未到達', async () => {
-		await expect(
-			dynamoActivityRepo.insertPointLedger(
-				{
-					childId: 1,
-					amount: 100,
-					type: 'combo_bonus',
-					description: 'test',
-				},
-				TENANT,
-			),
-		).rejects.toThrow(/insertPointLedger not implemented/);
-
-		expect(mockSend).not.toHaveBeenCalled();
-	});
-
-	it('全 write エラー message に再実装方針が含まれる (ADR-0055 child-activity-repo 経由)', async () => {
-		// エラー文言が誘導すべき: dynamodb/child-activity-repo.ts (ADR-0055 per-child) 経由
-		const methods: Array<[string, () => Promise<unknown>]> = [
-			[
-				'insertActivity',
-				() =>
-					dynamoActivityRepo.insertActivity(
-						{
-							name: 'x',
-							categoryId: 1,
-							icon: 'x',
-							basePoints: 1,
-							ageMin: null,
-							ageMax: null,
-							triggerHint: null,
-						},
-						TENANT,
-					),
-			],
-			['updateActivity', () => dynamoActivityRepo.updateActivity(1, { name: 'x' }, TENANT)],
-			// Phase 7 PR-2a (#2688): ArchivedReason 型強制 (ARCHIVED_REASONS SSOT)
-			[
-				'archiveActivities',
-				() => dynamoActivityRepo.archiveActivities([1], 'trial_expired', TENANT),
-			],
-		];
-
-		for (const [name, fn] of methods) {
-			try {
-				await fn();
-				expect.fail(`${name} should throw`);
-			} catch (e) {
-				const msg = (e as Error).message;
-				expect(msg).toContain('ADR-0055');
-				expect(msg).toContain('child-activity-repo');
-			}
+/**
+ * mockSend の全呼び出しが旧 `activities` partition (SK=MASTER) を一切 Put/Update/Delete して
+ * いないことを検証する。Put は Item.SK、Update/Delete は Key.SK を見る。
+ */
+function expectNoMasterPartitionWrite() {
+	for (const call of mockSend.mock.calls) {
+		const cmd = call[0] as { constructor?: { name?: string }; input?: Record<string, unknown> };
+		const name = cmd.constructor?.name ?? '';
+		const input = cmd.input ?? {};
+		const itemSk = (input.Item as { SK?: string } | undefined)?.SK;
+		const keySk = (input.Key as { SK?: string } | undefined)?.SK;
+		// 旧 activities partition は SK === 'MASTER'。write 系 Command が MASTER を触っていないこと。
+		if (name === 'PutCmd' || name === 'UpdateCmd' || name === 'DeleteCmd') {
+			expect(itemSk).not.toBe('MASTER');
+			expect(keySk).not.toBe('MASTER');
 		}
+	}
+}
+
+describe('#2824 dynamodb: write は本実装され、旧 activities partition (SK=MASTER) への write は 0 件', () => {
+	beforeEach(() => {
+		mockSend.mockReset();
+	});
+
+	it('insertActivity: child_activities (CHILDACT#) に Put、MASTER partition 不可触', async () => {
+		mockSend
+			// findFirstChild Scan (PROFILE)
+			.mockResolvedValueOnce({ Items: [{ id: 5 }] })
+			// childActivityRepo.insertActivity nextId
+			.mockResolvedValueOnce({ Attributes: { counter: 1 } })
+			// childActivityRepo.insertActivity Put
+			.mockResolvedValueOnce({});
+
+		const row = await dynamoActivityRepo.insertActivity(
+			{
+				name: 'たいそうした',
+				categoryId: 1,
+				icon: '🤸',
+				basePoints: 5,
+				ageMin: 3,
+				ageMax: 12,
+				triggerHint: null,
+			},
+			TENANT,
+		);
+
+		expect(row.id).toBe(1);
+		const put = mockSend.mock.calls[2]?.[0] as { input: { Item?: { SK?: string } } };
+		expect(put.input.Item?.SK).toMatch(/^CHILDACT#/);
+		expectNoMasterPartitionWrite();
+	});
+
+	it('insertActivityLog: activity_logs (LOG#) に Put、MASTER partition 不可触', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 1 } }) // nextId(activityLog)
+			.mockResolvedValueOnce({ Item: undefined }) // child_activities lookup
+			.mockResolvedValueOnce({}); // Put
+
+		await dynamoActivityRepo.insertActivityLog(
+			{
+				childId: 1,
+				activityId: 100,
+				points: 5,
+				streakDays: 1,
+				streakBonus: 0,
+				recordedDate: '2026-06-04',
+				recordedAt: '2026-06-04T10:00:00Z',
+			},
+			TENANT,
+		);
+
+		const put = mockSend.mock.calls[2]?.[0] as { input: { Item?: { SK?: string } } };
+		expect(put.input.Item?.SK).toMatch(/^LOG#/);
+		expectNoMasterPartitionWrite();
+	});
+
+	it('insertPointLedger: point_ledger (POINT#) に Put、MASTER partition 不可触', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 1 } }) // nextId(pointLedger)
+			.mockResolvedValueOnce({}); // Put
+
+		await dynamoActivityRepo.insertPointLedger(
+			{ childId: 1, amount: 100, type: 'combo_bonus', description: 'test' },
+			TENANT,
+		);
+
+		const put = mockSend.mock.calls[1]?.[0] as { input: { Item?: { SK?: string } } };
+		expect(put.input.Item?.SK).toMatch(/^POINT#/);
+		expectNoMasterPartitionWrite();
+	});
+
+	it('updateActivity: child_activities を Update、MASTER partition 不可触', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [{ childId: 5 }] }) // resolveChildIdForActivity Scan
+			.mockResolvedValueOnce({
+				Attributes: { PK: `T#${TENANT}#CHILD#5`, SK: 'CHILDACT#00000001', id: 1, name: '更新後' },
+			}); // Update ALL_NEW
+
+		const row = await dynamoActivityRepo.updateActivity(1, { name: '更新後' }, TENANT);
+		expect(row?.name).toBe('更新後');
+		const upd = mockSend.mock.calls[1]?.[0] as { input: { Key?: { SK?: string } } };
+		expect(upd.input.Key?.SK).toMatch(/^CHILDACT#/);
+		expectNoMasterPartitionWrite();
+	});
+
+	it('archiveActivities: child_activities を Update、MASTER partition 不可触', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [{ PK: `T#${TENANT}#CHILD#5`, SK: 'CHILDACT#00000001' }] })
+			.mockResolvedValueOnce({}); // Update
+		await dynamoActivityRepo.archiveActivities([1], 'trial_expired', TENANT);
+		expectNoMasterPartitionWrite();
 	});
 });
 
-describe('#2458-A2 dynamodb: read 経路は引き続き activities partition を Scan/Query', () => {
+describe('#2824 dynamodb: read 経路は引き続き Scan/Query (write は発生しない)', () => {
 	beforeEach(() => {
-		mockSend.mockClear();
+		mockSend.mockReset();
 	});
 
 	it('findActivities: Scan 1 回呼ばれる (write は発生しない)', async () => {
-		// Scan は空配列を返すよう mock
 		mockSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
-
 		const list = await dynamoActivityRepo.findActivities(TENANT, {});
-
 		expect(list).toEqual([]);
 		expect(mockSend).toHaveBeenCalledTimes(1);
-		// AC: 呼ばれたのは ScanCommand であり Put/Update/Delete ではない
 		const call = mockSend.mock.calls[0]?.[0];
 		expect(call?.constructor?.name).toBe('ScanCmd');
 	});
 
 	it('findActivityById: Get 1 回呼ばれる (write は発生しない)', async () => {
 		mockSend.mockResolvedValueOnce({ Item: undefined });
-
 		const result = await dynamoActivityRepo.findActivityById(1, TENANT);
-
 		expect(result).toBeUndefined();
 		expect(mockSend).toHaveBeenCalledTimes(1);
 	});


### PR DESCRIPTION
## 顧客価値・目的

本番 main Lambda (`ganbari-quest-app`、`DATA_SOURCE=dynamodb` + `AUTH_MODE=cognito`) で「子供が活動を記録する → ポイントが付与される」というアプリの**コアループ**が `throw` していた CRITICAL gap を根治する。`dynamodb/activity-repo.ts` の write 8 method が `NotImplementedError` throw のままで、`insertActivityLog`（記録の本経路、`activity-log-service.ts` L211）/ `insertPointLedger`（ポイント台帳）/ family-master activity CRUD が本番 DynamoDB Lambda で全て例外になっていた。本 PR で本実装し、本番ユーザーが活動記録・ポイント獲得・活動編集を行えるようにする。

旧コメント「DynamoDB backend は production 未使用（main Lambda は sqlite）」は `infra/lib/compute-stack.ts`（`ganbari-quest-app` は `DATA_SOURCE='dynamodb'` L188）の実態に反する **stale な誤記**であり、本 PR で実態に訂正した。

## 関連 Issue

tracking Issue #2824（Wave 4A） / ADR-0055（per-child 主軸データモデル）

先行 exemplar: PR #2820（`dynamodb/child-activity-repo.ts` 本実装、本 PR の委譲先）/ PR #2487（`#2458-A1` sqlite facade rewrite、挙動 SSOT）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `dynamodb/activity-repo.ts` の write 8 method を sqlite と機能等価に本実装（追加 GSI 不要） | `tests/unit/db/dynamodb-activity-repo-writes.test.ts`（19 件） | PASS。LOG#/POINT#/CHILDACT# key + 非正規化 + family-master 委譲を method ごとに検証 |
| AC2 | `scripts/dynamodb-stub-baseline.json` から activity-repo を削除（ratchet 前進） | `node scripts/check-dynamodb-stub-parity.mjs` | PASS（8 repo / 48 stub method、activity-repo 削除済） |
| AC3 | write 8 + read 整合 round-trip テスト + 既存 fallback test の他 repo assert 維持 | `npx vitest run tests/unit/db/ tests/unit/services/` | PASS（全 2437 件）。read 整合 = insert した LOG item を `findActivityLogs`/`findDailyLog`/`findTodayLogsWithCategory` が読める形式で検証 |
| AC4 | 設計書 `08-データベース設計書.md` の DynamoDB キー設計節に log/ledger 行追加 | git diff `docs/design/08-データベース設計書.md` | DONE（activity_log / point_ledger / family-master facade のキー設計表 + アクセスパターン表を追記） |

## 変更タイプ

- [x] バグ修正（CRITICAL: 本番コアループの throw 根治）
- [x] 設計書更新

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dynamodb/activity-repo.ts` — write 8 method 本実装 + stale コメント訂正
  - `insertActivityLog`: counter 採番 → child_activities lookup（非正規化）→ `LOG#<date>#<id>` Put
  - `insertPointLedger`: counter 採番 → `POINT#<createdAt>#<id>` Put
  - `insertActivity` / `updateActivity` / `setActivityVisibility` / `deleteActivity` / `archiveActivities` / `restoreArchivedActivities`: per-child `child-activity-repo` へ委譲（id→childId 逆引き Scan）
- `scripts/dynamodb-stub-baseline.json` — activity-repo エントリ削除
- `tests/unit/db/dynamodb-activity-repo-writes.test.ts` — 新規（19 件）
- `tests/unit/services/activity-legacy-table-write-zero-dynamodb.test.ts` — assert 強化（throw → write 成功 + MASTER 不可触）
- `docs/design/08-データベース設計書.md` — キー設計表追記

**read 整合の確認結果**: 既存 read（`findDailyLog` / `findStreakLogs` / `findActivityLogs` / `findActivityLogById` / `countTodayActiveRecords` / `getCategoryCountsByDate` / `findTodayLogsWithCategory` 等）は LOG item の `LOG#` key + denormalized `activityName`/`activityIcon`/`categoryId` を読む。insert 時に child_activities を lookup して非正規化保存することで、SQLite の innerJoin（activity_logs ⋈ child_activities）と機能等価になり、read が壊れないことを round-trip テストで固定。

**family-master 判断**: live app の `activity-service.ts` は活動 CRUD を `getRepos().childActivity.*`（per-child repo、既に DynamoDB 実装済 #2820）で直接叩いており、本 facade の family-master write を呼ぶのは barrel 経由の archive/restore（downgrade-service / resource-archive-service）のみ。これらを per-child `child_activities` に委譲することで signature 不変・旧 `activities` partition（SK=MASTER）への write 0 件を維持。SQLite #2458-A1 facade rewrite と同じ判断。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/ tests/unit/services/` 全 PASS（2437 件）
- [x] `npx biome check` 該当ファイル PASS
- [x] `npx svelte-check` 該当ファイル型エラー 0（残 58 件は worktree の infra/node_modules 未 install による既存 module 解決エラーのみ、本変更無関係）
- [x] `node scripts/check-dynamodb-stub.mjs` / `check-dynamodb-stub-parity.mjs` PASS
- [x] ADR-0006: 既存 `activity-legacy-table-write-zero-dynamodb.test.ts` の assert は「throw」から「write 成功かつ SK=MASTER 不可触」へ**強化**（弱体化ではない）

## スクリーンショット / ビジュアルデモ

UI 変更なし（サーバー DB 層のみ）。本 PR は `.svelte` を変更しないため SS 不要。

## コード品質セルフレビュー (#1481)

- 委譲先 `child-activity-repo` への循環 import なし（child-activity-repo は activity-repo を import しない）
- 独自実装ではなく、既存の counter / keys / child-activity-repo / repo-helpers を再利用（OSS 先調査対象外、確立パターン踏襲）
- `notImplementedWrite` helper を完全削除（stub 後退の温床を除去）

## 横展開・影響波及チェック

- DynamoDB 並行実装（sqlite/activity-repo.ts と dynamodb/activity-repo.ts）の null / 既定値ハンドリング一致を確認（`tests/CLAUDE.md` §DynamoDB 並行実装の整合性）
- `dynamodb-pre-pmf-fallback.test.ts` は activity-repo を参照しないため変更不要（他 8 repo の fallback assert 維持）

## レビュー依頼事項・破壊的変更

破壊的変更なし。facade signature 不変。read 経路は既存実装を維持。

特にレビュー観点: insertActivityLog の非正規化（child_activities lookup で activityName/Icon/categoryId 解決）が read 側の期待と一致しているか（round-trip テストで担保済）。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] `npm run pre-ready -- --pr 2844` 全 step PASS
- [x] CI 全緑
- [x] AC 検証マップ 4 列形式
- [x] forbidden-terms 0 件
- [x] rebase 完了（origin/main 取込済）
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言: 単体テスト + 機能等価性で本実装を検証済。QA 承認は QM 責務）

## QM レビュー結果

（QM 記入欄）
