### PR TITLE
chore: #3344 capture-spec の削除済 create-form step を撤去

### DIFF
--- a/scripts/capture-specs/flows/admin-challenges-per-child-pr2479.mjs
+++ b/scripts/capture-specs/flows/admin-challenges-per-child-pr2479.mjs
@@ -79,33 +79,12 @@ export default async (page, capture) => {
 	);
 	await capture('pr2479-admin-challenges-child-tab-903');
 
-	// --- 3) 作成フォーム展開: childIds 複数選択 checkbox UI ---
-	// PR-7 で導入された「対象お子さま (cooperative 設計 + 兄弟連動表示)」fieldset を確認
-	await page.goto(`${BASE_URL}/admin/challenges?screenshot=all`);
-	await page.waitForLoadState('networkidle');
-	await waitForChildTabs(page);
-	// 「＋ 新規チャレンジ」ボタンをクリック (creating = true)
-	// CHALLENGES_LABELS.createButton = '＋ 新規チャレンジ' (labels.ts L2726)
-	const createBtn = page.getByRole('button', { name: /新規チャレンジ/ }).first();
-	await createBtn.click({ timeout: 10_000 }).catch(() => {});
-	await page
-		.locator('[data-testid="admin-challenges-create-form"]')
-		.waitFor({ state: 'visible', timeout: 10_000 })
-		.catch(() => {});
-	// scroll form into view (mobile / desktop で form 全体が見えるよう)
-	await page
-		.locator('[data-testid="admin-challenges-create-form"]')
-		.scrollIntoViewIfNeeded()
-		.catch(() => {});
-	await page.evaluate(
-		() =>
-			new Promise((resolve) =>
-				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
-			),
-	);
-	await capture('pr2479-admin-challenges-create-form-with-child-checkboxes');
+	// #3344: 旧「3) 作成フォーム展開」step は撤去。チャレンジは #3195/#3231 で自動生成一本化 +
+	// 読取専用ビュー化され「＋ 新規チャレンジ」ボタン / create-form (testid
+	// `admin-challenges-create-form`) は削除済。dead な click → catch 握りつぶしで空 SS を量産する
+	// だけのため step ごと除去した (撮影対象は 兄弟連動 group の閲覧表示に限定)。
 
-	// --- 4) SiblingChallengeComparison focus: 兄弟連動 group の scroll-into-view ---
+	// --- 3) SiblingChallengeComparison focus: 兄弟連動 group の scroll-into-view ---
 	// 兄弟連動 UI 単体を強調撮影 (903/902/904 progress bar の 3 行を強調)
 	await page.goto(`${BASE_URL}/admin/challenges?screenshot=all`);
 	await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（CI/SS 生成の健全性）

**解決する課題**: チャレンジ自動生成一本化（#3195/#3231、読取専用ビュー化）で「＋ 新規チャレンジ」ボタン / create-form は撤去済だが、capture-spec flow に dead な click → catch 握りつぶしで空 SS を量産する step + 削除済 labels.ts 行を指す dangling コメントが残っていた。

**期待される効果**: 撤去済 UI を撮ろうとする無効 step を除去し、空 SS 量産・誤コメントを排除する。

## 関連 Issue

closes #3344

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | create-form 関連 step を撤去 | `scripts/capture-specs/flows/admin-challenges-per-child-pr2479.mjs` | section「3) 作成フォーム展開」を除去（閲覧専用のため） |
| AC2 | dangling コメント/誤 line 番号を除去 | 同上 | 「labels.ts L2726」等の削除済参照コメントを撤去 |
| AC3 | 既存 step を壊さない | `node --check` + `npx biome check` | syntax OK / biome clean / waitForChildTabs は他 step で継続使用 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP
- [x] chore: 雑務（capture-spec 残骸掃除）

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI（`scripts/capture-specs/`）

**影響を受ける画面・機能**: capture-spec の SS 生成 flow のみ（production code 非影響）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: N/A（dead capture step の除去。node --check + biome PASS）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（capture-spec script の dead step 除去、production UI 非変更）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（script cleanup）
- [x] **DRY**: 撤去済 UI への重複参照を除去
- [x] **YAGNI**: 任意の CHALLENGES_LABELS 全 key fitness test は scope 外（#3239 で dead label は削除済）
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: 無効 step 除去で capture flow わずかに短縮

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): capture-spec の dead step 除去、設計仕様変更なし
- [x] **並行 PR overlap** (#1200): 当該 capture-spec を変更する open PR は他に無し
- [x] N/A — その他並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（dead capture step の除去のみ）

**レビュー依頼事項・QA**:
- 撤去 step の SS（pr2479-...-create-form-...）が他で参照されていないか

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->
