### PR TITLE
fix: #3449 cohort 集計の UTC↔ローカル月混在を UTC SSOT で根治 + 境界不変条件 lock

### DIFF
--- a/src/lib/server/services/cohort-analysis-service.ts
+++ b/src/lib/server/services/cohort-analysis-service.ts
@@ -57,10 +57,19 @@ const MIN_FREE_COHORT_SIZE = 30;
 // ============================================================
 
 /**
- * テナントのサインアップ月を YYYY-MM で返す
+ * #3449: 月境界 SSOT。Date を **UTC 月** `YYYY-MM` に変換する。cohort 鍵・月列挙・churn 判定が
+ * 全て本 helper (UTC 基準) を通ることで、UTC↔ローカル混在による月境界テナント取りこぼしを防ぐ。
+ */
+export function utcMonthKey(d: Date): string {
+	return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+/**
+ * テナントのサインアップ月を YYYY-MM (UTC) で返す。
+ * createdAt は ISO UTC 文字列のため slice(0,7) は UTC 月と一致 (#3449、utcMonthKey と同値)。
  */
 function getSignupMonth(tenant: Tenant): string {
-	return tenant.createdAt.slice(0, 7);
+	return utcMonthKey(new Date(tenant.createdAt));
 }
 
 /**
@@ -163,11 +172,15 @@ export async function getCohortAnalysis(monthsBack = 6): Promise<CohortAnalysisR
 		cohortMap.set(month, existing);
 	}
 
-	// 直近 N ヶ月分のコホートを抽出
+	// 直近 N ヶ月分のコホートを抽出。
+	// #3449: cohort 鍵 (getSignupMonth = createdAt.slice(0,7) = UTC 月) と一致させるため、月列挙も
+	// **UTC 基準**で行う (旧実装は now.getFullYear()/getMonth() のローカル月でズレ、JST 月初 = UTC 前月末に
+	// signup したテナントが key mismatch で取りこぼされ /ops の retention/ARPU/churn が境界分過小集計、
+	// Lambda(UTC)/dev(JST) で結果分岐していた)。UTC を月境界 SSOT に統一する。
 	const targetMonths: string[] = [];
 	for (let i = monthsBack - 1; i >= 0; i--) {
-		const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-		targetMonths.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`);
+		const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1));
+		targetMonths.push(utcMonthKey(d));
 	}
 
 	// 全体メトリクス計算
@@ -177,8 +190,8 @@ export async function getCohortAnalysis(monthsBack = 6): Promise<CohortAnalysisR
 	// ARPU: 月間売上 / 有料ユーザー数 (概算: standard=500, family=780)
 	const arpu = paidTenants.length > 0 ? calculateArpu(paidTenants) : 0;
 
-	// 月次解約率
-	const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+	// 月次解約率。#3449: 「今月」境界も UTC 基準に統一 (cohort 鍵 = UTC 月と整合)。
+	const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
 	const terminatedThisMonth = tenants.filter((t) => {
 		if (t.status !== SUBSCRIPTION_STATUS.TERMINATED) return false;
 		const updated = new Date(t.updatedAt);

--- a/tests/unit/services/cohort-analysis-service.test.ts
+++ b/tests/unit/services/cohort-analysis-service.test.ts
@@ -31,6 +31,7 @@ vi.mock('$lib/server/logger', () => ({
 import {
 	getCohortAnalysis,
 	RETENTION_DAYS,
+	utcMonthKey,
 } from '../../../src/lib/server/services/cohort-analysis-service';
 
 // --- Helper ---
@@ -80,6 +81,32 @@ describe('getCohortAnalysis', () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
+	});
+
+	// #3449 (prod latent バグの不変条件 lock): UTC↔ローカル月混在で月境界 signup テナントが
+	// cohort key mismatch で取りこぼされる問題を、UTC 月 SSOT 統一 (utcMonthKey) で根治した。
+	// fake clock を複数の境界日で parametrize し、境界テナントが正しい UTC 月コホートに入ることを固定する。
+	it('#3449: utcMonthKey は境界時刻でも UTC 月を返す (JST 翌月になる UTC 月末も UTC 月)', () => {
+		// 2026-05-31T23:00:00Z は JST(+9) では 2026-06-01 09:00 = 翌月。だが UTC 月は 2026-05。
+		expect(utcMonthKey(new Date('2026-05-31T23:00:00Z'))).toBe('2026-05');
+		expect(utcMonthKey(new Date('2026-06-01T00:00:00Z'))).toBe('2026-06');
+		expect(utcMonthKey(new Date('2026-12-31T23:59:59Z'))).toBe('2026-12'); // 年境界
+	});
+
+	it.each([
+		// [signup createdAt(UTC), 期待 UTC 月コホート]
+		['2026-05-31T23:00:00Z', '2026-05'], // UTC 月末 = JST 翌月境界
+		['2026-05-01T00:00:00Z', '2026-05'], // UTC 月初
+		['2026-06-30T23:30:00Z', '2026-06'], // 当月 UTC 月末
+	])('#3449: 月境界 signup テナント (%s) が UTC 月コホート %s に取りこぼされず計上される', async (createdAt, expectedMonth) => {
+		mockListAllTenants.mockResolvedValue([
+			makeTenant({ tenantId: 'boundary', createdAt, plan: SUBSCRIPTION_PLAN.MONTHLY }),
+		]);
+		// clock 2026-06-15 / monthsBack=2 → targetMonths = [2026-05, 2026-06] (UTC 列挙)
+		const result = await getCohortAnalysis(2);
+		const cohort = result.cohorts.find((c) => c.month === expectedMonth);
+		expect(cohort, `cohort ${expectedMonth} が targetMonths に存在する`).toBeDefined();
+		expect(cohort?.size).toBe(1); // 境界テナントが当該 UTC 月に計上される
 	});
 
 	it('テナントが 0 件の場合、空のコホートが返る', async () => {

--- a/tests/unit/services/cohort-analysis-service.test.ts
+++ b/tests/unit/services/cohort-analysis-service.test.ts
@@ -1,7 +1,7 @@
 // tests/unit/services/cohort-analysis-service.test.ts
 // コホート別 LTV / チャーン率推移サービスのユニットテスト (#838)
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SUBSCRIPTION_PLAN } from '$lib/domain/constants/subscription-plan';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import type { Tenant } from '../../../src/lib/server/auth/entities';
@@ -64,6 +64,22 @@ function firstCohort(cohorts: Awaited<ReturnType<typeof getCohortAnalysis>>['coh
 // =============================================================
 
 describe('getCohortAnalysis', () => {
+	// #3449 回帰テストの TZ pin (vacuous test 防止 / failing-test-first 成立条件):
+	// 旧バグ (targetMonths をローカル `new Date(y, m-i, 1)` で列挙) は cohort 鍵 (createdAt の UTC 月) と
+	// ローカル月がズレる **非 UTC TZ でのみ**顕在化する。CI 既定の UTC では旧 enumeration も UTC と一致し、
+	// 月境界テナントが取りこぼされないため旧 (develop) コードでもテストが green = 回帰を検出できない。
+	// 本ファイルを Asia/Tokyo に固定し、月末 UTC = JST 翌月になる境界クロック (下記 it.each) で
+	// ローカル列挙が UTC コホート鍵から乖離する状況を再現する (UTC enumeration の HEAD のみ PASS)。
+	// 注: TZ は Date 呼び出しごとに参照されるため beforeAll/afterAll の runtime set で scope 内に閉じる
+	// (process.env.TZ 変更は次の Date 演算から反映、Node 実機検証済)。
+	const ORIGINAL_TZ = process.env.TZ;
+	beforeAll(() => {
+		process.env.TZ = 'Asia/Tokyo';
+	});
+	afterAll(() => {
+		process.env.TZ = ORIGINAL_TZ;
+	});
+
 	// 日付固定クロック (#2078 cohort flake の根治): 本サービスは getSignupMonth が
 	// `createdAt.slice(0,7)` (UTC) でコホート月を決める一方、targetMonths / 各テストの
 	// 月計算は `getMonth()` (ローカル=JST) を使う。両者が混在するため、実日付が UTC↔JST の
@@ -86,6 +102,16 @@ describe('getCohortAnalysis', () => {
 	// #3449 (prod latent バグの不変条件 lock): UTC↔ローカル月混在で月境界 signup テナントが
 	// cohort key mismatch で取りこぼされる問題を、UTC 月 SSOT 統一 (utcMonthKey) で根治した。
 	// fake clock を複数の境界日で parametrize し、境界テナントが正しい UTC 月コホートに入ることを固定する。
+	// TZ pin が実際に効いていることの machine guard (vacuous 回帰の再発防止 / ADR-0061)。
+	// この assert が落ちる = TZ pin 不全 = 下記境界テストが UTC で vacuous 化している、を即検出する。
+	it('#3449 前提: テスト TZ が Asia/Tokyo に固定され UTC とローカル月の境界が再現される', () => {
+		expect(process.env.TZ).toBe('Asia/Tokyo');
+		// Asia/Tokyo が効いていれば local 2026-06-01 00:00 = UTC 前日 15:00 (UTC とローカル月の境界が発生)
+		expect(new Date(2026, 5, 1).toISOString()).toBe('2026-05-31T15:00:00.000Z');
+		// 2026-06-30T23:30Z の local 月は JST で 7 月 (getMonth=6) = 旧コードのローカル列挙が UTC とずれる時刻
+		expect(new Date('2026-06-30T23:30:00Z').getMonth()).toBe(6);
+	});
+
 	it('#3449: utcMonthKey は境界時刻でも UTC 月を返す (JST 翌月になる UTC 月末も UTC 月)', () => {
 		// 2026-05-31T23:00:00Z は JST(+9) では 2026-06-01 09:00 = 翌月。だが UTC 月は 2026-05。
 		expect(utcMonthKey(new Date('2026-05-31T23:00:00Z'))).toBe('2026-05');
@@ -97,12 +123,17 @@ describe('getCohortAnalysis', () => {
 		// [signup createdAt(UTC), 期待 UTC 月コホート]
 		['2026-05-31T23:00:00Z', '2026-05'], // UTC 月末 = JST 翌月境界
 		['2026-05-01T00:00:00Z', '2026-05'], // UTC 月初
-		['2026-06-30T23:30:00Z', '2026-06'], // 当月 UTC 月末
+		['2026-06-30T23:30:00Z', '2026-06'], // 当月 UTC 月末 = JST 翌月境界
 	])('#3449: 月境界 signup テナント (%s) が UTC 月コホート %s に取りこぼされず計上される', async (createdAt, expectedMonth) => {
+		// failing-test-first 成立条件: TZ=Asia/Tokyo + 月末 UTC = JST 翌月になる境界クロックに上書きする。
+		// この時刻だと旧コードのローカル列挙 (JST 7 月基準) targetMonths=[2026-06,2026-07] が
+		// UTC コホート鍵 2026-05 を含まず取りこぼす → develop (旧) で FAIL。
+		// HEAD の UTC 列挙は getUTCMonth=5(6月) 基準で targetMonths=[2026-05,2026-06] のため取りこぼさず PASS。
+		vi.setSystemTime(new Date('2026-06-30T23:30:00Z'));
 		mockListAllTenants.mockResolvedValue([
 			makeTenant({ tenantId: 'boundary', createdAt, plan: SUBSCRIPTION_PLAN.MONTHLY }),
 		]);
-		// clock 2026-06-15 / monthsBack=2 → targetMonths = [2026-05, 2026-06] (UTC 列挙)
+		// clock UTC=2026-06-30T23:30Z / monthsBack=2 → targetMonths(UTC)=[2026-05, 2026-06]
 		const result = await getCohortAnalysis(2);
 		const cohort = result.cohorts.find((c) => c.month === expectedMonth);
 		expect(cohort, `cohort ${expectedMonth} が targetMonths に存在する`).toBeDefined();


### PR DESCRIPTION
## 顧客価値・目的

/ops の cohort/retention/ARPU/churn/LTV 分析の精度を根治。getSignupMonth は UTC 月鍵だが月列挙はローカル月で行っていたため、**月境界(JST 月初 = UTC 前月末)に signup したテナントが取りこぼされ過小集計**され、Lambda(UTC)/dev(JST)で結果が分岐していた。founder の価格/解約判断を誤らせる internal 分析の silent 精度劣化を UTC SSOT 統一で根治する。

## 関連 Issue

closes #3449

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | targetMonths/churn の月列挙を UTC 基準に統一 (UTC SSOT を 1 つに) | grep | HEAD `49c8885b8` / utcMonthKey helper 導入、getSignupMonth/targetMonths/monthStart を全て UTC 化。production に local getMonth/getFullYear 残存なし |
| AC2 | 月境界 signup 取りこぼしゼロの回帰テスト (境界日 parametrize) | `npx vitest run tests/unit/services/cohort-analysis-service.test.ts` | HEAD `49c8885b8` / "#3449: utcMonthKey 境界" + "#3449: 月境界 signup テナント…取りこぼされず計上" it.each 3 ケース(UTC 月末=JST 翌月/月初/当月末)。19 passed |
| AC3 | #2078/#3445 と同 class の date 依存横展開確認 | grep | HEAD `49c8885b8` / cohort-analysis-service の production パスに local 月使用なしを確認。month 境界は utcMonthKey SSOT に集約 |

## 変更タイプ

- [x] バグ修正 (fix)

## 影響範囲・変更コンポーネント

- `src/lib/server/services/cohort-analysis-service.ts` — utcMonthKey SSOT + UTC 統一
- `tests/unit/services/cohort-analysis-service.test.ts` — 境界 parametrized 回帰テスト

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/services/cohort-analysis-service.test.ts` <!-- PASS --> → 19 passed
- `npx svelte-check --threshold error` <!-- PASS --> → 0 ERRORS / biome clean

## スクリーンショット / ビジュアルデモ

/ops 内部分析の集計ロジック修正で UI レイアウト不変(境界テナントが正しく計上されるようになる挙動修正)。SS 対象外。

## コード品質セルフレビュー (#1481)

- 月境界 SSOT を utcMonthKey 1 関数に集約し、getSignupMonth/targetMonths/monthStart が全て同一基準を通る(UTC↔ローカル混在を構造的に排除)
- createdAt は UTC 保存 (memory: UTC保存JST表示) のため UTC 月が正準

## 横展開・影響波及チェック

- cohort-analysis-service の production パスに local getMonth/getFullYear 残存なしを grep 確認
- #2078(margin 拡大の対症療法)/#3445(clock pin)と同 class の date 依存を UTC SSOT で根治

## レビュー依頼事項・破壊的変更

破壊的変更なし。集計鍵が一貫 UTC になり境界テナントが正しく計上される(過小集計の是正)。

## 配布済み env / secret (ADR-0006)

env / secret の追加なし。

## Ready for Review チェックリスト

- [x] root-cause 修正 + 境界回帰テスト + green
- [x] AC 検証マップ記載
- [x] 横展開確認

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
