### PR TITLE
fix: #3233 admin e2e 3 spec を refactor (#3221/#3186/#3098) に同期 (統合 blocker 解除)

### DIFF
--- a/tests/e2e/admin-activities-delete.spec.ts
+++ b/tests/e2e/admin-activities-delete.spec.ts
@@ -116,7 +116,9 @@ test.describe('#2744 admin/activities Delete UI (AC4 family scope)', () => {
 		await expect(dialog).toBeHidden();
 
 		// outcome 2: Toast success が表示 (DL.deleteSuccess、labels.ts SSOT 参照)
-		await expect(page.getByRole('alert').filter({ hasText: '活動を削除しました' })).toBeVisible();
+		// #3233: #3221/ADR-0062 で success Toast は role="status"(polite) に変更 (WCAG 4.1.3 —
+		//   成功通知は assertive=alert ではなく polite=status。error のみ role="alert")。
+		await expect(page.getByRole('status').filter({ hasText: '活動を削除しました' })).toBeVisible();
 
 		// outcome 3: 一覧件数が確実に -1 (delete action は activity ログがあれば hidden 化、
 		//           なければ hard delete、いずれも一覧表示からは消える)

--- a/tests/e2e/admin-resource-layout-contract.spec.ts
+++ b/tests/e2e/admin-resource-layout-contract.spec.ts
@@ -247,37 +247,25 @@ test.describe('#3097 admin リソース正準スロット契約 (activities / re
 			test('(d) registry 宣言と DOM (子供タブ / child-binding モデル) が整合する', async ({
 				page,
 			}) => {
-				// 子供タブ: per-child-tabs / family-distribute いずれも child タブを描画する (本 PR では両モデルとも常時表示)。
+				// 子供タブ: 3 資源とも per-child-tabs で child タブを常時描画する。
 				await expect(page.getByTestId(model.childTabsTestid)).toBeVisible();
 
-				if (model.binding === 'child-selection-dialog') {
-					// per-child-tabs (activity / reward) は ChildSelectionDialog で取込先 child を選ぶ。
-					// family master 専用の配信 VisibilityChip (`checklist-distribution-visibility`) を
-					// **絶対に持たない**ことを assert する (per-child リソースが配信モデルを混入させたら fail)。
-					await expect(page.getByTestId('checklist-distribution-visibility')).toHaveCount(0);
-				} else {
-					// family-distribute (checklist) は「配信される」モデル。配信導線が item 件数 0 でも
-					// 必ず存在することを能動的に assert する (旧実装は `if (sectionCount > 0)` で 0 件時に
-					// 何も検証せず vacuous pass していた — toothless 分岐)。
-					//   - templates ≥ 1: 各 template に per-template 配信 section が出る
-					//   - templates = 0: empty state が配信元 (marketplace) への import bridge link を出す
-					// いずれかの配信導線が DOM 上に存在することを assert し、両状態で契約を貫通検証する。
-					const distributionSections = page.locator(
-						'[data-testid^="checklist-distribution-section-"]',
-					);
-					const importBridgeLink = page.getByTestId('checklists-empty-import-link');
-					const sectionCount = await distributionSections.count();
-					const bridgeCount = await importBridgeLink.count();
-					expect(
-						sectionCount + bridgeCount,
-						'family-distribute (checklist) の配信導線 (per-template 配信 section または empty state の import bridge link) が item 件数に関わらず 1 つも存在しない (配信モデル契約逸脱)',
-					).toBeGreaterThan(0);
-					if (sectionCount > 0) {
-						await expect(distributionSections.first()).toBeVisible();
-					} else {
-						await expect(importBridgeLink).toBeVisible();
-					}
-				}
+				// #3233: #3098/#3126 で checklist も child 主軸 (binding='child-selection-dialog' /
+				//   visibilityChipTestid=null) に統一済。registry 上 family-distribute を binding に持つ
+				//   資源は現存しないため、旧 if/else の else (family-distribute 配信導線 assert) は
+				//   到達不能な dead branch だった (前回監査 sev2 mp-3)。registry SSOT を唯一の真実とし、
+				//   全資源で「配信 VisibilityChip を page-top に surface しない」契約だけを表明する。
+				expect(
+					model.binding,
+					`registry binding が child-selection-dialog 以外 (${model.binding})。family-distribute 資源を再導入する場合は本契約 test を拡張すること`,
+				).toBe('child-selection-dialog');
+				expect(model.visibilityChipTestid, 'registry visibilityChipTestid は null 契約').toBeNull();
+
+				// checklist は配信 VisibilityChip を「配信先編集 dialog」(二次導線、初期 close) 内にのみ
+				// 持つ。activity / reward は DOM に存在しない。いずれも page 初期表示で surface しない
+				// (= page-top に配信 chip を常設しない契約)。per-child リソースが配信 chip を page-top に
+				// 常設したら toBeHidden が fail する。
+				await expect(page.getByTestId('checklist-distribution-visibility')).toBeHidden();
 			});
 		});
 	}

--- a/tests/e2e/admin-settings-routes.spec.ts
+++ b/tests/e2e/admin-settings-routes.spec.ts
@@ -68,7 +68,9 @@ test.describe('#2320 /admin/settings 6 グループ child routes', () => {
 			waitUntil: 'domcontentloaded',
 		});
 		// notification status 要素 (clientside onMount で更新される)
-		await expect(page.locator('#notification-status')).toBeVisible();
+		// #3233: #3186 で旧 `#notification-status` (命令的 DOM 更新) を撤廃し、
+		//   常時描画される宣言的コンテナ `notification-browser-status` に集約 (ON/OFF + 異常系)。
+		await expect(page.getByTestId('notification-browser-status')).toBeVisible();
 	});
 
 	test('data route が表示される (data-export-section が存在)', async ({ page }) => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ 開発・QA（統合パイプライン）

**解決する課題**: 統合 PR の最重厚レーンで admin e2e 3 spec が全 shard fail し、release→main の統合が STOP していた。3 件とも **正しい refactor に対し対応 e2e が未同期**（production 機能は正常、stale test）。本 PR で 3 spec を SSOT に同期し統合 blocker を解除する。

**期待される効果**: 統合パイプラインの admin e2e が green に戻り、SIGSEGV 解消済の release を main へ進められる。

## 関連 Issue

closes #3233

regression 起因 refactor: #3221（統一エラー通知 Toast role）/ #3186（通知ステータス集約）/ #3098・#3126（checklist child 主軸）。関連予防 EPIC: #3152 / #3172 / #3173。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 削除通知 spec を実描画に整合（admin-activities-delete:119 green） | `npx playwright test tests/e2e/admin-activities-delete.spec.ts --project=tablet` | HEAD `8919c10d` / 22 passed（3 spec 合算）/ #3221・ADR-0062 で success Toast は `role="status"`(polite、WCAG 4.1.3)。test を alert→status に同期 |
| AC2 | checklist 配信 visibility 契約を実 UI（#3126 child 主軸）に整合 + 前回 mp-3 dead branch 解消（admin-resource-layout-contract:247 green） | 同上 | HEAD `8919c10d` / registry SSOT は 3 資源とも `binding=child-selection-dialog` / `visibilityChipTestid=null`。配信 chip は二次 dialog（初期 close）に降格済のため `toHaveCount(0)`→`toBeHidden()`。dead な family-distribute else 分岐を registry 駆動 assert に置換 |
| AC3 | notifications route 要素と spec を整合（admin-settings-routes:65 green） | 同上 | HEAD `8919c10d` / #3186 で旧 `#notification-status`（命令的 DOM）撤廃 → 常時描画の `data-testid="notification-browser-status"` に集約。locator を testid に同期 |
| AC4 | 3 spec が green | `npx playwright test <3 spec> --project=tablet --workers=2` | HEAD `8919c10d` / **22 passed (30.4s)** / 失敗 0 |
| AC5 | refactor×markup の per-PR 重量 e2e 整合を #3152/#3172/#3173 で機械化（横展開） | 本 PR scope 外（予防 EPIC #3152/#3172/#3173 が担当）。本 PR は #3233 の e2e 同期に限定 | 横展開セクション参照 |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI（E2E テスト 3 spec のみ。production code 無変更）

**影響を受ける画面・機能**: テストのみ変更。production の admin 活動削除 / 通知設定 / checklist 配信 UI は無変更（既に正しく動作）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: admin e2e 3 spec の assertion を refactor 後の実 DOM/role に同期（production code 無変更）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high、test sync）

## スクリーンショット / ビジュアルデモ

該当なし（E2E テスト assertion のみの変更。production UI 無変更のため視覚差分ゼロ）。

**インタラクティブ状態**: N/A。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 各 spec を SSOT（ADR-0062 role / #3186 markup / registry binding）に 1 対 1 で整合
- [x] **DRY**: contract test の dead な family-distribute 分岐を registry 駆動の単一 assert に統合
- [x] **YAGNI**: family-distribute 資源は現存しないため当該分岐を削除（再導入時に拡張する旨を明記）
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: success=status / error=alert の WCAG 4.1.3 整合をテストでも担保
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [x] E2E / ユニットシード + チュートリアルを同期（本 PR の主眼）
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [x] 並行 PR overlap 確認 (#1200)（#3221 merged / #3186 merged / #3098・#3126 merged を develop 上で確認）
- [ ] N/A — 並行実装の影響範囲外

> root class（軽量レーンすり抜け→統合 e2e でのみ露見、#3104→#3132→#3163→#3233）の機械捕捉は予防 EPIC #3152（shift-left fitness）/ #3172（qa gate）/ #3173（dev gate）が担う。本 PR は #3233 の e2e 同期に限定し、予防策は当該 EPIC で実装する。

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**: AC1 は Issue 本文の「role=alert で回復」表現と異なり **role=status に同期**した。理由は ADR-0062（#3221、本セッションで PO 承認済）が成功通知 = `role="status"`(polite、WCAG 4.1.3) を定めており、削除成功は success Toast のため status が正。alert への巻き戻しは ADR-0062 違反になる。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC5 予防 EPIC は scope 外として明記）
- [x] UI 変更なし（test sync のため SS 該当なし）
- [x] 該当 3 spec を tablet project 単独で 22 passed 確認

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
