### PR TITLE
fix: #3388 Discord allowed_mentions 構造防御 + email ZWSP 破損回帰の是正 (#3211 follow-up)

### DIFF
--- a/src/lib/server/services/discord-notify-service.ts
+++ b/src/lib/server/services/discord-notify-service.ts
@@ -43,7 +43,7 @@ function getWebhookUrl(channel: DiscordChannel): string | undefined {
  * - `<@123>` / `<@!123>` / `<@&123>` (user/role) / `<#123>` (channel) mention は `<` 直後に同様
  *
  * 文字は削除せず可視内容は保持する。email 等の正当な `@here`/`@everyone` 部分文字列を含む値
- * (`foo@here.com`) には適用しない (ZWSP 混入でコピペが壊れるため、#3388)。
+ * (`foo@here.com`) には適用しない (zero-width space 混入でコピペが壊れるため、#3388)。
  */
 export function sanitizeDiscordText(text: string): string {
 	return text.replace(/@(everyone|here)/gi, '@​$1').replace(/<(@!?&?|#)(\d+)>/g, '<​$1$2>');
@@ -249,8 +249,8 @@ export async function notifyInquiry(
 	};
 
 	// #3388: ping の構造的無効化は notifyDiscord の allowed_mentions:{parse:[]} が担う (単一点防御)。
-	// 本文 (text、childAge を含む自由記述) は表示上のノイズ低減と二重防御で ZWSP 中和を継続する。
-	// email / replyEmail は ZWSP 中和しない: `foo@here.com` 等 mention 語を含む正当アドレスが破損し
+	// 本文 (text、childAge を含む自由記述) は表示上のノイズ低減と二重防御で zero-width space 中和を継続する。
+	// email / replyEmail は zero-width space 中和しない: `foo@here.com` 等 mention 語を含む正当アドレスが破損し
 	// コピペ返信が壊れるため (#3211 回帰)。ping は allowed_mentions で既に無効化済で中和不要。
 	await notifyDiscord('inquiry', {
 		title: `📬 ${categoryLabel[category] ?? category}${inquiryId ? ` (${inquiryId})` : ''}`,

--- a/src/lib/server/services/discord-notify-service.ts
+++ b/src/lib/server/services/discord-notify-service.ts
@@ -34,15 +34,16 @@ function getWebhookUrl(channel: DiscordChannel): string | undefined {
 /**
  * #3211: ユーザー自由記述を Discord embed に載せる前の sanitization。
  *
- * Discord は embed の description / field value 内では @everyone / @here / role mention を
- * ping 発火させない (ping は webhook の top-level `content` のみ) が、将来 content 化された
- * ときの誤爆と、運用画面での視認ノイズを防ぐため defense-in-depth で mention 構文を中和する。
- * お子さまの年齢など PII を含む自由記述 (#3211 item1) が webhook JSON に素通りするのを抑える。
+ * ping の構造的無効化は notifyDiscord の `allowed_mentions:{parse:[]}` (Discord 公式機構、#3388) が
+ * 担う。本関数は **mention 構文の視認ノイズ低減 + 二重防御** のための補助的中和であり、
+ * 自由記述本文 (text) にのみ適用する。PII (childAge 等) は本関数では redaction されない
+ * (平文のまま送信される)。実 PII redaction/retention は別途 #3211 item1b の領域。
  *
  * - `@everyone` / `@here` は `@` 直後に zero-width space (U+200B) を挿入して mention 文字列を壊す
  * - `<@123>` / `<@!123>` / `<@&123>` (user/role) / `<#123>` (channel) mention は `<` 直後に同様
  *
- * 文字は削除せず可視内容は保持する (運用者が原文を読めるよう、無害化のみ行う)。
+ * 文字は削除せず可視内容は保持する。email 等の正当な `@here`/`@everyone` 部分文字列を含む値
+ * (`foo@here.com`) には適用しない (ZWSP 混入でコピペが壊れるため、#3388)。
  */
 export function sanitizeDiscordText(text: string): string {
 	return text.replace(/@(everyone|here)/gi, '@​$1').replace(/<(@!?&?|#)(\d+)>/g, '<​$1$2>');
@@ -59,6 +60,10 @@ export async function notifyDiscord(channel: DiscordChannel, embed: DiscordEmbed
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({
 				embeds: [{ ...embed, timestamp: embed.timestamp ?? new Date().toISOString() }],
+				// #3388: allowed_mentions parse:[] で全 channel/field の @everyone/@here/role/user
+				// mention の ping を Discord 公式機構で構造的に無効化する (単一点防御)。これにより
+				// embed 内のユーザー自由記述が ping を発火させない。表示はそのまま (無害)、ping のみ抑止。
+				allowed_mentions: { parse: [] },
 			}),
 		});
 
@@ -243,8 +248,10 @@ export async function notifyInquiry(
 		other: 'その他',
 	};
 
-	// #3211: ユーザー自由記述 (text=本文、childAge を含む / replyEmail / email) は
-	// mention 構文を中和してから embed に載せる (PII 自由記述の webhook 素通り抑止 + 誤 ping 防止)。
+	// #3388: ping の構造的無効化は notifyDiscord の allowed_mentions:{parse:[]} が担う (単一点防御)。
+	// 本文 (text、childAge を含む自由記述) は表示上のノイズ低減と二重防御で ZWSP 中和を継続する。
+	// email / replyEmail は ZWSP 中和しない: `foo@here.com` 等 mention 語を含む正当アドレスが破損し
+	// コピペ返信が壊れるため (#3211 回帰)。ping は allowed_mentions で既に無効化済で中和不要。
 	await notifyDiscord('inquiry', {
 		title: `📬 ${categoryLabel[category] ?? category}${inquiryId ? ` (${inquiryId})` : ''}`,
 		description: sanitizeDiscordText(text.slice(0, 2000)),
@@ -252,10 +259,10 @@ export async function notifyInquiry(
 		fields: [
 			...(inquiryId ? [{ name: '受付番号', value: inquiryId, inline: true }] : []),
 			{ name: 'テナント', value: tenantId, inline: true },
-			{ name: '送信者', value: sanitizeDiscordText(email), inline: true },
+			{ name: '送信者', value: email, inline: true },
 			{
 				name: '返信先',
-				value: replyEmail ? sanitizeDiscordText(replyEmail) : 'なし',
+				value: replyEmail || 'なし',
 				inline: true,
 			},
 		],

--- a/tests/unit/services/discord-notify-service.test.ts
+++ b/tests/unit/services/discord-notify-service.test.ts
@@ -231,13 +231,13 @@ describe('discord-notify-service', () => {
 			expect(desc).toContain('見てください');
 		});
 
-		it('#3388: email/返信先は ZWSP 中和せず原文のまま (foo@here.com 破損回帰の防止)', async () => {
+		it('#3388: email/返信先は zero-width space 中和せず原文のまま (foo@here.com 破損回帰の防止)', async () => {
 			await notifyInquiry('tenant-1', 'other', '本文', 'parent@here.com', 'reply@everyone.org');
 			const body = getLastBody();
 			const fields = body.embeds[0].fields as Array<{ name: string; value: string }>;
 			const sender = fields.find((f) => f.name === '送信者')?.value;
 			const reply = fields.find((f) => f.name === '返信先')?.value;
-			// ZWSP が混入せず原文一致 (コピペ返信が壊れない)。ping は allowed_mentions で無効化済。
+			// zero-width space が混入せず原文一致 (コピペ返信が壊れない)。ping は allowed_mentions で無効化済。
 			expect(sender).toBe('parent@here.com');
 			expect(reply).toBe('reply@everyone.org');
 		});

--- a/tests/unit/services/discord-notify-service.test.ts
+++ b/tests/unit/services/discord-notify-service.test.ts
@@ -82,6 +82,12 @@ describe('discord-notify-service', () => {
 			expect(body.embeds[0].timestamp).toBeDefined();
 		});
 
+		it('#3388: 全 payload に allowed_mentions:{parse:[]} を含み ping を構造的に無効化する', async () => {
+			await notifyDiscord('inquiry', { title: 'mention テスト', color: 0 });
+			const body = getLastBody();
+			expect(body.allowed_mentions).toEqual({ parse: [] });
+		});
+
 		it('inquiry チャネルは FEEDBACK_DISCORD_WEBHOOK_URL にフォールバックする', async () => {
 			await notifyDiscord('inquiry', {
 				title: '問い合わせテスト',
@@ -223,6 +229,17 @@ describe('discord-notify-service', () => {
 			expect(desc).not.toMatch(/<@&999>/);
 			expect(desc).toContain('everyone'); // zero-width space 挿入で文字自体は保持
 			expect(desc).toContain('見てください');
+		});
+
+		it('#3388: email/返信先は ZWSP 中和せず原文のまま (foo@here.com 破損回帰の防止)', async () => {
+			await notifyInquiry('tenant-1', 'other', '本文', 'parent@here.com', 'reply@everyone.org');
+			const body = getLastBody();
+			const fields = body.embeds[0].fields as Array<{ name: string; value: string }>;
+			const sender = fields.find((f) => f.name === '送信者')?.value;
+			const reply = fields.find((f) => f.name === '返信先')?.value;
+			// ZWSP が混入せず原文一致 (コピペ返信が壊れない)。ping は allowed_mentions で無効化済。
+			expect(sender).toBe('parent@here.com');
+			expect(reply).toBe('reply@everyone.org');
 		});
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（Discord 通知の受け手）+ 問い合わせする保護者

**解決する課題**: #3211 で per-field の ZWSP 中和を入れたが、(1) 新規 free-text フィールド追加時に sanitizer 呼び忘れ余地がある fragile な防御、(2) email/replyEmail にも ZWSP が混入し `foo@here.com` 等の正当アドレスが破損しコピペ返信が壊れる回帰、があった。

**期待される効果**: Discord 公式の `allowed_mentions:{parse:[]}` で全 channel/field の ping を構造的に無効化（単一点防御）し、email 破損回帰を解消する。

## 関連 Issue

closes #3388

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | allowed_mentions:{parse:[]} で ping 構造無効化（item1） | `npx vitest run tests/unit/services/discord-notify-service.test.ts` | 「全 payload に allowed_mentions:{parse:[]}」テスト PASS。notifyIncident 含む全 channel 自動カバー（item2） |
| AC2 | email/replyEmail の ZWSP 破損回帰是正（item3） | 同 test | 「email/返信先は原文のまま」テスト PASS（parent@here.com 非破損）|
| AC3 | docstring の PII over-claim 是正（item4） | sanitizeDiscordText docstring | 「mention 中和のみ、PII redaction は #3211 item1b」に是正 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`)

**影響を受ける画面・機能**: 運用者向け Discord 通知（全 channel）。ping 無効化 + email 原文化。ユーザー向け UI 非影響。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: allowed_mentions assertion + email 非破損回帰テスト（18 passed）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（サーバー側 Discord 通知、UI 変更なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: ping 防御を notifyDiscord 単一点に集約（per-field 依存を解消）
- [x] **DRY**: allowed_mentions 1 箇所で全 channel/field カバー
- [x] **YAGNI**: 本文 ZWSP は二重防御で残し、email は中和対象から外す最小変更
- [x] **Security（OSS 公開前提）**: ping 無効化を Discord 公式機構で構造化（fragile regex 依存を低減）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（運用者向け通知）
- [x] **設計書同期** (ADR-0001): 既存通知の防御強化、外部仕様変更なし
- [x] **並行 PR overlap** (#1200): discord-notify-service を変更する open PR は他に無し（#3404 は別 push 領域で merge 済方向、本 PR は discord のみ）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（ping 無効化 + email 原文化、表示は改善方向）

**レビュー依頼事項・QA**:
- allowed_mentions:{parse:[]} が全 notify* 関数の payload に乗るか
- email 原文化で ping リスクが残らないか（allowed_mentions が担保）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->
