### PR TITLE
fix(security): #3246 export endpoint を import と対称な owner/parent gate に揃える（家庭内 IDOR、#3244 HOLD）

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -371,6 +371,22 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 - **anchor robustness の不変条件（#3139）**: 本防御は「`child.avatarUrl` は server が tenant-scoped key からのみ生成し attacker が設定できない」ことに依存する。import/restore が attacker-influenced な値を `avatarUrl` に書けると anchor が silently 無効化されるため、`remapChildAvatarUrls` が外部入力由来の avatarUrl を verbatim 永続化しない（null か取込先 tenant prefix 配下の server key にのみ再構成）ことを `tests/unit/services/import-service-avatar-remap.test.ts` の invariant test で固定する（`insertChild` は構造的に avatarUrl 引数を取らない = 初期 null）。
 - **deny 理由の観測性（#3139）**: 全 deny path（`no-context` / `malformed-filename` / `no-child` / `ownership-mismatch` / `file-missing`）は存在秘匿のため一律 **404**（レスポンスは不変）だが、配信ハンドラ（`uploads/avatars/[filename]/+server.ts` の `denyAvatar`）が deny 理由を内部ログ（`logger.info`、response には漏らさない）に記録し、攻撃 404（`ownership-mismatch` 等）と正常 404（default-icon fallback）の監視切り分けを可能にする。
 
+#### 5.2.2 export endpoint group の認可境界（家庭内 IDOR 防止、#3246）
+
+`ROUTE_RULES` の `/api/v1/**` は child role 到達を許す（子供画面が自分のデータを GET するため）。一方 export endpoint は `?childId` 指定で他の子供（兄弟）のデータを一括取得できるため、**import と対称に owner/parent gate をハンドラ層で強制**する。child role が `?childId` で兄弟データを列挙できる家庭内 IDOR（CWE-639）を塞ぐ。
+
+| export endpoint | 許可ロール（`requireRole`） | child role |
+|---|---|---|
+| `/api/v1/activities/export`（#3246） | `['owner', 'parent']` | 403 |
+| `/api/v1/checklists/export`（#3246） | `['owner', 'parent']` | 403 |
+| `/api/v1/special-rewards/export`（#3246） | `['owner', 'parent']` | 403 |
+| `/api/v1/export`（全体バックアップ） | `['owner', 'parent']` | 403 |
+| `/api/v1/export/cloud`（`GET` / `POST`） | `['owner', 'parent']` | 403 |
+| `/api/v1/export/cloud/[id]` | `['owner', 'parent']` | 403 |
+| `/api/v1/admin/account/export` | `['owner']`（owner 限定の更に厳格な gate） | 403 |
+
+- **fitness function**: `tests/unit/routes/export-authz-symmetry-3246.test.ts` が「全 `/api/v1/**/export/**/+server.ts` が `requireRole(['owner', 'parent'])` を呼び、許可ロールに `'child'` を含まない」ことを契約テストで機械検証する（新規 export 追加時の gate 漏れを検出）。あわせて child role → 403 / parent role → gate 通過 の振る舞いを担保する。
+
 ### 5.3 ライセンス状態による制限
 
 | ライセンス状態 | アクセス制限 |

--- a/src/routes/api/v1/activities/export/+server.ts
+++ b/src/routes/api/v1/activities/export/+server.ts
@@ -12,6 +12,7 @@ import { json } from '@sveltejs/kit';
 import { CATEGORY_CODES } from '$lib/domain/validation/activity';
 import { dispatchExportToJson } from '$lib/marketplace/export-dispatcher';
 import type { ActivityPackPayload } from '$lib/marketplace/schemas/activity-pack-schema';
+import { requireRole } from '$lib/server/auth/factory';
 import { getActivities } from '$lib/server/services/activity-service';
 import type { RequestHandler } from './$types';
 
@@ -21,6 +22,8 @@ for (const [i, code] of CATEGORY_CODES.entries()) {
 }
 
 export const GET: RequestHandler = async ({ locals }) => {
+	// #3246: export は import と同じ owner/parent gate に揃える (child role 到達不可)。
+	requireRole(locals, ['owner', 'parent']);
 	const context = locals.context;
 	if (!context) {
 		return json({ error: '認証が必要です' }, { status: 401 });

--- a/src/routes/api/v1/checklists/export/+server.ts
+++ b/src/routes/api/v1/checklists/export/+server.ts
@@ -12,6 +12,7 @@ import { json } from '@sveltejs/kit';
 import { buildAttachmentContentDisposition } from '$lib/domain/export-format';
 import { dispatchExportToJson } from '$lib/marketplace/export-dispatcher';
 import type { ChecklistPayload } from '$lib/marketplace/schemas/checklist-schema';
+import { requireRole } from '$lib/server/auth/factory';
 import { findTemplateById, findTemplateItems } from '$lib/server/db/checklist-repo';
 import type { RequestHandler } from './$types';
 
@@ -27,6 +28,8 @@ function timeSlotToTiming(timeSlot: string): ChecklistPayload['timing'] {
 }
 
 export const GET: RequestHandler = async ({ locals, url }) => {
+	// #3246: export は import と同じ owner/parent gate に揃える (child role 到達不可)。
+	requireRole(locals, ['owner', 'parent']);
 	const context = locals.context;
 	if (!context) {
 		return json({ error: '認証が必要です' }, { status: 401 });

--- a/src/routes/api/v1/special-rewards/export/+server.ts
+++ b/src/routes/api/v1/special-rewards/export/+server.ts
@@ -11,12 +11,16 @@ import { json } from '@sveltejs/kit';
 import { REWARD_CATEGORIES } from '$lib/domain/validation/special-reward';
 import { dispatchExportToJson } from '$lib/marketplace/export-dispatcher';
 import type { RewardSetPayload } from '$lib/marketplace/schemas/reward-set-schema';
+import { requireRole } from '$lib/server/auth/factory';
 import { getChildSpecialRewards } from '$lib/server/services/special-reward-service';
 import type { RequestHandler } from './$types';
 
 const VALID_CATEGORIES = new Set<string>(REWARD_CATEGORIES);
 
 export const GET: RequestHandler = async ({ locals, url }) => {
+	// #3246: export は import と同じ owner/parent gate に揃える (child role 到達不可)。
+	// child から ?childId 指定で兄弟データを列挙できる家庭内 IDOR を塞ぐ。
+	requireRole(locals, ['owner', 'parent']);
 	const context = locals.context;
 	if (!context) {
 		return json({ error: '認証が必要です' }, { status: 401 });

--- a/tests/unit/routes/export-authz-symmetry-3246.test.ts
+++ b/tests/unit/routes/export-authz-symmetry-3246.test.ts
@@ -1,0 +1,100 @@
+// tests/unit/routes/export-authz-symmetry-3246.test.ts
+//
+// #3246: export endpoint の role 認可境界を import と対称化する。
+// 新設の special-rewards / checklists / activities export が child role で到達でき、
+// ?childId 指定で兄弟データを列挙できた (家庭内 IDOR)。import 側は owner/parent gate 済で非対称。
+//
+// 本テストは 2 段で守る:
+//   (A) 契約テスト: 全 /api/v1/**/export/**/+server.ts が requireRole(['owner','parent']) を呼ぶ
+//       (新規 export 追加時の gate 漏れを機械検出 = fitness function)
+//   (B) 振る舞いテスト: child role で 3 endpoint を叩くと 403、parent role は gate を通過する
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { glob } from 'glob';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(__dirname, '../../..');
+
+// 認可境界を持たない正当な例外 (別 gate で守られる / 別レイヤ):
+//   - admin/account/export: 既に requireRole 済
+//   - export/cloud: 既に requireRole 済
+// → これらも requireRole を持つので除外不要だが、将来 gate 方式が異なる endpoint を
+//   ここに列挙して握り潰さないよう、原則「全 export が requireRole を呼ぶ」を要求する。
+describe('#3246 (A) export 認可境界 契約テスト', () => {
+	it('全 /api/v1/**/export/**/+server.ts が requireRole(owner/parent) を呼ぶ', async () => {
+		const files = await glob('src/routes/api/v1/**/export/**/+server.ts', { cwd: ROOT });
+		expect(files.length).toBeGreaterThan(0);
+
+		const offenders: string[] = [];
+		for (const rel of files) {
+			const src = readFileSync(resolve(ROOT, rel), 'utf8');
+			// requireRole(locals, [...]) を呼び、許可ロールに 'child' を含まないこと。
+			// (account/export の ['owner'] のような owner 限定の更に厳格な gate も許容する)
+			const m = src.match(/requireRole\s*\(\s*locals\s*,\s*\[([^\]]*)\]/);
+			const allowsChild = !!m && /['"]child['"]/.test(m[1] ?? '');
+			if (!m || allowsChild) offenders.push(rel);
+		}
+		expect(
+			offenders,
+			`requireRole(owner/parent) 欠落の export endpoint: ${offenders.join(', ')}`,
+		).toEqual([]);
+	});
+});
+
+function childLocals() {
+	return {
+		context: { tenantId: 't-1', role: 'child', childId: 1 },
+	} as unknown as App.Locals;
+}
+function parentLocals() {
+	return {
+		context: { tenantId: 't-1', role: 'parent' },
+	} as unknown as App.Locals;
+}
+
+async function callGet(
+	modPath: string,
+	locals: App.Locals,
+	urlStr: string,
+): Promise<{ status?: number; thrown?: unknown }> {
+	const mod = await import(modPath);
+	try {
+		const res = await mod.GET({ locals, url: new URL(urlStr) } as never);
+		return { status: res?.status };
+	} catch (e) {
+		return { thrown: e, status: (e as { status?: number })?.status };
+	}
+}
+
+describe('#3246 (B) child role は export に到達できない (403)', () => {
+	it('special-rewards/export: child=403 / parent はgate通過 (childId 無で 400)', async () => {
+		const p = '../../../src/routes/api/v1/special-rewards/export/+server';
+		const child = await callGet(
+			p,
+			childLocals(),
+			'http://x/api/v1/special-rewards/export?childId=2',
+		);
+		expect(child.status).toBe(403);
+		const parent = await callGet(p, parentLocals(), 'http://x/api/v1/special-rewards/export');
+		expect(parent.status).not.toBe(403); // gate 通過 (childId 無で 400 になる)
+	});
+
+	it('checklists/export: child=403', async () => {
+		const child = await callGet(
+			'../../../src/routes/api/v1/checklists/export/+server',
+			childLocals(),
+			'http://x/api/v1/checklists/export?templateId=5',
+		);
+		expect(child.status).toBe(403);
+	});
+
+	it('activities/export: child=403', async () => {
+		const child = await callGet(
+			'../../../src/routes/api/v1/activities/export/+server',
+			childLocals(),
+			'http://x/api/v1/activities/export',
+		);
+		expect(child.status).toBe(403);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

統合 PR #3244 監査 (security sev3-1, merge HOLD 要因) の修正。新設 export endpoint (special-rewards / checklists / activities) が **child role で到達でき、`?childId` 指定で同一家庭内の兄弟データを列挙**できた (家庭内 IDOR)。import 側は owner/parent gate 済で非対称。export を import と同じ認可境界に揃え、家庭内のデータ分離 + parent-gate 設計意図を回復する。

## 関連 Issue

closes #3246
related: 統合 PR #3244 (HOLD) / #3083 #3085 (export 新設元)

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 |
|---|---|---|---|
| AC1 | 全 export を import と同じ owner/parent gate に揃える (child 到達不可) | special-rewards/checklists/activities export に `requireRole(['owner','parent'])` 追加 | 反映済 |
| AC2 | child role で export → 403 を検証 | `export-authz-symmetry-3246.test.ts` 振る舞いテスト (child→403 ×3) | PASS |
| AC3 | 同一家庭内で子が兄弟 export を取得できない | child role 全 export 403 (parent-gate 経由のみ許可) | PASS |
| AC4 | export/import 認可境界対称性を契約テスト化 | 同 test 契約テスト (全 /api/v1/**/export/**/+server.ts が requireRole かつ child 非許可) | PASS |

## 変更タイプ

- [x] fix: バグ修正 (セキュリティ)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] API エンドポイント (`src/routes/api/v1/{special-rewards,checklists,activities}/export`)

**影響を受ける画面・機能**: 個別バックアップ export (admin の保存/復元動線)。owner/parent には影響なし (従来通り)。child role のみ 403 (元々 export は親操作)。

## テスト & 安全装置セルフチェック

- [x] **関連 unit PASS**: `export-authz-symmetry-3246.test.ts` 4件 (契約1 + 振る舞い3) / svelte-check 0 errors / biome クリーン
- [x] 契約テスト = fitness function: 新規 export 追加時の gate 漏れを機械検出 (#3152 適用先)
- [x] `npm run pre-ready -- --pr <num>` 全 Step (結果反映)
- **認可境界**: requireRole は SvelteKit `error(401/403)` を throw。cross-tenant は既存 tenant scope で担保済 (本 PR は家庭内 child↔sibling 境界を追加)。

## スクリーンショット / ビジュアルデモ

**該当なし (security / API)** — `.svelte` / `.css` / `site/**` の変更なし。サーバー API の認可 gate 追加のみ。

## コード品質セルフレビュー (#1481)

- [x] **DRY/一貫性**: import と同じ `requireRole` SSOT を再利用 (認可方式の drift 防止)
- [x] **Security (OSS 公開前提)**: 家庭内 IDOR を塞ぐ。秘密情報なし
- [x] **YAGNI**: 新規 gate 機構は作らず既存 requireRole を適用

## 横展開・影響波及チェック

- [x] 全 export endpoint (activities / rewards / special-rewards / checklists / family / cloud / account) の role gate を棚卸し → 契約テストで対称化を機械担保
- [x] account/export(['owner']) / export(family) / export/cloud は既に gate 済 (契約テストで確認)
- [ ] N/A — UI / labels / 並行実装の影響なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 破壊的変更は**含まれない** (export は元々親操作で child UI からは呼ばれない。child role の export 到達を 403 にするのみ)

**レビュー依頼事項・QA**: ①owner/parent gate の妥当性 (export = 親操作) ②契約テストの網羅性 (将来 export 追加時の gate 漏れ検出)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret なし

## Ready for Review チェックリスト

- [x] `npm run pre-ready -- --pr 3249` Step 1-8 PASS をローカル確認 (Step 9 は本修正で解消、UI変更なしのため 11b skip)
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] UI 変更なし (SS 不要、N/A)
- [x] 認証画面変更時: N/A (API 認可 gate のみ)

## QM レビュー結果

[QM 5 手順は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

