### PR TITLE
feat: #3424 Child 集約 Slice B ボーナス・報酬・メッセージ系 10 表 DDL + JSON 解体

### DIFF
--- a/src/lib/domain/constants/child-challenge.ts
+++ b/src/lib/domain/constants/child-challenge.ts
@@ -1,0 +1,10 @@
+// src/lib/domain/constants/child-challenge.ts
+// per-child チャレンジ (#2362 PR-7) の固定集合 SSOT (#3424 DSQL 移管で runtime 配列化)。
+// DSQL child_challenges の CHECK 生成 (fitness#13) が参照する。
+// challenge_type ('cooperative' 単値、#2296) は新型追加があり得る増減集合のため CHECK 対象外。
+
+export const CHILD_CHALLENGE_STATUSES = ['active', 'completed', 'expired'] as const;
+export type ChildChallengeStatus = (typeof CHILD_CHALLENGE_STATUSES)[number];
+
+export const CHALLENGE_PERIOD_TYPES = ['weekly', 'monthly', 'custom'] as const;
+export type ChallengePeriodType = (typeof CHALLENGE_PERIOD_TYPES)[number];

--- a/src/lib/domain/constants/redemption-status.ts
+++ b/src/lib/domain/constants/redemption-status.ts
@@ -1,0 +1,12 @@
+// src/lib/domain/constants/redemption-status.ts
+// ごほうびショップ交換申請の状態機械 SSOT (#1337、#3424 DSQL 移管で runtime 配列化)。
+// 遷移: pending_parent_approval → approved / rejected / expired。
+// DSQL reward_redemption_requests.status の CHECK 生成 (fitness#13) と型定義が共有する。
+
+export const REDEMPTION_STATUSES = [
+	'pending_parent_approval',
+	'approved',
+	'rejected',
+	'expired',
+] as const;
+export type RedemptionStatus = (typeof REDEMPTION_STATUSES)[number];

--- a/src/lib/server/db/dsql/schema.ts
+++ b/src/lib/server/db/dsql/schema.ts
@@ -26,12 +26,18 @@ import { ARCHIVED_REASONS } from '$lib/domain/archive-types';
 import { BATTLE_OUTCOMES, DAILY_BATTLE_STATUSES } from '$lib/domain/battle-types';
 import { CHECKLIST_OVERRIDE_ACTIONS } from '$lib/domain/constants/checklist-override-action';
 import { type TimeSlot, VALID_TIME_SLOTS } from '$lib/domain/constants/checklist-time-slot';
+import {
+	CHALLENGE_PERIOD_TYPES,
+	CHILD_CHALLENGE_STATUSES,
+} from '$lib/domain/constants/child-challenge';
+import { REDEMPTION_STATUSES } from '$lib/domain/constants/redemption-status';
 import { STAMP_CARD_STATUSES, type StampCardStatus } from '$lib/domain/constants/stamp-card-status';
 import {
 	ALL_SUBSCRIPTION_STATUSES,
 	type SubscriptionStatus,
 } from '$lib/domain/constants/subscription-status';
 import { UI_MODES } from '$lib/domain/validation/age-tier-types';
+import { MESSAGE_TYPES } from '$lib/domain/validation/message';
 import {
 	AUTH_PROVIDERS,
 	type AuthProviderKind,
@@ -680,4 +686,243 @@ export const childActivityPreferences = pgTable(
 			.defaultNow(),
 	},
 	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.activityId] })],
+);
+
+// ── Child 集約 残り表 Slice B: ボーナス・報酬・メッセージ系 10 表 (§11.2 / §5、#3424) ──
+
+// login_bonuses — ログインボーナス (自然複合 PK、anchor (a) ADR-0012: 1日1回 §11.2)。
+// rank はおみくじ演出の増減集合のため CHECK 対象外。
+export const loginBonuses = pgTable(
+	'login_bonuses',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		loginDate: text('login_date').notNull(),
+		rank: text('rank').notNull(),
+		basePoints: integer('base_points').notNull(),
+		multiplier: real('multiplier').notNull().default(1.0),
+		totalPoints: integer('total_points').notNull(),
+		consecutiveDays: integer('consecutive_days').notNull().default(1),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.loginDate] })],
+);
+
+// certificates — がんばり証明書 (UUID surrogate、§11.2 governing rule: 再発行/周期型証書が
+// roadmap プラウジブル)。metadata は発行後 immutable・不検索で §5 上 jsonb 可だが、backup の
+// verbatim 移送 (§9.1) を優先し text 維持 ({mode:'json'} 化は repo PR で判断)。
+// certificate_type は増減集合 (周期型証書の追加があり得る) のため CHECK 対象外。
+// 「1 type 有効1通」の active_key 生成列 + UNIQUE (§11.2「要時、droppable」) は、現 product に
+// 有効/無効 (revoke) 概念が無く「要時」に該当しないため未設置 (導入時に ALTER で追加可)。
+export const certificates = pgTable(
+	'certificates',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		certificateId: uuid('certificate_id').notNull().default(sql`gen_random_uuid()`),
+		certificateType: text('certificate_type').notNull(),
+		title: text('title').notNull(),
+		description: text('description'),
+		issuedAt: timestamp('issued_at', { mode: 'string', withTimezone: true }).notNull().defaultNow(),
+		metadata: text('metadata'),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.certificateId] })],
+);
+
+// special_rewards — 特別ごほうび。granted_by は親 user 等の polymorphic 参照 (旧 int/新 uuid
+// 混在許容で text、point_ledger.reference_id と同判断)。shop_category は増減集合で CHECK 対象外。
+export const specialRewards = pgTable(
+	'special_rewards',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		rewardId: uuid('reward_id').notNull().default(sql`gen_random_uuid()`),
+		grantedBy: text('granted_by'),
+		title: text('title').notNull(),
+		description: text('description'),
+		points: integer('points').notNull(),
+		icon: text('icon'),
+		category: text('category').notNull(),
+		grantedAt: timestamp('granted_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		shownAt: timestamp('shown_at', { mode: 'string', withTimezone: true }),
+		sourcePresetId: text('source_preset_id'),
+		shopCategory: text('shop_category'),
+	},
+	(t) => [
+		primaryKey({ columns: [t.familyId, t.childId, t.rewardId] }),
+		// findUnshownReward hot (§11.2 補助 secondary)。
+		index('special_rewards_granted_idx').on(t.familyId, t.childId, t.grantedAt),
+	],
+);
+
+// reward_redemption_requests — ごほうびショップ交換申請 (#1337)。
+// requested_at/resolved_at/shown_to_child_at は旧 epoch integer → timestamptz に正規化 (§11.3)。
+// reward_title/points/icon は申請時点 snapshot (#2832、非正規化は実装事実と一致 判断①)。
+export const rewardRedemptionRequests = pgTable(
+	'reward_redemption_requests',
+	{
+		familyId: uuid('family_id').notNull(),
+		redemptionId: uuid('redemption_id').notNull().default(sql`gen_random_uuid()`),
+		childId: uuid('child_id').notNull(),
+		rewardId: uuid('reward_id').notNull(),
+		requestedAt: timestamp('requested_at', { mode: 'string', withTimezone: true }).notNull(),
+		status: text('status').notNull().default('pending_parent_approval'),
+		parentNote: text('parent_note'),
+		resolvedAt: timestamp('resolved_at', { mode: 'string', withTimezone: true }),
+		resolvedByParentId: text('resolved_by_parent_id'),
+		shownToChildAt: timestamp('shown_to_child_at', { mode: 'string', withTimezone: true }),
+		rewardTitle: text('reward_title'),
+		rewardPoints: integer('reward_points'),
+		rewardIcon: text('reward_icon'),
+	},
+	(t) => [
+		primaryKey({ columns: [t.familyId, t.redemptionId] }),
+		// §11.2 補助 secondary 2 本 (child×status / status×requested_at)。
+		index('redemption_child_status_idx').on(t.familyId, t.childId, t.status),
+		index('redemption_status_requested_idx').on(t.familyId, t.status, t.requestedAt),
+		check('reward_redemption_requests_status_ck', enumCheck(t.status, REDEMPTION_STATUSES)),
+	],
+);
+
+// parent_messages — 親→子メッセージ。sent_at は sort 用途 (PK に入れない §11.2、
+// findMessages/findUnshownMessage は PK プレフィクス + shown_at 残差 + sort LIMIT)。
+export const parentMessages = pgTable(
+	'parent_messages',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		msgId: uuid('msg_id').notNull().default(sql`gen_random_uuid()`),
+		messageType: text('message_type').notNull(),
+		stampCode: text('stamp_code'),
+		body: text('body'),
+		icon: text('icon').notNull().default('💌'),
+		sentAt: timestamp('sent_at', { mode: 'string', withTimezone: true }).notNull().defaultNow(),
+		shownAt: timestamp('shown_at', { mode: 'string', withTimezone: true }),
+		bonusPoints: integer('bonus_points'),
+		rewardCategory: text('reward_category'),
+	},
+	(t) => [
+		primaryKey({ columns: [t.familyId, t.childId, t.msgId] }),
+		check('parent_messages_message_type_ck', enumCheck(t.messageType, MESSAGE_TYPES)),
+	],
+);
+
+// sibling_cheers — 兄弟応援 (family scope、from/to の 2 child 参照のため child 主軸にしない §11.2)。
+export const siblingCheers = pgTable(
+	'sibling_cheers',
+	{
+		familyId: uuid('family_id').notNull(),
+		cheerId: uuid('cheer_id').notNull().default(sql`gen_random_uuid()`),
+		fromChildId: uuid('from_child_id').notNull(),
+		toChildId: uuid('to_child_id').notNull(),
+		stampCode: text('stamp_code').notNull(),
+		sentAt: timestamp('sent_at', { mode: 'string', withTimezone: true }).notNull().defaultNow(),
+		shownAt: timestamp('shown_at', { mode: 'string', withTimezone: true }),
+	},
+	(t) => [
+		primaryKey({ columns: [t.familyId, t.cheerId] }),
+		// findUnshownCheers hot (§11.2 補助 secondary)。
+		index('sibling_cheers_to_shown_idx').on(t.familyId, t.toChildId, t.shownAt),
+	],
+);
+
+// character_images — キャラ画像 (key+メタのみ §9.4、バイトは IStorageRepo)。
+export const characterImages = pgTable(
+	'character_images',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		imageId: uuid('image_id').notNull().default(sql`gen_random_uuid()`),
+		type: text('type').notNull(),
+		filePath: text('file_path').notNull(),
+		promptHash: text('prompt_hash'),
+		generatedAt: timestamp('generated_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.imageId] })],
+);
+
+// child_custom_voices — ユーザー録音ボイス (source/not-yet-exported = backup 必須 §11.2)。
+// key+メタのみ (§9.4)、scene は素の列。
+export const childCustomVoices = pgTable(
+	'child_custom_voices',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		voiceId: uuid('voice_id').notNull().default(sql`gen_random_uuid()`),
+		scene: text('scene').notNull().default('complete'),
+		label: text('label').notNull(),
+		filePath: text('file_path').notNull(),
+		publicUrl: text('public_url').notNull(),
+		durationMs: integer('duration_ms'),
+		isActive: boolean('is_active').notNull().default(false),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.voiceId] })],
+);
+
+// child_challenges — per-child チャレンジ (#2362 PR-7)。targetConfig/rewardConfig は
+// 列展開 (§5: target_metric / target_category_id 論理FK / base_target / reward_points /
+// reward_message)。challenge_type は増減集合 (CHECK 対象外)。
+export const childChallenges = pgTable(
+	'child_challenges',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		challengeId: uuid('challenge_id').notNull().default(sql`gen_random_uuid()`),
+		title: text('title').notNull(),
+		description: text('description'),
+		challengeType: text('challenge_type').notNull().default('cooperative'),
+		periodType: text('period_type').notNull().default('weekly'),
+		startDate: text('start_date').notNull(),
+		endDate: text('end_date').notNull(),
+		targetMetric: text('target_metric').notNull(),
+		targetCategoryId: text('target_category_id'),
+		baseTarget: integer('base_target').notNull(),
+		rewardPoints: integer('reward_points').notNull(),
+		rewardMessage: text('reward_message'),
+		status: text('status').notNull().default('active'),
+		isActive: boolean('is_active').notNull().default(true),
+		sourceTemplateId: text('source_template_id'),
+		currentValue: integer('current_value').notNull().default(0),
+		targetValue: integer('target_value').notNull(),
+		completed: boolean('completed').notNull().default(false),
+		completedAt: timestamp('completed_at', { mode: 'string', withTimezone: true }),
+		rewardClaimed: boolean('reward_claimed').notNull().default(false),
+		rewardClaimedAt: timestamp('reward_claimed_at', { mode: 'string', withTimezone: true }),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		updatedAt: timestamp('updated_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [
+		primaryKey({ columns: [t.familyId, t.childId, t.challengeId] }),
+		// findActiveOrUnclaimed hot (§11.2 補助 secondary)。
+		index('child_challenges_status_idx').on(t.familyId, t.childId, t.status),
+		check('child_challenges_status_ck', enumCheck(t.status, CHILD_CHALLENGE_STATUSES)),
+		check('child_challenges_period_type_ck', enumCheck(t.periodType, CHALLENGE_PERIOD_TYPES)),
+	],
+);
+
+// usage_logs — 利用時間ログ。started_at/ended_at は timestamptz、duration_sec は終了時算出。
+export const usageLogs = pgTable(
+	'usage_logs',
+	{
+		familyId: uuid('family_id').notNull(),
+		childId: uuid('child_id').notNull(),
+		logId: uuid('log_id').notNull().default(sql`gen_random_uuid()`),
+		startedAt: timestamp('started_at', { mode: 'string', withTimezone: true }).notNull(),
+		endedAt: timestamp('ended_at', { mode: 'string', withTimezone: true }),
+		durationSec: integer('duration_sec'),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.logId] })],
 );

--- a/tests/unit/db/dsql-check-from-ssot.test.ts
+++ b/tests/unit/db/dsql-check-from-ssot.test.ts
@@ -123,6 +123,32 @@ describe('fitness#13: children DDL CHECK は SSOT 生成 (手書き二重化禁�
 		for (const a of CHECKLIST_OVERRIDE_ACTIONS) expect(s2).toContain(`'${a}'`);
 	});
 
+	// ── Slice B: parent_messages / reward_redemption_requests / child_challenges (#3424) ──
+
+	it('parent_messages message_type CHECK が MESSAGE_TYPES 全値を含む (SSOT 生成)', async () => {
+		const { MESSAGE_TYPES } = await import('../../../src/lib/domain/validation/message');
+		const s2 = await checkSql('parent_messages_message_type_ck', 'parentMessages');
+		for (const m of MESSAGE_TYPES) expect(s2).toContain(`'${m}'`);
+	});
+
+	it('reward_redemption_requests status CHECK が REDEMPTION_STATUSES 全値を含む (SSOT 生成)', async () => {
+		const { REDEMPTION_STATUSES } = await import(
+			'../../../src/lib/domain/constants/redemption-status'
+		);
+		const s2 = await checkSql('reward_redemption_requests_status_ck', 'rewardRedemptionRequests');
+		for (const st of REDEMPTION_STATUSES) expect(s2).toContain(`'${st}'`);
+	});
+
+	it('child_challenges status/period_type CHECK が SSOT 全値を含む (challenge_type は増減集合で対象外)', async () => {
+		const { CHILD_CHALLENGE_STATUSES, CHALLENGE_PERIOD_TYPES } = await import(
+			'../../../src/lib/domain/constants/child-challenge'
+		);
+		const statusSql = await checkSql('child_challenges_status_ck', 'childChallenges');
+		for (const st of CHILD_CHALLENGE_STATUSES) expect(statusSql).toContain(`'${st}'`);
+		const periodSql = await checkSql('child_challenges_period_type_ck', 'childChallenges');
+		for (const pt of CHALLENGE_PERIOD_TYPES) expect(periodSql).toContain(`'${pt}'`);
+	});
+
 	// ── invites / consents (§6.6、#3528 cycle (b)) ──
 
 	it('invites status/role CHECK が SSOT 全値を含む (INVITE_STATUSES / ROLES)', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管の書込整合基盤）

**解決する課題**: Child 集約のボーナス・報酬・メッセージ系 10 表（ログインボーナス / 証明書 / 特別ごほうび / 交換申請 / 親メッセージ / 兄弟応援 / キャラ画像 / 録音ボイス / チャレンジ / 利用ログ)の DSQL 側テーブルが未定義。child_challenges.targetConfig/rewardConfig の JSON-in-TEXT（§5 判断③）も未解体だった。

**期待される効果**: これで **Child 集約の全テナント表 DDL が §11.2 凍結 PK 準拠で完備**し（残りは Family 系 8 表のみ）、repo 層・backup 移送・recordActivity optional 結線の実装に進める。

## 関連 Issue

- EPIC #3424（Phase C 集約別 DDL の最終 Child スライス。Slice A = PR #3563 と対）
- related: `dsql-data-model.md` §11.2 / §5 / §9.4（key+メタ原則）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 10 表の PK == §11.2 凍結表（login_bonuses / certificates / special_rewards / reward_redemption_requests / parent_messages / sibling_cheers / character_images / child_custom_voices / child_challenges / usage_logs） | `npx vitest run tests/unit/db/pk-freeze-manifest.test.ts`（fitness#9 [2][3]） | HEAD `ec6ac77c` / 4 passed（doc-parse + 全表走査の自動突合） |
| AC2 | child_challenges の targetConfig/rewardConfig を列展開（§5: target_metric / target_category_id 論理FK / base_target / reward_points / reward_message） | schema.ts 差分 | HEAD `ec6ac77c` / childChallenges の 5 列展開 + 進捗 inline 列（currentValue 等）は sqlite 実装事実を踏襲 |
| AC3 | enum CHECK は SSOT 生成（parent_messages.message_type / redemption.status / challenge.status+period_type、fitness#13）。増減集合（rank / certificate_type / challenge_type / shop_category）は CHECK 対象外の判断根拠をコメント明記 | `npx vitest run tests/unit/db/dsql-check-from-ssot.test.ts` | HEAD `ec6ac77c` / 18 passed / **red 実測: CHECK SSOT 3 test が実装前 fail → green**。MESSAGE_TYPES は既存 runtime SSOT 再利用、REDEMPTION_STATUSES / CHILD_CHALLENGE_STATUSES / CHALLENGE_PERIOD_TYPES は domain constants 新設 |
| AC4 | temporal 正規化: reward_redemption_requests の epoch integer 3 列（requested/resolved/shown_to_child）を timestamptz {mode:'string'} 化（§11.3）+ fitness#6 自動検証 | `npx vitest run tests/unit/db/` | HEAD `ec6ac77c` / **552/552 pass** |
| AC5 | §11.2 補助 secondary 4 本（special_rewards granted_at / redemption child×status + status×requested_at / child_challenges status / sibling_cheers to×shown）を指定通り設置 | schema.ts 差分と §11.2 の突合 | HEAD `ec6ac77c` / 各 index 定義に §11.2 出典コメント付き |
| AC6 | certificates の active_key 生成列 + UNIQUE（§11.2「要時、droppable」）は現 product に revoke 概念が無く「要時」非該当のため未設置（導入時 ALTER 追加可） | schema.ts コメント | HEAD `ec6ac77c` / 判断根拠を DDL コメントに明記（QM 確認事項として下記に再掲） |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（DSQL backend の DDL 追加 + domain 定数新設のみ。既存コードからの参照ゼロ、既存挙動変更なし）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `dsql-check-from-ssot.test.ts` に CHECK SSOT 3 test 追記（red→green）。PK/temporal/§P2 は既存 fitness が自動検証
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（未変更）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし**（DB スキーマ + domain 定数 + テストのみ。UI 変更なし）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: enum SSOT は既存同型（archive-types 等）の domain constants パターン。DDL は宣言のみ
- [x] **DRY**: MESSAGE_TYPES は既存 runtime SSOT を再利用（新設せず）。CHECK は enumCheck helper 共有
- [x] **YAGNI**: certificates の active_key UNIQUE は「要時」非該当で未設置（前倒し導入しない）。metadata の jsonb 化も backup verbatim 優先で text 維持（repo PR で判断）
- [x] **Security（OSS 公開前提）**: 全表 family_id 先頭 PK（§P9）。granted_by は polymorphic 参照で text 化（reference_id と同判断）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: secondary は §11.2 指定の 4 本のみ（PK covering 最優先 §4.1、hot な二次 index 共有による OCC 競合面積も最小化 §8）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): 列レベル DDL は drizzle schema が SSOT（§11.3 委譲済）
- [x] **並行 PR overlap** (#1200): `db/dsql/schema.ts` は本セッション直列管理。**本 branch は Slice A（PR #3563、Ready）の上に stack** しており、#3563 merge 後に本 PR の diff が単体化する
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（DDL 追加 + 参照ゼロの定数新設のみ）

**レビュー依頼事項・QA**:
- certificates の active_key 生成列 + UNIQUE を「要時非該当」で未設置とした判断（AC6。現 product に証明書の有効/無効概念が無い。導入時は ALTER ADD COLUMN + UNIQUE で後付け可 = 可逆）
- certificates.metadata を jsonb でなく text 維持とした判断（§5 は jsonb 可だが、backup verbatim 移送 §9.1 との整合を repo PR で確定するまで保守側に倒した）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし。参照側コメントの stale 化 grep 確認済 = #3547 QM 指摘の教訓）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: Child 集約は Slice A（#3563）/ Slice B（本 PR）で完結。次スライス = Family 系 8 表 DDL
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
