### PR TITLE
feat: #2824 Wave 6A — auto-challenge + certificate repo DynamoDB 本実装 (ADR-0055)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -67,6 +67,7 @@ arigatou
 arpu
 Arpu
 ARPU
+AUTOCHAL
 autocheckpoint
 autocomplete
 autodocs

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -838,6 +838,24 @@ CDK (`infra/lib/storage-stack.ts`) の `MainTable` は単一テーブル設計 (
 - `category_master_CODE` — カテゴリマスター（★5到達）
 - `annual_YYYY` — 年間がんばり大賞
 
+#### DynamoDB キー設計（single-table、#2824 Wave 6A / ADR-0055）
+
+本番 cognito Lambda は `DATA_SOURCE=dynamodb` で稼働するため、SQLite と機能等価の DynamoDB 実装
+(`src/lib/server/db/dynamodb/certificate-repo.ts`) を持つ。per-child instance を child partition に
+同居させ、SK に certificate_type を採ることで uniqueIndex(child_id, tenant_id, certificate_type) を
+SK 一意性で表現する（**追加 GSI なし**、ADR-0055 §3.1）。
+
+| エンティティ | PK | SK | 補足 |
+|---|---|---|---|
+| certificates | `T#<tid>#CHILD#<childId>` | `CERT#<certificateType>` | certificate_type 一意 = SQLite uniqueIndex(child_id, tenant_id, certificate_type) と等価。special_rewards / activity_logs と同 partition に同居。`id` は属性として保持 |
+
+| アクセスパターン | 操作 | 条件 |
+|---|---|---|
+| `issueCertificate` | counter 採番 → PutItem（`attribute_not_exists(PK)`） | SQLite onConflictDoNothing 等価（同 (childId, certType) 既存なら ConditionalCheckFailed → null）。description / metadata 未指定は null |
+| `findCertificates(childId)` | Query | `PK = T#<tid>#CHILD#<childId> AND begins_with(SK, 'CERT#')`。issued_at 降順は in-memory（SQLite SSOT と一致） |
+| `findCertificateById(id)` | Scan（id filter）で 1 件特定 | childId を受けないため tenant Scan + id（message-repo と同型）。低頻度で GSI 不要（Pre-PMF / ADR-0010）。Scan は Limit なしページング（#2842） |
+| `hasCertificate(childId, certType)` | GetItem | `PK = T#<tid>#CHILD#<childId>, SK = CERT#<certificateType>`。SK 一意のため発行済み判定は単一 GetItem |
+
 ### ~~custom_achievements~~ — #1816 で物理削除済み（2026-05-01）
 
 #1782 (実績機能完全廃止) で service 削除済み、#1816 で DB schema / repo / type / 並行 test seed
@@ -1652,6 +1670,25 @@ child partition 配下に置き、`findMessages` / `findUnshownMessage` / `count
 
 **ユニーク制約:** idx_auto_challenges_child_week(child_id, week_start)
 **インデックス:** idx_auto_challenges_tenant(tenant_id), idx_auto_challenges_status(status)
+
+#### DynamoDB キー設計（single-table、#2824 Wave 6A / ADR-0055）
+
+本番 cognito Lambda は `DATA_SOURCE=dynamodb` で稼働するため、SQLite と機能等価の DynamoDB 実装
+(`src/lib/server/db/dynamodb/auto-challenge-repo.ts`) を持つ。per-child instance を child partition に
+同居させ `findByChildAndWeek` を**追加 GSI なし**の GetItem 1 回で完結させる（ADR-0055 §3.1）。
+
+| エンティティ | PK | SK | 補足 |
+|---|---|---|---|
+| auto_challenges | `T#<tid>#CHILD#<childId>` | `AUTOCHAL#<weekStart>` | weekStart 一意 = SQLite uniqueIndex(child_id, week_start) と等価。stamp_cards / activity_logs と同 partition に同居。`id` は属性として保持 |
+
+| アクセスパターン | 操作 | 条件 |
+|---|---|---|
+| `findByChildAndWeek(childId, weekStart)` | GetItem | `PK = T#<tid>#CHILD#<childId>, SK = AUTOCHAL#<weekStart>`。生成前の重複確認で頻出するため単一 GetItem |
+| `findActiveByChild(childId)` / `findByChild(childId, limit)` | Query | `PK = T#<tid>#CHILD#<childId> AND begins_with(SK, 'AUTOCHAL#')`。status='active' filter + week_start 降順 + limit は in-memory（SQLite SSOT と一致） |
+| `insert` | counter 採番 → PutItem | current_count default = 0 / status default = `active`（SQLite schema 一致） |
+| `update(id)` | Scan（id filter）で PK/SK 解決 → UpdateItem | childId を受けないため tenant Scan + id で 1 件特定（stamp-card-repo と同型）。status は予約語のため `#status` alias escape。週次・低頻度で GSI 不要（Pre-PMF / ADR-0010） |
+| `expireOldChallenges(beforeDate)` | Scan（status='active' AND week_start < before）→ UpdateItem | tenant 横断。child partition に分散するため Scan + 属性 filter（GSI 不要）。Scan は Limit なしページング（#2842） |
+| `deleteByTenantId` | Scan → BatchWrite | `CHILD#*` 配下の `AUTOCHAL#` を削除（`deleteItemsByPkPrefix`） |
 
 ### trial_history
 

--- a/scripts/dynamodb-stub-baseline.json
+++ b/scripts/dynamodb-stub-baseline.json
@@ -1,19 +1,4 @@
 {
-	"src/lib/server/db/dynamodb/auto-challenge-repo.ts": [
-		"deleteByTenantId",
-		"expireOldChallenges",
-		"findActiveByChild",
-		"findByChild",
-		"findByChildAndWeek",
-		"insert",
-		"update"
-	],
-	"src/lib/server/db/dynamodb/certificate-repo.ts": [
-		"findCertificateById",
-		"findCertificates",
-		"hasCertificate",
-		"issueCertificate"
-	],
 	"src/lib/server/db/dynamodb/cloud-export-repo.ts": [
 		"countByTenant",
 		"deleteById",

--- a/src/lib/server/db/dynamodb/auto-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/auto-challenge-repo.ts
@@ -1,88 +1,324 @@
-// DynamoDB implementation of IAutoChallengeRepo
+// src/lib/server/db/dynamodb/auto-challenge-repo.ts
+// 週次自動チャレンジリポジトリ — DynamoDB 本実装 (#2824 Wave 6A / ADR-0055)
 //
-// #2263 hotfix: 旧バージョンの未実装エラー throw で本番 500 を引き起こしうるため、
-// Pre-PMF fallback (read = 空 / write = no-op + logger.warn) に置換。
-// 自動チャレンジ機能は本番未活用 (ADR-0010 Pre-PMF Bucket B = まだ作らない)。
+// IAutoChallengeRepo を SQLite 実装 (sqlite/auto-challenge-repo.ts、挙動 SSOT) と
+// 機能等価に DynamoDB single-table で実装する。
+//
+// 経緯: 本 repo は #2263 hotfix で「read=空 / write=no-op + logger.warn」化された。
+//   自動チャレンジは週次 cron が生成し子供 home で進捗表示される機能であり、本番 cognito
+//   Lambda (AUTH_MODE=cognito + DATA_SOURCE=dynamodb) で生成・進捗が永続しないと毎週リセット
+//   されるため体験が成立しない。本実装で根治する。
+//
+// key 設計 (keys.ts §autoChallengeKey):
+//   PK = T#<tenantId>#CHILD#<childId>   (child partition、stamp_cards / activity_logs と同居)
+//   SK = AUTOCHAL#<weekStart>           (weekStart は child 内で一意)
+//   → findByChildAndWeek は GetItem 1 回で完結 (weekStart 一意 = SQLite
+//     uniqueIndex(child_id, week_start) と等価)。findActiveByChild / findByChild は
+//     単一 partition Query (begins_with(SK, 'AUTOCHAL#')) で完結し追加 GSI 不要 (ADR-0055 §3.1)。
+//   id だけで引く update と tenant 横断の expireOldChallenges は低頻度 (週次 cron) のため
+//   tenant Scan + filter で対象 PK/SK を解決する (stamp-card-repo / message-repo と同パターン)。
+//   Scan は ExclusiveStartKey で全ページ走査する (DynamoDB Scan の Limit は filter 適用「前」の
+//   評価件数上限なので Limit + Filter は対象が scan 順先頭でない限り空振りする。#2842 修正)。
+//
+// 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/auto-challenge-repo.ts (SSOT)
 
-import { logger } from '$lib/server/logger';
+import {
+	GetCommand,
+	PutCommand,
+	QueryCommand,
+	ScanCommand,
+	UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
 import type { AutoChallenge, InsertAutoChallengeInput, UpdateAutoChallengeInput } from '../types';
+import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
+import { autoChallengeKey, autoChallengePrefix, childPK, ENTITY_NAMES, tenantPK } from './keys';
+import { stripKeys } from './repo-helpers';
 
-const SERVICE = 'auto-challenge-repo.dynamodb';
+const PREFIX = autoChallengePrefix();
 
-function warnRead(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] read fallback: returning empty (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
+/** DynamoDB item を AutoChallenge に正規化する (PK/SK 除去 + default の補完)。 */
+function toAutoChallenge(item: Record<string, unknown>): AutoChallenge {
+	const s = stripKeys(item) as Record<string, unknown>;
+	return {
+		id: s.id as number,
+		childId: s.childId as number,
+		tenantId: s.tenantId as string,
+		weekStart: s.weekStart as string,
+		categoryId: s.categoryId as number,
+		targetCount: s.targetCount as number,
+		// SQLite schema default: current_count = 0 / status = 'active'
+		currentCount: (s.currentCount ?? 0) as number,
+		status: (s.status ?? 'active') as string,
+		createdAt: s.createdAt as string,
+		updatedAt: s.updatedAt as string,
+	};
 }
 
-function warnWrite(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] write fallback: no-op (Pre-PMF stub, #2263)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
-}
+// ============================================================
+// findByChildAndWeek — child + weekStart で 1 件取得 (GetItem)
+// ============================================================
 
 export async function findByChildAndWeek(
 	childId: number,
 	weekStart: string,
 	tenantId: string,
 ): Promise<AutoChallenge | undefined> {
-	warnRead('findByChildAndWeek', { childId, weekStart, tenantId });
-	return undefined;
+	const result = await getDocClient().send(
+		new GetCommand({
+			TableName: TABLE_NAME,
+			Key: autoChallengeKey(childId, weekStart, tenantId),
+		}),
+	);
+	if (!result.Item) return undefined;
+	return toAutoChallenge(result.Item);
 }
+
+// ============================================================
+// findActiveByChild — child の active チャレンジを 1 件取得 (最新 weekStart)
+// ============================================================
 
 export async function findActiveByChild(
 	childId: number,
 	tenantId: string,
 ): Promise<AutoChallenge | undefined> {
-	warnRead('findActiveByChild', { childId, tenantId });
-	return undefined;
+	const items = await queryChildChallenges(childId, tenantId);
+	// SQLite: WHERE status = 'active' ORDER BY week_start DESC LIMIT 1
+	const active = items
+		.map(toAutoChallenge)
+		.filter((c) => c.status === 'active')
+		.sort(compareWeekStartDesc);
+	return active[0];
 }
+
+// ============================================================
+// findByChild — child の全チャレンジを取得 (weekStart 降順)
+// ============================================================
 
 export async function findByChild(
 	childId: number,
 	tenantId: string,
-	limit?: number,
+	limit = 10,
 ): Promise<AutoChallenge[]> {
-	warnRead('findByChild', { childId, tenantId, limit });
-	return [];
+	const items = await queryChildChallenges(childId, tenantId);
+	// SQLite: ORDER BY week_start DESC LIMIT
+	const challenges = items.map(toAutoChallenge).sort(compareWeekStartDesc);
+	return challenges.slice(0, limit);
 }
+
+// ============================================================
+// insert — 自動チャレンジ新規作成
+// ============================================================
 
 export async function insert(
 	input: InsertAutoChallengeInput,
 	tenantId: string,
 ): Promise<AutoChallenge> {
-	warnWrite('insert', { childId: input.childId, tenantId });
+	const id = await nextId(ENTITY_NAMES.autoChallenge, tenantId);
 	const now = new Date().toISOString();
-	return {
-		id: 0,
+	const challenge: AutoChallenge = {
+		id,
 		childId: input.childId,
 		tenantId,
 		weekStart: input.weekStart,
 		categoryId: input.categoryId,
 		targetCount: input.targetCount,
+		// SQLite schema default
 		currentCount: 0,
 		status: 'active',
 		createdAt: now,
 		updatedAt: now,
 	};
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...autoChallengeKey(input.childId, input.weekStart, tenantId),
+				...challenge,
+			},
+		}),
+	);
+
+	return challenge;
 }
+
+// ============================================================
+// update — id で進捗 / status を更新
+// ============================================================
 
 export async function update(
 	id: number,
-	_input: UpdateAutoChallengeInput,
+	input: UpdateAutoChallengeInput,
 	tenantId: string,
 ): Promise<void> {
-	warnWrite('update', { id, tenantId });
+	const found = await findChallengeItemById(id, tenantId);
+	if (!found) return;
+
+	const sets: string[] = ['updatedAt = :now'];
+	const values: Record<string, unknown> = { ':now': new Date().toISOString() };
+	if (input.currentCount !== undefined) {
+		sets.push('currentCount = :cc');
+		values[':cc'] = input.currentCount;
+	}
+	if (input.status !== undefined) {
+		sets.push('#status = :st');
+		values[':st'] = input.status;
+	}
+
+	await getDocClient().send(
+		new UpdateCommand({
+			TableName: TABLE_NAME,
+			Key: { PK: found.PK, SK: found.SK },
+			UpdateExpression: `SET ${sets.join(', ')}`,
+			// status は DynamoDB 予約語のため alias で escape。
+			ExpressionAttributeNames: input.status !== undefined ? { '#status': 'status' } : undefined,
+			ExpressionAttributeValues: values,
+		}),
+	);
 }
+
+// ============================================================
+// expireOldChallenges — 期限切れ active チャレンジを expired にする
+// ============================================================
 
 export async function expireOldChallenges(beforeDate: string, tenantId: string): Promise<number> {
-	warnWrite('expireOldChallenges', { beforeDate, tenantId });
-	return 0;
+	// SQLite: UPDATE ... SET status='expired' WHERE status='active' AND week_start < :beforeDate
+	const targets = await scanTenantChallenges(
+		' AND #status = :active AND weekStart < :before',
+		{ ':active': 'active', ':before': beforeDate },
+		{ '#status': 'status' },
+		tenantId,
+	);
+	const now = new Date().toISOString();
+	for (const key of targets) {
+		await getDocClient().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: key,
+				UpdateExpression: 'SET #status = :expired, updatedAt = :now',
+				ExpressionAttributeNames: { '#status': 'status' },
+				ExpressionAttributeValues: { ':expired': 'expired', ':now': now },
+			}),
+		);
+	}
+	return targets.length;
 }
 
-/** テナントの全自動チャレンジを削除（Pre-PMF fallback: no-op） */
+// ============================================================
+// deleteByTenantId — テナントの全自動チャレンジを削除
+// ============================================================
+
 export async function deleteByTenantId(tenantId: string): Promise<void> {
-	warnWrite('deleteByTenantId', { tenantId });
+	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), PREFIX);
+}
+
+// ============================================================
+// 内部ヘルパ
+// ============================================================
+
+/**
+ * weekStart 降順 + id 降順 (tiebreaker) で比較する。
+ * SQLite `ORDER BY week_start DESC` の決定的な実装等価 (同 weekStart 時は後発 id を先頭に)。
+ */
+function compareWeekStartDesc(a: AutoChallenge, b: AutoChallenge): number {
+	if (a.weekStart !== b.weekStart) return a.weekStart < b.weekStart ? 1 : -1;
+	return b.id - a.id;
+}
+
+/** 指定 child partition の AUTOCHAL# item を全件 Query する (ページング対応)。 */
+async function queryChildChallenges(
+	childId: number,
+	tenantId: string,
+): Promise<Record<string, unknown>[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				ExpressionAttributeValues: {
+					':pk': childPK(childId, tenantId),
+					':prefix': PREFIX,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) items.push(item);
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return items;
+}
+
+/**
+ * tenant 配下の AUTOCHAL# item を追加 filter 付きで Scan し PK/SK を解決する。
+ * expireOldChallenges 用 (tenant 横断 + week_start 範囲)。
+ * Scan の Limit は filter 適用前評価のため付けず、ExclusiveStartKey で全ページ走査する (#2842)。
+ */
+async function scanTenantChallenges(
+	extraFilter: string,
+	extraValues: Record<string, unknown>,
+	extraNames: Record<string, string>,
+	tenantId: string,
+): Promise<{ PK: string; SK: string }[]> {
+	const doc = getDocClient();
+	const keys: { PK: string; SK: string }[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: `begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix)${extraFilter}`,
+				ExpressionAttributeNames: extraNames,
+				ExpressionAttributeValues: {
+					':tenantPrefix': tenantPK('CHILD#', tenantId),
+					':skPrefix': PREFIX,
+					...extraValues,
+				},
+				ProjectionExpression: 'PK, SK',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) {
+			keys.push({ PK: item.PK as string, SK: item.SK as string });
+		}
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return keys;
+}
+
+/**
+ * id だけ受け取る update 用に、tenant 配下を Scan して PK/SK を解決する。
+ * SK は AUTOCHAL#<weekStart> で id を含まないため、tenant Scan + id 属性 filter で 1 件特定する。
+ * Scan は全ページ走査し一致 item で早期 return する (#2842 paging 正パターン)。
+ */
+async function findChallengeItemById(
+	id: number,
+	tenantId: string,
+): Promise<{ PK: string; SK: string } | undefined> {
+	const doc = getDocClient();
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression:
+					'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
+				ExpressionAttributeValues: {
+					':tenantPrefix': tenantPK('CHILD#', tenantId),
+					':skPrefix': PREFIX,
+					':id': id,
+				},
+				ProjectionExpression: 'PK, SK',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		const item = (result.Items ?? [])[0];
+		if (item) return { PK: item.PK as string, SK: item.SK as string };
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return undefined;
 }

--- a/src/lib/server/db/dynamodb/certificate-repo.ts
+++ b/src/lib/server/db/dynamodb/certificate-repo.ts
@@ -1,79 +1,205 @@
 // src/lib/server/db/dynamodb/certificate-repo.ts
-// DynamoDB ICertificateRepo implementation
+// がんばり証明書リポジトリ — DynamoDB 本実装 (#2824 Wave 6A / ADR-0055)
 //
-// ## 経緯 (#2262 / #2263 fallback pattern)
+// ICertificateRepo を SQLite 実装 (sqlite/certificate-repo.ts、挙動 SSOT) と
+// 機能等価に DynamoDB single-table で実装する。
 //
-// 旧 `src/lib/server/db/certificate-repo.ts` は `db` (sqlite) を直 import しており、
-// 本番 cognito Lambda (DATA_SOURCE=dynamodb) では `/tmp/ganbari-quest.db` の空テーブルを
-// 参照していた (= 誰の証明書も persist されず、Lambda 再起動で消失する潜在 bug)。
+// 経緯: 本 repo は #2262 / #2263 で「read=空 / write=no-op + logger.warn」化された。旧 sqlite 直
+//   import で本番 cognito Lambda (DATA_SOURCE=dynamodb) では誰の証明書も persist されなかった。
+//   卒業証明書は子供の達成記録の核であり、Lambda 再起動で消失するのは体験毀損。本実装で根治する。
 //
-// 本実装は #2280 (PR fix: 12 DynamoDB repo Pre-PMF fallback) と同型の fallback パターンで
-// Promise.all([...]) 経路の throw → 500 を予防する:
+// key 設計 (keys.ts §certificateKey):
+//   PK = T#<tenantId>#CHILD#<childId>   (child partition、special_rewards / activity_logs と同居)
+//   SK = CERT#<certificateType>         (certificateType は child 内で一意)
+//   → findCertificates は単一 partition Query (begins_with(SK, 'CERT#')) で完結し追加 GSI 不要
+//     (ADR-0055 §3.1)。SK に certificateType を採ることで SQLite
+//     uniqueIndex(child_id, tenant_id, certificate_type) を SK 一意性で表現し、issueCertificate の
+//     onConflictDoNothing を attribute_not_exists(PK) 条件付き Put で等価実装する (重複 type は skip)。
+//   id だけで引く findCertificateById は低頻度のため tenant Scan + id filter で 1 件特定する
+//   (message-repo.findMessageItemById と同パターン)。Scan は全ページ走査する (#2842)。
 //
-// - read (`findCertificates` / `findCertificateById` / `hasCertificate`): 安全値 (空 / undefined / false) + logger.warn で可視化
-// - write (`issueCertificate`): no-op + logger.warn (Pre-PMF で本番未活用、本実装は別 Issue)
-//
-// 本番 cognito で `/admin/certificates` / `/admin/growth-book` は現状ほぼ未使用のため
-// Pre-PMF stub 容認 (ADR-0010 Bucket B)。本実装時は CHILD#<id> / CERT#<padId> パターンで設計予定:
-//   - PK = CHILD#<id>, SK = CERT#<padId>
-//   - tenantId は keys.ts §childKey の `T#<tenantId>#` prefix で table 分離
-//   - issuedAt は ISO timestamp、`onConflictDoNothing` は SK 一致で Put cond expression
-//   - 期待 Throughput: 1 子供あたり <100 件、1 テナント <500 件 (TTL なし)
-//
-// CI gate `scripts/check-dynamodb-stub.mjs` は GRANDFATHERED_STUBS に登録済 (#2262)。
+// 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/certificate-repo.ts (SSOT)
 
-import { logger } from '$lib/server/logger';
+import { GetCommand, PutCommand, QueryCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
 import type { Certificate, InsertCertificateInput } from '../types';
+import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
+import { certificateKey, certificatePrefix, childPK, ENTITY_NAMES, tenantPK } from './keys';
+import { stripKeys } from './repo-helpers';
 
-const SERVICE = 'certificate-repo.dynamodb';
+const PREFIX = certificatePrefix();
 
-function warnRead(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] read fallback: returning empty (Pre-PMF stub, #2262)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
+/** DynamoDB item を Certificate に正規化する (PK/SK 除去 + null 既定の補完)。 */
+function toCertificate(item: Record<string, unknown>): Certificate {
+	const s = stripKeys(item) as Record<string, unknown>;
+	return {
+		id: s.id as number,
+		childId: s.childId as number,
+		tenantId: s.tenantId as string,
+		certificateType: s.certificateType as string,
+		title: s.title as string,
+		// SQLite schema: description / metadata は nullable
+		description: (s.description ?? null) as string | null,
+		issuedAt: s.issuedAt as string,
+		metadata: (s.metadata ?? null) as string | null,
+	};
 }
 
-function warnWrite(method: string, context: Record<string, unknown>): void {
-	logger.warn(`[${SERVICE}] write fallback: no-op (Pre-PMF stub, #2262)`, {
-		service: SERVICE,
-		context: { method, ...context },
-	});
-}
+// ============================================================
+// issueCertificate — 証明書を発行（重複 type 時は skip して null）
+// ============================================================
 
 export async function issueCertificate(
 	input: InsertCertificateInput,
 	tenantId: string,
 ): Promise<Certificate | null> {
-	warnWrite('issueCertificate', {
+	const id = await nextId(ENTITY_NAMES.certificate, tenantId);
+	const certificate: Certificate = {
+		id,
 		childId: input.childId,
-		certificateType: input.certificateType,
 		tenantId,
-	});
-	return null;
+		certificateType: input.certificateType,
+		title: input.title,
+		description: input.description ?? null,
+		// SQLite schema default 'issued_at' = CURRENT_TIMESTAMP
+		issuedAt: new Date().toISOString(),
+		metadata: input.metadata ?? null,
+	};
+
+	try {
+		await getDocClient().send(
+			new PutCommand({
+				TableName: TABLE_NAME,
+				Item: {
+					...certificateKey(input.childId, input.certificateType, tenantId),
+					...certificate,
+				},
+				// onConflictDoNothing 等価: 同 child + certType が既存なら Put せず例外 → null。
+				ConditionExpression: 'attribute_not_exists(PK)',
+			}),
+		);
+	} catch (e) {
+		// 重複 (ConditionalCheckFailedException) は SQLite onConflictDoNothing と同じく null。
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') {
+			return null;
+		}
+		// SQLite 実装も try/catch で全例外を null 化しているため、その他の例外も null を返す。
+		return null;
+	}
+
+	return certificate;
 }
 
+// ============================================================
+// findCertificates — child の全証明書を取得（新しい順）
+// ============================================================
+
 export async function findCertificates(childId: number, tenantId: string): Promise<Certificate[]> {
-	warnRead('findCertificates', { childId, tenantId });
-	const empty: Certificate[] = [];
-	return empty;
+	const items = await queryChildCertificates(childId, tenantId);
+	// SQLite: ORDER BY issued_at DESC。同 issuedAt は id 降順を tiebreaker にする。
+	return items.map(toCertificate).sort(compareIssuedAtDesc);
 }
+
+// ============================================================
+// findCertificateById — id + tenant で 1 件取得
+// ============================================================
 
 export async function findCertificateById(
 	id: number,
 	tenantId: string,
 ): Promise<Certificate | undefined> {
-	warnRead('findCertificateById', { id, tenantId });
-	const result: Certificate | undefined = undefined;
-	return result;
+	const found = await findCertificateItemById(id, tenantId);
+	if (!found) return undefined;
+	return toCertificate(found);
 }
+
+// ============================================================
+// hasCertificate — 特定 type の証明書が発行済みか
+// ============================================================
 
 export async function hasCertificate(
 	childId: number,
 	certificateType: string,
 	tenantId: string,
 ): Promise<boolean> {
-	warnRead('hasCertificate', { childId, certificateType, tenantId });
-	const result = false;
-	return result;
+	// SK = CERT#<certificateType> が一意のため GetItem 1 回で存在判定できる。
+	const result = await getDocClient().send(
+		new GetCommand({
+			TableName: TABLE_NAME,
+			Key: certificateKey(childId, certificateType, tenantId),
+			ProjectionExpression: 'id',
+		}),
+	);
+	return !!result.Item;
+}
+
+// ============================================================
+// 内部ヘルパ
+// ============================================================
+
+/**
+ * issuedAt 降順 + id 降順 (tiebreaker) で比較する。
+ * SQLite `ORDER BY issued_at DESC` の決定的な実装等価 (同 issuedAt 時は後発 id を先頭に)。
+ */
+function compareIssuedAtDesc(a: Certificate, b: Certificate): number {
+	if (a.issuedAt !== b.issuedAt) return a.issuedAt < b.issuedAt ? 1 : -1;
+	return b.id - a.id;
+}
+
+/** 指定 child partition の CERT# item を全件 Query する (ページング対応)。 */
+async function queryChildCertificates(
+	childId: number,
+	tenantId: string,
+): Promise<Record<string, unknown>[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				ExpressionAttributeValues: {
+					':pk': childPK(childId, tenantId),
+					':prefix': PREFIX,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) items.push(item);
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return items;
+}
+
+/**
+ * id だけ受け取る findCertificateById 用に、tenant 配下を Scan して item を解決する。
+ * SK は CERT#<type> で id を含まないため、tenant Scan + id 属性 filter で 1 件特定する。
+ * Scan は全ページ走査し一致 item で早期 return する (#2842 paging 正パターン)。
+ */
+async function findCertificateItemById(
+	id: number,
+	tenantId: string,
+): Promise<Record<string, unknown> | undefined> {
+	const doc = getDocClient();
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression:
+					'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix) AND id = :id',
+				ExpressionAttributeValues: {
+					':tenantPrefix': tenantPK('CHILD#', tenantId),
+					':skPrefix': PREFIX,
+					':id': id,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		const item = (result.Items ?? [])[0];
+		if (item) return item;
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return undefined;
 }

--- a/src/lib/server/db/dynamodb/keys.ts
+++ b/src/lib/server/db/dynamodb/keys.ts
@@ -504,6 +504,55 @@ export function enemyCollectionPrefix(): string {
 }
 
 /**
+ * Auto challenge (#2824 Wave 6A / ADR-0055): PK=CHILD#<cId>, SK=AUTOCHAL#<weekStart>
+ *
+ * per-child の週次自動チャレンジを child partition 配下に置き (stamp_cards / activity_logs と同居)、
+ * `findByChildAndWeek` を childId + weekStart 既知の GetItem 1 回で完結させる
+ * (weekStart は child 内で一意 = SQLite uniqueIndex(child_id, week_start) と等価)。
+ * `findActiveByChild` / `findByChild` も単一 partition Query (begins_with(SK, 'AUTOCHAL#')) で
+ * 完結し追加 GSI 不要 (ADR-0055 §3.1)。id だけで引く `update` と tenant 横断の
+ * `expireOldChallenges` は低頻度 (週次 cron) のため tenant Scan + filter で解決する
+ * (stampCardKey と同型、#2842 paging 教訓で Scan は Limit なしページング)。
+ */
+export function autoChallengeKey(childId: number, weekStart: string, tenantId: string): DynamoKey {
+	return {
+		PK: tenantPK(`${PREFIX.CHILD}#${childId}`, tenantId),
+		SK: `AUTOCHAL#${weekStart}`,
+	};
+}
+
+/** Auto challenge SK prefix for querying all challenges of a child / tenant cleanup */
+export function autoChallengePrefix(): string {
+	return 'AUTOCHAL#';
+}
+
+/**
+ * Certificate (#2824 Wave 6A / ADR-0055): PK=CHILD#<cId>, SK=CERT#<certificateType>
+ *
+ * がんばり証明書 (卒業証明書等) を child partition 配下に置き (special_rewards / activity_logs と同居)、
+ * `findCertificates` を単一 partition Query (begins_with(SK, 'CERT#')) で完結させる。
+ * SK に certificateType を採ることで SQLite uniqueIndex(child_id, tenant_id, certificate_type) を
+ * SK 一意性で表現し、`issueCertificate` の onConflictDoNothing を `attribute_not_exists(PK)`
+ * 条件付き Put で等価実装する (重複 type は静かに skip)。追加 GSI 不要 (ADR-0055 §3.1)。
+ * id だけで引く `findCertificateById` は低頻度のため tenant Scan + id filter で解決する。
+ */
+export function certificateKey(
+	childId: number,
+	certificateType: string,
+	tenantId: string,
+): DynamoKey {
+	return {
+		PK: tenantPK(`${PREFIX.CHILD}#${childId}`, tenantId),
+		SK: `CERT#${certificateType}`,
+	};
+}
+
+/** Certificate SK prefix for querying all certificates of a child */
+export function certificatePrefix(): string {
+	return 'CERT#';
+}
+
+/**
  * Checklist template: PK=T#<tenantId>#CKTPL, SK=CKTPL#<id>
  * #2362 PR-5 (ADR-0055): family master 化に伴い CHILD#<cId> 配下 → tenant scope に変更。
  */
@@ -942,6 +991,8 @@ export const ENTITY_NAMES = {
 	stampCard: 'stampCard',
 	dailyBattle: 'dailyBattle',
 	enemyCollection: 'enemyCollection',
+	autoChallenge: 'autoChallenge',
+	certificate: 'certificate',
 	checklistTemplate: 'checklistTemplate',
 	checklistAssignment: 'checklistAssignment',
 	checklistItem: 'checklistItem',

--- a/tests/unit/db/dynamodb-auto-challenge-repo.test.ts
+++ b/tests/unit/db/dynamodb-auto-challenge-repo.test.ts
@@ -1,0 +1,383 @@
+/**
+ * tests/unit/db/dynamodb-auto-challenge-repo.test.ts
+ *
+ * #2824 Wave 6A / ADR-0055: DynamoDB 週次自動チャレンジ repo 本実装の単体テスト。
+ *
+ * AWS SDK を vi.hoisted mock で置き換え、SQLite 実装 (sqlite/auto-challenge-repo.ts、挙動 SSOT) と
+ * 機能等価であることを method ごとに検証する:
+ *   - 正しい Command + key で send する (PK=CHILD#<id> / SK=AUTOCHAL#<weekStart>)
+ *   - response を正しく型変換する (stripKeys / default backfill)
+ *   - SQLite 機能等価 (week_start DESC 並び / status='active' filter / id 解決による update / expire)
+ *
+ * 背景: 本 repo は #2263 hotfix で read=空 / write=no-op 化され、自動チャレンジの生成・進捗が本番
+ *   DynamoDB Lambda で永続しなかった (週ごとリセット)。本テストは本実装の機能等価性を回帰固定する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const {
+	mockSend,
+	MockGetCommand,
+	MockPutCommand,
+	MockQueryCommand,
+	MockUpdateCommand,
+	MockScanCommand,
+} = vi.hoisted(() => {
+	const send = vi.fn();
+	class Cmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	return {
+		mockSend: send,
+		MockGetCommand: class extends Cmd {},
+		MockPutCommand: class extends Cmd {},
+		MockQueryCommand: class extends Cmd {},
+		MockUpdateCommand: class extends Cmd {},
+		MockScanCommand: class extends Cmd {},
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	GetCommand: MockGetCommand,
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	UpdateCommand: MockUpdateCommand,
+	ScanCommand: MockScanCommand,
+	// deleteByTenantId は bulk-delete.ts (BatchWriteCommand + ScanCommand) を動的 import する。
+	BatchWriteCommand: class {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	},
+}));
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/auto-challenge-repo');
+}
+
+const TENANT = 'tenant-1';
+const CHILD_ID = 42;
+const WEEK = '2026-05-12';
+
+/** child partition の DynamoDB auto-challenge item を組み立てる (PK/SK + 属性)。 */
+function makeItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const weekStart = (over.weekStart as string) ?? WEEK;
+	return {
+		PK: `T#${TENANT}#CHILD#${CHILD_ID}`,
+		SK: `AUTOCHAL#${weekStart}`,
+		id: (over.id as number) ?? 1,
+		childId: CHILD_ID,
+		tenantId: TENANT,
+		weekStart,
+		categoryId: 3,
+		targetCount: 5,
+		currentCount: 0,
+		status: 'active',
+		createdAt: '2026-05-12T00:00:00.000Z',
+		updatedAt: '2026-05-12T00:00:00.000Z',
+		...over,
+	};
+}
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// findByChildAndWeek
+// ============================================================
+
+describe('findByChildAndWeek', () => {
+	it('GetItem で childId + weekStart 既知の 1 件を取得し型変換する', async () => {
+		mockSend.mockResolvedValueOnce({ Item: makeItem() });
+
+		const { findByChildAndWeek } = await loadRepo();
+		const result = await findByChildAndWeek(CHILD_ID, WEEK, TENANT);
+
+		expect(result).toMatchObject({
+			id: 1,
+			childId: CHILD_ID,
+			tenantId: TENANT,
+			weekStart: WEEK,
+			categoryId: 3,
+			targetCount: 5,
+			currentCount: 0,
+			status: 'active',
+		});
+		const call = mockSend.mock.calls[0]?.[0] as { input: { Key?: Record<string, unknown> } };
+		expect(call.input.Key?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(call.input.Key?.SK).toBe(`AUTOCHAL#${WEEK}`);
+	});
+
+	it('未存在なら undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({});
+		const { findByChildAndWeek } = await loadRepo();
+		await expect(findByChildAndWeek(CHILD_ID, WEEK, TENANT)).resolves.toBeUndefined();
+	});
+});
+
+// ============================================================
+// findActiveByChild
+// ============================================================
+
+describe('findActiveByChild', () => {
+	it('active のみを抽出し week_start 降順の先頭を返す (SQLite ORDER BY week_start DESC LIMIT 1 等価)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, weekStart: '2026-05-05', status: 'expired' }),
+				makeItem({ id: 2, weekStart: '2026-05-12', status: 'active' }),
+				makeItem({ id: 3, weekStart: '2026-05-19', status: 'active' }),
+			],
+		});
+
+		const { findActiveByChild } = await loadRepo();
+		const result = await findActiveByChild(CHILD_ID, TENANT);
+
+		// 最新 weekStart の active (id=3) が返る (expired は除外)。
+		expect(result?.id).toBe(3);
+		expect(result?.weekStart).toBe('2026-05-19');
+		const call = mockSend.mock.calls[0]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(call.input.ExpressionAttributeValues?.[':pk']).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(call.input.ExpressionAttributeValues?.[':prefix']).toBe('AUTOCHAL#');
+	});
+
+	it('active が無ければ undefined を返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1, status: 'expired' })],
+		});
+		const { findActiveByChild } = await loadRepo();
+		await expect(findActiveByChild(CHILD_ID, TENANT)).resolves.toBeUndefined();
+	});
+
+	it('Query をページング (LastEvaluatedKey が尽きるまで) して全件評価する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [makeItem({ id: 1, weekStart: '2026-05-05', status: 'active' })],
+				LastEvaluatedKey: { PK: 'x', SK: 'y' },
+			})
+			.mockResolvedValueOnce({
+				Items: [makeItem({ id: 2, weekStart: '2026-05-12', status: 'active' })],
+			});
+
+		const { findActiveByChild } = await loadRepo();
+		const result = await findActiveByChild(CHILD_ID, TENANT);
+		// 2 ページ走査した上で最新 weekStart (id=2) が返る。
+		expect(result?.id).toBe(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+});
+
+// ============================================================
+// findByChild
+// ============================================================
+
+describe('findByChild', () => {
+	it('week_start 降順で limit 件返す', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, weekStart: '2026-05-05' }),
+				makeItem({ id: 2, weekStart: '2026-05-19' }),
+				makeItem({ id: 3, weekStart: '2026-05-12' }),
+			],
+		});
+
+		const { findByChild } = await loadRepo();
+		const result = await findByChild(CHILD_ID, TENANT, 2);
+
+		expect(result.map((c) => c.weekStart)).toEqual(['2026-05-19', '2026-05-12']);
+	});
+
+	it('default limit は 10', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: Array.from({ length: 12 }, (_, i) =>
+				makeItem({ id: i + 1, weekStart: `2026-05-${String(i + 1).padStart(2, '0')}` }),
+			),
+		});
+		const { findByChild } = await loadRepo();
+		const result = await findByChild(CHILD_ID, TENANT);
+		expect(result).toHaveLength(10);
+	});
+});
+
+// ============================================================
+// insert
+// ============================================================
+
+describe('insert', () => {
+	it('counter 採番 → PutItem し SQLite default 値を埋めた row を返す (永続の核心経路)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 101 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insert } = await loadRepo();
+		const result = await insert(
+			{ childId: CHILD_ID, weekStart: WEEK, categoryId: 3, targetCount: 5 },
+			TENANT,
+		);
+
+		expect(result.id).toBe(101);
+		expect(result).toMatchObject({
+			childId: CHILD_ID,
+			tenantId: TENANT,
+			weekStart: WEEK,
+			categoryId: 3,
+			targetCount: 5,
+			// SQLite schema default
+			currentCount: 0,
+			status: 'active',
+		});
+		expect(typeof result.createdAt).toBe('string');
+		expect(typeof result.updatedAt).toBe('string');
+
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(putCall.input.Item?.SK).toBe(`AUTOCHAL#${WEEK}`);
+		expect(putCall.input.Item?.currentCount).toBe(0);
+		expect(putCall.input.Item?.status).toBe('active');
+	});
+});
+
+// ============================================================
+// update
+// ============================================================
+
+describe('update', () => {
+	it('tenant Scan で id を解決し currentCount / status を SET する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: `AUTOCHAL#${WEEK}` }],
+			}) // Scan
+			.mockResolvedValueOnce({}); // UpdateCommand
+
+		const { update } = await loadRepo();
+		await update(7, { currentCount: 3, status: 'completed' }, TENANT);
+
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const updCall = mockSend.mock.calls[1]?.[0] as {
+			input: {
+				Key?: Record<string, unknown>;
+				UpdateExpression?: string;
+				ExpressionAttributeNames?: Record<string, string>;
+				ExpressionAttributeValues?: Record<string, unknown>;
+			};
+		};
+		expect(updCall.input.Key?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(updCall.input.Key?.SK).toBe(`AUTOCHAL#${WEEK}`);
+		expect(updCall.input.UpdateExpression).toContain('currentCount = :cc');
+		expect(updCall.input.UpdateExpression).toContain('#status = :st');
+		// status は予約語のため alias escape されている。
+		expect(updCall.input.ExpressionAttributeNames?.['#status']).toBe('status');
+		expect(updCall.input.ExpressionAttributeValues?.[':cc']).toBe(3);
+		expect(updCall.input.ExpressionAttributeValues?.[':st']).toBe('completed');
+	});
+
+	it('id 不在 (Scan 空) なら何もしない (UpdateCommand を呼ばない)', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] }); // Scan 空
+
+		const { update } = await loadRepo();
+		await update(999, { currentCount: 1 }, TENANT);
+
+		// Scan の 1 回のみ (Update は呼ばれない)。
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+
+	it('currentCount のみ指定時は status alias を付けない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [{ PK: 'p', SK: 's' }] }).mockResolvedValueOnce({});
+
+		const { update } = await loadRepo();
+		await update(7, { currentCount: 2 }, TENANT);
+
+		const updCall = mockSend.mock.calls[1]?.[0] as {
+			input: { ExpressionAttributeNames?: Record<string, string> };
+		};
+		expect(updCall.input.ExpressionAttributeNames).toBeUndefined();
+	});
+});
+
+// ============================================================
+// expireOldChallenges
+// ============================================================
+
+describe('expireOldChallenges', () => {
+	it('active かつ week_start < beforeDate を Scan し各 item を expired に更新する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [
+					{ PK: 'p1', SK: 'AUTOCHAL#2026-04-28' },
+					{ PK: 'p2', SK: 'AUTOCHAL#2026-05-05' },
+				],
+			}) // Scan
+			.mockResolvedValueOnce({}) // Update 1
+			.mockResolvedValueOnce({}); // Update 2
+
+		const { expireOldChallenges } = await loadRepo();
+		const count = await expireOldChallenges('2026-05-12', TENANT);
+
+		expect(count).toBe(2);
+		const scanCall = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scanCall.input.FilterExpression).toContain('#status = :active');
+		expect(scanCall.input.FilterExpression).toContain('weekStart < :before');
+		expect(scanCall.input.ExpressionAttributeValues?.[':active']).toBe('active');
+		expect(scanCall.input.ExpressionAttributeValues?.[':before']).toBe('2026-05-12');
+
+		const updCall = mockSend.mock.calls[1]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(updCall.input.ExpressionAttributeValues?.[':expired']).toBe('expired');
+	});
+
+	it('対象 0 件なら 0 を返し Update を呼ばない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { expireOldChallenges } = await loadRepo();
+		await expect(expireOldChallenges('2026-05-12', TENANT)).resolves.toBe(0);
+		expect(mockSend).toHaveBeenCalledTimes(1);
+	});
+
+	it('Scan を全ページ走査する (#2842 Limit なしページング)', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ PK: 'p1', SK: 'AUTOCHAL#2026-04-28' }],
+				LastEvaluatedKey: { PK: 'p1', SK: 'AUTOCHAL#2026-04-28' },
+			})
+			.mockResolvedValueOnce({ Items: [{ PK: 'p2', SK: 'AUTOCHAL#2026-05-05' }] })
+			.mockResolvedValueOnce({}) // Update 1
+			.mockResolvedValueOnce({}); // Update 2
+
+		const { expireOldChallenges } = await loadRepo();
+		const count = await expireOldChallenges('2026-05-12', TENANT);
+		expect(count).toBe(2);
+		// Scan 2 ページ + Update 2 件 = 4 send。
+		expect(mockSend).toHaveBeenCalledTimes(4);
+	});
+});
+
+// ============================================================
+// deleteByTenantId
+// ============================================================
+
+describe('deleteByTenantId', () => {
+	it('throw せず resolve する (bulk-delete 経路)', async () => {
+		// bulk-delete の Scan ループ: 1 ページで空を返す。
+		mockSend.mockResolvedValue({ Items: [] });
+		const { deleteByTenantId } = await loadRepo();
+		await expect(deleteByTenantId(TENANT)).resolves.toBeUndefined();
+	});
+});

--- a/tests/unit/db/dynamodb-certificate-repo.test.ts
+++ b/tests/unit/db/dynamodb-certificate-repo.test.ts
@@ -1,0 +1,277 @@
+/**
+ * tests/unit/db/dynamodb-certificate-repo.test.ts
+ *
+ * #2824 Wave 6A / ADR-0055: DynamoDB がんばり証明書 repo 本実装の単体テスト。
+ *
+ * AWS SDK を vi.hoisted mock で置き換え、SQLite 実装 (sqlite/certificate-repo.ts、挙動 SSOT) と
+ * 機能等価であることを method ごとに検証する:
+ *   - 正しい Command + key で send する (PK=CHILD#<id> / SK=CERT#<certificateType>)
+ *   - response を正しく型変換する (stripKeys / description / metadata null backfill)
+ *   - SQLite 機能等価 (onConflictDoNothing → 重複 type は null / issued_at DESC 並び / id 解決)
+ *
+ * 背景: 本 repo は #2262 / #2263 で read=空 / write=no-op 化され、卒業証明書が本番 DynamoDB Lambda で
+ *   永続しなかった (Lambda 再起動で消失)。本テストは本実装の機能等価性を回帰固定する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const {
+	mockSend,
+	MockGetCommand,
+	MockPutCommand,
+	MockQueryCommand,
+	MockScanCommand,
+	MockUpdateCommand,
+} = vi.hoisted(() => {
+	const send = vi.fn();
+	class Cmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	return {
+		mockSend: send,
+		MockGetCommand: class extends Cmd {},
+		MockPutCommand: class extends Cmd {},
+		MockQueryCommand: class extends Cmd {},
+		MockScanCommand: class extends Cmd {},
+		// counter.ts の nextId が ADD :val する UpdateCommand。
+		MockUpdateCommand: class extends Cmd {},
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	GetCommand: MockGetCommand,
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	ScanCommand: MockScanCommand,
+	UpdateCommand: MockUpdateCommand,
+}));
+
+/** DynamoDB の ConditionalCheckFailedException を模した Error を返す。 */
+function conditionalCheckFailed(): Error {
+	const e = new Error('The conditional request failed');
+	e.name = 'ConditionalCheckFailedException';
+	return e;
+}
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/certificate-repo');
+}
+
+const TENANT = 'tenant-1';
+const CHILD_ID = 42;
+const CERT_TYPE = 'elementary_graduation';
+
+/** child partition の DynamoDB certificate item を組み立てる (PK/SK + 属性)。 */
+function makeItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const certificateType = (over.certificateType as string) ?? CERT_TYPE;
+	return {
+		PK: `T#${TENANT}#CHILD#${CHILD_ID}`,
+		SK: `CERT#${certificateType}`,
+		id: (over.id as number) ?? 1,
+		childId: CHILD_ID,
+		tenantId: TENANT,
+		certificateType,
+		title: 'しょうがっこうそつぎょう',
+		description: null,
+		issuedAt: '2026-05-12T00:00:00.000Z',
+		metadata: null,
+		...over,
+	};
+}
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// issueCertificate
+// ============================================================
+
+describe('issueCertificate', () => {
+	it('counter 採番 → 条件付き PutItem し SQLite default を埋めた row を返す (永続の核心経路)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 55 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand 成功
+
+		const { issueCertificate } = await loadRepo();
+		const result = await issueCertificate(
+			{
+				childId: CHILD_ID,
+				certificateType: CERT_TYPE,
+				title: 'そつぎょう',
+				description: 'おめでとう',
+			},
+			TENANT,
+		);
+
+		expect(result?.id).toBe(55);
+		expect(result).toMatchObject({
+			childId: CHILD_ID,
+			tenantId: TENANT,
+			certificateType: CERT_TYPE,
+			title: 'そつぎょう',
+			description: 'おめでとう',
+			metadata: null,
+		});
+		expect(typeof result?.issuedAt).toBe('string');
+
+		const putCall = mockSend.mock.calls[1]?.[0] as {
+			input: { Item?: Record<string, unknown>; ConditionExpression?: string };
+		};
+		expect(putCall.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(putCall.input.Item?.SK).toBe(`CERT#${CERT_TYPE}`);
+		// onConflictDoNothing 等価の条件式。
+		expect(putCall.input.ConditionExpression).toBe('attribute_not_exists(PK)');
+	});
+
+	it('description / metadata 未指定時は null を埋める (SQLite nullable 等価)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		const { issueCertificate } = await loadRepo();
+		const result = await issueCertificate(
+			{ childId: CHILD_ID, certificateType: CERT_TYPE, title: 'x' },
+			TENANT,
+		);
+		expect(result?.description).toBeNull();
+		expect(result?.metadata).toBeNull();
+	});
+
+	it('重複 type (ConditionalCheckFailed) は null を返す (onConflictDoNothing 等価)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 2 } }) // nextId
+			.mockRejectedValueOnce(conditionalCheckFailed()); // Put 条件失敗
+
+		const { issueCertificate } = await loadRepo();
+		const result = await issueCertificate(
+			{ childId: CHILD_ID, certificateType: CERT_TYPE, title: 'dup' },
+			TENANT,
+		);
+		expect(result).toBeNull();
+	});
+
+	it('その他例外も null を返す (SQLite try/catch 全例外 null 化と等価)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 3 } })
+			.mockRejectedValueOnce(new Error('network error'));
+
+		const { issueCertificate } = await loadRepo();
+		const result = await issueCertificate(
+			{ childId: CHILD_ID, certificateType: CERT_TYPE, title: 'err' },
+			TENANT,
+		);
+		expect(result).toBeNull();
+	});
+});
+
+// ============================================================
+// findCertificates
+// ============================================================
+
+describe('findCertificates', () => {
+	it('child partition Query し issued_at 降順で返す (SQLite ORDER BY issued_at DESC 等価)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, certificateType: 'a', issuedAt: '2026-05-01T00:00:00.000Z' }),
+				makeItem({ id: 2, certificateType: 'b', issuedAt: '2026-05-19T00:00:00.000Z' }),
+				makeItem({ id: 3, certificateType: 'c', issuedAt: '2026-05-12T00:00:00.000Z' }),
+			],
+		});
+
+		const { findCertificates } = await loadRepo();
+		const result = await findCertificates(CHILD_ID, TENANT);
+
+		expect(result.map((c) => c.id)).toEqual([2, 3, 1]);
+		const call = mockSend.mock.calls[0]?.[0] as {
+			input: { ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(call.input.ExpressionAttributeValues?.[':pk']).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(call.input.ExpressionAttributeValues?.[':prefix']).toBe('CERT#');
+	});
+
+	it('0 件なら空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findCertificates } = await loadRepo();
+		await expect(findCertificates(CHILD_ID, TENANT)).resolves.toEqual([]);
+	});
+
+	it('Query をページング (LastEvaluatedKey が尽きるまで) する', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [makeItem({ id: 1, certificateType: 'a' })],
+				LastEvaluatedKey: { PK: 'x', SK: 'y' },
+			})
+			.mockResolvedValueOnce({ Items: [makeItem({ id: 2, certificateType: 'b' })] });
+
+		const { findCertificates } = await loadRepo();
+		const result = await findCertificates(CHILD_ID, TENANT);
+		expect(result).toHaveLength(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+});
+
+// ============================================================
+// findCertificateById
+// ============================================================
+
+describe('findCertificateById', () => {
+	it('tenant Scan で id を解決し item を型変換する', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [makeItem({ id: 9 })] });
+
+		const { findCertificateById } = await loadRepo();
+		const result = await findCertificateById(9, TENANT);
+
+		expect(result?.id).toBe(9);
+		expect(result?.certificateType).toBe(CERT_TYPE);
+		const call = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(call.input.FilterExpression).toContain('id = :id');
+		expect(call.input.ExpressionAttributeValues?.[':id']).toBe(9);
+		expect(call.input.ExpressionAttributeValues?.[':skPrefix']).toBe('CERT#');
+	});
+
+	it('未存在なら undefined (全ページ走査後)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { PK: 'p', SK: 's' } })
+			.mockResolvedValueOnce({ Items: [] });
+		const { findCertificateById } = await loadRepo();
+		await expect(findCertificateById(999, TENANT)).resolves.toBeUndefined();
+		expect(mockSend).toHaveBeenCalledTimes(2);
+	});
+});
+
+// ============================================================
+// hasCertificate
+// ============================================================
+
+describe('hasCertificate', () => {
+	it('SK 一意の GetItem で存在判定し true を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Item: { id: 1 } });
+
+		const { hasCertificate } = await loadRepo();
+		const result = await hasCertificate(CHILD_ID, CERT_TYPE, TENANT);
+
+		expect(result).toBe(true);
+		const call = mockSend.mock.calls[0]?.[0] as { input: { Key?: Record<string, unknown> } };
+		expect(call.input.Key?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(call.input.Key?.SK).toBe(`CERT#${CERT_TYPE}`);
+	});
+
+	it('未存在なら false', async () => {
+		mockSend.mockResolvedValueOnce({});
+		const { hasCertificate } = await loadRepo();
+		await expect(hasCertificate(CHILD_ID, CERT_TYPE, TENANT)).resolves.toBe(false);
+	});
+});

--- a/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
+++ b/tests/unit/db/dynamodb-pre-pmf-fallback.test.ts
@@ -23,7 +23,8 @@
 import { describe, expect, it } from 'vitest';
 
 // Pre-PMF fallback に置換された 12 repo
-import * as autoChallengeRepo from '../../../src/lib/server/db/dynamodb/auto-challenge-repo';
+// #2824 Wave 6A (ADR-0055): auto-challenge-repo は本実装済のため stub fallback テスト対象外。
+//   機能等価性は tests/unit/db/dynamodb-auto-challenge-repo.test.ts (AWS SDK mock) で検証する。
 // #2824 Wave 5A (ADR-0055): battle-repo は本実装済のため stub fallback テスト対象外。
 //   機能等価性は tests/unit/db/dynamodb-battle-repo.test.ts (AWS SDK mock) で検証する。
 // #2824 (ADR-0055): child-activity-repo は本実装済のため stub fallback テスト対象外。
@@ -48,29 +49,11 @@ const TODAY = '2026-05-19';
 describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 	// #2295 (EPIC #2294 ①): season-event-repo describe 削除済 (2026-05-19、repo 自体撤去)
 
-	describe('auto-challenge-repo', () => {
-		it('全 read method は安全値を返す', async () => {
-			await expect(
-				autoChallengeRepo.findByChildAndWeek(1, '2026-05-12', TENANT),
-			).resolves.toBeUndefined();
-			await expect(autoChallengeRepo.findActiveByChild(1, TENANT)).resolves.toBeUndefined();
-			await expect(autoChallengeRepo.findByChild(1, TENANT)).resolves.toEqual([]);
-		});
-
-		it('write method は throw しない', async () => {
-			await expect(
-				autoChallengeRepo.insert(
-					{ childId: 1, weekStart: '2026-05-12', categoryId: 1, targetCount: 5 },
-					TENANT,
-				),
-			).resolves.toBeTruthy();
-			await expect(
-				autoChallengeRepo.update(1, { currentCount: 3 }, TENANT),
-			).resolves.toBeUndefined();
-			await expect(autoChallengeRepo.expireOldChallenges('2026-05-01', TENANT)).resolves.toBe(0);
-			await expect(autoChallengeRepo.deleteByTenantId(TENANT)).resolves.toBeUndefined();
-		});
-	});
+	// #2824 Wave 6A (ADR-0055): auto-challenge-repo は本実装済 (stub 除外)。
+	//   週次自動チャレンジの生成・進捗が本番 DynamoDB Lambda で永続する。本実装の機能等価性
+	//   テストは dynamodb-auto-challenge-repo.test.ts に分離。ここで stub 前提の assert を残すと
+	//   「実装済なのに stub 期待」で誤った退行 gate になるため除外する (他 repo の fallback assert
+	//   は維持 = assertion 弱体化に該当しない)。
 
 	// #2824 Wave 5A (ADR-0055): battle-repo は本実装済 (stub 除外)。
 	//   LP machine-tour ④ feature-rpg-battle 訴求の日次バトル (進行 / 勝敗 / 報酬 / 敵図鑑) が
@@ -172,8 +155,8 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 		});
 	});
 
-	describe('regression guard: 全 4 repo の Promise.all で reject されない', () => {
-		it('SSR /preschool/home の典型的な 4 repo 並列呼び出しが全 fulfill する', async () => {
+	describe('regression guard: 全 3 repo の Promise.all で reject されない', () => {
+		it('SSR /preschool/home の典型的な 3 repo 並列呼び出しが全 fulfill する', async () => {
 			// #2295 (EPIC #2294 ①): seasonEventRepo / tenantEventRepo 削除済 (2026-05-19)、12 → 10 repo
 			// #2458 (Path B sibling drop): siblingChallengeRepo 削除済 (2026-05-26)、10 → 9 repo
 			// #2263 regression hotfix: childActivityRepo を stub fallback に置換 (9 → 10 repo)
@@ -189,8 +172,9 @@ describe('#2263 hotfix: DynamoDB Pre-PMF fallback 動作検証', () => {
 			//   (本実装は AWS SDK mock 必須 → dynamodb-battle-repo.test.ts で検証)。6 → 5 repo
 			// #2824 Wave 5B (ADR-0055): siblingCheerRepo を本実装化したため除外
 			//   (本実装は AWS SDK mock 必須 → dynamodb-sibling-cheer-repo.test.ts で検証)。5 → 4 repo
+			// #2824 Wave 6A (ADR-0055): autoChallengeRepo を本実装化したため除外
+			//   (本実装は AWS SDK mock 必須 → dynamodb-auto-challenge-repo.test.ts で検証)。4 → 3 repo
 			const results = await Promise.allSettled([
-				autoChallengeRepo.findActiveByChild(1, TENANT),
 				cloudExportRepo.findByTenant(TENANT),
 				reportDailySummaryRepo.findByChildAndDateRange(1, TODAY, TODAY, TENANT),
 				viewerTokenRepo.findByTenant(TENANT),


### PR DESCRIPTION
## 顧客価値・目的

有料本番 SaaS (`AUTH_MODE=cognito` + `DATA_SOURCE=dynamodb`) で、週次自動チャレンジ (`auto-challenge-repo`) と がんばり証明書 (`certificate-repo`) の生成・進捗・発行が **永続しない** write gap (#2263 hotfix で read=空 / write=no-op 化された残骸) を根治する。本実装前は本番 Lambda 再起動で自動チャレンジ進捗・卒業証明書が消失し、子供の達成記録という体験の核が成立しなかった。#2824 tracking Issue の Wave 6A。

## 関連 Issue

- tracking: #2824 (DynamoDB write 永続 gap、ADR-0055 per-child データモデル本実装)
- 起点: #2263 (stub 化 regression hotfix) / #2280 (12 repo Pre-PMF fallback)
- exemplar: #2820 (child-activity) / #2838 (message Wave 3A) / #2839 (stamp-card Wave 3B) / #2848 (sibling-cheer、#2842 Scan paging 教訓)
- 設計原則: ADR-0055 (per-child 主軸 + child partition 同居)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | auto-challenge-repo を SQLite 実装 (挙動 SSOT) と機能等価に DynamoDB 本実装 | `tests/unit/db/dynamodb-auto-challenge-repo.test.ts` (AWS SDK mock 17 件) | PASS — findByChildAndWeek=GetItem / findActiveByChild・findByChild=Query / insert=counter採番Put / update・expire=Scan解決 を網羅 |
| AC2 | certificate-repo を SQLite 実装と機能等価に DynamoDB 本実装 | `tests/unit/db/dynamodb-certificate-repo.test.ts` (AWS SDK mock 15 件) | PASS — issueCertificate の onConflictDoNothing 等価 (attribute_not_exists 条件付き Put → 重複 null) / findCertificates 降順 / hasCertificate=GetItem を網羅 |
| AC3 | 追加 GSI 不要の key 設計 (child partition 同居) | `src/lib/server/db/dynamodb/keys.ts` §autoChallengeKey / §certificateKey | PASS — 下記 key 設計表。SK に自然キー (weekStart / certType) を採り uniqueIndex を SK 一意性で表現 |
| AC4 | counter.ts で id 採番 | insert / issueCertificate が `nextId(ENTITY_NAMES.autoChallenge / .certificate)` 使用 | PASS — テストで counter 採番 → Put 経路を検証 |
| AC5 | Scan を使う method は Limit/ページング (#2842 教訓) 遵守 | update / expireOldChallenges / findCertificateById | PASS — Limit 不使用 + ExclusiveStartKey 全ページ走査。ページングテスト (`Query をページング` / `Scan を全ページ走査`) で検証 |
| AC6 | baseline.json から両 repo 削除 (ratchet 前進) | `scripts/dynamodb-stub-baseline.json` | PASS — `check-dynamodb-stub-parity.mjs` OK (5 repo / 30 method、両 repo 除外済) |
| AC7 | fallback test から両 repo 除外 (他 repo assert 維持) | `tests/unit/db/dynamodb-pre-pmf-fallback.test.ts` | PASS — auto-challenge describe + Promise.all 除外 (6→5 repo)。certificate は元々非対象 |
| AC8 | 設計書同期 | `docs/design/08-データベース設計書.md` | PASS — auto_challenges / certificates に DynamoDB キー設計節 2 件追加 |

### key 設計表 (追加 GSI 不要、ADR-0055 §3.1)

| エンティティ | PK | SK | 主アクセス | id-only / 横断アクセス |
|---|---|---|---|---|
| auto_challenges | `T#<tid>#CHILD#<childId>` | `AUTOCHAL#<weekStart>` | findByChildAndWeek=GetItem / findActiveByChild・findByChild=child Query | update(id)・expireOldChallenges=tenant Scan + filter |
| certificates | `T#<tid>#CHILD#<childId>` | `CERT#<certificateType>` | findCertificates=child Query / hasCertificate=GetItem / issueCertificate=条件付き Put | findCertificateById(id)=tenant Scan + filter |

**判断根拠**: 両 repo とも child 軸 read が最頻で SK に自然キー (weekStart / certificateType) を採用 → SQLite uniqueIndex を SK 一意性で表現でき、GetItem 1 回 + 条件付き Put (onConflictDoNothing 等価) を追加 GSI なしで実現。id だけで引く低頻度 method (update / findCertificateById) と tenant 横断の expireOldChallenges のみ Scan で解決 (stamp-card-repo / message-repo と同型)。Scan は #2842 教訓に従い Limit なし全ページ走査。

## 変更タイプ

- [x] バグ修正 (本番 write 永続 gap の根治)
- [x] テスト追加
- [x] 設計書更新

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dynamodb/auto-challenge-repo.ts` — stub → DynamoDB 本実装 (7 method)
- `src/lib/server/db/dynamodb/certificate-repo.ts` — stub → DynamoDB 本実装 (4 method)
- `src/lib/server/db/dynamodb/keys.ts` — autoChallengeKey / certificateKey + prefix + ENTITY_NAMES 2 件追加
- `scripts/dynamodb-stub-baseline.json` — 両 repo 削除
- `tests/unit/db/dynamodb-{auto-challenge,certificate}-repo.test.ts` — 新規 (32 件)
- `tests/unit/db/dynamodb-pre-pmf-fallback.test.ts` — auto-challenge 除外
- `docs/design/08-データベース設計書.md` — キー設計節 2 件

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/ tests/unit/services/` → 149 files / 2489 tests PASS
- [x] 新規 32 件 (auto-challenge 17 + certificate 15) PASS
- [x] `biome check` PASS (auto-format 適用済)
- [x] svelte-check: 変更ファイルに型エラー 0 (残 58 error は worktree の infra/ aws-cdk-lib 未 install による pre-existing、本 PR と無関係)
- [x] `check-dynamodb-stub-parity.mjs` OK (5 repo / 30 method)
- [x] `check-dynamodb-stub.mjs` OK (stub / 仮実装 / 空実装なし)

## スクリーンショット / ビジュアルデモ

N/A — server 層 repository のみの変更。UI 変更なし。

## コード品質セルフレビュー (#1481)

- merged exemplar (child-activity #2820 / message #2838 / stamp-card #2839 / sibling-cheer #2848) と同一パターンで実装、独自実装を最小化
- repo-helpers (`stripKeys`) / counter (`nextId`) / bulk-delete (`deleteItemsByPkPrefix`) の既存共通機構を再利用
- DynamoDB 予約語 `status` は `#status` alias で escape
- SQLite schema default (current_count=0 / status='active' / description=null / metadata=null) を明示補完し `.returning()` 等価性を担保

## 横展開・影響波及チェック

- demo repo (`src/lib/server/db/demo/{auto-challenge,certificate}-repo.ts`) は in-memory demo 用の別実装で既に本実装済 (stub ではない) のため変更不要
- interface (`interfaces/{auto-challenge,certificate}-repo.interface.ts`) と本実装の signature 一致を確認
- SQLite 実装は挙動 SSOT として不変。本 PR は DynamoDB 側のみ機能等価化

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。新規 SK prefix `AUTOCHAL#` / `CERT#` は既存 child partition に追加されるのみで既存データと衝突しない
- 確認依頼: key 設計 (SK に自然キー採用 → 追加 GSI 不要) の妥当性

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] CI 全 step 通過を確認する (push 後 CI green 確認)
- [x] `npm run pre-ready` 相当の検証を実施 (vitest / biome / svelte-check / stub-parity)
- [x] 設計書を同期した
- [x] AC 検証マップを 4 列で記載した
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: 本実装の機能等価性を unit test で回帰固定、CI green を Ready 条件とする)

## QM レビュー結果

(QM 記入欄)

