### PR TITLE
test: #3416 NAV_TIMEOUT_MS SSOT 化 + parent-gate 正方向回帰テスト追加

### DIFF
--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -11,6 +11,7 @@ import Button from '$lib/ui/primitives/Button.svelte';
 import Dialog from '$lib/ui/primitives/Dialog.svelte';
 import PinInput from '$lib/ui/primitives/PinInput.svelte';
 import { soundService } from '$lib/ui/sound/sound-service';
+import { NAV_TIMEOUT_MS } from './nav-timeout';
 
 let { data } = $props();
 
@@ -35,12 +36,10 @@ let navigatingError = $state<boolean>(false);
 // timeout の二重起動防止 + 成功 unload 前のクリア用ハンドル。
 let navigatingTimeout: ReturnType<typeof setTimeout> | null = null;
 
-// #3101: ナビ失敗とみなすまでの待機時間。旧実装は 8s 固定だったが、回線が遅い
+// #3101 / #3416: ナビ失敗とみなすまでの待機時間。旧実装は 8s 固定だったが、回線が遅い
 // (CloudFront cold-miss 等で実測 4.2s が伸びる) slow-but-successful nav が 8s を超えると
 // 成功直前に「読込失敗」が誤表示される問題があった (PO 指摘: 8s 上限に根拠なし)。
-// 一般的なサーバータイムアウト (CloudFront/Lambda の上限が ~30s) に合わせ、真にハングした
-// 場合のみ error 表示する。正常時はナビ完了でページごと置換されるため本タイマーは発火しない。
-const NAV_TIMEOUT_MS = 30_000;
+// 値は nav-timeout.ts に SSOT 集約し、E2E test (parent-gate.spec.ts) と結合させる。
 
 // #3089: /admin へのハードナビを fail-safe で起動する。NAV_TIMEOUT_MS 経っても unload しなければ
 // (ナビ失敗とみなして) overlay を error 状態に切り替え、window.location.assign が同期 throw

--- a/src/routes/switch/nav-timeout.ts
+++ b/src/routes/switch/nav-timeout.ts
@@ -1,0 +1,13 @@
+// src/routes/switch/nav-timeout.ts
+// /switch → /admin ハードナビのタイムアウト SSOT (#3101 / #3416)。
+//
+// +page.svelte (本番実装) と tests/e2e/parent-gate.spec.ts (回帰 test) の双方が
+// 本値を import する。test がマジックナンバー直書きだと、将来 NAV_TIMEOUT_MS を
+// 変更したとき test が誤検知するため、結合を SSOT 1 箇所に集約する (ADR-0061)。
+
+/**
+ * ナビ失敗とみなすまでの待機時間 (ms)。一般的なサーバータイムアウト
+ * (CloudFront/Lambda の上限 ~30s) に合わせる。正常時はナビ完了でページごと
+ * 置換されるため本タイマーは発火しない (真にハングした場合のみ error 表示)。
+ */
+export const NAV_TIMEOUT_MS = 30_000;

--- a/tests/e2e/parent-gate.spec.ts
+++ b/tests/e2e/parent-gate.spec.ts
@@ -10,6 +10,7 @@
 // 既存 auth.setup.ts / E2E spec を破壊しない構造的妥協 (本 EPIC + ADR-0050 §運用)。
 
 import { expect, test } from '@playwright/test';
+import { NAV_TIMEOUT_MS } from '../../src/routes/switch/nav-timeout';
 
 const PARENT_GATE_ACTIVE = process.env.PARENT_GATE_FORCE_ACTIVE === 'true';
 
@@ -402,8 +403,9 @@ function registerParentGateTests(): void {
 			// spinner overlay は一旦表示される
 			await expect(page.getByTestId('parent-gate-navigating')).toBeVisible({ timeout: 5_000 });
 
-			// NAV_TIMEOUT_MS (30s) を fast-forward → dead-end でなく error 状態 (role=alert + 再試行) へ
-			await page.clock.fastForward(31_000);
+			// NAV_TIMEOUT_MS を超えるまで fast-forward → dead-end でなく error 状態 (role=alert + 再試行) へ。
+			// #3416: マジックナンバー直書きを止め NAV_TIMEOUT_MS SSOT 由来に連動させる (値変更時の誤検知防止)。
+			await page.clock.fastForward(NAV_TIMEOUT_MS + 1_000);
 			const errorOverlay = page.getByTestId('parent-gate-navigating-error');
 			await expect(errorOverlay).toBeVisible({ timeout: 5_000 });
 			await expect(errorOverlay).toContainText('もう一度');
@@ -411,6 +413,40 @@ function registerParentGateTests(): void {
 			await expect(page.getByTestId('parent-gate-navigating')).toBeHidden();
 			// 再試行ボタンが操作可能 (もう一度ナビを起動できる)
 			await expect(errorOverlay.getByRole('button')).toBeEnabled();
+		});
+
+		// #3416 正方向回帰 (ADR-0006): #3101 が直す実バグ「NAV_TIMEOUT_MS 未満の slow-but-successful
+		// nav では誤 error を出さない」を固定する。NAV_TIMEOUT_MS の手前まで時間を進めても error overlay
+		// が出ず、その後 nav が成功して /admin に到達することを assert する (旧 8s 上限の誤検知の再発防止)。
+		test('#3416: NAV_TIMEOUT_MS 手前で完了する slow nav は誤 error を出さず /admin に到達する', async ({
+			page,
+		}) => {
+			await page.clock.install();
+
+			// /admin への document nav を NAV_TIMEOUT_MS 未満だけ遅延させ、最終的に成功させる (slow-but-successful)。
+			await page.route('**/admin', async (route) => {
+				if (route.request().resourceType() === 'document') {
+					await new Promise((resolve) => setTimeout(resolve, 1200));
+				}
+				await route.continue();
+			});
+
+			await page.goto('/switch?pinRequired=1', { waitUntil: 'domcontentloaded' });
+			await expect(page.getByTestId('parent-gate-modal')).toBeVisible();
+
+			await typePinInto(page, '3690');
+			await expect(page.getByTestId('parent-gate-create')).toHaveAttribute('data-step', 'confirm');
+			await typePinInto(page, '3690');
+
+			// spinner overlay は出る (遷移中フィードバック)
+			await expect(page.getByTestId('parent-gate-navigating')).toBeVisible({ timeout: 5_000 });
+
+			// NAV_TIMEOUT_MS の手前まで時間を進めても error overlay は出ない (誤検知しない)
+			await page.clock.fastForward(NAV_TIMEOUT_MS - 5_000);
+			await expect(page.getByTestId('parent-gate-navigating-error')).toBeHidden();
+
+			// nav は成功し /admin に到達する (dead-end でない)
+			await page.waitForURL(/\/admin/, { timeout: 15_000 });
 		});
 
 		test('確認不一致はエラー表示 + 1 段目からやり直し (dead-end でない)', async ({ page }) => {


### PR DESCRIPTION
## 顧客価値・目的

PR #3406 (#3101) で /switch→/admin のナビ失敗判定を 8s→30s (NAV_TIMEOUT_MS) に SSOT 化し、slow-but-successful nav の誤 error を解消した。その test hardening 残課題に対応し、(1) test のマジックナンバーを NAV_TIMEOUT_MS SSOT 由来に連動させ将来の値変更時の誤検知を防ぎ、(2) 「30s 未満の slow nav で誤 error を出さない」実バグ修正を固定する正方向回帰 test を追加することで、本機能の品質を機械担保する。

## 関連 Issue

closes #3416

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (item1) | NAV_TIMEOUT_MS を SSOT 化し test を const 連動 | grep + svelte-check | HEAD `14de4c318` / src/routes/switch/nav-timeout.ts:14 を +page.svelte:13 と parent-gate.spec.ts:13 が import。fastForward(NAV_TIMEOUT_MS + 1_000) に変更 (parent-gate.spec.ts) |
| AC2 (item2) | 正方向回帰 test 追加 (slow-but-successful で誤 error なし → /admin 到達) | `npx playwright test ... --list` | HEAD `14de4c318` / "#3416: NAV_TIMEOUT_MS 手前で完了する slow nav は誤 error を出さず /admin に到達する" 登録確認 (parent-gate.spec.ts:421) |
| AC3 | 型 / lint green | `npx svelte-check` / `npx biome check` | HEAD `14de4c318` / svelte-check 0 ERRORS / biome No fixes applied |

item3 (retry backoff / error overlay→再試行 Button focus 移動 a11y / ?screenshot=all overlay 露出) は #3101 で継続追跡のため本 PR 範囲外。

## 変更タイプ

- [x] テスト (test)

## 影響範囲・変更コンポーネント

- `src/routes/switch/nav-timeout.ts` — 新規。NAV_TIMEOUT_MS SSOT
- `src/routes/switch/+page.svelte` — ローカル const を SSOT import に置換 (挙動不変)
- `tests/e2e/parent-gate.spec.ts` — const 連動 + 正方向回帰 test 追加

## テスト & 安全装置セルフチェック

- `npx svelte-check --threshold error` <!-- PASS --> → 0 ERRORS
- `npx biome check` <!-- PASS --> → No fixes applied
- `PARENT_GATE_FORCE_ACTIVE=true npx playwright test tests/e2e/parent-gate.spec.ts --list` <!-- PASS --> → 新旧 test 全て登録 (parse 成功 = src import 解決確認)

## スクリーンショット / ビジュアルデモ

ロジック不変 (NAV_TIMEOUT_MS の値は 30_000 のまま、test と SSOT 結合のみ)。UI 表示変化なし。SS 対象外。

## コード品質セルフレビュー (#1481)

- +page.svelte は const をモジュール import に置換しただけで挙動完全不変
- e2e は他 spec の `../../src/...` 相対 import 規約に従う

## 横展開・影響波及チェック

- NAV_TIMEOUT_MS の他参照を grep → +page.svelte と parent-gate.spec.ts の 2 箇所のみで一致確認
- 正方向 / 負方向 (dead-end) の両 test が同一 SSOT 値で連動

## レビュー依頼事項・破壊的変更

破壊的変更なし。

## 配布済み env / secret (ADR-0006)

env / secret の追加なし。

## Ready for Review チェックリスト

- [x] svelte-check / biome green
- [x] AC 検証マップ記載
- [x] 正方向 / 負方向 test 連動確認

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
