### PR TITLE
infra: #3012 SS render 健全性 gate — 撮影時 assert + CI error ページ混入検出の 2 層防御

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -501,3 +501,12 @@ webui
 # ===== #2975 single-branch refspec self-heal (resolve-base-branch.mjs / branch-strategy SOP) =====
 # refspec = git fetch/push の ref mapping 指定 (+refs/heads/develop:refs/remotes/origin/develop)
 refspec
+
+# ===== #3012 SS render health gate (PR #3023) =====
+# dogfooding/quotepath/taskkill/greyscale/fullpage/Pngs = pr-quality-gate.yml / capture scripts / sharp / test 内の技術用語
+dogfooding
+quotepath
+taskkill
+greyscale
+fullpage
+Pngs

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -150,6 +150,45 @@ jobs:
           export PR_LABELS
           node scripts/check-ss-blob-sha-uniqueness.mjs
 
+  # ============================================================
+  # #3012 — SS render 健全性検証 (500 / error ページ混入検出)
+  #   PR #3006 で 500 エラーページが「実画面 SS」として screenshots branch に
+  #   2 度 push され、既存 gate (blob SHA 一意性 / ローカルパス禁止) を素通りした
+  #   事故への補完 gate。根本層は capture.mjs / capture-app-baseline.mjs の
+  #   撮影時 assert (scripts/lib/screenshot-helpers.mjs checkRenderHealth) が担い、
+  #   本 job は screenshots branch pr-<N>/ の .dom.html (#1766 DOM snapshot) を
+  #   text scan して error ページ marker を検出する軽量 heuristic 1 つに限定
+  #   (画像解析は不採用、ADR-0010 Pre-PMF)。
+  #   CHECK_MODE=error: error ページ混入は顧客提示物の毀損で致命的なため
+  #   #2063 と同様 warn 段階を経ず hard-fail。marker は src/routes/+error.svelte /
+  #   infra/error-pages 固有の class / 文言で false positive リスク ~0、
+  #   正当な error ページ SS には 'ss:error-page-intended' ラベル exempt あり。
+  # ============================================================
+  ss-render-health-check:
+    name: "SS render 健全性検証 (error ページ混入検出 #3012)"
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/check-ss-render-health.mjs
+            scripts/lib/screenshot-helpers.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Run check-ss-render-health.mjs
+        env:
+          CHECK_MODE: error
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          PR_LABELS=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --json labels --jq '[.labels[].name] | join(",")')
+          export PR_LABELS
+          node scripts/check-ss-render-health.mjs
+
   design-doc-check:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false

--- a/scripts/capture-app-baseline.mjs
+++ b/scripts/capture-app-baseline.mjs
@@ -232,6 +232,9 @@ async function main() {
 				fullPage: spec.fullPage ?? true,
 				...(cookies ? { cookies } : {}),
 				...(spec.interact ? { interact: spec.interact } : {}),
+				// #3012: error ページ (500 / +error.svelte / infra/error-pages) を baseline として
+				// 撮影しない。違反時は当該 spec が FAIL になり exit 1 + baseline 更新も中止される。
+				renderHealthCheck: true,
 			});
 			if (result.ok) {
 				console.log(`  [OK]   ${spec.name.padEnd(24)} ${spec.url} (${result.size} bytes)`);
@@ -247,6 +250,14 @@ async function main() {
 	console.log(`\n撮影完了: ${targets.length - failed}/${targets.length} 件 → ${CURRENT_DIR}`);
 
 	if (args.updateBaseline) {
+		// #3012: 撮影 fail (render 健全性違反含む) があるまま baseline を部分更新しない。
+		// 壊れた画面 / 欠落した spec が baseline に混入・凍結されるのを防ぐ。
+		if (failed > 0) {
+			console.error(
+				`❌ 撮影 ${failed} 件 fail のため baseline 更新を中止しました (#3012)。fail 原因を修正して再実行してください。`,
+			);
+			process.exit(1);
+		}
 		fs.mkdirSync(BASELINE_DIR, { recursive: true });
 		const ext = args.webp ? '.webp' : '.png';
 		let copied = 0;

--- a/scripts/capture.mjs
+++ b/scripts/capture.mjs
@@ -77,6 +77,9 @@ const { values, positionals } = parseArgs({
 		// #1825: Splide.js carousel 初期化完了を待機する。
 		// `--server-mode lp` 指定時は自動的に有効化される。
 		'wait-splide': { type: 'boolean', default: false },
+		// #3012: SS render 健全性検証の opt-out。エラーページ自体のデザイン SS を
+		// 意図的に撮影する場合のみ指定する (デフォルトは検証 ON、違反検出で exit 1)。
+		'allow-error-page': { type: 'boolean', default: false },
 		help: { type: 'boolean', default: false },
 	},
 });
@@ -149,6 +152,15 @@ Splide.js 初期化待機 (#1825):
   --wait-splide     hero carousel 等の Splide.js 初期化完了 (.splide__slide.is-active 出現) を待ってから撮影。
                     LP 撮影で carousel が黒ブロック化する問題への対処。--server-mode lp 指定時は自動有効化。
                     Splide が存在しないページでは silent skip するため副作用なし
+
+SS render 健全性検証 (#3012):
+  デフォルトで撮影直前に「エラーページを撮ろうとしていないか」を assert します:
+    - HTTP response status >= 500 (サーバーエラー)
+    - アプリ error ページ DOM marker (src/routes/+error.svelte の .error-page / .error-status)
+    - infra error ページ marker (infra/error-pages の "Error 5xx" / title)
+  違反検出時は SS を撮影せず exit 1 で停止します (screenshots branch にも push されません)。
+  PR #3006 で 500 エラーページが「実画面 SS」として 2 度 push された事故の構造的再発防止。
+  --allow-error-page  検証を無効化 (エラーページ自体のデザイン SS を意図的に撮る場合のみ)
 
   --help            このヘルプを表示
 
@@ -239,6 +251,13 @@ const domSnapshotEnabled = !values['no-dom-snapshot'];
 // #1825: Splide.js 初期化完了待機。`--server-mode lp` 指定時は自動有効化（LP 撮影で hero carousel
 // が黒ブロック化する問題への対処）。明示的に `--wait-splide` 指定時も有効化。
 const waitSplideEnabled = values['wait-splide'] || serverMode === 'lp';
+
+// #3012: SS render 健全性検証 (デフォルト ON)。--allow-error-page で opt-out。
+const renderHealthEnabled = !values['allow-error-page'];
+
+// #3012: render 健全性違反の収集先。1 件でもあれば screenshots branch push 前に exit 1。
+/** @type {Array<{ name: string; message: string }>} */
+const renderHealthViolations = [];
 
 // プリセット検証（早期エラー）
 for (const name of presetNames) {
@@ -614,6 +633,11 @@ async function runFlowMode() {
 function recordCaptureResult(result, capturedFiles, domFiles) {
 	if (!result.ok) {
 		console.error(`  エラー: ${result.error.message}`);
+		// #3012: render 健全性違反 (エラーページ撮影) は通常の撮影失敗と区別して収集し、
+		// 全撮影完了後に screenshots branch push 前で exit 1 させる。
+		if (/** @type {Error & { code?: string }} */ (result.error).code === 'ERR_RENDER_HEALTH') {
+			renderHealthViolations.push({ name: 'capture', message: result.error.message });
+		}
 		return false;
 	}
 	console.log(`  -> ${result.filePath} (${(result.size / 1024).toFixed(0)} KB)`);
@@ -716,6 +740,7 @@ async function runConfigMode() {
 				storageState,
 				waitSplide: waitSplideEnabled,
 				cookies,
+				renderHealthCheck: renderHealthEnabled,
 			});
 			if (recordCaptureResult(result, capturedFiles, domFiles)) success++;
 		}
@@ -777,6 +802,7 @@ async function runUrlMode() {
 			section: values.section,
 			storageState,
 			waitSplide: waitSplideEnabled,
+			renderHealthCheck: renderHealthEnabled,
 		});
 		recordCaptureResult(result, capturedFiles, domFiles);
 	}
@@ -828,6 +854,27 @@ try {
 	}
 
 	const { screenshots: capturedFiles, domFiles } = result;
+
+	// #3012: SS render 健全性違反 (エラーページ撮影) 検出時は screenshots branch push 前に
+	// fail-fast する。違反した URL の SS は撮影自体が行われていない (ファイル不生成) が、
+	// 他の成功分も push せず exit 1 で停止し、修正後の再撮影を強制する。
+	if (renderHealthViolations.length > 0) {
+		console.error(
+			`\nSS render 健全性違反 (#3012): ${renderHealthViolations.length} 件のエラーページ描画を検出しました。`,
+		);
+		console.error(
+			[
+				'',
+				'対応方法:',
+				'  1. 対象ページが 500 / 404 を返す原因 (load 関数 / service 層の例外等) を修正する',
+				'  2. 修正後に同じコマンドで SS を撮り直す',
+				'  3. エラーページ自体のデザイン SS が必要な場合のみ --allow-error-page を付けて再実行する',
+				'',
+				'参考: Issue #3012 (PR #3006 で 500 エラーページが実画面 SS として push された事故の再発防止)',
+			].join('\n'),
+		);
+		process.exit(1);
+	}
 
 	// #2059: Before / After sha256 同一検出ガード
 	// 撮影完了直後にローカル file hash で完全一致を検出し、screenshots branch push 前に

--- a/scripts/check-ss-render-health.mjs
+++ b/scripts/check-ss-render-health.mjs
@@ -144,6 +144,7 @@ export function findImagesMissingDomPair(imageNames, domNames) {
  *   dir 不在なら null
  */
 export async function fetchPrScreenshotEntries({ repo, prNumber, fetcher = fetch }) {
+	/** @type {Record<string, string>} */
 	const headers = {
 		Accept: 'application/vnd.github+json',
 		'X-GitHub-Api-Version': '2022-11-28',
@@ -254,7 +255,7 @@ async function main() {
 	try {
 		result = await checkSsRenderHealth({ repo: REPO, prNumber: PR_NUMBER, labels: PR_LABELS });
 	} catch (err) {
-		console.error(`${prefix} internal error:`, err.message);
+		console.error(`${prefix} internal error:`, err instanceof Error ? err.message : String(err));
 		return 2;
 	}
 
@@ -279,9 +280,10 @@ async function main() {
 	}
 
 	// fail
+	const violations = result.violations ?? [];
 	console.log(`\n${prefix} ${isError ? 'ERROR' : 'WARN'} — ${result.reason}`);
 	console.log('\nerror ページ marker が検出された SS:');
-	for (const v of result.violations) {
+	for (const v of violations) {
 		console.log(`  - pr-${PR_NUMBER}/${v.name}`);
 		for (const r of v.reasons) {
 			console.log(`      ${r}`);
@@ -299,7 +301,7 @@ async function main() {
 			'  3. エラーページ自体のデザイン SS が正当な場合のみ PR ラベル',
 			`     '${ERROR_PAGE_INTENDED_LABEL}' を付与して re-run する`,
 			'',
-			`mode=${MODE}, violations=${result.violations.length} ` +
+			`mode=${MODE}, violations=${violations.length} ` +
 				`(${isError ? 'CI を red にします' : 'warning として記録、CI は通過させます'})`,
 		].join('\n'),
 	);

--- a/scripts/check-ss-render-health.mjs
+++ b/scripts/check-ss-render-health.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+/**
+ * scripts/check-ss-render-health.mjs (#3012)
+ *
+ * screenshots branch に push された PR SS の **render 健全性** (500 / error ページ混入) を
+ * 検証する CI gate (補完層)。
+ *
+ * # 設計背景
+ *
+ * PR #3006 で /admin/rewards・/admin/checklists の 500 サーバーエラーページが
+ * 「実画面 SS」として screenshots branch (`pr-3006/`) に 2 度 push され、既存 CI gate
+ * (`ss-blob-sha-uniqueness-check` #2063 / `screenshot-quality-check` #1740/#1741) を
+ * green で素通りした。既存 gate は「偽装 (同一画像)」「ローカルパス」を見るが、
+ * 「SS が正常画面か」は誰も見ていなかった。
+ *
+ * # 2 層防御における位置付け
+ *
+ * - 根本層 (撮影時 assert): `scripts/lib/screenshot-helpers.mjs` `checkRenderHealth`
+ *   — capture.mjs / capture-app-baseline.mjs が撮影直前に error ページを検出して exit 1。
+ *   error ページ SS はそもそも生成・push されない。
+ * - 補完層 (本 script): 旧版 capture script の使用 / 手動 push 等で撮影時 assert を
+ *   バイパスされた場合に備え、screenshots branch `pr-<N>/` の `.dom.html`
+ *   (SS と同一 page から取得される DOM snapshot、#1766) を text scan して
+ *   error ページ marker を検出する。画像解析 (OCR / pixelmatch) は行わない
+ *   (Pre-PMF 軽量方針、ADR-0010 — marker 定義は撮影時 assert と同一 SSOT
+ *   `detectErrorMarkersInHtml` を共有 #1442)。
+ *
+ * 加えて、画像 (png/webp/jpeg) が push されているのに対応する `.dom.html` が
+ * 存在しないものは **warning として列挙** する (#3006 の実事故 push `744dc5c3a` は
+ * dom.html なしの PNG のみ = capture.mjs 正規経路をバイパスした手動 push であり、
+ * dom scan では検出不能なため、QM レビュー時の手掛かりとして可視化する)。
+ * legit な欠落ケース (before-* rename 運用 / --no-dom-snapshot / *-flow.webp 合成) が
+ * あるため hard-fail にはしない。
+ *
+ * # スキップ条件
+ *
+ * - PR ラベル `refactor:internal-no-doc-impact` (SS 不要 refactor、#2017 と同パターン)
+ * - PR ラベル `ss:error-page-intended` (エラーページ自体のデザイン変更 PR で
+ *   error ページ SS の添付が正当な場合。capture.mjs --allow-error-page と対)
+ * - screenshots branch に `pr-<N>/` が存在しない / `.dom.html` が 0 件
+ *
+ * # 環境変数
+ *
+ *   PR_NUMBER         — PR 番号 (github.event.pull_request.number)
+ *   PR_LABELS         — カンマ区切りの PR ラベル
+ *   GH_TOKEN          — GitHub API token
+ *   GITHUB_REPOSITORY — `owner/repo`
+ *   CHECK_MODE        — 'warn' | 'error' (default: 'error'。error ページ混入は顧客提示物の
+ *                       毀損で致命的なため #2063 と同様 warn 段階を経ず hard-fail)
+ *
+ * # ローカル実行
+ *
+ *   PR_NUMBER=3006 GITHUB_REPOSITORY=Takenori-Kusaka/ganbari-quest \
+ *   CHECK_MODE=error node scripts/check-ss-render-health.mjs
+ *
+ * # exit code
+ *
+ *   0 — OK / skip / warn モードで違反あり
+ *   1 — error モードで違反あり
+ *   2 — internal error (API 失敗等)
+ */
+
+import { resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { detectErrorMarkersInHtml } from './lib/screenshot-helpers.mjs';
+
+const MODE = (process.env.CHECK_MODE || 'error').toLowerCase();
+const PR_NUMBER = process.env.PR_NUMBER || '';
+const REPO = process.env.GITHUB_REPOSITORY || '';
+const PR_LABELS = (process.env.PR_LABELS || '')
+	.split(',')
+	.map((s) => s.trim())
+	.filter(Boolean);
+
+// ---------------------------------------------------------------------------
+// Pure functions (named exports for vitest)
+// ---------------------------------------------------------------------------
+
+/** #2017 / #1985 / #2063 共通の内部 refactor exempt ラベル */
+export const INTERNAL_REFACTOR_LABEL = 'refactor:internal-no-doc-impact';
+
+/**
+ * エラーページ自体のデザイン変更 PR 用 exempt ラベル (#3012)。
+ * capture.mjs `--allow-error-page` (撮影時 assert の opt-out) と対になる CI 側 opt-out。
+ */
+export const ERROR_PAGE_INTENDED_LABEL = 'ss:error-page-intended';
+
+/**
+ * exempt ラベル判定。
+ * @param {string[]} labels
+ * @returns {{ exempt: boolean; label?: string }}
+ */
+export function findExemptLabel(labels) {
+	for (const candidate of [INTERNAL_REFACTOR_LABEL, ERROR_PAGE_INTENDED_LABEL]) {
+		if (labels.some((l) => l.trim().toLowerCase() === candidate)) {
+			return { exempt: true, label: candidate };
+		}
+	}
+	return { exempt: false };
+}
+
+/**
+ * `.dom.html` ファイル群を scan して error ページ marker 違反を検出する。
+ *
+ * @param {Array<{ name: string; html: string }>} files
+ * @returns {Array<{ name: string; reasons: string[] }>}
+ */
+export function judgeDomSnapshots(files) {
+	const violations = [];
+	for (const f of files) {
+		const reasons = detectErrorMarkersInHtml(f.html);
+		if (reasons.length > 0) {
+			violations.push({ name: f.name, reasons });
+		}
+	}
+	return violations;
+}
+
+/**
+ * 画像ファイル名一覧のうち、対応する `.dom.html` (同 basename) が存在しないものを返す。
+ *
+ * 除外 (legit な dom なしケース):
+ *   - `*-flow.webp` (FlowRecorder のグリッド合成、DOM snapshot 対象外)
+ *
+ * @param {string[]} imageNames - 画像ファイル名 (png/webp/jpeg)
+ * @param {string[]} domNames - `.dom.html` ファイル名
+ * @returns {string[]} dom pair 欠落の画像ファイル名
+ */
+export function findImagesMissingDomPair(imageNames, domNames) {
+	const domBases = new Set(domNames.map((n) => n.replace(/\.dom\.html$/, '')));
+	return imageNames.filter((name) => {
+		if (/-flow\.webp$/i.test(name)) return false;
+		const base = name.replace(/\.(png|jpe?g|webp|gif)$/i, '');
+		return !domBases.has(base);
+	});
+}
+
+/**
+ * screenshots branch の `pr-<N>/` 配下のファイル一覧を取得し、`.dom.html` の中身を fetch する。
+ *
+ * @param {{ repo: string; prNumber: string | number; fetcher?: typeof fetch }} input
+ * @returns {Promise<{ domFiles: Array<{ name: string; html: string }>; imageNames: string[] } | null>}
+ *   dir 不在なら null
+ */
+export async function fetchPrScreenshotEntries({ repo, prNumber, fetcher = fetch }) {
+	const headers = {
+		Accept: 'application/vnd.github+json',
+		'X-GitHub-Api-Version': '2022-11-28',
+	};
+	const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+	if (token) headers.Authorization = `Bearer ${token}`;
+
+	const listUrl = `https://api.github.com/repos/${repo}/contents/pr-${prNumber}?ref=screenshots`;
+	const listRes = await fetcher(listUrl, { headers });
+	if (listRes.status === 404) return null;
+	if (!listRes.ok) {
+		throw new Error(`GitHub API failed for pr-${prNumber} listing: ${listRes.status}`);
+	}
+	const entries = await listRes.json();
+	if (!Array.isArray(entries)) return null;
+
+	const fileNames = entries
+		.filter((e) => e.type === 'file' && typeof e.name === 'string')
+		.map((e) => e.name);
+	const imageNames = fileNames.filter((n) => /\.(png|jpe?g|webp|gif)$/i.test(n));
+
+	const domEntries = entries.filter(
+		(e) => e.type === 'file' && typeof e.name === 'string' && e.name.endsWith('.dom.html'),
+	);
+
+	const domFiles = [];
+	for (const entry of domEntries) {
+		if (!entry.download_url) continue;
+		const res = await fetcher(entry.download_url, { headers });
+		if (!res.ok) {
+			throw new Error(`GitHub raw fetch failed for ${entry.name}: ${res.status}`);
+		}
+		domFiles.push({ name: entry.name, html: await res.text() });
+	}
+	return { domFiles, imageNames };
+}
+
+/**
+ * 本体処理。fetcher を DI 可能にして test で mock 注入する。
+ *
+ * @param {{ repo: string; prNumber: string; labels: string[]; fetcher?: typeof fetch }} input
+ * @returns {Promise<{ status: 'pass' | 'fail' | 'skip'; reason: string; violations?: Array<{ name: string; reasons: string[] }>; missingDomPairs?: string[] }>}
+ */
+export async function checkSsRenderHealth({ repo, prNumber, labels, fetcher = fetch }) {
+	const exempt = findExemptLabel(labels);
+	if (exempt.exempt) {
+		return {
+			status: 'skip',
+			reason: `PR ラベル '${exempt.label}' により exempt (#3012)`,
+		};
+	}
+	if (!prNumber) {
+		return { status: 'skip', reason: 'PR_NUMBER 未指定 (PR コンテキスト外)' };
+	}
+	if (!repo) {
+		return { status: 'skip', reason: 'GITHUB_REPOSITORY 未指定' };
+	}
+
+	const entries = await fetchPrScreenshotEntries({ repo, prNumber, fetcher });
+	if (entries === null) {
+		return {
+			status: 'skip',
+			reason: `screenshots branch に pr-${prNumber}/ が存在しません (SS 未 push)`,
+		};
+	}
+	const { domFiles, imageNames } = entries;
+
+	// #3006 実事故 (744dc5c3a) パターンの可視化: dom.html なし画像 = capture.mjs 正規経路
+	// バイパスの疑い。legit ケースがあるため warn のみ (hard-fail しない)。
+	const missingDomPairs = findImagesMissingDomPair(
+		imageNames,
+		domFiles.map((f) => f.name),
+	);
+
+	if (domFiles.length === 0) {
+		return {
+			status: 'skip',
+			reason: `pr-${prNumber}/ に .dom.html が 0 件 (撮影時 assert #3012 と QM 目視が担保)`,
+			missingDomPairs,
+		};
+	}
+
+	const violations = judgeDomSnapshots(domFiles);
+	if (violations.length === 0) {
+		return {
+			status: 'pass',
+			reason: `${domFiles.length} 件の .dom.html すべてで error ページ marker なし`,
+			missingDomPairs,
+		};
+	}
+	return {
+		status: 'fail',
+		reason: `${violations.length}/${domFiles.length} 件の SS が error ページを描画 (混入疑い)`,
+		violations,
+		missingDomPairs,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Main entry
+// ---------------------------------------------------------------------------
+
+async function main() {
+	const isError = MODE === 'error';
+	const prefix = '[ss-render-health]';
+
+	let result;
+	try {
+		result = await checkSsRenderHealth({ repo: REPO, prNumber: PR_NUMBER, labels: PR_LABELS });
+	} catch (err) {
+		console.error(`${prefix} internal error:`, err.message);
+		return 2;
+	}
+
+	// #3006 (744dc5c3a) パターン: dom.html を伴わない画像 push の warning (non-blocking)
+	if (result.missingDomPairs && result.missingDomPairs.length > 0) {
+		console.log(
+			`${prefix} WARN — ${result.missingDomPairs.length} 件の画像に対応する .dom.html がありません ` +
+				'(capture.mjs 正規経路バイパスの疑い。QM は SS 実視認時に注意):',
+		);
+		for (const name of result.missingDomPairs) {
+			console.log(`  - pr-${PR_NUMBER}/${name}`);
+		}
+	}
+
+	if (result.status === 'skip') {
+		console.log(`${prefix} SKIP — ${result.reason}`);
+		return 0;
+	}
+	if (result.status === 'pass') {
+		console.log(`${prefix} OK — ${result.reason}`);
+		return 0;
+	}
+
+	// fail
+	console.log(`\n${prefix} ${isError ? 'ERROR' : 'WARN'} — ${result.reason}`);
+	console.log('\nerror ページ marker が検出された SS:');
+	for (const v of result.violations) {
+		console.log(`  - pr-${PR_NUMBER}/${v.name}`);
+		for (const r of v.reasons) {
+			console.log(`      ${r}`);
+		}
+	}
+	console.log(
+		[
+			'',
+			'背景: PR #3006 で 500 エラーページが「実画面 SS」として screenshots branch に',
+			'2 度 push され、QM の手動目視でのみ検出された (#3012)。',
+			'',
+			'対応方法:',
+			'  1. 対象ページが 500 / 404 を返す原因を修正する',
+			'  2. node scripts/capture.mjs --pr <N> で SS を撮り直す (撮影時 assert #3012 が再発を防ぐ)',
+			'  3. エラーページ自体のデザイン SS が正当な場合のみ PR ラベル',
+			`     '${ERROR_PAGE_INTENDED_LABEL}' を付与して re-run する`,
+			'',
+			`mode=${MODE}, violations=${result.violations.length} ` +
+				`(${isError ? 'CI を red にします' : 'warning として記録、CI は通過させます'})`,
+		].join('\n'),
+	);
+
+	return isError ? 1 : 0;
+}
+
+const isMain = (() => {
+	try {
+		return pathResolve(fileURLToPath(import.meta.url)) === pathResolve(process.argv[1] || '');
+	} catch {
+		return false;
+	}
+})();
+
+if (isMain) {
+	main().then(
+		(code) => process.exit(code),
+		(err) => {
+			console.error('[ss-render-health] uncaught:', err);
+			process.exit(2);
+		},
+	);
+}

--- a/scripts/lib/screenshot-helpers.mjs
+++ b/scripts/lib/screenshot-helpers.mjs
@@ -251,6 +251,130 @@ export async function waitForStablePage(page, options = {}) {
 }
 
 // ============================================================
+// #3012: SS render 健全性検証 (500 / error ページ混入検出)
+// ============================================================
+//
+// 設計背景: PR #3006 で /admin/rewards・/admin/checklists の 500 エラーページが
+// 「実画面 SS」として screenshots branch に 2 度 push され、既存 CI gate
+// (blob SHA 一意性 #2063 / ローカルパス禁止 #1741) を素通りした。
+// 「SS が正常画面か (error ページでないか)」を検証する層がゼロだったため、
+// 撮影 script 側で撮影直前に assert する (根本層)。CI 側の補完 gate は
+// scripts/check-ss-render-health.mjs (.dom.html marker scan) が担う。
+//
+// マーカーの実体 (SSOT):
+//   - アプリ error ページ: src/routes/+error.svelte
+//       root: <div class="error-page" data-role=...> + <p class="error-status">{status}</p>
+//       (Svelte scoping class が付くため `class="error-page ` 前方一致で検出)
+//   - infra error ページ: infra/error-pages/{500,502,503,504}.html
+//       <p class="code">Error 5xx</p> + <title>エラーが おきたよ - がんばりクエスト</title>
+
+/** infra/error-pages/*.html の title / h1 に含まれる固有マーカー文言 */
+export const INFRA_ERROR_TITLE_MARKER = 'エラーが おきたよ';
+
+/**
+ * render 健全性の純粋判定。Playwright page から抽出した facts を受け取り、
+ * error ページ描画 / 5xx 応答なら unhealthy を返す。
+ *
+ * 判定ルール:
+ *   1. HTTP status >= 500 → unhealthy (SSR が 500 を返した)
+ *   2. アプリ error ページの DOM marker (.error-page .error-status に 3 桁 status) → unhealthy
+ *      (404 / 403 含む — error ページを「実画面 SS」として撮ることは常に誤り)
+ *   3. infra error ページの marker (<p class="code">Error 5xx</p> / title マーカー) → unhealthy
+ *
+ * @param {object} facts
+ * @param {number | null} [facts.httpStatus] - page.goto() response の HTTP status
+ * @param {string | null} [facts.appErrorStatus] - `.error-page .error-status` の textContent
+ * @param {string | null} [facts.infraCode] - `p.code` の textContent
+ * @param {string} [facts.title] - document.title
+ * @returns {{ healthy: true; reason: '' } | { healthy: false; reason: string }}
+ */
+export function evaluateRenderHealth({
+	httpStatus = null,
+	appErrorStatus = null,
+	infraCode = null,
+	title = '',
+} = {}) {
+	if (typeof httpStatus === 'number' && httpStatus >= 500) {
+		return { healthy: false, reason: `HTTP ${httpStatus} 応答 (サーバーエラー)` };
+	}
+	if (typeof appErrorStatus === 'string' && /^\d{3}$/.test(appErrorStatus.trim())) {
+		return {
+			healthy: false,
+			reason: `アプリ error ページ描画 (status ${appErrorStatus.trim()}、src/routes/+error.svelte)`,
+		};
+	}
+	if (typeof infraCode === 'string' && /^Error 5\d\d$/.test(infraCode.trim())) {
+		return {
+			healthy: false,
+			reason: `infra error ページ描画 (${infraCode.trim()}、infra/error-pages/)`,
+		};
+	}
+	if (typeof title === 'string' && title.includes(INFRA_ERROR_TITLE_MARKER)) {
+		return {
+			healthy: false,
+			reason: `infra error ページ描画 (title "${INFRA_ERROR_TITLE_MARKER}")`,
+		};
+	}
+	return { healthy: true, reason: '' };
+}
+
+/**
+ * Playwright page から render 健全性 facts を抽出して判定する。
+ *
+ * SS 撮影直前に呼び、unhealthy なら撮影せずに fail させる用途。
+ * テスト容易性のため page は `evaluate` のみを要求する duck-typed 受け取り
+ * (captureDomSnapshot と同パターン)。
+ *
+ * @param {{ evaluate: (fn: () => unknown) => Promise<unknown> }} page
+ * @param {{ httpStatus?: number | null }} [options]
+ * @returns {Promise<{ healthy: boolean; reason: string }>}
+ */
+export async function checkRenderHealth(page, { httpStatus = null } = {}) {
+	const facts =
+		/** @type {{ appErrorStatus: string|null; infraCode: string|null; title: string }} */ (
+			await page.evaluate(() => {
+				const appErrorEl = document.querySelector('.error-page .error-status');
+				const codeEl = document.querySelector('p.code');
+				return {
+					appErrorStatus: appErrorEl?.textContent?.trim() ?? null,
+					infraCode: codeEl?.textContent?.trim() ?? null,
+					title: document.title || '',
+				};
+			})
+		);
+	return evaluateRenderHealth({ httpStatus, ...facts });
+}
+
+/**
+ * HTML 文字列 (.dom.html スナップショット等) から error ページ固有マーカーを検出する。
+ *
+ * CI 側補完 gate (scripts/check-ss-render-health.mjs) が screenshots branch に
+ * push 済みの `.dom.html` を scan する用途。撮影時 assert (checkRenderHealth) と
+ * 同じマーカー定義を共有する (SSOT)。
+ *
+ * 注: Svelte の scoping class (`class="error-page svelte-xxxx"`) を考慮し前方一致で照合。
+ *
+ * @param {string} html
+ * @returns {string[]} 検出理由の配列 (空 = healthy)
+ */
+export function detectErrorMarkersInHtml(html) {
+	const reasons = [];
+	if (/class="error-page[\s"]/.test(html) && /class="error-status[\s"]/.test(html)) {
+		const statusMatch = html.match(/class="error-status[^"]*"[^>]*>\s*(\d{3})/);
+		reasons.push(
+			`アプリ error ページ marker (.error-page + .error-status${statusMatch ? `, status ${statusMatch[1]}` : ''})`,
+		);
+	}
+	if (/<p class="code">\s*Error 5\d\d\s*<\/p>/.test(html)) {
+		reasons.push('infra error ページ marker (<p class="code">Error 5xx</p>)');
+	}
+	if (html.includes(INFRA_ERROR_TITLE_MARKER)) {
+		reasons.push(`infra error ページ marker ("${INFRA_ERROR_TITLE_MARKER}")`);
+	}
+	return reasons;
+}
+
+// ============================================================
 // #1424: 新規エクスポート — プリセット・純粋関数
 // ============================================================
 
@@ -492,6 +616,12 @@ export class ScreenshotCapture {
 	 *   ❓ ガイドを開く等の user-gesture を必要とする "操作後の状態" を baseline 撮影するために使う。
 	 *   この hook 内で `page.click()` / `page.addStyleTag()` / box 安定待ち等を行い、撮影したい
 	 *   settled 状態を作る。例外は capture() の戻り値 `{ ok: false, error }` に集約される。
+	 * @param {boolean} [opts.renderHealthCheck=false] - SS render 健全性検証 (#3012)。
+	 *   true の場合、撮影直前に HTTP status >= 500 / error ページ DOM marker
+	 *   (src/routes/+error.svelte / infra/error-pages) を検出し、検出時は撮影せず
+	 *   `{ ok: false, error }` (error.code = 'ERR_RENDER_HEALTH') を返す。
+	 *   PR #3006 で 500 エラーページが「実画面 SS」として push された事故の根本対策。
+	 *   default false (capture-hp-screenshots.mjs 等の既存利用箇所の挙動を変えない)。
 	 * @returns {Promise<{ ok: true; filePath: string; size: number; domPath?: string; domSize?: number } | { ok: false; error: Error }>}
 	 */
 	async capture({
@@ -508,6 +638,7 @@ export class ScreenshotCapture {
 		waitSplide = false,
 		cookies,
 		interact,
+		renderHealthCheck = false,
 	}) {
 		if (!this.#browser) throw new Error('setup() を先に呼び出してください。');
 
@@ -541,16 +672,38 @@ export class ScreenshotCapture {
 			// Normalize: strip duplicate leading slashes (Windows Git Bash expands /foo to //foo)
 			const normalizedPath = `/${url.replace(/^\/+/, '')}`;
 			const targetUrl = `${this.#baseUrl}${normalizedPath}`;
-			await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 15000 }).catch(() => {
-				throw new Error(
-					`サーバーに接続できません: ${targetUrl}\nnpm run dev または npm run dev:cognito でサーバーを起動してください。`,
-				);
-			});
+			// #3012: render 健全性検証のため goto response (HTTP status) を保持する
+			const response = await page
+				.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: 15000 })
+				.catch(() => {
+					throw new Error(
+						`サーバーに接続できません: ${targetUrl}\nnpm run dev または npm run dev:cognito でサーバーを起動してください。`,
+					);
+				});
 			await waitForStablePage(page, { selector, skipNetworkIdle: true, waitSplide });
 
 			// #2928: 撮影直前の任意操作 hook (❓ ガイドを開く等)。settled 状態の調整は hook 内で行う。
 			if (interact) {
 				await interact(page);
+			}
+
+			// #3012: SS render 健全性 assert — error ページを「実画面 SS」として撮影しない。
+			// 撮影前に検証するため、違反時は SS ファイル自体が生成されない (screenshots branch
+			// push 対象にもならない)。PR #3006 (500 ページ 2 度 push) の構造的再発防止。
+			if (renderHealthCheck) {
+				const health = await checkRenderHealth(page, {
+					httpStatus: response ? response.status() : null,
+				});
+				if (!health.healthy) {
+					const err = new Error(
+						`SS render 健全性違反 (#3012): ${health.reason}\n` +
+							`  URL: ${targetUrl}\n` +
+							'  エラーページは「実画面 SS」として撮影できません。対象ページの 500/404 を修正してください。\n' +
+							'  エラーページ自体のデザイン SS が必要な場合のみ capture.mjs の --allow-error-page を使ってください。',
+					);
+					/** @type {Error & { code?: string }} */ (err).code = 'ERR_RENDER_HEALTH';
+					throw err;
+				}
 			}
 
 			const screenshotType = format === 'jpeg' ? 'jpeg' : 'png';

--- a/tests/unit/scripts/ss-render-health.test.ts
+++ b/tests/unit/scripts/ss-render-health.test.ts
@@ -1,0 +1,361 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+	checkSsRenderHealth,
+	ERROR_PAGE_INTENDED_LABEL,
+	findExemptLabel,
+	findImagesMissingDomPair,
+	INTERNAL_REFACTOR_LABEL,
+	judgeDomSnapshots,
+} from '../../../scripts/check-ss-render-health.mjs';
+import {
+	checkRenderHealth,
+	detectErrorMarkersInHtml,
+	evaluateRenderHealth,
+	INFRA_ERROR_TITLE_MARKER,
+} from '../../../scripts/lib/screenshot-helpers.mjs';
+
+// ============================================================
+// fixture: src/routes/+error.svelte の実レンダリング相当 (Svelte scoping class 付き)
+// ============================================================
+
+const APP_ERROR_PAGE_HTML = `<!DOCTYPE html><html lang="ja"><head><title>500エラー - がんばりクエスト</title></head><body>
+<div class="error-page svelte-1abc23" data-role="parent">
+	<div class="error-container svelte-1abc23">
+		<p class="error-status svelte-1abc23">500</p>
+		<h1 class="error-title svelte-1abc23">エラーが はっせいしました</h1>
+		<p class="error-description svelte-1abc23">予期しないエラーが発生しました。時間をおいて再度お試しください。</p>
+	</div>
+</div>
+</body></html>`;
+
+const APP_404_PAGE_HTML = APP_ERROR_PAGE_HTML.replace(/500/g, '404');
+
+const HEALTHY_ADMIN_HTML = `<!DOCTYPE html><html lang="ja"><head><title>活動管理 - がんばりクエスト</title></head><body>
+<header class="admin-resource-header"><h1>活動管理</h1></header>
+<main><ul class="activity-list"><li>あさのしたく</li></ul></main>
+</body></html>`;
+
+// infra/error-pages/500.html の実ファイルを fixture として読む (marker と実装の同期を保証)
+const INFRA_500_HTML = readFileSync(
+	join(process.cwd(), 'infra', 'error-pages', '500.html'),
+	'utf8',
+);
+
+// ============================================================
+// evaluateRenderHealth (#3012 — 撮影時 assert の純粋判定)
+// ============================================================
+
+describe('evaluateRenderHealth (#3012)', () => {
+	it('HTTP 500 応答は unhealthy', () => {
+		const result = evaluateRenderHealth({ httpStatus: 500 });
+		expect(result.healthy).toBe(false);
+		expect(result.reason).toContain('HTTP 500');
+	});
+
+	it('HTTP 503 応答は unhealthy', () => {
+		expect(evaluateRenderHealth({ httpStatus: 503 }).healthy).toBe(false);
+	});
+
+	it('HTTP 200 + marker なしは healthy', () => {
+		const result = evaluateRenderHealth({ httpStatus: 200 });
+		expect(result.healthy).toBe(true);
+		expect(result.reason).toBe('');
+	});
+
+	it('HTTP 404 単独 (DOM marker なし) は HTTP 層では fail しない (DOM marker 層が担当)', () => {
+		expect(evaluateRenderHealth({ httpStatus: 404 }).healthy).toBe(true);
+	});
+
+	it('アプリ error ページ marker (status 500) は unhealthy', () => {
+		const result = evaluateRenderHealth({ httpStatus: 200, appErrorStatus: '500' });
+		expect(result.healthy).toBe(false);
+		expect(result.reason).toContain('+error.svelte');
+		expect(result.reason).toContain('500');
+	});
+
+	it('アプリ error ページ marker (status 404、SPA レンダリングで HTTP 200) も unhealthy', () => {
+		const result = evaluateRenderHealth({ httpStatus: 200, appErrorStatus: '404' });
+		expect(result.healthy).toBe(false);
+		expect(result.reason).toContain('404');
+	});
+
+	it('appErrorStatus が 3 桁数値でない文字列は false positive にしない', () => {
+		expect(evaluateRenderHealth({ httpStatus: 200, appErrorStatus: 'こんにちは' }).healthy).toBe(
+			true,
+		);
+	});
+
+	it('infra error ページの <p class="code">Error 502</p> は unhealthy', () => {
+		const result = evaluateRenderHealth({ httpStatus: 200, infraCode: 'Error 502' });
+		expect(result.healthy).toBe(false);
+		expect(result.reason).toContain('infra/error-pages');
+	});
+
+	it('p.code が無関係なテキストなら false positive にしない', () => {
+		expect(evaluateRenderHealth({ httpStatus: 200, infraCode: 'ABC-123' }).healthy).toBe(true);
+	});
+
+	it('title に infra error マーカー文言を含むと unhealthy', () => {
+		const result = evaluateRenderHealth({
+			httpStatus: 200,
+			title: `${INFRA_ERROR_TITLE_MARKER} - がんばりクエスト`,
+		});
+		expect(result.healthy).toBe(false);
+	});
+
+	it('facts 全省略 (httpStatus 不明) は healthy 扱い', () => {
+		expect(evaluateRenderHealth({}).healthy).toBe(true);
+		expect(evaluateRenderHealth().healthy).toBe(true);
+	});
+});
+
+// ============================================================
+// checkRenderHealth (#3012 — duck-typed page で facts 抽出経路を検証)
+// ============================================================
+
+describe('checkRenderHealth (#3012)', () => {
+	it('error ページ facts を返す page は unhealthy (撮影が拒否される)', async () => {
+		const fakePage = {
+			evaluate: async () => ({ appErrorStatus: '500', infraCode: null, title: '500エラー' }),
+		};
+		const result = await checkRenderHealth(fakePage, { httpStatus: 200 });
+		expect(result.healthy).toBe(false);
+		expect(result.reason).toContain('500');
+	});
+
+	it('healthy facts を返す page は healthy', async () => {
+		const fakePage = {
+			evaluate: async () => ({ appErrorStatus: null, infraCode: null, title: '活動管理' }),
+		};
+		const result = await checkRenderHealth(fakePage, { httpStatus: 200 });
+		expect(result.healthy).toBe(true);
+	});
+
+	it('HTTP 500 は DOM facts が healthy でも unhealthy', async () => {
+		const fakePage = {
+			evaluate: async () => ({ appErrorStatus: null, infraCode: null, title: '活動管理' }),
+		};
+		const result = await checkRenderHealth(fakePage, { httpStatus: 500 });
+		expect(result.healthy).toBe(false);
+	});
+});
+
+// ============================================================
+// detectErrorMarkersInHtml (#3012 — CI 側 .dom.html scan の SSOT)
+// ============================================================
+
+describe('detectErrorMarkersInHtml (#3012)', () => {
+	it('アプリ error ページ (Svelte scoping class 付き) を検出する', () => {
+		const reasons = detectErrorMarkersInHtml(APP_ERROR_PAGE_HTML);
+		expect(reasons.length).toBeGreaterThan(0);
+		expect(reasons.join('\n')).toContain('status 500');
+	});
+
+	it('アプリ 404 error ページも検出する', () => {
+		const reasons = detectErrorMarkersInHtml(APP_404_PAGE_HTML);
+		expect(reasons.join('\n')).toContain('status 404');
+	});
+
+	it('infra/error-pages/500.html (実ファイル) を検出する — marker と実装の同期回帰', () => {
+		const reasons = detectErrorMarkersInHtml(INFRA_500_HTML);
+		expect(reasons.length).toBeGreaterThan(0);
+		expect(reasons.join('\n')).toContain('Error 5xx');
+	});
+
+	it('正常な admin 画面 HTML では何も検出しない', () => {
+		expect(detectErrorMarkersInHtml(HEALTHY_ADMIN_HTML)).toEqual([]);
+	});
+
+	it('.error-page class 単独 (error-status なし) では false positive にしない', () => {
+		const html = '<div class="error-page-like">error-page という語を含むだけの本文</div>';
+		expect(detectErrorMarkersInHtml(html)).toEqual([]);
+	});
+});
+
+// ============================================================
+// check-ss-render-health.mjs (#3012 — CI gate 本体)
+// ============================================================
+
+describe('check-ss-render-health.mjs — findExemptLabel', () => {
+	it('exempt ラベル定数が workflow / capture.mjs と整合する固定値', () => {
+		expect(INTERNAL_REFACTOR_LABEL).toBe('refactor:internal-no-doc-impact');
+		expect(ERROR_PAGE_INTENDED_LABEL).toBe('ss:error-page-intended');
+	});
+
+	it('refactor:internal-no-doc-impact で exempt', () => {
+		expect(findExemptLabel(['type:fix', 'refactor:internal-no-doc-impact']).exempt).toBe(true);
+	});
+
+	it('ss:error-page-intended で exempt', () => {
+		const result = findExemptLabel(['SS:Error-Page-Intended']);
+		expect(result.exempt).toBe(true);
+		expect(result.label).toBe(ERROR_PAGE_INTENDED_LABEL);
+	});
+
+	it('無関係なラベルのみでは exempt しない', () => {
+		expect(findExemptLabel(['type:infra', 'priority:high']).exempt).toBe(false);
+		expect(findExemptLabel([]).exempt).toBe(false);
+	});
+});
+
+describe('check-ss-render-health.mjs — judgeDomSnapshots', () => {
+	it('error ページ dom.html を violation として返す', () => {
+		const violations = judgeDomSnapshots([
+			{ name: 'admin-rewards-mobile.dom.html', html: APP_ERROR_PAGE_HTML },
+			{ name: 'admin-activities-mobile.dom.html', html: HEALTHY_ADMIN_HTML },
+		]);
+		expect(violations).toHaveLength(1);
+		expect(violations[0].name).toBe('admin-rewards-mobile.dom.html');
+		expect(violations[0].reasons.length).toBeGreaterThan(0);
+	});
+
+	it('全件 healthy なら空配列', () => {
+		expect(judgeDomSnapshots([{ name: 'a.dom.html', html: HEALTHY_ADMIN_HTML }])).toEqual([]);
+	});
+});
+
+describe('check-ss-render-health.mjs — findImagesMissingDomPair (#3006 744dc5c3a パターン)', () => {
+	it('dom pair が揃っていれば空配列', () => {
+		expect(
+			findImagesMissingDomPair(
+				['admin-home-mobile.png', 'admin-home-desktop.webp'],
+				['admin-home-mobile.dom.html', 'admin-home-desktop.dom.html'],
+			),
+		).toEqual([]);
+	});
+
+	it('#3006 実事故 push (PNG 6 件 / dom.html 0 件) は全件 missing として列挙する', () => {
+		const incidentPngs = [
+			'admin-activities-desktop.png',
+			'admin-activities-mobile.png',
+			'admin-checklists-desktop.png',
+			'admin-checklists-mobile.png',
+			'admin-rewards-desktop.png',
+			'admin-rewards-mobile.png',
+		];
+		expect(findImagesMissingDomPair(incidentPngs, [])).toEqual(incidentPngs);
+	});
+
+	it('*-flow.webp (FlowRecorder 合成) は legit な dom なしケースとして除外する', () => {
+		expect(findImagesMissingDomPair(['add-activity-flow.webp'], [])).toEqual([]);
+	});
+
+	it('一部欠落のみを列挙する', () => {
+		expect(
+			findImagesMissingDomPair(['a-mobile.png', 'b-mobile.png'], ['a-mobile.dom.html']),
+		).toEqual(['b-mobile.png']);
+	});
+});
+
+describe('check-ss-render-health.mjs — checkSsRenderHealth (fetcher DI)', () => {
+	const repo = 'Takenori-Kusaka/ganbari-quest';
+
+	/** GitHub contents API + raw download の mock fetcher を作る */
+	function makeFetcher(entries: Array<{ name: string; html: string }>) {
+		return async (url: string) => {
+			if (url.includes('/contents/pr-')) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () =>
+						entries.map((e) => ({
+							type: 'file',
+							name: e.name,
+							download_url: `https://raw.example/${e.name}`,
+						})),
+				};
+			}
+			const entry = entries.find((e) => url.endsWith(e.name));
+			return {
+				ok: !!entry,
+				status: entry ? 200 : 404,
+				text: async () => entry?.html ?? '',
+			};
+		};
+	}
+
+	it('error ページ dom.html 混入で fail (PR #3006 再発パターン)', async () => {
+		const fetcher = makeFetcher([
+			{ name: 'admin-rewards-mobile.dom.html', html: APP_ERROR_PAGE_HTML },
+			{ name: 'admin-checklists-mobile.dom.html', html: INFRA_500_HTML },
+		]);
+		const result = await checkSsRenderHealth({
+			repo,
+			prNumber: '3006',
+			labels: [],
+			fetcher: fetcher as unknown as typeof fetch,
+		});
+		expect(result.status).toBe('fail');
+		expect(result.violations).toHaveLength(2);
+	});
+
+	it('全件 healthy なら pass', async () => {
+		const fetcher = makeFetcher([{ name: 'admin-home-mobile.dom.html', html: HEALTHY_ADMIN_HTML }]);
+		const result = await checkSsRenderHealth({
+			repo,
+			prNumber: '3012',
+			labels: [],
+			fetcher: fetcher as unknown as typeof fetch,
+		});
+		expect(result.status).toBe('pass');
+	});
+
+	it('pr ディレクトリ 404 (SS 未 push) は skip', async () => {
+		const fetcher = async () => ({ ok: false, status: 404, json: async () => ({}) });
+		const result = await checkSsRenderHealth({
+			repo,
+			prNumber: '9999',
+			labels: [],
+			fetcher: fetcher as unknown as typeof fetch,
+		});
+		expect(result.status).toBe('skip');
+	});
+
+	it('.dom.html 0 件は skip だが、dom pair 欠落画像を missingDomPairs として返す (#3006 replay)', async () => {
+		const fetcher = async (url: string) => {
+			if (url.includes('/contents/pr-')) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () => [
+						{ type: 'file', name: 'admin-rewards-mobile.png', download_url: 'x' },
+						{ type: 'file', name: 'admin-rewards-desktop.png', download_url: 'x' },
+					],
+				};
+			}
+			return { ok: true, status: 200, text: async () => '' };
+		};
+		const result = await checkSsRenderHealth({
+			repo,
+			prNumber: '3006',
+			labels: [],
+			fetcher: fetcher as unknown as typeof fetch,
+		});
+		expect(result.status).toBe('skip');
+		expect(result.missingDomPairs).toEqual([
+			'admin-rewards-mobile.png',
+			'admin-rewards-desktop.png',
+		]);
+	});
+
+	it('ss:error-page-intended ラベルで skip (エラーページ SS が正当な PR)', async () => {
+		const result = await checkSsRenderHealth({
+			repo,
+			prNumber: '3012',
+			labels: ['ss:error-page-intended'],
+			// fetcher が呼ばれないことを保証 (呼ばれたら throw)
+			fetcher: (async () => {
+				throw new Error('fetcher should not be called');
+			}) as unknown as typeof fetch,
+		});
+		expect(result.status).toBe('skip');
+	});
+
+	it('PR_NUMBER 未指定は skip', async () => {
+		const result = await checkSsRenderHealth({ repo, prNumber: '', labels: [] });
+		expect(result.status).toBe('skip');
+	});
+});

--- a/tests/unit/scripts/ss-render-health.test.ts
+++ b/tests/unit/scripts/ss-render-health.test.ts
@@ -208,8 +208,8 @@ describe('check-ss-render-health.mjs — judgeDomSnapshots', () => {
 			{ name: 'admin-activities-mobile.dom.html', html: HEALTHY_ADMIN_HTML },
 		]);
 		expect(violations).toHaveLength(1);
-		expect(violations[0].name).toBe('admin-rewards-mobile.dom.html');
-		expect(violations[0].reasons.length).toBeGreaterThan(0);
+		expect(violations[0]?.name).toBe('admin-rewards-mobile.dom.html');
+		expect(violations[0]?.reasons.length).toBeGreaterThan(0);
 	});
 
 	it('全件 healthy なら空配列', () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（間接的に顧客 — 顧客レビューに提示される SS / PR 証跡の品質保証）

**解決する課題**: PR #3006 で `/admin/rewards`・`/admin/checklists` の **500 エラーページが「実画面 SS」として screenshots branch に 2 度 push** され、既存 CI gate（blob SHA 一意性 #2063 / ローカルパス禁止 #1741）を green で素通りし、QM の手動目視でのみ検出された。「SS が正常画面か（error ページでないか）」を検証する層がゼロだった。

**期待される効果**: 壊れた画面（500 / 404 / infra error）が「撮影済 SS」として PR 証跡・visual baseline に混入することを機械検出で阻止。AdminResourceHeader 統一（#2998）で「1 箇所壊れると 3 画面同時に壊れる」リスクが増した状況での blind spot を解消する。

## 関連 Issue

closes #3012

related: #3006（事故 PR）/ #2063（SS Blob SHA 偽装防止 — 本 PR は「偽装」でなく「壊れた画面の見落とし」を補完）/ #2928（app-visual-regression）/ #1766（DOM snapshot — CI 補完 gate が再利用）

## AC 検証マップ (ADR-0004)

<!-- Issue #3012 は AC checkbox 形式でないため、提案セクション + Dev 指示 scope（2 層防御 + 回帰テスト）から AC を導出 -->

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | capture.mjs（PR SS、#3006 事故経路）が error ページ撮影時に exit 1（HTTP >= 500 + DOM marker の両層） | 実動作ログ: 強制 500 server / SPA error DOM server に対し `node scripts/capture.mjs --url ... --base-url http://localhost:539x` | HEAD `4a112f969` / HTTP 500 → `SS render 健全性違反 (#3012): HTTP 500 応答` + EXIT_CODE=1 / DOM marker (HTTP 200) → `アプリ error ページ描画 (status 500、src/routes/+error.svelte)` + EXIT_CODE=1 / SS ファイル不生成を確認（下記検証ログ） |
| AC2 | capture-app-baseline.mjs（app 層 baseline）も同 assert + fail 時は `--update-baseline` を中止 | 実動作ログ: `BASE_URL=http://localhost:5395 node scripts/capture-app-baseline.mjs --only age --update-baseline` | HEAD `4a112f969` / `[FAIL] app-baby-home ... HTTP 500 応答` + `❌ 撮影 1 件 fail のため baseline 更新を中止しました (#3012)` + EXIT_CODE=1 / `scripts/app-screenshot-baseline/` に diff なし（git status clean） |
| AC3 | 正常ページ撮影は両 script とも従来どおり PASS（false positive なし） | 実動作ログ: healthy server (200) に対し capture.mjs / capture-app-baseline.mjs 実行 | HEAD `4a112f969` / capture.mjs `完了: 1/1 キャプチャ` EXIT_CODE=0 / capture-app-baseline `[OK] app-baby-home ... 撮影完了: 1/1 件` EXIT_CODE=0。CI 補完 gate も実 PR #3006（修正済 HEAD、dom.html 6 件）で `OK — 6 件の .dom.html すべてで error ページ marker なし` |
| AC4 | CI 側補完 gate: screenshots branch `pr-<N>/` の SS に error ページ判定を適用し hard-fail | `scripts/check-ss-render-health.mjs` + `pr-quality-gate.yml` `ss-render-health-check` job（CHECK_MODE=error）/ ローカル実行 `PR_NUMBER=3006 ... node scripts/check-ss-render-health.mjs` | HEAD `4a112f969` / .github/workflows/pr-quality-gate.yml:153-200 / marker 定義は撮影時 assert と同一 SSOT `detectErrorMarkersInHtml`（scripts/lib/screenshot-helpers.mjs、#1442 再利用）/ skip 動線（pr dir 不在 / label exempt）もログ確認済 |
| AC5 | 回帰テスト: error ページ撮影が拒否されること・CI gate 判定を unit で検証 | `npx vitest run tests/unit/scripts/ss-render-health.test.ts` | HEAD `4a112f969` / **35 passed**（evaluateRenderHealth 12 / checkRenderHealth 3 / detectErrorMarkersInHtml 5（`infra/error-pages/500.html` 実ファイル fixture 込み）/ CI gate 15。既存 capture.test.ts / screenshot-helpers.test.ts 含む 77 passed） |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

（`scripts/lib/screenshot-helpers.mjs` / `scripts/capture.mjs` / `scripts/capture-app-baseline.mjs` / `scripts/check-ss-render-health.mjs`（新規）/ `.github/workflows/pr-quality-gate.yml` / `tests/unit/scripts/ss-render-health.test.ts`（新規））

**影響を受ける画面・機能**: アプリ画面への変更なし。SS 撮影フロー（PR SS / app visual baseline）と PR Quality Gate CI に新しい検証層が追加される。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/scripts/ss-render-health.test.ts`（新規、35 tests）: 撮影時 assert の純粋判定（HTTP >= 500 / `+error.svelte` DOM marker / `infra/error-pages` marker / false positive 防御）、duck-typed page での facts 抽出経路、CI gate（label exempt / dom.html scan / `#3006` 実事故 744dc5c3a の「dom なし PNG only push」replay = missingDomPairs warning）を検証。`infra/error-pages/500.html` 実ファイルを fixture として読み、marker と実装の同期回帰を担保
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（CI job は既存 `GITHUB_TOKEN` のみ使用）
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

### 実動作検証ログ（撮影時 assert、ローカル）

検証用 server（`tmp/`、非 commit）: healthy(200) / http500（`infra/error-pages/500.html` を 500 で返す）/ app-error-dom（`+error.svelte` 相当 DOM を 200 で返す = SPA レンダリング error 再現）

```
=== capture.mjs 正常ページ (200) ===
Capturing /admin/activities [mobile] ...
  -> tmp\3012-verify\healthy\....png (19 KB)
完了: 1/1 キャプチャ
EXIT_CODE=0

=== capture.mjs 強制 HTTP 500 ===
  エラー: SS render 健全性違反 (#3012): HTTP 500 応答 (サーバーエラー)
  URL: http://localhost:5392/admin/rewards
完了: 0/1 キャプチャ
SS render 健全性違反 (#3012): 1 件のエラーページ描画を検出しました。
EXIT_CODE=1   （SS ファイル未生成 = screenshots branch push 対象にならない）

=== capture.mjs SPA レンダリング error ページ (HTTP 200 + DOM marker) ===
  エラー: SS render 健全性違反 (#3012): アプリ error ページ描画 (status 500、src/routes/+error.svelte)
EXIT_CODE=1

=== capture.mjs --allow-error-page (意図的なエラーページ SS、opt-out) ===
完了: 1/1 キャプチャ
EXIT_CODE=0

=== capture-app-baseline.mjs 正常 (200) ===
  [OK]   app-baby-home            /baby/home (19077 bytes)
EXIT_CODE=0

=== capture-app-baseline.mjs 強制 500 + --update-baseline ===
  [FAIL] app-baby-home ... SS render 健全性違反 (#3012): HTTP 500 応答 (サーバーエラー)
❌ 撮影 1 件 fail のため baseline 更新を中止しました (#3012)。
EXIT_CODE=1   （scripts/app-screenshot-baseline/ 無変更）

=== check-ss-render-health.mjs（CI 補完 gate、実データ） ===
PR_NUMBER=3006 → [ss-render-health] OK — 6 件の .dom.html すべてで error ページ marker なし（修正済 HEAD）
PR_NUMBER=999999 → [ss-render-health] SKIP — screenshots branch に pr-999999/ が存在しません
```

### CI 側 gate の採否判断（Dev 指示「判断根拠を PR body に記録」）

- **採用**: `pr-quality-gate.yml` に `ss-render-health-check` job（軽量、node builtins のみ / npm ci 不要）。screenshots branch `pr-<N>/` の **`.dom.html`（#1766 DOM snapshot）text scan** を heuristic 1 つとして hard-fail（CHECK_MODE=error）。marker は `+error.svelte` / `infra/error-pages` 固有の class・文言で false positive リスク ~0、正当な error ページ SS（error ページ自体のデザイン変更 PR）には `ss:error-page-intended` ラベル exempt + capture.mjs `--allow-error-page` を用意。
- **補強（warn-only）**: 実事故 push `744dc5c3a` を調査した結果 **PNG 6 件のみで `.dom.html` が 0 件**（= capture.mjs 正規経路をバイパスした手動 push）であり、dom scan 単独ではこの replay を検出できないことが判明。そこで「画像はあるのに dom pair が無い」ファイルを **warning として列挙**（QM 目視の手掛かり）。hard-fail にしないのは legit ケース（`before-*` rename 運用 / `--no-dom-snapshot` / `*-flow.webp` 合成）があるため。
- **不採用**: Issue 提案の「既知 error ページ baseline との pixelmatch」「byte size 閾値」— pixelmatch は CI job への node_modules install（sharp / pixelmatch）+ viewport 別 baseline 維持が必要で、根本層（撮影時 assert がデフォルト ON で SS 自体を生成させない）がある以上 Pre-PMF 過剰（ADR-0010）。byte size 閾値（事故時 9,058 B / 18,318 B）は簡素な正常画面と区別できず false positive が高いため不採用。

### LP 層（capture-hp-screenshots.mjs）は本 PR の対象外（scope 境界の明記）

並行 PR との衝突回避のため、Dev 指示により本 PR の適用対象は `capture.mjs` / `capture-app-baseline.mjs` の 2 本に限定し、`capture-hp-screenshots.mjs`（LP 層）/ `scripts/lp-screenshot-baseline/` には触れていない。`ScreenshotCapture.capture()` の `renderHealthCheck` option は default false のため LP 経路の挙動は不変。LP 層へ適用する場合は option を渡すだけで本 PR 実装済みの機構をそのまま使える（追加実装不要）。

## スクリーンショット / ビジュアルデモ

**該当なし（UI 変更を含まない infra/CI PR — `src/` 配下の変更ゼロ。アプリ画面の描画・スタイル・文言に一切影響しない。ただし検証ログは上記「実動作検証ログ」セクションに必須記載済み）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 判定純粋関数（`evaluateRenderHealth` / `detectErrorMarkersInHtml`）と I/O（page 抽出 / GitHub API fetch）を分離。page / fetcher は duck-typed DI で test mock 可能（既存 `captureDomSnapshot` / `check-ss-blob-sha-uniqueness.mjs` と同パターン）
- [x] **DRY**: marker 定義は `scripts/lib/screenshot-helpers.mjs` の 1 箇所（撮影時 assert と CI gate が共有、#1442 使い捨て禁止）。既存 `checkBeforeAfterIdentical`（#2059）と同じ「lib 純粋関数 + capture.mjs exit 1」構造に揃えた
- [x] **YAGNI**: pixelmatch / OCR / byte-size heuristic は不採用（上記採否判断）。FlowRecorder への適用も現時点の事故経路でないため見送り
- [x] **Security（OSS 公開前提）**: 秘密情報 hardcode なし。CI job は既存 `GITHUB_TOKEN`（contents: read）のみ、外部送信なし
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: 撮影時 assert は page.evaluate 1 回（数 ms）。CI gate は GitHub API 数リクエストのみ（node_modules install 不要の sparse checkout）

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] **並行 PR overlap** (#1200): Dev 指示に従い `capture-hp-screenshots.mjs` / `scripts/lp-screenshot-baseline/` には触れていない（並行 PR が変更中の可能性があるため。`git diff --name-only origin/develop` で対象外を確認済）。`ScreenshotCapture.capture()` への option 追加は default false で LP 経路の挙動不変
- [x] N/A — 並行実装の影響範囲外（UI ラベル / 年齢モード / demo / ナビ / DB / チュートリアルのいずれにも非該当。`check-ss-blob-sha-uniqueness.mjs`（#2063 兄弟 gate）/ `screenshot-quality-check`（#1740）との責務境界は各 script ヘッダに明記）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

（注: capture.mjs はデフォルトで render 健全性検証が ON になるため、「error ページを意図的に撮影する」既存ワークフローがあれば `--allow-error-page` 指定が必要になる。grep した範囲でそのような用途の呼び出しは存在しない）

**レビュー依頼事項・QA**:
- CI gate `ss-render-health-check` は branch ruleset の required checks 未登録（管理者作業）。初回緑を確認後、required 化の要否は QM / 管理者判断に委ねる
- `ss:error-page-intended` ラベルは未作成。exempt が必要になった時点で `gh label create` で作成する運用（事前作成しない判断 — 使用頻度が極めて低い見込み）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（N/A — 分割なし。LP 層は Dev 指示による scope 境界、上記セクション参照）
- [x] UI 変更時: N/A（UI 変更なし、SS 不要根拠は該当セクションに明記）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
