### PR TITLE
feat: #3329 スタンプカード + 押印の backup round-trip 実装

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -269,6 +269,31 @@ export interface ExportChildChallenge {
 	updatedAt: string;
 }
 
+/**
+ * #3329: per-child スタンプカード (週単位) + 押印 entry を nested で保全する。
+ * stampMasterId はグローバル master (環境間で同一 seed) を参照するため値のまま保持する
+ * (import 時に存在しなければ当該 entry を skip)。card status / redeemed / earnedAt を round-trip 復元。
+ */
+export interface ExportStampEntry {
+	stampMasterId: number | null;
+	omikujiRank: string | null;
+	slot: number;
+	loginDate: string;
+	earnedAt: string;
+}
+
+export interface ExportStampCard {
+	childRef: string;
+	weekStart: string;
+	weekEnd: string;
+	status: string;
+	redeemedPoints: number | null;
+	redeemedAt: string | null;
+	createdAt: string;
+	updatedAt: string;
+	entries: ExportStampEntry[];
+}
+
 export interface ExportChecklistTemplate {
 	childRef: string;
 	name: string;
@@ -343,6 +368,8 @@ export interface ExportTransactionData {
 	rewardRedemptions: ExportRewardRedemption[];
 	/** #3329: per-child チャレンジ instance (auto:weekly 含む。進捗/完了/請求を保全) */
 	childChallenges: ExportChildChallenge[];
+	/** #3329: per-child スタンプカード + 押印 entry (nested、status/redeemed/earnedAt 保全) */
+	stampCards: ExportStampCard[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 	childAvatarItems: never[];

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -146,14 +146,16 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	stampCard: {
 		classification: 'source',
 		schemaTable: 'stampCards',
-		backupStatus: 'not-yet-exported',
-		reason: 'スタンプカード。export 未対応 (#3329)',
+		backupStatus: 'exported',
+		reason:
+			'スタンプカード。export/import 実装済 (#3329、status/redeemed/日時を insertCardForRestore で保全)',
 	},
 	stampEntry: {
 		classification: 'source',
 		schemaTable: 'stampEntries',
-		backupStatus: 'not-yet-exported',
-		reason: 'スタンプ押印。export 未対応 (#3329)',
+		backupStatus: 'exported',
+		reason:
+			'スタンプ押印。export/import 実装済 (#3329、stampCard に nested 同梱・earnedAt 保全。stampMasterId はグローバル master 参照を維持)',
 	},
 	certificate: {
 		classification: 'source',

--- a/src/lib/server/db/demo/stamp-card-repo.ts
+++ b/src/lib/server/db/demo/stamp-card-repo.ts
@@ -69,6 +69,53 @@ export async function insertEntry(_input: InsertStampEntryInput, _tenantId: stri
 	// Stub: no-op
 }
 
+export async function findCardsByChild(childId: number, _tenantId: string): Promise<StampCard[]> {
+	return DEMO_STAMP_CARDS.filter((c) => c.childId === childId);
+}
+
+export async function findEntriesByCardId(
+	cardId: number,
+	_tenantId: string,
+): Promise<
+	Array<{
+		stampMasterId: number | null;
+		omikujiRank: string | null;
+		slot: number;
+		loginDate: string;
+		earnedAt: string;
+	}>
+> {
+	return DEMO_STAMP_ENTRIES.filter((e) => e.cardId === cardId).map((e) => ({
+		stampMasterId: e.stampMasterId,
+		omikujiRank: e.omikujiRank,
+		slot: e.slot,
+		loginDate: e.loginDate,
+		earnedAt: (e as { earnedAt?: string }).earnedAt ?? '',
+	}));
+}
+
+export async function insertCardForRestore(
+	input: Omit<StampCard, 'id'>,
+	_tenantId: string,
+): Promise<StampCard> {
+	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
+	return { ...input, id: 0 };
+}
+
+export async function insertEntryForRestore(
+	_input: {
+		cardId: number;
+		stampMasterId: number | null;
+		omikujiRank: string | null;
+		slot: number;
+		loginDate: string;
+		earnedAt: string;
+	},
+	_tenantId: string,
+): Promise<void> {
+	// Stub: no-op
+}
+
 export async function updateCardStatus(
 	_childId: number,
 	_cardId: number,

--- a/src/lib/server/db/dynamodb/stamp-card-repo.ts
+++ b/src/lib/server/db/dynamodb/stamp-card-repo.ts
@@ -146,6 +146,116 @@ export async function insertCard(
 }
 
 // ============================================================
+// findCardsByChild / findEntriesByCardId — backup export 用 (#3329)
+// ============================================================
+
+export async function findCardsByChild(childId: number, tenantId: string): Promise<StampCard[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				ExpressionAttributeValues: {
+					':pk': childPK(childId, tenantId),
+					':prefix': CARD_PREFIX,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) items.push(item);
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	const cards = items.map(toCard);
+	cards.sort((a, b) => a.weekStart.localeCompare(b.weekStart));
+	return cards;
+}
+
+export async function findEntriesByCardId(
+	cardId: number,
+	tenantId: string,
+): Promise<
+	Array<{
+		stampMasterId: number | null;
+		omikujiRank: string | null;
+		slot: number;
+		loginDate: string;
+		earnedAt: string;
+	}>
+> {
+	const items = await queryCardEntries(cardId, tenantId);
+	const rows = items.map((item) => {
+		const stripped = stripKeys(item) as Record<string, unknown>;
+		return {
+			stampMasterId: (stripped.stampMasterId ?? null) as number | null,
+			omikujiRank: (stripped.omikujiRank ?? null) as string | null,
+			slot: stripped.slot as number,
+			loginDate: stripped.loginDate as string,
+			earnedAt: (stripped.earnedAt ?? '') as string,
+		};
+	});
+	rows.sort((a, b) => a.slot - b.slot);
+	return rows;
+}
+
+// ============================================================
+// insertCardForRestore / insertEntryForRestore — backup restore 用 (#3329、全フィールド保全)
+// ============================================================
+
+export async function insertCardForRestore(
+	input: Omit<StampCard, 'id'>,
+	tenantId: string,
+): Promise<StampCard> {
+	const id = await nextId(ENTITY_NAMES.stampCard, tenantId);
+	const card: StampCard = { ...input, id };
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...stampCardKey(input.childId, input.weekStart, tenantId),
+				...card,
+			},
+		}),
+	);
+	return card;
+}
+
+export async function insertEntryForRestore(
+	input: {
+		cardId: number;
+		stampMasterId: number | null;
+		omikujiRank: string | null;
+		slot: number;
+		loginDate: string;
+		earnedAt: string;
+	},
+	tenantId: string,
+): Promise<void> {
+	try {
+		await getDocClient().send(
+			new PutCommand({
+				TableName: TABLE_NAME,
+				Item: {
+					...stampEntryKey(input.cardId, input.slot, tenantId),
+					cardId: input.cardId,
+					stampMasterId: input.stampMasterId,
+					omikujiRank: input.omikujiRank,
+					slot: input.slot,
+					loginDate: input.loginDate,
+					earnedAt: input.earnedAt,
+				},
+				ConditionExpression: 'attribute_not_exists(PK)',
+			}),
+		);
+	} catch (e) {
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return;
+		throw e;
+	}
+}
+
+// ============================================================
 // findEntriesWithMasterByCardId — card の entry 一覧 (master JOIN 付き)
 // ============================================================
 

--- a/src/lib/server/db/interfaces/stamp-card-repo.interface.ts
+++ b/src/lib/server/db/interfaces/stamp-card-repo.interface.ts
@@ -17,6 +17,43 @@ export interface IStampCardRepo {
 	insertCard(input: InsertStampCardInput, tenantId: string): Promise<StampCard>;
 	findEntriesWithMasterByCardId(cardId: number, tenantId: string): Promise<StampEntryWithMaster[]>;
 	insertEntry(input: InsertStampEntryInput, tenantId: string): Promise<void>;
+
+	/** #3329 backup: child の全スタンプカード (status / 期間問わず)。 */
+	findCardsByChild(childId: number, tenantId: string): Promise<StampCard[]>;
+
+	/** #3329 backup: card に紐づく押印 raw 行 (master join せず earnedAt まで保全)。 */
+	findEntriesByCardId(
+		cardId: number,
+		tenantId: string,
+	): Promise<
+		Array<{
+			stampMasterId: number | null;
+			omikujiRank: string | null;
+			slot: number;
+			loginDate: string;
+			earnedAt: string;
+		}>
+	>;
+
+	/**
+	 * #3329 backup restore 用: status / redeemedPoints / redeemedAt / 日時を保全して card を復元する。
+	 * insertCard は status 既定化 + redeemed/日時を保持しないため round-trip で交換済状態が失われる。
+	 * id は新規採番、childId は呼び出し側が解決済。
+	 */
+	insertCardForRestore(input: Omit<StampCard, 'id'>, tenantId: string): Promise<StampCard>;
+
+	/** #3329 backup restore 用: earnedAt を保全して押印を復元する (cardId は復元後の card を指す)。 */
+	insertEntryForRestore(
+		input: {
+			cardId: number;
+			stampMasterId: number | null;
+			omikujiRank: string | null;
+			slot: number;
+			loginDate: string;
+			earnedAt: string;
+		},
+		tenantId: string,
+	): Promise<void>;
 	/**
 	 * #2845 課題①: full composite-key addressing。childId + cardId の複合キーで対象を
 	 * 特定し、repo 入口で child 所有権を構造的に検証する。不一致なら no-op。

--- a/src/lib/server/db/sqlite/stamp-card-repo.ts
+++ b/src/lib/server/db/sqlite/stamp-card-repo.ts
@@ -83,6 +83,91 @@ export async function findEntriesWithMasterByCardId(
 		.all();
 }
 
+/** #3329 backup: child の全スタンプカード。 */
+export async function findCardsByChild(childId: number, _tenantId: string): Promise<StampCard[]> {
+	return db
+		.select()
+		.from(schema.stampCards)
+		.where(eq(schema.stampCards.childId, childId))
+		.orderBy(schema.stampCards.weekStart)
+		.all();
+}
+
+/** #3329 backup: card に紐づく押印 raw 行 (earnedAt まで含む)。 */
+export async function findEntriesByCardId(
+	cardId: number,
+	_tenantId: string,
+): Promise<
+	Array<{
+		stampMasterId: number | null;
+		omikujiRank: string | null;
+		slot: number;
+		loginDate: string;
+		earnedAt: string;
+	}>
+> {
+	return db
+		.select({
+			stampMasterId: schema.stampEntries.stampMasterId,
+			omikujiRank: schema.stampEntries.omikujiRank,
+			slot: schema.stampEntries.slot,
+			loginDate: schema.stampEntries.loginDate,
+			earnedAt: schema.stampEntries.earnedAt,
+		})
+		.from(schema.stampEntries)
+		.where(eq(schema.stampEntries.cardId, cardId))
+		.orderBy(schema.stampEntries.slot)
+		.all();
+}
+
+/** #3329 backup restore 用: status / redeemed / 日時を保全して card を復元する。 */
+export async function insertCardForRestore(
+	input: Omit<StampCard, 'id'>,
+	_tenantId: string,
+): Promise<StampCard> {
+	const card = db
+		.insert(schema.stampCards)
+		.values({
+			childId: input.childId,
+			weekStart: input.weekStart,
+			weekEnd: input.weekEnd,
+			status: input.status,
+			redeemedPoints: input.redeemedPoints,
+			redeemedAt: input.redeemedAt,
+			createdAt: input.createdAt,
+			updatedAt: input.updatedAt,
+		})
+		.returning()
+		.get();
+	if (!card) throw new Error('insertCardForRestore: insert returned no row');
+	return card;
+}
+
+/** #3329 backup restore 用: earnedAt を保全して押印を復元する。 */
+export async function insertEntryForRestore(
+	input: {
+		cardId: number;
+		stampMasterId: number | null;
+		omikujiRank: string | null;
+		slot: number;
+		loginDate: string;
+		earnedAt: string;
+	},
+	_tenantId: string,
+): Promise<void> {
+	db.insert(schema.stampEntries)
+		.values({
+			cardId: input.cardId,
+			stampMasterId: input.stampMasterId,
+			omikujiRank: input.omikujiRank,
+			slot: input.slot,
+			loginDate: input.loginDate,
+			earnedAt: input.earnedAt,
+		})
+		.onConflictDoNothing()
+		.run();
+}
+
 /** スタンプエントリを挿入（同日重複時は無視） */
 export async function insertEntry(input: InsertStampEntryInput, _tenantId: string): Promise<void> {
 	db.insert(schema.stampEntries)

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -22,6 +22,7 @@ import {
 	type ExportRewardRedemption,
 	type ExportSetting,
 	type ExportSpecialReward,
+	type ExportStampCard,
 	type ExportStatus,
 	type ExportStatusHistory,
 	type ExportTitle,
@@ -228,6 +229,7 @@ interface ChildTransactionData {
 	specialRewards: ExportSpecialReward[];
 	rewardRedemptions: ExportRewardRedemption[];
 	childChallenges: ExportChildChallenge[];
+	stampCards: ExportStampCard[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 }
@@ -256,6 +258,7 @@ async function collectForChild(
 		specialRewards,
 		redemptions,
 		challenges,
+		stampCardsRaw,
 		checklistTemplates,
 	] = await Promise.all([
 		// #3327 P2: per-child 活動インスタンスを backup に保持 (archive 済も含む)。
@@ -271,6 +274,8 @@ async function collectForChild(
 		findRedemptionRequestsByTenant(tenantId, { childId, limit: MAX_EXPORT_ROWS }),
 		// #3329: per-child チャレンジ instance を backup に保持 (auto:weekly 含む全 status)。
 		getRepos().childChallenge.findByChildId(childId, tenantId),
+		// #3329: per-child スタンプカードを backup に保持 (entry は後段で card ごとに収集)。
+		getRepos().stampCard.findCardsByChild(childId, tenantId),
 		// #3106: backup なので includeInactive=true + includeArchived=true。
 		// archive 済 template も含め、その checklistLog の silent drop を防ぐ。
 		findTemplatesByChild(childId, tenantId, true, true),
@@ -421,6 +426,32 @@ async function collectForChild(
 		updatedAt: c.updatedAt,
 	}));
 
+	// #3329: スタンプカード + 押印 entry を nested で出力。card ごとに entry を引く (件数小)。
+	warnIfTruncated('stampCards', childId, stampCardsRaw.length);
+	const stampRepo = getRepos().stampCard;
+	const stampCardsOut: ExportStampCard[] = await Promise.all(
+		stampCardsRaw.map(async (card) => {
+			const entries = await stampRepo.findEntriesByCardId(card.id, tenantId);
+			return {
+				childRef,
+				weekStart: card.weekStart,
+				weekEnd: card.weekEnd,
+				status: card.status,
+				redeemedPoints: card.redeemedPoints,
+				redeemedAt: card.redeemedAt,
+				createdAt: card.createdAt,
+				updatedAt: card.updatedAt,
+				entries: entries.map((e) => ({
+					stampMasterId: e.stampMasterId,
+					omikujiRank: e.omikujiRank,
+					slot: e.slot,
+					loginDate: e.loginDate,
+					earnedAt: e.earnedAt,
+				})),
+			};
+		}),
+	);
+
 	// Checklist templates with items
 	// #3078 / #3107: templateId → (name, exportId) マップを構築し checklistLogs の参照解決に使う。
 	// exportId は export 内で安定な識別子 (`chk-${childRef}-${templateId}`) で、同名 template が
@@ -488,6 +519,7 @@ async function collectForChild(
 		specialRewards: specialRewardsOut,
 		rewardRedemptions: rewardRedemptionsOut,
 		childChallenges: childChallengesOut,
+		stampCards: stampCardsOut,
 		checklistTemplates: checklistTemplatesOut,
 		checklistLogs: checklistLogsOut,
 	};
@@ -526,6 +558,7 @@ async function collectTransactionData(
 		specialRewards: perChild.flatMap((p) => p.specialRewards),
 		rewardRedemptions: perChild.flatMap((p) => p.rewardRedemptions),
 		childChallenges: perChild.flatMap((p) => p.childChallenges),
+		stampCards: perChild.flatMap((p) => p.stampCards),
 		checklistTemplates: perChild.flatMap((p) => p.checklistTemplates),
 		checklistLogs: perChild.flatMap((p) => p.checklistLogs), // #3078
 		childAvatarItems: [],

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -63,6 +63,11 @@ export interface ImportResult {
 	/** #3329: per-child チャレンジ instance の取込件数 (auto:weekly 含む) */
 	childChallengesImported: number;
 	childChallengesSkipped: number;
+	/** #3329: スタンプカード / 押印 entry の取込件数 */
+	stampCardsImported: number;
+	stampCardsSkipped: number;
+	stampEntriesImported: number;
+	stampEntriesSkipped: number;
 	loginBonusesImported: number;
 	loginBonusesSkipped: number;
 	statusHistoryImported: number;
@@ -278,6 +283,8 @@ export async function importFamilyData(
 	await importRewardRedemptionsData(data, childIdMap, tenantId, result);
 	// #3329: per-child チャレンジ (auto:weekly 含む) を進捗/完了/請求保全で復元。childIdMap のみ必要。
 	await importChildChallengesData(data, childIdMap, tenantId, result);
+	// #3329: スタンプカード + 押印。card を復元 → 新 cardId に entry を貼り直す。childIdMap のみ必要。
+	await importStampCardsData(data, childIdMap, tenantId, result);
 	await importStatusHistoryData(data, childIdMap, tenantId, result);
 	// #3327/#3328: 評価 (週次評価) の取込。従来 import 関数が無く restore で全喪失していた網羅漏れを解消。
 	await importEvaluationsData(data, childIdMap, tenantId, result);
@@ -482,6 +489,74 @@ async function importChildChallengesData(
 	}
 }
 
+/**
+ * スタンプカード + 押印 entry を復元する (#3329)。
+ * childRef で取込先 child に解決し insertCardForRestore で card (status/redeemed/日時) を復元、
+ * 返却された新 cardId に各 entry を insertEntryForRestore で貼り直す (earnedAt 保全)。
+ * entry の stampMasterId はグローバル master を指すため値のまま書き戻すが、対象環境に存在しない
+ * 場合は FK で insert 失敗 → 当該 entry のみ skip+warning (card と他 entry は保全)。
+ */
+async function importStampCardsData(
+	data: ExportData,
+	childIdMap: Map<string, number>,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	const repo = getRepos().stampCard;
+	for (const card of data.data.stampCards ?? []) {
+		const childId = childIdMap.get(card.childRef);
+		if (!childId) {
+			result.stampCardsSkipped++;
+			continue;
+		}
+		let newCardId: number;
+		try {
+			const restored = await repo.insertCardForRestore(
+				{
+					childId,
+					weekStart: card.weekStart,
+					weekEnd: card.weekEnd,
+					status: card.status,
+					redeemedPoints: card.redeemedPoints,
+					redeemedAt: card.redeemedAt,
+					createdAt: card.createdAt,
+					updatedAt: card.updatedAt,
+				},
+				tenantId,
+			);
+			newCardId = restored.id;
+			result.stampCardsImported++;
+		} catch (e) {
+			result.stampCardsSkipped++;
+			result.errors.push(
+				`スタンプカード insert 失敗 (child=${card.childRef}, week=${card.weekStart}): ${String(e)}`,
+			);
+			continue;
+		}
+		for (const entry of card.entries) {
+			try {
+				await repo.insertEntryForRestore(
+					{
+						cardId: newCardId,
+						stampMasterId: entry.stampMasterId,
+						omikujiRank: entry.omikujiRank,
+						slot: entry.slot,
+						loginDate: entry.loginDate,
+						earnedAt: entry.earnedAt,
+					},
+					tenantId,
+				);
+				result.stampEntriesImported++;
+			} catch (e) {
+				result.stampEntriesSkipped++;
+				result.errors.push(
+					`スタンプ押印 insert 失敗 (child=${card.childRef}, slot=${entry.slot}): ${String(e)}`,
+				);
+			}
+		}
+	}
+}
+
 function createEmptyImportResult(): ImportResult {
 	return {
 		childrenImported: 0,
@@ -499,6 +574,10 @@ function createEmptyImportResult(): ImportResult {
 		rewardRedemptionsSkipped: 0,
 		childChallengesImported: 0,
 		childChallengesSkipped: 0,
+		stampCardsImported: 0,
+		stampCardsSkipped: 0,
+		stampEntriesImported: 0,
+		stampEntriesSkipped: 0,
 		loginBonusesImported: 0,
 		loginBonusesSkipped: 0,
 		statusHistoryImported: 0,

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -134,10 +134,8 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 			'childCustomVoices',
 			'parentMessage',
 			'restDays',
-			// rewardRedemption / setting は #3329 で export 実装済 → exported へ flip (本ベースラインから除外)
+			// rewardRedemption / setting / stampCard / stampEntry は #3329 で export 実装済 → exported へ flip
 			'siblingCheer',
-			'stampCard',
-			'stampEntry',
 		]);
 	});
 

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -177,6 +177,33 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		);
 		await getRepos().childChallenge.updateProgress(challenge.id, 2, T);
 
+		// #3329: スタンプカード (交換済) + 押印 1 件を seed。round-trip 後に status/redeemed と
+		// 押印 (omikujiRank/earnedAt) が保全されることを検証する。
+		const stampCard = await getRepos().stampCard.insertCardForRestore(
+			{
+				childId: 1,
+				weekStart: '2026-02-23',
+				weekEnd: '2026-03-01',
+				status: 'redeemed',
+				redeemedPoints: 20,
+				redeemedAt: '2026-03-01T10:00:00Z',
+				createdAt: '2026-02-23T00:00:00Z',
+				updatedAt: '2026-03-01T10:00:00Z',
+			},
+			T,
+		);
+		await getRepos().stampCard.insertEntryForRestore(
+			{
+				cardId: stampCard.id,
+				stampMasterId: null,
+				omikujiRank: 'test-rank',
+				slot: 0,
+				loginDate: '2026-02-24',
+				earnedAt: '2026-02-24T08:00:00Z',
+			},
+			T,
+		);
+
 		// --- export ---
 		const data = await exportFamilyData({ tenantId: T });
 		// export が全種別を捕捉していること (sanity)
@@ -193,6 +220,9 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(settingKeys, 'export:設定 pin_hash 除外').not.toContain('pin_hash');
 		expect(data.data.childChallenges.length, 'export:チャレンジ').toBe(1);
 		expect(data.data.childChallenges[0]?.currentValue, 'export:チャレンジ進捗').toBe(2);
+		expect(data.data.stampCards.length, 'export:スタンプカード').toBe(1);
+		expect(data.data.stampCards[0]?.status, 'export:カード status').toBe('redeemed');
+		expect(data.data.stampCards[0]?.entries.length, 'export:押印').toBe(1);
 
 		// --- replace = clear → import ---
 		await clearAllFamilyData(T);
@@ -233,6 +263,18 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(restoredChallenges.length, 'チャレンジ').toBe(1);
 		expect(restoredChallenges[0]?.currentValue, 'チャレンジ進捗保全').toBe(2);
 		expect(restoredChallenges[0]?.title, 'チャレンジ title 保全').toBe('うんどうチャレンジ');
+
+		// #3329: スタンプカードが status/redeemed を保ち、押印 (omikujiRank) が復元される。
+		const restoredCards = await getRepos().stampCard.findCardsByChild(cid, T);
+		expect(restoredCards.length, 'スタンプカード').toBe(1);
+		expect(restoredCards[0]?.status, 'カード status 保全').toBe('redeemed');
+		expect(restoredCards[0]?.redeemedPoints, 'カード redeemedPoints 保全').toBe(20);
+		const restoredEntries = await getRepos().stampCard.findEntriesByCardId(
+			restoredCards[0]?.id as number,
+			T,
+		);
+		expect(restoredEntries.length, '押印').toBe(1);
+		expect(restoredEntries[0]?.omikujiRank, '押印 omikujiRank 保全').toBe('test-rank');
 	});
 
 	// #3329 QM-fix (2)(a): auto:weekly チャレンジの dedup round-trip。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全ユーザー（バックアップ・移管利用者）

**解決する課題**: バックアップ ZIP を別環境へ import すると **スタンプカードの交換状態と押印履歴が一切復元されない**（本番 t-82c17558 の喪失の一部）。stamp_cards / stamp_entries に export/import 経路が無く、replace import で全消失していた。

**期待される効果**: 週単位スタンプカードが status（収集中/交換可/交換済）・交換ポイント・押印 entry（おみくじ結果/獲得日時）を保ったまま round-trip 復元される。

## 関連 Issue

関連: #3329 #3328（未 export source の stampCard / stampEntry を実装。残 5 件は registry を起点に順次対応するため #3329 は close しない）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|----|------|---------|------------------|
| AC1 | スタンプカード + 押印 (nested) を export に含める | export-format / export-service | HEAD `975cfc58` |
| AC2 | import で childRef→child 解決し card 復元→新 cardId に entry を貼り直す | import-service `importStampCardsData` | HEAD `975cfc58` |
| AC3 | round-trip (交換済カード status/redeemedPoints + 押印 omikujiRank が保全) | `backup-roundtrip-completeness.test.ts` | HEAD `975cfc58` |
| AC4 | insert* (status 既定化/earnedAt=now) と分離した復元専用経路を 3 実装で機能等価に提供 | repo `insertCardForRestore` / `insertEntryForRestore` | HEAD `975cfc58` |
| AC5 | グローバル master (stampMasterId) 参照を維持、不在時は entry のみ skip | importStampCardsData per-entry try/catch | HEAD `975cfc58` |
| AC6 | registry の stampCard / stampEntry を exported へ flip + ratchet 整合 | `backup-entity-registry.test.ts` | HEAD `975cfc58` |
| AC7 | 型・lint・cspell・全 unit 健全 | svelte-check / biome / cspell / vitest | svelte-check 0 ERROR / biome クリーン / cspell クリーン / unit 2758 passed |

## 変更タイプ

- [x] fix: バグ修正（データ喪失）
- [x] feat: 新機能（backup 対象拡張）

## 影響範囲・変更コンポーネント

- [x] サービス層（export-service / import-service）
- [x] DB 層（stamp-card repo: interface + sqlite/dynamodb/demo に find-all/raw-entries/2 restore inserts 追加）
- [x] ドメイン型（export-format）

**影響を受ける機能**: バックアップ export / import。UI 非変更。clear は child_id/card_id cascade で自動削除のため tenant-cleanup 変更不要。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3329stamp` 全 Step PASS**
- [x] 追加・変更テスト: completeness に交換済カード + 押印 round-trip 保全 assert を追加
- [x] **DynamoDB 実装変更時**: 4 メソッドを sqlite/dynamodb/demo で機能等価に実装 (stub parity guard 整合、復元専用経路は status/earnedAt を初期化しない)
- [x] **スキーマ変更**: なし

## スクリーンショット / ビジュアルデモ

**該当なし**: `.svelte` / `.css` 変更なし（バックエンドのデータ経路のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: 復元専用 insert を card/entry 各 1 メソッドに集約し 3 実装で等価。rewardRedemption/setting/challenge と同パターン
- [x] **データ整合**: nested 構造で card→entry の所属を保ち、新 cardId に正しく貼り直す。redeemed 状態を保全（再交換による二重付与を避ける）
- [x] **グローバル master 参照**: stampMasterId はグローバル seed (環境間同一) を維持。不在環境では entry のみ degrade（card と他 entry は保全）
- [x] **YAGNI**: stampCard/stampEntry の 2 テーブルのみ

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): registry の stampCard / stampEntry 分類を exported に更新
- [x] **並行 PR overlap** (#1200): #3373/#3378/#3385（交換履歴/設定/チャレンジ）が develop へ先行マージ済。同一ファイル (export-format/export-service/import-service/completeness test) に追記する形で衝突最小化、develop 最新化済

## レビュー依頼事項・破壊的変更

- [x] 破壊的変更は**含まれない**（新規 optional field のみ、旧 backup の import も継続可）

**レビュー依頼**: stampMasterId をグローバル master 参照のまま維持する方針（環境間 seed 同一前提）と、card→entry の nested 復元順（card 先・新 cardId 解決後に entry）の妥当性をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3329stamp` 全 Step PASS** をローカル確認
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] Phase 分割: 残 source 5 件は registry を起点に順次対応
- [x] UI / 認証画面変更: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
