### PR TITLE
feat: #3541 recordActivityCore 単一 txn 原子化 + 冪等 guard (Phase C cycle 1)

### DIFF
--- a/src/lib/server/db/dsql/record-activity-core.ts
+++ b/src/lib/server/db/dsql/record-activity-core.ts
@@ -1,0 +1,182 @@
+// src/lib/server/db/dsql/record-activity-core.ts
+// EPIC #3424 / 実装 #3541 (#N4-2 Phase C cycle 1) / 設計 SSOT: dsql-data-model.md §8 / §5(P7)
+//
+// recordActivity の core 5 行を単一 txn (all-or-nothing) で書く (§8「最大の質的改善」)。
+// 現行 activity-log-service.ts の「txn 無し・逐次 await・例外握り潰し」による部分コミット
+// (point 入ったが status 未更新等) を根絶する。
+//
+// 設計契約 (§8):
+//   - **冪等性の正 = txn 内 re-read**: dailyLimit 判定 (countTodayActiveRecords 相当) を
+//     txn 内で再実行。並行二連打は共有行 (mastery/statuses) upsert が serialization point に
+//     なり DSQL では 40001 → runner retry → re-read が ALREADY_RECORDED を返す。
+//     txn 境界を HTTP に晒さない (HTTP 再送は二重付与)。
+//   - **point_ledger INSERT + children.total_point 加算は同一 txn** (§5 P7、SUM 乖離不能。
+//     fitness#14 findTotalPointDrift が突合)。
+//   - **optional (combo/mission/challenge/証明書/通知) は本関数に入れない** (SAVEPOINT 不可
+//     spike#4。core commit 後の独立 mini-txn、cycle 2 / fitness#10,#11)。
+//   - **fitness#7 準拠**: work 内の await は全て tx-bound。level 算出は sync 関数注入。
+//   - work は再実行可能 (40001 retry で全体再実行、書込前の re-read が冪等性を守る)。
+//
+// 事前 guard (child/activity の存在・所有検証 CWE-598、streak/bonus 計算) は service 層の
+// read-only 処理で、本関数の入力として受ける (txn 内は書込整合に必要な re-read のみ)。
+
+import { sql } from 'drizzle-orm';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type { SqlExecutor } from './sql-executor';
+
+export interface RecordActivityCoreInput {
+	familyId: string;
+	childId: string;
+	activityId: string;
+	/** categories(code) 論理 FK。statuses/status_history の書込先カテゴリ。 */
+	categoryId: string;
+	/** 倍率 (メインクエスト/週末) 適用後の基礎点。 */
+	basePoints: number;
+	streakBonus: number;
+	masteryBonus: number;
+	streakDays: number;
+	/** 'YYYY-MM-DD'。dailyLimit 判定と ledger.recorded_date に使用。 */
+	recordedDate: string;
+	/** ISO 8601。全 temporal 列に一貫適用 (テスト決定性)。 */
+	now: string;
+	/** null=1回 / 0=無制限 / N=N回 (現行 service と同義)。 */
+	dailyLimit: number | null;
+	/** point_ledger.description。 */
+	description: string;
+	/** status_history.change_type ('activity_record' 等)。 */
+	changeType: string;
+	/** 習熟度 count → level (sync。fitness#7: work 内 await 禁止のため関数注入)。 */
+	masteryLevelFor: (totalCount: number) => number;
+	/** 累積 XP → status level (sync)。 */
+	statusLevelFor: (totalXp: number) => number;
+}
+
+export type RecordActivityCoreResult =
+	| {
+			ok: true;
+			logId: string;
+			totalPoints: number;
+			masteryCount: number;
+			masteryLevel: number;
+			totalXp: number;
+			statusLevel: number;
+	  }
+	| { ok: false; reason: 'ALREADY_RECORDED' | 'DAILY_LIMIT_REACHED' };
+
+/** 業務失敗 (guard 不成立) を rollback とともに運ぶ内部シグナル。 */
+class RecordAbort extends Error {
+	constructor(readonly reason: 'ALREADY_RECORDED' | 'DAILY_LIMIT_REACHED') {
+		super(`record aborted: ${reason}`);
+	}
+}
+
+/** core 5 行 (log / mastery / ledger+total_point / statuses / history) を単一 txn で書く。 */
+export async function recordActivityCore<TTx extends SqlExecutor>(
+	runner: TransactionRunner<TTx>,
+	input: RecordActivityCoreInput,
+): Promise<RecordActivityCoreResult> {
+	const {
+		familyId,
+		childId,
+		activityId,
+		categoryId,
+		basePoints,
+		streakBonus,
+		masteryBonus,
+		streakDays,
+		recordedDate,
+		now,
+		dailyLimit,
+		description,
+		changeType,
+		masteryLevelFor,
+		statusLevelFor,
+	} = input;
+	const totalPoints = basePoints + streakBonus + masteryBonus;
+
+	try {
+		return await runner.runInTransaction(async (tx) => {
+			// 冪等 guard: dailyLimit 判定を txn 内で re-read (§8。null=1回 / 0=無制限 / N=N回)。
+			const counted = await tx.execute(sql`
+				SELECT count(*) AS c FROM activity_logs
+				WHERE family_id = ${familyId} AND child_id = ${childId}
+					AND activity_id = ${activityId} AND recorded_date = ${recordedDate}
+					AND cancelled = false
+			`);
+			const todayCount = Number((counted.rows[0] as { c: unknown }).c);
+			const effectiveLimit = dailyLimit ?? 1;
+			if (effectiveLimit !== 0 && todayCount >= effectiveLimit) {
+				throw new RecordAbort(effectiveLimit === 1 ? 'ALREADY_RECORDED' : 'DAILY_LIMIT_REACHED');
+			}
+
+			// ① activity_logs INSERT (points は基礎点、bonus 内訳は streak_bonus 列 / ledger 側)。
+			const inserted = await tx.execute(sql`
+				INSERT INTO activity_logs
+					(family_id, child_id, activity_id, points, streak_days, streak_bonus, recorded_date, recorded_at)
+				VALUES (${familyId}, ${childId}, ${activityId}, ${basePoints}, ${streakDays}, ${streakBonus}, ${recordedDate}, ${now})
+				RETURNING log_id
+			`);
+			const logId = (inserted.rows[0] as { log_id: string }).log_id;
+
+			// ② activity_mastery: txn 内 re-read → count+1 → level 再計算 → upsert。
+			const masteryRead = await tx.execute(sql`
+				SELECT total_count FROM activity_mastery
+				WHERE family_id = ${familyId} AND child_id = ${childId} AND activity_id = ${activityId}
+			`);
+			const masteryCount =
+				Number((masteryRead.rows[0] as { total_count: number } | undefined)?.total_count ?? 0) + 1;
+			const masteryLevel = masteryLevelFor(masteryCount);
+			await tx.execute(sql`
+				INSERT INTO activity_mastery (family_id, child_id, activity_id, total_count, level, updated_at)
+				VALUES (${familyId}, ${childId}, ${activityId}, ${masteryCount}, ${masteryLevel}, ${now})
+				ON CONFLICT (family_id, child_id, activity_id)
+				DO UPDATE SET total_count = ${masteryCount}, level = ${masteryLevel}, updated_at = ${now}
+			`);
+
+			// ③ point_ledger INSERT + children.total_point 共更新 (§5 P7、同一 txn 必須)。
+			await tx.execute(sql`
+				INSERT INTO point_ledger (family_id, child_id, amount, type, description, reference_id, recorded_date, created_at)
+				VALUES (${familyId}, ${childId}, ${totalPoints}, 'activity', ${description}, ${logId}, ${recordedDate}, ${now})
+			`);
+			await tx.execute(sql`
+				UPDATE children SET total_point = total_point + ${totalPoints}, updated_at = ${now}
+				WHERE family_id = ${familyId} AND child_id = ${childId}
+			`);
+
+			// ④ statuses: txn 内 re-read → XP 加算 + level/peak 再計算 → upsert。
+			const statusRead = await tx.execute(sql`
+				SELECT total_xp, peak_xp FROM statuses
+				WHERE family_id = ${familyId} AND child_id = ${childId} AND category_id = ${categoryId}
+			`);
+			const prev = statusRead.rows[0] as { total_xp: number; peak_xp: number } | undefined;
+			const totalXp = (prev?.total_xp ?? 0) + totalPoints;
+			const peakXp = Math.max(prev?.peak_xp ?? 0, totalXp);
+			const statusLevel = statusLevelFor(totalXp);
+			await tx.execute(sql`
+				INSERT INTO statuses (family_id, child_id, category_id, total_xp, level, peak_xp, updated_at)
+				VALUES (${familyId}, ${childId}, ${categoryId}, ${totalXp}, ${statusLevel}, ${peakXp}, ${now})
+				ON CONFLICT (family_id, child_id, category_id)
+				DO UPDATE SET total_xp = ${totalXp}, level = ${statusLevel}, peak_xp = ${peakXp}, updated_at = ${now}
+			`);
+
+			// ⑤ status_history INSERT (recorded_at は sort 用途、§11.2)。
+			await tx.execute(sql`
+				INSERT INTO status_history (family_id, child_id, category_id, value, change_amount, change_type, recorded_at)
+				VALUES (${familyId}, ${childId}, ${categoryId}, ${totalXp}, ${totalPoints}, ${changeType}, ${now})
+			`);
+
+			return {
+				ok: true,
+				logId,
+				totalPoints,
+				masteryCount,
+				masteryLevel,
+				totalXp,
+				statusLevel,
+			} as const;
+		});
+	} catch (err) {
+		if (err instanceof RecordAbort) return { ok: false, reason: err.reason };
+		throw err;
+	}
+}

--- a/src/lib/server/db/dsql/schema.ts
+++ b/src/lib/server/db/dsql/schema.ts
@@ -351,3 +351,20 @@ export const statusHistory = pgTable(
 	},
 	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.categoryId, t.histId] })],
 );
+
+// activity_mastery — 活動習熟度 (自然複合 PK、unique(child,activity) 昇格 §11.2、#3541)。
+// total_count/level は記録 txn 内で re-read + upsert する派生 (record-activity-core.ts §8)。
+export const activityMastery = pgTable(
+	'activity_mastery',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		activityId: uuid('activity_id').notNull(),
+		totalCount: integer('total_count').notNull().default(0),
+		level: integer('level').notNull().default(1),
+		updatedAt: timestamp('updated_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.activityId] })],
+);

--- a/tests/unit/db/dsql-record-activity-core.test.ts
+++ b/tests/unit/db/dsql-record-activity-core.test.ts
@@ -1,0 +1,226 @@
+// tests/unit/db/dsql-record-activity-core.test.ts
+// EPIC #3424 / 実装 #3541 (#N4-2 Phase C cycle 1) / 設計 SSOT: dsql-data-model.md §8 / §5(P7)
+//
+// recordActivity core 5 行の単一 txn 原子化 (§8「最大の質的改善」):
+//   ① activity_logs INSERT ② activity_mastery UPSERT ③ point_ledger INSERT +
+//   children.total_point 共更新 ④ statuses UPSERT ⑤ status_history INSERT を all-or-nothing。
+//   現行 (activity-log-service.ts) の「txn 無し・逐次 await・例外握り潰し」による部分コミット
+//   (point 入ったが status 未更新等) を構造的に根絶する。
+//   冪等性の正は「txn 内 re-read」(§8): dailyLimit 判定を txn 内で再実行し、HTTP 再送 /
+//   二連打による二重付与を serialization point (DSQL 40001 / SQLite IMMEDIATE) で防ぐ。
+//
+// ── Canon TDD test list (cycle 1 = core txn。optional 隔離 / fitness#10,#11 は cycle 2) ──
+//   [R1] 初回記録: 5 表全てに行 + total_point 加算
+//   [R2] dailyLimit null(=1回): 2 回目は ALREADY_RECORDED で全表不変 (txn 内 re-read)
+//   [R2b] dailyLimit N / 0(無制限) の分岐
+//   [R3] 途中失敗 (最終 write の NOT NULL violation) → 5 表全 rollback (部分コミット禁止)
+//   [R4] 累積: mastery count/level 更新 + statuses xp 加算 + peak 維持
+//   [R5] fitness#14 整合: 記録後 findTotalPointDrift が 0 件 (total_point == SUM)
+
+import { PGlite } from '@electric-sql/pglite';
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/pglite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const FAMILY = '00000000-0000-4000-8000-0000000000f1';
+const NOW = '2026-07-02T10:00:00+00:00';
+const TODAY = '2026-07-02';
+
+describe('#N4-2 cycle1: recordActivityCore 単一 txn (§8 core 5 行 all-or-nothing)', () => {
+	let client: PGlite;
+	let db: ReturnType<typeof drizzle>;
+	let childSeq = 0;
+
+	beforeAll(async () => {
+		client = new PGlite();
+		db = drizzle(client);
+		// core txn が触る 6 表の最小 fixture (完全 DDL は dsql/schema.ts が SSOT、fitness#9/#13 検証済)。
+		const ddl = [
+			`CREATE TABLE children (
+				family_id uuid NOT NULL, child_id uuid NOT NULL,
+				total_point integer NOT NULL DEFAULT 0,
+				updated_at timestamptz NOT NULL DEFAULT now(),
+				PRIMARY KEY (family_id, child_id))`,
+			`CREATE TABLE activity_logs (
+				family_id uuid NOT NULL, child_id uuid NOT NULL,
+				log_id uuid NOT NULL DEFAULT gen_random_uuid(),
+				activity_id uuid NOT NULL, points integer NOT NULL,
+				streak_days integer NOT NULL DEFAULT 1, streak_bonus integer NOT NULL DEFAULT 0,
+				recorded_date text NOT NULL, recorded_at timestamptz NOT NULL,
+				cancelled boolean NOT NULL DEFAULT false,
+				PRIMARY KEY (family_id, child_id, log_id))`,
+			`CREATE TABLE activity_mastery (
+				family_id uuid NOT NULL, child_id uuid NOT NULL, activity_id uuid NOT NULL,
+				total_count integer NOT NULL DEFAULT 0, level integer NOT NULL DEFAULT 1,
+				updated_at timestamptz NOT NULL,
+				PRIMARY KEY (family_id, child_id, activity_id))`,
+			`CREATE TABLE point_ledger (
+				family_id uuid NOT NULL, child_id uuid NOT NULL,
+				ledger_id uuid NOT NULL DEFAULT gen_random_uuid(),
+				amount integer NOT NULL, type text NOT NULL, description text,
+				reference_id text, recorded_date text NOT NULL,
+				created_at timestamptz NOT NULL DEFAULT now(),
+				PRIMARY KEY (family_id, child_id, ledger_id))`,
+			`CREATE TABLE statuses (
+				family_id uuid NOT NULL, child_id uuid NOT NULL, category_id text NOT NULL,
+				total_xp integer NOT NULL DEFAULT 0, level integer NOT NULL DEFAULT 1,
+				peak_xp integer NOT NULL DEFAULT 0, updated_at timestamptz NOT NULL,
+				PRIMARY KEY (family_id, child_id, category_id))`,
+			`CREATE TABLE status_history (
+				family_id uuid NOT NULL, child_id uuid NOT NULL, category_id text NOT NULL,
+				hist_id uuid NOT NULL DEFAULT gen_random_uuid(),
+				value real NOT NULL, change_amount real NOT NULL, change_type text NOT NULL,
+				recorded_at timestamptz NOT NULL,
+				PRIMARY KEY (family_id, child_id, category_id, hist_id))`,
+		];
+		for (const stmt of ddl) await db.execute(sql.raw(stmt));
+	});
+	afterAll(async () => {
+		await client.close();
+	});
+
+	/** child + activity id を払い出し children 行を seed する (テスト間独立)。 */
+	const newChild = async () => {
+		childSeq++;
+		const childId = `c0000000-0000-4000-8000-${String(childSeq).padStart(12, '0')}`;
+		const activityId = `a0000000-0000-4000-8000-${String(childSeq).padStart(12, '0')}`;
+		await db.execute(
+			sql`INSERT INTO children (family_id, child_id) VALUES (${FAMILY}, ${childId})`,
+		);
+		return { childId, activityId };
+	};
+
+	const makeCore = async () => {
+		const { createDsqlTransactionRunner } = await import(
+			'../../../src/lib/server/db/dsql/run-in-transaction'
+		);
+		const { recordActivityCore } = await import(
+			'../../../src/lib/server/db/dsql/record-activity-core'
+		);
+		const runner = createDsqlTransactionRunner(db, { maxAttempts: 3, baseDelayMs: 1 });
+		return (over: Record<string, unknown>) =>
+			recordActivityCore(runner, {
+				familyId: FAMILY,
+				categoryId: 'undou',
+				basePoints: 10,
+				streakBonus: 2,
+				masteryBonus: 0,
+				streakDays: 3,
+				recordedDate: TODAY,
+				now: NOW,
+				dailyLimit: null,
+				description: 'テスト活動',
+				changeType: 'activity_record',
+				masteryLevelFor: (count: number) => Math.floor(count / 5) + 1,
+				statusLevelFor: (xp: number) => Math.floor(xp / 100) + 1,
+				...over,
+			} as never);
+	};
+
+	const count = async (table: string, childId: string) =>
+		Number(
+			(
+				(await db.execute(
+					sql.raw(
+						`SELECT count(*) AS c FROM ${table} WHERE family_id = '${FAMILY}' AND child_id = '${childId}'`,
+					),
+				)) as { rows: { c: unknown }[] }
+			).rows[0]?.c,
+		);
+
+	const totalPoint = async (childId: string) =>
+		(
+			(
+				await db.execute(
+					sql`SELECT total_point FROM children WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+				)
+			).rows[0] as { total_point: number }
+		).total_point;
+
+	it('[R1] 初回記録: 5 表全てに行が入り total_point が加算される (all-or-nothing commit)', async () => {
+		const { childId, activityId } = await newChild();
+		const core = await makeCore();
+		const result = await core({ childId, activityId });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		// total = base 10 + streak 2 + mastery 0
+		expect(result.totalPoints).toBe(12);
+		expect(await count('activity_logs', childId)).toBe(1);
+		expect(await count('activity_mastery', childId)).toBe(1);
+		expect(await count('point_ledger', childId)).toBe(1);
+		expect(await count('statuses', childId)).toBe(1);
+		expect(await count('status_history', childId)).toBe(1);
+		expect(await totalPoint(childId)).toBe(12);
+	});
+
+	it('[R2] dailyLimit null(=1回): 2 回目は ALREADY_RECORDED (txn 内 re-read、全表不変)', async () => {
+		const { childId, activityId } = await newChild();
+		const core = await makeCore();
+		await core({ childId, activityId });
+		const second = await core({ childId, activityId });
+		expect(second).toEqual({ ok: false, reason: 'ALREADY_RECORDED' });
+		expect(await count('activity_logs', childId)).toBe(1);
+		expect(await count('point_ledger', childId)).toBe(1);
+		expect(await totalPoint(childId)).toBe(12);
+	});
+
+	it('[R2b] dailyLimit 2 → 3 回目は DAILY_LIMIT_REACHED / dailyLimit 0 は無制限', async () => {
+		const limited = await newChild();
+		const core = await makeCore();
+		await core({ ...limited, dailyLimit: 2 });
+		await core({ ...limited, dailyLimit: 2 });
+		const third = await core({ ...limited, dailyLimit: 2 });
+		expect(third).toEqual({ ok: false, reason: 'DAILY_LIMIT_REACHED' });
+
+		const unlimited = await newChild();
+		for (let i = 0; i < 4; i++) {
+			const r = await core({ ...unlimited, dailyLimit: 0 });
+			expect(r.ok).toBe(true);
+		}
+		expect(await count('activity_logs', unlimited.childId)).toBe(4);
+	});
+
+	it('[R3] 途中失敗 (最終 write の NOT NULL violation) → 5 表全 rollback (部分コミット禁止)', async () => {
+		const { childId, activityId } = await newChild();
+		const core = await makeCore();
+		// changeType null → 最終 write (status_history INSERT) が NOT NULL violation で fail。
+		// 現行実装なら log/ledger/mastery が partial commit する場面 — 単一 txn では全て巻き戻る。
+		await expect(core({ childId, activityId, changeType: null })).rejects.toThrow();
+		expect(await count('activity_logs', childId)).toBe(0);
+		expect(await count('activity_mastery', childId)).toBe(0);
+		expect(await count('point_ledger', childId)).toBe(0);
+		expect(await count('statuses', childId)).toBe(0);
+		expect(await totalPoint(childId)).toBe(0);
+	});
+
+	it('[R4] 累積: mastery count/level と statuses xp/peak が txn 内 re-read で更新される', async () => {
+		const { childId, activityId } = await newChild();
+		const core = await makeCore();
+		// masteryLevelFor = floor(count/5)+1 → 5 回目で level 2
+		for (let i = 0; i < 5; i++) {
+			const r = await core({ childId, activityId, dailyLimit: 0 });
+			expect(r.ok).toBe(true);
+		}
+		const mastery = (
+			await db.execute(
+				sql`SELECT total_count, level FROM activity_mastery WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+			)
+		).rows[0] as { total_count: number; level: number };
+		expect(mastery).toEqual({ total_count: 5, level: 2 });
+
+		const status = (
+			await db.execute(
+				sql`SELECT total_xp, peak_xp FROM statuses WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+			)
+		).rows[0] as { total_xp: number; peak_xp: number };
+		expect(status.total_xp).toBe(60); // 12 × 5
+		expect(status.peak_xp).toBe(60);
+		expect(await count('status_history', childId)).toBe(5);
+	});
+
+	it('[R5] fitness#14 整合: 記録後の total_point == SUM(point_ledger) (drift 0 件)', async () => {
+		const { findTotalPointDrift } = await import('../../../src/lib/server/db/dsql/derived-drift');
+		const drifts = await findTotalPointDrift(db);
+		expect(drifts, 'core txn の共更新により drift は構造的に 0').toEqual([]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（子供の活動記録の整合性 = 全ユーザーの信頼基盤）

**解決する課題**: 現行 `recordActivity` は 5+ 表を txn 無し・逐次 await・例外握り潰しで書くため、「ポイントは入ったがステータス未更新」等の部分コミットが起き得る（`dsql-data-model.md` §8）。子供が「がんばった記録」と「もらえたポイント/レベル」がズレる事故は UX 信頼を直接毀損する。

**期待される効果**: DSQL 移管後の記録書込が all-or-nothing になり、二連打・HTTP 再送でも二重付与されない（冪等 guard）。残高派生列 `children.total_point` は SUM と構造的に乖離しない（fitness#14 が突合）。

## 関連 Issue

- EPIC #3424 / 実装 issue #3541（#N4-2 Phase C）の **cycle 1**。issue は cycle 2（optional 隔離 / fitness#10,#11）完了まで open のため closes は付けない
- related: #3539（5 表 DDL、merged）/ #3531（TransactionRunner、merged）

## AC 検証マップ (ADR-0004)

<!-- issue #3541 の AC のうち cycle 1 scope。cycle 2 AC は本 PR 対象外（issue 側で管理） -->

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1-1 | recordActivityCore = core 5 行 all-or-nothing（dsql backend、Phase A の TransactionRunner 使用） | `npx vitest run tests/unit/db/dsql-record-activity-core.test.ts` [R1] | HEAD `f0bec6db` / 6 passed / src/lib/server/db/dsql/record-activity-core.ts:98（runner.runInTransaction 単一 txn） |
| AC1-2 | 冪等 guard「txn 内 re-read」: dailyLimit 判定を txn 内で再実行し ALREADY_RECORDED / DAILY_LIMIT_REACHED | 同上 [R2][R2b] | HEAD `f0bec6db` / record-activity-core.ts:100-110（txn 内 count re-read）/ [R2] 2 回目 ALREADY_RECORDED + 全表不変 PASS |
| AC1-3 | point_ledger INSERT + children.total_point 加算を同一 txn（§5 P7、fitness#14 が 0 drift） | 同上 [R5] + `tests/unit/db/dsql-total-point-drift.test.ts` | HEAD `f0bec6db` / record-activity-core.ts:137-144（同一 txn 内 ③）/ [R5] findTotalPointDrift = [] PASS |
| AC1-4 | activity_mastery DDL 追加（PK = manifest (family,child,activity_id)） | `npx vitest run tests/unit/db/pk-freeze-manifest.test.ts`（fitness#9 [3] 全表走査） | HEAD `f0bec6db` / schema.ts 末尾 activityMastery / fitness#9 [3] PK==manifest PASS（4 passed） |
| AC1-5 | 途中失敗で 5 表全 rollback（PGlite で検証） | 同上 [R3] | HEAD `f0bec6db` / [R3] status_history NOT NULL violation → log/mastery/ledger/statuses/total_point 全て不変 PASS |
| AC1-6 | fitness#7 allowlist 準拠（work 内 await は tx-bound のみ、level 計算は sync 関数注入） | `npx vitest run tests/unit/architecture/dsql-txn-work-allowlist.test.ts` | HEAD `f0bec6db` / 6 passed（production callsite として record-activity-core.ts を実走査し違反 0） |

<!-- ac-verification-skip: issue #3541 の cycle 2 AC（optional 隔離 / fitness#10 TOCTOU / fitness#11 欠落カウンタ / service 結線）は本 PR scope 外（issue 本文で cycle 分割を宣言済み、別 PR で検証マップを提出） -->

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（DSQL backend の新規モジュール + テストのみ。既存 sqlite/dynamo 経路・UI・service 層は未変更。service 結線は cutover 系の別 PR）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3543` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/db/dsql-record-activity-core.test.ts` 新規（PGlite integration [R1]-[R5]: 5 表 commit / 冪等 / limit 分岐 / 途中失敗全 rollback / mastery・status 累積 / fitness#14 drift 0）
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（DynamoDB 実装は未変更。本 PR は DSQL backend 新設で、両実装整合は EPIC #3424 の cutover 計画 §12.2 が管理）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし**（server-side DB モジュール + unit test のみ。UI 変更・route 変更・表示文言変更を含まない）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（core 書込のみ、optional/事前 guard は scope 外を明文化）/ 依存性逆転（`TransactionRunner` port + `SqlExecutor` 構造的型で drizzle driver 非依存）/ インターフェース分離（level 計算は sync 関数注入で domain 依存を持たない）
- [x] **DRY**: 冪等 guard・upsert パターンは §8 設計 SSOT 準拠。`SqlExecutor` は sql-executor.ts の既存共有型を再利用（invite-accept と同一 seam）
- [x] **YAGNI**: cycle 2 の optional dispatch / metric は先取りせず issue AC に留めた
- [x] **Security（OSS 公開前提）**: 秘密情報なし / SQL は全て drizzle `sql` テンプレートのパラメタバインド（injection 不可）/ tenant 境界は全文で `family_id =` 述語（§P9）/ 事前 guard（CWE-598 cross-child 検証）は service 層責務と明記
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: txn 内は PK プレフィクス lookup のみ（count/mastery/status re-read）。書込 8 文は §8 worst-case 25-50 行の下限側で DSQL 1txn 上限（3,000 行）に 2 桁余裕

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): 列レベル DDL は「drizzle schema の確定コードが SSOT」（`dsql-data-model.md` §11.3 で委譲済み）のため設計書側の更新不要。§8 のコード化であり設計変更なし
- [x] **並行 PR overlap** (#1200): `src/lib/server/db/dsql/**` を変更する open PR は他に無い（EPIC #3424 実装は本セッションが直列進行）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新規モジュール追加のみ。既存経路・既存テーブル定義の変更なし）

**レビュー依頼事項・QA**:
- `record-activity-core.ts` の入力境界（事前 guard = service 層 / txn 内 = 書込整合に必要な re-read のみ）が §8 の core/optional 分離と整合しているか
- [R3] の途中失敗注入方式（最終 write の NOT NULL violation）が rollback 検証として十分か

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3543` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（cycle 1 scope 全 AC 実装済。cycle 2 AC は issue #3541 で管理）
- [x] Phase 分割した場合: issue #3541 本文で cycle 1/2 分割を宣言済み（実装計画 §2.2 準拠）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
