### PR TITLE
test(infra): #3102 Origin Shield 追加の CDK 非 replacement を template-level で regression assert

### DIFF
--- a/tests/unit/infra/multi-lambda-cdk.test.ts
+++ b/tests/unit/infra/multi-lambda-cdk.test.ts
@@ -29,7 +29,7 @@ import { StorageStack } from '../../../infra/lib/storage-stack';
 // suite 全体で 1 回のみ synth してテンプレートを共有する。
 // テストは Template (read-only) の assertion のみなので相互干渉しない。
 
-// cspell:ignore hostedzone TESTPOOL
+// cspell:ignore hostedzone TESTPOOL oacs
 // Pre-populated cdk context: route53 + acm の fromLookup が credentials を要求するため、
 // CDK_DEFAULT_ACCOUNT と 本番と同じ hosted-zone lookup の cache を test の app に直接注入する。
 // 値は CDK synth が CFN を生成するためだけに使われ、AWS API は呼ばない。
@@ -257,6 +257,56 @@ describe('ADR-0048 Multi-Lambda Demo Deployment (#2097 week 4)', () => {
 			).Properties?.DistributionConfig?.Origins ?? []) as CfnOrigin[];
 			return origins.filter((o) => o.OriginShield?.Enabled === true);
 		}
+
+		// #3102: Origin Shield 追加 (#3087) の最重要不変条件 = 既存 s3ErrorOrigin の OAC 論理 ID が
+		// churn せず CloudFront Distribution が replace されないこと。#3087 は `/error/*` を `/_app/*` より
+		// 先に宣言し s3ErrorOrigin を origin index 2 に固定して preempt 済だが、shield 有無/region/count の
+		// assert のみで template-level の非 replacement を守れておらず、宣言順 preempt を崩す将来変更を
+		// deploy 直前 (check-cdk-replacement.mjs gate) まで検知できなかった。本 test 群で PR-lane に前倒す。
+		it('s3ErrorOrigin の OAC 論理 ID が origin index 2 由来で安定 = 宣言順 preempt が崩れていない (非 replacement、#3102)', () => {
+			const oacs = networkTemplate.findResources('AWS::CloudFront::OriginAccessControl');
+			const oacIds = Object.keys(oacs);
+			// s3ErrorOrigin の OAC ちょうど 1 本。
+			expect(oacIds.length).toBe(1);
+			// 論理 ID prefix は origin index (`CDNOrigin2`) 由来。`CDNOrigin2` → `CDNOrigin3` 等への変化 =
+			// origin 宣言順が変わり既存 error origin OAC が replace される signal (= CloudFront churn)。
+			// 末尾 hash は aws-cdk-lib バージョン依存のため prefix で判定し、CDK upgrade での誤検知を避けつつ
+			// 「index ずれ」だけを捕捉する。意図的に index を変える際は cdk diff で requires replacement 0 を
+			// 確認すること (ADR-0019)。
+			expect(oacIds[0]).toMatch(/^CDNOrigin2S3OriginAccessControl/);
+		});
+
+		it('本番 Distribution の s3ErrorOrigin が origin index 2 のまま (staticAssetOrigin 追加で displace されない、#3102)', () => {
+			const distributions = networkTemplate.findResources('AWS::CloudFront::Distribution');
+			const cdn = Object.entries(distributions).find(([lid]) => lid.startsWith('CDN'));
+			expect(cdn, '本番 CDN distribution が存在する').toBeDefined();
+			const origins = ((
+				cdn?.[1] as {
+					Properties?: {
+						DistributionConfig?: {
+							Origins?: Array<{
+								Id?: string;
+								OriginAccessControlId?: unknown;
+								S3OriginConfig?: unknown;
+							}>;
+						};
+					};
+				}
+			).Properties?.DistributionConfig?.Origins ?? []) as Array<{
+				Id?: string;
+				OriginAccessControlId?: unknown;
+				S3OriginConfig?: unknown;
+			}>;
+			// S3 (OAC) origin = s3ErrorOrigin。ちょうど 1 本で Id は index 2 (CDNOrigin2) を保つ。
+			const s3Origins = origins.filter(
+				(o) => o.OriginAccessControlId != null || o.S3OriginConfig != null,
+			);
+			expect(s3Origins.length).toBe(1);
+			expect(String(s3Origins[0]?.Id)).toContain('CDNOrigin2');
+			// origin は 3 本: lambda(index1) / s3Error(index2) / staticAsset shield(index3)。
+			// 新規 origin を index 2 より前に挿入すると s3Error が displace され OAC が churn する。
+			expect(origins.length).toBe(3);
+		});
 
 		it('本番 distribution の /_app/* origin に Origin Shield (us-east-1) が有効', () => {
 			const shielded = shieldOriginsFor('CDN');


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（インフラ安定性・デプロイ安全性）

**解決する課題**: PR #3099（#3087 CloudFront /_app/* Origin Shield）の最重要不変条件は、既存 s3ErrorOrigin の OAC 論理 ID が churn せず CloudFront Distribution が replace されないこと。#3087 は `/error/*` を `/_app/*` より先に宣言し s3ErrorOrigin を origin index 2 に固定して preempt 済だが、既存 unit test は shield 有無/region/count のみ assert し **template-level の非 replacement を守れておらず**、宣言順 preempt を崩す将来変更を deploy 直前まで検知できなかった。

**期待される効果**: 非 replacement 不変条件を PR-lane の unit test で regression 検出。origin 宣言順を崩す変更を deploy 前（PR 時点）に CI で捕捉する。

## 関連 Issue

closes #3102

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | s3ErrorOrigin の OAC 論理 ID 安定を template-level で assert | `tests/unit/infra/multi-lambda-cdk.test.ts` | HEAD `6a8aa8a0c` / OAC 1 本 + 論理 ID prefix `CDNOrigin2S3OriginAccessControl` (index 2 由来) を assert。index ずれ (replace signal) を捕捉。末尾 hash は CDK バージョン依存のため prefix 判定で誤検知回避。23 passed |
| AC2 | staticAssetOrigin 追加で s3ErrorOrigin が displace されない | 同 test | HEAD `6a8aa8a0c` / 本番 Distribution の S3(OAC) origin が index 2 (`CDNOrigin2`) のまま、origin 計 3 本 (lambda/s3Error/staticAsset shield) を assert |
| AC3 | cdk diff の PR-lane 機械検証の評価 | PR 本文に記載 | HEAD `6a8aa8a0c` / `check-cdk-replacement.mjs` は cdk diff で live AWS stack state を要し PR CI で実行不可。代替として本 unit snapshot を PR-lane regression 機構に採用、ADR-0019 deploy gate は維持 |

## 変更タイプ

- [x] test: テスト改善
- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] インフラ (`infra/`) — の CDK 構造に対する unit test のみ追加（infra 実装は不変）

**影響を受ける画面・機能**: なし（CDK regression test の追加のみ。stack 定義・デプロイ成果物は不変）。

## テスト & 安全装置セルフチェック

- [ ] `npm run pre-ready -- --pr <num>` 全 Step PASS（Draft、CI 検証中）
- [x] 追加・変更したテスト: 非 replacement 不変条件の 2 assert 追加（OAC 論理 ID prefix 安定 / s3ErrorOrigin index 2 維持）。23 passed
- [x] 新規 env / secret: N/A
- [x] DynamoDB 実装変更: N/A
- [x] Critical バグ修正: N/A
- [x] **重量 e2e 敏感領域チェック (dev-session #3173)**: 非該当（infra CDK test のみ、アプリ DB/export-import/reward/parent-gate 非接触）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: CDK 構造の unit test 追加で UI 非変更。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 既存 test の Origin Shield describe 内に同主旨の assert を追加、helper は既存パターン踏襲
- [x] **DRY**: networkTemplate.findResources を既存同様に再利用
- [x] **YAGNI**: part 3 (check-cdk-replacement PR-lane 化) は live AWS 依存で不可と評価し、unit snapshot で代替（過剰実装回避、ADR-0010）
- [x] **Security**: N/A（test）。OAC/IAM isolation の既存 regression は不変
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A（synth は既存 beforeAll で 1 回共有）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): N/A（infra 実装不変、regression test のみ。13-AWS設計書の Origin Shield 記述は #3087 で同期済）
- [x] **並行 PR overlap** (#1200): multi-lambda-cdk.test.ts を触る他 open PR なし

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（CDK regression test の追加のみ）

**レビュー依頼事項・QA**: OAC 論理 ID を exact-match でなく **prefix (`CDNOrigin2S3OriginAccessControl`) match** とした判断（CDK upgrade での hash 変動誤検知を避けつつ index ずれ = replace signal だけを捕捉）の妥当性をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3102` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了・先送りの AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（Phase 分割なし）
- [x] UI 変更時: N/A（infra test）
- [x] 認証画面変更時: N/A

## QM レビュー結果

QM 記入欄（未レビュー）。
