### PR TITLE
fix: #3132 admin/rewards round-trip の points>10000 ValiError を E2E seed の domain 整合で根治

### DIFF
--- a/tests/e2e/child-shop-exchange.spec.ts
+++ b/tests/e2e/child-shop-exchange.spec.ts
@@ -6,7 +6,8 @@
 //     - ポイント残高: 100pt（beforeEach で再調整するため parallel workers の汚染を防ぐ）
 //     - 交換可能なごほうび（交換可）: 50pt — 交換フローテスト専用
 //     - 交換可能なごほうび（キャンセル確認用）: 50pt — キャンセルテスト専用（独立）
-//     - 交換不可なごほうび: 99999pt（並行ワーカーがどれだけポイントを積んでも届かない閾値）
+//     - 交換不可なごほうび: 10000pt（special-reward ドメイン上限 = reward-set export schema 上限。
+//       テスト child の残高 ~100pt を遥かに超え交換不可を維持。#3132 で旧 99999pt = out-of-domain を是正）
 //
 // AC マッピング:
 //   AC1: 交換フロー全体（子が申請 → 申請中バッジ確認）
@@ -178,7 +179,7 @@ test.describe('#1335: ごほうびショップ 交換フロー', () => {
 
 		await expect(page.getByTestId('shop-page')).toBeVisible();
 
-		// 99999pt のごほうびカードを探す（E2Eテスト用ごほうび（交換不可））
+		// 10000pt のごほうびカードを探す（E2Eテスト用ごほうび（交換不可）。#3132 で 99999→10000）
 		const expensiveCard = page.locator('[data-testid^="reward-card-"]').filter({
 			hasText: 'E2Eテスト用ごほうび（交換不可）',
 		});

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1335,7 +1335,13 @@ export default async function globalSetup() {
 				.get(cId);
 			if (!existingExpensive) {
 				db.prepare(
-					"INSERT INTO special_rewards (child_id, title, points, icon, category, shown_at) VALUES (?, 'E2Eテスト用ごほうび（交換不可）', 99999, '💎', 'shop_e2e', CURRENT_TIMESTAMP)",
+					// #3132: points は special-reward ドメイン validation (special-reward.ts `.max(10000)`) +
+					// reward-set export schema (reward-set-schema.ts `maxValue(10000)`) の上限に合わせ 10000 とする。
+					// 旧値 99999 はドメイン上限超過 (直接 SQL で validation を迂回した out-of-domain 値) で、
+					// export → restore round-trip が reward-set-schema で弾かれていた (統合 blocker)。
+					// 10000 でも本 reward はテスト child の残高 (~100pt にリセット、§balance 調整) を遥かに超え
+					// 「交換不可」を維持する (child-shop-exchange は title 一致で card を探すため値非依存)。
+					"INSERT INTO special_rewards (child_id, title, points, icon, category, shown_at) VALUES (?, 'E2Eテスト用ごほうび（交換不可）', 10000, '💎', 'shop_e2e', CURRENT_TIMESTAMP)",
 				).run(cId);
 				console.log('[E2E Setup]   Created expensive shop reward for たろうくん.');
 			}

--- a/tests/unit/marketplace/reward-set-roundtrip-domain.test.ts
+++ b/tests/unit/marketplace/reward-set-roundtrip-domain.test.ts
@@ -1,0 +1,45 @@
+// tests/unit/marketplace/reward-set-roundtrip-domain.test.ts
+// #3132: reward の points 値域が「アプリが許容する domain 値域 ⊆ export schema 値域」を満たし、
+// export → restore round-trip が境界値で破綻しないことを固定する (統合 blocker #3131 の回帰防止)。
+//
+// 旧 bug: E2E seed が直接 SQL で points=99999 (domain 上限 10000 超過) を投入し、
+// export → restore が reward-set-schema (maxValue 10000) の検証エラーで round-trip 破綻。
+// domain (grantSpecialRewardSchema) と export schema (reward-set) の points 上限が一致することを
+// assert し、片方だけ変えた場合に CI で検出する。
+
+import * as v from 'valibot';
+import { describe, expect, it } from 'vitest';
+import { grantSpecialRewardSchema, REWARD_CATEGORIES } from '$lib/domain/validation/special-reward';
+import { RewardSetPayloadSchema } from '$lib/marketplace/schemas/reward-set-schema';
+
+const CAT = REWARD_CATEGORIES[0];
+const POINTS_MAX = 10000;
+
+const rewardSetPayload = (points: number) => ({
+	rewards: [{ title: 'テスト', points, icon: '🎁', category: CAT }],
+});
+const domainReward = (points: number) => ({ childId: 1, title: 'テスト', points, category: CAT });
+
+describe('#3132 reward points 値域: domain ⊆ export schema (round-trip 整合)', () => {
+	it('export schema (reward-set) は points=10000 (上限境界) を受理する', () => {
+		expect(v.safeParse(RewardSetPayloadSchema, rewardSetPayload(POINTS_MAX)).success).toBe(true);
+	});
+
+	it('export schema は points=10001 (上限超過) を拒否する', () => {
+		expect(v.safeParse(RewardSetPayloadSchema, rewardSetPayload(POINTS_MAX + 1)).success).toBe(
+			false,
+		);
+	});
+
+	it('domain (grantSpecialRewardSchema) も points=10000 受理 / 10001 拒否 (export schema と同一上限)', () => {
+		expect(grantSpecialRewardSchema.safeParse(domainReward(POINTS_MAX)).success).toBe(true);
+		expect(grantSpecialRewardSchema.safeParse(domainReward(POINTS_MAX + 1)).success).toBe(false);
+	});
+
+	it('round-trip 不変条件: アプリが許容する最大 reward (domain max) は export schema を必ず通る', () => {
+		// domain が受理する最大 points は export schema でも受理される (= domain 値域 ⊆ export schema 値域)。
+		// どちらか一方の上限を変更すると本 test が落ち、round-trip 破綻の再混入を CI で検出する。
+		expect(grantSpecialRewardSchema.safeParse(domainReward(POINTS_MAX)).success).toBe(true);
+		expect(v.safeParse(RewardSetPayloadSchema, rewardSetPayload(POINTS_MAX)).success).toBe(true);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体 / 移管する家族（ごほうび backup 完全性）

**解決する課題**: `admin/rewards` の export→restore round-trip（#3085）が `reward-set-schema` の points≤10000 検証で弾かれ、`admin-backup-restore.spec.ts:44`（rewards round-trip）が統合 PR #3131 の全 e2e shard + a11y で fail していた（機能 blocker）。家族データ移管（#3080）のごほうび backup が round-trip で失敗 = 顧客がごほうびを移管できない。

**期待される効果**: round-trip blocker を根治し、ごほうび backup の export↔restore 整合性を回復する。

## 関連 Issue

closes #3132

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | export 対象 reward の points が reward-set-schema 制約と一致することを保証 | コード調査 + `npx vitest run tests/unit/marketplace/reward-set-roundtrip-domain.test.ts` | HEAD `7f04e5a67` / reward create 経路は `grantSpecialRewardSchema`（domain `points.max(10000)`）で safeParse 強制 = 実データ ≤10000、export schema（reward-set `maxValue(10000)`）と一致。境界値 unit test 4 件 PASS |
| AC2 | export→restore round-trip で seed reward + points 上限境界値が validation を通ることを unit で検証 | `reward-set-roundtrip-domain.test.ts` | HEAD `7f04e5a67` / domain max=10000 が export schema を必ず通る round-trip 不変条件を固定（10000 受理 / 10001 拒否、domain と schema の上限一致）。e2e は統合 PR の重量レーンで貫通検証 |
| AC3 | `admin-backup-restore.spec.ts:44`（rewards round-trip）が green | E2E seed 修正 | HEAD `7f04e5a67` / `global-setup.ts:1338` の seed points を 99999→10000（domain/schema 上限内）に是正。重量 e2e は develop 軽量レーンで skip、統合 PR で実走貫通（develop 二層設計） |
| AC4 | 根本原因を特定し、なぜ seed ≤50 で >10000 検証が発火したかを Issue に追記 | 物理確認 + Issue コメント | HEAD `7f04e5a67` / **真因 = E2E seed (global-setup.ts:1338) が直接 SQL で points=99999（domain 上限超過）を投入**（child-shop-exchange の不可達閾値用）。Issue の「seed≤50」は demo-data.ts のみ grep した誤認。仮説 1/2/3 のいずれでもない（domain は 10000 を超えない＝仮説 1 否定）。Issue にコメント追記 |
| 横展開 | 4 type で「アプリ許容値域 ⊆ export schema 値域」点検 | grep 棚卸し | HEAD `7f04e5a67` / reward-set: domain 10000 = schema 10000（境界一致、本 PR 固定）/ activity-pack: domain 100 < schema 10000（安全）/ challenge-set・rule-preset: schema 10000（permissive）。domain > schema の危険方向は 4 type で皆無 |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] テスト（E2E seed `global-setup.ts` + `child-shop-exchange.spec.ts` コメント + 新規 unit test）

**影響を受ける画面・機能**: なし（アプリ実装・schema は不変。E2E seed の out-of-domain 値を domain 整合化 + round-trip 不変条件を固定）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: 新規 `reward-set-roundtrip-domain.test.ts`（domain⊆schema 不変条件 4 件）+ `global-setup.ts` seed 99999→10000 + `child-shop-exchange.spec.ts` コメント同期
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（priority:high 統合 blocker、critical ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: テスト（`.ts`）のみの変更で `.svelte`/`.css`/`site/` を含まず UI 変更なし（pre-ready SS gate 非該当）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（テスト / seed）
- [x] **DRY**: domain⊆schema の不変条件を 1 unit test に集約し、両 schema の上限 drift を CI 検出
- [x] **YAGNI**: rewards blocker 根治 + reward 値域不変条件に限定。4 type 網羅 round-trip は #3143 scope
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): アプリ実装 / schema は不変（seed の domain 整合化のため設計書更新不要）。4 type の値域整合は本 PR 横展開 + #3143 で固定
- [x] child-shop-exchange の 99999 依存をコメント含め 10000 に同期（title 一致で card を探すため値非依存を確認）
- [x] N/A — 並行実装ペアの影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: (1) 真因は E2E seed の out-of-domain 値（99999、domain validation を直接 SQL で迂回）で、export→restore は reward-set-schema で**正しく**弾いていた。reward create 経路は domain max 10000 を強制するため実ユーザは >10000 reward を作れず、export schema（10000）と整合。よって domain 上限の仕様変更（Issue no-go）を避け seed を domain 整合化した。(2) child-shop-exchange は reward を title 一致で探すため値変更（99999→10000）に非依存、10000 はテスト child 残高（~100pt）を遥かに超え「交換不可」を維持。(3) 重量 e2e（admin-backup-restore）は develop 軽量レーンで skip、統合 PR の重量レーンで実走貫通検証する（develop 二層設計）。unit test が schema 境界を deterministic に固定。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
