### PR TITLE
fix: #3136 family import の dangling avatarUrl を fileExists 検証で根治

### DIFF
--- a/src/lib/server/db/demo/image-repo.ts
+++ b/src/lib/server/db/demo/image-repo.ts
@@ -22,7 +22,7 @@ export async function insertCharacterImage(
 
 export async function updateChildAvatarUrl(
 	_childId: number,
-	_avatarUrl: string,
+	_avatarUrl: string | null,
 	_tenantId: string,
 ): Promise<void> {
 	// Stub: no-op

--- a/src/lib/server/db/dynamodb/image-repo.ts
+++ b/src/lib/server/db/dynamodb/image-repo.ts
@@ -65,7 +65,7 @@ export async function insertCharacterImage(
 /** 子供のアバターURLを更新 */
 export async function updateChildAvatarUrl(
 	childId: number,
-	avatarUrl: string,
+	avatarUrl: string | null,
 	tenantId: string,
 ): Promise<void> {
 	const now = new Date().toISOString();

--- a/src/lib/server/db/image-repo.ts
+++ b/src/lib/server/db/image-repo.ts
@@ -14,7 +14,11 @@ export async function findCachedImage(
 export async function insertCharacterImage(input: InsertCharacterImageInput, tenantId: string) {
 	return getRepos().image.insertCharacterImage(input, tenantId);
 }
-export async function updateChildAvatarUrl(childId: number, avatarUrl: string, tenantId: string) {
+export async function updateChildAvatarUrl(
+	childId: number,
+	avatarUrl: string | null,
+	tenantId: string,
+) {
 	return getRepos().image.updateChildAvatarUrl(childId, avatarUrl, tenantId);
 }
 export async function findChildForImage(childId: number, tenantId: string) {

--- a/src/lib/server/db/interfaces/image-repo.interface.ts
+++ b/src/lib/server/db/interfaces/image-repo.interface.ts
@@ -8,7 +8,7 @@ export interface IImageRepo {
 		tenantId: string,
 	): Promise<CharacterImage | undefined>;
 	insertCharacterImage(input: InsertCharacterImageInput, tenantId: string): Promise<void>;
-	updateChildAvatarUrl(childId: number, avatarUrl: string, tenantId: string): Promise<void>;
+	updateChildAvatarUrl(childId: number, avatarUrl: string | null, tenantId: string): Promise<void>;
 	findChildForImage(childId: number, tenantId: string): Promise<Child | undefined>;
 	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/sqlite/image-repo.ts
+++ b/src/lib/server/db/sqlite/image-repo.ts
@@ -39,7 +39,11 @@ export async function insertCharacterImage(
 }
 
 /** 子供のアバターURLを更新 */
-export async function updateChildAvatarUrl(childId: number, avatarUrl: string, _tenantId: string) {
+export async function updateChildAvatarUrl(
+	childId: number,
+	avatarUrl: string | null,
+	_tenantId: string,
+) {
 	db.update(children)
 		.set({ avatarUrl, updatedAt: new Date().toISOString() })
 		.where(eq(children.id, childId))

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -25,7 +25,7 @@ import { findRecentBonuses, insertLoginBonus } from '$lib/server/db/login-bonus-
 import { findSpecialRewards, insertSpecialReward } from '$lib/server/db/special-reward-repo';
 import { insertStatusHistory, upsertStatus } from '$lib/server/db/status-repo';
 import { logger } from '$lib/server/logger';
-import { saveFile } from '$lib/server/storage';
+import { fileExists, saveFile } from '$lib/server/storage';
 import { storageKeyToPublicUrl, tenantPrefix } from '$lib/server/storage-keys';
 
 // カテゴリコード → ID
@@ -1004,7 +1004,7 @@ async function importStaticFiles(
 	);
 }
 
-interface AvatarRemapState {
+export interface AvatarRemapState {
 	data: ExportData;
 	childIdMap: Map<string, number>;
 	/** sourceChildId (export 元 id) → 新 childId */
@@ -1019,7 +1019,7 @@ interface AvatarRemapState {
  * avatarUrl は `/tenants/<oldTenant>/avatars/<oldChildId>/<uuid>.<ext>` 形式。
  * tenant / childId セグメントを新環境のものに書き換え、復元済ファイルがあれば参照を更新する。
  */
-async function remapChildAvatarUrls(
+export async function remapChildAvatarUrls(
 	state: AvatarRemapState,
 	tenantId: string,
 	result: ImportResult,
@@ -1048,10 +1048,16 @@ async function remapChildAvatarUrls(
 			newRelPath = `${type}/${mappedChildId}/${rest}`;
 		}
 
+		// #3136: 実ファイルが復元されている場合のみ avatarUrl を貼り替える。ZIP に静的ファイルが
+		// 同梱されていない (JSON のみ移管) / 改竄破損で skip された場合に、存在しない storage key を
+		// 指す dangling avatarUrl を生成しないため、貼替前に fileExists で実在を検証する。実在しなければ
+		// avatarUrl を null 化する (旧 tenant path を据え置くと、それ自体が新環境で dangling になるため)。
+		const newKey = `${prefix}${newRelPath}`;
 		try {
+			const restored = await fileExists(newKey);
 			await updateChildAvatarUrl(
 				newChildId,
-				storageKeyToPublicUrl(`${prefix}${newRelPath}`),
+				restored ? storageKeyToPublicUrl(newKey) : null,
 				tenantId,
 			);
 		} catch (e) {

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -1026,6 +1026,16 @@ export async function remapChildAvatarUrls(
 ): Promise<void> {
 	const { data, childIdMap, oldChildToNew, relativeKeyRemap } = state;
 	const prefix = tenantPrefix(tenantId);
+
+	/** avatarUrl 更新を 1 箇所に集約し、失敗は result.errors に蓄積する。 */
+	const persist = async (childId: number, url: string | null, exportId: string): Promise<void> => {
+		try {
+			await updateChildAvatarUrl(childId, url, tenantId);
+		} catch (e) {
+			result.errors.push(`アバター参照の更新に失敗 (child=${exportId}): ${String(e)}`);
+		}
+	};
+
 	for (const child of data.family.children) {
 		if (!child.avatarUrl) continue;
 		const newChildId = childIdMap.get(child.exportId);
@@ -1036,16 +1046,16 @@ export async function remapChildAvatarUrls(
 		const oldRelPath = avatarMatch?.[1];
 		if (!oldRelPath) continue;
 
-		// 同梱ファイルから復元済の新パスを優先。なければ id セグメントだけ書き換える。
-		let newRelPath = relativeKeyRemap.get(oldRelPath);
-		if (!newRelPath) {
-			const relMatch = STATIC_FILE_PATH_RE.exec(oldRelPath);
-			const type = relMatch?.[1];
-			const oldChildIdStr = relMatch?.[2];
-			const rest = relMatch?.[3];
-			if (!type || !oldChildIdStr || !rest) continue;
-			const mappedChildId = oldChildToNew.get(Number(oldChildIdStr)) ?? newChildId;
-			newRelPath = `${type}/${mappedChildId}/${rest}`;
+		const newRelPath = resolveNewAvatarRelPath(oldRelPath, {
+			relativeKeyRemap,
+			oldChildToNew,
+			newChildId,
+		});
+		if (newRelPath === undefined) continue; // 抽出不能 → 据え置き (skip)
+		if (newRelPath === null) {
+			// zip-slip 防御で unsafe と判定 → dangling→null と同じく null 化する。
+			await persist(newChildId, null, child.exportId);
+			continue;
 		}
 
 		// #3136: 実ファイルが復元されている場合のみ avatarUrl を貼り替える。ZIP に静的ファイルが
@@ -1055,15 +1065,46 @@ export async function remapChildAvatarUrls(
 		const newKey = `${prefix}${newRelPath}`;
 		try {
 			const restored = await fileExists(newKey);
-			await updateChildAvatarUrl(
-				newChildId,
-				restored ? storageKeyToPublicUrl(newKey) : null,
-				tenantId,
-			);
+			await persist(newChildId, restored ? storageKeyToPublicUrl(newKey) : null, child.exportId);
 		} catch (e) {
 			result.errors.push(`アバター参照の更新に失敗 (child=${child.exportId}): ${String(e)}`);
 		}
 	}
+}
+
+/**
+ * 旧相対パスから貼替先の新相対パスを解決する (#3136 / zip-slip 防御)。
+ *
+ * - 同梱ファイル復元済 (`relativeKeyRemap` hit) を優先。これらは importStaticFiles 保存時に
+ *   `isSafeRelativePath` で検証済 (§importStaticFiles) のため再検証不要。
+ * - miss 時は backup 由来 avatarUrl から id セグメントを書き換えて再構成する。backup の avatarUrl は
+ *   `STATIC_FILE_PATH_RE` の `(.+)$` に `..` / 絶対パスを含み得るため、再構成 key に
+ *   `isSafeRelativePath` を適用する (importStaticFiles と同じ zip-slip ガード)。
+ *
+ * @returns 新相対パス / `undefined` (抽出不能 = skip) / `null` (unsafe = avatarUrl を null 化)
+ */
+function resolveNewAvatarRelPath(
+	oldRelPath: string,
+	ctx: {
+		relativeKeyRemap: Map<string, string>;
+		oldChildToNew: Map<number, number>;
+		newChildId: number;
+	},
+): string | null | undefined {
+	const hit = ctx.relativeKeyRemap.get(oldRelPath);
+	if (hit) return hit;
+
+	const relMatch = STATIC_FILE_PATH_RE.exec(oldRelPath);
+	const type = relMatch?.[1];
+	const oldChildIdStr = relMatch?.[2];
+	const rest = relMatch?.[3];
+	if (!type || !oldChildIdStr || !rest) return undefined;
+
+	const mappedChildId = ctx.oldChildToNew.get(Number(oldChildIdStr)) ?? ctx.newChildId;
+	const candidate = `${type}/${mappedChildId}/${rest}`;
+	// unsafe (`..` / 絶対パス) は fileExists で probe (存在オラクル化) / 永続化させない。
+	if (!isSafeRelativePath(candidate)) return null;
+	return candidate;
 }
 
 // Re-export labels type for API handler

--- a/tests/unit/services/import-service-avatar-remap.test.ts
+++ b/tests/unit/services/import-service-avatar-remap.test.ts
@@ -74,4 +74,19 @@ describe('#3136 remapChildAvatarUrls — dangling avatarUrl 防止', () => {
 		expect(updateMock).not.toHaveBeenCalled();
 		expect(fileExistsMock).not.toHaveBeenCalled();
 	});
+
+	it('relativeKeyRemap ミス時に .. traversal を含む avatarUrl は null 化し、traversed key を fileExists で probe しない（zip-slip 防御）', async () => {
+		// relativeKeyRemap は空 → fallback 分岐 (STATIC_FILE_PATH_RE 再構成) に入る。
+		// rest = `5/../../../t-other/avatars/9/secret.png` で `..` を含むため isSafeRelativePath が弾く想定。
+		const traversal = '/tenants/t-old/avatars/5/../../../t-other/avatars/9/secret.png';
+		await remapChildAvatarUrls(makeState(traversal), TENANT, makeResult());
+		// unsafe key は決して fileExists で probe されない（存在オラクル化を防ぐ）
+		expect(fileExistsMock).not.toHaveBeenCalled();
+		// dangling→null と同じ挙動で avatarUrl は null 化される
+		expect(updateMock).toHaveBeenCalledWith(100, null, TENANT);
+		// traversed/.. を含む key で更新しない（公開 URL を永続化しない）
+		for (const call of updateMock.mock.calls) {
+			expect(String(call[1])).not.toContain('..');
+		}
+	});
 });

--- a/tests/unit/services/import-service-avatar-remap.test.ts
+++ b/tests/unit/services/import-service-avatar-remap.test.ts
@@ -1,0 +1,77 @@
+// tests/unit/services/import-service-avatar-remap.test.ts
+// #3136: family import の remapChildAvatarUrls が、復元済ファイルが実在する場合のみ avatarUrl を
+// 貼り替え、欠落時は null 化して dangling reference を作らないことを検証する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// storage.fileExists / image-repo.updateChildAvatarUrl を mock（remap の分岐を制御）
+vi.mock('$lib/server/storage', () => ({ fileExists: vi.fn(), saveFile: vi.fn() }));
+vi.mock('$lib/server/db/image-repo', () => ({ updateChildAvatarUrl: vi.fn() }));
+
+import { updateChildAvatarUrl } from '$lib/server/db/image-repo';
+import {
+	type AvatarRemapState,
+	type ImportResult,
+	remapChildAvatarUrls,
+} from '$lib/server/services/import-service';
+import { fileExists } from '$lib/server/storage';
+
+const fileExistsMock = vi.mocked(fileExists);
+const updateMock = vi.mocked(updateChildAvatarUrl);
+
+const TENANT = 't-new';
+
+/** exportId / avatarUrl を持つ最小 child を含む AvatarRemapState を組み立てる */
+function makeState(
+	avatarUrl: string | null,
+	relativeKeyRemap: Map<string, string> = new Map(),
+): AvatarRemapState {
+	return {
+		// biome-ignore lint/suspicious/noExplicitAny: remap は data.family.children のみ参照する最小 stub
+		data: { family: { children: [{ exportId: 'c1', avatarUrl }] } } as any,
+		childIdMap: new Map([['c1', 100]]),
+		oldChildToNew: new Map([[5, 100]]),
+		relativeKeyRemap,
+	};
+}
+
+function makeResult(): ImportResult {
+	// biome-ignore lint/suspicious/noExplicitAny: errors 配列のみ参照する最小 stub
+	return { errors: [] } as any;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('#3136 remapChildAvatarUrls — dangling avatarUrl 防止', () => {
+	it('復元ファイルが実在しない（ZIP 同梱なし）場合は avatarUrl を null 化する', async () => {
+		fileExistsMock.mockResolvedValue(false);
+		await remapChildAvatarUrls(makeState('/tenants/t-old/avatars/5/abc.png'), TENANT, makeResult());
+		expect(fileExistsMock).toHaveBeenCalledWith('tenants/t-new/avatars/100/abc.png');
+		expect(updateMock).toHaveBeenCalledWith(100, null, TENANT);
+	});
+
+	it('復元ファイルが実在する場合は新 storage key の公開 URL に貼り替える', async () => {
+		fileExistsMock.mockResolvedValue(true);
+		await remapChildAvatarUrls(makeState('/tenants/t-old/avatars/5/abc.png'), TENANT, makeResult());
+		expect(updateMock).toHaveBeenCalledWith(100, '/tenants/t-new/avatars/100/abc.png', TENANT);
+	});
+
+	it('relativeKeyRemap（ZIP 復元）にヒットしても、実ファイル欠落なら null 化する（dangling 防止）', async () => {
+		fileExistsMock.mockResolvedValue(false);
+		const remap = new Map([['avatars/5/abc.png', 'avatars/100/abc.png']]);
+		await remapChildAvatarUrls(
+			makeState('/tenants/t-old/avatars/5/abc.png', remap),
+			TENANT,
+			makeResult(),
+		);
+		expect(updateMock).toHaveBeenCalledWith(100, null, TENANT);
+	});
+
+	it('avatarUrl が無い child は更新しない', async () => {
+		await remapChildAvatarUrls(makeState(null), TENANT, makeResult());
+		expect(updateMock).not.toHaveBeenCalled();
+		expect(fileExistsMock).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/services/import-service.test.ts
+++ b/tests/unit/services/import-service.test.ts
@@ -75,8 +75,15 @@ vi.mock('$lib/server/db/special-reward-repo', () => ({
 }));
 
 // #3077: 静的ファイル復元 (storage / image-repo)
+// #3136: fileExists は「実際に saveFile された key」のみ true を返す (savedKeys 追跡) ことで、
+// 復元済ファイルが実在する場合のみ avatarUrl を貼り替える remap の挙動を忠実に再現する。
+const savedKeys = new Set<string>();
 vi.mock('$lib/server/storage', () => ({
-	saveFile: (...args: unknown[]) => mockSaveFile(...args),
+	saveFile: (...args: unknown[]) => {
+		savedKeys.add(String(args[0]));
+		return mockSaveFile(...args);
+	},
+	fileExists: (key: string) => Promise.resolve(savedKeys.has(key)),
 }));
 
 vi.mock('$lib/server/db/image-repo', () => ({
@@ -168,6 +175,7 @@ beforeEach(() => {
 	mockFindLogsByChild.mockResolvedValue([]);
 	mockSaveFile.mockResolvedValue(undefined);
 	mockUpdateChildAvatarUrl.mockResolvedValue(undefined);
+	savedKeys.clear(); // #3136: fileExists 追跡をテストごとにリセット
 });
 
 // ============================================================
@@ -1536,22 +1544,20 @@ describe('importFamilyData', () => {
 			expect(mockUpdateChildAvatarUrl).not.toHaveBeenCalled();
 		});
 
-		it('同梱ファイルが無くても avatarUrl は id セグメントを書き換えて貼り替える', async () => {
+		it('#3136: avatar 実体が同梱されていない場合は avatarUrl を null 化する (dangling reference を作らない)', async () => {
 			const data = makeExportData();
 			data.family.children = [makeChildWithAvatar('c1', 7, '/tenants/old/avatars/7/keep.png')];
 			mockInsertChild.mockResolvedValue({ id: 202 });
 
-			// staticFiles は空だが avatarUrl 参照だけ書き換える必要がある
+			// staticFiles に avatar 実体が無い (voices のみ)。旧実装は存在しない storage key へ
+			// 貼り替えて dangling を生んでいたが、#3136 で「実在しなければ null 化」に是正。
 			const result = await importFamilyData(data, TENANT, {
 				'voices/7/x.mp3': new Uint8Array([1]),
 			});
 
 			expect(result.staticFilesRestored).toBe(1); // voices/7/x.mp3
-			expect(mockUpdateChildAvatarUrl).toHaveBeenCalledWith(
-				202,
-				`/tenants/${TENANT}/avatars/202/keep.png`,
-				TENANT,
-			);
+			// avatar 実ファイルが無いため null 化 (存在しない /tenants/.../avatars/202/keep.png を指さない)
+			expect(mockUpdateChildAvatarUrl).toHaveBeenCalledWith(202, null, TENANT);
 		});
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体 / 移管する家族（backup 完全性）

**解決する課題**: family import（#3083 ZIP 移管）の `remapChildAvatarUrls` が、ZIP に avatar 実体が同梱されない（JSON のみ移管）/ 改竄破損で skip された場合も fallback で id セグメントを書き換えた storage key へ avatarUrl を貼り替え、**存在しない storage key を指す dangling avatarUrl**（画像破損・null 化されない）を生成していた（統合 PR #3131 監査の data-integrity チーム物理裏取りで検出）。

**期待される効果**: 復元済ファイルが実在する場合のみ avatarUrl を貼り替え、欠落時は null 化することで dangling reference を作らない。

## 関連 Issue

closes #3136

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 復元済ファイルが実在する場合のみ avatarUrl を貼替（無ければ null 化）し dangling を作らない | git diff + `npx vitest run tests/unit/services/import-service-avatar-remap.test.ts` | HEAD `475fcf0e4` / `remapChildAvatarUrls` が `fileExists(newKey)` で実在検証 → 実在のみ公開 URL 貼替、欠落は null。`updateChildAvatarUrl` を `string \| null` に拡張（interface + 4 実装）。4 tests PASS |
| AC2 | ZIP 同梱 static file の integrity 検証（manifest / per-file checksum） | Issue 本文の Pre-PMF 判断 | HEAD `475fcf0e4` / **Issue 明記「Pre-PMF 優先度で manifest 追加の要否は判断可」に従い defer**（ADR-0010）。dangling は defect のため本 PR で根治、per-file sha256 manifest は完全性強化の optional として優先度判断に委ねる（本 PR scope 外） |
| AC3 | 改竄/欠落ファイルを含む import で dangling URL が生成されないことを unit/e2e で検証 | `import-service-avatar-remap.test.ts` + `import-service.test.ts` | HEAD `475fcf0e4` / 新規 4 ケース（欠落→null / 実在→remap / relativeKeyRemap ヒットでも欠落なら null / no-op）+ 既存 import-service.test.ts の旧バグ pin テストを「null 化」に是正。64 tests PASS |
| 横展開 | 外部ファイル受領 + URL remap の他経路の dangling fallback 点検 | grep | HEAD `475fcf0e4` / image-service / voice-service の `updateChildAvatarUrl` は保存直後に URL 設定で dangling なし。marketplace 取込は avatar 外部ファイル非対応。dangling fallback は family import remap 固有と確認 |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層（`import-service.ts` remap）
- [x] DB スキーマ / repo（`updateChildAvatarUrl` を `string | null` に拡張、interface + sqlite/dynamodb/demo）

**影響を受ける画面・機能**: family import 時の avatar 復元。実ファイルがある場合の挙動は不変、欠落時のみ null 化（dangling 解消）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: 新規 `import-service-avatar-remap.test.ts`（4 ケース）+ `import-service.test.ts` の storage mock に fileExists 追加 + 旧バグ pin テスト 1 件を是正
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: `updateChildAvatarUrl` を sqlite / dynamodb / demo 3 実装 + interface で同期して null 許容化。`null` は両 backend で valid（avatar_url nullable）
- [x] **Critical バグ修正の場合**: N/A（priority:medium data-integrity fix）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: `.ts`（サービス層 / repo / テスト）のみの変更で `.svelte`/`.css`/`site/` を含まず UI 変更なし（pre-ready SS gate 非該当）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: remap の責務（実在検証→貼替 or null）を 1 関数に局所化。repo signature 拡張は interface 経由で一貫
- [x] **DRY**: 既存 `fileExists` を再利用（新規ファイル存在判定を作らない）
- [x] **YAGNI**: dangling 根治（defect）に限定。manifest（AC2）は Pre-PMF defer
- [x] **Security（OSS 公開前提）**: dangling reference 解消（backup 完全性の毀損是正）。改竄 avatar の silent 復元に対する checksum manifest は AC2 の優先度判断に委ねる
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: remap ごとに fileExists 1 回（avatar 持つ child 数分のみ、軽微）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): 本変更は内部 remap ロジックの defect 修正。NUC→Web 移管 runbook §4（静的ファイル）の「ZIP で実体ごと復元」記述と整合（JSON のみ移管時は avatar 再設定が必要 = null 化と一致）
- [x] 外部ファイル remap の他経路（image-service / voice-service / marketplace）に同種 dangling fallback が無いことを確認
- [x] DynamoDB / SQLite / demo の `updateChildAvatarUrl` 3 実装 + interface を同期（null 許容）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（実ファイルがある通常 ZIP 移管の挙動は不変）

**レビュー依頼事項・QA**: (1) 旧 `import-service.test.ts` の「同梱ファイルが無くても avatarUrl を貼り替える」テストは **dangling バグを pin していた**ため、「avatar 実体が無ければ null 化」に是正（assertion 弱体化ではなく誤った期待値の修正、ADR-0006 整合）。(2) AC2 の per-file checksum manifest は Issue 明記の Pre-PMF 判断に従い defer（dangling defect のみ本 PR で根治）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC2 は Pre-PMF defer を明示）
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

