### PR TITLE
fix: #2932 [CRITICAL] 本番 trial 開始不能 — DynamoDB trial-history-repo 全関数 stub 本実装

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1755,6 +1755,20 @@ child partition 配下に置き、`findMessages` / `findUnshownMessage` / `count
 
 **インデックス:** idx_trial_history_tenant(tenant_id)
 
+**DynamoDB key 設計 (#1016 / #2932 / ADR-0055):**
+
+| 項目 | 値 |
+|------|----|
+| PK | `T#<tenantId>#TRIAL` （tenant 単位 partition） |
+| SK | `HIST#<paddedId>` （8 桁 0 埋め、counter 採番 = SQLite auto-increment 互換、辞書順 = id 昇順） |
+
+- `findLatestByTenant(tenantId)`: tenant partition を `ScanIndexForward=false` で Query `Limit 1` → 最大 id (=最新) を 1 read（GSI 不要）。
+- `findActiveTrials()`: tenantId を受けない全 tenant 横断 + 日次 cron の低頻度経路のため Scan + `begins_with(SK,'HIST#') AND endDate >= today` filter（GSI 追加は過剰防衛、ADR-0010）。
+- `updateConversion(id)`: tenantId 不明のため tenant 横断 Scan + id filter で PK/SK を解決して Update（Stripe webhook 経由の稀な経路）。
+- `deleteByTenantId(tenantId)`: tenant partition は trial history 専用のため exact PK 削除で完結（退会時、ADR-0049）。
+
+実装: `src/lib/server/db/dynamodb/trial-history-repo.ts`（挙動 SSOT は `sqlite/trial-history-repo.ts`）。
+
 ### viewer_tokens
 
 閲覧専用リンクトークン。祖父母等の外部家族向け閲覧用URL。

--- a/scripts/check-dynamodb-stub.mjs
+++ b/scripts/check-dynamodb-stub.mjs
@@ -54,7 +54,7 @@ const ALLOW_LIST = new Set([
 const GRANDFATHERED_STUBS = new Map([
 	['evaluation-repo.ts', 1014], // rest days 機能: follow-up Issue #1014
 	['message-repo.ts', 1015], // parent messages 機能: follow-up Issue #1015
-	['trial-history-repo.ts', 1016], // trial history 機能: follow-up Issue #1016
+	// trial-history-repo.ts (#1016) は #2932 で本実装完了し除去済 (本番 trial 開始不能 CRITICAL 根治)
 ]);
 
 /**

--- a/src/lib/server/db/dynamodb/keys.ts
+++ b/src/lib/server/db/dynamodb/keys.ts
@@ -1012,6 +1012,48 @@ export function cloudExportSKPrefix(): string {
 }
 
 // ============================================================
+// Trial history (#314 / #769 / #1016 / #2932) — トライアル履歴
+// ============================================================
+//
+// 設計方針 (GSI 不要、ADR-0055 §3.1 / ADR-0010):
+//   アクセスパターン:
+//     (a) findLatestByTenant(tenantId)  — tenant 内最新 1 件 (trial 状態判定の hot path)
+//     (b) findActiveTrials()            — endDate >= today の全 tenant 横断 (日次 cron 1 回)
+//     (c) insert(input)                 — trial 開始時 1 件追加
+//     (d) updateConversion(id)          — Stripe 本契約移行時 1 件更新 (tenantId なし、稀)
+//     (e) deleteByTenantId(tenantId)    — 退会時削除 (ADR-0049)
+//   (a)/(c)/(e) は tenant 既知のため tenant partition に集約する:
+//     PK = T#<tenantId>#TRIAL, SK = HIST#<paddedId>
+//   SK の paddedId は 8 桁 0 埋め (counter 採番 = SQLite auto-increment 互換) で辞書順 = id 昇順。
+//   (a) findLatestByTenant は tenant partition を ScanIndexForward=false で Query Limit 1 →
+//     最大 id (=最新) を 1 read で取得する (GSI 不要)。
+//   (b) findActiveTrials は tenantId を受けない全 tenant 横断 + 日次 cron の低頻度経路のため、
+//     Scan + FilterExpression(begins_with(SK,'HIST#') AND endDate >= today) で対応する
+//     (cancellation-reason-repo / cloud-export-repo.deleteExpired と同じ Pre-PMF 方針、
+//     GSI 追加は過剰防衛 ADR-0010)。
+//   (d) updateConversion は id のみ受け tenantId が不明なため、tenant 横断 Scan + id filter で
+//     PK/SK を解決して Update する (message-repo.markShown / stamp-card-repo の id 解決と同パターン、
+//     Stripe webhook 経由の稀な経路、#2842 教訓で Scan は Limit なしページング)。
+
+/** Trial history: PK=T#<tenant>#TRIAL, SK=HIST#<paddedId> */
+export function trialHistoryKey(historyId: number, tenantId: string): DynamoKey {
+	return {
+		PK: tenantPK('TRIAL', tenantId),
+		SK: `HIST#${padId(historyId)}`,
+	};
+}
+
+/** Trial history PK for tenant Query (findLatestByTenant / deleteByTenantId) */
+export function trialHistoryTenantPK(tenantId: string): string {
+	return tenantPK('TRIAL', tenantId);
+}
+
+/** Trial history SK prefix for querying all history of a tenant / tenant cleanup / cross-tenant Scan filter */
+export function trialHistoryPrefix(): string {
+	return 'HIST#';
+}
+
+// ============================================================
 // Viewer token (#2824 Wave 6B / #371) — 閲覧専用リンク token
 // ============================================================
 //
@@ -1107,6 +1149,8 @@ export const ENTITY_NAMES = {
 	reportDailySummary: 'reportDailySummary',
 	cloudExport: 'cloudExport',
 	viewerToken: 'viewerToken',
+	// #1016 / #2932 (ADR-0055): trial-history grandfathered stub 本実装
+	trialHistory: 'trialHistory',
 } as const;
 
 export type EntityName = (typeof ENTITY_NAMES)[keyof typeof ENTITY_NAMES];

--- a/src/lib/server/db/dynamodb/trial-history-repo.ts
+++ b/src/lib/server/db/dynamodb/trial-history-repo.ts
@@ -1,34 +1,201 @@
 // src/lib/server/db/dynamodb/trial-history-repo.ts
-// DynamoDB stub for ITrialHistoryRepo (#314, #769)
+// トライアル履歴 リポジトリ — DynamoDB 本実装 (#314 / #769 / #1016 / #2932 / ADR-0055)
+//
+// ITrialHistoryRepo (interfaces/trial-history-repo.interface.ts) を SQLite 実装
+// (sqlite/trial-history-repo.ts、挙動 SSOT) と機能等価に DynamoDB single-table で実装する。
+//
+// 経緯 (#2932 CRITICAL): 本 repo は #1021 の check-dynamodb-stub.mjs 導入時点で既に no-op stub の
+//   まま稼働しており GRANDFATHERED_STUBS (follow-up #1016) に登録されていた。EPIC #2897 Phase 2
+//   (#2824「write stub 12 repo 全廃」) でも grandfathered のため対象外で残存した結果、本番
+//   cognito Lambda (AUTH_MODE=cognito + DATA_SOURCE=dynamodb) で startTrial → insert() が no-op と
+//   なり、action は 200 success (偽 success) を返すが getTrialStatus → findLatestByTenant() が
+//   undefined を返すため UI が trial 表示に変化しない (新課金体系の hero CTA 動線が死ぬ)。本実装で根治する。
+//
+// key 設計 (keys.ts §trialHistoryKey):
+//   PK = T#<tenantId>#TRIAL   (tenant 単位 partition)
+//   SK = HIST#<paddedId>      (8 桁 0 埋め、counter 採番 = SQLite auto-increment 互換、辞書順 = id 昇順)
+//   → findLatestByTenant(tenantId) は tenant partition を ScanIndexForward=false で Query Limit 1 →
+//     最大 id (=最新) を 1 read で取得 (GSI 不要)。
+//   → findActiveTrials() は tenantId を受けない全 tenant 横断 + 日次 cron の低頻度経路のため、
+//     Scan + FilterExpression(begins_with(SK,'HIST#') AND endDate >= today) で対応
+//     (cancellation-reason-repo と同じ Pre-PMF 方針、ADR-0010 — GSI 追加は過剰防衛)。
+//   → updateConversion(id) は tenantId が不明なため tenant 横断 Scan + id filter で PK/SK を解決して
+//     Update する (message-repo.markShown / stamp-card-repo の id 解決と同パターン、Stripe webhook
+//     経由の稀な経路、#2842 教訓で Scan は Limit なしページング)。
+//
+// 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/trial-history-repo.ts (SSOT)
 
+import { PutCommand, QueryCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type {
 	InsertTrialHistoryInput,
 	TrialHistoryRow,
 	UpdateTrialConversionInput,
 } from '../interfaces/trial-history-repo.interface';
+import { getDocClient, TABLE_NAME } from './client';
+import { nextId } from './counter';
+import { ENTITY_NAMES, trialHistoryKey, trialHistoryPrefix, trialHistoryTenantPK } from './keys';
+import { stripKeys } from './repo-helpers';
 
-export async function findLatestByTenant(_tenantId: string): Promise<TrialHistoryRow | undefined> {
-	// TODO: DynamoDB implementation
-	return undefined;
+const PREFIX = trialHistoryPrefix();
+
+/** DynamoDB item を TrialHistoryRow に正規化する (PK/SK 除去 + null 既定の補完)。 */
+function toRow(item: Record<string, unknown>): TrialHistoryRow {
+	const s = stripKeys(item) as Record<string, unknown>;
+	return {
+		id: s.id as number,
+		tenantId: s.tenantId as string,
+		startDate: s.startDate as string,
+		endDate: s.endDate as string,
+		tier: s.tier as string,
+		source: s.source as string,
+		campaignId: (s.campaignId ?? null) as string | null,
+		stripeSubscriptionId: (s.stripeSubscriptionId ?? null) as string | null,
+		upgradeReason: (s.upgradeReason ?? null) as string | null,
+		trialStartSource: (s.trialStartSource ?? null) as string | null,
+		createdAt: s.createdAt as string,
+	};
 }
 
-/** endDate が今日以降のトライアル履歴を返す（DynamoDB未実装） */
+// ============================================================
+// findLatestByTenant — tenant 内の最新トライアル履歴 1 件
+// ============================================================
+
+export async function findLatestByTenant(tenantId: string): Promise<TrialHistoryRow | undefined> {
+	// SQLite: WHERE tenant_id = ? ORDER BY id DESC LIMIT 1
+	// SK = HIST#<paddedId> が id 昇順の辞書順のため、ScanIndexForward=false で先頭 = 最大 id = 最新。
+	const result = await getDocClient().send(
+		new QueryCommand({
+			TableName: TABLE_NAME,
+			KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+			ExpressionAttributeValues: {
+				':pk': trialHistoryTenantPK(tenantId),
+				':prefix': PREFIX,
+			},
+			ScanIndexForward: false,
+			Limit: 1,
+		}),
+	);
+	const item = result.Items?.[0];
+	return item ? toRow(item) : undefined;
+}
+
+// ============================================================
+// findActiveTrials — endDate が今日以降のトライアル履歴 (全 tenant 横断、cron 通知対象)
+// ============================================================
+
+/** endDate が今日以降のトライアル履歴を返す（cron 通知対象の取得用、全 tenant 横断） */
 export async function findActiveTrials(): Promise<TrialHistoryRow[]> {
-	// DynamoDB 未実装: #1033 のスコープ外。本番は DynamoDB だが Pre-PMF 段階では SQLite テスト用。
-	// GRANDFATHERED_STUBS (scripts/check-dynamodb-stub.mjs) に登録済み — follow-up Issue #1016
-	return [];
+	const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (SQLite 実装と同形式)
+	const doc = getDocClient();
+	const rows: TrialHistoryRow[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	// SQLite: WHERE end_date >= today。日次 cron の低頻度経路のため tenant 横断 Scan + 属性フィルタ。
+	// #2842 教訓: Scan の Limit は filter 前評価のため付けず ExclusiveStartKey で全ページ走査する。
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: 'begins_with(SK, :prefix) AND endDate >= :today',
+				ExpressionAttributeValues: {
+					':prefix': PREFIX,
+					':today': today,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) rows.push(toRow(item));
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return rows;
 }
 
-export async function insert(_input: InsertTrialHistoryInput): Promise<void> {
-	// TODO: DynamoDB implementation
+// ============================================================
+// insert — トライアル開始 (永続の核心経路)
+// ============================================================
+
+export async function insert(input: InsertTrialHistoryInput): Promise<void> {
+	const id = await nextId(ENTITY_NAMES.trialHistory, input.tenantId);
+	const createdAt = new Date().toISOString();
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...trialHistoryKey(id, input.tenantId),
+				id,
+				tenantId: input.tenantId,
+				startDate: input.startDate,
+				endDate: input.endDate,
+				tier: input.tier,
+				source: input.source,
+				campaignId: input.campaignId ?? null,
+				stripeSubscriptionId: null,
+				upgradeReason: null,
+				trialStartSource: input.trialStartSource ?? null,
+				createdAt,
+			},
+		}),
+	);
 }
 
-/** トライアル後のコンバージョン情報を記録（DynamoDB未実装） */
-export async function updateConversion(_input: UpdateTrialConversionInput): Promise<void> {
-	// TODO: DynamoDB implementation
+// ============================================================
+// updateConversion — トライアル後のコンバージョン情報を記録 (Stripe 本契約移行時)
+// ============================================================
+
+/** トライアル後のコンバージョン情報を記録（Stripe 本契約移行時に呼ぶ、id のみ受ける稀な経路） */
+export async function updateConversion(input: UpdateTrialConversionInput): Promise<void> {
+	const key = await scanKeyById(input.id);
+	if (!key) return; // 該当 id 不在は no-op (SQLite UPDATE ... WHERE id = ? が 0 row と等価)
+	await getDocClient().send(
+		new UpdateCommand({
+			TableName: TABLE_NAME,
+			Key: { PK: key.PK, SK: key.SK },
+			UpdateExpression: 'SET stripeSubscriptionId = :sub, upgradeReason = :reason',
+			ExpressionAttributeValues: {
+				':sub': input.stripeSubscriptionId,
+				':reason': input.upgradeReason,
+			},
+		}),
+	);
 }
 
-/** テナントの全トライアル履歴を削除（DynamoDB未実装: 書き込みがないため no-op） */
-export async function deleteByTenantId(_tenantId: string): Promise<void> {
-	// DynamoDB trial-history repo は未実装のため書き込みデータなし — no-op
+// ============================================================
+// deleteByTenantId — テナントの全トライアル履歴を削除 (退会時、ADR-0049)
+// ============================================================
+
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	const { deleteItemsByExactPk } = await import('./bulk-delete');
+	// tenant partition (PK=T#<tenant>#TRIAL) は trial history 専用のため exact PK 削除で完結。
+	await deleteItemsByExactPk(trialHistoryTenantPK(tenantId));
+}
+
+// ============================================================
+// 内部ヘルパ
+// ============================================================
+
+/**
+ * updateConversion 用に、historyId に一致する item の PK/SK を tenant 横断 Scan で解決する。
+ * conversion は id のみ受け tenantId が不明なため tenant 配下を走査する (Stripe webhook 経由の
+ * 稀な経路)。#2842 教訓: Scan の Limit は filter 前評価のため付けず ExclusiveStartKey で全ページ走査。
+ */
+async function scanKeyById(historyId: number): Promise<{ PK: string; SK: string } | undefined> {
+	const doc = getDocClient();
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: 'begins_with(SK, :prefix) AND id = :id',
+				ExpressionAttributeValues: {
+					':prefix': PREFIX,
+					':id': historyId,
+				},
+				ProjectionExpression: 'PK, SK',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		const item = result.Items?.[0];
+		if (item) return { PK: item.PK as string, SK: item.SK as string };
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	return undefined;
 }

--- a/tests/e2e/trial-flow.spec.ts
+++ b/tests/e2e/trial-flow.spec.ts
@@ -79,6 +79,12 @@ test.describe('#752 トライアルフロー — free ユーザー', () => {
 		await expect(page.getByTestId('trial-banner-active-cta')).toBeVisible();
 		// 「開始」バナーは消える
 		await expect(page.getByTestId('trial-banner-not-started')).toHaveCount(0);
+
+		// #2932 CRITICAL: reload 後も trial 状態が維持される（insert が永続していることの確認）。
+		// stub の no-op insert だった頃は reload で「開始」バナーに戻っていた（偽 success）。
+		await page.reload({ waitUntil: 'commit', timeout: 30_000 });
+		await expect(page.getByText(/無料体験中/)).toBeVisible({ timeout: 30_000 });
+		await expect(page.getByTestId('trial-banner-not-started')).toHaveCount(0);
 	});
 
 	// ========================================================

--- a/tests/unit/db/dynamodb-trial-history-repo.test.ts
+++ b/tests/unit/db/dynamodb-trial-history-repo.test.ts
@@ -1,0 +1,380 @@
+/**
+ * tests/unit/db/dynamodb-trial-history-repo.test.ts
+ *
+ * #1016 / #2932 / ADR-0055: DynamoDB トライアル履歴 repo 本実装の単体テスト。
+ *
+ * AWS SDK を vi.hoisted mock で置き換え、SQLite 実装 (sqlite/trial-history-repo.ts、挙動 SSOT) と
+ * 機能等価であることを method ごとに検証する:
+ *   - 正しい Command + key で send する (tenant partition への配置 / counter 採番)
+ *   - response を正しく型変換する (stripKeys / null backfill)
+ *   - SQLite 機能等価 (最新 1 件 / endDate>=today filter / conversion id 解決)
+ *
+ * 背景 (#2932 CRITICAL): 本 repo は GRANDFATHERED_STUBS (#1016) として全関数 no-op stub のまま
+ *   本番稼働しており、startTrial → insert() が永続せず trial 開始が偽 success になっていた。
+ *   本テストは本実装の機能等価性を回帰固定し、stub への後退を防ぐ。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const { mockSend, MockPutCommand, MockQueryCommand, MockUpdateCommand, MockScanCommand } =
+	vi.hoisted(() => {
+		const send = vi.fn();
+		class Cmd {
+			input: unknown;
+			constructor(input: unknown) {
+				this.input = input;
+			}
+		}
+		return {
+			mockSend: send,
+			MockPutCommand: class extends Cmd {},
+			MockQueryCommand: class extends Cmd {},
+			MockUpdateCommand: class extends Cmd {},
+			MockScanCommand: class extends Cmd {},
+		};
+	});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+	UpdateCommand: MockUpdateCommand,
+	ScanCommand: MockScanCommand,
+	// deleteByTenantId は bulk-delete.ts (BatchWriteCommand + QueryCommand) を動的 import する。
+	BatchWriteCommand: class {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	},
+}));
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/trial-history-repo');
+}
+
+const TENANT = 'tenant-1';
+
+/** tenant partition の DynamoDB trial history item を組み立てる (PK/SK + 属性)。 */
+function makeItem(over: Record<string, unknown> = {}): Record<string, unknown> {
+	const id = (over.id as number) ?? 1;
+	return {
+		PK: `T#${TENANT}#TRIAL`,
+		SK: `HIST#${String(id).padStart(8, '0')}`,
+		id,
+		tenantId: TENANT,
+		startDate: '2026-06-01',
+		endDate: '2026-06-08',
+		tier: 'standard',
+		source: 'user_initiated',
+		campaignId: null,
+		stripeSubscriptionId: null,
+		upgradeReason: null,
+		trialStartSource: null,
+		createdAt: '2026-06-01T00:00:00.000Z',
+		...over,
+	};
+}
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+// ============================================================
+// insert (永続の核心経路 — #2932 の本丸)
+// ============================================================
+
+describe('insert', () => {
+	it('counter 採番 → tenant partition に PutItem する (本番 startTrial 永続経路)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 42 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insert } = await loadRepo();
+		await insert({
+			tenantId: TENANT,
+			startDate: '2026-06-05',
+			endDate: '2026-06-12',
+			tier: 'standard',
+			source: 'user_initiated',
+		});
+
+		// nextId(counter) + Put の 2 回 send
+		expect(mockSend).toHaveBeenCalledTimes(2);
+
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.PK).toBe(`T#${TENANT}#TRIAL`);
+		expect(putCall.input.Item?.SK).toBe('HIST#00000042');
+		expect(putCall.input.Item?.id).toBe(42);
+		expect(putCall.input.Item?.tenantId).toBe(TENANT);
+		expect(putCall.input.Item?.startDate).toBe('2026-06-05');
+		expect(putCall.input.Item?.endDate).toBe('2026-06-12');
+		expect(putCall.input.Item?.tier).toBe('standard');
+		expect(putCall.input.Item?.source).toBe('user_initiated');
+		// conversion 列は null 初期化
+		expect(putCall.input.Item?.stripeSubscriptionId).toBeNull();
+		expect(putCall.input.Item?.upgradeReason).toBeNull();
+		expect(typeof putCall.input.Item?.createdAt).toBe('string');
+	});
+
+	it('campaignId / trialStartSource を保存する (null 既定)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		const { insert } = await loadRepo();
+		await insert({
+			tenantId: TENANT,
+			startDate: '2026-06-05',
+			endDate: '2026-06-12',
+			tier: 'family',
+			source: 'campaign',
+			campaignId: 'spring-2026',
+			trialStartSource: '/pricing',
+		});
+		const putCall = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.campaignId).toBe('spring-2026');
+		expect(putCall.input.Item?.trialStartSource).toBe('/pricing');
+		expect(putCall.input.Item?.tier).toBe('family');
+	});
+});
+
+// ============================================================
+// findLatestByTenant (trial 状態判定の hot path)
+// ============================================================
+
+describe('findLatestByTenant', () => {
+	it('tenant partition を逆順 Query Limit 1 で最新 1 件取得する', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [makeItem({ id: 9, source: 'admin_grant' })] });
+		const { findLatestByTenant } = await loadRepo();
+		const row = await findLatestByTenant(TENANT);
+
+		expect(row?.id).toBe(9);
+		expect(row?.source).toBe('admin_grant');
+		expect(row?.tenantId).toBe(TENANT);
+
+		const callArg = mockSend.mock.calls[0]?.[0] as {
+			input: {
+				KeyConditionExpression?: string;
+				ExpressionAttributeValues?: Record<string, string>;
+				ScanIndexForward?: boolean;
+				Limit?: number;
+			};
+		};
+		expect(callArg.input.KeyConditionExpression).toContain('PK = :pk');
+		expect(callArg.input.ExpressionAttributeValues?.[':pk']).toBe(`T#${TENANT}#TRIAL`);
+		expect(callArg.input.ExpressionAttributeValues?.[':prefix']).toBe('HIST#');
+		// ORDER BY id DESC LIMIT 1 と等価
+		expect(callArg.input.ScanIndexForward).toBe(false);
+		expect(callArg.input.Limit).toBe(1);
+	});
+
+	it('履歴が無いとき undefined を返す (未使用 = trial 非アクティブ)', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findLatestByTenant } = await loadRepo();
+		expect(await findLatestByTenant(TENANT)).toBeUndefined();
+	});
+
+	it('conversion 列が欠落した item を null backfill する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1, stripeSubscriptionId: undefined, upgradeReason: undefined })],
+		});
+		const { findLatestByTenant } = await loadRepo();
+		const row = await findLatestByTenant(TENANT);
+		expect(row?.stripeSubscriptionId).toBeNull();
+		expect(row?.upgradeReason).toBeNull();
+	});
+});
+
+// ============================================================
+// findActiveTrials (cron 通知対象、全 tenant 横断)
+// ============================================================
+
+describe('findActiveTrials', () => {
+	it('endDate >= today の filter で全 tenant 横断 Scan する', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 1, tenantId: 't-a' }), makeItem({ id: 2, tenantId: 't-b' })],
+		});
+		const { findActiveTrials } = await loadRepo();
+		const rows = await findActiveTrials();
+		expect(rows.map((r) => r.tenantId)).toEqual(['t-a', 't-b']);
+
+		const scanCall = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scanCall.input.FilterExpression).toContain('begins_with(SK, :prefix)');
+		expect(scanCall.input.FilterExpression).toContain('endDate >= :today');
+		expect(scanCall.input.ExpressionAttributeValues?.[':prefix']).toBe('HIST#');
+		expect(scanCall.input.ExpressionAttributeValues?.[':today']).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+	});
+
+	it('0 件のとき空配列を返す', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { findActiveTrials } = await loadRepo();
+		expect(await findActiveTrials()).toEqual([]);
+	});
+
+	it('#2842: LastEvaluatedKey で全ページを走査し Limit を付けない', async () => {
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [makeItem({ id: 1 })],
+				LastEvaluatedKey: { PK: 'cursor', SK: 'cursor' },
+			})
+			.mockResolvedValueOnce({ Items: [makeItem({ id: 2 })] });
+		const { findActiveTrials } = await loadRepo();
+		const rows = await findActiveTrials();
+		expect(rows).toHaveLength(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+
+		const firstScan = mockSend.mock.calls[0]?.[0] as { input: { Limit?: number } };
+		const secondScan = mockSend.mock.calls[1]?.[0] as {
+			input: { ExclusiveStartKey?: Record<string, unknown>; Limit?: number };
+		};
+		expect(firstScan.input.Limit).toBeUndefined();
+		expect(secondScan.input.ExclusiveStartKey).toEqual({ PK: 'cursor', SK: 'cursor' });
+		expect(secondScan.input.Limit).toBeUndefined();
+	});
+});
+
+// ============================================================
+// updateConversion (Stripe 本契約移行、id 解決経路)
+// ============================================================
+
+describe('updateConversion', () => {
+	it('id を Scan で解決し該当 item の conversion 列を SET する', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [{ PK: `T#${TENANT}#TRIAL`, SK: 'HIST#00000007' }] }) // scanKeyById
+			.mockResolvedValueOnce({}); // UpdateCommand
+
+		const { updateConversion } = await loadRepo();
+		await updateConversion({ id: 7, stripeSubscriptionId: 'sub_abc', upgradeReason: 'auto' });
+
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const scanCall = mockSend.mock.calls[0]?.[0] as {
+			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(scanCall.input.FilterExpression).toContain('id = :id');
+		expect(scanCall.input.ExpressionAttributeValues?.[':id']).toBe(7);
+		expect(scanCall.input.ExpressionAttributeValues?.[':prefix']).toBe('HIST#');
+
+		const updCall = mockSend.mock.calls[1]?.[0] as {
+			input: {
+				UpdateExpression?: string;
+				Key?: Record<string, unknown>;
+				ExpressionAttributeValues?: Record<string, unknown>;
+			};
+		};
+		expect(updCall.input.UpdateExpression).toContain('stripeSubscriptionId = :sub');
+		expect(updCall.input.UpdateExpression).toContain('upgradeReason = :reason');
+		expect(updCall.input.Key?.SK).toBe('HIST#00000007');
+		expect(updCall.input.ExpressionAttributeValues?.[':sub']).toBe('sub_abc');
+		expect(updCall.input.ExpressionAttributeValues?.[':reason']).toBe('auto');
+	});
+
+	it('該当 id 不在のとき Update を呼ばない (no-op、SQLite 0 row UPDATE と等価)', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] }); // 不在
+		const { updateConversion } = await loadRepo();
+		await updateConversion({ id: 99, stripeSubscriptionId: 'sub_x', upgradeReason: 'manual' });
+		expect(mockSend).toHaveBeenCalledTimes(1); // Scan のみ
+	});
+
+	it('#2842: 対象 id が先頭ページに無くても LastEvaluatedKey でページングして見つける', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { PK: 'c', SK: 'c' } })
+			.mockResolvedValueOnce({ Items: [{ PK: `T#${TENANT}#TRIAL`, SK: 'HIST#00000003' }] })
+			.mockResolvedValueOnce({}); // Update
+		const { updateConversion } = await loadRepo();
+		await updateConversion({ id: 3, stripeSubscriptionId: 'sub_y', upgradeReason: 'email_cta' });
+		expect(mockSend).toHaveBeenCalledTimes(3);
+		const secondScan = mockSend.mock.calls[1]?.[0] as {
+			input: { ExclusiveStartKey?: Record<string, unknown>; Limit?: number };
+		};
+		expect(secondScan.input.ExclusiveStartKey).toEqual({ PK: 'c', SK: 'c' });
+		expect(secondScan.input.Limit).toBeUndefined();
+	});
+});
+
+// ============================================================
+// deleteByTenantId (退会時削除、ADR-0049)
+// ============================================================
+
+describe('deleteByTenantId', () => {
+	it('tenant partition を exact PK Query して BatchWrite 削除する', async () => {
+		// bulk-delete.deleteItemsByExactPk: Query (keys) → BatchWrite
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [
+					{ PK: `T#${TENANT}#TRIAL`, SK: 'HIST#00000001' },
+					{ PK: `T#${TENANT}#TRIAL`, SK: 'HIST#00000002' },
+				],
+			})
+			.mockResolvedValueOnce({}); // BatchWrite
+
+		const { deleteByTenantId } = await loadRepo();
+		await deleteByTenantId(TENANT);
+
+		const queryCall = mockSend.mock.calls[0]?.[0] as {
+			input: {
+				KeyConditionExpression?: string;
+				ExpressionAttributeValues?: Record<string, unknown>;
+			};
+		};
+		expect(queryCall.input.KeyConditionExpression).toContain('PK = :pk');
+		expect(queryCall.input.ExpressionAttributeValues?.[':pk']).toBe(`T#${TENANT}#TRIAL`);
+	});
+
+	it('0 件のとき BatchWrite を呼ばない', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [] });
+		const { deleteByTenantId } = await loadRepo();
+		await deleteByTenantId(TENANT);
+		expect(mockSend).toHaveBeenCalledTimes(1); // Query のみ
+	});
+});
+
+// ============================================================
+// interface 適合 (SQLite との機能等価性 / stub 後退防止)
+// ============================================================
+
+describe('interface 適合 (ITrialHistoryRepo)', () => {
+	it('全メソッドを export している (stub に後退していない)', async () => {
+		const repo = await loadRepo();
+		for (const m of [
+			'findLatestByTenant',
+			'findActiveTrials',
+			'insert',
+			'updateConversion',
+			'deleteByTenantId',
+		]) {
+			expect(typeof (repo as Record<string, unknown>)[m]).toBe('function');
+		}
+	});
+
+	it('insert が no-op stub でない (採番 + 実 send する)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		const { insert } = await loadRepo();
+		await insert({
+			tenantId: TENANT,
+			startDate: '2026-06-05',
+			endDate: '2026-06-12',
+			tier: 'standard',
+			source: 'user_initiated',
+		});
+		// stub なら send 未呼出だった。本実装は採番 + Put で send する。
+		expect(mockSend).toHaveBeenCalled();
+	});
+
+	it('findLatestByTenant が固定 undefined stub でない (Query 結果を返す)', async () => {
+		mockSend.mockResolvedValueOnce({ Items: [makeItem({ id: 5 })] });
+		const { findLatestByTenant } = await loadRepo();
+		const row = await findLatestByTenant(TENANT);
+		// stub なら常に undefined だった。本実装は Query item を返す。
+		expect(row?.id).toBe(5);
+		expect(mockSend).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

本番 (cognito Lambda) で **trial 開始が完全に不能** だった CRITICAL バグを根治する。`trial-history-repo` (DynamoDB) が全関数 no-op stub のため、startTrial → insert() が永続せず action は偽 success(200) を返すが UI が trial 表示に変化しなかった。新課金体系 (カード不要 7 日 trial) の hero CTA 動線が死んでいた状態を復旧する。

## 関連 Issue

- Closes #2932
- 本実装パターン SSOT: #2824 (write stub 12 repo 全廃) / 直近 sibling #2848 (sibling-cheer) #2855 (cloud-export)
- 消化済 Issue: #1016 (trial history stub 撤廃)
- ブロック先解消: #2894 AC4 (trial→paid 実機) / EPIC #2897 残 scope checklist に追加済

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|---------|----------|-------------------|
| S1 | DynamoDB trial-history-repo 5 関数本実装 | `src/lib/server/db/dynamodb/trial-history-repo.ts` 全 5 関数 + key helper | unit `tests/unit/db/dynamodb-trial-history-repo.test.ts` 16 件 PASS |
| S2 | GRANDFATHERED_STUBS 除去 | `scripts/check-dynamodb-stub.mjs` の Map から trial-history-repo 行を削除 | `node scripts/check-dynamodb-stub.mjs` → OK (本実装を gate が直接検証) |
| S3 | 偽 success 防御 | `+page.server.ts:94` `fail(400)` 既出 + TrialBanner `use:enhance` + `invalidateAll` + reload で状態 self-communicate | E2E test 8 で reload 後も active 維持を assert (silent fail なし) |
| S4 | テスト (unit + E2E + 回帰) | 新規 unit 16 件 + `tests/e2e/trial-flow.spec.ts` に reload 後永続 assert 追加 | free ユーザー 3 テスト + setup 6 計 9 PASS (cleanup ログ "Removed 1 record" で insert 永続を実証) |
| DB 同期 | DB 設計書に DynamoDB key 設計追記 (ADR-0001) | `docs/design/08-データベース設計書.md` §trial_history に key 表追記 | diff 反映済 |

## 変更タイプ

- [x] バグ修正 (type:fix / priority:critical)

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dynamodb/trial-history-repo.ts` — stub → 本実装 (5 関数)
- `src/lib/server/db/dynamodb/keys.ts` — `trialHistoryKey` / `trialHistoryTenantPK` / `trialHistoryPrefix` + ENTITY_NAMES.trialHistory 追加
- `scripts/check-dynamodb-stub.mjs` — GRANDFATHERED_STUBS から trial-history-repo 除去
- `tests/unit/db/dynamodb-trial-history-repo.test.ts` — 新規 16 件
- `tests/e2e/trial-flow.spec.ts` — reload 後永続 assert 追加
- `docs/design/08-データベース設計書.md` — DynamoDB key 設計追記

SQLite / demo 実装は不変 (demo は ADR-0048 で意図的 stub のまま、scope 外)。

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/db/dynamodb-trial-history-repo.test.ts` → 16 PASS
- `npx vitest run tests/unit/db/` → 402 PASS (回帰なし)
- `npx vitest run src/lib/server/services/ tests/unit/services/trial-service.test.ts trial-notification-service.test.ts demo/stub-repos.test.ts` → 79+39 PASS
- `npx playwright test --config playwright.cognito-dev.config.ts trial-flow --grep "free ユーザー"` → 9 PASS (開始 → active → reload 後永続 + subscription 表示)
- `node scripts/check-dynamodb-stub.mjs` → OK / `npx biome check <changed>` → clean / `npx svelte-check` → 変更ファイル 0 error (既存 infra/ aws-cdk-lib noise のみ)

## スクリーンショット / ビジュアルデモ

UI 変更なし (バックエンド repo + E2E + docs のみ)。trial 開始 → active 切替の動作は `trial-flow.spec.ts` の E2E goal 完遂 (act → outcome + reload 永続) で検証。

## コード品質セルフレビュー (#1481)

- #2824 確立パターン (sibling-cheer / message-repo の id 解決 Scan、#2842 paging 教訓) に完全準拠
- GSI 追加せず単一 partition Query / 低頻度 Scan で完結 (ADR-0010 Pre-PMF 過剰防衛回避)
- key helper / counter / stripKeys / bulk-delete は既存共通層を再利用 (独自実装最小)

## 横展開・影響波及チェック

- 残 GRANDFATHERED_STUBS: `evaluation-repo.ts` (#1014) / `message-repo.ts` (#1015) ※ message-repo は #2838 で本番実装済だが GRANDFATHERED 表記が残存 (本 PR scope 外、別 Issue で整理推奨)。両者とも課金/コア trial 動線に直接影響なし
- demo repo (ADR-0048 意図的 stub) は不変

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。既存 trial データは本実装後の新規 insert から永続 (過去の no-op 期間に「開始」したつもりのユーザーは履歴未保存のため再開始可能 = 正しい挙動)
- `findActiveTrials` を GSI でなく Scan で実装した根拠 (日次 cron 1 回 / 全 tenant 横断 / cancellation-reason と同 Pre-PMF 方針) のレビュー希望

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] AC 全完了 / 提案全実装
- [x] ADR-0002 critical 5 要件: E2E 回帰 (trial-flow 9 PASS) / AC 全完了 / 提案全実装 / 5 age mode (admin 課金画面のみで子供 age mode 非依存、影響なし) / 直近 30 日重複変更チェック (trial-history-repo は #2824 系で grandfathered 残存のみ、重複変更なし)
- [x] biome / svelte-check / vitest / check-dynamodb-stub PASS
- [x] 設計書同期 (DB 設計書)

## QM レビュー結果

(QM レビュー待ち)
