### PR TITLE
fix(UX): #3204 プラン管理 checkout の silent-fail を Toast/Alert で根治 + 廃止済み年額トグル撤去

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -1838,6 +1838,9 @@ export const SUBSCRIPTION_PAGE_LABELS = {
 		`⚠️ プラン変更には${usesPin ? '親 PIN' : '確認フレーズ'}の入力が必要です`,
 	billingMonthly: '月額',
 	billingYearly: '年額（17% OFF）',
+	// #3204: checkout 失敗時のユーザ向けフィードバック (silent no-op 撲滅)
+	checkoutFailed: '決済を開始できませんでした。時間をおいて再度お試しください',
+	checkoutFailedToastTitle: '決済を開始できませんでした',
 
 	// スタンダードプラン
 	// #1963: atom (PLAN_TERMS / PRICE_TERMS) を terms.ts から参照

--- a/src/lib/features/admin/components/SaasLicensePanel.svelte
+++ b/src/lib/features/admin/components/SaasLicensePanel.svelte
@@ -42,6 +42,7 @@ import Alert from '$lib/ui/primitives/Alert.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import Dialog from '$lib/ui/primitives/Dialog.svelte';
+import { showToast } from '$lib/ui/primitives/Toast.svelte';
 
 let { data } = $props();
 
@@ -71,7 +72,9 @@ let trialSubmitting = $state(false);
 let trialStartError = $state('');
 let showChurnModal = $state(false);
 let selectedTier = $state<'standard' | 'family'>('standard');
-let billingInterval = $state<'monthly' | 'yearly'>('monthly');
+// #3204: 年額は #2719 で廃止確定 (checkout が yearly を reject)。月額固定にし、年額トグル UI を撤去。
+// #3204: checkout 失敗時のエラーメッセージ (silent no-op 撲滅、Toast と併用の in-page banner)
+let checkoutError = $state<string | null>(null);
 
 // #771 Portal を開く前の PIN / 確認フレーズ入力
 const DOWNGRADE_CONFIRM_PHRASE = 'プランを変更します';
@@ -165,16 +168,34 @@ const hasSubscription = $derived(!!license.stripeSubscriptionId);
 
 async function startCheckout(planId: string) {
 	checkoutLoading = true;
+	checkoutError = null;
 	try {
 		const res = await fetch('/api/stripe/checkout', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ planId }),
 		});
-		const data = await res.json();
-		if (data.url) {
+		const data = await res.json().catch(() => ({}));
+		if (res.ok && data.url) {
 			window.location.href = data.url;
+			return;
 		}
+		// #3204: silent no-op 撲滅。非 2xx / url 欠落時はサーバーメッセージを必ず提示する
+		// (decision 機能無効 = STRIPE_DISABLED は「決済機能は現在利用できません」、
+		//  INVALID_PLAN 等も同様)。demo/staging で押下しても無反応にしない。
+		const message =
+			typeof data?.message === 'string' && data.message
+				? data.message
+				: SUBSCRIPTION_PAGE_LABELS.checkoutFailed;
+		checkoutError = message;
+		showToast(SUBSCRIPTION_PAGE_LABELS.checkoutFailedToastTitle, message, 'error');
+	} catch {
+		checkoutError = SUBSCRIPTION_PAGE_LABELS.checkoutFailed;
+		showToast(
+			SUBSCRIPTION_PAGE_LABELS.checkoutFailedToastTitle,
+			SUBSCRIPTION_PAGE_LABELS.checkoutFailed,
+			'error',
+		);
 	} finally {
 		checkoutLoading = false;
 	}
@@ -520,24 +541,7 @@ async function openPortal() {
 		{:else}
 			<!-- サブスクリプション無し → プラン選択 -->
 			<div class="grid gap-4">
-				<!-- 請求間隔切り替え -->
-				<div class="flex justify-center gap-2 mb-2">
-					<button
-						class="interval-btn"
-						class:active={billingInterval === 'monthly'}
-						onclick={() => (billingInterval = 'monthly')}
-					>
-						{SUBSCRIPTION_PAGE_LABELS.billingMonthly}
-					</button>
-					<button
-						class="interval-btn"
-						class:active={billingInterval === 'yearly'}
-						onclick={() => (billingInterval = 'yearly')}
-					>
-						{SUBSCRIPTION_PAGE_LABELS.billingYearly}
-					</button>
-				</div>
-
+				<!-- #3204: 年額トグル撤去 (年額は #2719 で廃止確定、checkout が reject)。月額固定。 -->
 				<!-- PLAN_LABELS.standard -->
 				<div
 					class="plan-card"
@@ -553,14 +557,7 @@ async function openPortal() {
 							<p class="font-semibold text-[var(--color-text-primary)]">{SUBSCRIPTION_PAGE_LABELS.standardPlanName}</p>
 							<p class="text-xs text-[var(--color-text-muted)]">{SUBSCRIPTION_PAGE_LABELS.standardPlanDesc}</p>
 						</div>
-						{#if billingInterval === 'monthly'}
-							<p class="text-xl font-bold text-[var(--color-feedback-info-text)]">{SUBSCRIPTION_PAGE_LABELS.standardPriceMonthly}<span class="text-sm font-normal text-[var(--color-text-muted)]">{SUBSCRIPTION_PAGE_LABELS.standardPerMonth}</span></p>
-						{:else}
-							<div class="text-right">
-								<p class="text-xl font-bold text-[var(--color-feedback-info-text)]">{SUBSCRIPTION_PAGE_LABELS.standardPriceYearly}<span class="text-sm font-normal text-[var(--color-text-muted)]">{SUBSCRIPTION_PAGE_LABELS.standardPerYear}</span></p>
-								<p class="text-xs text-[var(--color-feedback-success-text)]" data-testid="standard-yearly-monthly-equiv">{SUBSCRIPTION_PAGE_LABELS.standardYearlyMonthlyEquiv}</p>
-							</div>
-						{/if}
+						<p class="text-xl font-bold text-[var(--color-feedback-info-text)]">{SUBSCRIPTION_PAGE_LABELS.standardPriceMonthly}<span class="text-sm font-normal text-[var(--color-text-muted)]">{SUBSCRIPTION_PAGE_LABELS.standardPerMonth}</span></p>
 					</div>
 					<ul class="text-xs text-[var(--color-text-muted)] space-y-1 mb-3">
 						{#each getLicenseHighlights('standard') as highlight}
@@ -586,14 +583,7 @@ async function openPortal() {
 							<p class="font-semibold text-[var(--color-text-primary)]">{SUBSCRIPTION_PAGE_LABELS.familyPlanName}</p>
 							<p class="text-xs text-[var(--color-text-muted)]">{SUBSCRIPTION_PAGE_LABELS.familyPlanDesc}</p>
 						</div>
-						{#if billingInterval === 'monthly'}
-							<p class="text-xl font-bold text-[var(--color-stat-purple)]">{SUBSCRIPTION_PAGE_LABELS.familyPriceMonthly}<span class="text-sm font-normal text-[var(--color-text-muted)]">{SUBSCRIPTION_PAGE_LABELS.standardPerMonth}</span></p>
-						{:else}
-							<div class="text-right">
-								<p class="text-xl font-bold text-[var(--color-stat-purple)]">{SUBSCRIPTION_PAGE_LABELS.familyPriceYearly}<span class="text-sm font-normal text-[var(--color-text-muted)]">{SUBSCRIPTION_PAGE_LABELS.standardPerYear}</span></p>
-								<p class="text-xs text-[var(--color-feedback-success-text)]" data-testid="family-yearly-monthly-equiv">{SUBSCRIPTION_PAGE_LABELS.familyYearlyMonthlyEquiv}</p>
-							</div>
-						{/if}
+						<p class="text-xl font-bold text-[var(--color-stat-purple)]">{SUBSCRIPTION_PAGE_LABELS.familyPriceMonthly}<span class="text-sm font-normal text-[var(--color-text-muted)]">{SUBSCRIPTION_PAGE_LABELS.standardPerMonth}</span></p>
 					</div>
 					<ul class="text-xs text-[var(--color-text-muted)] space-y-1 mb-3">
 						{#each getLicenseHighlights('family') as highlight}
@@ -604,14 +594,24 @@ async function openPortal() {
 
 				<!-- 購入ボタン -->
 				<Button
-					onclick={() => startCheckout(selectedTier === 'family' ? `family-${billingInterval}` : billingInterval)}
-					disabled={checkoutLoading}
+					onclick={() =>
+						startCheckout(
+							selectedTier === 'family'
+								? SUBSCRIPTION_PLAN.FAMILY_MONTHLY
+								: SUBSCRIPTION_PLAN.MONTHLY,
+						)}
+					loading={checkoutLoading}
 					variant="primary"
 					size="md"
 					class="w-full"
 				>
 					{SUBSCRIPTION_PAGE_LABELS.checkoutButton(selectedTier, checkoutLoading)}
 				</Button>
+
+				<!-- #3204: checkout 失敗時の in-page banner (Toast との 2 層 feedback、silent no-op 撲滅) -->
+				{#if checkoutError}
+					<Alert variant="danger" message={checkoutError} />
+				{/if}
 
 				<p class="text-xs text-[var(--color-text-tertiary)] text-center">
 					{SUBSCRIPTION_PAGE_LABELS.checkoutNote}
@@ -743,24 +743,6 @@ async function openPortal() {
 </div>
 
 <style>
-	.interval-btn {
-		padding: 6px 16px;
-		font-size: 0.8rem;
-		font-weight: 600;
-		border-radius: 8px;
-		border: 1px solid var(--color-neutral-200, #e5e7eb);
-		background: white;
-		color: var(--color-neutral-500, #6b7280);
-		cursor: pointer;
-		transition: all 0.15s;
-	}
-
-	.interval-btn.active {
-		background: var(--color-violet-500, #8b5cf6);
-		color: white;
-		border-color: var(--color-violet-500, #8b5cf6);
-	}
-
 	.plan-card {
 		position: relative;
 		border: 2px solid var(--color-neutral-200, #e5e7eb);

--- a/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
+++ b/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
@@ -1,83 +1,82 @@
 // tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
-// #2347 (EPIC #2345): 月額/年額切替 + 年額表示強化の E2E
+// #3204: 月額固定 checkout + 失敗フィードバック — /admin/subscription
 //
-// 目的:
-//   - /admin/subscription の月額/年額タブ切替 UI が `billingInterval` $state 経由で
-//     正しく Stripe price 連動すること (UI 既実装活用、Research 根本原因 a/b 解消)。
-//   - 年額表示強化「月換算 ¥417 (約 17% off)」の表示確認 (AC4 UX 改善)。
-//   - bypass 経路 (旧 `/checkout?plan=monthly` 等の単一固定パス) が site/ + src/ に
-//     残っていないこと (本テストは静的 grep にて確認、AC1)。
+// 経緯:
+//   - #2347 で月額/年額トグル UI を実装したが、#2719 で年額を廃止確定し checkout が
+//     `yearly` / `family-yearly` を server 側で reject するようになった。UI に年額トグルが
+//     残ると「年額を選ぶと必ず INVALID_PLAN」になるため、#3204 で年額トグルを撤去し月額固定化。
+//   - 併せて #3204 で checkout 失敗 (非 2xx / url 欠落) の silent no-op を撲滅し、
+//     失敗時にエラーメッセージ (Alert + Toast) を必ず提示するよう修正。
+//
+// 本 spec は (A) 年額トグル撤去 + 月額固定表示、(B) checkout 失敗時のエラー提示、
+// (C) 月額 planId が checkout に送信されることを検証する。
 //
 // テスト分類: Integration (page.route() で Stripe API モック、cognito-dev 認証必須)
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts stripe-checkout-monthly-yearly
 
 import { expect, test } from '@playwright/test';
 
-test.describe('#2347 月額/年額切替 + 年額表示強化 — /admin/subscription', () => {
+test.describe('#3204 月額固定 checkout + 失敗フィードバック — /admin/subscription', () => {
 	test.use({ storageState: 'playwright/.auth/free.json' });
 
-	test('billingInterval ボタンで月額/年額タブ切替できる (UI 既実装活用)', async ({ page }) => {
-		await page.route('/api/stripe/checkout', async (route) => {
-			await route.fulfill({
-				status: 200,
-				contentType: 'application/json',
-				body: JSON.stringify({ url: 'https://checkout.stripe.com/mock-monthly-yearly-2347' }),
-			});
-		});
-
-		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
-
-		// Stripe 未設定環境はスキップ (既存 upgrade-checkout.spec.ts と整合)
-		// #2330 で「決済機能は現在準備中です」placeholder が削除されたため、月額ボタン自体の visible 判定で skip 検出に変更
-		const monthlyBtn = page.getByRole('button', { name: '月額', exact: true });
-		const isMonthlyVisible = await monthlyBtn
+	/** Stripe 未設定環境 (plan card 非表示) では月額ボタンが出ないため skip 判定に使う */
+	async function skipIfStripeDisabled(page: import('@playwright/test').Page): Promise<boolean> {
+		const monthlyCheckoutBtn = page.getByTestId('standard-plan-card');
+		const visible = await monthlyCheckoutBtn
 			.waitFor({ state: 'visible', timeout: 5_000 })
 			.then(() => true)
 			.catch(() => false);
-
-		if (!isMonthlyVisible) {
+		if (!visible) {
 			test.info().annotations.push({
 				type: 'skip-reason',
 				description: 'Stripe 未設定環境 (stripeEnabled=false で plan card 非表示) のためスキップ',
 			});
-			return;
 		}
+		return visible;
+	}
 
-		// 月額/年額切替ボタンが両方存在することを確認 (UI 既実装、Research 根本原因 a 解消の前提)
-		const yearlyBtn = page.getByRole('button', { name: /年額/ });
+	test('年額トグルが撤去され月額固定で表示される (#2719 年額廃止と UI 整合)', async ({ page }) => {
+		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
+		if (!(await skipIfStripeDisabled(page))) return;
 
-		await expect(monthlyBtn).toBeVisible({ timeout: 15_000 });
-		await expect(yearlyBtn).toBeVisible({ timeout: 15_000 });
+		// 年額トグル・年額専用 UI が物理的に存在しないこと (年額選択 → INVALID_PLAN 経路の根絶)
+		await expect(page.getByRole('button', { name: /年額/ })).toHaveCount(0);
+		await expect(page.getByTestId('standard-yearly-monthly-equiv')).toHaveCount(0);
+		await expect(page.getByTestId('family-yearly-monthly-equiv')).toHaveCount(0);
 
-		// 年額タブをクリック → 年額表示強化 UI (月換算サブテキスト) が表示されること
-		await yearlyBtn.click();
-
-		const standardYearlyEquiv = page.getByTestId('standard-yearly-monthly-equiv');
-		await expect(standardYearlyEquiv).toBeVisible({ timeout: 5_000 });
-		await expect(standardYearlyEquiv).toContainText('月換算 ¥417');
-		await expect(standardYearlyEquiv).toContainText('17% off');
-
-		const familyYearlyEquiv = page.getByTestId('family-yearly-monthly-equiv');
-		await expect(familyYearlyEquiv).toBeVisible({ timeout: 5_000 });
-		await expect(familyYearlyEquiv).toContainText('月換算 ¥650');
-		await expect(familyYearlyEquiv).toContainText('17% off');
-
-		// 月額タブに戻すと月換算サブテキストが非表示になる
-		await monthlyBtn.click();
-		await expect(standardYearlyEquiv).not.toBeVisible({ timeout: 5_000 });
-		await expect(familyYearlyEquiv).not.toBeVisible({ timeout: 5_000 });
+		// 月額価格が表示されること
+		await expect(page.getByTestId('standard-plan-card')).toContainText('¥500');
+		await expect(page.getByTestId('family-plan-card')).toContainText('¥780');
 	});
 
-	test('月額/年額切替 → /api/stripe/checkout に対応する planId が送信される (mock)', async ({
+	test('checkout 失敗 (非 2xx) で silent no-op せずエラーを提示する (#3204)', async ({ page }) => {
+		// INVALID_PLAN 相当の 400 を返すモック
+		await page.route('/api/stripe/checkout', async (route) => {
+			await route.fulfill({
+				status: 400,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'プランが正しくありません' }),
+			});
+		});
+
+		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
+		if (!(await skipIfStripeDisabled(page))) return;
+
+		// プレミアム選択 → 「プレミアムプランで始める」押下
+		await page.getByTestId('family-plan-card').click();
+		await page.getByRole('button', { name: /プランで始める/ }).click();
+
+		// silent no-op でなく、サーバーメッセージが画面に提示されること (Alert / Toast の 2 層 feedback)
+		await expect(page.getByText('プランが正しくありません')).toBeVisible({ timeout: 8_000 });
+	});
+
+	test('月額 planId (monthly / family-monthly) が checkout に送信される (mock)', async ({
 		page,
 	}) => {
 		const capturedPayloads: Array<{ planId?: string }> = [];
-
 		await page.route('/api/stripe/checkout', async (route) => {
-			const req = route.request();
 			try {
-				const body = req.postDataJSON() as { planId?: string };
-				capturedPayloads.push(body);
+				capturedPayloads.push(route.request().postDataJSON() as { planId?: string });
 			} catch {
 				// no-op
 			}
@@ -88,56 +87,22 @@ test.describe('#2347 月額/年額切替 + 年額表示強化 — /admin/subscri
 			});
 		});
 
-		// stripe 設定が無い場合は preparingText で skip するため、UI 経由検証は
-		// 別 test で行い、本 test は fetch を直接モックして planId 連動を保証
 		await page.goto('/', { waitUntil: 'commit', timeout: 30_000 });
 
-		const monthlyResult = await page.evaluate(async () => {
-			const res = await fetch('/api/stripe/checkout', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ planId: 'monthly' }),
-			});
-			return res.status;
-		});
-		expect(monthlyResult).toBe(200);
+		for (const planId of ['monthly', 'family-monthly']) {
+			const status = await page.evaluate(async (pid) => {
+				const res = await fetch('/api/stripe/checkout', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ planId: pid }),
+				});
+				return res.status;
+			}, planId);
+			expect(status).toBe(200);
+		}
 
-		const yearlyResult = await page.evaluate(async () => {
-			const res = await fetch('/api/stripe/checkout', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ planId: 'yearly' }),
-			});
-			return res.status;
-		});
-		expect(yearlyResult).toBe(200);
-
-		const familyMonthlyResult = await page.evaluate(async () => {
-			const res = await fetch('/api/stripe/checkout', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ planId: 'family-monthly' }),
-			});
-			return res.status;
-		});
-		expect(familyMonthlyResult).toBe(200);
-
-		const familyYearlyResult = await page.evaluate(async () => {
-			const res = await fetch('/api/stripe/checkout', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ planId: 'family-yearly' }),
-			});
-			return res.status;
-		});
-		expect(familyYearlyResult).toBe(200);
-
-		// 4 種 planId 全パターンが route handler に到達したこと
-		expect(capturedPayloads.length).toBeGreaterThanOrEqual(4);
 		const planIds = capturedPayloads.map((p) => p.planId).filter(Boolean);
 		expect(planIds).toContain('monthly');
-		expect(planIds).toContain('yearly');
 		expect(planIds).toContain('family-monthly');
-		expect(planIds).toContain('family-yearly');
 	});
 });

--- a/tests/e2e/upgrade-flow.spec.ts
+++ b/tests/e2e/upgrade-flow.spec.ts
@@ -259,9 +259,8 @@ test.describe('#753 /admin/subscription プラン選択 UI — free', () => {
 		await expect(standardPlanCard).toBeVisible();
 		await expect(page.getByTestId('family-plan-card')).toBeVisible();
 
-		// 月額 / 年額の切り替えがある
-		await expect(page.getByText('月額')).toBeVisible();
-		await expect(page.getByText(/年額/)).toBeVisible();
+		// #3204: 年額トグルは撤去 (#2719 年額廃止と UI 整合)。月額固定で年額ボタンは存在しない。
+		await expect(page.getByRole('button', { name: /年額/ })).toHaveCount(0);
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 保護者（プラン契約導線 = 収益直結）

**解決する課題**: `/admin/subscription`（プラン管理）でプランを選んで「〜プランで始める」を押しても**何も起きない**。`startCheckout` が `/api/stripe/checkout` の 400（INVALID_PLAN 等）を握り潰し `data.url` が無いと無反応のため、ユーザは失敗を認識できず契約を断念する。さらに UI に残る「年額」トグルは #2719 で checkout が reject するため、年額選択は**必ず失敗**する不整合だった。

**期待される効果**: checkout 失敗を Toast + in-page Alert で必ず提示（silent no-op 撲滅）。年額トグルを撤去し月額固定にして、廃止済み年額を選んで失敗する経路を根絶する。

## 関連 Issue

closes #3204

関連: #2719（年額廃止確定）/ #3186（silent-fail UX 同クラス）/ Stripe Variables `STRIPE_PRICE_*_MONTHLY` 登録（INVALID_PLAN 自体の env 原因は GitHub Variables 登録で解消済）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | checkout 失敗時に Toast(error) + in-page error でサーバーメッセージ表示、silent no-op 撲滅 | SS（checkout-error）+ `startCheckout` コード | HEAD `3258a379` / `res.ok && data.url` 以外は `showToast`+`Alert` でサーバー message 提示。SS で Toast「決済を開始できませんでした」+ Alert「プランが正しくありません」の 2 層を確認 |
| AC2 | `STRIPE_DISABLED`（demo/staging）時も「決済機能は現在利用できません」と明示 | `+server.ts` messageMap + startCheckout | HEAD `3258a379` / サーバー message をそのまま表示するため STRIPE_DISABLED の文言も提示（無反応にしない） |
| AC3 | 年額トグル撤去（月額固定）。年額 dead UI 除去、`family-yearly`/`yearly` 送信経路を物理排除 | SS（plan-monthly-only）+ `git diff` | HEAD `3258a379` / billingInterval state + 年額トグル + 年額価格 + interval-btn CSS を削除。button は `FAMILY_MONTHLY`/`MONTHLY` 固定。SS で年額ボタン 0 件確認（capture log `hasYearly: 0`） |
| AC4 | checkout ボタンは loading 維持（二重送信防止） | `Button loading={checkoutLoading}` | HEAD `3258a379` / `loading` prop で spinner + disabled + aria-busy（旧 `disabled` から強化） |
| AC5 | e2e: 失敗フィードバック + 月額固定を検証 | `tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts` | HEAD `3258a379` / 3 test に rewrite（年額トグル不在 / 失敗時エラー提示 / 月額 planId 送信）。`upgrade-flow.spec.ts` の年額 assert も整合（重量 e2e 敏感領域、#3191 整合） |
| AC6 | SS: 失敗時エラー + 年額撤去後の月額固定 UI | screenshots ブランチ | HEAD `3258a379` / 下記 2 枚 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: `/admin/subscription`（`SaasLicensePanel`）のプラン選択 + checkout のみ。サーバー API は不変。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `stripe-checkout-monthly-yearly.spec.ts` を #3204 整合に rewrite（年額不在 / 失敗フィードバック / 月額 planId）。`upgrade-flow.spec.ts` の年額 assert を月額固定に更新
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high）

## スクリーンショット / ビジュアルデモ

dev:cognito（Stripe 有効・free ユーザ）で撮影。1 枚目=プラン選択 UI（**年額トグル撤去・月額固定**、¥500/¥780）。2 枚目=「プレミアムプランで始める」押下で checkout が 400 を返した時の **Toast「決済を開始できませんでした」+ in-page Alert「プランが正しくありません」の 2 層 feedback**（旧実装は無反応だった）。

### 月額固定 UI（年額トグル撤去）
![plan-monthly-only](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3204/3204-plan-monthly-only-desktop.png)

### checkout 失敗時のエラー提示（silent no-op 撲滅）
![checkout-error](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-3204/3204-checkout-error-desktop.png)

**4 スロット表**: 修正前は「何も起きない（無反応）」で提示できる差分 SS が無いため、修正後の 2 状態（月額固定 UI / 失敗エラー提示）を上記に提示。年額トグルは撤去済みのため修正後のみ。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 失敗処理を `startCheckout` 内に集約、表示は `showToast` + `Alert` primitive を再利用
- [x] **DRY**: 文言を `SUBSCRIPTION_PAGE_LABELS` に SSOT 化（直書きなし）
- [x] **YAGNI**: 年額 dead UI を削除（過剰 UI 除去）。年額再開は #2719 方針変更時の別 Issue で扱う
- [x] **Security（OSS 公開前提）**: サーバー message を表示するのみ（内部情報露出なし）
- [x] **アクセシビリティ**: `Button loading`（aria-busy）+ Toast（role="alert"）+ Alert（danger）で多重提示
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [x] E2E / ユニットシード + チュートリアルを同期（重量 e2e 敏感領域: checkout 系 e2e を同 PR で整合更新、#3191）
- [x] labels SSOT (ADR-0009)（`SUBSCRIPTION_PAGE_LABELS` に checkoutFailed* 追加）
- [ ] 設計書同期 (ADR-0001)
- [x] 並行 PR overlap 確認 (#1200)（SaasLicensePanel を触る他 open PR なし）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A（admin のみ。LP `site/pricing.html` の年額導線は #2719 整合の別件）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**: 年額撤去の妥当性（#2719 年額廃止確定と整合）と、失敗時 message をそのまま表示する方針をご確認ください。なお **LP `site/pricing.html` 側の年額トグル（`?billing=yearly` 直購入）も同じ #2719 不整合**を抱えるため、LP 側の年額撤去を別 Issue で扱うべき旨を申し添えます（本 PR は admin scope）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DESIGN.md §9 禁忌 6 点を目視確認（hex 直書きなし/primitive 使用/内部コード非露出/labels SSOT/インラインスタイルなし/style ブロック減）
- [x] 認証画面変更時: N/A（プラン管理は認証フォームではない。dev:cognito で撮影）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
