### PR TITLE
fix(ci): #3128 concurrency を pull_request 時のみ cancel し main-push 検証を保全

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # #3128: PR lane の重複 run のみ cancel する。main push (push:[main]) では
+  # group key が github.ref (=refs/heads/main) に fallback するため、batch-merge が
+  # 短時間に連続すると旧 main-push run が cancel され superseded な中間 commit の
+  # per-commit 再検証が欠落する。pull_request イベント時のみ cancel して main 検証を保全する。
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,10 @@ name: "CodeQL"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # #3128: PR lane の重複 run のみ cancel する。main push では group key が github.ref に
+  # fallback し batch-merge 連続時に旧 main-push scan が cancel され per-commit scan が
+  # 欠落するため、pull_request イベント時のみ cancel して main commit の独立 scan を保全する。
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（CI/監査の検証完全性）

**解決する課題**: PR #3124 が ci.yml / codeql.yml に `cancel-in-progress: true` を付与したが、両 workflow は `push:[main]` でも発火し group key が `github.ref`(=refs/heads/main) に fallback するため、batch-merge が短時間に連続すると旧 main-push の CI/CodeQL run が cancel され、superseded な中間 main commit の per-commit 再検証/scan が欠落していた。

**期待される効果**: PR lane の重複 run cancel（CI 効率化）は維持しつつ、main commit ごとの独立検証/scan を保全する。

## 関連 Issue

closes #3128

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | ci.yml / codeql.yml の main-push run を cancel 対象から除外 | `grep cancel-in-progress .github/workflows/{ci,codeql}.yml` | 両ファイルとも `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` |
| AC2 | PR lane の cancel 節約効果は維持 | 同上（pull_request イベント時は true 評価） | PR 時のみ cancel、#3124 の主目的を保持 |
| AC3 | YAML 構文が妥当 | `js-yaml` parse | 両ファイル OK |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`.github/`)

**影響を受ける画面・機能**: CI (`ci.yml`) / CodeQL (`codeql.yml`) の concurrency 制御のみ。production code 非影響。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: N/A（CI YAML の concurrency 式変更。js-yaml で構文検証済）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（CI 設定のみ、UI 変更なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: concurrency 1 行のみの最小変更
- [x] **DRY**: 両 workflow に同一パターンを適用
- [x] **YAGNI**: 推奨された最小 remediation のみ（per-run 分離 alt は不採用）
- [x] **Security（OSS 公開前提）**: CodeQL の main commit scan を保全する方向（むしろ改善）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: PR lane の cancel 効率は不変、main run は full 実行（意図通り）

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（CI 設定）
- [x] **設計書同期** (ADR-0001): CI 効率化 hardening のみ、設計仕様変更なし
- [x] **並行 PR overlap** (#1200): ci.yml / codeql.yml を変更する open PR は他に無し（確認済）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（PR lane の挙動は不変、main-push のみ非 cancel 化）

**レビュー依頼事項・QA**:
- `${{ github.event_name == 'pull_request' }}` 式が GitHub Actions の cancel-in-progress で正しく boolean 評価されるか
- deploy 安全性が不変であること（deploy.yml/pages.yml は push:[main] 独立発火で ci.yml 非依存）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->
