### PR TITLE
fix(security): #3139 avatarUrl anchor の invariant test + deny 理由の観測性 (IDOR hardening)

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -368,6 +368,8 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 - **公開アセットの扱い**: favicon は `/favicon-32x32.png`（static）/ `/api/v1/images?type=favicon`（認証済）で配信され、`/tenants/**` `/uploads/**` を経由しない。`tenants/` 配下の storage key は構造上すべて tenant-prefixed のため、tenant 非依存の公開アセットは存在せず whitelist 不要。
 - **モード別**: cross-tenant は cognito（マルチテナント SaaS）固有。local（NUC 単一家庭）/ anonymous（demo）provider は `authorize → allowed:true` だが、ハンドラ層 tenant 一致は全モードで効く（単一テナントでは自テナント一致で通過）。
 - **回帰テスト**: `tests/integration/api/tenant-static-file-idor.test.ts`（cross-tenant → 404 / storage 非到達。`/uploads/avatars` は **id-collision ケース**＝自テナントに同 id child が居ても avatarUrl 不一致 / null なら 404 を含む）+ `tests/unit/auth/authorization.test.ts`（両ルートの認証必須化 = default-allow に落ちない）。
+- **anchor robustness の不変条件（#3139）**: 本防御は「`child.avatarUrl` は server が tenant-scoped key からのみ生成し attacker が設定できない」ことに依存する。import/restore が attacker-influenced な値を `avatarUrl` に書けると anchor が silently 無効化されるため、`remapChildAvatarUrls` が外部入力由来の avatarUrl を verbatim 永続化しない（null か取込先 tenant prefix 配下の server key にのみ再構成）ことを `tests/unit/services/import-service-avatar-remap.test.ts` の invariant test で固定する（`insertChild` は構造的に avatarUrl 引数を取らない = 初期 null）。
+- **deny 理由の観測性（#3139）**: 全 deny path（`no-context` / `malformed-filename` / `no-child` / `ownership-mismatch` / `file-missing`）は存在秘匿のため一律 **404**（レスポンスは不変）だが、配信ハンドラ（`uploads/avatars/[filename]/+server.ts` の `denyAvatar`）が deny 理由を内部ログ（`logger.info`、response には漏らさない）に記録し、攻撃 404（`ownership-mismatch` 等）と正常 404（default-icon fallback）の監視切り分けを可能にする。
 
 ### 5.3 ライセンス状態による制限
 

--- a/src/routes/uploads/avatars/[filename]/+server.ts
+++ b/src/routes/uploads/avatars/[filename]/+server.ts
@@ -2,11 +2,26 @@
 // Serves from local filesystem (NUC) or S3 (Lambda)
 
 import { error } from '@sveltejs/kit';
+import { logger } from '$lib/server/logger';
 import { safeContentDisposition, safeContentType } from '$lib/server/security/file-sanitizer';
 import { getChildById } from '$lib/server/services/child-service';
 import { readFile } from '$lib/server/storage';
 import { storageKeyToPublicUrl } from '$lib/server/storage-keys';
 import type { RequestHandler } from './$types';
+
+// #3139: deny path は全て 404 で存在秘匿する (cross-tenant / unauth / avatarUrl=null / mismatch /
+// 実体 missing を区別しない)。レスポンスは 404 のまま、deny 理由のみ内部ログに記録し、攻撃 404 と
+// 正常 404 (default-icon fallback 等) の監視切り分けを可能にする (response には理由を漏らさない)。
+function denyAvatar(
+	reason: string,
+	meta: { tenantId?: string; context?: Record<string, unknown> },
+): never {
+	logger.info('avatar serve deny', {
+		tenantId: meta.tenantId,
+		context: { reason, ...meta.context },
+	});
+	throw error(404, 'File not found');
+}
 
 export const GET: RequestHandler = async ({ params, locals }) => {
 	const filename = params.filename;
@@ -34,19 +49,32 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 	// 存在有無を漏らさないよう全て 404 を返す。
 	const context = locals.context;
 	const childIdMatch = filename.match(/^avatar-(\d+)-/);
-	if (!context || !childIdMatch) {
-		throw error(404, 'File not found');
+	if (!context) {
+		denyAvatar('no-context', { context: { filename } });
+	}
+	if (!childIdMatch) {
+		denyAvatar('malformed-filename', { tenantId: context.tenantId, context: { filename } });
 	}
 	const child = await getChildById(Number(childIdMatch[1]), context.tenantId);
 	// file ownership anchor: avatarUrl がこの legacy filename を指していなければ拒否する
 	const expectedPublicUrl = storageKeyToPublicUrl(`uploads/avatars/${filename}`);
-	if (!child || child.avatarUrl !== expectedPublicUrl) {
-		throw error(404, 'File not found');
+	if (!child) {
+		denyAvatar('no-child', { tenantId: context.tenantId, context: { childId: childIdMatch[1] } });
+	}
+	if (child.avatarUrl !== expectedPublicUrl) {
+		// 所有権 anchor 不一致 (別ファイル参照 / avatarUrl=null)。cross-tenant 取得試行の主要シグナル。
+		denyAvatar('ownership-mismatch', {
+			tenantId: context.tenantId,
+			context: { childId: childIdMatch[1], hasAvatarUrl: child.avatarUrl !== null },
+		});
 	}
 
 	const result = await readFile(`uploads/avatars/${filename}`);
 	if (!result) {
-		throw error(404, 'File not found');
+		denyAvatar('file-missing', {
+			tenantId: context.tenantId,
+			context: { childId: childIdMatch[1] },
+		});
 	}
 
 	// #3105: avatar も tenants 配信路と対称に、ラスタ画像のみ inline / SVG 等は attachment

--- a/tests/unit/services/import-service-avatar-remap.test.ts
+++ b/tests/unit/services/import-service-avatar-remap.test.ts
@@ -90,3 +90,73 @@ describe('#3136 remapChildAvatarUrls — dangling avatarUrl 防止', () => {
 		}
 	});
 });
+
+// #3139: avatarUrl anchor の不変条件 — 「avatarUrl は server 生成 path 以外から設定されない」。
+// #3137 の cross-tenant IDOR 根治は「child.avatarUrl は server が tenant-scoped key からのみ生成する
+// (attacker 不可設定)」を anchor とする。将来 import/restore が attacker-influenced な avatarUrl を
+// そのまま採用すると anchor が silently 無効化され IDOR が再発しうる (CI は green のまま)。
+// 本テスト群は remapChildAvatarUrls が「外部入力由来の文字列を verbatim 永続化しない」ことを固定する。
+describe('#3139 invariant: avatarUrl は外部入力から verbatim 採用されない (anchor robustness)', () => {
+	it('attacker 由来の外部 URL (/tenants/ を含まない) は採用されず persist しない', async () => {
+		fileExistsMock.mockResolvedValue(true);
+		await remapChildAvatarUrls(
+			makeState('https://evil.example/avatars/5/x.png'),
+			TENANT,
+			makeResult(),
+		);
+		// regex 非マッチ → skip。外部 URL を verbatim 永続化しない
+		expect(updateMock).not.toHaveBeenCalled();
+		expect(fileExistsMock).not.toHaveBeenCalled();
+	});
+
+	it('javascript: scheme 等の非 path 文字列も採用しない', async () => {
+		fileExistsMock.mockResolvedValue(true);
+		await remapChildAvatarUrls(makeState('javascript:alert(1)'), TENANT, makeResult());
+		expect(updateMock).not.toHaveBeenCalled();
+	});
+
+	it('外部 host を含む偽装 path でも、host は剥がされ取込先 tenant の server key にのみ再構成される', async () => {
+		// `/tenants/t-evil/avatars/5/x.png` 部分が regex にマッチしても、再構成 key は取込先
+		// tenant (t-new) prefix + マップ済 childId で組まれ、外部 host / 別 tenant は反映されない。
+		fileExistsMock.mockResolvedValue(true);
+		await remapChildAvatarUrls(
+			makeState('https://evil.example/tenants/t-evil/avatars/5/x.png'),
+			TENANT,
+			makeResult(),
+		);
+		expect(updateMock).toHaveBeenCalledTimes(1);
+		const persistedUrl = String(updateMock.mock.calls[0]?.[1]);
+		expect(persistedUrl).toBe('/tenants/t-new/avatars/100/x.png');
+		expect(persistedUrl).not.toContain('evil.example');
+		expect(persistedUrl).not.toContain('t-evil');
+	});
+
+	it('別 tenant path も取込先 tenant prefix に再構成される (cross-tenant 越境しない)', async () => {
+		fileExistsMock.mockResolvedValue(true);
+		await remapChildAvatarUrls(makeState('/tenants/t-other/avatars/5/x.png'), TENANT, makeResult());
+		const persistedUrl = String(updateMock.mock.calls[0]?.[1]);
+		expect(persistedUrl).toBe('/tenants/t-new/avatars/100/x.png');
+		expect(persistedUrl).not.toContain('t-other');
+	});
+
+	it('不変条件: persist される avatarUrl は null か 取込先 tenant の server prefix 配下のみ (多様な悪性入力)', async () => {
+		const malicious = [
+			'https://evil.example/x.png',
+			'//evil.example/avatars/5/x.png',
+			'/etc/passwd',
+			'/tenants/t-other/avatars/5/legit.png',
+			'https://evil.example/tenants/t-evil/avatars/5/x.png',
+			'/tenants/t-old/avatars/5/../../../t-x/avatars/9/secret.png',
+		];
+		fileExistsMock.mockResolvedValue(true);
+		for (const url of malicious) {
+			await remapChildAvatarUrls(makeState(url), TENANT, makeResult());
+		}
+		// 1 件でも null/取込先 tenant prefix 以外を永続化したら invariant 違反
+		for (const call of updateMock.mock.calls) {
+			const persisted = call[1];
+			if (persisted === null) continue;
+			expect(String(persisted).startsWith(`/tenants/${TENANT}/`)).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（セキュリティ / 運用監視）

**解決する課題**: PR #3137（#3133）の cross-tenant IDOR 根治（file ownership anchor）の QM 再レビューで指摘された非 blocking な forward-risk / 監視課題。① anchor は「`child.avatarUrl` は server が生成し attacker 設定不可」に依存するが、将来 import/restore が外部入力 avatarUrl を採用すると anchor が silently 無効化され IDOR が再発しうる。② 全 deny path が一律 404 で攻撃 404 と正常 404 を監視切り分けできない。

**期待される効果**: anchor の不変条件を invariant test で固定し将来の silent regression を防ぐ。deny 理由を内部ログに記録し攻撃検知を可能にする（レスポンスは 404 のまま秘匿維持）。

## 関連 Issue

closes #3139

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | avatarUrl が外部入力から verbatim 採用されない invariant test | `tests/unit/services/import-service-avatar-remap.test.ts` | HEAD `a224e0956` / 外部 URL / javascript: / 偽装 host / cross-tenant path / .. traversal を網羅、persist は null か取込先 tenant prefix 配下のみ。10 passed（既存 5 + 新規 5） |
| AC2 | legacy drift audit | 運用確認事項（code 非該当） | HEAD `a224e0956` / #3136 が import 経路の dangling を null 化するため新規 drift は生じない。既存 prod legacy の整合は運用確認に委ねる（PR では code 化しない） |
| AC3 | 404 deny 理由の内部観測性（response は 404 維持） | `uploads/avatars/[filename]/+server.ts` `denyAvatar` | HEAD `a224e0956` / 5 reason（no-context/malformed-filename/no-child/ownership-mismatch/file-missing）を logger.info に記録、response 不変 |
| AC4 | 既存 IDOR 回帰の挙動不変 | `tests/integration/api/tenant-static-file-idor.test.ts` | HEAD `a224e0956` / 10 passed（ログ追加で 404 挙動は不変） |
| AC5 | 設計書 14-セキュリティ §5.2.1 同期 (ADR-0001) | `docs/design/14-セキュリティ設計書.md` diff | HEAD `a224e0956` / anchor robustness + deny 観測性を追記 |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/`) — avatar 配信ルートに deny 理由ログ追加（挙動不変）
- [x] 設定・CI 以外: 設計書 (14-セキュリティ) + import invariant unit test

**影響を受ける画面・機能**: avatar 静的配信（`/uploads/avatars/[filename]`）の deny 時内部ログのみ追加。配信挙動・レスポンスは不変。

## テスト & 安全装置セルフチェック

- [ ] `npm run pre-ready -- --pr <num>` 全 Step PASS（Draft、CI 検証中）
- [x] 追加・変更したテスト: avatar-remap invariant 5 ケース追加（10 passed）。IDOR 回帰 10 passed で挙動不変確認
- [x] 新規 env / secret: N/A
- [x] DynamoDB 実装変更: N/A
- [x] Critical バグ修正: N/A
- [x] **重量 e2e 敏感領域チェック (dev-session #3173)**: import-service は export/import 敏感領域だが本 PR は **invariant test の追加のみで behavior 変更なし**（remapChildAvatarUrls のロジック不変）。avatar route は logging 追加のみで 404 挙動不変（IDOR 回帰 10 passed）。(a) 並行実装は sqlite/dynamodb の avatarUrl 列を触らず非該当 / (b)(c)(d) schema/seed/domain 値域 非接触

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: ファイル配信ルートの内部ログ追加 + import の unit test 追加で UI 非変更。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: deny 処理を `denyAvatar` helper に集約（DRY + reason 一元管理）
- [x] **DRY**: 5 deny path を 1 helper に統合
- [x] **YAGNI**: legacy drift audit（part 2）は #3136 で新規 drift が生じないため code 化しない
- [x] **Security（OSS 公開前提）**: deny 理由は内部 logger のみ（response は 404 で秘匿維持、存在オラクル化しない）。invariant test で anchor の前提崩れを CI で検出
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A（deny path での logger.info 1 行）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): 14-セキュリティ §5.2.1 に anchor robustness + deny 観測性を追記
- [x] **並行 PR overlap** (#1200): avatar route / import-service avatar remap を触る他 open PR なし

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（avatar 配信の 404 挙動は不変、内部ログのみ追加）

**レビュー依頼事項・QA**: deny 理由ログ（`ownership-mismatch` 等）が response に漏れず内部 logger のみであること、invariant test が anchor の前提（avatarUrl は server 生成のみ）を正しく固定していることをご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3139` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了・先送りの AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（Phase 分割なし）
- [x] UI 変更時: N/A（ファイル配信ルート + unit test）
- [x] 認証画面変更時: N/A

## QM レビュー結果

QM 記入欄（未レビュー）。
