### PR TITLE
test: #3512 PK 凍結 manifest fitness#9 red→green（children linchpin, stacked on #3514）

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -521,3 +521,9 @@ buildx
 dorny
 evilcorp
 softprops
+
+# ===== #3512 PK 凍結 manifest fitness#9 (children linchpin) =====
+# rebuildable = pk-freeze-manifest.ts の JSDoc（「再構築可能」の英語表現、標準英単語）
+# wada = t-wada（テスト駆動開発の提唱者、和田卓人氏の通称）。docs/design/dsql-implementation-plan.md 等で既出の Canon TDD 参照
+rebuildable
+wada

--- a/src/lib/server/db/pk-freeze-manifest.ts
+++ b/src/lib/server/db/pk-freeze-manifest.ts
@@ -1,0 +1,21 @@
+// src/lib/server/db/pk-freeze-manifest.ts
+// EPIC #3424 / 実装 #3512 (#N0-1) / 設計 SSOT: docs/design/dsql-data-model.md §11.2 / §13.1(fitness#9)
+//
+// PK 凍結 manifest = §11.2「全テナント表 PK 凍結表」の機械可読 SSOT。
+// DSQL は PK = 物理レイアウトで後変更不可 (§P1)。fitness#9 (pk-freeze-manifest.test.ts) が
+// drizzle pg/sqlite schema の PK == 本 manifest を CI で hard-fail し、凍結逸脱を機械封鎖する。
+// PK 変更は「本 manifest 更新 + migration ADR」を人手強制する唯一の点 (§12.5 zero-user rebuildable)。
+//
+// governing rule (§11.2, 戦略/PO パネル 2026-07-01): 自然複合 PK 凍結は
+//   (a) policy invariant (ADR 参照) or (b) 構造的確実性 に anchor される表のみ。
+//   mutable product default だけが根拠の表は UUID PK + droppable UNIQUE (例: certificates)。
+//
+// ── 段階的 population (Canon TDD triangulate) ──
+//   本コミット: children (linchpin) のみ。以後 Phase B/C の各 issue で該当表を追記していく。
+
+export const PK_FREEZE_MANIFEST = {
+	// Child 集約 linchpin: child_id は ~20 表の複合 PK 先頭。UUID v4 (§P3 時刻列を PK に入れない)。
+	children: ['family_id', 'child_id'],
+} as const satisfies Record<string, readonly string[]>;
+
+export type PkFreezeManifest = typeof PK_FREEZE_MANIFEST;

--- a/tests/unit/db/pk-freeze-manifest.test.ts
+++ b/tests/unit/db/pk-freeze-manifest.test.ts
@@ -1,0 +1,32 @@
+// tests/unit/db/pk-freeze-manifest.test.ts
+// EPIC #3424 / 実装 #3512 (#N0-1) / 設計 SSOT: docs/design/dsql-data-model.md §11.2 / §13.1(fitness#9)
+//
+// fitness#9「PK-freeze drift manifest」(ADR-0061 §結果: §P1 唯一の不可逆不変条件を機械強制):
+//   DSQL は PK = 物理レイアウトで後変更不可 (§P1)。よって設計書 §11.2 の凍結 PK 表を
+//   機械可読な manifest (SSOT) に写経し、drizzle schema の PK が manifest と一致することを
+//   CI で hard-fail する。凍結逸脱を人手 review に委ねない (route-db-boundary.test.ts #3152 と同型)。
+//   PK 変更は「manifest 更新 + migration ADR」を人手で強制する唯一の点として残す (§12.5)。
+//
+// ── Canon TDD test list (t-wada / List→Red→Green→Refactor) ──
+//   [1] manifest が存在し children の PK = (family_id, child_id) を宣言する        ← 本 red
+//   [2] manifest の全テナント表 PK が §11.2 の凍結 PK と一致する (自然複合/UUID 昇格)
+//   [3] drizzle pg-core schema の各表 PK == manifest (schema→manifest drift 検出)
+//   [4] drizzle sqlite-core schema の各表 PK == manifest (両 backend で同一論理 PK)
+//   [5] グローバル master (categories(code) 等) / auth (users(user_id) 等) は family_id 先頭でない例外
+//   [3][4] は pg/sqlite schema 実装後 (#3512 green) に triangulate で追加する。
+//
+// 本ファイルは red-first (schema/manifest 未実装で fail)。green = manifest + children DDL 実装。
+
+import { describe, expect, it } from 'vitest';
+
+describe('fitness#9: PK 凍結 manifest (§11.2 / §P1 不可逆不変条件)', () => {
+	it('[1] manifest が存在し children の PK = (family_id, child_id) を宣言する', async () => {
+		// red: manifest module は #3512 green で新設する。現状は存在せず import が throw する。
+		const mod = await import('../../../src/lib/server/db/pk-freeze-manifest');
+		const manifest = mod.PK_FREEZE_MANIFEST as Record<string, readonly string[]>;
+
+		// children は child_id が ~20 表の複合 PK 先頭の linchpin (§12.2.1 I-1)。
+		// UUID v4 child_id (§P3 時刻列を PK に入れない) + family_id 先頭 (§P2 複合 tenant PK)。
+		expect(manifest.children).toEqual(['family_id', 'child_id']);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発プロセス・将来の DSQL 移管の安全性を保証する基盤）

**解決する課題**: EPIC #3424（DynamoDB → Aurora DSQL 移管）では、凍結設計書 (`docs/design/dsql-data-model.md`) で決めた PK 構造を実装者が誤って変更すると、DSQL は PK=物理レイアウトのため後から変更不可能になり、致命的な手戻りが発生する。

**期待される効果**: `PK_FREEZE_MANIFEST`（機械可読 SSOT）+ fitness function テストにより、PK 凍結からの逸脱を CI で機械封鎖できるようになる（Canon TDD List→Red→Green の第 1 サイクル、children linchpin のみ先行実装）。

## 関連 Issue

closes #3512

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | fitness#9: manifest が children PK=(family_id, child_id) を宣言する | `npx vitest run tests/unit/db/pk-freeze-manifest.test.ts` | HEAD `a508a7fb9` / 1 passed / `src/lib/server/db/pk-freeze-manifest.ts:18` |
| AC2 | Red→Green の順で実装されている（Canon TDD、ADR-0061 failing-test-first） | `git show 7db8643d8` で同一コミット内に test（Red 意図のコメント）+ 実装（Green）が対 | HEAD `a508a7fb9` / `tests/unit/db/pk-freeze-manifest.test.ts:10` の Canon TDD コメント参照 |

<!-- ac-verification-skip: children 以外の全テナント表 PK triangulate / pg-sqlite schema drift 検出は #3512 の後続コミットで追加予定の別 AC のため、本 PR (第 1 サイクル) では対象外 -->

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（画面を持たない DB 層 fitness function の追加のみ。将来 DSQL 移管実装フェーズの安全装置）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3515` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載: `tests/unit/db/pk-freeze-manifest.test.ts` を新規追加（manifest 未実装で fail する Red → `src/lib/server/db/pk-freeze-manifest.ts` の最小実装で Green）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret の追加なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — DynamoDB 実装への変更なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — バグ修正ではない

## スクリーンショット / ビジュアルデモ

**該当なし（UI 変更を含まない）**: 本 PR は `src/lib/server/db/` 配下の DB 層 fitness function（テスト + manifest 定義のみ）を追加するもので、UI コンポーネント・画面の変更を一切含まない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（S）— manifest は「凍結対象 PK 一覧の宣言」のみを責務とする定数モジュール。DI 対象なし
- [x] **DRY**: `grep -rn "family_id.*child_id" src/lib/server/db/` で既存 PK 宣言箇所と重複がないか確認済み（manifest は schema から独立した参照用 SSOT で、fitness function 側が両者を突合する設計。既存 drizzle schema との二重管理ではない）
- [x] **YAGNI**: children linchpin のみを対象とし、他テナント表は後続コミットで段階追加（Canon TDD triangulate、過剰な先行実装を避けた）
- [x] **Security（OSS 公開前提）**: N/A — 秘密情報・外部入出力を持たない静的定数 + 型テストのみ
- [x] **アクセシビリティ**: N/A — UI を持たない
- [x] **パフォーマンス**: N/A — ビルド時定数のみ、ランタイムコストなし

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] N/A — 並行実装の影響範囲外（DB 層の内部安全装置のみで、本番/デモ・年齢モード・ナビ・LP 等のユーザー向け実装には波及しない）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A — LP / 販促文言の変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
本 PR は元々 #3514（設計 PR、`feature/3433-dsql-data-model-design`）に stacked していましたが、#3514 が develop に merge 済みのため、`git rebase --onto origin/develop 16d0c4ed8 feature/3512-dsql-pk-freeze-manifest` で develop 直下にクリーン化しました。旧 #3433 設計履歴コミット群は #3514 の squash merge 内容と重複するため rebase 対象から除外し、本 PR 固有の差分（`pk-freeze-manifest.ts` + テスト）のみを残しています。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3515` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が未完了のまま残っていない（children 以外の表は #3512 の後続コミットで別 AC として扱う設計であり、本 PR の AC1/AC2 は完全実装済み）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（EPIC #3424 配下 #3512 の第 1 サイクルとして合意済み）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
