### PR TITLE
test: #3143 export/import 4 type の round-trip 不変条件を網羅する単体テスト整備

### DIFF
--- a/tests/unit/marketplace/export-import-roundtrip-invariants.test.ts
+++ b/tests/unit/marketplace/export-import-roundtrip-invariants.test.ts
@@ -1,0 +1,132 @@
+// tests/unit/marketplace/export-import-roundtrip-invariants.test.ts
+// #3143: export/import 4 type の round-trip 不変条件を網羅する単体テスト (予防的)。
+//
+// export/import クラスタ (#3079/#3083/#3085) が 2 サイクル連続で round-trip blocker を出した
+// 構造的問題への予防策。「アプリが許容する全データ状態 ⊆ export/import が往復できる状態」という
+// 不変条件を、重量 e2e を待たず develop 軽量レーン (unit) で機械的に表明する。
+//
+// 本ファイルが固定する根本クラス:
+//   ② 値域整合 (#3132): domain validation 上限 ⊆ export schema 上限 / schema 境界の自己整合。
+//   ③ 文字種整合 (#3104): 日本語/絵文字を含む name/title/icon が schema + JSON 往復を通る。
+// ④ completeness 整合 (#3136/#3106) は dangling avatarUrl = import-service-avatar-remap.test.ts、
+//   reward 値域単体 = reward-set-roundtrip-domain.test.ts で既に固定済 (本ファイルは重複しない)。
+//
+// property-based (fast-check) は未導入 (ADR-0014 OSS 先調査: Pre-PMF で新規 dep は過剰)。Issue #3143 の
+// 「過剰なら代表 + 境界の example-based で可」に従い example-based で表明する。
+
+import * as v from 'valibot';
+import { describe, expect, it } from 'vitest';
+import { ActivityPackItemSchema } from '$lib/marketplace/schemas/activity-pack-schema';
+import { ChallengeSetItemSchema } from '$lib/marketplace/schemas/challenge-set-schema';
+import { ChecklistItemSchema } from '$lib/marketplace/schemas/checklist-schema';
+import { RewardSetItemSchema } from '$lib/marketplace/schemas/reward-set-schema';
+
+// --- 各 type の代表 valid item (日本語 + 絵文字を含む = 文字種往復も兼ねる) ---
+const activityItem = (over: Record<string, unknown> = {}) => ({
+	name: 'からだをうごかす🏃',
+	categoryCode: 'undou',
+	icon: '🏃',
+	basePoints: 10,
+	ageMin: null,
+	ageMax: null,
+	gradeLevel: null,
+	...over,
+});
+const checklistItem = (over: Record<string, unknown> = {}) => ({
+	label: 'はみがき🪥をする',
+	icon: '🪥',
+	order: 0,
+	...over,
+});
+const challengeItem = (over: Record<string, unknown> = {}) => ({
+	title: 'ひなまつりチャレンジ🎎',
+	description: '3日間つづけてがんばろう✨',
+	monthDay: '03-03',
+	durationDays: 3,
+	categoryId: 1,
+	baseTarget: 10,
+	rewardPoints: 100,
+	icon: '🎎',
+	...over,
+});
+const rewardItem = (over: Record<string, unknown> = {}) => ({
+	title: 'ゲームのじかん🎮',
+	points: 50,
+	icon: '🎮',
+	category: 'other',
+	...over,
+});
+
+const ok = (schema: Parameters<typeof v.safeParse>[0], data: unknown) =>
+	v.safeParse(schema, data).success;
+
+describe('#3143 export/import round-trip 不変条件 (4 type)', () => {
+	describe('① 代表データが各 type の schema を通る', () => {
+		it('activity-pack / checklist / challenge-set / reward-set の代表 item が valid', () => {
+			expect(ok(ActivityPackItemSchema, activityItem())).toBe(true);
+			expect(ok(ChecklistItemSchema, checklistItem())).toBe(true);
+			expect(ok(ChallengeSetItemSchema, challengeItem())).toBe(true);
+			expect(ok(RewardSetItemSchema, rewardItem())).toBe(true);
+		});
+	});
+
+	describe('② 値域整合: schema 数値上限の境界 (上限値 受理 / 上限+1 拒否)', () => {
+		it('activity-pack basePoints 上限 10000 受理 / 10001 拒否', () => {
+			expect(ok(ActivityPackItemSchema, activityItem({ basePoints: 10000 }))).toBe(true);
+			expect(ok(ActivityPackItemSchema, activityItem({ basePoints: 10001 }))).toBe(false);
+		});
+		it('activity-pack の domain 上限 (basePoints 100) は export schema を必ず通る (domain ⊆ schema)', () => {
+			// domain validation (activity.ts: basePoints.max(100)) が許容する最大値が export schema を通る。
+			expect(ok(ActivityPackItemSchema, activityItem({ basePoints: 100 }))).toBe(true);
+		});
+		it('checklist order は 0 以上整数 (負値拒否)', () => {
+			expect(ok(ChecklistItemSchema, checklistItem({ order: 0 }))).toBe(true);
+			expect(ok(ChecklistItemSchema, checklistItem({ order: -1 }))).toBe(false);
+		});
+		it('challenge-set durationDays 90 / baseTarget 1000 / rewardPoints 10000 上限境界', () => {
+			expect(ok(ChallengeSetItemSchema, challengeItem({ durationDays: 90 }))).toBe(true);
+			expect(ok(ChallengeSetItemSchema, challengeItem({ durationDays: 91 }))).toBe(false);
+			expect(ok(ChallengeSetItemSchema, challengeItem({ baseTarget: 1000 }))).toBe(true);
+			expect(ok(ChallengeSetItemSchema, challengeItem({ baseTarget: 1001 }))).toBe(false);
+			expect(ok(ChallengeSetItemSchema, challengeItem({ rewardPoints: 10000 }))).toBe(true);
+			expect(ok(ChallengeSetItemSchema, challengeItem({ rewardPoints: 10001 }))).toBe(false);
+		});
+		it('reward-set points 上限 10000 受理 / 10001 拒否 (詳細 domain⊆schema は reward-set-roundtrip-domain.test.ts)', () => {
+			expect(ok(RewardSetItemSchema, rewardItem({ points: 10000 }))).toBe(true);
+			expect(ok(RewardSetItemSchema, rewardItem({ points: 10001 }))).toBe(false);
+		});
+	});
+
+	describe('③ 文字種整合: 日本語 + 絵文字を含む文字列が schema + JSON 往復を通る (#3104 root class)', () => {
+		const cases: Array<[string, Parameters<typeof v.safeParse>[0], () => unknown]> = [
+			['activity-pack', ActivityPackItemSchema, () => activityItem({ name: '日本語🎌テスト活動' })],
+			['checklist', ChecklistItemSchema, () => checklistItem({ label: '日本語🧹そうじする' })],
+			[
+				'challenge-set',
+				ChallengeSetItemSchema,
+				() => challengeItem({ title: '七夕🎋ちょうせん', description: '願いごと✍️をかこう' }),
+			],
+			['reward-set', RewardSetItemSchema, () => rewardItem({ title: 'おかし🍪パーティー' })],
+		];
+		for (const [name, schema, make] of cases) {
+			it(`${name}: 非 ASCII (日本語/絵文字) item が valid + JSON.stringify→parse で同値`, () => {
+				const item = make();
+				expect(ok(schema, item)).toBe(true);
+				// JSON シリアライズ往復で非 ASCII が壊れない (export = JSON body の round-trip 整合)
+				const roundTripped = JSON.parse(JSON.stringify(item));
+				expect(roundTripped).toEqual(item);
+				expect(ok(schema, roundTripped)).toBe(true);
+			});
+		}
+	});
+
+	describe('③b emoji icon (ZWJ 連結含む) が icon maxLength を通る', () => {
+		it('家族 ZWJ emoji 👨‍👩‍👧‍👦 (11 UTF-16 code units) が 4 type の icon を通る', () => {
+			const zwj = '👨‍👩‍👧‍👦';
+			expect(ok(ActivityPackItemSchema, activityItem({ icon: zwj }))).toBe(true);
+			expect(ok(ChecklistItemSchema, checklistItem({ icon: zwj }))).toBe(true);
+			expect(ok(ChallengeSetItemSchema, challengeItem({ icon: zwj }))).toBe(true);
+			expect(ok(RewardSetItemSchema, rewardItem({ icon: zwj }))).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / 開発チーム（家族データ移管 #3080 の backup/restore 信頼性）

**解決する課題**: export/import クラスタ（#3079/#3083/#3085）が 2 サイクル連続で round-trip blocker（#3104 文字種 → #3132 値域）を出している。個別 defect の都度パッチではなく、「アプリが許容する全データ状態 ⊆ export/import が往復できる状態」という round-trip 不変条件を網羅する単体テストを整備し、値域・文字種・completeness の非対称を CI で機械的に捕捉する。

**期待される効果**: 個別パッチの追いかけっこから「不変条件で一括防御」へ転換。重量 e2e（admin-backup-restore）でしか露見しなかった非対称を、develop 軽量レーンの高速 unit で統合監査を待たず捕捉する。

## 関連 Issue

closes #3143

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC① | 4 type で代表データ + 境界値を往復し欠落・取り違え・reject が無い | `npx vitest run tests/unit/marketplace/export-import-roundtrip-invariants.test.ts` | HEAD `323dd7efe` / 4 type の代表 item（日本語+絵文字含む）が schema を通る + 数値上限境界（上限受理 / 上限+1 拒否）。11 tests PASS |
| AC② | domain validation 上限と export schema 上限が一致 / export が schema 内（#3132 root class） | 同上 | HEAD `323dd7efe` / activity basePoints 10000/10001 境界 + domain 上限 100 が schema を通る（domain⊆schema）/ challenge durationDays 90・baseTarget 1000・rewardPoints 10000 境界 / reward points 境界。詳細 reward domain⊆schema は `reward-set-roundtrip-domain.test.ts`（#3132） |
| AC③ | name/title 等に非 ASCII（日本語/絵文字）を含むデータが往復できる（#3104 root class） | 同上 | HEAD `323dd7efe` / 4 type で日本語+絵文字 item が valid + `JSON.stringify→parse` で同値 + ZWJ 連結 emoji（👨‍👩‍👧‍👦）が 4 type の icon を通る |
| AC④ | ZIP 静的ファイル + checklistLogs の完全往復で checksum 対象と実復元対象が一致し dangling を生まない（#3136/#3106 root class） | 既存テスト参照 | HEAD `323dd7efe` / dangling avatarUrl = `import-service-avatar-remap.test.ts`（#3136）で固定済、checklistLog 往復 = `import-service.test.ts`（#3078/#3113）で固定済。本 file は重複しない。per-file checksum manifest は #3136 AC2 で Pre-PMF defer |
| AC⑤ | 可能なら property-based、過剰なら example-based（Pre-PMF 判断） | OSS 調査 | HEAD `323dd7efe` / fast-check 未導入（ADR-0014 OSS 先調査: Pre-PMF で新規 dep は過剰）→ Issue の「過剰なら example-based で可」に従い **example-based** で表明 |
| AC⑥ | develop 軽量レーンで走る単体テスト | 配置 | HEAD `323dd7efe` / `tests/unit/marketplace/`（ci.yml unit-test job、develop 軽量レーンで発火）に配置 |

## 変更タイプ

- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] テスト（`tests/unit/marketplace/` に新規 unit test 1 file）

**影響を受ける画面・機能**: なし（予防的不変条件テストの追加。アプリ実装・schema は不変）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `export-import-roundtrip-invariants.test.ts`（4 type × 代表/境界/値域/文字種、11 ケース）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: テスト（`.ts`）のみの追加で UI 変更なし（pre-ready SS gate 非該当）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 4 type を per-type の valid item factory + 共通 `ok()` helper で表明、責務分離
- [x] **DRY**: reward 値域 domain⊆schema（#3132）/ dangling（#3136）/ checklistLog 往復（#3078/#3113）の既存テストを重複せず参照
- [x] **YAGNI**: example-based に限定（fast-check 新規導入は Pre-PMF 過剰として不採用）
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: 高速 unit（schema parse のみ、~10ms）

## 横展開・影響波及チェック

- [x] N/A — 並行実装ペアの影響範囲外（予防的テスト）
- [x] **設計書同期** (ADR-0001): アプリ実装・schema 不変のため設計書更新不要。4 type の値域整合は #3132 横展開で棚卸し済（domain>schema の危険方向は皆無）
- [x] 既存 round-trip テスト（#3132 値域 / #3136 dangling / #3078 checklistLog）との重複を回避し参照で連携

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: blocked_by #3132 / #3136 はいずれも develop へ merge 済（#3146 / #3140）。本 PR は両者の回帰を固定する位置づけ。AC④ completeness は dangling（#3136 test）+ checklistLog 往復（既存 test）で既に固定済のため本 file は重複せず参照に留め、未固定の per-file checksum manifest は #3136 AC2 の Pre-PMF defer に従う。AC⑤ は fast-check 新規導入が Pre-PMF 過剰のため example-based（Issue 許容）を採用。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（④ は既存 test 参照 + manifest は #3136 defer、⑤ は example-based）
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
