### PR TITLE
feat: #3528 invite token_hash 生成・timing-safe 照合 util

### DIFF
--- a/src/lib/server/auth/invite-token.ts
+++ b/src/lib/server/auth/invite-token.ts
@@ -1,0 +1,60 @@
+// src/lib/server/auth/invite-token.ts
+// #3528: invite token_hash 生成 / timing-safe 照合 util (DSQL 移管 EPIC #3424)
+//
+// 設計 SSOT: docs/design/dsql-data-model.md §6.6 invites 行
+//   「token_hash（招待コードの timing-safe ハッシュ、raw 非保存）必須 =
+//     現行 inviteCode capability 機構の写像、bare bearer 化による機密性退行を防ぐ（CWE-522）」
+//
+// 設計判断 (OSS 先調査 #1350 / Pre-PMF ADR-0010):
+//   - node:crypto 標準 (randomBytes / createHash / timingSafeEqual) のみで実装し、新規依存は追加しない。
+//     repo 内の既存 crypto 慣行に整合:
+//       - randomBytes(32).toString('base64url') = viewer-token-service.ts の capability token 生成と同型
+//       - sha256 hex + timing-safe hex 比較 (長さ不一致は throw せず false) = pin-reset-otp.ts の
+//         timingSafeEqualHex と同パターン
+//       - HMAC (cookie-signature / context-token.ts) は「秘密鍵で署名する cookie / stateless payload」
+//         用途。invite token は DB に hash を保存して lookup する capability であり、鍵管理を増やさず
+//         sha256(token) で十分 (token 自体が 256bit 高エントロピーのため salt / pepper 不要、
+//         パスワードと違い辞書攻撃が成立しない)。
+//   - raw token は生成時に呼び出し元へ返すのみ。DB には tokenHash (UNIQUE(token_hash)) だけを保存する。
+
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+
+/** invite token のエントロピー (bytes)。32 bytes = 256 bit、base64url で 43 chars */
+export const INVITE_TOKEN_BYTES = 32;
+
+/**
+ * 招待 token を新規生成する。
+ *
+ * - token: crypto 安全乱数 32 bytes の base64url (URL-safe、招待リンクに埋め込む raw capability)
+ * - tokenHash: sha256(token) hex。DB (invites.token_hash) にはこちらのみ保存する (raw 非保存、CWE-522)
+ */
+export function generateInviteToken(): { token: string; tokenHash: string } {
+	const token = randomBytes(INVITE_TOKEN_BYTES).toString('base64url');
+	return { token, tokenHash: hashInviteToken(token) };
+}
+
+/**
+ * 提示された token を照合用にハッシュ化する (DB lookup キー算出)。
+ * generateInviteToken と同一写像 (sha256 hex 小文字) であることが contract。
+ */
+export function hashInviteToken(token: string): string {
+	return createHash('sha256').update(token, 'utf8').digest('hex');
+}
+
+/**
+ * 提示 token と保存済み token_hash を timing-safe に照合する。
+ *
+ * - 提示 token を hash してから比較するため、比較対象は常に固定長 (64 hex chars) になり
+ *   token 長による timing 差は生じない
+ * - storedHash が長さ不一致 / 不正でも throw せず false (timingSafeEqual の長さ例外を漏らさない、
+ *   pin-reset-otp.ts の timingSafeEqualHex と同パターン)
+ */
+export function verifyInviteTokenHash(presentedToken: string, storedHash: string): boolean {
+	const presentedHash = hashInviteToken(presentedToken);
+	if (presentedHash.length !== storedHash.length) return false;
+	try {
+		return timingSafeEqual(Buffer.from(presentedHash, 'utf8'), Buffer.from(storedHash, 'utf8'));
+	} catch {
+		return false;
+	}
+}

--- a/tests/unit/auth/invite-token.test.ts
+++ b/tests/unit/auth/invite-token.test.ts
@@ -1,0 +1,102 @@
+// tests/unit/auth/invite-token.test.ts
+// #3528: invite token_hash 生成 / timing-safe 照合 util のテスト (Canon TDD、ADR-0061)
+// 設計 SSOT: docs/design/dsql-data-model.md §6.6 invites 行
+//   「token_hash（招待コードの timing-safe ハッシュ、raw 非保存）必須 =
+//     現行 inviteCode capability 機構の写像、bare bearer 化による機密性退行を防ぐ（CWE-522）」
+
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+	generateInviteToken,
+	hashInviteToken,
+	verifyInviteTokenHash,
+} from '../../../src/lib/server/auth/invite-token';
+
+/** base64url 文字集合のみ許容 (padding なし、URL-safe) */
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+
+/** sha256 hex (64 chars) */
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+
+describe('generateInviteToken', () => {
+	it('token は 32 bytes 由来の base64url 文字列 (43 chars、padding なし)', () => {
+		const { token } = generateInviteToken();
+		// 32 bytes → base64url は 43 文字 (ceil(32*4/3) = 43、padding 除去)
+		expect(token).toHaveLength(43);
+		expect(token).toMatch(BASE64URL_RE);
+	});
+
+	it('tokenHash は sha256 hex (64 chars) で token 自身と一致する', () => {
+		const { token, tokenHash } = generateInviteToken();
+		expect(tokenHash).toMatch(SHA256_HEX_RE);
+		// 生成時 hash と照合用 hash 関数は同一写像 (DB lookup の前提)
+		expect(hashInviteToken(token)).toBe(tokenHash);
+		// 独立に計算した sha256(token) hex とも一致 (アルゴリズム固定の contract)
+		expect(tokenHash).toBe(createHash('sha256').update(token, 'utf8').digest('hex'));
+	});
+
+	it('tokenHash に raw token が含まれない (CWE-522: raw 非保存の前提)', () => {
+		const { token, tokenHash } = generateInviteToken();
+		expect(tokenHash).not.toContain(token);
+		expect(tokenHash.toLowerCase()).not.toContain(token.toLowerCase());
+	});
+
+	it('複数回生成で token / tokenHash が衝突しない (高エントロピー)', () => {
+		const tokens = new Set<string>();
+		const hashes = new Set<string>();
+		for (let i = 0; i < 100; i++) {
+			const { token, tokenHash } = generateInviteToken();
+			tokens.add(token);
+			hashes.add(tokenHash);
+		}
+		expect(tokens.size).toBe(100);
+		expect(hashes.size).toBe(100);
+	});
+});
+
+describe('hashInviteToken', () => {
+	it('同一 token → 同一 hash (決定的)', () => {
+		expect(hashInviteToken('abc')).toBe(hashInviteToken('abc'));
+	});
+
+	it('異なる token → 異なる hash', () => {
+		expect(hashInviteToken('abc')).not.toBe(hashInviteToken('abd'));
+	});
+
+	it('sha256 hex (64 chars 小文字) を返す', () => {
+		expect(hashInviteToken('any-token')).toMatch(SHA256_HEX_RE);
+	});
+});
+
+describe('verifyInviteTokenHash', () => {
+	it('正しい token と stored hash の組で true', () => {
+		const { token, tokenHash } = generateInviteToken();
+		expect(verifyInviteTokenHash(token, tokenHash)).toBe(true);
+	});
+
+	it('異なる token では false', () => {
+		const { tokenHash } = generateInviteToken();
+		const { token: otherToken } = generateInviteToken();
+		expect(verifyInviteTokenHash(otherToken, tokenHash)).toBe(false);
+	});
+
+	it('長さ不一致の stored hash でも throw せず false (timingSafeEqual の長さ例外を漏らさない)', () => {
+		const { token } = generateInviteToken();
+		expect(() => verifyInviteTokenHash(token, 'deadbeef')).not.toThrow();
+		expect(verifyInviteTokenHash(token, 'deadbeef')).toBe(false);
+		expect(verifyInviteTokenHash(token, '')).toBe(false);
+	});
+
+	it('1 文字違いの hash で false (同一長の負ケース)', () => {
+		const { token, tokenHash } = generateInviteToken();
+		const lastChar = tokenHash.at(-1) === '0' ? '1' : '0';
+		const tampered = tokenHash.slice(0, -1) + lastChar;
+		expect(tampered).toHaveLength(tokenHash.length);
+		expect(verifyInviteTokenHash(token, tampered)).toBe(false);
+	});
+
+	it('空 token でも throw せず false', () => {
+		const { tokenHash } = generateInviteToken();
+		expect(verifyInviteTokenHash('', tokenHash)).toBe(false);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 保護者（家族招待の安全性）+ システム全体

**解決する課題**: DSQL 移管後の invites テーブルは raw 招待コードを保存しない設計（`dsql-data-model.md` §6.6 token_hash、CWE-522: DB 漏えい時に有効な招待リンクが流出する bare bearer 化を防ぐ）だが、token の生成・timing-safe 照合 util が未実装で invite service の DSQL 結線に進めない。

**期待される効果**: 招待コードが DB 漏えい耐性を持つ capability として発行・照合でき、照合処理は timing attack にも耐える。

## 関連 Issue

- issue #3528（#N2-1 Phase B）残 AC「token_hash の生成・timing-safe 照合」。issue は fitness#3 / fitness#2 repo 束縛の残 AC があるため closes は付けない
- related: PR #3537（invites DDL + 受諾 txn、merged。本 util が hash 生成側を担う）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | generateInviteToken: 高エントロピー capability（randomBytes 32 = 256bit、base64url）+ sha256 hex の tokenHash。raw 非保存前提の API 形状 | `npx vitest run tests/unit/auth/invite-token.test.ts` | HEAD `04e20894` / 12 passed（base64url 43 chars 形式 / 100 回生成衝突ゼロ / hash に raw 非含有） |
| AC2 | verifyInviteTokenHash: timing-safe 照合（node:crypto timingSafeEqual、提示 token を先に hash して固定長比較 = token 長由来の timing 差なし。長さ不一致・不正 hash でも throw せず false） | 同上 | HEAD `04e20894` / verify 正・負・1 文字違い・長さ不一致・空 token の 5 ケース PASS / src/lib/server/auth/invite-token.ts:52-61 |
| AC3 | OSS 先調査（#1350）: 新規依存なしの根拠を記録 | コード先頭コメント + 本 PR body | HEAD `04e20894` / 既存慣行整合: viewer-token-service.ts（randomBytes base64url）/ pin-reset-otp.ts（sha256 + timingSafeEqualHex 同パターン）。HMAC 系（cookie-signature ADR-0050 / context-token.ts）は「秘密鍵で署名」用途で要件が異なるため不採用。token 自体が 256bit 乱数で辞書攻撃不成立のため salt/pepper 不要（パスワードハッシュとは別問題） |

<!-- ac-verification-skip: invites テーブルへの実配線（insert 時 tokenHash 保存 / accept 時 hashInviteToken lookup）は issue #3528 の auth repo 実装 PR の AC（本 PR は pure util のみ） -->

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（`src/lib/server/auth/invite-token.ts` 新規 util + テストのみ。既存コードからの参照ゼロ、既存挙動変更なし）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/auth/invite-token.test.ts` 新規 12 テスト（形式 / 衝突 / hash 一意性 / timing-safe verify 正負 / 例外非漏えい）
- [x] 新規 env / secret 追加時: N/A（鍵不要設計 — HMAC でなく sha256、根拠は AC3）
- [x] DynamoDB 実装変更時: N/A
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし**（server-side crypto util + unit test のみ。UI 変更なし）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（生成 / hash / 照合の 3 関数のみ）/ 依存ゼロ（node:crypto 標準のみ）
- [x] **DRY**: 既存の pin-reset-otp / viewer-token パターンに整合（新奇パターンを持ち込まない）
- [x] **YAGNI**: DB 配線・service 統合は後続 PR（pure util に限定）
- [x] **Security（OSS 公開前提）**: CWE-522 対応（raw 非保存）/ timing-safe 比較 / 例外から情報を漏らさない / 秘密情報 hardcode なし
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: sha256 単発、hot path でない

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): §6.6 の記載事項のコード化であり設計変更なし
- [x] **並行 PR overlap** (#1200): 新規ファイルのみで overlap なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新規 util のみ、参照ゼロ）

**レビュー依頼事項・QA**:
- HMAC + 秘密鍵でなく plain sha256 とした判断（AC3 の根拠: token 自体が 256bit 高エントロピーで辞書攻撃不成立、鍵管理を増やさない）がセキュリティポリシーと整合するか
- 本実装は並行 Agent (worktree 分離) が TDD で作成し、本体セッションがコードレビュー + pipeline 環境で再検証したもの

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（pure util scope。DB 配線は issue #3528 の後続 PR AC）
- [x] Phase 分割した場合: issue #3528 の残 AC 分割に準拠
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
