### PR TITLE
infra: #3171 admin 正準 guard の FS-walk を recursive 化し nested route の登録漏れも封殺

### DIFF
--- a/src/lib/features/admin/admin-resource-model-registry.ts
+++ b/src/lib/features/admin/admin-resource-model-registry.ts
@@ -266,27 +266,35 @@ export const ALL_ADMIN_RESOURCE_PAGES = [
  */
 
 /**
- * admin 直下の route dir 名 → §10 正準契約の resource key への map。
+ * admin route path (admin/ からの相対、nested は '/' 区切り) → §10 正準契約の resource key への map。
  * resource-list 管理画面 (AdminResourceHeader / child-tabs を持つ §10 対象) のみを列挙する。
  * value は `ADMIN_RESOURCE_MODEL_REGISTRY` (正準) か `NON_CANONICAL_ADMIN_RESOURCES` (明示除外) の key。
  *
- * 注: `rules` (とくべつルール) は `/admin/settings/rules` の **settings サブページ**で admin 直下 dir では
- * ないため本 map には現れない (NON_CANONICAL_ADMIN_RESOURCES には引き続き存在)。
+ * #3171: FS 走査を recursive 化したため、nested route の `settings/rules` (とくべつルール、rule-preset
+ * marketplace 取込先) も母数に含まれるようになった。これを NON_CANONICAL の `rules` key に map し、
+ * 「nested に新規 resource 管理画面を追加すると guard が検出せず silent-pass する」理論的 gap を封じる。
  */
 export const ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY = {
 	activities: 'activity',
 	rewards: 'reward',
 	checklists: 'checklist',
 	challenges: 'challenges',
+	// #3171: nested route。NON_CANONICAL_ADMIN_RESOURCES.rules (settings サブページの rule-preset) へ map。
+	'settings/rules': 'rules',
 } as const;
 
 /**
- * admin 直下の route dir のうち、§10「admin リソース管理画面」(resource-list) **ではない** page。
- * FS 走査の母数を全 admin page で説明するための明示除外 (silent gap を作らない)。新規に admin 直下 page を
- * 追加したら、resource-list なら `ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY` + registry/除外へ、そうでなければ
- * 本リストへ reason 付きで登録する (どちらにも無いと FS 走査 test が fail する)。
+ * admin route path (admin/ からの相対、nested は '/' 区切り) のうち、§10「admin リソース管理画面」
+ * (resource-list) **ではない** page。FS 走査 (#3171 で recursive 化) の母数を全 admin page で説明する
+ * ための明示除外 (silent gap を作らない)。新規に admin page を追加したら、resource-list なら
+ * `ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY` + registry/除外へ、そうでなければ本リストへ reason 付きで登録する
+ * (どちらにも無いと FS 走査 test が fail する)。
+ *
+ * #3171: recursive 化で nested route (settings サブページ / 詳細・編集ページ / 解約フロー等) も母数に
+ * 含まれるため、それらも本リストで明示分類する。`[id]` は動的セグメントを literal で表す。
  */
 export const NON_RESOURCE_ADMIN_PAGE_ROUTES = {
+	// --- top-level non-resource ---
 	billing: { reason: '課金・プラン管理画面 (resource-list ではない)' },
 	certificates: { reason: '表彰状の発行・閲覧画面 (resource-list ではない)' },
 	cheer: { reason: 'おうえんメッセージ送信画面 (resource-list ではない)' },
@@ -296,11 +304,25 @@ export const NON_RESOURCE_ADMIN_PAGE_ROUTES = {
 	packs: { reason: 'バックアップ/エクスポート (パック) 画面 (resource-list ではない)' },
 	points: { reason: 'ポイント調整・履歴画面 (resource-list ではない)' },
 	reports: { reason: 'レポート閲覧画面 (resource-list ではない)' },
-	settings: {
-		reason: '設定 (サブページ集約)。配下の rules は NON_CANONICAL_ADMIN_RESOURCES で別途説明',
-	},
+	settings: { reason: '設定ハブ (サブページ集約)。配下の各サブページは個別に分類' },
 	status: { reason: 'ステータス閲覧画面 (resource-list ではない)' },
 	subscription: { reason: 'サブスクリプション管理画面 (resource-list ではない)' },
+	// --- nested: 詳細・編集ページ (動的セグメント含む、#3171) ---
+	'activities/[id]/edit': { reason: '活動の編集ページ (詳細フォーム、resource-list ではない)' },
+	'certificates/[id]': { reason: '表彰状の個別表示ページ (詳細、resource-list ではない)' },
+	'rewards/requests': {
+		reason: 'ごほうび交換の承認待ち一覧 (redemption sub-page、resource-list ではない)',
+	},
+	// --- nested: 解約フロー (#3171) ---
+	'billing/cancel': { reason: '解約フローの導入ページ (resource-list ではない)' },
+	'billing/cancel/graduation': { reason: '解約フロー (卒業) ページ (resource-list ではない)' },
+	'billing/cancel/thanks': { reason: '解約フロー (完了) ページ (resource-list ではない)' },
+	// --- nested: settings サブページ (#3171。rules は ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY で resource 扱い) ---
+	'settings/account': { reason: '設定 > アカウント (OYAKAGI / PIN、resource-list ではない)' },
+	'settings/activities': { reason: '設定 > 活動 (ステータス減少設定、resource-list ではない)' },
+	'settings/data': { reason: '設定 > データ (エクスポート/復元、resource-list ではない)' },
+	'settings/notifications': { reason: '設定 > 通知 (resource-list ではない)' },
+	'settings/support': { reason: '設定 > サポート (フィードバック、resource-list ではない)' },
 } as const;
 
 /**

--- a/tests/unit/features/admin-resource-model-registry.test.ts
+++ b/tests/unit/features/admin-resource-model-registry.test.ts
@@ -16,26 +16,42 @@ import {
 	NON_RESOURCE_ADMIN_PAGE_ROUTES,
 } from '../../../src/lib/features/admin/admin-resource-model-registry';
 
-// #3164: admin route の実 FS から「admin 直下で +page.* を持つ route dir」を導出する。
+// #3164 / #3171: admin route の実 FS から「+page.* を持つ route dir」を導出する。
 // 母数を手管理 literal でなく実 route に固定することで、新規 admin 画面の登録漏れを silent pass させない。
+// #3171: **recursive 化**。旧実装は admin 直下 (top-level) のみ走査しており、nested route
+// (settings/rules・rewards/requests・activities/[id]/edit 等) を母数から取りこぼしていた
+// (= nested に新規 resource 管理画面を追加すると guard が検出せず silent-pass する理論的 gap)。
+// 本実装は admin/ 配下の **全 dir** を再帰走査し、+page.* を持つ dir の相対 route path
+// (admin/ からの相対、'/' 区切り) を返す。admin 直下の +page.* (admin ホーム) 自体は subdir でないため
+// 旧実装と同様に対象外 (route dir = subdirectory のみを分類対象とする)。
 const ADMIN_ROUTES_DIR = resolve(
 	dirname(fileURLToPath(import.meta.url)),
 	'../../../src/routes/(parent)/admin',
 );
 
+const PAGE_FILES = ['+page.svelte', '+page.server.ts', '+page.ts'] as const;
+
+function hasPageFile(absDir: string): boolean {
+	return PAGE_FILES.some((f) => existsSync(resolve(absDir, f)));
+}
+
 function discoverAdminPageRoutes(): string[] {
 	if (!existsSync(ADMIN_ROUTES_DIR)) {
 		throw new Error(`admin routes dir not found: ${ADMIN_ROUTES_DIR}`);
 	}
-	return readdirSync(ADMIN_ROUTES_DIR, { withFileTypes: true })
-		.filter((e) => e.isDirectory())
-		.filter((e) =>
-			['+page.svelte', '+page.server.ts', '+page.ts'].some((f) =>
-				existsSync(resolve(ADMIN_ROUTES_DIR, e.name, f)),
-			),
-		)
-		.map((e) => e.name)
-		.sort();
+	const routes: string[] = [];
+	// admin/ 配下を再帰走査。各 subdir で +page.* を持てば相対 path を route として記録する。
+	const walk = (absDir: string, relPath: string): void => {
+		for (const e of readdirSync(absDir, { withFileTypes: true })) {
+			if (!e.isDirectory()) continue;
+			const childAbs = resolve(absDir, e.name);
+			const childRel = relPath ? `${relPath}/${e.name}` : e.name;
+			if (hasPageFile(childAbs)) routes.push(childRel);
+			walk(childAbs, childRel);
+		}
+	};
+	walk(ADMIN_ROUTES_DIR, '');
+	return routes.sort();
 }
 
 describe('#3134 admin リソース正準契約の網羅性 (no silent gap)', () => {
@@ -78,11 +94,14 @@ describe('#3134 admin リソース正準契約の網羅性 (no silent gap)', () 
 describe('#3164 母数を実 route FS から導出する (literal 未更新の silent pass を封殺)', () => {
 	const discovered = discoverAdminPageRoutes();
 
-	it('admin 直下の page route が実在し空でない (FS 走査が機能している sanity)', () => {
+	it('admin の page route が実在し空でない (FS 走査が機能している sanity)', () => {
 		expect(discovered.length).toBeGreaterThan(0);
 		// 既知の代表 route が含まれること (走査ロジックが壊れていない確認)
 		expect(discovered).toContain('activities');
 		expect(discovered).toContain('settings');
+		// #3171: recursive 化で nested route も母数に入る (top-level only だと取りこぼしていた)
+		expect(discovered).toContain('settings/rules');
+		expect(discovered).toContain('rewards/requests');
 	});
 
 	it('実在する全 admin page route が resource / non-resource のいずれかで説明される (unclassified 0)', () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者・正準契約の保守）

**解決する課題**: PR #3170（#3164）が admin 正準 guard の母数を実 route FS 走査で導出し top-level admin 画面の登録漏れ silent-pass を封殺したが、走査が `readdirSync` top-level のみで **nested route**（settings/rules・rewards/requests・activities/[id]/edit 等）を取りこぼしていた。将来 nested に新規 resource 管理画面を追加すると guard が検出せず silent-pass する理論的 gap（#3170 QM 指摘）。

**期待される効果**: FS 走査を recursive 化し、nested route も母数に含めて全分類することで、no-silent-gap 保証を nested 階層まで拡張。新規 nested admin 画面の未登録を CI で検出する。

## 関連 Issue

closes #3171

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | FS 走査を recursive 化（nested route 発見） | `tests/unit/features/admin-resource-model-registry.test.ts` | HEAD `ebef9467a` / discoverAdminPageRoutes() 再帰化、sanity test で settings/rules・rewards/requests 発見を assert。9 passed |
| AC2 | nested 各 route を resource/non-resource に分類（over-capture せず全明示） | registry 定数 + classifyAdminPageRoute | HEAD `ebef9467a` / nested 28 route 全分類（settings/rules→rules resource、他 nested を NON_RESOURCE に reason 付き登録）、unclassified 0 を assert |
| AC3 | 新規 nested 画面の未登録が CI fail する | 「分類定数が実 FS と過不足なく一致」test | HEAD `ebef9467a` / classified(28) === discovered(28) を assert。新規 route 追加→未登録なら不一致で fail |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ドメインモデル (`$lib/features/`) — admin-resource-model-registry.ts の分類定数拡張
- [x] 設定・CI 以外: fitness function unit test の FS-walk recursive 化

**影響を受ける画面・機能**: なし（fitness function guard の網羅範囲拡張のみ。アプリ挙動・UI 非変更）。

## テスト & 安全装置セルフチェック

- [ ] `npm run pre-ready -- --pr <num>` 全 Step PASS（Draft、CI 検証中）
- [x] 追加・変更したテスト: registry test を recursive 化 + nested 発見の sanity 追加（9 passed）
- [x] 新規 env / secret: N/A
- [x] DynamoDB 実装変更: N/A
- [x] Critical バグ修正: N/A
- [x] **重量 e2e 敏感領域チェック (dev-session #3173)**: 非該当（DB スキーマ / export-import / reward / child-shop / parent-gate 非接触）。fitness test と分類定数のみ、アプリ挙動不変

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: テスト / 分類定数の変更で UI 非変更。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 分類は純関数 classifyAdminPageRoute（key lookup）で不変、walk は再帰 helper に分離
- [x] **DRY**: PAGE_FILES / hasPageFile を共通化
- [x] **YAGNI**: prefix-based 自動分類（silent-gap リスク）は採らず、全 route 明示分類で no-silent-gap を厳守
- [x] **Security**: N/A（テスト基盤）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A（test 時の FS 再帰走査のみ）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): DESIGN.md §10 は guard を「top-level」と限定記載しておらず（registry + no-silent-gap を generic に記述）、recursive 化で stale 化しない（guard 強化のみ）。doc 変更不要
- [x] **並行 PR overlap** (#1200): admin-resource-model-registry を触る他 open PR なし

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（guard の網羅範囲拡張、アプリ挙動不変）

**レビュー依頼事項・QA**: nested route を「全明示分類」（prefix 自動分類でなく）とした設計判断の妥当性をご確認ください。over-capture（設定サブページ・解約フロー・[id] 詳細の取り込み）は no-silent-gap のための意図的な全列挙です。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3171` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了・先送りの AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（Phase 分割なし）
- [x] UI 変更時: N/A（テスト基盤）
- [x] 認証画面変更時: N/A

## QM レビュー結果

QM 記入欄（未レビュー）。
