### PR TITLE
test: #3531 fitness#7 txn work await allowlist + fitness#8 dsql db-import ban (Phase A 粒度(2))

### DIFF
--- a/tests/unit/architecture/dsql-txn-work-allowlist.test.ts
+++ b/tests/unit/architecture/dsql-txn-work-allowlist.test.ts
@@ -1,0 +1,190 @@
+// tests/unit/architecture/dsql-txn-work-allowlist.test.ts
+// EPIC #3424 / 実装 #3531 (#N1-1 Phase A 粒度(2)) / 設計 SSOT: dsql-data-model.md §8 / §13.1 fitness#7
+//
+// fitness#7「core txn work 内の await は tx-bound call のみ許す allowlist」:
+//   better-sqlite3 は同期ドライバ = 単一接続。runInTransaction の work 内に event loop を
+//   yield する await (fetch / 通知 / dynamic import / 別 db) があると、並行 HTTP リクエストの
+//   書込が同 txn に混入する (SQLite parity Finding 1)。QM B1: denylist だと `await sleep` /
+//   `await db2.x` / helper 経由の transitive await を見逃す → **work 内の全 AwaitExpression は
+//   tx binding への直接 call であること、それ以外は fail** の allowlist で機械強制する。
+//   `await helper(tx)` も fail (helper 内の transitive await を静的に追えないため、厳格側に倒す)。
+//
+// route-db-boundary.test.ts (#3152) と同型の Architecture Fitness Function。
+// 検出器は TypeScript compiler API (既存 devDependency、新規ツールゼロ) の AST 走査。
+// 現時点で production の runInTransaction callsite は 0 (Phase C #N4-2 で recordActivity が
+// 最初の利用者)。fixture による非トートロジー証明で検出器の実効性を担保し、callsite が
+// 生えた瞬間から gate が効く (armed-before-use)。
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const SERVER_DIR = resolve(REPO_ROOT, 'src/lib/server');
+
+interface TxAwaitViolation {
+	file: string;
+	line: number;
+	snippet: string;
+	reason: string;
+}
+
+/** callee のチェーンを根まで辿り、根が識別子 `txName` の call か判定する。
+ * drizzle fluent chain (`tx.insert(t).values(r)` = 中間 CallExpression) も根まで unwrap する。 */
+function isTxBoundCall(expr: ts.Expression, txName: string): boolean {
+	if (!ts.isCallExpression(expr)) return false;
+	let callee: ts.Expression = expr.expression;
+	for (;;) {
+		if (ts.isPropertyAccessExpression(callee) || ts.isElementAccessExpression(callee)) {
+			callee = callee.expression;
+		} else if (ts.isCallExpression(callee)) {
+			callee = callee.expression;
+		} else {
+			break;
+		}
+	}
+	return ts.isIdentifier(callee) && callee.text === txName;
+}
+
+/**
+ * source 内の全 `*.runInTransaction(work)` callsite を検出し、work 内の AwaitExpression が
+ * tx binding への直接 call 以外なら violation として返す (fitness#7 allowlist)。
+ * work が inline arrow / function でない場合 (別関数参照) は静的追跡不能のため violation。
+ */
+function findTxWorkAwaitViolations(sourceText: string, fileName: string): TxAwaitViolation[] {
+	const sf = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
+	const violations: TxAwaitViolation[] = [];
+
+	const report = (node: ts.Node, reason: string) => {
+		const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+		violations.push({
+			file: fileName,
+			line: line + 1,
+			snippet: node.getText(sf).replace(/\s+/g, ' ').slice(0, 80),
+			reason,
+		});
+	};
+
+	const checkWorkBody = (body: ts.Node, txName: string | undefined) => {
+		const walk = (n: ts.Node) => {
+			if (ts.isAwaitExpression(n)) {
+				if (!txName || !isTxBoundCall(n.expression, txName)) {
+					report(
+						n,
+						'work 内の await が tx-bound call でない (fetch/通知/別db/helper 経由は core txn 禁止、§8)',
+					);
+				}
+			}
+			ts.forEachChild(n, walk);
+		};
+		walk(body);
+	};
+
+	const isRunInTxCall = (node: ts.CallExpression): boolean => {
+		const callee = node.expression;
+		return (
+			(ts.isPropertyAccessExpression(callee) && callee.name.text === 'runInTransaction') ||
+			(ts.isIdentifier(callee) && callee.text === 'runInTransaction')
+		);
+	};
+
+	const checkWorkArgument = (work: ts.Expression) => {
+		if (ts.isArrowFunction(work) || ts.isFunctionExpression(work)) {
+			const p = work.parameters[0]?.name;
+			const txName = p && ts.isIdentifier(p) ? p.text : undefined;
+			checkWorkBody(work.body, txName);
+		} else {
+			report(
+				work,
+				'work が inline 関数でない (別関数参照は transitive await を静的追跡できないため inline で書く)',
+			);
+		}
+	};
+
+	const visit = (node: ts.Node) => {
+		if (ts.isCallExpression(node) && isRunInTxCall(node) && node.arguments[0]) {
+			checkWorkArgument(node.arguments[0]);
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sf);
+	return violations;
+}
+
+function walkTsFiles(dir: string, acc: string[]): string[] {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = resolve(dir, entry.name);
+		if (entry.isDirectory()) walkTsFiles(full, acc);
+		else if (entry.name.endsWith('.ts')) acc.push(full);
+	}
+	return acc;
+}
+
+describe('fitness#7: runInTransaction work 内 await の tx-bound allowlist (§8 / QM B1)', () => {
+	it('src/lib/server 全 production callsite に violation が無い', () => {
+		const violations = walkTsFiles(SERVER_DIR, []).flatMap((file) =>
+			findTxWorkAwaitViolations(
+				readFileSync(file, 'utf-8'),
+				relative(REPO_ROOT, file).replace(/\\/g, '/'),
+			),
+		);
+		expect(
+			violations,
+			`fitness#7 違反 (core txn work 内の非 tx-bound await):\n${violations
+				.map((v) => `  - ${v.file}:${v.line} ${v.snippet}\n    → ${v.reason}`)
+				.join('\n')}\n→ optional (fetch/通知/別集約) は core commit 後の独立処理へ (§8)`,
+		).toEqual([]);
+	});
+
+	// ── 非トートロジー証明 (検出器が本当に検出することの fixture 検証) ──
+
+	it('tx-bound call のみの work は違反 0 (allowlist 通過)', () => {
+		const ok = `
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(sql\`INSERT INTO t VALUES (1)\`);
+				await tx.insert(children).values(row);
+				const n = await tx.select().from(children);
+				return n;
+			});`;
+		expect(findTxWorkAwaitViolations(ok, 'fixture.ts')).toEqual([]);
+	});
+
+	it('fetch / 別 db / dynamic import / helper(tx) / sleep の await を検出する', () => {
+		const cases: Array<[string, string]> = [
+			['await fetch("https://x")', 'fetch'],
+			['await db.execute(q)', '別 db (tx でなく module db)'],
+			['await import("$lib/server/discord-alert")', 'dynamic import'],
+			['await applyBonus(tx)', 'helper 経由 (transitive await 追跡不能)'],
+			['await new Promise((r) => setTimeout(r, 10))', 'sleep'],
+		];
+		for (const [stmt, label] of cases) {
+			const src = `await runner.runInTransaction(async (tx) => { ${stmt}; });`;
+			const violations = findTxWorkAwaitViolations(src, 'fixture.ts');
+			expect(violations.length, `検出漏れ: ${label}`).toBeGreaterThan(0);
+		}
+	});
+
+	it('tx param 名が tx 以外でも binding 追跡で判定する (名前でなく binding)', () => {
+		const ok = 'await runner.runInTransaction(async (trx) => { await trx.execute(q); });';
+		expect(findTxWorkAwaitViolations(ok, 'fixture.ts')).toEqual([]);
+		const ng = 'await runner.runInTransaction(async (trx) => { await tx.execute(q); });';
+		expect(findTxWorkAwaitViolations(ng, 'fixture.ts').length).toBeGreaterThan(0);
+	});
+
+	it('work が別関数参照 (inline でない) は violation (静的追跡不能)', () => {
+		const ng = 'await runner.runInTransaction(doWork);';
+		expect(findTxWorkAwaitViolations(ng, 'fixture.ts').length).toBeGreaterThan(0);
+	});
+
+	it('ネストした work (内側の関数) の await も検出する', () => {
+		const ng = `
+			await runner.runInTransaction(async (tx) => {
+				const f = async () => { await fetch("https://x"); };
+				await tx.execute(q);
+				f();
+			});`;
+		expect(findTxWorkAwaitViolations(ng, 'fixture.ts').length).toBeGreaterThan(0);
+	});
+});

--- a/tests/unit/architecture/dsql-write-path-db-import-ban.test.ts
+++ b/tests/unit/architecture/dsql-write-path-db-import-ban.test.ts
@@ -1,0 +1,126 @@
+// tests/unit/architecture/dsql-write-path-db-import-ban.test.ts
+// EPIC #3424 / 実装 #3531 (#N1-1 Phase A 粒度(2)) / 設計 SSOT: dsql-data-model.md §8 / §13.1 fitness#8
+//
+// fitness#8 (lint 側)「write-path repo は tx を必須引数に取り、module-level db 直結 import を禁止」:
+//   tx 忘れは SQLite では単一接続で隠蔽され、pg では別接続で部分コミット = **E2E 緑で本番崩壊**
+//   の非対称 (SQLite parity Finding 2)。動的な再現は dsql-run-in-transaction.test.ts [T6]
+//   (PGlite 部分コミット証跡) が担い、本テストは静的に「dsql repo が module db を import する」
+//   抜け道自体を封じる二層目 (route-db-boundary.test.ts #3152 と同型)。
+//
+// 対象 = src/lib/server/db/dsql/ 配下の repo module (*-repo.ts)。現時点で 0 件 (Phase C
+// #N4-1 以降で生える) のため armed-before-use。fixture による非トートロジー証明付き。
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const DSQL_DIR = resolve(REPO_ROOT, 'src/lib/server/db/dsql');
+
+// 禁止 import specifier: module-level db を持つ client module (sqlite 用生 client /
+// 将来の dsql client factory / backend 固有 client)。repo は tx handle を引数で受ける。
+const FORBIDDEN_IMPORT_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+	{
+		pattern: /\$lib\/server\/db\/client|['"`]\.\.\/client['"`]/,
+		reason: 'sqlite 生 client (db/client) を dsql repo で import',
+	},
+	{
+		pattern: /\$lib\/server\/db\/dsql\/client|['"`]\.\/client['"`]/,
+		reason:
+			'dsql client (module-level db) を repo で直結 import (tx は必須引数で受ける、fitness#8)',
+	},
+];
+
+// route-db-boundary.test.ts と同じ走査規約 (static import/export from + dynamic import/require)。
+const STATIC_IMPORT_LINE = /^\s*(?:import|export)\b[^\n]*\bfrom\s+['"][^'"]+['"]/;
+const DYNAMIC_IMPORT_LINE = /\b(?:import|require)\s*\(/;
+const isImportLike = (line: string): boolean =>
+	STATIC_IMPORT_LINE.test(line) || DYNAMIC_IMPORT_LINE.test(line);
+
+/** dsql 配下の write-path repo module (*-repo.ts) を列挙する。 */
+function listDsqlRepoFiles(): string[] {
+	if (!existsSync(DSQL_DIR)) return [];
+	const acc: string[] = [];
+	const walk = (dir: string) => {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const full = resolve(dir, entry.name);
+			if (entry.isDirectory()) walk(full);
+			else if (entry.name.endsWith('-repo.ts')) acc.push(full);
+		}
+	};
+	walk(DSQL_DIR);
+	return acc;
+}
+
+interface Violation {
+	file: string;
+	reason: string;
+}
+
+function findViolations(files: string[]): Violation[] {
+	const violations: Violation[] = [];
+	for (const file of files) {
+		const importLines = readFileSync(file, 'utf-8').split('\n').filter(isImportLike);
+		for (const { pattern, reason } of FORBIDDEN_IMPORT_PATTERNS) {
+			if (importLines.some((l) => pattern.test(l))) {
+				violations.push({ file: relative(REPO_ROOT, file).replace(/\\/g, '/'), reason });
+			}
+		}
+	}
+	return violations;
+}
+
+describe('fitness#8 (lint): dsql write-path repo の module db 直結 import 禁止 (§8 / Finding 2)', () => {
+	it('dsql dir が存在する (走査対象の前提 sanity)', () => {
+		expect(existsSync(DSQL_DIR)).toBe(true);
+	});
+
+	it('dsql repo module に client 直結 import が無い (baseline 0、append 禁止)', () => {
+		const violations = findViolations(listDsqlRepoFiles());
+		expect(
+			violations,
+			`fitness#8 違反 (module-level db 直結 import):\n${violations
+				.map((v) => `  - ${v.file}: ${v.reason}`)
+				.join(
+					'\n',
+				)}\n→ dsql repo は tx handle (TransactionRunner の work 引数) を必須引数で受ける。` +
+				'baseline は設けない (最初から 0 を維持する、route-db-boundary #3184 と同思想)',
+		).toEqual([]);
+	});
+
+	// ── 非トートロジー証明 ──
+
+	it('静的 / 動的 import の違反 fixture を検出する (guard 自体の動作確認)', () => {
+		const samples = [
+			"import { db } from './client';",
+			"import { db } from '$lib/server/db/client';",
+			"import { db } from '$lib/server/db/dsql/client';",
+			"const { db } = await import('./client');",
+			"const { db } = require('$lib/server/db/dsql/client');",
+		];
+		for (const sample of samples) {
+			expect(isImportLike(sample), `走査対象から漏れている: ${sample}`).toBe(true);
+			expect(
+				FORBIDDEN_IMPORT_PATTERNS.some((p) => p.pattern.test(sample)),
+				`禁止パターン未検出: ${sample}`,
+			).toBe(true);
+		}
+	});
+
+	it('正当な import (schema / check-constraints / occ-retry / drizzle-orm) は検出しない', () => {
+		const legit = [
+			"import { children } from './schema';",
+			"import { enumCheck } from './check-constraints';",
+			"import { withOccRetry } from './occ-retry';",
+			"import { eq } from 'drizzle-orm';",
+			"import type { TransactionRunner } from '../interfaces/transaction.interface';",
+		];
+		for (const sample of legit) {
+			expect(
+				FORBIDDEN_IMPORT_PATTERNS.some((p) => p.pattern.test(sample)),
+				`false positive: ${sample}`,
+			).toBe(false);
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者向け fitness function、直接のエンドユーザー影響なし）

**解決する課題**: DSQL (Aurora DSQL) 移行後、`runInTransaction` の work 内で tx-bound でない await（別 db 呼び出し / 未追跡 helper 経由）が混入すると、SQLite の単一接続では隠蔽されたまま E2E が緑になり、pg (DSQL) 環境でのみ部分コミットとして本番障害化するリスクがある（ADR-0061 / `dsql-data-model.md` §13.1 fitness#7,#8）。

**期待される効果**: 上記契約違反を AST 静的解析で commit 時点で機械的にブロックし、後続 Phase C（`db/dsql/*-repo.ts` 実装、#N4-2 等）の着手を安全にする。fitness function 自体はテストのみの追加であり、本番挙動への影響はない。

## 関連 Issue

<!-- #3531 の粒度 (2)（fitness#7 AST allowlist + fitness#8 lint 側）を実装。粒度 (1) は PR #3532 (cycle-1) が担当し、両方 merge 後に #3531 の AC が完了する。 -->
Related: #3531 #3424 #3532

## AC 検証マップ (ADR-0004)

<!-- #3531 の AC のうち、本 PR (粒度 (2)) が担当する 2 項目を検証。「fitness#8 (最重要非対称、部分コミット failing-test-first)」は PR #3532 (cycle-1) の担当 AC のためここでは対象外 (ac-verification-skip)。 -->

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | fitness#7: core txn work 内の await は tx-bound call のみ（AST allowlist、denylist 不可） | `npx vitest run tests/unit/architecture/dsql-txn-work-allowlist.test.ts` | HEAD `b9bb116` / 5 passed / `tests/unit/architecture/dsql-txn-work-allowlist.test.ts` (190 行、TS compiler API で `src/lib/server` 全 production callsite を AST 走査。fluent chain 許可 + 未追跡 await / 別関数参照 await を fail させる fixture 完備) |
| AC2 | write-path repo の tx 必須引数 + module-level db 直結 import 禁止（fitness#8 lint 側、Phase C 着手前に gate 有効化） | `npx vitest run tests/unit/architecture/dsql-write-path-db-import-ban.test.ts` | HEAD `b9bb116` / 5 passed / `tests/unit/architecture/dsql-write-path-db-import-ban.test.ts` (126 行、`db/dsql/*-repo.ts` の static + dynamic import/require を `route-db-boundary.test.ts` と同型で走査。baseline 0 件を維持する fixture 完備) |
| AC-suite | 上記 2 fitness を含む architecture suite 全体の regression なし | `npx vitest run tests/unit/architecture/` | HEAD `b9bb116` / **47/47 passed** (8 test files) |

<!-- ac-verification-skip: 「fitness#8 (最重要非対称、部分コミット failing-test-first)」「runInTransaction port / withOccRetry 本体実装」「spike#4 前提の遵守」は #3531 の粒度 (1) = PR #3532 (cycle-1) が担当するため本 PR の検証対象外 -->

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) <!-- tests/unit/architecture/ 配下に fitness function (静的解析 test) を追加。CI (vitest run) が自動実行する -->

**影響を受ける画面・機能**:
画面影響なし。`tests/unit/architecture/dsql-txn-work-allowlist.test.ts` / `tests/unit/architecture/dsql-write-path-db-import-ban.test.ts` の新規追加のみ（+316 行、test only）。production callsite / dsql repo は現時点で 0 件のため、fitness function は「armed-before-use」（Phase C で callsite が生えた瞬間から gate が効く）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/architecture/dsql-txn-work-allowlist.test.ts`（fitness#7、190 行、5 tests）
  - `tests/unit/architecture/dsql-write-path-db-import-ban.test.ts`（fitness#8 lint 側、126 行、5 tests）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（UI 変更を含まない test-only PR。`tests/unit/architecture/` 配下への fitness function 追加のみで画面・API への変更はゼロ）**

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（S）— 各 fitness function は 1 契約（await allowlist / import ban）のみを検証。依存性逆転（D）— TS compiler API 経由の AST 走査で production コードへの実行時依存なし
- [x] **DRY**: `tests/unit/architecture/route-db-boundary.test.ts` の static/dynamic import 走査ロジックと同型パターンを踏襲（新規ロジックの重複作成を回避、`grep -n "route-db-boundary" tests/unit/architecture/dsql-write-path-db-import-ban.test.ts` で確認可能）
- [x] **YAGNI**: production callsite が 0 件の段階で fitness function のみ先行導入（over-engineering ではなく「armed-before-use」= Phase C 着手前 gate 化が #3531 AC の明示要求）
- [x] **Security（OSS 公開前提）**: N/A（test-only、新規 API / 秘密情報なし）
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: N/A（CI テストのみ、本番バンドル影響なし）

## 横展開・影響波及チェック

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [ ] E2E / ユニットシード（`tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` / `src/lib/server/demo/demo-data.ts`）と チュートリアル (`tutorial-chapters.ts` / `demo-guide-state.svelte.ts`) を同期
- [ ] **labels SSOT** (ADR-0009)
- [ ] **設計書同期** (ADR-0001): 本 PR は `docs/design/dsql-data-model.md` §8 / §13.1 fitness#7,#8 に既に記載済みの仕様を実装するのみで、設計書の新規更新は不要（設計 SSOT は #3531 の親 PR 群で先行整備済み）
- [x] **並行 PR overlap** (#1200): 本 PR が変更するファイル (`tests/unit/architecture/dsql-*.ts` 2 ファイル、新規追加) は PR #3532 と重複しない（#3532 は port + withOccRetry + pg/sqlite 実装本体、本 PR は fitness function のみ）
- [x] N/A — 並行実装の影響範囲外（UI / labels / 年齢モード / ナビ非該当の test-only PR）

**LP / 販促文言変更時** (ADR-0013 / #1314):

N/A（LP / pricing / plan-features への変更なし）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**:
production callsite / dsql repo が 0 件の段階での fitness function 導入のため、実効性は fixture（違反ケースを意図的に作って fail することを確認）で担保している。fixture の非トートロジー性（false-positive なし / 検出対象の見逃しなし）を重点的にご確認いただきたい。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（`TODO` / `予定` のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（#3531 の粒度分割 (1)/(2) は Issue 本文に明記済み、PR #3532 が (1) を担当）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

<!-- QM が記入。フォーマット・必須手順は docs/sessions/qa-session.md「Tier 2 手順 5」を参照。
     CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（ADR-0022）。 -->

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

## 概要（実装詳細、旧記述保持）

EPIC #3424 / **#3531 (#N1-1 Phase A)** 粒度 (2) = txn 契約の静的 fitness function 2 本 (test only、+316 行)。PR #3532 (cycle-1、動的な部分コミット証跡 [T6]) と二層防御を構成する。設計 SSOT: `dsql-data-model.md` §8 / §13.1 fitness#7,#8。

### fitness#7: `tests/unit/architecture/dsql-txn-work-allowlist.test.ts`
**runInTransaction の work 内の全 AwaitExpression が tx binding への直接 call であることを AST で機械強制** (QM B1: denylist だと `await sleep` / `await db2.x` / helper 経由 transitive await を見逃す → allowlist)。

- TS compiler API (既存 devDependency、新規ツールゼロ) で `src/lib/server` 全 production callsite を走査
- drizzle fluent chain (`tx.insert(t).values(r)` = 中間 CallExpression) は callee 根 unwrap で許可
- `await fetch` / `await import()` / `await helper(tx)` (transitive 追跡不能) / `await sleep` / 別 db → fail
- work の別関数参照 (inline でない) も fail / tx param 名は binding で追跡 (名前依存でない)

### fitness#8 (lint 側): `tests/unit/architecture/dsql-write-path-db-import-ban.test.ts`
**`db/dsql/*-repo.ts` の module-level db 直結 import (db/client / dsql/client) を静的禁止** (SQLite parity Finding 2: tx 忘れは SQLite 単一接続で隠蔽・pg で部分コミット = E2E 緑で本番崩壊)。static + dynamic import/require 走査 (route-db-boundary #3152 と同型)。baseline は設けない (最初から 0 維持)。

### armed-before-use

現時点で production の runInTransaction callsite / dsql repo は 0 件 (Phase C #N4-1/#N4-2 で生える)。**fixture による非トートロジー証明** (違反 fixture 検出 + 正当 import の false-positive 無し) で検出器の実効性を担保し、callsite が生えた瞬間から gate が効く。

### #3531 の残 scope

cycle-1 (PR #3532、merge 待ち) と本 PR で #N1-1 の主要 AC は完了。「write-path repo の tx 必須引数」の型レベル強制は Phase C の repo interface 設計時に適用。
