### PR TITLE
infra: #3298 高権限 GitHub Actions の SHA pin 化 + regression guard (ADR-0061)

### DIFF
--- a/.github/workflows/app-visual-regression.yml
+++ b/.github/workflows/app-visual-regression.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/audit-run.yml
+++ b/.github/workflows/audit-run.yml
@@ -51,7 +51,7 @@ jobs:
       - run: npm ci
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/child-home-visual-regression.yml
+++ b/.github/workflows/child-home-visual-regression.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
               - 'package-lock.json'
               - 'scripts/native-dep-smoke.mjs'
               - 'scripts/check-native-dep-pin.mjs'
+              # #3298: 高権限 GitHub Actions の SHA pin gate (workflow / guard 変更で再検査)
+              - '.github/workflows/**'
+              - 'scripts/check-action-sha-pin.mjs'
             # #3191: dependabot 設定 (main 直行封鎖 regression guard) の変更検出
             dependabot:
               - '.github/dependabot.yml'
@@ -331,6 +334,12 @@ jobs:
       - name: SIGSEGV-safe native dep pin guard (#3302)
         run: node scripts/check-native-dep-pin.mjs
 
+      # 高権限 GitHub Actions (create-github-app-token / attest / cache) の floating tag pin への
+      # regression を捕捉。tag は mutable で再付け替えにより secret 消費 CI に任意コード混入し得る
+      # (GitHub 公式 security hardening guide が SHA pin 推奨)。#3298。
+      - name: 高権限 GitHub Actions SHA pin guard (#3298)
+        run: node scripts/check-action-sha-pin.mjs
+
   # #1006 Phase 2: vitest を 2 shard に分割して並列化 (1m 23s → ~40s 目標)
   # 各 shard は coverage を出力し、unit-test-merge で合算してラチェットチェック。
   # shard 実行時は threshold 未達でも fail しない (部分カバレッジのため不正確)。
@@ -480,7 +489,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -525,7 +534,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -593,7 +602,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -685,7 +694,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache-matrix
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -742,7 +751,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache-cognito
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -835,7 +844,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache-demo
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -517,7 +517,7 @@ jobs:
       # 同一 workflow run 内では test job が保存した cache を即時利用可能
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/hotfix-back-merge.yml
+++ b/.github/workflows/hotfix-back-merge.yml
@@ -162,7 +162,7 @@ jobs:
           steps.classify.outputs.do_back_merge == 'true' &&
           steps.noop.outputs.already_in_develop == 'false' &&
           steps.appcreds.outputs.present == 'true'
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.INTEGRATION_BOT_APP_ID }}
           private-key: ${{ secrets.INTEGRATION_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/integration-attest.yml
+++ b/.github/workflows/integration-attest.yml
@@ -243,7 +243,7 @@ jobs:
         id: attest
         if: steps.classify.outputs.is_integration == 'true'
         continue-on-error: true
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ${{ github.repository }}@${{ steps.classify.outputs.merge_sha }}
           subject-digest: sha1:${{ steps.classify.outputs.merge_sha }}

--- a/.github/workflows/integration-pr.yml
+++ b/.github/workflows/integration-pr.yml
@@ -193,7 +193,7 @@ jobs:
           steps.diff.outputs.has_diff == 'true' &&
           inputs.dry_run != 'true' &&
           steps.appcreds.outputs.present == 'true'
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.INTEGRATION_BOT_APP_ID }}
           private-key: ${{ secrets.INTEGRATION_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/lp-visual-regression.yml
+++ b/.github/workflows/lp-visual-regression.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -796,6 +796,7 @@ HTTP レスポンスヘッダーで CSP を付与できないため、`<meta htt
 - **CodeQL**: プッシュごとにセキュリティスキャン実行
 - **Dependabot**: 依存ライブラリの脆弱性を自動検出・PR作成
 - **コミット前チェック**: Biome lint + svelte-check + Vitest + Playwright E2E
+- **高権限 Actions の SHA pin (#3298)**: secret を消費する / provenance を発行する / cache を書く高権限 Actions（`actions/create-github-app-token` / `actions/attest` / `actions/cache`）は mutable な floating tag（`@v3` 等）ではなく full-length commit SHA + `# vX.Y.Z` コメントで pin する（tag 再付け替えによる supply-chain 注入の防止、GitHub 公式 hardening guide 整合）。floating tag への regression は `scripts/check-action-sha-pin.mjs`（CI `deps-supply-chain-check` job、SSOT = `HIGH_PRIVILEGE_ACTIONS`）が hard-fail する。repo 全体の SHA pin 化は churn / 運用コストが大きく Pre-PMF（ADR-0010）で PO 判断待ち（高権限 subset のみ強制）。dependabot は SHA pin + コメント方式でも更新追従する
 
 ---
 

--- a/scripts/check-action-sha-pin.mjs
+++ b/scripts/check-action-sha-pin.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// @ts-nocheck — CLI gate script。unit test が import するため TS graph に入るが untyped JS の CLI ツール。
+//
+// scripts/check-action-sha-pin.mjs (#3298)
+//
+// 高権限 GitHub Actions が full-length commit SHA で pin されているかを静的検査し、
+// floating tag pin (例 @v3) への regression を deterministic に hard-fail する (ADR-0061 shift-left)。
+//
+// 背景: 当 repo は全 Actions を floating major tag pin (例 actions/checkout@v7) で運用し dependabot が
+// bump する。tag は mutable で、供給元が同一 tag を悪性コミットに再付け替えすると secrets/OIDC/write
+// 権限を持つ CI で任意コード実行に至る (GitHub 公式 security hardening guide が SHA pin を推奨)。
+// 特に「secret を消費する / provenance を発行する / cache を書く」高権限 action は被害が甚大。
+//
+// 本 gate は HIGH_PRIVILEGE_ACTIONS (SSOT below) が 40-hex commit SHA で pin されていることを保証する。
+// dependabot は SHA pin + `# vX.Y.Z` コメント方式でも更新追従するため、SHA bump は本 gate を素通りする
+// (= 安全な更新は妨げず、tag への巻き戻しのみ捕捉)。
+//
+// scope: 本 gate は高権限 action のみを対象とする。repo 全体の SHA pin 化は churn / 運用コストが大きく
+// Pre-PMF (ADR-0010) で PO 判断待ちのため、本 gate では強制しない (#3298 §対応案 2)。
+//
+// 使用: node scripts/check-action-sha-pin.mjs
+// CI: deps-supply-chain-check job (.github/ 変更時)。tag pin 検出で exit 1。
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const WORKFLOWS_DIR = path.join(REPO_ROOT, '.github', 'workflows');
+
+// ---------------------------------------------------------------------------
+// 高権限 Actions SSOT (#3298)
+//
+// SHA pin を必須とする action 名 (owner/repo、サブパス除く前方一致)。被害インパクトの根拠を reason に残す。
+// 新たに secret 消費 / write 権限 / provenance / cache を扱う高権限 action を導入したら本 list に追記する。
+// ---------------------------------------------------------------------------
+
+export const HIGH_PRIVILEGE_ACTIONS = [
+	{
+		name: 'actions/create-github-app-token',
+		reason:
+			'INTEGRATION_BOT_APP_PRIVATE_KEY secret を消費し merge/write 可能な app token を発行する',
+	},
+	{
+		name: 'actions/attest',
+		reason: 'build provenance を発行する。改竄で偽 attestation が成立する',
+	},
+	{
+		name: 'actions/cache',
+		reason: 'cache を書き込む。cache poisoning で後続 job に汚染物が伝播し得る',
+	},
+];
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+/** `.github/workflows/` 配下の *.yml / *.yaml 絶対パスを返す。 */
+export function listWorkflowFiles(dir = WORKFLOWS_DIR) {
+	if (!fs.existsSync(dir)) return [];
+	return fs
+		.readdirSync(dir)
+		.filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+		.map((f) => path.join(dir, f));
+}
+
+/**
+ * workflow source 1 本を走査し、高権限 action が SHA pin でない `uses:` 行を violation で返す pure function。
+ * `uses: <owner/repo>[/subpath]@<ref>` の ref が 40-hex SHA でなければ違反。owner/repo は前方一致で判定
+ * (codeql-action のようなサブパス付きも owner/repo 部分で照合)。
+ *
+ * @param {string} source workflow YAML の本文
+ * @param {string} fileRel リポジトリ相対パス (違反メッセージ用)
+ * @param {{name:string, reason:string}[]} actions 高権限 action SSOT
+ * @returns {{file:string, line:number, action:string, ref:string, reason:string}[]}
+ */
+export function findTagPinViolations(source, fileRel, actions = HIGH_PRIVILEGE_ACTIONS) {
+	const violations = [];
+	const lines = source.split(/\r?\n/);
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] ?? '';
+		// `uses: owner/repo[/sub]@ref`。ref は空白前まで (末尾 `# comment` は ref に含まれない)。
+		const m = line.match(/uses:\s*([A-Za-z0-9._-]+\/[A-Za-z0-9._/-]+)@(\S+)/);
+		if (!m) continue;
+		const usedPath = m[1];
+		const ref = m[2];
+		// owner/repo 前方一致 (サブパス付き action も owner/repo で照合)。
+		const hit = actions.find((a) => usedPath === a.name || usedPath.startsWith(`${a.name}/`));
+		if (!hit) continue;
+		if (!SHA_RE.test(ref)) {
+			violations.push({
+				file: fileRel,
+				line: i + 1,
+				action: usedPath,
+				ref,
+				reason: hit.reason,
+			});
+		}
+	}
+	return violations;
+}
+
+/** 全 workflow を走査して violations を集約する。 */
+export function scanAllWorkflows(files = listWorkflowFiles()) {
+	const all = [];
+	for (const file of files) {
+		const source = fs.readFileSync(file, 'utf8');
+		const rel = path.relative(REPO_ROOT, file).replace(/\\/g, '/');
+		all.push(...findTagPinViolations(source, rel));
+	}
+	return all;
+}
+
+function main() {
+	console.log('[check-action-sha-pin] 高権限 GitHub Actions の SHA pin 検査 (#3298)');
+	const violations = scanAllWorkflows();
+	if (violations.length === 0) {
+		console.log(
+			`[check-action-sha-pin] ✓ PASS — ${HIGH_PRIVILEGE_ACTIONS.map((a) => a.name).join(', ')} は全て SHA pin`,
+		);
+		return 0;
+	}
+
+	console.log('\n[check-action-sha-pin] ✗ FAIL — SHA pin されていない高権限 action:\n');
+	for (const v of violations) {
+		console.log(`  ${v.file}:${v.line}  ${v.action}@${v.ref}`);
+		console.log(`    理由: ${v.reason}`);
+	}
+	console.log(
+		'\n修正方針 (#3298):\n' +
+			'  - 該当 action を full-length commit SHA に pin し、`# vX.Y.Z` コメントで version を注記する。\n' +
+			'    例: uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0\n' +
+			'  - SHA は `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha` で解決する。\n' +
+			'  - dependabot は SHA pin + コメント方式でも更新追従するため運用負荷は増えない。\n' +
+			'  - 新規高権限 action は scripts/check-action-sha-pin.mjs の HIGH_PRIVILEGE_ACTIONS に追記する。\n',
+	);
+	return 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	process.exit(main());
+}

--- a/tests/unit/scripts/check-action-sha-pin.test.ts
+++ b/tests/unit/scripts/check-action-sha-pin.test.ts
@@ -1,0 +1,67 @@
+// tests/unit/scripts/check-action-sha-pin.test.ts
+// #3298: 高権限 GitHub Actions の SHA pin gate の回帰ガード (ADR-0061 shift-left)。
+//
+// floating tag pin (@v3 等) は mutable で、供給元の tag 再付け替えで secret 消費 / write 権限を持つ
+// CI に任意コード混入し得る。本テストは check-action-sha-pin.mjs が「高権限 action の tag pin」を
+// 検出し、SHA pin / 非対象 action / コメント付き SHA を正しく扱うことを機械検証する。
+
+import { describe, expect, it } from 'vitest';
+import {
+	findTagPinViolations,
+	HIGH_PRIVILEGE_ACTIONS,
+	scanAllWorkflows,
+} from '../../../scripts/check-action-sha-pin.mjs';
+
+const SHA = 'bcd2ba49218906704ab6c1aa796996da409d3eb1';
+
+describe('#3298 findTagPinViolations', () => {
+	it('高権限 action の tag pin を検出する', () => {
+		const src = '      - uses: actions/create-github-app-token@v3\n';
+		const v = findTagPinViolations(src, 'wf.yml');
+		expect(v).toHaveLength(1);
+		expect(v[0]?.action).toBe('actions/create-github-app-token');
+		expect(v[0]?.ref).toBe('v3');
+	});
+
+	it('SHA pin (コメント付き) は違反にしない', () => {
+		const src = `      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0\n`;
+		expect(findTagPinViolations(src, 'wf.yml')).toHaveLength(0);
+	});
+
+	it('SHA pin (コメントなし) も違反にしない', () => {
+		const src = `      - uses: actions/attest@${SHA}\n`;
+		expect(findTagPinViolations(src, 'wf.yml')).toHaveLength(0);
+	});
+
+	it('非対象 action の tag pin は無視する (repo 全体 pin は scope 外、PO 判断待ち)', () => {
+		const src = '      - uses: actions/checkout@v7\n      - uses: actions/setup-node@v6\n';
+		expect(findTagPinViolations(src, 'wf.yml')).toHaveLength(0);
+	});
+
+	it('サブパス付き高権限 action も owner/repo 前方一致で検出する', () => {
+		const src = '      - uses: actions/cache/restore@v6\n';
+		const v = findTagPinViolations(src, 'wf.yml');
+		expect(v).toHaveLength(1);
+		expect(v[0]?.action).toBe('actions/cache/restore');
+	});
+
+	it('version range / branch ref も SHA でなければ違反', () => {
+		for (const ref of ['v3.2.0', 'main', 'latest']) {
+			const src = `      - uses: actions/attest@${ref}\n`;
+			expect(findTagPinViolations(src, 'wf.yml'), `ref=${ref}`).toHaveLength(1);
+		}
+	});
+
+	it('SSOT: 3 つの高権限 action (token 発行 / attest / cache) を含む', () => {
+		const names = HIGH_PRIVILEGE_ACTIONS.map((a) => a.name);
+		expect(names).toContain('actions/create-github-app-token');
+		expect(names).toContain('actions/attest');
+		expect(names).toContain('actions/cache');
+	});
+});
+
+describe('#3298 scanAllWorkflows (実 workflow)', () => {
+	it('現行 .github/workflows/ は高権限 action 違反 0 (SHA pin 維持)', () => {
+		expect(scanAllWorkflows()).toEqual([]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（CI/CD 供給網セキュリティ）

**解決する課題**: 高権限 GitHub Actions が mutable な floating tag（`@v3` 等）で pin され、供給元の tag 再付け替えで secret 消費 CI に任意コードが混入し得る。

**期待される効果**: secret 発行 / provenance / cache を扱う高権限 action を commit SHA に固定し、tag 再付け替え経由の supply-chain 注入を遮断する。

## 関連 Issue

closes #3298

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 高権限 3 action を full-length SHA + version コメントに pin | `grep -rn "create-github-app-token@\|attest@\|cache@" .github/workflows/` | HEAD `21a0a5bc` / 15 ref が SHA pin（create-github-app-token×2 / attest×1 / cache×12）、tag pin 0 |
| AC2 | floating tag への regression を CI で hard-fail | `node scripts/check-action-sha-pin.mjs` + ci.yml step | HEAD `21a0a5bc` / ✓ PASS / deps-supply-chain-check job に step 追加 |
| AC3 | guard を unit test で機械担保（ADR-0061） | `npx vitest run tests/unit/scripts/check-action-sha-pin.test.ts` | HEAD `21a0a5bc` / 8 passed（tag/SHA/コメント付き/非対象/サブパス/range/SSOT/実 workflow 0 件） |
| AC4 | 設計書同期（ADR-0001） | `docs/design/14-セキュリティ設計書.md` §11.4 | HEAD `21a0a5bc` / SHA pin policy + guard + Pre-PMF scope を追記 |
| AC5 | repo 全体 SHA pin 化は PO 判断待ちとして明示（過剰防衛回避） | script header + 設計書 + 本 PR | HEAD `21a0a5bc` / 高権限 subset のみ強制、repo-wide は PO 判断に委ねる |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/` 等)
- [x] インフラ (`infra/`) 相当（GitHub Actions workflows）

**影響を受ける画面・機能**: なし（CI/CD パイプラインのみ。ランタイム挙動・UI 不変）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**
- [x] 追加・変更したテストの概要: `tests/unit/scripts/check-action-sha-pin.test.ts`（8 ケース、findTagPinViolations + scanAllWorkflows）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（infra のみ、UI 変更なし）**: `.github/workflows/**` + `scripts/` + `tests/` + 設計書のみで、`.svelte` / `.css` / `site/` の変更なし。CI/CD 設定変更でランタイム UI に影響しない。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: guard は findTagPinViolations（pure）/ scanAllWorkflows / main の単一責任分離
- [x] **DRY**: HIGH_PRIVILEGE_ACTIONS を単独 SSOT 化、検出ロジックは 1 箇所
- [x] **YAGNI**: 高権限 subset のみ。repo 全体 pin は PO 判断待ちで先行実装しない
- [x] **Security**: 本 PR 自体が supply-chain hardening。SHA は `gh api commits/<tag>` で解決した実値
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A（CI lint は O(workflow 行数)）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): `docs/design/14-セキュリティ設計書.md` §11.4 更新
- [x] **並行 PR overlap** (#1200): 同一 workflow を変更する open PR なし（draft 時点確認）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: SHA は `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha` で解決した実値（create-github-app-token v3.2.0 / attest v4.1.0 / cache v6.0.0）。dependabot は SHA pin + コメント方式でも更新追従するため、今後の bump は SHA + コメントが更新され guard を素通りする。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A（repo-wide pin は PO 判断事項）
- [x] UI 変更時: N/A（infra のみ）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
