### PR TITLE
refactor: #3299 self-ref-change lint の言い換え拡充 + unit test (ADR-0061)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -74,6 +74,7 @@ autodocs
 AUTOINCREMENT
 autoreply
 backfill
+banlist
 bedrock
 Bedrock
 benkyou

--- a/scripts/check-internal-terms.mjs
+++ b/scripts/check-internal-terms.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// @ts-nocheck — CLI lint script。#3299 で unit test が import するため TS graph に入るが、
+// 本 file は untyped JS の CLI ツール (check-doc-code-references.mjs と同方針で型検査を無効化)。
 /**
  * scripts/check-internal-terms.mjs (#2288 EPIC #2283 ⑤)
  *
@@ -32,7 +34,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -96,11 +98,18 @@ const CONN_INFO_BANLIST = [
 // 対象: labels.ts (compound UI 文字列の本体) + 全 routes + features の .ts / .svelte。
 // comment 行は除外 (isCommentLine) — issue note 等「#NNNN で統合済」コメントは正当な開発記録。
 // baseline なし — 残存 0 で導入し、新規 1 件で即 fail (conn-info group と同型)。
-// 検出語は「動作の完了報告 (〜しました / 〜されています)」に限定し、子供向けの内容語
-// (「がんばりをまとめました」等のデータ要約) を誤検出しない短語 (整理/統合 単独) は採らない。
+//
+// ⚠️ 位置づけ (#3299): 本 group は「特定の自己言及句の再混入を防ぐ regression guard」(ADR-0061)
+// であって、内部事情文言の網羅検出ではない。言い換え (「カード別に分類」等) は無限に作れるため
+// 機械的な完全網羅は非現実的。検出語は「構造再編の完了報告 (〜しました / 〜されています)」に
+// 限定し、子供向け内容語 (「がんばりをまとめました」等のデータ要約) や正当な成功 toast
+// (「ポイントを変更しました」等) を誤検出しないよう、短語単独 (整理 / 統合) や汎用動詞
+// (改善しました / 変更しました) は採らない。新パターンは「人手レビューで発見 → banlist 追記」
+// の運用 (PR レビュー併用前提)。
 // ---------------------------------------------------------------------------
 
-const SELF_REF_CHANGE_BANLIST = [
+export const SELF_REF_CHANGE_BANLIST = [
+	// 構造再編の完了報告 (初版 9 語、#3259)
 	'整理しました',
 	'整理されています',
 	'統合しました',
@@ -110,6 +119,16 @@ const SELF_REF_CHANGE_BANLIST = [
 	'リニューアルしました',
 	'新しくなりました',
 	'生まれ変わりました',
+	// 言い換えすり抜け対策の追加語 (#3299、人手レビューで観測された再編系)
+	'見直しました',
+	'見直しています',
+	'再編しました',
+	'再構成しました',
+	'集約しました',
+	'まとめ直しました',
+	'分類しました',
+	'分類されています',
+	'整頓しました',
 ];
 
 const SELF_REF_ROOTS = ['src/lib/domain/labels.ts', 'src/routes', 'src/lib/features'];
@@ -199,7 +218,7 @@ function walk(dir, out = [], extensions = EXTENSIONS, exclude = shouldExclude) {
 // コメント行判定 (check-no-plan-literals.mjs と同パターン)
 // ---------------------------------------------------------------------------
 
-function isCommentLine(line) {
+export function isCommentLine(line) {
 	const trimmed = line.trim();
 	if (trimmed.startsWith('//')) return true;
 	if (trimmed.startsWith('*')) return true;
@@ -293,6 +312,32 @@ function scanConnInfo() {
 // self-ref-change group 検査 (#3259) — UI 文字列の「実装変更の自己言及」
 // ---------------------------------------------------------------------------
 
+/**
+ * テキスト内の self-ref-change 違反を検出する pure function (#3299: unit test 可能化)。
+ * comment 行は除外し、非コメント行 (string リテラル等) の banlist 語のみ hit にする。
+ * @param {string} text  ファイル本文
+ * @returns {{ line: number, col: number, pattern: string, snippet: string }[]}
+ */
+export function findSelfRefChangeHits(text) {
+	const lines = text.split(/\r?\n/);
+	const hits = [];
+	for (let i = 0; i < lines.length; i++) {
+		if (isCommentLine(lines[i])) continue; // 開発記録コメントは正当 (string 値のみ検査)
+		for (const pattern of SELF_REF_CHANGE_BANLIST) {
+			const idx = lines[i].indexOf(pattern);
+			if (idx >= 0) {
+				hits.push({
+					line: i + 1,
+					col: idx + 1,
+					pattern,
+					snippet: lines[i].trim().slice(0, 200),
+				});
+			}
+		}
+	}
+	return hits;
+}
+
 function scanSelfRefChange() {
 	const files = [];
 	for (const root of SELF_REF_ROOTS) {
@@ -302,22 +347,8 @@ function scanSelfRefChange() {
 	for (const f of files) {
 		// テストは UI 文言ではないため対象外
 		if (/\.(test|spec)\.(ts|mjs)$/.test(f)) continue;
-		const lines = fs.readFileSync(f, 'utf8').split(/\r?\n/);
-		for (let i = 0; i < lines.length; i++) {
-			if (isCommentLine(lines[i])) continue; // 開発記録コメントは正当 (string 値のみ検査)
-			for (const pattern of SELF_REF_CHANGE_BANLIST) {
-				const idx = lines[i].indexOf(pattern);
-				if (idx >= 0) {
-					violations.push({
-						file: relPath(f),
-						line: i + 1,
-						col: idx + 1,
-						pattern,
-						category: 'self-ref-change',
-						snippet: lines[i].trim().slice(0, 200),
-					});
-				}
-			}
+		for (const hit of findSelfRefChangeHits(fs.readFileSync(f, 'utf8'))) {
+			violations.push({ file: relPath(f), category: 'self-ref-change', ...hit });
 		}
 	}
 	return { fileCount: files.length, violations };
@@ -491,5 +522,7 @@ function main() {
 	return 1;
 }
 
-const code = main();
-process.exit(code);
+// #3299: CLI 直接実行時のみ main() を走らせる (unit test での import 時は実行しない)。
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	process.exit(main());
+}

--- a/tests/unit/scripts/check-internal-terms-self-ref.test.ts
+++ b/tests/unit/scripts/check-internal-terms-self-ref.test.ts
@@ -1,0 +1,110 @@
+/**
+ * tests/unit/scripts/check-internal-terms-self-ref.test.ts (#3299)
+ *
+ * check-internal-terms.mjs の self-ref-change group (UI 文字列への実装変更の自己言及検出) の
+ * 検出/非検出境界を回帰固定する。#3259 で導入した lint には Fix 時の一時 probe しか無く、
+ * ADR-0061 (guard は test で守る) に沿い永続 unit test を追加する。
+ *
+ * 検証境界:
+ *   - string リテラル行の banlist 語は hit する
+ *   - comment 行 (// / * / 行内なし / <!-- -->) の同語は hit しない (開発記録コメントは正当)
+ *   - 初版 9 語 + #3299 追加の言い換え語の双方を検出する
+ *   - 子供向け内容語 / 正当な成功 toast (まとめました / 変更しました / 改善しました) は誤検出しない
+ *   - 完全網羅ではない (言い換えは無限) — regression guard としての境界を固定する
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	findSelfRefChangeHits,
+	isCommentLine,
+	SELF_REF_CHANGE_BANLIST,
+} from '../../../scripts/check-internal-terms.mjs';
+
+describe('check-internal-terms self-ref-change group (#3299)', () => {
+	describe('findSelfRefChangeHits — string リテラルを検出', () => {
+		it('初版 9 語の「整理しました」を string 行で検出する', () => {
+			const hits = findSelfRefChangeHits(`const x = '設定をグループ別に整理しました';`);
+			expect(hits).toHaveLength(1);
+			expect(hits[0]?.pattern).toBe('整理しました');
+			expect(hits[0]?.line).toBe(1);
+		});
+
+		it('#3299 追加の言い換え語 (見直しました / 分類しました / 再編しました) を検出する', () => {
+			for (const phrase of [
+				'使いやすく見直しました',
+				'カード別に分類しました',
+				'画面を再編しました',
+			]) {
+				const hits = findSelfRefChangeHits(`label: '${phrase}'`);
+				expect(hits.length, phrase).toBe(1);
+			}
+		});
+
+		it('複数行で正しい行番号を返す', () => {
+			const text = ['行1: ふつうの文言', `行2: '統合しました'`, '行3: ふつうの文言'].join('\n');
+			const hits = findSelfRefChangeHits(text);
+			expect(hits).toHaveLength(1);
+			expect(hits[0]?.line).toBe(2);
+			expect(hits[0]?.pattern).toBe('統合しました');
+		});
+	});
+
+	describe('findSelfRefChangeHits — comment 行は除外 (開発記録は正当)', () => {
+		it('// 行コメント中の banlist 語は hit しない', () => {
+			expect(findSelfRefChangeHits('// #3033 で開始導線を整理しました')).toHaveLength(0);
+		});
+
+		it('JSDoc (* 始まり) コメント中の語は hit しない', () => {
+			expect(findSelfRefChangeHits(' * 旧 LABELS は本 PR で統合しました')).toHaveLength(0);
+		});
+
+		it('HTML コメント (<!-- -->) 中の語は hit しない', () => {
+			expect(findSelfRefChangeHits('<!-- ここは再編しました -->')).toHaveLength(0);
+		});
+	});
+
+	describe('findSelfRefChangeHits — 誤検出しない (内容語 / 成功 toast)', () => {
+		it('データ要約「がんばりをまとめました」は hit しない (まとめました は非対象語)', () => {
+			expect(
+				findSelfRefChangeHits(`hint: '1 か月のお子さまのがんばりをまとめました'`),
+			).toHaveLength(0);
+		});
+
+		it('正当な成功 toast (変更しました / 改善しました) は hit しない (汎用動詞は非対象)', () => {
+			expect(findSelfRefChangeHits(`toast: 'ポイントを変更しました'`)).toHaveLength(0);
+			expect(findSelfRefChangeHits(`toast: '記録を改善しました'`)).toHaveLength(0);
+		});
+
+		it('自己言及のない純粋な操作案内は hit しない', () => {
+			expect(
+				findSelfRefChangeHits(`hubDesc: '下のカードから設定したい項目を選んでください。'`),
+			).toHaveLength(0);
+		});
+	});
+
+	describe('isCommentLine 境界', () => {
+		it('// / * / <!-- 始まりを comment 判定する', () => {
+			expect(isCommentLine('// foo')).toBe(true);
+			expect(isCommentLine(' * foo')).toBe(true);
+			expect(isCommentLine('<!-- foo -->')).toBe(true);
+		});
+		it('コード行 (string 値を含む) は comment ではない', () => {
+			expect(isCommentLine(`label: '整理しました'`)).toBe(false);
+		});
+	});
+
+	describe('SELF_REF_CHANGE_BANLIST 構成', () => {
+		it('初版 9 語 + #3299 追加語を含む', () => {
+			// 初版
+			expect(SELF_REF_CHANGE_BANLIST).toContain('整理しました');
+			expect(SELF_REF_CHANGE_BANLIST).toContain('生まれ変わりました');
+			// #3299 追加
+			expect(SELF_REF_CHANGE_BANLIST).toContain('見直しました');
+			expect(SELF_REF_CHANGE_BANLIST).toContain('分類しました');
+			// 汎用動詞は誤検出回避のため意図的に非収録
+			expect(SELF_REF_CHANGE_BANLIST).not.toContain('変更しました');
+			expect(SELF_REF_CHANGE_BANLIST).not.toContain('改善しました');
+			expect(SELF_REF_CHANGE_BANLIST).not.toContain('まとめました');
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発チーム / システム全体（品質ガード）

**解決する課題**: PR #3290 (#3259) で導入した「UI 文言への実装変更の自己言及」検出 lint (self-ref-change group) の QM adversarial 指摘 2 点 — ① 完全一致 9 語のみで言い換え (「カード別に分類」等) がすり抜ける、② lint 自体の永続 unit test が無い (ADR-0061 違反) — を解消する。

**期待される効果**: 内部事情文言の再混入をより広くガードしつつ、検出精度の regression を unit test で固定。「機械的に網羅検出」ではなく「特定パターンの regression guard + 人手レビュー併用」という正しい位置づけを明文化。

## 関連 Issue

closes #3299

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| 1 | 言い換え語を banlist 拡充（誤検出回避の境界付き） | `npx vitest run tests/unit/scripts/check-internal-terms-self-ref.test.ts` | HEAD `1509f038` / 12 passed。見直し/再編/集約/分類 等 9 語追加、汎用動詞(改善/変更しました)・短語単独は非収録を test で固定 |
| 2 | lint の unit test 追加（string vs comment / 検出語 / 誤検出なし / 行番号） | 同上 | HEAD `1509f038` / findSelfRefChangeHits を pure function 化 + export、12 ケースで境界固定 |
| 3 | 位置づけ是正（regression guard + 人手レビュー併用、PR #3290 の「機械的に再混入防止」過大表現の修正） | 目視 | HEAD `1509f038` / check-internal-terms.mjs header に ⚠️ 位置づけ注記追加 |
| 4 | 既存挙動不変（CLI / lint 結果） | `node scripts/check-internal-terms.mjs` | HEAD `1509f038` / CLI exit 0 / self-ref-change 355 files 走査・違反 0 件 PASS |

## 変更タイプ

- [x] refactor: リファクタリング
- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/` 等) ※lint script + unit test

**影響を受ける画面・機能**: なし（lint script の検出強化 + test）。UI / 振る舞いの変更なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**
- [x] 追加・変更したテストの概要: tests/unit/scripts/check-internal-terms-self-ref.test.ts（12 ケース、検出/非検出境界）。
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / test）**: lint script (`scripts/check-internal-terms.mjs`) + unit test のみで UI ファイル変更なし。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 検出ロジックを pure function findSelfRefChangeHits に分離（単一責任、test 可能化）。scanSelfRefChange は file I/O のみ担当。
- [x] **DRY**: scanSelfRefChange が findSelfRefChangeHits を再利用。既存 isCommentLine を共有。
- [x] **YAGNI**: 完全網羅な NLP 検出は実装しない（非現実的）。観測済みパターンの banlist 拡充に限定。
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: lint は 355 files の line 走査で軽量。

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): lint 強化のみ、設計仕様変更なし。位置づけは script header に記述。
- [x] **labels SSOT** (ADR-0009): N/A（lint script）
- [x] **並行 PR overlap** (#1200): scripts/check-internal-terms.mjs を触る open PR は #3295（F0 check-guide-copy linter）と lint テーマで関連だが別 file・別 group。本 PR は self-ref-change group + test に局所。
- [ ] N/A — 上記以外は影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（banlist 追加 + pure function 抽出 + main guard + test、CLI 挙動不変）。

**レビュー依頼事項・QA**: 追加した言い換え語 9 件の選定（誤検出回避のため汎用動詞・短語単独を除外した境界）が妥当か。完全網羅は意図的に目指さず人手レビュー併用前提（issue #3299 の方針）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み
- [x] UI 変更時: 該当なし（lint script + test）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
