### PR TITLE
test: #3352 item B stripe-checkout の return-skip を honest test.skip 化

### DIFF
--- a/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
+++ b/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
@@ -19,25 +19,27 @@ import { expect, test } from '@playwright/test';
 test.describe('#3204 月額固定 checkout + 失敗フィードバック — /admin/subscription', () => {
 	test.use({ storageState: 'playwright/.auth/free.json' });
 
-	/** Stripe 未設定環境 (plan card 非表示) では月額ボタンが出ないため skip 判定に使う */
-	async function skipIfStripeDisabled(page: import('@playwright/test').Page): Promise<boolean> {
+	/**
+	 * Stripe 未設定環境 (plan card 非表示) では月額ボタンが出ないため honest に test.skip する。
+	 * #3352: 旧実装は false を返し caller が `if (!...) return` で test.skip() を呼ばず終了 → runner が
+	 * SKIPPED でなく **PASSED** 計上し、fail-closed path 未検証を監査が「検証済」と誤認する Goodhart
+	 * hazard だった。test.skip(condition) で SKIPPED に正す (visible なら no-op で続行)。
+	 */
+	async function skipIfStripeDisabled(page: import('@playwright/test').Page): Promise<void> {
 		const monthlyCheckoutBtn = page.getByTestId('standard-plan-card');
 		const visible = await monthlyCheckoutBtn
 			.waitFor({ state: 'visible', timeout: 5_000 })
 			.then(() => true)
 			.catch(() => false);
-		if (!visible) {
-			test.info().annotations.push({
-				type: 'skip-reason',
-				description: 'Stripe 未設定環境 (stripeEnabled=false で plan card 非表示) のためスキップ',
-			});
-		}
-		return visible;
+		test.skip(
+			!visible,
+			'Stripe 未設定環境 (stripeEnabled=false で plan card 非表示) のためスキップ (#3352)',
+		);
 	}
 
 	test('年額トグルが撤去され月額固定で表示される (#2719 年額廃止と UI 整合)', async ({ page }) => {
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
-		if (!(await skipIfStripeDisabled(page))) return;
+		await skipIfStripeDisabled(page);
 
 		// 年額トグル・年額専用 UI が物理的に存在しないこと (年額選択 → INVALID_PLAN 経路の根絶)
 		await expect(page.getByRole('button', { name: /年額/ })).toHaveCount(0);
@@ -60,7 +62,7 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 		});
 
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
-		if (!(await skipIfStripeDisabled(page))) return;
+		await skipIfStripeDisabled(page);
 
 		// プレミアム選択 → 「プレミアムプランで始める」押下
 		await page.getByTestId('family-plan-card').click();
@@ -88,7 +90,7 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 		});
 
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
-		if (!(await skipIfStripeDisabled(page))) return;
+		await skipIfStripeDisabled(page);
 
 		// hydration ゲート: skipIfStripeDisabled は SSR 描画済 plan card の visible のみ待つため、
 		// interactive island の hydration 完了前に click すると onclick が発火しない。plan card 選択
@@ -138,7 +140,7 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 		});
 
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
-		if (!(await skipIfStripeDisabled(page))) return;
+		await skipIfStripeDisabled(page);
 
 		// hydration ゲート: skipIfStripeDisabled は SSR 描画済 plan card の visible のみ待つため、
 		// interactive island の hydration 完了前に click すると onclick が発火しない。plan card 選択


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（CI 信頼性 / 監査の正確性）

**解決する課題**: `stripe-checkout-monthly-yearly.spec` の `skipIfStripeDisabled` が plan card 不可視時に `false` を返し、caller が `if (!...) return` で `test.skip()` を呼ばず終了していた。runner は SKIPPED でなく **PASSED** として計上し、checkout の fail-closed path が CI で一度も assertion されていないのに監査（integration-attest / pass count）が「検証済」と誤認する Goodhart hazard だった。

**期待される効果**: 未検証を honest に SKIPPED として可視化し、false-green を解消する。

## 関連 Issue

closes #

関連: #3352（item B honest-skip を消化、item A = CI lane への test STRIPE key 供給は残置）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | return-skip を honest test.skip 化（PASSED 偽装解消） | `tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts` | helper を `test.skip(!visible, reason)` に変更、4 caller を `await skipIfStripeDisabled(page)` に統一。stripe 無効時は SKIPPED 計上 |
| AC2 | 型・lint 健全性 | `npx svelte-check` / `npx eslint <spec>` | 0 errors（playwright rule 違反なし）|
| AC3 | item A（CI E2E lane に test STRIPE key 供給で実 assertion 実行） | CI secrets 設定（admin/infra）を要す | #3352 残置 <!-- ac-verification-skip: item A は CI secrets 設定が必要、本 PR 範囲外 --> |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI（E2E spec のみ）

**影響を受ける画面・機能**: stripe-checkout E2E spec の skip 計上のみ（production code 非変更）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: skipIfStripeDisabled を honest test.skip 化（4 caller 統一）。stripe 有効環境では従来どおり実行
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（item A の test key 供給は別 PR）
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（E2E spec の skip 計上修正、UI 変更なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: skip 判定を helper 1 箇所に集約
- [x] **DRY**: 4 caller の `if (!...) return` パターンを単一 `await` に統一
- [x] **YAGNI**: item A（CI key 供給）は別 PR
- [x] **Security（OSS 公開前提）**: fail-closed path 検証の偽装を解消（監査の正確性向上）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（E2E spec）
- [x] **設計書同期** (ADR-0001): test の skip 計上修正、設計仕様変更なし
- [x] **並行 PR overlap** (#1200): 当該 spec を変更する open PR は他に無し

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（skip 計上が PASSED→SKIPPED に正されるのみ）

**レビュー依頼事項・QA**:
- stripe 有効環境（local / dummy key）で 4 test が従来どおり実行されるか
- item A（CI lane への test key 供給）を後続で進めるべきか

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC が実装済み（item A は #3352 残置を明記）
- [x] Phase 分割した場合: item 単位
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->
