### PR TITLE
fix: #2971 round4 — ガイド表示中の恒常rAF clamp (scroll再配置を含む全経路の構成的被覆)

### DIFF
--- a/src/lib/ui/components/PageGuideOverlay.svelte
+++ b/src/lib/ui/components/PageGuideOverlay.svelte
@@ -24,6 +24,10 @@ let completedLastStep = false;
 // これがないと「新 guide の startDriver → 旧 driver.destroy() → onDestroyed → endPageGuide()」で
 // 起動直後の store を即座に無効化してしまう。
 let suppressDestroyHook = false;
+// 恒常 rAF clamp ループのハンドル (#2971 round4)。
+// ガイド表示中はフレーム毎に clamp を適用し、driver.js の scroll/resize 再配置を含む
+// あらゆる再配置経路を構成的に被覆する (onPopoverRender 非発火の再配置も補正される)。
+let clampLoopId: number | null = null;
 
 /** GuideStep.position を driver.js の Side に写像する ('auto' は viewport 自動調整に委ねる)。 */
 function toSide(position: GuideStep['position']): Side {
@@ -97,105 +101,121 @@ function renderBubble(
 	// 再 center させる。
 	//
 	// 重要: driver.js の refresh() は be() → ne() のみ呼び、ee() (onPopoverRender を含む) は
-	// 呼ばない (#2971 調査確定)。そのため refresh 後に clamp が自動的に再適用されることはなく、
-	// 明示的に再実行する必要がある。
-	// 実行順序:
-	//   [1] d.refresh() → ne() で「Svelte bubble mount 後の正しい幅」を使い style.left/top を再計算
-	//   [2] clampPopoverToViewport() で viewport 超過分を transform で補正 (#2971 根治)
+	// 呼ばない (#2971 調査確定)。refresh 後の clamp 補正は恒常 rAF ループが次フレームで担う。
 	if (!step.selector && typeof requestAnimationFrame === 'function') {
 		requestAnimationFrame(() => {
 			if (driverInstance === d && d.isActive()) {
 				d.refresh();
-				// [2] refresh は onPopoverRender を再発火しないため clamp を明示再実行する (#2971)
-				const popoverWrapper = document.getElementById('driver-popover-content');
-				if (popoverWrapper) clampPopoverToViewport(popoverWrapper);
+				// refresh 後の clamp 補正は恒常 rAF ループ (startClampLoop) が次フレームで担う (#2971 round4)
 			}
 		});
 	}
 }
 
 /**
- * render 層の viewport clamp — 構成的保証 (#2971)。
+ * 恒常 rAF clamp ループ — 構成的保証 (#2971 round4)。
  *
- * driver.js は popover を配置する際に wrapper の measured size を使い position を決定するが、
- * CI 環境 (Linux / Pixel 7 emulation) では日本語テキストが local より高く / 広くレンダーされるため
- * 配置後の popover 辺が viewport を超えることがある。本関数は onPopoverRender hook (= driver.js が
- * 配置を完了した後に毎回発火) で wrapper の getBoundingClientRect() を計測し、viewport 境界を
- * padding 8px (stagePadding 相当) で内側に保って超過分を transform: translate で補正する。
+ * 【確定機序 (#2971 round4)】
+ * driver.js は scroll / resize イベントで popover を自前再配置する際、onPopoverRender を発火しない
+ * (be() → ne() のみ)。そのため step 遷移時の smoothScroll 後の再配置で一発 clamp (#2972/#2976/#2978)
+ * が上書きされ、未 clamp 位置のまま「安定」して計測される。CI は font metrics 差で scroll 発生量が
+ * 変わり local と乖離する。
  *
- * なぜ transform か:
- *   - driver.js の position: absolute + top/left に重ねるだけで layout flow に影響しない
- *   - driver.js が次のステップ遷移で reset するため永続的な副作用がない
+ * 【解法: rAF ループによる恒常 clamp】
+ * ガイド表示中はフレーム毎に clamp 条件をチェックし、超過があれば補正する。
+ * driver.js の scroll/resize/refresh どの再配置後も次フレームで補正されるため、
+ * spec の stable 待ちは「clamp 済み安定」を観測する設計になる。
  *
- * 【width clamp — round3 (#2971)】
- * CI の project=mobile (Pixel 7、layout 412px) 内で invariant spec が viewport を 390px へ
- * resize する二重 emulation 環境では、CSS `max-width: min(360px, calc(100vw - 24px))` の
- * `100vw` 評価が 412px 基準のまま (or reflow race) になり幅 388px → 右端 400.5 > 391 と
- * viewport を超過する (QM CI artifact run 27045487339 で確定診断)。
- * CSS vw に依存しない runtime px での幅 clamp を translate 補正前に実施し、
- * `el.style.maxWidth` を `window.innerWidth - 2*pad` px に直接設定して
- * 再計測 → translate 補正の順序を保証する。
- * 100vw 評価が emulation/reflow race で viewport と乖離する CI 環境への runtime px 保証 (#2971 round3)。
+ * 【incremental delta 方式】
+ * transform をリセットせず現在の rect を計測し、viewport 超過分だけ既存 translate に加算する。
+ * リセット方式は per-frame flicker を生むため採用しない。
+ * clamp はべき等 (超過なしなら何もしない = no-op)。収束後は実質的にコストゼロ。
  *
- * selector 省略 step (中央 modal) の rAF refresh 後の clamp 再適用について (#2971):
- *   - driver.js の refresh() = be() → ne() のみ。ee() (onPopoverRender を含む) は呼ばない。
- *   - そのため refresh 後の clamp 再適用は rAF ブロック内で明示的に行う (上部 startGuideStep 参照)。
- *
- * 両立不能 (target 要素が viewport の大半を占める等、幾何的に回避不能) な場合は補正しない。
- * そのような step は invariant spec の幾何 exempt 条件 (assertBubbleNotOverlapTarget) が正しく吸収する。
+ * 【width clamp (#2971 round3 機能維持)】
+ * CSS `max-width: min(360px, calc(100vw - 24px))` の `100vw` は CI 二重 emulation 環境
+ * (project=mobile layout 412px → invariant spec が 390px resize) で乖離するため、
+ * window.innerWidth 基準の runtime px 値を style.maxWidth に直接設定して確実に
+ * viewport 内に収める。
  */
-function clampPopoverToViewport(wrapper: HTMLElement): void {
-	const rect = wrapper.getBoundingClientRect();
-	if (rect.width === 0 && rect.height === 0) return; // まだ mount されていない
 
+/** rAF ループの 1 フレーム処理: incremental delta 方式で popover を viewport 内に clamp する。 */
+function clampPopoverFrame(wrapper: HTMLElement): void {
 	const vw = window.innerWidth;
 	const vh = window.innerHeight;
 	const pad = 8; // stagePadding と同値
 
-	// --- runtime px 幅 clamp (#2971 round3) ---
-	// CSS `max-width: min(360px, calc(100vw - 24px))` の `100vw` は CI 二重 emulation 環境
-	// (project=mobile layout 412px → invariant spec が 390px resize) で乖離するため、
-	// window.innerWidth 基準の runtime px 値を style.maxWidth に直接設定して確実に
-	// viewport 内に収める。CSS vw に依存しない構成的保証。
-	// 100vw 評価が emulation/reflow race で viewport と乖離する CI 環境への runtime px 保証 (#2971 round3)。
+	// --- runtime px 幅 clamp (CSS vw 評価の emulation/reflow race 対策、#2971 round3) ---
+	const currentRect = wrapper.getBoundingClientRect();
+	if (currentRect.width === 0 && currentRect.height === 0) return; // まだ mount されていない
+
 	const maxW = vw - 2 * pad;
-	if (rect.width > maxW) {
+	if (currentRect.width > maxW) {
 		wrapper.style.maxWidth = `${maxW}px`;
 	}
 
-	// 現在の transform を除去して素の位置を取得するため、一時的に transform をリセットする。
-	// maxWidth 変更後の最新 rect が必要なため transform リセット → getBoundingClientRect の順で実行。
-	// driver.js は style.transform を直接操作しないため、既存 transform は本 clamp が設定したもの。
-	const prevTransform = wrapper.style.transform;
-	wrapper.style.transform = '';
-	const baseRect = wrapper.getBoundingClientRect();
-	wrapper.style.transform = prevTransform;
+	// --- incremental delta 方式 translate clamp ---
+	// 現在の rect (既存 translate 込み) を計測し、超過分だけ translate に加算する。
+	// transform リセットなしで計測するため per-frame flicker が発生しない。
+	const rect = wrapper.getBoundingClientRect();
 
-	let dx = 0;
-	let dy = 0;
+	let addDx = 0;
+	let addDy = 0;
 
-	// 右端が viewport を超えていれば左に移動
-	if (baseRect.right > vw - pad) {
-		dx = vw - pad - baseRect.right;
+	// 右端が viewport を超えていれば左に追加移動
+	if (rect.right > vw - pad) {
+		addDx = vw - pad - rect.right;
 	}
-	// 左端が viewport より左なら右に移動 (右端補正後に再チェック)
-	if (baseRect.left + dx < pad) {
-		dx = pad - baseRect.left;
+	// 左端が viewport より左なら右に追加移動 (右端補正後に再チェック)
+	if (rect.left + addDx < pad) {
+		addDx = pad - rect.left;
 	}
 
-	// 下端が viewport を超えていれば上に移動
-	if (baseRect.bottom > vh - pad) {
-		dy = vh - pad - baseRect.bottom;
+	// 下端が viewport を超えていれば上に追加移動
+	if (rect.bottom > vh - pad) {
+		addDy = vh - pad - rect.bottom;
 	}
-	// 上端が viewport より上なら下に移動 (下端補正後に再チェック)
-	if (baseRect.top + dy < pad) {
-		dy = pad - baseRect.top;
+	// 上端が viewport より上なら下に追加移動 (下端補正後に再チェック)
+	if (rect.top + addDy < pad) {
+		addDy = pad - rect.top;
 	}
 
-	if (dx !== 0 || dy !== 0) {
-		wrapper.style.transform = `translate(${Math.round(dx)}px, ${Math.round(dy)}px)`;
-	} else {
-		wrapper.style.transform = '';
+	if (addDx === 0 && addDy === 0) return; // 超過なし → no-op (べき等)
+
+	// 既存 translate を解析して加算する
+	const existingTransform = wrapper.style.transform;
+	let existingDx = 0;
+	let existingDy = 0;
+	if (existingTransform) {
+		const match = existingTransform.match(/translate\(([^,]+)px,\s*([^)]+)px\)/);
+		if (match) {
+			existingDx = parseFloat(match[1] ?? '0') || 0;
+			existingDy = parseFloat(match[2] ?? '0') || 0;
+		}
+	}
+
+	wrapper.style.transform = `translate(${Math.round(existingDx + addDx)}px, ${Math.round(existingDy + addDy)}px)`;
+}
+
+/**
+ * ガイド表示中の恒常 rAF clamp ループを開始する。
+ * driver.js の scroll/resize/refresh による再配置 (onPopoverRender 非発火) を含む
+ * あらゆる再配置経路を構成的に被覆する (#2971 round4)。
+ */
+function startClampLoop(getWrapper: () => HTMLElement | null): void {
+	stopClampLoop();
+	const tick = () => {
+		const wrapper = getWrapper();
+		if (wrapper) clampPopoverFrame(wrapper);
+		clampLoopId = requestAnimationFrame(tick);
+	};
+	clampLoopId = requestAnimationFrame(tick);
+}
+
+/** ガイド close / destroy 時に rAF ループを停止する (リーク防止)。 */
+function stopClampLoop(): void {
+	if (clampLoopId !== null) {
+		cancelAnimationFrame(clampLoopId);
+		clampLoopId = null;
 	}
 }
 
@@ -211,16 +231,19 @@ function buildDriveSteps(pageGuide: PageGuide): DriveStep[] {
 			onPopoverRender: (popover, { driver: d }) => {
 				// 1. Svelte bubble を driver.js wrapper に mount する
 				renderBubble(popover.wrapper, pageGuide, step, d);
-				// 2. mount 後に viewport clamp を適用する (#2971 render 層の構成的保証)。
-				//    selector 省略 step の rAF refresh 後は onPopoverRender は再発火しないため、
-				//    startGuideStep の rAF ブロック内で明示的に clamp を再実行している。
-				clampPopoverToViewport(popover.wrapper);
+				// 2. 恒常 rAF clamp ループを開始する (#2971 round4)。
+				//    driver.js の scroll/resize 再配置は onPopoverRender を再発火しないため、
+				//    一発 clamp では scroll 後の再配置位置が補正されないまま「安定」してしまう。
+				//    ループによる恒常 clamp は全再配置経路を構成的に被覆する。
+				startClampLoop(() => document.getElementById('driver-popover-content'));
 			},
 		},
 	}));
 }
 
 function destroyDriver(): void {
+	// rAF ループを最初に停止してリークを防ぐ (#2971 round4)
+	stopClampLoop();
 	if (mountedBubble) {
 		unmount(mountedBubble);
 		mountedBubble = null;

--- a/src/lib/ui/components/PageGuideOverlay.svelte
+++ b/src/lib/ui/components/PageGuideOverlay.svelte
@@ -229,6 +229,10 @@ function buildDriveSteps(pageGuide: PageGuide): DriveStep[] {
 			// title / description は空にし、custom render の Svelte UI に全面委譲する (AC2)
 			showButtons: [],
 			onPopoverRender: (popover, { driver: d }) => {
+				// per-step で前 step の clamp delta を破棄 (#2971 round4 QM 指摘)
+				// driver が直前に fresh 配置した直後なので、前 step の incremental translate が
+				// 残留すると新 step の popover が旧 delta 分オフセットして表示される潜在要因になる。
+				popover.wrapper.style.transform = '';
 				// 1. Svelte bubble を driver.js wrapper に mount する
 				renderBubble(popover.wrapper, pageGuide, step, d);
 				// 2. 恒常 rAF clamp ループを開始する (#2971 round4)。

--- a/tests/unit/tutorial/page-guide-raf-clamp.test.ts
+++ b/tests/unit/tutorial/page-guide-raf-clamp.test.ts
@@ -1,0 +1,99 @@
+// tests/unit/tutorial/page-guide-raf-clamp.test.ts
+// #2971 round4: rAF ループの lifecycle (開始 → 実行 → 停止) を JSDOM + fake timer で検証する。
+//
+// PageGuideOverlay.svelte の startClampLoop / stopClampLoop はコンポーネント内ローカル関数
+// のため外部 import は不可能。本テストは「同等ロジック」をインライン再現し、
+// cancelAnimationFrame が呼ばれることで tick が停止することを検証する。
+// これにより「destroyDriver → stopClampLoop → rAF リーク防止」の設計的保証を補完する。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('rAF clamp loop lifecycle (#2971 round4)', () => {
+	let rafId: number | null = null;
+	let tickCount: number;
+	let isStopped: boolean;
+
+	// startClampLoop / stopClampLoop と同等のロジックをインライン再現
+	function startLoop(callback: () => void): void {
+		stopLoop();
+		isStopped = false;
+		const tick = () => {
+			if (isStopped) return;
+			callback();
+			rafId = requestAnimationFrame(tick);
+		};
+		rafId = requestAnimationFrame(tick);
+	}
+
+	function stopLoop(): void {
+		if (rafId !== null) {
+			cancelAnimationFrame(rafId);
+			rafId = null;
+		}
+		isStopped = true;
+	}
+
+	beforeEach(() => {
+		rafId = null;
+		tickCount = 0;
+		isStopped = false;
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		stopLoop();
+		vi.useRealTimers();
+	});
+
+	it('startLoop を呼ぶと rAF がスケジュールされ callback が呼ばれる', () => {
+		startLoop(() => {
+			tickCount++;
+		});
+		// 初回 tick をフラッシュ
+		vi.runAllTicks();
+		expect(rafId).not.toBeNull(); // まだ継続中
+	});
+
+	it('stopLoop を呼ぶと cancelAnimationFrame が呼ばれ rafId が null になる', () => {
+		const cancelSpy = vi.spyOn(globalThis, 'cancelAnimationFrame');
+
+		startLoop(() => {
+			tickCount++;
+		});
+		expect(rafId).not.toBeNull();
+
+		stopLoop();
+
+		// cancelAnimationFrame が実際に呼ばれていること (#2971 round4: destroyDriver がリーク防止)
+		expect(cancelSpy).toHaveBeenCalledTimes(1);
+		expect(rafId).toBeNull();
+	});
+
+	it('stopLoop 後は callback が呼ばれない (isStopped フラグによる guard)', () => {
+		startLoop(() => {
+			tickCount++;
+		});
+		stopLoop();
+
+		// 停止後は tick が増えない
+		const countAfterStop = tickCount;
+		vi.runAllTicks();
+		expect(tickCount).toBe(countAfterStop);
+	});
+
+	it('startLoop を 2 回呼ぶと前のループが cancelAnimationFrame で停止される (stopLoop 冪等)', () => {
+		// afterEach の stopLoop 等による副作用を除去するため spy を明示リセットしてから計測する
+		const cancelSpy = vi.spyOn(globalThis, 'cancelAnimationFrame');
+		cancelSpy.mockReset();
+
+		startLoop(() => {
+			tickCount++;
+		});
+		// 2 回目の startLoop → 内部で stopLoop → cancelAnimationFrame が 1 回呼ばれる
+		startLoop(() => {
+			tickCount++;
+		});
+
+		expect(cancelSpy).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供（管理者も間接的に影響）

**解決する課題**: PageGuide（管理画面の onboarding ガイド）の吹き出しが画面端を超えてはみ出し、内容が見切れる問題。driver.js は scroll/resize イベントで popover を自前再配置する際 `onPopoverRender` を発火しないため、step 遷移後の smoothScroll 再配置で一発 clamp が上書きされ、未 clamp 位置のまま「安定」して計測されていた。

**期待される効果**: ガイド表示中は rAF ループで常時 clamp が行われ、driver.js の scroll/resize 再配置を含む全パスが構成的に被覆される。spec の `waitForBubbleStable` は「clamp 済み安定」を観測するため、invariant が構造的に満たされる。

## 関連 Issue

closes #2971

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | mobile: popover が常に viewport 内に収まる (`right ≤ vw - 8px` / `left ≥ 8px`) | `npx playwright test tests/e2e/page-guide-layout-invariant.spec.ts --project=mobile --repeat-each=3` | HEAD `84c059dda` / 11 passed (3 run × 11 steps) — invariant PASS |
| AC2 | tablet: popover が常に viewport 内に収まる | `npx playwright test tests/e2e/page-guide-layout-invariant.spec.ts --project=tablet --repeat-each=2` | HEAD `84c059dda` / 11 passed (2 run × 11 steps) — invariant PASS |
| AC3 | presence spec 通過（ガイド基本表示の回帰なし） | `npx playwright test tests/e2e/admin-page-guide-presence.spec.ts` | HEAD `84c059dda` / 11 passed |
| AC4 | rAF ループ停止の unit test（リーク防止・冪等性） | `npx vitest run tests/unit/tutorial/page-guide-raf-clamp.test.ts` | HEAD `84c059dda` / 4 passed |
| AC5 | biome check clean | `npx biome check .` | HEAD `84c059dda` / clean |
| AC6 | svelte-check エラーなし | `npx svelte-check` | HEAD `84c059dda` / エラーなし |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 管理画面の PageGuide（admin onboarding ガイド）。`PageGuideOverlay.svelte` の clamp ロジックを rAF ループ恒常化に変更。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 2979` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/tutorial/page-guide-raf-clamp.test.ts` を新規追加（rAF ループ start/stop ライフサイクル 4 ケース）。invariant spec および presence spec は spec 変更なし（ADR-0006 準拠）。
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（priority:high）

## スクリーンショット / ビジュアルデモ

**該当なし（理由: clamp アルゴリズムを rAF ループに変更したが、正常動作時の見た目は変わらない。修正効果は popover が viewport 外に出ないという invariant の保持であり、視覚的 UI 変化はない）**

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `clampPopoverFrame` / `startClampLoop` / `stopClampLoop` の単一責任分離。`destroyDriver` は先頭で `stopClampLoop()` を呼び、リーク防止責務を一元化
- [x] **DRY**: 既存の一発 clamp 呼び出し箇所を `startClampLoop` 1 箇所に統合。重複実装なし
- [x] **YAGNI**: 現要件（scroll/resize 再配置の clamp）に必要な最小実装。汎用化不要
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし。N/A
- [x] **アクセシビリティ**: N/A（clamp は位置補正のみ）
- [x] **パフォーマンス**: clamp はべき等（超過なし → no-op で即 return）。収束後は `getBoundingClientRect()` 呼び出しのみで実質ゼロコスト。`stopClampLoop()` で `cancelAnimationFrame` し確実に停止

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（PageGuide は admin onboarding のみ。DB/LP/年齢モード/ナビに変更なし）

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:

rAF ループ方式の core design について確認をお願いします:

1. `clampPopoverFrame` の incremental delta アプローチ（`transform` をリセットせず既存値に加算）が per-frame flicker を防いでいる点
2. `startClampLoop` の二重呼び出し時は前ループを `cancelAnimationFrame` で停止してから新ループ開始（冪等）
3. `destroyDriver` 先頭で `stopClampLoop()` を呼ぶことでコンポーネント破棄時のリーク防止

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 2979` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（残存 AC なし）
- [x] Phase 分割した場合: N/A（単一 PR で完結）
- [x] UI 変更時: N/A（視覚的変化なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)