### PR TITLE
infra: #2918 — pre-ready に UI 変更 PR の SS embed 未完了 hard-fail gate を追加

### DIFF
--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -167,6 +167,14 @@ MSYS_NO_PATHCONV=1 node scripts/capture.mjs --url /admin/children --presets mobi
 - mobile 390px / desktop 1280px の両ビューポート
 - 色 / 形 / 用語 / 間隔 / 状態 / アクセシビリティ / 読解容易性
 
+### SS push + embed 完了までは Ready 化禁止 (#2918)
+
+UI 変更（`.svelte` / `.css` / `.scss` / `site/`）を含む PR は、**SS 撮影 → screenshots branch push → PR body への embed 完了までは `gh pr ready` を実行しない**。「SS は後で push する」「添付予定」等の未来形記述のまま Ready 化すると、CI `screenshot-check` fail で BLOCK → QM が Fix Agent を spawn して往復するコスト（1 PR あたり 20-40 分）が発生する（#2913 / #2914 / #2915 / #2909 で 4 件連続再発した教訓）。
+
+- **Ready 化前に `npm run pre-ready -- --pr <N>` の Step 11b（SS embed gate）が PASS することを必須確認**。本 gate は CI `screenshot-check` と同一 SSOT 関数（`scripts/check-pr-screenshot.mjs` の `checkScreenshotEmbedReadiness`）を Ready 化前のローカルで前倒し実行し、UI 変更 + SS 未 embed / ローカルパス（`tmp/`）参照 / 未来形記述を hard-fail する。
+- **embed する URL は GitHub Web 上で表示できるもの**（`raw.githubusercontent.com/.../screenshots/pr-<N>/` または user-attachments）。`tmp/...` 相対パス・テキスト表のみ・embed 0 件はいずれも fail。
+- **UI 変更を含まない PR**（純粋な docs / refactor / chore）は PR body に「該当なし（refactor / docs / chore）」と明記すれば skip される。視覚差分ゼロの内部 refactor は `refactor:internal-no-doc-impact` ラベル（#2017 / ADR-0003 §4）で exempt。
+
 ## 「描画変化なし」主張のルール (#1744)
 
 「描画変化なし」「pixel-perfect 同一」を主張する場合、以下を PR 本文に箇条書きで明記。1 文字でも目視差分が出る変更は「描画変化なし」ではない:

--- a/scripts/check-pr-screenshot.mjs
+++ b/scripts/check-pr-screenshot.mjs
@@ -209,6 +209,124 @@ export function hasDomSnapshotReference(body) {
 }
 
 // ---------------------------------------------------------------------------
+// #2918: SS embed 未完了 (未来形記述 / GitHub 表示可能な embed 画像不在) の検出
+//
+// QM レビューで UI 変更 PR が「SS は後で push する」という未来形記述のまま Ready 化され、
+// CI screenshot-check fail で BLOCK → Fix Agent 往復 が 4 件連続 (#2913 / #2914 / #2915 /
+// #2909) 発生した。実装品質は高いが「SS 撮影 → screenshots branch push → body embed」の
+// 最終ステップだけが省略される構造に対し、Ready 化前 (ローカル pre-ready) で hard-fail する。
+//
+// CI screenshot-check (main 処理) とロジック SSOT を共有するため、検出関数は本ファイルに集約し
+// pre-ready は env SCREENSHOT_EMBED_GATE 経由で本検証のみを error モードで起動する (二重実装しない)。
+// ---------------------------------------------------------------------------
+
+// 未来形 / 予告記述パターン。「SS は (後で) push する」「添付予定」「撮影予定」等の未完了宣言。
+// 「push 済み」「添付しました」等の完了形は誤検出しないよう、予告を示す語尾のみに限定する。
+const FUTURE_TENSE_PATTERNS = [
+	/screenshots?\s*branch\s*へ?\s*(?:後で|あとで)?\s*push\s*(?:する|します|予定)/i,
+	/(?:スクリーンショット|スクショ|SS|画像)\s*(?:は|を)?\s*(?:後で|あとで|別途|のちほど)/,
+	/(?:添付|撮影|貼付|貼り付け|push|アップロード)\s*(?:予定|します|する予定|したい|する)\b/,
+	/(?:後で|あとで|のちほど|別途)\s*(?:添付|撮影|貼付|貼り付け|push|アップロード|追加)/,
+	/(?:TODO|todo)\s*[:：]?\s*(?:SS|スクショ|スクリーンショット|画像)/,
+];
+
+/**
+ * PR body 内に「SS は後で push する / 添付予定」等の未来形・未完了宣言が含まれるかを判定 (#2918)。
+ *
+ * 例 (fail とすべき記述):
+ * - 「SS は screenshots branch へ push する」
+ * - 「スクリーンショットは後で添付します」
+ * - 「TODO: スクショ追加」
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function hasFutureTenseScreenshotMarker(body) {
+	return FUTURE_TENSE_PATTERNS.some((p) => p.test(body));
+}
+
+/**
+ * PR body 内に GitHub Web 上で表示可能な (= remote URL の) スクリーンショット embed 画像が
+ * 1 件以上あるかを判定 (#2918)。
+ *
+ * - ローカルパス (tmp/ / .tmp-screenshots/) のみの参照は embed とみなさない (detectLocalPaths で別途 fail)
+ * - http(s) URL かつ画像拡張子 (.png/.jpg/.jpeg/.webp/.gif) を持つものを embed として数える
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function hasEmbeddedScreenshotImage(body) {
+	const urls = extractImageUrls(body);
+	return urls.some((url) => /^https?:\/\//i.test(url) && isScreenshotUrl(url));
+}
+
+/**
+ * Ready 化前 SS embed ゲート (#2918)。
+ *
+ * UI 変更があり exempt でない PR について、PR body に GitHub 表示可能な embed 画像が無い、
+ * または未来形記述 (「後で push する」) が残っている場合に違反を返す。
+ *
+ * skip 条件 (CI screenshot-check と同一 SSOT):
+ * - UI 関連ファイル変更なし (isUiPr=false)
+ * - 「該当なし（refactor / docs / chore）」「UI 変更なし」明示 (hasUiNotApplicableMarker)
+ * - ラベル refactor:internal-no-doc-impact (hasInternalRefactorLabel)
+ *
+ * @param {{ body: string; files: string[]; labels: string[] }} input
+ * @returns {{ skipped: boolean; skipReason: string | null; violations: { id: string; issue: string; message: string }[] }}
+ */
+export function checkScreenshotEmbedReadiness({ body, files, labels }) {
+	const violations = [];
+
+	// ローカルパス参照は UI PR かどうかに関わらず常に違反 (#1741 と同方針)
+	const localViolation = checkLocalPathViolation(body);
+	if (localViolation) violations.push(localViolation);
+
+	if (!isUiPr(files)) {
+		return { skipped: true, skipReason: 'UI 関連ファイル変更なし', violations };
+	}
+	if (hasUiNotApplicableMarker(body)) {
+		return { skipped: true, skipReason: '「該当なし」明示記述あり', violations };
+	}
+	if (hasInternalRefactorLabel(labels)) {
+		return {
+			skipped: true,
+			skipReason: `PR ラベル '${INTERNAL_REFACTOR_LABEL}' により内部 refactor として exempt (#2017 / ADR-0003 §4)`,
+			violations,
+		};
+	}
+
+	// 未来形記述の検出 (#2918)
+	if (hasFutureTenseScreenshotMarker(body)) {
+		violations.push({
+			id: 'future-tense-screenshot',
+			issue: '#2918',
+			message:
+				'PR body に「SS は後で push する / 添付予定」等の未来形・未完了の記述が残っています。\n' +
+				'Ready 化前に SS 撮影 → screenshots branch push → body embed を完了してください。\n' +
+				'  - node scripts/capture.mjs --pr <N> で撮影 (SS + DOM HTML が screenshots branch に push されます)\n' +
+				'  - 出力された Markdown スニペット (raw.githubusercontent.com の embed) を PR body に貼り付け\n' +
+				'  - UI 変更を含まない PR の場合は「該当なし（refactor / docs / chore）」と明記してください。',
+		});
+	}
+
+	// GitHub 表示可能な embed 画像の不在検出 (#2918)
+	if (!hasEmbeddedScreenshotImage(body)) {
+		violations.push({
+			id: 'screenshot-embed-missing',
+			issue: '#2918',
+			message:
+				'UI 変更 PR ですが、PR body に GitHub Web 上で表示可能な SS embed 画像が 1 件もありません。\n' +
+				'(テキスト表のみ / ローカルパス参照のみ / embed 0 件 は Ready 化前 fail です — #2913 / #2914 / #2915 / #2909)\n' +
+				'  - node scripts/capture.mjs --pr <N> で撮影 → screenshots branch push\n' +
+				'  - raw.githubusercontent.com/.../screenshots/pr-<N>/ 形式の embed 画像を 1 件以上 body に貼り付け\n' +
+				'  - UI 変更を含まない PR の場合は「該当なし（refactor / docs / chore）」と明記してください。',
+		});
+	}
+
+	return { skipped: false, skipReason: null, violations };
+}
+
+// ---------------------------------------------------------------------------
 // メイン処理
 // ---------------------------------------------------------------------------
 
@@ -339,6 +457,42 @@ function main() {
 	return isError ? 1 : 0;
 }
 
+/**
+ * #2918: Ready 化前 SS embed ゲートの CLI エントリ。
+ *
+ * pre-ready Step から `SCREENSHOT_EMBED_GATE=1` env で起動される。UI 変更 + SS 未 embed /
+ * 未来形記述を hard-fail (exit 1) する。検証ロジックは checkScreenshotEmbedReadiness に集約
+ * (CI screenshot-check と同一 SSOT 関数を再利用)。
+ *
+ * @returns {number} exit code (0 = PASS / skip, 1 = 違反)
+ */
+function mainEmbedGate() {
+	const { skipped, skipReason, violations } = checkScreenshotEmbedReadiness({
+		body: PR_BODY,
+		files: PR_FILES,
+		labels: PR_LABELS,
+	});
+
+	if (skipped && violations.length === 0) {
+		console.log(`[screenshot-embed-gate] ${skipReason} — SS embed 検証をスキップ`);
+		return 0;
+	}
+
+	if (violations.length === 0) {
+		console.log('[screenshot-embed-gate] OK — SS embed 済み (違反なし)');
+		return 0;
+	}
+
+	for (const v of violations) {
+		console.log(`\n[screenshot-embed-gate] ERROR (${v.id}, ${v.issue}):`);
+		console.log(v.message);
+	}
+	console.log(
+		`\n[screenshot-embed-gate] violations=${violations.length} — Ready 化前に SS embed を完了してください (#2918)`,
+	);
+	return 1;
+}
+
 import { resolve as pathResolve } from 'node:path';
 // CLI 実行時のみ main を呼ぶ（テスト import 時は呼ばない）
 // Windows では import.meta.url が file:///C:/... 形式、process.argv[1] が C:\... 形式になるため
@@ -355,7 +509,14 @@ const isMain = (() => {
 
 if (isMain) {
 	try {
-		process.exit(main());
+		// #2918: SCREENSHOT_EMBED_GATE=1 で Ready 化前 SS embed ゲートを起動 (pre-ready Step 用)。
+		// 未設定時は従来の CI screenshot-check (before/after / DOM / ローカルパス) を実行する。
+		const runner =
+			(process.env.SCREENSHOT_EMBED_GATE || '').toLowerCase() === '1' ||
+			(process.env.SCREENSHOT_EMBED_GATE || '').toLowerCase() === 'true'
+				? mainEmbedGate
+				: main;
+		process.exit(runner());
 	} catch (err) {
 		console.error('[screenshot-check] internal error:', err);
 		process.exit(2);

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -61,6 +61,7 @@ const SKIP_FLAGS = {
 	'--skip-pr-body': 'skipPrBody',
 	'--skip-doc-code-references': 'skipDocCodeReferences',
 	'--skip-terminology-coherence': 'skipTerminologyCoherence',
+	'--skip-ss-embed-gate': 'skipSsEmbedGate',
 	'--skip-capture': 'skipCapture',
 };
 
@@ -79,6 +80,7 @@ function parseArgs(argv) {
 		skipPrBody: false,
 		skipDocCodeReferences: false,
 		skipTerminologyCoherence: false,
+		skipSsEmbedGate: false,
 		skipCapture: false,
 		help: false,
 	};
@@ -119,6 +121,7 @@ Options:
   --skip-pr-body         Step 9 PR body 検査をスキップ
   --skip-doc-code-references Step 10 デッドリンク検査をスキップ
   --skip-terminology-coherence Step 11 用語不統一・add 経路重複検査をスキップ
+  --skip-ss-embed-gate   Step 11b SS embed gate (UI 変更 PR の SS 未 embed hard-fail、#2918) をスキップ
   --skip-capture         Step 12 capture (UI 変更時のみ) をスキップ
   --help, -h             このヘルプ
 
@@ -134,6 +137,7 @@ Steps:
   9.  Readiness gate              — Ready checklist [x] 完了 / AC 4 列 / forbidden-terms / 必須セクション 13 個 / mergeable (check-pr-body.mjs、PR 番号必須、#2632)
   10. check-doc-code-references.mjs — ドキュメントのデッドリンク検知 (#2577)
   11. check-terminology-coherence.ts — 用語不統一・add 経路重複検知 (#2555)
+  11b. check-pr-screenshot.mjs (SS embed gate) — UI 変更 PR の SS embed 未完了を hard-fail (#2918、CI screenshot-check と SSOT 共有)
   12. capture.mjs --pr            — UI 変更検知時のみ撮影 (現状は手動推奨。本 step は実行ガイダンスのみ)
 
 Exit codes:
@@ -193,6 +197,64 @@ async function getChangedFiles() {
 			);
 		});
 		child.on('error', () => resolveP([]));
+	});
+}
+
+/**
+ * 子プロセスを spawn し、追加 env を渡して exit code を返す (#2918 SS embed gate 用)。
+ * stdout/stderr は親に inherit する。
+ *
+ * @param {string} cmd 表示用ラベル
+ * @param {string[]} argv 実行コマンド (argv[0] が executable)
+ * @param {Record<string, string>} extraEnv 追加環境変数
+ * @returns {Promise<number>} exit code
+ */
+function runWithEnv(cmd, argv, extraEnv) {
+	return new Promise((resolveP) => {
+		console.log(`\n[pre-ready] ▶ ${cmd}`);
+		const child = spawn(argv[0], argv.slice(1), {
+			cwd: repoRoot,
+			stdio: 'inherit',
+			shell: true,
+			env: { ...process.env, ...extraEnv },
+		});
+		child.on('exit', (code) => resolveP(code ?? 1));
+		child.on('error', (err) => {
+			console.error(`[pre-ready] ${cmd} error:`, err.message);
+			resolveP(1);
+		});
+	});
+}
+
+/**
+ * `gh pr view <num> --json body,labels` で PR body / ラベル一覧を取得する (#2918)。
+ * gh 失敗時は null を返す (gate 側で skip + warning に倒す)。
+ *
+ * @param {string} prNumber
+ * @returns {Promise<{ body: string; labels: string[] } | null>}
+ */
+function fetchPrBodyAndLabels(prNumber) {
+	return new Promise((resolveP) => {
+		const child = spawn('gh', ['pr', 'view', String(prNumber), '--json', 'body,labels'], {
+			cwd: repoRoot,
+			stdio: ['ignore', 'pipe', 'ignore'],
+			shell: true,
+		});
+		let out = '';
+		child.stdout.on('data', (d) => (out += d.toString()));
+		child.on('exit', (code) => {
+			if (code !== 0) return resolveP(null);
+			try {
+				const parsed = JSON.parse(out);
+				resolveP({
+					body: parsed.body || '',
+					labels: (parsed.labels || []).map((l) => l.name).filter(Boolean),
+				});
+			} catch {
+				resolveP(null);
+			}
+		});
+		child.on('error', () => resolveP(null));
 	});
 }
 
@@ -386,6 +448,48 @@ function buildSteps(args, changedFiles) {
 			fixHint:
 				'  用語の不統一、または add 経路の重複を検知しました。\n' +
 				'  修正: labels.ts の当該箇所を SSOT 用語 (terms.ts) に合わせるか、add 経路を集約してください。',
+		},
+		// Step 11b: SS embed gate (#2918)
+		// UI 変更 PR が「SS は後で push する」未来形のまま / embed 画像なしで Ready 化され、
+		// CI screenshot-check fail → Fix Agent 往復 が 4 件連続 (#2913 / #2914 / #2915 / #2909) した
+		// 構造への対策。CI screenshot-check と同一 SSOT 関数 (checkScreenshotEmbedReadiness) を
+		// SCREENSHOT_EMBED_GATE=1 env で error モード起動し、Ready 化前に hard-fail する。
+		// UI 変更がない / --pr 未指定 / exempt label 時は gate 内部で skip。
+		{
+			name: 'ss-embed-gate',
+			label:
+				uiChanged && args.pr
+					? 'Step 11b/12: SS embed gate (check-pr-screenshot.mjs、UI 変更 PR の SS embed 未完了を hard-fail、#2918)'
+					: `Step 11b/12: SS embed gate (${!args.pr ? '--pr 未指定 — skip' : 'UI 変更なし — skip'}、#2918)`,
+			skip: args.skipSsEmbedGate || !uiChanged || !args.pr,
+			runner: async () => {
+				const pr = await fetchPrBodyAndLabels(args.pr);
+				if (!pr) {
+					console.log(
+						'[pre-ready] WARN: gh pr view で PR body / labels 取得失敗 — SS embed gate を skip (#2918)',
+					);
+					return 0;
+				}
+				const tmpFiles = changedFiles.join('\n');
+				return runWithEnv(
+					'check-pr-screenshot (SS embed gate)',
+					['node', 'scripts/check-pr-screenshot.mjs'],
+					{
+						SCREENSHOT_EMBED_GATE: '1',
+						PR_BODY: pr.body,
+						PR_FILES: tmpFiles,
+						PR_LABELS: pr.labels.join(','),
+					},
+				);
+			},
+			fixHint:
+				'  UI 変更 PR ですが SS embed が未完了です (#2918、#2913 / #2914 / #2915 / #2909 の再発防止)。\n' +
+				'  Ready 化前に以下を完了してください:\n' +
+				'    1. node scripts/capture.mjs --pr <N> で撮影 → screenshots branch push\n' +
+				'    2. raw.githubusercontent.com/.../screenshots/pr-<N>/ 形式の embed 画像を PR body に貼付\n' +
+				'    3. 「後で push する」「添付予定」等の未来形記述を完了形 (実 embed) に置換\n' +
+				'  UI 変更を含まない PR の場合は PR body に「該当なし（refactor / docs / chore）」と明記、\n' +
+				'  または視覚差分ゼロの内部 refactor なら refactor:internal-no-doc-impact ラベルを付与。',
 		},
 		{
 			name: 'capture',

--- a/tests/unit/scripts/check-pr-screenshot.test.ts
+++ b/tests/unit/scripts/check-pr-screenshot.test.ts
@@ -8,10 +8,13 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+	checkScreenshotEmbedReadiness,
 	detectBeforeAfterLabels,
 	detectLocalPaths,
 	extractImageUrls,
 	hasDomSnapshotReference,
+	hasEmbeddedScreenshotImage,
+	hasFutureTenseScreenshotMarker,
 	hasUiNotApplicableMarker,
 	isScreenshotUrl,
 	isUiPr,
@@ -189,5 +192,145 @@ describe('hasDomSnapshotReference (#1766 / #1747 AC4)', () => {
 		const body = 'DOM スナップショット (.dom.html) は未対応';
 		// URL ではなく説明文中の言及なので検出されない
 		expect(hasDomSnapshotReference(body)).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #2918: SS embed 未完了 (未来形 / embed 不在) の検出 + Ready 化前ゲート
+// ---------------------------------------------------------------------------
+
+describe('hasFutureTenseScreenshotMarker (#2918)', () => {
+	it('「screenshots branch へ push する」を検出', () => {
+		expect(hasFutureTenseScreenshotMarker('SS は screenshots branch へ push する')).toBe(true);
+	});
+
+	it('「スクリーンショットは後で添付します」を検出', () => {
+		expect(hasFutureTenseScreenshotMarker('スクリーンショットは後で添付します')).toBe(true);
+	});
+
+	it('「TODO: スクショ追加」を検出', () => {
+		expect(hasFutureTenseScreenshotMarker('TODO: スクショ追加')).toBe(true);
+	});
+
+	it('「SS は別途撮影します」を検出', () => {
+		expect(hasFutureTenseScreenshotMarker('SS は別途撮影します')).toBe(true);
+	});
+
+	it('embed 済みの完了形 PR body は false', () => {
+		const body =
+			'## SS\n![after-mobile](https://raw.githubusercontent.com/x/y/screenshots/pr-1/a.png)';
+		expect(hasFutureTenseScreenshotMarker(body)).toBe(false);
+	});
+});
+
+describe('hasEmbeddedScreenshotImage (#2918)', () => {
+	it('GitHub raw URL の embed 画像があれば true', () => {
+		const body =
+			'![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-1/after.png)';
+		expect(hasEmbeddedScreenshotImage(body)).toBe(true);
+	});
+
+	it('HTML img の remote URL embed も true', () => {
+		expect(hasEmbeddedScreenshotImage('<img src="https://example.com/a.webp">')).toBe(true);
+	});
+
+	it('ローカルパス参照のみは false (embed とみなさない)', () => {
+		expect(hasEmbeddedScreenshotImage('![x](tmp/screenshots/pr-1/x.png)')).toBe(false);
+	});
+
+	it('テキストのみ・画像 0 件は false', () => {
+		expect(hasEmbeddedScreenshotImage('## SS\n| 修正前 | 修正後 |\n|---|---|\n| a | b |')).toBe(
+			false,
+		);
+	});
+
+	it('拡張子なし user-attachments の uuid は false (screenshot URL 判定不可)', () => {
+		expect(
+			hasEmbeddedScreenshotImage(
+				'![x](https://github.com/user-attachments/assets/9c6c8430-1234-5678-aaaa-bbbb)',
+			),
+		).toBe(false);
+	});
+});
+
+describe('checkScreenshotEmbedReadiness (#2918 — Ready 化前ゲート)', () => {
+	// case 1: UI 変更あり + SS embed なし → fail (違反検出)
+	it('UI 変更あり + SS embed なし → violations を返す (fail)', () => {
+		const result = checkScreenshotEmbedReadiness({
+			body: '## 変更内容\nボタンの色を変えた。SS は後で push する。',
+			files: ['src/routes/admin/+page.svelte'],
+			labels: [],
+		});
+		expect(result.skipped).toBe(false);
+		expect(result.violations.length).toBeGreaterThan(0);
+		const ids = result.violations.map((v) => v.id);
+		expect(ids).toContain('screenshot-embed-missing');
+		expect(ids).toContain('future-tense-screenshot');
+	});
+
+	it('UI 変更あり + テキスト表のみ (embed 0 件) → fail (#2914 再現)', () => {
+		const result = checkScreenshotEmbedReadiness({
+			body: '## SS\n| 修正前 | 修正後 |\n|---|---|\n| 旧 | 新 |',
+			files: ['src/lib/ui/primitives/Button.svelte'],
+			labels: [],
+		});
+		expect(result.skipped).toBe(false);
+		expect(result.violations.map((v) => v.id)).toContain('screenshot-embed-missing');
+	});
+
+	it('UI 変更あり + ローカルパス参照のみ → fail (#2913 再現)', () => {
+		const result = checkScreenshotEmbedReadiness({
+			body: '![before](tmp/screenshots/2894/before.png)',
+			files: ['src/routes/admin/+page.svelte'],
+			labels: [],
+		});
+		expect(result.skipped).toBe(false);
+		const ids = result.violations.map((v) => v.id);
+		// ローカルパス禁止 (#1741) + embed 不在 (#2918) の両方を検出
+		expect(ids).toContain('local-path-forbidden');
+		expect(ids).toContain('screenshot-embed-missing');
+	});
+
+	// case 2: UI 変更あり + SS embed あり → pass (違反なし)
+	it('UI 変更あり + GitHub raw URL embed あり → 違反なし (pass)', () => {
+		const result = checkScreenshotEmbedReadiness({
+			body: '## SS\n![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2918/after-mobile.png)',
+			files: ['src/routes/admin/+page.svelte'],
+			labels: [],
+		});
+		expect(result.skipped).toBe(false);
+		expect(result.violations).toHaveLength(0);
+	});
+
+	// case 3: docs-only → skip (UI 変更なしで検証スキップ)
+	it('docs / .ts のみ変更 (UI 変更なし) → skip (違反なし)', () => {
+		const result = checkScreenshotEmbedReadiness({
+			body: '本文に embed 画像なし',
+			files: ['docs/CLAUDE.md', 'src/lib/server/db/schema.ts'],
+			labels: [],
+		});
+		expect(result.skipped).toBe(true);
+		expect(result.skipReason).toBe('UI 関連ファイル変更なし');
+		expect(result.violations).toHaveLength(0);
+	});
+
+	it('UI 変更あり + 「該当なし（refactor）」明示 → skip', () => {
+		const result = checkScreenshotEmbedReadiness({
+			body: 'SS: 該当なし（refactor / docs / chore）',
+			files: ['src/lib/ui/primitives/Button.svelte'],
+			labels: [],
+		});
+		expect(result.skipped).toBe(true);
+		expect(result.violations).toHaveLength(0);
+	});
+
+	it('UI 変更あり + refactor:internal-no-doc-impact ラベル → skip (exempt 互換維持)', () => {
+		const result = checkScreenshotEmbedReadiness({
+			body: '内部 refactor。SS は後で push する。', // 未来形があっても exempt label で skip
+			files: ['src/lib/ui/primitives/Button.svelte'],
+			labels: ['refactor:internal-no-doc-impact'],
+		});
+		expect(result.skipped).toBe(true);
+		expect(result.violations).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（Dev / QM の開発プロセス）

**解決する課題**: UI 変更 PR が「SS は後で push する」という未来形記述のまま / embed 画像なしで Ready 化され、CI `screenshot-check` fail で BLOCK → QM が Fix Agent を spawn して往復するパターンが 4 件連続 (#2913 / #2914 / #2915 / #2909) で発生していた。いずれも実装品質は高く、SS 撮影 → screenshots branch push → body embed の最終ステップだけが省略されている。

**期待される効果**: SS embed 未完了を Ready 化前にローカル (`npm run pre-ready`) で hard-fail させることで、QM の往復コスト（1 PR あたり 20-40 分）を構造的に削減し、Ready 化 PR の品質を底上げする。

## 関連 Issue

closes #2918

- #2913 / #2914 / #2915 / #2909（再発実例 4 件）
- #2017（screenshot-check exempt label）/ #2063（SS Blob SHA gate）/ ADR-0030（pre-ready CLI）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | pre-ready が UI 変更 + SS 未 embed の組合せを Ready 化前に fail させる (CI screenshot-check とロジック SSOT 共有) | `npx vitest run tests/unit/scripts/check-pr-screenshot.test.ts` の `checkScreenshotEmbedReadiness` 3 case + pre-ready Step 11b 組込 (`scripts/pre-ready.mjs` `ss-embed-gate`) | PASS（46 tests）。CI と同一 SSOT 関数 `checkScreenshotEmbedReadiness`（`scripts/check-pr-screenshot.mjs`）を `SCREENSHOT_EMBED_GATE=1` env で error モード起動。case1 (UI+SSなし) exit 1 / case2 (UI+SSあり) exit 0 / case3 (docs-only) exit 0 を CLI smoke test で確認 |
| AC2 | ローカルパス / 未来形記述の検出 | `hasFutureTenseScreenshotMarker` / `detectLocalPaths` (既存 #1741 再利用) の unit test | PASS。SS 添付を先送りする未来形/未完了宣言パターン (実装の検出語彙準拠、本セルには語そのものを非掲載) を test fixture で検出。`tmp/` ローカルパス参照は `local-path-forbidden` 違反として検出 (#2913 再現 test) |
| AC3 | dev-session.md へのルール明記 | `docs/sessions/dev-session.md` §「SS push + embed 完了までは Ready 化禁止 (#2918)」追記 | PASS。SS push + embed 完了までは `gh pr ready` 禁止 + Step 11b PASS 必須 + exempt 条件を明記 |
| AC4 | 既存 exempt (refactor:internal-no-doc-impact label) 互換維持 | `checkScreenshotEmbedReadiness` の exempt test（label / 「該当なし」marker / docs-only skip） | PASS。`refactor:internal-no-doc-impact` ラベル + 「該当なし（refactor / docs / chore）」marker + UI 変更なし の 3 経路すべて skip（未来形記述があっても exempt label で skip を unit test で確認） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/` 等) — `scripts/pre-ready.mjs` / `scripts/check-pr-screenshot.mjs`

**影響を受ける画面・機能**: 開発プロセス（`npm run pre-ready` Ready 化前検証）のみ。アプリ本体・LP の挙動には影響しない。CI `screenshot-check`（`pr-quality-gate.yml`）の既存挙動は不変（`SCREENSHOT_EMBED_GATE` 未設定時は従来の before/after / DOM / ローカルパス検査をそのまま実行）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— `npm run pre-ready -- --pr 2923` 実行済: biome / svelte-check / vitest 6352 件 PASS（新規 +21 test 込み）/ check-hardcoded-strings 0 件 / check-no-plan-literals PASS（LP 系 Step は変更なしのため skip）。新 gate 自体の実走確認: `SCREENSHOT_EMBED_GATE=1 node scripts/check-pr-screenshot.mjs --pr 2923` → UI 非変更で skip / exit 0
- [x] 追加・変更したテストの概要: `tests/unit/scripts/check-pr-screenshot.test.ts` に `hasFutureTenseScreenshotMarker` / `hasEmbeddedScreenshotImage` / `checkScreenshotEmbedReadiness` の検証を追加（UI+SSなし→fail / UI+SSあり→pass / docs-only→skip の 3 case + 未来形・embed・exempt 検出、計 +21 test）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（`SCREENSHOT_EMBED_GATE` は pre-ready が内部設定する実行時フラグで、配布対象の secret ではない）
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（infra / CI 変更、UI 描画変更なし）**。本 PR は `scripts/` と docs の変更のみで `.svelte` / `.css` / `site/` の変更を含まないため UI 描画の差分はない。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 検出ロジックは pure function に分離（`checkScreenshotEmbedReadiness` が orchestration、`hasFutureTenseScreenshotMarker` / `hasEmbeddedScreenshotImage` が単機能）。CI / pre-ready 両方が同一関数を再利用
- [x] **DRY**: CI `screenshot-check` と Ready 化前 gate でロジックを二重実装せず、`scripts/check-pr-screenshot.mjs` の export 関数 1 箇所に集約（#1442 使い捨て script を新設しない方針）。既存 `extractImageUrls` / `isScreenshotUrl` / `detectLocalPaths` / `isUiPr` / `hasInternalRefactorLabel` を再利用
- [x] **YAGNI**: 新規 script を作らず既存 `check-pr-screenshot.mjs` に env 駆動の分岐を追加するのみ
- [x] **Security**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A（CLI 検証ツール）
- [x] **パフォーマンス**: N/A（正規表現マッチのみ、PR body 文字列に対する O(n)）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外（CI / 開発プロセスの検証ツール）

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（既存 CI `screenshot-check` は `SCREENSHOT_EMBED_GATE` 未設定時に従来通り動作。pre-ready は UI 変更 + `--pr` 指定時のみ新 Step 11b を実行し、それ以外は skip）

**レビュー依頼事項・QA**:
- 本 PR 自体は infra 変更で UI 差分なしのため、SS embed gate (Step 11b) は「該当なし」明記で skip される運用を想定。
- gate ロジックの SSOT 共有方針（CI と pre-ready が同一 `checkScreenshotEmbedReadiness` を再利用）の妥当性をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（`SCREENSHOT_EMBED_GATE` は pre-ready が子プロセスへ渡す実行時フラグ）

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（`npm run pre-ready -- --pr 2923`、Step 1-8 PASS / Step 9 は本 checkbox 記入で解消。新 gate の本 PR 実走 skip/exit 0 も確認）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— D-5 点検: 4 file +417/-1、新規 script なしで既存 2 script 拡張 + test + dev-session.md 追記のみ
- [x] 全 AC が実装済み（AC1-AC4、本 PR body の AC 検証マップ参照）
- [x] UI 変更時: N/A（infra/script 変更のみ、UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


