### PR TITLE
test: #3512 fitness#6 temporal dialect-parity guard (pg {mode:'string'} 機械強制)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -532,3 +532,7 @@ wada
 # validationexception = lowercase 例外クラス名の例（blocklist test payload）
 SQLSTATE
 validationexception
+
+# ===== #3512 fitness#6 temporal dialect-parity guard =====
+# timestamptz = PostgreSQL/DSQL の標準型名 (TIMESTAMP WITH TIME ZONE の略記、造語ではない)
+timestamptz

--- a/tests/unit/db/dsql-temporal-parity.test.ts
+++ b/tests/unit/db/dsql-temporal-parity.test.ts
@@ -1,0 +1,92 @@
+// tests/unit/db/dsql-temporal-parity.test.ts
+// EPIC #3424 / 実装 #3512 (#N0-1) / 設計 SSOT: docs/design/dsql-data-model.md §11.3 / §13.1(fitness#6)
+//
+// fitness#6「dialect-parity: temporal {mode:'string'} を両 backend で assert」:
+//   §11.3 変換規則は「全 temporal は {mode:'string'} 固定」— pg が Date を返すと
+//   SQLite[string] と型 drift + backup verbatim 破壊 (SQLite parity Finding 6)。
+//   drizzle では mode 省略時の既定が Date mode (dataType='date') のため、
+//   表追記時に {mode:'string'} を書き忘れるだけで silent drift する → CI で機械強制。
+//
+//   検査は schema module の全 export 表を走査する（children 固定列挙にしない）ため、
+//   Phase B/C で表を追記しても本テストの変更なしで自動カバーされる。
+//
+// ── Canon TDD test list ──
+//   [1] pg: dsql/schema.ts 全表の temporal 列 (PgTimestamp*/PgDate*) が dataType='string'
+//   [2] pg: timestamp 列は全て withTimezone=true (§11.3 timestamptz↔text(ISO))
+//   [3] sqlite: pg schema と同名の表に Date-mode 列 (dataType='date') が無い
+//   red 確認は mutation（children の {mode:'string'} を外す）で drift 検出を実証済。
+
+import { getTableName, is } from 'drizzle-orm';
+import { PgTable, getTableConfig as pgTableConfig } from 'drizzle-orm/pg-core';
+import { SQLiteTable, getTableConfig as sqliteTableConfig } from 'drizzle-orm/sqlite-core';
+import { describe, expect, it } from 'vitest';
+import * as dsqlSchema from '../../../src/lib/server/db/dsql/schema';
+import * as sqliteSchema from '../../../src/lib/server/db/schema';
+
+/** dsql/schema.ts の全 pg 表（export 走査、表追記で自動拡張） */
+const pgTables = Object.values(dsqlSchema).filter((v): v is PgTable => is(v, PgTable));
+
+/** pg temporal 列 = timestamp / date 系 columnType（mode により *String suffix が付く） */
+const isPgTemporal = (columnType: string) =>
+	columnType.startsWith('PgTimestamp') || columnType.startsWith('PgDate');
+
+describe('fitness#6: temporal dialect-parity (§11.3 / SQLite parity Finding 6)', () => {
+	it('dsql schema に pg 表が最低 1 つ存在する（走査の空振り防止）', () => {
+		expect(pgTables.length).toBeGreaterThan(0);
+	});
+
+	it('[1] pg: 全 temporal 列が {mode:"string"} (dataType="string"、Date mode 禁止)', () => {
+		const violations: string[] = [];
+		let temporalCount = 0;
+		for (const table of pgTables) {
+			const cfg = pgTableConfig(table);
+			for (const col of cfg.columns) {
+				if (!isPgTemporal(col.columnType)) continue;
+				temporalCount++;
+				if (col.dataType !== 'string') {
+					violations.push(`${cfg.name}.${col.name} (columnType=${col.columnType})`);
+				}
+			}
+		}
+		// created_at/updated_at を持つ children が既に居るため 0 件は走査バグ（vacuous pass 防止）
+		expect(temporalCount).toBeGreaterThan(0);
+		expect(violations, 'temporal 列は {mode:"string"} 必須 (§11.3)').toEqual([]);
+	});
+
+	it('[2] pg: timestamp 列は全て withTimezone=true (timestamptz、§11.3)', () => {
+		const violations: string[] = [];
+		for (const table of pgTables) {
+			const cfg = pgTableConfig(table);
+			for (const col of cfg.columns) {
+				if (!col.columnType.startsWith('PgTimestamp')) continue;
+				// PgTimestamp / PgTimestampString は withTimezone プロパティを持つ
+				const withTz = (col as unknown as { withTimezone?: boolean }).withTimezone;
+				if (withTz !== true) {
+					violations.push(`${cfg.name}.${col.name}`);
+				}
+			}
+		}
+		expect(violations, 'timestamp は timestamptz 固定 (§11.3)').toEqual([]);
+	});
+
+	it('[3] sqlite: pg schema と同名の表に Date-mode 列が無い（両 backend 共に string）', () => {
+		const pgTableNames = new Set(pgTables.map((t) => getTableName(t)));
+		const sqliteTables = Object.values(sqliteSchema).filter((v): v is SQLiteTable =>
+			is(v, SQLiteTable),
+		);
+		const paired = sqliteTables.filter((t) => pgTableNames.has(getTableName(t)));
+		// pg 側に children が居る以上、sqlite 側にも同名表が居るはず（parity pair の空振り防止）
+		expect(paired.length).toBeGreaterThan(0);
+
+		const violations: string[] = [];
+		for (const table of paired) {
+			const cfg = sqliteTableConfig(table);
+			for (const col of cfg.columns) {
+				if (col.dataType === 'date') {
+					violations.push(`${cfg.name}.${col.name} (columnType=${col.columnType})`);
+				}
+			}
+		}
+		expect(violations, 'sqlite 側も temporal は string（integer timestamp mode 禁止）').toEqual([]);
+	});
+});

--- a/tests/unit/db/dsql-temporal-parity.test.ts
+++ b/tests/unit/db/dsql-temporal-parity.test.ts
@@ -24,7 +24,13 @@ import * as dsqlSchema from '../../../src/lib/server/db/dsql/schema';
 import * as sqliteSchema from '../../../src/lib/server/db/schema';
 
 /** dsql/schema.ts の全 pg 表（export 走査、表追記で自動拡張） */
-const pgTables = Object.values(dsqlSchema).filter((v): v is PgTable => is(v, PgTable));
+// `is(v, PgTable)` を型述語 (`v is PgTable`) 付きで使うと、schema module の export が
+// 表ごとに具体的な `PgTableWithColumns<{name:"children";...}>` 型を持つため、
+// 述語の型 (PgTable) が parameter 型 (具体的な表の型) に非互換と判定され svelte-check
+// エラーになる。型述語を使わず filter 後に `as PgTable<any>[]` へ型アサーションすることで
+// 「pg 表であるかどうか」の実行時走査を型チェックの制約なしに成立させる。
+// biome-ignore lint/suspicious/noExplicitAny: 表ごとに異なる具体的 column 型を持つため、走査用の型ガードとして意図的にジェネリクスを緩めている（上記コメント参照）
+const pgTables = Object.values(dsqlSchema).filter((v) => is(v, PgTable)) as PgTable<any>[];
 
 /** pg temporal 列 = timestamp / date 系 columnType（mode により *String suffix が付く） */
 const isPgTemporal = (columnType: string) =>
@@ -70,11 +76,13 @@ describe('fitness#6: temporal dialect-parity (§11.3 / SQLite parity Finding 6)'
 	});
 
 	it('[3] sqlite: pg schema と同名の表に Date-mode 列が無い（両 backend 共に string）', () => {
-		const pgTableNames = new Set(pgTables.map((t) => getTableName(t)));
-		const sqliteTables = Object.values(sqliteSchema).filter((v): v is SQLiteTable =>
-			is(v, SQLiteTable),
-		);
-		const paired = sqliteTables.filter((t) => pgTableNames.has(getTableName(t)));
+		const pgTableNames = new Set<string>(pgTables.map((t) => getTableName(t)));
+		// pg 側と同様、型述語を使わず filter 後にアサーションする（表追記で export union が
+		// 変わっても svelte-check エラーにならない汎用走査にするため）。
+		const sqliteTables = Object.values(sqliteSchema).filter((v) => is(v, SQLiteTable));
+		// biome-ignore lint/suspicious/noExplicitAny: pg 側と同様、走査用型ガードとして意図的
+		const typedSqliteTables = sqliteTables as SQLiteTable<any>[];
+		const paired = typedSqliteTables.filter((t) => pgTableNames.has(getTableName(t)));
 		// pg 側に children が居る以上、sqlite 側にも同名表が居るはず（parity pair の空振り防止）
 		expect(paired.length).toBeGreaterThan(0);
 


### PR DESCRIPTION
## 概要

EPIC #3424 / #3512 (Phase 0) の TDD 第 4 サイクル。設計 SSOT `docs/design/dsql-data-model.md` §13.1 **fitness#6**（dialect-parity: temporal `{mode:'string'}` を両 backend で assert）のうち temporal mode ガードを恒久テスト化する。

## 背景 (§11.3 / SQLite parity Finding 6)

- §11.3 変換規則: 「全 temporal は `{mode:'string'}` 固定」。pg が `Date` を返すと SQLite[string] と型 drift + backup verbatim 破壊。
- drizzle は mode 省略時の既定が Date mode のため、Phase B/C で表を追記する際に `{mode:'string'}` を書き忘れるだけで silent drift する → CI で機械強制 (ADR-0061 fitness function)。

## 変更内容

- `tests/unit/db/dsql-temporal-parity.test.ts` 新規 (test only、+92 行):
  - **[1]** pg: `db/dsql/schema.ts` 全 export 表の temporal 列 (PgTimestamp*/PgDate*) が `dataType='string'`
  - **[2]** pg: timestamp 列は全て `withTimezone=true` (§11.3 timestamptz↔text(ISO))
  - **[3]** sqlite: pg schema と同名表に Date-mode 列が無い（両 backend 共に string）
  - schema module 全 export 走査（children 固定列挙にしない）+ temporal 0 件 / parity pair 0 件の vacuous pass 防止 assert 付き → **表追記時に本テスト変更なしで自動カバー**

## 検証

- `npx vitest run tests/unit/db/` → **500/500 pass**
- red 実証 (mutation): children `created_at` の `{mode:'string', withTimezone:true}` を `{mode:'date', withTimezone:false}` に一時変更 → [1][2] が fail することを確認後 revert
- `npx biome check --write` 適用済

## 顧客価値・目的

**対象ユーザー**: システム全体（開発基盤 / データ整合性）

**解決する課題**: DynamoDB → Aurora DSQL 移管 (EPIC #3424) において、pg/SQLite 両 backend の temporal 列定義が drizzle mode 省略により暗黙に drift すると、バックアップ verbatim 復元や dialect-parity が壊れる。人手レビューでは表追加のたびに見落としが発生し得るため、CI で機械的に検出できるようにする。

**期待される効果**: 新規テーブル追加時に temporal 列の `{mode:'string'}` 忘れを CI が即座に検出し、DSQL 移行中のデータ破壊リスクを構造的に防ぐ。

## 関連 Issue

関連: #3512（fitness#6 dialect-parity のうち temporal 分。生成列 owner_guard 等 + UNIQUE / CHECK の dialect-parity 残分は Phase B で拡張するため本 PR では closes しない）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC-fitness6-temporal-1 | pg schema 全 export 表の temporal 列が `{mode:'string'}` | `npx vitest run tests/unit/db/dsql-temporal-parity.test.ts` | HEAD `b44e5386a` / 3 tests pass / `tests/unit/db/dsql-temporal-parity.test.ts` |
| AC-fitness6-temporal-2 | pg timestamp 列は全て `withTimezone=true` | 同上（同ファイル test [2]） | HEAD `b44e5386a` / pass / `tests/unit/db/dsql-temporal-parity.test.ts:56` |
| AC-fitness6-temporal-3 | sqlite 側に Date-mode 列が存在しない（両 backend string 統一） | 同上（同ファイル test [3]） | HEAD `b44e5386a` / pass / `tests/unit/db/dsql-temporal-parity.test.ts:69` |
| AC-regression | 既存 unit test 群に regression なし | `npx vitest run tests/unit/db/` | HEAD `b44e5386a` / 500/500 pass |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)（検証テストの追加のみ、スキーマ自体は無変更）
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（test-only PR、UI/画面変更なし）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載: `tests/unit/db/dsql-temporal-parity.test.ts` 新規追加（pg/sqlite dialect-parity fitness function、+92 行）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret の追加なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — DynamoDB 実装変更なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — critical バグ修正ではない

## スクリーンショット / ビジュアルデモ

該当なし（test-only PR、UI 変更を含まない）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（S）— schema module 全 export 走査のみを担う独立したテストファイル
- [x] **DRY**: 同一ロジック / 同一バグが他ファイルにないか確認済み（既存 `dsql-schema-parity` 系テストと重複しないことを `grep -rn "dsql-temporal-parity\|withTimezone" tests/unit/db/` で確認）
- [x] **YAGNI**: 現要件に不要な抽象化を追加していない（schema 全走査 + assert のみ）
- [x] **Security（OSS 公開前提）**: N/A — 秘密情報・内部 URL の hardcode なし、test コードのみ
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: N/A — CI test 実行時間への影響は軽微（vitest 全体 500 tests で数 ms オーダー）

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（test-only、UI / LP / 年齢モード / ナビゲーションへの影響なし）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A — LP / 販促文言の変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
本 PR は fitness#6 (dialect-parity) のうち temporal 分のみをカバーする。生成列 (owner_guard 等) + UNIQUE / CHECK の dialect-parity 残分は EPIC #3424 Phase B (auth 5 表拡張) の PR でカバーする。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 本 PR scope（fitness#6 dialect-parity の temporal 分）の AC は全て実装・検証済み。残 dialect-parity 分は EPIC #3424 Phase B の別 PR が担当
- [x] Phase 分割: N/A（Phase 分割は EPIC #3424 起票時点で既に合意済みの計画）
- [x] UI 変更時の SS 添付: N/A（UI 変更なし）
- [x] 認証画面変更時の SS 添付: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
