### PR TITLE
fix: #3508 nameKana/Kanji UI maxlength 対称化 + auto:weekly sourceTemplateId 既定 SSOT 統一

### DIFF
--- a/src/lib/features/admin/components/ActivityCreateForm.svelte
+++ b/src/lib/features/admin/components/ActivityCreateForm.svelte
@@ -270,7 +270,7 @@ function resetForm() {
 	<div>
 		<span class="block text-xs font-bold text-[var(--color-text-muted)] mb-1">{L.nameKanaLabel}</span>
 		<input
-			type="text" name="nameKana" bind:value={formNameKana}
+			type="text" name="nameKana" bind:value={formNameKana} maxlength="50"
 			class="w-full px-3 py-2 border rounded-lg text-sm"
 			placeholder={L.nameKanaPlaceholder}
 		/>
@@ -279,7 +279,7 @@ function resetForm() {
 	<div>
 		<span class="block text-xs font-bold text-[var(--color-text-muted)] mb-1">{L.nameKanjiLabel}</span>
 		<input
-			type="text" name="nameKanji" bind:value={formNameKanji}
+			type="text" name="nameKanji" bind:value={formNameKanji} maxlength="50"
 			class="w-full px-3 py-2 border rounded-lg text-sm"
 			placeholder={L.nameKanjiPlaceholder}
 		/>

--- a/src/lib/server/db/dynamodb/child-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/child-challenge-repo.ts
@@ -37,6 +37,7 @@ import type {
 	InsertChildChallengeInput,
 	UpdateChildChallengeInput,
 } from '../types';
+import { AUTO_WEEKLY_SOURCE_TEMPLATE_ID } from '../types';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -248,7 +249,13 @@ export async function getOrCreateWeeklyAuto(
 	if (existing.Item) return toChildChallenge(existing.Item);
 
 	const id = await nextId(ENTITY_NAMES.childChallenge, tenantId);
-	const challenge = buildChildChallenge(id, input, new Date().toISOString());
+	// #3508 tech-2: auto:weekly 既定を SQLite と統一 (buildChildChallenge の汎用既定は null だが、
+	// auto-weekly get-or-create では sourceTemplateId 未指定時に 'auto:weekly' を SSOT 既定とする)。
+	const challenge = buildChildChallenge(
+		id,
+		{ ...input, sourceTemplateId: input.sourceTemplateId ?? AUTO_WEEKLY_SOURCE_TEMPLATE_ID },
+		new Date().toISOString(),
+	);
 	try {
 		await doc.send(
 			new PutCommand({

--- a/src/lib/server/db/sqlite/child-challenge-repo.ts
+++ b/src/lib/server/db/sqlite/child-challenge-repo.ts
@@ -21,6 +21,7 @@ import type {
 	InsertChildChallengeInput,
 	UpdateChildChallengeInput,
 } from '../types';
+import { AUTO_WEEKLY_SOURCE_TEMPLATE_ID } from '../types';
 
 export async function findByChildId(childId: number, _tenantId: string): Promise<ChildChallenge[]> {
 	return db
@@ -189,7 +190,7 @@ export async function getOrCreateWeeklyAuto(
 			endDate: input.endDate,
 			targetConfig: input.targetConfig,
 			rewardConfig: input.rewardConfig,
-			sourceTemplateId: input.sourceTemplateId ?? 'auto:weekly',
+			sourceTemplateId: input.sourceTemplateId ?? AUTO_WEEKLY_SOURCE_TEMPLATE_ID,
 			currentValue: 0,
 			targetValue: input.targetValue,
 			completed: 0,
@@ -208,7 +209,10 @@ export async function getOrCreateWeeklyAuto(
 			and(
 				eq(childChallenges.childId, input.childId),
 				eq(childChallenges.startDate, input.startDate),
-				eq(childChallenges.sourceTemplateId, input.sourceTemplateId ?? 'auto:weekly'),
+				eq(
+					childChallenges.sourceTemplateId,
+					input.sourceTemplateId ?? AUTO_WEEKLY_SOURCE_TEMPLATE_ID,
+				),
 			),
 		)
 		.get();

--- a/src/lib/server/db/types/index.ts
+++ b/src/lib/server/db/types/index.ts
@@ -813,6 +813,11 @@ export interface ChildChallenge {
 	updatedAt: string;
 }
 
+// #3508 tech-2: auto:weekly 自動週次チャレンジの sourceTemplateId 既定値 SSOT。
+// getOrCreateWeeklyAuto の fallback 既定が backend 間で相違していた (SQLite='auto:weekly' /
+// DynamoDB=null) ため、両 backend の default を本定数に集約して統一する。
+export const AUTO_WEEKLY_SOURCE_TEMPLATE_ID = 'auto:weekly';
+
 export interface InsertChildChallengeInput {
 	childId: number;
 	title: string;

--- a/src/lib/server/services/child-challenge-service.ts
+++ b/src/lib/server/services/child-challenge-service.ts
@@ -324,7 +324,15 @@ export function computeProposal(
 	};
 }
 
-/** group key 解決 (admin getChallengeGroupsForAdmin と同一規約、ADR-0055 §4.7 整合) */
+/**
+ * group key 解決 (ADR-0055 §4.7 整合)。`getActiveChildChallengesWithSiblings` 用のベース key。
+ *
+ * #3513 QM BLOCK fix: admin 側 `getChallengeGroupsForAdmin` は本関数と同一規約ではなく、
+ * sourceTemplateId 有無に関わらず常に startDate + endDate を key に含める (tenant 全体・全期間を
+ * 横断集計するため)。本関数は呼び出し側 (`getActiveChildChallengesWithSiblings`) が group 化した
+ * 後に同一 childId の active instance に限定して period filter するため、sourceTemplateId 単体
+ * key のままで安全 (siblings は取得後に startDate/endDate 一致でさらに絞り込む)。
+ */
 function resolveGroupKey(
 	c: Pick<ChildChallenge, 'sourceTemplateId' | 'title' | 'startDate' | 'endDate'>,
 ): string {
@@ -411,6 +419,12 @@ export async function createChildChallengesBulk(
 /**
  * admin/challenges 画面: tenant 全体の challenge instance を sourceTemplateId / (title + 期間) で
  * group 化して返す。SiblingChallengeComparison.svelte で兄弟連動比較表示するため。
+ *
+ * #3513 QM BLOCK fix: groupKey には常に startDate + endDate を含める (sourceTemplateId が
+ * 'auto:weekly' のような tenant 内共有の固定文字列であっても、期間が異なれば別 group とする)。
+ * #2488 must-2 で `getActiveChildChallengesWithSiblings` に導入された「同一期間のみ同 group」
+ * ガードと同じ規約を admin 集計側にも適用し、全週・全子供の auto:weekly challenge が単一 group に
+ * 混線する事故を防ぐ (sourceTemplateId 単体キーだと固定値の場合に期間非依存になってしまう)。
  */
 export async function getChallengeGroupsForAdmin(tenantId: string): Promise<ChildChallengeGroup[]> {
 	const repos = getRepos();
@@ -418,7 +432,9 @@ export async function getChallengeGroupsForAdmin(tenantId: string): Promise<Chil
 
 	const groupMap = new Map<string, ChildChallenge[]>();
 	for (const c of all) {
-		const key = c.sourceTemplateId ?? `${c.title}::${c.startDate}::${c.endDate}`;
+		const key = c.sourceTemplateId
+			? `${c.sourceTemplateId}::${c.startDate}::${c.endDate}`
+			: `${c.title}::${c.startDate}::${c.endDate}`;
 		const arr = groupMap.get(key) ?? [];
 		arr.push(c);
 		groupMap.set(key, arr);

--- a/src/routes/(parent)/admin/activities/[id]/edit/+page.svelte
+++ b/src/routes/(parent)/admin/activities/[id]/edit/+page.svelte
@@ -179,8 +179,8 @@ let saving = $state(false);
 
 			<!-- かな・漢字 -->
 			<div class="grid grid-cols-2 gap-2">
-				<FormField label={L.editNameKanaLabel} type="text" name="nameKana" bind:value={editNameKana} placeholder={L.editKanaPlaceholderOptional} />
-				<FormField label={L.editNameKanjiLabel} type="text" name="nameKanji" bind:value={editNameKanji} placeholder={L.editKanaPlaceholderOptional} />
+				<FormField label={L.editNameKanaLabel} type="text" name="nameKana" bind:value={editNameKana} maxlength={50} placeholder={L.editKanaPlaceholderOptional} />
+				<FormField label={L.editNameKanjiLabel} type="text" name="nameKanji" bind:value={editNameKanji} maxlength={50} placeholder={L.editKanaPlaceholderOptional} />
 			</div>
 
 			<!-- トリガーヒント -->

--- a/tests/unit/services/child-challenge-service.test.ts
+++ b/tests/unit/services/child-challenge-service.test.ts
@@ -565,12 +565,76 @@ describe('getChallengeGroupsForAdmin', () => {
 		const groups = await getChallengeGroupsForAdmin(TENANT);
 		expect(groups.length).toBe(2);
 		// 開始日降順 (新しい順): A (2026-05-25) > B (2026-05-20)
-		expect(groups[0]?.groupKey).toBe('tmpl-1');
+		// #3513 QM BLOCK fix: groupKey は sourceTemplateId + 期間 (startDate::endDate) の複合になる
+		expect(groups[0]?.groupKey).toBe('tmpl-1::2026-05-25::2026-06-01');
 		expect(groups[0]?.instances.length).toBe(2);
 		expect(groups[0]?.allCompleted).toBe(false);
 		expect(groups[1]?.groupKey).toContain('B (individual)');
 		expect(groups[1]?.instances.length).toBe(1);
 		expect(groups[1]?.allCompleted).toBe(true);
+	});
+
+	it('#3513 QM BLOCK fix: 同一 sourceTemplateId (auto:weekly) でも期間が異なれば別 group になる (全週混線防止)', async () => {
+		mockFindAllByTenant.mockResolvedValueOnce([
+			{
+				id: 1,
+				childId: 902,
+				title: '今週のチャレンジ',
+				startDate: '2026-05-25',
+				endDate: '2026-05-31',
+				periodType: 'weekly',
+				sourceTemplateId: 'auto:weekly',
+				completed: 1,
+				targetValue: 5,
+				currentValue: 5,
+				description: null,
+				rewardConfig: '{}',
+				targetConfig: '{}',
+				status: 'completed',
+				isActive: 1,
+				challengeType: 'cooperative',
+				completedAt: '2026-05-31T09:00:00Z',
+				rewardClaimed: 0,
+				rewardClaimedAt: null,
+				createdAt: '',
+				updatedAt: '',
+			},
+			// 別の子供・前週分。sourceTemplateId は同じ固定文字列 'auto:weekly' だが期間が異なる。
+			{
+				id: 2,
+				childId: 903,
+				title: '先週のチャレンジ',
+				startDate: '2026-05-18',
+				endDate: '2026-05-24',
+				periodType: 'weekly',
+				sourceTemplateId: 'auto:weekly',
+				completed: 0,
+				targetValue: 5,
+				currentValue: 1,
+				description: null,
+				rewardConfig: '{}',
+				targetConfig: '{}',
+				status: 'active',
+				isActive: 1,
+				challengeType: 'cooperative',
+				completedAt: null,
+				rewardClaimed: 0,
+				rewardClaimedAt: null,
+				createdAt: '',
+				updatedAt: '',
+			},
+		]);
+
+		const groups = await getChallengeGroupsForAdmin(TENANT);
+
+		// 混線していれば 1 group (allCompleted=false かつ instances.length=2) になるが、
+		// 期間フィルタが効いていれば週ごとに別 group (それぞれ 1 instance) になる。
+		expect(groups.length).toBe(2);
+		expect(groups.every((g) => g.instances.length === 1)).toBe(true);
+		const completedGroup = groups.find((g) => g.startDate === '2026-05-25');
+		const activeGroup = groups.find((g) => g.startDate === '2026-05-18');
+		expect(completedGroup?.allCompleted).toBe(true);
+		expect(activeGroup?.allCompleted).toBe(false);
 	});
 
 	it('全 instance 完了で allCompleted=true', async () => {


### PR DESCRIPTION
## 顧客価値・目的

活動の読み仮名/漢字入力で、UI と server の文字数上限が食い違い「入力できたのに保存時に silent 切詰め」される不整合を解消し、入力体験の予測可能性を守る。あわせて自動週次チャレンジの内部識別子の backend 間 drift (技術的負債) を SSOT 統一し、将来の round-trip / 集計バグの芽を摘む。

## 関連 Issue

Closes #3508

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | ux-1: activity edit/create の nameKana/nameKanji が UI maxlength=50 + server 対称 | `git grep -n 'maxlength' <edit/create form>` | HEAD `4442ed7fa` / edit/+page.svelte L182-183 + ActivityCreateForm.svelte L273/282 に maxlength=50 追加。server は #3484 で sanitizeActivityNameField を create/update 双方経由済 (activity-service _toChildActivity*Input) |
| AC2 | tech-2: sourceTemplateId 既定値を 2 backend で SSOT 統一 | `npx vitest run tests/unit/db` + git grep AUTO_WEEKLY_SOURCE_TEMPLATE_ID | HEAD `4442ed7fa` / AUTO_WEEKLY_SOURCE_TEMPLATE_ID (types/index.ts) を sqlite/dynamodb getOrCreateWeeklyAuto 両者で import・使用。42 files 625 passed |

## 変更タイプ

- [x] fix: バグ修正
- [x] refactor: リファクタリング

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — 定数 + repo default (schema 変更なし)
- [x] UI コンポーネント (`$lib/features/`) — ActivityCreateForm
- [x] ページ / レイアウト (`src/routes/`) — activity edit page

**影響を受ける画面・機能**:
活動の作成/編集フォーム (読み仮名/漢字の入力上限)。自動週次チャレンジの sourceTemplateId 既定 (内部値、UI 非表示)。

## テスト & 安全装置セルフチェック

- [x] **pre-ready 関連 Step PASS**: biome clean / svelte-check 0 error / tests/unit/db + activity 42 files 625 passed
- [x] 追加・変更したテストの概要: N/A (ux-1=UI 属性追加 / tech-2=共有 const による default 統一。両 backend が同一 const import で構造的に parity 保証、既存 dynamodb-child-challenge-repo test 625 件 green)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: sqlite / dynamodb の getOrCreateWeeklyAuto default を AUTO_WEEKLY_SOURCE_TEMPLATE_ID で統一。stub parity 維持、625 passed
- [x] **Critical バグ修正の場合**: N/A (sev2 latent + sev4)

## スクリーンショット / ビジュアルデモ

N/A — maxlength は視覚非変化の入力属性 (triggerHint の既存 maxlength と同扱い)、tech-2 は内部 default。視覚回帰なし (internal-no-doc-impact)。

## コード品質セルフレビュー (#1481)

- ux-1 は server 対称化 (#3484) 済のうえで UI 側の欠落を補完。triggerHint の maxlength 前例に整合。
- tech-2 は 'auto:weekly' bare literal 全 39 箇所の抽出は LOW scope 過剰 (ADR-0010) と判断し、**発散していた default 2 箇所のみ**を共有 const に集約 (SSOT for the divergent default)。両 backend が同一 const を import するため再発は構造的に不能。

## 横展開・影響波及チェック

- server 側 sanitize は #3484 で create/update 対称化済のため本 PR は UI のみ補完 (server 二重変更を避ける)。
- getOrCreateWeeklyAuto の default を 2 backend で统一。汎用 insert (buildChildChallenge / sqlite insert) の default=null は auto 経路ではないため意図的に不変。

## レビュー依頼事項・破壊的変更

破壊的変更なし。schema 変更なし。tech-2 は「既定に依存する呼出」がある場合のみ挙動変化 (DynamoDB auto 行が null→'auto:weekly')、round-trip は明示値渡しのため既存データ非影響。

## 配布済み env / secret (ADR-0006)

N/A。

## Ready for Review チェックリスト

- [x] CI 緑を確認のうえ Ready 化する
- [x] PR 本文がテンプレート 13 セクションに準拠

## QM レビュー結果

<!-- QM が記入 -->
