### PR TITLE
docs: #3165 #3166 設計書同期 — 08-DB shop_category/source_preset_id + 07-API parent-gate OTP endpoint (ADR-0001)

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -38,7 +38,7 @@
 
 | メソッド | パス | 概要 | 認証 |
 |----------|------|------|------|
-| POST | /api/v1/parent-gate/setup | 初回 PIN 設定（`{ pin }`、4 桁。未設定時のみ。設定済は 403 `ALREADY_CONFIGURED`） | cognito（tenant 一致） |
+| POST | /api/v1/parent-gate/setup | 初回 PIN 設定（`{ pin }`、4〜6 桁。未設定時のみ。設定済は 403 `ALREADY_CONFIGURED`） | cognito（tenant 一致） |
 | POST | /api/v1/parent-gate/verify | PIN 検証 → 親 session cookie 発行（`{ pin }`。不一致 401） | cognito（tenant 一致） |
 | POST | /api/v1/parent-gate/logout | 親 session cookie クリア | cognito |
 | POST | /api/v1/parent-gate/reset-request-code | **federated 専用**（#3070）。登録メール（`locals.identity.email`）へ 6 桁 OTP を送信し、署名 httpOnly cookie（`pin_reset_otp`、stateless）に格納。enumeration 防止のため送信成否に依らず常に `{ ok: true }`。code はログに残さない。非 federated / 非 cognito は 400 `NOT_SUPPORTED` | cognito（federated、tenant 一致） |

--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -32,6 +32,22 @@
 | GET | /auth/callback | Cognito OAuth コールバック | 不要 |
 | POST/GET | /auth/logout | ログアウト（Cookie クリア + リダイレクト） | 不要 |
 
+### 親ゲート（PIN）認証（#2310 / #3070）
+
+保護者専用画面（`/admin/*` / `/switch`）を子供から保護する PIN ゲート。session は `cookie-signature` 署名 httpOnly cookie（ADR-0050）。PIN reset は本人確認方式を識別タイプで分岐する: **password ユーザは再認証 password**、**federated（Google）ユーザは登録メールへの 6 桁 email-OTP**（#3070、子はメールを読めないため silent SSO 通過の穴を塞ぐ）。
+
+| メソッド | パス | 概要 | 認証 |
+|----------|------|------|------|
+| POST | /api/v1/parent-gate/setup | 初回 PIN 設定（`{ pin }`、4 桁。未設定時のみ。設定済は 403 `ALREADY_CONFIGURED`） | cognito（tenant 一致） |
+| POST | /api/v1/parent-gate/verify | PIN 検証 → 親 session cookie 発行（`{ pin }`。不一致 401） | cognito（tenant 一致） |
+| POST | /api/v1/parent-gate/logout | 親 session cookie クリア | cognito |
+| POST | /api/v1/parent-gate/reset-request-code | **federated 専用**（#3070）。登録メール（`locals.identity.email`）へ 6 桁 OTP を送信し、署名 httpOnly cookie（`pin_reset_otp`、stateless）に格納。enumeration 防止のため送信成否に依らず常に `{ ok: true }`。code はログに残さない。非 federated / 非 cognito は 400 `NOT_SUPPORTED` | cognito（federated、tenant 一致） |
+| POST | /api/v1/parent-gate/reset-verified | PIN reset 実行 + 本人確認（`{ newPin, password?, code? }`）。federated は `code`（OTP cookie 照合）、password ユーザは `password`（アカウント再認証）で検証 → `setupPin` で再設定 → 親 session 発行。`newPin` 不正は 400 `PIN_FORMAT` | cognito（tenant 一致） |
+
+- **email-OTP フロー（federated）**: `reset-request-code`（OTP 発行 → メール送信 + `pin_reset_otp` 署名 cookie set）→ `reset-verified`（`{ newPin, code }` で cookie 照合）。OTP 形式は `^\d{6}$`。
+- **レートリミット**: `reset-request-code` / `reset-verified` とも IP 単位 **5 回 / 15 分**（超過 429 `RATE_LIMITED`）。brute force 防止。
+- **対象外**: local / anonymous モード（local の PIN 救済は operator reset #2994）。
+
 ### 子供関連
 
 | メソッド | パス | 概要 | 認証 |

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1360,6 +1360,8 @@ Stripe at-least-once delivery 仕様 + CLI `stripe events resend` で同一 even
 | category | TEXT | NO | - | 報酬カテゴリ |
 | granted_at | TEXT | NO | CURRENT_TIMESTAMP | 付与日時 |
 | shown_at | TEXT | YES | NULL | 子供に表示済みの日時 |
+| source_preset_id | TEXT | YES | NULL | マーケットプレイスプリセット由来の識別子（#1254 G1、import 時の重複検知に利用） |
+| shop_category | TEXT | YES | NULL | ショップ陳列系統（`physical` / `money` / `privilege`、#3147 / #3150）。**登録カテゴリ（`category` 列）とは直交する別軸**。親が登録時に明示選択した値を優先し、NULL（旧行 / 未選択）のときのみ `deriveShopCategory(title/icon/description)` で推定 fallback（後方互換）。既存 DB は `validateAndMigrate` が `ALTER TABLE ADD COLUMN` を自動適用（backfill 不要、ADR-0031） |
 
 **インデックス:** (child_id, granted_at)
 

--- a/src/lib/domain/shop-category.ts
+++ b/src/lib/domain/shop-category.ts
@@ -8,12 +8,11 @@
 // 背景:
 // - `special_rewards.category` は `RewardCategory` (academic/sports/social/creative/life/other)
 //   であり、UI 上の 3 系統 (実物/お小遣い/特権) とは独立した分類軸。
-// - preset 段階では `shopCategory` を持つが、DB 保存時に落ちる (#1336 残課題)。
-// - DB schema 拡張は Pre-PMF コストが高いため (ADR-0010)、reward の title / icon /
-//   description から決定的ルールで `ShopCategory` を派生して UI フィルタに用いる。
-//
-// 将来 (PMF 後) `special_rewards.shop_category` 列を追加し migration で
-// 既存 reward を本ヒューリスティックで埋めれば、本ファイルは「型再エクスポート」のみに縮退する。
+// - `special_rewards.shop_category` 列は #3150 で追加済 (schema.ts / create-tables.ts)。
+//   preset / 取込時に `shopCategory` が永続化される。
+// - `deriveShopCategory()` は列が null の場合 (列追加前の legacy 行 / 未指定 reward) の
+//   fallback として用いる。呼び出し側は `reward.shopCategory ?? deriveShopCategory(...)` で
+//   「保存値優先・無ければ title / icon / description から決定的ルールで派生」を実現する。
 
 import type { ShopCategory } from '$lib/data/preset-rewards';
 


### PR DESCRIPTION
## 顧客価値・目的

実装と設計書の乖離 (ADR-0001 設計書 SSOT 違反) は将来の改修者を誤誘導し、特に認証系 endpoint の欠落は security レビュー時の見落としリスクになる。統合 PR #3162 の 8 領域監査 (docs-SSOT チーム) で検出した 2 件の設計書欠落を同期し、設計書を実装の正しい SSOT に戻す。

## 関連 Issue

- closes #3165 (08-DB に ごほうび shop_category 未記載)
- closes #3166 (07-API に parent-gate OTP endpoint 未掲載)
- 実装元: #3147 / #3150 (shop_category) / #3092 / #3070 (parent-gate email-OTP)

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 根拠 |
|---|---|---|---|
| 08-DB に shop_category (型/null/分離意図/fallback) を追記 | special_rewards 表に行追加 | PASS | 08-DB special_rewards 表 |
| shop_category を使う他テーブル/列を併記 | 他テーブルに shop_category なしを確認、同テーブル未記載の source_preset_id を同時補完 | PASS | schema.ts grep で special_rewards のみと確認 |
| 07-API に parent-gate OTP endpoint (path/method/req-res/認証/rate-limit) を追記 | 親ゲート認証サブセクション新設 | PASS | 07-API 認証セクション |
| email-OTP フロー (request-code → verify) の endpoint 関係を明記 | フロー注記追加 | PASS | 同上 |

## 変更タイプ

- [x] ドキュメント (docs) — ADR-0001 設計書同期

## 影響範囲・変更コンポーネント

- `docs/design/08-データベース設計書.md`: special_rewards 表に `shop_category` + `source_preset_id` を追記。
- `docs/design/07-API設計書.md`: 「親ゲート（PIN）認証」サブセクション新設 (setup/verify/logout + OTP 2 endpoint)。
- **本番コード変更なし**。

## テスト & 安全装置セルフチェック

- 記載値は schema.ts (`shopCategory: text('shop_category')` / `sourcePresetId: text('source_preset_id')`) と endpoint handler (`reset-request-code` / `reset-verified` の RATE_LIMIT_MAX=5 / WINDOW=15分、OTP_PATTERN=`^\d{6}$`、federated 分岐) を物理確認して転記。
- doc-code-references baseline 内 (新規違反 0)。

## スクリーンショット / ビジュアルデモ

該当なし (docs のみ、`.svelte`/`.css`/`site/` 変更なし、pre-ready SS gate 非発火)。

## コード品質セルフレビュー (#1481)

- shop_category は「登録カテゴリと直交する陳列系統」「列優先 + NULL fallback」を明記し category 列との混同を防止。
- OTP endpoint は password vs federated 分岐 / enumeration 防止 / rate-limit / 対象外 (local/anonymous) を網羅し security レビュー時の判断材料を提供。

## 横展開・影響波及チェック

- 監査同種の docs 乖離 (#3135 / #3108) と同根 (スキーマ/API 変更 → 設計書同期が人手依存)。設計書同期の機械強制は #3152 (fitness function EPIC) で扱う候補。
- 08-DB の special_rewards で同時に未記載だった source_preset_id (#1254 G1) も補完し、同一テーブルの ADR-0001 gap を残さない。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。記載内容が実装と一致するかの確認のみ。

## 配布済み env / secret (ADR-0006)

該当なし。

## Ready for Review チェックリスト

- [x] 記載値を実装 (schema.ts / endpoint handler) から物理転記
- [x] 同一テーブルの既知 gap (source_preset_id) も同時補完
- [x] doc-code-references 新規違反 0
- [x] 本番コード変更なし

## QM レビュー結果

(QM チーム記入欄)
