### PR TITLE
fix(data-integrity): #3245 child_challenges auto:weekly 一意制約復活 + atomic getOrCreate（ポイント二重付与根治、#3244 HOLD）

### DIFF
--- a/src/lib/server/db/create-tables.ts
+++ b/src/lib/server/db/create-tables.ts
@@ -556,6 +556,9 @@ export const SQL_CREATE_TABLES = `
 		ON child_challenges(start_date, end_date);
 	CREATE INDEX IF NOT EXISTS idx_child_challenges_source
 		ON child_challenges(source_template_id);
+	-- #3245: auto:weekly は (child_id, start_date) で一意 (concurrent 二重 INSERT = ポイント二重付与 を防ぐ)
+	CREATE UNIQUE INDEX IF NOT EXISTS idx_child_challenges_auto_weekly_unique
+		ON child_challenges(child_id, start_date) WHERE source_template_id = 'auto:weekly';
 
 	-- #1593 (ADR-0023 I6) subscriber_role: 'parent' | 'owner' のみ許容、'child' は subscribe 拒否。
 	-- 既存行 backfill 用の default 'parent' (ADR-0031 NULL 混在防止)。

--- a/src/lib/server/db/demo/child-challenge-repo.ts
+++ b/src/lib/server/db/demo/child-challenge-repo.ts
@@ -86,6 +86,24 @@ export async function insert(
 	};
 }
 
+/**
+ * #3245: auto:weekly の atomic get-or-create (demo stub)。
+ * demo は read=fixture / write=stub のため、当週 fixture があればそれを返し、無ければ insert stub を返す。
+ */
+export async function getOrCreateWeeklyAuto(
+	input: InsertChildChallengeInput,
+	tenantId: string,
+): Promise<ChildChallenge> {
+	const existing = DEMO_CHILD_CHALLENGES.find(
+		(c) =>
+			c.childId === input.childId &&
+			c.startDate === input.startDate &&
+			c.sourceTemplateId === (input.sourceTemplateId ?? 'auto:weekly'),
+	);
+	if (existing) return existing;
+	return insert(input, tenantId);
+}
+
 export async function insertBulk(
 	inputs: readonly InsertChildChallengeInput[],
 	tenantId: string,

--- a/src/lib/server/db/dynamodb/child-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/child-challenge-repo.ts
@@ -21,7 +21,13 @@
 //
 // 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/child-challenge-repo.ts (SSOT)
 
-import { DeleteCommand, PutCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import {
+	DeleteCommand,
+	GetCommand,
+	PutCommand,
+	ScanCommand,
+	UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
 import type {
 	ChildChallenge,
 	InsertChildChallengeInput,
@@ -30,6 +36,7 @@ import type {
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
+	childChallengeAutoWeeklyKey,
 	childChallengeKey,
 	childChallengePrefix,
 	childPK,
@@ -178,6 +185,45 @@ export async function insert(
 	);
 
 	return challenge;
+}
+
+/**
+ * #3245: auto:weekly の atomic get-or-create。
+ * SK を weekStart 由来の決定的キー (childChallengeAutoWeeklyKey) にし、
+ * 条件付き PutItem (attribute_not_exists(PK)) で concurrent 二重作成を atomic に防ぐ。
+ * 衝突時は同キーを GetItem して勝者 1 行に収束させる (= ポイント二重付与を不可能化)。
+ */
+export async function getOrCreateWeeklyAuto(
+	input: InsertChildChallengeInput,
+	tenantId: string,
+): Promise<ChildChallenge> {
+	const doc = getDocClient();
+	const key = childChallengeAutoWeeklyKey(input.childId, input.startDate, tenantId);
+
+	// fast path: 既存があれば即返す (proposal 再計算も省ける)
+	const existing = await doc.send(new GetCommand({ TableName: TABLE_NAME, Key: key }));
+	if (existing.Item) return toChildChallenge(existing.Item);
+
+	const id = await nextId(ENTITY_NAMES.childChallenge, tenantId);
+	const challenge = buildChildChallenge(id, input, new Date().toISOString());
+	try {
+		await doc.send(
+			new PutCommand({
+				TableName: TABLE_NAME,
+				Item: { ...key, ...challenge },
+				// 同一 (child, week) の auto 行が既存なら書込まない (atomic)
+				ConditionExpression: 'attribute_not_exists(PK)',
+			}),
+		);
+		return challenge;
+	} catch (e) {
+		// concurrent な先行作成と衝突 → 勝者を読み直す
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') {
+			const won = await doc.send(new GetCommand({ TableName: TABLE_NAME, Key: key }));
+			if (won.Item) return toChildChallenge(won.Item);
+		}
+		throw e;
+	}
 }
 
 export async function insertBulk(

--- a/src/lib/server/db/dynamodb/keys.ts
+++ b/src/lib/server/db/dynamodb/keys.ts
@@ -143,6 +143,23 @@ export function childChallengePrefix(): string {
 	return 'CHILDCHAL#';
 }
 
+/**
+ * #3245: アプリ週次自動生成 (auto:weekly) の **決定的** key。
+ * SK を id 採番でなく weekStart 由来にすることで、(child, weekStart) が一意に定まり、
+ * 条件付き PutItem (attribute_not_exists) で concurrent 二重作成を atomic に防げる。
+ * `CHILDCHAL#` で始まるため既存の begins_with(SK,'CHILDCHAL#') Query にもそのまま載る。
+ */
+export function childChallengeAutoWeeklyKey(
+	childId: number,
+	weekStart: string,
+	tenantId: string,
+): DynamoKey {
+	return {
+		PK: tenantPK(`${PREFIX.CHILD}#${childId}`, tenantId),
+		SK: `CHILDCHAL#AUTO#${weekStart}`,
+	};
+}
+
 /** Activity log: PK=CHILD#<cId>, SK=LOG#<date>#<id> */
 export function activityLogKey(
 	childId: number,

--- a/src/lib/server/db/interfaces/child-challenge-repo.interface.ts
+++ b/src/lib/server/db/interfaces/child-challenge-repo.interface.ts
@@ -43,6 +43,18 @@ export interface IChildChallengeRepo {
 	/** 1 child に 1 instance insert */
 	insert(input: InsertChildChallengeInput, tenantId: string): Promise<ChildChallenge>;
 
+	/**
+	 * #3245: アプリ週次自動生成 (sourceTemplateId='auto:weekly') の **atomic** get-or-create。
+	 * (child_id, start_date) の一意性を DB レベル (SQLite=部分 unique index / DynamoDB=決定的キー +
+	 * 条件付き書込) で担保し、concurrent 二重 INSERT (= ポイント二重付与) を不可能化する。
+	 * 既存があればそれを、無ければ新規作成して返す (どちらが勝っても 1 行に収束)。
+	 * input.sourceTemplateId は 'auto:weekly'、startDate を週キーとして扱う。
+	 */
+	getOrCreateWeeklyAuto(
+		input: InsertChildChallengeInput,
+		tenantId: string,
+	): Promise<ChildChallenge>;
+
 	/** bulk insert (兄弟一括追加 / preset 取込で複数 child に同時挿入) */
 	insertBulk(
 		inputs: readonly InsertChildChallengeInput[],

--- a/src/lib/server/db/migration/lazy-startup-migrations.ts
+++ b/src/lib/server/db/migration/lazy-startup-migrations.ts
@@ -143,6 +143,52 @@ function migrateDropAutoChallenges(db: Database.Database): void {
 	run();
 }
 
+function indexExists(db: Database.Database, name: string): boolean {
+	return !!db.prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?").get(name);
+}
+
+/**
+ * #3245: child_challenges の auto:weekly に (child_id, start_date) 部分 unique index を復活。
+ * 旧 auto_challenges の UNIQUE(child_id, week_start) が #3213/#3220 一本化で喪失していたため、
+ * concurrent 二重 INSERT (= ポイント二重付与) を DB レベルで不可能化する。
+ *
+ * 既存 production DB に重複行があると CREATE UNIQUE INDEX が失敗するため、
+ * 先に重複 auto:weekly 行を dedup (各 child×start_date で最小 id を残し他を削除) してから index 作成。
+ * 冪等: index 既存なら skip。
+ */
+function migrateChildChallengeAutoWeeklyUnique(db: Database.Database): void {
+	if (!tableExists(db, 'child_challenges')) return;
+	if (indexExists(db, 'idx_child_challenges_auto_weekly_unique')) return;
+
+	const run = db.transaction(() => {
+		// dedup: 同一 (child_id, start_date) の auto:weekly 行のうち最小 id 以外を削除
+		const dedup = db
+			.prepare(`
+			DELETE FROM child_challenges
+			WHERE source_template_id = 'auto:weekly'
+			  AND id NOT IN (
+				SELECT MIN(id) FROM child_challenges
+				WHERE source_template_id = 'auto:weekly'
+				GROUP BY child_id, start_date
+			  )
+		`)
+			.run();
+		if (dedup.changes > 0) {
+			console.info(
+				`[lazy-migrate #3245] deduped ${dedup.changes} duplicate auto:weekly child_challenges rows`,
+			);
+		}
+		db.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_child_challenges_auto_weekly_unique
+			 ON child_challenges(child_id, start_date) WHERE source_template_id = 'auto:weekly';`,
+		);
+		console.info(
+			'[lazy-migrate #3245] created partial unique index for auto:weekly child_challenges',
+		);
+	});
+	run();
+}
+
 /**
  * #2362 PR-3 (Phase 7b-2a): activity 系テーブルの FK target を
  * 旧 `activities` から `child_activities` に切替。
@@ -841,6 +887,9 @@ export function applyLazyStartupMigrations(db: Database.Database): void {
 		migrateChecklistTemplatesDropKind(db);
 		// #3213 (EPIC #3193): auto_challenges DROP。FK switchover 前の単純 table drop。
 		migrateDropAutoChallenges(db);
+		// #3245: child_challenges auto:weekly に (child_id, start_date) 部分 unique index 復活
+		// (dedup → index)。auto_challenges drop 後、child_challenges を触る前に実行。
+		migrateChildChallengeAutoWeeklyUnique(db);
 		migrateActivityFkSwitchover(db);
 		// #2510 / #2513: FK switchover (dim 3) の **後** に data copy (dim 4) を実行。
 		// FK target が child_activities になった後でないと remap が整合しないため順序固定。

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -800,6 +800,12 @@ export const childChallenges = sqliteTable(
 		index('idx_child_challenges_child').on(table.childId, table.status),
 		index('idx_child_challenges_dates').on(table.startDate, table.endDate),
 		index('idx_child_challenges_source').on(table.sourceTemplateId),
+		// #3245: アプリ週次自動生成 (sourceTemplateId='auto:weekly') は child×week で一意。
+		// 旧 auto_challenges の UNIQUE(child_id, week_start) を child_challenges 一本化で喪失していたため
+		// 部分 unique index で復活し、concurrent 二重 INSERT (= ポイント二重付与) を DB レベルで不可能化する。
+		uniqueIndex('idx_child_challenges_auto_weekly_unique')
+			.on(table.childId, table.startDate)
+			.where(sql`source_template_id = 'auto:weekly'`),
 	],
 );
 

--- a/src/lib/server/db/sqlite/child-challenge-repo.ts
+++ b/src/lib/server/db/sqlite/child-challenge-repo.ts
@@ -122,6 +122,55 @@ export async function insert(
 	return row;
 }
 
+/**
+ * #3245: auto:weekly の atomic get-or-create。
+ * 部分 unique index idx_child_challenges_auto_weekly_unique により (child_id, start_date) は
+ * auto:weekly 行で一意。`onConflictDoNothing` で concurrent 二重 INSERT を DB レベルで no-op 化し、
+ * 直後の SELECT で勝者 1 行に収束させる (= ポイント二重付与を不可能化)。
+ */
+export async function getOrCreateWeeklyAuto(
+	input: InsertChildChallengeInput,
+	_tenantId: string,
+): Promise<ChildChallenge> {
+	const now = new Date().toISOString();
+	db.insert(childChallenges)
+		.values({
+			childId: input.childId,
+			title: input.title,
+			description: input.description ?? null,
+			challengeType: input.challengeType ?? 'cooperative',
+			periodType: input.periodType ?? 'weekly',
+			startDate: input.startDate,
+			endDate: input.endDate,
+			targetConfig: input.targetConfig,
+			rewardConfig: input.rewardConfig,
+			sourceTemplateId: input.sourceTemplateId ?? 'auto:weekly',
+			currentValue: 0,
+			targetValue: input.targetValue,
+			completed: 0,
+			rewardClaimed: 0,
+			createdAt: now,
+			updatedAt: now,
+		})
+		// 部分 unique index への衝突 (= 同一 child×week の auto 行が既存) は no-op
+		.onConflictDoNothing()
+		.run();
+
+	const row = db
+		.select()
+		.from(childChallenges)
+		.where(
+			and(
+				eq(childChallenges.childId, input.childId),
+				eq(childChallenges.startDate, input.startDate),
+				eq(childChallenges.sourceTemplateId, input.sourceTemplateId ?? 'auto:weekly'),
+			),
+		)
+		.get();
+	if (!row) throw new Error('getOrCreateWeeklyAuto: row not found after upsert');
+	return row;
+}
+
 export async function insertBulk(
 	inputs: readonly InsertChildChallengeInput[],
 	tenantId: string,

--- a/src/lib/server/services/child-challenge-service.ts
+++ b/src/lib/server/services/child-challenge-service.ts
@@ -489,7 +489,10 @@ export async function getOrCreateWeeklyChildChallenge(
 		message: proposal.reason,
 	});
 
-	return repos.childChallenge.insert(
+	// #3245: insert ではなく atomic getOrCreateWeeklyAuto を使う。
+	// 上の existing 事前チェックは最適化に過ぎず、concurrent race (両者が「無し」と判定) でも
+	// DB の一意制約 + 条件付き書込で 1 行に収束させ、ポイント二重付与を不可能化する。
+	return repos.childChallenge.getOrCreateWeeklyAuto(
 		{
 			childId,
 			title: `今週は「${proposal.categoryName}」を${proposal.targetCount}回`,

--- a/tests/unit/db/sqlite/child-challenge-auto-weekly-unique-3245.test.ts
+++ b/tests/unit/db/sqlite/child-challenge-auto-weekly-unique-3245.test.ts
@@ -1,0 +1,90 @@
+// tests/unit/db/sqlite/child-challenge-auto-weekly-unique-3245.test.ts
+//
+// #3245: auto:weekly の (child_id, start_date) 一意性 + atomic getOrCreateWeeklyAuto を
+// 実 SQLite で固定する。旧 auto_challenges UNIQUE(child_id, week_start) を child_challenges
+// 一本化で喪失していたため、concurrent 二重 INSERT (= ポイント二重付与) を DB レベルで不可能化する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestDb, type TestSqlite } from '../../helpers/test-db';
+
+const dbHolder: { sqlite: TestSqlite | null; db: ReturnType<typeof createTestDb>['db'] | null } = {
+	sqlite: null,
+	db: null,
+};
+
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		if (!dbHolder.db) throw new Error('test db not initialized');
+		return dbHolder.db;
+	},
+}));
+
+import { childChallenges, children } from '$lib/server/db/schema';
+import { getOrCreateWeeklyAuto, insert } from '$lib/server/db/sqlite/child-challenge-repo';
+
+const TENANT = 't-3245';
+const WEEK = '2026-06-22';
+
+function autoInput(childId: number, startDate = WEEK) {
+	return {
+		childId,
+		title: `今週は「うんどう」を3回`,
+		description: 'desc',
+		challengeType: 'cooperative',
+		periodType: 'weekly',
+		startDate,
+		endDate: '2026-06-28',
+		targetConfig: '{"metric":"count","categoryId":1,"baseTarget":3}',
+		rewardConfig: '{"points":30}',
+		sourceTemplateId: 'auto:weekly',
+		targetValue: 3,
+	};
+}
+
+describe('#3245 child_challenges auto:weekly 一意性 / atomic getOrCreateWeeklyAuto', () => {
+	let childId: number;
+
+	beforeEach(() => {
+		const { sqlite, db } = createTestDb();
+		dbHolder.sqlite = sqlite;
+		dbHolder.db = db;
+		childId = db
+			.insert(children)
+			.values({ nickname: 'けんた', age: 8, theme: 'default', uiMode: 'elementary' })
+			.returning()
+			.get().id;
+	});
+
+	it('concurrent な複数 getOrCreateWeeklyAuto が 1 行に収束する (二重 INSERT なし)', async () => {
+		const results = await Promise.all(
+			Array.from({ length: 5 }, () => getOrCreateWeeklyAuto(autoInput(childId), TENANT)),
+		);
+
+		// 全 caller が同一 id を受け取る
+		const ids = new Set(results.map((r) => r.id));
+		expect(ids.size).toBe(1);
+
+		// DB 上も auto:weekly 行は 1 件のみ (= ポイント二重付与の源 = 二重行 が存在しない)
+		const rows = dbHolder
+			.db!.select()
+			.from(childChallenges)
+			.all()
+			.filter((c) => c.childId === childId && c.startDate === WEEK);
+		expect(rows.length).toBe(1);
+	});
+
+	it('別週 (別 start_date) は別行として共存できる', async () => {
+		await getOrCreateWeeklyAuto(autoInput(childId, '2026-06-22'), TENANT);
+		await getOrCreateWeeklyAuto(autoInput(childId, '2026-06-29'), TENANT);
+		const rows = dbHolder.db!.select().from(childChallenges).all();
+		expect(rows.filter((c) => c.sourceTemplateId === 'auto:weekly').length).toBe(2);
+	});
+
+	it('部分 index は auto:weekly 以外を制約しない (手動行は同一 child×date で複数可)', async () => {
+		const manual = { ...autoInput(childId), sourceTemplateId: null };
+		await insert(manual, TENANT);
+		await insert(manual, TENANT);
+		const rows = dbHolder.db!.select().from(childChallenges).all();
+		expect(rows.filter((c) => c.sourceTemplateId === null).length).toBe(2);
+	});
+});

--- a/tests/unit/helpers/test-db.ts
+++ b/tests/unit/helpers/test-db.ts
@@ -594,6 +594,7 @@ export const SQL_TABLES = `
 	CREATE INDEX idx_child_challenges_child ON child_challenges(child_id, status);
 	CREATE INDEX idx_child_challenges_dates ON child_challenges(start_date, end_date);
 	CREATE INDEX idx_child_challenges_source ON child_challenges(source_template_id);
+	CREATE UNIQUE INDEX idx_child_challenges_auto_weekly_unique ON child_challenges(child_id, start_date) WHERE source_template_id = 'auto:weekly';
 
 	-- sibling_cheers
 	CREATE TABLE sibling_cheers (

--- a/tests/unit/services/child-challenge-service.test.ts
+++ b/tests/unit/services/child-challenge-service.test.ts
@@ -10,6 +10,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockInsert = vi.fn();
+const mockGetOrCreateWeeklyAuto = vi.fn();
 const mockInsertBulk = vi.fn();
 const mockFindAllByTenant = vi.fn();
 const mockFindByChildId = vi.fn();
@@ -23,6 +24,7 @@ vi.mock('$lib/server/db/factory', () => ({
 	getRepos: () => ({
 		childChallenge: {
 			insert: (...a: unknown[]) => mockInsert(...a),
+			getOrCreateWeeklyAuto: (...a: unknown[]) => mockGetOrCreateWeeklyAuto(...a),
 			insertBulk: (...a: unknown[]) => mockInsertBulk(...a),
 			findAllByTenant: (...a: unknown[]) => mockFindAllByTenant(...a),
 			findByChildId: (...a: unknown[]) => mockFindByChildId(...a),
@@ -222,7 +224,8 @@ describe('getOrCreateWeeklyChildChallenge (#3195 アプリ自動生成)', () => 
 	it('当週分が無ければ child_challenges を自動生成する (targetConfig に metric/categoryId/genMode 内包)', async () => {
 		mockFindByChildId.mockResolvedValue([]); // 既存なし
 		mockCategoryCounts({ 1: 8, 2: 6, 3: 4, 4: 2, 5: 0 });
-		mockInsert.mockImplementation(async (input) => ({
+		// #3245: 生成は atomic な getOrCreateWeeklyAuto 経由
+		mockGetOrCreateWeeklyAuto.mockImplementation(async (input) => ({
 			id: 1,
 			currentValue: 0,
 			completed: 0,
@@ -231,8 +234,8 @@ describe('getOrCreateWeeklyChildChallenge (#3195 アプリ自動生成)', () => 
 
 		await getOrCreateWeeklyChildChallenge(10, TENANT);
 
-		expect(mockInsert).toHaveBeenCalledTimes(1);
-		const input = mockInsert.mock.calls[0]?.[0];
+		expect(mockGetOrCreateWeeklyAuto).toHaveBeenCalledTimes(1);
+		const input = mockGetOrCreateWeeklyAuto.mock.calls[0]?.[0];
 		expect(input.sourceTemplateId).toBe('auto:weekly');
 		expect(input.challengeType).toBe('cooperative');
 		expect(input.periodType).toBe('weekly');
@@ -258,6 +261,7 @@ describe('getOrCreateWeeklyChildChallenge (#3195 アプリ自動生成)', () => 
 
 		const result = await getOrCreateWeeklyChildChallenge(10, TENANT);
 		expect(result).toBe(existing);
+		expect(mockGetOrCreateWeeklyAuto).not.toHaveBeenCalled();
 		expect(mockInsert).not.toHaveBeenCalled();
 		expect(mockAggregateActivityLogsByCategory).not.toHaveBeenCalled();
 	});


### PR DESCRIPTION
## 顧客価値・目的

統合 PR #3244 監査 (data-integrity sev3-2, merge HOLD 要因) の修正。チャレンジ自動生成一本化 (#3220/#3213/#3194) で旧 `auto_challenges` の `UNIQUE(child_id, week_start)` が喪失し、getOrCreate が非アトミック (SELECT→無ければINSERT) だったため、**concurrent リクエストで同一週チャレンジが二重 INSERT → ポイント二重付与**になり得た。ポイントはゲーミフィケーションの中核通貨で、二重付与は残高破壊 = 顧客信頼毀損。DB レベルで根治する。

## 関連 Issue

closes #3245
related: 統合 PR #3244 (HOLD) / #3220 #3213 #3194 (一本化元)

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 |
|---|---|---|---|
| AC1 | child_challenges に UNIQUE(child_id, start_date) 相当を復活 | schema/create-tables/test-db に部分 unique index `idx_child_challenges_auto_weekly_unique` WHERE source_template_id='auto:weekly' | 反映済 |
| AC2 | getOrCreate を atomic upsert 化 (重複 INSERT を DB レベルで不可能化) | repo `getOrCreateWeeklyAuto` 新設 (SQLite: ON CONFLICT DO NOTHING+再SELECT / DynamoDB: 決定的キー+条件付きPut) | 反映済 |
| AC3 | concurrent 二重 INSERT がポイント二重付与を起こさない (実DB並行) | `child-challenge-auto-weekly-unique-3245.test.ts` 実SQLite Promise.all×5→1行収束 | PASS |
| AC4 | 既存重複の点検/dedup + DynamoDB 並行実装の一意性整合 | lazy-startup-migration で dedup(最小id残し)→部分index作成 (冪等) / DynamoDB 決定的キー実装 | 反映済 |
| AC5 | points 加算が「1達成=1加算」 | 二重行排除(一意制約) + rewardClaimed フラグ(同一行冪等) で担保 | 反映済 |

## 変更タイプ

- [x] fix: バグ修正 (data-integrity)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`child_challenges` 部分 unique index)
- [x] サービス層 (`child-challenge-service` getOrCreate を atomic 経路へ)
- [x] DB repo (sqlite / dynamodb / demo に getOrCreateWeeklyAuto)

**影響を受ける画面・機能**: 週次自動生成チャレンジの生成経路 (子供 home / challenges load)。UI 描画は不変。

## テスト & 安全装置セルフチェック

- [x] **関連 unit PASS**: child-challenge-auto-weekly-unique-3245 (実SQLite concurrent) / child-challenge-service / lazy-startup-migrations 計54件 + dynamodb child-challenge 群 / svelte-check 0 errors / biome クリーン
- [x] `npm run pre-ready -- --pr <num>` 全 Step (結果反映)
- **DBスキーマ変更 (tests/CLAUDE.md)**: 部分 unique index 追加。既存 DB は lazy-startup で dedup→index 作成 (冪等、重複行は最小 id を残し削除)。並行実装4ファイル + 3 repo 同期。

### 重量 e2e 敏感領域 (#3173、DBスキーマ変更)
- [x] (a) 並行実装ペア: schema/create-tables/test-db/lazy-startup-migrations + sqlite/dynamodb/demo repo を同期
- [x] (c) e2e seed/test-db: test-db DDL に部分 unique index 追加
- [x] (d) 値域整合: auto:weekly の (child_id, start_date) 一意。手動行 (source_template_id != 'auto:weekly') は非制約 (部分 index)

## スクリーンショット / ビジュアルデモ

**該当なし** — DB / サービス層のみ。`.svelte` / `.css` / `site/**` の変更なし。UI 描画不変。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: getOrCreateWeeklyAuto を repo interface に追加し 3 実装で対称化
- [x] **Security**: 秘密情報なし
- [x] **パフォーマンス**: fast-path (既存があれば即返す) + atomic upsert。新テーブル/ロック不要
- [x] **不変条件を DB 制約で担保** (アプリロジック依存をやめる、root class 対処)

## 横展開・影響波及チェック

- [x] 設計書同期: child_challenges 一意性は DB 設計の不変条件 (08-DB は別 follow 不要、index は schema SSOT)
- [x] DB 並行実装同期 (schema/create-tables/test-db/lazy-startup + 3 repo)
- [x] 他 per-child×period (stamp_cards 等) は別 unique 制約済 (横展開点検済、本撤去対象外)
- [ ] N/A — UI / labels 影響なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 破壊的変更は**含まれない** (既存 DB は migration で dedup→index、生成チャレンジは存続)

**レビュー依頼事項・QA**: ①部分 unique index + atomic upsert の設計 ②DynamoDB 決定的キー (CHILDCHAL#AUTO#<weekStart>) の妥当性 ③dedup migration (最小 id 残し) の方針

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret なし

## Ready for Review チェックリスト

- [x] `npm run pre-ready -- --pr 3250` Step 1-8 PASS をローカル確認 (Step 9 は本修正で解消、UI変更なしのため 11b skip)
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] UI 変更なし (SS 不要、N/A)
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

