### PR TITLE
docs: #2884 — 13-AWS設計書 cron 表を実装と同期 (欠落追加 + 乖離是正)

### DIFF
--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -126,26 +126,33 @@
   - `dryRun: true` payload で env 注入確認のみ実行可 (副作用なし、smoke test 用)
 - 実装: `infra/lambda/cron-dispatcher/index.ts`
 
-**EventBridge Rules (#1376):**
+**Cron ジョブ一覧 (#1376):**
 
-| ルール名 | スケジュール (UTC) | JST 換算 | 対応ジョブ |
-|---------|-----------------|---------|----------|
-| `ganbari-quest-cron-retention-cleanup` | `cron(0 16 * * ? *)` | 01:00 | retention-cleanup |
-| `ganbari-quest-cron-trial-notifications` | `cron(0 0 * * ? *)` | 09:00 | trial-notifications |
-| `ganbari-quest-cron-lifecycle-emails` (#1601) | `cron(30 0 * * ? *)` | 09:30 | lifecycle-emails (期限切れ前リマインド + 休眠復帰メール) |
-| `ganbari-quest-cron-pmf-survey` (#1598) | `cron(0 0 1 6,12 ? *)` | 6/1・12/1 09:00 | pmf-survey (Sean Ellis Test 配信) |
-| `ganbari-quest-cron-analytics-aggregator-daily` (#1693) | `cron(0 18 * * ? *)` | 03:00 | analytics-aggregator-daily (前日分 funnel + cancellation 事前集計) |
-| `ganbari-quest-cron-challenge-aggregator-daily` (#1742) | `cron(30 18 * * ? *)` | 03:30 | challenge-aggregator-daily (当日分の全テナント `questionnaire_challenges` スナップショット集計、`/ops/analytics` プリセット分布画面の N+1 移行用) |
-| `ganbari-quest-cron-deletion-warning-emails` (#2399, **Phase 1 で追加予定**) | `cron(0 0 * * ? *)` | 09:00 | deletion-warning-emails (アカウント削除予約済テナントの所有者へ削除予告メール送信。family プラン 14 日前 / standard プラン 1 日前) |
+スケジュール SSOT は `src/lib/server/cron/schedule-registry.ts`。本表は registry の全 8 ジョブと 1:1 で対応する。
+「EventBridge」列は AWS 本番でジョブを駆動する EventBridge Rule (`infra/lib/compute-stack.ts` の `CRON_JOBS`) の有無、
+「dispatcher」列は cron-dispatcher Lambda の `KNOWN_ENDPOINTS` (`infra/lambda/cron-dispatcher/index.ts`) への登録有無を示す。
+NUC セルフホスト版は AWS を経由せず `scripts/scheduler.ts` が registry 全 8 ジョブを node-cron で直接駆動するため、
+EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 
-- スケジュール SSOT: `src/lib/server/cron/schedule-registry.ts`
-- ターゲット: `ganbari-quest-cron-dispatcher` Lambda (JSON payload `{ cronJob: "<job-name>" }`)
+| ジョブ (registry name) | スケジュール (UTC) | JST 換算 | EventBridge | dispatcher | 概要 |
+|---------|-----------------|---------|:-:|:-:|----------|
+| retention-cleanup | `cron(0 16 * * ? *)` | 毎日 01:00 | ✓ | ✓ | 保存期間超過データの自動削除バッチ (#717 / #729) |
+| trial-notifications | `cron(0 0 * * ? *)` | 毎日 09:00 | ✓ | ✓ | トライアル終了通知バッチ (#737) |
+| age-recalc | `cron(0 15 * * ? *)` | 毎日 00:00 | ✗ | ✗ | 子供の年齢自動インクリメント (#1381)。**AWS EventBridge / dispatcher 未登録のため AWS 本番では未駆動、現状は NUC scheduler のみで起動** (`schedule-consistency.test.ts` で既知 drift として明示) |
+| lifecycle-emails | `cron(30 0 * * ? *)` | 毎日 09:30 | ✓ | ✓ | 期限切れ前リマインド + 休眠復帰メール (#1601, ADR-0023 §5 I11) |
+| grace-period-deletion | `cron(0 17 * * ? *)` | 毎日 02:00 | ✗ | ✓ | グレースピリオド期限切れテナントの物理削除バッチ (#1648 R43, `grace-period-service.ts`)。**dispatcher には登録済だが AWS EventBridge Rule 未作成のため AWS 本番では未駆動、現状は NUC scheduler のみで起動** |
+| pmf-survey | `cron(0 0 1 6,12 ? *)` | 6/1・12/1 09:00 | ✓ | ✓ | PMF 判定アンケート (Sean Ellis Test) 年 2 回配信 (#1598, ADR-0023 §5 I7) |
+| analytics-aggregator-daily | `cron(0 18 * * ? *)` | 毎日 03:00 | ✓ | ✓ | 前日分 funnel + cancellation 事前集計バッチ (#1693, #1639 follow-up) |
+| challenge-aggregator-daily | `cron(30 18 * * ? *)` | 毎日 03:30 | ✓ | ✓ | 当日分の全テナント `questionnaire_challenges` スナップショット集計、`/ops/analytics` プリセット分布画面の N+1 移行用 (#1742, #1602) |
+
+- ターゲット: AWS では `ganbari-quest-cron-dispatcher` Lambda (JSON payload `{ cronJob: "<job-name>" }`) が EventBridge から起動され `/api/cron/:job` を HTTP POST する
+- AWS EventBridge Rule 名は `ganbari-quest-cron-<job-name>` (例: `ganbari-quest-cron-retention-cleanup`)
 - `ganbari-quest-cron-license-expire` は license key 全廃 (#2822 / Epic #2525 Phase 7 PR-L3) で撤去済。期限管理は Stripe `customer.subscription.deleted` webhook に代替
 - `lifecycle-emails` (#1601, ADR-0023 §5 I11): 親オーナー宛のみ送信。年 6 回マーケティングメール上限を遵守。List-Unsubscribe ヘッダ + 配信停止リンク必須。Anti-engagement 整合 (中立トーン)。
-- `deletion-warning-emails` (#2399, **Phase 1 計画**): `softDeleteTenant` で `physical_deletion_date` が記録されたテナントの所有者宛に削除予告メールを送信。family プラン 14 日前 / standard プラン 1 日前 (グレース 7 日のため 14 日前は到達不能)。idempotency は `settings.deletion_warning_sent_at` で保証。**法務通知扱いのため `marketing-email-counter` (年 6 回上限) には乗せない**。詳細は [`docs/runbooks/account-deletion-email-automation.md`](../runbooks/account-deletion-email-automation.md) (#2399 本 PR で計画策定)
+- **registry 外の endpoint**: `/api/cron/expire-redemptions` (#1337, 30 日以上 pending の交換申請を expired に移行) は endpoint として存在するが registry / EventBridge / dispatcher いずれにも未登録のため、自動スケジュール駆動はされない (手動 / 外部呼び出し前提)
 - **検証手順 / runbook**: [`docs/runbooks/cron-3-endpoints-verification.md`](../runbooks/cron-3-endpoints-verification.md) (#1377 Sub A-3)
 - **認証ヘッダ**: dispatcher は `Authorization: Bearer <CRON_SECRET>` を送信。endpoint 側は `verifyCronAuth` (`src/lib/server/auth/cron-auth.ts`) で `Authorization: Bearer` と `x-cron-secret` の両ヘッダを受理する (#1377 で統一、NUC scheduler / AWS dispatcher 双方互換)
-- **Sub A-3 検証層** (#1377): `tests/unit/cron/schedule-consistency.test.ts` が registry / CDK / dispatcher の三者整合性を CI で 0 tolerance で検出する。`scripts/check-cron-observability.mjs` (`npm run check:cron-observability`) が logger / Alarm 定義の存在を静的検査する
+- **Sub A-3 検証層** (#1377): `tests/unit/cron/schedule-consistency.test.ts` が registry / CDK / dispatcher の整合性を検証する。Sub A-3 対象 endpoint (retention-cleanup / trial-notifications) は 0 tolerance で厳密検証する一方、`age-recalc` は EventBridge / dispatcher 未反映の既知 drift として `KNOWN_DRIFT_OUT_OF_SCOPE` で除外している (上表「✗」と整合)。`scripts/check-cron-observability.mjs` (`npm run check:cron-observability`) が logger / Alarm 定義の存在を静的検査する
 
 ### 3.4 OpsStack（監視・コスト防衛）
 

--- a/docs/runbooks/account-deletion-email-automation.md
+++ b/docs/runbooks/account-deletion-email-automation.md
@@ -13,7 +13,7 @@
 | 状態 | 実装 | docs SSOT |
 |------|------|----------|
 | アカウント削除予約 (`softDeleteTenant`) | 実装済 (`src/lib/server/services/grace-period-service.ts`) | `account-deletion-flow.md §4` |
-| グレースピリオド物理削除 cron (`grace-period-deletion`) | 実装済 (#1648, EventBridge `cron(0 17 * * ? *)` 02:00 JST 毎日) | 同上 / `schedule-registry.ts` |
+| グレースピリオド物理削除 cron (`grace-period-deletion`) | 実装済 (#1648, registry `cron(0 17 * * ? *)` 02:00 JST 毎日)。**AWS EventBridge Rule 未作成のため AWS 本番では未駆動、現状は NUC scheduler のみで起動** (dispatcher `KNOWN_ENDPOINTS` には登録済、`13-AWSサーバレスアーキテクチャ設計書.md` cron 表参照) | 同上 / `schedule-registry.ts` |
 | 削除完了メール (`sendDeletionCompleteEmail`) | 実装済 (`email-service.ts` L323) | 同上 |
 | グレース開始通知 (`sendCancellationEmail`) | 実装済 (`email-service.ts` L304) | 同上 |
 | **14 日前予告メール** | **未実装** ← 本 Issue でカバー | (本 runbook で SSOT 化) |


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体 (cron 表を参照する運用者・実装者)

**解決する課題**: `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` の cron 表が実装 (`schedule-registry.ts` SSOT) と乖離していた。実装済みの `age-recalc` / `grace-period-deletion` が表に未掲載で運用者が実在 job を見落とすリスク、逆に未実装の `deletion-warning-emails` が「EventBridge Rule として実在」と掲載され実在と誤認するリスク (ADR-0013 違反状態) があった。

**期待される効果**: cron 表を信じた運用者が「実在 job の見落とし」「未実装 job を実在と誤認」しなくなる。表が実コード (registry / CDK / dispatcher) の事実と 1:1 に整合し、各 job の実駆動状態 (AWS EventBridge / NUC scheduler) が正確になる。

## 関連 Issue

closes #2884

関連: PR #2883 (license-expire 行同期、本 Issue の検出元) / #2822 (Phase 7 PR-L3) / ADR-0001 (設計書 SSOT) / ADR-0013 (実装の事実が SSOT)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | cron 表を `schedule-registry.ts` (SSOT) の現存 8 ジョブと 1:1 に同期 | `grep -oP "name: '\K[^']+" src/lib/server/cron/schedule-registry.ts` (8 件) と 13-AWS設計書 cron 表行 (8 行) を突合 | PASS — 表 8 行 = registry 8 ジョブ完全一致 (retention-cleanup / trial-notifications / age-recalc / lifecycle-emails / grace-period-deletion / pmf-survey / analytics-aggregator-daily / challenge-aggregator-daily) |
| AC2 | 未実装 `deletion-warning-emails` は削除 or 「計画 (未実装)」明記 (ADR-0013 整合) | `grep -n "deletion-warning" docs/design/13-AWSサーバレスアーキテクチャ設計書.md` | PASS — 0 件 (表 + 注記から完全削除を選択。計画 runbook `account-deletion-email-automation.md` には Plan & Design として残置) |
| AC3 | 表と registry の 1:1 を機械検証できるか検討 (任意) | `node scripts/check-doc-code-references.mjs` (exit 0、新規違反なし) + 既存 `tests/unit/cron/schedule-consistency.test.ts` が registry / CDK / dispatcher 整合を検証 | PASS — check-doc-code-references 新規違反 0。schedule-consistency.test.ts が三者 drift を検出 (age-recalc は KNOWN_DRIFT_OUT_OF_SCOPE として明示) する旨を表 ✗ 列と注記で整合化 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)
- [x] ドキュメント (`docs/`) — `13-AWSサーバレスアーキテクチャ設計書.md` cron 表 + `account-deletion-email-automation.md` 実装状態注記のみ

**影響を受ける画面・機能**: なし (docs のみ、コード・スキーマ・UI 変更なし)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— `npm run pre-ready -- --pr 2922` 実行済: biome / svelte-check / vitest 6335 件 PASS / check-hardcoded-strings 0 件 / check-no-plan-literals PASS（LP 系 Step は変更なしのため skip）
- [x] 追加・変更したテストの概要を以下に記載: N/A (docs 同期のみ、コード変更なし。表の根拠は既存 `tests/unit/cron/schedule-consistency.test.ts` が担保)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（理由: docs テキストのみの変更で UI / LP / 描画への影響なし）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A (docs のみ)
- [x] **DRY**: cron 表をミラーする他 doc を `grep` で全走査済。13-AWS設計書が SSOT 表、`account-deletion-email-automation.md` の grace-period-deletion 実装状態誤記も同 PR で是正
- [x] **YAGNI**: 表に EventBridge / dispatcher 列を追加したのは「実装の事実 (AWS 未駆動)」を正確化するための最小限の情報のみ
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001) — 13-AWS設計書 cron 表を registry 実装に同期。cron 表をミラーする `account-deletion-email-automation.md` の grace-period-deletion 実装状態も同期是正
- [x] 並行 PR overlap 確認 (#1200) — `gh pr list --search "2884"` で対応 PR なし確認済
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- 本 PR の調査で Issue 把握外の追加事実が判明: registry 8 ジョブのうち `age-recalc` (EventBridge / dispatcher 両欠落) と `grace-period-deletion` (EventBridge Rule 未作成、dispatcher のみ登録) は **AWS 本番では未駆動、NUC scheduler のみで起動**。表を「EventBridge Rules 一覧」から「Cron ジョブ一覧 (EventBridge / dispatcher 起動経路の ✓/✗ 列付き)」に拡張し、虚偽の「EventBridge Rule として実在」記載を回避した。
- この AWS 未駆動 drift 自体の解消 (EventBridge Rule 追加) は infra 変更を伴うため本 docs PR の scope 外。drift は既存 `schedule-consistency.test.ts` が `KNOWN_DRIFT_OUT_OF_SCOPE` として認識している既知事項であり、本 PR は docs を実態に合わせる是正のみ。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（`npm run pre-ready -- --pr 2922`、Step 1-8 PASS / Step 9 は本 checkbox 記入で解消）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— D-5 点検: docs 2 file +24/-17（13-AWS設計書 cron 表 + ミラー runbook 1 行）のみ
- [x] 全 AC が実装済み（AC1-AC3、本 PR body の AC 検証マップ + 実装 vs docs 突合表参照）
- [x] UI 変更時: N/A（docs のみ、UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

