### PR TITLE
feat: #2824 Wave 5B — sibling-cheer-repo (きょうだいおうえん) DynamoDB 本実装 (ADR-0055)

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -703,6 +703,29 @@ per-child チャレンジ instance。旧 `sibling_challenges` (family-wide + 別
 
 **インデックス:** (to_child_id, shown_at)
 
+#### DynamoDB キー設計 (#2824 Wave 5B、ADR-0055)
+
+本番 cognito Lambda は `DATA_SOURCE=dynamodb` で稼働するため、SQLite と機能等価の
+DynamoDB 実装 (`src/lib/server/db/dynamodb/sibling-cheer-repo.ts`) を持つ。おうえんは
+**受信 child (to_child_id)** partition 配下に置き、最頻 read の `findUnshownCheers(toChildId)` を
+**追加 GSI なし**の単一 partition Query で完結させる（ADR-0055 §3.1）。
+
+| エンティティ | PK | SK | 補足 |
+|---|---|---|---|
+| sibling_cheer | `T#<tid>#CHILD#<toChildId>` | `CHEER#<paddedId>` | id は 8 桁 0 埋め。activity_logs / parent_message と同 partition に同居（受信 child 軸）。fromChildId / sentAt は属性として保持 |
+
+| アクセスパターン | 操作 | 条件 |
+|---|---|---|
+| `insertCheer` | counter 採番 → PutItem | 受信 child partition (`toChildId`) に配置。sentAt は ISO 文字列で保存、shownAt は null 初期化 |
+| `findUnshownCheers(toChildId)` | Query（受信 child partition）+ in-memory filter | `PK = T#<tid>#CHILD#<toChildId> AND begins_with(SK, 'CHEER#')` で取得し `shown_at IS NULL` を filter |
+| `countTodayCheersFrom(fromChildId)` | Scan（`fromChildId` + `sentAt >= 当日00:00:00` filter） | 送信者軸の read（送信時 1 日上限 ≤5/日 チェック、低頻度）。データは受信 child partition に分散するため tenant Scan で集計。sentAt 比較は SQLite と同じ ISO 文字列辞書順 |
+| `markShown(cheerIds[])` | Scan（id filter）で PK/SK 解決 → 個別 UpdateItem | toChildId を受けないため id 集合で対象 item を tenant Scan 1 回で一括解決（message-repo / stamp-card-repo の id 解決 Scan と同型、overlay 表示直後の低頻度経路） |
+| `deleteByTenantId` | Scan → BatchWrite | `CHILD#*` 配下の `CHEER#` を削除（`deleteItemsByPkPrefix`） |
+
+新規 SK prefix `CHEER#` は既存テーブルにそのまま乗るため **CDK 変更不要**（追加 GSI なし）。
+きょうだいおうえんは child 画面の `SiblingCheerOverlay` で active であり、本 repo は #2263 hotfix で
+「read=空 / write=no-op」化されていた（本番で送信が永続しない）gap を本実装で根治。
+
 ### push_subscriptions
 
 Web Push 通知の購読情報。1ブラウザ1レコード。

--- a/scripts/dynamodb-stub-baseline.json
+++ b/scripts/dynamodb-stub-baseline.json
@@ -31,13 +31,6 @@
 		"findByTenantAndDateRange",
 		"upsert"
 	],
-	"src/lib/server/db/dynamodb/sibling-cheer-repo.ts": [
-		"countTodayCheersFrom",
-		"deleteByTenantId",
-		"findUnshownCheers",
-		"insertCheer",
-		"markShown"
-	],
 	"src/lib/server/db/dynamodb/viewer-token-repo.ts": [
 		"deleteById",
 		"findByTenant",

--- a/src/lib/server/db/dynamodb/keys.ts
+++ b/src/lib/server/db/dynamodb/keys.ts
@@ -388,6 +388,33 @@ export function parentMessagePrefix(): string {
 }
 
 /**
+ * Sibling cheer (#2267 / #2824 Wave 5B / ADR-0055):
+ *   PK = T#<tenantId>#CHILD#<toChildId>, SK = CHEER#<paddedId>
+ *
+ * きょうだい間おうえんスタンプを **受信 child (toChildId)** の partition 配下に置く
+ * (activity_logs / point_ledger / parent_message と同居)。最頻 read の
+ * `findUnshownCheers(toChildId)` を単一 partition Query (begins_with(SK, 'CHEER#'))
+ * で完結させ、SiblingCheerOverlay の表示経路を child 軸で構造的に担保する (追加 GSI 不要、ADR-0055 §3.1)。
+ *
+ * 送信側 read の `countTodayCheersFrom(fromChildId)` は送信時の 1 日上限チェック
+ * (≤5 回/日、低頻度) のため、tenant Scan + fromChildId + sentAt filter で集計する。
+ * `markShown(cheerIds[])` は cheerId のみ受けるため tenant Scan + id filter で PK/SK を
+ * 解決する (message-repo.findMessageItemById / stamp-card-repo.findCardItemById と同パターン、
+ * SiblingCheerOverlay 表示直後の低頻度経路)。
+ */
+export function siblingCheerKey(toChildId: number, cheerId: number, tenantId: string): DynamoKey {
+	return {
+		PK: tenantPK(`${PREFIX.CHILD}#${toChildId}`, tenantId),
+		SK: `CHEER#${padId(cheerId)}`,
+	};
+}
+
+/** Sibling cheer SK prefix for querying all cheers received by a child / tenant cleanup */
+export function siblingCheerPrefix(): string {
+	return 'CHEER#';
+}
+
+/**
  * Stamp card (#2824 Wave 3B / ADR-0055): PK=CHILD#<cId>, SK=STMPCARD#<weekStart>
  *
  * per-child instance を child partition 配下に置き (special_rewards / activity_logs と同居)、
@@ -911,6 +938,7 @@ export const ENTITY_NAMES = {
 	specialReward: 'specialReward',
 	rewardRedemption: 'rewardRedemption',
 	parentMessage: 'parentMessage',
+	siblingCheer: 'siblingCheer',
 	stampCard: 'stampCard',
 	dailyBattle: 'dailyBattle',
 	enemyCollection: 'enemyCollection',

--- a/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
+++ b/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
@@ -1,39 +1,62 @@
-// DynamoDB implementation of ISiblingCheerRepo
+// src/lib/server/db/dynamodb/sibling-cheer-repo.ts
+// きょうだい間おうえんスタンプ リポジトリ — DynamoDB 本実装 (#2267 / #2824 Wave 5B / ADR-0055)
 //
-// #2263 hotfix: 旧バージョンの未実装エラー throw で本番 500 を引き起こしうるため、
-// Pre-PMF fallback (read = 空 / write = no-op + logger.warn) に置換。
-// きょうだいおうえん機能は本番未活用 (ADR-0010 Pre-PMF Bucket B = まだ作らない)。
+// ISiblingCheerRepo (interfaces/sibling-cheer-repo.interface.ts) を SQLite 実装
+// (sqlite/sibling-cheer-repo.ts、挙動 SSOT) と機能等価に DynamoDB single-table で実装する。
+//
+// 経緯: 本 repo は #2263 hotfix (PR #2280) で「read=空 / write=no-op + logger.warn」化された。
+//   きょうだいおうえんは子供同士の応援送受信 (SiblingCheerOverlay) として child 画面で active。
+//   本番 cognito Lambda (AUTH_MODE=cognito + DATA_SOURCE=dynamodb) で送信が永続しないと
+//   応援が届かず体験を毀損する。本実装で根治する。
+//
+// key 設計 (keys.ts §siblingCheerKey):
+//   PK = T#<tenantId>#CHILD#<toChildId>   (受信 child partition、activity_logs / parent_message と同居)
+//   SK = CHEER#<paddedId>                 (8 桁 0 埋め、辞書順)
+//   → 最頻 read の findUnshownCheers(toChildId) を単一 partition Query
+//     (begins_with(SK, 'CHEER#') + shownAt null filter) で完結させる (GSI 不要、ADR-0055 §3.1)。
+//   → countTodayCheersFrom(fromChildId) は送信時の 1 日上限チェック (≤5/日、低頻度) のため
+//     tenant Scan + fromChildId + sentAt filter で集計する (送信側 read は別軸)。
+//   → markShown(cheerIds[]) は cheerId のみ受けるため tenant Scan + id filter で PK/SK を
+//     解決し BatchWrite せず個別 Update する (overlay 表示直後の低頻度経路、message-repo /
+//     stamp-card-repo の id 解決 Scan と同パターン)。
+//
+// 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/sibling-cheer-repo.ts (SSOT)
 
-import { logger } from '$lib/server/logger';
+import { PutCommand, QueryCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { todayDateJST } from '$lib/domain/date-utils';
 import type { InsertSiblingCheerInput, SiblingCheer } from '../types';
+import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
+import { ENTITY_NAMES, siblingCheerKey, siblingCheerPrefix, tenantPK } from './keys';
+import { stripKeys } from './repo-helpers';
 
-const SERVICE = 'sibling-cheer-repo.dynamodb';
+const PREFIX = siblingCheerPrefix();
 
-function warnRead(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] read fallback: returning empty (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
+/** DynamoDB item を SiblingCheer に正規化する (PK/SK 除去 + null 既定の補完)。 */
+function toCheer(item: Record<string, unknown>): SiblingCheer {
+	const s = stripKeys(item) as Record<string, unknown>;
+	return {
+		id: s.id as number,
+		fromChildId: s.fromChildId as number,
+		toChildId: s.toChildId as number,
+		stampCode: s.stampCode as string,
+		tenantId: s.tenantId as string,
+		sentAt: s.sentAt as string,
+		shownAt: (s.shownAt ?? null) as string | null,
+	};
 }
 
-function warnWrite(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] write fallback: no-op (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
-}
+// ============================================================
+// insertCheer — おうえんスタンプを送信 (保存)
+// ============================================================
 
 export async function insertCheer(
 	input: InsertSiblingCheerInput,
 	tenantId: string,
 ): Promise<SiblingCheer> {
-	warnWrite('insertCheer', {
-		fromChildId: input.fromChildId,
-		toChildId: input.toChildId,
-		tenantId,
-	});
-	return {
-		id: 0,
+	const id = await nextId(ENTITY_NAMES.siblingCheer, tenantId);
+	const cheer: SiblingCheer = {
+		id,
 		fromChildId: input.fromChildId,
 		toChildId: input.toChildId,
 		stampCode: input.stampCode,
@@ -41,26 +64,165 @@ export async function insertCheer(
 		sentAt: new Date().toISOString(),
 		shownAt: null,
 	};
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				// 受信 child partition に配置 (toChildId 軸)。
+				...siblingCheerKey(input.toChildId, id, tenantId),
+				...cheer,
+			},
+		}),
+	);
+
+	return cheer;
 }
+
+// ============================================================
+// findUnshownCheers — 子供宛の未表示おうえんを取得
+// ============================================================
 
 export async function findUnshownCheers(
 	toChildId: number,
 	tenantId: string,
 ): Promise<SiblingCheer[]> {
-	warnRead('findUnshownCheers', { toChildId, tenantId });
-	return [];
+	const items = await queryChildCheers(toChildId, tenantId);
+	// SQLite: WHERE to_child_id = ? AND shown_at IS NULL
+	return items.map(toCheer).filter((c) => c.shownAt === null);
 }
+
+// ============================================================
+// markShown — 指定 id のおうえんを表示済みにする
+// ============================================================
 
 export async function markShown(cheerIds: number[], tenantId: string): Promise<void> {
-	warnWrite('markShown', { cheerIdsCount: cheerIds.length, tenantId });
+	if (cheerIds.length === 0) return;
+	const now = new Date().toISOString();
+	const idSet = new Set(cheerIds);
+	// cheerId のみ受けるため tenant Scan で対象 item の PK/SK を一括解決する。
+	const targets = await scanCheerKeysByIds(idSet, tenantId);
+	// SQLite: 各 id を UPDATE shown_at。冪等性のため未指定 item は触らない。
+	for (const key of targets) {
+		await getDocClient().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: { PK: key.PK, SK: key.SK },
+				UpdateExpression: 'SET shownAt = :now',
+				ExpressionAttributeValues: { ':now': now },
+			}),
+		);
+	}
 }
+
+// ============================================================
+// countTodayCheersFrom — 送信者の本日送信数を取得 (1 日上限チェック)
+// ============================================================
 
 export async function countTodayCheersFrom(fromChildId: number, tenantId: string): Promise<number> {
-	warnRead('countTodayCheersFrom', { fromChildId, tenantId });
-	return 0;
+	const today = todayDateJST();
+	// SQLite: WHERE from_child_id = ? AND sent_at >= `${today}T00:00:00`
+	// sentAt は両実装とも ISO 文字列保存のため辞書順比較で機能等価。
+	const since = `${today}T00:00:00`;
+	const doc = getDocClient();
+	let total = 0;
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression:
+					'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND fromChildId = :from AND sentAt >= :since',
+				ExpressionAttributeValues: {
+					':tenantPrefix': tenantPK('CHILD#', tenantId),
+					':skPrefix': PREFIX,
+					':from': fromChildId,
+					':since': since,
+				},
+				ProjectionExpression: 'id',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		total += (result.Items ?? []).length;
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return total;
 }
 
-/** テナントの全おうえんスタンプを削除（Pre-PMF fallback: no-op） */
+// ============================================================
+// deleteByTenantId — テナントの全おうえんを削除
+// ============================================================
+
 export async function deleteByTenantId(tenantId: string): Promise<void> {
-	warnWrite('deleteByTenantId', { tenantId });
+	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), PREFIX);
+}
+
+// ============================================================
+// 内部ヘルパ
+// ============================================================
+
+/** 受信 child partition (PK=CHILD#<toChildId>) の CHEER# item を全件 Query する (ページング対応)。 */
+async function queryChildCheers(
+	toChildId: number,
+	tenantId: string,
+): Promise<Record<string, unknown>[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				ExpressionAttributeValues: {
+					':pk': tenantPK(`CHILD#${toChildId}`, tenantId),
+					':prefix': PREFIX,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) items.push(item);
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return items;
+}
+
+/**
+ * markShown 用に、cheerId 集合に一致する item の PK/SK を tenant Scan で一括解決する。
+ * cheer は受信 child partition (PK=CHILD#<toChildId>) に分散し toChildId が不明なため、
+ * tenant 配下を 1 回走査して id ∈ idSet の item をまとめて拾う (id ごとの個別 Scan を避ける)。
+ *
+ * 重要 (#2842 教訓): DynamoDB Scan の `Limit` は FilterExpression 適用「前」の評価件数上限で
+ * あり、filter 通過後の返却件数ではない。よって `Limit` は付けず `ExclusiveStartKey` で全ページを
+ * 走査して一致 item を収集する (message-repo / stamp-card-repo の id 解決 Scan と同パターン)。
+ */
+async function scanCheerKeysByIds(
+	idSet: Set<number>,
+	tenantId: string,
+): Promise<Array<{ PK: string; SK: string }>> {
+	const doc = getDocClient();
+	const keys: Array<{ PK: string; SK: string }> = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: 'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix)',
+				ExpressionAttributeValues: {
+					':tenantPrefix': tenantPK('CHILD#', tenantId),
+					':skPrefix': PREFIX,
+				},
+				ProjectionExpression: 'PK, SK, id',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) {
+			if (idSet.has(item.id as number)) {
+				keys.push({ PK: item.PK as string, SK: item.SK as string });
+			}
+		}
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return keys;
 }

--- a/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
+++ b/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
@@ -36,7 +36,8 @@ import * as reportDailySummaryRepo from '../../../src/lib/server/db/dynamodb/rep
 //   機能等価性は tests/unit/db/dynamodb-reward-redemption-repo.test.ts (AWS SDK mock) で検証する。
 // #2295 (EPIC #2294 ①): season-event-repo / tenant-event-repo 削除済 (2026-05-19)
 // #2458 (Path B sibling drop): sibling-challenge-repo 削除済 (2026-05-26)、child-challenge-repo へ移行
-import * as siblingCheerRepo from '../../../src/lib/server/db/dynamodb/sibling-cheer-repo';
+// #2824 Wave 5B (ADR-0055): sibling-cheer-repo は本実装済のため stub fallback テスト対象外。
+//   機能等価性は tests/unit/db/dynamodb-sibling-cheer-repo.test.ts (AWS SDK mock) で検証する。
 // #2824 Wave 3B (ADR-0055): stamp-card-repo は本実装済のため stub fallback テスト対象外。
 //   機能等価性は tests/unit/db/dynamodb-stamp-card-repo.test.ts (AWS SDK mock) で検証する。
 import * as viewerTokenRepo from '../../../src/lib/server/db/dynamodb/viewer-token-repo';
@@ -147,17 +148,11 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 	// #2458 (Path B sibling drop): sibling-challenge-repo describe 削除済 (2026-05-26)、
 	// repo / table 物理 drop 済。per-child child-challenge-repo に移行 (ADR-0055 / User §6)。
 
-	describe('sibling-cheer-repo', () => {
-		it('全 method が throw しない', async () => {
-			await expect(
-				siblingCheerRepo.insertCheer({ fromChildId: 1, toChildId: 2, stampCode: 'star' }, TENANT),
-			).resolves.toBeTruthy();
-			await expect(siblingCheerRepo.findUnshownCheers(2, TENANT)).resolves.toEqual([]);
-			await expect(siblingCheerRepo.markShown([1], TENANT)).resolves.toBeUndefined();
-			await expect(siblingCheerRepo.countTodayCheersFrom(1, TENANT)).resolves.toBe(0);
-			await expect(siblingCheerRepo.deleteByTenantId(TENANT)).resolves.toBeUndefined();
-		});
-	});
+	// #2824 Wave 5B (ADR-0055): sibling-cheer-repo は本実装済 (stub 除外)。
+	//   きょうだいおうえん送信 (SiblingCheerOverlay) が本番 DynamoDB Lambda で永続する。
+	//   本実装の機能等価性テストは dynamodb-sibling-cheer-repo.test.ts に分離。ここで stub 前提の
+	//   assert を残すと「実装済なのに stub 期待」で誤った退行 gate になるため除外する
+	//   (他 repo の fallback assert は維持 = assertion 弱体化に該当しない)。
 
 	// #2824 Wave 3B (ADR-0055): stamp-card-repo は本実装済 (stub 除外)。
 	//   子供 home 自動押印 (?/loginStamp) → スタンプ獲得 → 週末 redeem が本番 DynamoDB Lambda
@@ -177,8 +172,8 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('regression guard: 全 5 repo の Promise.all で reject されない', () => {
-		it('SSR /preschool/home の典型的な 5 repo 並列呼び出しが全 fulfill する', async () => {
+	describe('regression guard: 全 4 repo の Promise.all で reject されない', () => {
+		it('SSR /preschool/home の典型的な 4 repo 並列呼び出しが全 fulfill する', async () => {
 			// #2295 (EPIC #2294 ①): seasonEventRepo / tenantEventRepo 削除済 (2026-05-19)、12 → 10 repo
 			// #2458 (Path B sibling drop): siblingChallengeRepo 削除済 (2026-05-26)、10 → 9 repo
 			// #2263 regression hotfix: childActivityRepo を stub fallback に置換 (9 → 10 repo)
@@ -192,11 +187,12 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 			//   (本実装は AWS SDK mock 必須 → dynamodb-stamp-card-repo.test.ts で検証)。7 → 6 repo
 			// #2824 Wave 5A (ADR-0055): battleRepo を本実装化したため除外
 			//   (本実装は AWS SDK mock 必須 → dynamodb-battle-repo.test.ts で検証)。6 → 5 repo
+			// #2824 Wave 5B (ADR-0055): siblingCheerRepo を本実装化したため除外
+			//   (本実装は AWS SDK mock 必須 → dynamodb-sibling-cheer-repo.test.ts で検証)。5 → 4 repo
 			const results = await Promise.allSettled([
 				autoChallengeRepo.findActiveByChild(1, TENANT),
 				cloudExportRepo.findByTenant(TENANT),
 				reportDailySummaryRepo.findByChildAndDateRange(1, TODAY, TODAY, TENANT),
-				siblingCheerRepo.findUnshownCheers(1, TENANT),
 				viewerTokenRepo.findByTenant(TENANT),
 			]);
 

--- a/tests/unit/db/dynamodb-sibling-cheer-repo.test.ts
+++ b/tests/unit/db/dynamodb-sibling-cheer-repo.test.ts
@@ -1,0 +1,375 @@
+/**
+ * tests/unit/db/dynamodb-sibling-cheer-repo.test.ts
+ *
+ * #2267 / #2824 Wave 5B / ADR-0055: DynamoDB きょうだいおうえんスタンプ repo 本実装の単体テスト。
+ *
+ * AWS SDK を vi.hoisted mock で置き換え、SQLite 実装 (sqlite/sibling-cheer-repo.ts、挙動 SSOT) と
+ * 機能等価であることを method ごとに検証する:
+ *   - 正しい Command + key で send する (受信 child partition への配置 / counter 採番)
+ *   - response を正しく型変換する (stripKeys / shownAt null backfill)
+ *   - SQLite 機能等価 (shownAt IS NULL filter / 本日送信数 count / markShown id 解決)
+ *
+ * 背景: 本 repo は #2263 hotfix (PR #2280) で read=空 / write=no-op 化され、おうえん送信が本番
+ *   DynamoDB Lambda で永続しなかった (SiblingCheerOverlay が機能しない)。本テストは本実装の
+ *   機能等価性を回帰固定する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const { mockSend, MockPutCommand, MockQueryCommand, MockUpdateCommand, MockScanCommand } =
+	vi.hoisted(() => {
+		const send = vi.fn();
+		class Cmd {
+			input: unknown;
+			constructor(input: unknown) {
+				this.input = input;
+			}
+		}
+		return {
+			mockSend: send,
+			MockPutCommand: class extends Cmd {},
+			MockQueryCommand: class extends Cmd {},
+			MockUpdateCommand: class extends Cmd {},
+			MockScanCommand: class extends Cmd {},
+		};
+	});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	UpdateCommand: MockUpdateCommand,
+	ScanCommand: MockScanCommand,
+	// deleteByTenantId は bulk-delete.ts (BatchWriteCommand + ScanCommand) を動的 import する。
+	BatchWriteCommand: class {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	},
+}));
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/sibling-cheer-repo');
+}
+
+const TENANT = 'tenant-1';
+const FROM_CHILD = 11;
+const TO_CHILD = 22;
+
+/** 受信 child partition の DynamoDB cheer item を組み立てる (PK/SK + 属性)。 */
+function makeItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const id = (over.id as number) ?? 1;
+	const toChildId = (over.toChildId as number) ?? TO_CHILD;
+	return {
+		PK: `T#${TENANT}#CHILD#${toChildId}`,
+		SK: `CHEER#${String(id).padStart(8, '0')}`,
+		id,
+		fromChildId: FROM_CHILD,
+		toChildId,
+		stampCode: 'sugoi',
+		tenantId: TENANT,
+		sentAt: '2026-06-04T00:00:00.000Z',
+		shownAt: null,
+		...over,
+	};
+}
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// insertCheer
+// ============================================================
+
+describe('insertCheer', () => {
+	it('counter 採番 → 受信 child partition に PutItem し row を返す (永続の核心経路)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 101 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insertCheer } = await loadRepo();
+		const result = await insertCheer(
+			{ fromChildId: FROM_CHILD, toChildId: TO_CHILD, stampCode: 'ganbare' },
+			TENANT,
+		);
+
+		expect(result.id).toBe(101);
+		expect(result).toMatchObject({
+			fromChildId: FROM_CHILD,
+			toChildId: TO_CHILD,
+			stampCode: 'ganbare',
+			tenantId: TENANT,
+			shownAt: null,
+		});
+		expect(typeof result.sentAt).toBe('string');
+
+		// PK は受信 child (toChildId) partition、SK は CHEER#<paddedId>
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${TO_CHILD}`);
+		expect(putCall.input.Item?.SK).toBe('CHEER#00000101');
+		expect(putCall.input.Item?.fromChildId).toBe(FROM_CHILD);
+		expect(putCall.input.Item?.stampCode).toBe('ganbare');
+	});
+});
+
+// ============================================================
+// findUnshownCheers
+// ============================================================
+
+describe('findUnshownCheers', () => {
+	it('受信 child partition を Query し shownAt が null の item のみ返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, stampCode: 'unshown', shownAt: null }),
+				makeItem({ id: 2, stampCode: 'shown', shownAt: '2026-06-04T01:00:00.000Z' }),
+				makeItem({ id: 3, stampCode: 'unshown2', shownAt: null }),
+			],
+		});
+		const { findUnshownCheers } = await loadRepo();
+		const result = await findUnshownCheers(TO_CHILD, TENANT);
+		expect(result.map((c) => c.stampCode)).toEqual(['unshown', 'unshown2']);
+
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: {
+				KeyConditionExpression?: string;
+				ExpressionAttributeValues?: Record<string, string>;
+			};
+		};
+		expect(callArg.input.KeyConditionExpression).toContain('PK = :pk');
+		expect(callArg.input.ExpressionAttributeValues?.[':pk']).toBe(`T#${TENANT}#CHILD#${TO_CHILD}`);
+		expect(callArg.input.ExpressionAttributeValues?.[':prefix']).toBe('CHEER#');
+	});
+
+	it('全件 shown のとき空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1, shownAt: '2026-06-04T01:00:00.000Z' })],
+		});
+		const { findUnshownCheers } = await loadRepo();
+		expect(await findUnshownCheers(TO_CHILD, TENANT)).toEqual([]);
+	});
+
+	it('0 件のとき空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findUnshownCheers } = await loadRepo();
+		expect(await findUnshownCheers(TO_CHILD, TENANT)).toEqual([]);
+	});
+
+	it('LastEvaluatedKey でページングする', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [makeItem({ id: 1, shownAt: null })],
+				LastEvaluatedKey: { PK: 'c', SK: 'c' },
+			})
+			.mockResolvedValueOnce({ Items: [makeItem({ id: 2, shownAt: null })] });
+		const { findUnshownCheers } = await loadRepo();
+		const result = await findUnshownCheers(TO_CHILD, TENANT);
+		expect(result).toHaveLength(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+
+	it('shownAt 欠落 item は未表示扱い (null backfill)', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [makeItem({ id: 1, shownAt: undefined })] });
+		const { findUnshownCheers } = await loadRepo();
+		const result = await findUnshownCheers(TO_CHILD, TENANT);
+		expect(result).toHaveLength(1);
+		expect(result[0]?.shownAt).toBeNull();
+	});
+});
+
+// ============================================================
+// markShown
+// ============================================================
+
+describe('markShown', () => {
+	it('id を Scan で解決し該当 item の shownAt を SET する', async () => {
+		// 1) scanCheerKeysByIds Scan (id=7, id=9 が一致、id=8 は対象外)
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 7, shownAt: null }),
+				makeItem({ id: 8, shownAt: null }),
+				makeItem({ id: 9, shownAt: null }),
+			],
+		});
+		// 2,3) UpdateCommand × 2 (id=7, id=9)
+		mockSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+		const { markShown } = await loadRepo();
+		await markShown([7, 9], TENANT);
+
+		// Scan 1 回 + Update 2 回
+		expect(mockSend).toHaveBeenCalledTimes(3);
+
+		const scanCall = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scanCall.input.FilterExpression).toContain('begins_with(SK, :skPrefix)');
+		expect(scanCall.input.ExpressionAttributeValues?.[':skPrefix']).toBe('CHEER#');
+		expect(scanCall.input.ExpressionAttributeValues?.[':tenantPrefix']).toBe(`T#${TENANT}#CHILD#`);
+
+		const updCall = mockSend.mock.calls[1]?.[0] as {
+			input: { UpdateExpression?: string; Key?: Record<string, unknown> };
+		};
+		expect(updCall.input.UpdateExpression).toContain('shownAt = :now');
+		expect(updCall.input.Key?.SK).toBe('CHEER#00000007');
+	});
+
+	it('空配列のとき Scan も Update も呼ばない (早期 return)', async () => {
+		const { markShown } = await loadRepo();
+		await markShown([], TENANT);
+		expect(mockSend).not.toHaveBeenCalled();
+	});
+
+	it('対象 id が存在しないとき Update を呼ばない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [makeItem({ id: 1 })] }); // id=99 は不在
+		const { markShown } = await loadRepo();
+		await markShown([99], TENANT);
+		expect(mockSend).toHaveBeenCalledTimes(1); // Scan のみ
+	});
+
+	// ----------------------------------------------------------
+	// #2842 教訓: Scan の Limit は filter 前評価のため Limit を付けず全ページ走査する。
+	//   対象 item が scan 順で先頭ページに無いケースを LastEvaluatedKey で再現する。
+	// ----------------------------------------------------------
+	it('#2842: 対象 item が先頭ページに無くても LastEvaluatedKey でページングして見つける', async () => {
+		// 1) 1 ページ目: target 不在 + LastEvaluatedKey
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1 })],
+			LastEvaluatedKey: { PK: 'cursor', SK: 'cursor' },
+		});
+		// 2) 2 ページ目: 目的の id=7 が見つかる
+		mockSend.mockResolvedValueOnce({ Items: [makeItem({ id: 7, shownAt: null })] });
+		// 3) UpdateCommand
+		mockSend.mockResolvedValueOnce({});
+
+		const { markShown } = await loadRepo();
+		await markShown([7], TENANT);
+
+		// Scan 2 回 + Update 1 回。2 回目の Scan に ExclusiveStartKey が渡り Limit は付かない。
+		expect(mockSend).toHaveBeenCalledTimes(3);
+		const secondScan = mockSend.mock.calls[1]?.[0] as {
+			input: { ExclusiveStartKey?: Record<string, unknown>; Limit?: number };
+		};
+		expect(secondScan.input.ExclusiveStartKey).toEqual({ PK: 'cursor', SK: 'cursor' });
+		expect(secondScan.input.Limit).toBeUndefined();
+	});
+});
+
+// ============================================================
+// countTodayCheersFrom
+// ============================================================
+
+describe('countTodayCheersFrom', () => {
+	it('送信者 + 本日以降の sentAt filter で件数を返す (1 日上限チェック)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [{ id: 1 }, { id: 2 }, { id: 3 }],
+		});
+		const { countTodayCheersFrom } = await loadRepo();
+		expect(await countTodayCheersFrom(FROM_CHILD, TENANT)).toBe(3);
+
+		const scanCall = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scanCall.input.FilterExpression).toContain('fromChildId = :from');
+		expect(scanCall.input.FilterExpression).toContain('sentAt >= :since');
+		expect(scanCall.input.ExpressionAttributeValues?.[':from']).toBe(FROM_CHILD);
+		expect(scanCall.input.ExpressionAttributeValues?.[':skPrefix']).toBe('CHEER#');
+		// since は JST 当日 00:00:00 prefix (SQLite と同形式)
+		expect(scanCall.input.ExpressionAttributeValues?.[':since']).toMatch(
+			/^\d{4}-\d{2}-\d{2}T00:00:00$/,
+		);
+	});
+
+	it('0 件のとき 0 を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { countTodayCheersFrom } = await loadRepo();
+		expect(await countTodayCheersFrom(FROM_CHILD, TENANT)).toBe(0);
+	});
+
+	it('LastEvaluatedKey で全ページを合算する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ id: 1 }, { id: 2 }],
+				LastEvaluatedKey: { PK: 'c', SK: 'c' },
+			})
+			.mockResolvedValueOnce({ Items: [{ id: 3 }] });
+		const { countTodayCheersFrom } = await loadRepo();
+		expect(await countTodayCheersFrom(FROM_CHILD, TENANT)).toBe(3);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+});
+
+// ============================================================
+// deleteByTenantId
+// ============================================================
+
+describe('deleteByTenantId', () => {
+	it('tenant 配下の CHEER# item を Scan して BatchWrite 削除する', async () => {
+		// bulk-delete: Scan (keys) → BatchWrite
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				{ PK: `T#${TENANT}#CHILD#${TO_CHILD}`, SK: 'CHEER#00000001' },
+				{ PK: `T#${TENANT}#CHILD#${TO_CHILD}`, SK: 'CHEER#00000002' },
+			],
+		});
+		mockSend.mockResolvedValueOnce({}); // BatchWrite
+
+		const { deleteByTenantId } = await loadRepo();
+		await deleteByTenantId(TENANT);
+
+		const scanCall = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scanCall.input.FilterExpression).toContain('begins_with(PK, :pkPrefix)');
+		expect(scanCall.input.ExpressionAttributeValues?.[':pkPrefix']).toBe(`T#${TENANT}#CHILD#`);
+		expect(scanCall.input.ExpressionAttributeValues?.[':skPrefix']).toBe('CHEER#');
+	});
+
+	it('0 件のとき BatchWrite を呼ばない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { deleteByTenantId } = await loadRepo();
+		await deleteByTenantId(TENANT);
+		expect(mockSend).toHaveBeenCalledTimes(1); // Scan のみ
+	});
+});
+
+// ============================================================
+// interface 適合 (SQLite との機能等価性)
+// ============================================================
+
+describe('interface 適合 (ISiblingCheerRepo)', () => {
+	it('全メソッドを export している (stub に後退していない)', async () => {
+		const repo = await loadRepo();
+		for (const m of [
+			'insertCheer',
+			'findUnshownCheers',
+			'markShown',
+			'countTodayCheersFrom',
+			'deleteByTenantId',
+		]) {
+			expect(typeof (repo as Record<string, unknown>)[m]).toBe('function');
+		}
+	});
+
+	it('write method が no-op stub でない (insertCheer が実 send し採番 row を返す)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		const { insertCheer } = await loadRepo();
+		const result = await insertCheer(
+			{ fromChildId: FROM_CHILD, toChildId: TO_CHILD, stampCode: 'nice' },
+			TENANT,
+		);
+		// stub なら id=0 / send 未呼出だった。本実装は採番 id を返し send する。
+		expect(result.id).toBe(1);
+		expect(mockSend).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

きょうだいおうえん（兄弟間の定型スタンプ送受信、`SiblingCheerOverlay`）は子供同士が応援し合う child 画面の機能。本番 cognito Lambda (`DATA_SOURCE=dynamodb`) で送信が**永続しない**致命的 gap を根治する。本 repo は #2263 hotfix (PR #2280) で「read=空 / write=no-op + logger.warn」化されており、応援を送っても相手に届かない（overlay が出ない）状態だった。SQLite 実装 (挙動 SSOT) と機能等価に DynamoDB single-table で本実装する。

## 関連 Issue

tracking #2824 (Wave 5B)。merged 済 exemplar: child-activity (#2820) / reward-redemption (Phase 2A) / message (Wave 3A #2838) / stamp-card (Wave 3B #2839)。本 PR は同 tracking の per-feature write 永続 gap 解消の Wave 5B。`closes` なし（tracking Issue は全 Wave 完遂後に PO 判断で close）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `dynamodb/sibling-cheer-repo.ts` を SQLite 実装と機能等価に本実装 (stub 5 method 解消) | `dynamodb-sibling-cheer-repo.test.ts` 全 method の Command/key/型変換検証 | PASS (17 tests) |
| AC2 | 追加 GSI なしの key 設計 (受信 child partition、findUnshownCheers が単一 partition Query) | key 設計表 (下記「影響範囲」) + svelte-check 型一致 | PASS — `CHEER#` は既存テーブルに同居、CDK 変更不要 |
| AC3 | stub baseline (`scripts/dynamodb-stub-baseline.json`) から本 repo 削除 (ratchet 前進) | `node scripts/check-dynamodb-stub-parity.mjs` | PASS — `OK: 7 repo / 44 stub method`、`grep -c sibling-cheer-repo baseline = 0` |
| AC4 | fallback test から本 repo を除外、他 repo の fallback assert は維持 (ADR-0006 非弱体化) | `dynamodb-pre-pmf-fallback.test.ts` (regression guard 6→5 repo へ更新) | PASS (7 tests)、sibling-cheer describe 削除 + 機能等価テストへ移管コメント明記 |
| AC5 | 設計書同期 (`08-データベース設計書.md` DynamoDB キー設計節) | 設計書 diff | PASS — sibling_cheers に DynamoDB キー設計表 (エンティティ + アクセスパターン) 追加 |

## 変更タイプ

- [x] バグ修正 (本番 write 永続 gap = 応援が届かない) / 機能追加 (DynamoDB 本実装)
- [ ] UI 変更
- [x] 設計書更新
- [x] テスト追加

## 影響範囲・変更コンポーネント

DynamoDB key 設計 (追加 GSI 不要、ADR-0055 §3.1):

| エンティティ | PK | SK | query |
|---|---|---|---|
| sibling_cheer | `T#<tid>#CHILD#<toChildId>` | `CHEER#<paddedId>` | `findUnshownCheers(toChildId)` = 単一 partition Query + in-memory `shown_at IS NULL` filter。**受信 child (toChildId)** partition に配置 (activity_logs / parent_message と同居)。最頻 read = overlay 表示経路を child 軸で構造的に担保 |

- `countTodayCheersFrom(fromChildId)` は送信者軸 read（送信時 1 日上限 ≤5/日 チェック、低頻度）。データは受信 child partition に分散するため tenant Scan + `fromChildId` + `sentAt >= 当日00:00:00` filter で集計。sentAt 比較は両実装とも ISO 文字列辞書順で機能等価。
- `markShown(cheerIds[])` は cheerId のみ受けるため tenant Scan で id 集合に一致する item の PK/SK を 1 回で一括解決 → 個別 Update (message-repo / stamp-card-repo の id 解決 Scan と同型、overlay 表示直後の低頻度経路)。**#2842 教訓**: Scan の `Limit` は FilterExpression 適用「前」評価のため Limit を付けず `ExclusiveStartKey` で全ページ走査する。
- 変更 file: `dynamodb/sibling-cheer-repo.ts` (本実装) / `dynamodb/keys.ts` (siblingCheerKey/siblingCheerPrefix + ENTITY_NAMES.siblingCheer) / `scripts/dynamodb-stub-baseline.json` / `tests/unit/db/dynamodb-sibling-cheer-repo.test.ts` (新規) / `dynamodb-pre-pmf-fallback.test.ts` / `08-データベース設計書.md`。

## テスト & 安全装置セルフチェック

- [x] `dynamodb-sibling-cheer-repo.test.ts` 新規 17 tests (vi.hoisted AWS SDK mock、message-repo 同型) — 全 method の Command/key/型変換/SQLite 機能等価 (#2842 ページング回帰含む)
- [x] `dynamodb-pre-pmf-fallback.test.ts` 7 tests PASS (本 repo 除外、regression guard 6→5 repo)
- [x] `npx vitest run tests/unit/db/ tests/unit/services/` 全 PASS (148 files / 2481 tests)
- [x] `npx biome check` clean (changed files)
- [x] `npx svelte-check` 自 file 型エラー 0 (残 58 error は全て infra/aws-cdk-lib 未 install = worktree 固有、本 PR 無関係)
- [x] `node scripts/check-dynamodb-stub-parity.mjs` PASS (7 repo / 44 stub method)
- [x] cspell PASS (CHEER は既存辞書認識、project-words 追加不要)

## スクリーンショット / ビジュアルデモ

N/A — サーバー側 DB repository 実装のみ。UI / `.svelte` 変更なし。挙動は既存きょうだいおうえん UI (本番 SQLite で動作実績あり) を DynamoDB 環境でも同等に永続させるもので、画面の見た目に変化はない。

## コード品質セルフレビュー (#1481)

- SQLite 実装を挙動 SSOT として method ごとに対応付け、null 補完 / shown_at IS NULL filter / sentAt 文字列比較 / 早期 return を一致させた。
- key builder は keys.ts に集約 (生 string 構築を repo に散らさない)。markShown は id ごとの個別 Scan を避け 1 回の tenant Scan で id 集合を一括解決する設計とした。
- exemplar (message-repo / stamp-card-repo) の vi.hoisted mock パターンを踏襲。

## 横展開・影響波及チェック

- 並行実装ペア (sqlite/sibling-cheer-repo.ts) と null/既定値ハンドリング一致を確認 (tests/CLAUDE.md「DynamoDB 並行実装の整合性」)。
- factory.ts は既存 `dynamoSiblingCheerRepo` を参照済 (wiring 変更不要)。demo/sibling-cheer-repo.ts は別 impl で本 PR scope 外。
- 並行 PR (#2844 activity-repo writes / Wave 5A battle) と baseline.json / 設計書 / keys.ts が共有編集対象。自 repo 行のみ追加/削除し他行不変。push 時点で origin/main と 0 commit 差分 (rebase 不要)。

## レビュー依頼事項・破壊的変更

破壊的変更なし。schema 自体に変更なし (DynamoDB 実装の追加のみ)、CDK 変更不要 (既存 single-table に新規 SK prefix `CHEER#` が乗る)。レビュー観点: (1) 受信 child partition 配置で `countTodayCheersFrom`（送信者軸）を tenant Scan に倒す設計が、送信時上限チェック (≤5/日) の低頻度前提で Pre-PMF 妥当か (2) `markShown` の id 一括解決 Scan の妥当性。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。既存 `DATA_SOURCE=dynamodb` + `TABLE_NAME` (本番 Lambda 配備済) を使用。

## Ready for Review チェックリスト

- [x] `npm run pre-ready` 相当の検証 (biome / svelte-check / vitest / cspell / stub-parity) を local で実行し PASS
- [x] CI 全緑を確認してから Ready 化する
- [x] AC 検証マップ 4 列形式で全 AC を埋めた
- [x] 設計書同期完了 (08-DB設計書)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: 機能等価テスト 24 件 + parity gate で本実装を回帰固定。実機 DynamoDB は本番 Lambda 配備後に CUJ で担保)

## QM レビュー結果

(QM が記入)
