### PR TITLE
perf: #3088 admin landing load を並列化 — 逐次 await + per-child N+1 の wall-clock 短縮

### DIFF
--- a/src/routes/(parent)/admin/+page.server.ts
+++ b/src/routes/(parent)/admin/+page.server.ts
@@ -19,24 +19,31 @@ import {
 } from '$lib/server/services/value-preview-service';
 import type { Actions, PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals, parent }) => {
-	const tenantId = requireTenantId(locals);
+// #3088: admin landing の load を高速化するための独立ブロック helper 群。
+// 各ブロックは children + tenantId のみ依存で相互独立のため、load 本体で Promise.all 並列実行する
+// (従来は 6 ブロックを逐次 await + per-child で balance→status を逐次しており wall-clock が sum 加算
+//  だった。並列化で max に短縮。クエリロジック自体は不変で機能回帰なし)。
 
-	// #726: 親 layout で解決済みの planTier をそのまま継承する。
-	// ここで独自に resolvePlanTier を呼ぶとトライアル情報を渡し忘れ、
-	// トライアル中でも free と判定される（歓迎画面が出ない）バグにつながる。
-	const parentData = await parent();
-	const tier = parentData.planTier;
+type AdminChildren = Awaited<ReturnType<typeof getAllChildren>>;
+type MonthlySummaries = Record<
+	number,
+	{ totalActivities: number; currentLevel: number; newAchievements: number }
+>;
+type TodayUsage = { childId: number; childName: string; durationMin: number }[];
+type WeeklyUsage = {
+	childId: number;
+	childName: string;
+	dailySummary: { date: string; durationMin: number }[];
+}[];
 
-	const [children, onboarding] = await Promise.all([
-		getAllChildren(tenantId),
-		getOnboardingProgress(tenantId, '/admin'),
-	]);
-
-	const childrenWithStatus = await Promise.all(
+/** 子供ごとの残高 + ステータス。per-child の balance/status も並列取得する (#3088)。 */
+async function loadChildrenWithStatus(children: AdminChildren, tenantId: string) {
+	return Promise.all(
 		children.map(async (child) => {
-			const balance = await getPointBalance(child.id, tenantId);
-			const status = await getChildStatus(child.id, tenantId);
+			const [balance, status] = await Promise.all([
+				getPointBalance(child.id, tenantId),
+				getChildStatus(child.id, tenantId),
+			]);
 			if ('error' in balance) {
 				logger.warn('[admin] ポイント取得フォールバック', {
 					context: { childId: child.id, error: balance.error },
@@ -55,69 +62,102 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 			};
 		}),
 	);
+}
 
-	// 今月の簡易サマリー
-	const now = new Date();
-	const yearMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-	let monthlySummaries: Record<
-		number,
-		{ totalActivities: number; currentLevel: number; newAchievements: number }
-	> = {};
+/** 今月の簡易サマリー (失敗時は空でフォールバック)。 */
+async function loadMonthlySummaries(
+	tenantId: string,
+	yearMonth: string,
+): Promise<MonthlySummaries> {
 	try {
 		const summaryMap = await getAllChildrenSimpleSummary(tenantId, yearMonth);
-		monthlySummaries = Object.fromEntries(summaryMap);
+		return Object.fromEntries(summaryMap);
 	} catch (e) {
 		logger.warn('[admin] 月次サマリー取得フォールバック', { context: { error: String(e) } });
+		return {};
 	}
+}
 
-	// 有料プラン歓迎画面フラグ（トライアル中も有料扱い）
-	const isPaid = isPaidTier(tier);
-	let showPremiumWelcome = false;
-	if (isPaid) {
-		const welcomeSettings = await getSettings(['premium_welcome_shown'], tenantId);
-		showPremiumWelcome = welcomeSettings.premium_welcome_shown !== 'true';
-	}
+/** 有料プラン歓迎画面フラグ (トライアル中も有料扱い)。 */
+async function loadPremiumWelcome(isPaid: boolean, tenantId: string): Promise<boolean> {
+	if (!isPaid) return false;
+	const welcomeSettings = await getSettings(['premium_welcome_shown'], tenantId);
+	return welcomeSettings.premium_welcome_shown !== 'true';
+}
 
-	// #2295 (EPIC #2294 ①): 季節コンテンツ情報 / 思い出チケット削除済 (2026-05-19)
-	// #3033: planStats (#767) は /admin/subscription (+page.server.ts) に一本化 — home では取得しない
-
-	// #1292: 本日の子供ごとの使用時間サマリー
-	let todayUsage: { childId: number; childName: string; durationMin: number }[] = [];
+/** #1292: 本日の子供ごとの使用時間サマリー (失敗時は空)。 */
+async function loadTodayUsage(children: AdminChildren, tenantId: string): Promise<TodayUsage> {
 	try {
-		todayUsage = await getTodayUsageSummary(
+		return await getTodayUsageSummary(
 			tenantId,
 			children.map((c) => ({ id: c.id, nickname: c.nickname })),
 		);
 	} catch (e) {
 		logger.warn('[admin] 使用時間取得フォールバック', { context: { error: String(e) } });
+		return [];
 	}
+}
 
-	// #1576: 週次使用時間サマリー（子供ごとの日別使用時間）
-	let weeklyUsage: {
-		childId: number;
-		childName: string;
-		dailySummary: { date: string; durationMin: number }[];
-	}[] = [];
+/** #1576: 週次使用時間サマリー (失敗時は空)。 */
+async function loadWeeklyUsage(children: AdminChildren, tenantId: string): Promise<WeeklyUsage> {
 	try {
-		const weeklyResults = await Promise.all(
+		return await Promise.all(
 			children.map(async (child) => {
 				const dailySummary = await getWeeklyUsageSummary(tenantId, child.id);
 				return { childId: child.id, childName: child.nickname, dailySummary };
 			}),
 		);
-		weeklyUsage = weeklyResults;
 	} catch (e) {
 		logger.warn('[admin] 週次使用時間取得フォールバック', { context: { error: String(e) } });
+		return [];
 	}
+}
 
-	// #1600 ADR-0023 I9: 初月価値プレビュー（マイルストーン + 30 日プレビュー）
-	// 取得失敗時はフォールバック（preview セクション非表示）で admin 全体は守る
-	let valuePreview: TenantValuePreview | null = null;
+/** #1600: 初月価値プレビュー (失敗時は null = preview セクション非表示)。 */
+async function loadValuePreview(tenantId: string): Promise<TenantValuePreview | null> {
 	try {
-		valuePreview = await getTenantValuePreview(tenantId);
+		return await getTenantValuePreview(tenantId);
 	} catch (e) {
 		logger.warn('[admin] 価値プレビュー取得フォールバック', { context: { error: String(e) } });
+		return null;
 	}
+}
+
+export const load: PageServerLoad = async ({ locals, parent }) => {
+	const tenantId = requireTenantId(locals);
+
+	// #726: 親 layout で解決済みの planTier をそのまま継承する。
+	// ここで独自に resolvePlanTier を呼ぶとトライアル情報を渡し忘れ、
+	// トライアル中でも free と判定される（歓迎画面が出ない）バグにつながる。
+	const parentData = await parent();
+	const tier = parentData.planTier;
+
+	const [children, onboarding] = await Promise.all([
+		getAllChildren(tenantId),
+		getOnboardingProgress(tenantId, '/admin'),
+	]);
+
+	const now = new Date();
+	const yearMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+	const isPaid = isPaidTier(tier);
+
+	// #3088: 以降の 6 ブロックは children + tenantId のみ依存で相互独立 → 並列実行して wall-clock を短縮。
+	// #2295: 季節コンテンツ / 思い出チケット削除済。#3033: planStats は /admin/subscription に一本化。
+	const [
+		childrenWithStatus,
+		monthlySummaries,
+		showPremiumWelcome,
+		todayUsage,
+		weeklyUsage,
+		valuePreview,
+	] = await Promise.all([
+		loadChildrenWithStatus(children, tenantId),
+		loadMonthlySummaries(tenantId, yearMonth),
+		loadPremiumWelcome(isPaid, tenantId),
+		loadTodayUsage(children, tenantId),
+		loadWeeklyUsage(children, tenantId),
+		loadValuePreview(tenantId),
+	]);
 
 	return {
 		children: childrenWithStatus,


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: `/admin`（親画面）の origin（Lambda）レンダリングが 4.2s（HAR #3088 実測）かかり、PIN ログイン後の親画面表示が遅い。原因の一つは `+page.server.ts` の load が **6 つの相互独立ブロック（子供別残高/ステータス・月次サマリー・歓迎フラグ・本日使用時間・週次使用時間・価値プレビュー）を逐次 await** し、さらに per-child で `getPointBalance → getChildStatus` を逐次実行して wall-clock が sum 加算されていたこと。

**期待される効果**: 独立ブロックを並列実行し data-load の wall-clock を sum→max に短縮。親画面表示の体感速度を改善する（cold start 分は Pre-PMF 低トラフィックの構造的側面として本 PR scope 外）。

## 関連 Issue

closes #3088

- HAR 解析から派生（姉妹: #3087 CloudFront edge offload = 別セッション #3099 で対応済 / #3089 PIN 遷移 progress = #3091）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | cold start と data-load の内訳を記録（4.2s の出どころ定量化）| コード分析 + HAR | HAR で `/admin` HTML origin = 4,214ms（`no-cache`・`x-cache:Miss`）。内訳の厳密 split は X-Ray 等の profiling infra を要し本 PR では未計測だが、data-load 側の構造的無駄（6 ブロック逐次 + per-child 逐次）を特定し解消。cold start 分は別軸（provisioned concurrency は ADR-0010 コスト要注意のため非対象）|
| AC2 | data-load 短縮（N+1 batch or 並列化）| `git diff` + e2e | 6 独立ブロックを `Promise.all` 並列実行（sum→max）、per-child の balance/status も `Promise.all` 化。逐次依存していた DB 呼び出しを並列化 |
| AC3 | 機能回帰なし | `npx svelte-check` + admin e2e | svelte-check **0 errors** / `value-preview-and-milestone.spec.ts` 含む **746 passed / 0 failed**。返却データ shape・フォールバック挙動は不変 |
| AC4 | DynamoDB 変更時の両実装等価 + 08-DB 同期 | — | **N/A**（DB クエリ・repo は不変。load の await 並列化のみで DynamoDB/SQLite 実装に変更なし）|
| AC5 | コスト増対策を採る場合 ADR-0010 + 財務影響明記 | — | **N/A**（provisioned concurrency 等のコスト増対策は採らず、ロジック並列化のみ。コスト影響ゼロ）|

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正（perf）
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API エンドポイント
- [x] ページ / レイアウト (`src/routes/(parent)/admin/+page.server.ts`)
- [ ] UI コンポーネント
- [ ] ドメインモデル
- [ ] インフラ
- [ ] LP サイト
- [ ] 設定・CI

**影響を受ける画面・機能**: `/admin`（親画面ホーム）の load のみ。返却データは不変のため UI 描画に変化なし（表示速度のみ改善）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: 返却データ shape・挙動が不変のため新規テストなし。既存 admin e2e（746 passed）+ svelte-check 0 で回帰固定
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（DB 層不変）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor: サーバー側 `+page.server.ts` load の await 並列化のみ。返却データ shape 不変で UI 変更なし・視覚差分ゼロ）**。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 各独立ブロックを単一責務の helper（`loadChildrenWithStatus` 等）に抽出
- [x] **DRY**: try/catch フォールバックを helper に集約
- [x] **YAGNI**: 並列化のみ。profiling/メトリクス基盤や provisioned concurrency は導入しない
- [x] **Security（OSS 公開前提）**: N/A（ロジック並列化）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: 本 PR の主目的。逐次 6 ブロック + per-child 逐次 → `Promise.all` で wall-clock を sum→max に短縮

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001) — load の内部実装最適化で利用者向け仕様変更なし
- [x] 並行 PR overlap 確認 (#1200) — #3087（infra、#3099 で対応済）/ #3089（PIN progress、#3091）と作業面分離
- [x] N/A — `/admin` home load 固有。他画面の load は対象外（本 PR は #3088 の /admin に限定）

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（返却データ shape・フォールバック挙動は完全に不変、await の並列化のみ）

**レビュー依頼事項・QA**: AC1 の「cold start vs data-load」厳密 split は X-Ray 等の profiling infra を要するため本 PR では未計測とし、data-load 側の構造的無駄（6 ブロック逐次 + per-child 逐次）の解消にスコープを絞った。DynamoDB Scan の Query 化（admin landing が叩く集計系）と cold start 対策は別軸として残すこの scope 判断の妥当性を確認いただきたい。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし（サーバー側 load のみ、見た目不変）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


---
> **[QM triage 2026-06-18]** `design-doc-check` は false-positive。本 PR は `src/routes/(parent)/admin/+page.server.ts` の load を Promise.all で並列化した**純粋な内部 perf refactor** (return 形・fallback 意味・クエリロジック不変、機能仕様変化なし) であり、QM が full diff を実読して behavior-preserving を確認済。ADR-0003 §4 / #1985 の内部 refactor exempt に該当するため `refactor:internal-no-doc-impact` label を付与。本 note は `edited` event で gate を再評価させるためのもの。
