### PR TITLE
fix: #2894 ごほうびセット本番登録不可 — PlanLimitError 表示壊れ根治 + 取込経路 gate 統一 (CRITICAL)

### DIFF
--- a/docs/design/billing-redesign/phase1-license-key-removal-final-requirements.md
+++ b/docs/design/billing-redesign/phase1-license-key-removal-final-requirements.md
@@ -201,6 +201,7 @@ PR-L0〜L5 (#2807 / #2812 / #2814 / #2822 / #2841 / #2879、全マージ済) 完
 | OQ-2 | business | campaign 配布 (`ops/license/issue`) 実需要 | **Stripe Coupon / Promotion Code 代替** (ops 発行 UI 撤去、§3.6) | ✅ PO 確定 2026-06-03 |
 | OQ-3 | UX | `site/help/license-key.html` 処遇 | **完全削除 + `/admin/subscription` 301 redirect** (§3.4) | ✅ PO 確定 2026-06-03 |
 | OQ-4 | security | `LICENSE_KEY_STATUS` enum + `licenseKey` 列 (+ 当初 `LICENSE_PLAN` も含めていた) | **物理削除** (列 DROP + enum 削除、expand-contract §3.8、rollback 不可点)。ただし `LICENSE_PLAN` は判断時に license key 関連と誤分類していたもので、実体は Tenant 課金プラン enum のため **物理削除でなく `SUBSCRIPTION_PLAN` へ rename** (PR-L5 #2879) | ✅ PO 確定 2026-06-03 (LICENSE_PLAN rename 修正 2026-06-04) |
+| OQ-5 | business | license 時代に paid だった既存テナント (Stripe subscription を持たない) の entitlement 処遇 (#2894 で表面化) | **移行措置なし、free 降格が正**。entitlement SSOT は Stripe subscription (OQ-1 顧客ゼロ前提と整合)。license 由来の暫定 grant は作らない。paid 機能は trial 開始 or Stripe subscribe で得る | ✅ PO 確定 2026-06-04 (#2894) |
 
 ---
 

--- a/scripts/capture-specs/flows/admin-rewards-plan-limit-error-2894.mjs
+++ b/scripts/capture-specs/flows/admin-rewards-plan-limit-error-2894.mjs
@@ -1,0 +1,63 @@
+/**
+ * scripts/capture-specs/flows/admin-rewards-plan-limit-error-2894.mjs
+ *
+ * #2894 AC3: free tier の reward-set 取込 → PlanLimitError 構造化メッセージ + upgrade 導線。
+ *
+ * 旧 bug: `String(error)` が PlanLimitError オブジェクトを `[object Object]` 化していた。
+ * 本 fix で getActionErrorDisplay 経由で構造化メッセージ + `/admin/subscription` リンクを表示する。
+ *
+ * 撮影 2 状態:
+ *   1. ?import=<presetId> → ChildSelectionDialog auto-open (free state)
+ *   2. 確定 click → PlanLimitError banner (rewards-action-message) + upgrade 導線 (rewards-upgrade-link)
+ *
+ * 前提: cognito-dev サーバ (port 5174) + free storageState。
+ *   AUTH_MODE=cognito COGNITO_DEV_MODE=true npm run dev:cognito で起動し、
+ *   --storage-state playwright/.auth/free.json を渡す。
+ *
+ * 使用例:
+ *   MSYS_NO_PATHCONV=1 BASE_URL=http://localhost:5174 node scripts/capture.mjs \
+ *     --flow admin-rewards-plan-limit-error-2894 \
+ *     --url "/admin/rewards?import=kinder-rewards" \
+ *     --actions scripts/capture-specs/flows/admin-rewards-plan-limit-error-2894.mjs \
+ *     --storage-state playwright/.auth/free.json \
+ *     --presets desktop --pr 2894
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
+
+async function waitForDialogOpen(page, testid) {
+	await page.waitForFunction(
+		(t) => {
+			const el = document.querySelector(`[data-testid="${t}"]`);
+			if (!el) return false;
+			return el.getAttribute('data-state') === 'open' && !el.hasAttribute('hidden');
+		},
+		testid,
+		{ timeout: 15_000, polling: 100 },
+	);
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	// --- 1) ?import=<presetId> → ChildSelectionDialog auto-open ---
+	await page.goto(`${BASE_URL}/admin/rewards?import=kinder-rewards`);
+	await waitForDialogOpen(page, 'reward-import-child-selection-dialog');
+	await capture('2894-rewards-import-dialog-open');
+
+	// --- 2) 確定 → free tier の PlanLimitError banner + upgrade 導線 ---
+	const confirm = page.getByTestId('child-selection-confirm');
+	await confirm.click();
+	// banner が表示され、[object Object] でない構造化メッセージ + upgrade link を待つ。
+	await page.getByTestId('rewards-action-message').waitFor({ state: 'visible', timeout: 15_000 });
+	await page.getByTestId('rewards-upgrade-link').waitFor({ state: 'visible', timeout: 10_000 });
+	await capture('2894-rewards-plan-limit-error-with-upgrade-link');
+};

--- a/src/lib/domain/errors.ts
+++ b/src/lib/domain/errors.ts
@@ -134,3 +134,39 @@ export function getErrorMessage(value: unknown): string {
 	}
 	return '';
 }
+
+/**
+ * admin 取込フローの action error 表示情報 (#2894 AC3)。
+ *
+ * banner / toast に出す確定済みメッセージと、PlanLimitError の場合のみ非 null になる
+ * アップグレード導線 URL をまとめて返す。
+ */
+export interface ActionErrorDisplay {
+	/** banner / toast に表示する確定済みメッセージ（空にはならない） */
+	message: string;
+	/** PlanLimitError の場合のみ設定されるアップグレード導線 URL。それ以外は null */
+	upgradeUrl: PlanLimitError['upgradeUrl'] | null;
+}
+
+/**
+ * ActionResult の `data.error` を admin 取込フローの banner / toast 用の表示情報に正規化する (#2894 AC3)。
+ *
+ * marketplace 5 type (activities / rewards / checklists / challenges / rules) の
+ * `handleChildSelectionConfirm` 等が `String(error)` で PlanLimitError オブジェクトを
+ * `"[object Object]"` 化していた壊れ表示 (#2894 根本原因 #4) を共通 helper で根治する。
+ *
+ * - error が PlanLimitError → 構造化された `message`（上限/プラン名込み）+ `/admin/subscription`
+ *   への upgradeUrl を返す（NN/G #9 error recovery、呼び出し側がアップグレードリンクを併記する）
+ * - error が文字列 / `.message` を持つオブジェクト → そのメッセージ
+ * - error が空 / 未知形状 → `fallback`
+ *
+ * @param value `result.data?.error` の生値
+ * @param fallback message が空になる場合に使う既定メッセージ（page 固有の「取込に失敗しました」等）
+ */
+export function getActionErrorDisplay(value: unknown, fallback: string): ActionErrorDisplay {
+	if (isPlanLimitError(value)) {
+		return { message: value.message, upgradeUrl: value.upgradeUrl };
+	}
+	const message = getErrorMessage(value);
+	return { message: message || fallback, upgradeUrl: null };
+}

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -440,6 +440,15 @@ export const PLAN_GATE_LABELS = {
 	 *   - api/v1/admin/viewer-tokens/+server.ts: 'ファミリープラン限定の機能です'
 	 */
 	viewerTokenFamilyOnly: `${PLAN_FULL_TERMS.premium}限定の機能です`,
+
+	/**
+	 * プラン制限エラー banner / toast に併記するアップグレード導線リンクのラベル (#2894 AC3)。
+	 *
+	 * PlanLimitError (`upgradeUrl='/admin/subscription'`) を受領した admin 取込フローで、
+	 * エラーメッセージの隣に表示する `<a>` のテキスト。NN/G #9 (error recovery) 整合で
+	 * 「どこへ行けば解消できるか」を必ず提示する。
+	 */
+	upgradeLinkLabel: `${UPGRADE_TERMS.actionVerb}する`,
 } as const;
 
 export const SUBSCRIPTION_PLAN_LABELS: Record<string, string> = {

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -265,6 +265,25 @@ export const actions: Actions = {
 
 		if (!packId) return fail(400, { error: 'パックIDが必要です' });
 
+		// #2894 AC2: marketplace 取込経路でも free tier のカスタム活動上限を enforce
+		// (importPackToChildren と同型、`create` 単発の gate を取込経路に横展開)。
+		const importPackLicenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
+		const importPackLimitCheck = await checkActivityLimit(tenantId, importPackLicenseStatus);
+		if (!importPackLimitCheck.allowed) {
+			const tier = await resolveFullPlanTier(
+				tenantId,
+				importPackLicenseStatus,
+				locals.context?.plan,
+			);
+			return fail(403, {
+				error: createPlanLimitError(
+					tier,
+					'standard',
+					`カスタム活動は最大${importPackLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+				),
+			});
+		}
+
 		// #2365 (ADR-0052): Strategy + dispatchImport 経由
 		try {
 			const source = loadFromMarketplace('activity-pack', packId);
@@ -388,6 +407,23 @@ export const actions: Actions = {
 
 		if (!packId) return fail(400, { error: 'パックIDが必要です' });
 		if (!childIdsRaw) return fail(400, { error: '対象のお子さまを選択してください' });
+
+		// #2894 AC2: free tier のカスタム活動上限 (maxActivities=3, tenant-wide) を取込経路でも
+		// enforce する。`create` action には上限 check があったが import 経路は漏れており
+		// (root cause: SSOT 上の上限が取込で bypass されていた)、free tier が上限超過で取込できた。
+		// `create` と同じ PlanLimitError 形式で 403 を返し、UI 側で構造化メッセージ + upgrade 導線を出す。
+		const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
+		const activityLimitCheck = await checkActivityLimit(tenantId, licenseStatus);
+		if (!activityLimitCheck.allowed) {
+			const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
+			return fail(403, {
+				error: createPlanLimitError(
+					tier,
+					'standard',
+					`カスタム活動は最大${activityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+				),
+			});
+		}
 
 		// childIds: 'all' or comma-separated number list
 		let childIds: number[] | undefined;
@@ -532,6 +568,20 @@ export const actions: Actions = {
 			return fail(400, { error: 'カテゴリを選択してください' });
 		}
 		if (!childIdsRaw) return fail(400, { error: '対象のお子さまを選択してください' });
+
+		// #2894 AC2: bulk create も free tier のカスタム活動上限を enforce (`create` 単発と同型)。
+		const bulkLicenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
+		const bulkActivityLimitCheck = await checkActivityLimit(tenantId, bulkLicenseStatus);
+		if (!bulkActivityLimitCheck.allowed) {
+			const tier = await resolveFullPlanTier(tenantId, bulkLicenseStatus, locals.context?.plan);
+			return fail(403, {
+				error: createPlanLimitError(
+					tier,
+					'standard',
+					`カスタム活動は最大${bulkActivityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+				),
+			});
+		}
 
 		let childIds: number[];
 		if (childIdsRaw === 'all') {

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 import { deserialize } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
+import { getActionErrorDisplay } from '$lib/domain/errors';
 import { splitIcon } from '$lib/domain/icon-utils';
 import {
 	ADMIN_ACTIVITIES_PAGE_LABELS,
 	APP_LABELS,
 	FEATURES_LABELS,
 	PAGE_TITLES,
+	PLAN_GATE_LABELS,
 	UI_LABELS,
 } from '$lib/domain/labels';
 import { CHILD_TERMS } from '$lib/domain/terms';
@@ -43,6 +45,8 @@ const activityLimit = $derived(
 let filterCategoryId = $state(0);
 let searchQuery = $state('');
 let actionMessage = $state('');
+// #2894 AC3: PlanLimitError 受領時のアップグレード導線 URL (null=非表示)。
+let actionUpgradeUrl = $state<string | null>(null);
 let showClearConfirm = $state(false);
 let clearLoading = $state(false);
 
@@ -259,6 +263,21 @@ function acceptAiPreview(preview: AiPreviewData) {
 	addMode = 'manual';
 }
 
+// #2894 AC3: 取込失敗 (resp.ok=false) 時に ActionResult を deserialize し、PlanLimitError を
+// `[object Object]` 化せず構造化メッセージ + upgrade 導線として banner / toast に出す。
+// handleChildSelectionConfirm の cognitive complexity を上げないため helper に切り出す。
+function applyImportFailure(failText: string) {
+	const failResult = deserialize(failText);
+	const failError =
+		failResult.type === 'failure'
+			? (failResult.data as { error?: unknown } | undefined)?.error
+			: undefined;
+	const display = getActionErrorDisplay(failError, ADMIN_ACTIVITIES_PAGE_LABELS.importFailed);
+	actionMessage = display.message;
+	actionUpgradeUrl = display.upgradeUrl;
+	showToast(display.message, undefined, 'error');
+}
+
 // ChildSelectionDialog 確定ハンドラ: 'all' or number[] (選択 child IDs)
 async function handleChildSelectionConfirm(result: 'all' | number[]) {
 	if (!pendingImportPresetId) {
@@ -278,6 +297,8 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 
 	// #2632 CX-DoR #9 NN/G #1: 取込実行中は confirm ボタンを loading 表示する。
 	isImporting = true;
+	// #2894 AC3: 新しい取込試行ごとに前回のアップグレード導線をクリアする。
+	actionUpgradeUrl = null;
 
 	// #2745 fix: SvelteKit form action を fetch で叩く際は `x-sveltekit-action: true`
 	// + `accept: application/json` ヘッダー必須 (admin/rewards `importPresetToChildren`
@@ -337,7 +358,10 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 			showToast(message, undefined, tone);
 			await invalidateAll();
 		} else {
-			actionMessage = ADMIN_ACTIVITIES_PAGE_LABELS.importFailed;
+			// #2894 AC3: 403 (PlanLimitError) を含む失敗 body を deserialize し、
+			// `[object Object]` 化せず構造化メッセージ + upgrade 導線を表示する (helper 経由)。
+			// 旧実装は resp.ok=false 時に error body を読まず generic な importFailed のみ出していた。
+			applyImportFailure(await resp.text());
 		}
 	} catch {
 		// SvelteKit deserialize / network exception を捕捉。in-page banner で
@@ -611,7 +635,13 @@ function selectChild(childId: number) {
 	-->
 	{#if actionMessage}
 		<div class="action-message" role="status" data-testid="admin-activities-action-message">
-			{actionMessage}
+			<span>{actionMessage}</span>
+			<!-- #2894 AC3: PlanLimitError 受領時はアップグレード導線を併記 (NN/G #9) -->
+			{#if actionUpgradeUrl}
+				<a class="action-upgrade-link" href={actionUpgradeUrl} data-testid="activities-upgrade-link">
+					{PLAN_GATE_LABELS.upgradeLinkLabel}
+				</a>
+			{/if}
 		</div>
 	{/if}
 
@@ -877,6 +907,15 @@ function selectChild(childId: number) {
 		border: 1px solid var(--color-feedback-warning-border);
 		color: var(--color-feedback-warning-text);
 		font-size: 0.85rem;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem;
+	}
+	.action-upgrade-link {
+		font-weight: 600;
+		color: var(--color-text-link);
+		text-decoration: underline;
 	}
 
 	/* #2362 PR-3 Phase 4: child tabs */

--- a/src/routes/(parent)/admin/challenges/+page.svelte
+++ b/src/routes/(parent)/admin/challenges/+page.svelte
@@ -2,11 +2,13 @@
 import { deserialize, enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
 import { todayDateJST } from '$lib/domain/date-utils';
+import { getActionErrorDisplay } from '$lib/domain/errors';
 import {
 	ADMIN_CHALLENGES_PAGE_LABELS,
 	APP_LABELS,
 	CHALLENGES_LABELS,
 	PAGE_TITLES,
+	PLAN_GATE_LABELS,
 } from '$lib/domain/labels';
 import { TEMPLATE_TERMS } from '$lib/domain/terms';
 // CX-DoR #9・#11 横展開 (Round 18): empty state を共通 SSOT に統一 (NN/G #4 consistency)
@@ -26,6 +28,8 @@ const isFamily = $derived(data.planTier === 'family');
 let creating = $state(false);
 
 let marketplaceImportMessage = $state('');
+// #2894 AC3: PlanLimitError 受領時のアップグレード導線 URL (null=非表示)。
+let marketplaceImportUpgradeUrl = $state<string | null>(null);
 
 // #2554 follow-up CUJ-CH2 完全化: ChildSelectionDialog state (per-child 取込時 auto-open)
 // admin-rewards / admin-activities と同型 pattern (ADR-0055 per-child fan-out + CWE-598)。
@@ -81,6 +85,8 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 
 	// #2632 CX-DoR #9 NN/G #1: 取込実行中は confirm ボタンを loading 表示する。
 	isImporting = true;
+	// #2894 AC3: 新しい取込試行ごとに前回のアップグレード導線をクリアする。
+	marketplaceImportUpgradeUrl = null;
 
 	try {
 		const resp = await fetch('?/importMarketplaceChallengeSet', {
@@ -113,9 +119,14 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 				await invalidateAll();
 			}
 		} else if (actionResult.type === 'failure') {
-			marketplaceImportMessage = String(
-				actionResult.data?.error ?? ADMIN_CHALLENGES_PAGE_LABELS.importFailed,
+			// #2894 AC3: PlanLimitError オブジェクトの `[object Object]` 化壊れ表示を根治。
+			// challenge 取込は family-only gate のため free / standard で PlanLimitError が返る。
+			const display = getActionErrorDisplay(
+				actionResult.data?.error,
+				ADMIN_CHALLENGES_PAGE_LABELS.importFailed,
 			);
+			marketplaceImportMessage = display.message;
+			marketplaceImportUpgradeUrl = display.upgradeUrl;
 		} else {
 			marketplaceImportMessage = ADMIN_CHALLENGES_PAGE_LABELS.importFailed;
 		}
@@ -290,10 +301,20 @@ function tabHref(childId: number | 'all'): string {
 	<section data-testid="challenges-marketplace-import-section">
 		{#if marketplaceImportMessage}
 			<div
-				class="mb-2 px-3 py-2 rounded-md text-sm bg-[var(--color-feedback-success-bg)] text-[var(--color-feedback-success-text)]"
+				class="mb-2 px-3 py-2 rounded-md text-sm bg-[var(--color-feedback-success-bg)] text-[var(--color-feedback-success-text)] flex flex-wrap items-center gap-2"
 				data-testid="challenges-marketplace-import-result"
 			>
-				{marketplaceImportMessage}
+				<span>{marketplaceImportMessage}</span>
+				<!-- #2894 AC3: PlanLimitError 受領時はアップグレード導線を併記 (NN/G #9) -->
+				{#if marketplaceImportUpgradeUrl}
+					<a
+						href={marketplaceImportUpgradeUrl}
+						class="font-semibold underline text-[var(--color-text-link)]"
+						data-testid="challenges-upgrade-link"
+					>
+						{PLAN_GATE_LABELS.upgradeLinkLabel}
+					</a>
+				{/if}
 			</div>
 		{/if}
 		<a

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 import { deserialize, enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
+import { getActionErrorDisplay } from '$lib/domain/errors';
 import {
 	ADMIN_CHECKLISTS_PAGE_LABELS,
 	APP_LABELS,
 	OVERFLOW_MENU_LABELS,
 	PAGE_TITLES,
+	PLAN_GATE_LABELS,
 	UI_LABELS,
 } from '$lib/domain/labels';
 import type { ChecklistPreviewData } from '$lib/features/admin/components/AiSuggestChecklistPanel.svelte';
@@ -213,6 +215,8 @@ const importedPresetIds = $derived(
 let showChildSelectionDialog = $state(false);
 let pendingImportPresetId = $state<string | null>(null);
 let actionMessage = $state('');
+// #2894 AC3: PlanLimitError 受領時のアップグレード導線 URL (null=非表示)。
+let actionUpgradeUrl = $state<string | null>(null);
 // #2632 CX-DoR #9 NN/G #1: 取込実行中フラグ (confirm ボタン loading 表示)
 let isImporting = $state(false);
 
@@ -337,6 +341,8 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 
 	// #2632 CX-DoR #9 NN/G #1: 取込実行中は confirm ボタンを loading 表示する。
 	isImporting = true;
+	// #2894 AC3: 新しい取込試行ごとに前回のアップグレード導線をクリアする。
+	actionUpgradeUrl = null;
 
 	try {
 		const resp = await fetch('?/importPresetToChildren', {
@@ -378,9 +384,14 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 				showToast(actionMessage, undefined, imp > 0 ? 'success' : 'info');
 			}
 		} else if (actionResult.type === 'failure') {
-			actionMessage =
-				actionResult.data?.error ??
-				ADMIN_CHECKLISTS_PAGE_LABELS.importToastError(pendingImportPresetId);
+			// #2894 AC3: PlanLimitError オブジェクトの `[object Object]` 化壊れ表示を根治。
+			// free tier の per-child テンプレ上限超過時は構造化メッセージ + upgrade 導線を出す。
+			const display = getActionErrorDisplay(
+				actionResult.data?.error,
+				ADMIN_CHECKLISTS_PAGE_LABELS.importToastError(pendingImportPresetId),
+			);
+			actionMessage = display.message;
+			actionUpgradeUrl = display.upgradeUrl;
 			showToast(actionMessage, undefined, 'error');
 		} else {
 			actionMessage = ADMIN_CHECKLISTS_PAGE_LABELS.importToastError(pendingImportPresetId);
@@ -514,11 +525,21 @@ function getChildName(childId: number): string {
 
 	{#if actionMessage}
 		<div
-			class="bg-[var(--color-feedback-info-bg)] border border-[var(--color-feedback-info-border)] text-[var(--color-feedback-info-text)] rounded-xl p-3 text-sm"
+			class="bg-[var(--color-feedback-info-bg)] border border-[var(--color-feedback-info-border)] text-[var(--color-feedback-info-text)] rounded-xl p-3 text-sm flex flex-wrap items-center gap-2"
 			role="status"
 			data-testid="checklists-action-message"
 		>
-			{actionMessage}
+			<span>{actionMessage}</span>
+			<!-- #2894 AC3: PlanLimitError 受領時はアップグレード導線を併記 (NN/G #9) -->
+			{#if actionUpgradeUrl}
+				<a
+					href={actionUpgradeUrl}
+					class="font-semibold underline text-[var(--color-text-link)]"
+					data-testid="checklists-upgrade-link"
+				>
+					{PLAN_GATE_LABELS.upgradeLinkLabel}
+				</a>
+			{/if}
 		</div>
 	{/if}
 

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -11,11 +11,12 @@
 
 import { deserialize, enhance } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
-import { getErrorMessage } from '$lib/domain/errors';
+import { getActionErrorDisplay, getErrorMessage } from '$lib/domain/errors';
 import {
 	ADMIN_REWARDS_PAGE_LABELS,
 	APP_LABELS,
 	PAGE_TITLES,
+	PLAN_GATE_LABELS,
 	REWARDS_LABELS,
 } from '$lib/domain/labels';
 import { CHILD_TERMS, TEMPLATE_TERMS } from '$lib/domain/terms';
@@ -67,6 +68,10 @@ const perChildRewards = $derived(
 let showChildSelectionDialog = $state(false);
 let pendingImportPresetId = $state<string | null>(null);
 let actionMessage = $state('');
+// #2894 AC3: PlanLimitError 受領時のアップグレード導線 URL (null=非表示)。
+// banner / toast 文字列化壊れ (`[object Object]`) を getActionErrorDisplay で根治し、
+// free tier の取込失敗時に /admin/subscription へのリンクを併記する (NN/G #9)。
+let actionUpgradeUrl = $state<string | null>(null);
 // #2632 CX-DoR #9 NN/G #1: 取込実行中フラグ (confirm ボタン loading 表示)
 let isImporting = $state(false);
 
@@ -214,6 +219,8 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 
 	// #2632 CX-DoR #9 NN/G #1: 取込実行中は confirm ボタンを loading 表示する。
 	isImporting = true;
+	// #2894 AC3: 新しい取込試行ごとに前回のアップグレード導線をクリアする。
+	actionUpgradeUrl = null;
 
 	try {
 		const resp = await fetch('?/importPresetToChildren', {
@@ -250,14 +257,23 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 				await invalidateAll();
 			}
 		} else if (actionResult.type === 'failure') {
-			actionMessage = String(actionResult.data?.error ?? ADMIN_REWARDS_PAGE_LABELS.importFailed);
+			// #2894 AC3: PlanLimitError オブジェクトを `String()` で `[object Object]` 化していた
+			// 壊れ表示を getActionErrorDisplay で根治。free tier には upgrade 導線も併記する。
+			const display = getActionErrorDisplay(
+				actionResult.data?.error,
+				ADMIN_REWARDS_PAGE_LABELS.importFailed,
+			);
+			actionMessage = display.message;
+			actionUpgradeUrl = display.upgradeUrl;
 			showToast(actionMessage, undefined, 'error');
 		} else {
 			actionMessage = ADMIN_REWARDS_PAGE_LABELS.importFailed;
+			actionUpgradeUrl = null;
 			showToast(ADMIN_REWARDS_PAGE_LABELS.importFailed, undefined, 'error');
 		}
 	} catch {
 		actionMessage = ADMIN_REWARDS_PAGE_LABELS.importFailed;
+		actionUpgradeUrl = null;
 		showToast(ADMIN_REWARDS_PAGE_LABELS.importFailed, undefined, 'error');
 	} finally {
 		isImporting = false;
@@ -296,6 +312,8 @@ async function handleCopyFromChild() {
 	const formData = new FormData();
 	formData.append('sourceChildId', String(copySourceChildId));
 	formData.append('targetChildId', String(selectedChildId));
+	// #2894 AC3: 新しい copy 試行ごとに前回のアップグレード導線をクリアする。
+	actionUpgradeUrl = null;
 
 	try {
 		const resp = await fetch('?/copyFromChild', {
@@ -320,7 +338,13 @@ async function handleCopyFromChild() {
 			copySourceChildId = null;
 			await invalidateAll();
 		} else if (actionResult.type === 'failure') {
-			actionMessage = String(actionResult.data?.error ?? ADMIN_REWARDS_PAGE_LABELS.copyFailed);
+			// #2894 AC3: PlanLimitError 壊れ表示の根治 (import 経路と同型)。
+			const display = getActionErrorDisplay(
+				actionResult.data?.error,
+				ADMIN_REWARDS_PAGE_LABELS.copyFailed,
+			);
+			actionMessage = display.message;
+			actionUpgradeUrl = display.upgradeUrl;
 			showToast(actionMessage, undefined, 'error');
 		} else {
 			actionMessage = ADMIN_REWARDS_PAGE_LABELS.copyFailed;
@@ -465,7 +489,13 @@ async function handleCopyFromChild() {
 			role="status"
 			data-testid="rewards-action-message"
 		>
-			{actionMessage}
+			<span>{actionMessage}</span>
+			<!-- #2894 AC3: PlanLimitError 受領時はアップグレード導線を併記 (NN/G #9) -->
+			{#if actionUpgradeUrl}
+				<a class="action-upgrade-link" href={actionUpgradeUrl} data-testid="rewards-upgrade-link">
+					{PLAN_GATE_LABELS.upgradeLinkLabel}
+				</a>
+			{/if}
 		</div>
 	{/if}
 
@@ -739,6 +769,15 @@ async function handleCopyFromChild() {
 		border: 1px solid var(--color-feedback-info-border);
 		color: var(--color-feedback-info-text);
 		font-size: 0.85rem;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem;
+	}
+	.action-upgrade-link {
+		font-weight: 600;
+		color: var(--color-text-link);
+		text-decoration: underline;
 	}
 
 	/* Copy dialog */

--- a/tests/e2e/plan-gated-features.spec.ts
+++ b/tests/e2e/plan-gated-features.spec.ts
@@ -33,6 +33,43 @@ test.describe('#776 /admin/rewards プランゲート — free', () => {
 		await expect(page.getByTestId('rewards-upgrade-banner')).toBeVisible();
 		await expect(page.getByTestId('rewards-upgrade-cta')).toBeVisible();
 	});
+
+	// #2894 AC5: free tier の reward-set 取込 → PlanLimitError が正しく描画される。
+	// 根本原因 (#2894): `String(error)` で PlanLimitError オブジェクトが `[object Object]` 化し、
+	// 「件数表示すら正しくない」壊れた表示になっていた。getActionErrorDisplay 経由で
+	// 構造化メッセージ + アップグレード導線が出ることを検証する (NN/G #9 error recovery)。
+	test('free プランで reward-set 取込 → PlanLimitError 構造化メッセージ + upgrade 導線 (#2894 AC3)', async ({
+		page,
+	}) => {
+		test.slow(); // Vite dev コールドコンパイル耐性
+
+		// ?import=<presetId> で ChildSelectionDialog auto-open
+		await page.goto('/admin/rewards?import=kinder-rewards', { waitUntil: 'domcontentloaded' });
+		const dialog = page.getByTestId('reward-import-child-selection-dialog');
+		await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+		// 「全員に追加」default → 確定 click。free tier は importPresetToChildren で 403 を返す。
+		const confirm = page.getByTestId('child-selection-confirm');
+		await expect(confirm).toBeEnabled();
+		const [resp] = await Promise.all([
+			page.waitForResponse((r) => /\?\/importPresetToChildren/.test(r.url())),
+			confirm.click(),
+		]);
+		// SvelteKit form action の fail(403) は ActionResult として body 内 error を返す。
+		expect(resp.ok()).toBeTruthy();
+
+		// banner が表示され、`[object Object]` でない構造化メッセージが出る (壊れ表示の根治検証)。
+		const banner = page.getByTestId('rewards-action-message');
+		await expect(banner).toBeVisible({ timeout: 10_000 });
+		await expect(banner).not.toContainText('[object Object]');
+		// PlanLimitError メッセージ (UPGRADE_MESSAGE = PLAN_GATE_LABELS.standardOrAboveFor) を含む。
+		await expect(banner).toContainText('スタンダードプラン');
+
+		// AC3 / NN/G #9: アップグレード導線リンクが /admin/subscription へ向く。
+		const upgradeLink = page.getByTestId('rewards-upgrade-link');
+		await expect(upgradeLink).toBeVisible();
+		await expect(upgradeLink).toHaveAttribute('href', '/admin/subscription');
+	});
 });
 
 test.describe('#776 /admin/rewards プランゲート — standard', () => {
@@ -41,6 +78,33 @@ test.describe('#776 /admin/rewards プランゲート — standard', () => {
 	test('standard プランではアップグレードバナーが表示されない', async ({ page }) => {
 		await page.goto('/admin/rewards');
 		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
+	});
+
+	// #2894 AC5: paid tier (standard) は reward-set 取込が成功し一覧に反映される
+	// (free の 403 と対になる positive case)。upgrade 導線は出ない。
+	test('standard プランで reward-set 取込 → 成功 + upgrade 導線なし (#2894 AC5)', async ({
+		page,
+	}) => {
+		test.slow();
+
+		await page.goto('/admin/rewards?import=kinder-rewards', { waitUntil: 'domcontentloaded' });
+		const dialog = page.getByTestId('reward-import-child-selection-dialog');
+		await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+		const confirm = page.getByTestId('child-selection-confirm');
+		await expect(confirm).toBeEnabled();
+		const [resp] = await Promise.all([
+			page.waitForResponse((r) => /\?\/importPresetToChildren/.test(r.url())),
+			confirm.click(),
+		]);
+		expect(resp.ok()).toBeTruthy();
+
+		// 成功 banner が出て `[object Object]` も upgrade 導線も出ない。
+		const banner = page.getByTestId('rewards-action-message');
+		await expect(banner).toBeVisible({ timeout: 10_000 });
+		await expect(banner).not.toContainText('[object Object]');
+		await expect(banner).not.toContainText('スタンダードプラン以上');
+		await expect(page.getByTestId('rewards-upgrade-link')).toHaveCount(0);
 	});
 });
 

--- a/tests/unit/domain/errors.test.ts
+++ b/tests/unit/domain/errors.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	createPlanLimitError,
+	getActionErrorDisplay,
 	getErrorMessage,
 	isPlanLimitError,
 	type PlanLimitError,
@@ -156,5 +157,49 @@ describe('#787 getErrorMessage', () => {
 	it('プリミティブ（数値 / boolean）は空文字', () => {
 		expect(getErrorMessage(403)).toBe('');
 		expect(getErrorMessage(true)).toBe('');
+	});
+});
+
+describe('#2894 getActionErrorDisplay', () => {
+	it('PlanLimitError から message + upgradeUrl を返す（[object Object] 化しない）', () => {
+		const err = createPlanLimitError(
+			'free',
+			'standard',
+			'ごほうび管理はスタンダードプラン以上でご利用いただけます',
+		);
+		const display = getActionErrorDisplay(err, '取込に失敗しました');
+		expect(display.message).toBe('ごほうび管理はスタンダードプラン以上でご利用いただけます');
+		expect(display.upgradeUrl).toBe('/admin/subscription');
+		// 旧 String(err) は '[object Object]' を返していた。新 helper では絶対に含まない。
+		expect(display.message).not.toContain('[object Object]');
+	});
+
+	it('文字列エラーはそのまま message、upgradeUrl は null', () => {
+		const display = getActionErrorDisplay('こどもを選択してください', 'fallback');
+		expect(display.message).toBe('こどもを選択してください');
+		expect(display.upgradeUrl).toBeNull();
+	});
+
+	it('error が undefined / null のとき fallback を使い upgradeUrl は null', () => {
+		expect(getActionErrorDisplay(undefined, '取込に失敗しました')).toEqual({
+			message: '取込に失敗しました',
+			upgradeUrl: null,
+		});
+		expect(getActionErrorDisplay(null, '取込に失敗しました')).toEqual({
+			message: '取込に失敗しました',
+			upgradeUrl: null,
+		});
+	});
+
+	it('空文字 error も fallback に置換する（空 banner を出さない）', () => {
+		const display = getActionErrorDisplay('', 'コピーに失敗しました');
+		expect(display.message).toBe('コピーに失敗しました');
+		expect(display.upgradeUrl).toBeNull();
+	});
+
+	it('message プロパティを持つ任意オブジェクトは message を抽出し upgradeUrl は null', () => {
+		const display = getActionErrorDisplay({ message: 'バリデーションエラー' }, 'fallback');
+		expect(display.message).toBe('バリデーションエラー');
+		expect(display.upgradeUrl).toBeNull();
 	});
 });

--- a/tests/unit/routes/admin-activities-import-plan-gate.test.ts
+++ b/tests/unit/routes/admin-activities-import-plan-gate.test.ts
@@ -1,0 +1,227 @@
+// tests/unit/routes/admin-activities-import-plan-gate.test.ts
+// #2894 AC2: 活動取込経路 (importPackToChildren / importPack / bulkCreateForChildren) の
+// free tier カスタム活動上限 (maxActivities=3) enforcement 検証。
+//
+// 根本原因 (#2894): `create` action には checkActivityLimit があったが、marketplace
+// 取込経路 (importPackToChildren 等) は gate が漏れており、free tier が上限を超えて
+// カスタム活動を取り込めた。SSOT (plan-limit-service.ts PLAN_LIMITS.free.maxActivities=3) と
+// 整合させ、取込経路でも上限超過時に PlanLimitError 形式の 403 を返すことを検証する。
+//
+// **設計判断**: challenges family-gate テスト (admin-challenges-marketplace-import-plan-gate.test.ts)
+// と同型。SvelteKit CSRF を回避するため action handler を直接呼び出して検証する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- モック ---
+const mockRequireTenantId = vi.fn();
+const mockResolveFullPlanTier = vi.fn();
+const mockCheckActivityLimit = vi.fn();
+const mockDispatchImport = vi.fn();
+const mockLoadFromMarketplace = vi.fn();
+const mockGetAllChildren = vi.fn();
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: mockRequireTenantId,
+	getAuthMode: vi.fn(() => 'cognito'),
+}));
+
+vi.mock('$lib/server/services/plan-limit-service', async () => {
+	const actual = await vi.importActual<typeof import('$lib/server/services/plan-limit-service')>(
+		'$lib/server/services/plan-limit-service',
+	);
+	return {
+		...actual,
+		resolveFullPlanTier: mockResolveFullPlanTier,
+		checkActivityLimit: mockCheckActivityLimit,
+	};
+});
+
+vi.mock('$lib/marketplace', () => ({
+	dispatchImport: mockDispatchImport,
+}));
+
+vi.mock('$lib/marketplace/sources/marketplace-source', () => ({
+	loadFromMarketplace: mockLoadFromMarketplace,
+}));
+
+vi.mock('$lib/marketplace/sources/file-source', () => ({
+	FileSourceError: class FileSourceError extends Error {},
+	loadActivityPackFromFile: vi.fn(),
+}));
+
+vi.mock('$lib/server/services/child-service', () => ({
+	getAllChildren: mockGetAllChildren,
+}));
+
+// 取込経路は 403 で早期 return するため到達しないが、import 解決のため stub を置く。
+vi.mock('$lib/server/services/activity-service', () => ({
+	createActivity: vi.fn(),
+	deleteActivityWithCleanup: vi.fn(),
+	getActivities: vi.fn(async () => []),
+	getActivityLogCounts: vi.fn(async () => ({})),
+	getMainQuestCount: vi.fn(async () => 0),
+	hasActivityLogs: vi.fn(async () => false),
+	MAIN_QUEST_MAX: 3,
+	setActivityVisibility: vi.fn(),
+	setMainQuest: vi.fn(),
+	updateActivity: vi.fn(),
+}));
+
+vi.mock('$lib/server/services/child-activity-copy-service', () => ({
+	copyChildActivitiesToSibling: vi.fn(),
+	copyChildActivitiesToSiblings: vi.fn(),
+}));
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: vi.fn(() => ({
+		childActivity: {
+			findActivitiesByChild: vi.fn(async () => []),
+			insertActivitiesBulk: vi.fn(async () => []),
+		},
+	})),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const mod = await import('../../../src/routes/(parent)/admin/activities/+page.server');
+
+type PlanLimitErrorShape = {
+	code: 'PLAN_LIMIT_EXCEEDED';
+	message: string;
+	currentTier: 'free' | 'standard' | 'family';
+	requiredTier: 'standard' | 'family';
+	upgradeUrl: '/admin/subscription';
+};
+type ActionResult = {
+	status?: number;
+	data?: { error: PlanLimitErrorShape | string };
+	perChildImport?: boolean;
+	imported?: number;
+	bulkCreated?: boolean;
+	createdCount?: number;
+};
+
+const importPackToChildrenAction = mod.actions.importPackToChildren as unknown as (event: {
+	request: Request;
+	locals: App.Locals;
+}) => Promise<ActionResult>;
+const bulkCreateForChildrenAction = mod.actions.bulkCreateForChildren as unknown as (event: {
+	request: Request;
+	locals: App.Locals;
+}) => Promise<ActionResult>;
+
+function makeLocals(opts: { licenseStatus?: string; plan?: string } = {}) {
+	return {
+		context: {
+			tenantId: 'tenant-1',
+			licenseStatus: opts.licenseStatus ?? 'none',
+			plan: opts.plan,
+		},
+	} as unknown as App.Locals;
+}
+
+function makeFormRequest(fields: Record<string, string | number>): Request {
+	const form = new FormData();
+	for (const [k, v] of Object.entries(fields)) {
+		form.append(k, String(v));
+	}
+	return new Request('http://localhost/admin/activities', { method: 'POST', body: form });
+}
+
+describe('/admin/activities page.server — #2894 取込経路の活動上限 enforcement', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRequireTenantId.mockReturnValue('tenant-1');
+		mockGetAllChildren.mockResolvedValue([
+			{ id: 902, nickname: 'preschool', tenantId: 'tenant-1' },
+			{ id: 903, nickname: 'elementary', tenantId: 'tenant-1' },
+		]);
+		mockLoadFromMarketplace.mockReturnValue({
+			payload: { activities: [{ name: 'a' }] },
+			displayName: 'テスト用 activity-pack',
+		});
+		mockDispatchImport.mockResolvedValue({
+			packName: 'テスト用 activity-pack',
+			imported: 1,
+			skipped: 0,
+			total: 1,
+			errors: [],
+		});
+	});
+
+	describe('importPackToChildren (marketplace 取込 → ChildSelectionDialog)', () => {
+		it('free tier が上限到達済みなら 403 PlanLimitError を返し dispatchImport を呼ばない', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+			mockCheckActivityLimit.mockResolvedValue({ allowed: false, current: 3, max: 3 });
+
+			const result = await importPackToChildrenAction({
+				request: makeFormRequest({ packId: 'kinder-starter', childIds: 'all' }),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(result.status).toBe(403);
+			const err = result.data?.error as PlanLimitErrorShape;
+			expect(err).toMatchObject({
+				code: 'PLAN_LIMIT_EXCEEDED',
+				currentTier: 'free',
+				requiredTier: 'standard',
+				upgradeUrl: '/admin/subscription',
+			});
+			expect(err.message).toContain('3');
+			expect(mockDispatchImport).not.toHaveBeenCalled();
+		});
+
+		it('free tier が上限未満なら取込を実行する', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+			mockCheckActivityLimit.mockResolvedValue({ allowed: true, current: 1, max: 3 });
+
+			const result = await importPackToChildrenAction({
+				request: makeFormRequest({ packId: 'kinder-starter', childIds: 'all' }),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(result.status).toBeUndefined();
+			expect(result.perChildImport).toBe(true);
+			expect(mockDispatchImport).toHaveBeenCalledTimes(1);
+		});
+
+		it('paid tier (standard) は上限 null で取込を実行する', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('standard');
+			mockCheckActivityLimit.mockResolvedValue({ allowed: true, current: 0, max: null });
+
+			const result = await importPackToChildrenAction({
+				request: makeFormRequest({ packId: 'kinder-starter', childIds: 'all' }),
+				locals: makeLocals({ licenseStatus: 'active', plan: 'standard_monthly' }),
+			});
+
+			expect(result.status).toBeUndefined();
+			expect(mockDispatchImport).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('bulkCreateForChildren (一括追加)', () => {
+		it('free tier が上限到達済みなら 403 PlanLimitError を返す', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+			mockCheckActivityLimit.mockResolvedValue({ allowed: false, current: 3, max: 3 });
+
+			const result = await bulkCreateForChildrenAction({
+				request: makeFormRequest({
+					name: 'あたらしい活動',
+					categoryId: 1,
+					childIds: 'all',
+				}),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(result.status).toBe(403);
+			const err = result.data?.error as PlanLimitErrorShape;
+			expect(err).toMatchObject({
+				code: 'PLAN_LIMIT_EXCEEDED',
+				currentTier: 'free',
+				requiredTier: 'standard',
+			});
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

本番 (AWS) で marketplace のごほうびセット取込・カスタムごほうび追加等の reward 系操作が全て失敗し、その際の plan-limit エラー表示が `[object Object]` 化して「件数表示すら正しくない」壊れた体験になっていた問題 (CRITICAL、PO 実機 2026-06-04) を根治する。license 全廃後に free 降格したテナントでも、何が起きたか・どうすれば解消するか (アップグレード導線) が正しく伝わるようにする。

## 関連 Issue

Closes #2894 (EPIC #2897 最終フェーズ最優先)
関連: #728 (reward gate 導入) / #787 (PlanLimitError) / #2813 #2822 (license 全廃) / ADR-0059 (cutover)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | license 時代 paid テナントの entitlement 処遇 | 決定記録 (移行措置を実装しない決定) | ✅ **移行措置なし・free 降格が正** (Stripe SSOT)。`docs/design/billing-redesign/phase1-license-key-removal-final-requirements.md` §6 OQ-5 追記 (cdb28383) + issue #2894 コメント記録 (PO 判断 2026-06-04) |
| AC2 | 取込系 action の plan gate を 5 type で SSOT 照合・統一 | code trace + 新規 unit test | ✅ reward=isPaidTier 維持 / checklists=per-child 上限 enforce 済 (`admin/checklists/+page.server.ts` L411-438) / **activities 取込経路の上限漏れを修正** (`admin/activities/+page.server.ts` `importPackToChildren` / `importPack` / `bulkCreateForChildren` に `checkActivityLimit` 追加、cdb28383)。`tests/unit/routes/admin-activities-import-plan-gate.test.ts` で 403 検証 |
| AC3 | PlanLimitError を正しく表示 + upgrade 誘導 (NN/G #9) | helper 集約 + E2E | ✅ `src/lib/domain/errors.ts` `getActionErrorDisplay` で `[object Object]` 化を根治、5 type 横断で構造化メッセージ + `/admin/subscription` リンク併記。`tests/e2e/plan-gated-features.spec.ts` で banner text + link href assert (実機 PASS) |
| AC4 | 本番 (DynamoDB) reward 取込 → 一覧反映 → reload 残存 PO 実機確認 | 本番デプロイ後 PO 実機 | ⏳ **post-merge 持越し** (本番デプロイ後、下記「AC4 手順書」参照) |
| AC5 | E2E に free 取込 plan-limit メッセージ / paid 取込成功 両 case | E2E + unit | ✅ `tests/e2e/plan-gated-features.spec.ts` free (403 + 構造化 + 導線) / standard (成功 + 導線なし) 2 case 実機 PASS (8 passed)。`errors.test.ts` 拡充 + activities import gate unit 新規 |

### AC4 手順書 (PO 本番実機確認)

1. 本 PR merge → 本番デプロイ完了を待つ
2. trial 未開始の本番アカウントで `/admin/subscription` から 7 日間無料トライアルを開始 (or Stripe subscribe) → paid tier 化
3. `/marketplace` → ごほうびセット → 取込 → `/admin/rewards` の child タブ件数が増える / reload 後も残存することを確認
4. (任意) free tier アカウントで同手順 → `[object Object]` でない「ごほうび管理はスタンダードプラン以上で…」+ 「アップグレードする」リンクが出ることを確認

## 変更タイプ

- [x] バグ修正 (CRITICAL)

## 影響範囲・変更コンポーネント

- `src/lib/domain/errors.ts` — `getActionErrorDisplay()` + `ActionErrorDisplay` 型を追加
- `src/lib/domain/labels.ts` — `PLAN_GATE_LABELS.upgradeLinkLabel` 追加 (UPGRADE_TERMS atom 参照、ADR-0045)
- `src/routes/(parent)/admin/{rewards,activities,checklists,challenges}/+page.svelte` — error 表示を helper 経由に統一 + upgrade 導線リンク描画
- `src/routes/(parent)/admin/activities/+page.server.ts` — 取込経路 3 action に `checkActivityLimit` gate 追加 (AC2 enforcement gap)
- `docs/design/billing-redesign/phase1-license-key-removal-final-requirements.md` — OQ-5 (AC1 決定記録)

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/domain/ tests/unit/services/` — 2996 PASS / `tests/unit/routes/` — 257 PASS
- 新規 unit: `admin-activities-import-plan-gate.test.ts` (取込 free 上限 403) / `errors.test.ts` 拡充
- E2E (cognito-dev): `plan-gated-features.spec.ts` #2894 free/standard 2 case 実機 PASS (8 passed)
- `npm run build` PASS / `biome check` PASS / `svelte-check` 変更ファイル 0 error
- `check-no-plan-literals` PASS / `generate-lp-labels --check` 同期済 / pre-commit SSOT companion 検査 PASS

## スクリーンショット / ビジュアルデモ

cognito-dev free state (`/admin/rewards?import=kinder-rewards`) で reward-set 取込フローを撮影。`scripts/capture-specs/flows/admin-rewards-plan-limit-error-2894.mjs` 経由で撮影し screenshots branch に push (`pr-2913/`)。

![after-rewards-import-dialog-open](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2913/after-rewards-import-dialog-open-desktop.png)

*After ①*: `?import=kinder-rewards` で `ChildSelectionDialog` が auto-open (全員に追加 / 各お子さま選択)。

![after-rewards-plan-limit-error-with-upgrade-link](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2913/after-rewards-plan-limit-error-with-upgrade-link-desktop.png)

*After ②*: 取込確定 → free tier の `rewards-action-message` banner が **`[object Object]` ではなく構造化メッセージ**「ごほうび管理はスタンダードプラン以上でご利用いただけます」を表示し、`rewards-upgrade-link`「アップグレードする」(→ `/admin/subscription`) を併記 (AC3 根治確認)。E2E `plan-gated-features.spec.ts` でも banner text + link href を assert 済。

[DOM HTML スナップショット (admin/rewards free state、構造化 gate / `[object Object]` ゼロ)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2913/after-rewards-free-state-desktop.dom.html)

**After-only の理由**: 旧 bug の `[object Object]` 壊れ表示は本 fix branch では再現不可 (修正コミットが同一 branch 上にあり、checkout で巻き戻すと fix 自体が消える)。よって before-* / after-* ペアは作らず After-only とする (SS Blob SHA 偽装防止 gate の比較対象なし → skip)。child 画面非影響 (admin 画面のみの変更) のため 5 age mode 撮影は不要 (影響なし)。

## コード品質セルフレビュー (#1481)

5 type で重複していた error 表示ロジックを `getActionErrorDisplay` 1 箇所に集約 (補佐設計品質ガード: 3 つ目以降の類似実装 → 共通化判断)。activities handler の complexity 超過を避けるため `applyImportFailure` helper に切り出し。文言は labels.ts compound に追加 (atom 直書き禁止)。

## 横展開・影響波及チェック

- 5 type (activities/rewards/checklists/challenges/rules) の error 表示経路を確認。rules は `?import=` auto-import で ChildSelectionDialog 非経由 + gate 対象外 (rule-preset 上限なし) のため変更不要。settings/data は別概念のため対象外。
- SSOT 照合: reward=`canCustomReward` / activities=`maxActivities` / checklists=`maxChecklistTemplates` / challenges=family-only。`importFile` (バックアップ復元) は marketplace 取込と別概念 (DESIGN.md §10) のため gate 対象外。
- 直近 30 日重複変更チェック: 同領域の最近の変更 (#2811/#2817/#2820 等) は UX/dead-end/honesty 系で本 gate ロジックと conflict なし。

## レビュー依頼事項・破壊的変更

破壊的変更なし。AC4 (本番実機) は post-merge。activities 取込経路の上限 enforce 追加により、free tier で既に 3 個カスタム活動がある状態での取込は 403 (構造化メッセージ + upgrade 導線) になる点が挙動変化 (= SSOT 通りの正仕様化)。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] AC 検証マップ記載 (4 列、AC4 post-merge 明記)
- [x] 必須 13 セクション記載
- [x] テスト追加 (unit + E2E) + 全 PASS
- [x] SS 添付 (After、screenshots branch `pr-2913/` に embed 済)
- [x] AC4 (本番実機) は post-merge — N/A (デプロイ後 PO 確認、手順書記載済)

## QM レビュー結果

(QM レビュー待ち)

