### PR TITLE
fix: #3022 email/password ログインに refresh token cookie 保存 — セッション 1 時間 → 30 日 (#1365 適用漏れ是正)

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -136,6 +136,8 @@ Layer 2: Context（署名付きトークン）
 
 **サイレントリフレッシュ (#1365)**: `resolveIdentity()` 内で ID Token が期限切れの場合に `gq_refresh` Cookie を用いて自動更新。ログアウト時は `/oauth2/revoke` エンドポイントで Refresh Token を失効させる。
 
+**refresh cookie 保存経路 (#1365 / #3022)**: `gq_refresh` の保存箇所は ① OAuth callback (`src/routes/auth/callback/+server.ts`) ② signup 自動ログイン (`src/routes/auth/signup/+page.server.ts`) ③ email/password ログイン (`src/routes/auth/login/+page.server.ts` の `establishSession`、通常 / MFA / confirmCode の全成功経路) の 3 経路。新規ログイン経路を追加する際は `setRefreshCookie` (`src/lib/server/auth/providers/cognito-oauth.ts`) の配線を必須とする — identity_token のみ保存するとセッションが 1 時間で失効する。
+
 **Cognito User Pool 設定:**
 
 | 設定項目 | 値 |

--- a/src/routes/auth/login/+page.server.ts
+++ b/src/routes/auth/login/+page.server.ts
@@ -13,7 +13,7 @@ import {
 	resendConfirmationCode,
 	respondToMfaChallenge,
 } from '$lib/server/auth/providers/cognito-direct-auth';
-import { setIdentityCookie } from '$lib/server/auth/providers/cognito-oauth';
+import { setIdentityCookie, setRefreshCookie } from '$lib/server/auth/providers/cognito-oauth';
 import { COOKIE_SECURE } from '$lib/server/cookie-config';
 import { logger } from '$lib/server/logger';
 import {
@@ -94,7 +94,7 @@ export const actions: Actions = {
 			const loginResult = await authenticateWithCognito(email, password);
 			if (loginResult.success) {
 				await resetLoginFailures(email);
-				setIdentityCookie(cookies, loginResult.idToken);
+				establishSession(cookies, loginResult);
 				redirect(302, '/admin');
 			}
 		}
@@ -157,10 +157,24 @@ export const actions: Actions = {
 		}
 
 		// MFA成功 → セッション確立
-		setIdentityCookie(cookies, result.idToken);
+		establishSession(cookies, result);
 		redirect(302, '/admin');
 	},
 };
+
+/**
+ * 認証成功時のセッション cookie 確立
+ * identity cookie (1時間) + refresh cookie (30日、#1365 / #3022) をセットで保存する
+ */
+function establishSession(
+	cookies: import('@sveltejs/kit').Cookies,
+	result: { idToken: string; refreshToken?: string },
+): void {
+	setIdentityCookie(cookies, result.idToken);
+	if (result.refreshToken) {
+		setRefreshCookie(cookies, result.refreshToken);
+	}
+}
 
 /** devモード: ダミーユーザーで認証 */
 async function handleDevLogin(
@@ -259,6 +273,6 @@ async function handleCognitoLogin(
 
 	// 認証成功: ロックアウトカウンターをリセット → セッション確立
 	await resetLoginFailures(email);
-	setIdentityCookie(cookies, result.idToken);
+	establishSession(cookies, result);
 	redirect(302, '/admin');
 }

--- a/tests/unit/services/login-actions.test.ts
+++ b/tests/unit/services/login-actions.test.ts
@@ -1,0 +1,235 @@
+// tests/unit/services/login-actions.test.ts
+// ログイン server action のセッション cookie テスト (#3022)
+// - email/password ログイン成功時に refresh token cookie が保存されること (#1365 適用漏れの回帰防止)
+// - MFA 成功時 / confirmCode 自動ログイン成功時も同様
+// - refreshToken 不在時は identity cookie のみで失敗しないこと
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Cognito Direct Auth モック ---
+const mockAuthenticate = vi.fn();
+const mockRespondToMfaChallenge = vi.fn();
+const mockConfirmSignUp = vi.fn();
+const mockResendConfirmationCode = vi.fn();
+vi.mock('$lib/server/auth/providers/cognito-direct-auth', () => ({
+	authenticateWithCognito: (...args: unknown[]) => mockAuthenticate(...args),
+	respondToMfaChallenge: (...args: unknown[]) => mockRespondToMfaChallenge(...args),
+	confirmSignUp: (...args: unknown[]) => mockConfirmSignUp(...args),
+	resendConfirmationCode: (...args: unknown[]) => mockResendConfirmationCode(...args),
+}));
+
+// --- Cognito OAuth モック (identity / refresh cookie 設定) ---
+const mockSetIdentityCookie = vi.fn();
+const mockSetRefreshCookie = vi.fn();
+vi.mock('$lib/server/auth/providers/cognito-oauth', () => ({
+	setIdentityCookie: (...args: unknown[]) => mockSetIdentityCookie(...args),
+	setRefreshCookie: (...args: unknown[]) => mockSetRefreshCookie(...args),
+}));
+
+// --- Auth Factory モック (本番 cognito モード固定) ---
+vi.mock('$lib/server/auth/factory', () => ({
+	getAuthMode: () => 'cognito',
+	isCognitoDevMode: () => false,
+}));
+
+// --- Account Lockout モック ---
+const mockCheckAccountLockout = vi.fn();
+const mockRecordLoginFailure = vi.fn();
+const mockResetLoginFailures = vi.fn();
+vi.mock('$lib/server/security/account-lockout', () => ({
+	checkAccountLockout: (...args: unknown[]) => mockCheckAccountLockout(...args),
+	recordLoginFailure: (...args: unknown[]) => mockRecordLoginFailure(...args),
+	resetLoginFailures: (...args: unknown[]) => mockResetLoginFailures(...args),
+}));
+
+// --- Logger モック ---
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+beforeEach(() => {
+	mockAuthenticate.mockReset();
+	mockRespondToMfaChallenge.mockReset();
+	mockConfirmSignUp.mockReset();
+	mockResendConfirmationCode.mockReset();
+	mockSetIdentityCookie.mockReset();
+	mockSetRefreshCookie.mockReset();
+	mockCheckAccountLockout.mockReset();
+	mockCheckAccountLockout.mockResolvedValue({ locked: false });
+	mockRecordLoginFailure.mockReset();
+	mockResetLoginFailures.mockReset();
+	mockResetLoginFailures.mockResolvedValue(undefined);
+});
+
+/** FormData モック */
+function createFormData(data: Record<string, string>): FormData {
+	const fd = new FormData();
+	for (const [k, v] of Object.entries(data)) {
+		fd.set(k, v);
+	}
+	return fd;
+}
+
+/** RequestEvent モック */
+function createEvent(formData: Record<string, string>) {
+	const store = new Map<string, string>();
+	return {
+		request: { formData: () => Promise.resolve(createFormData(formData)) } as unknown as Request,
+		cookies: {
+			get: (name: string) => store.get(name),
+			set: (name: string, value: string, _opts?: unknown) => store.set(name, value),
+			delete: (name: string, _opts?: unknown) => store.delete(name),
+		},
+		locals: { authenticated: false, identity: null, context: null },
+	};
+}
+
+/** /admin への 302 redirect throw を assert する */
+async function expectRedirectToAdmin(promise: Promise<unknown>) {
+	try {
+		await promise;
+		expect.unreachable('should have thrown redirect');
+	} catch (e) {
+		expect((e as { status: number }).status).toBe(302);
+		expect((e as { location: string }).location).toBe('/admin');
+	}
+}
+
+// ============================================================
+// login action (email/password)
+// ============================================================
+describe('login action — refresh token cookie (#3022)', () => {
+	it('ログイン成功時に identity + refresh の両 cookie を設定する', async () => {
+		mockAuthenticate.mockResolvedValue({
+			success: true,
+			idToken: 'id-token-1',
+			accessToken: 'access-token-1',
+			refreshToken: 'refresh-token-1',
+		});
+
+		const { actions } = await import('../../../src/routes/auth/login/+page.server');
+		const event = createEvent({ email: 'user@example.com', password: 'Password1' });
+
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		await expectRedirectToAdmin((actions.login as any)(event));
+
+		expect(mockSetIdentityCookie).toHaveBeenCalledWith(event.cookies, 'id-token-1');
+		expect(mockSetRefreshCookie).toHaveBeenCalledWith(event.cookies, 'refresh-token-1');
+		expect(mockResetLoginFailures).toHaveBeenCalledWith('user@example.com');
+	});
+
+	it('refreshToken 不在時は identity cookie のみ設定し失敗しない', async () => {
+		mockAuthenticate.mockResolvedValue({
+			success: true,
+			idToken: 'id-token-2',
+			accessToken: 'access-token-2',
+			refreshToken: undefined,
+		});
+
+		const { actions } = await import('../../../src/routes/auth/login/+page.server');
+		const event = createEvent({ email: 'user@example.com', password: 'Password1' });
+
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		await expectRedirectToAdmin((actions.login as any)(event));
+
+		expect(mockSetIdentityCookie).toHaveBeenCalledWith(event.cookies, 'id-token-2');
+		expect(mockSetRefreshCookie).not.toHaveBeenCalled();
+	});
+
+	it('認証失敗時はどちらの cookie も設定しない', async () => {
+		mockAuthenticate.mockResolvedValue({
+			success: false,
+			error: 'INVALID_CREDENTIALS',
+			message: 'メールアドレスまたはパスワードが正しくありません',
+		});
+		mockRecordLoginFailure.mockResolvedValue({ locked: false });
+
+		const { actions } = await import('../../../src/routes/auth/login/+page.server');
+		const event = createEvent({ email: 'user@example.com', password: 'wrong' });
+
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		const result = await (actions.login as any)(event);
+
+		expect(result.status).toBe(401);
+		expect(mockSetIdentityCookie).not.toHaveBeenCalled();
+		expect(mockSetRefreshCookie).not.toHaveBeenCalled();
+	});
+});
+
+// ============================================================
+// mfa action
+// ============================================================
+describe('mfa action — refresh token cookie (#3022)', () => {
+	it('MFA 成功時に identity + refresh の両 cookie を設定する', async () => {
+		mockRespondToMfaChallenge.mockResolvedValue({
+			success: true,
+			idToken: 'mfa-id-token',
+			accessToken: 'mfa-access-token',
+			refreshToken: 'mfa-refresh-token',
+		});
+
+		const { actions } = await import('../../../src/routes/auth/login/+page.server');
+		const event = createEvent({
+			session: 'mfa-session',
+			mfaCode: '123456',
+			challengeName: 'SOFTWARE_TOKEN_MFA',
+			email: 'user@example.com',
+		});
+
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		await expectRedirectToAdmin((actions.mfa as any)(event));
+
+		expect(mockSetIdentityCookie).toHaveBeenCalledWith(event.cookies, 'mfa-id-token');
+		expect(mockSetRefreshCookie).toHaveBeenCalledWith(event.cookies, 'mfa-refresh-token');
+	});
+
+	it('MFA 成功で refreshToken 不在なら refresh cookie は設定しない', async () => {
+		mockRespondToMfaChallenge.mockResolvedValue({
+			success: true,
+			idToken: 'mfa-id-token',
+			accessToken: 'mfa-access-token',
+			refreshToken: undefined,
+		});
+
+		const { actions } = await import('../../../src/routes/auth/login/+page.server');
+		const event = createEvent({
+			session: 'mfa-session',
+			mfaCode: '123456',
+			challengeName: 'SOFTWARE_TOKEN_MFA',
+			email: 'user@example.com',
+		});
+
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		await expectRedirectToAdmin((actions.mfa as any)(event));
+
+		expect(mockSetRefreshCookie).not.toHaveBeenCalled();
+	});
+});
+
+// ============================================================
+// confirmCode action (確認コード → 自動ログイン)
+// ============================================================
+describe('confirmCode action — refresh token cookie (#3022)', () => {
+	it('確認成功 + 自動ログイン成功時に identity + refresh の両 cookie を設定する', async () => {
+		mockConfirmSignUp.mockResolvedValue({ success: true });
+		mockAuthenticate.mockResolvedValue({
+			success: true,
+			idToken: 'auto-id-token',
+			accessToken: 'auto-access-token',
+			refreshToken: 'auto-refresh-token',
+		});
+
+		const { actions } = await import('../../../src/routes/auth/login/+page.server');
+		const event = createEvent({
+			email: 'user@example.com',
+			code: '123456',
+			password: 'Password1',
+		});
+
+		// biome-ignore lint/suspicious/noExplicitAny: test mock
+		await expectRedirectToAdmin((actions.confirmCode as any)(event));
+
+		expect(mockSetIdentityCookie).toHaveBeenCalledWith(event.cookies, 'auto-id-token');
+		expect(mockSetRefreshCookie).toHaveBeenCalledWith(event.cookies, 'auto-refresh-token');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）— email/password ログインを使う全ユーザー

**解決する課題**: email/password ログインで確立したセッションが実質 1 時間で失効し、頻繁に再ログインを強制されていた（PO 実報告: 「1 日でセッションタイムアウト、以前は 1 ヶ月だったはず」2026-06-11）。Google OAuth は 30 日維持されるのに対し、#1365 の refresh token cookie 保存が login action だけ適用漏れしていた。

**期待される効果**: email/password ログインのセッションが Google OAuth と同等の 30 日に延長され、毎日の利用で再ログインが不要になる。

## 関連 Issue

closes #3022

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | handleCognitoLogin 成功時に refresh cookie が set される | `npx vitest run tests/unit/services/login-actions.test.ts` | HEAD `0e4df724` / 「ログイン成功時に identity + refresh の両 cookie を設定する」PASS / src/routes/auth/login/+page.server.ts `establishSession` 呼出 |
| AC2 | mfa action 成功時に refresh cookie が set される | 同上 | HEAD `0e4df724` / 「MFA 成功時に identity + refresh の両 cookie を設定する」PASS |
| AC3 | confirmCode 自動ログイン成功時に refresh cookie が set される | 同上 | HEAD `0e4df724` / 「確認成功 + 自動ログイン成功時に…」PASS |
| AC4 | refreshToken 不在時は identity cookie のみで失敗しない | 同上 | HEAD `0e4df724` / 「refreshToken 不在時は identity cookie のみ設定し失敗しない」+ MFA 同等 case PASS（計 2 件） |
| AC5 | unit test: 上記 4 ケースを mock で assert | `npx vitest run tests/unit/services/login-actions.test.ts` | HEAD `0e4df724` / 6 passed (6)（認証失敗時の非保存 assert 含む） |
| AC6 | 横展開: setIdentityCookie 呼出全数調査で他の適用漏れなし | `grep -rn "setIdentityCookie" src --include=*.ts` | HEAD `0e4df724` / 呼出元 3 file: callback (set 済) / signup (set 済) / login (本 PR で是正)。dev login は dev-jwt 直 set で Cognito refresh token 概念なし = 対象外 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/` 等)

**影響を受ける画面・機能**: /auth/login の server action のみ（通常ログイン / MFA / 確認コード後自動ログイン）。画面描画・UI 変更なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/services/login-actions.test.ts` 新規（6 件: login 成功で両 cookie / refreshToken 不在で identity のみ / 認証失敗で非保存 / MFA 成功で両 cookie / MFA refreshToken 不在 / confirmCode 自動ログインで両 cookie）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（priority:critical ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（server action の cookie 保存のみで UI 描画変更ゼロ。login 画面の見た目・DOM に差分なし）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — cookie 確立を `establishSession` helper に集約（3 箇所の重複排除 + biome cognitive complexity 21→20 内に解消）
- [x] **DRY**: `grep -rn "setIdentityCookie" src` で全呼出を調査、callback/signup は既に同型実装、login のみ漏れと確認
- [x] **YAGNI**: 既存 `setRefreshCookie` (OAuth callback と同一実装) を再利用、新規抽象なし
- [x] **Security**: refresh token は既存の httpOnly + secure + sameSite=strict cookie 経路 (#1449 確立) をそのまま使用。token 値の log 出力なし
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: N/A（cookie set 1 回追加のみ）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードと チュートリアルを同期
- [ ] labels SSOT
- [ ] 設計書同期 (ADR-0001): 14-セキュリティ設計書の記述「Refresh Token で 30 日延長 (#1365)」は経路非依存の記述で変更不要（適用漏れの是正であり仕様変更なし）
- [x] 並行 PR overlap: `src/routes/auth/login/+page.server.ts` を変更する open PR は他になし
- [x] N/A — 並行実装の影響範囲外（demo は AnonymousAuthProvider で login 画面なし、子供画面影響なし）

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: refresh cookie 不在時に `refreshCognitoIdToken` が無ログで null を返す（= 今回の発見遅延の一因）件は、観測性改善として別 Issue 化が適切か併せてご意見ください（本 PR は適用漏れ是正に scope 限定）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割: N/A（単一 PR で完結）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: server action のみで画面描画差分なし。unit test 6 件で 3 経路の cookie 動作を検証済み

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
