### PR TITLE
fix(data-integrity): #3284 チャレンジ報酬受取の二重付与窓を冪等ゲートで根治

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -740,12 +740,14 @@ per-child チャレンジ instance。旧 `sibling_challenges` (family-wide + 別
 | target_value | INTEGER | NO | - | 年齢調整済み目標値 |
 | completed | INTEGER | NO | 0 | 達成フラグ |
 | completed_at | TEXT | YES | - | 達成日時 |
-| reward_claimed | INTEGER | NO | 0 | 報酬受取フラグ |
+| reward_claimed | INTEGER | NO | 0 | 報酬受取フラグ。**#3284 でポイント二重付与防止の冪等ゲートに昇格** (下記) |
 | reward_claimed_at | TEXT | YES | - | 報酬受取日時 |
 | created_at | TEXT | NO | CURRENT_TIMESTAMP | 作成日時 |
 | updated_at | TEXT | NO | CURRENT_TIMESTAMP | 更新日時 |
 
 **インデックス:** (child_id, status), (start_date, end_date), source_template_id
+
+**報酬受取の冪等性 (#3284):** `claimChildChallengeReward` は `claimReward` を **ledger insert より先に** 実行し、`reward_claimed = 0` の行のみを 0→1 に条件付き更新する (SQLite=`WHERE reward_claimed = 0` の changes 数 / DynamoDB=`ConditionExpression: rewardClaimed <> :one`)。実際に flip した場合のみ point_ledger に `type='child_challenge'` を insert するため、並行 claim / 再試行の 2 回目は flip が false を返し ledger 二重 insert を行わない (二重付与窓の根治)。`reward_claimed` フラグ自体が「(child, challenge) 単位の冪等キー」として機能する。**point_ledger 側の `UNIQUE(child_id, type, reference_id)` 案は不採用**: `type='special_reward'` (ごほうび購入) は同一 `reference_id`(=reward.id) で正当に複数回 insert される (繰り返し購入) ため、ledger に blanket UNIQUE を張ると正当な再購入を破壊する。冪等性は付与経路ごとの自然キー (challenge は reward_claimed フラグ) で担保する。
 
 #### DynamoDB キー設計（single-table、#2824 / ADR-0055 Phase 2B）
 

--- a/src/lib/server/db/demo/child-challenge-repo.ts
+++ b/src/lib/server/db/demo/child-challenge-repo.ts
@@ -127,8 +127,9 @@ export async function markCompleted(_id: number, _tenantId: string): Promise<voi
 	// Stub: no-op
 }
 
-export async function claimReward(_id: number, _tenantId: string): Promise<void> {
-	// Stub: no-op
+export async function claimReward(_id: number, _tenantId: string): Promise<boolean> {
+	// #3284: demo は client-side state (永続なし) のため best-effort で true を返す。
+	return true;
 }
 
 export async function update(

--- a/src/lib/server/db/dynamodb/child-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/child-challenge-repo.ts
@@ -282,18 +282,28 @@ export async function markCompleted(id: number, tenantId: string): Promise<void>
 	);
 }
 
-export async function claimReward(id: number, tenantId: string): Promise<void> {
+export async function claimReward(id: number, tenantId: string): Promise<boolean> {
 	const key = await resolveKeyById(id, tenantId);
-	if (!key) return;
+	if (!key) return false;
 	const now = new Date().toISOString();
-	await getDocClient().send(
-		new UpdateCommand({
-			TableName: TABLE_NAME,
-			Key: key,
-			UpdateExpression: 'SET rewardClaimed = :one, rewardClaimedAt = :now, updatedAt = :now',
-			ExpressionAttributeValues: { ':one': 1, ':now': now },
-		}),
-	);
+	// #3284: rewardClaimed <> 1 の条件付き UpdateItem (二重付与防止の原子ゲート)。
+	// 既に受取済なら ConditionalCheckFailedException → false を返し ledger 二重 insert を防ぐ
+	// (SQLite の `WHERE reward_claimed = 0` と等価、#3258 SQLite⇔DynamoDB 等価契約)。
+	try {
+		await getDocClient().send(
+			new UpdateCommand({
+				TableName: TABLE_NAME,
+				Key: key,
+				UpdateExpression: 'SET rewardClaimed = :one, rewardClaimedAt = :now, updatedAt = :now',
+				ConditionExpression: 'rewardClaimed <> :one',
+				ExpressionAttributeValues: { ':one': 1, ':now': now },
+			}),
+		);
+		return true;
+	} catch (err) {
+		if (err instanceof Error && err.name === 'ConditionalCheckFailedException') return false;
+		throw err;
+	}
 }
 
 /** UpdateChildChallengeInput で渡された field のみ更新する (SQLite .set({...}) 等価)。 */

--- a/src/lib/server/db/interfaces/child-challenge-repo.interface.ts
+++ b/src/lib/server/db/interfaces/child-challenge-repo.interface.ts
@@ -67,8 +67,14 @@ export interface IChildChallengeRepo {
 	/** 完了マーク (currentValue >= targetValue 達成時) */
 	markCompleted(id: number, tenantId: string): Promise<void>;
 
-	/** ごほうび受取マーク */
-	claimReward(id: number, tenantId: string): Promise<void>;
+	/**
+	 * ごほうび受取マーク (#3284: 二重付与防止の冪等ゲート)。
+	 * `rewardClaimed = 0` の行のみを 0→1 に条件付き更新し、実際に flip したかを返す。
+	 * 既に受取済 (= 並行 / 再試行の 2 回目) なら false を返し、呼び出し側は ledger insert を行わない。
+	 * SQLite は `WHERE reward_claimed = 0` の changes 数、DynamoDB は ConditionExpression で原子的に判定する。
+	 * @returns このコールで実際に受取済へ flip した場合 true / 既に受取済なら false
+	 */
+	claimReward(id: number, tenantId: string): Promise<boolean>;
 
 	/** メタ更新 (status / 期間 / target / reward 変更) */
 	update(id: number, input: UpdateChildChallengeInput, tenantId: string): Promise<void>;

--- a/src/lib/server/db/sqlite/child-challenge-repo.ts
+++ b/src/lib/server/db/sqlite/child-challenge-repo.ts
@@ -203,12 +203,16 @@ export async function markCompleted(id: number, _tenantId: string): Promise<void
 		.run();
 }
 
-export async function claimReward(id: number, _tenantId: string): Promise<void> {
+export async function claimReward(id: number, _tenantId: string): Promise<boolean> {
 	const now = new Date().toISOString();
-	db.update(childChallenges)
+	// #3284: reward_claimed = 0 の行のみ 0→1 に条件付き更新 (二重付与防止の原子ゲート)。
+	// changes が 0 = 既に受取済 (並行/再試行の 2 回目) → false を返し ledger 二重 insert を防ぐ。
+	const result = db
+		.update(childChallenges)
 		.set({ rewardClaimed: 1, rewardClaimedAt: now, updatedAt: now })
-		.where(eq(childChallenges.id, id))
+		.where(and(eq(childChallenges.id, id), eq(childChallenges.rewardClaimed, 0)))
 		.run();
+	return result.changes > 0;
 }
 
 export async function update(

--- a/src/lib/server/services/child-challenge-service.ts
+++ b/src/lib/server/services/child-challenge-service.ts
@@ -710,6 +710,13 @@ export async function claimChildChallengeReward(
 	if (challenge.rewardClaimed === 1) return { error: 'すでに受け取り済みです' };
 
 	const rewardConfig: RewardConfig = JSON.parse(challenge.rewardConfig);
+	// #3284: 二重付与防止。claimReward を **先に** 条件付き flip (reward_claimed 0→1) し、実際に
+	// 受取済へ遷移した場合のみ ledger を insert する。並行 / 再試行の 2 回目は flip が false を返し
+	// ledger 二重 insert を行わない (旧実装は ledger insert → claim の順で、間の error / 再試行で
+	// 二重付与窓が残っていた)。ledger の冪等キー (UNIQUE) 案は special_reward 等が同一 referenceId で
+	// 正当に複数 insert するため不採用 (#3284 設計判断、08-DB 設計書参照)。
+	const claimed = await repos.childChallenge.claimReward(challengeId, tenantId);
+	if (!claimed) return { error: 'すでに受け取り済みです' };
 	await insertPointLedger(
 		{
 			childId,
@@ -720,7 +727,6 @@ export async function claimChildChallengeReward(
 		},
 		tenantId,
 	);
-	await repos.childChallenge.claimReward(challengeId, tenantId);
 	return { points: rewardConfig.points, message: rewardConfig.message };
 }
 

--- a/tests/unit/db/dynamodb-child-challenge-repo.test.ts
+++ b/tests/unit/db/dynamodb-child-challenge-repo.test.ts
@@ -463,19 +463,39 @@ describe('markCompleted', () => {
 });
 
 describe('claimReward', () => {
-	it('rewardClaimed=1 を Update する', async () => {
+	it('rewardClaimed=1 を条件付き Update し true を返す (#3284 ConditionExpression)', async () => {
 		mockSend
 			.mockResolvedValueOnce({
 				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDCHAL#00000001' }],
 			})
 			.mockResolvedValueOnce({});
 		const { claimReward } = await loadRepo();
-		await claimReward(1, TENANT);
+		const claimed = await claimReward(1, TENANT);
+		expect(claimed).toBe(true);
 		const upd = mockSend.mock.calls[1]?.[0] as {
-			input: { UpdateExpression?: string; ExpressionAttributeValues?: Record<string, unknown> };
+			input: {
+				UpdateExpression?: string;
+				ConditionExpression?: string;
+				ExpressionAttributeValues?: Record<string, unknown>;
+			};
 		};
 		expect(upd.input.UpdateExpression).toContain('rewardClaimed = :one');
 		expect(upd.input.ExpressionAttributeValues?.[':one']).toBe(1);
+		// #3284: 既に受取済 (rewardClaimed=1) を弾く原子ゲート
+		expect(upd.input.ConditionExpression).toBe('rewardClaimed <> :one');
+	});
+
+	it('既に受取済 (ConditionalCheckFailed) では false を返す (二重付与防止、SQLite changes=0 と対称)', async () => {
+		const condErr = new Error('conditional check failed');
+		condErr.name = 'ConditionalCheckFailedException';
+		mockSend
+			.mockResolvedValueOnce({
+				Items: [{ PK: `T#${TENANT}#CHILD#${CHILD_ID}`, SK: 'CHILDCHAL#00000001' }],
+			})
+			.mockRejectedValueOnce(condErr);
+		const { claimReward } = await loadRepo();
+		const claimed = await claimReward(1, TENANT);
+		expect(claimed).toBe(false);
 	});
 });
 

--- a/tests/unit/server/db/sqlite/child-challenge-repo.test.ts
+++ b/tests/unit/server/db/sqlite/child-challenge-repo.test.ts
@@ -236,4 +236,34 @@ describe('sqlite/child-challenge-repo', () => {
 		expect(sharedInstances.length).toBe(2);
 		expect(new Set(sharedInstances.map((c) => c.childId))).toEqual(new Set([1, 2]));
 	});
+
+	// #3284: claimReward は reward_claimed=0 の行のみ 0→1 に条件付き flip し、実際に flip したかを返す。
+	// 並行 / 再試行の 2 回目は false を返す (= ledger 二重 insert を呼び出し側が防げる冪等ゲート)。
+	describe('#3284 claimReward 冪等ゲート (二重付与防止)', () => {
+		it('初回 claim は true、2 回目以降は false を返す (条件付き 0→1 flip)', async () => {
+			const c = await insert(
+				buildInput({
+					childId: 1,
+					title: 'claim-idem',
+					startDate: '2026-06-01',
+					endDate: '2026-06-07',
+				}),
+				TENANT,
+			);
+			await markCompleted(c.id, TENANT);
+
+			const first = await claimReward(c.id, TENANT);
+			expect(first).toBe(true); // 0→1 に flip
+
+			const second = await claimReward(c.id, TENANT);
+			expect(second).toBe(false); // 既に 1 → no-op (二重付与窓なし)
+
+			const third = await claimReward(c.id, TENANT);
+			expect(third).toBe(false);
+
+			// flag は 1 のまま (冪等)
+			const row = await findById(c.id, TENANT);
+			expect(row?.rewardClaimed).toBe(1);
+		});
+	});
 });


### PR DESCRIPTION
## 顧客価値・目的

ごほうび (チャレンジ報酬) のポイント付与で、`claimChildChallengeReward` が ledger insert → claim フラグ更新の順だったため、2 呼び出しの間に error / 再試行 / 並行 claim が起きると **ポイントが二重付与される窓** が残っていた (監査 #3281 cuj-orch-1、pre-existing latent)。ポイントは子供の達成の対価であり、二重付与は整合性破壊。本 PR で claim を冪等ゲート化し二重付与窓を根治する。

## 関連 Issue

Closes #3284。原因元: 監査 #3281 cuj-orch-1。関連: #3245 (別経路の atomic 化) / #3258 (SQLite⇔DynamoDB 等価教訓)。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 同一報酬の二重付与を DB 層で弾く冪等性を導入 | unit (sqlite + dynamodb repo) | HEAD `511643c11` / `reward_claimed` フラグを冪等キーに昇格。SQLite=`WHERE reward_claimed=0` の changes 数、DynamoDB=`ConditionExpression: rewardClaimed <> :one` で原子判定。**注: ledger UNIQUE 案は不採用** — special_reward が同一 reference_id で正当に複数 insert (繰り返し購入) するため (本文「設計判断」) |
| AC2 | claim の ledger insert + flag 更新を二重付与窓が消えるよう冪等/atomic 化 | コード (`child-challenge-service.ts:claimChildChallengeReward`) | HEAD `511643c11` / claim を **ledger insert より先に** 条件付き flip し、flip した場合のみ ledger insert する claim-first 方式。並行/再試行の 2 回目は flip=false で ledger 二重 insert なし |
| AC3 | concurrent claim 模擬 unit test (2 回 claim → ledger 1 / balance 1) を **両 backend 対称**に追加 | `npx vitest run ...child-challenge-repo.test.ts` | HEAD `511643c11` / SQLite: 初回 true / 2-3 回目 false + flag=1 維持。DynamoDB: ConditionExpression 送出 + ConditionalCheckFailed→false。両 backend 対称 (#3258 教訓) |
| AC4 | 08-DB 設計書に冪等制約を記載 | `docs/design/08-データベース設計書.md` §child_challenges | HEAD `511643c11` / reward_claimed の冪等ゲート + ledger UNIQUE 不採用理由を記載 |

## 変更タイプ

- [x] バグ修正

## 影響範囲・変更コンポーネント

- `child-challenge-service.ts`: `claimChildChallengeReward` を claim-first 冪等ゲート方式に。flip=false なら「すでに受け取り済み」を返し ledger insert しない。
- `child-challenge-repo` interface + sqlite/dynamodb/demo: `claimReward` を `Promise<boolean>` に (条件付き flip 有無を返す)。SQLite=conditional UPDATE changes / DynamoDB=ConditionExpression / demo=best-effort true。
- tests: sqlite repo 冪等ゲート test + dynamodb ConditionExpression/ConditionalCheckFailed test。
- `docs/design/08-データベース設計書.md`: §child_challenges 冪等性記載。
- スキーマ変更なし (既存 reward_claimed フラグを冪等キーに活用)。.svelte 変更なし。

## テスト & 安全装置セルフチェック

- unit: child-challenge sqlite/dynamodb/service = 75 passed (新規冪等ゲート test 含む)。db 層全体 494 passed (回帰なし)
- svelte-check: 0 errors / biome --error-on-warnings: clean
- DynamoDB stub parity / 等価契約: claimReward を両 backend で boolean 化し対称検証

## スクリーンショット / ビジュアルデモ

サーバ side のデータ整合性ロジック修正のみ (.svelte / CSS 変更なし)。冪等ゲートの挙動は unit で決定的に検証 (AC3)。UI 表示の変化なし。

## コード品質セルフレビュー (#1481)

- 既存 `reward_claimed` フラグを冪等キーに活用 (新 schema / 新 index なし、migration 不要)。
- claim-first + 条件付き flip は SQLite (changes) / DynamoDB (ConditionExpression) の原子性プリミティブを各々活用 (#2845 同型)。
- 検証: `npx vitest run tests/unit/server/db/sqlite/child-challenge-repo.test.ts tests/unit/db/dynamodb-child-challenge-repo.test.ts` (HEAD `511643c11`)

## 横展開・影響波及チェック

- `claimReward` の全呼び出し元 (service 1 + test 3) を確認。service は boolean を利用、test は破棄 (挙動不変)。
- ledger 冪等性は付与経路ごとの自然キーで担保する方針を確立 (challenge=reward_claimed フラグ)。special_reward 等の繰り返し購入は ledger 複数 insert が正当のため UNIQUE を張らない。
- under-grant トレードオフ: claim flip 成功後に ledger insert が稀に throw した場合「受取済だが未付与」になりうるが、(a) 二重付与 (旧挙動) より軽微 + admin 復旧可能、(b) ledger insert 失敗は極稀。二重付与窓の根治を優先。

## レビュー依頼事項・破壊的変更

破壊的変更なし。`claimReward` の戻り型が `void`→`boolean` に変わる (内部 repo API)。AC1 で ledger UNIQUE を採用しなかった設計判断 (special_reward 繰り返し購入との両立) のレビューをお願いします。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 二重付与窓を冪等ゲートで根治 + 両 backend 対称 test
- [x] 設計書同期 (08-DB §child_challenges)
- [x] AC 全行に検証手段 + エビデンス (AC1 の設計判断を明記)
- [x] 横展開確認済 (全呼び出し元 + under-grant トレードオフ明記)

## QM レビュー結果

(QM チーム記入欄)
