### PR TITLE
fix: develop lane の svelte-check 19 errors (#1432 warning=error) を解消

### DIFF
--- a/src/routes/(child)/+layout.svelte
+++ b/src/routes/(child)/+layout.svelte
@@ -160,6 +160,7 @@ let stampDialogOpen = $state(false);
 // #2353 設計欠陥 6: PIN gate 初心者導線 dialog
 // data.pinGateOnboardingSeen が false (settings 未保存) のとき初回 mount 時に開く。
 // 「今後表示しない」checkbox で確認のうえ閉じる → POST /api/v1/settings/pin-gate-onboarding。
+// svelte-ignore state_referenced_locally
 let pinGateOnboardingOpen = $state(!data.pinGateOnboardingSeen && !isBaby);
 let dontShowAgainChecked = $state(true);
 

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -66,6 +66,7 @@ let restoreLoading = $state(false);
 // Round 18 Cluster K (#1870 評価 Round 3): cookie fallback を fallback chain に追加。
 // marketplace (ひな選択) → admin/activities 遷移時に「たろうくんタブが active」になる
 // per-child scope 不整合を解消 (memory `feedback_per_child_scope_consistency` 整合)。
+// svelte-ignore state_referenced_locally
 let childIdOverride = $state<number | undefined>(
 	data.initialChildId != null && data.children.some((c) => c.id === data.initialChildId)
 		? data.initialChildId

--- a/src/routes/(parent)/admin/activities/[id]/edit/+page.svelte
+++ b/src/routes/(parent)/admin/activities/[id]/edit/+page.svelte
@@ -23,22 +23,30 @@ const a = $derived(data.activity);
 // svelte-ignore state_referenced_locally
 const parsed = splitIcon(data.activity.icon);
 
+// svelte-ignore state_referenced_locally
 let editName = $state(a.name);
+// svelte-ignore state_referenced_locally
 let editCategoryId = $state(a.categoryId);
 let editMainIcon = $state(parsed.main);
 let editSubIcon = $state(parsed.sub ?? '');
 const editIcon = $derived(joinIcon(editMainIcon, editSubIcon || null));
+// svelte-ignore state_referenced_locally
 let editPoints = $state(a.basePoints);
 // #2362 PR-3 Phase 7b-2c: ChildActivity は ageMin/ageMax を持たないため空初期化。
 // per-child instance 移行後は年齢 filter 概念が消えるため、edit UI 上は空入力 = 制限なし扱い。
 // Phase 7b-2d 以降で UI から age 入力欄を撤去予定。
 let editAgeMin = $state('');
 let editAgeMax = $state('');
+// svelte-ignore state_referenced_locally
 let editDailyLimit = $state<string>(a.dailyLimit != null ? String(a.dailyLimit) : '');
+// svelte-ignore state_referenced_locally
 let editNameKana = $state(a.nameKana ?? '');
+// svelte-ignore state_referenced_locally
 let editNameKanji = $state(a.nameKanji ?? '');
+// svelte-ignore state_referenced_locally
 let editTriggerHint = $state(a.triggerHint ?? '');
 // #1756 (#1709-B): must トグル
+// svelte-ignore state_referenced_locally
 let editIsMust = $state(a.priority === 'must');
 let saving = $state(false);
 </script>

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -49,6 +49,7 @@ const errorMessage = $derived(getErrorMessage(form?.error));
 
 // #2362 PR-4: 子供タブ切替 UI
 //   `?childId=<n>` query で初期 child 復元、未指定なら最初の child
+// svelte-ignore state_referenced_locally
 let childIdOverride = $state<number | undefined>(
 	data.initialChildId != null && data.children.some((c) => c.id === data.initialChildId)
 		? data.initialChildId

--- a/src/routes/setup/rewards/+page.svelte
+++ b/src/routes/setup/rewards/+page.svelte
@@ -6,6 +6,7 @@ import Button from '$lib/ui/primitives/Button.svelte';
 let { data } = $props();
 
 let selectedItems = $state<Set<string>>(new Set());
+// svelte-ignore state_referenced_locally
 let selectedChildId = $state<number>(data.children[0]?.id ?? 0);
 let submitting = $state(false);
 let skipMode = $state(false);

--- a/src/routes/setup/rules/+page.svelte
+++ b/src/routes/setup/rules/+page.svelte
@@ -6,6 +6,7 @@ import Button from '$lib/ui/primitives/Button.svelte';
 let { data } = $props();
 
 let selectedItems = $state<Set<string>>(new Set());
+// svelte-ignore state_referenced_locally
 let selectedChildId = $state<number | ''>(data.children[0]?.id ?? '');
 let submitting = $state(false);
 let skipMode = $state(false);


### PR DESCRIPTION
## 顧客価値・目的
**対象ユーザー**: システム全体（開発チーム）
**解決する課題**: develop ブランチの `lint-and-test` CI lane が `svelte-check --threshold warning` (#1432 warning=error) step で fail し続け、全 develop 系 PR の merge を塞いでいた（直近 12 run すべて failure/cancelled = lane 全停止）。
**期待される効果**: develop lane が green に復帰し、待機中の全 develop PR が再び merge 可能になる。

## 関連 Issue
関連: develop lane CI 復旧（QM 調査による lane red 検出。トラッキング Issue 未採番のため auto-close なし）

## AC 検証マップ (ADR-0004)
| AC 番号 | AC 内容 | 検証方法 | 結果 |
|---|---|---|---|
| AC1 | develop で svelte-check が 0 errors / 0 warnings になる | `npx svelte-check` (infra 依存込み) → `0 ERRORS 0 WARNINGS` | PASS |
| AC2 | 機能・表示が不変 (コメント行追加のみ) | `git diff` 目視 (13 行すべて `// svelte-ignore` コメント) | PASS |
| AC3 | 新規 lint 退行を作らない | `cspell` CI glob → Issues found: 0 | PASS |

## 変更タイプ
- [x] バグ修正（CI lane 復旧 / 非機能）

## 影響範囲・変更コンポーネント
**変更レイヤー**: routes（`.svelte` の `<script>` コメントのみ）
**影響を受ける画面・機能**: なし（コンパイル出力不変。`// svelte-ignore` は warning 抑止のみで生成コードに影響しない）

変更 6 file:
- `src/routes/(child)/+layout.svelte` — `pinGateOnboardingOpen`
- `src/routes/(parent)/admin/activities/+page.svelte` — `childIdOverride`
- `src/routes/(parent)/admin/activities/[id]/edit/+page.svelte` — 編集フォーム 8 欄
- `src/routes/(parent)/admin/rewards/+page.svelte` — `childIdOverride`
- `src/routes/setup/rewards/+page.svelte` — `selectedChildId`
- `src/routes/setup/rules/+page.svelte` — `selectedChildId`

### root cause / forward-fix 方針
- **症状**: 6 route .svelte で計 19 件の Svelte 5 `state_referenced_locally` warning。`--threshold warning` (#1432) により CI 上は error 化。
- **本質**: いずれも「ロード済み `data` / `$derived` を編集可能なローカル `$state` へ一度だけ seed する」**意図的パターン**（form 入力欄 / dialog open フラグ / 子供タブ override）。これらを `$derived` 化すると `data` 変化のたびにユーザー編集が巻き戻り機能破壊になるため、ローカル `$state` が正しい。
- **established idiom 準拠**: 同一パターンは既に `src/lib/features/admin/components/ActivityCreateForm.svelte` 等 **21 箇所**で `// svelte-ignore state_referenced_locally` により抑止済（同 edit/+page.svelte でも line 23 で既存使用）。本 PR は同 idiom を残り 6 file に水平展開しただけで、安易な無効化ではなく project-sanctioned な正しい解消。
- **regression 由来 merge**: edit/+page.svelte は `const a = $derived(data.activity)`（#2362 PR-5, commit 09036839a）が seed 元を reactive 化したことで warning が顕在化した形跡。ただし他 5 file は元から同型で、CI 側 #1432 (`--threshold warning`) 適用により lane 全体が error 判定に転じたのが lane red の直接原因。機能意図は維持したまま idiom で解消。

## テスト & 安全装置セルフチェック
- [x] `npx svelte-check` → 0 errors / 0 warnings（infra 依存 install 済の決定的環境）
- [x] `cspell` CI glob（`src/**/*.{ts,svelte}` 他）→ Issues found: 0
- [ ] **新規 env / secret 追加時**（ADR-0006）: N/A
- 注: 本変更は `.svelte` の script コメントのみ。unit/E2E の振る舞いに影響しないため局所実行は省略（svelte-check が対象 lane の SSOT）。

## スクリーンショット / ビジュアルデモ
N/A — UI のレンダリング結果・スタイル・文言いずれも不変（`// svelte-ignore` コメントは warning 抑止のみでコンパイル出力に影響なし）。視覚差分が発生しないため SS 添付対象外。

## コード品質セルフレビュー (#1481)
- 既存 codebase の established idiom（`ActivityCreateForm.svelte` 等）に厳密準拠。新規パターンを持ち込まない。
- 各 `// svelte-ignore` は「編集可能ローカル state の意図的 seed」という同一意図にのみ付与（過剰抑止なし）。
- 差分は 13 行追加のみ、削除・ロジック変更ゼロ。

## 横展開・影響波及チェック
- `grep -rn "svelte-ignore state_referenced_locally" src/` で既存 21 箇所を確認し idiom 一致を担保。
- 同種 warning を持つ file は本 PR の 6 file で網羅（svelte-check 全走査で 0 warnings 確認済）。

## レビュー依頼事項・破壊的変更
- 破壊的変更なし。
- 確認依頼: `// svelte-ignore` 抑止が「意図的な one-time seed」に限定されており、reactivity を意図的に切っている点が妥当か（form/dialog/tab の編集可能性を保つため $derived 化は不可）。

## 配布済み env / secret (ADR-0006)
N/A — 新規 env / secret なし。

## Ready for Review チェックリスト
- [x] AC 検証マップ記載
- [x] 必須セクション充足
- [x] `[x]` は実証跡あり（svelte-check / cspell 出力で確認）
- [x] SS スロット: N/A 明記（視覚差分なし）

## QM レビュー結果
（QM 記入欄）
