### PR TITLE
test: #3209 checkout 失敗 path の test 補完 (503 STRIPE_DISABLED + network throw)

### DIFF
--- a/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
+++ b/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
@@ -70,6 +70,53 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 		await expect(page.getByText('プランが正しくありません')).toBeVisible({ timeout: 8_000 });
 	});
 
+	// #3209: 503 STRIPE_DISABLED (demo/staging 頻出) path の test 補完。汎用「時間をおいて再度…」
+	// でなく STRIPE_DISABLED 専用の server message ('決済機能は現在利用できません') が surface され、
+	// retry 不能状況で誤って再試行を促さないことを検証する (#3205 で未 test だった branch)。
+	test('checkout 失敗 (503 STRIPE_DISABLED) で専用 server message を提示する (#3209)', async ({
+		page,
+	}) => {
+		// SvelteKit error(503, '決済機能は現在利用できません') 相当の body
+		await page.route('/api/stripe/checkout', async (route) => {
+			await route.fulfill({
+				status: 503,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: '決済機能は現在利用できません' }),
+			});
+		});
+
+		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
+		if (!(await skipIfStripeDisabled(page))) return;
+
+		await page.getByTestId('family-plan-card').click();
+		await page.getByRole('button', { name: /プランで始める/ }).click();
+
+		// STRIPE_DISABLED 専用文言が surface され、汎用 retry 文言ではないこと (Part 2 整合)
+		await expect(page.getByText('決済機能は現在利用できません')).toBeVisible({ timeout: 8_000 });
+	});
+
+	// #3209: network throw (fetch reject = catch branch) path の test 補完。catch 分岐でも
+	// silent no-op せず汎用 feedback (checkoutFailed) が提示されることを検証する。
+	test('checkout 失敗 (network throw / catch branch) で silent no-op せずエラーを提示する (#3209)', async ({
+		page,
+	}) => {
+		// route.abort() で fetch を reject させ catch branch を発火させる
+		await page.route('/api/stripe/checkout', async (route) => {
+			await route.abort('failed');
+		});
+
+		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
+		if (!(await skipIfStripeDisabled(page))) return;
+
+		await page.getByTestId('family-plan-card').click();
+		await page.getByRole('button', { name: /プランで始める/ }).click();
+
+		// catch 分岐の汎用 feedback が提示されること (silent no-op でない)
+		await expect(page.getByText('決済を開始できませんでした', { exact: false })).toBeVisible({
+			timeout: 8_000,
+		});
+	});
+
 	test('月額 planId (monthly / family-monthly) が checkout に送信される (mock)', async ({
 		page,
 	}) => {

--- a/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
+++ b/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
@@ -77,7 +77,9 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 		page,
 	}) => {
 		// SvelteKit error(503, '決済機能は現在利用できません') 相当の body
+		let checkoutCallCount = 0;
 		await page.route('/api/stripe/checkout', async (route) => {
+			checkoutCallCount += 1;
 			await route.fulfill({
 				status: 503,
 				contentType: 'application/json',
@@ -88,11 +90,37 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
 		if (!(await skipIfStripeDisabled(page))) return;
 
-		await page.getByTestId('family-plan-card').click();
-		await page.getByRole('button', { name: /プランで始める/ }).click();
+		// hydration ゲート: skipIfStripeDisabled は SSR 描画済 plan card の visible のみ待つため、
+		// interactive island の hydration 完了前に click すると onclick が発火しない。plan card 選択
+		// (selectedTier) が checkout button label に反映される (= hydration 完了) まで poll-click し、
+		// 確実に interactive 化を待ってから checkout を起動する (flaky 防止)。card click は checkout を
+		// 呼ばないため checkoutCallCount には影響しない。
+		await page.waitForLoadState('load');
+		await expect(async () => {
+			await page.getByTestId('family-plan-card').click();
+			await expect(page.getByRole('button', { name: 'プレミアムプランで始める' })).toBeVisible({
+				timeout: 1_000,
+			});
+		}).toPass({ timeout: 15_000 });
+
+		const checkoutBtn = page.getByRole('button', { name: /プランで始める/ });
+		await checkoutBtn.click();
 
 		// STRIPE_DISABLED 専用文言が surface され、汎用 retry 文言ではないこと (Part 2 整合)
-		await expect(page.getByText('決済機能は現在利用できません')).toBeVisible({ timeout: 8_000 });
+		// 2 層 feedback (Alert banner + Toast、DESIGN.md §5) で同一文言が複数描画されるため first()
+		await expect(page.getByText('決済機能は現在利用できません').first()).toBeVisible({ timeout: 8_000 });
+
+		// fail-closed①: Stripe checkout へ遷移せず元 plan ページに留まること。
+		// 実装 (SaasLicensePanel.startCheckout) は res.ok && data.url の時のみ
+		// window.location.href = data.url で遷移し、503 失敗時は遷移しない不変条件。
+		await expect(page).toHaveURL(/\/admin\/subscription/);
+		expect(page.url()).not.toContain('stripe');
+
+		// fail-closed②: button が loading/disabled に stuck せず再 enable され、
+		// 単一 click で checkout API が二重起動しないこと (finally で checkoutLoading=false)。
+		await expect(checkoutBtn).toBeEnabled();
+		await expect(checkoutBtn).not.toHaveAttribute('aria-busy', 'true');
+		expect(checkoutCallCount).toBe(1);
 	});
 
 	// #3209: network throw (fetch reject = catch branch) path の test 補完。catch 分岐でも
@@ -101,20 +129,47 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 		page,
 	}) => {
 		// route.abort() で fetch を reject させ catch branch を発火させる
+		let checkoutCallCount = 0;
 		await page.route('/api/stripe/checkout', async (route) => {
+			checkoutCallCount += 1;
 			await route.abort('failed');
 		});
 
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
 		if (!(await skipIfStripeDisabled(page))) return;
 
-		await page.getByTestId('family-plan-card').click();
-		await page.getByRole('button', { name: /プランで始める/ }).click();
+		// hydration ゲート: skipIfStripeDisabled は SSR 描画済 plan card の visible のみ待つため、
+		// interactive island の hydration 完了前に click すると onclick が発火しない。plan card 選択
+		// (selectedTier) が checkout button label に反映される (= hydration 完了) まで poll-click し、
+		// 確実に interactive 化を待ってから checkout を起動する (flaky 防止)。card click は checkout を
+		// 呼ばないため checkoutCallCount には影響しない。
+		await page.waitForLoadState('load');
+		await expect(async () => {
+			await page.getByTestId('family-plan-card').click();
+			await expect(page.getByRole('button', { name: 'プレミアムプランで始める' })).toBeVisible({
+				timeout: 1_000,
+			});
+		}).toPass({ timeout: 15_000 });
+
+		const checkoutBtn = page.getByRole('button', { name: /プランで始める/ });
+		await checkoutBtn.click();
 
 		// catch 分岐の汎用 feedback が提示されること (silent no-op でない)
-		await expect(page.getByText('決済を開始できませんでした', { exact: false })).toBeVisible({
+		// 2 層 feedback (Alert banner + Toast、DESIGN.md §5) で同一文言が複数描画されるため first()
+		await expect(page.getByText('決済を開始できませんでした', { exact: false }).first()).toBeVisible({
 			timeout: 8_000,
 		});
+
+		// fail-closed①: catch branch でも Stripe checkout へ遷移しないこと。
+		// window.location.href は成功時のみ set されるため、fetch reject 時は元 plan ページに留まる。
+		await expect(page).toHaveURL(/\/admin\/subscription/);
+		expect(page.url()).not.toContain('stripe');
+
+		// fail-closed②: button が loading/disabled に stuck せず再 enable され、
+		// 単一 click で checkout API が二重起動しないこと (finally で checkoutLoading=false)。
+		await expect(checkoutBtn).toBeEnabled();
+		await expect(checkoutBtn).not.toHaveAttribute('aria-busy', 'true');
+		expect(checkoutCallCount).toBe(1);
 	});
 
 	test('月額 planId (monthly / family-monthly) が checkout に送信される (mock)', async ({

--- a/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
+++ b/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
@@ -108,7 +108,9 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 
 		// STRIPE_DISABLED 専用文言が surface され、汎用 retry 文言ではないこと (Part 2 整合)
 		// 2 層 feedback (Alert banner + Toast、DESIGN.md §5) で同一文言が複数描画されるため first()
-		await expect(page.getByText('決済機能は現在利用できません').first()).toBeVisible({ timeout: 8_000 });
+		await expect(page.getByText('決済機能は現在利用できません').first()).toBeVisible({
+			timeout: 8_000,
+		});
 
 		// fail-closed①: Stripe checkout へ遷移せず元 plan ページに留まること。
 		// 実装 (SaasLicensePanel.startCheckout) は res.ok && data.url の時のみ
@@ -156,7 +158,9 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 
 		// catch 分岐の汎用 feedback が提示されること (silent no-op でない)
 		// 2 層 feedback (Alert banner + Toast、DESIGN.md §5) で同一文言が複数描画されるため first()
-		await expect(page.getByText('決済を開始できませんでした', { exact: false }).first()).toBeVisible({
+		await expect(
+			page.getByText('決済を開始できませんでした', { exact: false }).first(),
+		).toBeVisible({
 			timeout: 8_000,
 		});
 


### PR DESCRIPTION
## 顧客価値・目的

PR #3205 で checkout の silent-fail を Toast/Alert の 2 層 feedback で根治したが、regression spec は **400 path のみ** test で、demo/staging 頻出の **503 STRIPE_DISABLED** と **network throw (catch branch)** が未 test だった。本 PR でこの 2 branch の test を補完し、#3187 型の「未 test branch の silent regression 再混入」を防ぐ。あわせて STRIPE_DISABLED で汎用 retry 文言でなく専用 message が出ること (retry 不能状況で誤誘導しない) を test で固定する。

## 関連 Issue

Closes #3209。原因元: PR #3205 (#3204) QM 再レビュー adversarial #2 (code は正、test coverage が partial)。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 503 STRIPE_DISABLED + network throw path の test を追加 | `CI=1 npx playwright test --config playwright.cognito-dev.config.ts stripe-checkout-monthly-yearly` | HEAD `458b93aa4` / **11 passed** (新規 #9 503 + #10 network throw 含む、実機 cognito-dev e2e) |
| AC2 | STRIPE_DISABLED 専用文言 (retry 不能で誤誘導しない) | 503 test の assert | HEAD `458b93aa4` / server `error(503,'決済機能は現在利用できません')` (checkout/+server.ts:66) を client が `data.message` で surface 済を確認。test で「決済機能は現在利用できません」visible を固定 (汎用「時間をおいて再度…」にならない)。**Part 2 は実装済のため test で固定するのみ** |

## 変更タイプ

- [x] テスト (type:test 相当)

## 影響範囲・変更コンポーネント

- `tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts`: 既存 400-path test と同一 pattern で 2 case 追加。
  - 503 STRIPE_DISABLED: `route.fulfill({status:503, body:{message:'決済機能は現在利用できません'}})` → 専用 message visible を assert。
  - network throw: `route.abort('failed')` で fetch reject → catch 分岐の汎用 feedback (`SUBSCRIPTION_PAGE_LABELS.checkoutFailed`) visible を assert。
- production code 変更なし (test のみ)。STRIPE_DISABLED 専用文言は既存実装で充足 (checkout/+server.ts messageMap + SaasLicensePanel が data.message surface)。

## テスト & 安全装置セルフチェック

- cognito-dev e2e (`stripe-checkout-monthly-yearly`): 11 passed (auth.setup 6 + spec 5、新規 2 case green)
- biome --error-on-warnings: clean
- production code 無変更のため回帰リスクなし

## スクリーンショット / ビジュアルデモ

test 追加のみ (.spec.ts)。UI / production code 変更なし。検証は cognito-dev e2e 実機 run (11 passed) で担保。

## コード品質セルフレビュー (#1481)

- 既存 400-path test と同一 pattern (route mock → plan card click → button → message assert) を踏襲。
- 503 test は server の実 message を、network test は client catch 分岐の実 label を assert し、実装の事実に整合。
- 検証: `CI=1 npx playwright test --config playwright.cognito-dev.config.ts stripe-checkout-monthly-yearly` (HEAD `458b93aa4`、11 passed)

## 横展開・影響波及チェック

- checkout の全 failure branch (400 / 503 / url 欠落 / network throw) が test 網羅されたことを確認 (400=既存、503/network=本 PR、url 欠落は非 2xx と同経路)。
- client `startCheckout` (SaasLicensePanel) は全 failure path で `checkoutError` + `showToast` の 2 層 feedback 済 (#3205)、本 PR はその test 補完。

## レビュー依頼事項・破壊的変更

破壊的変更なし (test 追加のみ)。Part 2 (STRIPE_DISABLED 専用文言) は既存実装で充足済のため test で固定するに留めた点をご確認ください。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 503 + network throw path の test 追加 + 実機 e2e 11 passed
- [x] AC 全行に検証手段 + エビデンス
- [x] 横展開確認済 (全 failure branch 網羅)
- [x] Part 2 (専用文言) 既存実装充足を test で固定

## QM レビュー結果

(QM チーム記入欄)
