### PR TITLE
feat: #3424 Child 集約 Slice A 記録系 9 表 DDL + JSON 解体 + enum SSOT 化

### DIFF
--- a/src/lib/domain/battle-types.ts
+++ b/src/lib/domain/battle-types.ts
@@ -86,7 +86,9 @@ export interface TurnAction {
 }
 
 /** バトル結果 */
-export type BattleOutcome = 'win' | 'lose';
+// runtime 配列は DSQL daily_battles.outcome の CHECK 生成 SSOT (#3424、手書き二重化禁止)
+export const BATTLE_OUTCOMES = ['win', 'lose'] as const;
+export type BattleOutcome = (typeof BATTLE_OUTCOMES)[number];
 
 /** バトル結果データ */
 export interface BattleResult {
@@ -105,7 +107,9 @@ export interface BattleResult {
 // ============================================================
 
 /** 日次バトル状態 */
-export type DailyBattleStatus = 'pending' | 'completed';
+// runtime 配列は DSQL daily_battles.status の CHECK 生成 SSOT (#3424)
+export const DAILY_BATTLE_STATUSES = ['pending', 'completed'] as const;
+export type DailyBattleStatus = (typeof DAILY_BATTLE_STATUSES)[number];
 
 /** 日次バトル記録 */
 export interface DailyBattle {

--- a/src/lib/domain/constants/checklist-override-action.ts
+++ b/src/lib/domain/constants/checklist-override-action.ts
@@ -1,0 +1,7 @@
+// src/lib/domain/constants/checklist-override-action.ts
+// チェックリスト日次 override の操作種別 SSOT (#3424 DSQL 移管で runtime 配列化)。
+// 'add' = その日だけ項目を追加 / 'remove' = その日だけ項目を除外。
+// DSQL checklist_overrides.action の CHECK 生成 (fitness#13) と service 層の分岐が共有する。
+
+export const CHECKLIST_OVERRIDE_ACTIONS = ['add', 'remove'] as const;
+export type ChecklistOverrideAction = (typeof CHECKLIST_OVERRIDE_ACTIONS)[number];

--- a/src/lib/server/db/dsql/schema.ts
+++ b/src/lib/server/db/dsql/schema.ts
@@ -23,6 +23,8 @@ import {
 	uuid,
 } from 'drizzle-orm/pg-core';
 import { ARCHIVED_REASONS } from '$lib/domain/archive-types';
+import { BATTLE_OUTCOMES, DAILY_BATTLE_STATUSES } from '$lib/domain/battle-types';
+import { CHECKLIST_OVERRIDE_ACTIONS } from '$lib/domain/constants/checklist-override-action';
 import { type TimeSlot, VALID_TIME_SLOTS } from '$lib/domain/constants/checklist-time-slot';
 import { STAMP_CARD_STATUSES, type StampCardStatus } from '$lib/domain/constants/stamp-card-status';
 import {
@@ -508,4 +510,174 @@ export const checklistTemplateAssignments = pgTable(
 		primaryKey({ columns: [t.familyId, t.templateId, t.childId] }),
 		index('checklist_template_assignments_child_idx').on(t.familyId, t.childId),
 	],
+);
+
+// ── Child 集約 残り表 Slice A: 記録系 9 表 (§11.2 / §5、#3424) ──
+// PK は pk-freeze-manifest (= §11.2 凍結) と fitness#9 [3] が自動突合。
+
+// evaluations — 週次評価。scoresJson は evaluation_scores 子表に解体 (§5 判断③)。
+// created_at は sort 用途 (findEvaluationsByChild = PK プレフィクス + sort LIMIT、§11.2)。
+export const evaluations = pgTable(
+	'evaluations',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		evalId: uuid('eval_id').notNull().default(sql`gen_random_uuid()`),
+		weekStart: text('week_start').notNull(),
+		weekEnd: text('week_end').notNull(),
+		bonusPoints: integer('bonus_points').notNull().default(0),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.evalId] })],
+);
+
+// evaluation_scores — scoresJson の子表化 (§5: 真の GROUP BY を持つ evaluation 系集計のため列展開)。
+export const evaluationScores = pgTable(
+	'evaluation_scores',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		evalId: uuid('eval_id').notNull(),
+		categoryId: text('category_id').notNull(),
+		score: real('score').notNull(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.evalId, t.categoryId] })],
+);
+
+// rest_days — おやすみ日 (自然複合 PK 昇格、anchor (a) ADR-0012: 1日1回 = policy invariant §11.2)。
+export const restDays = pgTable(
+	'rest_days',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		date: text('date').notNull(),
+		reason: text('reason').notNull().default('rest'),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.date] })],
+);
+
+// daily_battles — 日次バトル (自然複合 PK 昇格、anchor (a) ADR-0012 §11.2)。
+// playerStatsJson は固定 5 キー (BattleStats hp/atk/def/spd/rec) のため列展開 (§11.3 の
+// 「実装時にキー数で確定」を 5 固定と実測して確定。ALTER ADD COLUMN 可で可逆)。
+// enemy_id はコード内 enemy master の安定 id (DB 採番 surrogate でないため integer 維持)。
+export const dailyBattles = pgTable(
+	'daily_battles',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		date: text('date').notNull(),
+		enemyId: integer('enemy_id').notNull(),
+		status: text('status').notNull().default('pending'),
+		outcome: text('outcome'),
+		rewardPoints: integer('reward_points').notNull().default(0),
+		turnsUsed: integer('turns_used').notNull().default(0),
+		playerHp: integer('player_hp').notNull().default(0),
+		playerAtk: integer('player_atk').notNull().default(0),
+		playerDef: integer('player_def').notNull().default(0),
+		playerSpd: integer('player_spd').notNull().default(0),
+		playerRec: integer('player_rec').notNull().default(0),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		updatedAt: timestamp('updated_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [
+		primaryKey({ columns: [t.familyId, t.childId, t.date] }),
+		check('daily_battles_status_ck', enumCheck(t.status, DAILY_BATTLE_STATUSES)),
+		check('daily_battles_outcome_ck', enumCheck(t.outcome, BATTLE_OUTCOMES)),
+	],
+);
+
+// enemy_collection — 敵図鑑 (自然複合 PK 昇格 §11.2)。enemy_id はコード内 master の安定 id。
+export const enemyCollection = pgTable(
+	'enemy_collection',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		enemyId: integer('enemy_id').notNull(),
+		firstDefeatedAt: timestamp('first_defeated_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		defeatCount: integer('defeat_count').notNull().default(1),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.enemyId] })],
+);
+
+// checklist_logs — 日次チェック記録 (自然複合 PK 昇格 §11.2)。itemsJson は
+// checklist_log_items 子表に解体 (§5 判断③)。
+export const checklistLogs = pgTable(
+	'checklist_logs',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		templateId: uuid('template_id').notNull(),
+		checkedDate: text('checked_date').notNull(),
+		completedAll: boolean('completed_all').notNull().default(false),
+		pointsAwarded: integer('points_awarded').notNull().default(0),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.templateId, t.checkedDate] })],
+);
+
+// checklist_log_items — itemsJson の子表化 (§5: item_id は checklist_template_items 論理FK)。
+export const checklistLogItems = pgTable(
+	'checklist_log_items',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		templateId: uuid('template_id').notNull(),
+		checkedDate: text('checked_date').notNull(),
+		itemId: uuid('item_id').notNull(),
+		checked: boolean('checked').notNull().default(false),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.templateId, t.checkedDate, t.itemId] })],
+);
+
+// checklist_overrides — 日次 override (UUID surrogate §11.2: 自然キー一意の前提を置かず確定 N5)。
+export const checklistOverrides = pgTable(
+	'checklist_overrides',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		overrideId: uuid('override_id').notNull().default(sql`gen_random_uuid()`),
+		targetDate: text('target_date').notNull(),
+		action: text('action').notNull(),
+		itemName: text('item_name').notNull(),
+		icon: text('icon').notNull().default('📦'),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [
+		primaryKey({ columns: [t.familyId, t.childId, t.overrideId] }),
+		check('checklist_overrides_action_ck', enumCheck(t.action, CHECKLIST_OVERRIDE_ACTIONS)),
+	],
+);
+
+// child_activity_preferences — ピン留め設定 (自然複合 PK 昇格、§3 欠落→編入 §11.2)。
+export const childActivityPreferences = pgTable(
+	'child_activity_preferences',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		activityId: uuid('activity_id').notNull(),
+		isPinned: boolean('is_pinned').notNull().default(false),
+		pinOrder: integer('pin_order'),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		updatedAt: timestamp('updated_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.activityId] })],
 );

--- a/tests/unit/db/dsql-check-from-ssot.test.ts
+++ b/tests/unit/db/dsql-check-from-ssot.test.ts
@@ -103,6 +103,26 @@ describe('fitness#13: children DDL CHECK は SSOT 生成 (手書き二重化禁�
 		for (const t of VALID_TIME_SLOTS) expect(s).toContain(`'${t}'`);
 	});
 
+	// ── daily_battles / checklist_overrides (#3424 Child 集約 Slice A) ──
+
+	it('daily_battles status/outcome CHECK が SSOT 全値を含む (DAILY_BATTLE_STATUSES / BATTLE_OUTCOMES)', async () => {
+		const { DAILY_BATTLE_STATUSES, BATTLE_OUTCOMES } = await import(
+			'../../../src/lib/domain/battle-types'
+		);
+		const statusSql = await checkSql('daily_battles_status_ck', 'dailyBattles');
+		for (const st of DAILY_BATTLE_STATUSES) expect(statusSql).toContain(`'${st}'`);
+		const outcomeSql = await checkSql('daily_battles_outcome_ck', 'dailyBattles');
+		for (const o of BATTLE_OUTCOMES) expect(outcomeSql).toContain(`'${o}'`);
+	});
+
+	it('checklist_overrides action CHECK が CHECKLIST_OVERRIDE_ACTIONS 全値を含む (SSOT 生成)', async () => {
+		const { CHECKLIST_OVERRIDE_ACTIONS } = await import(
+			'../../../src/lib/domain/constants/checklist-override-action'
+		);
+		const s2 = await checkSql('checklist_overrides_action_ck', 'checklistOverrides');
+		for (const a of CHECKLIST_OVERRIDE_ACTIONS) expect(s2).toContain(`'${a}'`);
+	});
+
 	// ── invites / consents (§6.6、#3528 cycle (b)) ──
 
 	it('invites status/role CHECK が SSOT 全値を含む (INVITE_STATUSES / ROLES)', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管の書込整合基盤）

**解決する課題**: Child 集約の記録系 9 表（週次評価 / おやすみ日 / バトル / チェックリスト記録・override / ピン留め）の DSQL 側テーブルが未定義で、repo 層・backup 移送の実装に進めない。加えて evaluations.scoresJson / checklist_logs.itemsJson / daily_battles.playerStatsJson の JSON-in-TEXT（§5 判断③）が未解体のままだった。

**期待される効果**: §11.2 凍結 PK 準拠の 9 表が確定し、JSON 列は子表/列展開に正規化され（評価集計の真の GROUP BY が SQL で可能に）、enum は SSOT 生成 CHECK で DB 強制される。

## 関連 Issue

- EPIC #3424（Phase C 集約別 DDL、実装計画 §1 の既定スライス。#3547 = StampCard/ChecklistTemplate と同型）
- related: `dsql-data-model.md` §11.2 / §5（JSON 解体判定）/ §11.3（列展開 vs 子表の確定事項）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 9 表の PK == §11.2 凍結表（evaluations / evaluation_scores / rest_days / daily_battles / enemy_collection / checklist_logs / checklist_log_items / checklist_overrides / child_activity_preferences） | `npx vitest run tests/unit/db/pk-freeze-manifest.test.ts`（fitness#9 [2][3]） | HEAD `c05d0b6e` / 4 passed（manifest は population 済、schema 追加分を doc-parse + 全表走査で自動突合） |
| AC2 | JSON 解体（§5 判断③）: scoresJson → evaluation_scores 子表 / itemsJson → checklist_log_items 子表 / playerStatsJson → 列展開 | schema.ts 差分 + §11.3 確定事項 | HEAD `c05d0b6e` / playerStatsJson は BattleStats（src/lib/domain/battle-types.ts:34、hp/atk/def/spd/rec の固定 5 キー）を実測し §11.3「実装時にキー数で確定」を列展開で確定 |
| AC3 | enum CHECK は SSOT 生成（daily_battles.status/outcome / checklist_overrides.action、fitness#13） | `npx vitest run tests/unit/db/dsql-check-from-ssot.test.ts` | HEAD `c05d0b6e` / 15 passed / **red 実測: CHECK SSOT 2 test が実装前 fail → green**。BATTLE_OUTCOMES / DAILY_BATTLE_STATUSES は battle-types.ts で runtime 化（型同値）、CHECKLIST_OVERRIDE_ACTIONS は domain constants 新設 |
| AC4 | temporal {mode:'string'}（fitness#6）+ §P2 family_id 先頭（fitness#9 [2b]）の自動検証 | `npx vitest run tests/unit/db/` | HEAD `c05d0b6e` / **549/549 pass** |
| AC5 | enemy_id の型判断: コード内 enemy master の安定 id（DB 採番 surrogate でない）のため integer 維持（uuid 変換規則の対象外） | schema.ts コメント + battle-service.ts の master 参照 | HEAD `c05d0b6e` / dailyBattles/enemyCollection の enemyId integer + 判断根拠コメント |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（DSQL backend の DDL 追加 + enum の runtime SSOT 化のみ。BattleOutcome/DailyBattleStatus の型は derive で同値のため既存コード無影響、既存挙動変更なし）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `dsql-check-from-ssot.test.ts` に daily_battles status/outcome + checklist_overrides action の CHECK SSOT 2 test 追記（red→green）。PK/temporal は既存 fitness が自動検証
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（未変更）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし**（DB スキーマ + domain 定数 + テストのみ。UI 変更なし）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（DDL / enum SSOT / テストを分離）。enum SSOT は既存の同心円（archive-types / subscription-status と同型）
- [x] **DRY**: CHECK は enumCheck helper + SSOT 共有（fitness#13）。BattleOutcome 等の型は runtime 配列から derive し二重定義なし
- [x] **YAGNI**: secondary index は §11.2 指定分のみ（本スライスは 0 本 = PK covering、§4.1）。repo/service 結線は後続
- [x] **Security（OSS 公開前提）**: 全表 family_id 先頭 PK（§P9 tenant 境界）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: PK covering 最優先（§4.1）。JSON 解体により evaluation 集計が index 可能な素の列に

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): 列レベル DDL は drizzle schema が SSOT（§11.3 委譲済）。playerStatsJson の列展開確定は §11.3 の「実装時確定」事項の履行
- [x] **並行 PR overlap** (#1200): `db/dsql/schema.ts` を触る open PR なし（本セッション直列管理）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（DDL 追加 + 型同値の SSOT 化のみ）

**レビュー依頼事項・QA**:
- daily_battles.playerStatsJson の列展開（固定 5 キー実測）判断。将来 BattleStats にキーが増える場合は ALTER ADD COLUMN で追従（§11.3 で可逆と明記済）
- enemy_id を integer 維持した判断（コード内 master の安定 id = uuid 変換規則の対象外）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし。#3547 QM 指摘の教訓 = PK 変更時の参照側コメント総ざらいを本 PR でも grep 確認済）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: Child 集約残りは Slice A（本 PR、記録系 9 表）/ Slice B（メッセージ・報酬系 8 表、次 PR）に分割
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
