### PR TITLE
infra: #3164 admin 正準 guard の母数を実 route FS 走査で導出 — 新規画面の登録漏れ silent pass を封殺

### DIFF
--- a/src/lib/features/admin/admin-resource-model-registry.ts
+++ b/src/lib/features/admin/admin-resource-model-registry.ts
@@ -237,3 +237,67 @@ export const ALL_ADMIN_RESOURCE_PAGES = [
 	'challenges',
 	'rules',
 ] as const;
+
+/**
+ * #3164: `ALL_ADMIN_RESOURCE_PAGES` (手管理 literal) の網羅性を **実 route FS から導出**するための
+ * 分類 SSOT。#3134 の no-silent-gap guard は 3 定数の整合は assert するが、母数自体が手管理 literal の
+ * ため「真に新規の admin 画面を literal 未更新で追加すると silent pass」する blind spot があった
+ * (#3134 root の部分達成、#3152 fitness function 機械強制の最初の具体適用先)。
+ *
+ * `tests/unit/features/admin-resource-model-registry.test.ts` が `src/routes/(parent)/admin/` 直下の
+ * `+page.*` を持つ全 route dir を FS 走査し、各 dir が **resource page (key へ map) か non-resource page
+ * (明示除外) のいずれか**で必ず説明されることを assert する。未分類の dir (= 新規 admin 画面の登録漏れ)
+ * があれば fail する = 母数が SSOT (実 route FS) から導出される。
+ */
+
+/**
+ * admin 直下の route dir 名 → §10 正準契約の resource key への map。
+ * resource-list 管理画面 (AdminResourceHeader / child-tabs を持つ §10 対象) のみを列挙する。
+ * value は `ADMIN_RESOURCE_MODEL_REGISTRY` (正準) か `NON_CANONICAL_ADMIN_RESOURCES` (明示除外) の key。
+ *
+ * 注: `rules` (とくべつルール) は `/admin/settings/rules` の **settings サブページ**で admin 直下 dir では
+ * ないため本 map には現れない (NON_CANONICAL_ADMIN_RESOURCES には引き続き存在)。
+ */
+export const ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY = {
+	activities: 'activity',
+	rewards: 'reward',
+	checklists: 'checklist',
+	challenges: 'challenges',
+} as const;
+
+/**
+ * admin 直下の route dir のうち、§10「admin リソース管理画面」(resource-list) **ではない** page。
+ * FS 走査の母数を全 admin page で説明するための明示除外 (silent gap を作らない)。新規に admin 直下 page を
+ * 追加したら、resource-list なら `ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY` + registry/除外へ、そうでなければ
+ * 本リストへ reason 付きで登録する (どちらにも無いと FS 走査 test が fail する)。
+ */
+export const NON_RESOURCE_ADMIN_PAGE_ROUTES = {
+	billing: { reason: '課金・プラン管理画面 (resource-list ではない)' },
+	certificates: { reason: '表彰状の発行・閲覧画面 (resource-list ではない)' },
+	cheer: { reason: 'おうえんメッセージ送信画面 (resource-list ではない)' },
+	children: { reason: 'お子さま登録・編集画面 (resource-list ではない)' },
+	'growth-book': { reason: '成長記録 (グロースブック) 閲覧画面 (resource-list ではない)' },
+	members: { reason: '家族メンバー管理画面 (resource-list ではない)' },
+	packs: { reason: 'バックアップ/エクスポート (パック) 画面 (resource-list ではない)' },
+	points: { reason: 'ポイント調整・履歴画面 (resource-list ではない)' },
+	reports: { reason: 'レポート閲覧画面 (resource-list ではない)' },
+	settings: {
+		reason: '設定 (サブページ集約)。配下の rules は NON_CANONICAL_ADMIN_RESOURCES で別途説明',
+	},
+	status: { reason: 'ステータス閲覧画面 (resource-list ではない)' },
+	subscription: { reason: 'サブスクリプション管理画面 (resource-list ではない)' },
+} as const;
+
+/**
+ * admin 直下の route dir 1 件を分類する純関数 (#3164)。FS 走査 test が各 dir に対して呼ぶ。
+ * - `'resource'` — §10 resource-list 管理画面 (`ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY` に存在)
+ * - `'non-resource'` — resource-list ではない admin page (`NON_RESOURCE_ADMIN_PAGE_ROUTES` に存在)
+ * - `'unclassified'` — どちらにも無い = 新規画面の登録漏れ (guard が fail させる対象)
+ */
+export function classifyAdminPageRoute(
+	routeDir: string,
+): 'resource' | 'non-resource' | 'unclassified' {
+	if (routeDir in ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY) return 'resource';
+	if (routeDir in NON_RESOURCE_ADMIN_PAGE_ROUTES) return 'non-resource';
+	return 'unclassified';
+}

--- a/tests/unit/features/admin-resource-model-registry.test.ts
+++ b/tests/unit/features/admin-resource-model-registry.test.ts
@@ -3,12 +3,40 @@
 // DESIGN.md §10 の全 admin リソース管理画面が、正準 registry か明示除外リストの
 // いずれかで必ず説明されること (= 契約が自身の網羅漏れを silent に見逃さない) を保証する。
 
+import { existsSync, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
 	ADMIN_RESOURCE_MODEL_REGISTRY,
+	ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY,
 	ALL_ADMIN_RESOURCE_PAGES,
+	classifyAdminPageRoute,
 	NON_CANONICAL_ADMIN_RESOURCES,
+	NON_RESOURCE_ADMIN_PAGE_ROUTES,
 } from '../../../src/lib/features/admin/admin-resource-model-registry';
+
+// #3164: admin route の実 FS から「admin 直下で +page.* を持つ route dir」を導出する。
+// 母数を手管理 literal でなく実 route に固定することで、新規 admin 画面の登録漏れを silent pass させない。
+const ADMIN_ROUTES_DIR = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	'../../../src/routes/(parent)/admin',
+);
+
+function discoverAdminPageRoutes(): string[] {
+	if (!existsSync(ADMIN_ROUTES_DIR)) {
+		throw new Error(`admin routes dir not found: ${ADMIN_ROUTES_DIR}`);
+	}
+	return readdirSync(ADMIN_ROUTES_DIR, { withFileTypes: true })
+		.filter((e) => e.isDirectory())
+		.filter((e) =>
+			['+page.svelte', '+page.server.ts', '+page.ts'].some((f) =>
+				existsSync(resolve(ADMIN_ROUTES_DIR, e.name, f)),
+			),
+		)
+		.map((e) => e.name)
+		.sort();
+}
 
 describe('#3134 admin リソース正準契約の網羅性 (no silent gap)', () => {
 	const registryKeys = Object.keys(ADMIN_RESOURCE_MODEL_REGISTRY);
@@ -44,5 +72,56 @@ describe('#3134 admin リソース正準契約の網羅性 (no silent gap)', () 
 		const accounted = [...registryKeys, ...nonCanonicalKeys].sort();
 		const known = [...ALL_ADMIN_RESOURCE_PAGES].sort();
 		expect(accounted).toEqual(known);
+	});
+});
+
+describe('#3164 母数を実 route FS から導出する (literal 未更新の silent pass を封殺)', () => {
+	const discovered = discoverAdminPageRoutes();
+
+	it('admin 直下の page route が実在し空でない (FS 走査が機能している sanity)', () => {
+		expect(discovered.length).toBeGreaterThan(0);
+		// 既知の代表 route が含まれること (走査ロジックが壊れていない確認)
+		expect(discovered).toContain('activities');
+		expect(discovered).toContain('settings');
+	});
+
+	it('実在する全 admin page route が resource / non-resource のいずれかで説明される (unclassified 0)', () => {
+		const unclassified = discovered.filter((r) => classifyAdminPageRoute(r) === 'unclassified');
+		expect(
+			unclassified,
+			`admin 直下の page route ${JSON.stringify(unclassified)} が ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY ` +
+				'にも NON_RESOURCE_ADMIN_PAGE_ROUTES にも無い (新規画面の登録漏れ = fitness function blind spot)。' +
+				'resource-list 管理画面なら ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY + registry/除外へ、そうでなければ ' +
+				'NON_RESOURCE_ADMIN_PAGE_ROUTES へ reason 付きで登録する',
+		).toEqual([]);
+	});
+
+	it('分類定数が実 FS と過不足なく一致する (stale エントリ / 走査漏れの双方向検出)', () => {
+		const classified = [
+			...Object.keys(ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY),
+			...Object.keys(NON_RESOURCE_ADMIN_PAGE_ROUTES),
+		].sort();
+		expect(classified).toEqual(discovered);
+	});
+
+	it('resource page route の map 先 key が registry か明示除外に存在する (#3134 整合)', () => {
+		const accounted = new Set([
+			...Object.keys(ADMIN_RESOURCE_MODEL_REGISTRY),
+			...Object.keys(NON_CANONICAL_ADMIN_RESOURCES),
+		]);
+		for (const [route, key] of Object.entries(ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY)) {
+			expect(
+				accounted.has(key),
+				`resource route "${route}" の map 先 key "${key}" が registry にも除外にも無い`,
+			).toBe(true);
+		}
+	});
+
+	it('未知の admin route は unclassified に分類される (新規登録漏れを guard が fail させる固定)', () => {
+		// 実在しない仮の新規画面名 → どの分類定数にも無いので unclassified。
+		// これにより「新規 admin 画面を登録せず追加 → FS 走査 test が fail」を unit で固定する (AC2)。
+		expect(classifyAdminPageRoute('badges-not-registered-yet')).toBe('unclassified');
+		expect(classifyAdminPageRoute('activities')).toBe('resource');
+		expect(classifyAdminPageRoute('settings')).toBe('non-resource');
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

admin 正準契約の fitness function (#3134/#3141) が「新規 admin 画面を REGISTRY 未登録で追加しても silent pass する」blind spot を持っていた。これは #3134 が防ぎたかった当のもの (契約自身の網羅漏れ) であり、品質基盤の網羅性を毀損する。母数を実 route FS から導出し、登録漏れを CI で必ず fail させることで、admin リソース管理画面の DESIGN.md §10 正準構成ドリフトを機械強制で検出する。

## 関連 Issue

- closes #3164
- 前段: #3134 / #3141 (no-silent-gap guard) / 上位 EPIC #3152 (fitness function 機械強制) の最初の具体適用先

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 根拠 |
|---|---|---|---|
| guard の検査母数を FS 走査 (SSOT 導出) にし REGISTRY 未登録の admin 画面を検出 fail | test が `src/routes/(parent)/admin/` 直下の `+page.*` route dir を FS 走査し分類定数と双方向一致を assert | PASS | 「分類定数が実 FS と過不足なく一致する」test |
| 新規 admin 画面を REGISTRY 未登録で追加 → guard が fail することをテストで固定 | `classifyAdminPageRoute('未知名') === 'unclassified'` + FS 一致 test で実 dir 検出 | PASS | 「未知の admin route は unclassified」test |
| challenges/rules の明示除外は #3141 の意図を維持 | NON_CANONICAL_ADMIN_RESOURCES / 既存 #3134 guard 4 test を不変で維持 | PASS | 既存 test 4 件 + challenges を resource map→NON_CANONICAL key で接続 |

## 変更タイプ

- [x] 品質基盤 (infra) — fitness function 母数の SSOT 化

## 影響範囲・変更コンポーネント

- `src/lib/features/admin/admin-resource-model-registry.ts`: `ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY` (dir→key map) / `NON_RESOURCE_ADMIN_PAGE_ROUTES` (12 件の非 resource page を reason 付き明示除外) / `classifyAdminPageRoute()` 純関数を追加 (export 追加のみ、既存 export 不変)。
- `tests/unit/features/admin-resource-model-registry.test.ts`: FS 走査で全 admin page route を導出し分類網羅性を assert する 5 test を追加 (既存 4 test は不変)。
- **本番挙動・スキーマ・既存 export 不変**。

## テスト & 安全装置セルフチェック

- 16 admin 直下 page route を実分類: resource 4 (activities/rewards/checklists/challenges) + non-resource 12。AdminResourceHeader / child-tabs 使用箇所を grep で物理確認して分類。
- `npx vitest run tests/unit/features/admin-resource-model-registry.test.ts` → 9/9 PASS。
- assertion 弱体化なし (検出力を増す方向の追加)。

## スクリーンショット / ビジュアルデモ

該当なし (`.svelte`/`.css`/`site/` 変更なし、test + 内部定数のみ。pre-ready SS gate 非発火)。

## コード品質セルフレビュー (#1481)

- 分類を純関数 `classifyAdminPageRoute` に切り出し unit で固定 (FS 非依存の決定的 test)。
- FS 走査と分類定数の **双方向一致** (走査漏れ + stale エントリ 両方) を検出。
- `rules` は settings サブページのため admin 直下 FS 走査の母数外であることをコメントで明示 (NON_CANONICAL には引き続き存在)。

## 横展開・影響波及チェック

- e2e `admin-resource-layout-contract.spec.ts` / `admin-add-path-isomorphism.spec.ts` は registry の既存 export を参照 (本 PR は追加のみ) のため影響なし。
- 新規 admin 直下 page を追加する開発者は resource なら map + registry/除外、非 resource なら NON_RESOURCE へ reason 付き登録が必須になる (未登録は CI fail)。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。観点: 12 件の非 resource page 分類の妥当性 / FS 走査パスの Windows/CI 両対応 (paren group dir)。

## 配布済み env / secret (ADR-0006)

該当なし。

## Ready for Review チェックリスト

- [x] 母数を実 route FS から導出 (手管理 literal の silent pass を封殺)
- [x] 新規未登録画面 → fail を純関数 + FS 一致 test で固定
- [x] challenges/rules の明示除外と既存 #3134 guard を不変で維持
- [x] 9/9 unit PASS / biome PASS / 既存 export 不変

## QM レビュー結果

(QM チーム記入欄)
