### PR TITLE
fix: #3337 DynamoDB resolved_by_parent_id legacy 0 を読出時 null 正規化

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1385,7 +1385,7 @@ Stripe at-least-once delivery 仕様 + CLI `stripe events resend` で同一 even
 | status | TEXT | NO | 'pending_parent_approval' | 申請状態: `pending_parent_approval` / `approved` / `rejected` / `expired` |
 | parent_note | TEXT | YES | NULL | 却下時の親メモ（最大 100 文字）。承認時は NULL |
 | resolved_at | INTEGER | YES | NULL | 承認/却下日時（Unix epoch 秒） |
-| resolved_by_parent_id | TEXT | YES | NULL | 承認/却下した保護者の認証 userId (cognito sub 等)。監査証跡。local 実行モードや userId 不明時は NULL。**#3320 で INTEGER→TEXT**: 整数の親内部 ID は存在せず identity.userId は文字列 (cognito sub) のため。旧実装は常に 0 (解決者不明 sentinel) を記録していた |
+| resolved_by_parent_id | TEXT | YES | NULL | 承認/却下した保護者の認証 userId (cognito sub 等)。監査証跡。local 実行モードや userId 不明時は NULL。**#3320 で INTEGER→TEXT**: 整数の親内部 ID は存在せず identity.userId は文字列 (cognito sub) のため。旧実装は常に 0 (解決者不明 sentinel) を記録していた。**#3337**: SQLite は startup migration で legacy `0`→NULL 正規化済だが、本番 DynamoDB の historical レコードは `0` (number) が残存するため、DynamoDB repo の読出 (`toRow`) で `0`/`'0'` → null を吸収し cross-backend で表現を揃える (write-only 監査カラムだが number が string\|null 型に紛れる coercion trap を断つ) |
 | shown_to_child_at | INTEGER | YES | NULL | 子供への完了/却下通知を表示した日時（NULL = 未表示） |
 | reward_title | TEXT | YES | NULL | **申請時点 snapshot**（#2832）。申請作成時の reward タイトル。NULL = snapshot 列導入前の旧行（live JOIN 値に fallback） |
 | reward_points | INTEGER | YES | NULL | **申請時点 snapshot**（#2832）。申請作成時の reward ポイント。承認時の控除はこの値を使う |

--- a/src/lib/server/db/dynamodb/reward-redemption-repo.ts
+++ b/src/lib/server/db/dynamodb/reward-redemption-repo.ts
@@ -56,6 +56,16 @@ interface DenormFields {
 	rewardPoints: number;
 }
 
+// #3337: legacy DynamoDB レコードは resolvedByParentId=0 (number) を持つ (旧 approve/reject の
+// placeholder)。`?? null` は 0 が nullish でないため legacy 0 を素通しし、string|null 型に number が
+// 紛れる coercion trap になる。read-side で 0 / '0' / null/undefined を null に正規化し、SQLite
+// (lazy-startup-migrations で legacy 0→NULL 正規化済) と cross-backend 表現を揃える。
+// 実 parent userId は string で保存されるためそのまま String 化して返す。
+function normalizeResolvedByParentId(raw: unknown): string | null {
+	if (raw === null || raw === undefined || raw === 0 || raw === '0') return null;
+	return String(raw);
+}
+
 // DynamoDB item から PK/SK + 非正規化フィールドを除いた RedemptionRequestRow を作る。
 function toRow(item: Record<string, unknown>): RedemptionRequestRow {
 	const stripped = stripKeys(item) as Record<string, unknown>;
@@ -67,7 +77,7 @@ function toRow(item: Record<string, unknown>): RedemptionRequestRow {
 		status: stripped.status as string,
 		parentNote: (stripped.parentNote ?? null) as string | null,
 		resolvedAt: (stripped.resolvedAt ?? null) as number | null,
-		resolvedByParentId: (stripped.resolvedByParentId ?? null) as string | null,
+		resolvedByParentId: normalizeResolvedByParentId(stripped.resolvedByParentId),
 		shownToChildAt: (stripped.shownToChildAt ?? null) as number | null,
 	};
 }

--- a/tests/unit/db/dynamodb-reward-redemption-repo.test.ts
+++ b/tests/unit/db/dynamodb-reward-redemption-repo.test.ts
@@ -206,6 +206,29 @@ describe('findRedemptionRequestsByChild', () => {
 		const { findRedemptionRequestsByChild } = await loadRepo();
 		expect(await findRedemptionRequestsByChild(CHILD_ID, TENANT)).toEqual([]);
 	});
+
+	it('#3337: legacy resolvedByParentId=0 / "0" は読出時に null へ正規化する (SQLite と cross-backend 整合)', async () => {
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({ id: 1, requestedAt: 300, status: 'approved', resolvedByParentId: 0 }),
+				makeItem({ id: 2, requestedAt: 200, status: 'rejected', resolvedByParentId: '0' }),
+				makeItem({
+					id: 3,
+					requestedAt: 100,
+					status: 'approved',
+					resolvedByParentId: 'parent-sub-9',
+				}),
+			],
+		});
+		const { findRedemptionRequestsByChild } = await loadRepo();
+		const rows = await findRedemptionRequestsByChild(CHILD_ID, TENANT);
+		const byId = new Map(rows.map((r) => [r.id, r.resolvedByParentId]));
+		// legacy placeholder 0 / '0' は null へ (number が string|null 型に紛れる coercion trap を断つ)
+		expect(byId.get(1)).toBeNull();
+		expect(byId.get(2)).toBeNull();
+		// 実 parent userId はそのまま保持
+		expect(byId.get(3)).toBe('parent-sub-9');
+	});
 });
 
 // ============================================================


### PR DESCRIPTION
## 顧客価値・目的

承認/却下した保護者の監査証跡 (resolved_by_parent_id) を cross-backend で一貫させる。PR #3331 (#3320) は SQLite の legacy 0→NULL 正規化を完遂したが、本番 DynamoDB の historical レコードは 0 (number) が残存し SQLite (NULL) と乖離していた。read-side で 0/'0'→null を吸収し、将来 read 時の coercion trap (number が string|null 型に紛れる) を断つ。

## 関連 Issue

closes #3337

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (item1/2) | DynamoDB read 時に legacy resolvedByParentId 0/'0' を null 正規化 (option b) | `npx vitest run tests/unit/db/dynamodb-reward-redemption-repo.test.ts` | HEAD `d701b5cba` / 新 test "#3337: legacy resolvedByParentId=0 / '0' は読出時に null へ正規化する" + reward-redemption-repo.ts normalizeResolvedByParentId / toRow |
| AC2 | 実 parent userId (string) はそのまま保持 | 同上 | HEAD `d701b5cba` / 同 test で parent-sub-9 が保持されることを assert。26 passed |
| AC3 | 08-DB 設計書同期 (cross-backend 正規化方針) | grep | HEAD `d701b5cba` / 08-データベース設計書.md L1388 (#3337 注記) |

item3 (audit UI = 誰が承認したかの保護者向け可視化) は顧客価値顕在化の product 判断が必要なため本 PR 範囲外。one-off scan/backfill (option a) ではなく read-side 正規化 (option b) を採用 (運用リスクが低く決定的)。

## 変更タイプ

- [x] バグ修正 (fix)

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dynamodb/reward-redemption-repo.ts` — toRow に normalizeResolvedByParentId 追加
- `tests/unit/db/dynamodb-reward-redemption-repo.test.ts` — 回帰テスト追加
- `docs/design/08-データベース設計書.md` — cross-backend 正規化方針を注記

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/db/dynamodb-reward-redemption-repo.test.ts` <!-- PASS --> → 26 passed
- `npx biome check` <!-- PASS --> → clean
- 列追加でなく read-side 正規化のため schema migration 不要

## スクリーンショット / ビジュアルデモ

サーバー側 DB read 層 + 設計書 + テストの変更で UI 影響なし。SS 対象外。

## コード品質セルフレビュー (#1481)

- normalizeResolvedByParentId は nullish + 0/'0' sentinel を吸収する pure helper
- SQLite (startup migration で 0→NULL 済) と read 表現を揃える

## 横展開・影響波及チェック

- resolvedByParentId の DynamoDB 利用箇所 (reward-redemption-repo の toRow) のみが read 経路。grep で確認済
- SQLite 側は #3320 migration 済、本 PR は DynamoDB read 側を対称化

## レビュー依頼事項・破壊的変更

破壊的変更なし。write-only 監査カラムの read 表現を null 正規化するのみ。

## 配布済み env / secret (ADR-0006)

env / secret の追加なし。

## Ready for Review チェックリスト

- [x] テスト追加 + green
- [x] AC 検証マップ記載
- [x] 設計書同期

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
