### PR TITLE
fix: #2982 統合 #2968 follow-up — doc 悪例差し替え + baseBranch whitelist clamp + #2971 cleanup

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -204,6 +204,7 @@ Lottie
 lowr
 LOWR
 maxlength
+metacharacter
 Metas
 microticks
 miteruyo

--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -697,7 +697,7 @@ PO 提案「マーケプレ rule-preset 集約による settings 初期値配布
 
 **presence 不変条件（導線インベントリテスト、#2905）:** 全登録ページで「`?` トリガが存在し、click でガイド overlay が開き、Escape で閉じる」を `tests/e2e/admin-page-guide-presence.spec.ts` がループ検証する。新ページの登録漏れ / 登録解除はこの spec が必ず fail させる（M6 構造 invariant）。
 
-**narrative 標準（3 部構成、ADR-0012）:** 各ページの guide は **「①概要 → ②画面の見方 → ③最頻操作」の 3 部構成**に統一する。1 ページの step は **最大 5**（情報過多回避）。`①概要` は `selector` を省略し画面中央 modal でページ全体像を説明する（特定 UI に紐付かない俯瞰のため）。`②画面の見方` / `③最頻操作` は **具体的な `data-tutorial` アンカー**（例: `[data-tutorial="rewards-child-tabs"]` / `[data-tutorial="points-section"]`）を target にし、一覧 section 全体などの巨大コンテナは target にしない（spotlight cutout が viewport 大半を覆い、バブル配置の余地が物理的に消えるため）。各 step は `what` / `how` / `goal` の 3 フィールドを深く記述する（`page-guide-types.ts`）。
+**narrative 標準（3 部構成、ADR-0012）:** 各ページの guide は **「①概要 → ②画面の見方 → ③最頻操作」の 3 部構成**に統一する。1 ページの step は **最大 5**（情報過多回避）。`①概要` は `selector` を省略し画面中央 modal でページ全体像を説明する（特定 UI に紐付かない俯瞰のため）。`②画面の見方` / `③最頻操作` は **具体的な `data-tutorial` アンカー**（例: `[data-tutorial="rewards-child-tabs"]` / `[data-tutorial="points-first-balance"]` — いずれも常設の小〜中要素）を target にし、`points-section` のような一覧 section 全体 = 巨大コンテナは target にしない（spotlight cutout が viewport 大半を覆い、バブル配置の余地が物理的に消えるため）。各 step は `what` / `how` / `goal` の 3 フィールドを深く記述する（`page-guide-types.ts`）。
 
 **selector 省略 step の中央 modal 再 positioning:** `①概要` のような `selector` 省略 step は driver.js が画面中央 modal で表示する。driver.js は mount 前の空 wrapper 幅で center 計算するため、Svelte bubble mount 後に wrapper が最終幅（max 360px）へ成長すると左端がずれる。`PageGuideOverlay.svelte` は `selector` 省略 step に限り `requestAnimationFrame` 後に `driver.refresh()` を呼び、最終幅で再 center する（element 紐付き step は driver.js の collision 回避が target 基準で働くため refresh しない）。
 

--- a/scripts/lib/resolve-base-branch.mjs
+++ b/scripts/lib/resolve-base-branch.mjs
@@ -77,6 +77,20 @@ export function resolveBaseBranch({
 }
 
 /**
+ * base branch 名の whitelist 検証 (#2982、unit test 対象)。
+ * develop 二層ブランチ戦略 (docs/sessions/branch-strategy.md) の正当な lane は main / develop の
+ * 2 つのみ。解決値を `shell: true` のコマンド文字列 (`origin/${base}` 等) に展開する消費側
+ * (scripts/pre-ready.mjs getChangedFiles / 本 CLI --verify-base) は、展開前に本関数で防御的に
+ * clamp する (脅威モデルは「本人の local tool」のため理論枠だが、injection 面を構造的に閉じる)。
+ *
+ * @param {string} name
+ * @returns {boolean}
+ */
+export function isAllowedBaseBranch(name) {
+	return /^(main|develop)$/.test(name);
+}
+
+/**
  * remote.origin.fetch の refspec 行が origin/develop の追跡を含むかの純粋判定 (#2975、unit test 対象)。
  * `+refs/heads/*:refs/remotes/origin/*` (全 branch) または develop 明示行があれば true。
  *
@@ -223,8 +237,11 @@ if (isMain) {
 		if (process.argv.includes('--verify-base')) {
 			// #2975 AC2: 基点鮮度の機械検証。branch 作成直後 / push 前に
 			// 「HEAD が origin/<base> の最新を取り込んでいる (behind 0)」ことを exit code で保証する。
-			if (!/^[\w./-]+$/.test(base)) {
-				console.error(`[resolve-base-branch] ERROR: 不正な base branch 名: ${base}`);
+			// #2982: 後続の execSync コマンド文字列に base を展開するため whitelist 検証 (main / develop の 2 lane のみ)
+			if (!isAllowedBaseBranch(base)) {
+				console.error(
+					`[resolve-base-branch] ERROR: 不正な base branch 名: ${base} (whitelist: main / develop、#2982)`,
+				);
 				process.exit(1);
 			}
 			/** @param {string} cmd 固定コマンド + validate 済 base 名のみ @param {number} [timeout] ms */

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -40,7 +40,7 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolveBaseBranchAuto } from './lib/resolve-base-branch.mjs';
+import { isAllowedBaseBranch, resolveBaseBranchAuto } from './lib/resolve-base-branch.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -185,8 +185,18 @@ function run(cmd, argv) {
  * @returns {Promise<string[]>}
  */
 async function getChangedFiles(baseBranch) {
+	// #2982: shell:true 下で `origin/${baseBranch}` をコマンド文字列に展開するため、展開前に
+	// whitelist (main / develop の 2 lane) で防御的に clamp する。脅威モデルは「本人の local tool」
+	// のため理論枠 (ADR-0010 整合で非 BLOCK 裁定済) だが、injection 面を構造的に閉じる。
+	let base = baseBranch;
+	if (!isAllowedBaseBranch(base)) {
+		console.warn(
+			`[pre-ready] WARN: 想定外の base branch "${base}" (whitelist: main / develop) — origin/main に clamp します (#2982)`,
+		);
+		base = 'main';
+	}
 	return new Promise((resolveP) => {
-		const child = spawn('git', ['diff', `origin/${baseBranch}...HEAD`, '--name-only'], {
+		const child = spawn('git', ['diff', `origin/${base}...HEAD`, '--name-only'], {
 			cwd: repoRoot,
 			stdio: ['ignore', 'pipe', 'ignore'],
 			shell: true,

--- a/src/lib/ui/components/PageGuideOverlay.svelte
+++ b/src/lib/ui/components/PageGuideOverlay.svelte
@@ -261,7 +261,12 @@ function buildDriveSteps(pageGuide: PageGuide): DriveStep[] {
 				//    driver.js の scroll/resize 再配置は onPopoverRender を再発火しないため、
 				//    一発 clamp では scroll 後の再配置位置が補正されないまま「安定」してしまう。
 				//    ループによる恒常 clamp は全再配置経路を構成的に被覆する。
-				startClampLoop(() => document.getElementById('driver-popover-content'));
+				//    wrapper は driver.js 内部 id (`driver-popover-content`) の getElementById でなく
+				//    onPopoverRender が渡す popover.wrapper を直接参照する (#2982 / #2971 cleanup —
+				//    内部 id 命名への依存を撤去)。destroy 後は isConnected=false で no-op になり、
+				//    ループ自体も destroyDriver → stopClampLoop で停止する (二重防御)。
+				const { wrapper } = popover;
+				startClampLoop(() => (wrapper.isConnected ? wrapper : null));
 			},
 		},
 	}));

--- a/tests/e2e/page-guide-layout-invariant.spec.ts
+++ b/tests/e2e/page-guide-layout-invariant.spec.ts
@@ -128,7 +128,10 @@ async function assertBubbleNotOverlapTarget(
 	const bubbleBox = await bubble.boundingBox();
 	const targetBox = await target.boundingBox();
 	if (!bubbleBox || !targetBox) return;
-	const vp = page.viewportSize();
+	// #2982 (#2971 cleanup): assertBubbleWithinViewport と同じく window.innerWidth/innerHeight を
+	// 参照し、boundingBox() と同一座標空間で fits 判定する。page.viewportSize() は device emulation
+	// 下で要求値を返し実 CSS px 空間 (例: Pixel 7 = 412px) と乖離するため使わない (#2971 round6 同件)。
+	const vp = await page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
 	if (!vp) return;
 
 	// driver.js が element 省略 step で center 配置のために挿入する 0×0 placeholder (#driver-dummy-element)

--- a/tests/unit/scripts/resolve-base-branch.test.ts
+++ b/tests/unit/scripts/resolve-base-branch.test.ts
@@ -3,6 +3,7 @@
 // develop 二層ブランチ戦略 (docs/sessions/branch-strategy.md §3/§5) のクライアント側 SSOT。
 import { describe, expect, it } from 'vitest';
 import {
+	isAllowedBaseBranch,
 	refspecCoversDevelop,
 	resolveBaseBranch,
 } from '../../../scripts/lib/resolve-base-branch.mjs';
@@ -101,5 +102,33 @@ describe('refspecCoversDevelop (#2975)', () => {
 
 	it('空配列 (refspec 未設定) は cover しない', () => {
 		expect(refspecCoversDevelop([])).toBe(false);
+	});
+});
+
+// Issue #2982: shell:true コマンド文字列へ展開する前の base branch whitelist 検証。
+// develop 二層戦略の正当な lane (main / develop) のみ許可し、injection 面を構造的に閉じる
+// (脅威モデルは local tool のため理論枠、ADR-0010 整合)。
+describe('isAllowedBaseBranch (#2982)', () => {
+	it('正当な 2 lane (main / develop) のみ許可する', () => {
+		expect(isAllowedBaseBranch('main')).toBe(true);
+		expect(isAllowedBaseBranch('develop')).toBe(true);
+	});
+
+	it('origin/ prefix 付き・feature branch・空文字は拒否する', () => {
+		expect(isAllowedBaseBranch('origin/main')).toBe(false);
+		expect(isAllowedBaseBranch('feature/123-foo')).toBe(false);
+		expect(isAllowedBaseBranch('')).toBe(false);
+	});
+
+	it('shell metacharacter を含む文字列は拒否する (injection 面の閉鎖)', () => {
+		expect(isAllowedBaseBranch('main; rm -rf /')).toBe(false);
+		expect(isAllowedBaseBranch('main && echo pwned')).toBe(false);
+		expect(isAllowedBaseBranch('$(whoami)')).toBe(false);
+		expect(isAllowedBaseBranch('main\ndevelop')).toBe(false);
+	});
+
+	it('部分一致 (mainline / developer) は拒否する (anchored regex)', () => {
+		expect(isAllowedBaseBranch('mainline')).toBe(false);
+		expect(isAllowedBaseBranch('developer')).toBe(false);
 	});
 });


### PR DESCRIPTION
<!-- Issue #2982 — 統合 #2968 follow-up (Copilot [must] 残存 2 件 + #2971 cleanup 束ね) -->

## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（Dev 補佐含む）

**解決する課題**: 初回 develop→main 統合 PR #2968 の adversarial review で非ブロッキング裁定された Copilot [must] 残存 2 件（06-UI設計書の自己矛盾例示 / pre-ready の shell:true baseBranch 展開）と、#2971 9 round サイクルの残存 cleanup 3 点が未消化のまま disposition だけ記録されていた。

**期待される効果**: (1) ページガイド SSOT の例示が原則と整合し、次に guide step を追加する Dev を誤誘導しない (2) base branch 解決値の shell 展開面が whitelist で構造的に閉じる (3) ページガイド E2E / 実装の #2971 残存負債が解消 or 据置理由つきで確定する。

## 関連 Issue

closes #2982

related: #2968 (統合 PR、QM 裁定記録) / #2971 (9 round サイクル) / #2960 / #2962 / #3020 (resolve-base-branch ensureDevelopRefspec) / ADR-0010

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 項目 1: doc 例示差し替え（巨大コンテナ悪例 `points-section` を良例に） | `grep -n 'points-first-balance' docs/design/06-UI設計書.md` + 実在 selector 照合 | HEAD `ad10f17` / §4.13.1 narrative 標準行の例示を `[data-tutorial="points-first-balance"]`（`src/routes/(parent)/admin/points/+page.svelte:199` 実在 + `points/_guide.ts:35` 実使用の常設小要素）に差し替え。`points-section` は「target にしない」側の名指し例として残置し自己矛盾を解消 |
| AC2 | 項目 2: baseBranch whitelist clamp（pre-ready + resolve-base-branch 両側） | `npx vitest run tests/unit/scripts/resolve-base-branch.test.ts` | HEAD `ad10f17` / 20 passed。`scripts/lib/resolve-base-branch.mjs` に `isAllowedBaseBranch()` (`/^(main|develop)$/`) を export 追加し、`--verify-base` の旧 `/^[\w./-]+$/` 検証を whitelist に強化。`scripts/pre-ready.mjs getChangedFiles()` は shell:true 展開前に whitelist 検証 + 不一致時 `origin/main` clamp + WARN。unit test に whitelist 4 ケース（2 lane 許可 / prefix・feature・空文字拒否 / shell metacharacter 拒否 / anchored 部分一致拒否）追加 |
| AC3 | 項目 3: #2971 cleanup 3 点の実施 or 据置判断記録 | 本 PR body §「#2971 cleanup 3 点の disposition」 | HEAD `ad10f17` / (a) 実施 / (b) 据置 + 理由記録 / (c) 実施。下記参照 |
| AC4 | invariant / presence spec PASS 維持 | `npx playwright test tests/e2e/page-guide-layout-invariant.spec.ts tests/e2e/admin-page-guide-presence.spec.ts --project tablet` | HEAD `ad10f17` / **33 passed (1.3m)** ローカル全緑（invariant 22 = 11 page × 2 viewport + presence 11） |

## #2971 cleanup 3 点の disposition (AC3 詳細)

| # | 項目 | 判断 | 内容 / 理由 |
|---|------|------|------------|
| (a) | `assertBubbleNotOverlapTarget` 内 `page.viewportSize()` → innerWidth 系統一 | **実施** | `assertBubbleWithinViewport`（#2971 round6 で innerWidth 化済）と同じく `page.evaluate(() => window.innerWidth/innerHeight)` に統一。`boundingBox()` と同一座標空間で fits 判定するため、device emulation 下の要求値 vs 実 CSS px 乖離（Pixel 7 = 412px 問題）の系統差が消える。小 diff（spec のみ） |
| (b) | rAF clamp unit test を実装関数直接参照に | **据置** | `startClampLoop` / `stopClampLoop` は `PageGuideOverlay.svelte` 内の component-local closure（`clampLoopId` を閉包）。直接参照には module 抽出 refactor が必要で、#2971 で 9 round かけて安定化した hot path をテスト構造の審美性のみを目的に動かすことになる。実ループの挙動は invariant spec（11 page × 2 viewport × 全 step）が毎回 end-to-end で実行しており、lifecycle の設計保証はインライン再現 test + E2E の二重で担保済。Pre-PMF の risk/benefit（ADR-0010）で据置。将来 PageGuideOverlay を機能改修で触る際に同梱で抽出するのが適切 |
| (c) | `getElementById('driver-popover-content')` → `popover.wrapper` 参照化 / visualViewport 検討 | **wrapper 参照化は実施 / visualViewport は据置** | `onPopoverRender` が渡す `popover.wrapper` を closure capture し `isConnected` guard 付きで `startClampLoop` に渡す形に置換。driver.js 内部 id 命名（`driver-popover-content`）への依存を撤去し、destroy 後は no-op（ループ自体も `destroyDriver → stopClampLoop` で停止する二重防御は不変）。**visualViewport 採用は据置**: clamp の目的は CI emulation 下の layout viewport 超過補正であり、`boundingBox()` / spec 計測と同一座標空間は `window.innerWidth`（layout viewport）。pinch-zoom 時の visual viewport 追従は CI matrix にも顧客シナリオにも現状なく、導入すると spec 計測空間と二重系になる（Pre-PMF 過剰、ADR-0010） |

## 変更タイプ

- [x] fix: バグ修正
- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] UI コンポーネント (`$lib/ui/`) — `PageGuideOverlay.svelte`（clamp loop の wrapper 参照化、挙動等価）
- [x] 設定・CI (`scripts/`) — `pre-ready.mjs` / `lib/resolve-base-branch.mjs`
- [x] docs — `docs/design/06-UI設計書.md` §4.13.1

**影響を受ける画面・機能**: admin 全 11 ページのページガイド（`?` トリガ）— レンダリング挙動は等価（E2E 33 件で確認）。pre-ready / pre-push の base branch 解決 tooling。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3038 --skip-biome` 全 Step PASS**（#1775 / ADR-0030）。Step 1 biome は worktree が `.claude/worktrees/` 配下にあり biome.json の `!**/.claude` exclude で 0 files になる環境制約のため、`npx biome check --error-on-warnings <変更 5 files>` で個別検証 PASS（Checked 5 files / exit 0、CI 側 biome job が repo root で正検証）
- [x] 追加・変更したテストの概要:
  - `tests/unit/scripts/resolve-base-branch.test.ts` に `isAllowedBaseBranch (#2982)` describe（4 ケース: 2 lane 許可 / origin prefix・feature branch・空文字拒否 / shell metacharacter 拒否 / anchored 部分一致拒否）を追加
  - `tests/e2e/page-guide-layout-invariant.spec.ts` の overlap 判定座標空間を innerWidth 系に統一（assertion 強度は不変 — 同一座標空間化で判定が正確化、ADR-0006 弱体化なし）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:critical ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs — UI 変更なし、`refactor:internal-no-doc-impact` ラベル付与済 #2017）**: 本 PR の変更は (1) 設計書の例示文言 (2) ローカル tooling script の防御的 clamp (3) ページガイド clamp loop の参照取得方法の等価置換（`getElementById` → closure capture、描画結果・配置ロジック不変）のみで、**ピクセル出力に影響する UI 変更を含まない**。挙動等価性は `page-guide-layout-invariant.spec.ts`（11 page × 2 viewport × 全 step の非重複 / viewport 収容 / spotlight 表示）+ `admin-page-guide-presence.spec.ts` の **33 passed** で機械検証済（SS 目視より強い幾何 assert）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `isAllowedBaseBranch` は単一責務の純粋関数として SSOT (`resolve-base-branch.mjs`) に配置し、消費側 2 箇所 (pre-ready / CLI --verify-base) が共有
- [x] **DRY**: whitelist regex を 1 箇所に集約（pre-ready 側に regex 直書きしない）。`grep -rn 'origin/\${' scripts/` で他の shell 展開消費箇所がないこと確認済
- [x] **YAGNI**: whitelist は現行 2 lane のみ。将来 lane 追加時に 1 行修正
- [x] **Security**: CWE-78 (OS command injection) の理論面を whitelist で閉鎖（脅威モデルは本人の local tool のため理論枠、ADR-0010 整合の防御的 clamp）。shell metacharacter 拒否を unit test で固定
- [x] **アクセシビリティ**: N/A（描画変更なし）
- [x] **パフォーマンス**: clamp loop は毎フレーム `getElementById` → closure 参照になり微減（実質等価）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): 本 PR 自体が 06-UI設計書の整合修正。`points-section` の他 doc 残存は `grep -rn 'points-section' docs/` で確認 — 残るのは `_guide.ts` 内コメント（「巨大要素は target にしない」という正しい向きの言及）のみ
- [x] **並行 PR overlap** (#1200): 並行 PR が触る `docs/sessions/` 系・`src/lib/server/db/dynamodb/special-reward*` には触れていない（scope = guide doc / scripts / tests / PageGuideOverlay のみ）
- [x] N/A — 並行実装ペア（demo / 年齢モード / ナビ / labels / E2E seed）への影響なし。`resolve-base-branch.mjs` の他消費箇所（`.husky/pre-push`）は `resolveBaseBranchAuto` 経由で解決値が main/develop に限られるため挙動不変

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- `GANBARI_PR_BASE` escape hatch に main/develop 以外を渡した場合、`--verify-base` は exit 1、pre-ready の変更ファイル検出は origin/main に clamp + WARN になります（resolution 自体の値は維持 — 解決 semantics は不変で、shell 展開の消費点のみ防御）。この消費点 clamp 方式で問題ないかご確認ください
- cleanup (b) の据置判断（rAF loop の module 抽出は将来の機能改修同梱が適切）の妥当性

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3038 --skip-biome` 全 Step PASS** をローカル確認した（biome は変更 5 files 個別で `--error-on-warnings` PASS、worktree path 制約は上記参照）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（項目 3 は実施 2 + 据置 1、据置理由を本 body に記録 = AC の「実施 or 据置判断記録」を充足）
- [x] Phase 分割: N/A
- [x] UI 変更時 SS: N/A（上記理由、E2E 幾何 assert 33 件で代替検証）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
