### PR TITLE
fix: #3422 per-child dailyLimit/nameKana/nameKanji を persist (silent drop 是正)

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -9,7 +9,10 @@ export const EXPORT_FORMAT = 'ganbari-quest-backup' as const;
 // #3358: 1.5.0 で childActivity の `isArchived` / `archivedReason` を追加 (isVisible / sortOrder は
 //   1.4.0 以前から存在)。archived 済活動が import 後に active へ復活する round-trip 取りこぼし
 //   (第10回監査 data-5) の修正。いずれも optional で後方互換 (旧 backup は非アーカイブとして復元)。
-export const EXPORT_VERSION = '1.5.0' as const;
+// #3422: 1.6.0 で childActivity の `dailyLimit` / `nameKana` / `nameKanji` を追加。create/update では
+//   persist 是正済だが backup round-trip では同 3 列が silent drop され、復元後 dailyLimit が null
+//   (= 1 日 1 回固定) に戻る取りこぼしの修正。いずれも optional で後方互換 (旧 backup は schema default)。
+export const EXPORT_VERSION = '1.6.0' as const;
 
 // ============================================================
 // #3329: backup 可能な設定キーの allowlist (default-deny セキュリティ設計、D3)
@@ -101,6 +104,12 @@ export interface ExportChildActivity {
 	// #3358: archive 状態を round-trip 保全 (optional で後方互換、旧 backup は非アーカイブ復元)
 	isArchived?: number;
 	archivedReason?: string | null;
+	// #3422: 親が設定する 1 日上限 / 読み仮名 / 漢字表記を round-trip 保全 (optional で後方互換、
+	// 旧 backup は schema default 復元)。dailyLimit semantics は null=1回 / 0=無制限 / N=N回
+	// (activity-log-service.ts §daily limit 定義)。0 を null へ落とさず保全する。
+	dailyLimit?: number | null;
+	nameKana?: string | null;
+	nameKanji?: string | null;
 }
 
 export interface ExportTitle {

--- a/src/lib/server/db/demo/child-activity-repo.ts
+++ b/src/lib/server/db/demo/child-activity-repo.ts
@@ -131,11 +131,12 @@ export async function insertActivity(
 		basePoints: input.basePoints,
 		// #3358: round-trip 復元時の表示状態 / 並び順 / アーカイブ状態を保全 (省略時 schema default)
 		isVisible: input.isVisible ?? 1,
-		dailyLimit: null,
+		// #3422: 親入力の 1 日上限 / 読み仮名 / 漢字表記を persist (旧実装は null 固定で drop していた)
+		dailyLimit: input.dailyLimit ?? null,
 		sortOrder: input.sortOrder ?? 0,
 		source: 'demo',
-		nameKana: null,
-		nameKanji: null,
+		nameKana: input.nameKana ?? null,
+		nameKanji: input.nameKanji ?? null,
 		triggerHint: input.triggerHint ?? null,
 		isMainQuest: input.isMainQuest ?? 0,
 		isArchived: input.isArchived ?? 0,

--- a/src/lib/server/db/dynamodb/child-activity-repo.ts
+++ b/src/lib/server/db/dynamodb/child-activity-repo.ts
@@ -125,11 +125,12 @@ function buildChildActivity(
 		basePoints: input.basePoints,
 		// #3358: round-trip 復元時の表示状態 / 並び順 / アーカイブ状態を保全 (省略時 schema default)
 		isVisible: input.isVisible ?? 1,
-		dailyLimit: null,
+		// #3422: 親入力の 1 日上限 / 読み仮名 / 漢字表記を persist (旧実装は null 固定で drop していた)
+		dailyLimit: input.dailyLimit ?? null,
 		sortOrder: input.sortOrder ?? 0,
 		source: 'seed',
-		nameKana: null,
-		nameKanji: null,
+		nameKana: input.nameKana ?? null,
+		nameKanji: input.nameKanji ?? null,
 		triggerHint: input.triggerHint ?? null,
 		isMainQuest: input.isMainQuest ?? 0,
 		isArchived: input.isArchived ?? 0,
@@ -197,6 +198,10 @@ export async function updateActivity(
 		'triggerHint',
 		'isMainQuest',
 		'priority',
+		// #3422: 親入力の編集を persist (旧実装は update 対象外で silent drop)
+		'dailyLimit',
+		'nameKana',
+		'nameKanji',
 	] as const;
 
 	const sets: string[] = [];

--- a/src/lib/server/db/sqlite/child-activity-repo.ts
+++ b/src/lib/server/db/sqlite/child-activity-repo.ts
@@ -122,6 +122,10 @@ export async function insertActivity(
 			sortOrder: input.sortOrder ?? 0,
 			isArchived: input.isArchived ?? 0,
 			archivedReason: (input.archivedReason ?? null) as ArchivedReason | null,
+			// #3422: 親入力の 1 日上限 / 読み仮名 / 漢字表記を persist (旧 service が drop していた)
+			dailyLimit: input.dailyLimit ?? null,
+			nameKana: input.nameKana ?? null,
+			nameKanji: input.nameKanji ?? null,
 		})
 		.returning()
 		.get();

--- a/src/lib/server/db/types/index.ts
+++ b/src/lib/server/db/types/index.ts
@@ -408,6 +408,11 @@ export interface InsertChildActivityInput {
 	sortOrder?: number;
 	isArchived?: number;
 	archivedReason?: string | null;
+	// #3422: 親が設定する 1 日上限 / 読み仮名 / 漢字表記。child_activities 列は存在するが
+	// 旧 service が drop しており常に null (= ProdDashboardSections で dailyLimit ?? 1 固定) だった。
+	dailyLimit?: number | null;
+	nameKana?: string | null;
+	nameKanji?: string | null;
 }
 
 export interface UpdateChildActivityInput {
@@ -418,6 +423,10 @@ export interface UpdateChildActivityInput {
 	triggerHint?: string | null;
 	isMainQuest?: number;
 	priority?: ActivityPriority;
+	// #3422: dailyLimit / nameKana / nameKanji の編集を persist する (旧実装は silent drop)。
+	dailyLimit?: number | null;
+	nameKana?: string | null;
+	nameKanji?: string | null;
 }
 
 export interface InsertActivityLogInput {

--- a/src/lib/server/services/activity-service.ts
+++ b/src/lib/server/services/activity-service.ts
@@ -135,9 +135,10 @@ async function _resolveChildIdForActivity(
 /**
  * `CreateActivityInput` (Activity master 型) を `InsertChildActivityInput` に変換。
  *
- * ageMin / ageMax / gradeLevel / subcategory / description / dailyLimit / source /
- * nameKana / nameKanji は ChildActivity に存在しないため drop。Phase 7b-2c で
- * callsite 側で渡されなくなる想定。
+ * ageMin / ageMax / gradeLevel / subcategory / description / source は child_activities に
+ * 列が無いため drop。dailyLimit / nameKana / nameKanji は child_activities に列が存在するため
+ * persist する (#3422: 旧実装は「存在しない」と誤認して drop し、親の 1 日上限設定が常に無視され
+ * ProdDashboardSections の dailyLimit ?? 1 で 1 日 1 回固定になっていた = NN/G #1 visibility 違反)。
  */
 function _toChildActivityInsertInput(
 	input: CreateActivityInput,
@@ -151,6 +152,10 @@ function _toChildActivityInsertInput(
 		basePoints: input.basePoints,
 		triggerHint: input.triggerHint ?? null,
 		priority: input.priority,
+		// #3422: 親入力を persist (列は child_activities に存在)。
+		dailyLimit: input.dailyLimit ?? null,
+		nameKana: input.nameKana ?? null,
+		nameKanji: input.nameKanji ?? null,
 	};
 }
 
@@ -168,6 +173,10 @@ function _toChildActivityUpdateInput(
 	if (input.triggerHint !== undefined) update.triggerHint = input.triggerHint;
 	if (input.isMainQuest !== undefined) update.isMainQuest = input.isMainQuest;
 	if (input.priority !== undefined) update.priority = input.priority;
+	// #3422: dailyLimit / nameKana / nameKanji の編集を persist (旧実装は silent drop)。
+	if (input.dailyLimit !== undefined) update.dailyLimit = input.dailyLimit;
+	if (input.nameKana !== undefined) update.nameKana = input.nameKana;
+	if (input.nameKanji !== undefined) update.nameKanji = input.nameKanji;
 	return update;
 }
 

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -308,6 +308,11 @@ async function collectForChild(
 		// #3358: archive 状態を round-trip 保全 (archived→active 復活防止)
 		isArchived: a.isArchived,
 		archivedReason: a.archivedReason ?? null,
+		// #3422: 親設定の 1 日上限 / 読み仮名 / 漢字表記を round-trip 保全 (silent drop で
+		// dailyLimit が復元後 null=1 日 1 回固定に戻る取りこぼし防止)。0 (無制限) も保持する。
+		dailyLimit: a.dailyLimit,
+		nameKana: a.nameKana,
+		nameKanji: a.nameKanji,
 	}));
 
 	// ステータス履歴は全カテゴリ分を取得

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -151,8 +151,8 @@ export function validateExportData(
 		return { valid: false, error: `フォーマットが不正です（期待: ${EXPORT_FORMAT}）` };
 	}
 	// #3106/#3107: EXPORT_VERSION を bump しても既存 backup を import 可能に保つ
-	// (新 field はすべて optional で後方互換)。#3358 で 1.5.0 へ bump、1.4.0 も明示維持。
-	const supportedVersions = [EXPORT_VERSION, '1.4.0', '1.3.0', '1.2.0', '1.1.0', '1.0.0'];
+	// (新 field はすべて optional で後方互換)。#3358 で 1.5.0、#3422 で 1.6.0 へ bump。旧版も明示維持。
+	const supportedVersions = [EXPORT_VERSION, '1.5.0', '1.4.0', '1.3.0', '1.2.0', '1.1.0', '1.0.0'];
 	if (!supportedVersions.includes(d.version as string)) {
 		return {
 			valid: false,
@@ -783,6 +783,11 @@ async function importChildActivitiesData(
 					sortOrder: a.sortOrder,
 					isArchived: a.isArchived,
 					archivedReason: a.archivedReason ?? null,
+					// #3422: 1 日上限 / 読み仮名 / 漢字表記を round-trip 復元 (省略 = 旧 backup は
+					// schema default)。dailyLimit=0 (無制限) を null=1 回固定へ落とさず保全する。
+					dailyLimit: a.dailyLimit,
+					nameKana: a.nameKana ?? null,
+					nameKanji: a.nameKanji ?? null,
 				},
 				tenantId,
 			);

--- a/tests/unit/server/db/sqlite/child-activity-repo.test.ts
+++ b/tests/unit/server/db/sqlite/child-activity-repo.test.ts
@@ -97,6 +97,35 @@ describe('sqlite/child-activity-repo', () => {
 			expect(list[0]?.name).toBe('はみがきした');
 		});
 
+		it('#3422: dailyLimit / nameKana / nameKanji を persist する (旧 silent drop 回帰防止)', async () => {
+			const a = await insertActivity(
+				{
+					childId: 1,
+					name: 'おてつだい',
+					categoryId: 1,
+					icon: '🧹',
+					basePoints: 5,
+					dailyLimit: 3,
+					nameKana: 'おてつだい',
+					nameKanji: 'お手伝い',
+				},
+				TENANT,
+			);
+			expect(a.dailyLimit).toBe(3);
+			expect(a.nameKana).toBe('おてつだい');
+			expect(a.nameKanji).toBe('お手伝い');
+
+			// update でも persist される (1 日上限を 3→無制限(null) に変更)
+			const updated = await updateActivity(
+				a.id,
+				1,
+				{ dailyLimit: null, nameKana: 'かわった' },
+				TENANT,
+			);
+			expect(updated?.dailyLimit).toBeNull();
+			expect(updated?.nameKana).toBe('かわった');
+		});
+
 		it('別 child の activity は取得 list に出ない (cross-child isolation)', async () => {
 			await insertActivity(
 				{ childId: 1, name: 'たろう専用', categoryId: 1, icon: '🤸', basePoints: 5 },

--- a/tests/unit/server/db/sqlite/child-activity-repo.test.ts
+++ b/tests/unit/server/db/sqlite/child-activity-repo.test.ts
@@ -115,7 +115,8 @@ describe('sqlite/child-activity-repo', () => {
 			expect(a.nameKana).toBe('おてつだい');
 			expect(a.nameKanji).toBe('お手伝い');
 
-			// update でも persist される (1 日上限を 3→無制限(null) に変更)
+			// update でも persist される。dailyLimit semantics は null=1回 / 0=無制限 / N=N回
+			// (activity-log-service.ts §daily limit 定義)。1 日上限を 3→1回(null) に変更する。
 			const updated = await updateActivity(
 				a.id,
 				1,
@@ -124,6 +125,10 @@ describe('sqlite/child-activity-repo', () => {
 			);
 			expect(updated?.dailyLimit).toBeNull();
 			expect(updated?.nameKana).toBe('かわった');
+
+			// dailyLimit=0 (無制限) を persist できる。0 を falsy 扱いで null へ落とさないことを固定。
+			const unlimited = await updateActivity(a.id, 1, { dailyLimit: 0 }, TENANT);
+			expect(unlimited?.dailyLimit).toBe(0);
 		});
 
 		it('別 child の activity は取得 list に出ない (cross-child isolation)', async () => {

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -556,13 +556,13 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		// --- export: 3 列が ExportChildActivity に載っていること (silent drop なら undefined で fail) ---
 		const data = await exportFamilyData({ tenantId: T });
 		expect(data.data.childActivities.length, 'export:活動 2 件').toBe(2);
-		const exTesudai = data.data.childActivities.find((a) => a.name === 'おてつだい');
-		const exMizu = data.data.childActivities.find((a) => a.name === 'みずをのむ');
-		expect(exTesudai?.dailyLimit, 'export:dailyLimit=3').toBe(3);
-		expect(exTesudai?.nameKana, 'export:nameKana').toBe('おてつだい');
-		expect(exTesudai?.nameKanji, 'export:nameKanji').toBe('お手伝い');
+		const exHelp = data.data.childActivities.find((a) => a.name === 'おてつだい');
+		const exWater = data.data.childActivities.find((a) => a.name === 'みずをのむ');
+		expect(exHelp?.dailyLimit, 'export:dailyLimit=3').toBe(3);
+		expect(exHelp?.nameKana, 'export:nameKana').toBe('おてつだい');
+		expect(exHelp?.nameKanji, 'export:nameKanji').toBe('お手伝い');
 		// 0 が export で欠落 (undefined) / null 化されず、数値 0 のまま載ること。
-		expect(exMizu?.dailyLimit, 'export:dailyLimit=0 (無制限) 保持').toBe(0);
+		expect(exWater?.dailyLimit, 'export:dailyLimit=0 (無制限) 保持').toBe(0);
 
 		// --- replace = clear → import ---
 		await clearAllFamilyData(T);
@@ -571,14 +571,14 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		const children = testDb.select().from(schema.children).all();
 		const cid = children[0]?.id as number;
 		const acts = await getChildActivities(cid, T);
-		const tesudai = acts.find((a) => a.name === 'おてつだい');
-		const mizu = acts.find((a) => a.name === 'みずをのむ');
+		const help = acts.find((a) => a.name === 'おてつだい');
+		const water = acts.find((a) => a.name === 'みずをのむ');
 
 		// dailyLimit=3 / 読み仮名 / 漢字が round-trip で保全される。
-		expect(tesudai?.dailyLimit, 'restore:dailyLimit=3 保全').toBe(3);
-		expect(tesudai?.nameKana, 'restore:nameKana 保全').toBe('おてつだい');
-		expect(tesudai?.nameKanji, 'restore:nameKanji 保全').toBe('お手伝い');
+		expect(help?.dailyLimit, 'restore:dailyLimit=3 保全').toBe(3);
+		expect(help?.nameKana, 'restore:nameKana 保全').toBe('おてつだい');
+		expect(help?.nameKanji, 'restore:nameKanji 保全').toBe('お手伝い');
 		// **dailyLimit=0 (無制限) が null=1 回固定へ落ちず 0 のまま復元される** (本 PR の核心エッジ)。
-		expect(mizu?.dailyLimit, 'restore:dailyLimit=0 (無制限) が null へ落ちない').toBe(0);
+		expect(water?.dailyLimit, 'restore:dailyLimit=0 (無制限) が null へ落ちない').toBe(0);
 	});
 });

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -521,4 +521,64 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(restored[0]?.sentAt, 'sentAt 保全').toBe('2026-02-15T10:00:00Z');
 		expect(restored[0]?.shownAt, 'shownAt 保全').toBe('2026-02-15T12:00:00Z');
 	});
+
+	// #3422: per-child 活動の dailyLimit / nameKana / nameKanji が backup round-trip で保全される。
+	// create/update では persist 是正済だが export/import 境界で同 3 列が silent drop され、復元後に
+	// dailyLimit が null (= 1 日 1 回固定) へ戻る取りこぼしを赤で機械再現し潰す。
+	// dailyLimit semantics は null=1回 / 0=無制限 / N=N回 (activity-log-service.ts §daily limit)。
+	// **特に dailyLimit=0 (無制限) が `?? null` のエッジで 1 回固定へ落ちないことを直接固定**する。
+	it('活動の dailyLimit (0=無制限含む) / nameKana / nameKanji が export→clear→import で保全される', async () => {
+		testDb.insert(schema.children).values({ nickname: 'みお', age: 8, theme: 'pink' }).run(); // id=1
+		// 非デフォルト値の活動 2 件: dailyLimit=3 (3 回) と dailyLimit=0 (無制限)。
+		seedChildActivities(testDb, 1, [
+			{
+				name: 'おてつだい',
+				categoryId: 1,
+				icon: '🧹',
+				basePoints: 5,
+				dailyLimit: 3,
+				nameKana: 'おてつだい',
+				nameKanji: 'お手伝い',
+				sortOrder: 1,
+			},
+			{
+				name: 'みずをのむ',
+				categoryId: 3,
+				icon: '💧',
+				basePoints: 1,
+				dailyLimit: 0, // 無制限
+				nameKana: 'みずをのむ',
+				nameKanji: '水を飲む',
+				sortOrder: 2,
+			},
+		]);
+
+		// --- export: 3 列が ExportChildActivity に載っていること (silent drop なら undefined で fail) ---
+		const data = await exportFamilyData({ tenantId: T });
+		expect(data.data.childActivities.length, 'export:活動 2 件').toBe(2);
+		const exTesudai = data.data.childActivities.find((a) => a.name === 'おてつだい');
+		const exMizu = data.data.childActivities.find((a) => a.name === 'みずをのむ');
+		expect(exTesudai?.dailyLimit, 'export:dailyLimit=3').toBe(3);
+		expect(exTesudai?.nameKana, 'export:nameKana').toBe('おてつだい');
+		expect(exTesudai?.nameKanji, 'export:nameKanji').toBe('お手伝い');
+		// 0 が export で欠落 (undefined) / null 化されず、数値 0 のまま載ること。
+		expect(exMizu?.dailyLimit, 'export:dailyLimit=0 (無制限) 保持').toBe(0);
+
+		// --- replace = clear → import ---
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T);
+
+		const children = testDb.select().from(schema.children).all();
+		const cid = children[0]?.id as number;
+		const acts = await getChildActivities(cid, T);
+		const tesudai = acts.find((a) => a.name === 'おてつだい');
+		const mizu = acts.find((a) => a.name === 'みずをのむ');
+
+		// dailyLimit=3 / 読み仮名 / 漢字が round-trip で保全される。
+		expect(tesudai?.dailyLimit, 'restore:dailyLimit=3 保全').toBe(3);
+		expect(tesudai?.nameKana, 'restore:nameKana 保全').toBe('おてつだい');
+		expect(tesudai?.nameKanji, 'restore:nameKanji 保全').toBe('お手伝い');
+		// **dailyLimit=0 (無制限) が null=1 回固定へ落ちず 0 のまま復元される** (本 PR の核心エッジ)。
+		expect(mizu?.dailyLimit, 'restore:dailyLimit=0 (無制限) が null へ落ちない').toBe(0);
+	});
 });


### PR DESCRIPTION
## 顧客価値・目的

親が活動ごとに設定した「1 日の上限回数 (dailyLimit)」「読み仮名 (nameKana)」「漢字表記 (nameKanji)」が保存処理で silent に捨てられており、上限を何回に設定しても子供画面では常に「1 日 1 回固定」(`ProdDashboardSections` の `dailyLimit ?? 1`) になっていた。親の意図した設定が反映されない = NN/G #1 (visibility of system status) 違反。本 PR で 3 項目を insert / update 両経路で persist し、親設定どおりに動くようにする。

## 関連 Issue

closes #3422

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 親入力の dailyLimit / nameKana / nameKanji が insert で永続化される | `npx vitest run tests/unit/server/db/sqlite/child-activity-repo.test.ts` | HEAD `1ce880b6d` / 13 passed / test "#3422: dailyLimit / nameKana / nameKanji を persist する" (child-activity-repo.test.ts:100) |
| AC2 | update でも 3 項目が永続化される (1日上限 3→無制限 等) | 同上 | HEAD `1ce880b6d` / 同 test 内 updateActivity 検証 (child-activity-repo.test.ts:118-126) |
| AC3 | service 層が 3 項目を drop せず repo へ carry する | grep | activity-service.ts:155-158 (insert) / 176-179 (update) |
| AC4 | dynamodb / demo 並行実装も同一ハンドリング (ADR tests/CLAUDE.md DynamoDB 整合) | grep | dynamodb/child-activity-repo.ts:129-133,202-204 / demo/child-activity-repo.ts:135,138-139 |

## 変更タイプ

- [x] バグ修正 (fix)

## 影響範囲・変更コンポーネント

- `src/lib/server/db/types/index.ts` — `InsertChildActivityInput` / `UpdateChildActivityInput` に 3 field 追加
- `src/lib/server/services/activity-service.ts` — `_toChildActivityInsertInput` / `_toChildActivityUpdateInput` が 3 field を carry + 旧誤認コメント是正
- `src/lib/server/db/sqlite/child-activity-repo.ts` — insert `.values()` で persist (update は generic `.set(input)` で自動追従)
- `src/lib/server/db/dynamodb/child-activity-repo.ts` — `buildChildActivity` で input 値採用 + update `fields` 配列に 3 列追加
- `src/lib/server/db/demo/child-activity-repo.ts` — insert stub で input 値採用
- `tests/unit/server/db/sqlite/child-activity-repo.test.ts` — 回帰テスト追加

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/server/db/sqlite/child-activity-repo.test.ts tests/unit/db/dynamodb-child-activity-repo.test.ts tests/unit/services/activity-service.test.ts` <!-- PASS --> → 82 passed
- 新規列追加ではなく既存列 (schema.ts に実在) への persist 修正のため schema migration 不要

## スクリーンショット / ビジュアルデモ

UI 変更なし (サーバー側 data persistence の修正)。子供画面の表示文言・レイアウトは不変で、親設定値が正しく反映されるようになる挙動修正のみ。SS 対象外。

## コード品質セルフレビュー (#1481)

- biome check: 5 source files で No fixes applied (clean)
- 既存 `#3358` の isVisible/sortOrder/isArchived persist と同一パターンに揃えた
- sqlite update は generic `.set(input)` のため追加コード不要、dynamodb は hardcoded fields 配列のため明示追加

## 横展開・影響波及チェック

- sqlite / dynamodb / demo の 3 backend 全てで insert を同期 (tests/CLAUDE.md「DynamoDB 並行実装の整合性」準拠)
- server action `(parent)/admin/activities/+page.server.ts` は既に formData から 3 項目を読み service へ渡しており、chain は本 PR で完結
- demo update は元から no-op stub (read 投影のみ) のため変更なし

## レビュー依頼事項・破壊的変更

破壊的変更なし。既存の null 固定挙動を、親入力があればその値を採用する挙動に修正。既存データ (3 列が NULL の行) は従来どおり子供画面で `?? 1` フォールバックされ無害。

## 配布済み env / secret (ADR-0006)

env / secret の追加なし。

## Ready for Review チェックリスト

- [x] CI green を確認した
- [x] AC 検証マップを記載した
- [x] テストを追加した
- [x] 横展開を確認した

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
