### PR TITLE
fix(security): #3133 /tenants + /uploads/avatars の cross-tenant IDOR を tenant 一致検証で封殺

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -362,11 +362,12 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 | ルート | storage key 構造 | ハンドラ層 tenant 一致検証 |
 |---|---|---|
 | `/tenants/[...path]`（`src/routes/tenants/[...path]/+server.ts`） | `tenants/<tenantId>/<type>/<childId>/<file>`（`storage-keys.ts`、全 key が tenant-prefixed） | path 先頭セグメント `=== locals.context.tenantId`。不一致 / 未認証 → **404**（存在有無を漏らさない） |
-| `/uploads/avatars/[filename]`（`src/routes/uploads/avatars/[filename]/+server.ts`） | legacy flat `uploads/avatars/avatar-<childId>-<...>`（旧形式のみ） | filename の `childId` を `getChildById(childId, locals.context.tenantId)` で照合、自テナントの子供でなければ → **404** |
+| `/uploads/avatars/[filename]`（`src/routes/uploads/avatars/[filename]/+server.ts`） | legacy flat `uploads/avatars/avatar-<childId>-<...>`（旧形式のみ、tenant 非依存の flat 配置） | filename の `childId` を `getChildById(childId, locals.context.tenantId)` で自テナント存在確認したうえで、解決した child の `avatarUrl` が要求 filename の公開 URL（`storageKeyToPublicUrl('uploads/avatars/<filename>')` = `/uploads/avatars/<filename>`）と**一致する場合のみ**配信。一致しない / `avatarUrl` が null / 未認証 → **404** |
 
+- **id-collision 対策（file ownership anchor、#3133 QM BLOCK 対応）**: child id は tenant-scoped に採番される（`nextId(child, tenantId)`、全テナントに id=1,2,... が存在し得る）一方、legacy flat key は tenant 非依存の flat 配置のため、`getChildById(childId, tenantId)` の成功は「自テナントに同 id の子供が居る」ことしか証明できず、その filename がその子供のアバターである保証にならない。child 存在確認だけだと、攻撃者が自テナントの child id=1 を用いて被害者テナントの `avatar-1-<victimSuffix>.png` を取得できる cross-tenant IDOR が残る。これを根治するため、**解決した child の `avatarUrl` が要求 filename を指すこと（file ownership）を必須条件**とし、指さない場合は fail-closed で 404 にする。
 - **公開アセットの扱い**: favicon は `/favicon-32x32.png`（static）/ `/api/v1/images?type=favicon`（認証済）で配信され、`/tenants/**` `/uploads/**` を経由しない。`tenants/` 配下の storage key は構造上すべて tenant-prefixed のため、tenant 非依存の公開アセットは存在せず whitelist 不要。
 - **モード別**: cross-tenant は cognito（マルチテナント SaaS）固有。local（NUC 単一家庭）/ anonymous（demo）provider は `authorize → allowed:true` だが、ハンドラ層 tenant 一致は全モードで効く（単一テナントでは自テナント一致で通過）。
-- **回帰テスト**: `tests/integration/api/tenant-static-file-idor.test.ts`（cross-tenant → 404 / storage 非到達）+ `tests/unit/auth/authorization.test.ts`（両ルートの認証必須化 = default-allow に落ちない）。
+- **回帰テスト**: `tests/integration/api/tenant-static-file-idor.test.ts`（cross-tenant → 404 / storage 非到達。`/uploads/avatars` は **id-collision ケース**＝自テナントに同 id child が居ても avatarUrl 不一致 / null なら 404 を含む）+ `tests/unit/auth/authorization.test.ts`（両ルートの認証必須化 = default-allow に落ちない）。
 
 ### 5.3 ライセンス状態による制限
 

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -347,11 +347,26 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 | `/child/**` | owner, parent, child | `/auth/login` |
 | `/api/v1/admin/**` | owner, parent | 401 |
 | `/api/v1/**` | owner, parent, child | 401 |
+| `/tenants/**`（テナント静的ファイル配信、#3133） | owner, parent, child | `/auth/login` |
+| `/uploads/**`（legacy アバター配信、#3133） | owner, parent, child | `/auth/login` |
 | `/`, `/auth/**`, `/switch`, `/legal/**` | 全員（認証不要） | — |
 | `/api/health` | 全員（認証不要） | — |
 | `/api/stripe/webhook` | 全員（認証不要、Stripe署名で検証） | — |
 
 認可チェックは `hooks.server.ts` → `authorization.ts` の `authorizeCognito()` で一元実行。ルート × ロール × ライセンス状態の三軸で判定する。
+
+#### 5.2.1 静的ファイル配信の tenant 一致検証（cross-tenant IDOR 防止、#3133）
+
+`ROUTE_RULES` のロール検査は path 内の `tenantId` を知らないため、静的ファイル配信ルートは **ハンドラ層で tenant 一致を強制**する（二段防御）。`ROUTE_RULES` 未登録だと `findMatchingRule` が undefined → `authorizeCognito` の default-allow（`if (!rule) return { allowed: true }`）に落ち、認証済なら他テナントのファイルを GET できる cross-tenant IDOR になるため、両ルートを明示登録したうえでハンドラで以下を検証する:
+
+| ルート | storage key 構造 | ハンドラ層 tenant 一致検証 |
+|---|---|---|
+| `/tenants/[...path]`（`src/routes/tenants/[...path]/+server.ts`） | `tenants/<tenantId>/<type>/<childId>/<file>`（`storage-keys.ts`、全 key が tenant-prefixed） | path 先頭セグメント `=== locals.context.tenantId`。不一致 / 未認証 → **404**（存在有無を漏らさない） |
+| `/uploads/avatars/[filename]`（`src/routes/uploads/avatars/[filename]/+server.ts`） | legacy flat `uploads/avatars/avatar-<childId>-<...>`（旧形式のみ） | filename の `childId` を `getChildById(childId, locals.context.tenantId)` で照合、自テナントの子供でなければ → **404** |
+
+- **公開アセットの扱い**: favicon は `/favicon-32x32.png`（static）/ `/api/v1/images?type=favicon`（認証済）で配信され、`/tenants/**` `/uploads/**` を経由しない。`tenants/` 配下の storage key は構造上すべて tenant-prefixed のため、tenant 非依存の公開アセットは存在せず whitelist 不要。
+- **モード別**: cross-tenant は cognito（マルチテナント SaaS）固有。local（NUC 単一家庭）/ anonymous（demo）provider は `authorize → allowed:true` だが、ハンドラ層 tenant 一致は全モードで効く（単一テナントでは自テナント一致で通過）。
+- **回帰テスト**: `tests/integration/api/tenant-static-file-idor.test.ts`（cross-tenant → 404 / storage 非到達）+ `tests/unit/auth/authorization.test.ts`（両ルートの認証必須化 = default-allow に落ちない）。
 
 ### 5.3 ライセンス状態による制限
 

--- a/src/lib/server/auth/authorization.ts
+++ b/src/lib/server/auth/authorization.ts
@@ -57,6 +57,13 @@ const ROUTE_RULES: RouteRule[] = [
 		pattern: '/api/v1',
 		roles: ['owner', 'parent', 'child'],
 	},
+	// テナント配下の静的ファイル配信 — 全ロール（認証必須）。
+	// #3133: ROUTE_RULES 不在だと findMatchingRule が undefined → default-allow に落ち、
+	// 認証済なら他テナントの静的ファイルを GET できる cross-tenant IDOR になる。
+	// 明示登録で「認証必須」を担保し、実際の tenant 一致検証は各ハンドラ側で行う
+	// (ROUTE_RULES はロール検査のみで path 内の tenantId を知らないため)。
+	{ pattern: '/tenants', roles: ['owner', 'parent', 'child'], unauthRedirect: '/auth/login' },
+	{ pattern: '/uploads', roles: ['owner', 'parent', 'child'], unauthRedirect: '/auth/login' },
 ];
 
 /**

--- a/src/routes/tenants/[...path]/+server.ts
+++ b/src/routes/tenants/[...path]/+server.ts
@@ -6,12 +6,22 @@ import { safeContentDisposition, safeContentType } from '$lib/server/security/fi
 import { readFile } from '$lib/server/storage';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, locals }) => {
 	const path = params.path;
 
 	// Prevent path traversal
 	if (!path || path.includes('..')) {
 		throw error(400, 'Invalid path');
+	}
+
+	// #3133: cross-tenant IDOR 防止。storage key は `tenants/<tenantId>/<type>/<childId>/<file>`
+	// 構造（storage-keys.ts）であり、path の先頭セグメントが tenantId。認証コンテキストの
+	// tenantId と一致しない場合は他テナントのファイルへのアクセスのため拒否する。
+	// 存在有無を漏らさないよう 403 ではなく 404 を返す。
+	const context = locals.context;
+	const requestedTenantId = path.split('/')[0];
+	if (!context || requestedTenantId !== context.tenantId) {
+		throw error(404, 'File not found');
 	}
 
 	const storageKey = `tenants/${path}`;

--- a/src/routes/uploads/avatars/[filename]/+server.ts
+++ b/src/routes/uploads/avatars/[filename]/+server.ts
@@ -5,6 +5,7 @@ import { error } from '@sveltejs/kit';
 import { safeContentDisposition, safeContentType } from '$lib/server/security/file-sanitizer';
 import { getChildById } from '$lib/server/services/child-service';
 import { readFile } from '$lib/server/storage';
+import { storageKeyToPublicUrl } from '$lib/server/storage-keys';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params, locals }) => {
@@ -17,15 +18,29 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 
 	// #3133: cross-tenant IDOR 防止。本経路は legacy flat 配置のアバター
 	// (`uploads/avatars/avatar-<childId>-<...>`、storage-keys.ts の旧形式) のみを配信する。
-	// filename に埋め込まれた childId が認証コンテキストの tenant に属する子供かを検証し、
-	// 他テナントの子供のアバターを GET できないようにする。存在有無を漏らさないよう 404 を返す。
+	//
+	// 【id-collision 対策（QM BLOCK 対応）】childId は tenant-scoped に採番される
+	// (`nextId(child, tenantId)`) ため、どのテナントにも child id=1,2,... が存在し得る。
+	// 一方 legacy flat key (`uploads/avatars/avatar-<childId>-<suffix>`) は tenant 非依存の
+	// flat 配置のため、`getChildById(<filename の childId>, tenantId)` が成功しても
+	// 「自テナントに同 id の子供が居る」ことしか証明できず、その filename が
+	// 本当にその子供のアバターである保証にならない。攻撃者は自テナントの child id=1 を
+	// 用いて被害者テナントの `avatar-1-<victimSuffix>.png` を取得できてしまう。
+	//
+	// そこで file ownership を anchor で検証する: 解決した child の `avatarUrl`
+	// (= `storageKeyToPublicUrl('uploads/avatars/avatar-<id>-<suffix>')`、先頭 `/` 付与)
+	// が、要求された filename を指している場合のみ配信する。avatarUrl が null /
+	// 別ファイルを指す（= この legacy file の所有者ではない）場合は fail-closed で 404。
+	// 存在有無を漏らさないよう全て 404 を返す。
 	const context = locals.context;
 	const childIdMatch = filename.match(/^avatar-(\d+)-/);
 	if (!context || !childIdMatch) {
 		throw error(404, 'File not found');
 	}
 	const child = await getChildById(Number(childIdMatch[1]), context.tenantId);
-	if (!child) {
+	// file ownership anchor: avatarUrl がこの legacy filename を指していなければ拒否する
+	const expectedPublicUrl = storageKeyToPublicUrl(`uploads/avatars/${filename}`);
+	if (!child || child.avatarUrl !== expectedPublicUrl) {
 		throw error(404, 'File not found');
 	}
 

--- a/src/routes/uploads/avatars/[filename]/+server.ts
+++ b/src/routes/uploads/avatars/[filename]/+server.ts
@@ -3,15 +3,30 @@
 
 import { error } from '@sveltejs/kit';
 import { safeContentDisposition, safeContentType } from '$lib/server/security/file-sanitizer';
+import { getChildById } from '$lib/server/services/child-service';
 import { readFile } from '$lib/server/storage';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, locals }) => {
 	const filename = params.filename;
 
 	// Prevent path traversal
 	if (!filename || filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
 		throw error(400, 'Invalid filename');
+	}
+
+	// #3133: cross-tenant IDOR 防止。本経路は legacy flat 配置のアバター
+	// (`uploads/avatars/avatar-<childId>-<...>`、storage-keys.ts の旧形式) のみを配信する。
+	// filename に埋め込まれた childId が認証コンテキストの tenant に属する子供かを検証し、
+	// 他テナントの子供のアバターを GET できないようにする。存在有無を漏らさないよう 404 を返す。
+	const context = locals.context;
+	const childIdMatch = filename.match(/^avatar-(\d+)-/);
+	if (!context || !childIdMatch) {
+		throw error(404, 'File not found');
+	}
+	const child = await getChildById(Number(childIdMatch[1]), context.tenantId);
+	if (!child) {
+		throw error(404, 'File not found');
 	}
 
 	const result = await readFile(`uploads/avatars/${filename}`);

--- a/tests/helpers/mock-event.ts
+++ b/tests/helpers/mock-event.ts
@@ -10,6 +10,11 @@ export function createMockEvent(opts: {
 	url: string;
 	params?: Record<string, string>;
 	body?: unknown;
+	/**
+	 * `locals.context` の上書き。省略時は既定の `{ tenantId: 'test-tenant' }`。
+	 * `null` を明示するとテナント未所属（未認証）を表現する（#3133 cross-tenant IDOR テスト用）。
+	 */
+	context?: { tenantId: string; role?: string; licenseStatus?: string } | null;
 	// biome-ignore lint/suspicious/noExplicitAny: RequestEvent モックは型の完全互換が不要
 }): any {
 	const requestUrl = new URL(opts.url, 'http://localhost');
@@ -27,7 +32,7 @@ export function createMockEvent(opts: {
 		url: requestUrl,
 		params: opts.params ?? {},
 		route: { id: null },
-		locals: { context: { tenantId: 'test-tenant' } },
+		locals: { context: 'context' in opts ? opts.context : { tenantId: 'test-tenant' } },
 		cookies: {
 			get: () => undefined,
 			set: () => {},

--- a/tests/integration/api/tenant-static-file-idor.test.ts
+++ b/tests/integration/api/tenant-static-file-idor.test.ts
@@ -1,0 +1,124 @@
+// tests/integration/api/tenant-static-file-idor.test.ts
+// #3133: /tenants/[...path] + /uploads/avatars/[filename] の cross-tenant IDOR ハンドラ層回帰テスト。
+// 認証済ユーザが他テナントの静的ファイルを GET できないこと（tenant 一致しない → 404）を検証する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockEvent } from '../../helpers/mock-event';
+
+// storage / child-service を mock（IDOR guard は storage / DB 到達前に効くべき）
+vi.mock('../../../src/lib/server/storage', () => ({ readFile: vi.fn() }));
+vi.mock('$lib/server/storage', () => ({ readFile: vi.fn() }));
+vi.mock('../../../src/lib/server/services/child-service', () => ({ getChildById: vi.fn() }));
+vi.mock('$lib/server/services/child-service', () => ({ getChildById: vi.fn() }));
+
+import { getChildById } from '$lib/server/services/child-service';
+import { readFile } from '$lib/server/storage';
+import { GET as tenantsGET } from '../../../src/routes/tenants/[...path]/+server';
+import { GET as avatarsGET } from '../../../src/routes/uploads/avatars/[filename]/+server';
+
+const readFileMock = vi.mocked(readFile);
+const getChildByIdMock = vi.mocked(getChildById);
+
+/** ハンドラ呼び出しで throw された HttpError の status を取り出す（throw しなければ null） */
+async function statusOf(result: unknown): Promise<number | null> {
+	try {
+		await result;
+		return null;
+	} catch (e) {
+		return (e as { status?: number }).status ?? -1;
+	}
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	readFileMock.mockResolvedValue({ data: Buffer.from([1, 2, 3]), contentType: 'image/png' });
+	// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小 Child スタブ
+	getChildByIdMock.mockResolvedValue({ id: 1, tenantId: 't-self' } as any);
+});
+
+describe('#3133 /tenants/[...path] cross-tenant IDOR guard', () => {
+	it('他テナントの path（先頭セグメント不一致）は 404、storage に到達しない', async () => {
+		const event = createMockEvent({
+			url: '/tenants/t-other/avatars/1/x.png',
+			params: { path: 't-other/avatars/1/x.png' },
+			context: { tenantId: 't-self', role: 'owner' },
+		});
+		expect(await statusOf(tenantsGET(event))).toBe(404);
+		expect(readFileMock).not.toHaveBeenCalled();
+	});
+
+	it('未認証（context=null）は 404', async () => {
+		const event = createMockEvent({
+			url: '/tenants/t-self/avatars/1/x.png',
+			params: { path: 't-self/avatars/1/x.png' },
+			context: null,
+		});
+		expect(await statusOf(tenantsGET(event))).toBe(404);
+		expect(readFileMock).not.toHaveBeenCalled();
+	});
+
+	it('自テナントの path は配信される（storage に到達）', async () => {
+		const event = createMockEvent({
+			url: '/tenants/t-self/avatars/1/x.png',
+			params: { path: 't-self/avatars/1/x.png' },
+			context: { tenantId: 't-self', role: 'child' },
+		});
+		const res = (await tenantsGET(event)) as Response;
+		expect(res.status).toBe(200);
+		expect(readFileMock).toHaveBeenCalledWith('tenants/t-self/avatars/1/x.png');
+	});
+
+	it('path traversal（..）は 400（既存防御を維持）', async () => {
+		const event = createMockEvent({
+			url: '/tenants/t-self/../t-other/x.png',
+			params: { path: 't-self/../t-other/x.png' },
+			context: { tenantId: 't-self', role: 'owner' },
+		});
+		expect(await statusOf(tenantsGET(event))).toBe(400);
+	});
+});
+
+describe('#3133 /uploads/avatars/[filename] legacy cross-tenant IDOR guard', () => {
+	it('childId が自テナントの子供でない（getChildById=undefined）は 404、storage に到達しない', async () => {
+		getChildByIdMock.mockResolvedValue(undefined);
+		const event = createMockEvent({
+			url: '/uploads/avatars/avatar-999-abc.png',
+			params: { filename: 'avatar-999-abc.png' },
+			context: { tenantId: 't-self', role: 'owner' },
+		});
+		expect(await statusOf(avatarsGET(event))).toBe(404);
+		expect(readFileMock).not.toHaveBeenCalled();
+	});
+
+	it('legacy 命名（avatar-<childId>-）に合致しない filename は 404', async () => {
+		const event = createMockEvent({
+			url: '/uploads/avatars/random.png',
+			params: { filename: 'random.png' },
+			context: { tenantId: 't-self', role: 'owner' },
+		});
+		expect(await statusOf(avatarsGET(event))).toBe(404);
+		expect(readFileMock).not.toHaveBeenCalled();
+	});
+
+	it('未認証（context=null）は 404', async () => {
+		const event = createMockEvent({
+			url: '/uploads/avatars/avatar-1-abc.png',
+			params: { filename: 'avatar-1-abc.png' },
+			context: null,
+		});
+		expect(await statusOf(avatarsGET(event))).toBe(404);
+		expect(readFileMock).not.toHaveBeenCalled();
+	});
+
+	it('childId が自テナントの子供なら配信される（getChildById で tenant scope 検証）', async () => {
+		const event = createMockEvent({
+			url: '/uploads/avatars/avatar-1-abc.png',
+			params: { filename: 'avatar-1-abc.png' },
+			context: { tenantId: 't-self', role: 'parent' },
+		});
+		const res = (await avatarsGET(event)) as Response;
+		expect(res.status).toBe(200);
+		expect(getChildByIdMock).toHaveBeenCalledWith(1, 't-self');
+		expect(readFileMock).toHaveBeenCalledWith('uploads/avatars/avatar-1-abc.png');
+	});
+});

--- a/tests/integration/api/tenant-static-file-idor.test.ts
+++ b/tests/integration/api/tenant-static-file-idor.test.ts
@@ -32,8 +32,14 @@ async function statusOf(result: unknown): Promise<number | null> {
 beforeEach(() => {
 	vi.clearAllMocks();
 	readFileMock.mockResolvedValue({ data: Buffer.from([1, 2, 3]), contentType: 'image/png' });
-	// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小 Child スタブ
-	getChildByIdMock.mockResolvedValue({ id: 1, tenantId: 't-self' } as any);
+	// 既定では「自テナントの子供 id=1 で、avatarUrl が要求 filename を指す」正常 Child を返す。
+	// avatarUrl は legacy flat key の公開 URL (`/uploads/avatars/avatar-1-abc.png`)。
+	getChildByIdMock.mockResolvedValue({
+		id: 1,
+		tenantId: 't-self',
+		avatarUrl: '/uploads/avatars/avatar-1-abc.png',
+		// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小 Child スタブ
+	} as any);
 });
 
 describe('#3133 /tenants/[...path] cross-tenant IDOR guard', () => {
@@ -110,7 +116,7 @@ describe('#3133 /uploads/avatars/[filename] legacy cross-tenant IDOR guard', () 
 		expect(readFileMock).not.toHaveBeenCalled();
 	});
 
-	it('childId が自テナントの子供なら配信される（getChildById で tenant scope 検証）', async () => {
+	it('自テナントの子供かつ avatarUrl が要求 filename を指すなら配信される（file ownership 一致）', async () => {
 		const event = createMockEvent({
 			url: '/uploads/avatars/avatar-1-abc.png',
 			params: { filename: 'avatar-1-abc.png' },
@@ -120,5 +126,41 @@ describe('#3133 /uploads/avatars/[filename] legacy cross-tenant IDOR guard', () 
 		expect(res.status).toBe(200);
 		expect(getChildByIdMock).toHaveBeenCalledWith(1, 't-self');
 		expect(readFileMock).toHaveBeenCalledWith('uploads/avatars/avatar-1-abc.png');
+	});
+
+	it('id-collision: 自テナントに同 id の子供が居ても avatarUrl が別ファイルなら 404、storage に到達しない', async () => {
+		// 攻撃シナリオ: テナント A の攻撃者が自テナントの child id=1 を持つ。
+		// getChildById(1, t-self) は VALID な自テナント child を返すが、その avatarUrl は
+		// 別ファイル（被害者の avatar-1-victim.png ではない）を指す。
+		// 旧実装は「同 id child が存在する」だけで配信していたため被害者ファイルを漏洩した。
+		getChildByIdMock.mockResolvedValue({
+			id: 1,
+			tenantId: 't-self',
+			avatarUrl: '/uploads/avatars/avatar-1-myown.png',
+			// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小 Child スタブ
+		} as any);
+		const event = createMockEvent({
+			url: '/uploads/avatars/avatar-1-victim.png',
+			params: { filename: 'avatar-1-victim.png' },
+			context: { tenantId: 't-self', role: 'owner' },
+		});
+		expect(await statusOf(avatarsGET(event))).toBe(404);
+		expect(readFileMock).not.toHaveBeenCalled();
+	});
+
+	it('id-collision: 自テナントに同 id の子供が居ても avatarUrl=null なら 404、storage に到達しない', async () => {
+		getChildByIdMock.mockResolvedValue({
+			id: 1,
+			tenantId: 't-self',
+			avatarUrl: null,
+			// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小 Child スタブ
+		} as any);
+		const event = createMockEvent({
+			url: '/uploads/avatars/avatar-1-victim.png',
+			params: { filename: 'avatar-1-victim.png' },
+			context: { tenantId: 't-self', role: 'owner' },
+		});
+		expect(await statusOf(avatarsGET(event))).toBe(404);
+		expect(readFileMock).not.toHaveBeenCalled();
 	});
 });

--- a/tests/integration/api/tenant-static-file-idor.test.ts
+++ b/tests/integration/api/tenant-static-file-idor.test.ts
@@ -136,7 +136,7 @@ describe('#3133 /uploads/avatars/[filename] legacy cross-tenant IDOR guard', () 
 		getChildByIdMock.mockResolvedValue({
 			id: 1,
 			tenantId: 't-self',
-			avatarUrl: '/uploads/avatars/avatar-1-myown.png',
+			avatarUrl: '/uploads/avatars/avatar-1-mine.png',
 			// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小 Child スタブ
 		} as any);
 		const event = createMockEvent({

--- a/tests/unit/auth/authorization.test.ts
+++ b/tests/unit/auth/authorization.test.ts
@@ -247,4 +247,37 @@ describe('authorizeCognito', () => {
 			expect(authorizeCognito('/preschool/home', id, ctx).allowed).toBe(true);
 		});
 	});
+
+	// ============================================================
+	// #3133: 静的ファイル配信ルートの認証必須化（default-allow 禁止）
+	// ============================================================
+	describe('静的ファイル配信ルート (#3133 cross-tenant IDOR)', () => {
+		const id = cognitoIdentity();
+
+		it('/tenants/* は未認証で 401（default-allow に落ちない）', () => {
+			const result = authorizeCognito('/tenants/t-other/avatars/1/x.png', null, null);
+			expect(result.allowed).toBe(false);
+			if (!result.allowed) expect(result.status).toBe(401);
+		});
+
+		it('/uploads/avatars/* は未認証で 401（default-allow に落ちない）', () => {
+			const result = authorizeCognito('/uploads/avatars/avatar-1-x.png', null, null);
+			expect(result.allowed).toBe(false);
+			if (!result.allowed) expect(result.status).toBe(401);
+		});
+
+		it('/tenants/* は認証済の全ロールで allowed（tenant 一致検証はハンドラ層）', () => {
+			for (const role of ['owner', 'parent', 'child'] as const) {
+				const ctx = makeContext({ role });
+				expect(authorizeCognito('/tenants/t-test/avatars/1/x.png', id, ctx).allowed).toBe(true);
+			}
+		});
+
+		it('/uploads/avatars/* は認証済の全ロールで allowed（tenant 一致検証はハンドラ層）', () => {
+			for (const role of ['owner', 'parent', 'child'] as const) {
+				const ctx = makeContext({ role });
+				expect(authorizeCognito('/uploads/avatars/avatar-1-x.png', id, ctx).allowed).toBe(true);
+			}
+		});
+	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体 / 全保護者・子供（家族間プライバシー）

**解決する課題**: `/tenants/[...path]` と `/uploads/avatars/[filename]` の静的ファイル配信が tenant 一致検証なしで、認証済ユーザが**他テナント（他家族）の子の生成画像・avatar・voice を GET できる cross-tenant IDOR**（既存欠陥、統合 PR #3131 監査の security チーム物理裏取りで検出）。`authorization.ts` の `ROUTE_RULES` に両 route が不在 → `findMatchingRule` undefined → default-allow に落ち、ハンドラも tenant 検証なし（`..` traversal チェックのみ）。

**期待される効果**: 家族間プライバシー（子の生成画像/音声/avatar の cross-tenant 漏洩）を二段防御で封殺する。

## 関連 Issue

closes #3133

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 両ハンドラで tenant 一致を強制（不一致は 403/404） | git diff + `npx vitest run tests/integration/api/tenant-static-file-idor.test.ts` | HEAD `c423edc96` / tenants は path 先頭セグメント vs `locals.context.tenantId`、uploads は `getChildById(childId, tenantId)` 照合、不一致 404。8 tests PASS（cross-tenant 404 + storage 非到達） |
| AC2 | `ROUTE_RULES` に両 route を明示登録し default-allow に落ちないように | `npx vitest run tests/unit/auth/authorization.test.ts` | HEAD `c423edc96` / authorization.ts に `/tenants` `/uploads`（roles owner/parent/child）登録。未認証 401 を assert（default-allow に落ちない） |
| AC3 | tenant 非依存の公開アセット（favicon 等）の扱いを設計 | コード調査 + 設計書 | HEAD `c423edc96` / favicon は `/favicon-32x32.png`（static）+ `/api/v1/images?type=favicon`（認証済）で配信され `/tenants` `/uploads` を経由しない。`tenants/` 配下は全 key tenant-prefixed（storage-keys.ts）で非依存アセット皆無 → whitelist 不要。設計書 §5.2.1 に明記 |
| AC4 | cross-tenant GET が 403/404 になることを認可境界 spec で検証 | `tests/integration/api/tenant-static-file-idor.test.ts` | HEAD `c423edc96` / 両 route の cross-tenant → 404 + storage/DB 非到達を deterministic に検証。handler-layer integration test を採用（理由は下記レビュー依頼参照） |
| 横展開 | 静的配信を行う全 route の点検 | `find src/routes -name +server.ts` | HEAD `c423edc96` / 静的配信 route は tenants / uploads/avatars / api/v1/images の 3 つのみ。前 2 を本 PR 修正、api/v1/images は `/api/v1` ROUTE_RULES + 内部で `context.tenantId` 利用済で安全 |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] API エンドポイント（`src/routes/tenants` / `src/routes/uploads`、file-serving handler）
- [x] ドメインモデル / 認可（`$lib/server/auth/authorization.ts`）

**影響を受ける画面・機能**: 静的ファイル配信（子の生成画像/avatar/voice）。自テナントの配信は不変、他テナント GET のみ 404 化。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/integration/api/tenant-static-file-idor.test.ts`（新規 8 ケース、cross-tenant→404）+ `tests/unit/auth/authorization.test.ts`（両 route 認証必須化）+ `tests/helpers/mock-event.ts` に context override（後方互換）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A（getChildById は既存、両 backend 実装済）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high security fix、critical ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: `.ts`（file-serving handler / 認可ロジック / テスト）+ `.md` のみの変更で `.svelte`/`.css`/`site/` を含まず UI 変更なし（pre-ready SS gate 非該当）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 認可（ROUTE_RULES）とハンドラ（tenant 一致）の二段防御で責務分離。tenant 一致は各ハンドラに局所化
- [x] **DRY**: 既存 `getChildById(id, tenantId)` を再利用（legacy avatar の tenant scope 検証）
- [x] **YAGNI**: 署名 URL 化等の過剰防衛は不採用（Issue no-go 準拠、Pre-PMF）
- [x] **Security（OSS 公開前提）**: OWASP A01 (Broken Access Control) / IDOR を境界で封殺。403 でなく 404 で存在漏洩防止。path traversal 既存防御を維持
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: tenant 不一致は storage/DB 到達前に 404（早期 return、無駄な I/O なし）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): `docs/design/14-セキュリティ設計書.md` §5.2 表 + §5.2.1（静的ファイル tenant 一致検証）を追記
- [x] 静的配信 route 全点検済（tenants / uploads/avatars / api/v1/images の 3 つ、前 2 を修正・3 つ目は安全確認）
- [x] モード横断確認: cross-tenant は cognito 固有。local（NUC 単一家庭）/ anonymous（demo）は単一テナントでハンドラ層 tenant 一致が自テナント一致で通過（demo 画像配信・LP SS 撮影は不変）
- [x] N/A 以外の並行実装ペア該当なし

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（自テナントの配信は不変、他テナント GET のみ 404）

**レビュー依頼事項・QA**: AC4 は e2e ではなく **handler-layer integration test** を採用した。理由: cross-tenant guard は純粋なハンドラロジック（path/filename パース + tenantId 比較 + getChildById）で、integration test が cross-tenant→404 + storage/DB 非到達を deterministic に検証できる。2-tenant cognito-dev e2e は transport 層の確認のみ追加で guard ロジックの追加 coverage はなく、2-tenant fixture の setup flake を招く（ADR-0005 / tests/CLAUDE.md「実サーバー不要 + モックで完結 → Integration」）。403 でなく 404 を選択（存在有無の漏洩防止）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A（handler / 認可 / テスト / docs のみ）
- [x] 認証画面変更時: N/A（認可ロジックだが認証画面の UI 変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
