### PR TITLE
feat: #3512 DSQL pg-core children DDL + PK drift 検出（TDD 第2サイクル、develop ベース）

### DIFF
--- a/src/lib/server/db/dsql/check-constraints.ts
+++ b/src/lib/server/db/dsql/check-constraints.ts
@@ -1,0 +1,22 @@
+// src/lib/server/db/dsql/check-constraints.ts
+// EPIC #3424 / 実装 #3512 / 設計 SSOT: docs/design/dsql-data-model.md §11.1 / §13.1(fitness#13)
+//
+// enum CHECK 制約を domain SSOT から生成する共有 helper (手書き二重化禁止)。
+// children の theme/ui_mode/archived_reason CHECK は本 helper 経由で
+// age-tier-types.ts / labels.ts / archive-types.ts の SSOT から生成する。
+// pg/sqlite 両 backend が本 helper + 同一 SSOT を共有するため CHECK 文字列は一致する
+// (dialect-parity、fitness#13)。SSOT に値を足せば全 backend の CHECK に自動反映。
+
+import { type SQL, sql } from 'drizzle-orm';
+import type { AnyPgColumn } from 'drizzle-orm/pg-core';
+import { THEME_LABELS } from '$lib/domain/labels';
+
+// theme の SSOT = THEME_LABELS のキー (§2 カラートークン / labels.ts)。
+export const THEME_KEYS = Object.keys(THEME_LABELS) as (keyof typeof THEME_LABELS)[];
+
+// SSOT 配列から `col IN ('a', 'b', ...)` の CHECK 式を生成する。
+// 値のシングルクォートは '' にエスケープ。nullable 列は NULL が CHECK を通過する (SQL 標準)。
+export function enumCheck(column: AnyPgColumn, values: readonly string[]): SQL {
+	const inList = values.map((v) => `'${v.replace(/'/g, "''")}'`).join(', ');
+	return sql`${column} IN (${sql.raw(inList)})`;
+}

--- a/src/lib/server/db/dsql/schema.ts
+++ b/src/lib/server/db/dsql/schema.ts
@@ -11,6 +11,7 @@
 import { sql } from 'drizzle-orm';
 import {
 	boolean,
+	check,
 	integer,
 	pgTable,
 	primaryKey,
@@ -20,6 +21,8 @@ import {
 	uuid,
 } from 'drizzle-orm/pg-core';
 import { ARCHIVED_REASONS } from '$lib/domain/archive-types';
+import { UI_MODES } from '$lib/domain/validation/age-tier-types';
+import { enumCheck, THEME_KEYS } from './check-constraints';
 
 // children — Child 集約の linchpin (§11.1)。
 // 変更点 (vs sqlite 現行):
@@ -53,5 +56,11 @@ export const children = pgTable(
 		isArchived: boolean('is_archived').notNull().default(false),
 		archivedReason: text('archived_reason', { enum: ARCHIVED_REASONS }),
 	},
-	(t) => [primaryKey({ columns: [t.familyId, t.childId] })],
+	(t) => [
+		primaryKey({ columns: [t.familyId, t.childId] }),
+		// CHECK は SSOT から生成 (fitness#13、手書き二重化禁止)。pg/sqlite が同一 helper 共有で一致。
+		check('children_ui_mode_ck', enumCheck(t.uiMode, UI_MODES)),
+		check('children_theme_ck', enumCheck(t.theme, THEME_KEYS)),
+		check('children_archived_reason_ck', enumCheck(t.archivedReason, ARCHIVED_REASONS)),
+	],
 );

--- a/src/lib/server/db/dsql/schema.ts
+++ b/src/lib/server/db/dsql/schema.ts
@@ -1,0 +1,57 @@
+// src/lib/server/db/dsql/schema.ts
+// EPIC #3424 / 実装 #3512 (#N0-1) / 設計 SSOT: docs/design/dsql-data-model.md §11.1 / §11.2 / §5
+//
+// DSQL (Aurora DSQL, PostgreSQL 互換) backend の drizzle pg-core schema。
+// sqlite-core (db/schema.ts) と「同一論理モデル・物理は backend 別」(§4.1)。
+// PK は §11.2 凍結表 = pk-freeze-manifest.ts と一致必須 (fitness#9 / §P1 不可逆)。
+//
+// ── 段階的 population (Canon TDD triangulate) ──
+//   本コミット: children (linchpin) のみ。以後 Phase B/C の各 issue で該当表を追記。
+
+import { sql } from 'drizzle-orm';
+import {
+	boolean,
+	integer,
+	pgTable,
+	primaryKey,
+	real,
+	text,
+	timestamp,
+	uuid,
+} from 'drizzle-orm/pg-core';
+import { ARCHIVED_REASONS } from '$lib/domain/archive-types';
+
+// children — Child 集約の linchpin (§11.1)。
+// 変更点 (vs sqlite 現行):
+//   - PK: 整数 autoincrement id → 複合 (family_id, child_id uuid v4)。§P2 複合 tenant PK + §P3 UUID。
+//   - age 列を撤去 → birth_date から compute-on-read で ui_mode 派生 (§11.1 age→ui_mode 読取時導出)。
+//   - _sv (楽観ロック version) を撤去 → DSQL は OCC (§8) ゆえ不要。
+//   - temporal 列は { mode: 'string' } 固定 (fitness#6、pg=Date/sqlite=string の型 drift 防止)。
+//   - theme / ui_mode / archived_reason の CHECK 制約 (SSOT 生成) は次サイクル (fitness#13 dialect-parity)。
+export const children = pgTable(
+	'children',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull().default(sql`gen_random_uuid()`),
+		nickname: text('nickname').notNull(),
+		// age 列は持たない (§11.1 compute-on-read)。birth_date が唯一の年齢ソース。
+		birthDate: text('birth_date'),
+		theme: text('theme').notNull().default('pink'),
+		uiMode: text('ui_mode').notNull().default('preschool'),
+		uiModeManuallySet: boolean('ui_mode_manually_set').notNull().default(false),
+		avatarUrl: text('avatar_url'),
+		displayConfig: text('display_config'),
+		userId: text('user_id'),
+		birthdayBonusMultiplier: real('birthday_bonus_multiplier').notNull().default(1.0),
+		lastBirthdayBonusYear: integer('last_birthday_bonus_year'),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		updatedAt: timestamp('updated_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		isArchived: boolean('is_archived').notNull().default(false),
+		archivedReason: text('archived_reason', { enum: ARCHIVED_REASONS }),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId] })],
+);

--- a/tests/unit/db/dsql-check-from-ssot.test.ts
+++ b/tests/unit/db/dsql-check-from-ssot.test.ts
@@ -1,0 +1,43 @@
+// tests/unit/db/dsql-check-from-ssot.test.ts
+// EPIC #3424 / 実装 #3512 / 設計 SSOT: docs/design/dsql-data-model.md §11.1 / §13.1(fitness#13)
+//
+// fitness#13「dialect-parity / CHECK は SSOT 生成」:
+//   children の theme/ui_mode/archived_reason CHECK 制約は age-tier-types.ts / labels.ts /
+//   archive-types.ts の SSOT から生成し、DDL に値を手書き二重化しない (§11.1)。
+//   SSOT に値を足したのに DDL の CHECK が古いまま = drift を CI で検出する。
+//   pg/sqlite 両 backend が同一 helper (enumCheck) + 同一 SSOT を使うため CHECK 文字列は
+//   構造的に一致する (dialect-parity)。sqlite 側 children の CHECK 付与は cutover [4] で追加。
+//
+// ── Canon TDD (red-first) ── check-constraints helper + children CHECK 未実装で fail。
+
+import { getTableConfig, PgDialect } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+import { ARCHIVED_REASONS } from '$lib/domain/archive-types';
+import { UI_MODES } from '$lib/domain/validation/age-tier-types';
+
+describe('fitness#13: children DDL CHECK は SSOT 生成 (手書き二重化禁止)', () => {
+	const dialect = new PgDialect();
+
+	async function checkSql(name: string): Promise<string> {
+		const { children } = await import('../../../src/lib/server/db/dsql/schema');
+		const ck = getTableConfig(children).checks.find((c) => c.name === name);
+		if (!ck) throw new Error(`CHECK not found: ${name}`);
+		return dialect.sqlToQuery(ck.value).sql;
+	}
+
+	it('ui_mode CHECK が UI_MODES 全値を含む (SSOT 生成)', async () => {
+		const s = await checkSql('children_ui_mode_ck');
+		for (const m of UI_MODES) expect(s).toContain(`'${m}'`);
+	});
+
+	it('archived_reason CHECK が ARCHIVED_REASONS 全値を含む (SSOT 生成)', async () => {
+		const s = await checkSql('children_archived_reason_ck');
+		for (const r of ARCHIVED_REASONS) expect(s).toContain(`'${r}'`);
+	});
+
+	it('theme CHECK が THEME_KEYS 全値を含む (SSOT 生成)', async () => {
+		const { THEME_KEYS } = await import('../../../src/lib/server/db/dsql/check-constraints');
+		const s = await checkSql('children_theme_ck');
+		for (const t of THEME_KEYS) expect(s).toContain(`'${t}'`);
+	});
+});

--- a/tests/unit/db/pk-freeze-manifest.test.ts
+++ b/tests/unit/db/pk-freeze-manifest.test.ts
@@ -29,4 +29,16 @@ describe('fitness#9: PK 凍結 manifest (§11.2 / §P1 不可逆不変条件)', 
 		// UUID v4 child_id (§P3 時刻列を PK に入れない) + family_id 先頭 (§P2 複合 tenant PK)。
 		expect(manifest.children).toEqual(['family_id', 'child_id']);
 	});
+
+	it('[3] drizzle pg-core (DSQL) children schema の PK == manifest (drift 検出)', async () => {
+		// red: DSQL pg-core schema は #3512 green で新設。現状は存在せず import が throw する。
+		const { getTableConfig } = await import('drizzle-orm/pg-core');
+		const { children } = await import('../../../src/lib/server/db/dsql/schema');
+		const { PK_FREEZE_MANIFEST } = await import('../../../src/lib/server/db/pk-freeze-manifest');
+
+		// 複合 PK は primaryKeys[0].columns で取得 (§11.2 凍結表と一致すること)。
+		const cfg = getTableConfig(children);
+		const pkCols = cfg.primaryKeys[0]?.columns.map((c) => c.name) ?? [];
+		expect(pkCols).toEqual([...PK_FREEZE_MANIFEST.children]);
+	});
 });


### PR DESCRIPTION
## 概要
#3512（PK 凍結 manifest + children linchpin DDL）の継続。cycle-1（manifest + test [1]）は #3515 で merge 済。本 PR は **children の pg-core DDL 本体 + PK drift 検出 [3]**。設計が develop に入ったため **develop ベース**（stack 解消）。

## 変更（Canon TDD triangulate）
- **Red**: test list [3]（pg children schema PK == manifest、dsql/schema 未実装で fail）
- **Green**: `src/lib/server/db/dsql/schema.ts` の children pg テーブル
  - PK: 複合 `(family_id, child_id uuid v4 gen_random_uuid())` §P2/§P3
  - **age 列撤去** → birth_date から compute-on-read（§11.1）
  - **_sv 撤去**（DSQL は OCC §8）、temporal `{mode:'string'}`（fitness#6）

## 顧客価値・目的

**対象ユーザー**: システム全体（DB 基盤、直接のエンドユーザー影響なし）

**解決する課題**: DSQL 移行（EPIC #3424）において `child_id` は約 20 表の複合 PK 先頭の linchpin であり、DSQL は PK 凍結後に変更不可（§P1）。children の pg-core DDL を先行して確定し、以後の実装が凍結 manifest からの逸脱を機械検出できる土台を作る必要がある。

**期待される効果**: children テーブルの PK / age 列 / `_sv` 列の設計が固まり、後続の DSQL 移行タスク（sqlite-core 移行・dialect-parity・全テナント表展開）が drift なく安全に進められる。ユーザー向け機能・UI への直接影響はなし。

## 関連 Issue

<!-- 本 PR は #3512 (EPIC #3424) の一部 AC (AC4 + AC1 の一部) のみを充足する継続 PR。AC2/AC3/AC5 および sqlite-core 移行は後続サイクルのため closes しない -->
関連: #3512 (EPIC #3424 の sub-issue、AC4 完了 / 残 AC は後続サイクルで対応のため close しない)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC4 (#3512) | children pg DDL（uuid 複合 PK / age 撤去 / _sv 撤去、§11.1） | `src/lib/server/db/dsql/schema.ts` 実装 + 型チェック | HEAD 時点で `dsql/schema.ts` に PK `(family_id, child_id)` / age 列なし / `_sv` 列なし を実装済み、`npx svelte-check` PASS |
| [3] (drift 検出) | fitness#9: pg schema PK == manifest（drift 検出） | `npx vitest run tests/unit/db/pk-freeze-manifest.test.ts` | 2 tests green（Red→Green の TDD 第2サイクル、`unit-test-merge` CI job PASS） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（`src/lib/server/db/dsql/schema.ts` + PK drift 検出テストのみ。DSQL 移行はまだ本番切替前段階で、既存 sqlite/本番経路には未接続）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載: `tests/unit/db/pk-freeze-manifest.test.ts` に pg children schema の PK が凍結 manifest と一致することを検証する fitness function を追加（Red: schema 未実装で fail → Green: `dsql/schema.ts` 実装で 2 tests green）
- [ ] **新規 env / secret 追加時**（ADR-0006）: N/A
- [ ] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [ ] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（UI 変更を含まない DB スキーマ / テストのみの変更のため）**

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: schema 定義は `dsql/schema.ts` 単一責任、manifest との整合は fitness function（テスト層）に分離
- [x] **DRY**: PK 定義を manifest 1 箇所に集約し、pg schema からの重複定義を避けている（drift 検出テストで machine-verify）
- [x] **YAGNI**: 本サイクルで必要な children テーブルのみ実装、他テナント表は後続サイクルへ
- [ ] **Security（OSS 公開前提）**: N/A（DB スキーマ定義のみ、外部入出力なし）
- [ ] **アクセシビリティ**: N/A（UI 変更なし）
- [ ] **パフォーマンス**: N/A（スキーマ定義のみ）

## 横展開・影響波及チェック

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [ ] E2E / ユニットシード（`tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` / `src/lib/server/demo/demo-data.ts`）と チュートリアル (`tutorial-chapters.ts` / `demo-guide-state.svelte.ts`) を同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): `docs/design/dsql-data-model.md` §11.1/§11.2 が本変更の設計 SSOT（既存設計書に沿った実装のため追加更新なし）
- [x] **並行 PR overlap** (#1200): #3515 (cycle-1、manifest + test) merge 済み、本 PR は stack 解消済みで develop ベースに切替済み。他の並行変更なし
- [x] N/A — 並行実装の影響範囲外（DSQL 移行は本番未接続の基盤整備段階）

該当なしの場合は「N/A」と明記。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**:
残（後続サイクル）:
- [4] sqlite-core children の drift 検出 + 実 sqlite 移行（cutover、~20 表 cascade）
- fitness#13 dialect-parity（theme/ui_mode/archived_reason の CHECK を SSOT 生成、pg/sqlite 一致）
- manifest の全テナント表 population [2]

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope の AC4 + drift 検出 [3] のみ。残 AC2/AC3/AC5 は親 Issue #3512 に残し後続サイクルで対応、未完了項目を本文に残していない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（#3512 EPIC #3424 の合意済み分割計画に沿った継続 PR）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（該当なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
