### PR TITLE
fix: #3017 ?screenshot=* で誕生日ボーナス banner 抑止 — visual regression 撮影日依存 flake 根治 (#3000/#3015 同根解消)

### DIFF
--- a/docs/design/lp-deploy-pipeline.md
+++ b/docs/design/lp-deploy-pipeline.md
@@ -106,6 +106,14 @@ demo (`/demo/**`) 配下に 3 段階の `?screenshot` mode を導入。SSOT は 
 - demo seed (`src/lib/server/demo/demo-data.ts`) の 902 番ペルソナは「ひなちゃん」（旧「ゆうきちゃん」、13 日分活動ログ ≥ 10 件で `records_10` マイルストーン達成済）に固定し、本番 NUC ユーザ視覚と一致させる
 - `scripts/capture-hp-screenshots.mjs` の `withScreenshotParam(path)` のデフォルトは `screenshot=all` (#1893 で変更)。後方互換で `?screenshot=1` (noise-only) が必要な場合は `withScreenshotParam(path, { mode: 'noise-only' })` を使う
 
+### 日付依存演出の抑止（決定的撮影、#3017）
+
+screenshot mode の「演出強制 ON」は **撮影日に依らず決定的に再現可能な演出のみ** を対象とする。撮影日で表示が変わる日付依存演出は、visual regression baseline (LP / child-home / app の 3 層、[docs/CLAUDE.md §visual regression 3 層](../CLAUDE.md)) との比較決定性を壊すため、screenshot mode 中（`noise-only` / `all` 両方）は **OFF** にする。
+
+- **誕生日ボーナス banner** (`BirthdayBanner`、子供 home 最上部): demo fixture 5 子の birthDate は固定のため、撮影日が誕生日 window（誕生日から 3 日間、`birthday-bonus-service.ts` の `CLAIM_WINDOW_DAYS`）に入ると banner が全要素を押し下げ、baseline と diff >10% で誤 fail する。`src/routes/(child)/[uiMode=uiMode]/home/+page.svelte` で `isScreenshotMode` 中は非 render（通常表示の挙動は不変）
+- 回帰検証: `tests/e2e/demo-lambda/visual-equality.spec.ts` が `?screenshot=all` / `?screenshot=1` で `birthday-banner` testid 0 件を assert
+- 新規の日付依存演出（季節・記念日等）を子供画面に追加する場合は、同様に screenshot mode 中の抑止を併せて実装する
+
 ### 並行実装
 
 `?screenshot` mode 仕様変更時は以下を同時更新する（[parallel-implementations.md](parallel-implementations.md)）:

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
@@ -523,7 +523,12 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 {:else}
 <div class="px-[var(--sp-sm)] py-1" data-testid="{data.uiMode}-home-page">
 	<!-- Birthday bonus banner -->
-	{#if data.birthdayBonus}
+	<!-- #3017: `?screenshot=*` 中は抑止 — 撮影日が demo fixture の誕生日 window (誕生日から 3 日間)
+	     に重なると banner が出現して全要素を押し下げ、LP/child-home/app の visual regression
+	     baseline と diff >10% で誤 fail する (年 5 回再発する撮影日依存 flake)。screenshot mode は
+	     「決定的に再現可能な演出のみ ON」(#1893) が趣旨であり、日付依存演出は OFF が整合的。
+	     通常表示 (screenshot mode off) の挙動は不変。 -->
+	{#if data.birthdayBonus && !isScreenshotMode}
 		<BirthdayBanner
 			nickname={data.child?.nickname ?? ''}
 			newAge={data.birthdayBonus.newAge ?? 0}

--- a/tests/e2e/demo-lambda/visual-equality.spec.ts
+++ b/tests/e2e/demo-lambda/visual-equality.spec.ts
@@ -92,6 +92,54 @@ test.describe('#2097 AC12: 5 年齢モード home の構造等価 (demo Lambda)'
 		});
 	}
 
+	// #3017: 撮影の決定性 assert — `?screenshot=all` では日付依存演出 (誕生日ボーナス banner) を
+	// 抑止する。demo fixture 5 子の birthDate は固定 (901=01-15 / 902=06-10 / 903=03-22 /
+	// 904=08-05 / 906=11-20) のため、撮影日が誕生日 window (誕生日から 3 日間、
+	// birthday-bonus-service.ts CLAIM_WINDOW_DAYS) に入ると banner が home 最上部に出現し
+	// LP / child-home / app の visual regression baseline と diff >10% で誤 fail していた
+	// (年 5 回再発する撮影日依存 flake)。capture-hp-screenshots.mjs は `?screenshot=all` で
+	// 撮影するため、screenshot mode 中の banner 非表示 = 撮影の決定性を保証する。
+	test('#3017: ?screenshot=all で誕生日ボーナス banner が表示されない (日付依存演出の決定的撮影)', async ({
+		context,
+		page,
+	}) => {
+		// preschool (902 ひな birthDate=2020-06-10) を代表として検証。
+		// 他 4 子も同一 +page.svelte の同一分岐を通るため 1 mode で regression 検出可能。
+		await context.clearCookies();
+		await context.addCookies([
+			{ name: 'selectedChildId', value: '902', domain: 'localhost', path: '/' },
+		]);
+
+		// 1) screenshot mode off: 今日が誕生日 window 内なら banner が表示される (通常挙動は不変)。
+		//    window 外の日は banner 不在 = 観測のみ (vacuous でも後段の count(0) assert は常に有効)。
+		await page.goto('/preschool/home');
+		await expect(page.locator('main').first()).toBeVisible();
+		const bannerVisibleToday = await page
+			.getByTestId('birthday-banner')
+			.isVisible()
+			.catch(() => false);
+
+		// 2) screenshot mode (`?screenshot=all`): 日付依存演出は常に抑止 — 撮影日に依らず 0 件。
+		await page.goto('/preschool/home?screenshot=all');
+		await expect(page.locator('main').first()).toBeVisible();
+		await expect(page.getByTestId('birthday-banner')).toHaveCount(0);
+
+		// 3) 後方互換 `?screenshot=1` (noise-only) でも同様に抑止 (#2097 PR-B1 hotfix と同型の
+		//    isScreenshotMode 判定を共有するため)。
+		await page.goto('/preschool/home?screenshot=1');
+		await expect(page.locator('main').first()).toBeVisible();
+		await expect(page.getByTestId('birthday-banner')).toHaveCount(0);
+
+		// 誕生日 window 内に実行された場合のみ「banner あり → screenshot で消える」の実差分を
+		// 検証できたことを test 出力に残す (window 外では off 側が元々非表示で vacuous)。
+		test.info().annotations.push({
+			type: 'birthday-window',
+			description: bannerVisibleToday
+				? 'in-window: suppression exercised (banner visible without ?screenshot)'
+				: 'out-of-window: count(0) assert only (banner absent in both modes today)',
+		});
+	});
+
 	test('AC12-summary: 5 年齢モード home が全て 200 で hydrate する (集約 regression)', async ({
 		context,
 		page,


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（CI 品質 gate の信頼性）

**解決する課題**: demo fixture 5 子の birthDate が固定のため、CI 撮影日が誕生日 window（誕生日から 3 日間）に重なると「おたんじょうびボーナスがとどいているよ！」banner が preschool home 等の最上部に出現して全要素を押し下げ、LP / child-home / app の visual regression が diff >10% で**年 5 回再発する撮影日依存 flake** になっていた（#3017 なぜなぜ分析）。本日 2026-06-11 はまさに ひなちゃん (902, birthDate=2020-06-10) の window 内で、#3010 / #3011 / #2996 の CI が決定的に fail していた（#3000 / #3015）。

**期待される効果**: `?screenshot=*` モードで日付依存演出を抑止することで撮影が決定的になり、LP visual regression の誤 fail（boy-who-cried-wolf によるシグナル毀損）が根治する。通常表示（screenshot mode off）の挙動は不変。

## 関連 Issue

closes #3017
closes #3000
closes #3015

> #3000 / #3015 は本 PR の banner 抑止と同根（3 失敗画像は全て preschool home 系 = banner 起因の縦シフト）。CI (Linux) 環境での workflow_dispatch 検証結果は下記 AC2 / AC-3000-1 参照。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (#3017) | 案 A/B の設計判断と実装 | コード diff + 本セクション | 案 A 採用（Issue 推奨）。`src/routes/(child)/[uiMode=uiMode]/home/+page.svelte` L526 で `{#if data.birthdayBonus && !isScreenshotMode}` に変更（既存 #2097 PR-B1 hotfix の SSOT context パターン L885/912 と同型、page 側 searchParams 再読出しなし）。案 B（fixture 相対日付化）は他用途（年齢表示・E2E seed）への波及が大きく不採用、案 C は Issue 自体が不採用判定 |
| AC2 (#3017) | 撮影日を誕生日に固定した再現テスト（または該当日 CI）で visual 3 層が fail しない | 本日 2026-06-11 = window 内での実検証: ① SSR curl ② E2E ③ `workflow_dispatch` (lp-visual-regression.yml on Linux CI) | ① `curl /preschool/home` (cookie 902) → `birthday-banner` 1 件 / `?screenshot=all` → 0 件（window 内の実差分で抑止を実証）。② `npx playwright test --config playwright.demo.config.ts tests/e2e/demo-lambda/visual-equality.spec.ts` → 7 passed（新規 #3017 test 含む）。③ **CI run 27335630234 = success（全 53 画像 PASS、window 内当日の Linux 撮影で hard-fail 層 = LP 層が緑）**。child-home / app 層は warn-only かつ同一抑止分岐を共有 |
| AC3 (#3017) | 同種の日付依存演出の棚卸し結果を記録 | grep 棚卸（下記「日付依存 UI 棚卸」セクション） | シーズン演出は #2295 で撤去済を確認（残存は撤去コメントのみ）。>10% 級のレイアウトシフトを起こす日付依存 UI は誕生日 banner のみ。詳細は下記表 |
| AC-3000-1 (#3000) | benign vs 真の regression 判定（投機的 --update-baseline 禁止） | diff PNG 目視（`tmp/visual-regression-diffs/`） | 目視結果: 3 画像の diff はレイアウトシフトなし・全テキスト輪郭線のみ = banner 起因シフト（CI）+ フォントレンダリング差（ローカル Windows）。**真の layout regression なし = benign**。baseline 更新は本 PR では実施しない（下記「baseline 更新の要否判断」） |
| AC-3000-2 (#3000) | benign 確定なら baseline 更新 / 真の regression なら原因 commit 特定 | workflow_dispatch CI 結果 | banner 抑止で CI (Linux) が閾値内に戻る見込みのため**更新不要**が結論。CI で残 fail があれば CI artifact（Linux 撮影 current SS）から該当画像のみ更新する（ローカル Windows 撮影での更新は baseline を OS 間レンダリング差で汚染するため禁止） |
| AC-3000-3 (#3000) | per-image 閾値 / mask の検討 | 本セクション | 不採用（Pre-PMF）: 根因（日付依存演出）を抑止したため閾値緩和は不要。閾値緩和は ADR 合意必須（runbook §2）であり、シグナル毀損リスクの方が大きい |
| AC-3015-1 (#3015) | baseline drift の解消 | 同上 (AC2 ③) | banner 抑止で同根解消。残 drift があれば CI artifact ベースで対応 |
| AC-3015-2 (#3015) | 撮影の決定性強化の検討 | `tests/e2e/demo-lambda/visual-equality.spec.ts` 追加 test | `?screenshot=all` / `?screenshot=1` で `birthday-banner` testid 0 件を assert する再発防止 E2E を追加（撮影日が window 内なら抑止の実差分を、window 外でも count(0) を常時検証） |

## 変更タイプ

- [x] fix: バグ修正
- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/`)

**影響を受ける画面・機能**:
子供ホーム画面（preschool/elementary/junior/senior — baby は banner 非対象）の `?screenshot=*` 撮影モードのみ。通常表示は不変。

## 日付依存 UI 棚卸（#3017 AC3 / 横展開）

| 候補 | 所在 | 判定 | 理由 |
|------|------|------|------|
| 誕生日ボーナス banner | `home/+page.svelte` L526 / `BirthdayBanner.svelte` | **本 PR で screenshot 抑止** | 全要素を押し下げる唯一の >10% 級レイアウトシフト。window = 誕生日から 3 日間（`birthday-bonus-service.ts` CLAIM_WINDOW_DAYS） |
| 誕生日ボーナス modal (`BirthdayModal` / FSM `birthday`) | `OverlaysSection.svelte` | 対象外 | banner クリックでのみ open（自動トリガーから除外済、`+page.svelte` L422 コメント）。banner 抑止で撮影中に到達不能 |
| シーズンイベント演出 | — | **撤去済を確認** | #2295 (EPIC #2294 ①) で機構ごと削除。`home/+page.svelte` L241/618、`variants/index.ts` L60、`AdminHome.svelte` L42/71/265 に撤去コメントのみ残存。`grep -i season` で実装ゼロ確認 |
| `lastBirthdayBonusYear` 表示分岐 | service / db / fixture 層のみ | 対象外 | UI 表示分岐なし（claim 冪等性フラグ）。demo fixture は全子 null |
| login bonus / stamp press overlay | `demo-service.ts` L154-164 | 対象外（決定的） | demo data source は fixture bonus 保持子に `claimedToday: true` を返すため auto-claim 演出は発火しない |
| 日替わりおすすめ (`selectRecommendations` の dateHash seed) | `recommendation-service.ts` L79 | 対象外 | `recommendedActivityIds` は load で返るが `.svelte` での参照ゼロ（grep 確認）= 表示に未使用 |
| demo fixture の相対日付 | `demo-data.ts` L70-83 | 対象外（決定的） | NOW='2026-03-27' 固定アンカー。activity log / challenge 期間 (endDate=2026-03-31〜04-01、常に期限切れで安定) / streak は撮影日に依らず同一描画 |
| baby home 3 歳カウントダウン (`BabyHomePage.svelte` L14-37) | app 層 baseline (baby home) | 対象外（理由記録） | 「あと N ヶ月」の数字 1 文字が月 1 回変わるのみ。diff への寄与は text 1 文字レベルで閾値 10% に対し negligible + app 層は warn-only。screenshot 抑止すると本番 truth (ADR-0013) から乖離するため非抑止が整合的 |
| admin/status 月次レポートの月ラベル | LP 層 (feature-monthly-report) | 対象外（理由記録） | 月 1 回の小テキスト変化のみ（fixture 固定アンカーにより集計値は不変）。negligible |

## baseline 更新の要否判断（#3000/#3015、目視結果）

1. **ローカル撮影 + 目視**: 抑止実装後に `capture-hp-screenshots.mjs --webp` 53/53 撮影 → `check-lp-visual-regression.mjs` 実行。diff PNG（age-kinder / carousel-1 / growth-stage-preschool / feature-rpg-battle）を目視した結果、**レイアウトシフトは一切なく、全テキスト・絵文字の輪郭線のみが差分** = ローカル Windows と CI Linux のフォントレンダリング差（OK 画像でも一律 3〜6% のノイズが乗る）。banner 起因の縦シフトは消失。
2. **ローカル Windows 撮影での `--update-baseline` は実施しない**: baseline は CI (Linux) レンダリングが正。Windows 撮影で上書きすると全画像に OS 間レンダリング差が混入し CI が大量 fail する（投機的更新禁止 #3000 とも整合）。
0. **同日 A/B 証跡 (2026-06-11 = window 内)**: develop tip (fix なし) の lp-visual-regression run 27337181837 = **failure**（age-kinder 10.700% / carousel-1-child-home-mobile 11.913% / growth-stage-preschool 10.633%）に対し、本 branch (fix あり) の run 27335630234 = **success**（同 3 画像 8.211% / 8.687% / 8.176%）。同日同環境での banner 抑止の効果差分が CI 上で実証された。
3. **CI (Linux) での検証 — PASS、baseline 更新不要が確定**: `gh workflow run lp-visual-regression.yml --ref fix/3017-deterministic-screenshot-birthday` を dispatch（lp-visual-regression は main 向け PR のみ発火のため、develop 向け本 PR では workflow_dispatch で代替検証）。**run 27335630234 = success、全 53 画像 PASS**。旧 fail 3 画像は 10.65〜11.92% → **8.18〜8.69%** に低下（age-kinder 8.211% / carousel-1-child-home-mobile 8.687% / growth-stage-preschool 8.176%、artifact `lp-visual-regression.json`）。
4. **残リスク（閾値際）**: `feature-settings.webp` 9.895% が最も閾値に近い（#3015 の「閾値際 9.2〜9.9%」観測に対応する develop 累積 rendering 変化 + font/emoji 非決定性）。現状 PASS のため投機的更新はしない（#3000 明示要求）。今後 10% を超えた場合は runbook (`docs/runbooks/lp-visual-regression-baseline.md`) に従い CI artifact（Linux 撮影 current SS）から該当画像のみ benign 目視 → targeted 更新する。**ローカル (Windows) 撮影での更新は OS 間フォントレンダリング差で baseline を汚染するため禁止**（本 PR 検証中にローカル比較で OK 画像にも一律 3〜6% のノイズが乗ることを実測）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 注: 本作業は `.claude/worktrees/` 配下の Agent worktree で実施しており、`.gitignore` の `.claude/worktrees/` により biome VCS 連携が全 path を ignore するため `pre-ready` Step 1 (`biome check .`) が環境固有で "No files were processed" となる。**全 step を個別コマンドで等価実行し PASS を確認**: ① `npx biome check --error-on-warnings <変更 2 files>` PASS ② `npx svelte-check` 0 errors ③ `npx vitest run` 全 passed ④ `check-hardcoded-strings` 0 件 ⑤ measure-lp-dimensions = LP 無変更で対象外 ⑥ sync-lp-fallback = labels 無変更で対象外 ⑦ `check-no-plan-literals` OK ⑧ generate-lp-labels = terms/labels/age-tier 無変更で対象外 ⑨ `check-pr-body --pr 3027` PASS（pre-push hook で検証）⑩ capture = SS 撮影済（下記セクション）
- [x] 追加・変更したテストの概要: `tests/e2e/demo-lambda/visual-equality.spec.ts` に「#3017: ?screenshot=all で誕生日ボーナス banner が表示されない」を追加（screenshot=all / screenshot=1 双方で `birthday-banner` testid 0 件 + 通常表示の banner 可視性を annotation 記録）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（priority:medium）

## スクリーンショット / ビジュアルデモ

撮影条件: 本日 2026-06-11 = ひなちゃん (902) の誕生日 window 内。URL は `/preschool/home?screenshot=all`（LP SS 撮影と同一モード）。**修正前 = banner が screenshot=all でも出現し全要素を押し下げる（CI fail の原因画面そのもの）/ 修正後 = banner 消滅し baseline と同構図**。DOM HTML スナップショットを同ディレクトリに併記（#1747 / #1766）。

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | ![before-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3027/before-preschool-home-screenshot-all-mobile.png) | ![before-pc](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3027/before-preschool-home-screenshot-all-desktop.png) |
| **修正後** | ![after-mobile](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3027/after-preschool-home-screenshot-all-mobile.png) | ![after-pc](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3027/after-preschool-home-screenshot-all-desktop.png) |

**通常表示の挙動不変証跡**: ![after-normal-mode](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3027/after-preschool-home-normal-mode-mobile.png) — 修正後も screenshot mode off では banner が render される（同 SS の DOM スナップショット `after-preschool-home-normal-mode-mobile.dom.html` に `birthday-banner` testid 1 件、cheer dialog が前面の場合も背面に banner 描画あり）。SSR curl でも `birthday-banner` = 通常 1 件 / `?screenshot=all` 0 件 / `?screenshot=1` 0 件を確認。

**インタラクティブ状態**: N/A（banner click → modal は screenshot mode では banner 非 render のため到達不能。通常表示の click 経路は無変更）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: screenshot mode 判定は SSOT context (`screenshot-mode.ts`) 経由、page 側 searchParams 再読出しなし
- [x] **DRY**: 既存 `isScreenshotMode` 抑止パターン（L885/912）を再利用、新規機構なし
- [x] **YAGNI**: per-image 閾値 / mask 機構は不採用（根因抑止で不要）
- [x] **Security（OSS 公開前提）**: N/A（表示条件 1 行のみ）
- [x] **アクセシビリティ**: N/A（撮影モード限定の非表示、通常 UI 不変）
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開 — banner は非 baby 4 モード共通の単一 `+page.svelte` 分岐のため 1 箇所で全モードに効く。baby は banner 非対象（server load が birthdayBonus: null）
- [x] E2E / ユニットシード同期 — demo fixture (`demo-data.ts`) は無変更（案 B 不採用のため）。visual-equality.spec.ts に回帰 test 追加
- [x] N/A — labels / ナビ / LP 文言 / DB / チュートリアルへの影響なし

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- 抑止を `'all'` 限定でなく `noise-only` 含む `isScreenshotMode` 全体にした判断（#2097 PR-B1 hotfix の auto-open dialog 抑止と同型に揃えた。`?screenshot=1` も撮影用途であり日付依存演出は決定性を壊すため）
- baseline 更新を本 PR で行わない判断（CI Linux 検証 → 必要時のみ CI artifact から targeted 更新）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（worktree 環境固有の biome VCS ignore のみ個別コマンドで等価実行、詳細は「テスト & 安全装置セルフチェック」注記）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし — 変更は `+page.svelte` の条件 1 箇所 + コメント、E2E 1 test のみ）
- [x] 全 AC が実装済み（未完了のまま残っている AC がない）
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（screenshots branch pr-3027/）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
