### PR TITLE
feat: #3329 チャレンジ instance (進捗/完了/請求/auto:weekly) の backup round-trip 実装

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -241,6 +241,34 @@ export interface ExportSetting {
 	value: string;
 }
 
+/**
+ * #3329: per-child チャレンジ instance (auto:weekly 自動週次も sourceTemplateId='auto:weekly' の
+ * 行として同テーブルに含まれるため本 export で両方を保全する)。進捗 / 完了 / 請求 / status を round-trip
+ * 復元する (id / childId は import で振り直すため childRef で再結合)。
+ */
+export interface ExportChildChallenge {
+	childRef: string;
+	title: string;
+	description: string | null;
+	challengeType: string;
+	periodType: string;
+	startDate: string;
+	endDate: string;
+	targetConfig: string;
+	rewardConfig: string;
+	status: string;
+	isActive: number;
+	sourceTemplateId: string | null;
+	currentValue: number;
+	targetValue: number;
+	completed: number;
+	completedAt: string | null;
+	rewardClaimed: number;
+	rewardClaimedAt: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
 export interface ExportChecklistTemplate {
 	childRef: string;
 	name: string;
@@ -313,6 +341,8 @@ export interface ExportTransactionData {
 	specialRewards: ExportSpecialReward[];
 	/** #3329: ごほうびショップ交換/購入履歴 (per-child、rewardRef で reward に再結合) */
 	rewardRedemptions: ExportRewardRedemption[];
+	/** #3329: per-child チャレンジ instance (auto:weekly 含む。進捗/完了/請求を保全) */
+	childChallenges: ExportChildChallenge[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 	childAvatarItems: never[];

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -132,14 +132,16 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	childChallenge: {
 		classification: 'source',
 		schemaTable: 'childChallenges',
-		backupStatus: 'not-yet-exported',
-		reason: 'チャレンジ + 達成履歴。export 未対応 (#3329)',
+		backupStatus: 'exported',
+		reason:
+			'チャレンジ + 達成履歴。export/import 実装済 (#3329、進捗/完了/請求/status を insertForRestore で保全)',
 	},
 	childChallengeAutoWeekly: {
 		classification: 'source',
 		// 専用 SQLite table なし (child_challenges の自動週次フラグ運用 + DynamoDB key 専用)
-		backupStatus: 'not-yet-exported',
-		reason: '自動週次チャレンジ。export 未対応 (#3329)',
+		backupStatus: 'exported',
+		reason:
+			"自動週次チャレンジ。child_challenges の sourceTemplateId='auto:weekly' 行として childChallenge 同梱で export/import 済 (#3329)",
 	},
 	stampCard: {
 		classification: 'source',

--- a/src/lib/server/db/demo/child-challenge-repo.ts
+++ b/src/lib/server/db/demo/child-challenge-repo.ts
@@ -56,6 +56,14 @@ export async function findById(id: number, _tenantId: string): Promise<ChildChal
 	return DEMO_CHILD_CHALLENGES.find((c) => c.id === id);
 }
 
+export async function insertForRestore(
+	input: Omit<ChildChallenge, 'id'>,
+	_tenantId: string,
+): Promise<ChildChallenge> {
+	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
+	return { ...input, id: 0 };
+}
+
 export async function insert(
 	input: InsertChildChallengeInput,
 	_tenantId: string,

--- a/src/lib/server/db/dynamodb/child-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/child-challenge-repo.ts
@@ -195,6 +195,15 @@ export async function insert(
 /**
  * #3329 backup restore 用: 進捗 / 完了 / 請求 / status / 日時を含む全フィールドを保全して復元する。
  * insert と異なり buildChildChallenge の初期化を経ず、引数の値をそのまま書き戻す (id は新規採番)。
+ *
+ * #3329 QM-fix: auto:weekly 行は dedup SK (childChallengeAutoWeeklyKey = CHILDCHAL#AUTO#<weekStart>)
+ * で書き戻す。regular 行と同じ CHILDCHAL#<paddedId> に入れると、後続の getOrCreateWeeklyAuto
+ * (当該 (child, weekStart) の AUTO# key を GetItem で dedup) が復元行を miss し 2 個目の auto:weekly
+ * を生成してしまう (週次チャレンジ重複 / 進捗分裂)。SQLite SSOT は部分 unique index
+ * (child_id, start_date) で復元行が get-or-create 勝者になり重複しないため、DynamoDB でも復元行を
+ * dedup key に置いて機能等価にする。id 属性は Item に保持されるため findById / resolveKeyById
+ * (#3258 id-addressable Scan) は SK 形式に依存せず auto 行も解決でき、findByChildId の
+ * begins_with(SK,'CHILDCHAL#') Query でも auto 行を拾える。
  */
 export async function insertForRestore(
 	input: Omit<ChildChallenge, 'id'>,
@@ -203,11 +212,16 @@ export async function insertForRestore(
 	const id = await nextId(ENTITY_NAMES.childChallenge, tenantId);
 	const challenge: ChildChallenge = { ...input, id };
 
+	const key =
+		input.sourceTemplateId === 'auto:weekly'
+			? childChallengeAutoWeeklyKey(input.childId, input.startDate, tenantId)
+			: childChallengeKey(input.childId, id, tenantId);
+
 	await getDocClient().send(
 		new PutCommand({
 			TableName: TABLE_NAME,
 			Item: {
-				...childChallengeKey(input.childId, id, tenantId),
+				...key,
 				...challenge,
 			},
 		}),

--- a/src/lib/server/db/dynamodb/child-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/child-challenge-repo.ts
@@ -193,6 +193,30 @@ export async function insert(
 }
 
 /**
+ * #3329 backup restore 用: 進捗 / 完了 / 請求 / status / 日時を含む全フィールドを保全して復元する。
+ * insert と異なり buildChildChallenge の初期化を経ず、引数の値をそのまま書き戻す (id は新規採番)。
+ */
+export async function insertForRestore(
+	input: Omit<ChildChallenge, 'id'>,
+	tenantId: string,
+): Promise<ChildChallenge> {
+	const id = await nextId(ENTITY_NAMES.childChallenge, tenantId);
+	const challenge: ChildChallenge = { ...input, id };
+
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...childChallengeKey(input.childId, id, tenantId),
+				...challenge,
+			},
+		}),
+	);
+
+	return challenge;
+}
+
+/**
  * #3245: auto:weekly の atomic get-or-create。
  * SK を weekStart 由来の決定的キー (childChallengeAutoWeeklyKey) にし、
  * 条件付き PutItem (attribute_not_exists(PK)) で concurrent 二重作成を atomic に防ぐ。

--- a/src/lib/server/db/interfaces/child-challenge-repo.interface.ts
+++ b/src/lib/server/db/interfaces/child-challenge-repo.interface.ts
@@ -44,6 +44,14 @@ export interface IChildChallengeRepo {
 	insert(input: InsertChildChallengeInput, tenantId: string): Promise<ChildChallenge>;
 
 	/**
+	 * #3329 backup restore 用: 進捗 / 完了 / 請求 / status / 日時を含む全フィールドを保全して復元する。
+	 * 通常の insert は currentValue / completed / rewardClaimed / createdAt を初期化するため round-trip で
+	 * 進捗・完了・請求状態が失われる。本メソッドは export された値をそのまま書き戻す (id は新規採番、
+	 * childId は呼び出し側が import 後の child に解決済)。
+	 */
+	insertForRestore(input: Omit<ChildChallenge, 'id'>, tenantId: string): Promise<ChildChallenge>;
+
+	/**
 	 * #3245: アプリ週次自動生成 (sourceTemplateId='auto:weekly') の **atomic** get-or-create。
 	 * (child_id, start_date) の一意性を DB レベル (SQLite=部分 unique index / DynamoDB=決定的キー +
 	 * 条件付き書込) で担保し、concurrent 二重 INSERT (= ポイント二重付与) を不可能化する。

--- a/src/lib/server/db/sqlite/child-challenge-repo.ts
+++ b/src/lib/server/db/sqlite/child-challenge-repo.ts
@@ -123,6 +123,45 @@ export async function insert(
 }
 
 /**
+ * #3329 backup restore 用: 進捗 / 完了 / 請求 / status / 日時を含む全フィールドを保全して復元する。
+ * insert と異なり currentValue / completed / rewardClaimed / createdAt 等を引数の値のまま書き戻す。
+ * id は新規採番 (元 id は保全しない、childId は呼び出し側が解決済)。
+ */
+export async function insertForRestore(
+	input: Omit<ChildChallenge, 'id'>,
+	_tenantId: string,
+): Promise<ChildChallenge> {
+	const row = db
+		.insert(childChallenges)
+		.values({
+			childId: input.childId,
+			title: input.title,
+			description: input.description,
+			challengeType: input.challengeType,
+			periodType: input.periodType,
+			startDate: input.startDate,
+			endDate: input.endDate,
+			targetConfig: input.targetConfig,
+			rewardConfig: input.rewardConfig,
+			status: input.status,
+			isActive: input.isActive,
+			sourceTemplateId: input.sourceTemplateId,
+			currentValue: input.currentValue,
+			targetValue: input.targetValue,
+			completed: input.completed,
+			completedAt: input.completedAt,
+			rewardClaimed: input.rewardClaimed,
+			rewardClaimedAt: input.rewardClaimedAt,
+			createdAt: input.createdAt,
+			updatedAt: input.updatedAt,
+		})
+		.returning()
+		.get();
+	if (!row) throw new Error('insertForRestore: insert returned no row');
+	return row;
+}
+
+/**
  * #3245: auto:weekly の atomic get-or-create。
  * 部分 unique index idx_child_challenges_auto_weekly_unique により (child_id, start_date) は
  * auto:weekly 行で一意。`onConflictDoNothing` で concurrent 二重 INSERT を DB レベルで no-op 化し、

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -13,6 +13,7 @@ import {
 	type ExportChecklistTemplate,
 	type ExportChild,
 	type ExportChildActivity,
+	type ExportChildChallenge,
 	type ExportData,
 	type ExportEvaluation,
 	type ExportLoginBonus,
@@ -226,6 +227,7 @@ interface ChildTransactionData {
 	evaluations: ExportEvaluation[];
 	specialRewards: ExportSpecialReward[];
 	rewardRedemptions: ExportRewardRedemption[];
+	childChallenges: ExportChildChallenge[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 }
@@ -253,6 +255,7 @@ async function collectForChild(
 		evaluations,
 		specialRewards,
 		redemptions,
+		challenges,
 		checklistTemplates,
 	] = await Promise.all([
 		// #3327 P2: per-child 活動インスタンスを backup に保持 (archive 済も含む)。
@@ -266,6 +269,8 @@ async function collectForChild(
 		// #3329: ごほうびショップ交換/購入履歴を backup に保持 (WithDetails = snapshot 解決済の
 		// rewardTitle/Icon/Points 付き)。childId filter で per-child 収集する。
 		findRedemptionRequestsByTenant(tenantId, { childId, limit: MAX_EXPORT_ROWS }),
+		// #3329: per-child チャレンジ instance を backup に保持 (auto:weekly 含む全 status)。
+		getRepos().childChallenge.findByChildId(childId, tenantId),
 		// #3106: backup なので includeInactive=true + includeArchived=true。
 		// archive 済 template も含め、その checklistLog の silent drop を防ぐ。
 		findTemplatesByChild(childId, tenantId, true, true),
@@ -391,6 +396,31 @@ async function collectForChild(
 		rewardIcon: r.rewardIcon,
 	}));
 
+	// #3329: per-child チャレンジ instance を childRef 付きで出力 (進捗/完了/請求/status 保全)。
+	warnIfTruncated('childChallenges', childId, challenges.length);
+	const childChallengesOut: ExportChildChallenge[] = challenges.map((c) => ({
+		childRef,
+		title: c.title,
+		description: c.description,
+		challengeType: c.challengeType,
+		periodType: c.periodType,
+		startDate: c.startDate,
+		endDate: c.endDate,
+		targetConfig: c.targetConfig,
+		rewardConfig: c.rewardConfig,
+		status: c.status,
+		isActive: c.isActive,
+		sourceTemplateId: c.sourceTemplateId,
+		currentValue: c.currentValue,
+		targetValue: c.targetValue,
+		completed: c.completed,
+		completedAt: c.completedAt,
+		rewardClaimed: c.rewardClaimed,
+		rewardClaimedAt: c.rewardClaimedAt,
+		createdAt: c.createdAt,
+		updatedAt: c.updatedAt,
+	}));
+
 	// Checklist templates with items
 	// #3078 / #3107: templateId → (name, exportId) マップを構築し checklistLogs の参照解決に使う。
 	// exportId は export 内で安定な識別子 (`chk-${childRef}-${templateId}`) で、同名 template が
@@ -457,6 +487,7 @@ async function collectForChild(
 		evaluations: evaluationsOut,
 		specialRewards: specialRewardsOut,
 		rewardRedemptions: rewardRedemptionsOut,
+		childChallenges: childChallengesOut,
 		checklistTemplates: checklistTemplatesOut,
 		checklistLogs: checklistLogsOut,
 	};
@@ -494,6 +525,7 @@ async function collectTransactionData(
 		evaluations: perChild.flatMap((p) => p.evaluations),
 		specialRewards: perChild.flatMap((p) => p.specialRewards),
 		rewardRedemptions: perChild.flatMap((p) => p.rewardRedemptions),
+		childChallenges: perChild.flatMap((p) => p.childChallenges),
 		checklistTemplates: perChild.flatMap((p) => p.checklistTemplates),
 		checklistLogs: perChild.flatMap((p) => p.checklistLogs), // #3078
 		childAvatarItems: [],

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -60,6 +60,9 @@ export interface ImportResult {
 	/** #3329: ごほうびショップ交換/購入履歴の取込件数 */
 	rewardRedemptionsImported: number;
 	rewardRedemptionsSkipped: number;
+	/** #3329: per-child チャレンジ instance の取込件数 (auto:weekly 含む) */
+	childChallengesImported: number;
+	childChallengesSkipped: number;
 	loginBonusesImported: number;
 	loginBonusesSkipped: number;
 	statusHistoryImported: number;
@@ -273,6 +276,8 @@ export async function importFamilyData(
 	// #3329: ごほうび交換/購入履歴。reward を先に取込済 (FK rewardRef → rewardId を再解決) なので
 	// importSpecialRewards の後に実行する。
 	await importRewardRedemptionsData(data, childIdMap, tenantId, result);
+	// #3329: per-child チャレンジ (auto:weekly 含む) を進捗/完了/請求保全で復元。childIdMap のみ必要。
+	await importChildChallengesData(data, childIdMap, tenantId, result);
 	await importStatusHistoryData(data, childIdMap, tenantId, result);
 	// #3327/#3328: 評価 (週次評価) の取込。従来 import 関数が無く restore で全喪失していた網羅漏れを解消。
 	await importEvaluationsData(data, childIdMap, tenantId, result);
@@ -423,6 +428,60 @@ async function importSettingsData(
 	}
 }
 
+/**
+ * per-child チャレンジ instance を復元する (#3329)。
+ * childId は import で振り直されるため childRef で取込先 child に解決し、insertForRestore で
+ * 進捗 (currentValue/completed) / 請求 (rewardClaimed) / status / 日時を申請時点のまま書き戻す。
+ * auto:weekly 行 (sourceTemplateId='auto:weekly') も同テーブルの行として保全される。
+ */
+async function importChildChallengesData(
+	data: ExportData,
+	childIdMap: Map<string, number>,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	for (const c of data.data.childChallenges ?? []) {
+		const childId = childIdMap.get(c.childRef);
+		if (!childId) {
+			result.childChallengesSkipped++;
+			continue;
+		}
+		try {
+			await getRepos().childChallenge.insertForRestore(
+				{
+					childId,
+					title: c.title,
+					description: c.description,
+					challengeType: c.challengeType,
+					periodType: c.periodType,
+					startDate: c.startDate,
+					endDate: c.endDate,
+					targetConfig: c.targetConfig,
+					rewardConfig: c.rewardConfig,
+					status: c.status,
+					isActive: c.isActive,
+					sourceTemplateId: c.sourceTemplateId,
+					currentValue: c.currentValue,
+					targetValue: c.targetValue,
+					completed: c.completed,
+					completedAt: c.completedAt,
+					rewardClaimed: c.rewardClaimed,
+					rewardClaimedAt: c.rewardClaimedAt,
+					createdAt: c.createdAt,
+					updatedAt: c.updatedAt,
+				},
+				tenantId,
+			);
+			result.childChallengesImported++;
+		} catch (e) {
+			result.childChallengesSkipped++;
+			result.errors.push(
+				`チャレンジ insert 失敗 (child=${c.childRef}, title=${c.title}): ${String(e)}`,
+			);
+		}
+	}
+}
+
 function createEmptyImportResult(): ImportResult {
 	return {
 		childrenImported: 0,
@@ -438,6 +497,8 @@ function createEmptyImportResult(): ImportResult {
 		specialRewardsSkipped: 0,
 		rewardRedemptionsImported: 0,
 		rewardRedemptionsSkipped: 0,
+		childChallengesImported: 0,
+		childChallengesSkipped: 0,
 		loginBonusesImported: 0,
 		loginBonusesSkipped: 0,
 		statusHistoryImported: 0,

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -130,8 +130,7 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 			'certificate',
 			'checklistAssignment',
 			'checklistOverride',
-			'childChallenge',
-			'childChallengeAutoWeekly',
+			// childChallenge / childChallengeAutoWeekly は #3329 で export 実装済 → exported へ flip
 			'childCustomVoices',
 			'parentMessage',
 			'restDays',

--- a/tests/unit/db/dynamodb-child-challenge-repo.test.ts
+++ b/tests/unit/db/dynamodb-child-challenge-repo.test.ts
@@ -710,6 +710,113 @@ describe('#3258 auto:weekly 行の id 解決 (read/write 対称性)', () => {
 });
 
 // ============================================================
+// #3329 QM-fix: insertForRestore の dedup key 整合 (auto:weekly → AUTO# SK)
+// ============================================================
+//
+// backup restore で auto:weekly 行を regular SK (CHILDCHAL#<padId>) に書き戻すと、後続の
+// getOrCreateWeeklyAuto が AUTO# key を GetItem で dedup する経路で復元行を miss し 2 個目の
+// auto:weekly を生成する (週次チャレンジ重複)。SQLite SSOT は部分 unique index で復元行が
+// get-or-create 勝者になり重複しないため、DynamoDB でも復元行を dedup key (AUTO# SK) に置いて
+// 機能等価にする。本 block は read/write key 解決の対称性 (insertForRestore の Put SK ===
+// getOrCreateWeeklyAuto の GetItem SK) を回帰固定する。
+
+describe('#3329 insertForRestore dedup key 整合', () => {
+	const WEEK_START = '2026-06-01';
+	const AUTO_SK = `CHILDCHAL#AUTO#${WEEK_START}`;
+
+	function restoreInput(over: Record<string, unknown> = {}) {
+		return {
+			childId: CHILD_ID,
+			title: '復元チャレンジ',
+			description: null,
+			challengeType: 'cooperative',
+			periodType: 'weekly',
+			startDate: WEEK_START,
+			endDate: '2026-06-07',
+			targetConfig: '{"metric":"count","baseTarget":5}',
+			rewardConfig: '{"points":50}',
+			status: 'active',
+			isActive: 1,
+			sourceTemplateId: null,
+			currentValue: 0,
+			targetValue: 5,
+			completed: 0,
+			completedAt: null,
+			rewardClaimed: 0,
+			rewardClaimedAt: null,
+			createdAt: '2026-06-01T00:00:00.000Z',
+			updatedAt: '2026-06-01T00:00:00.000Z',
+			...over,
+		} as Parameters<Awaited<ReturnType<typeof loadRepo>>['insertForRestore']>[0];
+	}
+
+	it('auto:weekly 行は dedup SK (CHILDCHAL#AUTO#<weekStart>) に書き戻す', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 201 } }) // nextId
+			.mockResolvedValueOnce({}); // Put
+		const { insertForRestore } = await loadRepo();
+		const result = await insertForRestore(
+			restoreInput({ sourceTemplateId: 'auto:weekly', currentValue: 4 }),
+			TENANT,
+		);
+		expect(result.id).toBe(201);
+		expect(result.currentValue).toBe(4);
+		const put = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		// regular SK (CHILDCHAL#<padId>) ではなく dedup SK に置く。
+		expect(put.input.Item?.SK).toBe(AUTO_SK);
+		expect(put.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${CHILD_ID}`);
+		expect(put.input.Item?.sourceTemplateId).toBe('auto:weekly');
+		expect(put.input.Item?.currentValue).toBe(4);
+	});
+
+	it('regular 行 (auto:weekly 以外) は従来どおり CHILDCHAL#<padId> に書き戻す', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 202 } }).mockResolvedValueOnce({});
+		const { insertForRestore } = await loadRepo();
+		await insertForRestore(restoreInput({ sourceTemplateId: null }), TENANT);
+		const put = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(put.input.Item?.SK).toBe('CHILDCHAL#00000202');
+	});
+
+	it('復元後の getOrCreateWeeklyAuto(同一週) が復元行を dedup で拾い 2 個目を生成しない', async () => {
+		// 1) insertForRestore(auto:weekly) → AUTO# SK に Put
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 210 } }).mockResolvedValueOnce({});
+		const repo = await loadRepo();
+		await repo.insertForRestore(
+			restoreInput({ sourceTemplateId: 'auto:weekly', currentValue: 4 }),
+			TENANT,
+		);
+		const restorePut = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
+		const restoreSK = restorePut.input.Item?.SK;
+
+		// 2) getOrCreateWeeklyAuto(同一 child, 同一 weekStart): fast-path GetItem が復元行に hit。
+		mockSend.mockReset();
+		mockSend.mockResolvedValueOnce({
+			Item: makeItem({ id: 210, SK: AUTO_SK, sourceTemplateId: 'auto:weekly', currentValue: 4 }),
+		});
+		const got = await repo.getOrCreateWeeklyAuto(
+			{
+				childId: CHILD_ID,
+				title: '復元チャレンジ',
+				startDate: WEEK_START,
+				endDate: '2026-06-07',
+				targetConfig: '{"metric":"count","baseTarget":5}',
+				rewardConfig: '{"points":50}',
+				targetValue: 5,
+			},
+			TENANT,
+		);
+		// fast-path で復元行を返す (nextId / Put を発行しない = 2 個目を作らない)。
+		expect(mockSend).toHaveBeenCalledTimes(1);
+		expect(got.id).toBe(210);
+		expect(got.currentValue).toBe(4);
+		// dedup GetItem の Key SK が insertForRestore の Put SK と一致する (read=write 対称)。
+		const get = mockSend.mock.calls[0]?.[0] as { input: { Key?: { SK: string } } };
+		expect(get.input.Key?.SK).toBe(AUTO_SK);
+		expect(get.input.Key?.SK).toBe(restoreSK);
+	});
+});
+
+// ============================================================
 // interface 適合 (SQLite との機能等価性)
 // ============================================================
 
@@ -723,6 +830,8 @@ describe('interface 適合 (IChildChallengeRepo)', () => {
 			'findAllByTenant',
 			'findById',
 			'insert',
+			'insertForRestore',
+			'getOrCreateWeeklyAuto',
 			'insertBulk',
 			'updateProgress',
 			'markCompleted',

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -234,4 +234,159 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(restoredChallenges[0]?.currentValue, 'チャレンジ進捗保全').toBe(2);
 		expect(restoredChallenges[0]?.title, 'チャレンジ title 保全').toBe('うんどうチャレンジ');
 	});
+
+	// #3329 QM-fix (2)(a): auto:weekly チャレンジの dedup round-trip。
+	// 復元行が getOrCreateWeeklyAuto の dedup 経路 (SQLite=部分 unique index / DynamoDB=AUTO# SK) に
+	// 収まり、後続の getOrCreateWeeklyAuto(同一週) が **同一の単一行** を返す (= 週次チャレンジが
+	// 復元後に二重生成されない) ことを実 SQLite で固定する。
+	it('auto:weekly チャレンジが round-trip 後も単一行で、後続 get-or-create が重複生成しない', async () => {
+		testDb.insert(schema.children).values({ nickname: 'あおい', age: 9, theme: 'green' }).run(); // id=1
+
+		// auto:weekly を get-or-create で seed (sourceTemplateId は既定 'auto:weekly')。
+		const auto = await getRepos().childChallenge.getOrCreateWeeklyAuto(
+			{
+				childId: 1,
+				title: '今週のチャレンジ',
+				periodType: 'weekly',
+				startDate: '2026-03-02',
+				endDate: '2026-03-08',
+				targetConfig: '{"metric":"count","baseTarget":5}',
+				rewardConfig: '{"points":80}',
+				targetValue: 5,
+			},
+			T,
+		);
+		expect(auto.sourceTemplateId, 'seed:auto sourceTemplateId').toBe('auto:weekly');
+		// 進捗を前進させる (round-trip で保全されること)。
+		await getRepos().childChallenge.updateProgress(auto.id, 4, T);
+
+		// export
+		const data = await exportFamilyData({ tenantId: T });
+		expect(data.data.childChallenges.length, 'export:auto challenge').toBe(1);
+		expect(data.data.childChallenges[0]?.sourceTemplateId, 'export:auto sourceTemplateId').toBe(
+			'auto:weekly',
+		);
+		expect(data.data.childChallenges[0]?.currentValue, 'export:auto 進捗').toBe(4);
+
+		// replace = clear → import
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T);
+
+		const children = testDb.select().from(schema.children).all();
+		const cid = children[0]?.id as number;
+
+		// 復元行: auto:weekly が単一行 + 進捗保全。
+		const restored = await getRepos().childChallenge.findByChildId(cid, T);
+		expect(restored.length, '復元後 auto challenge 1 件').toBe(1);
+		expect(restored[0]?.sourceTemplateId, '復元 sourceTemplateId').toBe('auto:weekly');
+		expect(restored[0]?.currentValue, '復元 進捗保全').toBe(4);
+		const restoredId = restored[0]?.id as number;
+
+		// 後続 get-or-create(同一週) が **復元行と同一の単一行** を返す (= 復元行が dedup 経路に収まり
+		// 2 個目を生成しない)。重複していれば findByChildId が 2 件になり fail する。
+		const reGot = await getRepos().childChallenge.getOrCreateWeeklyAuto(
+			{
+				childId: cid,
+				title: '今週のチャレンジ',
+				periodType: 'weekly',
+				startDate: '2026-03-02',
+				endDate: '2026-03-08',
+				targetConfig: '{"metric":"count","baseTarget":5}',
+				rewardConfig: '{"points":80}',
+				targetValue: 5,
+			},
+			T,
+		);
+		expect(reGot.id, 'get-or-create が復元行に収束 (重複生成なし)').toBe(restoredId);
+		expect(reGot.currentValue, 'get-or-create が進捗を破壊しない').toBe(4);
+		const afterReGet = await getRepos().childChallenge.findByChildId(cid, T);
+		expect(afterReGet.length, '後続 get-or-create 後も 1 件 (二重生成なし)').toBe(1);
+	});
+
+	// #3329 QM-fix (2)(b): 完了 + 受取済 (completed/rewardClaimed/各日時/status) の全フィールド保全。
+	it('completed=1 + rewardClaimed=1 のチャレンジが全フィールド保全で round-trip する', async () => {
+		testDb.insert(schema.children).values({ nickname: 'はると', age: 10, theme: 'blue' }).run(); // id=1
+
+		const ch = await getRepos().childChallenge.insert(
+			{
+				childId: 1,
+				title: '完了チャレンジ',
+				periodType: 'weekly',
+				startDate: '2026-03-09',
+				endDate: '2026-03-15',
+				targetConfig: '{"metric":"count","baseTarget":3}',
+				rewardConfig: '{"points":120}',
+				targetValue: 3,
+			},
+			T,
+		);
+		// 進捗 → 完了 → ごほうび受取 まで進め、completed/completedAt/status/rewardClaimed/rewardClaimedAt を立てる。
+		await getRepos().childChallenge.updateProgress(ch.id, 3, T);
+		await getRepos().childChallenge.markCompleted(ch.id, T);
+		const claimed = await getRepos().childChallenge.claimReward(ch.id, T);
+		expect(claimed, 'seed: claimReward 成功').toBe(1);
+
+		// seed 後の確定状態を取得 (id 以外を round-trip 後と厳格比較する基準)。
+		const seeded = await getRepos().childChallenge.findById(ch.id, T);
+		expect(seeded?.completed, 'seed: completed').toBe(1);
+		expect(seeded?.rewardClaimed, 'seed: rewardClaimed').toBe(1);
+		expect(seeded?.status, 'seed: status').toBe('completed');
+		expect(seeded?.completedAt, 'seed: completedAt 非 null').toBeTruthy();
+		expect(seeded?.rewardClaimedAt, 'seed: rewardClaimedAt 非 null').toBeTruthy();
+
+		const data = await exportFamilyData({ tenantId: T });
+		expect(data.data.childChallenges.length, 'export:完了 challenge').toBe(1);
+
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T);
+
+		const children = testDb.select().from(schema.children).all();
+		const cid = children[0]?.id as number;
+		const restored = (await getRepos().childChallenge.findByChildId(cid, T))[0];
+		expect(restored, '復元 challenge 存在').toBeTruthy();
+
+		// 全フィールドが verbatim 保全される (id / childId は再採番されるため除外して厳格比較)。
+		expect(
+			{
+				title: restored?.title,
+				challengeType: restored?.challengeType,
+				periodType: restored?.periodType,
+				startDate: restored?.startDate,
+				endDate: restored?.endDate,
+				targetConfig: restored?.targetConfig,
+				rewardConfig: restored?.rewardConfig,
+				status: restored?.status,
+				isActive: restored?.isActive,
+				sourceTemplateId: restored?.sourceTemplateId,
+				currentValue: restored?.currentValue,
+				targetValue: restored?.targetValue,
+				completed: restored?.completed,
+				completedAt: restored?.completedAt,
+				rewardClaimed: restored?.rewardClaimed,
+				rewardClaimedAt: restored?.rewardClaimedAt,
+				createdAt: restored?.createdAt,
+				updatedAt: restored?.updatedAt,
+			},
+			'完了/受取/日時/status 全フィールド保全',
+		).toEqual({
+			title: seeded?.title,
+			challengeType: seeded?.challengeType,
+			periodType: seeded?.periodType,
+			startDate: seeded?.startDate,
+			endDate: seeded?.endDate,
+			targetConfig: seeded?.targetConfig,
+			rewardConfig: seeded?.rewardConfig,
+			status: seeded?.status,
+			isActive: seeded?.isActive,
+			sourceTemplateId: seeded?.sourceTemplateId,
+			currentValue: seeded?.currentValue,
+			targetValue: seeded?.targetValue,
+			completed: seeded?.completed,
+			completedAt: seeded?.completedAt,
+			rewardClaimed: seeded?.rewardClaimed,
+			rewardClaimedAt: seeded?.rewardClaimedAt,
+			createdAt: seeded?.createdAt,
+			updatedAt: seeded?.updatedAt,
+		});
+	});
 });

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -44,6 +44,7 @@ import {
 	findEvaluationsByChild,
 	insertEvaluation,
 } from '../../../src/lib/server/db/evaluation-repo';
+import { getRepos } from '../../../src/lib/server/db/factory';
 import { findRecentBonuses, insertLoginBonus } from '../../../src/lib/server/db/login-bonus-repo';
 import { findPointHistory } from '../../../src/lib/server/db/point-repo';
 import {
@@ -160,6 +161,22 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		await setSetting('point_unit_mode', 'custom', T);
 		await setSetting('pin_hash', '$2b$10$fake.hash.not.restored', T);
 
+		// #3329: チャレンジを 1 件 seed し進捗を進める。round-trip 後に currentValue/status が保全されることを検証。
+		const challenge = await getRepos().childChallenge.insert(
+			{
+				childId: 1,
+				title: 'うんどうチャレンジ',
+				periodType: 'weekly',
+				startDate: '2026-03-01',
+				endDate: '2026-03-07',
+				targetConfig: '{"metric":"count","baseTarget":3}',
+				rewardConfig: '{"points":50}',
+				targetValue: 3,
+			},
+			T,
+		);
+		await getRepos().childChallenge.updateProgress(challenge.id, 2, T);
+
 		// --- export ---
 		const data = await exportFamilyData({ tenantId: T });
 		// export が全種別を捕捉していること (sanity)
@@ -174,6 +191,8 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		const settingKeys = data.data.settings.map((s) => s.key);
 		expect(settingKeys, 'export:設定 allowlist 含む').toContain('point_unit_mode');
 		expect(settingKeys, 'export:設定 pin_hash 除外').not.toContain('pin_hash');
+		expect(data.data.childChallenges.length, 'export:チャレンジ').toBe(1);
+		expect(data.data.childChallenges[0]?.currentValue, 'export:チャレンジ進捗').toBe(2);
 
 		// --- replace = clear → import ---
 		await clearAllFamilyData(T);
@@ -208,5 +227,11 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		// #3329: 設定の round-trip — allowlist キーは復元、秘匿キーは clear 後も復元されない。
 		expect(await getSetting('point_unit_mode', T), '設定 round-trip').toBe('custom');
 		expect(await getSetting('pin_hash', T), '秘匿キー非復元').toBeUndefined();
+
+		// #3329: チャレンジが進捗 (currentValue) を保って復元される。
+		const restoredChallenges = await getRepos().childChallenge.findByChildId(cid, T);
+		expect(restoredChallenges.length, 'チャレンジ').toBe(1);
+		expect(restoredChallenges[0]?.currentValue, 'チャレンジ進捗保全').toBe(2);
+		expect(restoredChallenges[0]?.title, 'チャレンジ title 保全').toBe('うんどうチャレンジ');
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全ユーザー（バックアップ・移管利用者）

**解決する課題**: バックアップ ZIP を別環境へ import すると **チャレンジの進捗・完了・受取状態が一切復元されない**（本番 t-82c17558 で確認された喪失の一部）。child_challenges に export/import 経路が無く、replace import で全消失していた。

**期待される効果**: チャレンジ instance が進捗 (currentValue) / 完了 (completed/completedAt) / 受取 (rewardClaimed) / status を保ったまま round-trip 復元される。アプリ自動週次チャレンジ (auto:weekly) も同テーブル行として保全。

## 関連 Issue

関連: #3329 #3328（未 export source の childChallenge / childChallengeAutoWeekly を実装。残 7 件は registry を起点に順次対応するため #3329 は close しない）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|----|------|---------|------------------|
| AC1 | チャレンジを export に含める (per-child、auto:weekly 含む) | export-format / export-service | HEAD `9cfb3bd0` |
| AC2 | import で childRef → child 解決し進捗/完了/請求/status を insertForRestore で保全 | import-service `importChildChallengesData` | HEAD `9cfb3bd0` |
| AC3 | round-trip (進捗 currentValue=2 が export→clear→import で保全) | `backup-roundtrip-completeness.test.ts` | HEAD `9cfb3bd0` |
| AC4 | insert (進捗初期化) と分離した復元専用経路を 3 実装で機能等価に提供 | repo `insertForRestore` (sqlite/dynamodb/demo) | HEAD `9cfb3bd0` |
| AC5 | registry の childChallenge / childChallengeAutoWeekly を exported へ flip + ratchet 整合 | `backup-entity-registry.test.ts` | HEAD `9cfb3bd0` |
| AC6 | 型・lint・全 unit 健全 | svelte-check / biome / cspell / vitest | svelte-check 0 ERROR / biome クリーン / cspell クリーン / unit 2732 passed |

## 変更タイプ

- [x] fix: バグ修正（データ喪失）
- [x] feat: 新機能（backup 対象拡張）

## 影響範囲・変更コンポーネント

- [x] サービス層（export-service / import-service）
- [x] DB 層（child-challenge repo: interface + sqlite/dynamodb/demo に `insertForRestore` 追加）
- [x] ドメイン型（export-format）

**影響を受ける機能**: バックアップ export / import。UI 非変更。clear は child_id cascade で自動削除のため tenant-cleanup 変更不要。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3329challenge` 全 Step PASS**
- [x] 追加・変更テスト: completeness にチャレンジ (進捗) round-trip 保全 assert を追加
- [x] **DynamoDB 実装変更時**: insertForRestore を sqlite/dynamodb/demo で機能等価に実装 (進捗/status を初期化しない復元専用経路)
- [x] **スキーマ変更**: なし

## スクリーンショット / ビジュアルデモ

**該当なし**: `.svelte` / `.css` 変更なし（バックエンドのデータ経路のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: 復元専用 insert を 1 メソッドに集約し 3 実装で等価。rewardRedemption / setting と同パターン
- [x] **YAGNI**: childChallenge 1 テーブルのみ（auto:weekly は同テーブル行として同梱、別実装不要）
- [x] **データ整合**: 進捗/受取状態を保全（受取済 reward の二重付与を避けるため rewardClaimed も保全）
- [x] **auto:weekly (dedup 整合)**: 復元行は **2 経路の dedup 機構の双方**に正しく収まる — SQLite は部分 unique index `(child_id, start_date)`、**DynamoDB は決定的 dedup SK `CHILDCHAL#AUTO#<weekStart>`**。`insertForRestore` は `sourceTemplateId==='auto:weekly'` を分岐し、SQLite は通常 INSERT (部分 index で後続 get-or-create が勝者収束)、DynamoDB は `childChallengeAutoWeeklyKey` で書き戻すことで、復元後の `getOrCreateWeeklyAuto(当週)` が復元行を dedup で拾い **2 個目の auto:weekly を生成しない** (QM BLOCK 是正、`55738b16e`。当初 DynamoDB は全行を `CHILDCHAL#<padId>` に書き戻し dedup SK を外す欠陥があった)。replace import (clear 後) でも当週行は AUTO# SK / 部分 index へ収束する。insert 失敗時は skip+warning で全体を止めない

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): registry の childChallenge / childChallengeAutoWeekly 分類を exported に更新
- [x] **並行 PR overlap** (#1200): #3373 (rewardRedemption) / #3378 (settings) が develop へ先行マージ済。両者と同一ファイルを触るため develop へ rebase し設定/交換履歴/チャレンジの 3 機能を共存解決済

## レビュー依頼事項・破壊的変更

- [x] 破壊的変更は**含まれない**（新規 optional field のみ、旧 backup の import も継続可）

**レビュー依頼**: insertForRestore が status/進捗/受取を初期化せず書き戻す方針と、auto:weekly 行の同梱 export の妥当性をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3329challenge` 全 Step PASS** をローカル確認
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] Phase 分割: 残 source 7 件は registry を起点に順次対応
- [x] UI / 認証画面変更: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

