### PR TITLE
refactor: #3484 activity 値検証を service 層単一強制点へ push-down (class-lock)

### DIFF
--- a/src/lib/server/services/activity-service.ts
+++ b/src/lib/server/services/activity-service.ts
@@ -1,4 +1,9 @@
-import type { GradeLevel, Source } from '$lib/domain/validation/activity';
+import {
+	type GradeLevel,
+	type Source,
+	sanitizeActivityNameField,
+	sanitizeDailyLimit,
+} from '$lib/domain/validation/activity';
 import type { UiMode } from '$lib/domain/validation/age-tier-types';
 import {
 	countPointLedgerEntriesByTypeAndDate,
@@ -152,10 +157,12 @@ function _toChildActivityInsertInput(
 		basePoints: input.basePoints,
 		triggerHint: input.triggerHint ?? null,
 		priority: input.priority,
-		// #3422: 親入力を persist (列は child_activities に存在)。
-		dailyLimit: input.dailyLimit ?? null,
-		nameKana: input.nameKana ?? null,
-		nameKanji: input.nameKanji ?? null,
+		// #3422 / #3484: 親入力を persist。値検証は本 service 層の単一強制点で push-down 適用する
+		// (form 4 経路は createActivity→本 helper を通るため callsite ごとの sanitize 重複配線が不要に
+		// なり、新規 callsite でも漏れない。ADR-0061 push-down-pyramid / same-class→guard)。
+		dailyLimit: sanitizeDailyLimit(input.dailyLimit),
+		nameKana: sanitizeActivityNameField(input.nameKana),
+		nameKanji: sanitizeActivityNameField(input.nameKanji),
 	};
 }
 
@@ -173,10 +180,11 @@ function _toChildActivityUpdateInput(
 	if (input.triggerHint !== undefined) update.triggerHint = input.triggerHint;
 	if (input.isMainQuest !== undefined) update.isMainQuest = input.isMainQuest;
 	if (input.priority !== undefined) update.priority = input.priority;
-	// #3422: dailyLimit / nameKana / nameKanji の編集を persist (旧実装は silent drop)。
-	if (input.dailyLimit !== undefined) update.dailyLimit = input.dailyLimit;
-	if (input.nameKana !== undefined) update.nameKana = input.nameKana;
-	if (input.nameKanji !== undefined) update.nameKanji = input.nameKanji;
+	// #3422 / #3484: dailyLimit / nameKana / nameKanji の編集を persist。値検証は service 層の単一
+	// 強制点で push-down 適用 (form 全経路を 1 箇所で covered、ADR-0061)。
+	if (input.dailyLimit !== undefined) update.dailyLimit = sanitizeDailyLimit(input.dailyLimit);
+	if (input.nameKana !== undefined) update.nameKana = sanitizeActivityNameField(input.nameKana);
+	if (input.nameKanji !== undefined) update.nameKanji = sanitizeActivityNameField(input.nameKanji);
 	return update;
 }
 

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -148,7 +148,7 @@ export const actions: Actions = {
 		const ageMin = formData.get('ageMin') ? Number(formData.get('ageMin')) : null;
 		const ageMax = formData.get('ageMax') ? Number(formData.get('ageMax')) : null;
 		const dailyLimitRaw = formData.get('dailyLimit');
-		const dailyLimit = sanitizeDailyLimit(dailyLimitRaw); // #3463 item4: NaN/負/巨大/非整数を [0,99] int or null に clamp
+		const dailyLimit = dailyLimitRaw != null && dailyLimitRaw !== '' ? Number(dailyLimitRaw) : null; // #3484: 値検証は service 層 (createActivity/updateActivity) の単一強制点へ push-down 済
 		const nameKana = String(formData.get('nameKana') ?? '').trim() || null;
 		const nameKanji = String(formData.get('nameKanji') ?? '').trim() || null;
 		const triggerHint = String(formData.get('triggerHint') ?? '').trim() || null;
@@ -221,7 +221,7 @@ export const actions: Actions = {
 		const ageMin = formData.get('ageMin') ? Number(formData.get('ageMin')) : null;
 		const ageMax = formData.get('ageMax') ? Number(formData.get('ageMax')) : null;
 		const dailyLimitRaw = formData.get('dailyLimit');
-		const dailyLimit = sanitizeDailyLimit(dailyLimitRaw); // #3463 item4: NaN/負/巨大/非整数を [0,99] int or null に clamp
+		const dailyLimit = dailyLimitRaw != null && dailyLimitRaw !== '' ? Number(dailyLimitRaw) : null; // #3484: 値検証は service 層 (createActivity/updateActivity) の単一強制点へ push-down 済
 		const nameKana = String(formData.get('nameKana') ?? '').trim() || null;
 		const nameKanji = String(formData.get('nameKanji') ?? '').trim() || null;
 		const triggerHint = String(formData.get('triggerHint') ?? '').trim() || null;

--- a/tests/unit/services/activity-service.test.ts
+++ b/tests/unit/services/activity-service.test.ts
@@ -141,6 +141,48 @@ describe('activity-service', () => {
 		expect(updated?.name).toBe('ラジオたいそう');
 	});
 
+	// #3484 (ADR-0061 push-down / same-class→guard): dailyLimit / nameKana / nameKanji の値検証を
+	// service 層 (createActivity / updateActivity) の単一強制点に push-down した不変条件を fitness
+	// function として lock する。callsite が sanitize を配線していなくても service が必ず clamp するため、
+	// 新規 form callsite で検証漏れが起きても本 test が検出する (instance パッチでなく class を lock)。
+	it('#3484: createActivity が範囲外 dailyLimit / 巨大 nameKana を service 層で clamp する', async () => {
+		const created = await createActivity(
+			{
+				name: 'けんしょう',
+				categoryId: 2,
+				icon: '🔢',
+				basePoints: 5,
+				ageMin: null,
+				ageMax: null,
+				dailyLimit: 1000, // 範囲外 (max 99)
+				nameKana: 'あ'.repeat(120), // max 50 超
+				nameKanji: 'い'.repeat(120),
+			},
+			'test-tenant',
+		);
+		expect(created.dailyLimit).toBe(99); // [0,99] に clamp
+		expect(created.nameKana).toHaveLength(50); // max 50 に切詰め
+		expect(created.nameKanji).toHaveLength(50);
+	});
+
+	it('#3484: updateActivity も範囲外 dailyLimit / 巨大 nameKana を service 層で clamp する', async () => {
+		// 前テスト state 非依存にするため fresh に作成してから更新する。
+		const created = await createActivity(
+			{ name: 'こうしん', categoryId: 2, icon: '🔧', basePoints: 5, ageMin: null, ageMax: null },
+			'test-tenant',
+		);
+		const updated = await updateActivity(
+			created.id,
+			{ dailyLimit: 1000, nameKana: 'う'.repeat(80) },
+			'test-tenant',
+		);
+		expect(updated?.dailyLimit).toBe(99); // 上限超 → 99 に clamp
+		expect(updated?.nameKana).toHaveLength(50);
+		// 負値は安全既定 null (= 1 回固定。無制限 0 への昇格を避ける) になることも確認
+		const neg = await updateActivity(created.id, { dailyLimit: -5 }, 'test-tenant');
+		expect(neg?.dailyLimit).toBeNull();
+	});
+
 	// UT-ACT-08: 活動表示/非表示切替
 	it('UT-ACT-08: 活動表示/非表示切替', async () => {
 		const hidden = await setActivityVisibility(1, false, 'test-tenant');


### PR DESCRIPTION
## 顧客価値・目的

#3463 で activity の値検証を callsite ごとに重複配線していた構造(新規 callsite が増えると不変条件が再度破れる、ADR-0061 push-down-pyramid 違反)を、**service 層の単一強制点への push-down**(class-lock)で解消する。フォームの全経路を 1 箇所で covered にし、将来の検証漏れを fitness function で機械的に防ぐ。

## 関連 Issue

closes #3484

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | nameKana/nameKanji/dailyLimit 検証を service 層 (createActivity/updateActivity) の単一強制点へ push-down | grep | HEAD `22c27aa34` / _toChildActivityInsertInput / _toChildActivityUpdateInput で sanitize。page.server.ts create/update の重複 sanitize を撤去 |
| AC2 | 新規 callsite で検証漏れが起きないことを fitness function / unit test で機械強制 | `npx vitest run tests/unit/services/activity-service.test.ts` | HEAD `22c27aa34` / "#3484: createActivity/updateActivity が範囲外値を service 層で clamp する" 2 ケース。35 passed |
| AC3 | silent 切詰めの user feedback 要否を判断 | — | Pre-PMF accepted-residual: form の maxlength 属性 + 値正規化で十分。侵襲的 feedback は ADR-0010 過剰防衛のため不採用 (ADR-0061 §5 accepted-residual gate の適用) |

bulk(#618)/import(import-service)は repo 直呼びの**明示的 boundary 例外**で各々 sanitize を維持(bulk は name 系を書かず dailyLimit のみ、import は #3463 で sanitize 済)。値検証 LOGIC SSOT は validation/activity.ts の sanitizeDailyLimit/sanitizeActivityNameField の 1 定義。

## 変更タイプ

- [x] リファクタリング (refactor)

## 影響範囲・変更コンポーネント

- `src/lib/server/services/activity-service.ts` — _toChildActivity*Input helper で sanitize (単一強制点)
- `src/routes/(parent)/admin/activities/+page.server.ts` — create/update の重複 sanitize 撤去 (bulk は維持)
- `tests/unit/services/activity-service.test.ts` — service clamp の fitness function

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/services/activity-service.test.ts` <!-- PASS --> → 35 passed
- `npx svelte-check --threshold error` <!-- PASS --> → 0 ERRORS / biome clean

## スクリーンショット / ビジュアルデモ

サーバー側の値検証 push-down (behavior-equivalent) で UI 表示不変。正常値は不変、不正値のみ正規化。SS 対象外。

## コード品質セルフレビュー (#1481)

- 既存の field sanitizer (validation/activity.ts、#3463) を SSOT 再利用 (二重実装なし)
- service が単一強制点になり、新規 form callsite は createActivity 経由で auto-covered

## 横展開・影響波及チェック

- form 4 経路 (create/update/bulk/edit) を確認: create/update は service push-down、bulk は dailyLimit のみ (name 系不使用)、import は #3463 で covered
- fitness function が service 層の clamp を lock → instance 追加でなく class 全体を機械固定 (ADR-0061)

## レビュー依頼事項・破壊的変更

破壊的変更なし。これは ADR-0061 push-down-pyramid + same-class→guard の class-lock 実例。

## 配布済み env / secret (ADR-0006)

env / secret の追加なし。

## Ready for Review チェックリスト

- [x] push-down + fitness function + green
- [x] AC 検証マップ記載
- [x] 全 form 経路の covered 確認

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
