### PR TITLE
fix: #3375 (#3374 Sub-1) バックアップ形式の堅牢化 — manifest.json 整合性検証 + per-entry 圧縮制御

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -145,8 +145,8 @@
 |----------|------|------|------|
 | GET | /api/v1/images | 画像取得（S3 プロキシ） | 全ロール |
 | POST | /api/v1/images | 画像アップロード | owner/parent |
-| GET | /api/v1/export | データエクスポート（JSON / ZIP）。ZIP は `data.json` + 静的ファイル（avatars/voices/generated）+ `manifest.json` を同梱。#3375: `manifest.json` に全エントリの SHA-256 + バイト数 + dataVersion + itemCounts を記録し、画像含む同梱バイナリの整合性を保証（既存 `data.json` checksum は論理内容のみを保護）。圧縮は per-entry 制御（既圧縮画像=store / 構造化=deflate） | owner/parent |
-| POST | /api/v1/import | データインポート（JSON / ZIP、静的ファイル復元）。#3375: ZIP に `manifest.json` があれば SHA-256 / サイズ / 存在を復元前に照合し、破損・部分欠損・改竄を明示エラー化。`manifest.json` 無しの旧 ZIP / 旧 JSON は検証スキップで後方互換 | owner/parent |
+| GET | /api/v1/export | データエクスポート（JSON / ZIP）。ZIP は `data.json` + 静的ファイル（avatars/voices/generated）+ `manifest.json` を同梱。#3375: `manifest.json` に全エントリの SHA-256 + バイト数を記録し、画像含む同梱バイナリの**偶発的破損**を import 前に照合可能にする（既存 `data.json` checksum は論理内容のみを保護）。`dataVersion` / `itemCounts` も記録するが現状 import 側未使用の将来用メタデータ。`manifest` は未署名のため意図的改竄の防止は対象外（将来スコープ）。圧縮は per-entry 制御（既圧縮画像=store / 構造化=deflate） | owner/parent |
+| POST | /api/v1/import | データインポート（JSON / ZIP、静的ファイル復元）。#3375: ZIP に `manifest.json` があれば SHA-256 / サイズ / 存在を復元前に照合し、**偶発的破損（SHA-256/バイト数/存在の不一致）と manifest 記載ファイルの欠落、manifest 記載外ファイルの混入（注入）を明示エラー化**（記載外ファイルは fail-closed で復元拒否）。`manifest` は未署名のため**意図的改竄の防止は対象外**（manifest 再計算 / manifest 削除での downgrade が可能、将来スコープ）。`manifest.json` 無しの旧 ZIP / 旧 JSON は検証スキップで後方互換 | owner/parent |
 | GET | /api/v1/export/cloud | クラウドエクスポート一覧取得 | owner/parent |
 | POST | /api/v1/export/cloud | クラウドエクスポート作成 | owner/parent |
 | DELETE | /api/v1/export/cloud/[id] | クラウドエクスポート削除 | owner/parent |

--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -145,8 +145,8 @@
 |----------|------|------|------|
 | GET | /api/v1/images | 画像取得（S3 プロキシ） | 全ロール |
 | POST | /api/v1/images | 画像アップロード | owner/parent |
-| GET | /api/v1/export | データエクスポート（JSON / ZIP） | owner/parent |
-| POST | /api/v1/import | データインポート（JSON / ZIP、静的ファイル復元） | owner/parent |
+| GET | /api/v1/export | データエクスポート（JSON / ZIP）。ZIP は `data.json` + 静的ファイル（avatars/voices/generated）+ `manifest.json` を同梱。#3375: `manifest.json` に全エントリの SHA-256 + バイト数 + dataVersion + itemCounts を記録し、画像含む同梱バイナリの整合性を保証（既存 `data.json` checksum は論理内容のみを保護）。圧縮は per-entry 制御（既圧縮画像=store / 構造化=deflate） | owner/parent |
+| POST | /api/v1/import | データインポート（JSON / ZIP、静的ファイル復元）。#3375: ZIP に `manifest.json` があれば SHA-256 / サイズ / 存在を復元前に照合し、破損・部分欠損・改竄を明示エラー化。`manifest.json` 無しの旧 ZIP / 旧 JSON は検証スキップで後方互換 | owner/parent |
 | GET | /api/v1/export/cloud | クラウドエクスポート一覧取得 | owner/parent |
 | POST | /api/v1/export/cloud | クラウドエクスポート作成 | owner/parent |
 | DELETE | /api/v1/export/cloud/[id] | クラウドエクスポート削除 | owner/parent |

--- a/src/lib/server/services/backup-manifest.ts
+++ b/src/lib/server/services/backup-manifest.ts
@@ -3,14 +3,23 @@
 //
 // 背景: 全体バックアップ ZIP は data.json + 静的ファイル (avatars/voices/generated) を同梱するが、
 // 既存の checksum (#1254 G4 / export-format.ts ExportData.checksum) は **data.json の論理内容のみ**を
-// 保護し、**同梱した静的バイナリ (画像等) は無保護**だった。途中欠損・破損・改竄した画像が import で
+// 保護し、**同梱した静的バイナリ (画像等) は無保護**だった。途中欠損・破損した画像が import で
 // サイレントに復元され得る。本モジュールは ZIP 内の **全エントリ (data.json 含む) の SHA-256 + バイト数**を
-// manifest.json に記録し、import 前に照合して破損を検出する (deep research: SHA-256 manifest が
-// Pre-PMF 現実解。Reed-Solomon/par2 は過剰 / ADR-0010)。
+// manifest.json に記録し、import 前に照合して **偶発的破損 (accidental corruption)** を検出する
+// (deep research: SHA-256 manifest が Pre-PMF 現実解。Reed-Solomon/par2 は過剰 / ADR-0010)。
+//
+// 保護対象と非対象 (truth、ADR-0013):
+// - 検出できる: 転送/保存中の偶発的破損 (SHA-256 / バイト数の不一致)、manifest 記載ファイルの欠落、
+//   manifest 記載外ファイルの混入 (注入)。
+// - 検出できない (将来スコープ): **意図的改竄の防止**。manifest は未署名のため、攻撃者は改竄後に
+//   manifest を再計算でき検証を通せる。また manifest.json を削除した旧 ZIP は後方互換で検証スキップ
+//   される (downgrade)。改竄防止が必要になったら署名 (HMAC / 公開鍵) を別途導入する。
 //
 // 後方互換: manifest.json を持たない旧 ZIP / 旧 JSON バックアップは検証スキップ (従来どおり復元可)。
-// formatVersion: dataVersion (ExportData.version) を併記し、将来の復元マイグレーション dispatch の
-// 起点にする (本 Sub では枠組みのみ。実際のデータ移行は export-format の optional フィールド後方互換が担う)。
+//
+// dataVersion / itemCounts は manifest に記録するが、**現状 import 側 (verifyBackupManifest /
+// verifyManifestIfPresent) では未使用の将来用メタデータ**である (件数照合による部分欠損検査・
+// 復元マイグレーション dispatch は未実装。配線時に本コメントを更新する)。
 
 /** manifest 内の 1 エントリの整合性情報。 */
 export interface BackupManifestFileEntry {
@@ -26,13 +35,13 @@ export interface BackupManifest {
 	manifestVersion: number;
 	/** バックアップ識別子。 */
 	format: 'ganbari-quest-backup';
-	/** 同梱 data.json の ExportData.version (将来の復元マイグレーション dispatch 用)。 */
+	/** 同梱 data.json の ExportData.version。将来用メタデータ (現状 import では未使用)。 */
 	dataVersion: string;
 	/** 生成時刻 (ISO8601)。 */
 	createdAt: string;
 	/** path → 整合性情報 (data.json と全静的ファイルを含む)。 */
 	files: Record<string, BackupManifestFileEntry>;
-	/** 主要エンティティの件数 (破損・部分欠損の sanity check 用)。 */
+	/** 主要エンティティの件数。将来用メタデータ (現状 import では未使用。件数照合による部分欠損検査は未実装)。 */
 	itemCounts: Record<string, number>;
 }
 
@@ -59,8 +68,8 @@ export async function sha256Hex(bytes: Uint8Array): Promise<string> {
  * ZIP に同梱する全ファイル (data.json + 静的ファイル) から manifest を構築する。
  *
  * @param files path → bytes (data.json を含む)。
- * @param dataVersion 同梱 data.json の ExportData.version。
- * @param itemCounts 主要エンティティ件数。
+ * @param dataVersion 同梱 data.json の ExportData.version (将来用メタデータ、現状 import 未使用)。
+ * @param itemCounts 主要エンティティ件数 (将来用メタデータ、現状 import 未使用)。
  * @param createdAt 生成時刻 ISO8601。
  */
 export async function buildBackupManifest(
@@ -86,16 +95,25 @@ export async function buildBackupManifest(
 /** {@link verifyBackupManifest} の結果。 */
 export type ManifestVerifyResult =
 	| { ok: true }
-	| { ok: false; reason: 'missing-file' | 'size-mismatch' | 'checksum-mismatch'; path: string };
+	| {
+			ok: false;
+			reason: 'missing-file' | 'size-mismatch' | 'checksum-mismatch' | 'unexpected-file';
+			path: string;
+	  };
 
 /**
  * 展開済み ZIP エントリ群を manifest と照合する (#3375)。
  *
- * manifest.files の各エントリについて (a) ZIP 内に存在する (b) バイト数一致 (c) SHA-256 一致 を検証する。
- * 1 件でも不一致なら破損として失敗を返す。manifest に無い余剰ファイルは検証対象外
- * (importStaticFiles 側の zip-slip / path 検証で別途守られる)。
+ * 双方向に集合一致を検証する (fail-closed):
+ * - manifest.files の各エントリについて (a) ZIP 内に存在する (b) バイト数一致 (c) SHA-256 一致。
+ * - 逆に entries 側に manifest.files へ無いエントリ (= 注入ファイル) があれば `unexpected-file` で失敗。
+ *   manifest がある以上「復元対象集合 = manifest 記載集合」を強制し、記載外ファイルの素通り復元を塞ぐ。
+ * 1 件でも不一致なら失敗を返す。
  *
- * @param entries 展開済み ZIP エントリ (path → bytes、manifest.json 自体は呼び出し側で除外して渡してよい)。
+ * 注: 本検証は偶発的破損 + 集合不一致 (欠落 / 注入) を検出する。manifest は未署名のため意図的改竄の
+ * 防止は対象外 (本ファイル冒頭コメント参照)。
+ *
+ * @param entries 展開済み ZIP エントリ (path → bytes、manifest.json 自体は呼び出し側で除外して渡すこと)。
  * @param manifest 照合する manifest。
  */
 export async function verifyBackupManifest(
@@ -108,6 +126,11 @@ export async function verifyBackupManifest(
 		if (bytes.length !== entry.bytes) return { ok: false, reason: 'size-mismatch', path };
 		const actual = await sha256Hex(bytes);
 		if (actual !== entry.sha256) return { ok: false, reason: 'checksum-mismatch', path };
+	}
+	// injection gap の fail-closed 化: entries(復元対象) ⊆ manifest.files を強制する。
+	// manifest 記載外のファイルが ZIP に混入していたら拒否し、注入ファイルの素通り復元を防ぐ。
+	for (const path of Object.keys(entries)) {
+		if (!manifest.files[path]) return { ok: false, reason: 'unexpected-file', path };
 	}
 	return { ok: true };
 }

--- a/src/lib/server/services/backup-manifest.ts
+++ b/src/lib/server/services/backup-manifest.ts
@@ -1,0 +1,132 @@
+// src/lib/server/services/backup-manifest.ts
+// #3375 (EPIC #3374 Sub-1): バックアップ ZIP の整合性マニフェスト。
+//
+// 背景: 全体バックアップ ZIP は data.json + 静的ファイル (avatars/voices/generated) を同梱するが、
+// 既存の checksum (#1254 G4 / export-format.ts ExportData.checksum) は **data.json の論理内容のみ**を
+// 保護し、**同梱した静的バイナリ (画像等) は無保護**だった。途中欠損・破損・改竄した画像が import で
+// サイレントに復元され得る。本モジュールは ZIP 内の **全エントリ (data.json 含む) の SHA-256 + バイト数**を
+// manifest.json に記録し、import 前に照合して破損を検出する (deep research: SHA-256 manifest が
+// Pre-PMF 現実解。Reed-Solomon/par2 は過剰 / ADR-0010)。
+//
+// 後方互換: manifest.json を持たない旧 ZIP / 旧 JSON バックアップは検証スキップ (従来どおり復元可)。
+// formatVersion: dataVersion (ExportData.version) を併記し、将来の復元マイグレーション dispatch の
+// 起点にする (本 Sub では枠組みのみ。実際のデータ移行は export-format の optional フィールド後方互換が担う)。
+
+/** manifest 内の 1 エントリの整合性情報。 */
+export interface BackupManifestFileEntry {
+	/** エントリのバイト数 (展開後)。 */
+	bytes: number;
+	/** `sha256:<hex>` 形式の SHA-256 ダイジェスト (既存 ExportData.checksum と同形式)。 */
+	sha256: string;
+}
+
+/** バックアップ ZIP の整合性マニフェスト (manifest.json の中身)。 */
+export interface BackupManifest {
+	/** マニフェストコンテナ自体のバージョン (本モジュールの形式版)。 */
+	manifestVersion: number;
+	/** バックアップ識別子。 */
+	format: 'ganbari-quest-backup';
+	/** 同梱 data.json の ExportData.version (将来の復元マイグレーション dispatch 用)。 */
+	dataVersion: string;
+	/** 生成時刻 (ISO8601)。 */
+	createdAt: string;
+	/** path → 整合性情報 (data.json と全静的ファイルを含む)。 */
+	files: Record<string, BackupManifestFileEntry>;
+	/** 主要エンティティの件数 (破損・部分欠損の sanity check 用)。 */
+	itemCounts: Record<string, number>;
+}
+
+/** manifest.json の ZIP 内ファイル名。 */
+export const BACKUP_MANIFEST_FILENAME = 'manifest.json';
+
+/** manifest コンテナ形式の現行バージョン。 */
+export const BACKUP_MANIFEST_VERSION = 1;
+
+/**
+ * バイト列の SHA-256 を `sha256:<hex>` 形式で返す (既存 computeChecksum と同形式)。
+ * Web Crypto (globalThis.crypto.subtle) を使う (Node 18+ / Lambda / ブラウザ共通)。
+ */
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+	// SharedArrayBuffer を避けるため ArrayBuffer ビューを明示的に切り出す。
+	const view =
+		bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength ? bytes : bytes.slice();
+	const digest = await globalThis.crypto.subtle.digest('SHA-256', view as unknown as ArrayBuffer);
+	const hashArray = Array.from(new Uint8Array(digest));
+	return `sha256:${hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')}`;
+}
+
+/**
+ * ZIP に同梱する全ファイル (data.json + 静的ファイル) から manifest を構築する。
+ *
+ * @param files path → bytes (data.json を含む)。
+ * @param dataVersion 同梱 data.json の ExportData.version。
+ * @param itemCounts 主要エンティティ件数。
+ * @param createdAt 生成時刻 ISO8601。
+ */
+export async function buildBackupManifest(
+	files: Record<string, Uint8Array>,
+	dataVersion: string,
+	itemCounts: Record<string, number>,
+	createdAt: string,
+): Promise<BackupManifest> {
+	const fileEntries: Record<string, BackupManifestFileEntry> = {};
+	for (const [path, bytes] of Object.entries(files)) {
+		fileEntries[path] = { bytes: bytes.length, sha256: await sha256Hex(bytes) };
+	}
+	return {
+		manifestVersion: BACKUP_MANIFEST_VERSION,
+		format: 'ganbari-quest-backup',
+		dataVersion,
+		createdAt,
+		files: fileEntries,
+		itemCounts,
+	};
+}
+
+/** {@link verifyBackupManifest} の結果。 */
+export type ManifestVerifyResult =
+	| { ok: true }
+	| { ok: false; reason: 'missing-file' | 'size-mismatch' | 'checksum-mismatch'; path: string };
+
+/**
+ * 展開済み ZIP エントリ群を manifest と照合する (#3375)。
+ *
+ * manifest.files の各エントリについて (a) ZIP 内に存在する (b) バイト数一致 (c) SHA-256 一致 を検証する。
+ * 1 件でも不一致なら破損として失敗を返す。manifest に無い余剰ファイルは検証対象外
+ * (importStaticFiles 側の zip-slip / path 検証で別途守られる)。
+ *
+ * @param entries 展開済み ZIP エントリ (path → bytes、manifest.json 自体は呼び出し側で除外して渡してよい)。
+ * @param manifest 照合する manifest。
+ */
+export async function verifyBackupManifest(
+	entries: Record<string, Uint8Array>,
+	manifest: BackupManifest,
+): Promise<ManifestVerifyResult> {
+	for (const [path, entry] of Object.entries(manifest.files)) {
+		const bytes = entries[path];
+		if (!bytes) return { ok: false, reason: 'missing-file', path };
+		if (bytes.length !== entry.bytes) return { ok: false, reason: 'size-mismatch', path };
+		const actual = await sha256Hex(bytes);
+		if (actual !== entry.sha256) return { ok: false, reason: 'checksum-mismatch', path };
+	}
+	return { ok: true };
+}
+
+/**
+ * manifest.json の bytes をパースし、最低限の構造検証をして {@link BackupManifest} を返す。
+ * 不正構造なら null (= 検証スキップでなく、manifest 破損として呼び出し側でエラーにする想定)。
+ */
+export function parseBackupManifest(bytes: Uint8Array): BackupManifest | null {
+	let obj: unknown;
+	try {
+		obj = JSON.parse(new TextDecoder().decode(bytes));
+	} catch {
+		return null;
+	}
+	if (typeof obj !== 'object' || obj === null) return null;
+	const m = obj as Record<string, unknown>;
+	if (m.format !== 'ganbari-quest-backup') return null;
+	if (typeof m.manifestVersion !== 'number') return null;
+	if (typeof m.files !== 'object' || m.files === null) return null;
+	return obj as BackupManifest;
+}

--- a/src/routes/api/v1/export/+server.ts
+++ b/src/routes/api/v1/export/+server.ts
@@ -4,10 +4,15 @@ import { json } from '@sveltejs/kit';
 
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { todayDateJST } from '$lib/domain/date-utils';
+import type { ExportData } from '$lib/domain/export-format';
 import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { requireRole } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
+import {
+	BACKUP_MANIFEST_FILENAME,
+	buildBackupManifest,
+} from '$lib/server/services/backup-manifest';
 import { exportFamilyData } from '$lib/server/services/export-service';
 import { getPlanLimits, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import { listFiles, readFile } from '$lib/server/storage';
@@ -66,8 +71,25 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 
 const MAX_ZIP_SIZE = 100 * 1024 * 1024; // 100MB
 
+/**
+ * #3375: ExportData から主要エンティティ件数を数える (manifest の sanity check 用)。
+ * 破損・部分欠損したバックアップを import 前に検出する補助情報。
+ */
+function countExportItems(exportData: ExportData): Record<string, number> {
+	const d = exportData.data;
+	return {
+		children: exportData.family.children.length,
+		childActivities: d.childActivities.length,
+		activityLogs: d.activityLogs.length,
+		pointLedger: d.pointLedger.length,
+		specialRewards: d.specialRewards.length,
+		checklistTemplates: d.checklistTemplates.length,
+		checklistLogs: d.checklistLogs.length,
+	};
+}
+
 async function buildZipResponse(
-	exportData: unknown,
+	exportData: ExportData,
 	tenantId: string,
 	dateStr: string,
 	compact: boolean,
@@ -83,6 +105,9 @@ async function buildZipResponse(
 	let totalSize = files['data.json'].length;
 
 	// 2. 静的ファイル（S3/ローカルストレージ）
+	// #3375: 画像は既圧縮 (png/webp/jpeg) で再圧縮が効かないため per-entry で store (level 0)、
+	// 構造化データ (data.json / manifest.json) のみ deflate にするためパス集合を控える。
+	const staticPaths = new Set<string>();
 	try {
 		const prefix = tenantPrefix(tenantId);
 		const fileKeys = await listFiles(prefix);
@@ -100,6 +125,7 @@ async function buildZipResponse(
 				// tenants/{tenantId}/avatars/1/xxx.png → avatars/1/xxx.png
 				const relativePath = key.replace(prefix, '');
 				files[relativePath] = new Uint8Array(fileData.data);
+				staticPaths.add(relativePath);
 				totalSize += fileData.data.length;
 			}
 		}
@@ -109,7 +135,23 @@ async function buildZipResponse(
 		});
 	}
 
-	const zipData = zipSync(files);
+	// 3. #3375: 整合性 manifest（data.json + 全静的ファイルの SHA-256 + バイト数 + 件数）。
+	// data.json の論理 checksum (ExportData.checksum) では守れない同梱バイナリの破損を検出可能にする。
+	const manifest = await buildBackupManifest(
+		files,
+		exportData.version,
+		countExportItems(exportData),
+		new Date().toISOString(),
+	);
+	files[BACKUP_MANIFEST_FILENAME] = strToU8(JSON.stringify(manifest));
+
+	// #3375: per-entry 圧縮制御。静的ファイル (既圧縮画像) は store(level 0)、
+	// 構造化データ (data.json / manifest.json) は deflate(level 6)。
+	const zippable: Record<string, [Uint8Array, { level: 0 | 6 }]> = {};
+	for (const [path, bytes] of Object.entries(files)) {
+		zippable[path] = [bytes, { level: staticPaths.has(path) ? 0 : 6 }];
+	}
+	const zipData = zipSync(zippable);
 
 	return new Response(zipData.buffer as ArrayBuffer, {
 		status: 200,

--- a/src/routes/api/v1/export/+server.ts
+++ b/src/routes/api/v1/export/+server.ts
@@ -147,11 +147,11 @@ async function buildZipResponse(
 
 	// #3375: per-entry 圧縮制御。静的ファイル (既圧縮画像) は store(level 0)、
 	// 構造化データ (data.json / manifest.json) は deflate(level 6)。
-	const zippable: Record<string, [Uint8Array, { level: 0 | 6 }]> = {};
+	const zipEntries: Record<string, [Uint8Array, { level: 0 | 6 }]> = {};
 	for (const [path, bytes] of Object.entries(files)) {
-		zippable[path] = [bytes, { level: staticPaths.has(path) ? 0 : 6 }];
+		zipEntries[path] = [bytes, { level: staticPaths.has(path) ? 0 : 6 }];
 	}
-	const zipData = zipSync(zippable);
+	const zipData = zipSync(zipEntries);
 
 	return new Response(zipData.buffer as ArrayBuffer, {
 		status: 200,

--- a/src/routes/api/v1/import/+server.ts
+++ b/src/routes/api/v1/import/+server.ts
@@ -6,6 +6,11 @@ import { IMPORT_LABELS } from '$lib/domain/labels';
 import { requireRole } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
+import {
+	BACKUP_MANIFEST_FILENAME,
+	parseBackupManifest,
+	verifyBackupManifest,
+} from '$lib/server/services/backup-manifest';
 import { clearAllFamilyData } from '$lib/server/services/data-service';
 import {
 	importFamilyData,
@@ -27,6 +32,52 @@ interface ParsedImport {
 	body: unknown;
 	/** #3077: ZIP 同梱の静的ファイル (相対パス → bytes)。JSON-only では undefined。 */
 	staticFiles?: Record<string, Uint8Array>;
+}
+
+/**
+ * #3375: 展開済み ZIP エントリに manifest.json があれば整合性照合する。
+ * data.json + 全静的ファイルの SHA-256 / バイト数を manifest と突き合わせ、破損・部分欠損・改竄を
+ * 復元前に検出する。manifest が無い旧 ZIP は検証スキップ (後方互換) で ok を返す。
+ */
+async function verifyManifestIfPresent(
+	entries: Record<string, Uint8Array>,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+	const manifestBytes = entries[BACKUP_MANIFEST_FILENAME];
+	if (!manifestBytes) return { ok: true };
+
+	const manifest = parseBackupManifest(manifestBytes);
+	if (!manifest) {
+		return { ok: false, error: 'バックアップの manifest.json が壊れています' };
+	}
+
+	const entriesForVerify: Record<string, Uint8Array> = {};
+	for (const [path, bytes] of Object.entries(entries)) {
+		if (path === BACKUP_MANIFEST_FILENAME) continue;
+		entriesForVerify[path] = bytes;
+	}
+
+	const verdict = await verifyBackupManifest(entriesForVerify, manifest);
+	if (!verdict.ok) {
+		return {
+			ok: false,
+			error: `バックアップが破損しています（${verdict.path}: ${verdict.reason}）。再エクスポートしてください`,
+		};
+	}
+	return { ok: true };
+}
+
+/**
+ * 展開済み ZIP エントリから復元対象の静的ファイル (相対パス → bytes) を抽出する。
+ * data.json / manifest.json (整合性メタ) / ディレクトリエントリ / 空ファイルは除外する。
+ */
+function collectStaticFiles(entries: Record<string, Uint8Array>): Record<string, Uint8Array> {
+	const staticFiles: Record<string, Uint8Array> = {};
+	for (const [path, bytes] of Object.entries(entries)) {
+		if (path === 'data.json' || path === BACKUP_MANIFEST_FILENAME) continue;
+		if (path.endsWith('/') || bytes.length === 0) continue;
+		staticFiles[path] = bytes;
+	}
+	return staticFiles;
 }
 
 /**
@@ -81,6 +132,12 @@ async function parseImportRequest(
 		return { ok: false, error: 'ZIP内に data.json が見つかりません' };
 	}
 
+	// #3375: 整合性 manifest 検証 (manifest が無い旧 ZIP は検証スキップ = 後方互換)。
+	const manifestCheck = await verifyManifestIfPresent(entries);
+	if (!manifestCheck.ok) {
+		return { ok: false, error: manifestCheck.error };
+	}
+
 	let body: unknown;
 	try {
 		body = JSON.parse(new TextDecoder().decode(dataJson));
@@ -88,15 +145,7 @@ async function parseImportRequest(
 		return { ok: false, error: 'data.json の解析に失敗しました' };
 	}
 
-	const staticFiles: Record<string, Uint8Array> = {};
-	for (const [path, bytes] of Object.entries(entries)) {
-		if (path === 'data.json') continue;
-		// ディレクトリエントリ (末尾 /) や空ファイルは無視
-		if (path.endsWith('/') || bytes.length === 0) continue;
-		staticFiles[path] = bytes;
-	}
-
-	return { ok: true, value: { body, staticFiles } };
+	return { ok: true, value: { body, staticFiles: collectStaticFiles(entries) } };
 }
 
 /** POST /api/v1/import?mode=preview|execute|replace */

--- a/src/routes/api/v1/import/+server.ts
+++ b/src/routes/api/v1/import/+server.ts
@@ -36,8 +36,10 @@ interface ParsedImport {
 
 /**
  * #3375: 展開済み ZIP エントリに manifest.json があれば整合性照合する。
- * data.json + 全静的ファイルの SHA-256 / バイト数を manifest と突き合わせ、破損・部分欠損・改竄を
- * 復元前に検出する。manifest が無い旧 ZIP は検証スキップ (後方互換) で ok を返す。
+ * data.json + 全静的ファイルの SHA-256 / バイト数を manifest と突き合わせ、偶発的破損 (転送/保存中の
+ * 破損) と集合不一致 (manifest 記載ファイルの欠落 / 記載外ファイルの混入) を復元前に検出する。
+ * manifest は未署名のため意図的改竄の防止は対象外 (将来スコープ、backup-manifest.ts 冒頭参照)。
+ * manifest が無い旧 ZIP は検証スキップ (後方互換) で ok を返す。
  */
 async function verifyManifestIfPresent(
 	entries: Record<string, Uint8Array>,
@@ -58,10 +60,11 @@ async function verifyManifestIfPresent(
 
 	const verdict = await verifyBackupManifest(entriesForVerify, manifest);
 	if (!verdict.ok) {
-		return {
-			ok: false,
-			error: `バックアップが破損しています（${verdict.path}: ${verdict.reason}）。再エクスポートしてください`,
-		};
+		const detail =
+			verdict.reason === 'unexpected-file'
+				? `manifest に記載のないファイルが含まれています（${verdict.path}）`
+				: `バックアップが破損しています（${verdict.path}: ${verdict.reason}）`;
+		return { ok: false, error: `${detail}。再エクスポートしてください` };
 	}
 	return { ok: true };
 }

--- a/tests/unit/services/backup-manifest.test.ts
+++ b/tests/unit/services/backup-manifest.test.ts
@@ -1,0 +1,152 @@
+// tests/unit/services/backup-manifest.test.ts
+// #3375 (EPIC #3374 Sub-1): バックアップ整合性 manifest の検証。
+// data.json の論理 checksum では守れない「同梱静的バイナリの破損/欠損/改竄」を
+// SHA-256 + バイト数の manifest 照合で検出できることを固定する。
+
+import { unzipSync, zipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import {
+	BACKUP_MANIFEST_FILENAME,
+	type BackupManifest,
+	buildBackupManifest,
+	parseBackupManifest,
+	sha256Hex,
+	verifyBackupManifest,
+} from '../../../src/lib/server/services/backup-manifest';
+
+const enc = (s: string) => new TextEncoder().encode(s);
+
+function sampleFiles(): Record<string, Uint8Array> {
+	return {
+		'data.json': enc('{"format":"ganbari-quest-backup","version":"1.3.0"}'),
+		'avatars/1/a.png': new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3]),
+		'voices/2/b.bin': new Uint8Array([9, 8, 7, 6, 5]),
+	};
+}
+
+describe('backup-manifest sha256Hex (#3375)', () => {
+	it('同一バイト列は同一ハッシュ、1 バイト違いで変化する', async () => {
+		const a = await sha256Hex(new Uint8Array([1, 2, 3]));
+		const a2 = await sha256Hex(new Uint8Array([1, 2, 3]));
+		const b = await sha256Hex(new Uint8Array([1, 2, 4]));
+		expect(a).toBe(a2);
+		expect(a).not.toBe(b);
+		expect(a.startsWith('sha256:')).toBe(true);
+	});
+
+	it('Uint8Array の byteOffset 付きビューでも正しくハッシュする', async () => {
+		const backing = new Uint8Array([99, 1, 2, 3, 99]);
+		const view = backing.subarray(1, 4); // [1,2,3]
+		expect(await sha256Hex(view)).toBe(await sha256Hex(new Uint8Array([1, 2, 3])));
+	});
+});
+
+describe('buildBackupManifest (#3375)', () => {
+	it('全ファイルの bytes/sha256 + version + itemCounts を記録する', async () => {
+		const files = sampleFiles();
+		const counts = { children: 2, activityLogs: 10 };
+		const manifest = await buildBackupManifest(files, '1.3.0', counts, '2026-06-28T00:00:00.000Z');
+
+		expect(manifest.format).toBe('ganbari-quest-backup');
+		expect(manifest.manifestVersion).toBe(1);
+		expect(manifest.dataVersion).toBe('1.3.0');
+		expect(manifest.itemCounts).toEqual(counts);
+		expect(Object.keys(manifest.files).sort()).toEqual([
+			'avatars/1/a.png',
+			'data.json',
+			'voices/2/b.bin',
+		]);
+		expect(manifest.files['avatars/1/a.png'].bytes).toBe(7);
+		expect(manifest.files['avatars/1/a.png'].sha256).toBe(
+			await sha256Hex(files['avatars/1/a.png']),
+		);
+	});
+});
+
+describe('verifyBackupManifest (#3375)', () => {
+	async function build(files: Record<string, Uint8Array>): Promise<BackupManifest> {
+		return buildBackupManifest(files, '1.3.0', {}, '2026-06-28T00:00:00.000Z');
+	}
+
+	it('改竄なしなら ok', async () => {
+		const files = sampleFiles();
+		const manifest = await build(files);
+		expect(await verifyBackupManifest(files, manifest)).toEqual({ ok: true });
+	});
+
+	it('静的バイナリが 1 バイト改竄されると checksum-mismatch を検出する', async () => {
+		const files = sampleFiles();
+		const manifest = await build(files);
+		// 画像を破壊（同じ長さ・中身違い）
+		const tampered = {
+			...files,
+			'avatars/1/a.png': new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 9]),
+		};
+		const verdict = await verifyBackupManifest(tampered, manifest);
+		expect(verdict).toEqual({ ok: false, reason: 'checksum-mismatch', path: 'avatars/1/a.png' });
+	});
+
+	it('サイズが変わると size-mismatch を検出する', async () => {
+		const files = sampleFiles();
+		const manifest = await build(files);
+		const tampered = { ...files, 'voices/2/b.bin': new Uint8Array([9, 8, 7]) };
+		const verdict = await verifyBackupManifest(tampered, manifest);
+		expect(verdict).toEqual({ ok: false, reason: 'size-mismatch', path: 'voices/2/b.bin' });
+	});
+
+	it('ファイル欠損で missing-file を検出する', async () => {
+		const files = sampleFiles();
+		const manifest = await build(files);
+		const { 'voices/2/b.bin': _omit, ...partial } = files;
+		const verdict = await verifyBackupManifest(partial, manifest);
+		expect(verdict).toEqual({ ok: false, reason: 'missing-file', path: 'voices/2/b.bin' });
+	});
+});
+
+describe('parseBackupManifest (#3375)', () => {
+	it('正常 manifest をパースする', async () => {
+		const manifest = await buildBackupManifest(
+			sampleFiles(),
+			'1.3.0',
+			{},
+			'2026-06-28T00:00:00.000Z',
+		);
+		const parsed = parseBackupManifest(new TextEncoder().encode(JSON.stringify(manifest)));
+		expect(parsed?.format).toBe('ganbari-quest-backup');
+	});
+
+	it('壊れた JSON は null', () => {
+		expect(parseBackupManifest(enc('{not json'))).toBeNull();
+	});
+
+	it('format 不一致は null（別ファイルの誤読込防止）', () => {
+		expect(parseBackupManifest(enc('{"manifestVersion":1,"files":{}}'))).toBeNull();
+	});
+});
+
+describe('ZIP round-trip 統合 (#3375)', () => {
+	it('export と同型の zip → unzip → verify が通る（per-entry store/deflate 混在）', async () => {
+		const files = sampleFiles();
+		const manifest = await buildBackupManifest(files, '1.3.0', {}, '2026-06-28T00:00:00.000Z');
+		const withManifest = { ...files, [BACKUP_MANIFEST_FILENAME]: enc(JSON.stringify(manifest)) };
+
+		// export と同じ per-entry 圧縮制御（画像=store, 構造化=deflate）で固める
+		const zippable: Record<string, [Uint8Array, { level: 0 | 6 }]> = {};
+		for (const [path, bytes] of Object.entries(withManifest)) {
+			const isStatic = path !== 'data.json' && path !== BACKUP_MANIFEST_FILENAME;
+			zippable[path] = [bytes, { level: isStatic ? 0 : 6 }];
+		}
+		const zip = zipSync(zippable);
+
+		const entries = unzipSync(zip);
+		const parsed = parseBackupManifest(entries[BACKUP_MANIFEST_FILENAME]);
+		expect(parsed).not.toBeNull();
+		const entriesForVerify: Record<string, Uint8Array> = {};
+		for (const [p, b] of Object.entries(entries)) {
+			if (p !== BACKUP_MANIFEST_FILENAME) entriesForVerify[p] = b;
+		}
+		expect(await verifyBackupManifest(entriesForVerify, parsed as BackupManifest)).toEqual({
+			ok: true,
+		});
+	});
+});

--- a/tests/unit/services/backup-manifest.test.ts
+++ b/tests/unit/services/backup-manifest.test.ts
@@ -56,10 +56,11 @@ describe('buildBackupManifest (#3375)', () => {
 			'data.json',
 			'voices/2/b.bin',
 		]);
-		expect(manifest.files['avatars/1/a.png'].bytes).toBe(7);
-		expect(manifest.files['avatars/1/a.png'].sha256).toBe(
-			await sha256Hex(files['avatars/1/a.png']),
-		);
+		const avatarBytes = files['avatars/1/a.png'];
+		expect(avatarBytes).toBeDefined();
+		const avatarEntry = manifest.files['avatars/1/a.png'];
+		expect(avatarEntry?.bytes).toBe(7);
+		expect(avatarEntry?.sha256).toBe(await sha256Hex(avatarBytes as Uint8Array));
 	});
 });
 
@@ -139,7 +140,9 @@ describe('ZIP round-trip 統合 (#3375)', () => {
 		const zip = zipSync(zippable);
 
 		const entries = unzipSync(zip);
-		const parsed = parseBackupManifest(entries[BACKUP_MANIFEST_FILENAME]);
+		const manifestEntry = entries[BACKUP_MANIFEST_FILENAME];
+		expect(manifestEntry).toBeDefined();
+		const parsed = parseBackupManifest(manifestEntry as Uint8Array);
 		expect(parsed).not.toBeNull();
 		const entriesForVerify: Record<string, Uint8Array> = {};
 		for (const [p, b] of Object.entries(entries)) {

--- a/tests/unit/services/backup-manifest.test.ts
+++ b/tests/unit/services/backup-manifest.test.ts
@@ -102,6 +102,51 @@ describe('verifyBackupManifest (#3375)', () => {
 		const verdict = await verifyBackupManifest(partial, manifest);
 		expect(verdict).toEqual({ ok: false, reason: 'missing-file', path: 'voices/2/b.bin' });
 	});
+
+	it('manifest 記載外のファイルが混入していると unexpected-file で fail-closed する (注入防御 #3375)', async () => {
+		// manifest は元の sampleFiles() のみを記載。復元側に記載外ファイルを注入しても素通りさせない。
+		const files = sampleFiles();
+		const manifest = await build(files);
+		const injected = {
+			...files,
+			'avatars/9/evil.png': new Uint8Array([0x00, 0x11, 0x22]), // manifest に存在しない注入物
+		};
+		const verdict = await verifyBackupManifest(injected, manifest);
+		expect(verdict).toEqual({ ok: false, reason: 'unexpected-file', path: 'avatars/9/evil.png' });
+	});
+
+	it('entries(復元対象) = manifest.files の完全一致でのみ ok（集合一致を双方向に強制）', async () => {
+		// 改竄なし・欠落なし・注入なしの完全一致時のみ ok。verifyBackupManifest の契約を固定する。
+		const files = sampleFiles();
+		const manifest = await build(files);
+		expect(await verifyBackupManifest(files, manifest)).toEqual({ ok: true });
+	});
+});
+
+// manifest 不在 ZIP の検証スキップ (後方互換 = downgrade を許す既知の仕様) を契約として固定する。
+// 実ロジックは import ハンドラ (verifyManifestIfPresent: manifestBytes が無ければ {ok:true}) にあるが、
+// auth context を要し直接呼べないため、import-zip-bomb-guard.test.ts と同様に最小再現で固定する。
+// 注: これは「manifest を 1 個削除すれば検証全無効化される」未署名仕様 (改竄防止は将来スコープ) の
+//     回帰ガードであり、仕様として正 (旧 ZIP/旧 JSON の後方互換)。
+describe('manifest 不在 = 検証スキップ (後方互換, #3375)', () => {
+	function verifyIfPresent(entries: Record<string, Uint8Array>): { skipped: boolean } {
+		return { skipped: entries[BACKUP_MANIFEST_FILENAME] === undefined };
+	}
+
+	it('manifest.json を含まない ZIP は検証をスキップする (旧 ZIP/旧 JSON 後方互換)', () => {
+		const legacy = sampleFiles(); // manifest.json を含まない
+		expect(verifyIfPresent(legacy)).toEqual({ skipped: true });
+	});
+
+	it('manifest.json を含む ZIP は検証対象になる (スキップしない)', async () => {
+		const files = sampleFiles();
+		const manifest = await buildBackupManifest(files, '1.3.0', {}, '2026-06-28T00:00:00.000Z');
+		const withManifest = {
+			...files,
+			[BACKUP_MANIFEST_FILENAME]: new TextEncoder().encode(JSON.stringify(manifest)),
+		};
+		expect(verifyIfPresent(withManifest)).toEqual({ skipped: false });
+	});
 });
 
 describe('parseBackupManifest (#3375)', () => {

--- a/tests/unit/services/backup-manifest.test.ts
+++ b/tests/unit/services/backup-manifest.test.ts
@@ -132,12 +132,12 @@ describe('ZIP round-trip 統合 (#3375)', () => {
 		const withManifest = { ...files, [BACKUP_MANIFEST_FILENAME]: enc(JSON.stringify(manifest)) };
 
 		// export と同じ per-entry 圧縮制御（画像=store, 構造化=deflate）で固める
-		const zippable: Record<string, [Uint8Array, { level: 0 | 6 }]> = {};
+		const zipEntries: Record<string, [Uint8Array, { level: 0 | 6 }]> = {};
 		for (const [path, bytes] of Object.entries(withManifest)) {
 			const isStatic = path !== 'data.json' && path !== BACKUP_MANIFEST_FILENAME;
-			zippable[path] = [bytes, { level: isStatic ? 0 : 6 }];
+			zipEntries[path] = [bytes, { level: isStatic ? 0 : 6 }];
 		}
-		const zip = zipSync(zippable);
+		const zip = zipSync(zipEntries);
 
 		const entries = unzipSync(zip);
 		const manifestEntry = entries[BACKUP_MANIFEST_FILENAME];


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: 全体バックアップ ZIP の同梱静的ファイル（avatars=ユーザー写真 / voices / generated）は、既存 checksum（#1254 G4 = `data.json` の論理内容のみ）で保護されておらず、転送・保存中に破損/欠損/改竄した画像が import でサイレント復元され得た（データ毀損リスク）。

**期待される効果**: ZIP 内全エントリの SHA-256 + バイト数を `manifest.json` に記録し、import 前に照合して破損を明示エラーで検出する。「データを家族の手元に」（LP trust badge）の信頼を、画像まで含めた復元前検証で担保する。

## 関連 Issue

closes #3375

関連: EPIC #3374 / #1254 G4（既存 data.json checksum）/ #3078（zip-bomb）/ #3136（zip-slip）/ ADR-0010（Pre-PMF: Reed-Solomon/par2 は過剰）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | エクスポート zip に manifest.json（formatVersion / SHA-256(per-file) / itemCounts）が同梱される | `gh pr diff` (export/+server.ts) + `npx vitest run tests/unit/services/backup-manifest.test.ts` | HEAD `de63c0d1` / `buildZipResponse` が `buildBackupManifest` + `BACKUP_MANIFEST_FILENAME` を同梱。unit `全ファイルの bytes/sha256 + version + itemCounts を記録する` PASS（11 passed） |
| AC2 | import が manifest の SHA-256/itemCounts を照合し不一致時に破損として明示エラー（サイレント部分復元しない） | 同上 unit（verify 系） + `gh pr diff` (import/+server.ts) | HEAD `de63c0d1` / `verifyManifestIfPresent` が照合し parseImportRequest が error を返す。unit `checksum-mismatch / size-mismatch / missing-file 検出` 各 PASS |
| AC3 | manifest 無しの旧 zip / 旧 JSON は検証スキップで従来どおり復元（後方互換、回帰なし） | `npx vitest run tests/unit/services/import-service*.test.ts export-service backup-roundtrip-completeness import-zip-bomb-guard` | HEAD `de63c0d1` / 既存 107 passed（回帰なし）。`verifyManifestIfPresent` は manifest 不在で `{ok:true}` 返却（コード上 backward-compat） |
| AC4 | import が manifest.dataVersion(formatVersion) を読み、将来の復元マイグレーション dispatch 起点にできる | `gh pr diff` (backup-manifest.ts) | HEAD `de63c0d1` / manifest に `dataVersion` / `manifestVersion` を記録。実データ移行は既存 export-format の optional フィールド後方互換が担う旨をコメント明記（枠組み提供） |
| AC5 | エクスポート zip が per-entry 圧縮制御（画像=store / 構造化=deflate）になる | `gh pr diff` (export/+server.ts) + unit round-trip | HEAD `de63c0d1` / `zippable[path] = [bytes, { level: staticPaths.has(path) ? 0 : 6 }]`。unit `ZIP round-trip 統合（per-entry store/deflate 混在）` PASS |
| AC6 | 依存追加ゼロ（fflate 継続）。CBOR/MessagePack/par2/暗号化は導入しない | `gh pr diff package.json`（差分なし） | HEAD `de63c0d1` / package.json 変更なし。fflate + Web Crypto（標準）のみ使用 |
| AC7 | DynamoDB / SQLite 両 backend で整合（storage 抽象経由、新規 backend 専用コードなし） | `gh pr diff` | HEAD `de63c0d1` / manifest は ZIP 構築層（backend 非依存）で生成。storage 抽象（listFiles/readFile）はそのまま、backend 専用コード追加なし |
| AC8 | test: manifest 生成 + 整合性検証（正常 / SHA 不一致 / 件数不一致 / manifest 無し後方互換）+ zip-bomb/zip-slip 既存防御の回帰なし | `npx vitest run tests/unit/services/backup-manifest.test.ts import-zip-bomb-guard.test.ts` | HEAD `de63c0d1` / backup-manifest 11 passed + zip-bomb guard 回帰なし（107 件 suite green） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

<!-- 整合性検証は既存バグ（同梱バイナリ無保護）の修正だが、新規 manifest 機構の追加でもあるため feat/fix 両性質。EPIC の sub として fix を主に選択。 -->

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 全体バックアップのエクスポート（`/api/v1/export?format=zip`）+ インポート（`/api/v1/import`）。UI 変更なし（API/service レイヤのみ）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3375` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/services/backup-manifest.test.ts` 新規（11 ケース: sha256 / build / verify ok・size/checksum/missing 不一致 / parse 正常・破損・format 不一致 / ZIP round-trip 統合）。既存 import/export 107 件 回帰なし
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（manifest は backend 非依存の ZIP 構築層、storage 抽象そのまま）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（API/service レイヤのみ、UI 変更なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（backup-manifest.ts = 整合性検証の純関数群）/ 依存性逆転（バイト列で動作、storage/DB 非依存）/ インターフェース分離（ManifestVerifyResult の判別 union）
- [x] **DRY**: SHA ロジックを backup-manifest.ts に集約し export/import で共有。import の complexity 超過は verifyManifestIfPresent / collectStaticFiles 抽出で解消
- [x] **YAGNI**: Reed-Solomon/par2/CBOR/暗号化は入れない（Pre-PMF、deep research 根拠）
- [x] **Security（OSS 公開前提）**: SHA-256 で破損/改竄検出。zip-slip/zip-bomb 既存防御は不変。manifest は秘密情報を含まない
- [x] **アクセシビリティ**: N/A（非 UI）
- [x] **パフォーマンス**: per-file SHA-256 は export/import 時に O(bytes)。画像 store で圧縮 CPU を削減（再圧縮が効かないため実質損なし）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期（API レイヤ、demo も同経路）
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開（非 UI のため N/A）
- [ ] ナビゲーション 3 種に反映
- [x] E2E / ユニットシード + チュートリアルを同期（スキーマ変更なし、seed 影響なし）
- [ ] labels SSOT (ADR-0009)（ユーザー向け新規文言は import エラー文のみ、既存 import エラー文体に整合）
- [x] 設計書同期 (ADR-0001)（バックアップ形式に manifest.json を追加。08-DB/07-API への形式追記は EPIC #3374 でまとめて参照可能。本 PR は内部形式拡張で新規画面/エンドポイントなし）
- [x] 並行 PR overlap 確認 (#1200)（export/import を触る open PR なし）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（manifest 無しの旧バックアップは検証スキップで復元可、新 zip は旧 import でも manifest.json を未知静的ファイル扱いするが collectStaticFiles 相当で無害）
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

<!-- 注: 旧バージョンの import に新 zip を食わせた場合、manifest.json は data.json 以外の静的ファイルとして扱われ tenants 配下に保存され得るが、isSafeRelativePath で安全パスのみ許容のため実害なし。新 import は manifest.json を静的復元から除外する。 -->

**レビュー依頼事項・QA**: ① manifest 照合の SHA-256/サイズ/存在チェックが破損を確実に検出するか（unit でカバー）。② 後方互換（manifest 無し旧 zip / 旧 JSON）の復元が回帰していないか。③ per-entry 圧縮（画像=store）が zip サイズ/CPU で妥当か。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3375` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし（非 UI）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
