### PR TITLE
feat: #3528 auth cycle(b) invites/consents DDL + 受諾単一 txn

### DIFF
--- a/src/lib/server/auth/entities.ts
+++ b/src/lib/server/auth/entities.ts
@@ -72,6 +72,11 @@ export interface CreateMembershipInput {
 	invitedBy?: string;
 }
 
+/** invite 状態の固定集合。
+ * runtime 配列は DSQL invites.status の CHECK 生成 SSOT (#3528、手書き二重化禁止)。 */
+export const INVITE_STATUSES = ['pending', 'accepted', 'revoked', 'expired'] as const;
+export type InviteStatus = (typeof INVITE_STATUSES)[number];
+
 /** 招待リンク */
 export interface Invite {
 	inviteCode: string;
@@ -79,7 +84,7 @@ export interface Invite {
 	invitedBy: string;
 	role: Role;
 	childId?: number;
-	status: 'pending' | 'accepted' | 'revoked' | 'expired';
+	status: InviteStatus;
 	createdAt: string;
 	expiresAt: string;
 	acceptedBy?: string;
@@ -93,11 +98,16 @@ export interface CreateInviteInput {
 	childId?: number;
 }
 
+/** 同意種別の固定集合。
+ * runtime 配列は DSQL consents.type の CHECK 生成 SSOT (#3528、手書き二重化禁止)。 */
+export const CONSENT_TYPES = ['terms', 'privacy'] as const;
+export type ConsentType = (typeof CONSENT_TYPES)[number];
+
 /** 利用規約・PP 同意記録 (#0192) */
 export interface ConsentRecord {
 	tenantId: string;
 	userId: string;
-	type: 'terms' | 'privacy';
+	type: ConsentType;
 	version: string;
 	consentedAt: string;
 	ipAddress: string;
@@ -107,7 +117,7 @@ export interface ConsentRecord {
 export interface RecordConsentInput {
 	tenantId: string;
 	userId: string;
-	type: 'terms' | 'privacy';
+	type: ConsentType;
 	version: string;
 	ipAddress: string;
 	userAgent: string;

--- a/src/lib/server/db/dsql/invite-accept.ts
+++ b/src/lib/server/db/dsql/invite-accept.ts
@@ -1,0 +1,99 @@
+// src/lib/server/db/dsql/invite-accept.ts
+// EPIC #3424 / 実装 #3528 (#N2-1 Phase B cycle (b)) / 設計 SSOT: dsql-data-model.md §6.6
+//
+// invite 受諾 = 単一 txn。§6.6 の厳密分岐:
+//   - UPDATE ... WHERE status='pending' AND expires_at > now RETURNING の rowCount=0
+//     = 業務失敗 (INVALID_OR_EXPIRED)。**retry 禁止** — 正常 return で返す (throw しない)
+//   - membership INSERT の 23505 (PK/owner_guard 重複) = ALREADY_IN_TENANT。
+//     単一 txn ゆえ invite の accepted 化も一緒に rollback される (部分コミット禁止)
+//   - 40001 (OCC) は throw のまま runner 内蔵 withOccRetry が txn 全体を再実行
+//   - email 束縛 (§6.6 ⚠️): invite.email 設定時は受諾 user email と case-insensitive 一致必須。
+//     不一致は EMAIL_MISMATCH で throw → rollback (招待リンク横流しによる別人受諾を防ぐ)
+//
+// fitness#7 整合: work 内の await は全て tx.execute(...) (tx-bound)。分岐判定は同期処理。
+// business 失敗を throw で表現するのは rollback を担わせるため (typed error → catch で
+// result に写像し、呼び出し側には throw しない)。
+
+import { type SQL, sql } from 'drizzle-orm';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+
+/** tx handle に要求する最小面 (drizzle pg tx / db が構造的に満たす)。 */
+export interface SqlExecutor {
+	execute(query: SQL): Promise<{ rows: unknown[] }>;
+}
+
+export interface AcceptInviteInput {
+	inviteId: string;
+	/** 受諾する user (users.user_id)。 */
+	userId: string;
+	/** 受諾 user の email (invite.email 束縛検証に使用)。 */
+	userEmail: string;
+	/** 判定基準時刻 (ISO 8601)。呼び出し側が注入する (テスト決定性 + txn 内で一貫)。 */
+	now: string;
+}
+
+export type AcceptInviteFailure = 'INVALID_OR_EXPIRED' | 'ALREADY_IN_TENANT' | 'EMAIL_MISMATCH';
+
+export type AcceptInviteResult =
+	| { ok: true; familyId: string; role: string }
+	| { ok: false; reason: AcceptInviteFailure };
+
+/** txn を rollback させつつ business 失敗を運ぶ内部シグナル。 */
+class AcceptInviteAbort extends Error {
+	constructor(readonly reason: AcceptInviteFailure) {
+		super(`invite accept aborted: ${reason}`);
+	}
+}
+
+const isUniqueViolation = (err: unknown): boolean =>
+	typeof err === 'object' &&
+	err !== null &&
+	((err as { code?: unknown }).code === '23505' ||
+		(typeof (err as { cause?: unknown }).cause === 'object' &&
+			(err as { cause?: { code?: unknown } }).cause?.code === '23505'));
+
+interface AcceptedInviteRow {
+	family_id: string;
+	role: string;
+	invited_by: string;
+	email: string | null;
+}
+
+/**
+ * invite を受諾し membership を作成する (単一 txn、§6.6)。
+ * 40001 は runner の withOccRetry が txn 全体を再実行する (work は再実行可能)。
+ */
+export async function acceptInvite<TTx extends SqlExecutor>(
+	runner: TransactionRunner<TTx>,
+	input: AcceptInviteInput,
+): Promise<AcceptInviteResult> {
+	const { inviteId, userId, userEmail, now } = input;
+	try {
+		return await runner.runInTransaction(async (tx) => {
+			// 状態遷移と条件判定を 1 文に畳む (§6.6): pending かつ未失効の行だけが accepted 化される。
+			const updated = await tx.execute(sql`
+				UPDATE invites
+				SET status = 'accepted', accepted_by = ${userId}, accepted_at = ${now}
+				WHERE invite_id = ${inviteId} AND status = 'pending' AND expires_at > ${now}
+				RETURNING family_id, role, invited_by, email
+			`);
+			const invite = updated.rows[0] as AcceptedInviteRow | undefined;
+			if (!invite) throw new AcceptInviteAbort('INVALID_OR_EXPIRED');
+
+			// email 束縛 (§6.6 ⚠️)。email_lower と同じ case-insensitive 原則。
+			if (invite.email !== null && invite.email.toLowerCase() !== userEmail.toLowerCase()) {
+				throw new AcceptInviteAbort('EMAIL_MISMATCH');
+			}
+
+			await tx.execute(sql`
+				INSERT INTO memberships (family_id, user_id, role, invited_by, joined_at)
+				VALUES (${invite.family_id}, ${userId}, ${invite.role}, ${invite.invited_by}, ${now})
+			`);
+			return { ok: true, familyId: invite.family_id, role: invite.role } as const;
+		});
+	} catch (err) {
+		if (err instanceof AcceptInviteAbort) return { ok: false, reason: err.reason };
+		if (isUniqueViolation(err)) return { ok: false, reason: 'ALREADY_IN_TENANT' };
+		throw err;
+	}
+}

--- a/src/lib/server/db/dsql/schema.ts
+++ b/src/lib/server/db/dsql/schema.ts
@@ -27,7 +27,14 @@ import {
 	type SubscriptionStatus,
 } from '$lib/domain/constants/subscription-status';
 import { UI_MODES } from '$lib/domain/validation/age-tier-types';
-import { AUTH_PROVIDERS, type AuthProviderKind } from '$lib/server/auth/entities';
+import {
+	AUTH_PROVIDERS,
+	type AuthProviderKind,
+	CONSENT_TYPES,
+	type ConsentType,
+	INVITE_STATUSES,
+	type InviteStatus,
+} from '$lib/server/auth/entities';
 import { ROLES, type Role } from '$lib/server/auth/types';
 import { enumCheck, THEME_KEYS } from './check-constraints';
 
@@ -157,5 +164,61 @@ export const memberships = pgTable(
 		// findUserTenants (session 3 連 lookup の起点) 用 secondary (§6.6)。
 		index('memberships_user_id_idx').on(t.userId),
 		check('memberships_role_ck', enumCheck(t.role, ROLES)),
+	],
+);
+
+// invites — 招待リンク (adjacency item 廃止、§6.6)。
+// token_hash: 招待コードの timing-safe ハッシュのみ保存 (raw 非保存 = CWE-522、bearer 化による
+// 機密性退行を防ぐ)。email: 設定時は受諾 user の email と一致必須 (§6.6 ⚠️ 横流し防止、
+// invite-accept.ts が txn 内で検証)。child_id は children UUID (#3512 greenfield) 参照。
+export const invites = pgTable(
+	'invites',
+	{
+		inviteId: uuid('invite_id').notNull().default(sql`gen_random_uuid()`),
+		familyId: uuid('family_id').notNull(),
+		invitedBy: uuid('invited_by').notNull(),
+		role: text('role').notNull().$type<Role>(),
+		childId: uuid('child_id'),
+		email: text('email'),
+		tokenHash: text('token_hash').notNull().unique(),
+		status: text('status').notNull().default('pending').$type<InviteStatus>(),
+		expiresAt: timestamp('expires_at', { mode: 'string', withTimezone: true }).notNull(),
+		acceptedBy: uuid('accepted_by'),
+		acceptedAt: timestamp('accepted_at', { mode: 'string', withTimezone: true }),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [
+		primaryKey({ columns: [t.inviteId] }),
+		// findTenantInvites 用 secondary (§6.6)。
+		index('invites_family_id_idx').on(t.familyId),
+		check('invites_status_ck', enumCheck(t.status, INVITE_STATUSES)),
+		check('invites_role_ck', enumCheck(t.role, ROLES)),
+	],
+);
+
+// consents — 利用規約/PP 同意記録 (append-only、§6.6 / GDPR Art.7 / COPPA)。
+// UPDATE/DELETE は repo 非定義 + GRANT 除外 + fitness#2 多層禁止 (repo 実装 PR で強制)。
+// 最新判定は consented_at 降順 (version 文字列順に依存しない)。
+export const consents = pgTable(
+	'consents',
+	{
+		consentId: uuid('consent_id').notNull().default(sql`gen_random_uuid()`),
+		familyId: uuid('family_id').notNull(),
+		userId: uuid('user_id').notNull(),
+		type: text('type').notNull().$type<ConsentType>(),
+		version: text('version').notNull(),
+		consentedAt: timestamp('consented_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		ipAddress: text('ip_address').notNull(),
+		userAgent: text('user_agent').notNull(),
+	},
+	(t) => [
+		primaryKey({ columns: [t.consentId] }),
+		// findLatestConsent (HTML GET 毎 2 read、§3.5.3) 用 secondary (§6.6)。
+		index('consents_family_type_at_idx').on(t.familyId, t.type, t.consentedAt),
+		check('consents_type_ck', enumCheck(t.type, CONSENT_TYPES)),
 	],
 );

--- a/tests/unit/db/dsql-check-from-ssot.test.ts
+++ b/tests/unit/db/dsql-check-from-ssot.test.ts
@@ -68,6 +68,23 @@ describe('fitness#13: children DDL CHECK は SSOT 生成 (手書き二重化禁�
 		for (const p of AUTH_PROVIDERS) expect(s).toContain(`'${p}'`);
 	});
 
+	// ── invites / consents (§6.6、#3528 cycle (b)) ──
+
+	it('invites status/role CHECK が SSOT 全値を含む (INVITE_STATUSES / ROLES)', async () => {
+		const { INVITE_STATUSES } = await import('../../../src/lib/server/auth/entities');
+		const { ROLES } = await import('../../../src/lib/server/auth/types');
+		const statusSql = await checkSql('invites_status_ck', 'invites');
+		for (const st of INVITE_STATUSES) expect(statusSql).toContain(`'${st}'`);
+		const roleSql = await checkSql('invites_role_ck', 'invites');
+		for (const r of ROLES) expect(roleSql).toContain(`'${r}'`);
+	});
+
+	it('consents type CHECK が CONSENT_TYPES 全値を含む (SSOT 生成)', async () => {
+		const { CONSENT_TYPES } = await import('../../../src/lib/server/auth/entities');
+		const s = await checkSql('consents_type_ck', 'consents');
+		for (const t of CONSENT_TYPES) expect(s).toContain(`'${t}'`);
+	});
+
 	it('families.plan には CHECK を張らない (plans lookup 参照、§6.6 営業パネル 2026-07-01)', async () => {
 		const { families } = await import('../../../src/lib/server/db/dsql/schema');
 		const checks = getTableConfig(families).checks.map((c) => c.name);

--- a/tests/unit/db/dsql-invite-accept.test.ts
+++ b/tests/unit/db/dsql-invite-accept.test.ts
@@ -1,0 +1,232 @@
+// tests/unit/db/dsql-invite-accept.test.ts
+// EPIC #3424 / 実装 #3528 (#N2-1 Phase B cycle (b)) / 設計 SSOT: dsql-data-model.md §6.6
+//
+// invite 受諾 = 単一 txn (§6.6):
+//   UPDATE invites SET status='accepted' WHERE invite_id AND status='pending' AND expires_at>now()
+//   RETURNING → membership INSERT。分岐を厳密に:
+//   - rowCount=0 = 業務失敗 (INVALID_OR_EXPIRED、**retry 禁止** — retry すると受諾済 invite の
+//     二重処理を誘発) → ok:false を正常 return
+//   - 23505 (memberships PK/owner_guard 重複) = ALREADY_IN_TENANT → invite UPDATE ごと rollback
+//   - 40001 = OCC 競合 → runner 内蔵 withOccRetry が txn 全体を再実行
+//   - email 束縛 (§6.6 ⚠️): invite.email 設定時は accepting user の email と一致必須 (不一致 =
+//     EMAIL_MISMATCH で全 rollback)。招待リンク横流しによる別人受諾を防ぐ
+//
+// token_hash (CWE-522): raw 招待コードは保存しない前提の DDL (UNIQUE)。hash 生成・照合は
+// service 層 (後続 PR)。本テストは fixture hash を直接 insert する。
+//
+// ── Canon TDD test list ──
+//   [B1] 成功: pending+未失効 → accepted + membership 作成 (単一 txn)
+//   [B2] 失効 → INVALID_OR_EXPIRED (status は pending のまま、membership 無し)
+//   [B3] 非 pending (accepted 済/revoked) → INVALID_OR_EXPIRED
+//   [B4] 既 member (23505) → ALREADY_IN_TENANT + **invite UPDATE も rollback (原子性)**
+//   [B5] email 束縛不一致 → EMAIL_MISMATCH + 全 rollback
+//   [B7] consents: append-only 表に insert できる (GRANT/repo 束縛 = fitness#2 は repo 実装 PR)
+
+import { PGlite } from '@electric-sql/pglite';
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/pglite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const NOW = '2026-07-02T10:00:00+00:00';
+const FUTURE = '2026-12-31T00:00:00+00:00';
+const PAST = '2026-01-01T00:00:00+00:00';
+
+describe('#3528(b): invite 受諾単一 txn (§6.6 厳密分岐)', () => {
+	let client: PGlite;
+	let db: ReturnType<typeof drizzle>;
+
+	const FAMILY = '00000000-0000-4000-8000-000000000001';
+	const INVITER = '00000000-0000-4000-8000-000000000002';
+	const ACCEPTOR = '00000000-0000-4000-8000-000000000003';
+
+	beforeAll(async () => {
+		client = new PGlite();
+		db = drizzle(client);
+		// 実 DDL (dsql/schema.ts) を drizzle-kit 生成なしで再現するため、schema module から
+		// CREATE TABLE を組み立てる代わりに必要 2 表を §6.6 と同構造で作成する…のではなく、
+		// schema drift を避けるため drizzle-kit 相当の生成はせず、テーブルは raw DDL で
+		// dsql/schema.ts と同名・同列に定義する (PK/CHECK/UNIQUE は fitness#9/#13 が
+		// schema.ts 側を検証済。本テストの関心は受諾 txn の分岐)。
+		// extended protocol は 1 execute 1 文のため表ごとに分割。
+		await db.execute(
+			sql.raw(`CREATE TABLE invites (
+				invite_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+				family_id uuid NOT NULL,
+				invited_by uuid NOT NULL,
+				role text NOT NULL,
+				child_id uuid,
+				email text,
+				token_hash text NOT NULL UNIQUE,
+				status text NOT NULL DEFAULT 'pending',
+				expires_at timestamptz NOT NULL,
+				accepted_by uuid,
+				accepted_at timestamptz,
+				created_at timestamptz NOT NULL DEFAULT now()
+			)`),
+		);
+		await db.execute(
+			sql.raw(`CREATE TABLE memberships (
+				family_id uuid NOT NULL,
+				user_id uuid NOT NULL,
+				role text NOT NULL,
+				owner_guard uuid GENERATED ALWAYS AS (CASE WHEN role = 'owner' THEN family_id END) STORED UNIQUE,
+				invited_by uuid,
+				joined_at timestamptz NOT NULL DEFAULT now(),
+				PRIMARY KEY (family_id, user_id)
+			)`),
+		);
+		await db.execute(
+			sql.raw(`CREATE TABLE consents (
+				consent_id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+				family_id uuid NOT NULL,
+				user_id uuid NOT NULL,
+				type text NOT NULL,
+				version text NOT NULL,
+				consented_at timestamptz NOT NULL DEFAULT now(),
+				ip_address text NOT NULL,
+				user_agent text NOT NULL
+			)`),
+		);
+	});
+	afterAll(async () => {
+		await client.close();
+	});
+
+	const seedInvite = async (over: {
+		id: string;
+		status?: string;
+		expiresAt?: string;
+		email?: string | null;
+		role?: string;
+	}) => {
+		await db.execute(sql`
+			INSERT INTO invites (invite_id, family_id, invited_by, role, email, token_hash, status, expires_at)
+			VALUES (${over.id}, ${FAMILY}, ${INVITER}, ${over.role ?? 'parent'}, ${over.email ?? null},
+				${`hash-${over.id}`}, ${over.status ?? 'pending'}, ${over.expiresAt ?? FUTURE})
+		`);
+	};
+
+	const inviteStatus = async (id: string) =>
+		(await db.execute(sql`SELECT status FROM invites WHERE invite_id = ${id}`)).rows[0] as {
+			status: string;
+		};
+
+	const membershipCount = async (userId: string) =>
+		Number(
+			(
+				(await db.execute(
+					sql`SELECT count(*) AS c FROM memberships WHERE family_id = ${FAMILY} AND user_id = ${userId}`,
+				)) as { rows: { c: unknown }[] }
+			).rows[0]?.c,
+		);
+
+	const makeRunner = async () => {
+		const { createDsqlTransactionRunner } = await import(
+			'../../../src/lib/server/db/dsql/run-in-transaction'
+		);
+		return createDsqlTransactionRunner(db, { maxAttempts: 3, baseDelayMs: 1 });
+	};
+
+	it('[B1] pending + 未失効 → accepted + membership 作成 (単一 txn)', async () => {
+		const { acceptInvite } = await import('../../../src/lib/server/db/dsql/invite-accept');
+		const id = '10000000-0000-4000-8000-000000000001';
+		await seedInvite({ id });
+		const result = await acceptInvite(await makeRunner(), {
+			inviteId: id,
+			userId: ACCEPTOR,
+			userEmail: 'parent@example.com',
+			now: NOW,
+		});
+		expect(result.ok).toBe(true);
+		expect((await inviteStatus(id)).status).toBe('accepted');
+		expect(await membershipCount(ACCEPTOR)).toBe(1);
+	});
+
+	it('[B2] 失効 invite → INVALID_OR_EXPIRED (retry 禁止の業務失敗、状態不変)', async () => {
+		const { acceptInvite } = await import('../../../src/lib/server/db/dsql/invite-accept');
+		const id = '10000000-0000-4000-8000-000000000002';
+		const user = '20000000-0000-4000-8000-000000000002';
+		await seedInvite({ id, expiresAt: PAST });
+		const result = await acceptInvite(await makeRunner(), {
+			inviteId: id,
+			userId: user,
+			userEmail: 'x@example.com',
+			now: NOW,
+		});
+		expect(result).toEqual({ ok: false, reason: 'INVALID_OR_EXPIRED' });
+		expect((await inviteStatus(id)).status).toBe('pending');
+		expect(await membershipCount(user)).toBe(0);
+	});
+
+	it('[B3] 非 pending (受諾済 / revoked) → INVALID_OR_EXPIRED', async () => {
+		const { acceptInvite } = await import('../../../src/lib/server/db/dsql/invite-accept');
+		for (const [suffix, status] of [
+			['3a', 'accepted'],
+			['3b', 'revoked'],
+		] as const) {
+			const id = `10000000-0000-4000-8000-00000000003${suffix.charCodeAt(1) % 10}`;
+			const user = `20000000-0000-4000-8000-00000000003${suffix.charCodeAt(1) % 10}`;
+			await seedInvite({ id, status });
+			const result = await acceptInvite(await makeRunner(), {
+				inviteId: id,
+				userId: user,
+				userEmail: 'x@example.com',
+				now: NOW,
+			});
+			expect(result, `status=${status}`).toEqual({ ok: false, reason: 'INVALID_OR_EXPIRED' });
+		}
+	});
+
+	it('[B4] 既 member (memberships 23505) → ALREADY_IN_TENANT + invite UPDATE も rollback (原子性)', async () => {
+		const { acceptInvite } = await import('../../../src/lib/server/db/dsql/invite-accept');
+		const id = '10000000-0000-4000-8000-000000000004';
+		const user = '20000000-0000-4000-8000-000000000004';
+		await seedInvite({ id });
+		await db.execute(
+			sql`INSERT INTO memberships (family_id, user_id, role) VALUES (${FAMILY}, ${user}, 'parent')`,
+		);
+		const result = await acceptInvite(await makeRunner(), {
+			inviteId: id,
+			userId: user,
+			userEmail: 'x@example.com',
+			now: NOW,
+		});
+		expect(result).toEqual({ ok: false, reason: 'ALREADY_IN_TENANT' });
+		// 単一 txn ゆえ membership INSERT 失敗で invite の accepted 化も巻き戻る (部分コミット禁止)
+		expect((await inviteStatus(id)).status).toBe('pending');
+	});
+
+	it('[B5] email 束縛不一致 → EMAIL_MISMATCH + 全 rollback (§6.6 ⚠️ 招待リンク横流し防止)', async () => {
+		const { acceptInvite } = await import('../../../src/lib/server/db/dsql/invite-accept');
+		const id = '10000000-0000-4000-8000-000000000005';
+		const user = '20000000-0000-4000-8000-000000000005';
+		await seedInvite({ id, email: 'Intended@Example.com' });
+		const result = await acceptInvite(await makeRunner(), {
+			inviteId: id,
+			userId: user,
+			userEmail: 'attacker@example.com',
+			now: NOW,
+		});
+		expect(result).toEqual({ ok: false, reason: 'EMAIL_MISMATCH' });
+		expect((await inviteStatus(id)).status).toBe('pending');
+		expect(await membershipCount(user)).toBe(0);
+
+		// 大文字小文字差は一致扱い (email_lower と同じ case-insensitive 原則)
+		const result2 = await acceptInvite(await makeRunner(), {
+			inviteId: id,
+			userId: user,
+			userEmail: 'intended@example.com',
+			now: NOW,
+		});
+		expect(result2.ok).toBe(true);
+	});
+
+	it('[B7] consents 表に insert できる (append-only 表の正常系。fitness#2 repo 束縛は後続 PR)', async () => {
+		await db.execute(sql`
+			INSERT INTO consents (family_id, user_id, type, version, ip_address, user_agent)
+			VALUES (${FAMILY}, ${ACCEPTOR}, 'terms', '2026-01', '127.0.0.1', 'vitest')
+		`);
+		const rows = (await db.execute(sql`SELECT type, version FROM consents`)).rows;
+		expect(rows).toEqual([{ type: 'terms', version: '2026-01' }]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（EPIC #3424 DynamoDB → Aurora DSQL 移管の基盤、直接のエンドユーザー向け画面変更なし）

**解決する課題**: 現行 DynamoDB single-table 設計は招待（invite）と同意記録（consent）が adjacency item / 属性混在で JOIN 不可・整合性検証が困難。invite 受諾処理も複数リクエストに分散しており、招待コードの横流しや二重受諾（既に別テナントに所属済みの状態での再受諾）を DB レベルで防げない。

**期待される効果**: invites / consents をリレーショナル 2 表に分離し、招待受諾を単一トランザクションに集約することで、(1) raw 招待コード非保存（CWE-522 対策）、(2) email 束縛による招待リンク横流し防止、(3) 既存メンバーの二重受諾時に招待状態が誤って `accepted` に固定される不整合を防止する。最終的には家庭の認証・招待フロー全体の堅牢性向上に寄与する。

## 関連 Issue

closes #3528

## AC 検証マップ (ADR-0004)

<!-- 本 PR は #3528 の 粒度 (b) = invites / consents DDL + 受諾単一 txn のみを scope とする。
     (a) users / families / memberships + owner_guard は PR #3530 (merge 済) が担当。
     Issue #3528 の AC 8 項目のうち (b) スコープ外の項目は「対象外」として理由付きで明記する。 -->

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | owner_guard 生成列 + UNIQUE で owner ≤ 1 を DB 強制 | N/A（cycle (a) スコープ） | 対象外。PR #3530（merge 済）の `memberships` 表で実装済み。本 PR は `memberships` を変更しない |
| AC2 | fitness#3: 全 role-mutation を `requireRole(['owner'])` 背後に + parent→403 negative test | N/A（repo/route 実装 PR スコープ） | 対象外。PR 本文「#3528 の残 scope」に明記済み。本 PR は DDL + 受諾 txn のみで role-mutation route 自体を含まない。後続の repo/route 実装 PR の必須 AC として引き継ぎ |
| AC3 | fitness#2: consents append-only（repo に update/delete 非定義 + erasure caller 束縛） | `npx vitest run tests/unit/db/dsql-invite-accept.test.ts` (`[B7]`) | HEAD `46e338d` / DDL 側の append-only 前提（`consented_at` 降順 secondary index、UPDATE/DELETE 文を repo に一切書かない）は本 PR で実装・`[B7]` insert 正常系で確認（`tests/unit/db/dsql-invite-accept.test.ts:495-502`）。repo 層での update/delete 非定義の機械強制 + GRANT 除外は #3528 残 scope（auth repo 実装 PR）として明記済み |
| AC4 | invite 受諾単一 txn（rowCount=0 / 40001 / 23505 厳密分岐 + token_hash、CWE-522） | `npx vitest run tests/unit/db/dsql-invite-accept.test.ts` | HEAD `46e338d` / `[B1]`〜`[B5]`,`[B7]` 6/6 pass（成功 / 失効 / 非 pending / 既メンバー原子性 rollback / email 束縛 / consents insert）/ 実装: `src/lib/server/db/dsql/invite-accept.ts:124-157` / `token_hash` UNIQUE 制約: `src/lib/server/db/dsql/schema.ts:196` |
| AC5 | email_lower GENERATED + UNIQUE（findUserByEmail HOT、case-insensitive 重複防止） | N/A（cycle (a) スコープ） | 対象外。PR #3530（merge 済）の `users` 表で実装済み。本 PR は `users` を変更しない |
| AC6 | CHECK 値は SSOT 生成（手書き二重化禁止 = fitness#13 と同 helper） | `npx vitest run tests/unit/db/dsql-check-from-ssot.test.ts` | HEAD `46e338d` / `invites_status_ck`（`INVITE_STATUSES`）/ `invites_role_ck`（`ROLES`）/ `consents_type_ck`（`CONSENT_TYPES`）全値カバー pass / `tests/unit/db/dsql-check-from-ssot.test.ts:248-261` / SSOT 定義: `src/lib/server/auth/entities.ts:9-33` |
| AC7 | temporal は `{mode:'string'}`（fitness#6 が自動検査） | `npx vitest run tests/unit/db/dsql-temporal-parity.test.ts` | HEAD `46e338d` / 本テストは `dsql/schema.ts` の全 pg 表を走査するため表追記のみで自動カバー（テストファイル自体は本 PR で無変更）。`invites.expiresAt/acceptedAt/createdAt` / `consents.consentedAt` は全て `timestamp(..., { mode: 'string', withTimezone: true })` / `src/lib/server/db/dsql/schema.ts:198-227` |
| AC8 | PK 凍結: auth 5 表の PK を pk-freeze-manifest に §6.6 準拠で追記（users/invites/consents は family_id 先頭でない例外） | `npx vitest run tests/unit/db/pk-freeze-manifest.test.ts` | HEAD `46e338d` / `invites: ['invite_id']` / `consents: ['consent_id']` は cycle (a)（PR #3530、merge 済）で population 済のため本 PR では未変更。`src/lib/server/db/pk-freeze-manifest.ts:74-75` で現存確認 |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
画面変更なし。DSQL 移管基盤（EPIC #3424）の DB スキーマ + トランザクション関数のみ。現行 DynamoDB 実装・画面には未接続（後続の repo/route 実装 PR で接続する）。

## テスト & 安全装置セルフチェック

- [ ] `npm run pre-ready -- --pr 3537` 全 Step PASS（本追記時点でローカル一括実行は未確認。個別コマンドの実行結果は「AC 検証マップ」および元 PR 記述「573/573 pass」「svelte-check 0 errors」「biome clean」を参照。CI (`ci.yml`) 側でも同 4 コマンドを実行）
- [x] 追加・変更したテストの概要: `tests/unit/db/dsql-invite-accept.test.ts`（新規、`[B1]`〜`[B5]`,`[B7]` 6 ケース）/ `tests/unit/db/dsql-check-from-ssot.test.ts`（invites/consents CHECK SSOT 検証 2 ケース追加）
- [x] 新規 env / secret 追加時（ADR-0006）: N/A — 追加なし
- [x] DynamoDB 実装変更時（ADR-0010 / #1021）: N/A — 本 PR は DSQL 側のみ、DynamoDB 実装は無変更
- [x] Critical バグ修正の場合（ADR-0002）: N/A — feat（新規 DDL）であり critical バグ修正ではない

## スクリーンショット / ビジュアルデモ

該当なし（DB スキーマ + サーバーサイドトランザクション関数のみで UI 変更を含まない）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `acceptInvite` は単一責任（招待受諾の txn 内分岐のみ）。`TransactionRunner<TTx>` インターフェース経由で DI（依存性逆転）
- [x] **DRY**: `enumCheck` helper（fitness#13 と同一）を再利用し CHECK SSOT 生成を重複させていない。`grep -rn "INVITE_STATUSES\|CONSENT_TYPES" src/` で他ファイルへのハードコード無しを確認済み
- [x] **YAGNI**: token_hash の生成・timing-safe 照合ロジックは本 PR に含めず（#3528 残 scope、service 層実装 PR）。DDL + txn 分岐に限定
- [x] **Security（OSS 公開前提）**: `token_hash` UNIQUE で raw 招待コード非保存（CWE-522）。email 束縛の case-insensitive 比較で招待リンク横流し（別人受諾）を防止。秘密情報のハードコードなし
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: N+1 なし（受諾処理は単一 txn 内 UPDATE 1 文 + INSERT 1 文）。`invites_family_id_idx` / `consents_family_type_at_idx` を新設し想定クエリ（findTenantInvites / findLatestConsent）を secondary index でカバー

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアル同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): 設計 SSOT `docs/design/dsql-data-model.md` §6.6 は既に本 DDL 仕様を凍結済み（本 PR は同仕様の実装）。追加更新なし
- [x] **並行 PR overlap** (#1200): `git log --oneline -- src/lib/server/db/dsql/schema.ts src/lib/server/db/dsql/invite-accept.ts` で本 PR 対象ファイルを同時期に変更する他の open PR なしを確認
- [x] N/A — 並行実装の影響範囲外（UI / LP / 年齢モード / ナビ / E2E シード / labels は本 PR の変更範囲外。DSQL 移管基盤は現行 DynamoDB 実装と並行稼働中で、切替は EPIC #3424 後続フェーズ）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A — LP / 販促文言の変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新規 DDL 追加のみ。既存 DynamoDB 実装・現行稼働画面は無影響）

**レビュー依頼事項・QA**:
AC2（fitness#3 role-mutation guard）と AC3 の repo 束縛部分は `#3528 の残 scope` として意図的に後続 PR（repo/route 実装 PR）に委譲しています。本 PR のスコープが cycle (b)「invites/consents DDL + 受諾単一 txn」に限定されている前提で AC 充足判断をお願いします。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] `npm run pre-ready -- --pr 3537` 全 Step PASS をローカル確認した — ローカル一括 CLI 実行は本追記時点で未再実行だが、同一検証内容（biome / svelte-check / vitest / AC 検証マップ）は CI (`lint-and-test` / `unit-test` / `Verify AC map in PR body`) で全 pass 確認済み
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（`TODO` / `「予定」` のまま残っている AC がない） — cycle (b) スコープ内 AC（AC4/AC6/AC7）は実装済み、スコープ外 AC（AC1/AC2/AC3 repo 束縛/AC5/AC8）は上記マップの通り理由明記のうえ対象外化
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — Issue #3528 本文「粒度 (≤400 LOC、超過時 2 分割)」に (a)/(b) 分割が明記済み。(a) は PR #3530 で実装・merge 済
- [x] UI 変更時: 該当なし（画面変更を含まない DB スキーマ + トランザクション関数 PR）
- [x] 認証画面変更時: 該当なし（画面変更なし）

## QM レビュー結果

<!-- QM が記入。フォーマット・必須手順は docs/sessions/qa-session.md「Tier 2 手順 5」を参照。
     CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（ADR-0022）。 -->

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

---

## 変更内容

### DDL (`db/dsql/schema.ts` +2 表)
- **invites**: `token_hash` UNIQUE (**raw 招待コード非保存 = CWE-522**、bearer 化による機密性退行防止) / status + role CHECK (SSOT 生成) / `email` 束縛列 (§6.6 ⚠️) / `(family_id)` secondary。adjacency item 廃止
- **consents**: **append-only** 表 (GDPR Art.7 / COPPA)。`(family_id, type, consented_at)` secondary — 最新判定は consented_at 降順 (version 文字列順非依存)。UPDATE/DELETE の repo 非定義 + GRANT 除外 + fitness#2 束縛は repo 実装 PR で強制
- `INVITE_STATUSES` / `CONSENT_TYPES` runtime SSOT 化 (既存型と同値)

### 受諾単一 txn (`db/dsql/invite-accept.ts`)
`acceptInvite(runner, input)` — §6.6 の厳密分岐を実装:

| 事象 | 分岐 |
|---|---|
| `UPDATE ... WHERE status='pending' AND expires_at > now RETURNING` が 0 行 | `INVALID_OR_EXPIRED` (**retry 禁止**、正常 return) |
| membership INSERT の 23505 (PK/owner_guard 重複) | `ALREADY_IN_TENANT` — **単一 txn ゆえ invite の accepted 化も rollback** ([B4] で原子性検証) |
| 40001 (OCC) | throw のまま → runner 内蔵 withOccRetry が txn 全体を再実行 |
| invite.email 設定 + 受諾 user email 不一致 (case-insensitive) | `EMAIL_MISMATCH` + 全 rollback (招待リンク横流し防止、§6.6 ⚠️) |

- `now` は呼び出し側注入 (テスト決定性 + txn 内一貫)
- **fitness#7 (PR #3534) を実運用で初通過**: work 内の await は全て tx-bound (`tx.execute`)。helper await を避ける設計制約が実際に機能

## 検証 (Canon TDD)

- red (module 未実在) → green: PGlite integration **[B1]-[B7] 6/6 pass** (成功 / 失効 / 非 pending / 既 member 原子性 / email 束縛 / consents insert)
- `tests/unit/db/` + `tests/unit/architecture/` **573/573 pass** (fitness#6/#9/#13 が新 2 表を自動カバー、AUTH_PK_MANIFEST は cycle (a) で population 済)
- `svelte-check` **0 errors** / biome clean

## #3528 の残 scope

- fitness#3 (全 role-mutation の requireRole route guard + parent→403 negative) — repo/route 実装 PR の必須 AC
- fitness#2 の repo 束縛 (consents update/delete 非定義 + erasure caller 束縛) — auth repo 実装 PR
- token_hash の生成・timing-safe 照合 — service 層実装 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
