### PR TITLE
test: #3153 roundtrip invariants — activity domain⊆schema 独立 oracle 化 + dead assertion 除去

### DIFF
--- a/tests/unit/marketplace/export-import-roundtrip-invariants.test.ts
+++ b/tests/unit/marketplace/export-import-roundtrip-invariants.test.ts
@@ -16,6 +16,7 @@
 
 import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
+import { createActivitySchema } from '$lib/domain/validation/activity';
 import { ActivityPackItemSchema } from '$lib/marketplace/schemas/activity-pack-schema';
 import { ChallengeSetItemSchema } from '$lib/marketplace/schemas/challenge-set-schema';
 import { ChecklistItemSchema } from '$lib/marketplace/schemas/checklist-schema';
@@ -75,9 +76,28 @@ describe('#3143 export/import round-trip 不変条件 (4 type)', () => {
 			expect(ok(ActivityPackItemSchema, activityItem({ basePoints: 10000 }))).toBe(true);
 			expect(ok(ActivityPackItemSchema, activityItem({ basePoints: 10001 }))).toBe(false);
 		});
-		it('activity-pack の domain 上限 (basePoints 100) は export schema を必ず通る (domain ⊆ schema)', () => {
-			// domain validation (activity.ts: basePoints.max(100)) が許容する最大値が export schema を通る。
+		it('activity domain ⊆ export schema: 実 domain validator を oracle に値域整合を cross-assert (#3153)', () => {
+			// #3153: 旧 test は basePoints=100 を hardcode し domain validator を import していなかったため、
+			// domain max が export schema max を超えて drift しても緑のままだった (#3132 class を catch できない)。
+			// 実 domain validator (createActivitySchema) を独立 oracle として import し、
+			// 「domain が受理する値は export schema も受理」「export schema の上限超過値は domain も拒否」を assert する。
+			const domainActivity = (basePoints: number) => ({
+				name: 'からだをうごかす',
+				categoryId: 1,
+				icon: '🏃',
+				basePoints,
+				ageMin: null,
+				ageMax: null,
+			});
+			// domain validator の境界を実 validator で確認 (hardcode でなく validator が boundary を決める)。
+			expect(createActivitySchema.safeParse(domainActivity(100)).success).toBe(true);
+			expect(createActivitySchema.safeParse(domainActivity(101)).success).toBe(false);
+			// domain が受理する最大値 (100) は export schema を必ず通る (domain ⊆ schema)。
 			expect(ok(ActivityPackItemSchema, activityItem({ basePoints: 100 }))).toBe(true);
+			// 値域整合の drift guard: export schema 上限超過 (10001) を domain validator も拒否する。
+			// domain max が export schema max (10000) を超えて drift すると domain が 10001 を受理 → 本 assert が落ち、
+			// #3132 と同 class (domain 値域 ⊄ export schema 値域) の再混入を CI で検出する。
+			expect(createActivitySchema.safeParse(domainActivity(10001)).success).toBe(false);
 		});
 		it('checklist order は 0 以上整数 (負値拒否)', () => {
 			expect(ok(ChecklistItemSchema, checklistItem({ order: 0 }))).toBe(true);
@@ -109,13 +129,16 @@ describe('#3143 export/import round-trip 不変条件 (4 type)', () => {
 			['reward-set', RewardSetItemSchema, () => rewardItem({ title: 'おかし🍪パーティー' })],
 		];
 		for (const [name, schema, make] of cases) {
-			it(`${name}: 非 ASCII (日本語/絵文字) item が valid + JSON.stringify→parse で同値`, () => {
+			it(`${name}: 非 ASCII (日本語/絵文字) item が JSON シリアライズ往復後も schema を通る`, () => {
 				const item = make();
 				expect(ok(schema, item)).toBe(true);
-				// JSON シリアライズ往復で非 ASCII が壊れない (export = JSON body の round-trip 整合)
-				const roundTripped = JSON.parse(JSON.stringify(item));
-				expect(roundTripped).toEqual(item);
-				expect(ok(schema, roundTripped)).toBe(true);
+				// #3153: 旧 test の `JSON.parse(JSON.stringify(item)).toEqual(item)` は plain object で常に成立する
+				// dead assertion だったため除去。export body は JSON 文字列として送受信されるため、JSON 往復後の
+				// 「文字列値」を再 parse して schema を通ること (= 非 ASCII が JSON serialize で壊れない) を有効検証する。
+				const serialized = JSON.stringify(item);
+				// 非 ASCII が JSON 文字列にエスケープ落ちせず保持される (mojibake/欠落の検出)。
+				expect(serialized).toContain(String((item as Record<string, unknown>).icon ?? ''));
+				expect(ok(schema, JSON.parse(serialized))).toBe(true);
 			});
 		}
 	});


### PR DESCRIPTION
## 顧客価値・目的

**対象**: 開発チーム（テスト実効性）。PR #3149 (#3143) の export/import round-trip 不変条件テストの実効性を高め、#3132 class（domain 値域 ⊄ export schema 値域 → round-trip 破綻）の再混入を develop 軽量レーンで確実に捕捉する。QM adversarial が指摘した非 blocking 強化点（priority:low）を消化。

## 関連 Issue

- closes #3153
- 強化対象: #3143 (#3149 merged) / 一次 #3132 class

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 根拠 |
|---|---|---|---|
| domain⊆schema test の独立 oracle 化（実 domain max を import） | `createActivitySchema` を import し domain⊆schema + over-limit 拒否を cross-assert | PASS | activity domain⊆schema test（11 PASS） |
| dead assertion（③ JSON round-trip toEqual）除去 | plain object で常に成立する toEqual を除去し有効検証に置換 | PASS | ③ 非 ASCII test |
| challenge/checklist の同型確認 | 独立 domain validator（数値 max）を持たず bound=export schema 単一ソースのため drift 構造上不可と確認 | PASS（対象外確定） | challenge-set/checklist schema |

## 変更タイプ

- [x] テスト改善 (test)

## 影響範囲・変更コンポーネント

- `tests/unit/marketplace/export-import-roundtrip-invariants.test.ts`: activity の domain⊆schema を `createActivitySchema` を oracle に置換（hardcode 100 除去）、③ の dead JSON toEqual を有効検証に置換。
- **本番コード不変**（test のみ）。

## テスト & 安全装置セルフチェック

- 重量 e2e 敏感領域（#3173）= export/import schema 値域整合の (d) safeguard 自体の強化。schema/domain/seed は変更せず、guard test の実効性のみ向上（behavior 変更なし → 重量 e2e 回帰なし）。
- 11/11 PASS / biome `--error-on-warnings` PASS。
- assertion 弱体化なし（dead assert を有効 assert に置換 = 強化。新規 drift guard 追加）。

## スクリーンショット / ビジュアルデモ

該当なし（test のみ。pre-ready SS gate 非発火）。

## コード品質セルフレビュー (#1481)

- 実 domain validator を独立 oracle にすることで「domain max が export schema max を超える drift」を機械検出（#3132 直系の class guard）。
- challenge/checklist は独立 domain validator を持たない事実を明記し、無いものを捏造しない（honest scope）。

## 横展開・影響波及チェック

- reward の domain⊆schema は `reward-set-roundtrip-domain.test.ts` で既に guard 済（本 file は重複しない）。
- activity の domain validator（`createActivitySchema`）を直接参照したため、domain max 変更時に本 test が追従検出する。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。観点: oracle 化の妥当性 / challenge/checklist 対象外判断。

## 配布済み env / secret (ADR-0006)

該当なし。

## Ready for Review チェックリスト

- [x] 実 domain validator を import し hardcode を除去（#3132 drift guard 強化）
- [x] dead assertion を有効検証に置換（弱体化でなく強化）
- [x] challenge/checklist の対象外を honest に確定
- [x] 11/11 PASS / biome PASS / 本番コード不変

## QM レビュー結果

(QM チーム記入欄)
