### PR TITLE
infra: #3302 SIGSEGV-safe native dep pin gate + dependabot ignore (better-sqlite3 12.11.x)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,11 @@ updates:
     ignore:
       - dependency-name: "@types/*"
         update-types: ["version-update:semver-patch"]
+      # #3302: better-sqlite3 12.11.x は demo/SQLite (file-backed + WAL) を SIGSEGV crash させる
+      # (#3190/#3192 で 12.10.0 exact pin に根治)。upstream 修正確認まで 12.11.x を ignore。
+      # 12.12+ は再提案を許可 (修正版採用時は scripts/check-native-dep-pin.mjs の pin と同期更新)。
+      - dependency-name: "better-sqlite3"
+        versions: ["12.11.x"]
     groups:
       npm-minor-patch:
         update-types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - 'scripts/native-dep-smoke.mjs'
+              - 'scripts/check-native-dep-pin.mjs'
             # #3191: dependabot 設定 (main 直行封鎖 regression guard) の変更検出
             dependabot:
               - '.github/dependabot.yml'
@@ -323,6 +324,12 @@ jobs:
       # 軽量レーンで捕捉する shift-left smoke (#3190 SIGSEGV class、#3191 AC3)
       - name: Native dependency smoke (SQLite/bcrypt/sharp binding 健全性)
         run: node scripts/native-dep-smoke.mjs
+
+      # SIGSEGV-safe pin (better-sqlite3@12.10.0) からの逸脱を package.json + lock で静的捕捉。
+      # #3302: runtime smoke (#3197) が CI runner 上で 12.11.1 を load でき crash を再現せず、
+      # dependabot #3293 の 12.11.1 再提案が CI green ですり抜けた空洞化を deterministic に塞ぐ。
+      - name: SIGSEGV-safe native dep pin guard (#3302)
+        run: node scripts/check-native-dep-pin.mjs
 
   # #1006 Phase 2: vitest を 2 shard に分割して並列化 (1m 23s → ~40s 目標)
   # 各 shard は coverage を出力し、unit-test-merge で合算してラチェットチェック。

--- a/scripts/check-native-dep-pin.mjs
+++ b/scripts/check-native-dep-pin.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// @ts-nocheck — CLI gate script。unit test が import するため TS graph に入るが untyped JS の CLI ツール。
+//
+// scripts/check-native-dep-pin.mjs (#3302)
+//
+// SIGSEGV-safe にピン留めした native 依存が、安全版から変わる PR を deterministic に hard-fail する。
+//
+// 背景: #3190 で better-sqlite3 12.11.1 が demo/SQLite (file-backed Database + WAL) を SIGSEGV crash
+// させ、#3192 HOTFIX が 12.10.0 exact pin で根治した。だが #3197 の native-dep-smoke (runtime load)
+// は CI runner 上で 12.11.1 を load できてしまい crash を再現せず、dependabot #3293 の 12.11.1 再提案が
+// CI green ですり抜けた (gate の空洞化)。
+//
+// 本 gate は runtime load に依存せず、package.json + package-lock.json の version を静的照合し、
+// SIGSEGV-safe pin (SSOT below) から逸脱したら即 fail する (ADR-0061 shift-left の機械強制)。
+// dependabot.yml の ignore (12.11.x) と二重防御: ignore は再提案を抑止し、本 gate は手動 bump /
+// transitive 巻き戻し / ignore すり抜けを最終捕捉する。
+//
+// 使用: node scripts/check-native-dep-pin.mjs
+// CI: deps-supply-chain-check job (deps / dependabot 変更時)。逸脱で exit 1。
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// SIGSEGV-safe pin SSOT
+//
+// native binding の ABI/実装が特定版で demo/NUC runtime を crash させるため exact pin する依存。
+// version を変えるときは「該当 upstream 修正を確認 + native-dep-smoke + demo/NUC 実機検証」を経て
+// ここを更新する (= 単独 SSOT)。dependabot.yml の ignore も同期更新すること。
+// ---------------------------------------------------------------------------
+
+export const SIGSEGV_SAFE_PINS = [
+	{
+		name: 'better-sqlite3',
+		version: '12.10.0',
+		reason: '#3190/#3192: 12.11.1 が demo/SQLite (file-backed + WAL) を SIGSEGV crash させる',
+	},
+];
+
+/**
+ * package.json + package-lock.json を pins と静的照合し、逸脱を violations で返す pure function。
+ * @param {{dependencies?:Record<string,string>, devDependencies?:Record<string,string>}} pkgJson
+ * @param {{packages?:Record<string,any>}} lockJson
+ * @param {{name:string, version:string, reason:string}[]} pins
+ * @returns {{name:string, where:string, expected:string, actual:string, reason:string}[]}
+ */
+export function findPinViolations(pkgJson, lockJson, pins) {
+	const violations = [];
+	const deps = { ...(pkgJson.dependencies ?? {}), ...(pkgJson.devDependencies ?? {}) };
+	const lockPkgs = lockJson.packages ?? {};
+
+	for (const pin of pins) {
+		// 1) package.json: exact 一致 (caret / tilde / range は不可 = exact pin 維持)
+		const declared = deps[pin.name];
+		if (declared === undefined) {
+			violations.push({
+				name: pin.name,
+				where: 'package.json',
+				expected: pin.version,
+				actual: '(未宣言)',
+				reason: pin.reason,
+			});
+		} else if (declared !== pin.version) {
+			violations.push({
+				name: pin.name,
+				where: 'package.json',
+				expected: pin.version,
+				actual: declared,
+				reason: pin.reason,
+			});
+		}
+
+		// 2) package-lock.json: 解決済 version 一致
+		const lockEntry = lockPkgs[`node_modules/${pin.name}`];
+		const lockVersion = lockEntry?.version;
+		if (lockVersion === undefined) {
+			violations.push({
+				name: pin.name,
+				where: 'package-lock.json',
+				expected: pin.version,
+				actual: '(lock に node_modules entry なし)',
+				reason: pin.reason,
+			});
+		} else if (lockVersion !== pin.version) {
+			violations.push({
+				name: pin.name,
+				where: 'package-lock.json',
+				expected: pin.version,
+				actual: lockVersion,
+				reason: pin.reason,
+			});
+		}
+	}
+	return violations;
+}
+
+function main() {
+	console.log('[check-native-dep-pin] SIGSEGV-safe native dep pin 検査 (#3302)');
+	let pkgJson;
+	let lockJson;
+	try {
+		pkgJson = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+		lockJson = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package-lock.json'), 'utf8'));
+	} catch (err) {
+		console.error(`[check-native-dep-pin] read error: ${err.message}`);
+		return 1;
+	}
+
+	const violations = findPinViolations(pkgJson, lockJson, SIGSEGV_SAFE_PINS);
+	if (violations.length === 0) {
+		console.log(
+			`[check-native-dep-pin] ✓ PASS — ${SIGSEGV_SAFE_PINS.map((p) => `${p.name}@${p.version}`).join(', ')} 据え置き維持`,
+		);
+		return 0;
+	}
+
+	console.log('\n[check-native-dep-pin] ✗ FAIL — SIGSEGV-safe pin から逸脱した native 依存:\n');
+	for (const v of violations) {
+		console.log(`  ${v.name} [${v.where}]: expected ${v.expected} / actual ${v.actual}`);
+		console.log(`    理由: ${v.reason}`);
+	}
+	console.log(
+		'\n修正方針 (#3302):\n' +
+			'  - 該当依存を SIGSEGV-safe pin に戻す (package.json exact + lock 同期)。\n' +
+			'  - 安全版を更新する場合は upstream 修正確認 + native-dep-smoke + demo/NUC 実機検証後、\n' +
+			'    scripts/check-native-dep-pin.mjs の SIGSEGV_SAFE_PINS と .github/dependabot.yml ignore を同時更新する。\n',
+	);
+	return 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	process.exit(main());
+}

--- a/tests/unit/scripts/check-native-dep-pin.test.ts
+++ b/tests/unit/scripts/check-native-dep-pin.test.ts
@@ -1,0 +1,66 @@
+/**
+ * tests/unit/scripts/check-native-dep-pin.test.ts (#3302)
+ *
+ * check-native-dep-pin.mjs の SIGSEGV-safe pin 逸脱検出を回帰固定する (ADR-0061: guard は test で守る)。
+ * #3197 の runtime smoke がすり抜けた dependabot #3293 (better-sqlite3 12.11.1) を、本 gate が
+ * package.json + lock の静的照合で hard-fail することを境界ごとに検証する。
+ */
+
+import { describe, expect, it } from 'vitest';
+import { findPinViolations, SIGSEGV_SAFE_PINS } from '../../../scripts/check-native-dep-pin.mjs';
+
+const PIN = [{ name: 'better-sqlite3', version: '12.10.0', reason: 'test' }];
+
+/** lock の最小形 (node_modules/<name>.version を持つ packages map)。 */
+function lock(version: string | undefined) {
+	const packages: Record<string, { version?: string }> = { '': {} };
+	if (version !== undefined) packages['node_modules/better-sqlite3'] = { version };
+	return { packages };
+}
+
+describe('check-native-dep-pin findPinViolations (#3302)', () => {
+	it('pin 一致 (package.json + lock とも 12.10.0) なら違反 0', () => {
+		const pkg = { dependencies: { 'better-sqlite3': '12.10.0' } };
+		expect(findPinViolations(pkg, lock('12.10.0'), PIN)).toEqual([]);
+	});
+
+	it('package.json が 12.11.1 (#3293 regression) を violation 検出する', () => {
+		const pkg = { dependencies: { 'better-sqlite3': '12.11.1' } };
+		const v = findPinViolations(pkg, lock('12.11.1'), PIN);
+		// package.json と lock 両方で逸脱 → 2 件
+		expect(v).toHaveLength(2);
+		expect(v.some((x) => x.where === 'package.json' && x.actual === '12.11.1')).toBe(true);
+		expect(v.some((x) => x.where === 'package-lock.json' && x.actual === '12.11.1')).toBe(true);
+	});
+
+	it('lock のみ逸脱 (package.json は 12.10.0 だが lock が 12.11.1) も検出する', () => {
+		const pkg = { dependencies: { 'better-sqlite3': '12.10.0' } };
+		const v = findPinViolations(pkg, lock('12.11.1'), PIN);
+		expect(v).toHaveLength(1);
+		expect(v[0]?.where).toBe('package-lock.json');
+	});
+
+	it('caret / range 指定 (^12.10.0) は exact pin でないため violation', () => {
+		const pkg = { dependencies: { 'better-sqlite3': '^12.10.0' } };
+		const v = findPinViolations(pkg, lock('12.10.0'), PIN);
+		expect(v.some((x) => x.where === 'package.json' && x.actual === '^12.10.0')).toBe(true);
+	});
+
+	it('依存未宣言 / lock entry 欠落も検出する', () => {
+		const v = findPinViolations({ dependencies: {} }, lock(undefined), PIN);
+		expect(v).toHaveLength(2);
+		expect(v.some((x) => x.actual.includes('未宣言'))).toBe(true);
+		expect(v.some((x) => x.actual.includes('lock'))).toBe(true);
+	});
+
+	it('devDependencies 側の pin も照合する', () => {
+		const pkg = { devDependencies: { 'better-sqlite3': '12.10.0' } };
+		expect(findPinViolations(pkg, lock('12.10.0'), PIN)).toEqual([]);
+	});
+
+	it('SSOT (SIGSEGV_SAFE_PINS) に better-sqlite3@12.10.0 を含む', () => {
+		const bs = SIGSEGV_SAFE_PINS.find((p) => p.name === 'better-sqlite3');
+		expect(bs?.version).toBe('12.10.0');
+		expect(bs?.reason).toMatch(/SIGSEGV/);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（依存供給線の安全性）

**解決する課題**: #3197 の SIGSEGV 再発防止 gate（native-dep-smoke、runtime load 検査）が、CI runner 上で better-sqlite3 12.11.1 を load できてしまい crash を再現せず、dependabot #3293 の 12.11.1 再提案が CI green ですり抜けた（gate の空洞化）。

**期待される効果**: better-sqlite3 が SIGSEGV-safe pin（12.10.0）から変わる PR を、runtime に依存しない静的照合で deterministic に hard-fail。dependabot ignore と二重防御で demo/NUC SQLite の SIGSEGV crash 再発を機械的に封じる。

## 関連 Issue

closes #3302

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| 1 | better-sqlite3 が 12.10.0 から変わる PR を package.json + lock で hard-fail | `npx vitest run tests/unit/scripts/check-native-dep-pin.test.ts` | HEAD `469ce456` / 7 passed（一致/不一致/caret 不可/未宣言/devDeps/SSOT）。`node scripts/check-native-dep-pin.mjs` develop で PASS |
| 2 | SIGSEGV-safe 版を単独 SSOT に持つ | コードレビュー | HEAD `469ce456` / check-native-dep-pin.mjs `SIGSEGV_SAFE_PINS`（better-sqlite3@12.10.0 + reason） |
| 3 | #3197 gate（deps-supply-chain-check job）に組込み | ci.yml diff | HEAD `469ce456` / job に step 追加 + changes deps filter に script 追加 |
| 4 | dependabot が 12.11.x を再提案しない | dependabot.yml diff | HEAD `469ce456` / better-sqlite3 `versions: ["12.11.x"]` ignore（12.12+ 修正版は許可） |

## 変更タイプ

- [x] infra: インフラ・CI/CD
- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/` 等)

**影響を受ける画面・機能**: なし（CI gate + dependabot 設定 + unit test）。依存供給線の安全装置。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**
- [x] 追加・変更したテストの概要: tests/unit/scripts/check-native-dep-pin.test.ts（7 ケース、pin 逸脱検出境界）。
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（SIGSEGV regression の再発防止 gate）

## スクリーンショット / ビジュアルデモ

**該当なし（infra / test）**: CI gate script + dependabot.yml + unit test のみで UI ファイル変更なし。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 検出ロジックを pure function findPinViolations に分離（単一責任、test 可能化）。main は I/O。
- [x] **DRY**: SIGSEGV-safe 版を SIGSEGV_SAFE_PINS の単独 SSOT に集約（pin 値の散在を防ぐ）。
- [x] **YAGNI**: 任意の visual-regression gate（UI-runtime 依存 bump）は scope 拡大のため見送り、後続課題に残す。
- [x] **Security**: SIGSEGV crash class（#3190）の再発を機械的に防止。runtime 非依存の静的検査。
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: 静的 JSON 照合のみ、軽量。

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): CI gate の追加。SSOT は script 内 SIGSEGV_SAFE_PINS + dependabot.yml に記述。
- [x] **labels SSOT** (ADR-0009): N/A
- [x] **並行 PR overlap** (#1200): #3293（better-sqlite3 据え置きの実施）と補完関係。本 PR は gate/ignore/test に局所、package.json は変更しない。
- [ ] N/A — 上記以外は影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（CI gate + dependabot ignore + unit test の追加。既存依存は不変）。

**レビュー依頼事項・QA**: ① 静的 gate（version-pin）と runtime smoke（#3197）の二重化が適切か。② dependabot ignore の `12.11.x` 範囲指定が将来の 12.12+ 修正版を妨げないか。任意項目（visual gate）は 後続課題に残す扱いとした判断。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み
- [x] UI 変更時: 該当なし（infra / test）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

