### PR TITLE
fix: #2877 check-recent-deploy-deletion を merge-base (three-dot) 判定化

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -160,6 +160,7 @@ GANBARI
 ganbariquestsupport
 ganbatta
 genai
+gpgsign
 gohoubi
 gohubi
 greenlight

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -93,6 +93,11 @@ if [ -n "$PR_NUM" ]; then
 	echo "[pre-push] (2/3) 本日 deploy 全 file 削除 0 verify (PR #$PR_NUM)"
 	# 本 step は本日 merged PR の全 file 削除を検出する (#2603 第 4 弾 gate)。
 	#
+	# #2877: 削除判定は three-dot (merge-base) diff `<base>...HEAD` で「PR 自身の削除」のみを
+	# 検出する。two-dot (端点比較) は sibling PR が main に追加した file が HEAD tree に無いだけで
+	# 偽陽性 BLOCK していた (単日 4 PR #2853/#2857/#2855/#2859 連続誤 BLOCK) が、three-dot 化で
+	# main 進化を PR の削除と誤算入しなくなった。意図的削除は three-dot でも D として検出維持される。
+	#
 	# #2647 hotfix (第 9 弾): `--pr "$PR_NUM"` 引数は **付与しない**。
 	# 理由: `--pr <N>` 指定時は worktree HEAD = remote PR HEAD verify gate (#2618 第 4 弾) が走るが、
 	# push 前 hook 経路では local が rebase + new commit を持つため worktree HEAD ≠ remote PR HEAD

--- a/docs/sessions/qa-session.md
+++ b/docs/sessions/qa-session.md
@@ -151,13 +151,15 @@ gh pr checks <num>
 
 approve & merge コマンドを発行する前に、本 PR diff が **直近 7 日に main へ merge された file を削除していないか** を機械検証する。2026-05-28 単日に rebase drift で「main 進化を取り込まずに古い base から派生 → 過去 merge を revert する状態」が 5 連続再発 (#2582 / #2595 / #2598 / #2602 / #2560) し、特に #2602 / #2560 では当日 deploy した PR #2599 (ADR-0056 + QM drift prevention 案 1) 関連 file を削除する状態が Review Agent honest verify で事前 gate された。Dev 側 SKILL (#2598) は構造的に弱く、QM review 側に machine-verify を追加する Defense in Depth が必要。
 
+削除判定は **three-dot (merge-base) diff `<base>...HEAD`** で「PR 自身の diff が削除する file」のみを検出する (#2877)。two-dot (端点比較) は sibling PR が main に追加した file が HEAD tree に無いだけで偽陽性 BLOCK していた (単日 4 PR #2853 / #2857 / #2855 / #2859 連続誤 BLOCK) が、three-dot 化で main 進化を PR の削除と誤算入しなくなった。意図的削除 (#2822 / #2841 型) は three-dot でも D として検出維持されるため、真陽性の検出能力は変わらない。base が ancestor (rebase 済) かつ削除 0 件なら early fast-path で即 exit 0 する (AC2)。
+
 ```bash
 node scripts/check-recent-deploy-deletion.mjs --pr <N>
 ```
 
-- exit 0 → 直近 deploy file 削除なし、approve 判断へ進む
-- exit 2 → **BLOCK 必須**。rebase 不足の典型 symptom。Fix Agent dispatch で `git rebase origin/main` (または `git merge origin/main`) を要求し、`screenshots` branch も再 push (#2063)
-- exit 3 → internal error。base ref / git config を確認
+- exit 0 → PR 自身が直近 deploy file を削除していない、approve 判断へ進む
+- exit 2 → **BLOCK 必須**。PR 自身が直近 merge file を削除している。意図的削除でなければ rebase 不足の symptom。Fix Agent dispatch で `git rebase origin/main` (または `git merge origin/main`) を要求し、`screenshots` branch も再 push (#2063)
+- exit 3 → internal error または worktree HEAD ≠ PR HEAD mismatch (#2618)。base ref / git config / 明示 checkout を確認
 
 archive 移動 (ADR 1-in-1-out 等) の legitimate な delete は `--ignore-pattern '^docs/decisions/archive/'` で除外可能。
 

--- a/scripts/check-recent-deploy-deletion.mjs
+++ b/scripts/check-recent-deploy-deletion.mjs
@@ -35,15 +35,23 @@
  * - **ADR-0010 Pre-PMF Bucket A**: 本日 5 連続再発 + race condition 4 連続観察 =
  *   実観察 defect への直接対処
  *
- * **判定ロジック**:
+ * **判定ロジック** (#2877 で three-dot 化):
  *
- * 1. `git merge-base origin/main HEAD` を取得し、`origin/main..HEAD` の削除 file を列挙
+ * 1. `git diff -M --name-status origin/main...HEAD` (**three-dot = merge-base 比較**) で
+ *    PR 自身の diff が削除する file を列挙 (main 進化の追加 file を誤算入しない)
+ * 1.5. `git merge-base --is-ancestor origin/main HEAD` が真 (rebase 済) かつ削除 0 件なら
+ *    即 exit 0 (AC2 fast-path、recent merge 走査を省略)
  * 2. 直近 N 日 (default 7) に main に merge された commit (`--merges`) を `git log` で取得
  * 3. 各 merge commit が touch した file (additions / modifications / deletions 不問) と
  *    PR の削除 file を path level で照合
  * 4. 重複 file が存在し、かつ `--ignore-pattern` regex にマッチしない場合 → exit 2
  *    + stderr に違反 listing (file:commit:date)
  * 5. 重複なし → exit 0
+ *
+ * **two-dot → three-dot 化 (#2877)**: two-dot (`origin/main..HEAD`) は端点 tree 比較で、
+ * PR が削除していなくても main 進化で base 以降追加された file が HEAD tree に無いだけで
+ * D 判定する偽陽性があった (単日 4 PR #2853/#2857/#2855/#2859 連続誤 BLOCK)。three-dot は
+ * merge-base 起点で PR 側変更のみを抽出し、squash merge の実セマンティクスと一致する。
  *
  * **Edge cases**:
  *
@@ -158,15 +166,29 @@ export function runGit(args, options = {}) {
 /**
  * PR diff から削除 file 一覧を取得する。
  *
- * `git diff -M --name-status <base>..HEAD` を実行し、
+ * `git diff -M --name-status <base>...HEAD` (**three-dot = merge-base 比較**) を実行し、
  *   - 'D' status の file → 削除 file として収集
  *   - 'R' status の file → rename として除外 (legitimate な move を保護、archive 移動等)
+ *
+ * **three-dot (merge-base) を使う理由 (#2877)**:
+ *
+ * two-dot (`<base>..HEAD`) は **端点同士の tree 比較** であり、「PR が何も削除して
+ * いないのに、PR base 以降 main へ **追加** された file が HEAD tree に無い」だけで
+ * D 判定する。sibling PR が高頻度 merge される日には、fresh に rebase 済みでも数
+ * commit 遅れた瞬間に全 PR が偽陽性 BLOCK する (#2853 / #2857 / #2855 / #2859 で
+ * 単日 4 PR 連続誤 BLOCK)。
+ *
+ * three-dot (`<base>...HEAD`) は **merge-base (共通祖先) を起点に HEAD 側の変更のみ**を
+ * 抽出するため、「PR 自身の diff が削除する file」だけを検出する。これは squash merge
+ * 時に main に landing する実セマンティクス (PR の変更だけが反映される) と一致し、
+ * main 側の進化 (新規追加) を PR の責任に誤算入しない。意図的削除 (#2822 / #2841) は
+ * three-dot でも D として残るため、真陽性の検出能力は維持される。
  *
  * @param {string} base 比較 base (例: 'origin/main')
  * @returns {string[]|null} 削除 file path 配列、git 失敗時 null
  */
 export function getDeletedFiles(base) {
-	const output = runGit(['diff', '-M', '--name-status', `${base}..HEAD`]);
+	const output = runGit(['diff', '-M', '--name-status', `${base}...HEAD`]);
 	if (output === null) {
 		return null;
 	}
@@ -184,6 +206,30 @@ export function getDeletedFiles(base) {
 		// rename ('R100' / 'R85' 等) は skip
 	}
 	return deleted;
+}
+
+/**
+ * `<base>` が HEAD の ancestor か (= PR が base の最新を取り込み済か) を判定する (#2877)。
+ *
+ * `git merge-base --is-ancestor <base> HEAD` は exit 0 で ancestor、exit 1 で非 ancestor
+ * を返す。`runGit` は exit != 0 で null を返すため、本関数では `spawnSync` の status を
+ * 直接判定する (null=falsy だと「非 ancestor」と「git エラー」を区別できないため)。
+ *
+ * 早期 fast-path (AC2) の用途: base が ancestor (rebase 済) かつ three-dot 削除 0 件なら、
+ * 削除が一切無いことが確定するので即 exit 0 にできる (recent merge 走査を省略)。
+ *
+ * @param {string} base 比較 base (例: 'origin/main')
+ * @returns {boolean | null} ancestor なら true / 非 ancestor なら false / git 失敗時 null
+ */
+export function isAncestor(base) {
+	const result = spawnSync('git', ['merge-base', '--is-ancestor', base, 'HEAD'], {
+		encoding: 'utf8',
+		shell: false,
+	});
+	// is-ancestor の慣習: status 0 = ancestor, 1 = 非 ancestor, それ以外 = error
+	if (result.status === 0) return true;
+	if (result.status === 1) return false;
+	return null;
 }
 
 /**
@@ -511,7 +557,11 @@ export function helpText() {
 		'#2618 / ADR-0056 §D: --pr 指定時は worktree HEAD = PR HEAD verify が走り、',
 		'  不一致時は exit 3 で BLOCK (機構運用層 bypass 防止、Fix Agent 偽陽性対策)。',
 		'',
-		'See docs/sessions/qa-session.md §Step 5 / Issue #2603 / #2615 (time-aware) / #2618 (worktree verify) for context.',
+		'#2877: 削除判定は three-dot (merge-base) diff `<base>...HEAD` で「PR 自身の削除」のみを',
+		'  検出する (main 進化の追加 file を誤算入しない)。<base> が ancestor (rebase 済) かつ',
+		'  削除 0 件なら early fast-path で即 exit 0 する。',
+		'',
+		'See docs/sessions/qa-session.md §Step 5 / Issue #2603 / #2615 (time-aware) / #2618 (worktree verify) / #2877 (three-dot) for context.',
 	].join('\n');
 }
 
@@ -579,6 +629,8 @@ async function main() {
 		}
 	}
 
+	// #2877: three-dot (merge-base) 比較で「PR 自身の diff が削除する file」のみを抽出。
+	// two-dot (端点比較) は main 進化 (新規追加) を PR の削除と誤認するため不採用。
 	const deletedFiles = getDeletedFiles(opts.base);
 	if (deletedFiles === null) {
 		process.stderr.write(
@@ -587,10 +639,23 @@ async function main() {
 		return 3;
 	}
 
+	// #2877 AC2: 早期 fast-path — base が ancestor (= PR が base 最新を取り込み済) かつ
+	// three-dot 削除 0 件なら、削除が一切無いことが確定するので recent merge 走査を省略して
+	// 即 exit 0。is-ancestor が偽 (rebase drift 中) でも three-dot は PR 自身の削除のみを見る
+	// ため偽陽性は出ないが、本 fast-path で「rebase 済 + 削除 0」の最頻 case を最短化する。
+	const ancestor = isAncestor(opts.base);
 	if (deletedFiles.length === 0) {
-		process.stdout.write(
-			`[check-recent-deploy-deletion] OK: no deleted files in ${opts.base}..HEAD${opts.prNumber ? ` (PR #${opts.prNumber})` : ''}.\n`,
-		);
+		if (ancestor === true) {
+			process.stdout.write(
+				`[check-recent-deploy-deletion] OK: ${opts.base} is ancestor of HEAD and no files deleted in ${opts.base}...HEAD (fast-path)${opts.prNumber ? ` (PR #${opts.prNumber})` : ''}.\n`,
+			);
+		} else {
+			// 非 ancestor (rebase drift) / is-ancestor 判定失敗でも、three-dot 削除 0 件なら
+			// PR 自身は何も削除していないので OK。
+			process.stdout.write(
+				`[check-recent-deploy-deletion] OK: no files deleted in ${opts.base}...HEAD (merge-base diff)${opts.prNumber ? ` (PR #${opts.prNumber})` : ''}.\n`,
+			);
+		}
 		return 0;
 	}
 

--- a/tests/unit/scripts/check-recent-deploy-deletion.test.ts
+++ b/tests/unit/scripts/check-recent-deploy-deletion.test.ts
@@ -33,13 +33,19 @@
  *   - ADR-0056 (QM drift prevention、本 script は案 1 deploy 保全機構)
  */
 
-import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import {
 	DEFAULT_BASE,
 	DEFAULT_DAYS,
 	findViolations,
+	getDeletedFiles,
 	helpText,
+	isAncestor,
 	isIgnored,
 	parseArgs,
 	resolveSinceWindow,
@@ -577,5 +583,166 @@ describe('AC-4 rename detection 仕様 (integration note)', () => {
 	it('rename detection は git diff -M で D 行のみ収集 (仕様 comment)', () => {
 		// no-op assertion: 仕様 documentation のみ
 		expect(true).toBe(true);
+	});
+});
+
+/**
+ * Issue #2877: three-dot (merge-base) 化の integration 検証
+ *
+ * `getDeletedFiles` / `isAncestor` は実 git repo の状態に依存するため、mock では検証
+ * できない (two-dot vs three-dot の差は端点 tree vs merge-base diff の git 挙動そのもの)。
+ * 本 describe は一時 git repo を fixture として組み立て、以下を実 git 操作で検証する:
+ *
+ *   - AC1 (偽陽性解消): main 進化で追加された file が branch HEAD tree に無くても、PR 自身が
+ *     削除していなければ getDeletedFiles は 0 件 (two-dot なら Z を誤検出 = 偽陽性が出る case)
+ *   - AC3-1 (behind だが削除なし → exit 0 相当): rebase 未済 (behind) でも three-dot 削除 0 件
+ *   - AC3-2 (真の削除 → exit 2 相当): PR 自身が削除した file は three-dot D として検出される
+ *   - AC3-3 (意図的削除も真 D): #2822/#2841 型の意図的削除は現挙動どおり D として残る
+ *   - AC2 (is-ancestor fast-path): rebase 済で is-ancestor 真 / behind で is-ancestor 偽
+ *
+ * 各 test は `process.chdir` で fixture repo に入り、afterEach で元 cwd へ復元する
+ * (`getDeletedFiles` 等は process.cwd() の git repo に対し実行されるため)。
+ */
+describe('#2877 three-dot (merge-base) integration (実 git fixture)', () => {
+	let repoDir: string;
+	let originalCwd: string;
+	let baseSha: string;
+
+	/** fixture repo 内で git を実行する helper (stdout を返す) */
+	function git(...args: string[]): string {
+		return execFileSync('git', args, { cwd: repoDir, encoding: 'utf8' });
+	}
+
+	/** ファイルを書き込み add + commit する helper */
+	function writeCommit(file: string, content: string, message: string): void {
+		execFileSync(
+			'node',
+			['-e', `require('fs').writeFileSync(process.argv[1], process.argv[2])`, file, content],
+			{
+				cwd: repoDir,
+			},
+		);
+		git('add', file);
+		git('commit', '-m', message);
+	}
+
+	beforeAll(() => {
+		originalCwd = process.cwd();
+		repoDir = mkdtempSync(join(tmpdir(), 'rdd-2877-'));
+		// fixture repo を初期化 (CI / local の global git config に依存しない最小設定)
+		git('init', '-q', '-b', 'main');
+		git('config', 'user.email', 'test@example.com');
+		git('config', 'user.name', 'Test');
+		git('config', 'commit.gpgsign', 'false');
+		// base commit: file-x.txt / file-y.txt を作る
+		writeCommit('file-x.txt', 'X v1\n', 'base: add x and y (part 1)');
+		writeCommit('file-y.txt', 'Y v1\n', 'base: add y (part 2)');
+		// 各 test で main を base まで戻すための起点 SHA を記録
+		baseSha = git('rev-parse', 'HEAD').trim();
+	});
+
+	afterAll(() => {
+		process.chdir(originalCwd);
+		rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	beforeEach(() => {
+		process.chdir(repoDir);
+		// 各 test 開始時に main を base SHA まで戻し、前 test の feature branch を削除して
+		// test 独立性を担保する (前 test が main を進めた / feature を作った状態を巻き戻す)。
+		execFileSync('git', ['checkout', '-q', 'main'], { cwd: repoDir });
+		execFileSync('git', ['reset', '-q', '--hard', baseSha], { cwd: repoDir });
+		execFileSync('git', ['clean', '-fdq'], { cwd: repoDir });
+		try {
+			execFileSync('git', ['branch', '-D', 'feature'], { cwd: repoDir, stdio: 'ignore' });
+		} catch {
+			// feature branch 未作成 (初回) は無視
+		}
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+	});
+
+	it('AC1 (偽陽性解消): main 進化で Z が追加されても、PR が削除していなければ getDeletedFiles は 0 件', () => {
+		// base から feature を作る (Z 取込前 = behind の状態)
+		git('checkout', '-q', '-b', 'feature');
+		// feature では file-y を編集するだけ (削除なし)
+		writeCommit('file-y.txt', 'Y v2 (edited by feature)\n', 'feature: edit y (no deletion)');
+		// main を進めて file-z.txt を追加 (feature は未取込 = rebase drift)
+		git('checkout', '-q', 'main');
+		writeCommit('file-z.txt', 'Z v1\n', 'main evolves: add z (sibling PR merge)');
+		// feature に戻して getDeletedFiles を実行
+		git('checkout', '-q', 'feature');
+
+		// three-dot: feature 自身は何も削除していないので 0 件 (Z は main 側追加なので誤算入しない)
+		const deleted = getDeletedFiles('main');
+		expect(deleted).not.toBeNull();
+		expect(deleted).toEqual([]);
+
+		// 反証: two-dot (`main..HEAD`) は Z を D として誤検出する (本 PR が解消した偽陽性)。
+		// two-dot diff の D エントリに file-z.txt が含まれることを確認し、three-dot 化の必要性を実証。
+		const twoDot = git('diff', '-M', '--name-status', 'main..HEAD');
+		expect(twoDot).toContain('D\tfile-z.txt');
+		// three-dot には file-z.txt の D は含まれない
+		const threeDot = git('diff', '-M', '--name-status', 'main...HEAD');
+		expect(threeDot).not.toContain('file-z.txt');
+	});
+
+	it('AC3-1 (behind だが削除なし → exit 0 相当): rebase 未済でも three-dot 削除 0 件 + is-ancestor 偽', () => {
+		git('checkout', '-q', '-b', 'feature');
+		writeCommit('file-y.txt', 'Y v2\n', 'feature: edit y');
+		git('checkout', '-q', 'main');
+		writeCommit('file-z.txt', 'Z v1\n', 'main evolves: add z');
+		git('checkout', '-q', 'feature');
+
+		// behind 状態: main は feature の ancestor ではない (is-ancestor 偽)
+		expect(isAncestor('main')).toBe(false);
+		// しかし three-dot 削除は 0 件 → main fast-path で OK 判定される (exit 0 相当)
+		expect(getDeletedFiles('main')).toEqual([]);
+	});
+
+	it('AC3-2 (真の削除 → exit 2 相当): PR 自身が file-x を削除 → three-dot D に file-x が出る', () => {
+		git('checkout', '-q', '-b', 'feature');
+		// feature で file-x.txt を意図的に削除
+		git('rm', '-q', 'file-x.txt');
+		git('commit', '-q', '-m', 'feature: delete file-x intentionally');
+
+		const deleted = getDeletedFiles('main');
+		if (deleted === null) throw new Error('getDeletedFiles must not be null in fixture repo');
+		expect(deleted).toContain('file-x.txt');
+		expect(deleted).toHaveLength(1);
+		// この削除 file が直近 merge と重複していれば findViolations で violation (exit 2) になる
+		const merges = [
+			{ commit: 'abc12345', date: '2026-06-04 10:00:00 +0900', files: ['file-x.txt'] },
+		];
+		expect(findViolations(deleted, merges, [])).toHaveLength(1);
+	});
+
+	it('AC3-3 (意図的削除も真 D、#2822/#2841 型): rebase 済 + 意図的削除でも three-dot で検出維持', () => {
+		// feature を main 最新から派生 (rebase 済 = is-ancestor 真)
+		git('checkout', '-q', '-b', 'feature');
+		git('rm', '-q', 'file-y.txt');
+		git('commit', '-q', '-m', 'feature: delete file-y (intentional, rebased)');
+
+		// rebase 済なので is-ancestor 真
+		expect(isAncestor('main')).toBe(true);
+		// 意図的削除は three-dot でも D として検出される (真陽性の検出能力維持)
+		expect(getDeletedFiles('main')).toEqual(['file-y.txt']);
+	});
+
+	it('AC2 (is-ancestor fast-path): rebase 済 + 削除 0 件 → is-ancestor 真 かつ deleted 0 件', () => {
+		// main 最新から feature を作り、追加のみ (削除なし)
+		git('checkout', '-q', '-b', 'feature');
+		writeCommit('file-w.txt', 'W v1\n', 'feature: add w only (no deletion, rebased)');
+
+		expect(isAncestor('main')).toBe(true);
+		expect(getDeletedFiles('main')).toEqual([]);
+		// → main 側 fast-path で即 exit 0 になる条件 (is-ancestor 真 ∧ 削除 0)
+	});
+
+	it('isAncestor: 存在しない base ref → null (git エラーと非 ancestor を区別)', () => {
+		git('checkout', '-q', 'main');
+		expect(isAncestor('no-such-ref-xyz')).toBeNull();
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（Dev / QM の PR 運用品質）

**解決する課題**: `scripts/check-recent-deploy-deletion.mjs` の `getDeletedFiles` は `git diff -M --name-status <base>..HEAD` (two-dot = 端点 tree 比較) を使っていたため、PR が何も削除していなくても、PR base 以降に main へ **追加** された file が HEAD tree に無いだけで D 判定する偽陽性があった。sibling PR が高頻度 merge される日には fresh に rebase 済みでも数 commit 遅れた瞬間に偽陽性 BLOCK し、単日 4 PR (#2853 / #2857 / #2855 / #2859) を連続誤 BLOCK していた。`.husky/pre-push` と `npm run pre-ready` の両方からこの gate が呼ばれるため、誤 BLOCK は QM Re-Review の判定コスト増 + `--no-verify` 誘発の構造リスクに直結する。

**期待される効果**: `getDeletedFiles` を three-dot (merge-base 比較) 化することで、「PR 自身の diff が削除する file」のみを検出する。これは squash merge の実セマンティクス (PR の変更だけが main に反映される) と一致し、main 側の進化 (新規追加) を PR の削除と誤算入しない。偽陽性 BLOCK が解消され、意図的削除 (#2822 / #2841 型) の真陽性検出は維持されるため、QM / Dev の PR 運用コストが下がる。

## 関連 Issue

closes #2877

関連: #2603 (本 script 起票) / #2615 (time-aware flag) / #2618 (worktree HEAD verify) / #2654 (運用 SSOT 化)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `getDeletedFiles` を three-dot (merge-base 比較) `git diff -M --name-status <base>...HEAD` に変更 — PR 自身の削除のみ検出 | `grep -n "name-status" scripts/check-recent-deploy-deletion.mjs` + `npx vitest run tests/unit/scripts/check-recent-deploy-deletion.test.ts` | HEAD `af85479e` / scripts:184 が `${base}...HEAD` (three-dot) / 53 passed。AC1 test「main 進化で Z 追加でも削除 0 件」で two-dot は `D file-z.txt` 誤検出を反証、three-dot は 0 件 |
| AC2 | 早期 fast-path — `git merge-base --is-ancestor <base> HEAD` 真 かつ three-dot D=0 で即 exit 0 | `grep -n "isAncestor" scripts/check-recent-deploy-deletion.mjs` + 同 vitest | HEAD `af85479e` / `isAncestor(base)` 追加 (scripts:195-) + main() fast-path (scripts:629-) / 「AC2 (is-ancestor fast-path)」test が is-ancestor 真 ∧ 削除 0 を assert |
| AC3 | unit test に「behind だが削除なし → exit 0」「真の削除 (three-dot D あり) → exit 2」両ケース + 意図的削除の現挙動維持を追加 | `npx vitest run tests/unit/scripts/check-recent-deploy-deletion.test.ts` + 手元 fixture CLI 実演 | HEAD `af85479e` / 53 passed (実 git fixture 6 件追加: AC1 偽陽性反証 / AC3-1 behind exit0 / AC3-2 真削除 exit2 / AC3-3 意図的削除 D 維持 / AC2 fast-path / isAncestor null)。CLI 実演: CASE1 偽陽性=exit 0 / CASE2 真陽性=exit 2 |
| AC4 | `.husky/pre-push` / qa-session.md §手順5 の運用記述を新セマンティクスに同期 | `grep -n "three-dot" .husky/pre-push docs/sessions/qa-session.md` | HEAD `af85479e` / .husky/pre-push Step 2.2 コメント + qa-session.md §手順5 に three-dot セマンティクス + 偽陽性経緯 + AC2 fast-path を追記 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/` 等) — `scripts/check-recent-deploy-deletion.mjs` / `.husky/pre-push` / `tests/unit/scripts/` / `docs/sessions/qa-session.md`

**影響を受ける画面・機能**: QM gate script (`check-recent-deploy-deletion.mjs`) の削除判定ロジック。`.husky/pre-push` Step 2.2 と `npm run pre-ready` Step 9 の両経路から呼ばれる。ユーザー向け UI 画面への影響なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載: `tests/unit/scripts/check-recent-deploy-deletion.test.ts` に実 git fixture を組み立てる integration describe を追加 (6 test)。AC1 で two-dot 偽陽性 (`D file-z.txt`) を反証、three-dot が出さないことを実証。AC3-1 (behind exit0) / AC3-2 (真削除 exit2) / AC3-3 (意図的削除 D 維持) / AC2 (is-ancestor fast-path) / isAncestor null をカバー。全 53 test PASS
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high、critical ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）** — 本 PR は QM gate script (`.mjs`) / unit test / pre-push hook / 運用 docs の変更のみで、ユーザー向け UI (`*.svelte` / `site/`) を一切変更しない。UI 変更なし。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `isAncestor(base)` を独立純粋関数として追加し単一責任を保つ。`getDeletedFiles` は diff 種別の変更のみで signature 不変
- [x] **DRY**: `grep -rn "name-status" scripts/` で他の two-dot 使用箇所が無いことを確認済（本 script の getDeletedFiles のみ該当）。既存 `runGit` helper を再利用
- [x] **YAGNI**: 現要件 (three-dot 化 + is-ancestor fast-path) のみ。新規抽象化なし
- [x] **Security（OSS 公開前提）**: 秘密情報 hardcode なし。git CLI 呼び出しは既存同様 `spawnSync` shell:false で injection 防止
- [x] **アクセシビリティ**: N/A（CLI script）
- [x] **パフォーマンス**: fast-path で is-ancestor 真 ∧ 削除 0 件時に recent merge 走査を省略し、最頻 case を最短化

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期 — N/A
- [ ] LP ↔ アプリ双方向整合 — N/A
- [ ] 全年齢モード 5 種に横展開 — N/A
- [ ] ナビゲーション 3 種に反映 — N/A
- [ ] E2E / ユニットシード + チュートリアルを同期 — N/A
- [ ] labels SSOT (ADR-0009) — N/A
- [x] **設計書同期** (ADR-0001): QM gate script の運用記述 SSOT である `docs/sessions/qa-session.md` §手順5 を three-dot セマンティクスに同期更新済
- [x] **並行 PR overlap** (#1200): `scripts/check-recent-deploy-deletion.mjs` / `.husky/pre-push` を同時変更する open PR は他に無し
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** — 既存 CLI 互換 (`--ignore-pattern` / `--base` / `--days` / `--since*` / `--pr` worktree verify) を全維持。three-dot 化により偽陽性が消えるのみで、真陽性 (意図的削除) の検出能力は不変
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**: three-dot 化の核心 (two-dot が main 進化を PR 削除と誤認する偽陽性) を `tests/unit/scripts/check-recent-deploy-deletion.test.ts` の AC1 test で「two-dot diff は `D file-z.txt` を出すが three-dot は出さない」と反証付きで pin している。意図的削除 (#2822/#2841 型) が three-dot でも D として残ることは AC3-3 test で担保。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

<!-- Draft PR 据え置き (Ready 化禁止指示)。Ready 化前に Dev が全 [x] 化する。 -->

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（`npm run pre-ready -- --pr 2924`、Step 1-8 PASS: biome / svelte-check / vitest 6341 件 PASS（新規 integration test 6 件込み）/ check-hardcoded-strings 0 件 / check-no-plan-literals PASS。Step 9 は本 checkbox 記入で解消）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— D-5 点検: 4 file +251/-12（script three-dot 化 + isAncestor fast-path / 実 git fixture test / pre-push・qa-session.md 同期）
- [x] 全 AC が実装済み（AC1-AC4、本 PR body の AC 検証マップ + 真偽両 case 実演 log 参照）
- [x] Phase 分割した場合: N/A（本 PR は Phase 分割なし）
- [x] UI 変更時: N/A（本 PR は UI 変更なし）
- [x] 認証画面変更時: N/A（本 PR は認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

