### PR TITLE
fix: 監査残課題 — reset-pin a11y(ux-1) / family export N+1(perf-6) / auto_challenges DROP 保全テスト(cuj-2)

### DIFF
--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -11,8 +11,6 @@ import {
 	type ExportChecklistLog,
 	type ExportChecklistTemplate,
 	type ExportChild,
-	type ExportChildAchievement,
-	type ExportChildTitle,
 	type ExportData,
 	type ExportEvaluation,
 	type ExportLoginBonus,
@@ -195,213 +193,249 @@ export async function exportFamilyData(options: ExportOptions): Promise<ExportDa
 	return exportData;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: 複雑なビジネスロジックのため、別 Issue でリファクタ予定
+/**
+ * capped query が cap ちょうどの件数を返した = silent truncation の可能性を observable にする
+ * (#3259 perf-6、no-silent-cap 原則。MAX_EXPORT_ROWS で頭打ちした export は半損のため warn する)。
+ */
+function warnIfTruncated(kind: string, childId: number, count: number): void {
+	if (count >= MAX_EXPORT_ROWS) {
+		logger.warn(
+			'[export] 取得件数が上限に達しました — export が truncate されている可能性があります',
+			{
+				context: { kind, childId, count, cap: MAX_EXPORT_ROWS },
+			},
+		);
+	}
+}
+
+/** 1 child 分の transaction データ。collectForChild が返し、collectTransactionData が childIds 順に連結する。 */
+interface ChildTransactionData {
+	activityLogs: ExportActivityLog[];
+	pointLedger: ExportPointLedger[];
+	statuses: ExportStatus[];
+	statusHistory: ExportStatusHistory[];
+	loginBonuses: ExportLoginBonus[];
+	evaluations: ExportEvaluation[];
+	specialRewards: ExportSpecialReward[];
+	checklistTemplates: ExportChecklistTemplate[];
+	checklistLogs: ExportChecklistLog[];
+}
+
+/**
+ * 1 child 分の全 transaction データを収集する。
+ * #3259 perf-6: 旧実装は childIds を sequential `for...of await` で回し N child = N 回の
+ * 直列ラウンドトリップになっていた (N+1)。本関数を child 単位に切り出し、呼び出し側で
+ * `Promise.all(childIds.map(...))` 並列化する。出力は childIds 順に連結するため checksum は決定的。
+ */
+async function collectForChild(
+	childId: number,
+	childExportIdMap: Map<number, string>,
+	tenantId: string,
+): Promise<ChildTransactionData> {
+	const childRef = childExportIdMap.get(childId) ?? `child-${childId}`;
+
+	// 各データを並列取得
+	const [
+		activityLogs,
+		pointHistory,
+		statuses,
+		loginBonuses,
+		evaluations,
+		specialRewards,
+		checklistTemplates,
+	] = await Promise.all([
+		findActivityLogs(childId, tenantId),
+		findPointHistory(childId, { limit: MAX_EXPORT_ROWS, offset: 0 }, tenantId),
+		findStatuses(childId, tenantId),
+		findRecentBonuses(childId, tenantId, MAX_EXPORT_ROWS),
+		findEvaluationsByChild(childId, MAX_EXPORT_ROWS, tenantId),
+		findSpecialRewards(childId, tenantId),
+		// #3106: backup なので includeInactive=true + includeArchived=true。
+		// archive 済 template も含め、その checklistLog の silent drop を防ぐ。
+		findTemplatesByChild(childId, tenantId, true, true),
+	]);
+
+	// ステータス履歴は全カテゴリ分を取得
+	const statusHistoryResults = await Promise.all(
+		[1, 2, 3, 4, 5].map((catId) =>
+			findRecentStatusHistory(childId, catId, tenantId, MAX_EXPORT_ROWS),
+		),
+	);
+
+	// #3259 perf-6: cap 到達 (= 取りこぼし可能性) を observable 化
+	warnIfTruncated('pointLedger', childId, pointHistory.length);
+	warnIfTruncated('loginBonuses', childId, loginBonuses.length);
+	warnIfTruncated('evaluations', childId, evaluations.length);
+	for (const entries of statusHistoryResults) {
+		warnIfTruncated('statusHistory', childId, entries.length);
+	}
+
+	const activityLogsOut: ExportActivityLog[] = activityLogs.map((log) => ({
+		childRef,
+		activityName: log.activityName,
+		activityCategory: getCategoryCode(log.categoryId),
+		points: log.points,
+		streakDays: log.streakDays,
+		streakBonus: log.streakBonus,
+		recordedDate: log.recordedAt.split('T')[0] ?? log.recordedAt,
+		recordedAt: log.recordedAt,
+		cancelled: false,
+	}));
+
+	const pointLedgerOut: ExportPointLedger[] = pointHistory.map((entry) => ({
+		childRef,
+		amount: entry.amount,
+		type: entry.type,
+		description: entry.description,
+		createdAt: entry.createdAt,
+	}));
+
+	const statusesOut: ExportStatus[] = statuses.map((status) => ({
+		childRef,
+		categoryCode: getCategoryCode(status.categoryId),
+		totalXp: status.totalXp,
+		level: status.level,
+		peakXp: status.peakXp,
+		updatedAt: status.updatedAt,
+	}));
+
+	const statusHistoryOut: ExportStatusHistory[] = statusHistoryResults.flatMap((entries) =>
+		entries.map((entry) => ({
+			childRef,
+			categoryCode: getCategoryCode(entry.categoryId),
+			value: entry.value,
+			changeAmount: entry.changeAmount,
+			changeType: entry.changeType,
+			recordedAt: entry.recordedAt,
+		})),
+	);
+
+	// 実績システム廃止（#322）— Achievements / Titles スキップ
+
+	const loginBonusesOut: ExportLoginBonus[] = loginBonuses.map((lb) => ({
+		childRef,
+		loginDate: lb.loginDate,
+		rank: lb.rank,
+		basePoints: lb.basePoints,
+		multiplier: lb.multiplier,
+		totalPoints: lb.totalPoints,
+		consecutiveDays: lb.consecutiveDays,
+		createdAt: lb.createdAt,
+	}));
+
+	const evaluationsOut: ExportEvaluation[] = evaluations.map((ev) => ({
+		childRef,
+		weekStart: ev.weekStart,
+		weekEnd: ev.weekEnd,
+		scoresJson: ev.scoresJson,
+		bonusPoints: ev.bonusPoints,
+		createdAt: ev.createdAt,
+	}));
+
+	const specialRewardsOut: ExportSpecialReward[] = specialRewards.map((sr) => ({
+		childRef,
+		title: sr.title,
+		description: sr.description,
+		points: sr.points,
+		icon: sr.icon,
+		category: sr.category,
+		grantedAt: sr.grantedAt,
+		sourcePresetId: sr.sourcePresetId,
+	}));
+
+	// Checklist templates with items
+	// #3078 / #3107: templateId → (name, exportId) マップを構築し checklistLogs の参照解決に使う。
+	// exportId は export 内で安定な識別子 (`chk-${childRef}-${templateId}`) で、同名 template が
+	// 複数あっても log を取り違えない round-trip キーにする。
+	// #3259 perf-6: template ごとの findTemplateItems も sequential N+1 だったため Promise.all 並列化
+	// (出力は checklistTemplates の元順を維持するため index 対応で組み立てる)。
+	const templateItems = await Promise.all(
+		checklistTemplates.map((tpl) => findTemplateItems(tpl.id, tenantId)),
+	);
+	const templateNameById = new Map<number, string>();
+	const exportIdByTemplateId = new Map<number, string>();
+	const checklistTemplatesOut: ExportChecklistTemplate[] = checklistTemplates.map((tpl, idx) => {
+		templateNameById.set(tpl.id, tpl.name);
+		const exportId = `chk-${childRef}-${tpl.id}`;
+		exportIdByTemplateId.set(tpl.id, exportId);
+		return {
+			childRef,
+			name: tpl.name,
+			icon: tpl.icon,
+			pointsPerItem: tpl.pointsPerItem,
+			completionBonus: tpl.completionBonus,
+			isActive: tpl.isActive === 1,
+			sourcePresetId: tpl.sourcePresetId,
+			exportId, // #3107
+			isArchived: tpl.isArchived === 1, // #3106: archive 状態を round-trip 保全
+			items: (templateItems[idx] ?? []).map((item) => ({
+				name: item.name,
+				icon: item.icon,
+				frequency: item.frequency,
+				direction: item.direction,
+				sortOrder: item.sortOrder,
+			})),
+		};
+	});
+
+	// #3078 / #3106: チェックリスト完了ログ。#3106 で archive 済 template も export に含めたため、
+	// その log も exportId 経由で保全される (従来は name 解決不能で silent drop していた)。
+	const checklistLogsRaw = await findLogsByChild(childId, tenantId);
+	const checklistLogsOut: ExportChecklistLog[] = [];
+	for (const log of checklistLogsRaw) {
+		const templateName = templateNameById.get(log.templateId);
+		const templateExportId = exportIdByTemplateId.get(log.templateId);
+		// template が export に含まれない場合のみスキップ (#3106 で archived も含むため通常は解決可)
+		if (!templateName || !templateExportId) continue;
+		checklistLogsOut.push({
+			childRef,
+			templateName,
+			templateExportId, // #3107: import 側はこれを優先して再マップ
+			checkedDate: log.checkedDate,
+			itemsJson: log.itemsJson,
+			completedAll: log.completedAll === 1,
+			pointsAwarded: log.pointsAwarded,
+			createdAt: log.createdAt,
+		});
+	}
+
+	return {
+		activityLogs: activityLogsOut,
+		pointLedger: pointLedgerOut,
+		statuses: statusesOut,
+		statusHistory: statusHistoryOut,
+		loginBonuses: loginBonusesOut,
+		evaluations: evaluationsOut,
+		specialRewards: specialRewardsOut,
+		checklistTemplates: checklistTemplatesOut,
+		checklistLogs: checklistLogsOut,
+	};
+}
+
 async function collectTransactionData(
 	childIds: number[],
 	childExportIdMap: Map<number, string>,
 	_achievementMap: Map<number, { code: string }>,
 	tenantId: string,
 ): Promise<ExportTransactionData> {
-	const allActivityLogs: ExportActivityLog[] = [];
-	const allPointLedger: ExportPointLedger[] = [];
-	const allStatuses: ExportStatus[] = [];
-	const allStatusHistory: ExportStatusHistory[] = [];
-	const allChildAchievements: ExportChildAchievement[] = [];
-	const allChildTitles: ExportChildTitle[] = [];
-	const allLoginBonuses: ExportLoginBonus[] = [];
-	const allEvaluations: ExportEvaluation[] = [];
-	const allSpecialRewards: ExportSpecialReward[] = [];
-	const allChecklistTemplates: ExportChecklistTemplate[] = [];
-	const allChecklistLogs: ExportChecklistLog[] = [];
-	for (const childId of childIds) {
-		const childRef = childExportIdMap.get(childId) ?? `child-${childId}`;
-
-		// 各データを並列取得
-		const [
-			activityLogs,
-			pointHistory,
-			statuses,
-			loginBonuses,
-			evaluations,
-			specialRewards,
-			checklistTemplates,
-		] = await Promise.all([
-			findActivityLogs(childId, tenantId),
-			findPointHistory(childId, { limit: MAX_EXPORT_ROWS, offset: 0 }, tenantId),
-			findStatuses(childId, tenantId),
-			findRecentBonuses(childId, tenantId, MAX_EXPORT_ROWS),
-			findEvaluationsByChild(childId, MAX_EXPORT_ROWS, tenantId),
-			findSpecialRewards(childId, tenantId),
-			// #3106: backup なので includeInactive=true + includeArchived=true。
-			// archive 済 template も含め、その checklistLog の silent drop を防ぐ。
-			findTemplatesByChild(childId, tenantId, true, true),
-		]);
-
-		// ステータス履歴は全カテゴリ分を取得
-		const statusHistoryPromises = [1, 2, 3, 4, 5].map((catId) =>
-			findRecentStatusHistory(childId, catId, tenantId, MAX_EXPORT_ROWS),
-		);
-		const statusHistoryResults = await Promise.all(statusHistoryPromises);
-
-		// Activity logs
-		for (const log of activityLogs) {
-			allActivityLogs.push({
-				childRef,
-				activityName: log.activityName,
-				activityCategory: getCategoryCode(log.categoryId),
-				points: log.points,
-				streakDays: log.streakDays,
-				streakBonus: log.streakBonus,
-				recordedDate: log.recordedAt.split('T')[0] ?? log.recordedAt,
-				recordedAt: log.recordedAt,
-				cancelled: false,
-			});
-		}
-
-		// Point ledger
-		for (const entry of pointHistory) {
-			allPointLedger.push({
-				childRef,
-				amount: entry.amount,
-				type: entry.type,
-				description: entry.description,
-				createdAt: entry.createdAt,
-			});
-		}
-
-		// Statuses
-		for (const status of statuses) {
-			allStatuses.push({
-				childRef,
-				categoryCode: getCategoryCode(status.categoryId),
-				totalXp: status.totalXp,
-				level: status.level,
-				peakXp: status.peakXp,
-				updatedAt: status.updatedAt,
-			});
-		}
-
-		// Status history
-		for (const entries of statusHistoryResults) {
-			for (const entry of entries) {
-				allStatusHistory.push({
-					childRef,
-					categoryCode: getCategoryCode(entry.categoryId),
-					value: entry.value,
-					changeAmount: entry.changeAmount,
-					changeType: entry.changeType,
-					recordedAt: entry.recordedAt,
-				});
-			}
-		}
-
-		// 実績システム廃止（#322）— Achievements スキップ
-		// 称号システム廃止（#322）— Titles スキップ
-
-		// Login bonuses
-		for (const lb of loginBonuses) {
-			allLoginBonuses.push({
-				childRef,
-				loginDate: lb.loginDate,
-				rank: lb.rank,
-				basePoints: lb.basePoints,
-				multiplier: lb.multiplier,
-				totalPoints: lb.totalPoints,
-				consecutiveDays: lb.consecutiveDays,
-				createdAt: lb.createdAt,
-			});
-		}
-
-		// Evaluations
-		for (const ev of evaluations) {
-			allEvaluations.push({
-				childRef,
-				weekStart: ev.weekStart,
-				weekEnd: ev.weekEnd,
-				scoresJson: ev.scoresJson,
-				bonusPoints: ev.bonusPoints,
-				createdAt: ev.createdAt,
-			});
-		}
-
-		// Special rewards
-		for (const sr of specialRewards) {
-			allSpecialRewards.push({
-				childRef,
-				title: sr.title,
-				description: sr.description,
-				points: sr.points,
-				icon: sr.icon,
-				category: sr.category,
-				grantedAt: sr.grantedAt,
-				sourcePresetId: sr.sourcePresetId,
-			});
-		}
-
-		// Checklist templates with items
-		// #3078 / #3107: templateId → (name, exportId) マップを構築し checklistLogs の参照解決に使う。
-		// exportId は export 内で安定な識別子 (`chk-${childRef}-${templateId}`) で、同名 template が
-		// 複数あっても log を取り違えない round-trip キーにする。
-		const templateNameById = new Map<number, string>();
-		const exportIdByTemplateId = new Map<number, string>();
-		for (const tpl of checklistTemplates) {
-			templateNameById.set(tpl.id, tpl.name);
-			const exportId = `chk-${childRef}-${tpl.id}`;
-			exportIdByTemplateId.set(tpl.id, exportId);
-			const items = await findTemplateItems(tpl.id, tenantId);
-			allChecklistTemplates.push({
-				childRef,
-				name: tpl.name,
-				icon: tpl.icon,
-				pointsPerItem: tpl.pointsPerItem,
-				completionBonus: tpl.completionBonus,
-				isActive: tpl.isActive === 1,
-				sourcePresetId: tpl.sourcePresetId,
-				exportId, // #3107
-				isArchived: tpl.isArchived === 1, // #3106: archive 状態を round-trip 保全
-				items: items.map((item) => ({
-					name: item.name,
-					icon: item.icon,
-					frequency: item.frequency,
-					direction: item.direction,
-					sortOrder: item.sortOrder,
-				})),
-			});
-		}
-
-		// #3078 / #3106: チェックリスト完了ログ。#3106 で archive 済 template も export に含めたため、
-		// その log も exportId 経由で保全される (従来は name 解決不能で silent drop していた)。
-		const checklistLogs = await findLogsByChild(childId, tenantId);
-		for (const log of checklistLogs) {
-			const templateName = templateNameById.get(log.templateId);
-			const templateExportId = exportIdByTemplateId.get(log.templateId);
-			// template が export に含まれない場合のみスキップ (#3106 で archived も含むため通常は解決可)
-			if (!templateName || !templateExportId) continue;
-			allChecklistLogs.push({
-				childRef,
-				templateName,
-				templateExportId, // #3107: import 側はこれを優先して再マップ
-				checkedDate: log.checkedDate,
-				itemsJson: log.itemsJson,
-				completedAll: log.completedAll === 1,
-				pointsAwarded: log.pointsAwarded,
-				createdAt: log.createdAt,
-			});
-		}
-	}
+	// #3259 perf-6: child を並列収集 (旧 sequential N+1 解消)。Promise.all は入力順を維持するため、
+	// 連結後の childRef 順は childIds 順で決定的 = checksum 安定 (round-trip 不変)。
+	const perChild = await Promise.all(
+		childIds.map((childId) => collectForChild(childId, childExportIdMap, tenantId)),
+	);
 
 	return {
-		activityLogs: allActivityLogs,
-		pointLedger: allPointLedger,
-		statuses: allStatuses,
-		statusHistory: allStatusHistory,
-		childAchievements: allChildAchievements,
-		childTitles: allChildTitles,
-		loginBonuses: allLoginBonuses,
-		evaluations: allEvaluations,
-		specialRewards: allSpecialRewards,
-		checklistTemplates: allChecklistTemplates,
-		checklistLogs: allChecklistLogs, // #3078
+		activityLogs: perChild.flatMap((p) => p.activityLogs),
+		pointLedger: perChild.flatMap((p) => p.pointLedger),
+		statuses: perChild.flatMap((p) => p.statuses),
+		statusHistory: perChild.flatMap((p) => p.statusHistory),
+		childAchievements: [], // 実績システム廃止（#322）
+		childTitles: [], // 称号システム廃止（#322）
+		loginBonuses: perChild.flatMap((p) => p.loginBonuses),
+		evaluations: perChild.flatMap((p) => p.evaluations),
+		specialRewards: perChild.flatMap((p) => p.specialRewards),
+		checklistTemplates: perChild.flatMap((p) => p.checklistTemplates),
+		checklistLogs: perChild.flatMap((p) => p.checklistLogs), // #3078
 		childAvatarItems: [],
 		dailyMissions: [], // Phase 2: エフェメラルデータ対応後に対応
 	};

--- a/src/lib/ui/primitives/PinInput.stories.svelte
+++ b/src/lib/ui/primitives/PinInput.stories.svelte
@@ -25,6 +25,24 @@ const completeSpy = fn();
 <Story name="Length4" args={{ length: 4, mask: true }} />
 
 <!--
+  WithLabel (#3259 ux-1 follow-up): label prop で accessible name を上書きできることを固定。
+  同一画面に複数 PinInput を置くとき (reset-pin の「確認コード」+「新しい PIN」) に
+  汎用 'PINコード' が重複し SR で曖昧化する退行を防ぐ。custom label が描画され、
+  既定の汎用ラベル 'PINコード' に退行していないことを assert する。
+-->
+<Story
+	name="WithLabel"
+	args={{ length: 4, mask: false, label: '確認コード（6桁の数字）' }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		// custom label が描画される (Ark Label → input 関連付け)。getByText は不在で throw。
+		await waitFor(() => canvas.getByText('確認コード（6桁の数字）'));
+		// 汎用既定ラベルに退行していない (重複の原因を回帰固定)。
+		expect(canvas.queryByText('PINコード')).toBeNull();
+	}}
+/>
+
+<!--
   CompleteFlow (length=4 / unmasked): 4 桁を順に入力 → onComplete が valueAsString='1234' で発火。
   mask=false で input が role=textbox になり Testing Library から query できる
   (mask=true は type=password で role を持たないため、操作回帰には unmasked を使う)。

--- a/src/lib/ui/primitives/PinInput.svelte
+++ b/src/lib/ui/primitives/PinInput.svelte
@@ -5,29 +5,43 @@ import { UI_PRIMITIVES_LABELS } from '$lib/domain/labels';
 interface Props {
 	length?: number;
 	mask?: boolean;
+	/**
+	 * accessible name (screen reader 読み上げラベル)。既定は汎用の「PINコード」。
+	 * 同一画面に複数 PinInput を同時表示する場合は、各々に区別できる label を渡して
+	 * accessible name の重複・曖昧化を防ぐこと (例: reset-pin の「確認コード」+「新しい PIN」)。
+	 */
+	label?: string;
+	/**
+	 * label の表示クラス。既定は `sr-only` (視覚的に隠し SR のみ)。視覚ラベルにしたい場合は
+	 * 表示用クラスを渡す (Ark の Label → input 関連付けで重複なく 1 ラベルになる)。
+	 */
+	labelClass?: string;
 	onComplete?: (details: { value: string[]; valueAsString: string }) => void;
 }
 
-let { length = 6, mask = true, onComplete }: Props = $props();
+let {
+	length = 6,
+	mask = true,
+	label = UI_PRIMITIVES_LABELS.pinCodeLabel,
+	labelClass = 'sr-only',
+	onComplete,
+}: Props = $props();
 
 function handleValueComplete(details: { value: string[]; valueAsString: string }) {
 	onComplete?.(details);
 }
 </script>
 
-<ArkPinInput.Root
-	onValueComplete={handleValueComplete}
-	{mask}
-	type="numeric"
-	class="flex gap-[var(--sp-sm)] justify-center"
->
-	<ArkPinInput.Label class="sr-only">{UI_PRIMITIVES_LABELS.pinCodeLabel}</ArkPinInput.Label>
-	{#each Array(length) as _, i}
-		<ArkPinInput.Input
-			index={i}
-			class="w-12 h-14 text-center text-xl font-bold border-2 border-[var(--theme-secondary)] rounded-[var(--radius-sm)]
-				focus:border-[var(--theme-primary)] focus:outline-none transition-colors bg-white"
-		/>
-	{/each}
+<ArkPinInput.Root onValueComplete={handleValueComplete} {mask} type="numeric" class="flex flex-col gap-[var(--sp-sm)]">
+	<ArkPinInput.Label class={labelClass}>{label}</ArkPinInput.Label>
+	<ArkPinInput.Control class="flex gap-[var(--sp-sm)] justify-center">
+		{#each Array(length) as _, i}
+			<ArkPinInput.Input
+				index={i}
+				class="w-12 h-14 text-center text-xl font-bold border-2 border-[var(--theme-secondary)] rounded-[var(--radius-sm)]
+					focus:border-[var(--theme-primary)] focus:outline-none transition-colors bg-white"
+			/>
+		{/each}
+	</ArkPinInput.Control>
 	<ArkPinInput.HiddenInput />
 </ArkPinInput.Root>

--- a/src/lib/ui/primitives/PinInput.svelte
+++ b/src/lib/ui/primitives/PinInput.svelte
@@ -32,7 +32,10 @@ function handleValueComplete(details: { value: string[]; valueAsString: string }
 }
 </script>
 
-<ArkPinInput.Root onValueComplete={handleValueComplete} {mask} type="numeric" class="flex flex-col gap-[var(--sp-sm)]">
+<!-- Root は flex-col だが gap を持たない: 視覚差分ゼロを保つため、ラベル ↔ 桁行の余白は
+	可視ラベル側の margin (labelClass の mb-* 等) に委ねる。sr-only ラベル時は余白ゼロで
+	桁行が最上段に来る (旧実装の単独桁行と同一)。桁ボックス間の gap は Control が持つ。 -->
+<ArkPinInput.Root onValueComplete={handleValueComplete} {mask} type="numeric" class="flex flex-col">
 	<ArkPinInput.Label class={labelClass}>{label}</ArkPinInput.Label>
 	<ArkPinInput.Control class="flex gap-[var(--sp-sm)] justify-center">
 		{#each Array(length) as _, i}

--- a/src/routes/auth/reset-pin/+page.svelte
+++ b/src/routes/auth/reset-pin/+page.svelte
@@ -203,9 +203,14 @@ async function submitReset() {
 								<Alert variant="info" data-testid="pin-reset-verified-code-sent">{infoMessage}</Alert>
 							{/if}
 							<div>
-								<span class="text-sm font-semibold text-[var(--color-text-primary)] block mb-2">{PIN_RESET_LABELS.resetFederatedCodeLabel}</span>
 								{#key codeInputKey}
-									<PinInput length={6} mask={false} onComplete={handleCodeComplete} />
+									<PinInput
+										length={6}
+										mask={false}
+										label={PIN_RESET_LABELS.resetFederatedCodeLabel}
+										labelClass="text-sm font-semibold text-[var(--color-text-primary)] block mb-2"
+										onComplete={handleCodeComplete}
+									/>
 								{/key}
 							</div>
 						{:else}
@@ -221,9 +226,14 @@ async function submitReset() {
 							/>
 						{/if}
 						<div>
-							<span class="text-sm font-semibold text-[var(--color-text-primary)] block mb-2">{PIN_RESET_LABELS.resetPinLabel}</span>
 							{#key pinInputKey}
-								<PinInput length={4} mask onComplete={handlePinComplete} />
+								<PinInput
+									length={4}
+									mask
+									label={PIN_RESET_LABELS.resetPinLabel}
+									labelClass="text-sm font-semibold text-[var(--color-text-primary)] block mb-2"
+									onComplete={handlePinComplete}
+								/>
 							{/key}
 						</div>
 						<Button

--- a/tests/unit/db/lazy-startup-migrations.test.ts
+++ b/tests/unit/db/lazy-startup-migrations.test.ts
@@ -181,6 +181,51 @@ describe('applyLazyStartupMigrations', () => {
 			expect(tableExists(db, 'auto_challenges')).toBe(false);
 		});
 
+		it('auto_challenges DROP が child_challenges の auto:weekly 行を保全する (#3259 cuj-2 / #3213 一本化)', () => {
+			// #3213 の DROP は「data loss 許容」だが、それは生成チャレンジが child_challenges 側に
+			// 存続することが前提 (#3195 一本化)。本 test は DROP が一本化先 (child_challenges) の
+			// auto:weekly データを巻き込んで失わないこと = 保全を機械的に固定する。
+			db.exec(`
+				CREATE TABLE child_challenges (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_id INTEGER NOT NULL,
+					title TEXT NOT NULL,
+					start_date TEXT NOT NULL,
+					end_date TEXT NOT NULL,
+					source_template_id TEXT,
+					current_value INTEGER NOT NULL DEFAULT 0,
+					status TEXT NOT NULL DEFAULT 'active'
+				);
+			`);
+			db.prepare("INSERT INTO children (nickname, age) VALUES ('A', 8)").run();
+			// 一本化された週次自動チャレンジ (auto:weekly) — DROP で失われてはならない保全対象
+			db.prepare(
+				"INSERT INTO child_challenges (child_id, title, start_date, end_date, source_template_id, current_value) VALUES (1, '先週のチャレンジ', '2026-06-15', '2026-06-21', 'auto:weekly', 5)",
+			).run();
+			db.prepare(
+				"INSERT INTO child_challenges (child_id, title, start_date, end_date, source_template_id, current_value) VALUES (1, '今週のチャレンジ', '2026-06-22', '2026-06-28', 'auto:weekly', 2)",
+			).run();
+			// legacy auto_challenges (DROP 対象)
+			db.prepare(
+				"INSERT INTO auto_challenges (child_id, tenant_id, week_start, category_id, target_count) VALUES (1, 'default', '2026-06-22', 1, 3)",
+			).run();
+
+			applyLazyStartupMigrations(db);
+
+			// 冗長 legacy table は消えるが…
+			expect(tableExists(db, 'auto_challenges')).toBe(false);
+			// …一本化先の auto:weekly データは件数・進捗値ともに完全保全される (collateral loss なし)。
+			const rows = db
+				.prepare(
+					"SELECT title, start_date, current_value FROM child_challenges WHERE source_template_id = 'auto:weekly' ORDER BY start_date",
+				)
+				.all() as { title: string; start_date: string; current_value: number }[];
+			expect(rows).toEqual([
+				{ title: '先週のチャレンジ', start_date: '2026-06-15', current_value: 5 },
+				{ title: '今週のチャレンジ', start_date: '2026-06-22', current_value: 2 },
+			]);
+		});
+
 		it('checklist_templates を child_id (NOT NULL) → tenant_id (NOT NULL) に flip し assignments に migrate する (#2362 PR-5)', () => {
 			db.prepare("INSERT INTO children (nickname, age) VALUES ('A', 5)").run();
 			db.prepare("INSERT INTO children (nickname, age) VALUES ('B', 7)").run();

--- a/tests/unit/services/export-service.test.ts
+++ b/tests/unit/services/export-service.test.ts
@@ -1,7 +1,7 @@
 // tests/unit/services/export-service.test.ts
 // データエクスポートサービスのユニットテスト
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EXPORT_FORMAT, EXPORT_VERSION } from '../../../src/lib/domain/export-format';
 
 // モック定義
@@ -276,12 +276,15 @@ vi.mock('$lib/server/db/achievement-repo', () => ({
 		childId === 1 ? Promise.resolve(mockUnlockedAchievements) : Promise.resolve([]),
 	),
 }));
-const mockFindTemplatesByChild = vi.fn((childId: number) =>
-	childId === 1 ? Promise.resolve(mockChecklistTemplates) : Promise.resolve([]),
-);
-const mockFindLogsByChild = vi.fn((childId: number) =>
-	childId === 1 ? Promise.resolve(mockChecklistLogs) : Promise.resolve([]),
-);
+// #3259 perf-6: export は child を並列収集する (Promise.all) ようになり findLogsByChild /
+// findTemplatesByChild の呼び出し順が child 間で interleave しうる。childId キーの
+// default impl にしておくことで call 順に依存せず決定的になる (production も childId で query)。
+const defaultFindTemplatesByChild = (childId: number) =>
+	childId === 1 ? Promise.resolve(mockChecklistTemplates) : Promise.resolve([]);
+const defaultFindLogsByChild = (childId: number) =>
+	childId === 1 ? Promise.resolve(mockChecklistLogs) : Promise.resolve([]);
+const mockFindTemplatesByChild = vi.fn(defaultFindTemplatesByChild);
+const mockFindLogsByChild = vi.fn(defaultFindLogsByChild);
 vi.mock('$lib/server/db/checklist-repo', () => ({
 	findTemplatesByChild: (...args: unknown[]) => mockFindTemplatesByChild(...(args as [number])),
 	findTemplateItems: vi.fn(() => Promise.resolve(mockChecklistItems)),
@@ -319,6 +322,12 @@ vi.mock('$lib/server/db/status-repo', () => ({
 import { exportFamilyData } from '../../../src/lib/server/services/export-service';
 
 describe('exportFamilyData', () => {
+	// #3259 perf-6: 並列収集化で call 順非依存にするため、各 test 前に childId キーの default へ戻す。
+	beforeEach(() => {
+		mockFindTemplatesByChild.mockImplementation(defaultFindTemplatesByChild);
+		mockFindLogsByChild.mockImplementation(defaultFindLogsByChild);
+	});
+
 	it('正しいフォーマットとバージョンでエクスポートされる', async () => {
 		const result = await exportFamilyData({ tenantId: 'test-tenant' });
 		expect(result.format).toBe(EXPORT_FORMAT);
@@ -334,6 +343,24 @@ describe('exportFamilyData', () => {
 		expect(result.family.children[0]?.nickname).toBe('テスト太郎');
 		expect(result.family.children[1]?.exportId).toBe('child-2');
 		expect(result.family.children[1]?.nickname).toBe('テスト花子');
+	});
+
+	it('#3259 perf-6: child 並列収集後も childRef 順 + checksum が決定的 (N+1 解消で順序が崩れない)', async () => {
+		// 並列化 (Promise.all over children) で取り違え / 順序非決定にならないことを固定。
+		// childRef は childIds 順 (child-1 → child-2) を維持し、同入力なら checksum 完全一致。
+		const a = await exportFamilyData({ tenantId: 'test-tenant' });
+		const b = await exportFamilyData({ tenantId: 'test-tenant' });
+
+		const childRefs = a.data.activityLogs.map((l) => l.childRef);
+		// child-1 の log 群が child-2 の log 群より前に並ぶ (interleave していない)。
+		const firstChild2 = childRefs.indexOf('child-2');
+		if (firstChild2 >= 0) {
+			expect(childRefs.slice(0, firstChild2).every((r) => r === 'child-1')).toBe(true);
+		}
+		// data ペイロード (checksum 計算対象、exportedAt 除く) が 2 回の run で完全一致 = 決定的。
+		// (exportedAt は run ごとに異なるため checksum 自体ではなく data を比較する)
+		expect(JSON.stringify(a.data)).toBe(JSON.stringify(b.data));
+		expect(JSON.stringify(a.family)).toBe(JSON.stringify(b.family));
 	});
 
 	it('childIdsでフィルタリングできる', async () => {
@@ -469,23 +496,29 @@ describe('exportFamilyData', () => {
 				createdAt: '2025-05-01T00:00:00Z',
 				updatedAt: '2025-05-20T00:00:00Z',
 			};
-			mockFindTemplatesByChild.mockImplementationOnce(() =>
-				Promise.resolve([...mockChecklistTemplates, archivedTemplate]),
+			// #3259 perf-6: child 並列収集で call 順が変わりうるため childId キーで override
+			// (child-1 のみ archived template + log を返す。child-2 は default の [])。
+			mockFindTemplatesByChild.mockImplementation((childId: number) =>
+				childId === 1
+					? Promise.resolve([...mockChecklistTemplates, archivedTemplate])
+					: Promise.resolve([]),
 			);
-			mockFindLogsByChild.mockImplementationOnce(() =>
-				Promise.resolve([
-					...mockChecklistLogs,
-					{
-						id: 2,
-						childId: 1,
-						templateId: 2, // archive 済 template に紐づく log
-						checkedDate: '2026-02-10',
-						itemsJson: '{"9":true}',
-						completedAll: 1,
-						pointsAwarded: 3,
-						createdAt: '2026-02-10T08:00:00Z',
-					},
-				]),
+			mockFindLogsByChild.mockImplementation((childId: number) =>
+				childId === 1
+					? Promise.resolve([
+							...mockChecklistLogs,
+							{
+								id: 2,
+								childId: 1,
+								templateId: 2, // archive 済 template に紐づく log
+								checkedDate: '2026-02-10',
+								itemsJson: '{"9":true}',
+								completedAll: 1,
+								pointsAwarded: 3,
+								createdAt: '2026-02-10T08:00:00Z',
+							},
+						])
+					: Promise.resolve([]),
 			);
 
 			const result = await exportFamilyData({ tenantId: 'test-tenant' });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / システム全体

**解決する課題**: release/2026-06-23 監査 (#3257 / #3258 / #3259) で記録された非緊急の残課題 3 件を解消する。① reset-pin の PinInput がスクリーンリーダーで 2 フィールドを同じ汎用名で読み上げ曖昧化 (ux-1)、② family export の per-child N+1 + 上限到達の silent truncation (perf-6)、③ auto_challenges DROP の保全データ未検証 (cuj-2)。

**期待される効果**: a11y 向上（PIN 入力の各フィールドが固有名で読み上げ）、export の round-trip 安定 + 大量データ時の取りこぼし可視化、一本化移行 DROP のデータ保全を回帰固定。

## 関連 Issue

closes #3279
監査残課題 (#3259 関連、専用 Issue なし — 補佐が直実装): ux-1 / perf-6 / cuj-2。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| ux-1 | reset-pin の 2 PinInput が固有のアクセシブル名を持ち汎用名が重複しない | `npx vitest run --project storybook src/lib/ui/primitives/PinInput.stories.svelte` | HEAD `a4ed7dee` / 5 passed（WithLabel play: custom label 描画 + 'PINコード' 非退行）。reset-pin は label prop で「確認コード」/「新しい PIN」を渡し未関連付け span 撤去 |
| perf-6a | family export の child 収集が並列化され順序が決定的 | `npx vitest run tests/unit/services/export-service.test.ts` | HEAD `a4ed7dee` / 24 passed（2 run で data 完全一致 + childRef 非 interleave）。collectForChild + Promise.all(childIds.map) |
| perf-6b | 上限 (MAX_EXPORT_ROWS) 到達が observable | コードレビュー | HEAD `a4ed7dee` / export-service.ts warnIfTruncated（pointLedger/loginBonuses/evaluations/statusHistory で cap 到達時 logger.warn） |
| cuj-2 | auto_challenges DROP が child_challenges の auto:weekly 行を保全 | `npx vitest run tests/unit/db/lazy-startup-migrations.test.ts` | HEAD `a4ed7dee` / 20 passed（DROP 後も auto:weekly 行が件数・進捗値ともに保全） |

## 変更タイプ

- [x] fix: バグ修正
- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`)
- [x] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`)

**影響を受ける画面・機能**: /auth/reset-pin（PIN 入力ラベルの a11y 関連付け）/ family データ export / DB lazy-startup migration（テストのみ）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**
- [x] 追加・変更したテストの概要:
  - PinInput.stories.svelte: WithLabel play（label prop の描画 + 汎用名非退行）。
  - export-service.test.ts: 並列収集後の決定性（2 run data 一致 + childRef 順）。#3106 mock を childId キー化。
  - lazy-startup-migrations.test.ts: auto_challenges DROP のデータ保全。
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（非緊急の品質改善）

## スクリーンショット / ビジュアルデモ

**該当なし（refactor: 視覚差分ゼロの a11y 関連付け変更）**: reset-pin のラベルは同一テキスト（「確認コード（6桁の数字）」/「新しい${''}PIN…」）・同一スタイル（`text-sm font-semibold … block mb-2`）・同一位置（桁行の直上）のまま、`<span>`（未関連付け）から Ark `<label>`（input 関連付け）に置換しただけで、視認できる画面差分はない。PinInput の Root は `flex flex-col`（gap なし）にし、桁行間 gap は Control が、ラベル↔桁行の余白は可視ラベルの `mb-2` が担うため旧レイアウトと一致する（switch 等 sr-only ラベル箇所も余白ゼロで桁行最上段＝従来同一）。component 層の見た目・操作は `PinInput.stories.svelte` の play で担保。`refactor:internal-no-doc-impact` ラベル付与。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: PinInput に最小 prop 追加（後方互換 default）。export 収集を child 単位関数に分離（単一責任）。
- [x] **DRY**: export の per-child ロジックを collectForChild に集約。
- [x] **YAGNI**: MAX_EXPORT_ROWS は据置き、観測ログのみ追加。
- [x] **Security**: N/A
- [x] **アクセシビリティ**: PinInput の各インスタンスが固有アクセシブル名を持つ（WCAG: 入力の name 重複/曖昧化を解消）。
- [x] **パフォーマンス**: export の child 並列収集 + template items 並列化で直列ラウンドトリップを削減。

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): 振る舞い仕様変更なし（a11y / perf / test）。設計書更新不要。
- [x] **labels SSOT** (ADR-0009): reset-pin のラベルは既存 `PIN_RESET_LABELS` を使用（新規直書きなし）。
- [x] **並行 PR overlap** (#1200): PinInput は他 callsite（switch ×2）に後方互換（default 維持）。export-service / migration test に競合 open PR なし。
- [ ] N/A — 上記以外は影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（PinInput prop は後方互換 default、export 出力 shape/順序は不変、migration は既存挙動 + 保全テスト追加）。

**レビュー依頼事項・QA**: ① PinInput の Root を flex-col + Control 行構成に変更したが gap を持たせず視覚差分ゼロを維持（switch ページの PIN 入力に差分が出ていないか）。② export の child 並列化で checksum 決定性が保たれるか（2 run data 一致テストで担保）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み
- [x] UI 変更時: 視覚差分ゼロの a11y 関連付け変更のため SS 不要（`refactor:internal-no-doc-impact`、上記 SS セクション参照）
- [x] 認証画面変更時: 視覚差分なし（component play で担保）。実画面操作系の振る舞い変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

