### PR TITLE
fix: #3247 チャレンジ一本化の取り残し（challenge-set CTA dead-end + per-child functional e2e、#3244 sev3-3/4）

### DIFF
--- a/src/lib/marketplace/ui/UnifiedImportHub.svelte
+++ b/src/lib/marketplace/ui/UnifiedImportHub.svelte
@@ -27,6 +27,8 @@ import {
 	type MarketplaceTypeCodeClient,
 	type MarketplaceTypeMeta,
 } from '$lib/marketplace/client-types';
+// #3247: 陳列対象 (browseable) 判定 SSOT。types.ts は type-only import で browser-safe。
+import { isBrowseableMarketplaceType } from '$lib/marketplace/types';
 import Button from '$lib/ui/primitives/Button.svelte';
 
 type MarketplaceTypeCode = MarketplaceTypeCodeClient;
@@ -67,9 +69,13 @@ let {
 	importedPresetIds,
 }: Props = $props();
 
-// client-types SSOT から動的に type 一覧を取得（typeCode 指定時はその 1 件のみ）
+// client-types SSOT から動的に type 一覧を取得（typeCode 指定時はその 1 件のみ）。
+// #3247: 全 type tab モードでは陳列対象 (browseable) のみ表示する。#2896 で非陳列化した
+// challenge-set / rule-preset を取込タブに出すと、撤去済み action へ向かう dead-end になるため除外。
 const descriptors = $derived<MarketplaceTypeMeta[]>(
-	typeCode ? [getMarketplaceTypeMetaClient(typeCode)] : [...MARKETPLACE_TYPE_METAS_CLIENT],
+	typeCode
+		? [getMarketplaceTypeMetaClient(typeCode)]
+		: MARKETPLACE_TYPE_METAS_CLIENT.filter((m) => isBrowseableMarketplaceType(m.typeCode)),
 );
 
 // 単一 type モードかタブ表示モードか

--- a/tests/e2e/admin-challenges-per-child-3247.spec.ts
+++ b/tests/e2e/admin-challenges-per-child-3247.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * #3247 sev3-4: per-child チャレンジ UI の functional e2e (ADR-0005 ratchet 回復)。
+ *
+ * #3195 で admin/challenges を「アプリ自動生成された子のチャレンジを親が閲覧する読み取り専用ビュー」に
+ * 再編した際、旧 admin-challenges-per-child.spec.ts (手動作成前提) を削除し代替を追加しなかったため、
+ * #3238 の挙動変更面 (child-tabs / ?childId sync / per-child filtering) の functional e2e が
+ * page-LOAD smoke に後退していた (tests/CLAUDE.md render-only 禁止 / ADR-0005 違反)。
+ *
+ * 本 spec は render-only でなく act→outcome で検証する:
+ *   - 子供 challenges ページ訪問でアプリが child_challenge を自動生成する (生成 → admin 表示の CUJ)
+ *   - admin/challenges でその子のチャレンジが一覧表示される
+ *   - 子供タブ click → URL ?childId 同期 (act→outcome)
+ *   - per-child filtering: 別の子タブでは per-child empty state に切替わる
+ */
+
+import { expect, test } from '@playwright/test';
+
+test.describe('#3247 admin/challenges per-child UI (自動生成 → 親閲覧)', () => {
+	test('子供 challenges 訪問で自動生成 → admin に表示される', async ({ page }) => {
+		// #3195: 子供 challenges ページ load が getOrCreateWeeklyChildChallengeView 経由で
+		// 当週チャレンジを child_challenges に冪等生成する。
+		await page.goto('/elementary/challenges');
+		await page.waitForLoadState('domcontentloaded');
+
+		await page.goto('/admin/challenges');
+		// 「すべて」タブで生成済みチャレンジ group が 1 件以上表示される (生成 → 親閲覧 の goal 完遂)
+		await expect(page.getByTestId('admin-challenges-child-tabs')).toBeVisible();
+		await expect(page.getByTestId('admin-challenges-group').first()).toBeVisible();
+	});
+
+	test('子供タブ click → ?childId 同期 + per-child view へ切替 (act→outcome)', async ({ page }) => {
+		await page.goto('/admin/challenges');
+		const tabs = page.locator('[data-testid^="admin-challenges-child-tab-"]');
+		// global-setup は 5 children を seed (ADR-0006: skip でなく precondition assert)
+		const count = await tabs.count();
+		expect(
+			count,
+			'2 child 以上 (all タブ + child タブ) が必要 (global-setup TEST_CHILDREN)',
+		).toBeGreaterThanOrEqual(3);
+
+		// 'all' でない最初の child タブを click → URL ?childId が同期される
+		const childTab = page
+			.locator('[data-testid^="admin-challenges-child-tab-"]:not([data-testid$="-all"])')
+			.first();
+		const tid = await childTab.getAttribute('data-testid');
+		const childId = tid?.replace('admin-challenges-child-tab-', '');
+		expect(childId).toMatch(/^\d+$/);
+
+		await childTab.click();
+		await expect.poll(() => new URL(page.url()).searchParams.get('childId')).toBe(childId);
+
+		// per-child view: その子の group が出るか、未生成なら per-child empty state が出る
+		// (dead/blank ページでないこと = act→outcome)。
+		const group = page.getByTestId('admin-challenges-group');
+		const empty = page.getByTestId('admin-challenges-empty-state');
+		await expect(group.or(empty).first()).toBeVisible();
+	});
+});

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -705,6 +705,8 @@ export default async function globalSetup() {
 			CREATE INDEX IF NOT EXISTS idx_child_challenges_child ON child_challenges(child_id, status);
 			CREATE INDEX IF NOT EXISTS idx_child_challenges_dates ON child_challenges(start_date, end_date);
 			CREATE INDEX IF NOT EXISTS idx_child_challenges_source ON child_challenges(source_template_id);
+			-- #3245 並行実装整合: auto:weekly は (child_id, start_date) で一意 (e2e DB も本番/test-db と同制約)
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_child_challenges_auto_weekly_unique ON child_challenges(child_id, start_date) WHERE source_template_id = 'auto:weekly';
 		`);
 
 		// sibling_cheers テーブル（#0216 きょうだいスタンプ）


### PR DESCRIPTION
## 顧客価値・目的

#3244 監査 sev3-3 / sev3-4 (チャレンジ一本化 #3220/#3195/#3213 の取り残し、release 品質)。

- **sev3-3**: UnifiedImportHub の全 type タブモードが registry 全 5 type を列挙し、#2896 で非陳列化した challenge-set / rule-preset まで取込タブに出していた (撤去済み action へ向かう dead-end / stale)。
- **sev3-4**: #3195 で admin/challenges を読み取り専用化した際に削除した per-child e2e の代替が無く、#3238 挙動 (child-tabs / ?childId sync / per-child filtering) の functional 検証が smoke に後退 (ADR-0005 ratchet 違反)。

## 関連 Issue
closes #3247
related: 統合 PR #3244 / #3220 #3238 #3195 #3213 #2896 / 予防 #3175 / ADR-0005

## AC 検証マップ (ADR-0004)
| AC | 内容 | 検証手段 | 結果 |
|---|---|---|---|
| AC1 (sev3-3) | challenge-set の取込導線 dead-end/404/stale を 0 に | UnifiedImportHub descriptors を `isBrowseableMarketplaceType` で filter (非陳列 type をタブ除外) | 反映済 |
| AC2 (sev3-3) | marketplace-challenge-set-import.spec (陳列されない回帰) と整合 | challenge-set は items 0件で詳細到達不可 + registry は #2896 compat 維持 | 整合 |
| AC3 (sev3-4) | per-child UI の functional e2e 追加 (act→outcome) | `admin-challenges-per-child-3247.spec.ts`: 自動生成→admin表示 / child-tab click→?childId sync / per-child filtering | 追加 |
| AC4 (sev3-4) | render-only でない (tests/CLAUDE.md 準拠) | click→URL同期 + group/empty-state outcome assert | 反映済 |

## 変更タイプ
- [x] fix: バグ修正 (取り残し是正)
- [x] test: テスト改善 (e2e ratchet 回復)

## 影響範囲・変更コンポーネント
- [x] UI コンポーネント (`UnifiedImportHub.svelte` — 全 type タブ filter)
- [x] E2E (`admin-challenges-per-child-3247.spec.ts` 新規)

**影響を受ける画面・機能**: UnifiedImportHub の全 type タブモード (現在どの route にも mount されておらず Storybook/unit のみ)。route 描画への影響なし。

## テスト & 安全装置セルフチェック
- [x] **関連 unit PASS**: `UnifiedImportHub.test.ts` 12件 (registry metadata 不変) / svelte-check 0 errors / biome クリーン
- [x] Hub stories は全て単一 type モード (challenge-set 非依存) → filter で非破壊
- [x] `npm run pre-ready -- --pr <num>` 全 Step (結果反映)
- 新規 e2e は重量レーンで実行 (admin/challenges は #3173 敏感領域外)

## スクリーンショット / ビジュアルデモ
**該当なし (refactor / 内部)** — `UnifiedImportHub.svelte` は現在どの route にも mount されておらず (Storybook/unit のみ、#2558 で in-page browse 撤去済)、**route 描画への影響なし**。変更は全 type タブモードの filter のみ (非陳列 type をタブから除外)。`.spec.ts` は test 追加。`refactor:internal-no-doc-impact` ラベル付与。

## コード品質セルフレビュー (#1481)
- [x] **DRY/SSOT**: `isBrowseableMarketplaceType` (#2896 SSOT) を再利用し陳列判定を一元化
- [x] **一貫性**: marketplace browse / Hub の陳列対象を同一 SSOT に揃える
- [x] **Security**: 該当なし

## 横展開・影響波及チェック
- [x] 設計書同期: #2896 (marketplace 3 type 陳列) と整合 (本 PR は Hub を SSOT に追従)
- [x] 並行 PR overlap: #3245/#3246 (別 audit fix) と非衝突
- [ ] N/A — labels / 並行実装影響なし

## レビュー依頼事項・破壊的変更
- [x] 破壊的変更は**含まれない** (非陳列 type のタブ除外 + e2e 追加)

**レビュー依頼事項・QA**: ①Hub filter の妥当性 (非陳列 type をタブに出さない) ②新規 e2e の per-child 検証 (自動生成→admin)

## 配布済み env / secret (ADR-0006)
- [x] N/A

## Ready for Review チェックリスト
- [x] `npm run pre-ready -- --pr 3252` 全 Step PASS をローカル確認 (新規 e2e も 737 passed/0 failed)
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] UI 変更: route 描画影響なし (refactor:internal-no-doc-impact、SS 該当なし)



## QM レビュー結果

[QM 5 手順は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
