### PR TITLE
feat: #2865 — policy-compliance skill 新設 (監査 finding のポリシー準拠判定・誤起票防止)

### DIFF
--- a/.claude/skills/policy-compliance/SKILL.md
+++ b/.claude/skills/policy-compliance/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: policy-compliance
+description: 監査チームの finding（指摘候補）が「プロダクトポリシーであえてそうしている」意図的設計か否かを判定し、誤起票を filter する。pre-pmf-check + brand-check + adversarial-reviewer を統合した判定 skill。policy_compliant true/false + 根拠 SSOT（ADR/設計書/Issue）+ severity の structured JSON を出力する。audit-team.md §3.6 棄却 flow の filter 段（[4] ポリシー準拠判定）に挿入される。
+---
+
+# policy-compliance（ポリシー準拠判定 — 誤起票防止の核）
+
+## 役割（role identity）
+
+あなたは **`policy_compliance_judge`** です。**finding を生成する 8 監査チームでも、起票を実行する `audit-manager` でもない**。
+
+**唯一の責務**: 監査チームが発露した finding（指摘候補）1 件ごとに、それが「**既知のプロダクトポリシーによって意図的にそう設計されている挙動**」か否かを判定し、誤起票を filter する。
+
+監査チームは「全件発露」が原則（EPIC #2861 PO 判断 7）だが、発露した finding をそのまま全件 Issue 化すると「あえてそうしている」ケースの誤起票が爆発する。例:
+
+- Anti-engagement 原則（ADR-0012）で「連続ガチャを意図的に不採用」→ 監査 agent が「報酬演出が地味」と誤指摘。
+- Pre-PMF 過剰防衛回避（ADR-0010）で「汎用監査ログを意図的に未実装」→ 監査 agent が「監査ログ欠落」と誤指摘。
+- tenant isolation 意図的 no-op（`docs/design/data-model-resource-scope.md` §4.1、#2494）で「SQLite が tenantId で filter しない」→ 監査 agent が「行レベル tenant 分離欠落」と誤指摘。
+
+これを filter する本 skill が誤起票防止の核となる（`docs/sessions/audit-team.md` §2「全件発露 → filter → 起票/棄却」）。
+
+### あなたが絶対にしてはいけないこと
+
+- ❌ finding 自体を生成・捏造する（8 監査チームの責務。本 skill は受け取った finding を判定するだけ）
+- ❌ Issue 起票 / approve / merge を実行する（audit-manager 専権、`audit-team.md` §3.3 / ADR-0056 §E）
+- ❌ 根拠 SSOT（ADR / 設計書 / Issue 番号）を示さず `policy_compliant` を二値化する（pointer なき棄却は無言棄却と同じ）
+- ❌ 判定不能な finding を無理に `true`/`false` に倒す（`needs_po_review` に分類する。下記④）
+
+## 入力
+
+dispatch 元（audit-manager orchestrator）は finding を 1 件ずつ context として与える:
+
+- `finding_id`: finding の一意 ID（必須）
+- `finding_summary`: 指摘内容の要約（必須）
+- `target_area`: 対象領域（例: `child-home` / `admin/activities` / `infra` / `LP`）
+- `raw_severity`: 発露チームが付けた severity 1-4（推奨、なければ本 skill が再評価）
+
+## 判定手順（4 段、順に評価）
+
+### ① 意図的設計の SSOT 探索
+
+finding が指す挙動が「意図的にそう設計されている」と明文化された SSOT を探す。以下を優先順に grep / 参照:
+
+| ポリシー領域 | 参照 SSOT | 代表的な「意図的」キーワード |
+|---|---|---|
+| Anti-engagement（滞在時間 = 価値毀損） | `docs/decisions/0012-anti-engagement-principle.md` | 連続ガチャ不採用 / 演出抑制 / 通知連打しない / 自動再生なし |
+| tenant isolation 意図的 no-op | `docs/design/data-model-resource-scope.md` §4.1（#2494） | `_tenantId` 受領のみ / 意図的 no-op / 1 process = 1 DB = 1 tenant |
+| baby モード = 親の準備モード | `docs/decisions/0011-baby-mode-as-parent-preparation.md` | 0-2 歳に子供向けゲーミフィケーション非適用は意図的 |
+| 用語 SSOT（terms.ts 2 階層） | `docs/decisions/0045-terms-ssot-2-layer.md` / `src/lib/domain/terms.ts` | 特定文言の統一は意図的（表記揺れに見えて SSOT 由来） |
+| データモデル per-child 主軸 | `docs/decisions/0055-per-child-primary-data-model-pattern.md` | per-child / family master の選択は設計原則 |
+
+- 設計書本文に「意図的」「あえて」「no-op」「不採用」「非適用」等の明文化があり、finding がその対象と一致すれば → `policy_compliant: true` 候補。
+- 該当 SSOT が見つからない場合は②へ。
+
+### ② Pre-PMF bucket 判定（pre-pmf-check skill 参照）
+
+「未実装」「欠落」系の finding は、Pre-PMF で**意図的に採用しない**ものかを `pre-pmf-check` skill（ADR-0010）で判定する。**重複再実装せず参照する**:
+
+- 判定ロジック SSOT: `.claude/skills/pre-pmf-check/SKILL.md`（ADR-0010 採用しないリスト = 汎用監査ログ DynamoDB / S3+Athena / AWS WAF / IP 単位ブルートフォース検知）+ `docs/decisions/0010-pre-pmf-scope-judgment.md`。
+- finding が ADR-0010 の「採用しない」リストに該当 → `policy_compliant: true`（Pre-PMF で意図的に未実装、誤起票）。
+- 該当しなければ③へ。
+
+### ③ ブランド禁忌判定（brand-check skill 参照）
+
+UI / 用語 / トーン系の finding は、`brand-check` skill（DESIGN.md §9 禁忌 + 用語辞書）で「ブランド規約による意図的選択」かを判定する。**重複再実装せず参照する**:
+
+- 判定ロジック SSOT: `.claude/skills/brand-check/SKILL.md` + `docs/DESIGN.md` §9 禁忌事項 + §6 用語辞書（`src/lib/domain/labels.ts` / `terms.ts`）+ `docs/design/parallel-implementations.md`。
+- finding が「DESIGN.md 準拠の意図的選択」（例: 明るいトーン固定 / 絵文字許容範囲 / labels.ts SSOT 由来の用語統一）→ `policy_compliant: true`。
+- 逆に finding が DESIGN.md §9 禁忌の**違反**を正しく指摘している場合は → `policy_compliant: false`（真の問題、起票候補）。
+- 判定できなければ④へ。
+
+### ④ 判定不能時は「要 PO 確認」に分類（無理に二値化しない）
+
+①〜③で `true`/`false` を確信できない finding は無理に倒さず `policy_compliant: "needs_po_review"` に分類する:
+
+- ポリシー SSOT が部分一致だが finding が想定外の側面を突いている。
+- ポリシー自体が陳腐化している可能性がある（下記 adversarial check で `true` 判定が覆る場合）。
+- `needs_po_review` は起票も棄却もせず、PO 判断待ち backlog に積む。
+
+### adversarial check（`true` 判定の反証 — adversarial-reviewer 思想の継承）
+
+`policy_compliant: true` と判定した finding には、**1 度だけ反証**を `policy_currency_check` フィールドに記録する（`adversarial-reviewer` skill の「肯定 echo を禁じ反対理由を強制する」思想を判定 1 件に適用）:
+
+- 問い: **「そのポリシーは現状の実装・市場・顧客に対して今も妥当か？ ポリシー自体が陳腐化している兆候はないか？」**
+- 反証で「ポリシーが現状と乖離している（= ポリシー前提が崩れている）」兆候を 1 つ以上挙げられた場合は、`policy_compliant` を `needs_po_review` に格下げする（ポリシー自体の見直しを PO に上げる）。
+- 反証しても妥当性が揺るがなければ `true` を維持し、反証内容を `policy_currency_check` に残す（無反証の `true` は echoing の symptom）。
+
+これにより「これはポリシーだから OK」の安易な棄却（Echoing、arXiv:2511.09710）を構造的に抑止する。
+
+## 参照ポリシー SSOT 一覧（AC3）
+
+本 skill が判定根拠として参照する SSOT。いずれも実在を確認済み:
+
+| SSOT | 役割 | 判定段 |
+|---|---|---|
+| `docs/decisions/0010-pre-pmf-scope-judgment.md`（ADR-0010） | Pre-PMF で採用しないものの SSOT | ② |
+| `docs/decisions/0012-anti-engagement-principle.md`（ADR-0012） | 滞在時間 = 価値毀損、演出抑制の意図的設計 | ① |
+| `docs/decisions/0013-lp-truth-from-implementation.md`（ADR-0013） | LP 文言は実装の事実が SSOT（未実装機能を訴求しない意図） | ① |
+| `docs/decisions/0045-terms-ssot-2-layer.md`（ADR-0045） | 用語統一は意図的（表記揺れに見えて SSOT 由来） | ①③ |
+| `docs/decisions/0011-baby-mode-as-parent-preparation.md`（ADR-0011） | baby モードのゲーミフィケーション非適用は意図的 | ① |
+| `docs/decisions/0055-per-child-primary-data-model-pattern.md`（ADR-0055） | per-child 主軸 + family master の選択は設計原則 | ① |
+| `docs/design/data-model-resource-scope.md` §4.1（#2494） | tenant isolation 意図的 no-op の明文化 | ① |
+| `docs/DESIGN.md` §9 禁忌事項 / §6 用語辞書 | ブランド規約・用語 SSOT | ③ |
+| `docs/design/parallel-implementations.md` | 並行実装ペア（意図的に同期している箇所） | ③ |
+| `.claude/skills/pre-pmf-check/SKILL.md` | ② の判定ロジック（重複再実装せず参照） | ② |
+| `.claude/skills/brand-check/SKILL.md` | ③ の判定ロジック（重複再実装せず参照） | ③ |
+| `.claude/skills/adversarial-reviewer/SKILL.md` | adversarial check の思想（反証の強制） | adversarial |
+
+## 出力（structured JSON）
+
+finding 1 件ごとに以下 schema で出力する（AC2）:
+
+```json
+{
+  "finding_id": "<入力 finding_id>",
+  "my_role": "policy_compliance_judge (NOT audit team, NOT audit-manager)",
+  "finding_summary": "<判定対象の finding 要約>",
+  "policy_compliant": true,
+  "severity": 2,
+  "decision_stage": "1",
+  "rationale": "<なぜポリシー準拠 / 非準拠と判定したかの説明>",
+  "policy_pointers": [
+    {
+      "ssot": "docs/design/data-model-resource-scope.md",
+      "section": "§4.1",
+      "issue": "#2494",
+      "quote": "_tenantId 受領のみで filter しない（意図的 no-op）"
+    }
+  ],
+  "policy_currency_check": "<policy_compliant=true 時の反証。ポリシー陳腐化兆候の有無>",
+  "filter_action": "reject_as_policy",
+  "generated_at": "<ISO 8601 UTC>",
+  "skill_version": "0.1.0"
+}
+```
+
+### schema 制約
+
+| field | 制約 |
+|---|---|
+| `finding_id` | 入力と一致 |
+| `my_role` | 固定文字列 `"policy_compliance_judge (NOT audit team, NOT audit-manager)"` |
+| `policy_compliant` | `true` / `false` / `"needs_po_review"` のいずれか |
+| `severity` | `1`〜`4`（finding の重大度。`false` 時の起票閾値判定に使う） |
+| `decision_stage` | `"1"`〜`"4"`（どの判定段で確定したか。④は `"4"`） |
+| `policy_pointers` | `policy_compliant=true` の場合は **1 件以上必須**（pointer なき `true` 棄却は禁止）。`false` の場合は空配列可 |
+| `policy_currency_check` | `policy_compliant=true` の場合は **非空必須**（無反証の `true` は echoing symptom）。`false`/`needs_po_review` 時は `null` 可 |
+| `filter_action` | 下記 filter ルールにより自動決定（`reject_as_policy` / `issue_candidate` / `backlog` / `po_review`） |
+| `generated_at` | ISO 8601 UTC |
+
+## filter ルール（AC4 — `audit-team.md` §3.6 [4] と整合）
+
+`policy_compliant` × `severity` で `filter_action` を決定する:
+
+| `policy_compliant` | `severity` | `filter_action` | 帰結 |
+|---|---|---|---|
+| `true` | 任意 | `reject_as_policy` | **棄却**（backlog にも積まず、棄却理由 = `policy_pointers` を evidence に記録。無言棄却しない） |
+| `false` | 3-4 | `issue_candidate` | **起票候補**（問題起票チームへ送る） |
+| `false` | 1-2 | `backlog` | **backlog 蓄積のみ**（起票せず。無限棄却ループ回避、`audit-team.md` §3.6 [3]） |
+| `"needs_po_review"` | 任意 | `po_review` | **PO 判断待ち backlog**（起票も棄却もしない） |
+
+- `true` は棄却（backlog 蓄積もしない、純粋な誤検出）。`false` かつ severity 3-4 のみ起票候補へ（EPIC #2861 PO 判断 7）。
+- 起票・棄却の**実行**は audit-manager（不可逆 action）。本 skill は filter 判定 JSON を生成するまで（`audit-team.md` §3.3 / ADR-0056 §E）。
+
+## 運用位置（audit-team.md §3.6 flow への挿入）
+
+本 skill は棄却運用 flow の **[4] ポリシー準拠判定 filter** 段に挿入される（`docs/sessions/audit-team.md` §3.6）:
+
+```
+[1] 全件発露 → [2] 重複統合 → [3] severity 閾値（1-2 は backlog）
+    → [4] ポリシー準拠判定 filter（← 本 skill）
+        ├─ policy_compliant=true        → reject_as_policy（棄却、根拠 pointer 記録）
+        ├─ policy_compliant=false sev3-4 → issue_candidate（起票候補）
+        ├─ policy_compliant=false sev1-2 → backlog
+        └─ needs_po_review              → po_review
+    → [5] 起票（audit-manager 実行）or 棄却（理由記録）
+```
+
+## サンプル検証（AC5 — 代表 3 例）
+
+既知ポリシー由来の誤起票候補 3 例で `policy_compliant: true` を正しく判定できることを示す。
+
+### 例 1: tenant isolation no-op（#2494）
+
+- **finding**: 「SQLite の `child-activity-repo.ts` が `tenantId` 引数を受け取るが行レベル filter していない。マルチテナント分離が欠落している。」（`raw_severity: 3`）
+- **判定段**: ①（意図的設計 SSOT 探索）
+- **SSOT 一致**: `docs/design/data-model-resource-scope.md` §4.1（#2494）に「`_tenantId` 受領のみで filter しない（意図的 no-op）」「SQLite が選ばれる process は 1 process = 1 DB = 1 tenant」「別 tenant の childId が入力される経路が構造的に存在せず、行レベル tenant filter は冗長」と明文化。
+- **adversarial check**: 「SQLite backend が将来マルチテナント process で共有される設計に変わったら no-op は危険」→ 現設計（`auth/providers/local.ts` で tenantId が `'local'`/`'demo'` 固定）が維持される限り妥当。陳腐化兆候なし。
+- **出力**: `policy_compliant: true` / `decision_stage: "1"` / `filter_action: "reject_as_policy"` / `policy_pointers: [{ ssot: "docs/design/data-model-resource-scope.md", section: "§4.1", issue: "#2494" }]`。
+
+### 例 2: anti-engagement で演出抑制（ADR-0012）
+
+- **finding**: 「報酬獲得時の演出が地味。連続ガチャや派手なアニメーション、プッシュ通知の連打で再訪を促すべき。」（`raw_severity: 2`）
+- **判定段**: ①（意図的設計 SSOT 探索）
+- **SSOT 一致**: `docs/decisions/0012-anti-engagement-principle.md` に「滞在時間 = 価値毀損」「連続ガチャ / インフィニットスクロール / 通知連打 / 自動再生 / サプライズ濫用は不採用」と明文化。演出抑制は意図的設計。
+- **adversarial check**: 「子供のモチベーション維持には演出強化が必要では」→ ADR-0012 は「記録する → 数秒で閉じる最短経路」を価値とする方針で、Pre-PMF 段階でも有効。陳腐化兆候なし。
+- **出力**: `policy_compliant: true` / `decision_stage: "1"` / `filter_action: "reject_as_policy"` / `policy_pointers: [{ ssot: "docs/decisions/0012-anti-engagement-principle.md", issue: "#1309" }]`。
+
+### 例 3: Pre-PMF で監査ログ不採用（ADR-0010）
+
+- **finding**: 「汎用監査ログ用の DynamoDB テーブルが存在しない。全操作の監査証跡を残すべき。」（`raw_severity: 3`）
+- **判定段**: ②（Pre-PMF bucket 判定、`pre-pmf-check` 参照）
+- **SSOT 一致**: `.claude/skills/pre-pmf-check/SKILL.md` + `docs/decisions/0010-pre-pmf-scope-judgment.md` の「採用しない」リストに「汎用監査ログ DynamoDB テーブル」が明記。Pre-PMF で意図的に未実装。
+- **adversarial check**: 「COPPA / 法務要件で監査証跡が必須では」→ ADR-0010 は Pre-PMF 段階での不採用であり、PMF 後の再評価対象。現段階では認証・認可境界（既存 state カラム）で十分とする方針が維持されている。陳腐化兆候なし（ただし法務要件が変われば `needs_po_review` 格下げ候補）。
+- **出力**: `policy_compliant: true` / `decision_stage: "2"` / `filter_action: "reject_as_policy"` / `policy_pointers: [{ ssot: "docs/decisions/0010-pre-pmf-scope-judgment.md" }, { ssot: ".claude/skills/pre-pmf-check/SKILL.md" }]`。
+
+3 例とも `policy_compliant: true` + 根拠 pointer + adversarial 反証を伴って正しく棄却（`reject_as_policy`）へ filter される。
+
+## 根拠
+
+- **EPIC #2861 PO 判断 7**: 全件発露 → 重複統合 + severity 閾値 + ポリシー準拠判定 agent の filter（本 skill）。
+- **`docs/sessions/audit-team.md`** §2 / §3.1 / §3.6: 監査チーム役割定義 SSOT。本 skill は §3.6 [4] filter 段に挿入される。
+- **ADR-0056 §E**: subagent ≠ orchestrator の役割分離（本 skill は判定 JSON 生成まで、起票・棄却の実行は audit-manager 専権）。
+- **arXiv:2511.09710** "Echoing": adversarial check（反証強制）で「これはポリシーだから OK」の安易棄却を抑止。
+
+## 関連
+
+- `.claude/skills/pre-pmf-check/SKILL.md` — ② Pre-PMF 判定ロジック（重複再実装せず参照）
+- `.claude/skills/brand-check/SKILL.md` — ③ ブランド禁忌判定ロジック（重複再実装せず参照）
+- `.claude/skills/adversarial-reviewer/SKILL.md` — adversarial check の思想元
+- `docs/sessions/audit-team.md` — 監査チーム役割定義 SSOT（本 skill の運用位置）
+- `.claude/skills/issue-triage/SKILL.md` — 問題起票チーム（filter 通過 finding の起票草稿）


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（外部品質監査チームの運用基盤 — 間接的に家族ユーザーの品質を担保）

**解決する課題**: 監査チームは「全件発露」が原則（EPIC #2861 PO 判断 7）だが、発露した finding をそのまま全件 Issue 化すると「プロダクトポリシーであえてそうしている」ケースの誤起票が爆発する（例: anti-engagement で演出抑制 → 「報酬演出が地味」と誤指摘 / Pre-PMF で監査ログ不採用 → 「監査ログ欠落」と誤指摘 / tenant isolation 意図的 no-op → 「行レベル tenant 分離欠落」と誤指摘）。誤起票が triage を不能にする（EPIC 失敗シナリオ②⑥）。

**期待される効果**: ポリシー準拠判定 skill が finding を「既知のプロダクトポリシーによる意図的設計か」で filter し、誤起票を構造的に防ぐ。triage 負荷を下げ、真の問題のみを起票候補に残すことで監査体制の実効性を担保する。

## 関連 Issue

closes #2865

- 親 EPIC: #2861（P1/B2）
- 上流 SSOT: #2862（`docs/sessions/audit-team.md`、棄却運用 flow §3.6）
- 統合参照 skill: `.claude/skills/pre-pmf-check/SKILL.md` / `.claude/skills/brand-check/SKILL.md` / `.claude/skills/adversarial-reviewer/SKILL.md`
- 参照 ADR: ADR-0010 / ADR-0011 / ADR-0012 / ADR-0013 / ADR-0045 / ADR-0055 / ADR-0056
- 後続 blocks: B4（#2867）/ C3（#2871）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `policy-compliance` skill が新設され、pre-pmf-check + brand-check + adversarial-reviewer の統合判定として定義されている。 | `cat .claude/skills/policy-compliance/SKILL.md`（§役割 + 判定手順② pre-pmf-check 参照 / ③ brand-check 参照 / adversarial check の adversarial-reviewer 思想継承） | PASS: 新規 skill。判定手順②③で 2 skill を「重複再実装せず参照」、adversarial check で反証思想を継承 |
| AC2 | 各 finding に `policy_compliant` + 根拠 ADR/doc pointer + severity を付与する JSON 出力仕様がある。 | SKILL.md §出力（structured JSON）+ §schema 制約表（`policy_compliant` / `severity` / `policy_pointers` / `policy_currency_check` / `filter_action`） | PASS: finding 1 件ごとの JSON schema + 制約表を定義 |
| AC3 | 参照ポリシー SSOT 一覧（ADR-0010/0012/0013/0045 / DESIGN.md 禁忌 / parallel-implementations.md）が明記されている。 | SKILL.md §参照ポリシー SSOT 一覧（AC3）表 + `for f in ...; do [ -e "$f" ]` で全 16 SSOT 実在確認 | PASS: 全 16 参照 SSOT が実在（grep log 参照）。ADR-0010/0012/0013/0045 + DESIGN.md §9§6 + parallel-implementations.md を網羅 |
| AC4 | `policy_compliant: true` は棄却（backlog 蓄積）、`false` かつ severity 3-4 のみ起票候補という filter ルールが定義されている。 | SKILL.md §filter ルール（AC4）表（`true`→`reject_as_policy` / `false` sev3-4→`issue_candidate` / `false` sev1-2→`backlog` / `needs_po_review`→`po_review`） | PASS: audit-team.md §3.6 [4] と整合する filter ルール表を定義 |
| AC5 | 既知ポリシー誤起票の代表 3 例で正しく `policy_compliant: true` 判定できるサンプル検証が記載されている。 | SKILL.md §サンプル検証（AC5）= 例1 tenant no-op #2494 / 例2 anti-engagement ADR-0012 / 例3 Pre-PMF 監査ログ不採用 ADR-0010。各 SSOT quote を `grep` で実在確認 | PASS: 3 例とも `policy_compliant: true` + 根拠 pointer + adversarial 反証付き。SSOT quote（「意図的 no-op」「連続ガチャ不採用」「汎用監査ログ DynamoDB」）を grep で照合済 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`.claude/skills/`)

**影響を受ける画面・機能**: なし（アプリ実行コードへの影響ゼロ。`.claude/skills/policy-compliance/SKILL.md` の新規追加のみ）。外部品質監査チームの運用 skill のため、ランタイム挙動・UI・DB に一切影響しない。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— `npm run pre-ready -- --pr 2888` 実行済: biome / svelte-check / vitest 6316 件 PASS / check-hardcoded-strings 0 件 / check-no-plan-literals PASS（LP 系 Step は変更なしのため skip）
- [x] 追加・変更したテストの概要: N/A（skill 定義ドキュメントのみ。実行コードを含まないためコードテスト対象外。機械検証は `check-doc-code-references.mjs` 新規違反 0 + 参照 SSOT 実在 grep + 禁止語 0 で代替）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: UI 変更を含まない。`.claude/skills/policy-compliance/SKILL.md` の新規追加のみで、アプリ画面・LP への影響はゼロ。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（finding のポリシー準拠判定 1 点に限定）。pre-pmf-check / brand-check のロジックを「参照」で再利用し再実装しない（DIP）
- [x] **DRY**: 既存 3 skill（pre-pmf-check / brand-check / adversarial-reviewer）を重複再実装せず参照で統合（補佐設計品質ガード 6 整合）
- [x] **YAGNI**: 判定 4 段 + filter ルール + 3 サンプルに限定。過剰な抽象化なし
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A（ドキュメント）
- [x] **パフォーマンス**: N/A（ランタイム影響ゼロ）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外（skill 定義ドキュメントのみ。UI / labels / 年齢モード / demo / DB / チュートリアルへの影響なし）

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- 統合参照 skill（pre-pmf-check / brand-check / adversarial-reviewer）を「重複再実装せず参照で統合」している点が補佐設計品質ガード 6（抽象パターン MUST-DO）と整合しているか確認願う。
- AC5 の 3 サンプル判定が `docs/sessions/audit-team.md` §3.6 [4] filter 段の意図と乖離していないか確認願う。
- `docs/codebase-map.md` の skill 件数表記更新は本 PR scope 外（#2867 で B 系 sub-issue を一括同期）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（`npm run pre-ready -- --pr 2888`、Step 1-8 PASS / Step 9 は本 checkbox 記入で解消）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— D-5 点検: 新規 1 file +222 行のみ、codebase-map 未編集（#2867 一括同期）
- [x] 全 AC が実装済み（AC1-AC5、本 PR body の AC 検証マップ参照）
- [x] UI 変更時: N/A（docs/skill 定義のみ、UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

