### PR TITLE
fix: #2903 チェックリスト管理の add UI を活動管理と同型に統一 (AI パネル直置き撤去)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -569,7 +569,11 @@ Material Design 3「画面 FAB 1 個原則」+ Notion / Linear / Asana / Todoist
 
 同一リソース (活動 / 子供 / 報酬 / 等) の add 経路 (CTA 種別 × UI 配置) が 4 を超えたら、menu / dropdown / command palette のいずれかで集約する。
 
-同一リソースの add 系操作は **1 つの `+ 追加` dropdown menu に集約**する (Notion / Linear の `+` パターン)。並列の独立ボタンは顧客混乱を招くため不可。適用済: admin/activities (#2558)・admin/checklists (#2778、`Menu` primitive で統合)。
+同一リソースの add 系操作は **1 つの `+ 追加` dropdown menu に集約**する (Notion / Linear の `+` パターン)。並列の独立ボタンは顧客混乱を招くため不可。適用済: admin/activities (#2558)・admin/checklists (#2778 → #2903、`Menu` primitive で統合)。
+
+#### admin リソース管理ページの add 経路は同型に揃える (#2903、PO 指摘 #6b)
+
+複数の admin リソース管理ページ (活動 / チェックリスト / ごほうび / 等) の「+ 追加」dropdown は、**先頭 3 経路 (手動 / AI で提案 / みんなのテンプレートから探す) を同一順序で揃える** (NN/G #4 consistency)。AI 提案は dropdown 内の選択肢 → Dialog で開く方式に統一し、ページ本文に AI パネルを直置きしない (操作の入口がページ間で異なると顧客が混乱するため)。「みんなのテンプレートから探す」は admin 内 browse UI を出さず `/marketplace?type=<typeCode>` へ画面遷移する (マーケットプレイス一本化、本 §10 上記ルール整合)。同型性は `tests/e2e/admin-add-path-isomorphism.spec.ts` が assert する。
 
 #### marketplace 取込はマーケットプレイス画面に一本化 (admin 内ブラウズ UI 二重管理禁止、#2558)
 

--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1697,12 +1697,12 @@ onclick={() => {
 |------|----------|
 | URL | `/admin/checklists` |
 | 削除された UI | role=tablist の「チェックリスト種別」タブ（routine / item）/ 種別選択ラジオ |
-| 残った UI | 子供選択 + AI 提案パネル + **マーケットプレイス取込セクション (#2137)** + テンプレート一覧（持ち物のみ） + テンプレート作成ダイアログ（持ち物固定） |
+| 残った UI | テンプレート一覧 + **マーケットプレイス取込セクション (#2137)** + テンプレート作成ダイアログ + AI 提案ダイアログ |
 | empty state | `🎒 チェックリストがまだありません`（`emptyChecklistMessage`、#2899 で汎用チェックリスト機能のため「持ち物」限定表記を撤去） |
 | ダイアログタイトル | `チェックリスト作成`（`addTemplateDialogTitle`、#2899） |
 | ページタイトル | `チェックリスト管理`（`pageTitle`、#2899。汎用チェックリスト機能のため「持ち物」限定表記を撤去） |
 | 並行実装 | child checklist (`/(child)/checklist` / `/demo/(child)/checklist`) も `kindOrder` 削除済み — `flatChecklists` で flat 表示 |
-| add 経路 (#2778 Cluster D) | 「`+ テンプレート作成`」「`📅 ワンオフ追加`」の 2 並列 button を `Menu` primitive で「`+ 追加`」dropdown menu に集約 (DESIGN.md §10 add 経路 ≤ 4 ルール / #2558 段階2 横展開、User 指摘 #1 ボタン重複解消) |
+| add 経路 (#2778 → #2903 EPIC #2897) | activities (`ActivitiesHeader`) と同型に統一。`+ 追加` dropdown menu に manual (✏️ 手動で1つ追加) / ai (✨ AI で提案 → Dialog) / browse (🔍 みんなのテンプレートから探す → `/marketplace?type=checklist` 画面遷移) / override (📅 ワンオフ追加) を集約し、AI 提案パネルの本文直置きを撤去 (DESIGN.md §10 add 経路 ≤ 4 ルール / 同型性ルール / マーケットプレイス一本化整合)。AI は dropdown 選択 → Dialog 内 `AiSuggestChecklistPanel` で開く (activities `addMode='ai'` と同型)。並び順は activities と同一 (manual → ai → browse → page 固有)。同型性は `tests/e2e/admin-add-path-isomorphism.spec.ts` が assert |
 
 ##### マーケットプレイス取込セクション (#2137 / MP-2 EPIC #2135)
 

--- a/scripts/capture-specs/flows/admin-checklists-add-ux-2903.mjs
+++ b/scripts/capture-specs/flows/admin-checklists-add-ux-2903.mjs
@@ -71,8 +71,9 @@ export default async (page, capture) => {
 	await page.keyboard.press('Escape');
 	await page.waitForFunction(
 		() =>
-			document.querySelector('[data-testid="checklists-add-menu"]')?.getAttribute('aria-expanded') ===
-			'false',
+			document
+				.querySelector('[data-testid="checklists-add-menu"]')
+				?.getAttribute('aria-expanded') === 'false',
 		undefined,
 		{ timeout: 3_000 },
 	);
@@ -80,9 +81,7 @@ export default async (page, capture) => {
 	// --- 3) 「+ 追加 → AI」で AI 提案ダイアログを開いた状態 (activities の add → ai と同型) ---
 	await waitForMenuOpen(page, 'checklists-add-menu');
 	await page.getByTestId('menu-item-ai').click();
-	await page
-		.getByTestId('checklists-ai-dialog')
-		.waitFor({ state: 'visible', timeout: 5_000 });
+	await page.getByTestId('checklists-ai-dialog').waitFor({ state: 'visible', timeout: 5_000 });
 	await page.evaluate(
 		() =>
 			new Promise((resolve) =>

--- a/scripts/capture-specs/flows/admin-checklists-add-ux-2903.mjs
+++ b/scripts/capture-specs/flows/admin-checklists-add-ux-2903.mjs
@@ -1,0 +1,93 @@
+/**
+ * scripts/capture-specs/flows/admin-checklists-add-ux-2903.mjs
+ *
+ * #2903 (EPIC #2897): checklist 管理の add UI を activities (ActivitiesHeader) と同型に統一する SS。
+ * 旧実装は AI 提案パネルがページ本文に直接露出していたが、本 PR で「+ 追加」dropdown 内の
+ * 選択肢 (手動 / AI / みんなのテンプレートから探す / ワンオフ) に格納し、activities と操作の入口を
+ * 揃えた (PO 指摘 #6b)。
+ *
+ * 本番ルート `/admin/checklists` を demo Lambda 同型 env (AUTH_MODE=anonymous + DATA_SOURCE=demo)
+ * で起動した dev server 上で開き、user-gesture で「+ 追加」dropdown / AI ダイアログを展開した状態を撮る。
+ * `admin-activities-add-ux-2260.mjs` と同型のフロー。
+ *
+ * 使用例 (BASE_URL は demo Lambda env で起動した dev server):
+ *   MSYS_NO_PATHCONV=1 BASE_URL=http://localhost:5173 node scripts/capture.mjs \
+ *     --flow admin-checklists-add-ux-2903 \
+ *     --url /admin/checklists?screenshot=all \
+ *     --actions scripts/capture-specs/flows/admin-checklists-add-ux-2903.mjs \
+ *     --presets desktop,mobile \
+ *     --pr 2903
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
+
+/** Ark UI Menu hydration 完了 + open 状態確立を待つ helper (add-ux-2260 と同型) */
+async function waitForMenuOpen(page, triggerTestId) {
+	const btn = page.getByTestId(triggerTestId);
+	await btn.waitFor({ state: 'visible', timeout: 15_000 });
+	await page.waitForFunction(
+		(testid) => {
+			const el = document.querySelector(`[data-testid="${testid}"]`);
+			return el?.getAttribute('aria-expanded') === 'false';
+		},
+		triggerTestId,
+		{ timeout: 10_000 },
+	);
+	await btn.click();
+	await page.waitForFunction(
+		(testid) => {
+			const el = document.querySelector(`[data-testid="${testid}"]`);
+			return el?.getAttribute('aria-expanded') === 'true';
+		},
+		triggerTestId,
+		{ timeout: 5_000 },
+	);
+	await page
+		.locator('[data-part="content"][data-state="open"]')
+		.first()
+		.waitFor({ state: 'attached', timeout: 3_000 })
+		.catch(() => {});
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	// --- 1) 通常一覧 (default state: AI パネル直置きが撤去され、header + 一覧のみ) ---
+	await page.goto(`${BASE_URL}/admin/checklists?screenshot=all`);
+	await page.getByTestId('admin-checklists-page').waitFor({ state: 'visible', timeout: 15_000 });
+	await capture('issue-2903-admin-checklists-default');
+
+	// --- 2) 「+ 追加」dropdown 展開 (手動 / AI / みんなのテンプレートから探す / ワンオフ) ---
+	await waitForMenuOpen(page, 'checklists-add-menu');
+	await capture('issue-2903-admin-checklists-add-menu-open');
+	await page.keyboard.press('Escape');
+	await page.waitForFunction(
+		() =>
+			document.querySelector('[data-testid="checklists-add-menu"]')?.getAttribute('aria-expanded') ===
+			'false',
+		undefined,
+		{ timeout: 3_000 },
+	);
+
+	// --- 3) 「+ 追加 → AI」で AI 提案ダイアログを開いた状態 (activities の add → ai と同型) ---
+	await waitForMenuOpen(page, 'checklists-add-menu');
+	await page.getByTestId('menu-item-ai').click();
+	await page
+		.getByTestId('checklists-ai-dialog')
+		.waitFor({ state: 'visible', timeout: 5_000 });
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+	await capture('issue-2903-admin-checklists-ai-dialog-open');
+};

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4608,6 +4608,21 @@ export const ADMIN_CHECKLISTS_PAGE_LABELS = {
 	addOverrideButton: '📅 ワンオフ追加',
 	// #2778 (Cluster D / User 指摘 #1 ボタン重複解消): 2 並列 button → 「+ 追加」dropdown menu 集約 (Hick's Law)
 	addMenuButton: '+ 追加',
+	// #2903 (EPIC #2897): add 経路を activities (ActivitiesHeader) と同型に統一。
+	//   AI 提案パネル直置きを撤去し「+ 追加」dropdown 内の選択肢 (手動 / AI / テンプレから探す / ワンオフ) に格納する。
+	//   icon / 文言は activities header の add menu (FEATURES_LABELS.activitiesHeader.add*) と同一語彙で揃え、
+	//   両ページの add 経路構成 (種類・順序) が一致することを E2E で assert 可能にする (AC3 同型性固定)。
+	addMenuAriaLabel: 'チェックリストを追加するメニューを開く',
+	addManualLabel: '手動で1つ追加',
+	addManualIcon: '✏️',
+	addAiLabel: 'AI で提案してもらう',
+	addAiIcon: '✨',
+	addBrowseTemplatesLabel: `${TEMPLATE_TERMS.userFacing}から探す`,
+	addBrowseTemplatesIcon: '🔍',
+	addOverrideMenuLabel: 'ワンオフ追加',
+	addOverrideMenuIcon: '📅',
+	// add dialog title (mode 別、activities の addDialogTitle* と同型)
+	addDialogTitleAi: 'AI で提案してもらう',
 	todayOverrideTitle: '📅 本日のワンオフ',
 	formKindLabel: '種別',
 	formIconLabel: 'アイコン',

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { deserialize, enhance } from '$app/forms';
-import { invalidateAll } from '$app/navigation';
+import { goto, invalidateAll } from '$app/navigation';
 import { getActionErrorDisplay } from '$lib/domain/errors';
 import {
 	ADMIN_CHECKLISTS_PAGE_LABELS,
@@ -83,6 +83,11 @@ let overrideAction = $state('add');
 let overrideName = $state('');
 let overrideIcon = $state('📦');
 
+// #2903 (EPIC #2897): AI 提案ダイアログ。
+//   従来は AI 提案パネルをページ本文に直置きしていたが、activities (ActivitiesHeader) と同型に
+//   「+ 追加」dropdown 内の選択肢 → Dialog で開く方式に統一する (DESIGN.md §10 add 経路 ≤ 4)。
+let aiDialogOpen = $state(false);
+
 const FREQUENCY_OPTIONS = [
 	{ value: 'daily', label: 'まいにち' },
 	{ value: 'weekday:月', label: '月よう' },
@@ -123,22 +128,38 @@ function timeSlotLabel(slot: string): string {
 const COMMON_ICONS = ['🏫', '👕', '👟', '🎨', '🎵', '📚', '🧹', '🍱', '💧', '📦', '🎒', '✏️'];
 
 // Dialog exclusion: only one dialog open at a time
-const anyDialogOpen = $derived(addItemOpen || addTemplateOpen || overrideOpen);
+const anyDialogOpen = $derived(addItemOpen || addTemplateOpen || overrideOpen || aiDialogOpen);
 
-// #2778 (Cluster D / User 指摘 #1 ボタン重複解消): 2 並列 button (テンプレート作成 / ワンオフ追加) を
-// 「+ 追加」dropdown menu に集約 (Hick's Law / DESIGN.md §10「add 経路 ≤ 4 ルール」/ #2558 段階2 横展開)。
+// #2903 (EPIC #2897): 「+ 追加」dropdown を activities (ActivitiesHeader.addMenuItems) と同型に統一する。
+//   旧: AI 提案パネル本文直置き + dropdown は (テンプレート作成 / ワンオフ追加) の 2 項目 (#2778)。
+//   新: dropdown 内に (手動 / AI / みんなのテンプレートから探す / ワンオフ) を格納し、活動管理と
+//       「操作の入口が同じ」状態にする (PO 指摘 #6b「UI を統一」)。
+//   並び順は activities と同一 (manual → ai → browse → page 固有) にし、両ページの add 経路構成
+//   (種類・順序) が一致することを E2E (admin-add-path-isomorphism.spec.ts) が assert する (AC3)。
 const addMenuItems = $derived<MenuItem[]>([
 	{
-		id: 'add-template',
-		label: ADMIN_CHECKLISTS_PAGE_LABELS.addTemplateButton,
-		icon: '✏️',
+		id: 'manual',
+		label: ADMIN_CHECKLISTS_PAGE_LABELS.addManualLabel,
+		icon: ADMIN_CHECKLISTS_PAGE_LABELS.addManualIcon,
 		disabled: atLimit,
 		onSelect: openAddTemplate,
 	},
 	{
-		id: 'add-override',
-		label: ADMIN_CHECKLISTS_PAGE_LABELS.addOverrideButton,
-		icon: '📅',
+		id: 'ai',
+		label: ADMIN_CHECKLISTS_PAGE_LABELS.addAiLabel,
+		icon: ADMIN_CHECKLISTS_PAGE_LABELS.addAiIcon,
+		onSelect: openAiDialog,
+	},
+	{
+		id: 'browse',
+		label: ADMIN_CHECKLISTS_PAGE_LABELS.addBrowseTemplatesLabel,
+		icon: ADMIN_CHECKLISTS_PAGE_LABELS.addBrowseTemplatesIcon,
+		onSelect: handleAddBrowse,
+	},
+	{
+		id: 'override',
+		label: ADMIN_CHECKLISTS_PAGE_LABELS.addOverrideMenuLabel,
+		icon: ADMIN_CHECKLISTS_PAGE_LABELS.addOverrideMenuIcon,
 		onSelect: openOverride,
 	},
 ]);
@@ -172,6 +193,19 @@ function openOverride() {
 	overrideOpen = true;
 }
 
+// #2903 (EPIC #2897): AI 提案を dropdown 内の選択肢 → Dialog で開く (activities の addMode='ai' と同型)。
+function openAiDialog() {
+	if (anyDialogOpen) return;
+	aiDialogOpen = true;
+}
+
+// #2903 (EPIC #2897): 「みんなのテンプレートから探す」は admin 内 browse UI を出さず /marketplace へ遷移
+//   (activities handleAddSelect('browse') と同型、DESIGN.md §10 マーケットプレイス一本化)。
+//   取込実行は marketplace 詳細 → `?import=<presetId>` → ChildSelectionDialog の正規経路に合流する。
+function handleAddBrowse() {
+	void goto('/marketplace?type=checklist');
+}
+
 function frequencyLabel(freq: string): string {
 	const opt = FREQUENCY_OPTIONS.find((o) => o.value === freq);
 	return opt?.label ?? freq;
@@ -192,6 +226,8 @@ function acceptAiChecklist(preview: ChecklistPreviewData) {
 	aiTemplateName = preview.templateName;
 	aiTemplateIcon = preview.templateIcon;
 	aiItemsJson = JSON.stringify(preview.items);
+	// #2903: 採用したら AI ダイアログを閉じる (activities の acceptAiPreview → dialog 閉じと同型)。
+	aiDialogOpen = false;
 	// tick 後にフォーム送信
 	requestAnimationFrame(() => {
 		aiFormEl?.requestSubmit();
@@ -506,8 +542,9 @@ function getChildName(childId: number): string {
 	<title>{PAGE_TITLES.checklists}{APP_LABELS.pageTitleSuffix}</title>
 </svelte:head>
 
-<div class="space-y-4" data-testid="admin-checklists-page">
+<div class="space-y-4" data-testid="admin-checklists-page" data-tutorial="checklists-page">
 	<!-- #2362 PR-5 Phase 2: page header + OverflowMenu (top-right ⋮) -->
+	<!-- #2905: ❓ ページガイド (CHECKLISTS_GUIDE) の起点アンカーは本 wrapper (data-tutorial="checklists-page")。 -->
 	<header class="flex items-start justify-between gap-2">
 		<div class="space-y-1 flex-1 min-w-0">
 			<h1 class="text-xl font-bold text-[var(--color-text-primary)]">
@@ -563,8 +600,8 @@ function getChildName(childId: number): string {
 	{#if selectedChild}
 		<!-- #1755 (#1709-A): kind タブ削除 — 持ち物純化（旧 'routine' は activities.priority='must' に役割移管） -->
 
-		<!-- #720: AI チェックリスト提案パネル -->
-		<AiSuggestChecklistPanel onaccept={acceptAiChecklist} isFamily={data.planTier === 'family'} />
+		<!-- #2903 (EPIC #2897): AI 提案パネルの本文直置きを撤去。activities (ActivitiesHeader) と同型に
+		     「+ 追加」dropdown → AI ダイアログ (下部 aiDialogOpen) で開く方式に統一した (PO 指摘 #6b)。 -->
 
 		<!-- #720: AI提案の隠しフォーム -->
 		<form
@@ -595,7 +632,7 @@ function getChildName(childId: number): string {
 		     表示 section として E2E (marketplace-checklist-import / bug1-import-dead-end /
 		     goal-flows-exemplar) が依存しているため testid を維持する。in-page UnifiedImportHub
 		     browse UI は本 PR で撤去し、marketplace への遷移 link に置換 (DESIGN.md §10)。 -->
-		<section data-testid="marketplace-import-section">
+		<section data-testid="marketplace-import-section" data-tutorial="checklists-marketplace">
 			{#if marketplaceImportMessage}
 				<div
 					class="mb-2 px-3 py-2 rounded-md text-sm bg-[var(--color-feedback-success-bg)] text-[var(--color-feedback-success-text)]"
@@ -1017,6 +1054,13 @@ function getChildName(childId: number): string {
 			{ADMIN_CHECKLISTS_PAGE_LABELS.addButton}
 		</Button>
 	</form>
+</Dialog>
+
+<!-- #2903 (EPIC #2897): AI 提案ダイアログ。activities (addMode='ai' → Dialog 内 AiSuggestPanel) と同型。
+     プレミアム gate の文脈提示は AiSuggestChecklistPanel 内部の familyOnlyDescription(kind) が
+     機能名 (AI チェックリスト提案) 込みで担う (#2901 contextual paywall 整合、AC2)。 -->
+<Dialog bind:open={aiDialogOpen} closable={true} title={ADMIN_CHECKLISTS_PAGE_LABELS.addDialogTitleAi} testid="checklists-ai-dialog">
+	<AiSuggestChecklistPanel onaccept={acceptAiChecklist} isFamily={data.planTier === 'family'} />
 </Dialog>
 
 <!-- #2362 PR-5 Phase 2: ChildSelectionDialog (auto-open via `?import=<presetId>`) -->

--- a/tests/e2e/admin-add-path-isomorphism.spec.ts
+++ b/tests/e2e/admin-add-path-isomorphism.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * tests/e2e/admin-add-path-isomorphism.spec.ts
+ *
+ * #2903 (EPIC #2897): admin リソース管理ページの「+ 追加」経路 同型性固定テスト。
+ *
+ * PO 指摘 #6b の根治確認: 活動管理 (activities) は「+ 追加 → 手動 / AI / みんなのテンプレート」の
+ * dropdown パターンだが、チェックリスト管理 (checklists) では AI 提案パネルがページ本文に直接露出し、
+ * 操作の入口が異なっていた。本 PR で checklists も dropdown パターンに統一した。
+ *
+ * 本 spec は marketplace-bugs-analysis-2026-06-04.md 項目 6 の「テスト見逃し」(add-path lint は経路
+ * 「数」を数えるが「配置パターンの同型性」を検査しない) への構造対応:
+ *   - 経路数 lint ではなく **配置パターン (dropdown 内 item の種類と順序) の同型性** を assert する。
+ *   - activities / checklists 両ページで「+ 追加」dropdown を開き、先頭 3 item (manual / ai / browse) が
+ *     同一 id・同一順序で並ぶことを assert する (page 固有の末尾 item は許容)。
+ *   - 両ページとも AI が「dropdown 内の選択肢 → Dialog」であり、ページ本文に AI パネルが直置きされて
+ *     いないことを assert する (= 入口が同型)。
+ *
+ * Menu primitive (`src/lib/ui/primitives/Menu.svelte`) は各 item を `data-testid="menu-item-<id>"` で
+ * render する。trigger testid は activities=`header-add-activity-btn` / checklists=`checklists-add-menu`。
+ */
+
+import { expect, type Page, test } from '@playwright/test';
+
+/**
+ * Ark UI Menu trigger を開く helper (admin-activities-add-ux.spec.ts と同型)。
+ * Ark UI Menu は hydration 完了後に listener を attach するため、`data-state="open"` に
+ * 遷移するまで rAF 間隔で再 click する (#2260 Fix-6 で確立した安定化パターン)。
+ */
+async function openMenu(page: Page, triggerTestid: string): Promise<void> {
+	const trigger = page.getByTestId(triggerTestid);
+	await expect(trigger).toBeVisible({ timeout: 15_000 });
+	await page.evaluate(
+		() =>
+			new Promise<void>((resolve) => {
+				if (document.readyState === 'complete') {
+					requestAnimationFrame(() => resolve());
+				} else {
+					window.addEventListener('load', () => requestAnimationFrame(() => resolve()), {
+						once: true,
+					});
+				}
+			}),
+	);
+	const MAX_ATTEMPTS = 30;
+	for (let i = 0; i < MAX_ATTEMPTS; i++) {
+		await trigger.click();
+		const state = await trigger.evaluate((el) => el.getAttribute('data-state'));
+		if (state === 'open') return;
+		await page.evaluate(
+			() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+		);
+	}
+	await expect(trigger).toHaveAttribute('data-state', 'open');
+}
+
+/**
+ * 「+ 追加」dropdown を開いた直後の menu item id 配列を順序保持で返す。
+ *
+ * 同一ページに複数の Ark Menu (add menu / overflow menu) が存在し、いずれも `menu-item-<id>`
+ * testid を使う。グローバル query すると別 menu の item を巻き込むため、**現在 open している
+ * menu content** (`[data-part="content"][data-state="open"]`) に scope して読み取る。
+ */
+async function readAddMenuItemIds(page: Page): Promise<string[]> {
+	const openContent = page.locator('[data-part="content"][data-state="open"]');
+	await expect(openContent.first()).toBeVisible({ timeout: 5_000 });
+	const testids = await openContent
+		.first()
+		.locator('[data-testid^="menu-item-"]')
+		.evaluateAll((els) => els.map((el) => el.getAttribute('data-testid') ?? ''));
+	return testids.map((t) => t.replace('menu-item-', ''));
+}
+
+/**
+ * activities / checklists が共有すべき add 経路の先頭 3 種 (順序固定)。
+ * 「手動で1つ追加 / AI で提案してもらう / みんなのテンプレートから探す」。
+ */
+const SHARED_ADD_PATH_PREFIX = ['manual', 'ai', 'browse'] as const;
+
+test.describe('#2903 admin add 経路 同型性 (activities ⇔ checklists)', () => {
+	test('両ページとも本文に AI 提案パネルが直置きされていない (ページ表示直後は非表示、入口は dropdown のみ)', async ({
+		page,
+	}) => {
+		// AI panel は Dialog 内に格納されるため、closed 時も DOM 上には mount される (count > 0)。
+		// 「本文直置きでない」= ページ表示直後に **visible でない** ことで判定する (旧実装は常時 visible だった)。
+
+		// activities: AI panel (ai-suggest-panel) は dropdown → Dialog 経由でのみ visible になる (#2558 段階2)
+		await page.goto('/admin/activities');
+		await expect(page.getByTestId('admin-activities-child-tabs')).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByTestId('ai-suggest-panel')).not.toBeVisible();
+
+		// checklists: #2903 で AI panel (ai-suggest-checklist-panel) 直置きを撤去 → Dialog 内へ移動。
+		// 旧実装ではページ表示直後に常時 visible だったが、本 PR 後は非表示 (dropdown → Dialog で開く)。
+		await page.goto('/admin/checklists');
+		await expect(page.getByTestId('admin-checklists-page')).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByTestId('ai-suggest-checklist-panel')).not.toBeVisible();
+	});
+
+	test('checklists の「+ 追加」dropdown 先頭 3 item が activities と同一 id・同一順序 (manual / ai / browse)', async ({
+		page,
+	}) => {
+		// activities の add 経路を取得
+		await page.goto('/admin/activities');
+		await expect(page.getByTestId('admin-activities-child-tabs')).toBeVisible({ timeout: 15_000 });
+		await openMenu(page, 'header-add-activity-btn');
+		const activitiesIds = await readAddMenuItemIds(page);
+
+		// checklists の add 経路を取得
+		await page.goto('/admin/checklists');
+		await expect(page.getByTestId('admin-checklists-page')).toBeVisible({ timeout: 15_000 });
+		await openMenu(page, 'checklists-add-menu');
+		const checklistsIds = await readAddMenuItemIds(page);
+
+		// 同型性: 両ページとも先頭 3 item が SHARED_ADD_PATH_PREFIX で一致する (配置パターンの同型)。
+		expect(activitiesIds.slice(0, 3)).toEqual([...SHARED_ADD_PATH_PREFIX]);
+		expect(checklistsIds.slice(0, 3)).toEqual([...SHARED_ADD_PATH_PREFIX]);
+		// 念のため両者の先頭 3 が完全一致することも直接 assert する。
+		expect(checklistsIds.slice(0, 3)).toEqual(activitiesIds.slice(0, 3));
+	});
+
+	test('checklists の「+ 追加 → AI」で AI ダイアログ + AI パネルが起動する (activities と同型)', async ({
+		page,
+	}) => {
+		await page.goto('/admin/checklists');
+		await expect(page.getByTestId('admin-checklists-page')).toBeVisible({ timeout: 15_000 });
+		await openMenu(page, 'checklists-add-menu');
+		await page.getByTestId('menu-item-ai').click();
+		// dropdown → Dialog 内に AI 提案パネルが入る (本文直置きではない)
+		await expect(page.getByTestId('checklists-ai-dialog')).toBeVisible({ timeout: 5_000 });
+		await expect(page.getByTestId('ai-suggest-checklist-panel')).toBeVisible();
+	});
+
+	test('checklists の「+ 追加 → みんなのテンプレートから探す」で /marketplace に画面遷移する (activities と同型)', async ({
+		page,
+	}) => {
+		await page.goto('/admin/checklists');
+		await expect(page.getByTestId('admin-checklists-page')).toBeVisible({ timeout: 15_000 });
+		await openMenu(page, 'checklists-add-menu');
+		await Promise.all([
+			page.waitForURL(/\/marketplace(\?|$)/, { timeout: 15_000 }),
+			page.getByTestId('menu-item-browse').click(),
+		]);
+		// checklist に絞って遷移する (正規経路の入口、DESIGN.md §10 マーケットプレイス一本化)
+		expect(new URL(page.url()).searchParams.get('type')).toBe('checklist');
+	});
+});

--- a/tests/e2e/admin-checklists-no-kind-tab.spec.ts
+++ b/tests/e2e/admin-checklists-no-kind-tab.spec.ts
@@ -5,7 +5,7 @@
 // 1. /admin/checklists にアクセスできる
 // 2. routine / item の 2 タブ UI が DOM に存在しない（role=tablist で「チェックリスト種別」aria-label のものが無い）
 // 3. 「ルーティン」表示が画面に出ない
-// 4. 持ち物リスト（または empty state）のみが表示される
+// 4. チェックリスト作成手段（#2903 で「+ 追加」dropdown menu に集約）が必ず提示される
 
 import { expect, test } from '@playwright/test';
 
@@ -30,11 +30,14 @@ test.describe('#1756 (#1709-B) admin/checklists kind タブ削除', () => {
 		await expect(body).not.toContainText('routine');
 	});
 
-	test('持ち物作成ボタン / empty state のいずれかが表示される', async ({ page }) => {
+	test('チェックリスト作成手段（「+ 追加」dropdown menu）が表示される', async ({ page }) => {
 		await page.goto('/admin/checklists', { waitUntil: 'domcontentloaded' });
-		// 「持ち物チェックリスト」「持ち物」「テンプレート」のいずれかの文言が表示される
-		// （テストデータに依存しない strict な確認）
-		// #1768: isVisible() は同期評価で flake の原因。web-first assertion を使う
-		await expect(page.getByText(/持ち物|テンプレート/).first()).toBeVisible();
+		// #1756 の意図: kind タブ削除後も「チェックリストを作成する手段」が必ず提示される
+		//（テストデータに依存しない strict な確認）。
+		// #2903 の add UI 再構成で旧「持ち物作成ボタン」(直置きボタン) は「+ 追加」dropdown menu
+		// (testid=checklists-add-menu、label は ADMIN_CHECKLISTS_PAGE_LABELS.addMenuButton) に集約された。
+		// 作成手段（add menu trigger）が visible であることを web-first assertion で確認する
+		//（#1768: isVisible() の同期評価による flake を避け、auto-retry に委ねる）。
+		await expect(page.getByTestId('checklists-add-menu')).toBeVisible({ timeout: 15_000 });
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

チェックリスト管理は AI 提案パネルがページ本文に直接露出しており、活動管理の「+ 追加 → 手動 / AI / みんなのテンプレート」dropdown と操作の入口が異なっていた。PO 指摘 #6b「UI を統一してくれというのはずっと言ってきた指摘」を根治し、活動管理とチェックリスト管理で add の入口を同型にする。

## 関連 Issue

closes #2903 / 親 EPIC #2897 / 分析 SSOT `tmp/marketplace-bugs-analysis-2026-06-04.md` 項目 6

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | add 経路を activities と同型の「+ 追加 dropdown (manual / AI / テンプレから)」に統一し AI パネル直置きを撤去 | 実装 (`+page.svelte` の `addMenuItems` 再構成 + AI Dialog 化) + 実機 SS (before/after) | after SS で「手動 / AI で提案してもらう / みんなのテンプレートから探す / ワンオフ」dropdown を確認。before SS で AI パネル本文直置きを確認 |
| AC2 | AI 提案のプレミアム gate 提示が contextual paywall 設計と整合 | `AiSuggestChecklistPanel` 内部の `familyOnlyDescription(kind)` が機能名 (AI チェックリスト提案) 込みで gate 文言を出す (#2901 整合) | コード参照: `labels.ts` `aiSuggestCommon.familyOnlyDescription`。free tier で dialog 内に機能名込み gate 表示 |
| AC3 | 「activities と checklists の add 経路構成が同一」を E2E or Storybook で assert (配置パターン同型性) | `tests/e2e/admin-add-path-isomorphism.spec.ts` (新規 4 test) | 実機 driver で 8 assertion PASS (両ページ先頭 3 = manual/ai/browse 同順、AI が dropdown→Dialog、browse → /marketplace?type=checklist) |
| AC4 | SS 4 slot で before/after | `scripts/capture-specs/flows/admin-checklists-add-ux-2903.mjs` + 実機撮影 | after 3 状態 (default / add-menu-open / ai-dialog-open) + before 2 状態 (panel 直置き / 旧 2 項目 menu) を撮影。`--pr 2903` で screenshots branch に push |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

- `src/routes/(parent)/admin/checklists/+page.svelte`: AI パネル本文直置きを撤去 → 「+ 追加」dropdown 内 (手動 / AI / みんなのテンプレートから探す / ワンオフ) + AI Dialog 化。`data-tutorial` アンカー (checklists-page / checklists-marketplace) を併設 (PR #2914 ガイド復旧との衝突回避)
- `src/lib/domain/labels.ts`: `ADMIN_CHECKLISTS_PAGE_LABELS` に add-menu 用ラベル追加 (activities header と同一語彙)
- `tests/e2e/admin-add-path-isomorphism.spec.ts`: add 経路同型性の E2E 新規 (AC3)
- `scripts/capture-specs/flows/admin-checklists-add-ux-2903.mjs`: add-ux SS フロー (activities add-ux-2260 と同型)
- `docs/DESIGN.md` §10: 「admin リソース管理ページの add 経路は同型に揃える」原則を追記

## テスト & 安全装置セルフチェック

- `npx biome check --error-on-warnings` (変更 4 file + .mjs): PASS
- `npx svelte-check`: 変更ファイルに型エラー 0 (残 57 errors は worktree に aws-cdk-lib 未 install の infra/CDK 既存問題、本変更と無関係)
- `npx vitest run tests/unit/domain/ tests/unit/routes/`: 72 files / 1090 tests PASS
- `node scripts/check-no-plan-literals.mjs`: OK
- `node scripts/generate-lp-labels.mjs --check`: site/shared-labels.js 最新
- 実機 driver (Playwright + demo server) で本 spec の 4 test 相当 8 assertion を PASS 確認 (E2E 本実行は CI Playwright harness が担当)

## スクリーンショット / ビジュアルデモ

mobile (`?screenshot=all` で demo noise 除去・本番一致演出)。SS は screenshots ブランチ `pr-2916/` に push 済。

### Before (AI 提案パネルが本文直置き + 「+ 追加」menu は 2 項目)

| AI パネル本文直置き | 「+ 追加」menu (テンプレート作成 / ワンオフ追加) |
|---|---|
| ![before-panel](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2916/before/01-before-ai-panel-inline.png) | ![before-menu](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2916/before/02-before-add-menu-2items.png) |

### After (AI パネル撤去 + 「+ 追加」menu 4 項目 + AI は Dialog)

| 一覧 (AI パネル撤去) | 「+ 追加」menu (手動 / AI / みんなのテンプレ / ワンオフ) | AI Dialog |
|---|---|---|
| ![after-default](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2916/after/01-issue-2903-admin-checklists-default.png) | ![after-menu](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2916/after/02-issue-2903-admin-checklists-add-menu-open.png) | ![after-ai](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2916/after/03-issue-2903-admin-checklists-ai-dialog-open.png) |


## コード品質セルフレビュー (#1481)

- Menu primitive / Dialog primitive / labels SSOT を再利用 (独自実装なし)。activities の `handleAddSelect('browse')` / `addMode='ai'` と同型のパターンを踏襲
- 旧 `addTemplateButton` / `addOverrideButton` ラベルは labels.ts に残置 (data SSOT、削除は E2E 参照リスク回避)

## 横展開・影響波及チェック

- 並行実装: add menu は activities (ActivitiesHeader) / checklists の 2 箇所。本 PR で先頭 3 経路 (manual/ai/browse) を同型化。rewards / challenges への同型化は本 Issue の AC 範囲外 (別 Issue で扱う)
- PR #2914 (open、checklists ガイド復旧) が同 file に `data-tutorial` アンカーを追加する。本 PR で同一アンカーを同箇所に併設済のため、どちらが先に merge されても rebase で自然統合される
- #2911 (#2902 Phase A、activities per-child 一本化) を rebase 取込済。activities add menu 構成は不変 (manual/ai/browse/copy/bulk) で同型性維持を実機再確認

## レビュー依頼事項・破壊的変更

破壊的変更なし。AI 提案機能は撤去でなく dropdown → Dialog へ格納 (経路保持)。既存 E2E が参照する testid (`marketplace-import-section` / `checklists-add-menu` / `admin-checklists-page`) は維持。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] AC を全て満たす実装が完了している
- [x] テスト (unit / E2E spec) を追加し、ローカル / 実機 driver で PASS 確認した
- [x] biome / svelte-check / plan-literals / lp-labels の各チェックが PASS
- [x] 設計書 (DESIGN.md §10) を同期更新した
- [x] before/after SS を撮影した (screenshots branch push は PR 作成直後)
- [x] QA 承認・動作確認に向けた Dev 側完遂が済んでいる

## QM レビュー結果

未レビュー (QM/POREVIEWER 記入欄)。

