### PR TITLE
fix(infra): #3570 AWS deploy の DKIM replacement 承認 + ADR-0019 GetAtt 悲観判定 例外注記

### DIFF
--- a/docs/decisions/0019-cdk-replacement-detection-gate.md
+++ b/docs/decisions/0019-cdk-replacement-detection-gate.md
@@ -97,6 +97,12 @@ replacement-approved: UserPool,UserPool/PublicClient
 - Storage スタックが未デプロイ (初回デプロイ) の場合、diff はすべて `[+]` (新規追加) のみ → Replacement なし → 正常通過
 - `cdk diff` は `--strict` なしで使用。`--strict` は変更があるだけで exit 1 になる
 
+### `Fn::GetAtt` ベース Route53 RecordSet の悲観的 `may-cause-replacement`（SES DKIM 系）
+
+`cdk diff` の template-only 比較は、replacement 強制プロパティ（Route53 RecordSet の `Name`/`Type`/`HostedZoneId`）に**未解決 `Fn::GetAtt` トークンが含まれる場合、値を確定できず「変わったかもしれない=may-cause-replacement」と悲観判定する**（既知挙動: aws-cdk issue #21164）。SES `EmailIdentity`（Easy DKIM）が自動生成する `DkimDnsToken1/2/3` は `Name`・`Value` とも同一 EmailIdentity への `Fn::GetAtt` で、**identity が replace されない限り SES 発行値（DKIM 検証ホスト）は不変**（AWS SES 公式: Easy DKIM トークンは domain identity 単位で安定）。
+
+→ **aws-cdk-lib の bump 等で `EmailIdentity/DkimDnsToken*` に `may-cause-replacement` が出ても、infra コードが EmailIdentity を無変更なら実値変化ではなく differ のアーティファクト**。承認前に `cdk diff --method=change-set`（CloudFormation の正確判定で悲観判定を排除）+ deploy 後 `aws sesv2 get-email-identity` で `DkimStatus=SUCCESS` を smoke 確認すれば安全に承認できる。初回事例: aws-cdk-lib 2.260→2.261 bump で `EmailIdentity/DkimDnsToken3` が false-BLOCK（#3570 統合、一次情報で実値不変を確定）。
+
 ### 承認の取り消し
 
 `replacement-approved` マーカーを含む PR が一度マージされた後でも、次の deploy では


### PR DESCRIPTION
## 顧客価値・目的

第12回統合 #3570（main=6aefcb4e、100 PR）の AWS 本番 deploy が ADR-0019 CDK Replacement 検知で BLOCK された。対象 `EmailIdentity/DkimDnsToken3` の replacement を承認し AWS deploy を成立させる（本番は旧 build で稼働継続中・無傷）。あわせて再発防止の例外注記を ADR-0019 に追加。

**replacement-approved: EmailIdentity/DkimDnsToken3**

## 関連 Issue

related #3570 #3063（ADR-0019）

## 根本原因

`aws-cdk-lib 2.260.0→2.261.0` bump（#3570 の deps 更新）が唯一の変数。一次確認で 2.261.0 に SES/DKIM/Route53 変更はゼロ、`EasyDkim.bind()` は両版 byte-identical。`DkimDnsToken3` の name/value は同一 EmailIdentity への `Fn::GetAtt` で、identity が replace されない限り SES 発行値（DKIM 検証ホスト）は不変。`may-cause-replacement` は未解決 GetAtt に対する cdk diff の悲観判定アーティファクト（CDK #21164）で実値変化ではない。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | commit message に `replacement-approved: EmailIdentity/DkimDnsToken3` を含み deploy gate を通過 | AWS deploy re-run の replacement check | merge 後 deploy で確認 |
| AC2 | deploy 後 SES DkimStatus=SUCCESS + Function URL /api/health 200 | post-deploy smoke | deploy 後記入 |

## 変更タイプ

- [x] バグ修正

## 影響範囲・変更コンポーネント

`docs/decisions/0019-cdk-replacement-detection-gate.md` に GetAtt ベース Route53 RecordSet（SES DKIM）の悲観判定 例外注記を追加。commit message で `EmailIdentity/DkimDnsToken3` replacement を承認。プロダクトコード・infra 定義は無変更。

## テスト & 安全装置セルフチェック

| 検証観点 | 集約結果 | エビデンス |
|---|---|---|
| infra 定義無変更（EmailIdentity 未変更） | `git diff` で ses-stack.ts 無変更確認済 | 本 PR diff |
| DKIM 実値不変（一次情報接地） | aws-cdk-lib 2.260↔2.261 SES 変更ゼロ / GetAtt 悲観判定 | ADR-0019 例外注記 |
| deploy 後 SES smoke | deploy 後 `get-email-identity` DkimStatus=SUCCESS | deploy 後記入 |

## スクリーンショット / ビジュアルデモ

docs + deploy 承認のみのため SS 対象外。

## コード品質セルフレビュー (#1481)

プロダクトコード無変更。ADR 注記 + deploy 承認 marker のみ。

## 横展開・影響波及チェック

ADR-0019 に本パターン（SES DKIM 系 bump の GetAtt false-BLOCK）を注記したことで、今後同種の deps bump で誤 BLOCK した際の判断根拠を残す。

## レビュー依頼事項・破壊的変更

破壊的変更なし。approve + merge は `ganbariquestsupport-lab`（ADR-0022）。squash merge で commit message の承認 marker を main HEAD に載せる。

## 配布済み env / secret (ADR-0006)

新規 env なし。

## Ready for Review チェックリスト

- [x] replacement 承認の根拠を一次情報で確定した（リスク低、PO 承認済）
- [x] ADR-0019 に例外注記を追加した
- [x] deploy 後 SES/health smoke を AC に明記した

## QM レビュー結果

<!-- lab (監査 role) が記入 -->
