### PR TITLE
infra: #3063 NUC deploy workflow を nuc runner に pin — 誤割り当て根治 (Part 2/3)

### DIFF
--- a/.github/workflows/deploy-nuc-staging.yml
+++ b/.github/workflows/deploy-nuc-staging.yml
@@ -44,7 +44,10 @@ concurrency:
 
 jobs:
   deploy-nuc-staging:
-    runs-on: [self-hosted, Windows, X64]
+    # NUC 専用 runner (local_nuc) に pin する。`nuc` ラベルなしの汎用 self-hosted runner
+    # (ci-runner-win 等、docker 不在 / NETWORK SERVICE 実行ポリシー Restricted) への誤割り当てを
+    # 排除する。本 job が ci-runner-win に割り当たり Step 0 で即死した事象の根治 (#3063)。
+    runs-on: [self-hosted, Windows, X64, nuc]
     # Self-hosted runner actor guard: 本番 deploy-nuc.yml と同じ ADR-0022 体制の 2 account に限定。
     # NUC 本番マシン上 (staging container も同マシンに同居) での想定外 actor による任意コード実行を防ぐ。
     if: contains(fromJSON('["Takenori-Kusaka", "ganbariquestsupport-lab"]'), github.actor)

--- a/.github/workflows/deploy-nuc.yml
+++ b/.github/workflows/deploy-nuc.yml
@@ -23,7 +23,10 @@ concurrency:
 
 jobs:
   deploy-nuc:
-    runs-on: [self-hosted, Windows, X64]
+    # NUC 専用 runner (local_nuc) に pin する。`nuc` ラベルなしの汎用 self-hosted runner
+    # (ci-runner-win 等、docker 不在 / 実行ポリシー Restricted) への誤割り当てを排除し、
+    # 本番 deploy を必ず実 NUC で走らせる (#3063 runner 誤割り当て根治)。
+    runs-on: [self-hosted, Windows, X64, nuc]
     # Self-hosted runner actor guard: restrict self-hosted NUC runner execution to
     # trusted actors performing main push / workflow_dispatch.
     #


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体 / 運営（デプロイ基盤）

**解決する課題**: self-hosted Windows runner が 2 台（`local_nuc`=実NUC / `ci-runner-win`=汎用CI）あり、両 deploy workflow が `runs-on: [self-hosted, Windows, X64]` で両方にマッチしていた。`deploy-nuc-staging` が `ci-runner-win`（docker 不在・NETWORK SERVICE 実行ポリシー Restricted）に誤割り当てされ Step 0 で即死した。本番 `deploy-nuc.yml` にも同じ穴があり、誤割り当て時に本番を誤マシンで deploy する事故になり得る。

**期待される効果**: `local_nuc` に付与した `nuc` ラベルで両 workflow を pin し、NUC deploy を必ず実 NUC で走らせる。誤割り当て事故を根治する。

## 関連 Issue

closes #3063

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | local_nuc に nuc ラベル付与 | `gh api repos/.../actions/runners --jq '.runners[]'` | local_nuc labels = `self-hosted, Windows, X64, nuc`（付与済）|
| AC2 | deploy-nuc.yml を nuc runner に pin | `grep -n "X64, nuc" .github/workflows/deploy-nuc.yml` | deploy-nuc.yml:26 `runs-on: [self-hosted, Windows, X64, nuc]` |
| AC3 | deploy-nuc-staging.yml を nuc runner に pin | `grep -n "X64, nuc" .github/workflows/deploy-nuc-staging.yml` | deploy-nuc-staging.yml `runs-on: [self-hosted, Windows, X64, nuc]` |
| AC4 | 次回 NUC deploy が local_nuc で走る | deploy run の `Runner name` ログ | merge 後の本番 deploy / staging run で確認（post-merge 検証） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: NUC デプロイ workflow（本番 + staging）の runner 割り当てのみ。アプリ実行コード・デプロイ手順（step）への影響なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready` 該当 Step PASS**: YAML 妥当性確認（`yaml.safe_load` PASS）
- [x] 追加・変更したテストの概要: N/A（workflow runner 割り当て変更のみ）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: infra のみ（runner 割り当て）。UI 変更なし。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（workflow 設定）
- [x] **DRY**: 両 NUC workflow を同一ラベル集合で pin
- [x] **YAGNI**: ラベル 1 個追加のみ（過剰な runner group 等は導入せず）
- [x] **Security**: `nuc` ラベルで信頼 runner を明示。actor guard（既存）は不変
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): runner 構成の記述は本 EPIC #3063 Part 3（docs PR）で同期
- [x] **並行 PR overlap** (#1200): deploy-nuc*.yml を変更する open PR なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（runner pin、deploy step は不変）

**レビュー依頼事項・QA**: `nuc` ラベルは付与済（gh api）。pin 後に runner 不在で pending しないこと（merge 後の deploy run で `Runner name: local_nuc` を確認）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **YAML 妥当性確認**済（both valid YAML）
- [x] セルフレビュー済み（不要な差分なし）
- [x] 全 AC が実装済み（AC4 のみ merge 後 deploy run で確認）
- [x] Phase 分割: EPIC #3063 を 3 PR 分割、PO 承認済
- [x] UI 変更なし
- [x] 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
