### PR TITLE
refactor: #3556 owner-only ad-hoc 判定の残存 6 箇所を requireRole seam に統一 (behavior-preserving)

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -412,6 +412,20 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 - **email 未指定の招待は従来通り受諾可**（email を持たない受諾者向け、child 招待等）。この nullable 設計は [dsql-data-model.md §6.6](dsql-data-model.md) の invite email フィールド設計と一致する。
 - **fitness function**: `tests/unit/services/invite-service.test.ts` が email 一致（大小文字差含む）→ 受諾成功 / 不一致・未提供 → `INVITE_EMAIL_MISMATCH` + 招待 pending 保持 / email 未指定 → 従来通り受諾可、を検証する。
 
+#### 5.2.5 account / tenant ライフサイクル admin API の owner-gate seam 統一（behavior-preserving、#3556 / #3528）
+
+テナントの契約・アカウントそのものを終了・変更するライフサイクル操作（アカウント削除、削除前情報取得、解約申請、解約キャンセル）は、いずれも従来から **owner 専用**である。これらは §5.2.3 の role-mutation とは異なり**新規制限の追加ではなく**、ハンドラ内に残存していた ad-hoc な `context.role !== 'owner'` 判定を、ルート横断の唯一の seam（`src/lib/server/auth/guards.ts` の `requireRole`）へ統一する（#3528 fitness#3）。認可の意味・許可ロール・403 の status / body は置換前とバイト一致で保存される（behavior-preserving）。`requireRole` は旧 ad-hoc 判定と同一 SSOT である `locals.context.role` を検証する。
+
+| account / tenant endpoint | 許可ロール（`requireRole`） | parent / child |
+|---|---|---|
+| `POST /api/v1/admin/account/delete`（owner-only / owner-with-transfer / owner-full-delete の 3 pattern） | `['owner']` | 403 |
+| `GET /api/v1/admin/account/deletion-info`（削除前情報取得） | `['owner']` | 403 |
+| `POST /api/v1/admin/tenant/cancel`（解約申請） | `['owner']` | 403 |
+| `POST /api/v1/admin/tenant/reactivate`（解約キャンセル） | `['owner']` | 403 |
+
+- **response 形の互換**: 既存 client が依存する endpoint 固有の `{ error: <日本語文言> }` body と 403 status を維持するため、`requireRole` が throw する `HttpError(403)` を `isHttpError(e, 403)` で捕捉して各 endpoint の `{ error }` JSON に変換する（401 等は re-throw）。`account/delete` は 3 pattern で判定を共有するため `ownerGuardResponse(locals)` helper に集約する。
+- **fitness function**: `tests/unit/routes/admin-owner-guard-rollout.test.ts` が 4 endpoint（`account/delete` は 3 pattern）で owner → 成功経路 / parent・child → 403 + `{ error }` body バイト一致維持、および判定が `requireRole(locals, ['owner'])` seam 経由であることを spy で機械検証する。
+
 ### 5.3 ライセンス状態による制限
 
 | ライセンス状態 | アクセス制限 |

--- a/src/routes/api/v1/admin/account/delete/+server.ts
+++ b/src/routes/api/v1/admin/account/delete/+server.ts
@@ -17,8 +17,9 @@
 // 詳細: docs/design/account-deletion-flow.md §3 / §4.2 (#741 Stripe キャンセル先行原則)。
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { json } from '@sveltejs/kit';
+import { isHttpError, json } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { requireRole } from '$lib/server/auth/guards';
 import { logger } from '$lib/server/logger';
 import {
 	deleteChildAccount,
@@ -38,6 +39,21 @@ interface DeleteRequestBody {
 	pattern: 'owner-only' | 'owner-with-transfer' | 'owner-full-delete' | 'child' | 'member';
 	/** Pattern 2a のみ: 移譲先ユーザーID */
 	newOwnerId?: string;
+}
+
+// #3556: owner 系 3 pattern (owner-only / owner-with-transfer / owner-full-delete) の
+// role 判定は requireRole seam (#3528 fitness#3) に統一。response 形は既存 client 互換の
+// {error} JSON を維持する（403 の status / body は置換前とバイト一致）。
+function ownerGuardResponse(locals: App.Locals): Response | null {
+	try {
+		requireRole(locals, ['owner']);
+		return null;
+	} catch (e) {
+		if (isHttpError(e, 403)) {
+			return json({ error: 'owner のみ実行できます' }, { status: 403 });
+		}
+		throw e;
+	}
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: 複雑なビジネスロジックのため、別 Issue でリファクタ予定
@@ -67,8 +83,9 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	try {
 		switch (pattern) {
 			case 'owner-only': {
-				if (context.role !== 'owner') {
-					return json({ error: 'owner のみ実行できます' }, { status: 403 });
+				const guard = ownerGuardResponse(locals);
+				if (guard) {
+					return guard;
 				}
 
 				// #1781: プラン別グレースピリオド配線。
@@ -120,8 +137,9 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			}
 
 			case 'owner-with-transfer': {
-				if (context.role !== 'owner') {
-					return json({ error: 'owner のみ実行できます' }, { status: 403 });
+				const guard = ownerGuardResponse(locals);
+				if (guard) {
+					return guard;
 				}
 				if (!newOwnerId) {
 					return json({ error: '移譲先 (newOwnerId) が必要です' }, { status: 400 });
@@ -134,8 +152,9 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			}
 
 			case 'owner-full-delete': {
-				if (context.role !== 'owner') {
-					return json({ error: 'owner のみ実行できます' }, { status: 403 });
+				const guard = ownerGuardResponse(locals);
+				if (guard) {
+					return guard;
 				}
 
 				// #1781: 全削除パターンも同様にグレースピリオドを適用する。

--- a/src/routes/api/v1/admin/account/deletion-info/+server.ts
+++ b/src/routes/api/v1/admin/account/deletion-info/+server.ts
@@ -2,7 +2,8 @@
 // Owner 削除前の情報取得（他メンバー一覧、移譲先候補）
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { json } from '@sveltejs/kit';
+import { isHttpError, json } from '@sveltejs/kit';
+import { requireRole } from '$lib/server/auth/guards';
 import { getOwnerDeletionInfo } from '$lib/server/services/account-deletion-service';
 
 export const GET: RequestHandler = async ({ locals }) => {
@@ -15,8 +16,15 @@ export const GET: RequestHandler = async ({ locals }) => {
 
 	const tenantId = context.tenantId;
 
-	if (context.role !== 'owner') {
-		return json({ error: 'owner のみ取得できます' }, { status: 403 });
+	// #3556: role 判定は requireRole seam (#3528 fitness#3) に統一。
+	// response 形は既存 client 互換の {error} JSON を維持する
+	try {
+		requireRole(locals, ['owner']);
+	} catch (e) {
+		if (isHttpError(e, 403)) {
+			return json({ error: 'owner のみ取得できます' }, { status: 403 });
+		}
+		throw e;
 	}
 
 	try {

--- a/src/routes/api/v1/admin/tenant/cancel/+server.ts
+++ b/src/routes/api/v1/admin/tenant/cancel/+server.ts
@@ -16,8 +16,9 @@
 // DB 更新をスキップさせる（#741 のアカウント削除と同じパターン）。
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { error, json } from '@sveltejs/kit';
+import { error, isHttpError, json } from '@sveltejs/kit';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { requireRole } from '$lib/server/auth/guards';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { notifyCancellation } from '$lib/server/services/discord-notify-service';
@@ -33,8 +34,15 @@ export const POST: RequestHandler = async ({ locals }) => {
 		return json({ error: '認証が必要です' }, { status: 401 });
 	}
 
-	if (context.role !== 'owner') {
-		return json({ error: 'owner のみ解約申請できます' }, { status: 403 });
+	// #3556: role 判定は requireRole seam (#3528 fitness#3) に統一。
+	// response 形は既存 client 互換の {error} JSON を維持する
+	try {
+		requireRole(locals, ['owner']);
+	} catch (e) {
+		if (isHttpError(e, 403)) {
+			return json({ error: 'owner のみ解約申請できます' }, { status: 403 });
+		}
+		throw e;
 	}
 
 	const tenantId = context.tenantId;

--- a/src/routes/api/v1/admin/tenant/reactivate/+server.ts
+++ b/src/routes/api/v1/admin/tenant/reactivate/+server.ts
@@ -8,8 +8,9 @@
 // 誘導する。
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { json } from '@sveltejs/kit';
+import { isHttpError, json } from '@sveltejs/kit';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { requireRole } from '$lib/server/auth/guards';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { notifyCancellationReverted } from '$lib/server/services/discord-notify-service';
@@ -21,8 +22,15 @@ export const POST: RequestHandler = async ({ locals }) => {
 		return json({ error: '認証が必要です' }, { status: 401 });
 	}
 
-	if (context.role !== 'owner') {
-		return json({ error: 'owner のみ解約キャンセルできます' }, { status: 403 });
+	// #3556: role 判定は requireRole seam (#3528 fitness#3) に統一。
+	// response 形は既存 client 互換の {error} JSON を維持する
+	try {
+		requireRole(locals, ['owner']);
+	} catch (e) {
+		if (isHttpError(e, 403)) {
+			return json({ error: 'owner のみ解約キャンセルできます' }, { status: 403 });
+		}
+		throw e;
 	}
 
 	const tenantId = context.tenantId;

--- a/tests/unit/routes/admin-owner-guard-rollout.test.ts
+++ b/tests/unit/routes/admin-owner-guard-rollout.test.ts
@@ -1,0 +1,286 @@
+// tests/unit/routes/admin-owner-guard-rollout.test.ts
+// #3556 (behavior-preserving): owner-only ad-hoc role 判定の残存 4 route
+// (tenant/cancel / tenant/reactivate / account/deletion-info / account/delete 3 pattern)
+// を requireRole seam (src/lib/server/auth/guards.ts) に統一する回帰テスト。
+// admin-role-mutation-authz.test.ts (#3528 fitness#3) と同方式だが、
+// account/tenant 系は mock 構成 (stripe / grace-period / account-deletion service)
+// が大きく異なるため別 file とする。
+//
+// テスト観点:
+// - 各 route が requireRole(locals, ['owner']) seam を経由して判定していること
+//   (red: 現実装はインライン context.role !== 'owner' 判定で requireRole を呼ばない
+//   ため seam spy assertion が fail する)
+// - negative (parent / child): 403 + 既存 `{ error: <既存日本語文言> }` body が
+//   バイト一致で維持されること (回帰固定: 現実装でも green)
+// - positive (owner): 成功経路に入ること (回帰固定: 現実装でも green)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------- mocks ----------
+
+// requireRole seam の spy: 実装 (throw error(401/403)) はそのまま使い、呼び出しを観測する
+const requireRoleSpy = vi.fn();
+vi.mock('$lib/server/auth/guards', async () => {
+	const actual =
+		await vi.importActual<typeof import('../../../src/lib/server/auth/guards')>(
+			'$lib/server/auth/guards',
+		);
+	return {
+		...actual,
+		requireRole: (...args: Parameters<typeof actual.requireRole>) => {
+			requireRoleSpy(...args);
+			return actual.requireRole(...args);
+		},
+	};
+});
+
+const mockRepos = {
+	auth: {
+		findTenantById: vi.fn(),
+		updateTenantStripe: vi.fn(),
+	},
+};
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => mockRepos,
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const mockCancelSubscription = vi.fn();
+vi.mock('$lib/server/services/stripe-service', () => ({
+	cancelSubscription: (...args: unknown[]) => mockCancelSubscription(...args),
+}));
+
+vi.mock('$lib/server/services/discord-notify-service', () => ({
+	notifyCancellation: vi.fn().mockResolvedValue(undefined),
+	notifyCancellationReverted: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('$lib/server/services/email-service', () => ({
+	sendCancellationEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockDeleteOwnerOnlyAccount = vi.fn();
+const mockDeleteOwnerFullDelete = vi.fn();
+const mockTransferOwnershipAndLeave = vi.fn();
+const mockGetOwnerDeletionInfo = vi.fn();
+vi.mock('$lib/server/services/account-deletion-service', () => ({
+	deleteChildAccount: vi.fn(),
+	deleteMemberAccount: vi.fn(),
+	deleteOwnerFullDelete: (...args: unknown[]) => mockDeleteOwnerFullDelete(...args),
+	deleteOwnerOnlyAccount: (...args: unknown[]) => mockDeleteOwnerOnlyAccount(...args),
+	transferOwnershipAndLeave: (...args: unknown[]) => mockTransferOwnershipAndLeave(...args),
+	getOwnerDeletionInfo: (...args: unknown[]) => mockGetOwnerDeletionInfo(...args),
+}));
+
+const mockSoftDeleteTenant = vi.fn();
+vi.mock('$lib/server/services/grace-period-service', () => ({
+	DELETION_GRACE_PERIOD_DAYS: { free: 0, standard: 7, premium: 30, family: 30 },
+	softDeleteTenant: (...args: unknown[]) => mockSoftDeleteTenant(...args),
+}));
+
+const mockResolveFullPlanTier = vi.fn();
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	resolveFullPlanTier: (...args: unknown[]) => mockResolveFullPlanTier(...args),
+}));
+
+const { POST: tenantCancel } = await import(
+	'../../../src/routes/api/v1/admin/tenant/cancel/+server'
+);
+const { POST: tenantReactivate } = await import(
+	'../../../src/routes/api/v1/admin/tenant/reactivate/+server'
+);
+const { GET: deletionInfo } = await import(
+	'../../../src/routes/api/v1/admin/account/deletion-info/+server'
+);
+const { POST: accountDelete } = await import(
+	'../../../src/routes/api/v1/admin/account/delete/+server'
+);
+
+// ---------- helpers ----------
+
+type Role = 'owner' | 'parent' | 'child';
+
+function createLocals(role: Role) {
+	return {
+		context: { tenantId: 't-test', role, plan: 'free', licenseStatus: 'none' },
+		identity: { type: 'cognito', userId: 'u-caller', email: 'caller@example.com' },
+	};
+}
+
+function createSimpleEvent(role: Role) {
+	return { locals: createLocals(role) } as unknown as Parameters<
+		NonNullable<typeof tenantCancel>
+	>[0];
+}
+
+function createDeleteEvent(role: Role, pattern: string, extra: Record<string, unknown> = {}) {
+	return {
+		request: new Request('http://localhost/api/v1/admin/account/delete', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ pattern, ...extra }),
+		}),
+		locals: createLocals(role),
+	} as unknown as Parameters<NonNullable<typeof accountDelete>>[0];
+}
+
+function expectSeamCalledWith(role: Role) {
+	expect(requireRoleSpy).toHaveBeenCalledWith(
+		expect.objectContaining({ context: expect.objectContaining({ role }) }),
+		['owner'],
+	);
+}
+
+// ---------- tests ----------
+
+describe('owner-only ad-hoc guard 残存 route の requireRole seam 統一 (#3556)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRepos.auth.findTenantById.mockResolvedValue({
+			status: 'active',
+			stripeSubscriptionId: 'sub_1',
+		});
+		mockRepos.auth.updateTenantStripe.mockResolvedValue(undefined);
+		mockCancelSubscription.mockResolvedValue({ status: 'canceled' });
+		mockResolveFullPlanTier.mockResolvedValue('free');
+		mockDeleteOwnerOnlyAccount.mockResolvedValue({ success: true, pattern: 'owner-only' });
+		mockDeleteOwnerFullDelete.mockResolvedValue({ success: true, pattern: 'owner-full-delete' });
+		mockTransferOwnershipAndLeave.mockResolvedValue({
+			success: true,
+			pattern: 'owner-with-transfer',
+		});
+		mockGetOwnerDeletionInfo.mockResolvedValue({ members: [], transferCandidates: [] });
+	});
+
+	describe('POST /api/v1/admin/tenant/cancel', () => {
+		it('owner は成功経路に入る (positive、回帰固定)', async () => {
+			const res = await tenantCancel(createSimpleEvent('owner'));
+			expect(res.status).toBe(200);
+			await expect(res.json()).resolves.toMatchObject({ success: true });
+			expect(mockCancelSubscription).toHaveBeenCalledWith('t-test');
+		});
+
+		it('owner 判定は requireRole seam 経由で行われる (red → green)', async () => {
+			await tenantCancel(createSimpleEvent('owner'));
+			expectSeamCalledWith('owner');
+		});
+
+		it('parent は 403 + 既存 {error} body バイト一致 (negative、回帰固定)', async () => {
+			const res = await tenantCancel(createSimpleEvent('parent'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ解約申請できます' });
+			expect(mockCancelSubscription).not.toHaveBeenCalled();
+			expect(mockRepos.auth.updateTenantStripe).not.toHaveBeenCalled();
+		});
+
+		it('child は 403 (negative)', async () => {
+			const res = await tenantCancel(createSimpleEvent('child'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ解約申請できます' });
+			expect(mockCancelSubscription).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('POST /api/v1/admin/tenant/reactivate', () => {
+		beforeEach(() => {
+			mockRepos.auth.findTenantById.mockResolvedValue({
+				status: 'grace_period',
+				stripeSubscriptionId: 'sub_1',
+			});
+		});
+
+		it('owner は成功経路に入る (positive、回帰固定)', async () => {
+			const res = await tenantReactivate(createSimpleEvent('owner'));
+			expect(res.status).toBe(200);
+			await expect(res.json()).resolves.toEqual({ success: true });
+			expect(mockRepos.auth.updateTenantStripe).toHaveBeenCalled();
+		});
+
+		it('owner 判定は requireRole seam 経由で行われる (red → green)', async () => {
+			await tenantReactivate(createSimpleEvent('owner'));
+			expectSeamCalledWith('owner');
+		});
+
+		it('parent は 403 + 既存 {error} body バイト一致 (negative、回帰固定)', async () => {
+			const res = await tenantReactivate(createSimpleEvent('parent'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ解約キャンセルできます' });
+			expect(mockRepos.auth.updateTenantStripe).not.toHaveBeenCalled();
+		});
+
+		it('child は 403 (negative)', async () => {
+			const res = await tenantReactivate(createSimpleEvent('child'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ解約キャンセルできます' });
+			expect(mockRepos.auth.updateTenantStripe).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('GET /api/v1/admin/account/deletion-info', () => {
+		it('owner は成功経路に入る (positive、回帰固定)', async () => {
+			const res = await deletionInfo(createSimpleEvent('owner'));
+			expect(res.status).toBe(200);
+			await expect(res.json()).resolves.toEqual({ members: [], transferCandidates: [] });
+			expect(mockGetOwnerDeletionInfo).toHaveBeenCalledWith('t-test', 'u-caller');
+		});
+
+		it('owner 判定は requireRole seam 経由で行われる (red → green)', async () => {
+			await deletionInfo(createSimpleEvent('owner'));
+			expectSeamCalledWith('owner');
+		});
+
+		it('parent は 403 + 既存 {error} body バイト一致 (negative、回帰固定)', async () => {
+			const res = await deletionInfo(createSimpleEvent('parent'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ取得できます' });
+			expect(mockGetOwnerDeletionInfo).not.toHaveBeenCalled();
+		});
+
+		it('child は 403 (negative)', async () => {
+			const res = await deletionInfo(createSimpleEvent('child'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: 'owner のみ取得できます' });
+			expect(mockGetOwnerDeletionInfo).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('POST /api/v1/admin/account/delete (owner 系 3 pattern)', () => {
+		for (const pattern of ['owner-only', 'owner-with-transfer', 'owner-full-delete'] as const) {
+			describe(`pattern=${pattern}`, () => {
+				const extra = pattern === 'owner-with-transfer' ? { newOwnerId: 'u-next' } : {};
+
+				it('owner は成功経路に入る (positive、回帰固定)', async () => {
+					const res = await accountDelete(createDeleteEvent('owner', pattern, extra));
+					expect(res.status).toBe(200);
+					await expect(res.json()).resolves.toMatchObject({ success: true });
+				});
+
+				it('owner 判定は requireRole seam 経由で行われる (red → green)', async () => {
+					await accountDelete(createDeleteEvent('owner', pattern, extra));
+					expectSeamCalledWith('owner');
+				});
+
+				it('parent は 403 + 既存 {error} body バイト一致 (negative、回帰固定)', async () => {
+					const res = await accountDelete(createDeleteEvent('parent', pattern, extra));
+					expect(res.status).toBe(403);
+					await expect(res.json()).resolves.toEqual({ error: 'owner のみ実行できます' });
+					expect(mockDeleteOwnerOnlyAccount).not.toHaveBeenCalled();
+					expect(mockDeleteOwnerFullDelete).not.toHaveBeenCalled();
+					expect(mockTransferOwnershipAndLeave).not.toHaveBeenCalled();
+				});
+
+				it('child は 403 (negative)', async () => {
+					const res = await accountDelete(createDeleteEvent('child', pattern, extra));
+					expect(res.status).toBe(403);
+					await expect(res.json()).resolves.toEqual({ error: 'owner のみ実行できます' });
+					expect(mockDeleteOwnerOnlyAccount).not.toHaveBeenCalled();
+					expect(mockDeleteOwnerFullDelete).not.toHaveBeenCalled();
+					expect(mockTransferOwnershipAndLeave).not.toHaveBeenCalled();
+				});
+			});
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（owner 専用操作の認可保証の均質化）

**解決する課題**: owner 専用 API の role 判定が ad-hoc なインライン `context.role !== 'owner'` で 6 箇所（4 file）に散在しており、guard の付け忘れ・書き間違いを構造的に防げない（PR #3551 で確立した requireRole seam の残存箇所、issue #3556 / 調査 SSOT `tmp/research-fitness3-role-mutation-inventory-2026-07-03.md`）。

**期待される効果**: 解約申請・解約キャンセル・アカウント削除系の owner guard が全て requireRole seam（guards.ts:29）経由になり、seam spy テストで「guard が seam を通っていること」自体が回帰固定される。ユーザー可視の挙動は完全不変（behavior-preserving）。

## 関連 Issue

- issue #3556 の seam 統一 scope を完遂 → closes #3556（error body 形統一は issue 記載の通り ADR-0062 適用判断として本 PR から除外、必要になれば当該 ADR 系 issue で扱う）
- related: PR #3551（パターン確立元）/ #3528 fitness#3 / ADR-0062

closes #3556

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 残存 ad-hoc owner 判定の全列挙と seam 置換（grep で route 直書きゼロ） | `grep -rn "role !== 'owner'" src/routes/api/` | HEAD `1e92528a` / 実測 6 guard / 4 file（tenant/cancel:36 / tenant/reactivate:24 / account/deletion-info:18 / account/delete:70,123,137）を置換。owner-or-parent 許可・逆 guard・削除対象 role 判定は対象外として列挙判断を commit に記録 |
| AC2 | 各 route の positive + negative test（403 status + body バイト一致 pin） | `npx vitest run tests/unit/routes/admin-owner-guard-rollout.test.ts` | HEAD `1e92528a` / 24 tests（owner positive / seam spy / parent 403 / child 403 × 4 route 系）。**red 実測: seam spy 6 件が置換前 fail（requireRole 呼び出し 0 回）**、403 挙動 18 件は回帰固定（既存挙動のため置換前から green と明記） |
| AC3 | 既存挙動の無退行（既存テスト expectation 変更ゼロ） | `npx vitest run tests/unit/routes/ tests/unit/auth/ tests/unit/services/` | HEAD `1e92528a` / **2817/2817 pass**（pipeline 環境で再検証済）/ 403 body は `toEqual` 厳密一致で既存文言 pin / 401 経路は既存 `!context` check 先行で不変 |

## 変更タイプ

- [x] refactor: リファクタリング
- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（内部 seam 置換のみ。403 status / body / 401 経路とも既存完全一致）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/routes/admin-owner-guard-rollout.test.ts` 新設 24 tests（account/tenant 系は mock 構成が既存 file と異なるため新 file、方式は admin-role-mutation-authz.test.ts 踏襲）。既存テストの変更ゼロ
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし**（API 内部の seam 置換のみ。UI・表示文言の変更なし）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一 seam（requireRole）への集約 = 認可判定の単一責任化。guards.ts 無変更（既存 20+ callsite 無影響）
- [x] **DRY**: account/delete の同一 body 3 箇所は局所 helper `ownerGuardResponse()` に集約（seam + isHttpError(e,403) パターンは PR #3551 と同一）
- [x] **YAGNI**: error body 形の統一（message vs error 混在）は行わない（issue #3556 の判断事項として ADR-0062 系に委譲、本 PR は挙動不変が価値）
- [x] **Security（OSS 公開前提）**: 認可 guard の構造統一（付け忘れ検出可能化）。挙動変更なし
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: N/A（関数呼び出し 1 段の置換）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [x] **labels SSOT** (ADR-0009): 表示文言の変更なし（既存 403 文言をバイト一致で維持）
- [x] **設計書同期** (ADR-0001): 内部 refactor で設計変更なし（ADR-0003 §4 internal refactor exempt）
- [x] **並行 PR overlap** (#1200): 変更 4 file を触る open PR なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（403 status / body バイト一致をテストで pin）

**レビュー依頼事項・QA**:
- これで `src/routes/api/` の owner-only ad-hoc 判定は grep ゼロ（fitness#3 系の seam 統一が完了）。「seam 経由必須」を静的 lint（eslint-local / architecture test）に昇格するかは費用対効果を見て別判断としたい
- 本実装は並行 Agent が TDD で作成し、本体セッションが pipeline 環境で再検証（2817/2817 + svelte-check 0 errors）+ コードレビューしたもの

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（issue #3556 の seam 統一 scope 完遂）
- [x] Phase 分割した場合: N/A（単一 PR）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
