### PR TITLE
fix: #3505 checklistTemplate isArchived を import round-trip で保全 (archived→active 復活を根絶)

### DIFF
--- a/src/lib/server/db/demo/checklist-repo.ts
+++ b/src/lib/server/db/demo/checklist-repo.ts
@@ -135,7 +135,7 @@ export async function insertTemplate(
 		completionBonus: input.completionBonus ?? 0,
 		timeSlot: input.timeSlot ?? 'anytime',
 		isActive: input.isActive ?? 1,
-		isArchived: 0,
+		isArchived: input.isArchived ?? 0, // #3505: import round-trip で archive 状態を保全
 		archivedReason: null,
 		createdAt: now,
 		updatedAt: now,

--- a/src/lib/server/db/dynamodb/checklist-repo.ts
+++ b/src/lib/server/db/dynamodb/checklist-repo.ts
@@ -131,7 +131,7 @@ export async function insertTemplate(
 		completionBonus: input.completionBonus ?? 10,
 		timeSlot: input.timeSlot ?? 'anytime',
 		isActive: input.isActive ?? 1,
-		isArchived: 0,
+		isArchived: input.isArchived ?? 0, // #3505: import round-trip で archive 状態を保全
 		archivedReason: null,
 		createdAt: now,
 		updatedAt: now,

--- a/src/lib/server/db/types/index.ts
+++ b/src/lib/server/db/types/index.ts
@@ -520,6 +520,11 @@ export interface InsertChecklistTemplateInput {
 	completionBonus?: number;
 	timeSlot?: string;
 	isActive?: number;
+	// #3505 (#3358 と同一クラス): backup → restore round-trip で archive 状態を保全する
+	// (省略時は schema default = 非アーカイブ)。archived template が import 後に active へ復活する
+	// silent なデータ破綻 (第11回監査 tech-1) を防ぐ。export 契約 (ExportChecklistTemplate) が
+	// 出力するのは isArchived のみのため archivedReason は本 input の対象外。
+	isArchived?: number;
 	// #1755 (#1709-A): kind 削除 — 持ち物純化
 	// #1254 G1: マーケットプレイスプリセット由来の識別子
 	sourcePresetId?: string | null;

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -1365,6 +1365,9 @@ async function importOneChecklistTemplate(
 				pointsPerItem: tpl.pointsPerItem,
 				completionBonus: tpl.completionBonus,
 				isActive: tpl.isActive ? 1 : 0,
+				// #3505 (#3358 と同一クラス): archive 状態を round-trip 保全。未渡しだと import 後に
+				// archived template が active 復活する (display filter が isArchived===1 のみ除外するため)。
+				isArchived: tpl.isArchived ? 1 : 0,
 				sourcePresetId: tpl.sourcePresetId ?? null,
 			},
 			tenantId,

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -705,4 +705,40 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(overrides[0]?.itemName, 'override itemName 保全').toBe('すいとう');
 		expect(overrides[0]?.createdAt, 'override createdAt 保全').toBe('2026-03-05T07:00:00Z');
 	});
+
+	// #3505 (#3358 と同型の field-level 回帰固定): archived checklistTemplate が import 後に active
+	// 復活しないこと。従来の完全性 test は非 archived template のみ seed するため、export は isArchived を
+	// 出力する (export-service:554) のに import が drop する field-drop を件数一致では見逃していた。
+	it('archived checklistTemplate が round-trip 後も archived のまま (active 復活しない、#3505)', async () => {
+		testDb.insert(schema.children).values({ nickname: 'そら', age: 8, theme: 'blue' }).run(); // id=1
+		const repo = getRepos().checklist;
+
+		// isArchived=1 の archived template を作成し child へ配信 (import round-trip の保全対象)。
+		const tpl = await repo.insertTemplate(
+			{ name: 'アーカイブ済リスト', icon: '📋', isArchived: 1 },
+			T,
+		);
+		await repo.assignTemplateToChildren(tpl.id, [1], T);
+
+		// export は archived template を isArchived:true で出力する (includeArchived=true 取得)。
+		const data = await exportFamilyData({ tenantId: T });
+		const exported = data.data.checklistTemplates.find((t) => t.name === 'アーカイブ済リスト');
+		expect(exported, 'export: archived template を出力').toBeTruthy();
+		expect(exported?.isArchived, 'export: isArchived=true').toBe(true);
+
+		// replace = clear → import
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T);
+
+		// 復元後も archived のまま (import が isArchived を drop すると default 0 = active 復活 → fail)。
+		const children = testDb.select().from(schema.children).all();
+		const cid = children[0]?.id as number;
+		const restored = (await repo.findTemplatesByChild(cid, T, true, true)).find(
+			(t) => t.name === 'アーカイブ済リスト',
+		);
+		expect(restored, '復元された').toBeTruthy();
+		expect(restored?.isArchived, 'archived のまま (active 復活しない、#3505 regression 固定)').toBe(
+			1,
+		);
+	});
 });


### PR DESCRIPTION
## 顧客価値・目的

家族データのバックアップ復元で、アーカイブ済みのチェックリストが勝手に「表示中」に復活する silent なデータ破綻を根絶する。顧客が意図的に片付けた持ち物リストが復元後に再出現する体験毀損を防ぎ、backup = 完全な状態復元という信頼を守る (本 release #3329 の最重点=取りこぼし根絶)。

## 関連 Issue

Closes #3505

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | checklistTemplate の isArchived が export→import round-trip で保全される | `npx vitest run tests/unit/services/backup-roundtrip-completeness.test.ts` | HEAD `afeb63998` / 7 passed。新 case が export:isArchived=true → import 後 isArchived=1 を assert |
| AC2 | archived template が復元後も archived (active 復活しない) | 同上 (failing-test-first 負のコントロール) | HEAD `afeb63998` / fix 無しで `expected +0 to be 1` fail → fix 有りで pass = regression を機械固定 |
| AC3 | completeness test に archived ケース追加 (#3358 と同型の field-level 回帰固定) | `git show` test diff | HEAD `afeb63998` / backup-roundtrip-completeness.test.ts に「archived checklistTemplate が round-trip 後も archived のまま」を追加 |

## 変更タイプ

- [x] fix: バグ修正
- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — 型 + repo (schema.ts 列は既存、追加なし)
- [x] サービス層 — import-service
- [x] ドメインモデル — InsertChecklistTemplateInput

**影響を受ける画面・機能**:
持ち物チェックリストの backup 復元。archived template が復元後も archived を維持 (表示ロジック自体は非変更)。

## テスト & 安全装置セルフチェック

- [x] **pre-ready 関連 Step PASS**: biome clean / svelte-check 0 error / 関連 unit 136 files 2349 passed
- [x] 追加・変更したテストの概要: backup-roundtrip-completeness に archived checklistTemplate round-trip case を追加。failing-test-first で fix 無し fail / fix 有り pass を確認済
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: sqlite (.values spread で自動 persist) / dynamodb / demo の 3 backend で isArchived persist を整合。stub parity 維持
- [x] **Critical バグ修正の場合**: N/A (sev3、schema 列は既存で migration 不要)

## スクリーンショット / ビジュアルデモ

N/A — サーバー側 data-integrity 修正、UI 非変更。

## コード品質セルフレビュー (#1481)

- #3358 (childActivity の同一クラス修正) を手本に、export が出力する field を import が確実に consume する形へ是正。
- sqlite は spread で自動 persist だが dynamodb/demo は hardcode 0 だったため 3 backend を明示整合 (並行実装 drift 防止)。
- archivedReason は ExportChecklistTemplate 契約に無い (export 未出力) ため input 対象外とし、dead field を作らない。

## 横展開・影響波及チェック

- 3 backend (sqlite/dynamodb/demo) の insertTemplate を点検し isArchived persist を整合。
- **同一クラス (entity は round-trip するが field が import で落ちる) の機械捕捉は #3507 (field-level ratchet) で継続** — 本 PR は tech-1 instance の根治 + 該当 field の回帰固定を担い、class 全体の網羅 guard を #3507 に接続する (ADR-0061 §2)。
- 件数一致では見逃す field-drop を、非既定値 (isArchived=1) seed + field 等価 assert で捕捉する pattern を確立。

## レビュー依頼事項・破壊的変更

破壊的変更なし。schema 列 (is_archived) は既存のため migration 不要。export 形式も非変更 (isArchived は v1.3.0+ で既に出力済、import 側の欠落を是正しただけ)。

## 配布済み env / secret (ADR-0006)

N/A。

## Ready for Review チェックリスト

- [x] CI 緑を確認のうえ Ready 化する
- [x] PR 本文がテンプレート 13 セクションに準拠

## QM レビュー結果

<!-- QM が記入 -->
