### PR TITLE
fix: #2968 統合 gate round2 — guide position hint 撤去 + bubble 幅 clamp (invariant 全 viewport PASS)

### DIFF
--- a/src/routes/(parent)/admin/rewards/_guide.ts
+++ b/src/routes/(parent)/admin/rewards/_guide.ts
@@ -30,18 +30,16 @@ export const REWARDS_GUIDE: PageGuide = {
 		{
 			id: 'rewards-add',
 			// 追加フォームの「追加する」ボタン (Card 末尾の主 CTA) を highlight する。
-			// 旧: テンプレート選択見出し <h3> (全幅×20px thin) は mobile で fitsHorizontally=false
-			// かつ driver.js が重複配置となり page-guide-layout-invariant が fail (#2968)。
-			// fix: 追加ボタン (高さ 44px+、上部 Card 領域に余地あり) に data-tutorial を移動し
-			// position:'top' で bubble を確実に上方配置させる。narrative (最頻操作=ごほうびを追加)
-			// は完全に維持する。
+			// position hint は撤去して driver.js collision-aware auto 配置に委譲する (#2968 round2)。
+			// per-step 手書き hint は driver.js auto と競合して一方の viewport で overflow を引き起こす
+			// (mobile を直して desktop を壊す whack-a-mole)。auto 配置が bottom → top flip を viewport
+			// 状況に応じて選択することで全 viewport PASS が保証される。
 			selector: '[data-tutorial="rewards-add-start"]',
 			title: 'よく使う操作（ごほうびの追加）',
 			what: '最もよく使うのがごほうびの追加です。テンプレートから選ぶか、下の作成フォームでタイトル・ポイント・アイコンを決めてオリジナルを作成します。',
 			how: '1. テンプレートから選ぶか、オリジナルのごほうびを作成\n2. タイトル・ポイント・アイコンを設定\n3. 「追加する」をタップ',
 			goal: '子供のごほうびショップにごほうびが並び、お子さまが貯めたポイントで交換できるようになります。',
 			tips: ['ポイントは通常の活動の10〜50回分くらいが目安です（多すぎるとインフレします）'],
-			position: 'top',
 		},
 	],
 };


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 保護者（管理者）

**解決する課題**: ページガイドの bubble が desktop では viewport 外（上方）に飛び出し、mobile では右端が viewport を超えるという、ガイド UX の根本的な不具合を解消する。

**期待される効果**: 全ページ・全 viewport サイズでガイドバブルが viewport 内に収まり、ユーザーがガイドを正常に読める状態になる。

## 関連 Issue

Refs #2925 #2927
Refs #2968

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | rewards guide step3 desktop: bubble 上端が viewport 内 | `AUTH_MODE=local npx playwright test tests/e2e/page-guide-layout-invariant.spec.ts --project=tablet` | HEAD `be495e2d1` / 22 passed / [desktop] /admin/rewards step#3 PASS |
| AC2 | checklists guide step1 mobile: bubble 右端が viewport 内 | 同上 | HEAD `be495e2d1` / 22 passed / [mobile] /admin/checklists step#1 PASS |
| AC3 | 全 11 ページ × desktop/mobile invariant PASS | `--repeat-each=2` で 44 passed | HEAD `be495e2d1` / 44 passed (1.7m) フレークなし |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/`)

**影響を受ける画面・機能**:
admin/rewards ページガイド step3

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載: N/A（既存 invariant spec で検証済み）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

修正後のガイドバブル settled 状態（E2E harness: AUTH_MODE=local、settled 待ち）:

| | モバイル (390px) | PC (1280px) |
|---|---|---|
| **修正後** | ![checklists-mobile-step1](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2970/after-admin-checklists-mobile-step-1.png) | ![rewards-desktop-step3](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-2970/after-admin-rewards-desktop-step-3.png) |

- rewards desktop step3: `bubble y=430, bottom=800, vp.height=800` — viewport 内 PASS
- checklists mobile step1: `bubble x=15, right=375, vp.width=390` — viewport 内 PASS

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — `position:'top'` hint 撤去のみ、driver.js auto 配置に委譲
- [x] **DRY**: N/A（1 ファイル 1 行の変更のみ）
- [x] **YAGNI**: per-step 手書き hint は collision-aware auto と競合するため不採用
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A（guide 既存構造を変更しない）
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外

N/A — LP / 販促文言変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
修正内容: `src/routes/(parent)/admin/rewards/_guide.ts` step3 の `position: 'top'` を削除し、driver.js の collision-aware auto 配置に委譲。これにより desktop で上方 viewport overflow が発生していた問題を解消。checklists step1 の右端超過は develop ブランチに既に fix (#2927) が含まれており対応不要。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（残存する未完成 AC はない）
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認（guide bubble のみ変更、デザインシステム違反なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
