### PR TITLE
infra: #2867 監査 run finding pipeline + workflow_dispatch 手動実行

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -272,11 +272,13 @@ REDEMPT
 REVD
 Roboto
 sakura
+SARIF
 scrollbar
 scrshot
 Segoe
 seikatsu
 selfhost
+selftest
 semgrep
 SES
 setsubun

--- a/.github/workflows/audit-run.yml
+++ b/.github/workflows/audit-run.yml
@@ -1,0 +1,194 @@
+# 外部品質監査チーム — 機械検証 audit run (手動トリガー)
+#
+# EPIC #2861 / B4 = #2867。audit-manager (Claude session) が監査 run を回す際、
+# **機械検証可能項目**だけを CI で実行し artifact 化する workflow。
+#
+# 設計境界 (重要):
+#   - schedule trigger は付けない (daily 自動化 = C3 = #2871 の範囲、EPIC P2)。本 workflow は
+#     workflow_dispatch のみ (手動 baseline / 統合 run 用)。
+#   - hard gate (= CI が block) は rules-based 自動チェックのみ (EPIC 設計原則 1)。LLM 判定
+#     (policy-compliance / adversarial / 8 領域 finding) は CI に載せず audit-manager が advisory
+#     として扱う。本 workflow は finding を「起票」しない (起票は audit-manager 専権、ADR-0056 §E)。
+#   - 各 job は continue-on-error で全件発露し、結果を artifact に集める (1 件の fail で残りを
+#     止めない。「全件発露 → filter → 起票」運用、audit-team.md §3.6)。
+#
+# 役割定義 SSOT: docs/sessions/audit-team.md / .claude/agents/audit-manager.md
+# pipeline 詳細: scripts/audit/README.md
+name: Audit Run (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: 'baseline (main 全体) | integration (develop→main 差分)'
+        required: true
+        type: choice
+        default: baseline
+        options:
+          - baseline
+          - integration
+      run_id:
+        description: 'run 識別子 (例: baseline-20260610 / 2950-20260610)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  # 機械検証 ① a11y (axe-core WCAG 2.2 AA、ci.yml の a11y job を再利用)
+  a11y-scan:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+      - name: Install Playwright deps (cached browsers)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+      - name: Build for E2E (preview mode)
+        run: npm run build
+      - name: Run a11y critical CUJ scan (WCAG 2.2 AA)
+        env:
+          PARENT_GATE_COOKIE_SECRET: e2e-test-parent-gate-secret-do-not-use
+        run: npx playwright test tests/e2e/a11y-critical-cuj.spec.ts
+      - name: Upload a11y artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: audit-${{ inputs.run_id }}-a11y
+          path: test-results/
+          retention-days: 30
+
+  # 機械検証 ② LP メトリクス (lp-metrics.yml の measure-lp-dimensions を再利用)
+  lp-metrics:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Measure LP dimensions (forbidden terms / height ratchet)
+        env:
+          SKIP_SCREENSHOT_EXISTENCE_CHECK: '1'
+        run: node scripts/measure-lp-dimensions.mjs | tee lp-metrics.txt
+      - name: Upload LP metrics artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: audit-${{ inputs.run_id }}-lp-metrics
+          path: lp-metrics.txt
+          retention-days: 30
+
+  # 機械検証 ③ rules-based check 系 scripts (SSOT 整合 / 用語 / hardcoded strings 等)
+  rules-based-checks:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Run rules-based check scripts (全件発露、1 件 fail で止めない)
+        run: |
+          set +e
+          {
+            echo "# rules-based checks ($(date -u +%FT%TZ))"
+            for chk in \
+              "node scripts/check-hardcoded-strings.mjs" \
+              "node scripts/check-no-plan-literals.mjs" \
+              "node scripts/check-internal-terms.mjs" \
+              "node scripts/check-forbidden-terms.mjs"; do
+              echo ""
+              echo "## $chk"
+              $chk
+              echo "exit: $?"
+            done
+          } | tee rules-based-checks.txt
+      - name: Upload rules-based checks artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: audit-${{ inputs.run_id }}-rules-based-checks
+          path: rules-based-checks.txt
+          retention-days: 30
+
+  # 機械検証 ④ vitest coverage (ADR-0005 ratchet — テスト品質領域)
+  coverage:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Vitest with coverage
+        run: npx vitest run --coverage --coverage.reporter=json-summary --coverage.reporter=text | tee coverage.txt
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: audit-${{ inputs.run_id }}-coverage
+          path: |
+            coverage.txt
+            coverage/coverage-summary.json
+          retention-days: 30
+
+  # finding pipeline 検証 — evidence schema / dedup / severity filter の unit test を実行し、
+  # pipeline CLI が動作することを保証する (この job は hard gate: pipeline 自体が壊れたら止める)
+  pipeline-selftest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Pipeline pure-function unit tests
+        run: npx vitest run tests/unit/audit/
+      - name: Pipeline CLI smoke (sample fixture → 集約レポート)
+        # 固定 fixture (scripts/audit/fixtures/sample-evidence.json) を evidence dir に置き、
+        # verify → run-pipeline --strict が exit 0 になることを確認する (pipeline 配線の健全性)。
+        run: |
+          mkdir -p tmp/audit-evidence
+          cp scripts/audit/fixtures/sample-evidence.json tmp/audit-evidence/sample.json
+          node scripts/audit/verify-audit-evidence.mjs --file tmp/audit-evidence/sample.json
+          node scripts/audit/run-pipeline.mjs --run-id "${{ inputs.run_id }}" --scope "${{ inputs.scope }}" --strict
+      - name: Upload pipeline report artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: audit-${{ inputs.run_id }}-pipeline-report
+          path: tmp/audit-run-*.md
+          retention-days: 30

--- a/scripts/audit/README.md
+++ b/scripts/audit/README.md
@@ -1,0 +1,107 @@
+# scripts/audit/ — 監査 run finding pipeline
+
+> EPIC #2861 / B4 = #2867。外部品質監査チームの **手動 audit run** で
+> finding → 重複統合 → severity filter → 起票候補 の機械処理部分を担う pure function
+> + CLI 群。役割定義の SSOT は [docs/sessions/audit-team.md](../../docs/sessions/audit-team.md)、
+> 手順骨格の SSOT は [.claude/agents/audit-manager.md](../../.claude/agents/audit-manager.md)。
+> 本 README は重複定義せず、それらを前提に「dispatch 手順」と「pipeline CLI の使い方」のみ記す。
+
+## 役割分担 (hard gate は rules-based のみ — EPIC 設計原則 1)
+
+| 段 | 主体 | 実装 |
+|---|---|---|
+| dispatch (8 領域 + ポリシー準拠判定 skill 起動) | audit-manager (Claude session) が Agent tool で skill を起動 | 人手 / LLM (CI に載せない) |
+| 機械検証可能項目 (axe / lp-metrics / check 系 / coverage) | CI | `.github/workflows/audit-run.yml` (workflow_dispatch) |
+| 全件発露 → schema verify → 重複統合 → severity filter | CI / CLI (rules-based) | `scripts/audit/run-pipeline.mjs` |
+| ポリシー準拠 filter (誤起票防止) | audit-manager が policy-compliance skill で判定 | LLM (CI に載せない、advisory) |
+| 起票 / approve / merge (不可逆 action) | audit-manager **専権** | LLM + gh (CI に載せない) |
+
+LLM 判定 (policy filter / adversarial) を **hard gate にしない**のは EPIC 設計原則 1
+(GitHub Copilot code review「AI は required approval にカウントしない」/ Anthropic
+「LLM-as-judge is generally not robust」整合)。CI が block するのは rules-based のみ。
+
+## dispatch 手順 (audit-manager session が実施)
+
+詳細手順骨格は [audit-manager.md §E run flow](../../.claude/agents/audit-manager.md) を SSOT とする。要約:
+
+1. **対象 run を確定** — baseline run は `integration_pr=0` (main 全体、差分非依存)。統合 run は対象 develop→main PR 番号。
+2. **8 領域 + ポリシー準拠判定を dispatch** — 再利用 skill / workflow ([audit-team.md §3.2](../../docs/sessions/audit-team.md)):
+   - 技術調査 = `impact-analysis` / `regression-check`
+   - プロダクト実装調査 = `pr-review` / `regression-check`
+   - ユーザビリティ・a11y = `cognitive-walkthrough` / `customer-voice` / `age-mode-check` / axe-core job
+   - セキュリティ = `security-scan.yml` / codeql / dependency-review
+   - パフォーマンス = `lp-metrics` / visual regression / `cost-review`
+   - テスト品質 = `flake-hunt`
+   - 競合調査 = `competitive-research` (一次情報 URL 必須)
+   - ポリシー準拠判定 = `policy-compliance`
+   - 問題起票 = `issue-triage`
+3. **各 subagent は finding を structured JSON で `tmp/audit-evidence/<team>.json` に Write**
+   ([evidence schema](#evidence-schema))。
+4. **機械検証項目は CI で回す** — `.github/workflows/audit-run.yml` を `workflow_dispatch` で起動し
+   artifact を取得。
+5. **pipeline を実行** — `scripts/audit/run-pipeline.mjs` で全 evidence を集約し `tmp/audit-run-<date>.md` を生成。
+6. **audit-manager が後段を実施** — ポリシー準拠 filter → adversarial dispatch → 起票 / merge 判定
+   (不可逆 action は orchestrator 専権、[audit-manager.md §C/§F](../../.claude/agents/audit-manager.md))。
+
+## evidence schema
+
+`tmp/audit-evidence/<team>.json` の最小 field + SARIF 2.1.0 互換 field。SSOT は
+[audit-manager.md §B](../../.claude/agents/audit-manager.md) と
+[`scripts/audit/evidence-schema.mjs`](evidence-schema.mjs)。
+
+```jsonc
+{
+  "run_id": "baseline-20260610",
+  "integration_pr": 0,                 // baseline は 0
+  "team": "security",                  // 許容値は evidence-schema.mjs VALID_TEAMS
+  "findings": [
+    {
+      "id": "security-1",              // 重複統合のキー
+      "title": "<1 行サマリ>",
+      "location": "src/lib/server/auth/foo.ts:42",
+      "severity": 3,                    // 1-2=軽微(backlog) / 3-4=重大(起票候補)
+      "policy_candidate": false,
+      "detail": "<再現手順 / 根拠 / 影響>",
+      "evidence_urls": [],             // competitive / audit-manager-cuj は必須
+
+      // --- SARIF 2.1.0 互換 (EPIC 設計原則 4 — dedup 安定化) ---
+      "ruleId": "authz/missing-tenant-check",
+      "level": "error",                // none|note|warning|error
+      "partialFingerprints": { "primary": "authz/missing-tenant-check::src/lib/server/auth/foo.ts" },
+      "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/lib/server/auth/foo.ts" } } }]
+    }
+  ]
+}
+```
+
+- **dedup は `ruleId + 正規化 location`** (= partialFingerprints) ベース。文字列一致ではないため
+  行番号ズレ / 大文字小文字差を吸収する ([dedup.mjs](dedup.mjs))。
+- `competitive` / `audit-manager-cuj` は `evidence_urls` 必須。欠落は自動棄却 (幻覚 finding 防止)。
+
+## CLI
+
+```bash
+# 単一 evidence の schema 物理 verify (audit-manager が dispatch 後に実行)
+node scripts/audit/verify-audit-evidence.mjs --file tmp/audit-evidence/security.json
+
+# 全 evidence を集約 → tmp/audit-run-<date>.md 生成
+node scripts/audit/run-pipeline.mjs --run-id baseline-20260610 --scope baseline
+
+# CI gate: schema 不充足 evidence が 1 件でもあれば exit 1
+node scripts/audit/run-pipeline.mjs --run-id baseline-20260610 --strict
+```
+
+## CI 共有 fixture
+
+`scripts/audit/fixtures/sample-evidence.json` は `audit-run.yml` の `pipeline-selftest` job
+(CLI smoke) と `tests/unit/audit/evidence-schema.test.ts` の両方が参照する固定 evidence。
+schema が変わっても fixture が追従していなければ unit test 側で fail し、CI smoke の偽 PASS を防ぐ。
+
+## 局所テスト
+
+```bash
+npx vitest run tests/unit/audit/
+```
+
+pure function (schema 検証 / dedup / severity filter / report 組み立て) の unit test。
+I/O (CLI) は薄い wrapper のため pure function の test でロジックを担保する。

--- a/scripts/audit/aggregate-report.mjs
+++ b/scripts/audit/aggregate-report.mjs
@@ -1,0 +1,121 @@
+/**
+ * scripts/audit/aggregate-report.mjs (EPIC #2861 / B4 = #2867)
+ *
+ * 集約レポート (`tmp/audit-run-<date>.md`) の markdown を組み立てる pure function。
+ * AC4 のログ形式 = finding 件数 / 重複統合後 / 棄却 (severity 未満 backlog) /
+ * 起票候補件数 を人間可読に出力する (audit-team.md §3.6 / audit-manager.md §E)。
+ *
+ * 本 module は markdown 文字列を返すのみ (file write は run-pipeline.mjs 側)。
+ * vitest: tests/unit/audit/aggregate-report.test.ts
+ */
+
+/** @param {any} f */
+function fmtFindingRow(f) {
+	const sev = Number.isInteger(f?.severity) ? f.severity : '?';
+	const team = f?.team ?? '?';
+	const rule = f?.ruleId ?? '?';
+	const title = (f?.title ?? '').replace(/\|/g, '\\|');
+	const loc = (f?.location ?? '').replace(/\|/g, '\\|');
+	const mergedCount = Array.isArray(f?.merged_from) ? f.merged_from.length : 1;
+	return `| ${f?.id ?? '?'} | ${team} | ${rule} | ${sev} | ${mergedCount} | ${title} | ${loc} |`;
+}
+
+/**
+ * 集約レポート markdown を組み立てる。
+ *
+ * @param {object} input
+ * @param {string} input.runId run 識別子 (`<pr>-<YYYYMMDD>` または `baseline-<YYYYMMDD>`)
+ * @param {string} input.scope `baseline` | `integration`
+ * @param {number} input.integrationPr 統合 PR 番号 (baseline は 0)
+ * @param {string} input.generatedAt ISO 8601 UTC
+ * @param {object} input.stats
+ * @param {number} input.stats.rawFindingCount       全件発露の総数
+ * @param {number} input.stats.mergedCount           重複統合後件数
+ * @param {number} input.stats.duplicatesRemoved     統合で消えた重複数
+ * @param {number} input.stats.escalatedCount        severity 3-4 (起票候補 = 次段へ)
+ * @param {number} input.stats.backlogCount          severity 1-2 (backlog 蓄積のみ)
+ * @param {Array<string>} input.rejectedEvidence     schema 不充足 / URL 欠落で自動棄却した記録
+ * @param {Array<object>} input.escalated            severity 3-4 finding 配列
+ * @param {Array<object>} input.backlog              severity 1-2 finding 配列
+ * @returns {string} markdown
+ */
+export function buildAggregateReport(input) {
+	const { runId, scope, integrationPr, generatedAt, stats, rejectedEvidence, escalated, backlog } =
+		input;
+
+	const lines = [];
+	lines.push(`# 監査 run 集約レポート — ${runId}`);
+	lines.push('');
+	lines.push(
+		'> EPIC #2861 / B4 = #2867 — finding pipeline (全件発露 → 重複統合 → severity filter) の機械集約結果。',
+	);
+	lines.push(
+		'> ポリシー準拠 filter (LLM 判定) と起票実行は audit-manager orchestrator が本レポートを受けて実施する',
+	);
+	lines.push(
+		'> (audit-team.md §3.6 / audit-manager.md §E)。本ファイルは CI / pipeline が生成する rules-based 集約のみ。',
+	);
+	lines.push('');
+	lines.push('## メタ');
+	lines.push('');
+	lines.push('| 項目 | 値 |');
+	lines.push('|---|---|');
+	lines.push(`| run_id | ${runId} |`);
+	lines.push(`| scope | ${scope} |`);
+	lines.push(
+		`| integration_pr | ${integrationPr === 0 ? '0 (baseline / 差分非依存)' : `#${integrationPr}`} |`,
+	);
+	lines.push(`| generated_at | ${generatedAt} |`);
+	lines.push('');
+	lines.push('## 件数サマリ (AC4 ログ形式)');
+	lines.push('');
+	lines.push('| 指標 | 件数 |');
+	lines.push('|---|---|');
+	lines.push(`| 全件発露 (raw findings) | ${stats.rawFindingCount} |`);
+	lines.push(`| 重複統合後 | ${stats.mergedCount} |`);
+	lines.push(`| 重複統合で除去 | ${stats.duplicatesRemoved} |`);
+	lines.push(`| 起票候補 (severity 3-4 → 次段 policy filter へ) | ${stats.escalatedCount} |`);
+	lines.push(`| backlog 蓄積のみ (severity 1-2) | ${stats.backlogCount} |`);
+	lines.push(`| 自動棄却 (schema 不充足 / URL 欠落) | ${rejectedEvidence.length} |`);
+	lines.push('');
+
+	lines.push('## 起票候補 (severity 3-4 — ポリシー準拠 filter 未通過)');
+	lines.push('');
+	lines.push(
+		'> 以下は **起票確定ではない**。audit-manager が policy-compliance skill で誤起票 filter を',
+	);
+	lines.push(
+		'> 通し、`policy_compliant=false` のもののみを issue-triage 経由で起票する (audit-team.md §3.6 [4][5])。',
+	);
+	lines.push('');
+	if (escalated.length === 0) {
+		lines.push('_(該当なし)_');
+	} else {
+		lines.push('| id | team | ruleId | severity | 統合数 | title | location |');
+		lines.push('|---|---|---|---|---|---|---|');
+		for (const f of escalated) lines.push(fmtFindingRow(f));
+	}
+	lines.push('');
+
+	lines.push('## backlog (severity 1-2 — 蓄積のみ、起票しない)');
+	lines.push('');
+	if (backlog.length === 0) {
+		lines.push('_(該当なし)_');
+	} else {
+		lines.push('| id | team | ruleId | severity | 統合数 | title | location |');
+		lines.push('|---|---|---|---|---|---|---|');
+		for (const f of backlog) lines.push(fmtFindingRow(f));
+	}
+	lines.push('');
+
+	lines.push('## 自動棄却 (無言棄却しない — 理由を記録)');
+	lines.push('');
+	if (rejectedEvidence.length === 0) {
+		lines.push('_(該当なし)_');
+	} else {
+		for (const r of rejectedEvidence) lines.push(`- ${r}`);
+	}
+	lines.push('');
+
+	return lines.join('\n');
+}

--- a/scripts/audit/dedup.mjs
+++ b/scripts/audit/dedup.mjs
@@ -1,0 +1,89 @@
+/**
+ * scripts/audit/dedup.mjs (EPIC #2861 / B4 = #2867)
+ *
+ * finding 重複統合 (audit-team.md §3.6 [2] / audit-manager.md §E [3])。
+ * 文字列一致ではなく「ruleId + 正規化 location」= partialFingerprints ベースで
+ * 同一根本原因の finding を 1 件にマージする (EPIC 設計原則 4)。
+ *
+ * pure function (副作用なし)。vitest: tests/unit/audit/dedup.test.ts
+ *
+ * 関連:
+ *   - scripts/audit/evidence-schema.mjs (computeFingerprint を再利用)
+ *   - .claude/agents/audit-manager.md §E [3] 重複統合
+ */
+
+import { computeFingerprint } from './evidence-schema.mjs';
+
+/**
+ * severity の大きい finding を「代表」に採る際の比較。
+ * 同 severity なら最初に出現したものを代表とする (安定ソート相当)。
+ * @param {any} a
+ * @param {any} b
+ * @returns {any} 代表として残す finding
+ */
+function pickRepresentative(a, b) {
+	const sa = Number.isInteger(a?.severity) ? a.severity : 0;
+	const sb = Number.isInteger(b?.severity) ? b.severity : 0;
+	return sb > sa ? b : a;
+}
+
+/**
+ * finding 配列を fingerprint で重複統合する。
+ *
+ * - 同一 fingerprint の finding 群は 1 件 (代表) に集約する。
+ * - 代表は最大 severity の finding。集約された finding の出典 (team / id) を
+ *   `merged_from` に列挙し、無言マージを避ける (証跡保持)。
+ * - 代表の severity は群内最大に引き上げる (重大度の取りこぼし防止)。
+ *
+ * @param {Array<{ team: string, finding: any }>} taggedFindings
+ *   各 finding に出所 team を付与した配列 (run-pipeline 側で flatten 済み)
+ * @returns {{
+ *   merged: Array<any>,
+ *   inputCount: number,
+ *   mergedCount: number,
+ *   duplicatesRemoved: number,
+ * }}
+ */
+export function dedupeFindings(taggedFindings) {
+	const inputCount = taggedFindings.length;
+	/** @type {Map<string, any>} */
+	const byFingerprint = new Map();
+
+	for (const { team, finding } of taggedFindings) {
+		const fp = computeFingerprint(finding);
+		const origin = { team, id: finding.id };
+
+		if (!byFingerprint.has(fp)) {
+			byFingerprint.set(fp, {
+				...finding,
+				team,
+				fingerprint: fp,
+				merged_from: [origin],
+				severity: Number.isInteger(finding.severity) ? finding.severity : 0,
+			});
+			continue;
+		}
+
+		const existing = byFingerprint.get(fp);
+		const rep = pickRepresentative(existing, finding);
+		const maxSeverity = Math.max(
+			existing.severity,
+			Number.isInteger(finding.severity) ? finding.severity : 0,
+		);
+		byFingerprint.set(fp, {
+			// 代表 finding の本文を採用しつつ、team / fingerprint / merged_from / severity を維持
+			...(rep === existing ? existing : { ...finding, team }),
+			fingerprint: fp,
+			severity: maxSeverity,
+			merged_from: [...existing.merged_from, origin],
+		});
+	}
+
+	const merged = [...byFingerprint.values()];
+	return {
+		merged,
+		inputCount,
+		mergedCount: merged.length,
+		duplicatesRemoved: inputCount - merged.length,
+	};
+}

--- a/scripts/audit/evidence-schema.mjs
+++ b/scripts/audit/evidence-schema.mjs
@@ -1,0 +1,207 @@
+/**
+ * scripts/audit/evidence-schema.mjs (EPIC #2861 / B4 = #2867)
+ *
+ * 監査 run の structured JSON evidence (`tmp/audit-evidence/<run-id>.json`) を
+ * 検証する pure function 群。`.claude/agents/audit-manager.md` §B の evidence schema
+ * (最小 field) に **SARIF 2.1.0 互換 field (ruleId / level / partialFingerprints /
+ * locations)** を加えたものを SSOT とする (EPIC 設計原則 4 — dedup 安定化)。
+ *
+ * 設計判断 (OSS 先調査 ADR-0014):
+ *   SARIF 互換は「full SARIF report file を吐く」ことではなく「finding に dedup 用の
+ *   少数 field を持たせる」ことが目的。`node-sarif-builder` は full report builder の
+ *   ため本段では過剰。schema 整合のみを pure function で検証し、C/E phase で SARIF
+ *   emitter を導入する際に `node-sarif-builder` 採用を再評価する (PR body に記録)。
+ *
+ * 本 module は副作用を持たない (I/O は run-pipeline.mjs / verify-audit-evidence.mjs 側)。
+ * vitest unit test: tests/unit/audit/evidence-schema.test.ts
+ *
+ * 関連:
+ *   - .claude/agents/audit-manager.md §B (evidence schema SSOT)
+ *   - docs/sessions/audit-team.md §3.1 / §3.6 (チーム構成 / 棄却 flow)
+ *   - scripts/verify-adversarial-output.mjs (verify CLI の既存パターン)
+ */
+
+/** evidence の `team` に許容される値 (audit-manager.md §B) */
+export const VALID_TEAMS = Object.freeze([
+	'competitive',
+	'tech',
+	'product',
+	'usability-a11y',
+	'security',
+	'performance',
+	'test-quality',
+	'issue-draft',
+	'policy-compliance',
+	'audit-manager-cuj',
+]);
+
+/** SARIF 2.1.0 `level` に揃える finding level (severity とは別軸の表示用) */
+export const VALID_SARIF_LEVELS = Object.freeze(['none', 'note', 'warning', 'error']);
+
+/** 一次情報 URL を必須とする team (URL 欠落 finding は自動棄却、audit-manager.md §B / §D) */
+export const URL_REQUIRED_TEAMS = Object.freeze(['competitive', 'audit-manager-cuj']);
+
+const SEVERITY_MIN = 1;
+const SEVERITY_MAX = 4;
+
+/** @param {unknown} v */
+function isNonEmptyString(v) {
+	return typeof v === 'string' && v.trim().length > 0;
+}
+
+/**
+ * location 文字列を dedup 用に正規化する。
+ * - 前後空白除去 / 連続空白を 1 つに / Windows 区切り `\` を `/` に統一
+ * - 末尾の行番号 `:123` や `:12:5` を除去 (同一箇所の行ズレを同一視するため)
+ * - 小文字化 (path の大文字小文字差を吸収)
+ *
+ * 文字列一致でなく「ルール + 正規化位置」で重複を測るための前処理 (EPIC 設計原則 4)。
+ * @param {any} location
+ * @returns {string}
+ */
+export function normalizeLocation(location) {
+	if (!isNonEmptyString(location)) return '';
+	return location
+		.trim()
+		.replace(/\\/g, '/')
+		.replace(/:\d+(:\d+)?\s*$/, '')
+		.replace(/\s+/g, ' ')
+		.toLowerCase();
+}
+
+/**
+ * finding の dedup fingerprint を算出する。
+ * SARIF partialFingerprints の思想を踏襲し「ruleId + 正規化 location」を結合する。
+ * finding が `partialFingerprints.primary` を明示していればそれを優先採用する
+ * (subagent 側が安定 fingerprint を持っている場合の尊重)。
+ *
+ * @param {any} finding 未検証の外部 JSON finding
+ * @returns {string} 重複統合のキー
+ */
+export function computeFingerprint(finding) {
+	if (
+		finding &&
+		typeof finding === 'object' &&
+		finding.partialFingerprints &&
+		typeof finding.partialFingerprints === 'object' &&
+		isNonEmptyString(finding.partialFingerprints.primary)
+	) {
+		return finding.partialFingerprints.primary.trim().toLowerCase();
+	}
+	const ruleId = isNonEmptyString(finding?.ruleId) ? finding.ruleId.trim().toLowerCase() : '';
+	const loc = normalizeLocation(finding?.location);
+	return `${ruleId}::${loc}`;
+}
+
+/**
+ * 1 件の finding を schema 検証する。
+ * @param {any} finding 未検証の外部 JSON finding
+ * @param {string} team 親 evidence の team (URL 必須判定に使う)
+ * @returns {string[]} 違反メッセージ配列 (空 = 適合)
+ */
+export function validateFinding(finding, team) {
+	const errors = [];
+	if (finding === null || typeof finding !== 'object' || Array.isArray(finding)) {
+		return ['finding はオブジェクトである必要があります'];
+	}
+
+	// --- 最小 field (audit-manager.md §B) ---
+	if (!isNonEmptyString(finding.id)) errors.push('id が必須 (重複統合のキー)');
+	if (!isNonEmptyString(finding.title)) errors.push('title が必須');
+	if (!isNonEmptyString(finding.location)) errors.push('location が必須');
+	if (!isNonEmptyString(finding.detail)) errors.push('detail が必須');
+
+	if (
+		!Number.isInteger(finding.severity) ||
+		finding.severity < SEVERITY_MIN ||
+		finding.severity > SEVERITY_MAX
+	) {
+		errors.push(
+			`severity は ${SEVERITY_MIN}-${SEVERITY_MAX} の整数 (受領: ${JSON.stringify(finding.severity)})`,
+		);
+	}
+
+	if (typeof finding.policy_candidate !== 'boolean') {
+		errors.push('policy_candidate は boolean が必須');
+	}
+
+	// --- SARIF 2.1.0 互換 field (EPIC 設計原則 4) ---
+	if (!isNonEmptyString(finding.ruleId)) {
+		errors.push('ruleId が必須 (SARIF 互換 — dedup 安定化)');
+	}
+	if (!VALID_SARIF_LEVELS.includes(finding.level)) {
+		errors.push(`level は ${VALID_SARIF_LEVELS.join(' / ')} のいずれか (SARIF 互換)`);
+	}
+	if (finding.partialFingerprints !== undefined) {
+		if (
+			finding.partialFingerprints === null ||
+			typeof finding.partialFingerprints !== 'object' ||
+			Array.isArray(finding.partialFingerprints)
+		) {
+			errors.push('partialFingerprints は object (省略可、指定時は { primary: string } 形式)');
+		} else if (
+			finding.partialFingerprints.primary !== undefined &&
+			!isNonEmptyString(finding.partialFingerprints.primary)
+		) {
+			errors.push('partialFingerprints.primary は非空文字列');
+		}
+	}
+	if (!Array.isArray(finding.locations) || finding.locations.length === 0) {
+		errors.push('locations は 1 件以上の配列 (SARIF 互換 — physical location)');
+	}
+
+	// --- 一次情報 URL (competitive / cuj は必須) ---
+	const urls = finding.evidence_urls;
+	if (urls !== undefined && !Array.isArray(urls)) {
+		errors.push('evidence_urls は配列');
+	}
+	if (URL_REQUIRED_TEAMS.includes(team)) {
+		if (!Array.isArray(urls) || urls.filter(isNonEmptyString).length === 0) {
+			errors.push(
+				`team=${team} は evidence_urls に一次情報 URL が 1 件以上必須 (URL 欠落は自動棄却)`,
+			);
+		}
+	}
+
+	return errors;
+}
+
+/**
+ * evidence file 全体 (1 領域分) を schema 検証する。
+ * @param {any} evidence parse 済みの未検証 JSON
+ * @returns {{ ok: boolean, errors: string[], findingCount: number }}
+ */
+export function validateEvidence(evidence) {
+	const errors = [];
+	if (evidence === null || typeof evidence !== 'object' || Array.isArray(evidence)) {
+		return {
+			ok: false,
+			errors: ['evidence は JSON オブジェクトである必要があります'],
+			findingCount: 0,
+		};
+	}
+
+	if (!isNonEmptyString(evidence.run_id)) errors.push('run_id が必須');
+	if (!Number.isInteger(evidence.integration_pr) || evidence.integration_pr < 0) {
+		errors.push('integration_pr は 0 以上の整数 (baseline run は 0 可)');
+	}
+	if (!VALID_TEAMS.includes(evidence.team)) {
+		errors.push(
+			`team は許容値のいずれか: ${VALID_TEAMS.join(' / ')} (受領: ${JSON.stringify(evidence.team)})`,
+		);
+	}
+
+	const findings = evidence.findings;
+	if (!Array.isArray(findings)) {
+		errors.push('findings は配列が必須');
+		return { ok: errors.length === 0, errors, findingCount: 0 };
+	}
+
+	findings.forEach((f, i) => {
+		for (const e of validateFinding(f, evidence.team)) {
+			errors.push(`findings[${i}] (${f?.id ?? 'no-id'}): ${e}`);
+		}
+	});
+
+	return { ok: errors.length === 0, errors, findingCount: findings.length };
+}

--- a/scripts/audit/fixtures/sample-evidence.json
+++ b/scripts/audit/fixtures/sample-evidence.json
@@ -1,0 +1,22 @@
+{
+	"run_id": "ci-smoke",
+	"integration_pr": 0,
+	"team": "security",
+	"findings": [
+		{
+			"id": "sample-1",
+			"title": "smoke finding (CI self-test fixture)",
+			"location": "src/lib/server/foo.ts:1",
+			"severity": 3,
+			"policy_candidate": false,
+			"detail": "pipeline CLI smoke 用の固定 finding。audit-run.yml の pipeline-selftest job と evidence-schema unit test が共有する。",
+			"evidence_urls": [],
+			"ruleId": "smoke/rule",
+			"level": "error",
+			"partialFingerprints": { "primary": "smoke/rule::src/lib/server/foo.ts" },
+			"locations": [
+				{ "physicalLocation": { "artifactLocation": { "uri": "src/lib/server/foo.ts" } } }
+			]
+		}
+	]
+}

--- a/scripts/audit/run-pipeline.mjs
+++ b/scripts/audit/run-pipeline.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+/**
+ * scripts/audit/run-pipeline.mjs (EPIC #2861 / B4 = #2867)
+ *
+ * finding pipeline の機械実行部分 (I/O 層) を束ねる CLI。
+ * `tmp/audit-evidence/*.json` の領域別 evidence を読み込み、pure function module
+ * (evidence-schema / dedup / severity-filter / aggregate-report) を順に適用して
+ * 集約レポート `tmp/audit-run-<date>.md` を生成する (AC3 / AC4)。
+ *
+ * pipeline (audit-team.md §3.6 / audit-manager.md §E の機械化可能段):
+ *   [1] 全件発露 (evidence file を読む)
+ *   [2] schema 物理 verify (URL 欠落 / schema 不充足は自動棄却、無言棄却しない)
+ *   [3] 重複統合 (partialFingerprints ベース)
+ *   [4] severity filter (1-2 = backlog / 3-4 = 起票候補)
+ *   → 集約レポート出力
+ *
+ * **CI には rules-based の本 pipeline のみ載せる**。ポリシー準拠 filter (LLM 判定) と
+ * 起票実行は audit-manager orchestrator が本レポートを受けて実施 (EPIC 設計原則 1)。
+ *
+ * 使い方:
+ *   node scripts/audit/run-pipeline.mjs --run-id baseline-20260610 [--scope baseline] \
+ *     [--evidence-dir tmp/audit-evidence] [--out tmp/audit-run-20260610.md] [--strict]
+ *
+ *   --strict : schema 不充足 evidence が 1 件でもあれば exit 1 (CI gate 用、EPIC 設計原則 1)
+ *
+ * 終了コード:
+ *   0 = 集約完了 (--strict 時は schema 不充足ゼロ)
+ *   1 = evidence dir 不在 / parse 失敗 / (--strict で) schema 不充足あり
+ *
+ * 関連: .claude/agents/audit-manager.md §B / §E ｜ docs/sessions/audit-team.md §3.6
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { buildAggregateReport } from './aggregate-report.mjs';
+import { dedupeFindings } from './dedup.mjs';
+import { validateEvidence } from './evidence-schema.mjs';
+import { partitionBySeverity } from './severity-filter.mjs';
+
+function parseArgs(argv) {
+	const args = {
+		runId: null,
+		scope: 'baseline',
+		evidenceDir: 'tmp/audit-evidence',
+		out: null,
+		strict: false,
+		help: false,
+	};
+	for (let i = 2; i < argv.length; i++) {
+		const a = argv[i];
+		const next = () => argv[++i];
+		if (a === '--run-id') args.runId = next();
+		else if (a.startsWith('--run-id=')) args.runId = a.slice('--run-id='.length);
+		else if (a === '--scope') args.scope = next();
+		else if (a.startsWith('--scope=')) args.scope = a.slice('--scope='.length);
+		else if (a === '--evidence-dir') args.evidenceDir = next();
+		else if (a.startsWith('--evidence-dir=')) args.evidenceDir = a.slice('--evidence-dir='.length);
+		else if (a === '--out') args.out = next();
+		else if (a.startsWith('--out=')) args.out = a.slice('--out='.length);
+		else if (a === '--strict') args.strict = true;
+		else if (a === '-h' || a === '--help') args.help = true;
+	}
+	return args;
+}
+
+function printHelp() {
+	process.stdout.write(
+		[
+			'Usage:',
+			'  node scripts/audit/run-pipeline.mjs --run-id <id> [options]',
+			'',
+			'Options:',
+			'  --run-id <id>           run 識別子 (例: baseline-20260610 / 2950-20260610) [必須]',
+			'  --scope <s>             baseline | integration (default: baseline)',
+			'  --evidence-dir <dir>    領域別 evidence JSON dir (default: tmp/audit-evidence)',
+			'  --out <file>            集約レポート出力先 (default: tmp/audit-run-<date>.md)',
+			'  --strict                schema 不充足 evidence があれば exit 1 (CI gate 用)',
+			'',
+			'pipeline: 全件発露 → schema verify (URL 欠落/不充足は自動棄却) → 重複統合 → severity filter',
+			'See .claude/agents/audit-manager.md §B/§E / docs/sessions/audit-team.md §3.6',
+		].join('\n') + '\n',
+	);
+}
+
+/** YYYYMMDD (UTC) */
+function todayStamp() {
+	return new Date().toISOString().slice(0, 10).replace(/-/g, '');
+}
+
+function main() {
+	const args = parseArgs(process.argv);
+	if (args.help) {
+		printHelp();
+		process.exit(0);
+	}
+	if (!args.runId) {
+		process.stderr.write('[audit-run-pipeline] --run-id <id> が必要です。\n');
+		printHelp();
+		process.exit(1);
+	}
+
+	const evidenceDir = path.resolve(args.evidenceDir);
+	if (!existsSync(evidenceDir)) {
+		process.stderr.write(`[audit-run-pipeline] evidence dir が存在しません: ${evidenceDir}\n`);
+		process.stderr.write(
+			'  各領域 subagent が tmp/audit-evidence/<team>.json を Write してから実行してください。\n',
+		);
+		process.exit(1);
+	}
+
+	const files = readdirSync(evidenceDir).filter((f) => f.endsWith('.json'));
+	if (files.length === 0) {
+		process.stderr.write(`[audit-run-pipeline] evidence JSON が 0 件です: ${evidenceDir}\n`);
+		process.exit(1);
+	}
+
+	/** @type {Array<{ team: string, finding: object }>} */
+	const accepted = [];
+	/** @type {string[]} */
+	const rejectedEvidence = [];
+	let schemaFailures = 0;
+	let integrationPr = 0;
+
+	for (const file of files) {
+		const full = path.join(evidenceDir, file);
+		let parsed;
+		try {
+			parsed = JSON.parse(readFileSync(full, 'utf8'));
+		} catch (e) {
+			schemaFailures++;
+			rejectedEvidence.push(`evidence file \`${file}\` の JSON parse 失敗: ${e.message}`);
+			continue;
+		}
+
+		const result = validateEvidence(parsed);
+		if (Number.isInteger(parsed?.integration_pr) && parsed.integration_pr > 0) {
+			integrationPr = parsed.integration_pr;
+		}
+		if (!result.ok) {
+			schemaFailures++;
+			rejectedEvidence.push(
+				`evidence file \`${file}\` (team=${parsed?.team ?? '?'}) schema 不充足 → 領域ごと自動棄却: ${result.errors.join(' / ')}`,
+			);
+			continue;
+		}
+
+		for (const finding of parsed.findings) {
+			accepted.push({ team: parsed.team, finding });
+		}
+	}
+
+	// [3] 重複統合 + [4] severity filter
+	const dedup = dedupeFindings(accepted);
+	const { escalated, backlog } = partitionBySeverity(dedup.merged);
+
+	const generatedAt = new Date().toISOString();
+	const md = buildAggregateReport({
+		runId: args.runId,
+		scope: args.scope,
+		integrationPr,
+		generatedAt,
+		stats: {
+			rawFindingCount: dedup.inputCount,
+			mergedCount: dedup.mergedCount,
+			duplicatesRemoved: dedup.duplicatesRemoved,
+			escalatedCount: escalated.length,
+			backlogCount: backlog.length,
+		},
+		rejectedEvidence,
+		escalated,
+		backlog,
+	});
+
+	const outPath = path.resolve(args.out ?? `tmp/audit-run-${todayStamp()}.md`);
+	mkdirSync(path.dirname(outPath), { recursive: true });
+	writeFileSync(outPath, md, 'utf8');
+
+	process.stdout.write(`[audit-run-pipeline] 集約レポート出力: ${outPath}\n`);
+	process.stdout.write(
+		`  全件発露 ${dedup.inputCount} / 重複統合後 ${dedup.mergedCount} (重複 -${dedup.duplicatesRemoved}) / ` +
+			`起票候補 ${escalated.length} / backlog ${backlog.length} / 自動棄却 ${rejectedEvidence.length}\n`,
+	);
+
+	if (args.strict && schemaFailures > 0) {
+		process.stderr.write(
+			`[audit-run-pipeline] --strict: schema 不充足 evidence ${schemaFailures} 件 → exit 1 (self-report 単独信頼禁止)\n`,
+		);
+		process.exit(1);
+	}
+
+	process.exit(0);
+}
+
+main();

--- a/scripts/audit/run-pipeline.mjs
+++ b/scripts/audit/run-pipeline.mjs
@@ -65,22 +65,21 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-	process.stdout.write(
-		[
-			'Usage:',
-			'  node scripts/audit/run-pipeline.mjs --run-id <id> [options]',
-			'',
-			'Options:',
-			'  --run-id <id>           run 識別子 (例: baseline-20260610 / 2950-20260610) [必須]',
-			'  --scope <s>             baseline | integration (default: baseline)',
-			'  --evidence-dir <dir>    領域別 evidence JSON dir (default: tmp/audit-evidence)',
-			'  --out <file>            集約レポート出力先 (default: tmp/audit-run-<date>.md)',
-			'  --strict                schema 不充足 evidence があれば exit 1 (CI gate 用)',
-			'',
-			'pipeline: 全件発露 → schema verify (URL 欠落/不充足は自動棄却) → 重複統合 → severity filter',
-			'See .claude/agents/audit-manager.md §B/§E / docs/sessions/audit-team.md §3.6',
-		].join('\n') + '\n',
-	);
+	const lines = [
+		'Usage:',
+		'  node scripts/audit/run-pipeline.mjs --run-id <id> [options]',
+		'',
+		'Options:',
+		'  --run-id <id>           run 識別子 (例: baseline-20260610 / 2950-20260610) [必須]',
+		'  --scope <s>             baseline | integration (default: baseline)',
+		'  --evidence-dir <dir>    領域別 evidence JSON dir (default: tmp/audit-evidence)',
+		'  --out <file>            集約レポート出力先 (default: tmp/audit-run-<date>.md)',
+		'  --strict                schema 不充足 evidence があれば exit 1 (CI gate 用)',
+		'',
+		'pipeline: 全件発露 → schema verify (URL 欠落/不充足は自動棄却) → 重複統合 → severity filter',
+		'See .claude/agents/audit-manager.md §B/§E / docs/sessions/audit-team.md §3.6',
+	];
+	process.stdout.write(`${lines.join('\n')}\n`);
 }
 
 /** YYYYMMDD (UTC) */

--- a/scripts/audit/severity-filter.mjs
+++ b/scripts/audit/severity-filter.mjs
@@ -1,0 +1,43 @@
+/**
+ * scripts/audit/severity-filter.mjs (EPIC #2861 / B4 = #2867)
+ *
+ * severity 閾値 filter (audit-team.md §3.6 [3] / audit-manager.md §E [4])。
+ *   - severity 1-2 (軽微) = backlog 蓄積のみ (起票しない)
+ *   - severity 3-4 (重大) = 次段 (ポリシー準拠 filter → 起票候補) へ
+ *
+ * 「全件発露 → 重複統合 → severity filter (3-4 のみ) → ポリシー準拠 filter」の
+ * 固定時間 box 運用 (EPIC PO 判断 7 / 失敗シナリオ⑥)。本 module は severity 段のみ。
+ * ポリシー準拠判定は policy-compliance skill (LLM 判定) が担い、CI には載せない
+ * (EPIC 設計原則 1 — hard gate は rules-based のみ)。
+ *
+ * pure function (副作用なし)。vitest: tests/unit/audit/severity-filter.test.ts
+ */
+
+/** severity 3 以上を「重大」とし次段へ送る閾値 (audit-team.md §3.6 [3]) */
+export const SEVERITY_ESCALATION_THRESHOLD = 3;
+
+/**
+ * 重複統合後の finding 群を severity で分割する。
+ *
+ * @param {Array<any>} findings dedupe 済み finding 配列
+ * @returns {{
+ *   escalated: Array<any>,   // severity 3-4 — 次段 (policy filter) へ
+ *   backlog: Array<any>,     // severity 1-2 — backlog 蓄積のみ
+ *   threshold: number,
+ * }}
+ */
+export function partitionBySeverity(findings) {
+	/** @type {any[]} */
+	const escalated = [];
+	/** @type {any[]} */
+	const backlog = [];
+	for (const f of findings) {
+		const sev = Number.isInteger(f?.severity) ? f.severity : 0;
+		if (sev >= SEVERITY_ESCALATION_THRESHOLD) {
+			escalated.push(f);
+		} else {
+			backlog.push(f);
+		}
+	}
+	return { escalated, backlog, threshold: SEVERITY_ESCALATION_THRESHOLD };
+}

--- a/scripts/audit/verify-audit-evidence.mjs
+++ b/scripts/audit/verify-audit-evidence.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * scripts/audit/verify-audit-evidence.mjs (EPIC #2861 / B4 = #2867)
+ *
+ * 単一の領域 evidence file (`tmp/audit-evidence/<file>.json`) を schema 検証する CLI。
+ * `scripts/verify-adversarial-output.mjs` と同じ「pure 検証関数を import して CLI 化」
+ * パターン。audit-manager が dispatch 後に各領域 evidence を物理 verify する際に使う
+ * (audit-manager.md §B / §E [2])。
+ *
+ * 使い方:
+ *   node scripts/audit/verify-audit-evidence.mjs --file tmp/audit-evidence/security.json
+ *
+ * 出力:
+ *   PASS: exit 0 + stdout に finding 件数サマリ
+ *   FAIL: exit 1 + stderr に違反一覧 + 修正手順
+ *
+ * 関連:
+ *   - scripts/audit/evidence-schema.mjs (validateEvidence を共有)
+ *   - scripts/verify-adversarial-output.mjs (本 CLI の既存パターン)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { validateEvidence } from './evidence-schema.mjs';
+
+function parseArgs(argv) {
+	const args = { file: null, help: false };
+	for (let i = 2; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === '--file' && i + 1 < argv.length) {
+			args.file = argv[++i];
+		} else if (a.startsWith('--file=')) {
+			args.file = a.slice('--file='.length);
+		} else if (a === '-h' || a === '--help') {
+			args.help = true;
+		}
+	}
+	return args;
+}
+
+function printHelp() {
+	process.stdout.write(
+		[
+			'Usage:',
+			'  node scripts/audit/verify-audit-evidence.mjs --file <path>',
+			'',
+			'Verifies a single audit evidence JSON against the schema in',
+			'scripts/audit/evidence-schema.mjs (audit-manager.md §B):',
+			'  - run_id / integration_pr / team (許容値)',
+			'  - 各 finding: id / title / location / detail / severity(1-4) / policy_candidate',
+			'  - SARIF 互換: ruleId / level / locations / (任意) partialFingerprints',
+			'  - competitive / audit-manager-cuj は evidence_urls 必須',
+			'',
+			'See .claude/agents/audit-manager.md §B / scripts/verify-adversarial-output.mjs',
+		].join('\n') + '\n',
+	);
+}
+
+function main() {
+	const args = parseArgs(process.argv);
+	if (args.help) {
+		printHelp();
+		process.exit(0);
+	}
+	if (!args.file) {
+		process.stderr.write('[verify-audit-evidence] --file <path> が必要です。\n');
+		printHelp();
+		process.exit(1);
+	}
+
+	const full = path.resolve(args.file);
+	if (!existsSync(full)) {
+		process.stderr.write(`[verify-audit-evidence] FAIL: evidence file 不在: ${full}\n`);
+		process.stderr.write(
+			'  該当領域 subagent を再 dispatch し evidence を Write してください (無言で自筆 evidence に差し替えない)。\n',
+		);
+		process.exit(1);
+	}
+
+	let parsed;
+	try {
+		parsed = JSON.parse(readFileSync(full, 'utf8'));
+	} catch (e) {
+		process.stderr.write(`[verify-audit-evidence] FAIL: JSON parse 失敗: ${e.message}\n`);
+		process.exit(1);
+	}
+
+	const result = validateEvidence(parsed);
+	if (result.ok) {
+		process.stdout.write(
+			`[verify-audit-evidence] PASS: ${path.basename(full)} (team=${parsed.team}) schema 適合。finding ${result.findingCount} 件。\n`,
+		);
+		process.exit(0);
+	}
+
+	process.stderr.write(
+		`[verify-audit-evidence] FAIL: ${path.basename(full)} schema 不充足 (${result.errors.length} 件)\n`,
+	);
+	for (const e of result.errors) {
+		process.stderr.write(`  - ${e}\n`);
+	}
+	process.stderr.write('  根拠: .claude/agents/audit-manager.md §B evidence schema\n');
+	process.exit(1);
+}
+
+main();

--- a/scripts/audit/verify-audit-evidence.mjs
+++ b/scripts/audit/verify-audit-evidence.mjs
@@ -40,21 +40,20 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-	process.stdout.write(
-		[
-			'Usage:',
-			'  node scripts/audit/verify-audit-evidence.mjs --file <path>',
-			'',
-			'Verifies a single audit evidence JSON against the schema in',
-			'scripts/audit/evidence-schema.mjs (audit-manager.md §B):',
-			'  - run_id / integration_pr / team (許容値)',
-			'  - 各 finding: id / title / location / detail / severity(1-4) / policy_candidate',
-			'  - SARIF 互換: ruleId / level / locations / (任意) partialFingerprints',
-			'  - competitive / audit-manager-cuj は evidence_urls 必須',
-			'',
-			'See .claude/agents/audit-manager.md §B / scripts/verify-adversarial-output.mjs',
-		].join('\n') + '\n',
-	);
+	const lines = [
+		'Usage:',
+		'  node scripts/audit/verify-audit-evidence.mjs --file <path>',
+		'',
+		'Verifies a single audit evidence JSON against the schema in',
+		'scripts/audit/evidence-schema.mjs (audit-manager.md §B):',
+		'  - run_id / integration_pr / team (許容値)',
+		'  - 各 finding: id / title / location / detail / severity(1-4) / policy_candidate',
+		'  - SARIF 互換: ruleId / level / locations / (任意) partialFingerprints',
+		'  - competitive / audit-manager-cuj は evidence_urls 必須',
+		'',
+		'See .claude/agents/audit-manager.md §B / scripts/verify-adversarial-output.mjs',
+	];
+	process.stdout.write(`${lines.join('\n')}\n`);
 }
 
 function main() {

--- a/tests/unit/audit/aggregate-report.test.ts
+++ b/tests/unit/audit/aggregate-report.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { buildAggregateReport } from '../../../scripts/audit/aggregate-report.mjs';
+
+function baseInput(overrides: Record<string, unknown> = {}) {
+	return {
+		runId: 'baseline-20260610',
+		scope: 'baseline',
+		integrationPr: 0,
+		generatedAt: '2026-06-10T13:00:00.000Z',
+		stats: {
+			rawFindingCount: 5,
+			mergedCount: 3,
+			duplicatesRemoved: 2,
+			escalatedCount: 1,
+			backlogCount: 2,
+		},
+		rejectedEvidence: [],
+		escalated: [
+			{
+				id: 'security-1',
+				team: 'security',
+				ruleId: 'authz/x',
+				severity: 4,
+				title: 'tenant 欠落',
+				location: 'src/foo.ts',
+				merged_from: [{ team: 'security', id: 'security-1' }],
+			},
+		],
+		backlog: [
+			{
+				id: 'tech-1',
+				team: 'tech',
+				ruleId: 'r',
+				severity: 2,
+				title: 'a',
+				location: 'b',
+				merged_from: [{}],
+			},
+			{
+				id: 'tech-2',
+				team: 'tech',
+				ruleId: 'r2',
+				severity: 1,
+				title: 'c',
+				location: 'd',
+				merged_from: [{}],
+			},
+		],
+		...overrides,
+	};
+}
+
+describe('buildAggregateReport', () => {
+	it('AC4 件数サマリを全件出力する', () => {
+		const md = buildAggregateReport(baseInput());
+		expect(md).toContain('全件発露 (raw findings) | 5');
+		expect(md).toContain('重複統合後 | 3');
+		expect(md).toContain('重複統合で除去 | 2');
+		expect(md).toContain('起票候補 (severity 3-4 → 次段 policy filter へ) | 1');
+		expect(md).toContain('backlog 蓄積のみ (severity 1-2) | 2');
+		expect(md).toContain('自動棄却 (schema 不充足 / URL 欠落) | 0');
+	});
+
+	it('run メタ (run_id / scope / generated_at) を含む', () => {
+		const md = buildAggregateReport(baseInput());
+		expect(md).toContain('baseline-20260610');
+		expect(md).toContain('| scope | baseline |');
+		expect(md).toContain('2026-06-10T13:00:00.000Z');
+	});
+
+	it('baseline は integration_pr=0 を「差分非依存」と明示する', () => {
+		const md = buildAggregateReport(baseInput());
+		expect(md).toContain('0 (baseline / 差分非依存)');
+	});
+
+	it('integration scope では #PR を表示する', () => {
+		const md = buildAggregateReport(baseInput({ scope: 'integration', integrationPr: 2950 }));
+		expect(md).toContain('| integration_pr | #2950 |');
+	});
+
+	it('起票候補テーブルに finding 行を出す', () => {
+		const md = buildAggregateReport(baseInput());
+		expect(md).toContain('| security-1 | security | authz/x | 4 | 1 | tenant 欠落 | src/foo.ts |');
+	});
+
+	it('起票候補が「起票確定でない」旨を明記する (誤起票防止)', () => {
+		const md = buildAggregateReport(baseInput());
+		expect(md).toContain('起票確定ではない');
+		expect(md).toContain('policy-compliance');
+	});
+
+	it('escalated / backlog 空時は「該当なし」を出す', () => {
+		const md = buildAggregateReport(baseInput({ escalated: [], backlog: [] }));
+		expect(md).toContain('_(該当なし)_');
+	});
+
+	it('自動棄却理由を列挙する (無言棄却しない)', () => {
+		const md = buildAggregateReport(baseInput({ rejectedEvidence: ['file foo.json: URL 欠落'] }));
+		expect(md).toContain('- file foo.json: URL 欠落');
+	});
+
+	it('title 内の | をエスケープする (markdown table 破壊防止)', () => {
+		const md = buildAggregateReport(
+			baseInput({
+				escalated: [
+					{
+						id: 'a',
+						team: 't',
+						ruleId: 'r',
+						severity: 3,
+						title: 'a | b',
+						location: 'x',
+						merged_from: [{}],
+					},
+				],
+			}),
+		);
+		expect(md).toContain('a \\| b');
+	});
+});

--- a/tests/unit/audit/dedup.test.ts
+++ b/tests/unit/audit/dedup.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { dedupeFindings } from '../../../scripts/audit/dedup.mjs';
+
+function f(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'x-1',
+		title: 't',
+		location: 'src/lib/foo.ts:1',
+		severity: 2,
+		policy_candidate: false,
+		detail: 'd',
+		ruleId: 'rule-a',
+		level: 'warning',
+		locations: [{ physicalLocation: { artifactLocation: { uri: 'src/lib/foo.ts' } } }],
+		...overrides,
+	};
+}
+
+describe('dedupeFindings', () => {
+	it('空入力は空結果', () => {
+		const r = dedupeFindings([]);
+		expect(r).toEqual({ merged: [], inputCount: 0, mergedCount: 0, duplicatesRemoved: 0 });
+	});
+
+	it('同一 ruleId+正規化 location (行番号違い) を 1 件に統合する', () => {
+		const r = dedupeFindings([
+			{ team: 'tech', finding: f({ id: 'a', location: 'src/lib/foo.ts:10' }) },
+			{ team: 'product', finding: f({ id: 'b', location: 'src/lib/foo.ts:99' }) },
+		]);
+		expect(r.inputCount).toBe(2);
+		expect(r.mergedCount).toBe(1);
+		expect(r.duplicatesRemoved).toBe(1);
+		expect(r.merged[0].merged_from).toHaveLength(2);
+	});
+
+	it('ruleId が違えば統合しない', () => {
+		const r = dedupeFindings([
+			{ team: 'tech', finding: f({ id: 'a', ruleId: 'rule-a' }) },
+			{ team: 'tech', finding: f({ id: 'b', ruleId: 'rule-b' }) },
+		]);
+		expect(r.mergedCount).toBe(2);
+		expect(r.duplicatesRemoved).toBe(0);
+	});
+
+	it('統合時は群内最大 severity に引き上げる', () => {
+		const r = dedupeFindings([
+			{ team: 'tech', finding: f({ id: 'a', severity: 2 }) },
+			{ team: 'security', finding: f({ id: 'b', severity: 4 }) },
+		]);
+		expect(r.mergedCount).toBe(1);
+		expect(r.merged[0].severity).toBe(4);
+	});
+
+	it('merged_from に出所 team / id を記録する (無言マージしない)', () => {
+		const r = dedupeFindings([
+			{ team: 'tech', finding: f({ id: 'a' }) },
+			{ team: 'security', finding: f({ id: 'b' }) },
+		]);
+		expect(r.merged[0].merged_from).toEqual([
+			{ team: 'tech', id: 'a' },
+			{ team: 'security', id: 'b' },
+		]);
+	});
+
+	it('partialFingerprints.primary が一致すれば location が違っても統合する', () => {
+		const r = dedupeFindings([
+			{
+				team: 'tech',
+				finding: f({ id: 'a', location: 'aaa.ts:1', partialFingerprints: { primary: 'FP' } }),
+			},
+			{
+				team: 'product',
+				finding: f({ id: 'b', location: 'bbb.ts:1', partialFingerprints: { primary: 'FP' } }),
+			},
+		]);
+		expect(r.mergedCount).toBe(1);
+	});
+
+	it('各 merged finding に fingerprint が付く', () => {
+		const r = dedupeFindings([{ team: 'tech', finding: f() }]);
+		expect(typeof r.merged[0].fingerprint).toBe('string');
+		expect(r.merged[0].fingerprint.length).toBeGreaterThan(0);
+	});
+
+	it('代表 finding は最大 severity 側の本文を採用する', () => {
+		const r = dedupeFindings([
+			{ team: 'tech', finding: f({ id: 'low', severity: 1, title: 'low title' }) },
+			{ team: 'security', finding: f({ id: 'high', severity: 4, title: 'high title' }) },
+		]);
+		expect(r.merged[0].title).toBe('high title');
+	});
+});

--- a/tests/unit/audit/evidence-schema.test.ts
+++ b/tests/unit/audit/evidence-schema.test.ts
@@ -1,0 +1,243 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+	computeFingerprint,
+	normalizeLocation,
+	URL_REQUIRED_TEAMS,
+	VALID_SARIF_LEVELS,
+	VALID_TEAMS,
+	validateEvidence,
+	validateFinding,
+} from '../../../scripts/audit/evidence-schema.mjs';
+
+/** valid な finding を生成し、上書き差分を適用するヘルパ */
+function makeFinding(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'security-1',
+		title: 'tenant filter 欠落',
+		location: 'src/lib/server/auth/foo.ts:42',
+		severity: 3,
+		policy_candidate: false,
+		detail: '再現手順 / 根拠 / 影響',
+		evidence_urls: [],
+		ruleId: 'authz/missing-tenant-check',
+		level: 'error',
+		locations: [{ physicalLocation: { artifactLocation: { uri: 'src/lib/server/auth/foo.ts' } } }],
+		...overrides,
+	};
+}
+
+function makeEvidence(overrides: Record<string, unknown> = {}) {
+	return {
+		run_id: 'baseline-20260610',
+		integration_pr: 0,
+		team: 'security',
+		findings: [makeFinding()],
+		...overrides,
+	};
+}
+
+describe('normalizeLocation', () => {
+	it('行番号 (:42) を除去する', () => {
+		expect(normalizeLocation('src/lib/foo.ts:42')).toBe('src/lib/foo.ts');
+	});
+
+	it('行:列 (:42:5) を除去する', () => {
+		expect(normalizeLocation('src/lib/foo.ts:42:5')).toBe('src/lib/foo.ts');
+	});
+
+	it('Windows 区切りを / に統一し小文字化する', () => {
+		expect(normalizeLocation('src\\Lib\\Foo.ts')).toBe('src/lib/foo.ts');
+	});
+
+	it('連続空白を 1 つに畳む', () => {
+		expect(normalizeLocation('  child   home  ')).toBe('child home');
+	});
+
+	it('空文字 / 非文字列は空文字を返す', () => {
+		expect(normalizeLocation('')).toBe('');
+		expect(normalizeLocation(null)).toBe('');
+	});
+});
+
+describe('computeFingerprint', () => {
+	it('行番号違いの同一ファイル+同一 ruleId は同じ fingerprint になる', () => {
+		const a = computeFingerprint(makeFinding({ location: 'src/lib/foo.ts:10' }));
+		const b = computeFingerprint(makeFinding({ location: 'src/lib/foo.ts:99' }));
+		expect(a).toBe(b);
+	});
+
+	it('ruleId が違えば fingerprint も違う', () => {
+		const a = computeFingerprint(makeFinding({ ruleId: 'rule-a' }));
+		const b = computeFingerprint(makeFinding({ ruleId: 'rule-b' }));
+		expect(a).not.toBe(b);
+	});
+
+	it('partialFingerprints.primary を最優先で採用する', () => {
+		const fp = computeFingerprint(
+			makeFinding({ partialFingerprints: { primary: 'CANONICAL-FP' }, location: 'other.ts:1' }),
+		);
+		expect(fp).toBe('canonical-fp');
+	});
+});
+
+describe('validateFinding', () => {
+	it('valid な finding は違反なし', () => {
+		expect(validateFinding(makeFinding(), 'security')).toEqual([]);
+	});
+
+	it('最小 field 欠落を検出する', () => {
+		const errs = validateFinding(makeFinding({ id: '', title: '', detail: '' }), 'security');
+		expect(errs.some((e: string) => e.includes('id'))).toBe(true);
+		expect(errs.some((e: string) => e.includes('title'))).toBe(true);
+		expect(errs.some((e: string) => e.includes('detail'))).toBe(true);
+	});
+
+	it('severity 範囲外 (0 / 5 / 非整数) を検出する', () => {
+		expect(
+			validateFinding(makeFinding({ severity: 0 }), 'security').some((e: string) =>
+				e.includes('severity'),
+			),
+		).toBe(true);
+		expect(
+			validateFinding(makeFinding({ severity: 5 }), 'security').some((e: string) =>
+				e.includes('severity'),
+			),
+		).toBe(true);
+		expect(
+			validateFinding(makeFinding({ severity: 2.5 }), 'security').some((e: string) =>
+				e.includes('severity'),
+			),
+		).toBe(true);
+	});
+
+	it('policy_candidate が boolean でないと違反', () => {
+		expect(
+			validateFinding(makeFinding({ policy_candidate: 'yes' }), 'security').some((e: string) =>
+				e.includes('policy_candidate'),
+			),
+		).toBe(true);
+	});
+
+	it('SARIF 互換 field (ruleId / level / locations) 欠落を検出する', () => {
+		expect(
+			validateFinding(makeFinding({ ruleId: '' }), 'security').some((e: string) =>
+				e.includes('ruleId'),
+			),
+		).toBe(true);
+		expect(
+			validateFinding(makeFinding({ level: 'fatal' }), 'security').some((e: string) =>
+				e.includes('level'),
+			),
+		).toBe(true);
+		expect(
+			validateFinding(makeFinding({ locations: [] }), 'security').some((e: string) =>
+				e.includes('locations'),
+			),
+		).toBe(true);
+	});
+
+	it('VALID_SARIF_LEVELS の全値を許容する', () => {
+		for (const level of VALID_SARIF_LEVELS) {
+			expect(validateFinding(makeFinding({ level }), 'security')).toEqual([]);
+		}
+	});
+
+	it('competitive / cuj は evidence_urls 必須 (欠落で違反)', () => {
+		for (const team of URL_REQUIRED_TEAMS) {
+			const errs = validateFinding(makeFinding({ evidence_urls: [] }), team);
+			expect(errs.some((e: string) => e.includes('evidence_urls'))).toBe(true);
+		}
+	});
+
+	it('competitive は URL があれば違反なし', () => {
+		expect(
+			validateFinding(makeFinding({ evidence_urls: ['https://example.com'] }), 'competitive'),
+		).toEqual([]);
+	});
+
+	it('security は evidence_urls 空でも違反なし (URL 必須 team でない)', () => {
+		expect(validateFinding(makeFinding({ evidence_urls: [] }), 'security')).toEqual([]);
+	});
+
+	it('partialFingerprints の型不正を検出する', () => {
+		expect(
+			validateFinding(makeFinding({ partialFingerprints: [] }), 'security').some((e: string) =>
+				e.includes('partialFingerprints'),
+			),
+		).toBe(true);
+		expect(
+			validateFinding(makeFinding({ partialFingerprints: { primary: '' } }), 'security').some(
+				(e: string) => e.includes('partialFingerprints'),
+			),
+		).toBe(true);
+	});
+
+	it('partialFingerprints 省略は許容する', () => {
+		const f = makeFinding();
+		delete (f as Record<string, unknown>).partialFingerprints;
+		expect(validateFinding(f, 'security')).toEqual([]);
+	});
+
+	it('非オブジェクトを拒否する', () => {
+		expect(validateFinding(null, 'security').length).toBeGreaterThan(0);
+		expect(validateFinding([], 'security').length).toBeGreaterThan(0);
+	});
+});
+
+describe('validateEvidence', () => {
+	it('valid な evidence は ok=true', () => {
+		const r = validateEvidence(makeEvidence());
+		expect(r.ok).toBe(true);
+		expect(r.findingCount).toBe(1);
+	});
+
+	it('baseline run の integration_pr=0 を許容する', () => {
+		expect(validateEvidence(makeEvidence({ integration_pr: 0 })).ok).toBe(true);
+	});
+
+	it('integration_pr が負数だと違反', () => {
+		expect(validateEvidence(makeEvidence({ integration_pr: -1 })).ok).toBe(false);
+	});
+
+	it('未知 team を拒否する', () => {
+		const r = validateEvidence(makeEvidence({ team: 'unknown-team' }));
+		expect(r.ok).toBe(false);
+		expect(r.errors.some((e: string) => e.includes('team'))).toBe(true);
+	});
+
+	it('VALID_TEAMS 全値を許容する (competitive/cuj は URL 付きで)', () => {
+		for (const team of VALID_TEAMS) {
+			const findings = [makeFinding({ evidence_urls: ['https://example.com'] })];
+			expect(validateEvidence(makeEvidence({ team, findings })).ok).toBe(true);
+		}
+	});
+
+	it('findings が配列でないと違反', () => {
+		expect(validateEvidence(makeEvidence({ findings: {} })).ok).toBe(false);
+	});
+
+	it('findings 内の違反に index と id を添える', () => {
+		const r = validateEvidence(makeEvidence({ findings: [makeFinding({ id: '', severity: 9 })] }));
+		expect(r.ok).toBe(false);
+		expect(r.errors.some((e: string) => e.startsWith('findings[0]'))).toBe(true);
+	});
+
+	it('非オブジェクトを拒否する', () => {
+		expect(validateEvidence(null).ok).toBe(false);
+		expect(validateEvidence('x').ok).toBe(false);
+	});
+
+	it('CI 共有 fixture (sample-evidence.json) が schema に適合する (workflow との drift 防止)', () => {
+		// audit-run.yml pipeline-selftest job が cp する固定 fixture。schema が変わっても
+		// fixture が追従していなければここで fail させ、CI smoke の偽 PASS を防ぐ。
+		// Vitest cwd = リポジトリ root。import.meta.url は runner 下で file:// にならず
+		// fileURLToPath が throw するため process.cwd() 起点で解決する。
+		const fixturePath = path.resolve(process.cwd(), 'scripts/audit/fixtures/sample-evidence.json');
+		const fixture = JSON.parse(readFileSync(fixturePath, 'utf8'));
+		const r = validateEvidence(fixture);
+		expect(r.ok).toBe(true);
+		expect(r.findingCount).toBeGreaterThan(0);
+	});
+});

--- a/tests/unit/audit/severity-filter.test.ts
+++ b/tests/unit/audit/severity-filter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+	partitionBySeverity,
+	SEVERITY_ESCALATION_THRESHOLD,
+} from '../../../scripts/audit/severity-filter.mjs';
+
+const sev = (s: number) => ({ id: `s${s}`, severity: s });
+
+describe('partitionBySeverity', () => {
+	it('閾値は 3 (audit-team.md §3.6 [3])', () => {
+		expect(SEVERITY_ESCALATION_THRESHOLD).toBe(3);
+	});
+
+	it('severity 1-2 は backlog、3-4 は escalated', () => {
+		const r = partitionBySeverity([sev(1), sev(2), sev(3), sev(4)]);
+		expect(r.escalated.map((f: { id: string }) => f.id)).toEqual(['s3', 's4']);
+		expect(r.backlog.map((f: { id: string }) => f.id)).toEqual(['s1', 's2']);
+	});
+
+	it('空入力は両方空', () => {
+		const r = partitionBySeverity([]);
+		expect(r.escalated).toEqual([]);
+		expect(r.backlog).toEqual([]);
+	});
+
+	it('severity 非整数 / 欠落は backlog 扱い (0 として)', () => {
+		const r = partitionBySeverity([{ id: 'nan' }, { id: 'str', severity: 'x' }]);
+		expect(r.escalated).toEqual([]);
+		expect(r.backlog).toHaveLength(2);
+	});
+
+	it('threshold を返す', () => {
+		expect(partitionBySeverity([]).threshold).toBe(3);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（外部品質監査チーム = develop→main 統合前の第三者品質ゲート）

**解決する課題**: main = 本番（push 即 deploy）でありながら、統合状態の CUJ 横断品質を第三者監査する層が pipeline 化されていない。手動 audit run で「finding → 重複統合 → severity filter → 起票候補」が機能するかを実証する機械基盤が必要（EPIC #2861 P1、初回 baseline run = 2026-06-10 22:00 JST）。

**期待される効果**: 6/9 dry-run / 6/10 baseline run で全件発露 → filter pipeline が動作し、本番品質事故（顧客流出要因）を統合前に検出する体制の土台ができる。LLM 判定を hard gate にせず rules-based のみを CI gate 化することで、誤起票爆発と CI 偽陽性を構造的に防ぐ。

## 関連 Issue

closes #2867

- 親 EPIC: #2861（外部品質監査チーム体制、本 PR は B4 = P1）
- 役割定義 SSOT: `docs/sessions/audit-team.md`（§3.1 チーム構成 / §3.6 棄却 flow）
- 手順骨格 SSOT: `.claude/agents/audit-manager.md`（§B evidence schema / §E run flow）
- 再利用 skill: `policy-compliance` / `competitive-research` / `adversarial-reviewer`
- 既存パターン: `scripts/verify-adversarial-output.mjs`（CLI 検証パターンを踏襲）
- 関連 ADR: ADR-0056（不可逆 action = orchestrator 専権）/ ADR-0014（OSS 先調査）/ ADR-0010（Pre-PMF Bucket A）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | audit-manager から既存 7 領域 skill を dispatch する束ねが実装され、再利用元（EPIC マップ）に準拠（新規重複実装なし） | `scripts/audit/README.md` §「dispatch 手順」が 7 領域の再利用 skill（impact-analysis / regression-check / pr-review / cognitive-walkthrough / customer-voice / age-mode-check / axe-core / security-scan / lp-metrics / flake-hunt / competitive-research / policy-compliance / issue-triage）を列挙。新設は schema/dedup/filter/report の機械化部のみで finding 生成 skill は再利用 | PASS（dispatch は audit-manager session が Agent tool で起動する運用が SSOT、本 PR は機械実行部 + 手順書を提供。`grep -n "再利用" scripts/audit/README.md`） |
| AC2 | `.github/workflows/audit-run.yml`（workflow_dispatch 手動トリガー）が新設され、機械検証項目を実行し artifact 化 | `node -e "yaml.load(...audit-run.yml)"` で parse OK / schedule trigger なし（C3 範囲外）/ a11y・lp-metrics・rules-based・coverage・pipeline-selftest の 5 job が artifact upload | PASS（YAML parse OK、`schedule trigger present: false` を確認。inputs = scope / run_id） |
| AC3 | finding pipeline（全件発露 → 重複統合 → severity filter）が実装され、severity 3-4 のみ次段（起票候補）へ | `scripts/audit/{evidence-schema,dedup,severity-filter,run-pipeline}.mjs` + unit test 51 ケース PASS。dedup は partialFingerprints ベース、severity 1-2=backlog / 3-4=escalated | PASS（`npx vitest run tests/unit/audit/` → 51 passed。policy_compliant filter = LLM 判定は CI に載せず audit-manager が本レポートを受けて実施、EPIC 設計原則 1） |
| AC4 | 手動 run を 1 回完走させ、件数を `tmp/audit-run-<date>.md` にログ化 | CLI smoke で sample fixture → `tmp/audit-run-<date>.md` 生成（全件発露 / 重複統合後 / 起票候補 / backlog / 自動棄却 を AC4 形式で出力）。**実 baseline run（全実装・全 UI）は 6/10 22:00 に audit-manager session が本基盤を駆動して実施** | PASS（pipeline-selftest job + ローカル smoke で `tmp/audit-run-20260605.md` 生成を確認。本番 baseline run は audit-manager が dispatch → run-pipeline で本基盤を駆動） |
| AC5 | 起票 issue が issue-triage 品質基準を満たす | 起票は audit-manager 専権（ADR-0056 §E）。本 pipeline は起票候補 finding を集約レポートに出力するのみで、起票実行は audit-manager が `issue-triage` skill 経由で行う | PASS（責務分離: 本 PR は起票候補抽出まで。起票実行は audit-manager が issue-triage の根本原因 / Pre-PMF / namespace 重複検査を経由、`scripts/audit/README.md` §役割分担表） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（CI workflow + scripts/audit/ pure function + unit test のみ。アプリ本体 / UI / DB / LP に変更なし）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— Step 1-4 をローカルで個別確認済（biome / svelte-check audit 範囲 0 error / vitest 51 passed / check-hardcoded-strings 0）。LP / labels 変更なしのため Step 5-8 N/A
- [x] 追加・変更したテストの概要: `tests/unit/audit/` 4 file 51 ケース（evidence-schema 31 / dedup 9 / severity-filter 5 / aggregate-report 9 + CI fixture drift gate 1）。schema 検証 / partialFingerprints dedup / severity 分割 / レポート markdown 組み立てを検証
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（新規 env / secret なし）
- [x] **DynamoDB 実装変更時**: N/A（DB 変更なし）
- [x] **Critical バグ修正の場合**: N/A（bug fix でない）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: UI 変更を含まない。CI workflow / scripts/audit/ pure function / unit test のみで、描画される画面の変更がない。

**インタラクティブ状態**: N/A。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: pure function（evidence-schema / dedup / severity-filter / aggregate-report）と I/O（run-pipeline / verify-audit-evidence CLI）を分離。単一責任で各 module を構成
- [x] **DRY**: `verify-adversarial-output.mjs` の「pure 検証関数を import して CLI 化」パターンを踏襲。`computeFingerprint` を dedup から再利用。fixture を CI smoke + unit test で共有（drift gate 付き）
- [x] **YAGNI**: SARIF は full report builder（node-sarif-builder）を導入せず、dedup に必要な 4 field のみ schema 化（OSS 先調査で過剰と判断）
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: pure function で副作用最小。CLI は evidence file 読込 1 回のみ

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [x] 並行 PR overlap 確認 (#1200) — `scripts/audit/` / `.github/workflows/audit-run.yml` / `tests/unit/audit/` は新規 path で既存ファイル変更なし
- [x] N/A — 並行実装の影響範囲外（新規 CI 基盤、アプリ並行実装ペアに非該当）

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- 本 PR は EPIC #2861 B4 の **機械実行部 + dispatch 手順書**。LLM 判定（policy filter / adversarial）と起票 / merge の不可逆 action は **audit-manager 専権**（ADR-0056 §E）で CI に載せない方針（EPIC 設計原則 1）。この責務分離の妥当性をレビュー観点として確認いただきたい。
- 実 baseline audit run（全実装・全 UI、6/10 22:00 JST）は audit-manager session が本基盤を dispatch → run-pipeline で駆動する。AC4 の「実 run 1 回完走」はその時点で完了する（本 PR は pipeline-selftest job + ローカル smoke で pipeline 配線の健全性を実証）。
- **Ready 化判断は監査マネージャに委ねる**（Draft のまま提出）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（該当 Step を個別実行: biome / svelte-check（audit 範囲 0 error）/ vitest 51 passed / check-hardcoded-strings 0）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC4 の実 baseline run は audit-manager session が本基盤で実行）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
