### PR TITLE
feat: #3097 admin リソース正準スロット契約 + child-binding registry + fitness function (EPIC #3096 Sub-1)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -586,6 +586,37 @@ Material Design 3「画面 FAB 1 個原則」+ Notion / Linear / Asana / Todoist
 
 新規の admin リソース管理画面を作る際は、独自ヘッダーを inline で組まず **`AdminResourceHeader` を使う**。`ActivitiesHeader.svelte` は本コンポーネントの thin wrapper (活動固有の menu item 構成のみ担当)。`?` ページガイド trigger は `AdminLayout` (全 admin 共通) が担うため本コンポーネント scope 外。
 
+#### admin リソース管理画面の正準スロット縦順契約 (#3097、EPIC #3096)
+
+admin リソース管理 3 画面 (活動 / チェックリスト / ごほうび) は、本文の縦スロットを**以下の正準順で固定**する。各画面は「持つスロットだけ」を埋め、順序・実装・共有 component を不変に保つ (NN/G #4 consistency、画面ごとの操作学び直しコスト根絶)。
+
+| slot | 名称 | 必須 | 実装 |
+|---|---|---|---|
+| 1 | ヘッダー | ✓ | `AdminResourceHeader` (`data-testid="admin-resource-header"` を内包) |
+| 2 | 子供タブ | ✓ | `.child-tab-row` (常時 = 子供 1 人以上で表示、role="tablist")。testid `admin-<res>-child-tabs` |
+| 3 | 子供コンテキストバナー | — | `.child-context-banner` (選択中の子供 + 件数 + ヒント) |
+| 4 | プラン系バナー | — | upgrade / limit バナー (任意) |
+| 5 | **検索 + フィルタ行** | ✓ | **一覧の直上**、検索必須。(B) ドメイン固有フィルタ (活動カテゴリ等) は本スロットに同居 |
+| 6 | action message | — | `role="status"`、testid `<res>-action-message` (操作後のみ表示) |
+| 7 | 一覧 | ✓ | 空時は `UnifiedEmptyState` (SSOT)。testid `admin-<res>-list` |
+| 8 | 補助セクション | — | 一覧の下 (checklist 日次 override 等、(B) ドメイン差) |
+
+**(A) / (B) 線引き**:
+
+- **(A) 真の構造的不統一** (同概念・別配置 / 別実装) → 中身を統一する。例: 検索位置 (一覧直上に統一) / 子供タブ表示条件 (1 人以上に統一) / action message・プラン系バナーの slot 固定 / 子供コンテキストバナーの全画面追加 / 最外 spacing (`space-y-4`) / empty state の `UnifiedEmptyState` 化。
+- **(B) 正当なドメイン差** (その資源固有機能) → **撤去せず、正準スロットに置くだけ**。例: 活動のカテゴリフィルタ / copy・一括追加 (slot 5 or header `+`) / チェックリストの日次 override・配信先設定 (slot 8) は機能を消さない。
+
+**child-binding モデル契約 (ADR-0055 整合)**: 各資源の「子供との関係モデル」を `src/lib/features/admin/admin-resource-model-registry.ts` (SSOT) に宣言する。
+
+| 資源 | organizingModel | binding |
+|---|---|---|
+| activity / reward | `per-child-tabs` (子供が持つ) | `child-selection-dialog` (取込先 child を選ぶ) |
+| checklist | `family-distribute` (配信される) | `visibility-chip` (配信先 child を ON/OFF) |
+
+> checklist は Sub-2 (#3096) で per-child-tabs へ寄せる予定 (family master データモデルは維持)。本 PR では現状を宣言する。
+
+**fitness function (CI ガードレール)**: `tests/e2e/admin-resource-layout-contract.spec.ts` が registry を SSOT とし、各画面の DOM から「出現スロットの testid 順」を抽出 → 正準順の部分列 (subsequence) か / 必須スロット存在 / 共有 component 使用 / registry とモデル整合 を assert する (Architecture Fitness Function、『Building Evolutionary Architecture』Neal Ford 他)。`admin-add-path-isomorphism.spec.ts` (#2998、add 経路 dropdown の同型性) とは補完関係 (本 spec = 縦スロット順 + モデル / add-path spec = dropdown item の種類・順序)。以後どの改修も契約外レイアウト / 独自再実装 / モデル逸脱を作れば CI が即落ちる。
+
 #### admin リソース管理ページの add 経路は同型に揃える (#2903 / #2998、PO 指摘 #6b)
 
 複数の admin リソース管理ページ (活動 / チェックリスト / ごほうび / 等) の「+ 追加」dropdown は、**先頭 3 経路 (手動 / AI で提案 / みんなのテンプレートから探す) を同一順序で揃える** (NN/G #4 consistency)。AI 提案は dropdown 内の選択肢 → Dialog で開く方式に統一し、ページ本文に AI パネルを直置きしない (操作の入口がページ間で異なると顧客が混乱するため)。「みんなのテンプレートから探す」は admin 内 browse UI を出さず `/marketplace?type=<typeCode>` へ画面遷移する (マーケットプレイス一本化、本 §10 上記ルール整合)。同型性は **3 画面 (活動 / チェックリスト / ごほうび)** を対象に `tests/e2e/admin-add-path-isomorphism.spec.ts` が assert する (経路「数」でなく dropdown item の種類・順序の配置パターン同型性、#2998 AC6)。

--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -731,6 +731,52 @@ PO 提案「マーケプレ rule-preset 集約による settings 初期値配布
 
 同型性は **3 画面（活動 / チェックリスト / ごほうび）** を対象に `tests/e2e/admin-add-path-isomorphism.spec.ts` が assert する（経路「数」でなく dropdown item の種類・順序の配置パターン同型性、#2998 AC6）。`?` ページガイド trigger は `AdminLayout`（全 admin 共通）が担うため本コンポーネント scope 外。横断ポリシーの SSOT は [docs/DESIGN.md §10](../DESIGN.md)「admin リソース管理画面の標準構成」を参照。
 
+### 4.13.3 admin リソース管理画面 正準スロット縦順契約（#3097 / EPIC #3096 Sub-1）
+
+admin リソース管理 3 画面（活動 / チェックリスト / ごほうび）は、本文の縦スロットを**正準順で固定**する。各画面は「持つスロットだけ」を埋め、順序・実装・共有 component を不変に保つ（NN/G #4 consistency、画面ごとの操作学び直しコスト根絶）。
+
+#### 正準スロット縦順
+
+| slot | 名称 | 必須 | 代表 testid | 実装 |
+|---|---|:---:|---|---|
+| 1 | ヘッダー | ✓ | `admin-resource-header` | `AdminResourceHeader`（§4.13.2、画面に 1 個のみ） |
+| 2 | 子供タブ | ✓ | `admin-<res>-child-tabs` | `.child-tab-row`（子供 1 人以上で常時表示、`role="tablist"`） |
+| 3 | 子供コンテキストバナー | — | `<res>-child-context-banner` ／ `child-context-banner`（活動） | 選択中の子供 + 件数 + ヒント |
+| 4 | プラン系バナー | — | `admin-<res>-plan-banner` | upgrade / limit バナー |
+| 5 | 検索 + フィルタ行 | ✓ | `admin-<res>-search` | **一覧の直上**、検索必須。(B) ドメイン固有フィルタ（活動カテゴリ等）は本スロットに同居 |
+| 6 | action message | — | `<res>-action-message`（`role="status"`） | 操作後のみ表示 |
+| 7 | 一覧 | ✓ | `admin-<res>-list` | 空時は `UnifiedEmptyState`（SSOT） |
+| 8 | 補助セクション | — | （ドメイン固有 testid） | 一覧の下（checklist 日次 override・配信先設定等、(B) ドメイン差） |
+
+`<res>` = `activities` / `rewards` / `checklists`。必須スロット（header / child-tabs / search / list）は全画面で存在し、出現スロットは上から正準順（部分列）に並ぶ。スロット間に非正準の slot-level 要素を割り込ませない。
+
+#### (A) / (B) 線引き
+
+- **(A) 真の構造的不統一**（同概念・別配置 / 別実装）→ 中身を統一する。例: 検索位置（一覧直上に統一）/ 子供タブ表示条件（1 人以上に統一）/ action message・プラン系バナーの slot 固定 / 子供コンテキストバナーの全画面追加 / 最外 spacing（`space-y-4`）/ empty state の `UnifiedEmptyState` 化。
+- **(B) 正当なドメイン差**（その資源固有機能）→ **撤去せず、正準スロットに置くだけ**。例: 活動のカテゴリフィルタ / copy・一括追加（slot 5 or header `+`）/ チェックリストの日次 override・配信先設定（slot 8）は機能を消さない。
+
+#### child-binding モデル（ADR-0055 整合）
+
+各資源の「子供との関係モデル」を `src/lib/features/admin/admin-resource-model-registry.ts`（SSOT）に宣言する。
+
+| 資源 | organizingModel | binding | 配信 chip testid |
+|---|---|---|---|
+| activity / reward | `per-child-tabs`（子供が持つ） | `child-selection-dialog`（取込先 child を選ぶ） | なし（`null`） |
+| checklist | `family-distribute`（配信される） | `visibility-chip`（配信先 child を ON/OFF） | `checklist-distribution-visibility` |
+
+per-child リソース（activity / reward）は family master 専用の配信 VisibilityChip を持たない。checklist は配信導線（per-template 配信 section、または templates 0 件時は empty state の import bridge link）を item 件数に関わらず提供する。checklist は Sub-2（#3096）で `per-child-tabs` へ寄せる予定（family master データモデルは維持）。本 PR では現状を宣言する。registry の `organizingModel` / `binding` 型は本 registry が code 初出であり ADR-0055 設計 doc の二重宣言ではない（Sub-2 で共有 scope 型に統一 + drift gate 併設予定）。
+
+#### fitness function（CI ガードレール）
+
+`tests/e2e/admin-resource-layout-contract.spec.ts` が registry を SSOT とし、各画面の DOM から検証する（Architecture Fitness Function、『Building Evolutionary Architecture』Neal Ford 他）:
+
+- **(a) 順序 + 割り込み禁止**: 出現スロットが正準順（部分列）に並び、かつスロット間に非正準の slot-level 要素が割り込まない。
+- **(b) 必須スロット存在**: header / child-tabs / search / list が描画される。
+- **(c) 共有 component**: `AdminResourceHeader` を画面に 1 個だけ使い（inline 再実装で 0 個 / 2 個になれば fail）、一覧は canonical 共有スロット（`admin-<res>-list`）で描画する。
+- **(d) モデル整合**: 子供タブが描画され、per-child は配信 VisibilityChip を持たない（count 0）／family-distribute は配信導線を item 件数 0 でも持つ。
+
+`admin-add-path-isomorphism.spec.ts`（#2998、add 経路 dropdown の同型性）とは補完関係（本 spec = 縦スロット順 + モデル / add-path spec = dropdown item の種類・順序）。横断ポリシーの SSOT は [docs/DESIGN.md §10](../DESIGN.md)「admin リソース管理画面の正準スロット縦順契約」を参照。
+
 ### 4.14 証明書・シェアカード（CertificateCard / ShareCard）
 
 がんばり証明書の一覧表示と SNS シェア用カード。

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4041,6 +4041,9 @@ export const MARKETPLACE_IMPORT_FEEDBACK_LABELS = {
  * 子供別タブ切替 + 兄弟共通化 UX (copy / 一括追加) の SSOT。
  */
 export const ADMIN_ACTIVITIES_PAGE_LABELS = {
+	// #3097 (EPIC #3096): 検索ラベルを SSOT 化 (旧 inline hardcoded `活動名で検索` を labels へ移管)
+	searchLabel: '活動を検索',
+	searchPlaceholder: '🔍 活動名で検索...',
 	// 子供別タブ
 	childTabsAriaLabel: `${CHILD_TERMS.honorific}を選択`,
 	childCountSuffix: '件',
@@ -4715,6 +4718,13 @@ export const DEMO_CHILD_CHECKLIST_LABELS = {
 } as const;
 
 export const ADMIN_CHECKLISTS_PAGE_LABELS = {
+	// #3097 (EPIC #3096): 正準スロット契約に conform — 子供タブ / 子供コンテキストバナー / 検索を
+	//   activities (ADMIN_ACTIVITIES_PAGE_LABELS) と同型に揃える (NN/G #4 consistency)。
+	childTabsAriaLabel: `${CHILD_TERMS.honorific}を選択`,
+	childContextSuffix: 'のチェックリスト',
+	childContextHint: `配信先を切り替えると、他の${CHILD_TERMS.honorific}の進捗を確認できます`,
+	searchLabel: 'チェックリストを検索',
+	searchPlaceholder: 'チェックリスト名で検索...',
 	// #1755 (#1709-A): kind 削除に伴い tabAriaLabel は本 sub では未使用化
 	//   後続 sub-issue (#1709-B) で他用途に流用 / 削除を検討
 	tabAriaLabel: 'チェックリスト種別',

--- a/src/lib/features/admin/admin-resource-model-registry.ts
+++ b/src/lib/features/admin/admin-resource-model-registry.ts
@@ -1,0 +1,177 @@
+/**
+ * admin-resource-model-registry.ts — admin リソース管理画面の正準スロット契約 + child-binding モデル SSOT
+ * (#3097 / EPIC #3096)
+ *
+ * admin リソース管理 3 画面 (活動 / チェックリスト / ごほうび) は同じ「admin リソース管理画面」だが、
+ * スロット配置順・子供との関係モデル (per-child「子供が持つ」/ family master「配信される」) が
+ * 画面ごとにドリフトしていた (PO 約 12 回の指摘でも収束せず)。本 registry を SSOT として、
+ *   1. **正準スロット縦順** (CANONICAL_SLOT_ORDER) — 各画面はこの順で「持つスロットだけ」埋める
+ *   2. **child-binding モデル** (ADMIN_RESOURCE_MODEL_REGISTRY) — organizing / binding の宣言
+ * を 1 箇所に集約する。fitness function (`tests/e2e/admin-resource-layout-contract.spec.ts`) が
+ * 各画面の DOM をこの SSOT と照合し、契約逸脱を CI で検出する (Architecture Fitness Function、
+ * 『Building Evolutionary Architecture』Neal Ford 他の確立パターン)。
+ *
+ * 関連: DESIGN.md §10 / ADR-0055 (per-child / family master データモデル) /
+ *       tests/e2e/admin-add-path-isomorphism.spec.ts (#2998、add 経路同型性 — 補完関係)
+ */
+
+/**
+ * admin リソースの「子供との関係モデル」分類。
+ *
+ * - `organizingModel`:
+ *   - `'per-child-tabs'` — リソースが per-child instance で、子供タブで「この子のリソース」を切替表示する
+ *     (活動 / ごほうび。ADR-0055 per-child 主軸)。
+ *   - `'family-distribute'` — リソースが family master で、配信先の子供を選んで複数の子に配る
+ *     (チェックリスト。family master データモデル)。Sub-2 (#3096) で per-child-tabs へ寄せる予定。
+ * - `binding` — 取込 / 追加時に「どの子に紐付けるか」を確定する UI:
+ *   - `'child-selection-dialog'` — ChildSelectionDialog で取込先の子供を選ぶ (per-child リソース)。
+ *   - `'visibility-chip'` — VisibilityChipGroup で配信先の子供を ON/OFF する (family master リソース)。
+ */
+export type AdminResourceOrganizingModel = 'per-child-tabs' | 'family-distribute';
+export type AdminResourceBinding = 'child-selection-dialog' | 'visibility-chip';
+
+export interface AdminResourceModel {
+	/** リソース種別キー (registry の key と一致) */
+	readonly resource: 'activity' | 'reward' | 'checklist';
+	/** ルート path (fitness function が goto する) */
+	readonly route: string;
+	/** リソース一覧をどう編成するか */
+	readonly organizingModel: AdminResourceOrganizingModel;
+	/** 取込 / 追加時の child 紐付け UI */
+	readonly binding: AdminResourceBinding;
+	/**
+	 * DOM 整合検証用の代表 testid。
+	 * - `childTabsTestid` — 子供タブ row (per-child-tabs では必須出現)。
+	 * - `visibilityChipTestid` — family-distribute の配信先 chip (DOM 上に存在すべきか判定)。
+	 *   per-child-tabs リソースでは null (配信 chip を持たない)。
+	 */
+	readonly childTabsTestid: string;
+	readonly visibilityChipTestid: string | null;
+}
+
+/**
+ * 正準スロット縦順 (#3096 SSOT)。各画面はこの順で「持つスロットだけ」埋める。
+ * 順序・実装は不変。fitness function は各画面の DOM から「出現したスロットの testid」を上から順に
+ * 抽出し、本配列の部分列 (subsequence) になっているか (= 正準順に並んでいるか) を assert する。
+ *
+ * slot index と意味:
+ *   1 ヘッダー (AdminResourceHeader)
+ *   2 子供タブ (常時 = 1 人以上)
+ *   3 子供コンテキストバナー
+ *   4 プラン系バナー (任意 — upgrade / limit)
+ *   5 検索 + フィルタ行 (一覧の直上、検索必須)
+ *   6 action message (role="status")
+ *   7 一覧 (空時 UnifiedEmptyState)
+ *   8 補助セクション (任意 — 一覧の下)
+ */
+export interface CanonicalSlot {
+	readonly index: number;
+	readonly name: string;
+	/** この画面区分の代表 testid (画面ごとに prefix が異なるため、resource ごとに解決する) */
+	readonly testid: (resource: AdminResourceModel['resource']) => string | null;
+	/** 必須スロットか (header / child-tabs / search / list は全画面で必須) */
+	readonly required: boolean;
+}
+
+/**
+ * 各 resource の代表 testid を slot 単位で解決する。画面固有の prefix を吸収しつつ、
+ * 「同じ slot は同じ役割の testid」を SSOT 化する。null = その resource はそのスロットを持たない。
+ */
+const SLOT_TESTIDS = {
+	header: () => 'admin-resource-header',
+	childTabs: (r: AdminResourceModel['resource']) =>
+		r === 'activity'
+			? 'admin-activities-child-tabs'
+			: r === 'reward'
+				? 'admin-rewards-child-tabs'
+				: 'admin-checklists-child-tabs',
+	childContextBanner: (r: AdminResourceModel['resource']) =>
+		r === 'activity'
+			? 'child-context-banner'
+			: r === 'reward'
+				? 'rewards-child-context-banner'
+				: 'admin-checklists-child-context-banner',
+	planBanner: (r: AdminResourceModel['resource']) =>
+		r === 'activity'
+			? 'admin-activities-plan-banner'
+			: r === 'reward'
+				? 'admin-rewards-plan-banner'
+				: 'admin-checklists-plan-banner',
+	search: (r: AdminResourceModel['resource']) =>
+		r === 'activity'
+			? 'admin-activities-search'
+			: r === 'reward'
+				? 'admin-rewards-search'
+				: 'admin-checklists-search',
+	actionMessage: (r: AdminResourceModel['resource']) =>
+		r === 'activity'
+			? 'admin-activities-action-message'
+			: r === 'reward'
+				? 'rewards-action-message'
+				: 'checklists-action-message',
+	list: (r: AdminResourceModel['resource']) =>
+		r === 'activity'
+			? 'admin-activities-list'
+			: r === 'reward'
+				? 'admin-rewards-list'
+				: 'admin-checklists-list',
+} as const;
+
+export const CANONICAL_SLOT_ORDER: readonly CanonicalSlot[] = [
+	{ index: 1, name: 'header', testid: SLOT_TESTIDS.header, required: true },
+	{ index: 2, name: 'child-tabs', testid: SLOT_TESTIDS.childTabs, required: true },
+	{
+		index: 3,
+		name: 'child-context-banner',
+		testid: SLOT_TESTIDS.childContextBanner,
+		required: false,
+	},
+	{ index: 4, name: 'plan-banner', testid: SLOT_TESTIDS.planBanner, required: false },
+	{ index: 5, name: 'search', testid: SLOT_TESTIDS.search, required: true },
+	{ index: 6, name: 'action-message', testid: SLOT_TESTIDS.actionMessage, required: false },
+	{ index: 7, name: 'list', testid: SLOT_TESTIDS.list, required: true },
+] as const;
+
+/**
+ * 必須スロット名 (header / child-tabs / search / list)。fitness function が「存在」を assert する。
+ * action-message は条件付き表示 (操作後のみ) のため必須ではなく順序検証のみ対象。
+ */
+export const REQUIRED_SLOT_NAMES: readonly string[] = CANONICAL_SLOT_ORDER.filter(
+	(s) => s.required,
+).map((s) => s.name);
+
+/**
+ * child-binding モデル registry (SSOT)。
+ *
+ * activity / reward = per-child「子供が持つ」(per-child-tabs + child-selection-dialog)。
+ * checklist = family master「配信される」(family-distribute + visibility-chip)。
+ *   Sub-2 (#3096) で checklist を per-child-tabs に更新予定だが、本 PR では現状を宣言する。
+ */
+export const ADMIN_RESOURCE_MODEL_REGISTRY = {
+	activity: {
+		resource: 'activity',
+		route: '/admin/activities',
+		organizingModel: 'per-child-tabs',
+		binding: 'child-selection-dialog',
+		childTabsTestid: 'admin-activities-child-tabs',
+		visibilityChipTestid: null,
+	},
+	reward: {
+		resource: 'reward',
+		route: '/admin/rewards',
+		organizingModel: 'per-child-tabs',
+		binding: 'child-selection-dialog',
+		childTabsTestid: 'admin-rewards-child-tabs',
+		visibilityChipTestid: null,
+	},
+	checklist: {
+		resource: 'checklist',
+		route: '/admin/checklists',
+		organizingModel: 'family-distribute',
+		binding: 'visibility-chip',
+		childTabsTestid: 'admin-checklists-child-tabs',
+		visibilityChipTestid: 'checklist-distribution-visibility',
+	},
+} as const satisfies Record<string, AdminResourceModel>;
+
+export type AdminResourceKey = keyof typeof ADMIN_RESOURCE_MODEL_REGISTRY;

--- a/src/lib/features/admin/admin-resource-model-registry.ts
+++ b/src/lib/features/admin/admin-resource-model-registry.ts
@@ -146,6 +146,13 @@ export const REQUIRED_SLOT_NAMES: readonly string[] = CANONICAL_SLOT_ORDER.filte
  * activity / reward = per-child「子供が持つ」(per-child-tabs + child-selection-dialog)。
  * checklist = family master「配信される」(family-distribute + visibility-chip)。
  *   Sub-2 (#3096) で checklist を per-child-tabs に更新予定だが、本 PR では現状を宣言する。
+ *
+ * **ADR-0055 との関係 (Sub-1 暫定宣言)**: per-child / family master のデータモデル原則は ADR-0055 が
+ * SSOT だが、ADR-0055 は設計 doc であり code-level の共有 type を持たない (本 registry 起票時点で
+ * `organizingModel` / `binding` の TypeScript 型は本ファイルが初出)。よって本宣言は ADR-0055 の値を
+ * **再宣言ではなく初の code 化**であり二重 SSOT ではない。将来 ADR-0055 由来の共有 scope 型
+ * (`data-model-resource-scope`) が code 化された場合は、Sub-2 (#3096) で本 registry をそれに寄せて
+ * 統一し、drift gate (registry 値 ⇄ schema/ADR 整合の CI 照合) を併設する。
  */
 export const ADMIN_RESOURCE_MODEL_REGISTRY = {
 	activity: {

--- a/src/lib/features/admin/components/AdminResourceHeader.svelte
+++ b/src/lib/features/admin/components/AdminResourceHeader.svelte
@@ -86,7 +86,7 @@ let {
 }: Props = $props();
 </script>
 
-<header class="admin-resource-header">
+<header class="admin-resource-header" data-testid="admin-resource-header">
 	<div class="admin-resource-header__meta">
 		<div class="admin-resource-header__title-row">
 			<h2 class="admin-resource-header__title">{title}</h2>

--- a/src/lib/ui/styles/app.css
+++ b/src/lib/ui/styles/app.css
@@ -966,3 +966,64 @@ h1, h2, h3, h4 {
 .animate-btn-pulse {
 	animation: btn-pulse 0.8s ease-in-out infinite;
 }
+
+/* ============================================================
+   Admin resource layout — canonical slot shared classes (#3097 / EPIC #3096)
+   ------------------------------------------------------------
+   admin リソース管理 3 画面 (活動 / チェックリスト / ごほうび) の
+   子供タブ row + 子供コンテキストバナーを 1 箇所に集約 (DRY)。
+   旧: activities / rewards が各 component scope で同一定義を重複保持していた。
+   ============================================================ */
+
+.child-tab-row {
+	display: flex;
+	gap: 0.375rem;
+	flex-wrap: wrap;
+	align-items: center;
+	padding: 0.5rem;
+	background: var(--color-surface-muted);
+	border-radius: var(--radius-md);
+}
+
+.child-tab {
+	border-radius: 9999px !important;
+	font-size: 0.85rem !important;
+}
+
+.child-tab--inactive {
+	background: var(--color-surface) !important;
+	color: var(--color-text-secondary) !important;
+}
+
+.child-tab__count {
+	font-size: 0.75rem;
+	opacity: 0.8;
+	margin-left: 0.25rem;
+}
+
+.child-tab-actions {
+	display: flex;
+	gap: 0.25rem;
+	margin-left: auto;
+}
+
+.child-context-banner {
+	padding: 0.5rem 0.75rem;
+	background: var(--color-surface-accent);
+	border-left: 3px solid var(--color-border-accent);
+	border-radius: var(--radius-sm);
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+}
+
+.child-context-banner__label {
+	font-size: 0.9rem;
+	font-weight: 600;
+	color: var(--color-text-primary);
+}
+
+.child-context-banner__hint {
+	font-size: 0.75rem;
+	color: var(--color-text-muted);
+}

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -438,7 +438,7 @@ function selectChild(childId: number) {
 	<title>{PAGE_TITLES.activities}{APP_LABELS.pageTitleSuffix}</title>
 </svelte:head>
 
-<div class="space-y-3">
+<div class="space-y-4" data-testid="admin-activities-page">
 	<ActivitiesHeader
 		clearConfirmOpen={showClearConfirm}
 		onClearAll={() => { showClearConfirm = true; }}
@@ -504,10 +504,15 @@ function selectChild(childId: number) {
 		/>
 	{/if}
 
+	<!-- #3097 (EPIC #3096): プラン系バナー (slot 4) — 正準スロットに固定配置 -->
 	{#if activityLimit && !activityLimit.allowed}
-		<ActivityLimitBanner current={activityLimit.current} max={activityLimit.max} />
+		<div data-testid="admin-activities-plan-banner">
+			<ActivityLimitBanner current={activityLimit.current} max={activityLimit.max} />
+		</div>
 	{/if}
 
+	<!-- #3097 (EPIC #3096): 検索 + フィルタ行 (slot 5、一覧の直上)。
+	     (B) カテゴリフィルタは活動固有のドメイン差のため撤去せず本スロットに配置する。 -->
 	<!-- カテゴリフィルタ -->
 	<div class="filter-row" data-tutorial="category-filter">
 		<Button
@@ -531,8 +536,10 @@ function selectChild(childId: number) {
 		{/each}
 	</div>
 
-	<!-- 検索 -->
-	<FormField id="activity-search" label="活動名で検索" type="search" bind:value={searchQuery} placeholder="🔍 活動名で検索..." />
+	<!-- 検索 (slot 5、一覧の直上) -->
+	<div data-testid="admin-activities-search">
+		<FormField id="activity-search" label={ADMIN_ACTIVITIES_PAGE_LABELS.searchLabel} type="search" bind:value={searchQuery} placeholder={ADMIN_ACTIVITIES_PAGE_LABELS.searchPlaceholder} />
+	</div>
 
 	<!-- アクションメッセージ -->
 	<!--
@@ -557,7 +564,7 @@ function selectChild(childId: number) {
 	<!-- #2902 Phase A: 活動一覧（メインコンテンツ）— 選択中 child の per-child instance を
 	     単一表示。全行が ActivityListItem (編集 / 表示切替 / メインクエスト / 削除のフル CRUD)。
 	     旧 per-child read-only badge 行 + family master 並存表示は撤去 (二重表示 / 件数水増し解消)。 -->
-	<div class="space-y-1" data-tutorial="activity-list">
+	<div class="space-y-1" data-tutorial="activity-list" data-testid="admin-activities-list">
 		{#each filteredActivities as activity (activity.id)}
 			<div data-testid="per-child-activity-{activity.id}">
 				<ActivityListItem
@@ -820,47 +827,9 @@ function selectChild(childId: number) {
 		text-decoration: underline;
 	}
 
-	/* #2362 PR-3 Phase 4: child tabs */
-	.child-tab-row {
-		display: flex;
-		gap: 0.375rem;
-		flex-wrap: wrap;
-		align-items: center;
-		padding: 0.5rem;
-		background: var(--color-surface-muted);
-		border-radius: var(--radius-md);
-	}
-	:global(.child-tab) {
-		border-radius: 9999px !important;
-		font-size: 0.85rem !important;
-	}
-	:global(.child-tab--inactive) {
-		background: var(--color-surface) !important;
-		color: var(--color-text-secondary) !important;
-	}
-	.child-tab__count {
-		font-size: 0.75rem;
-		opacity: 0.8;
-		margin-left: 0.25rem;
-	}
-	.child-context-banner {
-		padding: 0.5rem 0.75rem;
-		background: var(--color-surface-accent);
-		border-left: 3px solid var(--color-border-accent);
-		border-radius: var(--radius-sm);
-		display: flex;
-		flex-direction: column;
-		gap: 0.125rem;
-	}
-	.child-context-banner__label {
-		font-size: 0.9rem;
-		font-weight: 600;
-		color: var(--color-text-primary);
-	}
-	.child-context-banner__hint {
-		font-size: 0.75rem;
-		color: var(--color-text-muted);
-	}
+	/* #3097 (EPIC #3096): child-tab-row / child-context-banner styles moved to
+	   app.css "Admin resource layout" shared classes (DRY across 3 admin pages).
+	   CSS comments use ASCII to satisfy local/no-hardcoded-jp-text in style blocks. */
 
 	/* #2902 Phase A: old .age-filter-banner / .per-child-item* (read-only rows) removed —
 	   display unified into ActivityListItem (ASCII comment to satisfy local/no-hardcoded-jp-text). */

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -43,21 +43,35 @@ import VisibilityChipGroup, {
 
 let { data, form } = $props();
 
-let selectedChildId = $state(0);
-
-$effect(() => {
-	const first = data.children[0];
-	if (selectedChildId === 0 && first) {
-		selectedChildId = first.id;
-	}
-});
+// #3097 (EPIC #3096): selectedChildId を SSR-safe な override + derived パターンに統一
+//   (activities / rewards と同型)。旧 `$state(0)` + `$effect` 初期化は SSR 時点で 0 のため、
+//   子供コンテキストバナー / 一覧 (slot 3 / 7) が hydration 前に描画されず正準スロット契約に
+//   反していた。derived の fallback を `children[0].id` にすることで SSR から確定する。
+let childIdOverride = $state<number | undefined>(undefined);
+const selectedChildId = $derived(
+	childIdOverride !== undefined && data.children.some((c) => c.id === childIdOverride)
+		? childIdOverride
+		: (data.children[0]?.id ?? 0),
+);
 
 const selectedChild = $derived(data.children.find((c) => c.id === selectedChildId));
+
+// #3097 (EPIC #3096): 正準スロット契約に conform — 検索 (slot 5、一覧の直上) を activities / rewards と
+//   同型に追加する。template 名で絞り込む (NN/G #4 consistency)。
+let searchQuery = $state('');
 
 // #2362 PR-5 Phase 2 (ADR-0055): family scope の templates 一覧 (childId 軸ではなく family 軸)
 //   旧 per-child templates 表示は廃止し、family templates を表示する。
 //   override 操作のみ child 軸が残るため selectedChild を維持。
-const filteredTemplates = $derived(data.familyTemplates);
+// #3097: searchQuery で template 名を絞り込む (一覧 slot の表示軸)。
+const filteredTemplates = $derived(
+	searchQuery.trim()
+		? data.familyTemplates.filter((t) =>
+				t.name.toLowerCase().includes(searchQuery.trim().toLowerCase()),
+			)
+		: data.familyTemplates,
+);
+const hasSearchActive = $derived(searchQuery.trim().length > 0);
 
 // #723: Free プランのテンプレート上限（UI ゲート用、family scope での件数）
 // null = 無制限（Standard/Family）
@@ -693,6 +707,87 @@ function getChildName(childId: number): string {
 		</AdminResourceHeader>
 	</div>
 
+	<!-- #3097 (EPIC #3096): 子供タブ (slot 2) — 正準スロット契約に conform。
+	     旧: 「2 人以上」表示条件 + Tailwind 直書き styling だったが、activities / rewards と同型に
+	     「1 人以上」常時表示 + `.child-tab-row` styling + role="tablist" に統一する (NN/G #4 consistency)。
+	     checklist は family master 配信モデルのため、本タブは override / 進捗確認の child 選択に使う。 -->
+	{#if data.children.length > 0}
+		<div
+			class="child-tab-row"
+			data-testid="admin-checklists-child-tabs"
+			role="tablist"
+			aria-label={ADMIN_CHECKLISTS_PAGE_LABELS.childTabsAriaLabel}
+		>
+			{#each data.children as child (child.id)}
+				<Button
+					variant={selectedChildId === child.id ? 'primary' : 'ghost'}
+					size="sm"
+					class="child-tab {selectedChildId === child.id ? '' : 'child-tab--inactive'}"
+					data-testid="checklists-child-tab-{child.id}"
+					role="tab"
+					aria-selected={selectedChildId === child.id}
+					onclick={() => (childIdOverride = child.id)}
+				>
+					{child.nickname}
+				</Button>
+			{/each}
+		</div>
+
+		<!-- #3097 (EPIC #3096): 子供コンテキストバナー (slot 3) — activities / rewards と同型に追加。 -->
+		{#if selectedChild}
+			<div class="child-context-banner" data-testid="admin-checklists-child-context-banner">
+				<span class="child-context-banner__label">
+					{selectedChild.nickname}{ADMIN_CHECKLISTS_PAGE_LABELS.childContextSuffix}
+				</span>
+				<span class="child-context-banner__hint">
+					{ADMIN_CHECKLISTS_PAGE_LABELS.childContextHint}
+				</span>
+			</div>
+		{/if}
+	{/if}
+
+	<!-- #3097 (EPIC #3096): プラン系バナー (slot 4) — free プラン上限の誘導を正準スロットに固定配置。
+	     旧: 一覧の下 (templates 描画後) にあったため activities / rewards (slot 4) と配置がズレていた。 -->
+	{#if !data.isPremium && checklistMax !== null}
+		<div class="px-4 py-3 rounded-lg bg-[var(--color-surface-trial)] border border-[var(--color-border-trial)] text-sm" data-testid="admin-checklists-plan-banner">
+			<div class="flex items-center justify-between gap-2">
+				<div class="flex items-center gap-2">
+					<span class="text-base">📋</span>
+					<span class="text-[var(--color-text-primary)]">
+						{#if atLimit}
+							{ADMIN_CHECKLISTS_PAGE_LABELS.limitReachedText(checklistMax)}
+						{:else}
+							{ADMIN_CHECKLISTS_PAGE_LABELS.limitCountText(currentCount, checklistMax)}
+						{/if}
+					</span>
+				</div>
+				<a
+					href="/pricing"
+					class="text-xs font-bold text-[var(--color-action-primary)] hover:underline"
+				>
+					{ADMIN_CHECKLISTS_PAGE_LABELS.upgradeLink}
+				</a>
+			</div>
+			{#if atLimit}
+				<p class="mt-1 text-xs text-[var(--color-text-secondary)]">
+					{ADMIN_CHECKLISTS_PAGE_LABELS.upgradeDesc}
+				</p>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- #3097 (EPIC #3096): 検索 (slot 5、一覧の直上) — activities / rewards と同型に追加。 -->
+	<section data-testid="admin-checklists-search">
+		<FormField
+			label={ADMIN_CHECKLISTS_PAGE_LABELS.searchLabel}
+			type="search"
+			bind:value={searchQuery}
+			placeholder={ADMIN_CHECKLISTS_PAGE_LABELS.searchPlaceholder}
+		/>
+	</section>
+
+	<!-- #3097 (EPIC #3096): action message (slot 6、role="status") — 正準スロットに固定配置。
+	     旧: ヘッダー直下 (slot 2 相当) にあったため activities / rewards (slot 6) と配置がズレていた。 -->
 	{#if actionMessage}
 		<div
 			class="bg-[var(--color-feedback-info-bg)] border border-[var(--color-feedback-info-border)] text-[var(--color-feedback-info-text)] rounded-xl p-3 text-sm flex flex-wrap items-center gap-2"
@@ -710,22 +805,6 @@ function getChildName(childId: number): string {
 					{PLAN_GATE_LABELS.upgradeLinkLabel}
 				</a>
 			{/if}
-		</div>
-	{/if}
-
-	<!-- Child selector (override 操作用に残す) -->
-	{#if data.children.length > 1}
-		<div class="flex gap-2" data-testid="checklists-child-tabs">
-			{#each data.children as child (child.id)}
-				<Button
-					variant={selectedChildId === child.id ? 'primary' : 'ghost'}
-					size="sm"
-					class={selectedChildId === child.id ? '' : 'bg-white text-[var(--color-text-secondary)] hover:bg-[var(--color-feedback-info-bg)]'}
-					onclick={() => (selectedChildId = child.id)}
-				>
-					{child.nickname}
-				</Button>
-			{/each}
 		</div>
 	{/if}
 
@@ -782,23 +861,27 @@ function getChildName(childId: number): string {
 			</a>
 		</section>
 
+		<!-- #3097 (EPIC #3096): 一覧 (slot 7、検索の直下)。空時は UnifiedEmptyState (SSOT)。 -->
 		<!-- #1755 (#1709-A): kind 削除 — 全テンプレート一覧表示 -->
 		<!-- CX-DoR #9・#11 横展開 (Round 18): 独自 empty markup を UnifiedEmptyState SSOT に統一。
 		     文言 (🎒 + emptyChecklistMessage) を override props で渡し視覚回帰ゼロ。add は header `+`
 		     menu / marketplace browse link が別途あるため shell 内 CTA は出さない (showPrimary/canImport=false)。 -->
+		<div data-testid="admin-checklists-list">
 		{#if filteredTemplates.length === 0}
 			<Card variant="elevated" padding="lg">
 				{#snippet children()}
 				<!-- #2998 (EPIC #2897): empty state の CTA 出し分けを 3 画面で統一 (AC4)。
 				     activities (ActivityEmptyState) と同型に、初期 setup 期の発見性として
 				     「みんなのテンプレートから探す」secondary link (DESIGN.md §10 bulk import bridge) を出す。
-				     primary 追加は header `+ 追加` dropdown に集約済のため showPrimary=false で重複を避ける。 -->
+				     primary 追加は header `+ 追加` dropdown に集約済のため showPrimary=false で重複を避ける。
+				     #3097: 検索結果空 (hasSearchActive) のときは filter-empty 表示に切替え、import link は出さない。 -->
 				<UnifiedEmptyState
 					testid="admin-checklists-empty-state"
 					icon="🎒"
+					hasFilter={hasSearchActive}
 					noItemsText={ADMIN_CHECKLISTS_PAGE_LABELS.emptyChecklistMessage}
 					showPrimary={false}
-					canImport={true}
+					canImport={!hasSearchActive}
 					importLinkLabel={ADMIN_CHECKLISTS_PAGE_LABELS.marketplaceSeeMore}
 					importTestid="checklists-empty-import-link"
 					secondaryMode="link"
@@ -958,40 +1041,13 @@ function getChildName(childId: number): string {
 				{/snippet}
 			</Card>
 		{/each}
-
-		<!-- #723: Free プランで上限到達時のアップグレード誘導 -->
-		{#if !data.isPremium && checklistMax !== null}
-			<div class="px-4 py-3 rounded-lg bg-[var(--color-surface-trial)] border border-[var(--color-border-trial)] text-sm">
-				<div class="flex items-center justify-between gap-2">
-					<div class="flex items-center gap-2">
-						<span class="text-base">📋</span>
-						<span class="text-[var(--color-text-primary)]">
-							{#if atLimit}
-								{ADMIN_CHECKLISTS_PAGE_LABELS.limitReachedText(checklistMax)}
-							{:else}
-								{ADMIN_CHECKLISTS_PAGE_LABELS.limitCountText(currentCount, checklistMax)}
-							{/if}
-						</span>
-					</div>
-					<a
-						href="/pricing"
-						class="text-xs font-bold text-[var(--color-action-primary)] hover:underline"
-					>
-						{ADMIN_CHECKLISTS_PAGE_LABELS.upgradeLink}
-					</a>
-				</div>
-				{#if atLimit}
-					<p class="mt-1 text-xs text-[var(--color-text-secondary)]">
-						{ADMIN_CHECKLISTS_PAGE_LABELS.upgradeDesc}
-					</p>
-				{/if}
-			</div>
-		{/if}
+		</div>
 
 		<!-- #2998 (EPIC #2897): 「+ 追加」dropdown + PremiumBadge は AdminResourceHeader に集約済
-		     (旧: 本文下部に Menu を別置きしていたが、3 画面で add 経路の入口を header に統一)。 -->
+		     (旧: 本文下部に Menu を別置きしていたが、3 画面で add 経路の入口を header に統一)。
+		     #3097: Free プラン上限バナーは slot 4 (プラン系バナー) に移動済 (正準スロット契約)。 -->
 
-		<!-- Today's overrides -->
+		<!-- Today's overrides (slot 8、補助セクション — 一覧の下、(B) checklist 固有の日次 override) -->
 		{#if selectedChild.overrides.length > 0}
 			<Card variant="default" padding="none">
 				{#snippet children()}

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -745,29 +745,7 @@ async function handleCopyFromChild() {
 		</p>
 	</div>
 
-	{#if !data.isPremium}
-		<!-- #728: 無料プラン向けアップグレード誘導 -->
-		<div class="bg-[var(--color-premium-bg)] rounded-xl p-4 space-y-3 border border-[var(--color-border-premium)]" data-testid="rewards-upgrade-banner">
-			<div class="flex items-start gap-3">
-				<span class="text-2xl">✨</span>
-				<div class="flex-1">
-					<p class="font-bold text-[var(--color-premium)]">{REWARDS_LABELS.upgradeBannerTitle}</p>
-					<p class="text-xs text-[var(--color-premium-light)] mt-1">
-						{REWARDS_LABELS.upgradeBannerDesc}
-					</p>
-				</div>
-			</div>
-			<a
-				href="/admin/subscription"
-				class="inline-block px-3 py-1.5 bg-[var(--color-premium)] text-[var(--color-text-inverse)] rounded-lg font-bold text-sm hover:opacity-90 transition-colors"
-				data-testid="rewards-upgrade-cta"
-			>
-				{REWARDS_LABELS.upgradeButton}
-			</a>
-		</div>
-	{/if}
-
-	<!-- #2362 PR-4: 子供タブ切替 UI -->
+	<!-- #2362 PR-4: 子供タブ切替 UI (slot 2、正準スロット契約 #3097) -->
 	{#if data.children.length > 0}
 		<div
 			class="child-tab-row"
@@ -817,10 +795,67 @@ async function handleCopyFromChild() {
 					{ADMIN_REWARDS_PAGE_LABELS.childContextHint}
 				</span>
 			</div>
+		{/if}
+	{/if}
 
-			<!-- #2832: 選択中 child のごほうび一覧 (編集 / 削除)。
-			     削除は pending redemption ガード (AC1)、編集は申請時点 snapshot note (AC2 案 b)。 -->
-			<section class="reward-list" data-testid="rewards-per-child-list">
+	<!-- #3097 (EPIC #3096): プラン系バナー (slot 4) — 正準スロットに固定配置。
+	     旧: child タブの上にあったため activities (slot 4 = limit banner) と配置がズレていた。 -->
+	{#if !data.isPremium}
+		<!-- #728: 無料プラン向けアップグレード誘導 -->
+		<div class="bg-[var(--color-premium-bg)] rounded-xl p-4 space-y-3 border border-[var(--color-border-premium)]" data-testid="admin-rewards-plan-banner">
+			<div class="flex items-start gap-3" data-testid="rewards-upgrade-banner">
+				<span class="text-2xl">✨</span>
+				<div class="flex-1">
+					<p class="font-bold text-[var(--color-premium)]">{REWARDS_LABELS.upgradeBannerTitle}</p>
+					<p class="text-xs text-[var(--color-premium-light)] mt-1">
+						{REWARDS_LABELS.upgradeBannerDesc}
+					</p>
+				</div>
+			</div>
+			<a
+				href="/admin/subscription"
+				class="inline-block px-3 py-1.5 bg-[var(--color-premium)] text-[var(--color-text-inverse)] rounded-lg font-bold text-sm hover:opacity-90 transition-colors"
+				data-testid="rewards-upgrade-cta"
+			>
+				{REWARDS_LABELS.upgradeButton}
+			</a>
+		</div>
+	{/if}
+
+	<!-- #2268: 検索 UI (slot 5、一覧の直上、正準スロット契約 #3097) -->
+	<section data-testid="admin-rewards-search">
+		<FormField
+			label={REWARDS_LABELS.searchLabel}
+			type="search"
+			bind:value={searchQuery}
+			placeholder={REWARDS_LABELS.searchPlaceholder}
+		/>
+	</section>
+
+	<!-- アクションメッセージ (取込結果 / copy 結果 / invalid preset 警告) — slot 6 (role="status") -->
+	{#if actionMessage}
+		<div
+			class="action-message"
+			role="status"
+			data-testid="rewards-action-message"
+		>
+			<span>{actionMessage}</span>
+			<!-- #2894 AC3: PlanLimitError 受領時はアップグレード導線を併記 (NN/G #9) -->
+			{#if actionUpgradeUrl}
+				<a class="action-upgrade-link" href={actionUpgradeUrl} data-testid="rewards-upgrade-link">
+					{PLAN_GATE_LABELS.upgradeLinkLabel}
+				</a>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- #3097 (EPIC #3096): ごほうび一覧 (slot 7、検索の直下)。
+	     #2832: 選択中 child のごほうび一覧 (編集 / 削除)。削除は pending redemption ガード (AC1)、
+	     編集は申請時点 snapshot note (AC2 案 b)。旧: child-context バナー直下 (slot 3) に置かれ
+	     検索 (slot 5) より上だったため正準順に違反していた。 -->
+	{#if selectedChild}
+		<section class="reward-list" data-testid="admin-rewards-list">
+			<div data-testid="rewards-per-child-list">
 				{#if perChildRewards.length === 0}
 					<p class="reward-list__empty" data-testid="rewards-per-child-empty">
 						{ADMIN_REWARDS_PAGE_LABELS.rewardListEmpty}
@@ -859,35 +894,8 @@ async function handleCopyFromChild() {
 						</div>
 					{/each}
 				{/if}
-			</section>
-		{/if}
-	{/if}
-
-	<!-- #2268: 検索 UI -->
-	<section>
-		<FormField
-			label={REWARDS_LABELS.searchLabel}
-			type="search"
-			bind:value={searchQuery}
-			placeholder={REWARDS_LABELS.searchPlaceholder}
-		/>
-	</section>
-
-	<!-- アクションメッセージ (取込結果 / copy 結果 / invalid preset 警告) -->
-	{#if actionMessage}
-		<div
-			class="action-message"
-			role="status"
-			data-testid="rewards-action-message"
-		>
-			<span>{actionMessage}</span>
-			<!-- #2894 AC3: PlanLimitError 受領時はアップグレード導線を併記 (NN/G #9) -->
-			{#if actionUpgradeUrl}
-				<a class="action-upgrade-link" href={actionUpgradeUrl} data-testid="rewards-upgrade-link">
-					{PLAN_GATE_LABELS.upgradeLinkLabel}
-				</a>
-			{/if}
-		</div>
+			</div>
+		</section>
 	{/if}
 
 	<!-- Error Display -->
@@ -1246,52 +1254,9 @@ async function handleCopyFromChild() {
 		text-decoration: underline;
 	}
 
-	/* #2362 PR-4: child tab row + actions */
-	.child-tab-row {
-		display: flex;
-		gap: 0.375rem;
-		flex-wrap: wrap;
-		align-items: center;
-		padding: 0.5rem;
-		background: var(--color-surface-muted);
-		border-radius: var(--radius-md);
-	}
-	:global(.child-tab) {
-		border-radius: 9999px !important;
-		font-size: 0.85rem !important;
-	}
-	:global(.child-tab--inactive) {
-		background: var(--color-surface) !important;
-		color: var(--color-text-secondary) !important;
-	}
-	.child-tab__count {
-		font-size: 0.75rem;
-		opacity: 0.8;
-		margin-left: 0.25rem;
-	}
-	.child-tab-actions {
-		display: flex;
-		gap: 0.25rem;
-		margin-left: auto;
-	}
-	.child-context-banner {
-		padding: 0.5rem 0.75rem;
-		background: var(--color-surface-accent);
-		border-left: 3px solid var(--color-border-accent);
-		border-radius: var(--radius-sm);
-		display: flex;
-		flex-direction: column;
-		gap: 0.125rem;
-	}
-	.child-context-banner__label {
-		font-size: 0.9rem;
-		font-weight: 600;
-		color: var(--color-text-primary);
-	}
-	.child-context-banner__hint {
-		font-size: 0.75rem;
-		color: var(--color-text-muted);
-	}
+	/* #3097 (EPIC #3096): child-tab-row / child-context-banner styles moved to
+	   app.css "Admin resource layout" shared classes (DRY across 3 admin pages).
+	   CSS comments use ASCII to satisfy local/no-hardcoded-jp-text in style blocks. */
 
 	.action-message {
 		padding: 0.5rem 0.75rem;

--- a/tests/e2e/admin-resource-layout-contract.spec.ts
+++ b/tests/e2e/admin-resource-layout-contract.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * tests/e2e/admin-resource-layout-contract.spec.ts
+ *
+ * #3097 (EPIC #3096): admin リソース管理画面の「正準スロット契約」fitness function。
+ *
+ * admin リソース管理 3 画面 (活動 / チェックリスト / ごほうび) のスロット配置順・共有 component 使用・
+ * child-binding モデルが画面ごとにドリフトする問題 (PO 約 12 回の指摘でも収束せず) の根治。
+ * `src/lib/features/admin/admin-resource-model-registry.ts` の SSOT を唯一の真実とし、各画面の DOM を
+ * 照合する。契約逸脱 (順序違反 / 必須スロット欠落 / 共有 component 不使用 / モデル不整合) があれば
+ * CI で即 fail する (Architecture Fitness Function、『Building Evolutionary Architecture』Neal Ford 他)。
+ *
+ * `admin-add-path-isomorphism.spec.ts` (#2998、add 経路 dropdown の同型性) とは補完関係:
+ *   - add-path test = 「+ 追加」dropdown 内 item の種類・順序の同型性
+ *   - 本 test     = 画面の縦スロット順・共有 component・child-binding モデルの整合性
+ *
+ * 認証は demo 無認証 (`AUTH_MODE=anonymous DATA_SOURCE=demo`) 前提。本 spec は構造 (testid の出現順序 +
+ * 存在 + 整合) を assert するため、render-only 禁止原則 (tests/CLAUDE.md) の対象外 (操作を伴わない
+ * 構造契約検証)。可視性 + 出現順序で十分。
+ */
+
+import { expect, type Page, test } from '@playwright/test';
+import {
+	ADMIN_RESOURCE_MODEL_REGISTRY,
+	type AdminResourceModel,
+	CANONICAL_SLOT_ORDER,
+	REQUIRED_SLOT_NAMES,
+} from '../../src/lib/features/admin/admin-resource-model-registry';
+
+const RESOURCES = Object.values(ADMIN_RESOURCE_MODEL_REGISTRY);
+
+/**
+ * ページ DOM から「正準スロットのうち実際に出現したもの」を、document 上の出現順序で返す。
+ *
+ * 各スロットの代表 testid を `[data-testid="..."]` で query し、可視要素を document 内の DOM 順
+ * (`compareDocumentPosition`) で並べる。fitness function は「出現したスロットが CANONICAL_SLOT_ORDER の
+ * 部分列 (subsequence) になっているか」= 正準順に並んでいるかを照合する。
+ */
+async function readVisibleSlotsInDomOrder(
+	page: Page,
+	resource: AdminResourceModel['resource'],
+): Promise<string[]> {
+	// 各スロットの testid → slot 名 の対応を作る (null のスロットは除外)。
+	const slotTestids = CANONICAL_SLOT_ORDER.map((slot) => ({
+		name: slot.name,
+		testid: slot.testid(resource),
+	})).filter((s): s is { name: string; testid: string } => Boolean(s.testid));
+
+	const present: { name: string; testid: string }[] = [];
+	for (const slot of slotTestids) {
+		const loc = page.getByTestId(slot.testid);
+		// action-message 等の条件付きスロットは未表示のことがある。可視のものだけ拾う。
+		if (
+			await loc
+				.first()
+				.isVisible()
+				.catch(() => false)
+		) {
+			present.push(slot);
+		}
+	}
+
+	// DOM 出現順に並べ替える (testid → DOM index)。
+	const orderedNames = await page.evaluate(
+		(testids: string[]) => {
+			const nodes = testids
+				.map((t) => ({ t, el: document.querySelector(`[data-testid="${t}"]`) }))
+				.filter((x): x is { t: string; el: Element } => x.el !== null);
+			nodes.sort((a, b) => {
+				const pos = a.el.compareDocumentPosition(b.el);
+				// a が b より前 (DOCUMENT_POSITION_FOLLOWING on b) → a 先
+				// eslint-disable-next-line no-bitwise
+				if (pos & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+				// eslint-disable-next-line no-bitwise
+				if (pos & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+				return 0;
+			});
+			return nodes.map((n) => n.t);
+		},
+		present.map((p) => p.testid),
+	);
+
+	// testid → slot 名に戻す
+	const testidToName = new Map(present.map((p) => [p.testid, p.name]));
+	return orderedNames.map((t) => testidToName.get(t) ?? t);
+}
+
+/** observed が canonical の部分列 (subsequence) なら true (= observed が正準順に並んでいる)。 */
+function isSubsequence(observed: string[], canonical: string[]): boolean {
+	let ci = 0;
+	for (const name of observed) {
+		const found = canonical.indexOf(name, ci);
+		if (found === -1) return false;
+		ci = found + 1;
+	}
+	return true;
+}
+
+const CANONICAL_NAMES = CANONICAL_SLOT_ORDER.map((s) => s.name);
+
+test.describe('#3097 admin リソース正準スロット契約 (activities / rewards / checklists)', () => {
+	for (const model of RESOURCES) {
+		test.describe(`${model.resource} (${model.route})`, () => {
+			test.beforeEach(async ({ page }) => {
+				await page.goto(model.route);
+				// header は全画面必須 — 描画完了の anchor に使う。
+				await expect(page.getByTestId('admin-resource-header')).toBeVisible({ timeout: 15_000 });
+			});
+
+			test('(a) 出現スロットが正準順 (CANONICAL_SLOT_ORDER の部分列) に並ぶ', async ({ page }) => {
+				const observed = await readVisibleSlotsInDomOrder(page, model.resource);
+				expect(
+					isSubsequence(observed, CANONICAL_NAMES),
+					`observed slot order ${JSON.stringify(observed)} は canonical ${JSON.stringify(CANONICAL_NAMES)} の部分列ではない (順序違反)`,
+				).toBe(true);
+			});
+
+			test('(b) 必須スロット (header / child-tabs / search / list) が存在する', async ({
+				page,
+			}) => {
+				const observed = await readVisibleSlotsInDomOrder(page, model.resource);
+				for (const required of REQUIRED_SLOT_NAMES) {
+					expect(observed, `必須スロット "${required}" が描画されていない`).toContain(required);
+				}
+			});
+
+			test('(c) 共有 component を使用している (header=AdminResourceHeader / empty=UnifiedEmptyState testid 体系)', async ({
+				page,
+			}) => {
+				// header = AdminResourceHeader (admin-resource-header testid を内包)
+				await expect(page.getByTestId('admin-resource-header')).toBeVisible();
+			});
+
+			test('(d) registry 宣言と DOM (子供タブ / child-binding モデル) が整合する', async ({
+				page,
+			}) => {
+				// 子供タブ: per-child-tabs / family-distribute いずれも child タブを描画する (本 PR では両モデルとも常時表示)。
+				await expect(page.getByTestId(model.childTabsTestid)).toBeVisible();
+
+				if (model.binding === 'child-selection-dialog') {
+					// per-child-tabs (activity / reward) は ChildSelectionDialog で取込先 child を選ぶ。
+					// 取込 dialog が DOM 上に mount されている (closed でも Ark UI が DOM に保持) ことを確認し、
+					// family master 専用の配信 VisibilityChip は持たないことを assert する。
+					await expect(page.getByTestId('checklist-distribution-visibility')).toHaveCount(0);
+				} else {
+					// family-distribute (checklist) は配信先設定の入口 (distribution section) を持つ。
+					// VisibilityChip 本体は Dialog open 時のみ Portal に mount されるため、ここでは
+					// 配信モデルの入口 (per-template distribution section) が DOM 上に存在することを確認する。
+					// (templates が 0 件のときは section が無いため、その場合は child-tabs 存在で代替検証する。)
+					const distributionSections = page.locator(
+						'[data-testid^="checklist-distribution-section-"]',
+					);
+					const sectionCount = await distributionSections.count();
+					if (sectionCount > 0) {
+						await expect(distributionSections.first()).toBeVisible();
+					}
+				}
+			});
+		});
+	}
+});

--- a/tests/e2e/admin-resource-layout-contract.spec.ts
+++ b/tests/e2e/admin-resource-layout-contract.spec.ts
@@ -28,6 +28,15 @@ import {
 
 const RESOURCES = Object.values(ADMIN_RESOURCE_MODEL_REGISTRY);
 
+/** 全 resource の全 slot 代表 testid 集合 (drift 検出時の「正準 testid か」判定に使う)。 */
+const ALL_CANONICAL_TESTIDS = new Set<string>(
+	RESOURCES.flatMap((r) =>
+		CANONICAL_SLOT_ORDER.map((slot) => slot.testid(r.resource)).filter((t): t is string =>
+			Boolean(t),
+		),
+	),
+);
+
 /**
  * ページ DOM から「正準スロットのうち実際に出現したもの」を、document 上の出現順序で返す。
  *
@@ -84,6 +93,89 @@ async function readVisibleSlotsInDomOrder(
 	return orderedNames.map((t) => testidToName.get(t) ?? t);
 }
 
+/**
+ * canonical スロット間に「非正準の slot-level 兄弟要素」が割り込んでいないか検出する。
+ *
+ * `readVisibleSlotsInDomOrder` は **canonical-named testid だけ** を query するため、スロットとスロットの
+ * 間に正準でない section / banner が挿入されても部分列照合では見えない (順序は崩れていないため PASS)。
+ * これを塞ぐため、canonical スロット要素の共通親 (LCA) を求め、その **直接の子要素**を document 順に
+ * 走査し、「canonical スロットを含む子」の連続帯 (first〜last canonical child) の中に、
+ * canonical でない `data-testid` を持つ slot-level 兄弟が割り込んでいないかを assert する。
+ *
+ * 返り値: 割り込んでいた非正準 testid の配列 (空なら drift なし)。
+ */
+async function findIntruderTestidsBetweenSlots(
+	page: Page,
+	resource: AdminResourceModel['resource'],
+): Promise<string[]> {
+	const canonicalTestids = CANONICAL_SLOT_ORDER.map((slot) => slot.testid(resource)).filter(
+		(t): t is string => Boolean(t),
+	);
+	return page.evaluate(
+		({ canonicalTestids, allCanonicalTestids }) => {
+			// canonical スロット要素群の lowest common ancestor (LCA) を返す (browser context helper)。
+			const findLca = (els: Element[]): Element | null => {
+				let lca: Element | null = els[0] ?? null;
+				for (let i = 1; i < els.length && lca; i++) {
+					const ancestors = new Set<Element>();
+					for (let a: Element | null = lca; a; a = a.parentElement) ancestors.add(a);
+					let b: Element | null = els[i] ?? null;
+					while (b && !ancestors.has(b)) b = b.parentElement;
+					lca = b;
+				}
+				return lca;
+			};
+
+			const present = canonicalTestids
+				.map((t) => document.querySelector(`[data-testid="${t}"]`))
+				.filter((el): el is Element => el !== null);
+			if (present.length < 2) return [];
+
+			const lca = findLca(present);
+			if (!lca) return [];
+
+			// LCA の直接の子のうち「canonical スロットを内包する子」の index 範囲を求める。
+			const children = Array.from(lca.children);
+			const containsCanonical = (child: Element): boolean =>
+				present.some((slot) => child === slot || child.contains(slot));
+			const canonicalChildIdx = children
+				.map((c, i) => (containsCanonical(c) ? i : -1))
+				.filter((i) => i >= 0);
+			const firstIdx = canonicalChildIdx[0];
+			const lastIdx = canonicalChildIdx[canonicalChildIdx.length - 1];
+			if (firstIdx === undefined || lastIdx === undefined) return [];
+
+			// first〜last の帯の中で、canonical スロットを含まないのに「slot 名前空間 testid」を持つ
+			// 直接の子 = 割り込み (drift)。
+			//
+			// 判定対象は **slot 名前空間** `admin-<res>-*` (+ `<res>-action-message` /
+			// `<res>-child-context-banner` の variant) とする。`admin-<res>-` で始まる testid を持つ
+			// 直接の子は「page-level slot」を名乗っているとみなし、canonical 集合外なら割り込み (新規 slot)
+			// として捕捉する (例: `admin-checklists-promo-banner` を search と list の間に追加)。
+			//
+			// (B) 正当なドメインセクション (marketplace-import-section / checklist-distribution-section-*
+			// 等) は `admin-<res>-` 接頭辞を持たない固有 testid であり、かつ各自の canonical スロット内に
+			// 置かれる限り「canonical を含む子」として帯から除外されるため誤検出しない。
+			const slotNamespaceRe =
+				/^admin-(activities|rewards|checklists)-|-(action-message|child-context-banner)$/;
+			const isIntruder = (child: Element): string | null => {
+				if (containsCanonical(child)) return null;
+				const tid = child.getAttribute('data-testid');
+				return tid && slotNamespaceRe.test(tid) && !allCanonicalTestids.includes(tid) ? tid : null;
+			};
+
+			const intruders: string[] = [];
+			for (let i = firstIdx + 1; i < lastIdx; i++) {
+				const child = children[i];
+				const tid = child ? isIntruder(child) : null;
+				if (tid) intruders.push(tid);
+			}
+			return intruders;
+		},
+		{ canonicalTestids, allCanonicalTestids: Array.from(ALL_CANONICAL_TESTIDS) },
+	);
+}
+
 /** observed が canonical の部分列 (subsequence) なら true (= observed が正準順に並んでいる)。 */
 function isSubsequence(observed: string[], canonical: string[]): boolean {
 	let ci = 0;
@@ -106,12 +198,23 @@ test.describe('#3097 admin リソース正準スロット契約 (activities / re
 				await expect(page.getByTestId('admin-resource-header')).toBeVisible({ timeout: 15_000 });
 			});
 
-			test('(a) 出現スロットが正準順 (CANONICAL_SLOT_ORDER の部分列) に並ぶ', async ({ page }) => {
+			test('(a) 出現スロットが正準順 (CANONICAL_SLOT_ORDER の部分列) かつ間に非正準 slot が割り込まない', async ({
+				page,
+			}) => {
 				const observed = await readVisibleSlotsInDomOrder(page, model.resource);
 				expect(
 					isSubsequence(observed, CANONICAL_NAMES),
 					`observed slot order ${JSON.stringify(observed)} は canonical ${JSON.stringify(CANONICAL_NAMES)} の部分列ではない (順序違反)`,
 				).toBe(true);
+
+				// 部分列照合は canonical-named testid しか見ないため、スロット間に非正準の slot-level 要素
+				// (例: 新規 `admin-checklists-promo-banner` を search と list の間に挿入) が割り込んでも
+				// 順序は崩れず見逃す。共通親の直接子帯を走査し、slot 名前空間の割り込みが 0 件であることを assert する。
+				const intruders = await findIntruderTestidsBetweenSlots(page, model.resource);
+				expect(
+					intruders,
+					`canonical スロット間に非正準の slot-level 要素が割り込んでいる: ${JSON.stringify(intruders)} (正準スロット契約逸脱)`,
+				).toEqual([]);
 			});
 
 			test('(b) 必須スロット (header / child-tabs / search / list) が存在する', async ({
@@ -123,11 +226,22 @@ test.describe('#3097 admin リソース正準スロット契約 (activities / re
 				}
 			});
 
-			test('(c) 共有 component を使用している (header=AdminResourceHeader / empty=UnifiedEmptyState testid 体系)', async ({
+			test('(c) 共有 component を使用している (AdminResourceHeader は画面に 1 個 / list は canonical 共有スロット)', async ({
 				page,
 			}) => {
-				// header = AdminResourceHeader (admin-resource-header testid を内包)
-				await expect(page.getByTestId('admin-resource-header')).toBeVisible();
+				// 共有 AdminResourceHeader を**ちょうど 1 個**使う。inline header を独自再実装すると
+				// 0 個 (testid 無し) か、共有 + inline の 2 個になるため、count===1 で「共有 component を
+				// 正しく 1 回だけ使っている」ことを assert する (beforeEach の visible 再確認では検出不可)。
+				await expect(page.getByTestId('admin-resource-header')).toHaveCount(1);
+
+				// 一覧 slot は canonical 共有 testid (`admin-<res>-list`) で描画される。この container の
+				// 空時 branch は UnifiedEmptyState SSOT を使う契約 (demo fixture はデータ投入済のため空に
+				// ならず、ここでは「canonical list slot が存在する」= 共有スロット使用を assert する)。
+				const listTestid = CANONICAL_SLOT_ORDER.find((s) => s.name === 'list')?.testid(
+					model.resource,
+				);
+				expect(listTestid, 'list スロットの testid が registry に定義されていない').toBeTruthy();
+				await expect(page.getByTestId(listTestid as string)).toHaveCount(1);
 			});
 
 			test('(d) registry 宣言と DOM (子供タブ / child-binding モデル) が整合する', async ({
@@ -138,20 +252,30 @@ test.describe('#3097 admin リソース正準スロット契約 (activities / re
 
 				if (model.binding === 'child-selection-dialog') {
 					// per-child-tabs (activity / reward) は ChildSelectionDialog で取込先 child を選ぶ。
-					// 取込 dialog が DOM 上に mount されている (closed でも Ark UI が DOM に保持) ことを確認し、
-					// family master 専用の配信 VisibilityChip は持たないことを assert する。
+					// family master 専用の配信 VisibilityChip (`checklist-distribution-visibility`) を
+					// **絶対に持たない**ことを assert する (per-child リソースが配信モデルを混入させたら fail)。
 					await expect(page.getByTestId('checklist-distribution-visibility')).toHaveCount(0);
 				} else {
-					// family-distribute (checklist) は配信先設定の入口 (distribution section) を持つ。
-					// VisibilityChip 本体は Dialog open 時のみ Portal に mount されるため、ここでは
-					// 配信モデルの入口 (per-template distribution section) が DOM 上に存在することを確認する。
-					// (templates が 0 件のときは section が無いため、その場合は child-tabs 存在で代替検証する。)
+					// family-distribute (checklist) は「配信される」モデル。配信導線が item 件数 0 でも
+					// 必ず存在することを能動的に assert する (旧実装は `if (sectionCount > 0)` で 0 件時に
+					// 何も検証せず vacuous pass していた — toothless 分岐)。
+					//   - templates ≥ 1: 各 template に per-template 配信 section が出る
+					//   - templates = 0: empty state が配信元 (marketplace) への import bridge link を出す
+					// いずれかの配信導線が DOM 上に存在することを assert し、両状態で契約を貫通検証する。
 					const distributionSections = page.locator(
 						'[data-testid^="checklist-distribution-section-"]',
 					);
+					const importBridgeLink = page.getByTestId('checklists-empty-import-link');
 					const sectionCount = await distributionSections.count();
+					const bridgeCount = await importBridgeLink.count();
+					expect(
+						sectionCount + bridgeCount,
+						'family-distribute (checklist) の配信導線 (per-template 配信 section または empty state の import bridge link) が item 件数に関わらず 1 つも存在しない (配信モデル契約逸脱)',
+					).toBeGreaterThan(0);
 					if (sectionCount > 0) {
 						await expect(distributionSections.first()).toBeVisible();
+					} else {
+						await expect(importBridgeLink).toBeVisible();
 					}
 				}
 			});


### PR DESCRIPTION
## 顧客価値・目的

admin リソース管理 3 画面 (活動 / チェックリスト / ごほうび) の UI 構造ドリフト (PO 約 12 回の指摘でも収束せず) を、**正準スロット縦順契約 + child-binding registry + CI fitness function** で根治する。保護者 (P2) が画面ごとに操作を学び直すコストを根絶する (NN/G #4 consistency)。ガードレールと 3 画面の (A) conformance を同 PR で land し、以後の改修で契約逸脱を作れば CI が即落ちる (Architecture Fitness Function)。EPIC #3096 Sub-1。

## 関連 Issue

- closes #3097
- 親 EPIC: #3096
- 基盤 (補完関係・矛盾させない): #2998 (add 経路同型性 `admin-add-path-isomorphism.spec.ts`) / #2897 (`AdminResourceHeader`) / #2362 (`UnifiedEmptyState`) / ADR-0055 (per-child / family master データモデル)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | DESIGN.md §10 にスロット契約 + (A)/(B)線引き明文化 | `docs/DESIGN.md` §10「admin リソース管理画面の正準スロット縦順契約 (#3097)」追加 | ✓ slot 表 + (A)/(B) + child-binding モデル + fitness function を明文化 |
| AC2 | registry + `admin-resource-layout-contract.spec.ts` が3画面でグリーン (順序/必須/共有component/モデル整合) | demo 無認証 server に対し fitness function ロジックを headless browser で実行 | ✓ activity/reward/checklist 全て a(order)/b(required)/c(shared)/d(model) = PASS。observed = `[header, child-tabs, child-context-banner, search, list]` 3画面一致 |
| AC3 | 検索が3画面とも一覧直上 / 子供タブ条件統一 / empty=UnifiedEmptyState / action message・banner 固定スロット / spacing統一 / AI flow | DOM curl + SS 目視 | ✓ 検索=slot5 (一覧直上) 3画面統一 / 子供タブ「1人以上」+`.child-tab-row`統一 / empty=`UnifiedEmptyState` / action message=slot6 / プラン系バナー=slot4 / `space-y-4`統一。AI flow は §レビュー依頼参照 |
| AC4 | 既存 E2E (add-path-isomorphism / marketplace import / 各 plan-gate) 非破壊 | testid 互換性 grep + ローカル DOM 検証 | ✓ 既存 testid 全保持 (`child-context-banner`/`rewards-upgrade-banner`/`rewards-per-child-list`/`checklists-action-message`/`marketplace-import-section` 等)。旧 `checklists-child-tabs` は E2E 参照 0 件のため `admin-checklists-child-tabs` に rename。CI で full E2E 実行 |
| AC5 | (B)ドメイン差(カテゴリフィルタ/override/copy/bulk)は撤去せず正準スロット配置のみ | コード差分 | ✓ 活動カテゴリフィルタ (slot5)・copy/bulk (header `+`)・checklist 日次override (slot8)・配信先設定 を全保持 |
| AC6 | SS で3画面の縦並びが一致 | demo 無認証 capture × mobile/desktop | ✓ §スクリーンショット参照。3画面とも header→child-tabs→context-banner→search→list の同一 scaffold |

## 変更タイプ

- [x] リファクタリング (構造統一 / ガードレール導入)
- [x] テスト追加 (fitness function E2E)
- [x] ドキュメント (DESIGN.md §10)

## 影響範囲・変更コンポーネント

- `src/lib/features/admin/admin-resource-model-registry.ts` (新規 SSOT)
- `tests/e2e/admin-resource-layout-contract.spec.ts` (新規 fitness function)
- `src/routes/(parent)/admin/{activities,checklists,rewards}/+page.svelte` (slot conform)
- `src/lib/features/admin/components/AdminResourceHeader.svelte` (`data-testid="admin-resource-header"` 付与)
- `src/lib/ui/styles/app.css` (child-tab / child-context-banner 共有クラス集約、DRY)
- `src/lib/domain/labels.ts` (検索 / 子供コンテキスト labels 追加)
- `docs/DESIGN.md` §10

## テスト & 安全装置セルフチェック

- [x] `npx biome check` — clean (924 files)
- [x] `npx svelte-check --threshold error` — 変更ファイル 0 error (残 81 は infra/node_modules 未install の環境依存・pre-existing)
- [x] `node scripts/check-hardcoded-strings.mjs` — 0 (baseline 0)
- [x] `node scripts/check-no-plan-literals.mjs` — OK
- [x] `npm run lint:terminology` — PASS
- [x] fitness function ロジックを headless browser で 3画面 PASS 確認
- [x] full E2E (add-path-isomorphism / marketplace-*-import / plan-free,standard,family / cuj5 / 新規 layout-contract) は **CI の playwright job で実行**される (ローカルは webServer 起動が 9分超 timeout する環境制約のため未実行、fitness function ロジック + 3画面描画は手動 demo server で実証済)。CI 緑を QM レビューで確認

## スクリーンショット / ビジュアルデモ

demo 無認証 (`AUTH_MODE=anonymous DATA_SOURCE=demo`) server に `capture.mjs --base-url` で 3画面 × mobile/desktop を撮影。**3画面とも同一縦 scaffold (header → 子供タブ pill row → 子供コンテキストバナー → 検索 → 一覧) で縦並びが一致**（検索が3画面とも一覧直上に統一、ごほうび=従来は下→上に是正）。

| 画面 | Desktop |
|---|---|
| 活動 | ![activities](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3100/admin-activities-desktop.png) |
| チェックリスト | ![checklists](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3100/admin-checklists-desktop.png) |
| ごほうび | ![rewards](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3100/admin-rewards-desktop.png) |

Mobile も撮影・縦並び一致を確認: [活動](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3100/admin-activities-mobile.png) / [チェックリスト](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3100/admin-checklists-mobile.png) / [ごほうび](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3100/admin-rewards-mobile.png)。DOM HTML も同 path に併置 (#1747)。

> 注: 本 PR はレイアウト scaffold の統一。チェックリストの child 主軸表示軸統一（タブで選択中の子の分のみ表示、family master データモデルは維持）は Sub-2 #3098。

## コード品質セルフレビュー (#1481)

- registry を SSOT とし testid 体系を 1 箇所に集約 (DRY)。
- child-tab / child-context-banner styles を 3画面の重複定義から app.css 共有クラスへ集約。
- checklist の `selectedChildId` を SSR-safe な override+derived パターンに統一 (activities/rewards と同型) — hydration 前に一覧/バナーが描画されない不整合を解消。

## 横展開・影響波及チェック

- 既存 testid 全保持で E2E 非破壊。旧 `checklists-child-tabs` のみ rename (参照 0 件確認済)。
- `admin-add-path-isomorphism.spec.ts` (#2998) と補完関係 (縦スロット順 vs dropdown 同型) で矛盾なし。
- checklist データモデル変更は **Sub-2 (#3096) scope** であり本 PR では現状 (family-distribute) を宣言するのみ。

## レビュー依頼事項・破壊的変更

- **破壊的変更なし** (testid 互換厳守 / ドメイン機能撤去なし)。
- **要判断 (1点)**: Issue の (A) 項目「checklist AI flow の hidden-form 自動送信を活動型の Dialog フォーム表示に統一」は、本 PR で **AI が Dialog 経由で開く入口同型性 (`checklists-ai-dialog` + `ai-suggest-checklist-panel`、`admin-add-path-isomorphism.spec.ts` が assert) を達成済**。accept 時の `createFromAi` 自動送信を確認フォーム化する内部挙動変更は `createFromAi` 経路の振る舞い変更 (E2E 非依存だが UX 変更) を伴うため、今夜リリースの非破壊優先で本 PR scope から除外し、EPIC #3096 Sub-2 (child 主軸化) に統合する判断を QM に仰ぐ。本項は scope 境界の明示であり、入口同型性 (= add-path 同型性テストが守る部分) は本 PR で完遂済。

## 配布済み env / secret (ADR-0006)

- 新規 env / secret なし。

## Ready for Review チェックリスト

- [x] QA 承認・動作確認が完了している (N/A: 本 PR は Draft 維持、merge / Ready 化判断は QM 専権。Dev 側の機械検証 + ローカル動作確認は完了)
- [x] `npx biome check` / svelte-check (変更分) / hardcoded / plan-literals / terminology PASS
- [x] AC 検証マップ記載
- [x] 既存 testid 互換確認
- [x] full E2E は CI に委譲 (本環境の playwright webServer 起動 timeout のため。fitness function ロジックは headless browser で 3画面 PASS 確認済)

## QM レビュー結果

(QM 記入欄)

