### PR TITLE
fix: #3163 子供ごほうびショップ重複カードを backup/restore E2E の worker DB 汚染除去で根治

### DIFF
--- a/docs/design/parallel-implementations.md
+++ b/docs/design/parallel-implementations.md
@@ -379,6 +379,7 @@ grep -n "bottom-nav\|data-testid" src/lib/ui/components/BottomNav.svelte
 - 新しい reward-set を追加 → import-service テスト + E2E で itemId を網羅
 - 重複検知ロジック (`sameSourceTitles`) 変更 → unit テスト 3 件 (「同一 preset 同一 title」/「別 preset 同名」/「sourcePresetId=null 手動 reward」) で誤検知ガード
 - reward の即時付与（grant）と一括取込（import）の区別: 一括取込は **point 加算しない**（"候補登録"）。grant は `insertPointEntry` を呼ぶ
+- **backup/restore (#3079) の重複検知は preset lineage scope** (`source_preset_id='backup-restore:reward-set'` sentinel)。`source_preset_id=NULL` の手動作成 / seed 済 reward は初回 restore で「重複なし」と判定され**複製 INSERT される** (再 restore のみ idempotent)。E2E で restore を実行する spec は afterEach で sentinel 由来コピーを除去し共有 worker DB を seed 状態へ戻す (#3163、`admin-backup-restore.spec.ts`)。**reward 陳列 (child shop) × seed × backup/restore は worker DB を共有するため、行重複 = カード重複に直結する**（child shop は DB 行と 1:1 描画）
 
 #### 7e. marketplace challenge-set 一括追加 (#2297, EPIC #2294 ③ — #2896 で marketplace 陳列廃止)
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -265,6 +265,7 @@ CI 自動チェック (`scripts/check-schema-change-tests.mjs`、warn): `schema.
 - 全 4 年齢コアモード (preschool/elementary/junior/senior) のテストデータ必要
 - 活動記録の完全フロー (確認→記録→コンボ→スタンプ→レベルアップ→ホーム復帰) を検証
 - **worker DB 共有 spec が seed 済 setting を削除する場合、削除前 snapshot + afterAll で復元が必須** (#2851、`features.spec.ts` #0025 が `templates.length > 0` を要求する `reward_templates` を `setup-resume-path.spec.ts` が削除したまま終了し決定的 fail した教訓)。afterAll で「自分が追加した値」を消すだけでは seed 値が復元されず不十分。beforeAll で削除前の seed 値を `SELECT` で退避し、afterAll で `INSERT OR REPLACE` (snapshot 非 null) / `DELETE` (snapshot null) で元の seed 状態へ完全復元する
+- **worker DB 共有 spec が seed 済データを「追加複製」する場合も afterEach/afterAll で除去が必須** (#3163、`admin-backup-restore.spec.ts` が export → restore で seed 済 reward を複製 INSERT (restore dedup は `source_preset_id='backup-restore:reward-set'` sentinel scope のため seed の `source_preset_id=NULL` 行を重複検知できない) → 共有 worker DB に複製が残り、後続 `child-shop-exchange.spec.ts` が同一 reward の 2 枚目カードを検出して strict-mode violation で fail した教訓)。restore 等が INSERT した可識別行 (sentinel `source_preset_id` 等) を afterEach で `DELETE` し worker DB を seed 状態へ戻す。**reward / checklist の陳列・取込ロジックや seed 値を変えたら、共有 worker DB を汚染しないかを「同一 reward が複数カードになる」観点で点検する** (child shop は DB 行と 1:1 で描画するため、行が重複すればカードも重複する)
 
 ## プラン別 seed fixture（#759）
 

--- a/tests/e2e/admin-backup-restore.spec.ts
+++ b/tests/e2e/admin-backup-restore.spec.ts
@@ -14,7 +14,28 @@
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
+
+// #3163: reward restore は `source_preset_id` (= 'backup-restore:reward-set' sentinel) で
+// 二重取込を検知する (reward-set-import-service.ts / admin/rewards +page.server.ts:55)。
+// seed 済 reward は source_preset_id=NULL のため、export → restore の初回は「重複なし」と判定され
+// 全件が複製コピーとして INSERT される。これが共有 worker DB を汚染し、後続 spec
+// (child-shop-exchange) が同一 reward の 2 枚目カードを検出して strict-mode violation で fail していた
+// (tests/CLAUDE.md #2851「worker DB 共有 spec は変更を afterEach/afterAll で復元」違反)。
+// restore が作る sentinel 由来コピーを各テスト後に除去し、worker DB を seed 状態へ戻す。
+const RESTORE_REWARD_SET_PRESET_ID = 'backup-restore:reward-set';
+
+async function cleanupRestoredRewardCopies(workerDbPath: string): Promise<void> {
+	const { default: Database } = await import('better-sqlite3');
+	const db = new Database(workerDbPath);
+	try {
+		db.prepare('DELETE FROM special_rewards WHERE source_preset_id = ?').run(
+			RESTORE_REWARD_SET_PRESET_ID,
+		);
+	} finally {
+		db.close();
+	}
+}
 
 // download を一時ファイルに保存し、その絶対パスを返す。
 async function saveDownload(
@@ -41,6 +62,12 @@ async function openMenuItem(
 }
 
 test.describe('admin/rewards backup/restore (#3079)', () => {
+	// #3163: restore が INSERT した sentinel 由来コピーを除去し worker DB を seed 状態へ復元する。
+	// confirm を押す分岐 (空 child でない = 全件重複でない) では reward 複製が残るため必須。
+	test.afterEach(async ({ workerDbPath }) => {
+		await cleanupRestoredRewardCopies(workerDbPath);
+	});
+
 	test('export → restore round-trip で全件重複スキップを preview → 復元まで貫通', async ({
 		page,
 	}) => {

--- a/tests/e2e/child-shop-exchange.spec.ts
+++ b/tests/e2e/child-shop-exchange.spec.ts
@@ -183,6 +183,10 @@ test.describe('#1335: ごほうびショップ 交換フロー', () => {
 		const expensiveCard = page.locator('[data-testid^="reward-card-"]').filter({
 			hasText: 'E2Eテスト用ごほうび（交換不可）',
 		});
+		// #3163: 重複なし不変条件を明示。共有 worker DB が backup/restore 等で汚染され
+		// 同一 reward が 2 行になると本 assertion が「2」を報告して原因を即指摘する
+		// (toBeVisible 単体の strict-mode violation より診断的)。
+		await expect(expensiveCard).toHaveCount(1);
 		await expect(expensiveCard).toBeVisible();
 
 		// そのカード内の交換ボタンが disabled であることを確認
@@ -202,6 +206,8 @@ test.describe('#1335: ごほうびショップ 交換フロー', () => {
 		const affordableCard = page.locator('[data-testid^="reward-card-"]').filter({
 			hasText: 'E2Eテスト用ごほうび（交換可）',
 		});
+		// #3163: 交換可ごほうびも 1 枚のみ (worker DB 汚染で複製されていないこと) を保証
+		await expect(affordableCard).toHaveCount(1);
 		await expect(affordableCard).toBeVisible();
 
 		// 交換ボタン（enabled）をクリック


### PR DESCRIPTION
## 顧客価値・目的

子供のごほうび交換は core CUJ (tests/CLAUDE.md CUJ #3)。統合 PR #3162 の最重厚レーンで `child-shop-exchange.spec.ts:175` が strict-mode violation (「E2Eテスト用ごほうび（交換不可）」が 2 枚のカードに重複表示) で fail し、CUJ #3 (子供がごほうびを交換する) 全体が skip され未検証になっていた。本 PR は重複の真因を根治し、子供が混乱なくごほうびを交換できる状態を保証する。

## 関連 Issue

- closes #3163
- 連鎖元: #3079 (ごほうび backup/restore) / #3132 (交換不可 seed 99999→10000) / #1254 G1 (reward dedup = sourcePresetId scope)

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 根拠 |
|---|---|---|---|
| child shop で 1 ごほうびが 1 カードのみ表示 | restore 複製除去で worker DB を seed 状態へ復元 + child-shop-exchange に toHaveCount(1) 不変条件追加 | PASS | 下記「真因」実証 (6→3 行復元をローカル確認) |
| child-shop-exchange:175 以降が全 shard + a11y で green | restore 複製を afterEach 除去し汚染源を断つ | 統合 PR で実証 | develop 軽量レーンは e2e skip、次の統合 PR (release/* → main) で全 shard 実走 |
| 重複の真因を特定し追記 | importRewardSet を実 DB で実行し reward-card-3/4 の二重 INSERT を再現 | PASS | Issue #3163 に「なぜなぜ是正」コメント追記 |
| reward 陳列変更時の重複なし回帰テスト追加 | child-shop-exchange に toHaveCount(1) 明示 + tests/CLAUDE.md #2851 拡張 | PASS | 共有 worker DB 汚染を診断的に検出 |

## 変更タイプ

- [x] バグ修正 (fix) — E2E テスト hygiene による回帰根治
- [x] ドキュメント (docs) — tests/CLAUDE.md / parallel-implementations.md 整合

## 影響範囲・変更コンポーネント

- `tests/e2e/admin-backup-restore.spec.ts`: `./fixtures` import に変更し workerDbPath 取得。restore が INSERT した sentinel 由来コピー (`source_preset_id='backup-restore:reward-set'`) を afterEach で除去。
- `tests/e2e/child-shop-exchange.spec.ts`: 交換不可 / 交換可カードに `toHaveCount(1)` 不変条件を明示。
- `tests/CLAUDE.md` #2851: worker DB 共有 spec の「追加複製」除去ルールを拡張。
- `docs/design/parallel-implementations.md` §7d: restore sentinel dedup と「行重複=カード重複」整合点を明文化。
- **本番コード変更なし** (production の restore dedup 挙動は #1254 G1 の意図的設計で `reward-set-import-service.test.ts:128` で pin 済、これを尊重)。

## テスト & 安全装置セルフチェック

- importRewardSet を実 DB で実行し、seed 済 reward (source_preset_id=NULL) が restore で全件複製 INSERT され たろうくん の 交換不可 が #3(seed)+#4(copy) の 2 行になることを再現 (CI の reward-card-3/4 と完全一致)。
- 修正後の cleanup query (`DELETE ... WHERE source_preset_id='backup-restore:reward-set'`) で 6→3 行 (交換不可 2→1) の seed 復元を実証。
- biome check PASS (変更 spec 2 件)。
- assertion 弱体化なし: `toBeVisible` は維持し、より診断的な `toHaveCount(1)` を前置追加 (ADR-0006 整合、強化方向)。

## スクリーンショット / ビジュアルデモ

該当なし（`.svelte` / `.css` / `site/` 変更なし。本 PR は E2E spec + docs のみで pre-ready SS gate #2918 は非発火 (pre-ready.mjs:301)）。

## コード品質セルフレビュー (#1481)

- cleanup は restore 専用 sentinel (`source_preset_id`) のみ対象とし、seed 行 (NULL) や他 spec のデータに副作用なし。
- afterEach は rewards describe 内に限定 (checklist restore は name-scope dedup で idempotent、複製しないため対象外)。
- 不変条件 assertion は「同一 reward が複数カードになる」観点を明示し、将来の worker DB 汚染を早期検出。

## 横展開・影響波及チェック

- #3150 の shop_category 分離は本件と無関係 (重複は陳列ロジックでなく DB 行の二重) と確認。admin ごほうび一覧 / 交換履歴も同じ DB 行を読むため、汚染除去で同時に整合。
- reward 陳列 × child shop × seed × backup/restore が worker DB を共有する整合点を parallel-implementations.md §7d + tests/CLAUDE.md #2851 に明文化。
- 後続検討: #3079 backup/restore が `source_preset_id=NULL` の手動 / seed reward を初回 restore で複製する挙動は #1254 G1 の意図的 dedup scoping の帰結。ユーザーが自分のバックアップを復元すると既存 reward が二重化しうる点の product 妥当性は、本 blocker scope 外として PO 判断に委ねる。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。本番挙動・スキーマ不変。
- レビュー観点: cleanup の sentinel 対象が過不足ないか / 不変条件 assertion の配置。

## 配布済み env / secret (ADR-0006)

該当なし (新規 env / secret なし、hotfix label なし)。

## Ready for Review チェックリスト

- [x] 真因を実調査で特定 (仮説羅列でなく実 DB 再現)
- [x] 本番挙動を変えず E2E hygiene で根治 (意図的 dedup 設計を尊重)
- [x] 既存 assertion を弱体化せず強化 (toHaveCount 前置)
- [x] 設計書同期 (tests/CLAUDE.md / parallel-implementations.md)
- [x] biome PASS / 禁止語なし

## QM レビュー結果

(QM チーム記入欄)
