### PR TITLE
feat: #3424 PR-R3 — DSQL activity 系 3 repo 実装 (child-activity / pref / mastery)

### DIFF
--- a/src/lib/server/db/dsql/activity-mastery-repo.ts
+++ b/src/lib/server/db/dsql/activity-mastery-repo.ts
@@ -1,0 +1,84 @@
+// src/lib/server/db/dsql/activity-mastery-repo.ts
+// EPIC #3424 / PR-R3 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §11.2 / §P9
+//
+// IActivityMasteryRepo の DSQL backend 実装。設計契約:
+//   - **factory 注入** (fitness#8) + **§P9 tenant 述語** (全メソッド family_id = tenantId)。
+//   - activity_mastery は自然複合 PK (family_id, child_id, activity_id) で surrogate id 列を
+//     持たない (§11.2 凍結、#3541)。entity の `id: string` は `${child_id}:${activity_id}` を
+//     決定的に合成する (opaque token 契約、lookup key には使われない)。
+//   - upsert は複合 PK への単文 ON CONFLICT DO UPDATE (record-activity-core.ts ② と同型。
+//     sqlite の read-then-write と異なり atomic で txn 不要)。
+//   - record txn 内の mastery 共更新 (count+1 / level 再計算) は record-activity-core.ts が正 —
+//     本 repo の upsert は呼び出し側が算出済みの totalCount/level を書く CRUD 契約。
+
+import { sql } from 'drizzle-orm';
+import { asActivityId, asChildId } from '$lib/domain/ids';
+import type { IActivityMasteryRepo } from '../interfaces/activity-mastery-repo.interface';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type { ActivityMastery } from '../types';
+import type { SqlExecutor } from './sql-executor';
+
+interface MasteryRow {
+	family_id: string;
+	child_id: string;
+	activity_id: string;
+	total_count: number;
+	level: number;
+	updated_at: string;
+}
+
+const MASTERY_COLUMNS = sql.raw('family_id, child_id, activity_id, total_count, level, updated_at');
+
+/** row → entity (surrogate id 無しのため複合 PK から決定的合成)。 */
+function toMastery(row: MasteryRow): ActivityMastery {
+	return {
+		id: `${row.child_id}:${row.activity_id}`,
+		childId: asChildId(row.child_id),
+		activityId: asActivityId(row.activity_id),
+		totalCount: row.total_count,
+		level: row.level,
+		updatedAt: row.updated_at,
+	};
+}
+
+/** DSQL 用 IActivityMasteryRepo を生成する (db/runner は注入、fitness#8。
+ * 全メソッド単文で txn 不要のため runner は現状未使用だが factory 契約で受ける)。 */
+export function createDsqlActivityMasteryRepo<TTx extends SqlExecutor>(
+	db: SqlExecutor,
+	_runner: TransactionRunner<TTx>,
+): IActivityMasteryRepo {
+	return {
+		async findByChildAndActivity(childId, activityId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${MASTERY_COLUMNS} FROM activity_mastery
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND activity_id = ${activityId}
+			`);
+			const row = result.rows[0] as unknown as MasteryRow | undefined;
+			return row ? toMastery(row) : undefined;
+		},
+
+		async findAllByChild(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${MASTERY_COLUMNS} FROM activity_mastery
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+				ORDER BY activity_id
+			`);
+			return (result.rows as unknown as MasteryRow[]).map(toMastery);
+		},
+
+		async upsert(childId, activityId, totalCount, level, tenantId) {
+			const result = await db.execute(sql`
+				INSERT INTO activity_mastery (family_id, child_id, activity_id, total_count, level)
+				VALUES (${tenantId}, ${childId}, ${activityId}, ${totalCount}, ${level})
+				ON CONFLICT (family_id, child_id, activity_id)
+				DO UPDATE SET total_count = ${totalCount}, level = ${level}, updated_at = now()
+				RETURNING ${MASTERY_COLUMNS}
+			`);
+			return toMastery(result.rows[0] as unknown as MasteryRow);
+		},
+
+		async deleteByTenantId(tenantId) {
+			await db.execute(sql`DELETE FROM activity_mastery WHERE family_id = ${tenantId}`);
+		},
+	};
+}

--- a/src/lib/server/db/dsql/activity-pref-repo.ts
+++ b/src/lib/server/db/dsql/activity-pref-repo.ts
@@ -6,9 +6,14 @@
 //   - child_activity_preferences は自然複合 PK (family_id, child_id, activity_id) で surrogate id
 //     列を持たない (§11.2 凍結)。entity の `id: string` は `${child_id}:${activity_id}` を
 //     決定的に合成する (呼び出し側は id を lookup key に使っていない — opaque token 契約)。
-//   - togglePin(pinned=true) は「MAX(pin_order)+1 読取 → upsert」を単一 txn で行う
-//     (sqlite は同期ドライバで暗黙直列、DSQL は txn + OCC retry が同等の serialization point)。
-//     work 内 await は tx.execute(...) 直呼びのみ (fitness#7)。
+//   - togglePin(pinned=true) は「MAX(pin_order)+1 読取 → 別 activity 行への upsert」を単一 txn で
+//     行う。この read-then-write は同一 child の別 activity を並行 pin すると write-skew を起こす
+//     (両 txn が同じ MAX をスナップショット読取 → 同じ nextOrder を別行に INSERT → 別行ゆえ OCC
+//     40001 は発火せず pin_order が tie。設計書 §4.1: read-write 依存は非検出 = write skew を
+//     OCC では防げない)。よって txn 冒頭で children 行を FOR UPDATE ロックし、同一 child の pin
+//     操作を直列化する (§8。#3546 daily-mission と同型の serialization anchor)。異なる child は
+//     別行ロックで非競合。sqlite は同期ドライバで暗黙直列のため parity 上も等価。
+//     work 内 await は tx.execute(...) 直呼びのみ (fitness#7、helper 閉包経由 await 禁止)。
 //   - upsert は複合 PK への ON CONFLICT DO UPDATE (record-activity-core.ts と同型)。
 //   - sqlite parity: findAllByChild の並びは pin_order ASC で NULL 先頭 (SQLite の NULL 順)。
 //     Postgres 既定 (NULLS LAST) と異なるため NULLS FIRST を明示する。
@@ -86,8 +91,20 @@ export function createDsqlActivityPrefRepo<TTx extends SqlExecutor>(
 
 		async togglePin(childId, activityId, pinned, tenantId) {
 			if (pinned) {
-				// MAX+1 採番と upsert を単一 txn で (並行 pin の採番衝突は OCC retry が解消、§8)。
+				// MAX+1 採番と別 activity 行への upsert を単一 txn で行う。同一 child の pin 操作は
+				// txn 冒頭の children 行 FOR UPDATE で直列化する: 別 activity 行への INSERT ゆえ OCC
+				// 40001 は発火せず (§4.1 read-write 依存は非検出)、そのままでは 2 つの並行 pin が同じ
+				// MAX をスナップショット読取 → 同じ pin_order を別行に採番して tie となる write-skew を
+				// 起こす。children 行 (child ごと 1 行) を write-intent 化して pin 採番を直列化する
+				// (#3546 と同型、§8)。異なる child は別行ロックゆえ非競合。
 				return runner.runInTransaction(async (tx) => {
+					// serialization anchor: 同一 child の並行 pin を直列化 (pin 対象 activity の child は
+					// 存在前提)。集約関数と併用しない単純行ロックゆえ FOR UPDATE 制約に抵触しない。
+					await tx.execute(sql`
+						SELECT 1 FROM children
+						WHERE family_id = ${tenantId} AND child_id = ${childId}
+						FOR UPDATE
+					`);
 					const maxRead = await tx.execute(sql`
 						SELECT COALESCE(MAX(pin_order), 0)::int AS max_order FROM child_activity_preferences
 						WHERE family_id = ${tenantId} AND child_id = ${childId} AND is_pinned = true

--- a/src/lib/server/db/dsql/activity-pref-repo.ts
+++ b/src/lib/server/db/dsql/activity-pref-repo.ts
@@ -1,0 +1,149 @@
+// src/lib/server/db/dsql/activity-pref-repo.ts
+// EPIC #3424 / PR-R3 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §11.2 / §P9
+//
+// IActivityPrefRepo の DSQL backend 実装。設計契約:
+//   - **factory 注入** (fitness#8) + **§P9 tenant 述語** (全メソッド family_id = tenantId)。
+//   - child_activity_preferences は自然複合 PK (family_id, child_id, activity_id) で surrogate id
+//     列を持たない (§11.2 凍結)。entity の `id: string` は `${child_id}:${activity_id}` を
+//     決定的に合成する (呼び出し側は id を lookup key に使っていない — opaque token 契約)。
+//   - togglePin(pinned=true) は「MAX(pin_order)+1 読取 → upsert」を単一 txn で行う
+//     (sqlite は同期ドライバで暗黙直列、DSQL は txn + OCC retry が同等の serialization point)。
+//     work 内 await は tx.execute(...) 直呼びのみ (fitness#7)。
+//   - upsert は複合 PK への ON CONFLICT DO UPDATE (record-activity-core.ts と同型)。
+//   - sqlite parity: findAllByChild の並びは pin_order ASC で NULL 先頭 (SQLite の NULL 順)。
+//     Postgres 既定 (NULLS LAST) と異なるため NULLS FIRST を明示する。
+
+import { sql } from 'drizzle-orm';
+import { asActivityId, asChildId } from '$lib/domain/ids';
+import type { IActivityPrefRepo } from '../interfaces/activity-pref-repo.interface';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type { ChildActivityPreference } from '../types';
+import type { SqlExecutor } from './sql-executor';
+
+interface PrefRow {
+	family_id: string;
+	child_id: string;
+	activity_id: string;
+	is_pinned: boolean;
+	pin_order: number | null;
+	created_at: string;
+	updated_at: string;
+}
+
+const PREF_COLUMNS = sql.raw(
+	'family_id, child_id, activity_id, is_pinned, pin_order, created_at, updated_at',
+);
+
+/** row → entity (surrogate id 無しのため複合 PK から決定的合成、boolean → 0/1 契約)。 */
+function toPref(row: PrefRow): ChildActivityPreference {
+	return {
+		id: `${row.child_id}:${row.activity_id}`,
+		childId: asChildId(row.child_id),
+		activityId: asActivityId(row.activity_id),
+		isPinned: row.is_pinned ? 1 : 0,
+		pinOrder: row.pin_order,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+/** DSQL 用 IActivityPrefRepo を生成する (db/runner は注入、fitness#8)。 */
+export function createDsqlActivityPrefRepo<TTx extends SqlExecutor>(
+	db: SqlExecutor,
+	runner: TransactionRunner<TTx>,
+): IActivityPrefRepo {
+	return {
+		async findAllByChild(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${PREF_COLUMNS} FROM child_activity_preferences
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+				ORDER BY pin_order NULLS FIRST, created_at, activity_id
+			`);
+			return (result.rows as unknown as PrefRow[]).map(toPref);
+		},
+
+		async insertForRestore(input, tenantId) {
+			// #3329: isPinned/pinOrder/日時を verbatim 書き戻す (togglePin の再採番を経由しない)。
+			// 複合 PK 重複は 23505 throw のまま呼び出し側契約 (restore 先は新規 child 前提)。
+			const result = await db.execute(sql`
+				INSERT INTO child_activity_preferences
+					(family_id, child_id, activity_id, is_pinned, pin_order, created_at, updated_at)
+				VALUES (${tenantId}, ${input.childId}, ${input.activityId}, ${input.isPinned !== 0},
+					${input.pinOrder}, ${input.createdAt}, ${input.updatedAt})
+				RETURNING ${PREF_COLUMNS}
+			`);
+			return toPref(result.rows[0] as unknown as PrefRow);
+		},
+
+		async findPinnedByChild(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${PREF_COLUMNS} FROM child_activity_preferences
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND is_pinned = true
+				ORDER BY pin_order, activity_id
+			`);
+			return (result.rows as unknown as PrefRow[]).map(toPref);
+		},
+
+		async togglePin(childId, activityId, pinned, tenantId) {
+			if (pinned) {
+				// MAX+1 採番と upsert を単一 txn で (並行 pin の採番衝突は OCC retry が解消、§8)。
+				return runner.runInTransaction(async (tx) => {
+					const maxRead = await tx.execute(sql`
+						SELECT COALESCE(MAX(pin_order), 0)::int AS max_order FROM child_activity_preferences
+						WHERE family_id = ${tenantId} AND child_id = ${childId} AND is_pinned = true
+					`);
+					const nextOrder = Number((maxRead.rows[0] as { max_order: number }).max_order) + 1;
+					const result = await tx.execute(sql`
+						INSERT INTO child_activity_preferences
+							(family_id, child_id, activity_id, is_pinned, pin_order)
+						VALUES (${tenantId}, ${childId}, ${activityId}, true, ${nextOrder})
+						ON CONFLICT (family_id, child_id, activity_id)
+						DO UPDATE SET is_pinned = true, pin_order = ${nextOrder}, updated_at = now()
+						RETURNING ${PREF_COLUMNS}
+					`);
+					return toPref(result.rows[0] as unknown as PrefRow);
+				});
+			}
+			// ピン解除 (未存在なら isPinned=0 で作成 = sqlite parity)。単文 upsert で txn 不要。
+			const result = await db.execute(sql`
+				INSERT INTO child_activity_preferences
+					(family_id, child_id, activity_id, is_pinned, pin_order)
+				VALUES (${tenantId}, ${childId}, ${activityId}, false, NULL)
+				ON CONFLICT (family_id, child_id, activity_id)
+				DO UPDATE SET is_pinned = false, pin_order = NULL, updated_at = now()
+				RETURNING ${PREF_COLUMNS}
+			`);
+			return toPref(result.rows[0] as unknown as PrefRow);
+		},
+
+		async countPinnedInCategory(childId, categoryId, tenantId) {
+			// JOIN は child_activities の PK (family, child, activity) 完全一致 (§P9 越境不能)。
+			const result = await db.execute(sql`
+				SELECT count(*)::int AS c
+				FROM child_activity_preferences p
+				JOIN child_activities a
+					ON a.family_id = p.family_id AND a.child_id = p.child_id AND a.activity_id = p.activity_id
+				WHERE p.family_id = ${tenantId} AND p.child_id = ${childId}
+					AND p.is_pinned = true AND a.category_id = ${categoryId}
+			`);
+			return Number((result.rows[0] as { c: number }).c);
+		},
+
+		async getUsageCounts(childId, sinceDate, tenantId) {
+			const result = await db.execute(sql`
+				SELECT activity_id, count(*)::int AS usage_count FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND recorded_date >= ${sinceDate} AND cancelled = false
+				GROUP BY activity_id
+			`);
+			return (result.rows as { activity_id: string; usage_count: number }[]).map((r) => ({
+				activityId: asActivityId(r.activity_id),
+				usageCount: Number(r.usage_count),
+			}));
+		},
+
+		async deleteByTenantId(tenantId) {
+			await db.execute(sql`DELETE FROM child_activity_preferences WHERE family_id = ${tenantId}`);
+		},
+	};
+}

--- a/src/lib/server/db/dsql/child-activity-repo.ts
+++ b/src/lib/server/db/dsql/child-activity-repo.ts
@@ -1,0 +1,269 @@
+// src/lib/server/db/dsql/child-activity-repo.ts
+// EPIC #3424 / PR-R3 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §11.2 / §3 / §P9
+//
+// IChildActivityRepo の DSQL backend 実装。設計契約:
+//   - **factory 注入** (fitness#8: module-level db/client import 禁止)。db (SqlExecutor) と
+//     TransactionRunner を呼び出し側 (将来の client factory / テスト) が渡す。
+//   - **§P9 tenant 述語**: 全メソッドが family_id = tenantId を WHERE に含む。findActivityById /
+//     update / delete は (family_id, child_id, activity_id) の 3 軸 = PK 完全一致で cross-child
+//     access を構造的に防ぐ (ADR-0055 §3.1)。
+//   - entity 境界: isVisible / isMainQuest / isArchived は number (0/1) 契約 — boolean 列を
+//     読み出し時に変換 (既存 sqlite backend と同一 shape、child-repo.ts toChild と同型)。
+//   - record 系 hot path (recordActivityCore) は record-activity-core.ts が正 — 本 repo は
+//     CRUD / 検索系のみ (重複実装しない)。
+//   - insertActivitiesBulk は単一 txn (取込の per-child 配信を all-or-nothing に)。work 内
+//     await は tx.execute(...) 直呼びのみ (fitness#7、SQL 構築 helper は await しない)。
+//   - sqlite parity: findActivitiesByChild は sort_order 順 (同値は created_at, activity_id で
+//     安定化)。copyActivitiesAcrossChildren の copy 対象は sqlite 実装と同じ subset
+//     (name/category/icon/basePoints/triggerHint/isMainQuest/sourcePresetId/priority のみ。
+//     isVisible/sortOrder/dailyLimit 等は default に落とす)。
+
+import { sql } from 'drizzle-orm';
+import { asActivityId, asCategoryId, asChildId } from '$lib/domain/ids';
+import type { IChildActivityRepo } from '../interfaces/child-activity-repo.interface';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type {
+	ActivityPriority,
+	ChildActivity,
+	InsertChildActivityInput,
+	UpdateChildActivityInput,
+} from '../types';
+import { createDsqlChildRepo } from './child-repo';
+import type { SqlExecutor } from './sql-executor';
+
+interface ChildActivityRow {
+	family_id: string;
+	child_id: string;
+	activity_id: string;
+	name: string;
+	category_id: string;
+	icon: string;
+	base_points: number;
+	is_visible: boolean;
+	daily_limit: number | null;
+	sort_order: number;
+	source: string;
+	name_kana: string | null;
+	name_kanji: string | null;
+	trigger_hint: string | null;
+	is_main_quest: boolean;
+	is_archived: boolean;
+	archived_reason: string | null;
+	source_preset_id: string | null;
+	priority: string;
+	created_at: string;
+}
+
+const ACTIVITY_COLUMNS = sql.raw(
+	`family_id, child_id, activity_id, name, category_id, icon, base_points, is_visible,
+	 daily_limit, sort_order, source, name_kana, name_kanji, trigger_hint, is_main_quest,
+	 is_archived, archived_reason, source_preset_id, priority, created_at`,
+);
+
+/** row → ChildActivity entity (boolean → 0/1 数値契約 = sqlite 互換 shape)。 */
+function toChildActivity(row: ChildActivityRow): ChildActivity {
+	return {
+		id: asActivityId(row.activity_id),
+		childId: asChildId(row.child_id),
+		name: row.name,
+		categoryId: asCategoryId(row.category_id),
+		icon: row.icon,
+		basePoints: row.base_points,
+		isVisible: row.is_visible ? 1 : 0,
+		dailyLimit: row.daily_limit,
+		sortOrder: row.sort_order,
+		source: row.source,
+		nameKana: row.name_kana,
+		nameKanji: row.name_kanji,
+		triggerHint: row.trigger_hint,
+		isMainQuest: row.is_main_quest ? 1 : 0,
+		isArchived: row.is_archived ? 1 : 0,
+		archivedReason: row.archived_reason,
+		createdAt: row.created_at,
+		sourcePresetId: row.source_preset_id,
+		priority: row.priority as ActivityPriority,
+	};
+}
+
+/**
+ * INSERT 文を構築する (insertActivity / insertActivitiesBulk で共有)。
+ * `source` 列は schema default ('seed') に委ねる (sqlite parity: insert 側は指定しない)。
+ */
+function buildInsertSql(input: InsertChildActivityInput, tenantId: string) {
+	return sql`
+		INSERT INTO child_activities
+			(family_id, child_id, name, category_id, icon, base_points, trigger_hint, is_main_quest,
+			 source_preset_id, priority, is_visible, sort_order, is_archived, archived_reason,
+			 daily_limit, name_kana, name_kanji)
+		VALUES (${tenantId}, ${input.childId}, ${input.name}, ${input.categoryId}, ${input.icon},
+			${input.basePoints}, ${input.triggerHint ?? null}, ${(input.isMainQuest ?? 0) !== 0},
+			${input.sourcePresetId ?? null}, ${input.priority ?? 'optional'},
+			${(input.isVisible ?? 1) !== 0}, ${input.sortOrder ?? 0}, ${(input.isArchived ?? 0) !== 0},
+			${input.archivedReason ?? null}, ${input.dailyLimit ?? null}, ${input.nameKana ?? null},
+			${input.nameKanji ?? null})
+		RETURNING ${ACTIVITY_COLUMNS}
+	`;
+}
+
+/** UpdateChildActivityInput → SET 句 (undefined field は不変 = 部分更新契約)。 */
+function buildUpdateSets(input: UpdateChildActivityInput) {
+	const sets: ReturnType<typeof sql>[] = [];
+	if (input.name !== undefined) sets.push(sql`name = ${input.name}`);
+	if (input.categoryId !== undefined) sets.push(sql`category_id = ${input.categoryId}`);
+	if (input.icon !== undefined) sets.push(sql`icon = ${input.icon}`);
+	if (input.basePoints !== undefined) sets.push(sql`base_points = ${input.basePoints}`);
+	if (input.triggerHint !== undefined) sets.push(sql`trigger_hint = ${input.triggerHint}`);
+	if (input.isMainQuest !== undefined) sets.push(sql`is_main_quest = ${input.isMainQuest !== 0}`);
+	if (input.priority !== undefined) sets.push(sql`priority = ${input.priority}`);
+	if (input.dailyLimit !== undefined) sets.push(sql`daily_limit = ${input.dailyLimit}`);
+	if (input.nameKana !== undefined) sets.push(sql`name_kana = ${input.nameKana}`);
+	if (input.nameKanji !== undefined) sets.push(sql`name_kanji = ${input.nameKanji}`);
+	return sets;
+}
+
+/** DSQL 用 IChildActivityRepo を生成する (db/runner は注入、fitness#8)。 */
+export function createDsqlChildActivityRepo<TTx extends SqlExecutor>(
+	db: SqlExecutor,
+	runner: TransactionRunner<TTx>,
+): IChildActivityRepo {
+	// findChildById convenience は child-repo の compute-on-read 契約 (§11.1) へ委譲する
+	// (age / ui_mode 導出ロジックの二重実装を避ける)。
+	const childRepo = createDsqlChildRepo(db, runner);
+
+	const insertActivitiesBulk = async (
+		inputs: InsertChildActivityInput[],
+		tenantId: string,
+	): Promise<ChildActivity[]> => {
+		if (inputs.length === 0) return [];
+		// 取込の per-child 配信を all-or-nothing に (§8)。work 内 await は tx.execute 直呼びのみ
+		// (fitness#7。buildInsertSql は同期の SQL 構築で await しない)。
+		return runner.runInTransaction(async (tx) => {
+			const created: ChildActivity[] = [];
+			for (const input of inputs) {
+				const result = await tx.execute(buildInsertSql(input, tenantId));
+				created.push(toChildActivity(result.rows[0] as unknown as ChildActivityRow));
+			}
+			return created;
+		});
+	};
+
+	const findActivitiesByChild: IChildActivityRepo['findActivitiesByChild'] = async (
+		childId,
+		tenantId,
+		options,
+	) => {
+		const conditions = [sql`family_id = ${tenantId}`, sql`child_id = ${childId}`];
+		if (!options?.includeArchived) conditions.push(sql`is_archived = false`);
+		if (options?.visibleOnly) conditions.push(sql`is_visible = true`);
+		const result = await db.execute(sql`
+			SELECT ${ACTIVITY_COLUMNS} FROM child_activities
+			WHERE ${sql.join(conditions, sql` AND `)}
+			ORDER BY sort_order, created_at, activity_id
+		`);
+		return (result.rows as unknown as ChildActivityRow[]).map(toChildActivity);
+	};
+
+	return {
+		findActivitiesByChild,
+
+		async findActivityById(id, childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${ACTIVITY_COLUMNS} FROM child_activities
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND activity_id = ${id}
+			`);
+			const row = result.rows[0] as unknown as ChildActivityRow | undefined;
+			return row ? toChildActivity(row) : undefined;
+		},
+
+		async countMainQuestActivities(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT count(*)::int AS c FROM child_activities
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND is_main_quest = true AND is_visible = true AND is_archived = false
+			`);
+			return Number((result.rows[0] as { c: number }).c);
+		},
+
+		async insertActivity(input, tenantId) {
+			const result = await db.execute(buildInsertSql(input, tenantId));
+			return toChildActivity(result.rows[0] as unknown as ChildActivityRow);
+		},
+
+		insertActivitiesBulk,
+
+		async updateActivity(id, childId, input, tenantId) {
+			const sets = buildUpdateSets(input);
+			if (sets.length === 0) return this.findActivityById(id, childId, tenantId);
+			const result = await db.execute(sql`
+				UPDATE child_activities SET ${sql.join(sets, sql`, `)}
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND activity_id = ${id}
+				RETURNING ${ACTIVITY_COLUMNS}
+			`);
+			const row = result.rows[0] as unknown as ChildActivityRow | undefined;
+			return row ? toChildActivity(row) : undefined;
+		},
+
+		async setActivityVisibility(id, childId, visible, tenantId) {
+			const result = await db.execute(sql`
+				UPDATE child_activities SET is_visible = ${visible}
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND activity_id = ${id}
+				RETURNING ${ACTIVITY_COLUMNS}
+			`);
+			const row = result.rows[0] as unknown as ChildActivityRow | undefined;
+			return row ? toChildActivity(row) : undefined;
+		},
+
+		async deleteActivity(id, childId, tenantId) {
+			const result = await db.execute(sql`
+				DELETE FROM child_activities
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND activity_id = ${id}
+				RETURNING ${ACTIVITY_COLUMNS}
+			`);
+			const row = result.rows[0] as unknown as ChildActivityRow | undefined;
+			return row ? toChildActivity(row) : undefined;
+		},
+
+		async copyActivitiesAcrossChildren(sourceChildId, targetChildId, tenantId) {
+			// source の active 全件 (visible 不問) を読み、sqlite parity の subset で target に複製。
+			const sourceActivities = await findActivitiesByChild(sourceChildId, tenantId, {
+				includeArchived: false,
+				visibleOnly: false,
+			});
+			if (sourceActivities.length === 0) return [];
+			const inputs: InsertChildActivityInput[] = sourceActivities.map((a) => ({
+				childId: targetChildId,
+				name: a.name,
+				categoryId: a.categoryId,
+				icon: a.icon,
+				basePoints: a.basePoints,
+				triggerHint: a.triggerHint,
+				isMainQuest: a.isMainQuest,
+				sourcePresetId: a.sourcePresetId,
+				priority: a.priority,
+			}));
+			return insertActivitiesBulk(inputs, tenantId);
+		},
+
+		async archiveActivities(ids, reason, tenantId) {
+			if (ids.length === 0) return;
+			await db.execute(sql`
+				UPDATE child_activities SET is_archived = true, archived_reason = ${reason}
+				WHERE family_id = ${tenantId} AND activity_id IN (${sql.join(
+					ids.map((id) => sql`${id}`),
+					sql`, `,
+				)})
+			`);
+		},
+
+		async restoreArchivedActivities(reason, tenantId) {
+			await db.execute(sql`
+				UPDATE child_activities SET is_archived = false, archived_reason = NULL
+				WHERE family_id = ${tenantId} AND is_archived = true AND archived_reason = ${reason}
+			`);
+		},
+
+		async findChildById(id, tenantId) {
+			return childRepo.findChildById(id, tenantId);
+		},
+	};
+}

--- a/tests/unit/db/dsql-activity-repos.test.ts
+++ b/tests/unit/db/dsql-activity-repos.test.ts
@@ -1,0 +1,578 @@
+// tests/unit/db/dsql-activity-repos.test.ts
+// EPIC #3424 / PR-R3 / 設計 SSOT: dsql-data-model.md §11.2 / §3 / §P9
+//
+// activity 系 3 repo (IChildActivityRepo / IActivityPrefRepo / IActivityMasteryRepo) の
+// DSQL backend テスト。実 schema (pushSchema 適用、dsql-test-db helper) に対して:
+//
+// child-activity:
+//   [A1] insert → findById round-trip (uuid 採番、0/1 数値契約、schema default)
+//   [A2] findActivitiesByChild: sort_order 順 + archived 既定除外 + includeArchived/visibleOnly
+//   [A3] §P9 tenant 分離: 他 family から不可視・更新/削除不能
+//   [A4] countMainQuestActivities = main quest ∧ visible ∧ 非 archived のみ
+//   [A5] update 部分更新 / setActivityVisibility / deleteActivity (返り値契約 undefined 含む)
+//   [A6] insertActivitiesBulk + copyActivitiesAcrossChildren (archived 除外、sqlite parity の
+//        copy 対象 subset、target childId 差替)
+//   [A7] archive/restore (reason 束縛) + CHECK 実効 (priority / archived_reason 不正値 reject)
+//   [A8] findChildById convenience (child-repo compute-on-read へ委譲)
+// activity-pref:
+//   [P1] togglePin: pin → MAX+1 採番 / unpin → pinOrder null / 未存在 unpin → isPinned=0 行作成
+//   [P2] findPinnedByChild (pin_order 順) / findAllByChild (unpinned 含む、NULLS FIRST parity)
+//   [P3] countPinnedInCategory (child_activities JOIN)
+//   [P4] getUsageCounts: since 窓 + cancelled 除外 + GROUP BY
+//   [P5] insertForRestore: pinOrder/日時 verbatim 保全 + 複合 PK UNIQUE 実効 (重複 throw)
+//   [P6] §P9 tenant 分離 + deleteByTenantId が tenant scope
+// activity-mastery:
+//   [M1] upsert insert → find round-trip / 再 upsert は同一行更新 (複合 PK UNIQUE 実効)
+//   [M2] findAllByChild / §P9 tenant 分離 / deleteByTenantId が tenant scope
+
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	type ActivityId,
+	asCategoryId,
+	asChildId,
+	type ChildId,
+} from '../../../src/lib/domain/ids';
+import { createDsqlActivityMasteryRepo } from '../../../src/lib/server/db/dsql/activity-mastery-repo';
+import { createDsqlActivityPrefRepo } from '../../../src/lib/server/db/dsql/activity-pref-repo';
+import { createDsqlChildActivityRepo } from '../../../src/lib/server/db/dsql/child-activity-repo';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import type { IActivityMasteryRepo } from '../../../src/lib/server/db/interfaces/activity-mastery-repo.interface';
+import type { IActivityPrefRepo } from '../../../src/lib/server/db/interfaces/activity-pref-repo.interface';
+import type { IChildActivityRepo } from '../../../src/lib/server/db/interfaces/child-activity-repo.interface';
+import type { InsertChildActivityInput } from '../../../src/lib/server/db/types';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+const FAMILY = '00000000-0000-4000-8000-0000000000b1';
+const OTHER_FAMILY = '00000000-0000-4000-8000-0000000000b2';
+const CAT_EXERCISE = asCategoryId('1');
+const CAT_STUDY = asCategoryId('2');
+
+let t: DsqlTestDb;
+let activityRepo: IChildActivityRepo;
+let prefRepo: IActivityPrefRepo;
+let masteryRepo: IActivityMasteryRepo;
+
+/** 直接 INSERT で child を作る (child-repo は PR-R1 検証済のため seed は raw で十分)。 */
+async function seedChild(familyId: string, nickname: string): Promise<ChildId> {
+	const res = await t.db.execute(sql`
+		INSERT INTO children (family_id, nickname, birth_date, theme, ui_mode)
+		VALUES (${familyId}, ${nickname}, '2018-01-15', 'blue', 'preschool')
+		RETURNING child_id
+	`);
+	return asChildId((res.rows[0] as { child_id: string }).child_id);
+}
+
+function activityInput(
+	childId: ChildId,
+	overrides: Partial<InsertChildActivityInput> = {},
+): InsertChildActivityInput {
+	return {
+		childId,
+		name: 'はみがき',
+		categoryId: CAT_EXERCISE,
+		icon: '🦷',
+		basePoints: 5,
+		...overrides,
+	};
+}
+
+beforeAll(async () => {
+	t = await createDsqlTestDb();
+	const runner = createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 });
+	activityRepo = createDsqlChildActivityRepo(t.db, runner);
+	prefRepo = createDsqlActivityPrefRepo(t.db, runner);
+	masteryRepo = createDsqlActivityMasteryRepo(t.db, runner);
+}, 60_000);
+afterAll(async () => {
+	await t.close();
+});
+
+describe('DSQL child-activity-repo (PR-R3、実 schema PGlite)', () => {
+	it('[A1] insert → findById round-trip (uuid 採番、0/1 数値契約、default 反映)', async () => {
+		const child = await seedChild(FAMILY, 'A1');
+		const created = await activityRepo.insertActivity(activityInput(child), FAMILY);
+		expect(created.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(created.childId).toBe(child);
+		expect(created.name).toBe('はみがき');
+		expect(created.categoryId).toBe(CAT_EXERCISE);
+		expect(created.basePoints).toBe(5);
+		// 0/1 数値契約 (sqlite 互換 shape) + schema default
+		expect(created.isVisible).toBe(1);
+		expect(created.isMainQuest).toBe(0);
+		expect(created.isArchived).toBe(0);
+		expect(created.sortOrder).toBe(0);
+		expect(created.priority).toBe('optional');
+		expect(created.dailyLimit).toBe(null);
+		expect(created.archivedReason).toBe(null);
+		expect(typeof created.createdAt).toBe('string');
+
+		const found = await activityRepo.findActivityById(created.id, child, FAMILY);
+		expect(found).toEqual(created);
+	});
+
+	it('[A1b] insert は #3358/#3422 の保全 field (visible/sort/archived/dailyLimit/kana) を persist する', async () => {
+		const child = await seedChild(FAMILY, 'A1b');
+		const created = await activityRepo.insertActivity(
+			activityInput(child, {
+				isVisible: 0,
+				sortOrder: 7,
+				isArchived: 1,
+				archivedReason: 'trial_expired',
+				dailyLimit: 3,
+				nameKana: 'はみがき',
+				nameKanji: '歯磨き',
+				triggerHint: '朝ごはんのあと',
+				isMainQuest: 1,
+				priority: 'must',
+				sourcePresetId: 'preset-1',
+			}),
+			FAMILY,
+		);
+		expect(created.isVisible).toBe(0);
+		expect(created.sortOrder).toBe(7);
+		expect(created.isArchived).toBe(1);
+		expect(created.archivedReason).toBe('trial_expired');
+		expect(created.dailyLimit).toBe(3);
+		expect(created.nameKana).toBe('はみがき');
+		expect(created.nameKanji).toBe('歯磨き');
+		expect(created.triggerHint).toBe('朝ごはんのあと');
+		expect(created.isMainQuest).toBe(1);
+		expect(created.priority).toBe('must');
+		expect(created.sourcePresetId).toBe('preset-1');
+	});
+
+	it('[A2] findActivitiesByChild: sort_order 順 + archived 既定除外 + option filter', async () => {
+		const child = await seedChild(FAMILY, 'A2');
+		const b = await activityRepo.insertActivity(
+			activityInput(child, { name: '2番目', sortOrder: 2 }),
+			FAMILY,
+		);
+		const a = await activityRepo.insertActivity(
+			activityInput(child, { name: '1番目', sortOrder: 1 }),
+			FAMILY,
+		);
+		const hidden = await activityRepo.insertActivity(
+			activityInput(child, { name: '非表示', sortOrder: 3, isVisible: 0 }),
+			FAMILY,
+		);
+		const archived = await activityRepo.insertActivity(
+			activityInput(child, {
+				name: 'アーカイブ済',
+				sortOrder: 0,
+				isArchived: 1,
+				archivedReason: 'trial_expired',
+			}),
+			FAMILY,
+		);
+
+		const defaults = await activityRepo.findActivitiesByChild(child, FAMILY);
+		expect(defaults.map((x) => x.id)).toEqual([a.id, b.id, hidden.id]); // sort_order 順、archived 除外
+
+		const all = await activityRepo.findActivitiesByChild(child, FAMILY, {
+			includeArchived: true,
+		});
+		expect(all.map((x) => x.id)).toEqual([archived.id, a.id, b.id, hidden.id]);
+
+		const visible = await activityRepo.findActivitiesByChild(child, FAMILY, {
+			visibleOnly: true,
+		});
+		expect(visible.map((x) => x.id)).toEqual([a.id, b.id]);
+	});
+
+	it('[A3] §P9 tenant 分離: 他 family から不可視・更新/削除不能', async () => {
+		const child = await seedChild(FAMILY, 'A3');
+		const mine = await activityRepo.insertActivity(activityInput(child), FAMILY);
+
+		expect(await activityRepo.findActivityById(mine.id, child, OTHER_FAMILY)).toBeUndefined();
+		expect(await activityRepo.findActivitiesByChild(child, OTHER_FAMILY)).toEqual([]);
+		expect(
+			await activityRepo.updateActivity(mine.id, child, { name: '乗っ取り' }, OTHER_FAMILY),
+		).toBeUndefined();
+		expect(await activityRepo.deleteActivity(mine.id, child, OTHER_FAMILY)).toBeUndefined();
+
+		const intact = await activityRepo.findActivityById(mine.id, child, FAMILY);
+		expect(intact?.name).toBe('はみがき');
+	});
+
+	it('[A3b] cross-child 分離: 別 child の id 指定では取得/更新できない (3 軸契約)', async () => {
+		const child1 = await seedChild(FAMILY, 'A3b-1');
+		const child2 = await seedChild(FAMILY, 'A3b-2');
+		const act = await activityRepo.insertActivity(activityInput(child1), FAMILY);
+		expect(await activityRepo.findActivityById(act.id, child2, FAMILY)).toBeUndefined();
+		expect(
+			await activityRepo.updateActivity(act.id, child2, { name: 'x' }, FAMILY),
+		).toBeUndefined();
+	});
+
+	it('[A4] countMainQuestActivities: main quest ∧ visible ∧ 非 archived のみ', async () => {
+		const child = await seedChild(FAMILY, 'A4');
+		await activityRepo.insertActivity(activityInput(child, { isMainQuest: 1 }), FAMILY);
+		await activityRepo.insertActivity(activityInput(child, { isMainQuest: 1 }), FAMILY);
+		await activityRepo.insertActivity(
+			activityInput(child, { isMainQuest: 1, isVisible: 0 }),
+			FAMILY,
+		);
+		await activityRepo.insertActivity(
+			activityInput(child, { isMainQuest: 1, isArchived: 1, archivedReason: 'trial_expired' }),
+			FAMILY,
+		);
+		await activityRepo.insertActivity(activityInput(child), FAMILY); // not main quest
+		expect(await activityRepo.countMainQuestActivities(child, FAMILY)).toBe(2);
+		expect(await activityRepo.countMainQuestActivities(child, OTHER_FAMILY)).toBe(0);
+	});
+
+	it('[A5] update 部分更新 / setActivityVisibility / deleteActivity の返り値契約', async () => {
+		const child = await seedChild(FAMILY, 'A5');
+		const act = await activityRepo.insertActivity(activityInput(child), FAMILY);
+
+		const updated = await activityRepo.updateActivity(
+			act.id,
+			child,
+			{ name: '歯みがき改', categoryId: CAT_STUDY, dailyLimit: 2, nameKana: 'はみがきかい' },
+			FAMILY,
+		);
+		expect(updated?.name).toBe('歯みがき改');
+		expect(updated?.categoryId).toBe(CAT_STUDY);
+		expect(updated?.dailyLimit).toBe(2);
+		expect(updated?.nameKana).toBe('はみがきかい');
+		expect(updated?.icon).toBe('🦷'); // 未指定 field 不変
+		expect(updated?.basePoints).toBe(5);
+
+		// 空 update は現状値を返す (sqlite parity: SET 句なしでも row を返す)
+		const noop = await activityRepo.updateActivity(act.id, child, {}, FAMILY);
+		expect(noop?.name).toBe('歯みがき改');
+
+		const hidden = await activityRepo.setActivityVisibility(act.id, child, false, FAMILY);
+		expect(hidden?.isVisible).toBe(0);
+		const shown = await activityRepo.setActivityVisibility(act.id, child, true, FAMILY);
+		expect(shown?.isVisible).toBe(1);
+
+		const deleted = await activityRepo.deleteActivity(act.id, child, FAMILY);
+		expect(deleted?.id).toBe(act.id);
+		expect(await activityRepo.findActivityById(act.id, child, FAMILY)).toBeUndefined();
+		expect(await activityRepo.deleteActivity(act.id, child, FAMILY)).toBeUndefined();
+	});
+
+	it('[A6] insertActivitiesBulk: 空 [] / 入力順維持 / 全行 persist', async () => {
+		const source = await seedChild(FAMILY, 'A6-src');
+
+		expect(await activityRepo.insertActivitiesBulk([], FAMILY)).toEqual([]);
+
+		const bulk = await activityRepo.insertActivitiesBulk(
+			[
+				activityInput(source, { name: 'bulk-1', sortOrder: 1 }),
+				activityInput(source, { name: 'bulk-2', sortOrder: 2, priority: 'must' }),
+			],
+			FAMILY,
+		);
+		expect(bulk).toHaveLength(2);
+		expect(bulk.map((x) => x.name)).toEqual(['bulk-1', 'bulk-2']); // 入力順維持
+		expect(bulk[1]?.priority).toBe('must');
+		expect(await activityRepo.findActivitiesByChild(source, FAMILY)).toHaveLength(2);
+	});
+
+	it('[A6b] copyActivitiesAcrossChildren: 空 source は []、copy は sqlite parity subset', async () => {
+		const source = await seedChild(FAMILY, 'A6b-src');
+		const target = await seedChild(FAMILY, 'A6b-dst');
+
+		expect(await activityRepo.copyActivitiesAcrossChildren(source, target, FAMILY)).toEqual([]);
+
+		await activityRepo.insertActivity(
+			activityInput(source, {
+				name: 'コピー元',
+				sortOrder: 5,
+				dailyLimit: 4,
+				triggerHint: 'ヒント',
+				isMainQuest: 1,
+				priority: 'must',
+				sourcePresetId: 'p-9',
+				isVisible: 0,
+			}),
+			FAMILY,
+		);
+		await activityRepo.insertActivity(
+			activityInput(source, {
+				name: 'アーカイブは対象外',
+				isArchived: 1,
+				archivedReason: 'trial_expired',
+			}),
+			FAMILY,
+		);
+
+		const copied = await activityRepo.copyActivitiesAcrossChildren(source, target, FAMILY);
+		expect(copied).toHaveLength(1);
+		const c = copied[0];
+		expect(c?.childId).toBe(target);
+		expect(c?.name).toBe('コピー元');
+		expect(c?.triggerHint).toBe('ヒント');
+		expect(c?.isMainQuest).toBe(1);
+		expect(c?.priority).toBe('must');
+		expect(c?.sourcePresetId).toBe('p-9');
+		// sqlite parity: isVisible/sortOrder/dailyLimit は copy 対象外 → schema default
+		expect(c?.isVisible).toBe(1);
+		expect(c?.sortOrder).toBe(0);
+		expect(c?.dailyLimit).toBe(null);
+		// source 側は不変
+		const srcAfter = await activityRepo.findActivitiesByChild(source, FAMILY);
+		expect(srcAfter).toHaveLength(1);
+	});
+
+	it('[A7] archive → 既定一覧から消え restore (reason 束縛) で復帰', async () => {
+		const child = await seedChild(FAMILY, 'A7');
+		const a1 = await activityRepo.insertActivity(activityInput(child, { name: 'a1' }), FAMILY);
+		const a2 = await activityRepo.insertActivity(activityInput(child, { name: 'a2' }), FAMILY);
+		await activityRepo.archiveActivities([], 'trial_expired', FAMILY); // 空は no-op
+		await activityRepo.archiveActivities([a1.id, a2.id], 'trial_expired', FAMILY);
+
+		expect(await activityRepo.findActivitiesByChild(child, FAMILY)).toEqual([]);
+		const archived = await activityRepo.findActivitiesByChild(child, FAMILY, {
+			includeArchived: true,
+		});
+		expect(archived.every((x) => x.isArchived === 1 && x.archivedReason === 'trial_expired')).toBe(
+			true,
+		);
+
+		// 別 reason の restore は効かない (reason 束縛)
+		await activityRepo.restoreArchivedActivities('downgrade_user_selected', FAMILY);
+		expect(await activityRepo.findActivitiesByChild(child, FAMILY)).toEqual([]);
+
+		await activityRepo.restoreArchivedActivities('trial_expired', FAMILY);
+		const restored = await activityRepo.findActivitiesByChild(child, FAMILY);
+		expect(restored.map((x) => x.id).sort()).toEqual([a1.id, a2.id].sort());
+		expect(restored.every((x) => x.archivedReason === null)).toBe(true);
+	});
+
+	it('[A7b] tenant 越境 archive 不能 + CHECK 実効 (priority / archived_reason 不正値)', async () => {
+		const child = await seedChild(FAMILY, 'A7b');
+		const act = await activityRepo.insertActivity(activityInput(child), FAMILY);
+		await activityRepo.archiveActivities([act.id], 'trial_expired', OTHER_FAMILY);
+		const intact = await activityRepo.findActivityById(act.id, child, FAMILY);
+		expect(intact?.isArchived).toBe(0);
+
+		// CHECK 制約の実効性 (schema SSOT の enumCheck が実 DB に効いている)。
+		// drizzle は DB error を「Failed query: …」に wrap するため message でなく
+		// 「reject + 行が残らない」で CHECK の実効を assert する。
+		await expect(
+			t.db.execute(sql`
+				INSERT INTO child_activities (family_id, child_id, name, category_id, icon, priority)
+				VALUES (${FAMILY}, ${String(child)}, 'bad', '1', 'x', 'urgent')
+			`),
+		).rejects.toThrow();
+		await expect(
+			t.db.execute(sql`
+				INSERT INTO child_activities (family_id, child_id, name, category_id, icon, archived_reason)
+				VALUES (${FAMILY}, ${String(child)}, 'bad', '1', 'x', 'bogus_reason')
+			`),
+		).rejects.toThrow();
+		const bad = await t.db.execute(sql`
+			SELECT count(*)::int AS c FROM child_activities WHERE family_id = ${FAMILY} AND name = 'bad'
+		`);
+		expect((bad.rows[0] as { c: number }).c).toBe(0);
+	});
+
+	it('[A8] findChildById convenience: child-repo と同じ compute-on-read 契約', async () => {
+		const child = await seedChild(FAMILY, 'A8');
+		const found = await activityRepo.findChildById(child, FAMILY);
+		expect(found?.nickname).toBe('A8');
+		expect(found?.age).toBe(8); // 2018-01-15 生まれ → compute-on-read
+		expect(found?.uiMode).toBe('elementary'); // stored 'preschool' でなく年齢再導出 (§11.1)
+		expect(await activityRepo.findChildById(child, OTHER_FAMILY)).toBeUndefined();
+	});
+});
+
+describe('DSQL activity-pref-repo (PR-R3、実 schema PGlite)', () => {
+	let child: ChildId;
+	let actA: ActivityId;
+	let actB: ActivityId;
+	let actC: ActivityId;
+
+	beforeAll(async () => {
+		child = await seedChild(FAMILY, 'pref');
+		actA = (await activityRepo.insertActivity(activityInput(child, { name: 'pA' }), FAMILY)).id;
+		actB = (
+			await activityRepo.insertActivity(
+				activityInput(child, { name: 'pB', categoryId: CAT_STUDY }),
+				FAMILY,
+			)
+		).id;
+		actC = (await activityRepo.insertActivity(activityInput(child, { name: 'pC' }), FAMILY)).id;
+	});
+
+	it('[P1] togglePin: pin は MAX+1 採番、unpin は pinOrder null、未存在 unpin は isPinned=0 行作成', async () => {
+		const p1 = await prefRepo.togglePin(child, actA, true, FAMILY);
+		expect(p1.isPinned).toBe(1);
+		expect(p1.pinOrder).toBe(1);
+		expect(p1.childId).toBe(child);
+		expect(p1.activityId).toBe(actA);
+
+		const p2 = await prefRepo.togglePin(child, actB, true, FAMILY);
+		expect(p2.pinOrder).toBe(2); // MAX+1
+
+		const un = await prefRepo.togglePin(child, actA, false, FAMILY);
+		expect(un.isPinned).toBe(0);
+		expect(un.pinOrder).toBe(null);
+
+		// 再 pin で MAX+1 再採番 (既存行の upsert、行は増えない)
+		const rePin = await prefRepo.togglePin(child, actA, true, FAMILY);
+		expect(rePin.pinOrder).toBe(3);
+		const rows = await t.db.execute(sql`
+			SELECT count(*)::int AS c FROM child_activity_preferences
+			WHERE family_id = ${FAMILY} AND child_id = ${String(child)} AND activity_id = ${String(actA)}
+		`);
+		expect((rows.rows[0] as { c: number }).c).toBe(1);
+
+		// 未存在 activity の unpin → isPinned=0 で作成 (sqlite parity)
+		const created = await prefRepo.togglePin(child, actC, false, FAMILY);
+		expect(created.isPinned).toBe(0);
+		expect(created.pinOrder).toBe(null);
+	});
+
+	it('[P2] findPinnedByChild は pin_order 順 / findAllByChild は unpinned 含む NULLS FIRST', async () => {
+		// 現状: actB(order2) / actA(order3) が pinned、actC は unpinned
+		const pinned = await prefRepo.findPinnedByChild(child, FAMILY);
+		expect(pinned.map((p) => p.activityId)).toEqual([actB, actA]);
+
+		const all = await prefRepo.findAllByChild(child, FAMILY);
+		expect(all).toHaveLength(3);
+		expect(all[0]?.activityId).toBe(actC); // pinOrder null が先頭 (sqlite NULL 順 parity)
+		expect(all.map((p) => p.activityId).slice(1)).toEqual([actB, actA]);
+	});
+
+	it('[P3] countPinnedInCategory: child_activities JOIN で category filter', async () => {
+		expect(await prefRepo.countPinnedInCategory(child, CAT_EXERCISE, FAMILY)).toBe(1); // actA
+		expect(await prefRepo.countPinnedInCategory(child, CAT_STUDY, FAMILY)).toBe(1); // actB
+		expect(await prefRepo.countPinnedInCategory(child, asCategoryId('99'), FAMILY)).toBe(0);
+	});
+
+	it('[P4] getUsageCounts: since 窓 + cancelled 除外 + GROUP BY 集計', async () => {
+		const seedLog = (activityId: ActivityId, date: string, cancelled = false) =>
+			t.db.execute(sql`
+				INSERT INTO activity_logs (family_id, child_id, activity_id, points, recorded_date, recorded_at, cancelled)
+				VALUES (${FAMILY}, ${String(child)}, ${String(activityId)}, 5, ${date}, now(), ${cancelled})
+			`);
+		await seedLog(actA, '2026-07-01');
+		await seedLog(actA, '2026-07-02');
+		await seedLog(actA, '2026-06-01'); // since 窓外
+		await seedLog(actB, '2026-07-03');
+		await seedLog(actB, '2026-07-03', true); // cancelled 除外
+
+		const counts = await prefRepo.getUsageCounts(child, '2026-06-15', FAMILY);
+		const byId = new Map(counts.map((c) => [c.activityId, c.usageCount]));
+		expect(byId.get(actA)).toBe(2);
+		expect(byId.get(actB)).toBe(1);
+		expect(counts).toHaveLength(2);
+	});
+
+	it('[P5] insertForRestore: pinOrder/日時 verbatim 保全 + 複合 PK UNIQUE 実効', async () => {
+		const c2 = await seedChild(FAMILY, 'pref-restore');
+		const act = (await activityRepo.insertActivity(activityInput(c2, { name: 'restore' }), FAMILY))
+			.id;
+		const restored = await prefRepo.insertForRestore(
+			{
+				childId: c2,
+				activityId: act,
+				isPinned: 1,
+				pinOrder: 42,
+				createdAt: '2026-01-02T03:04:05.000Z',
+				updatedAt: '2026-01-03T03:04:05.000Z',
+			},
+			FAMILY,
+		);
+		expect(restored.isPinned).toBe(1);
+		expect(restored.pinOrder).toBe(42);
+		expect(Date.parse(restored.createdAt)).toBe(Date.parse('2026-01-02T03:04:05.000Z'));
+		expect(Date.parse(restored.updatedAt)).toBe(Date.parse('2026-01-03T03:04:05.000Z'));
+
+		// 複合 PK (family, child, activity) UNIQUE の実効
+		await expect(
+			prefRepo.insertForRestore(
+				{
+					childId: c2,
+					activityId: act,
+					isPinned: 0,
+					pinOrder: null,
+					createdAt: '2026-01-02T03:04:05.000Z',
+					updatedAt: '2026-01-02T03:04:05.000Z',
+				},
+				FAMILY,
+			),
+		).rejects.toThrow();
+	});
+
+	it('[P6] §P9 tenant 分離 + deleteByTenantId は tenant scope のみ削除', async () => {
+		// OTHER_FAMILY 側に 1 行作る
+		const otherChild = await seedChild(OTHER_FAMILY, 'other-pref');
+		const otherAct = (
+			await activityRepo.insertActivity(activityInput(otherChild, { name: 'oA' }), OTHER_FAMILY)
+		).id;
+		await prefRepo.togglePin(otherChild, otherAct, true, OTHER_FAMILY);
+
+		expect(await prefRepo.findAllByChild(child, OTHER_FAMILY)).toEqual([]);
+		expect(await prefRepo.findPinnedByChild(child, OTHER_FAMILY)).toEqual([]);
+		expect(await prefRepo.getUsageCounts(child, '2026-06-15', OTHER_FAMILY)).toEqual([]);
+		expect(await prefRepo.countPinnedInCategory(child, CAT_EXERCISE, OTHER_FAMILY)).toBe(0);
+
+		await prefRepo.deleteByTenantId(OTHER_FAMILY);
+		expect(await prefRepo.findAllByChild(otherChild, OTHER_FAMILY)).toEqual([]);
+		// FAMILY 側は残存
+		expect((await prefRepo.findAllByChild(child, FAMILY)).length).toBeGreaterThan(0);
+	});
+});
+
+describe('DSQL activity-mastery-repo (PR-R3、実 schema PGlite)', () => {
+	let child: ChildId;
+	let actA: ActivityId;
+	let actB: ActivityId;
+
+	beforeAll(async () => {
+		child = await seedChild(FAMILY, 'mastery');
+		actA = (await activityRepo.insertActivity(activityInput(child, { name: 'mA' }), FAMILY)).id;
+		actB = (await activityRepo.insertActivity(activityInput(child, { name: 'mB' }), FAMILY)).id;
+	});
+
+	it('[M1] upsert insert → find round-trip / 再 upsert は同一行更新', async () => {
+		expect(await masteryRepo.findByChildAndActivity(child, actA, FAMILY)).toBeUndefined();
+
+		const created = await masteryRepo.upsert(child, actA, 1, 1, FAMILY);
+		expect(created.childId).toBe(child);
+		expect(created.activityId).toBe(actA);
+		expect(created.totalCount).toBe(1);
+		expect(created.level).toBe(1);
+		expect(typeof created.updatedAt).toBe('string');
+
+		const updated = await masteryRepo.upsert(child, actA, 10, 2, FAMILY);
+		expect(updated.totalCount).toBe(10);
+		expect(updated.level).toBe(2);
+
+		const found = await masteryRepo.findByChildAndActivity(child, actA, FAMILY);
+		expect(found?.totalCount).toBe(10);
+		expect(found?.level).toBe(2);
+
+		const rows = await t.db.execute(sql`
+			SELECT count(*)::int AS c FROM activity_mastery
+			WHERE family_id = ${FAMILY} AND child_id = ${String(child)} AND activity_id = ${String(actA)}
+		`);
+		expect((rows.rows[0] as { c: number }).c).toBe(1); // 複合 PK で単一行維持
+	});
+
+	it('[M2] findAllByChild / §P9 tenant 分離 / deleteByTenantId は tenant scope', async () => {
+		await masteryRepo.upsert(child, actB, 3, 1, FAMILY);
+		const all = await masteryRepo.findAllByChild(child, FAMILY);
+		expect(all.map((m) => m.activityId).sort()).toEqual([actA, actB].sort());
+
+		expect(await masteryRepo.findByChildAndActivity(child, actA, OTHER_FAMILY)).toBeUndefined();
+		expect(await masteryRepo.findAllByChild(child, OTHER_FAMILY)).toEqual([]);
+
+		// OTHER_FAMILY に 1 行作って tenant scope 削除を検証
+		const otherChild = await seedChild(OTHER_FAMILY, 'other-mastery');
+		const otherAct = (
+			await activityRepo.insertActivity(activityInput(otherChild, { name: 'oM' }), OTHER_FAMILY)
+		).id;
+		await masteryRepo.upsert(otherChild, otherAct, 1, 1, OTHER_FAMILY);
+
+		await masteryRepo.deleteByTenantId(OTHER_FAMILY);
+		expect(await masteryRepo.findAllByChild(otherChild, OTHER_FAMILY)).toEqual([]);
+		expect((await masteryRepo.findAllByChild(child, FAMILY)).length).toBe(2); // FAMILY 残存
+	});
+});

--- a/tests/unit/db/dsql-activity-repos.test.ts
+++ b/tests/unit/db/dsql-activity-repos.test.ts
@@ -399,6 +399,11 @@ describe('DSQL activity-pref-repo (PR-R3、実 schema PGlite)', () => {
 		actC = (await activityRepo.insertActivity(activityInput(child, { name: 'pC' }), FAMILY)).id;
 	});
 
+	// [P1 並行性ガード] togglePin(pin=true) は同一 child の別 activity 並行 pin による pin_order
+	// tie (write-skew) を txn 冒頭の children 行 FOR UPDATE で直列化して防ぐ (#3546 と同型)。
+	// PGlite は単一接続ゆえ真の並行 txn を再現できず (#3546 [F10-4] と同じ制約)、本 spec は逐次
+	// 採番 (MAX+1) の正当性のみを assert する。FOR UPDATE 直列化そのものの回帰は本番 DSQL / OCC
+	// runner の統合検証に委ね、ここでは serialization anchor が採番ロジックを壊さないことを保証する。
 	it('[P1] togglePin: pin は MAX+1 採番、unpin は pinOrder null、未存在 unpin は isPinned=0 行作成', async () => {
 		const p1 = await prefRepo.togglePin(child, actA, true, FAMILY);
 		expect(p1.isPinned).toBe(1);


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管 repo 層第 3 弾 = activity 集約）

**解決する課題**: 記録 CUJ の中核である活動系 3 interface（IChildActivityRepo / IActivityPrefRepo / IActivityMasteryRepo）の DSQL 実装が無く、hot path（recordActivityCore、実装済）の周辺 CRUD が結線できなかった。

**期待される効果**: 活動の作成・検索・bulk 取込・copy・pin・習熟度の全操作が DSQL で動作し、per-child 3 軸 PK（family, child, activity）による cross-child 越境不能がテストで実証される。

## 関連 Issue

- EPIC #3424（§12.2.1 build order PR-2 系 = child-cluster repo。children #3582 / auth #3586 の次）
- related: PR #3582（実装パターン SSOT = factory 注入 / pushSchema テスト基盤）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 3 repo の全メソッド DSQL 実装（factory 注入 = fitness#8、§P9 family_id 述語、branded id 境界変換） | `npx vitest run tests/unit/db/dsql-activity-repos.test.ts` | HEAD `ae03f9b5` / **20 passed**（A1-A8/P1-P6/M1-M2）。**red 実測: import 解決不能 fail → green**（commit message 記録）。本体セッション独立再検証: db+architecture 656/656 + svelte-check 7677 files 0 errors |
| AC2 | 3 軸 PK による cross-child 越境不能 + §P9 tenant 分離 | test（cross-child / cross-tenant の不可視・更新不能） | HEAD `ae03f9b5` / pass |
| AC3 | insertActivitiesBulk = 単一 txn（all-or-nothing、work 内 await は tx.execute 直呼びのみ = fitness#7） | test + `tests/unit/architecture/` 54 passed | HEAD `ae03f9b5` / pass。sqlite の非 atomic loop からの改善（取込配信の部分挿入を排除、§8） |
| AC4 | togglePin = MAX+1 採番 → ON CONFLICT upsert の単一 txn、findAllByChild は pin_order NULLS FIRST（sqlite parity） | test P 系 | HEAD `ae03f9b5` / pass |
| AC5 | mastery = 単文 ON CONFLICT upsert（record-activity-core と同型、hot path 重複実装なし） | test M 系 + diff | HEAD `ae03f9b5` / pass |
| AC6 | CHECK / 複合 PK UNIQUE の実効（不正値・重複が DB レベルで拒否される） | test（reject + 行 0 件 assert） | HEAD `ae03f9b5` / pass |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)（dsql/ に repo 3 file 新設。schema/interface 無変更）
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（新設 4 file のみ、DATA_SOURCE dispatch 未結線）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: dsql-activity-repos.test.ts 20 本新設（pushSchema 実 schema 基盤、手書き fixture なし）
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（未変更）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）**: server 側 repo 新設のみで UI 変更なし（.svelte 変更 0 file）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: interface 契約無変更で backend 追加（OCP）。3 repo を責務ごとに file 分離（SRP）
- [x] **DRY**: record hot path（recordActivityCore / mastery upsert）と重複実装なし。テスト基盤・実装パターンは PR-R1/R2 を再利用
- [x] **YAGNI**: dispatch 結線なし（cutover 配線 PR で実施）
- [x] **Security（OSS 公開前提）**: 全 SQL family_id 述語（§P9）+ 3 軸 PK で cross-child 越境も構造的に不能（ADR-0055 整合）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: 検索は PK プレフィクス。JOIN は PK 完全一致のみ（§4.1 covering 方針）
- 補足（明示的設計判断）: pref/mastery の entity `id` は surrogate 列が無いため `child:activity` の決定的合成文字列（全 callsite grep で id を lookup key に使う箇所ゼロを確認、opaque token 契約 #3575 に整合。値形式は backend 依存）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): §11.2 記載設計の実装であり設計変更なし
- [x] **並行 PR overlap** (#1200): PR-R4（point/status、別 branch）と対象 file 完全独立（worktree 分離で並行実装、merge 順不問）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新設のみ）

**レビュー依頼事項・QA**:
- entity `id` の合成文字列方式（`child:activity`。sqlite backend は数値文字列のため値形式が backend 間で異なるが、opaque token 契約 #3575 の下で lookup key 使用ゼロを実測済み）
- insertActivitiesBulk の単一 txn 化（sqlite の非 atomic loop より強い保証。挙動差は「部分挿入が起きない」方向のみ）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（Agent 実装を本体セッションが独立再検証: 656/656 + svelte-check 0 + cspell 0）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: child-cluster repo は activity（本 PR）/ point+status（PR-R4、並行）/ stamp・checklist 系（次サイクル）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
