### PR TITLE
docs: #3533 §10.2 プラン別ゲーティング UI 表示パターン改訂 (P1-P5 / disabled+popover 収斂)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1406,21 +1406,49 @@ hooks.server.ts
 >
 > **注 2（#3033）**: PlanStatusCard（利用状況 3 stat + アップグレード CTA）の配置は **`/admin/subscription`（SaasLicensePanel 内）のみ**。admin home の body にプランカードは置かない（body 常設プランカードは業界慣行外 + banner blindness。プラン情報の常設表示は header の pill / badge / upgrade-btn が担う）。
 
-### 10.2 disabled 表示パターン（共通原則）
+### 10.2 有料機能の表示パターン（共通原則、EPIC #3533 で改訂）
 
-free/standard ユーザーから有料機能に触れたとき、**機能の存在は示し、実行は不可、アップセル CTA を表示する** のが原則。隠す（hidden）のも、403 を踏ませるのも禁止。
+free/standard ユーザーが有料機能・上限超過に触れたとき、**機能の存在は示し、実行は不可（disabled）** にするのが原則。隠す（hidden）のも、403 を踏ませるのも禁止。ただし **画面内に個別アップセル CTA / quota カウンタ（「N/M」「あと何個」）は置かない**（EPIC #3533 で変更）。制約詳細（quota / 上限 / 各プランでできること）は **プラン画面（`/admin/subscription`）に一元化**し、アップグレード導線は **header に一本化**する。
 
-| パターン | コンポーネント | 用途 | 例 |
+**確定ポリシー P1–P5（EPIC #3533、deep-research + PO 合意済み）**:
+
+- **P1（制約詳細はプラン画面へ）**: quota / 上限 / 各プランでできることの一覧は `/admin/subscription` に集約。機能画面は「存在を示す・操作不可」に留め、**画面内 quota カウンタ・個別アップセル CTA を持たない**。理由: 同一ゲートを 1 画面で何度も recognition させると NN/G #6（recognition vs recall）に反し、banner blindness を招く。
+- **P2（disabled は tap→popover）**: disabled 要素は tap で popover / bottom sheet を出し、① 利用不可の明示 ② 対象プラン名 ③ プラン画面リンク（1 本）を示す（§10.2.1）。モバイル hover 不可対策 + dead-end 回避（NN/G #1 visibility of system status）。
+- **P3（導線は header 一本化）**: アップグレード導線は header の現在プラン名 / アップグレードに一本化。画面内に個別 CTA を置かない。header 常設導線（tier 導線）と画面内 disabled（機能ゲート）は意味が分離しているため重複と見なさない。
+- **P4（専用プランバッジ非採用）**: Gemini 生成の専用プランバッジは非採用。汎用ロック（🔒）+ popover で代替する。deep-research 上の根拠が無く、anti-engagement（ADR-0012）+ 生成コストに見合わないため。将来トリガ待ち。
+- **P5（文言は SSOT）**: popover / disabled / エラーの文言は `PLAN_GATE_LABELS`（§10.7）を参照。独自文言を持たない（ADR-0045）。
+
+| パターン | コンポーネント | 用途 | 表示 |
 |---------|--------------|------|---|
-| **A. ボタン disabled + Badge** | `FeatureGate display="inline" buttonLabel="..."` | リスト内・カード末尾の単発操作 | 「クラウドエクスポート」ボタン（free） |
-| **B. セクションオーバーレイ + Badge** | `FeatureGate display="section"` | パネル・カード全体（中身をぼかし表示） | 「AI提案」パネル（free） |
-| **C. カード全体置き換え** | 個別実装（PremiumBadge + CTA） | データ管理カード等の重要セクション | 設定画面のクラウド共有カード（#773） |
+| **A. ボタン disabled + popover** | `FeatureGate display="inline"` | 単発操作 / quota 上限到達時の「+追加」等 | 🔒 disabled、tap で popover（§10.2.1） |
+| **B. セクション disabled + popover** | `FeatureGate display="section"` | パネル・カード全体 | 中身は見せて操作 disabled、tap で popover |
+| **C. カード全体置き換え** | 個別実装 | 重要セクション | 可能なら A/B に寄せる（新規は個別実装を避ける） |
 
 実装ルール:
 
 - 既存有料機能を追加・改修するときは **必ず `FeatureGate` を経由する**。`{#if planTier !== 'free'}` の生分岐をコンポーネント内に書かない。
 - バックエンドでは別途 `requirePaidTier()` 等で 403 を返す。フロントの `FeatureGate` は **二重防御** であって唯一の砦ではない。
 - A/B どちらを選ぶかは「ユーザーが押せる単位」で決める。1 ボタン = A、1 機能セット = B。
+
+#### 10.2.1 モバイル popover（P2）
+
+disabled 要素の tap で popover / bottom sheet を開く（Ark UI primitive 経由、`role` / `data-testid` 付与）。内容は 3 要素のみ:
+
+1. 利用不可の明示（例:「現在のプランでは利用できません」）
+2. 対象プラン名（例:「スタンダードプラン以上」）
+3. プラン画面（`/admin/subscription`）へのリンク **1 本**
+
+文言は `PLAN_GATE_LABELS`（§10.7）参照。popover 自体が独自文言を持たない。`data-testid` 規約: `feature-gate-popover` / `feature-gate-popover-link`。
+
+#### 10.2.2 quota ゲート（P1 / P2）
+
+上限（N/M）を持つ機能では、**画面に N/M カウンタを出さない**。`plan-limit-service` が返す `{ allowed, current, max }` を FeatureGate に渡し:
+
+- `current < max`（未到達）: 操作可
+- `current >= max`（到達）: 「+追加」等を **disabled + popover**（§10.2.1）にする
+- `max === null`（無制限プラン）: **ゲート痕跡を一切描画しない**（disabled も popover も出さない）
+
+「あと何個」は割り切りでプラン画面に委ねる（P1）。
 
 ### 10.3 トライアル表示（header pill + TrialBanner）仕様
 
@@ -1438,7 +1466,7 @@ free/standard ユーザーから有料機能に触れたとき、**機能の存�
 | expired | バナーなし | 一回限りの TrialEndedDialog（#770）+ subscription ページの状態表示 |
 | standard / family（契約済み） | バナーなし | — |
 
-**「何が無料版で制限されるか」の recognition**（NN/G #6）は、常設バナーでの列挙ではなく**ロック機能に接触した時点の文脈表示**が担う（§10.2 FeatureGate / AiSuggestPanel の locked badge + upgrade card / rewards-upgrade-banner / export-upsell）。
+**「何が無料版で制限されるか」の recognition**（NN/G #6）は、常設バナーでの列挙ではなく**ロック機能に接触した時点の文脈表示**が担う（§10.2 FeatureGate の disabled + popover）。EPIC #3533 の P1/P3 に従い、画面ごとの個別アップセル（旧 AiSuggestPanel の upgrade card / rewards-upgrade-banner / export-upsell 等）は `FeatureGate` の disabled + popover に収斂し、制約詳細はプラン画面（`/admin/subscription`）へ一元化する。
 
 `data-testid` 規約: `header-trial-pill`（#3033） / `trial-banner-urgent` / `trial-banner-active-cta` / `subscription-start-trial-button`。
 
@@ -1475,7 +1503,7 @@ free/standard ユーザーから有料機能に触れたとき、**機能の存�
 **アップグレードの主な経路**:
 
 1. TrialBanner（not-started）→ 「7日間 無料で試す」 → `?/startTrial` action → トライアル開始 → 即座に有料機能解放（ただし license plan は free のまま）
-2. TrialBanner / PlanStatusCard / FeatureGate の各 CTA → `/admin/license` → Stripe Checkout → webhook で license plan 更新 → 次回 admin ロード時に PremiumWelcome 表示
+2. TrialBanner / PlanStatusCard / FeatureGate popover のプラン画面リンク（§10.2.1）→ プラン画面（`/admin/subscription`）→ Stripe Checkout → webhook で license plan 更新 → 次回 admin ロード時に PremiumWelcome 表示（EPIC #3533 で FeatureGate 個別 CTA → popover リンク一本化）
 
 **ダウングレード**: 詳細フローと超過リソース処理の確認画面は #738 / #754 で別途設計（現状は `/admin/license` から Stripe Customer Portal を経由）。
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: プラン別ゲーティング UI がアドホックで、同一制限が 1 画面で最大 4 表現に散在（例 `/admin/checklists`: ①タイトルバッジ ②quota+アップグレード→ ③弾かれ時エラー ④header 常設アップグレード）。ユーザーが「何が・なぜ・どうすれば解除されるか」を recognition できない（NN/G #6 不全）。20 回以上再指摘されている。

**期待される効果**: EPIC #3533 の合意済みポリシー P1–P5 を設計 SSOT（§10.2）に明文化することで、以後の gated 画面が「disabled + popover」の単一パターンに収斂でき、過剰・不整合な販促表現が構造的に発生しなくなる。本 PR は上流の設計改訂（AC1）で、実装は後続 PR。

## 関連 Issue

EPIC #3533 の AC1（§10.2 設計書改訂）を消化。統合 PR で main 反映時に集約 close される運用のため、本 PR body では EPIC への close 宣言は行わず参照に留める（AC2–6 が別 PR で残るため EPIC は未 close）。
関連: #3533

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | §10.2 に確定ポリシー P1–P5 を明文化（quota 型パターン + 1 画面 recognition 原則を追加） | `docs/design/06-UI設計書.md` §10.2 / §10.2.1 / §10.2.2 目視 | HEAD `0f8c90a8` / §10.2 に P1–P5 明記（06-UI設計書.md:1409 付近）、§10.2.1 popover / §10.2.2 quota ゲート新設 |
| AC1-a | 旧個別アップセル参照（§10.3 / §10.6）を popover 収斂へ整合 | 同上 目視 | HEAD `0f8c90a8` / §10.3 note + §10.6 経路2 を popover リンク一本化に更新 |
| AC1-b | doc-code 参照の新規違反ゼロ | `node scripts/check-doc-code-references.mjs` | HEAD `0f8c90a8` / baseline 内 149 件、新規違反なし |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設計・CI (`package.json`, `.github/`, `biome.json` 等) — `docs/design/` 設計書のみ

**影響を受ける画面・機能**: なし（設計書のみ。実装・UI 変更は後続 PR で実施）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready` 相当の docs 検証**: `node scripts/check-doc-code-references.mjs` PASS（baseline 内、新規違反なし）
- [x] 追加・変更したテストの概要: N/A（docs-only）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: docs-only（設計書 §10.2 の文言・パターン定義改訂のみ）。UI 実装変更は後続 PR（AC2–6）で行い、その PR に SS を添付する。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（docs-only）
- [x] **DRY**: 既存 §10.7 `PLAN_GATE_LABELS` を参照する形にし、文言 SSOT を重複させていない
- [x] **YAGNI**: 新規 component / 抽象を追加せず、既存 `FeatureGate` 拡張方針として記述
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: popover に `role` / `data-testid` 付与を規約化（実装は後続）
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): UI 変更方針を `docs/design/06-UI設計書.md` §10 に反映（本 PR 本体）
- [x] **labels SSOT** (ADR-0009 / ADR-0045): 文言は §10.7 `PLAN_GATE_LABELS` 参照を明記（P5）
- [x] **並行 PR overlap** (#1200): 本 PR は `docs/design/06-UI設計書.md` のみ変更。同ファイルを同時変更する open PR なし（並行 PR ファイル重複チェック pass 確認済み）
- [x] N/A — 本番/デモ同期・年齢モード・ナビ・E2E シードは docs-only のため対象外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A（LP・pricing 文言の変更なし）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: §10.2 の P1–P5 が引継ぎ（PO 合意済みポリシー）と齟齬ないかの確認。特に P1（画面内 quota カウンタ・個別 CTA の撤廃）と P4（Gemini 専用バッジ非採用）が意図どおりか。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] docs 検証（`check-doc-code-references.mjs`）PASS をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = AC1 のみ。AC2–6 は後続 PR）
- [x] Phase 分割した場合: EPIC #3533 で PO と合意済み、サブタスク列挙済み
- [x] UI 変更時: N/A（docs-only）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
