### PR TITLE
docs: #2440 PR-A1 — ADR-0042 を 150 行上限に縮約 (詳細は DESIGN.md §4 SSOT へ pointer 化)

### DIFF
--- a/docs/decisions/0042-lp-spacing-layout-tokens.md
+++ b/docs/decisions/0042-lp-spacing-layout-tokens.md
@@ -10,58 +10,29 @@
 | 関連 ADR | ADR-0001 (設計書 SSOT) / ADR-0009 (LP labels.ts SSOT) / ADR-0013 (LP truth from implementation) / ADR-0025 (LP SSOT 注入機構) / ADR-0032 (LP 静的コンテンツ コンポーネント設計原則) |
 | 関連監視機構 | #1840 / PR #1841 (`cumulative-lp-metrics` ジョブ — pre-merge cumulative gate) |
 
+> **詳細仕様の SSOT**: Base / Semantic トークンの一覧・値・用途、設計原則表、禁忌、適用範囲、実体（定義 / 参照ファイル）は [`docs/DESIGN.md` §4「LP Spacing/Layout 3 層トークン」](../DESIGN.md) を参照。全 `--lp-*` Semantic トークンの網羅列挙は実装の事実である `site/shared.css` の `:root` ブロックを正とする。本 ADR は**意思決定の核（なぜ 3 層化したか / 選択肢比較 / トレードオフ）**のみを記録する。
+
 ## 1. コンテキスト
 
-LP (`site/index.html` ほか) の section padding / margin / heading 余白 / faq 内 padding 等の Layout 系設計値が、**過去 5 PR で多層的に圧縮**されている状態。
+LP (`site/index.html` ほか) の section padding / margin / heading 余白 / faq 内 padding 等の Layout 系設計値が、**過去 5 PR (#1759 / #1798 / #1827 / #1831 / #1836) で多層的に圧縮**された結果、`<style>` ブロック内に同種設計値（`28px` / `14px` / `36px` 等）が**散在**し、次回 ratchet 違反時に**どこを削るべきか判断不能**な状態に陥っていた。
 
-### 1.1 多層圧縮の経緯
+§2 カラートークンは既に **Base → Semantic → Component の 3 層 SSOT** で運用済み（`docs/DESIGN.md` §2）。Spacing/Layout も同水準の設計品質に揃えるべき、という観点で本 ADR を起票した。
 
-| PR | 圧縮対象 | Before → After |
-|----|--------|---------------|
-| #1759 | hero / soft-features padding | 初期 |
-| #1798 | `.cta-bottom` padding-bottom | 56 → 80 (拡大、後に再圧縮) |
-| #1827 | LP copy / IA bundle 全般 | section padding 微調整 |
-| #1831 | `.cta-bottom` / `.faq-item` padding | 56 → 40 / 18 → 14 |
-| #1836 | `.section` / `.section-desc` / `.cta-bottom` padding | 40 → 28 / 16 → 14 / 40 → 28 |
-
-5 PR にわたる漸進的圧縮の結果、`site/index.html` `<style>` ブロック内に同種設計値（`28px` / `14px` / `36px` 等）が**散在**し、次回 ratchet 違反時に**どこを削るべきか判断不能**な状態に陥っていた。
-
-### 1.2 同種多層化の前例 (Color)
-
-§2 カラートークンは既に **Base → Semantic → Component の 3 層 SSOT** で運用済み（`docs/DESIGN.md` §2）。Spacing/Layout も同水準の設計品質に揃えるべき、という観点で本 ADR を起票。
-
-### 1.3 累積監視機構との関係 (#1840)
-
-Issue #1840 で「PR ごとの累積 desktopHeight 監視機構（pre-merge cumulative gate）」が PR #1841 で実装済み。`.github/workflows/lp-metrics.yml` に `cumulative-lp-metrics` ジョブが追加され、過去 N PR の累積膨張を pre-merge で検出する設計。
-
-**本リファクタは累積監視機構と相補的に機能する**:
-
-| 防御層 | 役割 | 担当 |
-|-------|------|------|
-| 実装側 (本 ADR) | 多層化を**防ぐ** (Semantic トークンに集約させ、Component 側に値を散らさない) | Dev / PR レビュー |
-| CI 側 (#1840) | 累積膨張を**検出する** (Semantic トークン値の変化が累積で閾値を超えたら fail) | CI / pre-merge gate |
-
-実装側だけでは新規 Component 追加で散在を再発する可能性があり、CI 側だけでは多層化の温床（散在した直書き値）を残してしまう。両者を組み合わせて**多層防御**とする。
+なお Issue #1840 で実装された累積 desktopHeight 監視機構（`cumulative-lp-metrics` ジョブ、PR #1841）とは**相補的に機能する**。実装側 (本 ADR) で多層化を**防ぎ**（Semantic トークンに集約させ Component 側に値を散らさない）、CI 側 (#1840) で累積膨張を**検出する**。実装側だけでは新規 Component 追加で散在が再発し、CI 側だけでは多層化の温床（散在した直書き値）を残してしまうため、両者を組み合わせて多層防御とする。
 
 ## 2. 検討した選択肢（OSS / 確立パターン 2 件以上 — #1350）
 
-調査した一次資料:
-
-- **MDN — CSS custom properties (variables)** — `:root` 変数で base token 化、変数差替えで variant を実現する確立パターン
-- **Tailwind CSS spacing scale** — 4px グリッド (0 / 1 / 2 / ... / 16) を utility class で提供。industry de facto standard
-- **Material Design — spacing system** — 8dp grid をベースに `dp1` / `dp2` / ... の token 体系を提供
-- **Bootstrap 5 — spacers utility** — `$spacer * 0.25` / `$spacer * 0.5` / ... を Sass 変数で管理
-- **CUBE CSS / Every Layout (Andy Bell)** — utility class (`u-stack-md` 等) で spacing variant を表現
+調査した一次資料: **MDN — CSS custom properties** (`:root` 変数で base token 化、変数差替えで variant 実現の確立パターン) / **Tailwind CSS spacing scale** (4px グリッド、industry de facto standard) / **Material Design — spacing system** (8dp grid token 体系) / **Bootstrap 5 — spacers utility** (Sass 変数で管理) / **CUBE CSS / Every Layout (Andy Bell)** (utility class での spacing variant)。
 
 ### 選択肢 1: CSS Custom Properties で 3 層トークン化 (採用)
 
-- 概要: `site/shared.css` の `:root` に Base spacing (`--space-0` 〜 `--space-16`、4px グリッド 14 段階) と Semantic LP トークン (`--lp-section-padding-y` 等 12 種) を定義し、`site/index.html` の `<style>` から Semantic 経由で参照
+- 概要: `site/shared.css` の `:root` に Base spacing (`--space-*`、4px グリッド) と Semantic LP トークン (`--lp-section-padding-y` 等) を定義し、`site/index.html` の `<style>` から Semantic 経由で参照
 - メリット:
   - **build pipeline ゼロ** — LP は GitHub Pages 静的配信のため、PostCSS / Tailwind 等の build step 追加は Pre-PMF 過剰投資 (ADR-0010 バケット C)
   - **既存 Color 3 層と同じパターン** — DESIGN.md §2 に既存記述があり、設計同型
   - **ADR-0025 SSOT 注入機構と無干渉** — `data-lp-key` 注入経路に影響なし
 - デメリット: stylelint で hard-fail 化するまでは直書きを禁止できない（Phase 2 で対応）
-- Pre-PMF コスト: `:root` 定義 14 + 12 行追加 + Component 側の置換のみ。build 影響ゼロ
+- Pre-PMF コスト: `:root` 定義 + Component 側の置換のみ。build 影響ゼロ
 
 ### 選択肢 2: PostCSS / Sass のビルドパイプライン導入
 
@@ -85,127 +56,13 @@ Issue #1840 で「PR ごとの累積 desktopHeight 監視機構（pre-merge cumu
 
 ## 3. 決定
 
-`site/shared.css` の `:root` ブロックに以下の 3 層トークンを定義し、`site/index.html` `<style>` から Semantic 経由で参照する。
+`site/shared.css` の `:root` ブロックに **Base Spacing トークン (4px グリッド)** と **Semantic LP Spacing トークン (`--lp-*`)** を定義し、`site/index.html` 等の `<style>` から **Semantic 経由でのみ参照**する。3 層 (Base → Semantic → Component) の責務分離は §2 カラートークンと同型とする。
 
-### 3.1 Base Spacing (4px グリッド、14 段階)
+- **Base / Semantic トークンの一覧・値・用途**、設計原則表、禁忌、適用範囲、実体（定義 / 参照ファイル）は [`docs/DESIGN.md` §4](../DESIGN.md) が SSOT。全 `--lp-*` Semantic トークンの網羅列挙は実装の事実である `site/shared.css` の `:root` ブロックを正とする（DESIGN.md §4 §実体）。
+- 命名規約は「`--lp-<部位>-<軸 or 用途>`」に固定し、variant 爆発を防ぐ。
+- baseline pin 機構: `scripts/check-lp-inline-style.mjs` + `scripts/lp-inline-style-baseline.json` で残ローカル装飾値 (gap / 微小余白 / 絵文字 padding 等) を pin し、新規違反 1 件で CI fail (`lp-metrics.yml` `inline-style-check` ジョブ、#1851)。意図的増減時のみ `--update-baseline` で更新する。
 
-`--space-0` (0) / `--space-1` (4px) / `--space-2` (8px) / `--space-3` (12px) / `--space-4` (16px) / `--space-5` (20px) / `--space-6` (24px) / `--space-7` (28px) / `--space-8` (32px) / `--space-9` (36px) / `--space-10` (40px) / `--space-12` (48px) / `--space-14` (56px) / `--space-16` (64px)
-
-Tailwind / Material Design 系列に整合。4px グリッド外の値（14px = `--space-3` と `--space-4` の中間）は Semantic 側で直値定義する。
-
-### 3.2 Semantic LP Spacing (12 種)
-
-| トークン | 値 | 用途 |
-|---------|----|------|
-| `--lp-section-padding-y` | `var(--space-7)` | `.section` 縦 padding (28px、#1836 圧縮済み) |
-| `--lp-section-padding-x` | `var(--space-4)` | `.section` 横 padding (16px) |
-| `--lp-section-title-mb` | `var(--space-1)` | `.section-title` 下マージン (4px、#1831 圧縮済み) |
-| `--lp-section-desc-mb-default` | `14px` | `.section-desc` 下マージン (#1836、4px グリッド外のため直値) |
-| `--lp-faq-item-padding-y` | `14px` | `.faq-item` 上下 padding (#1831、4px グリッド外のため直値) |
-| `--lp-hero-padding-top` | `var(--space-12)` | `.hero` 上 padding (48px) |
-| `--lp-hero-padding-bottom` | `var(--space-9)` | `.hero` 下 padding (36px) |
-| `--lp-card-padding-y` | `var(--space-4)` | card 系統合 (`.tour-card` / `.soft-card` / `.core-loop-card`) 縦 padding 既定 (16px、#1911 B-1 で `var(--space-5)` から圧縮) — 詳細は §3.5 |
-| `--lp-card-padding-x` | `14px` | card 系統合 横 padding 既定 (14px、4px グリッド外のため直値、#1911 B-1 で `var(--space-4)` から圧縮) — 詳細は §3.5 |
-| `--lp-card-gap` | `var(--space-5)` | grid 間隔 (20px) |
-| `--lp-container-max` | `1080px` | section-inner / header-inner / footer-inner の最大幅 |
-| `--lp-container-max-wide` | `1280px` | hero / machine-tour / guide 用ワイド版 |
-
-### 3.3 Component (置換対象)
-
-Phase 1 で `site/index.html` の主要 6 セレクタを Semantic 経由参照に置換: `.section` / `.section-title` / `.section-desc` / `.hero` / `.faq-item` / `#core-loop`。
-
-**注**: 当初は 7 セレクタ目に `.cta-bottom` を含んでいたが、PR #1842 (#1838) で `.cta-bottom` セクション自体が全削除されたため、本 PR の rebase 時に `.cta-bottom` 関連 CSS ルールおよび Semantic トークン (`--lp-cta-bottom-padding-top/-bottom`) も併せて削除。Phase 1 完了時点で `.cta-bottom` は LP に存在しない。
-
-### 3.4 段階適用
-
-| Phase | 対象 | 担当 | ステータス |
-|-------|------|------|----------|
-| Phase 1 (PR #1850) | `:root` トークン整備 + 主要 6 セレクタ置換 | Dev | **完了 (2026-05-02)** |
-| Phase 2 (#1851 / 本 PR) | 残り構造的 padding/margin の Semantic 化 + `pricing.html` 波及 + `scripts/check-lp-inline-style.mjs` baseline pin 機構の導入 | Dev | **完了 (2026-05-06)** |
-| Phase 3 (#2395) | `pamphlet.html` / `faq.html` / `selfhost.html` / `graduation.html` へ同パターンで波及 (4 HTML baseline 72 → 0、削減率 100%) | Dev | **完了 (2026-05-22)** |
-
-### 3.5 Phase 2 で追加された Semantic トークン
-
-`site/index.html` 用 (構造的 padding/margin):
-
-| トークン | 値 | 用途 |
-|---------|----|------|
-| `--lp-card-padding-y` / `-x` (#1911 B-1) | `var(--space-4)` / `14px` | card 系統合 (`.tour-card` / `.soft-card` / `.core-loop-card`) 既定 (16px / 14px) |
-| `--lp-card-padding-y-md` / `-x-md` (#1911 B-1) | `var(--space-6)` / `22px` | card 系統合 @≥1024px (24px / 22px) |
-| `--lp-card-padding-y-lg` / `-x-lg` (#1911 B-1) | `var(--space-7)` / `var(--space-6)` | card 系統合 @≥1440px (28px / 24px) |
-| `--lp-card-shot-aspect-ratio` (#1911 B-3) | `390/844` | card 系 scrshot 枠 (`.tour-shot` / `.soft-shot` / `.age-panel-shot`) aspect-ratio 統一値 |
-| `--lp-trust-badge-padding-y` / `-x` | `var(--space-6)` / `var(--space-5)` | `.trust-badge` (24px / 20px) |
-| `--lp-trust-badge-padding-y-lg` / `-x-lg` | `var(--space-5)` / `var(--space-4)` | `.trust-badge` @≥1024px (20px / 16px) |
-| `--lp-trust-disclaimer-margin-top` | `var(--space-8)` | `.trust-disclaimer` (32px) |
-| `--lp-trust-disclaimer-padding-y` / `-x` | `var(--space-4)` / `var(--space-5)` | `.trust-disclaimer` (16px / 20px) |
-| `--lp-versus-card-padding-y` / `-x` | `10px` / `var(--space-3)` | `.versus-card` 既定 (10px / 12px) |
-| `--lp-versus-card-padding-y-sm` / `-x-sm` | `var(--space-2)` / `10px` | `.versus-card` @≤640px (8px / 10px) |
-| `--lp-pp-band-padding-y` / `-x` | `var(--space-6)` / `22px` | `.pp-band` 既定 (24px / 22px) |
-| `--lp-pp-band-padding-y-sm` / `-x-sm` | `18px` / `14px` | `.pp-band` @≤640px |
-| `--lp-floating-cta-padding-y` / `-x` | `10px` / `var(--space-4)` | `.floating-cta` (10px / 16px) |
-| `--lp-floating-cta-btn-padding-y` / `-x` | `var(--space-2)` / `var(--space-4)` | `.floating-cta .btn` (8px / 16px) |
-| `--lp-age-panel-padding-y` / `-x` | `var(--space-8)` / `var(--space-7)` | `.age-panel` 既定 (32px / 28px) |
-| `--lp-age-panel-padding-y-sm` / `-x-sm` | `var(--space-6)` / `var(--space-5)` | `.age-panel` @≤640px (24px / 20px) |
-| (`--lp-core-loop-card-padding` 削除、#1911 B-1) | — | `.core-loop-card` は `--lp-card-padding-*` に統合 |
-| `--lp-growth-roadmap-padding-y` / `-x` | `var(--space-6)` / `var(--space-4)` | `#growth-roadmap` (24px / 16px) |
-| `--lp-versus-section-padding-y` / `-x` | `var(--space-4)` / `var(--space-4)` | `#versus` (16px / 16px) |
-
-`site/pricing.html` 用 (AC3 波及):
-
-| トークン | 値 | 用途 |
-|---------|----|------|
-| `--lp-pricing-hero-padding-top` / `-bottom` / `-x` | `80px` / `60px` / `var(--space-4)` | `.pricing-hero` |
-| `--lp-plans-section-padding-y-top` / `-bottom` / `-x` | `var(--space-12)` / `var(--space-16)` / `var(--space-4)` | `.plans-section` (48px / 64px / 16px) |
-| `--lp-plan-card-padding-y` / `-x` | `var(--space-8)` / `var(--space-6)` | `.plan-card` (32px / 24px) |
-| `--lp-trial-section-padding-y` / `-x` | `var(--space-16)` / `var(--space-4)` | `.trial-section` (64px / 16px) |
-| `--lp-trial-box-padding-y` / `-x` | `var(--space-10)` / `var(--space-8)` | `.trial-box` 既定 (40px / 32px) |
-| `--lp-trial-box-padding-y-sm` / `-x-sm` | `var(--space-7)` / `var(--space-5)` | `.trial-box` @≤768px (28px / 20px) |
-| `--lp-faq-section-padding-y` / `-x` | `var(--space-16)` / `var(--space-4)` | `.faq-section` (64px / 16px) |
-| `--lp-cta-bottom-padding-y` / `-x` | `var(--space-16)` / `var(--space-4)` | `.cta-bottom` (64px / 16px) |
-| `--lp-family-patterns-padding-y` / `-x` | `var(--space-16)` / `var(--space-4)` | `.family-patterns` (64px / 16px) |
-| `--lp-pattern-card-padding` | `var(--space-6)` | `.pattern-card` (24px) |
-| `--lp-comparison-section-padding-x` / `-bottom` | `var(--space-4)` / `var(--space-16)` | `.comparison-section` (16px / 64px) |
-
-### 3.6 Phase 2 baseline pin 機構
-
-`scripts/check-lp-inline-style.mjs` + `scripts/lp-inline-style-baseline.json` で **残ローカル装飾値 (gap / 微小余白 / 絵文字 padding 等) を pin**。新規違反 1 件で CI fail。意図的増加時のみ `--update-baseline` で更新。
-
-`.github/workflows/lp-metrics.yml` に `inline-style-check` ジョブ追加 (#1851)。
-
-#### Phase 2 baseline 初期値 (2026-05-06)
-
-| ファイル | violation 数 | 内訳 |
-|---------|------------|------|
-| `site/index.html` | 51 | 主に gap / 微小余白 / 絵文字 padding (構造的 padding/margin は全 Semantic 化済) |
-| `site/pricing.html` | 46 | 同上 |
-| `site/faq.html` | 28 | Phase 3 で同パターン適用予定 |
-| `site/graduation.html` | 17 | Phase 3 |
-| `site/selfhost.html` | 20 | Phase 3 |
-| `site/pamphlet.html` | 7 | Phase 3 |
-| `site/privacy.html` | 7 | legal page、リファクタ予定なし |
-| `site/tokushoho.html` | 4 | legal page |
-| `site/sla.html` / `site/terms.html` | 0 | shared.css + 直書き極小 |
-
-#### Phase 3 baseline 結果 (2026-05-22、#2395)
-
-| ファイル | Phase 2 baseline | Phase 3 baseline | 削減 |
-|---------|-----------------|-----------------|------|
-| `site/faq.html` | 28 | **0** | -28 (100%) |
-| `site/graduation.html` | 17 | **0** | -17 (100%) |
-| `site/selfhost.html` | 20 | **0** | -20 (100%) |
-| `site/pamphlet.html` | 7 | **0** | -7 (100%) |
-| **4 HTML 合計** | **72** | **0** | **-72 (100%)** |
-
-Phase 3 で追加された Semantic トークン群 (`site/shared.css` `:root`):
-
-- **content 共通 hero / CTA / section spacing** (`--lp-content-hero-*` / `--lp-content-cta-*` / `--lp-content-section-*` / `--lp-content-hero-title-mb`) — faq / graduation / selfhost で共有
-- **selfhost hero 専用** (`--lp-selfhost-hero-padding-y-top` / `-bottom` / `-x` / `-desc-mb`) — 60px グリッド外 padding を独立定義
-- **faq 専用** (`--lp-faq-toc-*` / `--lp-faq-sections-*` / `--lp-faq-category-*` / `--lp-faq-item-*` / `--lp-faq-answer-*` / `--lp-faq-cta-trust-mt` / `--lp-faq-contact-mt`) — toc / sections / category / item / answer 階層
-- **graduation 専用** (`--lp-graduation-breadcrumb-*` / `--lp-graduation-detail-*` / `--lp-gr-stage-*` / `--lp-gr-age-*` / `--lp-gr-body-*` / `--lp-gr-shot-margin-y` / `--lp-gr-benefit-margin-y` / `--lp-graduation-cta-*`) — breadcrumb / 5 stage カード / CTA
-- **selfhost 専用** (`--lp-selfhost-setup-code-*` / `--lp-selfhost-feature-list-*` / `--lp-selfhost-table-*` / `--lp-selfhost-note-box-*` / `--lp-selfhost-req-*`) — code / list / table / note-box / req-grid
-- **pamphlet 専用** (`--lp-pamphlet-control-*` / `--lp-pamphlet-screen-controls-*` / `--lp-pamphlet-page-num-*` / `--lp-pamphlet-fi-layer-badge-*`) — 印刷用ページ frame + 操作 UI (mm 単位は対象外)
-
-注: pamphlet.html の本文 padding/margin は印刷用 mm 単位 (`docs/troubleshoot/screenshot_capture.md` 規約) で、`check-lp-inline-style.mjs` の検出範囲 (`px|em|rem|%`) 外。今回置換対象は `px` 単位の screen-controls / page frame / fi-layer-badge のみ。
+段階適用は Phase 1 (PR #1850、`:root` トークン整備 + 主要 6 セレクタ置換) → Phase 2 (#1851、残構造的 padding/margin の Semantic 化 + `pricing.html` 波及 + baseline pin 機構導入) → Phase 3 (#2395、`pamphlet.html` / `faq.html` / `selfhost.html` / `graduation.html` へ波及、4 HTML baseline 72 → 0) の順で完遂済み。各 Phase で追加された Semantic トークン群と baseline 数値は DESIGN.md §4 §実体および `site/shared.css` を参照。
 
 ## 4. 帰結 (Consequences)
 
@@ -219,7 +76,7 @@ Phase 3 で追加された Semantic トークン群 (`site/shared.css` `:root`):
 ### 4.2 ネガティブ / リスク
 
 - Phase 2 完了まで直書きと Semantic 経由が混在する（リスク低、Phase 2 で stylelint hard-fail 化により恒久解消）
-- Semantic トークン名 (`--lp-*`) の命名規約が緩いと variant 爆発のリスク → 命名規則「`--lp-<部位>-<軸 or 用途>`」を本 ADR §3.2 で固定
+- Semantic トークン名 (`--lp-*`) の命名規約が緩いと variant 爆発のリスク → 命名規則「`--lp-<部位>-<軸 or 用途>`」を §3 で固定
 
 ### 4.3 維持すべき不変条件
 
@@ -243,10 +100,3 @@ Phase 3 で追加された Semantic トークン群 (`site/shared.css` `:root`):
 - LP メトリクス: cta-bottom 削除済み main を base としても `mobileHeight ≤ 15000` / `desktopHeight ≤ 8000` / `forbiddenTerms=0` / `ctaVariants ≤ 3` 全閾値内
 - before/after スクリーンショット: 視覚的差異ゼロ（mobile / desktop の md5 ハッシュ完全一致を Phase 1 で担保）
 - `npm run pre-ready -- --pr 1850` の 7 Step 全 PASS
-
-## 7. 改訂履歴
-
-| 日付 | 改訂内容 |
-|------|---------|
-| 2026-05-02 | 初版（Phase 1 実装に伴う ADR 起票） |
-| 2026-05-06 | Phase 2 完了 (#1851 PR)。残構造的 padding/margin の Semantic 化 + `pricing.html` 波及 + baseline pin 機構 (`scripts/check-lp-inline-style.mjs` + `lp-metrics.yml inline-style-check` ジョブ) 追加。Phase 2 で追加された Semantic トークン 30 種を §3.5 に明記、baseline 初期値を §3.6 に明記 |


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者 / AI Agent — docs を SSOT として参照する全員）

**解決する課題**: ADR-0042 は 231 行 / 7 セクションで per-ADR ボリューム上限 (≤150 行 / ≤7 セクション、`docs/decisions/README.md` §ボリューム上限ルール) の **最大違反**だった。詳細トークン表が本文の大半を占め、ADR の本務である「意思決定の核」が埋もれて 5 分通読不能になっていた。2026-05-09 棚卸でも「詳細表が大半 → `docs/DESIGN.md §4` への分離が候補」と記録済み。

**期待される効果**: ADR-0042 を意思決定の核（コンテキスト / 選択肢比較 / 決定 / 帰結 / 関連 ADR / 検証）に縮約し 102 行 / 6 セクションへ。詳細トークン仕様は既に SSOT を持つ `docs/DESIGN.md §4` + `site/shared.css`（全 `--lp-*` 網羅列挙の実体）へ pointer 化。「現状の正解」のみを端的に記述する docs SSOT 原則（#2440）に整合し、ADR を常時参照可能なルールに戻す。本 PR は #2440 確定計画の PR-A1（1 ADR = 1 PR 粒度）。

## 関連 Issue

refs #2440

関連 ADR: ADR-0042（本 PR の対象）/ ADR-0001（設計書 SSOT）

## AC 検証マップ (ADR-0004)

本 PR は #2440 全体 AC のうち PR-A1 scope（ADR-0042 単体の volume 是正、AC3 / AC10 / AC11 系）を担う。PR-A1 固有の受け入れ基準を以下に定義する。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| A1-1 | ADR-0042 を ≤150 行に縮約 | `wc -l docs/decisions/0042-lp-spacing-layout-tokens.md` | PASS — 252 → 102 行 |
| A1-2 | ADR-0042 を ≤7 セクションに縮約 | `grep -c "^## " docs/decisions/0042-lp-spacing-layout-tokens.md` | PASS — 7 → 6 セクション |
| A1-3 | 意思決定の核（コンテキスト / 選択肢比較 / 決定 / トレードオフ）を意味変更ゼロで保持 | git diff 目視 + 下記「無損失対応表」 | PASS — §1 圧縮経緯要点 / §2 選択肢 3 件 / §3 決定 / §4 帰結 / §5 関連 ADR / §6 検証 を全保持 |
| A1-4 | 削除した詳細はどこにも消えず DESIGN.md §4 / 実 SSOT に存在（情報無損失） | 下記「無損失対応表」+ `grep -c "\-\-lp-" site/shared.css` (159 件) | PASS — 全削除ブロックは DESIGN.md §4 既存記述 or `site/shared.css` / `lp-inline-style-baseline.json` に既存 |
| A1-5 | ADR-0042 被参照（CLAUDE.md / ADR-0045 / codebase-map / script 等）の指す節・内容が縮約後も成立（anchor 切れゼロ） | `grep -rn "ADR-0042"` 全件 vs 縮約後本文の claim 照合 | PASS — Phase 2 / cumulative gate / Base→Semantic→Component / ADR-0032 関係 / baseline pin の全被参照成立 |
| A1-6 | `check-doc-code-references.mjs` 新規違反なし | `node scripts/check-doc-code-references.mjs` | PASS — baseline 内 143 件、新規違反 0、exit 0 |
| A1-7 | ADR ヘッダ（ステータス表）・README.md 表行・棚卸レポートは不変 | git diff（本 PR は ADR 1 file のみ変更） | PASS — `git diff --stat` = 1 file changed |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI / docs (`docs/decisions/`)

**影響を受ける画面・機能**: なし（docs 1 file のみ。実装コード・LP・UI への影響ゼロ）。`docs/decisions/0042-lp-spacing-layout-tokens.md` の縮約のみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— `npm run pre-ready -- --pr 2859` 実行済（biome / svelte-check / vitest 6286 件 PASS / check-hardcoded-strings 0 件 / check-no-plan-literals OK、LP 系 Step は変更なしのため skip）
- [x] 追加・変更したテストの概要: N/A（docs 縮約のみ、テスト変更なし）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: docs（ADR markdown）の縮約のみで UI 変更を含まないため。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（docs 縮約）
- [x] **DRY**: 縮約の目的そのものが重複排除（ADR の詳細トークン表 → DESIGN.md §4 SSOT への一本化）
- [x] **YAGNI**: N/A
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 設計書同期 (ADR-0001) — DESIGN.md §4 が既に詳細トークン SSOT を保持しており、本 PR は ADR → DESIGN.md §4 への pointer 化で整合を維持
- [x] N/A — 上記以外の並行実装の影響範囲外（本番/デモ・LP・年齢モード・ナビ・labels への影響なし）

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- 情報無損失の核心: ADR §3.5 / §3.6 の Phase 別追加トークン列挙・baseline 数値は「Phase ごとの追加」という経緯メタ情報（#2440 docs SSOT 原則で docs 本文に置かない対象）であり、全 `--lp-*` トークンの実体 SSOT は `site/shared.css`（159 件）、baseline 現状は `scripts/lp-inline-style-baseline.json` に存在する。DESIGN.md §4 §実体が両者を pointer しているため、ADR からの削除は無損失。
- ADR ヘッダの「関連 Issue: #1839 / #1851」は意図的に不変（旧 §3.4 に記載のあった #2395 は §3 決定本文に保持）。

### 無損失対応表（削除ブロック → 重複 or 移設先）

| ADR 旧ブロック (行) | 内容 | 削除可の根拠（重複 or 既存 SSOT） |
|---|---|---|
| §1.1 多層圧縮の経緯（PR 表 L17-27） | 5 PR の Before→After 表 | §1 本文に「過去 5 PR (#1759 / #1798 / #1827 / #1831 / #1836) で多層的に圧縮」と要点保持。PR 別 diff は git 履歴が SSOT |
| §1.2 同種多層化の前例（L29-31） | Color 3 層前例 | §1 本文に「§2 カラートークンは既に 3 層 SSOT で運用済み」として保持 |
| §1.3 累積監視機構との関係（防御層表 L33-44） | 2 層防御の表 | §1 本文 + §4.1 + §5 に「実装側で防ぐ / CI 側で検出する 2 層防御」を散文で保持 |
| §3.1 Base Spacing 全 14 段階列挙（L90-94） | `--space-0`〜`--space-16` 値 | **DESIGN.md §4「Base Spacing トークン (4px グリッド)」表（L102-119）と重複**。実体は `site/shared.css :root` |
| §3.2 Semantic LP Spacing 12 種表（L96-111） | 主要 `--lp-*` 値 | **DESIGN.md §4「Semantic LP Spacing トークン」表（L121-139）と重複** |
| §3.3 Component 置換 + .cta-bottom 削除注記（L113-117） | 主要 6 セレクタ + cta-bottom 撤去経緯 | §3 決定本文に「主要 6 セレクタ置換」を保持。cta-bottom 撤去は経緯メタ（#2440 で docs 本文非対象）、git 履歴 (#1842 / #1838) が SSOT |
| §3.4 段階適用 Phase 表（L119-125） | Phase 1/2/3 完了ステータス | §3 決定本文に Phase 1→2→3 の対象範囲を散文で保持。「完了 (日付)」datestamp は経緯メタ（#2440 非対象） |
| §3.5 Phase 2 追加 Semantic トークン全列挙（L127-167） | trust-badge / versus-card / pp-band / age-panel / pricing 系 30+ トークン | **実体 SSOT = `site/shared.css :root`（159 `--lp-*` トークン、存在確認済）**。DESIGN.md §4 §実体（L147-151）が「全 `--lp-*` 網羅列挙は site/shared.css を正とする」旨を保持 |
| §3.6 baseline pin 機構 + 初期値/Phase3 結果表（L169-208） | baseline 数値スナップショット | baseline pin 機構の説明は §3 決定本文に保持。**baseline 現状の実体 SSOT = `scripts/lp-inline-style-baseline.json`**。数値スナップショットは経緯メタ（#2440 非対象）、git 履歴が SSOT。DESIGN.md §4 §実体が JSON を pointer |
| §7 改訂履歴（L247-252） | 日付別改訂ログ | **#2440 docs SSOT 原則で明示禁止の「変更履歴」節**。git log / 本 PR description が SSOT |

> 注: 上記「移設」は新規追加ゼロで成立した（削除ブロックの内容は全て DESIGN.md §4 既存記述 / `site/shared.css` / baseline JSON / git 履歴のいずれかに既存）。DESIGN.md §4 を尊重し（主要トークンのみ掲載、全列挙は shared.css に委譲する既存方針）、経緯メタ情報を docs 本文に逆流させない #2440 原則を厳守した。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（`npm run pre-ready -- --pr 2859`、Step 1-8 PASS / Step 9 は本 checkbox 記入で解消）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（PR-A1 scope の A1-1〜A1-7）
- [x] UI 変更時: 該当なし（docs のみ）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

