### PR TITLE
fix: #3329 ごほうび交換/購入履歴の backup round-trip 実装 + clear FK 連鎖バグ修正

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -175,6 +175,22 @@ export interface ExportSpecialReward {
 	sourcePresetId?: string | null;
 }
 
+export interface ExportRewardRedemption {
+	childRef: string;
+	/** import 後に FK rewardId を再解決するための reward タイトル (per-child で一意) */
+	rewardRef: string;
+	requestedAt: number;
+	status: string;
+	parentNote: string | null;
+	resolvedAt: number | null;
+	resolvedByParentId: string | null;
+	shownToChildAt: number | null;
+	// #2832: 申請時点 snapshot (reward 改名/削除後も申請時の内容で表示・控除する)
+	rewardTitle: string | null;
+	rewardPoints: number | null;
+	rewardIcon: string | null;
+}
+
 export interface ExportChecklistTemplate {
 	childRef: string;
 	name: string;
@@ -245,6 +261,8 @@ export interface ExportTransactionData {
 	loginBonuses: ExportLoginBonus[];
 	evaluations: ExportEvaluation[];
 	specialRewards: ExportSpecialReward[];
+	/** #3329: ごほうびショップ交換/購入履歴 (per-child、rewardRef で reward に再結合) */
+	rewardRedemptions: ExportRewardRedemption[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 	childAvatarItems: never[];

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -125,8 +125,9 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	rewardRedemption: {
 		classification: 'source',
 		schemaTable: 'rewardRedemptionRequests',
-		backupStatus: 'not-yet-exported',
-		reason: 'ごほうびショップ交換/購入履歴。残高整合に必須だが export 未対応 (#3329)',
+		backupStatus: 'exported',
+		reason:
+			'ごほうびショップ交換/購入履歴。export/import 実装済 (#3329、rewardRef で reward に再結合・status/snapshot 保全)',
 	},
 	childChallenge: {
 		classification: 'source',

--- a/src/lib/server/db/demo/reward-redemption-repo.ts
+++ b/src/lib/server/db/demo/reward-redemption-repo.ts
@@ -24,6 +24,36 @@ export async function insertRedemptionRequest(
 	};
 }
 
+export async function insertRedemptionForRestore(
+	input: {
+		childId: number;
+		rewardId: number;
+		requestedAt: number;
+		status: string;
+		parentNote: string | null;
+		resolvedAt: number | null;
+		resolvedByParentId: string | null;
+		shownToChildAt: number | null;
+		rewardTitle: string | null;
+		rewardPoints: number | null;
+		rewardIcon: string | null;
+	},
+	_tenantId: string,
+): Promise<RedemptionRequestRow> {
+	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
+	return {
+		id: 0,
+		childId: input.childId,
+		rewardId: input.rewardId,
+		requestedAt: input.requestedAt,
+		status: input.status,
+		parentNote: input.parentNote,
+		resolvedAt: input.resolvedAt,
+		resolvedByParentId: input.resolvedByParentId,
+		shownToChildAt: input.shownToChildAt,
+	};
+}
+
 export async function findRedemptionRequestsByChild(
 	_childId: number,
 	_tenantId: string,

--- a/src/lib/server/db/dynamodb/reward-redemption-repo.ts
+++ b/src/lib/server/db/dynamodb/reward-redemption-repo.ts
@@ -162,6 +162,61 @@ export const insertRedemptionRequest: IRewardRedemptionRepo['insertRedemptionReq
 };
 
 // ============================================================
+// insertRedemptionForRestore — backup restore 用 (全フィールド保全、#3329)
+// ============================================================
+
+export const insertRedemptionForRestore: IRewardRedemptionRepo['insertRedemptionForRestore'] =
+	async (input, tenantId): Promise<RedemptionRequestRow> => {
+		const id = await nextId(ENTITY_NAMES.rewardRedemption, tenantId);
+
+		const row: RedemptionRequestRow = {
+			id,
+			childId: input.childId,
+			rewardId: input.rewardId,
+			requestedAt: input.requestedAt,
+			status: input.status,
+			parentNote: input.parentNote,
+			resolvedAt: input.resolvedAt,
+			resolvedByParentId: input.resolvedByParentId,
+			shownToChildAt: input.shownToChildAt,
+		};
+
+		// JOIN 代替の非正規化フィールド: snapshot を優先し、欠落時のみ live 解決へ fallback。
+		const child = await findChildByIdRaw(input.childId, tenantId);
+		let rewardTitle = input.rewardTitle;
+		let rewardIcon = input.rewardIcon;
+		let rewardPoints = input.rewardPoints;
+		if (rewardTitle === null || rewardPoints === null) {
+			const reward = await findRewardFields(input.childId, input.rewardId, tenantId);
+			rewardTitle = rewardTitle ?? reward?.title ?? '';
+			rewardIcon = rewardIcon ?? reward?.icon ?? null;
+			rewardPoints = rewardPoints ?? reward?.points ?? 0;
+		}
+
+		const denorm: DenormFields = {
+			childName: child?.nickname ?? '',
+			rewardTitle: rewardTitle ?? '',
+			rewardIcon,
+			rewardPoints: rewardPoints ?? 0,
+		};
+
+		await getDocClient().send(
+			new PutCommand({
+				TableName: TABLE_NAME,
+				Item: {
+					...rewardRedemptionKey(input.childId, id, tenantId),
+					...row,
+					// denorm.rewardTitle/Icon/Points は snapshot 優先で解決済 (SQLite の
+					// COALESCE(snapshot, live) 読み出しと等価の表示値を item に非正規化保存)。
+					...denorm,
+				},
+			}),
+		);
+
+		return row;
+	};
+
+// ============================================================
 // findRedemptionRequestsByChild — 子供の申請一覧 (最新順)
 // ============================================================
 

--- a/src/lib/server/db/interfaces/reward-redemption-repo.interface.ts
+++ b/src/lib/server/db/interfaces/reward-redemption-repo.interface.ts
@@ -30,6 +30,29 @@ export interface IRewardRedemptionRepo {
 		tenantId: string,
 	): Promise<RedemptionRequestRow>;
 
+	/**
+	 * #3329 backup restore 用: 申請時点の全フィールド (status / 解決情報 / snapshot) を保全して
+	 * 復元する。通常の insertRedemptionRequest は status を pending 固定 + live reward を引くため
+	 * round-trip で承認済/却下/snapshot が失われる。本メソッドは export された値をそのまま書き戻す。
+	 * id は新規採番 (元 id は保全しない、FK は呼び出し側が解決済の rewardId を渡す)。
+	 */
+	insertRedemptionForRestore(
+		input: {
+			childId: number;
+			rewardId: number;
+			requestedAt: number;
+			status: string;
+			parentNote: string | null;
+			resolvedAt: number | null;
+			resolvedByParentId: string | null;
+			shownToChildAt: number | null;
+			rewardTitle: string | null;
+			rewardPoints: number | null;
+			rewardIcon: string | null;
+		},
+		tenantId: string,
+	): Promise<RedemptionRequestRow>;
+
 	findRedemptionRequestsByChild(childId: number, tenantId: string): Promise<RedemptionRequestRow[]>;
 
 	findRedemptionRequestsByTenant(

--- a/src/lib/server/db/reward-redemption-repo.ts
+++ b/src/lib/server/db/reward-redemption-repo.ts
@@ -13,6 +13,26 @@ export async function findRedemptionRequestsByChild(childId: number, tenantId: s
 	return getRepos().rewardRedemption.findRedemptionRequestsByChild(childId, tenantId);
 }
 
+/** #3329 backup restore 用: 申請時点の全フィールド (status / 解決情報 / snapshot) を保全して復元。 */
+export async function insertRedemptionForRestore(
+	input: {
+		childId: number;
+		rewardId: number;
+		requestedAt: number;
+		status: string;
+		parentNote: string | null;
+		resolvedAt: number | null;
+		resolvedByParentId: string | null;
+		shownToChildAt: number | null;
+		rewardTitle: string | null;
+		rewardPoints: number | null;
+		rewardIcon: string | null;
+	},
+	tenantId: string,
+) {
+	return getRepos().rewardRedemption.insertRedemptionForRestore(input, tenantId);
+}
+
 export async function findRedemptionRequestsByTenant(
 	tenantId: string,
 	opts?: { status?: string; childId?: number; limit?: number },

--- a/src/lib/server/db/sqlite/reward-redemption-repo.ts
+++ b/src/lib/server/db/sqlite/reward-redemption-repo.ts
@@ -51,6 +51,46 @@ export async function insertRedemptionRequest(
 		.get();
 }
 
+/**
+ * #3329 backup restore 用: 申請時点の全フィールドを保全して復元する。
+ * insertRedemptionRequest と異なり status / 解決情報 / snapshot を引数の値のまま書き戻す
+ * (live reward 参照しない)。FK rewardId は呼び出し側が import 後の reward に解決済。
+ */
+export async function insertRedemptionForRestore(
+	input: {
+		childId: number;
+		rewardId: number;
+		requestedAt: number;
+		status: string;
+		parentNote: string | null;
+		resolvedAt: number | null;
+		resolvedByParentId: string | null;
+		shownToChildAt: number | null;
+		rewardTitle: string | null;
+		rewardPoints: number | null;
+		rewardIcon: string | null;
+	},
+	_tenantId: string,
+) {
+	return db
+		.insert(rewardRedemptionRequests)
+		.values({
+			childId: input.childId,
+			rewardId: input.rewardId,
+			requestedAt: input.requestedAt,
+			status: input.status,
+			parentNote: input.parentNote,
+			resolvedAt: input.resolvedAt,
+			resolvedByParentId: input.resolvedByParentId,
+			shownToChildAt: input.shownToChildAt,
+			rewardTitle: input.rewardTitle,
+			rewardPoints: input.rewardPoints,
+			rewardIcon: input.rewardIcon,
+		})
+		.returning()
+		.get();
+}
+
 /** 子供の交換申請一覧を取得（最新順） */
 export async function findRedemptionRequestsByChild(childId: number, _tenantId: string) {
 	return db

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -17,6 +17,7 @@ import {
 	type ExportLoginBonus,
 	type ExportOptions,
 	type ExportPointLedger,
+	type ExportRewardRedemption,
 	type ExportSpecialReward,
 	type ExportStatus,
 	type ExportStatusHistory,
@@ -35,6 +36,7 @@ import { findEvaluationsByChild } from '$lib/server/db/evaluation-repo';
 import { getRepos } from '$lib/server/db/factory';
 import { findRecentBonuses } from '$lib/server/db/login-bonus-repo';
 import { findPointHistory } from '$lib/server/db/point-repo';
+import { findRedemptionRequestsByTenant } from '$lib/server/db/reward-redemption-repo';
 import { findSpecialRewards } from '$lib/server/db/special-reward-repo';
 import { findRecentStatusHistory, findStatuses } from '$lib/server/db/status-repo';
 import { logger } from '$lib/server/logger';
@@ -220,6 +222,7 @@ interface ChildTransactionData {
 	loginBonuses: ExportLoginBonus[];
 	evaluations: ExportEvaluation[];
 	specialRewards: ExportSpecialReward[];
+	rewardRedemptions: ExportRewardRedemption[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 }
@@ -246,6 +249,7 @@ async function collectForChild(
 		loginBonuses,
 		evaluations,
 		specialRewards,
+		redemptions,
 		checklistTemplates,
 	] = await Promise.all([
 		// #3327 P2: per-child 活動インスタンスを backup に保持 (archive 済も含む)。
@@ -256,6 +260,9 @@ async function collectForChild(
 		findRecentBonuses(childId, tenantId, MAX_EXPORT_ROWS),
 		findEvaluationsByChild(childId, MAX_EXPORT_ROWS, tenantId),
 		findSpecialRewards(childId, tenantId),
+		// #3329: ごほうびショップ交換/購入履歴を backup に保持 (WithDetails = snapshot 解決済の
+		// rewardTitle/Icon/Points 付き)。childId filter で per-child 収集する。
+		findRedemptionRequestsByTenant(tenantId, { childId, limit: MAX_EXPORT_ROWS }),
 		// #3106: backup なので includeInactive=true + includeArchived=true。
 		// archive 済 template も含め、その checklistLog の silent drop を防ぐ。
 		findTemplatesByChild(childId, tenantId, true, true),
@@ -364,6 +371,23 @@ async function collectForChild(
 		sourcePresetId: sr.sourcePresetId,
 	}));
 
+	// #3329: 交換履歴。FK rewardId は import 後に変わるため rewardRef (reward title) で再結合する。
+	// WithDetails の rewardTitle は snapshot 優先で解決済 (COALESCE(snapshot, live))。
+	warnIfTruncated('rewardRedemptions', childId, redemptions.length);
+	const rewardRedemptionsOut: ExportRewardRedemption[] = redemptions.map((r) => ({
+		childRef,
+		rewardRef: r.rewardTitle,
+		requestedAt: r.requestedAt,
+		status: r.status,
+		parentNote: r.parentNote,
+		resolvedAt: r.resolvedAt,
+		resolvedByParentId: r.resolvedByParentId,
+		shownToChildAt: r.shownToChildAt,
+		rewardTitle: r.rewardTitle,
+		rewardPoints: r.rewardPoints,
+		rewardIcon: r.rewardIcon,
+	}));
+
 	// Checklist templates with items
 	// #3078 / #3107: templateId → (name, exportId) マップを構築し checklistLogs の参照解決に使う。
 	// exportId は export 内で安定な識別子 (`chk-${childRef}-${templateId}`) で、同名 template が
@@ -429,6 +453,7 @@ async function collectForChild(
 		loginBonuses: loginBonusesOut,
 		evaluations: evaluationsOut,
 		specialRewards: specialRewardsOut,
+		rewardRedemptions: rewardRedemptionsOut,
 		checklistTemplates: checklistTemplatesOut,
 		checklistLogs: checklistLogsOut,
 	};
@@ -457,6 +482,7 @@ async function collectTransactionData(
 		loginBonuses: perChild.flatMap((p) => p.loginBonuses),
 		evaluations: perChild.flatMap((p) => p.evaluations),
 		specialRewards: perChild.flatMap((p) => p.specialRewards),
+		rewardRedemptions: perChild.flatMap((p) => p.rewardRedemptions),
 		checklistTemplates: perChild.flatMap((p) => p.checklistTemplates),
 		checklistLogs: perChild.flatMap((p) => p.checklistLogs), // #3078
 		childAvatarItems: [],

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -23,6 +23,7 @@ import { insertEvaluation } from '$lib/server/db/evaluation-repo';
 import { getRepos } from '$lib/server/db/factory';
 import { updateChildAvatarUrl } from '$lib/server/db/image-repo';
 import { findRecentBonuses, insertLoginBonus } from '$lib/server/db/login-bonus-repo';
+import { insertRedemptionForRestore } from '$lib/server/db/reward-redemption-repo';
 import { findSpecialRewards, insertSpecialReward } from '$lib/server/db/special-reward-repo';
 import { insertStatusHistory, upsertStatus } from '$lib/server/db/status-repo';
 import { logger } from '$lib/server/logger';
@@ -50,6 +51,9 @@ export interface ImportResult {
 	titlesImported: number;
 	specialRewardsImported: number;
 	specialRewardsSkipped: number;
+	/** #3329: ごほうびショップ交換/購入履歴の取込件数 */
+	rewardRedemptionsImported: number;
+	rewardRedemptionsSkipped: number;
 	loginBonusesImported: number;
 	loginBonusesSkipped: number;
 	statusHistoryImported: number;
@@ -257,6 +261,9 @@ export async function importFamilyData(
 	const templateIdMap = await importChecklistTemplatesData(data, childIdMap, tenantId, result);
 	await importChecklistLogsData(data, childIdMap, templateIdMap, tenantId, result);
 	await importSpecialRewards(data, childIdMap, tenantId, result);
+	// #3329: ごほうび交換/購入履歴。reward を先に取込済 (FK rewardRef → rewardId を再解決) なので
+	// importSpecialRewards の後に実行する。
+	await importRewardRedemptionsData(data, childIdMap, tenantId, result);
 	await importStatusHistoryData(data, childIdMap, tenantId, result);
 	// #3327/#3328: 評価 (週次評価) の取込。従来 import 関数が無く restore で全喪失していた網羅漏れを解消。
 	await importEvaluationsData(data, childIdMap, tenantId, result);
@@ -308,6 +315,75 @@ async function importEvaluationsData(
 	}
 }
 
+/**
+ * ごほうびショップ交換/購入履歴を復元する (#3329)。
+ * FK rewardId は import で振り直されるため、export の `rewardRef` (reward title) を取込先 child の
+ * reward 一覧から再解決して結合する。reward が解決できない行 (元 reward 未取込/同名衝突) は
+ * skip + warning (FK NOT NULL を満たせないため。残高への影響は別途 pointLedger が真実を持つ)。
+ * status / 解決情報 / snapshot は insertRedemptionForRestore で申請時点のまま書き戻す。
+ */
+async function importRewardRedemptionsData(
+	data: ExportData,
+	childIdMap: Map<string, number>,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	const redemptions = data.data.rewardRedemptions ?? [];
+	if (redemptions.length === 0) return;
+
+	// 取込先 child ごとに reward title → rewardId の lookup を構築する (新規 insert + 既存 dedup 双方を含む)。
+	const rewardIdByChildTitle = new Map<number, Map<string, number>>();
+	async function rewardLookup(childId: number): Promise<Map<string, number>> {
+		let map = rewardIdByChildTitle.get(childId);
+		if (!map) {
+			const rows = await findSpecialRewards(childId, tenantId);
+			map = new Map(rows.map((r) => [r.title, r.id]));
+			rewardIdByChildTitle.set(childId, map);
+		}
+		return map;
+	}
+
+	for (const r of redemptions) {
+		const childId = childIdMap.get(r.childRef);
+		if (!childId) {
+			result.rewardRedemptionsSkipped++;
+			continue;
+		}
+		const rewardId = (await rewardLookup(childId)).get(r.rewardRef);
+		if (!rewardId) {
+			result.rewardRedemptionsSkipped++;
+			result.warnings.push(
+				`交換履歴スキップ: ごほうび「${r.rewardRef}」(child=${r.childRef}) が取込先に見つかりません`,
+			);
+			continue;
+		}
+		try {
+			await insertRedemptionForRestore(
+				{
+					childId,
+					rewardId,
+					requestedAt: r.requestedAt,
+					status: r.status,
+					parentNote: r.parentNote,
+					resolvedAt: r.resolvedAt,
+					resolvedByParentId: r.resolvedByParentId,
+					shownToChildAt: r.shownToChildAt,
+					rewardTitle: r.rewardTitle,
+					rewardPoints: r.rewardPoints,
+					rewardIcon: r.rewardIcon,
+				},
+				tenantId,
+			);
+			result.rewardRedemptionsImported++;
+		} catch (e) {
+			result.rewardRedemptionsSkipped++;
+			result.errors.push(
+				`交換履歴 insert 失敗 (child=${r.childRef}, reward=${r.rewardRef}): ${String(e)}`,
+			);
+		}
+	}
+}
+
 function createEmptyImportResult(): ImportResult {
 	return {
 		childrenImported: 0,
@@ -321,6 +397,8 @@ function createEmptyImportResult(): ImportResult {
 		titlesImported: 0,
 		specialRewardsImported: 0,
 		specialRewardsSkipped: 0,
+		rewardRedemptionsImported: 0,
+		rewardRedemptionsSkipped: 0,
 		loginBonusesImported: 0,
 		loginBonusesSkipped: 0,
 		statusHistoryImported: 0,

--- a/src/lib/server/services/tenant-cleanup-service.ts
+++ b/src/lib/server/services/tenant-cleanup-service.ts
@@ -225,6 +225,16 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 		logger.warn(`[tenant-cleanup] loginBonus 削除失敗: ${String(err)}`);
 	}
 
+	// #3329: ごほうび交換履歴は special_rewards を reward_id (no cascade) で参照するため、
+	// special_rewards 削除より先に消す。残すと special_rewards 削除が FK で失敗し、さらに
+	// special_rewards.child_id (no cascade) が children 削除も阻む (replace import で子ごと喪失)。
+	try {
+		await r.rewardRedemption.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[tenant-cleanup] rewardRedemption 削除失敗: ${String(err)}`);
+	}
+
 	// Special rewards
 	try {
 		await r.specialReward.deleteByTenantId(tenantId);

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -135,7 +135,7 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 			'childCustomVoices',
 			'parentMessage',
 			'restDays',
-			'rewardRedemption',
+			// rewardRedemption は #3329 で export 実装済 → exported へ flip (本ベースラインから除外)
 			'setting',
 			'siblingCheer',
 			'stampCard',

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -47,6 +47,11 @@ import {
 import { findRecentBonuses, insertLoginBonus } from '../../../src/lib/server/db/login-bonus-repo';
 import { findPointHistory } from '../../../src/lib/server/db/point-repo';
 import {
+	findRedemptionRequestsByTenant,
+	insertRedemptionRequest,
+	updateRedemptionRequestStatus,
+} from '../../../src/lib/server/db/reward-redemption-repo';
+import {
 	findSpecialRewards,
 	insertSpecialReward,
 } from '../../../src/lib/server/db/special-reward-repo';
@@ -123,7 +128,7 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 			},
 			T,
 		);
-		await insertSpecialReward(
+		const reward = await insertSpecialReward(
 			{
 				childId: 1,
 				title: 'ごほうびX',
@@ -136,6 +141,19 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 			T,
 		);
 
+		// #3329: ごほうび交換履歴を 1 件 seed し、承認済 (approved) まで進める。
+		// round-trip 後に status=approved と snapshot がそのまま復元されることを検証する。
+		const redemption = await insertRedemptionRequest(
+			{ childId: 1, rewardId: reward.id, requestedAt: 1_700_000_000_000 },
+			T,
+		);
+		await updateRedemptionRequestStatus(
+			1,
+			redemption.id,
+			{ status: 'approved', resolvedAt: 1_700_000_100_000, resolvedByParentId: 'parent-1' },
+			T,
+		);
+
 		// --- export ---
 		const data = await exportFamilyData({ tenantId: T });
 		// export が全種別を捕捉していること (sanity)
@@ -144,6 +162,8 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(data.data.pointLedger.length, 'export:台帳').toBe(1);
 		expect(data.data.evaluations.length, 'export:評価').toBe(1);
 		expect(data.data.specialRewards.length, 'export:ごほうび').toBe(1);
+		expect(data.data.rewardRedemptions.length, 'export:交換履歴').toBe(1);
+		expect(data.data.rewardRedemptions[0]?.status, 'export:交換履歴 status').toBe('approved');
 
 		// --- replace = clear → import ---
 		await clearAllFamilyData(T);
@@ -165,5 +185,14 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect((await findRecentBonuses(cid, T, 999)).length, 'ログインボーナス').toBe(1);
 		expect((await findEvaluationsByChild(cid, 999, T)).length, '評価').toBe(1);
 		expect((await findSpecialRewards(cid, T)).length, 'ごほうび').toBe(1);
+
+		// #3329: 交換履歴が status / snapshot を保って復元される。
+		const restoredRedemptions = await findRedemptionRequestsByTenant(T, {
+			childId: cid,
+			limit: 999,
+		});
+		expect(restoredRedemptions.length, '交換履歴').toBe(1);
+		expect(restoredRedemptions[0]?.status, '交換履歴 status 保全').toBe('approved');
+		expect(restoredRedemptions[0]?.rewardTitle, '交換履歴 snapshot 保全').toBe('ごほうびX');
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全ユーザー（NUC セルフホスト / SaaS のバックアップ・移管利用者）

**解決する課題**: バックアップ ZIP を別環境へ import すると **ごほうびショップの交換/購入履歴が一切復元されない**（本番 t-82c17558 で「ごほうびショップの内容もインポートできてない」と実報告された喪失の一部）。export/import に交換履歴の経路が無く、replace import で全消失していた。

**期待される効果**: 交換履歴が status（承認/却下/期限切れ）・解決情報・申請時点 snapshot を保ったまま round-trip 復元される。#3329 分類レジストリの未 export source 筆頭を解消。

## 関連 Issue

関連: #3329 #3328（#3329 で分類した未 export source 12 件のうち rewardRedemption を実装。残 11 件は本 registry を起点に順次対応するため #3329 は close しない）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|----|------|---------|------------------|
| AC1 | 交換履歴を export に含める（per-child、FK は rewardRef で再結合可能化） | export-format / export-service | HEAD `8331e34f` |
| AC2 | import で取込先 child の reward へ rewardRef→rewardId 再解決して復元。status/snapshot 保全 | import-service `importRewardRedemptionsData` | HEAD `8331e34f` |
| AC3 | round-trip 完全性（approved + snapshot が export→clear→import で保全） | `backup-roundtrip-completeness.test.ts`（交換履歴 seed 追加） | HEAD `8331e34f` / 1 件 status=approved + snapshot 一致を assert |
| AC4 | clear 経路の FK 障害修正（reward_id no-cascade が reward/child 削除を阻む構造バグ） | `tenant-cleanup-service`（specialReward より先に redemption 削除） | HEAD `8331e34f` / completeness test が摘出・緑化 |
| AC5 | registry を exported へ flip + ratchet 整合 | `backup-entity-registry.test.ts` | HEAD `8331e34f` |
| AC6 | 型・lint・全 unit 健全 | svelte-check / biome / vitest | svelte-check 0 ERROR / biome クリーン / unit 2729 passed |

## 変更タイプ

- [x] fix: バグ修正（データ喪失）
- [x] feat: 新機能（backup 対象拡張）

## 影響範囲・変更コンポーネント

- [x] サービス層（export-service / import-service / tenant-cleanup-service / data-service 経路）
- [x] DB 層（reward-redemption repo: interface + sqlite/dynamodb/demo + facade に `insertRedemptionForRestore` 追加）
- [x] ドメイン型（export-format）

**影響を受ける機能**: バックアップ export / import / 全データ削除（clear）。UI 非変更。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3329redempt` 全 Step PASS**
- [x] 追加・変更テスト: completeness test に交換履歴 round-trip（approved + snapshot）assert を追加
- [x] **DynamoDB 実装変更時**: insertRedemptionForRestore を sqlite/dynamodb/demo で機能等価に実装（snapshot 優先で denorm 解決、SQLite COALESCE 読み出しと等価）
- [x] **スキーマ変更**: なし（既存 reward_redemption_requests を利用）

## スクリーンショット / ビジュアルデモ

**該当なし**: `.svelte` / `.css` 変更なし（バックエンドのデータ経路のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: 復元専用 insert を 1 メソッドに集約し 3 実装で等価。FK 再結合は既存の childRef パターン（specialRewards 同様）に揃える
- [x] **YAGNI**: rewardRedemption 1 実体のみ。残 source は段階対応
- [x] **Security**: 交換履歴は家族内データ。外部送信なし。snapshot に機微情報を含めない
- [x] **データ整合**: 残高の真実は pointLedger（別 export 済）。reward 解決不能行は skip+warning で FK NOT NULL を侵さない

## 横展開・影響波及チェック

- [x] **clear 経路の同型 FK バグを摘出・修正**: reward_id（no cascade）残存 → special_rewards 削除失敗 → special_rewards.child_id（no cascade）が children 削除も阻む連鎖を tenant-cleanup の削除順で根治
- [x] **設計書同期** (ADR-0001): `backup-import-redesign.md` の registry に整合（exported flip）
- [x] **並行 PR overlap** (#1200): #3362（registry、merged）の上に積層。develop 最新化済

## レビュー依頼事項・破壊的変更

- [x] 破壊的変更は**含まれない**（export format は後方互換: 新 field のみ追加、旧 backup の import も継続可）

**レビュー依頼**: rewardRef 再結合方針（同名 reward が取込先に無い場合 skip+warning）と、clear 削除順変更（redemption→specialReward）の妥当性をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3329redempt` 全 Step PASS** をローカル確認
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] Phase 分割: 残 source 11 件は registry を起点に順次対応
- [x] UI / 認証画面変更: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
