### PR TITLE
docs: #3123 .github/CLAUDE.md の auto-close 記述を branch-strategy.md §3.2 と整合

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -7,7 +7,7 @@
 - 新規チケットは `gh issue create`。`docs/tickets/` への新規ファイル禁止（レガシー、参照のみ）
 - テンプレート: `.github/ISSUE_TEMPLATE/dev_ticket.yml` / `bug_report.yml` / `feature_request.yml`
 - ラベル: `type:feat|fix|refactor|infra|design|docs|marketing|test` / `priority:critical|high|medium|low` / `status:blocked|in-progress|on-hold` / `area:auth|billing|child-ui|admin|lp|db`
-- PR / コミットで `closes #<num>` 自動クローズ
+- PR / コミットでの自動クローズは **`Closes #<num>` / `Fixes #<num>`（closing keyword の直後に `#番号`）が default branch（= `main`）に到達した時のみ**発火する。**conventional-commit prefix（`fix:` / `feat:` / `docs:` / `infra:` `#<num>`）は Issue 参照であって closing keyword ではなく、merge しても auto-close しない**。develop 二層では base=develop（非 default branch）かつ commit 規約が conventional-commit のため、Issue は基本的に main 反映でも auto-close されない。close 運用の SSOT は [docs/sessions/branch-strategy.md §3.2](../docs/sessions/branch-strategy.md)（手動 `- [x]` close + AC gate、または明示 `Closes #N` keyword 付与）
 
 ## Issue 起票ルール（CRITICAL — ADR-0003）
 
@@ -78,10 +78,12 @@ docs/ 配下の変更ファイル数が **50 超で QM 警告、100 超で BLOCK
 
 | close 経路 | gate 挙動 |
 |---|---|
-| PR の `closes #N` で auto-close | **skip** (PR Ready チェックリストで検証済み) |
-| squash merge commit message の `closes #N` で auto-close | **skip** (PR 経由と同等) |
+| PR の `Closes #N` keyword（default branch=main 向け PR、例 hotfix）で auto-close | **skip** (PR Ready チェックリストで検証済み) |
+| squash merge commit message の `Closes #N` keyword が main に到達して auto-close | **skip** (PR 経由と同等) |
 | `gh issue close` / GitHub UI ボタンで手動 close | **AC 検証 gate を通す** (`- [ ]` 残存で reopen) |
 | `wontfix` / `duplicate` ラベル付き close | **skip** (従来通り) |
+
+> **develop 二層での実態（#3119 / #3123）**: 上 2 行の auto-close 経路は **`Closes #N` / `Fixes #N` closing keyword が main に到達した場合のみ**発火する。本リポジトリの commit 規約は conventional-commit prefix（`fix:` / `feat:` / `docs:` / `infra:` `#N`）で closing keyword を含まないため、**develop 二層の通常フローでは auto-close 経路はほぼ発火せず、close はほぼ全て下段の手動 close 経路（AC gate を通る）になる**。詳細は [docs/sessions/branch-strategy.md §3.2](../docs/sessions/branch-strategy.md)。`Closes #N` を明示した main 向け hotfix PR / commit のみが上 2 行に該当する。
 
 判定純粋関数: `scripts/issue-close-gate-skip-judge.mjs` (unit test 11 ケース: `tests/unit/github/issue-close-gate-skip-judge.test.ts`)。
 

--- a/scripts/issue-close-gate-skip-judge.mjs
+++ b/scripts/issue-close-gate-skip-judge.mjs
@@ -17,8 +17,17 @@
  *
  * - `wontfix` / `duplicate` ラベル付き → skip (従来通り)
  * - 直近 ClosedEvent の `closer.__typename === 'PullRequest'` → PR 経由 close、skip
- * - 直近 ClosedEvent の `closer.__typename === 'Commit'` → squash merge commit message 経由、skip
+ * - 直近 ClosedEvent の `closer.__typename === 'Commit'` → commit message の closing keyword 経由、skip
  * - 直近 ClosedEvent の `closer === null` → 手動 close (`gh issue close` / GitHub UI)、AC gate 通す
+ *
+ * ## conventional-commit 規約下での堅牢性 (#3123)
+ *
+ * 本判定は commit / PR body のテキストを `closes #N` で grep するのではなく、**GitHub が記録した
+ * 権威ある `ClosedEvent.closer` フィールドを読む**ため、commit 規約に依存せず正しく動作する。
+ * 本リポジトリの conventional-commit prefix (`fix:` / `feat:` / `docs:` `#N`) は closing keyword では
+ * ないため develop 二層では auto-close がほぼ発火せず、その場合 closer は null（= 後続の手動 close）と
+ * なり AC gate を通す。明示的に `Closes #N` keyword を含めた場合のみ closer が PR/Commit になり skip
+ * する。詳細な close 運用は docs/sessions/branch-strategy.md §3.2 / .github/CLAUDE.md を参照。
  *
  * ## SSOT
  *
@@ -96,7 +105,7 @@ export function judgeSkipAcGate(ctx) {
 	if (closerType === 'Commit') {
 		return {
 			skip: true,
-			reason: `Issue #${ctx.issueNumber}: Commit ${latest.closer?.oid?.slice(0, 8)} 経由 auto-close を検出 (squash merge "closes #N")、AC gate skip`,
+			reason: `Issue #${ctx.issueNumber}: Commit ${latest.closer?.oid?.slice(0, 8)} 経由 auto-close を検出 (commit message の Closes/Fixes keyword)、AC gate skip`,
 		};
 	}
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（開発チーム / QM / 監査チーム）

**解決する課題**: PR #3119 の QM adversarial review objection #1 — 下流 SSOT `.github/CLAUDE.md` が一般形の auto-close（「PR/コミットで `closes #N` 自動クローズ」）を断定し、#3119 が SSOT 化した `branch-strategy.md §3.2`（conventional-commit prefix は closing keyword 非該当 → develop 二層では auto-close されない）と factual に衝突していた。#3119 scope 外のため別 Issue（#3123）で reconcile。

**期待される効果**: auto-close 記述を §3.2 に整合させ、開発者が「`fix: #N` で merge すれば Issue が自動で閉じる」と誤認して未 close を放置する事故を防ぐ。close 運用の SSOT 階層（branch-strategy.md §3.2 が頂点）を一貫させる。

## 関連 Issue

closes #3123

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| やること1 | `.github/CLAUDE.md` L10/L81/L82 を closing keyword + default branch=main 区別で整合（main-hotfix と develop 二層を区別） | git diff | HEAD `0e1084279` / L10 を「`Closes #N`/`Fixes #N` が main 到達時のみ発火、conventional-commit prefix は Issue 参照で非 auto-close」に是正 + §3.2 参照。issue-close-gate skip table に conventional-commit carve-out 注記追加 |
| やること2 | `scripts/issue-close-gate-skip-judge.mjs` + test の skip 判定が `fix: #N` 規約で破綻しないか確認 | コード確認 + `npx vitest run tests/unit/github/issue-close-gate-skip-judge.test.ts` | HEAD `0e1084279` / 判定は GitHub の権威 `ClosedEvent.closer` フィールドを読む（commit text を grep しない）ため commit 規約非依存で堅牢。auto-close 非発火時は closer=null → 手動 close 経路 = AC gate。doc-comment に堅牢性明記 + 誤解例修正。**11 tests PASS（ロジック不変）** |
| やること3 | branch-strategy.md §3.2 と `.github/CLAUDE.md` の相互参照が circular でなく階層整合 | check-doc-code-references + 目視 | HEAD `0e1084279` / CLAUDE.md → §3.2 を SSOT として参照（一方向）、§3.2 → CLAUDE.md は issue-close-gate 機械層を参照（別レイヤー）。循環なし。doc-code-references 新規違反 0 |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`.github/CLAUDE.md`) + `scripts/`（コメント + reason 文字列のみ、ロジック不変）

**影響を受ける画面・機能**: なし（運用 SSOT の整合 + script doc-comment。close gate のロジック挙動は不変）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: テスト変更なし。既存 `tests/unit/github/issue-close-gate-skip-judge.test.ts` 11 件 PASS を確認（reason 文字列の assertion は `Commit c62581c3` / `AC gate skip` を見ており、変更した parenthetical は非 assertion）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: docs + script doc-comment のみの変更で UI 変更を含まないため。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（docs + comment）
- [x] **DRY**: close 運用の正は branch-strategy.md §3.2 に一元化し、CLAUDE.md は参照に留める（断定の二重定義を解消）
- [x] **YAGNI**: §3.2 への整合に限定。skip-judge のロジックは堅牢なため変更せず（コメント精度のみ）
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（運用 SSOT docs）
- [x] **設計書同期** (ADR-0001): branch-strategy.md §3.2（SSOT 頂点、#3119 で QM 是正済）に .github/CLAUDE.md を追従。issue-close-gate-skip-judge.mjs の doc も整合

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: GitHub closing keyword の colon 対応は出典間で見解が割れる（GitHub docs は `Closes: #10` 可と明記 / 別ソースは conventional `fix: #N` は非該当と記載）。ただし (1) `infra:`/`docs:`/`feat:` prefix はそもそも GitHub keyword 9 種に含まれず確実に非 closing、(2) 本セッションの実 squash commit（#3099/#3109/#3114）が closing keyword を含まないことを実測確認したため、「auto-close を当てにせず手動 close 経路を正準とする」§3.2 の運用結論は edge case に依らず堅牢。よって `fix:` の colon 論争を再燃させず、§3.2（QM が #3119 merge 時に確定した SSOT）に CLAUDE.md を整合させる方針とした。skip-judge は GitHub の `closer` field 駆動でテキスト grep しないため commit 規約に依存しない（ロジック変更不要）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A（docs のみ）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
