### PR TITLE
infra: #2943 [Phase A/A-1] PR lane 判定 SSOT 新設 — scripts/pr-lane.mjs + composite action (4 lane 決定的分類)

### DIFF
--- a/.github/workflows/pr-lane-smoke.yml
+++ b/.github/workflows/pr-lane-smoke.yml
@@ -1,0 +1,78 @@
+name: PR Lane Smoke
+
+# Issue #2943 (Phase A/A-1): lane 判定 SSOT の動作実証。
+#
+# AC4「composite action を 2 つ以上の gate workflow で実際に `uses: ./actions/pr-lane`
+# して lane を取得できることを本 issue の PR 内で最低 1 gate の試験適用で示す」を満たす
+# 最小の試験適用。既存 gate 6 本 (pr-template-gate 等) の改修は A-2〜A-5 の scope であり
+# 本 issue では触らない (no-go) ため、本 issue では独立した smoke workflow で
+# `uses: ./actions/pr-lane` の動作を実証する。A-2 以降が同 action を本番 gate に組み込む。
+#
+# 本 workflow は comment-only / block しない (label 付与すらしない)。lane 値を log と
+# step summary に出すだけの非 required check。main ruleset の required context は増やさない
+# (no-go: 既存 10 context を変更しない)。
+
+on:
+  pull_request:
+    branches: [main, develop]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        description: 'base branch (手動 smoke 用)'
+        required: false
+        default: 'main'
+      head-ref:
+        description: 'head branch (手動 smoke 用)'
+        required: false
+        default: 'develop'
+      actor:
+        description: 'actor (手動 smoke 用)'
+        required: false
+        default: 'manual'
+
+permissions:
+  contents: read
+
+jobs:
+  lane-smoke:
+    name: PR lane 判定の動作実証
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # pull_request event では context の base_ref/head_ref/actor を、
+      # workflow_dispatch では手動入力を渡す (composite action は両対応)。
+      - name: Classify lane (pull_request context)
+        if: github.event_name == 'pull_request'
+        id: lane-pr
+        uses: ./actions/pr-lane
+
+      - name: Classify lane (workflow_dispatch inputs)
+        if: github.event_name == 'workflow_dispatch'
+        id: lane-dispatch
+        uses: ./actions/pr-lane
+        with:
+          base-ref: ${{ github.event.inputs.base-ref }}
+          head-ref: ${{ github.event.inputs.head-ref }}
+          actor: ${{ github.event.inputs.actor }}
+
+      - name: Report lane (outputs contract 実証)
+        env:
+          LANE: ${{ steps.lane-pr.outputs.lane || steps.lane-dispatch.outputs.lane }}
+        run: |
+          set -euo pipefail
+          if [ -z "${LANE}" ]; then
+            echo "::error::lane output が空です。actions/pr-lane の outputs.lane contract を確認してください。"
+            exit 1
+          fi
+          case "${LANE}" in
+            feature|integration|hotfix|dependabot)
+              echo "PR lane = ${LANE}（4 lane のいずれか、contract OK）" ;;
+            *)
+              echo "::error::想定外の lane='${LANE}'（feature/integration/hotfix/dependabot 以外）"
+              exit 1 ;;
+          esac
+          echo "### PR lane: \`${LANE}\`" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "判定 SSOT: \`scripts/pr-lane.mjs\` / composite action: \`actions/pr-lane\`（#2943）" >> "${GITHUB_STEP_SUMMARY}"

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,12 @@ docs/pr-screenshots/
 
 # PR# プレフィックスの screenshots は screenshots ブランチに push（main 追跡禁止）
 pr-*/
+# 例外: composite action `actions/pr-lane/` は `pr-*/` に偶発マッチするが追跡必須 (#2943)。
+# GitHub の制約上 local composite action は repo root の `actions/` に置く必要があり
+# (`.github/actions/` だと reusable workflow と誤認される)、その配下 `pr-lane/` が
+# screenshots 用 `pr-*/` rule に巻き込まれるため明示的に un-ignore する。
+!actions/
+!actions/**
 
 # 一時 screenshots / 旧 PR アセット / 孤児 sound は履歴から filter-repo で抹消済み（main 追跡禁止）
 tmp-screenshots/

--- a/actions/pr-lane/action.yml
+++ b/actions/pr-lane/action.yml
@@ -1,0 +1,71 @@
+# actions/pr-lane/action.yml — Issue #2943 (Phase A/A-1、親 #2942 / EPIC #2861)
+#
+# PR の base/head/actor を context から受け取り、scripts/pr-lane.mjs (SSOT) を呼び出して
+# lane 文字列 (feature / integration / hotfix / dependabot) を outputs.lane に set する
+# 薄い composite action。判定ロジックは持たず、context → script への配線のみを担う。
+#
+# 【配置が actions/ (repo root) であって .github/actions/ でない理由】
+#   composite action を `.github/actions/` 配下ではなく **repo root の `actions/`** に置く。
+#   `.github/` 配下に action.yml を置くと、一部の tooling / linter が reusable workflow
+#   (workflow_call) と誤認しやすく、また GitHub の慣習上 reusable workflow は
+#   `.github/workflows/` に、local composite action は repo root の任意 dir に置く
+#   (Docs: Reusing workflow configurations / community #18601)。本 repo では root の
+#   `actions/` を local composite action の確立配置とする (#2943 no-go に明記)。
+#
+# 【利用 event の制約】
+#   `github.base_ref` / `github.head_ref` は **pull_request / pull_request_target event でのみ**
+#   定義される (push event では空)。本 action は pull_request 系 event の job からのみ呼ぶこと
+#   (#2943 no-go)。caller 側で base/head を明示渡しすれば event 非依存にも使えるが、
+#   既定は context の base_ref / head_ref / actor を入力にする。
+#
+# 【出力 contract (後続 gate A-2〜A-5 が参照)】
+#   steps.<id>.outputs.lane で lane 文字列を取得する。
+#   例:
+#     - id: lane
+#       uses: ./actions/pr-lane
+#     - run: echo "lane=${{ steps.lane.outputs.lane }}"
+#
+# resolve-base-branch.mjs (#2959、クライアント tooling 用) との責務分担は
+# scripts/pr-lane.mjs の冒頭コメントを参照 (CI gate 用 vs local tooling 用で別 SSOT)。
+
+name: 'PR Lane Classifier'
+description: >-
+  Classify a pull request into one of 4 lanes (feature / integration / hotfix / dependabot)
+  from base/head/actor using scripts/pr-lane.mjs (SSOT). Lightweight wiring only — no logic.
+
+inputs:
+  base-ref:
+    description: 'PR base branch name (default: github.base_ref). pull_request event でのみ自動取得可。'
+    required: false
+    default: ${{ github.base_ref }}
+  head-ref:
+    description: 'PR head branch name (default: github.head_ref).'
+    required: false
+    default: ${{ github.head_ref }}
+  actor:
+    description: 'PR author login (default: github.actor). bot 判定に使用。'
+    required: false
+    default: ${{ github.actor }}
+
+outputs:
+  lane:
+    description: 'Classified lane: feature | integration | hotfix | dependabot'
+    value: ${{ steps.classify.outputs.lane }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Classify PR lane (scripts/pr-lane.mjs SSOT)
+      id: classify
+      shell: bash
+      env:
+        # context を env 経由で渡し、bash の引数注入 (改行 / メタ文字) を避ける
+        PR_LANE_BASE: ${{ inputs.base-ref }}
+        PR_LANE_HEAD: ${{ inputs.head-ref }}
+        PR_LANE_ACTOR: ${{ inputs.actor }}
+      run: |
+        set -euo pipefail
+        lane="$(node "${GITHUB_ACTION_PATH}/../../scripts/pr-lane.mjs" \
+          --base "${PR_LANE_BASE}" --head "${PR_LANE_HEAD}" --actor "${PR_LANE_ACTOR}")"
+        echo "Classified lane: ${lane} (base=${PR_LANE_BASE} head=${PR_LANE_HEAD} actor=${PR_LANE_ACTOR})"
+        echo "lane=${lane}" >> "${GITHUB_OUTPUT}"

--- a/scripts/pr-lane.mjs
+++ b/scripts/pr-lane.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * scripts/pr-lane.mjs — Issue #2943 (Phase A/A-1、親 #2942 / EPIC #2861)
+ *
+ * develop 二層ブランチ戦略 (docs/sessions/branch-strategy.md §3〜§5) における
+ * 「この PR がどのレーンか」を判定する **CI 側 (サーバ gate 用) の正準ロジック (SSOT)**。
+ *
+ * 背景:
+ *   現状、PR の種別判定は (1) Dependabot exempt = `github.actor != 'dependabot[bot]'` の
+ *   文字列が 6+ workflow に inline 重複、(2) main/develop/hotfix の base/head 判定 =
+ *   `ci.yml` の `main-pr-base-guard` に bash で 1 箇所だけ、と散在している。
+ *   lane-aware 化 (A-2〜A-5) を進めると同じ判定を 6 workflow にコピペすることになり、
+ *   判定基準のドリフトが構造的に発生する。本 script はその判定を 1 つの純粋関数に集約し、
+ *   composite action (actions/pr-lane) 経由で全 gate が同一 SSOT を参照する
+ *   (terms.ts / ADR-0042 の 3 層トークンと同型の SSOT 思想)。
+ *
+ * `scripts/lib/resolve-base-branch.mjs` (#2959) との責務分担:
+ *   - resolve-base-branch.mjs = **クライアント tooling 用** (local git 基点)。
+ *     「現在の branch がどの base に push / PR すべきか」を local git / gh から解決する。
+ *     副作用あり (execSync で git / gh を叩く)。
+ *   - pr-lane.mjs (本 file) = **CI gate 用** (PR event payload 基点)。
+ *     既に確定した PR の baseRef / headRef / actor から lane を分類する純粋関数。
+ *     副作用ゼロ (GitHub API / file write を一切行わない、AC6)。
+ *   両者は入力源 (local git 推定 vs PR event payload の確定値) と用途が異なるため統合せず、
+ *   概念整合を本コメントで相互参照する (#2943 related / #2959 follow-up 評価結果)。
+ *   統合しない判断: pr-lane は base/head/actor を「確定値」として受け取る pure function で
+ *   ある一方、resolve-base-branch は local git を推定走査する副作用関数であり、
+ *   片方を他方の入力にすると pure function の testability (AC6) が崩れるため。
+ *
+ * lane 分類 (4 種、決定的・優先順位付き = 最初にマッチした lane を返す):
+ *   1. actor が `dependabot[bot]` / `renovate[bot]`       → 'dependabot'
+ *   2. headRef === 'develop' かつ baseRef === 'main'      → 'integration' (統合 PR、重量レーン)
+ *   3. headRef が 'fix/' で始まり baseRef === 'main'      → 'hotfix'      (ADR-0002 重量レーン)
+ *   4. baseRef === 'develop'                              → 'feature'    (軽量レーン)
+ *   5. 上記いずれにも非該当                                → 'feature'    (既定、後方互換)
+ *
+ * back-merge PR の帰属 (#2960 / #2967 実地観測):
+ *   hotfix を main に merge した後の main → develop back-merge PR
+ *   (head=main、base=develop、branch-strategy.md §3「ホットフィックス経路」)は
+ *   rule 4 (baseRef === 'develop') で **'feature' (軽量レーン)** に分類される。
+ *   develop に取り込む変更は軽量レーン gate で十分であり、5 つ目の lane を新設しない
+ *   (no-go: 「lane を 4 種から増やさない」ADR-0010 Pre-PMF)。rule 2 の integration は
+ *   head=develop & base=main の逆向きなので back-merge とは衝突しない。
+ *
+ * Usage (CLI、AC5):
+ *   node scripts/pr-lane.mjs --base main --head develop --actor x   # => "integration"
+ *   node scripts/pr-lane.mjs --base develop --head feat/123 --actor Takenori-Kusaka  # => "feature"
+ *
+ * exit: 0 = 分類成功 (lane を stdout に出力) / 2 = 引数不足
+ */
+
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEPENDABOT_ACTORS = new Set(['dependabot[bot]', 'renovate[bot]']);
+
+/**
+ * PR lane 判定の純粋関数 (unit test 対象、AC1)。副作用なし (AC6)。
+ *
+ * @param {{
+ *   baseRef: string;   // PR の base branch 名 (例: 'main' / 'develop')。GitHub Actions では `github.base_ref`
+ *   headRef: string;   // PR の head branch 名 (例: 'develop' / 'feat/123-x' / 'fix/999')。`github.head_ref`
+ *   actor: string;     // PR を作成した actor (例: 'Takenori-Kusaka' / 'dependabot[bot]')。`github.actor`
+ * }} input
+ * @returns {'feature' | 'integration' | 'hotfix' | 'dependabot'}
+ */
+export function classifyLane({ baseRef, headRef, actor }) {
+	const base = (baseRef ?? '').trim();
+	const head = (headRef ?? '').trim();
+	const who = (actor ?? '').trim();
+
+	// 1. bot は base/head より優先 (Dependabot exempt を lane の 1 種として吸収)
+	if (DEPENDABOT_ACTORS.has(who)) return 'dependabot';
+	// 2. develop → main = 統合 PR (重量レーン)
+	if (head === 'develop' && base === 'main') return 'integration';
+	// 3. fix/* → main = hotfix (ADR-0002 重量レーン)
+	if (head.startsWith('fix/') && base === 'main') return 'hotfix';
+	// 4. → develop = 軽量レーン (back-merge main→develop もここに帰属)
+	if (base === 'develop') return 'feature';
+	// 5. 既定: cutover 前の main 向け通常 PR も軽量観点で扱う (後方互換)
+	return 'feature';
+}
+
+/**
+ * 簡易 argv パーサ (--base / --head / --actor)。pure 関数ではないが
+ * classifyLane の入力収集に限定し、判定 logic は持たない。
+ *
+ * @param {string[]} argv process.argv.slice(2)
+ * @returns {{ baseRef: string; headRef: string; actor: string }}
+ */
+export function parseArgs(argv) {
+	/** @type {Record<string, string>} */
+	const out = { base: '', head: '', actor: '' };
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		const eq = arg.indexOf('=');
+		if (arg.startsWith('--') && eq !== -1) {
+			// --base=main 形式
+			out[arg.slice(2, eq)] = arg.slice(eq + 1);
+		} else if (arg.startsWith('--')) {
+			// --base main 形式
+			out[arg.slice(2)] = argv[i + 1] ?? '';
+			i += 1;
+		}
+	}
+	return { baseRef: out.base, headRef: out.head, actor: out.actor };
+}
+
+const isMain = (() => {
+	try {
+		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
+	} catch {
+		return false;
+	}
+})();
+
+if (isMain) {
+	const { baseRef, headRef, actor } = parseArgs(process.argv.slice(2));
+	if (!baseRef && !headRef && !actor) {
+		console.error(
+			'[pr-lane] Usage: node scripts/pr-lane.mjs --base <baseRef> --head <headRef> --actor <actor>',
+		);
+		process.exit(2);
+	}
+	process.stdout.write(`${classifyLane({ baseRef, headRef, actor })}\n`);
+	process.exit(0);
+}

--- a/scripts/pr-lane.mjs
+++ b/scripts/pr-lane.mjs
@@ -93,17 +93,18 @@ export function parseArgs(argv) {
 	const out = { base: '', head: '', actor: '' };
 	for (let i = 0; i < argv.length; i += 1) {
 		const arg = argv[i];
+		if (arg === undefined || !arg.startsWith('--')) continue;
 		const eq = arg.indexOf('=');
-		if (arg.startsWith('--') && eq !== -1) {
+		if (eq !== -1) {
 			// --base=main 形式
 			out[arg.slice(2, eq)] = arg.slice(eq + 1);
-		} else if (arg.startsWith('--')) {
+		} else {
 			// --base main 形式
 			out[arg.slice(2)] = argv[i + 1] ?? '';
 			i += 1;
 		}
 	}
-	return { baseRef: out.base, headRef: out.head, actor: out.actor };
+	return { baseRef: out.base ?? '', headRef: out.head ?? '', actor: out.actor ?? '' };
 }
 
 const isMain = (() => {

--- a/tests/unit/github/pr-lane.test.ts
+++ b/tests/unit/github/pr-lane.test.ts
@@ -1,0 +1,152 @@
+// Issue #2943 (Phase A/A-1) AC2: PR lane 判定 SSOT (scripts/pr-lane.mjs) の
+// 決定的 4 lane 分類 (feature / integration / hotfix / dependabot) の境界を網羅する unit test。
+// develop 二層ブランチ戦略 (docs/sessions/branch-strategy.md §3〜§5) の CI gate 側 SSOT。
+import { describe, expect, it } from 'vitest';
+import { classifyLane, parseArgs } from '../../../scripts/pr-lane.mjs';
+
+describe('classifyLane (#2943 AC1/AC2)', () => {
+	// --- AC2 で明示された 6 境界条件 ---
+	it('feature: base develop / head feat/* / 通常 actor', () => {
+		expect(classifyLane({ baseRef: 'develop', headRef: 'feat/x', actor: 'Takenori-Kusaka' })).toBe(
+			'feature',
+		);
+	});
+
+	it('integration: head develop & base main', () => {
+		expect(classifyLane({ baseRef: 'main', headRef: 'develop', actor: 'Takenori-Kusaka' })).toBe(
+			'integration',
+		);
+	});
+
+	it('hotfix: head fix/* & base main', () => {
+		expect(classifyLane({ baseRef: 'main', headRef: 'fix/urgent', actor: 'Takenori-Kusaka' })).toBe(
+			'hotfix',
+		);
+	});
+
+	it('dependabot: actor が base/head より優先 (develop→main でも bot なら dependabot)', () => {
+		expect(classifyLane({ baseRef: 'main', headRef: 'develop', actor: 'dependabot[bot]' })).toBe(
+			'dependabot',
+		);
+	});
+
+	it('feature 既定: base main / head feat/* (cutover 前 main 向け通常 PR = 軽量観点)', () => {
+		expect(classifyLane({ baseRef: 'main', headRef: 'feat/x', actor: 'Takenori-Kusaka' })).toBe(
+			'feature',
+		);
+	});
+
+	it('dependabot: renovate[bot] も bot 扱い (base develop / head fix/*)', () => {
+		expect(classifyLane({ baseRef: 'develop', headRef: 'fix/x', actor: 'renovate[bot]' })).toBe(
+			'dependabot',
+		);
+	});
+
+	// --- 優先順位 (最初にマッチした lane を返す) の追加境界 ---
+	it('優先順位: bot は hotfix 形 (fix/* → main) でも dependabot が勝つ', () => {
+		expect(
+			classifyLane({ baseRef: 'main', headRef: 'fix/dep-bump', actor: 'dependabot[bot]' }),
+		).toBe('dependabot');
+	});
+
+	it('優先順位: integration は hotfix より先に判定 (head develop & base main)', () => {
+		// develop は fix/ で始まらないので hotfix にはならないが、判定順序の固定を明示
+		expect(classifyLane({ baseRef: 'main', headRef: 'develop', actor: 'someone' })).toBe(
+			'integration',
+		);
+	});
+
+	// --- back-merge PR の帰属 (#2960 / #2967 実地観測) ---
+	it('back-merge: main → develop (head main / base develop) は feature 軽量レーンに帰属', () => {
+		expect(classifyLane({ baseRef: 'develop', headRef: 'main', actor: 'Takenori-Kusaka' })).toBe(
+			'feature',
+		);
+	});
+
+	it('back-merge 派生: hotfix-backport branch → develop も feature に帰属', () => {
+		expect(
+			classifyLane({ baseRef: 'develop', headRef: 'fix/999-backport', actor: 'Takenori-Kusaka' }),
+		).toBe('feature');
+	});
+
+	// --- hotfix は base が main のときのみ。develop 向けは feature ---
+	it('fix/* → develop は hotfix ではなく feature (base develop が優先)', () => {
+		expect(classifyLane({ baseRef: 'develop', headRef: 'fix/123', actor: 'Takenori-Kusaka' })).toBe(
+			'feature',
+		);
+	});
+
+	// --- 各種ブランチ接頭辞 → develop はすべて feature ---
+	it('refactor/* / docs/* / infra/* → develop はすべて feature', () => {
+		for (const head of ['refactor/x', 'docs/x', 'infra/x', 'chore/x']) {
+			expect(classifyLane({ baseRef: 'develop', headRef: head, actor: 'Takenori-Kusaka' })).toBe(
+				'feature',
+			);
+		}
+	});
+
+	// --- 空・null 入力の堅牢性 (副作用なし・throw しない) ---
+	it('空文字 / null 入力でも throw せず feature 既定を返す', () => {
+		expect(classifyLane({ baseRef: '', headRef: '', actor: '' })).toBe('feature');
+		// @ts-expect-error 意図的な null 入力で堅牢性を検証
+		expect(classifyLane({ baseRef: null, headRef: null, actor: null })).toBe('feature');
+	});
+
+	it('前後空白は trim される (CI env var 由来の改行/空白対策)', () => {
+		expect(
+			classifyLane({ baseRef: ' main ', headRef: ' develop ', actor: ' Takenori-Kusaka ' }),
+		).toBe('integration');
+		expect(classifyLane({ baseRef: 'main', headRef: 'develop', actor: ' dependabot[bot] ' })).toBe(
+			'dependabot',
+		);
+	});
+
+	// --- 4 lane のいずれかを必ず返す (網羅性 invariant、AC1) ---
+	it('AC1: 出力は常に 4 lane のいずれか', () => {
+		const lanes = new Set(['feature', 'integration', 'hotfix', 'dependabot']);
+		const cases = [
+			{ baseRef: 'develop', headRef: 'feat/x', actor: 'u' },
+			{ baseRef: 'main', headRef: 'develop', actor: 'u' },
+			{ baseRef: 'main', headRef: 'fix/x', actor: 'u' },
+			{ baseRef: 'main', headRef: 'feat/x', actor: 'u' },
+			{ baseRef: 'main', headRef: 'develop', actor: 'dependabot[bot]' },
+		];
+		for (const c of cases) {
+			expect(lanes.has(classifyLane(c))).toBe(true);
+		}
+	});
+});
+
+describe('parseArgs (#2943 AC5 CLI)', () => {
+	it('--base main --head develop --actor x をパースする (空白区切り)', () => {
+		expect(parseArgs(['--base', 'main', '--head', 'develop', '--actor', 'x'])).toEqual({
+			baseRef: 'main',
+			headRef: 'develop',
+			actor: 'x',
+		});
+	});
+
+	it('--base=main 形式 (= 区切り) もパースする', () => {
+		expect(parseArgs(['--base=main', '--head=develop', '--actor=x'])).toEqual({
+			baseRef: 'main',
+			headRef: 'develop',
+			actor: 'x',
+		});
+	});
+
+	it('未指定 flag は空文字 (CLI 呼び出し側で classifyLane が feature 既定)', () => {
+		expect(parseArgs([])).toEqual({ baseRef: '', headRef: '', actor: '' });
+	});
+
+	it('parseArgs + classifyLane の結合で integration を得る (AC5 経路)', () => {
+		const { baseRef, headRef, actor } = parseArgs([
+			'--base',
+			'main',
+			'--head',
+			'develop',
+			'--actor',
+			'x',
+		]);
+		expect(classifyLane({ baseRef, headRef, actor })).toBe('integration');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発フロー基盤）/ 間接的に顧客（本番品質）

**解決する課題**: PR の「種別判定」が散在・重複している。(1) Dependabot exempt = `github.actor != 'dependabot[bot]'` の文字列が 6+ workflow に inline 重複、(2) main/develop/hotfix の base/head 判定 = `ci.yml` の `main-pr-base-guard` に bash で 1 箇所だけ存在。lane-aware 化（A-2〜A-5）を進めると同じ base/head/actor 判定を 6 workflow にコピペすることになり、判定基準のドリフトが構造的に発生する。

**期待される効果**: lane 判定を 1 つの純粋関数（`scripts/pr-lane.mjs`）+ composite action（`actions/pr-lane`）に集約し、後続 gate（A-2〜A-5）が同一 SSOT を参照する。判定基準の変更が 1 箇所修正で全 gate に伝播する（terms.ts / ADR-0042 の 3 層トークンと同型の SSOT 思想）。本 PR は Phase A の **基盤**であり、A-2〜A-5（gate 6 本の lane-aware 化）はすべて本 SSOT を消費する。

## 関連 Issue

closes #2943

- **統括**: Phase A 統括 #2942（マネージャ判断記録 5「main-pr-base-guard の pr-lane.mjs 寄せは本 phase scope 外」を遵守）
- **親 EPIC**: #2861
- **blocks**: A-2 / A-3 / A-4 / A-5（gate 6 本の lane-aware 化）
- **related**: ADR-0042（3 層トークン SSOT 思想）/ #2959（`resolve-base-branch.mjs` = client tooling 用 base 解決、本 PR の CI gate 用 pr-lane.mjs とは責務分離。統合可否を評価した結果は「レビュー依頼事項」に記載）/ #2967（back-merge PR の実地観測）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `scripts/pr-lane.mjs` が純粋関数 `classifyLane({ baseRef, headRef, actor })` を named export し、4 lane のいずれかを返す | `tests/unit/github/pr-lane.test.ts` の「AC1: 出力は常に 4 lane のいずれか」+ named export を test が import | PASS（19 件）。`export function classifyLane` を `scripts/pr-lane.mjs` で named export |
| AC2 | 境界条件を unit test（`tests/unit/github/pr-lane.test.ts`）で網羅（feature / integration / hotfix / dependabot 優先 / main+feat 既定 / renovate） | `npx vitest run tests/unit/github/pr-lane.test.ts` | PASS（6 AC 境界 + 優先順位 + back-merge + 空/null 堅牢性 + trim = 19 件 PASS） |
| AC3 | `actions/pr-lane/action.yml` が composite action として存在し、`actions/` 配下（`.github/` 配下ではない）に置かれ `outputs.lane` で lane 文字列を返す | `actions/pr-lane/action.yml`（repo root の actions/ 配下、`.github/` 配下ではない）。`outputs.lane.value: ${{ steps.classify.outputs.lane }}` | PASS。配置理由（`.github/` だと reusable workflow 誤認）を action.yml 冒頭コメントに明記 |
| AC4 | composite action を gate workflow で実際に `uses: ./actions/pr-lane` して lane を取得できることを最低 1 gate の試験適用で示す | `.github/workflows/pr-lane-smoke.yml` が `uses: ./actions/pr-lane` で lane を取得し contract（4 lane のいずれか）を assert | PASS。既存 gate 6 本は A-2〜A-5 scope のため改変せず、独立 smoke workflow で実証（A-2 以降が本番 gate に組込） |
| AC5 | `node scripts/pr-lane.mjs --base main --head develop --actor x` の CLI 実行が `integration` を stdout に出力し exit 0 | `node scripts/pr-lane.mjs --base main --head develop --actor x` | PASS。stdout=`integration` exit=0（feature/hotfix/dependabot/back-merge も検証済） |
| AC6 | `pr-lane.mjs` が GitHub API 呼び出し・file write を一切行わない | `grep -nE 'fetch\|execSync\|writeFile\|child_process\|\bgh ' scripts/pr-lane.mjs`（docstring 以外の実コード一致 0 件）+ import は `node:path` / `node:url` のみ | PASS。実行コードに副作用ゼロ（docstring 内の resolve-base-branch.mjs 説明のみ一致） |
| AC7 | lane 判定ロジックが `scripts/pr-lane.mjs` 1 箇所のみに存在し、composite action / 各 gate に inline 重複していない | `grep -rln "classifyLane" scripts/ actions/ .github/workflows/` → `scripts/pr-lane.mjs` のみ。`grep -nE 'dependabot\[bot\]\|renovate\[bot\]' actions/pr-lane/action.yml .github/workflows/pr-lane-smoke.yml` → 0 件 | PASS。判定は SSOT 1 箇所、新規 inline judgment なし |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（UI 非変更）。CI gate 基盤のみ。新設の `pr-lane-smoke.yml` は comment-only / 非 required で既存 gate 6 本・main ruleset の required 10 context を一切変更しない。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/github/pr-lane.test.ts` に `classifyLane` の 4 lane 分類（AC2 の 6 境界）+ 優先順位（bot 優先 / integration 先行）+ back-merge（main→develop = feature）+ 空/null 堅牢性 + trim + `parseArgs` CLI を 19 件追加
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は CI gate 基盤（script + composite action + smoke workflow + unit test）のみで UI 変更を含まない。docs/DESIGN.md §9 禁忌事項はいずれも非該当。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `classifyLane`（判定）/ `parseArgs`（入力収集）/ composite action（配線）で単一責任分離。判定 logic は SSOT 1 箇所のみ
- [x] **DRY**: lane 判定を 1 純粋関数に集約。既存の inline 重複（Dependabot exempt × 6 workflow / main-pr-base-guard bash）を将来吸収可能にする基盤（本 PR では既存改変せず、A-2〜A-5 で消費）
- [x] **YAGNI**: lane は 4 種固定。汎用 rule engine 化せず switch 相当の決定的分類のみ（ADR-0010）。back-merge も 5 つ目の lane を作らず既存 feature に帰属
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし。composite action は context を env 経由で渡し bash 引数注入を回避
- [x] **アクセシビリティ**: N/A（UI 非変更）
- [x] **パフォーマンス**: pure function（O(1) 文字列比較）。bundle 影響なし（CI script のみ、本番 bundle 非搭載）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [x] 並行 PR overlap 確認 (#1200): Phase A 兄弟（A-2〜A-5）は本 SSOT を **消費する側**で本 PR と file overlap なし。`resolve-base-branch.mjs`（#2959）とは別 file・別責務
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:

1. **back-merge lane 帰属判断**: hotfix を main に merge した後の main → develop back-merge PR（head=main / base=develop、branch-strategy.md §3 / #2967 実地観測）は、`classifyLane` の rule 4（`baseRef === 'develop'`）で **`feature`（軽量レーン）** に分類される。develop に取り込む変更は軽量レーン gate で十分であり、no-go「lane を 4 種から増やさない」（ADR-0010 Pre-PMF）を遵守して 5 つ目の lane を新設していない。rule 2 の integration（head=develop & base=main）は back-merge の逆向きのため衝突しない。test「back-merge: main → develop は feature 軽量レーンに帰属」で固定。
2. **`resolve-base-branch.mjs`（#2959）との統合評価**: 統合**しない**判断。`pr-lane.mjs` は PR event payload の確定値（base/head/actor）を入力する **pure function**（副作用ゼロ、AC6）であり CI gate 用。一方 `resolve-base-branch.mjs` は local git / gh を `execSync` で走査する **副作用関数**でクライアント tooling 用（「現在の branch がどの base に push すべきか」を推定）。入力源・用途・副作用の有無が異なり、片方を他方の入力にすると pure function の testability（AC6 / unit test 境界網羅）が崩れる。概念整合は両 file の冒頭コメントで相互参照済（#2943 related の評価結果）。
3. **gitignore 変更**: `actions/pr-lane/action.yml` が screenshot 用 `pr-*/` rule（`.gitignore` L105）に偶発マッチするため `!actions/**` で un-ignore した。screenshot dir（`pr-9999/` 等）は引き続き ignore されることを `git check-ignore` で確認済。
4. **main-pr-base-guard 非置換**: #2942 マネージャ判断 5 に従い、`ci.yml` の既存 `main-pr-base-guard` bash 判定は本 PR で改修していない（CLI export を提供するに留め、置換は A-6 で「将来 SSOT 化候補」と注記される）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A（UI 非変更）
- [x] 認証画面変更時: N/A（認証画面非変更）
- [x] QA 承認・動作確認に必要な Dev 完遂宣言は済（実装・テスト・pre-ready 全 PASS）。`gh pr ready` 化の最終判断は監査マネージャに委ねるため本 PR は Draft 据え置き

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
