### PR TITLE
fix: #3021 CodeQL js/bad-tag-filter 3 件根治 — PR body コメント検出 regex を robust 化

### DIFF
--- a/scripts/check-ac-verification-map.mjs
+++ b/scripts/check-ac-verification-map.mjs
@@ -82,7 +82,8 @@ function findEmptyRows(rows) {
 			.split('|')
 			.slice(1, -1)
 			.map((c) => c.trim());
-		return cells.some((c) => c === '' || /^<!--.*-->$/.test(c));
+		// js/bad-tag-filter (CodeQL): 改行を含むコメント + `--!>` 終端も検出する
+		return cells.some((c) => c === '' || /^<!--[\s\S]*--!?>$/.test(c));
 	});
 }
 

--- a/scripts/pr-template-gate-checks.mjs
+++ b/scripts/pr-template-gate-checks.mjs
@@ -258,7 +258,7 @@ export function checkIssueReference({ body, labels, template, lane }) {
 		.filter((l) => !l.startsWith(heading))
 		.filter((l) => !/^closes\s+#\s*$/.test(l.trim()))
 		.filter((l) => !/^\s*<!--/.test(l))
-		.filter((l) => !/^\s*-->\s*$/.test(l))
+		.filter((l) => !/^\s*--!?>\s*$/.test(l))
 		.filter((l) => l.trim().length > 0);
 	const meaningfulText = meaningfulLines.join('').replace(/\s/g, '');
 	if (meaningfulText.length >= 10) {
@@ -392,7 +392,8 @@ export function checkCustomerValue({ body, labels, template, lane }) {
 		const m = body.match(new RegExp(`\\*\\*${escaped}\\*\\*:\\s*(.*)`));
 		if (m) {
 			const val = (m[1] ?? '').trim();
-			if (!val || /^<!--.*-->$/.test(val)) {
+			// js/bad-tag-filter (CodeQL): 改行を含むコメント + `--!>` 終端も検出する
+			if (!val || /^<!--[\s\S]*--!?>$/.test(val)) {
 				errors.push(`\`**${field}**\` がプレースホルダーのまま未記入です。`);
 			}
 		}

--- a/tests/unit/github/pr-template-gate-checks.test.ts
+++ b/tests/unit/github/pr-template-gate-checks.test.ts
@@ -256,6 +256,24 @@ describe('feature lane: 現行観点維持 (#2944 AC4)', () => {
 		expect(r.ok).toBe(false);
 		expect(r.message).toContain('対象ユーザー');
 	});
+	it('customer-value FAIL: `--!>` 終端の placeholder も未記入扱いで検出 (js/bad-tag-filter, #3021)', () => {
+		// 旧 regex `/^<!--.*-->$/` は `--!>` 終端を comment と認識せず gate を通過させた。
+		const tplNoComment = `## 顧客価値・目的
+
+**対象ユーザー**: <!-- 子供 / 親 -->
+
+## 関連 Issue
+`;
+		const body = `## 顧客価値・目的
+
+**対象ユーザー**: <!-- 子供 / 親 --!>
+
+## 関連 Issue
+`;
+		const r = checkCustomerValue({ ...base, template: tplNoComment, body });
+		expect(r.ok).toBe(false);
+		expect(r.message).toContain('対象ユーザー');
+	});
 	it('test-results PASS: 結果列記入済み', () => {
 		expect(checkTestResults({ ...base, body: VALID_FEATURE_BODY }).ok).toBe(true);
 	});

--- a/tests/unit/scripts/check-ac-verification-map.test.ts
+++ b/tests/unit/scripts/check-ac-verification-map.test.ts
@@ -30,6 +30,16 @@ const FEATURE_AC_MAP_EMPTY_CELL = `
 | AC1 | ログイン後 | \`vitest\` |  |
 `;
 
+// js/bad-tag-filter (#3021 CodeQL): `--!>` 終端のコメントは旧 regex `/^<!--.*-->$/` が
+// 検出できず空欄プレースホルダのまま gate を通過した。robust 化後は空欄扱いで検出される。
+const FEATURE_AC_MAP_COMMENT_EVASION = `
+## AC 検証マップ
+
+| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
+|---|---|---|---|
+| AC1 | ログイン | \`vitest\` | <!-- まだ書いてない --!> |
+`;
+
 const FEATURE_AC_MAP_TODO = `
 ## AC 検証マップ
 
@@ -104,6 +114,12 @@ describe('checkPerPrAcMap (feature/hotfix lane、AC4)', () => {
 
 	it('FAIL: 空欄セルがある', () => {
 		const r = checkPerPrAcMap(FEATURE_AC_MAP_EMPTY_CELL, 'feature');
+		expect(r.ok).toBe(false);
+		expect(r.error).toContain('空欄');
+	});
+
+	it('FAIL: `--!>` 終端のコメントプレースホルダも空欄扱い (js/bad-tag-filter, #3021)', () => {
+		const r = checkPerPrAcMap(FEATURE_AC_MAP_COMMENT_EVASION, 'feature');
 		expect(r.ok).toBe(false);
 		expect(r.error).toContain('空欄');
 	});


### PR DESCRIPTION
## 顧客価値・目的

統合 PR #3021 を BLOCK している CodeQL の新規 high 3 件を根治し、main への統合を再開可能にする。PR body の未記入プレースホルダ検出 gate の regex 堅牢性を上げ、改行入りコメント / `--!>` 終端を使った gate 回避余地を塞ぐ。顧客には間接的に「PR 品質ゲートの信頼性維持」の価値。

## 関連 Issue

related #2944 #2945 #3021

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | CodeQL js/bad-tag-filter 3 件 (改行コメント / `--!>` 終端) を解消する regex 修正 | `scripts/check-ac-verification-map.mjs:85` / `scripts/pr-template-gate-checks.mjs:261,395` を `[\s\S]` + `--!?>` に robust 化 | 実装済 |
| AC2 | 既存 gate 挙動に回帰がない | `vitest run` 既存 58 テスト | PASS |
| AC3 | 回避ケース (`--!>` 終端 placeholder) が検出される regression テスト追加 | 新規 2 テスト (ac-verification + pr-template-gate) | PASS (計 60) |

## 変更タイプ

- [x] バグ修正（セキュリティ / 静的解析）

## 影響範囲・変更コンポーネント

- `scripts/check-ac-verification-map.mjs` (1 regex)
- `scripts/pr-template-gate-checks.mjs` (2 regex)
- `tests/unit/scripts/check-ac-verification-map.test.ts` / `tests/unit/github/pr-template-gate-checks.test.ts` (回帰テスト各 1)
- プロダクトアプリコード・UI への影響なし (CI gate スクリプトのみ)

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/scripts/check-ac-verification-map.test.ts tests/unit/github/pr-template-gate-checks.test.ts` → 60 PASS (既存 58 + 新 2)。
- `npx biome check` → clean。
- 追加テストは旧 regex では fail し新 regex で pass する回避ケース (`<!-- ... --!>`) を assert し、修正をロックする。

## スクリーンショット / ビジュアルデモ

UI 変更なし (CI gate スクリプト修正) のため SS 非該当。

## コード品質セルフレビュー (#1481)

- CodeQL 指摘箇所のみ最小修正。`/^<!--[\s\S]*--!?>$/` は anchored full-match を維持しつつ改行 + `--!>` を吸収。
- 実害評価: 当該スクリプトは PR body を parse する CI gate であり、攻撃者は自分の PR の body gate を回避するに留まる (内部・Pre-PMF・顧客非接触) ため severity は実質低。ただし新規 high・required check のため dismiss でなく根治を選択。

## 横展開・影響波及チェック

- 同種の不完全 HTML コメント regex が他 gate スクリプトに無いか grep 確認: 本 PR の 3 箇所が CodeQL フラグ対象の全件。
- 修正後、#3021 (develop→main 統合 PR) の CodeQL が緑化し再監査が進む。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。gate の検出が「より厳密」になる方向のみ (false-negative を塞ぐ)。
- レビュー観点: regex が既存の正常 placeholder (`<!-- 例 -->`) も引き続き検出すること (60 テストで担保)。

## 配布済み env / secret (ADR-0006)

- 新規 env / secret なし。

## Ready for Review チェックリスト

- [x] CodeQL 3 件に対応する regex 修正
- [x] 回帰テスト追加 (60 PASS)
- [x] biome clean

## QM レビュー結果

外部品質監査 audit-manager が #3021 統合 CI の CodeQL FAILURE (新規 high 3 件) を真因調査し、PR body コメント検出 regex の `js/bad-tag-filter` と特定。CI gate スクリプトで実害は低いが新規 high・required のため dismiss でなく根治。develop-light-lane でマージ後、#3021 再監査に合流する。
