### PR TITLE
fix: #2851 setup-resume-path.spec の reward_templates seed snapshot/restore (test isolation regression)

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -254,6 +254,7 @@ CI 自動チェック (`scripts/check-schema-change-tests.mjs`、warn): `schema.
 - DB スキーマ変更時は `tests/e2e/global-setup.ts` のテストデータ投入も更新
 - 全 4 年齢コアモード (preschool/elementary/junior/senior) のテストデータ必要
 - 活動記録の完全フロー (確認→記録→コンボ→スタンプ→レベルアップ→ホーム復帰) を検証
+- **worker DB 共有 spec が seed 済 setting を削除する場合、削除前 snapshot + afterAll で復元が必須** (#2851、`features.spec.ts` #0025 が `templates.length > 0` を要求する `reward_templates` を `setup-resume-path.spec.ts` が削除したまま終了し決定的 fail した教訓)。afterAll で「自分が追加した値」を消すだけでは seed 値が復元されず不十分。beforeAll で削除前の seed 値を `SELECT` で退避し、afterAll で `INSERT OR REPLACE` (snapshot 非 null) / `DELETE` (snapshot null) で元の seed 状態へ完全復元する
 
 ## プラン別 seed fixture（#759）
 

--- a/tests/e2e/setup-resume-path.spec.ts
+++ b/tests/e2e/setup-resume-path.spec.ts
@@ -11,7 +11,12 @@
 // reward_templates / onboarding_child_screen_visited を書き換えると ambient な onboarding
 // 状態が非決定になるため、各 test 前に worker DB を直接操作して **必ず「進行中 (未完了)」
 // 状態に固定** する (rewards 設定 + child_screen フラグを削除)。完了状態の検証時のみ
-// additive に設定を書き、最後に afterAll で除去して sibling spec への影響を残さない。
+// additive に設定を書く。
+//
+// #2851: 本 spec は global-setup が seed した reward_templates を削除する。afterAll で
+// 「削除した値」を消すだけでは seed 値が復元されず、同 worker 後続 spec
+// (features.spec.ts #0025 が templates.length > 0 を要求) が決定的に fail していた。
+// beforeAll で削除前の seed 値を snapshot し、afterAll で元の seed 状態へ完全復元する。
 //
 // act → outcome (#2544 / tests/CLAUDE.md): バナー表示だけでなく「CTA click → 別画面に着地
 // (URL 変化) → そこに文脈バナーが出る」= dead-end ゼロを assert する。
@@ -37,6 +42,47 @@ function forceOnboardingIncomplete(dbPath: string): void {
 	}
 }
 
+// #2851: 削除前の seed 値スナップショット。`null` = その key が settings に存在しなかった。
+type SettingsSnapshot = { reward: string | null; childScreen: string | null };
+
+// 削除/書換の前に、worker DB の現在値 (global-setup が seed した reward_templates 等) を退避する。
+function snapshotOnboardingSettings(dbPath: string): SettingsSnapshot {
+	const db = openDb(dbPath);
+	try {
+		const read = (key: string): string | null => {
+			const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as
+				| { value: string }
+				| undefined;
+			return row ? row.value : null;
+		};
+		return { reward: read(REWARD_KEY), childScreen: read(CHILD_SCREEN_KEY) };
+	} finally {
+		db.close();
+	}
+}
+
+// スナップショットした seed 値を worker DB に書き戻す (非 null は INSERT OR REPLACE、null は DELETE)。
+// sibling spec (features.spec.ts #0025 が reward_templates 由来の templates.length > 0 を要求) への
+// 影響を残さないため、afterAll で元の seed 状態へ完全復元する。
+function restoreOnboardingSettings(dbPath: string, snapshot: SettingsSnapshot): void {
+	const db = openDb(dbPath);
+	try {
+		const apply = (key: string, value: string | null): void => {
+			if (value === null) {
+				db.prepare('DELETE FROM settings WHERE key = ?').run(key);
+			} else {
+				db.prepare(
+					'INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)',
+				).run(key, value);
+			}
+		};
+		apply(REWARD_KEY, snapshot.reward);
+		apply(CHILD_SCREEN_KEY, snapshot.childScreen);
+	} finally {
+		db.close();
+	}
+}
+
 // onboarding を完了させる (不足していた required item を満たす)。
 function forceOnboardingComplete(dbPath: string): void {
 	const db = openDb(dbPath);
@@ -57,10 +103,27 @@ function forceOnboardingComplete(dbPath: string): void {
 // AWS / cognito 環境では local テナント seed / settings 直接操作が成立しないため未登録。
 if (!isAwsEnv()) {
 	test.describe('#2821 セットアップ再開導線 (SetupResumeBanner)', () => {
-		// sibling spec への影響を残さないため additive 設定を後始末する。
+		// #2851: 最初の削除前に worker DB の seed 値 (reward_templates 等) を退避し、
+		// afterAll で元の seed 状態へ完全復元する。これがないと本 spec が seed 済設定を
+		// 削除したまま終了し、同 worker 後続 spec (features.spec.ts #0025 が
+		// templates.length > 0 を要求) が決定的に fail する。
+		let seedSnapshot: SettingsSnapshot | null = null;
+
+		test.beforeAll(({ workerDbPath }) => {
+			try {
+				seedSnapshot = snapshotOnboardingSettings(workerDbPath);
+			} catch {
+				// DB 未生成 (全 skip 等) は無視。
+				seedSnapshot = null;
+			}
+		});
+
+		// sibling spec への影響を残さないため、本 spec が削除/書換した seed 設定を元へ復元する。
 		test.afterAll(({ workerDbPath }) => {
 			try {
-				forceOnboardingIncomplete(workerDbPath);
+				if (seedSnapshot) {
+					restoreOnboardingSettings(workerDbPath, seedSnapshot);
+				}
 			} catch {
 				// DB 未生成 (全 skip 等) は無視。
 			}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者・CI）

**解決する課題**: PR #2835 で追加された `tests/e2e/setup-resume-path.spec.ts` が `forceOnboardingIncomplete` で global-setup の seed した `reward_templates` / `onboarding_child_screen_visited` を削除し、`afterAll` が「自分が追加した値」を消すだけで seed 値を復元しないため、同一 worker DB を共有する後続 spec（`features.spec.ts` #0025 = `templates.length > 0` を要求）が決定的に fail していた。

**期待される効果**: test isolation を回復し、E2E shard の worker 分配順に依存しない安定したテスト実行を担保する。CI flake / 偽陰性を根絶する。

## 関連 Issue

closes #2851

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 削除前に `reward_templates` / `onboarding_child_screen_visited` の seed 値を snapshot する | `tests/e2e/setup-resume-path.spec.ts` の `snapshotOnboardingSettings` + `beforeAll` | HEAD `3f9ef62b1` / `tests/e2e/setup-resume-path.spec.ts:49-62`（`SELECT value FROM settings WHERE key=?`）+ `:112-118`（`beforeAll` で snapshot） |
| AC2 | `afterAll` で snapshot 値を復元（非 null は INSERT OR REPLACE / null は DELETE）。per-test forcing は維持 | `restoreOnboardingSettings` + `afterAll` | HEAD `3f9ef62b1` / `tests/e2e/setup-resume-path.spec.ts:67-84`（INSERT OR REPLACE / DELETE 分岐）+ `:121-131`（`afterAll` で restore）。`forceOnboardingIncomplete`/`forceOnboardingComplete` は `:36-43` / `:87-101` で不変維持 |
| AC3 | 両 spec が同一 worker で green（features #0025 = `templates.length > 0` 回復） | `npx playwright test tests/e2e/setup-resume-path.spec.ts tests/e2e/features.spec.ts --workers=1 --project=tablet` | HEAD `3f9ef62b1` / `#0025 テンプレート一覧 API が 200 を返す` = **passed**（4/4 #0025 passed）+ setup-resume 3/3 passed。下記「テスト実行結果」参照 |
| AC4 | tests/CLAUDE.md に worker DB 共有 spec の snapshot/restore 必須ルールを追記 | `tests/CLAUDE.md` §「E2E 固有」 | HEAD `3f9ef62b1` / `tests/CLAUDE.md:257`（「worker DB 共有 spec が seed 済 setting を削除する場合、削除前 snapshot + afterAll で復元が必須」#2851） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI（`tests/e2e/` E2E spec + `tests/CLAUDE.md`）

**影響を受ける画面・機能**: E2E テストのみ（アプリ本体コードへの影響なし）。`tests/e2e/setup-resume-path.spec.ts` + 同一 worker DB を共有する全 spec（特に `features.spec.ts` #0025）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）: test-only 変更のため本 worktree では AC3 の targeted playwright 回帰 + `npx biome check tests/e2e/setup-resume-path.spec.ts`（PASS、無出力）を直接実行済。Ready 化時に pre-ready 一括を実行する
- [x] 追加・変更したテストの概要: `tests/e2e/setup-resume-path.spec.ts` に `snapshotOnboardingSettings` / `restoreOnboardingSettings` + `beforeAll`/`afterAll` の seed snapshot/restore を追加。per-test の onboarding forcing ロジックは不変
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:critical ではない test isolation fix）

### テスト実行結果

`npx playwright test tests/e2e/setup-resume-path.spec.ts tests/e2e/features.spec.ts --workers=1 --project=tablet`（HEAD `3f9ef62b1`、local dev webServer）:

- **`#0025: 特別報酬 API › テンプレート一覧 API が 200 を返す` = passed**（修正対象の決定的 fail テスト）。`#0025` 4/4 passed
- `setup-resume-path.spec.ts` AC1/AC2/AC4 = 3/3 passed
- 全体 65 passed / 1 failed。failed は `#0029 Baby ホーム画面が表示される`（`/switch` 子供選択 navigation timeout、実行中に vite「optimized dependencies changed. reloading」が出た local dev-server HMR reload race）で seed/settings とは無関係。単独再実行で **passed**（12.3s）であることを確認済み

## スクリーンショット / ビジュアルデモ

**該当なし（test-only 変更。アプリ UI に差分なし）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: snapshot / restore を独立した純粋関数に分離（単一責任）。`SettingsSnapshot` 型で I/O 契約を明示
- [x] **DRY**: 既存 `forceOnboardingIncomplete` / `forceOnboardingComplete` の DB 接続パターン（`openDb` + try/finally close）を踏襲。同種の「seed 削除して復元しない」spec が他に無いか確認済み（本 spec のみ）
- [x] **YAGNI**: 対象 2 key（`reward_templates` / `onboarding_child_screen_visited`）のみを snapshot。汎用 settings 全 dump はしない
- [x] **Security（OSS 公開前提）**: テスト DB の settings 操作のみ。秘密情報なし
- [x] **アクセシビリティ**: N/A（test コード）
- [x] **パフォーマンス**: snapshot/restore は describe あたり各 1 回（beforeAll/afterAll）。per-test オーバーヘッドなし

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードと チュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [ ] **設計書同期** (ADR-0001)
- [ ] **並行 PR overlap** (#1200)
- [x] N/A — test isolation のみ。アプリ実装・seed データ定義への変更なし（seed 値は復元され元と等価）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**: `afterAll` の復元が「削除した値を消す」から「snapshot を書き戻す」に変わった点が主眼。snapshot が null（seed に当該 key 不在）の場合は DELETE で「不在状態」も忠実に復元する設計。`#0029 Baby ホーム` の 1 failed は本変更と無関係な local dev-server HMR reload race（単独 passed で確認済）である点をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した: test-only のため AC3 targeted playwright 回帰 + biome check を直接実行（上記「テスト & 安全装置セルフチェック」参照）。pre-ready 一括は Ready 化時に実行する
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（残課題なし）
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A（test-only）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
