### PR TITLE
fix: #2894 — license 全廃後の tier 解決で reward 系 action 全 403 (PlanLimitError 表示修正 + plan gate 回帰 E2E)

### DIFF
--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -11,6 +11,7 @@
 
 import { deserialize, enhance } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
+import type { PlanLimitError } from '$lib/domain/errors';
 import { getErrorMessage } from '$lib/domain/errors';
 import {
 	ADMIN_REWARDS_PAGE_LABELS,
@@ -231,7 +232,10 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 					type: 'success';
 					data?: { imported?: number; skipped?: number; total?: number };
 			  }
-			| { type: 'failure'; data?: { error?: string } }
+			// #2894 AC3: plan gate 拒否 (#728/#787) は error が PlanLimitError オブジェクト。
+			// 旧型は `error?: string` のみで、`String(error)` だと「[object Object]」になり
+			// plan-limit メッセージも件数表示も壊れていた (Issue 証拠④)。
+			| { type: 'failure'; data?: { error?: string | PlanLimitError } }
 			| { type: 'redirect'; location: string }
 			| { type: 'error'; error: unknown };
 
@@ -250,7 +254,12 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 				await invalidateAll();
 			}
 		} else if (actionResult.type === 'failure') {
-			actionMessage = String(actionResult.data?.error ?? ADMIN_REWARDS_PAGE_LABELS.importFailed);
+			// #2894 AC3: getErrorMessage が string / PlanLimitError どちらでも message を取り出す。
+			// plan gate 403 (free tier) のときは PlanLimitError.message =
+			// PLAN_GATE_LABELS.standardOrAboveFor('ごほうび管理') が表示される。
+			// アップグレード誘導は画面上部の rewards-upgrade-banner (!data.isPremium 時) が担う。
+			actionMessage =
+				getErrorMessage(actionResult.data?.error) || ADMIN_REWARDS_PAGE_LABELS.importFailed;
 			showToast(actionMessage, undefined, 'error');
 		} else {
 			actionMessage = ADMIN_REWARDS_PAGE_LABELS.importFailed;
@@ -308,7 +317,9 @@ async function handleCopyFromChild() {
 		});
 		const actionResult = deserialize(await resp.text()) as
 			| { type: 'success'; data?: { copiedCount?: number } }
-			| { type: 'failure'; data?: { error?: string } }
+			// #2894 AC3: copyFromChild も plan gate (#728) で PlanLimitError を返すため
+			// error は string | PlanLimitError。
+			| { type: 'failure'; data?: { error?: string | PlanLimitError } }
 			| { type: 'redirect'; location: string }
 			| { type: 'error'; error: unknown };
 
@@ -320,7 +331,9 @@ async function handleCopyFromChild() {
 			copySourceChildId = null;
 			await invalidateAll();
 		} else if (actionResult.type === 'failure') {
-			actionMessage = String(actionResult.data?.error ?? ADMIN_REWARDS_PAGE_LABELS.copyFailed);
+			// #2894 AC3: getErrorMessage で PlanLimitError / string を一貫表示。
+			actionMessage =
+				getErrorMessage(actionResult.data?.error) || ADMIN_REWARDS_PAGE_LABELS.copyFailed;
 			showToast(actionMessage, undefined, 'error');
 		} else {
 			actionMessage = ADMIN_REWARDS_PAGE_LABELS.copyFailed;

--- a/tests/e2e/plan-gated-features.spec.ts
+++ b/tests/e2e/plan-gated-features.spec.ts
@@ -33,6 +33,60 @@ test.describe('#776 /admin/rewards プランゲート — free', () => {
 		await expect(page.getByTestId('rewards-upgrade-banner')).toBeVisible();
 		await expect(page.getByTestId('rewards-upgrade-cta')).toBeVisible();
 	});
+
+	// #2894 AC5 (case 1): free tier (cognito-dev dev-free-owner, licenseStatus=NONE) で
+	// marketplace reward-set を取込もうとすると importPresetToChildren action が
+	// plan gate (#728) で 403 + PlanLimitError を返す。修正前は handleChildSelectionConfirm が
+	// `String(error)` するため toast / banner が「[object Object]」になり plan-limit
+	// メッセージが壊れていた (Issue 証拠④)。修正後 (getErrorMessage 経由) は
+	// PLAN_GATE_LABELS.standardOrAboveFor('ごほうび管理') を含む可読メッセージが表示される。
+	test('#2894: free で reward 取込確定 → plan-limit メッセージが表示され [object Object] にならない', async ({
+		page,
+	}) => {
+		test.slow(); // Vite dev コールドコンパイル耐性
+
+		// ?import=<presetId> で ChildSelectionDialog auto-open (kinder-rewards は実在 preset)
+		await page.goto('/admin/rewards?import=kinder-rewards', { waitUntil: 'domcontentloaded' });
+
+		const dialog = page.getByTestId('reward-import-child-selection-dialog');
+		await expect(dialog, 'ChildSelectionDialog auto-open (dead-end でない前提)').toBeVisible({
+			timeout: 15_000,
+		});
+
+		// default = 「全員に追加」選択済 → 確定 click。
+		// 副作用 A: importPresetToChildren network 発火 (free では 403 plan gate で reject される)。
+		const confirm = page.getByTestId('child-selection-confirm');
+		await expect(confirm).toBeEnabled();
+		const [resp] = await Promise.all([
+			page.waitForResponse((r) => /\?\/importPresetToChildren/.test(r.url())),
+			confirm.click(),
+		]);
+		// SvelteKit form action は fail(403, ...) を 200 ActionResult (type:failure) で返す。
+		// HTTP status は 200 だが body に PlanLimitError が入る。
+		expect([200, 403].includes(resp.status())).toBe(true);
+
+		// 副作用 B: 結果 feedback (Toast role=alert または banner role=status) が
+		//   plan-limit メッセージを表示する。修正前バグの「[object Object]」を含まないこと、
+		//   かつ「スタンダードプラン」を含む可読メッセージであることを assert。
+		const actionMsg = page.getByTestId('rewards-action-message');
+		const toast = page.getByRole('alert');
+		// banner / toast のどちらか先に出た方を待つ (2 層防御、DESIGN.md §5 Toast)
+		await expect(actionMsg.or(toast).first()).toBeVisible({ timeout: 10_000 });
+
+		const bannerText = (await actionMsg.textContent().catch(() => '')) ?? '';
+		const toastText =
+			(await toast
+				.first()
+				.textContent()
+				.catch(() => '')) ?? '';
+		const combined = `${bannerText}${toastText}`;
+		// #2894 回帰: 壊れた文字列化を二度と踏まない
+		expect(combined, 'plan-limit feedback が [object Object] になっていない').not.toContain(
+			'[object Object]',
+		);
+		// plan-limit メッセージ (PLAN_GATE_LABELS.standardOrAboveFor) の可読性を担保
+		expect(combined, 'plan-limit メッセージにプラン名が含まれる').toContain('スタンダードプラン');
+	});
 });
 
 test.describe('#776 /admin/rewards プランゲート — standard', () => {
@@ -41,6 +95,56 @@ test.describe('#776 /admin/rewards プランゲート — standard', () => {
 	test('standard プランではアップグレードバナーが表示されない', async ({ page }) => {
 		await page.goto('/admin/rewards');
 		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
+	});
+
+	// #2894 AC5 (case 2): paid tier (cognito-dev dev-standard-owner, licenseStatus=ACTIVE +
+	// plan=standard_monthly) では plan gate を通過し、reward 取込が成功する。
+	// free との対比で「reward だけ paid 限定」という #728 committed 仕様 (pricing SSOT §3.2) を
+	// 双方向で固定する (ADR-0006 mirror 関係)。
+	test('#2894: standard で reward 取込確定 → plan gate を通過し成功フィードバックが出る', async ({
+		page,
+	}) => {
+		test.slow(); // Vite dev コールドコンパイル耐性
+
+		await page.goto('/admin/rewards?import=kinder-rewards', { waitUntil: 'domcontentloaded' });
+
+		const dialog = page.getByTestId('reward-import-child-selection-dialog');
+		await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+		const confirm = page.getByTestId('child-selection-confirm');
+		await expect(confirm).toBeEnabled();
+		// 副作用 A: importPresetToChildren network 発火 + response OK (plan gate 通過 = 403 で reject されない)
+		const [resp] = await Promise.all([
+			page.waitForResponse((r) => /\?\/importPresetToChildren/.test(r.url())),
+			confirm.click(),
+		]);
+		expect(resp.ok()).toBeTruthy();
+		const respBody = await resp.text();
+		// 成功 ActionResult (type:success) で対象 presetId を含む = Strategy dispatch 完了。
+		// plan gate 403 (PlanLimitError) なら body に "PLAN_LIMIT_EXCEEDED" が含まれるため、
+		// 成功経路ではそれを含まないことを併せて確認 (free との対比)。
+		expect(respBody.includes('kinder-rewards')).toBeTruthy();
+		expect(
+			respBody.includes('PLAN_LIMIT_EXCEEDED'),
+			'standard は plan gate で reject されない (PlanLimitError を返さない)',
+		).toBeFalsy();
+
+		// 副作用 B: 成功 feedback (banner role=status または Toast) が表示され
+		//   plan-limit メッセージは出ない。
+		const actionMsg = page.getByTestId('rewards-action-message');
+		const toast = page.getByRole('alert');
+		await expect(actionMsg.or(toast).first()).toBeVisible({ timeout: 10_000 });
+		const bannerText = (await actionMsg.textContent().catch(() => '')) ?? '';
+		const toastText =
+			(await toast
+				.first()
+				.textContent()
+				.catch(() => '')) ?? '';
+		const combined = `${bannerText}${toastText}`;
+		expect(combined).not.toContain('[object Object]');
+		expect(combined, 'standard 成功時は plan-limit メッセージを出さない').not.toContain(
+			'スタンダードプラン以上',
+		);
 	});
 });
 

--- a/tests/unit/domain/errors.test.ts
+++ b/tests/unit/domain/errors.test.ts
@@ -157,4 +157,23 @@ describe('#787 getErrorMessage', () => {
 		expect(getErrorMessage(403)).toBe('');
 		expect(getErrorMessage(true)).toBe('');
 	});
+
+	// #2894 AC3 回帰: admin/rewards の handleChildSelectionConfirm / handleCopyFromChild が
+	// form action failure の data.error を `String(error)` していたため、reward 系 action の
+	// plan gate 403 (PlanLimitError オブジェクト) が「[object Object]」と表示され、
+	// plan-limit メッセージも件数表示も壊れていた (Issue #2894 証拠④)。
+	// 修正後は getErrorMessage 経由で PlanLimitError.message を正しく取り出す。
+	it('#2894: PlanLimitError を String() すると壊れるが getErrorMessage は message を返す', () => {
+		const planLimitError = createPlanLimitError(
+			'free',
+			'standard',
+			'ごほうび管理はスタンダードプラン以上でご利用いただけます',
+		);
+		// 旧バグ経路 (String) は壊れた表示になる — この回帰を二度と踏まないことを明示
+		expect(String(planLimitError)).toBe('[object Object]');
+		// 修正経路 (getErrorMessage) は人間可読な plan-limit メッセージを返す
+		expect(getErrorMessage(planLimitError)).toBe(
+			'ごほうび管理はスタンダードプラン以上でご利用いただけます',
+		);
+	});
 });


### PR DESCRIPTION
## 顧客価値・目的

本番 (AWS / AUTH_MODE=cognito) で marketplace のごほうびセット取込・カスタムごほうび追加等の reward 系操作が全失敗し、activity / checklist は成功するため「ごほうびだけ壊れている」体験になっていた (PO 実機確認 2026-06-04)。本 PR は失敗時に表示が壊れる UI バグ (AC3) を根治し、plan gate の双方向回帰を E2E で固定する (AC5)。entitlement 設計の根本対処 (AC1) と gate 統一方針 (AC2) は PO 判断を仰ぐ事項として整理した。

## 関連 Issue

Closes #2894

関連: #728 (reward plan gate 導入) / #787 (PlanLimitError 統一) / #2813 #2822 (license key 全廃 Phase 7) / pricing 戦略書 §3.2 (カスタム報酬設定 = 有料、committed) / license-key-removal-final OQ-1 (license 救済 skip、PO 確定 2026-06-02)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | license 時代に paid だった既存テナントの entitlement を cutover で保全 | policy-compliance skill 判定 + billing-redesign cutover docs 照合 | 未実装 (PO 判断を仰ぐ)。PO 確定「Stripe を plan の唯一 SSOT・license 救済 skip」(README L16 / FR-5 / OQ-1) と矛盾するため Dev 単独実装不可。下記「レビュー依頼事項」に選択肢提示 |
| AC2 | 取込系 action の plan gate 方針を 5 type で統一 | pricing SSOT (plan-features + 戦略書 §3.2) 照合 | 整理完了 (PO 判断を仰ぐ)。reward 全面 gate は committed 仕様 (戦略書 §3.2「カスタム報酬設定: フリー=不可」)。activity プリセット利用は全種無料のため import gate なしも仕様どおり。gate 撤去は pricing 戦略変更のため PO 判断事項 |
| AC3 | PlanLimitError を dialog flow で正しく表示 (文字列化壊れ修正 + アップグレード誘導) | unit `tests/unit/domain/errors.test.ts` + E2E (AC5 free case) | 実装済。`String(data.error)` → `getErrorMessage(data.error)` に修正 (`+page.svelte` L259/L327)。アップグレード誘導は既存 `rewards-upgrade-banner` (!isPremium 時) が担う |
| AC4 | 本番 (DynamoDB) で reward セット取込 → 一覧反映 → reload 残存を PO 実機確認 | PO 実機 | 未チェック (PO 実機確認領域)。手順は下記「レビュー依頼事項」に記載 |
| AC5 | E2E に free→plan-limit メッセージ / paid→取込成功 の両 case 追加 | `tests/e2e/plan-gated-features.spec.ts` | 実装済。free describe (storageState free.json) に plan-limit メッセージ検証、standard describe に取込成功検証を追加。`[object Object]` でないことを assert |

## 変更タイプ

- [x] バグ修正 (fix)
- [ ] 新機能 (feat)
- [ ] リファクタリング (refactor)
- [ ] ドキュメント (docs)

priority:critical (本番ごほうび管理の全 write 不能 + 表示壊れ)

## 影響範囲・変更コンポーネント

- `src/routes/(parent)/admin/rewards/+page.svelte` — `handleChildSelectionConfirm` / `handleCopyFromChild` の form action failure 処理を `getErrorMessage` 経由に修正 (PlanLimitError 型を import)
- `tests/unit/domain/errors.test.ts` — #2894 回帰 unit (String() は壊れ getErrorMessage は message を返す)
- `tests/e2e/plan-gated-features.spec.ts` — free / standard の reward 取込 plan gate 双方向 E2E

DB スキーマ変更なし。server action (`+page.server.ts`) は無変更 (PlanLimitError は既に正しく fail(403) で返している。バグは UI 側の文字列化のみ)。

## テスト & 安全装置セルフチェック

- [x] unit: `npx vitest run tests/unit/domain/errors.test.ts` → 19 passed (回帰ケース含む)
- [x] unit: `npx vitest run tests/unit/services/plan-limit-service.test.ts tests/unit/domain/errors.test.ts` → 95 passed
- [x] biome check (変更 3 ファイル) → 整形適用後 PASS
- [x] svelte-check (変更ファイル) → ERROR 0 (既存 `data` 初期値参照 WARNING のみ、本変更箇所外)
- [ ] E2E `plan-gated-features.spec.ts` (cognito-dev config) → CI 実行で検証
- ADR-0006 遵守: assertion 弱体化なし。`getErrorMessage` 既存ヘルパー活用、PlanLimitError → message 抽出は既存 unit で担保済

## スクリーンショット / ビジュアルデモ

本 PR の主変更は「失敗時の toast / banner 文字列が `[object Object]` から可読 plan-limit メッセージに変わる」挙動修正。free tier での実画面確認は `npm run dev:cognito` + `free@example.com` ログイン → `/admin/rewards?import=kinder-rewards` → 確定 で再現可能。E2E (AC5) が文字列内容を機械検証するため、視覚回帰の主担保は E2E に置く。

## コード品質セルフレビュー (#1481)

- 既存 `getErrorMessage` (string | PlanLimitError 正規化ヘルパー) を再利用し独自実装を追加しない
- form action failure の型を `error?: string` → `error?: string | PlanLimitError` に訂正 (実態と一致)
- 2 箇所 (confirm / copy) を同一パターンで修正し一貫性を保つ

## 横展開・影響波及チェック

- `String(...data?.error)` の同種バグを admin 配下全体で grep → rewards のみ該当 (activities/checklists は plan gate が `checkActivityLimit` 数量上限経由で PlanLimitError を toast 直表示しない構造)。横展開対象なし
- 並行実装 (parallel-implementations.md): 本変更は UI 表示処理のみで labels / 年齢モード / demo / DB に波及しない

## レビュー依頼事項・破壊的変更

破壊的変更なし。以下 2 点を PO 判断事項として提示する:

**AC1 (entitlement 保全) — PO 判断を仰ぐ**: 本番 owner (運用者本人) が `stripeSubscriptionId` を持たないため `resolvePlanTier` で free 降格する。これは「Stripe Subscription を plan の唯一 SSOT」(billing-redesign README L16 / FR-5) + 「license 救済 skip, Pre-PMF 顧客ゼロ前提」(OQ-1, PO 確定 2026-06-02) どおりの設計挙動。救済には以下いずれかの PO 判断が必要 (no-gos「isPaidTier 弱体化(全員 paid 扱い)」は侵さない):
- (a) PO/運用 owner が Stripe checkout で課金 (設計どおりの正規経路)
- (b) owner role に entitlement を無条件付与する pricing 戦略変更 (運用者は課金不要とする決定)
- (c) `tenant.plan` を持つテナントを entitlement source に昇格 (Stripe 単一 SSOT 原則の改訂が必要)

policy-compliance skill 判定では (c) は PO 確定方針と矛盾し `needs_po_review`。Dev 単独実装は越権のため未実装とした。

**AC2 (gate 統一) — PO 判断を仰ぐ**: reward 全面 gate は pricing 戦略書 §3.2「カスタム報酬設定: フリー = 不可」の committed 仕様。activity プリセット取込が gate なしなのは「プリセット活動利用は全種無料」(§3.2) どおり。gate 撤去は pricing 戦略変更となるため PO 判断事項。現状の gate 維持が pricing SSOT 整合という整理を提示する。

**AC4 (本番実機確認)**: AC1 の PO 判断後、本番 DynamoDB で reward セット取込 → 一覧反映 → reload 残存を PO が実機確認する。

## 配布済み env / secret (ADR-0006)

新規 env / secret の追加なし。`DEBUG_PLAN` (#758、dev/E2E only) は既配備。

## Ready for Review チェックリスト

- [ ] `npm run pre-ready -- --pr <num>` 全 step PASS (Draft 段階、AC1/AC2 PO 判断後に実施)
- [ ] QA 承認・動作確認が完了している
- [x] commit message 規約準拠 (Co-Authored-By 付与)
- [x] 変更ファイルに型エラー・lint エラーなし (errors unit 19 / plan-limit+errors 95 passed)

(Draft PR: AC1/AC2 の PO 判断と AC4 実機確認が前提のため pre-ready / QA 承認は未完。AC3/AC5 のコード + テストは完遂済)

## QM レビュー結果

(QM レビュー前)
