### PR TITLE
test: #3319 subscription guide の data-tutorial anchor を runtime-bound で機械担保

### DIFF
--- a/tests/unit/tutorial/page-guide-runtime-filter.test.ts
+++ b/tests/unit/tutorial/page-guide-runtime-filter.test.ts
@@ -8,6 +8,9 @@
 //   - runtimeMode 未確定 (undefined) は fail-closed で saas/nuc 限定手順を除外 (#3296 Part 3)
 //   - requiredStripe='enabled' → Stripe 有効時のみ表示、無効/未確定は fail-closed で除外 (#3296 Part 1)
 
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
 	filterGuideStepsByRuntime,
@@ -15,6 +18,8 @@ import {
 } from '../../../src/lib/ui/tutorial/page-guide-registry';
 import type { PageGuide } from '../../../src/lib/ui/tutorial/page-guide-types';
 import { SUBSCRIPTION_GUIDE } from '../../../src/routes/(parent)/admin/subscription/_guide';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
 const fixture: PageGuide = {
 	pageId: 'test-page',
@@ -92,6 +97,43 @@ describe('#3291/#3296 filterGuideStepsByRuntime', () => {
 				).toBeTruthy();
 			}
 		}
+	});
+
+	// #3319: 各環境で「残った step」の data-tutorial anchor が、その環境で描画される Panel の
+	// markup に実在することを決定的に検証する (AC1 の趣旨 = 環境別 anchor 解決の機械担保)。
+	// #3307 の global anchor-existence gate は anchor をどこかの src に存在することしか保証しないが、
+	// 本 test は「nuc step の anchor は NucLicensePanel に / saas step の anchor は SaasLicensePanel に」
+	// と Panel を runtime に bind して検証するため、Panel の markup 退行 (anchor 削除/typo) による
+	// 空 spotlight (本 PR が直したのと同クラス、ADR-0061 same-class) を runtime 単位で捕捉する。
+	const PANEL_BY_RUNTIME: Record<'nuc' | 'saas', string> = {
+		nuc: 'src/lib/features/admin/components/NucLicensePanel.svelte',
+		saas: 'src/lib/features/admin/components/SaasLicensePanel.svelte',
+	};
+	const extractAnchor = (selector: string | undefined): string | null =>
+		selector?.match(/\[data-(?:tutorial|testid)="([^"]+)"\]/)?.[1] ?? null;
+
+	it('#3319: 環境別 subscription step の anchor が対応 Panel の markup に実在する (runtime-bound 空 spotlight 検出)', () => {
+		const panelSrc: Record<'nuc' | 'saas', string> = {
+			nuc: readFileSync(resolve(REPO_ROOT, PANEL_BY_RUNTIME.nuc), 'utf8'),
+			saas: readFileSync(resolve(REPO_ROOT, PANEL_BY_RUNTIME.saas), 'utf8'),
+		};
+		const missing = SUBSCRIPTION_GUIDE.steps
+			.filter((s) => s.requiredRuntime === 'nuc' || s.requiredRuntime === 'saas')
+			.map((s) => {
+				const runtime = s.requiredRuntime as 'nuc' | 'saas';
+				const anchor = extractAnchor(s.selector);
+				return { id: s.id, runtime, anchor };
+			})
+			.filter(
+				({ runtime, anchor }) =>
+					anchor === null || !panelSrc[runtime].includes(`data-tutorial="${anchor}"`),
+			)
+			.map(({ id, runtime, anchor }) => `${id} (${runtime}) → data-tutorial="${anchor}"`);
+		expect(
+			missing,
+			`環境固有 step の anchor が対応 Panel に存在しない (その環境で空 spotlight になる)。` +
+				`対応 Panel に data-tutorial を追加するか step を再分類すること:\n${missing.join('\n')}`,
+		).toEqual([]);
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

ページガイドの真実性 (ADR-0013) は data-tutorial アンカーが実画面に存在することに依存する。subscription ガイドは実行環境 (NUC / SaaS) で描画 Panel が変わるため、各環境固有 step の anchor がその環境の Panel markup に存在しないと「空 spotlight + 実装にない操作案内」になる。本 PR は anchor 解決を **runtime に bind** して決定的に検証し、Panel markup 退行 (anchor 削除/typo) による環境固有の空 spotlight (#3303/#3308/#3309/#3315 と同クラス、ADR-0061) を機械捕捉する。

## 関連 Issue

closes #3319

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | subscription 各 step (saas: current-plan/plan-management、nuc: edition/usage) が対応環境で anchor 解決する | `npx vitest run tests/unit/tutorial/page-guide-runtime-filter.test.ts` | HEAD `691127bde` / 新 test "#3319: 環境別 subscription step の anchor が対応 Panel の markup に実在する" (page-guide-runtime-filter.test.ts) + 既存 "SUBSCRIPTION_GUIDE: nuc-prod では…SaaS では…" で環境別 step 出し分けを assert。10 passed |
| AC2 | fail-closed (runtime undefined) 時に環境限定 step が出ない | 同上 | HEAD `691127bde` / 既存 test "runtimeMode 未確定 (undefined / 未知値) は fail-closed で saas/nuc 限定手順を除外" + SUBSCRIPTION_GUIDE undefined→intro のみ |
| AC3 | page-guide 全体の step.selector に対応する data-tutorial が実在する fitness function | `npx vitest run tests/unit/architecture/page-guide-coverage.test.ts` | HEAD `691127bde` / 既存 #3307 gate "全 REGISTERED ガイドの selector anchor が描画側マークアップに属性形で存在する" が全 guide を網羅。本 PR で runtime-bound binding を追加 |

備考: 環境別 step 出し分け (#3291/#3296) と global anchor 実在 (#3307) は既存テストで充足済。本 PR は両者の隙間 (「anchor がその環境の Panel に bind して存在するか」) を埋める。browser レベルの NUC/SaaS Lambda 横断 E2E は CI コスト大のため ADR-0010 Pre-PMF で範囲外 (#3307 既存コメントに記録済の方針を踏襲)。

## 変更タイプ

- [x] テスト (test)

## 影響範囲・変更コンポーネント

- `tests/unit/tutorial/page-guide-runtime-filter.test.ts` — runtime-bound panel anchor 検証 test を 1 件追加

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/tutorial/page-guide-runtime-filter.test.ts` <!-- PASS --> → 10 passed
- `npx vitest run tests/unit/architecture/page-guide-coverage.test.ts` <!-- PASS --> → 既存 #3307 gate green
- `npx biome check` <!-- PASS --> → No fixes applied

## スクリーンショット / ビジュアルデモ

テスト追加のみで UI 変更なし。SS 対象外。

## コード品質セルフレビュー (#1481)

- 既存 #3307 の extractAnchor / readFileSync パターンを踏襲
- PANEL_BY_RUNTIME で runtime → Panel を明示 mapping し、anchor を runtime に bind

## 横展開・影響波及チェック

- subscription 4 anchor (nuc-edition / nuc-usage / subscription-current-plan / subscription-plan-management) が各 Panel に実在することを確認済
- 既存の環境別 filter test (#3291/#3296) + global anchor gate (#3307) と補完関係

## レビュー依頼事項・破壊的変更

破壊的変更なし。テスト強化のみ。

## 配布済み env / secret (ADR-0006)

env / secret の追加なし。

## Ready for Review チェックリスト

- [x] 新 test green
- [x] AC 検証マップ記載
- [x] 既存 gate との補完関係確認

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
