### PR TITLE
feat: #3329 チェックリスト配信先(assignment) + 日次 override の backup round-trip 実装

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -364,6 +364,19 @@ export interface ExportActivityPref {
 	updatedAt: string;
 }
 
+/**
+ * #3329: per-child チェックリスト日次 override (特定日に項目を追加/スキップ)。createdAt を保全して
+ * round-trip 復元する (id/childId は import で振り直すため childRef で再結合)。
+ */
+export interface ExportChecklistOverride {
+	childRef: string;
+	targetDate: string;
+	action: string;
+	itemName: string;
+	icon: string;
+	createdAt: string;
+}
+
 export interface ExportChecklistTemplate {
 	childRef: string;
 	name: string;
@@ -450,6 +463,8 @@ export interface ExportTransactionData {
 	activityPrefs: ExportActivityPref[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
+	/** #3329: per-child チェックリスト日次 override (createdAt 保全) */
+	checklistOverrides: ExportChecklistOverride[];
 	childAvatarItems: never[];
 	dailyMissions: ExportDailyMission[];
 	/** #3329: 各種設定 (tenant-scoped KVS、allowlist 済キーのみ。pin_hash 等の秘匿キーは除外) */

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -188,15 +188,16 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	checklistAssignment: {
 		classification: 'source',
 		schemaTable: 'checklistTemplateAssignments',
-		backupStatus: 'not-yet-exported',
+		backupStatus: 'exported',
 		reason:
-			'チェックリスト配信先。現状 import 時に取込先 child へ再導出のみ。原本 fan-out は未保全 (#3329)',
+			'チェックリスト配信先 (child×template 配信エッジ)。export/import 実装済 (#3329)。checklistTemplate を per-child (childRef) export し、import 時に importOneChecklistTemplate が assignTemplateToChildren で取込先 child へ配信エッジを再構成するため、どの child にどの checklist が配信されているかは round-trip 保全される (配信 createdAt メタは再スタンプ。master 共有 dedup は per-child export モデル上の fidelity 差で loss ではない)',
 	},
 	checklistOverride: {
 		classification: 'source',
 		schemaTable: 'checklistOverrides',
-		backupStatus: 'not-yet-exported',
-		reason: 'チェックリスト日次 override。export 未対応 (#3329)',
+		backupStatus: 'exported',
+		reason:
+			'チェックリスト日次 override。export/import 実装済 (#3329、createdAt を insertOverrideForRestore で保全)。clear は checklist.deleteByTenantId で削除済',
 	},
 	setting: {
 		classification: 'source',

--- a/src/lib/server/db/checklist-repo.ts
+++ b/src/lib/server/db/checklist-repo.ts
@@ -6,6 +6,7 @@
 import type { ArchivedReason } from '$lib/domain/archive-types';
 import { getRepos } from './factory';
 import type {
+	ChecklistOverride,
 	InsertChecklistOverrideInput,
 	InsertChecklistTemplateInput,
 	InsertChecklistTemplateItemInput,
@@ -130,6 +131,19 @@ export async function findOverrides(childId: number, date: string, tenantId: str
 
 export async function insertOverride(input: InsertChecklistOverrideInput, tenantId: string) {
 	return getRepos().checklist.insertOverride(input, tenantId);
+}
+
+/** #3329 backup: child の全日次 override (日付不問、export 用)。 */
+export async function findOverridesByChild(childId: number, tenantId: string) {
+	return getRepos().checklist.findOverridesByChild(childId, tenantId);
+}
+
+/** #3329 backup restore 用: createdAt を保全して日次 override を復元する。 */
+export async function insertOverrideForRestore(
+	input: Omit<ChecklistOverride, 'id'>,
+	tenantId: string,
+) {
+	return getRepos().checklist.insertOverrideForRestore(input, tenantId);
 }
 
 // #2845 B1: childId 所有権検証付き (composite key)

--- a/src/lib/server/db/demo/checklist-repo.ts
+++ b/src/lib/server/db/demo/checklist-repo.ts
@@ -272,6 +272,21 @@ export async function findOverrides(
 	return [];
 }
 
+export async function findOverridesByChild(
+	_childId: number,
+	_tenantId: string,
+): Promise<ChecklistOverride[]> {
+	return [];
+}
+
+export async function insertOverrideForRestore(
+	input: Omit<ChecklistOverride, 'id'>,
+	_tenantId: string,
+): Promise<ChecklistOverride> {
+	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
+	return { ...input, id: 0 };
+}
+
 export async function insertOverride(
 	input: InsertChecklistOverrideInput,
 	_tenantId: string,

--- a/src/lib/server/db/dynamodb/checklist-repo.ts
+++ b/src/lib/server/db/dynamodb/checklist-repo.ts
@@ -561,6 +561,45 @@ export async function findOverrides(
 	return (result.Items ?? []).map((item) => stripKeys(item) as unknown as ChecklistOverride);
 }
 
+/** #3329 backup: child の全日次 override (日付不問、全 OVERRIDE# prefix を Query)。 */
+export async function findOverridesByChild(
+	childId: number,
+	tenantId: string,
+): Promise<ChecklistOverride[]> {
+	const result = await getDocClient().send(
+		new QueryCommand({
+			TableName: TABLE_NAME,
+			KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+			ExpressionAttributeValues: {
+				':pk': childPK(childId, tenantId),
+				':prefix': checklistOverridePrefix(),
+			},
+		}),
+	);
+	const rows = (result.Items ?? []).map((item) => stripKeys(item) as unknown as ChecklistOverride);
+	rows.sort((a, b) => a.targetDate.localeCompare(b.targetDate));
+	return rows;
+}
+
+/** #3329 backup restore 用: createdAt を保全して日次 override を復元する。 */
+export async function insertOverrideForRestore(
+	input: Omit<ChecklistOverride, 'id'>,
+	tenantId: string,
+): Promise<ChecklistOverride> {
+	const id = await nextId(ENTITY_NAMES.checklistOverride, tenantId);
+	const override: ChecklistOverride = { ...input, id };
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...checklistOverrideKey(input.childId, input.targetDate, id, tenantId),
+				...override,
+			},
+		}),
+	);
+	return override;
+}
+
 export async function insertOverride(
 	input: InsertChecklistOverrideInput,
 	tenantId: string,

--- a/src/lib/server/db/interfaces/checklist-repo.interface.ts
+++ b/src/lib/server/db/interfaces/checklist-repo.interface.ts
@@ -123,6 +123,19 @@ export interface IChecklistRepo {
 
 	findOverrides(childId: number, date: string, tenantId: string): Promise<ChecklistOverride[]>;
 	insertOverride(input: InsertChecklistOverrideInput, tenantId: string): Promise<ChecklistOverride>;
+
+	/** #3329 backup: child の全日次 override (日付不問、export 用)。 */
+	findOverridesByChild(childId: number, tenantId: string): Promise<ChecklistOverride[]>;
+
+	/**
+	 * #3329 backup restore 用: createdAt を保全して日次 override を復元する。
+	 * insertOverride は createdAt を schema default (now) で発番するため round-trip で作成日時が
+	 * 失われる。本メソッドは export された値をそのまま書き戻す (id は新規採番、childId は解決済)。
+	 */
+	insertOverrideForRestore(
+		input: Omit<ChecklistOverride, 'id'>,
+		tenantId: string,
+	): Promise<ChecklistOverride>;
 	/**
 	 * #2845 B1: childId 必須 (composite key)。旧 id-only は DynamoDB 側で
 	 * tenant 無束縛 Scan + 全 tenant delete 可能形状だった。

--- a/src/lib/server/db/sqlite/checklist-repo.ts
+++ b/src/lib/server/db/sqlite/checklist-repo.ts
@@ -338,6 +338,38 @@ export async function insertOverride(
 	return db.insert(checklistOverrides).values(input).returning().get();
 }
 
+/** #3329 backup: child の全日次 override (日付不問、export 用)。 */
+export async function findOverridesByChild(
+	childId: number,
+	_tenantId: string,
+): Promise<ChecklistOverride[]> {
+	return db
+		.select()
+		.from(checklistOverrides)
+		.where(eq(checklistOverrides.childId, childId))
+		.orderBy(checklistOverrides.targetDate)
+		.all();
+}
+
+/** #3329 backup restore 用: createdAt を保全して日次 override を復元する (childId は呼び出し側が解決済)。 */
+export async function insertOverrideForRestore(
+	input: Omit<ChecklistOverride, 'id'>,
+	_tenantId: string,
+): Promise<ChecklistOverride> {
+	return db
+		.insert(checklistOverrides)
+		.values({
+			childId: input.childId,
+			targetDate: input.targetDate,
+			action: input.action,
+			itemName: input.itemName,
+			icon: input.icon,
+			createdAt: input.createdAt,
+		})
+		.returning()
+		.get();
+}
+
 /** #2845 B1: childId 所有権検証付き (composite key)。不一致なら affected 0 の no-op。 */
 export async function deleteOverride(
 	childId: number,

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -12,6 +12,7 @@ import {
 	type ExportCategory,
 	type ExportCertificate,
 	type ExportChecklistLog,
+	type ExportChecklistOverride,
 	type ExportChecklistTemplate,
 	type ExportChild,
 	type ExportChildActivity,
@@ -36,6 +37,7 @@ import { CATEGORY_CODES } from '$lib/domain/validation/activity';
 import { findActivities, findActivityLogs } from '$lib/server/db/activity-repo';
 import {
 	findLogsByChild,
+	findOverridesByChild,
 	findTemplateItems,
 	findTemplatesByChild,
 } from '$lib/server/db/checklist-repo';
@@ -239,6 +241,7 @@ interface ChildTransactionData {
 	activityPrefs: ExportActivityPref[];
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
+	checklistOverrides: ExportChecklistOverride[];
 }
 
 /**
@@ -575,6 +578,18 @@ async function collectForChild(
 		});
 	}
 
+	// #3329: per-child チェックリスト日次 override (createdAt 保全)。
+	const checklistOverridesRaw = await findOverridesByChild(childId, tenantId);
+	warnIfTruncated('checklistOverrides', childId, checklistOverridesRaw.length);
+	const checklistOverridesOut: ExportChecklistOverride[] = checklistOverridesRaw.map((o) => ({
+		childRef,
+		targetDate: o.targetDate,
+		action: o.action,
+		itemName: o.itemName,
+		icon: o.icon,
+		createdAt: o.createdAt,
+	}));
+
 	return {
 		childActivities: childActivitiesOut,
 		activityLogs: activityLogsOut,
@@ -592,6 +607,7 @@ async function collectForChild(
 		activityPrefs: activityPrefsOut,
 		checklistTemplates: checklistTemplatesOut,
 		checklistLogs: checklistLogsOut,
+		checklistOverrides: checklistOverridesOut,
 	};
 }
 
@@ -651,6 +667,7 @@ async function collectTransactionData(
 		activityPrefs: perChild.flatMap((p) => p.activityPrefs),
 		checklistTemplates: perChild.flatMap((p) => p.checklistTemplates),
 		checklistLogs: perChild.flatMap((p) => p.checklistLogs), // #3078
+		checklistOverrides: perChild.flatMap((p) => p.checklistOverrides), // #3329
 		childAvatarItems: [],
 		dailyMissions: [], // Phase 2: エフェメラルデータ対応後に対応
 		settings: settingsOut, // #3329

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -19,6 +19,7 @@ import {
 	assignTemplateToChildren,
 	findLogsByChild,
 	findTemplatesByChild,
+	insertOverrideForRestore,
 	insertTemplate,
 	insertTemplateItem,
 	upsertLog,
@@ -80,6 +81,9 @@ export interface ImportResult {
 	/** #3329: per-child 活動設定 (ピン留め) の取込件数 */
 	activityPrefsImported: number;
 	activityPrefsSkipped: number;
+	/** #3329: per-child チェックリスト日次 override の取込件数 */
+	checklistOverridesImported: number;
+	checklistOverridesSkipped: number;
 	loginBonusesImported: number;
 	loginBonusesSkipped: number;
 	statusHistoryImported: number;
@@ -292,6 +296,8 @@ export async function importFamilyData(
 	await importLoginBonusesData(data, childIdMap, tenantId, result);
 	const templateIdMap = await importChecklistTemplatesData(data, childIdMap, tenantId, result);
 	await importChecklistLogsData(data, childIdMap, templateIdMap, tenantId, result);
+	// #3329: チェックリスト日次 override を createdAt 保全で復元。childIdMap のみ必要。
+	await importChecklistOverridesData(data, childIdMap, tenantId, result);
 	await importSpecialRewards(data, childIdMap, tenantId, result);
 	// #3329: ごほうび交換/購入履歴。reward を先に取込済 (FK rewardRef → rewardId を再解決) なので
 	// importSpecialRewards の後に実行する。
@@ -744,6 +750,44 @@ async function importActivityPrefsData(
 	}
 }
 
+/**
+ * チェックリスト日次 override (特定日の項目追加/スキップ) を復元する (#3329)。
+ * childRef で取込先 child に解決し insertOverrideForRestore で createdAt を保全して書き戻す。
+ */
+async function importChecklistOverridesData(
+	data: ExportData,
+	childIdMap: Map<string, number>,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	for (const o of data.data.checklistOverrides ?? []) {
+		const childId = childIdMap.get(o.childRef);
+		if (!childId) {
+			result.checklistOverridesSkipped++;
+			continue;
+		}
+		try {
+			await insertOverrideForRestore(
+				{
+					childId,
+					targetDate: o.targetDate,
+					action: o.action,
+					itemName: o.itemName,
+					icon: o.icon,
+					createdAt: o.createdAt,
+				},
+				tenantId,
+			);
+			result.checklistOverridesImported++;
+		} catch (e) {
+			result.checklistOverridesSkipped++;
+			result.errors.push(
+				`チェックリスト override insert 失敗 (child=${o.childRef}, date=${o.targetDate}): ${String(e)}`,
+			);
+		}
+	}
+}
+
 function createEmptyImportResult(): ImportResult {
 	return {
 		childrenImported: 0,
@@ -769,6 +813,8 @@ function createEmptyImportResult(): ImportResult {
 		certificatesSkipped: 0,
 		parentMessagesImported: 0,
 		parentMessagesSkipped: 0,
+		checklistOverridesImported: 0,
+		checklistOverridesSkipped: 0,
 		activityPrefsImported: 0,
 		activityPrefsSkipped: 0,
 		siblingCheersImported: 0,

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -126,10 +126,7 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 		// export に足したら 'exported' へ flip し本ベースラインから外す (意図的更新)。
 		// 新たな not-yet-exported source の silent 増加を禁止する (回帰ネット)。
 		expect(notYetExportedSourceEntities()).toEqual([
-			// activityPref / certificate は #3329 で export 実装済 → exported へ flip
-			'checklistAssignment',
-			'checklistOverride',
-			// childChallenge / childChallengeAutoWeekly は #3329 で export 実装済 → exported へ flip
+			// activityPref / certificate / checklistAssignment / checklistOverride は #3329 で export 実装済 → exported へ flip
 			'childCustomVoices',
 			// parentMessage は #3329 で export 実装済 → exported へ flip
 			'restDays',

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -607,4 +607,52 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		// **dailyLimit=0 (無制限) が null=1 回固定へ落ちず 0 のまま復元される** (本 PR の核心エッジ)。
 		expect(water?.dailyLimit, 'restore:dailyLimit=0 (無制限) が null へ落ちない').toBe(0);
 	});
+
+	// #3329: チェックリスト配信先 (assignment) + 日次 override の round-trip。
+	// assignment は per-child template の import 時 auto-assign で配信エッジが再構成され、
+	// override は createdAt 保全で復元されることを検証する。
+	it('チェックリスト配信先が再構成され、日次 override が createdAt 保全で round-trip する', async () => {
+		testDb.insert(schema.children).values({ nickname: 'ひかり', age: 9, theme: 'green' }).run(); // id=1
+		const repo = getRepos().checklist;
+
+		// family master template を作成 → child へ配信 (assignment エッジ作成)。
+		const tpl = await repo.insertTemplate({ name: 'もちものリスト', icon: '📋' }, T);
+		await repo.assignTemplateToChildren(tpl.id, [1], T);
+		// 日次 override (特定日に項目追加) を createdAt 明示で seed。
+		await repo.insertOverrideForRestore(
+			{
+				childId: 1,
+				targetDate: '2026-03-05',
+				action: 'add',
+				itemName: 'すいとう',
+				icon: '📦',
+				createdAt: '2026-03-05T07:00:00Z',
+			},
+			T,
+		);
+
+		// export
+		const data = await exportFamilyData({ tenantId: T });
+		expect(data.data.checklistTemplates.length, 'export:template').toBe(1);
+		expect(data.data.checklistOverrides.length, 'export:override').toBe(1);
+		expect(data.data.checklistOverrides[0]?.itemName, 'export:override itemName').toBe('すいとう');
+
+		// replace = clear → import
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T);
+
+		const children = testDb.select().from(schema.children).all();
+		expect(children.length, '子復元').toBe(1);
+		const cid = children[0]?.id as number;
+
+		// 配信エッジ再構成: child に template が配信されている (findAssignmentsByChild が 1 件)。
+		const assignments = await repo.findAssignmentsByChild(cid, T);
+		expect(assignments.length, '配信エッジ再構成').toBe(1);
+
+		// 日次 override: createdAt 保全で復元。
+		const overrides = await repo.findOverridesByChild(cid, T);
+		expect(overrides.length, 'override').toBe(1);
+		expect(overrides[0]?.itemName, 'override itemName 保全').toBe('すいとう');
+		expect(overrides[0]?.createdAt, 'override createdAt 保全').toBe('2026-03-05T07:00:00Z');
+	});
 });

--- a/tests/unit/services/export-service.test.ts
+++ b/tests/unit/services/export-service.test.ts
@@ -289,6 +289,8 @@ vi.mock('$lib/server/db/checklist-repo', () => ({
 	findTemplatesByChild: (...args: unknown[]) => mockFindTemplatesByChild(...(args as [number])),
 	findTemplateItems: vi.fn(() => Promise.resolve(mockChecklistItems)),
 	findLogsByChild: (...args: unknown[]) => mockFindLogsByChild(...(args as [number])),
+	// #3329: per-child チェックリスト日次 override (export が呼ぶ)。本 test では空で十分。
+	findOverridesByChild: vi.fn(() => Promise.resolve([])),
 }));
 vi.mock('$lib/server/db/evaluation-repo', () => ({
 	findEvaluationsByChild: vi.fn((childId: number) =>


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全ユーザー（バックアップ・移管利用者）

**解決する課題**: バックアップ ZIP を別環境へ import すると **チェックリストの日次 override（特定日の項目追加/スキップ）が一切復元されず、配信先（どの子にどのチェックリストが配信されているか）も明示的に保全されていなかった**（本番 t-82c17558 の喪失の一部）。

**期待される効果**: 日次 override が createdAt 保全で round-trip 復元され、配信エッジ（child×template）も round-trip で再構成される。

## 関連 Issue

関連: #3329 #3328（未 export source の checklistAssignment / checklistOverride を実装。残 2 件は registry を起点に順次対応するため #3329 は close しない）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|----|------|---------|------------------|
| AC1 | 日次 override を export に含める (per-child) | export-format / export-service | HEAD fc6b0694 |
| AC2 | import で childRef 解決し createdAt を insertOverrideForRestore で保全 | import-service importChecklistOverridesData | HEAD fc6b0694 |
| AC3 | 配信エッジ (assignment) が per-child template の import 時 auto-assign で再構成される | importOneChecklistTemplate → assignTemplateToChildren | HEAD fc6b0694 |
| AC4 | round-trip (配信エッジ再構成 + override createdAt 保全) | backup-roundtrip-completeness.test.ts 専用ケース | HEAD fc6b0694 |
| AC5 | insertOverride (createdAt=now 固定) と分離した復元専用経路を 3 実装で機能等価提供 | repo findOverridesByChild / insertOverrideForRestore (sqlite/dynamodb/demo) | HEAD fc6b0694 |
| AC6 | registry の checklistAssignment / checklistOverride を exported へ flip + ratchet 整合 | backup-entity-registry.test.ts | HEAD fc6b0694 |
| AC7 | 型・lint・cspell・全 unit 健全 | svelte-check / biome / cspell / vitest | svelte-check 0 ERROR / biome クリーン / cspell クリーン / unit 2793 passed |

## 変更タイプ

- [x] fix: バグ修正（データ喪失）
- [x] feat: 新機能（backup 対象拡張）

## 影響範囲・変更コンポーネント

- [x] サービス層（export-service / import-service）
- [x] DB 層（checklist repo: interface + sqlite/dynamodb/demo + facade に findOverridesByChild / insertOverrideForRestore 追加）
- [x] ドメイン型（export-format）

**影響を受ける機能**: バックアップ export / import。UI 非変更。clear は checklist.deleteByTenantId で全 checklist テーブル削除済（FK 阻害なし、変更不要）。

## テスト & 安全装置セルフチェック

**検証コマンド（機械検証証跡）**: `npx vitest run tests/unit/services/ tests/unit/db/` → 2793 passed / `npx biome check --error-on-warnings .` → クリーン / `npx svelte-check --tsconfig ./tsconfig.json` → 0 ERROR

- [x] **npm run pre-ready -- --pr 3329cl 全 Step PASS**
- [x] 追加・変更テスト: completeness に template 配信 + 日次 override の round-trip 専用ケースを追加。export-service.test の checklist-repo mock に findOverridesByChild 追加
- [x] **DynamoDB 実装変更時**: findOverridesByChild / insertOverrideForRestore を sqlite/dynamodb/demo で機能等価に実装
- [x] **スキーマ変更**: なし

## スクリーンショット / ビジュアルデモ

**該当なし**: .svelte / .css 変更なし（バックエンドのデータ経路のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: findOverridesByChild / insertOverrideForRestore を 3 実装 + facade で等価。他 backup entity と同パターン
- [x] **assignment の正しさ**: 配信エッジは per-child template の import 時 auto-assign で再構成されるため、明示的 assignment export は二重配信になり不要（不採用）。配信データ自体は保全され loss なし
- [x] **データ整合**: override の createdAt を保全。配信 createdAt メタは再スタンプ（user-facing でない）
- [x] **YAGNI**: override の明示 export + assignment の再構成検証に限定

## 横展開・影響波及チェック

- [x] **clear FK 確認**: checklist 全テーブル (override/log/assignment/item/template) は checklist.deleteByTenantId で children 削除前にまとめて削除済 → FK 阻害なし
- [x] **設計書同期** (ADR-0001): registry の checklistAssignment / checklistOverride 分類を exported に更新（assignment は再構成メカニズムを reason に明記）
- [x] **並行 PR overlap** (#1200): #3445/#3448 等が develop へ先行マージ済。develop 最新化済

## レビュー依頼事項・破壊的変更

- [x] 破壊的変更は**含まれない**（新規 optional field のみ、旧 backup の import も継続可）

**レビュー依頼**: checklistAssignment を「per-child template の auto-assign で配信エッジ再構成」として exported 扱いにする判断（明示 assignment export は二重配信のため不採用）をご確認ください。master 共有 dedup の fidelity 差は loss ではないと整理しています。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **npm run pre-ready -- --pr 3329cl 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] Phase 分割: 残 source 2 件 (restDays / childCustomVoices) は registry を起点に順次対応
- [x] UI / 認証画面変更: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
