### PR TITLE
test: #3472 auto-challenge skip 算出の integration test + skip≠vacation 判断記録

### DIFF
--- a/src/lib/server/services/child-challenge-service.ts
+++ b/src/lib/server/services/child-challenge-service.ts
@@ -300,6 +300,10 @@ export function computeProposal(
 	// #3203 item1: skippedWeeks = 直近生成週から今週までに challenge を生成しなかった (skip した) 週数。
 	// 週を skip する child = disengaging であり rescue (易しい得意 challenge で成功体験を積ませる) の本来対象。
 	// skip 週を miss として streak に加算し、跨いでも rescue を発火させる。
+	// #3472 item2 (skip≠vacation の判断・記録): 旅行/帰省で離れた優良家庭も skip-as-disengagement で
+	// rescue 対象になり得るが、(a) rescue は「易しい得意 challenge」で penalty も催促もなく benign、
+	// (b) vacation 検出 (カレンダー連携/不在判定) は Pre-PMF (ADR-0010) で過剰投資のため、現状は
+	// skip=disengagement の単純モデルを採用する。誤分類時の害が小さく ADR-0012 anti-engagement とも整合。
 	const skippedWeeks = Math.max(0, opts?.skippedWeeks ?? 0);
 	// 生成時点での「連続未達週数」(前週が未達なら前週の streak + 1、達成ならリセット) + skip 週 (disengagement)。
 	const prevMissed = prev != null && prev.status !== 'completed';

--- a/tests/unit/services/child-challenge-service.test.ts
+++ b/tests/unit/services/child-challenge-service.test.ts
@@ -316,6 +316,87 @@ describe('getOrCreateWeeklyChildChallenge (#3195 アプリ自動生成)', () => 
 		expect(mockInsert).not.toHaveBeenCalled();
 		expect(mockAggregateActivityLogsByCategory).not.toHaveBeenCalled();
 	});
+
+	// #3472 (integration): getOrCreateWeeklyChildChallenge 経由で priorAuto 採用 + weeksBetween-1 の
+	// skip 算出を検証する。unit (#3203) は computeProposal へ直接 skippedWeeks を手渡すが、本 test は
+	// repo 行 (複数 prior・連続/非連続週・同一週重複) からの skip 導出 path 全体を網羅する (ADR-0005/0006)。
+	describe('#3472: skip 算出 integration (priorAuto + weeksBetween-1)', () => {
+		/** 過去 prior auto:weekly 行を組み立てる。completed=1 で前週完了相当。 */
+		function priorAutoRow(startDate: string, over: Record<string, unknown> = {}) {
+			return {
+				id: 1,
+				childId: 10,
+				sourceTemplateId: 'auto:weekly',
+				startDate,
+				targetConfig: JSON.stringify({ categoryId: 2, genMissStreak: 0 }),
+				targetValue: 3,
+				currentValue: 3,
+				completed: 1, // 完了 → prev streak 0
+				status: 'completed',
+				...over,
+			};
+		}
+		/** weekStart を n 週前へ戻す。 */
+		async function weeksAgo(n: number): Promise<string> {
+			const { getWeekStart, getLastWeekStart } = await import(
+				'../../../src/lib/server/services/child-challenge-service'
+			);
+			let w = getWeekStart();
+			for (let i = 0; i < n; i++) w = getLastWeekStart(w);
+			return w;
+		}
+
+		beforeEach(() => {
+			mockCategoryCounts({ 1: 8, 2: 6, 3: 4, 4: 2, 5: 0 }); // 非 explore
+			mockGetOrCreateWeeklyAuto.mockImplementation(async (input) => ({
+				id: 1,
+				currentValue: 0,
+				completed: 0,
+				...input,
+			}));
+		});
+
+		it('完了後 3 週前の prior のみ (= 2 週 skip) → rescue-strength を生成', async () => {
+			const w3 = await weeksAgo(3); // 3 週前 → weeksBetween=3 → skip=2
+			mockFindByChildId.mockResolvedValue([priorAutoRow(w3)]);
+
+			await getOrCreateWeeklyChildChallenge(10, TENANT);
+			const cfg = JSON.parse(mockGetOrCreateWeeklyAuto.mock.calls[0]?.[0].targetConfig);
+			expect(cfg.genMode).toBe('rescue-strength');
+			expect(cfg.genMissStreak).toBe(2); // skip 2 を miss streak に反映
+		});
+
+		it('連続週 (1 週前完了、skip 0) → rescue にならない', async () => {
+			const w1 = await weeksAgo(1); // 1 週前 → weeksBetween=1 → skip=0
+			mockFindByChildId.mockResolvedValue([priorAutoRow(w1)]);
+
+			await getOrCreateWeeklyChildChallenge(10, TENANT);
+			const cfg = JSON.parse(mockGetOrCreateWeeklyAuto.mock.calls[0]?.[0].targetConfig);
+			expect(cfg.genMode).not.toBe('rescue-strength');
+			expect(cfg.genMissStreak).toBe(0);
+		});
+
+		it('複数 prior 行から最新週を prev に採用する (sort 検証)', async () => {
+			const w1 = await weeksAgo(1);
+			const w4 = await weeksAgo(4);
+			// 順不同で渡しても最新 (w1) が prev → skip 0
+			mockFindByChildId.mockResolvedValue([priorAutoRow(w4), priorAutoRow(w1)]);
+
+			await getOrCreateWeeklyChildChallenge(10, TENANT);
+			const cfg = JSON.parse(mockGetOrCreateWeeklyAuto.mock.calls[0]?.[0].targetConfig);
+			expect(cfg.genMissStreak).toBe(0); // w1 採用 = skip 0
+		});
+
+		it('同一 startDate の prior 重複時も決定的に動く (skip 一意)', async () => {
+			const w2 = await weeksAgo(2); // skip=1
+			mockFindByChildId.mockResolvedValue([priorAutoRow(w2), priorAutoRow(w2)]);
+
+			await getOrCreateWeeklyChildChallenge(10, TENANT);
+			const cfg = JSON.parse(mockGetOrCreateWeeklyAuto.mock.calls[0]?.[0].targetConfig);
+			// 2 週前完了 → skip 1 → streak 1 (rescue 閾値 2 未満)
+			expect(cfg.genMissStreak).toBe(1);
+		});
+	});
 });
 
 describe('calcAgeAdjustedTarget', () => {


### PR DESCRIPTION
## 顧客価値・目的

PR #3468 (#3203) で実装した「skip→rescue 連動」の skip 算出ロジック (priorAuto 採用 + weeksBetween-1) を、unit (computeProposal 直接) だけでなく **getOrCreateWeeklyChildChallenge 経由の integration path** で機械検証し、複数 prior 行・連続/非連続週・同一週重複時の決定性を回帰固定する。加えて skip≠vacation の product 判断を記録する。

## 関連 Issue

closes #3472

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | getOrCreateWeeklyChildChallenge 経由の skip 算出 integration test (複数prior/連続非連続/同一週重複) | `npx vitest run tests/unit/services/child-challenge-service.test.ts` | HEAD `82a0a3dd9` / describe "#3472: skip 算出 integration" 4 ケース (3週前→rescue / 連続週→非rescue / 複数prior最新採用 / 同一週重複決定性)。47 passed |
| AC2 | skip≠vacation の扱いを判断・記録 | grep | HEAD `82a0a3dd9` / child-challenge-service.ts に判断記録コメント (skip=disengagement 単純モデル採用、vacation 検出は Pre-PMF 過剰投資、rescue benign) |

## 変更タイプ

- [x] テスト (test)

## 影響範囲・変更コンポーネント

- `tests/unit/services/child-challenge-service.test.ts` — integration test 4 ケース追加
- `src/lib/server/services/child-challenge-service.ts` — skip≠vacation 判断記録コメント (ロジック不変)

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/services/child-challenge-service.test.ts` <!-- PASS --> → 47 passed (旧 43 + 新 4)
- `npx svelte-check --threshold error` <!-- PASS --> → 0 ERRORS / biome / cspell clean

## スクリーンショット / ビジュアルデモ

テスト追加 + コメントのみで UI / ロジック変化なし。SS 対象外。

## コード品質セルフレビュー (#1481)

- 既存 getOrCreateWeeklyChildChallenge test の mock パターン (mockFindByChildId / mockGetOrCreateWeeklyAuto) を踏襲
- weeksAgo helper で getLastWeekStart を chain し prior 週を決定的に構築

## 横展開・影響波及チェック

- skip 算出の中核 (weeksBetween off-by-one / priorAuto sort / weeksBetween-1) を integration path で網羅
- computeProposal 直接 test (#3203) と補完関係

## レビュー依頼事項・破壊的変更

破壊的変更なし。テスト + 判断記録コメントのみ。

## 配布済み env / secret (ADR-0006)

env / secret の追加なし。

## Ready for Review チェックリスト

- [x] integration test 追加 + green
- [x] AC 検証マップ記載
- [x] skip≠vacation 判断記録

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
