### PR TITLE
fix: #2971 round6 — invariant spec の viewport 比較を実座標空間 (window.innerWidth) に正確化

### DIFF
--- a/tests/e2e/page-guide-layout-invariant.spec.ts
+++ b/tests/e2e/page-guide-layout-invariant.spec.ts
@@ -74,7 +74,12 @@ async function assertBubbleWithinViewport(page: Page, bubble: Locator, ctx: stri
 	const box = await bubble.boundingBox();
 	expect(box, `${ctx}: バブルの bounding box が取得できる`).not.toBeNull();
 	if (!box) return;
-	const vp = page.viewportSize();
+	// #2971 round6: project device emulation 下では setViewportSize がページ layout に
+	// 反映されないことがあり、viewportSize() との比較は座標空間不一致になる。
+	// boundingBox() は実 CSS px 空間 (例: Pixel 7 emulation = 412px) を返すが、
+	// page.viewportSize() は要求値 (390px) を返すため比較が誤る。
+	// window.innerWidth を使うことで rect と同一座標空間を参照する。
+	const vp = await page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
 	expect(vp, `${ctx}: viewport size`).not.toBeNull();
 	if (!vp) return;
 	const tol = 1; // sub-pixel 丸め許容
@@ -197,6 +202,9 @@ test.describe('#2926 PageGuide layout invariant — driver.js 委譲後の (a)(b
 				page,
 			}) => {
 				await page.setViewportSize({ width, height });
+				// #2971 round6: 診断用 — 要求値と実 window.innerWidth の乖離をログ (assert はしない)
+				const actualVp = await page.evaluate(() => ({ w: window.innerWidth })).catch(() => null);
+				console.log(`[viewport-diag] requested=${width} actual=${actualVp?.w ?? 'unknown'}`);
 				await page.goto(path);
 				await page.waitForLoadState('domcontentloaded');
 				await dismissWelcome(page);


### PR DESCRIPTION
## 背景と目的

**サマリー**: 統合 PR #2968 の heavy gate で 8 round 継続した `[mobile] /admin/checklists step#1 (b) バブル右端超過` の確定根治。QM の最終診断: **invariant spec が要素 rect (実 layout 座標空間) を `page.viewportSize()` (要求値) と比較しており、project=mobile (Pixel 7 device emulation) 下では `setViewportSize(390)` がページ layout (412px のまま) に反映されず、分子と分母が別座標空間になっていた** — failure SS の child タブ縦書き squeeze (実機に存在しない描画) が証跡。component 側 7 連続 fix (round1-5: anchor/hint/clamp/loop/bubble maxWidth) が received=400.5 を 1px も動かせなかったのは、bubble が実ページ内 (412 空間) では正しく収まっていたため。

## 顧客価値・目的

invariant suite が「実ユーザーの viewport で bubble が収まるか」を正しく検証するようになり、偽陽性 (実害なしの fail) で統合 pipeline が止まる事態を根治。ガイドの実品質保証 (a)(b)(c) は全 page × 全 viewport で維持される。

## 関連 Issue

Refs #2971 (本 PR は develop 向けのため auto-close されない — #2968 heavy gate green 確認後に QM が手動 close 判断) / #2968 (統合 PR、BLOCK 解消対象)

## AC 検証マップ (ADR-0004)

| AC | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | viewport 比較を rect と同一座標空間 (window.innerWidth/innerHeight) に正確化 | diff: `page.viewportSize()` → `page.evaluate(() => ({width: innerWidth, height: innerHeight}))` | 実装済 — tol=1 / assert 構造 / 他 assert (overlap, spotlight) は一切不変 (ADR-0006: 弱体化でなく座標空間の正確化) |
| AC2 | 要求値と実値の乖離を診断ログ出力 (assert なし) | setViewportSize 直後の `[viewport-diag]` console.log | 実装済 |
| AC3 | invariant spec が両 project で PASS | local: mobile/tablet 実行 | local PASS (環境ノイズ除き)。**確証は #2968 heavy gate round 9 (CI) — merge 後に QM が確認** |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更カテゴリ**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ルート / ページ (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメイン層 (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`tests/e2e/page-guide-layout-invariant.spec.ts` 1 file のみ)

**影響を受ける画面・機能**: なし (E2E spec のみ、本番コード変更ゼロ)

## テスト & 安全装置セルフチェック

- [x] **テスト実行結果**: spec 自身の修正。local 実行で対象 spec PASS、確証は #2968 heavy gate (CI) で取得
- [x] 機能を変更したテストの形骸化なし: assert 閾値 (tol=1) / 構造は不変。比較基準を rect と同一座標空間に正したのみ — 偽陽性の除去であり検出力は維持 (実 viewport 超過は引き続き fail する)
- [x] **新規 env / secret 追加時** (ADR-0006): N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合** (ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

**該当なし (E2E spec のみ)** — UI 変更を含まない。診断根拠の failure SS (child タブ縦書き squeeze) は #2968 の CI artifact (run 27053321627) に記録済。

**4 スロット代入** (#1740):

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし (spec のみ) | 該当なし (spec のみ) |
| **修正後** | 該当なし (spec のみ) | 該当なし (spec のみ) |

**スクリーンショット状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A — spec 1 関数の比較基準修正
- [x] **DRY**: N/A
- [x] **YAGNI**: 診断 log は assert なしの最小追加
- [x] **Security (OSS 公開前提)**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:
- [ ] 本番ページ + デモ版同期
- [ ] LP → アプリ訴求整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [x] E2E / スクリーンショット + アサーション同期 — 同型の `page.viewportSize()` 比較が他 spec にあれば同修正候補 (本 PR は invariant spec のみ、横展開は #2971 close 時に grep 判断)
- [ ] labels SSOT
- [ ] 設計書同期
- [x] 並行 PR overlap 確認 (#1200) — 同 file を触る open PR なし

**LP / 訴求文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] この PR に破壊的変更は**含まれない**

**レビュー依頼事項**: 「弱体化ではない」ことの確認観点 — 実 viewport (innerWidth) を超える bubble は引き続き fail する。変わるのは「ページが見ていない座標 (要求値) との比較」が消えることのみ。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**: spec 1 file の変更。check-pr-body は body 是正後に PASS を確認
- [x] テンプレートの形骸な空欄・プレースホルダーなし
- [x] 全 AC が実装済 (AC3 の CI 確証は merge 後の heavy gate で取得と明記)
- [x] UI 変更時: N/A (spec のみ)
- [x] 認証画面変更時: N/A

## QM レビュー結果

(QM 5 手順 approve body は merge 時に記録)
