### PR TITLE
infra: #2872 staging workflow self-provisioning bootstrap — PO 手作業実質ゼロ化

### DIFF
--- a/.github/workflows/deploy-nuc-staging.yml
+++ b/.github/workflows/deploy-nuc-staging.yml
@@ -13,10 +13,16 @@ name: Deploy to NUC (Staging)
 #   - pull_request (base=main) = 統合 PR (develop→main) の検証で発火。
 #   - workflow_dispatch = develop HEAD を手動 deploy (AC1)。
 #
-# 位置付け (当面 advisory、PO 手作業 §7-3):
-#   本 workflow は当面 required check に登録しない。staging working-dir (C:\Docker\ganbari-quest-staging)
-#   が物理 NUC 上に未 provision の間、develop→main 取込をブロックしないため。
-#   merge blocker 化 (AC3) は staging provision + ruleset 配線 (PO 手作業 §7) 完了後に行う。
+# 位置付け (当面 advisory):
+#   本 workflow は当面 required check に登録しない。staging 初回緑を確認するまで develop→main
+#   取込をブロックしないため。merge blocker 化 (AC3) は初回緑確認後に audit-manager が
+#   main ruleset の required_status_checks へ `deploy-nuc-staging` を追加して行う。
+#
+# self-provisioning (Step 0):
+#   staging working-dir (C:\Docker\ganbari-quest-staging) が NUC 上に未 provision でも、
+#   Step 0 が自動 clone して bootstrap する。NUC runner は本番 working-dir
+#   (C:\Docker\ganbari-quest) で credential 済み git fetch の稼働実績があるため、
+#   同一 credential で plain https clone が成立する。物理 NUC 上の手作業は不要。
 
 on:
   pull_request:
@@ -38,6 +44,26 @@ jobs:
         shell: powershell
         working-directory: C:\Docker\ganbari-quest-staging
     steps:
+      # Step 0: Bootstrap — staging working-dir が未 provision なら自動 clone (self-provisioning)。
+      # defaults.working-directory は dir 不在だと step 起動自体が fail するため、本 step のみ
+      # working-directory を C:\ に上書きして provision する。clone 済みなら no-op (冪等)。
+      # NUC runner の global git credential (本番 dir の fetch 実績) を流用するため token 埋め込み不要。
+      - name: Bootstrap staging working-dir (self-provisioning)
+        working-directory: C:\
+        run: |
+          if (-not (Test-Path "C:\Docker\ganbari-quest-staging\.git")) {
+            Write-Host "Staging working-dir not provisioned. Cloning into C:\Docker\ganbari-quest-staging ..."
+            New-Item -ItemType Directory -Force -Path "C:\Docker" | Out-Null
+            git clone "https://github.com/${{ github.repository }}.git" "C:\Docker\ganbari-quest-staging"
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "::error::git clone failed. NUC runner の git credential を確認してください (本番 dir C:\Docker\ganbari-quest の fetch が動く credential と同一のはず)。"
+              exit 1
+            }
+            Write-Host "::notice::staging working-dir provisioned (initial clone)."
+          } else {
+            Write-Host "Staging working-dir already provisioned (skip)."
+          }
+
       # Step 1: Checkout 対象 ref を staging working-dir に強制同期。
       # - pull_request: 統合 PR の HEAD (develop→main の develop 側)。
       # - workflow_dispatch: develop HEAD (AC1 = develop HEAD を deploy)。

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -139,7 +139,8 @@ docker compose logs -f scheduler
 | health | `localhost:3000/api/health` | `localhost:3100/api/health` (200 + `schema.schemaValid=true` assert) |
 
 - **snapshot-forward 起動**: staging は本番 DB snapshot から起動し `applyLazyStartupMigrations` を貫通させる (過去状態からのマイグレーション込み実機起動の実機担保、#2872 AC6)。snapshot は本番 DB を read のみで取得 (本番 DB へ write しない)。
-- **当面 advisory**: required check 未登録。staging working-dir 未 provision 時に develop→main 取込をブロックしない。物理 provision (staging dir / port 3100 / ruleset) は PO 手作業。
+- **self-provisioning**: staging working-dir 未 provision でも workflow Step 0 が自動 clone する (NUC runner の global git credential 流用、物理 NUC 上の手作業不要)。health check は runner 自身からの `localhost:3100` のため Firewall 設定も不要 (LAN 越しにブラウザで見たい場合のみ任意で許可)。
+- **当面 advisory**: required check 未登録。staging 初回緑を確認するまで develop→main 取込をブロックしない。merge blocker 化 (#2872 AC3) は初回緑確認後に audit-manager が main ruleset の `required_status_checks` へ `deploy-nuc-staging` を追加して行う。
 - 検証手順 SSOT: [.claude/skills/deploy-verify/SKILL.md](../.claude/skills/deploy-verify/SKILL.md) / 構成詳細: [docs/design/13-AWSサーバレスアーキテクチャ設計書.md §4.2](../docs/design/13-AWSサーバレスアーキテクチャ設計書.md)。
 
 ## EventBridge Cron Rules (#1376)


### PR DESCRIPTION
## 顧客価値・目的

#2872 NUC staging (PR #2997 merge 済) の follow-up。PO 指摘「手作業はなぜあなた (audit-manager) ができないのか」の再点検により、PO 手作業として残していた 6 項目のうち真に手作業が必要なものは無いと判明したため、self-provisioning bootstrap で実質ゼロ化する。staging 実働までのリードタイムを物理作業待ちなしに短縮し、初回 baseline 監査の前提 (audit-team.md §3.7 項目2/5) 充足を早める。

## 関連 Issue

related #2872 #2861

## AC 検証マップ (ADR-0004)

| AC番号 | AC内容 | 検証手段 | 結果/エビデンス |
|---|---|---|---|
| AC1 | staging working-dir 未 provision でも workflow が自動 bootstrap する | Step 0 追加 (dir 不在時 `git clone`、冪等 / 失敗時 error 案内)。yaml parse PASS | ✅ |
| AC2 | 本番不変条件の維持 | Step 0 は `C:\Docker\ganbari-quest-staging` のみ作成、本番 dir / 本番 DB に触れない | ✅ |
| AC3 | PO 手作業の残骸記述の是正 | workflow header + infra/CLAUDE.md を「self-provisioning / ruleset 配線は audit-manager が初回緑後に実施」へ更新 | ✅ |

## 変更タイプ

- [x] インフラ

## 影響範囲・変更コンポーネント

- `.github/workflows/deploy-nuc-staging.yml`（Step 0 bootstrap 追加 + header 注記更新）
- `infra/CLAUDE.md`（staging 節の手作業記述是正）

既存 `deploy-nuc.yml` / `docker-compose.yml` / アプリコードは無改変。

## テスト & 安全装置セルフチェック

- yaml parse PASS。workflow は self-hosted runner 専用のため CI 実走は統合 PR / dispatch 時。
- Step 0 は冪等（clone 済みなら skip）。clone 失敗時は明示 error で案内し silent fallback しない（ADR-0006 整合）。
- actor guard (`Takenori-Kusaka` / `ganbariquestsupport-lab`) は既存のまま、Step 0 も同 guard 配下。

## スクリーンショット / ビジュアルデモ

N/A（workflow のみ、UI 変更なし）

## コード品質セルフレビュー (#1481)

PowerShell step は既存 deploy-nuc / staging step の記法（`$LASTEXITCODE` 判定 / `::error::` / `::notice::`）を踏襲。

## 横展開・影響波及チェック

- #2873 (AWS staging) でも「PO 手作業を最小化し audit-manager が gh api / CDK で実施できる範囲を最大化する」同原則を適用する（設計時に反映）。
- merge blocker 化 (AC3) の実施主体が PO → audit-manager に移ったため、#2872 の AC 充足判定は「staging 初回緑 + audit-manager の ruleset 配線」で完了する。

## レビュー依頼事項・破壊的変更

破壊的変更なし。Step 0 の clone が NUC runner の global git credential に依存する点（本番 dir の fetch 実績と同一 credential）が前提。

## 配布済み env / secret (ADR-0006)

なし（新規 env/secret なし）。

## Ready for Review チェックリスト

- [x] 関連 Issue を記載した
- [x] AC 検証マップを埋めた
- [x] 本番不変条件 (本番 dir / DB 無接触) を維持した

## QM レビュー結果

（QM チーム記入欄）
