### PR TITLE
feat: #3424 PR-R2 — DSQL IAuthRepo 実装 (token_hash 配線 #3528 + owner 空白防止 hardening)

### DIFF
--- a/src/lib/server/auth/invite-code-hash.ts
+++ b/src/lib/server/auth/invite-code-hash.ts
@@ -1,0 +1,20 @@
+// src/lib/server/auth/invite-code-hash.ts
+// EPIC #3424 / PR-R2 / 設計 SSOT: dsql-data-model.md §6.6 invites.token_hash
+//
+// 招待コード hash の SSOT。DSQL invites 表は raw 招待コードを保存せず、
+// sha256(raw) の hex のみを token_hash に保存する (CWE-522: bare bearer token の
+// DB 平文保存による機密性退行を防ぐ。DB dump が漏れても招待リンクとして使えない)。
+//
+// - lookup は WHERE token_hash = hashInviteCode(raw) の等値照合。ユーザ入力と
+//   秘密の直接比較を行わないため、B-tree 照合の timing で raw が漏れる面は
+//   hash の前像困難性で遮断される (現行 DynamoDB inviteCode capability 機構の写像)。
+// - salt / pepper は不採用: 招待コードは inv-<uuidv4> で 122bit エントロピーがあり
+//   総当たり・レインボー表が成立しない (パスワード hash とは脅威モデルが異なる)。
+//   決定的 hash でないと WHERE 等値 lookup ができない。
+
+import { createHash } from 'node:crypto';
+
+/** 招待コード raw → invites.token_hash 保存値 (sha256 hex、決定的)。 */
+export function hashInviteCode(code: string): string {
+	return createHash('sha256').update(code).digest('hex');
+}

--- a/src/lib/server/auth/invite-code-hash.ts
+++ b/src/lib/server/auth/invite-code-hash.ts
@@ -8,7 +8,7 @@
 // - lookup は WHERE token_hash = hashInviteCode(raw) の等値照合。ユーザ入力と
 //   秘密の直接比較を行わないため、B-tree 照合の timing で raw が漏れる面は
 //   hash の前像困難性で遮断される (現行 DynamoDB inviteCode capability 機構の写像)。
-// - salt / pepper は不採用: 招待コードは inv-<uuidv4> で 122bit エントロピーがあり
+// - salt / pepper は不採用: 招待コードは inv-<uuid v4> で 122bit エントロピーがあり
 //   総当たり・レインボー表が成立しない (パスワード hash とは脅威モデルが異なる)。
 //   決定的 hash でないと WHERE 等値 lookup ができない。
 

--- a/src/lib/server/db/dsql/auth-repo.ts
+++ b/src/lib/server/db/dsql/auth-repo.ts
@@ -1,0 +1,478 @@
+// src/lib/server/db/dsql/auth-repo.ts
+// EPIC #3424 / PR-R2 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §6.6 / §P9
+//
+// IAuthRepo の DSQL backend 実装。設計契約:
+//   - **factory 注入** (fitness#8: module-level db/client import 禁止)。db (SqlExecutor) と
+//     TransactionRunner を呼び出し側 (将来の client factory / テスト) が渡す。
+//   - **§P9 tenant 述語**: family 系メソッドは family_id を WHERE に含む。users は
+//     グローバル表 (§6.6 正準、§11.2 例外) のため tenant 述語を持たない。
+//   - **createTenant / updateTenantOwner / deleteTenant は単一 txn** (§6.6)。work 内の
+//     await は tx.execute(...) 直呼びのみ (fitness#7、helper 閉包経由 await 禁止 — PR-R1 教訓)。
+//   - **invite は token_hash のみ保存** (CWE-522、raw 非保存)。hash SSOT は
+//     $lib/server/auth/invite-code-hash.ts。raw code を知るのは作成時の呼び出し側だけ。
+//   - **invite 受諾は invite-accept.ts が正** (§6.6 厳密分岐の単一 txn)。本 repo の
+//     updateInviteStatus は revoke / expire 等の管理系遷移用で pending 条件を課さない。
+//   - 23505 (email_lower / owner_guard UNIQUE 違反) は throw のまま呼び出し側契約
+//     (dynamo backend の ConditionExpression 失敗 throw / invite-accept の catch と同型)。
+
+import { randomUUID } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { MS_PER_DAY } from '$lib/domain/constants/time';
+import { asChildId } from '$lib/domain/ids';
+import { INVITE_EXPIRY_DAYS } from '$lib/domain/validation/auth';
+import type {
+	AuthUser,
+	ConsentRecord,
+	Invite,
+	Membership,
+	Tenant,
+} from '$lib/server/auth/entities';
+import { hashInviteCode } from '$lib/server/auth/invite-code-hash';
+import type { Role } from '$lib/server/auth/types';
+import type { IAuthRepo } from '../interfaces/auth-repo.interface';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type { SqlExecutor } from './sql-executor';
+
+// ---------------------------------------------------------------- row 型 + mapper
+
+interface UserRow {
+	user_id: string;
+	email: string;
+	provider: string;
+	display_name: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+const USER_COLUMNS = sql.raw('user_id, email, provider, display_name, created_at, updated_at');
+
+function toUser(row: UserRow): AuthUser {
+	return {
+		userId: row.user_id,
+		email: row.email,
+		provider: row.provider as AuthUser['provider'],
+		displayName: row.display_name ?? undefined,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+interface FamilyRow {
+	family_id: string;
+	name: string;
+	owner_user_id: string | null;
+	status: string;
+	plan: string | null;
+	stripe_customer_id: string | null;
+	stripe_subscription_id: string | null;
+	plan_expires_at: string | null;
+	trial_used_at: string | null;
+	last_active_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+const FAMILY_COLUMNS = sql.raw(
+	`family_id, name, owner_user_id, status, plan, stripe_customer_id, stripe_subscription_id,
+	 plan_expires_at, trial_used_at, last_active_at, created_at, updated_at`,
+);
+
+function toTenant(row: FamilyRow): Tenant {
+	return {
+		tenantId: row.family_id,
+		name: row.name,
+		// owner_user_id は denormalized cache (SSOT = memberships.owner_guard、§6.6)。
+		// createTenant / updateTenantOwner が常に設定する運用のため NULL は理論上無いが、
+		// entity は必須 string ゆえ防御的に '' を返す (memberships への追加 lookup はしない)。
+		ownerId: row.owner_user_id ?? '',
+		status: row.status as Tenant['status'],
+		plan: (row.plan ?? undefined) as Tenant['plan'],
+		stripeCustomerId: row.stripe_customer_id ?? undefined,
+		stripeSubscriptionId: row.stripe_subscription_id ?? undefined,
+		planExpiresAt: row.plan_expires_at ?? undefined,
+		trialUsedAt: row.trial_used_at ?? undefined,
+		lastActiveAt: row.last_active_at ?? undefined,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+interface MembershipRow {
+	family_id: string;
+	user_id: string;
+	role: string;
+	invited_by: string | null;
+	joined_at: string;
+}
+
+const MEMBERSHIP_COLUMNS = sql.raw('family_id, user_id, role, invited_by, joined_at');
+
+function toMembership(row: MembershipRow): Membership {
+	return {
+		userId: row.user_id,
+		tenantId: row.family_id,
+		role: row.role as Role,
+		joinedAt: row.joined_at,
+		invitedBy: row.invited_by ?? undefined,
+	};
+}
+
+interface InviteRow {
+	invite_id: string;
+	family_id: string;
+	invited_by: string;
+	role: string;
+	child_id: string | null;
+	email: string | null;
+	status: string;
+	expires_at: string;
+	accepted_by: string | null;
+	accepted_at: string | null;
+	created_at: string;
+}
+
+const INVITE_COLUMNS = sql.raw(
+	`invite_id, family_id, invited_by, role, child_id, email, status, expires_at,
+	 accepted_by, accepted_at, created_at`,
+);
+
+/** row → Invite。raw code は DB に無い (CWE-522) ため呼び出し側が inviteCode を供給する。 */
+function toInvite(row: InviteRow, inviteCode: string): Invite {
+	return {
+		inviteCode,
+		tenantId: row.family_id,
+		invitedBy: row.invited_by,
+		role: row.role as Role,
+		childId: row.child_id != null ? asChildId(row.child_id) : undefined,
+		email: row.email ?? undefined,
+		status: row.status as Invite['status'],
+		createdAt: row.created_at,
+		expiresAt: row.expires_at,
+		acceptedBy: row.accepted_by ?? undefined,
+		acceptedAt: row.accepted_at ?? undefined,
+	};
+}
+
+interface ConsentRow {
+	family_id: string;
+	user_id: string;
+	type: string;
+	version: string;
+	consented_at: string;
+	ip_address: string;
+	user_agent: string;
+}
+
+const CONSENT_COLUMNS = sql.raw(
+	'family_id, user_id, type, version, consented_at, ip_address, user_agent',
+);
+
+function toConsent(row: ConsentRow): ConsentRecord {
+	return {
+		tenantId: row.family_id,
+		userId: row.user_id,
+		type: row.type as ConsentRecord['type'],
+		version: row.version,
+		consentedAt: row.consented_at,
+		ipAddress: row.ip_address,
+		userAgent: row.user_agent,
+	};
+}
+
+// ---------------------------------------------------------------- factory
+
+/** DSQL 用 IAuthRepo を生成する (db/runner は注入、fitness#8)。 */
+export function createDsqlAuthRepo<TTx extends SqlExecutor>(
+	db: SqlExecutor,
+	runner: TransactionRunner<TTx>,
+): IAuthRepo {
+	return {
+		// ---------------------------------------------------------- User (global 表、§6.6)
+
+		async findUserByEmail(email) {
+			// email_lower 生成列 + UNIQUE (spike#6 F7)。case-insensitive lookup の SSOT。
+			const result = await db.execute(
+				sql`SELECT ${USER_COLUMNS} FROM users WHERE email_lower = lower(${email})`,
+			);
+			const row = result.rows[0] as UserRow | undefined;
+			return row ? toUser(row) : undefined;
+		},
+
+		async findUserById(userId) {
+			const result = await db.execute(
+				sql`SELECT ${USER_COLUMNS} FROM users WHERE user_id = ${userId}`,
+			);
+			const row = result.rows[0] as UserRow | undefined;
+			return row ? toUser(row) : undefined;
+		},
+
+		async createUser(input) {
+			// email 重複 (case-insensitive) は email_lower UNIQUE の 23505 で throw のまま
+			// (dynamo backend の ConditionExpression 失敗 throw と同型契約)。
+			const result = await db.execute(sql`
+				INSERT INTO users (email, provider, display_name)
+				VALUES (${input.email}, ${input.provider}, ${input.displayName ?? null})
+				RETURNING ${USER_COLUMNS}
+			`);
+			return toUser(result.rows[0] as UserRow);
+		},
+
+		async deleteUser(userId) {
+			await db.execute(sql`DELETE FROM users WHERE user_id = ${userId}`);
+		},
+
+		// ---------------------------------------------------------- Tenant (families)
+
+		async findTenantById(tenantId) {
+			const result = await db.execute(
+				sql`SELECT ${FAMILY_COLUMNS} FROM families WHERE family_id = ${tenantId}`,
+			);
+			const row = result.rows[0] as FamilyRow | undefined;
+			return row ? toTenant(row) : undefined;
+		},
+
+		async findTenantByStripeCustomerId(stripeCustomerId) {
+			// UNIQUE(stripe_customer_id) で 2hop→1hop (§6.6、spike#6 F8)。
+			const result = await db.execute(
+				sql`SELECT ${FAMILY_COLUMNS} FROM families WHERE stripe_customer_id = ${stripeCustomerId}`,
+			);
+			const row = result.rows[0] as FamilyRow | undefined;
+			return row ? toTenant(row) : undefined;
+		},
+
+		async listAllTenants() {
+			// §6.6 は created_at cursor ページング (OFFSET 不使用) を規定するが、現 interface は
+			// 無引数で全件契約 → 全件 SELECT (安定順序: created_at, family_id)。cursor 化は
+			// interface 進化 (cursor/limit 引数追加) が必要で、cutover 配線 PR 以降の課題。
+			const result = await db.execute(
+				sql`SELECT ${FAMILY_COLUMNS} FROM families ORDER BY created_at, family_id`,
+			);
+			return (result.rows as unknown as FamilyRow[]).map(toTenant);
+		},
+
+		async createTenant(input) {
+			// families INSERT + owner membership INSERT の単一 txn (§6.6: role の SSOT は
+			// memberships、owner_user_id は cache)。owner_guard 生成列 UNIQUE が owner ≤ 1 を
+			// DB 強制する。work 内 await は tx.execute のみ (fitness#7)。
+			return runner.runInTransaction(async (tx) => {
+				const inserted = await tx.execute(sql`
+					INSERT INTO families (name, owner_user_id, status)
+					VALUES (${input.name}, ${input.ownerId}, ${SUBSCRIPTION_STATUS.ACTIVE})
+					RETURNING ${FAMILY_COLUMNS}
+				`);
+				const family = inserted.rows[0] as FamilyRow;
+				await tx.execute(sql`
+					INSERT INTO memberships (family_id, user_id, role)
+					VALUES (${family.family_id}, ${input.ownerId}, 'owner')
+				`);
+				return toTenant(family);
+			});
+		},
+
+		async updateTenantStatus(tenantId, status) {
+			await db.execute(sql`
+				UPDATE families SET status = ${status}, updated_at = now()
+				WHERE family_id = ${tenantId}
+			`);
+		},
+
+		async updateTenantStripe(tenantId, data) {
+			const sets: ReturnType<typeof sql>[] = [];
+			if (data.stripeCustomerId !== undefined)
+				sets.push(sql`stripe_customer_id = ${data.stripeCustomerId}`);
+			if (data.stripeSubscriptionId !== undefined)
+				sets.push(sql`stripe_subscription_id = ${data.stripeSubscriptionId}`);
+			if (data.plan !== undefined) sets.push(sql`plan = ${data.plan}`);
+			if (data.planExpiresAt !== undefined) sets.push(sql`plan_expires_at = ${data.planExpiresAt}`);
+			if (data.trialUsedAt !== undefined) sets.push(sql`trial_used_at = ${data.trialUsedAt}`);
+			if (data.status !== undefined) sets.push(sql`status = ${data.status}`);
+			if (sets.length === 0) return;
+			await db.execute(sql`
+				UPDATE families SET ${sql.join(sets, sql`, `)}, updated_at = now()
+				WHERE family_id = ${tenantId}
+			`);
+		},
+
+		async updateTenantOwner(tenantId, newOwnerId) {
+			// 全て単一 txn (§6.6)。owner_guard UNIQUE と両立する更新順序:
+			// 旧 owner を先に demote してから新 owner を promote (逆順だと一瞬 owner 2 行で 23505)。
+			// 新 owner の membership が無い場合 promote は 0 行 = owner 空白になるため、
+			// 呼び出し側 (requireRole(['owner']) route、§6.6 ⚠️) が既存 member であることを保証する。
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(sql`
+					UPDATE memberships SET role = 'parent'
+					WHERE family_id = ${tenantId} AND role = 'owner' AND user_id <> ${newOwnerId}
+				`);
+				await tx.execute(sql`
+					UPDATE memberships SET role = 'owner'
+					WHERE family_id = ${tenantId} AND user_id = ${newOwnerId}
+				`);
+				await tx.execute(sql`
+					UPDATE families SET owner_user_id = ${newOwnerId}, updated_at = now()
+					WHERE family_id = ${tenantId}
+				`);
+			});
+		},
+
+		async updateTenantLastActiveAt(tenantId, lastActiveAt) {
+			// hooks の best-effort 呼び出し (#1601)。存在しない tenant は 0 行 = silent no-op
+			// (dynamo backend の ConditionalCheckFailed 黙認と同型契約)。
+			await db.execute(sql`
+				UPDATE families SET last_active_at = ${lastActiveAt}, updated_at = ${lastActiveAt}
+				WHERE family_id = ${tenantId}
+			`);
+		},
+
+		async deleteTenant(tenantId) {
+			// 本 PR の scope は auth 4 表 (families/memberships/invites/consents) の単一 txn 削除のみ。
+			// users は cross-tenant (global 表) なので消さない。§6.6 の family 全削除 orchestrator
+			// (children 集約含む全 40 テナント表 cascade、§P4 FK 非対応ゆえ明示 DELETE) は
+			// cutover 級の別 PR が担う — 本メソッドはその orchestrator の auth 部分として呼ばれる想定。
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(sql`DELETE FROM consents WHERE family_id = ${tenantId}`);
+				await tx.execute(sql`DELETE FROM invites WHERE family_id = ${tenantId}`);
+				await tx.execute(sql`DELETE FROM memberships WHERE family_id = ${tenantId}`);
+				await tx.execute(sql`DELETE FROM families WHERE family_id = ${tenantId}`);
+			});
+		},
+
+		// ---------------------------------------------------------- Membership
+
+		async findMembership(userId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${MEMBERSHIP_COLUMNS} FROM memberships
+				WHERE family_id = ${tenantId} AND user_id = ${userId}
+			`);
+			const row = result.rows[0] as MembershipRow | undefined;
+			return row ? toMembership(row) : undefined;
+		},
+
+		async findUserTenants(userId) {
+			// user 起点 lookup (session 3 連 lookup の起点、memberships_user_id_idx、§6.6)。
+			const result = await db.execute(sql`
+				SELECT ${MEMBERSHIP_COLUMNS} FROM memberships
+				WHERE user_id = ${userId} ORDER BY joined_at, family_id
+			`);
+			return (result.rows as unknown as MembershipRow[]).map(toMembership);
+		},
+
+		async findTenantMembers(tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${MEMBERSHIP_COLUMNS} FROM memberships
+				WHERE family_id = ${tenantId} ORDER BY joined_at, user_id
+			`);
+			return (result.rows as unknown as MembershipRow[]).map(toMembership);
+		},
+
+		async createMembership(input) {
+			// 2 人目 owner は owner_guard UNIQUE の 23505 で throw のまま
+			// (invite-accept 側が ALREADY_IN_TENANT へ写像する契約、§6.6)。
+			const result = await db.execute(sql`
+				INSERT INTO memberships (family_id, user_id, role, invited_by)
+				VALUES (${input.tenantId}, ${input.userId}, ${input.role}, ${input.invitedBy ?? null})
+				RETURNING ${MEMBERSHIP_COLUMNS}
+			`);
+			return toMembership(result.rows[0] as MembershipRow);
+		},
+
+		async deleteMembership(userId, tenantId) {
+			await db.execute(
+				sql`DELETE FROM memberships WHERE family_id = ${tenantId} AND user_id = ${userId}`,
+			);
+		},
+
+		// ---------------------------------------------------------- Invite (token_hash、CWE-522)
+
+		async createInvite(input) {
+			// raw code は repo が採番し (dynamo backend と同形式 inv-<uuidv4>、122bit エントロピー)、
+			// DB には hash のみ INSERT。raw を知るのは作成時の戻り値だけ (以後復元不能)。
+			const inviteCode = `inv-${randomUUID()}`;
+			const expiresAt = new Date(Date.now() + INVITE_EXPIRY_DAYS * MS_PER_DAY).toISOString();
+			const result = await db.execute(sql`
+				INSERT INTO invites (family_id, invited_by, role, child_id, email, token_hash, expires_at)
+				VALUES (${input.tenantId}, ${input.invitedBy}, ${input.role}, ${input.childId ?? null},
+					${input.email ? input.email.toLowerCase() : null}, ${hashInviteCode(inviteCode)}, ${expiresAt})
+				RETURNING ${INVITE_COLUMNS}
+			`);
+			return toInvite(result.rows[0] as InviteRow, inviteCode);
+		},
+
+		async findInviteByCode(inviteCode) {
+			const result = await db.execute(sql`
+				SELECT ${INVITE_COLUMNS} FROM invites WHERE token_hash = ${hashInviteCode(inviteCode)}
+			`);
+			const row = result.rows[0] as InviteRow | undefined;
+			// 呼び出し側が raw code を提示できた = capability 保持者。entity には引数の raw を返す。
+			return row ? toInvite(row, inviteCode) : undefined;
+		},
+
+		async updateInviteStatus(inviteCode, status, acceptedBy) {
+			// 管理系遷移 (revoke / expire / 旧経路 accept)。pending→accepted の厳密分岐
+			// (rowCount=0 / 23505 / 40001) は invite-accept.ts が正 (§6.6)。
+			if (acceptedBy) {
+				await db.execute(sql`
+					UPDATE invites SET status = ${status}, accepted_by = ${acceptedBy}, accepted_at = now()
+					WHERE token_hash = ${hashInviteCode(inviteCode)}
+				`);
+				return;
+			}
+			await db.execute(sql`
+				UPDATE invites SET status = ${status} WHERE token_hash = ${hashInviteCode(inviteCode)}
+			`);
+		},
+
+		async findTenantInvites(tenantId) {
+			// ⚠️ raw code は非保存で復元不能 (CWE-522)。一覧 entity の inviteCode には
+			// invite_id (uuid) を入れる。したがって一覧から得た「code」を findInviteByCode /
+			// updateInviteStatus / deleteInvite (hash 照合) に渡しても一致しない — 管理操作は
+			// inviteId ベースへの interface 進化が必要 (cutover 配線 PR で対応、issue 起票は
+			// 本体セッション)。この挙動はテスト [I2] で固定している。
+			const result = await db.execute(sql`
+				SELECT ${INVITE_COLUMNS} FROM invites
+				WHERE family_id = ${tenantId} ORDER BY created_at, invite_id
+			`);
+			return (result.rows as unknown as InviteRow[]).map((row) => toInvite(row, row.invite_id));
+		},
+
+		async deleteInvite(inviteCode, tenantId) {
+			// family_id 束縛必須 (§P9): 他 tenant の invite は hash が一致しても消せない。
+			await db.execute(sql`
+				DELETE FROM invites
+				WHERE token_hash = ${hashInviteCode(inviteCode)} AND family_id = ${tenantId}
+			`);
+		},
+
+		// ---------------------------------------------------------- Consent (append-only、§6.6)
+
+		async recordConsent(input) {
+			// append-only: UPDATE/DELETE は repo 非定義 + GRANT 除外 + fitness 多層禁止 (§6.6)。
+			const result = await db.execute(sql`
+				INSERT INTO consents (family_id, user_id, type, version, ip_address, user_agent)
+				VALUES (${input.tenantId}, ${input.userId}, ${input.type}, ${input.version},
+					${input.ipAddress}, ${input.userAgent})
+				RETURNING ${CONSENT_COLUMNS}
+			`);
+			return toConsent(result.rows[0] as ConsentRow);
+		},
+
+		async findLatestConsent(tenantId, type) {
+			// 最新判定は consented_at 降順 (version 文字列順に依存しない、§6.6)。
+			const result = await db.execute(sql`
+				SELECT ${CONSENT_COLUMNS} FROM consents
+				WHERE family_id = ${tenantId} AND type = ${type}
+				ORDER BY consented_at DESC LIMIT 1
+			`);
+			const row = result.rows[0] as ConsentRow | undefined;
+			return row ? toConsent(row) : undefined;
+		},
+
+		async findAllConsents(tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${CONSENT_COLUMNS} FROM consents
+				WHERE family_id = ${tenantId} ORDER BY consented_at, consent_id
+			`);
+			return (result.rows as unknown as ConsentRow[]).map(toConsent);
+		},
+	};
+}

--- a/src/lib/server/db/dsql/auth-repo.ts
+++ b/src/lib/server/db/dsql/auth-repo.ts
@@ -391,7 +391,7 @@ export function createDsqlAuthRepo<TTx extends SqlExecutor>(
 		// ---------------------------------------------------------- Invite (token_hash、CWE-522)
 
 		async createInvite(input) {
-			// raw code は repo が採番し (dynamo backend と同形式 inv-<uuidv4>、122bit エントロピー)、
+			// raw code は repo が採番し (dynamo backend と同形式 inv-<uuid v4>、122bit エントロピー)、
 			// DB には hash のみ INSERT。raw を知るのは作成時の戻り値だけ (以後復元不能)。
 			const inviteCode = `inv-${randomUUID()}`;
 			const expiresAt = new Date(Date.now() + INVITE_EXPIRY_DAYS * MS_PER_DAY).toISOString();

--- a/src/lib/server/db/dsql/auth-repo.ts
+++ b/src/lib/server/db/dsql/auth-repo.ts
@@ -297,17 +297,23 @@ export function createDsqlAuthRepo<TTx extends SqlExecutor>(
 		async updateTenantOwner(tenantId, newOwnerId) {
 			// 全て単一 txn (§6.6)。owner_guard UNIQUE と両立する更新順序:
 			// 旧 owner を先に demote してから新 owner を promote (逆順だと一瞬 owner 2 行で 23505)。
-			// 新 owner の membership が無い場合 promote は 0 行 = owner 空白になるため、
-			// 呼び出し側 (requireRole(['owner']) route、§6.6 ⚠️) が既存 member であることを保証する。
+			// 新 owner が member でない場合は promote 0 行 = owner 空白になるため、
+			// RETURNING 行数を検証し 0 行なら throw → txn ごと rollback (demote も巻き戻る)。
 			await runner.runInTransaction(async (tx) => {
 				await tx.execute(sql`
 					UPDATE memberships SET role = 'parent'
 					WHERE family_id = ${tenantId} AND role = 'owner' AND user_id <> ${newOwnerId}
 				`);
-				await tx.execute(sql`
+				const promoted = await tx.execute(sql`
 					UPDATE memberships SET role = 'owner'
 					WHERE family_id = ${tenantId} AND user_id = ${newOwnerId}
+					RETURNING 1
 				`);
+				if (promoted.rows.length === 0) {
+					throw new Error(
+						`updateTenantOwner: new owner ${newOwnerId} is not a member of tenant ${tenantId}`,
+					);
+				}
 				await tx.execute(sql`
 					UPDATE families SET owner_user_id = ${newOwnerId}, updated_at = now()
 					WHERE family_id = ${tenantId}

--- a/tests/unit/db/dsql-auth-repo.test.ts
+++ b/tests/unit/db/dsql-auth-repo.test.ts
@@ -1,0 +1,369 @@
+// tests/unit/db/dsql-auth-repo.test.ts
+// EPIC #3424 / PR-R2 / 設計 SSOT: dsql-data-model.md §6.6 / §P9
+//
+// DSQL IAuthRepo 実装のテスト。実 schema (pushSchema 適用、dsql-test-db helper) に対して:
+//   [U1] createUser → findById/findByEmail round-trip (uuid 採番、displayName NULL→undefined)
+//   [U2] email_lower: 大文字小文字非区別 lookup + case 違い重複 INSERT は 23505 で拒否
+//   [U3] deleteUser
+//   [T1] createTenant = families INSERT + owner membership INSERT の単一 txn
+//   [T2] owner_guard UNIQUE が 2 人目 owner の createMembership を物理拒否 (throw 契約)
+//   [T3] updateTenantOwner の txn 整合 (旧 owner demote → 新 owner promote → cache 更新)
+//   [T4] updateTenantStatus / updateTenantStripe / findTenantByStripeCustomerId
+//   [T5] updateTenantLastActiveAt (存在しない tenant は silent no-op)
+//   [T6] listAllTenants (created_at 順)
+//   [T7] deleteTenant = auth 4 表削除の単一 txn (users は cross-tenant で survive)
+//   [M1] membership CRUD (findUserTenants / findTenantMembers / deleteMembership)
+//   [I1] createInvite → findInviteByCode round-trip (raw code 維持、DB は token_hash のみ保存)
+//   [I2] findTenantInvites の inviteCode = invite_id (raw 非保存のため復元不能、挙動固定)
+//   [I3] invite email の小文字正規化 (§6.6)
+//   [I4] updateInviteStatus (hash 照合、acceptedBy/acceptedAt 設定)
+//   [I5] deleteInvite の tenant 束縛 (他 tenant からは消せない)
+//   [N1] consent append-only + findLatestConsent (consented_at 降順) + §P9 tenant 分離
+
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SUBSCRIPTION_PLAN } from '../../../src/lib/domain/constants/subscription-plan';
+import { asChildId } from '../../../src/lib/domain/ids';
+import { hashInviteCode } from '../../../src/lib/server/auth/invite-code-hash';
+import { createDsqlAuthRepo } from '../../../src/lib/server/db/dsql/auth-repo';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import type { IAuthRepo } from '../../../src/lib/server/db/interfaces/auth-repo.interface';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+const USER_A = '00000000-0000-4000-8000-0000000000b1';
+const USER_B = '00000000-0000-4000-8000-0000000000b2';
+const USER_C = '00000000-0000-4000-8000-0000000000b3';
+const NO_SUCH = '00000000-0000-4000-8000-00000000dead';
+const CHILD_1 = '00000000-0000-4000-8000-0000000000c1';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
+	let t: DsqlTestDb;
+	let repo: IAuthRepo;
+
+	beforeAll(async () => {
+		t = await createDsqlTestDb();
+		const runner = createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 });
+		repo = createDsqlAuthRepo(t.db, runner);
+	}, 60_000);
+	afterAll(async () => {
+		await t.close();
+	});
+
+	// ---------------------------------------------------------- User
+
+	it('[U1] createUser → findUserById/findUserByEmail round-trip', async () => {
+		const created = await repo.createUser({ email: 'Kenta@Example.com', provider: 'cognito' });
+		expect(created.userId).toMatch(UUID_RE);
+		expect(created.email).toBe('Kenta@Example.com'); // 表示用 email は原文保持
+		expect(created.provider).toBe('cognito');
+		expect(created.displayName).toBeUndefined(); // NULL → undefined 変換
+
+		const byId = await repo.findUserById(created.userId);
+		expect(byId?.email).toBe('Kenta@Example.com');
+
+		const withName = await repo.createUser({
+			email: 'named@example.com',
+			provider: 'cognito',
+			displayName: 'なまえ',
+		});
+		expect((await repo.findUserById(withName.userId))?.displayName).toBe('なまえ');
+	});
+
+	it('[U2] email_lower: 大文字小文字非区別 lookup + case 違い重複は 23505 拒否', async () => {
+		const found = await repo.findUserByEmail('KENTA@EXAMPLE.COM');
+		expect(found?.email).toBe('Kenta@Example.com');
+		expect(await repo.findUserByEmail('kenta@example.com')).toBeDefined();
+		expect(await repo.findUserByEmail('unknown@example.com')).toBeUndefined();
+
+		// case 違いの同一 email は email_lower UNIQUE が拒否 (throw のまま = 既存 backend 契約)
+		await expect(
+			repo.createUser({ email: 'KENTA@example.com', provider: 'cognito' }),
+		).rejects.toThrow();
+	});
+
+	it('[U3] deleteUser で消える', async () => {
+		const u = await repo.createUser({ email: 'delete-me@example.com', provider: 'cognito' });
+		await repo.deleteUser(u.userId);
+		expect(await repo.findUserById(u.userId)).toBeUndefined();
+		expect(await repo.findUserByEmail('delete-me@example.com')).toBeUndefined();
+	});
+
+	// ---------------------------------------------------------- Tenant
+
+	it('[T1] createTenant = families + owner membership の単一 txn', async () => {
+		const tenant = await repo.createTenant({ name: 'テスト家', ownerId: USER_A });
+		expect(tenant.tenantId).toMatch(UUID_RE);
+		expect(tenant.name).toBe('テスト家');
+		expect(tenant.ownerId).toBe(USER_A);
+		expect(tenant.status).toBe('active');
+		expect(tenant.plan).toBeUndefined(); // NULL → undefined
+		expect(tenant.stripeCustomerId).toBeUndefined();
+
+		const found = await repo.findTenantById(tenant.tenantId);
+		expect(found?.ownerId).toBe(USER_A);
+
+		// owner membership が同時作成されている (§6.6: SSOT = memberships)
+		const member = await repo.findMembership(USER_A, tenant.tenantId);
+		expect(member?.role).toBe('owner');
+	});
+
+	it('[T2] owner_guard UNIQUE が 2 人目 owner を物理拒否 (23505 throw 契約)', async () => {
+		const tenant = await repo.createTenant({ name: 'ガード家', ownerId: USER_A });
+		await expect(
+			repo.createMembership({ userId: USER_B, tenantId: tenant.tenantId, role: 'owner' }),
+		).rejects.toThrow();
+		// parent は許容される
+		const parent = await repo.createMembership({
+			userId: USER_B,
+			tenantId: tenant.tenantId,
+			role: 'parent',
+		});
+		expect(parent.role).toBe('parent');
+	});
+
+	it('[T3] updateTenantOwner: 旧 owner demote + 新 owner promote + cache 更新の txn 整合', async () => {
+		const tenant = await repo.createTenant({ name: '移譲家', ownerId: USER_A });
+		await repo.createMembership({ userId: USER_B, tenantId: tenant.tenantId, role: 'parent' });
+
+		await repo.updateTenantOwner(tenant.tenantId, USER_B);
+
+		expect((await repo.findMembership(USER_A, tenant.tenantId))?.role).toBe('parent'); // demote
+		expect((await repo.findMembership(USER_B, tenant.tenantId))?.role).toBe('owner'); // promote
+		expect((await repo.findTenantById(tenant.tenantId))?.ownerId).toBe(USER_B); // cache 更新
+	});
+
+	it('[T4] updateTenantStatus / updateTenantStripe / stripe lookup', async () => {
+		const tenant = await repo.createTenant({ name: '課金家', ownerId: USER_A });
+
+		await repo.updateTenantStatus(tenant.tenantId, 'grace_period');
+		expect((await repo.findTenantById(tenant.tenantId))?.status).toBe('grace_period');
+
+		const expires = '2026-08-01T00:00:00.000Z';
+		await repo.updateTenantStripe(tenant.tenantId, {
+			stripeCustomerId: 'cus_r2test',
+			stripeSubscriptionId: 'sub_r2test',
+			plan: SUBSCRIPTION_PLAN.MONTHLY,
+			planExpiresAt: expires,
+			trialUsedAt: '2026-07-01T00:00:00.000Z',
+			status: 'active',
+		});
+		const updated = await repo.findTenantById(tenant.tenantId);
+		expect(updated?.stripeCustomerId).toBe('cus_r2test');
+		expect(updated?.stripeSubscriptionId).toBe('sub_r2test');
+		expect(updated?.plan).toBe(SUBSCRIPTION_PLAN.MONTHLY);
+		expect(Date.parse(updated?.planExpiresAt ?? '')).toBe(Date.parse(expires));
+		expect(updated?.status).toBe('active');
+
+		const byStripe = await repo.findTenantByStripeCustomerId('cus_r2test');
+		expect(byStripe?.tenantId).toBe(tenant.tenantId);
+		expect(await repo.findTenantByStripeCustomerId('cus_unknown')).toBeUndefined();
+
+		// 部分更新: 未指定 field は不変
+		await repo.updateTenantStripe(tenant.tenantId, { status: 'suspended' });
+		const partial = await repo.findTenantById(tenant.tenantId);
+		expect(partial?.status).toBe('suspended');
+		expect(partial?.stripeCustomerId).toBe('cus_r2test');
+	});
+
+	it('[T5] updateTenantLastActiveAt (存在しない tenant は silent no-op)', async () => {
+		const tenant = await repo.createTenant({ name: '活動家', ownerId: USER_A });
+		const ts = '2026-07-04T01:02:03.000Z';
+		await repo.updateTenantLastActiveAt(tenant.tenantId, ts);
+		expect(Date.parse((await repo.findTenantById(tenant.tenantId))?.lastActiveAt ?? '')).toBe(
+			Date.parse(ts),
+		);
+		// dynamo backend の best-effort 契約と同じく throw しない
+		await expect(repo.updateTenantLastActiveAt(NO_SUCH, ts)).resolves.toBeUndefined();
+	});
+
+	it('[T6] listAllTenants は created_at 順で全件返す', async () => {
+		const all = await repo.listAllTenants();
+		expect(all.length).toBeGreaterThanOrEqual(4);
+		const times = all.map((x) => Date.parse(x.createdAt));
+		expect([...times].sort((a, b) => a - b)).toEqual(times);
+	});
+
+	it('[T7] deleteTenant = auth 4 表削除の単一 txn (users は survive)', async () => {
+		const owner = await repo.createUser({ email: 'survivor@example.com', provider: 'cognito' });
+		const tenant = await repo.createTenant({ name: '削除家', ownerId: owner.userId });
+		await repo.createInvite({ tenantId: tenant.tenantId, invitedBy: owner.userId, role: 'parent' });
+		await repo.recordConsent({
+			tenantId: tenant.tenantId,
+			userId: owner.userId,
+			type: 'terms',
+			version: 'v1',
+			ipAddress: '127.0.0.1',
+			userAgent: 'vitest',
+		});
+
+		await repo.deleteTenant(tenant.tenantId);
+
+		expect(await repo.findTenantById(tenant.tenantId)).toBeUndefined();
+		expect(await repo.findMembership(owner.userId, tenant.tenantId)).toBeUndefined();
+		expect(await repo.findTenantInvites(tenant.tenantId)).toEqual([]);
+		expect(await repo.findAllConsents(tenant.tenantId)).toEqual([]);
+		// users は cross-tenant なので消えない
+		expect(await repo.findUserById(owner.userId)).toBeDefined();
+	});
+
+	// ---------------------------------------------------------- Membership
+
+	it('[M1] membership CRUD (findUserTenants / findTenantMembers / delete)', async () => {
+		const t1 = await repo.createTenant({ name: 'メンバ家1', ownerId: USER_C });
+		await repo.createMembership({
+			userId: USER_B,
+			tenantId: t1.tenantId,
+			role: 'child',
+			invitedBy: USER_C,
+		});
+
+		const members = await repo.findTenantMembers(t1.tenantId);
+		expect(members.map((m) => m.userId).sort()).toEqual([USER_B, USER_C].sort());
+		const childMember = members.find((m) => m.userId === USER_B);
+		expect(childMember?.role).toBe('child');
+		expect(childMember?.invitedBy).toBe(USER_C);
+
+		const tenantsOfB = await repo.findUserTenants(USER_B);
+		expect(tenantsOfB.some((m) => m.tenantId === t1.tenantId)).toBe(true);
+
+		await repo.deleteMembership(USER_B, t1.tenantId);
+		expect(await repo.findMembership(USER_B, t1.tenantId)).toBeUndefined();
+	});
+
+	// ---------------------------------------------------------- Invite
+
+	it('[I1] createInvite → findInviteByCode round-trip (raw code 維持、DB は hash のみ)', async () => {
+		const tenant = await repo.createTenant({ name: '招待家', ownerId: USER_A });
+		const before = Date.now();
+		const invite = await repo.createInvite({
+			tenantId: tenant.tenantId,
+			invitedBy: USER_A,
+			role: 'parent',
+			childId: asChildId(CHILD_1),
+		});
+		// 作成時のみ raw code を返す (dynamo backend と同形式)
+		expect(invite.inviteCode).toMatch(/^inv-/);
+		expect(invite.status).toBe('pending');
+		expect(invite.childId).toBe(CHILD_1);
+		// expiresAt ≈ +7 日 (INVITE_EXPIRY_DAYS)
+		const expiresMs = Date.parse(invite.expiresAt);
+		expect(expiresMs).toBeGreaterThan(before + 6.9 * 24 * 3600 * 1000);
+		expect(expiresMs).toBeLessThan(before + 7.1 * 24 * 3600 * 1000);
+
+		// DB には raw code を保存しない (CWE-522): token_hash = sha256(raw) のみ
+		const rows = await t.db.execute(
+			sql`SELECT token_hash FROM invites WHERE family_id = ${tenant.tenantId}`,
+		);
+		const stored = (rows.rows[0] as { token_hash: string }).token_hash;
+		expect(stored).toBe(hashInviteCode(invite.inviteCode));
+		expect(stored).not.toContain(invite.inviteCode);
+
+		const found = await repo.findInviteByCode(invite.inviteCode);
+		expect(found?.inviteCode).toBe(invite.inviteCode); // 引数の raw code を維持
+		expect(found?.tenantId).toBe(tenant.tenantId);
+		expect(found?.invitedBy).toBe(USER_A);
+		expect(found?.role).toBe('parent');
+		expect(await repo.findInviteByCode('inv-unknown')).toBeUndefined();
+	});
+
+	it('[I2] findTenantInvites の inviteCode = invite_id (raw 非保存で復元不能、挙動固定)', async () => {
+		const tenant = await repo.createTenant({ name: '一覧家', ownerId: USER_A });
+		const created = await repo.createInvite({
+			tenantId: tenant.tenantId,
+			invitedBy: USER_A,
+			role: 'child',
+		});
+
+		const listed = await repo.findTenantInvites(tenant.tenantId);
+		expect(listed).toHaveLength(1);
+		// raw code は復元不能 → invite_id (uuid) を返す (interface 進化までの固定挙動)
+		expect(listed[0]?.inviteCode).toMatch(UUID_RE);
+		expect(listed[0]?.inviteCode).not.toBe(created.inviteCode);
+		expect(listed[0]?.role).toBe('child');
+		// §P9: 他 tenant の一覧には出ない
+		const other = await repo.createTenant({ name: '別家', ownerId: USER_B });
+		expect(await repo.findTenantInvites(other.tenantId)).toEqual([]);
+	});
+
+	it('[I3] invite email は小文字正規化して保存される (§6.6)', async () => {
+		const tenant = await repo.createTenant({ name: '宛先家', ownerId: USER_A });
+		const invite = await repo.createInvite({
+			tenantId: tenant.tenantId,
+			invitedBy: USER_A,
+			role: 'parent',
+			email: 'Aunt.Mari@Example.COM',
+		});
+		expect(invite.email).toBe('aunt.mari@example.com');
+		expect((await repo.findInviteByCode(invite.inviteCode))?.email).toBe('aunt.mari@example.com');
+	});
+
+	it('[I4] updateInviteStatus: hash 照合 + acceptedBy/acceptedAt 設定', async () => {
+		const tenant = await repo.createTenant({ name: '状態家', ownerId: USER_A });
+		const inv1 = await repo.createInvite({
+			tenantId: tenant.tenantId,
+			invitedBy: USER_A,
+			role: 'parent',
+		});
+		await repo.updateInviteStatus(inv1.inviteCode, 'revoked');
+		expect((await repo.findInviteByCode(inv1.inviteCode))?.status).toBe('revoked');
+
+		const inv2 = await repo.createInvite({
+			tenantId: tenant.tenantId,
+			invitedBy: USER_A,
+			role: 'parent',
+		});
+		await repo.updateInviteStatus(inv2.inviteCode, 'accepted', USER_B);
+		const accepted = await repo.findInviteByCode(inv2.inviteCode);
+		expect(accepted?.status).toBe('accepted');
+		expect(accepted?.acceptedBy).toBe(USER_B);
+		expect(accepted?.acceptedAt).toBeDefined();
+	});
+
+	it('[I5] deleteInvite は tenant 束縛 (他 tenant からは消せない)', async () => {
+		const mine = await repo.createTenant({ name: '自家', ownerId: USER_A });
+		const other = await repo.createTenant({ name: '他家', ownerId: USER_B });
+		const invite = await repo.createInvite({
+			tenantId: mine.tenantId,
+			invitedBy: USER_A,
+			role: 'parent',
+		});
+
+		await repo.deleteInvite(invite.inviteCode, other.tenantId); // 他 tenant → no-op
+		expect(await repo.findInviteByCode(invite.inviteCode)).toBeDefined();
+
+		await repo.deleteInvite(invite.inviteCode, mine.tenantId);
+		expect(await repo.findInviteByCode(invite.inviteCode)).toBeUndefined();
+	});
+
+	// ---------------------------------------------------------- Consent
+
+	it('[N1] consent append-only + latest 判定 (consented_at 降順) + §P9 分離', async () => {
+		const tenant = await repo.createTenant({ name: '同意家', ownerId: USER_A });
+		const other = await repo.createTenant({ name: '無同意家', ownerId: USER_B });
+		const base = {
+			tenantId: tenant.tenantId,
+			userId: USER_A,
+			ipAddress: '127.0.0.1',
+			userAgent: 'vitest',
+		};
+
+		const first = await repo.recordConsent({ ...base, type: 'terms', version: 'v1' });
+		expect(first.version).toBe('v1');
+		expect(first.consentedAt).toBeTruthy();
+		// consented_at 降順判定 (version 文字列順に依存しない、§6.6) — timestamp を確実に分離
+		await new Promise((r) => setTimeout(r, 10));
+		await repo.recordConsent({ ...base, type: 'terms', version: 'v0-later' });
+		await repo.recordConsent({ ...base, type: 'privacy', version: 'p1' });
+
+		const latest = await repo.findLatestConsent(tenant.tenantId, 'terms');
+		expect(latest?.version).toBe('v0-later'); // 後から記録した方が latest
+		expect((await repo.findLatestConsent(tenant.tenantId, 'privacy'))?.version).toBe('p1');
+		expect(await repo.findLatestConsent(other.tenantId, 'terms')).toBeUndefined(); // §P9
+
+		const all = await repo.findAllConsents(tenant.tenantId);
+		expect(all).toHaveLength(3);
+		expect(await repo.findAllConsents(other.tenantId)).toEqual([]);
+	});
+});

--- a/tests/unit/db/dsql-auth-repo.test.ts
+++ b/tests/unit/db/dsql-auth-repo.test.ts
@@ -366,4 +366,15 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 		expect(all).toHaveLength(3);
 		expect(await repo.findAllConsents(other.tenantId)).toEqual([]);
 	});
+
+	it('[T8] updateTenantOwner: 非 member への移譲は throw + rollback (owner 空白防止)', async () => {
+		const owner = await repo.createUser({ email: 't8-owner@example.com', provider: 'cognito' });
+		const tenant = await repo.createTenant({ name: 'T8家', ownerId: owner.userId });
+		await expect(
+			repo.updateTenantOwner(tenant.tenantId, '00000000-0000-4000-8000-00000000dead'),
+		).rejects.toThrow(/not a member/);
+		// rollback 検証: demote も巻き戻り旧 owner が owner のまま (owner 空白が生じない)
+		const members = await repo.findTenantMembers(tenant.tenantId);
+		expect(members.find((m) => m.userId === owner.userId)?.role).toBe('owner');
+	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管 repo 層第 2 弾 = 認証集約）

**解決する課題**: DSQL の auth リレーショナル 5 表（users/families/memberships/invites/consents、§6.6）は DDL 完備済だが IAuthRepo の DSQL 実装が無く、また §6.6 で確定した token_hash（招待 raw code 非保存、CWE-522）の DB 配線（#3528 残タスク）が未着手だった。

**期待される効果**: 認証集約の全 24 メソッドが DSQL で動作し、invite-accept（実装済）と合わせて auth ドメインの DSQL 側が完結。owner_guard / email_lower 生成列 UNIQUE / CHECK が実際に不正を拒否することもテストで実証された。

## 関連 Issue

- EPIC #3424（§12.2.1 build order PR-1 系 = auth repo。children repo = PR #3582 の次）
- #3528（token_hash の DB 配線 = 本 PR の `invite-code-hash.ts` + hash 照合で完遂）
- #3585（invite 管理操作の inviteId ベース interface 進化 — 本 PR の raw 非保存の帰結として**事前起票済み**、cutover 配線 PR で対応）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | IAuthRepo 全 24 メソッドの DSQL 実装（factory 注入 = fitness#8 適合、PR-R1 パターン準拠） | `npx vitest run tests/unit/db/dsql-auth-repo.test.ts` | HEAD `61e46e8c` / **18 passed**（U1-U3/T1-T8/M1/I1-I5/N1）。db suite 全体 582/582。**red 実測: import 解決不能 fail → green**（commit 15f01888 message に記録） |
| AC2 | token_hash 配線（§6.6 / #3528）: `invite-code-hash.ts`（sha256 hex SSOT、CWE-522 根拠コメント）+ raw code 非保存。createInvite は repo 内採番（dynamo 同形式 `inv-<uuid>`）→ hash 保存 → 作成時のみ raw を返す。findInviteByCode/updateInviteStatus/deleteInvite は hash 照合 | test I1-I5（round-trip / 一覧の raw 非復元 / email 小文字正規化 / delete の tenant 束縛） | HEAD `61e46e8c` / pass。findTenantInvites は inviteCode に invite_id を返す挙動をテスト I2 で**固定**（#3585 の interface 進化まで） |
| AC3 | createTenant = families INSERT + owner membership を単一 txn。owner_guard 生成列が 2 人目 owner を DB 拒否 | test T 系（owner_guard 23505 実測） | HEAD `61e46e8c` / pass |
| AC4 | updateTenantOwner = demote→promote→cache 更新の単一 txn + **非 member への移譲は RETURNING 検証で throw → 全 rollback（owner 空白 tenant の構造的防止）** | test T8（throw + demote 巻き戻りの実証。本体セッションが Agent 実装の設計懸念をレビューで検出し hardening） | HEAD `61e46e8c` / pass |
| AC5 | email_lower 生成列 UNIQUE による case-insensitive 一意 + findUserByEmail の大文字小文字非区別 | test U 系 | HEAD `61e46e8c` / pass |
| AC6 | fitness#7/#8 適合（txn work は tx.execute inline のみ / module-level client import なし） | `npx vitest run tests/unit/architecture/` | HEAD `61e46e8c` / 54 passed |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)（dsql/auth-repo.ts 新設。schema/interface 無変更）
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

補足: `src/lib/server/auth/invite-code-hash.ts` 新設（auth 層の純関数、既存コードからの参照なし）

**影響を受ける画面・機能**: なし（新設 3 file のみ、DATA_SOURCE dispatch 未結線で既存挙動への影響ゼロ）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: dsql-auth-repo.test.ts 18 本新設（pushSchema 実 schema 基盤。owner_guard 23505 / families_status_ck / users_provider_ck の CHECK・UNIQUE 実効性を副次実証）
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（未変更）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）**: server 側 repo 新設のみで UI 変更なし（.svelte 変更 0 file）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: IAuthRepo 契約無変更で backend 追加（OCP）。hash は invite-code-hash.ts 単一 SSOT（SRP）
- [x] **DRY**: invite 受諾は実装済 invite-accept.ts に委譲（updateInviteStatus は管理系遷移用で pending 条件を課さない旨コメントで責務分離を明記）。テスト基盤は PR-R1 の pushSchema helper を再利用
- [x] **YAGNI**: deleteTenant の全テナント表 cascade は実装しない（family 削除 orchestrator = cutover 級別 PR、auth 4 表のみの scope をコメント明記）。listAllTenants の cursor 化も interface 進化待ち（§6.6 記載、コメント化）
- [x] **Security（OSS 公開前提）**: raw 招待コード非保存（CWE-522）+ email 小文字正規化（#3549 判断2 の横流し防止と整合）+ owner 空白防止 rollback + §P9 tenant 述語（consents/invites/memberships）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: findUserByEmail/findInviteByCode は生成列 UNIQUE の単点 lookup。findUserTenants は §6.6 指定の secondary (user_id) を使用

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): §6.6 記載設計の実装であり設計変更なし
- [x] **並行 PR overlap** (#1200): `db/dsql/**` は本セッション直列管理、open PR なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新設のみ、既存 backend / dispatch 無変更）

**レビュー依頼事項・QA**:
- **findTenantInvites の inviteCode = invite_id 固定挙動**（raw 非保存の帰結。既存 caller が一覧から得た値を hash 照合系に渡すと不一致になるため、cutover 配線までに #3585 の interface 進化が必須 — dispatch 未結線の現時点では実害なし）
- **deleteTenant の scope 限定**（auth 4 表のみ。users は cross-tenant で不削除。全テナント表 cascade は family 削除 orchestrator 別 PR）
- **cutover 時の ID 形式注意**: users/families は uuid PK のため旧 `u-<uuid>`/`t-<uuid>` 形式の session/cookie 値が WHERE に流入すると 22P02。配線 PR で境界正規化が必要（handoff 記録済）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（Agent 実装を本体セッションが独立レビューし、owner 空白リスクを hardening（T8）で構造的に封鎖）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: repo 層は children（#3582）→ auth（本 PR）→ child-cluster 各 repo の §12.2.1 順で継続
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面の UI 変更なし。auth backend の新設のみで dev:cognito 対象画面に変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
