### PR TITLE
feat: #3329 子のカスタム音声の backup round-trip 実装 (最後の未 export source / #3329 完遂)

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -389,6 +389,24 @@ export interface ExportRestDay {
 	createdAt: string;
 }
 
+/**
+ * #3329: 子のカスタム音声 (ユーザーがアップロードした録音)。音声ファイル本体は #3077 の
+ * ZIP 同梱静的ファイル機構で別途復元されるため、本 export は DB 行 (scene/label/durationMs/
+ * isActive/createdAt) + `voiceRelPath` (tenant prefix を除いた `voices/<oldChildId>/<rest>`) を保持する。
+ * import 時に childRef で childId を解決し、filePath/publicUrl を新 tenant+childId へ再構成する
+ * (#3077 が voices/<newChildId>/ へ復元したファイルと一致)。
+ */
+export interface ExportChildVoice {
+	childRef: string;
+	scene: string;
+	label: string;
+	/** tenant prefix を除いた相対 storage パス (`voices/<oldChildId>/<rest>`)。import で新 tenant+childId へ再構成 */
+	voiceRelPath: string;
+	durationMs: number | null;
+	isActive: number;
+	createdAt: string;
+}
+
 export interface ExportChecklistTemplate {
 	childRef: string;
 	name: string;
@@ -479,6 +497,8 @@ export interface ExportTransactionData {
 	checklistOverrides: ExportChecklistOverride[];
 	/** #3329: per-child おやすみ日 (createdAt 保全。DynamoDB では空) */
 	restDays: ExportRestDay[];
+	/** #3329: 子のカスタム音声 DB 行 (ファイル本体は #3077 ZIP 同梱で復元、行は voiceRelPath で再結合) */
+	childVoices: ExportChildVoice[];
 	childAvatarItems: never[];
 	dailyMissions: ExportDailyMission[];
 	/** #3329: 各種設定 (tenant-scoped KVS、allowlist 済キーのみ。pin_hash 等の秘匿キーは除外) */

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -217,9 +217,9 @@ export const BACKUP_ENTITY_REGISTRY: Record<string, BackupEntityEntry> = {
 	childCustomVoices: {
 		classification: 'source',
 		schemaTable: 'childCustomVoices',
-		backupStatus: 'not-yet-exported',
+		backupStatus: 'exported',
 		reason:
-			'子のカスタム音声 (ユーザーがアップロードした録音、file_path/public_url はストレージ実体参照)。再生成不能のユーザー生成データ。export 未対応 (#3329)',
+			'子のカスタム音声 (ユーザーがアップロードした録音)。export/import 実装済 (#3329)。DB 行 (scene/label/durationMs/isActive/createdAt) を保全し、filePath/publicUrl は voiceRelPath 経由で import 時に新 tenant+childId へ再構成する。音声ファイル本体は #3077 ZIP 同梱静的ファイル機構が voices/<newChildId>/ へ復元する。clear は voice.deleteByChild で削除済',
 	},
 
 	// ---- derived: source から再計算で復元 (backup 不要) ----

--- a/src/lib/server/db/demo/voice-repo.ts
+++ b/src/lib/server/db/demo/voice-repo.ts
@@ -30,6 +30,21 @@ export async function insert(
 	return { id: 0 };
 }
 
+export async function findAllByChild(
+	_childId: number,
+	_tenantId: string,
+): Promise<ChildCustomVoice[]> {
+	return [];
+}
+
+export async function insertForRestore(
+	_voice: Omit<ChildCustomVoice, 'id'>,
+	_tenantId: string,
+): Promise<{ id: number }> {
+	// Stub: return dummy id
+	return { id: 0 };
+}
+
 export async function setActive(
 	_id: number,
 	_childId: number,

--- a/src/lib/server/db/dynamodb/voice-repo.ts
+++ b/src/lib/server/db/dynamodb/voice-repo.ts
@@ -111,6 +111,52 @@ export async function insert(
 	return { id };
 }
 
+/** #3329 backup: child の全カスタム音声 (scene 不問)。 */
+export async function findAllByChild(
+	childId: number,
+	tenantId: string,
+): Promise<ChildCustomVoice[]> {
+	const result = await getDocClient().send(
+		new QueryCommand({
+			TableName: TABLE_NAME,
+			KeyConditionExpression: 'PK = :pk',
+			ExpressionAttributeValues: { ':pk': voicePK(childId, tenantId) },
+		}),
+	);
+	const voices = (result.Items ?? []).map((item) => toEntity(item, tenantId));
+	voices.sort((a, b) => a.scene.localeCompare(b.scene));
+	return voices;
+}
+
+/** #3329 backup restore 用: createdAt / filePath / publicUrl / isActive を保全して音声行を復元する。 */
+export async function insertForRestore(
+	voice: Omit<ChildCustomVoice, 'id'>,
+	_tenantId: string,
+): Promise<{ id: number }> {
+	const id = await nextId('voice', voice.tenantId);
+	await getDocClient().send(
+		new PutCommand({
+			TableName: TABLE_NAME,
+			Item: {
+				...voiceKey(voice.childId, id, voice.tenantId),
+				GSI1PK: `VOICEID#${padId(id)}`,
+				GSI1SK: 'DETAIL',
+				voiceId: id,
+				childId: voice.childId,
+				scene: voice.scene,
+				label: voice.label,
+				filePath: voice.filePath,
+				publicUrl: voice.publicUrl,
+				durationMs: voice.durationMs,
+				isActive: voice.isActive,
+				tenantId: voice.tenantId,
+				createdAt: voice.createdAt,
+			},
+		}),
+	);
+	return { id };
+}
+
 export async function setActive(
 	id: number,
 	childId: number,

--- a/src/lib/server/db/interfaces/voice-repo.interface.ts
+++ b/src/lib/server/db/interfaces/voice-repo.interface.ts
@@ -9,6 +9,18 @@ export interface IVoiceRepo {
 		tenantId: string,
 	): Promise<ChildCustomVoice | null>;
 	insert(voice: Omit<ChildCustomVoice, 'id' | 'createdAt'>): Promise<{ id: number }>;
+
+	/** #3329 backup: child の全カスタム音声 (scene 不問、export 用)。 */
+	findAllByChild(childId: number, tenantId: string): Promise<ChildCustomVoice[]>;
+
+	/**
+	 * #3329 backup restore 用: createdAt / filePath / publicUrl / isActive を保全して音声行を復元する。
+	 * insert は createdAt を now で発番するため round-trip で作成日時が失われる。本メソッドは
+	 * 呼び出し側が新 tenant+childId へ remap 済の filePath/publicUrl をそのまま書き戻す
+	 * (音声ファイル本体は #3077 importStaticFiles が voices/<newChildId>/ へ復元済)。id は新規採番。
+	 */
+	insertForRestore(voice: Omit<ChildCustomVoice, 'id'>, tenantId: string): Promise<{ id: number }>;
+
 	setActive(id: number, childId: number, scene: string, tenantId: string): Promise<void>;
 	deleteById(id: number, tenantId: string): Promise<void>;
 	deleteByChild(childId: number, tenantId: string): Promise<void>;

--- a/src/lib/server/db/sqlite/voice-repo.ts
+++ b/src/lib/server/db/sqlite/voice-repo.ts
@@ -54,6 +54,28 @@ export async function insert(
 	return { id: Number(result.lastInsertRowid) };
 }
 
+/** #3329 backup: child の全カスタム音声 (scene 不問、export 用)。 */
+export async function findAllByChild(
+	childId: number,
+	_tenantId: string,
+): Promise<ChildCustomVoice[]> {
+	return db
+		.select()
+		.from(childCustomVoices)
+		.where(eq(childCustomVoices.childId, childId))
+		.orderBy(childCustomVoices.scene)
+		.all() as ChildCustomVoice[];
+}
+
+/** #3329 backup restore 用: createdAt / filePath / publicUrl / isActive を保全して音声行を復元する。 */
+export async function insertForRestore(
+	voice: Omit<ChildCustomVoice, 'id'>,
+	_tenantId: string,
+): Promise<{ id: number }> {
+	const result = db.insert(childCustomVoices).values(voice).run();
+	return { id: Number(result.lastInsertRowid) };
+}
+
 export async function setActive(
 	id: number,
 	childId: number,

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -17,6 +17,7 @@ import {
 	type ExportChild,
 	type ExportChildActivity,
 	type ExportChildChallenge,
+	type ExportChildVoice,
 	type ExportData,
 	type ExportEvaluation,
 	type ExportLoginBonus,
@@ -52,6 +53,7 @@ import { getSettings } from '$lib/server/db/settings-repo';
 import { findSpecialRewards } from '$lib/server/db/special-reward-repo';
 import { findRecentStatusHistory, findStatuses } from '$lib/server/db/status-repo';
 import { logger } from '$lib/server/logger';
+import { tenantPrefix } from '$lib/server/storage-keys';
 
 // カテゴリID → コード マッピング（5件固定）
 const CATEGORY_ID_TO_CODE: Record<number, string> = {
@@ -244,6 +246,7 @@ interface ChildTransactionData {
 	checklistLogs: ExportChecklistLog[];
 	checklistOverrides: ExportChecklistOverride[];
 	restDays: ExportRestDay[];
+	childVoices: ExportChildVoice[];
 }
 
 /**
@@ -602,6 +605,22 @@ async function collectForChild(
 		createdAt: r.createdAt,
 	}));
 
+	// #3329: 子のカスタム音声 DB 行。filePath から tenant prefix を除いた相対パス (voices/<childId>/<rest>)
+	// を voiceRelPath として出力し、import 時に新 tenant+childId へ再構成する。音声ファイル本体は
+	// #3077 ZIP 同梱機構が別途復元する。
+	const voicesRaw = await getRepos().voice.findAllByChild(childId, tenantId);
+	warnIfTruncated('childVoices', childId, voicesRaw.length);
+	const prefix = tenantPrefix(tenantId);
+	const childVoicesOut: ExportChildVoice[] = voicesRaw.map((v) => ({
+		childRef,
+		scene: v.scene,
+		label: v.label,
+		voiceRelPath: v.filePath.startsWith(prefix) ? v.filePath.slice(prefix.length) : v.filePath,
+		durationMs: v.durationMs,
+		isActive: v.isActive,
+		createdAt: v.createdAt,
+	}));
+
 	return {
 		childActivities: childActivitiesOut,
 		activityLogs: activityLogsOut,
@@ -621,6 +640,7 @@ async function collectForChild(
 		checklistLogs: checklistLogsOut,
 		checklistOverrides: checklistOverridesOut,
 		restDays: restDaysOut,
+		childVoices: childVoicesOut,
 	};
 }
 
@@ -682,6 +702,7 @@ async function collectTransactionData(
 		checklistLogs: perChild.flatMap((p) => p.checklistLogs), // #3078
 		checklistOverrides: perChild.flatMap((p) => p.checklistOverrides), // #3329
 		restDays: perChild.flatMap((p) => p.restDays), // #3329
+		childVoices: perChild.flatMap((p) => p.childVoices), // #3329
 		childAvatarItems: [],
 		dailyMissions: [], // Phase 2: エフェメラルデータ対応後に対応
 		settings: settingsOut, // #3329

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -91,6 +91,9 @@ export interface ImportResult {
 	/** #3329: per-child おやすみ日の取込件数 (DynamoDB では no-op で skip) */
 	restDaysImported: number;
 	restDaysSkipped: number;
+	/** #3329: 子のカスタム音声 DB 行の取込件数 (ファイル本体は #3077 が復元) */
+	childVoicesImported: number;
+	childVoicesSkipped: number;
 	loginBonusesImported: number;
 	loginBonusesSkipped: number;
 	statusHistoryImported: number;
@@ -307,6 +310,8 @@ export async function importFamilyData(
 	await importChecklistOverridesData(data, childIdMap, tenantId, result);
 	// #3329: おやすみ日を createdAt 保全で復元。childIdMap のみ必要 (DynamoDB では insert が no-op)。
 	await importRestDaysData(data, childIdMap, tenantId, result);
+	// #3329: 子のカスタム音声 DB 行を復元 (filePath/publicUrl を新 tenant+childId へ remap)。childIdMap のみ必要。
+	await importChildVoicesData(data, childIdMap, tenantId, result);
 	await importSpecialRewards(data, childIdMap, tenantId, result);
 	// #3329: ごほうび交換/購入履歴。reward を先に取込済 (FK rewardRef → rewardId を再解決) なので
 	// importSpecialRewards の後に実行する。
@@ -831,6 +836,61 @@ async function importRestDaysData(
 	}
 }
 
+/** voiceRelPath (`voices/<oldChildId>/<rest>`) の rest 部を抽出する正規表現 (#3329)。 */
+const VOICE_REL_PATH_RE = /^voices\/\d+\/(.+)$/;
+
+/**
+ * 子のカスタム音声 DB 行を復元する (#3329)。
+ * childRef で取込先 child に解決し、voiceRelPath から rest (uuid.ext) を取り出して
+ * filePath = `<tenantPrefix>voices/<newChildId>/<rest>` / publicUrl = `/<filePath>` を新環境向けに
+ * 再構成して書き戻す (音声ファイル本体は #3077 importStaticFiles が同一パスへ復元済)。createdAt/
+ * scene/label/durationMs/isActive を保全。child or path 解決不能行は skip。
+ */
+async function importChildVoicesData(
+	data: ExportData,
+	childIdMap: Map<string, number>,
+	tenantId: string,
+	result: ImportResult,
+): Promise<void> {
+	for (const v of data.data.childVoices ?? []) {
+		const childId = childIdMap.get(v.childRef);
+		if (!childId) {
+			result.childVoicesSkipped++;
+			continue;
+		}
+		const rest = VOICE_REL_PATH_RE.exec(v.voiceRelPath)?.[1];
+		if (!rest) {
+			result.childVoicesSkipped++;
+			result.warnings.push(
+				`音声スキップ: voiceRelPath「${v.voiceRelPath}」(child=${v.childRef}) を解決できません`,
+			);
+			continue;
+		}
+		const filePath = `${tenantPrefix(tenantId)}voices/${childId}/${rest}`;
+		const publicUrl = storageKeyToPublicUrl(filePath);
+		try {
+			await getRepos().voice.insertForRestore(
+				{
+					childId,
+					scene: v.scene,
+					label: v.label,
+					filePath,
+					publicUrl,
+					durationMs: v.durationMs,
+					isActive: v.isActive,
+					tenantId,
+					createdAt: v.createdAt,
+				},
+				tenantId,
+			);
+			result.childVoicesImported++;
+		} catch (e) {
+			result.childVoicesSkipped++;
+			result.errors.push(`音声 insert 失敗 (child=${v.childRef}, scene=${v.scene}): ${String(e)}`);
+		}
+	}
+}
+
 function createEmptyImportResult(): ImportResult {
 	return {
 		childrenImported: 0,
@@ -858,6 +918,8 @@ function createEmptyImportResult(): ImportResult {
 		parentMessagesSkipped: 0,
 		checklistOverridesImported: 0,
 		checklistOverridesSkipped: 0,
+		childVoicesImported: 0,
+		childVoicesSkipped: 0,
 		restDaysImported: 0,
 		restDaysSkipped: 0,
 		activityPrefsImported: 0,

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -866,6 +866,19 @@ async function importChildVoicesData(
 			);
 			continue;
 		}
+		// CWE-22 path traversal 防御 (default-deny): 正常 export の rest は `<uuid>.<ext>` (storage-keys.ts
+		// voiceKey、単一ファイル名) だが、backup は untrusted input。細工 voiceRelPath
+		// (`voices/1/../../../../etc/secret`) で rest に `..` / 絶対パス / バックスラッシュ等が紛れ込むと
+		// filePath/publicUrl が tenant 境界外を指し cross-tenant LFI 相当になる。importStaticFiles と同じ
+		// isSafeRelativePath で rest を検証し、unsafe なら insert せず skip + warning で 1 件落とす
+		// (全 restore は止めない)。
+		if (!isSafeRelativePath(rest)) {
+			result.childVoicesSkipped++;
+			result.warnings.push(
+				`音声スキップ: voiceRelPath「${v.voiceRelPath}」(child=${v.childRef}) に不正なパスが含まれます`,
+			);
+			continue;
+		}
 		const filePath = `${tenantPrefix(tenantId)}voices/${childId}/${rest}`;
 		const publicUrl = storageKeyToPublicUrl(filePath);
 		try {
@@ -1596,9 +1609,10 @@ async function importSpecialRewards(
 const STATIC_FILE_PATH_RE = /^(avatars|voices|generated)\/(\d+)\/(.+)$/;
 
 /**
- * ZIP 相対パスに path-escape (`..` や絶対パス) が含まれていないか検証する (zip-slip 防御)。
- * `STATIC_FILE_PATH_RE` の `rest` (`.+`) は任意文字を許すため、ここで `..` セグメント・
- * 先頭スラッシュ・Windows ドライブ等を弾く。安全なら true。
+ * 相対 storage パスに path-escape (`..` や絶対パス) が含まれていないか検証する (zip-slip / CWE-22 防御)。
+ * `STATIC_FILE_PATH_RE` の `rest` (`.+`、importStaticFiles) / `VOICE_REL_PATH_RE` の `rest`
+ * (`.+`、importChildVoicesData) は任意文字を許すため、ここで `..` セグメント・先頭スラッシュ・
+ * Windows ドライブ・バックスラッシュ等を弾く。安全なら true。
  */
 function isSafeRelativePath(relPath: string): boolean {
 	// バックスラッシュは OS 非依存で無条件拒否する (Linux では `\` がファイル名のリテラル

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -122,15 +122,11 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 		}
 	});
 
-	it('未 export の source 実体ベースライン (#3329 残課題、ratchet)', () => {
-		// export に足したら 'exported' へ flip し本ベースラインから外す (意図的更新)。
-		// 新たな not-yet-exported source の silent 増加を禁止する (回帰ネット)。
-		expect(notYetExportedSourceEntities()).toEqual([
-			// 残り 1 件: childCustomVoices (ユーザー録音音声、ストレージ実体参照で別途検討)。
-			// その他 (activityPref/certificate/checklist*/parentMessage/restDays/rewardRedemption/
-			// setting/stampCard/stampEntry/siblingCheer/childChallenge*) は #3329 で export 実装済 → exported へ flip。
-			'childCustomVoices',
-		]);
+	it('未 export の source 実体ベースライン (#3329 完遂、ratchet)', () => {
+		// #3329 で全 source 実体の export/import を実装完了 → 未 export source は 0 件。
+		// 以後 not-yet-exported な source を新規追加すると本 assert が fail する (新 source の
+		// backup 取りこぼしを CI で即検知する回帰ネット)。
+		expect(notYetExportedSourceEntities()).toEqual([]);
 	});
 
 	it('excluded 繰延 (deferred) 実体ベースライン (#3329 Phase 2 再分類強制、ratchet)', () => {

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -254,6 +254,23 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 			T,
 		);
 
+		// #3329: 子のカスタム音声 DB 行を 1 件 seed (filePath/publicUrl に childId 含む)。round-trip 後に
+		// createdAt/scene/label が保全され、filePath/publicUrl が新 childId へ remap されることを検証する。
+		await getRepos().voice.insertForRestore(
+			{
+				childId: 1,
+				scene: 'complete',
+				label: 'できたよ',
+				filePath: `tenants/${T}/voices/1/sample.mp3`,
+				publicUrl: `/tenants/${T}/voices/1/sample.mp3`,
+				durationMs: 1200,
+				isActive: 1,
+				tenantId: T,
+				createdAt: '2026-02-20T00:00:00Z',
+			},
+			T,
+		);
+
 		// --- export ---
 		const data = await exportFamilyData({ tenantId: T });
 		// export が全種別を捕捉していること (sanity)
@@ -283,6 +300,10 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		);
 		expect(data.data.restDays.length, 'export:おやすみ日').toBe(1);
 		expect(data.data.restDays[0]?.reason, 'export:おやすみ日 reason').toBe('sick');
+		expect(data.data.childVoices.length, 'export:音声').toBe(1);
+		expect(data.data.childVoices[0]?.voiceRelPath, 'export:音声 voiceRelPath').toBe(
+			'voices/1/sample.mp3',
+		);
 		expect(data.data.parentMessages.length, 'export:メッセージ').toBe(1);
 		expect(data.data.parentMessages[0]?.shownAt, 'export:メッセージ shownAt').toBe(
 			'2026-02-10T18:00:00Z',
@@ -365,6 +386,19 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(restoredRestDays[0]?.reason, 'おやすみ日 reason 保全').toBe('sick');
 		expect(restoredRestDays[0]?.createdAt, 'おやすみ日 createdAt 保全').toBe(
 			'2026-03-03T00:00:00Z',
+		);
+
+		// #3329: カスタム音声 DB 行が createdAt/scene 保全 + filePath/publicUrl を新 childId へ remap して復元される。
+		const restoredVoices = await getRepos().voice.findAllByChild(cid, T);
+		expect(restoredVoices.length, '音声').toBe(1);
+		expect(restoredVoices[0]?.scene, '音声 scene 保全').toBe('complete');
+		expect(restoredVoices[0]?.label, '音声 label 保全').toBe('できたよ');
+		expect(restoredVoices[0]?.createdAt, '音声 createdAt 保全').toBe('2026-02-20T00:00:00Z');
+		expect(restoredVoices[0]?.filePath, '音声 filePath remap').toBe(
+			`tenants/${T}/voices/${cid}/sample.mp3`,
+		);
+		expect(restoredVoices[0]?.publicUrl, '音声 publicUrl remap').toBe(
+			`/tenants/${T}/voices/${cid}/sample.mp3`,
 		);
 	});
 

--- a/tests/unit/services/import-service.test.ts
+++ b/tests/unit/services/import-service.test.ts
@@ -43,11 +43,16 @@ vi.mock('$lib/server/db/activity-repo', () => ({
 // factory の childActivity facade を mock する (insertActivity / findActivitiesByChild)。
 const mockChildActivityInsert = vi.fn();
 const mockChildActivityFindByChild = vi.fn();
+// #3329: childVoices DB 行復元は getRepos().voice.insertForRestore 経由。
+const mockVoiceInsertForRestore = vi.fn();
 vi.mock('$lib/server/db/factory', () => ({
 	getRepos: () => ({
 		childActivity: {
 			insertActivity: (...args: unknown[]) => mockChildActivityInsert(...args),
 			findActivitiesByChild: (...args: unknown[]) => mockChildActivityFindByChild(...args),
+		},
+		voice: {
+			insertForRestore: (...args: unknown[]) => mockVoiceInsertForRestore(...args),
 		},
 	}),
 }));
@@ -1574,6 +1579,65 @@ describe('importFamilyData', () => {
 			expect(result.staticFilesRestored).toBe(1); // voices/7/x.mp3
 			// avatar 実ファイルが無いため null 化 (存在しない /tenants/.../avatars/202/keep.png を指さない)
 			expect(mockUpdateChildAvatarUrl).toHaveBeenCalledWith(202, null, TENANT);
+		});
+	});
+
+	describe('子のカスタム音声 (childVoices) のインポート (#3329 / CWE-22 path traversal 防御)', () => {
+		const makeVoice = (childRef: string, voiceRelPath: string) => ({
+			childRef,
+			scene: 'praise' as const,
+			label: 'よくできました',
+			voiceRelPath,
+			durationMs: 1200,
+			isActive: 1,
+			createdAt: '2026-03-15T08:30:00Z',
+		});
+
+		it('正常な voiceRelPath (voices/<id>/<uuid>.ext) は新 tenant+childId へ再構成され insert される', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.childVoices = [makeVoice('c1', 'voices/7/abcd-1234.mp3')];
+			mockInsertChild.mockResolvedValue({ id: 101 });
+			mockVoiceInsertForRestore.mockResolvedValue(undefined);
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.childVoicesImported).toBe(1);
+			expect(result.childVoicesSkipped).toBe(0);
+			expect(mockVoiceInsertForRestore).toHaveBeenCalledTimes(1);
+			const row = mockVoiceInsertForRestore.mock.calls[0]?.[0];
+			expect(row.filePath).toBe(`tenants/${TENANT}/voices/101/abcd-1234.mp3`);
+			expect(row.publicUrl).toBe(`/tenants/${TENANT}/voices/101/abcd-1234.mp3`);
+		});
+
+		it('細工された voiceRelPath (`..` 等のトラバーサル) は insert されず skip + warning になる', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.childVoices = [
+				makeVoice('c1', 'voices/1/../../../../etc/secret'), // 親ディレクトリ脱出
+				makeVoice('c1', 'voices/1/..\\..\\evil'), // バックスラッシュ脱出 (Windows)
+				makeVoice('c1', 'voices/1//etc/passwd'), // rest 先頭スラッシュ = 絶対パス
+				makeVoice('c1', 'voices/7/safe.mp3'), // 正常エントリ (1 件だけ通る)
+			];
+			mockInsertChild.mockResolvedValue({ id: 101 });
+			mockVoiceInsertForRestore.mockResolvedValue(undefined);
+
+			const result = await importFamilyData(data, TENANT);
+
+			// 正常 1 件のみ insert、トラバーサル 3 件は skip
+			expect(result.childVoicesImported).toBe(1);
+			expect(result.childVoicesSkipped).toBe(3);
+			expect(mockVoiceInsertForRestore).toHaveBeenCalledTimes(1);
+			// tenant 境界外を指す filePath / publicUrl は一切 insert されない
+			for (const call of mockVoiceInsertForRestore.mock.calls) {
+				const [row] = call;
+				expect(String(row.filePath)).not.toContain('..');
+				expect(String(row.filePath)).not.toContain('etc/secret');
+				expect(String(row.filePath)).not.toContain('etc/passwd');
+				expect(String(row.filePath)).not.toContain('\\');
+				expect(String(row.filePath).startsWith(`tenants/${TENANT}/voices/`)).toBe(true);
+			}
+			expect(result.warnings.some((w) => w.includes('不正なパス'))).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全ユーザー（バックアップ・移管利用者）

**解決する課題**: バックアップ ZIP を別環境へ import すると **子のカスタム音声（ユーザーがアップロードした録音）の DB 行が一切復元されず、音声が消える**（本番 t-82c17558 の喪失の一部、未 export source の最後の 1 件）。音声ファイル本体は #3077 の ZIP 同梱機構で復元されていたが、それを参照する DB 行が export/import されていなかった。

**期待される効果**: カスタム音声の DB 行が round-trip 復元され、filePath/publicUrl が新環境（新 tenant+childId）へ再構成されて #3077 が復元した音声ファイルと一致する。**これで #3329 の全 source 実体の backup 実装が完了**（未 export source 0 件）。

## 関連 Issue

関連: #3329 #3328（未 export source の最後の 1 件 childCustomVoices を実装。本 PR で #3329 の全 source backup 実装が完了し ratchet ベースラインが空になる）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|----|------|---------|------------------|
| AC1 | 音声 DB 行を export に含める (per-child、voiceRelPath で storage path を tenant 非依存化) | export-format / export-service | HEAD bd075132 |
| AC2 | import で childRef 解決 + voiceRelPath から filePath/publicUrl を新 tenant+childId へ再構成 | import-service importChildVoicesData | HEAD bd075132 |
| AC3 | round-trip (createdAt/scene/label 保全 + filePath/publicUrl の childId remap) | backup-roundtrip-completeness.test.ts | HEAD bd075132 |
| AC4 | 音声ファイル本体は #3077 が voices/<newChildId>/ へ復元（行とパス一致） | importStaticFiles (#3077) + 再構成パス整合 | HEAD bd075132 |
| AC5 | insert (createdAt=now) と分離した復元専用経路を 3 実装で機能等価提供 | repo findAllByChild / insertForRestore (sqlite/dynamodb/demo) | HEAD bd075132 |
| AC6 | registry の childCustomVoices を exported へ flip + ratchet ベースライン空 (#3329 完遂) | backup-entity-registry.test.ts | HEAD bd075132 |
| AC7 | 型・lint・cspell・全 unit 健全 | svelte-check / biome / cspell / vitest | svelte-check 0 ERROR / biome クリーン / cspell クリーン / unit 2804 passed |

## 変更タイプ

- [x] fix: バグ修正（データ喪失）
- [x] feat: 新機能（backup 対象拡張 — #3329 完遂）

## 影響範囲・変更コンポーネント

- [x] サービス層（export-service / import-service）
- [x] DB 層（voice repo: interface + sqlite/dynamodb/demo に findAllByChild / insertForRestore 追加）
- [x] ドメイン型（export-format）

**影響を受ける機能**: バックアップ export / import。UI 非変更。clear は voice.deleteByChild で children 削除前に削除済（child_id に FK なし、阻害なし）。

## テスト & 安全装置セルフチェック

**検証コマンド（機械検証証跡）**: `npx vitest run tests/unit/services/ tests/unit/db/` → 2804 passed / `npx biome check --error-on-warnings .` → クリーン / `npx svelte-check --tsconfig ./tsconfig.json` → 0 ERROR

- [x] **npm run pre-ready -- --pr 3329cv 全 Step PASS**
- [x] 追加・変更テスト: completeness にカスタム音声 DB 行 round-trip（createdAt/scene 保全 + filePath/publicUrl の新 childId remap）を追加
- [x] **DynamoDB 実装変更時**: findAllByChild / insertForRestore を sqlite/dynamodb/demo で機能等価に実装（voice 行は DynamoDB でも実保存される）
- [x] **スキーマ変更**: なし

## スクリーンショット / ビジュアルデモ

**該当なし**: .svelte / .css 変更なし（バックエンドのデータ経路のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY**: findAllByChild / insertForRestore を 3 実装で等価。他 backup entity と同パターン
- [x] **storage path remap**: voiceRelPath（tenant prefix 除去）で env 非依存化し、import で新 tenant+childId へ再構成。#3077 の avatarUrl remap と同型の発想
- [x] **データ整合**: createdAt/scene/label/durationMs/isActive を保全。音声ファイル本体は #3077 が同一パスへ復元
- [x] **既知 caveat**: JSON-only import（静的ファイル無し）では行のパスが実体不在になる（#3077 アバター同様の既知制約。full ZIP backup では一致）

## 横展開・影響波及チェック

- [x] **clear FK 確認**: child_custom_voices.child_id は FK 制約なし（`.references()` 無し）。voice.deleteByChild が children 削除前に削除済 → 阻害なし
- [x] **設計書同期** (ADR-0001): registry の childCustomVoices 分類を exported に更新 + ratchet ベースラインを空に（#3329 完遂を機械的に固定）
- [x] **並行 PR overlap** (#1200): #3470/#3481 等が develop へ先行マージ済。develop 最新化済

## レビュー依頼事項・破壊的変更

- [x] 破壊的変更は**含まれない**（新規 optional field のみ、旧 backup の import も継続可）

**レビュー依頼**: filePath/publicUrl を voiceRelPath 経由で新 tenant+childId へ再構成する方針（#3077 が同一パスへファイル復元する前提）と、JSON-only import 時の caveat 整理をご確認ください。本 PR で #3329 の全 source backup が完了します。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **npm run pre-ready -- --pr 3329cv 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] Phase 分割: 本 PR で #3329 の全 source backup 実装が完了（残 source 0 件）
- [x] UI / 認証画面変更: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
