### PR TITLE
docs: AWS cron 表 doc-sync + CronRuleLicenseExpire replacement 承認 (本番 deploy 復旧、#2822 帰結)

### DIFF
--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -130,7 +130,6 @@
 
 | ルール名 | スケジュール (UTC) | JST 換算 | 対応ジョブ |
 |---------|-----------------|---------|----------|
-| `ganbari-quest-cron-license-expire` | `cron(0 15 * * ? *)` | 00:00 | license-expire |
 | `ganbari-quest-cron-retention-cleanup` | `cron(0 16 * * ? *)` | 01:00 | retention-cleanup |
 | `ganbari-quest-cron-trial-notifications` | `cron(0 0 * * ? *)` | 09:00 | trial-notifications |
 | `ganbari-quest-cron-lifecycle-emails` (#1601) | `cron(30 0 * * ? *)` | 09:30 | lifecycle-emails (期限切れ前リマインド + 休眠復帰メール) |
@@ -141,6 +140,7 @@
 
 - スケジュール SSOT: `src/lib/server/cron/schedule-registry.ts`
 - ターゲット: `ganbari-quest-cron-dispatcher` Lambda (JSON payload `{ cronJob: "<job-name>" }`)
+- `ganbari-quest-cron-license-expire` は license key 全廃 (#2822 / Epic #2525 Phase 7 PR-L3) で撤去済。期限管理は Stripe `customer.subscription.deleted` webhook に代替
 - `lifecycle-emails` (#1601, ADR-0023 §5 I11): 親オーナー宛のみ送信。年 6 回マーケティングメール上限を遵守。List-Unsubscribe ヘッダ + 配信停止リンク必須。Anti-engagement 整合 (中立トーン)。
 - `deletion-warning-emails` (#2399, **Phase 1 計画**): `softDeleteTenant` で `physical_deletion_date` が記録されたテナントの所有者宛に削除予告メールを送信。family プラン 14 日前 / standard プラン 1 日前 (グレース 7 日のため 14 日前は到達不能)。idempotency は `settings.deletion_warning_sent_at` で保証。**法務通知扱いのため `marketing-email-counter` (年 6 回上限) には乗せない**。詳細は [`docs/runbooks/account-deletion-email-automation.md`](../runbooks/account-deletion-email-automation.md) (#2399 本 PR で計画策定)
 - **検証手順 / runbook**: [`docs/runbooks/cron-3-endpoints-verification.md`](../runbooks/cron-3-endpoints-verification.md) (#1377 Sub A-3)


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（有料本番 SaaS の全ユーザー）

**解決する課題**: #2822 (license key 全廃 Phase 7 PR-L3) が EventBridge Rule `CronRuleLicenseExpire` を撤去した際、ADR-0019 CDK replacement gate の承認行が merge commit に含まれず、**以降の全本番 deploy が block** されている (merge 済 11 PR — 記録コアループ #2844 / 取込永続 #2825 #2826 / setup 動線 #2835 等 — が本番未達)。

**期待される効果**: replacement 承認により本番 deploy が再開し、merge 済の CRITICAL 修正群が本番に到達する。設計書の cron 表も実態 (#2822 撤去済) に同期する。

## 関連 Issue

#2822 (撤去本体) / #2824 (deploy 待ちの DynamoDB 本実装系) / ADR-0019 (replacement gate)。本 PR は doc-sync + gate 承認のみのため新規 Issue なし (deploy 復旧の運用対応)。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 13-AWS設計書の cron 表から撤去済 license-expire 行を削除し webhook 代替を注記 | `grep -n "license-expire" docs/design/13-AWSサーバレスアーキテクチャ設計書.md` | 表から削除、撤去注記 1 行のみ残存 (本 diff) |
| AC2 | squash merge commit に replacement-approved 行が含まれ ADR-0019 gate が解除される | 本 PR body 末尾の承認行 (squash merge commit message に転写) | merge 後の deploy workflow success で確認 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし (docs のみ)。merge commit の承認行が deploy gate (ADR-0019) を解除する。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**: docs のみの変更 (biome/svelte-check/vitest 影響なし)、check-pr-body は本 body で検証
- [x] 追加・変更したテストの概要: N/A (docs のみ)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A (docs + gate 承認)

## スクリーンショット / ビジュアルデモ

**該当なし（docs のみ、UI 変更なし）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A (docs)
- [x] **DRY**: cron 一覧の SSOT は schedule-registry.ts、設計書は表示。撤去注記で乖離解消
- [x] **YAGNI**: N/A
- [x] **Security（OSS 公開前提）**: 秘密情報なし
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] **設計書同期** (ADR-0001): 本 PR 自体が #2822 の設計書同期
- [x] N/A — 並行実装の影響範囲外 (docs のみ)

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- 本 PR の merge (squash) commit message に下記の replacement-approved 行が含まれることが gate 解除の条件です (ADR-0019)。squash 時に body が転写されることをご確認ください
- 置換対象は #2822 で意図的に撤去された license-expire cron (期限管理は Stripe `customer.subscription.deleted` webhook 代替済)。EventBridge rule 削除のみでデータ無関係、PO 承認取得済 (2026-06-04)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (docs のみ、check-pr-body で検証)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A (docs のみ)
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

replacement-approved: CronRuleLicenseExpire,CronRuleLicenseExpire/AllowEventRuleGanbariQuestComputeCronDispatcherFn62D753EE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
