### PR TITLE
infra: #3255 (#3217 P2) client fetch silent-failure 再発防止 fitness (ratchet) を CI 化

### DIFF
--- a/docs/decisions/0062-unified-error-notification.md
+++ b/docs/decisions/0062-unified-error-notification.md
@@ -53,6 +53,7 @@
 
 ## 結果
 
-- 統一 helper `error-notify.ts`（`notifyApiError`/`notifyActionError`/`notifyNetworkError`/`resolveApiErrorMessage`）+ `ERROR_NOTIFY_LABELS`（labels.ts）+ `Toast` role/自動消滅改修を P0（#3218）で実装。silent-failure を順次 helper 経由に統一（P1）、`fetch` 未処理検出の fitness を P2（ADR-0061 適用例）で機械化。
+- 統一 helper `error-notify.ts`（`notifyApiError`/`notifyActionError`/`notifyNetworkError`/`resolveApiErrorMessage`）+ `ERROR_NOTIFY_LABELS`（labels.ts）+ `Toast` role/自動消滅改修を P0（#3218）で実装。silent-failure を helper 経由に統一（P1: #3241 parent/ops / #3248 packs / #3253 child age-tier 文言、`ERROR_NOTIFY_LABELS_CHILD` + `getErrorNotifyLabels`）。
+- **再発防止 fitness（P2、ADR-0061 適用例）**: `tests/unit/architecture/fetch-error-handling-ratchet.test.ts` が routes/features の client `fetch` のうちエラー処理（`*.ok` / catch / `notify*` / `showToast` / form action result 処理）を伴わないものを走査し、**baseline ratchet** で新規 silent fetch を CI で hard-fail する（`base-token-routes-ratchet` と同型）。意図的 fire-and-forget は直前コメント `fetch-error-exempt` で除外。
 - **トレードオフ**: 既存散在 state（`*Error` 個別命名）の全面置換は段階的（P1）。Banner/Dialog 振り分けの完全自動化はせず、重大度は呼出側が helper 戻り値 + Alert/Dialog 併用で判断する。
 - **10 枠ルール（README）**: 本 ADR 追加の 1-in-1-out は 2026-06 最終週の月 1 棚卸で archive 候補（proposed 据置 ADR-0014/0015/0016 等）と併せて消化する。

--- a/tests/unit/architecture/fetch-error-handling-ratchet.test.ts
+++ b/tests/unit/architecture/fetch-error-handling-ratchet.test.ts
@@ -1,0 +1,118 @@
+// tests/unit/architecture/fetch-error-handling-ratchet.test.ts
+// #3225 P2 (EPIC #3217 / ADR-0061 決定④ fitness function): client fetch の silent-failure
+// 再発防止 ratchet。
+//
+// 背景: バックエンドエラー時にユーザへ何も通知されない silent-failure が複数画面で反復した
+//   (#3186 → #3204 → EPIC #3217)。これは WCAG 3.3.1 (A) + 4.1.3 (AA) 二重違反。P0/P1 で
+//   helper (notifyApiError 等) を導入し既存 silent を解消したが、**新規の未処理 fetch が再び
+//   混入する**のを機械で止めるのが本 ratchet (ADR-0061 = band-aid でなく class を lock)。
+//
+// 検出ロジック (heuristic): routes / features の .svelte 内の client `fetch(` 呼び出しのうち、
+//   直後ウィンドウに「エラー処理の痕跡」(res.ok チェック / catch / notify* / showToast / throw)
+//   が**一切ない**ものを「未処理 fetch」として数える。base-token-routes-ratchet と同型の
+//   baseline ratchet で「新規違反 0 (= 増やさない)」を固定し、段階削減を促す。
+//
+// 既存の未処理 fetch (fire-and-forget な既読化 fetch 等) は BASELINE に織り込む。helper 配線で
+//   解消したら BASELINE を下げる (ratchet-down)。新規 silent fetch を足すと CI が落ちる。
+//
+// 注: server fetch (`+server.ts` / `+page.server.ts` / services の server-to-server) は
+//   別概念のため対象外 (.svelte の client fetch のみ走査)。
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const SCAN_DIRS = [resolve(REPO_ROOT, 'src/routes'), resolve(REPO_ROOT, 'src/lib/features')];
+
+// client fetch 呼び出し。
+const FETCH_CALL_RE = /\bfetch\s*\(/g;
+// fetch 直後ウィンドウ内に「エラー処理の痕跡」があれば handled とみなす。
+//   - `<var>.ok` チェック (res.ok / resp.ok / response.ok 等)
+//   - catch / notify* / showToast (例外・通知)
+//   - form action result 処理 (deserialize / result.type / actionResult.type / .type === 'failure'|'error')
+//   - 失敗表示 state の代入 (actionMessage / *Error =)
+//   - throw (上位へ委譲)
+const ERROR_HANDLING_RE =
+	/\b\w+\.ok\b|notifyApiError|notifyNetworkError|notifyActionError|showToast|\.catch\s*\(|catch\s*[({]|throw\b|deserialize\s*\(|\.type\s*===?\s*['"](?:failure|error)['"]|\btype\b\s*===?\s*['"](?:failure|error)['"]|actionMessage\s*=|Error\s*=/;
+// 直前ウィンドウに try ブロックがあれば fetch は try/catch に包まれている (handled)。
+const TRY_BEFORE_RE = /\btry\s*\{/;
+// fetch 直後 / 直前の走査ウィンドウ (form action 処理ブロックは長いので広めに取る)。
+const WINDOW_CHARS = 1100;
+const BACKWARD_CHARS = 240;
+// 明示 exempt マーカー (意図的な fire-and-forget。直前/同行コメントに付与)。
+const EXEMPT_MARKER = 'fetch-error-exempt';
+
+// #3225 P2 時点の既存「未処理 fetch」occurrence 数。helper 配線で解消したら下げる。増加は CI fail。
+//   現 develop の 1 件は `(child)/[uiMode]/home` の togglePin (PR #3253 で age-tier 文言配線、
+//   merge 後は実測 0 に減る)。#3253 が先に merge されれば本 baseline を 0 に ratchet-down する。
+const BASELINE_UNHANDLED = 1;
+
+function walkSvelteFiles(dir: string, acc: string[]): string[] {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = resolve(dir, entry.name);
+		if (entry.isDirectory()) {
+			walkSvelteFiles(full, acc);
+		} else if (entry.name.endsWith('.svelte')) {
+			acc.push(full);
+		}
+	}
+	return acc;
+}
+
+interface Unhandled {
+	file: string;
+	line: number;
+}
+
+function findUnhandledFetches(): Unhandled[] {
+	const found: Unhandled[] = [];
+	for (const dir of SCAN_DIRS) {
+		for (const file of walkSvelteFiles(dir, [])) {
+			const content = readFileSync(file, 'utf-8');
+			FETCH_CALL_RE.lastIndex = 0;
+			let m: RegExpExecArray | null = FETCH_CALL_RE.exec(content);
+			while (m !== null) {
+				const start = m.index;
+				const window = content.slice(start, start + WINDOW_CHARS);
+				const before = content.slice(Math.max(0, start - BACKWARD_CHARS), start);
+				const handled =
+					ERROR_HANDLING_RE.test(window) ||
+					TRY_BEFORE_RE.test(before) ||
+					before.includes(EXEMPT_MARKER);
+				if (!handled) {
+					const line = content.slice(0, start).split('\n').length;
+					found.push({ file: file.replace(REPO_ROOT, '').replace(/\\/g, '/'), line });
+				}
+				m = FETCH_CALL_RE.exec(content);
+			}
+		}
+	}
+	return found;
+}
+
+describe('#3225 P2: client fetch silent-failure 再発防止 ratchet (EPIC #3217 / ADR-0061)', () => {
+	it('エラー処理のない client fetch は baseline を超えない (新規 silent fetch 0)', () => {
+		const unhandled = findUnhandledFetches();
+		expect(
+			unhandled.length,
+			`エラー処理 (res.ok チェック / catch / notifyApiError 等 / showToast) を伴わない client ` +
+				`fetch が baseline (${BASELINE_UNHANDLED}) を超えた (実測 ${unhandled.length})。\n` +
+				`新規 fetch は失敗時にユーザへ可視フィードバックを出すこと (src/lib/ui/error-notify.ts の ` +
+				`notifyApiError / notifyNetworkError、ADR-0062)。意図的な fire-and-forget は直前コメントに ` +
+				`'${EXEMPT_MARKER}' を付与する。\n該当:\n${unhandled.map((u) => `  ${u.file}:${u.line}`).join('\n')}`,
+		).toBeLessThanOrEqual(BASELINE_UNHANDLED);
+	});
+
+	it('baseline は実測と大きく乖離していない (削減済なら ratchet-down を促す)', () => {
+		// 3 件以上まとめて解消したのに baseline 据置の場合に気付けるよう緩い下限を置く
+		// (1→0 のような小差では発火しない。base-token-routes-ratchet と同型)。
+		const actual = findUnhandledFetches().length;
+		expect(
+			BASELINE_UNHANDLED - actual,
+			`未処理 fetch が baseline より 3 以上少ない (実測 ${actual} / baseline ${BASELINE_UNHANDLED})。` +
+				'BASELINE_UNHANDLED を実測値へ下げて ratchet を締める。',
+		).toBeLessThan(3);
+	});
+});

--- a/tests/unit/architecture/fetch-error-handling-ratchet.test.ts
+++ b/tests/unit/architecture/fetch-error-handling-ratchet.test.ts
@@ -44,10 +44,10 @@ const BACKWARD_CHARS = 240;
 // 明示 exempt マーカー (意図的な fire-and-forget。直前/同行コメントに付与)。
 const EXEMPT_MARKER = 'fetch-error-exempt';
 
-// #3225 P2 時点の既存「未処理 fetch」occurrence 数。helper 配線で解消したら下げる。増加は CI fail。
-//   現 develop の 1 件は `(child)/[uiMode]/home` の togglePin (PR #3253 で age-tier 文言配線、
-//   merge 後は実測 0 に減る)。#3253 が先に merge されれば本 baseline を 0 に ratchet-down する。
-const BASELINE_UNHANDLED = 1;
+// 既存「未処理 fetch」occurrence 数。helper 配線で解消したら下げる。増加は CI fail。
+//   P1 (#3241/#3248/#3253) で audit 確定 silent をすべて解消したため develop 実測は 0。
+//   以降は新規 silent fetch を 1 件でも足すと CI が落ちる (hard guard)。
+const BASELINE_UNHANDLED = 0;
 
 function walkSvelteFiles(dir: string, acc: string[]): string[] {
 	for (const entry of readdirSync(dir, { withFileTypes: true })) {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発・QA（品質基盤）/ 間接的に全ユーザー（silent-failure 再発防止）

**解決する課題**: EPIC #3217 P0/P1 で既存の silent-failure（バックエンドエラー時に無反応）を helper 経由に統一したが、**新規の未処理 client `fetch` が再混入**するのを人手 review 任せにすると同クラスが再発する。ADR-0061（shift-left の機械強制）に従い fitness function で PR 時点に hard-fail させる。

**期待される効果**: エラー処理（`!res.ok` / catch / `notify*` / `showToast`）を伴わない新規 client `fetch` を CI が機械検出し、silent-failure の再発を構造的に止める。

## 関連 Issue

closes #3255

EPIC #3217（P2 = re-introduction guard）/ ADR-0061（fitness function）/ ADR-0062（統一エラー通知）/ P1: #3241 #3248 #3253

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | fetch 未処理検出 fitness が CI（vitest）で実行され新規 silent fetch を hard-fail | `npx vitest run tests/unit/architecture/fetch-error-handling-ratchet.test.ts` | HEAD `c303c3a7` / 2 passed / `tests/unit/architecture/` 配下のため pre-ready/CI の vitest で自動実行（`base-token-routes-ratchet` と同列） |
| AC2 | 現 develop の既存件数を baseline に固定（false-positive 排除 heuristic） | 同上（実測 1 = child togglePin） | HEAD `c303c3a7` / `BASELINE_UNHANDLED=1`。heuristic は `resp.ok` / `deserialize`+`result.type` / `actionMessage` / `showToast` / `try` を handled と認識し、初版で誤検出した 14 → 真の 1 件（#3253 で修正済の togglePin）に収束 |
| AC3 | ADR-0062 に P2 適用例を追記 | `docs/decisions/0062-unified-error-notification.md` §結果 | HEAD `c303c3a7` / 「再発防止 fitness（P2、ADR-0061 適用例）」を追記 |

## 変更タイプ

- [ ] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI（vitest fitness test 追加 + ADR）

**影響を受ける画面・機能**: なし（CI fitness test の追加のみ。production code 無変更）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `fetch-error-handling-ratchet.test.ts` 新規（ratchet 1 + stale-check 1 の 2 ケース）。architecture 全 9 tests PASS
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:low）

## スクリーンショット / ビジュアルデモ

該当なし（CI fitness test + ADR の追加。production UI 無変更）。

**インタラクティブ状態**: N/A。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 走査ロジックを純粋関数 `findUnhandledFetches` に分離、test は assertion のみ
- [x] **DRY**: 既存 `base-token-routes-ratchet` と同型の ratchet 構造を踏襲
- [x] **YAGNI**: AST 解析は使わず軽量な windowed heuristic + baseline ratchet（再発防止に必要十分）
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: 本 fitness が WCAG 3.3.1/4.1.3 違反（silent-failure）の再発を機械防止
- [x] **パフォーマンス**: FS 走査のみ、数十 ms

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001)（ADR-0062 §結果に P2 適用例追記）
- [x] 並行 PR overlap 確認 (#1200)（baseline=1 は #3253 の child togglePin。#3253 merge 後 0 へ ratchet-down する旨を test コメントに明記）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**: heuristic は windowed（fetch 直後 1100 字 + 直前 240 字の `try`）で「エラー処理の痕跡ゼロ」のみを silent と判定する。初版で `resp.ok`（変数名差）/ form action の `deserialize`+`result.type` パターンを誤検出したため、`\w+\.ok` / `deserialize` / `.type === 'failure'|'error'` / `actionMessage` / `try {` を handled シグナルに追加し false-positive を排除済（14→1）。baseline=1 は #3253 が develop に入れば 0（test コメントに ratchet-down を明記、stale-check は 1→0 では発火しない緩い下限）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更なし（CI fitness test の追加）
- [x] fitness の false-positive を排除し真の silent fetch のみ検出することを確認

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
