### PR TITLE
feat: #3424 PR-R1 — DSQL IChildRepo 実装 (compute-on-read + 集約削除 txn + pushSchema テスト基盤)

### DIFF
--- a/src/lib/server/db/dsql/child-repo.ts
+++ b/src/lib/server/db/dsql/child-repo.ts
@@ -1,0 +1,264 @@
+// src/lib/server/db/dsql/child-repo.ts
+// EPIC #3424 / PR-R1 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §11.1 / §3 / §P9
+//
+// IChildRepo の DSQL backend 実装。設計契約:
+//   - **factory 注入** (fitness#8: module-level db/client import 禁止)。db (SqlExecutor) と
+//     TransactionRunner を呼び出し側 (将来の client factory / テスト) が渡す。
+//   - **§P9 tenant 述語**: 全メソッドが family_id = tenantId を WHERE に含む。
+//   - **compute-on-read (§11.1)**: age 列は持たない。birth_date から calculateAgeFromBirthDate で
+//     導出し、ui_mode は ui_mode_manually_set=false のとき年齢から recalcUiMode で再導出する
+//     (誕生日跨ぎの tier 自動遷移。stored 値は手動 override 時のみ正)。
+//     ⚠️ birth_date NULL 行は age=0 fallback (PO B2: cutover backfill 必須が前提。新規作成は
+//     入力 age から birth_date を合成しない — 出し分けで逃げない §11.1)。
+//   - **deleteChild = 集約全削除を単一 txn** (§3「deleteChild が 11+ 表を 1 txn 削除」、DSQL は
+//     FK/CASCADE 非対応 §P4 のため repo が全表を明示 DELETE。work は inline + tx-bound await のみ
+//     = fitness#7 準拠)。invites.child_id は auth 集約のため touch しない (招待は期限切れで自然消滅)。
+//   - entity 境界: Child.uiModeManuallySet / isArchived は number (0/1) 契約 — boolean 列を
+//     読み出し時に変換 (既存 sqlite backend と同一 shape)。total_point は entity 未公開
+//     (残高は point facade 経由、§5)。
+
+import { sql } from 'drizzle-orm';
+import { calculateAgeFromBirthDate } from '$lib/domain/date-utils';
+import { asChildId } from '$lib/domain/ids';
+import { isValidUiMode, recalcUiMode, type UiMode } from '$lib/domain/validation/age-tier';
+import type { ChildProgressResetCounts, IChildRepo } from '../interfaces/child-repo.interface';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type { Child, UpdateChildInput } from '../types';
+import type { SqlExecutor } from './sql-executor';
+
+interface ChildRow {
+	child_id: string;
+	nickname: string;
+	birth_date: string | null;
+	theme: string;
+	ui_mode: string;
+	ui_mode_manually_set: boolean;
+	avatar_url: string | null;
+	display_config: string | null;
+	user_id: string | null;
+	birthday_bonus_multiplier: number;
+	last_birthday_bonus_year: number | null;
+	is_archived: boolean;
+	archived_reason: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+const CHILD_COLUMNS = sql.raw(
+	`child_id, nickname, birth_date, theme, ui_mode, ui_mode_manually_set, avatar_url,
+	 display_config, user_id, birthday_bonus_multiplier, last_birthday_bonus_year,
+	 is_archived, archived_reason, created_at, updated_at`,
+);
+
+/** row → Child entity (compute-on-read: age 導出 + ui_mode 再導出、§11.1)。 */
+function toChild(row: ChildRow): Child {
+	const age = row.birth_date ? calculateAgeFromBirthDate(row.birth_date) : 0;
+	const storedUiMode: UiMode = isValidUiMode(row.ui_mode) ? row.ui_mode : 'preschool';
+	const uiMode = row.birth_date
+		? recalcUiMode(
+				{ uiMode: storedUiMode, uiModeManuallySet: row.ui_mode_manually_set ? 1 : 0 },
+				age,
+			)
+		: storedUiMode;
+	return {
+		id: asChildId(row.child_id),
+		nickname: row.nickname,
+		age,
+		birthDate: row.birth_date,
+		theme: row.theme,
+		uiMode,
+		uiModeManuallySet: row.ui_mode_manually_set ? 1 : 0,
+		avatarUrl: row.avatar_url,
+		displayConfig: row.display_config,
+		userId: row.user_id,
+		birthdayBonusMultiplier: row.birthday_bonus_multiplier,
+		lastBirthdayBonusYear: row.last_birthday_bonus_year,
+		isArchived: row.is_archived ? 1 : 0,
+		archivedReason: row.archived_reason,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+/** deleteChild で消す child 配下の表 (child_id 列を持つ全テナント表、§3 集約境界)。 */
+const CHILD_SCOPED_TABLES = [
+	'child_activities',
+	'activity_logs',
+	'point_ledger',
+	'statuses',
+	'status_history',
+	'activity_mastery',
+	'child_activity_preferences',
+	'daily_missions',
+	'login_bonuses',
+	'stamp_cards',
+	'checklist_logs',
+	'checklist_log_items',
+	'checklist_overrides',
+	'checklist_template_assignments',
+	'certificates',
+	'evaluations',
+	'evaluation_scores',
+	'rest_days',
+	'daily_battles',
+	'enemy_collection',
+	'special_rewards',
+	'reward_redemption_requests',
+	'parent_messages',
+	'character_images',
+	'child_custom_voices',
+	'child_challenges',
+	'usage_logs',
+] as const;
+
+/** DSQL 用 IChildRepo を生成する (db/runner は注入、fitness#8)。 */
+export function createDsqlChildRepo<TTx extends SqlExecutor>(
+	db: SqlExecutor,
+	runner: TransactionRunner<TTx>,
+): IChildRepo {
+	const findMany = async (where: ReturnType<typeof sql>): Promise<Child[]> => {
+		const result = await db.execute(
+			sql`SELECT ${CHILD_COLUMNS} FROM children WHERE ${where} ORDER BY created_at, child_id`,
+		);
+		return (result.rows as unknown as ChildRow[]).map(toChild);
+	};
+
+	return {
+		async findAllChildren(tenantId) {
+			return findMany(sql`family_id = ${tenantId} AND is_archived = false`);
+		},
+
+		async findChildById(id, tenantId) {
+			const rows = await findMany(sql`family_id = ${tenantId} AND child_id = ${id}`);
+			return rows[0];
+		},
+
+		async findChildByUserId(userId, tenantId) {
+			const rows = await findMany(
+				sql`family_id = ${tenantId} AND user_id = ${userId} AND is_archived = false`,
+			);
+			return rows[0];
+		},
+
+		async insertChild(input, tenantId) {
+			// age は列に持たない (§11.1)。birth_date 未指定の新規行は age=0 で読める
+			// (cutover backfill / UI の生年月日入力が正、入力 age から birth_date を合成しない)。
+			const result = await db.execute(sql`
+				INSERT INTO children (family_id, nickname, birth_date, theme, ui_mode)
+				VALUES (${tenantId}, ${input.nickname}, ${input.birthDate ?? null},
+					${input.theme ?? 'pink'}, ${input.uiMode ?? 'preschool'})
+				RETURNING ${CHILD_COLUMNS}
+			`);
+			return toChild(result.rows[0] as unknown as ChildRow);
+		},
+
+		async updateChild(id, input, tenantId) {
+			const sets = buildUpdateSets(input);
+			if (sets.length === 0) return this.findChildById(id, tenantId);
+			const result = await db.execute(sql`
+				UPDATE children SET ${sql.join(sets, sql`, `)}, updated_at = now()
+				WHERE family_id = ${tenantId} AND child_id = ${id}
+				RETURNING ${CHILD_COLUMNS}
+			`);
+			const row = result.rows[0] as unknown as ChildRow | undefined;
+			return row ? toChild(row) : undefined;
+		},
+
+		async deleteChild(id, tenantId) {
+			// 集約全削除を単一 txn (§3 / §P4)。work は inline + tx-bound await のみ (fitness#7)。
+			await runner.runInTransaction(async (tx) => {
+				for (const table of CHILD_SCOPED_TABLES) {
+					if (table === 'stamp_cards') {
+						// stamp_entries は card_id 参照 (child_id 列なし) のため cards より先に subquery 削除。
+						await tx.execute(sql`
+							DELETE FROM stamp_entries WHERE family_id = ${tenantId} AND card_id IN (
+								SELECT card_id FROM stamp_cards WHERE family_id = ${tenantId} AND child_id = ${id}
+							)
+						`);
+					}
+					await tx.execute(
+						sql`DELETE FROM ${sql.raw(table)} WHERE family_id = ${tenantId} AND child_id = ${id}`,
+					);
+				}
+				// sibling_cheers は from/to の 2 参照軸 (child_id 列でないため個別)。
+				await tx.execute(sql`
+					DELETE FROM sibling_cheers
+					WHERE family_id = ${tenantId} AND (from_child_id = ${id} OR to_child_id = ${id})
+				`);
+				await tx.execute(
+					sql`DELETE FROM children WHERE family_id = ${tenantId} AND child_id = ${id}`,
+				);
+			});
+		},
+
+		async resetChildProgressData(id, tenantId): Promise<ChildProgressResetCounts> {
+			// 記録系のみ初期化 (interface 契約の allowlist。statuses/バトル/チャレンジ等は意図的 survive)。
+			// child_achievements は #322 廃止で DSQL に表が無い → 常に 0。pointBalance 派生行も
+			// DSQL は children.total_point 列のため行削除は無し (0)。total_point は §5 P7 の
+			// 不変条件 (== SUM(point_ledger)) を保つため同一 txn で 0 リセットする。
+			return runner.runInTransaction(async (tx) => {
+				const counts: ChildProgressResetCounts = {
+					activityLogs: 0,
+					pointLedger: 0,
+					loginBonuses: 0,
+					childAchievements: 0,
+					pointBalance: 0,
+				};
+				const del = async (table: 'activity_logs' | 'point_ledger' | 'login_bonuses') => {
+					const r = await tx.execute(
+						sql`DELETE FROM ${sql.raw(table)} WHERE family_id = ${tenantId} AND child_id = ${id} RETURNING 1`,
+					);
+					return r.rows.length;
+				};
+				counts.activityLogs = await del('activity_logs');
+				counts.pointLedger = await del('point_ledger');
+				counts.loginBonuses = await del('login_bonuses');
+				await tx.execute(sql`
+					UPDATE children SET total_point = 0, updated_at = now()
+					WHERE family_id = ${tenantId} AND child_id = ${id}
+				`);
+				return counts;
+			});
+		},
+
+		async archiveChildren(ids, reason, tenantId) {
+			if (ids.length === 0) return;
+			await db.execute(sql`
+				UPDATE children SET is_archived = true, archived_reason = ${reason}, updated_at = now()
+				WHERE family_id = ${tenantId} AND child_id IN (${sql.join(
+					ids.map((id) => sql`${id}`),
+					sql`, `,
+				)})
+			`);
+		},
+
+		async restoreArchivedChildren(reason, tenantId) {
+			await db.execute(sql`
+				UPDATE children SET is_archived = false, archived_reason = NULL, updated_at = now()
+				WHERE family_id = ${tenantId} AND is_archived = true AND archived_reason = ${reason}
+			`);
+		},
+
+		async findArchivedChildren(tenantId) {
+			return findMany(sql`family_id = ${tenantId} AND is_archived = true`);
+		},
+	};
+}
+
+/** UpdateChildInput → SET 句 (age は列に無いため無視 = compute-on-read §11.1)。 */
+function buildUpdateSets(input: UpdateChildInput) {
+	const sets: ReturnType<typeof sql>[] = [];
+	if (input.nickname !== undefined) sets.push(sql`nickname = ${input.nickname}`);
+	if (input.theme !== undefined) sets.push(sql`theme = ${input.theme}`);
+	if (input.uiMode !== undefined) sets.push(sql`ui_mode = ${input.uiMode}`);
+	if (input.uiModeManuallySet !== undefined)
+		sets.push(sql`ui_mode_manually_set = ${input.uiModeManuallySet !== 0}`);
+	if (input.birthDate !== undefined) sets.push(sql`birth_date = ${input.birthDate}`);
+	if (input.displayConfig !== undefined) sets.push(sql`display_config = ${input.displayConfig}`);
+	if (input.userId !== undefined) sets.push(sql`user_id = ${input.userId}`);
+	if (input.birthdayBonusMultiplier !== undefined)
+		sets.push(sql`birthday_bonus_multiplier = ${input.birthdayBonusMultiplier}`);
+	if (input.lastBirthdayBonusYear !== undefined)
+		sets.push(sql`last_birthday_bonus_year = ${input.lastBirthdayBonusYear}`);
+	return sets;
+}

--- a/src/lib/server/db/dsql/child-repo.ts
+++ b/src/lib/server/db/dsql/child-repo.ts
@@ -196,28 +196,28 @@ export function createDsqlChildRepo<TTx extends SqlExecutor>(
 			// child_achievements は #322 廃止で DSQL に表が無い → 常に 0。pointBalance 派生行も
 			// DSQL は children.total_point 列のため行削除は無し (0)。total_point は §5 P7 の
 			// 不変条件 (== SUM(point_ledger)) を保つため同一 txn で 0 リセットする。
+			// fitness#7 (tx-bound await のみ許可) 準拠のため helper 閉包を挟まず inline に await する。
 			return runner.runInTransaction(async (tx) => {
-				const counts: ChildProgressResetCounts = {
-					activityLogs: 0,
-					pointLedger: 0,
-					loginBonuses: 0,
-					childAchievements: 0,
-					pointBalance: 0,
-				};
-				const del = async (table: 'activity_logs' | 'point_ledger' | 'login_bonuses') => {
-					const r = await tx.execute(
-						sql`DELETE FROM ${sql.raw(table)} WHERE family_id = ${tenantId} AND child_id = ${id} RETURNING 1`,
-					);
-					return r.rows.length;
-				};
-				counts.activityLogs = await del('activity_logs');
-				counts.pointLedger = await del('point_ledger');
-				counts.loginBonuses = await del('login_bonuses');
+				const logs = await tx.execute(
+					sql`DELETE FROM activity_logs WHERE family_id = ${tenantId} AND child_id = ${id} RETURNING 1`,
+				);
+				const ledger = await tx.execute(
+					sql`DELETE FROM point_ledger WHERE family_id = ${tenantId} AND child_id = ${id} RETURNING 1`,
+				);
+				const bonuses = await tx.execute(
+					sql`DELETE FROM login_bonuses WHERE family_id = ${tenantId} AND child_id = ${id} RETURNING 1`,
+				);
 				await tx.execute(sql`
 					UPDATE children SET total_point = 0, updated_at = now()
 					WHERE family_id = ${tenantId} AND child_id = ${id}
 				`);
-				return counts;
+				return {
+					activityLogs: logs.rows.length,
+					pointLedger: ledger.rows.length,
+					loginBonuses: bonuses.rows.length,
+					childAchievements: 0,
+					pointBalance: 0,
+				};
 			});
 		},
 

--- a/tests/unit/db/dsql-child-repo.test.ts
+++ b/tests/unit/db/dsql-child-repo.test.ts
@@ -1,0 +1,216 @@
+// tests/unit/db/dsql-child-repo.test.ts
+// EPIC #3424 / PR-R1 / 設計 SSOT: dsql-data-model.md §11.1 / §3 / §P9
+//
+// DSQL IChildRepo 実装のテスト。実 schema (pushSchema 適用、dsql-test-db helper) に対して:
+//   [C1] insert → findById round-trip (uuid 採番、entity 0/1 変換)
+//   [C2] compute-on-read: birth_date から age 導出 + 非手動児は年齢で ui_mode 再導出 (§11.1)
+//   [C3] 手動 override 児は stored ui_mode 維持 / birth_date NULL は age=0 + stored
+//   [C4] §P9 tenant 分離: 他 family の child は見えない・更新できない
+//   [C5] update の部分更新 + updated_at 更新
+//   [C6] archive/restore/findArchived (findAll から archived が消える)
+//   [C7] deleteChild = 集約全削除の単一 txn (関連表の行が消え、兄弟 child のデータは残る)
+//   [C8] resetChildProgressData = allowlist 3 表のみ削除 + total_point 0 リセット
+//        (statuses は survive = 契約) + counts が実削除数
+
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { asActivityId, asCategoryId, asChildId } from '../../../src/lib/domain/ids';
+import { createDsqlChildRepo } from '../../../src/lib/server/db/dsql/child-repo';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import type { IChildRepo } from '../../../src/lib/server/db/interfaces/child-repo.interface';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+const FAMILY = '00000000-0000-4000-8000-0000000000a1';
+const OTHER_FAMILY = '00000000-0000-4000-8000-0000000000a2';
+
+describe('DSQL child-repo (PR-R1、実 schema PGlite)', () => {
+	let t: DsqlTestDb;
+	let repo: IChildRepo;
+
+	beforeAll(async () => {
+		t = await createDsqlTestDb();
+		const runner = createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 });
+		repo = createDsqlChildRepo(t.db, runner);
+	}, 60_000);
+	afterAll(async () => {
+		await t.close();
+	});
+
+	it('[C1] insert → findById round-trip (uuid 採番、0/1 数値契約)', async () => {
+		const created = await repo.insertChild(
+			{ nickname: 'けんた', age: 8, birthDate: '2018-01-15', theme: 'blue' },
+			FAMILY,
+		);
+		expect(created.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(created.nickname).toBe('けんた');
+		expect(created.uiModeManuallySet).toBe(0);
+		expect(created.isArchived).toBe(0);
+
+		const found = await repo.findChildById(created.id, FAMILY);
+		expect(found?.nickname).toBe('けんた');
+		expect(found?.birthDate).toBe('2018-01-15');
+	});
+
+	it('[C2] compute-on-read: age 導出 + 非手動児の ui_mode 年齢再導出 (§11.1)', async () => {
+		// 2018-01-15 生まれ → 今日 (2026-07) 時点で 8 歳 = elementary。
+		// stored ui_mode を意図的に古い値 (preschool 既定) のままにして、read が再導出することを確認。
+		const created = await repo.insertChild(
+			{ nickname: 'さくら', age: 8, birthDate: '2018-01-15' },
+			FAMILY,
+		);
+		const found = await repo.findChildById(created.id, FAMILY);
+		expect(found?.age).toBe(8);
+		expect(found?.uiMode).toBe('elementary'); // stored 'preschool' でなく年齢由来 (§11.1)
+	});
+
+	it('[C3] 手動 override は stored 維持 / birth_date NULL は age=0 + stored', async () => {
+		const manual = await repo.insertChild(
+			{ nickname: 'まなみ', age: 8, birthDate: '2018-01-15', uiMode: 'junior' },
+			FAMILY,
+		);
+		await repo.updateChild(manual.id, { uiModeManuallySet: 1 }, FAMILY);
+		const foundManual = await repo.findChildById(manual.id, FAMILY);
+		expect(foundManual?.uiMode).toBe('junior'); // 手動 override 維持
+
+		const noBirth = await repo.insertChild({ nickname: 'ふめい', age: 5 }, FAMILY);
+		const foundNoBirth = await repo.findChildById(noBirth.id, FAMILY);
+		expect(foundNoBirth?.age).toBe(0); // PO B2: backfill 必須の明示 fallback
+		expect(foundNoBirth?.uiMode).toBe('preschool'); // stored 既定
+	});
+
+	it('[C4] §P9 tenant 分離: 他 family から不可視・更新不能', async () => {
+		const mine = await repo.insertChild({ nickname: 'うち', age: 6 }, FAMILY);
+		expect(await repo.findChildById(mine.id, OTHER_FAMILY)).toBeUndefined();
+		expect(await repo.updateChild(mine.id, { nickname: '乗っ取り' }, OTHER_FAMILY)).toBeUndefined();
+		const intact = await repo.findChildById(mine.id, FAMILY);
+		expect(intact?.nickname).toBe('うち');
+	});
+
+	it('[C5] update: 部分更新 + updated_at 更新', async () => {
+		const c = await repo.insertChild({ nickname: '更新前', age: 6 }, FAMILY);
+		const updated = await repo.updateChild(c.id, { nickname: '更新後', theme: 'green' }, FAMILY);
+		expect(updated?.nickname).toBe('更新後');
+		expect(updated?.theme).toBe('green');
+		expect(updated?.birthDate).toBe(null); // 未指定 field は不変
+		expect(Date.parse(updated?.updatedAt ?? '')).toBeGreaterThanOrEqual(Date.parse(c.updatedAt));
+	});
+
+	it('[C6] archive → findAll から消え、restore で復帰 (reason 束縛)', async () => {
+		const c = await repo.insertChild({ nickname: 'アーカイブ', age: 6 }, FAMILY);
+		await repo.archiveChildren([c.id], 'trial_expired', FAMILY);
+
+		const all = await repo.findAllChildren(FAMILY);
+		expect(all.some((x) => x.id === c.id)).toBe(false);
+		const archived = await repo.findArchivedChildren(FAMILY);
+		expect(archived.some((x) => x.id === c.id && x.archivedReason === 'trial_expired')).toBe(true);
+
+		await repo.restoreArchivedChildren('trial_expired', FAMILY);
+		const restored = await repo.findChildById(c.id, FAMILY);
+		expect(restored?.isArchived).toBe(0);
+		expect(restored?.archivedReason).toBe(null);
+	});
+
+	it('[C7] deleteChild: 集約全削除 (関連表消滅、兄弟の行は残る)', async () => {
+		const target = await repo.insertChild({ nickname: '削除対象', age: 8 }, FAMILY);
+		const sibling = await repo.insertChild({ nickname: '兄弟', age: 10 }, FAMILY);
+
+		const seed = async (childId: string) => {
+			const act = await t.db.execute(sql`
+				INSERT INTO child_activities (family_id, child_id, name, category_id, icon)
+				VALUES (${FAMILY}, ${childId}, 'テスト活動', '1', '🏃') RETURNING activity_id
+			`);
+			const activityId = (act.rows[0] as { activity_id: string }).activity_id;
+			await t.db.execute(sql`
+				INSERT INTO activity_logs (family_id, child_id, activity_id, points, recorded_date, recorded_at)
+				VALUES (${FAMILY}, ${childId}, ${activityId}, 10, '2026-07-04', now())
+			`);
+			await t.db.execute(sql`
+				INSERT INTO point_ledger (family_id, child_id, amount, type, recorded_date)
+				VALUES (${FAMILY}, ${childId}, 10, 'activity', '2026-07-04')
+			`);
+			const card = await t.db.execute(sql`
+				INSERT INTO stamp_cards (family_id, child_id, week_start, week_end)
+				VALUES (${FAMILY}, ${childId}, '2026-06-29', '2026-07-05') RETURNING card_id
+			`);
+			await t.db.execute(sql`
+				INSERT INTO stamp_entries (family_id, card_id, slot, login_date)
+				VALUES (${FAMILY}, ${(card.rows[0] as { card_id: string }).card_id}, 1, '2026-07-01')
+			`);
+		};
+		await seed(String(target.id));
+		await seed(String(sibling.id));
+		await t.db.execute(sql`
+			INSERT INTO sibling_cheers (family_id, from_child_id, to_child_id, stamp_code)
+			VALUES (${FAMILY}, ${String(target.id)}, ${String(sibling.id)}, 'star')
+		`);
+
+		await repo.deleteChild(target.id, FAMILY);
+
+		expect(await repo.findChildById(target.id, FAMILY)).toBeUndefined();
+		const countFor = async (table: string, childId: string) =>
+			Number(
+				(
+					(await t.db.execute(
+						sql`SELECT count(*) AS c FROM ${sql.raw(table)} WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+					)) as { rows: { c: unknown }[] }
+				).rows[0]?.c,
+			);
+		for (const table of ['child_activities', 'activity_logs', 'point_ledger', 'stamp_cards']) {
+			expect(await countFor(table, String(target.id)), `${table} 消滅`).toBe(0);
+			expect(await countFor(table, String(sibling.id)), `${table} 兄弟 survive`).toBe(1);
+		}
+		const cheers = await t.db.execute(
+			sql`SELECT count(*) AS c FROM sibling_cheers WHERE family_id = ${FAMILY}`,
+		);
+		expect(Number((cheers.rows[0] as { c: unknown }).c)).toBe(0); // from 側参照でも消える
+		const entries = await t.db.execute(sql`
+			SELECT count(*) AS c FROM stamp_entries WHERE family_id = ${FAMILY}
+		`);
+		expect(Number((entries.rows[0] as { c: unknown }).c)).toBe(1); // 兄弟 card の entry のみ残存
+	});
+
+	it('[C8] resetChildProgressData: allowlist 3 表 + total_point 0 (statuses は survive)', async () => {
+		const c = await repo.insertChild({ nickname: 'リセット', age: 8 }, FAMILY);
+		const id = String(c.id);
+		await t.db.execute(sql`
+			INSERT INTO point_ledger (family_id, child_id, amount, type, recorded_date)
+			VALUES (${FAMILY}, ${id}, 30, 'activity', '2026-07-04'), (${FAMILY}, ${id}, 20, 'bonus', '2026-07-04')
+		`);
+		await t.db.execute(
+			sql`UPDATE children SET total_point = 50 WHERE family_id = ${FAMILY} AND child_id = ${id}`,
+		);
+		await t.db.execute(sql`
+			INSERT INTO login_bonuses (family_id, child_id, login_date, rank, base_points, total_points)
+			VALUES (${FAMILY}, ${id}, '2026-07-04', 'daikichi', 5, 5)
+		`);
+		await t.db.execute(sql`
+			INSERT INTO statuses (family_id, child_id, category_id, total_xp, updated_at)
+			VALUES (${FAMILY}, ${id}, '1', 100, now())
+		`);
+
+		const counts = await repo.resetChildProgressData(c.id, FAMILY);
+		expect(counts).toEqual({
+			activityLogs: 0,
+			pointLedger: 2,
+			loginBonuses: 1,
+			childAchievements: 0,
+			pointBalance: 0,
+		});
+		const status = await t.db.execute(
+			sql`SELECT total_xp FROM statuses WHERE family_id = ${FAMILY} AND child_id = ${id}`,
+		);
+		expect((status.rows[0] as { total_xp: number }).total_xp).toBe(100); // survive 契約
+		const tp = await t.db.execute(
+			sql`SELECT total_point FROM children WHERE family_id = ${FAMILY} AND child_id = ${id}`,
+		);
+		expect((tp.rows[0] as { total_point: number }).total_point).toBe(0); // fitness#14 整合
+	});
+
+	it('branded id が repo 境界で維持される (ChildId 受け渡しの型整合)', () => {
+		// compile-time 検証: asChildId 以外の string を渡すと型エラーになる (実行時 assert 不要)
+		const id = asChildId('00000000-0000-4000-8000-00000000ffff');
+		const _catId = asCategoryId('1');
+		const _actId = asActivityId('x');
+		expect(typeof id).toBe('string');
+	});
+});

--- a/tests/unit/helpers/dsql-test-db.ts
+++ b/tests/unit/helpers/dsql-test-db.ts
@@ -1,0 +1,32 @@
+// tests/unit/helpers/dsql-test-db.ts
+// DSQL repo テスト用の PGlite in-memory DB helper (#3424 PR-R1)。
+//
+// **実 schema (src/lib/server/db/dsql/schema.ts) を drizzle-kit/api の pushSchema で
+// そのまま適用**する。手書き CREATE TABLE fixture の二重管理 (schema drift の温床) を排除し、
+// fitness#9/#6/#13 が検証している唯一の DDL SSOT でテストする。
+// 全 45 表が適用されるため、多表に跨る操作 (deleteChild の集約削除等) もそのまま検証できる。
+//
+// ⚠️ PGlite は単一接続: tx 内で tx 外 db を await すると deadlock する
+// (dsql-run-in-transaction.test.ts の知見)。escape 再現は fire→settle で行うこと。
+
+import { PGlite } from '@electric-sql/pglite';
+import { pushSchema } from 'drizzle-kit/api';
+import { drizzle } from 'drizzle-orm/pglite';
+import * as dsqlSchema from '../../../src/lib/server/db/dsql/schema';
+
+export type DsqlTestDb = Awaited<ReturnType<typeof createDsqlTestDb>>;
+
+/** 実 dsql schema を適用済みの PGlite DB を作る。afterAll で close() すること。 */
+export async function createDsqlTestDb() {
+	const client = new PGlite();
+	const db = drizzle(client);
+	// pushSchema は空 DB との diff = 全 CREATE を生成して適用する。
+	// biome-ignore lint/suspicious/noExplicitAny: drizzle-kit/api の型が drizzle 本体と別系列のため
+	const { apply } = await pushSchema(dsqlSchema as any, db as any);
+	await apply();
+	return {
+		db,
+		client,
+		close: () => client.close(),
+	};
+}


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管 repo 層の第 1 弾）

**解決する課題**: 全 45 表の DDL と branded id 基盤（PR #3579）は完備したが、DSQL backend の repo 実装が 1 つも無く、service 層への結線に進めなかった。また repo テストは手書き DDL fixture に依存し schema drift の温床だった。

**期待される効果**: linchpin である children（child_id が ~20 表の複合 PK 先頭、§12.2.1 PR-0 の I-1）の IChildRepo が DSQL で完全動作し、後続 repo（auth / child-cluster）の実装パターン（factory 注入 / compute-on-read / 集約削除 txn / pushSchema テスト基盤）が確立する。

## 関連 Issue

- EPIC #3424（§12.2.1 build order「PR-2 以降: child-cluster 各表 DDL + repo」の repo 側第 1 弾。DDL は Slice A/B/C で完備済）
- related: PR #3579（branded id 基盤、本 PR が最初の実利用）/ #3562（stamp repo 実装時に消化する QM 指摘 3 点 — 本 PR は children のみで対象外）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | IChildRepo 全 10 メソッドの DSQL 実装（factory 注入 = fitness#8 の module-level client import 禁止に適合、全メソッド §P9 family_id 述語） | `npx vitest run tests/unit/db/dsql-child-repo.test.ts` + `src/lib/server/db/dsql/child-repo.ts` | HEAD `d80dc40d` / 9 passed（C1-C8 + branded 型整合）。db suite 全体 564/564 |
| AC2 | compute-on-read（§11.1）: age は birth_date から導出、非手動児の ui_mode は年齢から再導出（誕生日跨ぎ tier 自動遷移）。birth_date NULL は age=0 明示 fallback（PO B2 backfill 前提、入力 age から birth_date を合成しない） | test C2/C3（stored 'preschool' の 8 歳児が read で 'elementary' になることを実証） | HEAD `d80dc40d` / pass |
| AC3 | deleteChild = 集約全削除を単一 txn（§3/§P4 FK 非対応、28 表 + stamp_entries は card 経由 subquery + sibling_cheers は from/to 両軸。work は inline + tx-bound await のみ = fitness#7 準拠） | test C7（関連表消滅 + 兄弟 child の行 survive + 兄弟 card の stamp_entry のみ残存） | HEAD `d80dc40d` / pass。fitness#7 AST 検査も db suite 内で green |
| AC4 | resetChildProgressData = interface 契約の allowlist 3 表のみ削除 + counts 実削除数 + statuses 等 survive。DSQL 固有: children.total_point を同一 txn で 0 リセット（fitness#14 の total_point == SUM(point_ledger) 不変条件を維持） | test C8（pointLedger:2 / loginBonuses:1 の実数 + statuses.total_xp=100 survive + total_point=0） | HEAD `d80dc40d` / pass |
| AC5 | §P9 tenant 分離（他 family から不可視・更新不能） | test C4 | HEAD `d80dc40d` / pass |
| AC6 | テスト基盤: 手書き DDL fixture を廃し、drizzle-kit/api `pushSchema` で**実 schema.ts を PGlite に直接適用**する共有 helper（`tests/unit/helpers/dsql-test-db.ts`）を新設 — fixture drift の恒久排除 | helper 実装 + 45 表適用の実動作（本テストが全面依存） | HEAD `d80dc40d` / 適用 45 表で C1-C8 全 pass。副次検証: children_archived_reason_ck が誤 reason 値を実際に拒否（実装中に実測） |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)（dsql/child-repo.ts 新設。schema/interface は無変更）
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（新設ファイル 3 つのみ。DATA_SOURCE dispatch 未結線のため既存挙動への影響ゼロ。結線は client factory 整備後の cutover 系 PR）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: dsql-child-repo.test.ts 9 本新設（実 schema PGlite、集約削除の survive 検証含む）+ dsql-test-db 共有 helper 新設
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（未変更）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）**: server 側 repo 新設のみで UI 変更なし（.svelte 変更 0 file）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: interface（IChildRepo）は既存契約を一切変えず backend を追加（OCP）。依存は factory 注入（DIP、fitness#8 と同型）
- [x] **DRY**: age/uiMode 導出は domain 既存関数（calculateAgeFromBirthDate / recalcUiMode）を再利用（repo 内再実装なし）。テスト DDL は pushSchema で schema.ts SSOT を直接使用
- [x] **YAGNI**: DATA_SOURCE dispatch への結線は本 PR でしない（client factory が Phase I 未達のため、結線だけの空配線を作らない）
- [x] **Security（OSS 公開前提）**: 全 SQL が family_id 述語必須（§P9、テスト C4 で cross-tenant 不可視を実証）。identifier の raw 展開は定数配列（CHILD_SCOPED_TABLES）のみで injection 面なし
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: read は PK/covering 前提の単純 SELECT。deleteChild は §P1 の 1txn=3000 行制限内が前提（1 child 分の行数。超過リスクは cutover 大量データ時のみで、その経路は backup import の chunk+saga §9.1 が担う）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): §12.2.1 build order 記載の PR-2 系実装であり設計変更なし
- [x] **並行 PR overlap** (#1200): `db/dsql/**` は本セッション直列管理、open PR なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新設のみ、既存 backend / dispatch 無変更）

**レビュー依頼事項・QA**:
- deleteChild の削除対象から **invites.child_id を意図的に除外**した判断（auth 集約のため touch しない、招待は期限切れで自然消滅。DDL コメントに明記）
- resetChildProgressData で **total_point を 0 リセット**する DSQL 固有動作（sqlite/dynamodb には無い列。fitness#14 不変条件 total_point == SUM(point_ledger) の維持が目的で、リセット後は両辺 0 で整合）
- birth_date NULL 児の age=0 fallback（§11.1 PO B2: cutover backfill 必須の前提。新規作成 UI は BirthdayInput で birth_date が入る運用）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: repo 層は children（本 PR）→ auth → child-cluster の §12.2.1 順で継続
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
