### PR TITLE
feat(security): #3549 招待 email 束縛 (宛先指定招待 + 受諾時照合)

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -402,6 +402,16 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 - **UI 整合**: `admin/members/+page.svelte` は `currentRole === 'owner'` のときのみ招待リンク作成カード・保留中招待の取消ボタンを描画し、parent には招待 UI 自体を非表示にして 403 到達導線を消す（API gate と UI 非表示の二段）。
 - **fitness function**: `tests/unit/routes/admin-role-mutation-authz.test.ts` が 4 endpoint すべてで owner → 成功経路 / parent・child → 403 + `{ error }` body 維持、および判定が `requireRole(locals, ['owner'])` seam 経由であることを spy で機械検証する。
 
+#### 5.2.4 招待の宛先 email 束縛（招待リンク横流し防止、#3549 判断2）
+
+招待作成時に任意の宛先 email を指定でき、指定した場合は**受諾者の検証済み email と case-insensitive 一致を必須**にする。email 指定なしの招待リンクは URL を知る任意の第三者が受諾でき、SNS 共有・転送・盗聴による別人受諾（横流し）の余地があったため、宛先を固定して正規宛先以外の受諾を塞ぐ。
+
+- **作成時（`createInvite` / `POST /api/v1/admin/invites`）**: 任意パラメータ `email` を受け付け、設定時は `trim().toLowerCase()` で正規化して保存する（照合は case-insensitive、`email_lower` と同原則）。空文字は未設定扱い。
+- **受諾時（`acceptInvite(inviteCode, userId, userEmail?)`）**: `invite.email` 設定時は、受諾 user の email と case-insensitive 一致必須。不一致・`userEmail` 未提供はいずれも **fail-closed** で `INVITE_EMAIL_MISMATCH` を返し、**招待は消費せず pending のまま保持**する（正規宛先による後続受諾の可能性を残す）。
+- **照合対象は Cognito 検証済みの `identity.email`**（呼出元 `providers/cognito.ts` が渡す、サーバ由来でクライアント改竄不可）である。クライアント入力値は照合材料にしない。
+- **email 未指定の招待は従来通り受諾可**（email を持たない受諾者向け、child 招待等）。この nullable 設計は [dsql-data-model.md §6.6](dsql-data-model.md) の invite email フィールド設計と一致する。
+- **fitness function**: `tests/unit/services/invite-service.test.ts` が email 一致（大小文字差含む）→ 受諾成功 / 不一致・未提供 → `INVITE_EMAIL_MISMATCH` + 招待 pending 保持 / email 未指定 → 従来通り受諾可、を検証する。
+
 ### 5.3 ライセンス状態による制限
 
 | ライセンス状態 | アクセス制限 |

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -3648,6 +3648,9 @@ export const MEMBERS_LABELS = {
 	// Invite section
 	inviteSectionTitle: 'メンバーを招待',
 	inviteRoleLabel: '招待ロール',
+	// #3549 判断2: 宛先 email 束縛 (任意入力。設定時は招待リンクをその email のアカウントでのみ受諾可能)
+	inviteEmailLabel: '宛先メールアドレス（任意）',
+	inviteEmailHint: '入力すると、このメールアドレスのアカウントだけが招待を受諾できます',
 	inviteChildLabel: '対象の子供（任意）',
 	inviteChildNone: '-- 後で紐づけ --',
 	inviteCreateLoading: '作成中...',

--- a/src/lib/domain/validation/auth.ts
+++ b/src/lib/domain/validation/auth.ts
@@ -70,4 +70,11 @@ export const INVITE_EXPIRY_DAYS = 7;
 export const createInviteSchema = z.object({
 	role: z.enum(['parent', 'child']),
 	childId: z.number().optional(),
+	// #3549 判断2: 宛先 email (任意)。設定時は受諾者 email 束縛 (§6.6)。空文字は未設定扱い
+	email: z
+		.string()
+		.trim()
+		.email('有効なメールアドレスを入力してください')
+		.optional()
+		.or(z.literal('').transform(() => undefined)),
 });

--- a/src/lib/server/auth/entities.ts
+++ b/src/lib/server/auth/entities.ts
@@ -84,6 +84,8 @@ export interface Invite {
 	invitedBy: string;
 	role: Role;
 	childId?: number;
+	/** #3549 判断2 (§6.6 ⚠️): 設定時は受諾 user の email と一致必須 (横流し防止)。小文字正規化して保存 */
+	email?: string;
 	status: InviteStatus;
 	createdAt: string;
 	expiresAt: string;
@@ -96,6 +98,8 @@ export interface CreateInviteInput {
 	invitedBy: string;
 	role: Role;
 	childId?: number;
+	/** 宛先 email (任意)。設定時は受諾者 email 束縛が有効になる (#3549 判断2) */
+	email?: string;
 }
 
 /** 同意種別の固定集合。

--- a/src/lib/server/auth/providers/cognito.ts
+++ b/src/lib/server/auth/providers/cognito.ts
@@ -219,7 +219,7 @@ export class CognitoAuthProvider implements AuthProvider {
 			}
 
 			// 招待受諾
-			const result = await acceptInvite(inviteCode, effectiveUserId);
+			const result = await acceptInvite(inviteCode, effectiveUserId, identity.email);
 
 			// Cookie を消費（成功でも失敗でも消す）
 			this.clearInviteCookie(event);

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -423,6 +423,7 @@ export const createInvite: IAuthRepo['createInvite'] = async (input) => {
 		invitedBy: input.invitedBy,
 		role: input.role,
 		childId: input.childId,
+		...(input.email ? { email: input.email } : {}),
 		status: 'pending',
 		createdAt: now.toISOString(),
 		expiresAt: expiresAt.toISOString(),

--- a/src/lib/server/services/invite-service.ts
+++ b/src/lib/server/services/invite-service.ts
@@ -15,11 +15,14 @@ export async function createInvite(
 	invitedBy: string,
 	role: Role,
 	childId?: number,
+	email?: string,
 ): Promise<Invite> {
 	if (role === 'owner') {
 		throw new Error('ownerロールでの招待はできません');
 	}
-	return repos().auth.createInvite({ tenantId, invitedBy, role, childId });
+	// #3549 判断2: 宛先 email は小文字正規化して保存 (照合は case-insensitive、email_lower と同原則)
+	const normalizedEmail = email?.trim().toLowerCase() || undefined;
+	return repos().auth.createInvite({ tenantId, invitedBy, role, childId, email: normalizedEmail });
 }
 
 /** 招待コードで招待を検索。期限切れの場合は自動で expired に更新 */
@@ -46,6 +49,7 @@ export async function getInvite(inviteCode: string): Promise<Invite | null> {
 export async function acceptInvite(
 	inviteCode: string,
 	userId: string,
+	userEmail?: string,
 ): Promise<{ membership: Membership } | { error: string }> {
 	const invite = await getInvite(inviteCode);
 	if (!invite) {
@@ -55,6 +59,13 @@ export async function acceptInvite(
 	// 自己招待防止 (#0203)
 	if (invite.invitedBy === userId) {
 		return { error: 'SELF_INVITE_NOT_ALLOWED' };
+	}
+
+	// 宛先 email 束縛 (#3549 判断2 / dsql-data-model.md §6.6 ⚠️): invite.email 設定時は
+	// 受諾 user の email と case-insensitive 一致必須。未提供は fail-closed (招待リンクの
+	// 横流しによる別人受諾を防ぐ)。招待は消費せず pending のまま (正規宛先の受諾可能性を保持)。
+	if (invite.email && invite.email.toLowerCase() !== userEmail?.trim().toLowerCase()) {
+		return { error: 'INVITE_EMAIL_MISMATCH' };
 	}
 
 	// 1ユーザー=1テナント制約チェック

--- a/src/routes/(parent)/admin/members/+page.svelte
+++ b/src/routes/(parent)/admin/members/+page.svelte
@@ -11,6 +11,7 @@ import NativeSelect from '$lib/ui/primitives/NativeSelect.svelte';
 let { data } = $props();
 
 let inviteRole = $state<'parent' | 'child'>('parent');
+let inviteEmail = $state('');
 let inviteChildId = $state<number | '' | undefined>(undefined);
 let creating = $state(false);
 let inviteLink = $state('');
@@ -33,9 +34,13 @@ async function createInvite() {
 	qrDataUrl = '';
 	copied = false;
 	try {
-		const body: { role: string; childId?: number } = { role: inviteRole };
+		const body: { role: string; childId?: number; email?: string } = { role: inviteRole };
 		if (inviteRole === 'child' && inviteChildId) {
 			body.childId = inviteChildId;
+		}
+		// #3549 判断2: 宛先 email (任意)。設定時は受諾者 email 束縛が有効になる
+		if (inviteEmail.trim()) {
+			body.email = inviteEmail.trim();
 		}
 		const res = await fetch('/api/v1/admin/invites', {
 			method: 'POST',
@@ -331,6 +336,14 @@ const roleLabel = (role: string) => {
 					/>
 				{/snippet}
 			</FormField>
+			<FormField
+				label={MEMBERS_LABELS.inviteEmailLabel}
+				id="invite-email"
+				type="email"
+				hint={MEMBERS_LABELS.inviteEmailHint}
+				bind:value={inviteEmail}
+				class="flex-1 min-w-[200px]"
+			/>
 			{#if inviteRole === 'child' && availableChildren.length > 0}
 				<FormField label={MEMBERS_LABELS.inviteChildLabel} class="flex-1 min-w-[120px]">
 					{#snippet children()}

--- a/src/routes/api/v1/admin/invites/+server.ts
+++ b/src/routes/api/v1/admin/invites/+server.ts
@@ -66,7 +66,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		);
 	}
 
-	const invite = await createInvite(tenantId, userId, parsed.data.role, parsed.data.childId);
+	const invite = await createInvite(
+		tenantId,
+		userId,
+		parsed.data.role,
+		parsed.data.childId,
+		parsed.data.email,
+	);
 
 	return json({ invite }, { status: 201 });
 };

--- a/tests/unit/routes/admin-role-mutation-authz.test.ts
+++ b/tests/unit/routes/admin-role-mutation-authz.test.ts
@@ -217,7 +217,14 @@ describe('owner 専用 member mutation API の requireRole seam 統一 (#3528 fi
 			await expect(res.json()).resolves.toMatchObject({
 				invite: { inviteCode: 'new-code' },
 			});
-			expect(mockCreateInvite).toHaveBeenCalledWith('t-test', 'u-caller', 'parent', undefined);
+			// #3549 判断2: email 引数 (未入力時 undefined) が追加された 5 引数形
+			expect(mockCreateInvite).toHaveBeenCalledWith(
+				't-test',
+				'u-caller',
+				'parent',
+				undefined,
+				undefined,
+			);
 		});
 
 		it('owner 判定は requireRole seam 経由で行われる', async () => {

--- a/tests/unit/services/invite-service.test.ts
+++ b/tests/unit/services/invite-service.test.ts
@@ -259,3 +259,74 @@ describe('listInvites', () => {
 		expect(result).toHaveLength(2);
 	});
 });
+
+// #3549 判断2 (PO 決裁 2026-07-03) / dsql-data-model.md §6.6 ⚠️:
+// invite.email 設定時は受諾 user の email と一致必須 (招待リンク横流しによる別人受諾防止)。
+// email 未設定の招待は従来通り (opt-in 束縛、child 招待等 email を持たない受諾者向け)。
+describe('招待 email 束縛 (#3549 判断2 / §6.6)', () => {
+	it('invite.email 設定 + 受諾者 email 不一致 → INVITE_EMAIL_MISMATCH (membership 未作成)', async () => {
+		inviteStore.set(
+			'em-1',
+			makePendingInvite({ inviteCode: 'em-1', email: 'intended@example.com' }),
+		);
+		tenantStore.set('t-test', {
+			tenantId: 't-test',
+			status: 'active',
+			createdAt: new Date().toISOString(),
+		} as Tenant);
+
+		const result = assertError(await acceptInvite('em-1', 'user-new', 'attacker@example.com'));
+		expect(result.error).toBe('INVITE_EMAIL_MISMATCH');
+		expect(membershipStore).toHaveLength(0);
+		// 招待は pending のまま (再受諾可能性を保持、消費しない)
+		expect(inviteStore.get('em-1')?.status).toBe('pending');
+	});
+
+	it('大文字小文字差は一致扱い (email_lower と同じ case-insensitive 原則)', async () => {
+		inviteStore.set(
+			'em-2',
+			makePendingInvite({ inviteCode: 'em-2', email: 'Intended@Example.com' }),
+		);
+		tenantStore.set('t-test', {
+			tenantId: 't-test',
+			status: 'active',
+			createdAt: new Date().toISOString(),
+		} as Tenant);
+
+		const result = assertSuccess(await acceptInvite('em-2', 'user-new', 'intended@example.com'));
+		expect(result.membership.tenantId).toBe('t-test');
+	});
+
+	it('invite.email 設定 + 受諾者 email 未提供 → INVITE_EMAIL_MISMATCH (fail-closed)', async () => {
+		inviteStore.set(
+			'em-3',
+			makePendingInvite({ inviteCode: 'em-3', email: 'intended@example.com' }),
+		);
+		tenantStore.set('t-test', {
+			tenantId: 't-test',
+			status: 'active',
+			createdAt: new Date().toISOString(),
+		} as Tenant);
+
+		const result = assertError(await acceptInvite('em-3', 'user-new'));
+		expect(result.error).toBe('INVITE_EMAIL_MISMATCH');
+	});
+
+	it('invite.email 未設定 → 従来通り受諾できる (opt-in 束縛)', async () => {
+		inviteStore.set('em-4', makePendingInvite({ inviteCode: 'em-4' }));
+		tenantStore.set('t-test', {
+			tenantId: 't-test',
+			status: 'active',
+			createdAt: new Date().toISOString(),
+		} as Tenant);
+
+		assertSuccess(await acceptInvite('em-4', 'user-new', 'anyone@example.com'));
+	});
+
+	it('createInvite が email を trim + 小文字化して repo に引き渡す', async () => {
+		await createInvite('t-test', 'user-owner', 'parent', undefined, '  Intended@Example.com ');
+		expect(mockAuthRepo.createInvite).toHaveBeenCalledWith(
+			expect.objectContaining({ email: 'intended@example.com' }),
+		);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 保護者（家族グループへの意図しない参加者の防止）

**解決する課題**: 招待リンクは高エントロピーの capability だが、リンクが転送・漏えいすると**任意の email アカウントで受諾できた**（`dsql-data-model.md` §6.6 ⚠️「accepting_user.email == invite.email 束縛」が現行 DynamoDB 経路に未実装 — fitness#3 調査 2026-07-03 で検出、issue #3549 判断2 で PO が先行適用を決裁）。

**期待される効果**: owner が宛先 email を指定して招待した場合、その email のアカウントだけが受諾でき、招待リンクの横流しによる別人参加を防げる。email 未指定の招待は従来通り（child 招待等、email を持たない受諾者向けの opt-in 設計 = §6.6 の nullable 設計と一致）。

## 関連 Issue

- **issue #3549（PO 決裁 2026-07-03: 判断2 = yes、email 束縛の現行経路先行適用）** — 判断1 (owner 専用化) は PR #3551 で実装済のため、本 PR で issue の両判断が完了 → closes #3549
- related: `dsql-data-model.md` §6.6 / PR #3537（DSQL 側 invite-accept.ts は実装済、本 PR は現行経路への写像）/ EPIC #3424

closes #3549

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | invite.email 設定時、受諾者 email 不一致は INVITE_EMAIL_MISMATCH（membership 未作成・招待は pending 保持） | `npx vitest run tests/unit/services/invite-service.test.ts` | HEAD `922f4a2f` / 23 passed / **red 実測: 実装前は不一致でも受諾成功**（failing-test-first、mismatch/fail-closed/引き渡し 3 test が fail → green） |
| AC2 | 照合は case-insensitive（email_lower と同原則）+ 保存時 trim/小文字正規化 | 同上（em-2 / createInvite 正規化 test） | HEAD `922f4a2f` / 'Intended@Example.com' 招待を 'intended@example.com' で受諾成功 PASS |
| AC3 | invite.email 設定 + 受諾者 email 未提供は fail-closed で拒否 | 同上（em-3） | HEAD `922f4a2f` / INVITE_EMAIL_MISMATCH PASS |
| AC4 | email 未設定の招待は従来通り受諾可（opt-in 束縛、既存挙動の無退行） | 同上（em-4）+ 既存 acceptInvite 全 test | HEAD `922f4a2f` / 既存テストの expectation 変更ゼロで 23/23 |
| AC5 | 受諾経路への配線: Cognito ログイン flow が identity.email を照合に渡す | `src/lib/server/auth/providers/cognito.ts` 差分 + `npx vitest run tests/unit/auth/` | HEAD `922f4a2f` / cognito.ts acceptInviteForUser（acceptInvite 3 引数化）/ auth suite pass |
| AC6 | UI: 招待フォームに宛先 email 欄（任意 + 束縛説明 hint、labels.ts SSOT） | SS 4 スロット + `npx vitest run tests/unit/routes/` | HEAD `922f4a2f` / MEMBERS_LABELS.inviteEmailLabel/Hint 追加 / FormField type=email / 343+ passed |
| AC7 | API: zod email 検証（不正形式は validationError、空文字は未設定扱い） | `src/lib/domain/validation/auth.ts` createInviteSchema 差分 | HEAD `922f4a2f` / z.string().trim().email().optional() + 空文字 transform |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: `/admin/members`（owner の招待フォームに宛先 email 欄が追加、任意入力）。DynamoDB invites item に email 属性追加（任意、スキーマ migration 不要 — 既存 item は email 無し = 束縛なしで従来通り動作）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3553` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/services/invite-service.test.ts` に email 束縛 describe（5 tests: mismatch / case-insensitive / fail-closed / opt-in / 正規化引き渡し）。`admin-role-mutation-authz.test.ts` の createInvite 引数 assert を 5 引数形に更新
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: DynamoDB 実装は createInvite の email 属性 pass-through のみ（読み書きは既存 spread/unmarshall で自動）。SQLite auth-repo は元来 throw stub（§3.5.3、local モードは認証未使用）のため両実装完成の対象外。`scripts/check-dynamodb-stub.mjs` は pre-ready/CI で PASS
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**撮影条件**: `npm run dev:cognito`（#1026）+ DEV_USERS **owner アカウント**でログイン（招待フォームは #3551 で owner 専用のため）。DOM スナップショット併記（#1747/#1766）。

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3553/before-admin-members-mobile.png) | ![before-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3553/before-admin-members-desktop.png) |
| **修正後** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3553/after-admin-members-mobile.png) | ![after-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3553/after-admin-members-desktop.png) |

DOM: [before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3553/before-admin-members-mobile.dom.html) / [before-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3553/before-admin-members-desktop.dom.html) / [after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3553/after-admin-members-mobile.dom.html) / [after-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3553/after-admin-members-desktop.dom.html)

**インタラクティブ状態**: N/A（任意入力欄の追加。エラー状態は zod validationError の既存表示経路を再利用し、表示 UI の変更なし）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（束縛判定は service 層 1 箇所、UI は入力のみ）/ 既存の error string 返却パターンに整合（新奇な例外機構を持ち込まない）
- [x] **DRY**: email 正規化（trim + 小文字）は保存側 1 箇所 + 照合側 1 箇所で §6.6 の email_lower 原則と同型。DSQL 側 invite-accept.ts（PR #3537）と同セマンティクス
- [x] **YAGNI**: 招待メール送信・宛先必須化は scope 外（PO 決裁は束縛のみ）
- [x] **Security（OSS 公開前提）**: 横流し対策（CWE-522 系の写像）。fail-closed（email 提供不能な受諾者は拒否）。email は PII だが招待 item は期限付き + テナント scope 内
- [x] **アクセシビリティ**: FormField primitive（label/hint 一貫、DESIGN.md §5）を使用
- [x] **パフォーマンス**: 文字列比較 1 回の追加のみ / N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [x] **labels SSOT** (ADR-0009): 新規文言（inviteEmailLabel / inviteEmailHint）は MEMBERS_LABELS（labels.ts）経由。リテラル直書きなし
- [x] **設計書同期** (ADR-0001): §6.6 記載事項の現行経路への写像であり設計変更なし。DSQL 側は PR #3537 で実装済（両経路のセマンティクス一致）
- [x] **並行 PR overlap** (#1200): 変更ファイルを触る open PR なし（#3551 は merge 済、本 branch はその上の develop 起点）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（email は任意フィールド。既存招待・email 未指定招待は挙動不変）

**レビュー依頼事項・QA**:
- 束縛エラー時に招待を pending のまま保持する設計（正規宛先が後から受諾できる可能性を残す。攻撃者の試行で招待が消費される DoS を防ぐ意図）の妥当性
- child 招待で親が子の email を持たないケースを考慮し「任意入力 = opt-in 束縛」とした判断（§6.6 nullable 設計準拠）の妥当性

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3553` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（issue #3549 判断1 = PR #3551 済 + 判断2 = 本 PR で issue 完了）
- [x] Phase 分割した場合: issue #3549 で判断1/2 の PR 分割を宣言済み
- [x] UI 変更時: SS 4 スロット + DOM HTML 併記済み、DESIGN.md §9 禁忌 6 点を目視確認（FormField primitive 使用 / labels SSOT / hex・インラインスタイルなし）
- [x] 認証画面変更時: `npm run dev:cognito`（#1026）で owner 実ログインの SS を添付済み

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
