### PR TITLE
fix: #3211 Discord webhook のユーザー自由記述 mention sanitization (item1a)

### DIFF
--- a/src/lib/server/services/discord-notify-service.ts
+++ b/src/lib/server/services/discord-notify-service.ts
@@ -31,6 +31,23 @@ function getWebhookUrl(channel: DiscordChannel): string | undefined {
 	return undefined;
 }
 
+/**
+ * #3211: ユーザー自由記述を Discord embed に載せる前の sanitization。
+ *
+ * Discord は embed の description / field value 内では @everyone / @here / role mention を
+ * ping 発火させない (ping は webhook の top-level `content` のみ) が、将来 content 化された
+ * ときの誤爆と、運用画面での視認ノイズを防ぐため defense-in-depth で mention 構文を中和する。
+ * お子さまの年齢など PII を含む自由記述 (#3211 item1) が webhook JSON に素通りするのを抑える。
+ *
+ * - `@everyone` / `@here` は `@` 直後に zero-width space (U+200B) を挿入して mention 文字列を壊す
+ * - `<@123>` / `<@!123>` / `<@&123>` (user/role) / `<#123>` (channel) mention は `<` 直後に同様
+ *
+ * 文字は削除せず可視内容は保持する (運用者が原文を読めるよう、無害化のみ行う)。
+ */
+export function sanitizeDiscordText(text: string): string {
+	return text.replace(/@(everyone|here)/gi, '@​$1').replace(/<(@!?&?|#)(\d+)>/g, '<​$1$2>');
+}
+
 /** Discord Webhook にメッセージを送信（失敗してもエラーを投げない） */
 export async function notifyDiscord(channel: DiscordChannel, embed: DiscordEmbed): Promise<void> {
 	const webhookUrl = getWebhookUrl(channel);
@@ -156,7 +173,8 @@ export async function notifyCancellationWithReason(input: {
 				? [
 						{
 							name: '自由記述',
-							value: input.freeText.slice(0, 1024),
+							// #3211: 解約理由の自由記述も mention 構文を中和して embed に載せる
+							value: sanitizeDiscordText(input.freeText.slice(0, 1024)),
 							inline: false,
 						},
 					]
@@ -225,15 +243,21 @@ export async function notifyInquiry(
 		other: 'その他',
 	};
 
+	// #3211: ユーザー自由記述 (text=本文、childAge を含む / replyEmail / email) は
+	// mention 構文を中和してから embed に載せる (PII 自由記述の webhook 素通り抑止 + 誤 ping 防止)。
 	await notifyDiscord('inquiry', {
 		title: `📬 ${categoryLabel[category] ?? category}${inquiryId ? ` (${inquiryId})` : ''}`,
-		description: text.slice(0, 2000),
+		description: sanitizeDiscordText(text.slice(0, 2000)),
 		color: category === 'bug' ? 0xff4444 : 0x4a90d9,
 		fields: [
 			...(inquiryId ? [{ name: '受付番号', value: inquiryId, inline: true }] : []),
 			{ name: 'テナント', value: tenantId, inline: true },
-			{ name: '送信者', value: email, inline: true },
-			{ name: '返信先', value: replyEmail || 'なし', inline: true },
+			{ name: '送信者', value: sanitizeDiscordText(email), inline: true },
+			{
+				name: '返信先',
+				value: replyEmail ? sanitizeDiscordText(replyEmail) : 'なし',
+				inline: true,
+			},
 		],
 	});
 }

--- a/tests/unit/services/discord-notify-service.test.ts
+++ b/tests/unit/services/discord-notify-service.test.ts
@@ -221,7 +221,7 @@ describe('discord-notify-service', () => {
 			expect(desc).not.toMatch(/@everyone/);
 			expect(desc).not.toMatch(/@here/);
 			expect(desc).not.toMatch(/<@&999>/);
-			expect(desc).toContain('everyone'); // ZWSP 挿入で文字自体は保持
+			expect(desc).toContain('everyone'); // zero-width space 挿入で文字自体は保持
 			expect(desc).toContain('見てください');
 		});
 	});

--- a/tests/unit/services/discord-notify-service.test.ts
+++ b/tests/unit/services/discord-notify-service.test.ts
@@ -30,6 +30,7 @@ import {
 	notifyIncident,
 	notifyInquiry,
 	notifyNewSignup,
+	sanitizeDiscordText,
 } from '$lib/server/services/discord-notify-service';
 
 describe('discord-notify-service', () => {
@@ -203,6 +204,48 @@ describe('discord-notify-service', () => {
 				expect.arrayContaining([
 					expect.objectContaining({ name: '返信先', value: 'reply@test.com' }),
 				]),
+			);
+		});
+
+		// #3211: ユーザー自由記述の mention 構文中和 (PII 自由記述の webhook 素通り抑止 + 誤 ping 防止)
+		it('本文の @everyone / @here / role mention を中和して embed に載せる', async () => {
+			await notifyInquiry(
+				'tenant-1',
+				'other',
+				'緊急 @everyone @here <@&999> 見てください',
+				'user@test.com',
+			);
+			const body = getLastBody();
+			const desc = body.embeds[0].description as string;
+			// 可視内容は保持しつつ mention 構文を壊す (素の @everyone / role mention は残らない)
+			expect(desc).not.toMatch(/@everyone/);
+			expect(desc).not.toMatch(/@here/);
+			expect(desc).not.toMatch(/<@&999>/);
+			expect(desc).toContain('everyone'); // ZWSP 挿入で文字自体は保持
+			expect(desc).toContain('見てください');
+		});
+	});
+
+	describe('sanitizeDiscordText (#3211)', () => {
+		it('@everyone / @here を中和する (文字は保持、mention は壊す)', () => {
+			const out = sanitizeDiscordText('@everyone and @here');
+			expect(out).not.toMatch(/@everyone/);
+			expect(out).not.toMatch(/@here/);
+			expect(out).toContain('everyone');
+			expect(out).toContain('here');
+		});
+
+		it('user / role / channel mention (<@123> / <@&123> / <#123>) を中和する', () => {
+			const out = sanitizeDiscordText('<@123> <@!456> <@&789> <#321>');
+			expect(out).not.toMatch(/<@123>/);
+			expect(out).not.toMatch(/<@!456>/);
+			expect(out).not.toMatch(/<@&789>/);
+			expect(out).not.toMatch(/<#321>/);
+		});
+
+		it('mention を含まない通常文はそのまま (誤変換しない)', () => {
+			expect(sanitizeDiscordText('普通の問い合わせ user@example.com')).toBe(
+				'普通の問い合わせ user@example.com',
 			);
 		});
 	});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（運用者向け Discord 通知の受け手）+ システム全体（PII 保護）

**解決する課題**: サポート問い合わせ統合（#3206）で、consult 時にお子さまの年齢（PII）を含むユーザー自由記述（inquiry 本文 / 返信先 / 解約理由）が無害化されずに Discord webhook embed に素通りしていた。mention 構文（@everyone 等）の誤爆余地もあった。

**期待される効果**: ユーザー自由記述の mention 構文を中和し、誤 ping・運用画面ノイズ・PII 素通りを抑止する（defense-in-depth）。

## 関連 Issue

<!-- #3211 は item1a のみ消化。残 item は同 issue に残置するため自動 close しない（keyword を付けない） -->
関連: #3211（item1a を消化、残 item1b/2/3 は同 issue 残置）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | item1a: Discord payload の mention sanitization | `npx vitest run tests/unit/services/discord-notify-service.test.ts` | HEAD 反映 / 16 passed（sanitizer 3 + notifyInquiry 中和 1 + 既存 12）/ discord-notify-service.ts:47 `sanitizeDiscordText` |
| AC2 | notifyInquiry / notifyCancellationWithReason に適用 | grep `sanitizeDiscordText` | discord-notify-service.ts text/email/replyEmail + freeText 各適用箇所 |
| AC3 | 通常文を誤変換しない（後方互換） | 同 test「mention を含まない通常文はそのまま」 | `user@example.com` 等が無変換で PASS |
| AC4 | item1b（childAge typed-column / retention）/ item2（UI polish）/ item3（success hadEmail） | 本 PR 範囲外（UI は SS 撮影を要し別 PR、PII retention は設計判断を要す） | #3211 残置 <!-- ac-verification-skip: 範囲外、#3211 で後続対応 --> |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`)

**影響を受ける画面・機能**: 運用者向け Discord 通知（サポート問い合わせ / 解約理由）。ユーザー向け UI には影響なし（サーバー側通知のみ）。caller（support / feedback / cancellation）は無変更（sanitization は service 内に集約）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `discord-notify-service.test.ts` に sanitizeDiscordText 単体 3 件 + notifyInquiry の mention 中和 1 件を追加（計 16 passed）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（サーバー側 Discord 通知サービスのみ、UI 変更なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: sanitization を service 内 1 関数に集約（caller 無変更）
- [x] **DRY**: 全 user-controlled フィールドで同一 `sanitizeDiscordText` を共用
- [x] **YAGNI**: 必要最小の正規表現 2 本のみ
- [x] **Security（OSS 公開前提）**: PII 自由記述の webhook 素通り抑止 + mention 誤爆中和（CWE-150 類縁）。可視内容は保持し無害化のみ
- [x] **アクセシビリティ**: N/A（サーバー通知）
- [x] **パフォーマンス**: 通知時に正規表現 2 回の軽量処理のみ

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（運用者向け Discord 通知サービス、本番/デモ UI 非依存）
- [x] **設計書同期** (ADR-0001): 外部仕様変更なし（既存通知に sanitization を内部追加）のため設計書更新なし
- [x] **並行 PR overlap** (#1200): `discord-notify-service.ts` を変更する open PR は他に無し（確認済）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（可視内容は保持、mention のみ無害化＝後方互換）

**レビュー依頼事項・QA**:
- zero-width space 挿入で mention が確実に壊れ、かつ通常文（`user@example.com` 等）を誤変換しないか
- 適用箇所（text / email / replyEmail / freeText）が user-controlled なフィールドを網羅しているか
- item1b/2/3 の本 PR 範囲外判断が妥当か

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（範囲外項目は #3211 残置を明記）
- [x] Phase 分割した場合: item 単位で分割（item1a を本 PR、残は #3211 残置）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->

