### PR TITLE
refactor: #2917 CONCEPT_ICONS 残存直書きの段階的 SSOT 化 (項目2 参照化 + 項目4 JSDoc)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4696,7 +4696,7 @@ export const ADMIN_RULES_PAGE_LABELS = {
 	emptyTitle: '取込済のルールがありません',
 	emptyDesc: `${TEMPLATE_TERMS.userFacing}から bonus / exchange ルールを取込むとここに表示されます`,
 	browseLink: `${CONCEPT_ICONS.template} ${TEMPLATE_TERMS.browse} →`,
-	sectionBonusTitle: '🎯 ボーナスルール',
+	sectionBonusTitle: `${CONCEPT_ICONS.challenge} ボーナスルール`,
 	sectionBonusDesc:
 		'活動記録時に発火するボーナスポイント。enabled な preset のみが活動記録時に評価されます。',
 	sectionExchangeDesc:

--- a/src/lib/ui/primitives/OverflowMenu.svelte
+++ b/src/lib/ui/primitives/OverflowMenu.svelte
@@ -14,7 +14,7 @@ import { Portal } from '@ark-ui/svelte/portal';
  * として渡す (Composition over Inheritance)。
  *
  * UX 規約 (User 合意済 2026-05-23 §6.1):
- *   📦 みんなのテンプレから取込
+ *   🏪 みんなのテンプレから取込
  *   🤖 AI で提案してもらう (Help と並ぶ「便利機能」レイヤ)
  *   ──────────
  *   ⬇ バックアップから復元


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（保守性・用語/アイコン一貫性の担保）

**解決する課題**: PR #2909 で新設した `CONCEPT_ICONS` atom (terms.ts) の守備範囲外に残ったアイコン直書き 4 件のうち、PO/UX 判断を要しない 2 件（lint 対象外の compound 直書き + JSDoc コメント残存）を SSOT 経由化する。直書きが残ると「同一概念 = 同一アイコン」の 1 箇所保証（DESIGN.md §6 CONCEPT_ICONS SSOT）が崩れ、将来のアイコン変更時に伝播漏れが発生する。

**期待される効果**: `sectionBonusTitle` のアイコンが `CONCEPT_ICONS.challenge` 参照となり、atom 1 行修正で全画面伝播する ADR-0045 規律に整合。OverflowMenu の UX 規約コメントも現値 (🏪) と一致し、実装者の誤読を防ぐ。

## 関連 Issue

Refs #2917（Issue の残項目 1・3 は PO/UX 判断を要するため close しない。下記「据置判断の記録」参照）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (項目2) | `sectionBonusTitle` の 🎯 直書きを `${CONCEPT_ICONS.*}` 参照化 + 概念判定記録 | `grep -n "sectionBonusTitle" src/lib/domain/labels.ts` | HEAD `fbea716c` / labels.ts:4699 が `` `${CONCEPT_ICONS.challenge} ボーナスルール` `` に置換済（値 🎯 不変・見た目据置）。概念判定根拠は下記「設計判断」節 |
| AC1 (項目4) | OverflowMenu.svelte JSDoc 内 📦 のコメント更新 | `grep -n "🏪" src/lib/ui/primitives/OverflowMenu.svelte` | HEAD `fbea716c` / OverflowMenu.svelte:17 が `🏪 みんなのテンプレから取込` に更新済（非描画コメントのみ） |
| AC2 (置換時 SS) | 置換時は該当画面 SS を添付（表示変化あり） | 描画値比較（下記 SS 節の「描画変化なし」明細） | N/A — `CONCEPT_ICONS.challenge` = 🎯 で評価値同一のため表示変化なし（AC の前提条件「表示変化あり」に非該当） |
| AC3 | `node scripts/check-no-plan-literals.mjs` PASS 維持 | 同コマンド (pipeline clone, HEAD `fbea716c`) | `[check-no-plan-literals] OK — リテラル直書きなし` |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: `/admin/settings/rules`（ボーナスルール section 見出し — 描画値は 🎯 のまま不変）。OverflowMenu は JSDoc コメントのみで描画影響なし。

## 設計判断（項目2 の概念判定根拠）

`sectionBonusTitle` は `ADMIN_RULES_PAGE_LABELS` namespace（`/admin/settings/rules` の取込済ルール一覧 section 見出し）で使用される。概念的には rule (📜) が正だが、**見た目据置原則**（表示変化を伴う変更は SS 添付 + PO 確認事項となるため本 PR では行わない）に従い、現値 🎯 と同値の `CONCEPT_ICONS.challenge` を参照化した。**rule (📜) への意味論的是正は Issue #2917 項目1 と同様に PO 判断として Issue 側に残置**（本 PR は「直書き排除 = SSOT 経由化」のみを完遂）。

## 据置判断の記録（Issue #2917 残項目）

| 項目 | 判断 | 根拠 |
|---|---|---|
| 項目1（`📋 活動管理` 等の activity 概念 📋→📝 統一） | 据置（PO/UX 判断へ） | ページヘッダ装飾層のため checklist 📋 との視認混同が実害になるかの UX 判断が必要。置換すると表示変化 → SS + PO 確認事項 |
| 項目3（`detailCtaImportRuleWithCount` の「ルールセット」文言調整） | 据置（PO 判断へ） | Issue 本文に「ADR-0045 5 ドメイン規律対象外のため必須ではない」と明記済。type 呼称との混在回避の文言選定は PO 確認が適切 |

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）<!-- Draft 提出時点では個別検証済 (biome / check-no-plan-literals / tests/unit/domain 41 files 833 passed)。Ready 化時に完遂: CI で lint-and-test (biome+svelte-check) / unit-test 1-2 / e2e-test 1-3 / storybook 全 SUCCESS + check-pr-body PASS を確認済 -->
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）: N/A — 値不変の参照化 refactor のため既存 unit test (`npx vitest run tests/unit/domain` → 41 files / 833 passed) で回帰検証
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）** — 本 PR は視覚差分ゼロ:

- `sectionBonusTitle`: 値が `'🎯 ボーナスルール'` → `` `${CONCEPT_ICONS.challenge} ボーナスルール` `` で **描画結果は同一文字列**（`CONCEPT_ICONS.challenge` = 🎯）
- `OverflowMenu.svelte`: JSDoc コメント内の絵文字更新のみ（非描画）

「描画変化なし」主張の明細 (#1744): 表示文字列の置換は行っておらず、テンプレートリテラル参照化（評価値同一）と非描画コメント修正のみ。`refactor:internal-no-doc-impact` ラベル付与（ADR-0003 §4: 機能仕様変化なし / atom 参照化 / リテラル置換のみ / import 利用 + literal removal の diff）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — labels.ts compound の atom 参照化のみ、責務移動なし
- [x] **DRY**: `grep -rn "🎯" src/lib/domain/labels.ts` で同型直書きを確認、scope 内は本 1 件（他は Issue #2917 項目1/3 で管理）
- [x] **YAGNI**: 新規抽象なし（既存 `CONCEPT_ICONS` atom の参照のみ）
- [x] **Security（OSS 公開前提）**: N/A — 文字列定数の参照化のみ
- [x] **アクセシビリティ**: N/A — 描画値不変
- [x] **パフォーマンス**: N/A — ビルド時定数評価

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] **labels SSOT** (ADR-0009): `sectionBonusTitle` を terms.ts atom (`CONCEPT_ICONS.challenge`) の template literal 参照に統一、リテラル直書き排除
- [x] N/A — 上記以外の並行実装ペア（demo / 年齢モード / ナビ / DB / チュートリアル）は影響範囲外（compound 値不変のため波及なし。LP shared-labels.js は `ADMIN_RULES_PAGE_LABELS` 非対象 namespace）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**: 項目2 の概念判定（rule が意味論的に正だが見た目据置で challenge 参照）の妥当性。意味論優先で 📜 化すべきと判断される場合は Issue #2917 項目1 と併せて PO 判断に回す想定。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した <!-- Ready 化時に完遂: 個別検証 (biome / check-no-plan-literals / domain unit 833 passed) + CI 全 green + check-pr-body PASS -->
- [x] セルフレビュー済み（不要な差分・デバッグコードなし — diff は 2 files / 2 行のみ）
- [x] 全 AC が実装済み（本 PR scope の項目2・項目4。残項目は「据置判断の記録」で Issue 側管理）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — N/A（Issue #2917 自体が段階消化を定義）
- [x] UI 変更時: N/A — 視覚差分ゼロ（「該当なし」明記 + `refactor:internal-no-doc-impact` ラベル）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

