### PR TITLE
feat: #3424 PR-R4 — DSQL point/status repo 実装 (P7 不変条件 + retention carryover 設計)

### DIFF
--- a/docs/design/dsql-data-model.md
+++ b/docs/design/dsql-data-model.md
@@ -161,6 +161,7 @@ DSQL: **PK = index-organized 表本体で全非キー列を自動 INCLUDE coveri
 
 ### 派生列（P7）
 - `children.total_point`（残高）: **不変条件 = 全ての `point_ledger` 書込（base / combo / mission / challenge / reward 等、core/optional を問わず）は、その INSERT を行う mini-txn 内で `children.total_point` を同一 txn 共更新する**（F2 整合: §8 で optional は core txn の外＝独立 mini-txn だが、各 optional 点付与も「point_ledger INSERT + total_point 加算」を 1 txn にする）。これにより SUM からの乖離不能。閲覧は列 read 1 回（SUM スキャン廃止 → DPU 削減）。
+- **retention 削除と P7 の両立 (carryover、#3424 PR-R4)**: `deletePointLedgerBeforeDate` (#729「ポイントは消えず過去明細だけが消える」契約) は、削除対象明細の合算を **`type='carryover'` の繰越エントリとして同一 txn で挿入**する (SUM 不変 = total_point 不変で fitness#14 と両立する唯一解)。carryover は履歴 UI に「繰越」として表示され得る (description で人間可読を担保)。
 - `statuses.total_xp/level/peak_xp`: status 更新 txn 内で派生維持。
 - `activity_logs.streak_days/streak_bonus`: 記録 txn 内で算出・確定。
 - 監査用の再計算は**バッチで突合**（drift 検出 fitness）し、正本は派生列。

--- a/src/lib/server/db/dsql/child-repo.ts
+++ b/src/lib/server/db/dsql/child-repo.ts
@@ -26,7 +26,7 @@ import type { TransactionRunner } from '../interfaces/transaction.interface';
 import type { Child, UpdateChildInput } from '../types';
 import type { SqlExecutor } from './sql-executor';
 
-interface ChildRow {
+export interface ChildRow {
 	child_id: string;
 	nickname: string;
 	birth_date: string | null;
@@ -44,14 +44,16 @@ interface ChildRow {
 	updated_at: string;
 }
 
-const CHILD_COLUMNS = sql.raw(
+/** children の SELECT 列 (point/status repo の findChildById も共有、二重管理禁止)。 */
+export const CHILD_COLUMNS = sql.raw(
 	`child_id, nickname, birth_date, theme, ui_mode, ui_mode_manually_set, avatar_url,
 	 display_config, user_id, birthday_bonus_multiplier, last_birthday_bonus_year,
 	 is_archived, archived_reason, created_at, updated_at`,
 );
 
-/** row → Child entity (compute-on-read: age 導出 + ui_mode 再導出、§11.1)。 */
-function toChild(row: ChildRow): Child {
+/** row → Child entity (compute-on-read: age 導出 + ui_mode 再導出、§11.1)。
+ * point/status repo の findChildById からも共有する (mapping 二重実装禁止)。 */
+export function toChild(row: ChildRow): Child {
 	const age = row.birth_date ? calculateAgeFromBirthDate(row.birth_date) : 0;
 	const storedUiMode: UiMode = isValidUiMode(row.ui_mode) ? row.ui_mode : 'preschool';
 	const uiMode = row.birth_date

--- a/src/lib/server/db/dsql/point-repo.ts
+++ b/src/lib/server/db/dsql/point-repo.ts
@@ -1,0 +1,184 @@
+// src/lib/server/db/dsql/point-repo.ts
+// EPIC #3424 / PR-R4 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §5(P7) / §11.2 / §P9
+//
+// IPointRepo の DSQL backend 実装。設計契約:
+//   - **factory 注入** (fitness#8: module-level db/client import 禁止)。
+//   - **§P9 tenant 述語**: 全メソッドが family_id = tenantId を WHERE に含む。
+//   - **§5 P7 不変条件**: point_ledger を book (追加/取消) する全 write は、同一 txn で
+//     children.total_point を同額共更新する (total_point == SUM(point_ledger.amount)、
+//     fitness#14 findTotalPointDrift が突合)。child 不在で total_point 更新先が無い場合は
+//     throw して txn ごと rollback (grant-optional-points.ts と同判断、片肺書込禁止)。
+//   - **残高 read は children.total_point 単読** (§5 compute-on-write。SUM 再計算しない —
+//     sqlite backend の SUM 実装との実装差は §5 で確定済の設計差分)。
+//   - **fitness#7 準拠**: txn work 内の await は全て tx.execute 直呼び (helper 閉包禁止)。
+//   - recorded_date (NOT NULL、冪等 lookup 用 §11.2) は InsertPointLedgerInput に無いため
+//     JST 今日 (todayDateJST、recorded_date カラムの全既存経路と同基準) で導出する。
+//   - retention (deletePointLedgerBeforeDate) は #729 設計「ポイントは消えず過去明細だけが
+//     消える」(dynamodb backend の documented 契約) を維持しつつ §5 P7 と両立させるため、
+//     削除合算の繰越 (carryover) エントリを同一 txn で挿入する (SUM 不変 = total_point 不変)。
+
+import { sql } from 'drizzle-orm';
+import { todayDateJST } from '$lib/domain/date-utils';
+import { asChildId } from '$lib/domain/ids';
+import type { IPointRepo } from '../interfaces/point-repo.interface';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type { PointLedgerEntry } from '../types';
+import { CHILD_COLUMNS, type ChildRow, toChild } from './child-repo';
+import type { SqlExecutor } from './sql-executor';
+
+interface LedgerRow {
+	ledger_id: string;
+	child_id: string;
+	amount: number;
+	type: string;
+	description: string | null;
+	reference_id: string | null;
+	created_at: string;
+}
+
+const LEDGER_COLUMNS = sql.raw(
+	'ledger_id, child_id, amount, type, description, reference_id, created_at',
+);
+
+/** row → PointLedgerEntry (既存 sqlite backend と同一 shape。recorded_date は entity 未公開)。 */
+function toEntry(row: LedgerRow): PointLedgerEntry {
+	return {
+		id: row.ledger_id,
+		childId: asChildId(row.child_id),
+		amount: row.amount,
+		type: row.type,
+		description: row.description,
+		referenceId: row.reference_id,
+		createdAt: row.created_at,
+	};
+}
+
+/** DSQL 用 IPointRepo を生成する (db/runner は注入、fitness#8)。 */
+export function createDsqlPointRepo<TTx extends SqlExecutor>(
+	db: SqlExecutor,
+	runner: TransactionRunner<TTx>,
+): IPointRepo {
+	return {
+		async getBalance(childId, tenantId) {
+			// §5 compute-on-write: 残高は派生列の単読 (SUM スキャン廃止)。child 不在は 0。
+			const result = await db.execute(sql`
+				SELECT total_point FROM children
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+			`);
+			const row = result.rows[0] as { total_point: number } | undefined;
+			return Number(row?.total_point ?? 0);
+		},
+
+		async findPointHistory(childId, options, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${LEDGER_COLUMNS} FROM point_ledger
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+				ORDER BY created_at DESC, ledger_id DESC
+				LIMIT ${options.limit} OFFSET ${options.offset}
+			`);
+			return (result.rows as unknown as LedgerRow[]).map(toEntry);
+		},
+
+		async insertPointEntry(input, tenantId) {
+			// §5 P7: ledger INSERT + total_point 共更新を同一 txn (fitness#14 の乖離不能設計)。
+			const recordedDate = todayDateJST();
+			return runner.runInTransaction(async (tx) => {
+				const inserted = await tx.execute(sql`
+					INSERT INTO point_ledger (family_id, child_id, amount, type, description, reference_id, recorded_date)
+					VALUES (${tenantId}, ${input.childId}, ${input.amount}, ${input.type},
+						${input.description}, ${input.referenceId ?? null}, ${recordedDate})
+					RETURNING ${LEDGER_COLUMNS}
+				`);
+				const updated = await tx.execute(sql`
+					UPDATE children SET total_point = total_point + ${input.amount}, updated_at = now()
+					WHERE family_id = ${tenantId} AND child_id = ${input.childId}
+					RETURNING child_id
+				`);
+				if (updated.rows.length === 0) {
+					// child 不在 = total_point 共更新不能。throw で txn ごと rollback (§5 P7)。
+					throw new Error(`insertPointEntry: child not found (${tenantId}/${input.childId})`);
+				}
+				return toEntry(inserted.rows[0] as unknown as LedgerRow);
+			});
+		},
+
+		async spendPointsAtomic(childId, amount, entry, tenantId) {
+			// #3347 TOCTOU 防止: DSQL は OCC — 残高 read と total_point UPDATE が同一 txn に
+			// 閉じるため、並行 spend は children 行更新の衝突で 40001 → retry → 再読込が
+			// 減算後残高で INSUFFICIENT を返す (二重減算・残高マイナス不能)。
+			const recordedDate = todayDateJST();
+			return runner.runInTransaction(async (tx) => {
+				const balanceRead = await tx.execute(sql`
+					SELECT total_point FROM children
+					WHERE family_id = ${tenantId} AND child_id = ${childId}
+				`);
+				const row = balanceRead.rows[0] as { total_point: number } | undefined;
+				const balance = Number(row?.total_point ?? 0);
+				if (row === undefined || balance < amount) {
+					return { error: 'INSUFFICIENT_POINTS' as const };
+				}
+
+				const inserted = await tx.execute(sql`
+					INSERT INTO point_ledger (family_id, child_id, amount, type, description, reference_id, recorded_date)
+					VALUES (${tenantId}, ${childId}, ${-amount}, ${entry.type},
+						${entry.description}, ${entry.referenceId ?? null}, ${recordedDate})
+					RETURNING ${LEDGER_COLUMNS}
+				`);
+				await tx.execute(sql`
+					UPDATE children SET total_point = total_point - ${amount}, updated_at = now()
+					WHERE family_id = ${tenantId} AND child_id = ${childId}
+				`);
+				return toEntry(inserted.rows[0] as unknown as LedgerRow);
+			});
+		},
+
+		async findChildById(id, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${CHILD_COLUMNS} FROM children
+				WHERE family_id = ${tenantId} AND child_id = ${id}
+			`);
+			const row = result.rows[0] as unknown as ChildRow | undefined;
+			return row ? toChild(row) : undefined;
+		},
+
+		async deleteByTenantId(tenantId) {
+			// tenant 全削除 (退会経路)。ledger 全削除と同一 txn で total_point を 0 に揃え、
+			// children 行が (削除順序の都合で) まだ残っていても §5 P7 不変条件を保つ。
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(sql`DELETE FROM point_ledger WHERE family_id = ${tenantId}`);
+				await tx.execute(sql`
+					UPDATE children SET total_point = 0, updated_at = now()
+					WHERE family_id = ${tenantId} AND total_point <> 0
+				`);
+			});
+		},
+
+		async deletePointLedgerBeforeDate(childId, cutoffDate, tenantId) {
+			// retention cleanup (#717/#729): cutoffDate (YYYY-MM-DD) 当日 0:00 前の明細を削除。
+			// #729 契約 = 「ポイントは消えず、過去明細だけが消える」(dynamodb backend と同義)。
+			// §5 P7 (total_point == SUM) と両立させるため、削除分の合算を繰越 (carryover)
+			// エントリとして同一 txn で挿入する — SUM 不変なので total_point は触らない。
+			const recordedDate = todayDateJST();
+			return runner.runInTransaction(async (tx) => {
+				const deleted = await tx.execute(sql`
+					DELETE FROM point_ledger
+					WHERE family_id = ${tenantId} AND child_id = ${childId}
+						AND created_at < ${cutoffDate}::timestamptz
+					RETURNING amount
+				`);
+				const removedSum = (deleted.rows as { amount: number }[]).reduce(
+					(acc, r) => acc + Number(r.amount),
+					0,
+				);
+				if (deleted.rows.length > 0 && removedSum !== 0) {
+					await tx.execute(sql`
+						INSERT INTO point_ledger (family_id, child_id, amount, type, description, recorded_date)
+						VALUES (${tenantId}, ${childId}, ${removedSum}, 'carryover',
+							${'ポイント繰越（保持期間外の明細を合算）'}, ${recordedDate})
+					`);
+				}
+				return deleted.rows.length;
+			});
+		},
+	};
+}

--- a/src/lib/server/db/dsql/schema.ts
+++ b/src/lib/server/db/dsql/schema.ts
@@ -931,6 +931,27 @@ export const usageLogs = pgTable(
 	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.logId] })],
 );
 
+// ── グローバル master (§11.2: tenant プレフィクスなし、自然キー PK) ──
+
+// market_benchmarks — 年齢×カテゴリ別の市場ベンチマーク (グローバル master、tenant 非依存)。
+// PK は自然キー (age, category_id) (§11.2「market_benchmarks(age,category_id) PK」/ §4)。
+// category_id はグローバル master categories(code) への論理 FK (text、child_activities と同判断)。
+// PK 凍結は GLOBAL_MASTER_PK_MANIFEST (pk-freeze-manifest.ts) で fitness#9 [3] が突合。
+export const marketBenchmarks = pgTable(
+	'market_benchmarks',
+	{
+		age: integer('age').notNull(),
+		categoryId: text('category_id').notNull(),
+		mean: real('mean').notNull(),
+		stdDev: real('std_dev').notNull(),
+		source: text('source'),
+		updatedAt: timestamp('updated_at', { mode: 'string', withTimezone: true })
+			.notNull()
+			.defaultNow(),
+	},
+	(t) => [primaryKey({ columns: [t.age, t.categoryId] })],
+);
+
 // ── Family 系 8 表 (§11.2 #3557 確定 / 調査 SSOT: tmp/research-family-tables-pk-2026-07-03.md、#3424) ──
 // settings のみ自然複合 (anchor (b) KVS 構造的確実性)、他 7 表は UUID surrogate。
 // endpoint/token/pin の global UNIQUE は無 tenant 単点 lookup の機能要件 (§11.2)。

--- a/src/lib/server/db/dsql/status-repo.ts
+++ b/src/lib/server/db/dsql/status-repo.ts
@@ -1,0 +1,232 @@
+// src/lib/server/db/dsql/status-repo.ts
+// EPIC #3424 / PR-R4 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §5 / §11.2 / §P9
+//
+// IStatusRepo の DSQL backend 実装。設計契約:
+//   - **factory 注入** (fitness#8: module-level db/client import 禁止)。
+//   - **§P9 tenant 述語**: market_benchmarks (グローバル master、tenant 非依存 §11.2) を除く
+//     全メソッドが family_id = tenantId を WHERE に含む。
+//   - statuses は自然複合 PK (family, child, category) で ON CONFLICT upsert 1 文
+//     (§11.2 unique(child,category) 昇格。sqlite の read→update/insert 2 発を単文化)。
+//     total_xp の負値 0 clamp は sqlite backend と同一契約。
+//   - statuses / market_benchmarks は surrogate id 列を持たない (§4 自然キー戦略) ため、
+//     entity の `id` は複合キーの合成文字列 (`child:category` / `age:category`) を返す。
+//     Status.id / MarketBenchmark.id の service/route 消費は 0 件 (grep 確認済) で、
+//     entity shape 契約 (id: string) のみ維持する。
+//   - hot path 書込 (recordActivity の statuses/status_history/XP 加算) は
+//     record-activity-core.ts §8 が担う — 本 repo は読取と管理系 upsert の contract 実装。
+//   - findStatusValueAtDate / findRecentStatusHistory の recorded_at は timestamptz。
+//     'YYYY-MM-DD' / ISO いずれの beforeDate も ::timestamptz cast で辞書順比較と同義。
+
+import { sql } from 'drizzle-orm';
+import { asCategoryId, asChildId } from '$lib/domain/ids';
+import type { IStatusRepo } from '../interfaces/status-repo.interface';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type { MarketBenchmark, Status, StatusHistoryEntry } from '../types';
+import { CHILD_COLUMNS, type ChildRow, toChild } from './child-repo';
+import type { SqlExecutor } from './sql-executor';
+
+interface StatusRow {
+	child_id: string;
+	category_id: string;
+	total_xp: number;
+	level: number;
+	peak_xp: number;
+	updated_at: string;
+}
+
+interface HistoryRow {
+	hist_id: string;
+	child_id: string;
+	category_id: string;
+	value: number;
+	change_amount: number;
+	change_type: string;
+	recorded_at: string;
+}
+
+interface BenchmarkRow {
+	age: number;
+	category_id: string;
+	mean: number;
+	std_dev: number;
+	source: string | null;
+	updated_at: string;
+}
+
+const STATUS_COLUMNS = sql.raw('child_id, category_id, total_xp, level, peak_xp, updated_at');
+const HISTORY_COLUMNS = sql.raw(
+	'hist_id, child_id, category_id, value, change_amount, change_type, recorded_at',
+);
+const BENCHMARK_COLUMNS = sql.raw('age, category_id, mean, std_dev, source, updated_at');
+
+/** row → Status (id は複合キー合成、§4 自然キー戦略)。 */
+function toStatus(row: StatusRow): Status {
+	return {
+		id: `${row.child_id}:${row.category_id}`,
+		childId: asChildId(row.child_id),
+		categoryId: asCategoryId(row.category_id),
+		totalXp: row.total_xp,
+		level: row.level,
+		peakXp: row.peak_xp,
+		updatedAt: row.updated_at,
+	};
+}
+
+function toHistory(row: HistoryRow): StatusHistoryEntry {
+	return {
+		id: row.hist_id,
+		childId: asChildId(row.child_id),
+		categoryId: asCategoryId(row.category_id),
+		value: Number(row.value),
+		changeAmount: Number(row.change_amount),
+		changeType: row.change_type,
+		recordedAt: row.recorded_at,
+	};
+}
+
+/** row → MarketBenchmark (id は複合キー合成、§4 自然キー戦略)。 */
+function toBenchmark(row: BenchmarkRow): MarketBenchmark {
+	return {
+		id: `${row.age}:${row.category_id}`,
+		age: row.age,
+		categoryId: asCategoryId(row.category_id),
+		mean: Number(row.mean),
+		stdDev: Number(row.std_dev),
+		source: row.source,
+		updatedAt: row.updated_at,
+	};
+}
+
+/** DSQL 用 IStatusRepo を生成する (db/runner は注入、fitness#8)。 */
+export function createDsqlStatusRepo<TTx extends SqlExecutor>(
+	db: SqlExecutor,
+	runner: TransactionRunner<TTx>,
+): IStatusRepo {
+	return {
+		async findStatuses(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${STATUS_COLUMNS} FROM statuses
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+				ORDER BY category_id
+			`);
+			return (result.rows as unknown as StatusRow[]).map(toStatus);
+		},
+
+		async findStatus(childId, categoryId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${STATUS_COLUMNS} FROM statuses
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND category_id = ${categoryId}
+			`);
+			const row = result.rows[0] as unknown as StatusRow | undefined;
+			return row ? toStatus(row) : undefined;
+		},
+
+		// biome-ignore lint/complexity/useMaxParams: interface 契約 (sqlite backend と同一、別 Issue でオブジェクト引数化予定)
+		async upsertStatus(childId, categoryId, totalXp, level, peakXp, tenantId) {
+			// 自然複合 PK への ON CONFLICT upsert 1 文 (§11.2)。負 XP は 0 clamp (sqlite parity)。
+			const clampedXp = Math.max(0, totalXp);
+			const result = await db.execute(sql`
+				INSERT INTO statuses (family_id, child_id, category_id, total_xp, level, peak_xp, updated_at)
+				VALUES (${tenantId}, ${childId}, ${categoryId}, ${clampedXp}, ${level}, ${peakXp}, now())
+				ON CONFLICT (family_id, child_id, category_id)
+				DO UPDATE SET total_xp = ${clampedXp}, level = ${level}, peak_xp = ${peakXp}, updated_at = now()
+				RETURNING ${STATUS_COLUMNS}
+			`);
+			return toStatus(result.rows[0] as unknown as StatusRow);
+		},
+
+		async insertStatusHistory(input, tenantId) {
+			const result = await db.execute(sql`
+				INSERT INTO status_history (family_id, child_id, category_id, value, change_amount, change_type)
+				VALUES (${tenantId}, ${input.childId}, ${input.categoryId}, ${input.value},
+					${input.changeAmount}, ${input.changeType})
+				RETURNING ${HISTORY_COLUMNS}
+			`);
+			return toHistory(result.rows[0] as unknown as HistoryRow);
+		},
+
+		async findRecentStatusHistory(childId, categoryId, tenantId, limit = 7) {
+			const result = await db.execute(sql`
+				SELECT ${HISTORY_COLUMNS} FROM status_history
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND category_id = ${categoryId}
+				ORDER BY recorded_at DESC
+				LIMIT ${limit}
+			`);
+			return (result.rows as unknown as HistoryRow[]).map(toHistory);
+		},
+
+		async findStatusValueAtDate(childId, categoryId, beforeDate, tenantId) {
+			const result = await db.execute(sql`
+				SELECT value FROM status_history
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND category_id = ${categoryId}
+					AND recorded_at < ${beforeDate}::timestamptz
+				ORDER BY recorded_at DESC
+				LIMIT 1
+			`);
+			const row = result.rows[0] as { value: number } | undefined;
+			return row ? Number(row.value) : null;
+		},
+
+		async findBenchmark(age, categoryId, _tenantId) {
+			// グローバル master (§11.2): tenant 述語なし (sqlite backend と同一契約)。
+			const result = await db.execute(sql`
+				SELECT ${BENCHMARK_COLUMNS} FROM market_benchmarks
+				WHERE age = ${age} AND category_id = ${categoryId}
+			`);
+			const row = result.rows[0] as unknown as BenchmarkRow | undefined;
+			return row ? toBenchmark(row) : undefined;
+		},
+
+		async findAllBenchmarks(_tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${BENCHMARK_COLUMNS} FROM market_benchmarks
+				ORDER BY age, category_id
+			`);
+			return (result.rows as unknown as BenchmarkRow[]).map(toBenchmark);
+		},
+
+		// biome-ignore lint/complexity/useMaxParams: interface 契約 (sqlite backend と同一、別 Issue でオブジェクト引数化予定)
+		async upsertBenchmark(age, categoryId, mean, stdDev, source, _tenantId) {
+			const result = await db.execute(sql`
+				INSERT INTO market_benchmarks (age, category_id, mean, std_dev, source, updated_at)
+				VALUES (${age}, ${categoryId}, ${mean}, ${stdDev}, ${source}, now())
+				ON CONFLICT (age, category_id)
+				DO UPDATE SET mean = ${mean}, std_dev = ${stdDev}, source = ${source}, updated_at = now()
+				RETURNING ${BENCHMARK_COLUMNS}
+			`);
+			return toBenchmark(result.rows[0] as unknown as BenchmarkRow);
+		},
+
+		async findChildById(id, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${CHILD_COLUMNS} FROM children
+				WHERE family_id = ${tenantId} AND child_id = ${id}
+			`);
+			const row = result.rows[0] as unknown as ChildRow | undefined;
+			return row ? toChild(row) : undefined;
+		},
+
+		async findLastActivityDates(childId, tenantId) {
+			// 既存命名の歪み parity: category と命名されているが activityId keyed (interface 注記参照)。
+			// DSQL は activity_id が uuid のため category は string で返る。
+			const result = await db.execute(sql`
+				SELECT activity_id, max(recorded_date) AS last_date FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND cancelled = false
+				GROUP BY activity_id
+			`);
+			return (result.rows as { activity_id: string; last_date: string | null }[]).map((r) => ({
+				category: r.activity_id,
+				lastDate: r.last_date,
+			}));
+		},
+
+		async deleteByTenantId(tenantId) {
+			// market_benchmarks はグローバル master のため削除しない (sqlite parity)。
+			// 2 表削除を単一 txn で (fitness#7: work 内 await は tx.execute 直呼びのみ)。
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(sql`DELETE FROM status_history WHERE family_id = ${tenantId}`);
+				await tx.execute(sql`DELETE FROM statuses WHERE family_id = ${tenantId}`);
+			});
+		},
+	};
+}

--- a/src/lib/server/db/interfaces/status-repo.interface.ts
+++ b/src/lib/server/db/interfaces/status-repo.interface.ts
@@ -53,9 +53,14 @@ export interface IStatusRepo {
 		tenantId: string,
 	): Promise<MarketBenchmark>;
 	findChildById(id: ChildId, tenantId: string): Promise<Child | undefined>;
+	/**
+	 * カテゴリ別と命名されているが実際は **activityId keyed**（既存命名の歪み、全 backend parity）。
+	 * `category` の型は歴史的に number (sqlite/dynamo の整数 activity id) だが、DSQL backend は
+	 * activity_id が uuid (§P3) のため string を返す (#3424 PR-R4 で widening)。
+	 */
 	findLastActivityDates(
 		childId: ChildId,
 		tenantId: string,
-	): Promise<{ category: number; lastDate: string | null }[]>;
+	): Promise<{ category: number | string; lastDate: string | null }[]>;
 	deleteByTenantId(tenantId: string): Promise<void>;
 }

--- a/src/lib/server/db/pk-freeze-manifest.ts
+++ b/src/lib/server/db/pk-freeze-manifest.ts
@@ -87,3 +87,12 @@ export const AUTH_PK_MANIFEST = {
 	invites: ['invite_id'],
 	consents: ['consent_id'],
 } as const satisfies Record<string, readonly string[]>;
+
+// ── グローバル master (§11.2 例外: tenant プレフィクスなし、自然キー PK) ──
+// §11.2「グローバル master（tenant 非依存）: categories(code) / stamp_masters /
+// market_benchmarks(age,category_id) / stripe_webhook_events(event_id)」の機械可読宣言。
+// schema.ts へグローバル master 表を追記する際は本 manifest にも 1 行追加する
+// (fitness#9 [3] が PK_FREEZE / AUTH / GLOBAL_MASTER の union で schema 全表を突合)。
+export const GLOBAL_MASTER_PK_MANIFEST = {
+	market_benchmarks: ['age', 'category_id'],
+} as const satisfies Record<string, readonly string[]>;

--- a/tests/unit/db/dsql-point-status-repos.test.ts
+++ b/tests/unit/db/dsql-point-status-repos.test.ts
@@ -1,0 +1,465 @@
+// tests/unit/db/dsql-point-status-repos.test.ts
+// EPIC #3424 / PR-R4 / 設計 SSOT: dsql-data-model.md §5(P7) / §11.2 / §P9
+//
+// DSQL IPointRepo + IStatusRepo 実装のテスト。実 schema (pushSchema 適用、dsql-test-db helper):
+//
+// ── IPointRepo ──
+//   [P1] insertPointEntry → entry round-trip + children.total_point 同一 txn 共更新 (== SUM)
+//   [P2] 負値エントリ (取消) も total_point 同期 (== SUM)
+//   [P3] child 不在への insert は throw + ledger 未挿入 (片肺書込の rollback、§5 P7)
+//   [P4] getBalance = children.total_point 単読 (SUM 再計算しない = compute-on-write §5)
+//   [P5] findPointHistory: created_at 降順 + limit/offset + 返り値 shape parity
+//   [P6] spendPointsAtomic 成功: 負値エントリ + total_point 減算 (== SUM)
+//   [P7] spendPointsAtomic 残高不足: INSUFFICIENT_POINTS + 無書込
+//   [P8] §P9 tenant 分離: 他 family から balance/history 不可視、spend も不能
+//   [P9] deletePointLedgerBeforeDate: cutoff 前だけ削除 + 繰越エントリで残高不変 (== SUM 維持、
+//        #729「ポイントは消えず過去明細だけが消える」× fitness#14 の両立)
+//   [P10] deleteByTenantId: ledger 全削除 + total_point 0 リセット (== SUM 維持)、他 tenant 無傷
+//
+// ── IStatusRepo ──
+//   [S1] upsertStatus: insert → update (負 XP は 0 clamp、sqlite parity) + shape
+//   [S2] findStatuses / findStatus + §P9 tenant 分離
+//   [S3] insertStatusHistory → findRecentStatusHistory (降順 + limit 既定 7)
+//   [S4] findStatusValueAtDate: 指定日前の最新値 / 該当なし null
+//   [S5] benchmark upsert (insert/update) + findBenchmark + findAllBenchmarks (グローバル master、
+//        tenant 非依存 = sqlite parity)
+//   [S6] findLastActivityDates: activityId keyed (既存命名の歪み parity 維持) + cancelled 除外
+//   [S7] deleteByTenantId: statuses/status_history 削除、market_benchmarks は survive
+
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { asCategoryId, asChildId, type ChildId } from '../../../src/lib/domain/ids';
+import { createDsqlChildRepo } from '../../../src/lib/server/db/dsql/child-repo';
+import { findTotalPointDrift } from '../../../src/lib/server/db/dsql/derived-drift';
+import { createDsqlPointRepo } from '../../../src/lib/server/db/dsql/point-repo';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import { createDsqlStatusRepo } from '../../../src/lib/server/db/dsql/status-repo';
+import type { IChildRepo } from '../../../src/lib/server/db/interfaces/child-repo.interface';
+import type { IPointRepo } from '../../../src/lib/server/db/interfaces/point-repo.interface';
+import type { IStatusRepo } from '../../../src/lib/server/db/interfaces/status-repo.interface';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+const FAMILY = '00000000-0000-4000-8000-0000000000b1';
+const OTHER_FAMILY = '00000000-0000-4000-8000-0000000000b2';
+
+describe('DSQL point-repo / status-repo (PR-R4、実 schema PGlite)', () => {
+	let t: DsqlTestDb;
+	let childRepo: IChildRepo;
+	let pointRepo: IPointRepo;
+	let statusRepo: IStatusRepo;
+
+	/** 新規 child を作って id を返す (各テストは自分の child で分離)。 */
+	const newChild = async (nickname: string, family = FAMILY): Promise<ChildId> => {
+		const c = await childRepo.insertChild({ nickname, age: 8, birthDate: '2018-01-15' }, family);
+		return c.id;
+	};
+
+	/** total_point == SUM(point_ledger.amount) 不変条件を assert する (§5 P7 / fitness#14)。 */
+	const expectNoDrift = async () => {
+		const drift = await findTotalPointDrift(t.db);
+		expect(drift, 'total_point == SUM(point_ledger.amount) (fitness#14)').toEqual([]);
+	};
+
+	const totalPointOf = async (childId: ChildId, family = FAMILY): Promise<number> => {
+		const r = await t.db.execute(
+			sql`SELECT total_point FROM children WHERE family_id = ${family} AND child_id = ${String(childId)}`,
+		);
+		return Number((r.rows[0] as { total_point: number }).total_point);
+	};
+
+	beforeAll(async () => {
+		t = await createDsqlTestDb();
+		const runner = createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 });
+		childRepo = createDsqlChildRepo(t.db, runner);
+		pointRepo = createDsqlPointRepo(t.db, runner);
+		statusRepo = createDsqlStatusRepo(t.db, runner);
+	}, 60_000);
+	afterAll(async () => {
+		await t.close();
+	});
+
+	// ─────────────────── IPointRepo ───────────────────
+
+	it('[P1] insertPointEntry: entry round-trip + total_point 同一 txn 共更新 (== SUM)', async () => {
+		const childId = await newChild('ポイント太郎');
+		const entry = await pointRepo.insertPointEntry(
+			{ childId, amount: 10, type: 'activity', description: 'てすと', referenceId: 'ref-1' },
+			FAMILY,
+		);
+		expect(entry.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(entry.childId).toBe(childId);
+		expect(entry.amount).toBe(10);
+		expect(entry.type).toBe('activity');
+		expect(entry.description).toBe('てすと');
+		expect(entry.referenceId).toBe('ref-1');
+		expect(typeof entry.createdAt).toBe('string');
+
+		expect(await totalPointOf(childId)).toBe(10);
+		await expectNoDrift();
+
+		// referenceId 未指定は null (sqlite parity)
+		const noRef = await pointRepo.insertPointEntry(
+			{ childId, amount: 5, type: 'bonus', description: 'ぼーなす' },
+			FAMILY,
+		);
+		expect(noRef.referenceId).toBe(null);
+		expect(await totalPointOf(childId)).toBe(15);
+	});
+
+	it('[P2] 負値エントリ (取消) も total_point 同期 (== SUM)', async () => {
+		const childId = await newChild('取消次郎');
+		await pointRepo.insertPointEntry(
+			{ childId, amount: 20, type: 'activity', description: '記録' },
+			FAMILY,
+		);
+		await pointRepo.insertPointEntry(
+			{ childId, amount: -8, type: 'activity_cancel', description: '取消' },
+			FAMILY,
+		);
+		expect(await totalPointOf(childId)).toBe(12);
+		expect(await pointRepo.getBalance(childId, FAMILY)).toBe(12);
+		await expectNoDrift();
+	});
+
+	it('[P3] child 不在への insert は throw + ledger 未挿入 (片肺書込 rollback)', async () => {
+		const ghost = asChildId('00000000-0000-4000-8000-00000000dead');
+		await expect(
+			pointRepo.insertPointEntry(
+				{ childId: ghost, amount: 10, type: 'activity', description: 'x' },
+				FAMILY,
+			),
+		).rejects.toThrow();
+		const rows = await t.db.execute(
+			sql`SELECT count(*) AS c FROM point_ledger WHERE family_id = ${FAMILY} AND child_id = ${String(ghost)}`,
+		);
+		expect(Number((rows.rows[0] as { c: unknown }).c)).toBe(0);
+	});
+
+	it('[P4] getBalance = children.total_point 単読 (SUM 再計算しない、§5 compute-on-write)', async () => {
+		const childId = await newChild('残高三郎');
+		await pointRepo.insertPointEntry(
+			{ childId, amount: 30, type: 'activity', description: '記録' },
+			FAMILY,
+		);
+		// 列を意図的に skew: getBalance が SUM でなく列を読むことの直接証明
+		await t.db.execute(
+			sql`UPDATE children SET total_point = 999 WHERE family_id = ${FAMILY} AND child_id = ${String(childId)}`,
+		);
+		expect(await pointRepo.getBalance(childId, FAMILY)).toBe(999);
+		// 後始末 (他テストの drift assert を汚さない)
+		await t.db.execute(
+			sql`UPDATE children SET total_point = 30 WHERE family_id = ${FAMILY} AND child_id = ${String(childId)}`,
+		);
+	});
+
+	it('[P5] findPointHistory: created_at 降順 + limit/offset + shape parity', async () => {
+		const childId = await newChild('履歴四郎');
+		for (const [amount, type] of [
+			[1, 'a'],
+			[2, 'b'],
+			[3, 'c'],
+		] as const) {
+			await pointRepo.insertPointEntry(
+				{ childId, amount, type, description: `entry-${amount}` },
+				FAMILY,
+			);
+		}
+		const page1 = await pointRepo.findPointHistory(childId, { limit: 2, offset: 0 }, FAMILY);
+		expect(page1.map((e) => e.amount)).toEqual([3, 2]); // 新しい順
+		const page2 = await pointRepo.findPointHistory(childId, { limit: 2, offset: 2 }, FAMILY);
+		expect(page2.map((e) => e.amount)).toEqual([1]);
+	});
+
+	it('[P6] spendPointsAtomic 成功: 負値エントリ + total_point 減算 (== SUM)', async () => {
+		const childId = await newChild('消費五郎');
+		await pointRepo.insertPointEntry(
+			{ childId, amount: 50, type: 'activity', description: '貯金' },
+			FAMILY,
+		);
+		const result = await pointRepo.spendPointsAtomic(
+			childId,
+			30,
+			{ type: 'reward_redeem', description: 'ごほうび交換', referenceId: 'reward-1' },
+			FAMILY,
+		);
+		expect(result).not.toHaveProperty('error');
+		if ('error' in result) throw new Error('unreachable');
+		expect(result.amount).toBe(-30);
+		expect(result.type).toBe('reward_redeem');
+		expect(result.referenceId).toBe('reward-1');
+		expect(await pointRepo.getBalance(childId, FAMILY)).toBe(20);
+		await expectNoDrift();
+	});
+
+	it('[P7] spendPointsAtomic 残高不足: INSUFFICIENT_POINTS + 無書込', async () => {
+		const childId = await newChild('不足六郎');
+		await pointRepo.insertPointEntry(
+			{ childId, amount: 10, type: 'activity', description: '少額' },
+			FAMILY,
+		);
+		const result = await pointRepo.spendPointsAtomic(
+			childId,
+			11,
+			{ type: 'reward_redeem', description: '買えない' },
+			FAMILY,
+		);
+		expect(result).toEqual({ error: 'INSUFFICIENT_POINTS' });
+		expect(await pointRepo.getBalance(childId, FAMILY)).toBe(10);
+		const rows = await t.db.execute(sql`
+			SELECT count(*) AS c FROM point_ledger
+			WHERE family_id = ${FAMILY} AND child_id = ${String(childId)} AND amount < 0
+		`);
+		expect(Number((rows.rows[0] as { c: unknown }).c)).toBe(0);
+		await expectNoDrift();
+	});
+
+	it('[P8] §P9 tenant 分離: 他 family から不可視 + spend 不能', async () => {
+		const childId = await newChild('分離七郎');
+		await pointRepo.insertPointEntry(
+			{ childId, amount: 40, type: 'activity', description: '自家' },
+			FAMILY,
+		);
+		expect(await pointRepo.getBalance(childId, OTHER_FAMILY)).toBe(0);
+		expect(
+			await pointRepo.findPointHistory(childId, { limit: 10, offset: 0 }, OTHER_FAMILY),
+		).toEqual([]);
+		expect(await pointRepo.findChildById(childId, OTHER_FAMILY)).toBeUndefined();
+		const result = await pointRepo.spendPointsAtomic(
+			childId,
+			10,
+			{ type: 'reward_redeem', description: '越境' },
+			OTHER_FAMILY,
+		);
+		expect(result).toEqual({ error: 'INSUFFICIENT_POINTS' });
+		expect(await pointRepo.getBalance(childId, FAMILY)).toBe(40); // 無傷
+	});
+
+	it('[P9] deletePointLedgerBeforeDate: cutoff 前削除 + 繰越で残高不変 (== SUM 維持)', async () => {
+		const childId = await newChild('保持八郎');
+		const id = String(childId);
+		// 古いエントリ 2 件 (cutoff 前) + 新しいエントリ 1 件を直接 seed
+		await t.db.execute(sql`
+			INSERT INTO point_ledger (family_id, child_id, amount, type, recorded_date, created_at)
+			VALUES
+				(${FAMILY}, ${id}, 10, 'activity', '2025-01-10', '2025-01-10T00:00:00Z'),
+				(${FAMILY}, ${id}, 5, 'bonus', '2025-02-10', '2025-02-10T00:00:00Z'),
+				(${FAMILY}, ${id}, 7, 'activity', '2026-06-01', '2026-06-01T00:00:00Z')
+		`);
+		await t.db.execute(
+			sql`UPDATE children SET total_point = 22 WHERE family_id = ${FAMILY} AND child_id = ${id}`,
+		);
+
+		const deleted = await pointRepo.deletePointLedgerBeforeDate(childId, '2026-01-01', FAMILY);
+		expect(deleted).toBe(2);
+		// #729: ポイントは消えず過去明細だけが消える → 残高不変
+		expect(await pointRepo.getBalance(childId, FAMILY)).toBe(22);
+		// fitness#14: 繰越エントリにより SUM も 22 のまま
+		await expectNoDrift();
+		const remaining = await t.db.execute(sql`
+			SELECT amount, type FROM point_ledger
+			WHERE family_id = ${FAMILY} AND child_id = ${id} ORDER BY amount
+		`);
+		const rows = remaining.rows as { amount: number; type: string }[];
+		expect(rows).toHaveLength(2); // 残存 1 件 + 繰越 1 件
+		expect(rows.some((r) => r.amount === 15 && r.type === 'carryover')).toBe(true);
+		expect(rows.some((r) => r.amount === 7)).toBe(true);
+	});
+
+	it('[P9b] deletePointLedgerBeforeDate: 対象 0 件は繰越を作らない', async () => {
+		const childId = await newChild('保持九郎');
+		await pointRepo.insertPointEntry(
+			{ childId, amount: 3, type: 'activity', description: '最近' },
+			FAMILY,
+		);
+		const deleted = await pointRepo.deletePointLedgerBeforeDate(childId, '2020-01-01', FAMILY);
+		expect(deleted).toBe(0);
+		const rows = await t.db.execute(
+			sql`SELECT count(*) AS c FROM point_ledger WHERE family_id = ${FAMILY} AND child_id = ${String(childId)}`,
+		);
+		expect(Number((rows.rows[0] as { c: unknown }).c)).toBe(1); // 繰越なし
+	});
+
+	it('[P10] deleteByTenantId: ledger 全削除 + total_point 0 (== SUM 維持)、他 tenant 無傷', async () => {
+		const mine = await newChild('全削除十郎', OTHER_FAMILY);
+		const other = await newChild('無傷十一郎');
+		await pointRepo.insertPointEntry(
+			{ childId: mine, amount: 25, type: 'activity', description: 'x' },
+			OTHER_FAMILY,
+		);
+		await pointRepo.insertPointEntry(
+			{ childId: other, amount: 9, type: 'activity', description: 'y' },
+			FAMILY,
+		);
+
+		await pointRepo.deleteByTenantId(OTHER_FAMILY);
+
+		expect(await pointRepo.getBalance(mine, OTHER_FAMILY)).toBe(0);
+		const gone = await t.db.execute(
+			sql`SELECT count(*) AS c FROM point_ledger WHERE family_id = ${OTHER_FAMILY}`,
+		);
+		expect(Number((gone.rows[0] as { c: unknown }).c)).toBe(0);
+		expect(await pointRepo.getBalance(other, FAMILY)).toBe(9); // 他 tenant 無傷
+		await expectNoDrift();
+	});
+
+	it('point-repo findChildById: Child entity round-trip (child-repo parity)', async () => {
+		const childId = await newChild('存在確認');
+		const found = await pointRepo.findChildById(childId, FAMILY);
+		expect(found?.nickname).toBe('存在確認');
+		expect(found?.age).toBe(8);
+		expect(found?.isArchived).toBe(0);
+	});
+
+	// ─────────────────── IStatusRepo ───────────────────
+
+	it('[S1] upsertStatus: insert → update (負 XP は 0 clamp) + shape', async () => {
+		const childId = await newChild('ステータス一郎');
+		const catId = asCategoryId('exercise');
+		const created = await statusRepo.upsertStatus(childId, catId, 100, 2, 100, FAMILY);
+		expect(created.childId).toBe(childId);
+		expect(created.categoryId).toBe(catId);
+		expect(created.totalXp).toBe(100);
+		expect(created.level).toBe(2);
+		expect(created.peakXp).toBe(100);
+		expect(typeof created.id).toBe('string');
+		expect(typeof created.updatedAt).toBe('string');
+
+		// update 経路 + 負 XP clamp (sqlite parity: Math.max(0, totalXp))
+		const updated = await statusRepo.upsertStatus(childId, catId, -5, 1, 100, FAMILY);
+		expect(updated.totalXp).toBe(0);
+		expect(updated.peakXp).toBe(100);
+		const all = await statusRepo.findStatuses(childId, FAMILY);
+		expect(all).toHaveLength(1); // upsert であり重複行を作らない
+	});
+
+	it('[S2] findStatuses / findStatus + §P9 tenant 分離', async () => {
+		const childId = await newChild('ステータス二郎');
+		await statusRepo.upsertStatus(childId, asCategoryId('study'), 10, 1, 10, FAMILY);
+		await statusRepo.upsertStatus(childId, asCategoryId('exercise'), 20, 1, 20, FAMILY);
+
+		const all = await statusRepo.findStatuses(childId, FAMILY);
+		expect(all).toHaveLength(2);
+		const one = await statusRepo.findStatus(childId, asCategoryId('study'), FAMILY);
+		expect(one?.totalXp).toBe(10);
+		expect(await statusRepo.findStatus(childId, asCategoryId('none'), FAMILY)).toBeUndefined();
+
+		expect(await statusRepo.findStatuses(childId, OTHER_FAMILY)).toEqual([]);
+		expect(
+			await statusRepo.findStatus(childId, asCategoryId('study'), OTHER_FAMILY),
+		).toBeUndefined();
+		expect(await statusRepo.findChildById(childId, OTHER_FAMILY)).toBeUndefined();
+	});
+
+	it('[S3] insertStatusHistory → findRecentStatusHistory (降順 + limit 既定 7)', async () => {
+		const childId = await newChild('履歴三郎');
+		const catId = asCategoryId('life');
+		for (let i = 1; i <= 9; i++) {
+			const entry = await statusRepo.insertStatusHistory(
+				{
+					childId,
+					categoryId: catId,
+					value: i * 10,
+					changeAmount: 10,
+					changeType: 'activity_record',
+				},
+				FAMILY,
+			);
+			expect(entry.id).toMatch(/^[0-9a-f-]{36}$/);
+			expect(entry.value).toBe(i * 10);
+		}
+		const recent = await statusRepo.findRecentStatusHistory(childId, catId, FAMILY);
+		expect(recent).toHaveLength(7); // 既定 limit
+		expect(recent[0]?.value).toBe(90); // 新しい順
+		const limited = await statusRepo.findRecentStatusHistory(childId, catId, FAMILY, 2);
+		expect(limited.map((e) => e.value)).toEqual([90, 80]);
+	});
+
+	it('[S4] findStatusValueAtDate: 指定日前の最新値 / 該当なし null', async () => {
+		const childId = await newChild('時点四郎');
+		const catId = asCategoryId('social');
+		await t.db.execute(sql`
+			INSERT INTO status_history (family_id, child_id, category_id, value, change_amount, change_type, recorded_at)
+			VALUES
+				(${FAMILY}, ${String(childId)}, 'social', 10, 10, 'activity_record', '2026-01-05T00:00:00Z'),
+				(${FAMILY}, ${String(childId)}, 'social', 25, 15, 'activity_record', '2026-02-05T00:00:00Z')
+		`);
+		expect(await statusRepo.findStatusValueAtDate(childId, catId, '2026-02-01', FAMILY)).toBe(10);
+		expect(await statusRepo.findStatusValueAtDate(childId, catId, '2026-03-01', FAMILY)).toBe(25);
+		expect(await statusRepo.findStatusValueAtDate(childId, catId, '2025-12-01', FAMILY)).toBe(null);
+	});
+
+	it('[S5] benchmark upsert/find: グローバル master (tenant 非依存、sqlite parity)', async () => {
+		const catId = asCategoryId('exercise');
+		const created = await statusRepo.upsertBenchmark(8, catId, 50, 10, 'survey-2026', FAMILY);
+		expect(created.age).toBe(8);
+		expect(created.categoryId).toBe(catId);
+		expect(created.mean).toBe(50);
+		expect(created.stdDev).toBe(10);
+		expect(created.source).toBe('survey-2026');
+
+		// 同 (age, category) への upsert は update (重複行を作らない)
+		const updated = await statusRepo.upsertBenchmark(8, catId, 55, 12, 'survey-2027', FAMILY);
+		expect(updated.mean).toBe(55);
+
+		// グローバル master: tenant を跨いで同じものが見える
+		const fromOther = await statusRepo.findBenchmark(8, catId, OTHER_FAMILY);
+		expect(fromOther?.mean).toBe(55);
+
+		await statusRepo.upsertBenchmark(6, asCategoryId('study'), 30, 5, 's', FAMILY);
+		const all = await statusRepo.findAllBenchmarks(FAMILY);
+		expect(all.length).toBeGreaterThanOrEqual(2);
+		// (age, category) 昇順 (sqlite parity)
+		const ages = all.map((b) => b.age);
+		expect(ages).toEqual([...ages].sort((a, b) => a - b));
+	});
+
+	it('[S6] findLastActivityDates: activityId keyed (既存命名の歪み parity) + cancelled 除外', async () => {
+		const childId = await newChild('活動五郎');
+		const id = String(childId);
+		const act = await t.db.execute(sql`
+			INSERT INTO child_activities (family_id, child_id, name, category_id, icon)
+			VALUES (${FAMILY}, ${id}, 'うんどう', 'exercise', '🏃') RETURNING activity_id
+		`);
+		const activityId = (act.rows[0] as { activity_id: string }).activity_id;
+		await t.db.execute(sql`
+			INSERT INTO activity_logs (family_id, child_id, activity_id, points, recorded_date, recorded_at, cancelled)
+			VALUES
+				(${FAMILY}, ${id}, ${activityId}, 10, '2026-06-01', now(), false),
+				(${FAMILY}, ${id}, ${activityId}, 10, '2026-06-10', now(), false),
+				(${FAMILY}, ${id}, ${activityId}, 10, '2026-06-20', now(), true)
+		`);
+		const dates = await statusRepo.findLastActivityDates(childId, FAMILY);
+		expect(dates).toHaveLength(1);
+		expect(dates[0]?.category).toBe(activityId); // uuid backend では activityId 文字列 keyed
+		expect(dates[0]?.lastDate).toBe('2026-06-10'); // cancelled=true は除外
+		expect(await statusRepo.findLastActivityDates(childId, OTHER_FAMILY)).toEqual([]);
+	});
+
+	it('[S7] deleteByTenantId: statuses/status_history 削除、benchmarks は survive', async () => {
+		const mine = await newChild('状態六郎', OTHER_FAMILY);
+		await statusRepo.upsertStatus(mine, asCategoryId('creative'), 10, 1, 10, OTHER_FAMILY);
+		await statusRepo.insertStatusHistory(
+			{
+				childId: mine,
+				categoryId: asCategoryId('creative'),
+				value: 10,
+				changeAmount: 10,
+				changeType: 'x',
+			},
+			OTHER_FAMILY,
+		);
+		const keep = await newChild('状態七郎');
+		await statusRepo.upsertStatus(keep, asCategoryId('creative'), 20, 1, 20, FAMILY);
+
+		await statusRepo.deleteByTenantId(OTHER_FAMILY);
+
+		expect(await statusRepo.findStatuses(mine, OTHER_FAMILY)).toEqual([]);
+		const hist = await t.db.execute(
+			sql`SELECT count(*) AS c FROM status_history WHERE family_id = ${OTHER_FAMILY}`,
+		);
+		expect(Number((hist.rows[0] as { c: unknown }).c)).toBe(0);
+		expect((await statusRepo.findStatuses(keep, FAMILY)).length).toBe(1); // 他 tenant 無傷
+		// グローバル master は削除しない (sqlite parity)
+		expect((await statusRepo.findAllBenchmarks(FAMILY)).length).toBeGreaterThanOrEqual(2);
+	});
+});

--- a/tests/unit/db/pk-freeze-manifest.test.ts
+++ b/tests/unit/db/pk-freeze-manifest.test.ts
@@ -108,15 +108,16 @@ describe('fitness#9: PK 凍結 manifest (§11.2 / §P1 不可逆不変条件)', 
 		const { PgTable, getTableConfig } = await import('drizzle-orm/pg-core');
 		const { is, getTableName } = await import('drizzle-orm');
 		const dsqlSchema = await import('../../../src/lib/server/db/dsql/schema');
-		const { PK_FREEZE_MANIFEST, AUTH_PK_MANIFEST } = await import(
+		const { PK_FREEZE_MANIFEST, AUTH_PK_MANIFEST, GLOBAL_MASTER_PK_MANIFEST } = await import(
 			'../../../src/lib/server/db/pk-freeze-manifest'
 		);
-		// テナント表 (§11.2) + auth 5 表 (§6.6、#3528) の union。schema に存在する全表が
-		// いずれかの manifest に凍結宣言を持つこと。
-		const manifest = { ...PK_FREEZE_MANIFEST, ...AUTH_PK_MANIFEST } as Record<
-			string,
-			readonly string[]
-		>;
+		// テナント表 (§11.2) + auth 5 表 (§6.6、#3528) + グローバル master (§11.2 例外、#3424 PR-R4)
+		// の union。schema に存在する全表がいずれかの manifest に凍結宣言を持つこと。
+		const manifest = {
+			...PK_FREEZE_MANIFEST,
+			...AUTH_PK_MANIFEST,
+			...GLOBAL_MASTER_PK_MANIFEST,
+		} as Record<string, readonly string[]>;
 
 		// dsql/schema.ts に実装された全 pg 表を走査 (表追記時に本テスト変更なしで自動カバー)。
 		// filter 後に cast することで、各 export の具体的な PgTableWithColumns<{name:"..."}>


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管 repo 層第 4 弾 = ポイント・ステータス集約）

**解決する課題**: ポイント台帳（point_ledger + total_point 派生列）とステータス（statuses / status_history）の DSQL repo が無く、§5 P7 の不変条件（total_point == SUM(ledger)）を保つ CRUD 経路が hot path（record-activity-core、実装済）以外に存在しなかった。また retention 削除（#729）と P7 の両立方法が設計書に未明文だった。

**期待される効果**: ポイント book / 消費 / retention 削除 / ステータス XP の全操作が fitness#14 の不変条件を保ったまま DSQL で動作する。retention × P7 の両立解（carryover 繰越）が設計書 §8 に明文化される。

## 関連 Issue

- EPIC #3424（§12.2.1 build order PR-2 系。activity 系 = PR #3590 と並行実装、対象 file 完全独立）
- related: #729（retention「ポイントは消えず過去明細だけが消える」契約 — 本 PR の carryover が DSQL での両立解）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | IPointRepo / IStatusRepo の全メソッド DSQL 実装（factory 注入 = fitness#8、§P9 述語、branded id） | `npx vitest run tests/unit/db/dsql-point-status-repos.test.ts` | HEAD `b641d70d` / **19 passed**。**red 実測: import 解決不能 fail → green**（commit message 記録）。本体独立再検証: db+architecture 655/655 + svelte-check 7676 files 0 errors |
| AC2 | **§5 P7 / fitness#14**: ledger への book（insertPointEntry / spendPointsAtomic）は同一 txn で children.total_point を共更新。child 不在は throw + rollback（片肺書込禁止）。getBalance は total_point 単読（SUM 再計算しない） | test（毎所 `findTotalPointDrift() == []` assert + 列 skew テストで SUM 非依存を直接証明） | HEAD `b641d70d` / pass |
| AC3 | **retention × P7 の両立（carryover）**: deletePointLedgerBeforeDate は削除合算を `type='carryover'` 繰越エントリとして同一 txn 挿入（SUM 不変 = total_point 不変。#729 契約と fitness#14 を同時充足する唯一解）。設計書 §8 に明文化（本 PR 同梱、ADR-0001） | test + `docs/design/dsql-data-model.md` diff | HEAD `b641d70d` / pass |
| AC4 | statuses upsert / XP 加算 / status_history append（sqlite parity の返り値 shape） | test | HEAD `b641d70d` / pass |
| AC5 | market_benchmarks（グローバル master、自然キー PK (age, category_id) = §11.2 L131/L403 記載どおり）の schema 追記 + GLOBAL_MASTER_PK_MANIFEST 新設で fitness#9 [3] 全表走査の union を拡張（**走査の迂回なし** — schema 全表がいずれかの manifest に凍結宣言を持つ検査は維持、global master の PK 値も schema 突合対象） | `npx vitest run tests/unit/db/pk-freeze-manifest.test.ts` | HEAD `b641d70d` / 4 passed。§11.2 記載との一致は本体セッションが手動照合済 |
| AC6 | fitness#7（txn work は tx.execute inline のみ、helper 閉包なし） | `npx vitest run tests/unit/architecture/` | HEAD `b641d70d` / 54 passed |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)（dsql/point-repo.ts + status-repo.ts 新設、schema.ts に market_benchmarks 追記、child-repo.ts の CHILD_COLUMNS/toChild を export 化（共有、二重管理禁止））
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（新設 + export 化のみ、DATA_SOURCE dispatch 未結線）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: dsql-point-status-repos.test.ts 19 本新設（drift ゼロ assert / total_point 列 skew による SUM 非依存証明 / carryover round-trip）。pk-freeze-manifest.test.ts は union 拡張（検査対象の拡張であり弱体化なし）
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（未変更）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）**: server 側 repo 新設のみで UI 変更なし（.svelte 変更 0 file）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: interface 契約無変更で backend 追加（OCP、findLastActivityDates の widening `number | string` のみ = 拡大方向で既存 caller 無影響・消費者 0 件 grep 済）
- [x] **DRY**: children の row mapping は child-repo.ts の toChild/CHILD_COLUMNS を export 共有（二重実装排除）。hot path（record-activity-core / grant-optional-points）と重複なし
- [x] **YAGNI**: dispatch 結線なし
- [x] **Security（OSS 公開前提）**: §P9 述語 + 片肺書込の throw/rollback（残高改ざんに繋がる不整合を DB レベルで防止）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: getBalance は total_point 単読（§5 compute-on-write の狙い通り、SUM スキャン排除）。market_benchmarks は自然キー単点 lookup（H4 の N+1 は repo 結線時の read-plan §3.5.5 で扱う）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): carryover 設計を §8 に追記（本 PR 同梱）。market_benchmarks は §11.2 既記載
- [x] **並行 PR overlap** (#1200): PR #3590（activity 系）と worktree 分離で並行実装、対象 file 完全独立（child-repo.ts の export 化は本 PR のみが触る）、merge 順不問
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新設 + export 化 + interface widening のみ）

**レビュー依頼事項・QA（判断ポイント）**:
- **carryover 方式の妥当性**（AC3。#729 契約 × fitness#14 の両立解として繰越エントリを採用。`type='carryover'` はポイント履歴に「繰越」1 行として現れ得る — 履歴 UI の type 別 label 消費箇所はゼロを grep 確認済みだが、cutover 後の履歴表示で違和感がないか PO 目線の確認を推奨）
- Status.id / MarketBenchmark.id の合成文字列（`child:category` / `age:category`。surrogate 列なし §4、id を lookup key に使う消費者 0 件確認済 — PR #3590 と同判断）
- findLastActivityDates の `category: number | string` widening（DSQL の activity_id が uuid のため。命名の歪み（実体 activityId keyed）は既存 parity 維持）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（Agent 実装を本体セッションが独立再検証 655/655 + svelte-check 0、carryover 設計と manifest 拡張の迂回なしを個別レビュー）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: child-cluster repo は activity（#3590）/ point+status（本 PR）/ stamp・checklist・残り（次サイクル）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
