### PR TITLE
infra: #3087 CloudFront /_app/* に Origin Shield を有効化し cold-miss burst の Lambda 直撃 429 を緩和

### DIFF
--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -214,9 +214,11 @@ EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 - デフォルト動作: Lambda Function URL (SSR + API)
   - キャッシュ無効（動的コンテンツ）
   - 全HTTPメソッド許可
+  - origin = `lambdaOrigin`（Origin Shield なし。キャッシュ無効な動的応答に二次キャッシュは無効で、余計な hop を載せないため）
 - `/_app/*`: SvelteKitの静的アセット
   - 365日キャッシュ（immutable）
   - Gzip + Brotli圧縮
+  - origin = `staticAssetOrigin`（**Origin Shield 有効 / region `us-east-1`、#3087**）。adapter-node + Lambda Web Adapter 構成では client 静的アセットも Lambda が配信するため、エッジ cache cold 時に ~224 本のチャンクが Lambda origin を一斉直撃し `TooManyRequestsException`(429) + HTTP/1.1 接続キュー輻輳で最遅 ~16s に達していた（HAR 実測）。Origin Shield（regional mid-tier cache）で cold-miss burst を 1 リージョンに集約 = 同一アセットの同時 origin fetch を 1 本に collapse + 二次キャッシュで Lambda 直撃を激減させる。region は origin (Lambda) と同一 us-east-1
 - `/error/*`: S3 エラーページ（OAC経由、Lambda障害時でもS3から配信）
 - カスタムエラーレスポンス: 500/502/503/504 → S3の子供向けエラーページ
 - Price Class: PriceClass_100（北米+欧州+アジア）
@@ -318,6 +320,7 @@ EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 - 別名: `demo.ganbari-quest.com`
 - ACM 証明書: `props.demoCertificateArn` (未指定時は本番 `certificateArn` を fallback、wildcard `*.ganbari-quest.com` が apex と sub-domain 双方をカバー)
 - キャッシュポリシー: 本番と同一 (`CACHING_DISABLED` 本系 + `/_app/*` 365 日キャッシュ)
+- Origin Shield: 本番と同型に `/_app/*` の `demoStaticAssetOrigin` で有効 (region `us-east-1`、#3087)。default behavior origin は本番同様 shield なし
 - セキュリティヘッダ: 本番と同一 (`SECURITY_HEADERS` policy)
 - CloudFront Function: query slash encode のみ (admin IP 制限は demo に適用しない、anonymous public demo のため)
 - geoRestriction: `JP` (本番と同一、Pre-PMF 段階)

--- a/infra/lib/network-stack.ts
+++ b/infra/lib/network-stack.ts
@@ -133,6 +133,25 @@ function handler(event) {
 			protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
 		});
 
+		// --- Origin Shield origin for /_app/* static assets (#3087) ---
+		// adapter-node + Lambda Web Adapter 構成では SvelteKit の build 済 client 静的
+		// アセット (/_app/immutable/*) も Lambda(Function URL) が配信する。エッジ cache が
+		// cold の間、親画面 1 表示で ~224 本のチャンクが Lambda origin を一斉直撃し、
+		// Lambda 同時実行スロットル (TooManyRequestsException / 429) + HTTP/1.1 接続キュー
+		// 輻輳で最遅 ~16s に達していた (HAR 実測、#3087)。
+		// Origin Shield (regional mid-tier cache) を /_app/* 専用 origin に有効化し、
+		// cold-miss burst を 1 リージョンに集約 = 同一アセットの同時 origin fetch を 1 本に
+		// collapse + 二次キャッシュで Lambda 直撃を激減させる。region は origin (Lambda) と
+		// 同一の us-east-1 (infra/CLAUDE.md「全リソース us-east-1 固定」整合)。
+		// default behavior (HTML/API、CACHING_DISABLED) は Origin Shield 経由にすると
+		// キャッシュ無しの動的応答に余計な hop が乗るため、shield なしの lambdaOrigin を維持し、
+		// 静的アセットのみ別 origin (staticAssetOrigin) に分離する。
+		const staticAssetOrigin = new origins.HttpOrigin(fnUrlDomain, {
+			protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
+			originShieldEnabled: true,
+			originShieldRegion: 'us-east-1',
+		});
+
 		this.distribution = new cloudfront.Distribution(this, 'CDN', {
 			comment: 'Ganbari Quest',
 			defaultBehavior: {
@@ -150,8 +169,19 @@ function handler(event) {
 				],
 			},
 			additionalBehaviors: {
+				// #3087: /error/* を /_app/* より先に宣言する。CDK は behavior の宣言順に origin
+				// index (CDNOrigin2/3...) を採番するため、既存 s3ErrorOrigin の index を 2 のまま
+				// 維持し、新規追加する staticAssetOrigin を末尾 (index 3) に置く。これにより既存
+				// error origin の OriginAccessControl 論理 ID が変わらず、cdk diff の不要な
+				// destroy/recreate (ADR-0019 gate ノイズ) を避ける。path pattern は非重複のため
+				// 宣言順は CloudFront のマッチング結果に影響しない。
+				'/error/*': {
+					origin: s3ErrorOrigin,
+					viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+					cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+				},
 				'/_app/*': {
-					origin: lambdaOrigin,
+					origin: staticAssetOrigin,
 					viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
 					cachePolicy: new cloudfront.CachePolicy(this, 'StaticAssetsCachePolicy', {
 						cachePolicyName: 'GanbariQuestStaticAssets',
@@ -161,11 +191,6 @@ function handler(event) {
 						enableAcceptEncodingGzip: true,
 						enableAcceptEncodingBrotli: true,
 					}),
-				},
-				'/error/*': {
-					origin: s3ErrorOrigin,
-					viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-					cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
 				},
 			},
 			errorResponses: [
@@ -315,6 +340,13 @@ function handler(event) {
 				protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
 			});
 
+			// /_app/* 静的アセット用 Origin Shield origin (#3087、本番と同型)。
+			const demoStaticAssetOrigin = new origins.HttpOrigin(demoFnUrlDomain, {
+				protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
+				originShieldEnabled: true,
+				originShieldRegion: 'us-east-1',
+			});
+
 			// demo 用 CloudFront Function: query slash encode のみ (admin IP 制限なし)。
 			const demoQueryFixFn = new cloudfront.Function(this, 'DemoQuerySlashEncodeFn', {
 				functionName: 'ganbari-quest-demo-query-slash-encode',
@@ -352,7 +384,7 @@ function handler(event) {
 				},
 				additionalBehaviors: {
 					'/_app/*': {
-						origin: demoLambdaOrigin,
+						origin: demoStaticAssetOrigin,
 						viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
 						cachePolicy: new cloudfront.CachePolicy(this, 'DemoStaticAssetsCachePolicy', {
 							cachePolicyName: 'GanbariQuestDemoStaticAssets',

--- a/tests/unit/infra/multi-lambda-cdk.test.ts
+++ b/tests/unit/infra/multi-lambda-cdk.test.ts
@@ -229,6 +229,72 @@ describe('ADR-0048 Multi-Lambda Demo Deployment (#2097 week 4)', () => {
 		});
 	});
 
+	describe('C-2b: /_app/* static asset Origin Shield (#3087)', () => {
+		// adapter-node + Lambda Web Adapter 構成では SvelteKit の build 済 client 静的アセット
+		// (/_app/immutable/*) も Lambda(Function URL) が配信する。エッジ cache cold 時に ~224 本の
+		// チャンクが Lambda origin を一斉直撃し TooManyRequestsException (429) + 輻輳で最遅 ~16s に
+		// 達していた (HAR 実測、#3087)。/_app/* 専用 origin に Origin Shield を有効化し cold-miss
+		// burst を 1 リージョンに collapse する。region は origin (Lambda) と同一 us-east-1。
+		type CfnOrigin = {
+			DomainName?: unknown;
+			CustomOriginConfig?: unknown;
+			OriginShield?: { Enabled?: boolean; OriginShieldRegion?: string };
+		};
+
+		function shieldOriginsFor(distributionLogicalIdPrefix: string): CfnOrigin[] {
+			const distributions = networkTemplate.findResources('AWS::CloudFront::Distribution');
+			const matched = Object.entries(distributions).filter(([logicalId]) =>
+				logicalId.startsWith(distributionLogicalIdPrefix),
+			);
+			expect(
+				matched.length,
+				`distribution with logical id prefix ${distributionLogicalIdPrefix} must exist`,
+			).toBe(1);
+			const entry = matched[0];
+			if (!entry) return [];
+			const origins = ((
+				entry[1] as { Properties?: { DistributionConfig?: { Origins?: CfnOrigin[] } } }
+			).Properties?.DistributionConfig?.Origins ?? []) as CfnOrigin[];
+			return origins.filter((o) => o.OriginShield?.Enabled === true);
+		}
+
+		it('本番 distribution の /_app/* origin に Origin Shield (us-east-1) が有効', () => {
+			const shielded = shieldOriginsFor('CDN');
+			// 静的アセット専用 origin (lambda function URL) のみ shield 有効、ちょうど 1 本
+			expect(shielded.length).toBe(1);
+			const origin = shielded[0];
+			if (!origin) throw new Error('unreachable: shielded.length === 1 asserted above');
+			expect(origin.OriginShield?.OriginShieldRegion).toBe('us-east-1');
+			// shield origin は HTTP custom origin (Lambda Function URL)、S3 ではない
+			expect(origin.CustomOriginConfig).toBeDefined();
+		});
+
+		it('demo distribution の /_app/* origin にも Origin Shield (us-east-1) が有効 (本番と同型)', () => {
+			const shielded = shieldOriginsFor('DemoCDN');
+			expect(shielded.length).toBe(1);
+			const origin = shielded[0];
+			if (!origin) throw new Error('unreachable: shielded.length === 1 asserted above');
+			expect(origin.OriginShield?.OriginShieldRegion).toBe('us-east-1');
+			expect(origin.CustomOriginConfig).toBeDefined();
+		});
+
+		it('default behavior (HTML/API) origin は Origin Shield 無し (動的応答に余計な hop を載せない)', () => {
+			// 各 distribution の origin は「shield 有効 1 本 + 無効 N 本」構成。
+			// default behavior が shield 経由になっていない = shield 無効 origin が最低 1 本あること。
+			const distributions = networkTemplate.findResources('AWS::CloudFront::Distribution');
+			for (const [logicalId, def] of Object.entries(distributions)) {
+				const origins = ((
+					def as { Properties?: { DistributionConfig?: { Origins?: CfnOrigin[] } } }
+				).Properties?.DistributionConfig?.Origins ?? []) as CfnOrigin[];
+				const nonShielded = origins.filter((o) => o.OriginShield?.Enabled !== true);
+				expect(
+					nonShielded.length,
+					`distribution ${logicalId} must keep at least one non-shielded origin for dynamic content`,
+				).toBeGreaterThanOrEqual(1);
+			}
+		});
+	});
+
 	describe('C-3: demo Fn environment variables', () => {
 		it('#2337: 本番 Fn (ganbari-quest-app) に PARENT_GATE_COOKIE_SECRET が注入される', () => {
 			// ADR-0050 + #2337 regression test: PR #2325 で本番 Lambda 未配備による /admin/* 500 障害再発防止。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ システム全体（AWS 版を使う全保護者）

**解決する課題**: AWS 版で PIN→親画面に入る初回表示時、CloudFront エッジ cold 状態だと SvelteKit の build 済 client 静的アセット (`/_app/immutable/*`) ~224 本が Lambda(Function URL) origin を一斉直撃し、Lambda 同時実行スロットル (`TooManyRequestsException` / 429 が 18 件) + HTTP/1.1 接続キュー輻輳で最遅 ~15.9s の待ちが発生していた（HAR 実測、#3087）。

**期待される効果**: `/_app/*` 専用 origin に Origin Shield を有効化し cold-miss burst を 1 リージョンに collapse することで、初回ログイン体験の 429 エラー + 長い待ちを緩和し、サインアップ直後の信頼毀損を防ぐ。

## 関連 Issue

closes #3087

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `/_app/*` の cold-miss burst で 429 が発生しないこと（Origin Shield 有効化） | `cd infra && npx cdk synth GanbariQuestNetwork` で OriginShield 設定を確認 | HEAD `32e77627f` / synth 出力に `OriginShield: {Enabled: true, OriginShieldRegion: us-east-1}` が prod+demo の 2 distribution 分。network-stack.ts:152 `staticAssetOrigin` / :346 `demoStaticAssetOrigin` |
| AC2 | origin(Lambda)直撃が大幅減（Origin Shield: 2 回目以降エッジ Hit + cold burst collapse） | cdk diff で `/_app/*` behavior が shielded origin を指すことを確認 | HEAD `32e77627f` / cdk diff: CDN の `/_app/*` TargetOriginId が新 shielded origin (CDNOrigin3) に変更、OriginShield Enabled:true 付与 |
| AC3 | CDK 差分が既存 distribution の Replacement を起こさない（ADR-0019） | `cd infra && npx cdk diff GanbariQuestNetwork` | HEAD `32e77627f` / CDN Distribution は `[~]` in-place 変更のみ、`requires replacement` / 非 demo destroy ゼロ。/error/* を先行宣言し既存 s3ErrorOrigin の OAC 論理 ID 維持。demo/Route53 の destroy はローカル synth artifact（git stash 比較で本変更非起因を実証） |
| AC4 | `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` の CloudFront origin/behavior 構成を同期（ADR-0001） | git diff | HEAD `32e77627f` / 13-*.md §3.5 NetworkStack の `/_app/*` に Origin Shield 記載 + §DemoCDN に同型記載追加 |
| AC5 | `infra && npx vitest run`（CDK 単体テスト）PASS | `npx vitest run tests/unit/infra/` | HEAD `32e77627f` / 4 files / 57 passed（新規 C-2b Origin Shield assert 3 件含む、multi-lambda-cdk.test.ts:232-300） |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] インフラ (`infra/`)

**影響を受ける画面・機能**: CloudFront 配信経路のみ（本番 + demo の `/_app/*` 静的アセット配信）。アプリ画面・ロジックの変更なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/infra/multi-lambda-cdk.test.ts` に describe `C-2b: /_app/* static asset Origin Shield (#3087)` を追加（prod/demo の `/_app/*` origin に OriginShield(us-east-1) が有効 / default behavior origin は shield 無し、の 3 assert）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（追加なし）
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high の infra fix）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: infra (`infra/lib/network-stack.ts`) + 設計書 + CDK テストのみの変更で、UI (`src/routes` / `src/lib/ui` / `src/lib/features` / `site/`) の変更を含まないため。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `/_app/*` 専用の shielded origin を独立生成し default(動的) origin と責務分離
- [x] **DRY**: prod / demo で同型の Origin Shield 構成（`staticAssetOrigin` / `demoStaticAssetOrigin`）。並行実装ペアとして両方に適用
- [x] **YAGNI**: 選択肢 A（Origin Shield）最小実装のみ。S3 offload（B）は scope 外
- [x] **Security（OSS 公開前提）**: secret hardcode なし。region 値 `us-east-1` は infra/CLAUDE.md の公開済み SSOT
- [x] **アクセシビリティ**: N/A（配信構成のみ）
- [x] **パフォーマンス**: cold-miss burst の origin fetch を collapse し Lambda 直撃・cold start 連鎖を削減（本変更の主目的）

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（CloudFront 配信構成のみ。ただし prod/demo の 2 distribution に同型適用済）
- [x] **設計書同期** (ADR-0001): `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` を同 PR で更新

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: 選択肢 A（Origin Shield、PO 承認）で #3087 の全 AC を充足する。選択肢 B（client 静的アセットの S3 offload による構造的根治）は deploy パイプライン変更を伴うため #3087 本文の段階適用方針のとおり後続 PR で扱う（本 PR scope 外）。cdk diff の Replacement 非発生は CI deploy gate（`check-cdk-replacement.mjs`）でも再検証される。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A（A で #3087 の全 AC 充足、子 Issue 不要）
- [x] UI 変更時: N/A（infra のみ）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
