### PR TITLE
hardening: #3115 Content-Disposition ASCII fallback で ; = も _ 化 (directive injection 防御)

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -263,14 +263,19 @@ export interface ExportOptions {
  * 優先し日本語名を復元、`filename*` 非対応の旧 browser は ASCII fallback を使う。
  *
  * 動的に user データからファイル名を組む全 export 経路は本関数を経由すること
- * (静的 ASCII 名は対象外で可、横展開方針 #3104)。
+ * (静的 ASCII 名 / timestamp・数値のみの補間は対象外で可、横展開方針 #3104)。
+ * **新規 export endpoint で user データ由来の動的ファイル名を Content-Disposition に入れる場合は
+ * 必ず本関数を経由する** (header 直書きすると #3104 ByteString 500 + injection が再発する、#3115)。
  *
  * @param filename ダウンロード時のファイル名 (拡張子込み、非 ASCII 可)
  */
 export function buildAttachmentContentDisposition(filename: string): string {
-	// ASCII fallback: 非 ASCII (> U+007E) と制御文字 (< U+0020) と " \ を `_` に置換し
-	// ByteString 安全 + ヘッダ injection 安全にする (printable ASCII 0x20-0x7E 以外 + 引用符)
-	const asciiFallback = filename.replace(/[^ -~]|["\\]/g, '_');
+	// ASCII fallback: 非 ASCII (> U+007E) / 制御文字 (< U+0020) / " \ ; = を `_` に置換し
+	// ByteString 安全 + ヘッダ injection 安全にする (printable ASCII 0x20-0x7E 以外 + 引用符)。
+	// #3115: `;` `=` も `_` 化する (defense-in-depth)。RFC 6266 の quoted-string 内では `;` `=` は
+	// 本来 inert だが、寛容/非準拠なパーサ・proxy・WAF が `filename="x"; foo=bar` を directive
+	// injection と解釈するリスクを断つ。CR/LF (header splitting) は制御文字として既に塞がれている。
+	const asciiFallback = filename.replace(/[^ -~]|["\\;=]/g, '_');
 	// RFC 5987 ext-value: encodeURIComponent は ' ( ) * ! ~ を escape しないが、これらは
 	// RFC 5987 ext-value grammar の attr-char ではないため、strict parser / proxy / WAF が
 	// 不正値として reject しうる。追加で percent-encode し attr-char + pct-encoded のみにする。

--- a/tests/unit/domain/export-format.test.ts
+++ b/tests/unit/domain/export-format.test.ts
@@ -43,6 +43,24 @@ describe('buildAttachmentContentDisposition (#3104)', () => {
 		expect(isByteStringSafe(cd)).toBe(true);
 	});
 
+	it('; と = は ASCII fallback で _ に置換される (directive injection の defense-in-depth、#3115)', () => {
+		// 寛容/非準拠パーサが `filename="x"; foo=bar` を directive 注入と解釈するリスクを断つ。
+		const cd = buildAttachmentContentDisposition('a;b=c.json');
+		expect(cd).toContain('filename="a_b_c.json"');
+		// quoted-string 部 (filename="...") に ; や = が literal で残っていない
+		const fnMatch = cd.match(/filename="([^"]*)"/);
+		expect(fnMatch?.[1]).not.toMatch(/[;=]/);
+		expect(isByteStringSafe(cd)).toBe(true);
+	});
+
+	it('"; foo=bar 風の偽 directive を挿入しようとしても ASCII fallback の filename 値が 1 つに保たれる (#3115)', () => {
+		// attacker が template 名等に注入を試みた最悪ケース。filename 値内に余分な directive 区切りを作らない。
+		const cd = buildAttachmentContentDisposition('evil"; attachment; filename=hack.exe');
+		const fnMatch = cd.match(/filename="([^"]*)"/);
+		expect(fnMatch?.[1]).not.toMatch(/["\\;=]/);
+		expect(isByteStringSafe(cd)).toBe(true);
+	});
+
 	it('絵文字 (サロゲートペア) を含む名でも ByteString 安全', () => {
 		const cd = buildAttachmentContentDisposition('checklist-📋ごはん.json');
 		expect(isByteStringSafe(cd)).toBe(true);


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（セキュリティ / データエクスポート利用者）

**解決する課題**: PR #3110（#3104）QM 再レビューで確認した defense-in-depth 残課題。`Content-Disposition` の ASCII fallback が `;` `=` を残すため、寛容/非準拠なパーサ・proxy・WAF が `filename="x"; foo=bar` を directive injection と解釈しうる余地があった（即時脆弱性ではないが quoted-string 解釈依存）。

**期待される効果**: ファイル名に含まれる `;` `=` を `_` 化し、quoted-string 解釈に依存しない堅牢な Content-Disposition を生成。将来の export endpoint 追加時の #3104 再発も規約明文化で抑止。

## 関連 Issue

closes #3115

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | ASCII fallback で `;` `=` を `_` 化（defense-in-depth） | `tests/unit/domain/export-format.test.ts` | HEAD `8e061567c` / `a;b=c.json`→`a_b_c.json`、filename 値に `;=` 残らない assert、8 passed |
| AC2 | 偽 directive 注入で filename 値が 1 つに保たれる | 同テスト「偽 directive」ケース | HEAD `8e061567c` / `evil"; attachment; filename=hack.exe` で filename 値に `"\;=` 残らない |
| AC3 | Item 1（helper 強制）= 規約明文化で recurrence 抑止 | `export-format.ts` JSDoc + 棚卸し | HEAD `8e061567c` / JSDoc に「新規 endpoint の user データ動的名は必ず本関数経由」追記。動的 user 名 endpoint は checklists/export のみ（helper 経由済）と確認 |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ドメインモデル (`$lib/domain/`) — `export-format.ts` の Content-Disposition helper + unit test

**影響を受ける画面・機能**: export ダウンロードの Content-Disposition ヘッダ（通常のファイル名は挙動不変、`;`/`=` を含む稀なケースのみ `_` 化）。

## テスト & 安全装置セルフチェック

- [ ] `npm run pre-ready -- --pr <num>` 全 Step PASS（Draft、CI 検証中）
- [x] 追加・変更したテスト: `tests/unit/domain/export-format.test.ts` に `;`/`=` の `_` 化 + 偽 directive 注入の 2 ケース追加（計 8 passed）
- [x] 新規 env / secret: N/A
- [x] DynamoDB 実装変更: N/A
- [x] Critical バグ修正: N/A
- [x] **重量 e2e 敏感領域チェック (dev-session #3173)**: 本変更は Content-Disposition の filename サニタイザ（純粋関数）のみで、**export/import の data schema・round-trip 不変条件・seed・domain 値域に非接触**。(a) 並行実装 pair なし（domain 純粋関数、sqlite/dynamodb split 無）/ (b)(c)(d) 該当なし。unit test で網羅

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: HTTP ヘッダ生成ロジックの変更で UI 非変更。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一の純粋関数内で完結。責務不変
- [x] **DRY**: 既存 helper を 1 箇所修正、全 export 経路に波及
- [x] **YAGNI**: Item 1 の重い CI/lint gate は false-positive リスクのため不採用（規約明文化に留める、ADR-0010）
- [x] **Security（OSS 公開前提）**: directive injection の defense-in-depth。header splitting (CR/LF) は既に塞済
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A（正規表現 1 文字追加のみ）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): N/A（Content-Disposition 生成は実装詳細、API 契約のヘッダ format は通常名で不変。helper JSDoc に規約追記）
- [x] **並行 PR overlap** (#1200): export-format.ts を触る他 open PR なし

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（通常のファイル名は挙動不変、`;`/`=` を含む稀な名のみ `_` 化）

**レビュー依頼事項・QA**: Item 1（helper 強制 gate）を「false-positive 過多のため不採用 + 規約明文化」とした判断の妥当性をご確認ください。動的 user データ名を持つ export endpoint は現状 checklists/export のみ（helper 経由済）です。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3115` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了・先送りの AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（Phase 分割なし）
- [x] UI 変更時: N/A（ヘッダ生成ロジック）
- [x] 認証画面変更時: N/A

## QM レビュー結果

QM 記入欄（未レビュー）。
