### PR TITLE
fix: #3034 refresh cookie 不在の silent refresh skip を debug ログで観測可能化

### DIFF
--- a/src/lib/server/auth/providers/cognito-oauth.ts
+++ b/src/lib/server/auth/providers/cognito-oauth.ts
@@ -179,7 +179,16 @@ export function clearRefreshCookie(cookies: Cookies): void {
  */
 export async function refreshCognitoIdToken(cookies: Cookies): Promise<{ idToken: string } | null> {
 	const refreshToken = cookies.get(REFRESH_COOKIE_NAME);
-	if (!refreshToken) return null;
+	if (!refreshToken) {
+		// #3034: refresh cookie 不在で silent refresh を skip する経路を観測可能にする。
+		//   このパスは匿名 / refresh cookie 未保存ユーザで高頻度に発火するため debug レベル
+		//   (本番デフォルト抑止 = isProduction で MIN_LOG_LEVEL='info'、診断時のみ LOG_LEVEL=debug で可視)
+		//   とし、prod ログ noise を避けつつセッション短命化の原因追跡を可能にする。
+		//   #3022 (login の refresh cookie 適用漏れ) が 14 日間無症状で検知されなかった
+		//   主因が「この skip が無ログ」だったことへの再発防止 (failure は #3026 で warn 済)。
+		logger.debug('[AUTH] Silent refresh skipped — refresh cookie absent');
+		return null;
+	}
 
 	const config = getCognitoOAuthConfig();
 	const tokenUrl = `https://${config.domain}/oauth2/token`;

--- a/tests/unit/services/cognito-oauth.test.ts
+++ b/tests/unit/services/cognito-oauth.test.ts
@@ -7,6 +7,8 @@ vi.mock('$lib/server/logger', () => ({
 	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+// #3034: mock 化された logger を import して debug 呼出を assert する
+import { logger } from '$lib/server/logger';
 // static import — vi.mock はホイストされるため安全
 // 各関数は呼び出し時に process.env を参照するため beforeEach での設定が有効
 import {
@@ -207,6 +209,14 @@ describe('cognito-oauth', () => {
 			// biome-ignore lint/suspicious/noExplicitAny: test mock
 			const result = await refreshCognitoIdToken(cookies as any);
 			expect(result).toBeNull();
+		});
+
+		it('#3034: refresh cookie 不在の silent skip を debug ログで観測可能にする', async () => {
+			const cookies = createMockCookies();
+			// biome-ignore lint/suspicious/noExplicitAny: test mock
+			await refreshCognitoIdToken(cookies as any);
+			// silent skip でなく debug ログが出る (本番は LOG_LEVEL=info で抑止、診断時のみ可視)
+			expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('refresh cookie absent'));
 		});
 
 		it('正常なリフレッシュで新しい ID Token を返す', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム（間接的に全ログインユーザー）

**解決する課題**: `refreshCognitoIdToken` は refresh cookie 不在時に**無ログで `null` を返して silent refresh を skip** していた。この無症状性が、#3022（email/password ログインの refresh cookie 適用漏れ → セッション 1 時間失効）が **14 日間検知されなかった主因**だった。

**期待される効果**: セッション短命化の原因（cookie 不在 vs refresh 失敗）を運営がログから切り分けられるようにし、同種の無症状障害の再発を防ぐ。本番ログを汚さないため高頻度パスは debug レベル（既定抑止 / 診断時のみ `LOG_LEVEL=debug` で可視）とする。

## 関連 Issue

closes #3034

- #3022 / PR #3026（本体修正。refresh 失敗パス = `response.ok=false` の `logger.warn` は #3026 で既出のため本 PR 対象外）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | refresh cookie 不在で silent skip する経路に debug ログを追加（高頻度のため dev only / sampling 相当） | `npx vitest run tests/unit/services/cognito-oauth.test.ts` | HEAD `4b539d4d` / 22 passed / `cognito-oauth.ts:181-191` `logger.debug('[AUTH] Silent refresh skipped — refresh cookie absent')` |
| AC2 | refresh 試行が Cognito 401 等で失敗した場合の warn ログ | `git show :src/lib/server/auth/providers/cognito-oauth.ts` | 既存（#3022 PR #3026）: `cognito-oauth.ts:218` `logger.warn('[AUTH] Refresh token exchange failed', {context:{status}})`。本 PR 対象外を明記 |
| AC3 | /ops セッションメトリクスに refresh 失敗率を追加（Pre-PMF 過剰なら見送り、ADR-0010） | 設計判断 | **見送り**（issue 記載どおり）。Pre-PMF で /ops メトリクス基盤新設は過剰防衛（ADR-0010）。debug/warn ログで原因切り分けは充足 |
| AC4 | 回帰テスト | 同 AC1 | `cognito-oauth.test.ts` に「silent skip が debug ログを出す」を追加（`logger.debug` toHaveBeenCalledWith assert）|

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: `src/lib/server/auth/providers/cognito-oauth.ts` の `refreshCognitoIdToken` のみ。挙動（戻り値・cookie 操作）は不変で、ログ出力を 1 行追加するだけ。silent refresh の成否・セッション継続性に変化なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/services/cognito-oauth.test.ts` に「refresh cookie 不在の silent skip が debug ログを出す」を 1 ケース追加（`logger.debug` toHaveBeenCalledWith）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（`LOG_LEVEL` は既存 env、新規追加なし）
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: サーバー側のログ出力 1 行追加のみで UI 変更なし。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 既存 `logger` を使い責務を逸脱しない
- [x] **DRY**: 既存 `logger.debug` API を再利用
- [x] **YAGNI**: /ops メトリクス基盤は現要件に不要として見送り（ADR-0010）。最小の 1 行ログのみ
- [x] **Security（OSS 公開前提）**: ログメッセージは固定文字列のみ。refresh token 値・ユーザー識別子は出力しない（cookie 値も非出力）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: debug ログは本番既定で `shouldLog` により早期 return（書き込み発生せず）。オーバーヘッドなし

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [ ] 並行 PR overlap 確認 (#1200)
- [x] N/A — Cognito refresh は cognito provider 固有経路（local/demo provider は別機構）。観測性ログ追加のため並行実装ペアなし。設計書は spec 変更を伴わない内部観測性のため更新不要（ADR-0001 = 仕様の SSOT、ログ出力は仕様外）

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（戻り値・cookie 挙動は不変、ログ 1 行追加のみ）

**レビュー依頼事項・QA**: refresh cookie 不在パスを `debug`（warn でなく）にした判断 — このパスは匿名 / refresh cookie 未保存ユーザで高頻度発火するため warn にすると本番ログが溢れる。原因追跡が必要な診断時のみ `LOG_LEVEL=debug` で可視化する設計の妥当性を確認いただきたい。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（`LOG_LEVEL` は既存）

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし（サーバー側のみ）
- [x] 認証画面変更時: 該当なし（認証ロジックだがログ追加のみ、画面表示への影響なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
