### PR TITLE
chore: #3215 LP yearly 撤去 follow-up — dead CSS + checker yearly 分岐除去

### DIFF
--- a/scripts/check-lp-plan-sync.mjs
+++ b/scripts/check-lp-plan-sync.mjs
@@ -7,7 +7,7 @@
  *
  * チェック対象:
  *  1. `site/pricing.html` — 網羅的な料金ページ。
- *     - PRICING_PAGE_META の全プランの `price` / `yearlyPrice` が HTML に現れる
+ *     - PRICING_PAGE_META の全プランの `price` が HTML に現れる
  *     - PRICING_PAGE_FEATURES の全 feature 文字列が HTML に現れる（完全一致 substring）
  *  2. `site/index.html` — LP トップの料金セクション。
  *     - PRICING_PAGE_META の全プランの `price` が HTML に現れる
@@ -98,16 +98,17 @@ function parsePlanFeatures() {
 
 	// PRICING_PAGE_META: Record<PlanKey, PricingPageMeta> = {
 	//   free: { ..., price: '¥0', unit: '', ... },
-	//   standard: { ..., price: '¥500', unit: '/月', yearlyPrice: '年額 ¥5,000 ...' },
+	//   standard: { ..., price: '¥500', unit: '/月', ... },
 	//   ...
 	// }
+	// 年額 (yearlyPrice) は #2719 / #3212 で全廃 (月額のみ)。yearly 分岐は #3215 で除去。
 	const metaBlockMatch = src.match(/export const PRICING_PAGE_META[^{]*{([\s\S]*?)\n} as const;/);
 	if (!metaBlockMatch) {
 		throw new Error('PRICING_PAGE_META block not found in plan-features.ts');
 	}
 	const metaBlock = metaBlockMatch[1];
 
-	/** @type {Record<'free'|'standard'|'family', { price: string; yearlyPrice?: string }>} */
+	/** @type {Record<'free'|'standard'|'family', { price: string }>} */
 	const meta = { free: { price: '' }, standard: { price: '' }, family: { price: '' } };
 	for (const plan of /** @type {const} */ (['free', 'standard', 'family'])) {
 		const planMatch = metaBlock.match(new RegExp(`${plan}:\\s*{([\\s\\S]*?)^\\s*}`, 'm'));
@@ -120,11 +121,6 @@ function parsePlanFeatures() {
 			throw new Error(`PRICING_PAGE_META.${plan}.price not found`);
 		}
 		meta[plan].price = priceMatch[1];
-
-		const yearlyMatch = body.match(/yearlyPrice:\s*'([^']+)'/);
-		if (yearlyMatch) {
-			meta[plan].yearlyPrice = yearlyMatch[1];
-		}
 	}
 
 	return { features, meta };
@@ -174,26 +170,19 @@ function verifyMinPaidPricePolicy(html, ssot) {
 }
 
 /**
- * 全プラン価格 (+ 条件次第で年額) を検証する既定ポリシー。
+ * 全プラン価格 (月額) を検証する既定ポリシー。
  *
  * @param {string} html
  * @param {ReturnType<typeof parsePlanFeatures>} ssot
- * @param {boolean} checkYearlyPrice
  * @returns {string[]}
  */
-function verifyAllPricesPolicy(html, ssot, checkYearlyPrice) {
+function verifyAllPricesPolicy(html, ssot) {
 	/** @type {string[]} */
 	const errors = [];
 	for (const plan of /** @type {const} */ (['free', 'standard', 'family'])) {
-		const { price, yearlyPrice } = ssot.meta[plan];
+		const { price } = ssot.meta[plan];
 		if (!htmlContains(html, price)) {
 			errors.push(`[${plan}] price "${price}" が HTML に現れない`);
-		}
-		if (checkYearlyPrice && yearlyPrice) {
-			const yearlyMatch = yearlyPrice.match(/年額\s*¥[\d,]+/);
-			if (yearlyMatch && !htmlContains(html, yearlyMatch[0])) {
-				errors.push(`[${plan}] yearlyPrice "${yearlyMatch[0]}" が HTML に現れない`);
-			}
 		}
 	}
 	return errors;
@@ -204,9 +193,8 @@ function verifyAllPricesPolicy(html, ssot, checkYearlyPrice) {
  *
  * @param {string} filePath
  * @param {ReturnType<typeof parsePlanFeatures>} ssot
- * @param {{ strictFeatures: boolean; checkYearlyPrice: boolean; checkFeatures?: boolean; pricePolicy?: 'all' | 'minPaid' }} opts
+ * @param {{ strictFeatures: boolean; checkFeatures?: boolean; pricePolicy?: 'all' | 'minPaid' }} opts
  *   strictFeatures=true: 全 feature が含まれる必要
- *   checkYearlyPrice=true: 年額価格もチェックする（pamphlet / index は月額のみなので除外）
  *   checkFeatures=false: features チェック自体をスキップ（#1141 以降の index.html
  *     のように feature を要約して書き直す summary セクション用。pricing.html への
  *     リンクがあり詳細は別ページで担保される場合に使う）
@@ -216,7 +204,7 @@ function verifyAllPricesPolicy(html, ssot, checkYearlyPrice) {
 function verifyHtmlFile(
 	filePath,
 	ssot,
-	{ strictFeatures, checkYearlyPrice, checkFeatures = true, pricePolicy = 'all' },
+	{ strictFeatures, checkFeatures = true, pricePolicy = 'all' },
 ) {
 	const rel = path.relative(REPO_ROOT, filePath);
 	if (!fs.existsSync(filePath)) {
@@ -231,7 +219,7 @@ function verifyHtmlFile(
 	const priceErrors =
 		pricePolicy === 'minPaid'
 			? verifyMinPaidPricePolicy(html, ssot)
-			: verifyAllPricesPolicy(html, ssot, checkYearlyPrice);
+			: verifyAllPricesPolicy(html, ssot);
 	errors.push(...priceErrors);
 
 	// --- 特典リストチェック ---
@@ -291,18 +279,17 @@ function main() {
 	const lpFiles = [SITE_PRICING_HTML, SITE_INDEX_HTML, SITE_PAMPHLET_HTML];
 
 	const results = [
-		verifyHtmlFile(SITE_PRICING_HTML, ssot, { strictFeatures: true, checkYearlyPrice: true }),
+		verifyHtmlFile(SITE_PRICING_HTML, ssot, { strictFeatures: true }),
 		// #1293 以降、index.html の料金セクションは「価格プロミスバンド」に簡素化された
 		// (freemium × 低価格帯での price disambiguation / 配置原則は lp-content-map.md 参照)。
 		// 最低有料価格と安心シグナル文言のみ pricePolicy='minPaid' で検証し、
-		// 全プラン網羅・年額・feature 詳細は pricing.html 側で strict チェックする。
+		// 全プラン網羅・feature 詳細は pricing.html 側で strict チェックする。
 		verifyHtmlFile(SITE_INDEX_HTML, ssot, {
 			strictFeatures: false,
-			checkYearlyPrice: false,
 			checkFeatures: false,
 			pricePolicy: 'minPaid',
 		}),
-		verifyHtmlFile(SITE_PAMPHLET_HTML, ssot, { strictFeatures: false, checkYearlyPrice: false }),
+		verifyHtmlFile(SITE_PAMPHLET_HTML, ssot, { strictFeatures: false }),
 	];
 
 	const bannedResults = lpFiles.map(verifyNoBannedTerms);

--- a/site/pricing.html
+++ b/site/pricing.html
@@ -71,14 +71,10 @@
 .plan-cta-direct:hover{background:var(--brand-50);text-decoration:none}
 .cta-trial-note{font-size:.7rem;color:var(--gray-500);text-align:center;margin:0 0 var(--space-2);line-height:1.5}
 .cta-direct-note{font-size:.7rem;color:var(--gray-700);background:var(--gray-50);border:1px solid var(--gray-200);border-radius:6px;padding:var(--space-2) var(--space-2);margin:0 0 var(--space-3);line-height:1.5;text-align:center}
-/* #3212: 月額/年額トグル (.billing-toggle) は撤去 (年額廃止 #2719) */
-.billing-toggle input[type=radio]:focus-visible + span{outline:2px solid var(--brand-500);outline-offset:2px;border-radius:2rem}
 /* #2103 F-2: CTA-bottom 直下の解約 small リンク (既存有料ユーザー誘導) */
 .existing-cancel-link{font-size:.82rem;color:var(--gray-700);margin-top:var(--space-4);line-height:1.6}
 .existing-cancel-link a{color:var(--brand-700);text-decoration:underline}
 .existing-cancel-link a:hover{color:var(--brand-800)}
-/* #2102 F-1: スクリーンリーダー専用 legend (visually hidden, modern clip-path 方式で負値を回避) */
-.billing-toggle .sr-only{position:absolute;width:1px;height:1px;overflow:hidden;clip-path:inset(50%);white-space:nowrap;border:0}
 .plan-features{list-style:none;padding:0;flex:1}
 .plan-features li{font-size:.85rem;color:var(--gray-700);padding:6px 0 6px 24px;position:relative;line-height:1.5}
 .plan-features li::before{content:'\2713';position:absolute;left:0;color:var(--green-500);font-weight:700}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（LP 保守性 / CI checker 健全性）

**解決する課題**: 年額廃止（#2719 / #3212）後に残った dead code が「撤去済」コメントと不整合で、将来 yearly 再追加時の blind spot にもなる。

**期待される効果**: orphan CSS と dead checker 分岐を除去し、LP / checker の整合を回復する。

## 関連 Issue

closes #3215

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | dead `.billing-toggle` CSS の除去 | `grep -rn billing-toggle site/` | orphan 2 selector 削除 / DOM 参照ゼロ確認 / 視覚影響なし |
| AC2 | `check-lp-plan-sync.mjs` の yearly 分岐除去 | `node scripts/check-lp-plan-sync.mjs --check` | checkYearlyPrice / yearlyPrice / yearly 分岐を全除去 / 全 LP 同期 PASS |
| AC3 | tokushoho / faq の年額残存 | #3208（priority:high 法務、PR #3216 merged）で対応済 | 本 PR 範囲外 <!-- ac-verification-skip: #3208 で対応済 --> |
| AC4 | FR-2 yearly 廃止の残 track（admin toggle / Stripe 等） | 進行中の独立 effort | 本 PR 範囲外 <!-- ac-verification-skip: 独立 effort --> |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] LP サイト (`site/`)
- [x] 設定・CI（`scripts/check-lp-plan-sync.mjs`）

**影響を受ける画面・機能**: LP 料金ページ（描画非影響の dead CSS 削除）+ CI checker。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: N/A（dead code 削除 + checker の yearly 分岐除去。`check-lp-plan-sync.mjs --check` で全 LP 同期確認）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（orphan CSS = 描画に効いていない dead selector の削除のみ、視覚影響なし。`refactor:internal-no-doc-impact` ラベル適用）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: checker の yearly 責務を完全除去
- [x] **DRY**: yearly 分岐の重複ロジックを撤去
- [x] **YAGNI**: 廃止済 feature の vestigial guard を除去
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A（削除した CSS は非描画 dead selector）
- [x] **パフォーマンス**: LP CSS わずか減（height 微減方向）

## 横展開・影響波及チェック

- [x] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: 年額廃止と整合（実装に存在しない年額の LP 記載を除去する方向）
- [x] **設計書同期** (ADR-0001): dead code 削除のみ、仕様変更なし
- [x] **並行 PR overlap** (#1200): `site/pricing.html` / `check-lp-plan-sync.mjs` を変更する open PR は他に無し

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A（dead CSS / checker 分岐の除去のみ、表示文言は不変）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- `.billing-toggle` が本当に DOM 未参照か（grep 証跡）
- checker から yearly を消しても全 LP 同期 PASS を保つか

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC が実装済み（AC3/AC4 は範囲外を明記）
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A（非描画 dead CSS の削除のみ）
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->
