### PR TITLE
feat: #3512 PK 凍結 manifest 全テナント表 population + §11.2 doc-parse 突合

### DIFF
--- a/src/lib/server/db/pk-freeze-manifest.ts
+++ b/src/lib/server/db/pk-freeze-manifest.ts
@@ -3,19 +3,61 @@
 //
 // PK 凍結 manifest = §11.2「全テナント表 PK 凍結表」の機械可読 SSOT。
 // DSQL は PK = 物理レイアウトで後変更不可 (§P1)。fitness#9 (pk-freeze-manifest.test.ts) が
-// drizzle pg/sqlite schema の PK == 本 manifest を CI で hard-fail し、凍結逸脱を機械封鎖する。
-// PK 変更は「本 manifest 更新 + migration ADR」を人手強制する唯一の点 (§12.5 zero-user rebuildable)。
+// (a) 本 manifest == §11.2 markdown 表 (test 内 parser で抽出) と
+// (b) drizzle pg/sqlite schema の PK == 本 manifest を CI で hard-fail し、凍結逸脱を機械封鎖する。
+// PK 変更は「§11.2 + 本 manifest の同時更新 + migration ADR」を人手強制する唯一の点 (§12.5)。
 //
 // governing rule (§11.2, 戦略/PO パネル 2026-07-01): 自然複合 PK 凍結は
 //   (a) policy invariant (ADR 参照) or (b) 構造的確実性 に anchor される表のみ。
 //   mutable product default だけが根拠の表は UUID PK + droppable UNIQUE (例: certificates)。
 //
-// ── 段階的 population (Canon TDD triangulate) ──
-//   本コミット: children (linchpin) のみ。以後 Phase B/C の各 issue で該当表を追記していく。
+// §11.2 で凍結対象外のため本 manifest に載せない表:
+//   - report_daily_summaries (廃止、§7 compute-on-read) / achievements 系 (drop 確定、§10-10)
+//   - Family 系 (settings 等、PK は §11.3 で確定 = 未凍結。確定時に追記)
+//   - グローバル master (categories(code) 等) / auth 5 表 (§6.6) — family_id 先頭でない例外 (test [5])
 
 export const PK_FREEZE_MANIFEST = {
-	// Child 集約 linchpin: child_id は ~20 表の複合 PK 先頭。UUID v4 (§P3 時刻列を PK に入れない)。
+	// ── Child 集約 (§3) ──
+	// children は linchpin: child_id が下記 ~30 表の複合 PK 先頭。UUID v4 (§P3 時刻列を PK に入れない)。
 	children: ['family_id', 'child_id'],
+	child_activities: ['family_id', 'child_id', 'activity_id'],
+	// activity_logs / point_ledger: UUID v4 random で hot-partition ゼロ。
+	// created_at は PK に入れない (sort 用途のみ = identity でない、§11.2 判断⑬訂正)。
+	activity_logs: ['family_id', 'child_id', 'log_id'],
+	point_ledger: ['family_id', 'child_id', 'ledger_id'],
+	statuses: ['family_id', 'child_id', 'category_id'],
+	status_history: ['family_id', 'child_id', 'category_id', 'hist_id'],
+	activity_mastery: ['family_id', 'child_id', 'activity_id'],
+	child_activity_preferences: ['family_id', 'child_id', 'activity_id'],
+	daily_missions: ['family_id', 'child_id', 'mission_date', 'activity_id'],
+	// login_bonuses / daily_battles / rest_days: 1日1回 = ADR-0012 anti-engagement の
+	// policy invariant に anchor された自然複合 PK (governing rule (a)、PO 決裁済)。
+	login_bonuses: ['family_id', 'child_id', 'login_date'],
+	// stamp_cards: anchor (b) シーズン撤去前提。条件 = シーズン/イベントカード復活が roadmap に無いこと。
+	stamp_cards: ['family_id', 'child_id', 'week_start'],
+	stamp_entries: ['family_id', 'card_id', 'slot'],
+	checklist_logs: ['family_id', 'child_id', 'template_id', 'checked_date'],
+	checklist_log_items: ['family_id', 'child_id', 'template_id', 'checked_date', 'item_id'],
+	checklist_overrides: ['family_id', 'child_id', 'override_id'],
+	checklist_templates: ['family_id', 'template_id'],
+	checklist_template_items: ['family_id', 'template_id', 'item_id'],
+	checklist_template_assignments: ['family_id', 'template_id', 'child_id'],
+	// certificates: governing rule で UUID surrogate 化 (再発行/周期型証書が roadmap プラウジブル、
+	// policy anchor 無し)。「1 type 有効1通」は生成列 + droppable UNIQUE で担保 (§11.2)。
+	certificates: ['family_id', 'child_id', 'certificate_id'],
+	evaluations: ['family_id', 'child_id', 'eval_id'],
+	evaluation_scores: ['family_id', 'child_id', 'eval_id', 'category_id'],
+	rest_days: ['family_id', 'child_id', 'date'],
+	daily_battles: ['family_id', 'child_id', 'date'],
+	enemy_collection: ['family_id', 'child_id', 'enemy_id'],
+	special_rewards: ['family_id', 'child_id', 'reward_id'],
+	reward_redemption_requests: ['family_id', 'redemption_id'],
+	parent_messages: ['family_id', 'child_id', 'msg_id'],
+	sibling_cheers: ['family_id', 'cheer_id'],
+	character_images: ['family_id', 'child_id', 'image_id'],
+	child_custom_voices: ['family_id', 'child_id', 'voice_id'],
+	child_challenges: ['family_id', 'child_id', 'challenge_id'],
+	usage_logs: ['family_id', 'child_id', 'log_id'],
 } as const satisfies Record<string, readonly string[]>;
 
 export type PkFreezeManifest = typeof PK_FREEZE_MANIFEST;

--- a/tests/unit/db/pk-freeze-manifest.test.ts
+++ b/tests/unit/db/pk-freeze-manifest.test.ts
@@ -55,15 +55,19 @@ const parseFrozenPkTable = (): Record<string, string[]> => {
 		// 表名: `activity_pref (child_activity_preferences)` は括弧内の実表名を採用。
 		// `**child_custom_voices**（**§3 欠落→編入**）` は強調 + 全角括弧注記を除去。
 		const paren = rawName.match(/\(([a-z0-9_]+)\)/);
-		const name = paren
-			? paren[1]
-			: rawName
-					.replace(/\*\*/g, '')
-					.replace(/（[^）]*）/g, '')
-					.trim();
+		const name =
+			paren?.[1] ??
+			rawName
+				.replace(/\*\*/g, '')
+				.replace(/（[^）]*）/g, '')
+				.trim();
 		expect(name, `表名が snake_case で抽出できる: "${rawName}"`).toMatch(/^[a-z0-9_]+$/);
 		// PK 列: `ledger_id uuid[v4]` / `activity_id uuid` 等の型注記を落とし列名のみ。
-		const cols = m[1].split(',').map((part) => part.trim().split(/\s+/)[0]);
+		const pkColumnList = m[1] ?? '';
+		const cols = pkColumnList.split(',').map((part) => {
+			const trimmed = part.trim();
+			return trimmed.split(/\s+/)[0] ?? trimmed;
+		});
 		frozen[name] = cols;
 	}
 	return frozen;
@@ -108,9 +112,12 @@ describe('fitness#9: PK 凍結 manifest (§11.2 / §P1 不可逆不変条件)', 
 		const manifest = PK_FREEZE_MANIFEST as Record<string, readonly string[]>;
 
 		// dsql/schema.ts に実装された全 pg 表を走査 (表追記時に本テスト変更なしで自動カバー)。
-		const pgTables = Object.values(dsqlSchema).filter((v): v is InstanceType<typeof PgTable> =>
-			is(v, PgTable),
-		);
+		// filter 後に cast することで、各 export の具体的な PgTableWithColumns<{name:"..."}>
+		// 型が InstanceType<typeof PgTable> (PgTable<TableConfig>) の type predicate に
+		// 非 assignable と判定される TS エラーを回避する (predicate は param 型のサブタイプが必要)。
+		const pgTables = Object.values(dsqlSchema).filter((v) => is(v, PgTable)) as InstanceType<
+			typeof PgTable
+		>[];
 		expect(pgTables.length).toBeGreaterThan(0);
 
 		for (const table of pgTables) {

--- a/tests/unit/db/pk-freeze-manifest.test.ts
+++ b/tests/unit/db/pk-freeze-manifest.test.ts
@@ -15,9 +15,59 @@
 //   [5] グローバル master (categories(code) 等) / auth (users(user_id) 等) は family_id 先頭でない例外
 //   [3][4] は pg/sqlite schema 実装後 (#3512 green) に triangulate で追加する。
 //
-// 本ファイルは red-first (schema/manifest 未実装で fail)。green = manifest + children DDL 実装。
+// [2] の実装方式 (2026-07-02 cycle-5): §11.2 の markdown 表を test 内 parser で機械抽出し
+//   manifest と完全一致を assert する。写経の二重化 (test にも PK 表を hardcode) ではなく
+//   「設計書 SSOT ↔ 機械可読 manifest」の drift を CI が直接検出する (ADR-0001 設計書 SSOT)。
+//   設計書の PK 変更 / manifest の勝手な変更のどちらも即 fail し、両者同時更新を人手強制する。
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+
+/**
+ * docs/design/dsql-data-model.md §11.2 の PK 凍結表 (markdown) から
+ * 「テナント表名 → 凍結 PK 列リスト」を抽出する。
+ *
+ * 抽出対象 = 確定 PK 列が `(family_id, ...)` backtick tuple で書かれた行のみ。
+ * 以下は §11.2 上の記載により対象外 (manifest にも入れない):
+ *   - report_daily_summaries (**廃止**、§7) / achievements 系 (drop 確定、§10-10)
+ *   - Family 系まとめ行 (`<natural or uuid>` placeholder = §11.3 で確定、未凍結)
+ *   - グローバル master 行 (確定 PK 列が tuple でない「自然キー」表記)
+ */
+const parseFrozenPkTable = (): Record<string, string[]> => {
+	const doc = readFileSync(join(__dirname, '../../../docs/design/dsql-data-model.md'), 'utf-8');
+	const lines = doc.split('\n');
+	const start = lines.findIndex((l) => l.includes('§11.2 全テナント表 PK 凍結表'));
+	const end = lines.findIndex((l, i) => i > start && l.includes('§11.3 per-column 完全 DDL'));
+	expect(start, '§11.2 見出しが設計書に存在する').toBeGreaterThanOrEqual(0);
+	expect(end, '§11.3 見出しが設計書に存在する').toBeGreaterThan(start);
+
+	const frozen: Record<string, string[]> = {};
+	for (const line of lines.slice(start, end)) {
+		if (!line.startsWith('|')) continue;
+		const cells = line.split('|').map((c) => c.trim());
+		// cells[0] は空 ('|' 先頭)、cells[1] = 表名、cells[2] = 確定 PK
+		const rawName = cells[1] ?? '';
+		const rawPk = cells[2] ?? '';
+		// 確定 PK が backtick の (col, col, ...) tuple である行だけが凍結対象。
+		const m = rawPk.match(/^`\(([^)<]+)\)`$/);
+		if (!m) continue;
+		// 表名: `activity_pref (child_activity_preferences)` は括弧内の実表名を採用。
+		// `**child_custom_voices**（**§3 欠落→編入**）` は強調 + 全角括弧注記を除去。
+		const paren = rawName.match(/\(([a-z0-9_]+)\)/);
+		const name = paren
+			? paren[1]
+			: rawName
+					.replace(/\*\*/g, '')
+					.replace(/（[^）]*）/g, '')
+					.trim();
+		expect(name, `表名が snake_case で抽出できる: "${rawName}"`).toMatch(/^[a-z0-9_]+$/);
+		// PK 列: `ledger_id uuid[v4]` / `activity_id uuid` 等の型注記を落とし列名のみ。
+		const cols = m[1].split(',').map((part) => part.trim().split(/\s+/)[0]);
+		frozen[name] = cols;
+	}
+	return frozen;
+};
 
 describe('fitness#9: PK 凍結 manifest (§11.2 / §P1 不可逆不変条件)', () => {
 	it('[1] manifest が存在し children の PK = (family_id, child_id) を宣言する', async () => {
@@ -30,15 +80,45 @@ describe('fitness#9: PK 凍結 manifest (§11.2 / §P1 不可逆不変条件)', 
 		expect(manifest.children).toEqual(['family_id', 'child_id']);
 	});
 
-	it('[3] drizzle pg-core (DSQL) children schema の PK == manifest (drift 検出)', async () => {
-		// red: DSQL pg-core schema は #3512 green で新設。現状は存在せず import が throw する。
-		const { getTableConfig } = await import('drizzle-orm/pg-core');
-		const { children } = await import('../../../src/lib/server/db/dsql/schema');
+	it('[2] manifest == §11.2 凍結 PK 表 (設計書 SSOT ↔ manifest の双方向 drift 検出)', async () => {
 		const { PK_FREEZE_MANIFEST } = await import('../../../src/lib/server/db/pk-freeze-manifest');
+		const frozen = parseFrozenPkTable();
 
-		// 複合 PK は primaryKeys[0].columns で取得 (§11.2 凍結表と一致すること)。
-		const cfg = getTableConfig(children);
-		const pkCols = cfg.primaryKeys[0]?.columns.map((c) => c.name) ?? [];
-		expect(pkCols).toEqual([...PK_FREEZE_MANIFEST.children]);
+		// parser の空振り防止: children linchpin + 代表的な自然複合 PK 表が必ず抽出される。
+		expect(frozen.children).toEqual(['family_id', 'child_id']);
+		expect(frozen.daily_battles).toEqual(['family_id', 'child_id', 'date']);
+		expect(Object.keys(frozen).length).toBeGreaterThanOrEqual(30);
+
+		// 完全一致 (キー集合 + 各 PK 列順)。設計書だけ変えても manifest だけ変えても fail する。
+		expect({ ...PK_FREEZE_MANIFEST }).toEqual(frozen);
+	});
+
+	it('[2b] 全テナント表の PK 先頭は family_id (§P2 複合 tenant PK)', async () => {
+		const { PK_FREEZE_MANIFEST } = await import('../../../src/lib/server/db/pk-freeze-manifest');
+		for (const [table, pk] of Object.entries(PK_FREEZE_MANIFEST)) {
+			expect(pk[0], `${table} の PK 先頭`).toBe('family_id');
+		}
+	});
+
+	it('[3] drizzle pg-core (DSQL) schema の全表 PK == manifest (drift 検出)', async () => {
+		const { PgTable, getTableConfig } = await import('drizzle-orm/pg-core');
+		const { is, getTableName } = await import('drizzle-orm');
+		const dsqlSchema = await import('../../../src/lib/server/db/dsql/schema');
+		const { PK_FREEZE_MANIFEST } = await import('../../../src/lib/server/db/pk-freeze-manifest');
+		const manifest = PK_FREEZE_MANIFEST as Record<string, readonly string[]>;
+
+		// dsql/schema.ts に実装された全 pg 表を走査 (表追記時に本テスト変更なしで自動カバー)。
+		const pgTables = Object.values(dsqlSchema).filter((v): v is InstanceType<typeof PgTable> =>
+			is(v, PgTable),
+		);
+		expect(pgTables.length).toBeGreaterThan(0);
+
+		for (const table of pgTables) {
+			const name = getTableName(table);
+			const cfg = getTableConfig(table);
+			const pkCols = cfg.primaryKeys[0]?.columns.map((c) => c.name) ?? [];
+			expect(manifest[name], `${name} は manifest (§11.2) に凍結宣言がある`).toBeDefined();
+			expect(pkCols, `${name} の PK == manifest`).toEqual([...(manifest[name] ?? [])]);
+		}
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管基盤、EPIC #3424 / #3512）

**解決する課題**: DSQL は PK = 物理レイアウトで後変更不可（§P1、唯一の不可逆不変条件）。設計書 §11.2 の凍結 PK 表が「書かれているだけ」で機械検証されないと、実装が設計書からドリフトしても気づけず、後から取り返しのつかない PK 変更が必要になるリスクがある。

**期待される効果**: 設計書 §11.2 の PK 凍結表を機械可読な manifest（SSOT）として population し、CI で「設計書 SSOT ↔ manifest」「manifest ↔ drizzle schema」の双方向 drift を hard-fail 検出できるようにする。以後の DSQL 移管作業（Phase A/B/C）が凍結逸脱を人手 review に委ねず、CI で機械的に守られる。

## 関連 Issue

関連: #3512（EPIC #3424 の PR-0、AC1「fitness#9: drizzle pg/sqlite schema の全 PK == 凍結 manifest」の一部を消化。本 PR は AC1 の TDD 第 5 サイクルであり #3512 全体を closes しない）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1-[1] | manifest が存在し children の PK = (family_id, child_id) を宣言する | `npx vitest run tests/unit/db/pk-freeze-manifest.test.ts` | HEAD `b751761c6` / 4 passed / `tests/unit/db/pk-freeze-manifest.test.ts:76-84` |
| AC1-[2] | manifest の全テナント表 PK が §11.2 の凍結 PK 表と完全一致する（doc-parse 突合、設計書 SSOT ↔ manifest 双方向 drift 検出） | 同上 | HEAD `b751761c6` / `tests/unit/db/pk-freeze-manifest.test.ts:86-97` / `parseFrozenPkTable()` が `docs/design/dsql-data-model.md` §11.2 を機械抽出し `PK_FREEZE_MANIFEST`（`src/lib/server/db/pk-freeze-manifest.ts`）と `toEqual` 一致を assert、32 表以上を population 済 |
| AC1-[2b] | 全テナント表の PK 先頭が family_id である（§P2 複合 tenant PK） | 同上 | HEAD `b751761c6` / `tests/unit/db/pk-freeze-manifest.test.ts:99-104` |
| AC1-[3] | drizzle pg-core (DSQL) schema の全表 PK == manifest（drift 検出、children 固定でなく `dsql/schema.ts` 全 export 走査に一般化） | 同上 | HEAD `b751761c6` / `tests/unit/db/pk-freeze-manifest.test.ts:106-124` |
| svelte-check | 本 PR で報告された 3 type error（noUncheckedIndexedAccess undefined ガード漏れ + PgTable type predicate 非 assignable）を解消 | `npx svelte-check --tsconfig ./tsconfig.json` | HEAD `b751761c6` / `0 ERRORS 0 WARNINGS` (`COMPLETED 7598 FILES`) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
画面影響なし。`src/lib/server/db/pk-freeze-manifest.ts`（PK 凍結 manifest SSOT）と対応する fitness function テスト（`tests/unit/db/pk-freeze-manifest.test.ts`）のみ。EPIC #3424 DSQL 移管の内部基盤。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載: `tests/unit/db/pk-freeze-manifest.test.ts` の `parseFrozenPkTable()` undefined ガード修正 + PgTable filter/cast 方式変更（機能追加ではなく svelte-check 型エラー 3 件の修正）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret の追加なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — DynamoDB 実装は対象外（DSQL pg-core / sqlite-core のみ）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — critical バグ修正ではない

## スクリーンショット / ビジュアルデモ

該当なし（UI 変更を含まない内部基盤・テストファイルのみの変更）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — `parseFrozenPkTable()` は設計書 §11.2 の抽出のみ担当、manifest 定義とは責務分離済み
- [x] **DRY**: 同一の undefined ガード漏れパターンが他ファイルにないか確認、本 PR 修正範囲（`pk-freeze-manifest.test.ts`）に限定
- [x] **YAGNI**: 現要件に不要な抽象化を追加していない
- [x] **Security（OSS 公開前提）**: N/A — 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: N/A — テストコードのみ、本番バンドル非同梱

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（`src/lib/server/db/pk-freeze-manifest.ts` は DSQL 移管専用の新規 SSOT で、既存の本番/デモ・年齢モード・ナビ等の並行実装ペアに影響しない）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A — LP / 販促文言の変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
svelte-check の 3 error（`tests/unit/db/pk-freeze-manifest.test.ts:66` `Object is possibly 'undefined'` 含む）は noUncheckedIndexedAccess 起因の型ガード漏れであり、テストのアサーション内容・ロジックは変更していません（既存 4 test は変更前後とも green）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 本 PR が扱う AC1 の test [1][2][2b][3] は全て実装済み・green（未実装のまま残っている項目はない）。AC2〜AC5 は親 Issue #3512 の別サイクルで扱う
- [x] Phase 分割した場合: N/A（同一 Issue 内の Canon TDD サイクル分割であり、別子 Issue への分割ではない）
- [x] UI 変更時: N/A — UI 変更なし
- [x] 認証画面変更時: N/A — 認証画面変更なし

## QM レビュー結果

<!-- QM が記入。フォーマット・必須手順は docs/sessions/qa-session.md「Tier 2 手順 5」を参照。
     CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（ADR-0022）。 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
