### PR TITLE
feat: #3329 親→子おうえんメッセージの backup round-trip 実装

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -307,6 +307,22 @@ export interface ExportCertificate {
 	metadata: string | null;
 }
 
+/**
+ * #3329: 親→子おうえんメッセージ (stamp/text/reward_notice)。sentAt / shownAt (既読) を保全して
+ * round-trip 復元する (id / childId は import 環境で振り直すため childRef で再結合)。
+ */
+export interface ExportParentMessage {
+	childRef: string;
+	messageType: string;
+	stampCode: string | null;
+	body: string | null;
+	icon: string;
+	sentAt: string;
+	shownAt: string | null;
+	bonusPoints: number | null;
+	rewardCategory: string | null;
+}
+
 export interface ExportChecklistTemplate {
 	childRef: string;
 	name: string;
@@ -385,6 +401,8 @@ export interface ExportTransactionData {
 	stampCards: ExportStampCard[];
 	/** #3329: per-child 証明書 (がんばり/卒業証明書 授与記録、issuedAt/metadata 保全) */
 	certificates: ExportCertificate[];
+	/** #3329: 親→子おうえんメッセージ (sentAt/shownAt 保全) */
+	parentMessages: ExportParentMessage[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 	childAvatarItems: never[];

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -167,8 +167,9 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	parentMessage: {
 		classification: 'source',
 		schemaTable: 'parentMessages',
-		backupStatus: 'not-yet-exported',
-		reason: '親→子メッセージ。export 未対応 (#3329)',
+		backupStatus: 'exported',
+		reason:
+			'親→子おうえんメッセージ。export/import 実装済 (#3329、sentAt/shownAt を insertForRestore で保全)。clear は tenant-cleanup の message.deleteByTenantId で既に削除済',
 	},
 	siblingCheer: {
 		classification: 'source',

--- a/src/lib/server/db/demo/message-repo.ts
+++ b/src/lib/server/db/demo/message-repo.ts
@@ -3,6 +3,14 @@
 
 import type { InsertParentMessageInput, ParentMessage } from '../types';
 
+export async function insertForRestore(
+	input: Omit<ParentMessage, 'id'>,
+	_tenantId: string,
+): Promise<ParentMessage> {
+	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
+	return { ...input, id: 0 };
+}
+
 export async function insertMessage(
 	input: InsertParentMessageInput,
 	_tenantId: string,

--- a/src/lib/server/db/dynamodb/message-repo.ts
+++ b/src/lib/server/db/dynamodb/message-repo.ts
@@ -54,6 +54,24 @@ function toMessage(item: Record<string, unknown>): ParentMessage {
 // insertMessage — おうえんメッセージを送信 (保存)
 // ============================================================
 
+export async function insertForRestore(
+	input: Omit<ParentMessage, 'id'>,
+	tenantId: string,
+): Promise<ParentMessage> {
+	const id = await nextId(ENTITY_NAMES.parentMessage, tenantId);
+	const message: ParentMessage = { ...input, id };
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...parentMessageKey(input.childId, id, tenantId),
+				...message,
+			},
+		}),
+	);
+	return message;
+}
+
 export async function insertMessage(
 	input: InsertParentMessageInput,
 	tenantId: string,

--- a/src/lib/server/db/interfaces/message-repo.interface.ts
+++ b/src/lib/server/db/interfaces/message-repo.interface.ts
@@ -2,6 +2,15 @@ import type { InsertParentMessageInput, ParentMessage } from '../types';
 
 export interface IMessageRepo {
 	insertMessage(input: InsertParentMessageInput, tenantId: string): Promise<ParentMessage>;
+
+	/**
+	 * #3329 backup restore 用: sentAt / shownAt を保全して親→子メッセージを復元する。
+	 * insertMessage は sentAt を schema default (now) で発番し shownAt を null 固定するため round-trip で
+	 * 送信日時・既読状態が失われる。本メソッドは export された値をそのまま書き戻す (id は新規採番、
+	 * childId は呼び出し側が解決済)。
+	 */
+	insertForRestore(input: Omit<ParentMessage, 'id'>, tenantId: string): Promise<ParentMessage>;
+
 	findMessages(childId: number, limit: number, tenantId: string): Promise<ParentMessage[]>;
 	findUnshownMessage(childId: number, tenantId: string): Promise<ParentMessage | undefined>;
 	countUnshownMessages(childId: number, tenantId: string): Promise<number>;

--- a/src/lib/server/db/sqlite/message-repo.ts
+++ b/src/lib/server/db/sqlite/message-repo.ts
@@ -20,6 +20,24 @@ export async function insertMessage(
 	return db.insert(parentMessages).values(input).returning().get();
 }
 
+/** #3329 backup restore 用: sentAt / shownAt を保全してメッセージを復元する。 */
+export async function insertForRestore(
+	input: {
+		childId: number;
+		messageType: string;
+		stampCode: string | null;
+		body: string | null;
+		icon: string;
+		sentAt: string;
+		shownAt: string | null;
+		bonusPoints: number | null;
+		rewardCategory: string | null;
+	},
+	_tenantId: string,
+) {
+	return db.insert(parentMessages).values(input).returning().get();
+}
+
 /** 子供のメッセージ履歴を取得（降順） */
 export async function findMessages(childId: number, limit: number, _tenantId: string) {
 	return db

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -19,6 +19,7 @@ import {
 	type ExportEvaluation,
 	type ExportLoginBonus,
 	type ExportOptions,
+	type ExportParentMessage,
 	type ExportPointLedger,
 	type ExportRewardRedemption,
 	type ExportSetting,
@@ -232,6 +233,7 @@ interface ChildTransactionData {
 	childChallenges: ExportChildChallenge[];
 	stampCards: ExportStampCard[];
 	certificates: ExportCertificate[];
+	parentMessages: ExportParentMessage[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 }
@@ -262,6 +264,7 @@ async function collectForChild(
 		challenges,
 		stampCardsRaw,
 		certificatesRaw,
+		parentMessagesRaw,
 		checklistTemplates,
 	] = await Promise.all([
 		// #3327 P2: per-child 活動インスタンスを backup に保持 (archive 済も含む)。
@@ -281,6 +284,8 @@ async function collectForChild(
 		getRepos().stampCard.findCardsByChild(childId, tenantId),
 		// #3329: per-child 証明書を backup に保持。
 		getRepos().certificate.findCertificates(childId, tenantId),
+		// #3329: 親→子おうえんメッセージを backup に保持。
+		getRepos().message.findMessages(childId, MAX_EXPORT_ROWS, tenantId),
 		// #3106: backup なので includeInactive=true + includeArchived=true。
 		// archive 済 template も含め、その checklistLog の silent drop を防ぐ。
 		findTemplatesByChild(childId, tenantId, true, true),
@@ -467,6 +472,20 @@ async function collectForChild(
 		metadata: c.metadata,
 	}));
 
+	// #3329: 親→子おうえんメッセージを childRef 付きで出力 (sentAt/shownAt 保全)。
+	warnIfTruncated('parentMessages', childId, parentMessagesRaw.length);
+	const parentMessagesOut: ExportParentMessage[] = parentMessagesRaw.map((m) => ({
+		childRef,
+		messageType: m.messageType,
+		stampCode: m.stampCode,
+		body: m.body,
+		icon: m.icon,
+		sentAt: m.sentAt,
+		shownAt: m.shownAt,
+		bonusPoints: m.bonusPoints,
+		rewardCategory: m.rewardCategory,
+	}));
+
 	// Checklist templates with items
 	// #3078 / #3107: templateId → (name, exportId) マップを構築し checklistLogs の参照解決に使う。
 	// exportId は export 内で安定な識別子 (`chk-${childRef}-${templateId}`) で、同名 template が
@@ -536,6 +555,7 @@ async function collectForChild(
 		childChallenges: childChallengesOut,
 		stampCards: stampCardsOut,
 		certificates: certificatesOut,
+		parentMessages: parentMessagesOut,
 		checklistTemplates: checklistTemplatesOut,
 		checklistLogs: checklistLogsOut,
 	};
@@ -576,6 +596,7 @@ async function collectTransactionData(
 		childChallenges: perChild.flatMap((p) => p.childChallenges),
 		stampCards: perChild.flatMap((p) => p.stampCards),
 		certificates: perChild.flatMap((p) => p.certificates),
+		parentMessages: perChild.flatMap((p) => p.parentMessages),
 		checklistTemplates: perChild.flatMap((p) => p.checklistTemplates),
 		checklistLogs: perChild.flatMap((p) => p.checklistLogs), // #3078
 		childAvatarItems: [],

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -71,6 +71,9 @@ export interface ImportResult {
 	/** #3329: per-child 証明書の取込件数 */
 	certificatesImported: number;
 	certificatesSkipped: number;
+	/** #3329: 親→子おうえんメッセージの取込件数 */
+	parentMessagesImported: number;
+	parentMessagesSkipped: number;
 	loginBonusesImported: number;
 	loginBonusesSkipped: number;
 	statusHistoryImported: number;
@@ -290,6 +293,8 @@ export async function importFamilyData(
 	await importStampCardsData(data, childIdMap, tenantId, result);
 	// #3329: 証明書 (がんばり/卒業証明書 授与記録) を issuedAt 保全で復元。childIdMap のみ必要。
 	await importCertificatesData(data, childIdMap, tenantId, result);
+	// #3329: 親→子おうえんメッセージを sentAt/shownAt 保全で復元。childIdMap のみ必要。
+	await importParentMessagesData(data, childIdMap, tenantId, result);
 	await importStatusHistoryData(data, childIdMap, tenantId, result);
 	// #3327/#3328: 評価 (週次評価) の取込。従来 import 関数が無く restore で全喪失していた網羅漏れを解消。
 	await importEvaluationsData(data, childIdMap, tenantId, result);
@@ -603,6 +608,47 @@ async function importCertificatesData(
 	}
 }
 
+/**
+ * 親→子おうえんメッセージ (stamp/text/reward_notice) を復元する (#3329)。
+ * childRef で取込先 child に解決し insertForRestore で sentAt / shownAt (既読) を保全して書き戻す。
+ */
+async function importParentMessagesData(
+	data: ExportData,
+	childIdMap: Map<string, number>,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	for (const m of data.data.parentMessages ?? []) {
+		const childId = childIdMap.get(m.childRef);
+		if (!childId) {
+			result.parentMessagesSkipped++;
+			continue;
+		}
+		try {
+			await getRepos().message.insertForRestore(
+				{
+					childId,
+					messageType: m.messageType,
+					stampCode: m.stampCode,
+					body: m.body,
+					icon: m.icon,
+					sentAt: m.sentAt,
+					shownAt: m.shownAt,
+					bonusPoints: m.bonusPoints,
+					rewardCategory: m.rewardCategory,
+				},
+				tenantId,
+			);
+			result.parentMessagesImported++;
+		} catch (e) {
+			result.parentMessagesSkipped++;
+			result.errors.push(
+				`メッセージ insert 失敗 (child=${m.childRef}, type=${m.messageType}): ${String(e)}`,
+			);
+		}
+	}
+}
+
 function createEmptyImportResult(): ImportResult {
 	return {
 		childrenImported: 0,
@@ -626,6 +672,8 @@ function createEmptyImportResult(): ImportResult {
 		stampEntriesSkipped: 0,
 		certificatesImported: 0,
 		certificatesSkipped: 0,
+		parentMessagesImported: 0,
+		parentMessagesSkipped: 0,
 		loginBonusesImported: 0,
 		loginBonusesSkipped: 0,
 		statusHistoryImported: 0,

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -132,7 +132,7 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 			'checklistOverride',
 			// childChallenge / childChallengeAutoWeekly は #3329 で export 実装済 → exported へ flip
 			'childCustomVoices',
-			'parentMessage',
+			// parentMessage は #3329 で export 実装済 → exported へ flip
 			'restDays',
 			// rewardRedemption / setting / stampCard / stampEntry は #3329 で export 実装済 → exported へ flip
 			'siblingCheer',

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -218,6 +218,22 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 			T,
 		);
 
+		// #3329: 親→子メッセージを 1 件 seed (既読 shownAt 明示)。round-trip 後に sentAt/shownAt が保全されること。
+		await getRepos().message.insertForRestore(
+			{
+				childId: 1,
+				messageType: 'text',
+				stampCode: null,
+				body: 'よくがんばったね',
+				icon: '💌',
+				sentAt: '2026-02-10T09:00:00Z',
+				shownAt: '2026-02-10T18:00:00Z',
+				bonusPoints: null,
+				rewardCategory: null,
+			},
+			T,
+		);
+
 		// --- export ---
 		const data = await exportFamilyData({ tenantId: T });
 		// export が全種別を捕捉していること (sanity)
@@ -240,6 +256,10 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(data.data.certificates.length, 'export:証明書').toBe(1);
 		expect(data.data.certificates[0]?.issuedAt, 'export:証明書 issuedAt').toBe(
 			'2026-02-01T00:00:00Z',
+		);
+		expect(data.data.parentMessages.length, 'export:メッセージ').toBe(1);
+		expect(data.data.parentMessages[0]?.shownAt, 'export:メッセージ shownAt').toBe(
+			'2026-02-10T18:00:00Z',
 		);
 
 		// --- replace = clear → import ---
@@ -298,6 +318,12 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(restoredCerts.length, '証明書').toBe(1);
 		expect(restoredCerts[0]?.issuedAt, '証明書 issuedAt 保全').toBe('2026-02-01T00:00:00Z');
 		expect(restoredCerts[0]?.certificateType, '証明書 type 保全').toBe('graduation');
+
+		// #3329: 親→子メッセージが sentAt/shownAt を保って復元される。
+		const restoredMsgs = await getRepos().message.findMessages(cid, 999, T);
+		expect(restoredMsgs.length, 'メッセージ').toBe(1);
+		expect(restoredMsgs[0]?.sentAt, 'メッセージ sentAt 保全').toBe('2026-02-10T09:00:00Z');
+		expect(restoredMsgs[0]?.shownAt, 'メッセージ shownAt 保全').toBe('2026-02-10T18:00:00Z');
 	});
 
 	// #3329 QM-fix (2)(a): auto:weekly チャレンジの dedup round-trip。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全ユーザー（バックアップ・移管利用者）

**解決する課題**: バックアップ ZIP を別環境へ import すると **親→子おうえんメッセージ（スタンプ/テキスト/応援通知）と既読状態が一切復元されない**（本番 t-82c17558 の喪失の一部）。parent_messages に export/import 経路が無く、replace import で全消失していた。

**期待される効果**: おうえんメッセージが送信日時(sentAt)・既読日時(shownAt)を保ったまま round-trip 復元される。

## 関連 Issue

関連: #3329 #3328（未 export source の parentMessage を実装。残 4 件は registry を起点に順次対応するため #3329 は close しない）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|----|------|---------|------------------|
| AC1 | おうえんメッセージを export に含める (per-child) | export-format / export-service | HEAD 9b82c3bc |
| AC2 | import で childRef→child 解決し sentAt/shownAt を insertForRestore で保全 | import-service importParentMessagesData | HEAD 9b82c3bc |
| AC3 | round-trip (sentAt/shownAt 既読保全) | backup-roundtrip-completeness.test.ts | HEAD 9b82c3bc |
| AC4 | insertMessage (sentAt=now/shownAt=null 固定) と分離した復元専用経路を 3 実装で機能等価提供 | repo insertForRestore (sqlite/dynamodb/demo) | HEAD 9b82c3bc |
| AC5 | registry の parentMessage を exported へ flip + ratchet 整合 | backup-entity-registry.test.ts | HEAD 9b82c3bc |
| AC6 | 型・lint・cspell・全 unit 健全 | svelte-check / biome / cspell / vitest | svelte-check 0 ERROR / biome クリーン / cspell クリーン / unit 2778 passed |

## 変更タイプ

- [x] fix: バグ修正（データ喪失）
- [x] feat: 新機能（backup 対象拡張）

## 影響範囲・変更コンポーネント

- [x] サービス層（export-service / import-service）
- [x] DB 層（message repo: interface + sqlite/dynamodb/demo に insertForRestore 追加）
- [x] ドメイン型（export-format）

**影響を受ける機能**: バックアップ export / import。UI 非変更。clear は tenant-cleanup の message.deleteByTenantId で既に削除済（certificate と異なり FK 阻害なし、変更不要）。

## テスト & 安全装置セルフチェック

- [x] **npm run pre-ready -- --pr 3329pm 全 Step PASS**
- [x] 追加・変更テスト: completeness に既読メッセージ (sentAt/shownAt 明示) round-trip 保全 assert を追加
- [x] **DynamoDB 実装変更時**: insertForRestore を sqlite/dynamodb/demo で機能等価に実装 (sentAt/shownAt を初期化しない復元専用経路)
- [x] **スキーマ変更**: なし

## スクリーンショット / ビジュアルデモ

**該当なし**: .svelte / .css 変更なし（バックエンドのデータ経路のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: insertForRestore を 3 実装で等価。rewardRedemption/certificate/challenge と同パターン
- [x] **データ整合**: sentAt/shownAt を保全（既読状態が再 import で未読に戻らない）
- [x] **YAGNI**: parentMessage 1 テーブルのみ
- [x] **clear 安全性**: message は既に tenant-cleanup で削除済のため FK 阻害なし（certificate のような追加対応は不要）

## 横展開・影響波及チェック

- [x] **clear FK 確認**: parent_messages.child_id は no-cascade だが message.deleteByTenantId が deleteTenantScopedData (children 削除前) で実行済のため FK 阻害なし。certificate のような追加修正は不要と確認
- [x] **設計書同期** (ADR-0001): registry の parentMessage 分類を exported に更新
- [x] **並行 PR overlap** (#1200): #3373/#3378/#3385/#3391/#3398 が develop へ先行マージ済。同一ファイルに追記する形で rebase 解決、develop 最新化済

## レビュー依頼事項・破壊的変更

- [x] 破壊的変更は**含まれない**（新規 optional field のみ、旧 backup の import も継続可）

**レビュー依頼**: shownAt (既読日時) を復元先で保全する方針（再 import で既読が未読に戻らない）をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **npm run pre-ready -- --pr 3329pm 全 Step PASS** をローカル確認
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] Phase 分割: 残 source 4 件は registry を起点に順次対応
- [x] UI / 認証画面変更: N/A

## QM レビュー結果

[QM 5 手順 approve body は docs/sessions/qa-session.md を参照](../docs/sessions/qa-session.md)
