### PR TITLE
refactor: #3227 marketplace 詳細から到達不能な challenge-set dead 分岐を除去 (sub-task 3)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -919,14 +919,9 @@ export const MARKETPLACE_LABELS = {
 	detailIncludedRewards: 'ふくまれるごほうび',
 	detailChecklistItems: 'チェック項目',
 	detailRuleContent: 'ルール内容',
-	/** #2297 (EPIC #2294 ③): challenge-set ふくまれるチャレンジ見出し */
-	detailIncludedChallenges: 'ふくまれるチャレンジ',
-	/** #2297: 各 challenge のメタ表記 (monthDay ・ durationDays日間) */
-	detailChallengePeriod: (monthDay: string, durationDays: number) =>
-		`${monthDay}・${durationDays}日間`,
-	/** #2297: 各 challenge の詳細行 (カテゴリ ・ 目標 N回 ・ ごほうび +NP) */
-	detailChallengeMeta: (category: string, baseTarget: number, rewardPoints: number) =>
-		`${category} ・ 目標 ${baseTarget}回 ・ ごほうび +${rewardPoints}P`,
+	// #3227: challenge-set 詳細見出し / プレビュー label (detailIncludedChallenges /
+	// detailChallengePeriod / detailChallengeMeta) は marketplace 詳細の isChallengeSet 到達不能
+	// 分岐除去に伴い参照ゼロの dead label となったため削除。
 	// #2558 bug-3: detailLegacyPackNote / detailLegacyPackLink / detailLegacyPackSuffix
 	// は参照ゼロの dead label (内部語彙「パック」露出元) のため削除。marketplace 取込の
 	// ユーザー向けラベルは TEMPLATE_TERMS (みんなのテンプレート / テンプレート) に統一。
@@ -1020,17 +1015,6 @@ export const MARKETPLACE_LABELS = {
 	detailCtaImportRuleSignedOut: '一括追加するには登録 / ログインが必要です',
 	detailRuleImportLinkToBonusList: '取込済ルール一覧へ →',
 	detailRuleImportLinkToRewardsList: 'ごほうび一覧へ →',
-	// #2297 (EPIC #2294 ③): challenge-set 一括追加 CTA
-	detailCtaImportChallengeSet: '🎯 このチャレンジ集を使ってみる',
-	detailCtaImportChallengeSetWithCount: (count: number) =>
-		`🎯 このチャレンジ集を使ってみる (${count}件)`,
-	detailCtaImportChallengeSetDesc:
-		'家族の見守り画面でフォームに反映されます。家族でお祝いしたい行事だけ選んで保存してください。',
-	detailCtaImportChallengeSetSignedOut: 'チャレンジ集を使うには登録 / ログインが必要です',
-	detailChallengeSetImportSuccess: (presetName: string, count: number) =>
-		`✨ 「${presetName}」から ${count} 件のチャレンジを追加しました`,
-	detailChallengeSetImportDuplicate: (presetName: string) =>
-		`⚠️ 「${presetName}」は既に取込済みです`,
 	backToTypeListSuffix: '一覧に戻る',
 	typeCountSuffix: '種',
 } as const;

--- a/src/routes/marketplace/[type]/[itemId]/+page.svelte
+++ b/src/routes/marketplace/[type]/[itemId]/+page.svelte
@@ -5,7 +5,6 @@
 import { APP_LABELS, formatAgeRange, MARKETPLACE_LABELS } from '$lib/domain/labels';
 import type {
 	ActivityPackPayload,
-	ChallengeSetPayload,
 	ChecklistPayload,
 	MarketplaceItem,
 	PersonaTag,
@@ -31,18 +30,6 @@ const isActivityPack = $derived(item.type === 'activity-pack');
 const isRewardSet = $derived(item.type === 'reward-set');
 const isChecklist = $derived(item.type === 'checklist');
 const isRulePreset = $derived(item.type === 'rule-preset');
-// #2297 (EPIC #2294 ③): challenge-set 表示判定
-const isChallengeSet = $derived(item.type === 'challenge-set');
-const challengeSetPayload = $derived(isChallengeSet ? (item.payload as ChallengeSetPayload) : null);
-const challengeCount = $derived(challengeSetPayload?.challenges.length ?? 0);
-// #2297: カテゴリ ID → 名称マッピング (sibling-challenge 5 軸と同一)
-const CATEGORY_LABELS: Record<number, string> = {
-	1: 'うんどう',
-	2: 'べんきょう',
-	3: 'せいかつ',
-	4: 'こうりゅう',
-	5: 'そうぞう',
-};
 
 // #2362 PR-4 (ADR-0055 / CWE-598): reward-set 一括追加 UI は admin/rewards 側 ChildSelectionDialog
 // に集約。marketplace 詳細では item count のみ表示。selectedChildId / rewardImport state は撤去。
@@ -201,8 +188,6 @@ function deselectAllActivities() {
 					{MARKETPLACE_LABELS.detailChecklistItems}
 				{:else if isRulePreset}
 					{MARKETPLACE_LABELS.detailRuleContent}
-				{:else if isChallengeSet}
-					{MARKETPLACE_LABELS.detailIncludedChallenges}
 				{/if}
 			</h2>
 
@@ -327,29 +312,6 @@ function deselectAllActivities() {
 									{MARKETPLACE_LABELS.detailRulePointBonus}: +{rule.pointBonus}P
 								</p>
 							{/if}
-						</div>
-					{/each}
-				</div>
-			{:else if isChallengeSet && challengeSetPayload}
-				<!-- #2297 (EPIC #2294 ③): challenge-set 内容プレビュー -->
-				<div class="space-y-2" data-testid="challenge-set-preview">
-					{#each challengeSetPayload.challenges as ch (ch.title)}
-						<div class="p-3 rounded-lg bg-[var(--color-surface-muted)]">
-							<div class="flex items-center gap-2 mb-1">
-								<span class="text-lg">{ch.icon}</span>
-								<span class="text-sm font-bold text-[var(--color-text-primary)]">{ch.title}</span>
-								<span class="text-[10px] text-[var(--color-text-tertiary)] ml-auto">
-									{MARKETPLACE_LABELS.detailChallengePeriod(ch.monthDay, ch.durationDays)}
-								</span>
-							</div>
-							<p class="text-xs text-[var(--color-text-secondary)] ml-8">{ch.description}</p>
-							<p class="text-xs text-[var(--color-text-tertiary)] ml-8 mt-1">
-								{MARKETPLACE_LABELS.detailChallengeMeta(
-									CATEGORY_LABELS[ch.categoryId] ?? '',
-									ch.baseTarget,
-									ch.rewardPoints,
-								)}
-							</p>
 						</div>
 					{/each}
 				</div>
@@ -535,35 +497,6 @@ function deselectAllActivities() {
 				</a>
 				<p class="text-xs text-center text-[var(--color-text-tertiary)]">
 					{MARKETPLACE_LABELS.detailCtaImportRuleSignedOut}
-				</p>
-			{:else if isChallengeSet && data.isAuthenticated}
-				<!-- #2297 (EPIC #2294 ③): challenge-set ログイン済 → /admin/challenges に遷移してフォーム pre-fill -->
-				<p class="text-xs text-[var(--color-text-tertiary)]">
-					{MARKETPLACE_LABELS.detailCtaImportChallengeSetDesc}
-				</p>
-				<a
-					href="/admin/challenges?import={item.itemId}"
-					class="block"
-					data-testid="challenge-set-import-cta"
-				>
-					<Button variant="primary" size="lg" class="w-full">
-						{MARKETPLACE_LABELS.detailCtaImportChallengeSetWithCount(challengeCount)}
-					</Button>
-				</a>
-			{:else if isChallengeSet}
-				<!-- #2297 / #2303: challenge-set 未ログイン → login へ誘導 (誤新規登録防止 / data integrity 保護)。
-					login 画面内「新規アカウント作成」リンクで signup へ到達可能 -->
-				<a
-					href="/auth/login?next=/marketplace/challenge-set/{item.itemId}"
-					class="block"
-					data-testid="challenge-set-signup-redirect"
-				>
-					<Button variant="primary" size="lg" class="w-full">
-						{MARKETPLACE_LABELS.detailCtaImportChallengeSet}
-					</Button>
-				</a>
-				<p class="text-xs text-center text-[var(--color-text-tertiary)]">
-					{MARKETPLACE_LABELS.detailCtaImportChallengeSetSignedOut}
 				</p>
 			{:else if isActivityPack && data.isAuthenticated && data.children.length > 0}
 				<!-- #2362 PR-3 Phase 5 (CWE-598): activity-pack ログイン済 + 子供登録済

--- a/tests/unit/routes/marketplace-auth-redirect.test.ts
+++ b/tests/unit/routes/marketplace-auth-redirect.test.ts
@@ -83,10 +83,11 @@ describe('#2303 marketplace 未ログイン CTA は /auth/login redirect', () =>
 			);
 		});
 
-		it('詳細画面 challenge-set 未ログイン CTA は /auth/login へ遷移する', () => {
-			// challenge-set CTA: `href="/auth/login?next=/marketplace/challenge-set/{item.itemId}"`
-			expect(content).toMatch(
-				/href=["']\/auth\/login\?next=\/marketplace\/challenge-set\/\{item\.itemId\}["']/,
+		it('#3227: challenge-set 未ログイン CTA (login redirect) も除去済 (到達不能分岐)', () => {
+			// challenge-set は preset 0 件で marketplace 詳細が必ず 404 するため、未ログイン
+			// signup-redirect 分岐も到達不能 dead code。本 PR で除去し再生を回帰防止する。
+			expect(content).not.toMatch(
+				/href=["']\/auth\/login\?next=\/marketplace\/challenge-set\//,
 			);
 		});
 
@@ -178,9 +179,15 @@ describe('#2303 marketplace 未ログイン CTA は /auth/login redirect', () =>
 			expect(content).toMatch(/data-testid=["']rule-preset-import-cta["']/);
 		});
 
-		it('challenge-set CTA は `<a href="/admin/challenges?import=...">` (旧 ?marketplace-import= 廃止)', () => {
-			expect(content).toMatch(/href=["']\/admin\/challenges\?import=\{item\.itemId\}["']/);
-			expect(content).toMatch(/data-testid=["']challenge-set-import-cta["']/);
+		it('#3227: challenge-set の dead 分岐 (import CTA / preview / signup redirect) は除去済', () => {
+			// #2896 で challenge-set は非陳列・preset 0 件化し、marketplace 詳細 loader は
+			// getMarketplaceItem('challenge-set', *)=undefined → error(404) を必ず投げるため、
+			// isChallengeSet 分岐は 100% 到達不能。admin/challenges も ?import= を parse しない
+			// (#3195) ため CTA は silent no-op の dead 分岐だった。本 PR で +page.svelte から除去。
+			expect(content).not.toMatch(/data-testid=["']challenge-set-import-cta["']/);
+			expect(content).not.toMatch(/data-testid=["']challenge-set-signup-redirect["']/);
+			expect(content).not.toMatch(/data-testid=["']challenge-set-preview["']/);
+			expect(content).not.toMatch(/href=["']\/admin\/challenges\?import=/);
 		});
 
 		it('activity-pack CTA は `<a href="/admin/activities?import=...">` + testid=activity-pack-import-cta (#2362 PR-3 既存)', () => {

--- a/tests/unit/routes/marketplace-auth-redirect.test.ts
+++ b/tests/unit/routes/marketplace-auth-redirect.test.ts
@@ -86,9 +86,7 @@ describe('#2303 marketplace 未ログイン CTA は /auth/login redirect', () =>
 		it('#3227: challenge-set 未ログイン CTA (login redirect) も除去済 (到達不能分岐)', () => {
 			// challenge-set は preset 0 件で marketplace 詳細が必ず 404 するため、未ログイン
 			// signup-redirect 分岐も到達不能 dead code。本 PR で除去し再生を回帰防止する。
-			expect(content).not.toMatch(
-				/href=["']\/auth\/login\?next=\/marketplace\/challenge-set\//,
-			);
+			expect(content).not.toMatch(/href=["']\/auth\/login\?next=\/marketplace\/challenge-set\//);
 		});
 
 		it('詳細画面 activity-pack 未ログイン CTA は /auth/login へ遷移する (#2362 PR-3 Phase 5)', () => {


### PR DESCRIPTION
## 顧客価値・目的

#3227(challenge 一本化 cutover の release-gate)の sub-task 3「dead challenge-set import CTA / type card 整理」を実施。marketplace 詳細に残っていた **100% 到達不能**な challenge-set 分岐(silent no-op の import CTA を含む)を除去し、将来の誤再生を回帰ガードで防止する。顧客に見える変化はない(到達不能分岐の dead code 除去)。

## 関連 Issue

- #3227(sub-task 3 = dead CTA / type card 整理。sub-task 1 carry-over は prod で moot・NUC で transient 非 dispositive、sub-task 2 dead write は #3213 で対応済。詳細は #3227 のコメント #issuecomment-4784114225 に検証済)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| sub-3a | dead challenge-set import CTA(`/admin/challenges?import=`、silent no-op)を除去 | `grep -n "challenge-set-import-cta"` + `npx vitest run tests/unit/routes/marketplace-auth-redirect.test.ts` | ✅ `+page.svelte`(HEAD cce995a0f)から isChallengeSet 認証済 CTA 分岐を除去。test を「CTA 不在」の回帰ガードに反転(27 passed) |
| sub-3b | 到達不能 challenge-set 分岐(見出し / プレビュー / signup redirect)を整理 | 同 test + svelte-check | ✅ challenge-set は preset 0 件で loader が必ず `error(404)`(`getMarketplaceItem('challenge-set',*)`=undefined)→ 全 isChallengeSet 分岐は描画され得ない dead code。+page.svelte から除去 |
| sub-3c | dead 化した label / import / 定数を整理 | `grep -rn "detailCtaImportChallengeSet" src tests`(参照ゼロ確認) | ✅ labels.ts の challenge-set 詳細 label 群 + ChallengeSetPayload import + dead CATEGORY_LABELS を除去 |
| sub-3d | LP truth 整合(全プラン開放) | `grep -in "challenge" site/index.html site/pricing.html` | ✅ LP は challenge を plan-gate せず一般機能として記載(#3195 全プラン開放と整合、ADR-0013 違反なし)。LP 変更不要 |

## 変更タイプ

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング(到達不能 dead code 除去、機能仕様変化なし・可視変化なし)
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `src/routes/marketplace/[type]/[itemId]/+page.svelte`: isChallengeSet 派生 3 件 + 4 分岐(見出し / プレビュー / 認証済 CTA / 未ログイン redirect)+ dead 化した `CATEGORY_LABELS` / `ChallengeSetPayload` import を除去
- `src/lib/domain/labels.ts`: 参照ゼロになった challenge-set 詳細 label 群を削除(SSOT 整理)
- `tests/unit/routes/marketplace-auth-redirect.test.ts`: challenge-set CTA / preview / signup-redirect の「不在」回帰ガードに反転

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/routes/marketplace-auth-redirect.test.ts` — 27 passed(dead 分岐不在の回帰ガード化)
- [x] `npx biome check` 3 file クリーン / `npx svelte-check` 0 ERRORS
- [x] `node scripts/check-hardcoded-strings.mjs` violations 0(label 削除のため増加なし)
- [x] challenge-set の型 / schema / strategy / fixture(#2896 非陳列 guard + export validation)は不変 — UI 詳細の到達不能分岐のみ除去

## スクリーンショット / ビジュアルデモ

該当なし(到達不能 dead code 除去で可視 UI 変化なし。challenge-set 詳細は preset 0 件 → 404 で到達不能、activity-pack / reward-set / checklist / rule-preset の生きた分岐は不変)。`refactor:internal-no-doc-impact` ラベルで screenshot-check exempt(#2017 / ADR-0003 §4)。

## コード品質セルフレビュー (#1481)

- [x] 除去は isChallengeSet 分岐に限定。activity-pack / reward-set / checklist / rule-preset の `{:else if}` チェーンは不変(svelte-check 0 ERRORS で構文健全性確認)
- [x] dead label / import / 定数を参照ゼロ確認後に削除(`grep -rn` で全 src/tests 確認)
- [x] challenge-set 型/schema/strategy は #2896 の非陳列 guard + export validation のため存続(過剰削除しない)

## 横展開・影響波及チェック

- [x] **LP ↔ アプリ双方向整合** (#1481 / ADR-0013): LP は challenge を plan-gate せず一般機能扱いで全プラン開放(#3195)と整合済、LP 変更不要
- [x] challenge-set 非陳列の回帰は `tests/e2e/marketplace-challenge-set-import.spec.ts` が担保(本 PR は UI 詳細分岐除去で非陳列方針を強化、矛盾なし)

## レビュー依頼事項・破壊的変更

破壊的変更なし。到達不能(404)な challenge-set 詳細分岐の dead code 除去のみで、生きた 4 type の挙動は不変。

## 配布済み env / secret (ADR-0006)

なし。

## Ready for Review チェックリスト

- [x] CI green 見込み(biome / svelte-check / 該当 vitest をローカル確認)
- [x] 必須セクション記入済(internal-refactor exempt のため SS は該当なし)
- [x] sub-task 3 を実装、sub-1/sub-2 の状況を #3227 コメントに検証済

## QM レビュー結果

<!-- QM が記入 -->
