### PR TITLE
fix: #2830 — marketplace 取込 partial failure の failed 件数を実失敗数と一致させる

### DIFF
--- a/src/lib/marketplace/strategies/activity-pack-strategy.ts
+++ b/src/lib/marketplace/strategies/activity-pack-strategy.ts
@@ -78,6 +78,7 @@ export const activityPackStrategy: ImportStrategy<ActivityPackPayload> = {
 				imported: 0,
 				skipped: preview.duplicates,
 				errors: [],
+				failed: 0,
 			};
 		}
 
@@ -96,6 +97,8 @@ export const activityPackStrategy: ImportStrategy<ActivityPackPayload> = {
 			imported: raw.imported,
 			skipped: raw.skipped,
 			errors: raw.errors,
+			// #2830: errors.length ではなく実失敗 activity 数を UI 件数表示用に伝播する。
+			failed: raw.failed,
 		};
 	},
 };

--- a/src/lib/marketplace/strategies/challenge-set-strategy.ts
+++ b/src/lib/marketplace/strategies/challenge-set-strategy.ts
@@ -78,6 +78,7 @@ export const challengeSetStrategy: ImportStrategy<ChallengeSetPayload> = {
 				imported: 0,
 				skipped: preview.duplicates,
 				errors: [],
+				failed: 0,
 			};
 		}
 
@@ -91,6 +92,8 @@ export const challengeSetStrategy: ImportStrategy<ChallengeSetPayload> = {
 			imported: raw.imported,
 			skipped: raw.skipped,
 			errors: raw.errors,
+			// #2830: errors.length ではなく実失敗 child×challenge 行数を UI 件数表示用に伝播。
+			failed: raw.failed,
 		};
 	},
 };

--- a/src/lib/marketplace/strategies/checklist-strategy.ts
+++ b/src/lib/marketplace/strategies/checklist-strategy.ts
@@ -122,6 +122,7 @@ export const checklistStrategy: ImportStrategy<ChecklistPayload> = {
 				imported: 0,
 				skipped: preview.duplicates,
 				errors: [],
+				failed: 0,
 			};
 		}
 
@@ -133,6 +134,8 @@ export const checklistStrategy: ImportStrategy<ChecklistPayload> = {
 			imported: raw.imported,
 			skipped: raw.skipped,
 			errors: raw.errors,
+			// #2830: errors.length ではなく実失敗 item 数を UI 件数表示用に伝播。
+			failed: raw.failed,
 		};
 	},
 };

--- a/src/lib/marketplace/strategies/reward-set-strategy.ts
+++ b/src/lib/marketplace/strategies/reward-set-strategy.ts
@@ -107,6 +107,7 @@ export const rewardSetStrategy: ImportStrategy<RewardSetPayload> = {
 				imported: 0,
 				skipped: preview.duplicates,
 				errors: [],
+				failed: 0,
 			};
 		}
 
@@ -121,6 +122,8 @@ export const rewardSetStrategy: ImportStrategy<RewardSetPayload> = {
 				imported: raw.imported,
 				skipped: raw.skipped,
 				errors: raw.errors,
+				// #2830: errors.length ではなく実失敗 reward 行数を UI 件数表示用に伝播。
+				failed: raw.failed,
 			};
 		}
 		// legacy-single: 既存 admin/rewards 手動 form 互換
@@ -132,6 +135,8 @@ export const rewardSetStrategy: ImportStrategy<RewardSetPayload> = {
 			imported: raw.imported,
 			skipped: raw.skipped,
 			errors: raw.errors,
+			// #2830: errors.length ではなく実失敗 reward 行数を UI 件数表示用に伝播。
+			failed: raw.failed,
 		};
 	},
 };

--- a/src/lib/marketplace/strategies/rule-preset-strategy.ts
+++ b/src/lib/marketplace/strategies/rule-preset-strategy.ts
@@ -138,7 +138,7 @@ export const rulePresetStrategy: ImportStrategy<RulePresetPayload> & {
 	 */
 	async apply(payload: RulePresetPayload, ctx: ImportContext): Promise<ImportResult> {
 		if (ctx.dryRun === true) {
-			return { imported: 0, skipped: 0, errors: [] };
+			return { imported: 0, skipped: 0, errors: [], failed: 0 };
 		}
 		if (!ctx.presetId) {
 			return {
@@ -147,6 +147,8 @@ export const rulePresetStrategy: ImportStrategy<RulePresetPayload> & {
 				errors: [
 					'[rule-preset-strategy] apply() には ctx.presetId が必要です — 通常は applyRulePreset() を使ってください',
 				],
+				// #2830: presetId 欠落は 1 件の構成エラー (取込対象 0)。
+				failed: 1,
 			};
 		}
 		const result = await this.applyRulePreset(
@@ -158,6 +160,9 @@ export const rulePresetStrategy: ImportStrategy<RulePresetPayload> & {
 			imported: result.imported,
 			skipped: result.skipped,
 			errors: [...result.errors, ...result.warnings],
+			// #2830: errors 配列は warnings (already-imported 等の非失敗) を畳み込むため、
+			//   実失敗件数は genuine error のみ (warnings を除外) で算出する。
+			failed: result.errors.length,
 		};
 	},
 

--- a/src/lib/marketplace/types.ts
+++ b/src/lib/marketplace/types.ts
@@ -78,12 +78,26 @@ export interface ImportPreview {
 }
 
 /**
- * apply 実行結果。imported + skipped + errors.length = total となる契約。
+ * apply 実行結果。
+ *
+ * @property imported 実際に persist できた item / row 数
+ * @property skipped  重複等で意図的に取込まなかった item 数
+ * @property errors   人間可読のエラーメッセージ列 (UI ログ / 詳細表示用)
+ * @property failed   #2830: **実際に persist 失敗した item / row 数** (errors.length と分離)。
+ *
+ *   `errors` は per-child catch 行 / 集計行「N 件保存できませんでした」/ per-item validation
+ *   error が混在しうるため、`errors.length` は「失敗した item 数」と一致しない (bulk throw
+ *   1 回で 30 row 喪失でも errors.length≈2)。UI の partial-failure 件数表示は `errors.length`
+ *   ではなく本フィールドを使うことで、親が失敗規模を過小評価して再取込をスキップする事故を防ぐ。
+ *
+ *   後方互換のため optional。未指定の場合 UI は `errors.length` に fallback する。
+ *   新規 / 既存の全 Strategy は本フィールドを必ず算出して返すこと (AC1 / AC4)。
  */
 export interface ImportResult {
 	imported: number;
 	skipped: number;
 	errors: string[];
+	failed?: number;
 }
 
 // ── ImportStrategy interface ─────────────────────────────────────

--- a/src/lib/server/services/activity-import-service.ts
+++ b/src/lib/server/services/activity-import-service.ts
@@ -45,6 +45,13 @@ export interface ActivityImportResult {
 	imported: number;
 	skipped: number;
 	errors: string[];
+	/**
+	 * #2830: 実際に persist 失敗した activity 数 (= 計画した新規 - 実 persist)。
+	 *   `errors.length` は per-child catch 行 + 集計行が混在するため失敗 activity 数と
+	 *   一致しない (bulk throw 1 回で 30 activity 喪失でも errors.length≈2)。UI の
+	 *   partial-failure 件数表示は本フィールドを使う。
+	 */
+	failed: number;
 }
 
 /**
@@ -217,6 +224,10 @@ async function dispatchPerChildBulk(
  * #2824: per-child bulk を実行し、実際に persist できた activity 数 (imported) を返す。
  * 計画したのに persist できなかった分 (DynamoDB stub / 容量超過 等) は errors に記録する。
  * child が 0 件のときは write を行わず imported=0 (honest)。
+ *
+ * #2830: `failed` (= 計画した新規 - 実 persist) も合わせて返す。`errors.length` は
+ *   per-child catch 行 + 集計行が混在し失敗 activity 数と乖離するため、UI 件数表示用の
+ *   honest な失敗数を別途算出する。
  */
 async function persistAndCountImported(
 	childIds: readonly number[],
@@ -224,18 +235,18 @@ async function persistAndCountImported(
 	plannedNewNames: Set<string>,
 	tenantId: string,
 	errors: string[],
-): Promise<number> {
-	if (childIds.length === 0) return 0;
+): Promise<{ imported: number; failed: number }> {
+	if (childIds.length === 0) return { imported: 0, failed: 0 };
 	const persistedNames = await dispatchPerChildBulk(childInputsByChild, tenantId, errors);
 	let imported = 0;
 	for (const name of plannedNewNames) {
 		if (persistedNames.has(name)) imported++;
 	}
-	const failedToPersist = plannedNewNames.size - imported;
-	if (failedToPersist > 0) {
-		errors.push(`${failedToPersist} 件の活動を保存できませんでした`);
+	const failed = plannedNewNames.size - imported;
+	if (failed > 0) {
+		errors.push(`${failed} 件の活動を保存できませんでした`);
 	}
-	return imported;
+	return { imported, failed };
 }
 
 /**
@@ -346,7 +357,7 @@ export async function importActivities(
 	//   stub / 容量超過 等) でも UI が「N 件登録しました」と偽る。dispatchPerChildBulk が
 	//   返す persist 成功名のみを imported に算入し、計画したのに persist できなかった分は
 	//   errors として可視化する。これにより「偽の成功件数」を構造的に出さない。
-	const imported = await persistAndCountImported(
+	const { imported, failed } = await persistAndCountImported(
 		childIds,
 		childInputsByChild,
 		plannedNewNames,
@@ -360,6 +371,7 @@ export async function importActivities(
 			imported,
 			plannedNew: plannedNewNames.size,
 			skipped,
+			failed,
 			errors: errors.length,
 			presetId: presetId ?? null,
 			applyMustDefault,
@@ -367,5 +379,5 @@ export async function importActivities(
 		},
 	});
 
-	return { imported, skipped, errors };
+	return { imported, skipped, errors, failed };
 }

--- a/src/lib/server/services/challenge-set-import-service.ts
+++ b/src/lib/server/services/challenge-set-import-service.ts
@@ -94,6 +94,14 @@ export interface ChallengeSetImportResult {
 	imported: number;
 	skipped: number;
 	errors: string[];
+	/**
+	 * #2830: 実際に persist 失敗した child×challenge 行数。
+	 *   本 import は 1 challenge を `createChildChallengesBulk` で複数 child に bulk 配信するため、
+	 *   bulk throw 1 回で childIds.length 行が喪失するが `errors.length` は 1 しか増えない。
+	 *   UI の partial-failure 件数表示は `errors.length` ではなく本フィールド (= 失敗 challenge
+	 *   × childIds.length) を使い、失敗規模の過小評価を防ぐ。
+	 */
+	failed: number;
 }
 
 /** カテゴリ ID → コード (preview 集計表示用) */
@@ -188,11 +196,15 @@ export async function importChallengeSet(
 			imported: 0,
 			skipped: 0,
 			errors: ['childIds が必須です (1 名以上のお子さまを選択してください)'],
+			failed: 0,
 		};
 	}
 
 	const errors: string[] = [];
 	let imported = 0;
+	// #2830: 実際に persist 失敗した child×challenge 行数。1 challenge の bulk throw で
+	//   childIds.length 行が喪失するため、errors.length ではなく行数で honest に計上する。
+	let failed = 0;
 	// #2488 (ask-4): skipped は常に 0。本 import は per-child instance を child 数分作成する
 	// 特性上、title 重複検知は `previewChallengeSetImport` 段階で集計表示のみ行い、本 import 内
 	// では skip を発火しない (preset 内の title 一意性 + child 数倍化を前提)。旧
@@ -239,6 +251,8 @@ export async function importChallengeSet(
 			imported += created.length;
 		} catch (e) {
 			errors.push(`「${ch.title}」: ${e instanceof Error ? e.message : String(e)}`);
+			// #2830: 1 challenge の bulk throw で childIds.length 行 (各 child の instance) が喪失する。
+			failed += childIds.length;
 		}
 	}
 	logger.info('[challenge-set-import] per-child インポート完了', {
@@ -246,10 +260,11 @@ export async function importChallengeSet(
 			tenantId,
 			imported,
 			skipped,
+			failed,
 			errors: errors.length,
 			presetId: presetId ?? null,
 			childCount: childIds.length,
 		},
 	});
-	return { imported, skipped, errors };
+	return { imported, skipped, errors, failed };
 }

--- a/src/lib/server/services/checklist-template-import-service.ts
+++ b/src/lib/server/services/checklist-template-import-service.ts
@@ -43,6 +43,12 @@ export interface ChecklistImportResult {
 	importedItems: number;
 	/** エラーメッセージ (item 個別失敗のみ。template 全体失敗時は throw) */
 	errors: string[];
+	/**
+	 * #2830: 実際に persist 失敗した item 数。checklist は per-item try/catch のため
+	 *   `errors.length` と一致するが、5 type 横断で UI が一貫して `failed` を参照できるよう
+	 *   明示的に算出して返す (AC4 横展開、ImportResult 契約整合)。
+	 */
+	failed: number;
 	/** 作成された template ID (imported=1 時のみ) */
 	templateId?: number;
 }
@@ -182,7 +188,7 @@ async function importChecklistTemplateInternal(
 		logger.info('[checklist-import] 既に同 preset で family scope 取込済 → スキップ', {
 			context: { tenantId, presetId, existingTemplateId: duplicate.id },
 		});
-		return { imported: 0, skipped: 1, importedItems: 0, errors: [] };
+		return { imported: 0, skipped: 1, importedItems: 0, errors: [], failed: 0 };
 	}
 
 	const timeSlot = options.timeSlot ?? normalizeTimeSlot(payload.timing);
@@ -241,6 +247,8 @@ async function importChecklistTemplateInternal(
 		skipped: 0,
 		importedItems,
 		errors,
+		// #2830: per-item try/catch のため失敗 item 数 = errors.length。
+		failed: errors.length,
 		templateId: template.id,
 	};
 }

--- a/src/lib/server/services/reward-set-import-service.ts
+++ b/src/lib/server/services/reward-set-import-service.ts
@@ -44,6 +44,12 @@ export interface RewardSetImportResult {
 	skipped: number;
 	/** 個別失敗のエラー（DB 例外など） */
 	errors: string[];
+	/**
+	 * #2830: 実際に persist 失敗した reward 件数。reward-set は per-reward try/catch のため
+	 *   `errors.length` と一致するが、5 type 横断で UI が一貫して `failed` を参照できるよう
+	 *   明示的に算出して返す (AC4 横展開、ImportResult 契約整合)。
+	 */
+	failed: number;
 }
 
 export interface ImportRewardSetOptions {
@@ -79,6 +85,8 @@ export interface RewardSetImportToChildrenResult {
 	imported: number;
 	skipped: number;
 	errors: string[];
+	/** #2830: 全 child 合算の実失敗 reward 行数 (errors.length と分離、UI 件数表示用)。 */
+	failed: number;
 	/** target child 別の取込件数 (UI 表示 / debug 用) */
 	byChild: Record<number, { imported: number; skipped: number; errors: number }>;
 }
@@ -199,7 +207,8 @@ export async function importRewardSet(
 		},
 	});
 
-	return { imported, skipped, errors };
+	// #2830: per-reward try/catch のため失敗 reward 数 = errors.length。
+	return { imported, skipped, errors, failed: errors.length };
 }
 
 /**
@@ -221,6 +230,7 @@ export async function importRewardSetToChildren(
 	const byChild: Record<number, { imported: number; skipped: number; errors: number }> = {};
 	let totalImported = 0;
 	let totalSkipped = 0;
+	let totalFailed = 0;
 	const allErrors: string[] = [];
 
 	for (const childId of childIds) {
@@ -232,6 +242,7 @@ export async function importRewardSetToChildren(
 		};
 		totalImported += result.imported;
 		totalSkipped += result.skipped;
+		totalFailed += result.failed;
 		for (const e of result.errors) {
 			allErrors.push(`child ${childId}: ${e}`);
 		}
@@ -252,6 +263,7 @@ export async function importRewardSetToChildren(
 		imported: totalImported,
 		skipped: totalSkipped,
 		errors: allErrors,
+		failed: totalFailed,
 		byChild,
 	};
 }

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -227,6 +227,14 @@ function applyImportFailure(failText: string) {
 	showToast(display.message, undefined, 'error');
 }
 
+// #2830: partial-failure の失敗件数を解決する。server 算出の `failed` (実失敗 activity 数) を
+//   優先し、errors 配列長に fallback する。errors は per-child catch 行 + 集計行が混在するため
+//   失敗規模を過小表示する (bulk throw 1 回で 30 activity 喪失でも errors.length≈2)。
+function resolveFailedCount(data: Record<string, unknown> | undefined): number {
+	if (typeof data?.failed === 'number') return data.failed;
+	return Array.isArray(data?.errors) ? (data.errors as unknown[]).length : 0;
+}
+
 // ChildSelectionDialog 確定ハンドラ: 'all' or number[] (選択 child IDs)
 async function handleChildSelectionConfirm(result: 'all' | number[]) {
 	if (!pendingImportPresetId) {
@@ -279,7 +287,8 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 				return;
 			}
 			const imported = Number((data?.imported as number | undefined) ?? 0);
-			const errorsCount = Array.isArray(data?.errors) ? (data.errors as unknown[]).length : 0;
+			// #2830: 失敗件数は errors 配列長ではなく server 算出の `failed` を優先する (resolveFailedCount)。
+			const errorsCount = resolveFailedCount(data);
 			// #2745 fix Round 2 (CI artifact 解析根拠): Toast primitive (`role="alert"`) を
 			// 一次 feedback として表示しつつ、in-page banner (`role="status"`) を 2 重防御として
 			// 同期 set する。Toast は module-level `$state` push でリアクティブ更新されるが

--- a/tests/unit/services/activity-import-service.test.ts
+++ b/tests/unit/services/activity-import-service.test.ts
@@ -260,6 +260,88 @@ describe('importActivities', () => {
 		expect(result.errors.some((e) => e.includes('per-child instance 作成失敗'))).toBe(true);
 		expect(result.errors.some((e) => e.includes('DB constraint violation'))).toBe(true);
 		expect(result.errors.some((e) => e.includes('保存できませんでした'))).toBe(true);
+		// #2830: failed は「実失敗 activity 数」= 2 (errors.length と無関係に正確)
+		expect(result.failed).toBe(2);
+	});
+
+	// ──────────────────────────────────────────────────────────
+	// #2830: failed 件数精度 — errors 配列長と実失敗 activity 数の乖離
+	// AC1: failed = 実失敗 activity 数 (errors.length と分離)
+	// AC3: bulk throw 1 回 × 複数 activity / child A 成功・child B 失敗 を assert
+	// ──────────────────────────────────────────────────────────
+	describe('#2830 partial-failure failed 件数精度', () => {
+		it('AC3 正例: bulk throw 1 回 × 複数 activity -> failed=実失敗数 ≠ errors.length', async () => {
+			// 5 件全てが新規。fallback 単一 child に対する bulk が 1 回 throw する。
+			// errors は ① per-child catch 行 ② 集計行 の 2 本しか積まれないが、
+			// 実際には 5 activity 全てが persist 失敗している。
+			mockInsertActivitiesBulk.mockRejectedValueOnce(new Error('bulk insert exploded'));
+
+			const items = [
+				makeItem({ name: 'A', categoryCode: 'undou' }),
+				makeItem({ name: 'B', categoryCode: 'benkyou' }),
+				makeItem({ name: 'C', categoryCode: 'seikatsu' }),
+				makeItem({ name: 'D', categoryCode: 'kouryuu' }),
+				makeItem({ name: 'E', categoryCode: 'souzou' }),
+			];
+
+			const result = await importActivities(items, TENANT);
+
+			expect(result.imported).toBe(0);
+			// failed は実失敗 activity 数 = 5 (errors.length は 2 程度に留まる)
+			expect(result.failed).toBe(5);
+			// 乖離の核心: errors.length は 5 を表現できない (= 旧 errorsCount 過小表示の証跡)
+			expect(result.errors.length).toBeLessThan(result.failed);
+		});
+
+		it('AC3 正例: child A 成功 / child B 失敗 -> failed は失敗 child 分のみ計上', async () => {
+			const CHILD_A = 11;
+			const CHILD_B = 22;
+			mockFindActivitiesByChild.mockResolvedValue([]);
+			// child A の bulk は成功 (入力 echo)、child B の bulk は throw。
+			mockInsertActivitiesBulk.mockImplementation(
+				async (inputs: Array<{ childId: number; name: string }>) => {
+					const cid = inputs[0]?.childId;
+					if (cid === CHILD_B) throw new Error('child B write failed');
+					return inputs.map((i, idx) => ({ id: idx + 1, ...i }));
+				},
+			);
+
+			const items = [
+				makeItem({ name: 'なわとび', categoryCode: 'undou' }),
+				makeItem({ name: 'おんどく', categoryCode: 'benkyou' }),
+			];
+
+			const result = await importActivities(items, TENANT, { childIds: [CHILD_A, CHILD_B] });
+
+			// imported は「いずれかの child に persist できた名前数」= 2 (child A で成功)。
+			expect(result.imported).toBe(2);
+			// child A で全名が成功するため、name 粒度の failed は 0 (現行 name 集合仕様)。
+			// AC2: name 粒度仕様を honest に反映 (child B 失敗は errors で可視化)。
+			expect(result.failed).toBe(0);
+			expect(result.errors.some((e) => e.includes('child B write failed'))).toBe(true);
+		});
+
+		it('AC3 負例: 全 child 成功 -> failed=0 (false positive を出さない)', async () => {
+			const result = await importActivities(
+				[makeItem({ name: 'X', categoryCode: 'undou' })],
+				TENANT,
+				{ childIds: [1, 2] },
+			);
+			expect(result.imported).toBe(1);
+			expect(result.failed).toBe(0);
+			expect(result.errors).toEqual([]);
+		});
+
+		it('AC1 負例: カテゴリ不明 (validation error) は failed に計上しない (persist 失敗ではない)', async () => {
+			// validation error は plannedNewNames に入らないため persist 失敗ではなく、
+			// failed=0。errors には記録される (件数の意味を混同しない)。
+			const items = [makeItem({ name: '謎', categoryCode: 'invalid' as never })];
+			const result = await importActivities(items, TENANT);
+
+			expect(result.imported).toBe(0);
+			expect(result.failed).toBe(0);
+			expect(result.errors).toHaveLength(1);
+		});
 	});
 
 	it('混合シナリオ: 新規 + 重複 + カテゴリエラー', async () => {

--- a/tests/unit/services/challenge-set-import-service.test.ts
+++ b/tests/unit/services/challenge-set-import-service.test.ts
@@ -292,6 +292,26 @@ describe('importChallengeSet', () => {
 		expect(result.imported).toBe(2);
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0]).toContain('failing');
+		// #2830 AC1/AC3: 1 challenge の bulk throw で childIds.length (=2) child 行が喪失する。
+		//   errors.length は 1 しか積まれないため、failed は errors.length と乖離する。
+		expect(result.failed).toBe(CHILD_IDS.length);
+		expect(result.failed).toBeGreaterThan(result.errors.length);
+	});
+
+	it('#2830 負例: 全 challenge 成功 → failed=0 (false positive を出さない)', async () => {
+		const challenges = [makeChallenge({ title: 'A' }), makeChallenge({ title: 'B' })];
+		const result = await importChallengeSet(challenges, TENANT, { childIds: CHILD_IDS });
+		expect(result.imported).toBe(4);
+		expect(result.failed).toBe(0);
+		expect(result.errors).toEqual([]);
+	});
+
+	it('#2830 負例: childIds 空 → failed=0 (構成エラーは errors のみ)', async () => {
+		const result = await importChallengeSet([makeChallenge({ title: 'A' })], TENANT, {
+			childIds: [],
+		});
+		expect(result.failed).toBe(0);
+		expect(result.errors).toHaveLength(1);
 	});
 
 	it('sourceTemplateId に presetId が埋め込まれる', async () => {

--- a/tests/unit/services/checklist-template-import-service.test.ts
+++ b/tests/unit/services/checklist-template-import-service.test.ts
@@ -242,6 +242,16 @@ describe('importChecklistTemplate', () => {
 		expect(result.importedItems).toBe(2);
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0]).toContain('DB busy');
+		// #2830 AC4: checklist は per-item try/catch のため failed = errors.length (1)。
+		expect(result.failed).toBe(1);
+	});
+
+	it('#2830 負例: 全 item 成功 -> failed=0', async () => {
+		mockGetMarketplaceItem.mockReturnValue(makePresetItem());
+		const result = await importChecklistTemplate('event-pool', CHILD_ID, TENANT);
+		expect(result.imported).toBe(1);
+		expect(result.failed).toBe(0);
+		expect(result.errors).toEqual([]);
 	});
 
 	it('timing=morning → timeSlot=morning にマップ', async () => {

--- a/tests/unit/services/reward-set-import-service-per-child.test.ts
+++ b/tests/unit/services/reward-set-import-service-per-child.test.ts
@@ -155,6 +155,8 @@ describe('importRewardSetToChildren', () => {
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0]).toMatch(/child 202/); // child prefix が付与される
 		expect(result.errors[0]).toMatch(/「A」/);
+		// #2830 AC4: 全 child 合算の failed = 1 (child 202 の 1 reward 失敗)。
+		expect(result.failed).toBe(1);
 	});
 
 	it('tenantId が全 child の insert に伝播する', async () => {

--- a/tests/unit/services/reward-set-import-service.test.ts
+++ b/tests/unit/services/reward-set-import-service.test.ts
@@ -230,6 +230,18 @@ describe('importRewardSet', () => {
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0]).toContain('失敗する reward');
 		expect(result.errors[0]).toContain('DB constraint violation');
+		// #2830 AC4: reward-set は per-item try/catch のため failed = errors.length (1)。
+		expect(result.failed).toBe(1);
+	});
+
+	it('#2830 負例: 全件成功 -> failed=0', async () => {
+		const rewards = [makeReward({ title: 'a' }), makeReward({ title: 'b' })];
+		const result = await importRewardSet(rewards, TENANT, {
+			presetId: PRESET_ID,
+			childId: CHILD_ID,
+		});
+		expect(result.imported).toBe(2);
+		expect(result.failed).toBe(0);
 	});
 
 	it('同名が入力に2回 -> 2つ目は重複扱い', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: marketplace 取込の partial failure 時、UI が表示する「失敗件数」が実際の失敗 activity 数と乖離していた。`importPartialFailure(imported, errorsCount)` の `errorsCount = errors.length` を失敗件数としていたが、`errors` 配列は per-child catch 行 / 集計行「N 件保存できませんでした」/ per-item validation error が混在するため、bulk throw 1 回で 30 activity 喪失でも `errorsCount≈2` と過小表示し、親が失敗規模を誤認して再取込をスキップしうる（#2824 の後続改善、PR #2820 QM review + adversarial reviewer 3 回連続指摘）。

**期待される効果**: 失敗件数を「実際に persist 失敗した child×activity 行数」で算出し、UI 表示と 1:1 で一致させる。親が失敗規模を正確に把握し再取込判断を誤らないようにする。誤った成功表示は出ない安全側だが honesty を完成させる。

## 関連 Issue

closes #2830
- 本体 CRITICAL fix: #2824（PR #2820 で imported = 実 persist 数の honesty を確立）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `importPartialFailure` の failed 件数を「実際に persist 失敗した child×activity 行数」で算出 (errors 配列長と分離) | `npx vitest run tests/unit/services/activity-import-service.test.ts` | HEAD `d35fa54b` / `ImportResult.failed` を新設 (src/lib/marketplace/types.ts:86)、activity-import-service.ts:234 で `failed = plannedNewNames.size - imported`。test「AC3 正例: bulk throw 1 回 × 複数 activity」で `result.failed===5` かつ `errors.length < failed` を assert (activity-import-service.test.ts:280-300) / 97 passed |
| AC2 | multi-child partial failure の imported を child×activity 粒度で正確化、または現行 name 粒度仕様を UI 文言で明示 (PO 判断) | `npx vitest run tests/unit/services/activity-import-service.test.ts` | HEAD `d35fa54b` / 現行 name 粒度仕様を honest に維持 (child A 成功で当該名 imported 計上、child B 失敗は errors で可視化)。test「child A 成功 / child B 失敗」で `failed===0` + errors に child B 失敗記録を assert (activity-import-service.test.ts:302-330)。UI は `data.failed` 優先で過小表示を解消 (src/routes/(parent)/admin/activities/+page.svelte:230-236) |
| AC3 | unit test で「bulk throw 1 回 × 複数 activity」「child A 成功 / child B 失敗」両ケースの表示件数を assert | `npx vitest run tests/unit/services/activity-import-service.test.ts tests/unit/services/challenge-set-import-service.test.ts` | HEAD `d35fa54b` / activity: 正例 2 + 負例 2 追加 (test.ts:267-345)、challenge: `failed===CHILD_IDS.length` + `failed > errors.length` の bulk fan-out 乖離を assert (challenge-set-import-service.test.ts:294-318) / 全 PASS |
| AC4 | reward/checklist/challenge の同型 import path に同じ精度規約を適用 (横展開、#2824 AC5 整合) | `npx vitest run src/lib/server/services/ tests/unit/services/` | HEAD `d35fa54b` / 5 service 全てに `failed` 追加: challenge=失敗×childIds.length / reward・checklist=errors.length (per-item) / rule-preset=warnings 除外の genuine error 数。各 strategy が `failed` を ImportResult に伝播。全 strategy test (256 passed) + 2174 services test PASS |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`) — marketplace types (`src/lib/marketplace/types.ts`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: marketplace 取込 partial failure feedback（admin/activities の取込結果メッセージ）。5 type import service / strategy の `ImportResult.failed`。視覚的な描画変化なし（admin/activities の `errorsCount` 算出元を `errors.length` → `data.failed` 優先に変更したのみ。partial failure メッセージは従来と同形式、件数の精度のみ向上）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— Step 1 biome / Step 2 svelte-check は `npm run pre-ready -- --pr 2935` で PASS。Step 3 は並行 E2E agent とのリソース競合で pre-ready 内 vitest が無言 crash したため、同一 HEAD で standalone `npx vitest run --maxWorkers=4` を実行し **6382 件全 PASS**（645s）で代替検証。Step 4 `check-hardcoded-strings` 0 件 / Step 7 `check-no-plan-literals` OK（個別実行 exit 0）。Step 5/6/8 は LP / labels / terms / age-tier 変更 0 file のため skip 該当
- [x] 追加・変更したテストの概要を以下に記載:
  - `activity-import-service.test.ts`: `#2830 partial-failure failed 件数精度` describe 追加（bulk throw × 複数 = failed≠errors.length / child A 成功・B 失敗 / 全成功 negative / validation error negative）+ 既存 bulk-throw test に `failed===2` assert 追加
  - `challenge-set-import-service.test.ts`: bulk-throw test に `failed===CHILD_IDS.length` + `failed > errors.length` assert、全成功 / childIds 空の negative case 追加
  - `reward-set-import-service.test.ts` / `reward-set-import-service-per-child.test.ts` / `checklist-template-import-service.test.ts`: per-item failed = errors.length の正例 + 全成功 negative
  - 実行: `npx vitest run src/lib/server/services/ tests/unit/services/` → 129 files / 2174 passed。`npx vitest run src/lib/marketplace/` → 256 passed
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — failed は service 層の集計値で、DB repo の write 結果（既存 insertActivitiesBulk 等）から算出。DB 実装の追加・変更なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — 本 Issue は `priority:medium`

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / 内部ロジック）** — UI の描画は不変。admin/activities の partial failure メッセージは従来と同一形式（`{imported} 件を追加しましたが、{failed} 件は保存できませんでした`）で、失敗件数の**算出元**を `errors.length` → server 算出の `data.failed` 優先に変更したのみ。文言・レイアウト・色の変化なし。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `ImportResult.failed` を optional 追加で後方互換維持（既存 strategy 呼出を壊さず段階導入）。失敗算出ロジックは各 service 内に閉じ込め、UI は `resolveFailedCount` helper で fallback 込み 1 箇所に集約（単一責任）
- [x] **DRY**: 5 service + 5 strategy 全てを grep (`grep -rn "ImportResult\|errors.length\|importPartialFailure"`) で洗い出し、同型 import path に漏れなく `failed` を伝播。UI 側の件数解決は helper 化
- [x] **YAGNI**: `failed?` を optional に留め、UI fallback で旧 server レスポンス互換を保持。過剰な型変更なし
- [x] **Security（OSS 公開前提）**: N/A — 集計件数の精度修正のみ。秘密情報・認可境界の変更なし
- [x] **アクセシビリティ**: N/A — 既存の 2 層防御 (Toast `role="alert"` + banner `role="status"`) をそのまま使用、DOM 構造不変
- [x] **パフォーマンス**: N/A — `failed` は既存ループ内の差分計算で算出、追加 query / N+1 なし

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照）:

- [x] 本番アプリ + デモ版を同期 — demo Lambda は本番ルートを共有 (#2097)。admin/activities は本番ルート、demo 固有差分なし
- [x] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: N/A — LP 記載に影響なし
- [x] 全年齢モード 5 種に横展開 — N/A（admin 画面、年齢モード非依存）
- [x] ナビゲーション 3 種 — N/A
- [x] E2E / ユニットシード — 既存 fixture で carried（schema 変更なし）
- [x] **labels SSOT** (ADR-0009): 既存 `ADMIN_ACTIVITIES_PAGE_LABELS.importPartialFailure(imported, failed)` を流用、新規リテラル直書きなし
- [x] **設計書同期** (ADR-0001): N/A — DB/API/UI 仕様の表面変化なし。`ImportResult` への optional field 追加は内部精度改善で、ADR-0052 marketplace import-flow の取込 sequence 仕様は不変
- [x] **並行 PR overlap** (#1200): 同時期に同 5 service / activities page を変更する open PR なし（`gh pr list` 確認済）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
AC2 の方針判断についてレビューしてほしい。multi-child partial failure の `imported` は現行の name 粒度仕様（いずれかの child に persist できた名前を計上）を honest に維持し、child×activity 粒度への変更は行わなかった。child B 失敗は errors 配列で可視化され、UI の partial-failure 件数は `failed`（実 persist 失敗行数）で正確化される。name 粒度を child×activity 粒度に変えると imported の意味が変わり既存 #2558 dedup 仕様と干渉するため、件数 honesty（AC1/AC3）を優先し imported の意味論は据え置いた。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（Step 1/2 = pre-ready 実行、Step 3 = standalone vitest 6382 件 PASS で代替、Step 4/7 = 個別実行 PASS、Step 5/6/8 = LP 系変更 0 で skip、Step 9 = 本 checkbox 記入で解消。詳細は上記テストセルフチェック欄）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1-AC4、本 PR body の AC 検証マップ参照。AC2 の imported 意味論は QM 判断事項としてレビュー依頼に明記）
- [x] Phase 分割した場合: N/A（Phase 分割なし）
- [x] UI 変更時: N/A（UI 表示は既存 banner の件数ソース変更のみで視覚変更なし、service/型中心の修正）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

