### PR TITLE
feat: #3329 おやすみ日(restDays)の backup round-trip 実装

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -377,6 +377,18 @@ export interface ExportChecklistOverride {
 	createdAt: string;
 }
 
+/**
+ * #3329: per-child おやすみ日 (ステータス減少停止日)。createdAt を保全して round-trip 復元する
+ * (id/childId は import で振り直すため childRef で再結合)。週次評価/streak/decay の input であり
+ * 活動記録から再構成不能。※DynamoDB には保存されない (NUC/SQLite 専用の Pre-PMF fallback)。
+ */
+export interface ExportRestDay {
+	childRef: string;
+	date: string;
+	reason: string;
+	createdAt: string;
+}
+
 export interface ExportChecklistTemplate {
 	childRef: string;
 	name: string;
@@ -465,6 +477,8 @@ export interface ExportTransactionData {
 	checklistLogs: ExportChecklistLog[];
 	/** #3329: per-child チェックリスト日次 override (createdAt 保全) */
 	checklistOverrides: ExportChecklistOverride[];
+	/** #3329: per-child おやすみ日 (createdAt 保全。DynamoDB では空) */
+	restDays: ExportRestDay[];
 	childAvatarItems: never[];
 	dailyMissions: ExportDailyMission[];
 	/** #3329: 各種設定 (tenant-scoped KVS、allowlist 済キーのみ。pin_hash 等の秘匿キーは除外) */

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -210,9 +210,9 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	restDays: {
 		classification: 'source',
 		schemaTable: 'restDays',
-		backupStatus: 'not-yet-exported',
+		backupStatus: 'exported',
 		reason:
-			'おやすみ日設定 (per-child、保護者が任意指定)。evaluation-repo が週次評価/streak/decay 計算の input に使い活動記録から再構成不能。export 未対応のため backup で失われる (#3329)',
+			'おやすみ日設定 (per-child、保護者が任意指定)。evaluation-repo が週次評価/streak/decay 計算の input に使い活動記録から再構成不能。export/import 実装済 (#3329、createdAt を insertRestDayForRestore で保全)。NUC/SQLite 専用 (DynamoDB は no-op、そもそも保存されないため backup 対象データなし)。clear は evaluation.deleteByTenantId で削除済',
 	},
 	childCustomVoices: {
 		classification: 'source',

--- a/src/lib/server/db/demo/evaluation-repo.ts
+++ b/src/lib/server/db/demo/evaluation-repo.ts
@@ -123,6 +123,18 @@ export async function findRestDays(
 	return [];
 }
 
+export async function findRestDaysByChild(_childId: number, _tenantId: string): Promise<RestDay[]> {
+	return [];
+}
+
+export async function insertRestDayForRestore(
+	_input: Omit<RestDay, 'id'>,
+	_tenantId: string,
+): Promise<RestDay | undefined> {
+	// Stub: demo は書き込み no-op。
+	return undefined;
+}
+
 export async function deleteByTenantId(_tenantId: string): Promise<void> {
 	// Stub: no-op
 }

--- a/src/lib/server/db/dynamodb/evaluation-repo.ts
+++ b/src/lib/server/db/dynamodb/evaluation-repo.ts
@@ -269,6 +269,19 @@ export async function findRestDays(
 	return [];
 }
 
+// #3329: restDays は DynamoDB に保存されない (insertRestDay も no-op、NUC/SQLite 専用の Pre-PMF
+// fallback)。backup の find/restore も同方針で no-op を返す (DynamoDB 環境では restDays は常に空)。
+export async function findRestDaysByChild(_childId: number, _tenantId: string): Promise<RestDay[]> {
+	return [];
+}
+
+export async function insertRestDayForRestore(
+	_input: Omit<RestDay, 'id'>,
+	_tenantId: string,
+): Promise<RestDay | undefined> {
+	return undefined;
+}
+
 /** テナントの全評価データを削除（CHILD#* 配下の EVAL# アイテム） */
 export async function deleteByTenantId(tenantId: string): Promise<void> {
 	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), evaluationPrefix());

--- a/src/lib/server/db/evaluation-repo.ts
+++ b/src/lib/server/db/evaluation-repo.ts
@@ -49,3 +49,16 @@ export async function countRestDaysInMonth(childId: number, yearMonth: string, t
 export async function findRestDays(childId: number, yearMonth: string, tenantId: string) {
 	return getRepos().evaluation.findRestDays(childId, yearMonth, tenantId);
 }
+
+/** #3329 backup: child の全おやすみ日 (月不問、export 用)。 */
+export async function findRestDaysByChild(childId: number, tenantId: string) {
+	return getRepos().evaluation.findRestDaysByChild(childId, tenantId);
+}
+
+/** #3329 backup restore 用: createdAt を保全しておやすみ日を復元する。 */
+export async function insertRestDayForRestore(
+	input: { childId: number; date: string; reason: string; createdAt: string },
+	tenantId: string,
+) {
+	return getRepos().evaluation.insertRestDayForRestore(input, tenantId);
+}

--- a/src/lib/server/db/interfaces/evaluation-repo.interface.ts
+++ b/src/lib/server/db/interfaces/evaluation-repo.interface.ts
@@ -34,5 +34,19 @@ export interface IEvaluationRepo {
 	isRestDay(childId: number, date: string, tenantId: string): Promise<boolean>;
 	countRestDaysInMonth(childId: number, yearMonth: string, tenantId: string): Promise<number>;
 	findRestDays(childId: number, yearMonth: string, tenantId: string): Promise<RestDay[]>;
+
+	/** #3329 backup: child の全おやすみ日 (月不問、export 用)。 */
+	findRestDaysByChild(childId: number, tenantId: string): Promise<RestDay[]>;
+
+	/**
+	 * #3329 backup restore 用: createdAt を保全しておやすみ日を復元する。
+	 * insertRestDay は createdAt を schema default (now) で発番するため round-trip で作成日時が
+	 * 失われる。本メソッドは export された値をそのまま書き戻す (id は新規採番、childId は解決済)。
+	 */
+	insertRestDayForRestore(
+		input: Omit<RestDay, 'id'>,
+		tenantId: string,
+	): Promise<RestDay | undefined>;
+
 	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/sqlite/evaluation-repo.ts
+++ b/src/lib/server/db/sqlite/evaluation-repo.ts
@@ -172,6 +172,34 @@ export async function countRestDaysInMonth(
 	return rows.length;
 }
 
+/** #3329 backup: child の全おやすみ日 (月不問、export 用)。 */
+export async function findRestDaysByChild(childId: number, _tenantId: string) {
+	return db
+		.select()
+		.from(restDays)
+		.where(eq(restDays.childId, childId))
+		.orderBy(restDays.date)
+		.all();
+}
+
+/** #3329 backup restore 用: createdAt を保全しておやすみ日を復元する。 */
+export async function insertRestDayForRestore(
+	input: { childId: number; date: string; reason: string; createdAt: string },
+	_tenantId: string,
+) {
+	return db
+		.insert(restDays)
+		.values({
+			childId: input.childId,
+			date: input.date,
+			reason: input.reason,
+			createdAt: input.createdAt,
+		})
+		.onConflictDoNothing()
+		.returning()
+		.get();
+}
+
 /** 子供のおやすみ日一覧を取得 */
 export async function findRestDays(childId: number, yearMonth: string, _tenantId: string) {
 	return db

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -23,6 +23,7 @@ import {
 	type ExportOptions,
 	type ExportParentMessage,
 	type ExportPointLedger,
+	type ExportRestDay,
 	type ExportRewardRedemption,
 	type ExportSetting,
 	type ExportSiblingCheer,
@@ -42,7 +43,7 @@ import {
 	findTemplatesByChild,
 } from '$lib/server/db/checklist-repo';
 import { findAllChildren } from '$lib/server/db/child-repo';
-import { findEvaluationsByChild } from '$lib/server/db/evaluation-repo';
+import { findEvaluationsByChild, findRestDaysByChild } from '$lib/server/db/evaluation-repo';
 import { getRepos } from '$lib/server/db/factory';
 import { findRecentBonuses } from '$lib/server/db/login-bonus-repo';
 import { findPointHistory } from '$lib/server/db/point-repo';
@@ -242,6 +243,7 @@ interface ChildTransactionData {
 	checklistTemplates: ExportChecklistTemplate[];
 	checklistLogs: ExportChecklistLog[];
 	checklistOverrides: ExportChecklistOverride[];
+	restDays: ExportRestDay[];
 }
 
 /**
@@ -590,6 +592,16 @@ async function collectForChild(
 		createdAt: o.createdAt,
 	}));
 
+	// #3329: per-child おやすみ日 (createdAt 保全)。DynamoDB では findRestDaysByChild が空を返す。
+	const restDaysRaw = await findRestDaysByChild(childId, tenantId);
+	warnIfTruncated('restDays', childId, restDaysRaw.length);
+	const restDaysOut: ExportRestDay[] = restDaysRaw.map((r) => ({
+		childRef,
+		date: r.date,
+		reason: r.reason,
+		createdAt: r.createdAt,
+	}));
+
 	return {
 		childActivities: childActivitiesOut,
 		activityLogs: activityLogsOut,
@@ -608,6 +620,7 @@ async function collectForChild(
 		checklistTemplates: checklistTemplatesOut,
 		checklistLogs: checklistLogsOut,
 		checklistOverrides: checklistOverridesOut,
+		restDays: restDaysOut,
 	};
 }
 
@@ -668,6 +681,7 @@ async function collectTransactionData(
 		checklistTemplates: perChild.flatMap((p) => p.checklistTemplates),
 		checklistLogs: perChild.flatMap((p) => p.checklistLogs), // #3078
 		checklistOverrides: perChild.flatMap((p) => p.checklistOverrides), // #3329
+		restDays: perChild.flatMap((p) => p.restDays), // #3329
 		childAvatarItems: [],
 		dailyMissions: [], // Phase 2: エフェメラルデータ対応後に対応
 		settings: settingsOut, // #3329

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -25,7 +25,7 @@ import {
 	upsertLog,
 } from '$lib/server/db/checklist-repo';
 import { insertChild } from '$lib/server/db/child-repo';
-import { insertEvaluation } from '$lib/server/db/evaluation-repo';
+import { insertEvaluation, insertRestDayForRestore } from '$lib/server/db/evaluation-repo';
 import { getRepos } from '$lib/server/db/factory';
 import { updateChildAvatarUrl } from '$lib/server/db/image-repo';
 import { findRecentBonuses, insertLoginBonus } from '$lib/server/db/login-bonus-repo';
@@ -84,6 +84,9 @@ export interface ImportResult {
 	/** #3329: per-child チェックリスト日次 override の取込件数 */
 	checklistOverridesImported: number;
 	checklistOverridesSkipped: number;
+	/** #3329: per-child おやすみ日の取込件数 (DynamoDB では no-op で skip) */
+	restDaysImported: number;
+	restDaysSkipped: number;
 	loginBonusesImported: number;
 	loginBonusesSkipped: number;
 	statusHistoryImported: number;
@@ -298,6 +301,8 @@ export async function importFamilyData(
 	await importChecklistLogsData(data, childIdMap, templateIdMap, tenantId, result);
 	// #3329: チェックリスト日次 override を createdAt 保全で復元。childIdMap のみ必要。
 	await importChecklistOverridesData(data, childIdMap, tenantId, result);
+	// #3329: おやすみ日を createdAt 保全で復元。childIdMap のみ必要 (DynamoDB では insert が no-op)。
+	await importRestDaysData(data, childIdMap, tenantId, result);
 	await importSpecialRewards(data, childIdMap, tenantId, result);
 	// #3329: ごほうび交換/購入履歴。reward を先に取込済 (FK rewardRef → rewardId を再解決) なので
 	// importSpecialRewards の後に実行する。
@@ -788,6 +793,40 @@ async function importChecklistOverridesData(
 	}
 }
 
+/**
+ * おやすみ日を復元する (#3329)。
+ * childRef で取込先 child に解決し insertRestDayForRestore で createdAt を保全して書き戻す。
+ * DynamoDB 環境では insertRestDayForRestore が no-op (undefined) を返すため import されない
+ * (restDays は NUC/SQLite 専用、DynamoDB には保存されない)。
+ */
+async function importRestDaysData(
+	data: ExportData,
+	childIdMap: Map<string, number>,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	for (const r of data.data.restDays ?? []) {
+		const childId = childIdMap.get(r.childRef);
+		if (!childId) {
+			result.restDaysSkipped++;
+			continue;
+		}
+		try {
+			const restored = await insertRestDayForRestore(
+				{ childId, date: r.date, reason: r.reason, createdAt: r.createdAt },
+				tenantId,
+			);
+			if (restored) result.restDaysImported++;
+			else result.restDaysSkipped++;
+		} catch (e) {
+			result.restDaysSkipped++;
+			result.errors.push(
+				`おやすみ日 insert 失敗 (child=${r.childRef}, date=${r.date}): ${String(e)}`,
+			);
+		}
+	}
+}
+
 function createEmptyImportResult(): ImportResult {
 	return {
 		childrenImported: 0,
@@ -815,6 +854,8 @@ function createEmptyImportResult(): ImportResult {
 		parentMessagesSkipped: 0,
 		checklistOverridesImported: 0,
 		checklistOverridesSkipped: 0,
+		restDaysImported: 0,
+		restDaysSkipped: 0,
 		activityPrefsImported: 0,
 		activityPrefsSkipped: 0,
 		siblingCheersImported: 0,

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -126,11 +126,10 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 		// export に足したら 'exported' へ flip し本ベースラインから外す (意図的更新)。
 		// 新たな not-yet-exported source の silent 増加を禁止する (回帰ネット)。
 		expect(notYetExportedSourceEntities()).toEqual([
-			// activityPref / certificate / checklistAssignment / checklistOverride は #3329 で export 実装済 → exported へ flip
+			// 残り 1 件: childCustomVoices (ユーザー録音音声、ストレージ実体参照で別途検討)。
+			// その他 (activityPref/certificate/checklist*/parentMessage/restDays/rewardRedemption/
+			// setting/stampCard/stampEntry/siblingCheer/childChallenge*) は #3329 で export 実装済 → exported へ flip。
 			'childCustomVoices',
-			// parentMessage は #3329 で export 実装済 → exported へ flip
-			'restDays',
-			// rewardRedemption / setting / stampCard / stampEntry / siblingCheer は #3329 で export 実装済 → exported へ flip
 		]);
 	});
 

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -248,6 +248,12 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 			T,
 		);
 
+		// #3329: おやすみ日を 1 件 seed (createdAt 明示)。round-trip 後に reason/createdAt が保全されること。
+		await getRepos().evaluation.insertRestDayForRestore(
+			{ childId: 1, date: '2026-03-03', reason: 'sick', createdAt: '2026-03-03T00:00:00Z' },
+			T,
+		);
+
 		// --- export ---
 		const data = await exportFamilyData({ tenantId: T });
 		// export が全種別を捕捉していること (sanity)
@@ -275,6 +281,8 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(data.data.activityPrefs[0]?.activityName, 'export:活動設定 activityName').toBe(
 			'うんどうA',
 		);
+		expect(data.data.restDays.length, 'export:おやすみ日').toBe(1);
+		expect(data.data.restDays[0]?.reason, 'export:おやすみ日 reason').toBe('sick');
 		expect(data.data.parentMessages.length, 'export:メッセージ').toBe(1);
 		expect(data.data.parentMessages[0]?.shownAt, 'export:メッセージ shownAt').toBe(
 			'2026-02-10T18:00:00Z',
@@ -350,6 +358,14 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(restoredPrefs[0]?.pinOrder, '活動設定 pinOrder 保全').toBe(1);
 		const restoredActs2 = await getChildActivities(cid, T);
 		expect(restoredPrefs[0]?.activityId, '活動設定 activityId 再結合').toBe(restoredActs2[0]?.id);
+
+		// #3329: おやすみ日が reason/createdAt 保全で復元される。
+		const restoredRestDays = await getRepos().evaluation.findRestDaysByChild(cid, T);
+		expect(restoredRestDays.length, 'おやすみ日').toBe(1);
+		expect(restoredRestDays[0]?.reason, 'おやすみ日 reason 保全').toBe('sick');
+		expect(restoredRestDays[0]?.createdAt, 'おやすみ日 createdAt 保全').toBe(
+			'2026-03-03T00:00:00Z',
+		);
 	});
 
 	// #3329 QM-fix (2)(a): auto:weekly チャレンジの dedup round-trip。

--- a/tests/unit/services/export-service.test.ts
+++ b/tests/unit/services/export-service.test.ts
@@ -296,6 +296,8 @@ vi.mock('$lib/server/db/evaluation-repo', () => ({
 	findEvaluationsByChild: vi.fn((childId: number) =>
 		childId === 1 ? Promise.resolve(mockEvaluations) : Promise.resolve([]),
 	),
+	// #3329: per-child おやすみ日 (export が呼ぶ)。本 test では空で十分。
+	findRestDaysByChild: vi.fn(() => Promise.resolve([])),
 }));
 vi.mock('$lib/server/db/login-bonus-repo', () => ({
 	findRecentBonuses: vi.fn((childId: number) =>


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: NUC セルフホスト版利用者（バックアップ・移管）

**解決する課題**: バックアップ ZIP を別環境へ import すると **おやすみ日設定（ステータス減少を停止する日）が一切復元されない**（本番 t-82c17558 の喪失の一部）。restDays は週次評価 / streak / decay 計算の input であり、活動記録から再構成不能なため失われると影響が大きい。

**期待される効果**: おやすみ日が reason / createdAt を保ったまま round-trip 復元される。

## 関連 Issue

関連: #3329 #3328（未 export source の restDays を実装。残 1 件 childCustomVoices は registry を起点に対応するため #3329 は close しない）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|----|------|---------|------------------|
| AC1 | おやすみ日を export に含める (per-child) | export-format / export-service | HEAD 214fa9ac |
| AC2 | import で childRef 解決し createdAt を insertRestDayForRestore で保全 | import-service importRestDaysData | HEAD 214fa9ac |
| AC3 | round-trip (reason/createdAt 保全) | backup-roundtrip-completeness.test.ts | HEAD 214fa9ac |
| AC4 | insertRestDay (createdAt=now 固定) と分離した復元専用経路を 3 実装で機能等価提供 | repo findRestDaysByChild / insertRestDayForRestore (sqlite/dynamodb/demo) | HEAD 214fa9ac |
| AC5 | DynamoDB は no-op (restDays は NUC/SQLite 専用、保存されない) | dynamodb evaluation-repo no-op + dynamodb-pre-pmf-fallback テスト | HEAD 214fa9ac |
| AC6 | registry の restDays を exported へ flip + ratchet 整合 | backup-entity-registry.test.ts | HEAD 214fa9ac |
| AC7 | 型・lint・cspell・全 unit 健全 | svelte-check / biome / cspell / vitest | svelte-check 0 ERROR / biome クリーン / cspell クリーン / unit 2800 passed |

## 変更タイプ

- [x] fix: バグ修正（データ喪失）
- [x] feat: 新機能（backup 対象拡張）

## 影響範囲・変更コンポーネント

- [x] サービス層（export-service / import-service）
- [x] DB 層（evaluation repo: interface + sqlite/dynamodb/demo + facade に findRestDaysByChild / insertRestDayForRestore 追加）
- [x] ドメイン型（export-format）

**影響を受ける機能**: バックアップ export / import（NUC/SQLite のみ実データ）。UI 非変更。clear は evaluation.deleteByTenantId で children 削除前に削除済（no-cascade FK 阻害なし）。

## テスト & 安全装置セルフチェック

**検証コマンド（機械検証証跡）**: `npx vitest run tests/unit/services/ tests/unit/db/` → 2800 passed / `npx biome check --error-on-warnings .` → クリーン / `npx svelte-check --tsconfig ./tsconfig.json` → 0 ERROR

- [x] **npm run pre-ready -- --pr 3329rd 全 Step PASS**
- [x] 追加・変更テスト: completeness に おやすみ日 round-trip 保全。export-service.test の evaluation-repo mock に findRestDaysByChild 追加
- [x] **DynamoDB 実装変更時**: restDays は DynamoDB 非保存 (insertRestDay が元々 no-op、Pre-PMF fallback)。新 find/restore も同方針 no-op で dynamodb-pre-pmf-fallback テスト整合
- [x] **スキーマ変更**: なし

## スクリーンショット / ビジュアルデモ

**該当なし**: .svelte / .css 変更なし（バックエンドのデータ経路のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: findRestDaysByChild / insertRestDayForRestore を 3 実装 + facade で等価。他 backup entity と同パターン
- [x] **DynamoDB 整合**: restDays は元々 DynamoDB 非保存のため、新 backup メソッドも no-op で一貫（stub 退行でなく既存方針の踏襲）
- [x] **データ整合**: reason / createdAt を保全
- [x] **YAGNI**: restDays 1 テーブルのみ

## 横展開・影響波及チェック

- [x] **clear FK 確認**: rest_days.child_id は no-cascade だが evaluation.deleteByTenantId が children 削除前 (deleteTenantScopedData) で restDays を削除済 → FK 阻害なし
- [x] **設計書同期** (ADR-0001): registry の restDays 分類を exported に更新（DynamoDB 非保存方針も reason に明記）
- [x] **並行 PR overlap** (#1200): #3448/#3470 等が develop へ先行マージ済。develop 最新化済

## レビュー依頼事項・破壊的変更

- [x] 破壊的変更は**含まれない**（新規 optional field のみ、旧 backup の import も継続可）

**レビュー依頼**: restDays を DynamoDB では no-op（NUC/SQLite 専用）のまま backup 対象に含める判断をご確認ください（DynamoDB 環境では restDays がそもそも保存されないため backup 対象データなし、という整理）。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **npm run pre-ready -- --pr 3329rd 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] Phase 分割: 残 source 1 件 (childCustomVoices) は registry を起点に対応
- [x] UI / 認証画面変更: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
