### PR TITLE
fix: #3203 auto-challenge の skip→rescue 連動 + カテゴリ抽選 seed 化

### DIFF
--- a/src/lib/server/db/sqlite/child-challenge-repo.ts
+++ b/src/lib/server/db/sqlite/child-challenge-repo.ts
@@ -6,6 +6,12 @@
 //
 // 旧 sibling_challenges / sibling_challenge_progress は #2458 (Path B sibling drop, 2026-05-26) で
 // 物理 drop 済。本 repo が単一の challenge 経路。
+//
+// tenant isolation について (#3203 item3): `childChallenges` table に tenant_id 列は無く、SQLite は
+// 1 process = 1 DB = 1 tenant のため `_tenantId` 引数は意図的 no-op。DynamoDB repo は PK に tenant を
+// 含み tenant-scoped だが、SQLite で対称化するには列追加 + 全 backend migration が必要で、childId は
+// DB 内 autoincrement unique のため cross-tenant exploit は構造的に不能 (= 防御価値ゼロ)。よって列追加は
+// ADR-0010 Pre-PMF 過剰防衛として採らず、本コメントで非対称の根拠を明示する (#3203 QM follow-up 裁定)。
 
 import { and, eq, gte, inArray, lte } from 'drizzle-orm';
 import { db } from '../client';

--- a/src/lib/server/services/child-challenge-service.ts
+++ b/src/lib/server/services/child-challenge-service.ts
@@ -131,6 +131,11 @@ function weekIndexOf(weekStart: string): number {
 	return Math.floor(ms / (7 * 24 * 60 * 60 * 1000));
 }
 
+/** 2 つの weekStart (Monday) 間の週数。連続週なら 1、1 週 skip なら 2 (#3203 item1)。 */
+function weeksBetween(earlier: string, later: string): number {
+	return weekIndexOf(later) - weekIndexOf(earlier);
+}
+
 /** 直近 2 週間のカテゴリ別記録数を集計する。週次自動生成の苦手判定入力に使う。 */
 export async function aggregateCategoryCounts(
 	childId: number,
@@ -172,12 +177,40 @@ function strongestCategory(counts: Record<number, number>): number {
  * 苦手バイアスの重み付き抽選。記録が少ないカテゴリほど重みが高い (rank 0 = WEAK_BIAS_BASE)。
  * excludeId を渡すと連続週の同一カテゴリを避ける。
  */
-function weightedWeakPick(counts: Record<number, number>, excludeId?: number): number {
+// #3203 item2: カテゴリ抽選を childId + weekStart で seed 化し決定的にする。
+// 生成時 1 回 persist されるため以後 flip-flop しないが、week-boundary/race で初回 insert 前に
+// flip し得た。seed 化で (a) 決定性 (同 child・同週は常に同結果) (b) 親への説明性 (c) test 容易性
+// を得る。childId 未指定時 (既存 test 等) は Math.random にフォールバックし後方互換を保つ。
+function hashSeed(childId: number, weekStart: string): number {
+	let h = 2166136261 ^ childId; // FNV-1a 風
+	for (let i = 0; i < weekStart.length; i++) {
+		h = Math.imul(h ^ weekStart.charCodeAt(i), 16777619);
+	}
+	return h >>> 0;
+}
+
+/** mulberry32: seed から決定的な [0,1) 乱数を返す PRNG を作る。 */
+function makeSeededRand(childId: number, weekStart: string): () => number {
+	let a = hashSeed(childId, weekStart);
+	return () => {
+		a |= 0;
+		a = (a + 0x6d2b79f5) | 0;
+		let t = Math.imul(a ^ (a >>> 15), 1 | a);
+		t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+function weightedWeakPick(
+	counts: Record<number, number>,
+	rand: () => number,
+	excludeId?: number,
+): number {
 	const cats = ALL_CATEGORY_IDS.filter((c) => c !== excludeId);
 	const sorted = [...cats].sort((a, b) => (counts[a] ?? 0) - (counts[b] ?? 0));
 	const weighted = sorted.map((c, rank) => ({ c, w: Math.max(1, WEAK_BIAS_BASE - rank) }));
 	const total = weighted.reduce((s, x) => s + x.w, 0);
-	let r = Math.random() * total;
+	let r = rand() * total;
 	for (const x of weighted) {
 		r -= x.w;
 		if (r <= 0) return x.c;
@@ -204,11 +237,12 @@ function selectCategory(
 	prev: ChallengePrev | undefined,
 	weekStart: string,
 	consecutiveMissCount: number,
+	rand: () => number,
 ): { categoryId: number; mode: ChallengeProposalMode } {
 	const totalRecords = Object.values(counts).reduce((a, b) => a + b, 0);
 	if (totalRecords < MIN_RECORDS_FOR_ANALYSIS) {
 		return {
-			categoryId: ALL_CATEGORY_IDS[Math.floor(Math.random() * ALL_CATEGORY_IDS.length)] ?? 1,
+			categoryId: ALL_CATEGORY_IDS[Math.floor(rand() * ALL_CATEGORY_IDS.length)] ?? 1,
 			mode: 'explore',
 		};
 	}
@@ -218,10 +252,10 @@ function selectCategory(
 	if (weekIndexOf(weekStart) % EVERY_N_WEEKS_STRONG === 0) {
 		return { categoryId: strongestCategory(counts), mode: 'strength' };
 	}
-	let categoryId = weightedWeakPick(counts);
+	let categoryId = weightedWeakPick(counts, rand);
 	// 直前週と同一カテゴリは原則回避 (interleaving の連続ブロック防止)
 	if (prev != null && categoryId === prev.categoryId) {
-		categoryId = weightedWeakPick(counts, prev.categoryId);
+		categoryId = weightedWeakPick(counts, rand, prev.categoryId);
 	}
 	return { categoryId, mode: 'weakness' };
 }
@@ -259,12 +293,20 @@ export function computeProposal(
 	counts: Record<number, number>,
 	prev: ChallengePrev | undefined,
 	weekStart: string,
+	opts?: { childId?: number; skippedWeeks?: number },
 ): ChallengeProposal {
-	// 生成時点での「連続未達週数」(前週が未達なら前週の streak + 1、達成ならリセット)
+	// #3203 item2: childId 指定時は seed 化した決定的 RNG、未指定 (既存 test) は Math.random。
+	const rand = opts?.childId != null ? makeSeededRand(opts.childId, weekStart) : Math.random;
+	// #3203 item1: skippedWeeks = 直近生成週から今週までに challenge を生成しなかった (skip した) 週数。
+	// 週を skip する child = disengaging であり rescue (Bandura mastery、易しい得意 challenge) の本来対象。
+	// skip 週を miss として streak に加算し、跨いでも rescue を発火させる。
+	const skippedWeeks = Math.max(0, opts?.skippedWeeks ?? 0);
+	// 生成時点での「連続未達週数」(前週が未達なら前週の streak + 1、達成ならリセット) + skip 週 (disengagement)。
 	const prevMissed = prev != null && prev.status !== 'completed';
-	const consecutiveMissCount = prevMissed ? (prev?.consecutiveMissCount ?? 0) + 1 : 0;
+	const consecutiveMissCount =
+		(prevMissed ? (prev?.consecutiveMissCount ?? 0) + 1 : 0) + skippedWeeks;
 
-	const { categoryId, mode } = selectCategory(counts, prev, weekStart, consecutiveMissCount);
+	const { categoryId, mode } = selectCategory(counts, prev, weekStart, consecutiveMissCount, rand);
 	const targetCount = decideTarget(counts, prev, categoryId, mode);
 
 	const categoryName = CATEGORY_NAMES[categoryId] ?? '';
@@ -466,15 +508,23 @@ export async function getOrCreateWeeklyChildChallenge(
 	);
 	if (existing) return existing;
 
-	const lastWeekStart = getLastWeekStart(weekStart);
-	const prevRow = all.find(
-		(c) => c.sourceTemplateId === AUTO_WEEKLY_SOURCE && c.startDate === lastWeekStart,
-	);
+	// #3203 item1: 直近の生成済 auto challenge (lastWeekStart に限らず最新の prior 週) を prev に使い、
+	// その週から今週までの skip 週数を disengagement signal として rescue に反映する。
+	const priorAuto = all
+		.filter((c) => c.sourceTemplateId === AUTO_WEEKLY_SOURCE && c.startDate < weekStart)
+		.sort((a, b) => (a.startDate < b.startDate ? 1 : -1)); // 新しい順
+	const prevRow = priorAuto[0];
+	// prevRow が lastWeekStart なら skip 0。さらに過去なら間の週数を skip として数える。
+	const skippedWeeks = prevRow ? weeksBetween(prevRow.startDate, weekStart) - 1 : 0;
 	const counts = await aggregateCategoryCounts(childId, tenantId);
 	const proposal = computeProposal(
 		counts,
 		prevRow ? toProposalPrev(prevRow) : undefined,
 		weekStart,
+		{
+			childId,
+			skippedWeeks,
+		},
 	);
 
 	const targetConfig = JSON.stringify({

--- a/src/lib/server/services/child-challenge-service.ts
+++ b/src/lib/server/services/child-challenge-service.ts
@@ -298,7 +298,7 @@ export function computeProposal(
 	// #3203 item2: childId 指定時は seed 化した決定的 RNG、未指定 (既存 test) は Math.random。
 	const rand = opts?.childId != null ? makeSeededRand(opts.childId, weekStart) : Math.random;
 	// #3203 item1: skippedWeeks = 直近生成週から今週までに challenge を生成しなかった (skip した) 週数。
-	// 週を skip する child = disengaging であり rescue (Bandura mastery、易しい得意 challenge) の本来対象。
+	// 週を skip する child = disengaging であり rescue (易しい得意 challenge で成功体験を積ませる) の本来対象。
 	// skip 週を miss として streak に加算し、跨いでも rescue を発火させる。
 	const skippedWeeks = Math.max(0, opts?.skippedWeeks ?? 0);
 	// 生成時点での「連続未達週数」(前週が未達なら前週の streak + 1、達成ならリセット) + skip 週 (disengagement)。

--- a/tests/unit/services/child-challenge-service.test.ts
+++ b/tests/unit/services/child-challenge-service.test.ts
@@ -226,6 +226,51 @@ describe('computeProposal — 翌週適応 (Flow 3 分岐、#3194 / #3213 移設
 	});
 });
 
+describe('computeProposal — #3203 item1: skip 週 (disengagement) を rescue に反映', () => {
+	const WEAK_COUNTS = algoCounts({ 1: 8, 2: 6, 3: 4, 4: 2, 5: 0 });
+
+	it('前週完了でも 2 週 skip すれば streak=2 で rescue-strength 発火', () => {
+		// 完了後に 2 週 challenge 未生成 (skip) = disengagement → 跨いで rescue 対象にする
+		const prev = makePrev({ status: 'completed', consecutiveMissCount: 0 });
+		const p = computeProposal(WEAK_COUNTS, prev, WEEK_WEAKNESS, { skippedWeeks: 2 });
+		expect(p.consecutiveMissCount).toBe(2);
+		expect(p.mode).toBe('rescue-strength');
+	});
+
+	it('前週未達 + 1 週 skip で streak=2 (1 missed + 1 skipped) → rescue', () => {
+		const prev = makePrev({ status: 'expired', consecutiveMissCount: 0 });
+		const p = computeProposal(WEAK_COUNTS, prev, WEEK_WEAKNESS, { skippedWeeks: 1 });
+		expect(p.consecutiveMissCount).toBe(2);
+		expect(p.mode).toBe('rescue-strength');
+	});
+
+	it('skippedWeeks=0 (連続週) は従来挙動 (完了→streak 0、rescue なし)', () => {
+		const prev = makePrev({ status: 'completed', consecutiveMissCount: 0 });
+		const p = computeProposal(WEAK_COUNTS, prev, WEEK_WEAKNESS, { skippedWeeks: 0 });
+		expect(p.consecutiveMissCount).toBe(0);
+		expect(p.mode).not.toBe('rescue-strength');
+	});
+});
+
+describe('computeProposal — #3203 item2: childId+weekStart で seed 化し決定的', () => {
+	const WEAK_COUNTS = algoCounts({ 1: 8, 2: 6, 3: 4, 4: 2, 5: 0 });
+
+	it('同 childId・同週は常に同一カテゴリを返す (flip-flop なし)', () => {
+		const a = computeProposal(WEAK_COUNTS, undefined, WEEK_WEAKNESS, { childId: 42 });
+		const b = computeProposal(WEAK_COUNTS, undefined, WEEK_WEAKNESS, { childId: 42 });
+		const c = computeProposal(WEAK_COUNTS, undefined, WEEK_WEAKNESS, { childId: 42 });
+		expect(a.categoryId).toBe(b.categoryId);
+		expect(b.categoryId).toBe(c.categoryId);
+		expect(a.mode).toBe('weakness');
+	});
+
+	it('childId 未指定でも従来通り動作する (Math.random フォールバック、後方互換)', () => {
+		const p = computeProposal(WEAK_COUNTS, undefined, WEEK_WEAKNESS);
+		expect(p.mode).toBe('weakness');
+		expect([1, 2, 3, 4, 5]).toContain(p.categoryId);
+	});
+});
+
 describe('getOrCreateWeeklyChildChallenge (#3195 アプリ自動生成)', () => {
 	it('当週分が無ければ child_challenges を自動生成する (targetConfig に metric/categoryId/genMode 内包)', async () => {
 		mockFindByChildId.mockResolvedValue([]); // 既存なし


### PR DESCRIPTION
## 顧客価値・目的

週次自動チャレンジの動機付け精度を高める。週を skip する子 (= disengaging) は本来 rescue (易しい得意チャレンジで成功体験) の対象なのに、従来は skip で miss streak がリセットされ rescue が発火しなかった。本 PR で skip 週を disengagement として streak に反映し、跨いでも rescue を発火させる。加えてカテゴリ抽選を seed 化し決定性・親への説明性・テスト容易性を得る。

## 関連 Issue

closes #3203

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (item1) | 週 skip を disengagement として rescue に反映 | `npx vitest run tests/unit/services/child-challenge-service.test.ts` | HEAD `` / describe "#3203 item1: skip 週 (disengagement) を rescue に反映" 3 ケース (完了後 2 週 skip→rescue / 未達+1 skip→rescue / skip 0 は従来) |
| AC2 (item2) | カテゴリ抽選を childId+weekStart で seed 化し決定的 | 同上 | HEAD `` / describe "#3203 item2" 同 childId・同週は常に同一カテゴリ + childId 未指定の後方互換。makeSeededRand (mulberry32) |
| AC3 (item3) | sqlite tenant-filter 非対称の根拠明示 | grep | HEAD `` / sqlite/child-challenge-repo.ts 冒頭コメント (tenant_id 列なし・single-tenant-per-DB で exploit 不能・ADR-0010 過剰防衛回避) |
| AC4 | 既存 algorithm 回帰なし | 同上 | HEAD `` / 43 passed (旧 38 + 新 5) |

item3 は「列追加なしには filter 実装不能 + 追加は exploit 不可シナリオへの過剰防衛 (ADR-0010)」のためコメント明示で確定 (QM 裁定踏襲)。

## 変更タイプ

- [x] バグ修正 (fix)

## 影響範囲・変更コンポーネント

- `src/lib/server/services/child-challenge-service.ts` — seeded RNG + skippedWeeks + weeksBetween + computeProposal opts + 生成 callsite で直近 prior 週採用
- `src/lib/server/db/sqlite/child-challenge-repo.ts` — tenant 非対称の根拠コメント
- `tests/unit/services/child-challenge-service.test.ts` — skip→rescue / seed 決定性 テスト追加

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/services/child-challenge-service.test.ts` <!-- PASS --> → 43 passed
- `npx svelte-check --threshold error` <!-- PASS --> → 0 ERRORS
- `npx biome check` <!-- PASS --> → clean

## スクリーンショット / ビジュアルデモ

サーバー側生成アルゴリズム + テストの変更で UI 影響なし (生成される challenge 文言は不変)。SS 対象外。

## コード品質セルフレビュー (#1481)

- computeProposal の新規 param は optional で既存 callsite / test 完全後方互換
- PRNG は決定的 (mulberry32 + FNV-1a 風 hash)、Math.random 依存を seed 化

## 横展開・影響波及チェック

- computeProposal の全 callsite (生成 service + tests 多数) を確認、optional param で非破壊
- dynamodb child-challenge-repo は元から tenant-scoped (PK に tenant)、sqlite 側のみ非対称の根拠明示

## レビュー依頼事項・破壊的変更

破壊的変更なし。skip 週検出は直近 prior 週採用に変更したが、連続週 (skip 0) では従来と同一挙動。

## 配布済み env / secret (ADR-0006)

env / secret の追加なし。

## Ready for Review チェックリスト

- [x] テスト追加 + green
- [x] AC 検証マップ記載
- [x] 後方互換確認

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
