### PR TITLE
fix(UX): #3125 親管理画面の放置を「固まる」から「子供選択画面へ自動リダイレクト」に変更

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -212,6 +212,7 @@ Layer 2: Context（署名付きトークン）
 3. **Sliding refresh**: 各 `/admin/*` request 時に `+layout.server.ts` が cookie 検証 + `lastActiveAt` 更新 + 再 sign して cookie 再発行 (15 分 timeout 延長)
 4. **未認証 / 失効時の redirect**: middleware が `/switch?pinRequired=1&next=<原 path>` に redirect → 入口で modal auto-open
 5. **明示削除 (EPIC 構造的核心 / 子#2314)**: `/switch` の `select` action で `cookies.delete('gq_parent_session')` を実行。親が child mode に戻った瞬間に session 失効し、次の子の admin アクセスは再 PIN を要求される
+6. **client inactivity redirect (放置時)**: 旧来 sliding/失効判定は server load (= ページ遷移時) のみだったため、admin 画面を放置すると失効後も画面が残り「操作だけ失敗 = 固まった」とユーザに見えた。`admin/+layout.svelte` の client タイマー (`startParentGateInactivityRedirect`、15 分 = `INACTIVITY_TIMEOUT_MS` と一致) が、PIN gate 有効時 (`pinGateActive`) のみアイドル 15 分で `POST /api/v1/parent-gate/logout` (parent session 破棄) → `/switch?timedOut=1` (子供選択画面) へ自動リダイレクトする。子供が放置画面を操作する穴を「固める」のでなく「子供選択画面に戻す」挙動で塞ぐ (ADR-0012 anti-engagement 整合)。dev/demo では起動しない
 
 #### 関連実装
 

--- a/scripts/capture-specs/flows/switch-timed-out.mjs
+++ b/scripts/capture-specs/flows/switch-timed-out.mjs
@@ -1,0 +1,60 @@
+/**
+ * scripts/capture-specs/flows/switch-timed-out.mjs (#3125)
+ *
+ * 親管理画面の inactivity redirect で `/switch?timedOut=1` に戻ったときの通知バナー
+ * (data-testid="parent-gate-timed-out-banner") を撮影する flow。
+ * owner login → /switch?timedOut=1 を開き、子供選択画面 + timedOut バナーを撮影する。
+ *
+ * 動作前提: PARENT_GATE_FORCE_ACTIVE=true npm run dev:cognito (port 5174)
+ *
+ * 使用例:
+ *   MSYS_NO_PATHCONV=1 PARENT_GATE_FORCE_ACTIVE=true node scripts/capture.mjs \
+ *     --pr 3127 --base-url http://localhost:5174 \
+ *     --flow switch-timed-out --url "/switch?timedOut=1" \
+ *     --actions scripts/capture-specs/flows/switch-timed-out.mjs \
+ *     --presets mobile,desktop
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
+
+async function loginAs(page, email, password) {
+	await page.goto(`${BASE_URL}/auth/login`);
+	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 15_000 });
+	await page.waitForFunction(
+		() => {
+			const input = document.querySelector('input[name="email"]');
+			return input?.getAttribute('type') === 'email';
+		},
+		{ timeout: 15_000 },
+	);
+	const emailInput = page.getByLabel('メールアドレス');
+	await emailInput.click();
+	for (const ch of email) {
+		await page.keyboard.type(ch, { delay: 20 });
+	}
+	const pwdInput = page.getByLabel('パスワード', { exact: true });
+	await pwdInput.click();
+	for (const ch of password) {
+		await page.keyboard.type(ch, { delay: 20 });
+	}
+	await page
+		.locator('button[type="submit"]:not([disabled])')
+		.first()
+		.waitFor({ state: 'visible', timeout: 30_000 });
+	await page.getByRole('button', { name: 'ログイン' }).click();
+	await page.waitForURL(/\/(admin|ops|setup|billing|switch|child)/, { timeout: 30_000 });
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	await loginAs(page, 'owner@example.com', 'Gq!Dev#Owner2026x');
+
+	await page.goto(`${BASE_URL}/switch?timedOut=1`);
+	const banner = page.getByTestId('parent-gate-timed-out-banner');
+	await banner.waitFor({ state: 'visible', timeout: 15_000 });
+
+	await capture('switch-timed-out');
+};

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -1334,6 +1334,8 @@ export const OYAKAGI_LABELS = {
 	// Issue #2353 Fix 5 (Phase A): gateDefaultHint (= '初期値は 5086（がんばり）です') は子供が見て即入れる脆弱性のため modal 用 atom を削除
 	// (#2992 以降は初回作成フローのため gate 経路に既定 PIN ヒント自体が不要。defaultValueHint は legacy local 文脈の PIN 変更画面のみで継続)
 	gatePinRequiredBanner: `${ADMIN_VIEW_TERMS.canonical}に入るには${OYAKAGI_TERMS.name}が必要です`,
+	// 親管理画面で一定時間操作がなく自動的に子供選択画面へ戻った旨の通知 (parent-gate inactivity redirect)
+	gateTimedOutNotice: `しばらく操作がなかったため${ADMIN_VIEW_TERMS.canonical}を閉じました。もう一度入るには${OYAKAGI_TERMS.name}を入力してください`,
 	// #2993: PIN 忘れ救済導線 (入力モード + cognito identity のみ表示、/auth/reset-pin = パスワード再入力方式へ遷移)
 	gateForgotPinLink: `${OYAKAGI_TERMS.name}を忘れた方`,
 	// #2994: local (self-host) では運用者向け reset 手順に誘導する (email/リンク導線なし)

--- a/src/lib/features/admin/parent-gate-inactivity.ts
+++ b/src/lib/features/admin/parent-gate-inactivity.ts
@@ -1,0 +1,67 @@
+// src/lib/features/admin/parent-gate-inactivity.ts
+//
+// 親管理画面 (/admin/*) の inactivity タイマー。一定時間 (既定 15 分、parent-gate session の
+// INACTIVITY_TIMEOUT_MS = 15 分 / NIST SP 800-63B-4 AAL1 と一致) 操作が無ければ onTimeout を
+// 1 度だけ発火する。呼び出し側はそこで parent session を logout し /switch (子供選択画面) へ
+// リダイレクトする。
+//
+// 背景: 旧来は parent session 失効を admin layout の server load (= ページ遷移時) でのみ判定して
+// いたため、放置中はナビが起きず、画面が /admin のまま残り「操作だけ失敗する = 固まった」と
+// ユーザに見えていた。本タイマーで「固める」のでなく「子供選択画面に戻す」挙動に変える
+// (子供が放置画面を触れないという本来の意図を、固まらせずに達成。ADR-0012 anti-engagement 整合)。
+
+/** parent-gate inactivity redirect の既定アイドル時間 (15 分)。server INACTIVITY_TIMEOUT_MS と一致。 */
+export const PARENT_GATE_INACTIVITY_MS = 15 * 60 * 1000;
+
+export interface ParentGateInactivityOptions {
+	/** アイドル判定時間 (ms)。既定 15 分。 */
+	timeoutMs?: number;
+	/** タイマー満了時に 1 度だけ呼ばれる。logout + /switch リダイレクトを行う。 */
+	onTimeout: () => void;
+	/** チェック間隔 (ms)。既定 30 秒。 */
+	tickMs?: number;
+	/** テスト用に上書き可能。既定 Date.now。 */
+	getNow?: () => number;
+}
+
+/**
+ * inactivity タイマーを開始する。戻り値はクリーンアップ関数。
+ * pointerdown / keydown / scroll / touchstart を「操作」とみなし lastActive を更新する。
+ */
+export function startParentGateInactivityRedirect(
+	options: ParentGateInactivityOptions,
+): () => void {
+	const {
+		timeoutMs = PARENT_GATE_INACTIVITY_MS,
+		onTimeout,
+		tickMs = 30_000,
+		getNow = () => Date.now(),
+	} = options;
+
+	let lastActive = getNow();
+	let fired = false;
+
+	const onActivity = () => {
+		lastActive = getNow();
+	};
+
+	const events: (keyof WindowEventMap)[] = ['pointerdown', 'keydown', 'scroll', 'touchstart'];
+	for (const ev of events) {
+		window.addEventListener(ev, onActivity, { passive: true });
+	}
+
+	const timer = setInterval(() => {
+		if (fired) return;
+		if (getNow() - lastActive >= timeoutMs) {
+			fired = true;
+			onTimeout();
+		}
+	}, tickMs);
+
+	return () => {
+		clearInterval(timer);
+		for (const ev of events) {
+			window.removeEventListener(ev, onActivity);
+		}
+	};
+}

--- a/src/routes/(parent)/admin/+layout.server.ts
+++ b/src/routes/(parent)/admin/+layout.server.ts
@@ -175,6 +175,9 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url }) => {
 	return {
 		pointSettings,
 		authMode,
+		// parent-gate inactivity redirect (client): PIN gate 有効時のみ admin で
+		// 15 分アイドル → /switch 自動リダイレクトを起動する (dev/demo では起動しない)
+		pinGateActive,
 		tenantStatus,
 		isPremium,
 		planTier,

--- a/src/routes/(parent)/admin/+layout.svelte
+++ b/src/routes/(parent)/admin/+layout.svelte
@@ -4,6 +4,7 @@ import AdminLayout from '$lib/features/admin/components/AdminLayout.svelte';
 import SetupResumeBanner from '$lib/features/admin/components/SetupResumeBanner.svelte';
 import TrialBanner from '$lib/features/admin/components/TrialBanner.svelte';
 import TrialEndedDialog from '$lib/features/admin/components/TrialEndedDialog.svelte';
+import { startParentGateInactivityRedirect } from '$lib/features/admin/parent-gate-inactivity';
 import type { OnboardingProgress } from '$lib/server/services/onboarding-service';
 import DebugPlanIndicator from '$lib/ui/components/DebugPlanIndicator.svelte';
 
@@ -26,11 +27,30 @@ interface Props {
 		};
 		// #2821: setup 由来遷移 (`?from=setup`) 時のみ非 null
 		setupOnboarding?: OnboardingProgress | null;
+		// parent-gate inactivity redirect 起動フラグ (PIN gate 有効時のみ true)
+		pinGateActive?: boolean;
 	};
 	children: Snippet;
 }
 
 let { data, children }: Props = $props();
+
+// parent-gate inactivity redirect: PIN gate 有効時のみ、15 分アイドルで親 session を logout し
+// /switch (子供選択画面) へ自動リダイレクトする。放置画面を子供が触れない本来の意図を、
+// 「固める」のでなく「子供選択画面に戻す」挙動で達成する (ユーザ報告: 放置でタイムアウト→操作不能)。
+$effect(() => {
+	if (!data.pinGateActive) return;
+	return startParentGateInactivityRedirect({
+		onTimeout: async () => {
+			try {
+				await fetch('/api/v1/parent-gate/logout', { method: 'POST' });
+			} catch {
+				// logout 失敗時も /switch には戻す (server session は遅くとも 15 分で失効する)
+			}
+			window.location.href = '/switch?timedOut=1';
+		},
+	});
+});
 
 const trial = $derived(data.trialStatus);
 // #3033 (PO 指摘 2026-06-12): body バナーは urgent (trial 残 1 日以下) のみ。

--- a/src/routes/switch/+page.server.ts
+++ b/src/routes/switch/+page.server.ts
@@ -18,6 +18,9 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	}
 	const reason = url.searchParams.get('reason');
 
+	// 親管理画面で一定時間アイドル → /switch?timedOut=1 で自動リダイレクトされた旨を通知
+	const timedOut = url.searchParams.get('timedOut') === '1';
+
 	// EPIC #2310 子#2312: PIN gate modal 自動起動の query
 	const pinRequired = url.searchParams.get('pinRequired') === '1';
 	const rawNext = url.searchParams.get('next') ?? '/admin';
@@ -60,6 +63,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 		adminLink,
 		showAdminLink,
 		reason,
+		timedOut,
 		pinRequired,
 		nextPath,
 		onboarding,

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -234,6 +234,10 @@ async function handlePinComplete(details: { valueAsString: string }) {
 		<div class="bg-[var(--color-gold-100)] text-[var(--color-gold-700)] py-3 px-4 text-center text-sm font-semibold border-b border-[var(--color-gold-500)]" role="alert">{SWITCH_PAGE_LABELS.adminForbiddenNotice}</div>
 	{/if}
 
+	{#if data.timedOut}
+		<div class="bg-[var(--color-feedback-info-bg)] text-[var(--color-feedback-info-text)] py-3 px-4 text-center text-sm font-semibold border-b border-[var(--color-feedback-info-border)]" role="status" data-testid="parent-gate-timed-out-banner">{OYAKAGI_LABELS.gateTimedOutNotice}</div>
+	{/if}
+
 	{#if data.pinRequired}
 		<div class="bg-[var(--color-feedback-info-bg)] text-[var(--color-feedback-info-text)] py-3 px-4 text-center text-sm font-semibold border-b border-[var(--color-feedback-info-border)]" role="status" data-testid="parent-gate-required-banner">{OYAKAGI_LABELS.gatePinRequiredBanner}</div>
 	{/if}

--- a/tests/unit/features/parent-gate-inactivity.test.ts
+++ b/tests/unit/features/parent-gate-inactivity.test.ts
@@ -1,0 +1,95 @@
+// tests/unit/features/parent-gate-inactivity.test.ts
+// 親管理画面 inactivity redirect タイマーの単体テスト。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	PARENT_GATE_INACTIVITY_MS,
+	startParentGateInactivityRedirect,
+} from '../../../src/lib/features/admin/parent-gate-inactivity';
+
+describe('startParentGateInactivityRedirect', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it('既定 timeout は 15 分 (server INACTIVITY_TIMEOUT_MS と一致)', () => {
+		expect(PARENT_GATE_INACTIVITY_MS).toBe(15 * 60 * 1000);
+	});
+
+	it('timeoutMs アイドルで onTimeout を 1 度だけ発火する', () => {
+		let now = 0;
+		const onTimeout = vi.fn();
+		const cleanup = startParentGateInactivityRedirect({
+			timeoutMs: 1000,
+			tickMs: 100,
+			onTimeout,
+			getNow: () => now,
+		});
+
+		// まだアイドルでない
+		now = 500;
+		vi.advanceTimersByTime(500);
+		expect(onTimeout).not.toHaveBeenCalled();
+
+		// timeout 到達
+		now = 1000;
+		vi.advanceTimersByTime(500);
+		expect(onTimeout).toHaveBeenCalledTimes(1);
+
+		// その後も再発火しない (1 度だけ)
+		now = 5000;
+		vi.advanceTimersByTime(2000);
+		expect(onTimeout).toHaveBeenCalledTimes(1);
+
+		cleanup();
+	});
+
+	it('操作 (keydown) で lastActive がリセットされ onTimeout が発火しない', () => {
+		let now = 0;
+		const onTimeout = vi.fn();
+		const cleanup = startParentGateInactivityRedirect({
+			timeoutMs: 1000,
+			tickMs: 100,
+			onTimeout,
+			getNow: () => now,
+		});
+
+		// 900ms 経過後に操作 → lastActive=900 にリセット
+		now = 900;
+		window.dispatchEvent(new KeyboardEvent('keydown'));
+		vi.advanceTimersByTime(900);
+
+		// 操作から 999ms (= now 1899) ではまだ未発火
+		now = 1899;
+		vi.advanceTimersByTime(999);
+		expect(onTimeout).not.toHaveBeenCalled();
+
+		// 操作から 1000ms (= now 1900) で発火
+		now = 1900;
+		vi.advanceTimersByTime(1);
+		expect(onTimeout).toHaveBeenCalledTimes(1);
+
+		cleanup();
+	});
+
+	it('cleanup でタイマーが停止し以後発火しない', () => {
+		let now = 0;
+		const onTimeout = vi.fn();
+		const cleanup = startParentGateInactivityRedirect({
+			timeoutMs: 1000,
+			tickMs: 100,
+			onTimeout,
+			getNow: () => now,
+		});
+
+		cleanup();
+		now = 5000;
+		vi.advanceTimersByTime(5000);
+		expect(onTimeout).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: 親管理画面（`/admin/*`）を一定時間放置すると parent-gate session が失効するが、**失効後も画面が `/admin` のまま残り操作だけ失敗する**ため「タイムアウトして動かなくなった / 固まった」と報告されていた（PO 報告）。本来の意図（放置画面を子供が操作するのを防ぐ）は、固めるのでなく「**子供選択画面へ自動リダイレクト**」で達成すべき（PO 提案）。

**期待される効果**: 放置 15 分で親 session を破棄し子供選択画面（`/switch`）へ自動リダイレクト。固まらず、子供が放置画面から PIN なしで admin に戻れない本来のセキュリティ意図も維持する。

## 関連 Issue

closes #3125

- EPIC #2310（親 PIN gate）/ ADR-0050 / ADR-0012（anti-engagement）/ #3089（/switch 周辺の PIN 遷移）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 放置 15 分で session 破棄 + `/switch` リダイレクト | `npx vitest run tests/unit/features/parent-gate-inactivity.test.ts` + コード | 4 passed。`admin/+layout.svelte` の `$effect` が `pinGateActive` 時に timer 起動 → `POST /api/v1/parent-gate/logout` → `window.location='/switch?timedOut=1'` |
| AC2 | リダイレクト後 admin 再進入は PIN 再入力要求 | コード | logout で `gq_parent_session` 削除 → `+layout.server.ts` の `verifyParentSession` false → `/switch?pinRequired=1` redirect |
| AC3 | 操作でリセット、活動中はリダイレクトしない | 同 vitest | 「keydown で lastActive リセット → 未発火」を assert |
| AC4 | dev/demo ではタイマー非起動 | コード | `data.pinGateActive`（server `forceActive \|\| (cognito && !devMode)`）が false なら `$effect` 即 return |
| AC5 | `/switch?timedOut=1` 通知バナー（labels SSOT）| SS（下記）+ `sync-lp-fallback --check` | `OYAKAGI_LABELS.gateTimedOutNotice` 経由。`data-testid="parent-gate-timed-out-banner"` |
| AC6 | timer unit test + parent-gate e2e 回帰なし | vitest + `npx playwright test parent-gate.spec.ts` | unit 4 passed / e2e **548 passed / 0 failed** / svelte-check 0 / biome clean |
| AC7 | `14-セキュリティ §4.3` 同期（ADR-0001）| doc diff | §4.3 に「6. client inactivity redirect」を追記 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API エンドポイント
- [x] ページ / レイアウト (`admin/+layout.{server.ts,svelte}` / `switch/+page.{server.ts,svelte}`)
- [x] UI コンポーネント (`$lib/features/admin/parent-gate-inactivity.ts`)
- [x] ドメインモデル (`labels.ts` 1 ラベル追加)
- [ ] インフラ
- [ ] LP サイト
- [ ] 設定・CI

**影響を受ける画面・機能**: `/admin/*`（放置 15 分で `/switch` へ自動遷移）+ `/switch`（`?timedOut=1` 通知バナー）。通常操作中・dev/demo は不変。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/features/parent-gate-inactivity.test.ts` 新設（timeout 発火 / 活動リセット / 単発 / cleanup）。capture flow `switch-timed-out.mjs` 追加
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high）

## スクリーンショット / ビジュアルデモ

可視変更は **`/switch?timedOut=1` の通知バナー**（admin layout 変更は `$effect` のみで視覚差分なし）。owner login → `/switch?timedOut=1` を実フロー（capture flow）で撮影:

**修正後（`/switch?timedOut=1`、子供選択画面 + 通知バナー、mobile + desktop 合成）**:

![修正後 timedOut バナー (mobile/desktop)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3127/switch-timed-out-flow.webp)

![修正後 timedOut バナー mobile 拡大](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3127/01-switch-timed-out.png)

**修正前**: 放置で admin 画面が `/admin` のまま残り操作だけ失敗（固まる）。子供選択画面への自動リダイレクト・通知バナーは存在しなかった（= 上記バナーが新規追加要素）。

**インタラクティブ状態**: admin 放置 15 分（pointer/key/scroll/touch 無し）で上記 `/switch?timedOut=1` に自動遷移。unit test（`parent-gate-inactivity.test.ts`）で timer 挙動を決定的検証。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: timer ロジックを testable な `startParentGateInactivityRedirect` に分離（`auto-sleep.ts` 同型）
- [x] **DRY**: 既存 logout endpoint / labels SSOT を再利用
- [x] **YAGNI**: keep-alive ping 等は導入せず、放置→子供選択画面の最小実装
- [x] **Security（OSS 公開前提）**: logout で session 破棄し再 PIN を強制（子供による admin 復帰穴を塞ぐ）
- [x] **アクセシビリティ**: バナーは `role="status"`
- [x] **パフォーマンス**: 30 秒間隔の軽量 interval + activity listener（passive）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [x] labels SSOT (ADR-0009) — `gateTimedOutNotice` 追加、`sync-lp-fallback --check` PASS
- [x] 設計書同期 (ADR-0001) — `14-セキュリティ §4.3`
- [x] 並行 PR overlap 確認 (#1200) — #3089（/switch PIN 遷移）と同 page だが別箇所（banner 追加 vs overlay）
- [x] N/A — `/admin` 配下共通の挙動。子供画面は対象外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（PIN gate 有効時のみ起動、放置時の挙動を「固まる」→「子供選択画面へ戻す」に改善）

**レビュー依頼事項・QA**: クライアント timer は活動（pointer/key/scroll/touch）でリセットされるが server session は従来どおりナビ時のみ slide する。活動中だがナビしないケース（長時間フォーム入力）では server session が先に失効し得るが、その場合も次リクエストで `/switch?pinRequired=1` へ redirect され「固まらない」。keep-alive ping による server session 同期は Pre-PMF 過剰として本 PR では入れていない判断の妥当性を確認いただきたい。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: `/switch?timedOut=1` バナーを実フロー撮影し embed（admin layout は視覚差分なし）
- [x] 認証画面変更時: parent-gate（PIN）周辺。parent-gate e2e 548 passed で検証

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
