### PR TITLE
fix: #3148 admin ホーム承認待ち件数の取得失敗を silent 非表示にしない

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -428,6 +428,7 @@ setup 完了後の子供画面初回遷移時に 1 回だけ表示する dialog 
 - **表示条件**: 承認待ち件数 > 0 のときのみ表示 (`{#if bannerCount > 0}`)。0 件のときは描画しない
 - **内容**: warning 色のバナー (`--color-surface-warning` / `--color-border-warning` / `--color-text-warm`)。`/admin/rewards/requests` へ遷移する `<a>`。文言は `ADMIN_HOME_LABELS.pendingRedemptionBanner(count)` (用語 SSOT、`REWARD_TERMS.canonical` 経由)。`data-testid="redemption-pending-banner"`
 - **件数取得**: `+page.server.ts` の load が `countPendingRedemptionsForParent(tenantId)` を呼び `pendingRedemptionCount` を供給する (件数は承認待ち全件を数え 50 件以上でも飽和しない、`reward-redemption-service` 参照)
+- **取得失敗時 (#3148)**: load は失敗を `pendingRedemptionCountFailed` フラグで区別する (`{ count: 0, failed: true }` を返す)。件数 0 でも failed=true なら **error 色のバナー** (`--color-surface-error` / `--color-feedback-error-border` / `--color-feedback-error-text`、⚠️ + `ADMIN_HOME_LABELS.pendingRedemptionLoadFailed` + `/admin/rewards/requests` 導線、`data-testid="redemption-pending-banner-error"`) を表示し、**true-0 (承認待ちなし) と failure-0 (取得障害) を区別**する。これにより DB/Scan 障害時に承認待ちが silent 非表示になって親が見落とすのを防ぐ (`?screenshot=all` 時は failure 状態を描画しない)
 - **screenshot モード**: `?screenshot=all` 時は代表件数 `Math.max(count, 2)` で強制描画し LP SS 撮影を可能にする (`MilestoneBanner` の `bypassSeenCheck` と同型の正規パターン、[src/routes/CLAUDE.md](../../src/routes/CLAUDE.md) §?screenshot)
 - **Anti-engagement (ADR-0012)**: 子供の滞在時間を延ばす engagement フックではなく、**親の未処理タスク (承認待ち) の発見性導線**であるため ADR-0012 非抵触。子供の engagement バッジ (#2109 撤廃) とは目的が異なる
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4252,6 +4252,8 @@ export const ADMIN_HOME_LABELS = {
 	// #3144: ごほうび交換の承認待ち導線バナー (pending > 0 のときのみ表示)
 	pendingRedemptionBanner: (count: number) =>
 		`${REWARD_TERMS.canonical}の交換申請が ${count} 件 承認待ちです。確認して受け渡しましょう`,
+	// #3148: 承認待ち件数の取得に失敗したときの導線 (silent 非表示で見落とすのを防ぐ)
+	pendingRedemptionLoadFailed: `${REWARD_TERMS.canonical}の承認待ち件数を取得できませんでした。交換申請の確認ページを開いてください`,
 	heading: '管理ダッシュボード',
 	headingDemoSuffix: '（デモ）',
 	onboardingCompleteText: 'すべてのセットアップが完了しました！',

--- a/src/lib/features/admin/components/RedemptionPendingBanner.stories.svelte
+++ b/src/lib/features/admin/components/RedemptionPendingBanner.stories.svelte
@@ -1,0 +1,42 @@
+<script module>
+import { defineMeta } from '@storybook/addon-svelte-csf';
+import { expect, within } from 'storybook/test';
+import { ADMIN_HOME_LABELS } from '$lib/domain/labels';
+import RedemptionPendingBanner from './RedemptionPendingBanner.svelte';
+
+// #3144 / #3148: admin ホームの承認待ち導線バナー。
+// - Pending: pending > 0 の発見性バナー (warning semantic token、件数表示)。
+// - Error: 件数取得失敗時の導線 (error semantic token、true-0 と failure-0 を区別)。
+// 表示文言は ADMIN_HOME_LABELS (REWARD_TERMS atom 経由) を参照し直書きしない。
+const { Story } = defineMeta({
+	title: 'Admin/RedemptionPendingBanner',
+	component: RedemptionPendingBanner,
+	tags: ['autodocs'],
+});
+</script>
+
+<!-- 承認待ちあり (pending > 0)。warning semantic token + 件数 + 確認ページ導線。 -->
+<Story
+	name="Pending"
+	args={{ variant: 'pending', count: 3 }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const banner = canvas.getByTestId('redemption-pending-banner');
+		await expect(banner).toBeVisible();
+		await expect(banner).toHaveAttribute('href', '/admin/rewards/requests');
+		await expect(banner).toHaveTextContent(ADMIN_HOME_LABELS.pendingRedemptionBanner(3));
+	}}
+/>
+
+<!-- #3148: 件数取得失敗 (failure-0)。error semantic token + 確認ページ導線で silent 非表示を回避。 -->
+<Story
+	name="Error"
+	args={{ variant: 'error' }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const banner = canvas.getByTestId('redemption-pending-banner-error');
+		await expect(banner).toBeVisible();
+		await expect(banner).toHaveAttribute('href', '/admin/rewards/requests');
+		await expect(banner).toHaveTextContent(ADMIN_HOME_LABELS.pendingRedemptionLoadFailed);
+	}}
+/>

--- a/src/lib/features/admin/components/RedemptionPendingBanner.svelte
+++ b/src/lib/features/admin/components/RedemptionPendingBanner.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+import { ADMIN_HOME_LABELS } from '$lib/domain/labels';
+
+// #3144 / #3148: ごほうび交換の承認待ち導線バナー。
+// - variant='pending': pending > 0 の発見性バナー (件数を表示)。
+// - variant='error': 件数取得失敗時の導線 (true-0 と failure-0 を区別し silent 非表示を避ける)。
+// 表示判定 (件数 > 0 / failed) は呼び出し側 (admin/+page.svelte) が担い、本コンポーネントは
+// 渡された variant に応じた markup を描画する presentational component。
+interface Props {
+	variant: 'pending' | 'error';
+	/** variant='pending' のときの承認待ち件数 */
+	count?: number;
+}
+
+let { variant, count = 0 }: Props = $props();
+</script>
+
+{#if variant === 'pending'}
+	<a class="redemption-pending-banner" href="/admin/rewards/requests" data-testid="redemption-pending-banner">
+		<span class="redemption-pending-banner__icon" aria-hidden="true">🎁</span>
+		<span class="redemption-pending-banner__text">{ADMIN_HOME_LABELS.pendingRedemptionBanner(count)}</span>
+		<span class="redemption-pending-banner__cta" aria-hidden="true">▶</span>
+	</a>
+{:else}
+	<a class="redemption-pending-banner redemption-pending-banner--error" href="/admin/rewards/requests" data-testid="redemption-pending-banner-error">
+		<span class="redemption-pending-banner__icon" aria-hidden="true">⚠️</span>
+		<span class="redemption-pending-banner__text">{ADMIN_HOME_LABELS.pendingRedemptionLoadFailed}</span>
+		<span class="redemption-pending-banner__cta" aria-hidden="true">▶</span>
+	</a>
+{/if}
+
+<style>
+	.redemption-pending-banner {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin-bottom: 16px;
+		padding: 0.875rem 1rem;
+		border: 1px solid var(--color-border-warning);
+		border-radius: 0.75rem;
+		background: var(--color-surface-warning);
+		color: var(--color-text-warm);
+		text-decoration: none;
+		font-weight: 600;
+	}
+	.redemption-pending-banner:hover {
+		background: var(--color-feedback-warning-bg-strong);
+	}
+	/* #3148: error variant for count-load failure (error semantic tokens, not warning) */
+	.redemption-pending-banner--error {
+		border-color: var(--color-feedback-error-border);
+		background: var(--color-surface-error);
+		color: var(--color-feedback-error-text);
+	}
+	.redemption-pending-banner--error:hover {
+		background: var(--color-feedback-error-bg-strong);
+	}
+	.redemption-pending-banner__icon {
+		font-size: 1.25rem;
+	}
+	.redemption-pending-banner__text {
+		flex: 1;
+		min-width: 0;
+	}
+	.redemption-pending-banner__cta {
+		color: var(--color-text-warm-muted);
+	}
+</style>

--- a/src/routes/(parent)/admin/+page.server.ts
+++ b/src/routes/(parent)/admin/+page.server.ts
@@ -133,14 +133,19 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 	const parentData = await parent();
 	const tier = parentData.planTier;
 
-	const [children, onboarding, pendingRedemptionCount] = await Promise.all([
+	const [children, onboarding, pendingRedemption] = await Promise.all([
 		getAllChildren(tenantId),
 		getOnboardingProgress(tenantId, '/admin'),
-		// #3144: ごほうび交換の承認待ち件数 (admin ホームの発見性バナー用)。失敗時は 0。
-		countPendingRedemptionsForParent(tenantId).catch((e) => {
-			logger.warn('[admin] 承認待ち件数取得フォールバック', { context: { error: String(e) } });
-			return 0;
-		}),
+		// #3144 / #3148: ごほうび交換の承認待ち件数 (admin ホームの発見性バナー用)。
+		// #3148: 取得失敗時に { count: 0 } を返すと「true-0 (承認待ちなし)」と「failure-0 (取得障害)」が
+		// 区別できず、障害時にバナーが恒久的に非表示になって親が承認待ちに気づかない (#3144 の目的を毀損)。
+		// failed フラグを返して UI で「件数取得に失敗」状態を出せるようにする。
+		countPendingRedemptionsForParent(tenantId)
+			.then((count) => ({ count, failed: false }))
+			.catch((e) => {
+				logger.warn('[admin] 承認待ち件数取得フォールバック', { context: { error: String(e) } });
+				return { count: 0, failed: true };
+			}),
 	]);
 
 	const now = new Date();
@@ -176,7 +181,9 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 		weeklyUsage,
 		valuePreview,
 		// #3144: ごほうび交換の承認待ち件数 (admin ホームの発見性バナー)
-		pendingRedemptionCount,
+		pendingRedemptionCount: pendingRedemption.count,
+		// #3148: 件数取得が失敗したか (true なら UI で「取得失敗」状態を出し silent 非表示を避ける)
+		pendingRedemptionCountFailed: pendingRedemption.failed,
 	};
 };
 

--- a/src/routes/(parent)/admin/+page.svelte
+++ b/src/routes/(parent)/admin/+page.svelte
@@ -14,6 +14,9 @@ const isScreenshotAll = $derived(getScreenshotModeKind() === 'all');
 const bannerCount = $derived(
 	isScreenshotAll ? Math.max(pendingRedemptionCount, 2) : pendingRedemptionCount,
 );
+// #3148: 承認待ち件数の取得が失敗したか。true なら「取得失敗」導線を出し、障害時に承認待ちを
+// silent 非表示にしない (true-0 と failure-0 を区別)。screenshot 撮影時は failure 状態を描画しない。
+const pendingCountFailed = $derived(!isScreenshotAll && data.pendingRedemptionCountFailed === true);
 
 // ADR-0048 Phase B-1 (#2097): demo Lambda (AUTH_MODE=anonymous) では
 // `(parent)/admin/+page.svelte` も isDemo=true として描画される。
@@ -30,6 +33,14 @@ const adminMode = $derived<'live' | 'demo'>(page.data.isDemo ? 'demo' : 'live');
 	<a class="redemption-pending-banner" href="/admin/rewards/requests" data-testid="redemption-pending-banner">
 		<span class="redemption-pending-banner__icon" aria-hidden="true">🎁</span>
 		<span class="redemption-pending-banner__text">{ADMIN_HOME_LABELS.pendingRedemptionBanner(bannerCount)}</span>
+		<span class="redemption-pending-banner__cta" aria-hidden="true">▶</span>
+	</a>
+{:else if pendingCountFailed}
+	<!-- #3148: 件数取得失敗時は silent 非表示にせず、承認待ち確認ページへの導線を出す
+	     (true-0 = 承認待ちなし と failure-0 = 取得障害 を区別し、親が承認待ちを見落とさない)。 -->
+	<a class="redemption-pending-banner redemption-pending-banner--error" href="/admin/rewards/requests" data-testid="redemption-pending-banner-error">
+		<span class="redemption-pending-banner__icon" aria-hidden="true">⚠️</span>
+		<span class="redemption-pending-banner__text">{ADMIN_HOME_LABELS.pendingRedemptionLoadFailed}</span>
 		<span class="redemption-pending-banner__cta" aria-hidden="true">▶</span>
 	</a>
 {/if}
@@ -66,6 +77,15 @@ const adminMode = $derived<'live' | 'demo'>(page.data.isDemo ? 'demo' : 'live');
 	}
 	.redemption-pending-banner:hover {
 		background: var(--color-feedback-warning-bg-strong);
+	}
+	/* #3148: 件数取得失敗の導線 (warning でなく error 系 semantic token で区別) */
+	.redemption-pending-banner--error {
+		border-color: var(--color-feedback-error-border);
+		background: var(--color-surface-error);
+		color: var(--color-feedback-error-text);
+	}
+	.redemption-pending-banner--error:hover {
+		background: var(--color-feedback-error-bg-strong);
 	}
 	.redemption-pending-banner__icon {
 		font-size: 1.25rem;

--- a/src/routes/(parent)/admin/+page.svelte
+++ b/src/routes/(parent)/admin/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { page } from '$app/state';
-import { ADMIN_HOME_LABELS } from '$lib/domain/labels';
 import AdminHome from '$lib/features/admin/components/AdminHome.svelte';
+import RedemptionPendingBanner from '$lib/features/admin/components/RedemptionPendingBanner.svelte';
 import { getScreenshotModeKind } from '$lib/features/demo/screenshot-mode';
 
 let { data } = $props();
@@ -30,19 +30,11 @@ const adminMode = $derived<'live' | 'demo'>(page.data.isDemo ? 'demo' : 'live');
 <!-- #3144: ごほうび交換の承認待ち導線 (pending > 0 のときのみ)。
      子供の engagement バッジ (#2109 撤廃) でなく親の管理タスク導線のため ADR-0012 非抵触。 -->
 {#if bannerCount > 0}
-	<a class="redemption-pending-banner" href="/admin/rewards/requests" data-testid="redemption-pending-banner">
-		<span class="redemption-pending-banner__icon" aria-hidden="true">🎁</span>
-		<span class="redemption-pending-banner__text">{ADMIN_HOME_LABELS.pendingRedemptionBanner(bannerCount)}</span>
-		<span class="redemption-pending-banner__cta" aria-hidden="true">▶</span>
-	</a>
+	<RedemptionPendingBanner variant="pending" count={bannerCount} />
 {:else if pendingCountFailed}
 	<!-- #3148: 件数取得失敗時は silent 非表示にせず、承認待ち確認ページへの導線を出す
 	     (true-0 = 承認待ちなし と failure-0 = 取得障害 を区別し、親が承認待ちを見落とさない)。 -->
-	<a class="redemption-pending-banner redemption-pending-banner--error" href="/admin/rewards/requests" data-testid="redemption-pending-banner-error">
-		<span class="redemption-pending-banner__icon" aria-hidden="true">⚠️</span>
-		<span class="redemption-pending-banner__text">{ADMIN_HOME_LABELS.pendingRedemptionLoadFailed}</span>
-		<span class="redemption-pending-banner__cta" aria-hidden="true">▶</span>
-	</a>
+	<RedemptionPendingBanner variant="error" />
 {/if}
 
 <AdminHome
@@ -60,41 +52,3 @@ const adminMode = $derived<'live' | 'demo'>(page.data.isDemo ? 'demo' : 'live');
 	weeklyUsage={data.weeklyUsage}
 	valuePreview={data.valuePreview}
 />
-
-<style>
-	.redemption-pending-banner {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		margin-bottom: 16px;
-		padding: 0.875rem 1rem;
-		border: 1px solid var(--color-border-warning);
-		border-radius: 0.75rem;
-		background: var(--color-surface-warning);
-		color: var(--color-text-warm);
-		text-decoration: none;
-		font-weight: 600;
-	}
-	.redemption-pending-banner:hover {
-		background: var(--color-feedback-warning-bg-strong);
-	}
-	/* #3148: error variant for count-load failure (error semantic tokens, not warning) */
-	.redemption-pending-banner--error {
-		border-color: var(--color-feedback-error-border);
-		background: var(--color-surface-error);
-		color: var(--color-feedback-error-text);
-	}
-	.redemption-pending-banner--error:hover {
-		background: var(--color-feedback-error-bg-strong);
-	}
-	.redemption-pending-banner__icon {
-		font-size: 1.25rem;
-	}
-	.redemption-pending-banner__text {
-		flex: 1;
-		min-width: 0;
-	}
-	.redemption-pending-banner__cta {
-		color: var(--color-text-warm-muted);
-	}
-</style>

--- a/src/routes/(parent)/admin/+page.svelte
+++ b/src/routes/(parent)/admin/+page.svelte
@@ -78,7 +78,7 @@ const adminMode = $derived<'live' | 'demo'>(page.data.isDemo ? 'demo' : 'live');
 	.redemption-pending-banner:hover {
 		background: var(--color-feedback-warning-bg-strong);
 	}
-	/* #3148: 件数取得失敗の導線 (warning でなく error 系 semantic token で区別) */
+	/* #3148: error variant for count-load failure (error semantic tokens, not warning) */
 	.redemption-pending-banner--error {
 		border-color: var(--color-feedback-error-border);
 		background: var(--color-surface-error);

--- a/tests/unit/routes/admin-premium-welcome.test.ts
+++ b/tests/unit/routes/admin-premium-welcome.test.ts
@@ -21,6 +21,8 @@ const mockGetChildStatus = vi.fn();
 const mockGetAllChildrenSimpleSummary = vi.fn();
 const mockGetSettings = vi.fn();
 const mockSetSetting = vi.fn();
+// #3148: 承認待ち件数取得 (失敗時の banner 状態検証用)
+const mockCountPendingRedemptionsForParent = vi.fn();
 // #2295 (EPIC #2294 ①): mockFindActiveEvents / mockGetMemoryTicketStatus 削除済 (2026-05-19)
 
 vi.mock('$lib/server/auth/factory', () => ({
@@ -69,6 +71,10 @@ vi.mock('$lib/server/logger', () => ({
 	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
+vi.mock('$lib/server/services/reward-redemption-service', () => ({
+	countPendingRedemptionsForParent: mockCountPendingRedemptionsForParent,
+}));
+
 const mod = await import('../../../src/routes/(parent)/admin/+page.server');
 const load = mod.load as unknown as (event: {
 	locals: App.Locals;
@@ -79,6 +85,8 @@ const load = mod.load as unknown as (event: {
 	monthlySummaries: unknown;
 	currentMonth: string;
 	onboarding: unknown;
+	pendingRedemptionCount: number;
+	pendingRedemptionCountFailed: boolean;
 }>;
 
 const dismissAction = mod.actions.dismissPremiumWelcome as unknown as (event: {
@@ -111,6 +119,32 @@ describe('/admin page.server — PremiumWelcome 表示制御 (#778)', () => {
 		// #2295: mockFindActiveEvents / mockGetMemoryTicketStatus 削除済
 		// デフォルトでは premium_welcome_shown は未設定（初回想定）
 		mockGetSettings.mockResolvedValue({});
+		// #3148: 承認待ち件数はデフォルト成功で 0 件
+		mockCountPendingRedemptionsForParent.mockResolvedValue(0);
+	});
+
+	// #3148: 承認待ち件数の取得失敗を silent 非表示にしない (failure-0 と true-0 の区別)
+	describe('load: pendingRedemptionCount 取得失敗の区別 (#3148)', () => {
+		it('取得成功 (3 件) → count=3 / failed=false', async () => {
+			mockCountPendingRedemptionsForParent.mockResolvedValue(3);
+			const result = await load({ locals: makeLocals(), parent: makeParent('family') });
+			expect(result.pendingRedemptionCount).toBe(3);
+			expect(result.pendingRedemptionCountFailed).toBe(false);
+		});
+
+		it('取得成功 (0 件 = 承認待ちなし) → count=0 / failed=false (true-0)', async () => {
+			mockCountPendingRedemptionsForParent.mockResolvedValue(0);
+			const result = await load({ locals: makeLocals(), parent: makeParent('family') });
+			expect(result.pendingRedemptionCount).toBe(0);
+			expect(result.pendingRedemptionCountFailed).toBe(false);
+		});
+
+		it('取得失敗 (例外) → count=0 / failed=true (failure-0 を UI が区別できる)', async () => {
+			mockCountPendingRedemptionsForParent.mockRejectedValue(new Error('Scan timeout'));
+			const result = await load({ locals: makeLocals(), parent: makeParent('family') });
+			expect(result.pendingRedemptionCount).toBe(0);
+			expect(result.pendingRedemptionCountFailed).toBe(true);
+		});
 	});
 
 	describe('load: showPremiumWelcome', () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象**: 保護者（admin ホーム）。承認待ちごほうび交換の件数取得が DB/Scan 障害で失敗すると、現状は `.catch(() => 0)` で 0 を返しバナーが恒久非表示になる。これは true-0（承認待ちなし）と failure-0（取得障害）が区別できず、#3144 が解消したかった「親が承認待ちに気づかない」を障害時に再現する。失敗時は専用導線（⚠️ + 確認ページ link）を出し、見落としを防ぐ。

## 関連 Issue

- closes #3148
- 前提: #3144（#3145 merged、承認待ち発見性バナー）

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 根拠 |
|---|---|---|---|
| load 失敗時に failure-0 を true-0 と区別 | catch を構造化し `pendingRedemptionCountFailed` を返す | PASS | unit 3 ケース（成功3/成功0/失敗例外） |
| 失敗時 UI で silent 非表示にしない | 件数 0 でも failed=true なら error variant バナー表示 | PASS | admin/+page.svelte error banner |
| Scan perf（GSI/counter 化） | ADR-0010 で Pre-PMF defer（Scan 1 回コスト軽微、Issue §1 判断） | scope 外 | Issue #3148 §1 |

## 変更タイプ

- [x] バグ修正 (fix) — 障害時 UX（silent 非表示の解消）

## 影響範囲・変更コンポーネント

- `admin/+page.server.ts`: count load の catch を `{ count, failed }` 構造化、`pendingRedemptionCountFailed` を返す。
- `admin/+page.svelte`: failed=true 時に error variant バナー（⚠️ + 確認ページ導線）。`?screenshot=all` 時は failure 状態を描画しない。
- `RedemptionPendingBanner.svelte`（**新規抽出**）: warning(pending) / error の 2 variant を持つ presentational component。markup・class・style を `+page.svelte` から無改変で移設し、表示判定 (件数 > 0 / failed) は親が維持（testid `redemption-pending-banner` / `redemption-pending-banner-error` 不変、screenshot 抑止ロジックも不変）。`RedemptionPendingBanner.stories.svelte` で 2 variant を play 検証 + 決定的 SS 撮影を可能化。
- `ADMIN_HOME_LABELS.pendingRedemptionLoadFailed`（REWARD_TERMS atom 経由）/ CSS は feedback-error 系 semantic token（hex なし）。
- unit 3 ケース追加。

## テスト & 安全装置セルフチェック

- 重量 e2e 敏感領域（#3173 list）外（admin home の count 表示、export/import・reward 陳列・schema 非該当）。(c) seed: schema 変更なし。
- unit 11 PASS（failing-test-first で失敗フラグを固定）/ svelte-check 0 error / biome `--error-on-warnings` PASS。
- assertion 弱体化なし（新規 failure 分岐を pin）。

## スクリーンショット / ビジュアルデモ

新規追加した `RedemptionPendingBanner.svelte` を **Storybook の決定的レンダリング**で撮影。実 markup・実 class (`.redemption-pending-banner--error` 等)・実ラベル (`ADMIN_HOME_LABELS.pendingRedemptionLoadFailed` / `pendingRedemptionBanner`) をそのまま描画している (文言ハードコードなし)。失敗状態は本番 route では DB 障害時のみ発生し `?screenshot=all` でも非表示のため標準 baseline 撮影は不可だが、本 Storybook 経由で error variant を決定的に視認できる。

### error variant (#3148、件数取得失敗 = failure-0、新規追加分)

| Desktop | Mobile |
|---|---|
| ![error desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3182/redemption-banner-error-desktop.png) | ![error mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3182/redemption-banner-error-mobile.png) |

- error semantic token (`--color-surface-error` / `--color-feedback-error-border` / `--color-feedback-error-text`) で warning variant と視覚的に区別。⚠️ + `/admin/rewards/requests` 導線で silent 非表示を回避し failure-0 を true-0 と区別する。

### pending variant (#3144、承認待ち > 0、既存挙動・参考)

| Desktop | Mobile |
|---|---|
| ![pending desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3182/redemption-banner-pending-desktop.png) | ![pending mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3182/redemption-banner-pending-mobile.png) |

- 撮影方法: `npx storybook build` → static を serve → `Admin/RedemptionPendingBanner` story の iframe を Playwright で撮影 (banner 要素を bounding box でクロップ、desktop 1280 / mobile 390、deviceScaleFactor 2)。Storybook play 関数 (2 件) で testid (`redemption-pending-banner` / `redemption-pending-banner-error`) + href + ラベル一致を assert 済 (`npm run test:storybook` 191 PASS)。
## コード品質セルフレビュー (#1481)

- 既存 warning バナーと同構造で error variant を追加し DRY。failure 状態を screenshot mode で抑止し SS 決定性を壊さない。
- ラベルは REWARD_TERMS atom 経由、CSS は semantic token のみ（DESIGN.md §2/§9 準拠）。

## 横展開・影響波及チェック

- count load の構造化は admin home のみ（他 page の count 表示には波及しない）。
- Scan perf（GSI/counter）は ADR-0010 で defer（本 PR scope 外、Issue に記録済）。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。観点: failure 状態の screenshot 抑止 / error variant の semantic token。

## 配布済み env / secret (ADR-0006)

該当なし。

## Ready for Review チェックリスト

- [x] failure-0 と true-0 を構造化 catch で区別
- [x] 失敗時 error banner で silent 非表示を解消
- [x] unit（failing-test-first）3 ケースで分岐を固定
- [x] svelte-check 0 error / biome PASS / Scan perf は ADR-0010 defer を明記

## QM レビュー結果

(QM チーム記入欄)


