### PR TITLE
feat: #3424 Family 系 8 表 DDL (Slice C) — 全 45 表の DSQL DDL 完備

### DIFF
--- a/src/lib/domain/constants/cloud-export-status.ts
+++ b/src/lib/domain/constants/cloud-export-status.ts
@@ -1,0 +1,7 @@
+// src/lib/domain/constants/cloud-export-status.ts
+// クラウドバックアップ export の非同期 build 状態機械 SSOT (#3504、#3424 で runtime 配列化)。
+// 遷移: pending → building → ready / failed (stale building は cron が reclaim、#3509)。
+// DSQL cloud_exports.status の CHECK 生成 (fitness#13) と型定義が共有する。
+
+export const CLOUD_EXPORT_STATUSES = ['pending', 'building', 'ready', 'failed'] as const;
+export type CloudExportStatus = (typeof CLOUD_EXPORT_STATUSES)[number];

--- a/src/lib/server/db/dsql/schema.ts
+++ b/src/lib/server/db/dsql/schema.ts
@@ -30,6 +30,10 @@ import {
 	CHALLENGE_PERIOD_TYPES,
 	CHILD_CHALLENGE_STATUSES,
 } from '$lib/domain/constants/child-challenge';
+import {
+	CLOUD_EXPORT_STATUSES,
+	type CloudExportStatus,
+} from '$lib/domain/constants/cloud-export-status';
 import { REDEMPTION_STATUSES } from '$lib/domain/constants/redemption-status';
 import { STAMP_CARD_STATUSES, type StampCardStatus } from '$lib/domain/constants/stamp-card-status';
 import {
@@ -925,4 +929,175 @@ export const usageLogs = pgTable(
 		durationSec: integer('duration_sec'),
 	},
 	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.logId] })],
+);
+
+// ── Family 系 8 表 (§11.2 #3557 確定 / 調査 SSOT: tmp/research-family-tables-pk-2026-07-03.md、#3424) ──
+// settings のみ自然複合 (anchor (b) KVS 構造的確実性)、他 7 表は UUID surrogate。
+// endpoint/token/pin の global UNIQUE は無 tenant 単点 lookup の機能要件 (§11.2)。
+
+// settings — family KVS (自然複合 (family_id, key)、anchor (b))。
+// ⚠️ sqlite 現行は tenant_id 列なし (key 単独 PK のグローバル KVS) — cutover で family_id を
+// 追加する前提差分 (#3557 PR body で QM 確認済。単一家族 NUC は定数 family_id、§P10)。
+export const settings = pgTable(
+	'settings',
+	{
+		familyId: uuid('family_id').notNull(),
+		key: text('key').notNull(),
+		value: text('value').notNull(),
+		updatedAt: timestamp('updated_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.key] })],
+);
+
+// push_subscriptions — Web Push 購読 (UUID surrogate: endpoint は rotate される mutable)。
+// endpoint は findByEndpoint が tenant 無しで値単独 lookup するため global UNIQUE 必須 (§11.2)。
+export const pushSubscriptions = pgTable(
+	'push_subscriptions',
+	{
+		familyId: uuid('family_id').notNull(),
+		subscriptionId: uuid('subscription_id').notNull().default(sql`gen_random_uuid()`),
+		endpoint: text('endpoint').notNull().unique(),
+		keysP256dh: text('keys_p256dh').notNull(),
+		keysAuth: text('keys_auth').notNull(),
+		userAgent: text('user_agent'),
+		subscriberRole: text('subscriber_role').notNull().default('parent'),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.subscriptionId] })],
+);
+
+// notification_logs — 通知送信ログ (UUID surrogate: append-only log)。sent_at は sort 用途。
+export const notificationLogs = pgTable(
+	'notification_logs',
+	{
+		familyId: uuid('family_id').notNull(),
+		logId: uuid('log_id').notNull().default(sql`gen_random_uuid()`),
+		notificationType: text('notification_type').notNull(),
+		title: text('title').notNull(),
+		body: text('body').notNull(),
+		sentAt: timestamp('sent_at', { mode: 'string', withTimezone: true }).notNull().defaultNow(),
+		success: boolean('success').notNull().default(true),
+		errorMessage: text('error_message'),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.logId] })],
+);
+
+// trial_history — トライアル履歴 (UUID surrogate: 1 tenant N 回)。tier/source/upgrade_reason は
+// 増減集合 (plan lookup 方針 §6.6 / campaign 追加あり得る) のため CHECK 対象外。
+// cross-tenant cron (findActiveTrials end_date) 用 secondary は §P5 計測後 (§11.2 #3557)。
+export const trialHistory = pgTable(
+	'trial_history',
+	{
+		familyId: uuid('family_id').notNull(),
+		trialId: uuid('trial_id').notNull().default(sql`gen_random_uuid()`),
+		startDate: text('start_date').notNull(),
+		endDate: text('end_date').notNull(),
+		tier: text('tier').notNull().default('standard'),
+		source: text('source').notNull(),
+		campaignId: text('campaign_id'),
+		stripeSubscriptionId: text('stripe_subscription_id'),
+		upgradeReason: text('upgrade_reason'),
+		trialStartSource: text('trial_start_source'),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.trialId] })],
+);
+
+// viewer_tokens — 閲覧専用リンク (UUID surrogate: token は revoke 後再発行あり)。
+// token は findByToken が tenant 無しで値単独 lookup するため global UNIQUE 必須 (§11.2)。
+// 失効判定は app 層述語 (revoked_at/expires_at 素の列、部分 index 不可 spike#2 §3.5.3)。
+export const viewerTokens = pgTable(
+	'viewer_tokens',
+	{
+		familyId: uuid('family_id').notNull(),
+		tokenId: uuid('token_id').notNull().default(sql`gen_random_uuid()`),
+		token: text('token').notNull().unique(),
+		label: text('label'),
+		expiresAt: timestamp('expires_at', { mode: 'string', withTimezone: true }),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+		revokedAt: timestamp('revoked_at', { mode: 'string', withTimezone: true }),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.tokenId] })],
+);
+
+// cloud_exports — クラウドバックアップ export (UUID surrogate: pin は expire 後再利用)。
+// pin_code は findByPin が tenant 無しで値単独 lookup するため global UNIQUE 必須。
+// status は state machine (pending→building→ready/failed #3504/#3509) で SSOT 生成 CHECK。
+// secondary(status) は cron drainPendingExports 用 (family 非依存の cross-tenant scan、§11.2 #3557)。
+export const cloudExports = pgTable(
+	'cloud_exports',
+	{
+		familyId: uuid('family_id').notNull(),
+		exportId: uuid('export_id').notNull().default(sql`gen_random_uuid()`),
+		exportType: text('export_type').notNull(),
+		pinCode: text('pin_code').notNull().unique(),
+		s3Key: text('s3_key').notNull(),
+		fileSizeBytes: integer('file_size_bytes').notNull(),
+		label: text('label'),
+		description: text('description'),
+		expiresAt: timestamp('expires_at', { mode: 'string', withTimezone: true }).notNull(),
+		downloadCount: integer('download_count').notNull().default(0),
+		maxDownloads: integer('max_downloads').notNull().default(10),
+		status: text('status').notNull().default('pending').$type<CloudExportStatus>(),
+		failureReason: text('failure_reason'),
+		buildStartedAt: timestamp('build_started_at', { mode: 'string', withTimezone: true }),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [
+		primaryKey({ columns: [t.familyId, t.exportId] }),
+		index('cloud_exports_status_idx').on(t.status),
+		check('cloud_exports_status_ck', enumCheck(t.status, CLOUD_EXPORT_STATUSES)),
+	],
+);
+
+// cancellation_reasons — 解約理由 (UUID surrogate: append-only、PO KPI 分析表)。
+// category は KPI 分類で追加があり得る増減集合のため CHECK 対象外。
+// cross-tenant 分析 secondary は §P5 計測後 (§11.2 #3557。hot path が cross-tenant である点は
+// Family repo 実装 PR で明示)。
+export const cancellationReasons = pgTable(
+	'cancellation_reasons',
+	{
+		familyId: uuid('family_id').notNull(),
+		reasonId: uuid('reason_id').notNull().default(sql`gen_random_uuid()`),
+		category: text('category').notNull(),
+		freeText: text('free_text'),
+		planAtCancellation: text('plan_at_cancellation'),
+		stripeSubscriptionId: text('stripe_subscription_id'),
+		createdAt: timestamp('created_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.familyId, t.reasonId] })],
+);
+
+// graduation_consent — 卒業同意 (UUID surrogate: 複数子×複数回で多数行が正)。
+// secondary(consented, consented_at) は publicSamples/aggregate 用 (cross-tenant、§11.2 #3557)。
+export const graduationConsent = pgTable(
+	'graduation_consent',
+	{
+		familyId: uuid('family_id').notNull(),
+		consentId: uuid('consent_id').notNull().default(sql`gen_random_uuid()`),
+		nickname: text('nickname').notNull(),
+		consented: boolean('consented').notNull().default(false),
+		userPoints: integer('user_points').notNull().default(0),
+		usagePeriodDays: integer('usage_period_days').notNull().default(0),
+		message: text('message'),
+		consentedAt: timestamp('consented_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [
+		primaryKey({ columns: [t.familyId, t.consentId] }),
+		index('graduation_consent_public_idx').on(t.consented, t.consentedAt),
+	],
 );

--- a/src/lib/server/db/types/index.ts
+++ b/src/lib/server/db/types/index.ts
@@ -1030,7 +1030,10 @@ export type CloudExportType = 'template' | 'full';
  * pending (build 待ち) → building (cron が build 中) → ready (DL 可) / failed (build 失敗)。
  * 本機構導入前に作成された既存レコードは lazy migration で 'ready' に backfill される。
  */
-export type CloudExportStatus = 'pending' | 'building' | 'ready' | 'failed';
+// #3424: runtime SSOT は $lib/domain/constants/cloud-export-status (DSQL CHECK 生成と共有、型同値)
+import type { CloudExportStatus } from '$lib/domain/constants/cloud-export-status';
+
+export type { CloudExportStatus };
 
 export interface CloudExportRecord {
 	id: number;

--- a/tests/unit/db/dsql-check-from-ssot.test.ts
+++ b/tests/unit/db/dsql-check-from-ssot.test.ts
@@ -149,6 +149,16 @@ describe('fitness#13: children DDL CHECK は SSOT 生成 (手書き二重化禁�
 		for (const pt of CHALLENGE_PERIOD_TYPES) expect(periodSql).toContain(`'${pt}'`);
 	});
 
+	// ── Slice C: cloud_exports (#3424 Family 系) ──
+
+	it('cloud_exports status CHECK が CLOUD_EXPORT_STATUSES 全値を含む (SSOT 生成)', async () => {
+		const { CLOUD_EXPORT_STATUSES } = await import(
+			'../../../src/lib/domain/constants/cloud-export-status'
+		);
+		const s2 = await checkSql('cloud_exports_status_ck', 'cloudExports');
+		for (const st of CLOUD_EXPORT_STATUSES) expect(s2).toContain(`'${st}'`);
+	});
+
 	// ── invites / consents (§6.6、#3528 cycle (b)) ──
 
 	it('invites status/role CHECK が SSOT 全値を含む (INVITE_STATUSES / ROLES)', async () => {

--- a/tests/unit/db/dsql-stamp-checklist-schema.test.ts
+++ b/tests/unit/db/dsql-stamp-checklist-schema.test.ts
@@ -35,3 +35,30 @@ describe('StampCard / ChecklistTemplate 集約 DDL の構造要件 (§11.2 補�
 		expect(indexCols).toContain('family_id,child_id');
 	});
 });
+
+describe('Family 系 8 表 DDL の構造要件 (§11.2 #3557 確定行の補助 UNIQUE/secondary)', () => {
+	it('無 tenant 単点 lookup の global UNIQUE 3 本 (endpoint / token / pin_code)', async () => {
+		const schema = await import('../../../src/lib/server/db/dsql/schema');
+		for (const [table, col] of [
+			[schema.pushSubscriptions, 'endpoint'],
+			[schema.viewerTokens, 'token'],
+			[schema.cloudExports, 'pin_code'],
+		] as const) {
+			const cfg = getTableConfig(table);
+			const single = cfg.columns.find((c) => c.name === col);
+			expect(single?.isUnique, `${col} は global UNIQUE 必須 (値単独 lookup)`).toBe(true);
+		}
+	});
+
+	it('cross-tenant secondary: cloud_exports(status) / graduation_consent(consented, consented_at)', async () => {
+		const schema = await import('../../../src/lib/server/db/dsql/schema');
+		const exportIdx = getTableConfig(schema.cloudExports).indexes.map((i) =>
+			i.config.columns.map((c) => ('name' in c ? (c as { name: string }).name : '')).join(','),
+		);
+		expect(exportIdx, 'cron findPendingBuilds 用 (family 非依存)').toContain('status');
+		const gradIdx = getTableConfig(schema.graduationConsent).indexes.map((i) =>
+			i.config.columns.map((c) => ('name' in c ? (c as { name: string }).name : '')).join(','),
+		);
+		expect(gradIdx, 'publicSamples/aggregate 用').toContain('consented,consented_at');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管の設計→実装フェーズ完遂の基盤）

**解決する課題**: Family 系 8 表（settings / push_subscriptions / notification_logs / trial_history / viewer_tokens / cloud_exports / cancellation_reasons / graduation_consent）の DSQL 側テーブルが未定義で、PR #3557 で凍結した PK の実装が残っていた。

**期待される効果**: **全テナント表 40 + auth 5 = 45 表の DSQL DDL が §11.2 凍結 PK 準拠で完備**し、EPIC #3424 の DDL フェーズが完了。以降は repo 層・backup 移送・cutover に集中できる。

## 関連 Issue

- EPIC #3424（Phase C 集約別 DDL の最終スライス。PK 凍結 = PR #3557 / 調査 SSOT: `tmp/research-family-tables-pk-2026-07-03.md`）
- related: PR #3563 / #3564（Child 集約 Slice A/B）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 8 表の PK == §11.2 凍結表（#3557 確定行。settings のみ自然複合、他 7 表 UUID surrogate） | `npx vitest run tests/unit/db/pk-freeze-manifest.test.ts`（fitness#9 [2][3]） | HEAD `05c0b38a` / 4 passed / **45 表全てが doc-parse + 全表走査で manifest 一致** |
| AC2 | 無 tenant 単点 lookup の global UNIQUE 3 本（endpoint / token / pin_code、§11.2 機能要件） | `npx vitest run tests/unit/db/dsql-stamp-checklist-schema.test.ts` | HEAD `05c0b38a` / **red 実測: 構造 2 test が実装前 fail → green** / 5 passed |
| AC3 | cross-tenant secondary 2 本（cloud_exports(status)=cron drainPendingBuilds / graduation_consent(consented,consented_at)=publicSamples）を §11.2 確定行の通り設置。trial_history / cancellation_reasons の cross-tenant secondary は §P5 計測後（未設置も §11.2 通り） | 同上 + schema.ts コメントの §11.2 出典 | HEAD `05c0b38a` / index 2 本 + 未設置根拠コメント |
| AC4 | cloud_exports.status の CHECK を SSOT 生成（state machine #3504/#3509）。tier/source/category 等の増減集合は CHECK 対象外の根拠コメント | `npx vitest run tests/unit/db/dsql-check-from-ssot.test.ts` | HEAD `05c0b38a` / 19 passed / **red 実測: CHECK test 実装前 fail** / CLOUD_EXPORT_STATUSES を domain constants 新設し db/types の型は derive（同値） |
| AC5 | settings の cutover 前提差分（sqlite 現行に tenant_id 列なし → family_id 追加、§P10 定数）を DDL コメントに明記 | schema.ts settings コメント | HEAD `05c0b38a` / #3557 PR body の QM 確認事項を実装側にも転記 |
| AC6 | temporal {mode:'string'} / §P2 family_id 先頭 / CloudExportStatus derive の無退行 | `npx vitest run tests/unit/db/ tests/unit/services/ src/lib/server/services/ tests/unit/routes/` | HEAD `05c0b38a` / **db 555/555 + services/routes 2744/2744 pass** / svelte-check 0 errors |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（DSQL backend の DDL 追加 + CloudExportStatus の型 derive 化 = 同値のため既存コード無影響）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: CHECK SSOT 1 test + 構造 2 test（global UNIQUE / cross-tenant secondary）追記、red→green
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（未変更）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし**（DB スキーマ + domain 定数 + テストのみ。UI 変更なし）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: enum SSOT は既存 domain constants パターン。db/types の型は derive で単一 SSOT 化
- [x] **DRY**: CHECK は enumCheck helper 共有。PK は §11.2 ↔ manifest ↔ schema の三者機械同期
- [x] **YAGNI**: 計測後と凍結した secondary（trial/cancellation）は未設置。family 削除 orchestrator（調査注意点 3）は Family repo 実装 PR の必須 AC として調査レポートに記録済
- [x] **Security（OSS 公開前提）**: 全表 family_id 先頭 PK（§P9）。viewer_tokens/cloud_exports の失効判定は app 層述語（部分 index 不可 spike#2、§3.5.3 準拠）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: cross-tenant scan（cron/分析）は §11.2 で確定した最小 secondary のみ

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): §11.2 #3557 確定行の実装であり設計変更なし
- [x] **並行 PR overlap** (#1200): `db/dsql/schema.ts` は本セッション直列管理、open PR なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（DDL 追加 + 型同値の derive 化のみ）

**レビュー依頼事項・QA**:
- push_subscriptions.subscriber_role に CHECK を張らなかった判断（既定 'parent' だが値集合が ROLES と同一か未確証のため保守側。repo PR で実データ確認後に判断）
- これで DDL フェーズ完了。次フェーズ（repo 層 = tx 必須引数 + fitness#7/#8 gate 稼働域、backup 移送、cutover §12.2）の着手順は EPIC 側で判断いただきたい

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし。参照側コメント stale 化の grep 確認済）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: DDL フェーズは Slice A/B/C で完結（本 PR が最終）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
