### PR TITLE
fix: #2971 clamp と rAF refresh の実行順序保証 — checklists 中央 modal の右端超過根治

### DIFF
--- a/src/lib/ui/components/PageGuideOverlay.svelte
+++ b/src/lib/ui/components/PageGuideOverlay.svelte
@@ -89,15 +89,27 @@ function renderBubble(
 	});
 
 	// selector 省略 step (= 画面中央 modal) のみ mount 後に driver.refresh() で再 positioning する。
-	// driver.js は popover を ae() で「mount 前の空 wrapper 実測幅」を使い center 配置するため、
+	// driver.js は popover を ee() で「mount 前の空 wrapper 実測幅」を使い center 配置するため、
 	// Svelte bubble mount 後に wrapper が最終幅 (max 360px) へ成長すると計測幅とずれ、特に CI mobile
 	// (production) では left = innerWidth/2 - realWidth/2 が過小評価され右端が viewport を超える
-	// (#2927: [mobile] checklists step#1 right=400.5 > 391)。element 紐付き step は driver.js の
-	// collision 回避が target 基準で正しく働くため refresh は不要 (refresh すると逆に再 mount 経由で
-	// 一時的な overlap を誘発しうる)。中央 modal に限定して最終幅で再 center させる。
+	// (#2971: [mobile] checklists step#1 right=400.5 > 391)。element 紐付き step は driver.js の
+	// collision 回避が target 基準で正しく働くため refresh は不要。中央 modal に限定して最終幅で
+	// 再 center させる。
+	//
+	// 重要: driver.js の refresh() は be() → ne() のみ呼び、ee() (onPopoverRender を含む) は
+	// 呼ばない (#2971 調査確定)。そのため refresh 後に clamp が自動的に再適用されることはなく、
+	// 明示的に再実行する必要がある。
+	// 実行順序:
+	//   [1] d.refresh() → ne() で「Svelte bubble mount 後の正しい幅」を使い style.left/top を再計算
+	//   [2] clampPopoverToViewport() で viewport 超過分を transform で補正 (#2971 根治)
 	if (!step.selector && typeof requestAnimationFrame === 'function') {
 		requestAnimationFrame(() => {
-			if (driverInstance === d && d.isActive()) d.refresh();
+			if (driverInstance === d && d.isActive()) {
+				d.refresh();
+				// [2] refresh は onPopoverRender を再発火しないため clamp を明示再実行する (#2971)
+				const popoverWrapper = document.getElementById('driver-popover-content');
+				if (popoverWrapper) clampPopoverToViewport(popoverWrapper);
+			}
 		});
 	}
 }
@@ -114,8 +126,10 @@ function renderBubble(
  * なぜ transform か:
  *   - driver.js の position: absolute + top/left に重ねるだけで layout flow に影響しない
  *   - driver.js が次のステップ遷移で reset するため永続的な副作用がない
- *   - onPopoverRender は selector 省略 step の rAF refresh 後にも再発火するため、
- *     refresh → clamp の順序が自然に保たれる
+ *
+ * selector 省略 step (中央 modal) の rAF refresh 後の clamp 再適用について (#2971):
+ *   - driver.js の refresh() = be() → ne() のみ。ee() (onPopoverRender を含む) は呼ばない。
+ *   - そのため refresh 後の clamp 再適用は rAF ブロック内で明示的に行う (上部 startGuideStep 参照)。
  *
  * 両立不能 (target 要素が viewport の大半を占める等、幾何的に回避不能) な場合は補正しない。
  * そのような step は invariant spec の幾何 exempt 条件 (assertBubbleNotOverlapTarget) が正しく吸収する。
@@ -176,8 +190,8 @@ function buildDriveSteps(pageGuide: PageGuide): DriveStep[] {
 				// 1. Svelte bubble を driver.js wrapper に mount する
 				renderBubble(popover.wrapper, pageGuide, step, d);
 				// 2. mount 後に viewport clamp を適用する (#2971 render 層の構成的保証)。
-				//    onPopoverRender は driver.js の配置完了後 + selector 省略 step の rAF refresh 後にも
-				//    再発火するため、clamp は常に最終配置位置に対して効く。
+				//    selector 省略 step の rAF refresh 後は onPopoverRender は再発火しないため、
+				//    startGuideStep の rAF ブロック内で明示的に clamp を再実行している。
 				clampPopoverToViewport(popover.wrapper);
 			},
 		},


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: `/admin/checklists` のページガイド初回ステップ (step#1、中央 modal) が [mobile] viewport で右端を超過し (`right=400.5 > 391`)、bubble が画面外に見切れる。3 round 連続・deterministic に失敗していた (#2968 統合 gate BLOCK 要因)。

**期待される効果**: 中央 modal の viewport clamp が `d.refresh()` 後も正しく再適用され、mobile/desktop どちらでも bubble が viewport 内に収まる。

## 関連 Issue

closes #2971

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | PageGuideOverlay に viewport clamp (+ 非重複 fallback) を実装、特定 page/step への個別パッチなし | `git diff origin/develop HEAD -- src/lib/ui/components/PageGuideOverlay.svelte` | HEAD `8ed41792f` / 変更は `PageGuideOverlay.svelte` 1 ファイルのみ。個別 page パッチなし |
| AC2 | `page-guide-layout-invariant.spec.ts` 全 page × 全 project PASS (CI で確認) | `npx playwright test tests/e2e/page-guide-layout-invariant.spec.ts --project=mobile --repeat-each=3` | HEAD `8ed41792f` / 184 passed (exit 0)。local PASS 確認済 |
| AC3 | rAF refresh と clamp の実行順序を明記 (コメント) | `grep -A 15 "requestAnimationFrame" src/lib/ui/components/PageGuideOverlay.svelte` | HEAD `8ed41792f` / `PageGuideOverlay.svelte` L108-114 に実行順序 [1][2] を明示コメント |
| AC4 | 統合 PR #2968 の heavy gate green 化 | CI で `page-guide-layout-invariant` PASS を確認 | 本 PR の CI 結果で確認 (develop ブランチへのベース PR) |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)

**影響を受ける画面・機能**:
- `PageGuideOverlay.svelte` — 全 admin ページの「?」ページガイドバブル (selector-less step = 中央 modal のみ影響)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要: N/A — `page-guide-layout-invariant.spec.ts` は無変更。invariant spec が ADR-0006 に従いすでに回帰保護を提供している
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (priority:high、critical ではない)

## スクリーンショット / ビジュアルデモ

本 PR は UI レイアウトのバグ修正 (viewport clamp の実行順序保証)。見た目の変化はなく、viewport 超過が解消されることが変化点。

UI 変更を含まない PR (fix のみ) — レイアウト超過解消は E2E spec で機械検証済み。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — `clampPopoverToViewport` の責務は変わらず、rAF ブロック内での再呼び出しを追加するのみ
- [x] **DRY**: 同一関数 `clampPopoverToViewport` を再利用。重複ロジックなし
- [x] **YAGNI**: 現要件に不要な抽象化を追加していない
- [x] **Security（OSS 公開前提）**: N/A (UI positioning のみ)
- [x] **アクセシビリティ**: N/A (popup 位置補正のみ)
- [x] **パフォーマンス**: rAF 1 回の追加 DOM 参照 (`getElementById`) のみ。N+1 なし

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- driver.js の `refresh()` が `onPopoverRender` を再発火しないことを `node_modules/driver.js/dist/driver.js.iife.js` の実装追跡で確認済み (`refresh = H → rAF(be) → be() → ne()` のみ、`ee()` は呼ばない)
- selector 省略 step (中央 modal) のみに rAF + clamp 再実行を限定。element 紐付き step には不要なため非適用 (driver.js の collision 回避が target 基準で正しく動作するため)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装完了済み
- [x] UI 変更なし (layout 超過解消のみ、見た目変化なし)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)