### PR TITLE
refactor: #3239 CHALLENGES_LABELS の dead label 49 件削除 (チャレンジ一本化の残骸)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -3556,100 +3556,23 @@ export const DEMO_SIGNUP_LABELS = {
 // ============================================================
 
 export const CHALLENGES_LABELS = {
-	// Family streak
+	// #3239: チャレンジ一本化 (#3195/#3231: アプリ週次自動生成 + 読み取り専用ビュー) に伴い、
+	// manual 作成フォーム / 一括 import 確認 UI / カテゴリ重複 (GROWTH_BOOK_LABELS と重複) の
+	// dead label (参照ゼロ) を削除。残すのは admin/challenges + setup/challenges が実参照する
+	// 13 key のみ (ADR-0045 labels SSOT 整合)。sectionTitle 等の訴求文言の現モデル整合は別途 PO 判断。
 	familyStreakTitle: (days: number) => `家族ストリーク: ${days}日`,
-	familyStreakRecorded: (count: number) => `今日は${count}人が記録済み`,
-	familyStreakNone: '今日はまだ誰も記録していません',
-	familyStreakMilestone: (remaining: number, days: number, points: number) =>
-		`あと${remaining}日で${days}日ボーナス（+${points}P）`,
-
-	// #3222 (#3193): チャレンジ全プラン開放に伴い「ファミリープラン限定機能」notice 文言を撤去
-	// (familyPlanTitle/Desc/Button は dead label 化、UI 参照ゼロ)。きょうだいランキングの
-	// family 限定は SETTINGS_LABELS.siblingRanking* が別途担う。
-
-	// Challenge section
 	sectionTitle: '👥 きょうだいチャレンジ',
-	cancelButton: 'キャンセル',
-	createButton: '＋ 新規チャレンジ',
-
-	// Notifications
-	createdNotice: 'チャレンジを作成しました',
 	deletedNotice: 'チャレンジを削除しました',
-
-	// Create form
-	formTitle: '新規チャレンジ作成',
-	titleLabel: 'タイトル',
-	titlePlaceholder: 'みんなで今週3回うんどう！',
-	descLabel: '説明（任意）',
-	descPlaceholder: '家族みんなでうんどうしよう',
-	typeLabel: '種別',
-	typeCooperative: '協力',
-	periodLabel: '期間',
-	periodWeekly: '週間',
-	periodMonthly: '月間',
-	periodCustom: 'カスタム',
-	categoryLabel: 'カテゴリ（任意）',
-	categoryAll: '全カテゴリ',
-	startDateLabel: '開始日',
-	endDateLabel: '終了日',
-	targetLabel: '目標回数',
-	rewardPointsLabel: '報酬ポイント',
-	rewardMessageLabel: '達成メッセージ（任意）',
-	rewardMessagePlaceholder: 'みんなすごい！',
-	submitButton: '作成',
-
-	// #2296 (EPIC #2294 ②): 説明文ヘッダ + empty state CTA + テンプレ導線 (2026-05-19)
-	// Research §3.2 (Harvard Health / UNH SAARA / ADR-0012 §6) で兄弟競争は厳禁。
-	// 協力タイプで家族コミュニケーションを促進する文言に統一。
-	headerDesc:
-		'家族で目標を決めて、いっしょに達成するきょうだいチャレンジ。兄弟が協力して取り組むことで、家族のコミュニケーションを促進します。',
-
-	// Empty state
 	noChallengeTitleIcon: '👥',
 	noChallengeTitle: 'チャレンジはまだありません',
-	noChallengeDesc: '上のボタンから作成してください',
-	emptyStateDesc:
-		'まずはテンプレートから始めてみませんか？家族の現実時間に合わせたチャレンジを選べます。',
-	emptyStateOrCreate: '自分で作る場合は上の「新規チャレンジ」ボタンから。',
-	templateCta: '🎁 テンプレートから始める',
-
-	// Challenge card
 	badgeAllCompleted: '全員クリア！',
 	badgeActive: '開催中',
-	badgeExpired: '終了',
-	targetGoal: (count: number) => `目標${count}回`,
 	rewardLabel: (points: number) => `報酬${points}P`,
 	deleteButton: '削除',
-	deleteConfirm: (title: string) => `「${title}」を削除しますか？`,
-
 	dateSeparator: ' 〜 ',
-
-	// Challenge type/period labels
-	typeLabelCooperative: '協力',
 	periodLabelWeekly: '週間',
 	periodLabelMonthly: '月間',
 	periodLabelCustom: 'カスタム',
-
-	// Category names (same as GROWTH_BOOK_LABELS)
-	categoryUndou: 'うんどう',
-	categoryBenkyou: 'べんきょう',
-	categorySeikatsu: 'せいかつ',
-	categoryKouryuu: 'こうりゅう',
-	categorySouzou: 'そうぞう',
-
-	// #2297 (EPIC #2294 ③): マーケプレ challenge-set 一括 import 確認 UI
-	importIcon: '🎯',
-	importHeading: (presetName: string) => `「${presetName}」を一括追加します`,
-	importTotalDesc: (count: number) =>
-		`合計 ${count}件のチャレンジを追加します。期間は当該行事の日付から自動展開されます。`,
-	importBreakdownSummary: '内訳を確認',
-	importItemSuffix: (monthDay: string, durationDays: number) =>
-		`（${monthDay} ・ ${durationDays}日間）`,
-	importCancel: 'キャンセル',
-	importSubmit: (count: number) => `${count}件 一括追加`,
-	importSuccessNotice: (presetName: string, count: number) =>
-		`✨ 「${presetName}」から ${count}件のチャレンジを追加しました`,
-	importErrorSummary: (count: number) => `エラー詳細 (${count}件)`,
 } as const;
 
 // ============================================================


### PR DESCRIPTION
## 顧客価値・目的

#3195/#3231 のチャレンジ一本化 (アプリ週次自動生成 + 読み取り専用ビューへ移行) で、`CHALLENGES_LABELS` の manual 作成フォーム / 一括 import 確認 UI / カテゴリ重複 label が **参照ゼロの dead code** 化していた (監査 #3238 QM adversarial 検出)。ADR-0045 (labels SSOT) 整合のため削除し、保守時の誤用・認知負荷を減らす。

## 関連 Issue

#3239 (Part 1 = dead label 削除を本 PR で対応)。原因元: PR #3238 (#3222) QM 再レビュー adversarial。Part 2 (sectionTitle/訴求文言の現モデル整合) は **copy/PO 判断が必要**のため本 PR scope 外 (下記)。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| Part 1 | manual 作成 UI 撤去に伴う dead label を参照ゼロ確認後に削除 | `grep CHALLENGES_LABELS.<key>` 全 .svelte/.ts | HEAD `15a658545` / 62→13 key。destructure (`= CHALLENGES_LABELS`) / dynamic (`CHALLENGES_LABELS[`) 無しを確認し、dotted-ref grep を権威とした。49 key 削除 |
| Part 1 | 削除後に残存参照が無い (機械担保) | `npx svelte-check` | HEAD `15a658545` / 0 errors。`as const` のため削除 key へのアクセスは TS error になる = 残存参照ゼロを型で保証 |
| Part 1 | lint gate PASS | check-hardcoded-strings / check-no-plan-literals / biome | HEAD `15a658545` / 全 PASS。LP labels (generate-lp-labels --check) も不変 (CHALLENGES_LABELS は非 LP) |
| Part 2 | sectionTitle/訴求文言の現モデル整合 | — (copy/PO 判断) | 本 PR scope 外。auto-gen challenge の正しい呼称・説明は PO 確認後に是正 (レビュー依頼事項に明記、#3239 を open 維持) |

## 変更タイプ

- [x] リファクタリング

## 影響範囲・変更コンポーネント

- `src/lib/domain/labels.ts`: `CHALLENGES_LABELS` を 62→13 key に削減 (-81/+4 行)。残存 13 key = admin/challenges + setup/challenges の 2 .svelte が実参照するもののみ (familyStreakTitle / sectionTitle / deletedNotice / noChallengeTitleIcon / noChallengeTitle / badgeAllCompleted / badgeActive / rewardLabel / deleteButton / dateSeparator / periodLabelWeekly/Monthly/Custom)。
- 削除した dead label: 作成フォーム系 (createButton/formTitle/titleLabel/.../submitButton) + 一括 import 確認系 (importIcon/.../importErrorSummary) + カテゴリ重複 (categoryUndou 等、GROWTH_BOOK_LABELS と重複) + familyStreak 詳細 / empty-state CTA 等。
- .svelte / CSS / src/routes / 設計書 変更なし (純粋な dead-code 削除)。

## テスト & 安全装置セルフチェック

- svelte-check: 0 errors (削除 key への残存アクセスを型で機械検出)
- biome --error-on-warnings: clean / check-hardcoded-strings: baseline 内 / check-no-plan-literals: OK
- routes + child-challenge-service test: 32 passed (回帰なし)

## スクリーンショット / ビジュアルデモ

UI コード (.svelte) / CSS 変更なし。dead label (どの .svelte からも参照されていない object property) の削除のみのため、描画・見た目への影響はゼロ (svelte-check 0 errors が残存参照ゼロを保証)。

## コード品質セルフレビュー (#1481)

- 削除前に destructure / dynamic access の不在を grep で確認し、dotted-ref を権威化 (誤削除防止)。
- `as const` の型システムを安全網に活用 (削除 key アクセスは svelte-check で必ず fail)。
- 検証: `npx svelte-check` (HEAD `15a658545`、0 errors)

## 横展開・影響波及チェック

- CHALLENGES_LABELS を参照する .svelte は 2 ファイルのみ (admin/challenges + setup/challenges)、いずれも残存 13 key のみ使用。
- DEMO_CHALLENGES_LABELS / SETUP_CHALLENGES_LABELS は別 const で CHALLENGES_LABELS を spread/参照しない (独立) ことを確認。
- LP labels (shared-labels.js) は CHALLENGES_LABELS 非依存 (generate-lp-labels --check 不変)。

## レビュー依頼事項・破壊的変更

破壊的変更なし (dead-code 削除)。**Part 2 (sectionTitle「👥 きょうだいチャレンジ」/ 訴求文言が現 auto-gen モデルと乖離している件) は copy/PO 判断が必要なため本 PR では触れていません** (sectionTitle は現行 admin で live のため値は維持)。auto-gen challenge の正しい呼称・説明を PO にご確認いただき次第、是正します (#3239 を open 維持)。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] dead label を参照ゼロ確認後に削除 (svelte-check 0 errors で機械担保)
- [x] AC (Part 1) 全行に検証手段 + エビデンス
- [x] 横展開確認済 (参照 .svelte 2 件 + 独立 const + LP 非依存)
- [x] Part 2 (PO 判断) を scope 外として明記

## QM レビュー結果

(QM チーム記入欄)
