### PR TITLE
fix: #3242 admin/packs silent-failure 解消 + disclosure raw button の primitive 化 (EPIC #3217 P1)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1211,8 +1211,9 @@ PO 既出方針として「must 表現はカード演出に統合し、専用セ
 | `admin/settings/activities`（decay 保存 / ポイント設定） | fetch / form action | `!res.ok` → `notifyApiError` + `catch` → `notifyNetworkError` / failure → `notifyActionError` |
 | `ops/export`（CSV エクスポート） | fetch | `!res.ok` → `notifyApiError` + `catch` → `notifyNetworkError` |
 | `admin/members`（招待 / ビューア取消 3 関数） | fetch | 失敗時は `reload()` せず `notifyApiError` + `catch` → `notifyNetworkError` |
+| `admin/packs`（パック取込 form action） | form action | failure / error → `notifyActionError`（#3242。同時に pack disclosure の raw `<button>` を Button primitive=ghost 左寄せ全幅へ変換し `local/no-raw-button` を解消） |
 
-`admin/packs`（パック取込 form action）は raw `<button>` の Button primitive 化（`local/no-raw-button`）と同時に配線するため、別 Issue で扱う。子供画面（`(child)/[uiMode]/home` の `togglePin` 等）の silent-fail は、`preschool` / `baby` のひらがな整合（§8 / DESIGN.md §8）のため age-tier 対応文言（#3225 ②b）と同時に配線する。
+子供画面（`(child)/[uiMode]/home` の `togglePin` 等）の silent-fail は、`preschool` / `baby` のひらがな整合（§8 / DESIGN.md §8）のため age-tier 対応文言（#3225 ②b）と同時に配線する。
 
 ---
 

--- a/src/routes/(parent)/admin/packs/+page.svelte
+++ b/src/routes/(parent)/admin/packs/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { APP_LABELS, PACKS_PAGE_LABELS, PAGE_TITLES } from '$lib/domain/labels';
+import { notifyActionError } from '$lib/ui/error-notify';
 import Button from '$lib/ui/primitives/Button.svelte';
 
 let { data } = $props();
@@ -47,13 +48,14 @@ const categoryLabels: Record<string, string> = {
 						? 'border-[var(--color-feedback-warning-border)] bg-[var(--color-feedback-warning-bg)]'
 						: 'border-[var(--color-border)] bg-white'}"
 			>
-				<!-- Pack header -->
-				<button
-					type="button"
-					class="w-full text-left p-4"
+				<!-- Pack header (#3242: disclosure を Button primitive 化、no-raw-button 解消) -->
+				<Button
+					variant="ghost"
+					aria-expanded={expandedPack === pack.packId}
+					class="!w-full !justify-start !p-4 !font-normal !rounded-none text-left"
 					onclick={() => (expandedPack = expandedPack === pack.packId ? null : pack.packId)}
 				>
-					<div class="flex items-start gap-3">
+					<div class="flex items-start gap-3 w-full">
 						<span class="text-3xl">{pack.icon}</span>
 						<div class="flex-1 min-w-0">
 							<div class="flex items-center gap-2 flex-wrap">
@@ -86,7 +88,7 @@ const categoryLabels: Record<string, string> = {
 							</div>
 						</div>
 					</div>
-				</button>
+				</Button>
 
 				<!-- Expanded content -->
 				{#if expandedPack === pack.packId}
@@ -113,8 +115,10 @@ const categoryLabels: Record<string, string> = {
 						{#if !pack.isFullyImported}
 							<form method="POST" action="?/importPack" use:enhance={() => {
 								importing = pack.packId;
-								return async ({ update }) => {
+								return async ({ result, update }) => {
 									importing = null;
+									// #3242: 取込失敗を silent にしない (failure/error を error Toast 化)
+									notifyActionError(result);
 									await update();
 								};
 							}}>


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: `admin/packs`（みんなのテンプレート取込）の `importPack` form action が **failure / error を無視**しており、取込に失敗してもユーザに何も通知されない（silent-failure、WCAG 3.3.1 A + 4.1.3 AA 二重違反）。EPIC #3217 P1 rollout（PR #3241）からは、同ファイルの pack 開閉用 raw `<button>`（`local/no-raw-button` CI hard-fail）を解消する必要があったため #3242 に分離していた。

**期待される効果**: パック取込の失敗が error Toast でユーザに伝わる。併せて disclosure ボタンを Button primitive に統一し lint 債務を解消する。

## 関連 Issue

closes #3242

EPIC #3217 / #3225（P1）/ PR #3241（packs を除く 4 サイト rollout）/ ADR-0062 / CLAUDE.md（no-raw-button）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `admin/packs` の取込失敗が error Toast でユーザに通知される（silent 解消） | `grep -n notifyActionError src/routes/(parent)/admin/packs/+page.svelte` | HEAD `17990f36` / importPack enhance callback で `notifyActionError(result)`（success パス不変） |
| AC2 | disclosure の raw `<button>` を解消し eslint 0 error | `npx eslint src/routes/(parent)/admin/packs/+page.svelte` | HEAD `17990f36` / `<button>` → `<Button variant="ghost">`（`!w-full !justify-start !p-4 !font-normal !rounded-none text-left` + `aria-expanded`）。`local/no-raw-button` 0 件 |
| AC3 | disclosure 開閉の視覚・操作回帰なし（視覚パリティ refactor） | `/admin/packs` を demo（`AUTH_MODE=anonymous DATA_SOURCE=demo`）で撮影し目視 | HEAD `17990f36` / 下記 SS①。全幅左寄せ・年齢表記 normal weight 維持（`!font-normal`）・バッジ / 説明 / タグ / ▼ レイアウト不変。develop と pixel ほぼ同一（373KB）で視覚差分ゼロを確認 |
| AC4 | 06-UI設計書 §7.1 rollout 表に packs を追記 | `docs/design/06-UI設計書.md` | HEAD `17990f36` / §7.1 表に `admin/packs` 行追加 |
| AC5 | 型健全 | `npx svelte-check --tsconfig ./tsconfig.json` | HEAD `17990f36` / 0 errors |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI

**影響を受ける画面・機能**: `admin/packs`（パック一覧の開閉 + 取込）。開閉 UI は視覚パリティ、取込は失敗時のみ error Toast 追加。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: helper（`notifyActionError`）は `error-notify.test.ts`（develop）で検証済。本 PR は wiring + primitive 化で、disclosure 開閉の視覚回帰は demo 撮影で目視確認（視覚パリティ）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:low）

## スクリーンショット / ビジュアルデモ

本 PR は (1) disclosure の Button primitive 化（**視覚パリティ＝視覚差分ゼロの refactor**）と (2) 取込失敗時の error Toast 配線、の 2 点。視覚差分が無い refactor のため同一画像の before/after 比較は提示せず（blob-SHA 偽装防止 #2063 の趣旨に合わせ意図的に同一ペアを置かない）、代わりに **(1) 配線後の `/admin/packs` 実描画** と **(2) 配線で出るようになった error Toast** の 2 点を証跡とする。

**① Button 化後の `/admin/packs`（demo）** — 全幅左寄せ・年齢「3〜8歳」等の normal weight・バッジ / 説明 / タグ / ▼ レイアウトが従来どおり（`!font-normal` で weight 維持、ghost の hover affordance のみ意図的付与）:

![packs-disclosure](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3248/packs-disclosure.png)

**② 取込失敗時に出るようになった error Toast**（配線前は silent = 無反応。Storybook `Primitives/Toast` `Error`、role=alert + 手動✕）:

![error-toast](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3248/error-toast.png)

**インタラクティブ状態**: 取込失敗時 = error Toast（role="alert" + 非自動消滅 + 手動✕、helper SSOT）。開閉 = `aria-expanded` 付き disclosure。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 取込失敗通知は helper に委譲。disclosure は Button primitive に統一（独自 button 廃止）
- [x] **DRY**: ボタンは primitive 1 本に集約、エラー文言は ERROR_NOTIFY_LABELS SSOT
- [x] **YAGNI**: 過度な component 抽出はせず、Button override + override class で最小変更
- [x] **Security（OSS 公開前提）**: 500 系は helper 側で汎用文言化（生例外露出なし）
- [x] **アクセシビリティ**: silent 解消で WCAG 3.3.1 + 4.1.3 / disclosure に `aria-expanded` 付与
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [x] labels SSOT (ADR-0009)（ERROR_NOTIFY_LABELS 参照、新規文言なし）
- [x] 設計書同期 (ADR-0001)（06-UI設計書 §7.1 rollout 表に packs 追記）
- [x] 並行 PR overlap 確認 (#1200)（#3241 が packs 以外の 4 サイト、本 PR が packs を担当。ファイル重複なし）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**: disclosure を Button(ghost) に変換する際、`!font-normal` で年齢・説明・タグの normal weight を維持し、`font-bold` 明示の pack 名・バッジのみ太字を保持。ghost variant 由来の subtle hover（`hover:bg-black/5`）は disclosure の操作 affordance として意図的に許容。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS（Button 化後の packs 描画 + error Toast）を添付（視覚パリティ refactor のため同一 before/after ペアは置かず）
- [x] eslint（no-raw-button）/ svelte-check 0 error

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

