### PR TITLE
infra: #3063 lane/gate を release/* 対応に拡張 — release ブランチ方式の統合 PR 基盤 (Part 1/3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,7 @@ jobs:
     # composite action (actions/pr-lane) 経由の needs 化は main push 経路 (base_ref 空) を壊すため
     # inline 式で OR する (handoff spec 承認済 / A-6 #2948 で対応表化予定)。
     if: >-
-      (github.base_ref == 'main' && github.head_ref == 'develop')
+      (github.base_ref == 'main' && (github.head_ref == 'develop' || startsWith(github.head_ref, 'release/')))
       || (github.base_ref != 'develop' && (needs.changes.outputs.deps == 'true' || needs.changes.outputs.stories == 'true'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -455,7 +455,7 @@ jobs:
     # #2874: 統合 PR (develop → main) では paths filter に依らず保証発火 (pr-lane.mjs rule 2 SSOT)。
     needs: [changes]
     if: >-
-      (github.base_ref == 'main' && github.head_ref == 'develop')
+      (github.base_ref == 'main' && (github.head_ref == 'develop' || startsWith(github.head_ref, 'release/')))
       || (github.base_ref != 'develop' && (needs.changes.outputs.app == 'true' || needs.changes.outputs.deps == 'true'))
     permissions:
       contents: read
@@ -527,7 +527,7 @@ jobs:
     # #2931 / branch-strategy.md §4: 重量レーン。develop 向け PR では skip。
     # #2874: 統合 PR (develop → main) では paths filter に依らず保証発火 (pr-lane.mjs rule 2 SSOT)。
     if: >-
-      (github.base_ref == 'main' && github.head_ref == 'develop')
+      (github.base_ref == 'main' && (github.head_ref == 'develop' || startsWith(github.head_ref, 'release/')))
       || (github.base_ref != 'develop' && (needs.changes.outputs.app == 'true' || needs.changes.outputs.deps == 'true'))
     permissions:
       contents: read
@@ -675,7 +675,7 @@ jobs:
     # #2931 / branch-strategy.md §4: 重量レーン。develop 向け PR では skip。
     # #2874: 統合 PR (develop → main) では paths filter に依らず保証発火 (pr-lane.mjs rule 2 SSOT)。
     if: >-
-      (github.base_ref == 'main' && github.head_ref == 'develop')
+      (github.base_ref == 'main' && (github.head_ref == 'develop' || startsWith(github.head_ref, 'release/')))
       || (github.base_ref != 'develop' && (needs.changes.outputs.cognito == 'true' || needs.changes.outputs.deps == 'true'))
     permissions:
       contents: read
@@ -738,7 +738,7 @@ jobs:
     # #2874: 統合 PR (develop → main) では paths filter に依らず保証発火 (pr-lane.mjs rule 2 SSOT)。
     needs: [changes]
     if: >-
-      (github.base_ref == 'main' && github.head_ref == 'develop')
+      (github.base_ref == 'main' && (github.head_ref == 'develop' || startsWith(github.head_ref, 'release/')))
       || (github.base_ref != 'develop' && (needs.changes.outputs.docker == 'true' || needs.changes.outputs.deps == 'true'))
     permissions:
       contents: read
@@ -766,7 +766,7 @@ jobs:
       || github.event_name == 'push'
       || (github.event_name == 'pull_request'
           && github.base_ref == 'main'
-          && github.head_ref == 'develop')
+          && (github.head_ref == 'develop' || startsWith(github.head_ref, 'release/')))
       || (github.event_name == 'pull_request'
           && github.base_ref != 'develop'
           && contains(github.event.pull_request.labels.*.name, 'area:demo'))
@@ -959,7 +959,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Check head branch is develop or fix/* (branch-strategy.md §3 / §7-1)
+      - name: Check head branch is develop, release/* or fix/* (branch-strategy.md §3 / §7-1)
         env:
           CUTOVER_AT: ${{ vars.BRANCH_STRATEGY_CUTOVER_AT }}
           HEAD_REF: ${{ github.head_ref }}
@@ -980,11 +980,11 @@ jobs:
             echo "PR 作成 ($PR_CREATED_AT) < cutover ($CUTOVER_AT) → grandfather 免除（§8 step 6）"
             exit 0
           fi
-          if [ "$HEAD_REF" = "develop" ] || [[ "$HEAD_REF" == fix/* ]]; then
-            echo "head=$HEAD_REF → OK（develop 統合 PR または hotfix）"
+          if [ "$HEAD_REF" = "develop" ] || [[ "$HEAD_REF" == release/* ]] || [[ "$HEAD_REF" == fix/* ]]; then
+            echo "head=$HEAD_REF → OK（develop/release 統合 PR または hotfix）"
             exit 0
           fi
-          echo "::error::main 向け PR の head は develop（統合 PR）または fix/*（hotfix、ADR-0002 重量 gate 必須）のみ許可されています。head=$HEAD_REF は develop 向けに PR を出し直してください（docs/sessions/branch-strategy.md §3 / §5）。"
+          echo "::error::main 向け PR の head は develop / release/*（統合 PR）または fix/*（hotfix、ADR-0002 重量 gate 必須）のみ許可されています。head=$HEAD_REF は develop 向けに PR を出し直してください（docs/sessions/branch-strategy.md §3 / §5）。"
           exit 1
 
   # Gate job: always runs and reports overall CI status.
@@ -1066,7 +1066,7 @@ jobs:
       always()
       && github.event_name == 'pull_request'
       && github.base_ref == 'main'
-      && github.head_ref == 'develop'
+      && (github.head_ref == 'develop' || startsWith(github.head_ref, 'release/'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/lib/resolve-base-branch.mjs
+++ b/scripts/lib/resolve-base-branch.mjs
@@ -15,6 +15,7 @@
  *   2. 現 branch に open PR が存在すれば、その baseRefName (最も権威ある情報)
  *   3. `origin/develop` 不在 → main (cutover 前 repo / clone 直後への後方互換)
  *   4. 現 branch == develop → main (統合 PR レーン)
+ *   4b. 現 branch が release/* → main (release ブランチ方式の統合標的、branch-strategy.md §3)
  *   5. branch が develop 固有 commit を含む → develop (develop 基点 feature branch)
  *   6. それ以外 → main (main 基点 hotfix、または develop == main で等価)
  *
@@ -70,6 +71,10 @@ export function resolveBaseBranch({
 	if (!hasDevelop) return 'main';
 	// 4. develop 自身は main へ向かう (統合 PR レーン)
 	if (currentBranch === 'develop') return 'main';
+	// 4b. release/* は develop の凍結コミットから cut した統合標的 → main へ向かう
+	//     (branch-strategy.md §3 release ブランチ方式)。release/* は develop 固有 commit を
+	//     含むため、rule 5 より前で判定しないと誤って develop 基点 feature と分類される。
+	if (currentBranch.startsWith('release/')) return 'main';
 	// 5. develop 固有 commit を含む branch は develop 基点の feature branch
 	if (containsDevelopOnlyCommits) return 'develop';
 	// 6. それ以外 = main 基点 hotfix、または develop == main (どちらでも等価)

--- a/scripts/pr-lane.mjs
+++ b/scripts/pr-lane.mjs
@@ -29,10 +29,16 @@
  *
  * lane 分類 (4 種、決定的・優先順位付き = 最初にマッチした lane を返す):
  *   1. actor が `dependabot[bot]` / `renovate[bot]`       → 'dependabot'
- *   2. headRef === 'develop' かつ baseRef === 'main'      → 'integration' (統合 PR、重量レーン)
+ *   2. baseRef === 'main' かつ (headRef === 'develop' または headRef が 'release/' で始まる)
+ *                                                         → 'integration' (統合 PR、重量レーン)
  *   3. headRef が 'fix/' で始まり baseRef === 'main'      → 'hotfix'      (ADR-0002 重量レーン)
  *   4. baseRef === 'develop'                              → 'feature'    (軽量レーン)
  *   5. 上記いずれにも非該当                                → 'feature'    (既定、後方互換)
+ *
+ * release ブランチ方式 (branch-strategy.md §3、#3021 動く標的問題の構造的解消):
+ *   develop の凍結コミットから cut した `release/*` を frozen 標的として main へ統合する。
+ *   release/* → main も develop → main と同じ integration (重量レーン) として扱い、
+ *   統合観点の AC gate / 重量 job を保証発火させる。
  *
  * back-merge PR の帰属 (#2960 / #2967 実地観測):
  *   hotfix を main に merge した後の main → develop back-merge PR
@@ -44,6 +50,7 @@
  *
  * Usage (CLI、AC5):
  *   node scripts/pr-lane.mjs --base main --head develop --actor x   # => "integration"
+ *   node scripts/pr-lane.mjs --base main --head release/2026-06-16 --actor x  # => "integration"
  *   node scripts/pr-lane.mjs --base develop --head feat/123 --actor Takenori-Kusaka  # => "feature"
  *
  * exit: 0 = 分類成功 (lane を stdout に出力) / 2 = 引数不足
@@ -89,8 +96,9 @@ export function classifyLane({ baseRef, headRef, actor }) {
 
 	// 1. bot は base/head より優先 (Dependabot exempt を lane の 1 種として吸収、BOT_ACTORS SSOT)
 	if (BOT_ACTOR_SET.has(who)) return 'dependabot';
-	// 2. develop → main = 統合 PR (重量レーン)
-	if (head === 'develop' && base === 'main') return 'integration';
+	// 2. develop → main または release/* → main = 統合 PR (重量レーン)
+	//    release/* は develop の凍結コミットから cut した統合標的 (branch-strategy.md §3)。
+	if (base === 'main' && (head === 'develop' || head.startsWith('release/'))) return 'integration';
 	// 3. fix/* → main = hotfix (ADR-0002 重量レーン)
 	if (head.startsWith('fix/') && base === 'main') return 'hotfix';
 	// 4. → develop = 軽量レーン (back-merge main→develop もここに帰属)

--- a/tests/unit/github/pr-lane.test.ts
+++ b/tests/unit/github/pr-lane.test.ts
@@ -24,6 +24,32 @@ describe('classifyLane (#2943 AC1/AC2)', () => {
 		);
 	});
 
+	// --- release ブランチ方式 (branch-strategy.md §3、動く標的問題の構造的解消) ---
+	it('integration: release/* → main も統合 PR (重量レーン) に帰属', () => {
+		expect(
+			classifyLane({ baseRef: 'main', headRef: 'release/2026-06-16', actor: 'Takenori-Kusaka' }),
+		).toBe('integration');
+	});
+
+	it('integration: release/ 接頭辞の各種命名 (日付 / 連番) も integration', () => {
+		for (const head of ['release/2026-06-16', 'release/v1.2.3', 'release/3021']) {
+			expect(classifyLane({ baseRef: 'main', headRef: head, actor: 'u' })).toBe('integration');
+		}
+	});
+
+	it('release/* → develop (base develop) は integration ではなく feature 軽量レーン', () => {
+		// base が develop のときは release 接頭辞でも feature (back-merge / 誤 base 防御)
+		expect(classifyLane({ baseRef: 'develop', headRef: 'release/2026-06-16', actor: 'u' })).toBe(
+			'feature',
+		);
+	});
+
+	it('優先順位: bot は release/* → main でも dependabot が勝つ', () => {
+		expect(
+			classifyLane({ baseRef: 'main', headRef: 'release/2026-06-16', actor: 'dependabot[bot]' }),
+		).toBe('dependabot');
+	});
+
 	it('dependabot: actor が base/head より優先 (develop→main でも bot なら dependabot)', () => {
 		expect(classifyLane({ baseRef: 'main', headRef: 'develop', actor: 'dependabot[bot]' })).toBe(
 			'dependabot',

--- a/tests/unit/scripts/resolve-base-branch.test.ts
+++ b/tests/unit/scripts/resolve-base-branch.test.ts
@@ -51,6 +51,17 @@ describe('resolveBaseBranch (#2959)', () => {
 		).toBe('main');
 	});
 
+	it('4b. release/* は main へ向かう (release ブランチ方式、develop 固有 commit を含んでも main)', () => {
+		// release/* は develop から cut するため develop 固有 commit を含むが、rule 5 より前で main に解決する
+		expect(
+			resolveBaseBranch({
+				...base,
+				currentBranch: 'release/2026-06-16',
+				containsDevelopOnlyCommits: true,
+			}),
+		).toBe('main');
+	});
+
 	it('5. develop 固有 commit を含む branch は develop (feature lane)', () => {
 		expect(resolveBaseBranch({ ...base, containsDevelopOnlyCommits: true })).toBe('develop');
 		expect(


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（外部品質監査プロセス）

**解決する課題**: 統合 PR（develop→main）の HEAD が develop の日次/毎時マージで動き続け、APPROVE→merge 直前に develop が動くたびに 8 領域監査・adversarial evidence（TTL 30 分）が無効化される「動く標的」問題が再監査ループを生んでいる（#3021）。

**期待される効果**: release ブランチ方式（develop の凍結コミットから cut した `release/*` を frozen 標的として main へ統合）を CI gate が正しく扱えるようにし、監査の動く標的問題を構造的に解消する基盤を作る。本 PR は Part 1（lane/gate 拡張）。

## 関連 Issue

closes #3063

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `classifyLane` が release/* → main を integration に分類 | `node scripts/pr-lane.mjs --base main --head release/2026-06-16 --actor x` + `npx vitest run tests/unit/github/pr-lane.test.ts` | HEAD `7c828895`+ / 出力 `integration` / pr-lane.test.ts:28-51 (release ケース 4 件) / 43 passed |
| AC2 | `resolveBaseBranch` が release/* branch を main 基点に解決 | `npx vitest run tests/unit/scripts/resolve-base-branch.test.ts` | resolve-base-branch.mjs:72-77 (rule 4b) / resolve-base-branch.test.ts:54-63 (rule 4b ケース) PASS |
| AC3 | main-pr-base-guard が head=release/* を許可 | `.github/workflows/ci.yml` `main-pr-base-guard` step | ci.yml:983 `[[ "$HEAD_REF" == release/* ]]` 追加 |
| AC4 | 重量 job 強制発火 + integration-evidence が release/* でも保証発火 | `grep "startsWith(github.head_ref, 'release/')" .github/workflows/ci.yml` | ci.yml 7 箇所 (413/458/530/678/741/769/1069) で release/* 条件追加 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: CI gate のみ（lane 判定 SSOT `scripts/pr-lane.mjs` / base 解決 `resolve-base-branch.mjs` / `ci.yml` の重量レーン発火条件）。アプリ実行コードへの影響なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（該当部: biome / vitest）— `npx biome check` PASS / `npx vitest run tests/unit/github/pr-lane.test.ts tests/unit/scripts/resolve-base-branch.test.ts` 43 passed
- [x] 追加・変更したテストの概要: `pr-lane.test.ts` に release/* → integration（4 ケース）/ `resolve-base-branch.test.ts` に release/* → main（rule 4b）を追加
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: infra のみ（CI gate ロジック）。UI 変更なし。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `classifyLane` / `resolveBaseBranch` は pure function を維持（既存 SSOT に rule 1 行追加のみ）
- [x] **DRY**: lane 判定は `pr-lane.mjs` 1 箇所の SSOT。ci.yml の重量発火条件は同一式を全 7 箇所で統一更新
- [x] **YAGNI**: lane を増やさず既存 integration に release/* を吸収（過剰抽象なし）
- [x] **Security（OSS 公開前提）**: `startsWith` で release/ 接頭辞のみ許可。base 解決の whitelist（main/develop）は既存維持
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): branch-strategy.md / audit-team.md は本 EPIC の Part 3（別 PR、#3063）で同期。本 PR は lane/gate 実装のみ
- [x] **並行 PR overlap** (#1200): `scripts/pr-lane.mjs` / `resolve-base-branch.mjs` / `ci.yml` を同時変更する open PR なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（既存 develop→main / fix/* の lane 判定は不変、release/* を追加するのみ）

**レビュー依頼事項・QA**: ci.yml の重量 job 強制発火条件 7 箇所が release/* を含むよう統一更新されているか（develop→main の既存挙動は不変）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready` 該当 Step PASS** をローカル確認した（biome / vitest）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（TODO / 「予定」のまま残っている AC がない）
- [x] Phase 分割: 本 EPIC #3063 を 3 PR に分割（lane/gate / runner pin / SSOT 文書）、PO 承認済
- [x] UI 変更なし（SS 該当なし）
- [x] 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
