### PR TITLE
docs: #2862 — 外部品質監査チーム役割定義 SSOT (audit-team.md) 新設

### DIFF
--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -60,6 +60,8 @@
 | [docs/sessions/dev-session.md](sessions/dev-session.md) | Dev セッション (実装・CI/CD・設計書同期、overall map) |
 | [docs/sessions/dev-process/README.md](sessions/dev-process/README.md) | 開発プロセス運用知 各論 (完遂原則 / アンチパターン / QA fix / 並列 Agent / 調査規律 / 横展開、#2516) |
 | [docs/sessions/qa-session.md](sessions/qa-session.md) | QA セッション (PR レビュー・品質ゲート) |
+| [docs/sessions/branch-strategy.md](sessions/branch-strategy.md) | ブランチ戦略 SSOT (develop 二層 + gate 二層 + merge 責任分担、#2858) |
+| [docs/sessions/audit-team.md](sessions/audit-team.md) | 外部品質監査チーム役割定義 SSOT (マネージャ + 8 チーム + ポリシー準拠判定、2 段 gate 境界、#2862 / EPIC #2861) |
 | [docs/design/06-UI設計書.md](design/06-UI設計書.md) | UI 機能・画面・オーバーレイ仕様 |
 | [docs/design/07-API設計書.md](design/07-API設計書.md) | API エンドポイント定義 |
 | [docs/design/08-データベース設計書.md](design/08-データベース設計書.md) | DB テーブル・カラム仕様 |
@@ -154,7 +156,7 @@
 
 | ディレクトリ | 役割 |
 |---|---|
-| `.claude/agents/` | セッション ロール定義 (po-session.md / dev-session.md / qa-session.md、起動時自動活性化) |
+| `.claude/agents/` | セッション ロール定義 (po-session.md / dev-session.md / qa-session.md、起動時自動活性化)。外部品質監査チームの役割定義は [docs/sessions/audit-team.md](../sessions/audit-team.md) が SSOT (audit-manager + 8 チーム + ポリシー準拠判定、新設 skill = competitive-research / policy-compliance / audit-manager の 3 点に限定、実装は EPIC #2861 の B 系 sub-issue が担う) |
 | `.claude/skills/` | タスク固有 Skills (14 件): `pr-review` / `issue-triage` / `pre-pmf-check` / `dev-open-pr` / `lp-review` / `db-migration` / `cost-review` / `age-mode-check` / `brand-check` / `customer-voice` / `deploy-verify` / `flake-hunt` / `regression-check` / **`impact-analysis`** (rename/モデル変更/大規模リファクタリングの Change Impact Analysis、4 layer 防御 + 21 カテゴリ checklist、2026-05-28 追加) |
 | `.claude/settings.json` | 全体設定 (permissions / hooks / env) |
 | `.claude/worktrees/` | 並行 Agent 用 worktree 分離 dir (Agent tool `isolation: "worktree"` 必須) |

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -156,7 +156,7 @@
 
 | ディレクトリ | 役割 |
 |---|---|
-| `.claude/agents/` | セッション ロール定義 (po-session.md / dev-session.md / qa-session.md、起動時自動活性化)。外部品質監査チームの役割定義は [docs/sessions/audit-team.md](../sessions/audit-team.md) が SSOT (audit-manager + 8 チーム + ポリシー準拠判定、新設 skill = competitive-research / policy-compliance / audit-manager の 3 点に限定、実装は EPIC #2861 の B 系 sub-issue が担う) |
+| `.claude/agents/` | セッション ロール定義 (po-session.md / dev-session.md / qa-session.md、起動時自動活性化)。外部品質監査チームの役割定義は [docs/sessions/audit-team.md](sessions/audit-team.md) が SSOT (audit-manager + 8 チーム + ポリシー準拠判定、新設 skill = competitive-research / policy-compliance / audit-manager の 3 点に限定、実装は EPIC #2861 の B 系 sub-issue が担う) |
 | `.claude/skills/` | タスク固有 Skills (14 件): `pr-review` / `issue-triage` / `pre-pmf-check` / `dev-open-pr` / `lp-review` / `db-migration` / `cost-review` / `age-mode-check` / `brand-check` / `customer-voice` / `deploy-verify` / `flake-hunt` / `regression-check` / **`impact-analysis`** (rename/モデル変更/大規模リファクタリングの Change Impact Analysis、4 layer 防御 + 21 カテゴリ checklist、2026-05-28 追加) |
 | `.claude/settings.json` | 全体設定 (permissions / hooks / env) |
 | `.claude/worktrees/` | 並行 Agent 用 worktree 分離 dir (Agent tool `isolation: "worktree"` 必須) |

--- a/docs/sessions/audit-team.md
+++ b/docs/sessions/audit-team.md
@@ -1,0 +1,161 @@
+# 外部品質監査チーム — 役割定義 SSOT
+
+> **このファイルの位置づけ**: develop → main 統合 PR を客観的第三者視点で監査する「外部品質監査チーム」のロール・責務・境界の SSOT。マネージャ orchestrator + 8 チーム + ポリシー準拠判定 agent の役割、skill 再利用マップ、QM との 2 段 gate 境界、マージ判定エビデンス基準、棄却運用 flow を定める。
+>
+> **関連 Issue**: EPIC #2861 ｜ A1 = #2862 ｜ **関連 ADR**: ADR-0056（QM Orchestrator role drift の構造的対処）/ ADR-0022（QM Approve 体制・admin bypass 禁止）/ ADR-0010（Pre-PMF scope）
+>
+> **上流 SSOT**: ブランチ運用・gate 二層・merge 責任分担は [branch-strategy.md](branch-strategy.md)。QM Tier1/Tier2 の 2 層構造は [qa-session.md](qa-session.md)。本ファイルはこの 2 つを継承し、develop → main レーンの監査チーム側のみを定義する。
+>
+> **本ファイルの守備範囲**: 役割定義 SSOT。daily cron 自動化 / NUC・AWS staging 構築 / 最重厚テスト束ね / 判定エビデンス自動生成などの**実装**は EPIC #2861 の各 sub-issue（B 系 / C 系 / D 系 / E 系）が担う。本ファイルでは「誰が・何を・どの境界で判定するか」のみを確定する。
+
+## §1 設計背景
+
+main = 本番（push 即 deploy、不変条件）であるにもかかわらず、現状の品質ゲートは「Dev 自己レビュー + QM 毎時レビュー（per-PR の機能正しさ判定）」までで止まっている。
+
+- **統合前に CUJ（Critical User Journey）を横断する第三者監査層が存在しない**: QM は feature → develop PR 単位で「その PR の機能が AC どおりか」を毎時判定するが、複数 PR が develop に積み上がった後の「統合状態で顧客体験が崩れていないか」を横断検査する役割が不在だった。個別 PR が全て緑でも、統合後に画面間の整合・CUJ 通し体験が崩れる事故は per-PR review では原理的に捕捉できない。
+- **この役割定義がないと困ること**: 監査チームが「何を判定し、何を判定しないか」が曖昧だと、(1) 毎時 QM レビューと判定が衝突して二重判定になる（EPIC 失敗シナリオ⑤）、(2) self-review が形骸化したまま統合 merge される（同①、ADR-0056 が実証した QM drift 42 回再発の延長）、(3) 検出問題を 1 件で即棄却して残りを発露させず triage 不能に陥る（同⑥）。役割・境界・エビデンス基準を SSOT として固定して初めて、これらの構造的失敗を防げる。
+- **既存の `docs/sessions/` 同型**: PO / Dev / QA のロール定義が `docs/sessions/` 配下にあるのと同じく、監査チームのロール定義もここに置く。QM の Tier1/Tier2 2 層構造（[qa-session.md](qa-session.md)）と ADR-0056 §E（subagent ≠ orchestrator の役割分離）を継承し、独自の構造を増やさない。
+
+## §2 設計原則
+
+- **マネージャ orchestrator 専権 + subagent は evidence 生成まで（ADR-0056 §E 継承）**: 不可逆 side-effect（統合 PR の approve / merge、Issue 起票の実行）は audit-manager orchestrator が直接実行する。8 チーム・ポリシー準拠判定の各 agent は finding（structured JSON evidence）を生成・報告するまでが責務で、approve / merge / 起票 action を肩代わりしない。これは QM Orchestrator の V-7 専権（[qa-session.md](qa-session.md) §「全手順 Pass → approve & merge」）と同型。
+- **self-report 単独信頼の禁止（PO 判断 5 / ADR-0056）**: 監査チームの merge 判定は structured JSON evidence + adversarial verify を物理強制する。各 agent の「問題なし」自己申告だけでは merge しない。Echoing（arXiv:2511.09710）と Persona Drift を抑制するため、Adversarial Reviewer による反対理由生成を evidence の一部として要求する。
+- **2 段 gate の責務分離（PO 判断 6）**: QM = feature → develop（per-PR の機能正、毎時）、監査チーム = develop → main（統合前の CUJ 横断、1 日 1 回）。両者は同一 gh アカウント `ganbariquestsupport-lab` を base branch（= レビュー対象 PR の種別）で role 区別する（[branch-strategy.md](branch-strategy.md) §6 継承）。二重判定が起きないよう §3.4 の境界表で「監査チームが判定しないこと」を明示する。
+- **全件発露 → filter → 起票/棄却（PO 判断 7）**: 問題は 1 件で即棄却せず、まず全件を発露させる。その後 (1) 重複統合、(2) severity 閾値、(3) ポリシー準拠判定 filter を順に通し、残ったものを Issue 起票 + 棄却判定する。「あえてそうしている」プロダクトポリシー由来の挙動を誤起票しないことが filter の主目的。
+- **Pre-PMF 整合（ADR-0010）**: 監査体制は Bucket A（顧客品質の構造的担保）。ただし staging stack / 最重厚テスト束ねは過剰防衛にならぬよう各 sub-issue で個別 bucket 判断する（本ファイルは役割定義のみで AWS コスト影響なし）。
+
+## §3 仕様
+
+### §3.1 チーム構成（マネージャ + 8 チーム + ポリシー準拠判定）
+
+| role | 責務 | 不可逆 action | evidence 形式 |
+|---|---|---|---|
+| **audit-manager（orchestrator）** | 統合 PR 単位で 8 チーム + ポリシー準拠判定を dispatch → evidence 集約 → 重複統合・severity filter → Issue 起票 + approve/merge を実行 | **可**（approve / merge / 起票は orchestrator 専権） | 集約 evidence + マージ判定エビデンス表（§3.5） |
+| 競合調査 | 競合プロダクトの機能・体験・価格を一次情報で調査し、本プロダクトの相対 gap を finding 化 | 不可 | structured JSON（一次情報 URL 必須） |
+| 技術調査 | 統合差分の影響範囲（rename / モデル変更 / 大規模リファクタリング）を 4 layer で網羅検査 | 不可 | structured JSON |
+| プロダクト実装調査 | 統合状態の実装一貫性・AC 充足・並行実装同期を横断検査 | 不可 | structured JSON |
+| ユーザビリティ・a11y | CUJ を仮ユーザ persona で通し、NN/G 観点 + WCAG 2.2 AA の体験品質を検査 | 不可 | structured JSON |
+| セキュリティ | 認可境界 / 依存脆弱性 / コードスキャン結果を集約し OWASP 観点で finding 化 | 不可 | structured JSON |
+| パフォーマンス | アプリ perf budget + LP メトリクス + visual regression の劣化を検査 | 不可 | structured JSON |
+| テスト品質 | テストカバレッジ ratchet・flaky・assertion 弱体化（ADR-0005 / ADR-0006）を検査 | 不可 | structured JSON |
+| 問題起票 | filter 通過 finding を Issue 草稿に整形（起票の**実行**は audit-manager） | 不可（草稿まで） | Issue 草稿 JSON |
+| **ポリシー準拠判定** | 各 finding が「プロダクトポリシーであえてそうしている」挙動でないかを判定し、誤起票を filter | 不可 | filter 判定 JSON（採否 + 根拠 ADR/docs） |
+
+- 各 agent の evidence は audit-manager が物理 verify する。evidence 不在・schema 不充足の agent finding は採用しない（self-report 単独信頼の禁止、§2）。
+- 競合調査 finding は一次情報 URL を必須とし、URL 欠落 finding は audit-manager が自動棄却する（EPIC 失敗シナリオ⑦の幻覚 finding 防止）。
+
+### §3.2 既存 skill / 機構 再利用マップ（重複新設禁止）
+
+EPIC #2861「既存資産再利用マップ」を本ファイルに正本化する。新設は **competitive-research / policy-compliance / audit-manager の 3 点に限定**し、残りは既存 skill / workflow を再利用する。
+
+| チーム | 実装方針 | 再利用元（実在する SSOT を文言で参照） |
+|---|---|---|
+| audit-manager orchestrator | 新設 | qa-session.md の Tier1/Tier2 2 層構造を継承 |
+| 競合調査 | 新設（薄い skill、WebSearch ベース） | issue-triage skill の prior art 手順 |
+| 技術調査 | 再利用 | impact-analysis skill / regression-check skill |
+| プロダクト実装調査 | 再利用 | pr-review skill / regression-check skill |
+| ユーザビリティ・a11y | 再利用 | cognitive-walkthrough skill / customer-voice skill / age-mode-check skill / a11y job（axe-core） |
+| セキュリティ | 再利用 | security-scan workflow / codeql workflow / dependency-review workflow |
+| パフォーマンス | 一部新設（アプリ perf budget） | lp-metrics workflow / visual regression 3 層 / cost-review skill |
+| テスト品質 | 再利用 | flake-hunt skill / ADR-0005 テスト品質 ratchet |
+| 問題起票 | 再利用 | issue-triage skill |
+| ポリシー準拠判定 | 新設 | pre-pmf-check skill + brand-check skill + adversarial-reviewer skill を統合した判定 |
+
+- 仮ユーザテスト基盤は `scripts/ai-evaluation/`（Stagehand + axe-core + persona の POC、EPIC #2861 D4）の本格化で賄う。本ファイルは役割定義のみで、基盤実装は D 系 sub-issue が担う。
+- a11y の `@axe-core/playwright` 採用根拠は ADR インベントリ（[../decisions/README.md](../decisions/README.md) §OSS 採用記録）を参照。
+
+### §3.3 ADR-0056 §E 継承（不可逆 side-effect = orchestrator 専権）
+
+ADR-0056 §E が定義する「subagent ≠ QM（役割分離 SSOT）」を、監査チームにそのまま適用する。
+
+- **subagent（8 チーム + ポリシー準拠判定）**: evidence 生成（finding を structured JSON で出力）が責務。approve / merge / Issue 起票の action 不可。
+- **audit-manager（orchestrator）**: subagent 起動 → evidence 物理 verify → filter → 不可逆 action 実行が責務。evidence 生成（finding 自体の捏造）は不可（Echoing 抑制のため自分で finding を作って自分で採用しない）。
+- **evidence 配置 SSOT**: structured JSON evidence は main repo 直下の規定ディレクトリに置く（subagent worktree 内のみは NG）。audit-manager は dispatch 後に evidence の物理存在を verify し、不在なら fallback（自筆ではなく再 dispatch ではなく、§3.4 の境界に従い該当 agent を再起動 or BLOCK）する。これは ADR-0056 §E の「evidence 流通 / action 接続点での drift」対策の継承。
+- **adversarial verify の物理強制**: merge 判定 evidence には Adversarial Reviewer による反対理由（structured JSON、`must_object_count` を満たす）を含める。これにより self-report 単独信頼を構造的に禁止する（ADR-0056 採用案 B 継承）。
+
+両者を混同すると drift が再発する（subagent が approve を肩代わり / orchestrator が finding を肩代わりで bias）ため、役割境界を越える動作は禁止する。
+
+### §3.4 2 段 gate 境界（QM vs 監査チーム）
+
+「誰が・いつ・何を判定し・何を判定しないか」を表で固定し、二重判定を防ぐ。
+
+| 項目 | QM（毎時 gate） | 外部品質監査チーム（1 日 1 回 gate） |
+|---|---|---|
+| レビュー対象 PR | feature/fix/docs/* → develop | develop → main 統合 PR |
+| cadence | 毎時 | 1 日 1 回（段階導入として週 1〜2 回から開始し、daily 自動化は C 系 sub-issue で確立） |
+| gate レーン | 軽量レーン（[branch-strategy.md](branch-strategy.md) §4） | 最重厚レーン（同 §4） |
+| 判定の主眼 | per-PR の機能正しさ（AC 充足 / SS / CI 緑 / 場当たり対応検出） | 統合状態の CUJ 横断品質（画面間整合 / 第三者 CUJ 通し体験 / 8 領域監査） |
+| **判定すること** | その PR の AC・実装・テスト・UI の正しさ | 統合後の顧客体験・8 領域 finding・competitive gap・マージ判定エビデンス表 |
+| **判定しないこと** | 統合後の CUJ 横断品質（= 監査チームの領域） | per-PR 単位の AC 再判定（= QM が develop 取込時点で済ませた領域。監査チームは再判定せず統合状態のみを見る） |
+| 不可逆 action 主体 | QM Orchestrator 本体（V-7） | audit-manager orchestrator |
+| gh アカウント | `ganbariquestsupport-lab`（QM role） | `ganbariquestsupport-lab`（監査 role、base branch で区別） |
+
+- **二重判定の回避原則**: 監査チームは QM が develop 取込時に確定済みの per-PR AC を再判定しない。監査チームは「develop に積み上がった統合状態」を新しい検査対象として扱い、QM が見られない横断品質のみを担う。逆に QM は統合後の CUJ 横断を判定しない。
+- **統合 PR の作成者 ≠ 承認者**: 統合 PR は Takenori-Kusaka 名義（監査マネージャ session）で作成し、`ganbariquestsupport-lab`（監査 role）が approve + merge する。ADR-0022 の作成者 ≠ 承認者分離を維持する（PO 判断 3 / [branch-strategy.md](branch-strategy.md) §6）。
+
+### §3.5 マージ判定エビデンス基準
+
+audit-manager が統合 PR の merge を判定する際に揃えるべき人間可読エビデンス。E 系 sub-issue でこの形式を自動生成するが、ここでは判定に使う仕様を定義する。
+
+**必須エビデンス（4 点 + NG 0 件条件）**:
+
+1. **新機能・修正一覧**: 統合 PR に含まれる develop 上の全変更（feature / fix）を 1 行ずつ列挙（出典 PR 番号 / 変更概要 / 対象領域）。
+2. **対応テストケース一覧**: 各変更に対応する unit / integration / E2E / Storybook テストケースを紐付け（変更 × テストの突合表）。
+3. **テスト結果表**: 上記テストの実行結果（pass / fail / skip）を最重厚レーン（[branch-strategy.md](branch-strategy.md) §4）の全 job 横断で集約。
+4. **自動テストカバレッジ**: カバレッジ値 + ratchet 閾値割れがないこと（ADR-0005 整合）。
+5. **NG 0 件エビデンス**: 8 領域 finding のうち severity 閾値以上（§3.6）の未解決 NG が **0 件**であること。残 NG があれば merge しない。
+
+判定可読仕様（表イメージ）:
+
+| 変更（出典 PR） | 対象領域 | 対応テストケース | 結果 | カバレッジ影響 | 残 NG |
+|---|---|---|---|---|---|
+| 例: 機能 A（#NNNN） | admin/activities | unit×N / e2e×M | pass | 閾値内 | 0 |
+| 例: 修正 B（#NNNN） | child-home | unit×N / e2e×M | pass | 閾値内 | 0 |
+
+- 全行が pass + 残 NG 合計 0 + カバレッジ閾値割れなし + adversarial evidence の反対理由が解消済、を満たして初めて audit-manager が merge を実行する。
+- 1 行でも fail / 残 NG > 0 の場合は merge せず、該当を §3.6 の起票/棄却 flow に送る。
+
+### §3.6 棄却運用 flow（全件発露 → filter → 起票/棄却）
+
+問題を 1 件で即棄却せず、全件発露 → 3 段 filter → 起票/棄却 の手順で処理する（PO 判断 7 / EPIC 失敗シナリオ②⑥⑦）。
+
+```
+[1] 全件発露
+    8 チーム + ポリシー準拠判定が finding を structured JSON で全件出力
+    （この時点では棄却しない。固定時間 box 内で発露を完了する）
+        │
+        ▼
+[2] 重複統合
+    audit-manager が同一原因・同一箇所の finding をマージし重複を 1 件化
+        │
+        ▼
+[3] severity 閾値
+    severity 1-2（軽微）= backlog 蓄積のみ（起票せず）
+    severity 3-4（重大）= 次段の filter へ
+        │
+        ▼
+[4] ポリシー準拠判定 filter
+    「あえてそうしているプロダクトポリシー」由来の挙動か判定
+      ├─ ポリシー由来（誤検出）→ 棄却（採否 + 根拠 ADR/docs を記録）
+      └─ 真の問題         → 次段へ
+        │
+        ▼
+[5] 起票 or 棄却
+    残った真の問題 → 問題起票チームが Issue 草稿 → audit-manager が起票実行
+    棄却分        → 棄却理由を evidence に記録（無言棄却しない）
+```
+
+- **無限棄却ループの回避**: severity 閾値で打ち切り、閾値未満は backlog 蓄積。各 run は固定時間 box で完了する（EPIC 失敗シナリオ⑥）。
+- **起票の実行主体**: Issue 起票の**実行**は audit-manager（不可逆 action）。問題起票チームは草稿生成まで（§3.1 / §3.3）。
+- **誤起票防止**: ポリシー準拠判定 filter（pre-pmf-check / brand-check / adversarial-reviewer 統合）で、Anti-engagement（ADR-0012）・Pre-PMF scope（ADR-0010）・ブランド規約に基づく意図的挙動を Issue 化しない。
+
+## §4 関連参照
+
+| 参照先 | 役割 |
+|---|---|
+| [branch-strategy.md](branch-strategy.md) | ブランチ運用・gate 二層・merge 責任分担の上流 SSOT（§6 役割分担を継承） |
+| [qa-session.md](qa-session.md) | QM Tier1/Tier2 2 層構造（audit-manager がこれを継承） |
+| [../decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md](../decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md) | §E 役割分離 SSOT（不可逆 side-effect = orchestrator 専権） |
+| [../decisions/0022-admin-bypass-disable-qm-approve.md](../decisions/0022-admin-bypass-disable-qm-approve.md) | 作成者 ≠ 承認者分離・admin bypass 禁止 |
+| [../decisions/0010-pre-pmf-scope-judgment.md](../decisions/0010-pre-pmf-scope-judgment.md) | Pre-PMF scope 判断（監査体制の bucket A 整合） |
+| EPIC #2861 | 5 phase 実装計画（本ファイルは A1、実装は B/C/D/E 系 sub-issue が担う） |


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（品質ガバナンス基盤）

**解決する課題**: main = 本番（push 即 deploy）であるにもかかわらず、現状の品質ゲートは Dev 自己レビュー + QM 毎時レビュー（per-PR 機能正）までで、統合前に CUJ を横断して第三者視点で監査する層が存在しない。監査チームが「何を判定し、何を判定しないか」の SSOT がないと、毎時 QM との二重判定衝突・self-review 形骸化の再発・1 件即棄却による triage 不能を招く。

**期待される効果**: 外部品質監査チームの役割・責務・境界を SSOT として固定し、develop → main 統合 PR の客観的第三者監査体制（EPIC #2861）の P0 規約基盤を確立する。これにより本番品質事故による顧客流出リスクを構造的に低減する。

## 関連 Issue

Closes #2862

関連: EPIC #2861（親、5 phase 実装計画の A1）/ #2858（branch-strategy.md、上流 SSOT）/ ADR-0056（QM drift 構造的対処）/ ADR-0022（QM Approve 体制）/ ADR-0010（Pre-PMF scope）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `docs/sessions/audit-team.md` 新設、マネージャ + 8 チーム + ポリシー準拠判定の役割が表で定義 | `docs/sessions/audit-team.md` §3.1 のチーム構成表（10 role 行 = audit-manager + 8 チーム + ポリシー準拠判定） | PASS: §3.1 表に audit-manager（orchestrator） / 競合調査 / 技術調査 / プロダクト実装調査 / ユーザビリティ・a11y / セキュリティ / パフォーマンス / テスト品質 / 問題起票 / ポリシー準拠判定 を責務・不可逆 action・evidence 形式の 4 列で定義 |
| AC2 | 2 段 gate 境界（QM vs 監査）が「誰が・いつ・何を判定し・何を判定しないか」の表として明記、二重判定回避 | `docs/sessions/audit-team.md` §3.4 の境界表 | PASS: §3.4 表に「判定すること / 判定しないこと」行を含む 8 項目で QM（feature→develop 毎時）と監査（develop→main 1 日 1 回）を分離。「監査チームは QM 確定済 per-PR AC を再判定しない / QM は統合後 CUJ 横断を判定しない」を二重判定回避原則として明文化 |
| AC3 | ADR-0056 §E（不可逆 side-effect = orchestrator 専権）継承を明文化、各領域 agent は finding 報告のみ | `docs/sessions/audit-team.md` §3.3 + §2 設計原則 | PASS: §3.3 で「subagent = evidence 生成まで / audit-manager = approve・merge・起票の不可逆 action 専権」を ADR-0056 §E 継承として明記。structured JSON evidence + adversarial verify 物理強制を規定 |
| AC4 | skill 再利用マップ正本化、新設は competitive-research / policy-compliance / audit-manager の 3 点に限定 | `docs/sessions/audit-team.md` §3.2 の再利用マップ表 | PASS: §3.2 表で 10 行を「新設 3 点（audit-manager / 競合調査 / ポリシー準拠判定）」と「再利用 7 領域（impact-analysis / regression-check / pr-review / cognitive-walkthrough / customer-voice / age-mode-check / security-scan / codeql / dependency-review / lp-metrics / cost-review / flake-hunt / issue-triage / pre-pmf-check / brand-check / adversarial-reviewer 等）」に区別 |
| AC5 | マージ判定エビデンス基準（新機能・修正一覧 × テストケース × 結果 + カバレッジ + NG 0 件）の人間可読仕様 | `docs/sessions/audit-team.md` §3.5 | PASS: §3.5 で必須エビデンス 5 点（新機能・修正一覧 / 対応テストケース一覧 / テスト結果表 / カバレッジ / NG 0 件）+ 判定可読仕様表（変更 × テスト × 結果 × カバレッジ影響 × 残 NG）を定義 |
| AC6 | 棄却運用 flow（全件発露 → 重複統合 → severity 閾値 → ポリシー準拠判定 → 起票/棄却）を図または手順で記載 | `docs/sessions/audit-team.md` §3.6 | PASS: §3.6 に 5 段 flow 図（[1]全件発露 → [2]重複統合 → [3]severity 閾値 → [4]ポリシー準拠判定 filter → [5]起票/棄却）+ 無限棄却ループ回避・起票実行主体・誤起票防止の補足 |
| AC7 | `docs/codebase-map.md` §3 / §8 に audit-team.md / 新設 skill への参照を追加（SSOT 同期） | `git diff docs/codebase-map.md` | PASS: §3 に audit-team.md + branch-strategy.md 行追加、§8 に外部品質監査チーム役割定義 SSOT + 新設 skill 3 点限定の言及を追加 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`docs/sessions/`, `docs/codebase-map.md` の SSOT docs のみ)

**影響を受ける画面・機能**: なし（docs のみ。コード・UI・DB・インフラへの影響ゼロ）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— `npm run pre-ready -- --pr 2881` を main rebase 後に実行: biome / svelte-check / vitest 6353 件 PASS / check-hardcoded-strings 0 件 / check-no-plan-literals PASS（LP 系 Step は変更なしのため skip）
- [x] 追加・変更したテストの概要: N/A（docs 新設のみ。機械検証は `node scripts/check-doc-code-references.mjs` 新規違反 0 件で代替）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: docs/sessions/audit-team.md 新設 + codebase-map.md 参照追加のみで UI 変更を含まない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（docs のみ）
- [x] **DRY**: 既存 SSOT（branch-strategy.md §6 / qa-session.md Tier 構造 / ADR-0056 §E / EPIC #2861 再利用マップ）を文言参照で継承し、内容重複を避けた
- [x] **YAGNI**: 役割定義 SSOT のみ。daily cron / staging / 最重厚テスト束ね等の実装は EPIC #2861 各 sub-issue と責務を分離
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 設計書同期 (ADR-0001): codebase-map.md §3 / §8 を同期更新（AC7）
- [x] N/A — 本番/デモ / LP / 年齢モード / ナビ / labels の並行実装の影響範囲外（docs のみ）

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- 上流 SSOT（branch-strategy.md §6 役割分担 / qa-session.md Tier1/Tier2 / ADR-0056 §E）との整合を §4 関連参照で文言リンクのみとし、経緯メタの混入（docs SSOT 原則 #2440）を避けている点を確認願いたい。
- 新設対象 3 skill（competitive-research / policy-compliance / audit-manager）は未実装のため、実在パスへの実参照は避け「実装は EPIC #2861 の各 issue」と責務を切っている（`node scripts/check-doc-code-references.mjs` 新規違反 0 件で確認済）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（`npm run pre-ready -- --pr 2881`、Step 1-8 PASS / Step 9 は本 checkbox 記入で解消）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— D-5 全 hunk 点検で codebase-map §8 の相対リンク破損（`../sessions/` → `sessions/` が正）を検出し fixup commit 53d874a0 で修正済
- [x] 全 AC が実装済み（AC1-AC7、本 PR body の AC 検証マップ参照）
- [x] UI 変更時: N/A（docs のみ、UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

