### PR TITLE
feat: #3329 各種設定の backup round-trip 実装 (default-deny allowlist で秘匿キー除外)

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -5,7 +5,52 @@ export const EXPORT_FORMAT = 'ganbari-quest-backup' as const;
 // #1254 G1: 1.2.0 で `sourcePresetId` フィールドを追加 (activities / specialRewards / checklistTemplates)
 // #3106 / #3107: 1.3.0 で checklist の `exportId` / `isArchived` / log `templateExportId` を追加
 //   (archive 済 template の log 保全 + 同名 template の round-trip 取り違え防止)。いずれも optional で後方互換。
-export const EXPORT_VERSION = '1.3.0' as const;
+// #3329: 1.4.0 で `data.settings` (各種設定 KVS の allowlist) を追加。optional で後方互換。
+export const EXPORT_VERSION = '1.4.0' as const;
+
+// ============================================================
+// #3329: backup 可能な設定キーの allowlist (default-deny セキュリティ設計、D3)
+// ============================================================
+// settings は任意キーの KVS。backup に「全キー」を載せると pin_hash (bcrypt の おやカギコード) /
+// session_token / lockout 状態 等の認証情報・秘匿状態が平文 ZIP に漏れる (CWE-522 平文認証情報 /
+// CWE-916 不十分なハッシュ保護 = bcrypt hash の offline crack 露出)。
+// そこで「載せてよいキーだけを明示列挙する default-deny allowlist」を採用する。新キー追加時は
+// デフォルト除外 = 安全側に倒れ、ユーザー設定として保全したい場合のみ意図的に本列挙へ足す。
+//
+// 意図的除外 (本 allowlist に**載せない**もの):
+//   - 認証/秘匿 (CWE-522/916): pin_hash / pin_locked_until / pin_failed_attempts / pin_reset_applied /
+//     session_token / session_expires_at
+//   - 課金/アカウントライフサイクル (環境間で移送すべきでない状態): deletion_grace_plan_tier /
+//     physical_deletion_date / soft_deleted_at / premium_welcome_shown / trial_expiration_modal_shown /
+//     dormant_reactivation_sent / marketing_unsubscribed_at
+// import 側でも本 allowlist で再 filter する (改竄/旧 backup に pin_hash が混在しても書き戻さない多層防御)。
+export const EXPORTABLE_SETTING_KEYS = [
+	'decay_intensity',
+	'notification_achievements_enabled',
+	'notification_quiet_end',
+	'notification_quiet_start',
+	'notification_reminder_time',
+	'notification_reminders_enabled',
+	'notification_streak_enabled',
+	'pin_gate_onboarding_seen',
+	'point_currency',
+	'point_rate',
+	'point_unit_mode',
+	'questionnaire_activity_level',
+	'questionnaire_challenges',
+	'reward_auto_approve',
+	'sibling_ranking_enabled',
+	'tutorial_banner_dismissed',
+	'tutorial_completed_at',
+	'tutorial_started_at',
+	'weekly_report_day',
+	'weekly_report_enabled',
+] as const;
+
+/** #3329: 設定キーが backup allowlist に含まれるか (export/import 双方の filter に使う SSOT)。 */
+export function isExportableSettingKey(key: string): boolean {
+	return (EXPORTABLE_SETTING_KEYS as readonly string[]).includes(key);
+}
 
 // ============================================================
 // マスタデータ型
@@ -191,6 +236,11 @@ export interface ExportRewardRedemption {
 	rewardIcon: string | null;
 }
 
+export interface ExportSetting {
+	key: string;
+	value: string;
+}
+
 export interface ExportChecklistTemplate {
 	childRef: string;
 	name: string;
@@ -267,6 +317,8 @@ export interface ExportTransactionData {
 	checklistLogs: ExportChecklistLog[];
 	childAvatarItems: never[];
 	dailyMissions: ExportDailyMission[];
+	/** #3329: 各種設定 (tenant-scoped KVS、allowlist 済キーのみ。pin_hash 等の秘匿キーは除外) */
+	settings: ExportSetting[];
 }
 
 export interface ExportData {

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -193,9 +193,9 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	setting: {
 		classification: 'source',
 		schemaTable: 'settings',
-		backupStatus: 'not-yet-exported',
+		backupStatus: 'exported',
 		reason:
-			'各種設定 (ポイント表示/onboarding 等)。export 未対応 (#3329)。PIN(pin_hash) は CWE-522/916 で除外 or 暗号化 (設計 D3)',
+			'各種設定 (ポイント表示/通知/onboarding 等)。export/import 実装済 (#3329)。default-deny allowlist (EXPORTABLE_SETTING_KEYS) で pin_hash / session_token 等の秘匿キーは構造的に除外 (CWE-522/916、設計 D3)',
 	},
 	// #3329 QM BLOCK 是正: schema.ts 権威列挙で surface した builder-less source テーブル。
 	restDays: {

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -4,6 +4,7 @@
 import {
 	EXPORT_FORMAT,
 	EXPORT_VERSION,
+	EXPORTABLE_SETTING_KEYS,
 	type ExportAchievement,
 	type ExportActivity,
 	type ExportActivityLog,
@@ -18,6 +19,7 @@ import {
 	type ExportOptions,
 	type ExportPointLedger,
 	type ExportRewardRedemption,
+	type ExportSetting,
 	type ExportSpecialReward,
 	type ExportStatus,
 	type ExportStatusHistory,
@@ -37,6 +39,7 @@ import { getRepos } from '$lib/server/db/factory';
 import { findRecentBonuses } from '$lib/server/db/login-bonus-repo';
 import { findPointHistory } from '$lib/server/db/point-repo';
 import { findRedemptionRequestsByTenant } from '$lib/server/db/reward-redemption-repo';
+import { getSettings } from '$lib/server/db/settings-repo';
 import { findSpecialRewards } from '$lib/server/db/special-reward-repo';
 import { findRecentStatusHistory, findStatuses } from '$lib/server/db/status-repo';
 import { logger } from '$lib/server/logger';
@@ -471,6 +474,14 @@ async function collectTransactionData(
 		childIds.map((childId) => collectForChild(childId, childExportIdMap, tenantId)),
 	);
 
+	// #3329: 各種設定 (tenant-scoped KVS)。default-deny allowlist のキーのみ取得し、
+	// pin_hash / session_token 等の秘匿キーは構造的に export に載らない (CWE-522/916、D3)。
+	// key 昇順で push して checksum を決定的に保つ。
+	const settingsMap = await getSettings([...EXPORTABLE_SETTING_KEYS], tenantId);
+	const settingsOut: ExportSetting[] = Object.keys(settingsMap)
+		.sort()
+		.map((key) => ({ key, value: settingsMap[key] as string }));
+
 	return {
 		childActivities: perChild.flatMap((p) => p.childActivities),
 		activityLogs: perChild.flatMap((p) => p.activityLogs),
@@ -487,5 +498,6 @@ async function collectTransactionData(
 		checklistLogs: perChild.flatMap((p) => p.checklistLogs), // #3078
 		childAvatarItems: [],
 		dailyMissions: [], // Phase 2: エフェメラルデータ対応後に対応
+		settings: settingsOut, // #3329
 	};
 }

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -1,7 +1,12 @@
 // src/lib/server/services/import-service.ts
 // 家族データインポートサービス（Phase 2 / #1254）
 
-import { EXPORT_FORMAT, EXPORT_VERSION, type ExportData } from '$lib/domain/export-format';
+import {
+	EXPORT_FORMAT,
+	EXPORT_VERSION,
+	type ExportData,
+	isExportableSettingKey,
+} from '$lib/domain/export-format';
 import { IMPORT_LABELS, type ImportSkipReason } from '$lib/domain/labels';
 import { CATEGORY_CODES } from '$lib/domain/validation/activity';
 import {
@@ -24,6 +29,7 @@ import { getRepos } from '$lib/server/db/factory';
 import { updateChildAvatarUrl } from '$lib/server/db/image-repo';
 import { findRecentBonuses, insertLoginBonus } from '$lib/server/db/login-bonus-repo';
 import { insertRedemptionForRestore } from '$lib/server/db/reward-redemption-repo';
+import { setSetting } from '$lib/server/db/settings-repo';
 import { findSpecialRewards, insertSpecialReward } from '$lib/server/db/special-reward-repo';
 import { insertStatusHistory, upsertStatus } from '$lib/server/db/status-repo';
 import { logger } from '$lib/server/logger';
@@ -64,6 +70,9 @@ export interface ImportResult {
 	/** #3078: チェックリスト完了履歴 */
 	checklistLogsImported: number;
 	checklistLogsSkipped: number;
+	/** #3329: 各種設定 (allowlist 済キーのみ取込)。skip = allowlist 外で書き戻し拒否したキー */
+	settingsImported: number;
+	settingsSkipped: number;
 	/** #3077: ZIP 同梱の静的ファイル (アバター画像 / 音声) の復元件数 */
 	staticFilesRestored: number;
 	staticFilesSkipped: number;
@@ -126,7 +135,7 @@ export function validateExportData(
 	}
 	// #3106/#3107: EXPORT_VERSION を 1.3.0 に bump したが、既存 1.2.0 backup も import 可能に保つ
 	// (新 field はすべて optional で後方互換)。
-	const supportedVersions = [EXPORT_VERSION, '1.2.0', '1.1.0', '1.0.0'];
+	const supportedVersions = [EXPORT_VERSION, '1.3.0', '1.2.0', '1.1.0', '1.0.0'];
 	if (!supportedVersions.includes(d.version as string)) {
 		return {
 			valid: false,
@@ -267,6 +276,8 @@ export async function importFamilyData(
 	await importStatusHistoryData(data, childIdMap, tenantId, result);
 	// #3327/#3328: 評価 (週次評価) の取込。従来 import 関数が無く restore で全喪失していた網羅漏れを解消。
 	await importEvaluationsData(data, childIdMap, tenantId, result);
+	// #3329: 各種設定 (tenant-scoped KVS)。allowlist 再 filter で秘匿キーを書き戻さない多層防御。
+	await importSettingsData(data, tenantId, result);
 
 	// #3077: ZIP 同梱の静的ファイル (アバター画像 / 音声) を新 childId に再マップして復元。
 	if (staticFiles && Object.keys(staticFiles).length > 0) {
@@ -384,6 +395,34 @@ async function importRewardRedemptionsData(
 	}
 }
 
+/**
+ * 各種設定 (tenant-scoped KVS) を復元する (#3329)。
+ * export 側で allowlist (EXPORTABLE_SETTING_KEYS) 済だが、import でも `isExportableSettingKey` で
+ * **再 filter** する (改竄 backup / 旧 backup に pin_hash・session_token 等が混在しても書き戻さない
+ * 多層防御、CWE-522/916・設計 D3)。allowlist 外キーは settingsSkipped として可視化する。
+ */
+async function importSettingsData(
+	data: ExportData,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	for (const s of data.data.settings ?? []) {
+		if (!isExportableSettingKey(s.key)) {
+			// 秘匿 / 非 allowlist キーは書き戻さない (多層防御)。
+			result.settingsSkipped++;
+			result.warnings.push(`設定「${s.key}」は backup 対象外のためスキップしました`);
+			continue;
+		}
+		try {
+			await setSetting(s.key, s.value, tenantId);
+			result.settingsImported++;
+		} catch (e) {
+			result.settingsSkipped++;
+			result.errors.push(`設定「${s.key}」の取込に失敗: ${String(e)}`);
+		}
+	}
+}
+
 function createEmptyImportResult(): ImportResult {
 	return {
 		childrenImported: 0,
@@ -407,6 +446,8 @@ function createEmptyImportResult(): ImportResult {
 		evaluationsSkipped: 0,
 		checklistLogsImported: 0,
 		checklistLogsSkipped: 0,
+		settingsImported: 0,
+		settingsSkipped: 0,
 		staticFilesRestored: 0,
 		staticFilesSkipped: 0,
 		skipped: { preset: 0, name: 0, constraint: 0 },

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -135,8 +135,7 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 			'childCustomVoices',
 			'parentMessage',
 			'restDays',
-			// rewardRedemption は #3329 で export 実装済 → exported へ flip (本ベースラインから除外)
-			'setting',
+			// rewardRedemption / setting は #3329 で export 実装済 → exported へ flip (本ベースラインから除外)
 			'siblingCheer',
 			'stampCard',
 			'stampEntry',

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -51,6 +51,7 @@ import {
 	insertRedemptionRequest,
 	updateRedemptionRequestStatus,
 } from '../../../src/lib/server/db/reward-redemption-repo';
+import { getSetting, setSetting } from '../../../src/lib/server/db/settings-repo';
 import {
 	findSpecialRewards,
 	insertSpecialReward,
@@ -154,6 +155,11 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 			T,
 		);
 
+		// #3329: 設定 KVS。allowlist キー (point_unit_mode) + 秘匿キー (pin_hash) を seed し、
+		// 秘匿キーが export に載らない (default-deny) こと + allowlist キーが round-trip することを検証。
+		await setSetting('point_unit_mode', 'custom', T);
+		await setSetting('pin_hash', '$2b$10$fake.hash.not.restored', T);
+
 		// --- export ---
 		const data = await exportFamilyData({ tenantId: T });
 		// export が全種別を捕捉していること (sanity)
@@ -164,6 +170,10 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(data.data.specialRewards.length, 'export:ごほうび').toBe(1);
 		expect(data.data.rewardRedemptions.length, 'export:交換履歴').toBe(1);
 		expect(data.data.rewardRedemptions[0]?.status, 'export:交換履歴 status').toBe('approved');
+		// #3329: 設定 export — allowlist キーは含み、秘匿キーは構造的に除外 (CWE-522/916)。
+		const settingKeys = data.data.settings.map((s) => s.key);
+		expect(settingKeys, 'export:設定 allowlist 含む').toContain('point_unit_mode');
+		expect(settingKeys, 'export:設定 pin_hash 除外').not.toContain('pin_hash');
 
 		// --- replace = clear → import ---
 		await clearAllFamilyData(T);
@@ -194,5 +204,9 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(restoredRedemptions.length, '交換履歴').toBe(1);
 		expect(restoredRedemptions[0]?.status, '交換履歴 status 保全').toBe('approved');
 		expect(restoredRedemptions[0]?.rewardTitle, '交換履歴 snapshot 保全').toBe('ごほうびX');
+
+		// #3329: 設定の round-trip — allowlist キーは復元、秘匿キーは clear 後も復元されない。
+		expect(await getSetting('point_unit_mode', T), '設定 round-trip').toBe('custom');
+		expect(await getSetting('pin_hash', T), '秘匿キー非復元').toBeUndefined();
 	});
 });

--- a/tests/unit/services/deletion-export-service.test.ts
+++ b/tests/unit/services/deletion-export-service.test.ts
@@ -69,6 +69,8 @@ const mockExportFamilyData = vi.fn().mockResolvedValue({
 		checklistLogs: [],
 		childAvatarItems: [],
 		dailyMissions: [],
+		rewardRedemptions: [],
+		settings: [],
 	},
 });
 

--- a/tests/unit/services/import-service-verify.test.ts
+++ b/tests/unit/services/import-service-verify.test.ts
@@ -120,6 +120,8 @@ function makeExportData(overrides: Partial<ExportData> = {}): ExportData {
 			checklistLogs: [],
 			childAvatarItems: [],
 			dailyMissions: [],
+			rewardRedemptions: [],
+			settings: [],
 		},
 		...overrides,
 	} as ExportData;

--- a/tests/unit/services/import-service.test.ts
+++ b/tests/unit/services/import-service.test.ts
@@ -155,6 +155,8 @@ function makeExportData(overrides: Partial<ExportData> = {}): ExportData {
 			checklistLogs: [],
 			childAvatarItems: [],
 			dailyMissions: [],
+			rewardRedemptions: [],
+			settings: [],
 		},
 		...overrides,
 	} as ExportData;


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全ユーザー（バックアップ・移管利用者）

**解決する課題**: バックアップ ZIP を別環境へ import すると **各種設定（通知設定・ポイント表示・onboarding 完了状態など）が一切復元されない**（本番 t-82c17558 で確認された喪失の一部）。settings KVS に export/import 経路が無く、replace import で全消失していた。

**期待される効果**: ユーザー設定が round-trip 復元される。**かつ pin_hash（おやカギコードの bcrypt ハッシュ）・session_token 等の認証/秘匿情報は構造的に backup に載らない**（セキュリティ）。

## 関連 Issue

関連: #3329 #3328（未 export source 12 件のうち setting を実装。残 10 件は registry を起点に順次対応するため #3329 は close しない）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|----|------|---------|------------------|
| AC1 | 設定を export に含める（tenant-scoped、allowlist キーのみ） | export-format / export-service | HEAD `ce3af0a4` |
| AC2 | **default-deny allowlist** で pin_hash / session_token 等の秘匿キーを構造的に除外（CWE-522/916、D3） | `EXPORTABLE_SETTING_KEYS` + export sanity test | HEAD `ce3af0a4` / completeness test が export に pin_hash 不在を assert |
| AC3 | import で allowlist 再 filter（改竄/旧 backup の秘匿キーを書き戻さない多層防御） | import-service `importSettingsData` + `isExportableSettingKey` | HEAD `ce3af0a4` |
| AC4 | round-trip（allowlist キーは復元 / 秘匿キーは clear 後も非復元） | `backup-roundtrip-completeness.test.ts` | HEAD `ce3af0a4` / point_unit_mode 復元 + pin_hash undefined を assert |
| AC5 | registry を exported へ flip + ratchet 整合 | `backup-entity-registry.test.ts` | HEAD `ce3af0a4` |
| AC6 | 型・lint・全 unit 健全 | svelte-check / biome / vitest | svelte-check 0 ERROR / biome クリーン / unit 2732 passed |

## 変更タイプ

- [x] fix: バグ修正（データ喪失）
- [x] feat: 新機能（backup 対象拡張）

## 影響範囲・変更コンポーネント

- [x] サービス層（export-service / import-service）
- [x] ドメイン型 + セキュリティ allowlist SSOT（export-format）

**影響を受ける機能**: バックアップ export / import。UI 非変更。settings の clear は既存 tenant-cleanup が担当（変更なし）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3329settings` 全 Step PASS**
- [x] 追加・変更テスト: completeness に allowlist + 秘匿キーの seed → export 除外 + round-trip + 非復元 assert
- [x] **DynamoDB 実装変更時**: repo 変更なし（既存 getSettings(keys)=BatchGet / setSetting=Put を再利用、両実装で動作）
- [x] **スキーマ変更**: なし

## スクリーンショット / ビジュアルデモ

**該当なし**: `.svelte` / `.css` 変更なし。

## コード品質セルフレビュー (#1481)

- [x] **Security（最重要）**: default-deny allowlist。新 setting キーは除外側に倒れる。export/import 双方で filter する多層防御。bcrypt hash / session token / lockout 状態を平文 ZIP に出さない（CWE-522/916）
- [x] **SOLID/DRY**: allowlist と isExportableSettingKey を export-format に SSOT 集約し export/import が共有
- [x] **YAGNI**: setting 1 実体のみ。残 source は段階対応
- [x] **後方互換**: EXPORT_VERSION 1.4.0、settings は optional field。旧 backup（1.0〜1.3）も import 可

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): registry の setting 分類を exported + allowlist 根拠に更新
- [x] **並行 PR overlap** (#1200): #3373（rewardRedemption）と独立。export-format の追加箇所が別（settings vs redemption）で衝突最小。develop 最新化済

## レビュー依頼事項・破壊的変更

- [x] 破壊的変更は**含まれない**（新規 optional field のみ）

**レビュー依頼**: allowlist の選定（含める=ユーザー設定 / 除外=認証・課金ライフサイクル・session）が妥当かご確認ください。特に onboarding/tutorial 完了フラグ（含めた）と premium_welcome_shown / trial_expiration_modal_shown（課金連動のため除外）の線引き。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3329settings` 全 Step PASS** をローカル確認
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] Phase 分割: 残 source 10 件は registry を起点に順次対応
- [x] UI / 認証画面変更: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
