### PR TITLE
fix(auth): #2992 初回保護者ゲートを PIN 新規作成フローに分岐 (既定 5086 ログイン廃止、初回 dead-end 解消)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -285,24 +285,26 @@
 └─────────────────────────────────┘
 ```
 
-### 4.6 おやカギコード認証画面 (S-07) + PIN gate modal (EPIC #2310 / #2353)
+### 4.6 おやカギコード認証画面 (S-07) + PIN gate modal (EPIC #2310 / #2353 / #2992)
 
-デフォルト値: `5086`（「がんばり」語呂合わせ）。`pin_hash` 未設定テナントは自動的に 5086 で入室可（#1360）。
+**初回は作る・既存は入る** (#2992、EPIC #2990): PIN 未設定テナントには gate modal を login でなく**新規作成 (入力→確認の 2 段) フロー**で表示する (Apple Screen Time / Google Family Link 同型)。parent-gate の verify 経路では既定 PIN 照合を行わない (`verifyPin` は未設定時 `PIN_NOT_SET`)。`DEFAULT_PIN` (`5086`、「がんばり」語呂合わせ) は legacy local 経路 (`/login` の `login()` / `changePin()` の現コード照合、#1360) のみで有効。
 
 #### 4.6.1 PIN gate modal (S-07a) — `/switch` inline
 
-EPIC #2310 で `/admin/*` middleware が未認証時 `/switch?pinRequired=1&next=…` redirect → `/switch` page で auto-open する Dialog 内 PinInput。
+EPIC #2310 で `/admin/*` middleware が未認証時 `/switch?pinRequired=1&next=…` redirect → `/switch` page で auto-open する Dialog 内 PinInput。`isPinConfigured(tenantId)` (load で `pinConfigured` として供給) で**作成モード / 入力モードに分岐**する。
 
 | 項目 | 仕様 |
 |---|---|
 | trigger 1 | `pinRequired=1` query (middleware redirect) で初期 `pinModalOpen=true` |
 | trigger 2 | `/switch` の「🔒 保護者の見守り画面」link click (#2353 漢字化、AC4) |
+| モード分岐 (#2992) | `pinConfigured === false` → **作成モード** (`data-testid="parent-gate-create"`、`data-step="enter"→"confirm"`): 1 段目入力 → 確認入力 → 一致で `POST /api/v1/parent-gate/setup` → session cookie 発行 → next へ。不一致は `gateCreateMismatch` エラー + 1 段目からやり直し。`true` → 従来の入力モード |
 | 入力 UI | `PinInput` primitive (4 桁、mask: true) |
-| 送信 | `POST /api/v1/parent-gate/verify { pin }` → `gq_parent_session` 署名 cookie 発行 |
+| 送信 (入力モード) | `POST /api/v1/parent-gate/verify { pin }` → `gq_parent_session` 署名 cookie 発行。未設定 tenant への verify は `PIN_NOT_SET` (作成モードへの race guard) |
+| 送信 (作成モード) | `POST /api/v1/parent-gate/setup { pin }` — **未設定 tenant のみ許可** (設定済みへは 403 `ALREADY_CONFIGURED` = 子供による上書き穴の防止。変更は現 PIN 確認付き changePin、忘れは reset 経路)。成功で verify と同じ session cookie 発行。rate limit 20/15min per IP |
 | 失敗時 | `pinError` 表示 + `pinInputKey += 1` で入力欄リセット |
 | ロックアウト時 (#2991) | 連続失敗でロックされた際、エラーに**ロック解除の絶対時刻**「HH:MM まで待ってから」を表示 (`OYAKAGI_LABELS.gateLockedUntilNotice`)。サーバが返す `lockedUntil` を `toLocaleTimeString('ja-JP',{hour,minute})` で整形。時刻不明時のみ `OYAKAGI_LABELS.lockedError` (時刻なし) を fallback。秒カウントダウンは不採用 (NIST SP 800-63B / iOS は残り時間明示、NN/g #1 visibility) |
-| 初期 PIN 5086 ヒント (#2353 設計欠陥 5、AC6) | **非表示** (子供が見て即入力できる脆弱性。`OYAKAGI_LABELS.gateDefaultHint` 空文字 + Svelte 側で `{#if hint}` 条件分岐) |
-| 「PINを忘れた方」link (#2353、AC5) | modal 下部に表示。click → `/auth/forgot-pin` 遷移 |
+| 初期 PIN ヒント | **非表示** (#2353 設計欠陥 5、AC6: 子供が見て即入力できる脆弱性)。#2992 以降は未設定者が自分で作成するため既定 PIN ヒント自体が不要。setup 完了画面 / onboarding dialog の案内も「初めて入るときに作成」型 (`SETUP_COMPLETE_LABELS.pinHintSuffix` / `PIN_GATE_ONBOARDING_LABELS.dialogPinHint`) |
+| 「PINを忘れた方」link (#2353、AC5) | **入力モードのみ** modal 下部に表示 (作成モードでは PIN 未存在のため非表示)。click → `/auth/forgot-pin` 遷移 |
 
 #### 4.6.2 PIN reset 画面 (S-07b / S-07c) — `/auth/forgot-pin` + `/auth/reset-pin/[token]`
 

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -205,19 +205,21 @@ Layer 2: Context（署名付きトークン）
 
 #### 主要 flow
 
-1. **PIN 入力**: 子供 / 親が `/switch` 「ご家族の見守り画面」リンク click → inline modal (Dialog + PinInput primitive、Ark UI) で 4 桁入力 → `POST /api/v1/parent-gate/verify` (JSON: `{pin}`) → 成功で `gq_parent_session` httpOnly signed cookie を発行 → `next` query で指定された `/admin/...` path に遷移
-2. **Sliding refresh**: 各 `/admin/*` request 時に `+layout.server.ts` が cookie 検証 + `lastActiveAt` 更新 + 再 sign して cookie 再発行 (15 分 timeout 延長)
-3. **未認証 / 失効時の redirect**: middleware が `/switch?pinRequired=1&next=<原 path>` に redirect → 入口で modal auto-open
-4. **明示削除 (EPIC 構造的核心 / 子#2314)**: `/switch` の `select` action で `cookies.delete('gq_parent_session')` を実行。親が child mode に戻った瞬間に session 失効し、次の子の admin アクセスは再 PIN を要求される
+1. **初回 PIN 作成 (#2992、「初回は作る・既存は入る」)**: PIN 未設定 tenant が gate に到達すると、modal は login でなく**新規作成 (入力→確認の 2 段)** を表示 → 一致で `POST /api/v1/parent-gate/setup` (JSON: `{pin}`) → setupPin + `gq_parent_session` cookie 発行 → `next` へ。`verifyPin` は未設定時 `PIN_NOT_SET` を返し既定 PIN 照合を行わない (gate 経路から `DEFAULT_PIN` 廃止。legacy local 経路 `login()` / `changePin()` のみ #1360 互換で維持)。setup は**未設定 tenant のみ許可** (設定済みへは 403 `ALREADY_CONFIGURED` = 子供による上書き穴の防止)
+2. **PIN 入力**: 子供 / 親が `/switch` 「ご家族の見守り画面」リンク click → inline modal (Dialog + PinInput primitive、Ark UI) で 4 桁入力 → `POST /api/v1/parent-gate/verify` (JSON: `{pin}`) → 成功で `gq_parent_session` httpOnly signed cookie を発行 → `next` query で指定された `/admin/...` path に遷移
+3. **Sliding refresh**: 各 `/admin/*` request 時に `+layout.server.ts` が cookie 検証 + `lastActiveAt` 更新 + 再 sign して cookie 再発行 (15 分 timeout 延長)
+4. **未認証 / 失効時の redirect**: middleware が `/switch?pinRequired=1&next=<原 path>` に redirect → 入口で modal auto-open
+5. **明示削除 (EPIC 構造的核心 / 子#2314)**: `/switch` の `select` action で `cookies.delete('gq_parent_session')` を実行。親が child mode に戻った瞬間に session 失効し、次の子の admin アクセスは再 PIN を要求される
 
 #### 関連実装
 
 - `src/lib/server/services/parent-gate-session.ts` (cookie 発行 / 検証 / sliding refresh)
+- `src/routes/api/v1/parent-gate/setup/+server.ts` (POST endpoint、初回作成 #2992。未設定 tenant のみ + rate limit 20/15min)
 - `src/routes/api/v1/parent-gate/verify/+server.ts` (POST endpoint、既存 verifyPin 流用)
 - `src/routes/api/v1/parent-gate/logout/+server.ts` (POST endpoint、cookie 削除)
 - `src/routes/(parent)/admin/+layout.server.ts` (middleware)
-- `src/routes/switch/+page.svelte` (PIN modal UI、PinInput primitive 初実用化)
-- `src/routes/switch/+page.server.ts` `select` action (cookie 明示削除)
+- `src/routes/switch/+page.svelte` (PIN modal UI = 作成 / 入力の 2 モード、PinInput primitive 初実用化)
+- `src/routes/switch/+page.server.ts` `select` action (cookie 明示削除) + load の `pinConfigured` 供給
 
 #### Anti-engagement 整合 (ADR-0012)
 
@@ -229,10 +231,10 @@ Layer 2: Context（署名付きトークン）
 
 | 表示文脈 | 初期 PIN ヒント `OYAKAGI_LABELS.defaultValueHint` (= `'初期値は 5086（がんばり）です'`) | 理由 |
 |---|---|---|
-| `/setup/complete/+page.svelte` (初期 setup 完了画面) | **表示** | 親が初期 setup を完了した直後の文脈、適切 |
-| `/admin/settings/account/+page.svelte` (PIN 変更画面) | **表示** | 親が自ら PIN 変更を試みる文脈、適切 |
-| `(child) onboarding dialog` (`PIN_GATE_ONBOARDING_LABELS.dialogPinHint`、Phase D) | **表示 (短縮版)** | 親が初回のみ読む onboarding dialog、「以降表示しない」で消える |
-| `/switch` PIN modal (`Dialog`) | **非表示** | 子供画面と同じ端末で表示される → 子供が見て即入れる脆弱性 |
+| `/setup/complete/+page.svelte` (初期 setup 完了画面) | **非表示** (#2992 で「初めて入るときに作成します」案内に置換、`SETUP_COMPLETE_LABELS.pinHintSuffix`) | gate 経路は初回作成フローになり既定 PIN の事前伝達が不要化 |
+| `/admin/settings/account/+page.svelte` (PIN 変更画面) | **表示** | legacy local 経路 (`changePin` の現コード照合) で未設定 tenant の現コード = `DEFAULT_PIN` のため、その文脈でのみ有効な案内 |
+| `(child) onboarding dialog` (`PIN_GATE_ONBOARDING_LABELS.dialogPinHint`、Phase D) | **非表示** (#2992 で「初めて入るときに作成します」案内に置換) | 同上 (gate 経路の初回は作成フロー) |
+| `/switch` PIN modal (`Dialog`) | **非表示** | 子供画面と同じ端末で表示される → 子供が見て即入れる脆弱性。#2992 以降は未設定者が自分で作るためヒント自体が不要 |
 
 `OYAKAGI_LABELS.gateDefaultHint` (PIN modal 専用 atom) は #2353 Phase A で **削除**。再追加禁止 (子供脆弱性、業界 prior art ゼロ)。
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -1338,6 +1338,17 @@ export const OYAKAGI_LABELS = {
 	// #2353 設計欠陥 4: PIN 忘れ救済導線 (SES magic link + jose JWT 30 分 token + 1 回限り)
 	gateForgotPinLink: `${OYAKAGI_TERMS.name}を忘れた方`,
 	gateForgotPinHelp: `${OYAKAGI_TERMS.name}が分からない場合は登録メールで再設定できます`,
+	// #2992 (EPIC #2990): 初回は「作る」フロー。PIN 未設定 tenant には login でなく
+	// 新規作成 (入力→確認の 2 段) を表示する (Apple Screen Time / Google Family Link 同型)。
+	// これにより既定 PIN を知らない保護者の初回 dead-end が構造的に解消する。
+	gateCreateTitle: `${OYAKAGI_TERMS.name}をつくってください`,
+	gateCreateDescription: `${ADMIN_VIEW_TERMS.canonical}に入るための${OYAKAGI_TERMS.name}（4〜6桁の数字）を、${PARENT_TERMS.neutral}が決めて入力してください。`,
+	gateCreateConfirmTitle: `もう一度入力してください`,
+	gateCreateConfirmDescription: `確認のため、同じ${OYAKAGI_TERMS.name}をもう一度入力してください。`,
+	gateCreateMismatch: `入力が一致しませんでした。最初からやり直してください`,
+	gateCreateAlreadyConfigured: `${OYAKAGI_TERMS.name}は設定済みです。入力画面からやり直してください`,
+	gateCreateGenericError: `${OYAKAGI_TERMS.name}の作成に失敗しました。もう一度お試しください`,
+	gateCreateSubmitting: 'つくっています…',
 } as const;
 
 /**
@@ -1394,7 +1405,9 @@ export const PIN_RESET_LABELS = {
 export const PIN_GATE_ONBOARDING_LABELS = {
 	dialogTitle: `${ADMIN_VIEW_TERMS.canonical}に入る方法`,
 	dialogIntro: `子供の画面から${ADMIN_VIEW_TERMS.canonical}に戻るには、トップの「だれがつかう？」画面で 🔒 ${ADMIN_VIEW_TERMS.parent} のリンクをタップしてください。`,
-	dialogPinHint: `初回ログイン時の${OYAKAGI_TERMS.name}は ${PIN_DEFAULT_TERMS.hintCompact} です。設定完了画面でも確認できます。`,
+	// #2992: 初回は既定 PIN の入力でなく新規作成 (入力→確認) フローになるため、
+	// 旧「初回ログイン時の○○は 初期 5086…」の既定値案内から作成フロー案内に変更。
+	dialogPinHint: `初めて${ADMIN_VIEW_TERMS.canonical}に入るときに、${PARENT_TERMS.neutral}が${OYAKAGI_TERMS.name}（4〜6桁の数字）を作成します。`,
 	dialogChangePinHint: `${OYAKAGI_TERMS.name}は${ADMIN_VIEW_TERMS.canonical}の「せってい」 → 「${OYAKAGI_TERMS.name}」からいつでも変更できます。`,
 	dontShowAgain: '今後表示しない',
 	// Issue #2353 Phase D / E2E 衝突対策: 子供向け Dialog の「とじる」と strict mode 衝突するため
@@ -3843,6 +3856,8 @@ export const SETUP_COMPLETE_LABELS = {
 	ctaSecondary: 'おやのせっていをみる',
 	pinHintPrefix: `💡 ${ADMIN_VIEW_TERMS.canonical}の「せってい」から`,
 	pinHintMiddle: 'を変更すると、おやの画面を守れるよ。',
+	// #2992: 初回は既定 PIN 入力でなく新規作成フローのため、旧 5086 注記 (defaultValueHint) を置換
+	pinHintSuffix: '初めて入るときに作成します。',
 } as const;
 
 export const CERTIFICATE_DETAIL_LABELS = {

--- a/src/lib/server/services/auth-service.ts
+++ b/src/lib/server/services/auth-service.ts
@@ -108,6 +108,18 @@ export type VerifyPinResult =
 export async function verifyPin(pin: string, tenantId: string): Promise<VerifyPinResult> {
 	const pinHash = await getSetting('pin_hash', tenantId);
 
+	// #2992: 未設定 tenant は DEFAULT_PIN 照合せず PIN_NOT_SET を返す。
+	// parent-gate は「初回は作成・既存は入る」(Apple Screen Time / Google Family Link 同型) に分岐し、
+	// 未設定者は /switch の作成フロー (POST /api/v1/parent-gate/setup) へ誘導される。
+	// 「既定 5086 を login で入力させる」経路は本関数からは廃止 (初回 dead-end の根因、EPIC #2990)。
+	// legacy local 経路 (login() / changePin()) の DEFAULT_PIN fallback は #1360 互換で維持。
+	if (!pinHash) {
+		logger.info('[AUTH] verifyPin: PIN 未設定 tenant (作成フローへ誘導)', {
+			context: { tenantIdPrefix: tenantId.slice(0, 12) },
+		});
+		return { ok: false, error: 'PIN_NOT_SET' };
+	}
+
 	// 2) ロックアウトチェック
 	const lockedUntil = await getSetting('pin_locked_until', tenantId);
 	if (lockedUntil && new Date(lockedUntil) > new Date()) {
@@ -115,13 +127,8 @@ export async function verifyPin(pin: string, tenantId: string): Promise<VerifyPi
 		return { ok: false, error: 'LOCKED_OUT', lockedUntil };
 	}
 
-	// 3) おやカギコード検証（pin_hash 未設定 → DEFAULT_PIN と照合）
-	let isValid: boolean;
-	if (!pinHash) {
-		isValid = pin === DEFAULT_PIN;
-	} else {
-		isValid = bcrypt.compareSync(pin, pinHash);
-	}
+	// 3) おやカギコード検証
+	const isValid = bcrypt.compareSync(pin, pinHash);
 	if (!isValid) {
 		await incrementFailedAttempts(tenantId);
 		// #2335 hotfix Phase 1: PIN gate 本番 5086 confirmation 失敗の root cause 特定用 debug log。

--- a/src/routes/api/v1/parent-gate/setup/+server.ts
+++ b/src/routes/api/v1/parent-gate/setup/+server.ts
@@ -1,0 +1,77 @@
+// POST /api/v1/parent-gate/setup — #2992 (EPIC #2990)
+//
+// 初回の保護者ゲートで PIN を新規作成する (「初回は作る・既存は入る」、
+// Apple Screen Time / Google Family Link 同型)。
+//
+// - **PIN 未設定 tenant のみ許可**。設定済み tenant への上書きは 403 ALREADY_CONFIGURED
+//   (子供が作成フローで親の PIN を勝手に再作成する穴を防ぐ。変更は現 PIN 確認付きの
+//   changePin (/admin/settings/account)、忘れた場合は reset 経路が担う)
+// - 成功で verify と同じ `gq_parent_session` 署名 cookie を発行し、そのまま親画面へ進める
+// - rate limit は verify 系と同等 (20 req / 15 min per IP)
+
+import { error, json } from '@sveltejs/kit';
+import { requireTenantId } from '$lib/server/auth/factory';
+import { COOKIE_SECURE } from '$lib/server/cookie-config';
+import { logger } from '$lib/server/logger';
+import { checkRateLimit } from '$lib/server/security/rate-limiter';
+import { isPinConfigured, setupPin } from '$lib/server/services/auth-service';
+import {
+	createParentSession,
+	PARENT_SESSION_COOKIE_NAME,
+} from '$lib/server/services/parent-gate-session';
+import type { RequestHandler } from './$types';
+
+const PIN_PATTERN = /^\d{4,6}$/;
+const COOKIE_MAX_AGE_SEC = 60 * 60 * 24; // verify と同じ 24 時間 hard max (sliding は 15 分)
+const RATE_LIMIT_MAX = 20;
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+
+export const POST: RequestHandler = async ({ request, cookies, locals, getClientAddress }) => {
+	const tenantId = requireTenantId(locals);
+
+	const limit = checkRateLimit(
+		`parent-gate-setup:${getClientAddress()}`,
+		RATE_LIMIT_MAX,
+		RATE_LIMIT_WINDOW_MS,
+	);
+	if (!limit.allowed) {
+		return json({ ok: false, error: 'RATE_LIMITED' }, { status: 429 });
+	}
+
+	let pin: string;
+	try {
+		const body = await request.json();
+		pin = typeof body?.pin === 'string' ? body.pin : '';
+	} catch {
+		error(400, 'INVALID_BODY');
+	}
+
+	if (!pin || !PIN_PATTERN.test(pin)) {
+		return json({ ok: false, error: 'PIN_FORMAT' }, { status: 400 });
+	}
+
+	// 未設定 tenant のみ作成可 (設定済みへの上書きは changePin / reset 経路に限定)
+	if (await isPinConfigured(tenantId)) {
+		logger.warn('[PARENT_GATE] setup rejected: PIN already configured', {
+			context: { tenantIdPrefix: tenantId.slice(0, 12) },
+		});
+		return json({ ok: false, error: 'ALREADY_CONFIGURED' }, { status: 403 });
+	}
+
+	await setupPin(pin, tenantId);
+	logger.info('[PARENT_GATE] PIN created via first-run setup (#2992)', {
+		context: { tenantIdPrefix: tenantId.slice(0, 12) },
+	});
+
+	// 作成した本人をそのまま親画面へ通す (verify 成功と同じ session 発行)
+	const sessionValue = createParentSession(tenantId);
+	cookies.set(PARENT_SESSION_COOKIE_NAME, sessionValue, {
+		path: '/',
+		httpOnly: true,
+		secure: COOKIE_SECURE,
+		sameSite: 'lax',
+		maxAge: COOKIE_MAX_AGE_SEC,
+	});
+
+	return json({ ok: true });
+};

--- a/src/routes/setup/complete/+page.svelte
+++ b/src/routes/setup/complete/+page.svelte
@@ -54,9 +54,9 @@ const childHomeUrl = $derived(firstChild ? `/${firstChild.uiMode}/home` : '/swit
 		</a>
 	</div>
 
-	<!-- PINヒント -->
+	<!-- PINヒント (#2992: 初回は新規作成フローのため、旧 5086 既定値注記から作成案内に変更) -->
 	<p class="text-[0.6875rem] text-[var(--color-neutral-400)] mt-2">
-		{SETUP_COMPLETE_LABELS.pinHintPrefix}{OYAKAGI_LABELS.name}{SETUP_COMPLETE_LABELS.pinHintMiddle}{OYAKAGI_LABELS.defaultValueHint}
+		{SETUP_COMPLETE_LABELS.pinHintPrefix}{OYAKAGI_LABELS.name}{SETUP_COMPLETE_LABELS.pinHintMiddle}{SETUP_COMPLETE_LABELS.pinHintSuffix}
 	</p>
 </div>
 

--- a/src/routes/switch/+page.server.ts
+++ b/src/routes/switch/+page.server.ts
@@ -2,6 +2,7 @@ import { redirect } from '@sveltejs/kit';
 import { dev } from '$app/environment';
 import { getAuthMode, requireTenantId } from '$lib/server/auth/factory';
 import { COOKIE_SECURE } from '$lib/server/cookie-config';
+import { isPinConfigured } from '$lib/server/services/auth-service';
 import { getAllChildren, getChildById } from '$lib/server/services/child-service';
 import {
 	getOnboardingProgress,
@@ -50,7 +51,20 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 		}
 	}
 
-	return { children, adminLink, showAdminLink, reason, pinRequired, nextPath, onboarding };
+	// #2992 (EPIC #2990): 「初回は作る・既存は入る」分岐。PIN 未設定 tenant には
+	// gate modal を login でなく新規作成 (入力→確認) フローで表示する。
+	const pinConfigured = await isPinConfigured(tenantId);
+
+	return {
+		children,
+		adminLink,
+		showAdminLink,
+		reason,
+		pinRequired,
+		nextPath,
+		onboarding,
+		pinConfigured,
+	};
 };
 
 export const actions: Actions = {

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { untrack } from 'svelte';
 import { enhance } from '$app/forms';
+import { invalidateAll } from '$app/navigation';
 import { APP_LABELS, OYAKAGI_LABELS, PAGE_TITLES, SWITCH_PAGE_LABELS } from '$lib/domain/labels';
 import SetupResumeBanner from '$lib/features/admin/components/SetupResumeBanner.svelte';
 import Logo from '$lib/ui/components/Logo.svelte';
@@ -28,16 +29,91 @@ let pinInputKey = $state<number>(0);
 // 子供画面から戻って `/switch?pinRequired=1` 再アクセス時、banner だけ残って modal が出ない bug の構造的修正。
 // $state は初期化のみで data.pinRequired の変化に追従しないため、$effect で同期する。
 // Research 結論 (Wave 28-A): 業界 8 サービス調査で「banner だけ + modal 出さない」設計は prior art ゼロ = 構造的 bug 確定。
+//
+// #2992: 前回値比較ガードを追加。data.pinRequired が true のまま $effect が再発火しても
+// 2 度目以降は no-op にし、`pinModalOpen` / `pinInputKey` への再書き込み連鎖
+// (effect_update_depth_exceeded、EPIC #2990 finding) を構造的に遮断する。
+// prevPinRequired は plain 変数 (非 reactive) のため $effect の依存にならない。
+let prevPinRequired = false;
 $effect(() => {
-	if (data.pinRequired) {
+	const required = data.pinRequired ?? false;
+	if (required && !prevPinRequired) {
 		pinModalOpen = true;
 		// 過去の error / lockout / 入力残骸をクリアして再入力できる状態に揃える
 		pinError = '';
 		pinInputKey += 1;
 	}
+	prevPinRequired = required;
 });
 
 const lockedNow = $derived(lockoutUntil !== null && Date.now() < (lockoutUntil ?? 0));
+
+// #2992 (EPIC #2990): 「初回は作る・既存は入る」。PIN 未設定 tenant は login modal でなく
+// 新規作成 (入力→確認の 2 段) フローを表示する (Apple Screen Time / Google Family Link 同型)。
+// 既定 PIN を知らない保護者の初回 dead-end を構造的に解消し、PIN 入力画面に初期値ヒントを
+// 出せない制約 (#2353 Fix 5) とも両立する (未設定者はヒント不要 = 自分で作るため)。
+const pinCreateMode = $derived(!data.pinConfigured);
+let createStep = $state<'enter' | 'confirm'>('enter');
+let createFirstPin = $state<string>('');
+
+function resetCreateFlow() {
+	createStep = 'enter';
+	createFirstPin = '';
+	pinInputKey += 1;
+}
+
+async function handleCreateComplete(details: { valueAsString: string }) {
+	if (pinSubmitting) return;
+	pinError = '';
+
+	// 1 段目: 入力を保持して確認入力へ
+	if (createStep === 'enter') {
+		createFirstPin = details.valueAsString;
+		createStep = 'confirm';
+		pinInputKey += 1;
+		return;
+	}
+
+	// 2 段目: 確認一致で作成 API へ
+	if (details.valueAsString !== createFirstPin) {
+		pinError = OYAKAGI_LABELS.gateCreateMismatch;
+		resetCreateFlow();
+		return;
+	}
+
+	pinSubmitting = true;
+	try {
+		const res = await fetch('/api/v1/parent-gate/setup', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ pin: details.valueAsString }),
+		});
+		const body = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+		if (res.ok && body.ok) {
+			pinModalOpen = false;
+			// next path が /admin 配下に限定されていることは server 側で保証済
+			window.location.href = data.nextPath ?? '/admin';
+			return;
+		}
+		if (body.error === 'ALREADY_CONFIGURED') {
+			// 別タブ等で先に作成済みのケース。data を再取得して入力 modal に切り替える
+			pinError = OYAKAGI_LABELS.gateCreateAlreadyConfigured;
+			resetCreateFlow();
+			await invalidateAll();
+		} else if (body.error === 'PIN_FORMAT') {
+			pinError = OYAKAGI_LABELS.gateFormatNotice;
+			resetCreateFlow();
+		} else {
+			pinError = OYAKAGI_LABELS.gateCreateGenericError;
+			resetCreateFlow();
+		}
+	} catch {
+		pinError = OYAKAGI_LABELS.gateCreateGenericError;
+		resetCreateFlow();
+	} finally {
+		pinSubmitting = false;
+	}
+}
 
 async function handleAdminLinkClick(e: MouseEvent) {
 	// cognito モードで /auth/login に飛ばす場合は本フローをスキップ (子供画面では本リンク自体が非表示)
@@ -182,18 +258,35 @@ async function handlePinComplete(details: { valueAsString: string }) {
 
 <Dialog
 	bind:open={pinModalOpen}
-	title={OYAKAGI_LABELS.gateModalTitle}
+	title={pinCreateMode
+		? createStep === 'enter'
+			? OYAKAGI_LABELS.gateCreateTitle
+			: OYAKAGI_LABELS.gateCreateConfirmTitle
+		: OYAKAGI_LABELS.gateModalTitle}
 	testid="parent-gate-modal"
 	size="sm"
 >
-	<p class="text-sm text-[var(--color-text-muted)] mb-4">{OYAKAGI_LABELS.gateModalDescription}</p>
-	{#key pinInputKey}
-		<PinInput length={4} mask onComplete={handlePinComplete} />
-	{/key}
+	{#if pinCreateMode}
+		<!-- #2992: 初回作成フロー (入力→確認の 2 段)。未設定 tenant に既定 PIN を要求しない -->
+		<div data-testid="parent-gate-create" data-step={createStep}>
+			<p class="text-sm text-[var(--color-text-muted)] mb-4">
+				{createStep === 'enter'
+					? OYAKAGI_LABELS.gateCreateDescription
+					: OYAKAGI_LABELS.gateCreateConfirmDescription}
+			</p>
+			{#key pinInputKey}
+				<PinInput length={4} mask onComplete={handleCreateComplete} />
+			{/key}
+		</div>
+	{:else}
+		<p class="text-sm text-[var(--color-text-muted)] mb-4">{OYAKAGI_LABELS.gateModalDescription}</p>
+		{#key pinInputKey}
+			<PinInput length={4} mask onComplete={handlePinComplete} />
+		{/key}
+	{/if}
 	<!-- Issue #2353 Fix 5 (Phase A): 初期 PIN 5086 ヒントを modal から削除 (子供脆弱性) -->
 	<!-- 業界 PIN 採用 4 サービス全てで初期値ヒントは setup 時のみ、modal では非表示 (Apple / Nintendo / Roblox / BusyKid) -->
-	<!-- setup/complete/+page.svelte の OYAKAGI_LABELS.defaultValueHint は適切な文脈 (初期 setup 完了時) なので維持 -->
-	<!-- Phase C: gateDefaultHint atom は labels.ts から削除済、ここでは Phase C 由来の Forgot PIN リンクのみ追加 -->
+	<!-- #2992 以降は「初回は作成フロー」のため既定 PIN ヒント自体が不要 (未設定者は自分で作る) -->
 
 	{#if pinError}
 		<div class="mt-3" data-testid="parent-gate-error">
@@ -201,12 +294,14 @@ async function handlePinComplete(details: { valueAsString: string }) {
 		</div>
 	{/if}
 	{#if pinSubmitting}
-		<p class="text-xs text-[var(--color-text-muted)] text-center mt-3" data-testid="parent-gate-submitting">{OYAKAGI_LABELS.gateModalSubmitting}</p>
+		<p class="text-xs text-[var(--color-text-muted)] text-center mt-3" data-testid="parent-gate-submitting">{pinCreateMode ? OYAKAGI_LABELS.gateCreateSubmitting : OYAKAGI_LABELS.gateModalSubmitting}</p>
 	{/if}
-	<!-- #2353 設計欠陥 4: PIN 忘れ救済導線 (SES magic link + jose JWT 30 分有効 + 1 回限り) -->
-	<div class="mt-4 text-center">
-		<a href="/auth/forgot-pin" class="text-sm text-[var(--color-text-link)] no-underline hover:underline" data-testid="parent-gate-forgot-pin-link">{OYAKAGI_LABELS.gateForgotPinLink}</a>
-	</div>
+	{#if !pinCreateMode}
+		<!-- #2353 設計欠陥 4: PIN 忘れ救済導線 (作成モードでは PIN が未存在のため非表示) -->
+		<div class="mt-4 text-center">
+			<a href="/auth/forgot-pin" class="text-sm text-[var(--color-text-link)] no-underline hover:underline" data-testid="parent-gate-forgot-pin-link">{OYAKAGI_LABELS.gateForgotPinLink}</a>
+		</div>
+	{/if}
 </Dialog>
 
 <style>

--- a/tests/e2e/parent-gate.spec.ts
+++ b/tests/e2e/parent-gate.spec.ts
@@ -278,13 +278,120 @@ function registerParentGateTests(): void {
 			const isVisible = await dialog.isVisible().catch(() => false);
 			if (isVisible) {
 				await expect(dialog).toContainText('ご家族の見守り画面');
-				await expect(dialog).toContainText('5086');
+				// #2992: 初回は既定 PIN 入力でなく新規作成フローのため、案内文言は
+				// 「5086 既定値」から「作成します」に変更済 (dialogPinHint)
+				await expect(dialog).toContainText('作成します');
+				await expect(dialog).not.toContainText('5086');
 				await expect(page.getByTestId('pin-gate-onboarding-dont-show-again')).toBeVisible();
 				// 「とじる」ボタンで閉じる + persist
 				await page.getByTestId('pin-gate-onboarding-close').click();
 				await expect(dialog).toBeHidden();
 			}
 			void request; // unused in skipped path
+		});
+	});
+
+	// #2992 (EPIC #2990): 初回 PIN 新規作成フロー (「初回は作る・既存は入る」)
+	// PIN 未設定 tenant は gate modal が login でなく作成 (入力→確認の 2 段) になり、
+	// 確認一致で setup API → parent session 発行 → /admin に到達する (初回 dead-end の根治)。
+	//
+	// cognito-dev config は単一 DB (data/ganbari-quest.db、global-setup が pin_hash を seed 済) のため、
+	// 「未設定 tenant」は spec 内で pin_hash を snapshot → 削除して再現し、afterAll で完全復元する
+	// (#2851 snapshot/restore パターン。削除したまま終了すると後続 spec の「設定済み」前提を壊す)。
+	test.describe('#2992 初回 PIN 作成フロー (PIN 未設定 tenant)', () => {
+		test.use({ storageState: 'playwright/.auth/owner.json' });
+
+		const DB_PATH = 'data/ganbari-quest.db';
+		let pinHashSnapshot: string | null = null;
+
+		test.beforeAll(async () => {
+			const { default: Database } = await import('better-sqlite3');
+			const db = new Database(DB_PATH);
+			try {
+				const row = db.prepare("SELECT value FROM settings WHERE key = 'pin_hash'").get() as
+					| { value: string }
+					| undefined;
+				pinHashSnapshot = row?.value ?? null;
+			} finally {
+				db.close();
+			}
+		});
+
+		test.beforeEach(async ({ context }) => {
+			await context.clearCookies({ name: 'gq_parent_session' });
+			// 各 test を「未設定」状態から開始 (先行 test の作成で pin_hash が入るため毎回削除)
+			const { default: Database } = await import('better-sqlite3');
+			const db = new Database(DB_PATH);
+			try {
+				db.prepare("DELETE FROM settings WHERE key = 'pin_hash'").run();
+			} finally {
+				db.close();
+			}
+		});
+
+		test.afterAll(async () => {
+			// seed 状態へ完全復元 (#2851: 自分が消した seed 値を必ず戻す)
+			const { default: Database } = await import('better-sqlite3');
+			const db = new Database(DB_PATH);
+			try {
+				if (pinHashSnapshot !== null) {
+					db.prepare(
+						"INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('pin_hash', ?, datetime('now'))",
+					).run(pinHashSnapshot);
+				} else {
+					db.prepare("DELETE FROM settings WHERE key = 'pin_hash'").run();
+				}
+			} finally {
+				db.close();
+			}
+		});
+
+		/** PinInput remount ({#key}) 後はフォーカスが外れるため、明示 click してから入力する */
+		async function typePinInto(page: import('@playwright/test').Page, pin: string) {
+			const firstInput = page.locator('[data-testid="parent-gate-modal"] input').first();
+			await firstInput.click();
+			for (const ch of pin) {
+				await page.keyboard.press(ch);
+			}
+		}
+
+		test('未設定 tenant: 作成フロー (入力→確認→一致) で /admin に到達する', async ({ page }) => {
+			await page.goto('/switch?pinRequired=1', { waitUntil: 'domcontentloaded' });
+			await expect(page.getByTestId('parent-gate-modal')).toBeVisible();
+
+			// login でなく作成フローが表示される (1 段目)
+			const create = page.getByTestId('parent-gate-create');
+			await expect(create).toBeVisible();
+			await expect(create).toHaveAttribute('data-step', 'enter');
+			// 作成モードでは「忘れた方」リンクは出ない (PIN がまだ存在しない)
+			await expect(page.getByTestId('parent-gate-forgot-pin-link')).toHaveCount(0);
+
+			// 1 段目入力 → 確認 step へ
+			await typePinInto(page, '4321');
+			await expect(create).toHaveAttribute('data-step', 'confirm');
+
+			// 2 段目 (一致) → setup API → /admin 到達 (goal 完遂、dead-end でない)
+			const setupResponse = page.waitForResponse(
+				(res) => res.url().includes('/api/v1/parent-gate/setup') && res.status() === 200,
+			);
+			await typePinInto(page, '4321');
+			await setupResponse;
+			await page.waitForURL(/\/admin/, { timeout: 15_000 });
+		});
+
+		test('確認不一致はエラー表示 + 1 段目からやり直し (dead-end でない)', async ({ page }) => {
+			await page.goto('/switch?pinRequired=1', { waitUntil: 'domcontentloaded' });
+			const create = page.getByTestId('parent-gate-create');
+			await expect(create).toHaveAttribute('data-step', 'enter');
+
+			await typePinInto(page, '4321');
+			await expect(create).toHaveAttribute('data-step', 'confirm');
+
+			// 不一致 → エラー + enter に戻る (リトライ可能)
+			await typePinInto(page, '9999');
+			await expect(page.getByTestId('parent-gate-error')).toBeVisible({ timeout: 10_000 });
+			await expect(page.getByTestId('parent-gate-error')).toContainText('一致しません');
+			await expect(create).toHaveAttribute('data-step', 'enter');
 		});
 	});
 }

--- a/tests/unit/routes/parent-gate-setup-api.test.ts
+++ b/tests/unit/routes/parent-gate-setup-api.test.ts
@@ -1,0 +1,119 @@
+// tests/unit/routes/parent-gate-setup-api.test.ts
+// #2992 (EPIC #2990): POST /api/v1/parent-gate/setup — 初回 PIN 新規作成 API
+//
+// 「初回は作る・既存は入る」の作成側 enforcement を検証する:
+//   - 未設定 tenant のみ作成可 (設定済みへの上書きは 403 = 子供が親の PIN を勝手に再作成する穴の防止)
+//   - 成功で setupPin + parent session cookie 発行 (verify 成功と同じ)
+//   - PIN format (4-6 桁数字) / rate limit ガード
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockIsPinConfigured = vi.fn();
+const mockSetupPin = vi.fn();
+const mockCheckRateLimit = vi.fn();
+
+vi.mock('$lib/server/services/auth-service', () => ({
+	isPinConfigured: mockIsPinConfigured,
+	setupPin: mockSetupPin,
+}));
+
+vi.mock('$lib/server/services/parent-gate-session', () => ({
+	createParentSession: vi.fn(() => 'signed-session-value'),
+	PARENT_SESSION_COOKIE_NAME: 'gq_parent_session',
+}));
+
+vi.mock('$lib/server/security/rate-limiter', () => ({
+	checkRateLimit: mockCheckRateLimit,
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const { POST } = await import('../../../src/routes/api/v1/parent-gate/setup/+server');
+
+function makeEvent(opts: { pin?: unknown; tenantId?: string } = {}) {
+	const request = new Request('http://localhost/api/v1/parent-gate/setup', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ pin: opts.pin ?? '4321' }),
+	});
+	const cookieSet = vi.fn();
+	return {
+		event: {
+			request,
+			locals: {
+				context: { tenantId: opts.tenantId ?? 'tenant-1', role: 'owner', licenseStatus: 'none' },
+				identity: { type: 'local' as const },
+			},
+			cookies: { set: cookieSet },
+			getClientAddress: () => '127.0.0.1',
+		} as unknown as Parameters<typeof POST>[0],
+		cookieSet,
+	};
+}
+
+describe('POST /api/v1/parent-gate/setup (#2992)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockCheckRateLimit.mockReturnValue({ allowed: true });
+		mockIsPinConfigured.mockResolvedValue(false);
+		mockSetupPin.mockResolvedValue(undefined);
+	});
+
+	it('未設定 tenant: PIN 作成成功で 200 + setupPin + session cookie 発行', async () => {
+		const { event, cookieSet } = makeEvent({ pin: '4321' });
+		const res = await POST(event);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+		expect(mockSetupPin).toHaveBeenCalledWith('4321', 'tenant-1');
+		// verify 成功と同じく作成者をそのまま親画面に通す (gq_parent_session 発行)
+		expect(cookieSet).toHaveBeenCalledWith(
+			'gq_parent_session',
+			'signed-session-value',
+			expect.objectContaining({ httpOnly: true, path: '/' }),
+		);
+	});
+
+	it('設定済み tenant: 403 ALREADY_CONFIGURED で setupPin を呼ばない (上書き穴の防止)', async () => {
+		mockIsPinConfigured.mockResolvedValue(true);
+		const { event, cookieSet } = makeEvent({ pin: '4321' });
+		const res = await POST(event);
+
+		expect(res.status).toBe(403);
+		expect(await res.json()).toEqual({ ok: false, error: 'ALREADY_CONFIGURED' });
+		expect(mockSetupPin).not.toHaveBeenCalled();
+		expect(cookieSet).not.toHaveBeenCalled();
+	});
+
+	it('PIN format 不正 (3 桁) は 400 PIN_FORMAT', async () => {
+		const { event } = makeEvent({ pin: '123' });
+		const res = await POST(event);
+		expect(res.status).toBe(400);
+		expect(await res.json()).toEqual({ ok: false, error: 'PIN_FORMAT' });
+		expect(mockSetupPin).not.toHaveBeenCalled();
+	});
+
+	it('PIN format 不正 (数字以外) は 400 PIN_FORMAT', async () => {
+		const { event } = makeEvent({ pin: 'abcd' });
+		const res = await POST(event);
+		expect(res.status).toBe(400);
+		expect(mockSetupPin).not.toHaveBeenCalled();
+	});
+
+	it('6 桁は許容される (PIN 仕様 4-6 桁)', async () => {
+		const { event } = makeEvent({ pin: '123456' });
+		const res = await POST(event);
+		expect(res.status).toBe(200);
+		expect(mockSetupPin).toHaveBeenCalledWith('123456', 'tenant-1');
+	});
+
+	it('rate limit 超過は 429 RATE_LIMITED', async () => {
+		mockCheckRateLimit.mockReturnValue({ allowed: false });
+		const { event } = makeEvent();
+		const res = await POST(event);
+		expect(res.status).toBe(429);
+		expect(mockSetupPin).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/services/auth-service.test.ts
+++ b/tests/unit/services/auth-service.test.ts
@@ -273,35 +273,32 @@ describe('auth-service', () => {
 			expect(attempts).toBe('1');
 		});
 
-		it('pin_hash 未設定時に DEFAULT_PIN (5086) で verifyPin 成功', async () => {
+		// #2992 (EPIC #2990): 「初回は作る・既存は入る」。未設定 tenant は DEFAULT_PIN 照合せず
+		// PIN_NOT_SET を返し、作成フロー (POST /api/v1/parent-gate/setup) へ誘導する。
+		// どんな入力 (5086 含む) でも通らないことを保証する (旧「未設定 → 5086 で ok」仕様を supersede)。
+		it('#2992: pin_hash 未設定時は 5086 でも PIN_NOT_SET (作成フローへ誘導)', async () => {
 			seedAuthSettings('');
 			const result = await verifyPin('5086', 'test-tenant');
-			expect(result).toEqual({ ok: true });
+			expect(result).toEqual({ ok: false, error: 'PIN_NOT_SET' });
 		});
 
-		it('pin_hash 未設定時に DEFAULT_PIN 以外で verifyPin 失敗 (INVALID_PIN)', async () => {
+		it('#2992: pin_hash 未設定時は任意の入力で PIN_NOT_SET', async () => {
 			seedAuthSettings('');
 			const result = await verifyPin('1234', 'test-tenant');
-			expect(result).toEqual({ ok: false, error: 'INVALID_PIN' });
+			expect(result).toEqual({ ok: false, error: 'PIN_NOT_SET' });
 		});
 
-		// #2335 hotfix Phase 1: 本番で「pin_hash 未設定 (DynamoDB scan 0 件) + pin='5086'」フローが
-		// 失敗している現象の logic 側を再確認する明示的テスト。logic が正常であることを保証し、
-		// 仮説 2 (getSetting が '' 返却) / 仮説 1 (PinInput valueAsString) / 仮説 3 (tenantId) /
-		// 仮説 4 (build minify) を切り分けるための baseline。
-		it('#2335 baseline: pin_hash 完全未挿入 (DEFAULT_PIN 比較経路) で 5086 → ok', async () => {
-			// settings から pin_hash 行を完全に削除 (空文字列ではなく row 自体が無い状態)
+		it('#2992: pin_hash 行が完全未挿入 (row 自体なし) でも PIN_NOT_SET', async () => {
+			// settings から pin_hash 行を完全に削除 (空文字列ではなく row 自体が無い状態、#2335 系列の経路)
 			sqlite.exec("DELETE FROM settings WHERE key = 'pin_hash'");
 			const result = await verifyPin('5086', 'test-tenant');
-			expect(result).toEqual({ ok: true });
+			expect(result).toEqual({ ok: false, error: 'PIN_NOT_SET' });
 		});
 
-		it('#2335 baseline: pin_hash 空文字列 (DynamoDB empty value 模擬) で 5086 → ok', async () => {
-			// 仮説 2: DynamoDB が empty string を返す可能性。
-			// 現在の logic では `!pinHash` が true になり DEFAULT_PIN 比較 path に入るはず。
+		it('#2992: pin_hash 未設定時は失敗カウントを増やさない (作成誘導はペナルティでない)', async () => {
 			seedAuthSettings('');
-			const result = await verifyPin('5086', 'test-tenant');
-			expect(result).toEqual({ ok: true });
+			await verifyPin('9999', 'test-tenant');
+			expect(await getSetting('pin_failed_attempts', 'test-tenant')).toBe('0');
 		});
 
 		it('5回失敗でロックアウト (login と共通のカウンタ)', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 保護者（管理者）、特に初めて保護者画面に入ろうとする保護者

**解決する課題**: 初めて保護者ゲートに到達した保護者に、現状は「おやカギコードを入力してください」(login) を表示するが、初期値 5086 は setup 完了画面の小さな注記等でしか伝えられず、modal では意図的に隠している (#2353 Fix5 子供脆弱性対策)。別端末・別人・見落とし・過去 setup の保護者は **PIN を知る術がなく詰む** (初回 dead-end、PO 直接指摘 2026-06-06 / EPIC #2990 問題③)。

**期待される効果**: 「**初回は作る・既存は入る**」(Apple Screen Time / Google Family Link / Nintendo / YouTube Kids 同型) に分岐し、未設定 tenant には**新規作成 (入力→確認の 2 段)** を表示する。既定 PIN を知らない保護者の dead-end が構造的に解消し、「5086 を隠す」制約 (Fix5) は「未設定者は自分で作るためヒント不要」として自然解消する。

## 関連 Issue

Refs #2992
Refs #2990

関連: #2353 (Fix5 前提変更 / 旧「未設定→5086 で入室可」#1360 仕様の gate 経路 supersede) / #2991 (先行 sub) / 研究 SSOT `tmp/research/pin-gate-ux-ideal-state.md` Q1

## AC 検証マップ (ADR-0004)

HEAD SHA: `55c20a64151bee772d75ba844e2dd50cf3f4cd6b`

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 未設定なら PIN 作成 modal (入力→確認の 2 段) → setupPin → 親画面へ | E2E `tests/e2e/parent-gate.spec.ts` #2992 describe (cognito-dev 2 段ハーネス、DB snapshot/restore #2851 型) | **PASS** — `✓ 未設定 tenant: 作成フロー (入力→確認→一致) で /admin に到達する (2.1s)` + `✓ 確認不一致はエラー表示 + 1 段目からやり直し (839ms)`。実 API (`POST /api/v1/parent-gate/setup`) 200 + `waitForURL(/admin)` の goal 完遂 verify |
| AC2 | PIN 設定済なら従来の入力 modal | 既存 parent-gate E2E (AC2/AC4/#2991/Fix1/Fix5) が「設定済」前提のまま green | **PASS** — 同 run で 14 passed (2 failed は #2353 既存の forgot-pin/reset-pin email reset、本 PR 非接触・EPIC #2990 #2993 が supersede 対象) |
| AC3 | 既定 5086 login 経路の廃止 (verifyPin は未設定で PIN_NOT_SET) | `npx vitest run tests/unit/services/auth-service.test.ts` | **PASS** — `#2992: pin_hash 未設定時は 5086 でも PIN_NOT_SET` 等 4 件 (旧「未設定→5086 ok」4 件を仕様 supersede で置換、失敗カウント非増加も assert)。`login()`/`changePin()` は #1360 互換で不変 (該当既存テスト green) |
| AC4 | setup/complete の 5086 注記見直し | `src/routes/setup/complete/+page.svelte:57-60` + `SETUP_COMPLETE_LABELS.pinHintSuffix` | 完了 — 「初期値は 5086…」を「初めて入るときに作成します。」に置換。onboarding dialog (`dialogPinHint`) も同方針で置換し E2E assert 更新 (`toContainText('作成します')` + `not.toContainText('5086')`) |
| AC5 | E2E: 未設定→作成フロー / 設定済→入力フロー | AC1/AC2 と同 run | **PASS** (上記) |
| AC6 | AC6 (5086 非表示) の既存 E2E が引き続き green | 同 run `Fix 5: PIN modal に初期 PIN 5086 ヒントが表示されない` | **PASS** ✓ |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [x] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- `/switch` 保護者ゲート modal: `pinConfigured` (load 供給) で**作成モード / 入力モード分岐**。作成モードでは「忘れた方」リンク非表示 (PIN 未存在)
- 新 API `POST /api/v1/parent-gate/setup`: **未設定 tenant のみ**作成可 (設定済へは 403 `ALREADY_CONFIGURED` = 子供による上書き穴の防止)。成功で verify と同じ `gq_parent_session` cookie 発行。rate limit 20/15min
- `verifyPin`: 未設定 → `PIN_NOT_SET` (DEFAULT_PIN 照合廃止)。**Stripe portal は既存の `isPinConfigured` 先行分岐 + PIN_NOT_SET ハンドリング済で不変** (`api/stripe/portal/+server.ts:32-53`)
- **legacy local 経路は不変**: `login()` (`/login` `api/v1/auth/login`) / `changePin()` の DEFAULT_PIN fallback は #1360 互換で維持 (local モードは gate 無効で本フロー非対象。PIN 変更画面の `defaultValueHint` もその文脈で残置)
- setup/complete + onboarding dialog の 5086 案内 → 「初めて入るときに作成」に置換
- #2353 Fix1 `$effect` に**前回値比較ガード**追加 — `effect_update_depth_exceeded` ループ (EPIC #2990 finding、PARENT_GATE_FORCE_ACTIVE 下で auth.setup を不安定化) を遮断

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030） — worktree node_modules 不在のため pipeline (full clone) で代行: biome clean / svelte-check 0 errors / vitest 3287 passed / E2E (下記「検証結果」)。CI 全 green (e2e-test(1) 初回 fail は admin-activities-per-child #2902 AC5 の shard 順序依存 flake、re-run green / main green / 本 PR は活動データ非接触)
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/routes/parent-gate-setup-api.test.ts` (新規 6 件): 作成成功 + cookie 発行 / 403 ALREADY_CONFIGURED + setupPin 非呼出 / PIN_FORMAT 2 種 / 6 桁許容 / 429
  - `tests/unit/services/auth-service.test.ts` (更新 4 件): verifyPin 未設定系を PIN_NOT_SET 仕様に置換 (5086 でも不可 / 任意入力不可 / row 不在 / 失敗カウント非増加)
  - `tests/e2e/parent-gate.spec.ts` (新規 describe 2 件 + onboarding 文言 assert 更新): 作成フロー goal 完遂 + 不一致リトライ。DB snapshot/restore (#2851) で「未設定 tenant」を再現し seed へ完全復元
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — settings repo 抽象越し (pin_hash) のみで repo 実装変更なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (priority:high)

**検証結果** (pipeline full clone、HEAD `55c20a64`):
- biome check (changed 9 files) → clean
- `npx svelte-check` → **0 errors** (19 warnings は既存)
- `npx vitest run tests/unit/services/auth-service.test.ts tests/unit/routes/parent-gate-setup-api.test.ts` → **38 passed**
- `npx vitest run tests/unit/routes/ tests/unit/services/ tests/unit/domain/` → **203 files / 3287 passed** (回帰なし)
- E2E (cognito-dev 2 段ハーネス: setup 6 passed → `PARENT_GATE_FORCE_ACTIVE=true` spec `--no-deps`): **#2992 2 件 ✓ + 既存 parent-gate 14 passed** (2 failed は #2353 既存の email reset spec、本 PR 非接触)

## スクリーンショット / ビジュアルデモ

**4 スロット添付**（#1740）: `/switch?pinRequired=1` の保護者ゲート modal、**PIN 未設定 tenant** (dev DB の pin_hash を削除して再現、撮影後 seed 復元)。

| | モバイル (375px) | PC (1280px) |
|---|---|---|
| **修正前** | ![before-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2992/before-mobile.png) | ![before-desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2992/before-desktop.png) |
| **修正後** | ![after-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2992/after-mobile-enter.png) | ![after-desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2992/after-desktop-enter.png) |

- **修正前** (origin/main): 未設定 tenant にも「おやカギコードを**入力してください**」(login)。初期値を知らない保護者はここで詰む (ヒントは Fix5 で意図的に非表示)
- **修正後** (本 PR): 「おやカギコードを**つくってください**」— 4〜6 桁を親が決めて入力 → 確認入力 ([confirm step desktop](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2992/after-desktop-confirm.png) / [mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2992/after-mobile-confirm.png)) → 一致で親画面へ

**インタラクティブ状態**: enter→confirm の step 遷移・一致で /admin 到達・不一致リトライは E2E で機械検証 (`parent-gate.spec.ts` #2992 describe)。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 作成 API は verify と同型の責務分離 (検証は auth-service、session は parent-gate-session、UI は switch)。setupPin / isPinConfigured 既存関数を再利用
- [x] **DRY**: cookie 発行は verify と同一パラメータ。判定 SSOT は `isPinConfigured` 1 関数
- [x] **YAGNI**: 既存 `PIN_NOT_SET` 型 / `isPinConfigured` / `setupPin` を実配線する最小実装。新規抽象なし
- [x] **Security（OSS 公開前提）**: 設定済 tenant への setup を 403 で拒否 (子供の上書き穴防止)。rate limit 20/15min。PIN は bcrypt hash 保存 (既存)。gate 経路から既定 PIN 照合を廃止 = 「公開された既定値で誰でも入れる」面の縮小
- [x] **アクセシビリティ**: Dialog / PinInput primitive 準拠 (構造は入力モードと同一、文言のみ分岐)
- [x] **パフォーマンス**: load の `isPinConfigured` は settings 1 read。N+1 なし

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — demo (anonymous) は gate 無効 (`admin/+layout.server.ts`) のため非対象。`settings` repo 抽象越しで sqlite/dynamodb/demo 非依存
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [x] E2E / ユニットシード + チュートリアルを同期 — global-setup は pin_hash seed 済 (既存 E2E は「設定済」前提のまま不変)。onboarding 文言 assert を新文言に同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [x] 設計書: `06-UI設計書 §4.6` (作成/入力 2 モード + setup API) / `14-セキュリティ設計書 §4.3` (主要 flow に初回作成 + ヒント表示ポリシー表更新) を同 PR で同期
- [ ] 並行 PR overlap 確認 (#1200)

**LP / 販促文言変更時** (ADR-0013): N/A

## 設計判断

**1. 「初回は作る・既存は入る」**: 研究 (`tmp/research/pin-gate-ux-ideal-state.md` Q1) で Apple Screen Time / Google Family Link / Nintendo / YouTube Kids 全社が「初回 = 新規作成 (入力→確認)」「既存 = 現行 PIN」に分岐していることを確認 (一次資料)。「既定 PIN を login で入力させる」現行運用は業界 prior art ゼロで、初期値ヒントを modal に出せない制約 (#2353 Fix5) と組み合わさり初回 dead-end の根因だった。未設定者が自分で作れば、隠すべき既定 PIN 自体が存在しなくなる。

**2. verifyPin から DEFAULT_PIN を外し、login()/changePin() は維持**: gate 経路 (verify) の呼出元は parent-gate verify API と Stripe portal の 2 つで、portal は既存の `isPinConfigured` 先行分岐 + PIN_NOT_SET ハンドリング済 (`念のため` コメント付き) のため非破壊を実コードで確認済。一方 `login()` は legacy local `/login` (#1360、local モードは gate 無効で本フロー非対象)、`changePin()` は「未設定 tenant の現コード = 既定値」という PIN 変更画面の案内 (`defaultValueHint`) と対のため、互換維持が最小リスク。gate 経路の supersede 範囲を 14-セキュリティ設計書に明記した。

**3. 設定済 tenant への setup 拒否 (403)**: 作成 API を無条件にすると「子供が作成フローで親の PIN を勝手に再作成する」穴になる。未設定時のみ許可し、変更は現 PIN 確認付き `changePin`、忘れは reset 経路に限定する (speed bump として最小十分、EPIC #2990 Q5)。

**4. $effect 前回値比較ガード**: #2991 検証時に観測した `effect_update_depth_exceeded` (switch:31-38、EPIC #2990 finding) を、`data.pinRequired` の前回値を plain 変数で比較し同値再発火を no-op 化することで遮断。根因 (Dialog bind 連鎖) に依存しない冪等化で、Fix1 の意図 (query 再到達で modal 再 open) は `false→true` 遷移検出として保存される。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** — gate 経路の「未設定→5086 で入室可」は仕様変更だが、対象 (cognito 本番) では既定 PIN を知らないユーザが入れない dead-end だった挙動の置換であり、global-setup seed 済の既存 E2E / legacy local 経路はすべて不変
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- 設定済 tenant への setup 403 ガード (上書き穴) の妥当性
- verifyPin の PIN_NOT_SET 化が portal / 他呼出元に影響しないこと (unit 3287 + E2E で回帰なし確認済)
- 作成フロー UX (enter→confirm、 不一致で最初から) の文言・体験

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (pipeline 代行: biome / svelte-check 0 / vitest 3287 / E2E 2 段)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (AC1-AC6 PASS、検証マップ参照)
- [x] UI 変更時: SS (before/after × mobile/PC + confirm step) を GitHub 上で表示確認、作成 modal 文言を目視確認
- [x] 認証画面変更時: cognito-dev で E2E (parent-gate spec 2 段ハーネス) 実行 + 作成フロー SS 添付済

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

