### PR TITLE
fix: #2955 marketplace 取込 partial-failure 表示の 3 admin page 横展開 + failed 件数 SSOT 化

### DIFF
--- a/docs/design/marketplace-import-flow.md
+++ b/docs/design/marketplace-import-flow.md
@@ -160,6 +160,19 @@ POC #2693 EPIC #2724 Round 18 で「activity-pack 取込完了後に何のフィ
 
 **他 type への波及方針**: reward-set (`admin/rewards/importPresetToChildren`) も既に `x-sveltekit-action` header + ActionResult deserialize の同型実装。checklist / rule-preset / challenge-set の admin 動線で fetch ActionResult 経由を採用する場合、本 SSOT 3 件 (Toast + 2 重防御 + `x-sveltekit-action` header) を必ず複製すること。
 
+##### partial-failure (一部保存失敗) feedback と `failed` 件数 SSOT (#2830 / #2955)
+
+取込が部分失敗した場合 (一部 item / row のみ persist 失敗)、「N 件登録しました」と偽らず **「N 件を追加しましたが、M 件は保存できませんでした」** を 2 層 feedback (Toast `error` + banner) で表示する。表示分岐は 4 admin page (activities / rewards / checklists / challenges) 共通の helper に集約する。
+
+| 項目 | 内容 | 実装 SSOT |
+|---|---|---|
+| **失敗件数の SSOT は `failed`** | UI が表示する失敗件数は Strategy 算出の `ImportResult.failed` (実 persist 失敗 item / row 数) のみ。`errors` 配列は per-child catch 行 / 集計行 / rule-preset の warnings merge が混在する**表示ログ専用**で、長さを失敗数として読まない (`errors.length` fallback は #2955 で撤去、`failed` は required 化済) | `src/lib/marketplace/types.ts` (`ImportResult.failed`) / `src/lib/marketplace/dispatcher.ts` (素通し) |
+| **message / tone 出し分け helper** | `resolveImportFeedback(data, labels)` — `failed > 0` → partial-failure (`error`) / `imported > 0` → success / それ以外 → 全件重複 (`info`)。partial-failure 文言は `MARKETPLACE_IMPORT_FEEDBACK_LABELS.partialFailure` (labels.ts、type 横断で同一文言) | `src/lib/marketplace/ui/import-feedback.ts` |
+| **server action の配線義務** | `?import=` 受領 action は dispatcher / Strategy の戻り値から `failed` を **必ず response に含めて返す**。新規 type の取込 action 追加時も同様 | 4 page の `+page.server.ts` (`importPackToChildren` / `importPresetToChildren` / `importMarketplaceChallengeSet`) |
+| **per-item 設計依存の注意** | reward / checklist の `failed = errors.length` 等式は「1 item = 1 error 行」の per-item try/catch 設計が前提。将来 bulk persist 化する場合は activity / challenge と同じ行数ベース集計 (planned − persisted) への再設計が必須 | `reward-set-import-service.ts` / `checklist-template-import-service.ts` 内コメント |
+
+回帰検証: UI 表示分岐は `tests/e2e/admin-import-partial-failure.spec.ts` (ActionResult fixture モック、3 page) + `tests/unit/marketplace/ui/import-feedback.test.ts`。server 層の `failed` 算出精度は `tests/unit/services/activity-import-service.test.ts` (#2830) 等。
+
 ##### `?import=<presetId>` auto-open 後の dialog 再 open 防止 (consumed latch、#2773 後 bug1 spec 検出)
 
 `?import=<presetId>` で `ChildSelectionDialog` を auto-open する `$effect` は `data.importPresetId`

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -3990,6 +3990,23 @@ export const ACTIVITY_FORM_LABELS = {
 } as const;
 
 /**
+ * marketplace 取込 feedback の type 横断共通 compound (#2955)
+ *
+ * partial-failure (一部保存失敗) の表示文言は 5 type (activities / rewards / checklists /
+ * challenges / rules) で同一にする (DESIGN.md §10 NN/G #4 consistency)。
+ * 各 admin page は `resolveImportFeedback()` ($lib/marketplace/ui/import-feedback) 経由で
+ * 本 compound を既定参照する。
+ */
+export const MARKETPLACE_IMPORT_FEEDBACK_LABELS = {
+	// #2818: 一部 (または全件) が保存できなかったとき正直に出す。
+	//   「N 件登録しました」と偽らず、追加できた件数と保存できなかった件数を分けて表示する。
+	partialFailure: (imported: number, failed: number) =>
+		imported > 0
+			? `${imported} 件を追加しましたが、${failed} 件は保存できませんでした`
+			: '保存に失敗しました。もう一度お試しください',
+} as const;
+
+/**
  * admin/activities ページ用ラベル (#2362 PR-3 Phase 4)
  * 子供別タブ切替 + 兄弟共通化 UX (copy / 一括追加) の SSOT。
  */
@@ -4032,11 +4049,8 @@ export const ADMIN_ACTIVITIES_PAGE_LABELS = {
 	importFailed: '取込に失敗しました',
 	importDemo: 'デモではお試し用です（実際の追加は行われません）',
 	// #2818: 一部 (または全件) が保存できなかったとき正直に出す。
-	//   「N 件登録しました」と偽らず、追加できた件数と保存できなかった件数を分けて表示する。
-	importPartialFailure: (imported: number, failed: number) =>
-		imported > 0
-			? `${imported} 件を追加しましたが、${failed} 件は保存できませんでした`
-			: '保存に失敗しました。もう一度お試しください',
+	// #2955: 文言の SSOT は MARKETPLACE_IMPORT_FEEDBACK_LABELS (3 admin page 横展開で共通化)。
+	importPartialFailure: MARKETPLACE_IMPORT_FEEDBACK_LABELS.partialFailure,
 	// Round 18 Cluster G (per-child scope badge): 英語内部語彙「per-child」UI 露出撤去 (ADR-0045 §9)
 	// 「お子さま別」= per-child scope (個別 child に紐付く activity) を親向けに明示する短い表示
 	scopeBadgePerChild: `${CHILD_TERMS.honorific}別`,

--- a/src/lib/marketplace/dispatcher.ts
+++ b/src/lib/marketplace/dispatcher.ts
@@ -33,6 +33,11 @@ export interface DispatchImportResult {
 	skipped: number;
 	total: number;
 	errors: string[];
+	/**
+	 * #2955: 実際に persist 失敗した item / row 数 (ImportResult.failed の素通し)。
+	 * UI の partial-failure 件数表示はこのフィールドが SSOT (errors.length は表示ログ専用)。
+	 */
+	failed: number;
 }
 
 /**
@@ -79,5 +84,8 @@ export async function dispatchImport(input: DispatchImportInput): Promise<Dispat
 		skipped: result.skipped,
 		total: preview.total,
 		errors: result.errors,
+		// #2955: Strategy 算出の failed (実失敗数) を素通しする。旧実装はここで drop しており、
+		// UI が errors.length に fallback して失敗規模を誤表示する経路の根因だった。
+		failed: result.failed,
 	};
 }

--- a/src/lib/marketplace/strategies/rule-preset-strategy.ts
+++ b/src/lib/marketplace/strategies/rule-preset-strategy.ts
@@ -162,6 +162,9 @@ export const rulePresetStrategy: ImportStrategy<RulePresetPayload> & {
 			errors: [...result.errors, ...result.warnings],
 			// #2830: errors 配列は warnings (already-imported 等の非失敗) を畳み込むため、
 			//   実失敗件数は genuine error のみ (warnings を除外) で算出する。
+			// #2955: この非対称 (errors = 表示ログ用 merge / failed = 実失敗数) は意図的。
+			//   ImportResult.failed が required 化されたため、UI が errors.length を失敗数として
+			//   読む fallback 経路は存在せず、warnings が失敗件数に誤算入されることはない。
 			failed: result.errors.length,
 		};
 	},

--- a/src/lib/marketplace/types.ts
+++ b/src/lib/marketplace/types.ts
@@ -113,17 +113,16 @@ export interface ImportPreview {
  *
  *   `errors` は per-child catch 行 / 集計行「N 件保存できませんでした」/ per-item validation
  *   error が混在しうるため、`errors.length` は「失敗した item 数」と一致しない (bulk throw
- *   1 回で 30 row 喪失でも errors.length≈2)。UI の partial-failure 件数表示は `errors.length`
- *   ではなく本フィールドを使うことで、親が失敗規模を過小評価して再取込をスキップする事故を防ぐ。
- *
- *   後方互換のため optional。未指定の場合 UI は `errors.length` に fallback する。
- *   新規 / 既存の全 Strategy は本フィールドを必ず算出して返すこと (AC1 / AC4)。
+ *   1 回で 30 row 喪失でも errors.length≈2)。さらに rule-preset は warnings (already-imported
+ *   等の非失敗通知) を `errors` に畳み込んで表示するため、`errors.length` を失敗数として
+ *   読むと無害な warning が失敗に誤算入される。UI の partial-failure 件数表示は必ず本
+ *   フィールドを使うこと (#2955 で optional fallback を撤去し required 化、5 strategy 全配線済)。
  */
 export interface ImportResult {
 	imported: number;
 	skipped: number;
 	errors: string[];
-	failed?: number;
+	failed: number;
 }
 
 // ── ImportStrategy interface ─────────────────────────────────────

--- a/src/lib/marketplace/ui/import-feedback.ts
+++ b/src/lib/marketplace/ui/import-feedback.ts
@@ -1,0 +1,72 @@
+/**
+ * marketplace 取込 result feedback 解決 helper — Issue #2955 (#2830 / #2935 follow-up)
+ *
+ * `?import=<presetId>` → ChildSelectionDialog 確定 → form action の成功 ActionResult を受けて、
+ * 2 層 feedback (Toast + in-page banner、DESIGN.md §5) に出す message / tone を 1 箇所で決める。
+ * 旧実装は同型の if/else 分岐が admin/activities にのみ存在し、rewards / checklists / challenges
+ * では server 算出の `failed` が UI に到達せず「部分失敗でも成功 toast のみ」になっていた
+ * (4 page 同型ロジックの重複を避けるため本 helper に共通化、CLAUDE.md [B] コンポーネント化)。
+ *
+ * 件数 SSOT (#2955 判断記録):
+ *   - 失敗件数は server (Strategy) 算出の `failed` のみを参照する。旧 `errors.length` fallback は
+ *     撤去した。理由: (1) 5 strategy 全てが `failed` を配線済で `ImportResult.failed` は required 化
+ *     済み (types.ts)、dispatcher (#2955) も素通しする。(2) `errors` は per-child catch 行 / 集計行 /
+ *     rule-preset の warnings merge が混在する表示ログであり、長さを失敗数として読むと過小
+ *     (bulk throw) にも過大 (warnings 誤算入) にも振れる。
+ *   - `failed` 欠落 (型契約違反の異常系) は 0 扱い = 旧来の成功表示に縮退し、誤った失敗件数を
+ *     表示しない側に倒す。
+ *
+ * 関連: ADR-0052 (ImportStrategy) / DESIGN.md §5 (Toast 2 層防御) / §10 (5 type consistency)
+ */
+
+import { MARKETPLACE_IMPORT_FEEDBACK_LABELS } from '$lib/domain/labels';
+
+export type ImportFeedbackTone = 'success' | 'info' | 'error';
+
+export interface ImportFeedback {
+	message: string;
+	tone: ImportFeedbackTone;
+}
+
+/**
+ * page 固有の文言セット。partialFailure は省略時 MARKETPLACE_IMPORT_FEEDBACK_LABELS を使う
+ * (type 横断で同一文言、NN/G #4 consistency)。
+ */
+export interface ImportFeedbackLabels {
+	/** imported > 0 かつ failed = 0 の成功文言 (例: 「✨ N 件のごほうびを追加しました」) */
+	success: (imported: number) => string;
+	/** imported = 0 かつ failed = 0 (純粋な重複 skip) の文言 */
+	allDuplicates: string;
+	/** failed > 0 の partial-failure 文言 (既定: 共通 compound) */
+	partialFailure?: (imported: number, failed: number) => string;
+}
+
+function toCount(value: unknown): number {
+	return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/**
+ * 取込成功 ActionResult の data から表示 message / tone を解決する。
+ *
+ * 優先順位 (#2824 取込永続 honesty / #2830):
+ *   1. failed > 0 → partial-failure (error tone)。imported > 0 でも「N 件登録しました」と偽らない
+ *   2. imported > 0 → success
+ *   3. それ以外 (純粋な全件重複) → allDuplicates (info)
+ */
+export function resolveImportFeedback(
+	data: Record<string, unknown> | undefined,
+	labels: ImportFeedbackLabels,
+): ImportFeedback {
+	const imported = toCount(data?.imported);
+	// #2955: server 算出 failed が件数 SSOT。errors.length への fallback は行わない (冒頭 doc 参照)。
+	const failed = toCount(data?.failed);
+	if (failed > 0) {
+		const partialFailure =
+			labels.partialFailure ?? MARKETPLACE_IMPORT_FEEDBACK_LABELS.partialFailure;
+		return { message: partialFailure(imported, failed), tone: 'error' };
+	}
+	if (imported > 0) {
+		return { message: labels.success(imported), tone: 'success' };
+	}
+	return { message: labels.allDuplicates, tone: 'info' };
+}

--- a/src/lib/server/services/checklist-template-import-service.ts
+++ b/src/lib/server/services/checklist-template-import-service.ts
@@ -248,6 +248,7 @@ async function importChecklistTemplateInternal(
 		importedItems,
 		errors,
 		// #2830: per-item try/catch のため失敗 item 数 = errors.length。
+		// #2955 注意: この等式は「1 item = 1 error 行」の per-item 設計が前提。将来 bulk persist 化する場合は activity/challenge と同じ行数ベース集計 (planned - persisted) への再設計が必須。
 		failed: errors.length,
 		templateId: template.id,
 	};

--- a/src/lib/server/services/reward-set-import-service.ts
+++ b/src/lib/server/services/reward-set-import-service.ts
@@ -208,6 +208,7 @@ export async function importRewardSet(
 	});
 
 	// #2830: per-reward try/catch のため失敗 reward 数 = errors.length。
+	// #2955 注意: この等式は「1 reward = 1 error 行」の per-item 設計が前提。将来 bulk persist 化する場合は activity/challenge と同じ行数ベース集計 (planned - persisted) への再設計が必須。
 	return { imported, skipped, errors, failed: errors.length };
 }
 

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -21,6 +21,7 @@ import ActivityListItem from '$lib/features/admin/components/ActivityListItem.sv
 import AiSuggestPanel from '$lib/features/admin/components/AiSuggestPanel.svelte';
 import type { AiPreviewData } from '$lib/features/admin/components/activity-types';
 import HiddenActivitiesSection from '$lib/features/admin/components/HiddenActivitiesSection.svelte';
+import { resolveImportFeedback } from '$lib/marketplace/ui/import-feedback';
 import Button from '$lib/ui/primitives/Button.svelte';
 import ChildSelectionDialog, {
 	type ChildOption,
@@ -227,14 +228,6 @@ function applyImportFailure(failText: string) {
 	showToast(display.message, undefined, 'error');
 }
 
-// #2830: partial-failure の失敗件数を解決する。server 算出の `failed` (実失敗 activity 数) を
-//   優先し、errors 配列長に fallback する。errors は per-child catch 行 + 集計行が混在するため
-//   失敗規模を過小表示する (bulk throw 1 回で 30 activity 喪失でも errors.length≈2)。
-function resolveFailedCount(data: Record<string, unknown> | undefined): number {
-	if (typeof data?.failed === 'number') return data.failed;
-	return Array.isArray(data?.errors) ? (data.errors as unknown[]).length : 0;
-}
-
 // ChildSelectionDialog 確定ハンドラ: 'all' or number[] (選択 child IDs)
 async function handleChildSelectionConfirm(result: 'all' | number[]) {
 	if (!pendingImportPresetId) {
@@ -286,9 +279,6 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 				showToast(ADMIN_ACTIVITIES_PAGE_LABELS.importDemo, undefined, 'info');
 				return;
 			}
-			const imported = Number((data?.imported as number | undefined) ?? 0);
-			// #2830: 失敗件数は errors 配列長ではなく server 算出の `failed` を優先する (resolveFailedCount)。
-			const errorsCount = resolveFailedCount(data);
 			// #2745 fix Round 2 (CI artifact 解析根拠): Toast primitive (`role="alert"`) を
 			// 一次 feedback として表示しつつ、in-page banner (`role="status"`) を 2 重防御として
 			// 同期 set する。Toast は module-level `$state` push でリアクティブ更新されるが
@@ -297,23 +287,15 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 			// banner は同 page state なので同期 set、handler return 後の re-render で即座に表示される。
 			// regression test (#2745 spec) は role="alert" を待つが、Toast / banner どちらが先に
 			// 表示されても regex マッチで PASS する 2 重防御。Anti-engagement 整合 (DESIGN.md §5)。
-			// #2824 (取込永続 honesty): server が errors を返したら「N 件登録しました」と
-			// 偽らず、保存できなかった事実を出す。imported=0 を「追加済み」(importAllDuplicates)
-			// で誤魔化す経路は errors=0 (= 純粋な重複) のときに限定する。
-			let message: string;
-			let tone: 'success' | 'info' | 'error';
-			if (errorsCount > 0) {
-				message = ADMIN_ACTIVITIES_PAGE_LABELS.importPartialFailure(imported, errorsCount);
-				tone = 'error';
-			} else if (imported > 0) {
-				message = ADMIN_ACTIVITIES_PAGE_LABELS.importSuccess(imported);
-				tone = 'success';
-			} else {
-				message = ADMIN_ACTIVITIES_PAGE_LABELS.importAllDuplicates;
-				tone = 'info';
-			}
-			actionMessage = message;
-			showToast(message, undefined, tone);
+			// #2824 (取込永続 honesty) / #2830 / #2955: 失敗件数は server 算出 `failed` が SSOT。
+			// message / tone の出し分けは 4 admin page 共通 helper (resolveImportFeedback) に集約。
+			const feedback = resolveImportFeedback(data, {
+				success: ADMIN_ACTIVITIES_PAGE_LABELS.importSuccess,
+				allDuplicates: ADMIN_ACTIVITIES_PAGE_LABELS.importAllDuplicates,
+				partialFailure: ADMIN_ACTIVITIES_PAGE_LABELS.importPartialFailure,
+			});
+			actionMessage = feedback.message;
+			showToast(feedback.message, undefined, feedback.tone);
 			await invalidateAll();
 		} else {
 			// #2894 AC3: 403 (PlanLimitError) を含む失敗 body を deserialize し、

--- a/src/routes/(parent)/admin/challenges/+page.server.ts
+++ b/src/routes/(parent)/admin/challenges/+page.server.ts
@@ -352,6 +352,8 @@ export const actions: Actions = {
 				skipped: result.skipped,
 				total: result.total,
 				errors: result.errors,
+				// #2955: 実失敗件数 (UI partial-failure 表示の SSOT、errors.length は表示ログ専用)
+				failed: result.failed,
 				presetId,
 			};
 		} catch (e) {

--- a/src/routes/(parent)/admin/challenges/+page.svelte
+++ b/src/routes/(parent)/admin/challenges/+page.svelte
@@ -11,6 +11,7 @@ import {
 	PLAN_GATE_LABELS,
 } from '$lib/domain/labels';
 // CX-DoR #9・#11 横展開 (Round 18): empty state を共通 SSOT に統一 (NN/G #4 consistency)
+import { resolveImportFeedback } from '$lib/marketplace/ui/import-feedback';
 import UnifiedEmptyState from '$lib/marketplace/ui/UnifiedEmptyState.svelte';
 import type { ChildChallenge, ChildChallengeGroup } from '$lib/server/db/types';
 import SiblingChallengeComparison from '$lib/ui/features/admin/SiblingChallengeComparison.svelte';
@@ -20,6 +21,7 @@ import ChildSelectionDialog, {
 } from '$lib/ui/primitives/ChildSelectionDialog.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
 import NativeSelect from '$lib/ui/primitives/NativeSelect.svelte';
+import { showToast } from '$lib/ui/primitives/Toast.svelte';
 
 let { data, form } = $props();
 
@@ -99,7 +101,13 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 		const actionResult = deserialize(await resp.text()) as
 			| {
 					type: 'success';
-					data?: { imported?: number; skipped?: number; total?: number; demo?: boolean };
+					data?: {
+						imported?: number;
+						skipped?: number;
+						total?: number;
+						failed?: number;
+						demo?: boolean;
+					};
 			  }
 			| { type: 'failure'; data?: { error?: string } }
 			| { type: 'redirect'; location: string }
@@ -110,11 +118,18 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 			if ((actionResult.data as Record<string, unknown> | undefined)?.demo === true) {
 				marketplaceImportMessage = ADMIN_CHALLENGES_PAGE_LABELS.importDemo;
 			} else {
-				const imp = Number(actionResult.data?.imported ?? 0);
-				marketplaceImportMessage =
-					imp === 0
-						? ADMIN_CHALLENGES_PAGE_LABELS.importAllDuplicates
-						: ADMIN_CHALLENGES_PAGE_LABELS.importSuccess(imp);
+				// #2955 (#2830 横展開): server 算出 `failed` > 0 のときは partial-failure を
+				// 2 層 feedback (Toast + banner) で正直に出す (admin/activities と同型、共通 helper)。
+				// 本 page は従来 banner 単層だったため、DESIGN.md §5 の 2 層防御に合わせ Toast を追加。
+				const feedback = resolveImportFeedback(
+					actionResult.data as Record<string, unknown> | undefined,
+					{
+						success: ADMIN_CHALLENGES_PAGE_LABELS.importSuccess,
+						allDuplicates: ADMIN_CHALLENGES_PAGE_LABELS.importAllDuplicates,
+					},
+				);
+				marketplaceImportMessage = feedback.message;
+				showToast(feedback.message, undefined, feedback.tone);
 				await invalidateAll();
 			}
 		} else if (actionResult.type === 'failure') {

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -486,6 +486,8 @@ export const actions: Actions = {
 				skipped: result.skipped,
 				total: result.total,
 				errors: result.errors,
+				// #2955: 実失敗件数 (UI partial-failure 表示の SSOT、errors.length は表示ログ専用)
+				failed: result.failed,
 				presetId,
 				distributedCount: childIds.length,
 			};

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -17,6 +17,7 @@ import AiSuggestChecklistPanel from '$lib/features/admin/components/AiSuggestChe
 // #2558 段階2 横展開: admin 内 marketplace 風 browse UI (UnifiedImportHub) を撤去し
 // `/marketplace?type=checklist` への画面遷移に統一 (DESIGN.md §10)。
 // CX-DoR #9・#11 横展開 (Round 18): empty state を共通 SSOT に統一 (NN/G #4 consistency)
+import { resolveImportFeedback } from '$lib/marketplace/ui/import-feedback';
 import UnifiedEmptyState from '$lib/marketplace/ui/UnifiedEmptyState.svelte';
 import PremiumBadge from '$lib/ui/components/PremiumBadge.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
@@ -399,6 +400,7 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 						imported?: number;
 						skipped?: number;
 						total?: number;
+						failed?: number;
 						distributedCount?: number;
 						packName?: string;
 					};
@@ -415,12 +417,19 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 			} else {
 				const packName = actionResult.data?.packName ?? '';
 				const distributedCount = Number(actionResult.data?.distributedCount ?? 0);
-				const imp = Number(actionResult.data?.imported ?? 0);
-				actionMessage =
-					imp === 0
-						? ADMIN_CHECKLISTS_PAGE_LABELS.importToastDuplicate(packName)
-						: ADMIN_CHECKLISTS_PAGE_LABELS.importToastSuccess(packName, distributedCount);
-				showToast(actionMessage, undefined, imp > 0 ? 'success' : 'info');
+				// #2955 (#2830 横展開): server 算出 `failed` > 0 のときは partial-failure を
+				// 2 層 feedback (Toast + banner) で正直に出す (admin/activities と同型、共通 helper)。
+				// success 文言は checklist 固有 (packName + 配信人数) のため closure で包む。
+				const feedback = resolveImportFeedback(
+					actionResult.data as Record<string, unknown> | undefined,
+					{
+						success: () =>
+							ADMIN_CHECKLISTS_PAGE_LABELS.importToastSuccess(packName, distributedCount),
+						allDuplicates: ADMIN_CHECKLISTS_PAGE_LABELS.importToastDuplicate(packName),
+					},
+				);
+				actionMessage = feedback.message;
+				showToast(actionMessage, undefined, feedback.tone);
 			}
 		} else if (actionResult.type === 'failure') {
 			// #2894 AC3: PlanLimitError オブジェクトの `[object Object]` 化壊れ表示を根治。

--- a/src/routes/(parent)/admin/rewards/+page.server.ts
+++ b/src/routes/(parent)/admin/rewards/+page.server.ts
@@ -246,6 +246,8 @@ export const actions: Actions = {
 				skipped: result.skipped,
 				total: result.total,
 				errors: result.errors,
+				// #2955: 実失敗件数 (UI partial-failure 表示の SSOT)
+				failed: result.failed,
 				presetId,
 			};
 		} catch (e) {
@@ -337,6 +339,8 @@ export const actions: Actions = {
 					skipped: result.skipped,
 					total: result.total,
 					errors: result.errors,
+					// #2955: 実失敗件数 (UI partial-failure 表示の SSOT、errors.length は表示ログ専用)
+					failed: result.failed,
 					presetId,
 				};
 			}
@@ -364,6 +368,7 @@ export const actions: Actions = {
 			};
 			let totalImported = 0;
 			let totalSkipped = 0;
+			let totalFailed = 0;
 			const allErrors: string[] = [];
 			for (const childId of childIds) {
 				const result = await rulePresetStrategy.applyRulePreset(identity, payload, {
@@ -372,6 +377,10 @@ export const actions: Actions = {
 				});
 				totalImported += result.imported;
 				totalSkipped += result.skipped;
+				// #2955: 実失敗数は genuine errors のみで数える。warnings (already-imported 等の
+				// 非失敗通知) は表示ログ (allErrors) には載せるが失敗件数に算入しない
+				// (rule-preset-strategy.apply の errors/failed 非対称と同じ精度規約)。
+				totalFailed += result.errors.length;
 				allErrors.push(...result.errors, ...result.warnings);
 			}
 			return {
@@ -381,6 +390,7 @@ export const actions: Actions = {
 				skipped: totalSkipped,
 				total: totalImported + totalSkipped,
 				errors: allErrors,
+				failed: totalFailed,
 				presetId,
 			};
 		} catch (e) {

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -24,6 +24,7 @@ import AdminResourceHeader from '$lib/features/admin/components/AdminResourceHea
 import type { RewardPreviewData } from '$lib/features/admin/components/AiSuggestRewardPanel.svelte';
 import AiSuggestRewardPanel from '$lib/features/admin/components/AiSuggestRewardPanel.svelte';
 // CX-DoR #9・#11 横展開 (Round 18): empty state を共通 SSOT に統一 (NN/G #4 consistency)
+import { resolveImportFeedback } from '$lib/marketplace/ui/import-feedback';
 import UnifiedEmptyState from '$lib/marketplace/ui/UnifiedEmptyState.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import ChildSelectionDialog, {
@@ -304,7 +305,7 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 		const actionResult = deserialize(await resp.text()) as
 			| {
 					type: 'success';
-					data?: { imported?: number; skipped?: number; total?: number };
+					data?: { imported?: number; skipped?: number; total?: number; failed?: number };
 			  }
 			| { type: 'failure'; data?: { error?: string } }
 			| { type: 'redirect'; location: string }
@@ -316,12 +317,17 @@ async function handleChildSelectionConfirm(result: 'all' | number[]) {
 				actionMessage = ADMIN_REWARDS_PAGE_LABELS.importDemo;
 				showToast(ADMIN_REWARDS_PAGE_LABELS.importDemo, undefined, 'info');
 			} else {
-				const imp = Number(actionResult.data?.imported ?? 0);
-				actionMessage =
-					imp === 0
-						? ADMIN_REWARDS_PAGE_LABELS.importAllDuplicates
-						: ADMIN_REWARDS_PAGE_LABELS.importSuccess(imp);
-				showToast(actionMessage, undefined, imp > 0 ? 'success' : 'info');
+				// #2955 (#2830 横展開): server 算出 `failed` > 0 のときは partial-failure を
+				// 2 層 feedback (Toast + banner) で正直に出す (admin/activities と同型、共通 helper)。
+				const feedback = resolveImportFeedback(
+					actionResult.data as Record<string, unknown> | undefined,
+					{
+						success: ADMIN_REWARDS_PAGE_LABELS.importSuccess,
+						allDuplicates: ADMIN_REWARDS_PAGE_LABELS.importAllDuplicates,
+					},
+				);
+				actionMessage = feedback.message;
+				showToast(actionMessage, undefined, feedback.tone);
 				await invalidateAll();
 			}
 		} else if (actionResult.type === 'failure') {

--- a/src/routes/(parent)/admin/settings/rules/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/rules/+page.server.ts
@@ -130,6 +130,9 @@ export const actions: Actions = {
 				skipped: result.skipped,
 				total: result.total,
 				errors: result.errors,
+				// #2955: rule-preset の errors は warnings (already-imported 等の非失敗) を merge した
+				// 表示ログ。失敗判定は genuine error 数の failed を使う (warnings 誤算入の根治)。
+				failed: result.failed,
 				presetId,
 			};
 		} catch (e) {

--- a/src/routes/(parent)/admin/settings/rules/+page.svelte
+++ b/src/routes/(parent)/admin/settings/rules/+page.svelte
@@ -56,6 +56,9 @@ type ImportFormResult = {
 	skipped?: number;
 	total?: number;
 	errors?: string[];
+	// #2955: 実失敗件数 (server 算出)。rule-preset の errors は warnings (already-imported 等の
+	// 非失敗通知) を merge した表示ログのため、失敗判定は errors.length でなく failed を使う。
+	failed?: number;
 	presetId?: string;
 	// #2823: demo write-guard が返す no-op マーカー (presetId なし)。real 経路とは別分岐で扱う。
 	demo?: boolean;
@@ -85,7 +88,9 @@ $effect(() => {
 			showToast(ADMIN_RULES_PAGE_LABELS.importToastSuccess(display), undefined, 'success');
 		} else if (r.skipped === r.total && (r.total ?? 0) > 0) {
 			showToast(ADMIN_RULES_PAGE_LABELS.importToastDuplicate(display), undefined, 'info');
-		} else if (r.errors && r.errors.length > 0) {
+		} else if ((r.failed ?? 0) > 0) {
+			// #2955: errors.length 判定だと rule-preset の warnings (非失敗) が error toast に
+			// 誤判定される (penalty/special の no-op warning 等)。failed (genuine error 数) で判定する。
 			showToast(ADMIN_RULES_PAGE_LABELS.importToastError(display), undefined, 'error');
 		}
 		cleanupImportQueryParam();

--- a/tests/e2e/admin-import-partial-failure.spec.ts
+++ b/tests/e2e/admin-import-partial-failure.spec.ts
@@ -56,7 +56,7 @@ async function mockPartialFailureAction(
 }
 
 /** `?import=` auto-open dialog → 確定 → action response 待ち → banner の partial-failure 表示 assert */
-async function runPartialFailureFlow(
+async function expectPartialFailureShown(
 	page: import('@playwright/test').Page,
 	opts: {
 		path: string;
@@ -119,7 +119,7 @@ test.describe('#2955 marketplace 取込 partial-failure 表示 (failed 件数の
 			failed: 2,
 			presetId: 'kinder-starter',
 		});
-		await runPartialFailureFlow(page, {
+		await expectPartialFailureShown(page, {
 			path: '/admin/activities?import=kinder-starter',
 			dialogTestid: 'import-child-selection-dialog',
 			actionName: 'importPackToChildren',
@@ -141,7 +141,7 @@ test.describe('#2955 marketplace 取込 partial-failure 表示 (failed 件数の
 			failed: 2,
 			presetId: 'kinder-rewards',
 		});
-		await runPartialFailureFlow(page, {
+		await expectPartialFailureShown(page, {
 			path: '/admin/rewards?import=kinder-rewards',
 			dialogTestid: 'reward-import-child-selection-dialog',
 			actionName: 'importPresetToChildren',
@@ -164,7 +164,7 @@ test.describe('#2955 marketplace 取込 partial-failure 表示 (failed 件数の
 			presetId: 'event-school-start',
 			distributedCount: 2,
 		});
-		await runPartialFailureFlow(page, {
+		await expectPartialFailureShown(page, {
 			path: '/admin/checklists?import=event-school-start',
 			dialogTestid: 'checklist-import-child-selection-dialog',
 			actionName: 'importPresetToChildren',

--- a/tests/e2e/admin-import-partial-failure.spec.ts
+++ b/tests/e2e/admin-import-partial-failure.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * marketplace 取込 partial-failure 表示 E2E — Issue #2955 (#2830 / #2935 follow-up)
+ *
+ * server (Strategy) 算出の `failed` (実失敗件数) が UI の 2 層 feedback (Toast + banner、
+ * DESIGN.md §5) に到達し、「N 件を追加しましたが、M 件は保存できませんでした」と正直に
+ * 表示されることを 3 admin page (activities / rewards / checklists) で検証する。
+ * 旧実装では activities のみに表示分岐があり、他 page は部分失敗でも成功 toast のみだった。
+ *
+ * partial-failure fixture 戦略 (Integration 相当、`page.route()` モック):
+ *   実 DB で partial failure (persist 途中の例外) を決定的に再現することは
+ *   できない (DB fault injection が必要) ため、form action の POST response を
+ *   `page.route()` で SvelteKit ActionResult 形式 (devalue stringify) の partial-failure
+ *   fixture に差し替え、**UI 層の表示分岐**を決定的に検証する (tests/CLAUDE.md §テスト分類の
+ *   Integration 相当。`tests/e2e/integration/upgrade-checkout.spec.ts` の Stripe mock と同パターン)。
+ *   server 層の `failed` 算出精度は unit test (#2830:
+ *   `tests/unit/services/activity-import-service.test.ts` 等) が担保し、
+ *   server → UI の素通し配線は型契約 (ImportResult.failed required 化 + dispatcher 素通し、
+ *   svelte-check) が担保する。
+ *
+ * 対象外: admin/challenges — #2896 で challenge-set は marketplace 陳列対象外となり
+ *   valid preset が 0 件のため、`?import=` 経由で ChildSelectionDialog を開く実ユーザー動線が
+ *   存在しない (互換 server 経路と UI 分岐は実装済、helper unit test
+ *   `tests/unit/marketplace/ui/import-feedback.test.ts` で表示ロジックを回帰固定)。
+ */
+
+import { expect, test } from '@playwright/test';
+import { stringify } from 'devalue';
+
+/** 期待する partial-failure 文言 (MARKETPLACE_IMPORT_FEEDBACK_LABELS.partialFailure(3, 2)) */
+const PARTIAL_FAILURE_RE = /3 件を追加しましたが、2 件は保存できませんでした/;
+
+/**
+ * form action POST を SvelteKit ActionResult (success) の partial-failure fixture に差し替える。
+ * deserialize() 互換: `{ type, status, data: devalue.stringify(payload) }`。
+ */
+async function mockPartialFailureAction(
+	page: import('@playwright/test').Page,
+	actionName: string,
+	data: Record<string, unknown>,
+) {
+	await page.route(
+		(url) => url.search.startsWith(`?/${actionName}`),
+		async (route) => {
+			if (route.request().method() !== 'POST') {
+				await route.fallback();
+				return;
+			}
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ type: 'success', status: 200, data: stringify(data) }),
+			});
+		},
+	);
+}
+
+/** `?import=` auto-open dialog → 確定 → action response 待ち → banner の partial-failure 表示 assert */
+async function runPartialFailureFlow(
+	page: import('@playwright/test').Page,
+	opts: {
+		path: string;
+		dialogTestid: string;
+		actionName: string;
+		bannerTestid: string;
+		screenshotName: string;
+	},
+) {
+	test.slow(); // Vite dev コールドコンパイル耐性 (CUJ-A3 と同 pattern)
+
+	await page.goto(opts.path, { waitUntil: 'domcontentloaded' });
+
+	// Vite dev 並列 cold compile (別 spec の /marketplace 初回 compile 等) で hydration が
+	// 遅延すると auto-open effect の発火も遅れるため 30s 待つ (admin-activities child-tabs と同基準)。
+	const dialog = page.getByTestId(opts.dialogTestid);
+	await expect(dialog, 'ChildSelectionDialog が auto-open する前提').toBeVisible({
+		timeout: 30_000,
+	});
+
+	const confirm = page.getByTestId('child-selection-confirm');
+	await expect(confirm).toBeEnabled();
+
+	const [resp] = await Promise.all([
+		page.waitForResponse((r) => new URL(r.url()).search.startsWith(`?/${opts.actionName}`)),
+		confirm.click(),
+	]);
+	expect(resp.ok(), `${opts.actionName} response not OK (status ${resp.status()})`).toBeTruthy();
+
+	// 2 層 feedback の banner 層 (`role="status"`、同期 set で race フリー) を assert する。
+	// Toast (`role="alert"`) は 3 秒自動消滅 + micro-task race があるため banner を正とする
+	// (DESIGN.md §5 2 層防御パターンの E2E 検証規約)。
+	const banner = page.getByTestId(opts.bannerTestid);
+	await expect(banner).toBeVisible({ timeout: 10_000 });
+
+	// SS 証跡 (PR body 添付用、#2955 AC1「SS 添付、表示変化あり」)。
+	// 文言 assert より前に撮ることで、修正前 code では「成功表示のまま」の before 証跡が残る。
+	await page.screenshot({ path: `tmp/ss-2955/${opts.screenshotName}.png`, fullPage: false });
+
+	await expect(
+		banner,
+		'partial-failure が「N 件を追加しましたが、M 件は保存できませんでした」と表示される',
+	).toContainText(PARTIAL_FAILURE_RE, { timeout: 10_000 });
+}
+
+test.describe('#2955 marketplace 取込 partial-failure 表示 (failed 件数の UI 到達)', () => {
+	test('activities: importPackToChildren の failed > 0 で件数付き partial-failure banner (回帰)', async ({
+		page,
+	}) => {
+		await mockPartialFailureAction(page, 'importPackToChildren', {
+			perChildImport: true,
+			importResult: true,
+			packName: 'ようじキッズ',
+			imported: 3,
+			skipped: 0,
+			total: 5,
+			errors: ['2 件の活動を保存できませんでした'],
+			failed: 2,
+			presetId: 'kinder-starter',
+		});
+		await runPartialFailureFlow(page, {
+			path: '/admin/activities?import=kinder-starter',
+			dialogTestid: 'import-child-selection-dialog',
+			actionName: 'importPackToChildren',
+			bannerTestid: 'admin-activities-action-message',
+			screenshotName: 'activities-partial-failure',
+		});
+	});
+
+	test('rewards: importPresetToChildren の failed > 0 で件数付き partial-failure banner (#2955 横展開)', async ({
+		page,
+	}) => {
+		await mockPartialFailureAction(page, 'importPresetToChildren', {
+			perChildImport: true,
+			packName: 'ようじごほうび',
+			imported: 3,
+			skipped: 0,
+			total: 5,
+			errors: ['2 件のごほうびを保存できませんでした'],
+			failed: 2,
+			presetId: 'kinder-rewards',
+		});
+		await runPartialFailureFlow(page, {
+			path: '/admin/rewards?import=kinder-rewards',
+			dialogTestid: 'reward-import-child-selection-dialog',
+			actionName: 'importPresetToChildren',
+			bannerTestid: 'rewards-action-message',
+			screenshotName: 'rewards-partial-failure',
+		});
+	});
+
+	test('checklists: importPresetToChildren の failed > 0 で件数付き partial-failure banner (#2955 横展開)', async ({
+		page,
+	}) => {
+		await mockPartialFailureAction(page, 'importPresetToChildren', {
+			perChildImport: true,
+			packName: '入学準備チェック',
+			imported: 3,
+			skipped: 0,
+			total: 5,
+			errors: ['2 件の項目を保存できませんでした'],
+			failed: 2,
+			presetId: 'event-school-start',
+			distributedCount: 2,
+		});
+		await runPartialFailureFlow(page, {
+			path: '/admin/checklists?import=event-school-start',
+			dialogTestid: 'checklist-import-child-selection-dialog',
+			actionName: 'importPresetToChildren',
+			bannerTestid: 'checklists-action-message',
+			screenshotName: 'checklists-partial-failure',
+		});
+	});
+
+	test('rewards: failed = 0 (純粋な重複) では partial-failure を出さず重複文言のまま (誤検知防止)', async ({
+		page,
+	}) => {
+		await mockPartialFailureAction(page, 'importPresetToChildren', {
+			perChildImport: true,
+			packName: 'ようじごほうび',
+			imported: 0,
+			skipped: 5,
+			total: 5,
+			// rule-preset 同型の「errors に非失敗メッセージが載る」ケースでも、
+			// failed = 0 なら失敗扱いしない (#2955 項目 2: errors.length fallback 撤去)。
+			errors: ['既に取込済みです'],
+			failed: 0,
+			presetId: 'kinder-rewards',
+		});
+		await page.goto('/admin/rewards?import=kinder-rewards', { waitUntil: 'domcontentloaded' });
+		const dialog = page.getByTestId('reward-import-child-selection-dialog');
+		await expect(dialog).toBeVisible({ timeout: 10_000 });
+		const confirm = page.getByTestId('child-selection-confirm');
+		await expect(confirm).toBeEnabled();
+		const [resp] = await Promise.all([
+			page.waitForResponse((r) => new URL(r.url()).search.startsWith('?/importPresetToChildren')),
+			confirm.click(),
+		]);
+		expect(resp.ok()).toBeTruthy();
+		const banner = page.getByTestId('rewards-action-message');
+		await expect(banner).toContainText(/既に追加済みです/, { timeout: 10_000 });
+		await expect(banner).not.toContainText(/保存できませんでした/);
+	});
+});

--- a/tests/e2e/admin-import-partial-failure.spec.ts
+++ b/tests/e2e/admin-import-partial-failure.spec.ts
@@ -92,6 +92,11 @@ async function expectPartialFailureShown(
 	const banner = page.getByTestId(opts.bannerTestid);
 	await expect(banner).toBeVisible({ timeout: 10_000 });
 
+	// 取込完了で ChildSelectionDialog が閉じること (#2819 one-shot guard) も assert する。
+	// SS をダイアログ越しにしないため撮影前に置く (orchestrator SS 自己レビューで
+	// rewards/activities の after SS がダイアログに覆われ証跡不成立だった是正)。
+	await expect(dialog).toBeHidden({ timeout: 15_000 });
+
 	// SS 証跡 (PR body 添付用、#2955 AC1「SS 添付、表示変化あり」)。
 	// 文言 assert より前に撮ることで、修正前 code では「成功表示のまま」の before 証跡が残る。
 	// DOM HTML スナップショットも同一 page インスタンスから併保する (#1747 AC4 と同思想)。

--- a/tests/e2e/admin-import-partial-failure.spec.ts
+++ b/tests/e2e/admin-import-partial-failure.spec.ts
@@ -23,6 +23,7 @@
  *   `tests/unit/marketplace/ui/import-feedback.test.ts` で表示ロジックを回帰固定)。
  */
 
+import { writeFile } from 'node:fs/promises';
 import { expect, test } from '@playwright/test';
 import { stringify } from 'devalue';
 
@@ -93,7 +94,9 @@ async function runPartialFailureFlow(
 
 	// SS 証跡 (PR body 添付用、#2955 AC1「SS 添付、表示変化あり」)。
 	// 文言 assert より前に撮ることで、修正前 code では「成功表示のまま」の before 証跡が残る。
+	// DOM HTML スナップショットも同一 page インスタンスから併保する (#1747 AC4 と同思想)。
 	await page.screenshot({ path: `tmp/ss-2955/${opts.screenshotName}.png`, fullPage: false });
+	await writeFile(`tmp/ss-2955/${opts.screenshotName}.dom.html`, await page.content(), 'utf-8');
 
 	await expect(
 		banner,

--- a/tests/unit/marketplace/registry.test.ts
+++ b/tests/unit/marketplace/registry.test.ts
@@ -44,6 +44,7 @@ function createDummyStrategy(): ImportStrategy<DummyPayload> {
 				imported: payload.items.length,
 				skipped: 0,
 				errors: [],
+				failed: 0,
 			}),
 		),
 	};

--- a/tests/unit/marketplace/ui/import-feedback.test.ts
+++ b/tests/unit/marketplace/ui/import-feedback.test.ts
@@ -1,0 +1,66 @@
+/**
+ * resolveImportFeedback unit test — Issue #2955 (#2830 / #2935 follow-up)
+ *
+ * marketplace 取込 result の message / tone 出し分け (partial-failure 含む) の精度規約を回帰固定する。
+ * 特に「failed が SSOT であり errors.length への fallback を行わない」判断 (#2955 項目 2) を
+ * 仕様としてテストで明文化する。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { MARKETPLACE_IMPORT_FEEDBACK_LABELS } from '$lib/domain/labels';
+import { resolveImportFeedback } from '$lib/marketplace/ui/import-feedback';
+
+const labels = {
+	success: (n: number) => `success:${n}`,
+	allDuplicates: 'all-duplicates',
+};
+
+describe('resolveImportFeedback (#2955)', () => {
+	it('failed > 0 で partial-failure (error tone) を返す — imported > 0 でも成功と偽らない (#2824)', () => {
+		const fb = resolveImportFeedback({ imported: 3, failed: 2, errors: ['x'] }, labels);
+		expect(fb.tone).toBe('error');
+		expect(fb.message).toBe(MARKETPLACE_IMPORT_FEEDBACK_LABELS.partialFailure(3, 2));
+		expect(fb.message).toContain('3 件を追加しましたが');
+		expect(fb.message).toContain('2 件は保存できませんでした');
+	});
+
+	it('imported = 0 かつ failed > 0 は全件保存失敗の文言 (error tone)', () => {
+		const fb = resolveImportFeedback({ imported: 0, failed: 5 }, labels);
+		expect(fb.tone).toBe('error');
+		expect(fb.message).toBe(MARKETPLACE_IMPORT_FEEDBACK_LABELS.partialFailure(0, 5));
+	});
+
+	it('failed = 0 かつ imported > 0 で success', () => {
+		const fb = resolveImportFeedback({ imported: 4, failed: 0, errors: [] }, labels);
+		expect(fb).toEqual({ message: 'success:4', tone: 'success' });
+	});
+
+	it('failed = 0 かつ imported = 0 (純粋な全件重複) で allDuplicates (info)', () => {
+		const fb = resolveImportFeedback({ imported: 0, skipped: 8, failed: 0 }, labels);
+		expect(fb).toEqual({ message: 'all-duplicates', tone: 'info' });
+	});
+
+	it('errors.length への fallback は行わない — failed 欠落時は errors があっても失敗扱いしない (#2955 項目 2 判断記録)', () => {
+		// rule-preset は warnings (already-imported 等の非失敗) を errors に merge して返すため、
+		// errors.length を失敗数として読むと warnings が失敗件数に誤算入される。
+		// failed (required 化済) のみを SSOT とし、欠落 (契約違反の異常系) は 0 縮退とする。
+		const fb = resolveImportFeedback(
+			{ imported: 2, errors: ['warning: already imported'] },
+			labels,
+		);
+		expect(fb).toEqual({ message: 'success:2', tone: 'success' });
+	});
+
+	it('data undefined / 不正値 (負数・非数) は 0 縮退で allDuplicates に落ちる', () => {
+		expect(resolveImportFeedback(undefined, labels).tone).toBe('info');
+		expect(resolveImportFeedback({ imported: -1, failed: '2' }, labels).tone).toBe('info');
+	});
+
+	it('page 固有の partialFailure override が優先される', () => {
+		const fb = resolveImportFeedback(
+			{ imported: 1, failed: 1 },
+			{ ...labels, partialFailure: (i: number, f: number) => `custom:${i}/${f}` },
+		);
+		expect(fb).toEqual({ message: 'custom:1/1', tone: 'error' });
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: marketplace 取込が部分失敗（一部 item / row のみ保存失敗）した際、`admin/rewards` / `admin/checklists` / `admin/challenges` では server が算出した失敗件数 (`failed`) が UI に到達せず、**成功 toast のみが表示されていた**。親が失敗規模を過小評価して再取込をスキップし、「追加したはずのごほうび / チェックリストが子供画面に出ない」事故につながる (#2830 起票動機が 3 page で未解消)。

**期待される効果**: 全 4 admin page (activities / rewards / checklists / challenges) で `failed > 0` のとき「N 件を追加しましたが、M 件は保存できませんでした」を 2 層 feedback (Toast `error` + in-page banner、DESIGN.md §5) で正直に表示する。失敗件数の SSOT を server 算出 `failed` に統一し (errors.length fallback 撤去)、rule-preset の warnings (already-imported 等の非失敗通知) が失敗件数に誤算入される経路も根治した。

## 関連 Issue

closes #2955

関連: PR #2935 (QM レビュー申し送り元) / #2830 / #2824 / ADR-0052 (ImportStrategy) / DESIGN.md §5 2 層 feedback・§10 consistency

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 項目 1: 3 page (rewards / checklists / challenges) に partial-failure 表示分岐 + E2E (SS 添付、表示変化あり) | `npx playwright test tests/e2e/admin-import-partial-failure.spec.ts --project=tablet` | HEAD `a894ede5a` / 4 passed (38.5s)。rewards: `src/routes/(parent)/admin/rewards/+page.svelte:325` / checklists: `+page.svelte:425` / challenges: `+page.svelte:120` が `resolveImportFeedback` 経由で `failed > 0` 分岐。修正前 code では同 spec の rewards / checklists が fail することを確認済 (表示変化の機械的証憑)。SS は下記 4 スロット + 3 page 分 |
| AC2 | 項目 2: fallback 撤去 or warnings 分離の判断記録 + 実装 | `npx vitest run tests/unit/marketplace/ui/` + `rg -n "failed" src/lib/marketplace/types.ts src/lib/marketplace/dispatcher.ts` | HEAD `a894ede5a` / 19 passed。**判断 = fallback 撤去を採用** (根拠は下記「レビュー依頼事項」§判断記録): `ImportResult.failed` required 化 (`src/lib/marketplace/types.ts:126`) + dispatcher 素通し (`dispatcher.ts:47`、旧実装は drop) + UI は `resolveImportFeedback` (`src/lib/marketplace/ui/import-feedback.ts:67`) で failed のみ参照。`admin/settings/rules` の `errors.length > 0` 誤判定も `failed` 判定に是正 (`settings/rules/+page.svelte:91`) |
| AC3 | 項目 3: 設計依存注意の 1 行記録 | `rg -n "#2955 注意" src/lib/server/services/` | HEAD `a894ede5a` / `reward-set-import-service.ts:211` + `checklist-template-import-service.ts:251` に「1 item = 1 error 行の per-item 設計前提、bulk persist 化時は行数ベース集計へ再設計必須」を記録。設計書 `docs/design/marketplace-import-flow.md` §「partial-failure feedback と failed 件数 SSOT」にも同表で記録 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 親管理画面の marketplace 取込 result feedback — `/admin/activities` (共通 helper への置換、文言不変) / `/admin/rewards` / `/admin/checklists` / `/admin/challenges` (partial-failure 表示の新規到達 + challenges は Toast 層追加) / `/admin/settings/rules` (warnings 誤算入の是正)。`src/lib/marketplace/` (types / dispatcher / rule-preset-strategy コメント / 新規 `ui/import-feedback.ts`)。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - 新規 E2E `tests/e2e/admin-import-partial-failure.spec.ts`: form action POST を `page.route()` で SvelteKit ActionResult 形式 (devalue) の partial-failure fixture に差し替え、activities (回帰) + rewards + checklists の banner に「3 件を追加しましたが、2 件は保存できませんでした」が出ることを assert。誤検知防止 (failed=0 + errors 残存で重複文言のまま) も 1 件。実 DB の partial failure は決定的再現不可 (DB fault injection が必要) なため Integration 相当の `page.route()` モック (`tests/e2e/integration/upgrade-checkout.spec.ts` の Stripe mock と同パターン、tests/CLAUDE.md §テスト分類)。server 層 `failed` 算出精度は既存 unit (#2830) が担保
  - 新規 unit `tests/unit/marketplace/ui/import-feedback.test.ts` (7 cases): failed>0 → error tone / 全件重複 → info / **errors.length fallback を行わない仕様の回帰固定** / partialFailure override
  - 既存 import 系 E2E 回帰: `admin-activities-import-marketplace` + `admin-rewards-import-marketplace` + `admin-checklists-import-marketplace` + `marketplace-{rule-preset,checklist,reward-set,challenge-set}-import` + `cuj5-checklist-import-child-visible` = 37 passed (1.7m)。唯一の fail「+追加 > みんなのテンプレートから探す」nav test は pristine origin/develop checkout でも同様に fail することを確認済 (pre-existing、本 PR 起因でない。Ark UI menu open の環境依存 flake)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (priority:critical でない)

## スクリーンショット / ビジュアルデモ

partial-failure fixture (failed=2 / imported=3 の ActionResult モック) で取込確定した直後の banner 表示。E2E spec 内の `page.screenshot` で撮影 (tablet 1280x800、修正前 = 旧 code を checkout して同 spec を実行)。

**4 スロット添付**（#1740）:

| | rewards (代表 page、1280px) | checklists (1280px) |
|---|---|---|
| **修正前** | ![before-rewards](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3031/before-rewards-partial-failure.png) | ![before-checklists](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3031/before-checklists-partial-failure.png) |
| **修正後** | ![after-rewards](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3031/after-rewards-partial-failure.png) | ![after-checklists](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3031/after-checklists-partial-failure.png) |

- 修正前: 2 件保存失敗しているのに rewards = 「✨ 3 件のごほうびを追加しました」(成功 toast のみ) / checklists = 「…を取込み、N名のお子さまに配信しました」
- 修正後: 両 page とも banner + Toast に「3 件を追加しましたが、2 件は保存できませんでした」(error tone)
- 補助 (activities 回帰 = 既存表示の維持): ![after-activities](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3031/after-activities-partial-failure.png) / 修正前 (failed 既読の既存分岐、表示同等): ![before-activities](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3031/before-activities-partial-failure.png)
- [DOM HTML (after-rewards)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3031/after-rewards-partial-failure.dom.html) — E2E fixture 実行時の DOM スナップショット (banner テキストを grep 検証可能)
- モバイル viewport: 本変更は banner / Toast の**文言と tone のみ**でレイアウト変更なし (mobile 固有差分なし)。banner はモバイルでも同一 component が描画される (E2E は tablet project で assert、文言は viewport 非依存)

**インタラクティブ状態**: エラー状態 (partial-failure banner) が上記 SS そのもの。N/A (他状態は変更なし)。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 出し分けロジックを `resolveImportFeedback` (純関数) に単一責任化。page 固有文言は `ImportFeedbackLabels` interface 経由で注入 (D)
- [x] **DRY**: 4 page の同型 if/else 分岐を共通 helper に集約 (`rg -n "resolveImportFeedback" src/routes` で 4 callsite 確認)。partial-failure 文言は `MARKETPLACE_IMPORT_FEEDBACK_LABELS` (labels.ts) に一本化
- [x] **YAGNI**: warnings の別 field 分離は不採用 (判断記録参照)、現要件は failed required 化で充足
- [x] **Security（OSS 公開前提）**: 秘密情報なし。server 算出値の素通しのみで新規入力経路なし
- [x] **アクセシビリティ**: Toast `role="alert"` + banner `role="status"` の 2 live region (既存パターン踏襲、DESIGN.md §5)
- [x] **パフォーマンス**: 純関数 1 回呼出のみ、N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — demo は同一 route を `AUTH_MODE=anonymous` で host (demo no-op 分岐 `data.demo===true` は不変)
- [x] LP ↔ アプリ双方向整合（ADR-0013）— LP 文言変更なし (`generate-lp-labels --check` / `sync-lp-fallback --check` PASS)
- [x] 全年齢モード 5 種に横展開 — 親管理画面のみの変更で子供画面 (年齢モード) 影響なし
- [x] ナビゲーション 3 種に反映 — ナビ変更なし (N/A)
- [x] E2E / ユニットシード + チュートリアルを同期 — シード変更なし。`tests/unit/marketplace/registry.test.ts` の dummy strategy に `failed: 0` を追補 (required 化追従)
- [x] **labels SSOT** (ADR-0009/0045): partial-failure 文言を `MARKETPLACE_IMPORT_FEEDBACK_LABELS` compound に集約、`ADMIN_ACTIVITIES_PAGE_LABELS.importPartialFailure` は同 compound への参照に置換 (リテラル直書きなし、`check-no-plan-literals` PASS)
- [x] **設計書同期** (ADR-0001): `docs/design/marketplace-import-flow.md` に §「partial-failure (一部保存失敗) feedback と `failed` 件数 SSOT (#2830 / #2955)」を追加
- [x] **並行 PR overlap** (#1200): `gh pr list --base develop` で本 PR 変更ファイルを触る open PR なしを確認
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

(注: `ImportResult.failed` の optional → required 化は型レベルの厳格化で、5 strategy 全てが既に算出済のため runtime 挙動の破壊なし。外部公開 API でもない)

**レビュー依頼事項・QA**:

**項目 2 の判断記録 (Issue 要求: 判断根拠を PR body に記録)** — **fallback 撤去を採用、warnings 別 field 分離は不採用**:

1. **fallback 撤去が可能な前提が揃っている**: 5 strategy (activity-pack / reward-set / checklist / challenge-set / rule-preset) 全てが `failed` を算出済 (`rg -n "failed:" src/lib/marketplace/strategies/` で確認)。`ImportResult.failed` を required 化することで TS strict が将来の未配線を compile error で防ぐ。**根因は dispatcher が `failed` を drop していたこと**で、本 PR で素通しを配線した (旧実装では activities ですら fallback 経由で errors.length を表示しており、bulk throw 時に失敗規模を過小表示していた)
2. **errors.length は失敗数として両方向に不正確**: 過小 (bulk throw 1 回で 30 row 喪失でも errors.length≈2) かつ過大 (rule-preset は warnings を errors に merge するため already-imported 等の非失敗が誤算入)。fallback を残す限りこの不正確さが UI に漏れる経路が残る
3. **warnings 別 field 分離は不採用**: `errors` 配列は人間可読の表示ログ専用であり、件数 SSOT を `failed` に一本化すれば分離の付加価値がない (YAGNI)。rule-preset-strategy の `errors: [...errors, ...warnings]` / `failed = genuine errors` 非対称は意図的である旨をコメントで明文化 (`rule-preset-strategy.ts:163-168`)
4. **異常系の縮退方向**: `failed` 欠落 (型契約違反) 時は 0 扱い = 成功表示に縮退し、誤った失敗件数を出さない側に倒す (`import-feedback.ts` doc 参照)
5. **横展開**: 同じ `errors.length > 0` 誤判定が `admin/settings/rules` (bonus auto-import toast) にも実在したため同 PR で是正 (penalty/special の no-op warning が「取込失敗」error toast に誤判定される経路を排除)

challenges page の E2E は対象外とした: #2896 で challenge-set は marketplace 陳列対象外 = valid preset 0 件のため `?import=` 経由で dialog を開く実ユーザー動線が存在しない (互換 server 経路 + UI 分岐は実装済、表示ロジックは helper unit test で回帰固定)。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A (認証画面変更なし)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
