### PR TITLE
docs: #2966 textlint ja-space-around-code を off (案 1) — repo 表記慣習と逆の rule を無効化、違反 180→143 件 (bump 前水準) 復帰

### DIFF
--- a/docs/zenn/.textlintrc.json
+++ b/docs/zenn/.textlintrc.json
@@ -11,7 +11,8 @@
 		},
 		"preset-jtf-style": true,
 		"preset-ja-spacing": {
-			"ja-space-between-half-and-full-width": { "space": "always" }
+			"ja-space-between-half-and-full-width": { "space": "always" },
+			"ja-space-around-code": false
 		},
 		"prh": { "rulePaths": ["./prh.yml"] }
 	}

--- a/docs/zenn/README.md
+++ b/docs/zenn/README.md
@@ -190,6 +190,8 @@ npx textlint "docs/zenn/**/*.md"
 3. **commit 前 diff 全件確認**: 機械生成を受け入れた場合でも commit 前に `git diff` で全件目視し、長音記号の重複・不正なネスト・意図しない置換を検知する
 4. **50 ファイル超は分割必須**: `docs/CLAUDE.md` §「巨大 docs refactor PR 分割ガイドライン」(#2225) に従い、50 files 超で警告 / 100 files 超で BLOCK。textlint 由来の大規模修正は同ガイドラインの対象
 
+> **`ja-space-around-code` は off (#2966)**: preset-ja-spacing 3.0.0 で default ON 化された本 rule は「インラインコード前後にスペースを入れない」思想だが、本 repo の表記慣習 (CLAUDE.md / docs/ 全体で日本語 + 半角スペース + インラインコード) と逆のため `.textlintrc.json` で off にしている。違反 +37 件に直面しても反射的に一括 `--fix` しないこと (#2243 の一括禁止運用)。
+
 #### CI 統合方針
 GitHub Actions (`zenn-lint.yml`) により、`docs/zenn/**` への変更時に自動で lint が実行されます。
 - 現在は導入初期のため `continue-on-error: true` (warning レベルの運用) としており、CI は失敗しません。


### PR DESCRIPTION
## 顧客価値・目的

textlint-rule-preset-ja-spacing 3.0.0 bump (PR #2965) で default ON 化された `ja-space-around-code` の新規違反 +37 件 (143 → 180) の disposition を消化する。CI (`zenn-lint.yml`) は `continue-on-error: true` のため fail はしないが、サイレント蓄積を放置すると次の執筆者がローカル lint で +37 warning に直面し、反射的な一括 `--fix` (#2223 の機械的誤変換事故の再発経路) を誘発するため、rule off + 注記で構造的に防ぐ。

closes #2966

## 関連 Issue

- closes #2966（PR #2965 QM レビュー申し送りの消化）
- 関連: #2965（preset 3.0.0 bump、dry-run 実測 +37 件）/ #2243（textlint `--fix` 一括禁止運用）/ #2223（機械的誤変換事故）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 案 1/2 の判断記録 + 実施 | 判断根拠を本 PR body「レビュー依頼事項」に記録 + `docs/zenn/.textlintrc.json` に `"ja-space-around-code": false` 追加 + `docs/zenn/README.md` §3.7 に off 理由 + 一括 `--fix` 禁止注記を追加 | ✅ **案 1 (rule off) を採用**（Issue 推奨どおり）。根拠: (1) 本 repo は CLAUDE.md / docs/ 全体で「日本語 + 半角スペース + インラインコード」を慣習化しており rule の思想（スペースを入れない）と正反対、(2) 案 2（37 件手動整形）は repo 慣習との不整合を docs/zenn/ にだけ持ち込み一貫性を壊す、(3) 最小 diff（config 1 行 + 注記 1 段落） |
| AC2 | `cd docs/zenn && npx textlint "**/*.md"` で違反 143 件 (bump 前水準) 以下に戻ることを確認 | textlint v15.7.1 + preset-ja-spacing 3.0.0 で before/after 実測（本 worktree は node_modules 未配備のため、repo の installed deps (`node_modules/textlint/bin/textlint.js`) + 本 branch の `--config`/対象 file で等価実行） | ✅ **before: 180 problems（うち `ja-spacing/ja-space-around-code` = 37 件、全件 README.md）→ after: 143 problems（`ja-space-around-code` 残 0 件）**。143 = bump 前水準ちょうど（AC の「143 件以下」充足）。追記した README 注記自体の新規違反も 0（after 合計が正確に 143 で増分なし） |

### 検証ログ要旨

```
# before (rule off 適用前、preset-ja-spacing 3.0.0)
✖ 180 problems (180 errors, 0 warnings, 0 infos)
ja-spacing/ja-space-around-code: 37 件（全件 docs/zenn/README.md）

# after (本 PR 適用後)
✖ 143 problems (143 errors, 0 warnings, 0 infos)
ja-spacing/ja-space-around-code: 0 件
```

## 変更タイプ

- [x] docs（lint config + 運用注記）
- [ ] feat / fix / refactor / infra

## 影響範囲・変更コンポーネント

- `docs/zenn/.textlintrc.json`（1 行追加: `"ja-space-around-code": false`）
- `docs/zenn/README.md` §3.7（off 理由 + 一括 `--fix` 禁止の注記 1 段落）
- `docs/zenn/` の記事本文（articles / books / scraps）への変更なし。`--fix` は一切使用していない（#2243 規律準拠）

## テスト & 安全装置セルフチェック

- textlint before/after 実測で AC2 を機械検証（上記ログ）
- `--fix` 不使用（dry-run 計測のみ、#2243 / #2223 教訓準拠）
- pre-push hook verify chain（base 解決 / rebase drift / biome — `.textlintrc.json` lint PASS）全 PASS
- CI `zenn-lint.yml` は docs/zenn/** 変更で発火し本 config を使用（continue-on-error のため現状 advisory）

## スクリーンショット / ビジュアルデモ

N/A — lint config (JSON) + docs (Markdown) のみの変更で UI / LP / `.svelte` / `.css` への変更が一切ないため、SS 撮影対象画面が存在しない。

## コード品質セルフレビュー (#1481)

- [x] 最小 diff（config 1 行 + 注記 1 段落、記事本文無変更）
- [x] 注記は §3.7 の既存「`--fix` 一括禁止」運用ルール直下に配置し、SSOT を分散させない
- [x] rule off は preset の公式 config 形式（`"<rule-name>": false`）で実装

## 横展開・影響波及チェック

- repo 内の他 textlint config: `grep -rn "textlintrc"` で docs/zenn/.textlintrc.json のみ（他箇所への波及なし）
- prh.yml / 他 preset 設定は無変更
- 同 preset 3.0.0 の他 rule に default 変化由来の新規違反がないことは before/after 差分が ja-space-around-code 37 件のみで一致することから確認済（180 − 37 = 143）

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。**判断記録（AC1）**: 案 1 (rule off) を採用。repo 全体の表記慣習（日本語 + 半角スペース + コード）との一貫性が決め手で、Issue 推奨と一致。将来 repo 慣習を rule 側に寄せる場合は本 config 1 行を外し 37 件を手動整形する（その際も一括 `--fix` 禁止）

## 配布済み env / secret (ADR-0006)

N/A — env / secret の追加・変更なし

## Ready for Review チェックリスト

- [x] AC 検証マップ全行記入（before/after 実測ログ付き）
- [x] 必須 13 セクション存在（check-pr-body）
- [x] SS N/A 根拠明記（docs / config only）
- [x] CI 緑確認後に Ready 化

## QM レビュー結果

（QM 記入欄）
