### PR TITLE
fix: #3101 PIN後 navigating overlay の timeout を 8s→30s (一般的サーバータイムアウト)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -313,7 +313,7 @@ PIN 認証成功 (verify / setup どちらも) 後、`/admin` へのハードナ
 | 状態 | 仕様 |
 |---|---|
 | spinner 状態 | `navigatingToAdmin === true` 中、`data-testid="parent-gate-navigating"` (`role="status"` + `aria-live="polite"`) で spinner + `OYAKAGI_LABELS.gateNavigating`「ご家族の見守り画面をひらいています…」を表示。`?screenshot=all` モード時は SS 撮影用に強制描画 (`isScreenshotAll`) |
-| timeout / error 状態 (fail-safe) | ハードナビ起動後 8s 経ってもページが unload しない (CloudFront 429 / `/admin` 5xx / 通信断 / cookie 失効 等の失敗) 場合、または `window.location.assign` が同期 throw した場合、spinner を解除し `data-testid="parent-gate-navigating-error"` (`role="alert"` + `aria-live="assertive"`) で `OYAKAGI_LABELS.gateNavigatingError` + 再試行ボタン (`OYAKAGI_LABELS.gateNavigatingRetry`、`Button` primitive) を表示する。spinner の永続 dead-end を回避し escape hatch を提供する (NN/g #9 help users recover from errors) |
+| timeout / error 状態 (fail-safe) | ハードナビ起動後 `NAV_TIMEOUT_MS` (30s、一般的なサーバータイムアウトに整合) 経ってもページが unload しない (CloudFront 429 / `/admin` 5xx / 通信断 / cookie 失効 等の失敗) 場合、または `window.location.assign` が同期 throw した場合、spinner を解除し `data-testid="parent-gate-navigating-error"` (`role="alert"` + `aria-live="assertive"`) で `OYAKAGI_LABELS.gateNavigatingError` + 再試行ボタン (`OYAKAGI_LABELS.gateNavigatingRetry`、`Button` primitive) を表示する。spinner の永続 dead-end を回避し escape hatch を提供する (NN/g #9 help users recover from errors) |
 | 再試行 | error 状態の再試行ボタンで `triggerAdminNavigation()` を再起動し spinner 状態へ戻す |
 | z-index | `var(--z-modal)` (§10 トークン、生数値直書きなし) |
 

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -35,7 +35,14 @@ let navigatingError = $state<boolean>(false);
 // timeout の二重起動防止 + 成功 unload 前のクリア用ハンドル。
 let navigatingTimeout: ReturnType<typeof setTimeout> | null = null;
 
-// #3089: /admin へのハードナビを fail-safe で起動する。8s 経っても unload しなければ
+// #3101: ナビ失敗とみなすまでの待機時間。旧実装は 8s 固定だったが、回線が遅い
+// (CloudFront cold-miss 等で実測 4.2s が伸びる) slow-but-successful nav が 8s を超えると
+// 成功直前に「読込失敗」が誤表示される問題があった (PO 指摘: 8s 上限に根拠なし)。
+// 一般的なサーバータイムアウト (CloudFront/Lambda の上限が ~30s) に合わせ、真にハングした
+// 場合のみ error 表示する。正常時はナビ完了でページごと置換されるため本タイマーは発火しない。
+const NAV_TIMEOUT_MS = 30_000;
+
+// #3089: /admin へのハードナビを fail-safe で起動する。NAV_TIMEOUT_MS 経っても unload しなければ
 // (ナビ失敗とみなして) overlay を error 状態に切り替え、window.location.assign が同期 throw
 // した場合も同様に error にフォールバックする。これにより spinner の永続 dead-end を構造的に解消する。
 function triggerAdminNavigation() {
@@ -44,11 +51,11 @@ function triggerAdminNavigation() {
 	navigatingError = false;
 	if (navigatingTimeout !== null) clearTimeout(navigatingTimeout);
 	navigatingTimeout = setTimeout(() => {
-		// ここに到達 = 8s 経ってもページが unload していない = ナビ失敗。
+		// ここに到達 = NAV_TIMEOUT_MS 経ってもページが unload していない = ナビ失敗 (真のハング)。
 		navigatingToAdmin = false;
 		navigatingError = true;
 		navigatingTimeout = null;
-	}, 8000);
+	}, NAV_TIMEOUT_MS);
 	try {
 		// next path が /admin 配下に限定されていることは server 側で保証済
 		window.location.assign(target);

--- a/tests/e2e/parent-gate.spec.ts
+++ b/tests/e2e/parent-gate.spec.ts
@@ -378,6 +378,10 @@ function registerParentGateTests(): void {
 		test('#3089: ハードナビが失敗すると navigating overlay は dead-end にならず error + 再試行が出る', async ({
 			page,
 		}) => {
+			// #3101: NAV_TIMEOUT_MS が 30s (一般的なサーバータイムアウト) に延びたため、実時間で待つと
+			// Playwright の test timeout (30s) を超える。page.clock で timer を制御し fast-forward する。
+			await page.clock.install();
+
 			// /admin への document nav を継続的に abort し、ページが unload しない (= ナビ失敗) を再現
 			await page.route('**/admin', async (route) => {
 				if (route.request().resourceType() === 'document') {
@@ -390,7 +394,7 @@ function registerParentGateTests(): void {
 			await page.goto('/switch?pinRequired=1', { waitUntil: 'domcontentloaded' });
 			await expect(page.getByTestId('parent-gate-modal')).toBeVisible();
 
-			// 作成フロー成功 → triggerAdminNavigation 起動 → nav abort → 8s timeout で error へ
+			// 作成フロー成功 → triggerAdminNavigation 起動 → nav abort → NAV_TIMEOUT_MS で error へ
 			await typePinInto(page, '2468');
 			await expect(page.getByTestId('parent-gate-create')).toHaveAttribute('data-step', 'confirm');
 			await typePinInto(page, '2468');
@@ -398,9 +402,10 @@ function registerParentGateTests(): void {
 			// spinner overlay は一旦表示される
 			await expect(page.getByTestId('parent-gate-navigating')).toBeVisible({ timeout: 5_000 });
 
-			// timeout (8s) 経過後、dead-end でなく error 状態 (role=alert + 再試行ボタン) に切り替わる
+			// NAV_TIMEOUT_MS (30s) を fast-forward → dead-end でなく error 状態 (role=alert + 再試行) へ
+			await page.clock.fastForward(31_000);
 			const errorOverlay = page.getByTestId('parent-gate-navigating-error');
-			await expect(errorOverlay).toBeVisible({ timeout: 12_000 });
+			await expect(errorOverlay).toBeVisible({ timeout: 5_000 });
 			await expect(errorOverlay).toContainText('もう一度');
 			// spinner overlay は消えている (dead-end でない = escape hatch 提供)
 			await expect(page.getByTestId('parent-gate-navigating')).toBeHidden();


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 保護者（管理画面に入る人）

**解決する課題**: PIN 認証後に管理画面へ遷移する間の「読み込み中」overlay が、8 秒固定タイマーで失敗判定していた。回線が遅い slow-but-successful な遷移（CloudFront cold-miss 等で実測 4.2s が伸びる）が 8 秒を超えると、成功直前に「読込失敗」が誤表示され「動いたのか不明」の困惑を error 形で再現していた（PO 指摘: 8 秒上限に根拠がない）。

**期待される効果**: 一般的なサーバータイムアウト（CloudFront/Lambda の ~30s）まで待ち、真にハングした場合のみ error を出す。正常遷移では誤「失敗」が出ない。

## 関連 Issue

関連: #3101（item1 timeout 是正を PO 判断で消化。item2 retry backoff / focus 移動は別経路のため #3101 残置）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 8s 固定 timeout を一般的サーバータイムアウトに是正 | `switch/+page.svelte` `NAV_TIMEOUT_MS` | `8000` → `NAV_TIMEOUT_MS = 30_000` const 化 |
| AC2 | 設計書同期（ADR-0001） | `06-UI設計書.md §4.6.1.1` | timeout 値を 30s に同期 |
| AC3 | fail-safe error 遷移の回帰が壊れない | `npx playwright test tests/e2e/parent-gate.spec.ts` | `page.clock.fastForward(31_000)` で 30s timer を制御し error overlay 出現を検証（実時間待ち回避）|
| AC4 | item2（retry backoff / focus 移動 a11y） | PO 判断対象外 | #3101 残置 <!-- ac-verification-skip: PO は timeout のみ決定、item2 は別途 --> |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/`)

**影響を受ける画面・機能**: `/switch` の PIN 認証後 navigating overlay（保護者の管理画面入場）。表示は不変、失敗判定までの待機時間のみ 8s→30s。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: parent-gate.spec.ts の fail-safe error test を `page.clock` で時間制御に変更（実時間 30s 待ちで test timeout 超過を回避）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（timeout 定数の変更のみ、overlay の描画は完全同一で視覚差分ゼロ）。`refactor:internal-no-doc-impact` ラベル適用（visual diff zero、#2017 / ADR-0003 §4）。設計書 06-UI は spec 値同期のため更新済み。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: マジックナンバー 8000 を意味のある名前付き定数 NAV_TIMEOUT_MS に
- [x] **DRY**: timeout 値を 1 箇所の const に集約
- [x] **YAGNI**: PO 決定の timeout 是正のみ。item2 は範囲外
- [x] **Security（OSS 公開前提）**: N/A（fail-safe の待機時間調整）
- [x] **アクセシビリティ**: error overlay の role=alert / 再試行ボタンは既存維持
- [x] **パフォーマンス**: 正常遷移ではタイマー未発火（ページ置換が先）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): 06-UI設計書 §4.6.1.1 の timeout 値を同期
- [x] **並行 PR overlap** (#1200): switch/+page.svelte / parent-gate.spec.ts を変更する open PR は他に無し（確認済）
- [x] N/A — その他並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（待機時間延長のみ、表示・挙動は同一）

**レビュー依頼事項・QA**:
- `page.clock` 導入（リポジトリ初）で fail-safe error test が決定的に通るか
- 30s が CloudFront/Lambda の一般的タイムアウトとして妥当か（item1 PO 決定）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC が実装済み（item2 は #3101 残置を明記）
- [x] Phase 分割した場合: item 単位
- [x] UI 変更時: 視覚差分ゼロ（timeout 値のみ）
- [x] 認証画面変更時: PIN gate overlay の挙動は parent-gate.spec.ts で回帰担保

## QM レビュー結果

<!-- QM が記入 -->

