### PR TITLE
fix: 設定ホーム UI の内部事情露出を除去 + 再混入 lint (self-ref-change group)

### DIFF
--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -178,6 +178,7 @@ MSYS_NO_PATHCONV=1 node scripts/capture.mjs --url /admin/children --presets mobi
 
 **撮影後の UI/UX セルフレビュー** — 詳細は `docs/sessions/qa-checklist-ui-quality.md` 参照。要点:
 - DESIGN.md §9 禁忌 6 点（hex 直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / `<style>` 50 行超）
+- **UI 文言に「実装変更の自己言及」を書かない**（「設定をグループ別に整理しました」等）。ユーザーには現在の使い方・状態だけ伝え、整理 / 統合 / 移行の経緯は git・docs に置く。`check-internal-terms.mjs` の self-ref-change group が string リテラル（コメント除く）を検出（#3259）
 - 5 年齢モード fontScale / タップサイズ
 - mobile 390px / desktop 1280px の両ビューポート
 - 色 / 形 / 用語 / 間隔 / 状態 / アクセシビリティ / 読解容易性

--- a/scripts/check-internal-terms.mjs
+++ b/scripts/check-internal-terms.mjs
@@ -84,6 +84,36 @@ const CONN_INFO_BANLIST = [
 	},
 	{ regex: /kusaka[-]server/, label: '<NUC_USER> (NUC SSH user)', category: 'conn-info' },
 ];
+
+// ---------------------------------------------------------------------------
+// SELF_REF_CHANGE_BANLIST (#3259 follow-up) — UI 文字列への「実装変更の自己言及」検知
+//
+// 「設定をグループ別に整理しました」等、コードベースの再編をユーザー向け文言で語るメタ言及を
+// 禁止する。ユーザーは内部の整理 / 統合 / 移行という事実を必要とせず、現在の使い方・状態だけ
+// 分かればよい (内部事情の UI 露出。実例: 設定ハブの hubDesc / settings _guide.ts、#3259)。
+// INTERNAL_TERMS (infra / SaaS 語) とは別カテゴリの「変更の自己言及」を対象にする。
+//
+// 対象: labels.ts (compound UI 文字列の本体) + 全 routes + features の .ts / .svelte。
+// comment 行は除外 (isCommentLine) — issue note 等「#NNNN で統合済」コメントは正当な開発記録。
+// baseline なし — 残存 0 で導入し、新規 1 件で即 fail (conn-info group と同型)。
+// 検出語は「動作の完了報告 (〜しました / 〜されています)」に限定し、子供向けの内容語
+// (「がんばりをまとめました」等のデータ要約) を誤検出しない短語 (整理/統合 単独) は採らない。
+// ---------------------------------------------------------------------------
+
+const SELF_REF_CHANGE_BANLIST = [
+	'整理しました',
+	'整理されています',
+	'統合しました',
+	'統合されました',
+	'移行しました',
+	'刷新しました',
+	'リニューアルしました',
+	'新しくなりました',
+	'生まれ変わりました',
+];
+
+const SELF_REF_ROOTS = ['src/lib/domain/labels.ts', 'src/routes', 'src/lib/features'];
+const SELF_REF_EXTENSIONS = ['.ts', '.svelte'];
 // ---------------------------------------------------------------------------
 // WORKFLOW_LANE_COVERAGE (#2948) — 全 workflow が gate × lane 対応表に記載済か検証
 //
@@ -260,6 +290,40 @@ function scanConnInfo() {
 }
 
 // ---------------------------------------------------------------------------
+// self-ref-change group 検査 (#3259) — UI 文字列の「実装変更の自己言及」
+// ---------------------------------------------------------------------------
+
+function scanSelfRefChange() {
+	const files = [];
+	for (const root of SELF_REF_ROOTS) {
+		walk(path.join(REPO_ROOT, root), files, SELF_REF_EXTENSIONS, () => false);
+	}
+	const violations = [];
+	for (const f of files) {
+		// テストは UI 文言ではないため対象外
+		if (/\.(test|spec)\.(ts|mjs)$/.test(f)) continue;
+		const lines = fs.readFileSync(f, 'utf8').split(/\r?\n/);
+		for (let i = 0; i < lines.length; i++) {
+			if (isCommentLine(lines[i])) continue; // 開発記録コメントは正当 (string 値のみ検査)
+			for (const pattern of SELF_REF_CHANGE_BANLIST) {
+				const idx = lines[i].indexOf(pattern);
+				if (idx >= 0) {
+					violations.push({
+						file: relPath(f),
+						line: i + 1,
+						col: idx + 1,
+						pattern,
+						category: 'self-ref-change',
+						snippet: lines[i].trim().slice(0, 200),
+					});
+				}
+			}
+		}
+	}
+	return { fileCount: files.length, violations };
+}
+
+// ---------------------------------------------------------------------------
 // workflow-lane-coverage group 検査 (#2948)
 // ---------------------------------------------------------------------------
 
@@ -354,7 +418,29 @@ function main() {
 		return 1;
 	}
 
-	// 6. workflow-lane-coverage group (#2948) — baseline なし、未記載 1 件で fail
+	// 6. self-ref-change group (#3259) — baseline なし、UI 文字列の自己言及 1 件で fail
+	const selfRef = scanSelfRefChange();
+	console.log(
+		`[check-internal-terms] self-ref-change group (#3259): 検査 ${selfRef.fileCount} files / 違反 ${selfRef.violations.length} 件`,
+	);
+	if (selfRef.violations.length > 0) {
+		console.log(
+			'\n[check-internal-terms] ✗ FAIL — UI 文字列に実装変更の自己言及が検出されました:\n',
+		);
+		for (const v of selfRef.violations) {
+			console.log(`  ${v.file}:${v.line}:${v.col}  [${v.category}] "${v.pattern}"`);
+			console.log(`    ${v.snippet}`);
+		}
+		console.log(
+			'\n修正方針 (#3259):\n' +
+				'  - 「整理しました」「統合しました」「移行しました」等、コード再編の自己言及を UI 文言から除去\n' +
+				'  - ユーザーには現在の使い方・状態のみ伝える (例:「下のカードから設定したい項目を選んでください」)\n' +
+				'  - 変更の経緯・履歴は git / docs に置き、UI には出さない (内部事情の UI 露出を避ける)\n',
+		);
+		return 1;
+	}
+
+	// 7. workflow-lane-coverage group (#2948) — baseline なし、未記載 1 件で fail
 	const laneCoverage = scanWorkflowLaneCoverage();
 	if (laneCoverage.error) {
 		console.log(

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -1464,7 +1464,7 @@ export const PAGE_GUIDE_LABELS = {
 			'settings-intro': {
 				title: 'このページについて',
 				what: `${ADMIN_VIEW_TERMS.canonical}の各種設定をまとめたページです。アクセスを守るおやカギ、ポイントの表示単位、データのバックアップなどをここから設定します。`,
-				how: '設定はグループ別のカードに整理されています。設定したい項目のカードを選んで、その中の設定画面に進みます。',
+				how: '設定したい項目のカードを選んで、その中の設定画面に進みます。',
 				goal: '必要な設定にすぐたどり着けるので、おやカギの変更やバックアップなどの「念のための備え」を迷わず行えます。',
 			},
 			'settings-hub': {
@@ -2075,7 +2075,7 @@ export const SETTINGS_LABELS = {
 
 	// #2319 Phase Settings-Audit: hub page (6 グループへのナビ集約)
 	hubTitle: '設定',
-	hubDesc: '設定をグループ別に整理しました。下のカードから設定したい項目を選んでください。',
+	hubDesc: '下のカードから設定したい項目を選んでください。',
 	groupAccountTitle: 'アカウント',
 	groupAccountDesc: 'おやかぎコード変更・ログアウト・アカウント削除',
 	groupActivitiesTitle: '活動・ポイント',


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: 設定ホーム画面に「設定をグループ別に整理しました」等、コードベース再編をユーザー向け文言で語るメタ言及（内部事情の UI 露出）が出ていた。ユーザーは内部の整理 / 統合 / 移行という事実を必要とせず、現在の使い方・状態だけ分かればよい。

**期待される効果**: UI 文言が「使い方の案内」に徹し、開発側の都合（実装変更の経緯）が顧客に漏れない。再混入を lint で機械的に防止する。

## 関連 Issue

closes #3297
release 監査 #3259 関連（専用 Issue なし — User 直接指摘: 設定ホームの内部事情露出スクリーンショット）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| 1 | 設定ホームの自己言及メタ文言を除去 | `grep -n "整理しました\|整理されています" src/lib/domain/labels.ts src/routes/(parent)/admin/settings/_guide.ts` | HEAD `2d80f9bb` / hubDesc・_guide.ts how から除去、純粋な操作案内に置換 |
| 2 | 類似の自己言及メタ文言が他 UI に無いことを確認 | `node scripts/check-internal-terms.mjs`（self-ref-change group） | HEAD `2d80f9bb` / 353 files 走査・違反 0 件 PASS |
| 3 | 再混入を検出する lint 機構（コメントと string リテラルを区別） | 一時 probe で negative test | HEAD `2d80f9bb` / string 値の「整理しました」を検出・同 verb のコメント行は非検出を確認。ci.yml で実行済のため CI 自動化済 |
| 4 | dev-session.md 改訂（簡潔） | 目視 | HEAD `2d80f9bb` / 撮影後 UI/UX セルフレビュー要点に 1 行追加のみ（肥大化回避） |

## 変更タイプ

- [x] fix: バグ修正
- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ドメインモデル (`$lib/domain/`)
- [x] ページ / レイアウト (`src/routes/`)
- [x] 設定・CI (`package.json`, `.github/` 等) ※lint script 拡張

**影響を受ける画面・機能**: /admin/settings（設定ホームの説明文・ページガイド how）。lint: 全 UI 文字列の再混入検出。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**
- [x] 追加・変更したテストの概要: lint の negative test（一時 probe で string 検出 + コメント非検出を確認）。check-internal-terms.mjs は既存 conn-info / workflow group 同様 CI 統合で検証（script は export 構造でないため unit test なし、既存パターン踏襲）。
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor: UI 文言の簡素化、.ts のみ変更）**: 変更は labels.ts / _guide.ts（.ts）と lint script / docs のみで .svelte / .css 変更なし。設定ホームの説明文が「設定をグループ別に整理しました。下のカードから…」→「下のカードから設定したい項目を選んでください。」に短縮されるテキスト変更で、レイアウト・構造の差分はない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: lint は既存 check-internal-terms.mjs の multi-group パターンに self-ref-change group を追加（conn-info / workflow group と同型）。
- [x] **DRY**: 既存 `isCommentLine` / `walk` / `relPath` を再利用（新規 script を作らず config 駆動拡張、#1442 / docs/CLAUDE.md 方針）。
- [x] **YAGNI**: 検出語は「動作完了報告 (〜しました/〜されています)」に限定し、子供向け内容語（「がんばりをまとめました」等）を誤検出しない。
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A（文言簡素化）
- [x] **パフォーマンス**: lint は 353 files 走査で軽量。

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): 振る舞い仕様変更なし（UI copy + lint）。
- [x] **labels SSOT** (ADR-0009): hubDesc は labels.ts SSOT 経由（LP 非同期ラベル、generate-lp-labels --check PASS）。
- [x] **並行 PR overlap** (#1200): labels.ts は頻繁更新ファイルだが本 PR の変更は hubDesc 1 行 + lint script + docs で局所。
- [ ] N/A — 上記以外は影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（UI 文言短縮 + lint group 追加 + docs 1 行）。

**レビュー依頼事項・QA**: self-ref-change lint の検出語リスト（整理しました / 統合しました / 移行しました 等）が過不足ないか。短語単独（整理 / 統合）は誤検出回避のため意図的に不採用。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み
- [x] UI 変更時: .ts 文言短縮のみで視覚構造差分なし（.svelte 変更なし、上記 SS セクション参照）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

