### PR TITLE
fix: #3225 silent-failure rollout — 残 parent/ops 4 サイトを統一エラー通知 helper に配線 (EPIC #3217 P1)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1201,6 +1201,25 @@ PO 既出方針として「must 表現はカード演出に統合し、専用セ
 
 **回帰検証の両輪**: Toast の role / 手動閉じの操作回帰は `Toast.stories.svelte` の `play` 関数（component 層、`npm run test:storybook`、CX-DoR #8）+ `tests/unit/ui/error-notify.test.ts`（helper の種別 × 文言マッピング unit）で担保する。error Toast の SS は capture flow `scripts/capture-specs/flows/error-toast-3218.mjs`（Storybook `Primitives/Toast` `Error` story）で撮影する。
 
+#### 4xx echo hardening + Toast stack-cap / dedup（#3225、PR #3237）
+
+- **echo hardening**（`resolveApiErrorMessage` / `sanitizeServerMessage`）: 4xx の serverMessage を verbatim 表示せず、(a) 制御文字除去 + (b) 最大長 200 字 cap + (c) 日本語を 1 つも含まない body（内部識別子 / 例外クラス名 / dump 疑い）はステータス別の汎用文言へフォールバック。info-disclosure + layout-break を抑える（XSS は Svelte textContent で既に閉）。
+- **Toast stack-cap / dedup**（`src/lib/ui/toast-stack.ts` `reconcileToastStack`）: error Toast が非自動消滅のため連続失敗で積み上がり UI / ✕ を覆う問題を抑制。同一（title / description / type）は多重表示せず、同時表示は `MAX_TOASTS`（4）を上限に最古から退避する。
+
+#### silent-failure rollout（#3225、PR #3241、EPIC #3217 P1）
+
+2026-06-22 監査で確定した残 silent-fail サイトを helper 経由でユーザ可視フィードバックに統一した。**成功パスは不変、失敗パスにのみ error Toast を追加**する wiring（通常画面の視覚差分ゼロ）。
+
+| 画面 / 経路 | 種別 | 配線 |
+|---|---|---|
+| `admin/status`（レベル称号 4 form action） | form action | failure / error → `notifyActionError` |
+| `admin/packs`（パック取込） | form action | failure → `notifyActionError` |
+| `admin/settings/activities`（decay 保存 / ポイント設定） | fetch / form action | `!res.ok` → `notifyApiError` + `catch` → `notifyNetworkError` / failure → `notifyActionError` |
+| `ops/export`（CSV エクスポート） | fetch | `!res.ok` → `notifyApiError` + `catch` → `notifyNetworkError` |
+| `admin/members`（招待 / ビューア取消 3 関数） | fetch | 失敗時は `reload()` せず `notifyApiError` + `catch` → `notifyNetworkError` |
+
+子供画面（`(child)/[uiMode]/home` の `togglePin` 等）の silent-fail は、`preschool` / `baby` のひらがな整合（§8 / DESIGN.md §8）のため age-tier 対応文言（#3225 ②b）と同時に配線する。
+
 ---
 
 ## 8. 表示カスタマイズ（DisplayConfig）

--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1213,12 +1213,11 @@ PO 既出方針として「must 表現はカード演出に統合し、専用セ
 | 画面 / 経路 | 種別 | 配線 |
 |---|---|---|
 | `admin/status`（レベル称号 4 form action） | form action | failure / error → `notifyActionError` |
-| `admin/packs`（パック取込） | form action | failure → `notifyActionError` |
 | `admin/settings/activities`（decay 保存 / ポイント設定） | fetch / form action | `!res.ok` → `notifyApiError` + `catch` → `notifyNetworkError` / failure → `notifyActionError` |
 | `ops/export`（CSV エクスポート） | fetch | `!res.ok` → `notifyApiError` + `catch` → `notifyNetworkError` |
 | `admin/members`（招待 / ビューア取消 3 関数） | fetch | 失敗時は `reload()` せず `notifyApiError` + `catch` → `notifyNetworkError` |
 
-子供画面（`(child)/[uiMode]/home` の `togglePin` 等）の silent-fail は、`preschool` / `baby` のひらがな整合（§8 / DESIGN.md §8）のため age-tier 対応文言（#3225 ②b）と同時に配線する。
+`admin/packs`（パック取込 form action）は raw `<button>` の Button primitive 化（`local/no-raw-button`）と同時に配線するため、別 Issue で扱う。子供画面（`(child)/[uiMode]/home` の `togglePin` 等）の silent-fail は、`preschool` / `baby` のひらがな整合（§8 / DESIGN.md §8）のため age-tier 対応文言（#3225 ②b）と同時に配線する。
 
 ---
 

--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1201,11 +1201,6 @@ PO 既出方針として「must 表現はカード演出に統合し、専用セ
 
 **回帰検証の両輪**: Toast の role / 手動閉じの操作回帰は `Toast.stories.svelte` の `play` 関数（component 層、`npm run test:storybook`、CX-DoR #8）+ `tests/unit/ui/error-notify.test.ts`（helper の種別 × 文言マッピング unit）で担保する。error Toast の SS は capture flow `scripts/capture-specs/flows/error-toast-3218.mjs`（Storybook `Primitives/Toast` `Error` story）で撮影する。
 
-#### 4xx echo hardening + Toast stack-cap / dedup（#3225、PR #3237）
-
-- **echo hardening**（`resolveApiErrorMessage` / `sanitizeServerMessage`）: 4xx の serverMessage を verbatim 表示せず、(a) 制御文字除去 + (b) 最大長 200 字 cap + (c) 日本語を 1 つも含まない body（内部識別子 / 例外クラス名 / dump 疑い）はステータス別の汎用文言へフォールバック。info-disclosure + layout-break を抑える（XSS は Svelte textContent で既に閉）。
-- **Toast stack-cap / dedup**（`src/lib/ui/toast-stack.ts` `reconcileToastStack`）: error Toast が非自動消滅のため連続失敗で積み上がり UI / ✕ を覆う問題を抑制。同一（title / description / type）は多重表示せず、同時表示は `MAX_TOASTS`（4）を上限に最古から退避する。
-
 #### silent-failure rollout（#3225、PR #3241、EPIC #3217 P1）
 
 2026-06-22 監査で確定した残 silent-fail サイトを helper 経由でユーザ可視フィードバックに統一した。**成功パスは不変、失敗パスにのみ error Toast を追加**する wiring（通常画面の視覚差分ゼロ）。

--- a/src/routes/(parent)/admin/members/+page.svelte
+++ b/src/routes/(parent)/admin/members/+page.svelte
@@ -2,6 +2,7 @@
 import QRCode from 'qrcode';
 import { page } from '$app/stores';
 import { APP_LABELS, MEMBERS_LABELS, PAGE_TITLES } from '$lib/domain/labels';
+import { notifyApiError, notifyNetworkError } from '$lib/ui/error-notify';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
@@ -63,7 +64,17 @@ async function createInvite() {
 
 async function revokeInvite(code: string) {
 	if (!confirm(MEMBERS_LABELS.revokeConfirm)) return;
-	await fetch(`/api/v1/admin/invites/${code}`, { method: 'DELETE' });
+	try {
+		const res = await fetch(`/api/v1/admin/invites/${code}`, { method: 'DELETE' });
+		// #3225: 取り消し失敗を silent にしない (失敗時は reload せず error Toast)
+		if (!res.ok) {
+			await notifyApiError(res);
+			return;
+		}
+	} catch {
+		notifyNetworkError();
+		return;
+	}
 	window.location.reload();
 }
 
@@ -117,13 +128,33 @@ async function createViewerLink() {
 
 async function revokeViewerToken(id: number) {
 	if (!confirm(MEMBERS_LABELS.viewerRevokeConfirm)) return;
-	await fetch(`/api/v1/admin/viewer-tokens/${id}?action=revoke`, { method: 'DELETE' });
+	try {
+		const res = await fetch(`/api/v1/admin/viewer-tokens/${id}?action=revoke`, {
+			method: 'DELETE',
+		});
+		if (!res.ok) {
+			await notifyApiError(res);
+			return;
+		}
+	} catch {
+		notifyNetworkError();
+		return;
+	}
 	window.location.reload();
 }
 
 async function deleteViewerToken(id: number) {
 	if (!confirm(MEMBERS_LABELS.viewerDeleteConfirm)) return;
-	await fetch(`/api/v1/admin/viewer-tokens/${id}`, { method: 'DELETE' });
+	try {
+		const res = await fetch(`/api/v1/admin/viewer-tokens/${id}`, { method: 'DELETE' });
+		if (!res.ok) {
+			await notifyApiError(res);
+			return;
+		}
+	} catch {
+		notifyNetworkError();
+		return;
+	}
 	window.location.reload();
 }
 

--- a/src/routes/(parent)/admin/packs/+page.svelte
+++ b/src/routes/(parent)/admin/packs/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { APP_LABELS, PACKS_PAGE_LABELS, PAGE_TITLES } from '$lib/domain/labels';
-import { notifyActionError } from '$lib/ui/error-notify';
 import Button from '$lib/ui/primitives/Button.svelte';
 
 let { data } = $props();
@@ -114,10 +113,8 @@ const categoryLabels: Record<string, string> = {
 						{#if !pack.isFullyImported}
 							<form method="POST" action="?/importPack" use:enhance={() => {
 								importing = pack.packId;
-								return async ({ result, update }) => {
+								return async ({ update }) => {
 									importing = null;
-									// #3225: 取込失敗を silent にしない (failure/error を error Toast 化)
-									notifyActionError(result);
 									await update();
 								};
 							}}>

--- a/src/routes/(parent)/admin/packs/+page.svelte
+++ b/src/routes/(parent)/admin/packs/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { APP_LABELS, PACKS_PAGE_LABELS, PAGE_TITLES } from '$lib/domain/labels';
+import { notifyActionError } from '$lib/ui/error-notify';
 import Button from '$lib/ui/primitives/Button.svelte';
 
 let { data } = $props();
@@ -113,8 +114,10 @@ const categoryLabels: Record<string, string> = {
 						{#if !pack.isFullyImported}
 							<form method="POST" action="?/importPack" use:enhance={() => {
 								importing = pack.packId;
-								return async ({ update }) => {
+								return async ({ result, update }) => {
 									importing = null;
+									// #3225: 取込失敗を silent にしない (failure/error を error Toast 化)
+									notifyActionError(result);
 									await update();
 								};
 							}}>

--- a/src/routes/(parent)/admin/settings/activities/+page.svelte
+++ b/src/routes/(parent)/admin/settings/activities/+page.svelte
@@ -8,6 +8,7 @@ import { APP_LABELS, PAGE_TITLES, SETTINGS_LABELS } from '$lib/domain/labels';
 import type { CurrencyCode, PointUnitMode } from '$lib/domain/point-display';
 import { CURRENCY_CODES, CURRENCY_DEFS, formatPointValue } from '$lib/domain/point-display';
 import { ErrorAlert, SuccessAlert } from '$lib/ui/components';
+import { notifyActionError, notifyApiError, notifyNetworkError } from '$lib/ui/error-notify';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
@@ -47,11 +48,17 @@ async function saveDecayIntensity() {
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ intensity: decayIntensity }),
 		});
-		if (!res.ok) throw new Error('Failed to save');
+		// #3225: 保存失敗を silent にしない (error Toast でユーザに通知)
+		if (!res.ok) {
+			await notifyApiError(res);
+			return;
+		}
 		decaySuccess = true;
 		setTimeout(() => {
 			decaySuccess = false;
 		}, 3000);
+	} catch {
+		notifyNetworkError();
 	} finally {
 		decaySaving = false;
 	}
@@ -153,6 +160,9 @@ const previewFormatted = $derived(
 					pointSubmitting = false;
 					if (result.type === 'success') {
 						pointSuccess = true;
+					} else {
+						// #3225: ポイント設定の保存失敗を silent にしない
+						notifyActionError(result);
 					}
 					await update();
 				};

--- a/src/routes/(parent)/admin/status/+page.svelte
+++ b/src/routes/(parent)/admin/status/+page.svelte
@@ -6,6 +6,7 @@ import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { calcDeviationScore, getComparisonLabel } from '$lib/domain/validation/status';
 import { SuccessAlert } from '$lib/ui/components';
 import RadarChart from '$lib/ui/components/RadarChart.svelte';
+import { notifyActionError } from '$lib/ui/error-notify';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
@@ -200,6 +201,9 @@ let levelTitleInputs: Record<number, string> = $state({});
 											levelTitleSuccess = true;
 											delete levelTitleInputs[lt.level];
 											await invalidateAll();
+										} else {
+											// #3225: 保存失敗を silent にしない (failure/error を error Toast 化)
+											notifyActionError(result);
 										}
 									};
 								}}
@@ -241,6 +245,9 @@ let levelTitleInputs: Record<number, string> = $state({});
 											levelTitleSuccess = true;
 											delete levelTitleInputs[lt.level];
 											await invalidateAll();
+										} else {
+											// #3225: 保存失敗を silent にしない (failure/error を error Toast 化)
+											notifyActionError(result);
 										}
 									};
 								}}
@@ -272,6 +279,9 @@ let levelTitleInputs: Record<number, string> = $state({});
 									levelTitleSuccess = true;
 									levelTitleInputs = {};
 									await invalidateAll();
+								} else {
+									// #3225: 一括リセット失敗を silent にしない
+									notifyActionError(result);
 								}
 							};
 						}}
@@ -369,6 +379,9 @@ let levelTitleInputs: Record<number, string> = $state({});
 								delete bmInputMean[bmKey];
 								delete bmInputSd[bmKey];
 								await invalidateAll();
+							} else {
+								// #3225: ベンチマーク更新失敗を silent にしない
+								notifyActionError(result);
 							}
 						};
 					}}

--- a/src/routes/ops/export/+page.svelte
+++ b/src/routes/ops/export/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { OPS_EXPORT_LABELS } from '$lib/domain/labels';
+import { notifyApiError, notifyNetworkError } from '$lib/ui/error-notify';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import NativeSelect from '$lib/ui/primitives/NativeSelect.svelte';
@@ -25,7 +26,11 @@ async function downloadCsv(type: 'sales' | 'expenses' | 'summary') {
 				headers: { Accept: 'text/csv' },
 			},
 		);
-		if (!res.ok) throw new Error(`Export failed: ${res.status}`);
+		// #3225: エクスポート失敗を silent にしない (catch 不在で例外が無反応化していた)
+		if (!res.ok) {
+			await notifyApiError(res);
+			return;
+		}
 
 		const blob = await res.blob();
 		const url = URL.createObjectURL(blob);
@@ -34,6 +39,8 @@ async function downloadCsv(type: 'sales' | 'expenses' | 'summary') {
 		a.download = `${type}_${year}_${monthFrom}-${monthTo}.csv`;
 		a.click();
 		URL.revokeObjectURL(url);
+	} catch {
+		notifyNetworkError();
 	} finally {
 		downloading = false;
 	}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ 運営（ops）

**解決する課題**: バックエンドエラー時に**ユーザへ何も通知されず無反応**になる silent-failure（WCAG 3.3.1 A + 4.1.3 AA 二重違反 / JIS X 8341-3:2016）を、2026-06-22 監査で確定した残サイトで根治する。P0（PR #3221）で helper + cheer/points を対応済み。本 PR は残る parent/ops の 4 サイトを統一 helper に配線する。

**期待される効果**: 設定保存・取込・エクスポート・メンバー取消などの失敗時に必ず error Toast が出て、ユーザが「失敗した」と分かる（再試行できる）。

## 関連 Issue

EPIC #3217 / #3225（P1 追跡 Issue、本 PR では close しない）/ ADR-0062 / PR #3221（P0 helper）/ PR #3237（hardening）

本 PR は #3225 のうち「全 form rollout（残 parent/ops silent-fail サイト）」を実装する。`admin/packs` は disclosure raw `<button>` の `no-raw-button` 解消と同時配線が必要なため #3242 に分離。child home togglePin（child 画面）と age-tier 対応 labels は #3225 ②b で同時対応する（理由は下記）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | admin/status の 4 form action failure を error Toast 化 | `grep -n notifyActionError src/routes/(parent)/admin/status/+page.svelte` | HEAD `3db92e86` / 4 箇所（saveLevelTitle/resetLevelTitle/resetAll/updateBenchmark）に `else { notifyActionError(result) }` |
| AC3 | settings/activities の decay 保存 fetch + point form action を非 silent 化 | 同ファイル grep | HEAD `3db92e86` / decay: `!res.ok→notifyApiError` + `catch→notifyNetworkError` / point: `else notifyActionError` |
| AC4 | ops/export の CSV fetch を非 silent 化（catch 不在で例外が無反応だった） | `src/routes/ops/export/+page.svelte` | HEAD `3db92e86` / `!res.ok→notifyApiError` + `catch→notifyNetworkError` |
| AC5 | admin/members の revoke/viewer 3 fetch を失敗時 reload せず error Toast 化 | `src/routes/(parent)/admin/members/+page.svelte` | HEAD `3db92e86` / revokeInvite/revokeViewerToken/deleteViewerToken の DELETE で `!res.ok→notifyApiError`（reload 抑止）+ `catch→notifyNetworkError` |
| AC6 | 成功パス不変・型健全 | `npx svelte-check --tsconfig ./tsconfig.json` | HEAD `3db92e86` / 0 errors（変更 5 file に warning なし）。success 分岐は無改変、失敗分岐の追加のみ |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI

**影響を受ける画面・機能**: admin/status・admin/settings/activities・admin/members・ops/export の **失敗時のみ** error Toast が追加。成功時 UI は不変。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: helper 自体は `error-notify.test.ts`（P0、develop）で検証済。本 PR は wiring（失敗分岐の追加）で、成功パス不変のため既存 E2E（admin-status/members 等の成功動線）に回帰なし。失敗動線は backend エラーの決定的再現が困難なため helper unit で担保
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:low）

## スクリーンショット / ビジュアルデモ

各画面の通常表示は不変（refactor）。本 PR の変更は backend エラー時にのみ既存 Toast primitive を表示する wiring で、配線後に出る error Toast の実描画を証跡として添付する（成功時 UI は無改変・視覚回帰ゼロ）。

![error-toast-after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3241/after-error-toast-alert.png)

before/after 合成: ![flow](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3241/error-toast-3218-flow.webp)

**インタラクティブ状態**: 失敗時 = error Toast（role="alert" + 非自動消滅 + 手動✕、helper SSOT）。成功時 = 既存 SuccessAlert / ファイル DL / reload を維持。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 各サイトは helper（`notifyApiError`/`notifyActionError`/`notifyNetworkError`）に委譲、表示ロジックを再実装しない
- [x] **DRY**: エラー文言・role/aria は helper + ERROR_NOTIFY_LABELS SSOT に集約
- [x] **YAGNI**: child home togglePin / age-tier labels は本 PR scope 外（#3225 ②b）
- [x] **Security（OSS 公開前提）**: 500 系は helper 側で汎用文言化（生例外露出なし）
- [x] **アクセシビリティ**: silent-failure 解消で WCAG 3.3.1 + 4.1.3 を満たす
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [x] labels SSOT (ADR-0009)（ERROR_NOTIFY_LABELS を参照、新規文言なし）
- [x] 設計書同期 (ADR-0001)（06-UI設計書 §7.1 rollout 表に追記）
- [x] 並行 PR overlap 確認 (#1200)（#3221 P0 merged 上に配線。#3237 hardening とは別ファイル群で衝突なし）
- [ ] N/A — 並行実装の影響範囲外

> **child home togglePin の意図的 scope 分離**: 同サイトは child 画面（preschool/baby はひらがな必須、DESIGN.md §8）。標準 ERROR_NOTIFY_LABELS は漢字のため、ここに配線すると age-mode 整合に反する。ひらがな化を伴う age-tier labels（#3225 ②b）と同時に対応するのが正しいため、本 parent/ops rollout からは分離した（silent のまま放置ではなく、②b で確実に対応）。

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**: 失敗分岐の追加のみで成功 UI は不変。form action への raw fetch（settings decay / members DELETE）は `!res.ok` で helper に渡し、message が取れない envelope はステータス別汎用文言にフォールバックする（生例外露出なし）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = 残 parent/ops 4 サイト）
- [x] UI 視覚差分なし（失敗時のみ既存 Toast を表示する wiring）
- [x] svelte-check 0 error を確認

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


