### PR TITLE
refactor: #3359 labels.ts plan 名 atom 直書きを ${PLAN_FULL_TERMS.*} 化 + ratchet で class-lock (ADR-0045/ADR-0061)

### DIFF
--- a/scripts/check-no-plan-literals.mjs
+++ b/scripts/check-no-plan-literals.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// @ts-nocheck — plain Node lint script。test (labels-plan-literal-ratchet #3359) が checkFile を import
+// するため checkJs:true の svelte-check 型グラフに入るが、本 script は型付け対象外 (scripts/ 他 lint と同方針)。
 /**
  * scripts/check-no-plan-literals.mjs (#972 + Phase 5 F1 #1918)
  *

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -1147,8 +1147,7 @@ export const TUTORIAL_CHAPTER_LABELS = {
 		},
 		'children-3': {
 			title: 'こどもの詳細',
-			description:
-				'各こどもの名前・年齢・ポイント残高が表示されます。「こどもごとの進捗をざっくり把握したい」時にここを見てください。\n\n⭐ 無料プランではこどもを2人まで登録できます。3人以上のきょうだいがいる場合はスタンダードプラン以上で無制限に登録できます。',
+			description: `各こどもの名前・年齢・ポイント残高が表示されます。「こどもごとの進捗をざっくり把握したい」時にここを見てください。\n\n⭐ ${PLAN_FULL_TERMS.free}ではこどもを2人まで登録できます。3人以上のきょうだいがいる場合は${PLAN_FULL_TERMS.standard}以上で無制限に登録できます。`,
 		},
 		'activities-1': {
 			title: '活動一覧',
@@ -4481,8 +4480,7 @@ export const FORGOT_PASSWORD_LABELS = {
 // ============================================================
 
 export const DEMO_REWARDS_LABELS = {
-	upgradeBannerDesc:
-		'無料プランではプリセット閲覧のみ可能です。スタンダードプラン以上にアップグレードすると、カスタムのボーナスごほうびを作成・付与できます。',
+	upgradeBannerDesc: `${PLAN_FULL_TERMS.free}ではプリセット閲覧のみ可能です。${PLAN_FULL_TERMS.standard}以上にアップグレードすると、カスタムのボーナスごほうびを作成・付与できます。`,
 	// #2272 AC2: 「テンプレート」UI 露出を REWARD_TERMS.preset 経由「プリセット」に置換
 	selectTemplateTitleDemo: `2. ${REWARD_TERMS.preset}を選択（またはカスタム）`,
 	confirmGrantTitleDemo: '3. 内容を確認して付与',
@@ -5121,8 +5119,8 @@ export const ADMIN_CHALLENGES_PAGE_LABELS = {
 export const CERTIFICATES_PAGE_LABELS = {
 	pageTitle: '📜 がんばり証明書',
 	backToReportsLink: 'レポートへ',
-	freePlanNotePrefix: '無料プランでは証明書の閲覧のみ可能です。PDF保存は',
-	freePlanNoteLink: 'スタンダードプラン以上',
+	freePlanNotePrefix: `${PLAN_FULL_TERMS.free}では証明書の閲覧のみ可能です。PDF保存は`,
+	freePlanNoteLink: `${PLAN_FULL_TERMS.standard}以上`,
 	freePlanNoteSuffix: 'で利用できます。',
 	emptyTitle: 'まだ証明書がありません',
 	emptyDesc: '活動を記録すると、マイルストーン達成時に証明書が発行されます',

--- a/tests/unit/domain/labels-plan-literal-ratchet.test.ts
+++ b/tests/unit/domain/labels-plan-literal-ratchet.test.ts
@@ -1,0 +1,55 @@
+// tests/unit/domain/labels-plan-literal-ratchet.test.ts
+// #3359 (ADR-0045 §3.3 / ADR-0061 §2 class-lock): labels.ts の compound 内 plan 名 atom 直書き ratchet。
+//
+// 背景: `src/lib/domain/labels.ts` は check-no-plan-literals の allowlist (#1918) で **全体 exempt** されている
+// (compound 組立て layer = terms.ts atom を参照する想定のため)。しかし実際には compound 値の中に
+// 'スタンダードプラン' / '無料プラン' 等の atom 値を直書きした compound が散在し、ADR-0045 §3.3
+// (atom 値は `${PLAN_FULL_TERMS.*}` で参照、文字列直書き禁止) に違反していても CI で検出されない gap がある。
+// #3359 監査 (arch-3) はこの 1 instance (賞状/成長記録ブック tips の '無料プラン') を指摘したが、instance
+// パッチのみでは同型違反が再び追加され follow-up を生む (ADR-0061 §2 same-class-N→guard 違反)。
+//
+// 本 ratchet は plan 名 literal の「**新規追加**」を機械的に封じる (generator stop)。検出は専用の脆い
+// regex を新設せず、実績ある check-no-plan-literals.mjs の `checkFile` (block-comment 追跡 + 行末コメント
+// 除外を内包) を再利用する (#1442 使い捨て script 禁止)。allowlist は `main()` 内 `shouldExclude` で効くため、
+// `checkFile` を直接呼べば labels.ts も走査できる。
+//
+// baseline = 既存 33 件を pin。これは FAQ / 利用規約 / トライアル説明など自然文に grammatically 埋め込まれた
+// pre-existing literal + 'ファミリープラン' naming-drift (atom `PLAN_FULL_TERMS.family` は 'プレミアムプラン'
+// を返すため `${...}` 置換で文言が変わってしまい単純変換不可) を含む。これらの削減は別 cleanup で baseline を
+// 下げる (base-token-routes-ratchet #3152 / lp-removal-residue #1790 と同型の ratchet 運用)。
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { checkFile } from '../../../scripts/check-no-plan-literals.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const LABELS_TS = path.join(REPO_ROOT, 'src/lib/domain/labels.ts');
+
+// PLAN_FULL_TERMS の atom 値 (= ADR-0045 で `${PLAN_FULL_TERMS.*}` 参照すべき plan 名)。
+// 価格 (¥500) / トライアル (7日間無料) / 無料訴求 (基本無料) 等の他 atom は #3359 の scope 外
+// (別 subset の broader concern) のため本 ratchet では計上しない。
+const PLAN_NAME_PATTERNS = [
+	'無料プラン',
+	'スタンダードプラン',
+	'プレミアムプラン',
+	'ファミリープラン',
+];
+
+// 現状の plan 名直書き件数。**この値を引き上げてはならない** (新規違反の混入を意味する)。
+// 既存削減で実数が下回ったら本値を実数へ下げる (ratchet down のみ許可)。
+const BASELINE = 33;
+
+describe('labels.ts plan-name literal ratchet (#3359, ADR-0045/ADR-0061)', () => {
+	it('compound 内の plan 名 atom 直書きが baseline 以下である (新規追加を禁止する class-lock)', () => {
+		const findings = checkFile(LABELS_TS).filter((f) => PLAN_NAME_PATTERNS.includes(f.pattern));
+		const detail = findings.map((f) => `  L${f.line} ${f.pattern}: ${f.snippet}`).join('\n');
+		expect(
+			findings.length,
+			`labels.ts の plan 名直書きが baseline (${BASELINE}) を超えました (実数 ${findings.length})。\n` +
+				"新規 compound は 'スタンダードプラン' 等を直書きせず PLAN_FULL_TERMS.standard を template literal で参照してください " +
+				'(ADR-0045 §3.3)。既存削減で baseline を下回った場合は本 BASELINE を実数へ下げてください。\n' +
+				detail,
+		).toBeLessThanOrEqual(BASELINE);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

UI ラベルの用語 SSOT (ADR-0045: terms.ts atom → labels.ts compound) を健全に保つことで、プラン名変更時に
`terms.ts` 1 行修正で全画面へ伝播する原則を守る。labels.ts compound に plan 名を直書きすると伝播が壊れ、
将来 LP / アプリ / 法務文書で表記が食い違う顧客影響につながるため、その class を機械 lock する。

## 関連 Issue

Closes #3359

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | labels.ts:1842/1863 の `無料プラン` 直書きを `${PLAN_FULL_TERMS.free}` 参照へ置換 | `git grep -n 'PLAN_FULL_TERMS.free' src/lib/domain/labels.ts` + `node scripts/check-no-plan-literals.mjs` | HEAD `f0e0b66e2` / labels.ts:1842/1863 が `${PLAN_FULL_TERMS.free}` 参照化 (値完全一致) / check-no-plan-literals OK (リテラル直書きなし) |
| AC2 | check-no-plan-literals が本パターンを検出できるか確認・未検出なら検出強化 | `npx vitest run tests/unit/domain/labels-plan-literal-ratchet.test.ts` | HEAD `f0e0b66e2` / 確認結果: labels.ts は allowlist (#1918) で全体 exempt のため未検出。検出強化として checkFile 再利用 ratchet を追加 (baseline 33、新規追加を機械検出) / 1 passed |

## 変更タイプ

- [x] refactor: リファクタリング
- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ドメインモデル (`$lib/domain/`)
- [x] 設定・CI (`package.json`, `.github/` 等) — テスト追加

**影響を受ける画面・機能**:
ガイド文言 (children-3 / 成長記録ブック / 賞状)・ごほうび管理 upgrade banner・証明書 free plan note。
いずれも `${PLAN_FULL_TERMS.free/standard}` は atom 値と完全一致のため**表示文字列は不変** (値非変更の内部 refactor)。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready` 関連 Step PASS**: biome (labels.ts / test 共に clean) / check-no-plan-literals OK / check-hardcoded-strings 0 (baseline 0) / svelte-check 増分 error 0 (check-no-plan-literals.mjs の pre-existing 17 件は labels-phase7-pr2b.test.ts が既に import 済、main と同数)
- [x] 追加・変更したテストの概要: `tests/unit/domain/labels-plan-literal-ratchet.test.ts` を追加。proven な `checkFile` を再利用し labels.ts の plan 名直書きを baseline (33) 以下に固定する ratchet。新規 plan 名直書きが混入すると fail
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

N/A — 表示文字列は `${PLAN_FULL_TERMS.*}` が atom 値と完全一致のため視覚変化なし (値不変の内部 refactor)。labels.ts は `.svelte`/`.css`/`site/` 非該当のため UI 撮影 gate 対象外。

## コード品質セルフレビュー (#1481)

- 監査が指摘した 1 instance (1842/1863) のみのパッチに留めず、同 class の compound 3 箇所も同時是正 (ADR-0061 §2 same-class-N→guard)。
- 検出強化は専用 regex の新設 (脆い: block-comment 誤食を実測で確認) を避け、実績ある `checkFile` を再利用 (#1442 使い捨て script 禁止)。
- ratchet baseline は base-token-routes-ratchet (#3152) / lp-removal-residue (#1790) と同型運用 (down のみ許可)。

## 横展開・影響波及チェック

- `site/shared-labels.js` / `site/*.html` fallback: pre-commit の generate-lp-labels --check / sync-lp-fallback --check が PASS (値不変のため desync なし)。
- 残存する plan 名直書き 33 件 (FAQ / 利用規約 / トライアル自然文 + 'ファミリープラン' naming-drift = atom `PLAN_FULL_TERMS.family` が 'プレミアムプラン' を返し単純置換不可) は baseline pin。これらの削減は後続 cleanup で baseline を下げる (本 PR では新規混入の封じ込めに focus、Pre-PMF ADR-0010)。

## レビュー依頼事項・破壊的変更

破壊的変更なし。表示文字列・LP fallback は不変。ratchet baseline=33 の妥当性 (Pre-PMF で full 変換せず class-lock に留める判断) をレビュー観点として共有。

## 配布済み env / secret (ADR-0006)

N/A — env / secret 追加なし。

## Ready for Review チェックリスト

- [x] CI 緑を確認のうえ Ready 化する
- [x] PR 本文がテンプレート 13 セクションに準拠

## QM レビュー結果

<!-- QM が記入 -->

