### PR TITLE
feat: #3329 きょうだい間おうえんスタンプの backup round-trip 実装

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -323,6 +323,18 @@ export interface ExportParentMessage {
 	rewardCategory: string | null;
 }
 
+/**
+ * #3329: きょうだい間おうえんスタンプ (tenant-scoped、from/to 2 child を参照)。sentAt/shownAt (既読) を
+ * 保全して round-trip 復元する (id/childId は import 環境で振り直すため fromChildRef/toChildRef で再結合)。
+ */
+export interface ExportSiblingCheer {
+	fromChildRef: string;
+	toChildRef: string;
+	stampCode: string;
+	sentAt: string;
+	shownAt: string | null;
+}
+
 export interface ExportChecklistTemplate {
 	childRef: string;
 	name: string;
@@ -403,6 +415,8 @@ export interface ExportTransactionData {
 	certificates: ExportCertificate[];
 	/** #3329: 親→子おうえんメッセージ (sentAt/shownAt 保全) */
 	parentMessages: ExportParentMessage[];
+	/** #3329: きょうだい間おうえんスタンプ (tenant-scoped、from/to 2 child、sentAt/shownAt 保全) */
+	siblingCheers: ExportSiblingCheer[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 	childAvatarItems: never[];

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -174,8 +174,9 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	siblingCheer: {
 		classification: 'source',
 		schemaTable: 'siblingCheers',
-		backupStatus: 'not-yet-exported',
-		reason: '兄弟応援。export 未対応 (#3329)',
+		backupStatus: 'exported',
+		reason:
+			'きょうだい間おうえんスタンプ。export/import 実装済 (#3329、from/to 2 child を childRef で再結合・sentAt/shownAt 保全)。clear は tenant-cleanup の siblingCheer.deleteByTenantId + child cascade で削除済',
 	},
 	activityPref: {
 		classification: 'source',

--- a/src/lib/server/db/demo/sibling-cheer-repo.ts
+++ b/src/lib/server/db/demo/sibling-cheer-repo.ts
@@ -20,6 +20,18 @@ export async function insertCheer(
 	};
 }
 
+export async function findAllByTenant(tenantId: string): Promise<SiblingCheer[]> {
+	return DEMO_SIBLING_CHEERS.filter((c) => c.tenantId === tenantId).slice();
+}
+
+export async function insertForRestore(
+	input: Omit<SiblingCheer, 'id' | 'tenantId'>,
+	tenantId: string,
+): Promise<SiblingCheer> {
+	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
+	return { ...input, id: 0, tenantId };
+}
+
 export async function findUnshownCheers(
 	toChildId: number,
 	_tenantId: string,

--- a/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
+++ b/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
@@ -80,6 +80,53 @@ export async function insertCheer(
 }
 
 // ============================================================
+// findAllByTenant / insertForRestore — backup export/restore 用 (#3329)
+// ============================================================
+
+export async function findAllByTenant(tenantId: string): Promise<SiblingCheer[]> {
+	const doc = getDocClient();
+	const items: Record<string, unknown>[] = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: 'begins_with(PK, :tenantPrefix) AND begins_with(SK, :skPrefix)',
+				ExpressionAttributeValues: {
+					':tenantPrefix': tenantPK('CHILD#', tenantId),
+					':skPrefix': PREFIX,
+				},
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of result.Items ?? []) items.push(item);
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	const cheers = items.map(toCheer);
+	cheers.sort((a, b) => a.sentAt.localeCompare(b.sentAt));
+	return cheers;
+}
+
+export async function insertForRestore(
+	input: Omit<SiblingCheer, 'id' | 'tenantId'>,
+	tenantId: string,
+): Promise<SiblingCheer> {
+	const id = await nextId(ENTITY_NAMES.siblingCheer, tenantId);
+	const cheer: SiblingCheer = { ...input, id, tenantId };
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				// 受信 child partition に配置 (toChildId 軸、insertCheer と同じ)。
+				...siblingCheerKey(input.toChildId, id, tenantId),
+				...cheer,
+			},
+		}),
+	);
+	return cheer;
+}
+
+// ============================================================
 // findUnshownCheers — 子供宛の未表示おうえんを取得
 // ============================================================
 

--- a/src/lib/server/db/interfaces/sibling-cheer-repo.interface.ts
+++ b/src/lib/server/db/interfaces/sibling-cheer-repo.interface.ts
@@ -2,6 +2,21 @@ import type { InsertSiblingCheerInput, SiblingCheer } from '../types';
 
 export interface ISiblingCheerRepo {
 	insertCheer(input: InsertSiblingCheerInput, tenantId: string): Promise<SiblingCheer>;
+
+	/** #3329 backup: テナントの全おうえんスタンプ (export 用)。 */
+	findAllByTenant(tenantId: string): Promise<SiblingCheer[]>;
+
+	/**
+	 * #3329 backup restore 用: sentAt / shownAt を保全して復元する。
+	 * insertCheer は sentAt を schema default (now) で発番し shownAt を null 固定するため round-trip で
+	 * 送信日時・既読状態が失われる。本メソッドは export された値をそのまま書き戻す (id は新規採番、
+	 * from/to childId は呼び出し側が解決済)。
+	 */
+	insertForRestore(
+		input: Omit<SiblingCheer, 'id' | 'tenantId'>,
+		tenantId: string,
+	): Promise<SiblingCheer>;
+
 	findUnshownCheers(toChildId: number, tenantId: string): Promise<SiblingCheer[]>;
 	markShown(cheerIds: number[], tenantId: string): Promise<void>;
 	countTodayCheersFrom(fromChildId: number, tenantId: string): Promise<number>;

--- a/src/lib/server/db/sqlite/sibling-cheer-repo.ts
+++ b/src/lib/server/db/sqlite/sibling-cheer-repo.ts
@@ -23,6 +23,30 @@ export async function insertCheer(
 	return result;
 }
 
+/** #3329 backup: テナントの全おうえんスタンプ (from/to/sentAt/shownAt)。 */
+export async function findAllByTenant(_tenantId: string): Promise<SiblingCheer[]> {
+	return db.select().from(siblingCheers).orderBy(siblingCheers.sentAt).all();
+}
+
+/** #3329 backup restore 用: sentAt / shownAt を保全して復元する (from/to childId は呼び出し側が解決済)。 */
+export async function insertForRestore(
+	input: Omit<SiblingCheer, 'id' | 'tenantId'>,
+	tenantId: string,
+): Promise<SiblingCheer> {
+	return db
+		.insert(siblingCheers)
+		.values({
+			fromChildId: input.fromChildId,
+			toChildId: input.toChildId,
+			stampCode: input.stampCode,
+			tenantId,
+			sentAt: input.sentAt,
+			shownAt: input.shownAt,
+		})
+		.returning()
+		.get();
+}
+
 export async function findUnshownCheers(
 	toChildId: number,
 	_tenantId: string,

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -23,6 +23,7 @@ import {
 	type ExportPointLedger,
 	type ExportRewardRedemption,
 	type ExportSetting,
+	type ExportSiblingCheer,
 	type ExportSpecialReward,
 	type ExportStampCard,
 	type ExportStatus,
@@ -581,6 +582,23 @@ async function collectTransactionData(
 		.sort()
 		.map((key) => ({ key, value: settingsMap[key] as string }));
 
+	// #3329: きょうだい間おうえんスタンプ (tenant-scoped、from/to 2 child)。childExportIdMap で
+	// 両 childId を childRef に解決し、どちらかが export 対象外なら skip する (childRef 解決不能を防ぐ)。
+	const siblingCheersRaw = await getRepos().siblingCheer.findAllByTenant(tenantId);
+	const siblingCheersOut: ExportSiblingCheer[] = [];
+	for (const c of siblingCheersRaw) {
+		const fromRef = childExportIdMap.get(c.fromChildId);
+		const toRef = childExportIdMap.get(c.toChildId);
+		if (!fromRef || !toRef) continue;
+		siblingCheersOut.push({
+			fromChildRef: fromRef,
+			toChildRef: toRef,
+			stampCode: c.stampCode,
+			sentAt: c.sentAt,
+			shownAt: c.shownAt,
+		});
+	}
+
 	return {
 		childActivities: perChild.flatMap((p) => p.childActivities),
 		activityLogs: perChild.flatMap((p) => p.activityLogs),
@@ -602,5 +620,6 @@ async function collectTransactionData(
 		childAvatarItems: [],
 		dailyMissions: [], // Phase 2: エフェメラルデータ対応後に対応
 		settings: settingsOut, // #3329
+		siblingCheers: siblingCheersOut, // #3329
 	};
 }

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -74,6 +74,9 @@ export interface ImportResult {
 	/** #3329: 親→子おうえんメッセージの取込件数 */
 	parentMessagesImported: number;
 	parentMessagesSkipped: number;
+	/** #3329: きょうだい間おうえんスタンプの取込件数 */
+	siblingCheersImported: number;
+	siblingCheersSkipped: number;
 	loginBonusesImported: number;
 	loginBonusesSkipped: number;
 	statusHistoryImported: number;
@@ -295,6 +298,8 @@ export async function importFamilyData(
 	await importCertificatesData(data, childIdMap, tenantId, result);
 	// #3329: 親→子おうえんメッセージを sentAt/shownAt 保全で復元。childIdMap のみ必要。
 	await importParentMessagesData(data, childIdMap, tenantId, result);
+	// #3329: きょうだい間おうえんスタンプ。from/to 両 childRef を解決して復元。childIdMap のみ必要。
+	await importSiblingCheersData(data, childIdMap, tenantId, result);
 	await importStatusHistoryData(data, childIdMap, tenantId, result);
 	// #3327/#3328: 評価 (週次評価) の取込。従来 import 関数が無く restore で全喪失していた網羅漏れを解消。
 	await importEvaluationsData(data, childIdMap, tenantId, result);
@@ -649,6 +654,45 @@ async function importParentMessagesData(
 	}
 }
 
+/**
+ * きょうだい間おうえんスタンプを復元する (#3329)。
+ * from/to 両 childRef を取込先 child に解決し、insertForRestore で sentAt/shownAt (既読) を保全する。
+ * どちらかの child が解決できない行は skip (FK NOT NULL を満たせないため)。
+ */
+async function importSiblingCheersData(
+	data: ExportData,
+	childIdMap: Map<string, number>,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	for (const c of data.data.siblingCheers ?? []) {
+		const fromChildId = childIdMap.get(c.fromChildRef);
+		const toChildId = childIdMap.get(c.toChildRef);
+		if (!fromChildId || !toChildId) {
+			result.siblingCheersSkipped++;
+			continue;
+		}
+		try {
+			await getRepos().siblingCheer.insertForRestore(
+				{
+					fromChildId,
+					toChildId,
+					stampCode: c.stampCode,
+					sentAt: c.sentAt,
+					shownAt: c.shownAt,
+				},
+				tenantId,
+			);
+			result.siblingCheersImported++;
+		} catch (e) {
+			result.siblingCheersSkipped++;
+			result.errors.push(
+				`おうえんスタンプ insert 失敗 (from=${c.fromChildRef}, to=${c.toChildRef}): ${String(e)}`,
+			);
+		}
+	}
+}
+
 function createEmptyImportResult(): ImportResult {
 	return {
 		childrenImported: 0,
@@ -674,6 +718,8 @@ function createEmptyImportResult(): ImportResult {
 		certificatesSkipped: 0,
 		parentMessagesImported: 0,
 		parentMessagesSkipped: 0,
+		siblingCheersImported: 0,
+		siblingCheersSkipped: 0,
 		loginBonusesImported: 0,
 		loginBonusesSkipped: 0,
 		statusHistoryImported: 0,

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -134,8 +134,7 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 			'childCustomVoices',
 			// parentMessage は #3329 で export 実装済 → exported へ flip
 			'restDays',
-			// rewardRedemption / setting / stampCard / stampEntry は #3329 で export 実装済 → exported へ flip
-			'siblingCheer',
+			// rewardRedemption / setting / stampCard / stampEntry / siblingCheer は #3329 で export 実装済 → exported へ flip
 		]);
 	});
 

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -480,4 +480,45 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 			updatedAt: seeded?.updatedAt,
 		});
 	});
+
+	// #3329: きょうだい間おうえんスタンプ (from/to 2 child) の round-trip。tenant-scoped かつ 2 child を
+	// 参照するため専用ケースで検証する (sentAt/shownAt 保全 + from/to の childRef 再結合)。
+	it('きょうだい間おうえんスタンプが from/to 再結合 + sentAt/shownAt 保全で round-trip する', async () => {
+		testDb.insert(schema.children).values({ nickname: 'あに', age: 10, theme: 'blue' }).run(); // id=1
+		testDb.insert(schema.children).values({ nickname: 'いもうと', age: 7, theme: 'pink' }).run(); // id=2
+
+		await getRepos().siblingCheer.insertForRestore(
+			{
+				fromChildId: 1,
+				toChildId: 2,
+				stampCode: 'good-job',
+				sentAt: '2026-02-15T10:00:00Z',
+				shownAt: '2026-02-15T12:00:00Z',
+			},
+			T,
+		);
+
+		// export
+		const data = await exportFamilyData({ tenantId: T });
+		expect(data.data.siblingCheers.length, 'export:おうえん').toBe(1);
+		expect(data.data.siblingCheers[0]?.fromChildRef, 'export:from ref').toBe('child-1');
+		expect(data.data.siblingCheers[0]?.toChildRef, 'export:to ref').toBe('child-2');
+
+		// replace = clear → import
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T);
+
+		const children = testDb.select().from(schema.children).all();
+		expect(children.length, '子復元').toBe(2);
+		// 復元後 child id を nickname で引き当て (autoincrement で id がずれ得るため)
+		const brother = children.find((c) => c.nickname === 'あに')?.id as number;
+		const sister = children.find((c) => c.nickname === 'いもうと')?.id as number;
+
+		const restored = await getRepos().siblingCheer.findAllByTenant(T);
+		expect(restored.length, 'おうえん').toBe(1);
+		expect(restored[0]?.fromChildId, 'from 再結合').toBe(brother);
+		expect(restored[0]?.toChildId, 'to 再結合').toBe(sister);
+		expect(restored[0]?.sentAt, 'sentAt 保全').toBe('2026-02-15T10:00:00Z');
+		expect(restored[0]?.shownAt, 'shownAt 保全').toBe('2026-02-15T12:00:00Z');
+	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全ユーザー（バックアップ・移管利用者）

**解決する課題**: バックアップ ZIP を別環境へ import すると **きょうだい間おうえんスタンプ（from→to の応援）と既読状態が一切復元されない**（本番 t-82c17558 の喪失の一部）。sibling_cheers に export/import 経路が無く、replace import で全消失していた。

**期待される効果**: きょうだい間おうえんが送信日時・既読日時を保ち、from/to の正しいきょうだいへ再結合された状態で round-trip 復元される。

## 関連 Issue

関連: #3329 #3328（未 export source の siblingCheer を実装。残 3 件は registry を起点に順次対応するため #3329 は close しない）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|----|------|---------|------------------|
| AC1 | おうえんスタンプを export に含める (tenant-scoped、from/to 2 child) | export-format / export-service | HEAD d333c377 |
| AC2 | import で from/to 両 childRef を child に解決し sentAt/shownAt を insertForRestore で保全 | import-service importSiblingCheersData | HEAD d333c377 |
| AC3 | round-trip (2 child seed で from/to 再結合 + sentAt/shownAt 既読保全) | backup-roundtrip-completeness.test.ts 専用ケース | HEAD d333c377 |
| AC4 | insertCheer (sentAt=now/shownAt=null 固定) と分離した復元専用経路を 3 実装で機能等価提供 | repo findAllByTenant / insertForRestore (sqlite/dynamodb/demo) | HEAD d333c377 |
| AC5 | registry の siblingCheer を exported へ flip + ratchet 整合 | backup-entity-registry.test.ts | HEAD d333c377 |
| AC6 | 型・lint・cspell・全 unit 健全 | svelte-check / biome / cspell / vitest | svelte-check 0 ERROR / biome クリーン / cspell クリーン / unit 2779 passed |

## 変更タイプ

- [x] fix: バグ修正（データ喪失）
- [x] feat: 新機能（backup 対象拡張）

## 影響範囲・変更コンポーネント

- [x] サービス層（export-service / import-service）
- [x] DB 層（sibling-cheer repo: interface + sqlite/dynamodb/demo に findAllByTenant / insertForRestore 追加）
- [x] ドメイン型（export-format）

**影響を受ける機能**: バックアップ export / import。UI 非変更。clear は tenant-cleanup の siblingCheer.deleteByTenantId + child cascade で削除済（FK 阻害なし、変更不要）。

## テスト & 安全装置セルフチェック

**検証コマンド（機械検証証跡）**: `npx vitest run tests/unit/services/backup-roundtrip-completeness.test.ts` → 4 passed / `npx biome check --error-on-warnings .` → クリーン / `npx svelte-check --tsconfig ./tsconfig.json` → 0 ERROR


- [x] **npm run pre-ready -- --pr 3329sc 全 Step PASS**
- [x] 追加・変更テスト: completeness に 2 child + 既読おうえんの round-trip 専用ケースを追加
- [x] **DynamoDB 実装変更時**: findAllByTenant / insertForRestore を sqlite/dynamodb/demo で機能等価に実装
- [x] **スキーマ変更**: なし

## スクリーンショット / ビジュアルデモ

**該当なし**: .svelte / .css 変更なし（バックエンドのデータ経路のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: findAllByTenant / insertForRestore を 3 実装で等価。parentMessage/certificate と同パターン
- [x] **データ整合**: from/to の 2 child を childRef で再結合（import で id が振り直されても正しいきょうだい関係を保つ）。sentAt/shownAt を保全
- [x] **YAGNI**: siblingCheer 1 テーブルのみ
- [x] **clear 安全性**: 既に tenant-cleanup + child cascade (from/to 両 FK が cascade) で削除済のため FK 阻害なし

## 横展開・影響波及チェック

- [x] **clear FK 確認**: sibling_cheers の from/to child_id は両方 onDelete cascade + tenant-cleanup でも削除済 → FK 阻害なし。certificate のような追加修正は不要と確認
- [x] **設計書同期** (ADR-0001): registry の siblingCheer 分類を exported に更新
- [x] **並行 PR overlap** (#1200): #3373/#3378/#3385/#3391/#3398/#3409 が develop へ先行マージ済。develop 最新化済、コンフリクトなし

## レビュー依頼事項・破壊的変更

- [x] 破壊的変更は**含まれない**（新規 optional field のみ、旧 backup の import も継続可）

**レビュー依頼**: tenant-scoped export で from/to どちらかが export 対象外の child を参照する cheer を skip する方針（childRef 解決不能を防ぐ）をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **npm run pre-ready -- --pr 3329sc 全 Step PASS** をローカル確認
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] Phase 分割: 残 source 3 件は registry を起点に順次対応
- [x] UI / 認証画面変更: N/A

## QM レビュー結果

[QM 5 手順 approve body は docs/sessions/qa-session.md を参照](../docs/sessions/qa-session.md)
