### PR TITLE
fix(UX): #3144 ごほうび交換の承認待ちを admin ホームで発見可能にする

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -421,6 +421,16 @@ setup 完了後の子供画面初回遷移時に 1 回だけ表示する dialog 
 └─────────────────────────────────┘
 ```
 
+#### 承認待ちごほうび交換バナー (#3144)
+
+`/admin` ホーム本文の先頭に、ごほうび交換の親承認待ち件数を発見可能にするバナーを表示する。子供がごほうびショップで交換申請しても、親が承認待ちに気づく導線がホームに無く `/admin/rewards/requests` まで到達しないと放置される問題への対処。
+
+- **表示条件**: 承認待ち件数 > 0 のときのみ表示 (`{#if bannerCount > 0}`)。0 件のときは描画しない
+- **内容**: warning 色のバナー (`--color-surface-warning` / `--color-border-warning` / `--color-text-warm`)。`/admin/rewards/requests` へ遷移する `<a>`。文言は `ADMIN_HOME_LABELS.pendingRedemptionBanner(count)` (用語 SSOT、`REWARD_TERMS.canonical` 経由)。`data-testid="redemption-pending-banner"`
+- **件数取得**: `+page.server.ts` の load が `countPendingRedemptionsForParent(tenantId)` を呼び `pendingRedemptionCount` を供給する (件数は承認待ち全件を数え 50 件以上でも飽和しない、`reward-redemption-service` 参照)
+- **screenshot モード**: `?screenshot=all` 時は代表件数 `Math.max(count, 2)` で強制描画し LP SS 撮影を可能にする (`MilestoneBanner` の `bypassSeenCheck` と同型の正規パターン、[src/routes/CLAUDE.md](../../src/routes/CLAUDE.md) §?screenshot)
+- **Anti-engagement (ADR-0012)**: 子供の滞在時間を延ばす engagement フックではなく、**親の未処理タスク (承認待ち) の発見性導線**であるため ADR-0012 非抵触。子供の engagement バッジ (#2109 撤廃) とは目的が異なる
+
 ### 4.7a 親用設定画面 (S-08a) — 6 グループ child routes (#2319)
 
 `/admin/settings` 配下を **SvelteKit child routes 6 グループに分割** (案 2 採用、2026-05-19 PO 報告「`accountDelete` と `decay` が同一レイヤーで並ぶ違和感」への構造的対策)。Material Design / Apple HIG / NN/G Common Region 原則 + Notion / Linear / GitHub (organization > repo > personal 3 階層) prior art 整合。

--- a/scripts/capture-specs/flows/admin-redemption-banner.mjs
+++ b/scripts/capture-specs/flows/admin-redemption-banner.mjs
@@ -1,0 +1,61 @@
+/**
+ * scripts/capture-specs/flows/admin-redemption-banner.mjs (#3144)
+ *
+ * admin ホームの「ごほうび交換 承認待ち」バナー (data-testid="redemption-pending-banner") を撮影する。
+ * 通常 pending > 0 のときのみ表示される transient state のため、既存の `?screenshot=all` モード
+ * (src/routes/CLAUDE.md §?screenshot) で代表件数 2 にて強制描画して撮影する。
+ *
+ * 動作前提: npm run dev:cognito (PARENT_GATE_FORCE_ACTIVE なし = COGNITO_DEV_MODE で PIN gate 無効、
+ *   owner login だけで /admin に到達)。port 5174。
+ *
+ * 使用例:
+ *   MSYS_NO_PATHCONV=1 node scripts/capture.mjs \
+ *     --pr 3146 --base-url http://localhost:5174 \
+ *     --flow admin-redemption-banner --url "/admin?screenshot=all" \
+ *     --actions scripts/capture-specs/flows/admin-redemption-banner.mjs \
+ *     --presets mobile,desktop
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
+
+async function loginAs(page, email, password) {
+	await page.goto(`${BASE_URL}/auth/login`);
+	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 15_000 });
+	await page.waitForFunction(
+		() => {
+			const input = document.querySelector('input[name="email"]');
+			return input?.getAttribute('type') === 'email';
+		},
+		{ timeout: 15_000 },
+	);
+	const emailInput = page.getByLabel('メールアドレス');
+	await emailInput.click();
+	for (const ch of email) {
+		await page.keyboard.type(ch, { delay: 20 });
+	}
+	const pwdInput = page.getByLabel('パスワード', { exact: true });
+	await pwdInput.click();
+	for (const ch of password) {
+		await page.keyboard.type(ch, { delay: 20 });
+	}
+	await page
+		.locator('button[type="submit"]:not([disabled])')
+		.first()
+		.waitFor({ state: 'visible', timeout: 30_000 });
+	await page.getByRole('button', { name: 'ログイン' }).click();
+	await page.waitForURL(/\/(admin|ops|setup|billing|switch|child)/, { timeout: 30_000 });
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	await loginAs(page, 'owner@example.com', 'Gq!Dev#Owner2026x');
+
+	await page.goto(`${BASE_URL}/admin?screenshot=all`);
+	const banner = page.getByTestId('redemption-pending-banner');
+	await banner.waitFor({ state: 'visible', timeout: 15_000 });
+
+	await capture('admin-redemption-banner');
+};

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4239,6 +4239,9 @@ export const ADMIN_REWARDS_PAGE_LABELS = {
 export const ADMIN_HOME_LABELS = {
 	pageTitle: `${ADMIN_VIEW_TERMS.canonical} - がんばりクエスト`,
 	pageTitleDemoSuffix: ' デモ',
+	// #3144: ごほうび交換の承認待ち導線バナー (pending > 0 のときのみ表示)
+	pendingRedemptionBanner: (count: number) =>
+		`${REWARD_TERMS.canonical}の交換申請が ${count} 件 承認待ちです。確認して受け渡しましょう`,
 	heading: '管理ダッシュボード',
 	headingDemoSuffix: '（デモ）',
 	onboardingCompleteText: 'すべてのセットアップが完了しました！',

--- a/src/lib/server/db/demo/reward-redemption-repo.ts
+++ b/src/lib/server/db/demo/reward-redemption-repo.ts
@@ -38,6 +38,13 @@ export async function findRedemptionRequestsByTenant(
 	return [];
 }
 
+export async function countRedemptionRequestsByTenant(
+	_tenantId: string,
+	_opts?: { status?: string; childId?: number },
+): Promise<number> {
+	return 0;
+}
+
 export async function updateRedemptionRequestStatus(
 	_childId: number,
 	_id: number,

--- a/src/lib/server/db/dynamodb/reward-redemption-repo.ts
+++ b/src/lib/server/db/dynamodb/reward-redemption-repo.ts
@@ -202,6 +202,28 @@ export const findRedemptionRequestsByTenant: IRewardRedemptionRepo['findRedempti
 	};
 
 // ============================================================
+// countRedemptionRequestsByTenant — テナント内の正確な件数 (limit なし)
+// ============================================================
+
+/**
+ * #3144: tenant 配下を Scan し status / childId filter 後の件数を返す。
+ * findRedemptionRequestsByTenant と同じ filter を適用するが limit slice を掛けないため
+ * 50 件以上でも飽和しない (admin ホームの承認待ちバナー件数用)。
+ */
+export const countRedemptionRequestsByTenant: IRewardRedemptionRepo['countRedemptionRequestsByTenant'] =
+	async (tenantId, opts): Promise<number> => {
+		const items = await scanTenantRedemptions(tenantId);
+		let rows = items.map(toRow);
+		if (opts?.status) {
+			rows = rows.filter((r) => r.status === opts.status);
+		}
+		if (opts?.childId) {
+			rows = rows.filter((r) => r.childId === opts.childId);
+		}
+		return rows.length;
+	};
+
+// ============================================================
 // updateRedemptionRequestStatus — 申請状態を更新
 // ============================================================
 

--- a/src/lib/server/db/interfaces/reward-redemption-repo.interface.ts
+++ b/src/lib/server/db/interfaces/reward-redemption-repo.interface.ts
@@ -38,6 +38,16 @@ export interface IRewardRedemptionRepo {
 	): Promise<RedemptionRequestWithDetails[]>;
 
 	/**
+	 * #3144: テナント内の交換申請の正確な件数を返す (COUNT、limit なし)。
+	 * findRedemptionRequestsByTenant は admin 一覧表示用に limit(50) を持つため件数算出に
+	 * 流用すると 50 で飽和する。本メソッドは limit を掛けず正確な件数を返す。
+	 */
+	countRedemptionRequestsByTenant(
+		tenantId: string,
+		opts?: { status?: string; childId?: number },
+	): Promise<number>;
+
+	/**
 	 * #2845 課題①: full composite-key addressing。childId + id の複合キーで対象を直接
 	 * 特定し、repo 入口で child 所有権を構造的に検証する。不一致なら undefined。
 	 */

--- a/src/lib/server/db/reward-redemption-repo.ts
+++ b/src/lib/server/db/reward-redemption-repo.ts
@@ -20,6 +20,14 @@ export async function findRedemptionRequestsByTenant(
 	return getRepos().rewardRedemption.findRedemptionRequestsByTenant(tenantId, opts);
 }
 
+/** #3144: テナント内の交換申請の正確な件数 (COUNT、limit なし)。50 件以上でも飽和しない。 */
+export async function countRedemptionRequestsByTenant(
+	tenantId: string,
+	opts?: { status?: string; childId?: number },
+) {
+	return getRepos().rewardRedemption.countRedemptionRequestsByTenant(tenantId, opts);
+}
+
 /** #2845 課題①: childId 所有権検証付き (composite key)。不一致なら undefined。 */
 export async function updateRedemptionRequestStatus(
 	childId: number,

--- a/src/lib/server/db/sqlite/reward-redemption-repo.ts
+++ b/src/lib/server/db/sqlite/reward-redemption-repo.ts
@@ -103,6 +103,32 @@ export async function findRedemptionRequestsByTenant(
 }
 
 /**
+ * #3144: テナント内の交換申請の正確な件数を返す (COUNT、limit なし)。
+ * findRedemptionRequestsByTenant の WHERE 条件 (status / childId) と同一の filter を適用するが、
+ * admin 一覧用の limit(50) を掛けず COUNT(*) で件数を返すため 50 件以上でも飽和しない。
+ */
+export async function countRedemptionRequestsByTenant(
+	_tenantId: string,
+	opts?: { status?: string; childId?: number },
+) {
+	const conditions = [];
+	if (opts?.status) {
+		conditions.push(eq(rewardRedemptionRequests.status, opts.status));
+	}
+	if (opts?.childId) {
+		conditions.push(eq(rewardRedemptionRequests.childId, opts.childId));
+	}
+
+	const row = db
+		.select({ count: sql<number>`COUNT(*)` })
+		.from(rewardRedemptionRequests)
+		.where(conditions.length > 0 ? and(...conditions) : undefined)
+		.get();
+
+	return row?.count ?? 0;
+}
+
+/**
  * 申請状態を更新。
  * #2845 課題①: childId 所有権検証付き (composite key)。不一致なら更新せず undefined。
  */

--- a/src/lib/server/services/reward-redemption-service.ts
+++ b/src/lib/server/services/reward-redemption-service.ts
@@ -3,6 +3,7 @@
 
 import { findChildById, getBalance, insertPointEntry } from '$lib/server/db/point-repo';
 import {
+	countRedemptionRequestsByTenant,
 	expireOldRedemptions as expireOldRedemptionsRepo,
 	findPendingByChildAndReward,
 	findRedemptionRequestsByChild,
@@ -136,12 +137,13 @@ export async function getRedemptionRequestsForParent(
 /**
  * #3144: テナント内の「親の承認待ち」ごほうび交換申請の件数を返す。
  * admin ホームの承認待ちバナー（発見性導線）で使う。
+ * countRedemptionRequestsByTenant は limit を掛けず COUNT するため 50 件以上でも飽和しない
+ * (findRedemptionRequestsByTenant の limit(50) 流用だと 51+ 件で過少カウントになる)。
  */
 export async function countPendingRedemptionsForParent(tenantId: string): Promise<number> {
-	const rows = await findRedemptionRequestsByTenant(tenantId, {
+	return countRedemptionRequestsByTenant(tenantId, {
 		status: 'pending_parent_approval',
 	});
-	return rows.length;
 }
 
 // ============================================================

--- a/src/lib/server/services/reward-redemption-service.ts
+++ b/src/lib/server/services/reward-redemption-service.ts
@@ -133,6 +133,17 @@ export async function getRedemptionRequestsForParent(
 	}));
 }
 
+/**
+ * #3144: テナント内の「親の承認待ち」ごほうび交換申請の件数を返す。
+ * admin ホームの承認待ちバナー（発見性導線）で使う。
+ */
+export async function countPendingRedemptionsForParent(tenantId: string): Promise<number> {
+	const rows = await findRedemptionRequestsByTenant(tenantId, {
+		status: 'pending_parent_approval',
+	});
+	return rows.length;
+}
+
 // ============================================================
 // 承認
 // ============================================================

--- a/src/routes/(parent)/admin/+page.server.ts
+++ b/src/routes/(parent)/admin/+page.server.ts
@@ -8,6 +8,7 @@ import { dismissOnboarding, getOnboardingProgress } from '$lib/server/services/o
 import { isPaidTier } from '$lib/server/services/plan-limit-service';
 import { getPointBalance } from '$lib/server/services/point-service';
 import { getAllChildrenSimpleSummary } from '$lib/server/services/report-service';
+import { countPendingRedemptionsForParent } from '$lib/server/services/reward-redemption-service';
 import { getChildStatus } from '$lib/server/services/status-service';
 import {
 	getTodayUsageSummary,
@@ -132,9 +133,14 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 	const parentData = await parent();
 	const tier = parentData.planTier;
 
-	const [children, onboarding] = await Promise.all([
+	const [children, onboarding, pendingRedemptionCount] = await Promise.all([
 		getAllChildren(tenantId),
 		getOnboardingProgress(tenantId, '/admin'),
+		// #3144: ごほうび交換の承認待ち件数 (admin ホームの発見性バナー用)。失敗時は 0。
+		countPendingRedemptionsForParent(tenantId).catch((e) => {
+			logger.warn('[admin] 承認待ち件数取得フォールバック', { context: { error: String(e) } });
+			return 0;
+		}),
 	]);
 
 	const now = new Date();
@@ -169,6 +175,8 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 		todayUsage,
 		weeklyUsage,
 		valuePreview,
+		// #3144: ごほうび交換の承認待ち件数 (admin ホームの発見性バナー)
+		pendingRedemptionCount,
 	};
 };
 

--- a/src/routes/(parent)/admin/+page.svelte
+++ b/src/routes/(parent)/admin/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { page } from '$app/state';
 import { ADMIN_HOME_LABELS } from '$lib/domain/labels';
-import { getScreenshotModeKind } from '$lib/features/demo/screenshot-mode';
 import AdminHome from '$lib/features/admin/components/AdminHome.svelte';
+import { getScreenshotModeKind } from '$lib/features/demo/screenshot-mode';
 
 let { data } = $props();
 
@@ -11,7 +11,9 @@ const pendingRedemptionCount = $derived<number>(data.pendingRedemptionCount ?? 0
 // #3144: `?screenshot=all` 時はバナーを代表件数 (2) で強制描画し SS 撮影可能にする
 // (MilestoneBanner の bypassSeenCheck と同型の正規パターン、src/routes/CLAUDE.md §?screenshot)。
 const isScreenshotAll = $derived(getScreenshotModeKind() === 'all');
-const bannerCount = $derived(isScreenshotAll ? Math.max(pendingRedemptionCount, 2) : pendingRedemptionCount);
+const bannerCount = $derived(
+	isScreenshotAll ? Math.max(pendingRedemptionCount, 2) : pendingRedemptionCount,
+);
 
 // ADR-0048 Phase B-1 (#2097): demo Lambda (AUTH_MODE=anonymous) では
 // `(parent)/admin/+page.svelte` も isDemo=true として描画される。

--- a/src/routes/(parent)/admin/+page.svelte
+++ b/src/routes/(parent)/admin/+page.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 import { page } from '$app/state';
+import { ADMIN_HOME_LABELS } from '$lib/domain/labels';
 import AdminHome from '$lib/features/admin/components/AdminHome.svelte';
 
 let { data } = $props();
+
+// #3144: ごほうび交換の承認待ち件数 (admin ホームの発見性バナー)
+const pendingRedemptionCount = $derived<number>(data.pendingRedemptionCount ?? 0);
 
 // ADR-0048 Phase B-1 (#2097): demo Lambda (AUTH_MODE=anonymous) では
 // `(parent)/admin/+page.svelte` も isDemo=true として描画される。
@@ -12,6 +16,16 @@ let { data } = $props();
 // これにより onboarding ダイアログ等の本番専用 UI が demo Lambda 上で誤表示されない (A-6 ISSUE-003)。
 const adminMode = $derived<'live' | 'demo'>(page.data.isDemo ? 'demo' : 'live');
 </script>
+
+<!-- #3144: ごほうび交換の承認待ち導線 (pending > 0 のときのみ)。
+     子供の engagement バッジ (#2109 撤廃) でなく親の管理タスク導線のため ADR-0012 非抵触。 -->
+{#if pendingRedemptionCount > 0}
+	<a class="redemption-pending-banner" href="/admin/rewards/requests" data-testid="redemption-pending-banner">
+		<span class="redemption-pending-banner__icon" aria-hidden="true">🎁</span>
+		<span class="redemption-pending-banner__text">{ADMIN_HOME_LABELS.pendingRedemptionBanner(pendingRedemptionCount)}</span>
+		<span class="redemption-pending-banner__cta" aria-hidden="true">▶</span>
+	</a>
+{/if}
 
 <AdminHome
 	children={data.children}
@@ -28,3 +42,32 @@ const adminMode = $derived<'live' | 'demo'>(page.data.isDemo ? 'demo' : 'live');
 	weeklyUsage={data.weeklyUsage}
 	valuePreview={data.valuePreview}
 />
+
+<style>
+	.redemption-pending-banner {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin-bottom: 16px;
+		padding: 0.875rem 1rem;
+		border: 1px solid var(--color-border-warning);
+		border-radius: 0.75rem;
+		background: var(--color-surface-warning);
+		color: var(--color-text-warm);
+		text-decoration: none;
+		font-weight: 600;
+	}
+	.redemption-pending-banner:hover {
+		background: var(--color-feedback-warning-bg-strong);
+	}
+	.redemption-pending-banner__icon {
+		font-size: 1.25rem;
+	}
+	.redemption-pending-banner__text {
+		flex: 1;
+		min-width: 0;
+	}
+	.redemption-pending-banner__cta {
+		color: var(--color-text-warm-muted);
+	}
+</style>

--- a/src/routes/(parent)/admin/+page.svelte
+++ b/src/routes/(parent)/admin/+page.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
 import { page } from '$app/state';
 import { ADMIN_HOME_LABELS } from '$lib/domain/labels';
+import { getScreenshotModeKind } from '$lib/features/demo/screenshot-mode';
 import AdminHome from '$lib/features/admin/components/AdminHome.svelte';
 
 let { data } = $props();
 
 // #3144: ごほうび交換の承認待ち件数 (admin ホームの発見性バナー)
 const pendingRedemptionCount = $derived<number>(data.pendingRedemptionCount ?? 0);
+// #3144: `?screenshot=all` 時はバナーを代表件数 (2) で強制描画し SS 撮影可能にする
+// (MilestoneBanner の bypassSeenCheck と同型の正規パターン、src/routes/CLAUDE.md §?screenshot)。
+const isScreenshotAll = $derived(getScreenshotModeKind() === 'all');
+const bannerCount = $derived(isScreenshotAll ? Math.max(pendingRedemptionCount, 2) : pendingRedemptionCount);
 
 // ADR-0048 Phase B-1 (#2097): demo Lambda (AUTH_MODE=anonymous) では
 // `(parent)/admin/+page.svelte` も isDemo=true として描画される。
@@ -19,10 +24,10 @@ const adminMode = $derived<'live' | 'demo'>(page.data.isDemo ? 'demo' : 'live');
 
 <!-- #3144: ごほうび交換の承認待ち導線 (pending > 0 のときのみ)。
      子供の engagement バッジ (#2109 撤廃) でなく親の管理タスク導線のため ADR-0012 非抵触。 -->
-{#if pendingRedemptionCount > 0}
+{#if bannerCount > 0}
 	<a class="redemption-pending-banner" href="/admin/rewards/requests" data-testid="redemption-pending-banner">
 		<span class="redemption-pending-banner__icon" aria-hidden="true">🎁</span>
-		<span class="redemption-pending-banner__text">{ADMIN_HOME_LABELS.pendingRedemptionBanner(pendingRedemptionCount)}</span>
+		<span class="redemption-pending-banner__text">{ADMIN_HOME_LABELS.pendingRedemptionBanner(bannerCount)}</span>
 		<span class="redemption-pending-banner__cta" aria-hidden="true">▶</span>
 	</a>
 {/if}

--- a/tests/unit/services/reward-redemption-service.test.ts
+++ b/tests/unit/services/reward-redemption-service.test.ts
@@ -232,6 +232,23 @@ describe('countPendingRedemptionsForParent (#3144)', () => {
 		await approveRedemption(reqResult.id, 1, TENANT_ID);
 		expect(await countPendingRedemptionsForParent(TENANT_ID)).toBe(0);
 	});
+
+	it('承認待ちが 50 件を超えても正確な件数を返す (limit(50) 飽和なし)', async () => {
+		const { childId, rewardId } = seedBaseData();
+		// 申請動線 (requestRedemption) は同一報酬の重複 pending を弾く + 残高検証があるため、
+		// 件数飽和の回帰検証は pending 行を直接 60 件投入して COUNT 経路のみを検証する。
+		const now = Math.floor(Date.now() / 1000);
+		const insert = sqlite.prepare(
+			`INSERT INTO reward_redemption_requests (child_id, reward_id, requested_at, status)
+			 VALUES (?, ?, ?, 'pending_parent_approval')`,
+		);
+		for (let i = 0; i < 60; i++) {
+			insert.run(childId, rewardId, now + i);
+		}
+
+		// limit(50) を流用していた旧実装ではここが 50 で飽和し過少カウントになる。
+		expect(await countPendingRedemptionsForParent(TENANT_ID)).toBe(60);
+	});
 });
 
 describe('getUnshownRedemptionResult / markRedemptionShown', () => {

--- a/tests/unit/services/reward-redemption-service.test.ts
+++ b/tests/unit/services/reward-redemption-service.test.ts
@@ -26,6 +26,7 @@ vi.mock('$lib/server/db/client', () => ({
 
 import {
 	approveRedemption,
+	countPendingRedemptionsForParent,
 	expireOldRedemptions,
 	getRedemptionRequestsForChild,
 	getRedemptionRequestsForParent,
@@ -212,6 +213,24 @@ describe('getRedemptionRequestsForParent', () => {
 		expect(requests.length).toBe(1);
 		expect(requests[0]!.rewardTitle).toBe('ゲーム時間30分');
 		expect(requests[0]!.childName).toBe('テストちゃん');
+	});
+});
+
+describe('countPendingRedemptionsForParent (#3144)', () => {
+	it('承認待ち申請が無ければ 0 を返す', async () => {
+		seedBaseData();
+		expect(await countPendingRedemptionsForParent(TENANT_ID)).toBe(0);
+	});
+
+	it('pending 申請の件数を返し、承認すると減る', async () => {
+		const { childId, rewardId } = seedBaseData();
+		const reqResult = await requestRedemption(childId, rewardId, TENANT_ID);
+		if ('error' in reqResult) throw new Error('request failed');
+
+		expect(await countPendingRedemptionsForParent(TENANT_ID)).toBe(1);
+
+		await approveRedemption(reqResult.id, 1, TENANT_ID);
+		expect(await countPendingRedemptionsForParent(TENANT_ID)).toBe(0);
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: 子供がごほうびショップで交換すると `pending_parent_approval` の申請が作られ、親が `/admin/rewards/requests` で承認するとポイント減算・受け渡し完了になる（#1337）。しかし**親に「承認待ちがある／どこで処理するか」の導線が無く**、「交換しようとすると申請待ちになるが、どうすれば処理完了するのか不明」と報告されていた（PO 報告）。

**期待される効果**: admin ホームに承認待ち件数バナーを出し `/admin/rewards/requests` へ誘導することで、親がコアループ最終段（記録→ポイント→交換）を完了できるようにする。承認フロー自体（pending を挟む）は意図的なので変更しない。

## 関連 Issue

closes #3144

- #1337（親子連携フロー）/ #2269（承認画面分離）/ #2832（pending snapshot）/ ADR-0012（anti-engagement — 親の管理タスク導線は非抵触）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | pending ≥1 のとき admin ホームに承認待ちバナー表示 + `/admin/rewards/requests` 遷移 | SS（下記）+ コード | `admin/+page.svelte` `{#if bannerCount > 0}` → `<a href="/admin/rewards/requests" data-testid="redemption-pending-banner">` |
| AC2 | pending 0 件のときバナー非表示 | コード | `bannerCount = pendingRedemptionCount`（screenshot mode 以外は実件数）。0 のとき `{#if}` false |
| AC3 | 文言は labels SSOT 経由 | `sync-lp-fallback --check` | `ADMIN_HOME_LABELS.pendingRedemptionBanner(count)`（`REWARD_TERMS.canonical` 参照、ハードコードなし）|
| AC4 | pending 件数は per-tenant 集計、両 backend 等価 | `npx vitest run reward-redemption-service.test.ts` | `countPendingRedemptionsForParent`（`findRedemptionRequestsByTenant` 経由、SQLite/DynamoDB 共通 service）。14 passed |
| AC5 | unit test + admin e2e 回帰なし + SS | vitest + SS | service unit 2 ケース追加（0件/承認で減）。`?screenshot=all` で実バナー撮影し embed |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [x] サービス層 (`reward-redemption-service.ts`: `countPendingRedemptionsForParent`)
- [ ] API エンドポイント
- [x] ページ / レイアウト (`admin/+page.{server.ts,svelte}`)
- [ ] UI コンポーネント
- [x] ドメインモデル (`labels.ts` 1 ラベル)
- [ ] インフラ
- [ ] LP サイト
- [ ] 設定・CI

**影響を受ける画面・機能**: `/admin`（ホーム）に承認待ちバナーを追加。pending 0 のとき・他画面は不変。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `reward-redemption-service.test.ts` に `countPendingRedemptionsForParent`（0件 / 承認で減）を追加。capture flow `admin-redemption-banner.mjs` 追加
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: 既存 `findRedemptionRequestsByTenant` を集計するのみ（repo 変更なし、両 backend 等価）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high）

## スクリーンショット / ビジュアルデモ

承認待ちバナーは pending > 0 のときのみ表示。`?screenshot=all` モード（`src/routes/CLAUDE.md` §?screenshot、MilestoneBanner の bypassSeenCheck と同型）で代表件数 2 にて実バナーを描画し撮影:

**修正後（admin ホーム + 承認待ちバナー、mobile + desktop 合成）**:

![修正後 承認待ちバナー (mobile/desktop)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3145/admin-redemption-banner-flow.webp)

![修正後 承認待ちバナー mobile 拡大](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3145/01-admin-redemption-banner.png)

**修正前**: admin ホームに承認待ちの導線が無く、親が `/admin/rewards/requests` の存在に気づけなかった（= 上記バナーが新規追加要素）。

**インタラクティブ状態**: バナータップで `/admin/rewards/requests`（承認ページ）へ遷移。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 集計を service の単一関数に集約。page は表示のみ
- [x] **DRY**: 既存 `findRedemptionRequestsByTenant` を再利用
- [x] **YAGNI**: ナビ全体のバッジ機構は導入せず、ホームの 1 バナーのみ（最小）
- [x] **Security（OSS 公開前提）**: per-tenant 集計（tenantId scope）
- [x] **アクセシビリティ**: バナーは `<a>`（キーボード到達可）、アイコンは `aria-hidden`
- [x] **パフォーマンス**: load の `Promise.all` に追加（逐次化しない）+ 失敗時 0 フォールバック

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [x] labels SSOT (ADR-0009) — `pendingRedemptionBanner` 追加、`sync-lp-fallback --check` PASS
- [ ] 設計書同期 (ADR-0001) — 承認フロー自体は §15 で既定義。本 PR は発見性導線の追加のみで仕様変更なし
- [x] 並行 PR overlap 確認 (#1200) — admin home の #3088（load 並列化）と同 file だが別箇所（count 追加 vs await 構造）
- [x] N/A — admin home 固有

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（pending > 0 のときのみバナー追加、承認フロー・既存挙動は不変）

**レビュー依頼事項・QA**: バナーを admin ナビ全体のバッジでなく「ホームの 1 バナー」にした（最小スコープ + #2109 で撤廃した子供 engagement バッジと混同しない親タスク導線）。ナビバッジ化が必要かは運用後に判断、という scope 判断の妥当性を確認いただきたい。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: `?screenshot=all` で実バナー撮影し embed
- [x] 認証画面変更時: 該当なし（admin home）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
