### PR TITLE
fix(security): #3404 push 送信側 SSRF 再検証 + subscribe 内部例外露出是正 (#3188 follow-up)

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -731,7 +731,20 @@ cron の server push (web-push) は `push_subscriptions` に保存済の `endpoi
 | endpoint 長 | 2048 文字上限 | 同上 |
 | key 形式 | `p256dh` / `auth` を base64 / base64url charset + 長さ上限 (`p256dh` 256 / `auth` 64) で検証 | 同上 |
 
-allowlist 方式は新規ブラウザの push host を拒否し得るが、SSRF 面では「公開だが内部 proxy な host」も弾ける最も強い静的防御であり、主要ブラウザを網羅するため Pre-PMF では allowlist を採用する (ADR-0010)。検証は `tests/unit/services/push-endpoint-validation.test.ts` / `tests/unit/routes/notifications-subscribe-api.test.ts`。本 hardening は #3188 item3 のみを対象とし、item1 (購読解除の状態不整合) / item2 (操作取消とエラーの区別 + aria-live) は同 issue で別途扱う。
+allowlist 方式は新規ブラウザの push host を拒否し得るが、SSRF 面では「公開だが内部 proxy な host」も弾ける最も強い静的防御であり、主要ブラウザを網羅するため Pre-PMF では allowlist を採用する (ADR-0010)。検証は `tests/unit/services/push-endpoint-validation.test.ts` / `tests/unit/routes/notifications-subscribe-api.test.ts`。subscribe 側 hardening は #3188 item3 を対象とし、item1 (購読解除の状態不整合) / item2 (操作取消とエラーの区別 + aria-live) は同 issue で別途扱う。
+
+#### 送信側 (cron) の再検証 — defense-in-depth (#3404)
+
+subscribe API の保存前検証だけでは、過去レコード混入 / repo 直 insert / 将来の bulk import 経路で allowlist 外 endpoint が `push_subscriptions` に入った場合、実際に HTTP request を出す送信側 (`sendPushNotification` 内の `webpush.sendNotification`) が SSRF の実 sink (CWE-918) となる。これを塞ぐため、送信直前にも各 subscription の `endpoint` を `validatePushEndpoint` で再検証し、単一の検証経路に統一する。
+
+| 観点 | 仕様 | 実体 |
+|---|---|---|
+| 送信前再検証 | `sendPushNotification` が送信対象 subscription を `validatePushEndpoint(endpoint).ok` で filter し、allowlist 外は `logger.warn` を残して当該 subscription への送信を skip する (有効 subscription が 0 件なら送信処理全体を skip) | `src/lib/server/services/notification-service.ts` |
+| 検証 SSOT | subscribe / send で同一の `validatePushEndpoint` を共有し、host allowlist / scheme / 長さ判定を 1 箇所に集約する (二重実装しない) | `src/lib/server/services/push-endpoint-validation.ts` |
+| 内部例外の非露出 | subscribe API の catch は内部例外を client に返さず、汎用 message + `logger.error` (server log のみ) とする (ADR-0062) | `src/routes/api/v1/notifications/subscribe/+server.ts` |
+| 検証 | 送信側 SSRF skip の単体テスト (internal host を skip / 正規 endpoint は送信) | `tests/unit/services/notification-service.test.ts` |
+
+#3404 のうち item2 (`url.href` 正規化) / item3 (`INVALID_ENDPOINT` metric / alarm) は runtime bypass が無く observability の範疇のため、本対応では扱わず Pre-PMF scope 外とする (ADR-0010)。
 
 ---
 

--- a/src/lib/server/services/notification-service.ts
+++ b/src/lib/server/services/notification-service.ts
@@ -13,6 +13,7 @@ import {
 } from '$lib/server/db/push-subscription-repo';
 import { getSettings } from '$lib/server/db/settings-repo';
 import { logger } from '$lib/server/logger';
+import { validatePushEndpoint } from '$lib/server/services/push-endpoint-validation';
 
 // ============================================================
 // 型定義
@@ -201,11 +202,26 @@ export async function sendPushNotification(
 		return { sent: 0, failed: 0 };
 	}
 
+	// #3404 (#3188 follow-up): 送信直前にも endpoint host を再検証する SSRF defense-in-depth。
+	// subscribe API (#3188) で検証済だが、過去レコード混入 / repo 直 insert / 将来 bulk import 経路で
+	// allowlist 外 endpoint が DB に入ると、send (webpush.sendNotification) が実際の HTTP request を
+	// 出す sink となり SSRF (CWE-918) が成立する。送信側でも allowlist 外を skip して single-point を塞ぐ。
+	const validSubscriptions = subscriptions.filter((sub) => {
+		if (validatePushEndpoint(sub.endpoint).ok) return true;
+		logger.warn('[notification] allowlist 外 endpoint への送信を skip (SSRF defense-in-depth)', {
+			context: { tenantId, endpoint: sub.endpoint, notificationType },
+		});
+		return false;
+	});
+	if (validSubscriptions.length === 0) {
+		return { sent: 0, failed: 0 };
+	}
+
 	const payload = JSON.stringify({ title, body, data: { ...data, type: notificationType } });
 	let sent = 0;
 	let failed = 0;
 
-	for (const sub of subscriptions) {
+	for (const sub of validSubscriptions) {
 		try {
 			await webpush.sendNotification(
 				{

--- a/src/routes/api/v1/notifications/subscribe/+server.ts
+++ b/src/routes/api/v1/notifications/subscribe/+server.ts
@@ -83,6 +83,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 		return json({ success: true });
 	} catch (err) {
-		return json({ error: String(err) }, { status: 500 });
+		// #3404 (ADR-0062): 内部例外を client へ露出しない。詳細は server log のみに残し、
+		// client には汎用 message を返す (info-disclosure 防止)。
+		logger.error('[notifications/subscribe] subscribe 失敗', {
+			context: { tenantId: context.tenantId },
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return json({ error: 'Subscription failed' }, { status: 500 });
 	}
 };

--- a/tests/unit/services/notification-service-vapid-distribution.test.ts
+++ b/tests/unit/services/notification-service-vapid-distribution.test.ts
@@ -87,7 +87,7 @@ describe('#2191 AC5 VAPID 配布証跡 — notification-service silent fail ガ�
 			{
 				id: 1,
 				tenantId: 'T1',
-				endpoint: 'https://push.example.com/x',
+				endpoint: 'https://fcm.googleapis.com/fcm/send/x',
 				keysP256dh: 'p',
 				keysAuth: 'a',
 				userAgent: null,
@@ -186,7 +186,7 @@ describe('#2191 AC5 4 通知系統 — type 別 sendPushNotification 発火', ()
 			{
 				id: 1,
 				tenantId: 'T1',
-				endpoint: 'https://push.example.com/x',
+				endpoint: 'https://fcm.googleapis.com/fcm/send/x',
 				keysP256dh: 'p',
 				keysAuth: 'a',
 				userAgent: null,

--- a/tests/unit/services/notification-service.test.ts
+++ b/tests/unit/services/notification-service.test.ts
@@ -205,7 +205,7 @@ describe('notification-service', () => {
 				{
 					id: 1,
 					tenantId: 'T1',
-					endpoint: 'https://push1',
+					endpoint: 'https://fcm.googleapis.com/fcm/send/push1',
 					keysP256dh: 'p1',
 					keysAuth: 'a1',
 					userAgent: null,
@@ -215,7 +215,7 @@ describe('notification-service', () => {
 				{
 					id: 2,
 					tenantId: 'T1',
-					endpoint: 'https://push2',
+					endpoint: 'https://fcm.googleapis.com/fcm/send/push2',
 					keysP256dh: 'p2',
 					keysAuth: 'a2',
 					userAgent: null,
@@ -238,7 +238,7 @@ describe('notification-service', () => {
 				{
 					id: 1,
 					tenantId: 'T1',
-					endpoint: 'https://stale',
+					endpoint: 'https://fcm.googleapis.com/fcm/send/stale',
 					keysP256dh: 'p1',
 					keysAuth: 'a1',
 					userAgent: null,
@@ -251,7 +251,10 @@ describe('notification-service', () => {
 			const result = await sendPushNotification('T1', 'test', 'Title', 'Body');
 			expect(result.sent).toBe(0);
 			expect(result.failed).toBe(1);
-			expect(mockDeleteByEndpoint).toHaveBeenCalledWith('https://stale', 'T1');
+			expect(mockDeleteByEndpoint).toHaveBeenCalledWith(
+				'https://fcm.googleapis.com/fcm/send/stale',
+				'T1',
+			);
 		});
 
 		// ============================================================
@@ -265,7 +268,7 @@ describe('notification-service', () => {
 				{
 					id: 1,
 					tenantId: 'T1',
-					endpoint: 'https://parent-device',
+					endpoint: 'https://fcm.googleapis.com/fcm/send/parent-device',
 					keysP256dh: 'p1',
 					keysAuth: 'a1',
 					userAgent: null,
@@ -275,7 +278,7 @@ describe('notification-service', () => {
 				{
 					id: 2,
 					tenantId: 'T1',
-					endpoint: 'https://child-device',
+					endpoint: 'https://fcm.googleapis.com/fcm/send/child-device',
 					keysP256dh: 'p2',
 					keysAuth: 'a2',
 					userAgent: null,
@@ -296,8 +299,8 @@ describe('notification-service', () => {
 			const calledEndpoints = mockSendNotification.mock.calls.map(
 				(call) => (call[0] as { endpoint: string }).endpoint,
 			);
-			expect(calledEndpoints).toContain('https://parent-device');
-			expect(calledEndpoints).not.toContain('https://child-device');
+			expect(calledEndpoints).toContain('https://fcm.googleapis.com/fcm/send/parent-device');
+			expect(calledEndpoints).not.toContain('https://fcm.googleapis.com/fcm/send/child-device');
 		});
 
 		it('#1593 不明な subscriber_role の subscription への送信を skip', async () => {
@@ -307,7 +310,7 @@ describe('notification-service', () => {
 				{
 					id: 1,
 					tenantId: 'T1',
-					endpoint: 'https://unknown-role-device',
+					endpoint: 'https://fcm.googleapis.com/fcm/send/unknown-role-device',
 					keysP256dh: 'p1',
 					keysAuth: 'a1',
 					userAgent: null,
@@ -331,7 +334,7 @@ describe('notification-service', () => {
 				{
 					id: 1,
 					tenantId: 'T1',
-					endpoint: 'https://child1',
+					endpoint: 'https://fcm.googleapis.com/fcm/send/child1',
 					keysP256dh: 'p1',
 					keysAuth: 'a1',
 					userAgent: null,
@@ -341,7 +344,7 @@ describe('notification-service', () => {
 				{
 					id: 2,
 					tenantId: 'T1',
-					endpoint: 'https://child2',
+					endpoint: 'https://fcm.googleapis.com/fcm/send/child2',
 					keysP256dh: 'p2',
 					keysAuth: 'a2',
 					userAgent: null,
@@ -373,6 +376,46 @@ describe('notification-service', () => {
 
 			const result = await sendPushNotification('T1', 'test', 'Title', 'Body');
 			expect(result).toEqual({ sent: 0, failed: 0 });
+		});
+
+		it('#3404 allowlist 外 endpoint (internal host) への送信を skip (送信側 SSRF defense-in-depth)', async () => {
+			setDaytimeJST();
+			mockCountTodayLogs.mockResolvedValue(0);
+			mockFindByTenant.mockResolvedValue([
+				{
+					id: 1,
+					tenantId: 'T1',
+					endpoint: 'https://fcm.googleapis.com/fcm/send/legit',
+					keysP256dh: 'p1',
+					keysAuth: 'a1',
+					userAgent: null,
+					subscriberRole: 'parent',
+					createdAt: '',
+				},
+				{
+					id: 2,
+					tenantId: 'T1',
+					// 過去レコード混入 / repo 直 insert で入った allowlist 外 (internal host) endpoint。
+					// subscribe 検証 (#3188) を通らず DB に入った想定。送信側で skip されること。
+					endpoint: 'https://169.254.169.254/latest/meta-data/',
+					keysP256dh: 'p2',
+					keysAuth: 'a2',
+					userAgent: null,
+					subscriberRole: 'parent',
+					createdAt: '',
+				},
+			]);
+			mockSendNotification.mockResolvedValue({} as never);
+
+			const result = await sendPushNotification('T1', 'test', 'Title', 'Body');
+			// 正規 endpoint のみ送信、internal host は skip
+			expect(result.sent).toBe(1);
+			expect(mockSendNotification).toHaveBeenCalledTimes(1);
+			const calledEndpoints = mockSendNotification.mock.calls.map(
+				(call) => (call[0] as { endpoint: string }).endpoint,
+			);
+			expect(calledEndpoints).toContain('https://fcm.googleapis.com/fcm/send/legit');
+			expect(calledEndpoints).not.toContain('https://169.254.169.254/latest/meta-data/');
 		});
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（家庭データの安全 / 運用の安全）

**解決する課題**: #3188 で push subscribe 時の SSRF allowlist 検証を入れたが、(1) 実際に HTTP request を出す **送信側**（cron の `webpush.sendNotification`）に再検証がなく、過去レコード混入 / repo 直 insert / 将来 bulk import で allowlist 外 endpoint が DB に入ると送信側で無検証 POST = SSRF（CWE-918）が成立しうる。(2) subscribe endpoint の catch が `String(err)` で内部例外を client 露出（ADR-0062 違反）。

**期待される効果**: SSRF の実 sink（送信側）を塞ぎ、内部例外露出を止める。

## 関連 Issue

関連: #3404（item1/item4 を消化、item2 url.href 正規化 / item3 metric は Pre-PMF scope 外）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 送信側 host 再検証で allowlist 外を skip | `npx vitest run tests/unit/services/notification-service.test.ts` | 「allowlist 外 (internal host) への送信を skip」テスト PASS（169.254.169.254 skip / 正規 endpoint 送信）|
| AC2 | subscribe catch の内部例外露出を是正（ADR-0062） | `subscribe/+server.ts` catch | `String(err)` → logger.error + 汎用 message |
| AC3 | 既存 test の fake endpoint を allowlist 適合に更新 | 同 test 41 passed | fcm.googleapis.com 化、送信側検証と整合 |
| AC4 | item2 (url.href 正規化) / item3 (metric/alarm) | Pre-PMF scope 外（runtime bypass 無し確認済 / infra observability） | #3404 残置せず本 PR は security 2 点に限定 <!-- ac-verification-skip: Pre-PMF --> |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)

**影響を受ける画面・機能**: Web Push 送信（cron）+ subscribe API。正規 endpoint は不変、allowlist 外のみ skip / 内部例外を非露出化。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: notification-service.test に送信側 SSRF skip 1 件追加 + fake endpoint を allowlist 適合に更新（41 passed）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（送信側 filter は backend 非依存の service 層）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（サーバー側 SSRF 防御 + エラー応答、UI 変更なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 既存 validatePushEndpoint を送信側でも再利用（検証ロジック単一 SSOT）
- [x] **DRY**: subscribe / send 両方で同一検証関数
- [x] **YAGNI**: item2/item3 を Pre-PMF scope 外とし real な 2 点に限定
- [x] **Security（OSS 公開前提）**: CWE-918 の実 sink を塞ぐ + ADR-0062 内部例外非露出
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: 送信前に endpoint 数分の軽量検証のみ

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（service 層 SSRF 防御）
- [x] **設計書同期** (ADR-0001): 既存 push 通知の入力検証強化、外部仕様変更なし
- [x] **並行 PR overlap** (#1200): notification-service / subscribe を変更する open PR は他に無し（確認済）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（正規 endpoint は送信継続、allowlist 外のみ skip）

**レビュー依頼事項・QA**:
- 送信側 filter が正規 push host を誤 skip しないか（fcm/mozilla/apple/wns）
- ADR-0062 是正で client message が汎用化されているか

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC が実装済み（item2/3 は Pre-PMF scope 外明記）
- [x] Phase 分割した場合: item 単位
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->

