### PR TITLE
docs: #3259 cuj-1 marketplace-import-flow を challenge-set 非取込に同期（#3277 補完）

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -201,7 +201,7 @@ LP (`site/index.html`) の section padding / margin / heading / faq-item など 
 
 - `loading=true` → spinner 表示 + `disabled` + `aria-busy="true"` を強制（スクリーンリーダーにも「処理中」を伝える）
 - `<button>` 描画時のみ有効。`href` 指定の `<a>` (navigation) には loading 非対応 — ページ遷移系の feedback は遷移先で担保する
-- `ChildSelectionDialog` の取込確定ボタンは `confirmLoading` prop で本機構を内包する。marketplace 5 type 取込 (`?import=` 受領 admin 画面) の `handleChildSelectionConfirm` 中は `confirmLoading={isImporting}` + `closeOnConfirm={false}` で「取込実行中」を表示し、完了後 (finally) に親が `open=false` する
+- `ChildSelectionDialog` の取込確定ボタンは `confirmLoading` prop で本機構を内包する。marketplace 取込 4 type (`?import=` 受領 admin 画面) の `handleChildSelectionConfirm` 中は `confirmLoading={isImporting}` + `closeOnConfirm={false}` で「取込実行中」を表示し、完了後 (finally) に親が `open=false` する
 - 旧 `components/LoadingButton.svelte` は文言固定の限定 variant。新規実装は `Button` の `loading` prop を優先する
 
 ### FormField の `type` 一覧（#1191）
@@ -630,11 +630,11 @@ admin リソース管理 3 画面 (活動 / チェックリスト / ごほうび
 
 - admin 画面の「みんなのテンプレートから探す」は `/marketplace?type=<typeCode>` への**画面遷移**とし、in-page ブラウズ UI を出さない。取込実行は marketplace 詳細 → `?import=<presetId>` → `ChildSelectionDialog` の正規経路 (`marketplace-import-flow.md` §3.1) に合流させる。
 - **ファイル復元 (JSON / CSV import) はマーケットプレイスとは別概念**。`UnifiedImportHub` がブラウズ UI とファイル復元を兼ねている場合、ブラウズ UI のみ撤去し、ファイル復元は独立した導線 (例: `︙` overflow menu の「バックアップから復元」+ 専用ダイアログ、`OVERFLOW_MENU_TERMS.itemRestore`) として保持する。
-- **適用範囲**: #2558 段階2 (activities) + 段階3 (rewards / challenges / checklists / settings/rules) で**全 5 type の admin 画面で in-page browse UI を撤去完了**。`UnifiedImportHub.svelte` component 自体は Storybook / unit test / 将来用途 (LP 経由公開ブラウズ等) のため存続させる。詳細は [marketplace-import-flow.md §5.1](design/marketplace-import-flow.md)。
+- **適用範囲**: 全 5 admin 画面 (activities / rewards / challenges / checklists / settings/rules) で**in-page browse UI を撤去完了**。ただし取込先となるのは取込 4 type (activities / rewards / checklists / settings/rules) のみで、admin/challenges は marketplace 取込先ではなく読み取り専用ビュー (#3195、challenge-set は取込型ではない)。`UnifiedImportHub.svelte` component 自体は Storybook / unit test / 将来用途 (LP 経由公開ブラウズ等) のため存続させる。詳細は [marketplace-import-flow.md §5.1](design/marketplace-import-flow.md)。
 
-#### marketplace 取込 CTA 5 type 統一原則 (#2774 + #2775 で完遂、User 指摘 #2/#4 根治)
+#### marketplace 取込 CTA 取込 4 type 統一原則 (#2774 + #2775 で完遂、User 指摘 #2/#4 根治)
 
-marketplace 詳細 (`/marketplace/<typeCode>/<itemId>`) の認証済取込 CTA は、**全 5 type で `<a href="/admin/<page>?import=${itemId}">` 形式に統一**する (server action 経由は不採用、admin 側 `?import=` query → `ChildSelectionDialog` auto-open に合流)。testid は `<typeCode>-import-cta` 命名。type に応じた Strategy 分岐は `importPresetToChildren` action が担う。詳細・命名一覧は [marketplace-import-flow.md §3.1](design/marketplace-import-flow.md) (#2774 / #2775)。
+marketplace 詳細 (`/marketplace/<typeCode>/<itemId>`) の認証済取込 CTA は、**取込 4 type (activity-pack / reward-set / checklist / rule-preset) で `<a href="/admin/<page>?import=${itemId}">` 形式に統一**する (server action 経由は不採用、admin 側 `?import=` query → `ChildSelectionDialog` auto-open に合流)。testid は `<typeCode>-import-cta` 命名。type に応じた Strategy 分岐は `importPresetToChildren` action が担う。challenge-set は取込型ではない (#3195 / #3227) ため取込 CTA を持たない。詳細・命名一覧は [marketplace-import-flow.md §3.1](design/marketplace-import-flow.md) (#2774 / #2775)。
 
 #### bulk import bridge ルール
 

--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1921,7 +1921,7 @@ onclick={() => {
 **設計理由 (CWE-598 privacy 排除)**:
 - marketplace は public surface のため URL/body の `childId` / `nickname` 露出 0 件を必達 (ADR-0055 / User §7.3 直接指針)
 - child binding 決定は AdminApp (PIN gate 通過後) に集約。Marketplace → AdminApp 遷移時の query string は `<itemId>` のみ
-- `reward-set` / `checklist` / `rule-preset` / `challenge-set` は Phase 6/7 で activity-pack と同型の admin redirect 動線に統一予定 (現状は legacy form 経由で `childId` を扱っている)
+- `reward-set` / `checklist` / `rule-preset` は activity-pack と同型の admin redirect 動線 (`?import=`) に統一済。challenge-set は取込型ではない (#3195 で admin/challenges を読み取り専用化済、取込 CTA / `?import=` を持たない) ため本統一の対象外
 
 **回帰検証**:
 - `tests/e2e/marketplace-activity-pack-no-childid.spec.ts` (4 AC、CWE-598 完全担保)
@@ -1929,7 +1929,7 @@ onclick={() => {
 
 ##### マーケットプレイス詳細 取込 CTA mobile sticky 化 (#2761 / Round 18 Cluster F)
 
-`/marketplace/[type]/[itemId]` (5 type 共通: activity-pack / checklist / reward-set / challenge-set / rule-preset) の取込 CTA は、長い detail content (item info / description / tags / 関連リンク) の下部 normal flow 配置のため mobile viewport で fold 外に押し出され、片手スクロール cost が高い保護者層 (preschool 親代表) が CTA に到達できない UX defect を抱えていた (Round 18 Cluster F、Issues #6 / #9 / #31 / #45)。
+`/marketplace/[type]/[itemId]` (取込 4 type: activity-pack / checklist / reward-set / rule-preset。challenge-set は取込型ではなく detail / 取込 CTA を持たない #3195) の取込 CTA は、長い detail content (item info / description / tags / 関連リンク) の下部 normal flow 配置のため mobile viewport で fold 外に押し出され、片手スクロール cost が高い保護者層 (preschool 親代表) が CTA に到達できない UX defect を抱えていた (Round 18 Cluster F、Issues #6 / #9 / #31 / #45)。
 
 | viewport | 配置 | z-index | safe-area | 挙動 |
 |---------|------|---------|-----------|------|

--- a/docs/design/marketplace-import-flow.md
+++ b/docs/design/marketplace-import-flow.md
@@ -240,21 +240,9 @@ Round 18 Round 3 評価で「30 件一括取込で個別選択不可」「既存
 - **family master type (checklist / rule-preset) は tenant 単位 dedup が正しい** (per-child instance ではないため、§3.3 参照)。これは変更対象外。
 - 回帰テスト: `tests/unit/services/activity-import-service.test.ts` §「#2558 per-child dedup 回帰」 + `tests/e2e/admin-activities-per-child.spec.ts` の goal 完遂テスト (1 人目に取込済 → 2 人目に取込 → 2 人目に活動が追加される)。
 
-challenge-set は **#2362 PR-7 (ADR-0055、User §6) で activity-pack と同型の per-child instance + admin redirect 動線に統一済 + #2774 で query 名を 5 type 統一**:
-- marketplace 詳細 `?import=<presetId>` で `/admin/challenges` に遷移 (childId URL に出さず、CWE-598 整合)
-- admin/challenges 側 `importMarketplaceChallengeSet` action が `childIds` body 必須 + ChildSelectionDialog 経由で per-child instance 作成
-- `MarketplaceTypeDescriptor.requiresChildSelection: true` を challenge-set にも追加 (本 PR で flip)
-- 同じ source preset から作成された複数 child instance は `source_template_id: 'challenge-set:<presetId>:<title>'` を共有し、admin/challenges 画面で `SiblingChallengeComparison.svelte` により兄弟連動表示される
-- family-only plan-gate は本 PR 維持 (LP/pricing 整合性確認は別 PR #2457 plan-limit と連携)
+**challenge-set は取込型ではない (取込 4 type に含めない)**: 週間チャレンジはアプリが自動生成する一本化方式 (#3195) で、親による手動取込は存在しない。challenge-set は marketplace 陳列対象外 (#2896) かつ valid preset 0 件で `/marketplace/challenge-set/*` は全環境 404、marketplace 詳細は取込 CTA を持たない。admin/challenges は `?import=` を処理せず読み取り専用ビュー (#3195)。`challenge-set` の型 / schema / Registry 登録は marketplace-item.ts に互換のため残置するが取込導線 (`?import=`) は持たない。
 
-**#2554 follow-up CUJ-CH2 完全化 (本 PR、2026-05-29)**: 上記 #2362 PR-7 動線のうち、`/admin/challenges` 側の **ChildSelectionDialog auto-open 配線が長期未実装**だった (data.marketplaceImport を受領するが UI ハンドラ無し、CUJ-CH2 が partial だった構造的原因)。本 PR で activities/rewards と同型の以下を移植して完全化:
-- `+page.svelte`: `ChildSelectionDialog` import + `?marketplace-import=<presetId>` を `$effect` で検出して auto-open + `handleChildSelectionConfirm` で `?/importMarketplaceChallengeSet` に CSV 形式で POST
-- `+page.server.ts` load: `importPresetId` / `importPresetInvalid` を export (rewards `?import=` 同型、dialog auto-open trigger 用)
-- `+page.server.ts` action `importMarketplaceChallengeSet`: CSV (`childIds=1,2,3` or `'all'`) 受領サポート追加 (旧 `getAll('childIds')` repeated 形式は後方互換維持) + **CWE-598 guard 追加** (`tenantChildren` の ID set に含まれない `childId` を 1 件でも検出すると 403 reject、admin-rewards `importPresetToChildren` 同型)
-- CUJ-CH2 の E2E 検証 (旧 `admin-challenges-import-marketplace.spec.ts`) は CUJ-A3 / CUJ-R2 と同型の完全 terminal goal verify に upgrade されていた
-- `src/lib/domain/labels.ts` `ADMIN_CHALLENGES_PAGE_LABELS`: `importSuccess / importAllDuplicates / importFailed / importDemo / importInvalidPreset` を追加 (admin-rewards 同型)
-
-> **#2896 (2026-06-11 PO 判断)**: marketplace を活動 / ごほうび / チェックリストの 3 type に絞る方針に伴い、challenge-set は陳列対象外とし唯一の preset (japan-annual-events) を廃止した。これにより上記 marketplace 経由のチャレンジ取込 (CUJ-CH2) は撤去し、検証 spec も削除した。`challenge-set` の型 / schema / Registry 登録は互換のため残置するが、marketplace 詳細の取込 CTA / 分岐は到達不能 dead code として除去済 (#3277)、admin/challenges も `?import=` を処理しない (#3195 読み取り専用ビュー)。チャレンジ機能本体 (アプリ自動生成、#3195 一本化) は `/admin/challenges` に保持。陳列方針・顧客価値は [44-チャレンジ設計書.md](44-チャレンジ設計書.md) を参照。
+> **#2896 補足**: marketplace を活動 / ごほうび / チェックリストの 3 type に絞る方針に伴い、challenge-set は陳列対象外とし唯一の preset (japan-annual-events) を廃止した。これにより上記 marketplace 経由のチャレンジ取込 (CUJ-CH2) は撤去し、検証 spec も削除した。`challenge-set` の型 / schema / Registry 登録は互換のため残置するが、marketplace 詳細の取込 CTA / 分岐は到達不能 dead code として除去済 (#3277)、admin/challenges も `?import=` を処理しない (#3195 読み取り専用ビュー)。チャレンジ機能本体 (アプリ自動生成、#3195 一本化) は `/admin/challenges` に保持。陳列方針・顧客価値は [44-チャレンジ設計書.md](44-チャレンジ設計書.md) を参照。
 
 #### reward-set 取込フロー (EPIC #2362 PR-4 で実装済)
 
@@ -368,19 +356,19 @@ CWE-598 (Information Exposure Through Query Strings in GET Request) 整合。
 
 EPIC #2362 で実装済の `UnifiedImportHub` (#2370 / PR #2384) は **type 別の marketplace preset 一覧 (browse) + file source を埋め込む in-page hub**。
 
-### 5.1 #2558 段階2 (activities) / 段階3 (残 4 type): 全 5 type で admin 内 browse UI 撤去 (マーケットプレイス一本化完遂)
+### 5.1 admin 内 browse UI 撤去 (全 5 admin 画面、マーケットプレイス一本化完遂)
 
 顧客クレーム (bug-3「追加メニュー内に『パックから追加』という見知らぬ用語」/ bug-4「『パックから追加』がマーケットプレイスに行かず独自 UI を開く」+ User 直接指摘「親管理画面で簡単なマーケットプレイス画面があるなど見た瞬間に指摘される」) を受け、PO 方針「**マーケットプレイス (みんなのテンプレート) で内容確認 → インポート → 親管理画面に取り込み、に一本化する。親管理画面内にマーケットプレイス風の簡易画面を出さない (二重管理)**」に従い、**全 admin 画面 (`activities` / `rewards` / `challenges` / `checklists` / `settings/rules`) の in-page browse UI を撤去**した (DESIGN.md §10 構造的ルール明示禁忌)。
 
-- 各 admin 画面の「みんなのテンプレートから探す」link / menu 項目は `/marketplace?type=<typeCode>` へ**画面遷移**する (§3.1 の正規 sequence に合流)。in-page の marketplace 風ブラウズ UI は出さない。typeCode 対応: activities → `activity-pack` / rewards → `reward-set` / challenges → `challenge-set` / checklists → `checklist` / settings/rules → `rule-preset`。
+- 取込 4 type (activities / rewards / checklists / settings/rules) の「みんなのテンプレートから探す」link / menu 項目は `/marketplace?type=<typeCode>` へ**画面遷移**する (§3.1 の正規 sequence に合流)。in-page の marketplace 風ブラウズ UI は出さない。typeCode 対応 (admin 画面 → marketplace type): activities → `activity-pack` / rewards → `reward-set` / checklists → `checklist` / settings/rules → `rule-preset`。admin/challenges は browse UI 撤去対象 (5 画面) だが marketplace 取込先ではなく `?import=` を処理しない読み取り専用ビュー (#3195) のため、取込導線 (`/marketplace?type=` link) を持たない (challenge-set は取込型ではない)。
 - 旧 `UnifiedImportHub` の **file source セクション (`?/importFile` による JSON/CSV 復元)** は marketplace とは別概念のため、admin/activities では `︙` overflow menu の「バックアップから復元」項目 + 専用ダイアログとして**独立保持**した (`OVERFLOW_MENU_TERMS.itemRestore` 経由)。他 admin 画面では現状 file 復元 UI を提供していない (必要に応じて follow-up Issue で同 pattern 横展開)。
 - `UnifiedImportHub.svelte` component 自体は **本 PR の admin 画面群からは参照されなくなった** が、Storybook story / unit test (`tests/unit/marketplace/ui/UnifiedImportHub.test.ts`) / 将来の用途 (LP 経由公開ブラウズ等) のため component 自体は削除せず存続させる (knip での dead-code 検出が出るか別 Issue で判断)。
 
-### 5.2 ChildSelectionDialog auto-open mechanism (5 type 共通の正規取込経路、#2774)
+### 5.2 ChildSelectionDialog auto-open mechanism (取込 4 type 共通の正規取込経路、#2774)
 
-各 admin page の server load は **`?import=<presetId>` query を 5 type 統一で validation** (activities /
-rewards / checklists / settings-rules / challenges) し、page svelte 側の `$effect` で
-`ChildSelectionDialog` を auto-open する mechanism を保持する。全 5 type で `?import=` に揃っている (5 type 取込導線完全統一)。
+取込 4 type の admin page の server load は **`?import=<presetId>` query を共通 validation** (activities /
+rewards / checklists / settings-rules) し、page svelte 側の `$effect` で
+`ChildSelectionDialog` を auto-open する mechanism を保持する。取込 4 type が `?import=` に揃っている。admin/challenges は `?import=` を処理しない読み取り専用ビュー (#3195) のため本経路の対象外 (challenge-set は取込型ではない)。
 
 Marketplace 詳細 → `<a href="/admin/<page>?import=${itemId}">` 直遷移 → admin 画面で
 ChildSelectionDialog auto-open → child binding 決定 → server action へ POST、が正規経路 (§3.1)。

--- a/docs/design/marketplace-import-flow.md
+++ b/docs/design/marketplace-import-flow.md
@@ -41,7 +41,9 @@ DDD Anti-Corruption Layer: Marketplace → AdminApp 遷移で Marketplace 側の
 
 ### 2.2 取込ダイアログの SSOT 化
 
-「誰に追加 / 全員」のダイアログ UI は **AdminApp 側 1 箇所のみで実装** (PR-2 Framework で抽象化)。各 type の取込フロー (`activity-pack` / `reward-set` / `checklist` / `rule-preset` / `challenge-set`) は同じダイアログを呼び出す。
+「誰に追加 / 全員」のダイアログ UI は **AdminApp 側 1 箇所のみで実装** (PR-2 Framework で抽象化)。各取込 type のフロー (`activity-pack` / `reward-set` / `checklist` / `rule-preset`) は同じダイアログを呼び出す。
+
+> **challenge-set は取込型ではない (#3195 / #3227)**: 週間チャレンジはアプリが自動生成する一本化方式で、親による手動取込は存在しない。challenge-set は marketplace 陳列対象外 (#2896) かつ valid preset 0 件で `/marketplace/challenge-set/*` は全環境 404。marketplace 詳細の challenge-set 取込 CTA / 分岐は到達不能 dead code として除去済 (#3277)。型 / schema / Registry 登録は互換のため残すが取込導線 (`?import=`) は持たない。
 
 #### 取込実行中の loading 表示 (#2632、NN/G #1 visibility of system status)
 
@@ -59,14 +61,15 @@ DDD Anti-Corruption Layer: Marketplace → AdminApp 遷移で Marketplace 側の
 
 ## 3. 取込フロー sequence
 
-### 3.1 全 type 共通の取込フロー (5 type 統一、#2774)
+### 3.1 取込 type 共通の取込フロー (取込 CTA 統一、#2774)
 
 **取込 CTA 統一形式** (#2774 / #2775):
 
-全 5 type (activity-pack / reward-set / checklist / rule-preset / challenge-set) の認証済
+取込対象 4 type (activity-pack / reward-set / checklist / rule-preset) の認証済
 取込 CTA は **`<a href="/admin/<page>?import=${itemId}">`** 形式に**完全統一**する (marketplace 詳細 page の
 server action は 0 件)。admin 側 server load は
 **`?import=<presetId>` query** を一律に読取り、ChildSelectionDialog auto-open する。
+(challenge-set は取込型ではない — §2.2 注記。)
 
 | type | marketplace 詳細 CTA href | admin 側 query 読取り | testid (統一命名) |
 |---|---|---|---|
@@ -75,13 +78,14 @@ server action は 0 件)。admin 側 server load は
 | checklist | `/admin/checklists?import=${itemId}` | `?import=` | `checklist-import-cta` |
 | rule-preset bonus | `/admin/settings/rules?import=${itemId}` | `?import=` | `rule-preset-import-bonus-cta` |
 | rule-preset exchange (#2775) | `/admin/rewards?import=${itemId}` | `?import=` | `rule-preset-import-cta` |
-| challenge-set | `/admin/challenges?import=${itemId}` | `?import=` | `challenge-set-import-cta` |
+
+> challenge-set は本表に含めない (取込型ではない、§2.2 注記)。marketplace 詳細は取込 CTA を持たず、admin/challenges は `?import=` を処理しない (#3195 で読み取り専用ビュー)。
 
 **rule-preset exchange 統一 (#2775、Issue #2774 Phase 2)**: special_rewards table への per-child
 取込を admin/rewards 側 ChildSelectionDialog 経由で受領するよう mechanism を拡張済。`?import=` server
 load が rule-preset (exchange) を判別し、`importPresetToChildren` action は item type を見て
 reward-set Strategy (`dispatchImport`) または rule-preset Strategy (`rulePresetStrategy.applyRulePreset`)
-に分岐する。**5 type 完全統一達成** = marketplace 詳細 page の server action は 0 件。
+に分岐する。**全取込 type で `<a href>` 統一達成** = marketplace 詳細 page の server action は 0 件。
 
 ```
 [親管理画面 /admin/*]
@@ -250,7 +254,7 @@ challenge-set は **#2362 PR-7 (ADR-0055、User §6) で activity-pack と同型
 - CUJ-CH2 の E2E 検証 (旧 `admin-challenges-import-marketplace.spec.ts`) は CUJ-A3 / CUJ-R2 と同型の完全 terminal goal verify に upgrade されていた
 - `src/lib/domain/labels.ts` `ADMIN_CHALLENGES_PAGE_LABELS`: `importSuccess / importAllDuplicates / importFailed / importDemo / importInvalidPreset` を追加 (admin-rewards 同型)
 
-> **#2896 (2026-06-11 PO 判断)**: marketplace を活動 / ごほうび / チェックリストの 3 type に絞る方針に伴い、challenge-set は陳列対象外とし唯一の preset (japan-annual-events) を廃止した。これにより上記 marketplace 経由のチャレンジ取込 (CUJ-CH2) は撤去し、検証 spec も削除した。`challenge-set` の型 / schema / Registry 登録 / `?import=` 受領経路は互換のため残置 (valid preset 不在時は invalid guidance を表示)。チャレンジ機能本体 (自作 + auto-challenge) は `/admin/challenges` に保持。陳列方針・顧客価値は [44-チャレンジ設計書.md](44-チャレンジ設計書.md) を参照。
+> **#2896 (2026-06-11 PO 判断)**: marketplace を活動 / ごほうび / チェックリストの 3 type に絞る方針に伴い、challenge-set は陳列対象外とし唯一の preset (japan-annual-events) を廃止した。これにより上記 marketplace 経由のチャレンジ取込 (CUJ-CH2) は撤去し、検証 spec も削除した。`challenge-set` の型 / schema / Registry 登録は互換のため残置するが、marketplace 詳細の取込 CTA / 分岐は到達不能 dead code として除去済 (#3277)、admin/challenges も `?import=` を処理しない (#3195 読み取り専用ビュー)。チャレンジ機能本体 (アプリ自動生成、#3195 一本化) は `/admin/challenges` に保持。陳列方針・顧客価値は [44-チャレンジ設計書.md](44-チャレンジ設計書.md) を参照。
 
 #### reward-set 取込フロー (EPIC #2362 PR-4 で実装済)
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発チーム（設計書 SSOT 利用者）

**解決する課題**: release 監査 #3259 cuj-1 の docs 同期。marketplace 詳細の challenge-set dead 分岐除去 (code) は EPIC #3227 sub-task 3 = **PR #3277** が担うが、#3277 は `marketplace-import-flow.md` を対象に含まず、同設計書は challenge-set を取込型として記載したままだった。本 PR は **docs のみ**を実態へ同期する（#3277 を補完）。

> **経緯メモ**: 本 PR は当初 #3258 + #3259 を同梱していたが、#3258 は #3273、#3259 の code (cuj-1 CTA / tq-4 test) は #3277 が担うと判明したため、本 PR を **#3259 の docs 同期のみ**に縮退した（重複・conflict 回避）。

## 関連 Issue

closes #3278
監査 #3259 cuj-1 の docs portion。code は #3277（EPIC #3227 sub-task 3）が担当。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| cuj-1-docs | marketplace-import-flow.md が challenge-set を取込型として記載しない（実態同期） | `grep -n "challenge-set" docs/design/marketplace-import-flow.md` + 目視 | HEAD `005134d6` / §2.2・§3.1 type 一覧から challenge-set 除外 + authoritative 注記追加、§3.1 表から challenge-set 行削除、#2896 注記を #3277/#3195 実態へ更新 |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)

**影響を受ける画面・機能**: なし（設計書のみ）。`docs/design/marketplace-import-flow.md` の challenge-set 記述を実態（取込型ではない / 詳細ページ 404 / CTA 除去済 #3277 / admin/challenges は ?import= 非処理 #3195）へ同期。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**
- [x] 追加・変更したテストの概要: N/A（docs 専用）。code 側の回帰 test は #3277 が担保（marketplace-auth-redirect.test.ts を CTA 不在ガードに反転、27 passed）。
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（docs）**: 設計書 (`docs/design/marketplace-import-flow.md`) のみの変更で UI ファイル変更なし。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（docs）
- [x] **DRY**: challenge-set の非取込説明を §2.2 に authoritative 集約し、§3.1 は参照のみ。
- [x] **YAGNI**: docs SSOT 原則に従い現状の正解のみ記述（経緯物語は最小限）。
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): 本 PR 自体が設計書同期。
- [x] **labels SSOT** (ADR-0009): N/A（docs）
- [x] **並行 PR overlap** (#1200): #3277（code）は `marketplace-import-flow.md` を touch しないため file 重複なし。本 PR は docs 専用で #3277 と非衝突。
- [ ] N/A — 上記以外は影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（docs のみ）。

**レビュー依頼事項・QA**: #3277（code）merge 順序に依存しない（docs は challenge-set が既に 404/dead な現状を記述）。§3.2 の challenge-set service 内部記述（Registry/strategy 残置）は import-service 実装が存続するため変更しない。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み
- [x] UI 変更時: docs 専用のため該当なし
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

