### PR TITLE
feat: #3329 backup 対象分類レジストリ + silent-gap 機械検証（取りこぼし構造を CI で根絶）

### DIFF
--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -1,0 +1,224 @@
+// src/lib/server/db/backup-entity-registry.ts
+// #3329: backup 対象実体の分類 SSOT（source / 派生 / 除外）。
+//
+// 背景: export/import が「アプリの保存する実体の一部」しか扱わず、replace import で活動・評価・
+// ごほうび交換履歴・設定 等が silent に失われた (本番 t-82c17558 で実証)。本レジストリは
+// `keys.ts` の全 key builder を分類し、`tests/unit/db/backup-entity-registry.test.ts` が
+// 「keys.ts の key builder ⊆ 本レジストリ」を機械検証する。新実体追加時に分類を強制し、
+// 「backup 対象への入れ忘れ」を CI で弾く (silent-gap ガード、設計 doc backup-import-redesign §3.1)。
+//
+// classification:
+//   - 'source'   : イベント=真実。backup 必須 (失えば再計算不能)。
+//   - 'derived'  : source + ルールから再計算で復元可。backup は不要 (復元時 rebuild)。
+//   - 'excluded' : backup 対象外 (グローバル master / 機能廃止 / 運用ログ / 再生成可 / billing infra 等)。
+//
+// backupStatus (source のみ意味を持つ): 'exported' = export/import 実装済 / 'not-yet-exported' = #3329 残課題。
+// 残課題は test がベースラインとして固定し、新たな not-yet-exported source の silent 増加を禁止する (ratchet)。
+
+export type BackupClassification = 'source' | 'derived' | 'excluded';
+export type BackupExportStatus = 'exported' | 'not-yet-exported';
+
+export interface BackupEntityEntry {
+	classification: BackupClassification;
+	/** source のときのみ: export/import で round-trip 済か。'not-yet-exported' は #3329 残課題 */
+	backupStatus?: BackupExportStatus;
+	reason: string;
+}
+
+/**
+ * `keys.ts` の key builder 名 (`<name>Key`) をキーに分類を宣言する SSOT。
+ * key builder を追加したら本レジストリにも追記する (未追記は coverage test で fail)。
+ */
+export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
+	// ---- source: 実装済 (export/import で round-trip 済) ----
+	child: { classification: 'source', backupStatus: 'exported', reason: '子供プロフィール' },
+	childActivity: {
+		classification: 'source',
+		backupStatus: 'exported',
+		reason: 'per-child 活動インスタンス (#3327 で per-child round-trip 化)',
+	},
+	activityLog: { classification: 'source', backupStatus: 'exported', reason: '活動記録' },
+	pointLedger: {
+		classification: 'source',
+		backupStatus: 'exported',
+		reason: 'ポイント台帳 (付与/交換/bonus、残高の真実)',
+	},
+	evaluation: {
+		classification: 'source',
+		backupStatus: 'exported',
+		reason: '週次評価 (#3327/#3328 で import 実装)',
+	},
+	loginBonus: {
+		classification: 'source',
+		backupStatus: 'exported',
+		reason: 'ログインボーナス記録 (streak は派生だがレコードは source)',
+	},
+	specialReward: { classification: 'source', backupStatus: 'exported', reason: '特別ごほうび' },
+	checklistTemplate: {
+		classification: 'source',
+		backupStatus: 'exported',
+		reason: 'チェックリストテンプレート',
+	},
+	checklistItem: {
+		classification: 'source',
+		backupStatus: 'exported',
+		reason: 'チェックリスト項目 (template に同梱 export)',
+	},
+	checklistLog: {
+		classification: 'source',
+		backupStatus: 'exported',
+		reason: 'チェックリスト完了記録',
+	},
+	statusHistory: {
+		classification: 'source',
+		backupStatus: 'exported',
+		reason:
+			'ステータス変更履歴 (daily_decay/admin_edit は activityLog から再構成不能のため source、設計 §3.1)',
+	},
+
+	// ---- source: 未実装 (#3329 残課題、export/import 経路が無い = backup で失われる) ----
+	rewardRedemption: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason: 'ごほうびショップ交換/購入履歴。残高整合に必須だが export 未対応 (#3329)',
+	},
+	childChallenge: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason: 'チャレンジ + 達成履歴。export 未対応 (#3329)',
+	},
+	childChallengeAutoWeekly: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason: '自動週次チャレンジ。export 未対応 (#3329)',
+	},
+	stampCard: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason: 'スタンプカード。export 未対応 (#3329)',
+	},
+	stampEntry: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason: 'スタンプ押印。export 未対応 (#3329)',
+	},
+	certificate: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason: '証明書/賞状の授与記録。export 未対応 (#3329)',
+	},
+	parentMessage: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason: '親→子メッセージ。export 未対応 (#3329)',
+	},
+	siblingCheer: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason: '兄弟応援。export 未対応 (#3329)',
+	},
+	activityPref: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason: '活動の per-child 設定。export 未対応 (#3329)',
+	},
+	checklistAssignment: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason:
+			'チェックリスト配信先。現状 import 時に取込先 child へ再導出のみ。原本 fan-out は未保全 (#3329)',
+	},
+	checklistOverride: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason: 'チェックリスト日次 override。export 未対応 (#3329)',
+	},
+	setting: {
+		classification: 'source',
+		backupStatus: 'not-yet-exported',
+		reason:
+			'各種設定 (ポイント表示/onboarding 等)。export 未対応 (#3329)。PIN(pin_hash) は CWE-522/916 で除外 or 暗号化 (設計 D3)',
+	},
+
+	// ---- derived: source から再計算で復元 (backup 不要) ----
+	status: {
+		classification: 'derived',
+		reason: 'カテゴリ別 現在 XP/level/peak。statusHistory + ルールから再構成可',
+	},
+	pointBalance: { classification: 'derived', reason: 'ポイント残高。pointLedger から再計算可' },
+	activityMastery: { classification: 'derived', reason: '活動習熟。活動記録から再計算可' },
+	dailyBattle: { classification: 'derived', reason: 'デイリーバトル結果。活動結果から派生' },
+	enemyCollection: { classification: 'derived', reason: '敵図鑑。バトル結果から派生' },
+
+	// ---- excluded: グローバル master / 機能廃止 / 運用 / 再生成可 / billing infra ----
+	category: {
+		classification: 'excluded',
+		reason: 'グローバルカテゴリ master (tenant 非依存 seed)',
+	},
+	activity: {
+		classification: 'excluded',
+		reason: 'legacy tenant 活動 master。per-child モデルは childActivity を使用 (ADR-0055)',
+	},
+	achievement: {
+		classification: 'excluded',
+		reason: 'グローバル実績 master (実績システム廃止 #322)',
+	},
+	childAchievement: {
+		classification: 'excluded',
+		reason: '子の実績 (実績システム廃止 #322、データ不在)',
+	},
+	title: { classification: 'excluded', reason: 'グローバル称号 master (称号システム廃止 #322)' },
+	childTitle: {
+		classification: 'excluded',
+		reason: '子の称号 (称号システム廃止 #322、データ不在)',
+	},
+	dailyMission: {
+		classification: 'excluded',
+		reason: 'デイリーミッション (Phase 2 繰延・エフェメラル。設計 D4 で意図的除外)',
+	},
+	characterImage: {
+		classification: 'excluded',
+		reason:
+			'生成キャラ画像 (Gemini 再生成可。設計 D4。バイト同一復元が必要なら将来 source 化を再判断)',
+	},
+	marketBenchmark: { classification: 'excluded', reason: 'グローバル年齢別ベンチマーク master' },
+	analyticsAggregate: {
+		classification: 'excluded',
+		reason: '運用集計 (前日 funnel 等、source から再集計可)',
+	},
+	challengeAggregate: { classification: 'excluded', reason: '運用集計 (challenge 事前集計)' },
+	reportDailySummary: {
+		classification: 'excluded',
+		reason: '運用日次サマリ集計 (source から再集計可)',
+	},
+	cancellationReason: {
+		classification: 'excluded',
+		reason: '解約理由 (運用/分析、家族コアデータ外)',
+	},
+	graduationConsent: {
+		classification: 'excluded',
+		reason: '卒業同意の運用記録 (家族コアデータ外、要レビュー)',
+	},
+	inquiry: { classification: 'excluded', reason: 'お問い合わせ (運用、家族データ外)' },
+	counter: { classification: 'excluded', reason: 'id 採番カウンタ (infra、復元時に再採番)' },
+	pushSubscription: { classification: 'excluded', reason: 'Push 購読 (device 固有、可搬性なし)' },
+	notificationLog: { classification: 'excluded', reason: '通知送信ログ (運用ログ)' },
+	stripeWebhookEvent: {
+		classification: 'excluded',
+		reason: 'Stripe webhook 冪等化 (billing infra)',
+	},
+	trialHistory: {
+		classification: 'excluded',
+		reason: 'トライアル履歴 (billing 状態、Stripe 管理)',
+	},
+	cloudExport: { classification: 'excluded', reason: 'クラウド export ジョブ自体の状態 (運用)' },
+	viewerToken: { classification: 'excluded', reason: '閲覧共有トークン (エフェメラル)' },
+};
+
+/** source かつ未 export の実体名一覧 (#3329 残課題の ratchet ベースライン)。 */
+export function notYetExportedSourceEntities(): string[] {
+	return Object.entries(BACKUP_ENTITY_REGISTRY)
+		.filter(([, e]) => e.classification === 'source' && e.backupStatus === 'not-yet-exported')
+		.map(([name]) => name)
+		.sort();
+}

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -2,9 +2,16 @@
 // #3329: backup 対象実体の分類 SSOT（source / 派生 / 除外）。
 //
 // 背景: export/import が「アプリの保存する実体の一部」しか扱わず、replace import で活動・評価・
-// ごほうび交換履歴・設定 等が silent に失われた (本番 t-82c17558 で実証)。本レジストリは
-// `keys.ts` の全 key builder を分類し、`tests/unit/db/backup-entity-registry.test.ts` が
-// 「keys.ts の key builder ⊆ 本レジストリ」を機械検証する。新実体追加時に分類を強制し、
+// ごほうび交換履歴・設定 等が silent に失われた (本番 t-82c17558 で実証)。
+//
+// 権威列挙 (#3329 QM BLOCK 是正): 実体の「真実集合」は `schema.ts` の **全 sqliteTable 定義**である。
+// 旧実装は `keys.ts` の key builder のみを列挙していたため、key builder を持たない実テーブル
+// (rest_days / child_custom_voices / usage_logs / stamp_masters) が盲点となり緑通過していた。
+// 本レジストリは各実体に `schemaTable` (対応する schema.ts の table const 名) を持たせ、
+// `tests/unit/db/backup-entity-registry.test.ts` が **「schema.ts の全テーブル ⊆ 本レジストリ」**を
+// 主軸で機械検証する (key builder の有無に依らず全実体を分類強制)。keys.ts の key builder 照合は
+// DynamoDB single-table key の網羅を担保する補助軸として残す。
+// 新実体 (schema テーブル or key builder) を追加して分類を忘れると test が fail し、
 // 「backup 対象への入れ忘れ」を CI で弾く (silent-gap ガード、設計 doc backup-import-redesign §3.1)。
 //
 // classification:
@@ -14,63 +21,101 @@
 //
 // backupStatus (source のみ意味を持つ): 'exported' = export/import 実装済 / 'not-yet-exported' = #3329 残課題。
 // 残課題は test がベースラインとして固定し、新たな not-yet-exported source の silent 増加を禁止する (ratchet)。
+//
+// excludedKind (excluded のみ意味を持つ):
+//   - 'permanent' : 恒久除外 (機能廃止 / グローバル master / billing infra / 運用ログ 等、将来も backup 対象外)。
+//   - 'deferred'  : 繰延除外 (Phase 2 等で将来 source 化を再判断する暫定除外)。test が exact-equality で
+//                   固定し、実装フェーズ到来時に再分類を強制する (source の not-yet-exported ratchet と同型)。
 
 export type BackupClassification = 'source' | 'derived' | 'excluded';
 export type BackupExportStatus = 'exported' | 'not-yet-exported';
+export type BackupExcludedKind = 'permanent' | 'deferred';
 
 export interface BackupEntityEntry {
 	classification: BackupClassification;
+	/**
+	 * 対応する `schema.ts` の sqliteTable const 名 (実テーブルの権威。schema 列挙との照合に使う)。
+	 * SQLite に実テーブルを持たない DynamoDB single-table 専用 key / 純粋な派生概念は省略する。
+	 */
+	schemaTable?: string;
 	/** source のときのみ: export/import で round-trip 済か。'not-yet-exported' は #3329 残課題 */
 	backupStatus?: BackupExportStatus;
+	/** excluded のときのみ: 恒久除外 / 繰延除外 (Phase 2 で再分類) の区別 */
+	excludedKind?: BackupExcludedKind;
 	reason: string;
 }
 
 /**
- * `keys.ts` の key builder 名 (`<name>Key`) をキーに分類を宣言する SSOT。
- * key builder を追加したら本レジストリにも追記する (未追記は coverage test で fail)。
+ * 実体名をキーに分類を宣言する SSOT。
+ * - schema.ts に table を持つ実体は `schemaTable` を必ず設定する (schema 権威列挙との照合キー)。
+ * - keys.ts に key builder を追加した / schema に table を追加したら本レジストリにも追記する
+ *   (未追記は coverage test で fail)。
  */
 export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	// ---- source: 実装済 (export/import で round-trip 済) ----
-	child: { classification: 'source', backupStatus: 'exported', reason: '子供プロフィール' },
+	child: {
+		classification: 'source',
+		schemaTable: 'children',
+		backupStatus: 'exported',
+		reason: '子供プロフィール',
+	},
 	childActivity: {
 		classification: 'source',
+		schemaTable: 'childActivities',
 		backupStatus: 'exported',
 		reason: 'per-child 活動インスタンス (#3327 で per-child round-trip 化)',
 	},
-	activityLog: { classification: 'source', backupStatus: 'exported', reason: '活動記録' },
+	activityLog: {
+		classification: 'source',
+		schemaTable: 'activityLogs',
+		backupStatus: 'exported',
+		reason: '活動記録',
+	},
 	pointLedger: {
 		classification: 'source',
+		schemaTable: 'pointLedger',
 		backupStatus: 'exported',
 		reason: 'ポイント台帳 (付与/交換/bonus、残高の真実)',
 	},
 	evaluation: {
 		classification: 'source',
+		schemaTable: 'evaluations',
 		backupStatus: 'exported',
 		reason: '週次評価 (#3327/#3328 で import 実装)',
 	},
 	loginBonus: {
 		classification: 'source',
+		schemaTable: 'loginBonuses',
 		backupStatus: 'exported',
 		reason: 'ログインボーナス記録 (streak は派生だがレコードは source)',
 	},
-	specialReward: { classification: 'source', backupStatus: 'exported', reason: '特別ごほうび' },
+	specialReward: {
+		classification: 'source',
+		schemaTable: 'specialRewards',
+		backupStatus: 'exported',
+		reason: '特別ごほうび',
+	},
 	checklistTemplate: {
 		classification: 'source',
+		schemaTable: 'checklistTemplates',
 		backupStatus: 'exported',
 		reason: 'チェックリストテンプレート',
 	},
 	checklistItem: {
 		classification: 'source',
+		schemaTable: 'checklistTemplateItems',
 		backupStatus: 'exported',
 		reason: 'チェックリスト項目 (template に同梱 export)',
 	},
 	checklistLog: {
 		classification: 'source',
+		schemaTable: 'checklistLogs',
 		backupStatus: 'exported',
 		reason: 'チェックリスト完了記録',
 	},
 	statusHistory: {
 		classification: 'source',
+		schemaTable: 'statusHistory',
 		backupStatus: 'exported',
 		reason:
 			'ステータス変更履歴 (daily_decay/admin_edit は activityLog から再構成不能のため source、設計 §3.1)',
@@ -79,140 +124,267 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	// ---- source: 未実装 (#3329 残課題、export/import 経路が無い = backup で失われる) ----
 	rewardRedemption: {
 		classification: 'source',
+		schemaTable: 'rewardRedemptionRequests',
 		backupStatus: 'not-yet-exported',
 		reason: 'ごほうびショップ交換/購入履歴。残高整合に必須だが export 未対応 (#3329)',
 	},
 	childChallenge: {
 		classification: 'source',
+		schemaTable: 'childChallenges',
 		backupStatus: 'not-yet-exported',
 		reason: 'チャレンジ + 達成履歴。export 未対応 (#3329)',
 	},
 	childChallengeAutoWeekly: {
 		classification: 'source',
+		// 専用 SQLite table なし (child_challenges の自動週次フラグ運用 + DynamoDB key 専用)
 		backupStatus: 'not-yet-exported',
 		reason: '自動週次チャレンジ。export 未対応 (#3329)',
 	},
 	stampCard: {
 		classification: 'source',
+		schemaTable: 'stampCards',
 		backupStatus: 'not-yet-exported',
 		reason: 'スタンプカード。export 未対応 (#3329)',
 	},
 	stampEntry: {
 		classification: 'source',
+		schemaTable: 'stampEntries',
 		backupStatus: 'not-yet-exported',
 		reason: 'スタンプ押印。export 未対応 (#3329)',
 	},
 	certificate: {
 		classification: 'source',
+		schemaTable: 'certificates',
 		backupStatus: 'not-yet-exported',
 		reason: '証明書/賞状の授与記録。export 未対応 (#3329)',
 	},
 	parentMessage: {
 		classification: 'source',
+		schemaTable: 'parentMessages',
 		backupStatus: 'not-yet-exported',
 		reason: '親→子メッセージ。export 未対応 (#3329)',
 	},
 	siblingCheer: {
 		classification: 'source',
+		schemaTable: 'siblingCheers',
 		backupStatus: 'not-yet-exported',
 		reason: '兄弟応援。export 未対応 (#3329)',
 	},
 	activityPref: {
 		classification: 'source',
+		schemaTable: 'childActivityPreferences',
 		backupStatus: 'not-yet-exported',
 		reason: '活動の per-child 設定。export 未対応 (#3329)',
 	},
 	checklistAssignment: {
 		classification: 'source',
+		schemaTable: 'checklistTemplateAssignments',
 		backupStatus: 'not-yet-exported',
 		reason:
 			'チェックリスト配信先。現状 import 時に取込先 child へ再導出のみ。原本 fan-out は未保全 (#3329)',
 	},
 	checklistOverride: {
 		classification: 'source',
+		schemaTable: 'checklistOverrides',
 		backupStatus: 'not-yet-exported',
 		reason: 'チェックリスト日次 override。export 未対応 (#3329)',
 	},
 	setting: {
 		classification: 'source',
+		schemaTable: 'settings',
 		backupStatus: 'not-yet-exported',
 		reason:
 			'各種設定 (ポイント表示/onboarding 等)。export 未対応 (#3329)。PIN(pin_hash) は CWE-522/916 で除外 or 暗号化 (設計 D3)',
+	},
+	// #3329 QM BLOCK 是正: schema.ts 権威列挙で surface した builder-less source テーブル。
+	restDays: {
+		classification: 'source',
+		schemaTable: 'restDays',
+		backupStatus: 'not-yet-exported',
+		reason:
+			'おやすみ日設定 (per-child、保護者が任意指定)。evaluation-repo が週次評価/streak/decay 計算の input に使い活動記録から再構成不能。export 未対応のため backup で失われる (#3329)',
+	},
+	childCustomVoices: {
+		classification: 'source',
+		schemaTable: 'childCustomVoices',
+		backupStatus: 'not-yet-exported',
+		reason:
+			'子のカスタム音声 (ユーザーがアップロードした録音、file_path/public_url はストレージ実体参照)。再生成不能のユーザー生成データ。export 未対応 (#3329)',
 	},
 
 	// ---- derived: source から再計算で復元 (backup 不要) ----
 	status: {
 		classification: 'derived',
+		schemaTable: 'statuses',
 		reason: 'カテゴリ別 現在 XP/level/peak。statusHistory + ルールから再構成可',
 	},
-	pointBalance: { classification: 'derived', reason: 'ポイント残高。pointLedger から再計算可' },
-	activityMastery: { classification: 'derived', reason: '活動習熟。活動記録から再計算可' },
-	dailyBattle: { classification: 'derived', reason: 'デイリーバトル結果。活動結果から派生' },
-	enemyCollection: { classification: 'derived', reason: '敵図鑑。バトル結果から派生' },
+	pointBalance: {
+		classification: 'derived',
+		// 専用 SQLite table なし (DynamoDB single-table の集約 key、SQLite は pointLedger から都度算出)
+		reason: 'ポイント残高。pointLedger から再計算可',
+	},
+	activityMastery: {
+		classification: 'derived',
+		schemaTable: 'activityMastery',
+		reason: '活動習熟。活動記録から再計算可',
+	},
+	dailyBattle: {
+		classification: 'derived',
+		schemaTable: 'dailyBattles',
+		reason: 'デイリーバトル結果。活動結果から派生',
+	},
+	enemyCollection: {
+		classification: 'derived',
+		schemaTable: 'enemyCollection',
+		reason: '敵図鑑。バトル結果から派生',
+	},
 
 	// ---- excluded: グローバル master / 機能廃止 / 運用 / 再生成可 / billing infra ----
 	category: {
 		classification: 'excluded',
+		schemaTable: 'categories',
+		excludedKind: 'permanent',
 		reason: 'グローバルカテゴリ master (tenant 非依存 seed)',
 	},
 	activity: {
 		classification: 'excluded',
+		schemaTable: 'activities',
+		excludedKind: 'permanent',
 		reason: 'legacy tenant 活動 master。per-child モデルは childActivity を使用 (ADR-0055)',
 	},
 	achievement: {
 		classification: 'excluded',
+		schemaTable: 'achievements',
+		excludedKind: 'permanent',
 		reason: 'グローバル実績 master (実績システム廃止 #322)',
 	},
 	childAchievement: {
 		classification: 'excluded',
+		schemaTable: 'childAchievements',
+		excludedKind: 'permanent',
 		reason: '子の実績 (実績システム廃止 #322、データ不在)',
 	},
-	title: { classification: 'excluded', reason: 'グローバル称号 master (称号システム廃止 #322)' },
+	title: {
+		classification: 'excluded',
+		// 専用 SQLite table なし (称号システム廃止 #322、DynamoDB key 残骸のみ)
+		excludedKind: 'permanent',
+		reason: 'グローバル称号 master (称号システム廃止 #322)',
+	},
 	childTitle: {
 		classification: 'excluded',
+		excludedKind: 'permanent',
 		reason: '子の称号 (称号システム廃止 #322、データ不在)',
 	},
 	dailyMission: {
 		classification: 'excluded',
-		reason: 'デイリーミッション (Phase 2 繰延・エフェメラル。設計 D4 で意図的除外)',
+		schemaTable: 'dailyMissions',
+		excludedKind: 'deferred',
+		reason: 'デイリーミッション (Phase 2 繰延・エフェメラル。設計 D4 で意図的除外、実装時に再分類)',
 	},
 	characterImage: {
 		classification: 'excluded',
+		schemaTable: 'characterImages',
+		excludedKind: 'deferred',
 		reason:
-			'生成キャラ画像 (Gemini 再生成可。設計 D4。バイト同一復元が必要なら将来 source 化を再判断)',
+			'生成キャラ画像 (Gemini 再生成可。設計 D4。バイト同一復元が必要なら将来 source 化を再判断する繰延除外)',
 	},
-	marketBenchmark: { classification: 'excluded', reason: 'グローバル年齢別ベンチマーク master' },
+	marketBenchmark: {
+		classification: 'excluded',
+		schemaTable: 'marketBenchmarks',
+		excludedKind: 'permanent',
+		reason: 'グローバル年齢別ベンチマーク master',
+	},
 	analyticsAggregate: {
 		classification: 'excluded',
+		// 専用 SQLite table なし (DynamoDB 集約 key、SQLite は source から再集計)
+		excludedKind: 'permanent',
 		reason: '運用集計 (前日 funnel 等、source から再集計可)',
 	},
-	challengeAggregate: { classification: 'excluded', reason: '運用集計 (challenge 事前集計)' },
+	challengeAggregate: {
+		classification: 'excluded',
+		excludedKind: 'permanent',
+		reason: '運用集計 (challenge 事前集計)',
+	},
 	reportDailySummary: {
 		classification: 'excluded',
+		schemaTable: 'reportDailySummaries',
+		excludedKind: 'permanent',
 		reason: '運用日次サマリ集計 (source から再集計可)',
 	},
 	cancellationReason: {
 		classification: 'excluded',
+		schemaTable: 'cancellationReasons',
+		excludedKind: 'permanent',
 		reason: '解約理由 (運用/分析、家族コアデータ外)',
 	},
 	graduationConsent: {
 		classification: 'excluded',
-		reason: '卒業同意の運用記録 (家族コアデータ外、要レビュー)',
+		schemaTable: 'graduationConsent',
+		excludedKind: 'permanent',
+		reason:
+			'卒業 (=解約) 時点の事例公開承諾 + ポジティブ churn KPI の運用記録 (tenant scope、ops-analytics 用)。COPPA のサービス利用同意ではなく公開承諾であり、卒業フローで都度取得される終端イベント artifact。家族のコア活動データではなく、データ復元 = 利用継続の文脈で再取得前提のため恒久除外 (graduation-service.ts 確認)',
 	},
-	inquiry: { classification: 'excluded', reason: 'お問い合わせ (運用、家族データ外)' },
-	counter: { classification: 'excluded', reason: 'id 採番カウンタ (infra、復元時に再採番)' },
-	pushSubscription: { classification: 'excluded', reason: 'Push 購読 (device 固有、可搬性なし)' },
-	notificationLog: { classification: 'excluded', reason: '通知送信ログ (運用ログ)' },
+	usageLogs: {
+		classification: 'excluded',
+		schemaTable: 'usageLogs',
+		excludedKind: 'permanent',
+		reason:
+			'利用時間ログ (起動/終了/滞在秒、ops 分析専用)。家族のコア活動データ外の運用計測ログで、ADR-0012 anti-engagement 上もユーザーへ復元する性質ではない。source から導出されないが運用集計目的のため恒久除外',
+	},
+	stampMasters: {
+		classification: 'excluded',
+		schemaTable: 'stampMasters',
+		excludedKind: 'permanent',
+		reason:
+			'スタンプ master (グローバル seed、create-tables.ts / seed.ts の 16 既定スタンプを INSERT OR IGNORE で配備)。ユーザー作成経路なし (sqlite repo は select のみ)、seed から再生成可のため恒久除外',
+	},
+	inquiry: {
+		classification: 'excluded',
+		// 専用 SQLite table なし (DynamoDB key 専用、運用問い合わせ)
+		excludedKind: 'permanent',
+		reason: 'お問い合わせ (運用、家族データ外)',
+	},
+	counter: {
+		classification: 'excluded',
+		excludedKind: 'permanent',
+		reason: 'id 採番カウンタ (infra、復元時に再採番)',
+	},
+	pushSubscription: {
+		classification: 'excluded',
+		schemaTable: 'pushSubscriptions',
+		excludedKind: 'permanent',
+		reason: 'Push 購読 (device 固有、可搬性なし)',
+	},
+	notificationLog: {
+		classification: 'excluded',
+		schemaTable: 'notificationLogs',
+		excludedKind: 'permanent',
+		reason: '通知送信ログ (運用ログ)',
+	},
 	stripeWebhookEvent: {
 		classification: 'excluded',
+		schemaTable: 'stripeWebhookEvents',
+		excludedKind: 'permanent',
 		reason: 'Stripe webhook 冪等化 (billing infra)',
 	},
 	trialHistory: {
 		classification: 'excluded',
+		schemaTable: 'trialHistory',
+		excludedKind: 'permanent',
 		reason: 'トライアル履歴 (billing 状態、Stripe 管理)',
 	},
-	cloudExport: { classification: 'excluded', reason: 'クラウド export ジョブ自体の状態 (運用)' },
-	viewerToken: { classification: 'excluded', reason: '閲覧共有トークン (エフェメラル)' },
+	cloudExport: {
+		classification: 'excluded',
+		schemaTable: 'cloudExports',
+		excludedKind: 'permanent',
+		reason: 'クラウド export ジョブ自体の状態 (運用)',
+	},
+	viewerToken: {
+		classification: 'excluded',
+		schemaTable: 'viewerTokens',
+		excludedKind: 'permanent',
+		reason: '閲覧共有トークン (エフェメラル)',
+	},
 };
 
 /** source かつ未 export の実体名一覧 (#3329 残課題の ratchet ベースライン)。 */
@@ -220,5 +392,21 @@ export function notYetExportedSourceEntities(): string[] {
 	return Object.entries(BACKUP_ENTITY_REGISTRY)
 		.filter(([, e]) => e.classification === 'source' && e.backupStatus === 'not-yet-exported')
 		.map(([name]) => name)
+		.sort();
+}
+
+/** excluded かつ繰延 (deferred) の実体名一覧 (#3329 Phase 2 再分類強制の ratchet ベースライン)。 */
+export function deferredExcludedEntities(): string[] {
+	return Object.entries(BACKUP_ENTITY_REGISTRY)
+		.filter(([, e]) => e.classification === 'excluded' && e.excludedKind === 'deferred')
+		.map(([name]) => name)
+		.sort();
+}
+
+/** registry が分類済として宣言する schema.ts テーブル const 名の集合 (schema 権威列挙との照合用)。 */
+export function classifiedSchemaTables(): string[] {
+	return Object.values(BACKUP_ENTITY_REGISTRY)
+		.map((e) => e.schemaTable)
+		.filter((t): t is string => typeof t === 'string')
 		.sort();
 }

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -1,0 +1,86 @@
+// tests/unit/db/backup-entity-registry.test.ts
+// #3329: backup 対象分類レジストリの機械検証 (silent-gap ガード)。
+//
+// keys.ts の全 key builder (`<name>Key`) が backup-entity-registry に分類済であることを assert する。
+// 新実体 (key builder) を追加して分類を忘れると本テストが fail し、「backup 対象への入れ忘れ」を
+// CI で検知する。replace import で活動/評価/ごほうび交換履歴等が silent に失われた事故 (#3327/#3329)
+// の構造的再発防止 (設計 doc backup-import-redesign §3.1)。
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+	BACKUP_ENTITY_REGISTRY,
+	notYetExportedSourceEntities,
+} from '../../../src/lib/server/db/backup-entity-registry';
+
+const KEYS_TS = join(process.cwd(), 'src/lib/server/db/dynamodb/keys.ts');
+
+/** keys.ts から `export function <name>Key(...)` の <name> を抽出する。 */
+function keyBuilderEntityNames(): string[] {
+	const src = readFileSync(KEYS_TS, 'utf8');
+	const names = new Set<string>();
+	const re = /export function (\w+)Key\b/g;
+	let m: RegExpExecArray | null;
+	// biome-ignore lint/suspicious/noAssignInExpressions: 正規表現の逐次 match 抽出
+	while ((m = re.exec(src)) !== null) {
+		const base = m[1];
+		if (base) names.add(base);
+	}
+	return [...names].sort();
+}
+
+describe('#3329 backup-entity-registry — silent-gap ガード', () => {
+	it('keys.ts の全 key builder が registry に分類されている (未分類で fail)', () => {
+		const entities = keyBuilderEntityNames();
+		expect(entities.length, 'keys.ts に key builder が存在する').toBeGreaterThan(20);
+
+		const unclassified = entities.filter((name) => !(name in BACKUP_ENTITY_REGISTRY));
+		expect(
+			unclassified,
+			`未分類の実体があります。src/lib/server/db/backup-entity-registry.ts に source/derived/excluded を追記してください: ${unclassified.join(', ')}`,
+		).toEqual([]);
+	});
+
+	it('registry に keys.ts に存在しない孤児エントリが無い', () => {
+		const entities = new Set(keyBuilderEntityNames());
+		const orphans = Object.keys(BACKUP_ENTITY_REGISTRY).filter((name) => !entities.has(name));
+		expect(
+			orphans,
+			`keys.ts に対応 key builder が無い registry エントリ: ${orphans.join(', ')}`,
+		).toEqual([]);
+	});
+
+	it('全エントリが妥当な classification + source は backupStatus を持つ', () => {
+		for (const [name, entry] of Object.entries(BACKUP_ENTITY_REGISTRY)) {
+			expect(['source', 'derived', 'excluded'], `${name} の classification`).toContain(
+				entry.classification,
+			);
+			expect(entry.reason.length, `${name} に reason`).toBeGreaterThan(0);
+			if (entry.classification === 'source') {
+				expect(['exported', 'not-yet-exported'], `${name} (source) は backupStatus 必須`).toContain(
+					entry.backupStatus,
+				);
+			}
+		}
+	});
+
+	it('未 export の source 実体ベースライン (#3329 残課題、ratchet)', () => {
+		// export に足したら 'exported' へ flip し本ベースラインから外す (意図的更新)。
+		// 新たな not-yet-exported source の silent 増加を禁止する (回帰ネット)。
+		expect(notYetExportedSourceEntities()).toEqual([
+			'activityPref',
+			'certificate',
+			'checklistAssignment',
+			'checklistOverride',
+			'childChallenge',
+			'childChallengeAutoWeekly',
+			'parentMessage',
+			'rewardRedemption',
+			'setting',
+			'siblingCheer',
+			'stampCard',
+			'stampEntry',
+		]);
+	});
+});

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -1,22 +1,46 @@
 // tests/unit/db/backup-entity-registry.test.ts
 // #3329: backup 対象分類レジストリの機械検証 (silent-gap ガード)。
 //
-// keys.ts の全 key builder (`<name>Key`) が backup-entity-registry に分類済であることを assert する。
-// 新実体 (key builder) を追加して分類を忘れると本テストが fail し、「backup 対象への入れ忘れ」を
-// CI で検知する。replace import で活動/評価/ごほうび交換履歴等が silent に失われた事故 (#3327/#3329)
-// の構造的再発防止 (設計 doc backup-import-redesign §3.1)。
+// 主軸 (#3329 QM BLOCK 是正): 実体の「真実集合」は schema.ts の **全 sqliteTable 定義**。
+// schema.ts の全テーブルが backup-entity-registry に分類済 (`schemaTable` で宣言) であることを assert する。
+// key builder を持たない実テーブル (rest_days / child_custom_voices / usage_logs / stamp_masters) も
+// 必ず分類対象に含めることで、「key builder が無い実テーブルが盲点で緑通過」する旧バグを根治する。
+//
+// 補助軸: keys.ts の全 key builder (`<name>Key`) も registry に分類済であること (DynamoDB single-table key の網羅)。
+//
+// いずれかの実体 (schema テーブル or key builder) を追加して分類を忘れると本テストが fail し、
+// 「backup 対象への入れ忘れ」を CI で検知する。replace import で活動/評価/ごほうび交換履歴等が
+// silent に失われた事故 (#3327/#3329) の構造的再発防止 (設計 doc backup-import-redesign §3.1)。
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
 	BACKUP_ENTITY_REGISTRY,
+	classifiedSchemaTables,
+	deferredExcludedEntities,
 	notYetExportedSourceEntities,
 } from '../../../src/lib/server/db/backup-entity-registry';
 
-const KEYS_TS = join(process.cwd(), 'src/lib/server/db/dynamodb/keys.ts');
+const DB_DIR = join(process.cwd(), 'src/lib/server/db');
+const SCHEMA_TS = join(DB_DIR, 'schema.ts');
+const KEYS_TS = join(DB_DIR, 'dynamodb/keys.ts');
 
-/** keys.ts から `export function <name>Key(...)` の <name> を抽出する。 */
+/** schema.ts の全 sqliteTable const 名を権威列挙する (実テーブルの真実集合)。 */
+function schemaTableConstNames(): string[] {
+	const src = readFileSync(SCHEMA_TS, 'utf8');
+	const names = new Set<string>();
+	const re = /export const (\w+) = sqliteTable\(/g;
+	let m: RegExpExecArray | null;
+	// biome-ignore lint/suspicious/noAssignInExpressions: 正規表現の逐次 match 抽出
+	while ((m = re.exec(src)) !== null) {
+		const name = m[1];
+		if (name) names.add(name);
+	}
+	return [...names].sort();
+}
+
+/** keys.ts から `export function <name>Key(...)` の <name> を抽出する (補助軸)。 */
 function keyBuilderEntityNames(): string[] {
 	const src = readFileSync(KEYS_TS, 'utf8');
 	const names = new Set<string>();
@@ -31,27 +55,55 @@ function keyBuilderEntityNames(): string[] {
 }
 
 describe('#3329 backup-entity-registry — silent-gap ガード', () => {
-	it('keys.ts の全 key builder が registry に分類されている (未分類で fail)', () => {
+	it('【主軸】schema.ts の全テーブルが registry に分類されている (key builder の有無に依らず、未分類で fail)', () => {
+		const tables = schemaTableConstNames();
+		expect(tables.length, 'schema.ts に sqliteTable 定義が存在する').toBeGreaterThan(30);
+
+		const classified = new Set(classifiedSchemaTables());
+		const unclassified = tables.filter((t) => !classified.has(t));
+		expect(
+			unclassified,
+			`未分類の schema テーブルがあります。src/lib/server/db/backup-entity-registry.ts に entry を追加し source/derived/excluded と schemaTable を宣言してください: ${unclassified.join(', ')}`,
+		).toEqual([]);
+	});
+
+	it('registry が宣言する schemaTable が全て schema.ts に実在する (stale schemaTable で fail)', () => {
+		const tables = new Set(schemaTableConstNames());
+		const stale = classifiedSchemaTables().filter((t) => !tables.has(t));
+		expect(
+			stale,
+			`schema.ts に存在しない schemaTable を registry が宣言しています: ${stale.join(', ')}`,
+		).toEqual([]);
+	});
+
+	it('【補助】keys.ts の全 key builder が registry に分類されている (未分類で fail)', () => {
 		const entities = keyBuilderEntityNames();
 		expect(entities.length, 'keys.ts に key builder が存在する').toBeGreaterThan(20);
 
 		const unclassified = entities.filter((name) => !(name in BACKUP_ENTITY_REGISTRY));
 		expect(
 			unclassified,
-			`未分類の実体があります。src/lib/server/db/backup-entity-registry.ts に source/derived/excluded を追記してください: ${unclassified.join(', ')}`,
+			`未分類の key builder があります。src/lib/server/db/backup-entity-registry.ts に source/derived/excluded を追記してください: ${unclassified.join(', ')}`,
 		).toEqual([]);
 	});
 
-	it('registry に keys.ts に存在しない孤児エントリが無い', () => {
-		const entities = new Set(keyBuilderEntityNames());
-		const orphans = Object.keys(BACKUP_ENTITY_REGISTRY).filter((name) => !entities.has(name));
+	it('registry に schema テーブルにも keys.ts builder にも対応しない孤児エントリが無い', () => {
+		const builders = new Set(keyBuilderEntityNames());
+		const tables = new Set(schemaTableConstNames());
+		const orphans = Object.entries(BACKUP_ENTITY_REGISTRY)
+			.filter(
+				([name, entry]) =>
+					!builders.has(name) &&
+					!(entry.schemaTable !== undefined && tables.has(entry.schemaTable)),
+			)
+			.map(([name]) => name);
 		expect(
 			orphans,
-			`keys.ts に対応 key builder が無い registry エントリ: ${orphans.join(', ')}`,
+			`schema テーブル / keys.ts key builder のどちらにも対応しない孤児 registry エントリ: ${orphans.join(', ')}`,
 		).toEqual([]);
 	});
 
-	it('全エントリが妥当な classification + source は backupStatus を持つ', () => {
+	it('全エントリが妥当な classification + source は backupStatus / excluded は excludedKind を持つ', () => {
 		for (const [name, entry] of Object.entries(BACKUP_ENTITY_REGISTRY)) {
 			expect(['source', 'derived', 'excluded'], `${name} の classification`).toContain(
 				entry.classification,
@@ -60,6 +112,11 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 			if (entry.classification === 'source') {
 				expect(['exported', 'not-yet-exported'], `${name} (source) は backupStatus 必須`).toContain(
 					entry.backupStatus,
+				);
+			}
+			if (entry.classification === 'excluded') {
+				expect(['permanent', 'deferred'], `${name} (excluded) は excludedKind 必須`).toContain(
+					entry.excludedKind,
 				);
 			}
 		}
@@ -75,12 +132,20 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 			'checklistOverride',
 			'childChallenge',
 			'childChallengeAutoWeekly',
+			'childCustomVoices',
 			'parentMessage',
+			'restDays',
 			'rewardRedemption',
 			'setting',
 			'siblingCheer',
 			'stampCard',
 			'stampEntry',
 		]);
+	});
+
+	it('excluded 繰延 (deferred) 実体ベースライン (#3329 Phase 2 再分類強制、ratchet)', () => {
+		// Phase 2 等で source / derived 化したら本ベースラインから外す (意図的更新)。
+		// 「暫定除外のまま放置」を禁止し、実装フェーズ到来時の再分類を強制する。
+		expect(deferredExcludedEntities()).toEqual(['characterImage', 'dailyMission']);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発（データ設計） / 運営

**解決する課題**: backup の export/import が「アプリの保存する実体の一部」しか扱わず、新実体を **silent に backup 対象から取りこぼす**構造（活動・評価・ごほうび交換履歴・設定 等が replace import で全喪失した #3327/#3329 の根）。本 PR は全 family 実体の **source/派生/除外 分類 SSOT** をコードに置き、「keys.ts の key builder ⊆ 分類レジストリ」を機械検証して**分類忘れ（=取りこぼし）を CI で弾く**。

**期待される効果**: 新実体追加時に backup 分類が必須化され、将来の silent な data-loss を構造的に防ぐ。残る未 export source 12 件を可視化・追跡（ratchet）。

## 関連 Issue

関連: #3329 #3328 #3327（本 PR は #3329 の基盤＝分類 SSOT + 機械検証。未 export source 12 件の export 実装は本 registry を起点に段階対応するため #3329 は close しない）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | keys.ts 全 key builder を source/派生/除外に分類 | `src/lib/server/db/backup-entity-registry.ts` | HEAD `4ef50ca7` / 50 実体分類（source 23 / 派生 5 / 除外 22） |
| AC2 | 「keys.ts ⊆ registry」を機械検証（未分類で fail） | `npx vitest run tests/unit/db/backup-entity-registry.test.ts` | HEAD `4ef50ca7` / 4 passed / 新 key builder 未分類で fail |
| AC3 | 未 export の source をベースライン固定（silent 増加禁止） | 同テスト notYetExportedSourceEntities ratchet | HEAD `4ef50ca7` / 12 件固定 |
| AC4 | 型・lint 健全 | `npx svelte-check` / `biome check` | HEAD `4ef50ca7` / svelte-check 0 ERROR / biome クリーン |

## 変更タイプ

- [x] feat: 新機能（CI ガードレール）

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB 層 (`$lib/server/db/` registry)
- [x] テスト (`tests/unit/db/`)

**影響を受ける画面・機能**: なし（分類 SSOT + 機械検証の追加のみ。ランタイム挙動不変）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3329pr` 全 Step PASS**
- [x] 追加・変更したテストの概要: `backup-entity-registry.test.ts`（coverage / orphan / classification 妥当性 / ratchet の 4 ケース）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A（registry は分類メタのみ、keys.ts を読むだけ）
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（DB 分類メタ + テストのみ、UI 非変更）**: `.svelte` / `.css` の変更なし。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: 分類を 1 レジストリに集約。keys.ts を SSOT に機械照合
- [x] **YAGNI**: 分類メタ + 検証のみ。export 実装は段階対応
- [x] **Security**: settings の PIN(pin_hash) を CWE-522/916 で「除外 or 暗号化」と分類に明記（設計 D3）
- [x] **アクセシビリティ/パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): 設計 `docs/design/backup-import-redesign.md` §3.1 を実装。三分類原則の ADR 昇格は今後検討
- [x] **並行 PR overlap** (#1200): backup-entity-registry 新規ファイルのみ、衝突なし
- [ ] N/A

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（分類メタ + テスト追加のみ）

**レビュー依頼事項・QA**: 分類の妥当性をご確認ください。特に borderline: graduationConsent（運用記録として excluded だが家族データ性あり）/ trialHistory（billing として excluded）/ loginBonus（記録は source・streak は派生）/ statusHistory（source 確定、設計 §3.1 根拠）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3329pr` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分なし）
- [x] 全 AC が実装済み
- [x] Phase 分割: 未 export source 12 件の export 実装は本 registry を起点に段階対応
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
