### PR TITLE
feat: #3533 /admin/activities プラン別 quota ゲートを収斂 (§10.2.3 locked-but-active)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1460,7 +1460,7 @@ dropdown / メニュー（Ark UI `Menu`）は選択で閉じるため popover �
 - ラベル文言は据え置き（断定的ブロック文言・個別アップセルを画面に持ち込まない）。上限到達の弾き返しは server 403 の保険として action-message（`role="status"`）が担う
 - tooltip は使わない（mobile hover 不可 / メニューが閉じる、[Primer tooltip alternatives](https://primer.style/guides/accessibility/tooltip-alternatives/)）
 
-適用例: `/admin/checklists`（quota gate、EPIC #3533 trigger case）/ `/admin/rewards`（カスタムごほうび = 有料機能の binary gate、`!isPremium` 時 manual を locked-but-active）の「+追加」dropdown「手動で追加」。activities（quota + AI パネル section gate）への横展開は後続。
+適用例: `/admin/checklists`（quota gate、EPIC #3533 trigger case）/ `/admin/rewards`（カスタムごほうび = 有料機能の binary gate、`!isPremium` 時 manual を locked-but-active）/ `/admin/activities`（quota gate、`activityLimit` 到達時 manual を locked-but-active + 旧 ActivityLimitBanner 撤去）の「+追加」dropdown「手動で追加」。activities の AI 提案パネル（`AiSuggestPanel` の premium section gate、dialog 内の upgrade card + CTA）の収斂は後続（standalone section のため §10.2.1 popover 適合を別途評価）。
 
 ### 10.3 トライアル表示（header pill + TrialBanner）仕様
 

--- a/src/lib/features/admin/components/ActivitiesHeader.svelte
+++ b/src/lib/features/admin/components/ActivitiesHeader.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { FEATURES_LABELS } from '$lib/domain/labels';
+import { FEATURES_LABELS, PLAN_GATE_LABELS } from '$lib/domain/labels';
 import AdminResourceHeader from '$lib/features/admin/components/AdminResourceHeader.svelte';
 import type { MenuItem } from '$lib/ui/primitives/Menu.svelte';
 
@@ -34,9 +34,12 @@ const L = FEATURES_LABELS.activitiesHeader;
 //   手動で1つ追加 / AI で提案してもらう / みんなのテンプレートから探す / 別のお子さまからコピー / 複数のお子さまにまとめて追加
 const addMenuItems = $derived<MenuItem[]>([
 	{
+		// EPIC #3533 §10.2.3: quota 上限到達 (!canAdd) 時は disabled でなく locked-but-active。
+		//   lock マーカー付きで活性のまま残し、選択 (onAddSelect('manual')) を page 側で
+		//   プラン画面遷移に振り替える。完全 disabled は NN/G アンチパターン (dead-end) のため回避。
 		id: 'manual',
 		label: L.addManualLabel,
-		icon: L.addManualIcon,
+		icon: canAdd ? L.addManualIcon : PLAN_GATE_LABELS.lockedItemIcon,
 		onSelect: () => onAddSelect('manual'),
 	},
 	{
@@ -119,7 +122,6 @@ const overflowItems = $derived<MenuItem[]>([
 	addMenuAriaLabel={L.addMenuAriaLabel}
 	addMenuTestid="header-add-activity-btn"
 	addMenuDataTutorial="add-activity-btn"
-	addDisabled={!canAdd}
 	overflowItems={overflowItems}
 	overflowTriggerLabel={L.overflowTriggerLabel}
 	overflowMenuAriaLabel={L.overflowMenuAriaLabel}

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -17,7 +17,6 @@ import ActivitiesHeader from '$lib/features/admin/components/ActivitiesHeader.sv
 import ActivityClearAllConfirm from '$lib/features/admin/components/ActivityClearAllConfirm.svelte';
 import ActivityCreateForm from '$lib/features/admin/components/ActivityCreateForm.svelte';
 import ActivityEmptyState from '$lib/features/admin/components/ActivityEmptyState.svelte';
-import ActivityLimitBanner from '$lib/features/admin/components/ActivityLimitBanner.svelte';
 import ActivityListItem from '$lib/features/admin/components/ActivityListItem.svelte';
 import AiSuggestPanel from '$lib/features/admin/components/AiSuggestPanel.svelte';
 import type { AiPreviewData } from '$lib/features/admin/components/activity-types';
@@ -180,8 +179,18 @@ const canAdd = $derived(!activityLimit || activityLimit.allowed);
 function handleAddSelect(mode: 'manual' | 'ai' | 'browse' | 'copy' | 'bulk') {
 	switch (mode) {
 		case 'manual':
+			// EPIC #3533 §10.2.3: quota 上限到達時は manual を locked-but-active にする
+			//   (完全 disabled は NN/G アンチパターン = dead-end)。選択でプラン画面へ誘導し、
+			//   制約詳細はプラン画面に一元化 (P1)。checklists / rewards と同一パターン。
+			if (!canAdd) {
+				void goto('/admin/subscription');
+				break;
+			}
+			addMode = 'manual';
+			showAddDialog = true;
+			break;
 		case 'ai':
-			addMode = mode;
+			addMode = 'ai';
 			showAddDialog = true;
 			break;
 		case 'browse':
@@ -506,12 +515,11 @@ function selectChild(childId: ChildId) {
 		/>
 	{/if}
 
-	<!-- #3097 (EPIC #3096): プラン系バナー (slot 4) — 正準スロットに固定配置 -->
-	{#if activityLimit && !activityLimit.allowed}
-		<div data-testid="admin-activities-plan-banner">
-			<ActivityLimitBanner current={activityLimit.current} max={activityLimit.max} />
-		</div>
-	{/if}
+	<!-- EPIC #3533 (§10.2 P1): 旧「プラン系バナー (slot 4、ActivityLimitBanner = quota カウンタ)」を撤去。
+	     画面内 quota カウンタ (current/max) を廃止し、制約詳細はプラン画面 (/admin/subscription) に一元化。
+	     機能画面側は「+ 追加」dropdown の manual 項目を locked-but-active (§10.2.3、lock マーカー +
+	     選択でプラン画面遷移) に留める。上限到達時の弾き返しは slot 6 の action-message が担う。 -->
+
 
 	<!-- #3097 (EPIC #3096): 検索 + フィルタ行 (slot 5、一覧の直上)。
 	     (B) カテゴリフィルタは活動固有のドメイン差のため撤去せず本スロットに配置する。 -->


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: `/admin/activities` で「カスタム活動上限（maxActivities quota）」の制約が **ActivityLimitBanner（quota カウンタ）+「+追加」トリガー全体 disabled** で表現され、後者は完全 disabled = dead-end（NN/G アンチパターン、ai/browse まで押せない）だった（EPIC #3533）。

**期待される効果**: 画面内 quota カウンタを撤去し、「+追加」トリガーは活性のまま manual のみ locked-but-active（§10.2.3）にする。制約詳細はプラン画面に一元化し、checklists (#3583) / rewards (#3587) と 3 画面で統一する。

## 関連 Issue

EPIC #3533 の AC5（横展開 その2: activities）を消化。統合 PR で集約 close されるため本 PR body では close 宣言せず参照に留める。
関連: #3533

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC5-a1 | ② ActivityLimitBanner（quota カウンタ）撤去 | `grep -c admin-activities-plan-banner "src/routes/(parent)/admin/activities/+page.svelte"` | HEAD `95d7e400` / testid 0 件 |
| AC5-a2 | 「+追加」トリガー全体 disabled（addDisabled）撤去 → manual のみ locked-but-active | `grep -c "addDisabled" src/lib/features/admin/components/ActivitiesHeader.svelte` + 目視 | HEAD `95d7e400` / addDisabled 0 件 / manual icon=canAdd?normal:lockedItemIcon |
| AC5-a3 | !canAdd 時 manual 選択でプラン画面へ遷移 | `+page.svelte` handleAddSelect 目視 | HEAD `95d7e400` / case 'manual': if(!canAdd) goto('/admin/subscription') |
| AC5-a4 | ai/browse/copy/bulk は活性維持（quota 非対象） | ActivitiesHeader addMenuItems 目視 | HEAD `95d7e400` / manual のみ icon 条件分岐、他は不変 |
| AC5-a5 | 描画回帰なし（unit/typecheck/lint） | `npx vitest run tests/unit/routes/ tests/unit/components/activity-empty-state.test.ts` / `npx svelte-check` / `node scripts/check-hardcoded-strings.mjs` | HEAD `95d7e400` / unit 383 passed / svelte-check 0 err / hardcoded 0 |

## 変更タイプ

- [x] feat: 新機能

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ページ / レイアウト (`src/routes/`) — `admin/activities/+page.svelte`
- [x] UI コンポーネント (`$lib/features/`) — `ActivitiesHeader.svelte`
- [x] 設定・CI（`docs/design/06-UI設計書.md` §10.2.3 適用例）

**影響を受ける画面・機能**: `/admin/activities`（親管理・活動管理）。server (`+page.server.ts`) は無変更。

## テスト & 安全装置セルフチェック

- [x] **unit / svelte-check / biome / hardcoded ローカル PASS**: `npx vitest run tests/unit/routes/ tests/unit/components/activity-empty-state.test.ts` 383 passed / `npx svelte-check` 0 err / `npx biome check` 0 / `node scripts/check-hardcoded-strings.mjs` 0
- [x] 追加・変更したテストの概要: N/A（既存 unit 全 pass。at-limit の locked-item→プラン画面遷移 goal 完遂 E2E は AC6 で追加する）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**at-limit の gate 視覚（banner 撤去 + locked manual）は checklists #3583 / rewards #3587 と同一機構**（§10.2.3 locked-but-active）。activities の上限は `checkActivityLimit(licenseStatus)` 由来で **`DEBUG_PLAN` に非連動**のため local dev で at-limit 実画面を再現できない（license-status ベース、age-mode 非依存）。よって本 PR は **通常状態（非 at-limit）の AFTER 実画面**を添付し、at-limit の before/after は #3583（checklists、同一 locked-but-active 機構の実画面 SS あり）を参照する。at-limit E2E は AC6 で担保。

**修正後（通常状態、「+追加」dropdown は活性維持）**:

| | モバイル (390px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし（at-limit のみ差異、local dev 再現不可） | 該当なし（同左） |
| **修正後** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3589/activities-after-page-mobile.png) | ![after-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3589/activities-after-page-pc.png) |

**修正後の「+ 追加」dropdown**: ![after-menu-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3589/activities-after-menu-pc.png)

DOM HTML スナップショット: [after-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3589/activities-after-page-pc.dom.html) / [after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3589/activities-after-page-mobile.dom.html)

**インタラクティブ状態**: at-limit 時の manual locked-but-active（🔒 + プラン画面遷移）は §10.2.3 の設計で定義、視覚は #3583 と同一。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: quota 表示ロジック（banner）を撤去し action-message / plan 画面の既存責務に集約
- [x] **DRY**: lock アイコンは `PLAN_GATE_LABELS.lockedItemIcon` SSOT を checklists / rewards と共有
- [x] **YAGNI**: dropdown item に FeatureGate popover を無理に適用せず §10.2.3 の locked-but-active を採用
- [x] **Security**: N/A（server 403 防御は不変）
- [x] **アクセシビリティ**: 完全 disabled（トリガー全体）を撤去し active + lock マーカーに（NN/G dead-end 回避）
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): §10.2.3 適用例に activities を追記（AI 提案パネル section gate 収斂は後続明記）
- [x] **labels SSOT**: `PLAN_GATE_LABELS.lockedItemIcon` 共有。新規リテラルなし
- [x] **並行 PR overlap** (#1200): 変更は activities +page.svelte / ActivitiesHeader.svelte / 設計書。同時変更の open PR なし
- [x] **本番/デモ同期**: 本番ルート（activities）の変更。demo Lambda も同ルートを host（ADR-0048）
- [x] N/A — 年齢モード（親管理・age mode 非依存）/ ナビ（変更なし）

**残タスク**: activities の AI 提案パネル（`AiSuggestPanel` の premium section gate = dialog 内 upgrade card + CTA）/ cloud-export / 週次レポート / 家族招待・きょうだいランキング 等の standalone/section gate は EPIC #3533 の後続で個別評価（FeatureGate section popover 適合含む）。

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（server 契約不変。UI 表示要素の撤去 + manual の onSelect 切替 + トリガー disable 解除のみ）

**レビュー依頼事項・QA**: 「+追加」トリガー全体 disable（dead-end）を撤去し manual のみ locked-but-active にした判断（ai/browse は quota 非対象のため活性維持）が checklists/rewards と一貫しているかの確認。at-limit SS が local dev 再現不可（license-status 由来）の点の許容。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] unit / svelte-check / biome / hardcoded ローカル PASS
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = AC5 activities。AI パネル等の残 gate / AC6 E2E は後続）
- [x] Phase 分割: EPIC #3533 で PO 合意済み
- [x] UI 変更時: AFTER 実画面 SS（GitHub 上表示）+ DOM HTML 併記、DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: N/A（admin 画面）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
