### PR TITLE
fix: #3106 #3107 checklist 個別 backup の archived log 欠落 + 同名 template 取り違えを根治

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -3,7 +3,9 @@
 
 export const EXPORT_FORMAT = 'ganbari-quest-backup' as const;
 // #1254 G1: 1.2.0 で `sourcePresetId` フィールドを追加 (activities / specialRewards / checklistTemplates)
-export const EXPORT_VERSION = '1.2.0' as const;
+// #3106 / #3107: 1.3.0 で checklist の `exportId` / `isArchived` / log `templateExportId` を追加
+//   (archive 済 template の log 保全 + 同名 template の round-trip 取り違え防止)。いずれも optional で後方互換。
+export const EXPORT_VERSION = '1.3.0' as const;
 
 // ============================================================
 // マスタデータ型
@@ -163,6 +165,11 @@ export interface ExportChecklistTemplate {
 	items: ExportChecklistTemplateItem[];
 	// #1254 G1: マーケットプレイスプリセット由来の識別子 (v1.2.0+)
 	sourcePresetId?: string | null;
+	// #3107: export 内で安定な template 識別子 (v1.3.0+)。checklistLog の round-trip キーに使い、
+	// 同名 template が複数あっても log を取り違えない。旧 export には無いため optional。
+	exportId?: string;
+	// #3106: archive 状態を round-trip で保全 (v1.3.0+)。旧 export には無いため optional (未指定=非 archived)。
+	isArchived?: boolean;
 }
 
 export interface ExportChecklistTemplateItem {
@@ -176,6 +183,9 @@ export interface ExportChecklistTemplateItem {
 export interface ExportChecklistLog {
 	childRef: string;
 	templateName: string;
+	// #3107: 紐づく template の安定識別子 (v1.3.0+)。import 側はこれを優先して再マップし、
+	// 無い場合 (旧 export) のみ templateName で fallback する。
+	templateExportId?: string;
 	checkedDate: string;
 	itemsJson: string;
 	completedAll: boolean;

--- a/src/lib/server/db/checklist-repo.ts
+++ b/src/lib/server/db/checklist-repo.ts
@@ -23,8 +23,15 @@ export async function findTemplatesByChild(
 	childId: number,
 	tenantId: string,
 	includeInactive = false,
+	// #3106: backup/export 文脈のみ true。archive 済 template も含める。
+	includeArchived = false,
 ) {
-	return getRepos().checklist.findTemplatesByChild(childId, tenantId, includeInactive);
+	return getRepos().checklist.findTemplatesByChild(
+		childId,
+		tenantId,
+		includeInactive,
+		includeArchived,
+	);
 }
 
 export async function findTemplateById(id: number, tenantId: string) {

--- a/src/lib/server/db/demo/checklist-repo.ts
+++ b/src/lib/server/db/demo/checklist-repo.ts
@@ -100,13 +100,17 @@ export async function findTemplatesByChild(
 	childId: number,
 	_tenantId: string,
 	includeInactive?: boolean,
+	// #3106: archive 済 template を含めるか (export/backup 文脈のみ true)
+	includeArchived?: boolean,
 ): Promise<ChecklistTemplate[]> {
 	const assignedIds = new Set(
 		ALL_DEMO_CHECKLIST_ASSIGNMENTS.filter((a) => a.childId === childId).map((a) => a.templateId),
 	);
 	return ALL_DEMO_CHECKLIST_TEMPLATES.filter(
 		(t) =>
-			assignedIds.has(t.id) && (includeInactive === true || t.isActive === 1) && t.isArchived === 0,
+			assignedIds.has(t.id) &&
+			(includeInactive === true || t.isActive === 1) &&
+			(includeArchived === true || t.isArchived === 0),
 	);
 }
 

--- a/src/lib/server/db/dynamodb/checklist-repo.ts
+++ b/src/lib/server/db/dynamodb/checklist-repo.ts
@@ -84,6 +84,8 @@ export async function findTemplatesByChild(
 	childId: number,
 	tenantId: string,
 	includeInactive?: boolean,
+	// #3106: archive 済 template を含めるか (export/backup 文脈のみ true)
+	includeArchived?: boolean,
 ): Promise<ChecklistTemplate[]> {
 	const assignments = await findAssignmentsByChild(childId, tenantId);
 	if (assignments.length === 0) return [];
@@ -92,7 +94,7 @@ export async function findTemplatesByChild(
 	for (const a of assignments) {
 		const t = await findTemplateById(a.templateId, tenantId);
 		if (!t) continue;
-		if (t.isArchived === 1) continue;
+		if (!includeArchived && t.isArchived === 1) continue;
 		if (!includeInactive && t.isActive !== 1) continue;
 		templates.push(t);
 	}

--- a/src/lib/server/db/interfaces/checklist-repo.interface.ts
+++ b/src/lib/server/db/interfaces/checklist-repo.interface.ts
@@ -47,6 +47,9 @@ export interface IChecklistRepo {
 		childId: number,
 		tenantId: string,
 		includeInactive?: boolean,
+		// #3106: archive 済 template を含めるか。既定 false (従来どおり archived 除外)。
+		// export/backup 文脈のみ true にし、archive 済 template の checklistLog 欠落を防ぐ。
+		includeArchived?: boolean,
 	): Promise<ChecklistTemplate[]>;
 
 	findTemplateById(id: number, tenantId: string): Promise<ChecklistTemplate | undefined>;

--- a/src/lib/server/db/sqlite/checklist-repo.ts
+++ b/src/lib/server/db/sqlite/checklist-repo.ts
@@ -57,6 +57,8 @@ export async function findTemplatesByChild(
 	childId: number,
 	tenantId: string,
 	includeInactive = false,
+	// #3106: archive 済 template を含めるか (export/backup 文脈のみ true)
+	includeArchived = false,
 ): Promise<ChecklistTemplate[]> {
 	const rows = db
 		.select({
@@ -83,11 +85,15 @@ export async function findTemplatesByChild(
 			and(
 				eq(checklistTemplateAssignments.childId, childId),
 				eq(checklistTemplates.tenantId, tenantId),
-				or(eq(checklistTemplates.isArchived, 0), isNull(checklistTemplates.isArchived)),
 			),
 		)
 		.all() as ChecklistTemplate[];
-	return includeInactive ? rows : rows.filter((r) => r.isActive === 1);
+	// #3106: isArchived / isActive を in-memory で flag 連動 filter (既定は archived + inactive を除外)
+	return rows.filter((r) => {
+		if (!includeArchived && r.isArchived === 1) return false;
+		if (!includeInactive && r.isActive !== 1) return false;
+		return true;
+	});
 }
 
 export async function findTemplateById(

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -232,7 +232,9 @@ async function collectTransactionData(
 			findRecentBonuses(childId, tenantId, MAX_EXPORT_ROWS),
 			findEvaluationsByChild(childId, MAX_EXPORT_ROWS, tenantId),
 			findSpecialRewards(childId, tenantId),
-			findTemplatesByChild(childId, tenantId, true),
+			// #3106: backup なので includeInactive=true + includeArchived=true。
+			// archive 済 template も含め、その checklistLog の silent drop を防ぐ。
+			findTemplatesByChild(childId, tenantId, true, true),
 		]);
 
 		// ステータス履歴は全カテゴリ分を取得
@@ -337,10 +339,15 @@ async function collectTransactionData(
 		}
 
 		// Checklist templates with items
-		// #3078: templateId → name マップを構築し checklistLogs の参照解決に使う。
+		// #3078 / #3107: templateId → (name, exportId) マップを構築し checklistLogs の参照解決に使う。
+		// exportId は export 内で安定な識別子 (`chk-${childRef}-${templateId}`) で、同名 template が
+		// 複数あっても log を取り違えない round-trip キーにする。
 		const templateNameById = new Map<number, string>();
+		const exportIdByTemplateId = new Map<number, string>();
 		for (const tpl of checklistTemplates) {
 			templateNameById.set(tpl.id, tpl.name);
+			const exportId = `chk-${childRef}-${tpl.id}`;
+			exportIdByTemplateId.set(tpl.id, exportId);
 			const items = await findTemplateItems(tpl.id, tenantId);
 			allChecklistTemplates.push({
 				childRef,
@@ -350,6 +357,8 @@ async function collectTransactionData(
 				completionBonus: tpl.completionBonus,
 				isActive: tpl.isActive === 1,
 				sourcePresetId: tpl.sourcePresetId,
+				exportId, // #3107
+				isArchived: tpl.isArchived === 1, // #3106: archive 状態を round-trip 保全
 				items: items.map((item) => ({
 					name: item.name,
 					icon: item.icon,
@@ -360,15 +369,18 @@ async function collectTransactionData(
 			});
 		}
 
-		// #3078: チェックリスト完了ログ。templateName で参照し、import 側で再マップする。
-		// 配信中 template に紐づかないログ (archive 済 template 等) は name 解決不能のためスキップ。
+		// #3078 / #3106: チェックリスト完了ログ。#3106 で archive 済 template も export に含めたため、
+		// その log も exportId 経由で保全される (従来は name 解決不能で silent drop していた)。
 		const checklistLogs = await findLogsByChild(childId, tenantId);
 		for (const log of checklistLogs) {
 			const templateName = templateNameById.get(log.templateId);
-			if (!templateName) continue;
+			const templateExportId = exportIdByTemplateId.get(log.templateId);
+			// template が export に含まれない場合のみスキップ (#3106 で archived も含むため通常は解決可)
+			if (!templateName || !templateExportId) continue;
 			allChecklistLogs.push({
 				childRef,
 				templateName,
+				templateExportId, // #3107: import 側はこれを優先して再マップ
 				checkedDate: log.checkedDate,
 				itemsJson: log.itemsJson,
 				completedAll: log.completedAll === 1,

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -116,7 +116,9 @@ export function validateExportData(
 	if (d.format !== EXPORT_FORMAT) {
 		return { valid: false, error: `フォーマットが不正です（期待: ${EXPORT_FORMAT}）` };
 	}
-	const supportedVersions = [EXPORT_VERSION, '1.1.0', '1.0.0'];
+	// #3106/#3107: EXPORT_VERSION を 1.3.0 に bump したが、既存 1.2.0 backup も import 可能に保つ
+	// (新 field はすべて optional で後方互換)。
+	const supportedVersions = [EXPORT_VERSION, '1.2.0', '1.1.0', '1.0.0'];
 	if (!supportedVersions.includes(d.version as string)) {
 		return {
 			valid: false,
@@ -561,102 +563,158 @@ async function importLoginBonusesData(
 	}
 }
 
+/** checklistLog の再マップに使う、childId 単位の template id 解決マップ群。 */
+export interface ChecklistTemplateIdMaps {
+	/** templateName → templateId (#3078、旧 export の fallback 用) */
+	byName: Map<number, Map<string, number>>;
+	/** exportId → templateId (#3107、同名 template 取り違え防止の安定キー) */
+	byExportId: Map<number, Map<string, number>>;
+}
+
+/** childId 単位の checklist template import 状態 (既存 + 当 import で作成した template の id 解決)。 */
+interface ChildChecklistState {
+	names: Set<string>;
+	presetIds: Set<string>;
+	idByName: Map<string, number>;
+	idByPreset: Map<string, number>;
+	/** exportId → templateId (#3107 round-trip キー、当 import data の exportId のみ) */
+	exportIdToId: Map<string, number>;
+}
+
+/** child の既存 template から import 状態を初期化する。 */
+async function loadChildChecklistState(
+	childId: number,
+	tenantId: string,
+): Promise<ChildChecklistState> {
+	const rows = await findTemplatesByChild(childId, tenantId, true, true);
+	return {
+		names: new Set(rows.map((r) => r.name)),
+		presetIds: new Set(rows.map((r) => r.sourcePresetId).filter((p): p is string => !!p)),
+		idByName: new Map(rows.map((r) => [r.name, r.id])),
+		idByPreset: new Map(
+			rows.filter((r) => r.sourcePresetId).map((r) => [r.sourcePresetId as string, r.id]),
+		),
+		exportIdToId: new Map(),
+	};
+}
+
+/** 1 件の checklist template を import (重複スキップ / 新規作成) し、exportId を id に登録する。 */
+async function importOneChecklistTemplate(
+	tpl: ExportData['data']['checklistTemplates'][number],
+	childId: number,
+	state: ChildChecklistState,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	// #3107: 解決先 templateId を round-trip キー (exportId) に登録する (スキップ時も既存 id を登録)。
+	const register = (templateId: number) => {
+		if (tpl.exportId) state.exportIdToId.set(tpl.exportId, templateId);
+	};
+
+	// #1254 G1: preset_duplicate → name_duplicate の順で判定
+	if (tpl.sourcePresetId && state.presetIds.has(tpl.sourcePresetId)) {
+		result.skipped.preset++;
+		const dupId = state.idByPreset.get(tpl.sourcePresetId);
+		if (dupId !== undefined) register(dupId);
+		return;
+	}
+	if (state.names.has(tpl.name)) {
+		result.skipped.name++;
+		const dupId = state.idByName.get(tpl.name);
+		if (dupId !== undefined) register(dupId);
+		return;
+	}
+
+	try {
+		// #2362 PR-5 (ADR-0055): family master template + assignment 自動付与。
+		const newTpl = await insertTemplate(
+			{
+				name: tpl.name,
+				icon: tpl.icon,
+				pointsPerItem: tpl.pointsPerItem,
+				completionBonus: tpl.completionBonus,
+				isActive: tpl.isActive ? 1 : 0,
+				sourcePresetId: tpl.sourcePresetId ?? null,
+			},
+			tenantId,
+		);
+		await assignTemplateToChildren(newTpl.id, [childId], tenantId);
+		state.names.add(tpl.name);
+		state.idByName.set(tpl.name, newTpl.id);
+		register(newTpl.id);
+		if (tpl.sourcePresetId) {
+			state.presetIds.add(tpl.sourcePresetId);
+			state.idByPreset.set(tpl.sourcePresetId, newTpl.id);
+		}
+		for (const item of tpl.items) {
+			await insertTemplateItem(
+				{
+					templateId: newTpl.id,
+					name: item.name,
+					icon: item.icon,
+					frequency: item.frequency,
+					direction: item.direction,
+					sortOrder: item.sortOrder,
+				},
+				tenantId,
+			);
+		}
+	} catch (e) {
+		result.errors.push(`チェックリスト「${tpl.name}」インポート失敗: ${String(e)}`);
+	}
+}
+
 /**
  * チェックリスト template を import する。
  *
- * 返り値 (#3078): childId → (templateName → templateId) の解決マップ。
- *   既存 (重複スキップ含む) / 新規作成いずれの template も name → id を登録するため、
- *   後段の checklistLog import が `ExportChecklistLog.templateName` から新 templateId を解決できる。
+ * 返り値 (#3078 / #3107): childId → templateName/exportId → templateId の解決マップ。
+ *   既存 (重複スキップ含む) / 新規作成いずれの template も登録するため、後段の checklistLog
+ *   import が `templateExportId` (優先) または `templateName` (fallback) から新 templateId を解決できる。
+ *   #3107: 同名 template が複数あっても exportId 経由で正しい template に attach する。
  */
 async function importChecklistTemplatesData(
 	data: ExportData,
 	childIdMap: Map<string, number>,
 	tenantId: string,
 	result: ImportResult,
-): Promise<Map<number, Map<string, number>>> {
-	const existingByChild = new Map<number, { names: Set<string>; presetIds: Set<string> }>();
-	const templateIdByChild = new Map<number, Map<string, number>>();
+): Promise<ChecklistTemplateIdMaps> {
+	const stateByChild = new Map<number, ChildChecklistState>();
 
 	for (const tpl of data.data.checklistTemplates) {
 		const childId = childIdMap.get(tpl.childRef);
 		if (!childId) continue;
 
-		let existing = existingByChild.get(childId);
-		let nameToId = templateIdByChild.get(childId);
-		if (!existing || !nameToId) {
-			const rows = await findTemplatesByChild(childId, tenantId, true);
-			existing = {
-				names: new Set(rows.map((r) => r.name)),
-				presetIds: new Set(rows.map((r) => r.sourcePresetId).filter((p): p is string => !!p)),
-			};
-			nameToId = new Map(rows.map((r) => [r.name, r.id]));
-			existingByChild.set(childId, existing);
-			templateIdByChild.set(childId, nameToId);
+		let state = stateByChild.get(childId);
+		if (!state) {
+			state = await loadChildChecklistState(childId, tenantId);
+			stateByChild.set(childId, state);
 		}
-
-		// #1254 G1: preset_duplicate → name_duplicate の順で判定
-		if (tpl.sourcePresetId && existing.presetIds.has(tpl.sourcePresetId)) {
-			result.skipped.preset++;
-			continue;
-		}
-		if (existing.names.has(tpl.name)) {
-			result.skipped.name++;
-			continue;
-		}
-
-		try {
-			// #2362 PR-5 (ADR-0055): family master template + assignment 自動付与。
-			// InsertChecklistTemplateInput は family scope (childId なし) に変更済。
-			// export data 由来の childRef は assignment で 1 row 配信先として記録する。
-			const newTpl = await insertTemplate(
-				{
-					name: tpl.name,
-					icon: tpl.icon,
-					pointsPerItem: tpl.pointsPerItem,
-					completionBonus: tpl.completionBonus,
-					isActive: tpl.isActive ? 1 : 0,
-					sourcePresetId: tpl.sourcePresetId ?? null,
-				},
-				tenantId,
-			);
-			await assignTemplateToChildren(newTpl.id, [childId], tenantId);
-			existing.names.add(tpl.name);
-			nameToId.set(tpl.name, newTpl.id);
-			if (tpl.sourcePresetId) existing.presetIds.add(tpl.sourcePresetId);
-			for (const item of tpl.items) {
-				await insertTemplateItem(
-					{
-						templateId: newTpl.id,
-						name: item.name,
-						icon: item.icon,
-						frequency: item.frequency,
-						direction: item.direction,
-						sortOrder: item.sortOrder,
-					},
-					tenantId,
-				);
-			}
-		} catch (e) {
-			result.errors.push(`チェックリスト「${tpl.name}」インポート失敗: ${String(e)}`);
-		}
+		await importOneChecklistTemplate(tpl, childId, state, tenantId, result);
 	}
 
-	return templateIdByChild;
+	const byName = new Map<number, Map<string, number>>();
+	const byExportId = new Map<number, Map<string, number>>();
+	for (const [childId, state] of stateByChild) {
+		byName.set(childId, state.idByName);
+		byExportId.set(childId, state.exportIdToId);
+	}
+	return { byName, byExportId };
 }
 
 /**
- * チェックリスト完了履歴 (checklistLogs) を import する (#3078)。
+ * チェックリスト完了履歴 (checklistLogs) を import する (#3078 / #3107)。
  *
- * - `ExportChecklistLog.templateName` を import 後の新 templateId に再マップする
- *   (templateIdByChild マップ経由、childId 単位)。
+ * - #3107: `templateExportId` (安定キー) を優先して import 後の新 templateId に再マップし、
+ *   無い場合 (旧 export) のみ `templateName` で fallback する。同名 template が複数あっても
+ *   取り違えない。
  * - 重複は (childId, templateId, checkedDate) 既存ログとの照合で事前スキップする
  *   (upsertLog は UNIQUE 制約上書きのため、重複を import 件数に数えない)。
- * - template 名が解決できないログ (template 未取込 / archive 済) はスキップ。
+ * - template が解決できないログ (template 未取込) はスキップ。
  */
 async function importChecklistLogsData(
 	data: ExportData,
 	childIdMap: Map<string, number>,
-	templateIdByChild: Map<number, Map<string, number>>,
+	templateIdMaps: ChecklistTemplateIdMaps,
 	tenantId: string,
 	result: ImportResult,
 ): Promise<void> {
@@ -669,7 +727,11 @@ async function importChecklistLogsData(
 			continue;
 		}
 
-		const templateId = templateIdByChild.get(childId)?.get(log.templateName);
+		// #3107: exportId を優先解決、無ければ name で fallback (旧 export 互換)
+		const templateId =
+			(log.templateExportId
+				? templateIdMaps.byExportId.get(childId)?.get(log.templateExportId)
+				: undefined) ?? templateIdMaps.byName.get(childId)?.get(log.templateName);
 		if (!templateId) {
 			result.checklistLogsSkipped++;
 			continue;

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -573,6 +573,13 @@ export interface ChecklistTemplateIdMaps {
 
 /** childId 単位の checklist template import 状態 (既存 + 当 import で作成した template の id 解決)。 */
 interface ChildChecklistState {
+	/**
+	 * #3107: tenant に **取込前から存在した** template 名のスナップショット (DB load 時点)。
+	 * re-import (同一 backup の再取込) の冪等性を担保する name-dedup はこの集合に対してのみ行う。
+	 * 当 import 内で新規作成した同名 template (distinct exportId) はここに含めず、collapse させない。
+	 */
+	preExistingNames: Set<string>;
+	/** preExisting + 当 import で作成した template 全ての名 (exportId なし旧 backup の fallback name-dedup 用)。 */
 	names: Set<string>;
 	presetIds: Set<string>;
 	idByName: Map<string, number>;
@@ -587,8 +594,10 @@ async function loadChildChecklistState(
 	tenantId: string,
 ): Promise<ChildChecklistState> {
 	const rows = await findTemplatesByChild(childId, tenantId, true, true);
+	const existingNames = new Set(rows.map((r) => r.name));
 	return {
-		names: new Set(rows.map((r) => r.name)),
+		preExistingNames: new Set(existingNames),
+		names: existingNames,
 		presetIds: new Set(rows.map((r) => r.sourcePresetId).filter((p): p is string => !!p)),
 		idByName: new Map(rows.map((r) => [r.name, r.id])),
 		idByPreset: new Map(
@@ -611,6 +620,13 @@ async function importOneChecklistTemplate(
 		if (tpl.exportId) state.exportIdToId.set(tpl.exportId, templateId);
 	};
 
+	// #3107: 同一 import data 内に同じ exportId が 2 度現れたら真の重複 → 既存解決先を再登録して skip。
+	//   (export-service は templateId ごとに distinct exportId を発番するため通常は発生しないが防御的に処理)
+	if (tpl.exportId && state.exportIdToId.has(tpl.exportId)) {
+		result.skipped.name++;
+		return;
+	}
+
 	// #1254 G1: preset_duplicate → name_duplicate の順で判定
 	if (tpl.sourcePresetId && state.presetIds.has(tpl.sourcePresetId)) {
 		result.skipped.preset++;
@@ -618,7 +634,15 @@ async function importOneChecklistTemplate(
 		if (dupId !== undefined) register(dupId);
 		return;
 	}
-	if (state.names.has(tpl.name)) {
+	// #3107: name-dedup の対象集合を exportId 有無で切り替える。
+	//   - exportId あり (新 backup): 取込前から存在した template (preExistingNames) との衝突のみ skip。
+	//     当 import 内で先に作成した同名 template (distinct exportId) には collapse させず、各々 distinct
+	//     な template として復元する (同名 template の log 取り違え = #3107 根治)。re-import の冪等性は
+	//     pre-existing 名一致で担保される (DB の既存行は exportId を持たないため name でしか照合できない)。
+	//   - exportId なし (旧 backup): 従来通り full names (preExisting + 当 import 作成分) で name-dedup
+	//     し後方互換を維持する。
+	const nameDedupSet = tpl.exportId ? state.preExistingNames : state.names;
+	if (nameDedupSet.has(tpl.name)) {
 		result.skipped.name++;
 		const dupId = state.idByName.get(tpl.name);
 		if (dupId !== undefined) register(dupId);

--- a/tests/unit/services/export-service.test.ts
+++ b/tests/unit/services/export-service.test.ts
@@ -221,6 +221,7 @@ const mockChecklistTemplates = [
 		pointsPerItem: 2,
 		completionBonus: 5,
 		isActive: 1,
+		isArchived: 0,
 		createdAt: '2025-06-01T00:00:00Z',
 		updatedAt: '2025-06-01T00:00:00Z',
 	},
@@ -275,14 +276,16 @@ vi.mock('$lib/server/db/achievement-repo', () => ({
 		childId === 1 ? Promise.resolve(mockUnlockedAchievements) : Promise.resolve([]),
 	),
 }));
+const mockFindTemplatesByChild = vi.fn((childId: number) =>
+	childId === 1 ? Promise.resolve(mockChecklistTemplates) : Promise.resolve([]),
+);
+const mockFindLogsByChild = vi.fn((childId: number) =>
+	childId === 1 ? Promise.resolve(mockChecklistLogs) : Promise.resolve([]),
+);
 vi.mock('$lib/server/db/checklist-repo', () => ({
-	findTemplatesByChild: vi.fn((childId: number) =>
-		childId === 1 ? Promise.resolve(mockChecklistTemplates) : Promise.resolve([]),
-	),
+	findTemplatesByChild: (...args: unknown[]) => mockFindTemplatesByChild(...(args as [number])),
 	findTemplateItems: vi.fn(() => Promise.resolve(mockChecklistItems)),
-	findLogsByChild: vi.fn((childId: number) =>
-		childId === 1 ? Promise.resolve(mockChecklistLogs) : Promise.resolve([]),
-	),
+	findLogsByChild: (...args: unknown[]) => mockFindLogsByChild(...(args as [number])),
 }));
 vi.mock('$lib/server/db/evaluation-repo', () => ({
 	findEvaluationsByChild: vi.fn((childId: number) =>
@@ -443,6 +446,63 @@ describe('exportFamilyData', () => {
 		expect(log?.checkedDate).toBe('2026-03-15');
 		expect(log?.completedAll).toBe(true);
 		expect(log?.pointsAwarded).toBe(7);
+	});
+
+	describe('#3106: archive 済 template の checklistLog を backup に含める', () => {
+		it('export は findTemplatesByChild を includeInactive=true + includeArchived=true で呼ぶ (AC2)', async () => {
+			await exportFamilyData({ tenantId: 'test-tenant' });
+			// signature: findTemplatesByChild(childId, tenantId, includeInactive, includeArchived)
+			expect(mockFindTemplatesByChild).toHaveBeenCalledWith(1, 'test-tenant', true, true);
+		});
+
+		it('archive 済 template の checklistLog が backup に含まれる (silent drop しない)', async () => {
+			// archive 済 template (id 2) + その完了ログ + active template (id 1) を返す
+			const archivedTemplate = {
+				id: 2,
+				childId: 1,
+				name: 'むかしのしたく',
+				icon: '📦',
+				pointsPerItem: 1,
+				completionBonus: 0,
+				isActive: 0,
+				isArchived: 1,
+				createdAt: '2025-05-01T00:00:00Z',
+				updatedAt: '2025-05-20T00:00:00Z',
+			};
+			mockFindTemplatesByChild.mockImplementationOnce(() =>
+				Promise.resolve([...mockChecklistTemplates, archivedTemplate]),
+			);
+			mockFindLogsByChild.mockImplementationOnce(() =>
+				Promise.resolve([
+					...mockChecklistLogs,
+					{
+						id: 2,
+						childId: 1,
+						templateId: 2, // archive 済 template に紐づく log
+						checkedDate: '2026-02-10',
+						itemsJson: '{"9":true}',
+						completedAll: 1,
+						pointsAwarded: 3,
+						createdAt: '2026-02-10T08:00:00Z',
+					},
+				]),
+			);
+
+			const result = await exportFamilyData({ tenantId: 'test-tenant' });
+
+			// archive 済 template 自体が export に含まれる
+			expect(result.data.checklistTemplates.map((t) => t.name)).toContain('むかしのしたく');
+			// archive 済 template の log も name + exportId 解決され silent drop しない
+			expect(result.data.checklistLogs).toHaveLength(2);
+			const archivedLog = result.data.checklistLogs.find(
+				(l) => l.templateName === 'むかしのしたく',
+			);
+			expect(archivedLog).toBeDefined();
+			expect(archivedLog?.checkedDate).toBe('2026-02-10');
+			expect(archivedLog?.pointsAwarded).toBe(3);
+			// #3107: exportId が発番され round-trip キーになっている
+			expect(archivedLog?.templateExportId).toBe('chk-child-1-2');
+		});
 	});
 
 	it('チェックサムが再現可能であること', async () => {

--- a/tests/unit/services/import-service.test.ts
+++ b/tests/unit/services/import-service.test.ts
@@ -1203,6 +1203,103 @@ describe('importFamilyData', () => {
 		});
 	});
 
+	describe('チェックリスト log の round-trip キー (#3107 同名取り違え防止)', () => {
+		it('templateExportId を優先して正しい template に再マップする (name でなく exportId 解決)', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			// 別名 2 template。log は 2 番目 (exportId e2) を指す。
+			data.data.checklistTemplates = [
+				{
+					childRef: 'c1',
+					name: 'あさのしたく',
+					icon: '🌅',
+					pointsPerItem: 1,
+					completionBonus: 0,
+					isActive: true,
+					items: [],
+					exportId: 'e1',
+				},
+				{
+					childRef: 'c1',
+					name: 'よるのしたく',
+					icon: '🌙',
+					pointsPerItem: 1,
+					completionBonus: 0,
+					isActive: true,
+					items: [],
+					exportId: 'e2',
+				},
+			];
+			data.data.checklistLogs = [
+				{
+					childRef: 'c1',
+					templateName: 'よるのしたく',
+					templateExportId: 'e2',
+					checkedDate: '2026-03-15',
+					itemsJson: '{}',
+					completedAll: true,
+					pointsAwarded: 1,
+					createdAt: '2026-03-15T20:00:00Z',
+				},
+			];
+			mockInsertChild.mockResolvedValue({ id: 101 });
+			// 1 件目 → id 50、2 件目 → id 51
+			mockInsertTemplate.mockResolvedValueOnce({ id: 50 }).mockResolvedValueOnce({ id: 51 });
+			mockAssignTemplateToChildren.mockResolvedValue([]);
+			mockUpsertLog.mockResolvedValue({ id: 1 });
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.checklistLogsImported).toBe(1);
+			// exportId e2 → 2 番目に作成した template (id 51) に attach (name 一致でなく exportId 解決)
+			expect(mockUpsertLog).toHaveBeenCalledWith(
+				expect.objectContaining({ childId: 101, templateId: 51 }),
+				TENANT,
+			);
+		});
+
+		it('templateExportId が無い旧 export は templateName で fallback する (後方互換)', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.checklistTemplates = [
+				{
+					childRef: 'c1',
+					name: 'あさのしたく',
+					icon: '🌅',
+					pointsPerItem: 1,
+					completionBonus: 0,
+					isActive: true,
+					items: [],
+					// exportId なし (旧 export 想定)
+				},
+			];
+			data.data.checklistLogs = [
+				{
+					childRef: 'c1',
+					templateName: 'あさのしたく',
+					// templateExportId なし
+					checkedDate: '2026-03-15',
+					itemsJson: '{}',
+					completedAll: true,
+					pointsAwarded: 1,
+					createdAt: '2026-03-15T08:00:00Z',
+				},
+			];
+			mockInsertChild.mockResolvedValue({ id: 101 });
+			mockInsertTemplate.mockResolvedValue({ id: 60 });
+			mockAssignTemplateToChildren.mockResolvedValue([]);
+			mockUpsertLog.mockResolvedValue({ id: 1 });
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.checklistLogsImported).toBe(1);
+			expect(mockUpsertLog).toHaveBeenCalledWith(
+				expect.objectContaining({ childId: 101, templateId: 60 }),
+				TENANT,
+			);
+		});
+	});
+
 	describe('静的ファイル (アバター画像 / 音声) のインポート (#3077)', () => {
 		function makeChildWithAvatar(exportId: string, sourceChildId: number, avatarUrl: string) {
 			return {

--- a/tests/unit/services/import-service.test.ts
+++ b/tests/unit/services/import-service.test.ts
@@ -1258,6 +1258,131 @@ describe('importFamilyData', () => {
 			);
 		});
 
+		it('同名 (name 衝突) 2 template を exportId で distinct に復元し log を取り違えない (#3107 実シナリオ)', async () => {
+			// #3107 の根本シナリオ: name に UNIQUE 制約が無く、同一 export 内に同名 template が複数存在する。
+			// 旧実装は name-dedup で 2 件目を skip し exportId を 1 件目に登録 → log が誤った template に attach。
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			// 同名 'あさのしたく' を 2 件。exportId は distinct (e1 / e2)。
+			data.data.checklistTemplates = [
+				{
+					childRef: 'c1',
+					name: 'あさのしたく',
+					icon: '🌅',
+					pointsPerItem: 1,
+					completionBonus: 0,
+					isActive: true,
+					items: [],
+					exportId: 'e1',
+				},
+				{
+					childRef: 'c1',
+					name: 'あさのしたく',
+					icon: '🌅',
+					pointsPerItem: 1,
+					completionBonus: 0,
+					isActive: true,
+					items: [],
+					exportId: 'e2',
+				},
+			];
+			// 2 つの log がそれぞれ別 template (e1 / e2) を指す。
+			data.data.checklistLogs = [
+				{
+					childRef: 'c1',
+					templateName: 'あさのしたく',
+					templateExportId: 'e1',
+					checkedDate: '2026-03-15',
+					itemsJson: '{}',
+					completedAll: true,
+					pointsAwarded: 1,
+					createdAt: '2026-03-15T08:00:00Z',
+				},
+				{
+					childRef: 'c1',
+					templateName: 'あさのしたく',
+					templateExportId: 'e2',
+					checkedDate: '2026-03-16',
+					itemsJson: '{}',
+					completedAll: true,
+					pointsAwarded: 1,
+					createdAt: '2026-03-16T08:00:00Z',
+				},
+			];
+			mockInsertChild.mockResolvedValue({ id: 101 });
+			// 同名でも 2 件とも作成される → id 50 / 51 (collapse されない)
+			mockInsertTemplate.mockResolvedValueOnce({ id: 50 }).mockResolvedValueOnce({ id: 51 });
+			mockAssignTemplateToChildren.mockResolvedValue([]);
+			mockUpsertLog.mockResolvedValue({ id: 1 });
+
+			const result = await importFamilyData(data, TENANT);
+
+			// 同名でも 2 template が distinct に作成される (name-collapse 解消)
+			expect(mockInsertTemplate).toHaveBeenCalledTimes(2);
+			expect(result.skipped.name).toBe(0);
+			// 2 件の log がそれぞれ正しい distinct template に attach される
+			expect(result.checklistLogsImported).toBe(2);
+			expect(result.checklistLogsSkipped).toBe(0);
+			// e1 の log → id 50、e2 の log → id 51 (取り違えなし)
+			expect(mockUpsertLog).toHaveBeenCalledWith(
+				expect.objectContaining({ childId: 101, templateId: 50, checkedDate: '2026-03-15' }),
+				TENANT,
+			);
+			expect(mockUpsertLog).toHaveBeenCalledWith(
+				expect.objectContaining({ childId: 101, templateId: 51, checkedDate: '2026-03-16' }),
+				TENANT,
+			);
+		});
+
+		it('exportId 付き backup を既存 tenant data に再取込しても同名 template を重複作成しない (冪等性)', async () => {
+			// #3107 の冪等性: pre-existing tenant に同名 template が既にある場合、exportId 付きでも
+			// name 一致で skip し重複作成しない (re-import で template が増殖しない)。
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.checklistTemplates = [
+				{
+					childRef: 'c1',
+					name: 'あさのしたく',
+					icon: '🌅',
+					pointsPerItem: 1,
+					completionBonus: 0,
+					isActive: true,
+					items: [],
+					exportId: 'e1',
+				},
+			];
+			data.data.checklistLogs = [
+				{
+					childRef: 'c1',
+					templateName: 'あさのしたく',
+					templateExportId: 'e1',
+					checkedDate: '2026-03-15',
+					itemsJson: '{}',
+					completedAll: true,
+					pointsAwarded: 1,
+					createdAt: '2026-03-15T08:00:00Z',
+				},
+			];
+			mockInsertChild.mockResolvedValue({ id: 101 });
+			// tenant に取込前から同名 template (id 70) が存在する
+			mockFindTemplatesByChild.mockResolvedValue([
+				{ id: 70, name: 'あさのしたく', sourcePresetId: null },
+			]);
+			mockUpsertLog.mockResolvedValue({ id: 1 });
+
+			const result = await importFamilyData(data, TENANT);
+
+			// pre-existing と同名 → 重複作成せず skip
+			expect(mockInsertTemplate).not.toHaveBeenCalled();
+			expect(result.skipped.name).toBe(1);
+			// log は既存 template (id 70) に exportId 経由で解決される
+			expect(result.checklistLogsImported).toBe(1);
+			expect(mockUpsertLog).toHaveBeenCalledWith(
+				expect.objectContaining({ childId: 101, templateId: 70 }),
+				TENANT,
+			);
+		});
+
 		it('templateExportId が無い旧 export は templateName で fallback する (後方互換)', async () => {
 			const data = makeExportData();
 			data.family.children = [makeChild('c1')];


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）／ NUC→Web 移管ユーザー

**解決する課題**: 家族データ backup（`/api/v1/export`）の checklist 完了履歴に 2 つの data-integrity 欠陥があった。
- **#3106**: archive 済 template に紐づく checklistLog が warning なく silent drop され、backup から欠落（過去ログが復元時に失われる data loss）。
- **#3107**: export/import が `templateName` を round-trip キーに使い、name に UNIQUE 制約が無いため同名 template が複数あると checklistLog が取り違えられた（mis-attribution）。

**期待される効果**: archive 済 template の log も backup に保全され、同名 template があっても log が正しい template に復元される。家族データ移管（#3080）の backup 完全性・正確性を担保。

## 関連 Issue

closes #3106
closes #3107

- #3083 / #3078（checklist export/import 実装）/ #3103（統合監査 data-integrity チーム sev3 #2/#3 で検出）/ #3104（同 #3083 由来 blocker）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| #3106-AC1 | export 経路で archive 済 template の checklistLog も含める | コード + e2e | `findTemplatesByChild` に `includeArchived` フラグ追加（3 backend + facade + interface、既定 false）。export-service は `(...,true,true)` で archived 含む → log が L368 で drop されない |
| #3106-AC2 | `includeInactive` 等のフラグが export 文脈で正しく効く unit | `npx vitest run tests/unit/services/import-service.test.ts` | 56 既存 + round-trip 2 件 passed。`includeArchived` は別フラグ化（他 caller の archived 除外を不変に保つ、設計判断参照）|
| #3106-AC3 | archive 済 template を含む round-trip で log 件数保存 e2e | `npx playwright test tests/e2e/admin-backup-restore.spec.ts` | **733 passed / 0 failed** |
| #3107-AC1 | round-trip キーを name でなく安定識別子にする | 同 vitest | export-format 1.3.0 で template に `exportId`、log に `templateExportId` を追加。import は exportId 優先解決・無ければ name fallback |
| #3107-AC2 | 同名 template 2 件の round-trip で log が正しい template に復元される unit | 同 vitest | 「templateExportId を優先して正しい template (id 51) に再マップ」を assert（name 一致でなく exportId 解決）|
| 横展開 | 他 export/import の name キー点検 | `git grep` | checklist のみ name round-trip。活動/ごほうびは childRef/静的名で name 取り違えなし。`isArchived` 無条件除外は checklist-repo のみ該当（他 type は archive 概念なし）|

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — `findTemplatesByChild` に `includeArchived` 追加（query パラメータ、schema 変更なし）
- [x] サービス層 (`$lib/server/services/`) — export-service / import-service
- [ ] API エンドポイント
- [ ] ページ / レイアウト
- [ ] UI コンポーネント
- [x] ドメインモデル (`$lib/domain/`) — export-format 1.3.0
- [ ] インフラ
- [ ] LP サイト
- [ ] 設定・CI

**影響を受ける画面・機能**: 家族データ export/import（`/api/v1/export` / `/api/v1/import`）の checklist 部のみ。通常の checklist UI（`findTemplatesByChild` を `includeArchived` 無しで呼ぶ全 caller）は不変。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `import-service.test.ts` に #3107 の exportId 優先解決 + name fallback 後方互換を追加。既存 56 + e2e round-trip で回帰確認
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: `findTemplatesByChild` を sqlite / dynamodb / demo の 3 backend で機能等価に更新（`includeArchived` 連動 filter）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:medium）

## スクリーンショット / ビジュアルデモ

**該当なし（サーバー側 export/import ロジックのみで UI 変更なし）**。検証は unit + e2e round-trip。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: import の per-template 処理を `importOneChecklistTemplate` / 状態初期化を `loadChildChecklistState` に抽出（cognitive complexity 解消）
- [x] **DRY**: round-trip キー解決を exportId/name の単一経路に集約
- [x] **YAGNI**: 安定キーは `chk-${childRef}-${templateId}` の決定的文字列で十分（UUID 等不要）
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: in-memory map 解決。archived 包含で export 件数が僅増するが backup 文脈のみ

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [x] E2E / ユニットシード + チュートリアルを同期 — 3 backend（sqlite/dynamodb/demo）を機能等価に更新
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001) — export schema の internal field 追加（仕様 SSOT 上の利用者向け変更なし、export-format.ts 自体がコメントで記録）
- [x] 並行 PR overlap 確認 (#1200) — #3104（export ヘッダ）/ #3105（配信）と作業面分離。export-format.ts は #3104 の `buildAttachmentContentDisposition` と別箇所
- [ ] N/A

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**。export_version を 1.3.0 に bump したが新 field は全て optional で、`supportedVersions` に 1.2.0 を明示追加し既存 backup の import 互換を維持。

**レビュー依頼事項・QA**:
1. **#3106 設計判断**: `includeInactive=true` を archived 包含に変える案は採らず、別フラグ `includeArchived` を追加した。理由: `findTemplatesByChild(...,true)` を呼ぶ既存 caller（downgrade-service / resource-archive-service / plan-limit-service 等）は archived 除外を前提とするため、`includeInactive` の意味を変えると壊れる。export 経路のみ `includeArchived=true` で opt-in する。
2. **archived 状態の round-trip**: 現状 `archiveTemplate` 等の infra が無いため、import は archived template を `isActive` 値どおり（通常 inactive）に再作成し、**archived フラグ自体は復元しない**（schema には `isArchived` を記録）。本 PR の主目的（log の silent drop 解消）は達成。archived フラグ復元は archive infra 追加を要するため scope 外。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし（サーバー側のみ）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
