### PR TITLE
infra: #2950 [Phase B/B-1] 統合 PR 専用 template 新設 + section SSOT + sync gate 相乗り

### DIFF
--- a/.github/INTEGRATION_PR_TEMPLATE.md
+++ b/.github/INTEGRATION_PR_TEMPLATE.md
@@ -1,0 +1,99 @@
+<!--
+統合 PR 専用 template (#2950 / Phase B/B-1、親 #2949 / 祖父 EPIC #2861)
+
+この template は develop→main の「統合 PR」専用です (feature → develop の PR は
+.github/PULL_REQUEST_TEMPLATE.md を使います)。統合 PR は単一 Issue に紐づかず・
+複数の feature/fix PR を集約し・1 日 1 回発行される性質を持つため、`closes #<single>` /
+per-PR AC 検証マップ / SS 4 スロットを前提とする feature 用 template とは別系統です。
+
+必須 `## ` 見出しの SSOT: .github/INTEGRATION_PR_TEMPLATE_SECTIONS.json
+(template ⇔ JSON 同期は check-pr-template-sections-sync.yml が検証)。
+
+lane-aware gate との接続 (Phase A/A-3):
+  - pr-ac-verification-check.yml (integration lane): エビデンス表 section (下記 §3) の
+    存在 + 4 列以上のデータ行 + 残 NG 0 件 明示を検証する (audit-team.md §3.5)。
+  - pr-merge-gate.yml (integration lane): env MERGE_GATE_INTEGRATION_SECTIONS で指定した
+    section の未チェック `- [ ]` を検証する。本 template は §5 (NG / カバレッジ宣言) を接続する。
+
+  注: gate は section 見出し文字列を本文から検索するため、この説明コメント内では
+  実際の `## ` 見出し文字列を再掲しない (誤マッチ回避)。各 section の正確な見出しは下記参照。
+
+B-3 (#2871) が含有 PR 一覧 + サマリを、B-4 (#2876) がエビデンス表を自動生成・差込します。
+本 template が確定するまでは手動記入し、placeholder には「B-3/B-4 で自動生成」と注記します。
+-->
+
+## 統合サマリ
+
+<!-- 対象 develop HEAD SHA / 統合対象期間 / 統合 PR 番号 (自動採番)。B-3 (#2871) が自動生成。 -->
+
+- 対象 develop HEAD: `<develop HEAD SHA>`
+- 統合対象期間: `<YYYY-MM-DD>` 〜 `<YYYY-MM-DD>` (前回統合 merge 〜 今回)
+- 統合 PR 番号: `#<自動採番>`
+
+> 統合 PR は単一 Issue に紐づきません (`closes #<single>` を持ちません)。変更の出典は
+> 「含有 PR 一覧」が担保します。Issue 非紐づけは統合 PR の設計前提です (#2950 AC4)。
+
+## 含有 PR 一覧
+
+<!--
+develop に積み上がった全 feature/fix PR を 1 行ずつ列挙する。
+B-3 (#2871) が develop の merge 履歴から自動生成する (それまでは手動記入)。
+-->
+
+| PR | title | type label | 対象領域 |
+|---|---|---|---|
+| #NNNN | `<title>` | `type:feat` | `<area>` |
+
+> _この表は B-3 (#2871) で develop merge 履歴から自動生成予定。_
+
+## マージ判定エビデンス表
+
+<!--
+audit-team.md §3.5 のマージ判定エビデンス基準 (6 列)。
+B-4 (#2876) が CI artifact (SARIF 集約 + カバレッジ gap map) から自動生成する。
+- 全行 pass + 残 NG 合計 0 + カバレッジ閾値割れなし を満たして初めて audit-manager が merge を実行する。
+- 1 行でも fail / 残 NG > 0 なら merge せず §3.6 起票/棄却 flow に送る。
+gate (pr-ac-verification-check.yml / integration lane) はこの section の存在 +
+4 列以上のデータ行 + 空欄/プレースホルダ無し + 「残 NG 0 件」明示を機械検証する。
+-->
+
+| 変更（出典 PR） | 対象領域 | 対応テストケース | 結果 | カバレッジ影響 | 残 NG |
+|---|---|---|---|---|---|
+| 機能 A（#NNNN） | admin/activities | unit×N / e2e×M | pass | 閾値内 | 0 |
+| 修正 B（#NNNN） | child-home | unit×N / e2e×M | pass | 閾値内 | 0 |
+
+> _この表は B-4 (#2876) で CI artifact (SARIF 集約 + カバレッジ gap map) から自動生成予定。_
+
+## 監査 run 結果リンク
+
+<!--
+当該統合 PR の audit run (`<pr>-<YYYYMMDD>`) の evidence (B-4 永続化先) と
+adversarial evidence への link。
+-->
+
+- audit run evidence: `<run URL / artifact link>` (run id: `<pr>-<YYYYMMDD>`)
+- adversarial evidence: `tmp/adversarial-evidence/<pr>.json` (B-4 で merge commit に永続化予定)
+
+## NG 0 件 / カバレッジ宣言
+
+<!--
+severity 3-4 + policy_compliant=false の未解決 finding が 0 件 +
+カバレッジ ratchet 閾値割れなしの宣言 (audit-team.md §3.5 #4/#5)。
+pr-merge-gate.yml (integration lane) が下記 `- [ ]` の全消化を機械検証する
+(env MERGE_GATE_INTEGRATION_SECTIONS が本 section を指す)。
+-->
+
+- 残 NG 合計 0 件 (severity 3-4 + policy_compliant=false の未解決 finding なし)
+- [ ] 8 領域 finding のうち severity 閾値以上の未解決 NG が **0 件**である
+- [ ] カバレッジ ratchet 閾値割れがない (ADR-0005 整合)
+- [ ] 最重厚レーン (branch-strategy.md §4) の全 job が緑である
+- [ ] adversarial evidence の反対理由が全件解消済みである
+
+## back-merge / drift 状態
+
+<!--
+直近 hotfix back-merge (B-5) の取り込み状況 + develop⇔main drift 日数。
+-->
+
+- 直近 hotfix back-merge: `<取り込み済み / 該当なし>` (出典: `<main→develop PR #NNNN>`)
+- develop⇔main drift: `<N>` 日 (前回統合 merge からの経過)

--- a/.github/INTEGRATION_PR_TEMPLATE_SECTIONS.json
+++ b/.github/INTEGRATION_PR_TEMPLATE_SECTIONS.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "./PR_TEMPLATE_SECTIONS.schema.json",
+	"description": "Issue #2950 SSOT: 統合 PR (develop→main) 本文の必須セクション (## 見出し) 一覧。.github/INTEGRATION_PR_TEMPLATE.md からこの JSON を生成し、check-pr-template-sections-sync.yml が同期を検証する。feature 用 PR_TEMPLATE_SECTIONS.json とは別系統 (統合 PR は単一 Issue 非紐づけ・複数 PR 集約・1 日 1 回発行)。template 更新時は本 JSON も同時更新が必要 (CI gate: scripts/check-pr-template-sections-sync.mjs --integration)。",
+	"source": ".github/INTEGRATION_PR_TEMPLATE.md",
+	"sections": [
+		"## 統合サマリ",
+		"## 含有 PR 一覧",
+		"## マージ判定エビデンス表",
+		"## 監査 run 結果リンク",
+		"## NG 0 件 / カバレッジ宣言",
+		"## back-merge / drift 状態"
+	]
+}

--- a/.github/workflows/check-pr-template-sections-sync.yml
+++ b/.github/workflows/check-pr-template-sections-sync.yml
@@ -8,22 +8,24 @@ name: PR template SSOT 同期検証
 #   pr-template-gate.yml の `必須セクションの存在確認` job が SSOT JSON を読むようになったが、
 #   template だけ更新して JSON を更新し忘れる drift を防ぐ必要がある。
 #
-# 検証対象:
-#   PR で `.github/PULL_REQUEST_TEMPLATE.md` または `.github/PR_TEMPLATE_SECTIONS.json` が
-#   変更された場合に、両者の `## ` 見出し配列が完全一致するかを検証する。
+# 検証対象 (複数ペア、#2950 で拡張):
+#   PR で下記いずれかが変更された場合に、各 template の `## ` 見出し配列と対応する SSOT JSON が
+#   完全一致するかを検証する。
+#     1. feature PR:     PULL_REQUEST_TEMPLATE.md ↔ PR_TEMPLATE_SECTIONS.json (#2060)
+#     2. integration PR: INTEGRATION_PR_TEMPLATE.md ↔ INTEGRATION_PR_TEMPLATE_SECTIONS.json (#2950)
 #
 # 修正方法:
-#   `node scripts/check-pr-template-sections-sync.mjs --fix` で JSON を template から再生成する。
+#   `node scripts/check-pr-template-sections-sync.mjs --fix` で全ペアの JSON を template から再生成する。
 #
-# ★ lane 概念との関係 (#2944 / Phase A/A-2、Phase B 接続点):
+# ★ lane 概念との関係 (#2944 / Phase A/A-2 → #2950 / Phase B/B-1):
 #   本 workflow は template ↔ JSON の 1 対 1 sync を検証する drift gate であり、PR の lane
 #   (feature / integration / hotfix / dependabot) には依存しない (全 PR で同一観点)。
-#   本 phase (A-2) では sync 対象を増やさず、現行の 1 JSON (PR_TEMPLATE_SECTIONS.json) のままにする。
-#   integration lane の必須 section set は `scripts/pr-template-gate-checks.mjs` の
-#   INTEGRATION_REQUIRED_SECTIONS (暫定) が担い、本 sync gate の対象外。
-#   Phase B (#2871) で統合 PR 専用 template (PR_TEMPLATE_SECTIONS.integration.json 等) を
-#   追加する際は、本 workflow の paths / sync 対象を複数 JSON に拡張する (本 phase では未対応)。
-#   = 本 issue (A-2) では「現行 sync を壊さない」確認のみ (#2944 AC7)。
+#   #2950 (Phase B/B-1) で develop→main 統合 PR 専用 template (INTEGRATION_PR_TEMPLATE.md) を
+#   別系統で新設したため、本 workflow の paths / sync 対象を 2 ペアに拡張した
+#   (専用 workflow を新設せず本 gate に相乗り、#1442)。
+#   integration lane の section-presence / checklist 検証は別 gate
+#   (pr-template-gate.yml / pr-merge-gate.yml / pr-ac-verification-check.yml) が担い、
+#   本 sync gate は「template と JSON の見出しが一致するか」のみを検証する。
 
 on:
   pull_request:
@@ -31,6 +33,8 @@ on:
     paths:
       - '.github/PULL_REQUEST_TEMPLATE.md'
       - '.github/PR_TEMPLATE_SECTIONS.json'
+      - '.github/INTEGRATION_PR_TEMPLATE.md'
+      - '.github/INTEGRATION_PR_TEMPLATE_SECTIONS.json'
       - 'scripts/check-pr-template-sections-sync.mjs'
 
 permissions:

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -57,9 +57,12 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_LABELS: ${{ toJson(github.event.pull_request.labels) }}
           PR_LANE: ${{ steps.lane.outputs.lane }}
-          # #2945 AC5: 統合 PR 用 section 名は env で差替可能 (Phase B #2871 で確定するまでの暫定既定を使う)。
-          # 値を設定すれば scripts/check-merge-gate-checklist.mjs の DEFAULT_INTEGRATION_LANE_SECTIONS を上書きする。
-          MERGE_GATE_INTEGRATION_SECTIONS: ""
+          # #2945 AC5 / #2950 (Phase B/B-1): 統合 PR 用 section 名は env で差替可能。
+          # #2950 で統合 PR 専用 template (.github/INTEGRATION_PR_TEMPLATE.md) が確定したため、
+          # その checklist section「## NG 0 件 / カバレッジ宣言」(残 NG 0 / カバレッジ閾値 / 全 job 緑 /
+          # adversarial 解消の `- [ ]`) を接続する。lane 判定ロジック自体は不変、env 値の接続のみ。
+          # 値を設定すると scripts/check-merge-gate-checklist.mjs の DEFAULT_INTEGRATION_LANE_SECTIONS を上書きする。
+          MERGE_GATE_INTEGRATION_SECTIONS: "## NG 0 件 / カバレッジ宣言"
         with:
           script: |
             const lane = process.env.PR_LANE || 'feature';

--- a/scripts/check-pr-template-sections-sync.mjs
+++ b/scripts/check-pr-template-sections-sync.mjs
@@ -1,29 +1,39 @@
 #!/usr/bin/env node
 /**
- * scripts/check-pr-template-sections-sync.mjs — Issue #2060
+ * scripts/check-pr-template-sections-sync.mjs — Issue #2060 / #2950
  *
- * `.github/PULL_REQUEST_TEMPLATE.md` の `## ` 見出しと
- * `.github/PR_TEMPLATE_SECTIONS.json` の `sections` 配列が完全一致するかを検証する CI gate。
+ * PR template (`.md`) の `## ` 見出しと、対応する section SSOT JSON の `sections` 配列が
+ * 完全一致するかを検証する CI gate。**複数の template / JSON ペアを 1 本の gate で検証する**。
+ *
+ * 検証ペア (PAIRS):
+ *   1. feature PR (feature → develop):
+ *        `.github/PULL_REQUEST_TEMPLATE.md` ↔ `.github/PR_TEMPLATE_SECTIONS.json` (#2060)
+ *   2. integration PR (develop → main、1 日 1 回 / 複数 PR 集約 / Issue 非紐づけ):
+ *        `.github/INTEGRATION_PR_TEMPLATE.md` ↔ `.github/INTEGRATION_PR_TEMPLATE_SECTIONS.json` (#2950)
  *
  * 設計背景:
  *   - PR #2039 / #2043 で「必須セクション 12 件全欠落」が連続再発。
  *     `dev-open-pr` skill の Ready 化前 gate と CI workflow `必須セクションの存在確認` が
  *     hardcoded list だったため、template と CI 検証の同期が author の手動運用に依存していた。
- *   - 本 Issue で `.github/PR_TEMPLATE_SECTIONS.json` を新規 SSOT 化し、
- *     template が更新されたら本 JSON も同時更新を強制する drift 検出 gate を導入する。
+ *   - #2060 で `.github/PR_TEMPLATE_SECTIONS.json` を SSOT 化し、template 更新で JSON も
+ *     同時更新を強制する drift 検出 gate を導入。
+ *   - #2950 (Phase B/B-1) で develop→main 統合 PR 専用 template を別系統で新設したため、
+ *     本 gate を「複数ペア」対応に拡張し、専用 workflow を新設せず相乗りで検証する (#1442)。
  *
- * 検出する drift:
+ * 検出する drift (各ペア共通):
  *   1. template に存在するが JSON に無い見出し (新規追加忘れ)
  *   2. JSON に存在するが template に無い見出し (template から削除されたのに JSON が古い)
  *   3. 並び順違い (template 順序が SSOT)
  *
  * Usage:
- *   node scripts/check-pr-template-sections-sync.mjs           # 検証のみ
- *   node scripts/check-pr-template-sections-sync.mjs --fix     # JSON を template から自動再生成
+ *   node scripts/check-pr-template-sections-sync.mjs                 # 全ペア検証
+ *   node scripts/check-pr-template-sections-sync.mjs --fix           # 全ペアの JSON を template から再生成
+ *   node scripts/check-pr-template-sections-sync.mjs --integration   # integration ペアのみ検証
+ *   node scripts/check-pr-template-sections-sync.mjs --feature       # feature ペアのみ検証
  *
  * Exit:
- *   0 = OK (一致)
- *   1 = drift 検出
+ *   0 = OK (全ペア一致)
+ *   1 = drift 検出 (1 ペア以上)
  *   2 = internal error
  */
 
@@ -33,8 +43,41 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
-const TEMPLATE_PATH = join(repoRoot, '.github', 'PULL_REQUEST_TEMPLATE.md');
-const SSOT_JSON_PATH = join(repoRoot, '.github', 'PR_TEMPLATE_SECTIONS.json');
+
+/**
+ * 検証する template ↔ SSOT JSON ペア定義。
+ * 新しい PR 種別 template を追加するときは本配列に 1 件足すだけで gate に乗る。
+ *
+ * @typedef {object} TemplatePair
+ * @property {'feature'|'integration'} id ペア識別子 (CLI フィルタ用)
+ * @property {string} label 人間可読ラベル (ログ用)
+ * @property {string} templatePath template (`.md`) の絶対パス
+ * @property {string} jsonPath SSOT JSON の絶対パス
+ * @property {string} description `--fix` で再生成する JSON の `description` フィールド
+ * @property {string} source `--fix` で再生成する JSON の `source` フィールド (template 相対パス)
+ */
+
+/** @type {TemplatePair[]} */
+const PAIRS = [
+	{
+		id: 'feature',
+		label: 'feature PR (feature → develop)',
+		templatePath: join(repoRoot, '.github', 'PULL_REQUEST_TEMPLATE.md'),
+		jsonPath: join(repoRoot, '.github', 'PR_TEMPLATE_SECTIONS.json'),
+		description:
+			'Issue #2060 SSOT: PR body 必須セクション (## 見出し) 一覧。.github/PULL_REQUEST_TEMPLATE.md からこの JSON を生成し、CI workflow / dev-open-pr skill / scripts/check-pr-body.mjs が共通参照する。template 更新時は本 JSON も同時更新が必要 (CI gate: scripts/check-pr-template-sections-sync.mjs)。',
+		source: '.github/PULL_REQUEST_TEMPLATE.md',
+	},
+	{
+		id: 'integration',
+		label: 'integration PR (develop → main)',
+		templatePath: join(repoRoot, '.github', 'INTEGRATION_PR_TEMPLATE.md'),
+		jsonPath: join(repoRoot, '.github', 'INTEGRATION_PR_TEMPLATE_SECTIONS.json'),
+		description:
+			'Issue #2950 SSOT: 統合 PR (develop→main) 本文の必須セクション (## 見出し) 一覧。.github/INTEGRATION_PR_TEMPLATE.md からこの JSON を生成し、check-pr-template-sections-sync.yml が同期を検証する。feature 用 PR_TEMPLATE_SECTIONS.json とは別系統 (統合 PR は単一 Issue 非紐づけ・複数 PR 集約・1 日 1 回発行)。template 更新時は本 JSON も同時更新が必要 (CI gate: scripts/check-pr-template-sections-sync.mjs --integration)。',
+		source: '.github/INTEGRATION_PR_TEMPLATE.md',
+	},
+];
 
 /**
  * `.github/PULL_REQUEST_TEMPLATE.md` から `^## ` 見出しを抽出する。
@@ -83,18 +126,18 @@ export function diffSections(fromTemplate, fromJson) {
 
 /**
  * `--fix` で再生成する JSON 本体。Biome が tab indent を要求するため `\t` で生成する
- * (`.github/PR_TEMPLATE_SECTIONS.json` を biome check が pass する形)。
+ * (section JSON を biome check が pass する形)。
  *
+ * @param {TemplatePair} pair
  * @param {string[]} sections
  * @returns {string}
  */
-function buildJsonContent(sections) {
+function buildJsonContent(pair, sections) {
 	/** @type {{ $schema: string; description: string; source: string; sections: string[] }} */
 	const data = {
 		$schema: './PR_TEMPLATE_SECTIONS.schema.json',
-		description:
-			'Issue #2060 SSOT: PR body 必須セクション (## 見出し) 一覧。.github/PULL_REQUEST_TEMPLATE.md からこの JSON を生成し、CI workflow / dev-open-pr skill / scripts/check-pr-body.mjs が共通参照する。template 更新時は本 JSON も同時更新が必要 (CI gate: scripts/check-pr-template-sections-sync.mjs)。',
-		source: '.github/PULL_REQUEST_TEMPLATE.md',
+		description: pair.description,
+		source: pair.source,
 		sections,
 	};
 	return `${JSON.stringify(data, null, '\t')}\n`;
@@ -102,55 +145,60 @@ function buildJsonContent(sections) {
 
 function parseArgs() {
 	const argv = process.argv.slice(2);
+	const onlyIds = [];
+	if (argv.includes('--integration')) onlyIds.push('integration');
+	if (argv.includes('--feature')) onlyIds.push('feature');
 	return {
 		fix: argv.includes('--fix'),
 		help: argv.includes('--help') || argv.includes('-h'),
+		onlyIds,
 	};
 }
 
 function printHelp() {
 	console.log(`
-check-pr-template-sections-sync.mjs — PR template / SSOT JSON 同期検証 (Issue #2060)
+check-pr-template-sections-sync.mjs — PR template / SSOT JSON 同期検証 (Issue #2060 / #2950)
 
 Usage:
-  node scripts/check-pr-template-sections-sync.mjs           # 検証のみ
-  node scripts/check-pr-template-sections-sync.mjs --fix     # JSON を template から自動再生成
+  node scripts/check-pr-template-sections-sync.mjs                 # 全ペア検証
+  node scripts/check-pr-template-sections-sync.mjs --fix           # 全ペアの JSON を template から再生成
+  node scripts/check-pr-template-sections-sync.mjs --integration   # integration ペアのみ検証
+  node scripts/check-pr-template-sections-sync.mjs --feature       # feature ペアのみ検証
 
-Files:
-  .github/PULL_REQUEST_TEMPLATE.md       (template SSOT)
-  .github/PR_TEMPLATE_SECTIONS.json      (派生 SSOT、本 CLI が同期保証)
+Pairs:
+  feature      .github/PULL_REQUEST_TEMPLATE.md           ↔ .github/PR_TEMPLATE_SECTIONS.json
+  integration  .github/INTEGRATION_PR_TEMPLATE.md         ↔ .github/INTEGRATION_PR_TEMPLATE_SECTIONS.json
 
 Exit codes:
-  0 = OK (一致)
+  0 = OK (全ペア一致)
   1 = drift 検出 (fix オプションで再生成)
   2 = internal error
 `);
 }
 
 /**
- * @returns {Promise<number>}
+ * 1 ペアの template ↔ JSON 同期を検証する (必要なら `--fix` で再生成)。
+ *
+ * @param {TemplatePair} pair
+ * @param {boolean} fix
+ * @returns {{ status: 'ok'|'fixed'|'drift'|'error' }}
  */
-export async function main() {
-	const args = parseArgs();
-	if (args.help) {
-		printHelp();
-		return 0;
-	}
-	if (!existsSync(TEMPLATE_PATH)) {
+function checkPair(pair, fix) {
+	if (!existsSync(pair.templatePath)) {
 		console.error(
-			`[check-pr-template-sections-sync] ERROR: template が見つかりません: ${TEMPLATE_PATH}`,
+			`[check-pr-template-sections-sync] (${pair.id}) ERROR: template が見つかりません: ${pair.templatePath}`,
 		);
-		return 2;
+		return { status: 'error' };
 	}
-	if (!existsSync(SSOT_JSON_PATH)) {
+	if (!existsSync(pair.jsonPath)) {
 		console.error(
-			`[check-pr-template-sections-sync] ERROR: SSOT JSON が見つかりません: ${SSOT_JSON_PATH}`,
+			`[check-pr-template-sections-sync] (${pair.id}) ERROR: SSOT JSON が見つかりません: ${pair.jsonPath}`,
 		);
-		return 2;
+		return { status: 'error' };
 	}
 
-	const template = readFileSync(TEMPLATE_PATH, 'utf-8');
-	const ssotRaw = readFileSync(SSOT_JSON_PATH, 'utf-8');
+	const template = readFileSync(pair.templatePath, 'utf-8');
+	const ssotRaw = readFileSync(pair.jsonPath, 'utf-8');
 
 	const fromTemplate = extractTemplateSections(template);
 	let fromJson;
@@ -158,10 +206,10 @@ export async function main() {
 		fromJson = extractJsonSections(ssotRaw);
 	} catch (err) {
 		console.error(
-			'[check-pr-template-sections-sync] ERROR: JSON parse 失敗:',
+			`[check-pr-template-sections-sync] (${pair.id}) ERROR: JSON parse 失敗:`,
 			err instanceof Error ? err.message : err,
 		);
-		return 2;
+		return { status: 'error' };
 	}
 
 	const diff = diffSections(fromTemplate, fromJson);
@@ -169,20 +217,23 @@ export async function main() {
 		diff.missingInJson.length === 0 && diff.extraInJson.length === 0 && !diff.orderMismatch;
 
 	if (inSync) {
-		console.log(`[check-pr-template-sections-sync] OK — ${fromTemplate.length} 件 sync 状態`);
-		return 0;
-	}
-
-	if (args.fix) {
-		const updated = buildJsonContent(fromTemplate);
-		writeFileSync(SSOT_JSON_PATH, updated, 'utf-8');
 		console.log(
-			`[check-pr-template-sections-sync] FIXED — JSON を template から再生成しました (${fromTemplate.length} 件)`,
+			`[check-pr-template-sections-sync] OK — ${pair.label}: ${fromTemplate.length} 件 sync 状態`,
 		);
-		return 0;
+		return { status: 'ok' };
 	}
 
-	console.error('[check-pr-template-sections-sync] FAIL — template と JSON が乖離しています:');
+	if (fix) {
+		writeFileSync(pair.jsonPath, buildJsonContent(pair, fromTemplate), 'utf-8');
+		console.log(
+			`[check-pr-template-sections-sync] FIXED — ${pair.label}: JSON を template から再生成しました (${fromTemplate.length} 件)`,
+		);
+		return { status: 'fixed' };
+	}
+
+	console.error(
+		`[check-pr-template-sections-sync] FAIL — ${pair.label}: template と JSON が乖離しています:`,
+	);
 	if (diff.missingInJson.length > 0) {
 		console.error(`\n  template には在るが JSON に無い (${diff.missingInJson.length} 件):`);
 		for (const s of diff.missingInJson) console.error(`    + ${s}`);
@@ -196,10 +247,37 @@ export async function main() {
 		console.error('  expected:', fromTemplate);
 		console.error('  actual:  ', fromJson);
 	}
+	const fixFlag = pair.id === 'feature' ? '--fix' : `--fix --${pair.id}`;
 	console.error(
-		'\n対応: `node scripts/check-pr-template-sections-sync.mjs --fix` で JSON を再生成してください。',
+		`\n対応: \`node scripts/check-pr-template-sections-sync.mjs ${fixFlag}\` で JSON を再生成してください。`,
 	);
-	return 1;
+	return { status: 'drift' };
+}
+
+/**
+ * @returns {Promise<number>}
+ */
+export async function main() {
+	const args = parseArgs();
+	if (args.help) {
+		printHelp();
+		return 0;
+	}
+
+	const targets =
+		args.onlyIds.length > 0 ? PAIRS.filter((p) => args.onlyIds.includes(p.id)) : PAIRS;
+
+	let hasError = false;
+	let hasDrift = false;
+	for (const pair of targets) {
+		const { status } = checkPair(pair, args.fix);
+		if (status === 'error') hasError = true;
+		if (status === 'drift') hasDrift = true;
+	}
+
+	if (hasError) return 2;
+	if (hasDrift) return 1;
+	return 0;
 }
 
 const isMain = (() => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 外部品質監査チーム role の merge 判定者 (lab) / システム全体の本番品質。

develop→main 統合 PR は単一 Issue に紐づかず・複数 feature PR を集約し・1 日 1 回発行される性質を持つ。feature 用 13 セクション template (`closes #` / AC 検証マップ / SS 4 スロット前提) をそのまま当てると placeholder 偽装・AC マップ表現不能・§3.5 エビデンス表の置き場欠落が起きる。本 PR は統合 PR 専用 template を別系統で新設し、監査 merge 判定が散文 self-report に退化しない構造化を確定する (ADR-0056 整合)。後続 B-3 (#2871) / B-4 (#2876) が参照する本文骨格 + section SSOT を供給する。

## 関連 Issue

closes #2950

related: #2949 (Phase B 統括) / #2861 (祖父 EPIC) / #2871 (B-3 自動発行) / #2876 (B-4 エビデンス自動生成) / #2862 (audit-team.md §3.5 SSOT) / #2945 #3052 (A-3 gate lane-aware 化 + env 差替) / #2060 (feature PR_TEMPLATE_SECTIONS SSOT)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `INTEGRATION_PR_TEMPLATE.md` 新設 + 6 セクション (統合サマリ / 含有 PR 一覧 / §3.5 エビデンス表 / 監査 run リンク / NG 0 件・カバレッジ宣言 / back-merge・drift 状態) | file 存在 + `## ` 見出し 6 件 grep | ✓ `grep -c '^## ' .github/INTEGRATION_PR_TEMPLATE.md` = 6。見出し = 統合サマリ / 含有 PR 一覧 / マージ判定エビデンス表 / 監査 run 結果リンク / NG 0 件 / カバレッジ宣言 / back-merge / drift 状態 |
| AC2 | `INTEGRATION_PR_TEMPLATE_SECTIONS.json` 新設 + 6 必須見出し列挙 | JSON parse + sections 配列 6 件 | ✓ sync gate「integration PR: 6 件 sync 状態」で JSON parse + 6 件確認 |
| AC3 | エビデンス表が audit-team.md §3.5 の 6 列 (変更/出典 PR・対象領域・対応テストケース・結果・カバレッジ影響・残 NG) と列一致 | §3.5 と template の表ヘッダ突合 | ✓ template L51 `\| 変更（出典 PR） \| 対象領域 \| 対応テストケース \| 結果 \| カバレッジ影響 \| 残 NG \|` = §3.5 L111 と完全一致 |
| AC4 | `closes #<single>` を必須化せず、出典は「含有 PR 一覧」で担保 (Issue 非紐づけ前提の明文化) | template 内 Issue 非紐づけ注記 + `closes` 必須欄なし確認 | ✓ §「統合サマリ」に「統合 PR は単一 Issue に紐づきません (`closes #<single>` を持ちません)…Issue 非紐づけは統合 PR の設計前提」明記。`closes` 必須欄なし |
| AC5 | feature 用 template / section JSON / `pr-template-gate.yml` の既存挙動が無改変 | `git diff` で feature template 系に変更なし確認 | ✓ `PULL_REQUEST_TEMPLATE.md` / `PR_TEMPLATE_SECTIONS.json` / `pr-template-gate.yml` に差分なし (git diff stat 確認)。feature pair unit test 14 件 PASS |
| AC6 | 統合 template / section JSON の同期検証が `check-pr-template-sections-sync.yml` に相乗り追加 (専用 workflow 新設なし) | workflow diff で統合 template 用 step 追加確認 | ✓ 既存 workflow の paths に統合 2 file 追加 + script を 2 ペア対応化。新規 workflow 0 件。sync gate PASS / fail 両ログ取得済 (下記) |

## 変更タイプ

- [x] その他 (infra / プロセス: PR template + section SSOT + 既存 gate 相乗り)

## 影響範囲・変更コンポーネント

- `.github/INTEGRATION_PR_TEMPLATE.md` (新設) — 統合 PR 専用 6 セクション template
- `.github/INTEGRATION_PR_TEMPLATE_SECTIONS.json` (新設) — 6 必須 `## ` 見出し SSOT
- `scripts/check-pr-template-sections-sync.mjs` (改修) — feature / integration 2 ペアを 1 gate で検証。pure export 関数 (`extractTemplateSections` / `extractJsonSections` / `diffSections`) は無改変
- `.github/workflows/check-pr-template-sections-sync.yml` (改修) — paths に統合 2 file 追加 (専用 workflow 新設なし #1442)
- `.github/workflows/pr-merge-gate.yml` (改修) — `MERGE_GATE_INTEGRATION_SECTIONS` env を本 template の checklist section に接続 (lane 判定ロジック不変)

deploy 経路 (main push) / feature PR gate / branch-strategy.md には触らない。

## テスト & 安全装置セルフチェック

<!-- PASS -->

- sync gate (両ペア): `node scripts/check-pr-template-sections-sync.mjs` → feature 13 件 + integration 6 件 OK (exit 0)
- sync gate fail 再現: integration template に 7 番目見出しを注入 → integration pair FAIL (missing 1 件、exit 1)、feature pair は OK のまま、restore で OK 復帰
- 既存 unit test `tests/unit/scripts/check-pr-template-sections-sync.test.ts` 14 件 PASS (pure 関数無改変)
- merge-gate (integration lane、env=本 template checklist section): 未チェック template → FAIL (4 未チェック) / 全 `[x]` → PASS
- AC verification gate (integration lane): 本 template body → PASS (エビデンス表 4 列 2 行 + 残 NG 0 件 明示)
- biome (JSON / script / 2 workflow) exit 0 / cspell 2 file Issues 0

## スクリーンショット / ビジュアルデモ

N/A — 本 PR は `.github/` 配下の PR template (md) + section SSOT (json) + CI script/workflow のみで、アプリ UI (`.svelte`) を一切変更しないため SS 不要 (docs/config 変更)。

## コード品質セルフレビュー (#1481)

- 複数ペア対応は `PAIRS` 配列 + `checkPair()` への抽出で実現。新 PR 種別追加時は配列 1 件追加で gate に乗る (拡張容易性)
- gate 誤マッチ回避: section 見出し文字列を template の説明コメント内に再掲しない (gate の `indexOf` collision で false PASS する不具合を実装中に検出・修正)
- 専用 workflow / 使い捨て script を新設せず既存 gate に相乗り (#1442 / ADR-0010 Pre-PMF)

## 横展開・影響波及チェック

- feature PR template 系統 (`PULL_REQUEST_TEMPLATE.md` / `PR_TEMPLATE_SECTIONS.json` / `pr-template-gate.yml`) は無改変 (AC5)
- A-3 が用意した `MERGE_GATE_INTEGRATION_SECTIONS` env を消費するのみで、lane 判定 (`scripts/pr-lane.mjs` / `actions/pr-lane`) は不変
- A-6 workflow 帰属検証 gate: 新規 workflow を追加しないため登録行不要。branch-strategy.md §4 (A-6 変更中) には触らない (衝突回避)
- 含有 PR 一覧 / エビデンス表は B-3 (#2871) / B-4 (#2876) で自動生成。本 PR は手動記入 placeholder + 自動生成注記の骨格まで

## レビュー依頼事項・破壊的変更

破壊的変更なし。統合 PR template は新設のため、既存 feature PR の運用に影響しない。本 template が実運用に乗るのは B-2 (gate lane-aware 化、A-3 で merge 済) + B-3 (自動発行) 完了後。

## 配布済み env / secret (ADR-0006)

新規 env / secret 追加なし。`MERGE_GATE_INTEGRATION_SECTIONS` は workflow 内の inline env (空 default は A-3 で導入済) に値を接続するのみで、外部 secret 配布は不要。

## Ready for Review チェックリスト

- [x] `npm run pre-ready` 相当の関連 step (biome / sync gate / cspell / unit test) を実行し PASS
- [x] AC 検証マップを 4 列で全行記入し、各 AC の検証エビデンスを添付
- [x] 必須セクションを全て記入 (placeholder / 禁止語なし)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: 上記 gate 両ログ取得 + 6 AC 物理検証済)

## QM レビュー結果

(QM 記入欄)
