### PR TITLE
test: #3507 backup round-trip の field-level ratchet — field 取りこぼし class を機械 lock

### DIFF
--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -7,6 +7,7 @@
 // 未実装の取込 (現状 evaluations は import 関数が無い、#3327) を **赤で機械再現** し、failing-test-first で
 // 潰す。新種別を export に足したら本テストへ assert を追加する規律で「silent な取りこぼし」を防ぐ。
 
+import { eq } from 'drizzle-orm';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as schema from '../../../src/lib/server/db/schema';
 import {
@@ -740,5 +741,161 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(restored?.isArchived, 'archived のまま (active 復活しない、#3505 regression 固定)').toBe(
 			1,
 		);
+	});
+});
+
+// #3507 (ADR-0061 §2 class-lock): entity 内 field 取りこぼし class を機械捕捉する field-level ratchet。
+// 件数一致 test (#3328) + entity registry (#3362) は「entity 取りこぼし」を防ぐが、entity は round-trip
+// するのに特定 field だけ import で落ちる drop (childActivity #3358 / checklistTemplate #3505 が同一クラス)
+// は各 entity を既定値 1 件 seed するため件数一致ですり抜ける。本 ratchet は:
+//   (1) export object の全 field key を frozen list と照合 → 新 export field 追加時に必ず fail させ、
+//       author に「round-trip assert も同時追加せよ」を強制する (silent gap を作らせない)。
+//   (2) 全 field を **非既定値**で seed → export→clear→import 後に field 等価を assert し、import が
+//       いずれかの field を drop すれば fail させる。
+// これにより #3358/#3505 と同型の field-drop が新規 entity/field で再発するのを構造的に防ぐ。
+describe('#3507 field-level ratchet — entity 内 field 取りこぼし class の機械捕捉', () => {
+	// export 契約 (export-format.ts) の全 field。新 field を export に追加したら本 list も更新し、
+	// **同時に下の round-trip assert も追加**すること (list 不一致で fail = 更新強制)。
+	const CHILD_ACTIVITY_EXPORT_KEYS = [
+		'childRef',
+		'name',
+		'categoryCode',
+		'icon',
+		'basePoints',
+		'triggerHint',
+		'isMainQuest',
+		'priority',
+		'sourcePresetId',
+		'isVisible',
+		'sortOrder',
+		'isArchived',
+		'archivedReason',
+		'dailyLimit',
+		'nameKana',
+		'nameKanji',
+	].sort();
+	const CHECKLIST_TEMPLATE_EXPORT_KEYS = [
+		'childRef',
+		'name',
+		'icon',
+		'pointsPerItem',
+		'completionBonus',
+		'isActive',
+		'sourcePresetId',
+		'exportId',
+		'isArchived',
+		'items',
+	].sort();
+
+	it('childActivity: 全 export field key が frozen set と一致し、非既定値で round-trip する', async () => {
+		testDb
+			.insert(schema.children)
+			.values({ nickname: 'ふぃーるど', age: 10, theme: 'purple' })
+			.run(); // id=1
+		// 全 seedable field を schema default と異なる distinctive 値で seed。
+		seedChildActivities(testDb, 1, [
+			{
+				name: 'フィールド網羅活動',
+				categoryId: 2, // default 1 以外 (categoryCode='benkyou' で round-trip)
+				icon: '🎯',
+				basePoints: 42,
+				triggerHint: 'ヒント文',
+				isMainQuest: 1, // default 0
+				priority: 'must', // default 'optional'
+				isVisible: 0, // default 1
+				sortOrder: 7, // default 0
+				dailyLimit: 3, // default null
+				nameKana: 'かなよみ',
+				nameKanji: '漢字表記',
+			},
+		]);
+		// isArchived / archivedReason は seed helper 対象外のため直接 archive (archivedReason は valid enum)。
+		testDb
+			.update(schema.childActivities)
+			.set({ isArchived: 1, archivedReason: 'downgrade_user_selected' })
+			.where(eq(schema.childActivities.name, 'フィールド網羅活動'))
+			.run();
+
+		const data = await exportFamilyData({ tenantId: T });
+		const exported = data.data.childActivities.find((a) => a.name === 'フィールド網羅活動');
+		expect(exported, 'export された').toBeTruthy();
+		// (1) key-freeze ratchet: 新 export field 追加で fail (round-trip assert 追加を強制)。
+		expect(
+			Object.keys(exported as object).sort(),
+			'childActivity export key set が frozen list と一致 (不一致=新 field。下の assert も追加せよ)',
+		).toEqual(CHILD_ACTIVITY_EXPORT_KEYS);
+
+		// (2) replace round-trip → 全 field 等価
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T);
+
+		const cid = testDb.select().from(schema.children).all()[0]?.id as number;
+		const restored = (
+			await getRepos().childActivity.findActivitiesByChild(cid, T, { includeArchived: true })
+		).find((a) => a.name === 'フィールド網羅活動');
+		expect(restored, '復元された').toBeTruthy();
+		expect(restored?.categoryId, 'categoryCode→categoryId round-trip').toBe(2);
+		expect(restored?.basePoints, 'basePoints').toBe(42);
+		expect(restored?.triggerHint, 'triggerHint').toBe('ヒント文');
+		expect(restored?.isMainQuest, 'isMainQuest').toBe(1);
+		expect(restored?.priority, 'priority').toBe('must');
+		expect(restored?.isVisible, 'isVisible').toBe(0);
+		expect(restored?.sortOrder, 'sortOrder').toBe(7);
+		expect(restored?.isArchived, 'isArchived').toBe(1);
+		expect(restored?.archivedReason, 'archivedReason').toBe('downgrade_user_selected');
+		expect(restored?.dailyLimit, 'dailyLimit').toBe(3);
+		expect(restored?.nameKana, 'nameKana').toBe('かなよみ');
+		expect(restored?.nameKanji, 'nameKanji').toBe('漢字表記');
+	});
+
+	it('checklistTemplate: 全 export field key が frozen set と一致し、非既定値で round-trip する', async () => {
+		testDb.insert(schema.children).values({ nickname: 'ちぇっく', age: 9, theme: 'green' }).run(); // id=1
+		const repo = getRepos().checklist;
+		const tpl = await repo.insertTemplate(
+			{
+				name: 'フィールド網羅リスト',
+				icon: '📋',
+				pointsPerItem: 7, // 非既定
+				completionBonus: 15, // 非既定
+				isActive: 1,
+				isArchived: 1, // #3505 fix で persist される
+				sourcePresetId: 'preset-chk',
+			},
+			T,
+		);
+		await repo.assignTemplateToChildren(tpl.id, [1], T);
+		await repo.insertTemplateItem(
+			{
+				templateId: tpl.id,
+				name: 'アイテムA',
+				icon: '✅',
+				frequency: 'daily',
+				direction: 'positive',
+				sortOrder: 0,
+			},
+			T,
+		);
+
+		const data = await exportFamilyData({ tenantId: T });
+		const exported = data.data.checklistTemplates.find((t) => t.name === 'フィールド網羅リスト');
+		expect(exported, 'export された').toBeTruthy();
+		expect(
+			Object.keys(exported as object).sort(),
+			'checklistTemplate export key set が frozen list と一致 (不一致=新 field。下の assert も追加せよ)',
+		).toEqual(CHECKLIST_TEMPLATE_EXPORT_KEYS);
+
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T);
+
+		const cid = testDb.select().from(schema.children).all()[0]?.id as number;
+		const restored = (await repo.findTemplatesByChild(cid, T, true, true)).find(
+			(t) => t.name === 'フィールド網羅リスト',
+		);
+		expect(restored, '復元された').toBeTruthy();
+		expect(restored?.pointsPerItem, 'pointsPerItem').toBe(7);
+		expect(restored?.completionBonus, 'completionBonus').toBe(15);
+		expect(restored?.isActive, 'isActive').toBe(1);
+		expect(restored?.isArchived, 'isArchived').toBe(1);
+		expect(restored?.sourcePresetId, 'sourcePresetId').toBe('preset-chk');
 	});
 });

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -792,7 +792,7 @@ describe('#3507 field-level ratchet — entity 内 field 取りこぼし class �
 			.insert(schema.children)
 			.values({ nickname: 'ふぃーるど', age: 10, theme: 'purple' })
 			.run(); // id=1
-		// 全 seedable field を schema default と異なる distinctive 値で seed。
+		// seed helper が受ける全 field を schema default と異なる distinctive 値で seed。
 		seedChildActivities(testDb, 1, [
 			{
 				name: 'フィールド網羅活動',


### PR DESCRIPTION
## 顧客価値・目的

バックアップ復元で「データ種別は戻るのに特定の属性(表示状態/並び順/アーカイブ/読み仮名等)だけ silent に消える」field-drop バグの class を機械的に封じ、顧客が復元したデータが完全一致で戻る信頼を構造的に守る。#3358 (childActivity) / #3505 (checklistTemplate) と同型の再発を CI で不可能化する。

## 関連 Issue

Closes #3507

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | completeness test が各 entity の全 export field を非既定値で seed し round-trip 等価を assert | `npx vitest run tests/unit/services/backup-roundtrip-completeness.test.ts` | HEAD `2e0058cef` / 9 passed。childActivity 16 field / checklistTemplate 10 field を非既定値 seed → 全 field 等価 assert |
| AC2 | tech-1(#3505) / #3358 クラスの field-drop が本 test で必ず検出される | 同上 (#3505 で負のコントロール実証済) | HEAD `2e0058cef` / #3505 で fix 無し `expected +0 to be 1` fail を確認済。本 PR は同 pattern を全 field へ拡張 |
| AC3 | 新規 export field 追加時に import 未対応があれば CI fail | key-freeze assert (`Object.keys(exported).sort()` == frozen list) | HEAD `2e0058cef` / export key が frozen list と不一致で toEqual fail → author に round-trip assert 追加を強制 |

## 変更タイプ

- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (テストのみ)

**影響を受ける画面・機能**:
なし (backup round-trip の回帰固定 test 追加のみ、production コード非変更)。

## テスト & 安全装置セルフチェック

- [x] **pre-ready 関連 Step PASS**: biome clean / svelte-check 0 error / 対象 test 9 passed
- [x] 追加・変更したテストの概要: backup-roundtrip-completeness に #3507 field-level ratchet describe を追加。(1) key-freeze で新 export field を捕捉 (2) childActivity/checklistTemplate の全 field を非既定値 round-trip
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A (test は SQLite backend で round-trip、export/import service 経由)
- [x] **Critical バグ修正の場合**: N/A (class-lock test、production 非変更)

## スクリーンショット / ビジュアルデモ

N/A — test only。

## コード品質セルフレビュー (#1481)

- ADR-0061 §2 (same-class-N→guard): #3358 (1 instance) + #3505 (2 instance) の field-drop class に対し、instance パッチでなく **class 全体を lock** する generator-stop を実装。
- key-freeze ratchet は新 field を silent に見逃さない (frozen list 不一致で fail → round-trip assert 追加を強制)。base-token-routes-ratchet / labels-plan-literal-ratchet (#3359) と同型の ratchet 運用。

## 横展開・影響波及チェック

- 既存 test (#3358 isVisible/sortOrder/isArchived / #3422 dailyLimit/nameKana/nameKanji / #3505 checklistTemplate isArchived) がカバーしていなかった field (triggerHint/isMainQuest/priority/basePoints/archivedReason + checklistTemplate pointsPerItem/completionBonus/isActive) を網羅追加。
- entity registry (#3362) = entity-level / 本 ratchet = field-level の 2 層で silent gap を塞ぐ。

## レビュー依頼事項・破壊的変更

破壊的変更なし。production 非変更。field-level 網羅の class-lock test 追加のみ。

## 配布済み env / secret (ADR-0006)

N/A。

## Ready for Review チェックリスト

- [x] CI 緑を確認のうえ Ready 化する
- [x] PR 本文がテンプレート 13 セクションに準拠

## QM レビュー結果

<!-- QM が記入 -->
