### PR TITLE
fix: #3181 checklist copy の quota TOCTOU 緩和 + drop件数明示 + copy audit

### DIFF
--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -624,33 +624,54 @@ export const actions: Actions = {
 			if (sourceTemplateIds.length === 0) {
 				return { copiedFromChild: true, added: 0 };
 			}
-			// #3098 QM BLOCK 対応: per-iteration の quota enforcement。
-			// 旧実装は「ループ前に 1 回 limit.allowed を見るだけ」で、5 件の source を copy すると
-			// free プラン target の per-child 上限 (maxChecklistTemplates) を超過 (over-grant) していた。
-			// limit.max === null (無制限プラン) → 全件 copy。
-			// 有限プラン → 残スロット (max - current) 件まで copy し、超過分は skip して partial-success を返す。
-			// distributeToChildren は既配信を skip し「実際に追加した childId」を返すため、
-			// inserted.length (= 0 or 1) を残スロットから消費する。
+			// #3098 QM BLOCK 対応 + #3181 item1 (quota TOCTOU 緩和): per-iteration の quota enforcement。
+			// 旧実装は「ループ前に 1 回 limit を読むだけ」で、(a) 5 件の source を copy すると free プラン
+			// target の per-child 上限 (maxChecklistTemplates) を超過 (over-grant) し、(b) 並行 POST 2 本が
+			// 同じ snapshot current を読むと app 横断で上限を超えて over-grant し得た (TOCTOU)。
+			// #3181 item1: snapshot 算術 (max - 初回 current) でなく、各 grant 直前に checkChecklistTemplateLimit を
+			// 再評価し live count で判定する。SQLite (NUC、同期 better-sqlite3) では直前 insert が即反映され
+			// race window が消える。DynamoDB でも once-read snapshot より window が大幅に縮小する。
+			// limit.max === null (無制限プラン) → 全件 copy。distributeToChildren は既配信 skip + 実追加 childId を返す。
 			let added = 0;
 			let limitReached = false;
 			for (const templateId of sourceTemplateIds) {
-				if (limit.max !== null && added >= limit.max - limit.current) {
-					// 残スロットを使い切った。残りの source は target 上限超過になるため copy しない。
-					limitReached = true;
-					break;
+				if (limit.max !== null) {
+					const live = await checkChecklistTemplateLimit(tenantId, licenseStatus, targetChildId);
+					if (!live.allowed) {
+						// live count が上限到達。残りの source は target 上限超過になるため copy しない。
+						limitReached = true;
+						break;
+					}
 				}
 				const inserted = await distributeToChildren(templateId, [targetChildId], tenantId);
 				added += inserted.length;
 			}
+			// #3181 item3 (success audit、defense-in-depth): 誰が誰の templateId を copy したかを
+			// 構造化 log に残し incident traceability を確保する (汎用 audit log でなく最小限の info、ADR-0010)。
+			const actorUserId = locals.identity?.type === 'cognito' ? locals.identity.userId : undefined;
+			logger.info('[admin/checklists] 別の子から checklist を copy', {
+				context: {
+					tenantId,
+					actorUserId,
+					sourceChildId,
+					targetChildId,
+					requestedTemplateIds: sourceTemplateIds,
+					added,
+					limitReached,
+				},
+			});
+			// #3181 item2 (partial-success の drop 件数明示): drop された件数を message + 戻り値に出す。
+			const dropped = sourceTemplateIds.length - added;
 			if (limitReached) {
 				return {
 					copiedFromChild: true,
 					added,
+					dropped,
 					limitReached: true,
-					message: `${added} 件取り込みました。フリープランの上限に達したため残りは取り込めませんでした。スタンダード以上で無制限。`,
+					message: `${added} 件取り込みました。フリープランの上限に達したため ${dropped} 件は取り込めませんでした。スタンダード以上で無制限。`,
 				};
 			}
-			return { copiedFromChild: true, added };
+			return { copiedFromChild: true, added, dropped };
 		} catch (e) {
 			logger.error('[admin/checklists] 別の子からの copy 失敗', {
 				error: e instanceof Error ? e.message : String(e),

--- a/tests/unit/routes/admin-checklists-copy-distribution.test.ts
+++ b/tests/unit/routes/admin-checklists-copy-distribution.test.ts
@@ -115,12 +115,27 @@ function createEvent(
 	} as unknown as Parameters<NonNullable<typeof actions.copyDistributionFromChild>>[0];
 }
 
+// #3181 item1 (TOCTOU 緩和): 実装は各 grant 直前に checkChecklistTemplateLimit を live で再評価する。
+// テスト mock も「target child の per-child テンプレ数が insert ごとに増える」 live DB を模す
+// (静的 count では re-count 化した実装の挙動を検証できない = mock fidelity)。
+let liveTargetCount = 0;
+
+/** target child の現在のテンプレ数 (= per-child quota の current) を設定する。 */
+function setTargetInitialCount(n: number) {
+	liveTargetCount = n;
+	mockRepoFindTemplatesByChild.mockImplementation(async () =>
+		Array.from({ length: liveTargetCount }, (_unused, i) => ({ id: 1000 + i })),
+	);
+}
+
 /** distributeToChildren を「単一 target child・既配信 skip」の実挙動で stub する。
- * assignedTemplateIds に含まれる templateId は inserted 0 件 (skip)、それ以外は呼ばれた childIds をそのまま返す。 */
+ * assignedTemplateIds に含まれる templateId は inserted 0 件 (skip)、それ以外は呼ばれた childIds を返す。
+ * 実 insert 時は liveTargetCount を +1 し、後続の checkChecklistTemplateLimit re-count に反映させる。 */
 function stubDistribute(assignedTemplateIds: Set<number>) {
 	mockDistributeToChildren.mockImplementation(
 		async (templateId: number, childIds: readonly number[]) => {
 			if (assignedTemplateIds.has(templateId)) return [];
+			liveTargetCount += 1; // live DB に 1 件追加された
 			return [...childIds]; // = [targetChildId]
 		},
 	);
@@ -130,6 +145,7 @@ const TENANT_CHILDREN = [{ id: 1 }, { id: 2 }, { id: 3 }];
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	liveTargetCount = 0;
 	mockGetAllChildren.mockResolvedValue(TENANT_CHILDREN);
 });
 
@@ -137,7 +153,7 @@ describe('POST /admin/checklists?/copyDistributionFromChild — plan-limit over-
 	it('Free target 2/3 + source 5 件 distinct → 1 件のみ copy (3/3)、残り skip / over-grant なし', async () => {
 		mockResolveFullPlanTier.mockResolvedValue('free');
 		// target child(2) は現在 2 件 (2/3)
-		mockRepoFindTemplatesByChild.mockResolvedValue([{ id: 100 }, { id: 101 }]);
+		setTargetInitialCount(2);
 		// source child(1) は 5 件配信済 (target には未配信なので distribute で全部 insert 候補)
 		mockFindAssignmentsByChild.mockResolvedValue([
 			{ templateId: 200 },
@@ -150,12 +166,21 @@ describe('POST /admin/checklists?/copyDistributionFromChild — plan-limit over-
 
 		const result = (await actions.copyDistributionFromChild!(
 			createEvent({ sourceChildId: '1', targetChildId: '2' }),
-		)) as { copiedFromChild: boolean; added: number; limitReached?: boolean; message?: string };
+		)) as {
+			copiedFromChild: boolean;
+			added: number;
+			dropped?: number;
+			limitReached?: boolean;
+			message?: string;
+		};
 
 		// 残スロット = 3 - 2 = 1 件のみ copy
 		expect(result.added).toBe(1);
 		expect(result.limitReached).toBe(true);
 		expect(result.message).toContain('1 件取り込みました');
+		// #3181 item2: drop 件数 (5 - 1 = 4) を明示
+		expect(result.dropped).toBe(4);
+		expect(result.message).toContain('4 件は取り込めませんでした');
 		// distributeToChildren は残スロット 1 件で打ち切り (2 回目以降を呼ばない = over-grant 防止)
 		expect(mockDistributeToChildren).toHaveBeenCalledTimes(1);
 		// per-child カウント (current 2 + added 1 = 3) が max(3) を超えない
@@ -165,7 +190,7 @@ describe('POST /admin/checklists?/copyDistributionFromChild — plan-limit over-
 
 	it('Free target 既に 3/3 到達 → 1 件も copy せず 403 + upgradeRequired', async () => {
 		mockResolveFullPlanTier.mockResolvedValue('free');
-		mockRepoFindTemplatesByChild.mockResolvedValue([{ id: 100 }, { id: 101 }, { id: 102 }]); // 3/3
+		setTargetInitialCount(3); // 3/3
 		mockFindAssignmentsByChild.mockResolvedValue([{ templateId: 200 }]);
 
 		const result = (await actions.copyDistributionFromChild!(
@@ -202,7 +227,7 @@ describe('POST /admin/checklists?/copyDistributionFromChild — plan-limit over-
 
 	it('Free target 0/3 + source の一部が既配信 → 既配信 skip 分を残スロットから消費しない', async () => {
 		mockResolveFullPlanTier.mockResolvedValue('free');
-		mockRepoFindTemplatesByChild.mockResolvedValue([]); // 0/3 → 残スロット 3
+		setTargetInitialCount(0); // 0/3 → 残スロット 3
 		mockFindAssignmentsByChild.mockResolvedValue([
 			{ templateId: 200 }, // 既配信 → insert 0
 			{ templateId: 201 }, // 新規 → insert 1
@@ -227,7 +252,7 @@ describe('POST /admin/checklists?/copyDistributionFromChild — plan-limit over-
 
 	it('source に配信なし → added 0 (early return)', async () => {
 		mockResolveFullPlanTier.mockResolvedValue('free');
-		mockRepoFindTemplatesByChild.mockResolvedValue([]);
+		setTargetInitialCount(0);
 		mockFindAssignmentsByChild.mockResolvedValue([]);
 
 		const result = (await actions.copyDistributionFromChild!(


### PR DESCRIPTION
## 顧客価値・目的

「別の子から取り込む」checklist copy の品質を高める。(item1) 並行リクエストで free プラン上限を超えて over-grant する TOCTOU を緩和し、(item2) 部分成功時に取り込めなかった件数を明示してユーザーの不安を解消し、(item3) 誰が誰のテンプレを copy したかを構造化ログに残し incident traceability を確保する。

## 関連 Issue

closes #3181

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (item1) | quota を各 grant 直前に live 再評価し snapshot TOCTOU を緩和 | `npx vitest run tests/unit/routes/admin-checklists-copy-distribution.test.ts` | HEAD `1001e4ff8` / checkChecklistTemplateLimit を loop 内で再評価。test を live count stateful mock に改修し 7 passed |
| AC2 (item2) | partial-success の drop 件数を message + 戻り値に明示 | 同上 | HEAD `1001e4ff8` / dropped = source - added、message に drop 件数 (例 4 件) を assert |
| AC3 (item3) | copy success を構造化 logger.info に記録 (actor/source/target/templateIds) | grep | HEAD `1001e4ff8` / +page.server.ts copyDistributionFromChild の logger.info |

## 変更タイプ

- [x] バグ修正 (fix)

## 影響範囲・変更コンポーネント

- `src/routes/(parent)/admin/checklists/+page.server.ts` — copyDistributionFromChild に live 再評価 + drop 件数 + audit log
- `tests/unit/routes/admin-checklists-copy-distribution.test.ts` — live count stateful mock + drop 件数 assertion

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/routes/admin-checklists-copy-distribution.test.ts` <!-- PASS --> → 7 passed
- `npx svelte-check --threshold error` <!-- PASS --> → 0 ERRORS
- `npx biome check` <!-- PASS --> → clean

## スクリーンショット / ビジュアルデモ

server action のロジック変更 (message 文言に drop 件数追加)。UI レイアウト不変、message は既存 toast 経路で表示。SS 対象外。

## コード品質セルフレビュー (#1481)

- live 再評価は既存 checkChecklistTemplateLimit を再利用 (二重実装なし)
- audit log は最小限の構造化 info (汎用 audit log でなく、ADR-0010)

## 横展開・影響波及チェック

- 同型 snapshot→loop pattern の createTemplate / activities / rewards quota は範囲外だが、本 PR は copy 経路の TOCTOU を live 再評価で緩和
- SQLite (同期 better-sqlite3) では直前 insert が即反映され race window 消失

## レビュー依頼事項・破壊的変更

破壊的変更なし。message に drop 件数を追記、戻り値に dropped を追加 (既存 added/limitReached 維持)。

## 配布済み env / secret (ADR-0006)

env / secret の追加なし。

## Ready for Review チェックリスト

- [x] テスト追加 + green
- [x] AC 検証マップ記載
- [x] live count fidelity 確認

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
