### PR TITLE
fix(security): #3549 role-mutation API の owner guard 統一 + invites owner 専用化 + UI 整合

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -387,6 +387,21 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 
 - **fitness function**: `tests/unit/routes/export-authz-symmetry-3246.test.ts` が「全 `/api/v1/**/export/**/+server.ts` が `requireRole(['owner', 'parent'])` を呼び、許可ロールに `'child'` を含まない」ことを契約テストで機械検証する（新規 export 追加時の gate 漏れを検出）。あわせて child role → 403 / parent role → gate 通過 の振る舞いを担保する。
 
+#### 5.2.3 role-mutation admin API の owner-gate（テナント権限昇格・招待濫用防止、#3549 / #3528）
+
+`ROUTE_RULES` の `/api/v1/admin/**` は owner / parent 両ロールの到達を許す（親管理画面の共通 API 群のため）。一方、テナントのメンバー構成・権限そのものを変える mutation（招待の発行・取消、メンバー削除、owner 移譲）は **owner 専用**とし、ハンドラ層で `requireRole(locals, ['owner'])` seam に統一して gate する。招待の発行・取消は従来 parent でも実行できたため、非 owner が家族メンバーを勝手に招待・排除できる濫用余地があった。これを owner-only に是正する（#3549 PO 決裁 (a)）。role 判定はルート横断の唯一の seam（`src/lib/server/auth/guards.ts` の `requireRole`）に集約し、ハンドラ内の ad-hoc な `context.role !== 'owner'` 判定を排する（#3528）。
+
+| role-mutation endpoint | 許可ロール（`requireRole`） | parent / child |
+|---|---|---|
+| `POST /api/v1/admin/invites`（招待発行、#3549） | `['owner']` | 403 |
+| `DELETE /api/v1/admin/invites/[code]`（招待取消、#3549） | `['owner']` | 403 |
+| `DELETE /api/v1/admin/members/[userId]`（メンバー削除） | `['owner']` | 403 |
+| `POST /api/v1/admin/members/[userId]/transfer-ownership`（owner 移譲） | `['owner']` | 403 |
+
+- **response 形の互換**: 既存 client（`admin/members/+page.svelte` が `d.error` を表示）が依存する `{ error: <日本語文言> }` body 形と 403 status を維持するため、`requireRole` が throw する `HttpError(403)` を `isHttpError(e, 403)` で捕捉し、endpoint 固有の `{ error }` JSON に変換して返す（401 等は re-throw）。
+- **UI 整合**: `admin/members/+page.svelte` は `currentRole === 'owner'` のときのみ招待リンク作成カード・保留中招待の取消ボタンを描画し、parent には招待 UI 自体を非表示にして 403 到達導線を消す（API gate と UI 非表示の二段）。
+- **fitness function**: `tests/unit/routes/admin-role-mutation-authz.test.ts` が 4 endpoint すべてで owner → 成功経路 / parent・child → 403 + `{ error }` body 維持、および判定が `requireRole(locals, ['owner'])` seam 経由であることを spy で機械検証する。
+
 ### 5.3 ライセンス状態による制限
 
 | ライセンス状態 | アクセス制限 |

--- a/scripts/create-owner-storage-state.mjs
+++ b/scripts/create-owner-storage-state.mjs
@@ -14,12 +14,17 @@
 import { parseArgs } from 'node:util';
 import { chromium } from 'playwright';
 
+// #3551: --email/--password で DEV_USERS の任意アカウント (parent 等) に汎用化 (#1442 使い捨て script 禁止)
 const { values } = parseArgs({
 	options: {
 		'base-url': { type: 'string', default: 'http://localhost:5174' },
 		output: { type: 'string', default: 'tmp/auth-state-owner.json' },
+		email: { type: 'string', default: 'owner@example.com' },
+		password: { type: 'string', default: 'Gq!Dev#Owner2026x' },
 	},
 });
+const EMAIL = values.email;
+const PASSWORD = values.password;
 
 const BASE_URL = values['base-url'];
 const OUTPUT = values.output;
@@ -29,7 +34,7 @@ const ctx = await browser.newContext();
 const page = await ctx.newPage();
 
 try {
-	console.log(`Logging in as owner@example.com at ${BASE_URL}/auth/login ...`);
+	console.log(`Logging in as ${EMAIL} at ${BASE_URL}/auth/login ...`);
 	await page.goto(`${BASE_URL}/auth/login`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
 	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 60_000 });
 	// `type="email"` への切替を待つ (cognito-dev では initial render が type="text")
@@ -42,11 +47,11 @@ try {
 	);
 
 	await page.getByLabel('メールアドレス').click();
-	for (const ch of 'owner@example.com') {
+	for (const ch of EMAIL) {
 		await page.keyboard.type(ch, { delay: 20 });
 	}
 	await page.getByLabel('パスワード', { exact: true }).click();
-	for (const ch of 'Gq!Dev#Owner2026x') {
+	for (const ch of PASSWORD) {
 		await page.keyboard.type(ch, { delay: 20 });
 	}
 	await page.locator('button[type="submit"]:not([disabled])').first().waitFor({

--- a/src/routes/(parent)/admin/members/+page.svelte
+++ b/src/routes/(parent)/admin/members/+page.svelte
@@ -311,7 +311,8 @@ const roleLabel = (role: string) => {
 		{/snippet}
 	</Card>
 
-	<!-- 招待リンク作成 -->
+	<!-- 招待リンク作成 (owner 専用、#3549 PO 決裁 (a): 招待の発行は owner のみ。API 側 guard と対) -->
+	{#if $page.data.currentRole === 'owner'}
 	<Card variant="default" padding="md" data-tutorial="members-invite">
 		{#snippet children()}
 		<h3 class="text-lg font-semibold text-[var(--color-text-secondary)] mb-3">{MEMBERS_LABELS.inviteSectionTitle}</h3>
@@ -399,6 +400,7 @@ const roleLabel = (role: string) => {
 		{/if}
 		{/snippet}
 	</Card>
+	{/if}
 
 	<!-- 保留中の招待 -->
 	{#if data.invites.length > 0}
@@ -417,13 +419,15 @@ const roleLabel = (role: string) => {
 								{MEMBERS_LABELS.inviteExpiresPrefix}{new Date(invite.expiresAt).toLocaleDateString('ja-JP')}
 							</span>
 						</div>
-						<Button
-							onclick={() => revokeInvite(invite.inviteCode)}
-							variant="danger"
-							size="sm"
-						>
-							{MEMBERS_LABELS.inviteRevokeButton}
-						</Button>
+						{#if $page.data.currentRole === 'owner'}
+							<Button
+								onclick={() => revokeInvite(invite.inviteCode)}
+								variant="danger"
+								size="sm"
+							>
+								{MEMBERS_LABELS.inviteRevokeButton}
+							</Button>
+						{/if}
 					</div>
 				{/each}
 			</div>

--- a/src/routes/api/v1/admin/invites/+server.ts
+++ b/src/routes/api/v1/admin/invites/+server.ts
@@ -2,9 +2,10 @@
 // GET  /api/v1/admin/invites — 招待一覧取得
 // (#0129, #1111)
 
-import { error, json } from '@sveltejs/kit';
+import { error, isHttpError, json } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createInviteSchema } from '$lib/domain/validation/auth';
+import { requireRole } from '$lib/server/auth/guards';
 import { validationError } from '$lib/server/errors';
 import { createInvite, listInvites } from '$lib/server/services/invite-service';
 import { checkFamilyMemberLimit } from '$lib/server/services/plan-limit-service';
@@ -26,6 +27,18 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		return json({ error: '認証が必要です' }, { status: 401 });
 	}
 	const tenantId = context.tenantId;
+
+	// #3549 決裁 (a): 招待作成は owner 専用。role 判定は requireRole seam (#3528 fitness#3)
+	// に統一し、response 形は既存 client 互換の {error} JSON を維持する
+	try {
+		requireRole(locals, ['owner']);
+	} catch (e) {
+		if (isHttpError(e, 403)) {
+			return json({ error: 'owner のみ招待を作成できます' }, { status: 403 });
+		}
+		throw e;
+	}
+
 	const identity = locals.identity;
 	if (!identity || identity.type !== 'cognito') {
 		error(401, 'Unauthorized');

--- a/src/routes/api/v1/admin/invites/[code]/+server.ts
+++ b/src/routes/api/v1/admin/invites/[code]/+server.ts
@@ -1,6 +1,7 @@
 // DELETE /api/v1/admin/invites/[code] — 招待取消し (#0129)
 
-import { json } from '@sveltejs/kit';
+import { isHttpError, json } from '@sveltejs/kit';
+import { requireRole } from '$lib/server/auth/guards';
 import { revokeInvite } from '$lib/server/services/invite-service';
 import type { RequestHandler } from './$types';
 
@@ -10,6 +11,18 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 		return json({ error: '認証が必要です' }, { status: 401 });
 	}
 	const tenantId = context.tenantId;
+
+	// #3549 決裁 (a): 招待取消は owner 専用。role 判定は requireRole seam (#3528 fitness#3)
+	// に統一し、response 形は既存 client 互換の {error} JSON を維持する
+	try {
+		requireRole(locals, ['owner']);
+	} catch (e) {
+		if (isHttpError(e, 403)) {
+			return json({ error: 'owner のみ招待を取り消しできます' }, { status: 403 });
+		}
+		throw e;
+	}
+
 	await revokeInvite(params.code, tenantId);
 	return json({ ok: true });
 };

--- a/src/routes/api/v1/admin/members/[userId]/+server.ts
+++ b/src/routes/api/v1/admin/members/[userId]/+server.ts
@@ -2,7 +2,8 @@
 // メンバー削除（owner のみ）
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { json } from '@sveltejs/kit';
+import { isHttpError, json } from '@sveltejs/kit';
+import { requireRole } from '$lib/server/auth/guards';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { sendMemberRemovedEmail } from '$lib/server/services/email-service';
@@ -15,8 +16,15 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 	const tenantId = context.tenantId;
 	const targetUserId = (params as Record<string, string>).userId ?? '';
 
-	if (context.role !== 'owner') {
-		return json({ error: 'owner のみメンバーを削除できます' }, { status: 403 });
+	// #3528: role 判定は requireRole seam に統一。response 形は既存 client
+	// (admin/members/+page.svelte が d.error を表示) 互換の {error} JSON を維持する
+	try {
+		requireRole(locals, ['owner']);
+	} catch (e) {
+		if (isHttpError(e, 403)) {
+			return json({ error: 'owner のみメンバーを削除できます' }, { status: 403 });
+		}
+		throw e;
 	}
 
 	if (!targetUserId) {

--- a/src/routes/api/v1/admin/members/[userId]/transfer-ownership/+server.ts
+++ b/src/routes/api/v1/admin/members/[userId]/transfer-ownership/+server.ts
@@ -2,7 +2,8 @@
 // owner 権限移譲（owner のみ）
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { json } from '@sveltejs/kit';
+import { isHttpError, json } from '@sveltejs/kit';
+import { requireRole } from '$lib/server/auth/guards';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { sendMemberJoinedEmail } from '$lib/server/services/email-service';
@@ -16,8 +17,15 @@ export const POST: RequestHandler = async ({ params, locals }) => {
 	const identity = locals.identity;
 	const targetUserId = (params as Record<string, string>).userId ?? '';
 
-	if (context.role !== 'owner') {
-		return json({ error: 'owner のみ権限を移譲できます' }, { status: 403 });
+	// #3528: role 判定は requireRole seam に統一。response 形は既存 client
+	// (admin/members/+page.svelte が d.error を表示) 互換の {error} JSON を維持する
+	try {
+		requireRole(locals, ['owner']);
+	} catch (e) {
+		if (isHttpError(e, 403)) {
+			return json({ error: 'owner のみ権限を移譲できます' }, { status: 403 });
+		}
+		throw e;
 	}
 
 	if (!identity || identity.type !== 'cognito') {

--- a/tests/unit/routes/admin-role-mutation-authz.test.ts
+++ b/tests/unit/routes/admin-role-mutation-authz.test.ts
@@ -49,6 +49,20 @@ vi.mock('$lib/server/services/email-service', () => ({
 	sendMemberRemovedEmail: vi.fn().mockResolvedValue(undefined),
 }));
 
+// #3549 決裁 (a): invites 作成・取消の owner 専用化のための service mocks
+const mockCreateInvite = vi.fn();
+const mockRevokeInvite = vi.fn();
+vi.mock('$lib/server/services/invite-service', () => ({
+	createInvite: (...args: unknown[]) => mockCreateInvite(...args),
+	revokeInvite: (...args: unknown[]) => mockRevokeInvite(...args),
+	listInvites: vi.fn().mockResolvedValue([]),
+}));
+
+const mockCheckFamilyMemberLimit = vi.fn();
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	checkFamilyMemberLimit: (...args: unknown[]) => mockCheckFamilyMemberLimit(...args),
+}));
+
 vi.mock('$lib/server/logger', () => ({
 	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
@@ -58,6 +72,10 @@ const { POST: transferOwnership } = await import(
 );
 const { DELETE: deleteMember } = await import(
 	'../../../src/routes/api/v1/admin/members/[userId]/+server'
+);
+const { POST: createInvitePost } = await import('../../../src/routes/api/v1/admin/invites/+server');
+const { DELETE: revokeInviteDelete } = await import(
+	'../../../src/routes/api/v1/admin/invites/[code]/+server'
 );
 
 // ---------- helpers ----------
@@ -73,6 +91,30 @@ function createEvent(role: Role, opts: { userId?: string; callerUserId?: string 
 			identity: { type: 'cognito', userId: callerUserId },
 		},
 	} as unknown as Parameters<NonNullable<typeof transferOwnership>>[0];
+}
+
+function createInviteCreateEvent(role: Role) {
+	return {
+		request: new Request('http://localhost/api/v1/admin/invites', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ role: 'parent' }),
+		}),
+		locals: {
+			context: { tenantId: 't-test', role, licenseStatus: 'active' },
+			identity: { type: 'cognito', userId: 'u-caller' },
+		},
+	} as unknown as Parameters<NonNullable<typeof createInvitePost>>[0];
+}
+
+function createInviteRevokeEvent(role: Role) {
+	return {
+		params: { code: 'invite-code-1' },
+		locals: {
+			context: { tenantId: 't-test', role },
+			identity: { type: 'cognito', userId: 'u-caller' },
+		},
+	} as unknown as Parameters<NonNullable<typeof revokeInviteDelete>>[0];
 }
 
 // ---------- tests ----------
@@ -159,6 +201,80 @@ describe('owner 専用 member mutation API の requireRole seam 統一 (#3528 fi
 			expect(res.status).toBe(403);
 			await expect(res.json()).resolves.toEqual({ error: 'owner のみメンバーを削除できます' });
 			expect(mockRepos.auth.deleteMembership).not.toHaveBeenCalled();
+		});
+	});
+
+	// #3549 PO 決裁 判断1 = (a): 招待作成・取消は owner 専用
+	describe('POST /api/v1/admin/invites (#3549 (a) 招待作成の owner 専用化)', () => {
+		beforeEach(() => {
+			mockCheckFamilyMemberLimit.mockResolvedValue({ allowed: true, current: 1, max: 6 });
+			mockCreateInvite.mockResolvedValue({ inviteCode: 'new-code', role: 'parent' });
+		});
+
+		it('owner は成功経路に入る (positive)', async () => {
+			const res = await createInvitePost(createInviteCreateEvent('owner'));
+			expect(res.status).toBe(201);
+			await expect(res.json()).resolves.toMatchObject({
+				invite: { inviteCode: 'new-code' },
+			});
+			expect(mockCreateInvite).toHaveBeenCalledWith('t-test', 'u-caller', 'parent', undefined);
+		});
+
+		it('owner 判定は requireRole seam 経由で行われる', async () => {
+			await createInvitePost(createInviteCreateEvent('owner'));
+			expect(requireRoleSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ context: expect.objectContaining({ role: 'owner' }) }),
+				['owner'],
+			);
+		});
+
+		it('parent は 403 + {error} body (negative: 現実装では parent が成功するため red)', async () => {
+			const res = await createInvitePost(createInviteCreateEvent('parent'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ招待を作成できます' });
+			expect(mockCreateInvite).not.toHaveBeenCalled();
+		});
+
+		it('child は 403 (negative)', async () => {
+			const res = await createInvitePost(createInviteCreateEvent('child'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ招待を作成できます' });
+			expect(mockCreateInvite).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('DELETE /api/v1/admin/invites/[code] (#3549 (a) 招待取消の owner 専用化)', () => {
+		beforeEach(() => {
+			mockRevokeInvite.mockResolvedValue(undefined);
+		});
+
+		it('owner は成功経路に入る (positive)', async () => {
+			const res = await revokeInviteDelete(createInviteRevokeEvent('owner'));
+			expect(res.status).toBe(200);
+			await expect(res.json()).resolves.toEqual({ ok: true });
+			expect(mockRevokeInvite).toHaveBeenCalledWith('invite-code-1', 't-test');
+		});
+
+		it('owner 判定は requireRole seam 経由で行われる', async () => {
+			await revokeInviteDelete(createInviteRevokeEvent('owner'));
+			expect(requireRoleSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ context: expect.objectContaining({ role: 'owner' }) }),
+				['owner'],
+			);
+		});
+
+		it('parent は 403 + {error} body (negative: 現実装では parent が成功するため red)', async () => {
+			const res = await revokeInviteDelete(createInviteRevokeEvent('parent'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ招待を取り消しできます' });
+			expect(mockRevokeInvite).not.toHaveBeenCalled();
+		});
+
+		it('child は 403 (negative)', async () => {
+			const res = await revokeInviteDelete(createInviteRevokeEvent('child'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ招待を取り消しできます' });
+			expect(mockRevokeInvite).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/tests/unit/routes/admin-role-mutation-authz.test.ts
+++ b/tests/unit/routes/admin-role-mutation-authz.test.ts
@@ -1,0 +1,164 @@
+// tests/unit/routes/admin-role-mutation-authz.test.ts
+// #3528 fitness#3 (behavior-preserving): owner 専用 API の ad-hoc role 判定を
+// requireRole seam (src/lib/server/auth/guards.ts) に統一する回帰テスト。
+//
+// テスト観点:
+// - transfer-ownership POST / members DELETE の両 route が requireRole(locals, ['owner'])
+//   seam を経由して判定していること (red: 現実装はインライン context.role !== 'owner' 判定で
+//   requireRole を呼ばないため spy assertion が fail する)
+// - negative (parent / child): 403 + 既存 client (admin/members/+page.svelte が d.error を表示)
+//   が依存する `{ error: <既存日本語文言> }` body 形が維持されること (回帰固定: 現実装でも green)
+// - positive (owner): 成功経路に入り `{ success: true }` が返ること (回帰固定: 現実装でも green)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------- mocks ----------
+
+// requireRole seam の spy: 実装 (throw error(401/403)) はそのまま使い、呼び出しを観測する
+const requireRoleSpy = vi.fn();
+vi.mock('$lib/server/auth/guards', async () => {
+	const actual =
+		await vi.importActual<typeof import('../../../src/lib/server/auth/guards')>(
+			'$lib/server/auth/guards',
+		);
+	return {
+		...actual,
+		requireRole: (...args: Parameters<typeof actual.requireRole>) => {
+			requireRoleSpy(...args);
+			return actual.requireRole(...args);
+		},
+	};
+});
+
+const mockRepos = {
+	auth: {
+		findMembership: vi.fn(),
+		deleteMembership: vi.fn(),
+		createMembership: vi.fn(),
+		updateTenantOwner: vi.fn(),
+		findUserById: vi.fn(),
+		findTenantById: vi.fn(),
+	},
+};
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => mockRepos,
+}));
+
+vi.mock('$lib/server/services/email-service', () => ({
+	sendMemberJoinedEmail: vi.fn().mockResolvedValue(undefined),
+	sendMemberRemovedEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { POST: transferOwnership } = await import(
+	'../../../src/routes/api/v1/admin/members/[userId]/transfer-ownership/+server'
+);
+const { DELETE: deleteMember } = await import(
+	'../../../src/routes/api/v1/admin/members/[userId]/+server'
+);
+
+// ---------- helpers ----------
+
+type Role = 'owner' | 'parent' | 'child';
+
+function createEvent(role: Role, opts: { userId?: string; callerUserId?: string } = {}) {
+	const { userId = 'u-target', callerUserId = 'u-caller' } = opts;
+	return {
+		params: { userId },
+		locals: {
+			context: { tenantId: 't-test', role },
+			identity: { type: 'cognito', userId: callerUserId },
+		},
+	} as unknown as Parameters<NonNullable<typeof transferOwnership>>[0];
+}
+
+// ---------- tests ----------
+
+describe('owner 専用 member mutation API の requireRole seam 統一 (#3528 fitness#3)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRepos.auth.findMembership.mockResolvedValue({ role: 'parent' });
+		mockRepos.auth.deleteMembership.mockResolvedValue(undefined);
+		mockRepos.auth.createMembership.mockResolvedValue(undefined);
+		mockRepos.auth.updateTenantOwner.mockResolvedValue(undefined);
+		mockRepos.auth.findUserById.mockResolvedValue({
+			email: 'target@example.com',
+			displayName: 'ターゲット',
+		});
+		mockRepos.auth.findTenantById.mockResolvedValue({ name: 'テスト家族' });
+	});
+
+	describe('POST /api/v1/admin/members/[userId]/transfer-ownership', () => {
+		it('owner は成功経路に入る (positive、回帰固定)', async () => {
+			const res = await transferOwnership(createEvent('owner'));
+			expect(res.status).toBe(200);
+			await expect(res.json()).resolves.toMatchObject({ success: true });
+			expect(mockRepos.auth.updateTenantOwner).toHaveBeenCalledWith('t-test', 'u-target');
+		});
+
+		it('owner 判定は requireRole seam 経由で行われる (red → green)', async () => {
+			await transferOwnership(createEvent('owner'));
+			expect(requireRoleSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ context: expect.objectContaining({ role: 'owner' }) }),
+				['owner'],
+			);
+		});
+
+		it('parent は 403 + 既存 {error} body 形を維持 (negative、client d.error 依存の互換固定)', async () => {
+			const res = await transferOwnership(createEvent('parent'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ権限を移譲できます' });
+			expect(mockRepos.auth.deleteMembership).not.toHaveBeenCalled();
+			expect(mockRepos.auth.updateTenantOwner).not.toHaveBeenCalled();
+		});
+
+		it('parent 拒否も requireRole seam 経由で判定される (red → green)', async () => {
+			await transferOwnership(createEvent('parent'));
+			expect(requireRoleSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ context: expect.objectContaining({ role: 'parent' }) }),
+				['owner'],
+			);
+		});
+
+		it('child は 403 (negative)', async () => {
+			const res = await transferOwnership(createEvent('child'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ権限を移譲できます' });
+			expect(mockRepos.auth.updateTenantOwner).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('DELETE /api/v1/admin/members/[userId]', () => {
+		it('owner は成功経路に入る (positive、回帰固定)', async () => {
+			const res = await deleteMember(createEvent('owner'));
+			expect(res.status).toBe(200);
+			await expect(res.json()).resolves.toMatchObject({ success: true });
+			expect(mockRepos.auth.deleteMembership).toHaveBeenCalledWith('u-target', 't-test');
+		});
+
+		it('owner 判定は requireRole seam 経由で行われる (red → green)', async () => {
+			await deleteMember(createEvent('owner'));
+			expect(requireRoleSpy).toHaveBeenCalledWith(
+				expect.objectContaining({ context: expect.objectContaining({ role: 'owner' }) }),
+				['owner'],
+			);
+		});
+
+		it('parent は 403 + 既存 {error} body 形を維持 (negative、client d.error 依存の互換固定)', async () => {
+			const res = await deleteMember(createEvent('parent'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみメンバーを削除できます' });
+			expect(mockRepos.auth.deleteMembership).not.toHaveBeenCalled();
+		});
+
+		it('child は 403 (negative)', async () => {
+			const res = await deleteMember(createEvent('child'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみメンバーを削除できます' });
+			expect(mockRepos.auth.deleteMembership).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 保護者（家族グループの権限安全性）+ システム全体

**解決する課題**: (1) 招待の発行・取消 API に owner guard が無く、**parent role でも招待リンクを発行・取消できた**（fitness#3 調査 2026-07-03 で検出。招待 = role 付き membership 発行の起点であり、owner の意図しないメンバー追加経路になる）。(2) 既に owner-gate 済みの member 削除 / owner 移譲も ad-hoc なインライン role 判定で、guard の付け忘れを構造的に防げない。

**期待される効果**: 家族グループの構成変更（招待・削除・移譲）が owner に一元化され（issue #3549 PO 決裁 (a)）、guard は `requireRole` seam に統一されて positive/negative テストで回帰固定される。parent には招待 UI 自体が表示されず、403 に到達する導線が消える。

## 関連 Issue

- **issue #3549（PO 決裁 2026-07-03: 判断1 = (a) 招待作成/取消の owner 専用化）** — 判断1 を本 PR で実装。判断2（email 束縛の現行経路適用）は別 PR のため closes は付けない
- issue #3528（#N2-1）fitness#3 の一部（requireRole seam 統一 + parent→403 negative test）
- related: `dsql-data-model.md` §6.6 ⚠️ / §13.1 fitness#3 / EPIC #3424

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 招待作成 (POST /api/v1/admin/invites) を owner 専用化（parent/child → 403） | `npx vitest run tests/unit/routes/admin-role-mutation-authz.test.ts` | HEAD `3764a597` / 17 passed / **failing-test-first 実測: guard 追加前は parent が `expected 201 to be 403` で成功していた**（commit e21b7c4b message に red 出力記録） |
| AC2 | 招待取消 (DELETE /api/v1/admin/invites/[code]) を owner 専用化 | 同上 | HEAD `3764a597` / guard 追加前は `expected 200 to be 403`（parent が取消可能だった実測）→ 追加後 403 PASS |
| AC3 | 既 owner-gate 済み 2 route（transfer-ownership / members DELETE）の ad-hoc 判定を `requireRole(locals,['owner'])` seam（guards.ts:29）に統一。403 status + `{error}` body の既存互換維持 | 同上（seam 経由 spy + response 形 pin） | HEAD `3764a597` / seam spy「requireRole 呼び出し」assert + 403 body 既存文言一致 / guards.ts は無変更（20+ 既存 callsite 無影響） |
| AC4 | UI 整合: parent には招待作成フォーム・招待取消ボタンを表示しない（保留中招待の閲覧は従来通り） | SS 4 スロット（下記）+ `npx vitest run tests/unit/routes/` | HEAD `3764a597` / Before: parent に「メンバーを招待」Card 表示 → After: 非表示（SS 参照）/ 343 passed |
| AC5 | 既存挙動の無退行（owner の全操作 / service 層 / 広域 suite） | `npx vitest run tests/unit/routes/ tests/unit/auth/ tests/unit/services/` | HEAD `3764a597` / **2776 tests 全 pass**（既存テストの expectation 変更ゼロ） |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: `/admin/members`（parent ログイン時のみ: 招待作成 Card と招待取消ボタンが非表示化。owner 表示は不変）。API: invites POST/DELETE が parent/child に 403。scripts/create-owner-storage-state.mjs に --email/--password 追加（SS 撮影用の汎用化、既定値は従来互換）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3551` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/routes/admin-role-mutation-authz.test.ts` 新設 17 tests（4 route × owner positive / seam spy / parent 403 / child 403。invites 2 route は failing-test-first で脆弱性を実測してから green 化）
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（repo 層未変更、route guard のみ）
- [x] Critical バグ修正の場合: N/A（priority:critical ラベルなし）

## スクリーンショット / ビジュアルデモ

**撮影条件**: `npm run dev:cognito`（#1026）+ DEV_USERS **parent アカウント**でログイン（変更が現れるのは parent 視点。owner 視点は不変のため Before/After 同一になり添付対象外）。DOM スナップショット併記（#1747/#1766）。

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3551/before-admin-members-mobile.png) | ![before-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3551/before-admin-members-desktop.png) |
| **修正後** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3551/after-admin-members-mobile.png) | ![after-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3551/after-admin-members-desktop.png) |

DOM: [before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3551/before-admin-members-mobile.dom.html) / [before-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3551/before-admin-members-desktop.dom.html) / [after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3551/after-admin-members-mobile.dom.html) / [after-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3551/after-admin-members-desktop.dom.html)

**インタラクティブ状態**: N/A（条件表示の除去のみ。エラー/空状態の変化なし）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（API guard / UI 表示 / SS ツール汎用化を commit 分離）/ 依存性逆転（requireRole seam 経由、guards.ts 無変更）
- [x] **DRY**: 4 route の owner guard が同一 seam + 同一 try/catch パターンに統一。403 文言は既存「owner のみ〜できます」系列（route 直書きが members 系の既存流儀、labels.ts 対象の新概念文言ではない）
- [x] **YAGNI**: 招待一覧の閲覧制限・email 束縛（#3549 判断2）は scope 外に保持
- [x] **Security（OSS 公開前提）**: 垂直権限昇格経路（parent の招待発行）の封鎖が本 PR の主目的。OWASP A01 Broken Access Control 対応。UI 非表示は防御でなく UX（防御は API 側 guard）
- [x] **アクセシビリティ**: 条件表示の除去のみで既存 primitives 不変 / N/A
- [x] **パフォーマンス**: N/A（guard 1 関数呼び出しの追加のみ）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [x] **labels SSOT** (ADR-0009): 新規表示文言なし（403 の error body は members 系 route 既存流儀の同系列文言。UI 文言は既存 MEMBERS_LABELS のまま）
- [x] **設計書同期** (ADR-0001): §6.6 ⚠️ セキュリティ不変条件の実装であり設計変更なし。同型の owner-only ad-hoc 判定が tenant/cancel 等 5 箇所に残存する件は error body 統一（ADR-0062 系）と合わせて別 issue 起票が適切（レビュー依頼事項参照）
- [x] **並行 PR overlap** (#1200): 変更 route/svelte を触る open PR は他に無い
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**影響範囲**: parent role のユーザーは招待の発行・取消ができなくなる（issue #3549 PO 決裁 (a) による意図的な仕様変更）。既存データへの影響なし、マイグレーション不要。発行済み招待リンクの有効性は不変。

**レビュー依頼事項・QA**:
- 同型の owner-only ad-hoc 判定が `tenant/cancel` / `tenant/reactivate` / `account/delete` 系 5 箇所に残存。seam 統一の横展開 + error body 形の統一（ADR-0062）を別 issue で扱う想定の妥当性
- E2E `features.spec.ts:756`（招待取消の冪等 200）は local auth provider が owner 固定のため静的には無影響と確認済みだが、E2E レーンでの実確認をお願いしたい

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3551` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（#3549 判断1 scope。判断2 は別 PR として issue で管理）
- [x] Phase 分割した場合: issue #3549 で判断1/判断2 の分割を宣言済み
- [x] UI 変更時: SS 4 スロット + DOM HTML 併記済み、DESIGN.md §9 禁忌 6 点を目視確認（hex 直書きなし / primitives 不変 / 内部コード露出なし / 文言 SSOT 維持 / インラインスタイル追加なし / style ブロック不変）
- [x] 認証画面変更時: `npm run dev:cognito`（#1026）で parent 実ログインの SS を添付済み

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
