### PR TITLE
fix(a11y): #3185 RedemptionPendingBanner に aria-live 付与 (件数取得失敗/承認待ちを SR 告知)

### DIFF
--- a/src/lib/features/admin/components/RedemptionPendingBanner.stories.svelte
+++ b/src/lib/features/admin/components/RedemptionPendingBanner.stories.svelte
@@ -25,6 +25,9 @@ const { Story } = defineMeta({
 		await expect(banner).toBeVisible();
 		await expect(banner).toHaveAttribute('href', '/admin/rewards/requests');
 		await expect(banner).toHaveTextContent(ADMIN_HOME_LABELS.pendingRedemptionBanner(3));
+		// #3185 a11y: 出現時に SR へ告知する live region。link role は保持 (role 上書きしない)。
+		await expect(banner).toHaveAttribute('aria-live', 'polite');
+		await expect(banner).not.toHaveAttribute('role'); // <a> の link role を上書きしない
 	}}
 />
 
@@ -38,5 +41,8 @@ const { Story } = defineMeta({
 		await expect(banner).toBeVisible();
 		await expect(banner).toHaveAttribute('href', '/admin/rewards/requests');
 		await expect(banner).toHaveTextContent(ADMIN_HOME_LABELS.pendingRedemptionLoadFailed);
+		// #3185 a11y: 件数取得失敗は assertive で即時告知。link role は保持 (対処画面へ遷移可能)。
+		await expect(banner).toHaveAttribute('aria-live', 'assertive');
+		await expect(banner).not.toHaveAttribute('role'); // <a> の link role を上書きしない
 	}}
 />

--- a/src/lib/features/admin/components/RedemptionPendingBanner.svelte
+++ b/src/lib/features/admin/components/RedemptionPendingBanner.svelte
@@ -15,14 +15,18 @@ interface Props {
 let { variant, count = 0 }: Props = $props();
 </script>
 
+<!-- #3185: バナーは「失敗/件数を告知する live region」かつ「対処画面へ遷移する link」の二役。
+     role="alert"/"status" は link role を上書きし SR が「リンク (対処可能)」と認識できなくなるため
+     使わず、aria-live で出現時にテキストを読み上げさせつつ link 役割を保持する。
+     error (件数取得失敗) は assertive、pending (新規発見性) は polite。 -->
 {#if variant === 'pending'}
-	<a class="redemption-pending-banner" href="/admin/rewards/requests" data-testid="redemption-pending-banner">
+	<a class="redemption-pending-banner" href="/admin/rewards/requests" data-testid="redemption-pending-banner" aria-live="polite">
 		<span class="redemption-pending-banner__icon" aria-hidden="true">🎁</span>
 		<span class="redemption-pending-banner__text">{ADMIN_HOME_LABELS.pendingRedemptionBanner(count)}</span>
 		<span class="redemption-pending-banner__cta" aria-hidden="true">▶</span>
 	</a>
 {:else}
-	<a class="redemption-pending-banner redemption-pending-banner--error" href="/admin/rewards/requests" data-testid="redemption-pending-banner-error">
+	<a class="redemption-pending-banner redemption-pending-banner--error" href="/admin/rewards/requests" data-testid="redemption-pending-banner-error" aria-live="assertive">
 		<span class="redemption-pending-banner__icon" aria-hidden="true">⚠️</span>
 		<span class="redemption-pending-banner__text">{ADMIN_HOME_LABELS.pendingRedemptionLoadFailed}</span>
 		<span class="redemption-pending-banner__cta" aria-hidden="true">▶</span>


### PR DESCRIPTION
## 顧客価値・目的

PR #3182 (#3148 承認待ち件数取得失敗を silent 非表示にしない、merged) の QM 再レビュー残課題のうち、**a11y** を是正する。`RedemptionPendingBanner` は bare `<a>` で `role` / `aria-live` 無く、スクリーンリーダー利用の保護者に「承認待ちあり」「件数取得失敗」が announce されなかった。link 役割 (対処画面へ遷移可能) を保持しつつ live region 化し、出現時に告知されるようにする。

## 関連 Issue

#3185 (Part 2 a11y を本 PR で対応 + Part 1 の component 単位 coverage を追加)。原因元: PR #3182 (#3148、merged `1fd76f7a`) QM 再レビュー (非 blocking)。Part 1 の page 統合 e2e (load 失敗 fault injection) と Part 3 (scale 時の監視/alert 併用) は Pre-PMF 留意のため本 PR scope 外 (下記)。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| Part 2 (a11y) | failure / pending バナーに live region を付与し SR へ告知 + Alert primitive 整合 | stories play (`RedemptionPendingBanner.stories.svelte`) + svelte-check | HEAD `926d6a092` / error=`aria-live="assertive"` / pending=`aria-live="polite"`。**link role 保持のため `role` は付与しない** (role=alert/status は `<a>` の link role を上書きし「対処可能なリンク」と認識できなくなるため)。play で aria-live 値 + role 不在を assert |
| Part 1 (component coverage) | failure 状態の決定的検証 | 同 stories Error play | HEAD `926d6a092` / Error variant の描画 + aria-live を component 層で固定。page 統合 e2e (fault injection) は下記理由で本 PR scope 外 |

## 変更タイプ

- [x] バグ修正 (a11y)

## 影響範囲・変更コンポーネント

- `src/lib/features/admin/components/RedemptionPendingBanner.svelte`: 両 variant の `<a>` に `aria-live` (error=assertive / pending=polite) を付与。role は link 保持のため非付与。
- `src/lib/features/admin/components/RedemptionPendingBanner.stories.svelte`: Pending / Error play に aria-live + role 不在の assertion を追加。
- 視覚的変化なし (aria-live は不可視属性)。

## テスト & 安全装置セルフチェック

- svelte-check: 0 errors / biome --error-on-warnings: clean
- stories play (aria-live / role assertion): CI `storybook-test` job で検証 (ローカルは browser session 起動が env 依存で flaky なため CI に委譲)
- 既存 IDOR / banner 表示判定ロジックは不変 (presentational component の属性追加のみ)

## スクリーンショット / ビジュアルデモ

**視覚的差分ゼロ** (aria-live は不可視の a11y 属性) のため `refactor:internal-no-doc-impact` で SS exempt。バナーの見た目・文言・semantic token は不変。SR 告知の追加のみ。

## コード品質セルフレビュー (#1481)

- role override (alert/status) でなく aria-live を選択し link affordance を保持 (SR ユーザが「対処画面へ遷移できるリンク」と認識できる) — a11y 上の trade-off を明示。
- play に aria-live 値 + role 不在を assert し regression を component 層で固定。
- 検証: `npx svelte-check` (HEAD `926d6a092`、0 errors)

## 横展開・影響波及チェック

- `RedemptionPendingBanner` は admin home の承認待ち導線専用。aria-live 付与は他バナーに影響しない。
- Part 1 page 統合 e2e (load 失敗で error バナー描画を assert) は fault injection / fixture variant が必要で、本 PR の component play + 既存 app-VR で当面の rendering 回帰は担保されるため Pre-PMF では component 層検証に留める。
- Part 3 (DynamoDB 障害時の遷移先 dead-end / 監視代替) は family-scoped app で thundering-herd 非現実的 (ADR-0010 Pre-PMF)、scale 時に監視/alert 併用を再評価。

## レビュー依頼事項・破壊的変更

破壊的変更なし (a11y 属性追加)。role を付与せず aria-live のみとした判断 (link role 保持優先) をご確認ください。Part 1 page e2e / Part 3 監視は Pre-PMF scope 外として #3185 を open 維持。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] aria-live 付与 + play assertion (component 層 coverage)
- [x] AC (Part 2 + Part 1 component) に検証手段 + エビデンス
- [x] 横展開確認済 + Part 1 full/Part 3 の scope 外理由明記
- [x] 視覚差分ゼロを根拠付きで明記

## QM レビュー結果

(QM チーム記入欄)
