### PR TITLE
docs: #2440 PR-A3 — ADR-0025 を 150 行上限に縮約 (XSS 設計詳細は設計書 SSOT へ)

### DIFF
--- a/docs/decisions/0025-lp-ssot-html-injection-with-xss-protection.md
+++ b/docs/decisions/0025-lp-ssot-html-injection-with-xss-protection.md
@@ -2,176 +2,79 @@
 
 | 項目 | 内容 |
 |------|------|
-| ステータス | **accepted (2026-04-30)** |
+| ステータス | **accepted (2026-04-30, #1683 完遂 + #1704)** |
 | 日付 | 2026-04-29（accepted 昇格 2026-04-30） |
 | 起票者 | PO |
 | 関連 Issue | #1683 / #1465 / #1346 / #1704 (umbrella close) |
-| 関連 ADR | ADR-0009（labels SSOT 原則） / ADR-0014（i18n 機構選定） / ADR-0008（設計ポリシー先行確認） |
-
-> **Status 昇格履歴 (2026-04-30, #1704)**: `proposed (amended)` → **`accepted`**。1683 sub-A (#1701/#1705 機構刷新) + sub-B (#1702/#1718 LP 339件) + sub-C (#1703/#1717 Legal 354件) が全て main 反映され、`scripts/lp-ssot-baseline.json` が `count: 0` を達成。本 ADR の§決定（innerHTML + DOMPurify CDN + LP_LEGAL_*_LABELS namespace + check-lp-ssot.mjs depth-stack 免除 + LEGAL coverage check rework）は実装で全件成立済。pamphlet.html の印刷タイミング再注入は `tests/e2e/pamphlet-print-ssot.spec.ts` (#1704) で E2E 担保。
->
-> **Amendment 履歴 (2026-04-29)**: 初版で曖昧だった 3 点を確定:
->
-> 1. SSOT は `site/shared-labels.js` ではなく **`scripts/generate-lp-labels.mjs` (applyLpKeys template, L377-392)**。`shared-labels.js` は同 script からの **生成物** であり、ADR §決定の文言を「自動生成テンプレート改修 + 再生成」に修正
-> 2. DOMPurify の配信方法を **CDN 必須** に確定（`site/` は GitHub Pages 上の static アセットで、npm bundle 経路を持たない）。`<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js">` を `site/*.html` 全 8 ファイルの `<head>` に追加し、`window.DOMPurify` 経由で参照する
-> 3. `scripts/check-lp-ssot.mjs` L186-260 の **`LEGAL_LABELS` coverage check** との整合性を §結果 Migration Plan に明記（法的文書を `LP_LEGAL_*_LABELS` namespace で labels.ts 化した後、双方向同期ロジックを再設計する）
+| 関連 ADR | ADR-0009（labels SSOT 原則、§例外「法的文書」を本 ADR が supersede） / ADR-0014（i18n 機構選定） / ADR-0029（LP CSP / CDN allowlist、表裏一体） |
 
 ## コンテキスト
 
-ADR-0009 で確立した「LP/Legal を含む全ユーザー露出文言の SSOT 化」を **100% 完遂**するために、現行の `site/shared-labels.js#applyLpKeys()` が抱える 3 つの構造的限界を解消する必要がある（Issue #1683 直前 Agent fail report でも identified）。
+ADR-0009 の「LP / Legal を含む全ユーザー露出文言の SSOT 化」を 100% 完遂するには、`site/shared-labels.js#applyLpKeys()`（旧実装）が抱える 3 つの構造的限界を解消する必要があった。
 
-1. **textContent 注入は nested HTML を破壊する** — 現在の実装は `el.textContent = value` で値を流し込む。LP の `data-lp-key` 付き要素のうち **156+ 件**（`<strong>` / `<em>` / `<a>` / `<span class>` / `<br>` 等を内包する 178 行サンプル経由で確認）が nested HTML を持っており、SSOT 化したくても机上不可能。例:
+1. **textContent 注入が nested HTML を破壊する** — `el.textContent = value` 方式では `<strong>` / `<em>` / `<a>` / `<span class>` / `<br>` を内包する LP 要素（156+ 件）を SSOT 化できない。
    ```html
    <p data-lp-key="heroPriceBand.container"><span><strong>基本無料</strong></span>・月<strong>¥500〜</strong>…</p>
    ```
-2. **法的文書（privacy/terms/sla/tokushoho 354 件）が SSOT 外** — `scripts/check-lp-ssot.mjs` で `EXCLUDED_LEGAL_FILES` として除外運用。PO 方針「SSOT 漏れのコンテンツは存在してはいけない」と直接矛盾。
-3. **pamphlet.html は印刷専用の独自構造** — `window.print()` 起動前に SSOT 注入が完了していない場合、未注入のフォールバックテキストが印刷される懸念。
+2. **法的文書（privacy/terms/sla/tokushoho 354 件）が SSOT 外** — `EXCLUDED_LEGAL_FILES` 除外運用が PO 方針「SSOT 漏れのコンテンツは存在してはいけない」と矛盾。
+3. **pamphlet.html は印刷専用構造** — `window.print()` 起動前に SSOT 注入が完了していないと未注入フォールバックが印刷される懸念。
 
-PO 判断 (#1683): **案 A** = architecture ADR 先行起票 → ADR 確定 → 1 PR で 693 件全件 SSOT 化。本 ADR はその architecture を確定する唯一の文書。
+PO 判断 (#1683): architecture ADR 先行確定 → 1 系統で LP 339 + Legal 354 = 693 件全件 SSOT 化。本 ADR がその architecture を確定する。
 
 ## 検討した選択肢（OSS 先調査 — #1350 / ADR-0014 整合）
 
-### 選択肢 A: DOMPurify による innerHTML 注入 + 許可タグ制限（推奨）
+### 選択肢 A: DOMPurify による innerHTML 注入 + 許可タグ制限（採用）
 
-- **概要**: [`DOMPurify`](https://github.com/cure53/DOMPurify) (v3.x、~22 KB gzip)。OWASP / Google / GitHub などが採用する業界標準 HTML sanitizer。weekly downloads 6M+、最終 commit 数日内、MIT。
-- **適用**: `applyLpKeys()` で `el.innerHTML = DOMPurify.sanitize(value, { ALLOWED_TAGS, ALLOWED_ATTR })` に置換。`ALLOWED_TAGS = ['strong','em','a','br','span','sup','sub']`、`ALLOWED_ATTR = ['href','target','rel','class','aria-hidden']`、`ALLOW_DATA_ATTR = false`、リンクは `target=_blank` 時 `rel=noopener noreferrer` 強制（DOMPurify hook）。
-- **メリット**: nested HTML を保持しつつ XSS を業界標準で防御、bundle 22 KB gzip は LP 規模で許容、SSR 不要のためビルドフロー追加なし。
-- **デメリット**: 22 KB の bundle 増。pamphlet.html は印刷タイミングと注入完了の同期が必要（後述 §Migration）。
-- **Pre-PMF コスト** (ADR-0010): 導入工数 低（1 ファイル + 1 dep）、学習コスト 低、bundle 影響 軽（LP は CDN/static、tree-shake 不要のメイン script は LP 訪問者のみ）、長期保守性 **高**。
+- **概要**: [`DOMPurify`](https://github.com/cure53/DOMPurify) (v3.x、~22 KB gzip)。OWASP / Google / GitHub 採用の業界標準 HTML sanitizer。weekly downloads 6M+、MIT。
+- **適用**: `applyLpKeys()` で `el.innerHTML = DOMPurify.sanitize(value, { ALLOWED_TAGS, ALLOWED_ATTR })` に置換。link の `target=_blank` には `rel=noopener noreferrer` を hook で強制。
+- **メリット**: nested HTML を保持しつつ XSS を業界標準で防御。SSR 不要でビルドフロー追加なし。
+- **Pre-PMF コスト** (ADR-0010): 導入工数 低（1 ファイル + 1 dep）、bundle 影響 軽（LP は CDN/static で訪問者のみロード）、長期保守性 高。
 
 ### 選択肢 B: nested tag を独立した `<span data-lp-key>` に分解
 
-- **概要**: `<p>...<strong>X</strong>...</p>` を全て葉まで `data-lp-key` で覆う。textContent 維持。
-- **メリット**: 追加 OSS 不要、XSS リスクゼロ。
-- **デメリット**: HTML が読めなくなる（1 行に 5+ key）。labels.ts キー数が現行 +200 程度に肥大、レビュー困難。Issue #1683 直前 Agent も失敗した方式。
-- **却下理由**: 機構として OK でもコンテンツ保守性が破綻。SSOT は「変更容易性」が目的であり、本末転倒。
+- **概要**: 葉まで `data-lp-key` で覆い textContent 維持。
+- **却下理由**: HTML が読めなくなり（1 行に 5+ key）、labels.ts キー数が +200 肥大。SSOT の目的「変更容易性」と本末転倒。Issue #1683 直前 Agent も失敗した方式。
 
 ### 選択肢 C: LP 全体を SvelteKit `adapter-static` 化して `+page.svelte` に吸収
 
-- **概要**: `site/**` を `src/routes/(marketing)/` に移し SSR/SSG。labels を直接 import。
-- **メリット**: 型安全、runtime 注入不要、SEO 完全。
-- **デメリット**: アーキテクチャ大改修（#566 で見送り、ADR-0010 バケット C 該当）、Pre-PMF 工数過大。
-- **却下理由**: ADR-0010 で「Pre-PMF 過剰」判定済み。ADR-0014 でも回避方針確認済。
+- **概要**: `site/**` を `src/routes/(marketing)/` に移し SSR/SSG、labels を直接 import。
+- **却下理由**: アーキ大改修で ADR-0010 バケット C（Pre-PMF 過剰）判定済（#566 で見送り）。
 
 ### 選択肢 D: 自前 sanitizer 実装
 
 - **概要**: 許可タグの正規表現でゼロ依存。
-- **却下理由**: XSS 関連は確立 OSS 必須（#1350 OSS 先調査ルール、10 行超）。長期保守でセキュリティリスク蓄積。
+- **却下理由**: XSS 関連は確立 OSS 必須（#1350、10 行超）。長期保守でセキュリティリスク蓄積。
 
 ## 決定
 
-**選択肢 A: DOMPurify を採用**。`scripts/generate-lp-labels.mjs` の `applyLpKeys()` テンプレート (L377-392) を innerHTML + DOMPurify sanitize に書換 → 再生成された `site/shared-labels.js` を deploy → **LP 339 件 + Legal 354 件 = 693 件すべて**を `data-lp-key` SSOT 配下に統合する。
+**選択肢 A: DOMPurify を採用**。SSOT は `scripts/generate-lp-labels.mjs` の `applyLpKeys()` テンプレート（生成物 `site/shared-labels.js` を直接編集しない）。同テンプレートを innerHTML + DOMPurify sanitize に書換 → 再生成 → LP 339 + Legal 354 = 693 件すべてを `data-lp-key` SSOT 配下に統合する。
 
-> **重要 (Amendment)**: `site/shared-labels.js` は **自動生成ファイル**である（`scripts/generate-lp-labels.mjs` 実行で再生成）。直接編集 → 上書き再生成で消失するため、SSOT は **generate-lp-labels.mjs の applyLpKeys template (L377-392)**。本 ADR の決定対象もそちらの template。
-
-### 適用範囲（PO 方針: 例外なし）
-
-1. **LP**: `site/index.html` / `pricing.html` / `faq.html` / `selfhost.html` / `pamphlet.html` / `help/license-key.html`
-2. **Legal**: `site/privacy.html` / `terms.html` / `sla.html` / `tokushoho.html`（**ADR-0009 §例外「法的文書」を本 ADR が supersede**）
-3. **labels.ts namespace**: 既存 `LP_*_LABELS` に加え新規 `LP_LEGAL_PRIVACY_LABELS` / `LP_LEGAL_TERMS_LABELS` / `LP_LEGAL_SLA_LABELS` / `LP_LEGAL_TOKUSHOHO_LABELS` / `LP_PAMPHLET_LABELS` / `LP_FAQ_BODY_LABELS` を追加（Phase 4 多言語化時に PO/JSON へ抽出可能な flat 構造を維持）。
-4. **DOMPurify 配信**: site/ は GitHub Pages の static asset であり npm bundle 経路を持たないため **CDN 必須**:
-   ```html
-   <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
-   <script src="shared-labels.js" defer></script>
-   ```
-   全 8 ファイル (`index.html` / `pricing.html` / `faq.html` / `selfhost.html` / `pamphlet.html` / `help/license-key.html` / `privacy.html` / `terms.html` / `sla.html` / `tokushoho.html`) の `<head>` に同様に追加。`applyLpKeys` は `window.DOMPurify` 参照で利用、DOMPurify が未ロードの場合は安全側で `textContent` フォールバック + console.warn (network 一時失敗時の劣化動作)。
-
-### DOMPurify 設定値（実装 Agent 直参照）
-
-`scripts/generate-lp-labels.mjs` の applyLpKeys template に以下を埋め込む（生成後 `site/shared-labels.js` の同等位置に展開される）:
-
-```js
-// generate-lp-labels.mjs L377-392 の applyLpKeys template 改修後イメージ
-function applyLpKeys() {
-  var elements = document.querySelectorAll('[data-lp-key]');
-  var Purify = (typeof window !== 'undefined') && window.DOMPurify;
-  var SANITIZE_CONFIG = {
-    ALLOWED_TAGS: ['strong','em','a','br','span','sup','sub','small','b','i'],
-    ALLOWED_ATTR: ['href','target','rel','class','aria-hidden','aria-label'],
-    ALLOW_DATA_ATTR: false,
-    ALLOW_UNKNOWN_PROTOCOLS: false,
-    ADD_ATTR: ['target']
-  };
-  if (Purify && !Purify.__gqHookInstalled) {
-    Purify.addHook('afterSanitizeAttributes', function(node) {
-      if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
-        node.setAttribute('rel', 'noopener noreferrer');
-      }
-    });
-    Purify.__gqHookInstalled = true;
-  }
-  elements.forEach(function(el) {
-    var key = el.getAttribute('data-lp-key');
-    var parts = key.split('.');
-    if (parts.length !== 2) return;
-    var sectionData = LP_LABELS[parts[0]];
-    if (!sectionData) return;
-    var value = sectionData[parts[1]];
-    if (value === undefined) return;
-    if (Purify) {
-      el.innerHTML = Purify.sanitize(value, SANITIZE_CONFIG);
-    } else {
-      el.textContent = value;
-      console.warn('[applyLpKeys] DOMPurify unavailable, fell back to textContent for', key);
-    }
-  });
-}
-```
-
-### pamphlet.html の印刷タイミング
-
-`<script src="shared-labels.js" defer>` で `DOMContentLoaded` までに注入完了を保証 + `window.print()` 直前に `applyAll()` 同期再実行（既に注入済みなら no-op）。テストは Playwright `emulateMedia({ media: 'print' })` で SS 検証。
-
-### LEGAL_LABELS coverage check との整合（Amendment 追記）
-
-`scripts/check-lp-ssot.mjs` L186-260 は現在「`LEGAL_LABELS` の値が `site/privacy.html` / `terms.html` に部分一致存在すること」を双方向同期で検証している。Legal docs を `LP_LEGAL_*_LABELS` namespace で labels.ts 化した後は:
-
-1. 既存 `LEGAL_LABELS` → `LP_LEGAL_PRIVACY_LABELS` / `LP_LEGAL_TERMS_LABELS` 等に **再分類** (用途別)。
-2. coverage check ロジックを「`LP_LEGAL_*_LABELS` の各キーが `data-lp-key="legal.*"` で 1 箇所以上参照されていること」を検証する**逆方向のチェック**に変更する。
-3. `EXCLUDED_LEGAL_FILES` 定数 (L32-37) を削除し、法的文書も baseline 0 件対象に追加する。
-
-詳細手順は §結果 Migration Plan の M4 に記載。
+- **適用範囲（例外なし）**: LP 6 ページ + Legal 4 ページ（`privacy` / `terms` / `sla` / `tokushoho`、ADR-0009 §例外「法的文書」を本 ADR が supersede）。labels.ts に `LP_LEGAL_*_LABELS` / `LP_PAMPHLET_LABELS` / `LP_FAQ_BODY_LABELS` namespace を追加。
+- **DOMPurify 配信**: `site/` は GitHub Pages static で npm bundle 経路を持たないため **CDN 必須**（`cdn.jsdelivr.net/npm/dompurify@3`、全 10 ファイルの `<head>`）。未ロード時は安全側で `textContent` フォールバック + console.warn。
+- **DOMPurify 設定値 / pamphlet 印刷タイミング / LEGAL coverage check rework の実装詳細**は §詳細仕様の所在を参照。
 
 ## 結果
 
 ### 利点
-- ADR-0009 が掲げる「100% SSOT」が **真に達成**（PO 強い方針の充足）
-- nested HTML を保持できるため LP コンテンツの表現力を犠牲にしない
-- XSS 防御を業界標準（OWASP 推奨）で実装、自前リスクなし
-- 法的文書も SSOT 配下に入り、文言ドリフト（規約 vs プラポリ vs LP）を構造的に防止
+- ADR-0009 の「100% SSOT」が真に達成（PO 方針充足）。nested HTML を保持し LP の表現力を犠牲にしない。
+- XSS 防御を業界標準（OWASP 推奨）で実装、自前リスクなし。法的文書も SSOT 配下に入り文言ドリフトを構造的に防止。
 
 ### トレードオフ
-- bundle に DOMPurify 22 KB gzip 追加（LP は 1 ロードのみ、許容範囲）
-- ADR-0009 §例外「法的文書」項目を本 ADR が supersede（履歴は ADR-0009 内に追補）
-- 実装 PR は LP 339 + Legal 354 = 693 件の手作業移行で大規模（後述 §Migration Plan）
+- bundle に DOMPurify 22 KB gzip 追加（LP は 1 ロードのみ、許容範囲）。CDN ロード失敗時は textContent 劣化注入。
+- ADR-0009 §例外「法的文書」を本 ADR が supersede。
+- 実装は 693 件の移行で大規模（4 sub-PR に分割、各 sub は単独完遂・partial close 禁止で進行）。
 
-### 移行計画（実装 Agent 引継ぎ — Amendment 後版）
+## 詳細仕様の所在
 
-PO 方針確認 (2026-04-29):
-- 「**partial PR 禁止 = 申し送り禁止 = AC 妥協禁止**」であって「**子 issue 分解禁止**」ではない
-- → **網羅的子 issue 分解 + 各子は単独完遂可能 + 全子 AC 合計が 100%** で進める
+実装詳細（DOMPurify config の ALLOWED_TAGS / ALLOWED_ATTR、pamphlet `beforeprint` 再注入、LEGAL coverage check の逆方向検証、対象 10 ファイル一覧、namespace key 数、sub-A〜D の Phase 区分）は以下の設計書 SSOT に集約済。本 ADR は意思決定の核のみを保持する。
 
-#### 子 issue 分解（#1683 配下に 4 件起票）
-
-各 sub-issue は単独で 1 PR 完遂できる scope。「ここまでで OK / 残りは続 PR」表現は AC に含めない（申し送りなし）。
-
-| Sub | Scope | 完遂 AC（抜粋） | 依存 |
-|-----|-------|---------------|------|
-| **1683-A** | applyLpKeys template 刷新 + DOMPurify CDN 注入 | (1) generate-lp-labels.mjs L377-392 改修, (2) site/*.html 全 8 ファイルに DOMPurify CDN script 追加, (3) `node scripts/generate-lp-labels.mjs` で shared-labels.js 再生成, (4) DOMPurify 設定値が ADR §決定どおり, (5) unit test: `<strong>` `<a>` 保持 + `<script>onerror>` 等 XSS payload escape, (6) 既存 339 件のうち単純文字列の SS 視覚回帰なし | (なし) |
-| **1683-B** | LP HTML 339 件 SSOT 化 | (1) `site/index.html` 84 件 → 0、(2) `site/pricing.html` 50 件 → 0、(3) `site/faq.html` 123 件 → 0、(4) `site/pamphlet.html` 82 件 → 0（defer + print 直前 applyAll 再実行）、(5) namespace `LP_INDEX_*_LABELS` / `LP_PRICING_LABELS` 拡張 / `LP_FAQ_*_LABELS` 拡張 / `LP_PAMPHLET_LABELS` 拡張、(6) check-lp-ssot.mjs で LP 部分 0 件、(7) 4 ファイル × mobile/desktop = 8 SS 視覚回帰なし | 1683-A |
-| **1683-C** | Legal HTML 354 件 SSOT 化 + LEGAL coverage check rework | (1) `site/privacy.html` 133 件 → 0、(2) `site/terms.html` 118 件 → 0、(3) `site/sla.html` 58 件 → 0、(4) `site/tokushoho.html` 45 件 → 0、(5) namespace `LP_LEGAL_PRIVACY_LABELS` / `LP_LEGAL_TERMS_LABELS` / `LP_LEGAL_SLA_LABELS` / `LP_LEGAL_TOKUSHOHO_LABELS` 新設、(6) check-lp-ssot.mjs L186-260 を「`LP_LEGAL_*_LABELS` の各キーが `data-lp-key` で参照されていること」検証に変更、(7) `EXCLUDED_LEGAL_FILES` (L32-37) 削除、(8) ADR-0009 §例外「法的文書」項目に supersede 表記、(9) 4 ファイル × mobile/desktop = 8 SS 視覚回帰なし | 1683-A（1683-B と並列可） |
-| **1683-D** | 検証 / baseline 0 化 / 設計書同期 / pamphlet 印刷 SS テスト | (1) `scripts/lp-ssot-baseline.json` を `count: 0` に更新、(2) Playwright `emulateMedia({ media: 'print' })` SS テスト追加 (`tests/e2e/pamphlet-print-ssot.spec.ts`)、(3) `docs/design/22a-アイコン・ラベル統一規約.md` SSOT 100% 達成記載、(4) `docs/design/06-UI設計書.md` 関連節更新、(5) `docs/decisions/0009-labels-ssot-principle.md` §例外 supersede 追補、(6) 全 10 ページ × mobile/desktop = 20 SS 視覚回帰なし、(7) #1683 umbrella close | 1683-A + 1683-B + 1683-C 全完了 |
-
-#### 完遂判定
-
-- 1683-A/B/C/D の全 PR が main にマージされ、AC が `[x]` 化され、**`scripts/lp-ssot-baseline.json` の `count = 0` + `EXCLUDED_LEGAL_FILES = []`** が成立した時点で #1683 を close
-- 各 sub-issue は AC 100% 完遂時点で個別 close（partial close 禁止）
-- 全子完了後、本 ADR を `proposed` → `accepted` に昇格
-
-**想定実装時間**: 8-16 時間 / sub × 4 = 32-64 時間（Agent 単独 4 セッション）。**partial PR 禁止 / 申し送り禁止 / AC 妥協禁止** (PO 方針)。
+- `docs/design/06-UI設計書.md` §19「LP / Legal 文言の SSOT 経路」 — SSOT 経路 / DOMPurify config / Table row 例外 / Print E2E
+- `docs/design/22a-アイコン・ラベル統一規約.md`「LP / Legal SSOT 100% 達成」 — 対象ファイル / 削減数 / Phase 区分
+- `docs/design/14-セキュリティ設計書.md` §7.1.2 / §7.2 — CSP allowlist（ADR-0029 連動） / DOMPurify を第一層とする XSS 多層防御
 
 ## 関連
-- ADR-0009（labels.ts SSOT 原則）— 本 ADR 承認時に §例外「法的文書」を supersede 表記
-- ADR-0014（i18n 機構選定）— Paraglide 移行前提として現 `shared-labels.js` 経路の延命策
-- Issue #1683（SSOT 100% 完全化）/ #1465（LP SSOT Phase A baseline）/ #1346（labels 機構 Umbrella）
+- ADR-0009（labels.ts SSOT 原則）— §例外「法的文書」を本 ADR が supersede（履歴は archive/0009 内）
+- ADR-0014（i18n 機構選定）— Paraglide 移行前の `shared-labels.js` 経路延命策
+- ADR-0029（LP CSP / CDN SRI Strategy）— DOMPurify CDN allowlist の根拠と表裏一体
+- Issue #1683（SSOT 100% 完全化）/ #1465 / #1346
 - DOMPurify: https://github.com/cure53/DOMPurify


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者 / AI Agent — docs を SSOT として参照する全員）

**解決する課題**: ADR-0025 は 177 行 / 5 セクションで per-ADR ボリューム上限 (≤150 行、`docs/decisions/README.md` §ボリューム上限ルール) を違反していた。DOMPurify 設定値のコード断片・pamphlet 印刷タイミング実装詳細・LEGAL coverage check rework 手順・子 issue 分解表 (移行計画) が本文の大半を占め、ADR の本務である「意思決定の核」が埋もれて 5 分通読不能になっていた。2026-05-09 棚卸でも「XSS 設計詳細 → 補助 doc への分離が次回棚卸の候補」と記録済み。

**期待される効果**: ADR-0025 を意思決定の核（コンテキスト / 選択肢 A-D 比較 / 決定 / 結果 / 詳細仕様の所在 / 関連）に縮約し 80 行 / 6 セクションへ。実装詳細は既に SSOT を持つ `docs/design/06-UI設計書.md §19` + `22a-アイコン・ラベル統一規約.md` + `14-セキュリティ設計書.md §7.1.2/§7.2` へ pointer 化。「現状の正解」のみを端的に記述する docs SSOT 原則（#2440）に整合し、ADR を常時参照可能なルールに戻す。本 PR は #2440 確定計画の PR-A3（1 ADR = 1 PR 粒度、PR-A1 #2859 の同型 playbook を踏襲）。

## 関連 Issue

refs #2440

関連 ADR: ADR-0025（本 PR の対象）/ ADR-0029（LP CSP、表裏一体）/ ADR-0001（設計書 SSOT）

## AC 検証マップ (ADR-0004)

本 PR は #2440 全体 AC のうち PR-A3 scope（ADR-0025 単体の volume 是正）を担う。PR-A3 固有の受け入れ基準を以下に定義する。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| A3-1 | ADR-0025 を ≤150 行に縮約 | `wc -l docs/decisions/0025-lp-ssot-html-injection-with-xss-protection.md` | PASS — 177 → 80 行 |
| A3-2 | ADR-0025 を ≤7 セクションに縮約 | `grep -c "^## " docs/decisions/0025-...md` | PASS — 5 → 6 セクション（≤7 上限内） |
| A3-3 | 意思決定の核（コンテキスト / 選択肢 A-D 比較 / 決定 / トレードオフ）を意味変更ゼロで保持 | git diff 目視 + 下記「無損失対応表」 | PASS — コンテキスト 3 限界 / 選択肢 A-D 4 件 / 決定 (DOMPurify 採用 + 適用範囲 + CDN) / 結果 (利点 + トレードオフ) を全保持 |
| A3-4 | 削除した詳細はどこにも消えず設計書 SSOT に存在（情報無損失） | 下記「無損失対応表」+ 各設計書 grep | PASS — 全削除ブロックは 06-UI §19 / 22a / 14 §7 の既存記述に存在、または経緯メタ (git 履歴 SSOT) |
| A3-5 | ADR-0025 被参照（ADR-0026/0029/0032/0042/0045/0049 関連 ADR 列 / archive 0009 supersede 表記 / README OSS 採用記録）の指す内容が縮約後も成立（anchor 切れゼロ） | `grep -rn "ADR-0025"` 全件 vs 縮約後本文の claim 照合 | PASS — 全被参照はファイル全体参照（`#anchor` なし）。ヘッダ・選択肢比較・決定・supersede 表記が保持され全成立 |
| A3-6 | `check-doc-code-references.mjs` 新規違反なし | `node scripts/check-doc-code-references.mjs` | PASS — baseline 内 152 件、新規違反 0、exit 0 |
| A3-7 | ADR ヘッダ（ステータス表）・README.md 表行・棚卸レポートは不変 | git diff（本 PR は ADR 1 file のみ変更） | PASS — `git diff --stat` = 1 file changed（ヘッダのステータス表記は accepted のまま、表記揺れ整形のみ） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI / docs (`docs/decisions/`)

**影響を受ける画面・機能**: なし（docs 1 file のみ。実装コード・LP・UI・script への影響ゼロ）。`docs/decisions/0025-lp-ssot-html-injection-with-xss-protection.md` の縮約のみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2880` 全 Step PASS**（#1775 / ADR-0030）— main rebase 後に実行: biome / svelte-check / vitest 6353 件 PASS / check-hardcoded-strings 0 件 / check-no-plan-literals PASS（LP 系 Step は変更なしのため skip）
- [x] 追加・変更したテストの概要: N/A（docs 縮約のみ、テスト変更なし）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: docs（ADR markdown）の縮約のみで UI 変更を含まないため。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（docs 縮約）
- [x] **DRY**: 縮約の目的そのものが重複排除（ADR の実装詳細 → 06-UI §19 / 22a / 14 §7 の設計書 SSOT への一本化）
- [x] **YAGNI**: N/A
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 設計書同期 (ADR-0001) — 06-UI §19 / 22a / 14 §7 が既に LP/Legal SSOT 注入機構の実装詳細を保持しており、本 PR は ADR → 設計書 §への pointer 化で整合を維持
- [x] N/A — 上記以外の並行実装の影響範囲外（本番/デモ・LP・年齢モード・ナビ・labels への影響なし）

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- 情報無損失の核心: 削除した DOMPurify config / pamphlet beforeprint 再注入 / LEGAL coverage check 逆方向検証 / EXCLUDED_LEGAL_FILES 撤廃 / 対象 10 ファイル / namespace key 数 / sub-A〜D Phase 区分 は全て `docs/design/06-UI設計書.md §19` + `22a-アイコン・ラベル統一規約.md` に既存（下記対応表で grep 検証済）。Amendment 履歴 / 移行計画の datestamp narrative は経緯メタ（#2440 docs SSOT 原則で docs 本文に置かない対象）であり git 履歴が SSOT。
- ADR ヘッダの「関連 Issue: #1683 / #1465 / #1346 / #1704」は意図的に不変。ステータスは accepted のまま（旧 status 昇格履歴 blockquote は経緯メタとして削除、git 履歴に保全）。

### 無損失対応表（削除ブロック → 重複 or 移設先）

| ADR 旧ブロック (行) | 内容 | 削除可の根拠（重複 or 既存 SSOT） |
|---|---|---|
| Status 昇格履歴 blockquote (L11) | proposed → accepted 昇格経緯 | **#2440 で明示禁止の経緯 narrative**。ヘッダ表に `accepted (2026-04-30, #1683 完遂 + #1704)` として要点保持、詳細は git 履歴 SSOT |
| Amendment 履歴 blockquote (L13-17) | 初版 3 点の確定経緯 (datestamp) | 経緯メタ（#2440 非対象）。確定結果（SSOT = generate-lp-labels.mjs template / CDN 必須 / LEGAL rework）は §決定本文に保持 |
| §決定「DOMPurify 設定値（実装 Agent 直参照）」コード断片 (L79-119) | applyLpKeys() JS 実装 + SANITIZE_CONFIG | **`docs/design/06-UI設計書.md §19.3`「DOMPurify config」行と重複**（ALLOWED_TAGS / ALLOWED_ATTR / ALLOW_DATA_ATTR）。実体 SSOT は `scripts/generate-lp-labels.mjs` applyLpKeys template |
| §決定「pamphlet.html の印刷タイミング」(L121-123) | defer + print 直前 applyAll 再実行 | **06-UI §19.2-3 + 22a L115 と重複**（`window.print()` 起動前 `beforeprint` で `reapplyLpKeys()` 再実行 / Print E2E `pamphlet-print-ssot.spec.ts`） |
| §決定「LEGAL_LABELS coverage check との整合」(L125-133) | 逆方向 check rework 3 手順 | **06-UI §19.3 CI gate 行 + 22a L116/L125 と重複**（逆方向検証 / `EXCLUDED_LEGAL_FILES` 撤廃） |
| §結果「移行計画」子 issue 分解表 sub-A〜D (L148-171) | 4 sub-issue scope + 完遂 AC + 想定時間 | **22a「Phase 区分」表 sub-A〜D（L134-137）と重複**（merged 済 PR 番号付き）。「想定実装時間」「PO 方針確認 (datestamp)」は経緯メタ（#2440 非対象）、git 履歴 SSOT。§結果トレードオフに「4 sub-PR に分割」要点保持 |

> 注: 上記「移設」は新規追加ゼロで成立した（削除ブロックの内容は全て 06-UI §19 / 22a / 14 §7 の既存記述、または経緯メタ = git 履歴のいずれかに既存）。設計書の既存構造（06-UI 3 部構成 / 22a / 14 §7 見出し体系）には一切変更を加えていない。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2880` 全 Step PASS** をローカル確認した（main rebase 後、Step 1-8 PASS / Step 9 は本 checkbox 記入で解消）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] QA 承認・動作確認が完了している — N/A（docs 単独 PR で動作確認対象なし。QM レビューは Ready 後の毎時フローで実施）

## QM レビュー結果

（QM 記入欄）

