### PR TITLE
fix: #3506 push subscribe smoke e2e の endpoint を SSRF allowlist 通過 host に是正 (4 件 fail 解消)

### DIFF
--- a/tests/e2e/push-notification-4-types.spec.ts
+++ b/tests/e2e/push-notification-4-types.spec.ts
@@ -26,7 +26,11 @@ test.describe('#2191 push 4 systems — Anti-engagement + VAPID distribution smo
 	test('#2191 AC1-1: subscribe API は未認証で 401 (構造防御)', async ({ request }) => {
 		const res = await request.post('/api/v1/notifications/subscribe', {
 			data: {
-				endpoint: 'https://push.example.com/test-reminder',
+				// #3506: endpoint は SSRF allowlist (#3188 validatePushEndpoint) 通過必須。
+				// local auth-skip では parent auto-context で validation まで到達するため、fake host
+				// (push.example.com) だと INVALID_ENDPOINT 400 で短絡し auth 構造 smoke を測れない。
+				// auth 構造 (未認証=401 / child=403) は cognito e2e + unit 12 件が担保する。
+				endpoint: 'https://fcm.googleapis.com/fcm/send/test-reminder',
 				keys: { p256dh: 'p', auth: 'a' },
 			},
 		});
@@ -51,7 +55,8 @@ test.describe('#2191 push 4 systems — Anti-engagement + VAPID distribution smo
 		// E2E では cognito-dev に child 専用 setup がないため、API の到達性のみ smoke 確認。
 		const res = await request.post('/api/v1/notifications/subscribe', {
 			data: {
-				endpoint: 'https://push.example.com/test-child',
+				// #3506: SSRF allowlist 通過 host を使う (理由は AC1-1 コメント参照)。
+				endpoint: 'https://fcm.googleapis.com/fcm/send/test-child',
 				keys: { p256dh: 'p', auth: 'a' },
 			},
 		});
@@ -73,7 +78,11 @@ test.describe('#2191 push 4 systems — Anti-engagement + VAPID distribution smo
 		// { sent: 0, failed: 0 } を返す。webpush.setVapidDetails 経由のクラッシュは起こさない。
 		// この性質を「subscribe→未認証 401」で間接的に担保する (E2E では実 push 経路を叩けない)。
 		const res = await request.post('/api/v1/notifications/subscribe', {
-			data: { endpoint: 'https://valid', keys: { p256dh: 'p', auth: 'a' } },
+			// #3506: SSRF allowlist 通過 host を使う (理由は AC1-1 コメント参照)。
+			data: {
+				endpoint: 'https://fcm.googleapis.com/fcm/send/test-vapid',
+				keys: { p256dh: 'p', auth: 'a' },
+			},
 		});
 		// 200 で silent OK なら subscribe レコードが入り、後で send 時に silent fail が
 		// 観察される (これは正常動作)。401/500 でも構造防御として OK。

--- a/tests/e2e/push-subscribe-anti-engagement.spec.ts
+++ b/tests/e2e/push-subscribe-anti-engagement.spec.ts
@@ -22,7 +22,10 @@ test.describe('#1593 push subscribe — Anti-engagement 構造防御 smoke', () 
 	test('未認証で POST すると 401', async ({ request }) => {
 		const res = await request.post('/api/v1/notifications/subscribe', {
 			data: {
-				endpoint: 'https://push.example.com/test',
+				// #3506: endpoint は SSRF allowlist (#3188 validatePushEndpoint) 通過必須。local auth-skip では
+				// parent auto-context で validation まで到達し、fake host は INVALID_ENDPOINT 400 で短絡するため
+				// 構造防御 smoke を測れない。未認証=401 の実検証は cognito e2e + unit 12 件が担保する。
+				endpoint: 'https://fcm.googleapis.com/fcm/send/test-anti-engagement',
 				keys: { p256dh: 'p', auth: 'a' },
 			},
 		});


### PR DESCRIPTION
## 顧客価値・目的

Web Push 購読 API の security smoke E2E を正しく機能させ、認証境界 (未認証拒否 / 子供拒否 COPPA) と push endpoint の SSRF 防御が回帰なく守られることを CI で保証する。統合 PR #3500 (release/2026-06-30) の merge blocker を解消し、顧客に届く前の品質ゲートを復旧する。

## 関連 Issue

Closes #3506

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | push security smoke 4 件 (未認証 401 / child 403 / VAPID crash-safe / anti-engagement) の恒常 fail を解消 | `npx playwright test tests/e2e/push-notification-4-types.spec.ts tests/e2e/push-subscribe-anti-engagement.spec.ts --project=tablet` | HEAD `c0e1a6aa0` / **10 passed (4.3s)** (旧 fail の AC1-1/AC1-2/AC2/未認証 含む全 PASS) |
| AC2 | 真因の特定 (監査「auth 順序が逆」は誤診断であることの立証) | `git show origin/develop:.../subscribe/+server.ts` + dev:5190 への live curl | HEAD `c0e1a6aa0` / auth gate (401 L23) は validation (400 L59) より先 = 順序正。真因は local auth-skip の parent auto-context が validation 到達 → fake host が #3188 SSRF で 400。curl 実測: fake→400 INVALID_ENDPOINT / valid FCM→200 success |

## 変更タイプ

- [x] fix: バグ修正
- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (E2E テストのみ)

**影響を受ける画面・機能**:
なし (E2E spec の endpoint 修正のみ)。production の `subscribe/+server.ts` は非改変 (auth 順序は既に正)。

## テスト & 安全装置セルフチェック

- [x] **pre-ready 関連 Step PASS**: biome clean / 対象 2 spec を tablet project で 10 passed
- [x] 追加・変更したテストの概要: push subscribe smoke 4 test の endpoint を fake host (push.example.com / https://valid) → SSRF allowlist 通過 host (fcm.googleapis.com) に変更。auth 構造 smoke を SSRF validation で短絡させない
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A (production guard 不変、test only)

## スクリーンショット / ビジュアルデモ

N/A — E2E test only、UI 非変更。

## コード品質セルフレビュー (#1481)

- 「仮説でなく現象を検証」に従い dev server への live curl で真因を確定 (fake→400 / valid→200)。監査の「auth 順序が逆」診断が事実誤りであることを git show + curl で立証。
- 対症療法 (status list に 400 追加) でなく、test の意図 (auth 構造 smoke) を SSRF validation で汚染しない valid endpoint 化を選択。auth 境界の実検証は cognito e2e + unit 12 件が担保する二重防御。

## 横展開・影響波及チェック

- 同 spec 内の他 test (AC1-3 不正 body→400 / AC1-4 GET→405 / cron auth) は非改変で PASS 維持。
- 他 e2e spec に同型の「fake push endpoint で subscribe を叩く」pattern が無いか grep 済 → 本 2 spec のみ該当。
- production の SSRF hardening (#3188/#3404/#3413) は正しく機能 (fake host を 400 拒否) しており本 PR で非改変。

## レビュー依頼事項・破壊的変更

破壊的変更なし。**監査 issue #3506 の提案 (auth 先行に順序変更) は採用しない** — auth は develop / release 双方で既に validation より先であることを git show + live curl で確認済。真因は test の fake endpoint であり、production コード変更は不要。この判断の妥当性をレビュー観点として共有。

## 配布済み env / secret (ADR-0006)

N/A。

## Ready for Review チェックリスト

- [x] CI 緑を確認のうえ Ready 化する
- [x] PR 本文がテンプレート 13 セクションに準拠

## QM レビュー結果

<!-- QM が記入 -->
