### PR TITLE
infra: #2947 [Phase A/A-5] dependabot-auto-merge.yml の lane 判定共通化 + bot exempt の lane SSOT 整合

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,16 @@
 name: Dependabot auto-merge
 
+# bot lane の SSOT は scripts/pr-lane.mjs の BOT_ACTORS (#2947 / 親 #2942 / EPIC #2861)。
+# 「bot とは誰か」(= dependabot lane の actor 集合) の正準定義は BOT_ACTORS = ['dependabot[bot]',
+# 'renovate[bot]'] に一本化されており、gate workflow の exempt (pr-template-gate.yml 等の
+# `github.actor != 'dependabot[bot]'`) も同 SSOT / classifyLane の dependabot lane 判定を参照する。
+#
+# ただし下記 auto-merge の発火条件は **dependabot[bot] のみ** で renovate を含まない (現行仕様、
+# #2947 no-go「auto-merge を renovate に拡大しない」)。BOT_ACTORS は「lane = dependabot として
+# exempt / 軽量扱いする actor」の定義であり「auto-merge 対象 actor」とは別概念のため、本 workflow
+# は意図的に actor == 'dependabot[bot]' で即絞る軽量な actor 判定を維持する (composite action
+# actions/pr-lane を挟むと全 PR で checkout+node が走りオーバーヘッドが増えるため不採用、#2947 選択肢 B 却下)。
+
 on: pull_request
 
 permissions:
@@ -9,6 +20,8 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    # auto-merge 対象は dependabot[bot] のみ (renovate は対象外、上記コメント参照)。
+    # bot lane SSOT = scripts/pr-lane.mjs の BOT_ACTORS。
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata

--- a/scripts/pr-lane.mjs
+++ b/scripts/pr-lane.mjs
@@ -52,7 +52,25 @@
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const DEPENDABOT_ACTORS = new Set(['dependabot[bot]', 'renovate[bot]']);
+/**
+ * `dependabot` lane に分類される bot actor の集合 (SSOT、#2947 AC1)。
+ *
+ * 「bot とは誰か」をこの 1 箇所だけで定義する。auto-merge (dependabot-auto-merge.yml) や
+ * gate workflow の exempt (`github.actor != 'dependabot[bot]'` 等の inline 重複) は、
+ * この集合 / `classifyLane` の `dependabot` lane 判定を SSOT として参照し、判定基準の
+ * 二重実装を解消する。新 bot (別の自動更新 bot 等) を追加する際は本配列を 1 行修正する
+ * だけで全 gate の bot 扱いに伝播する (terms.ts atom / ADR-0042 3 層トークンと同型の SSOT)。
+ *
+ * 注: `dependabot-auto-merge.yml` の auto-merge 発火条件は **dependabot[bot] のみ** で
+ * renovate を含まない (現行仕様、#2947 no-go「auto-merge を renovate に拡大しない」)。
+ * 本集合は「lane = dependabot として exempt / 軽量扱いする actor」の定義であり、
+ * 「auto-merge 対象 actor」とは別概念。両者を混同しないこと。
+ *
+ * @type {readonly string[]}
+ */
+export const BOT_ACTORS = Object.freeze(['dependabot[bot]', 'renovate[bot]']);
+
+const BOT_ACTOR_SET = new Set(BOT_ACTORS);
 
 /**
  * PR lane 判定の純粋関数 (unit test 対象、AC1)。副作用なし (AC6)。
@@ -69,8 +87,8 @@ export function classifyLane({ baseRef, headRef, actor }) {
 	const head = (headRef ?? '').trim();
 	const who = (actor ?? '').trim();
 
-	// 1. bot は base/head より優先 (Dependabot exempt を lane の 1 種として吸収)
-	if (DEPENDABOT_ACTORS.has(who)) return 'dependabot';
+	// 1. bot は base/head より優先 (Dependabot exempt を lane の 1 種として吸収、BOT_ACTORS SSOT)
+	if (BOT_ACTOR_SET.has(who)) return 'dependabot';
 	// 2. develop → main = 統合 PR (重量レーン)
 	if (head === 'develop' && base === 'main') return 'integration';
 	// 3. fix/* → main = hotfix (ADR-0002 重量レーン)

--- a/tests/unit/github/pr-lane.test.ts
+++ b/tests/unit/github/pr-lane.test.ts
@@ -2,7 +2,7 @@
 // 決定的 4 lane 分類 (feature / integration / hotfix / dependabot) の境界を網羅する unit test。
 // develop 二層ブランチ戦略 (docs/sessions/branch-strategy.md §3〜§5) の CI gate 側 SSOT。
 import { describe, expect, it } from 'vitest';
-import { classifyLane, parseArgs } from '../../../scripts/pr-lane.mjs';
+import { BOT_ACTORS, classifyLane, parseArgs } from '../../../scripts/pr-lane.mjs';
 
 describe('classifyLane (#2943 AC1/AC2)', () => {
 	// --- AC2 で明示された 6 境界条件 ---
@@ -114,6 +114,22 @@ describe('classifyLane (#2943 AC1/AC2)', () => {
 		for (const c of cases) {
 			expect(lanes.has(classifyLane(c))).toBe(true);
 		}
+	});
+});
+
+describe('BOT_ACTORS SSOT (#2947 AC1)', () => {
+	it('bot lane の actor 集合を named export する (dependabot[bot] / renovate[bot])', () => {
+		expect(BOT_ACTORS).toEqual(['dependabot[bot]', 'renovate[bot]']);
+	});
+
+	it('BOT_ACTORS の各 actor は classifyLane で dependabot lane に分類される (SSOT 整合)', () => {
+		for (const actor of BOT_ACTORS) {
+			expect(classifyLane({ baseRef: 'develop', headRef: 'feat/x', actor })).toBe('dependabot');
+		}
+	});
+
+	it('BOT_ACTORS は freeze されており実行時改変できない (SSOT 不変条件)', () => {
+		expect(Object.isFrozen(BOT_ACTORS)).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

Dependabot の PR 種別判定が現状 2 系統に分裂している ((1) `dependabot-auto-merge.yml` の `if: github.actor == 'dependabot[bot]'`、(2) gate workflow 群の `github.actor != 'dependabot[bot]'` inline 重複) ことで、「bot とは誰か」の定義が SSOT 化されておらず、新 bot 追加・renovate の扱い差異がドリフトする。本 PR は A-1 (`scripts/pr-lane.mjs`) の `dependabot` lane を SSOT として bot actor 集合を `BOT_ACTORS` named export に集約し、auto-merge と gate exempt が同一の lane SSOT を参照できる土台を整える (開発フロー基盤、間接的に本番品質)。

## 関連 Issue

closes #2947

親統括 #2942 (Phase A) / EPIC #2861 / blocked_by #2943 (A-1、merged #2973) / blocks Phase B #2871 / related #1808 #2430 (Dependabot exempt 二重防御)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `scripts/pr-lane.mjs` が `BOT_ACTORS = ['dependabot[bot]', 'renovate[bot]']` を named export し `classifyLane` が参照 | unit test `tests/unit/github/pr-lane.test.ts` §「BOT_ACTORS SSOT (#2947 AC1)」3 件 | PASS (22 passed)。`BOT_ACTORS` export 値 / dependabot lane 整合 / `Object.isFrozen` を assert |
| AC2 | `dependabot-auto-merge.yml` に「bot lane SSOT = `BOT_ACTORS`」のコメント参照追加 + auto-merge 発火条件 (dependabot のみ) 不変 | `git diff origin/develop -- .github/workflows/dependabot-auto-merge.yml` 目視 + executable `if:` actor 行数 develop=1 / 本 branch=1 | PASS。コメントのみ追加、`if: github.actor == 'dependabot[bot]'` の判定式は不変 |
| AC3 | Dependabot semver-minor/patch PR で auto-merge が成立 (lane 化後も gate が dependabot lane で skip 相当 success → required check 緑 → auto-merge) の経路が壊れていない | A-2〜A-4 の gate lane 化後の回帰確認 + 本 PR CLI fixture で lane=dependabot を確認 | 本 PR で fixture 確認済 (下記検証ログ)。gate 緑→auto-merge の実走確認は A-2〜A-4 merge 後に成立 (lane SSOT 整合のみ本 PR scope) |
| AC4 | gate 6 本 + `dependabot-auto-merge.yml` で `dependabot[bot]`/`renovate[bot]` の actor 判定が**新規 inline 重複追加されていない** | `MSYS_NO_PATHCONV=1 git show origin/develop:...` vs 本 branch の executable `if: ... github.actor` 行数比較 | PASS。develop=1 行 / 本 branch=1 行 (増加なし)。追加したのは SSOT 参照コメントのみで判定式は非増 |
| AC5 | 統合 PR の bot/GITHUB_TOKEN 自動発行時の gate 非発火リスク (release-please #922) が Phase B (#2871) の設計入力として記録 | Issue #2947 本文 no-gos に記載済 + 本 PR から #2871 へ comment 追記 | PASS。#2871 へ design-input comment 投稿 (PR 番号付き) |

## 変更タイプ

- [x] infra (CI/CD・workflow・SSOT 集約)

## 影響範囲・変更コンポーネント

- `scripts/pr-lane.mjs` — `DEPENDABOT_ACTORS` (module-private const) を `BOT_ACTORS` named export + `BOT_ACTOR_SET` に再構成。`classifyLane` の挙動は不変 (4 lane 決定的分類)。
- `.github/workflows/dependabot-auto-merge.yml` — bot lane SSOT 参照コメント追加。auto-merge 発火条件 (`if: github.actor == 'dependabot[bot]'`) は不変。
- `tests/unit/github/pr-lane.test.ts` — `BOT_ACTORS` SSOT 整合テスト 3 件追加。

**ファイル所有 (A-2/A-3/A-4 並行中)**: 本 PR は触ってよい 4 範囲 (`dependabot-auto-merge.yml` / 対応 test / `pr-lane.mjs` (A-1 成果物の AC1 named export 化) / .cspell) のみ変更。gate 6 本 (pr-template-gate / check-pr-template-sections-sync / pr-ac-verification-check / pr-merge-gate / pr-quality-gate / check-pr-screenshot) は**未変更** — 各 gate の bot exempt は A-2〜A-4 の lane-aware 化で `BOT_ACTORS` / `classifyLane` 経由に吸収される。branch-strategy.md lane 対応表 (A-6) も未変更。

## テスト & 安全装置セルフチェック

- `tests/unit/github/pr-lane.test.ts` 22 件 PASS (既存 19 + 新規 3)。
- biome check (`scripts/pr-lane.mjs` / test): No fixes applied。
- cspell: exit 0 (3 ファイル)。
- CLI fixture (AC3 lane 判定): 下記検証ログ参照。
- assertion 弱体化なし (ADR-0006)。新規テストは export 値 / lane 整合 / freeze を厳密 assert。

### fixture 検証ログ (AC3 dependabot lane)

```
$ node scripts/pr-lane.mjs --base main --head develop --actor 'dependabot[bot]'
dependabot
$ node scripts/pr-lane.mjs --base develop --head 'dependabot/npm_and_yarn/foo' --actor 'dependabot[bot]'
dependabot
$ node scripts/pr-lane.mjs --base develop --head 'renovate/foo' --actor 'renovate[bot]'
dependabot
$ node scripts/pr-lane.mjs --base main --head develop --actor 'Takenori-Kusaka'
integration   # 非 bot は base/head 判定にフォールバック (lane 整合)
```

### AC4 inline 判定非増の証跡

```
$ MSYS_NO_PATHCONV=1 git show "origin/develop:.github/workflows/dependabot-auto-merge.yml" | grep -cE "if:.*github.actor"
1
$ grep -cE "^\s+if:.*github\.actor" .github/workflows/dependabot-auto-merge.yml
1   # executable if: actor 判定行数は develop と同数 (コメント参照は判定式ではない)
```

## スクリーンショット / ビジュアルデモ

N/A (UI 非変更)。本 PR は CI workflow / Node script / unit test のみで `.svelte` / `site/` 変更なし。SS 撮影対象なし。

## コード品質セルフレビュー (#1481)

- `BOT_ACTORS` は `Object.freeze` で実行時改変を防止し SSOT 不変条件を担保。
- 「auto-merge 対象 actor (dependabot のみ)」と「dependabot lane exempt actor 集合 (dependabot+renovate)」が別概念であることを `pr-lane.mjs` / workflow 両方のコメントで明示し、混同を防止。
- composite action (checkout+node) を `dependabot-auto-merge.yml` に挟まず軽量 actor 判定を維持 (#2947 選択肢 B 却下根拠 = 全 PR オーバーヘッド回避、ADR-0010 Pre-PMF)。

## 横展開・影響波及チェック

- A-1 (`scripts/pr-lane.mjs`) の SSOT を参照する後続 gate (A-2〜A-4) は `classifyLane` / `BOT_ACTORS` 経由で bot 判定を共有する。本 PR で `DEPENDABOT_ACTORS` → `BOT_ACTORS` rename したが、A-1 時点では module-private const で外部参照ゼロのため後続への破壊なし (named export 化は純粋な追加)。
- composite action `actions/pr-lane` は `classifyLane` を CLI 経由で呼ぶのみで bot 集合名に非依存のため影響なし。
- A-2/A-3/A-4 所有 gate 6 本は本 PR で未変更。各 lane-aware 化 PR が `BOT_ACTORS` SSOT を吸収する。

## レビュー依頼事項・破壊的変更

破壊的変更なし。auto-merge の実挙動 (dependabot semver-minor/patch のみ auto-merge) は完全不変。`BOT_ACTORS` named export 化は A-1 の module-private const を公開しただけで lane 判定結果は不変 (回帰テスト 22 件で担保)。

## 配布済み env / secret (ADR-0006)

N/A。新規 env / secret の追加なし。`dependabot-auto-merge.yml` は既存の `secrets.GITHUB_TOKEN` のみ使用 (不変)。

## Ready for Review チェックリスト

- [x] `npm run pre-ready -- --pr <num>` 該当 step PASS (biome / vitest / cspell / check-pr-body)
- [x] AC 検証マップを 4 列形式で記入
- [x] 必須 13 セクションを全て記入
- [x] forbidden-terms 0 件 (申し送り語を含まない。AC3/AC5 は本文で完遂条件を明記し、依存関係 (#2942 Phase A / #2871 Phase B) の記録であって作業の先送りではない)
- [x] origin/develop に rebase 済 (本日 deploy 取込)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: CLI fixture + unit test + AC4 非増証跡で動作確認済)

## QM レビュー結果

(QM 記入欄)
