### PR TITLE
fix(ci): deploy smoke test の cron job を retention-cleanup に変更 (#2822 cleanup 漏れ、deploy 後段 fail 解消)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -302,7 +302,7 @@ jobs:
         run: |
           aws lambda invoke \
             --function-name ganbari-quest-cron-dispatcher \
-            --payload '{"cronJob":"license-expire","dryRun":true}' \
+            --payload '{"cronJob":"retention-cleanup","dryRun":true}' \
             --cli-binary-format raw-in-base64-out \
             --region $AWS_REGION \
             cron-dispatcher-response.json


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（deploy パイプラインの信頼性）

**解決する課題**: #2822 が `license-expire` を cron-dispatcher から撤去した際、deploy.yml の post-deploy「Cron dispatcher smoke test」が同 job を invoke したまま残り、deploy 後段が `unknown cronJob "license-expire"` (400) で fail する (run 26941486583 で実測。本体 deploy は成功するが Health check step が skip され workflow が failure 表示になる)。

**期待される効果**: smoke test が存続 job (`retention-cleanup`) で env 注入検証 (#1586 の本来目的) を継続し、deploy workflow が end-to-end green になる。

## 関連 Issue

#2822 (license-expire 撤去本体) / #1586 (smoke test の導入経緯) / #2824 (deploy 復旧で本番反映された修正群)。1 行差替えの cleanup 漏れ修正のため新規 Issue なし。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | smoke test が存続 job を dryRun invoke し statusCode 200 + dryRun:true を検証する | merge 後の deploy run (deploy.yml 変更は deploy trigger 対象) の「Cron dispatcher smoke test」step success | merge 後 deploy run で確認 (本 PR の差分は payload の cronJob 名 1 箇所のみ) |
| AC2 | retention-cleanup が dispatcher の有効 job である | `git cat-file -p "origin/main:infra/lambda/cron-dispatcher/index.ts"` の CRON_PATHS に `'retention-cleanup'` 存在 | 確認済 (`'retention-cleanup': '/api/cron/retention-cleanup'`) |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし (deploy workflow の smoke test payload 1 箇所のみ)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**: workflow yaml 1 行差替えのみ (app コード無変更)。check-pr-body は本 body で検証
- [x] 追加・変更したテストの概要: N/A (CI 構成修正。検証は merge 後 deploy run の smoke step success)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（CI workflow のみ、UI 変更なし）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A (yaml 1 行)
- [x] **DRY**: smoke 対象 job 名の他参照を grep 済 — `check-cron-observability.mjs` の license-expire 参照は src の endpoint 実在 (撤去対象外) と整合のため無変更
- [x] **YAGNI**: N/A
- [x] **Security（OSS 公開前提）**: 秘密情報なし、dryRun のみ
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] N/A — 並行実装の影響範囲外 (CI workflow のみ)

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- merge により deploy.yml trigger で本番 deploy が走ります (直前 deploy で app 本体は反映済のため再 deploy は同一 image の冪等更新 + smoke/health の full 検証になります)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (yaml のみ、check-pr-body で検証)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
