### PR TITLE
infra: #3087 [解決策B] /_app/immutable/* を S3 (OAC) origin から配信 — Lambda 0 直撃化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -175,6 +175,31 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Phase 2.4: #3087 解決策 B — deploy 済 image から SvelteKit client immutable アセットを抽出。
+      # NetworkStack の StaticAssetsDeploy (BucketDeployment) が `infra/static-assets/_app/immutable`
+      # を S3 に upload し、/_app/immutable/* を S3 (OAC) から配信する。
+      # 抽出元は「Lambda が実際に配信するのと同一の build artifact」(同一 image) のため、HTML が
+      # 参照する content-hash と S3 の hash が構造的に完全一致する (host 再ビルドによる hash drift を回避)。
+      # Dockerfile.lambda は build/ の中身を /app/ に COPY するため client は /app/client。
+      - name: Extract SvelteKit client assets for S3 offload (#3087)
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          IMAGE="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker pull "$IMAGE"
+          CID=$(docker create "$IMAGE")
+          rm -rf infra/static-assets
+          mkdir -p infra/static-assets
+          docker cp "$CID:/app/client/_app" infra/static-assets/_app
+          docker rm "$CID" >/dev/null
+          if [ ! -d infra/static-assets/_app/immutable ]; then
+            echo "::error::SvelteKit immutable assets not found at /app/client/_app/immutable in image (#3087)"
+            exit 1
+          fi
+          echo "::notice::Extracted $(find infra/static-assets/_app/immutable -type f | wc -l) immutable asset files for S3 offload"
+
       # Phase 2.5: Clean up failed stacks and orphaned resources
       - name: Cleanup failed stacks
         continue-on-error: true
@@ -209,6 +234,7 @@ jobs:
           npx cdk diff --all \
             -c domainName=${{ env.DOMAIN_NAME }} \
             -c certificateArn=${{ env.CERTIFICATE_ARN }} \
+            -c staticAssetsS3Offload=true \
             -c feedbackDiscordWebhookUrl=${{ secrets.FEEDBACK_DISCORD_WEBHOOK_URL }} \
             -c geminiApiKey=${{ secrets.GEMINI_API_KEY }} \
             -c adminAllowedIps=${{ secrets.ADMIN_ALLOWED_IPS }} \
@@ -234,6 +260,7 @@ jobs:
           npx cdk deploy --all --require-approval never --outputs-file cdk-outputs.json
           -c domainName=${{ env.DOMAIN_NAME }}
           -c certificateArn=${{ env.CERTIFICATE_ARN }}
+          -c staticAssetsS3Offload=true
           -c feedbackDiscordWebhookUrl=${{ secrets.FEEDBACK_DISCORD_WEBHOOK_URL }}
           -c geminiApiKey=${{ secrets.GEMINI_API_KEY }}
           -c adminAllowedIps=${{ secrets.ADMIN_ALLOWED_IPS }}

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -215,10 +215,13 @@ EventBridge / dispatcher 未登録のジョブも NUC では起動する。
   - キャッシュ無効（動的コンテンツ）
   - 全HTTPメソッド許可
   - origin = `lambdaOrigin`（Origin Shield なし。キャッシュ無効な動的応答に二次キャッシュは無効で、余計な hop を載せないため）
-- `/_app/*`: SvelteKitの静的アセット
-  - 365日キャッシュ（immutable）
-  - Gzip + Brotli圧縮
-  - origin = `staticAssetOrigin`（**Origin Shield 有効 / region `us-east-1`、#3087**）。adapter-node + Lambda Web Adapter 構成では client 静的アセットも Lambda が配信するため、エッジ cache cold 時に ~224 本のチャンクが Lambda origin を一斉直撃し `TooManyRequestsException`(429) + HTTP/1.1 接続キュー輻輳で最遅 ~16s に達していた（HAR 実測）。Origin Shield（regional mid-tier cache）で cold-miss burst を 1 リージョンに集約 = 同一アセットの同時 origin fetch を 1 本に collapse + 二次キャッシュで Lambda 直撃を激減させる。region は origin (Lambda) と同一 us-east-1
+- `/_app/immutable/*`: SvelteKit の content-hash 付き immutable 静的アセット（**S3 (OAC) から配信、#3087 解決策 B**）
+  - 365日キャッシュ（immutable）/ Gzip + Brotli 圧縮
+  - origin = S3 `StaticAssetsBucket`（OAC 経由）。**Lambda を一切経由しない**ため、エッジ cache cold 時に ~224 本のチャンクが Lambda origin を一斉直撃して `TooManyRequestsException`(429) + HTTP/1.1 接続キュー輻輳で最遅 ~16s に達していた問題（HAR 実測、#3087）が**構造的に消滅**する
+  - 配信元 = deploy 済 Docker image から抽出した `/app/client/_app/immutable`（= Lambda が SSR で参照するのと**同一 build artifact**）を `BucketDeployment` で S3 に upload。HTML が参照する content-hash と S3 の hash が完全一致する（`prune: false` で旧 hash も残し deploy window 中の旧 HTML 参照を 403 にしない）
+  - 解決策 A（Origin Shield）からの段階改善。CDK context `staticAssetsS3Offload`（deploy.yml が `true` 指定 + image から asset 抽出）で有効化。flag OFF（default）時は従来構成（下記 `/_app/*` の Origin Shield Lambda が immutable も配信）を維持し、本番 template と byte 一致（非 replacement、ADR-0019）
+- `/_app/*`: SvelteKit の非 immutable 静的アセット（`_app/version.json` 等。burst しない）
+  - origin = `staticAssetOrigin`（**Origin Shield 有効 / region `us-east-1`、#3087 解決策 A**）。S3 offload OFF 時は immutable も含め `/_app/*` 全体をここで配信。Origin Shield（regional mid-tier cache）で cold-miss burst を 1 リージョンに集約 = 同一アセットの同時 origin fetch を 1 本に collapse + 二次キャッシュで Lambda 直撃を激減。region は origin (Lambda) と同一 us-east-1
 - `/error/*`: S3 エラーページ（OAC経由、Lambda障害時でもS3から配信）
 - カスタムエラーレスポンス: 500/502/503/504 → S3の子供向けエラーページ
 - Price Class: PriceClass_100（北米+欧州+アジア）
@@ -321,6 +324,7 @@ EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 - ACM 証明書: `props.demoCertificateArn` (未指定時は本番 `certificateArn` を fallback、wildcard `*.ganbari-quest.com` が apex と sub-domain 双方をカバー)
 - キャッシュポリシー: 本番と同一 (`CACHING_DISABLED` 本系 + `/_app/*` 365 日キャッシュ)
 - Origin Shield: 本番と同型に `/_app/*` の `demoStaticAssetOrigin` で有効 (region `us-east-1`、#3087)。default behavior origin は本番同様 shield なし
+- S3 静的アセット offload (#3087 解決策 B): 本番と同型に `/_app/immutable/*` を S3 (OAC) から配信 (`staticAssetsS3Offload=true` 時)。本番と demo は同一 Docker image (= 同一 build) の immutable アセットを配信するため `StaticAssetsBucket` を 1 つ共有し、distribution ごとに OAC を持つ
 - セキュリティヘッダ: 本番と同一 (`SECURITY_HEADERS` policy)
 - CloudFront Function: query slash encode のみ (admin IP 制限は demo に適用しない、anonymous public demo のため)
 - geoRestriction: `JP` (本番と同一、Pre-PMF 段階)
@@ -504,7 +508,7 @@ infra/
 │   ├── storage-stack.ts  # DynamoDB + S3 + ECR + AWS Backup
 │   ├── auth-stack.ts     # Cognito User Pool + SSM Parameters
 │   ├── compute-stack.ts  # Lambda (本番 + demo #2097) + Function URL + IAM Role 分離
-│   ├── network-stack.ts  # CloudFront (本番 + demo #2097) + Route53 + ACM + S3エラーページ
+│   ├── network-stack.ts  # CloudFront (本番 + demo #2097) + Route53 + ACM + S3エラーページ + S3静的アセットoffload (#3087 解決策B)
 │   ├── ops-stack.ts      # CloudWatch Alarms/Dashboard + Budgets + Cost Anomaly + Health通知
 │   └── ses-stack.ts      # SES Email Identity + Configuration Set + メール受信パイプライン
 ├── error-pages/            # CloudFrontカスタムエラーページHTML（S3にデプロイ）

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -2,3 +2,7 @@ node_modules/
 cdk.out/
 *.js
 *.d.ts
+
+# #3087 解決策 B: deploy.yml が deploy 済 Docker image から抽出する SvelteKit client
+# immutable アセット (docker cp /app/client → infra/static-assets)。build 成果物のため commit 不可。
+static-assets/

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import * as path from 'node:path';
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { AuthStack } from '../lib/auth-stack';
@@ -29,6 +30,15 @@ const certificateArn = app.node.tryGetContext('certificateArn') as string | unde
 // PR body の "cert situation" として、本番 certificateArn が wildcard か apex 専用か明記する。
 const demoDomainName = app.node.tryGetContext('demoDomainName') as string | undefined;
 const demoCertificateArn = app.node.tryGetContext('demoCertificateArn') as string | undefined;
+
+// --- #3087 解決策 B: /_app/immutable/* の S3 origin offload ---
+// `-c staticAssetsS3Offload=true` 指定時のみ有効。deploy.yml が deploy 済 Docker image から
+// `docker cp /app/client` で抽出した build artifact を `infra/static-assets` に配置する。
+// flag 未指定 (default) では従来構成 (Origin Shield 経由 Lambda、#3087 解決策 A) を維持する。
+const staticAssetsS3Offload = String(app.node.tryGetContext('staticAssetsS3Offload')) === 'true';
+const staticAssetsSourceDir = staticAssetsS3Offload
+	? path.join(__dirname, '..', 'static-assets')
+	: undefined;
 
 const storage = new StorageStack(app, `${appName}Storage`, {
 	env,
@@ -67,6 +77,9 @@ const network = new NetworkStack(app, `${appName}Network`, {
 	demoFunctionUrl: compute.demoFunctionUrl,
 	demoDomainName,
 	demoCertificateArn,
+	// #3087 解決策 B
+	staticAssetsS3Offload,
+	staticAssetsSourceDir,
 });
 
 // SES Stack: メール送信基盤 + 受信パイプライン（support@ganbari-quest.com）

--- a/infra/lib/network-stack.ts
+++ b/infra/lib/network-stack.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as cdk from 'aws-cdk-lib';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
@@ -24,6 +25,18 @@ export interface NetworkStackProps extends cdk.StackProps {
 	//   - apex 専用証明書の場合は demo 専用証明書 ARN を新規発行して渡す
 	//   - 未指定 (undefined) の場合は本番 `certificateArn` を fallback する
 	demoCertificateArn?: string;
+	// --- #3087 解決策 B: /_app/immutable/* の S3 origin offload ---
+	// true の場合、SvelteKit の content-hash 済 immutable 静的アセット (/_app/immutable/*) を
+	// Lambda(Function URL) ではなく S3 (OAC) から配信する。Lambda は HTML/API/動的のみ担う。
+	// false (default) の場合は従来どおり Origin Shield 経由の Lambda origin が /_app/* 全体を
+	// 配信する (#3087 解決策 A)。本番 template 不変条件 = flag OFF で従来構成と byte 一致。
+	staticAssetsS3Offload?: boolean;
+	// staticAssetsS3Offload=true 時に必須。`_app/immutable/` を含むディレクトリ
+	// (= SvelteKit build 出力 `build/client` 相当)。deploy.yml が deploy 済 Docker image から
+	// `docker cp /app/client` で抽出し `infra/static-assets` に配置する (Lambda が配信するのと
+	// 同一 build artifact = content-hash 完全一致を構造的に保証)。未配置のまま flag ON だと
+	// throw する (ADR-0006 silent skip 禁止)。
+	staticAssetsSourceDir?: string;
 }
 
 export class NetworkStack extends cdk.Stack {
@@ -152,6 +165,91 @@ function handler(event) {
 			originShieldRegion: 'us-east-1',
 		});
 
+		// 静的アセット用 cache policy (365 日 immutable)。/_app/* (shield lambda) と
+		// /_app/immutable/* (S3 offload 時) で共有する。
+		const staticAssetsCachePolicy = new cloudfront.CachePolicy(this, 'StaticAssetsCachePolicy', {
+			cachePolicyName: 'GanbariQuestStaticAssets',
+			defaultTtl: cdk.Duration.days(365),
+			maxTtl: cdk.Duration.days(365),
+			minTtl: cdk.Duration.days(1),
+			enableAcceptEncodingGzip: true,
+			enableAcceptEncodingBrotli: true,
+		});
+
+		// --- #3087 解決策 B: /_app/immutable/* を S3 (OAC) から配信する ---
+		// adapter-node の build 済 client immutable アセット (content-hash 付き) を S3 に upload し、
+		// /_app/immutable/* behavior の origin を S3 (OAC) にする。Lambda は HTML/API のみ担うため
+		// cold-miss burst でも Lambda を 0 本直撃 = TooManyRequestsException (429) が構造的に消滅する。
+		// flag OFF (default) の場合は何も生成せず従来構成 (Lambda + Origin Shield が /_app/* 全体配信)
+		// を維持する (本番 template 不変条件)。
+		// 宣言順注意: behavior は /error/* → /_app/immutable/* → /_app/* の順に宣言し、既存
+		// s3ErrorOrigin を origin index 2 に preempt し続ける (OAC 論理 ID churn = CloudFront
+		// replacement を防ぐ、#3102 / ADR-0019)。
+		let prodImmutableS3Origin: cloudfront.IOrigin | undefined;
+		let demoImmutableS3Origin: cloudfront.IOrigin | undefined;
+		if (props.staticAssetsS3Offload) {
+			const srcDir = props.staticAssetsSourceDir;
+			const immutableDir = srcDir ? path.join(srcDir, '_app', 'immutable') : undefined;
+			if (!immutableDir || !fs.existsSync(immutableDir)) {
+				// ADR-0006: silent skip 禁止。flag ON で asset 不在は build / 抽出漏れの hard error。
+				throw new Error(
+					`[network-stack] staticAssetsS3Offload=true requires SvelteKit immutable assets at ${immutableDir ?? '<staticAssetsSourceDir unset>'}. ` +
+						'Run `npm run build` and extract `build/client` (deploy.yml: docker cp <image>:/app/client) into the source dir before synth (#3087 / ADR-0006).',
+				);
+			}
+
+			// network-local bucket (cross-stack cycle 回避、errorPagesBucket と同方針)。
+			// immutable 静的アセット専用。各 deploy で再 upload されるため DESTROY + autoDelete で良い。
+			const staticAssetsBucket = new s3.Bucket(this, 'StaticAssetsBucket', {
+				bucketName: `ganbari-quest-static-assets-${this.account}`,
+				removalPolicy: cdk.RemovalPolicy.DESTROY,
+				autoDeleteObjects: true,
+				blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+				encryption: s3.BucketEncryption.S3_MANAGED,
+			});
+
+			// content-hash 付きで immutable。prune:false で旧 hash を残し、deploy window 中に
+			// 旧 HTML (Lambda 由来) が参照する旧 chunk が 403 にならないようにする。
+			new s3deploy.BucketDeployment(this, 'StaticAssetsDeploy', {
+				sources: [s3deploy.Source.asset(immutableDir)],
+				destinationBucket: staticAssetsBucket,
+				destinationKeyPrefix: '_app/immutable',
+				prune: false,
+				cacheControl: [s3deploy.CacheControl.fromString('public, max-age=31536000, immutable')],
+			});
+
+			// 本番 / demo は同一 Docker image (= 同一 build) の immutable アセットを配信するため
+			// 1 つの bucket を共有する。distribution ごとに OAC + bucket policy が必要なため origin は
+			// それぞれ生成する (同一 bucket を参照)。
+			prodImmutableS3Origin = origins.S3BucketOrigin.withOriginAccessControl(staticAssetsBucket);
+			demoImmutableS3Origin = origins.S3BucketOrigin.withOriginAccessControl(staticAssetsBucket);
+		}
+
+		// 本番 distribution の additionalBehaviors を宣言順 (origin index) に組み立てる。
+		const prodAdditionalBehaviors: Record<string, cloudfront.BehaviorOptions> = {
+			// #3087: /error/* を最初に宣言し s3ErrorOrigin を origin index 2 に固定する。
+			'/error/*': {
+				origin: s3ErrorOrigin,
+				viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+				cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+			},
+		};
+		if (prodImmutableS3Origin) {
+			// /_app/immutable/* は /_app/* より specific なため CloudFront が優先 match する。
+			prodAdditionalBehaviors['/_app/immutable/*'] = {
+				origin: prodImmutableS3Origin,
+				viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+				cachePolicy: staticAssetsCachePolicy,
+			};
+		}
+		// /_app/* (version.json 等 non-immutable / offload OFF 時は immutable も含む) は引き続き
+		// Lambda + Origin Shield。offload ON でも /_app/version.json (no-cache、burst しない) はここ。
+		prodAdditionalBehaviors['/_app/*'] = {
+			origin: staticAssetOrigin,
+			viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+			cachePolicy: staticAssetsCachePolicy,
+		};
+
 		this.distribution = new cloudfront.Distribution(this, 'CDN', {
 			comment: 'Ganbari Quest',
 			defaultBehavior: {
@@ -168,31 +266,7 @@ function handler(event) {
 					},
 				],
 			},
-			additionalBehaviors: {
-				// #3087: /error/* を /_app/* より先に宣言する。CDK は behavior の宣言順に origin
-				// index (CDNOrigin2/3...) を採番するため、既存 s3ErrorOrigin の index を 2 のまま
-				// 維持し、新規追加する staticAssetOrigin を末尾 (index 3) に置く。これにより既存
-				// error origin の OriginAccessControl 論理 ID が変わらず、cdk diff の不要な
-				// destroy/recreate (ADR-0019 gate ノイズ) を避ける。path pattern は非重複のため
-				// 宣言順は CloudFront のマッチング結果に影響しない。
-				'/error/*': {
-					origin: s3ErrorOrigin,
-					viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-					cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-				},
-				'/_app/*': {
-					origin: staticAssetOrigin,
-					viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-					cachePolicy: new cloudfront.CachePolicy(this, 'StaticAssetsCachePolicy', {
-						cachePolicyName: 'GanbariQuestStaticAssets',
-						defaultTtl: cdk.Duration.days(365),
-						maxTtl: cdk.Duration.days(365),
-						minTtl: cdk.Duration.days(1),
-						enableAcceptEncodingGzip: true,
-						enableAcceptEncodingBrotli: true,
-					}),
-				},
-			},
+			additionalBehaviors: prodAdditionalBehaviors,
 			errorResponses: [
 				{
 					httpStatus: 500,
@@ -347,6 +421,35 @@ function handler(event) {
 				originShieldRegion: 'us-east-1',
 			});
 
+			const demoStaticAssetsCachePolicy = new cloudfront.CachePolicy(
+				this,
+				'DemoStaticAssetsCachePolicy',
+				{
+					cachePolicyName: 'GanbariQuestDemoStaticAssets',
+					defaultTtl: cdk.Duration.days(365),
+					maxTtl: cdk.Duration.days(365),
+					minTtl: cdk.Duration.days(1),
+					enableAcceptEncodingGzip: true,
+					enableAcceptEncodingBrotli: true,
+				},
+			);
+
+			// #3087 解決策 B (本番と同型): /_app/immutable/* を S3 (OAC) から配信。
+			// 宣言順 /_app/immutable/* → /_app/* で immutable S3 origin を先に採番する。
+			const demoAdditionalBehaviors: Record<string, cloudfront.BehaviorOptions> = {};
+			if (demoImmutableS3Origin) {
+				demoAdditionalBehaviors['/_app/immutable/*'] = {
+					origin: demoImmutableS3Origin,
+					viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+					cachePolicy: demoStaticAssetsCachePolicy,
+				};
+			}
+			demoAdditionalBehaviors['/_app/*'] = {
+				origin: demoStaticAssetOrigin,
+				viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+				cachePolicy: demoStaticAssetsCachePolicy,
+			};
+
 			// demo 用 CloudFront Function: query slash encode のみ (admin IP 制限なし)。
 			const demoQueryFixFn = new cloudfront.Function(this, 'DemoQuerySlashEncodeFn', {
 				functionName: 'ganbari-quest-demo-query-slash-encode',
@@ -382,20 +485,7 @@ function handler(event) {
 						},
 					],
 				},
-				additionalBehaviors: {
-					'/_app/*': {
-						origin: demoStaticAssetOrigin,
-						viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-						cachePolicy: new cloudfront.CachePolicy(this, 'DemoStaticAssetsCachePolicy', {
-							cachePolicyName: 'GanbariQuestDemoStaticAssets',
-							defaultTtl: cdk.Duration.days(365),
-							maxTtl: cdk.Duration.days(365),
-							minTtl: cdk.Duration.days(1),
-							enableAcceptEncodingGzip: true,
-							enableAcceptEncodingBrotli: true,
-						}),
-					},
-				},
+				additionalBehaviors: demoAdditionalBehaviors,
 				...(demoCertificate
 					? {
 							domainNames: [demoDomainName],

--- a/tests/unit/infra/static-assets-s3-offload.test.ts
+++ b/tests/unit/infra/static-assets-s3-offload.test.ts
@@ -1,0 +1,283 @@
+// tests/unit/infra/static-assets-s3-offload.test.ts
+// #3087 解決策 B — /_app/immutable/* の S3 origin offload の CDK 構造検証。
+//
+// このテストは 2 つの load-bearing 責務を持つ:
+//   (1) 非 replacement guard (AC3、最重要): S3 offload ON にしても既存 CloudFront Distribution
+//       (CDN / DemoCDN) の論理 ID と、既存 s3ErrorOrigin の OAC 論理 ID (origin index 2 由来 =
+//       CDNOrigin2...) が churn しないことを template-level で assert する。distribution 置換は
+//       本番ダウンを招くため、宣言順 preempt (/error/* → /_app/immutable/* → /_app/*) を崩す
+//       将来変更を PR-lane (deploy 前 check-cdk-replacement.mjs gate より前倒し) で検知する。
+//   (2) offload 構造 assert: flag ON で /_app/immutable/* が S3 (OAC) origin を指し、専用 bucket +
+//       BucketDeployment が生成されること。flag OFF (default) では一切生成されず従来構成のまま。
+//
+// flag OFF の従来構成 (origins=3 / OAC=1) は multi-lambda-cdk.test.ts C-2b が別途固定している。
+// 本 test の OFF assert はその二重防御。
+//
+// context stub パターンは tests/unit/infra/multi-lambda-cdk.test.ts を踏襲。
+// 参考: infra/lib/network-stack.ts (staticAssetsS3Offload) / docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { NetworkStack } from '../../../infra/lib/network-stack';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+
+// cspell:ignore TESTPOOL oacs
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+
+function makeApp(): cdk.App {
+	return new cdk.App({
+		context: {
+			'hosted-zone:account=000000000000:domainName=ganbari-quest.com:region=us-east-1': {
+				Id: '/hostedzone/Z00000000000000000000',
+				Name: 'ganbari-quest.com.',
+			},
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+				'us-east-1_TESTPOOL',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+				'test-client-id',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+				'auth.ganbari-quest.com',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+				'test-context-token-secret',
+			opsSecretKey: 'test-ops-secret-key',
+			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+		},
+	});
+}
+
+function buildNetwork(opts: {
+	app: cdk.App;
+	staticAssetsS3Offload?: boolean;
+	staticAssetsSourceDir?: string;
+}): NetworkStack {
+	const storage = new StorageStack(opts.app, 'TestStorage', { env });
+	const compute = new ComputeStack(opts.app, 'TestCompute', {
+		env,
+		table: storage.table,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+	return new NetworkStack(opts.app, 'TestNetwork', {
+		env,
+		functionUrl: compute.functionUrl,
+		domainName: 'ganbari-quest.com',
+		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
+		demoFunctionUrl: compute.demoFunctionUrl,
+		staticAssetsS3Offload: opts.staticAssetsS3Offload,
+		staticAssetsSourceDir: opts.staticAssetsSourceDir,
+	});
+}
+
+type CfnDistribution = {
+	Properties?: {
+		DistributionConfig?: {
+			Origins?: Array<{ Id?: string; OriginAccessControlId?: unknown; S3OriginConfig?: unknown }>;
+			CacheBehaviors?: Array<{ PathPattern?: string; TargetOriginId?: string }>;
+		};
+	};
+};
+
+function distribution(template: Template, prefix: string): CfnDistribution {
+	const distributions = template.findResources('AWS::CloudFront::Distribution');
+	const entry = Object.entries(distributions).find(([lid]) => lid.startsWith(prefix));
+	expect(entry, `distribution with logical id prefix ${prefix} must exist`).toBeDefined();
+	return entry?.[1] as CfnDistribution;
+}
+
+// ---- fixture: SvelteKit immutable assets ディレクトリ (build/client 相当) ----
+let fixtureDir: string;
+let onTemplate: Template;
+let offTemplate: Template;
+
+beforeAll(() => {
+	fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gq-static-assets-'));
+	const immutable = path.join(fixtureDir, '_app', 'immutable', 'chunks');
+	fs.mkdirSync(immutable, { recursive: true });
+	fs.writeFileSync(path.join(immutable, 'app.abc123.js'), 'export const x = 1;\n');
+	fs.writeFileSync(path.join(immutable, 'entry.def456.js'), 'export const y = 2;\n');
+
+	onTemplate = Template.fromStack(
+		buildNetwork({
+			app: makeApp(),
+			staticAssetsS3Offload: true,
+			staticAssetsSourceDir: fixtureDir,
+		}) as unknown as cdk.Stack,
+	);
+	offTemplate = Template.fromStack(buildNetwork({ app: makeApp() }) as unknown as cdk.Stack);
+}, 60_000);
+
+afterAll(() => {
+	if (fixtureDir) fs.rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+describe('#3087 解決策 B — /_app/immutable/* S3 origin offload', () => {
+	describe('AC3: 既存 distribution の非 replacement (最重要)', () => {
+		it('CloudFront Distribution は 2 本のまま (CDN / DemoCDN 論理 ID 不変)', () => {
+			onTemplate.resourceCountIs('AWS::CloudFront::Distribution', 2);
+			expect(Object.keys(distribution(onTemplate, 'CDN').Properties ?? {}).length).toBeGreaterThan(
+				0,
+			);
+			expect(
+				Object.keys(distribution(onTemplate, 'DemoCDN').Properties ?? {}).length,
+			).toBeGreaterThan(0);
+		});
+
+		it('既存 s3ErrorOrigin の OAC 論理 ID が CDNOrigin2 由来で安定 (宣言順 preempt が崩れていない)', () => {
+			// /error/* を /_app/immutable/* / /_app/* より先に宣言し s3Error を origin index 2 に固定。
+			// CDNOrigin2 → 別 index への変化 = error origin OAC replace = CloudFront churn の signal。
+			const oacs = onTemplate.findResources('AWS::CloudFront::OriginAccessControl');
+			const errorOac = Object.keys(oacs).find((id) =>
+				id.startsWith('CDNOrigin2S3OriginAccessControl'),
+			);
+			expect(errorOac, 'error origin OAC must stay at CDNOrigin2 (non-replacement)').toBeDefined();
+		});
+
+		it('本番 CDN の origin は 4 本 (lambda1 / s3Error2 / s3Immutable3 / shield-lambda4)、s3Error は index 2 を保持', () => {
+			const origins = distribution(onTemplate, 'CDN').Properties?.DistributionConfig?.Origins ?? [];
+			expect(origins.length).toBe(4);
+			// S3 (OAC) origin は s3Error(index2) と s3Immutable(index3) のちょうど 2 本。
+			const s3Origins = origins.filter(
+				(o) => o.OriginAccessControlId != null || o.S3OriginConfig != null,
+			);
+			expect(s3Origins.length).toBe(2);
+			// error origin は index 2 のまま (新規 immutable origin に displace されない)。
+			// Origin Id は構築パス prefix + hash suffix を含む (例: TestNetworkCDNOrigin2AA3327FF)
+			// ため substring 判定する。
+			const ids = origins.map((o) => String(o.Id));
+			expect(ids.some((id) => id.includes('CDNOrigin2'))).toBe(true);
+			expect(ids.some((id) => id.includes('CDNOrigin3'))).toBe(true);
+		});
+	});
+
+	describe('AC1/AC2: /_app/immutable/* が S3 (OAC) origin を指す', () => {
+		it('本番 CDN に PathPattern=/_app/immutable/* behavior があり S3 immutable origin (CDNOrigin3) を指す', () => {
+			const cfg = distribution(onTemplate, 'CDN').Properties?.DistributionConfig;
+			const behavior = (cfg?.CacheBehaviors ?? []).find(
+				(b) => b.PathPattern === '/_app/immutable/*',
+			);
+			expect(behavior, '/_app/immutable/* behavior が存在する').toBeDefined();
+			// immutable origin は index 3 (CDNOrigin3) = S3 (OAC)。Lambda(CDNOrigin1/4) ではない。
+			expect(String(behavior?.TargetOriginId)).toContain('CDNOrigin3');
+			// S3 origin (index3) は OAC を持つ。
+			const origins = cfg?.Origins ?? [];
+			const immutableOrigin = origins.find((o) => o.Id === behavior?.TargetOriginId);
+			expect(
+				immutableOrigin?.OriginAccessControlId,
+				'S3 immutable origin は OAC 経由',
+			).toBeDefined();
+		});
+
+		it('/_app/* (version.json 等 non-immutable) は引き続き Lambda + Origin Shield origin を指す', () => {
+			const cfg = distribution(onTemplate, 'CDN').Properties?.DistributionConfig;
+			const behavior = (cfg?.CacheBehaviors ?? []).find((b) => b.PathPattern === '/_app/*');
+			expect(behavior).toBeDefined();
+			const origins = cfg?.Origins ?? [];
+			const appOrigin = origins.find((o) => o.Id === behavior?.TargetOriginId);
+			// shield lambda origin は S3 ではない (OAC を持たない HTTP custom origin)。
+			expect(appOrigin?.OriginAccessControlId).toBeUndefined();
+			expect(appOrigin?.S3OriginConfig).toBeUndefined();
+		});
+
+		it('demo CDN にも /_app/immutable/* behavior があり S3 origin (DemoCDNOrigin2) を指す (本番同型)', () => {
+			const cfg = distribution(onTemplate, 'DemoCDN').Properties?.DistributionConfig;
+			const behavior = (cfg?.CacheBehaviors ?? []).find(
+				(b) => b.PathPattern === '/_app/immutable/*',
+			);
+			expect(behavior).toBeDefined();
+			expect(String(behavior?.TargetOriginId)).toContain('DemoCDNOrigin2');
+			const oacs = onTemplate.findResources('AWS::CloudFront::OriginAccessControl');
+			const demoOac = Object.keys(oacs).find((id) =>
+				id.startsWith('DemoCDNOrigin2S3OriginAccessControl'),
+			);
+			expect(demoOac, 'demo immutable origin OAC が存在する').toBeDefined();
+		});
+	});
+
+	describe('S3 bucket + BucketDeployment', () => {
+		it('専用 bucket ganbari-quest-static-assets-<account> が BLOCK_ALL + SSE で生成される', () => {
+			const buckets = onTemplate.findResources('AWS::S3::Bucket');
+			const serialized = JSON.stringify(buckets);
+			expect(serialized).toContain('ganbari-quest-static-assets-');
+			onTemplate.hasResourceProperties('AWS::S3::Bucket', {
+				BucketName: Match.stringLikeRegexp('^ganbari-quest-static-assets-'),
+				BucketEncryption: {
+					ServerSideEncryptionConfiguration: [
+						{ ServerSideEncryptionByDefault: { SSEAlgorithm: 'AES256' } },
+					],
+				},
+				PublicAccessBlockConfiguration: {
+					BlockPublicAcls: true,
+					BlockPublicPolicy: true,
+					IgnorePublicAcls: true,
+					RestrictPublicBuckets: true,
+				},
+			});
+		});
+
+		it('immutable cache-control 付きで BucketDeployment が _app/immutable prefix に upload する', () => {
+			const deployments = onTemplate.findResources('Custom::CDKBucketDeployment');
+			const matched = Object.values(deployments).filter((d) => {
+				const props = (d as { Properties?: Record<string, unknown> }).Properties ?? {};
+				return (
+					props.DestinationBucketKeyPrefix === '_app/immutable' &&
+					JSON.stringify(props.SystemMetadata ?? props).includes('max-age=31536000')
+				);
+			});
+			expect(matched.length).toBe(1);
+		});
+	});
+
+	describe('AC3 / ADR-0006: flag ON + asset 不在で synth が hard-fail (silent skip 禁止)', () => {
+		it('staticAssetsSourceDir 未指定で throw する', () => {
+			expect(() => buildNetwork({ app: makeApp(), staticAssetsS3Offload: true })).toThrow(
+				/staticAssetsS3Offload=true requires SvelteKit immutable assets/,
+			);
+		});
+
+		it('source dir に _app/immutable が無い場合 throw する', () => {
+			const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gq-empty-'));
+			try {
+				expect(() =>
+					buildNetwork({
+						app: makeApp(),
+						staticAssetsS3Offload: true,
+						staticAssetsSourceDir: emptyDir,
+					}),
+				).toThrow(/requires SvelteKit immutable assets/);
+			} finally {
+				fs.rmSync(emptyDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	describe('flag OFF (default) で従来構成を維持 (本番不変条件の二重防御)', () => {
+		it('S3 static-assets bucket / BucketDeployment を生成しない', () => {
+			const buckets = offTemplate.findResources('AWS::S3::Bucket');
+			expect(JSON.stringify(buckets)).not.toContain('ganbari-quest-static-assets-');
+			// OAC は error origin の 1 本のみ (CDNOrigin2)。
+			const oacs = offTemplate.findResources('AWS::CloudFront::OriginAccessControl');
+			expect(Object.keys(oacs).length).toBe(1);
+			expect(Object.keys(oacs)[0]).toMatch(/^CDNOrigin2S3OriginAccessControl/);
+		});
+
+		it('本番 CDN の origin は従来どおり 3 本 (lambda1 / s3Error2 / shield-lambda3)', () => {
+			const origins =
+				distribution(offTemplate, 'CDN').Properties?.DistributionConfig?.Origins ?? [];
+			expect(origins.length).toBe(3);
+		});
+
+		it('/_app/immutable/* behavior は存在しない (offload OFF では /_app/* のみ)', () => {
+			const cfg = distribution(offTemplate, 'CDN').Properties?.DistributionConfig;
+			const immutable = (cfg?.CacheBehaviors ?? []).find(
+				(b) => b.PathPattern === '/_app/immutable/*',
+			);
+			expect(immutable).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 子供 / システム全体（全 AWS 版ユーザー）

**解決する課題**: AWS 版で PIN 入力後の親画面初回表示時、CloudFront エッジ cold 状態だと SvelteKit の client 静的アセット `/_app/immutable/*` 約 224 本が Lambda(Function URL) origin を一斉直撃し、`TooManyRequestsException`(429) + HTTP/1.1 接続キュー輻輳で最遅 ~16s の待ちが発生していた（HAR 実測、#3087）。全保護者がログインのたびに遭遇するコア導線の構造的欠陥。

**期待される効果**: content-hash 付き immutable アセットを S3 (OAC) から配信し Lambda を一切経由しなくすることで、cold-miss burst でも Lambda 直撃 0 本 = 429 / 輻輳が構造的に消滅。初回ログイン体験の信頼毀損を解消する。解決策 A（Origin Shield、#3099/#3240 で緩和済）からの本命構造改善（解決策 B）。

## 関連 Issue

closes #3087

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `/_app/immutable/*` cold-miss burst で 429 が発生しない（S3 offload で Lambda 0 本直撃） | `npx vitest run tests/unit/infra/static-assets-s3-offload.test.ts`（offload ON で `/_app/immutable/*` → S3 OAC origin / Lambda origin ではないことを assert） | HEAD `7d8d84c8` / 13 passed / `tests/unit/infra/static-assets-s3-offload.test.ts` test "/_app/immutable/* behavior があり S3 immutable origin (CDNOrigin3) を指す" + "/_app/* は引き続き Lambda + Origin Shield" |
| AC2 | 親画面初回表示で origin(Lambda)直撃が大幅減（S3 offload 採用時 `/_app/*`=0 本）を説明 | 設計書 §3.5 + 本 PR「動作原理」節 + test 構造 assert（behavior=`/_app/immutable/*` の TargetOriginId が S3 OAC origin） | HEAD `7d8d84c8` / `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §3.5 CloudFront + DemoCDN 節 / immutable は S3、HTML/API/version.json のみ Lambda |
| AC3 | CDK 差分が既存 distribution の Replacement を起こさない（ADR-0019 PASS） | `npx vitest run tests/unit/infra/static-assets-s3-offload.test.ts`（error OAC=CDNOrigin2 安定 / distribution 2 本論理 ID 不変 / 宣言順 preempt）+ `multi-lambda-cdk.test.ts` flag OFF baseline | HEAD `7d8d84c8` / 13 passed（"既存 s3ErrorOrigin の OAC 論理 ID が CDNOrigin2 由来で安定" / "Distribution は 2 本のまま"）+ 72 passed (tests/unit/infra 全体) |
| AC4 | 設計書 §CloudFront origin/behavior 構成を同期（ADR-0001） | `git diff` 設計書 13 | HEAD `7d8d84c8` / `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §3.5 に `/_app/immutable/*` S3 OAC behavior + DemoCDN 同型 + file-tree 注記を追記 |
| AC5 | `cd infra && npx vitest run`（CDK 単体テスト）PASS | `npx vitest run tests/unit/infra/`（CDK テストは root `tests/unit/infra/` に集約、root vitest で実行）+ `cd infra && npx tsc --noEmit` | HEAD `7d8d84c8` / 5 files 72 passed / tsc exit 0 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] インフラ (`infra/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: CloudFront 経由の全画面の静的アセット配信経路（`/_app/immutable/*`）。UI / アプリコードの変更なし。本番 + demo の両 Distribution。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready` 相当の検証 PASS**: biome（変更 3 ファイル fixed→clean）/ svelte-check（0 errors、src 無変更）/ vitest infra 72 passed / infra tsc 0。E2E/Storybook は UI 無変更のため非該当
- [x] 追加・変更したテストの概要: `tests/unit/infra/static-assets-s3-offload.test.ts` を新規追加（非 replacement guard = error OAC 安定 / distribution 論理 ID 不変、offload 構造 = S3 OAC origin + BucketDeployment、flag OFF 従来構成の二重防御、ADR-0006 hard-fail = asset 不在で synth throw、計 13 ケース）
- [x] **新規 env / secret 追加時**: N/A（追加したのは CDK context flag `staticAssetsS3Offload` のみ。runtime secret ではない）
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（priority:high、type:infra）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: インフラ（CloudFront origin/behavior + CDK + deploy workflow）のみの変更で、UI / 画面の見た目変更を含まない。配信経路の最適化であり、ユーザーに見える画面は同一。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: NetworkStack の origin/behavior 構築を flag で分岐、cache policy を hoist して `/_app/*` と `/_app/immutable/*` で共有（DRY）。既存 errorPagesBucket の network-local pattern を踏襲（cross-stack cycle 回避）
- [x] **DRY**: 本番 / demo で同一 build の immutable アセットを 1 つの `StaticAssetsBucket` で共有。cache policy hoist で重複定義を解消
- [x] **YAGNI**: Origin Group failover 等の過剰機構は不採用（ADR-0010 Pre-PMF）。flag 1 つ + 既存 BucketDeployment パターンの最小構成
- [x] **Security（OSS 公開前提）**: S3 bucket は BLOCK_ALL + SSE-S3 + OAC 限定（公開アクセスなし）。秘密情報の hardcode なし
- [x] **アクセシビリティ**: N/A（インフラ）
- [x] **パフォーマンス**: Lambda 直撃 0 本化が本変更の主目的。S3 immutable 配信で 365 日 edge cache + Gzip/Brotli

## 横展開・影響波及チェック

- [x] 本番 + demo Distribution を同型に同期（両方に `/_app/immutable/*` S3 offload を適用、bucket 共有）
- [x] **labels SSOT**: N/A（文言変更なし）
- [x] **設計書同期** (ADR-0001): `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §3.5 を更新
- [x] **並行 PR overlap** (#1200): `infra/lib/network-stack.ts` を同時期に触る open PR なし（develop と network-stack.ts は base 時点で同一）
- [x] N/A — 年齢モード / ナビ / labels / シードは影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**動作原理 / レビュー観点**:
- **非 replacement の根拠**: behavior 宣言順を `/error/*` → `/_app/immutable/*` → `/_app/*` とし、既存 `s3ErrorOrigin` を origin index 2（OAC 論理 ID `CDNOrigin2...`）に preempt し続ける。新規 immutable S3 origin は index 3、shield-lambda は index 3→4 にシフトするが、いずれも distribution の inline 更新であり CFN リソース置換ではない。test が error OAC=CDNOrigin2 安定 + distribution 論理 ID 不変を template-level で固定（#3240 同型 pattern）。
- **hash 同期の保証**: deploy.yml が deploy 済 Docker image から `docker cp /app/client` で immutable アセットを抽出 → S3 へ upload する。Lambda が SSR で参照するのと**同一 image の同一 build artifact**のため、HTML が参照する content-hash と S3 の hash が構造的に完全一致する（host 側再ビルドによる hash drift を排除）。`prune: false` で旧 hash を残し、deploy window 中に旧 HTML が参照する旧 chunk が 403 にならないようにしている。
- **flag default OFF = 本番不変**: `staticAssetsS3Offload` 未指定（既存 cdk diff/deploy）では template が従来と byte 一致。deploy.yml で `-c staticAssetsS3Offload=true` を渡したときのみ有効化。merge 後の最初の本番 deploy で in-place 有効化される。
- **観察事項（初回有効化時のみ）**: S3 が空の状態での初回有効化 deploy 直後、すでにブラウザに読込済みの旧 HTML が旧 hash chunk を遅延 fetch すると一時的に 403 になり得る（S3 にまだ旧 hash がないため）。HTML は `CACHING_DISABLED`（Lambda 直、edge cache なし）で常に最新が配信されるため通常ナビゲーションは影響なし。Pre-PMF の低トラフィック帯での有効化を推奨。2 回目以降の deploy は `prune: false` で旧 hash が S3 に残るためこの窓は発生しない。

**実装方針の分岐（PO 判断材料）**:
- bucket: 新規専用 `StaticAssetsBucket`（network-local）を採用。理由 = StorageStack の `assetsBucket` はユーザーアップロード + バックアップ用途で lifecycle / 削除ポリシーが異なり、cross-stack 参照で cycle リスクがあるため。errorPagesBucket と同方針で isolation 明確。
- deploy フロー: 既存 build-push の直後に「image から client 抽出」step を 1 つ追加 + cdk diff/deploy --all に context flag を付与する最小追加に留めた（Dockerfile / build トリガーは無変更 = main 不変条件維持）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（CDK context flag `staticAssetsS3Offload` のみで runtime secret ではない）

## Ready for Review チェックリスト

- [x] **検証 全 Step PASS** をローカル確認した（biome / svelte-check 0 err / vitest infra 72 passed / infra tsc 0 / YAML 妥当）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（残存 AC なし）
- [x] Phase 分割なし（単一 PR で完結）
- [x] UI 変更なし（SS 該当なし）
- [x] 認証画面変更なし
- [x] QA 承認・動作確認は QM/lab が実施（Dev 完遂宣言: 上記 AC1〜AC5 を機械検証で達成）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
