### PR TITLE
fix: #3147 ごほうび shop_category 列 — 登録カテゴリと陳列系統を分離 (列優先 + null fallback)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -2206,15 +2206,34 @@ ADR-0011 の「baby = 親の準備モード」方針に基づいた独自 UI。
 | `money` | おこづかい | 金額相当のポイント交換 |
 | `privilege` | とくべつ | 特権 / 体験 / 時間延長 / メニューリクエスト等 |
 
-### 14.6 shopCategory 派生機構（#2157、暫定実装）
+### 14.6 shopCategory 決定機構（#2157 派生 → #3147 列優先 + fallback）
 
-`special_rewards` テーブルに `shop_category` 列は無いため、`src/lib/domain/shop-category.ts` の `deriveShopCategory(reward)` で title / icon から決定的に派生する。Pre-PMF コスト最小化方針 (ADR-0010)。
+ごほうびの陳列系統 (`physical` / `money` / `privilege`) は **登録カテゴリ (`RewardCategory` 6 値: academic/sports/social/creative/life/other) とは直交する独立軸**である。両者が無関係なため、以前はショップ表示時に `deriveShopCategory()` で推定するのみだった (#2157)。#3147 で `special_rewards.shop_category` 列を追加し、**親が登録時に明示選択 → 列値を優先 / 未選択 (null) のみ推定 fallback** の 2 段構えに変更した。
+
+#### 決定順序 (#3147)
+
+1. **列値優先**: `special_rewards.shop_category` に値があればそれをそのまま陳列タブに使う (親が登録/編集時に選んだ意図を尊重)。
+2. **null fallback**: 列値が `null` (旧行 / 親が「自動で振り分け」を選択) のときのみ `src/lib/domain/shop-category.ts` の `deriveShopCategory(reward)` で title / icon / description から決定的に推定する (後方互換)。
+
+実装: `shop/+page.server.ts` の `reward.shopCategory ?? deriveShopCategory({ title, icon, description })`。
+
+#### `deriveShopCategory()` の推定ルール (fallback 時のみ)
 
 - `money` 判定: 「おこづかい」「貯金」「○○円」 / 通貨絵文字 (🪙 💴 💵 💰 💸)
 - `privilege` 判定: 「時間」「○○けん」「リクエスト」「おでかけ」「えいが」 / 体験絵文字 (🌙 😴 🎮 📺 🚗 🍽️ 🎬 等)
 - `physical` 判定: 上記以外 (現物デフォルト)
 
-preset (`preset-rewards.ts`) との一致率は `tests/unit/domain/shop-category.test.ts` で 80% 以上を担保。将来 (PMF 後) DB schema 拡張で `shop_category` 列を追加した際は本ヒューリスティックを deprecate する。
+#### 登録 UI (親側、#3147)
+
+`/admin/rewards` の追加フォームに「ショップの並び（タブ）」セレクト (`name="shopCategory"`) を追加。選択肢は `自動で振り分け` (空値、既定) / `もの` / `おこづかい` / `とくべつ` の 4 種 (`ADMIN_REWARDS_PAGE_LABELS.shopCategory*`)。空値は server action で `null` に正規化し、上記 fallback に委ねる。
+
+#### 永続化 (#3147)
+
+- schema: `schema.ts` `specialRewards.shopCategory` (nullable text) + `create-tables.ts` `shop_category TEXT`。既存 DB は `validateAndMigrate` が `ALTER TABLE ADD COLUMN` を自動適用するため backfill migration 不要 (ADR-0031)。
+- marketplace round-trip: `RewardSetItemSchema` / `RewardSetPayload` に optional `shopCategory` を追加し、取込 (`reward-set-import-service`) / 兄弟コピー (`child-reward-copy-service`) で引き継ぐ。preset 側に値が無ければ取込先で `null` (fallback)。
+- DynamoDB / demo repo も同列を round-trip する。
+
+検証: 列優先 + null fallback は `tests/unit/routes/shop-shop-category-priority.test.ts`、登録フォーム受け渡しは `tests/unit/routes/admin-rewards-actions.test.ts`、推定ヒューリスティックと preset 一致率 (80% 以上) は `tests/unit/domain/shop-category.test.ts` で担保。`deriveShopCategory()` は列が普及するまで現行ユーザのデータ (列 null) を救済し続けるため、本機構の deprecate はしない (恒久 fallback)。
 
 ### 14.7 ポイント範囲 + 交換可能フィルタ（#2160）
 

--- a/scripts/capture-specs/flows/admin-rewards-shop-category-3147.mjs
+++ b/scripts/capture-specs/flows/admin-rewards-shop-category-3147.mjs
@@ -1,0 +1,106 @@
+/**
+ * scripts/capture-specs/flows/admin-rewards-shop-category-3147.mjs
+ *
+ * #3147: ごほうび登録フォームに「ショップの並び（タブ）」セレクトを追加した SS。
+ * 登録カテゴリ (RewardCategory 6 値) とは独立した陳列系統 (physical/money/privilege)
+ * を親が登録時に選べるようにし、未選択 (自動で振り分け) のときだけ表示側
+ * deriveShopCategory に fallback する 2 段構え (列優先 + null fallback)。
+ *
+ * 本番ルート `/admin/rewards` を demo Lambda 同型 env (AUTH_MODE=anonymous +
+ * DATA_SOURCE=demo) で起動した dev server 上で開く。`?plan=family` で premium
+ * gate を解除し (デモ既定は free)、`?screenshot=all` で demo 固有 UI を抑止する。
+ *
+ * 使用例:
+ *   MSYS_NO_PATHCONV=1 BASE_URL=http://localhost:5173 node scripts/capture.mjs \
+ *     --flow admin-rewards-shop-category-3147 \
+ *     --url "/admin/rewards?plan=family&screenshot=all" \
+ *     --actions scripts/capture-specs/flows/admin-rewards-shop-category-3147.mjs \
+ *     --presets desktop,mobile --pr 3147
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
+const ENTRY = '/admin/rewards?plan=family&screenshot=all';
+
+/**
+ * Ark UI Menu trigger を click し、portal 内の指定 menu-item が visible になるまで待つ。
+ * Svelte 5 hydration race を click retry (最大 5 回) で吸収する。
+ */
+async function openMenuAndWaitItem(page, triggerTestId, itemTestId) {
+	const btn = page.getByTestId(triggerTestId);
+	await btn.waitFor({ state: 'visible', timeout: 15_000 });
+	const item = page.getByTestId(itemTestId);
+	for (let attempt = 0; attempt < 5; attempt++) {
+		await btn.click();
+		try {
+			await item.waitFor({ state: 'visible', timeout: 2_000 });
+			await page.evaluate(
+				() =>
+					new Promise((resolve) =>
+						requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+					),
+			);
+			return;
+		} catch {
+			// hydration race / 再 click で吸収
+		}
+	}
+	await item.waitFor({ state: 'visible', timeout: 3_000 });
+}
+
+async function waitForDialogOpen(page, testid) {
+	await page.waitForFunction(
+		(t) => {
+			const el = document.querySelector(`[data-testid="${t}"]`);
+			return !!el && el.getAttribute('data-state') === 'open' && !el.hasAttribute('hidden');
+		},
+		testid,
+		{ timeout: 5_000, polling: 100 },
+	);
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	// --- 1) 通常一覧 (premium 解除済、ごほうび管理ヘッダー + per-child 一覧) ---
+	await page.goto(`${BASE_URL}${ENTRY}`);
+	await page.getByTestId('admin-rewards-list').waitFor({ state: 'visible', timeout: 15_000 });
+	await capture('issue-3147-admin-rewards-list');
+
+	// --- 2) 「+ 追加」dropdown → 「手動で1つ追加」で登録 dialog を開く ---
+	await openMenuAndWaitItem(page, 'rewards-add-menu', 'menu-item-manual');
+	await page.getByTestId('menu-item-manual').click();
+	await waitForDialogOpen(page, 'rewards-add-dialog');
+
+	// dialog 上部はプリセット選択グリッド。新規セレクトは下部の登録フォーム内にあるため、
+	// フォーム (title / points / icon / category / shopCategory) を埋めて見える位置までスクロールする。
+	await page.getByTestId('rewards-add-dialog').locator('input[name="title"]').fill('ゲーム30分');
+	const shopSelect = page.locator('[data-testid="rewards-add-dialog"] select[name="shopCategory"]');
+	await shopSelect.waitFor({ state: 'attached', timeout: 5_000 });
+	await shopSelect.scrollIntoViewIfNeeded();
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+	await capture('issue-3147-admin-rewards-add-dialog');
+
+	// --- 3) 「ショップの並び（タブ）」セレクトで privilege (とくべつ) を選んだ状態 ---
+	await shopSelect.selectOption('privilege');
+	await shopSelect.scrollIntoViewIfNeeded();
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+	await capture('issue-3147-admin-rewards-shop-category-selected');
+};

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4235,7 +4235,8 @@ export const ADMIN_REWARDS_PAGE_LABELS = {
 	// RewardCategory(6値) とは独立した「子供 shop の 3 タブ」のどれに並べるかの軸。
 	// 未選択 (auto) のときは表示側 deriveShopCategory が title/icon から推定する。
 	shopCategoryLabel: 'ショップの並び（タブ）',
-	shopCategoryHint: '子供のごほうびショップでどのタブに並べるかを選べます（未選択なら自動で振り分け）',
+	shopCategoryHint:
+		'子供のごほうびショップでどのタブに並べるかを選べます（未選択なら自動で振り分け）',
 	shopCategoryAuto: '自動で振り分け',
 	shopCategoryPhysical: 'もの（おもちゃ・おやつなど）',
 	shopCategoryMoney: 'おこづかい',

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4231,6 +4231,15 @@ export const ADMIN_REWARDS_PAGE_LABELS = {
 	// AC1: pending redemption ガード (hasPendingByReward) の削除拒否メッセージ
 	deletePendingBlocked:
 		'交換申請が処理待ちのため削除できません。申請を承認または却下してから削除してください',
+	// #3147: ショップ陳列系統 (physical/money/privilege) の登録時セレクト。
+	// RewardCategory(6値) とは独立した「子供 shop の 3 タブ」のどれに並べるかの軸。
+	// 未選択 (auto) のときは表示側 deriveShopCategory が title/icon から推定する。
+	shopCategoryLabel: 'ショップの並び（タブ）',
+	shopCategoryHint: '子供のごほうびショップでどのタブに並べるかを選べます（未選択なら自動で振り分け）',
+	shopCategoryAuto: '自動で振り分け',
+	shopCategoryPhysical: 'もの（おもちゃ・おやつなど）',
+	shopCategoryMoney: 'おこづかい',
+	shopCategoryPrivilege: 'とくべつ（ゲーム時間・おでかけなど）',
 } as const;
 
 /**

--- a/src/lib/domain/marketplace-item.ts
+++ b/src/lib/domain/marketplace-item.ts
@@ -7,6 +7,7 @@
 
 import { AGE_TIER_LABELS } from './labels.js';
 import { CONCEPT_ICONS } from './terms.js';
+import type { ShopCategory } from './shop-category.js';
 import type { CategoryCode, GradeLevel } from './validation/activity.js';
 import type { UiMode } from './validation/age-tier-types.js';
 import type { RewardCategory } from './validation/special-reward.js';
@@ -102,6 +103,9 @@ export interface RewardSetPayload {
 		icon: string;
 		category: RewardCategory;
 		description?: string;
+		// #3147: ショップ陳列系統 (physical/money/privilege)。省略時は取込側で推定 fallback。
+		// RewardCategory(6値) とは直交する軸 (登録カテゴリとショップ陳列の分離)。
+		shopCategory?: ShopCategory;
 	}[];
 }
 

--- a/src/lib/domain/marketplace-item.ts
+++ b/src/lib/domain/marketplace-item.ts
@@ -6,8 +6,8 @@
  */
 
 import { AGE_TIER_LABELS } from './labels.js';
-import { CONCEPT_ICONS } from './terms.js';
 import type { ShopCategory } from './shop-category.js';
+import { CONCEPT_ICONS } from './terms.js';
 import type { CategoryCode, GradeLevel } from './validation/activity.js';
 import type { UiMode } from './validation/age-tier-types.js';
 import type { RewardCategory } from './validation/special-reward.js';

--- a/src/lib/domain/validation/special-reward.ts
+++ b/src/lib/domain/validation/special-reward.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { SHOP_CATEGORIES } from '$lib/domain/shop-category';
 
 // 特別報酬カテゴリ
 export const REWARD_CATEGORIES = [
@@ -14,6 +15,10 @@ export type RewardCategory = (typeof REWARD_CATEGORIES)[number];
 // Zod スキーマ
 export const rewardCategorySchema = z.enum(REWARD_CATEGORIES);
 
+// #3147: ショップ陳列系統 (physical/money/privilege)。RewardCategory(6値)とは直交する軸。
+// SHOP_CATEGORIES は shop-category.ts の SSOT を再利用 (重複定義しない)。
+export const shopCategorySchema = z.enum(SHOP_CATEGORIES);
+
 export const grantSpecialRewardSchema = z.object({
 	childId: z.coerce.number().int().positive(),
 	title: z.string().min(1).max(100),
@@ -21,6 +26,8 @@ export const grantSpecialRewardSchema = z.object({
 	points: z.number().int().positive().max(10000),
 	icon: z.string().max(10).optional(),
 	category: rewardCategorySchema,
+	// #3147: 親が選ぶショップ陳列系統。省略時は表示側 deriveShopCategory に委ねる
+	shopCategory: shopCategorySchema.optional(),
 });
 
 export const specialRewardQuerySchema = z.object({

--- a/src/lib/marketplace/schemas/reward-set-schema.ts
+++ b/src/lib/marketplace/schemas/reward-set-schema.ts
@@ -34,10 +34,7 @@ export const RewardSetItemSchema = v.object({
 	// #3147: ショップ陳列系統 (physical/money/privilege)。省略時は取込側で推定 fallback。
 	// RewardCategory(6値) とは直交する軸 (登録カテゴリとショップ陳列の分離)。
 	shopCategory: v.optional(
-		v.picklist(
-			SHOP_CATEGORIES,
-			'shopCategory は SHOP_CATEGORIES のいずれかで指定してください',
-		),
+		v.picklist(SHOP_CATEGORIES, 'shopCategory は SHOP_CATEGORIES のいずれかで指定してください'),
 	),
 });
 

--- a/src/lib/marketplace/schemas/reward-set-schema.ts
+++ b/src/lib/marketplace/schemas/reward-set-schema.ts
@@ -7,6 +7,7 @@
  */
 
 import * as v from 'valibot';
+import { SHOP_CATEGORIES } from '$lib/domain/shop-category.js';
 import { REWARD_CATEGORIES } from '$lib/domain/validation/special-reward.js';
 
 /** reward-set item: 単一のごほうび (`RewardSetPayload['rewards'][number]` の rebuild) */
@@ -30,6 +31,14 @@ export const RewardSetItemSchema = v.object({
 		'category は REWARD_CATEGORIES のいずれかで指定してください',
 	),
 	description: v.optional(v.pipe(v.string(), v.maxLength(500))),
+	// #3147: ショップ陳列系統 (physical/money/privilege)。省略時は取込側で推定 fallback。
+	// RewardCategory(6値) とは直交する軸 (登録カテゴリとショップ陳列の分離)。
+	shopCategory: v.optional(
+		v.picklist(
+			SHOP_CATEGORIES,
+			'shopCategory は SHOP_CATEGORIES のいずれかで指定してください',
+		),
+	),
 });
 
 export const RewardSetPayloadSchema = v.object({

--- a/src/lib/server/db/create-tables.ts
+++ b/src/lib/server/db/create-tables.ts
@@ -251,7 +251,9 @@ export const SQL_CREATE_TABLES = `
 		granted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		shown_at TEXT,
 		-- #1254 G1: プリセット由来のごほうびを識別（NULL=プリセット非由来）
-		source_preset_id TEXT
+		source_preset_id TEXT,
+		-- #3147: ショップ陳列系統 (physical/money/privilege)。NULL は旧行/未指定で表示側が推定 fallback
+		shop_category TEXT
 	);
 	CREATE INDEX IF NOT EXISTS idx_special_rewards_child
 		ON special_rewards(child_id, granted_at);

--- a/src/lib/server/db/demo/special-reward-repo.ts
+++ b/src/lib/server/db/demo/special-reward-repo.ts
@@ -21,6 +21,8 @@ export async function insertSpecialReward(
 		grantedAt: new Date().toISOString(),
 		shownAt: null,
 		sourcePresetId: input.sourcePresetId ?? null,
+		// #3147: ショップ陳列系統 (physical/money/privilege)
+		shopCategory: input.shopCategory ?? null,
 	};
 }
 

--- a/src/lib/server/db/dynamodb/special-reward-repo.ts
+++ b/src/lib/server/db/dynamodb/special-reward-repo.ts
@@ -44,6 +44,8 @@ export async function insertSpecialReward(
 		grantedAt: now,
 		shownAt: null,
 		sourcePresetId: input.sourcePresetId ?? null,
+		// #3147: ショップ陳列系統 (physical/money/privilege)。省略時は null で表示側 fallback
+		shopCategory: input.shopCategory ?? null,
 	};
 
 	const key = specialRewardKey(input.childId, now, id, tenantId);

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -396,6 +396,9 @@ export const specialRewards = sqliteTable(
 		shownAt: text('shown_at'),
 		// #1254 G1: プリセット由来のごほうびを識別（import 時の preset_duplicate 検知に利用）
 		sourcePresetId: text('source_preset_id'),
+		// #3147: ショップ陳列系統 (physical/money/privilege)。null は旧行/未指定で表示側が
+		// deriveShopCategory に fallback。validateAndMigrate が既存 DB に ALTER ADD COLUMN 自動適用。
+		shopCategory: text('shop_category'),
 	},
 	(table) => [index('idx_special_rewards_child').on(table.childId, table.grantedAt)],
 );

--- a/src/lib/server/db/sqlite/special-reward-repo.ts
+++ b/src/lib/server/db/sqlite/special-reward-repo.ts
@@ -14,6 +14,8 @@ export async function insertSpecialReward(
 		icon?: string;
 		category: string;
 		sourcePresetId?: string | null;
+		// #3147: ショップ陳列系統 (physical/money/privilege)。省略時は null で表示側 fallback
+		shopCategory?: string | null;
 	},
 	_tenantId: string,
 ) {

--- a/src/lib/server/db/types/index.ts
+++ b/src/lib/server/db/types/index.ts
@@ -243,6 +243,8 @@ export interface SpecialReward {
 	shownAt: string | null;
 	// #1254 G1: プリセット非由来は NULL / 未設定
 	sourcePresetId?: string | null;
+	// #3147: ショップ陳列系統 (physical/money/privilege)。null は旧行/未指定で表示側が推定 fallback
+	shopCategory?: string | null;
 }
 
 /** ごほうびショップ交換申請 (#1337) */
@@ -477,6 +479,8 @@ export interface InsertSpecialRewardInput {
 	icon?: string;
 	category: string;
 	sourcePresetId?: string | null;
+	// #3147: ショップ陳列系統 (physical/money/privilege)。省略時は表示側 deriveShopCategory に委ねる
+	shopCategory?: string | null;
 }
 
 export interface InsertStatusHistoryInput {

--- a/src/lib/server/services/child-reward-copy-service.ts
+++ b/src/lib/server/services/child-reward-copy-service.ts
@@ -97,6 +97,8 @@ export async function copyChildRewardsToSiblings(
 						category: r.category,
 						// source の sourcePresetId はリネージとして引き継ぐ (取込重複検知互換)
 						sourcePresetId: r.sourcePresetId,
+						// #3147: ショップ陳列系統も兄弟間で引き継ぐ (null は表示側 fallback)
+						shopCategory: r.shopCategory ?? null,
 					},
 					tenantId,
 				);

--- a/src/lib/server/services/reward-set-import-service.ts
+++ b/src/lib/server/services/reward-set-import-service.ts
@@ -186,6 +186,8 @@ export async function importRewardSet(
 					icon: r.icon,
 					category: r.category,
 					sourcePresetId: presetId,
+					// #3147: preset 由来の shop_category を round-trip (null は表示側 fallback)
+					shopCategory: r.shopCategory ?? null,
 				},
 				tenantId,
 			);

--- a/src/lib/server/services/special-reward-service.ts
+++ b/src/lib/server/services/special-reward-service.ts
@@ -36,6 +36,8 @@ export interface SpecialRewardResult {
 	icon: string | null;
 	category: string;
 	grantedAt: string;
+	// #3147: ショップ陳列系統 (physical/money/privilege)。null は旧行/未指定で表示側 fallback
+	shopCategory: string | null;
 }
 
 /** 特別報酬の進捗情報（UI表示用） */
@@ -63,6 +65,8 @@ interface GrantInput {
 	points: number;
 	icon?: string;
 	category: string;
+	// #3147: ショップ陳列系統 (physical/money/privilege)。省略時は表示側 deriveShopCategory に委ねる
+	shopCategory?: string | null;
 }
 
 const TEMPLATES_KEY = 'reward_templates';
@@ -79,6 +83,7 @@ function toRewardResult(row: {
 	icon: string | null;
 	category: string;
 	grantedAt: string;
+	shopCategory?: string | null;
 }): SpecialRewardResult {
 	return {
 		id: row.id,
@@ -89,6 +94,8 @@ function toRewardResult(row: {
 		icon: row.icon,
 		category: row.category,
 		grantedAt: row.grantedAt,
+		// #3147: 列値をそのまま伝播 (undefined/null は表示側 deriveShopCategory に fallback)
+		shopCategory: row.shopCategory ?? null,
 	};
 }
 
@@ -113,6 +120,7 @@ export async function addReward(
 			points: data.points,
 			icon: data.icon,
 			category: data.category,
+			shopCategory: data.shopCategory ?? null,
 		},
 		tenantId,
 	);

--- a/src/routes/(child)/[uiMode=uiMode]/shop/+page.server.ts
+++ b/src/routes/(child)/[uiMode=uiMode]/shop/+page.server.ts
@@ -41,12 +41,16 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 			points: reward.points,
 			icon: reward.icon,
 			description: reward.description,
-			// #2157 ショップ 3 系統 (実物/お小遣い/特権)。DB に列が無いため title/icon から派生
-			shopCategory: deriveShopCategory({
-				title: reward.title,
-				icon: reward.icon,
-				description: reward.description,
-			}),
+			// #2157 / #3147 ショップ 3 系統 (実物/お小遣い/特権)。
+			// 親が登録時に選んだ shop_category 列を優先し、null (旧行/未指定) のときのみ
+			// title/icon から推定 fallback (後方互換)。
+			shopCategory:
+				reward.shopCategory ??
+				deriveShopCategory({
+					title: reward.title,
+					icon: reward.icon,
+					description: reward.description,
+				}),
 			latestRequestStatus: latestRequest?.status ?? null,
 			latestRequestId: latestRequest?.id ?? null,
 		};

--- a/src/routes/(parent)/admin/rewards/+page.server.ts
+++ b/src/routes/(parent)/admin/rewards/+page.server.ts
@@ -9,6 +9,8 @@ import { getMarketplaceItem } from '$lib/data/marketplace';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { ADMIN_REWARDS_PAGE_LABELS, PLAN_GATE_LABELS } from '$lib/domain/labels';
+// #3147: ショップ陳列系統 (physical/money/privilege) の SSOT
+import { SHOP_CATEGORIES } from '$lib/domain/shop-category';
 // #2366 (ADR-0052): reward-set を新 Strategy + dispatchImport 経由に移行。
 // `$lib/marketplace` の eager-load (`./types/reward-set`) で Registry 登録される。
 import { dispatchImport } from '$lib/marketplace';
@@ -170,12 +172,21 @@ export const actions: Actions = {
 		const points = Number(formData.get('points') ?? 0);
 		const icon = String(formData.get('icon') ?? '🎁');
 		const category = String(formData.get('category') ?? 'other');
+		// #3147: 親が選んだショップ陳列系統 (physical/money/privilege)。
+		// 未選択 (空) のときは null を渡し、shop 表示側で deriveShopCategory に fallback。
+		const shopCategoryRaw = String(formData.get('shopCategory') ?? '').trim();
+		const shopCategory = (SHOP_CATEGORIES as readonly string[]).includes(shopCategoryRaw)
+			? shopCategoryRaw
+			: null;
 
 		if (!childId) return fail(400, { error: 'こどもを選択してください' });
 		if (!title) return fail(400, { error: 'タイトルを入力してください' });
 		if (points <= 0 || points > 10000) return fail(400, { error: 'ポイントは1〜10000の範囲です' });
 
-		const result = await addReward({ childId, title, points, icon, category }, tenantId);
+		const result = await addReward(
+			{ childId, title, points, icon, category, shopCategory },
+			tenantId,
+		);
 		if ('error' in result) {
 			return fail(400, { error: result.error });
 		}

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -330,7 +330,17 @@ let customTitle = $state('');
 let customPoints = $state(100);
 let customIcon = $state('🎁');
 let customCategory = $state('とくべつ');
+// #3147: ショップ陳列系統 (physical/money/privilege)。'' = 自動振り分け (表示側 deriveShopCategory)
+let customShopCategory = $state('');
 let grantSuccess = $state(false);
+
+// #3147: ショップ陳列系統セレクトの選択肢 ('' = 自動振り分け先頭)
+const shopCategoryOptions = [
+	{ value: '', label: ADMIN_REWARDS_PAGE_LABELS.shopCategoryAuto },
+	{ value: 'physical', label: ADMIN_REWARDS_PAGE_LABELS.shopCategoryPhysical },
+	{ value: 'money', label: ADMIN_REWARDS_PAGE_LABELS.shopCategoryMoney },
+	{ value: 'privilege', label: ADMIN_REWARDS_PAGE_LABELS.shopCategoryPrivilege },
+];
 
 function selectTemplate(tmpl: { title: string; points: number; icon?: string; category: string }) {
 	selectedTemplate = { ...tmpl, icon: tmpl.icon ?? '🎁' };
@@ -1019,6 +1029,20 @@ async function handleCopyFromChild() {
 							{/snippet}
 						</FormField>
 					</div>
+					<!-- #3147: ショップ陳列系統 (physical/money/privilege)。未選択 ('') なら表示側 deriveShopCategory に fallback -->
+					<FormField
+						label={ADMIN_REWARDS_PAGE_LABELS.shopCategoryLabel}
+						hint={ADMIN_REWARDS_PAGE_LABELS.shopCategoryHint}
+					>
+						{#snippet children()}
+							<NativeSelect
+								name="shopCategory"
+								bind:value={customShopCategory}
+								disabled={!data.isPremium}
+								options={shopCategoryOptions}
+							/>
+						{/snippet}
+					</FormField>
 
 					<Button
 						type="submit"

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -233,6 +233,14 @@ export default async function globalSetup() {
 				}
 			}
 
+			// #3147: special_rewards.shop_category カラム追加（nullable、NULL は表示側で推定 fallback）
+			try {
+				db.exec('ALTER TABLE special_rewards ADD COLUMN shop_category TEXT');
+				console.log('[E2E Setup]   Added special_rewards.shop_category column (#3147).');
+			} catch {
+				// カラムが既に存在する場合は無視
+			}
+
 			// #1335: reward_redemption_requests テーブル追加
 			try {
 				db.exec(`CREATE TABLE IF NOT EXISTS reward_redemption_requests (

--- a/tests/unit/helpers/test-db.ts
+++ b/tests/unit/helpers/test-db.ts
@@ -312,7 +312,9 @@ export const SQL_TABLES = `
 		granted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		shown_at TEXT,
 		-- #1254 G1: プリセット由来のごほうびを識別（NULL=プリセット非由来）
-		source_preset_id TEXT
+		source_preset_id TEXT,
+		-- #3147: ショップ陳列系統 (physical/money/privilege)。NULL は旧行/未指定で表示側が推定 fallback
+		shop_category TEXT
 	);
 	CREATE INDEX idx_special_rewards_child ON special_rewards(child_id, granted_at);
 

--- a/tests/unit/routes/admin-rewards-actions.test.ts
+++ b/tests/unit/routes/admin-rewards-actions.test.ts
@@ -216,6 +216,59 @@ describe('/admin/rewards page.server', () => {
 			expect(mockGrantSpecialReward).toHaveBeenCalledTimes(1);
 			expect(result.granted).toBe(true);
 		});
+
+		// #3147: shop_category 列をフォームから addReward へ受け渡す
+		it('親が選んだ shopCategory (privilege) を addReward に渡す', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('standard');
+			mockGrantSpecialReward.mockResolvedValue({ id: 3, title: 'ゲーム30分', points: 100 });
+
+			await grantAction({
+				request: makeFormRequest({
+					childId: 1,
+					title: 'ゲーム30分',
+					points: 100,
+					icon: '🎮',
+					shopCategory: 'privilege',
+				}),
+				locals: makeLocals({ licenseStatus: 'active', plan: 'standard_monthly' }),
+			});
+
+			expect(mockGrantSpecialReward).toHaveBeenCalledTimes(1);
+			const arg = mockGrantSpecialReward.mock.calls[0]?.[0];
+			expect(arg.shopCategory).toBe('privilege');
+		});
+
+		it('shopCategory 未選択 (空) は null として addReward に渡す (表示側 fallback)', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('standard');
+			mockGrantSpecialReward.mockResolvedValue({ id: 4, title: 'おやつ', points: 30 });
+
+			await grantAction({
+				request: makeFormRequest({ childId: 1, title: 'おやつ', points: 30, icon: '🍪' }),
+				locals: makeLocals({ licenseStatus: 'active', plan: 'standard_monthly' }),
+			});
+
+			const arg = mockGrantSpecialReward.mock.calls[0]?.[0];
+			expect(arg.shopCategory).toBeNull();
+		});
+
+		it('shopCategory に不正値が来た場合は null に正規化する', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('standard');
+			mockGrantSpecialReward.mockResolvedValue({ id: 5, title: 'ふせい', points: 10 });
+
+			await grantAction({
+				request: makeFormRequest({
+					childId: 1,
+					title: 'ふせい',
+					points: 10,
+					icon: '🎁',
+					shopCategory: 'not-a-real-category',
+				}),
+				locals: makeLocals({ licenseStatus: 'active', plan: 'standard_monthly' }),
+			});
+
+			const arg = mockGrantSpecialReward.mock.calls[0]?.[0];
+			expect(arg.shopCategory).toBeNull();
+		});
 	});
 
 	describe('addPreset action', () => {

--- a/tests/unit/routes/shop-shop-category-priority.test.ts
+++ b/tests/unit/routes/shop-shop-category-priority.test.ts
@@ -1,0 +1,114 @@
+// tests/unit/routes/shop-shop-category-priority.test.ts
+// #3147: ごほうびショップ load の shopCategory 列優先 + null fallback 検証。
+//
+// 仕様:
+//   - special_rewards.shop_category 列に値があればそれを優先表示する
+//     (たとえ title/icon からの deriveShopCategory 推定と異なっても列値が勝つ)。
+//   - 列値が null (旧行/未指定) のときのみ deriveShopCategory(title/icon/description)
+//     に fallback する (後方互換)。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireTenantId = vi.fn();
+const mockGetBalance = vi.fn();
+const mockGetChildSpecialRewards = vi.fn();
+const mockGetRedemptionRequestsForChild = vi.fn();
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: mockRequireTenantId,
+}));
+vi.mock('$lib/server/db/point-repo', () => ({
+	getBalance: mockGetBalance,
+}));
+vi.mock('$lib/server/services/child-service', () => ({
+	getChildById: vi.fn(),
+}));
+vi.mock('$lib/server/services/reward-redemption-service', () => ({
+	getRedemptionRequestsForChild: mockGetRedemptionRequestsForChild,
+	requestRedemption: vi.fn(),
+}));
+vi.mock('$lib/server/services/special-reward-service', () => ({
+	getChildSpecialRewards: mockGetChildSpecialRewards,
+}));
+
+const mod = await import('../../../src/routes/(child)/[uiMode=uiMode]/shop/+page.server');
+const load = mod.load as unknown as (event: {
+	parent: () => Promise<{ child: { id: number } | null }>;
+	locals: App.Locals;
+}) => Promise<{ rewards: Array<{ id: number; shopCategory: string }> }>;
+
+function makeEvent(child: { id: number } | null) {
+	return {
+		parent: async () => ({ child }),
+		locals: {} as App.Locals,
+	};
+}
+
+describe('shop load — shopCategory 列優先 + fallback (#3147)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRequireTenantId.mockReturnValue('tenant-1');
+		mockGetBalance.mockResolvedValue(1000);
+		mockGetRedemptionRequestsForChild.mockResolvedValue([]);
+	});
+
+	it('shop_category 列値があれば deriveShopCategory 推定より列値を優先する', async () => {
+		// title「おこづかい」は deriveShopCategory なら money になるが、
+		// 列値 physical が明示されているため physical が勝つ。
+		mockGetChildSpecialRewards.mockResolvedValue({
+			rewards: [
+				{
+					id: 1,
+					title: 'おこづかい100円',
+					points: 100,
+					icon: '🪙',
+					description: null,
+					shopCategory: 'physical',
+				},
+			],
+			totalPoints: 0,
+		});
+
+		const result = await load(makeEvent({ id: 10 }));
+		expect(result.rewards[0]?.shopCategory).toBe('physical');
+	});
+
+	it('shop_category 列が null の旧行は title/icon から推定 fallback する', async () => {
+		// 列値 null → deriveShopCategory が「おこづかい」「円」「🪙」から money を推定。
+		mockGetChildSpecialRewards.mockResolvedValue({
+			rewards: [
+				{
+					id: 2,
+					title: 'おこづかい100円',
+					points: 100,
+					icon: '🪙',
+					description: null,
+					shopCategory: null,
+				},
+			],
+			totalPoints: 0,
+		});
+
+		const result = await load(makeEvent({ id: 10 }));
+		expect(result.rewards[0]?.shopCategory).toBe('money');
+	});
+
+	it('列値 privilege はそのまま表示される', async () => {
+		mockGetChildSpecialRewards.mockResolvedValue({
+			rewards: [
+				{
+					id: 3,
+					title: 'なぞのごほうび',
+					points: 50,
+					icon: '🎁',
+					description: null,
+					shopCategory: 'privilege',
+				},
+			],
+			totalPoints: 0,
+		});
+
+		const result = await load(makeEvent({ id: 10 }));
+		expect(result.rewards[0]?.shopCategory).toBe('privilege');
+	});
+});

--- a/tests/unit/services/reward-set-import-service.test.ts
+++ b/tests/unit/services/reward-set-import-service.test.ts
@@ -284,7 +284,31 @@ describe('importRewardSet', () => {
 				icon: '🏞️',
 				category: 'sports',
 				sourcePresetId: PRESET_ID,
+				// #3147: preset に shopCategory が無ければ null で round-trip (表示側 fallback)
+				shopCategory: null,
 			},
+			TENANT,
+		);
+	});
+
+	it('#3147: preset の shopCategory を insertSpecialReward に round-trip する', async () => {
+		const rewards = [
+			makeReward({
+				title: 'ゲーム30ぷん',
+				points: 50,
+				icon: '🎮',
+				category: 'other',
+				shopCategory: 'privilege',
+			}),
+		];
+
+		await importRewardSet(rewards, TENANT, {
+			presetId: PRESET_ID,
+			childId: CHILD_ID,
+		});
+
+		expect(mockInsertSpecialReward).toHaveBeenCalledWith(
+			expect.objectContaining({ shopCategory: 'privilege' }),
 			TENANT,
 		);
 	});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）+ 子供（ごほうびショップ利用者）

**解決する課題**: ごほうび登録時のカテゴリ（`RewardCategory` = うんどう/べんきょう/せいかつ/こうりゅう/そうぞう/とくべつ の 6 値）と、子供側ショップの陳列タブ（もの/おこづかい/とくべつ の 3 系統）が**無関係な別軸**であることが UI 上で不明瞭だった。従来は陳列系統を `deriveShopCategory()` の title/icon 推定だけで決めており、親が意図した並びにできず、推定ミスで「ゲーム30分」が「もの」タブに入る等のズレが起きていた。

**期待される効果**: 親が登録時に陳列タブ（もの/おこづかい/とくべつ）を明示選択できるようになり、子供のショップ表示が親の意図どおりになる。未選択（自動で振り分け）のときだけ従来の推定 fallback が働くため、既存ごほうび・既存挙動は一切壊れない（列優先 + null fallback の 2 段構え）。

## 関連 Issue

closes #3147

関連: #1336（ショップ 3 系統 SSOT）/ #2157（deriveShopCategory 派生機構）/ ADR-0031（schema 自動 ALTER）/ ADR-0055（per-child reward）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `special_rewards.shop_category`（nullable text）を 4 並行実装 + テスト基盤に追加 | `grep -n shop_category` schema.ts / create-tables.ts / test-db.ts / global-setup.ts | HEAD `252c0283` / schema.ts:`shopCategory: text('shop_category')` + create-tables.ts:`shop_category TEXT` + dynamodb/demo/sqlite repo insert round-trip + test-db.ts:315 / global-setup.ts ALTER ADD COLUMN |
| AC2 | 登録 UI で親が 3 系統を選択でき保存される（既定=自動振り分け→null）。`grantSpecialRewardSchema` に `shopCategory?` 追加 | `npx vitest run tests/unit/routes/admin-rewards-actions.test.ts` + SS | HEAD `252c0283` / 9 passed（privilege 受け渡し / 空→null / 不正値→null）/ admin/rewards/+page.svelte の `name="shopCategory"` セレクト（SS 参照） |
| AC3 | ショップ load は列値を優先し、null のとき `deriveShopCategory` に fallback（後方互換） | `npx vitest run tests/unit/routes/shop-shop-category-priority.test.ts` | HEAD `252c0283` / 3 passed（列値 physical が推定 money を上書き / null→money 推定 / privilege 透過）/ shop/+page.server.ts:`reward.shopCategory ?? deriveShopCategory(...)` |
| AC4 | marketplace reward-set schema / 取込 / 兄弟コピーで `shopCategory` を round-trip | `npx vitest run tests/unit/marketplace/schemas/reward-set-schema.test.ts` | HEAD `252c0283` / PASS / RewardSetItemSchema + RewardSetPayload に optional `shopCategory`、reward-set-import-service + child-reward-copy-service で round-trip |
| AC5 | 既存行の後方互換（backfill migration 不要、read-time fallback + 自動 ALTER で救済）+ ADR-0031 schema 互換 | `npx vitest run tests/unit/server tests/unit/db` | HEAD `252c0283` / 全 PASS / nullable 列のため `validateAndMigrate` が既存 DB に `ALTER TABLE ADD COLUMN` を自動適用（ADR-0031）。null 行は load 時に `deriveShopCategory` で救済するため explicit backfill は不要（恒久 fallback） |
| AC6 | unit（列優先/fallback + フォーム受け渡し）+ 既存回帰なし + 登録 UI の系統選択 SS | `npx vitest run tests/unit/{server,db,routes,marketplace,domain}` + SS | HEAD `252c0283` / 2330 passed / SS = 登録フォームの「ショップの並び（タブ）」セレクト（自動振り分け既定 + とくべつ選択状態、desktop/mobile） |
| AC7 | `06-UI設計書 §14.6` の「PMF 後に shop_category 列追加」記述を実装済に更新（ADR-0001） | `git diff docs/design/06-UI設計書.md` | HEAD `b406bba4` / §14.6 を「派生機構（暫定）」→「決定機構（列優先 + null fallback）」に改訂、決定順序 / 登録 UI / 永続化 / 検証を追記 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 親管理画面のごほうび管理（`/admin/rewards` 登録フォーム）、子供ごほうびショップ（`/(child)/[uiMode]/shop` 陳列タブ）、marketplace reward-set 取込、兄弟間ごほうびコピー

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3147` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/routes/shop-shop-category-priority.test.ts`（新規）: ショップ load の列優先 + null fallback を 3 ケースで検証
  - `tests/unit/routes/admin-rewards-actions.test.ts`（追加）: add action が shopCategory を addReward に受け渡す（valid/空→null/不正→null）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: SQLite + DynamoDB + demo の 3 repo に shopCategory round-trip を実装。`check-dynamodb-stub.mjs` は pre-ready で PASS
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:critical ではない）

## スクリーンショット / ビジュアルデモ

登録フォームに「ショップの並び（タブ）」セレクトを追加（新規フィールド）。下記は demo Lambda 同型 env（`AUTH_MODE=anonymous` + `DATA_SOURCE=demo`、`?plan=family&screenshot=all`）で本番ルート `/admin/rewards` を撮影。左上=ごほうび管理一覧、右上=登録ダイアログのフォーム（「ショップの並び（タブ）」= 既定「自動で振り分け」+ ヒント文）、下=「とくべつ（ゲーム時間・おでかけ）」を選択した状態。desktop + mobile 同梱。

### admin-rewards-shop-category-3147-flow
![admin-rewards-shop-category-3147-flow](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3147/admin-rewards-shop-category-3147-flow.webp)

**4 スロット表**: 本セレクトは新規追加フィールドのため「修正前」に同一フォーム内の対応要素が存在しない（追加のみ）。上記フローシートで「自動で振り分け（既定）」と「とくべつ（選択後）」の両状態 + desktop/mobile を提示し、修正後の挙動を担保する。

**インタラクティブ状態**: セレクトの既定値「自動で振り分け」（空値→server で null 正規化）と「とくべつ（privilege）」選択状態を上記フローシートで提示。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 陳列系統の SSOT（`SHOP_CATEGORIES`）を再利用し重複定義なし。登録カテゴリ軸と陳列軸を直交させ責務分離
- [x] **DRY**: `SHOP_CATEGORIES` / `deriveShopCategory` を既存 `shop-category.ts` から import、新規 namespace を作らない
- [x] **YAGNI**: 列は nullable のみ追加。backfill migration / age 係数等の不要拡張なし
- [x] **Security（OSS 公開前提）**: server action で `SHOP_CATEGORIES.includes` ホワイトリスト検証し不正値を null に正規化。秘密情報なし
- [x] **アクセシビリティ**: `FormField` + `NativeSelect` primitive 経由で label / hint を付与（直書き input なし）
- [x] **パフォーマンス**: 列 1 つ追加のみ。N+1 なし

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期（demo repo に shopCategory round-trip）
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [x] 全年齢モード 5 種に横展開（陳列タブは shop primitive 共通、年齢非依存）
- [ ] ナビゲーション 3 種に反映
- [x] E2E / ユニットシード + チュートリアルを同期（test-db.ts / global-setup.ts に列定義追加）
- [x] labels SSOT (ADR-0009)（`ADMIN_REWARDS_PAGE_LABELS.shopCategory*` 追加、`sync-lp-fallback --check` PASS）
- [x] 設計書同期 (ADR-0001)（06-UI設計書 §14.6）
- [x] 並行 PR overlap 確認 (#1200)（special_rewards 系の他 open PR なし）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**: nullable 列 + read-time fallback のため既存ごほうび（列 null）は従来どおり `deriveShopCategory` 推定で表示される。backfill を敢えてしない設計判断（恒久 fallback で現行データを救済し続ける）の妥当性をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3147` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DESIGN.md §9 禁忌 6 点を目視確認（hex 直書きなし / primitive 使用 / 内部コード非露出 / labels SSOT / インラインスタイルなし / style ブロック増なし）
- [x] 認証画面変更時: N/A（admin 画面は demo Lambda env で撮影、認証フォーム自体は不変）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
