### PR TITLE
feat: #3267 (#3260 C3) プラン・課金(subscription) + お支払い(billing) ページガイド

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -731,7 +731,7 @@ PO 提案「マーケプレ rule-preset 集約による settings 初期値配布
 
 **`?` ボタンの表示条件:** AdminLayout は現在のパスを `getPageGuide(path)` で解決し、ガイドが登録されているページでのみ `?` ボタンを表示する（未登録ページでは `?` 自体が出ない）。したがって **新規 admin ページを追加したら `_guide.ts` を作成し `page-guide-registry.ts` に登録しないと `?` が脱落する**（#2905 = #2294 EPIC で新設された checklists / challenges + status が未登録のまま `?` が見えなくなっていた regression の復旧）。
 
-**登録済みページ（`page-guide-registry.ts` SSOT）:** `/admin` / `/admin/children` / `/admin/activities` / `/admin/rewards` / `/admin/checklists` / `/admin/challenges` / `/admin/status` / `/admin/points` / `/admin/reports` / `/admin/cheer` / `/admin/settings`。
+**登録済みページ（`page-guide-registry.ts` SSOT）:** `/admin` / `/admin/children` / `/admin/activities` / `/admin/rewards` / `/admin/checklists` / `/admin/challenges` / `/admin/status` / `/admin/points` / `/admin/reports` / `/admin/cheer` / `/admin/settings` / `/admin/subscription` / `/admin/billing`（#3267）。EPIC #3260 で全顧客接点ページへ順次拡大中（#3262 F1: 未登録サブパスは親パスにフォールバックし `?` が空にならない）。
 
 **presence 不変条件（導線インベントリテスト、#2905）:** 全登録ページで「`?` トリガが存在し、click でガイド overlay が開き、Escape で閉じる」を `tests/e2e/admin-page-guide-presence.spec.ts` がループ検証する。新ページの登録漏れ / 登録解除はこの spec が必ず fail させる（M6 構造 invariant）。
 

--- a/scripts/capture-specs/flows/subscription-guide-3267.mjs
+++ b/scripts/capture-specs/flows/subscription-guide-3267.mjs
@@ -2,6 +2,8 @@
  * scripts/capture-specs/flows/subscription-guide-3267.mjs
  * PR #3291 (#3260 C3): /admin/subscription の ? ページガイド overlay を撮影。
  */
+import { waitForStablePage } from '../../lib/screenshot-helpers.mjs';
+
 const BASE_URL = process.env.BASE_URL || 'http://localhost:5191';
 
 export default async (page, capture) => {
@@ -22,6 +24,7 @@ export default async (page, capture) => {
 	await page
 		.locator('[role="dialog"][aria-labelledby="page-guide-title"]')
 		.waitFor({ state: 'visible', timeout: 8_000 });
-	await page.waitForTimeout(700);
+	// overlay の出現アニメ + フォント/レイアウト確定を待つ (waitForTimeout は scripts/ で禁止 #1208)
+	await waitForStablePage(page, { skipNetworkIdle: true });
 	await capture('subscription-guide');
 };

--- a/scripts/capture-specs/flows/subscription-guide-3267.mjs
+++ b/scripts/capture-specs/flows/subscription-guide-3267.mjs
@@ -1,0 +1,27 @@
+/**
+ * scripts/capture-specs/flows/subscription-guide-3267.mjs
+ * PR #3291 (#3260 C3): /admin/subscription の ? ページガイド overlay を撮影。
+ */
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5191';
+
+export default async (page, capture) => {
+	await page.goto(`${BASE_URL}/admin/subscription`);
+	await page.waitForLoadState('domcontentloaded');
+	// welcome overlay があれば閉じる
+	const welcome = page.locator('.welcome-overlay');
+	if (await welcome.isVisible({ timeout: 1500 }).catch(() => false)) {
+		await welcome
+			.locator('.welcome-cta')
+			.click()
+			.catch(() => {});
+		await welcome.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
+	}
+	const btn = page.locator('[data-tutorial="page-guide-btn"]');
+	await btn.waitFor({ state: 'visible', timeout: 15_000 });
+	await btn.first().click({ force: true });
+	await page
+		.locator('[role="dialog"][aria-labelledby="page-guide-title"]')
+		.waitFor({ state: 'visible', timeout: 8_000 });
+	await page.waitForTimeout(700);
+	await capture('subscription-guide');
+};

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -1482,6 +1482,61 @@ export const PAGE_GUIDE_LABELS = {
 			},
 		},
 	},
+	adminSubscription: {
+		title: 'プラン・課金',
+		steps: {
+			// ① ページ概要（selector 省略で画面中央 modal、全環境で表示）。NUC セルフホスト版では
+			// 現在のプラン／プラン管理セクションが無いため、intro は両環境で正しい「契約・プランの
+			// 状況を確認するページ」に留める（実装にない操作を案内しない、ADR-0013）。
+			'subscription-intro': {
+				title: 'このページについて',
+				what: '今ご利用中のプランや契約の状況を確認するページです。プランに関する操作の入り口がここに集まっています。',
+				how: '上から順に、現在の状況・プランの管理・支払い履歴への入り口が並びます。表示される項目はご利用環境によって変わります。',
+				goal: `プランの状況をひと目で把握でき、必要なときに${PLAN_CHANGE_TERMS.changeNoun}や支払いの管理へ迷わず進めます。`,
+			},
+			// ② 画面の見方（現在のプラン）— SaaS 版のみ（NUC では本セクション非表示のため除外）。
+			'subscription-current-plan': {
+				title: '画面の見方（現在のプラン）',
+				what: 'いま契約中のプランと、無料トライアル中ならその残り期間がここに表示されます。',
+				how: '1. 上部で現在のプランを確認します\n2. 下の「プラン管理」で変更できます',
+				goal: '今どのプランかをすぐ確認でき、変更前の状態を把握できます。',
+			},
+			// ③ 最頻操作（プラン管理）— SaaS 版のみ。実 UI は契約状況で分岐するため両分岐を記述する。
+			'subscription-plan-management': {
+				title: `よく使う操作（${PLAN_CHANGE_TERMS.changeNoun}）`,
+				what: `プランの開始・変更をここから行います。まだ有料プランをご契約でないときはプランを選んでお申し込みでき、ご契約済みのときは${STRIPE_PORTAL_TERMS.canonical}での管理に進めます。`,
+				how: `・未契約のとき: 1. プランを選びます 2. 申し込みボタンで手続きします\n・契約済みのとき: 1. ${STRIPE_PORTAL_TERMS.short}を開きます 2. プラン変更や支払い方法を手続きします`,
+				goal: `${PLAN_CHANGE_TERMS.changeNoun}が反映され、支払い方法も${STRIPE_PORTAL_TERMS.short}で管理できます。`,
+				tips: [`${CANCEL_TERMS.anytime}できます`],
+			},
+		},
+	},
+	adminBilling: {
+		title: 'お支払い',
+		steps: {
+			// ① ページ概要（selector 省略で画面中央 modal）。
+			'billing-intro': {
+				title: 'このページについて',
+				what: `ご契約の状況確認と、${STRIPE_PORTAL_TERMS.short}での支払い管理・${CANCEL_TERMS.canonical}をまとめたページです。`,
+				how: '上から「ご契約状況」「請求管理」の順に並びます。',
+				goal: `支払いの状況を把握でき、必要なら${STRIPE_PORTAL_TERMS.short}や${CANCEL_TERMS.canonicalVerb}手続きに進めます。`,
+			},
+			// ② 画面の見方（ご契約状況）。
+			'billing-overview': {
+				title: '画面の見方（ご契約状況）',
+				what: '契約中のプランの状態と、次回の請求予定がここに表示されます。',
+				how: '1. 契約状況を確認します\n2. 下の「請求管理」で支払い方法を変えられます',
+				goal: '今の契約と請求予定をひと目で確認できます。',
+			},
+			// ③ 最頻操作（請求管理ページ）。ご契約があるときに「請求管理ページを開く」ボタンが出る。
+			'billing-portal': {
+				title: `よく使う操作（${STRIPE_PORTAL_TERMS.short}）`,
+				what: `支払い方法の変更や領収書の確認は${STRIPE_PORTAL_TERMS.canonical}から行います。ご契約があるときに開くボタンが表示されます。`,
+				how: `1. ${STRIPE_PORTAL_TERMS.short}を開きます\n2. 支払い方法や${CANCEL_TERMS.canonical}を手続きします`,
+				goal: `支払い方法を最新に保て、${CANCEL_TERMS.anytime}できます。`,
+			},
+		},
+	},
 	adminStatus: {
 		title: '成長レポート',
 		steps: {

--- a/src/lib/features/admin/components/AdminLayout.svelte
+++ b/src/lib/features/admin/components/AdminLayout.svelte
@@ -11,7 +11,11 @@ import {
 import Logo from '$lib/ui/components/Logo.svelte';
 import PageGuideOverlay from '$lib/ui/components/PageGuideOverlay.svelte';
 import TutorialOverlay from '$lib/ui/components/TutorialOverlay.svelte';
-import { filterGuideStepsByTier, getPageGuide } from '$lib/ui/tutorial/page-guide-registry';
+import {
+	filterGuideStepsByRuntime,
+	filterGuideStepsByTier,
+	getPageGuide,
+} from '$lib/ui/tutorial/page-guide-registry';
 import { startPageGuide } from '$lib/ui/tutorial/page-guide-store.svelte';
 // #2375: v1 PageHelpButton + handleStartTutorial fallback 撤去 (P4)。
 // AC-V2-5 のため v2 PageGuide 起動時に v1 tutorial を強制終了する目的で endTutorial のみ import。
@@ -41,6 +45,9 @@ interface Props {
 	authMode?: string;
 	/** #3033: trial active 中のみ残日数 (null = trial 非 active で pill 非表示) */
 	trialDaysRemaining?: number | null;
+	/** #3291: ADR-0040 実行モード (`locals.runtimeMode` 由来)。NUC セルフホスト版で
+	 *   SaaS 専用ガイド手順 (requiredRuntime='saas') を除外するために使う。 */
+	runtimeMode?: string;
 }
 
 let {
@@ -51,6 +58,7 @@ let {
 	planTier = 'free',
 	authMode,
 	trialDaysRemaining = null,
+	runtimeMode,
 }: Props = $props();
 
 const isDemo = $derived(mode === 'demo');
@@ -73,7 +81,11 @@ $effect(() => {
 		// (空ガイドを開くと dead-end になるため)。現状 challenges は free でも非 gate 手順が
 		// 1 つ残るため button は維持されるが、将来 family 限定手順のみのページが追加されても
 		// 自動で button が抑止される。
-		hasPageGuide = guide !== null && filterGuideStepsByTier(guide, planTier) !== null;
+		// #3291: tier フィルタ後に runtime フィルタも適用し、NUC で SaaS 専用手順のみのページ
+		// (残 0) では ❓ を抑止する。両フィルタは filter → 残 0 なら null で同型・直列適用可。
+		const tierFiltered = guide === null ? null : filterGuideStepsByTier(guide, planTier);
+		hasPageGuide =
+			tierFiltered !== null && filterGuideStepsByRuntime(tierFiltered, runtimeMode) !== null;
 	});
 });
 
@@ -85,7 +97,10 @@ async function handleStartPageGuide() {
 	if (!guide) return;
 	// #2919: 現在のプランで表示できない手順 (requiredTier 未達、例: challenges-intro の family)
 	// を除外してから起動する。free ユーザーに「上位プラン限定」の手順を見せない (NN/G #1 / #5)。
-	const filtered = filterGuideStepsByTier(guide, planTier);
+	// #3291: NUC では SaaS 専用手順 (requiredRuntime='saas') も除外してから起動する。
+	const tierFiltered = filterGuideStepsByTier(guide, planTier);
+	const filtered =
+		tierFiltered === null ? null : filterGuideStepsByRuntime(tierFiltered, runtimeMode);
 	if (filtered) {
 		startPageGuide(filtered);
 	}

--- a/src/lib/features/admin/components/SaasLicensePanel.svelte
+++ b/src/lib/features/admin/components/SaasLicensePanel.svelte
@@ -341,7 +341,7 @@ async function openPortal() {
 	<!-- 現在のプラン -->
 	<Card variant="default" padding="lg">
 		{#snippet children()}
-		<h3 class="text-lg font-semibold text-[var(--color-text-secondary)] mb-4">{SUBSCRIPTION_PAGE_LABELS.currentPlanTitle}</h3>
+		<h3 class="text-lg font-semibold text-[var(--color-text-secondary)] mb-4" data-tutorial="subscription-current-plan">{SUBSCRIPTION_PAGE_LABELS.currentPlanTitle}</h3>
 
 		<div class="grid gap-4">
 			<div class="flex items-center justify-between py-2 border-b border-[var(--color-surface-muted)]">
@@ -516,7 +516,7 @@ async function openPortal() {
 	{#if stripeEnabled}
 	<Card variant="default" padding="lg">
 		{#snippet children()}
-		<h3 class="text-lg font-semibold text-[var(--color-text-secondary)] mb-4">{SUBSCRIPTION_PAGE_LABELS.planManagementTitle}</h3>
+		<h3 class="text-lg font-semibold text-[var(--color-text-secondary)] mb-4" data-tutorial="subscription-plan-management">{SUBSCRIPTION_PAGE_LABELS.planManagementTitle}</h3>
 
 		{#if hasSubscription}
 			<!-- サブスクリプション有り → Stripe Customer Portal で管理 (#771: PIN 再確認ゲート付き) -->

--- a/src/lib/ui/tutorial/page-guide-registry.ts
+++ b/src/lib/ui/tutorial/page-guide-registry.ts
@@ -26,6 +26,9 @@ const GUIDE_LOADERS: Record<
 	// #2270 / #2274 (EPIC #2266): /admin/messages 廃止 → /admin/cheer (応援) に統合
 	'/admin/cheer': () => import('../../../routes/(parent)/admin/cheer/_guide'),
 	'/admin/settings': () => import('../../../routes/(parent)/admin/settings/_guide'),
+	// #3267 (EPIC #3260 C3): プラン・課金 + お支払い
+	'/admin/subscription': () => import('../../../routes/(parent)/admin/subscription/_guide'),
+	'/admin/billing': () => import('../../../routes/(parent)/admin/billing/_guide'),
 };
 
 /** registry に dedicated guide が登録済のパス一覧（#3262 F1: 網羅 gate test 用）。 */
@@ -46,6 +49,9 @@ const GUIDE_EXPORT_NAMES: Record<string, string> = {
 	// #2270 / #2274 (EPIC #2266): /admin/messages 廃止 → /admin/cheer に統合
 	'/admin/cheer': 'CHEER_GUIDE',
 	'/admin/settings': 'SETTINGS_GUIDE',
+	// #3267 (EPIC #3260 C3)
+	'/admin/subscription': 'SUBSCRIPTION_GUIDE',
+	'/admin/billing': 'BILLING_GUIDE',
 };
 
 /**
@@ -123,4 +129,7 @@ export const ALL_PAGE_IDS = [
 	// #2270 / #2274 (EPIC #2266): admin-messages 廃止 → admin-cheer (応援) に統合
 	'admin-cheer',
 	'admin-settings',
+	// #3267 (EPIC #3260 C3)
+	'admin-subscription',
+	'admin-billing',
 ];

--- a/src/lib/ui/tutorial/page-guide-registry.ts
+++ b/src/lib/ui/tutorial/page-guide-registry.ts
@@ -114,6 +114,32 @@ export function filterGuideStepsByTier(guide: PageGuide, planTier: PlanTier): Pa
 	return { ...guide, steps };
 }
 
+/**
+ * ページガイドの手順を実行モードでフィルタする（#3291）。
+ *
+ * `requiredRuntime: 'saas'` を持つ手順は NUC セルフホスト版（`nuc-prod`）では除外する。
+ * 例: /admin/subscription は `nuc-prod` で `NucLicensePanel`（現在のプラン / プラン管理
+ * セクション無し）を描画するため、SaaS 専用手順（`subscription-current-plan` /
+ * `subscription-plan-management`）の selector が解決できず空 spotlight になる + NUC に
+ * 無い操作（プラン選択 / Stripe Portal）を案内してしまう（ADR-0013 truth 違反）。
+ * SaaS（`aws-prod` / `local-debug` / `demo` / `build`）では全手順を表示する。
+ *
+ * {@link filterGuideStepsByTier} と同型（filter → 残 0 なら null）。両者を直列適用できる。
+ *
+ * @param guide フィルタ対象のページガイド
+ * @param runtimeMode 現在の実行モード（ADR-0040、`locals.runtimeMode` 由来）
+ * @returns 当該モードで表示すべき手順だけのガイド。残手順が 0 なら null
+ */
+export function filterGuideStepsByRuntime(
+	guide: PageGuide,
+	runtimeMode: string | undefined,
+): PageGuide | null {
+	const isNuc = runtimeMode === 'nuc-prod';
+	const steps = guide.steps.filter((step) => !(isNuc && step.requiredRuntime === 'saas'));
+	if (steps.length === 0) return null;
+	return { ...guide, steps };
+}
+
 /** 全ガイドのページID一覧（完了状態表示用） */
 export const ALL_PAGE_IDS = [
 	'admin-home',

--- a/src/lib/ui/tutorial/page-guide-types.ts
+++ b/src/lib/ui/tutorial/page-guide-types.ts
@@ -40,6 +40,14 @@ export interface GuideStep {
 	relatedLinks?: readonly { label: string; href: string }[];
 	/** この手順を表示する最低プランティア */
 	requiredTier?: PlanTier;
+	/**
+	 * この手順を表示する実行モード制約（#3291）。
+	 * 'saas' を指定した手順は SaaS（aws-prod / local-debug / demo）でのみ表示し、
+	 * NUC セルフホスト版（nuc-prod）では除外する。NUC では当該 UI セクション
+	 * （現在のプラン / プラン管理 等）が存在せず、selector が解決できず空 spotlight に
+	 * なる + 実装にない操作を案内してしまう（ADR-0013）ため。未指定は全モードで表示。
+	 */
+	requiredRuntime?: 'saas';
 	/** バブルの表示位置 */
 	position?: 'top' | 'bottom' | 'left' | 'right' | 'auto';
 }

--- a/src/routes/(parent)/admin/+layout.svelte
+++ b/src/routes/(parent)/admin/+layout.svelte
@@ -29,6 +29,9 @@ interface Props {
 		setupOnboarding?: OnboardingProgress | null;
 		// parent-gate inactivity redirect 起動フラグ (PIN gate 有効時のみ true)
 		pinGateActive?: boolean;
+		// #3291: ADR-0040 実行モード (`+layout.server.ts` が locals.runtimeMode を配布)。
+		// AdminLayout へ橋渡しし、NUC で SaaS 専用ガイド手順を除外するために使う。
+		runtimeMode?: string;
 	};
 	children: Snippet;
 }
@@ -75,7 +78,7 @@ $effect(() => {
 // 設定 > サポート (/admin/settings/support) の単独 SSOT (PO 判断: 各ページには不要)。
 </script>
 
-<AdminLayout mode="live" basePath="/admin" isPremium={data.isPremium ?? false} planTier={data.planTier ?? 'free'} authMode={data.authMode} {trialDaysRemaining}>
+<AdminLayout mode="live" basePath="/admin" isPremium={data.isPremium ?? false} planTier={data.planTier ?? 'free'} authMode={data.authMode} {trialDaysRemaining} runtimeMode={data.runtimeMode}>
 	<!-- #2821: setup 由来で admin に着地したときの文脈バナー (続きの step へ戻る導線) -->
 	{#if data.setupOnboarding}
 		<div style:margin-bottom="16px">

--- a/src/routes/(parent)/admin/billing/+page.svelte
+++ b/src/routes/(parent)/admin/billing/+page.svelte
@@ -121,7 +121,7 @@ const statusLabel = $derived.by(() => {
 	<!-- サブスクリプション概要 -->
 	<Card variant="default" padding="lg">
 		{#snippet children()}
-		<h2 class="text-base font-semibold text-[var(--color-text-secondary)] mb-4">{BILLING_LABELS.subscriptionOverviewTitle}</h2>
+		<h2 class="text-base font-semibold text-[var(--color-text-secondary)] mb-4" data-tutorial="billing-overview">{BILLING_LABELS.subscriptionOverviewTitle}</h2>
 
 		<div class="billing-info-grid">
 			<div class="billing-info-item">
@@ -156,7 +156,7 @@ const statusLabel = $derived.by(() => {
 	<!-- Stripe Customer Portal セクション -->
 	<Card variant="default" padding="lg">
 		{#snippet children()}
-		<h2 class="text-base font-semibold text-[var(--color-text-secondary)] mb-2">{BILLING_LABELS.billingPortalTitle}</h2>
+		<h2 class="text-base font-semibold text-[var(--color-text-secondary)] mb-2" data-tutorial="billing-portal">{BILLING_LABELS.billingPortalTitle}</h2>
 		<p class="text-sm text-[var(--color-text-muted)] mb-4">
 			{BILLING_LABELS.billingPortalDesc}
 		</p>

--- a/src/routes/(parent)/admin/billing/_guide.ts
+++ b/src/routes/(parent)/admin/billing/_guide.ts
@@ -1,40 +1,35 @@
+import { PAGE_GUIDE_LABELS } from '$lib/domain/labels';
+import type { PageGuide } from '$lib/ui/tutorial/page-guide-types';
+
 // #3267 (EPIC #3260 C3): お支払い（billing）ページガイド。
 // narrative 3 部構成（①概要 → ②画面の見方 → ③最頻操作、#2927 / ADR-0012）。
-// 文言は SSOT（terms.ts）を参照し guide-copy-rules.md に準拠（check-guide-copy.ts 検査）。
-import { CANCEL_TERMS, STRIPE_PORTAL_TERMS } from '$lib/domain/terms';
-import type { PageGuide } from '$lib/ui/tutorial/page-guide-types';
+// #3264 (EPIC #3260 F3): 表示文言は labels.ts の PAGE_GUIDE_LABELS に SSOT 集約。
+// billing は runtimeMode 分岐の無い単一ページで、billing-overview / billing-portal の
+// アンカーは全環境で常に描画されるため requiredRuntime 制約は不要（#3291 検証済）。
+const L = PAGE_GUIDE_LABELS.adminBilling;
 
 export const BILLING_GUIDE: PageGuide = {
 	pageId: 'admin-billing',
-	title: 'お支払い',
+	title: L.title,
 	icon: '🧾',
 	steps: [
 		// ① ページ概要（selector 省略で画面中央 modal）
 		{
 			id: 'billing-intro',
-			title: 'このページについて',
-			what: `ご契約の状況確認と、${STRIPE_PORTAL_TERMS.short}・${CANCEL_TERMS.canonical}をまとめたページです。`,
-			how: '上から「ご契約状況」「請求管理」の順に並びます。',
-			goal: `支払い状況を把握し、必要なら${STRIPE_PORTAL_TERMS.short}や${CANCEL_TERMS.canonicalVerb}手続きに進めます。`,
+			...L.steps['billing-intro'],
 		},
 		// ② 画面の見方（ご契約状況）
 		{
 			id: 'billing-overview',
 			selector: '[data-tutorial="billing-overview"]',
-			title: '画面の見方（ご契約状況）',
-			what: '契約中のプランと、次回の請求予定がここに表示されます。',
-			how: '1. 契約状況を確認します\n2. 下の「請求管理」で支払い方法を変えられます',
-			goal: '今の契約と請求予定をひと目で確認できます。',
+			...L.steps['billing-overview'],
 			position: 'bottom',
 		},
 		// ③ 最頻操作（請求管理ページ）
 		{
 			id: 'billing-portal',
 			selector: '[data-tutorial="billing-portal"]',
-			title: `よく使う操作（${STRIPE_PORTAL_TERMS.short}）`,
-			what: `支払い方法の変更や領収書の確認は${STRIPE_PORTAL_TERMS.canonical}から行います。`,
-			how: `1. ${STRIPE_PORTAL_TERMS.short}を開きます\n2. 支払い方法や${CANCEL_TERMS.canonical}を手続きします`,
-			goal: `支払い方法を最新に保て、${CANCEL_TERMS.anytime}できます。`,
+			...L.steps['billing-portal'],
 			position: 'bottom',
 		},
 	],

--- a/src/routes/(parent)/admin/billing/_guide.ts
+++ b/src/routes/(parent)/admin/billing/_guide.ts
@@ -1,0 +1,41 @@
+// #3267 (EPIC #3260 C3): お支払い（billing）ページガイド。
+// narrative 3 部構成（①概要 → ②画面の見方 → ③最頻操作、#2927 / ADR-0012）。
+// 文言は SSOT（terms.ts）を参照し guide-copy-rules.md に準拠（check-guide-copy.ts 検査）。
+import { CANCEL_TERMS, STRIPE_PORTAL_TERMS } from '$lib/domain/terms';
+import type { PageGuide } from '$lib/ui/tutorial/page-guide-types';
+
+export const BILLING_GUIDE: PageGuide = {
+	pageId: 'admin-billing',
+	title: 'お支払い',
+	icon: '🧾',
+	steps: [
+		// ① ページ概要（selector 省略で画面中央 modal）
+		{
+			id: 'billing-intro',
+			title: 'このページについて',
+			what: `ご契約の状況確認と、${STRIPE_PORTAL_TERMS.short}・${CANCEL_TERMS.canonical}をまとめたページです。`,
+			how: '上から「ご契約状況」「請求管理」の順に並びます。',
+			goal: `支払い状況を把握し、必要なら${STRIPE_PORTAL_TERMS.short}や${CANCEL_TERMS.canonicalVerb}手続きに進めます。`,
+		},
+		// ② 画面の見方（ご契約状況）
+		{
+			id: 'billing-overview',
+			selector: '[data-tutorial="billing-overview"]',
+			title: '画面の見方（ご契約状況）',
+			what: '契約中のプランと、次回の請求予定がここに表示されます。',
+			how: '1. 契約状況を確認します\n2. 下の「請求管理」で支払い方法を変えられます',
+			goal: '今の契約と請求予定をひと目で確認できます。',
+			position: 'bottom',
+		},
+		// ③ 最頻操作（請求管理ページ）
+		{
+			id: 'billing-portal',
+			selector: '[data-tutorial="billing-portal"]',
+			title: `よく使う操作（${STRIPE_PORTAL_TERMS.short}）`,
+			what: `支払い方法の変更や領収書の確認は${STRIPE_PORTAL_TERMS.canonical}から行います。`,
+			how: `1. ${STRIPE_PORTAL_TERMS.short}を開きます\n2. 支払い方法や${CANCEL_TERMS.canonical}を手続きします`,
+			goal: `支払い方法を最新に保て、${CANCEL_TERMS.anytime}できます。`,
+			position: 'bottom',
+		},
+	],
+};

--- a/src/routes/(parent)/admin/subscription/_guide.ts
+++ b/src/routes/(parent)/admin/subscription/_guide.ts
@@ -1,46 +1,39 @@
+import { PAGE_GUIDE_LABELS } from '$lib/domain/labels';
+import type { PageGuide } from '$lib/ui/tutorial/page-guide-types';
+
 // #3267 (EPIC #3260 C3): プラン・課金（subscription）ページガイド。
 // narrative 3 部構成（①概要 → ②画面の見方 → ③最頻操作、#2927 / ADR-0012）。
-// 文言は SSOT（terms.ts）を参照し guide-copy-rules.md に準拠（check-guide-copy.ts 検査）。
-import {
-	CANCEL_TERMS,
-	PLAN_CHANGE_TERMS,
-	STRIPE_PORTAL_TERMS,
-	UPGRADE_TERMS,
-} from '$lib/domain/terms';
-import type { PageGuide } from '$lib/ui/tutorial/page-guide-types';
+// #3264 (EPIC #3260 F3): 表示文言は labels.ts の PAGE_GUIDE_LABELS に SSOT 集約。
+// #3291: step ②③ は SaaS 版 (SaasLicensePanel) 専用 UI を指すため requiredRuntime='saas'。
+//        NUC 版 (NucLicensePanel) には現在のプラン / プラン管理セクションが無く、selector
+//        未解決 → 空 spotlight + 実装にない操作案内になるため、nuc-prod では本 2 step を除外
+//        する（filterGuideStepsByRuntime、ADR-0013 truth）。intro は両環境で正しい内容に留める。
+const L = PAGE_GUIDE_LABELS.adminSubscription;
 
 export const SUBSCRIPTION_GUIDE: PageGuide = {
 	pageId: 'admin-subscription',
-	title: 'プラン・課金',
+	title: L.title,
 	icon: '💳',
 	steps: [
-		// ① ページ概要（selector 省略で画面中央 modal）
+		// ① ページ概要（selector 省略で画面中央 modal、全環境で表示）
 		{
 			id: 'subscription-intro',
-			title: 'このページについて',
-			what: `現在のプランの確認と、${UPGRADE_TERMS.canonical}・${STRIPE_PORTAL_TERMS.short}をまとめたページです。`,
-			how: '上から「現在のプラン」「プラン管理」「支払い履歴」の順に並びます。',
-			goal: `プランの状況をひと目で把握し、${PLAN_CHANGE_TERMS.changeNoun}や支払いの管理を迷わず行えます。`,
+			...L.steps['subscription-intro'],
 		},
-		// ② 画面の見方（現在のプラン）
+		// ② 画面の見方（現在のプラン）— SaaS 版のみ
 		{
 			id: 'subscription-current-plan',
 			selector: '[data-tutorial="subscription-current-plan"]',
-			title: '画面の見方（現在のプラン）',
-			what: 'いま契約中のプランと、無料トライアル中ならその残り期間がここに表示されます。',
-			how: '1. 上部で現在のプランを確認します\n2. 下の「プラン管理」で変更できます',
-			goal: '今どのプランかをすぐ確認でき、変更前の状態を把握できます。',
+			...L.steps['subscription-current-plan'],
+			requiredRuntime: 'saas',
 			position: 'bottom',
 		},
-		// ③ 最頻操作（プラン管理）
+		// ③ 最頻操作（プラン管理）— SaaS 版のみ
 		{
 			id: 'subscription-plan-management',
 			selector: '[data-tutorial="subscription-plan-management"]',
-			title: `よく使う操作（${PLAN_CHANGE_TERMS.changeNoun}）`,
-			what: `プランの選択・変更と、${STRIPE_PORTAL_TERMS.canonical}への移動をここから行います。`,
-			how: `1. 変更したいプランを選びます\n2. 確認のうえ${STRIPE_PORTAL_TERMS.short}で手続きします`,
-			goal: `${PLAN_CHANGE_TERMS.changeNoun}が反映され、支払い方法も${STRIPE_PORTAL_TERMS.short}で管理できます。`,
-			tips: [`${CANCEL_TERMS.anytime}できます`],
+			...L.steps['subscription-plan-management'],
+			requiredRuntime: 'saas',
 			position: 'bottom',
 		},
 	],

--- a/src/routes/(parent)/admin/subscription/_guide.ts
+++ b/src/routes/(parent)/admin/subscription/_guide.ts
@@ -1,0 +1,47 @@
+// #3267 (EPIC #3260 C3): プラン・課金（subscription）ページガイド。
+// narrative 3 部構成（①概要 → ②画面の見方 → ③最頻操作、#2927 / ADR-0012）。
+// 文言は SSOT（terms.ts）を参照し guide-copy-rules.md に準拠（check-guide-copy.ts 検査）。
+import {
+	CANCEL_TERMS,
+	PLAN_CHANGE_TERMS,
+	STRIPE_PORTAL_TERMS,
+	UPGRADE_TERMS,
+} from '$lib/domain/terms';
+import type { PageGuide } from '$lib/ui/tutorial/page-guide-types';
+
+export const SUBSCRIPTION_GUIDE: PageGuide = {
+	pageId: 'admin-subscription',
+	title: 'プラン・課金',
+	icon: '💳',
+	steps: [
+		// ① ページ概要（selector 省略で画面中央 modal）
+		{
+			id: 'subscription-intro',
+			title: 'このページについて',
+			what: `現在のプランの確認と、${UPGRADE_TERMS.canonical}・${STRIPE_PORTAL_TERMS.short}をまとめたページです。`,
+			how: '上から「現在のプラン」「プラン管理」「支払い履歴」の順に並びます。',
+			goal: `プランの状況をひと目で把握し、${PLAN_CHANGE_TERMS.changeNoun}や支払いの管理を迷わず行えます。`,
+		},
+		// ② 画面の見方（現在のプラン）
+		{
+			id: 'subscription-current-plan',
+			selector: '[data-tutorial="subscription-current-plan"]',
+			title: '画面の見方（現在のプラン）',
+			what: 'いま契約中のプランと、無料トライアル中ならその残り期間がここに表示されます。',
+			how: '1. 上部で現在のプランを確認します\n2. 下の「プラン管理」で変更できます',
+			goal: '今どのプランかをすぐ確認でき、変更前の状態を把握できます。',
+			position: 'bottom',
+		},
+		// ③ 最頻操作（プラン管理）
+		{
+			id: 'subscription-plan-management',
+			selector: '[data-tutorial="subscription-plan-management"]',
+			title: `よく使う操作（${PLAN_CHANGE_TERMS.changeNoun}）`,
+			what: `プランの選択・変更と、${STRIPE_PORTAL_TERMS.canonical}への移動をここから行います。`,
+			how: `1. 変更したいプランを選びます\n2. 確認のうえ${STRIPE_PORTAL_TERMS.short}で手続きします`,
+			goal: `${PLAN_CHANGE_TERMS.changeNoun}が反映され、支払い方法も${STRIPE_PORTAL_TERMS.short}で管理できます。`,
+			tips: [`${CANCEL_TERMS.anytime}できます`],
+			position: 'bottom',
+		},
+	],
+};

--- a/tests/e2e/admin-page-guide-presence.spec.ts
+++ b/tests/e2e/admin-page-guide-presence.spec.ts
@@ -38,6 +38,9 @@ const ADMIN_GUIDE_PAGES = [
 	'/admin/points',
 	'/admin/reports',
 	'/admin/cheer',
+	// #3267 (EPIC #3260 C3): プラン・課金 + お支払い
+	'/admin/subscription',
+	'/admin/billing',
 ] as const;
 
 const GUIDE_BTN = '[data-tutorial="page-guide-btn"]';

--- a/tests/e2e/page-guide-layout-invariant.spec.ts
+++ b/tests/e2e/page-guide-layout-invariant.spec.ts
@@ -30,6 +30,9 @@ const ADMIN_GUIDE_PAGES = [
 	'/admin/points',
 	'/admin/reports',
 	'/admin/cheer',
+	// #3267 (EPIC #3260 C3): プラン・課金 + お支払い
+	'/admin/subscription',
+	'/admin/billing',
 ] as const;
 
 const VIEWPORTS = [

--- a/tests/unit/architecture/page-guide-coverage.test.ts
+++ b/tests/unit/architecture/page-guide-coverage.test.ts
@@ -30,9 +30,7 @@ const PENDING_GUIDE_PATHS = [
 	'/admin/settings/notifications',
 	'/admin/settings/rules',
 	'/admin/settings/support',
-	// C3: プラン・課金 + billing
-	'/admin/subscription',
-	'/admin/billing',
+	// C3: プラン・課金 + billing → #3267 で REGISTERED へ移行済
 	// C4: members + packs
 	'/admin/members',
 	'/admin/packs',

--- a/tests/unit/tutorial/page-guide-runtime-filter.test.ts
+++ b/tests/unit/tutorial/page-guide-runtime-filter.test.ts
@@ -1,0 +1,72 @@
+// tests/unit/tutorial/page-guide-runtime-filter.test.ts
+// #3291: filterGuideStepsByRuntime の回帰ガード。
+//
+// /admin/subscription は nuc-prod で NucLicensePanel (現在のプラン / プラン管理セクション無し)
+// を描画するため、SaaS 専用ガイド手順 (requiredRuntime='saas') の selector が解決できず空
+// spotlight + 実装にない操作案内 (ADR-0013 違反) になる。本テストは NUC で SaaS 専用手順が
+// 除外され、SaaS では全手順が残ることを機械検証する (人の注意依存にしない、ADR-0061)。
+
+import { describe, expect, it } from 'vitest';
+import { filterGuideStepsByRuntime } from '../../../src/lib/ui/tutorial/page-guide-registry';
+import type { PageGuide } from '../../../src/lib/ui/tutorial/page-guide-types';
+import { SUBSCRIPTION_GUIDE } from '../../../src/routes/(parent)/admin/subscription/_guide';
+
+const fixture: PageGuide = {
+	pageId: 'test-page',
+	title: 'テスト',
+	icon: '🧪',
+	steps: [
+		{ id: 'intro', title: '概要', what: 'a', how: 'b', goal: 'c' },
+		{ id: 'saas-only', title: 'SaaS', what: 'a', how: 'b', goal: 'c', requiredRuntime: 'saas' },
+	],
+};
+
+describe('#3291 filterGuideStepsByRuntime', () => {
+	it('nuc-prod では requiredRuntime=saas の手順を除外する', () => {
+		const filtered = filterGuideStepsByRuntime(fixture, 'nuc-prod');
+		expect(filtered).not.toBeNull();
+		expect(filtered?.steps.map((s) => s.id)).toEqual(['intro']);
+	});
+
+	it('SaaS 系モード (aws-prod / local-debug / demo / undefined) では全手順を残す', () => {
+		for (const mode of ['aws-prod', 'local-debug', 'demo', 'build', undefined]) {
+			const filtered = filterGuideStepsByRuntime(fixture, mode);
+			expect(
+				filtered?.steps.map((s) => s.id),
+				`mode=${mode}`,
+			).toEqual(['intro', 'saas-only']);
+		}
+	});
+
+	it('nuc-prod で SaaS 専用手順のみのガイドは null を返す (❓ 抑止)', () => {
+		const saasOnly: PageGuide = {
+			...fixture,
+			steps: [fixture.steps[1] as PageGuide['steps'][number]],
+		};
+		expect(filterGuideStepsByRuntime(saasOnly, 'nuc-prod')).toBeNull();
+	});
+
+	it('SUBSCRIPTION_GUIDE: nuc-prod では intro のみ残り、SaaS では全 3 手順', () => {
+		// NUC では NucLicensePanel に存在しない現在のプラン / プラン管理 step を除外し、
+		// 画面中央 intro (selector 無し) だけが残る = 空 spotlight を作らない。
+		const nuc = filterGuideStepsByRuntime(SUBSCRIPTION_GUIDE, 'nuc-prod');
+		expect(nuc?.steps.map((s) => s.id)).toEqual(['subscription-intro']);
+
+		const saas = filterGuideStepsByRuntime(SUBSCRIPTION_GUIDE, 'aws-prod');
+		expect(saas?.steps.map((s) => s.id)).toEqual([
+			'subscription-intro',
+			'subscription-current-plan',
+			'subscription-plan-management',
+		]);
+
+		// SaaS 専用 step には selector が必ず付く (NUC で除外される対象 = NucLicensePanel に無い UI)
+		for (const step of SUBSCRIPTION_GUIDE.steps) {
+			if (step.requiredRuntime === 'saas') {
+				expect(
+					step.selector,
+					`${step.id} は SaaS UI を spotlight するため selector 必須`,
+				).toBeTruthy();
+			}
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: EPIC #3260 C3（★最優先）。プラン・課金（`/admin/subscription`）とお支払い（`/admin/billing`）は**課金という重要操作なのにページガイドが無い**（PO 懸念）。操作不明は信頼・継続に直結する。

**期待される効果**: 両ページで `?` ガイドが起動し、「現在のプラン確認 → プラン変更 → 請求管理ページ」「ご契約状況 → 請求管理 → 解約」の最頻操作をページ固有に案内する。

## 関連 Issue

closes #3267

EPIC #3260 / F0(#3261 文言 linter)/ F1(#3262 網羅 gate)/ ADR-0058(プラン命名)/ ADR-0045(terms SSOT)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | subscription + billing の `_guide.ts` 追加 + registry 登録 | `grep -n SUBSCRIPTION_GUIDE\|BILLING_GUIDE src/lib/ui/tutorial/page-guide-registry.ts` | HEAD `ffd056f6` / 両 `_guide.ts` 新設 + GUIDE_LOADERS/EXPORT_NAMES/ALL_PAGE_IDS 登録。coverage gate の backlog から REGISTERED へ移行（#3262 F1 ratchet 締め） |
| AC2 | 課金操作の最頻操作を内部事情・プラン文字列非露出で案内 | `npx tsx scripts/check-guide-copy.ts --fail-on-violation` | HEAD `ffd056f6` / F0 linter PASS。文言は `STRIPE_PORTAL_TERMS`/`UPGRADE_TERMS`/`PLAN_CHANGE_TERMS`/`CANCEL_TERMS` を `${...}` 参照（プラン文字列直書きなし） |
| AC3 | `?` ガイドが起動しページ固有内容が表示される | `npx playwright test admin-page-guide-presence.spec.ts -g "subscription\|billing" --project=tablet` | HEAD `ffd056f6` / 2 passed（? visible→click→overlay 開く→Escape 閉じる） |
| AC4 | 吹き出しが対象に被らない / viewport 収容 / spotlight 表示 | `npx playwright test page-guide-layout-invariant.spec.ts -g "subscription\|billing"` | HEAD `ffd056f6` / 4 passed（desktop+mobile × 2 ページ、全 step 非重複・収容・spotlight） |
| AC5 | narrative 3 部・≤5 step・上から順 | F0 linter（step 数）+ 目視（selector 上→下: current-plan→plan-management / overview→portal） | HEAD `ffd056f6` / 各 3 step、selector はページ上→下順 |

## 変更タイプ

- [ ] fix: バグ修正
- [x] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/` — subscription/billing _guide + billing page anchor)
- [x] UI コンポーネント (`$lib/ui/` — registry / SaasLicensePanel anchor)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI

**影響を受ける画面・機能**: `/admin/subscription`・`/admin/billing` の `?` ガイド（新設）+ `data-tutorial` アンカー（不可視属性、通常表示は不変）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: presence/layout-invariant E2E に 2 ページ追加（既存 spec の hardcoded list を registry と 1:1 同期）。coverage gate unit が REGISTERED 移行を検証
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

`/admin/subscription` で `?` ガイドを開いた状態（dedicated guide の overlay）。通常表示（ガイド非表示時）は `data-tutorial` 不可視属性のみで不変。

| | ガイド overlay |
|---|---|
| `/admin/subscription`（demo） | ![subscription-guide](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3291/subscription-guide.png) |

**インタラクティブ状態**: `?` click → narrative 3 step（①概要 中央 modal → ②現在のプラン → ③プラン管理）。Escape で閉じる。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: ガイドは `_guide.ts` データ定義、描画は共用 `PageGuideOverlay`（機構非変更）
- [x] **DRY**: 文言は terms.ts SSOT を参照（プラン/請求/解約用語の重複定義なし）
- [x] **YAGNI**: cancel/graduation/thanks 等の transient フローは個別ガイド作らず親 billing にフォールバック（F1 EXEMPT）
- [x] **Security（OSS 公開前提）**: 内部 route/識別子を文言に出さない（F0 linter で担保）
- [x] **アクセシビリティ**: 課金ページの操作ガイド（NN/G #1 visibility / #10 help）、吹き出し非重複（layout-invariant）
- [x] **パフォーマンス**: 動的 import、registry 既存機構

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [x] E2E / ユニットシード + チュートリアルを同期（presence/layout-invariant に 2 ページ追加、coverage gate 更新）
- [x] labels SSOT (ADR-0009)（terms.ts 参照、新規用語なし）
- [x] 設計書同期 (ADR-0001)（06-UI §4.13.1 登録済みページに追加）
- [x] 並行 PR overlap 確認 (#1200)（EPIC #3260。F0(#3274)/F1(#3275) の上に積層、registry/gate は F1 と整合）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**: ガイド文言は SSOT 用語を `${...}` 参照し F0 linter PASS。selector はページ上→下順（current-plan→plan-management / billing-overview→billing-portal）。cancel フロー等の transient ページは F1 EXEMPT（親 billing にフォールバック）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: ガイド overlay の SS を添付（通常表示は不可視属性のみで不変）
- [x] F0 linter / coverage gate / svelte-check 0 error / presence 2 + layout-invariant 4 E2E PASS

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

