### PR TITLE
docs: #3344 capture-spec header の削除済「作成フォーム展開」記述を是正 (#3440 residue)

### DIFF
--- a/scripts/capture-specs/flows/admin-challenges-per-child-pr2479.mjs
+++ b/scripts/capture-specs/flows/admin-challenges-per-child-pr2479.mjs
@@ -3,11 +3,13 @@
  *
  * PR #2479 (#2362 PR-7): admin/challenges per-child UX + 兄弟連動 UI SS フロー
  *
- * 撮影 4 状態 (mobile + desktop = 8 SS):
+ * 撮影 3 状態 (mobile + desktop = 6 SS):
  *   1. default state (子供別タブ + 兄弟連動 group + 個別 challenge group)
  *   2. 2nd child タブ切替後 (childId=903 けんたくん / 兄弟連動 + 個別 instance)
- *   3. 作成フォーム展開後 (childIds checkbox + 一括追加 UI)
- *   4. SiblingChallengeComparison scroll-into-view (兄弟連動 UI focus)
+ *   3. SiblingChallengeComparison scroll-into-view (兄弟連動 UI focus)
+ *
+ * #3344: 旧「3. 作成フォーム展開」は #3195/#3231 のチャレンジ自動生成一本化 + 読取専用ビュー化で
+ *   「＋ 新規チャレンジ」ボタン / create-form が削除されたため撤去済 (本体 step も除去、L82 付近参照)。
  *
  * 起動前提 (ADR-0048 demo Lambda 同型 env):
  *   AUTH_MODE=anonymous DATA_SOURCE=demo npx vite dev --port 5173 --strictPort


### PR DESCRIPTION
## 顧客価値・目的

チャレンジ自動生成一本化 (#3195/#3231) で撤去された「＋ 新規チャレンジ」create-form を、capture フローの header docstring が今も「撮影 4 状態」「3. 作成フォーム展開後」として記載する dangling reference を除去し、開発者が spec を読んで実在しない UI を探す混乱と誤 SS 期待を防ぐ (dev ツールの正確性維持)。

## 関連 Issue

Closes #3344

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | capture flow から create-form 関連 step を撤去 (チャレンジ閲覧専用) | `git show HEAD~..HEAD` + `node --check` | HEAD `8e0678563` / 本体 step は PR #3440 で撤去済。本 PR は header docstring の残 dangling 記述 (「4 状態」/「作成フォーム展開後」) を実 capture 3 件に整合 |
| AC2 | dangling コメント/誤 line 番号を除去 | 目視 diff + biome | HEAD `8e0678563` / header を「撮影 3 状態 (= 6 SS)」へ是正、create-form 行削除、#3344 由来を明記。biome clean / node --check OK |

## 変更タイプ

- [x] docs: ドキュメント
- [x] refactor: リファクタリング

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`scripts/` capture-spec の docstring)

**影響を受ける画面・機能**:
なし (capture-spec の header コメントのみ、撮影 step 挙動は不変)。

## テスト & 安全装置セルフチェック

- [x] **pre-ready 関連 Step PASS**: biome clean / node --check OK (capture-spec は CI test 非対象、docstring のみ)
- [x] 追加・変更したテストの概要: N/A (docstring 是正)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

N/A — capture-spec の header コメント是正、撮影対象・挙動は不変。

## コード品質セルフレビュー (#1481)

- PR #3440 (#3344) が本体 step + inline comment を撤去したが header docstring を残した incomplete fix を完遂。#3344 が名指しした「dangling reference 除去」に整合。
- inline の capture 番号 (1/2/3) は既に整合済のため header のみ是正 (最小差分)。

## 横展開・影響波及チェック

- 他 capture-spec に同種の削除済 UI 参照が無いか grep → 本 spec のみ (challenge 一本化固有)。

## レビュー依頼事項・破壊的変更

破壊的変更なし。docstring のみ。

## 配布済み env / secret (ADR-0006)

N/A。

## Ready for Review チェックリスト

- [x] CI 緑を確認のうえ Ready 化する
- [x] PR 本文がテンプレート 13 セクションに準拠

## QM レビュー結果

<!-- QM が記入 -->
