### PR TITLE
fix: #3463 childActivity dailyLimit/nameKana/nameKanji の import 値検証 + server clamp

### DIFF
--- a/src/lib/domain/validation/activity.ts
+++ b/src/lib/domain/validation/activity.ts
@@ -94,12 +94,20 @@ export const ACTIVITY_NAME_FIELD_MAX = 50;
  * #3463 item1/item4: dailyLimit を `[0, 99]` の整数 or null に正規化する (import 境界 + server clamp 共用)。
  * form action の zod (`min(0).max(99)`) は form 経路限定で、改竄/破損 ZIP 復元や API 直叩きの NaN/負値/
  * 巨大値/非整数を守らない。本 sanitizer を import-service と +page.server.ts の両境界で適用し default-deny 化する。
+ *
+ * dailyLimit semantics (`activity-log-service.ts` enforcement): `null=1回 (安全既定)` / `0=無制限 (最 permissive)` /
+ * `N=N回`。下限外 (負値) は改竄/破損由来の不正入力であり、最 permissive な 0 (無制限) へ昇格させると
+ * default-allow になる。よって負値は安全既定の null (=1回) に倒す。ユーザが明示入力した 0 は無制限として保持し、
+ * 上限超は 99 へ丸める (DAILY_LIMIT_MIN..MAX の範囲内のみ trunc clamp)。
  */
 export function sanitizeDailyLimit(raw: unknown): number | null {
 	if (raw == null || raw === '') return null;
 	const n = typeof raw === 'number' ? raw : Number(raw);
 	if (!Number.isFinite(n)) return null;
-	return Math.min(DAILY_LIMIT_MAX, Math.max(DAILY_LIMIT_MIN, Math.trunc(n)));
+	// 下限外 (負値) は不正入力 → 最 permissive な無制限 (0) への昇格を避け安全既定 null (=1回) に倒す。
+	// trunc 前に判定し、-0.5 等が -0 (=0=無制限) に丸まるのを防ぐ。
+	if (n < DAILY_LIMIT_MIN) return null;
+	return Math.min(DAILY_LIMIT_MAX, Math.trunc(n));
 }
 
 /**

--- a/src/lib/domain/validation/activity.ts
+++ b/src/lib/domain/validation/activity.ts
@@ -85,6 +85,32 @@ export const createActivitySchema = z.object({
 
 export const updateActivitySchema = createActivitySchema.partial();
 
+// #3463: dailyLimit / nameKana / nameKanji の許容境界 SSOT (form zod と同値)。
+export const DAILY_LIMIT_MIN = 0;
+export const DAILY_LIMIT_MAX = 99;
+export const ACTIVITY_NAME_FIELD_MAX = 50;
+
+/**
+ * #3463 item1/item4: dailyLimit を `[0, 99]` の整数 or null に正規化する (import 境界 + server clamp 共用)。
+ * form action の zod (`min(0).max(99)`) は form 経路限定で、改竄/破損 ZIP 復元や API 直叩きの NaN/負値/
+ * 巨大値/非整数を守らない。本 sanitizer を import-service と +page.server.ts の両境界で適用し default-deny 化する。
+ */
+export function sanitizeDailyLimit(raw: unknown): number | null {
+	if (raw == null || raw === '') return null;
+	const n = typeof raw === 'number' ? raw : Number(raw);
+	if (!Number.isFinite(n)) return null;
+	return Math.min(DAILY_LIMIT_MAX, Math.max(DAILY_LIMIT_MIN, Math.trunc(n)));
+}
+
+/**
+ * #3463 item1: 読み仮名 / 漢字表記を max 50 char に切詰める (import 境界)。巨大 nameKana/nameKanji 流入防止。
+ */
+export function sanitizeActivityNameField(raw: unknown): string | null {
+	if (raw == null) return null;
+	const s = String(raw);
+	return s.length > ACTIVITY_NAME_FIELD_MAX ? s.slice(0, ACTIVITY_NAME_FIELD_MAX) : s;
+}
+
 export const recordActivitySchema = z.object({
 	childId: z.number().int().positive(),
 	activityId: z.number().int().positive(),

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -8,7 +8,11 @@ import {
 	isExportableSettingKey,
 } from '$lib/domain/export-format';
 import { IMPORT_LABELS, type ImportSkipReason } from '$lib/domain/labels';
-import { CATEGORY_CODES } from '$lib/domain/validation/activity';
+import {
+	CATEGORY_CODES,
+	sanitizeActivityNameField,
+	sanitizeDailyLimit,
+} from '$lib/domain/validation/activity';
 import {
 	findActivities,
 	findActivityLogs,
@@ -925,9 +929,11 @@ async function importChildActivitiesData(
 					archivedReason: a.archivedReason ?? null,
 					// #3422: 1 日上限 / 読み仮名 / 漢字表記を round-trip 復元 (省略 = 旧 backup は
 					// schema default)。dailyLimit=0 (無制限) を null=1 回固定へ落とさず保全する。
-					dailyLimit: a.dailyLimit,
-					nameKana: a.nameKana ?? null,
-					nameKanji: a.nameKanji ?? null,
+					// #3463 item1: import 境界で値検証。改竄/破損 ZIP の範囲外 dailyLimit (NaN/負/巨大/非整数) を
+					// [0,99] int or null に、巨大 nameKana/nameKanji を max 50 char に正規化する (default-deny)。
+					dailyLimit: sanitizeDailyLimit(a.dailyLimit),
+					nameKana: sanitizeActivityNameField(a.nameKana),
+					nameKanji: sanitizeActivityNameField(a.nameKanji),
 				},
 				tenantId,
 			);

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -1,7 +1,7 @@
 import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
-import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
+import { CATEGORY_DEFS, sanitizeDailyLimit } from '$lib/domain/validation/activity';
 // #2767 Fix Round 1 B3 (Adversarial security): indexes query を Zod ベース input validation
 // 経由でパースし、NaN / 負数 / 非整数 / 空文字 / 重複の 4 edge case を回帰固定する。
 import { parseImportIndexes } from '$lib/domain/validation/marketplace-import-params';
@@ -148,7 +148,7 @@ export const actions: Actions = {
 		const ageMin = formData.get('ageMin') ? Number(formData.get('ageMin')) : null;
 		const ageMax = formData.get('ageMax') ? Number(formData.get('ageMax')) : null;
 		const dailyLimitRaw = formData.get('dailyLimit');
-		const dailyLimit = dailyLimitRaw != null && dailyLimitRaw !== '' ? Number(dailyLimitRaw) : null;
+		const dailyLimit = sanitizeDailyLimit(dailyLimitRaw); // #3463 item4: NaN/負/巨大/非整数を [0,99] int or null に clamp
 		const nameKana = String(formData.get('nameKana') ?? '').trim() || null;
 		const nameKanji = String(formData.get('nameKanji') ?? '').trim() || null;
 		const triggerHint = String(formData.get('triggerHint') ?? '').trim() || null;
@@ -221,7 +221,7 @@ export const actions: Actions = {
 		const ageMin = formData.get('ageMin') ? Number(formData.get('ageMin')) : null;
 		const ageMax = formData.get('ageMax') ? Number(formData.get('ageMax')) : null;
 		const dailyLimitRaw = formData.get('dailyLimit');
-		const dailyLimit = dailyLimitRaw != null && dailyLimitRaw !== '' ? Number(dailyLimitRaw) : null;
+		const dailyLimit = sanitizeDailyLimit(dailyLimitRaw); // #3463 item4: NaN/負/巨大/非整数を [0,99] int or null に clamp
 		const nameKana = String(formData.get('nameKana') ?? '').trim() || null;
 		const nameKanji = String(formData.get('nameKanji') ?? '').trim() || null;
 		const triggerHint = String(formData.get('triggerHint') ?? '').trim() || null;
@@ -566,7 +566,7 @@ export const actions: Actions = {
 		const icon = String(formData.get('icon') ?? '📝');
 		const basePoints = Number(formData.get('basePoints') ?? 5);
 		const dailyLimitRaw = formData.get('dailyLimit');
-		const dailyLimit = dailyLimitRaw != null && dailyLimitRaw !== '' ? Number(dailyLimitRaw) : null;
+		const dailyLimit = sanitizeDailyLimit(dailyLimitRaw); // #3463 item4: NaN/負/巨大/非整数を [0,99] int or null に clamp
 		const childIdsRaw = String(formData.get('childIds') ?? '').trim();
 
 		if (!name) return fail(400, { error: '名前を入力してください' });

--- a/src/routes/(parent)/admin/activities/[id]/edit/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/[id]/edit/+page.server.ts
@@ -2,7 +2,11 @@
 //   /admin/activities/[id]/edit で must トグル + 既存編集項目を扱う。
 //   form action は $lib/server/services/activity-service 経由で priority を含めた更新を行う。
 import { error, fail, redirect } from '@sveltejs/kit';
-import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
+import {
+	CATEGORY_DEFS,
+	sanitizeActivityNameField,
+	sanitizeDailyLimit,
+} from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
 import { getActivityById, updateActivity } from '$lib/server/services/activity-service';
@@ -41,9 +45,13 @@ export const actions: Actions = {
 		const ageMin = formData.get('ageMin') ? Number(formData.get('ageMin')) : null;
 		const ageMax = formData.get('ageMax') ? Number(formData.get('ageMax')) : null;
 		const dailyLimitRaw = formData.get('dailyLimit');
-		const dailyLimit = dailyLimitRaw != null && dailyLimitRaw !== '' ? Number(dailyLimitRaw) : null;
-		const nameKana = String(formData.get('nameKana') ?? '').trim() || null;
-		const nameKanji = String(formData.get('nameKanji') ?? '').trim() || null;
+		const dailyLimit = sanitizeDailyLimit(dailyLimitRaw); // #3463 item1/item4: NaN/負/巨大/非整数を [0,99] int or null に clamp (負値→null=1回 安全既定)
+		const nameKana = sanitizeActivityNameField(
+			String(formData.get('nameKana') ?? '').trim() || null,
+		);
+		const nameKanji = sanitizeActivityNameField(
+			String(formData.get('nameKanji') ?? '').trim() || null,
+		);
 		const triggerHint = String(formData.get('triggerHint') ?? '').trim() || null;
 		// #1756 (#1709-B): must トグル — checkbox は ON 時 'on' / OFF 時 null
 		const priorityRaw = formData.get('priority');

--- a/tests/unit/domain/activity-validation.test.ts
+++ b/tests/unit/domain/activity-validation.test.ts
@@ -29,8 +29,10 @@ describe('#3463 sanitizeDailyLimit (import 境界 + server clamp)', () => {
 		expect(sanitizeDailyLimit(0)).toBe(0);
 		expect(sanitizeDailyLimit('0')).toBe(0);
 	});
-	it('負値は 0 へ clamp', () => {
-		expect(sanitizeDailyLimit(-5)).toBe(0);
+	it('負値 (下限外の不正入力) は安全既定 null (=1回) に倒す — 0=無制限への昇格を避ける (#3463 item2 default-allow 防止)', () => {
+		expect(sanitizeDailyLimit(-5)).toBeNull();
+		expect(sanitizeDailyLimit('-1')).toBeNull();
+		expect(sanitizeDailyLimit(-0.5)).toBeNull();
 	});
 	it('上限超は 99 へ clamp', () => {
 		expect(sanitizeDailyLimit(1000)).toBe(99);

--- a/tests/unit/domain/activity-validation.test.ts
+++ b/tests/unit/domain/activity-validation.test.ts
@@ -9,9 +9,54 @@ import {
 	calcStreakBonus,
 	createActivitySchema,
 	recordActivitySchema,
+	sanitizeActivityNameField,
+	sanitizeDailyLimit,
 	todayDate,
 	updateActivitySchema,
 } from '../../../src/lib/domain/validation/activity';
+
+describe('#3463 sanitizeDailyLimit (import 境界 + server clamp)', () => {
+	it('null / 空文字 / undefined は null', () => {
+		expect(sanitizeDailyLimit(null)).toBeNull();
+		expect(sanitizeDailyLimit('')).toBeNull();
+		expect(sanitizeDailyLimit(undefined)).toBeNull();
+	});
+	it('範囲内の整数はそのまま', () => {
+		expect(sanitizeDailyLimit(3)).toBe(3);
+		expect(sanitizeDailyLimit('5')).toBe(5);
+	});
+	it('dailyLimit=0 (無制限) は保全する (#3422 整合)', () => {
+		expect(sanitizeDailyLimit(0)).toBe(0);
+		expect(sanitizeDailyLimit('0')).toBe(0);
+	});
+	it('負値は 0 へ clamp', () => {
+		expect(sanitizeDailyLimit(-5)).toBe(0);
+	});
+	it('上限超は 99 へ clamp', () => {
+		expect(sanitizeDailyLimit(1000)).toBe(99);
+	});
+	it('非整数は切り捨て', () => {
+		expect(sanitizeDailyLimit(3.9)).toBe(3);
+	});
+	it('NaN / 非数値文字列は null (default-deny)', () => {
+		expect(sanitizeDailyLimit('abc')).toBeNull();
+		expect(sanitizeDailyLimit(Number.NaN)).toBeNull();
+		expect(sanitizeDailyLimit(Number.POSITIVE_INFINITY)).toBeNull();
+	});
+});
+
+describe('#3463 sanitizeActivityNameField (読み仮名/漢字 max 50)', () => {
+	it('null は null', () => {
+		expect(sanitizeActivityNameField(null)).toBeNull();
+	});
+	it('50 文字以内はそのまま', () => {
+		expect(sanitizeActivityNameField('おてつだい')).toBe('おてつだい');
+	});
+	it('50 文字超は切詰め', () => {
+		const long = 'あ'.repeat(120);
+		expect(sanitizeActivityNameField(long)).toHaveLength(50);
+	});
+});
 
 describe('createActivitySchema', () => {
 	it('有効な入力を受け入れる', () => {

--- a/tests/unit/routes/admin-activities-edit-clamp.test.ts
+++ b/tests/unit/routes/admin-activities-edit-clamp.test.ts
@@ -1,0 +1,101 @@
+// tests/unit/routes/admin-activities-edit-clamp.test.ts
+// #3463 item1/item2: 活動編集 route (/admin/activities/[id]/edit) の save action が
+// dailyLimit / nameKana / nameKanji を sanitizer 経由で clamp することを検証する。
+//
+// 根本原因 (#3463 QM BLOCK): create/update/bulk action は sanitizeDailyLimit 化済だったが
+// 編集 route だけが旧 `Number(raw)` 直書きのまま残り、改竄/破損由来の NaN/負値/巨大値/巨大文字列が
+// 素通りしていた。本テストは編集経路でも sanitizer が適用されることを保証する。
+//
+// 設計判断: SvelteKit CSRF を回避するため action handler を直接呼び出す
+// (admin-activities-import-plan-gate.test.ts と同型)。save 成功時は redirect(303) を throw するため
+// updateActivity の呼出引数を検証する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireTenantId = vi.fn();
+const mockUpdateActivity = vi.fn();
+const mockGetActivityById = vi.fn();
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: mockRequireTenantId,
+}));
+
+vi.mock('$lib/server/services/activity-service', () => ({
+	getActivityById: mockGetActivityById,
+	updateActivity: mockUpdateActivity,
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const mod = await import('../../../src/routes/(parent)/admin/activities/[id]/edit/+page.server');
+
+type SaveEvent = {
+	request: Request;
+	locals: App.Locals;
+	params: { id: string };
+};
+const saveAction = mod.actions.save as unknown as (event: SaveEvent) => Promise<unknown>;
+
+function makeLocals() {
+	return { context: { tenantId: 'tenant-1' } } as unknown as App.Locals;
+}
+
+function makeFormRequest(fields: Record<string, string | number>): Request {
+	const form = new FormData();
+	for (const [k, v] of Object.entries(fields)) {
+		form.append(k, String(v));
+	}
+	return new Request('http://localhost/admin/activities/1/edit', { method: 'POST', body: form });
+}
+
+/** save action は成功時 redirect(303) を throw する。updateActivity が呼ばれた時点の payload を返す。 */
+async function runSave(fields: Record<string, string | number>) {
+	await saveAction({
+		request: makeFormRequest(fields),
+		locals: makeLocals(),
+		params: { id: '1' },
+	}).catch(() => {
+		// redirect(303) の throw を握りつぶす (成功経路)
+	});
+	expect(mockUpdateActivity).toHaveBeenCalledTimes(1);
+	return mockUpdateActivity.mock.calls[0]?.[1] as Record<string, unknown>;
+}
+
+const baseFields = { name: 'おてつだい', categoryId: 1, icon: '📝', basePoints: 5 };
+
+describe('/admin/activities/[id]/edit save action — #3463 dailyLimit/name sanitize', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRequireTenantId.mockReturnValue('tenant-1');
+		mockUpdateActivity.mockResolvedValue(undefined);
+	});
+
+	it('負値 dailyLimit は安全既定 null (=1回) に倒す (0=無制限への昇格を防ぐ)', async () => {
+		const payload = await runSave({ ...baseFields, dailyLimit: -5 });
+		expect(payload.dailyLimit).toBeNull();
+	});
+
+	it('dailyLimit=0 (無制限) は保持する', async () => {
+		const payload = await runSave({ ...baseFields, dailyLimit: 0 });
+		expect(payload.dailyLimit).toBe(0);
+	});
+
+	it('上限超 dailyLimit は 99 に丸める', async () => {
+		const payload = await runSave({ ...baseFields, dailyLimit: 1000 });
+		expect(payload.dailyLimit).toBe(99);
+	});
+
+	it('非整数 dailyLimit は切り捨てる', async () => {
+		const payload = await runSave({ ...baseFields, dailyLimit: 3.9 });
+		expect(payload.dailyLimit).toBe(3);
+	});
+
+	it('巨大 nameKana / nameKanji は 50 文字に切詰める', async () => {
+		const long = 'あ'.repeat(120);
+		const payload = await runSave({ ...baseFields, nameKana: long, nameKanji: long });
+		expect(payload.nameKana).toHaveLength(50);
+		expect(payload.nameKanji).toHaveLength(50);
+	});
+});

--- a/tests/unit/services/import-service.test.ts
+++ b/tests/unit/services/import-service.test.ts
@@ -107,7 +107,10 @@ vi.mock('$lib/server/logger', () => ({
 	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock('$lib/domain/validation/activity', () => ({
+vi.mock('$lib/domain/validation/activity', async (importActual) => ({
+	// #3463: sanitizeDailyLimit / sanitizeActivityNameField は実装をそのまま使う
+	// (mock が CATEGORY_CODES のみだと import-service の sanitize 呼び出しが undefined→throw する)。
+	...(await importActual<typeof import('$lib/domain/validation/activity')>()),
 	CATEGORY_CODES: ['undou', 'benkyou', 'seikatsu', 'kouryuu', 'souzou'],
 }));
 


### PR DESCRIPTION
## 顧客価値・目的

PR #3451 (#3422) で per-child dailyLimit 設定を persist できるようにしたが、**import/復元境界に値検証が無く**、改竄/破損 ZIP の範囲外 dailyLimit (NaN/負/巨大/非整数) や巨大 nameKana/nameKanji がそのまま書き込まれる security gap があった (#3409/#3398/#3418 と同クラス)。import 境界 + server で default-deny の値検証を入れ、不正値による DB 汚染を防ぐ。

## 関連 Issue

closes #3463

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (item1) | import の insertActivity で dailyLimit/nameKana/nameKanji を範囲/長さ検証 | `npx vitest run tests/unit/domain/activity-validation.test.ts` | HEAD `1e79cd6c8` / sanitizeDailyLimit [0,99] + sanitizeActivityNameField max50。import-service.ts:887-889。37 passed |
| AC4 (item4) | +page.server.ts の Number(dailyLimitRaw) を clamp (NaN/負/巨大) | grep | HEAD `1e79cd6c8` / sanitizeDailyLimit に 3 箇所置換 (151/224/569)。dailyLimit=0 保全 |
| AC-test | sanitizer の SSOT 単体テスト | 同上 | HEAD `1e79cd6c8` / "#3463 sanitizeDailyLimit" 7 ケース + "sanitizeActivityNameField" 3 ケース |

item2 (旧 backup ≤1.5.0 の dailyLimit 列欠落 UI notice) は意味論的に正 (旧列なし) + UI 体験範疇のため Pre-PMF scope 外 (ADR-0010)。item3 (export keys ⊆ 復元列 fitness) は #3422 round-trip test + 本 sanitizer test で field 粒度を担保。

## 変更タイプ

- [x] バグ修正 (fix)

## 影響範囲・変更コンポーネント

- `src/lib/domain/validation/activity.ts` — sanitizeDailyLimit / sanitizeActivityNameField SSOT
- `src/lib/server/services/import-service.ts` — import 境界で sanitize 適用
- `src/routes/(parent)/admin/activities/+page.server.ts` — server clamp (3 箇所)
- `tests/unit/domain/activity-validation.test.ts` — sanitizer 単体テスト

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/domain/activity-validation.test.ts` <!-- PASS --> → 37 passed
- `npx svelte-check --threshold error` <!-- PASS --> → 0 ERRORS / biome clean

## スクリーンショット / ビジュアルデモ

サーバー側の値検証 hardening で UI 表示不変 (不正値が DB に入らなくなるのみ)。SS 対象外。

## コード品質セルフレビュー (#1481)

- form zod (min0 max99 / max50) と同値の sanitizer を SSOT 集約 (二重実装なし)
- dailyLimit=0 (無制限) 保全を test で固定 (#3422 整合)

## 横展開・影響波及チェック

- import 境界 (import-service) + form server (page.server.ts) の両経路に適用し default-deny を非対称解消
- settings の多層防御 (allowlist) と同方針

## レビュー依頼事項・破壊的変更

破壊的変更なし。正常値は不変、不正値のみ正規化/拒否。

## 配布済み env / secret (ADR-0006)

env / secret の追加なし。

## Ready for Review チェックリスト

- [x] テスト追加 + green
- [x] AC 検証マップ記載
- [x] 両境界に適用

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
