### PR TITLE
fix(security): #3105 ZIP import 復元の SVG stored XSS を attachment 配信で封殺

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -553,6 +553,7 @@ HTTP レスポンスヘッダーで CSP を付与できないため、`<meta htt
 - SvelteKit はテンプレート出力を自動エスケープ（`{@html}` 以外）
 - `{@html}` の使用は最小限に制限
 - ユーザー入力はサーバー側でもバリデーション
+- **user 由来静的ファイルの安全配信（#3105）**: user がアップロード / ZIP import 復元した静的ファイル（`/tenants/[...path]` / `/uploads/avatars/[filename]`）は、ラスタ画像（`image/jpeg` / `image/png` / `image/webp`）のみ `Content-Disposition: inline`、それ以外（**`image/svg+xml`** / `audio/*` / 不明 type）は `attachment` で配信する。SVG は XML 文書として `script` を含み得るため、CSP が `script-src 'self' 'unsafe-inline'` の本アプリでは inline 配信すると top-level navigation で stored XSS が成立する（#3105、ZIP import 復元路が avatar 防御を bypass していた）。判定は `file-sanitizer.ts` の `safeContentDisposition()` に集約し、全静的配信路で対称に適用する。`<img>` 等の subresource 読込は `Content-Disposition` を無視するため、正規の fallback SVG avatar 表示は維持される（img 経由 SVG では script も実行されない）。
 
 ### 7.3 CSRF 対策
 

--- a/src/lib/server/security/file-sanitizer.ts
+++ b/src/lib/server/security/file-sanitizer.ts
@@ -93,3 +93,28 @@ const SAFE_CONTENT_TYPES = new Set([
 export function safeContentType(contentType: string): string {
 	return SAFE_CONTENT_TYPES.has(contentType) ? contentType : 'application/octet-stream';
 }
+
+/**
+ * inline 配信して安全な (= top-level navigation でも script を実行し得ない) Content-Type。
+ * ラスタ画像のみ。SVG は image だが XML 文書として script を実行し得るため除外する (#3105)。
+ */
+const INLINE_SAFE_CONTENT_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+
+/**
+ * user 由来データの静的配信時に使う Content-Disposition を返す (#3105)。
+ *
+ * 背景: ZIP import 復元 (#3083) で `image/svg+xml` を `inline` 配信していたため、認証済
+ * owner/parent が script 入り SVG を含む ZIP を import → その SVG へ top-level navigation すると
+ * CSP `unsafe-inline` 下で inline script が実行される stored XSS が成立していた (avatar 防御の非対称)。
+ *
+ * 対策: ラスタ画像 (jpeg/png/webp) のみ `inline`、それ以外 (SVG / audio / octet-stream 等) は
+ * `attachment` とし、document としてレンダリングさせない (= top-level navigation では download)。
+ * `<img src>` 等の subresource 読込は Content-Disposition を無視するため、正規の fallback SVG
+ * avatar 等の `<img>` 表示は維持される (script も img 経由 SVG では実行されない)。
+ *
+ * user データを静的配信する全経路 (tenants / uploads/avatars 等) は本関数を経由すること
+ * (横展開 #3105、安全配信ユーティリティへの集約)。
+ */
+export function safeContentDisposition(contentType: string): 'inline' | 'attachment' {
+	return INLINE_SAFE_CONTENT_TYPES.has(contentType) ? 'inline' : 'attachment';
+}

--- a/src/routes/tenants/[...path]/+server.ts
+++ b/src/routes/tenants/[...path]/+server.ts
@@ -2,7 +2,7 @@
 // Serves from local filesystem (NUC) or S3 (Lambda)
 
 import { error } from '@sveltejs/kit';
-import { safeContentType } from '$lib/server/security/file-sanitizer';
+import { safeContentDisposition, safeContentType } from '$lib/server/security/file-sanitizer';
 import { readFile } from '$lib/server/storage';
 import type { RequestHandler } from './$types';
 
@@ -20,14 +20,14 @@ export const GET: RequestHandler = async ({ params }) => {
 		throw error(404, 'File not found');
 	}
 
-	// 音声ファイルは attachment として配信（ブラウザでの直接実行を防止）
-	const isAudio = result.contentType.startsWith('audio/');
-	const disposition = isAudio ? 'attachment' : 'inline';
+	// #3105: ラスタ画像のみ inline、SVG / audio / 不明 type は attachment 配信
+	// (script 入り SVG への top-level navigation で inline script が実行される stored XSS を封殺)。
+	const ct = safeContentType(result.contentType);
 
 	return new Response(new Uint8Array(result.data), {
 		headers: {
-			'Content-Type': safeContentType(result.contentType),
-			'Content-Disposition': disposition,
+			'Content-Type': ct,
+			'Content-Disposition': safeContentDisposition(ct),
 			'Cache-Control': 'public, max-age=31536000, immutable',
 		},
 	});

--- a/src/routes/uploads/avatars/[filename]/+server.ts
+++ b/src/routes/uploads/avatars/[filename]/+server.ts
@@ -2,7 +2,7 @@
 // Serves from local filesystem (NUC) or S3 (Lambda)
 
 import { error } from '@sveltejs/kit';
-import { safeContentType } from '$lib/server/security/file-sanitizer';
+import { safeContentDisposition, safeContentType } from '$lib/server/security/file-sanitizer';
 import { readFile } from '$lib/server/storage';
 import type { RequestHandler } from './$types';
 
@@ -19,10 +19,14 @@ export const GET: RequestHandler = async ({ params }) => {
 		throw error(404, 'File not found');
 	}
 
+	// #3105: avatar も tenants 配信路と対称に、ラスタ画像のみ inline / SVG 等は attachment
+	// (upload 路は sharp 再エンコードで非 SVG だが、防御の対称化として共通 helper を経由)。
+	const ct = safeContentType(result.contentType);
+
 	return new Response(new Uint8Array(result.data), {
 		headers: {
-			'Content-Type': safeContentType(result.contentType),
-			'Content-Disposition': 'inline',
+			'Content-Type': ct,
+			'Content-Disposition': safeContentDisposition(ct),
 			'Cache-Control': 'public, max-age=31536000, immutable',
 		},
 	});

--- a/tests/unit/services/file-sanitizer.test.ts
+++ b/tests/unit/services/file-sanitizer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+	safeContentDisposition,
 	safeContentType,
 	sanitizeAudio,
 	sanitizeImage,
@@ -169,5 +170,29 @@ describe('safeContentType', () => {
 		expect(safeContentType('text/html')).toBe('application/octet-stream');
 		expect(safeContentType('application/javascript')).toBe('application/octet-stream');
 		expect(safeContentType('')).toBe('application/octet-stream');
+	});
+});
+
+describe('safeContentDisposition (#3105 SVG stored XSS)', () => {
+	it('ラスタ画像 (jpeg/png/webp) は inline 配信', () => {
+		expect(safeContentDisposition('image/jpeg')).toBe('inline');
+		expect(safeContentDisposition('image/png')).toBe('inline');
+		expect(safeContentDisposition('image/webp')).toBe('inline');
+	});
+
+	it('SVG は attachment 配信 (top-level navigation で inline script を実行させない)', () => {
+		// 本丸: image/svg+xml を inline で返していたのが stored XSS の root cause
+		expect(safeContentDisposition('image/svg+xml')).toBe('attachment');
+	});
+
+	it('audio は attachment 配信 (従来どおりブラウザ直接実行防止)', () => {
+		expect(safeContentDisposition('audio/mpeg')).toBe('attachment');
+		expect(safeContentDisposition('audio/wav')).toBe('attachment');
+	});
+
+	it('不明 / octet-stream は attachment 配信', () => {
+		expect(safeContentDisposition('application/octet-stream')).toBe('attachment');
+		expect(safeContentDisposition('text/html')).toBe('attachment');
+		expect(safeContentDisposition('image/gif')).toBe('attachment');
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全家族（テナント共有のため家族メンバー間で影響）

**解決する課題**: ZIP import 復元路（#3083）の静的ファイル配信が `image/svg+xml` を `Content-Disposition: inline` で返していたため、認証済 owner/parent が **script 入り SVG を含む細工 ZIP を import → その SVG へ top-level navigation すると CSP `unsafe-inline` 下で inline script が実行される stored XSS**（sev3）が成立していた。avatar upload 路は sharp 再エンコードで防御していたが ZIP import 路はこれを bypass（防御の非対称）。家族はテナント共有のため、細工 SVG が他家族メンバー閲覧時に実行され得る。

**期待される効果**: SVG を `attachment` 配信に統一し top-level navigation での script 実行を封殺。tenants / avatars 両配信路を共通 helper で対称化し、防御の非対称を解消。

## 関連 Issue

closes #3105

- #3083（ZIP import 実装）/ #3103（統合監査 security チーム sev3 #1 で検出）/ #3104（同 #3083 由来の blocker、並行）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `image/svg+xml` を inline 配信しない（除外 or sanitize） | `npx vitest run tests/unit/services/file-sanitizer.test.ts` | HEAD `c3318005` / 18 passed / `safeContentDisposition('image/svg+xml')==='attachment'` を assert。whitelist 除外は fallback SVG avatar の `<img>` 表示を壊すため非採用、attachment 配信で XSS を根治（理由は本文「設計判断」参照）|
| AC2 | 復元静的ファイルは `attachment`（inline 配信しない）に統一 | コード + 同 unit | `tenants/[...path]/+server.ts` / `uploads/avatars/[filename]/+server.ts` が `safeContentDisposition(ct)` 経由。ラスタ画像のみ inline、SVG/audio/不明は attachment |
| AC3 | 細工 SVG ZIP の import → navigation で script 実行されない | 配信ヘッダ検証（unit）+ 機構 | SVG は `attachment` で document レンダリングされず download される（top-level navigation で実行不可）。`safeContentDisposition` 単体回帰で svg→attachment を固定 |
| AC4 | avatar upload 路と同等の防御に揃える（対称化）| コード | tenants / avatars 両路を同一 helper `safeContentDisposition` 経由に統一（横展開で共通配信ユーティリティに集約）|
| AC5（横展開）| user 由来静的配信路の SVG inline 点検 + 集約 | `git grep safeContentType` | 静的配信路は `tenants` / `uploads/avatars` の 2 経路。両方を helper 経由に統一。policy は `file-sanitizer.ts` に集約 + `14-セキュリティ設計書.md §7.2` に記録（ADR-0001）|

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/`、security/file-sanitizer)
- [x] API エンドポイント (`src/routes/` 静的配信 2 路)
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト
- [ ] 設定・CI

**影響を受ける画面・機能**: `/tenants/[...path]`（ZIP import 復元ファイル / 生成アバター配信）と `/uploads/avatars/[filename]`（アップロードアバター配信）の Content-Disposition のみ。ラスタ画像（jpeg/png/webp）は従来どおり inline で `<img>` 表示。SVG は attachment になるが `<img>` 表示は Content-Disposition 非依存のため維持。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/services/file-sanitizer.test.ts` に `safeContentDisposition` の回帰（svg/audio/octet/text → attachment、ラスタ → inline）を追加
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high security、critical ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（サーバー API の Content-Disposition ヘッダ生成のみで UI 変更なし）**。検証は unit。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 配信安全判定を `safeContentDisposition` 単一 helper に集約、route から分離
- [x] **DRY**: 2 配信路が同一 helper を共有（防御対称化）
- [x] **YAGNI**: 最小（attachment 切替 + helper）。SVG sanitize ライブラリ導入等は過剰として不採用
- [x] **Security（OSS 公開前提）**: 本 PR 自体が stored XSS 根治。CSP `unsafe-inline` 撤廃は別 EPIC（scope 外、issue no-go）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: Set lookup のみ、影響なし

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001) — `14-セキュリティ設計書.md §7.2` に SVG attachment 配信ポリシーを追記
- [x] 並行 PR overlap 確認 (#1200) — #3104（同 #3083 由来 export）と作業面分離（本 PR は配信ヘッダ）
- [x] N/A — 静的配信路は tenants / uploads/avatars の 2 経路のみ、両方修正済

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（ラスタ画像 inline は不変。SVG が attachment になるが `<img>` 表示は維持、top-level で開くと download になる挙動変化のみ）

**レビュー依頼事項・QA**: **設計判断** — AC1 の「whitelist から svg 除外」案は採らず attachment 配信を選んだ。理由: fallback SVG avatar（`image-service.ts:130`、`generatedImageKey(...,'svg')` で `tenants` 配信）は `<img>` 表示されており、whitelist 除外で content-type が octet-stream になると img 表示が壊れる。attachment は `<img>`（subresource、Content-Disposition 非依存）の表示を維持しつつ top-level navigation の script 実行を封殺するため、XSS 根治と avatar 表示維持を両立する。この判断の妥当性を確認いただきたい。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし（サーバー API のみ）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
