### PR TITLE
feat: #3329 証明書 (がんばり/卒業証明書) の backup round-trip + clear FK バグ修正

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -294,6 +294,19 @@ export interface ExportStampCard {
 	entries: ExportStampEntry[];
 }
 
+/**
+ * #3329: per-child 証明書 (がんばり証明書/卒業証明書 等の授与記録)。issuedAt / metadata を保全して
+ * round-trip 復元する (id / tenantId は import 環境で振り直すため childRef で再結合)。
+ */
+export interface ExportCertificate {
+	childRef: string;
+	certificateType: string;
+	title: string;
+	description: string | null;
+	issuedAt: string;
+	metadata: string | null;
+}
+
 export interface ExportChecklistTemplate {
 	childRef: string;
 	name: string;
@@ -370,6 +383,8 @@ export interface ExportTransactionData {
 	childChallenges: ExportChildChallenge[];
 	/** #3329: per-child スタンプカード + 押印 entry (nested、status/redeemed/earnedAt 保全) */
 	stampCards: ExportStampCard[];
+	/** #3329: per-child 証明書 (がんばり/卒業証明書 授与記録、issuedAt/metadata 保全) */
+	certificates: ExportCertificate[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 	childAvatarItems: never[];

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -160,8 +160,9 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	certificate: {
 		classification: 'source',
 		schemaTable: 'certificates',
-		backupStatus: 'not-yet-exported',
-		reason: '証明書/賞状の授与記録。export 未対応 (#3329)',
+		backupStatus: 'exported',
+		reason:
+			'証明書/賞状の授与記録。export/import 実装済 (#3329、issuedAt/metadata を insertForRestore で保全)。child_id は no-cascade のため clear で certificate.deleteByTenantId を明示実行',
 	},
 	parentMessage: {
 		classification: 'source',

--- a/src/lib/server/db/demo/certificate-repo.ts
+++ b/src/lib/server/db/demo/certificate-repo.ts
@@ -36,6 +36,18 @@ export async function findCertificates(childId: number, tenantId: string): Promi
 	return DEMO_CERTIFICATES.filter((c) => c.childId === childId && c.tenantId === tenantId).slice();
 }
 
+export async function insertForRestore(
+	input: Omit<Certificate, 'id' | 'tenantId'>,
+	tenantId: string,
+): Promise<Certificate | null> {
+	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
+	return { ...input, id: 0, tenantId };
+}
+
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	// Stub: no-op
+}
+
 export async function findCertificateById(
 	id: number,
 	tenantId: string,

--- a/src/lib/server/db/dynamodb/certificate-repo.ts
+++ b/src/lib/server/db/dynamodb/certificate-repo.ts
@@ -134,6 +134,54 @@ export async function hasCertificate(
 }
 
 // ============================================================
+// insertForRestore — backup restore 用 (issuedAt / metadata 保全、#3329)
+// ============================================================
+
+export async function insertForRestore(
+	input: Omit<Certificate, 'id' | 'tenantId'>,
+	tenantId: string,
+): Promise<Certificate | null> {
+	const id = await nextId(ENTITY_NAMES.certificate, tenantId);
+	const certificate: Certificate = {
+		id,
+		childId: input.childId,
+		tenantId,
+		certificateType: input.certificateType,
+		title: input.title,
+		description: input.description,
+		issuedAt: input.issuedAt,
+		metadata: input.metadata,
+	};
+
+	try {
+		await getDocClient().send(
+			new PutCommand({
+				TableName: TABLE_NAME,
+				Item: {
+					...certificateKey(input.childId, input.certificateType, tenantId),
+					...certificate,
+				},
+				ConditionExpression: 'attribute_not_exists(PK)',
+			}),
+		);
+	} catch (e) {
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return null;
+		return null;
+	}
+
+	return certificate;
+}
+
+// ============================================================
+// deleteByTenantId — テナントの全証明書を削除 (#3329)
+// ============================================================
+
+export async function deleteByTenantId(tenantId: string): Promise<void> {
+	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
+	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), PREFIX);
+}
+
+// ============================================================
 // 内部ヘルパ
 // ============================================================
 

--- a/src/lib/server/db/interfaces/certificate-repo.interface.ts
+++ b/src/lib/server/db/interfaces/certificate-repo.interface.ts
@@ -13,4 +13,18 @@ export interface ICertificateRepo {
 	findCertificates(childId: number, tenantId: string): Promise<Certificate[]>;
 	findCertificateById(id: number, tenantId: string): Promise<Certificate | undefined>;
 	hasCertificate(childId: number, certificateType: string, tenantId: string): Promise<boolean>;
+
+	/**
+	 * #3329 backup restore 用: issuedAt / metadata を保全して証明書を復元する。
+	 * issueCertificate は issuedAt を schema default (now) で発番するため round-trip で授与日時が
+	 * 失われる。本メソッドは export された issuedAt をそのまま書き戻す (id は新規採番、
+	 * tenantId は復元先の値を使う、childId は呼び出し側が解決済)。
+	 */
+	insertForRestore(
+		input: Omit<Certificate, 'id' | 'tenantId'>,
+		tenantId: string,
+	): Promise<Certificate | null>;
+
+	/** #3329: テナントの全証明書を削除 (clear / テナント削除時。child_id は no-cascade のため明示削除が必要)。 */
+	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/sqlite/certificate-repo.ts
+++ b/src/lib/server/db/sqlite/certificate-repo.ts
@@ -34,6 +34,34 @@ export async function issueCertificate(
 	}
 }
 
+/** #3329 backup restore 用: issuedAt / metadata を保全して証明書を復元する。 */
+export async function insertForRestore(
+	input: Omit<Certificate, 'id' | 'tenantId'>,
+	tenantId: string,
+): Promise<Certificate | null> {
+	return (
+		db
+			.insert(certificates)
+			.values({
+				childId: input.childId,
+				tenantId,
+				certificateType: input.certificateType,
+				title: input.title,
+				description: input.description,
+				issuedAt: input.issuedAt,
+				metadata: input.metadata,
+			})
+			.onConflictDoNothing()
+			.returning()
+			.get() ?? null
+	);
+}
+
+/** #3329: テナントの全証明書を削除（SQLite: シングルテナントのため全行削除）。 */
+export async function deleteByTenantId(_tenantId: string): Promise<void> {
+	db.delete(certificates).run();
+}
+
 /** 子供の全証明書を取得（新しい順） */
 export async function findCertificates(childId: number, tenantId: string): Promise<Certificate[]> {
 	return db

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -9,6 +9,7 @@ import {
 	type ExportActivity,
 	type ExportActivityLog,
 	type ExportCategory,
+	type ExportCertificate,
 	type ExportChecklistLog,
 	type ExportChecklistTemplate,
 	type ExportChild,
@@ -230,6 +231,7 @@ interface ChildTransactionData {
 	rewardRedemptions: ExportRewardRedemption[];
 	childChallenges: ExportChildChallenge[];
 	stampCards: ExportStampCard[];
+	certificates: ExportCertificate[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 }
@@ -259,6 +261,7 @@ async function collectForChild(
 		redemptions,
 		challenges,
 		stampCardsRaw,
+		certificatesRaw,
 		checklistTemplates,
 	] = await Promise.all([
 		// #3327 P2: per-child 活動インスタンスを backup に保持 (archive 済も含む)。
@@ -276,6 +279,8 @@ async function collectForChild(
 		getRepos().childChallenge.findByChildId(childId, tenantId),
 		// #3329: per-child スタンプカードを backup に保持 (entry は後段で card ごとに収集)。
 		getRepos().stampCard.findCardsByChild(childId, tenantId),
+		// #3329: per-child 証明書を backup に保持。
+		getRepos().certificate.findCertificates(childId, tenantId),
 		// #3106: backup なので includeInactive=true + includeArchived=true。
 		// archive 済 template も含め、その checklistLog の silent drop を防ぐ。
 		findTemplatesByChild(childId, tenantId, true, true),
@@ -451,6 +456,16 @@ async function collectForChild(
 			};
 		}),
 	);
+	// #3329: per-child 証明書を childRef 付きで出力 (issuedAt/metadata 保全)。
+	warnIfTruncated('certificates', childId, certificatesRaw.length);
+	const certificatesOut: ExportCertificate[] = certificatesRaw.map((c) => ({
+		childRef,
+		certificateType: c.certificateType,
+		title: c.title,
+		description: c.description,
+		issuedAt: c.issuedAt,
+		metadata: c.metadata,
+	}));
 
 	// Checklist templates with items
 	// #3078 / #3107: templateId → (name, exportId) マップを構築し checklistLogs の参照解決に使う。
@@ -520,6 +535,7 @@ async function collectForChild(
 		rewardRedemptions: rewardRedemptionsOut,
 		childChallenges: childChallengesOut,
 		stampCards: stampCardsOut,
+		certificates: certificatesOut,
 		checklistTemplates: checklistTemplatesOut,
 		checklistLogs: checklistLogsOut,
 	};
@@ -559,6 +575,7 @@ async function collectTransactionData(
 		rewardRedemptions: perChild.flatMap((p) => p.rewardRedemptions),
 		childChallenges: perChild.flatMap((p) => p.childChallenges),
 		stampCards: perChild.flatMap((p) => p.stampCards),
+		certificates: perChild.flatMap((p) => p.certificates),
 		checklistTemplates: perChild.flatMap((p) => p.checklistTemplates),
 		checklistLogs: perChild.flatMap((p) => p.checklistLogs), // #3078
 		childAvatarItems: [],

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -68,6 +68,9 @@ export interface ImportResult {
 	stampCardsSkipped: number;
 	stampEntriesImported: number;
 	stampEntriesSkipped: number;
+	/** #3329: per-child 証明書の取込件数 */
+	certificatesImported: number;
+	certificatesSkipped: number;
 	loginBonusesImported: number;
 	loginBonusesSkipped: number;
 	statusHistoryImported: number;
@@ -285,6 +288,8 @@ export async function importFamilyData(
 	await importChildChallengesData(data, childIdMap, tenantId, result);
 	// #3329: スタンプカード + 押印。card を復元 → 新 cardId に entry を貼り直す。childIdMap のみ必要。
 	await importStampCardsData(data, childIdMap, tenantId, result);
+	// #3329: 証明書 (がんばり/卒業証明書 授与記録) を issuedAt 保全で復元。childIdMap のみ必要。
+	await importCertificatesData(data, childIdMap, tenantId, result);
 	await importStatusHistoryData(data, childIdMap, tenantId, result);
 	// #3327/#3328: 評価 (週次評価) の取込。従来 import 関数が無く restore で全喪失していた網羅漏れを解消。
 	await importEvaluationsData(data, childIdMap, tenantId, result);
@@ -557,6 +562,47 @@ async function importStampCardsData(
 	}
 }
 
+/**
+ * 証明書 (がんばり/卒業証明書 授与記録) を復元する (#3329)。
+ * childRef で取込先 child に解決し insertForRestore で issuedAt / metadata を保全して書き戻す。
+ * tenantId は復元先のものを使う (証明書は per-child の授与記録、id/tenantId は env 固有)。
+ * 同 child + certificateType の重複は onConflictDoNothing で skip (null 返却 → skip カウント)。
+ */
+async function importCertificatesData(
+	data: ExportData,
+	childIdMap: Map<string, number>,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	for (const cert of data.data.certificates ?? []) {
+		const childId = childIdMap.get(cert.childRef);
+		if (!childId) {
+			result.certificatesSkipped++;
+			continue;
+		}
+		try {
+			const restored = await getRepos().certificate.insertForRestore(
+				{
+					childId,
+					certificateType: cert.certificateType,
+					title: cert.title,
+					description: cert.description,
+					issuedAt: cert.issuedAt,
+					metadata: cert.metadata,
+				},
+				tenantId,
+			);
+			if (restored) result.certificatesImported++;
+			else result.certificatesSkipped++;
+		} catch (e) {
+			result.certificatesSkipped++;
+			result.errors.push(
+				`証明書 insert 失敗 (child=${cert.childRef}, type=${cert.certificateType}): ${String(e)}`,
+			);
+		}
+	}
+}
+
 function createEmptyImportResult(): ImportResult {
 	return {
 		childrenImported: 0,
@@ -578,6 +624,8 @@ function createEmptyImportResult(): ImportResult {
 		stampCardsSkipped: 0,
 		stampEntriesImported: 0,
 		stampEntriesSkipped: 0,
+		certificatesImported: 0,
+		certificatesSkipped: 0,
 		loginBonusesImported: 0,
 		loginBonusesSkipped: 0,
 		statusHistoryImported: 0,

--- a/src/lib/server/services/tenant-cleanup-service.ts
+++ b/src/lib/server/services/tenant-cleanup-service.ts
@@ -243,6 +243,15 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 		logger.warn(`[tenant-cleanup] specialReward 削除失敗: ${String(err)}`);
 	}
 
+	// #3329: 証明書 (certificates)。child_id が no-cascade のため children 削除より先に明示削除する
+	// (残すと children 削除が FK で失敗し replace import で子ごと喪失する。redemption と同型の修正)。
+	try {
+		await r.certificate.deleteByTenantId(tenantId);
+		deleted++;
+	} catch (err) {
+		logger.warn(`[tenant-cleanup] certificate 削除失敗: ${String(err)}`);
+	}
+
 	// Activity preferences（pin settings）
 	try {
 		await r.activityPref.deleteByTenantId(tenantId);

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -127,7 +127,7 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 		// 新たな not-yet-exported source の silent 増加を禁止する (回帰ネット)。
 		expect(notYetExportedSourceEntities()).toEqual([
 			'activityPref',
-			'certificate',
+			// certificate は #3329 で export 実装済 → exported へ flip
 			'checklistAssignment',
 			'checklistOverride',
 			// childChallenge / childChallengeAutoWeekly は #3329 で export 実装済 → exported へ flip

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -204,6 +204,20 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 			T,
 		);
 
+		// #3329: 証明書を 1 件 seed (issuedAt 明示)。round-trip 後に issuedAt が保全されること、
+		// および certificate.child_id (no-cascade) が clear を阻害せず「子復元=1」になることを検証する。
+		await getRepos().certificate.insertForRestore(
+			{
+				childId: 1,
+				certificateType: 'graduation',
+				title: 'そつぎょうしょうめいしょ',
+				description: null,
+				issuedAt: '2026-02-01T00:00:00Z',
+				metadata: null,
+			},
+			T,
+		);
+
 		// --- export ---
 		const data = await exportFamilyData({ tenantId: T });
 		// export が全種別を捕捉していること (sanity)
@@ -223,6 +237,10 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(data.data.stampCards.length, 'export:スタンプカード').toBe(1);
 		expect(data.data.stampCards[0]?.status, 'export:カード status').toBe('redeemed');
 		expect(data.data.stampCards[0]?.entries.length, 'export:押印').toBe(1);
+		expect(data.data.certificates.length, 'export:証明書').toBe(1);
+		expect(data.data.certificates[0]?.issuedAt, 'export:証明書 issuedAt').toBe(
+			'2026-02-01T00:00:00Z',
+		);
 
 		// --- replace = clear → import ---
 		await clearAllFamilyData(T);
@@ -275,6 +293,11 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		);
 		expect(restoredEntries.length, '押印').toBe(1);
 		expect(restoredEntries[0]?.omikujiRank, '押印 omikujiRank 保全').toBe('test-rank');
+		// #3329: 証明書が issuedAt を保って復元される (clear の FK 阻害も「子復元=1」で担保済)。
+		const restoredCerts = await getRepos().certificate.findCertificates(cid, T);
+		expect(restoredCerts.length, '証明書').toBe(1);
+		expect(restoredCerts[0]?.issuedAt, '証明書 issuedAt 保全').toBe('2026-02-01T00:00:00Z');
+		expect(restoredCerts[0]?.certificateType, '証明書 type 保全').toBe('graduation');
 	});
 
 	// #3329 QM-fix (2)(a): auto:weekly チャレンジの dedup round-trip。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全ユーザー（バックアップ・移管利用者）

**解決する課題**: バックアップ ZIP を別環境へ import すると **証明書（がんばり証明書/卒業証明書）の授与記録が一切復元されない**（本番 t-82c17558 の喪失の一部）。さらに証明書は **clear バグ**も抱えており、certificates.child_id が no-cascade かつ tenant-cleanup で未削除だったため、証明書が存在すると children 削除が FK で失敗し replace import で**子ごと喪失**する（rewardRedemption #3373 と同型）。

**期待される効果**: 証明書が授与日時(issuedAt)・metadata を保ったまま round-trip 復元される。clear の FK 連鎖も根治。

## 関連 Issue

関連: #3329 #3328（未 export source の certificate を実装。残 5 件は registry を起点に順次対応するため #3329 は close しない）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|----|------|---------|------------------|
| AC1 | 証明書を export に含める (per-child) | export-format / export-service | HEAD `95053341` |
| AC2 | import で childRef→child 解決し issuedAt/metadata を insertForRestore で保全 | import-service `importCertificatesData` | HEAD `95053341` |
| AC3 | round-trip (issuedAt/type 保全) | `backup-roundtrip-completeness.test.ts` | HEAD `95053341` |
| AC4 | clear の FK 連鎖修正 (no-cascade child_id が children 削除を阻む) | `tenant-cleanup-service` certificate.deleteByTenantId + completeness の「子復元=1」 | HEAD `95053341` |
| AC5 | insertForRestore (issuedAt 保全) + deleteByTenantId を 3 実装で機能等価提供 | repo (sqlite/dynamodb/demo) | HEAD `95053341` |
| AC6 | registry の certificate を exported へ flip + ratchet 整合 | `backup-entity-registry.test.ts` | HEAD `95053341` |
| AC7 | 型・lint・cspell・全 unit 健全 | svelte-check / biome / cspell / vitest | svelte-check 0 ERROR / biome クリーン / cspell クリーン / unit 2758 passed |

## 変更タイプ

- [x] fix: バグ修正（データ喪失 + clear FK 連鎖）
- [x] feat: 新機能（backup 対象拡張）

## 影響範囲・変更コンポーネント

- [x] サービス層（export-service / import-service / tenant-cleanup-service）
- [x] DB 層（certificate repo: interface + sqlite/dynamodb/demo に insertForRestore / deleteByTenantId 追加）
- [x] ドメイン型（export-format）

**影響を受ける機能**: バックアップ export / import / 全データ削除（clear）/ アカウント削除（共有 deleteTenantScopedData 経由）。UI 非変更。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3329cert` 全 Step PASS**
- [x] 追加・変更テスト: completeness に証明書 (issuedAt 明示) round-trip + 「子復元=1」で clear FK 解消を assert
- [x] **DynamoDB 実装変更時**: insertForRestore / deleteByTenantId を sqlite/dynamodb/demo で機能等価に実装
- [x] **スキーマ変更**: なし

## スクリーンショット / ビジュアルデモ

**該当なし**: `.svelte` / `.css` 変更なし（バックエンドのデータ経路のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: insertForRestore / deleteByTenantId を 3 実装で等価。rewardRedemption の clear FK 修正と同型
- [x] **データ整合**: issuedAt を保全（再発番しない）。重複 type は onConflictDoNothing で skip
- [x] **clear 安全性**: certificate.deleteByTenantId を children 削除前 (special_rewards 直後) に実行し no-cascade FK を解消。account 削除経路 (deleteTenantScopedData 共有) も同時にカバー
- [x] **YAGNI**: certificate 1 テーブルのみ

## 横展開・影響波及チェック

- [x] **同型 clear FK バグの横展開チェック**: no-cascade child_id を持つ証明書を rewardRedemption と同様に明示削除へ追加。残 source の no-cascade 有無は各 PR で個別確認
- [x] **設計書同期** (ADR-0001): registry の certificate 分類を exported に更新
- [x] **並行 PR overlap** (#1200): #3373/#3378/#3385/#3391 が develop へ先行マージ済。同一ファイルに追記する形で衝突を rebase 解決（交換履歴/設定/チャレンジ/スタンプ/証明書を共存）

## レビュー依頼事項・破壊的変更

- [x] 破壊的変更は**含まれない**（新規 optional field のみ、旧 backup の import も継続可）

**レビュー依頼**: clear 削除順（special_rewards 直後に certificate）と、issuedAt を復元先で保全する方針をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3329cert` 全 Step PASS** をローカル確認
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] Phase 分割: 残 source 5 件は registry を起点に順次対応
- [x] UI / 認証画面変更: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


