### PR TITLE
feat: #3541 optional 隔離 + fitness#10 TOCTOU 防止 + fitness#11 欠落カウンタ (Phase C cycle 2)

### DIFF
--- a/src/lib/server/db/dsql/daily-mission-complete.ts
+++ b/src/lib/server/db/dsql/daily-mission-complete.ts
@@ -57,10 +57,24 @@ export async function completeMissionAndMaybeGrantBonus<TTx extends SqlExecutor>
 		const completedNow = flipped.rows.length > 0;
 
 		// 同 txn 内で未完了残を確認 (自 txn の UPDATE は可視)。
+		// remaining SELECT は FOR UPDATE で他 mission 行を write-intent 化し write skew を
+		// OCC 40001 で防ぐ (設計書 §4.1 / 行 228: read-write は非検出 = write skew を防げず、
+		// read 値を条件に別行を書く不変条件は FOR UPDATE で write-intent 化して守る)。
+		// これが無いと、同日の最後の 2 mission A/B を別 txn がほぼ同時に flip した場合、
+		// 双方が「相手はまだ completed=false」とスナップショットで見て bonus 未付与のまま
+		// 異なる行への書込ゆえ 40001 も起きず両方 commit → daily bonus 永久欠落 (write skew)。
+		// FOR UPDATE で相手の completed=false 行に write-intent を張ると、相手が flip 済の同一行
+		// への write-write となり 40001 → runner が retry して正しく bonus を付与する。
+		// 注: PostgreSQL / PGlite は `count(*) ... FOR UPDATE` を
+		//   "FOR UPDATE is not allowed with aggregate functions" で拒否するため、
+		//   FOR UPDATE を内側サブクエリで行を確定してから外側で集約する。
 		const remaining = await tx.execute(sql`
-			SELECT count(*) AS c FROM daily_missions
-			WHERE family_id = ${familyId} AND child_id = ${childId}
-				AND mission_date = ${missionDate} AND completed = false
+			SELECT count(*) AS c FROM (
+				SELECT 1 FROM daily_missions
+				WHERE family_id = ${familyId} AND child_id = ${childId}
+					AND mission_date = ${missionDate} AND completed = false
+				FOR UPDATE
+			) AS unfinished
 		`);
 		const allComplete = Number((remaining.rows[0] as { c: unknown }).c) === 0;
 

--- a/src/lib/server/db/dsql/daily-mission-complete.ts
+++ b/src/lib/server/db/dsql/daily-mission-complete.ts
@@ -1,0 +1,83 @@
+// src/lib/server/db/dsql/daily-mission-complete.ts
+// EPIC #3424 / 実装 #3541 (#N4-2 Phase C cycle 2) / 設計 SSOT: dsql-data-model.md §8 / §13.1 fitness#10
+//
+// fitness#10 (TOCTOU / double-award 防止): mission bonus の point_ledger は unique 制約が
+// 無いため、count-then-insert 方式は double-tap / OCC 下で二重付与する (fitness#14 の
+// total_point 突合は self-consistent で検出不能)。本実装は once-per-day 系の正攻法として
+// **daily_missions の自然複合 PK 行 (§11.2 凍結: family, child, mission_date, activity_id)
+// への conditional UPDATE (completed = false → true) を serialization point** にする:
+//   - 同一 mission への並行/二連打は同一行 write-write → DSQL は片方 40001 (runner retry 後
+//     rowCount=0) / SQLite は IMMEDIATE 直列化 → **遷移はちょうど 1 回**
+//   - daily bonus は「未完了残 0 を同 txn 内で確認した、最後の 1 件を flip した txn」だけが
+//     付与 → 全 mission 完了 bonus も exactly-once
+//   - bonus (ledger + total_point) をフラグ遷移と同一 txn にする = 「フラグだけ立って
+//     bonus 消失」「bonus だけ入ってフラグ未遷移」の両方を排除
+
+import { sql } from 'drizzle-orm';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type { SqlExecutor } from './sql-executor';
+
+export interface CompleteMissionInput {
+	familyId: string;
+	childId: string;
+	/** 'YYYY-MM-DD'。 */
+	missionDate: string;
+	activityId: string;
+	/** 全 mission 完了時に付与する daily bonus (point_ledger type='mission_bonus')。 */
+	bonusPoints: number;
+	bonusDescription: string;
+	/** ISO 8601 (呼び出し側注入)。 */
+	now: string;
+}
+
+export interface CompleteMissionResult {
+	/** 本呼び出しで completed に遷移したか (false = 既に完了済 or mission 不在)。 */
+	completedNow: boolean;
+	/** 本 txn 終了時点で当日の全 mission が完了しているか。 */
+	allComplete: boolean;
+	/** 本呼び出しが daily bonus を付与したか (最後の 1 件を flip した txn のみ true)。 */
+	bonusGranted: boolean;
+}
+
+/** mission 完了遷移 + 全完了 daily bonus を単一 txn で行う (fitness#10 exactly-once)。 */
+export async function completeMissionAndMaybeGrantBonus<TTx extends SqlExecutor>(
+	runner: TransactionRunner<TTx>,
+	input: CompleteMissionInput,
+): Promise<CompleteMissionResult> {
+	const { familyId, childId, missionDate, activityId, bonusPoints, bonusDescription, now } = input;
+	return runner.runInTransaction(async (tx) => {
+		// serialization point: completed=false の行だけが遷移できる (二連打の 2 回目は rowCount 0)。
+		const flipped = await tx.execute(sql`
+			UPDATE daily_missions SET completed = true, completed_at = ${now}
+			WHERE family_id = ${familyId} AND child_id = ${childId}
+				AND mission_date = ${missionDate} AND activity_id = ${activityId}
+				AND completed = false
+			RETURNING activity_id
+		`);
+		const completedNow = flipped.rows.length > 0;
+
+		// 同 txn 内で未完了残を確認 (自 txn の UPDATE は可視)。
+		const remaining = await tx.execute(sql`
+			SELECT count(*) AS c FROM daily_missions
+			WHERE family_id = ${familyId} AND child_id = ${childId}
+				AND mission_date = ${missionDate} AND completed = false
+		`);
+		const allComplete = Number((remaining.rows[0] as { c: unknown }).c) === 0;
+
+		// bonus は「本呼び出しが最後の 1 件を flip した」場合のみ (exactly-once)。
+		const bonusGranted = completedNow && allComplete;
+		if (bonusGranted) {
+			await tx.execute(sql`
+				INSERT INTO point_ledger (family_id, child_id, amount, type, description, reference_id, recorded_date, created_at)
+				VALUES (${familyId}, ${childId}, ${bonusPoints}, 'mission_bonus', ${bonusDescription}, ${null}, ${missionDate}, ${now})
+			`);
+			// §5 P7: optional の point 付与も total_point を同一 txn 共更新 (fitness#14 整合)。
+			await tx.execute(sql`
+				UPDATE children SET total_point = total_point + ${bonusPoints}, updated_at = ${now}
+				WHERE family_id = ${familyId} AND child_id = ${childId}
+			`);
+		}
+
+		return { completedNow, allComplete, bonusGranted };
+	});
+}

--- a/src/lib/server/db/dsql/grant-optional-points.ts
+++ b/src/lib/server/db/dsql/grant-optional-points.ts
@@ -1,0 +1,52 @@
+// src/lib/server/db/dsql/grant-optional-points.ts
+// EPIC #3424 / 実装 #3541 (#N4-2 Phase C cycle 2) / 設計 SSOT: dsql-data-model.md §8 / §5(P7)
+//
+// optional (combo / mission / challenge / reward 等) の point 付与プリミティブ。
+// §8: optional は core commit 後の独立 mini-txn だが、**各 mini-txn 内で
+// point_ledger INSERT + children.total_point 加算を 1 txn** にする (§5 P7 の
+// 「全ての point_ledger 書込は total_point を同一 txn 共更新」不変条件を
+// core/optional 問わず維持 → fitness#14 findTotalPointDrift が 0 drift)。
+//
+// 対象 child が存在しない場合は throw (ledger だけ書けて total_point 更新先が無い
+// 片肺書込を禁止 — mini-txn ごと rollback される)。
+
+import { sql } from 'drizzle-orm';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type { SqlExecutor } from './sql-executor';
+
+export interface GrantOptionalPointsInput {
+	familyId: string;
+	childId: string;
+	amount: number;
+	/** point_ledger.type ('combo_bonus' / 'mission_bonus' 等)。 */
+	type: string;
+	description: string;
+	referenceId: string | null;
+	/** 'YYYY-MM-DD'。 */
+	recordedDate: string;
+	/** ISO 8601 (呼び出し側注入)。 */
+	now: string;
+}
+
+/** optional point 付与 = ledger INSERT + total_point 加算の独立 mini-txn。 */
+export async function grantOptionalPoints<TTx extends SqlExecutor>(
+	runner: TransactionRunner<TTx>,
+	input: GrantOptionalPointsInput,
+): Promise<void> {
+	const { familyId, childId, amount, type, description, referenceId, recordedDate, now } = input;
+	await runner.runInTransaction(async (tx) => {
+		await tx.execute(sql`
+			INSERT INTO point_ledger (family_id, child_id, amount, type, description, reference_id, recorded_date, created_at)
+			VALUES (${familyId}, ${childId}, ${amount}, ${type}, ${description}, ${referenceId}, ${recordedDate}, ${now})
+		`);
+		const updated = await tx.execute(sql`
+			UPDATE children SET total_point = total_point + ${amount}, updated_at = ${now}
+			WHERE family_id = ${familyId} AND child_id = ${childId}
+			RETURNING child_id
+		`);
+		if (updated.rows.length === 0) {
+			// child 不在 = total_point 共更新不能。throw で mini-txn ごと rollback (§5 P7)。
+			throw new Error(`grantOptionalPoints: child not found (${familyId}/${childId})`);
+		}
+	});
+}

--- a/src/lib/server/db/dsql/optional-write-guard.ts
+++ b/src/lib/server/db/dsql/optional-write-guard.ts
@@ -1,0 +1,36 @@
+// src/lib/server/db/dsql/optional-write-guard.ts
+// EPIC #3424 / 実装 #3541 (#N4-2 Phase C cycle 2) / 設計 SSOT: dsql-data-model.md §8 / §13.1 fitness#11
+//
+// optional 書込 (combo / mission / challenge / certificate / 通知) の隔離実行 wrapper。
+// §8: optional は additive で core の整合に不要 → 失敗は core を巻き込まず swallow する。
+// ただし「行が書かれない欠落」は fitness#14 の派生列突合では drift=0 で**検出不能**
+// (DB R1/QM R4/PO R1) → 失敗時に観測カウンタ (metric、ログでない) を emit して
+// 欠落率を可観測化する (fitness#11)。
+//
+// カウンタは injectable: db 層は analytics に依存しない (層分離)。service 層が
+// `analytics.trackEvent('optional_write_failed', { name })` 等に bind して使う。
+
+export type OptionalWriteFailureHandler = (name: string, error: unknown) => void;
+
+/**
+ * optional 書込を隔離実行する。失敗は swallow して null を返し、onFailure に通知する。
+ * @param name 観測カウンタの識別子 ('combo_bonus' / 'mission_bonus' 等)
+ * @param fn optional 書込本体 (独立 mini-txn を内包すること — core txn に入れない)
+ * @param onFailure 失敗カウンタ emitter (fitness#11。service 層で analytics に bind)
+ */
+export async function runOptionalWrite<T>(
+	name: string,
+	fn: () => Promise<T>,
+	onFailure: OptionalWriteFailureHandler,
+): Promise<T | null> {
+	try {
+		return await fn();
+	} catch (err) {
+		try {
+			onFailure(name, err);
+		} catch {
+			// カウンタ emit 自体の失敗で optional 隔離を壊さない (fire-and-forget)。
+		}
+		return null;
+	}
+}

--- a/src/lib/server/db/dsql/schema.ts
+++ b/src/lib/server/db/dsql/schema.ts
@@ -368,3 +368,19 @@ export const activityMastery = pgTable(
 	},
 	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.activityId] })],
 );
+
+// daily_missions — デイリーミッション (自然複合 PK、§11.2 凍結: unique(child,mission_date,activity) 昇格)。
+// completed=false→true の conditional UPDATE が once-per-day bonus の serialization point
+// (fitness#10、daily-mission-complete.ts。count-then-insert の TOCTOU 二重付与を構造排除)。
+export const dailyMissions = pgTable(
+	'daily_missions',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		missionDate: text('mission_date').notNull(),
+		activityId: uuid('activity_id').notNull(),
+		completed: boolean('completed').notNull().default(false),
+		completedAt: timestamp('completed_at', { mode: 'string', withTimezone: true }),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.missionDate, t.activityId] })],
+);

--- a/tests/unit/db/dsql-optional-writes.test.ts
+++ b/tests/unit/db/dsql-optional-writes.test.ts
@@ -17,6 +17,7 @@
 //   [F10-1] 同一 mission への二連打: completed 遷移 1 回のみ、bonus 1 回のみ
 //   [F10-2] 複数 mission: 最後の 1 件を flip した呼び出しだけが daily bonus を付与
 //   [F10-3] 全完了後の再呼び出し: bonus 再付与なし (rowCount=0 経路)
+//   [F10-4] remaining SELECT の FOR UPDATE (write skew ガード) が集約エラーなく allComplete を返す
 //   [F11-1] optional 失敗: 例外 swallow + onFailure カウンタ emit + null 返却
 //   [F11-2] optional 成功: onFailure 非発火、結果を返す
 
@@ -196,6 +197,48 @@ describe('#N4-2 cycle2: optional 書込の隔離 (§8 / fitness#10,#11)', () => 
 		expect(again).toMatchObject({ completedNow: false, bonusGranted: false });
 		expect(await ledgerRows(childId, 'mission_bonus')).toHaveLength(1);
 		expect(await totalPoint(childId)).toBe(30);
+	});
+
+	it('[F10-4] remaining SELECT が FOR UPDATE を伴っても構文/集約エラーなく allComplete を返す (write skew ガード)', async () => {
+		// QM #3546 BLOCK: remaining カウント SELECT に FOR UPDATE を付与し他 mission 行を
+		// write-intent 化して write skew (異なる 2 行の並行完了で daily bonus 永久欠落) を
+		// OCC 40001 で防ぐ。ただし `count(*) ... FOR UPDATE` は PostgreSQL/PGlite が
+		// "FOR UPDATE is not allowed with aggregate functions" で拒否するため、実装は
+		// 内側サブクエリで行を FOR UPDATE 確定 → 外側で count する形を採る。
+		// 本テストはその SQL が構文/集約エラーを出さず、かつ allComplete 判定が正しいことを保証する。
+		//
+		// 既知制約 (#3545 と同種): PGlite は単一接続のため TxnA/TxnB の真の並行実行
+		// (2 別 txn がミリ秒で重なり互いの completed=false 行を snapshot 上で見る状況) を
+		// 再現できない。よって「FOR UPDATE 有無で 40001 が発生する/しない」の直接検証は不可。
+		// ここでは (a) FOR UPDATE 付き SQL が実行可能であること (集約エラー回帰の恒久ガード) と
+		// (b) 未完了残ありでは allComplete=false / 全完了で true になる意味論の 2 点を検証する。
+		const { completeMissionAndMaybeGrantBonus } = await import(
+			'../../../src/lib/server/db/dsql/daily-mission-complete'
+		);
+		const { childId, act } = await newIds();
+		for (const n of [1, 2]) {
+			await db.execute(sql`
+				INSERT INTO daily_missions (family_id, child_id, mission_date, activity_id)
+				VALUES (${FAMILY}, ${childId}, ${TODAY}, ${act(n)})
+			`);
+		}
+		const runner = await makeRunner();
+		const base = {
+			familyId: FAMILY,
+			childId,
+			missionDate: TODAY,
+			bonusPoints: 15,
+			bonusDescription: '全ミッション達成',
+			now: NOW,
+		};
+		// 1 件目 flip: 残 1 → FOR UPDATE 付き remaining SELECT が集約エラーなく allComplete=false を返す
+		const r1 = await completeMissionAndMaybeGrantBonus(runner, { ...base, activityId: act(1) });
+		expect(r1).toMatchObject({ completedNow: true, allComplete: false, bonusGranted: false });
+		// 2 件目 (最後) flip: 残 0 → allComplete=true, bonus 付与
+		const r2 = await completeMissionAndMaybeGrantBonus(runner, { ...base, activityId: act(2) });
+		expect(r2).toMatchObject({ completedNow: true, allComplete: true, bonusGranted: true });
+		expect(await ledgerRows(childId, 'mission_bonus')).toHaveLength(1);
+		expect(await totalPoint(childId)).toBe(15);
 	});
 
 	it('[F11-1] optional 失敗: swallow + onFailure カウンタ emit + null (fitness#11 可観測化)', async () => {

--- a/tests/unit/db/dsql-optional-writes.test.ts
+++ b/tests/unit/db/dsql-optional-writes.test.ts
@@ -1,0 +1,230 @@
+// tests/unit/db/dsql-optional-writes.test.ts
+// EPIC #3424 / 実装 #3541 (#N4-2 Phase C cycle 2) / 設計 SSOT: dsql-data-model.md §8 / §13.1 fitness#10,#11
+//
+// optional 書込の隔離 3 点セット (§8: optional は core commit 後の独立 mini-txn):
+//   1. grantOptionalPoints: optional の point 付与も「point_ledger INSERT + total_point 加算」を
+//      1 txn にする (§5 P7 不変条件を core/optional 問わず維持 → fitness#14 が 0 drift)
+//   2. fitness#10 (TOCTOU 防止): mission bonus は count-then-insert だと double-tap/OCC 下で
+//      二重付与 (fitness#14 は self-consistent で検出不能)。daily_missions の自然複合 PK 行への
+//      conditional UPDATE (completed=false→true) を serialization point にし、
+//      「最後の 1 件を flip した txn だけが daily bonus を付与」で exactly-once を構造化
+//   3. fitness#11 (欠落の可観測化): optional 失敗は core を巻き込まず swallow するが、
+//      行が書かれない欠落は fitness#14 drift=0 で検出不能 → 失敗時に観測カウンタを emit
+//
+// ── Canon TDD test list ──
+//   [O1] grantOptionalPoints: ledger + total_point が 1 txn (drift 0)
+//   [O2] 対象 child 不在 → throw + ledger も rollback (total_point 共更新不能な片肺書込を禁止)
+//   [F10-1] 同一 mission への二連打: completed 遷移 1 回のみ、bonus 1 回のみ
+//   [F10-2] 複数 mission: 最後の 1 件を flip した呼び出しだけが daily bonus を付与
+//   [F10-3] 全完了後の再呼び出し: bonus 再付与なし (rowCount=0 経路)
+//   [F11-1] optional 失敗: 例外 swallow + onFailure カウンタ emit + null 返却
+//   [F11-2] optional 成功: onFailure 非発火、結果を返す
+
+import { PGlite } from '@electric-sql/pglite';
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/pglite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const FAMILY = '00000000-0000-4000-8000-0000000000e1';
+const NOW = '2026-07-02T10:00:00+00:00';
+const TODAY = '2026-07-02';
+
+describe('#N4-2 cycle2: optional 書込の隔離 (§8 / fitness#10,#11)', () => {
+	let client: PGlite;
+	let db: ReturnType<typeof drizzle>;
+	let seq = 0;
+
+	beforeAll(async () => {
+		client = new PGlite();
+		db = drizzle(client);
+		const ddl = [
+			`CREATE TABLE children (
+				family_id uuid NOT NULL, child_id uuid NOT NULL,
+				total_point integer NOT NULL DEFAULT 0,
+				updated_at timestamptz NOT NULL DEFAULT now(),
+				PRIMARY KEY (family_id, child_id))`,
+			`CREATE TABLE point_ledger (
+				family_id uuid NOT NULL, child_id uuid NOT NULL,
+				ledger_id uuid NOT NULL DEFAULT gen_random_uuid(),
+				amount integer NOT NULL, type text NOT NULL, description text,
+				reference_id text, recorded_date text NOT NULL,
+				created_at timestamptz NOT NULL DEFAULT now(),
+				PRIMARY KEY (family_id, child_id, ledger_id))`,
+			`CREATE TABLE daily_missions (
+				family_id uuid NOT NULL, child_id uuid NOT NULL,
+				mission_date text NOT NULL, activity_id uuid NOT NULL,
+				completed boolean NOT NULL DEFAULT false,
+				completed_at timestamptz,
+				PRIMARY KEY (family_id, child_id, mission_date, activity_id))`,
+		];
+		for (const stmt of ddl) await db.execute(sql.raw(stmt));
+	});
+	afterAll(async () => {
+		await client.close();
+	});
+
+	const newIds = async () => {
+		seq++;
+		const childId = `d0000000-0000-4000-8000-${String(seq).padStart(12, '0')}`;
+		await db.execute(
+			sql`INSERT INTO children (family_id, child_id) VALUES (${FAMILY}, ${childId})`,
+		);
+		const act = (n: number) => `b000000${n}-0000-4000-8000-${String(seq).padStart(12, '0')}`;
+		return { childId, act };
+	};
+
+	const makeRunner = async () => {
+		const { createDsqlTransactionRunner } = await import(
+			'../../../src/lib/server/db/dsql/run-in-transaction'
+		);
+		return createDsqlTransactionRunner(db, { maxAttempts: 3, baseDelayMs: 1 });
+	};
+
+	const totalPoint = async (childId: string) =>
+		(
+			(
+				await db.execute(
+					sql`SELECT total_point FROM children WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+				)
+			).rows[0] as { total_point: number }
+		).total_point;
+
+	const ledgerRows = async (childId: string, type: string) =>
+		(
+			await db.execute(
+				sql`SELECT amount FROM point_ledger WHERE family_id = ${FAMILY} AND child_id = ${childId} AND type = ${type}`,
+			)
+		).rows as { amount: number }[];
+
+	it('[O1] grantOptionalPoints: ledger INSERT + total_point 加算が 1 txn (§5 P7)', async () => {
+		const { grantOptionalPoints } = await import(
+			'../../../src/lib/server/db/dsql/grant-optional-points'
+		);
+		const { findTotalPointDrift } = await import('../../../src/lib/server/db/dsql/derived-drift');
+		const { childId } = await newIds();
+		await grantOptionalPoints(await makeRunner(), {
+			familyId: FAMILY,
+			childId,
+			amount: 7,
+			type: 'combo_bonus',
+			description: 'コンボ',
+			referenceId: null,
+			recordedDate: TODAY,
+			now: NOW,
+		});
+		expect(await totalPoint(childId)).toBe(7);
+		expect(await ledgerRows(childId, 'combo_bonus')).toHaveLength(1);
+		expect(await findTotalPointDrift(db)).toEqual([]);
+	});
+
+	it('[O2] 対象 child 不在 → throw + ledger も rollback (片肺書込禁止)', async () => {
+		const { grantOptionalPoints } = await import(
+			'../../../src/lib/server/db/dsql/grant-optional-points'
+		);
+		const ghost = 'd9999999-0000-4000-8000-000000000999';
+		await expect(
+			grantOptionalPoints(await makeRunner(), {
+				familyId: FAMILY,
+				childId: ghost,
+				amount: 5,
+				type: 'combo_bonus',
+				description: 'x',
+				referenceId: null,
+				recordedDate: TODAY,
+				now: NOW,
+			}),
+		).rejects.toThrow();
+		expect(await ledgerRows(ghost, 'combo_bonus')).toHaveLength(0);
+	});
+
+	it('[F10-1] 同一 mission 二連打: completed 遷移 1 回・bonus 1 回 (conditional UPDATE が serialization point)', async () => {
+		const { completeMissionAndMaybeGrantBonus } = await import(
+			'../../../src/lib/server/db/dsql/daily-mission-complete'
+		);
+		const { childId, act } = await newIds();
+		await db.execute(sql`
+			INSERT INTO daily_missions (family_id, child_id, mission_date, activity_id)
+			VALUES (${FAMILY}, ${childId}, ${TODAY}, ${act(1)})
+		`);
+		const runner = await makeRunner();
+		const input = {
+			familyId: FAMILY,
+			childId,
+			missionDate: TODAY,
+			activityId: act(1),
+			bonusPoints: 20,
+			bonusDescription: 'ミッション達成',
+			now: NOW,
+		};
+		const first = await completeMissionAndMaybeGrantBonus(runner, input);
+		const second = await completeMissionAndMaybeGrantBonus(runner, input);
+		expect(first).toEqual({ completedNow: true, allComplete: true, bonusGranted: true });
+		expect(second).toEqual({ completedNow: false, allComplete: true, bonusGranted: false });
+		// fitness#10 の核: 二連打でも bonus ledger は 1 行のみ (fitness#14 では検出不能な二重付与)
+		expect(await ledgerRows(childId, 'mission_bonus')).toHaveLength(1);
+		expect(await totalPoint(childId)).toBe(20);
+	});
+
+	it('[F10-2][F10-3] 複数 mission: 最後の 1 件を flip した呼び出しだけが daily bonus を付与', async () => {
+		const { completeMissionAndMaybeGrantBonus } = await import(
+			'../../../src/lib/server/db/dsql/daily-mission-complete'
+		);
+		const { childId, act } = await newIds();
+		for (const n of [1, 2, 3]) {
+			await db.execute(sql`
+				INSERT INTO daily_missions (family_id, child_id, mission_date, activity_id)
+				VALUES (${FAMILY}, ${childId}, ${TODAY}, ${act(n)})
+			`);
+		}
+		const runner = await makeRunner();
+		const base = {
+			familyId: FAMILY,
+			childId,
+			missionDate: TODAY,
+			bonusPoints: 30,
+			bonusDescription: '全ミッション達成',
+			now: NOW,
+		};
+		const r1 = await completeMissionAndMaybeGrantBonus(runner, { ...base, activityId: act(1) });
+		const r2 = await completeMissionAndMaybeGrantBonus(runner, { ...base, activityId: act(2) });
+		const r3 = await completeMissionAndMaybeGrantBonus(runner, { ...base, activityId: act(3) });
+		expect(r1).toMatchObject({ completedNow: true, allComplete: false, bonusGranted: false });
+		expect(r2).toMatchObject({ completedNow: true, allComplete: false, bonusGranted: false });
+		expect(r3).toMatchObject({ completedNow: true, allComplete: true, bonusGranted: true });
+		// 全完了後の再呼び出し (別 activity で二連打相当) も bonus 再付与なし
+		const again = await completeMissionAndMaybeGrantBonus(runner, { ...base, activityId: act(2) });
+		expect(again).toMatchObject({ completedNow: false, bonusGranted: false });
+		expect(await ledgerRows(childId, 'mission_bonus')).toHaveLength(1);
+		expect(await totalPoint(childId)).toBe(30);
+	});
+
+	it('[F11-1] optional 失敗: swallow + onFailure カウンタ emit + null (fitness#11 可観測化)', async () => {
+		const { runOptionalWrite } = await import(
+			'../../../src/lib/server/db/dsql/optional-write-guard'
+		);
+		const failures: { name: string; message: string }[] = [];
+		const result = await runOptionalWrite(
+			'combo_bonus',
+			async () => {
+				throw new Error('DSQL down');
+			},
+			(name, err) => failures.push({ name, message: (err as Error).message }),
+		);
+		expect(result).toBeNull();
+		expect(failures).toEqual([{ name: 'combo_bonus', message: 'DSQL down' }]);
+	});
+
+	it('[F11-2] optional 成功: onFailure 非発火、結果を返す', async () => {
+		const { runOptionalWrite } = await import(
+			'../../../src/lib/server/db/dsql/optional-write-guard'
+		);
+		let failed = 0;
+		const result = await runOptionalWrite(
+			'mission_bonus',
+			async () => 42,
+			() => failed++,
+		);
+		expect(result).toBe(42);
+		expect(failed).toBe(0);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供（bonus 演出の信頼性）+ システム全体（ポイント台帳の整合性）

**解決する課題**: (1) mission bonus は count-then-insert 方式のため、二連打・HTTP 再送・OCC 競合下で**二重付与**が起き得る（fitness#14 の total_point 突合は self-consistent で検出不能、`dsql-data-model.md` §13.1 fitness#10 QM R3）。(2) optional 書込（combo/mission 等）の失敗は core を巻き込まない設計だが、「行が書かれない欠落」は drift=0 で**検出不能**（fitness#11 DB R1/QM R4/PO R1）。

**期待される効果**: bonus の exactly-once が DB の serialization point で構造保証され、「取れたはずのボーナスが 2 回入る/消える」不整合が排除される。optional 欠落は観測カウンタで欠落率が可視化され、silent degradation を検知できる。

## 関連 Issue

- EPIC #3424 / 実装 issue #3541（#N4-2 Phase C）の **cycle 2**。残 AC は service 結線（cutover 系 §12.2、EPIC 側で管理）のみのため closes は付けず、issue 完了判断は QM/PO に委ねる
- related: PR #3543（cycle 1 recordActivityCore、merged）/ #3539 / #3531

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC2-1 | optional 隔離: core commit 後の独立 mini-txn、各 point 付与も total_point 共更新（§8/§5 P7） | `npx vitest run tests/unit/db/dsql-optional-writes.test.ts` [O1][O2] | HEAD `6069d581` / 6 passed / grant-optional-points.ts:36-52（1 txn: ledger INSERT + total_point UPDATE）/ [O1] findTotalPointDrift=[] PASS / [O2] child 不在で ledger rollback PASS |
| AC2-2 | fitness#10: 同一 child 二連打で mission bonus 2 回になる TOCTOU を構造排除 | 同上 [F10-1][F10-2][F10-3] | HEAD `6069d581` / daily-mission-complete.ts:55-63（conditional UPDATE completed=false→true が serialization point）/ [F10-1] 二連打で bonus ledger 1 行 PASS / [F10-2] 最後の flip のみ daily bonus PASS / [F10-3] 再呼び出し付与なし PASS |
| AC2-3 | fitness#11: optional-write 失敗時に観測カウンタを emit し欠落率を可観測化 | 同上 [F11-1][F11-2] | HEAD `6069d581` / optional-write-guard.ts:24-38（swallow + injectable onFailure、db 層は analytics 非依存の層分離）/ [F11-1] 失敗で counter emit + null PASS / [F11-2] 成功で非発火 PASS |
| AC2-4 | daily_missions DDL（PK = manifest (family,child,mission_date,activity_id) 自然複合、§11.2 凍結） | `npx vitest run tests/unit/db/pk-freeze-manifest.test.ts tests/unit/db/dsql-temporal-parity.test.ts` | HEAD `6069d581` / schema.ts 末尾 dailyMissions / fitness#9 [3] PK==manifest PASS + fitness#6 temporal PASS（8 passed） |
| AC2-5 | fitness#7 allowlist 準拠（work 内 await は tx-bound のみ） | `npx vitest run tests/unit/architecture/dsql-txn-work-allowlist.test.ts` | HEAD `6069d581` / 6 passed（grant-optional-points / daily-mission-complete の work を実走査し違反 0） |

<!-- ac-verification-skip: issue #3541 の「service 層結線（DATA_SOURCE dispatch）」は cutover 系（設計 §12.2）として本 PR scope 外。演出契約（確定値のみ描画）は UI 実装を伴う cutover PR の AC -->

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（DSQL backend の新規モジュール + テストのみ。既存 sqlite/dynamo 経路・UI・service 層は未変更）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/db/dsql-optional-writes.test.ts` 新規（PGlite integration [O1][O2][F10-1..3][F11-1..2]: mini-txn 整合 / 片肺書込 rollback / 二連打 exactly-once / 欠落カウンタ）
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（DynamoDB 実装は未変更。DSQL backend 新設で、両実装整合は EPIC #3424 の cutover 計画 §12.2 が管理）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし**（server-side DB モジュール + unit test のみ。UI 変更・route 変更・表示文言変更を含まない）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（付与プリミティブ / mission 状態遷移 / 隔離 wrapper を 3 モジュール分離）/ 依存性逆転（`TransactionRunner` port + `SqlExecutor` 構造型。fitness#11 カウンタは injectable で db 層が analytics に依存しない層分離）
- [x] **DRY**: total_point 共更新パターンは §5 P7 の設計指定（core と optional で同型なのは不変条件の帰結）。`SqlExecutor`/runner は既存 seam を再利用
- [x] **YAGNI**: 汎用 retry/queue 等の先取りなし。fitness#10 は新規 UNIQUE を足さず §11.2 凍結 PK をそのまま serialization point に使う最小構成
- [x] **Security（OSS 公開前提）**: 秘密情報なし / SQL は全て drizzle `sql` テンプレートのパラメタバインド / 全文 `family_id =` 述語で tenant 境界維持（§P9）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: mission 完了 txn は PK プレフィクス lookup + 1-4 write。ledger への hot-row なし（bonus は once-per-day）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): 列レベル DDL は drizzle schema が SSOT（§11.3 委譲済）。§8/§13.1 のコード化であり設計変更なし
- [x] **並行 PR overlap** (#1200): `src/lib/server/db/dsql/**` を変更する open PR は他に無い
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新規モジュール追加のみ）

**レビュー依頼事項・QA**:
- fitness#10 の実現方式: 設計 §13.1 は「mission bonus に相当 guard 追加（自然キー UNIQUE or serialization test）」— 本 PR は point_ledger への生成列 UNIQUE ではなく **daily_missions の凍結 PK 行への conditional UPDATE を serialization point にする方式**を採った（新規 UNIQUE 不要・凍結 PK 活用・「最後の flip した txn が bonus 付与」で exactly-once）。設計意図との整合を確認いただきたい
- fitness#11 カウンタの emit 先: db 層は injectable callback とし、analytics への bind は service 結線 PR で行う層分離が妥当か

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（cycle 2 scope 全 AC 実装済。service 結線は cutover 系として issue #3541 で管理）
- [x] Phase 分割した場合: issue #3541 本文で cycle 1/2 分割を宣言済み
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
