### PR TITLE
fix(data-integrity): #3258 DynamoDB auto:weekly チャレンジの mutation silent no-op を根治（id 属性で解決）

### DIFF
--- a/src/lib/server/db/dynamodb/child-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/child-challenge-repo.ts
@@ -11,12 +11,15 @@
 //
 // key 設計 (keys.ts §childChallengeKey):
 //   PK = T#<tenantId>#CHILD#<childId>   (child partition、child_activities / activity_logs と同居)
-//   SK = CHILDCHAL#<paddedId>           (8 桁 0 埋め、辞書順)
-//   → findByChildId は単一 partition Query で完結し追加 GSI 不要 (ADR-0055 §3.1)。
+//   SK = CHILDCHAL#<paddedId>           (regular instance、8 桁 0 埋め、辞書順)
+//   SK = CHILDCHAL#AUTO#<weekStart>     (auto:weekly instance、#3245 の atomic get-or-create 用)
+//   → findByChildId は単一 partition Query (begins_with(SK,'CHILDCHAL#')) で両種を取得し GSI 不要。
 //
 // child-activity との差分: interface の mutation method (update / markCompleted / claimReward /
 //   deleteChallenge / findById) が childId を受け取らず id 単独のため、id → PK/SK 解決を
-//   tenant 配下 Scan (begins_with(SK, 'CHILDCHAL#') AND SK = :sk) で行う。challenge instance は
+//   tenant 配下 Scan で行う。#3258: auto:weekly 行は SK が id-addressable でない (CHILDCHAL#AUTO#)
+//   ため SK exact-match では never match し全 mutation が silent no-op になっていた。解決は SK 形式
+//   非依存の id 属性 match (`#id = :id`) で行い regular / auto 双方に作用させる。challenge instance は
 //   1 child 当たり数件 (週次/月次) と低頻度なため Scan で十分 (ADR-0010 Pre-PMF、GSI 追加は過剰防衛)。
 //
 // 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/child-challenge-repo.ts (SSOT)
@@ -28,6 +31,7 @@ import {
 	ScanCommand,
 	UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
+import { logger } from '$lib/server/logger';
 import type {
 	ChildChallenge,
 	InsertChildChallengeInput,
@@ -41,7 +45,6 @@ import {
 	childChallengePrefix,
 	childPK,
 	ENTITY_NAMES,
-	padId,
 	tenantPK,
 } from './keys';
 import { queryAllItems, stripKeys } from './repo-helpers';
@@ -122,7 +125,9 @@ export async function findAllByTenant(tenantId: string): Promise<ChildChallenge[
 // ============================================================
 
 export async function findById(id: number, tenantId: string): Promise<ChildChallenge | undefined> {
-	const items = await scanTenantChallenges(tenantId, { sk: `${PREFIX}${padId(id)}` });
+	// #3258: SK 形式 (regular=CHILDCHAL#<padId> / auto=CHILDCHAL#AUTO#<weekStart>) に依存せず
+	// id 属性で解決する (auto:weekly 行が exact-SK match を外して silent に取得不能になるのを根治)。
+	const items = await scanTenantChallenges(tenantId, { id });
 	const item = items[0];
 	return item ? toChildChallenge(item) : undefined;
 }
@@ -402,21 +407,27 @@ export async function deleteByTenantId(tenantId: string): Promise<void> {
 
 /**
  * tenant 配下の CHILDCHAL# item を Scan で収集する。
- * @param opts.sk         SK 完全一致 (findById / resolveKeyById 用)
+ * @param opts.id         id 属性の完全一致 (findById / resolveKeyById 用)。
+ *                        auto:weekly 行は SK=CHILDCHAL#AUTO#<weekStart> で id-addressable でないため、
+ *                        SK 形式に依存せず id 属性で解決する (#3258 silent no-op 根治。
+ *                        regular 行 SK=CHILDCHAL#<padId> / auto 行 SK=CHILDCHAL#AUTO# 双方に作用)。
  * @param opts.projection ProjectionExpression (PK/SK のみ取得したいとき)
  */
 async function scanTenantChallenges(
 	tenantId: string,
-	opts?: { sk?: string; projection?: string },
+	opts?: { id?: number; projection?: string },
 ): Promise<Record<string, unknown>[]> {
 	const filters = ['begins_with(SK, :skPrefix)', 'begins_with(PK, :tenantPrefix)'];
 	const values: Record<string, unknown> = {
 		':skPrefix': PREFIX,
 		':tenantPrefix': tenantPK('CHILD#', tenantId),
 	};
-	if (opts?.sk) {
-		filters.push('SK = :sk');
-		values[':sk'] = opts.sk;
+	// `id` は DynamoDB の予約語ではないが、安全のため ExpressionAttributeNames で別名化する。
+	const names: Record<string, string> | undefined =
+		opts?.id !== undefined ? { '#id': 'id' } : undefined;
+	if (opts?.id !== undefined) {
+		filters.push('#id = :id');
+		values[':id'] = opts.id;
 	}
 
 	const items: Record<string, unknown>[] = [];
@@ -427,6 +438,7 @@ async function scanTenantChallenges(
 				TableName: TABLE_NAME,
 				FilterExpression: filters.join(' AND '),
 				ExpressionAttributeValues: values,
+				ExpressionAttributeNames: names,
 				ProjectionExpression: opts?.projection,
 				ExclusiveStartKey: lastKey,
 			}),
@@ -439,16 +451,28 @@ async function scanTenantChallenges(
 	return items;
 }
 
-/** id から PK/SK を解決する (mutation method 用)。不在なら undefined。 */
+/**
+ * id から PK/SK を解決する (mutation method 用)。不在なら undefined。
+ * #3258: id 属性で解決し、auto:weekly 行 (SK=CHILDCHAL#AUTO#<weekStart>) も id-addressable にする。
+ * 旧実装は SK=CHILDCHAL#<padId(id)> の exact match のみで auto 行を never match し、
+ * updateProgress/markCompleted/claimReward/update/delete が DynamoDB prod で silent no-op だった。
+ */
 async function resolveKeyById(
 	id: number,
 	tenantId: string,
 ): Promise<{ PK: string; SK: string } | undefined> {
 	const items = await scanTenantChallenges(tenantId, {
-		sk: `${PREFIX}${padId(id)}`,
+		id,
 		projection: 'PK, SK',
 	});
 	const item = items[0];
-	if (!item) return undefined;
+	if (!item) {
+		// #3258 AC5: id 解決失敗を observable にする。mutation 呼出時に id が解決できないのは
+		// (削除済 race を除き) 想定外であり、旧来の if(!key) return; の silent no-op を warn で可視化する。
+		logger.warn('child-challenge resolveKeyById: id 未解決 (mutation no-op)', {
+			context: { id, tenantId },
+		});
+		return undefined;
+	}
 	return { PK: item.PK as string, SK: item.SK as string };
 }

--- a/tests/unit/db/dynamodb-child-challenge-repo.test.ts
+++ b/tests/unit/db/dynamodb-child-challenge-repo.test.ts
@@ -265,16 +265,24 @@ describe('findAllByTenant', () => {
 // ============================================================
 
 describe('findById', () => {
-	it('SK 完全一致で Scan し 1 件返す', async () => {
+	it('id 属性で Scan し 1 件返す (#3258: SK 形式非依存解決)', async () => {
 		mockSend.mockResolvedValueOnce({ Items: [makeItem({ id: 7, title: 'X' })] });
 		const { findById } = await loadRepo();
 		const result = await findById(7, TENANT);
 		expect(result?.title).toBe('X');
 		const scan = mockSend.mock.calls[0]?.[0] as {
-			input: { FilterExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+			input: {
+				FilterExpression?: string;
+				ExpressionAttributeValues?: Record<string, unknown>;
+				ExpressionAttributeNames?: Record<string, string>;
+			};
 		};
-		expect(scan.input.FilterExpression).toContain('SK = :sk');
-		expect(scan.input.ExpressionAttributeValues?.[':sk']).toBe('CHILDCHAL#00000007');
+		// #3258: SK exact-match (CHILDCHAL#<padId>) ではなく id 属性で解決する
+		// (auto:weekly 行 SK=CHILDCHAL#AUTO#... も id-addressable にするため)。
+		expect(scan.input.FilterExpression).toContain('#id = :id');
+		expect(scan.input.FilterExpression).not.toContain('SK = :sk');
+		expect(scan.input.ExpressionAttributeValues?.[':id']).toBe(7);
+		expect(scan.input.ExpressionAttributeNames?.['#id']).toBe('id');
 	});
 
 	it('不在のとき undefined を返す', async () => {
@@ -603,6 +611,77 @@ describe('deleteByTenantId', () => {
 		expect(mockSend).toHaveBeenCalledTimes(3);
 		const del = mockSend.mock.calls[1]?.[0] as { input: { Key?: { PK: string } } };
 		expect(del.input.Key?.PK).toBe(`T#${TENANT}#CHILD#1`);
+	});
+});
+
+// ============================================================
+// #3258: auto:weekly 行 (SK=CHILDCHAL#AUTO#<weekStart>) の id 解決 — silent no-op 根治
+// ============================================================
+//
+// 旧実装は resolveKeyById/findById が SK=CHILDCHAL#<padId(id)> の exact match のみで解決し、
+// auto:weekly 行 (SK=CHILDCHAL#AUTO#...) を never match → updateProgress/markCompleted/
+// claimReward/update/delete が DynamoDB prod で silent no-op になり、コア体験 (チャレンジ→ごほうび)
+// が有料ユーザで永久停止していた。本 block は auto 行が id で解決され mutation が実 SK に作用する
+// (= read/write key 解決の対称性) を回帰固定する。
+
+describe('#3258 auto:weekly 行の id 解決 (read/write 対称性)', () => {
+	const AUTO_SK = 'CHILDCHAL#AUTO#2026-06-01';
+	const AUTO_KEY = { PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: AUTO_SK };
+
+	it('updateProgress は auto 行を id で解決し実 SK で Update する (silent no-op でない)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [AUTO_KEY] }) // resolveKeyById
+			.mockResolvedValueOnce({}); // Update
+		const { updateProgress } = await loadRepo();
+		await updateProgress(50, 3, TENANT);
+
+		// no-op でなく Update まで発行する (resolve + Update = 2 send)
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		// 解決は SK 形式非依存の id 属性 match で行う (auto 行 SK を exact-match で外さない)
+		const resolve = mockSend.mock.calls[0]?.[0] as {
+			input: {
+				FilterExpression?: string;
+				ExpressionAttributeValues?: Record<string, unknown>;
+				ExpressionAttributeNames?: Record<string, string>;
+			};
+		};
+		expect(resolve.input.FilterExpression).toContain('#id = :id');
+		expect(resolve.input.FilterExpression).not.toContain('SK = :sk');
+		expect(resolve.input.ExpressionAttributeValues?.[':id']).toBe(50);
+		expect(resolve.input.ExpressionAttributeNames?.['#id']).toBe('id');
+		// Update は auto 行の実 SK を対象にする (CHILDCHAL#AUTO#...)
+		const upd = mockSend.mock.calls[1]?.[0] as {
+			input: { Key?: { SK: string }; ExpressionAttributeValues?: Record<string, unknown> };
+		};
+		expect(upd.input.Key?.SK).toBe(AUTO_SK);
+		expect(upd.input.ExpressionAttributeValues?.[':cv']).toBe(3);
+	});
+
+	it('markCompleted / claimReward も auto 行に作用する (進捗→完了→報酬の貫通)', async () => {
+		const repo = await loadRepo();
+		// markCompleted
+		mockSend.mockResolvedValueOnce({ Items: [AUTO_KEY] }).mockResolvedValueOnce({});
+		await repo.markCompleted(50, TENANT);
+		expect((mockSend.mock.calls[1]?.[0] as { input: { Key?: { SK: string } } }).input.Key?.SK).toBe(
+			AUTO_SK,
+		);
+
+		mockSend.mockReset();
+		// claimReward
+		mockSend.mockResolvedValueOnce({ Items: [AUTO_KEY] }).mockResolvedValueOnce({});
+		await repo.claimReward(50, TENANT);
+		expect((mockSend.mock.calls[1]?.[0] as { input: { Key?: { SK: string } } }).input.Key?.SK).toBe(
+			AUTO_SK,
+		);
+	});
+
+	it('findById も auto 行を id で取得する (read=write 対称、SK 形式非依存)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [makeItem({ id: 50, SK: AUTO_SK, title: 'AUTO-WEEKLY' })],
+		});
+		const { findById } = await loadRepo();
+		const result = await findById(50, TENANT);
+		expect(result?.title).toBe('AUTO-WEEKLY');
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

`DATA_SOURCE=dynamodb`（有料 prod）で週次自動チャレンジ（auto:weekly）の進捗・完了・報酬受領が **silent no-op** になり、コア体験（チャレンジ→ごほうび）が有料ユーザで永久停止していた（SQLite/NUC は正常 = SQLite/DynamoDB 等価契約違反）。本 PR は auto 行を id で解決可能にし、有料本番で機能を復旧する（#3258、統合 PR #3257 監査 sev3 / merge HOLD 要因）。

## 関連 Issue

- #3258（DynamoDB auto:weekly チャレンジ mutation の silent no-op を根治）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | DynamoDB で auto:weekly 行が id 解決可能になる | `npx vitest run tests/unit/db/dynamodb-child-challenge-repo.test.ts` | ✅ `scanTenantChallenges` を SK exact-match から id 属性 match（`#id = :id`）に変更（child-challenge-repo.ts HEAD 99bdf8dca）。findById/resolveKeyById が regular（CHILDCHAL#<padId>）/ auto（CHILDCHAL#AUTO#）双方を id で解決 |
| AC2 | updateProgress/markCompleted/claimReward/update/delete が auto 行に DynamoDB でも作用する | 同 test の `#3258 auto:weekly 行の id 解決` describe | ✅ auto 行（SK=CHILDCHAL#AUTO#...）に対し resolve→Update が実 SK で発行され silent no-op でないことを assert |
| AC3 | DynamoDB auto-challenge mutation の等価 test を追加（進捗→完了→報酬） | 同 test | ✅ updateProgress/markCompleted/claimReward が auto 行に作用する貫通 test を追加（31 passed） |
| AC4 | SQLite/DynamoDB の challenge repo 等価契約を contract test 化（read/write key 解決の対称性） | 同 test | ✅ findById（read）/ resolveKeyById（write）が共に `#id = :id` で SK 形式非依存に解決することを assert（read=write 対称性の固定） |
| AC5 | silent no-op の構造（if(!key) return;）を観測可能にする検討 | コードレビュー（resolveKeyById） | ✅ resolveKeyById の id 未解決時に `logger.warn` を出し、想定外の no-op を可視化（削除 race 除く） |

## 変更タイプ

- [x] バグ修正（data-integrity、有料 prod 限定の機能停止）
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dynamodb/child-challenge-repo.ts`: `scanTenantChallenges` の解決を id 属性 match 化（`findById` / `resolveKeyById` 経由で全 mutation に波及）。未使用化した `padId` import を除去、`logger` import 追加、ヘッダ/関数コメントを id 解決に同期
- `tests/unit/db/dynamodb-child-challenge-repo.test.ts`: auto:weekly 行の id 解決 + mutation 作用 + read/write 対称性の回帰 test を追加、findById の旧 SK-exact assertion を id 解決に更新

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/dynamodb-child-challenge-repo.test.ts` — 31 passed（新規 #3258 + 更新 findById 含む）
- [x] `npx vitest run tests/unit/server/db/sqlite/child-challenge-repo.test.ts tests/unit/services/child-challenge-service.test.ts` — 周辺回帰なし（合計 73 passed）
- [x] `npx biome check` 2 file クリーン / `npx svelte-check` 0 ERRORS

## スクリーンショット / ビジュアルデモ

N/A（UI 変更なし — DynamoDB repo の内部 key 解決バグ修正）。

## コード品質セルフレビュー (#1481)

- [x] id 属性は DynamoDB 予約語ではないが `ExpressionAttributeNames`（`#id`）で別名化し将来の予約語衝突を防御
- [x] 変更は read（findById）/ write（resolveKeyById 経由の全 mutation）の解決を SK 形式非依存に統一し、regular/auto を同一経路で扱う（分岐を増やさない）
- [x] 横展開点検: `grep -rnE "SK = :sk" src/lib/server/db/dynamodb/` で他 repo を確認。同一 prefix 下に異種 SK を持つのは challenge の AUTO 変種のみで、activity/reward/checklist は単一形式 SK or begins_with+属性 filter 解決のため同型の非対称なし

## 横展開・影響波及チェック

- [x] **LP ↔ アプリ双方向整合** (#1481 / ADR-0013): サーバ内部の DB 解決バグ修正のため LP 訴求への波及なし
- [x] SQLite 側は #3245 で atomic 化済で正常。本 PR は DynamoDB 並行実装を SQLite 挙動 SSOT に整合させるもので、SK スキーマ（08-DB 設計書）は不変（解決方式のみ修正）

## レビュー依頼事項・破壊的変更

破壊的変更なし。SK スキーマ不変で、解決方式を SK exact-match から id 属性 match に変更するのみ。既存の regular 行も id で解決され従来通り動作する（test で固定）。

## 配布済み env / secret (ADR-0006)

なし（env / secret 追加なし）。

## Ready for Review チェックリスト

- [x] CI green 見込み（biome / svelte-check / 該当 vitest をローカル確認）
- [x] 必須セクション記入済
- [x] AC1〜AC5 を実装 + 回帰 test で固定、横展開点検済

## QM レビュー結果

<!-- QM が記入 -->
