### PR TITLE
test: #3183 shop_category の dynamodb null round-trip + assertion-erosion 是正

### DIFF
--- a/tests/unit/db/dynamodb-special-reward-repo.test.ts
+++ b/tests/unit/db/dynamodb-special-reward-repo.test.ts
@@ -158,6 +158,53 @@ describe('updateSpecialReward (#2832 / #2845 課題①)', () => {
 		expect(result?.title).toBe('ゲーム時間30分');
 		expect(mockSend).toHaveBeenCalledTimes(1);
 	});
+
+	// #3183 / #3154: shopCategory (陳列系統) の dynamodb round-trip。SQLite e2e は本体 PR で担保済だが
+	// dynamodb backend は未 exercise だった。明示値 / null リセット の両方が UpdateCommand に正しく
+	// marshalling され round-trip することを固定する (prod=dynamodb で「auto にリセット」が silent
+	// no-op になる latent risk の回帰防止、既出荷 icon nullable と構造同型)。
+	it('#3183: shopCategory 明示値を SET し round-trip する (money)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [makeRewardItem()] })
+			.mockResolvedValueOnce({ Attributes: makeRewardItem({ shopCategory: 'money' }) });
+		const { updateSpecialReward } = await loadRepo();
+		const result = await updateSpecialReward(
+			CHILD_ID,
+			REWARD_ID,
+			{ shopCategory: 'money' },
+			TENANT,
+		);
+		const update = mockSend.mock.calls[1]?.[0] as {
+			input: {
+				UpdateExpression?: string;
+				ExpressionAttributeNames?: Record<string, string>;
+				ExpressionAttributeValues?: Record<string, unknown>;
+			};
+		};
+		expect(update.input.UpdateExpression).toContain('#shopCategory = :shopCategory');
+		expect(update.input.ExpressionAttributeNames?.['#shopCategory']).toBe('shopCategory');
+		expect(update.input.ExpressionAttributeValues?.[':shopCategory']).toBe('money');
+		expect(result?.shopCategory).toBe('money');
+	});
+
+	it('#3183: shopCategory=null (auto リセット) も SET し null を marshalling round-trip する', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Items: [makeRewardItem({ shopCategory: 'money' })] })
+			.mockResolvedValueOnce({ Attributes: makeRewardItem({ shopCategory: null }) });
+		const { updateSpecialReward } = await loadRepo();
+		const result = await updateSpecialReward(CHILD_ID, REWARD_ID, { shopCategory: null }, TENANT);
+		const update = mockSend.mock.calls[1]?.[0] as {
+			input: {
+				UpdateExpression?: string;
+				ExpressionAttributeValues?: Record<string, unknown>;
+			};
+		};
+		// null も undefined と区別して SET される (no-op で旧値を残さない = auto へ確実にリセット)
+		expect(update.input.UpdateExpression).toContain('#shopCategory = :shopCategory');
+		expect(update.input.ExpressionAttributeValues).toHaveProperty(':shopCategory');
+		expect(update.input.ExpressionAttributeValues?.[':shopCategory']).toBeNull();
+		expect(result?.shopCategory).toBeNull();
+	});
 });
 
 describe('deleteSpecialReward (#2832 / #2845 課題①)', () => {

--- a/tests/unit/services/special-reward-service.test.ts
+++ b/tests/unit/services/special-reward-service.test.ts
@@ -596,6 +596,8 @@ describe('#2832 deleteReward / updateReward (pending redemption ガード)', () 
 			{ title: 'ゲーム時間30分', points: 80, shopCategory: 'money' },
 			'test-tenant',
 		);
+		// #3183 (ADR-0006): 早期 return だけだと error 退行を緑で通すため明示 assert を前置する
+		expect('error' in result).toBe(false);
 		if ('error' in result) return;
 		expect(result.shopCategory).toBe('money');
 
@@ -605,6 +607,7 @@ describe('#2832 deleteReward / updateReward (pending redemption ガード)', () 
 			{ title: 'ゲーム時間30分', points: 80, shopCategory: null },
 			'test-tenant',
 		);
+		expect('error' in cleared).toBe(false);
 		if ('error' in cleared) return;
 		expect(cleared.shopCategory).toBeNull();
 	});
@@ -623,6 +626,8 @@ describe('#2832 deleteReward / updateReward (pending redemption ガード)', () 
 			{ title: '新タイトル', points: 80 },
 			'test-tenant',
 		);
+		// #3183 (ADR-0006): 早期 return だけだと error 退行を緑で通すため明示 assert を前置する
+		expect('error' in result).toBe(false);
 		if ('error' in result) return;
 		expect(result.title).toBe('新タイトル');
 		expect(result.shopCategory).toBe('privilege');


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（prod=dynamodb のデータ整合）

**解決する課題**: ごほうび `shop_category`（陳列系統）の dynamodb 経路が未 exercise で、`shopCategory=null`（「auto に戻す」操作）が UpdateCommand に正しく marshalling されず silent no-op になる latent risk が回帰検知できていなかった。あわせて #3154 service test に assertion-erosion（早期 return だけで error 退行を緑で通す穴）が残っていた。

**期待される効果**: prod backend での shop_category round-trip を機械担保し、error 退行を緑で通さない。

## 関連 Issue

関連: #3183（Part 1/3 を消化、Part 2 e2e は範囲外）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | dynamodb で shopCategory round-trip を test 担保 | `npx vitest run tests/unit/db/dynamodb-special-reward-repo.test.ts` | money/null 両 round-trip 追加 / PASS |
| AC2 | null（auto リセット）が silent no-op しない回帰防止 | 同 test「shopCategory=null も SET し null を round-trip」 | `:shopCategory` が null で SET される assert PASS |
| AC3 | 既存 #3154 test の assertion 健全化（ADR-0006） | `npx vitest run tests/unit/services/special-reward-service.test.ts` | 3 箇所で `expect('error' in x).toBe(false)` 前置 / 54 tests PASS |
| AC4 | Part 2（child-shop 系統移動 e2e） | 本 PR 範囲外（重量 e2e、Pre-PMF Bucket B、ADR-0010） | <!-- ac-verification-skip: 範囲外 / Pre-PMF --> |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI（テストのみ）

**影響を受ける画面・機能**: `tests/` のみ。production code 変更なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: dynamodb-special-reward-repo.test.ts に money/null round-trip 2 件、special-reward-service.test.ts に assertion 前置 3 箇所
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（test 追加のみ、実装は既存挙動の固定）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（test 追加のみ、UI 変更なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 既存 test 構造に追随
- [x] **DRY**: 既存 `makeRewardItem` helper を再利用
- [x] **YAGNI**: 必要最小の round-trip 検証のみ
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（test 追加のみ）
- [x] **設計書同期** (ADR-0001): 仕様変更なし（既存挙動の test 固定）のため更新なし
- [x] **並行 PR overlap** (#1200): 対象 test ファイルを変更する open PR は他に無し

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- Part 1 の mock 期待値が dynamodb update fn 実装（`#shopCategory = :shopCategory`）と一致しているか
- Part 3 の expect 前置が ADR-0006 の意図に沿うか

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC が実装済み（Part 2 は範囲外を明記）
- [x] Phase 分割した場合: Part 単位で分割
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->

