### PR TITLE
fix(auth): #2991 おやカギコード ロック時に解除予定時刻を明示

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -300,6 +300,7 @@ EPIC #2310 で `/admin/*` middleware が未認証時 `/switch?pinRequired=1&next
 | 入力 UI | `PinInput` primitive (4 桁、mask: true) |
 | 送信 | `POST /api/v1/parent-gate/verify { pin }` → `gq_parent_session` 署名 cookie 発行 |
 | 失敗時 | `pinError` 表示 + `pinInputKey += 1` で入力欄リセット |
+| ロックアウト時 (#2991) | 連続失敗でロックされた際、エラーに**ロック解除の絶対時刻**「HH:MM まで待ってから」を表示 (`OYAKAGI_LABELS.gateLockedUntilNotice`)。サーバが返す `lockedUntil` を `toLocaleTimeString('ja-JP',{hour,minute})` で整形。時刻不明時のみ `OYAKAGI_LABELS.lockedError` (時刻なし) を fallback。秒カウントダウンは不採用 (NIST SP 800-63B / iOS は残り時間明示、NN/g #1 visibility) |
 | 初期 PIN 5086 ヒント (#2353 設計欠陥 5、AC6) | **非表示** (子供が見て即入力できる脆弱性。`OYAKAGI_LABELS.gateDefaultHint` 空文字 + Svelte 側で `{#if hint}` 条件分岐) |
 | 「PINを忘れた方」link (#2353、AC5) | modal 下部に表示。click → `/auth/forgot-pin` 遷移 |
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -1325,7 +1325,11 @@ export const OYAKAGI_LABELS = {
 	gateModalTitle: `${OYAKAGI_TERMS.name}を入力してください`,
 	gateModalDescription: `${ADMIN_VIEW_TERMS.canonical}には${PARENT_TERMS.neutral}のみが入れます。${OYAKAGI_TERMS.name}を入力してください。`,
 	gateModalSubmitting: 'かくにん中…',
-	gateLockoutNotice: (sec: number) => `連続で間違えたため、${sec}秒後に再度お試しください`,
+	// #2991: ロック時は解除予定の絶対時刻を提示する (NIST SP 800-63B / iOS Security Lockout は残り時間明示、
+	// NN/g heuristic #1 visibility)。秒カウントダウンは temporal vigilance で不安を増幅するため絶対時刻型を採用
+	// (research: tmp/research/pin-gate-ux-ideal-state.md Q2)。timeStr は呼び出し側で「HH:MM」整形した文字列。
+	gateLockedUntilNotice: (timeStr: string) =>
+		`${OYAKAGI_TERMS.name}の入力に連続して失敗しました。${timeStr} まで待ってから再度お試しください`,
 	gateFormatNotice: `${OYAKAGI_TERMS.name}は4〜6桁の数字です`,
 	gateGenericError: `${OYAKAGI_TERMS.name}の確認に失敗しました。もう一度お試しください`,
 	// Issue #2353 Fix 5 (Phase A): gateDefaultHint (= '初期値は 5086（がんばり）です') は子供が見て即入れる脆弱性のため modal 用 atom を削除

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -1325,7 +1325,7 @@ export const OYAKAGI_LABELS = {
 	gateModalTitle: `${OYAKAGI_TERMS.name}を入力してください`,
 	gateModalDescription: `${ADMIN_VIEW_TERMS.canonical}には${PARENT_TERMS.neutral}のみが入れます。${OYAKAGI_TERMS.name}を入力してください。`,
 	gateModalSubmitting: 'かくにん中…',
-	// #2991: ロック時は解除予定の絶対時刻を提示する (NIST SP 800-63B / iOS Security Lockout は残り時間明示、
+	// #2991: ロック時は解除の絶対時刻を提示する (NIST SP 800-63B / iOS Security Lockout は残り時間明示、
 	// NN/g heuristic #1 visibility)。秒カウントダウンは temporal vigilance で不安を増幅するため絶対時刻型を採用
 	// (research: tmp/research/pin-gate-ux-ideal-state.md Q2)。timeStr は呼び出し側で「HH:MM」整形した文字列。
 	gateLockedUntilNotice: (timeStr: string) =>

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -74,7 +74,7 @@ async function handlePinComplete(details: { valueAsString: string }) {
 		pinInputKey += 1;
 		if (body.error === 'LOCKED_OUT' && body.lockedUntil) {
 			lockoutUntil = new Date(body.lockedUntil).getTime();
-			// #2991: 解除予定の絶対時刻 (HH:MM、ローカルタイム) を提示し「いつ再試行できるか」を明示する。
+			// #2991: 解除の絶対時刻 (HH:MM、ローカルタイム) を提示し「いつ再試行できるか」を明示する。
 			// lockedUntil が parse 不能な場合のみ時刻なし fallback (lockedError)。
 			const unlockTime = new Date(body.lockedUntil);
 			pinError = Number.isNaN(unlockTime.getTime())

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -74,7 +74,14 @@ async function handlePinComplete(details: { valueAsString: string }) {
 		pinInputKey += 1;
 		if (body.error === 'LOCKED_OUT' && body.lockedUntil) {
 			lockoutUntil = new Date(body.lockedUntil).getTime();
-			pinError = OYAKAGI_LABELS.lockedError;
+			// #2991: 解除予定の絶対時刻 (HH:MM、ローカルタイム) を提示し「いつ再試行できるか」を明示する。
+			// lockedUntil が parse 不能な場合のみ時刻なし fallback (lockedError)。
+			const unlockTime = new Date(body.lockedUntil);
+			pinError = Number.isNaN(unlockTime.getTime())
+				? OYAKAGI_LABELS.lockedError
+				: OYAKAGI_LABELS.gateLockedUntilNotice(
+						unlockTime.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' }),
+					);
 		} else if (body.error === 'PIN_FORMAT') {
 			pinError = OYAKAGI_LABELS.gateFormatNotice;
 		} else if (body.error === 'INVALID_PIN' || body.error === 'PIN_NOT_SET') {

--- a/tests/e2e/parent-gate.spec.ts
+++ b/tests/e2e/parent-gate.spec.ts
@@ -63,7 +63,7 @@ function registerParentGateTests(): void {
 			await expect(page.getByTestId('parent-gate-error')).toBeVisible({ timeout: 10_000 });
 		});
 
-		test('#2991: ロック時に解除予定の絶対時刻が表示される', async ({ page }) => {
+		test('#2991: ロック時に解除の絶対時刻が表示される', async ({ page }) => {
 			// 実 lockout (6 回失敗) は PinInput remount で入力フォーカスが flaky になるため、
 			// verify API を LOCKED_OUT + 固定 lockedUntil で intercept し「サーバが返す解除時刻が
 			// クライアントで HH:MM 表示されるか」の wiring を決定的に検証する (page.route = Integration、
@@ -93,7 +93,7 @@ function registerParentGateTests(): void {
 
 			const errorAlert = page.getByTestId('parent-gate-error');
 			await expect(errorAlert).toBeVisible({ timeout: 10_000 });
-			// 解除予定の絶対時刻が文言に含まれる (時刻なし「しばらく」だけの表示でないこと)
+			// 解除の絶対時刻が文言に含まれる (時刻なし「しばらく」だけの表示でないこと)
 			await expect(errorAlert).toContainText(expectedTime);
 			await expect(errorAlert).not.toContainText('しばらく');
 		});

--- a/tests/e2e/parent-gate.spec.ts
+++ b/tests/e2e/parent-gate.spec.ts
@@ -63,6 +63,41 @@ function registerParentGateTests(): void {
 			await expect(page.getByTestId('parent-gate-error')).toBeVisible({ timeout: 10_000 });
 		});
 
+		test('#2991: ロック時に解除予定の絶対時刻が表示される', async ({ page }) => {
+			// 実 lockout (6 回失敗) は PinInput remount で入力フォーカスが flaky になるため、
+			// verify API を LOCKED_OUT + 固定 lockedUntil で intercept し「サーバが返す解除時刻が
+			// クライアントで HH:MM 表示されるか」の wiring を決定的に検証する (page.route = Integration、
+			// tests/CLAUDE.md 公認パターン)。実 lockout 閾値ロジックは auth-service.test.ts でカバー。
+			const lockedUntilIso = '2099-01-01T20:45:00.000Z';
+			// クライアントと同一ロジックで期待時刻を算出 (CI のタイムゾーンに依存せず一致させる)
+			const expectedTime = new Date(lockedUntilIso).toLocaleTimeString('ja-JP', {
+				hour: '2-digit',
+				minute: '2-digit',
+			});
+
+			await page.route('**/api/v1/parent-gate/verify', async (route) => {
+				await route.fulfill({
+					status: 423,
+					contentType: 'application/json',
+					body: JSON.stringify({ ok: false, error: 'LOCKED_OUT', lockedUntil: lockedUntilIso }),
+				});
+			});
+
+			await page.goto('/switch?pinRequired=1', { waitUntil: 'domcontentloaded' });
+			await expect(page.getByTestId('parent-gate-modal')).toBeVisible();
+
+			// 4 桁入力 → onComplete → verify (intercept) → LOCKED_OUT 表示
+			for (const ch of '1234') {
+				await page.keyboard.press(ch);
+			}
+
+			const errorAlert = page.getByTestId('parent-gate-error');
+			await expect(errorAlert).toBeVisible({ timeout: 10_000 });
+			// 解除予定の絶対時刻が文言に含まれる (時刻なし「しばらく」だけの表示でないこと)
+			await expect(errorAlert).toContainText(expectedTime);
+			await expect(errorAlert).not.toContainText('しばらく');
+		});
+
 		test('AC3: 子供モード切替時に PIN session cookie が破棄される (EPIC 構造的核心)', async ({
 			page,
 			context,

--- a/tests/unit/domain/oyakagi-lockout-labels.test.ts
+++ b/tests/unit/domain/oyakagi-lockout-labels.test.ts
@@ -1,9 +1,9 @@
 // tests/unit/domain/oyakagi-lockout-labels.test.ts
-// #2991: おやカギコード ロック時に解除予定時刻を明示する文言の SSOT 検証。
+// #2991: おやカギコード ロック時に解除時刻を明示する文言の SSOT 検証。
 //
 // 背景: 旧 lockedError は「しばらく待ってから」で解除時刻が無く、ユーザは「いつ再試行できるか」
 // 分からず不安 → サポート連絡を強いられていた (NN/g heuristic #1 violation)。
-// #2991 で gateLockedUntilNotice(timeStr) を導入し、解除予定の絶対時刻を提示する
+// #2991 で gateLockedUntilNotice(timeStr) を導入し、解除の絶対時刻を提示する
 // (NIST SP 800-63B / iOS Security Lockout は残り時間明示、秒カウントダウンは temporal vigilance で
 //  不安増大のため絶対時刻型を採用 — tmp/research/pin-gate-ux-ideal-state.md Q2)。
 
@@ -12,7 +12,7 @@ import { OYAKAGI_LABELS } from '$lib/domain/labels';
 import { OYAKAGI_TERMS } from '$lib/domain/terms';
 
 describe('#2991 OYAKAGI_LABELS.gateLockedUntilNotice (ロック解除時刻の明示)', () => {
-	it('解除予定の時刻文字列を文言に埋め込む', () => {
+	it('解除の時刻文字列を文言に埋め込む', () => {
 		const msg = OYAKAGI_LABELS.gateLockedUntilNotice('20:45');
 		expect(msg).toContain('20:45');
 	});

--- a/tests/unit/domain/oyakagi-lockout-labels.test.ts
+++ b/tests/unit/domain/oyakagi-lockout-labels.test.ts
@@ -1,0 +1,44 @@
+// tests/unit/domain/oyakagi-lockout-labels.test.ts
+// #2991: おやカギコード ロック時に解除予定時刻を明示する文言の SSOT 検証。
+//
+// 背景: 旧 lockedError は「しばらく待ってから」で解除時刻が無く、ユーザは「いつ再試行できるか」
+// 分からず不安 → サポート連絡を強いられていた (NN/g heuristic #1 violation)。
+// #2991 で gateLockedUntilNotice(timeStr) を導入し、解除予定の絶対時刻を提示する
+// (NIST SP 800-63B / iOS Security Lockout は残り時間明示、秒カウントダウンは temporal vigilance で
+//  不安増大のため絶対時刻型を採用 — tmp/research/pin-gate-ux-ideal-state.md Q2)。
+
+import { describe, expect, it } from 'vitest';
+import { OYAKAGI_LABELS } from '$lib/domain/labels';
+import { OYAKAGI_TERMS } from '$lib/domain/terms';
+
+describe('#2991 OYAKAGI_LABELS.gateLockedUntilNotice (ロック解除時刻の明示)', () => {
+	it('解除予定の時刻文字列を文言に埋め込む', () => {
+		const msg = OYAKAGI_LABELS.gateLockedUntilNotice('20:45');
+		expect(msg).toContain('20:45');
+	});
+
+	it('「いつ再試行できるか」を示す (時刻 + 待機を促す表現を含む)', () => {
+		const msg = OYAKAGI_LABELS.gateLockedUntilNotice('07:03');
+		// 解除時刻 + 「まで」+ 「待って」で「その時刻まで待てば再試行できる」ことを伝える
+		expect(msg).toContain('07:03');
+		expect(msg).toContain('まで');
+		expect(msg).toContain('待って');
+	});
+
+	it('おやカギコード用語を atom (OYAKAGI_TERMS.name) 経由で参照している (ADR-0045 SSOT)', () => {
+		const msg = OYAKAGI_LABELS.gateLockedUntilNotice('00:00');
+		expect(msg).toContain(OYAKAGI_TERMS.name);
+	});
+
+	it('時刻なしの旧 lockedError から脱却している (gateLockedUntilNotice は「しばらく」を含まない)', () => {
+		const msg = OYAKAGI_LABELS.gateLockedUntilNotice('23:59');
+		// 旧文言の曖昧表現「しばらく」を含まないこと (時刻提示への置換を保証)
+		expect(msg).not.toContain('しばらく');
+	});
+
+	it('任意の HH:MM をそのまま埋め込む (整形は呼び出し側責務、文言側は時刻を改変しない)', () => {
+		for (const t of ['00:00', '09:05', '13:30', '23:59']) {
+			expect(OYAKAGI_LABELS.gateLockedUntilNotice(t)).toContain(t);
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 保護者（管理者）

**解決する課題**: おやカギコード（保護者 PIN）を連続失敗してロックされた保護者に、現状は「しばらく待ってから再度お試しください」と**解除時刻なし**で表示していた。ユーザは「いつ再試行できるか分からない」不安から、本来不要なサポート連絡に追い込まれる（PO 指摘 2026-06-06）。

**期待される効果**: ロック時に**解除の絶対時刻「HH:MM まで待ってから」**を提示し「いつ再試行できるか」を明示する。サーバは正確な `lockedUntil` を既に返しクライアントも保持していたが、表示に未反映だった = データは手元にあり表示だけの欠落。これにより自己回復可能になり、サポート連絡を不要化する（NN/g heuristic #1 visibility / NIST SP 800-63B / iOS Security Lockout は残り時間を必ず明示）。

## 関連 Issue

Refs #2991
Refs #2990

関連: EPIC #2990 (PIN ゲート再設計) の先行 quick-fix。研究 SSOT: `tmp/research/pin-gate-ux-ideal-state.md` Q2 / ADR-0045 (labels SSOT)

## AC 検証マップ (ADR-0004)

HEAD SHA: `9e146c281e928... (改名 chore 反映、user-facing 文言不変)`

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | ロック時に解除の絶対時刻を表示 (秒カウントダウンは実装しない) | `src/routes/switch/+page.svelte` LOCKED_OUT 分岐 / `src/lib/domain/labels.ts` gateLockedUntilNotice | 実装済 — `switch/+page.svelte:74-83` で `lockedUntil` を `toLocaleTimeString('ja-JP',{hour,minute})` 整形し `OYAKAGI_LABELS.gateLockedUntilNotice(timeStr)` を表示。parse 不能時のみ `lockedError` fallback |
| AC2 | 文言は labels SSOT 経由 (atom 整合、ADR-0045) | `npx vitest run tests/unit/domain/oyakagi-lockout-labels.test.ts` | unit 追加済 — 時刻埋め込み / 「まで」「待って」/ `OYAKAGI_TERMS.name` atom 参照 / 「しばらく」非含有 を assert。pipeline 検証は下記 |
| AC3 | gateLockoutNotice (秒) の整理 | grep `gateLockoutNotice` | 完了 — 未使用の秒カウントダウン関数を絶対時刻型 `gateLockedUntilNotice` に置換 (研究 Q2: カウントダウンは temporal vigilance で不安増大、絶対時刻が望ましい) |
| AC4 | E2E で解除時刻表示の wiring を検証 | `tests/e2e/parent-gate.spec.ts` (`PARENT_GATE_FORCE_ACTIVE=true`) | **PASS** — `✓ #2991: ロック時に解除の絶対時刻が表示される (3.3s)` (cognito-dev、PARENT_GATE_FORCE_ACTIVE=true、2 段ハーネス: setup ゲート無し→spec ゲート有り `--no-deps`)。verify を LOCKED_OUT + 固定 lockedUntil で `page.route` intercept し HH:MM 表示を決定的に assert。同 run の 2 failures (forgot-pin INVALID_EMAIL / reset-pin TOKEN_INVALID) は **#2991 が触れない別ファイル (`/auth/forgot-pin` `/auth/reset-pin`) の既存 #2353 email-reset test** で無関係 (まさに EPIC #2990 が supersede するメール reset フロー) |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [x] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
`/switch` の保護者ゲート modal (おやカギコードロック時のエラー表示)。`labels.ts` の `OYAKAGI_LABELS` の lockout 文言。サーバ側ロジック (`auth-service.ts` の `verifyPin` / `lockedUntil`) は変更なし (既存の返却値を表示に反映するのみ)。`lockedError` (静的文言) は他 6 箇所 (login / admin/settings/account / billing / api auth / SaasLicensePanel) で使用継続のため**型・値とも不変**。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030） — worktree node_modules 不在のため pipeline full clone で代行: biome / svelte-check 0 errors / vitest 838 passed (上記「検証結果」)
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/domain/oyakagi-lockout-labels.test.ts` (新規): `gateLockedUntilNotice` の時刻埋め込み / 待機促し表現 / atom 参照 / 「しばらく」非含有
  - `tests/e2e/parent-gate.spec.ts` (追記): `page.route` で LOCKED_OUT 応答を mock し、解除時刻の HH:MM 表示を決定的に検証 (`PARENT_GATE_FORCE_ACTIVE=true` 時のみ登録)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — DB 層・サーバロジック不変
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (priority:high)

**検証結果** (pipeline full clone、HEAD `58e8d12f`):
- biome check (changed 4 files) → clean
- `npx svelte-check` → **0 errors** (19 warnings は既存)
- `npx vitest run tests/unit/domain/` → **42 files / 838 passed** (新規 oyakagi-lockout-labels 5/5 含む、labels.ts 変更の安全性確認)
- E2E (cognito-dev 2 段): `#2991: ロック時に解除の絶対時刻が表示される` **✓ PASS** (3.3s)
- SS: before (origin/main「しばらく待ってから」) / after (本 PR「05:45 まで待ってから」) を desktop+mobile で撮影、上記表に添付

**発見した既存課題 (本 PR scope 外、EPIC #2990 へ)**: `switch/+page.svelte:31-38` の #2353 Fix1 `$effect` が `pinInputKey += 1` (同一 state 読み書き) で `effect_update_depth_exceeded` ループする。PARENT_GATE_FORCE_ACTIVE 下の auth.setup を不安定化させるが描画は成立 (SS 成功)。#2991 は event handler のみ変更で本ループ非関与。EPIC #2990 の parent-gate 再設計で対処する

## スクリーンショット / ビジュアルデモ

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1280px) |
|---|---|---|
| **修正前** | ![before-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2996/before-mobile.png) | ![before-desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2996/before-desktop.png) |
| **修正後** | ![after-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2996/after-mobile.png) | ![after-desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2996/after-desktop.png) |

`/switch` 保護者ゲート modal のロック状態。verify API を LOCKED_OUT + 固定 lockedUntil (`2099-01-01T20:45:00Z` = JST 05:45) で route-mock して撮影 (local dev、cognito 不要)。

- **修正前** (origin/main): 「おやカギコードの入力に連続して失敗した**ため、しばらく待ってから**再度お試しください」(解除時刻なし)
- **修正後** (本 PR): 「おやカギコードの入力に連続して失敗しました。**05:45 まで待ってから**再度お試しください」(解除の絶対時刻)

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 表示文言生成を `OYAKAGI_LABELS.gateLockedUntilNotice` (SSOT) に集約、時刻整形は呼び出し側責務に分離
- [x] **DRY**: `lockedError` の他 6 箇所利用を壊さず、新関数追加で最小差分
- [x] **YAGNI**: 解除時刻表示の最小実装のみ。漸進遅延 (NIST) は別 sub で判断 (本 PR スコープ外)
- [x] **Security（OSS 公開前提）**: 秘密情報なし。表示する時刻はサーバが既に返す値
- [x] **アクセシビリティ**: 既存 `Alert variant="danger"` (role) に準拠、構造不変
- [x] **パフォーマンス**: 文字列整形のみ、秒カウントダウン (再描画ループ) を回さない設計で負荷増ゼロ

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — 文言は labels SSOT 経由で demo/本番共通
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [ ] 並行 PR overlap 確認 (#1200)
- [x] N/A — `lockedError` を共有する他 6 画面 (login / admin/settings/account / billing / api auth / SaasLicensePanel) は型・値とも不変で影響なし。それらへの解除時刻表示展開は別 sub (#2990 配下) で判断

**LP / 販促文言変更時** (ADR-0013): N/A

## 設計判断

**絶対時刻 vs 秒カウントダウン**: 研究 (`tmp/research/pin-gate-ux-ideal-state.md` Q2) で NIST SP 800-63B §5.2.2 / iOS Security Lockout は「残り時間を必ず明示」、NN/g heuristic #1 は「時刻なし表示は visibility 違反」、arXiv 2602.04138 は「秒カウントダウンは temporal vigilance で不安・焦燥を増幅」と示す。両立解として**解除の絶対時刻 (HH:MM)** を採用し、未使用だった `gateLockoutNotice(sec)` (秒カウントダウン型) を置換した。サーバ時刻 (`lockedUntil`) を SSOT とし、クライアントで秒カウントダウンを回さない。

**lockedError を変更しない理由**: `lockedError` は静的文字列として 6 箇所 (login / admin/settings/account / billing / api auth / SaasLicensePanel) で利用されており、関数化すると破壊的。本 PR は parent-gate modal (ユーザ報告の対象画面) に新関数 `gateLockedUntilNotice(timeStr)` を導入し、`lockederror` は時刻不明時の fallback として残す。他画面への解除時刻表示展開は EPIC #2990 配下の sub で判断する。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- 解除時刻のタイムゾーン整合 (`toLocaleTimeString('ja-JP')` はブラウザローカル時刻。E2E は同一ロジックで期待値算出し CI タイムゾーン非依存)
- `lockedError` を共有する他 6 画面への影響がないこと (型・値不変)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (pipeline 代行: biome / svelte-check 0 / vitest 838)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (AC1-AC4 完了、E2E PASS)
- [x] UI 変更時: SS (before/after × desktop/mobile) を GitHub 上で表示確認、解除時刻表示を目視確認
- [x] 認証画面変更時: cognito-dev で E2E (parent-gate spec) 実行 + ロック状態 SS 添付済

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)



