### PR TITLE
fix: #2941 trial-history-repo 申し送り対応 — updateConversion tenant scope 化 + startTrial negative path visible feedback

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1775,7 +1775,7 @@ child partition 配下に置き、`findMessages` / `findUnshownMessage` / `count
 
 - `findLatestByTenant(tenantId)`: tenant partition を `ScanIndexForward=false` で Query `Limit 1` → 最大 id (=最新) を 1 read（GSI 不要）。
 - `findActiveTrials()`: tenantId を受けない全 tenant 横断 + 日次 cron の低頻度経路のため Scan + `begins_with(SK,'HIST#') AND endDate >= today` filter（GSI 追加は過剰防衛、ADR-0010）。
-- `updateConversion(id)`: tenantId 不明のため tenant 横断 Scan + id filter で PK/SK を解決して Update（Stripe webhook 経由の稀な経路）。
+- `updateConversion(id, tenantId)`: id + tenantId で PK/SK が一意に確定するため exact Key で直接 Update（`attribute_exists(PK)` で不在時 no-op）。trial counter は tenant 別採番で id が tenant 間衝突するため、呼び出し元（Stripe webhook 経由の稀な経路）は tenant 解決済みの tenantId を必ず渡す（#2941）。
 - `deleteByTenantId(tenantId)`: tenant partition は trial history 専用のため exact PK 削除で完結（退会時、ADR-0049）。
 
 実装: `src/lib/server/db/dynamodb/trial-history-repo.ts`（挙動 SSOT は `sqlite/trial-history-repo.ts`）。

--- a/scripts/capture-specs/flows/trial-banner-start-error-2941.mjs
+++ b/scripts/capture-specs/flows/trial-banner-start-error-2941.mjs
@@ -22,6 +22,7 @@
  *     --server-mode cognito --presets desktop
  */
 
+import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 
@@ -86,6 +87,17 @@ export default async (page, capture) => {
 			.getByTestId('trial-banner-start-error')
 			.waitFor({ state: 'visible', timeout: 15_000 });
 		await capture('2941-trial-banner-start-error-visible');
+
+		// #1747: SS と同一 page から DOM snapshot を保存 (flow mode は per-step dom 出力が
+		// 無いため、エラー表示状態の outerHTML を明示保存して SS との同時取得を保証する)
+		const outDir = path.resolve(process.env.DOM_OUT_DIR || 'tmp/screenshots/pr-2941');
+		mkdirSync(outDir, { recursive: true });
+		const html = await page.evaluate(() => document.documentElement.outerHTML);
+		writeFileSync(
+			path.join(outDir, 'trial-banner-start-error-2941-flow.dom.html'),
+			html,
+			'utf-8',
+		);
 	} finally {
 		cleanTrial();
 	}

--- a/scripts/capture-specs/flows/trial-banner-start-error-2941.mjs
+++ b/scripts/capture-specs/flows/trial-banner-start-error-2941.mjs
@@ -93,11 +93,7 @@ export default async (page, capture) => {
 		const outDir = path.resolve(process.env.DOM_OUT_DIR || 'tmp/screenshots/pr-2941');
 		mkdirSync(outDir, { recursive: true });
 		const html = await page.evaluate(() => document.documentElement.outerHTML);
-		writeFileSync(
-			path.join(outDir, 'trial-banner-start-error-2941-flow.dom.html'),
-			html,
-			'utf-8',
-		);
+		writeFileSync(path.join(outDir, 'trial-banner-start-error-2941-flow.dom.html'), html, 'utf-8');
 	} finally {
 		cleanTrial();
 	}

--- a/scripts/capture-specs/flows/trial-banner-start-error-2941.mjs
+++ b/scripts/capture-specs/flows/trial-banner-start-error-2941.mjs
@@ -1,0 +1,92 @@
+/**
+ * scripts/capture-specs/flows/trial-banner-start-error-2941.mjs
+ *
+ * #2941 項目 2: trialUsed=true 再押下 negative path の visible feedback 撮影。
+ *
+ * 旧挙動: TrialBanner の use:enhance が failure result を黙殺し、startTrial の
+ * fail(400) がユーザーに一切見えなかった (NN/G #1 違反)。本 fix で
+ * getActionErrorDisplay (#2913) 経由の role=alert エラーメッセージを表示する。
+ *
+ * 撮影 2 状態:
+ *   1. trial 未使用 free ユーザーの「開始」バナー (stale 画面)
+ *   2. DB 直接 seed で使用済み化 → 再押下 → trial-banner-start-error 表示
+ *
+ * 前提: cognito-dev サーバ (port 5174) + free storageState。
+ *
+ * 使用例:
+ *   node scripts/capture.mjs --pr 2941 \
+ *     --flow trial-banner-start-error-2941 \
+ *     --url /admin \
+ *     --actions scripts/capture-specs/flows/trial-banner-start-error-2941.mjs \
+ *     --storage-state playwright/.auth/free.json \
+ *     --server-mode cognito --presets desktop
+ */
+
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
+const DB_PATH = path.resolve('data/ganbari-quest.db');
+const TENANT = 'dev-tenant-free';
+
+/** dev-tenant-free の trial 履歴を削除して未使用状態に戻す（撮影前後の冪等化）。 */
+function cleanTrial() {
+	const db = new Database(DB_PATH);
+	try {
+		db.prepare('DELETE FROM trial_history WHERE tenant_id = ?').run(TENANT);
+	} finally {
+		db.close();
+	}
+}
+
+/** 「別タブで既に開始済み」を再現する使用済み trial seed（tests/e2e/trial-flow.spec.ts と同手法）。 */
+function seedUsedTrial() {
+	const db = new Database(DB_PATH);
+	try {
+		const pastEnd = new Date();
+		pastEnd.setDate(pastEnd.getDate() - 3);
+		const pastStart = new Date();
+		pastStart.setDate(pastStart.getDate() - 10);
+		db.prepare(
+			'INSERT INTO trial_history (tenant_id, start_date, end_date, tier, source) VALUES (?, ?, ?, ?, ?)',
+		).run(
+			TENANT,
+			pastStart.toISOString().split('T')[0],
+			pastEnd.toISOString().split('T')[0],
+			'standard',
+			'user_initiated',
+		);
+	} finally {
+		db.close();
+	}
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	cleanTrial();
+	try {
+		// --- 1) trial 未使用の「開始」バナー (stale 画面の起点) ---
+		await page.goto(`${BASE_URL}/admin`);
+		await page
+			.getByTestId('trial-banner-start-button')
+			.waitFor({ state: 'visible', timeout: 30_000 });
+		// #702 hydration marker: use:enhance バインド前 click の native POST fallback を防ぐ
+		await page.waitForFunction(() => window.__APP_HYDRATED__ === true, undefined, {
+			timeout: 30_000,
+		});
+		await capture('2941-trial-banner-not-started');
+
+		// --- 2) 使用済み化 → 再押下 → エラーメッセージ表示 (NN/G #1) ---
+		seedUsedTrial();
+		await page.getByTestId('trial-banner-start-button').click();
+		await page
+			.getByTestId('trial-banner-start-error')
+			.waitFor({ state: 'visible', timeout: 15_000 });
+		await capture('2941-trial-banner-start-error-visible');
+	} finally {
+		cleanTrial();
+	}
+};

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -662,6 +662,12 @@ export const TRIAL_LABELS = {
 		FEATURE_LABELS.dataExport,
 	] as readonly string[],
 	bannerCtaSubmitting: ACTION_LABELS.submitting,
+	// #2941 項目 2: startTrial action の negative path (trialUsed=true 再押下 → fail 400) を
+	// ユーザーに見える形で表示する (NN/G #1 visibility of system status)。
+	// startErrorAlreadyUsed は server (subscription +page.server.ts) が fail body に入れ、
+	// startErrorFallback は client (TrialBanner) が getActionErrorDisplay の fallback に使う。
+	startErrorAlreadyUsed: `${ACTION_LABELS.freeTrial}はすでに使用済みです`,
+	startErrorFallback: `${ACTION_LABELS.freeTrial}を開始できませんでした。時間をおいて再度お試しください。`,
 	bannerTitleExpired: `${ACTION_LABELS.freeTrial}が終了しました`,
 	bannerDescExpired: `${ACTION_LABELS.upgrade}で全機能をご利用いただけます。`,
 	bannerDescExpiredWithArchive: `一部のデータが制限されています。${ACTION_LABELS.upgrade}ですべて復元できます。`,

--- a/src/lib/features/admin/components/TrialBanner.svelte
+++ b/src/lib/features/admin/components/TrialBanner.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
+import { getActionErrorDisplay } from '$lib/domain/errors';
 import { TRIAL_LABELS } from '$lib/domain/labels';
 
 interface Props {
@@ -27,6 +28,9 @@ const canStartTrial = $derived(planTier === 'free' && !trialUsed && !isTrialActi
 const isUrgent = $derived(daysRemaining <= 1);
 
 let submitting = $state(false);
+// #2941 項目 2: startTrial の fail(400) (trialUsed=true 再押下等) をユーザーに見える形で
+// 表示する (NN/G #1 visibility of system status)。getActionErrorDisplay (#2913) 経路。
+let startError = $state('');
 </script>
 
 {#if isTrialActive}
@@ -66,10 +70,17 @@ let submitting = $state(false);
 			action="/admin/subscription?/startTrial"
 			use:enhance={() => {
 				submitting = true;
+				startError = '';
 				return async ({ result, update }) => {
 					await update({ reset: false });
 					if (result.type === 'success') {
 						await invalidateAll();
+					} else if (result.type === 'failure') {
+						// #2941 項目 2: fail(400) をユーザーに見える形で表示 (NN/G #1)
+						startError = getActionErrorDisplay(
+							result.data?.error,
+							TRIAL_LABELS.startErrorFallback,
+						).message;
 					}
 					submitting = false;
 				};
@@ -84,6 +95,11 @@ let submitting = $state(false);
 				{submitting ? TRIAL_LABELS.bannerCtaSubmitting : TRIAL_LABELS.bannerCtaStart}
 			</button>
 		</form>
+		{#if startError}
+			<p class="trial-error" role="alert" data-testid="trial-banner-start-error">
+				{startError}
+			</p>
+		{/if}
 	</div>
 {:else if isTrialExpired}
 	<div class="trial-banner expired" data-testid="trial-banner-expired">
@@ -121,6 +137,17 @@ let submitting = $state(false);
 	.trial-banner.not-started {
 		border-color: var(--color-border-trial);
 		background: var(--gradient-surface-trial);
+		/* #2941: wrap so the startError row spans full width */
+		flex-wrap: wrap;
+	}
+
+	/* #2941 item 2: visible error feedback for startTrial failure (NN/G #1) */
+	.trial-error {
+		flex-basis: 100%;
+		margin: 4px 0 0;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--color-feedback-error-text);
 	}
 
 	.trial-banner.expired {

--- a/src/lib/server/db/dynamodb/trial-history-repo.ts
+++ b/src/lib/server/db/dynamodb/trial-history-repo.ts
@@ -19,9 +19,10 @@
 //   → findActiveTrials() は tenantId を受けない全 tenant 横断 + 日次 cron の低頻度経路のため、
 //     Scan + FilterExpression(begins_with(SK,'HIST#') AND endDate >= today) で対応
 //     (cancellation-reason-repo と同じ Pre-PMF 方針、ADR-0010 — GSI 追加は過剰防衛)。
-//   → updateConversion(id) は tenantId が不明なため tenant 横断 Scan + id filter で PK/SK を解決して
-//     Update する (message-repo.markShown / stamp-card-repo の id 解決と同パターン、Stripe webhook
-//     経由の稀な経路、#2842 教訓で Scan は Limit なしページング)。
+//   → updateConversion(id, tenantId) は trialHistoryKey(id, tenantId) で PK/SK が確定するため
+//     直接 Update する (#2941 項目 1: 旧 scanKeyById の tenant 横断 Scan + id filter は trial counter
+//     が tenant 別採番で id 衝突し cross-tenant 上書きの余地があったため撤去。tenantId は
+//     interface で必須化し、不在時は ConditionExpression で no-op)。
 //
 // 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/trial-history-repo.ts (SSOT)
 
@@ -141,21 +142,34 @@ export async function insert(input: InsertTrialHistoryInput): Promise<void> {
 // updateConversion — トライアル後のコンバージョン情報を記録 (Stripe 本契約移行時)
 // ============================================================
 
-/** トライアル後のコンバージョン情報を記録（Stripe 本契約移行時に呼ぶ、id のみ受ける稀な経路） */
+/**
+ * トライアル後のコンバージョン情報を記録（Stripe 本契約移行時に呼ぶ稀な経路）。
+ *
+ * #2941 項目 1: id + tenantId で trialHistoryKey が一意に確定するため直接 Update する。
+ * 旧実装の scanKeyById (tenant 横断 Scan + id filter) は trial counter が tenant 別採番で
+ * id が tenant 間衝突するため、cross-tenant の課金情報上書き (IDOR 形状) の余地があった。
+ * tenant 検証は KeyCondition 相当 (exact Key) に内包され、構造的に他 tenant へ届かない。
+ */
 export async function updateConversion(input: UpdateTrialConversionInput): Promise<void> {
-	const key = await scanKeyById(input.id);
-	if (!key) return; // 該当 id 不在は no-op (SQLite UPDATE ... WHERE id = ? が 0 row と等価)
-	await getDocClient().send(
-		new UpdateCommand({
-			TableName: TABLE_NAME,
-			Key: { PK: key.PK, SK: key.SK },
-			UpdateExpression: 'SET stripeSubscriptionId = :sub, upgradeReason = :reason',
-			ExpressionAttributeValues: {
-				':sub': input.stripeSubscriptionId,
-				':reason': input.upgradeReason,
-			},
-		}),
-	);
+	try {
+		await getDocClient().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: trialHistoryKey(input.id, input.tenantId),
+				UpdateExpression: 'SET stripeSubscriptionId = :sub, upgradeReason = :reason',
+				ExpressionAttributeValues: {
+					':sub': input.stripeSubscriptionId,
+					':reason': input.upgradeReason,
+				},
+				// 不在 key への UpdateItem は item を新規作成してしまうため、既存時のみ更新する。
+				ConditionExpression: 'attribute_exists(PK)',
+			}),
+		);
+	} catch (e) {
+		// 該当 record 不在は no-op (SQLite UPDATE ... WHERE id AND tenant_id が 0 row と等価)。
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return;
+		throw e;
+	}
 }
 
 // ============================================================
@@ -166,36 +180,4 @@ export async function deleteByTenantId(tenantId: string): Promise<void> {
 	const { deleteItemsByExactPk } = await import('./bulk-delete');
 	// tenant partition (PK=T#<tenant>#TRIAL) は trial history 専用のため exact PK 削除で完結。
 	await deleteItemsByExactPk(trialHistoryTenantPK(tenantId));
-}
-
-// ============================================================
-// 内部ヘルパ
-// ============================================================
-
-/**
- * updateConversion 用に、historyId に一致する item の PK/SK を tenant 横断 Scan で解決する。
- * conversion は id のみ受け tenantId が不明なため tenant 配下を走査する (Stripe webhook 経由の
- * 稀な経路)。#2842 教訓: Scan の Limit は filter 前評価のため付けず ExclusiveStartKey で全ページ走査。
- */
-async function scanKeyById(historyId: number): Promise<{ PK: string; SK: string } | undefined> {
-	const doc = getDocClient();
-	let lastKey: Record<string, unknown> | undefined;
-	do {
-		const result = await doc.send(
-			new ScanCommand({
-				TableName: TABLE_NAME,
-				FilterExpression: 'begins_with(SK, :prefix) AND id = :id',
-				ExpressionAttributeValues: {
-					':prefix': PREFIX,
-					':id': historyId,
-				},
-				ProjectionExpression: 'PK, SK',
-				ExclusiveStartKey: lastKey,
-			}),
-		);
-		const item = result.Items?.[0];
-		if (item) return { PK: item.PK as string, SK: item.SK as string };
-		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
-	} while (lastKey);
-	return undefined;
 }

--- a/src/lib/server/db/interfaces/trial-history-repo.interface.ts
+++ b/src/lib/server/db/interfaces/trial-history-repo.interface.ts
@@ -24,6 +24,13 @@ export interface InsertTrialHistoryInput {
 
 export interface UpdateTrialConversionInput {
 	id: number;
+	/**
+	 * #2941 項目 1: trial counter は tenant 別採番のため id は tenant 間で衝突する。
+	 * id 単独解決 (旧 DynamoDB scanKeyById) は cross-tenant の課金情報上書き (IDOR 形状、
+	 * #2845 同クラス) の余地があるため、呼び出し元 (将来の Stripe webhook ハンドラ) は
+	 * 必ず tenant 解決済みの tenantId を渡し、両実装とも tenant scope で record を特定する。
+	 */
+	tenantId: string;
 	stripeSubscriptionId: string;
 	upgradeReason: 'auto' | 'manual' | 'email_cta';
 }

--- a/src/lib/server/db/sqlite/trial-history-repo.ts
+++ b/src/lib/server/db/sqlite/trial-history-repo.ts
@@ -1,7 +1,7 @@
 // src/lib/server/db/sqlite/trial-history-repo.ts
 // SQLite implementation of ITrialHistoryRepo (#314, #769)
 
-import { desc, eq, gte } from 'drizzle-orm';
+import { and, desc, eq, gte } from 'drizzle-orm';
 import { db } from '../client';
 import type {
 	InsertTrialHistoryInput,
@@ -38,7 +38,11 @@ export async function insert(input: InsertTrialHistoryInput): Promise<void> {
 	});
 }
 
-/** トライアル後のコンバージョン情報を記録（Stripe 本契約移行時に呼ぶ） */
+/**
+ * トライアル後のコンバージョン情報を記録（Stripe 本契約移行時に呼ぶ）。
+ * #2941 項目 1: DynamoDB 実装 (tenant 別採番) との等価性 + cross-tenant 上書き防御のため、
+ * id 単独でなく tenant scope で record を特定する。
+ */
 export async function updateConversion(input: UpdateTrialConversionInput): Promise<void> {
 	await db
 		.update(trialHistory)
@@ -46,7 +50,7 @@ export async function updateConversion(input: UpdateTrialConversionInput): Promi
 			stripeSubscriptionId: input.stripeSubscriptionId,
 			upgradeReason: input.upgradeReason,
 		})
-		.where(eq(trialHistory.id, input.id));
+		.where(and(eq(trialHistory.id, input.id), eq(trialHistory.tenantId, input.tenantId)));
 }
 
 /** テナントの全トライアル履歴を削除 */

--- a/src/routes/(parent)/admin/subscription/+page.server.ts
+++ b/src/routes/(parent)/admin/subscription/+page.server.ts
@@ -8,6 +8,7 @@
 import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { TRIAL_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getActivities } from '$lib/server/services/activity-service';
 import { isPinConfigured } from '$lib/server/services/auth-service';
@@ -92,7 +93,9 @@ export const actions: Actions = {
 		});
 
 		if (!started) {
-			return fail(400, { error: 'トライアルはすでに使用済みです' });
+			// #2941 項目 2: メッセージは TRIAL_LABELS SSOT 経由。TrialBanner が
+			// getActionErrorDisplay でユーザーに見える形で表示する (NN/G #1)
+			return fail(400, { error: TRIAL_LABELS.startErrorAlreadyUsed });
 		}
 
 		return { success: true };

--- a/tests/e2e/trial-flow.spec.ts
+++ b/tests/e2e/trial-flow.spec.ts
@@ -147,3 +147,77 @@ test.describe('#752 トライアルフロー — trial-expired ユーザー', ()
 		await expect(card).toHaveAttribute('data-plan-tier', 'free');
 	});
 });
+
+// ============================================================
+// #2941 項目 2: negative path — trialUsed=true 再押下で fail(400) が
+// ユーザーに見えるエラーメッセージとして表示される (NN/G #1)
+// ============================================================
+test.describe('#2941 トライアル開始 negative path — 使用済み tenant の再押下', () => {
+	test.use({ storageState: 'playwright/.auth/free.json' });
+
+	// 本 describe は dev-tenant-free に使用済み trial を直接 seed するため、
+	// 終了後にクリーンアップして plan-free.spec.ts 等への副作用を防ぐ
+	// (上の free describe と同パターン)
+	test.afterAll(async () => {
+		const Database = (await import('better-sqlite3')).default;
+		const dbPath = path.resolve('data/ganbari-quest.db');
+		const db = new Database(dbPath);
+		try {
+			const result = db
+				.prepare("DELETE FROM trial_history WHERE tenant_id = 'dev-tenant-free'")
+				.run();
+			if (result.changes > 0) {
+				console.log(
+					`[trial-negative cleanup] Removed ${result.changes} trial record(s) for dev-tenant-free.`,
+				);
+			}
+		} finally {
+			db.close();
+		}
+	});
+
+	test('stale 画面から「開始」再押下 → 400 エラーがユーザーに見える形で表示される', async ({
+		page,
+	}) => {
+		// 1. trial 未使用状態で /admin を開く（「開始」ボタンが見える stale 画面を作る）
+		await page.goto('/admin', { waitUntil: 'commit', timeout: 30_000 });
+		await expect(page.getByTestId('trial-banner-start-button')).toBeVisible({ timeout: 30_000 });
+		// #702 hydration marker: use:enhance バインド前に click すると native form POST に
+		// fallback して /admin/subscription へ全画面遷移してしまうため、hydration 完了を待つ
+		await page.waitForFunction(() => window.__APP_HYDRATED__ === true, undefined, {
+			timeout: 30_000,
+		});
+
+		// 2. 「別タブで既に開始済み」の状況を再現: DB に使用済み trial を直接 seed
+		//    (global-setup.ts の dev-tenant-trial-expired seed と同手法)
+		const Database = (await import('better-sqlite3')).default;
+		const db = new Database(path.resolve('data/ganbari-quest.db'));
+		try {
+			const pastEnd = new Date();
+			pastEnd.setDate(pastEnd.getDate() - 3);
+			const pastStart = new Date();
+			pastStart.setDate(pastStart.getDate() - 10);
+			db.prepare(
+				'INSERT INTO trial_history (tenant_id, start_date, end_date, tier, source) VALUES (?, ?, ?, ?, ?)',
+			).run(
+				'dev-tenant-free',
+				pastStart.toISOString().split('T')[0],
+				pastEnd.toISOString().split('T')[0],
+				'standard',
+				'user_initiated',
+			);
+		} finally {
+			db.close();
+		}
+
+		// 3. stale 画面の「開始」ボタンを再押下 → server action は startTrial=false で fail(400)
+		await page.getByTestId('trial-banner-start-button').click();
+
+		// 4. NN/G #1: 400 が黙殺されず、role=alert のエラーメッセージとして表示される
+		//    (getActionErrorDisplay #2913 経路、TRIAL_LABELS.startErrorAlreadyUsed)
+		const error = page.getByTestId('trial-banner-start-error');
+		await expect(error).toBeVisible({ timeout: 30_000 });
+		await expect(error).toHaveText('無料体験はすでに使用済みです');
+		await expect(error).toHaveAttribute('role', 'alert');
+	});
+});

--- a/tests/unit/db/dynamodb-trial-history-repo.test.ts
+++ b/tests/unit/db/dynamodb-trial-history-repo.test.ts
@@ -243,60 +243,97 @@ describe('findActiveTrials', () => {
 });
 
 // ============================================================
-// updateConversion (Stripe 本契約移行、id 解決経路)
+// updateConversion (Stripe 本契約移行、#2941 項目 1: tenant scope 直接 Update)
 // ============================================================
 
 describe('updateConversion', () => {
-	it('id を Scan で解決し該当 item の conversion 列を SET する', async () => {
-		mockSend
-			.mockResolvedValueOnce({ Items: [{ PK: `T#${TENANT}#TRIAL`, SK: 'HIST#00000007' }] }) // scanKeyById
-			.mockResolvedValueOnce({}); // UpdateCommand
+	it('tenantId + id から確定した PK/SK へ直接 Update する (Scan を発行しない)', async () => {
+		mockSend.mockResolvedValueOnce({}); // UpdateCommand
 
 		const { updateConversion } = await loadRepo();
-		await updateConversion({ id: 7, stripeSubscriptionId: 'sub_abc', upgradeReason: 'auto' });
+		await updateConversion({
+			id: 7,
+			tenantId: TENANT,
+			stripeSubscriptionId: 'sub_abc',
+			upgradeReason: 'auto',
+		});
 
-		expect(mockSend).toHaveBeenCalledTimes(2);
-		const scanCall = mockSend.mock.calls[0]?.[0] as {
-			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
-		};
-		expect(scanCall.input.FilterExpression).toContain('id = :id');
-		expect(scanCall.input.ExpressionAttributeValues?.[':id']).toBe(7);
-		expect(scanCall.input.ExpressionAttributeValues?.[':prefix']).toBe('HIST#');
-
-		const updCall = mockSend.mock.calls[1]?.[0] as {
+		// #2941: 旧 scanKeyById (tenant 横断 Scan) は cross-tenant 上書きの余地があったため撤去。
+		// send は UpdateCommand 1 回のみで、Key が tenant partition に固定されている。
+		expect(mockSend).toHaveBeenCalledTimes(1);
+		const updCall = mockSend.mock.calls[0]?.[0] as {
 			input: {
 				UpdateExpression?: string;
+				ConditionExpression?: string;
 				Key?: Record<string, unknown>;
 				ExpressionAttributeValues?: Record<string, unknown>;
 			};
 		};
+		expect(updCall).toBeInstanceOf(MockUpdateCommand);
+		expect(updCall.input.Key?.PK).toBe(`T#${TENANT}#TRIAL`);
+		expect(updCall.input.Key?.SK).toBe('HIST#00000007');
 		expect(updCall.input.UpdateExpression).toContain('stripeSubscriptionId = :sub');
 		expect(updCall.input.UpdateExpression).toContain('upgradeReason = :reason');
-		expect(updCall.input.Key?.SK).toBe('HIST#00000007');
 		expect(updCall.input.ExpressionAttributeValues?.[':sub']).toBe('sub_abc');
 		expect(updCall.input.ExpressionAttributeValues?.[':reason']).toBe('auto');
+		// 不在 key への upsert (item 新規作成) を防ぐ
+		expect(updCall.input.ConditionExpression).toBe('attribute_exists(PK)');
 	});
 
-	it('該当 id 不在のとき Update を呼ばない (no-op、SQLite 0 row UPDATE と等価)', async () => {
-		mockSend.mockResolvedValueOnce({ Items: [] }); // 不在
+	it('該当 record 不在 (ConditionalCheckFailedException) は no-op で握りつぶす (SQLite 0 row UPDATE と等価)', async () => {
+		const condErr = new Error('The conditional request failed');
+		condErr.name = 'ConditionalCheckFailedException';
+		mockSend.mockRejectedValueOnce(condErr);
+
 		const { updateConversion } = await loadRepo();
-		await updateConversion({ id: 99, stripeSubscriptionId: 'sub_x', upgradeReason: 'manual' });
-		expect(mockSend).toHaveBeenCalledTimes(1); // Scan のみ
+		await expect(
+			updateConversion({
+				id: 99,
+				tenantId: TENANT,
+				stripeSubscriptionId: 'sub_x',
+				upgradeReason: 'manual',
+			}),
+		).resolves.toBeUndefined();
+		expect(mockSend).toHaveBeenCalledTimes(1);
 	});
 
-	it('#2842: 対象 id が先頭ページに無くても LastEvaluatedKey でページングして見つける', async () => {
-		mockSend
-			.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: { PK: 'c', SK: 'c' } })
-			.mockResolvedValueOnce({ Items: [{ PK: `T#${TENANT}#TRIAL`, SK: 'HIST#00000003' }] })
-			.mockResolvedValueOnce({}); // Update
+	it('ConditionalCheckFailedException 以外のエラーは rethrow する (silent skip 禁止)', async () => {
+		const otherErr = new Error('ProvisionedThroughputExceededException');
+		otherErr.name = 'ProvisionedThroughputExceededException';
+		mockSend.mockRejectedValueOnce(otherErr);
+
 		const { updateConversion } = await loadRepo();
-		await updateConversion({ id: 3, stripeSubscriptionId: 'sub_y', upgradeReason: 'email_cta' });
-		expect(mockSend).toHaveBeenCalledTimes(3);
-		const secondScan = mockSend.mock.calls[1]?.[0] as {
-			input: { ExclusiveStartKey?: Record<string, unknown>; Limit?: number };
-		};
-		expect(secondScan.input.ExclusiveStartKey).toEqual({ PK: 'c', SK: 'c' });
-		expect(secondScan.input.Limit).toBeUndefined();
+		await expect(
+			updateConversion({
+				id: 1,
+				tenantId: TENANT,
+				stripeSubscriptionId: 'sub_y',
+				upgradeReason: 'email_cta',
+			}),
+		).rejects.toThrow('ProvisionedThroughputExceededException');
+	});
+
+	it('#2941: 別 tenant を指定すると別 partition の Key になる (cross-tenant 上書き構造防止)', async () => {
+		mockSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+		const { updateConversion } = await loadRepo();
+		await updateConversion({
+			id: 7,
+			tenantId: 'tenant-A',
+			stripeSubscriptionId: 'sub_a',
+			upgradeReason: 'auto',
+		});
+		await updateConversion({
+			id: 7,
+			tenantId: 'tenant-B',
+			stripeSubscriptionId: 'sub_b',
+			upgradeReason: 'auto',
+		});
+		const first = mockSend.mock.calls[0]?.[0] as { input: { Key?: Record<string, unknown> } };
+		const second = mockSend.mock.calls[1]?.[0] as { input: { Key?: Record<string, unknown> } };
+		// 同一 id でも tenant が異なれば partition が分離され、互いの record に届かない
+		expect(first.input.Key?.PK).toBe('T#tenant-A#TRIAL');
+		expect(second.input.Key?.PK).toBe('T#tenant-B#TRIAL');
+		expect(first.input.Key?.SK).toBe(second.input.Key?.SK);
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ システム全体

**解決する課題**: PR #2939 (trial-history-repo stub 本実装) の QM 申し送り 3 件のうち、(1) `updateConversion` の tenant 検証欠落 (cross-tenant 課金情報上書きの IDOR 形状、dormant だが Stripe webhook 接続時に顕在化) と、(2) トライアル使用済みユーザーが開始ボタンを再押下したとき fail(400) が画面に一切表示されず「押しても何も起きない」体験 (NN/G #1 違反) になっていた問題。

**期待される効果**: (1) 将来の Stripe webhook 接続時に検証漏れが構造的に起こらない (interface が tenantId を強制)。(2) 再押下したユーザーに「無料体験はすでに使用済みです」が role=alert で見える形で表示され、無反応による再クリック連打・離脱を防ぐ。

## 関連 Issue

related #2941

（`closes` を使わない理由: Issue の項目 3「stub 障害期間の被害ユーザー対応」は PO 判断事項のため、本 PR では [判断材料を Issue コメントに整理](https://github.com/Takenori-Kusaka/ganbari-quest/issues/2941#issuecomment-4685769171) するまでを実施。項目 1 / 2 は本 PR で完了、Issue close は PO 判断記録後に行う）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 項目 1: dormant API (`updateConversion`→`scanKeyById`) への防御方針を記録 | コード diff + `npx vitest run tests/unit/db/dynamodb-trial-history-repo.test.ts` | [x] HEAD `6b98b2388` / **記録に留めず防御を実装** (判断根拠は下記「レビュー依頼事項」): `trial-history-repo.interface.ts:25-35` で `tenantId` 必須化 + `dynamodb/trial-history-repo.ts:145-173` で scanKeyById (tenant 横断 Scan) を撤去し exact Key Update + `attribute_exists(PK)` 化 + `sqlite/trial-history-repo.ts:47-60` を AND 条件化。17 passed (cross-tenant partition 分離 assert 含む) |
| AC2 | 項目 2: negative path E2E 1 ケース追加 (400 がユーザーに見える形で表示) | `npx playwright test --config playwright.cognito-dev.config.ts trial-flow` | [x] HEAD `6b98b2388` / 13 passed (新規: `tests/e2e/trial-flow.spec.ts:179` trialUsed=true 再押下 → `trial-banner-start-error` visible + 文言完全一致 + role=alert)。表示実装: `TrialBanner.svelte` (getActionErrorDisplay #2913 経路) |
| AC3 | 項目 3: PO 判断記録 | Issue #2941 コメント | 判断材料 (stub 期間 2026-04-04〜2026-06-05 / CloudWatch・DynamoDB 調査クエリ案 / 対応不要・再案内の中立併記) を [issuecomment-4685769171](https://github.com/Takenori-Kusaka/ganbari-quest/issues/2941#issuecomment-4685769171) に整理済み。判断と記録は PO が実施するため本 PR scope は材料整理まで |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — repo 実装 + interface (テーブル定義変更なし)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`) — `(parent)/admin/subscription/+page.server.ts` (fail メッセージを labels SSOT 化)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`) — `TrialBanner.svelte` (エラー表示追加)
- [x] ドメインモデル (`$lib/domain/`) — `labels.ts` (TRIAL_LABELS 2 件追加)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- 親管理画面の TrialBanner (全 admin route 上部)。表示変化は「startTrial 失敗時のみ」エラー行が追加される。成功経路・active/expired バナーは無変更
- `updateConversion` は app/service 呼び出し元ゼロ (dormant) のため実行時挙動の変化なし

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/db/dynamodb-trial-history-repo.test.ts`: updateConversion を tenant scope 直接 Update 仕様に書換 (Scan 不発行 / attribute_exists / ConditionalCheckFailedException no-op / 非該当エラー rethrow / 別 tenant partition 分離の 4 ケース)
  - `tests/e2e/trial-flow.spec.ts`: #2941 negative path describe 追加 (stale 画面再押下 → role=alert エラー表示、DB seed + afterAll 復元で他 spec への副作用なし)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: SQLite + DynamoDB 両実装を同時更新 (id + tenantId の AND 条件で機能等価)。`node scripts/check-dynamodb-stub.mjs` PASS
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (本 Issue は priority:critical ラベルなしの type:fix)

## スクリーンショット / ビジュアルデモ

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | N/A (下記理由) | ![before-pc](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2941/trial-banner-start-error-2941-steps/01-2941-trial-banner-not-started.png) |
| **修正後** | N/A (下記理由) | ![after-pc](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2941/trial-banner-start-error-2941-steps/02-2941-trial-banner-start-error-visible.png) |

フロースタンプシート (再押下 → エラー表示の 2 状態):

![trial-banner-start-error-flow](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-2941/trial-banner-start-error-2941-flow.webp)

- **DOM HTML スナップショット** (#1747、エラー表示状態と同一 page から取得): [trial-banner-start-error-2941-flow.dom.html](https://github.com/Takenori-Kusaka/ganbari-quest/blob/screenshots/pr-2941/trial-banner-start-error-2941-flow.dom.html)
- モバイル N/A の理由: 本変更の画面差分は既存 responsive バナー内に `flex-basis:100%` の 1 行 (テキストのみ) を追加するもので、breakpoint 固有のレイアウト分岐を持たない。撮影 flow: `scripts/capture-specs/flows/trial-banner-start-error-2941.mjs` (`npm run dev:cognito` 環境 #1026、free storageState)
- 撮影後の目視確認済み: エラー行がバナー内全幅で赤字表示、ボタン・バッジとの重なりなし、DESIGN.md §9 禁忌 6 点違反なし (semantic token `--color-feedback-error-text` 使用 / `<style>` 増分 +10 行)

**インタラクティブ状態**: エラー状態の SS が上記「修正後」そのもの。disabled 状態 (送信中) は既存実装のまま無変更のため N/A。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: interface (`ITrialHistoryRepo`) 経由の依存性逆転を維持。`UpdateTrialConversionInput` の契約変更は 3 実装 (sqlite / dynamodb / demo) 全てに同時適用
- [x] **DRY**: エラー表示は既存共通 helper `getActionErrorDisplay` (#2913) を再利用、メッセージは TRIAL_LABELS SSOT。`grep updateConversion` で全呼び出し元 (0 件 = dormant) を確認済み
- [x] **YAGNI**: 防御は exact Key + ConditionExpression のみ。GSI 追加等の過剰設計なし
- [x] **Security（OSS 公開前提）**: IDOR 形状 (CWE-639 同類) の構造的封鎖が本 PR の主目的。tenant scope は KeyCondition 相当 (exact PK) に内包され filter 後検証に依存しない
- [x] **アクセシビリティ**: エラーは `role="alert"` でスクリーンリーダーに通知。色のみに依存しない (テキストで内容を伝達)
- [x] **パフォーマンス**: 旧 scanKeyById の全 table Scan (O(table)) → exact Key Update (O(1)) に改善。N+1 なし

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照）:

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [x] **labels SSOT** (ADR-0009/0045): 新規文言 2 件 (`startErrorAlreadyUsed` / `startErrorFallback`) を `labels.ts` TRIAL_LABELS に追加し `${ACTION_LABELS.freeTrial}` atom 参照で組立。server (`+page.server.ts`) の旧リテラル `'トライアルはすでに使用済みです'` も同 SSOT に置換。`check-no-plan-literals` / `check-hardcoded-strings` / `generate-lp-labels --check` PASS
- [x] **設計書同期** (ADR-0001): `docs/design/08-データベース設計書.md` の trial_history DynamoDB key 設計節を更新 (`updateConversion(id)` の旧 tenant 横断 Scan 記述 → tenant scope exact Key Update 仕様に同期)。テーブル・カラム定義の変更なし / API エンドポイント追加なし / UI は既存バナー内のエラー行追加で `06-UI設計書.md` の新画面・新オーバーレイ定義に該当なし
- [x] **並行 PR overlap** (#1200): 並行作業が触る `special-reward-repo.ts` / `reward-redemption-repo.ts` には触れていない (本 PR は trial-history 系 + TrialBanner のみ)。`git diff --name-only origin/develop` で確認済み
- [ ] N/A — 並行実装の影響範囲外

**SQLite ↔ DynamoDB 並行実装** (tests/CLAUDE.md): `updateConversion` の tenant scope 化を両実装で同時適用し、demo 実装は型追従 (no-op のまま)。

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A (LP / pricing 文言変更なし)

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

（`UpdateTrialConversionInput` への `tenantId` 必須追加は型上は breaking だが、`updateConversion` の呼び出し元は app/service 全体で 0 件 (dormant API) のため実行時影響なし。`grep -rn "updateConversion" src/` で確認済み）

**レビュー依頼事項・QA**:

- **AC1 を「記録」でなく「実装」とした判断根拠**: Issue の対応案は「接続 PR の AC に含める記録」だったが、(i) tenantId 引数追加が小 diff で済む (interface +1 field、dynamodb は Scan helper 28 行削除で net 負 diff、sqlite は WHERE 1 条件追加)、(ii) 呼び出し元 0 件の今が interface 変更の最安タイミング、(iii) 記録のみだと接続時に忘れられるリスク (#2845 と同クラスの IDOR 形状) — の 3 点から、防御の前倒し実装が「接続 PR の AC に転記」より確実と判断した。将来の webhook 接続実装者は型エラーで tenantId 解決を強制される
- E2E の「stale 画面」再現は DB 直接 seed (global-setup の trial-expired seed と同手法)。`use:enhance` バインド前 click が native POST に fallback する flake を `__APP_HYDRATED__` marker (#702) で吸収している点を確認いただきたい

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（項目 3 は PO 判断事項のため材料整理までが本 PR の scope、related 参照で Issue は open 維持）
- [x] Phase 分割した場合: N/A (分割なし、Issue の 3 項目を 1 PR + Issue コメントで消化)
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) 環境 (cognito-dev port 5174 + free storageState) で撮影した SS を添付

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
