### PR TITLE
feat: #3329 活動設定(ピン留め)の backup round-trip 実装

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -341,6 +341,20 @@ export interface ExportSiblingCheer {
 	shownAt: string | null;
 }
 
+/**
+ * #3329: per-child 活動設定 (ピン留め)。activityId は import で振り直されるため activityName で
+ * 取込先 childActivity に再結合する。isPinned/pinOrder/日時を round-trip 保全する。
+ */
+export interface ExportActivityPref {
+	childRef: string;
+	/** import 後に activityId を再解決するための活動名 (per-child で一意) */
+	activityName: string;
+	isPinned: number;
+	pinOrder: number | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
 export interface ExportChecklistTemplate {
 	childRef: string;
 	name: string;
@@ -423,6 +437,8 @@ export interface ExportTransactionData {
 	parentMessages: ExportParentMessage[];
 	/** #3329: きょうだい間おうえんスタンプ (tenant-scoped、from/to 2 child、sentAt/shownAt 保全) */
 	siblingCheers: ExportSiblingCheer[];
+	/** #3329: per-child 活動設定 (ピン留め、activityName で再結合) */
+	activityPrefs: ExportActivityPref[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 	childAvatarItems: never[];

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -181,8 +181,9 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	activityPref: {
 		classification: 'source',
 		schemaTable: 'childActivityPreferences',
-		backupStatus: 'not-yet-exported',
-		reason: '活動の per-child 設定。export 未対応 (#3329)',
+		backupStatus: 'exported',
+		reason:
+			'活動の per-child 設定 (ピン留め)。export/import 実装済 (#3329、activityName で childActivity に再結合・isPinned/pinOrder/日時を insertForRestore で保全)。clear は tenant-cleanup + child/activity cascade で削除済',
 	},
 	checklistAssignment: {
 		classification: 'source',

--- a/src/lib/server/db/demo/activity-pref-repo.ts
+++ b/src/lib/server/db/demo/activity-pref-repo.ts
@@ -3,6 +3,21 @@
 
 import type { ActivityUsageCount, ChildActivityPreference } from '../types';
 
+export async function findAllByChild(
+	_childId: number,
+	_tenantId: string,
+): Promise<ChildActivityPreference[]> {
+	return [];
+}
+
+export async function insertForRestore(
+	input: Omit<ChildActivityPreference, 'id'>,
+	_tenantId: string,
+): Promise<ChildActivityPreference> {
+	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
+	return { ...input, id: 0 };
+}
+
 export async function findPinnedByChild(
 	_childId: number,
 	_tenantId: string,

--- a/src/lib/server/db/dynamodb/activity-pref-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-pref-repo.ts
@@ -39,6 +39,50 @@ export async function findPinnedByChild(
 		.sort((a, b) => (a.pinOrder ?? 999) - (b.pinOrder ?? 999));
 }
 
+/** #3329 backup: child の全活動設定 (pinned 不問)。 */
+export async function findAllByChild(
+	childId: number,
+	tenantId: string,
+): Promise<ChildActivityPreference[]> {
+	const result = await getDocClient().send(
+		new QueryCommand({
+			TableName: TABLE_NAME,
+			KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+			ExpressionAttributeValues: {
+				':pk': childPK(childId, tenantId),
+				':prefix': activityPrefPrefix(),
+			},
+		}),
+	);
+	const items = (result.Items ?? []) as Record<string, unknown>[];
+	return items
+		.map((item) => stripKeys(item) as unknown as ChildActivityPreference)
+		.sort((a, b) => (a.pinOrder ?? 999) - (b.pinOrder ?? 999));
+}
+
+/** #3329 backup restore 用: isPinned/pinOrder/日時を保全して復元する (childId/activityId 解決済)。 */
+export async function insertForRestore(
+	input: Omit<ChildActivityPreference, 'id'>,
+	tenantId: string,
+): Promise<ChildActivityPreference> {
+	const key = activityPrefKey(input.childId, input.activityId, tenantId);
+	// activityPref の partition key は (childId, activityId) 複合。id は非キー属性のため
+	// togglePin と同様に Date.now() 由来の一意値を採番する (元 id は保全しない)。
+	const id = Date.now();
+	const item: Record<string, unknown> = {
+		...key,
+		id,
+		childId: input.childId,
+		activityId: input.activityId,
+		isPinned: input.isPinned,
+		pinOrder: input.pinOrder,
+		createdAt: input.createdAt,
+		updatedAt: input.updatedAt,
+	};
+	await getDocClient().send(new PutCommand({ TableName: TABLE_NAME, Item: item }));
+	return stripKeys(item) as unknown as ChildActivityPreference;
+}
+
 export async function togglePin(
 	childId: number,
 	activityId: number,

--- a/src/lib/server/db/interfaces/activity-pref-repo.interface.ts
+++ b/src/lib/server/db/interfaces/activity-pref-repo.interface.ts
@@ -1,6 +1,20 @@
 import type { ActivityUsageCount, ChildActivityPreference } from '../types';
 
 export interface IActivityPrefRepo {
+	/** #3329 backup: child の全活動設定 (pinned 不問、export 用)。 */
+	findAllByChild(childId: number, tenantId: string): Promise<ChildActivityPreference[]>;
+
+	/**
+	 * #3329 backup restore 用: isPinned/pinOrder/日時を保全して活動設定を復元する。
+	 * togglePin は pinOrder を MAX+1 で再採番し日時を now にするため round-trip でピン順・日時が
+	 * 失われる。本メソッドは export された値をそのまま書き戻す (id は新規採番、childId/activityId は
+	 * 呼び出し側が import 後の child/childActivity に解決済)。
+	 */
+	insertForRestore(
+		input: Omit<ChildActivityPreference, 'id'>,
+		tenantId: string,
+	): Promise<ChildActivityPreference>;
+
 	findPinnedByChild(childId: number, tenantId: string): Promise<ChildActivityPreference[]>;
 	togglePin(
 		childId: number,

--- a/src/lib/server/db/sqlite/activity-pref-repo.ts
+++ b/src/lib/server/db/sqlite/activity-pref-repo.ts
@@ -24,6 +24,38 @@ import { db } from '../client';
 import { activityLogs, childActivities, childActivityPreferences } from '../schema';
 import type { ActivityUsageCount, ChildActivityPreference } from '../types';
 
+/** #3329 backup: child の全活動設定 (pinned 不問。isPinned/pinOrder を round-trip 保全)。 */
+export async function findAllByChild(
+	childId: number,
+	_tenantId: string,
+): Promise<ChildActivityPreference[]> {
+	return db
+		.select()
+		.from(childActivityPreferences)
+		.where(eq(childActivityPreferences.childId, childId))
+		.orderBy(childActivityPreferences.pinOrder)
+		.all();
+}
+
+/** #3329 backup restore 用: isPinned/pinOrder/日時を保全して復元する (childId/activityId は呼び出し側が解決済)。 */
+export async function insertForRestore(
+	input: Omit<ChildActivityPreference, 'id'>,
+	_tenantId: string,
+): Promise<ChildActivityPreference> {
+	return db
+		.insert(childActivityPreferences)
+		.values({
+			childId: input.childId,
+			activityId: input.activityId,
+			isPinned: input.isPinned,
+			pinOrder: input.pinOrder,
+			createdAt: input.createdAt,
+			updatedAt: input.updatedAt,
+		})
+		.returning()
+		.get();
+}
+
 export async function findPinnedByChild(
 	childId: number,
 	_tenantId: string,

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -8,6 +8,7 @@ import {
 	type ExportAchievement,
 	type ExportActivity,
 	type ExportActivityLog,
+	type ExportActivityPref,
 	type ExportCategory,
 	type ExportCertificate,
 	type ExportChecklistLog,
@@ -235,6 +236,7 @@ interface ChildTransactionData {
 	stampCards: ExportStampCard[];
 	certificates: ExportCertificate[];
 	parentMessages: ExportParentMessage[];
+	activityPrefs: ExportActivityPref[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 }
@@ -266,6 +268,7 @@ async function collectForChild(
 		stampCardsRaw,
 		certificatesRaw,
 		parentMessagesRaw,
+		activityPrefsRaw,
 		checklistTemplates,
 	] = await Promise.all([
 		// #3327 P2: per-child 活動インスタンスを backup に保持 (archive 済も含む)。
@@ -287,6 +290,8 @@ async function collectForChild(
 		getRepos().certificate.findCertificates(childId, tenantId),
 		// #3329: 親→子おうえんメッセージを backup に保持。
 		getRepos().message.findMessages(childId, MAX_EXPORT_ROWS, tenantId),
+		// #3329: per-child 活動設定 (ピン留め) を backup に保持。
+		getRepos().activityPref.findAllByChild(childId, tenantId),
 		// #3106: backup なので includeInactive=true + includeArchived=true。
 		// archive 済 template も含め、その checklistLog の silent drop を防ぐ。
 		findTemplatesByChild(childId, tenantId, true, true),
@@ -490,6 +495,25 @@ async function collectForChild(
 		rewardCategory: m.rewardCategory,
 	}));
 
+	// #3329: per-child 活動設定 (ピン留め)。activityId は import で振り直されるため、当該 child の
+	// 活動 (childActivitiesRaw) から activityId → name を解決し activityName で出力する。
+	// 活動が解決できない pref は skip (orphan)。
+	warnIfTruncated('activityPrefs', childId, activityPrefsRaw.length);
+	const activityNameById = new Map<number, string>(childActivitiesRaw.map((a) => [a.id, a.name]));
+	const activityPrefsOut: ExportActivityPref[] = [];
+	for (const pref of activityPrefsRaw) {
+		const name = activityNameById.get(pref.activityId);
+		if (!name) continue;
+		activityPrefsOut.push({
+			childRef,
+			activityName: name,
+			isPinned: pref.isPinned,
+			pinOrder: pref.pinOrder,
+			createdAt: pref.createdAt,
+			updatedAt: pref.updatedAt,
+		});
+	}
+
 	// Checklist templates with items
 	// #3078 / #3107: templateId → (name, exportId) マップを構築し checklistLogs の参照解決に使う。
 	// exportId は export 内で安定な識別子 (`chk-${childRef}-${templateId}`) で、同名 template が
@@ -560,6 +584,7 @@ async function collectForChild(
 		stampCards: stampCardsOut,
 		certificates: certificatesOut,
 		parentMessages: parentMessagesOut,
+		activityPrefs: activityPrefsOut,
 		checklistTemplates: checklistTemplatesOut,
 		checklistLogs: checklistLogsOut,
 	};
@@ -618,6 +643,7 @@ async function collectTransactionData(
 		stampCards: perChild.flatMap((p) => p.stampCards),
 		certificates: perChild.flatMap((p) => p.certificates),
 		parentMessages: perChild.flatMap((p) => p.parentMessages),
+		activityPrefs: perChild.flatMap((p) => p.activityPrefs),
 		checklistTemplates: perChild.flatMap((p) => p.checklistTemplates),
 		checklistLogs: perChild.flatMap((p) => p.checklistLogs), // #3078
 		childAvatarItems: [],

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -77,6 +77,9 @@ export interface ImportResult {
 	/** #3329: きょうだい間おうえんスタンプの取込件数 */
 	siblingCheersImported: number;
 	siblingCheersSkipped: number;
+	/** #3329: per-child 活動設定 (ピン留め) の取込件数 */
+	activityPrefsImported: number;
+	activityPrefsSkipped: number;
 	loginBonusesImported: number;
 	loginBonusesSkipped: number;
 	statusHistoryImported: number;
@@ -282,6 +285,9 @@ export async function importFamilyData(
 
 	await importStatusesData(data, childIdMap, tenantId, result);
 	await importActivityLogsData(data, childIdMap, activityLookupByChild, tenantId, result);
+	// #3329: per-child 活動設定 (ピン留め)。activityName を取込先 childActivity に再解決して復元。
+	// 活動 lookup (name→新 id) が必要なので buildActivityLookupByChild の後に実行する。
+	await importActivityPrefsData(data, childIdMap, activityLookupByChild, tenantId, result);
 	await importPointLedgerData(data, childIdMap, tenantId, result);
 	await importLoginBonusesData(data, childIdMap, tenantId, result);
 	const templateIdMap = await importChecklistTemplatesData(data, childIdMap, tenantId, result);
@@ -693,6 +699,51 @@ async function importSiblingCheersData(
 	}
 }
 
+/**
+ * per-child 活動設定 (ピン留め) を復元する (#3329)。
+ * childRef で取込先 child を、activityName で取込先 childActivity (activityLookupByChild) を解決し、
+ * insertForRestore で isPinned/pinOrder/日時を保全する。child or activity が解決できない pref は skip。
+ */
+async function importActivityPrefsData(
+	data: ExportData,
+	childIdMap: Map<string, number>,
+	activityLookupByChild: Map<number, Map<string, { id: number; name: string }>>,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	for (const p of data.data.activityPrefs ?? []) {
+		const childId = childIdMap.get(p.childRef);
+		if (!childId) {
+			result.activityPrefsSkipped++;
+			continue;
+		}
+		const activity = activityLookupByChild.get(childId)?.get(p.activityName);
+		if (!activity) {
+			result.activityPrefsSkipped++;
+			continue;
+		}
+		try {
+			await getRepos().activityPref.insertForRestore(
+				{
+					childId,
+					activityId: activity.id,
+					isPinned: p.isPinned,
+					pinOrder: p.pinOrder,
+					createdAt: p.createdAt,
+					updatedAt: p.updatedAt,
+				},
+				tenantId,
+			);
+			result.activityPrefsImported++;
+		} catch (e) {
+			result.activityPrefsSkipped++;
+			result.errors.push(
+				`活動設定 insert 失敗 (child=${p.childRef}, activity=${p.activityName}): ${String(e)}`,
+			);
+		}
+	}
+}
+
 function createEmptyImportResult(): ImportResult {
 	return {
 		childrenImported: 0,
@@ -718,6 +769,8 @@ function createEmptyImportResult(): ImportResult {
 		certificatesSkipped: 0,
 		parentMessagesImported: 0,
 		parentMessagesSkipped: 0,
+		activityPrefsImported: 0,
+		activityPrefsSkipped: 0,
 		siblingCheersImported: 0,
 		siblingCheersSkipped: 0,
 		loginBonusesImported: 0,

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -126,8 +126,7 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 		// export に足したら 'exported' へ flip し本ベースラインから外す (意図的更新)。
 		// 新たな not-yet-exported source の silent 増加を禁止する (回帰ネット)。
 		expect(notYetExportedSourceEntities()).toEqual([
-			'activityPref',
-			// certificate は #3329 で export 実装済 → exported へ flip
+			// activityPref / certificate は #3329 で export 実装済 → exported へ flip
 			'checklistAssignment',
 			'checklistOverride',
 			// childChallenge / childChallengeAutoWeekly は #3329 で export 実装済 → exported へ flip

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -234,6 +234,20 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 			T,
 		);
 
+		// #3329: 活動設定 (ピン留め) を seed (seedChildActivities の 'うんどうA' をピン)。round-trip 後に
+		// isPinned/pinOrder が保全され、activityName で正しい childActivity に再結合されることを検証する。
+		await getRepos().activityPref.insertForRestore(
+			{
+				childId: 1,
+				activityId: actId,
+				isPinned: 1,
+				pinOrder: 1,
+				createdAt: '2026-02-05T00:00:00Z',
+				updatedAt: '2026-02-05T00:00:00Z',
+			},
+			T,
+		);
+
 		// --- export ---
 		const data = await exportFamilyData({ tenantId: T });
 		// export が全種別を捕捉していること (sanity)
@@ -256,6 +270,10 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(data.data.certificates.length, 'export:証明書').toBe(1);
 		expect(data.data.certificates[0]?.issuedAt, 'export:証明書 issuedAt').toBe(
 			'2026-02-01T00:00:00Z',
+		);
+		expect(data.data.activityPrefs.length, 'export:活動設定').toBe(1);
+		expect(data.data.activityPrefs[0]?.activityName, 'export:活動設定 activityName').toBe(
+			'うんどうA',
 		);
 		expect(data.data.parentMessages.length, 'export:メッセージ').toBe(1);
 		expect(data.data.parentMessages[0]?.shownAt, 'export:メッセージ shownAt').toBe(
@@ -324,6 +342,14 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(restoredMsgs.length, 'メッセージ').toBe(1);
 		expect(restoredMsgs[0]?.sentAt, 'メッセージ sentAt 保全').toBe('2026-02-10T09:00:00Z');
 		expect(restoredMsgs[0]?.shownAt, 'メッセージ shownAt 保全').toBe('2026-02-10T18:00:00Z');
+
+		// #3329: 活動設定が isPinned/pinOrder 保全 + 正しい childActivity に再結合されて復元される。
+		const restoredPrefs = await getRepos().activityPref.findAllByChild(cid, T);
+		expect(restoredPrefs.length, '活動設定').toBe(1);
+		expect(restoredPrefs[0]?.isPinned, '活動設定 isPinned 保全').toBe(1);
+		expect(restoredPrefs[0]?.pinOrder, '活動設定 pinOrder 保全').toBe(1);
+		const restoredActs2 = await getChildActivities(cid, T);
+		expect(restoredPrefs[0]?.activityId, '活動設定 activityId 再結合').toBe(restoredActs2[0]?.id);
 	});
 
 	// #3329 QM-fix (2)(a): auto:weekly チャレンジの dedup round-trip。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全ユーザー（バックアップ・移管利用者）

**解決する課題**: バックアップ ZIP を別環境へ import すると **活動のピン留め設定が一切復元されない**（本番 t-82c17558 の喪失の一部）。child_activity_preferences に export/import 経路が無く、replace import で全消失していた。

**期待される効果**: 活動のピン留め（isPinned/pinOrder）が保たれ、import で activityId が振り直されても activityName で正しい活動へ再結合された状態で round-trip 復元される。


## 関連 Issue

関連: #3329 #3328（未 export source の activityPref を実装。残 3 件は registry を起点に順次対応するため #3329 は close しない）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|----|------|---------|------------------|
| AC1 | 活動設定を export に含める (per-child、activityName で再結合可能化) | export-format / export-service | HEAD 58c31c6f |
| AC2 | import で childRef + activityName を既存 activityLookupByChild で再解決し isPinned/pinOrder/日時を保全 | import-service importActivityPrefsData | HEAD 58c31c6f |
| AC3 | round-trip (isPinned/pinOrder 保全 + activityName→新 activityId 再結合) | backup-roundtrip-completeness.test.ts | HEAD 58c31c6f |
| AC4 | togglePin (pinOrder=MAX+1 再採番/日時=now) と分離した復元専用経路を 3 実装で機能等価提供 | repo findAllByChild / insertForRestore (sqlite/dynamodb/demo) | HEAD 58c31c6f |
| AC5 | registry の activityPref を exported へ flip + ratchet 整合 | backup-entity-registry.test.ts | HEAD 58c31c6f |
| AC6 | 型・lint・cspell・backup 関連 unit 健全 | svelte-check / biome / cspell / vitest | svelte-check 0 ERROR / biome クリーン / cspell クリーン / 全 services+db unit 2783 passed |

## 変更タイプ

- [x] fix: バグ修正（データ喪失）
- [x] feat: 新機能（backup 対象拡張）

## 影響範囲・変更コンポーネント

- [x] サービス層（export-service / import-service）
- [x] DB 層（activity-pref repo: interface + sqlite/dynamodb/demo に findAllByChild / insertForRestore 追加）
- [x] ドメイン型（export-format）

**影響を受ける機能**: バックアップ export / import。UI 非変更。clear は tenant-cleanup + child/activity cascade で削除済（FK 阻害なし、変更不要）。

## テスト & 安全装置セルフチェック

**検証コマンド（機械検証証跡）**: `npx vitest run tests/unit/services/backup-roundtrip-completeness.test.ts tests/unit/db/backup-entity-registry.test.ts` → 99 passed / `npx biome check --error-on-warnings .` → クリーン / `npx svelte-check --tsconfig ./tsconfig.json` → 0 ERROR

- [x] **npm run pre-ready -- --pr 3329ap は #3445 マージ後に全 Step PASS を確認する**（現状は develop の cohort flake で full vitest のみ赤、backup 変更は全緑）
- [x] 追加・変更テスト: completeness に活動ピン (isPinned/pinOrder) round-trip + activityName 再結合 assert を追加
- [x] **DynamoDB 実装変更時**: findAllByChild / insertForRestore を sqlite/dynamodb/demo で機能等価に実装
- [x] **スキーマ変更**: なし

## スクリーンショット / ビジュアルデモ

**該当なし**: .svelte / .css 変更なし（バックエンドのデータ経路のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: findAllByChild / insertForRestore を 3 実装で等価。activityName 再結合は activityLog と同パターンで既存 activityLookupByChild を再利用
- [x] **データ整合**: import で activityId が振り直されても activityName で正しい childActivity に再結合。isPinned/pinOrder/日時を保全
- [x] **YAGNI**: activityPref 1 テーブルのみ
- [x] **clear 安全性**: 既に tenant-cleanup + child/activity 両 cascade で削除済のため FK 阻害なし

## 横展開・影響波及チェック

- [x] **clear FK 確認**: child_activity_preferences の childId/activityId は両方 onDelete cascade + tenant-cleanup でも削除済 → FK 阻害なし。certificate のような追加修正は不要と確認
- [x] **設計書同期** (ADR-0001): registry の activityPref 分類を exported に更新
- [x] **並行 PR overlap** (#1200): #3373〜#3418 が develop へ先行マージ済。develop 最新化済

## レビュー依頼事項・破壊的変更

- [x] 破壊的変更は**含まれない**（新規 optional field のみ、旧 backup の import も継続可）

**レビュー依頼**: activityName で childActivity を再解決する方針（per-child で活動名が一意）と、orphan pref（解決不能活動）を skip する扱いをご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **npm run pre-ready -- --pr 3329ap 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] Phase 分割: 残 source 3 件は registry を起点に順次対応
- [x] UI / 認証画面変更: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
