### PR TITLE
feat: #3533 FeatureGate を disabled+popover 化 (§10.2.1 P2)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -6822,6 +6822,11 @@ export const UI_COMPONENTS_LABELS = {
 	featureGateLockTitle: (plan: string) => `${plan}プラン以上で利用可能`,
 	featureGateLockText: (plan: string) => `${plan}プラン以上で利用可能`,
 	featureGateUpgrade: 'アップグレード',
+	// EPIC #3533 §10.2.1: disabled 要素 tap→popover の 3 要素文言 (P2/P5)。
+	// planFull は PLAN_FULL_TERMS 値 (例「スタンダードプラン」) を受ける。
+	featureGatePopoverUnavailable: '現在のプランでは利用できません',
+	featureGatePopoverRequirement: (planFull: string) => `${planFull}以上でご利用いただけます`,
+	featureGatePopoverLink: 'プランを見る',
 
 	// ---- GoogleSignInButton ----
 	googleSignInLabel: 'Google でログイン',
@@ -8069,6 +8074,11 @@ export const STORYBOOK_LABELS = {
 	cardDefault: 'カード',
 	toastDefault: 'トースト',
 	selectDefault: '選択',
+	featureGate: {
+		buttonLabel: 'クラウドエクスポート',
+		unlockedContent: 'この機能は利用できます',
+		sectionTitle: 'AI 提案パネル',
+	},
 	button: {
 		primary: 'プライマリ',
 		secondary: 'セカンダリ',

--- a/src/lib/ui/components/FeatureGate.stories.svelte
+++ b/src/lib/ui/components/FeatureGate.stories.svelte
@@ -1,0 +1,77 @@
+<script module>
+import { defineMeta } from '@storybook/addon-svelte-csf';
+import { expect, screen, userEvent, waitFor } from 'storybook/test';
+import { STORYBOOK_LABELS } from '$lib/domain/labels';
+import FeatureGate from './FeatureGate.svelte';
+
+const L = STORYBOOK_LABELS.featureGate;
+
+const { Story } = defineMeta({
+	title: 'Components/FeatureGate',
+	component: FeatureGate,
+	tags: ['autodocs'],
+});
+</script>
+
+<!--
+  Unlocked: currentTier が requiredTier を満たすとき children をそのまま描画。
+-->
+<Story name="Unlocked" args={{ currentTier: 'family', requiredTier: 'standard' }}>
+	{#snippet children()}
+		<span>{L.unlockedContent}</span>
+	{/snippet}
+</Story>
+
+<!--
+  LockedInline: free が standard 機能に触れると 🔒 disabled ボタン。tap で popover が開き
+  ① 利用不可 ② 対象プラン名 ③ プラン画面リンク が出る (§10.2.1、CX-DoR #8 操作回帰)。
+  Popover は Portal 経由で描画されるため screen (document.body 起点) を使う。
+-->
+<Story
+	name="LockedInline"
+	args={{
+		currentTier: 'free',
+		requiredTier: 'standard',
+		display: 'inline',
+		buttonLabel: L.buttonLabel,
+	}}
+	play={async () => {
+		const trigger = await waitFor(() => screen.getByTestId('feature-gate-locked-trigger'));
+		await expect(trigger).toBeVisible();
+		await expect(trigger).toHaveAttribute('aria-disabled', 'true');
+		// tap → popover open (dead-end でない: プラン画面リンクを提示)
+		await userEvent.click(trigger);
+		const popover = await waitFor(() => screen.getByTestId('feature-gate-popover'));
+		await expect(popover).toBeVisible();
+		const link = screen.getByTestId('feature-gate-popover-link');
+		await expect(link).toHaveAttribute('href', '/admin/subscription');
+	}}
+>
+	{#snippet children()}
+		<span>{L.unlockedContent}</span>
+	{/snippet}
+</Story>
+
+<!--
+  LockedSection: パネル全体を disabled + overlay。overlay tap で同じ popover が開く。
+-->
+<Story
+	name="LockedSection"
+	args={{ currentTier: 'free', requiredTier: 'standard', display: 'section' }}
+	play={async () => {
+		const trigger = await waitFor(() => screen.getByTestId('feature-gate-locked-trigger'));
+		await userEvent.click(trigger);
+		const popover = await waitFor(() => screen.getByTestId('feature-gate-popover'));
+		await expect(popover).toBeVisible();
+	}}
+>
+	{#snippet children()}
+		<div>{L.sectionTitle}</div>
+	{/snippet}
+</Story>
+
+<style>
+	:global(.sb-story) {
+		min-height: 300px;
+	}
+</style>

--- a/src/lib/ui/components/FeatureGate.svelte
+++ b/src/lib/ui/components/FeatureGate.svelte
@@ -1,9 +1,23 @@
 <script lang="ts">
+import { Popover } from '@ark-ui/svelte/popover';
+import { Portal } from '@ark-ui/svelte/portal';
 import type { Snippet } from 'svelte';
 import { UI_COMPONENTS_LABELS } from '$lib/domain/labels';
-import { PLAN_TERMS } from '$lib/domain/terms';
+import { PLAN_FULL_TERMS, PLAN_TERMS } from '$lib/domain/terms';
 import { meetsRequiredTier, type PlanTier } from '$lib/ui/tutorial/tutorial-types';
-import PremiumBadge from './PremiumBadge.svelte';
+
+/**
+ * FeatureGate (EPIC #3533 §10.2 で popover 化)
+ *
+ * free/standard ユーザーが有料機能に触れたとき「存在は示す・操作不可 (disabled)」に留め、
+ * 画面内に個別アップセル CTA / quota カウンタを置かない (P1/P3)。disabled 要素の tap で
+ * popover を開き ① 利用不可 ② 対象プラン名 ③ プラン画面リンク1本 を示す (P2、§10.2.1)。
+ *
+ * disabled は native `disabled` 属性ではなく `aria-disabled="true"` で表現する — native disabled
+ * だと tap イベントが発火せず popover を開けないため。gated 操作の実行ハンドラは本 component が
+ * 肩代わりせず、trigger は popover を開くだけ (実行不可)。バックエンド 403 (requirePaidTier 等) が
+ * 唯一の砦で、本 component は二重防御。
+ */
 
 interface Props {
 	/** 現在のプラン */
@@ -12,12 +26,14 @@ interface Props {
 	requiredTier: PlanTier;
 	/** 有料機能へのコンテンツ */
 	children: Snippet;
-	/** ロック時の代替表示 (省略時はデフォルトのロック表示) */
+	/** ロック時の代替表示 (省略時はデフォルトの 🔒 disabled + popover) */
 	locked?: Snippet;
-	/** disabled ボタンとして表示する場合のラベル */
+	/** disabled ボタンとして表示する場合のラベル (display="inline" 用) */
 	buttonLabel?: string;
 	/** インライン表示（ボタン用）か、セクション表示か */
 	display?: 'inline' | 'section';
+	/** popover のプラン画面リンク先 (§10.2.1、既定 = プラン画面) */
+	planPageHref?: string;
 }
 
 let {
@@ -27,39 +43,79 @@ let {
 	locked,
 	buttonLabel,
 	display = 'section',
+	planPageHref = '/admin/subscription',
 }: Props = $props();
 
-// Phase 7 PR-L4 (#2836): 顧客可視の gate ラベルを premium atom 参照化 (ADR-0045 / ADR-0058)。
 const TIER_LABELS: Record<PlanTier, string> = {
 	free: PLAN_TERMS.free,
 	standard: PLAN_TERMS.standard,
 	family: PLAN_TERMS.premium,
 };
 
+// popover の「対象プラン名」はフル形 (「スタンダードプラン」) を使う (§10.2.1 ②)。
+const TIER_FULL_LABELS: Record<PlanTier, string> = {
+	free: PLAN_FULL_TERMS.free,
+	standard: PLAN_FULL_TERMS.standard,
+	family: PLAN_FULL_TERMS.premium,
+};
+
 // requiredTier を満たさない = ロック。tutorial-chapters / page-guide と同じ TIER_ORDER SSOT を共有する。
 const isLocked = $derived(!meetsRequiredTier(currentTier, requiredTier));
 const requiredLabel = $derived(TIER_LABELS[requiredTier]);
+const requiredFullLabel = $derived(TIER_FULL_LABELS[requiredTier]);
 </script>
+
+{#snippet popoverBody()}
+	<Portal>
+		<Popover.Positioner class="feature-gate-popover-positioner">
+			<Popover.Content class="feature-gate-popover" data-testid="feature-gate-popover">
+				<Popover.Title class="feature-gate-popover__title">
+					{UI_COMPONENTS_LABELS.featureGatePopoverUnavailable}
+				</Popover.Title>
+				<Popover.Description class="feature-gate-popover__desc">
+					{UI_COMPONENTS_LABELS.featureGatePopoverRequirement(requiredFullLabel)}
+				</Popover.Description>
+				<a href={planPageHref} class="feature-gate-popover__link" data-testid="feature-gate-popover-link">
+					{UI_COMPONENTS_LABELS.featureGatePopoverLink}
+				</a>
+			</Popover.Content>
+		</Popover.Positioner>
+	</Portal>
+{/snippet}
 
 {#if !isLocked}
 	{@render children()}
 {:else if locked}
 	{@render locked()}
 {:else if display === 'inline' && buttonLabel}
-	<span class="feature-gate-inline">
-		<button type="button" class="feature-gate-btn" disabled title={UI_COMPONENTS_LABELS.featureGateLockTitle(requiredLabel)}>
-			<span class="feature-gate-btn__icon">🔒</span>
+	<Popover.Root positioning={{ placement: 'top' }}>
+		<Popover.Trigger
+			class="feature-gate-btn"
+			aria-disabled="true"
+			data-testid="feature-gate-locked-trigger"
+			title={UI_COMPONENTS_LABELS.featureGateLockTitle(requiredLabel)}
+		>
+			<span class="feature-gate-btn__icon" aria-hidden="true">🔒</span>
 			<span class="feature-gate-btn__label">{buttonLabel}</span>
-		</button>
-		<PremiumBadge size="sm" label={requiredLabel} />
-	</span>
+		</Popover.Trigger>
+		{@render popoverBody()}
+	</Popover.Root>
 {:else}
 	<div class="feature-gate-section">
-		<div class="feature-gate-overlay">
-			<span class="feature-gate-lock">🔒</span>
-			<p class="feature-gate-text">{UI_COMPONENTS_LABELS.featureGateLockText(requiredLabel)}</p>
-			<PremiumBadge size="md" label={UI_COMPONENTS_LABELS.featureGateUpgrade} />
-		</div>
+		<Popover.Root positioning={{ placement: 'top' }}>
+			<Popover.Trigger
+				class="feature-gate-overlay"
+				aria-disabled="true"
+				data-testid="feature-gate-locked-trigger"
+				title={UI_COMPONENTS_LABELS.featureGateLockTitle(requiredLabel)}
+			>
+				<span class="feature-gate-lock" aria-hidden="true">🔒</span>
+				<span class="feature-gate-text">
+					{UI_COMPONENTS_LABELS.featureGateLockText(requiredLabel)}
+				</span>
+			</Popover.Trigger>
+			{@render popoverBody()}
+		</Popover.Root>
 		<div class="feature-gate-content" aria-hidden="true">
 			{@render children()}
 		</div>
@@ -67,13 +123,8 @@ const requiredLabel = $derived(TIER_LABELS[requiredTier]);
 {/if}
 
 <style>
-	.feature-gate-inline {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	.feature-gate-btn {
+	/* class passed to Ark Popover.Trigger crosses the component boundary -> :global (same as Menu.svelte) */
+	:global(.feature-gate-btn) {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.375rem;
@@ -105,7 +156,7 @@ const requiredLabel = $derived(TIER_LABELS[requiredTier]);
 		user-select: none;
 	}
 
-	.feature-gate-overlay {
+	:global(.feature-gate-overlay) {
 		position: absolute;
 		inset: 0;
 		display: flex;
@@ -113,9 +164,11 @@ const requiredLabel = $derived(TIER_LABELS[requiredTier]);
 		align-items: center;
 		justify-content: center;
 		gap: 0.5rem;
-		z-index: 10;
+		z-index: var(--z-dropdown);
 		background: var(--color-surface-overlay, rgba(255, 255, 255, 0.7));
+		border: none;
 		border-radius: var(--radius-md);
+		cursor: not-allowed;
 	}
 
 	.feature-gate-lock {
@@ -126,5 +179,42 @@ const requiredLabel = $derived(TIER_LABELS[requiredTier]);
 		font-size: 0.8rem;
 		font-weight: 600;
 		color: var(--color-text-secondary);
+	}
+
+	:global(.feature-gate-popover-positioner) {
+		/* DESIGN section 10: --z-dropdown = 20 token (popover layer, no raw z-index) */
+		z-index: var(--z-dropdown);
+	}
+
+	:global(.feature-gate-popover) {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		max-width: 16rem;
+		padding: 0.75rem 1rem;
+		background: var(--color-surface-card);
+		border: 1px solid var(--color-border-default);
+		border-radius: var(--radius-md);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+		outline: none;
+	}
+
+	:global(.feature-gate-popover__title) {
+		font-size: 0.875rem;
+		font-weight: 700;
+		color: var(--color-text-primary);
+	}
+
+	:global(.feature-gate-popover__desc) {
+		font-size: 0.8rem;
+		color: var(--color-text-secondary);
+	}
+
+	:global(.feature-gate-popover__link) {
+		align-self: flex-start;
+		font-size: 0.8rem;
+		font-weight: 600;
+		color: var(--color-text-link);
+		text-decoration: underline;
 	}
 </style>


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: free/standard が有料機能に触れた際の表現がアドホックで、同一制限が 1 画面に散在していた。EPIC #3533 §10.2 のポリシー P1–P5 に沿って、共通コンポーネント `FeatureGate` を「🔒 disabled + tap→popover」に統一する。

**期待される効果**: 以後 gated 画面が単一パターン（disabled + popover）に収斂でき、popover が ① 利用不可 ② 対象プラン名 ③ プラン画面リンク1本 を dead-end なく提示する（NN/G #1 visibility / #6 recognition）。

## 関連 Issue

EPIC #3533 の AC2（FeatureGate に mobile tap→popover 対応）を消化。統合 PR で集約 close されるため本 PR body では close 宣言せず参照に留める（AC3–6 が残るため EPIC 未 close）。
関連: #3533

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC2 | FeatureGate に tap→popover（inline / section）を Ark UI primitive で実装、role/data-testid 付与 | `STORYBOOK_TESTS=true vitest run --project storybook FeatureGate` | HEAD `071eb3da` / 3 passed（Unlocked/LockedInline/LockedSection play）/ FeatureGate.svelte:88 Popover.Trigger aria-disabled + testid=feature-gate-popover |
| AC2-a | popover 3 要素（利用不可 / 対象プラン名 / プラン画面リンク1本）を SSOT 文言で描画 | Storybook SS 目視 + labels.ts | HEAD `071eb3da` / SS 参照（下記）/ labels.ts featureGatePopover{Unavailable,Requirement,Link} |
| AC2-b | disabled は native disabled でなく aria-disabled（tap で popover 開く / dead-end 回避） | storybook play `toHaveAttribute('aria-disabled','true')` + link href | HEAD `071eb3da` / LockedInline play で href=/admin/subscription 検証 |
| AC2-c | 文言直書き・hardcoded JP 増加なし | `node scripts/check-hardcoded-strings.mjs` | HEAD `071eb3da` / violations 0 (baseline 0) |

## 変更タイプ

- [x] feat: 新機能

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`) — labels.ts に popover 文言 + STORYBOOK_LABELS 追加

**影響を受ける画面・機能**: `FeatureGate` component（現状 route 未マウント。実画面初出は AC4 の /admin/checklists 収斂 PR）。既存 callsite なしのため回帰面なし。

## テスト & 安全装置セルフチェック

- [x] **storybook / vitest / biome / svelte-check / hardcoded-strings ローカル PASS**: storybook 3 passed / vitest 48 passed（既存 gated 系）/ biome 0 / svelte-check FeatureGate 0 err / hardcoded-strings 0
- [x] 追加・変更したテストの概要: FeatureGate.stories.svelte 新設（Unlocked / LockedInline / LockedSection、play で tap→popover→リンク提示を操作回帰、CX-DoR #8）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

FeatureGate は現状 route 未マウントのため、視覚 + 操作の一次証跡は **Storybook story（play interaction test）**。以下は Storybook 実描画 SS（popover open 状態）。実画面 SS は AC4（/admin/checklists 収斂）PR で添付する。

**4 スロット添付**（新規 component のため「修正前」= 該当なし）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし（新規 component） | 該当なし（新規 component） |
| **修正後 (inline)** | ![after-inline-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3559/featuregate-locked-inline-mobile.png) | ![after-inline-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3559/featuregate-locked-inline-pc.png) |
| **修正後 (section)** | ![after-section-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3559/featuregate-locked-section-mobile.png) | ![after-section-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3559/featuregate-locked-section-pc.png) |

DOM HTML スナップショット: [inline-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3559/featuregate-locked-inline-mobile.dom.html) / [inline-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3559/featuregate-locked-inline-pc.dom.html) / [section-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3559/featuregate-locked-section-mobile.dom.html) / [section-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3559/featuregate-locked-section-pc.dom.html)

**インタラクティブ状態**: disabled trigger（aria-disabled）+ popover open 状態を撮影済（上記）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: FeatureGate は表示単一責任。popover 文言は labels SSOT に依存（DIP）
- [x] **DRY**: popover 本文は `{#snippet popoverBody()}` で inline/section 共有。文言は §10.7/UI_COMPONENTS_LABELS 参照
- [x] **YAGNI**: 新規 primitive を新設せず既存 FeatureGate を拡張（ADR-0010）。quota 対応（AC3）は別 PR
- [x] **Security**: N/A（表示のみ、バックエンド 403 が唯一の砦）
- [x] **アクセシビリティ**: aria-disabled で「操作不可」を SR に伝達 / popover は Ark role=dialog + aria-labelledby/describedby / link はキーボード到達可
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): §10.2.1 で定義した testid（feature-gate-popover / feature-gate-popover-link）を実装が満たす（§10.2 改訂は先行 PR #3542 で develop 反映済）
- [x] **labels SSOT** (ADR-0009 / ADR-0045): popover 文言は UI_COMPONENTS_LABELS、story は STORYBOOK_LABELS 経由。リテラル直書きなし
- [x] **並行 PR overlap** (#1200): 変更は FeatureGate.svelte / FeatureGate.stories.svelte / labels.ts。同時変更の open PR なし（並行重複チェックで確認）
- [x] N/A — 本番/デモ同期・年齢モード・ナビ・E2E シードは本 component の性質上対象外（route 未マウント）

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（FeatureGate は既存 callsite ゼロ。API は後方互換 + planPageHref prop 追加のみ）

**レビュー依頼事項・QA**: aria-disabled による tap→popover 方式（native disabled だと tap 不発のため）が §10.2.1 P2 の意図に合致するかの確認。popover の「以上でご利用いただけます」汎用文言が family 限定機能でも許容範囲か（AC5 横展開時に個別 gate 文言の要否を EPIC #3533 で再評価）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] storybook / vitest / biome / svelte-check / hardcoded-strings ローカル PASS
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = AC2。AC3–6 は後続 PR）
- [x] Phase 分割: EPIC #3533 で PO 合意済み、サブタスク列挙済み
- [x] UI 変更時: Storybook 実描画 SS + DOM HTML 併記、DESIGN.md §9 禁忌 6 点を目視確認（hex/primitive 再実装/内部コード露出/用語直書き/inline style/style 50 行超なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
