### PR TITLE
fix: #2971 round3 — popover 幅の runtime px clamp (CSS 100vw の emulation 乖離に依存しない構成的保証)

### DIFF
--- a/src/lib/ui/components/PageGuideOverlay.svelte
+++ b/src/lib/ui/components/PageGuideOverlay.svelte
@@ -127,6 +127,16 @@ function renderBubble(
  *   - driver.js の position: absolute + top/left に重ねるだけで layout flow に影響しない
  *   - driver.js が次のステップ遷移で reset するため永続的な副作用がない
  *
+ * 【width clamp — round3 (#2971)】
+ * CI の project=mobile (Pixel 7、layout 412px) 内で invariant spec が viewport を 390px へ
+ * resize する二重 emulation 環境では、CSS `max-width: min(360px, calc(100vw - 24px))` の
+ * `100vw` 評価が 412px 基準のまま (or reflow race) になり幅 388px → 右端 400.5 > 391 と
+ * viewport を超過する (QM CI artifact run 27045487339 で確定診断)。
+ * CSS vw に依存しない runtime px での幅 clamp を translate 補正前に実施し、
+ * `el.style.maxWidth` を `window.innerWidth - 2*pad` px に直接設定して
+ * 再計測 → translate 補正の順序を保証する。
+ * 100vw 評価が emulation/reflow race で viewport と乖離する CI 環境への runtime px 保証 (#2971 round3)。
+ *
  * selector 省略 step (中央 modal) の rAF refresh 後の clamp 再適用について (#2971):
  *   - driver.js の refresh() = be() → ne() のみ。ee() (onPopoverRender を含む) は呼ばない。
  *   - そのため refresh 後の clamp 再適用は rAF ブロック内で明示的に行う (上部 startGuideStep 参照)。
@@ -142,7 +152,19 @@ function clampPopoverToViewport(wrapper: HTMLElement): void {
 	const vh = window.innerHeight;
 	const pad = 8; // stagePadding と同値
 
+	// --- runtime px 幅 clamp (#2971 round3) ---
+	// CSS `max-width: min(360px, calc(100vw - 24px))` の `100vw` は CI 二重 emulation 環境
+	// (project=mobile layout 412px → invariant spec が 390px resize) で乖離するため、
+	// window.innerWidth 基準の runtime px 値を style.maxWidth に直接設定して確実に
+	// viewport 内に収める。CSS vw に依存しない構成的保証。
+	// 100vw 評価が emulation/reflow race で viewport と乖離する CI 環境への runtime px 保証 (#2971 round3)。
+	const maxW = vw - 2 * pad;
+	if (rect.width > maxW) {
+		wrapper.style.maxWidth = `${maxW}px`;
+	}
+
 	// 現在の transform を除去して素の位置を取得するため、一時的に transform をリセットする。
+	// maxWidth 変更後の最新 rect が必要なため transform リセット → getBoundingClientRect の順で実行。
 	// driver.js は style.transform を直接操作しないため、既存 transform は本 clamp が設定したもの。
 	const prevTransform = wrapper.style.transform;
 	wrapper.style.transform = '';


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: CI の `project=mobile` (Pixel 7、layout 412px) + invariant spec viewport resize (390px) の二重 emulation 環境で、PageGuide popover の右端が viewport を超過し (`right=400.5 > 391`)、レイアウト invariant spec が FAIL していた問題を修正する。

**期待される効果**: PageGuide がモバイル画面でも必ず viewport 内に収まることが機械保証され、CI の `[mobile] /admin/checklists step#1` 等での false fail が解消される。

## 関連 Issue

Refs #2971

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | invariant spec mobile 3回繰り返し 全 PASS | `CI=true npx playwright test tests/e2e/page-guide-layout-invariant.spec.ts --project=mobile --no-deps --repeat-each=3` | HEAD `6df2237aa` / 66 passed (22 tests × 3 repeats) |
| AC2 | invariant spec tablet 全 PASS | `CI=true npx playwright test tests/e2e/page-guide-layout-invariant.spec.ts --project=tablet` | HEAD `6df2237aa` / 22 passed |
| AC3 | presence spec 全 PASS | `CI=true npx playwright test tests/e2e/admin-page-guide-presence.spec.ts` | HEAD `6df2237aa` / 22 passed |
| AC4 | biome check PASS | `npx biome check src/lib/ui/components/PageGuideOverlay.svelte` | Checked 1 file. No fixes applied |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 全 admin ページの PageGuide overlay (mobile/tablet viewport)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）: 既存 invariant spec / presence spec が PASS することで検証
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — layout invariant fix

## スクリーンショット / ビジュアルデモ

UI 変更を含まない PR (runtime clamp ロジックのみ) — **該当なし（CSS vw 評価の runtime 補正のみ、見た目の変化なし）**

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `clampPopoverToViewport()` 関数内の単一責任 (viewport clamp のみ)
- [x] **DRY**: 同一 clamp ロジックは本関数 1 箇所のみ
- [x] **YAGNI**: 必要最小限の `style.maxWidth` 設定のみ追加
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A（ポジショニングロジックのみ）
- [x] **パフォーマンス**: `getBoundingClientRect` 追加呼び出しは 1 回のみ、rAF 内での実行

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（`PageGuideOverlay.svelte` の内部 clamp ロジックのみ）

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: `clampPopoverToViewport()` 内で `style.maxWidth` を設定した後に `transform = ''` → `getBoundingClientRect()` → translate 補正の順序が正しく維持されているか確認お願いします。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2978` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済みで完遂している（未完成 AC はゼロ）
- [x] Phase 分割なし
- [x] UI 変更なし — SS 不要（runtime clamp ロジックのみの変更）
- [x] 認証画面変更なし

## QM レビュー結果

<!-- QM が記入。フォーマット・必須手順は docs/sessions/qa-session.md「Tier 2 手順 5」を参照。
     CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（ADR-0022）。 -->

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)