### PR TITLE
infra: #3071 integration lane の evidence gate を type:docs/dependencies skip から除外 (空洞化防止)

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -55,6 +55,8 @@ Dependabot / Renovate の依存更新 PR は以下を自動 skip（`dependencies
 
 検証ロジックは `scripts/check-ac-verification-map.mjs` / `scripts/check-merge-gate-checklist.mjs`（unit test 済、inline 重複なし）。required context 名は不変。lane 別の全 gate 対応表は `docs/sessions/branch-strategy.md`（A-6）が SSOT。
 
+**integration lane の label/comment skip 無効化（#3071、空洞化防止）**: `type:docs` / `dependencies` label / 明示 skip コメント（`<!-- ac-verification-skip -->`）による検証 skip は **feature / hotfix lane でのみ有効**。統合 PR（lane=integration）に誤って `type:docs` 等が付いても §3.5 マージ判定エビデンス表 / 統合用 section / template gate の検証を必ず実行する（誤ラベルで required check が空洞緑化するのを防ぐ）。`pr-template-gate-checks.mjs` の 5 check も同様（`hasDependenciesLabel` / `type:docs` skip を integration で無効化）。dependabot lane（bot actor）は `dependabotSkip(lane)` で従来どおり skip 維持（#1808）。
+
 ## 巨大 docs refactor PR の分割 (#2225)
 
 docs/ 配下の変更ファイル数が **50 超で QM 警告、100 超で BLOCK** (Epic 級は事前分割必須)。SSOT ファイル削除 (`docs/sessions/*` / `docs/decisions/*` / `*CLAUDE.md`) は移動先 PR を先に merge してから別 PR で削除。詳細: `docs/CLAUDE.md` §「巨大 docs refactor PR 分割ガイドライン」。

--- a/scripts/check-ac-verification-map.mjs
+++ b/scripts/check-ac-verification-map.mjs
@@ -88,14 +88,20 @@ function findEmptyRows(rows) {
 }
 
 /**
- * skip 判定（lane=dependabot 以外でも label / 明示 skip コメントで skip する）。
- * 呼び出し側 workflow は lane=dependabot を job-level if でも skip するが、
- * dependencies / type:docs / 明示 skip コメントは全 lane 共通の skip 条件。
+ * skip 判定。feature / hotfix lane では label / 明示 skip コメントで skip する。
+ * **integration lane では skip を一切認めない（#3071、空洞化防止）**: 誤った type:docs /
+ * dependencies label が統合 PR に付いても §3.5 マージ判定エビデンス表の検証を必ず実行する。
+ * 呼び出し側 workflow は lane=dependabot を job-level if でも skip する（本関数には非 dependabot のみ到達）。
  *
- * @param {{ body: string; labels: string[] }} input
+ * @param {{ body: string; labels: string[]; lane?: string }} input
  * @returns {{ skip: boolean; reason?: string }}
  */
-export function shouldSkip({ body, labels }) {
+export function shouldSkip({ body, labels, lane }) {
+	// integration lane (統合 PR = release/* → main または develop → main) では
+	// label / 明示コメントによる skip を無効化する (#3071)。required 緑のまま evidence 検証が空洞化するのを防ぐ。
+	if (lane === 'integration') {
+		return { skip: false };
+	}
 	if (labels.includes('type:docs')) {
 		return { skip: true, reason: 'type:docs ラベル' };
 	}
@@ -288,7 +294,7 @@ export function checkIntegrationEvidenceTable(body) {
  * @returns {AcCheckResult}
  */
 export function checkAcVerification({ body, labels, lane }) {
-	const skip = shouldSkip({ body, labels });
+	const skip = shouldSkip({ body, labels, lane });
 	if (skip.skip) {
 		return { ok: true, lane, reason: `skip: ${skip.reason}` };
 	}

--- a/scripts/check-merge-gate-checklist.mjs
+++ b/scripts/check-merge-gate-checklist.mjs
@@ -65,12 +65,18 @@ export function resolveIntegrationSections(override) {
 }
 
 /**
- * skip 判定（dependencies ラベルは全 lane 共通の skip 条件、Dependabot exempt 二重防御）。
+ * skip 判定。feature / hotfix lane では dependencies ラベルで skip する（Dependabot exempt 二重防御）。
+ * **integration lane では skip を一切認めない（#3071、空洞化防止）**: 誤った dependencies label が
+ * 統合 PR に付いても統合 PR 用 section の検証を必ず実行する。
+ * 呼び出し側 workflow は lane=dependabot を job-level if でも skip する（本関数には非 dependabot のみ到達）。
  *
- * @param {{ labels: string[] }} input
+ * @param {{ labels: string[]; lane?: string }} input
  * @returns {{ skip: boolean; reason?: string }}
  */
-export function shouldSkip({ labels }) {
+export function shouldSkip({ labels, lane }) {
+	if (lane === 'integration') {
+		return { skip: false };
+	}
 	if (labels.some((l) => l.includes('dependencies'))) {
 		return { skip: true, reason: 'dependencies ラベル（Dependabot exempt）' };
 	}
@@ -119,7 +125,7 @@ function countUnchecked(body, section) {
  * @returns {ChecklistResult}
  */
 export function checkMergeGateChecklist({ body, labels, lane, integrationSectionsOverride }) {
-	const skip = shouldSkip({ labels });
+	const skip = shouldSkip({ labels, lane });
 	if (skip.skip) {
 		return { ok: true, lane, targetSections: [], reason: `skip: ${skip.reason}` };
 	}

--- a/scripts/pr-template-gate-checks.mjs
+++ b/scripts/pr-template-gate-checks.mjs
@@ -77,11 +77,15 @@ export const INTEGRATION_REQUIRED_SECTIONS = [
 ];
 
 /**
- * dependencies label / type:docs 等の既存 skip 条件 (lane と直交)。
+ * dependencies label による skip 条件。
+ * **integration lane では無効化する (#3071、空洞化防止)**: 誤った dependencies label が統合 PR に
+ * 付いても template gate を必ず実行する。feature / hotfix lane は現行どおり skip (Dependabot exempt 二重防御)。
  * @param {string[]} labels
+ * @param {Lane} [lane]
  * @returns {boolean}
  */
-function hasDependenciesLabel(labels) {
+function hasDependenciesLabel(labels, lane) {
+	if (lane === 'integration') return false;
 	return labels.some((l) => l.includes('dependencies'));
 }
 
@@ -121,7 +125,7 @@ export function extractTemplateSections(template) {
 export function checkSectionPresence({ body, labels, template, ssotSections, lane }) {
 	const dep = dependabotSkip(lane);
 	if (dep) return dep;
-	if (hasDependenciesLabel(labels)) {
+	if (hasDependenciesLabel(labels, lane)) {
 		return { ok: true, skipped: true, message: '依存関係更新 PR のためスキップ', lane };
 	}
 
@@ -206,7 +210,7 @@ function sliceSection(body, heading) {
 export function checkIssueReference({ body, labels, template, lane }) {
 	const dep = dependabotSkip(lane);
 	if (dep) return dep;
-	if (hasDependenciesLabel(labels)) {
+	if (hasDependenciesLabel(labels, lane)) {
 		return { ok: true, skipped: true, message: '依存関係更新 PR のためスキップ', lane };
 	}
 
@@ -312,7 +316,7 @@ export function detectChangeTypeHeading(template) {
 export function checkChangeType({ body, labels, template, lane }) {
 	const dep = dependabotSkip(lane);
 	if (dep) return dep;
-	if (hasDependenciesLabel(labels)) {
+	if (hasDependenciesLabel(labels, lane)) {
 		return { ok: true, skipped: true, message: '依存関係更新 PR のためスキップ', lane };
 	}
 
@@ -367,7 +371,7 @@ export function checkChangeType({ body, labels, template, lane }) {
 export function checkCustomerValue({ body, labels, template, lane }) {
 	const dep = dependabotSkip(lane);
 	if (dep) return dep;
-	if (hasDependenciesLabel(labels)) {
+	if (hasDependenciesLabel(labels, lane)) {
 		return { ok: true, skipped: true, message: '依存関係更新 PR のためスキップ', lane };
 	}
 
@@ -478,10 +482,11 @@ export function detectTestSectionKeyword(template) {
 export function checkTestResults({ body, labels, template, lane }) {
 	const dep = dependabotSkip(lane);
 	if (dep) return dep;
-	if (hasDependenciesLabel(labels)) {
+	if (hasDependenciesLabel(labels, lane)) {
 		return { ok: true, skipped: true, message: '依存関係更新 PR のためスキップ', lane };
 	}
-	if (labels.includes('type:docs')) {
+	// integration lane では type:docs による skip を無効化する (#3071、空洞化防止)。
+	if (lane !== 'integration' && labels.includes('type:docs')) {
 		return { ok: true, skipped: true, message: 'type:docs PR のためスキップ', lane };
 	}
 

--- a/tests/unit/github/pr-template-gate-checks.test.ts
+++ b/tests/unit/github/pr-template-gate-checks.test.ts
@@ -386,6 +386,16 @@ describe('integration lane: 観点切替・空洞化なし (#2944 AC2/AC3)', () 
 		expect(r.ok).toBe(true);
 		expect(r.message).toContain('INTEGRATION_REQUIRED_SECTIONS');
 	});
+	// #3071: integration PR に誤って dependencies / type:docs label が付いても skip しない (空洞化防止)
+	it('integration + dependencies label でも section-presence は skip しない (#3071)', () => {
+		const r = checkSectionPresence({ ...base, labels: ['dependencies'], body: INTEGRATION_BODY });
+		expect(r.skipped).toBeFalsy();
+		expect(r.ok).toBe(true);
+	});
+	it('integration + type:docs label でも test-results は skip しない (#3071)', () => {
+		const r = checkTestResults({ ...base, labels: ['type:docs'], body: INTEGRATION_BODY });
+		expect(r.skipped).toBeFalsy();
+	});
 	it('section-presence FAIL: 統合必須 section 欠落で fail (空洞化していない証跡)', () => {
 		const r = checkSectionPresence({
 			...base,

--- a/tests/unit/scripts/check-ac-verification-map.test.ts
+++ b/tests/unit/scripts/check-ac-verification-map.test.ts
@@ -190,6 +190,28 @@ describe('shouldSkip (全 lane 共通の skip 条件)', () => {
 	});
 });
 
+// --- #3071: integration lane では label / 明示コメントによる skip を無効化 (空洞化防止) ---
+
+describe('shouldSkip integration lane = skip 無効化 (#3071)', () => {
+	it('integration lane では type:docs ラベルでも skip しない', () => {
+		expect(shouldSkip({ body: '', labels: ['type:docs'], lane: 'integration' }).skip).toBe(false);
+	});
+	it('integration lane では dependencies ラベルでも skip しない', () => {
+		expect(shouldSkip({ body: '', labels: ['dependencies'], lane: 'integration' }).skip).toBe(
+			false,
+		);
+	});
+	it('integration lane では明示 skip コメントでも skip しない', () => {
+		expect(
+			shouldSkip({ body: '<!-- ac-verification-skip: x -->', labels: [], lane: 'integration' })
+				.skip,
+		).toBe(false);
+	});
+	it('feature lane は従来どおり type:docs で skip する (回帰なし)', () => {
+		expect(shouldSkip({ body: '', labels: ['type:docs'], lane: 'feature' }).skip).toBe(true);
+	});
+});
+
 // --- checkAcVerification (lane エントリ、観点切替を一気通貫で検証) ---
 
 describe('checkAcVerification (lane エントリ、AC3/AC4)', () => {

--- a/tests/unit/scripts/check-merge-gate-checklist.test.ts
+++ b/tests/unit/scripts/check-merge-gate-checklist.test.ts
@@ -187,3 +187,21 @@ describe('shouldSkip / dependabot lane (AC6)', () => {
 		expect(r.reason).toContain('skip');
 	});
 });
+
+// --- #3071: integration lane では dependencies label による skip を無効化 (空洞化防止) ---
+
+describe('shouldSkip integration lane = skip 無効化 (#3071)', () => {
+	it('integration lane では dependencies ラベルでも skip しない', () => {
+		expect(shouldSkip({ labels: ['dependencies'], lane: 'integration' }).skip).toBe(false);
+	});
+	it('checkMergeGateChecklist: integration + dependencies label でも skip せず section 検証が走る', () => {
+		// 統合 PR section 不在 → 空洞化なら skip で PASS してしまう。fix 後は必ず検証され fail する。
+		const r = checkMergeGateChecklist({
+			body: '## 関係ないセクション\n本文のみ',
+			labels: ['dependencies'],
+			lane: 'integration',
+		});
+		expect(r.reason ?? '').not.toContain('skip');
+		expect(r.ok).toBe(false);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（merge-to-main 品質 gate の健全性）

**解決する課題**: integration lane（統合 PR）の evidence gate（`pr-ac-verification-check.yml` / `pr-merge-gate.yml` / `pr-template-gate.yml`）が `type:docs` / `dependencies` label で skip 可能なため、統合 PR に**誤ラベルが付くと §3.5 マージ判定エビデンス表 / NG 宣言の検証が required check 緑のまま空洞化**し得る（監査 run 3068 sev3 #2）。

**期待される効果**: skip 判定に lane guard を追加し、lane=integration では label/明示コメントによる skip を無効化。誤ラベルでも evidence 検証が必ず走り、merge-to-main gate の空洞化を防ぐ。

## 関連 Issue

closes #3071

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | lane=integration では type:docs / dependencies skip を無効化（evidence 表 / NG 宣言を常に検証） | `npx vitest run tests/unit/scripts/ tests/unit/github/pr-template-gate-checks.test.ts` | HEAD `92f6ceef6` / 3 script の `shouldSkip`/`hasDependenciesLabel` に `lane==='integration'` guard 追加。test PASS |
| AC2 | 該当 3 script に unit test 追加（integration + type:docs label → skip されないこと） | 同上 | HEAD `92f6ceef6` / 各 test に「integration + type:docs/dependencies → skip しない」case 追加（ac-map / merge-gate / pr-template）。84 tests PASS |
| AC3 | dependabot lane（bot actor）は従来通り skip 維持（#1808 整合） | `pr-template-gate-checks.mjs` の `dependabotSkip(lane)` 不変確認 | HEAD `92f6ceef6` / `dependabotSkip(lane==='dependabot')` は無変更。feature lane の type:docs skip 回帰なし test も追加 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — 3 gate script + 3 unit test + `.github/CLAUDE.md`

**影響を受ける画面・機能**: なし（CI gate の skip 判定ロジック。アプリ挙動・画面影響ゼロ。feature/hotfix/dependabot lane は挙動不変、integration lane のみ skip 無効化）。

## テスト & 安全装置セルフチェック

- [x] **関連 step PASS**: `npx vitest run tests/unit/github/ tests/unit/scripts/` → 720 passed（#3071 regression guard 含む）/ `biome check --error-on-warnings`（6 files）exit 0
- [x] 追加・変更したテストの概要: 3 test に「integration + type:docs/dependencies label → skip されず検証が走る」regression guard を追加（空洞化なら skip で PASS してしまうのを fail で固定）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: CI gate ロジック（scripts + tests + doc）のみの infra PR。UI 変更ゼロ。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: skip 判定の lane 直交問題を、既存 `shouldSkip` / `hasDependenciesLabel` に lane 引数を足す最小差分で解消（責務は skip 判定のまま）
- [x] **DRY**: 3 script で同型の `lane==='integration'` guard を各 skip 関数に集約。call site は lane を渡すのみ
- [x] **YAGNI**: integration lane の skip 無効化のみ。feature/hotfix/dependabot は不変
- [x] **Security**: merge-to-main gate の空洞化（governance hole）を塞ぐ。検証を緩める方向の変更は一切なし（むしろ強化）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] **labels SSOT**
- [x] **設計書同期** (ADR-0001): `.github/CLAUDE.md` の lane-aware 節に #3071 注記を追加（integration で label/comment skip 無効化、dependabot skip 維持）。3 script の header コメントも「全 lane 共通の skip」→「integration では無効化」に更新
- [x] **並行 PR overlap** (#1200): 3 gate script は他 open PR と非重複
- [ ] N/A

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**: integration lane でのみ skip が無効化されるため、もし統合 PR を意図的に skip させたいケースがあれば運用上の影響を確認（現状そのようなケースはなく、統合 PR は常に evidence 検証されるべき）。feature/hotfix/dependabot lane の挙動は完全不変（回帰 guard test 追加済）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **関連 step PASS** をローカル確認した（vitest 720 / biome 6 files exit 0）
- [x] セルフレビュー済み（3 script + 3 test + doc、最小差分・回帰 guard 追加）
- [x] 全 AC が実装済み（AC1-3）
- [x] Phase 分割: N/A
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
