### PR TITLE
docs: Aurora DSQL 移管評価 rationale（Pre-PMF では DynamoDB 継続）

### DIFF
--- a/docs/rationale/13-aurora-dsql-migration-evaluation-rationale.md
+++ b/docs/rationale/13-aurora-dsql-migration-evaluation-rationale.md
@@ -1,0 +1,76 @@
+# Aurora DSQL 移管評価（DB バックエンド一本化）設計経緯
+
+<!-- 命名規則: NN-機能名-rationale.md -->
+
+## 議論の発端
+
+- **日時**: 2026-06-28
+- **発端**: PO（ユーザー）からの技術選定依頼
+- **問題意識**: 本番（AWS）は DynamoDB、ローカル / デモは SQLite を使っており、**NoSQL とリレーショナルの「データベースポリシー差」が設計を恒常的に複雑化**させている。Amazon Aurora DSQL（PostgreSQL 互換のサーバーレス分散 SQL）の費用・性能・特性を調査し、「運用費を月 100 円（≈$0.65）以下に死守する」制約を満たしつつ DynamoDB から移管する価値があるかを、**技術選定として評価できていない**状態を解消したい（採用しない結論でも可）。
+
+## 現状の複雑さ（定量化、2026-06-28 時点のコード調査）
+
+二重（実態は demo を含む三重）バックエンド併存の維持コスト:
+
+- `src/lib/server/db/dynamodb/` = **39 ファイル / 約 11,000 行**（DB 層の約 38%、SQLite 実装 4,845 行の約 2.3 倍）。single-table 設計の PK/SK 変換・GSI 管理・`counter.ts`（AUTOINCREMENT 代替）等が重い。
+- 1 概念 = interface 1 + 実装 3（dynamodb / sqlite / demo）= **原則 4 ファイル同期**。repo は 33 個。
+- スキーマ変更 1 回で **5〜6 箇所**を手動同期（`schema.ts` / `create-tables.ts` / `global-setup.ts` / `test-db.ts` / `demo-data.ts` / `dynamodb/keys.ts`）。
+- 二重実装の同期漏れを守る**専用 CI ゲート 2 本**（`check-dynamodb-stub.mjs` / `check-dynamodb-stub-parity.mjs`）。過去に「DynamoDB 未実装のまま merge → 本番 write 消失で UI が "N 件登録" と偽装」CRITICAL（#2824 / #1009）を生んだ構造的負債の証跡。
+- Drizzle ORM は **SQLite 側のみ**。DynamoDB 側は AWS SDK 手書きで型安全・マイグレーション生成の恩恵が片側にしか効かない。
+
+## 調査結果（一次ソース: AWS 公式、bulk price list `20260507014958` / 2026-05-07）
+
+### 費用 — 月 100 円制約は完全クリア（ただし決め手にならない）
+
+- DSQL は **完全従量・scale-to-zero・固定費ゼロ**。毎月「最初の 10 万 DPU + 1 GB ストレージ」が無料枠。
+- 東京（ap-northeast-1）単価: **$0.00001/DPU（$10/100 万 DPU）・$0.40/GB-month**（us-east-1 は $0.000008/DPU・$0.33/GB で約 2 割安）。
+- 想定（1 テナント・DB 数十 MB・月数千リクエスト）: **無料枠内で実質 $0**、枠を無視しても **約 $0.02/月**。$0.65 目標を 1〜2 桁下回る。
+- **ただし DynamoDB on-demand も同規模では実質 $0**（ストレージ 25 GB 無料枠 + リクエスト課金、アイドル $0）。→ **コスト削減は移管の動機にならない**。
+
+### 特性・制約（PostgreSQL 16 互換、ただし分散由来の差分大）
+
+採用時に必ず効く制約:
+- **外部キー制約なし**（参照整合性はアプリ層。現状 DynamoDB でも同様なので影響小）
+- **OCC（楽観的同時実行制御）→ serialization error のリトライ実装が必須**
+- **コネクション 60 分上限 + IAM 一時トークン認証**（静的パスワード前提の ORM 設定と異なる）
+- **1 書込トランザクション 3,000 行 / 10 MiB 上限** — 直近実装したバックアップ/一括 import（家族データ全量復元、#3376）が抵触し得る具体的設計制約
+- DB は `postgres` 1 個固定 / UTF-8・Collation C・UTC・Repeatable Read 固定 / `CREATE INDEX ASYNC` / トリガ・PL/pgSQL・一時テーブル・TRUNCATE 非対応
+- GA は **2025-05-27**（約 1 年）。東京はシングルリージョンのみ（マルチリージョンは us-east-1/2・us-west-2）。
+
+### 移管の現実性
+
+- 一般に NoSQL→SQL 移管は「データモデル全面作り直し」が最大障壁。**本案件はその障壁が半分済んでいる** — SQLite 側に正規化済みリレーショナルスキーマ（Drizzle 46 テーブル）が既存。DSQL 移管は "ゼロからの SQL 設計" でなく "既存リレーショナル設計を Postgres に寄せる" 作業で、コールド移管より大幅に低リスク。
+- 移管で削除可能: `db/dynamodb/`（約 11,000 行）+ migration hydrate の大半 + 専用 CI ゲート 2 本 ≈ **1.2〜1.3 万行（DB 層の 40〜45%）**。スキーマ同期は 5〜6 → 2〜3 へ半減。
+
+## 検討した代替案
+
+| 案 | 概要 | 検討した理由 |
+|----|------|-----------|
+| 採用案: DynamoDB 継続（DSQL は将来候補として記録） | 現状維持。DSQL を「料金クリア・技術的有力」と評価したうえで Pre-PMF では移管しない | Pre-PMF（ADR-0010）で純リファクタの大移行リスクを取らない |
+| 案 A: 今すぐ DSQL へ移管 | AWS backend を DynamoDB→DSQL、`db/dynamodb/` を削除し relational 一本化 | 二重実装税の恒久解消 |
+| 案 B: SQLite 互換サーバーレス（Turso/libSQL）へ一本化 | ローカル SQLite とさらに直接的に一本化 | パラダイム差を最小移植で解消 |
+
+## 棄却理由
+
+- **案 A（今すぐ移管）棄却**: (1) コスト削減ゼロ（DynamoDB も実質 $0）で移管の金銭的動機がない。(2) 顧客価値を生まない純リファクタに本番データ移行 + 全 repo 再配線 + 全回帰の大リスクを Pre-PMF で負うべきでない（ADR-0010）。(3) DSQL は GA 約 1 年で枠恒久性・東京マルチリージョン非対応など未知数。(4) OCC リトライ / 60 分コネクション / 3,000 行・10 MiB トランザクション上限の受容コスト。**保守性の価値は本物だが「今」ではない**。
+- **案 B（Turso/libSQL）棄却（現時点）**: AWS（CDK / Cognito / Lambda）に閉じた構成の整合を重視する現状では、AWS ネイティブの DSQL の方が将来移管時の選択肢として素直。ただし比較軸としては残す価値があるため本書に記録。
+
+## 採用案とその理由
+
+**Pre-PMF では DynamoDB を継続**し、Aurora DSQL は「料金制約を完全に満たし、かつ二重実装税を 1.2〜1.3 万行規模で解消できる将来の有力候補」として本 rationale に記録する。判断軸はコストではなく **(a) PMF 前は機能検証が最優先、(b) 移管は顧客価値ゼロの大リファクタ、(c) SQLite 側が既にリレーショナルなので将来移管は低リスク** の 3 点。これにより「技術選定として評価していない」状態を解消し、再評価のトリガを明文化する。
+
+## 残された懸念・フォローアップ（再評価トリガ）
+
+- [ ] **PMF 到達後の保守性投資フェーズ**に入ったら再評価する
+- [ ] **DynamoDB 二重実装に起因するバグ / 同期漏れが再度 CRITICAL 化**したら前倒し評価する（#2824 / #1009 の再発）
+- [ ] **大規模スキーマ変更を伴う EPIC の着手直前**に、その工数へ移管を相乗りさせられないか検討する
+- [ ] 前倒し検討時は **Drizzle pg-core へのスキーマ移植 / OCC リトライ機構 / Lambda の IAM トークン接続 / 一括 import の 3,000 行・10 MiB 分割（#3376 整合）** を PoC 検証する
+- [ ] 比較軸として **Turso/libSQL**（SQLite 互換サーバーレス）も同時評価する
+
+## 関連
+
+- **議論源**: PO セッション（2026-06-28）
+- **影響を受ける設計書**: `docs/design/08-データベース設計書.md` / `docs/design/parallel-implementations.md` §7
+- **関連先例 rationale**: `07-usage-log-dynamodb-deferred-rationale.md`
+- **関連 ADR**: [ADR-0010 Pre-PMF スコープ判断](../decisions/0010-pre-pmf-scope-judgment.md) / [ADR-0048 Multi-Lambda Demo Deployment](../decisions/0048-multi-lambda-demo-deployment.md)
+- **一次ソース**: AWS Aurora DSQL pricing（https://aws.amazon.com/rds/aurora/dsql/pricing/） / billing-metering（https://docs.aws.amazon.com/aurora-dsql/latest/userguide/billing-metering.html） / 非対応機能・移行（https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-unsupported-features.html） / クォータ（https://docs.aws.amazon.com/aurora-dsql/latest/userguide/CHAP_quotas.html） / GA ブログ（https://aws.amazon.com/blogs/aws/amazon-aurora-dsql-is-now-generally-available/）


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者（保守性 / 技術選定の意思決定者）

**解決する課題**: 本番（AWS）= DynamoDB、ローカル/デモ = SQLite という NoSQL/リレーショナルのポリシー差が設計を恒常的に複雑化させているが、「Aurora DSQL へ移管すべきか」を技術選定として評価した記録が存在しなかった。

**期待される効果**: 一次ソース（AWS 公式）ベースの費用・特性・移管価値の評価を `docs/rationale/` に正本化し、「評価していない」状態を解消。再評価トリガを明文化して将来の判断コストを下げる。

## 関連 Issue

Issue 紐付けなし（PO セッション 2026-06-28 の技術選定評価の記録。横断ポリシーではなく機能設計経緯のため ADR ではなく `docs/rationale/` に配置）。

## AC 検証マップ (ADR-0004)

該当なし（仕様変更を伴わない設計経緯ドキュメントの追加。検証対象の AC を持たない）。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | Aurora DSQL の費用/特性/移管価値を一次ソースで評価し rationale に正本化 | `docs/rationale/13-aurora-dsql-migration-evaluation-rationale.md` が存在し、料金・制約・結論・再評価トリガを含む | PASS（ファイル追加済） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**: ドキュメントのみ（`docs/rationale/` 1 ファイル追加）。コード・スキーマ・CI への影響なし。

**影響を受ける画面・機能**: なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>`**: docs 専用のため UI/コード変更なし。biome/svelte-check/vitest 対象外。
- [x] 追加・変更したテストの概要: N/A（docs のみ）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（評価記録のみ、実装変更なし）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（UI 変更を含まない docs PR）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（docs）
- [x] **DRY**: 既存 `07-usage-log-dynamodb-deferred-rationale.md` と重複しない別観点（DB 一本化評価）
- [x] **YAGNI**: 結論は「今は不採用」で過剰投資を回避
- [x] **Security**: 秘密情報・内部 URL の記載なし（一次ソースは AWS 公開ドキュメント）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 設計書同期 (ADR-0001)（`08-データベース設計書.md` / `parallel-implementations.md` を関連として明記、内容変更は不要）
- [x] N/A — コード並行実装（demo/LP/年齢モード/ナビ）の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（docs 追加のみ）

**レビュー依頼事項・QA**: 評価の事実・数値（DSQL 料金、無料枠、制約）と結論（Pre-PMF では DynamoDB 継続）の妥当性、再評価トリガの粒度をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] docs SSOT 原則（docs/CLAUDE.md）整合: 経緯・比較・棄却理由を rationale 層に配置、設計 docs 本文に経緯を混入させていない
- [x] rationale 命名規則（`NN-機能名-rationale.md`）準拠
- [x] UI 変更なし（SS 対象外）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
