### PR TITLE
feat: #2824 Wave 5A — battle-repo DynamoDB 本実装 (ADR-0055)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -139,6 +139,7 @@ DynamoDB
 EBML
 EFGH
 ehon
+ENEMYCOL
 epool
 EXIF
 favicon

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -915,6 +915,33 @@ CDK (`infra/lib/storage-stack.ts`) の `MainTable` は単一テーブル設計 (
 **ユニーク制約:** (child_id, enemy_id)
 **インデックス:** child_id
 
+#### DynamoDB キー設計（single-table、#2824 Wave 5A / ADR-0055）
+
+本番 cognito Lambda は `DATA_SOURCE=dynamodb` で稼働するため、SQLite と機能等価の
+DynamoDB 実装 (`src/lib/server/db/dynamodb/battle-repo.ts`) を持つ。バトルは LP machine-tour ④
+`feature-rpg-battle`（冒険のクライマックス）で訴求する機能で、書込みが永続しないと進行・報酬・
+敵図鑑が毎アクセスで失われる（ADR-0013 LP truth 違反級）。daily_battles / enemy_collection とも
+per-child instance のため child partition に同居させ、`findTodayBattle` / `findCollection` を
+**追加 GSI なし**で完結させる（ADR-0055 §3.1 / ADR-0010）。
+
+| エンティティ | PK | SK | 補足 |
+|---|---|---|---|
+| daily_battles | `T#<tid>#CHILD#<childId>` | `BATTLE#<date>` | date（YYYY-MM-DD）一意 = SQLite uniqueIndex(child_id, date) と等価。SK 辞書順 = 日付順。stamp_cards / activity_logs と同 partition に同居。`id` は属性として保持 |
+| enemy_collection | `T#<tid>#CHILD#<childId>` | `ENEMYCOL#<paddedEnemyId>` | paddedEnemyId は SQLite uniqueIndex(child_id, enemy_id) と等価。childId + enemyId が常に揃うため upsert は GetItem → ADD/Put で Scan 不要 |
+
+| アクセスパターン | 操作 | 条件 |
+|---|---|---|
+| `findTodayBattle(childId, date)` | GetItem | `PK = T#<tid>#CHILD#<childId>, SK = BATTLE#<date>`。core loop で頻出（home load 毎）のため単一 GetItem |
+| `findRecentBattles(childId, limit)` | Query（`ScanIndexForward=false`） | `PK = T#<tid>#CHILD#<childId> AND begins_with(SK, 'BATTLE#')`。SK 降順 = date desc（SQLite orderBy desc(date) 等価）+ サーバ側 Limit |
+| `countConsecutiveLosses(childId)` | Query（降順） | completed のみ抽出 → 先頭 5 件で lose 連続数（SQLite limit(5) + 先頭から lose 連続のロジック等価） |
+| `insertDailyBattle` | counter 採番 → PutItem | status default = `pending` / outcome = null / reward_points = 0 / turns_used = 0（SQLite schema 一致）。player_stats は JSON 文字列で保存 |
+| `completeBattle(battleId)` | Scan（id filter）で PK/SK 解決 → UpdateItem | childId を受けないため tenant Scan + id で 1 件特定（stamp-card updateCardStatus と同型）。Scan は `Limit` を付けず全ページ走査（filter 前評価上限による空振り防止、#2842）。1 日 1 戦・低頻度で GSI 不要（Pre-PMF / ADR-0010） |
+| `upsertCollectionEntry(childId, enemyId)` | GetItem → ADD/Put | 既存なら `ADD defeatCount :1`（SQLite `defeat_count + 1`）、不在なら counter 採番 → PutItem（`attribute_not_exists(PK)` で競合 no-op）。default defeat_count = 1 |
+| `deleteByTenantId` | Scan → BatchWrite（2 経路） | `CHILD#*` 配下の `BATTLE#`（battles）と `ENEMYCOL#`（collection）を削除（`deleteItemsByPkPrefix`） |
+
+新規 SK prefix `BATTLE#` / `ENEMYCOL#` は既存テーブルにそのまま乗るため **CDK 変更不要**
+（追加 GSI なし）。schema 自体に変更はなく DynamoDB 実装の追加のみ。
+
 ### usage_logs
 
 子供の使用時間ログ。15分自動スリープ（#1292）用のセッション記録。

--- a/scripts/dynamodb-stub-baseline.json
+++ b/scripts/dynamodb-stub-baseline.json
@@ -18,15 +18,6 @@
 		"insert",
 		"update"
 	],
-	"src/lib/server/db/dynamodb/battle-repo.ts": [
-		"completeBattle",
-		"countConsecutiveLosses",
-		"findCollection",
-		"findRecentBattles",
-		"findTodayBattle",
-		"insertDailyBattle",
-		"upsertCollectionEntry"
-	],
 	"src/lib/server/db/dynamodb/certificate-repo.ts": [
 		"findCertificateById",
 		"findCertificates",

--- a/src/lib/server/db/dynamodb/battle-repo.ts
+++ b/src/lib/server/db/dynamodb/battle-repo.ts
@@ -1,63 +1,187 @@
 // src/lib/server/db/dynamodb/battle-repo.ts
-// DynamoDB implementation of IBattleRepo
+// バトルアドベンチャーリポジトリ — DynamoDB 本実装 (#2824 Wave 5A / ADR-0055)
 //
-// #2263 hotfix: 旧バージョンの未実装エラー throw で本番 500 を引き起こしうるため、
-// Pre-PMF fallback (read = 空 / write = no-op + logger.warn) に置換。
-// バトル機能は本番未活用 (ADR-0010 Pre-PMF Bucket B = まだ作らない)。
+// IBattleRepo (interfaces/battle-repo.interface.ts) を SQLite 実装
+// (sqlite/battle-repo.ts、挙動 SSOT) と機能等価に DynamoDB single-table で実装する。
+//
+// 経緯: 本 repo は #2263 hotfix (PR #2280) で「read=空 / write=no-op + logger.warn」化された。
+//   バトルは LP machine-tour ④「冒険のクライマックス」(feature-rpg-battle) で訴求する RPG 機能で、
+//   子供 home から日次バトルを起動 → 勝敗 → ポイント報酬 → 敵図鑑収集という体験ループを持つ
+//   (battle-service.ts)。本番 cognito Lambda (AUTH_MODE=cognito + DATA_SOURCE=dynamodb) で
+//   書込みが永続しないと、毎アクセスで「今日のバトル未挑戦」に戻り報酬も図鑑も消える
+//   (ADR-0013 LP truth 違反級)。本実装で根治する。
+//
+// key 設計 (keys.ts §dailyBattleKey / §enemyCollectionKey):
+//   daily_battles  : PK = T#<tid>#CHILD#<childId>  SK = BATTLE#<date>
+//     → child partition 同居 (stamp_cards / activity_logs と同じ)。
+//       findTodayBattle は childId + date 既知の GetItem 1 回。date は child 内で一意
+//       = SQLite uniqueIndex(child_id, date) と等価。findRecentBattles /
+//       countConsecutiveLosses は begins_with(SK, 'BATTLE#') の child partition Query で
+//       取得し、date が YYYY-MM-DD なので SK 辞書順 = 日付順 → ScanIndexForward=false で
+//       desc(date) と等価。battleId だけで引く completeBattle は 1 日 1 戦の低頻度のため
+//       tenant Scan + id filter で PK/SK を解決する (stamp-card updateCardStatus と同型)。
+//   enemy_collection: PK = T#<tid>#CHILD#<childId> SK = ENEMYCOL#<paddedEnemyId>
+//     → child partition 同居。findCollection は begins_with(SK, 'ENEMYCOL#') Query で全件、
+//       upsertCollectionEntry は childId + enemyId 既知の GetItem → 不在なら Put /
+//       既存なら defeatCount を ADD する (childId が常に渡るため Scan 不要)。
+//   → 全アクセスパターンが child 軸 / id 軸で完結し追加 GSI 不要 (ADR-0055 §3.1 / ADR-0010)。
+//
+// 関連: ADR-0055 / ADR-0013 / docs/design/08-データベース設計書.md / sqlite/battle-repo.ts (SSOT)
 
+import {
+	GetCommand,
+	PutCommand,
+	QueryCommand,
+	ScanCommand,
+	UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
 import type { BattleOutcome, BattleStats } from '$lib/domain/battle-types';
-import { logger } from '$lib/server/logger';
 import type { DailyBattleRow, EnemyCollectionRow } from '../interfaces/battle-repo.interface';
+import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
+import {
+	dailyBattleKey,
+	dailyBattlePrefix,
+	ENTITY_NAMES,
+	enemyCollectionKey,
+	enemyCollectionPrefix,
+	tenantPK,
+} from './keys';
+import { stripKeys } from './repo-helpers';
 
-const SERVICE = 'battle-repo.dynamodb';
+const BATTLE_PREFIX = dailyBattlePrefix();
+const ENEMYCOL_PREFIX = enemyCollectionPrefix();
 
-function warnRead(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] read fallback: returning empty (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
+/** DynamoDB item を DailyBattleRow に正規化する (PK/SK 除去 + SQLite default の補完)。 */
+function toBattleRow(item: Record<string, unknown>): DailyBattleRow {
+	const s = stripKeys(item) as Record<string, unknown>;
+	return {
+		id: s.id as number,
+		childId: s.childId as number,
+		enemyId: s.enemyId as number,
+		date: s.date as string,
+		status: s.status as 'pending' | 'completed',
+		// SQLite: outcome は nullable (pending では null)。
+		outcome: (s.outcome ?? null) as BattleOutcome | null,
+		// SQLite: reward_points / turns_used は NOT NULL default 0。
+		rewardPoints: (s.rewardPoints ?? 0) as number,
+		turnsUsed: (s.turnsUsed ?? 0) as number,
+		playerStatsJson: (s.playerStatsJson ?? '{}') as string,
+		createdAt: s.createdAt as string,
+		updatedAt: s.updatedAt as string,
+	};
 }
 
-function warnWrite(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] write fallback: no-op (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
+/** DynamoDB item を EnemyCollectionRow に正規化する。 */
+function toCollectionRow(item: Record<string, unknown>): EnemyCollectionRow {
+	const s = stripKeys(item) as Record<string, unknown>;
+	return {
+		id: s.id as number,
+		childId: s.childId as number,
+		enemyId: s.enemyId as number,
+		firstDefeatedAt: s.firstDefeatedAt as string,
+		// SQLite: defeat_count は NOT NULL default 1。
+		defeatCount: (s.defeatCount ?? 1) as number,
+	};
 }
+
+// ============================================================
+// findTodayBattle — child + date で 1 件取得 (GetItem)
+// ============================================================
 
 export async function findTodayBattle(
 	childId: number,
 	date: string,
 	tenantId: string,
 ): Promise<DailyBattleRow | undefined> {
-	warnRead('findTodayBattle', { childId, date, tenantId });
-	return undefined;
+	const result = await getDocClient().send(
+		new GetCommand({
+			TableName: TABLE_NAME,
+			Key: dailyBattleKey(childId, date, tenantId),
+		}),
+	);
+	if (!result.Item) return undefined;
+	return toBattleRow(result.Item);
 }
+
+// ============================================================
+// findRecentBattles — 直近のバトル履歴 (date desc, limit)
+// ============================================================
 
 export async function findRecentBattles(
 	childId: number,
 	limit: number,
 	tenantId: string,
 ): Promise<DailyBattleRow[]> {
-	warnRead('findRecentBattles', { childId, limit, tenantId });
-	return [];
+	// child partition の BATTLE# item を SK 降順 (date desc) で取得。
+	// SK = BATTLE#<YYYY-MM-DD> なので辞書順降順 = 日付降順 (SQLite orderBy desc(date) と等価)。
+	const items = await queryChildBattles(childId, tenantId, { descending: true, limit });
+	return items.map(toBattleRow);
 }
 
+// ============================================================
+// countConsecutiveLosses — 直近の連敗数
+// ============================================================
+
 export async function countConsecutiveLosses(childId: number, tenantId: string): Promise<number> {
-	warnRead('countConsecutiveLosses', { childId, tenantId });
-	return 0;
+	// SQLite: status='completed' を date desc 5 件取り、先頭から outcome='lose' が続く数を数える。
+	// DynamoDB は SK 降順 Query (date desc) で completed のみ拾い、先頭 5 件で同じロジックを適用。
+	const items = await queryChildBattles(childId, tenantId, { descending: true });
+	const completed = items
+		.map(toBattleRow)
+		.filter((b) => b.status === 'completed')
+		.slice(0, 5);
+
+	let losses = 0;
+	for (const b of completed) {
+		if (b.outcome === 'lose') {
+			losses++;
+		} else {
+			break;
+		}
+	}
+	return losses;
 }
+
+// ============================================================
+// insertDailyBattle — 日次バトルを登録
+// ============================================================
 
 export async function insertDailyBattle(
 	childId: number,
 	enemyId: number,
 	date: string,
-	_playerStats: BattleStats,
+	playerStats: BattleStats,
 	tenantId: string,
 ): Promise<number> {
-	warnWrite('insertDailyBattle', { childId, enemyId, date, tenantId });
-	return 0;
+	const id = await nextId(ENTITY_NAMES.dailyBattle, tenantId);
+	const now = new Date().toISOString();
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...dailyBattleKey(childId, date, tenantId),
+				id,
+				childId,
+				enemyId,
+				date,
+				// SQLite schema default。
+				status: 'pending',
+				outcome: null,
+				rewardPoints: 0,
+				turnsUsed: 0,
+				playerStatsJson: JSON.stringify(playerStats),
+				createdAt: now,
+				updatedAt: now,
+			},
+		}),
+	);
+	return id;
 }
+
+// ============================================================
+// completeBattle — バトル結果を記録 (battleId → Scan で PK/SK 解決)
+// ============================================================
 
 export async function completeBattle(
 	battleId: number,
@@ -66,21 +190,205 @@ export async function completeBattle(
 	turnsUsed: number,
 	tenantId: string,
 ): Promise<void> {
-	warnWrite('completeBattle', { battleId, outcome, rewardPoints, turnsUsed, tenantId });
+	const found = await findBattleItemById(battleId, tenantId);
+	// SQLite UPDATE は対象不在で no-op。DynamoDB も解決できなければ no-op。
+	if (!found) return;
+	await getDocClient().send(
+		new UpdateCommand({
+			TableName: TABLE_NAME,
+			Key: { PK: found.PK, SK: found.SK },
+			UpdateExpression:
+				'SET #status = :status, outcome = :outcome, rewardPoints = :rp, turnsUsed = :tu, updatedAt = :ua',
+			ExpressionAttributeNames: { '#status': 'status' },
+			ExpressionAttributeValues: {
+				':status': 'completed',
+				':outcome': outcome,
+				':rp': rewardPoints,
+				':tu': turnsUsed,
+				':ua': new Date().toISOString(),
+			},
+		}),
+	);
 }
+
+// ============================================================
+// findCollection — 敵図鑑を取得
+// ============================================================
 
 export async function findCollection(
 	childId: number,
 	tenantId: string,
 ): Promise<EnemyCollectionRow[]> {
-	warnRead('findCollection', { childId, tenantId });
-	return [];
+	const items = await queryChildEnemyCollection(childId, tenantId);
+	return items.map(toCollectionRow);
 }
+
+// ============================================================
+// upsertCollectionEntry — 敵図鑑エントリを追加/更新
+// ============================================================
 
 export async function upsertCollectionEntry(
 	childId: number,
 	enemyId: number,
 	tenantId: string,
 ): Promise<void> {
-	warnWrite('upsertCollectionEntry', { childId, enemyId, tenantId });
+	const doc = getDocClient();
+	const key = enemyCollectionKey(childId, enemyId, tenantId);
+	const existing = await doc.send(new GetCommand({ TableName: TABLE_NAME, Key: key }));
+
+	if (existing.Item) {
+		// SQLite: defeat_count = defeat_count + 1。
+		await doc.send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: key,
+				UpdateExpression: 'ADD defeatCount :one',
+				ExpressionAttributeValues: { ':one': 1 },
+			}),
+		);
+		return;
+	}
+
+	// 新規: SQLite default (first_defeated_at=CURRENT_TIMESTAMP, defeat_count=1)。
+	const id = await nextId(ENTITY_NAMES.enemyCollection, tenantId);
+	try {
+		await doc.send(
+			new PutCommand({
+				TableName: TABLE_NAME,
+				Item: {
+					...key,
+					id,
+					childId,
+					enemyId,
+					firstDefeatedAt: new Date().toISOString(),
+					defeatCount: 1,
+				},
+				// 同時押下による二重 Put を防ぐ (既存なら ConditionalCheckFailed)。
+				ConditionExpression: 'attribute_not_exists(PK)',
+			}),
+		);
+	} catch (e) {
+		// 競合で既に作られていたら no-op で握りつぶす (SQLite の存在チェック分岐と等価)。
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return;
+		throw e;
+	}
+}
+
+// ============================================================
+// deleteByTenantId — テナントの全バトル・図鑑を削除
+// ============================================================
+//
+// IBattleRepo interface には未定義だが、テナントデータ削除 (退会等) の整合のため
+// 他 repo (stamp-card 等) と同様に提供する。両 entity とも child partition 配下。
+
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), BATTLE_PREFIX);
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), ENEMYCOL_PREFIX);
+}
+
+// ============================================================
+// 内部ヘルパ
+// ============================================================
+
+/**
+ * child partition (PK=CHILD#<cId>) の BATTLE# item を Query する (ページング対応)。
+ * descending=true で SK 降順 (date desc)。limit 指定時はサーバ側 Limit で打ち切る
+ * (begins_with の KeyCondition で他 entity は混ざらないため Limit が filter 前評価でも安全)。
+ */
+async function queryChildBattles(
+	childId: number,
+	tenantId: string,
+	opts?: { descending?: boolean; limit?: number },
+): Promise<Record<string, unknown>[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				ExpressionAttributeValues: {
+					':pk': dailyBattleKey(childId, '', tenantId).PK,
+					':prefix': BATTLE_PREFIX,
+				},
+				ScanIndexForward: !opts?.descending,
+				Limit: opts?.limit,
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) items.push(item);
+		// limit 充足で打ち切り (subsequent page 不要)。
+		if (opts?.limit != null && items.length >= opts.limit) {
+			return items.slice(0, opts.limit);
+		}
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return items;
+}
+
+/** child partition の ENEMYCOL# item を全件 Query する (ページング対応)。 */
+async function queryChildEnemyCollection(
+	childId: number,
+	tenantId: string,
+): Promise<Record<string, unknown>[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				ExpressionAttributeValues: {
+					':pk': enemyCollectionKey(childId, 0, tenantId).PK,
+					':prefix': ENEMYCOL_PREFIX,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) items.push(item);
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return items;
+}
+
+/**
+ * battleId だけ受け取る completeBattle 用に、tenant 配下を Scan して battle item (PK/SK) を
+ * 解決する。battle は child partition (PK=CHILD#<cId>, SK=BATTLE#<date>) に分散し childId が
+ * 不明なため、tenant Scan + id filter で 1 件特定する。1 日 1 戦・低頻度のため Pre-PMF では
+ * GSI 不要 (ADR-0010)。
+ *
+ * 重要 (#2842 教訓): DynamoDB Scan の `Limit` は FilterExpression 適用「前」の評価上限であり
+ * filter 通過後の返却件数ではない。`Limit: 1` + Filter だと対象が scan 順先頭でない限り空振り
+ * するため Limit は付けず、ExclusiveStartKey で全ページ走査し一致 item を見つけ次第 early
+ * return する (stamp-card findCardItemById と同じ正パターン)。1 件も無ければ undefined。
+ */
+async function findBattleItemById(
+	battleId: number,
+	tenantId: string,
+): Promise<{ PK: string; SK: string } | undefined> {
+	const doc = getDocClient();
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression:
+					'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
+				ExpressionAttributeValues: {
+					':tenantPrefix': tenantPK('CHILD#', tenantId),
+					':skPrefix': BATTLE_PREFIX,
+					':id': battleId,
+				},
+				ProjectionExpression: 'PK, SK',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		const item = (result.Items ?? [])[0];
+		if (item) return { PK: item.PK as string, SK: item.SK as string };
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return undefined;
 }

--- a/src/lib/server/db/dynamodb/keys.ts
+++ b/src/lib/server/db/dynamodb/keys.ts
@@ -435,6 +435,48 @@ export function stampEntryPrefix(): string {
 }
 
 /**
+ * Daily battle (#2824 Wave 5A / ADR-0055): PK=CHILD#<cId>, SK=BATTLE#<date>
+ *
+ * per-child instance を child partition 配下に置き (stamp_cards / activity_logs と同居)、
+ * `findTodayBattle` を childId + date 既知の GetItem 1 回で完結させる
+ * (date は child 内で一意 = SQLite uniqueIndex(child_id, date) と等価)。`findRecentBattles` /
+ * `countConsecutiveLosses` は child partition の begins_with(SK, 'BATTLE#') Query で取得し
+ * (date は YYYY-MM-DD で SK 辞書順 = 日付順)、追加 GSI 不要 (ADR-0055 §3.1)。
+ * battleId だけで引く `completeBattle` は 1 日 1 戦の低頻度のため tenant Scan + id filter で解決する。
+ */
+export function dailyBattleKey(childId: number, date: string, tenantId: string): DynamoKey {
+	return {
+		PK: tenantPK(`${PREFIX.CHILD}#${childId}`, tenantId),
+		SK: `BATTLE#${date}`,
+	};
+}
+
+/** Daily battle SK prefix for querying all battles of a child / tenant cleanup. */
+export function dailyBattlePrefix(): string {
+	return 'BATTLE#';
+}
+
+/**
+ * Enemy collection (#2824 Wave 5A / ADR-0055): PK=CHILD#<cId>, SK=ENEMYCOL#<paddedEnemyId>
+ *
+ * per-child 敵図鑑を child partition 配下に置く。`findCollection` は child partition の
+ * begins_with(SK, 'ENEMYCOL#') Query で全件取得、`upsertCollectionEntry` は childId + enemyId
+ * 既知の GetItem → 不在なら Put / 既存なら defeatCount を ADD する (childId が常に渡るため
+ * Scan 不要)。SK の paddedEnemyId は SQLite uniqueIndex(child_id, enemy_id) と等価。
+ */
+export function enemyCollectionKey(childId: number, enemyId: number, tenantId: string): DynamoKey {
+	return {
+		PK: tenantPK(`${PREFIX.CHILD}#${childId}`, tenantId),
+		SK: `ENEMYCOL#${padId(enemyId)}`,
+	};
+}
+
+/** Enemy collection SK prefix for querying all entries of a child / tenant cleanup. */
+export function enemyCollectionPrefix(): string {
+	return 'ENEMYCOL#';
+}
+
+/**
  * Checklist template: PK=T#<tenantId>#CKTPL, SK=CKTPL#<id>
  * #2362 PR-5 (ADR-0055): family master 化に伴い CHILD#<cId> 配下 → tenant scope に変更。
  */
@@ -870,6 +912,8 @@ export const ENTITY_NAMES = {
 	rewardRedemption: 'rewardRedemption',
 	parentMessage: 'parentMessage',
 	stampCard: 'stampCard',
+	dailyBattle: 'dailyBattle',
+	enemyCollection: 'enemyCollection',
 	checklistTemplate: 'checklistTemplate',
 	checklistAssignment: 'checklistAssignment',
 	checklistItem: 'checklistItem',

--- a/tests/unit/db/dynamodb-battle-repo.test.ts
+++ b/tests/unit/db/dynamodb-battle-repo.test.ts
@@ -1,0 +1,552 @@
+/**
+ * tests/unit/db/dynamodb-battle-repo.test.ts
+ *
+ * #2824 Wave 5A / ADR-0055: DynamoDB battle-repo 本実装の単体テスト。
+ *
+ * AWS SDK を vi.hoisted mock で置き換え、SQLite 実装 (sqlite/battle-repo.ts、挙動 SSOT) と
+ * 機能等価であることを method ごとに検証する:
+ *   - 正しい Command + key で send する (child partition battle / enemy collection)
+ *   - response を正しく型変換する (stripKeys / SQLite default 補完)
+ *   - SQLite 機能等価 (findTodayBattle GetItem / findRecentBattles 降順 limit /
+ *     countConsecutiveLosses の completed 先頭 5 件 lose 連続 / insertDailyBattle default /
+ *     completeBattle の battleId Scan 解決 / upsertCollectionEntry の存在分岐 ADD/Put /
+ *     deleteByTenantId 2 経路)
+ *
+ * 背景: 本 repo は #2263 hotfix (PR #2280) で read=空 / write=no-op 化され、LP machine-tour ④
+ *   feature-rpg-battle 訴求の日次バトル進行・勝敗・ポイント報酬・敵図鑑が本番 DynamoDB Lambda で
+ *   永続せず、毎アクセスで未挑戦に戻り報酬も図鑑も消える状態だった。本テストは本実装の機能
+ *   等価性を回帰固定する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const {
+	mockSend,
+	MockGetCommand,
+	MockPutCommand,
+	MockQueryCommand,
+	MockUpdateCommand,
+	MockScanCommand,
+} = vi.hoisted(() => {
+	const send = vi.fn();
+	class Cmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	return {
+		mockSend: send,
+		MockGetCommand: class extends Cmd {},
+		MockPutCommand: class extends Cmd {},
+		MockQueryCommand: class extends Cmd {},
+		MockUpdateCommand: class extends Cmd {},
+		MockScanCommand: class extends Cmd {},
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	GetCommand: MockGetCommand,
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	UpdateCommand: MockUpdateCommand,
+	ScanCommand: MockScanCommand,
+	// bulk-delete.ts が import する Command。deleteByTenantId 経路で使用。
+	BatchWriteCommand: class {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	},
+}));
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/battle-repo');
+}
+
+const TENANT = 'tenant-1';
+const CHILD_ID = 42;
+const DATE = '2026-06-01';
+const BATTLE_ID = 7;
+const ENEMY_ID = 3;
+
+/** child partition の daily_battle DynamoDB item を組み立てる。 */
+function makeBattleItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const id = (over.id as number) ?? BATTLE_ID;
+	const date = (over.date as string) ?? DATE;
+	return {
+		PK: `T#${TENANT}#CHILD#${CHILD_ID}`,
+		SK: `BATTLE#${date}`,
+		id,
+		childId: CHILD_ID,
+		enemyId: ENEMY_ID,
+		date,
+		status: 'pending',
+		outcome: null,
+		rewardPoints: 0,
+		turnsUsed: 0,
+		playerStatsJson: '{"hp":100,"atk":10,"def":5,"spd":5,"rec":2}',
+		createdAt: '2026-06-01T00:00:00.000Z',
+		updatedAt: '2026-06-01T00:00:00.000Z',
+		...over,
+	};
+}
+
+/** child partition の enemy_collection DynamoDB item を組み立てる。 */
+function makeCollectionItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const enemyId = (over.enemyId as number) ?? ENEMY_ID;
+	return {
+		PK: `T#${TENANT}#CHILD#${CHILD_ID}`,
+		SK: `ENEMYCOL#${String(enemyId).padStart(8, '0')}`,
+		id: 1,
+		childId: CHILD_ID,
+		enemyId,
+		firstDefeatedAt: '2026-06-01T09:00:00.000Z',
+		defeatCount: 1,
+		...over,
+	};
+}
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// findTodayBattle
+// ============================================================
+
+describe('findTodayBattle', () => {
+	it('child + date key で GetItem する', async () => {
+		mockSend.mockResolvedValueOnce({ Item: makeBattleItem() });
+		const { findTodayBattle } = await loadRepo();
+		const battle = await findTodayBattle(CHILD_ID, DATE, TENANT);
+		expect(battle?.id).toBe(BATTLE_ID);
+		expect(battle?.date).toBe(DATE);
+		const callArg = mockSend.mock.calls[0]?.[0] as { input: { Key?: { PK: string; SK: string } } };
+		expect(callArg.input.Key?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(callArg.input.Key?.SK).toBe(`BATTLE#${DATE}`);
+	});
+
+	it('不在のとき undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Item: undefined });
+		const { findTodayBattle } = await loadRepo();
+		expect(await findTodayBattle(CHILD_ID, DATE, TENANT)).toBeUndefined();
+	});
+
+	it('outcome / rewardPoints / turnsUsed 欠落 item を SQLite default に補完する', async () => {
+		const item = makeBattleItem();
+		delete item.outcome;
+		delete item.rewardPoints;
+		delete item.turnsUsed;
+		mockSend.mockResolvedValueOnce({ Item: item });
+		const { findTodayBattle } = await loadRepo();
+		const battle = await findTodayBattle(CHILD_ID, DATE, TENANT);
+		expect(battle?.outcome).toBeNull();
+		expect(battle?.rewardPoints).toBe(0);
+		expect(battle?.turnsUsed).toBe(0);
+	});
+});
+
+// ============================================================
+// findRecentBattles
+// ============================================================
+
+describe('findRecentBattles', () => {
+	it('child partition を SK 降順 (date desc) で Query し limit を渡す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeBattleItem({ id: 9, date: '2026-06-03' }),
+				makeBattleItem({ id: 8, date: '2026-06-02' }),
+			],
+		});
+		const { findRecentBattles } = await loadRepo();
+		const battles = await findRecentBattles(CHILD_ID, 10, TENANT);
+		expect(battles.map((b) => b.id)).toEqual([9, 8]);
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: {
+				ScanIndexForward?: boolean;
+				Limit?: number;
+				ExpressionAttributeValues?: Record<string, string>;
+			};
+		};
+		// desc(date) = SK 降順。
+		expect(callArg.input.ScanIndexForward).toBe(false);
+		expect(callArg.input.Limit).toBe(10);
+		expect(callArg.input.ExpressionAttributeValues?.[':pk']).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(callArg.input.ExpressionAttributeValues?.[':prefix']).toBe('BATTLE#');
+	});
+
+	it('limit を超えた page では打ち切る (slice)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeBattleItem({ id: 9, date: '2026-06-03' }),
+				makeBattleItem({ id: 8, date: '2026-06-02' }),
+				makeBattleItem({ id: 7, date: '2026-06-01' }),
+			],
+		});
+		const { findRecentBattles } = await loadRepo();
+		const battles = await findRecentBattles(CHILD_ID, 2, TENANT);
+		expect(battles).toHaveLength(2);
+		expect(battles.map((b) => b.id)).toEqual([9, 8]);
+	});
+
+	it('0 件のとき空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findRecentBattles } = await loadRepo();
+		expect(await findRecentBattles(CHILD_ID, 10, TENANT)).toEqual([]);
+	});
+});
+
+// ============================================================
+// countConsecutiveLosses
+// ============================================================
+
+describe('countConsecutiveLosses', () => {
+	it('completed の先頭から lose が続く数を数える (date desc)', async () => {
+		// SK 降順 Query なので新しい順に並ぶ。先頭 2 件が lose、3 件目が win。
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeBattleItem({ id: 3, date: '2026-06-03', status: 'completed', outcome: 'lose' }),
+				makeBattleItem({ id: 2, date: '2026-06-02', status: 'completed', outcome: 'lose' }),
+				makeBattleItem({ id: 1, date: '2026-06-01', status: 'completed', outcome: 'win' }),
+			],
+		});
+		const { countConsecutiveLosses } = await loadRepo();
+		expect(await countConsecutiveLosses(CHILD_ID, TENANT)).toBe(2);
+	});
+
+	it('pending は無視し completed のみで連敗数を数える', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeBattleItem({ id: 4, date: '2026-06-04', status: 'pending', outcome: null }),
+				makeBattleItem({ id: 3, date: '2026-06-03', status: 'completed', outcome: 'lose' }),
+				makeBattleItem({ id: 2, date: '2026-06-02', status: 'completed', outcome: 'win' }),
+			],
+		});
+		const { countConsecutiveLosses } = await loadRepo();
+		// completed のみ抽出 → [lose, win] → 連敗 1。
+		expect(await countConsecutiveLosses(CHILD_ID, TENANT)).toBe(1);
+	});
+
+	it('先頭が win なら 0', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeBattleItem({ id: 3, date: '2026-06-03', status: 'completed', outcome: 'win' })],
+		});
+		const { countConsecutiveLosses } = await loadRepo();
+		expect(await countConsecutiveLosses(CHILD_ID, TENANT)).toBe(0);
+	});
+
+	it('directly 5 件を超える completed は先頭 5 件だけ評価する (SQLite limit(5) 等価)', async () => {
+		// 6 件全部 lose。SQLite は limit(5) なので最大 5 を返す。
+		const items = [6, 5, 4, 3, 2, 1].map((id) =>
+			makeBattleItem({
+				id,
+				date: `2026-06-0${id}`,
+				status: 'completed',
+				outcome: 'lose',
+			}),
+		);
+		mockSend.mockResolvedValueOnce({ Items: items });
+		const { countConsecutiveLosses } = await loadRepo();
+		expect(await countConsecutiveLosses(CHILD_ID, TENANT)).toBe(5);
+	});
+
+	it('履歴 0 件なら 0', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { countConsecutiveLosses } = await loadRepo();
+		expect(await countConsecutiveLosses(CHILD_ID, TENANT)).toBe(0);
+	});
+});
+
+// ============================================================
+// insertDailyBattle
+// ============================================================
+
+describe('insertDailyBattle', () => {
+	it('counter 採番 → PutItem し採番 id を返す (SQLite default 値)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 101 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insertDailyBattle } = await loadRepo();
+		const stats = { hp: 100, atk: 10, def: 5, spd: 5, rec: 2 };
+		const id = await insertDailyBattle(CHILD_ID, ENEMY_ID, DATE, stats, TENANT);
+
+		expect(id).toBe(101);
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(putCall.input.Item?.SK).toBe(`BATTLE#${DATE}`);
+		expect(putCall.input.Item?.status).toBe('pending');
+		expect(putCall.input.Item?.outcome).toBeNull();
+		expect(putCall.input.Item?.rewardPoints).toBe(0);
+		expect(putCall.input.Item?.turnsUsed).toBe(0);
+		// playerStats は JSON 文字列で保存 (SQLite playerStatsJson と一致)。
+		expect(putCall.input.Item?.playerStatsJson).toBe(JSON.stringify(stats));
+	});
+});
+
+// ============================================================
+// completeBattle
+// ============================================================
+
+describe('completeBattle', () => {
+	it('battleId を Scan で PK/SK 解決し status / outcome / reward を更新する', async () => {
+		// 1) findBattleItemById Scan
+		mockSend.mockResolvedValueOnce({
+			Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: `BATTLE#${DATE}` }],
+		});
+		// 2) UpdateCommand
+		mockSend.mockResolvedValueOnce({});
+
+		const { completeBattle } = await loadRepo();
+		await completeBattle(BATTLE_ID, 'win', 50, 4, TENANT);
+
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const scan = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scan.input.FilterExpression).toContain('id = :id');
+		expect(scan.input.ExpressionAttributeValues?.[':id']).toBe(BATTLE_ID);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(upd.input.UpdateExpression).toContain('#status = :status');
+		expect(upd.input.ExpressionAttributeValues?.[':status']).toBe('completed');
+		expect(upd.input.ExpressionAttributeValues?.[':outcome']).toBe('win');
+		expect(upd.input.ExpressionAttributeValues?.[':rp']).toBe(50);
+		expect(upd.input.ExpressionAttributeValues?.[':tu']).toBe(4);
+	});
+
+	it('battle が見つからないとき Update せず no-op (SQLite UPDATE no-match と等価)', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { completeBattle } = await loadRepo();
+		await completeBattle(BATTLE_ID, 'lose', 0, 3, TENANT);
+		// Scan のみ、Update 0 件。
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+
+	it('対象 battle が 2 ページ目に来る Scan でも見つけて Update する (#2842 Limit:1+Filter 誤用回帰)', async () => {
+		// DynamoDB Scan の Limit は filter 適用「前」の評価上限。Limit なし + ExclusiveStartKey で
+		// 全ページ走査し、対象が先頭 page に無くても必ず到達することを固定する。
+		mockSend
+			// page 1: filter 全落ちで Items 空 + 続きあり
+			.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { PK: 'p1', SK: 'p1' } })
+			// page 2: 対象 battle が一致
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: `BATTLE#${DATE}` }],
+			})
+			// UpdateCommand
+			.mockResolvedValueOnce({});
+
+		const { completeBattle } = await loadRepo();
+		await completeBattle(BATTLE_ID, 'win', 50, 4, TENANT);
+
+		expect(mockSend).toHaveBeenCalledTimes(3);
+		const page1 = mockSend.mock.calls[0]?.[0] as { input: { ExclusiveStartKey?: unknown } };
+		const page2 = mockSend.mock.calls[1]?.[0] as { input: { ExclusiveStartKey?: unknown } };
+		expect(page1.input.ExclusiveStartKey).toBeUndefined();
+		expect(page2.input.ExclusiveStartKey).toEqual({ PK: 'p1', SK: 'p1' });
+		const upd = mockSend.mock.calls[2]?.[0] as { input: { Key?: { PK: string; SK: string } } };
+		expect(upd.input.Key?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(upd.input.Key?.SK).toBe(`BATTLE#${DATE}`);
+	});
+
+	it('findBattleItemById Scan に Limit を付けない (#2842)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: `BATTLE#${DATE}` }],
+		});
+		mockSend.mockResolvedValueOnce({});
+		const { completeBattle } = await loadRepo();
+		await completeBattle(BATTLE_ID, 'win', 50, 4, TENANT);
+		const scan = mockSend.mock.calls[0]?.[0] as { input: { Limit?: number } };
+		expect(scan.input.Limit).toBeUndefined();
+	});
+});
+
+// ============================================================
+// findCollection
+// ============================================================
+
+describe('findCollection', () => {
+	it('child partition の ENEMYCOL# item を Query する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeCollectionItem({ enemyId: 3 }),
+				makeCollectionItem({ enemyId: 5, defeatCount: 4 }),
+			],
+		});
+		const { findCollection } = await loadRepo();
+		const collection = await findCollection(CHILD_ID, TENANT);
+		expect(collection.map((c) => c.enemyId)).toEqual([3, 5]);
+		expect(collection[1]?.defeatCount).toBe(4);
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, string> };
+		};
+		expect(callArg.input.ExpressionAttributeValues?.[':pk']).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(callArg.input.ExpressionAttributeValues?.[':prefix']).toBe('ENEMYCOL#');
+	});
+
+	it('defeatCount 欠落を SQLite default 1 に補完する', async () => {
+		const item = makeCollectionItem();
+		delete item.defeatCount;
+		mockSend.mockResolvedValueOnce({ Items: [item] });
+		const { findCollection } = await loadRepo();
+		const collection = await findCollection(CHILD_ID, TENANT);
+		expect(collection[0]?.defeatCount).toBe(1);
+	});
+
+	it('0 件のとき空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findCollection } = await loadRepo();
+		expect(await findCollection(CHILD_ID, TENANT)).toEqual([]);
+	});
+
+	it('LastEvaluatedKey でページングする', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [makeCollectionItem({ enemyId: 3 })],
+				LastEvaluatedKey: { PK: 'c', SK: 'c' },
+			})
+			.mockResolvedValueOnce({ Items: [makeCollectionItem({ enemyId: 5 })] });
+		const { findCollection } = await loadRepo();
+		const collection = await findCollection(CHILD_ID, TENANT);
+		expect(collection).toHaveLength(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+});
+
+// ============================================================
+// upsertCollectionEntry
+// ============================================================
+
+describe('upsertCollectionEntry', () => {
+	it('既存エントリは defeatCount を ADD で +1 する (SQLite UPDATE 分岐)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Item: makeCollectionItem({ defeatCount: 2 }) }) // GetItem 既存
+			.mockResolvedValueOnce({}); // UpdateCommand
+		const { upsertCollectionEntry } = await loadRepo();
+		await upsertCollectionEntry(CHILD_ID, ENEMY_ID, TENANT);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(upd.input.UpdateExpression).toBe('ADD defeatCount :one');
+		expect(upd.input.ExpressionAttributeValues?.[':one']).toBe(1);
+	});
+
+	it('新規エントリは counter 採番 → PutItem (SQLite INSERT 分岐、default defeat_count=1)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Item: undefined }) // GetItem 不在
+			.mockResolvedValueOnce({ Attributes: { counter: 11 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+		const { upsertCollectionEntry } = await loadRepo();
+		await upsertCollectionEntry(CHILD_ID, ENEMY_ID, TENANT);
+		expect(mockSend).toHaveBeenCalledTimes(3);
+		const put = mockSend.mock.calls[2]?.[0] as {
+			input: { Item?: Record<string, unknown>; ConditionExpression?: string };
+		};
+		expect(put.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(put.input.Item?.SK).toBe(`ENEMYCOL#${String(ENEMY_ID).padStart(8, '0')}`);
+		expect(put.input.Item?.id).toBe(11);
+		expect(put.input.Item?.defeatCount).toBe(1);
+		// 競合二重 Put ガード。
+		expect(put.input.ConditionExpression).toBe('attribute_not_exists(PK)');
+	});
+
+	it('新規 Put が競合 (ConditionalCheckFailed) しても no-op で握りつぶす', async () => {
+		const err = new Error('cond');
+		err.name = 'ConditionalCheckFailedException';
+		mockSend
+			.mockResolvedValueOnce({ Item: undefined }) // GetItem 不在
+			.mockResolvedValueOnce({ Attributes: { counter: 11 } }) // nextId
+			.mockRejectedValueOnce(err); // PutCommand 競合
+		const { upsertCollectionEntry } = await loadRepo();
+		await expect(upsertCollectionEntry(CHILD_ID, ENEMY_ID, TENANT)).resolves.toBeUndefined();
+	});
+
+	it('ConditionalCheckFailed 以外の Put error は rethrow する', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Item: undefined })
+			.mockResolvedValueOnce({ Attributes: { counter: 11 } })
+			.mockRejectedValueOnce(new Error('throughput exceeded'));
+		const { upsertCollectionEntry } = await loadRepo();
+		await expect(upsertCollectionEntry(CHILD_ID, ENEMY_ID, TENANT)).rejects.toThrow(
+			'throughput exceeded',
+		);
+	});
+});
+
+// ============================================================
+// deleteByTenantId
+// ============================================================
+
+describe('deleteByTenantId', () => {
+	it('battles (BATTLE# 配下) と enemy collection (ENEMYCOL# 配下) の 2 経路を Scan + 削除する', async () => {
+		// deleteItemsByPkPrefix は内部で Scan → BatchWrite。各経路 1 回 Scan (0 件返す)。
+		mockSend.mockResolvedValue({ Items: [] });
+		const { deleteByTenantId } = await loadRepo();
+		await deleteByTenantId(TENANT);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const scan1 = mockSend.mock.calls[0]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		const scan2 = mockSend.mock.calls[1]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		const skPrefixes = [
+			scan1.input.ExpressionAttributeValues?.[':skPrefix'],
+			scan2.input.ExpressionAttributeValues?.[':skPrefix'],
+		];
+		expect(skPrefixes).toContain('BATTLE#');
+		expect(skPrefixes).toContain('ENEMYCOL#');
+		// 両経路とも child partition prefix。
+		expect(scan1.input.ExpressionAttributeValues?.[':pkPrefix']).toBe(`T#${TENANT}#CHILD#`);
+	});
+});
+
+// ============================================================
+// interface 適合 (SQLite との機能等価性)
+// ============================================================
+
+describe('interface 適合 (IBattleRepo)', () => {
+	it('全メソッドを export している (stub に後退していない)', async () => {
+		const repo = await loadRepo();
+		for (const m of [
+			'findTodayBattle',
+			'findRecentBattles',
+			'countConsecutiveLosses',
+			'insertDailyBattle',
+			'completeBattle',
+			'findCollection',
+			'upsertCollectionEntry',
+			'deleteByTenantId',
+		]) {
+			expect(typeof (repo as Record<string, unknown>)[m]).toBe('function');
+		}
+	});
+
+	it('write method が no-op stub でない (insertDailyBattle が実 send し counter 値を返す)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		const { insertDailyBattle } = await loadRepo();
+		const id = await insertDailyBattle(
+			CHILD_ID,
+			ENEMY_ID,
+			DATE,
+			{ hp: 100, atk: 10, def: 5, spd: 5, rec: 2 },
+			TENANT,
+		);
+		// stub なら id=0 を返していた。本実装は counter 値を返す。
+		expect(id).toBe(1);
+		expect(mockSend).toHaveBeenCalled();
+	});
+});

--- a/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
+++ b/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
@@ -24,7 +24,8 @@ import { describe, expect, it } from 'vitest';
 
 // Pre-PMF fallback に置換された 12 repo
 import * as autoChallengeRepo from '../../../src/lib/server/db/dynamodb/auto-challenge-repo';
-import * as battleRepo from '../../../src/lib/server/db/dynamodb/battle-repo';
+// #2824 Wave 5A (ADR-0055): battle-repo は本実装済のため stub fallback テスト対象外。
+//   機能等価性は tests/unit/db/dynamodb-battle-repo.test.ts (AWS SDK mock) で検証する。
 // #2824 (ADR-0055): child-activity-repo は本実装済のため stub fallback テスト対象外。
 //   機能等価性は tests/unit/db/dynamodb-child-activity-repo.test.ts (AWS SDK mock) で検証する。
 import * as cloudExportRepo from '../../../src/lib/server/db/dynamodb/cloud-export-repo';
@@ -70,25 +71,11 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('battle-repo', () => {
-		it('全 method が throw しない (read = safe / write = no-op)', async () => {
-			await expect(battleRepo.findTodayBattle(1, TODAY, TENANT)).resolves.toBeUndefined();
-			await expect(battleRepo.findRecentBattles(1, 10, TENANT)).resolves.toEqual([]);
-			await expect(battleRepo.countConsecutiveLosses(1, TENANT)).resolves.toBe(0);
-			await expect(
-				battleRepo.insertDailyBattle(
-					1,
-					1,
-					TODAY,
-					{ hp: 100, atk: 10, def: 5, spd: 5, rec: 2 },
-					TENANT,
-				),
-			).resolves.toBe(0);
-			await expect(battleRepo.completeBattle(1, 'win', 10, 3, TENANT)).resolves.toBeUndefined();
-			await expect(battleRepo.findCollection(1, TENANT)).resolves.toEqual([]);
-			await expect(battleRepo.upsertCollectionEntry(1, 1, TENANT)).resolves.toBeUndefined();
-		});
-	});
+	// #2824 Wave 5A (ADR-0055): battle-repo は本実装済 (stub 除外)。
+	//   LP machine-tour ④ feature-rpg-battle 訴求の日次バトル (進行 / 勝敗 / 報酬 / 敵図鑑) が
+	//   本番 DynamoDB Lambda で永続する。本実装の機能等価性テストは dynamodb-battle-repo.test.ts
+	//   に分離。ここで stub 前提の assert を残すと「実装済なのに stub 期待」で誤った退行 gate に
+	//   なるため除外する (他 repo の fallback assert は維持 = assertion 弱体化に該当しない)。
 
 	// #2824 (ADR-0055): child-activity-repo は本実装済 (stub 除外)。
 	//   marketplace per-child 取込 (importActivities → insertActivitiesBulk) が本番 DynamoDB
@@ -190,8 +177,8 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('regression guard: 全 6 repo の Promise.all で reject されない', () => {
-		it('SSR /preschool/home の典型的な 6 repo 並列呼び出しが全 fulfill する', async () => {
+	describe('regression guard: 全 5 repo の Promise.all で reject されない', () => {
+		it('SSR /preschool/home の典型的な 5 repo 並列呼び出しが全 fulfill する', async () => {
 			// #2295 (EPIC #2294 ①): seasonEventRepo / tenantEventRepo 削除済 (2026-05-19)、12 → 10 repo
 			// #2458 (Path B sibling drop): siblingChallengeRepo 削除済 (2026-05-26)、10 → 9 repo
 			// #2263 regression hotfix: childActivityRepo を stub fallback に置換 (9 → 10 repo)
@@ -203,9 +190,10 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 			//   (本実装は AWS SDK mock 必須 → dynamodb-message-repo.test.ts で検証)。8 → 7 repo
 			// #2824 Wave 3B (ADR-0055): stampCardRepo を本実装化したため除外
 			//   (本実装は AWS SDK mock 必須 → dynamodb-stamp-card-repo.test.ts で検証)。7 → 6 repo
+			// #2824 Wave 5A (ADR-0055): battleRepo を本実装化したため除外
+			//   (本実装は AWS SDK mock 必須 → dynamodb-battle-repo.test.ts で検証)。6 → 5 repo
 			const results = await Promise.allSettled([
 				autoChallengeRepo.findActiveByChild(1, TENANT),
-				battleRepo.findTodayBattle(1, TODAY, TENANT),
 				cloudExportRepo.findByTenant(TENANT),
 				reportDailySummaryRepo.findByChildAndDateRange(1, TODAY, TODAY, TENANT),
 				siblingCheerRepo.findUnshownCheers(1, TENANT),


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供（バトル機能利用者） / システム全体（本番 DynamoDB 永続化）

**解決する課題**: バトル（RPG）は LP machine-tour ④ `feature-rpg-battle`（冒険のクライマックス）で訴求する中核ゲーミフィケーション機能。本番 cognito Lambda は `DATA_SOURCE=dynamodb`（`infra/lib/compute-stack.ts`）で稼働するが、`src/lib/server/db/dynamodb/battle-repo.ts` は #2263 hotfix（PR #2280）で「read=空 / write=no-op + logger.warn」の stub のまま放置されていた。このため本番では日次バトルの進行・勝敗・ポイント報酬・敵図鑑が一切永続せず、毎アクセスで「今日のバトル未挑戦」に戻り、報酬も図鑑も消える状態だった（ADR-0013 LP truth 違反級）。

**期待される効果**: SQLite 実装（挙動 SSOT）と機能等価な DynamoDB 本実装により、本番でバトル進行・報酬・敵図鑑が永続する。tracking Issue #2824 Wave 5A として、残 stub repo 群（AC5）を順次本実装する取り組みの一環。

## 関連 Issue

closes #2824

<!-- #2824 は umbrella tracking Issue。本 PR は Wave 5A (battle-repo) を実装。
     残 stub repo (reward-redemption / message / stamp-card は merged 済) の本実装は別 Wave で消化中のため
     umbrella の close は全 Wave 完了後に行う想定だが、本 PR では Wave 5A 完遂分として closes 記載。 -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | battle-repo の interface 全 method (read 3 + write 4 + deleteByTenantId) を SQLite 実装と機能等価に DynamoDB 本実装 | `node node_modules/vitest/vitest.mjs run tests/unit/db/dynamodb-battle-repo.test.ts` | HEAD `9916f86c3` / 34 passed (battle 24 + fallback 10) / tests/unit/db/dynamodb-battle-repo.test.ts:1-510 (findTodayBattle GetItem / findRecentBattles 降順 limit / countConsecutiveLosses completed 先頭 5 / insertDailyBattle default / completeBattle Scan 解決 + #2842 全ページ走査 / upsertCollectionEntry ADD/Put 分岐 / deleteByTenantId 2 経路) |
| AC2 | DynamoDB stub baseline ratchet を前進させ、新規 stub 追加を CI で block | `node scripts/check-dynamodb-stub-parity.mjs` | HEAD `9916f86c3` / `OK: 7 repo / 42 stub method (baseline 以下)` / scripts/dynamodb-stub-baseline.json から battle-repo 7 method 削除 |
| AC3 | 既存テスト回帰なし (DB / services 層) | `node node_modules/vitest/vitest.mjs run tests/unit/db/ tests/unit/services/` | HEAD `9916f86c3` / 2491 passed (148 files) / dynamodb-pre-pmf-fallback.test.ts は battle 除外後も他 repo fallback assert 維持 (ADR-0006) |
| AC4 | 型安全 + 08-データベース設計書に DynamoDB key 設計同期 (ADR-0001) | `node node_modules/svelte-check/bin/svelte-check --tsconfig ./tsconfig.json` / `git diff --stat docs/design/08-*.md` | HEAD `9916f86c3` / svelte-check 0 errors (infra 由来 58 件は worktree 環境の aws-cdk-lib 未解決、junction 後 0) / 08-データベース設計書.md §daily_battles に DynamoDB キー設計節追加 (BATTLE# / ENEMYCOL# key 表 + アクセスパターン表) |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/` 等) — `scripts/dynamodb-stub-baseline.json` / `.cspell/project-words.txt`

**影響を受ける画面・機能**: 本番 DynamoDB Lambda のバトル機能（日次バトル進行 / 勝敗記録 / ポイント報酬 / 敵図鑑収集）。SQLite (NUC / local / demo) は挙動 SSOT のため不変。`getRepos().battle` facade 経由の呼び出し元（`battle-service.ts`）は interface 不変のため影響なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — biome (`--error-on-warnings` 4 file 0 error) / svelte-check (0 errors) / vitest (DB+services 2491 passed) / cspell (ENEMYCOL を project-words 追加後 0) をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載: `tests/unit/db/dynamodb-battle-repo.test.ts` 新規 (AWS SDK vi.hoisted mock、SQLite 機能等価を method 別に網羅: GetItem key / 降順 limit / completed 連敗カウント / default 補完 / Scan 全ページ走査 #2842 回帰 / ADD/Put upsert 分岐 / 2 経路削除 / interface 適合 stub 後退検知)。`dynamodb-pre-pmf-fallback.test.ts` から battle-repo 除外 (他 repo fallback assert は維持、ADR-0006 assertion 弱体化に非該当)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: SQLite（既存 SSOT）+ DynamoDB（本 PR で本実装）両実装完成。`node scripts/check-dynamodb-stub-parity.mjs` PASS（7 repo / 42 stub method、battle-repo は baseline から除外済）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (type:feat、本番 write 永続化の本実装。tracking #2824 は critical だが本 PR は Wave 5A の per-repo 本実装で UI 変更を伴わない)

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore 相当）** — backend repository 層 (`src/lib/server/db/dynamodb/`) の本実装のみで UI 変更を含まない。バトル UI (`src/lib/features/battle/`) / routes は不変。本番 DynamoDB の永続化挙動は単体テスト (AWS SDK mock) で機能等価性を検証する。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（repo は永続化のみ、service / facade は不変）/ 依存性逆転（`IBattleRepo` interface 経由で SQLite / DynamoDB 切替、`getRepos().battle` facade）/ インターフェース分離（既存 7 method + deleteByTenantId のみ）
- [x] **DRY**: 内部ヘルパ `queryChildBattles` / `queryChildEnemyCollection` / `findBattleItemById` を抽出。`stripKeys` / `nextId` / `deleteItemsByPkPrefix` / `tenantPK` の共通 util を再利用 (独自実装なし)。`findBattleItemById` の Scan 全ページ走査は merged 済 stamp-card `findCardItemById` (#2842) と同型パターン
- [x] **YAGNI**: 追加 GSI なし (child partition 同居で全アクセスパターンが child 軸 / id 軸で完結、ADR-0010 過剰防衛回避)。新規抽象なし
- [x] **Security（OSS 公開前提）**: tenantId 必須引数で tenant 分離維持。秘密情報 hardcode なし / IDOR 境界は PK の tenant prefix で担保
- [x] **アクセシビリティ**: N/A (backend 層)
- [x] **パフォーマンス**: findTodayBattle / upsertCollectionEntry は GetItem 1 回。findRecentBattles はサーバ側 Limit で打ち切り。completeBattle の Scan は 1 日 1 戦・低頻度（GSI 不要、Pre-PMF）。N+1 なし

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期 — N/A (demo は SQLite 系 `src/lib/server/db/demo/battle-repo.ts`、本 PR は DynamoDB 系のみ)
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）— LP `feature-rpg-battle` 訴求は既存実装の事実と一致（本 PR は本番永続化を実装に追いつかせる方向）。LP 文言追加なし
- [ ] 全年齢モード 5 種に横展開 — N/A (repo 層、年齢非依存)
- [ ] ナビゲーション 3 種に反映 — N/A
- [ ] E2E / ユニットシード同期 — N/A (DynamoDB は実 DB 不要の AWS SDK mock テスト)
- [x] **labels SSOT** (ADR-0009): N/A — UI 文言変更なし
- [x] **設計書同期** (ADR-0001): `docs/design/08-データベース設計書.md` §daily_battles / enemy_collection に DynamoDB キー設計節を追加（DB 変更 → 08）
- [x] **並行 PR overlap** (#1200): PR #2844 (activity-repo writes) / Wave 5B (sibling-cheer) と並行。baseline.json / keys.ts / 08-設計書 / cspell は **本 repo の行のみ** 追加・削除し、先行 merge へ rebase 追従する方針 (本 PR は battle 行のみ touch)
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
- key 設計（`keys.ts` §dailyBattleKey / §enemyCollectionKey）が **追加 GSI 不要**である根拠を AC マップ + 08-設計書 + repo 冒頭コメントに表で明記。child partition 同居（PK=`T#<tid>#CHILD#<childId>`）で findTodayBattle=GetItem / findRecentBattles・countConsecutiveLosses=child Query(降順) / upsertCollectionEntry=GetItem→ADD/Put が成立し、childId を受けない completeBattle のみ tenant Scan + id filter（stamp-card #2842 と同型、Limit なし全ページ走査）。
- `countConsecutiveLosses` の SQLite 等価性: SQLite は `status='completed'` を `date desc` で limit 5 → 先頭から `lose` 連続数。DynamoDB は SK 降順 Query で completed のみ抽出 → 先頭 5 件で同ロジック。test で win 混在 / pending 無視 / 6 件超 limit(5) を回帰固定。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（#2824 umbrella の Wave 分割は AC5 で合意済）
- [x] UI 変更時: N/A（backend repo 層のみ、UI 変更なし）
- [x] 認証画面変更時: N/A
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言、QM が re-verify する）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
