### PR TITLE
feat: #3533 FeatureGate に quota ゲート追加 (§10.2.2)

### DIFF
--- a/src/lib/ui/components/FeatureGate.stories.svelte
+++ b/src/lib/ui/components/FeatureGate.stories.svelte
@@ -70,6 +70,76 @@ const { Story } = defineMeta({
 	{/snippet}
 </Story>
 
+<!--
+  QuotaReached: quota 上限到達 (current >= max) で disabled + popover (§10.2.2)。
+  tier ではなく quota で開閉判定する。
+-->
+<Story
+	name="QuotaReached"
+	args={{
+		currentTier: 'free',
+		requiredTier: 'standard',
+		display: 'inline',
+		buttonLabel: L.buttonLabel,
+		quota: { allowed: false, current: 3, max: 3 },
+	}}
+	play={async () => {
+		const trigger = await waitFor(() => screen.getByTestId('feature-gate-locked-trigger'));
+		await userEvent.click(trigger);
+		const popover = await waitFor(() => screen.getByTestId('feature-gate-popover'));
+		await expect(popover).toBeVisible();
+	}}
+>
+	{#snippet children()}
+		<span>{L.unlockedContent}</span>
+	{/snippet}
+</Story>
+
+<!--
+  QuotaAvailable: 上限未到達 (current < max) は操作可 = children をそのまま描画 (gate なし)。
+-->
+<Story
+	name="QuotaAvailable"
+	args={{
+		currentTier: 'free',
+		requiredTier: 'standard',
+		display: 'inline',
+		buttonLabel: L.buttonLabel,
+		quota: { allowed: true, current: 1, max: 3 },
+	}}
+	play={async () => {
+		// gate 痕跡 (locked trigger) は出ず、children が見える
+		await expect(screen.queryByTestId('feature-gate-locked-trigger')).toBeNull();
+		await expect(screen.getByText(L.unlockedContent)).toBeVisible();
+	}}
+>
+	{#snippet children()}
+		<span>{L.unlockedContent}</span>
+	{/snippet}
+</Story>
+
+<!--
+  QuotaUnlimited: max===null (無制限プラン) はゲート痕跡を一切描画しない (§10.2.2)。
+-->
+<Story
+	name="QuotaUnlimited"
+	args={{
+		currentTier: 'family',
+		requiredTier: 'standard',
+		display: 'inline',
+		buttonLabel: L.buttonLabel,
+		quota: { allowed: true, current: 8, max: null },
+	}}
+	play={async () => {
+		await expect(screen.queryByTestId('feature-gate-locked-trigger')).toBeNull();
+		await expect(screen.getByText(L.unlockedContent)).toBeVisible();
+	}}
+>
+	{#snippet children()}
+		<span>{L.unlockedContent}</span>
+	{/snippet}
+</Story>
+
 <style>
 	:global(.sb-story) {
 		min-height: 300px;

--- a/src/lib/ui/components/FeatureGate.svelte
+++ b/src/lib/ui/components/FeatureGate.svelte
@@ -34,6 +34,15 @@ interface Props {
 	display?: 'inline' | 'section';
 	/** popover のプラン画面リンク先 (§10.2.1、既定 = プラン画面) */
 	planPageHref?: string;
+	/**
+	 * quota ゲート (§10.2.2)。plan-limit-service の `{ allowed, current, max }` をそのまま渡す。
+	 * 指定時は tier ではなく quota で開閉を判定する:
+	 *   - max === null (無制限): ゲート痕跡を一切描画しない (children をそのまま操作可)
+	 *   - allowed (current < max): 操作可
+	 *   - 到達 (!allowed): disabled + popover
+	 * requiredTier は「上限を引き上げる対象プラン名」として popover 文言に使う。
+	 */
+	quota?: { allowed: boolean; current: number; max: number | null };
 }
 
 let {
@@ -44,6 +53,7 @@ let {
 	buttonLabel,
 	display = 'section',
 	planPageHref = '/admin/subscription',
+	quota,
 }: Props = $props();
 
 const TIER_LABELS: Record<PlanTier, string> = {
@@ -59,8 +69,11 @@ const TIER_FULL_LABELS: Record<PlanTier, string> = {
 	family: PLAN_FULL_TERMS.premium,
 };
 
-// requiredTier を満たさない = ロック。tutorial-chapters / page-guide と同じ TIER_ORDER SSOT を共有する。
-const isLocked = $derived(!meetsRequiredTier(currentTier, requiredTier));
+// quota 指定時は quota で判定 (§10.2.2)。max===null は無制限 = 非ロック (ゲート痕跡なし)。
+// quota 未指定時は tier で判定 (tutorial-chapters / page-guide と同じ TIER_ORDER SSOT)。
+const isLocked = $derived(
+	quota ? quota.max !== null && !quota.allowed : !meetsRequiredTier(currentTier, requiredTier),
+);
 const requiredLabel = $derived(TIER_LABELS[requiredTier]);
 const requiredFullLabel = $derived(TIER_FULL_LABELS[requiredTier]);
 </script>


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: 上限（N/M）付き機能で、画面に「1/3 + アップグレード→」等の quota カウンタ + 個別 CTA が散在していた。EPIC #3533 §10.2.2 に沿って、`FeatureGate` に quota ゲートを追加し、上限到達時のみ「🔒 disabled + tap→popover」に収斂する。

**期待される効果**: 画面に N/M カウンタを出さず（P1、詳細はプラン画面へ）、上限未到達は操作可・到達時のみ非 dead-end な popover を提示。無制限プランではゲート痕跡を一切描画しない。

## 関連 Issue

EPIC #3533 の AC3（quota 到達時 disabled+popover、`max===null` 非描画）を消化。統合 PR で集約 close されるため本 PR body では close 宣言せず参照に留める。
関連: #3533

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC3 | plan-limit-service の `{allowed,current,max}` を quota prop で受け、tier でなく quota で開閉 | `STORYBOOK_TESTS=true vitest run --project storybook FeatureGate` | HEAD `3f440c5c` / 6 passed / FeatureGate.svelte isLocked = quota ? (max!==null && !allowed) : tier |
| AC3-a | `max===null`（無制限）でゲート痕跡を一切描画しない | storybook QuotaUnlimited play | HEAD `3f440c5c` / QuotaUnlimited: locked-trigger null + children 可視 |
| AC3-b | 上限到達（`current>=max`）で disabled+popover | storybook QuotaReached play + SS | HEAD `3f440c5c` / QuotaReached: tap→popover visible（SS 下記）|
| AC3-c | 上限未到達（`current<max`）は操作可（gate なし） | storybook QuotaAvailable play | HEAD `3f440c5c` / QuotaAvailable: locked-trigger null + children 可視 |
| AC3-d | 画面に N/M カウンタを出さない（P1） | FeatureGate.svelte 目視 | HEAD `3f440c5c` / quota 値は開閉判定のみに使用、current/max を描画しない |

## 変更タイプ

- [x] feat: 新機能

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)

**影響を受ける画面・機能**: `FeatureGate` component（route 未マウント。実画面初出は AC4 の /admin/checklists 収斂）。既存 callsite なしのため回帰面なし。quota prop は optional 追加で後方互換。

## テスト & 安全装置セルフチェック

- [x] **storybook / svelte-check / biome / hardcoded-strings ローカル PASS**: `STORYBOOK_TESTS=true npx vitest run --project storybook FeatureGate` 6 passed / `npx svelte-check` FeatureGate 0 err / `npx biome check src/lib/ui/components/FeatureGate.svelte` 0 / `node scripts/check-hardcoded-strings.mjs` 0
- [x] 追加・変更したテストの概要: FeatureGate.stories.svelte に QuotaReached / QuotaAvailable / QuotaUnlimited を追加（play で 3 分岐を操作回帰、CX-DoR #8）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

quota ゲートの popover 表現は §10.2.1（PR #3559 で導入済）と同一。本 PR の新規挙動 = 「quota 到達で disabled+popover / 未到達・無制限で gate なし」。到達状態の Storybook 実描画 SS を添付（未到達・無制限は children を描画するだけの視覚差のため play test で担保）。

**4 スロット添付**（新規挙動・「修正前」= 該当なし）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし（新規挙動） | 該当なし（新規挙動） |
| **修正後 (quota 到達)** | ![after-quota-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3580/featuregate-quota-reached-mobile.png) | ![after-quota-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3580/featuregate-quota-reached-pc.png) |

DOM HTML スナップショット: [quota-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3580/featuregate-quota-reached-mobile.dom.html) / [quota-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3580/featuregate-quota-reached-pc.dom.html)

**インタラクティブ状態**: quota 到達 disabled trigger + popover open を撮影済。未到達 / 無制限は children 描画（gate 痕跡なし）を play で検証。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: quota 判定を isLocked derive に集約（単一責任）。plan-limit-service の型に依存（DIP）
- [x] **DRY**: popover は §10.2.1 実装を再利用（quota / tier で分岐せず共通描画）
- [x] **YAGNI**: quota は optional prop。無指定時は従来 tier 判定を維持
- [x] **Security**: N/A（表示のみ、バックエンド 403 が唯一の砦）
- [x] **アクセシビリティ**: 既存 popover の role=dialog / aria-disabled を踏襲
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): §10.2.2（quota ゲート、`max===null` 非描画）は先行 PR #3542 で develop 反映済。実装が定義を満たす
- [x] **labels SSOT**: 文言は既存 UI_COMPONENTS_LABELS.featureGatePopover* を再利用。新規リテラルなし
- [x] **並行 PR overlap** (#1200): 変更は FeatureGate.svelte / FeatureGate.stories.svelte のみ。同時変更の open PR なし
- [x] N/A — 本番/デモ同期・年齢モード・ナビ・E2E シードは対象外（route 未マウント）

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（quota は optional prop 追加、既存 tier 挙動不変）

**レビュー依頼事項・QA**: quota mode でも requiredTier を popover の「対象プラン名」に流用する設計（quota を引き上げるプランを requiredTier で指定）が §10.2.2 の意図に合致するかの確認。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] storybook / svelte-check / biome / hardcoded-strings ローカル PASS
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = AC3。AC4–6 は後続 PR）
- [x] Phase 分割: EPIC #3533 で PO 合意済み
- [x] UI 変更時: Storybook 実描画 SS + DOM HTML 併記、DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
