### PR TITLE
feat: #3533 /admin/checklists プラン別ゲート 4 表現を収斂 (§10.2.3 locked-but-active)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1420,7 +1420,7 @@ free/standard ユーザーが有料機能・上限超過に触れたとき、**�
 
 | パターン | コンポーネント | 用途 | 表示 |
 |---------|--------------|------|---|
-| **A. ボタン disabled + popover** | `FeatureGate display="inline"` | 単発操作 / quota 上限到達時の「+追加」等 | 🔒 disabled、tap で popover（§10.2.1） |
+| **A. ボタン disabled + popover** | `FeatureGate display="inline"` | standalone の単発操作 / quota 上限到達（dropdown 内項目は §10.2.3） | 🔒 disabled、tap で popover（§10.2.1） |
 | **B. セクション disabled + popover** | `FeatureGate display="section"` | パネル・カード全体 | 中身は見せて操作 disabled、tap で popover |
 | **C. カード全体置き換え** | 個別実装 | 重要セクション | 可能なら A/B に寄せる（新規は個別実装を避ける） |
 
@@ -1445,10 +1445,22 @@ disabled 要素の tap で popover / bottom sheet を開く（Ark UI primitive �
 上限（N/M）を持つ機能では、**画面に N/M カウンタを出さない**。`plan-limit-service` が返す `{ allowed, current, max }` を FeatureGate に渡し:
 
 - `current < max`（未到達）: 操作可
-- `current >= max`（到達）: 「+追加」等を **disabled + popover**（§10.2.1）にする
+- `current >= max`（到達）: **standalone のボタン / セクション**なら `FeatureGate` の **disabled + popover**（§10.2.1）。**dropdown / メニュー内の項目**（例: 「+追加」dropdown の「手動で追加」）は §10.2.3 の **locked-but-active** にする
 - `max === null`（無制限プラン）: **ゲート痕跡を一切描画しない**（disabled も popover も出さない）
 
 「あと何個」は割り切りでプラン画面に委ねる（P1）。
+
+#### 10.2.3 dropdown / メニュー内項目の quota ゲート（locked-but-active、EPIC #3533）
+
+dropdown / メニュー（Ark UI `Menu`）は選択で閉じるため popover を anchor できない（§10.2.1 の popover は standalone 要素専用）。メニュー項目の quota ゲートは、業界収束パターン（Figma / Zapier / 汎用 Paywall = active item + lock マーカー + 選択で upgrade 導線）に倣い **locked-but-active** とする:
+
+- 上限到達時も項目を **完全 disabled にしない**（disabled + 説明なしは NN/G アンチパターン = dead-end。[NN/G Button States](https://www.nngroup.com/articles/button-states-communicate-interaction/)）
+- 項目 **アイコンを lock マーカー**（`PLAN_GATE_LABELS.lockedItemIcon` = 🔒）に差し替え、「制約あり」を最小表現（画面内 quota カウンタは出さない、P1）
+- **選択でプラン画面（`/admin/subscription`）へ遷移**（`goto`）。制約詳細・アップグレード CTA はプラン画面が SSOT（P1/P3）
+- ラベル文言は据え置き（断定的ブロック文言・個別アップセルを画面に持ち込まない）。上限到達の弾き返しは server 403 の保険として action-message（`role="status"`）が担う
+- tooltip は使わない（mobile hover 不可 / メニューが閉じる、[Primer tooltip alternatives](https://primer.style/guides/accessibility/tooltip-alternatives/)）
+
+適用例: `/admin/checklists` の「+追加」dropdown「手動で追加」（EPIC #3533 trigger case）。activities / rewards への横展開は後続。
 
 ### 10.3 トライアル表示（header pill + TrialBanner）仕様
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -453,7 +453,7 @@ export const PLAN_GATE_LABELS = {
 	upgradeLinkLabel: `${UPGRADE_TERMS.actionVerb}する`,
 
 	/**
-	 * dropdown / メニュー内の上限到達 add 項目に付ける lock マーカーアイコン (EPIC #3533 §10.2.2)。
+	 * dropdown / メニュー内の上限到達 add 項目に付ける lock マーカーアイコン (EPIC #3533 §10.2.3)。
 	 *
 	 * 上限到達時の add 系メニュー項目は完全 disabled にせず locked-but-active にし
 	 * (NN/G: disabled + 説明なしは dead-end アンチパターン)、本アイコンで「制約あり」を最小表現する。

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -451,6 +451,16 @@ export const PLAN_GATE_LABELS = {
 	 * 「どこへ行けば解消できるか」を必ず提示する。
 	 */
 	upgradeLinkLabel: `${UPGRADE_TERMS.actionVerb}する`,
+
+	/**
+	 * dropdown / メニュー内の上限到達 add 項目に付ける lock マーカーアイコン (EPIC #3533 §10.2.2)。
+	 *
+	 * 上限到達時の add 系メニュー項目は完全 disabled にせず locked-but-active にし
+	 * (NN/G: disabled + 説明なしは dead-end アンチパターン)、本アイコンで「制約あり」を最小表現する。
+	 * 選択でプラン画面へ遷移させ、制約詳細はプラン画面に一元化する (P1)。
+	 * standalone button / section の quota ゲートは FeatureGate の popover が担う (§10.2.1)。
+	 */
+	lockedItemIcon: '🔒',
 } as const;
 
 export const SUBSCRIPTION_PLAN_LABELS: Record<string, string> = {
@@ -5396,11 +5406,8 @@ export const ADMIN_CHECKLISTS_PAGE_LABELS = {
 	deleteButton: '削除',
 	timeSlotLabel: '時間帯:',
 	addItemButton: '+ アイテム追加',
-	limitReachedText: (max: number | string) => `フリープランの上限 (${max}個) に達しました`,
-	limitCountText: (current: number | string, max: number | string) =>
-		`チェックリスト ${current} / ${max}`,
-	upgradeLink: 'アップグレード →',
-	upgradeDesc: 'スタンダード以上にアップグレードすると無制限に作成できます。',
+	// EPIC #3533: 旧 free 上限バナー文言 (limitReachedText / limitCountText / upgradeLink / upgradeDesc) は
+	//   §10.2 P1/P3 に基づき撤去 (画面内 quota カウンタ・個別アップセル CTA を廃止、制約詳細はプラン画面へ一元化)。
 	addTemplateButton: '+ テンプレート作成',
 	addOverrideButton: '📅 ワンオフ追加',
 	// #2778 (Cluster D / User 指摘 #1 ボタン重複解消): 2 並列 button → 「+ 追加」dropdown menu 集約 (Hick's Law)
@@ -5427,7 +5434,8 @@ export const ADMIN_CHECKLISTS_PAGE_LABELS = {
 	addButton: '追加',
 	addItemDialogTitle: 'アイテム追加',
 	overrideDialogTitle: 'ワンオフ追加/除外',
-	premiumBadgeLabel: 'スタンダード以上',
+	// EPIC #3533: 旧 premiumBadgeLabel (ヘッダー「スタンダード以上」バッジ) は §10.2 P3/P4 で撤去
+	//   (tier 表示は header に一本化、画面内の個別プランバッジは非採用)。
 	// #2137 (MP-2): マーケットプレイス checklist 一括追加セクション (#2272: UI ラベルは TEMPLATE_TERMS atom 経由)
 	marketplaceSectionTitle: `${CONCEPT_ICONS.template} ${TEMPLATE_TERMS.userFacing}から一括追加`,
 	marketplaceSectionDesc:

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -21,7 +21,6 @@ import AiSuggestChecklistPanel from '$lib/features/admin/components/AiSuggestChe
 // CX-DoR #9・#11 横展開 (Round 18): empty state を共通 SSOT に統一 (NN/G #4 consistency)
 import { resolveImportFeedback } from '$lib/marketplace/ui/import-feedback';
 import UnifiedEmptyState from '$lib/marketplace/ui/UnifiedEmptyState.svelte';
-import PremiumBadge from '$lib/ui/components/PremiumBadge.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import ChildSelectionDialog, {
@@ -169,11 +168,14 @@ const anyDialogOpen = $derived(
 //   (種類・順序) が一致することを E2E (admin-add-path-isomorphism.spec.ts) が assert する (AC3)。
 const addMenuItems = $derived<MenuItem[]>([
 	{
+		// EPIC #3533 §10.2.2: 上限到達時は disabled にせず locked-but-active にする
+		//   (完全 disabled は NN/G アンチパターン = dead-end 化)。lock マーカー付きで活性のまま残し、
+		//   選択でプラン画面へ遷移させる (制約詳細はプラン画面に一元化 / dropdown item は popover 不適)。
+		//   業界収束パターン (Figma/Zapier/汎用 Paywall): active item + lock マーカー + 選択で upgrade 導線。
 		id: 'manual',
 		label: ADMIN_CHECKLISTS_PAGE_LABELS.addManualLabel,
-		icon: ADMIN_CHECKLISTS_PAGE_LABELS.addManualIcon,
-		disabled: atLimit,
-		onSelect: openAddTemplate,
+		icon: atLimit ? PLAN_GATE_LABELS.lockedItemIcon : ADMIN_CHECKLISTS_PAGE_LABELS.addManualIcon,
+		onSelect: atLimit ? goToPlanForLimit : openAddTemplate,
 	},
 	{
 		id: 'ai',
@@ -218,9 +220,17 @@ function openAddItem(templateId: string) {
 	addItemOpen = true;
 }
 
+// EPIC #3533 §10.2.2: 上限到達時の manual 追加は locked-but-active。選択でプラン画面へ誘導する
+//   (画面内に quota カウンタ / 個別 CTA を持たず、制約詳細はプラン画面に一元化 P1)。
+function goToPlanForLimit() {
+	void goto('/admin/subscription');
+}
+
 function openAddTemplate() {
 	if (anyDialogOpen) return;
-	// #723: Free プランで上限到達時はダイアログを開かない（サーバー側でも 403 で拒否）
+	// #723: Free プランで上限到達時はダイアログを開かない（サーバー側でも 403 で拒否）。
+	//   EPIC #3533 で manual の onSelect は上限時 goToPlanForLimit に切替わるため通常ここには来ないが、
+	//   直接呼び出し経路の防御として guard を残す。
 	if (atLimit) return;
 	templateName = '';
 	// #1755 (#1709-A): kind 削除 — 持ち物純化、初期アイコンは持ち物デフォルト 🎒
@@ -789,11 +799,6 @@ function getChildName(childId: ChildId): string {
 					testid="checklists-overflow-menu"
 				/>
 			{/snippet}
-			{#snippet badge()}
-				{#if !data.isPremium}
-					<PremiumBadge size="sm" label={ADMIN_CHECKLISTS_PAGE_LABELS.premiumBadgeLabel} />
-				{/if}
-			{/snippet}
 		</AdminResourceHeader>
 	</div>
 
@@ -836,35 +841,11 @@ function getChildName(childId: ChildId): string {
 		{/if}
 	{/if}
 
-	<!-- #3097 (EPIC #3096): プラン系バナー (slot 4) — free プラン上限の誘導を正準スロットに固定配置。
-	     旧: 一覧の下 (templates 描画後) にあったため activities / rewards (slot 4) と配置がズレていた。 -->
-	{#if !data.isPremium && checklistMax !== null}
-		<div class="px-4 py-3 rounded-lg bg-[var(--color-surface-trial)] border border-[var(--color-border-trial)] text-sm" data-testid="admin-checklists-plan-banner">
-			<div class="flex items-center justify-between gap-2">
-				<div class="flex items-center gap-2">
-					<span class="text-base">📋</span>
-					<span class="text-[var(--color-text-primary)]">
-						{#if atLimit}
-							{ADMIN_CHECKLISTS_PAGE_LABELS.limitReachedText(checklistMax)}
-						{:else}
-							{ADMIN_CHECKLISTS_PAGE_LABELS.limitCountText(currentCount, checklistMax)}
-						{/if}
-					</span>
-				</div>
-				<a
-					href="/pricing"
-					class="text-xs font-bold text-[var(--color-action-primary)] hover:underline"
-				>
-					{ADMIN_CHECKLISTS_PAGE_LABELS.upgradeLink}
-				</a>
-			</div>
-			{#if atLimit}
-				<p class="mt-1 text-xs text-[var(--color-text-secondary)]">
-					{ADMIN_CHECKLISTS_PAGE_LABELS.upgradeDesc}
-				</p>
-			{/if}
-		</div>
-	{/if}
+	<!-- EPIC #3533 (§10.2 P1/P3): 旧「プラン系バナー (slot 4、quota カウンタ + アップグレード CTA)」を撤去。
+	     同一の Free 上限制限が 1 画面に 4 表現 (badge / quota バナー / atLimit 文言 / action-message) で散在
+	     していた根本原因への対処。制約詳細・アップグレード導線はプラン画面 (/admin/subscription) に一元化し、
+	     機能画面側は「+ 追加」dropdown の manual 項目を locked-but-active (lock マーカー + 選択でプラン画面遷移)
+	     に留める。上限到達時の弾き返し文言は slot 6 の action-message (サーバー 403 の保険) が担う。 -->
 
 	<!-- #3097 (EPIC #3096): 検索 (slot 5、一覧の直上) — activities / rewards と同型に追加。 -->
 	<section data-testid="admin-checklists-search">

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -168,7 +168,7 @@ const anyDialogOpen = $derived(
 //   (種類・順序) が一致することを E2E (admin-add-path-isomorphism.spec.ts) が assert する (AC3)。
 const addMenuItems = $derived<MenuItem[]>([
 	{
-		// EPIC #3533 §10.2.2: 上限到達時は disabled にせず locked-but-active にする
+		// EPIC #3533 §10.2.3: 上限到達時は disabled にせず locked-but-active にする
 		//   (完全 disabled は NN/G アンチパターン = dead-end 化)。lock マーカー付きで活性のまま残し、
 		//   選択でプラン画面へ遷移させる (制約詳細はプラン画面に一元化 / dropdown item は popover 不適)。
 		//   業界収束パターン (Figma/Zapier/汎用 Paywall): active item + lock マーカー + 選択で upgrade 導線。
@@ -220,7 +220,7 @@ function openAddItem(templateId: string) {
 	addItemOpen = true;
 }
 
-// EPIC #3533 §10.2.2: 上限到達時の manual 追加は locked-but-active。選択でプラン画面へ誘導する
+// EPIC #3533 §10.2.3: 上限到達時の manual 追加は locked-but-active。選択でプラン画面へ誘導する
 //   (画面内に quota カウンタ / 個別 CTA を持たず、制約詳細はプラン画面に一元化 P1)。
 function goToPlanForLimit() {
 	void goto('/admin/subscription');


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: `/admin/checklists` で同一の Free プラン上限が **1 画面に 4 表現**（①タイトルバッジ「スタンダード以上」②quota バナー「1/3 + アップグレード→」③atLimit 文言 ④action-message）で散在し、ユーザーが「何が・なぜ・どうすれば解除されるか」を recognition できなかった（EPIC #3533 trigger case、NN/G #6 不全、20 回以上再指摘）。

**期待される効果**: 制約詳細・アップグレード導線をプラン画面に一元化し、機能画面側は最小の誘導に収斂。画面内 quota カウンタ・個別 CTA を撤去し、上限到達時の add は非 dead-end（locked-but-active → プラン画面遷移）にする。

## 関連 Issue

EPIC #3533 の AC4（`/admin/checklists` を 4 表現 → 収斂）を消化。統合 PR で集約 close されるため本 PR body では close 宣言せず参照に留める。
関連: #3533

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC4-1 | ① PremiumBadge「スタンダード以上」撤去 | 実画面 before/after SS + `grep premiumBadgeLabel` | HEAD `4b15be3a` / before=badge 有 / after=badge 無（SS 下記）/ label 撤去 |
| AC4-2 | ② quota バナー（カウンタ + CTA）撤去 | 実画面 SS + `grep -c admin-checklists-plan-banner "src/routes/(parent)/admin/checklists/+page.svelte"` | HEAD `4b15be3a` / after=banner 無（SS 下記）/ testid 0 件 |
| AC4-3 | 「+追加」manual を locked-but-active（lock + プラン画面遷移、非 disabled） | `+page.svelte` addMenuItems 目視 + §10.2.3 | HEAD `4b15be3a` / atLimit 時 icon=PLAN_GATE_LABELS.lockedItemIcon / onSelect=goToPlanForLimit |
| AC4-4 | ③ action-message（slot 6）維持（E2E 依存） | `npx vitest run tests/unit/routes/admin-checklists-create-template.test.ts` + `grep checklists-action-message tests/e2e` | HEAD `4b15be3a` / testid 維持 / 5 E2E spec 依存を保持 |
| AC4-5 | 設計書 §10.2.3 同期（dropdown item パターン明文化） | `docs/design/06-UI設計書.md` §10.2.3 | HEAD `4b15be3a` / §10.2.3 新設 + §10.2/§10.2.2 整合 |
| AC4-6 | 描画回帰なし（unit/typecheck/lint） | `npx vitest run tests/unit/routes/ tests/unit/domain/` / `npx svelte-check` / `node scripts/check-hardcoded-strings.mjs` | HEAD `4b15be3a` / unit 877 passed / svelte-check 0 err / hardcoded 0 |

## 変更タイプ

- [x] feat: 新機能

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/`) — `admin/checklists/+page.svelte`
- [x] ドメインモデル (`$lib/domain/`) — labels.ts（死んだ label 撤去 + lockedItemIcon 追加）
- [x] 設定・CI（`docs/design/06-UI設計書.md` §10.2.3）

**影響を受ける画面・機能**: `/admin/checklists`（親管理・チェックリスト管理）。server (`+page.server.ts`) は無変更（403 防御は不変）。

## テスト & 安全装置セルフチェック

- [x] **unit / svelte-check / biome / hardcoded ローカル PASS**: `npx vitest run tests/unit/routes/ tests/unit/domain/` 877 passed / `npx svelte-check` 0 err（本 PR ファイル）/ `npx biome check` 0 / `node scripts/check-hardcoded-strings.mjs` 0
- [x] 追加・変更したテストの概要: N/A（既存 unit 全 pass を確認。at-limit の locked-item→プラン画面遷移 goal 完遂 E2E は EPIC #3533 AC6 で追加する）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

実画面 `/admin/checklists`（`npm run dev` + `DEBUG_PLAN=free`）の before/after。①badge「スタンダード以上」+ ②banner「チェックリスト 1/3 アップグレード→」が after で撤去され、グローバル header の「アップグレード」（tier 導線、P3）のみ残る。

| | モバイル (390px) | PC (1440px) |
|---|---|---|
| **修正前** | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3583/checklists-before-page-mobile.png) | ![before-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3583/checklists-before-page-pc.png) |
| **修正後** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3583/checklists-after-page-mobile.png) | ![after-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3583/checklists-after-page-pc.png) |

DOM HTML スナップショット: [after-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3583/checklists-after-page-pc.dom.html) / [after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3583/checklists-after-page-mobile.dom.html)

**インタラクティブ状態**: 上限到達時の manual 項目 locked-but-active（🔒 + プラン画面遷移）は §10.2.3 の設計で定義。at-limit 実機 SS + E2E は AC6 で担保（本 PR の SS は free プラン通常状態の badge+banner 撤去を実証）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: ゲート表示ロジックを撤去し AdminResourceHeader / action-message の既存責務に集約
- [x] **DRY**: lock アイコンを `PLAN_GATE_LABELS.lockedItemIcon` に SSOT 化（横展開 sub-task 5 で再利用）
- [x] **YAGNI**: dropdown item に FeatureGate popover を無理に適用せず、業界収束の locked-but-active を採用
- [x] **Security**: N/A（server 403 防御は不変）
- [x] **アクセシビリティ**: 完全 disabled を避け（NN/G アンチパターン）active + lock マーカーに。tooltip 非依存（mobile hover 不可）
- [x] **パフォーマンス**: N/A（描画要素の撤去のみ）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): `docs/design/06-UI設計書.md` §10.2.3 新設（dropdown item の quota ゲート = locked-but-active）
- [x] **labels SSOT**: 死んだ label 撤去 + `PLAN_GATE_LABELS.lockedItemIcon` 追加。リテラル直書きなし
- [x] **並行 PR overlap** (#1200): 変更は checklists +page.svelte / labels.ts / 設計書。同時変更の open PR なし
- [x] **本番/デモ同期**: 本番ルート（checklists）の変更。demo Lambda も同ルートを host（ADR-0048）のため同一実装
- [x] N/A — 年齢モード（本画面は親管理・age mode 非依存）/ ナビ（変更なし）

**activities / rewards への横展開**（同じ badge+banner を持つ）は EPIC #3533 AC5 で実施（本 PR は checklists の trigger case に限定、§10.2.3 でパターン確定）。

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（server 契約不変。UI 表示要素の撤去 + dropdown item の onSelect 切替のみ）

**レビュー依頼事項・QA**: dropdown menu item の quota ゲートを popover でなく「locked-but-active（lock + プラン画面遷移）」にした判断（deep-research: Figma/Zapier/汎用 Paywall + NN/G disabled anti-pattern、一次情報）が §10.2 の意図と業界実績に整合するかの確認。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] unit / svelte-check / biome / hardcoded ローカル PASS
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = AC4。AC5 横展開 / AC6 E2E は後続 PR）
- [x] Phase 分割: EPIC #3533 で PO 合意済み
- [x] UI 変更時: 実画面 before/after SS（GitHub 上表示）+ DOM HTML 併記、DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: N/A（admin 画面は local dev + DEBUG_PLAN で撮影）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
