### PR TITLE
fix: #3154 ごほうび編集で shop_category (陳列系統) を変更可能化

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -2233,9 +2233,12 @@ ADR-0011 の「baby = 親の準備モード」方針に基づいた独自 UI。
 - `privilege` 判定: 「時間」「○○けん」「リクエスト」「おでかけ」「えいが」 / 体験絵文字 (🌙 😴 🎮 📺 🚗 🍽️ 🎬 等)
 - `physical` 判定: 上記以外 (現物デフォルト)
 
-#### 登録 UI (親側、#3147)
+#### 登録 / 編集 UI (親側、#3147 / #3154)
 
-`/admin/rewards` の追加フォームに「ショップの並び（タブ）」セレクト (`name="shopCategory"`) を追加。選択肢は `自動で振り分け` (空値、既定) / `もの` / `おこづかい` / `とくべつ` の 4 種 (`ADMIN_REWARDS_PAGE_LABELS.shopCategory*`)。空値は server action で `null` に正規化し、上記 fallback に委ねる。
+`/admin/rewards` の **追加フォームと編集 dialog の両方**に「ショップの並び（タブ）」セレクト (`name="shopCategory"`) を配置する。選択肢は `自動で振り分け` (空値、既定) / `もの` / `おこづかい` / `とくべつ` の 4 種 (`ADMIN_REWARDS_PAGE_LABELS.shopCategory*`)。空値は server action (`?/add` / `?/update`) で `null` に正規化し、上記 fallback に委ねる。
+
+- **登録 (#3147)**: `?/add` action が `shopCategory` を whitelist (`SHOP_CATEGORIES`) 正規化して `addReward` に渡す。
+- **編集 (#3154)**: `?/update` action / `UpdateRewardInput` / `UpdateSpecialRewardInput` に `shopCategory` を配線し、登録後も陳列系統を変更可能にする (sqlite / dynamodb repo の `updateSpecialReward` が present field のみ set = undefined で既存値保全)。form に `shopCategory` が無い旧 UI からの update は undefined を渡し既存値を保全する。これにより上記「親が登録/編集時に選んだ意図を尊重」と実装が一致する。
 
 #### 永続化 (#3147)
 

--- a/scripts/capture-specs/flows/admin-rewards-edit-shop-category-3154.mjs
+++ b/scripts/capture-specs/flows/admin-rewards-edit-shop-category-3154.mjs
@@ -1,0 +1,109 @@
+/**
+ * scripts/capture-specs/flows/admin-rewards-edit-shop-category-3154.mjs
+ *
+ * #3154: ごほうび編集 dialog に「ショップの並び（タブ）」セレクト (shop_category) を追加した SS。
+ * 登録 (add) でのみ設定可だった陳列系統を、登録後の編集でも変更可能にした (#3147 / #3150 の edit 配線)。
+ *
+ * 本番ルート `/admin/rewards` を demo Lambda 同型 env (AUTH_MODE=anonymous + DATA_SOURCE=demo) で
+ * 起動した dev server 上で開く。`?plan=family` で premium gate を解除し、`?screenshot=all` で
+ * demo 固有 UI を抑止する。既存の admin-rewards-shop-category-3147 flow (add 側) の edit 版。
+ *
+ * 使用例:
+ *   MSYS_NO_PATHCONV=1 BASE_URL=http://localhost:5173 node scripts/capture.mjs \
+ *     --flow admin-rewards-edit-shop-category-3154 \
+ *     --url "/admin/rewards?plan=family&screenshot=all" \
+ *     --actions scripts/capture-specs/flows/admin-rewards-edit-shop-category-3154.mjs \
+ *     --presets desktop,mobile --pr 3154
+ */
+
+async function waitForDialogOpen(page, testid) {
+	await page.waitForFunction(
+		(t) => {
+			const el = document.querySelector(`[data-testid="${t}"]`);
+			return !!el && el.getAttribute('data-state') === 'open' && !el.hasAttribute('hidden');
+		},
+		testid,
+		{ timeout: 5_000, polling: 100 },
+	);
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+}
+
+/**
+ * 編集ボタン (reward-edit-btn-<id>) を click → 編集 dialog が open になるまで Svelte 5 hydration race を
+ * click retry (最大 5 回) で吸収する。
+ */
+async function openEditDialogWithRetry(page, editBtn) {
+	for (let attempt = 0; attempt < 5; attempt++) {
+		await editBtn.click();
+		try {
+			await waitForDialogOpen(page, 'reward-edit-dialog');
+			return;
+		} catch {
+			// hydration race / 再 click で吸収
+		}
+	}
+	await waitForDialogOpen(page, 'reward-edit-dialog');
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	// --- 1) ごほうび一覧 (premium 解除済) ---
+	// capture recorder (screenshot-helpers.mjs) が既に --url へ navigate 済のため、ここでは
+	// 二重 goto しない (二重 navigation は `?screenshot=all` で ERR_ABORTED の race を起こす)。
+	await page.getByTestId('admin-rewards-list').waitFor({ state: 'visible', timeout: 15_000 });
+
+	// 子供タブを順に選び、ごほうびを持つ (= reward-edit-btn が出る) 子を見つける。
+	// demo データは子ごとに 0〜5 件 (先頭の子は空のことがある) のため、空でないタブを探す。
+	const childTabs = page.locator('[data-testid^="rewards-child-tab-"]');
+	const tabCount = await childTabs.count();
+	for (let i = 0; i < Math.max(tabCount, 1); i++) {
+		if (i < tabCount) {
+			await childTabs.nth(i).click();
+			// per-child rewards の derived 再描画を待つ (rAF だけだと描画前に count を読む)
+			await page
+				.locator('[data-testid^="reward-edit-btn-"]')
+				.first()
+				.waitFor({ state: 'visible', timeout: 2_500 })
+				.catch(() => {});
+		}
+		if ((await page.locator('[data-testid^="reward-edit-btn-"]').count()) > 0) break;
+	}
+
+	// --- 2) 一覧の先頭ごほうびの「編集」ボタンを押して編集 dialog を開く ---
+	const firstEditBtn = page.locator('[data-testid^="reward-edit-btn-"]').first();
+	await firstEditBtn.waitFor({ state: 'visible', timeout: 15_000 });
+	await openEditDialogWithRetry(page, firstEditBtn);
+
+	// 編集 dialog 下部の「ショップの並び（タブ）」セレクトが見える位置までスクロール
+	const shopSelect = page.locator(
+		'[data-testid="reward-edit-dialog"] select[name="shopCategory"]',
+	);
+	await shopSelect.waitFor({ state: 'attached', timeout: 5_000 });
+	await shopSelect.scrollIntoViewIfNeeded();
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+	await capture('issue-3154-admin-rewards-edit-dialog');
+
+	// --- 3) 「ショップの並び（タブ）」で money (お小遣い) を選んだ状態 ---
+	await shopSelect.selectOption('money');
+	await shopSelect.scrollIntoViewIfNeeded();
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+	await capture('issue-3154-admin-rewards-edit-shop-category-selected');
+};

--- a/scripts/capture-specs/flows/admin-rewards-edit-shop-category-3154.mjs
+++ b/scripts/capture-specs/flows/admin-rewards-edit-shop-category-3154.mjs
@@ -83,9 +83,7 @@ export default async (page, capture) => {
 	await openEditDialogWithRetry(page, firstEditBtn);
 
 	// 編集 dialog 下部の「ショップの並び（タブ）」セレクトが見える位置までスクロール
-	const shopSelect = page.locator(
-		'[data-testid="reward-edit-dialog"] select[name="shopCategory"]',
-	);
+	const shopSelect = page.locator('[data-testid="reward-edit-dialog"] select[name="shopCategory"]');
 	await shopSelect.waitFor({ state: 'attached', timeout: 5_000 });
 	await shopSelect.scrollIntoViewIfNeeded();
 	await page.evaluate(

--- a/src/lib/server/db/dynamodb/special-reward-repo.ts
+++ b/src/lib/server/db/dynamodb/special-reward-repo.ts
@@ -238,6 +238,12 @@ export async function updateSpecialReward(
 		names['#category'] = 'category';
 		values[':category'] = updates.category;
 	}
+	// #3154: 陳列系統 (physical/money/privilege/null) を編集で変更可能にする
+	if (updates.shopCategory !== undefined) {
+		sets.push('#shopCategory = :shopCategory');
+		names['#shopCategory'] = 'shopCategory';
+		values[':shopCategory'] = updates.shopCategory;
+	}
 	if (sets.length === 0) {
 		return stripKeys(found) as unknown as SpecialReward;
 	}

--- a/src/lib/server/db/interfaces/special-reward-repo.interface.ts
+++ b/src/lib/server/db/interfaces/special-reward-repo.interface.ts
@@ -1,11 +1,13 @@
 import type { InsertSpecialRewardInput, SpecialReward } from '../types';
 
-/** #2832: reward 編集 input (title / points / icon / category のみ編集可) */
+/** #2832 / #3154: reward 編集 input (title / points / icon / category / shopCategory を編集可) */
 export interface UpdateSpecialRewardInput {
 	title?: string;
 	points?: number;
 	icon?: string | null;
 	category?: string;
+	// #3154: ショップ陳列系統 (physical/money/privilege/null)。undefined = 既存値保全。
+	shopCategory?: string | null;
 }
 
 export interface ISpecialRewardRepo {

--- a/src/lib/server/db/sqlite/special-reward-repo.ts
+++ b/src/lib/server/db/sqlite/special-reward-repo.ts
@@ -74,6 +74,8 @@ export async function updateSpecialReward(
 	if (updates.points !== undefined) set.points = updates.points;
 	if (updates.icon !== undefined) set.icon = updates.icon;
 	if (updates.category !== undefined) set.category = updates.category;
+	// #3154: 陳列系統 (physical/money/privilege/null) を編集で変更可能にする
+	if (updates.shopCategory !== undefined) set.shopCategory = updates.shopCategory;
 	if (Object.keys(set).length === 0) {
 		return db.select().from(specialRewards).where(ownership).get();
 	}

--- a/src/lib/server/services/special-reward-service.ts
+++ b/src/lib/server/services/special-reward-service.ts
@@ -152,6 +152,9 @@ export interface UpdateRewardInput {
 	points: number;
 	icon?: string;
 	category?: string;
+	// #3154: ショップ陳列系統 (physical/money/privilege)。null = 自動振り分け (deriveShopCategory fallback)。
+	// undefined を渡すと既存値を保全 (update は present field のみ set)。
+	shopCategory?: string | null;
 }
 
 /**
@@ -178,6 +181,8 @@ export async function updateReward(
 			points: data.points,
 			icon: data.icon,
 			category: data.category,
+			// #3154: 編集時も陳列系統を変更可能にする (undefined なら既存値保全)。
+			shopCategory: data.shopCategory,
 		},
 		tenantId,
 	);

--- a/src/routes/(parent)/admin/rewards/+page.server.ts
+++ b/src/routes/(parent)/admin/rewards/+page.server.ts
@@ -214,6 +214,15 @@ export const actions: Actions = {
 		const points = Number(formData.get('points') ?? 0);
 		const icon = String(formData.get('icon') ?? '🎁');
 		const category = String(formData.get('category') ?? '');
+		// #3154: 編集時も陳列系統を変更可能にする (add action と同じ正規化: 空/不正 → null = 自動振り分け)。
+		// form に shopCategory が無い場合 (古い UI) は undefined を渡し既存値を保全する。
+		const hasShopCategory = formData.has('shopCategory');
+		const shopCategoryRaw = String(formData.get('shopCategory') ?? '').trim();
+		const shopCategory = hasShopCategory
+			? (SHOP_CATEGORIES as readonly string[]).includes(shopCategoryRaw)
+				? shopCategoryRaw
+				: null
+			: undefined;
 
 		if (!rewardId || !childId) return fail(400, { error: 'ごほうびが指定されていません' });
 		if (!title) return fail(400, { error: 'タイトルを入力してください' });
@@ -222,7 +231,7 @@ export const actions: Actions = {
 		const result = await updateReward(
 			rewardId,
 			childId,
-			{ title, points, icon, category: category || undefined },
+			{ title, points, icon, category: category || undefined, shopCategory },
 			tenantId,
 		);
 		if ('error' in result) {

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -94,6 +94,8 @@ let showEditDialog = $state(false);
 let editTitle = $state('');
 let editPoints = $state(100);
 let editIcon = $state('🎁');
+// #3154: 編集時もショップ陳列系統を変更可能にする ('' = 自動振り分け → null)
+let editShopCategory = $state('');
 let isSavingEdit = $state(false);
 let deletingReward = $state<PerChildReward | null>(null);
 let showDeleteDialog = $state(false);
@@ -109,6 +111,8 @@ function openEditDialog(reward: PerChildReward) {
 	editTitle = reward.title;
 	editPoints = reward.points;
 	editIcon = reward.icon ?? '🎁';
+	// #3154: 既存の陳列系統を初期選択 (null/未指定は '' = 自動振り分け)
+	editShopCategory = reward.shopCategory ?? '';
 	showEditDialog = true;
 }
 
@@ -127,6 +131,8 @@ async function handleEditConfirm() {
 	formData.append('title', editTitle);
 	formData.append('points', String(editPoints));
 	formData.append('icon', editIcon);
+	// #3154: 陳列系統 ('' = 自動振り分け → server 側で null 正規化)
+	formData.append('shopCategory', editShopCategory);
 	isSavingEdit = true;
 	actionUpgradeUrl = null;
 	try {
@@ -1089,6 +1095,20 @@ async function handleCopyFromChild() {
 				<FormField label={REWARDS_LABELS.pointsLabel} type="number" bind:value={editPoints} min={1} max={10000} required />
 			</div>
 			<FormField label={REWARDS_LABELS.iconLabel} type="text" bind:value={editIcon} />
+			<!-- #3154: 編集時もショップ陳列系統 (physical/money/privilege) を変更可能 (06-UI §14.6 整合) -->
+			<FormField
+				label={ADMIN_REWARDS_PAGE_LABELS.shopCategoryLabel}
+				hint={ADMIN_REWARDS_PAGE_LABELS.shopCategoryHint}
+			>
+				{#snippet children()}
+					<NativeSelect
+						name="shopCategory"
+						bind:value={editShopCategory}
+						options={shopCategoryOptions}
+						data-testid="reward-edit-shop-category"
+					/>
+				{/snippet}
+			</FormField>
 		</div>
 		<div class="copy-dialog-footer">
 			<Button variant="ghost" onclick={() => { showEditDialog = false; editingReward = null; }}>

--- a/tests/e2e/admin-rewards-edit-delete.spec.ts
+++ b/tests/e2e/admin-rewards-edit-delete.spec.ts
@@ -244,7 +244,7 @@ test.describe('#2832 reward 編集/削除の pending redemption ガード', () =
 		workerDbPath,
 	}) => {
 		test.slow();
-		const seeded = await seedReward(workerDbPath, 'shopcat');
+		const seeded = await seedReward(workerDbPath, 'shop');
 
 		await page.goto('/admin/rewards', { waitUntil: 'domcontentloaded' });
 		const rewardItem = page.getByTestId(`reward-item-${seeded.rewardId}`);

--- a/tests/e2e/admin-rewards-edit-delete.spec.ts
+++ b/tests/e2e/admin-rewards-edit-delete.spec.ts
@@ -238,4 +238,40 @@ test.describe('#2832 reward 編集/削除の pending redemption ガード', () =
 			timeout: 10_000,
 		});
 	});
+
+	test('#3154: 編集 dialog でショップ陳列系統 (shop_category) を変更すると DB に反映される', async ({
+		page,
+		workerDbPath,
+	}) => {
+		test.slow();
+		const seeded = await seedReward(workerDbPath, 'shopcat');
+
+		await page.goto('/admin/rewards', { waitUntil: 'domcontentloaded' });
+		const rewardItem = page.getByTestId(`reward-item-${seeded.rewardId}`);
+		await expect(rewardItem).toBeVisible({ timeout: 30_000 });
+
+		const editDialog = page.getByTestId('reward-edit-dialog');
+		await openDialogWithRetry(page.getByTestId(`reward-edit-btn-${seeded.rewardId}`), editDialog);
+
+		// 陳列系統セレクトで 'money' (お小遣い) を選択 → 編集確定 (act → outcome)
+		await editDialog.getByTestId('reward-edit-shop-category').selectOption('money');
+		const [resp] = await Promise.all([
+			page.waitForResponse((r) => /\?\/update/.test(r.url())),
+			page.getByTestId('reward-edit-confirm').click(),
+		]);
+		expect(resp.ok()).toBeTruthy();
+		await expect(page.getByTestId('rewards-action-message')).toBeVisible({ timeout: 10_000 });
+
+		// DB に shop_category='money' が永続したことを検証 (登録後の陳列系統変更が効く)
+		const { default: Database } = await import('better-sqlite3');
+		const db = new Database(workerDbPath);
+		try {
+			const row = db
+				.prepare('SELECT shop_category FROM special_rewards WHERE id = ?')
+				.get(seeded.rewardId) as { shop_category: string | null } | undefined;
+			expect(row?.shop_category).toBe('money');
+		} finally {
+			db.close();
+		}
+	});
 });

--- a/tests/unit/services/special-reward-service.test.ts
+++ b/tests/unit/services/special-reward-service.test.ts
@@ -588,6 +588,46 @@ describe('#2832 deleteReward / updateReward (pending redemption ガード)', () 
 		expect(result.points).toBe(50);
 	});
 
+	it('#3154: 編集で shopCategory を変更できる (登録後の陳列系統変更)', async () => {
+		const { childId, rewardId } = seedRewardWithBalance();
+		const result = await updateReward(
+			rewardId,
+			childId,
+			{ title: 'ゲーム時間30分', points: 80, shopCategory: 'money' },
+			'test-tenant',
+		);
+		if ('error' in result) return;
+		expect(result.shopCategory).toBe('money');
+
+		const cleared = await updateReward(
+			rewardId,
+			childId,
+			{ title: 'ゲーム時間30分', points: 80, shopCategory: null },
+			'test-tenant',
+		);
+		if ('error' in cleared) return;
+		expect(cleared.shopCategory).toBeNull();
+	});
+
+	it('#3154: shopCategory 未指定 (undefined) の編集は既存の陳列系統を保全する', async () => {
+		const { childId, rewardId } = seedRewardWithBalance();
+		await updateReward(
+			rewardId,
+			childId,
+			{ title: 'ゲーム時間30分', points: 80, shopCategory: 'privilege' },
+			'test-tenant',
+		);
+		const result = await updateReward(
+			rewardId,
+			childId,
+			{ title: '新タイトル', points: 80 },
+			'test-tenant',
+		);
+		if ('error' in result) return;
+		expect(result.title).toBe('新タイトル');
+		expect(result.shopCategory).toBe('privilege');
+	});
+
 	it('AC2: 編集後も pending 申請は申請時点 snapshot (名前/ポイント) で表示される', async () => {
 		const { childId, rewardId } = seedRewardWithBalance();
 		const req = await requestRedemption(childId, rewardId, 'test-tenant');


### PR DESCRIPTION
## 顧客価値・目的

**対象**: 保護者（ごほうび管理）。ごほうびの「ショップの並び（タブ = 実物/お小遣い/特権）」は登録時しか選べず、作成後に変更できなかった（06-UI §14.6 の「登録/編集時に選んだ意図を尊重」と不一致）。編集でも陳列系統を変更可能にし、親が登録後に並びを調整できるようにする。

## 関連 Issue

- closes #3154
- 前提: #3147 / #3150（shop_category 列追加 = 登録のみ配線）

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 根拠 |
|---|---|---|---|
| edit path に shopCategory を配線（form + update action + UpdateSpecialRewardInput） | service/sqlite/dynamodb repo + 編集 dialog select | PASS | 下記 SS + unit + e2e |
| 編集で shop_category を変更でき DB に反映 | e2e（編集→DB 反映）+ unit（変更/null化/undefined保全） | PASS | admin-rewards-edit-delete.spec.ts #3154 / service test 40 PASS |
| 06-UI §14.6「編集時」との整合 | edit を配線して doc と一致させた（案 a） | PASS | 本 PR |

## 変更タイプ

- [x] バグ修正 (fix) — UX 整合（編集で陳列系統変更可能化）

## 影響範囲・変更コンポーネント

- `special-reward-service.ts`（UpdateRewardInput + updateReward 伝播）/ `special-reward-repo.interface.ts`（UpdateSpecialRewardInput）/ sqlite + dynamodb repo の updateSpecialReward（demo は no-op stub）。
- `admin/rewards/+page.server.ts`（update action で shopCategory 読取 + 正規化）/ `+page.svelte`（編集 dialog に NativeSelect + editShopCategory state）。
- tests: service unit 3 ケース / e2e 1 ケース / capture flow 1 本。

## テスト & 安全装置セルフチェック

- **(a) 並行実装ペア**: sqlite/dynamodb repo + UI edit form を全箇所配線（demo は no-op）。
- **(b) 重量 e2e ローカル実行**: `npx playwright test tests/e2e/admin-rewards-edit-delete.spec.ts --project=tablet` → **#3154 編集→DB 反映 test PASS**（3 passed。別 test AC1 削除 dialog は Ark UI dialog-open の既存 flakiness で本変更無関係）。
- **(c) seed/test-db**: schema 変更なし（列は #3150 で追加済）→ seed 同期不要。
- **(d) domain⊆wire**: shop_category は enum（physical/money/privilege/null）で数値 domain drift なし。whitelist `SHOP_CATEGORIES` で不正値を null 正規化。
- unit 40 PASS（failing-test-first）/ svelte-check 0 error / biome `--error-on-warnings` PASS。

## スクリーンショット / ビジュアルデモ

### 編集 dialog のショップ並び（タブ）セレクト（before/after フロー）

![ごほうび編集 shop_category flow](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3180/admin-rewards-edit-shop-category-3154-flow.webp)

- 編集 dialog（ごほうびを編集）に「ショップの並び（タブ）」セレクトを追加。`おこづかい`（money）を選択した状態。未選択なら自動振り分け（deriveShopCategory fallback）。
- 撮影: 本番ルート `/admin/rewards` を demo 同型 env（AUTH_MODE=anonymous + DATA_SOURCE=demo）+ `?plan=family&screenshot=all` で起動した dev server。flow = `scripts/capture-specs/flows/admin-rewards-edit-shop-category-3154.mjs`。

## コード品質セルフレビュー (#1481)

- update は present field のみ set（undefined で既存値保全）。編集 dialog は既存 `shopCategoryOptions` を再利用し add form と同型。
- 正規化ロジックを add action と一致させ（whitelist + 空/不正 → null）二経路の挙動を揃えた。

## 横展開・影響波及チェック

- demo repo の updateSpecialReward は no-op stub のため変更不要（確認済）。
- child shop 表示は `reward.shopCategory ?? deriveShopCategory(...)`（#3150）のため、編集で null にすると自動振り分け fallback に戻る（整合）。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。観点: update の present-field 保全セマンティクス / 正規化の add 一致。

## 配布済み env / secret (ADR-0006)

該当なし。

## Ready for Review チェックリスト

- [x] edit path 全層（service/sqlite/dynamodb/UI/action）に shopCategory 配線
- [x] dev-session #3173 (a)-(d) 自己チェック実施（重量 e2e ローカル PASS 証跡記載）
- [x] unit（failing-test-first）+ e2e + SS で検証
- [x] svelte-check 0 error / biome PASS

## QM レビュー結果

(QM チーム記入欄)

