### PR TITLE
fix(ui): #3285 監査 UI 品質 3 件 — error-notify SSOT + .baby-card トークン化 + hardcoded JP 集約

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2230,6 +2230,13 @@ export const SETTINGS_LABELS = {
 	dataImportSelectFile: `${BACKUP_TERMS.file}を選択`,
 	// #backup-terms: 不正ファイル選択時 (内部フォーマット名は出さず「バックアップファイル」で統一)
 	dataImportInvalidFile: `${BACKUP_TERMS.file}を選択してください`,
+	// #3285 uiux-3: settings/data の import 検証 / クラウド連携メッセージを SSOT 集約 (旧: 直書き)
+	dataImportNoFile: `${BACKUP_TERMS.file}が選択されていません`,
+	dataImportFileTooLarge: (maxMb: string) => `ファイルサイズが大きすぎます（最大${maxMb}MB）`,
+	cloudExportPinIssued: (pinCode: string, expiry: string) =>
+		`PINコード: ${pinCode}（有効期限: ${expiry}）`,
+	cloudImportNoChildren:
+		'取込先のお子さまが登録されていません。先に /admin/children でお子さま登録をしてください。',
 	dataImportChecksumOk: '✓ ファイルの整合性を確認しました',
 	dataImportPreviewChildren: (n: number | string | undefined) => `子供: ${n}人`,
 	dataImportPreviewActivityLogs: (n: number | string | undefined) => `活動ログ: ${n}件`,

--- a/src/lib/ui/styles/app.css
+++ b/src/lib/ui/styles/app.css
@@ -1061,16 +1061,26 @@ h1, h2, h3, h4 {
 }
 .baby-card-main-quest {
 	box-shadow: 0 0 12px rgba(217, 119, 6, 0.4);
-	background: linear-gradient(135deg, #fffbeb, #fef3c7) !important;
+
+	/* #3285 uiux-2: hex 直書きを Semantic トークンに置換 (DESIGN.md §2)。色は不変。 */
+	background: linear-gradient(
+		135deg,
+		var(--color-feedback-warning-bg),
+		var(--color-feedback-warning-bg-strong)
+	) !important;
 }
 .baby-main-quest-badge {
 	position: absolute;
 	top: -0.375rem;
 	right: -0.375rem;
-	z-index: 10;
+
+	/* #3285 uiux-2: 生数値 z-index を §10 トークンに置換 (10 = --z-sticky)。 */
+	z-index: var(--z-sticky);
 	padding: 0.125rem 0.375rem;
 	border-radius: 9999px;
-	background: linear-gradient(135deg, #f59e0b, #d97706);
+
+	/* #3285 uiux-2: amber gradient の exact-match Semantic トークン (色不変)。 */
+	background: linear-gradient(135deg, var(--color-chart-2), var(--color-warning-hover));
 	color: white;
 	font-size: 0.625rem;
 	font-weight: 700;
@@ -1096,7 +1106,9 @@ h1, h2, h3, h4 {
 	display: inline-block;
 	width: 2rem;
 	height: 2rem;
-	border: 3px solid var(--theme-primary, #6366f1);
+
+	/* #3285 uiux-2: hex フォールバック撤去 (--theme-primary は全テーマで定義済、DESIGN.md §2)。 */
+	border: 3px solid var(--theme-primary);
 	border-right-color: transparent;
 	border-radius: 50%;
 	animation: spin 0.6s linear infinite;

--- a/src/routes/(parent)/admin/settings/data/+page.svelte
+++ b/src/routes/(parent)/admin/settings/data/+page.svelte
@@ -6,6 +6,7 @@ import { enhance } from '$app/forms';
 import { page } from '$app/stores';
 import {
 	APP_LABELS,
+	ERROR_NOTIFY_LABELS,
 	IMPORT_LABELS,
 	type ImportSkipReason,
 	PAGE_TITLES,
@@ -13,6 +14,8 @@ import {
 } from '$lib/domain/labels';
 import { ErrorAlert, SuccessAlert } from '$lib/ui/components';
 import PremiumBadge from '$lib/ui/components/PremiumBadge.svelte';
+// #3285 uiux-1: 生 err.message 露出を撤去し error-notify SSOT (500=汎用 / 4xx=sanitize) 経由に統一
+import { resolveApiErrorMessage } from '$lib/ui/error-notify';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import ChildSelectionDialog from '$lib/ui/primitives/ChildSelectionDialog.svelte';
@@ -121,7 +124,7 @@ const MAX_ZIP_BYTES = 100 * 1024 * 1024;
  * #3077: 選択ファイルが ZIP なら raw bytes を application/zip で、JSON なら従来通り JSON で送る。
  */
 async function postImport(mode: string): Promise<Response> {
-	if (!importFile) throw new Error('ファイルが選択されていません');
+	if (!importFile) throw new Error(SETTINGS_LABELS.dataImportNoFile);
 	if (importFile.name.endsWith('.zip')) {
 		return fetch(`/api/v1/import?mode=${mode}`, {
 			method: 'POST',
@@ -156,7 +159,7 @@ async function handleImportFileChange(e: Event) {
 	}
 	const maxBytes = isZip ? MAX_ZIP_BYTES : MAX_JSON_BYTES;
 	if (importFile.size > maxBytes) {
-		importError = `ファイルサイズが大きすぎます（最大${isZip ? '100' : '10'}MB）`;
+		importError = SETTINGS_LABELS.dataImportFileTooLarge(isZip ? '100' : '10');
 		importFile = null;
 		return;
 	}
@@ -164,14 +167,17 @@ async function handleImportFileChange(e: Event) {
 	importLoading = true;
 	try {
 		const res = await postImport('preview');
-		const d = await res.json();
+		const d = await res.json().catch(() => null);
 		if (!res.ok) {
-			throw new Error(d?.error?.message ?? 'プレビューに失敗しました');
+			// #3285 uiux-1: 生サーバ message を露出せず error-notify SSOT で無害化
+			importError = resolveApiErrorMessage(res.status, d?.error?.message ?? '');
+			importFile = null;
+			return;
 		}
 		importPreview = d.preview;
 		importStep = 'preview';
-	} catch (err) {
-		importError = err instanceof Error ? err.message : 'ファイルの読み込みに失敗しました';
+	} catch {
+		importError = ERROR_NOTIFY_LABELS.generic;
 		importFile = null;
 	} finally {
 		importLoading = false;
@@ -185,14 +191,15 @@ async function handleImportExecute() {
 	try {
 		const mode = importMode === 'replace' ? 'replace' : 'execute';
 		const res = await postImport(mode);
-		const d = await res.json();
+		const d = await res.json().catch(() => null);
 		if (!res.ok) {
-			throw new Error(d?.error?.message ?? 'インポートに失敗しました');
+			importError = resolveApiErrorMessage(res.status, d?.error?.message ?? '');
+			return;
 		}
 		importResult = d.result;
 		importStep = 'done';
-	} catch (err) {
-		importError = err instanceof Error ? err.message : 'インポートに失敗しました';
+	} catch {
+		importError = ERROR_NOTIFY_LABELS.generic;
 	} finally {
 		importLoading = false;
 	}
@@ -218,7 +225,8 @@ async function handleExport() {
 		const res = await fetch(`/api/v1/export${qs}`);
 		if (!res.ok) {
 			const d = await res.json().catch(() => null);
-			throw new Error(d?.error?.message ?? `エクスポートに失敗しました (${res.status})`);
+			exportError = resolveApiErrorMessage(res.status, d?.error?.message ?? '');
+			return;
 		}
 		const blob = await res.blob();
 		const disposition = res.headers.get('Content-Disposition') ?? '';
@@ -233,8 +241,8 @@ async function handleExport() {
 		a.click();
 		a.remove();
 		URL.revokeObjectURL(url);
-	} catch (err) {
-		exportError = err instanceof Error ? err.message : 'エクスポートに失敗しました';
+	} catch {
+		exportError = ERROR_NOTIFY_LABELS.generic;
 	} finally {
 		exportLoading = false;
 	}
@@ -263,14 +271,18 @@ async function handleCloudExport() {
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ exportType: cloudExportType }),
 		});
-		const d = await res.json();
+		const d = await res.json().catch(() => null);
 		if (!res.ok) {
-			throw new Error(d?.error?.message ?? 'クラウドエクスポートに失敗しました');
+			cloudError = resolveApiErrorMessage(res.status, d?.error?.message ?? '');
+			return;
 		}
-		cloudSuccess = `PINコード: ${d.pinCode}（有効期限: ${new Date(d.expiresAt).toLocaleDateString('ja-JP')}）`;
+		cloudSuccess = SETTINGS_LABELS.cloudExportPinIssued(
+			d.pinCode,
+			new Date(d.expiresAt).toLocaleDateString('ja-JP'),
+		);
 		await loadCloudExports();
-	} catch (err) {
-		cloudError = err instanceof Error ? err.message : 'クラウドエクスポートに失敗しました';
+	} catch {
+		cloudError = ERROR_NOTIFY_LABELS.generic;
 	} finally {
 		cloudLoading = false;
 	}
@@ -280,12 +292,13 @@ async function handleDeleteCloudExport(id: number) {
 	try {
 		const res = await fetch(`/api/v1/export/cloud/${id}`, { method: 'DELETE' });
 		if (!res.ok) {
-			const d = await res.json();
-			throw new Error(d?.error?.message ?? '削除に失敗しました');
+			const d = await res.json().catch(() => null);
+			cloudError = resolveApiErrorMessage(res.status, d?.error?.message ?? '');
+			return;
 		}
 		await loadCloudExports();
-	} catch (err) {
-		cloudError = err instanceof Error ? err.message : '削除に失敗しました';
+	} catch {
+		cloudError = ERROR_NOTIFY_LABELS.generic;
 	}
 }
 
@@ -299,14 +312,15 @@ async function handleCloudImportPreview() {
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ pinCode: cloudImportPin.trim() }),
 		});
-		const d = await res.json();
+		const d = await res.json().catch(() => null);
 		if (!res.ok) {
-			throw new Error(d?.error?.message ?? 'PINコードが無効です');
+			cloudImportError = resolveApiErrorMessage(res.status, d?.error?.message ?? '');
+			return;
 		}
 		cloudImportPreview = d.preview;
 		cloudImportStep = 'preview';
-	} catch (err) {
-		cloudImportError = err instanceof Error ? err.message : 'PINコードが無効です';
+	} catch {
+		cloudImportError = ERROR_NOTIFY_LABELS.generic;
 	} finally {
 		cloudImportLoading = false;
 	}
@@ -318,8 +332,7 @@ async function handleCloudImportExecute() {
 	// ChildSelectionDialog で取込先 child を選択させてから execute する。
 	if (isCloudImportTemplate) {
 		if (importTargetChildren.length === 0) {
-			cloudImportError =
-				'取込先のお子さまが登録されていません。先に /admin/children でお子さま登録をしてください。';
+			cloudImportError = SETTINGS_LABELS.cloudImportNoChildren;
 			return;
 		}
 		childSelectionOpen = true;
@@ -344,14 +357,15 @@ async function executeCloudImport(targetChildIds: number[] | null) {
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(body),
 		});
-		const d = await res.json();
+		const d = await res.json().catch(() => null);
 		if (!res.ok) {
-			throw new Error(d?.error?.message ?? 'インポートに失敗しました');
+			cloudImportError = resolveApiErrorMessage(res.status, d?.error?.message ?? '');
+			return;
 		}
 		cloudImportResult = d.result;
 		cloudImportStep = 'done';
-	} catch (err) {
-		cloudImportError = err instanceof Error ? err.message : 'インポートに失敗しました';
+	} catch {
+		cloudImportError = ERROR_NOTIFY_LABELS.generic;
 	} finally {
 		cloudImportLoading = false;
 	}


### PR DESCRIPTION
## 顧客価値・目的

第9回 develop→main 統合監査 (#3281、finding uiux-1/2/3) で検出した UI 品質の軽微違反 3 件を SSOT / DESIGN.md 整合のためクリーンアップする。いずれも merge 非ブロッカーだが、(1) settings/data のエラー経路が生サーバ message を露出 (info-disclosure 余地)、(2) `.baby-card-*` の hex / 生 z-index 直書き、(3) settings/data のハードコード日本語 が DESIGN.md §2/§6/§10 + error-notify SSOT に反していた。

## 関連 Issue

Closes #3285。原因元: 監査 #3281 uiux-1/2/3。関連: EPIC #3217 (silent-failure 撲滅) / DESIGN.md §2/§6/§10。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| uiux-1 | settings/data の import/export エラーを error-notify 経由に統一 (生 err.message 露出撤去) | `grep err.message settings/data` | HEAD `08d4c61e7` / 全 6 fetch ハンドラを `resolveApiErrorMessage` (500=汎用 / 4xx=sanitize) + catch=`ERROR_NOTIFY_LABELS.generic` に統一。生 err.message 露出 0 |
| uiux-2 | `.baby-card-*` の hex を §2 Semantic トークンに、z-index:10 を `var(--z-*)` に置換 | `npx stylelint app.css` | HEAD `08d4c61e7` / color-no-hex PASS。`#fffbeb`/`#fef3c7`/`#f59e0b`/`#d97706`/`#6366f1` を exact-match トークン化、`z-index:10`=`var(--z-sticky)`。**色不変** |
| uiux-3 | settings/data のハードコード日本語を labels.ts に集約 | `node scripts/check-hardcoded-strings.mjs` | HEAD `08d4c61e7` / 0 violations。検証/PIN/取込先 4 文言を SETTINGS_LABELS に集約 + error fallback JP は error-notify SSOT へ吸収 |
| 共通 | pre-ready 該当 step PASS | check-hardcoded-strings / stylelint color-no-hex | HEAD `08d4c61e7` / 両 PASS。svelte-check 0 errors / biome clean |
| 共通 | 視覚回帰 3 層 (app 層) で .baby-card 回帰なし | app-visual-regression.yml (app 変更で自動実行) | exact-match トークン置換で色不変のため回帰 0 を期待 (CI app-VR job で機械検証) |

## 変更タイプ

- [x] バグ修正

## 影響範囲・変更コンポーネント

- `src/lib/ui/styles/app.css`: `.baby-card-main-quest` / `.baby-main-quest-badge` / `.baby-card__spinner` の hex + 生 z-index を exact-match Semantic トークンへ (色・値不変)。
- `src/routes/(parent)/admin/settings/data/+page.svelte`: 6 fetch ハンドラを error-notify SSOT 経由に。検証/PIN/取込先文言を labels 経由に。
- `src/lib/domain/labels.ts`: SETTINGS_LABELS に 4 文言追加 (既存 namespace、新規 atom なし)。
- 新規トークン / 新規 spec なし — 既存 DESIGN.md §2/§6/§10 ルールの適用のみ (no-doc-impact)。

## テスト & 安全装置セルフチェック

- stylelint color-no-hex (app.css): PASS / check-hardcoded-strings: 0 violations / check-no-plan-literals: OK
- svelte-check (--threshold warning): 0 errors / biome --error-on-warnings: clean
- routes/unit: 316 passed (回帰なし)
- app-visual-regression (.baby-card): CI 自動実行で色不変を機械検証

## スクリーンショット / ビジュアルデモ

**視覚的差分ゼロ** のため `refactor:internal-no-doc-impact` ラベルで SS exempt (#2017 / ADR-0003 §4):
- app.css: hex → **exact-match** Semantic トークン (例: `#fffbeb`=`--color-feedback-warning-bg`)、z-index 値も同値 (`10`=`--z-sticky`) → 描画結果は完全に同一。回帰は AC 指定の **app-visual-regression (app 層、.baby-card)** が CI で機械検証する。
- settings/data: 正常系 UI は labels 経由で同一テキスト。差分はエラー発生時のメッセージのみ (生サーバ message → SSOT 無害化文言) で、レイアウト/見た目の変化なし。
- 新規 spec / トークン追加なし = design-doc impact なし。

## コード品質セルフレビュー (#1481)

- 既存 error-notify SSOT (`resolveApiErrorMessage`) を全 fetch ハンドラで共用 (新機構なし)。
- hex 置換は exact-match を grep で確認し色不変を担保 (visual regression リスク最小)。
- 検証コマンド: `npx stylelint src/lib/ui/styles/app.css` + `node scripts/check-hardcoded-strings.mjs` (HEAD `08d4c61e7`、両 PASS)

## 横展開・影響波及チェック

- uiux-1: settings/data の **全** fetch エラー経路 (6 ハンドラ) を一括是正 (import/export/cloud)。生 err.message 露出を grep で 0 件確認。
- uiux-2: `.baby-card-*` の hex/z-index を全置換。ActivityCard.svelte 等の同型 hex は pre-existing で本監査 (uiux-2 = app.css .baby-card) scope 外。
- uiux-3: import 機能の検証/連携文言を集約。danger-zone / PremiumBadge の pre-existing 文言は本監査の「移設で新規混入した 2 件」scope 外。

## レビュー依頼事項・破壊的変更

破壊的変更なし。error メッセージが context-specific (「インポートに失敗しました」) から SSOT 無害化文言に変わる点 (error-notify 統一の意図的挙動) をご確認ください。app.css の色は exact-match で不変です。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 3 finding (uiux-1/2/3) 全対応 + lint gate PASS
- [x] AC 全行に検証手段 + エビデンス
- [x] 横展開確認済 (全 fetch 経路 + scope 境界明記)
- [x] 視覚的差分ゼロを根拠付きで明記 (exact-match + app-VR)

## QM レビュー結果

(QM チーム記入欄)
