### PR TITLE
fix(security): #3188 push subscribe endpoint の SSRF hardening (item3)

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -718,6 +718,21 @@ HTTP レスポンスヘッダーで CSP を付与できないため、`<meta htt
 
 **DynamoDB (本番 AWS) (#1666)**: `scripts/migrate-dynamodb-push-subscriber-role.mjs` で `entityType = 'PUSH_SUB'` または `SK begins_with 'PUSH_SUB#'` の item を Scan し、`subscriberRole` 不在 / NULL / 不正値を `'parent'` で UpdateItem する idempotent script を提供。実行手順は [`docs/runbooks/push-subscription-role-migration.md`](../runbooks/push-subscription-role-migration.md) 参照。実行タイミングは DynamoDB push-subscription-repo 本実装マージ後（実装本体は本 follow-up Issue とは別 Issue で扱う、ADR-0010 Pre-PMF / #1021 段階的対応禁止に整合）。検証は CloudWatch Logs `[notification] 非 parent/owner role の subscription への送信をスキップ` warn 件数 = 0。
 
+### 8.9 Web Push subscribe endpoint の SSRF hardening (#3188 item3, CWE-918)
+
+cron の server push (web-push) は `push_subscriptions` に保存済の `endpoint` URL へ POST する。`POST /api/v1/notifications/subscribe` が受け取った `endpoint` を scheme / host 検証なしで保存すると、internal host (`169.254.169.254` / `localhost` / RFC1918 等) を endpoint に指定した攻撃者経由で server-side request forgery (CWE-918) が成立し得る。これを保存前の入力検証で構造的に遮断する。
+
+| 観点 | 仕様 | 実体 |
+|---|---|---|
+| 検証ロジック | `validatePushEndpoint(endpoint)` / `isValidPushKey(key, maxLen)` を独立モジュールに集約 | `src/lib/server/services/push-endpoint-validation.ts` |
+| API ガード | subscribe で保存前に検証し、不正 endpoint は `400` + `code: 'INVALID_ENDPOINT'`、不正 key は `400` + `code: 'INVALID_KEY'` を返す (理由は `logger.warn`、ユーザーには汎用文言) | `src/routes/api/v1/notifications/subscribe/+server.ts` |
+| scheme 制限 | `https:` のみ許可 (それ以外は拒否) | 同上 |
+| host allowlist | 既知 Web Push service host のみ許可。`fcm.googleapis.com` / `android.googleapis.com` (FCM、Chrome/Edge) は exact 一致、`.push.services.mozilla.com` (Firefox) / `.push.apple.com` (Safari) / `.notify.windows.com` / `.wns.windows.com` (WNS) は dot-suffix 末尾一致。末尾一致のため `fcm.googleapis.com.attacker.com` 等の偽装ホストおよび internal host は弾かれる | 同上 |
+| endpoint 長 | 2048 文字上限 | 同上 |
+| key 形式 | `p256dh` / `auth` を base64 / base64url charset + 長さ上限 (`p256dh` 256 / `auth` 64) で検証 | 同上 |
+
+allowlist 方式は新規ブラウザの push host を拒否し得るが、SSRF 面では「公開だが内部 proxy な host」も弾ける最も強い静的防御であり、主要ブラウザを網羅するため Pre-PMF では allowlist を採用する (ADR-0010)。検証は `tests/unit/services/push-endpoint-validation.test.ts` / `tests/unit/routes/notifications-subscribe-api.test.ts`。本 hardening は #3188 item3 のみを対象とし、item1 (購読解除の状態不整合) / item2 (操作取消とエラーの区別 + aria-live) は同 issue で別途扱う。
+
 ---
 
 ## 9. 監査ログ
@@ -760,7 +775,7 @@ HTTP レスポンスヘッダーで CSP を付与できないため、`<meta htt
 | A07 | 認証の不備 | **対策済み** | Cognito JWT検証、MFA対応(TOTP)、パスワードポリシー、認証レートリミット |
 | A08 | ソフトウェアとデータの整合性の不備 | **対策済み** | Docker イメージの ECR 管理、GitHub Actions CI/CD パイプライン |
 | A09 | セキュリティログと監視の不備 | **対策済み** | 構造化ログ、CloudWatch Logs、リクエストログ、エラーログ |
-| A10 | SSRF | **対策済み** | 外部 URL の直接取得なし、S3/DynamoDB は IAM ロール経由のみ |
+| A10 | SSRF | **対策済み** | 外部 URL の直接取得なし、S3/DynamoDB は IAM ロール経由のみ。cron server push が POST する Web Push endpoint は §8.9 の https + host allowlist 検証で internal host への SSRF を遮断 (CWE-918) |
 
 ---
 

--- a/src/lib/server/services/push-endpoint-validation.ts
+++ b/src/lib/server/services/push-endpoint-validation.ts
@@ -20,7 +20,7 @@ const ALLOWED_PUSH_HOSTS: readonly string[] = [
 	// Chrome / Edge / Brave / Opera (FCM)
 	'fcm.googleapis.com',
 	'android.googleapis.com',
-	// Firefox (autopush)
+	// Firefox (Mozilla push service)
 	'.push.services.mozilla.com',
 	// Safari / iOS / macOS (Apple Push)
 	'.push.apple.com',

--- a/src/lib/server/services/push-endpoint-validation.ts
+++ b/src/lib/server/services/push-endpoint-validation.ts
@@ -1,0 +1,88 @@
+// src/lib/server/services/push-endpoint-validation.ts
+//
+// #3188 (#3186 follow-up): Web Push subscribe endpoint の SSRF hardening。
+//
+// 背景: `/api/v1/notifications/subscribe` は受け取った `endpoint` URL を scheme/host 検証なしで
+// raw 保存していた。cron の server push (web-push) はこの保存済 URL へ POST するため、攻撃者が
+// internal host (169.254.169.254 / localhost / RFC1918) を endpoint に指定すると server-side
+// request forgery (CWE-918) の余地があった。p256dh / auth も未検証で raw 保存していた。
+//
+// 対策 (defense-in-depth):
+//   1. https 強制 (push protocol は https のみ)
+//   2. 既知 push service host の allowlist (FCM / Mozilla / Apple / WNS)。allowlist 方式は
+//      新規ブラウザの push host を拒否するリスクがあるが、SSRF 面では「公開だが内部 proxy な
+//      host」も弾ける最も強い静的防御であり、主要ブラウザ (Chrome/Edge=FCM, Firefox=Mozilla,
+//      Safari=Apple) を網羅するため Pre-PMF では allowlist を採用する (ADR-0010)。
+//   3. p256dh (65 byte ≈ 88 char) / auth (16 byte ≈ 24 char) の base64url 形式 + 長さ上限検証。
+
+/** 既知 Web Push service の host (hostname の exact または dot-suffix で照合)。 */
+const ALLOWED_PUSH_HOSTS: readonly string[] = [
+	// Chrome / Edge / Brave / Opera (FCM)
+	'fcm.googleapis.com',
+	'android.googleapis.com',
+	// Firefox (autopush)
+	'.push.services.mozilla.com',
+	// Safari / iOS / macOS (Apple Push)
+	'.push.apple.com',
+	// 旧 Edge / Windows (WNS)
+	'.notify.windows.com',
+	'.wns.windows.com',
+];
+
+/**
+ * hostname が allowlist に含まれるか。先頭ドット付きエントリは「その下のサブドメイン」を許可
+ * (`x.push.services.mozilla.com` は `.push.services.mozilla.com` で末尾一致)。ドットなしエントリは
+ * exact 一致のみ (`fcm.googleapis.com`)。末尾一致のため `evil.com.push.apple.com` のような
+ * 偽装ホストは弾かれる (真に Apple/Mozilla 管理ドメイン配下のみ通る)。
+ */
+function isAllowedPushHost(hostname: string): boolean {
+	const host = hostname.toLowerCase();
+	for (const entry of ALLOWED_PUSH_HOSTS) {
+		if (entry.startsWith('.')) {
+			if (host.endsWith(entry)) return true;
+		} else if (host === entry) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * push endpoint URL を検証する。https + 既知 push service host のみ許可 (SSRF 防御)。
+ *
+ * @returns ok=true で通過、ok=false で reason に拒否理由 (logger 用、ユーザーには汎用文言を返す)
+ */
+export function validatePushEndpoint(
+	endpoint: unknown,
+): { ok: true; url: string } | { ok: false; reason: string } {
+	if (typeof endpoint !== 'string' || endpoint.length === 0) {
+		return { ok: false, reason: 'endpoint is empty or not a string' };
+	}
+	if (endpoint.length > 2048) {
+		return { ok: false, reason: 'endpoint exceeds 2048 chars' };
+	}
+	let url: URL;
+	try {
+		url = new URL(endpoint);
+	} catch {
+		return { ok: false, reason: 'endpoint is not a valid URL' };
+	}
+	if (url.protocol !== 'https:') {
+		return { ok: false, reason: `endpoint scheme must be https (got ${url.protocol})` };
+	}
+	if (!isAllowedPushHost(url.hostname)) {
+		return { ok: false, reason: `endpoint host not in push-service allowlist (${url.hostname})` };
+	}
+	return { ok: true, url: endpoint };
+}
+
+/**
+ * Web Push key (p256dh / auth) が base64url 形式かつ妥当な長さか検証する。
+ * p256dh は uncompressed EC public key (65 byte ≈ 88 base64 char)、auth は 16 byte (≈ 24 char)。
+ * 厳密なバイト長はブラウザ実装で padding 差があるため、charset と上限のみ静的検証する。
+ */
+export function isValidPushKey(key: unknown, maxLen = 256): boolean {
+	if (typeof key !== 'string' || key.length === 0 || key.length > maxLen) return false;
+	// base64 / base64url の両方を許容 (+ / - _ と任意の = padding)
+	return /^[A-Za-z0-9_+/-]+={0,2}$/.test(key);
+}

--- a/src/routes/api/v1/notifications/subscribe/+server.ts
+++ b/src/routes/api/v1/notifications/subscribe/+server.ts
@@ -11,6 +11,10 @@ import { json } from '@sveltejs/kit';
 import { PUSH_NOTIFICATION_LABELS } from '$lib/domain/labels';
 import { findByEndpoint, insert } from '$lib/server/db/push-subscription-repo';
 import { logger } from '$lib/server/logger';
+import {
+	isValidPushKey,
+	validatePushEndpoint,
+} from '$lib/server/services/push-endpoint-validation';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -43,6 +47,23 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 		if (!body.endpoint || !body.keys?.p256dh || !body.keys?.auth) {
 			return json({ error: 'Missing required fields' }, { status: 400 });
+		}
+
+		// #3188 SSRF hardening: endpoint は https + 既知 push service host のみ許可。
+		// cron の server push が internal host へ POST する CWE-918 を防ぐ。
+		const endpointCheck = validatePushEndpoint(body.endpoint);
+		if (!endpointCheck.ok) {
+			logger.warn('[notifications/subscribe] 不正な push endpoint を拒否', {
+				context: { tenantId: context.tenantId, reason: endpointCheck.reason },
+			});
+			return json({ error: 'Invalid push endpoint', code: 'INVALID_ENDPOINT' }, { status: 400 });
+		}
+		// #3188: key は base64url 形式 + 長さ上限のみ検証 (raw 保存前の最小サニタイズ)。
+		if (!isValidPushKey(body.keys.p256dh) || !isValidPushKey(body.keys.auth, 64)) {
+			logger.warn('[notifications/subscribe] 不正な push key 形式を拒否', {
+				context: { tenantId: context.tenantId },
+			});
+			return json({ error: 'Invalid push key', code: 'INVALID_KEY' }, { status: 400 });
 		}
 
 		// 既存チェック（同じ endpoint が登録済みならスキップ）

--- a/tests/unit/routes/notifications-subscribe-api.test.ts
+++ b/tests/unit/routes/notifications-subscribe-api.test.ts
@@ -36,7 +36,7 @@ function makeEvent(opts: {
 		},
 		body: JSON.stringify(
 			opts.body ?? {
-				endpoint: 'https://push.example.com/abc',
+				endpoint: 'https://fcm.googleapis.com/fcm/send/abc',
 				keys: { p256dh: 'p256-key', auth: 'auth-key' },
 			},
 		),
@@ -63,7 +63,7 @@ describe('POST /api/v1/notifications/subscribe (#1593 ADR-0023 I6)', () => {
 		mockInsert.mockResolvedValue({
 			id: 1,
 			tenantId: 'tenant-1',
-			endpoint: 'https://push.example.com/abc',
+			endpoint: 'https://fcm.googleapis.com/fcm/send/abc',
 			keysP256dh: 'p256-key',
 			keysAuth: 'auth-key',
 			userAgent: null,
@@ -113,7 +113,7 @@ describe('POST /api/v1/notifications/subscribe (#1593 ADR-0023 I6)', () => {
 		expect(mockInsert).toHaveBeenCalledWith(
 			expect.objectContaining({
 				tenantId: 'tenant-1',
-				endpoint: 'https://push.example.com/abc',
+				endpoint: 'https://fcm.googleapis.com/fcm/send/abc',
 				subscriberRole: 'parent',
 			}),
 		);
@@ -125,7 +125,7 @@ describe('POST /api/v1/notifications/subscribe (#1593 ADR-0023 I6)', () => {
 		expect(mockInsert).toHaveBeenCalledWith(
 			expect.objectContaining({
 				tenantId: 'tenant-1',
-				endpoint: 'https://push.example.com/abc',
+				endpoint: 'https://fcm.googleapis.com/fcm/send/abc',
 				subscriberRole: 'owner',
 			}),
 		);
@@ -135,7 +135,7 @@ describe('POST /api/v1/notifications/subscribe (#1593 ADR-0023 I6)', () => {
 		mockFindByEndpoint.mockResolvedValue({
 			id: 99,
 			tenantId: 'tenant-1',
-			endpoint: 'https://push.example.com/abc',
+			endpoint: 'https://fcm.googleapis.com/fcm/send/abc',
 			keysP256dh: 'p',
 			keysAuth: 'a',
 			userAgent: null,
@@ -166,7 +166,51 @@ describe('POST /api/v1/notifications/subscribe (#1593 ADR-0023 I6)', () => {
 		const res = await POST(
 			makeEvent({
 				role: 'parent',
-				body: { endpoint: 'https://push.example.com/abc' },
+				body: { endpoint: 'https://fcm.googleapis.com/fcm/send/abc' },
+			}),
+		);
+		expect(res.status).toBe(400);
+		expect(mockInsert).not.toHaveBeenCalled();
+	});
+
+	// #3188 SSRF hardening: allowlist 外 / internal host の endpoint を 400 で拒否し保存しない
+	it('allowlist 外 endpoint (internal host) は 400 で拒否し insert しない', async () => {
+		const res = await POST(
+			makeEvent({
+				role: 'parent',
+				body: {
+					endpoint: 'https://169.254.169.254/latest/meta-data/',
+					keys: { p256dh: 'p256-key', auth: 'auth-key' },
+				},
+			}),
+		);
+		expect(res.status).toBe(400);
+		expect(mockInsert).not.toHaveBeenCalled();
+	});
+
+	it('非 https endpoint は 400 で拒否する', async () => {
+		const res = await POST(
+			makeEvent({
+				role: 'parent',
+				body: {
+					endpoint: 'http://fcm.googleapis.com/fcm/send/abc',
+					keys: { p256dh: 'p256-key', auth: 'auth-key' },
+				},
+			}),
+		);
+		expect(res.status).toBe(400);
+		expect(mockInsert).not.toHaveBeenCalled();
+	});
+
+	// #3188: 不正な key 形式 (制御文字 / 過長) も 400 で拒否
+	it('不正な key 形式は 400 で拒否する', async () => {
+		const res = await POST(
+			makeEvent({
+				role: 'parent',
+				body: {
+					endpoint: 'https://fcm.googleapis.com/fcm/send/abc',
+					keys: { p256dh: 'has space', auth: 'auth-key' },
+				},
 			}),
 		);
 		expect(res.status).toBe(400);

--- a/tests/unit/services/push-endpoint-validation.test.ts
+++ b/tests/unit/services/push-endpoint-validation.test.ts
@@ -1,0 +1,88 @@
+/**
+ * tests/unit/services/push-endpoint-validation.test.ts (#3188 #3)
+ *
+ * Web Push subscribe endpoint の SSRF hardening 検証。internal host / 非 https /
+ * 偽装ホストを拒否し、主要ブラウザの正規 push endpoint を通すことを固定する。
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+	isValidPushKey,
+	validatePushEndpoint,
+} from '../../../src/lib/server/services/push-endpoint-validation';
+
+describe('validatePushEndpoint (#3188 SSRF hardening)', () => {
+	it('主要ブラウザの正規 push endpoint を通す', () => {
+		const valid = [
+			'https://fcm.googleapis.com/fcm/send/abc123',
+			'https://fcm.googleapis.com/wp/xyz',
+			'https://android.googleapis.com/gcm/send/foo',
+			'https://updates.push.services.mozilla.com/wpush/v2/gAAAA',
+			'https://web.push.apple.com/QABC',
+			'https://abc.notify.windows.com/w/?token=xyz',
+		];
+		for (const ep of valid) {
+			expect(validatePushEndpoint(ep)).toEqual({ ok: true, url: ep });
+		}
+	});
+
+	it('https 以外 (http / file / gopher) を拒否', () => {
+		for (const ep of [
+			'http://fcm.googleapis.com/fcm/send/abc',
+			'file:///etc/passwd',
+			'gopher://fcm.googleapis.com/',
+		]) {
+			expect(validatePushEndpoint(ep).ok).toBe(false);
+		}
+	});
+
+	it('internal / metadata / private host を拒否 (SSRF 本丸)', () => {
+		for (const ep of [
+			'https://169.254.169.254/latest/meta-data/',
+			'https://localhost/push',
+			'https://127.0.0.1:8080/push',
+			'https://10.0.0.5/internal',
+			'https://192.168.1.1/admin',
+		]) {
+			expect(validatePushEndpoint(ep).ok).toBe(false);
+		}
+	});
+
+	it('allowlist ホストを末尾に偽装した host を拒否', () => {
+		for (const ep of [
+			'https://evil.com/fcm.googleapis.com',
+			'https://fcm.googleapis.com.attacker.com/send',
+			'https://push.apple.com.evil.net/x',
+		]) {
+			expect(validatePushEndpoint(ep).ok).toBe(false);
+		}
+	});
+
+	it('空 / 非文字列 / 不正 URL / 過長を拒否', () => {
+		expect(validatePushEndpoint('').ok).toBe(false);
+		expect(validatePushEndpoint(undefined).ok).toBe(false);
+		expect(validatePushEndpoint(12345).ok).toBe(false);
+		expect(validatePushEndpoint('not a url').ok).toBe(false);
+		expect(validatePushEndpoint(`https://fcm.googleapis.com/${'a'.repeat(3000)}`).ok).toBe(false);
+	});
+});
+
+describe('isValidPushKey (#3188)', () => {
+	it('base64 / base64url の正規 key を通す', () => {
+		expect(isValidPushKey('BNcRdmF-1234_abcXYZ')).toBe(true);
+		expect(isValidPushKey('abc+/def==')).toBe(true);
+		expect(isValidPushKey('a'.repeat(88))).toBe(true);
+	});
+
+	it('空 / 非文字列 / 不正文字 / 過長を拒否', () => {
+		expect(isValidPushKey('')).toBe(false);
+		expect(isValidPushKey(undefined)).toBe(false);
+		expect(isValidPushKey('has space')).toBe(false);
+		expect(isValidPushKey('has\nnewline')).toBe(false);
+		expect(isValidPushKey('<script>')).toBe(false);
+		expect(isValidPushKey('a'.repeat(300))).toBe(false);
+		// auth は短いので maxLen=64 を超えると拒否
+		expect(isValidPushKey('a'.repeat(80), 64)).toBe(false);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（家庭データの安全性 / 運用の安全）

**解決する課題**: `/api/v1/notifications/subscribe` が受け取った push `endpoint` URL を scheme/host 検証なしで raw 保存していた。cron の server push（web-push）はこの保存済 URL へ POST するため、攻撃者が internal host（169.254.169.254 / localhost / RFC1918）を endpoint に指定すると server-side request forgery（CWE-918）の余地があった。p256dh / auth も未検証で raw 保存していた。

**期待される効果**: push endpoint を https + 既知 push service host に限定し、internal host への SSRF を構造的に遮断する。

## 関連 Issue


関連: #3188（item3 SSRF を消化、item1/item2 は同 issue 残置）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | endpoint を https 強制 | `npx vitest run tests/unit/services/push-endpoint-validation.test.ts` | 「https 以外を拒否」テスト PASS（http/file/gopher 拒否）|
| AC2 | push service host allowlist（internal host SSRF 遮断） | 同 test | 169.254.169.254/localhost/127.0.0.1/RFC1918 + 偽装ホストを拒否、FCM/Mozilla/Apple/WNS 正規 endpoint を通す |
| AC3 | p256dh / auth の base64 検証 | 同 test `isValidPushKey` | 不正文字/過長を拒否、正規 base64url を通す |
| AC4 | subscribe endpoint で保存前に検証し非 2xx 返却 | `subscribe/+server.ts` 実装 | INVALID_ENDPOINT / INVALID_KEY を 400 で返却（logger.warn）|
| AC5 | item1（unsubscribe desync）/ item2（cancel-vs-fail + aria-live） | 別経路（UI 順序 / a11y）のため別 PR | #3188 残置 <!-- ac-verification-skip: item1/2 は UI 経路で別 PR --> |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)

**影響を受ける画面・機能**: Web Push 購読 API（parent/owner の通知 ON）。正規ブラウザの push endpoint は通過、不正/internal endpoint のみ 400 拒否。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `push-endpoint-validation.test.ts` 新規 7 件（https/allowlist/internal/偽装/base64）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（endpoint/key 検証は repo 層手前、両 backend 共通の API 層）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（サーバー側 API 検証のみ、UI 変更なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 検証ロジックを独立モジュールに分離（endpoint で利用）
- [x] **DRY**: endpoint/key 検証を 1 モジュールに集約
- [x] **YAGNI**: item3（SSRF）のみに絞り、item1/2 は別 PR
- [x] **Security（OSS 公開前提）**: CWE-918 SSRF の構造的遮断（allowlist + https）。OWASP A10 整合
- [x] **アクセシビリティ**: N/A（API 層）
- [x] **パフォーマンス**: subscribe 時に URL parse + 正規表現の軽量検証のみ

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（API 層検証、本番/デモ UI 非依存）
- [x] **設計書同期** (ADR-0001): API の入力検証強化（外部仕様の拒否条件追加）。07-API 設計書への追記は軽微だが、必要なら後続 PR（本 PR は検証ロジック追加に限定）
- [x] **並行 PR overlap** (#1200): subscribe/+server.ts / 新規モジュールを変更する open PR は他に無し（確認済）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（正規ブラウザの endpoint は通過、不正のみ拒否）

**レビュー依頼事項・QA**:
- allowlist（FCM/Mozilla/Apple/WNS）が主要ブラウザを網羅し、正規 push を誤拒否しないか
- dot-suffix 末尾一致が偽装ホスト（`fcm.googleapis.com.attacker.com`）を確実に弾くか
- item1/item2 を別 PR とした scope 判断の妥当性

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC が実装済み（item1/2 は #3188 残置を明記）
- [x] Phase 分割した場合: item 単位で分割
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->

