### PR TITLE
infra: #3048 CI 効率化 — concurrency 付与(P1) + admin-bypass cron 日次化(P2) + security-scan retention 短縮(P4)

### DIFF
--- a/.github/workflows/admin-bypass-evidence.yml
+++ b/.github/workflows/admin-bypass-evidence.yml
@@ -6,14 +6,16 @@ name: Admin Bypass Evidence Check
 
 on:
   schedule:
-    # 毎時 10 分に起動（LOOKBACK_HOURS=2 と組み合わせて merge 後 1h 以内に拾えるようにする）
-    - cron: '10 * * * *'
+    # #3048 P2: 毎時(24 run/日)から日次へ緩和。LOOKBACK_HOURS=26 で 24h の間隔 + 2h 余裕を
+    # カバーし merge 漏れを防ぐ（block しない事後追記要求のため日次粒度で十分、ADR-0044）。
+    # 15:10 UTC = 00:10 JST 日次起動。
+    - cron: '10 15 * * *'
   workflow_dispatch:
     inputs:
       lookback_hours:
-        description: 'Lookback window in hours (default 2)'
+        description: 'Lookback window in hours (default 26 = 日次 cron の 24h 間隔 + 余裕)'
         required: false
-        default: '2'
+        default: '26'
       dry_run:
         description: 'Skip comment posting (for testing)'
         required: false
@@ -32,7 +34,7 @@ jobs:
       - name: Run admin bypass evidence check
         env:
           REPO: ${{ github.repository }}
-          LOOKBACK_HOURS: ${{ github.event.inputs.lookback_hours || '2' }}
+          LOOKBACK_HOURS: ${{ github.event.inputs.lookback_hours || '26' }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/check-admin-bypass-evidence.mjs

--- a/.github/workflows/check-pr-template-sections-sync.yml
+++ b/.github/workflows/check-pr-template-sections-sync.yml
@@ -1,5 +1,9 @@
 name: PR template SSOT 同期検証
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Issue #2060: .github/PULL_REQUEST_TEMPLATE.md と
 # .github/PR_TEMPLATE_SECTIONS.json (SSOT) の整合性を検証する drift gate。
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,9 @@
 name: "CodeQL"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,9 @@
 name: "Dependency Review"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     # #2931 / branch-strategy.md §4: 軽量レーン（高速 + 依存脆弱性は per-PR で検知価値が高い）。

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,9 @@
 name: "Labeler"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request_target:
     # #1218: ready_for_review は除外（Draft でも走るため再実行は無駄）。

--- a/.github/workflows/lp-fallback-check.yml
+++ b/.github/workflows/lp-fallback-check.yml
@@ -1,5 +1,9 @@
 name: LP fallback check (labels.ts <-> site/*.html data-lp-key)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # #1919 Phase 5 F2: LP fallback テキスト整合 CI
 #
 # 背景:

--- a/.github/workflows/lp-metrics.yml
+++ b/.github/workflows/lp-metrics.yml
@@ -1,5 +1,9 @@
 name: LP Metrics (dimensions / forbidden terms / CTA variants / removal residue)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # #1163: LP (site/index.html) のページ肥大化・開発者語彙・CTA 文言散乱を CI で自動検知
 # 閾値違反 / 禁止用語出現 / CTA バリエーション過多 を FAIL にする
 # ratchet ルール: 閾値は下げることのみ許可、上げるには ADR が必要

--- a/.github/workflows/orphan-check.yml
+++ b/.github/workflows/orphan-check.yml
@@ -1,5 +1,9 @@
 name: Orphan resource detection (EPIC #2362 follow-up)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # 10 種類の orphan detection script を統合実行し、新規 orphan の流入を block する CI gate。
 #
 # 設計背景:

--- a/.github/workflows/pr-ac-verification-check.yml
+++ b/.github/workflows/pr-ac-verification-check.yml
@@ -1,5 +1,9 @@
 name: PR AC verification check (ADR-0038)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # #1165 / ADR-0038: PR 本文の「AC 検証マップ」が全行埋まっているかを機械検証する
 # 初期リリース: warn-only (continue-on-error: true)。
 # → hard-fail に昇格済み（pr-template-gate.yml 導入に合わせて統一）。

--- a/.github/workflows/pr-author-guard.yml
+++ b/.github/workflows/pr-author-guard.yml
@@ -1,5 +1,9 @@
 name: PR Author Guard
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # PR 起票アカウント違反の server side gate (#1994 / ADR-0022 amendment 4 相当)
 #
 # 背景:

--- a/.github/workflows/pr-info.yml
+++ b/.github/workflows/pr-info.yml
@@ -1,5 +1,9 @@
 name: PR Info
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # #1481 Phase 4: pr-size-check.yml + pr-file-overlap.yml を統合
 # 両ジョブとも comment-only（block しない）。マージ順序・サイズの注意喚起が目的。
 

--- a/.github/workflows/pr-lane-smoke.yml
+++ b/.github/workflows/pr-lane-smoke.yml
@@ -1,5 +1,9 @@
 name: PR Lane Smoke
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Issue #2943 (Phase A/A-1): lane 判定 SSOT の動作実証。
 #
 # AC4「composite action を 2 つ以上の gate workflow で実際に `uses: ./actions/pr-lane`

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -1,5 +1,9 @@
 name: PR Merge Gate
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # #1481: PR チェックリスト未完了 / AC 検証マップ未記入を CI でブロックする
 # Required status checks に `pr-merge-gate / checklist-check` を追加すること（デプロイ後に手動設定）
 #

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -1,5 +1,9 @@
 name: PR Quality Gate
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited, ready_for_review]

--- a/.github/workflows/pr-template-gate.yml
+++ b/.github/workflows/pr-template-gate.yml
@@ -1,5 +1,9 @@
 name: PR テンプレート必須ゲート
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # PR テンプレート (.github/PULL_REQUEST_TEMPLATE.md) の必須項目が
 # 適切に記入されているかを 5 つの並列ジョブで検証する。
 # いずれか 1 つでも失敗すると PR がブロックされる（hard-fail）。

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -36,7 +36,9 @@ jobs:
         with:
           name: security-audit-results
           path: audit-result.json
-          retention-days: 90
+          # #3048 P4: 90→30 日。npm audit スナップショットは scheduled run 毎に再生成される
+          # デバッグ用 backup で、90 日保持は過剰（監査 trail 系の長期保持とは別物）。
+          retention-days: 30
 
       - name: Ensure required labels exist
         if: always()

--- a/.github/workflows/zenn-lint.yml
+++ b/.github/workflows/zenn-lint.yml
@@ -1,5 +1,9 @@
 name: Zenn Lint
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     paths:


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者 / 運営（CI フィードバック速度・衛生）

**解決する課題**: public repo は GitHub Actions 課金 $0 だが、PR 連続 push 時に古い run が cancel されず二重三重に実行され、フィードバックが遅くなる。33 workflow 中 25 が `concurrency` 未設定で、特に重い ci/codeql/lp-metrics/PR gate 群が該当。admin-bypass-evidence は毎時 cron（24 run/日）で過剰。

**期待される効果**: 実行時間を圧縮し（古い run を即 cancel）、フィードバックを高速化。将来 private 化時の storage 課金・可読性低下にも備える。**コスト削減ではなく実行時間圧縮 / 衛生が目的**（priority:low、緊急性なし）。

## 関連 Issue

closes #3048

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| P1 | PR/push 系 workflow に `concurrency.cancel-in-progress` 付与（deploy 系除外） | git diff + js-yaml parse | HEAD `7a7b3615a` / 16 workflow に付与（ci/codeql/lp-metrics/pr-quality-gate/pr-template-gate/pr-ac-verification-check/pr-merge-gate/pr-lane-smoke/pr-info/orphan-check/dependency-review/lp-fallback-check/check-pr-template-sections-sync/zenn-lint/labeler/pr-author-guard）。group key=`github.workflow` + PR 番号優先（`pull_request.number`、push 時 `github.ref` へ fallback）で pull_request_target の PR 横断 cancel 罠を回避。deploy 系 + dependabot は除外。38 workflow 全 YAML parse OK |
| P2 | `admin-bypass-evidence` の cron を日次以下 or イベント駆動へ | git diff | HEAD `7a7b3615a` / `10 * * * *`→`10 15 * * *`（日次）+ LOOKBACK_HOURS 2→26（24h 間隔 + 余裕）。ADR-0044 事後追記要求のため日次粒度で十分 |
| P3 | docs-only 変更で重量 job が skip されるか検証、未対応なら path 分岐追加（required pending 罠回避） | ci.yml `if:` 条件 + ci-gate 検証 | HEAD `7a7b3615a` / **既に対応済**: `unit-test`(if app\|\|deps) / e2e / a11y / docker / storybook(if app + base_ref!=develop) が docs-only で skip。required は `ci-gate`(if:always() + needs 全 job 集約) 1 本で skip job を評価 → pending 罠は構造的に非発生。**新規 path 分岐は追加しない**（罠回避） |
| P4 | artifact retention 短縮 + 失敗時 upload 化、堆積方針決定 | git diff + retention 棚卸し | HEAD `7a7b3615a` / security-scan の npm audit backup 90→30 日。**監査 evidence 系（integration-attest 90d = in-toto trail / audit-run 30d / ci.yml integration-pr-evidence 30d）は意図的長期保持のため保全**。ci.yml の e2e/coverage は既に 3-7 日で最適化済。`if: failure()` 化は blob report が merge-reports の downstream 消費元のため適用せず（success 時の report 生成が壊れる） |
| 効率化前後比較 | 1 PR 連続 push 時の総 run 分を比較・記録 | 機構分析 | HEAD `7a7b3615a` / before: N 連続 push = N 本の full run 完走。after: cancel-in-progress により最新 push の 1 本のみ完走（古い run 即 cancel）。理論上 N 連続 push で最大 (N-1) 本分の run 時間を削減 |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`.github/`) — 18 workflow（16 concurrency + admin-bypass cron + security-scan retention）

**影響を受ける画面・機能**: なし（CI orchestration のみ。deploy 経路・アプリ挙動の変更なし）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: N/A（workflow YAML のみ。全 38 workflow を js-yaml で parse 検証、構文 OK）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: `.github/workflows/` のみの変更で UI 変更を含まないため。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（CI config）
- [x] **DRY**: 16 workflow で同一の concurrency block（group key は `github.workflow` で自動的に workflow 別に分離）
- [x] **YAGNI**: P1/P2/P4 の安全な範囲に限定。P3 は既対応のため新規 path 分岐を足さない（required pending 罠回避）。監査 evidence retention は保全
- [x] **Security**: pull_request_target（labeler/pr-author-guard）の concurrency group は `pull_request.number` 優先で PR 横断 cancel を回避。self-hosted runner への移管は public で危険のため不採用（Issue Non-Goals 準拠）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: 本変更自体が CI 実行時間の最適化

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（CI config）
- [x] **設計書同期** (ADR-0001): deploy 経路・gate 設計は不変（branch-strategy.md §4 の重量/軽量レーン分岐は維持）。concurrency 付与は実行回数の最適化のみで gate 範囲を変えない

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: (1) concurrency `cancel-in-progress: true` は required check（pr-merge-gate 等）でも安全 — 新 push で旧 run が cancel されても最新 commit の run が required を満たす（GitHub は最新 SHA で評価）。(2) deploy 系（中断危険）は対象外、dependabot-auto-merge（bot）も除外。(3) admin-bypass 日次化は ADR-0044 の事後追記要求のため粒度十分、LOOKBACK 26h で merge 漏れ防止。(4) P3 は既対応（ci-gate 集約で pending 罠なし）のため新規変更なし。(5) 監査 evidence retention（integration-attest 90d 等）は意図的保全。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（P1/P2/P4 実施 + P3 既対応検証 + 前後比較記録）
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A（CI config のみ）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

