### PR TITLE
feat: #3533 /admin/rewards プラン別ゲート 3 表現を収斂 (§10.2.3 locked-but-active)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1460,7 +1460,7 @@ dropdown / メニュー（Ark UI `Menu`）は選択で閉じるため popover �
 - ラベル文言は据え置き（断定的ブロック文言・個別アップセルを画面に持ち込まない）。上限到達の弾き返しは server 403 の保険として action-message（`role="status"`）が担う
 - tooltip は使わない（mobile hover 不可 / メニューが閉じる、[Primer tooltip alternatives](https://primer.style/guides/accessibility/tooltip-alternatives/)）
 
-適用例: `/admin/checklists` の「+追加」dropdown「手動で追加」（EPIC #3533 trigger case）。activities / rewards への横展開は後続。
+適用例: `/admin/checklists`（quota gate、EPIC #3533 trigger case）/ `/admin/rewards`（カスタムごほうび = 有料機能の binary gate、`!isPremium` 時 manual を locked-but-active）の「+追加」dropdown「手動で追加」。activities（quota + AI パネル section gate）への横展開は後続。
 
 ### 10.3 トライアル表示（header pill + TrialBanner）仕様
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4188,7 +4188,7 @@ export const REWARDS_LABELS = {
 	// #2268: CRUD 整備 + 命名訂正 + 検索 + grant→add リネーム
 	// 応援系語彙（とくべつなごほうび / ボーナス贈与 / ボーナスポイントを贈れます）は削除済
 	sectionTitle: '🎁 ごほうび管理',
-	premiumBadge: '有料限定',
+	// EPIC #3533: 旧 premiumBadge (ヘッダー「有料限定」バッジ) は §10.2 P3/P4 で撤去。
 	tabRewards: 'ごほうび',
 	// #2998 fix: pageDescTitle / pageDescText1 は AdminResourceHeader の title / description と
 	// 二重表示になっていたため撤去。応援機能との区別案内 (pageDescText2) と messages クロスリンク
@@ -4197,10 +4197,8 @@ export const REWARDS_LABELS = {
 	pageDescHintPrefix: '💌 スタンプやメッセージは',
 	pageDescHintLink: 'おうえんメッセージ',
 	pageDescHintSuffix: 'から送れます',
-	upgradeBannerTitle: 'ごほうび管理はスタンダードプラン以上の機能です',
-	upgradeBannerDesc:
-		'アップグレードすると、子供 shop に並べるごほうびを自由に作成・編集・削除できます。',
-	upgradeButton: 'プランを確認する',
+	// EPIC #3533: 旧 free 向けアップグレード誘導バナー文言 (upgradeBannerTitle/Desc/Button) は
+	//   §10.2 P1/P3 で撤去 (画面内 CTA バナーを廃止、制約詳細はプラン画面へ一元化)。
 	selectChildTitle: 'こどもを選択',
 	selectTemplateTitle: 'プリセットを選択',
 	presetToggle: (open: boolean) => `${open ? '▼' : '▶'} プリセットから追加`,

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -300,11 +300,17 @@ function closeAddDialog() {
 // 同一 id・同一順序で揃える (admin-add-path-isomorphism.spec.ts AC6 同型性固定)。
 const addMenuItems = $derived<MenuItem[]>([
 	{
+		// EPIC #3533 §10.2.3: カスタムごほうび作成は有料機能 (binary gate)。上限/gate 到達時は
+		//   disabled にせず locked-but-active (NN/G: disabled + 説明なしは dead-end アンチパターン)。
+		//   lock マーカー + 選択でプラン画面へ遷移させ、制約詳細はプラン画面に一元化 (P1)。
 		id: 'manual',
 		label: ADMIN_REWARDS_PAGE_LABELS.addManualLabel,
-		icon: ADMIN_REWARDS_PAGE_LABELS.addManualIcon,
-		disabled: !data.isPremium,
-		onSelect: () => handleAddSelect('manual'),
+		icon: data.isPremium
+			? ADMIN_REWARDS_PAGE_LABELS.addManualIcon
+			: PLAN_GATE_LABELS.lockedItemIcon,
+		onSelect: data.isPremium
+			? () => handleAddSelect('manual')
+			: () => void goto('/admin/subscription'),
 	},
 	{
 		id: 'ai',
@@ -726,11 +732,6 @@ async function handleCopyFromChild() {
 		addMenuTestid="rewards-add-menu"
 		addMenuDataTutorial="rewards-add-start"
 	>
-		{#snippet badge()}
-			{#if !data.isPremium}
-				<span class="inline-block px-2 py-0.5 text-[10px] rounded-full bg-[var(--color-premium)] text-[var(--color-text-inverse)] align-middle">{REWARDS_LABELS.premiumBadge}</span>
-			{/if}
-		{/snippet}
 		{#snippet toolbarLeading()}
 			{#if data.pendingRequestsCount > 0}
 				<span class="inline-flex items-center justify-center min-w-5 h-5 px-1 text-xs font-bold rounded-full bg-[var(--color-action-danger)] text-white" data-testid="pending-badge">
@@ -816,29 +817,11 @@ async function handleCopyFromChild() {
 		{/if}
 	{/if}
 
-	<!-- #3097 (EPIC #3096): プラン系バナー (slot 4) — 正準スロットに固定配置。
-	     旧: child タブの上にあったため activities (slot 4 = limit banner) と配置がズレていた。 -->
-	{#if !data.isPremium}
-		<!-- #728: 無料プラン向けアップグレード誘導 -->
-		<div class="bg-[var(--color-premium-bg)] rounded-xl p-4 space-y-3 border border-[var(--color-border-premium)]" data-testid="admin-rewards-plan-banner">
-			<div class="flex items-start gap-3" data-testid="rewards-upgrade-banner">
-				<span class="text-2xl">✨</span>
-				<div class="flex-1">
-					<p class="font-bold text-[var(--color-premium)]">{REWARDS_LABELS.upgradeBannerTitle}</p>
-					<p class="text-xs text-[var(--color-premium-light)] mt-1">
-						{REWARDS_LABELS.upgradeBannerDesc}
-					</p>
-				</div>
-			</div>
-			<a
-				href="/admin/subscription"
-				class="inline-block px-3 py-1.5 bg-[var(--color-premium)] text-[var(--color-text-inverse)] rounded-lg font-bold text-sm hover:opacity-90 transition-colors"
-				data-testid="rewards-upgrade-cta"
-			>
-				{REWARDS_LABELS.upgradeButton}
-			</a>
-		</div>
-	{/if}
+	<!-- EPIC #3533 (§10.2 P1/P3): 旧「プラン系バナー (slot 4、rewards-upgrade-banner + CTA)」を撤去。
+	     カスタムごほうび = 有料機能の gate を badge / banner / manual disabled と多重表現していた根本原因への
+	     対処。制約詳細・アップグレード導線はプラン画面 (/admin/subscription) に一元化し、機能画面側は
+	     「+ 追加」dropdown の manual 項目を locked-but-active (§10.2.3、lock マーカー + 選択でプラン画面遷移)
+	     に留める。gate 到達時の弾き返しは slot 6 の action-message (role="status") が担う。 -->
 
 	<!-- #2268: 検索 UI (slot 5、一覧の直上、正準スロット契約 #3097) -->
 	<section data-testid="admin-rewards-search">

--- a/tests/e2e/plan-free.spec.ts
+++ b/tests/e2e/plan-free.spec.ts
@@ -104,17 +104,19 @@ test.describe('#751 free プラン — 機能ゲート', () => {
 		await expect(page.getByTestId('ai-suggest-upgrade-cta')).toBeVisible();
 	});
 
-	test('/admin/rewards — アップグレードバナーが表示される', async ({ page }) => {
-		// plan-gated-features.spec.ts でも検証済みだが、
-		// free プランの正面検証パッケージとしてここでも押さえる
+	test('/admin/rewards — manual 追加が locked-but-active + 常設バナーなし', async ({ page }) => {
+		// EPIC #3533 §10.2.3: 旧 rewards-upgrade-banner 撤去。free の gate は「+ 追加」manual の
+		//   locked-but-active (lock マーカー + 選択でプラン画面遷移) で表現される。
+		//   plan-gated-features.spec.ts でも検証済みだが free の正面検証パッケージとしてここでも押さえる。
 		await page.goto('/admin/rewards');
-		await expect(page.getByTestId('rewards-upgrade-banner')).toBeVisible();
-		await expect(page.getByTestId('rewards-upgrade-cta')).toBeVisible();
+		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
+		await page.getByTestId('rewards-add-menu').click();
+		await expect(page.getByTestId('menu-item-manual')).toContainText('🔒');
 	});
 
 	// #2316: 旧 /admin/messages 「ひとことメッセージ」family-only ゲートテストは削除。
 	//   #2267 (PR #2293) で /admin/messages 廃止 + /admin/cheer 統合により、
 	//   メッセージ機能は応援機能の付随要素として全プラン解放された。
 	//   ADR-0006 (assertion erosion ban) に従い skip ではなく削除。
-	//   free プランのゲート確認は /admin/rewards rewards-upgrade-banner で担保。
+	//   free プランのゲート確認は /admin/rewards の manual locked-but-active (§10.2.3) で担保。
 });

--- a/tests/e2e/plan-gated-features.spec.ts
+++ b/tests/e2e/plan-gated-features.spec.ts
@@ -12,7 +12,7 @@
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts plan-gated-features
 //
 // 対応ゲート:
-//  - /admin/rewards: rewards-upgrade-banner（free のみ表示）
+//  - /admin/rewards: 「+ 追加」manual の locked-but-active（free のみ lock マーカー、EPIC #3533 §10.2.3）
 //
 // #2316 削除済 ゲート:
 //  - /admin/messages: ひとことメッセージボタン (free/standard disabled, family enabled)
@@ -28,10 +28,17 @@ import { expect, test } from '@playwright/test';
 test.describe('#776 /admin/rewards プランゲート — free', () => {
 	test.use({ storageState: 'playwright/.auth/free.json' });
 
-	test('free プランではアップグレードバナーが表示される', async ({ page }) => {
+	// EPIC #3533 §10.2.3: 旧 rewards-upgrade-banner (slot 4 常設 CTA バナー) は撤去。
+	//   free の gate は「+ 追加」dropdown の manual 項目が locked-but-active (lock マーカー +
+	//   選択でプラン画面遷移) で表現される。banner が消え、gate signal が manual 項目へ移ったことを検証する
+	//   (ADR-0006: assertion は弱体化でなく新 UX 機構への置換。click→プラン画面遷移の goal 完遂は AC6 で担保)。
+	test('free プランでは manual 追加が locked-but-active (lock マーカー) + 常設バナーなし', async ({
+		page,
+	}) => {
 		await page.goto('/admin/rewards');
-		await expect(page.getByTestId('rewards-upgrade-banner')).toBeVisible();
-		await expect(page.getByTestId('rewards-upgrade-cta')).toBeVisible();
+		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
+		await page.getByTestId('rewards-add-menu').click();
+		await expect(page.getByTestId('menu-item-manual')).toContainText('🔒');
 	});
 
 	// #2894 AC5: free tier の reward-set 取込 → PlanLimitError が正しく描画される。
@@ -75,9 +82,13 @@ test.describe('#776 /admin/rewards プランゲート — free', () => {
 test.describe('#776 /admin/rewards プランゲート — standard', () => {
 	test.use({ storageState: 'playwright/.auth/standard.json' });
 
-	test('standard プランではアップグレードバナーが表示されない', async ({ page }) => {
+	test('standard プランでは manual 追加が gate なし (lock マーカーなし) + 常設バナーなし', async ({
+		page,
+	}) => {
 		await page.goto('/admin/rewards');
 		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
+		await page.getByTestId('rewards-add-menu').click();
+		await expect(page.getByTestId('menu-item-manual')).not.toContainText('🔒');
 	});
 
 	// #2894 AC5: paid tier (standard) は reward-set 取込が成功し一覧に反映される
@@ -111,9 +122,13 @@ test.describe('#776 /admin/rewards プランゲート — standard', () => {
 test.describe('#776 /admin/rewards プランゲート — family', () => {
 	test.use({ storageState: 'playwright/.auth/family.json' });
 
-	test('family プランではアップグレードバナーが表示されない', async ({ page }) => {
+	test('family プランでは manual 追加が gate なし (lock マーカーなし) + 常設バナーなし', async ({
+		page,
+	}) => {
 		await page.goto('/admin/rewards');
 		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
+		await page.getByTestId('rewards-add-menu').click();
+		await expect(page.getByTestId('menu-item-manual')).not.toContainText('🔒');
 	});
 });
 

--- a/tests/e2e/upgrade-flow.spec.ts
+++ b/tests/e2e/upgrade-flow.spec.ts
@@ -127,19 +127,24 @@ test.describe('#753 PlanStatusCard → /admin/subscription — family', () => {
 test.describe('#753 /admin/rewards → アップグレード導線', () => {
 	test.use({ storageState: 'playwright/.auth/free.json' });
 
-	test('free プランで rewards-upgrade-banner が表示され、CTA が /admin/subscription へリンクする', async ({
+	// EPIC #3533 §10.2.3: 旧 rewards-upgrade-banner + CTA を撤去し、gate 導線を「+ 追加」dropdown の
+	//   manual 項目 (locked-but-active) に集約。free の upgrade 導線 = manual 選択でプラン画面へ遷移する
+	//   goal 完遂を検証する (banner→CTA と等価の非 dead-end 導線、AC6 相当の click-through も本 test が担保)。
+	test('free プランで「+ 追加」manual (locked) 選択が /admin/subscription へ遷移する', async ({
 		page,
 	}) => {
 		await page.goto('/admin/rewards', { waitUntil: 'commit', timeout: 30_000 });
 
-		const banner = page.getByTestId('rewards-upgrade-banner');
-		await expect(banner).toBeVisible({ timeout: 30_000 });
+		// 旧常設バナーは撤去済
+		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
 
-		const cta = page.getByTestId('rewards-upgrade-cta');
-		await expect(cta).toBeVisible();
+		await page.getByTestId('rewards-add-menu').click();
+		const manualItem = page.getByTestId('menu-item-manual');
+		await expect(manualItem).toBeVisible();
+		await expect(manualItem).toContainText('🔒');
 
-		// CTA をクリックすると /admin/subscription に遷移する
-		await cta.click();
+		// locked manual を選択するとプラン画面へ遷移する (dead-end でない)
+		await manualItem.click();
 		await page.waitForURL(/\/admin\/subscription/, { timeout: 30_000 });
 	});
 });
@@ -327,13 +332,15 @@ test.describe('#753 PremiumWelcome モーダル — family', () => {
 test.describe('#753 アップグレード後の機能有効化 — standard', () => {
 	test.use({ storageState: 'playwright/.auth/standard.json' });
 
-	test('standard プランでカスタムごほうびが有効（rewards-upgrade-banner 非表示）', async ({
+	test('standard プランでカスタムごほうびが有効（manual に lock マーカーなし + 常設バナーなし）', async ({
 		page,
 	}) => {
 		await page.goto('/admin/rewards', { waitUntil: 'commit', timeout: 30_000 });
 
-		// standard では rewards-upgrade-banner は非表示
+		// EPIC #3533 §10.2.3: 常設バナーは撤去済。standard では manual が gate なし (lock マーカーなし)。
 		await expect(page.getByTestId('rewards-upgrade-banner')).toHaveCount(0);
+		await page.getByTestId('rewards-add-menu').click();
+		await expect(page.getByTestId('menu-item-manual')).not.toContainText('🔒');
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: `/admin/rewards` で「カスタムごほうび = 有料機能」の制約が **badge「有料限定」+ 常設アップグレードバナー + manual disabled** と多重表現され、同一画面に散在していた（EPIC #3533、NN/G #6 不全）。checklists (#3583) と同じ根本原因。

**期待される効果**: 制約詳細・アップグレード導線をプラン画面に一元化し、機能画面側は「+ 追加」dropdown の manual 項目を locked-but-active（lock マーカー + 選択でプラン画面遷移）に収斂。完全 disabled（dead-end）を回避し、業界収束パターン（§10.2.3）に統一する。

## 関連 Issue

EPIC #3533 の AC5（横展開 その1: rewards）を消化。統合 PR で集約 close されるため本 PR body では close 宣言せず参照に留める。
関連: #3533

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC5-r1 | ①「有料限定」badge 撤去 | 実画面 before/after SS + `grep -c "premiumBadge: '有料限定'" src/lib/domain/labels.ts` | HEAD `6df72be2` / before=badge 有 / after=badge 無（SS 下記）/ label 0 件 |
| AC5-r2 | ② rewards-upgrade-banner（slot 4 常設 CTA）撤去 | 実画面 SS + `grep -c admin-rewards-plan-banner "src/routes/(parent)/admin/rewards/+page.svelte"` | HEAD `6df72be2` / after=banner 無（SS 下記）/ testid 0 件 |
| AC5-r3 | 「+追加」manual を locked-but-active（!isPremium 時 lock + プラン画面遷移、非 disabled） | 実画面 menu SS（🔒 手動で1つ追加）+ `+page.svelte` addMenuItems 目視 | HEAD `6df72be2` / !isPremium 時 icon=lockedItemIcon / onSelect=goto('/admin/subscription') |
| AC5-r4 | E2E を新 UX 機構へ更新（banner→locked-item、弱体化でなく置換） | `npx playwright test tests/e2e/plan-gated-features.spec.ts tests/e2e/plan-free.spec.ts tests/e2e/upgrade-flow.spec.ts`（CI cognito-dev） | HEAD `6df72be2` / free=banner 消失+manual lock / upgrade-flow=manual(locked)選択→/admin/subscription 遷移の goal 完遂 |
| AC5-r5 | 描画回帰なし（unit/typecheck/lint） | `npx vitest run tests/unit/routes/` / `npx svelte-check` / `node scripts/check-hardcoded-strings.mjs` | HEAD `6df72be2` / rewards unit 375 passed / svelte-check 0 err / hardcoded 0 |

## 変更タイプ

- [x] feat: 新機能

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/`) — `admin/rewards/+page.svelte`
- [x] ドメインモデル (`$lib/domain/`) — labels.ts（死んだ label 撤去）

**影響を受ける画面・機能**: `/admin/rewards`（親管理・ごほうび管理）。server (`+page.server.ts`) は無変更。E2E 3 spec を新 UX へ更新。

## テスト & 安全装置セルフチェック

- [x] **unit / svelte-check / biome / hardcoded ローカル PASS**: `npx vitest run tests/unit/routes/` 375 passed（rewards）/ `npx svelte-check` 0 err / `npx biome check` 0 / `node scripts/check-hardcoded-strings.mjs` 0
- [x] 追加・変更したテストの概要: E2E 3 spec を banner-visibility 検証 → locked-but-active 機構検証へ更新（ADR-0006: assertion 弱体化でなく新 UX への置換。upgrade-flow は manual→プラン画面遷移の goal 完遂を検証し、むしろ強化）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

実画面 `/admin/rewards`（`npm run dev` + `DEBUG_PLAN=free`）の before/after。①「有料限定」badge + ②常設アップグレードバナーが after で撤去され、「+ 追加」dropdown の manual が「🔒 手動で1つ追加」（locked-but-active）になる。

| | モバイル (390px) | PC (1440px) |
|---|---|---|
| **修正前** | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3587/rewards-before-page-mobile.png) | ![before-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3587/rewards-before-page-pc.png) |
| **修正後** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3587/rewards-after-page-mobile.png) | ![after-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3587/rewards-after-page-pc.png) |

**修正後の「+ 追加」dropdown（locked manual）**: ![after-menu-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3587/rewards-after-menu-pc.png)

DOM HTML スナップショット: [after-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3587/rewards-after-page-pc.dom.html) / [after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3587/rewards-after-page-mobile.dom.html)

**インタラクティブ状態**: 上限/gate 到達時の manual locked-but-active（🔒 + プラン画面遷移）を撮影。paid では通常表示（lock なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: ゲート表示ロジックを撤去し AdminResourceHeader / action-message の既存責務に集約
- [x] **DRY**: lock アイコンは `PLAN_GATE_LABELS.lockedItemIcon` SSOT を checklists と共有（#3583 で追加済）
- [x] **YAGNI**: dropdown item に FeatureGate popover を無理に適用せず §10.2.3 の locked-but-active を採用
- [x] **Security**: N/A（server 403 防御は不変）
- [x] **アクセシビリティ**: 完全 disabled を避け（NN/G アンチパターン）active + lock マーカーに。tooltip 非依存
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): §10.2.3（dropdown item = locked-but-active）は #3583 で develop 反映済。rewards は同パターンの横展開のため設計書追記なし
- [x] **labels SSOT**: 死んだ label 撤去。リテラル直書きなし
- [x] **並行 PR overlap** (#1200): 変更は rewards +page.svelte / labels.ts / E2E 3 spec。同時変更の open PR なし
- [x] **本番/デモ同期**: 本番ルート（rewards）の変更。demo Lambda も同ルートを host（ADR-0048）
- [x] N/A — 年齢モード（親管理・age mode 非依存）/ ナビ（変更なし）

activities への横展開（quota + AI パネル section gate）は EPIC #3533 の後続 PR で実施。

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（server 契約不変。UI 表示要素の撤去 + manual の onSelect 切替のみ）

**レビュー依頼事項・QA**: E2E 3 spec の assertion を banner-visibility から locked-but-active 機構へ置換した点（ADR-0006 は弱体化を禁じるが、本件は UX 機構が変わったための等価/強化置換。upgrade-flow は click→プラン画面遷移の goal 完遂を新規に検証）。checklists (#3583) と同一パターンで一貫しているかの確認。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] unit / svelte-check / biome / hardcoded ローカル PASS
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = AC5 rewards。activities 横展開 / AC6 E2E は後続）
- [x] Phase 分割: EPIC #3533 で PO 合意済み
- [x] UI 変更時: 実画面 before/after SS（GitHub 上表示）+ DOM HTML 併記、DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: N/A（admin 画面は local dev + DEBUG_PLAN で撮影）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
