### PR TITLE
feat: #3424 PR-R5 — DSQL IActivityRepo 実装 (activity_logs + 集計 SQL 1 クエリ化)

### DIFF
--- a/src/lib/server/db/dsql/activity-repo.ts
+++ b/src/lib/server/db/dsql/activity-repo.ts
@@ -1,0 +1,600 @@
+// src/lib/server/db/dsql/activity-repo.ts
+// EPIC #3424 / PR-R5 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §11.2 / §3.5.5 / §5(P7) / §P9
+//
+// IActivityRepo (activities + activity_logs) の DSQL backend 実装。設計契約:
+//   - **factory 注入** (fitness#8: module-level db/client import 禁止)。
+//   - **§P9 tenant 述語**: 全メソッドが family_id = tenantId を WHERE に含む。JOIN も
+//     family_id / child_id を結合条件に含め cross-tenant / cross-child 行の結合を構造的に防ぐ。
+//   - **Activity shape adapter parity**: sqlite facade (#2458-A1 `_toActivityShape`) と同一 —
+//     child_activities 行を Activity shape で返し、差分 field (ageMin/ageMax/gradeLevel/
+//     subcategory/description) は null 埋め。boolean 列は 0/1 数値契約に変換。
+//   - **record 系 hot path は record-activity-core.ts が正** (§8 単一 txn)。本 repo の
+//     insertActivityLog / markActivityLogCancelled は sqlite parity の単文 primitive
+//     (service 合成用) であり、5 表複合書込は重複実装しない。
+//   - **insertPointLedger は §5 P7 不変条件に従い** point_ledger INSERT + children.total_point
+//     共更新を同一 txn で行う (sqlite の単文 insert とは設計差分 — fitness#14 findTotalPointDrift
+//     が突合する DSQL 側の必須契約。point-repo.insertPointEntry と同判断で child 不在は throw
+//     して rollback、recorded_date は todayDateJST で導出)。txn work 内の await は tx.execute
+//     直呼びのみ (fitness#7)。
+//   - **集計は SQL 集計 1 クエリ** (§3.5.5: 1 接続逐次 await の N+1 を repo が自ら作らない)。
+//     findMustActivitiesWithToday も sqlite の 2 クエリ + app 側 Set 合成ではなく LEFT JOIN
+//     1 クエリで集計する。
+//   - countPointLedgerEntriesByTypeAndDate は recorded_date 列で冪等 lookup (§11.2 H21 —
+//     spike#7 採用の secondary (family,child,type,recorded_date) が covering)。
+//   - insertActivity の「tenant 先頭 child bind」は sqlite facade parity (#2458-A1)。DSQL は
+//     integer autoincrement が無いため created_at, child_id で先頭を決定する。
+
+import { sql } from 'drizzle-orm';
+import { todayDateJST } from '$lib/domain/date-utils';
+import { type ActivityId, asActivityId, asCategoryId, asChildId } from '$lib/domain/ids';
+import type { IActivityRepo } from '../interfaces/activity-repo.interface';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type { Activity, ActivityLog, ActivityLogSummary, ActivityPriority } from '../types';
+import { createDsqlChildRepo } from './child-repo';
+import type { SqlExecutor } from './sql-executor';
+
+interface ActivityRow {
+	activity_id: string;
+	child_id: string;
+	name: string;
+	category_id: string;
+	icon: string;
+	base_points: number;
+	is_visible: boolean;
+	daily_limit: number | null;
+	sort_order: number;
+	source: string;
+	name_kana: string | null;
+	name_kanji: string | null;
+	trigger_hint: string | null;
+	is_main_quest: boolean;
+	is_archived: boolean;
+	archived_reason: string | null;
+	source_preset_id: string | null;
+	priority: string;
+	created_at: string;
+}
+
+interface LogRow {
+	log_id: string;
+	child_id: string;
+	activity_id: string;
+	points: number;
+	streak_days: number;
+	streak_bonus: number;
+	recorded_date: string;
+	recorded_at: string;
+	cancelled: boolean;
+}
+
+const ACTIVITY_COLUMNS = sql.raw(
+	`activity_id, child_id, name, category_id, icon, base_points, is_visible, daily_limit,
+	 sort_order, source, name_kana, name_kanji, trigger_hint, is_main_quest, is_archived,
+	 archived_reason, source_preset_id, priority, created_at`,
+);
+
+const LOG_COLUMNS = sql.raw(
+	`log_id, child_id, activity_id, points, streak_days, streak_bonus, recorded_date,
+	 recorded_at, cancelled`,
+);
+
+/** 非 archived 述語 (DSQL は is_archived NOT NULL boolean のため NULL 互換分岐は不要)。 */
+const NOT_ARCHIVED = sql.raw('is_archived = false');
+
+/** row → Activity shape (sqlite `_toActivityShape` adapter parity、差分 field は null 埋め)。 */
+function toActivityShape(row: ActivityRow): Activity {
+	return {
+		id: asActivityId(row.activity_id),
+		name: row.name,
+		categoryId: asCategoryId(row.category_id),
+		icon: row.icon,
+		basePoints: row.base_points,
+		ageMin: null, // ChildActivity は per-child instance のため age filter なし (ADR-0055)
+		ageMax: null,
+		isVisible: row.is_visible ? 1 : 0,
+		dailyLimit: row.daily_limit,
+		sortOrder: row.sort_order,
+		source: row.source,
+		gradeLevel: null,
+		subcategory: null,
+		description: null,
+		nameKana: row.name_kana,
+		nameKanji: row.name_kanji,
+		triggerHint: row.trigger_hint,
+		isMainQuest: row.is_main_quest ? 1 : 0,
+		isArchived: row.is_archived ? 1 : 0,
+		archivedReason: row.archived_reason,
+		createdAt: row.created_at,
+		sourcePresetId: row.source_preset_id,
+		priority: row.priority as ActivityPriority,
+	};
+}
+
+/** row → ActivityLog entity (boolean → 0/1 数値契約 = sqlite 互換 shape)。 */
+function toActivityLog(row: LogRow): ActivityLog {
+	return {
+		id: row.log_id,
+		childId: asChildId(row.child_id),
+		activityId: asActivityId(row.activity_id),
+		points: row.points,
+		streakDays: row.streak_days,
+		streakBonus: row.streak_bonus,
+		recordedDate: row.recorded_date,
+		recordedAt: row.recorded_at,
+		cancelled: row.cancelled ? 1 : 0,
+	};
+}
+
+/** count 系クエリの単値取得 (PGlite/pg の bigint 文字列化を Number で正規化)。 */
+function scalarCount(result: { rows: unknown[] }): number {
+	return Number((result.rows[0] as { c: unknown } | undefined)?.c ?? 0);
+}
+
+/** DSQL 用 IActivityRepo を生成する (db/runner は注入、fitness#8)。 */
+export function createDsqlActivityRepo<TTx extends SqlExecutor>(
+	db: SqlExecutor,
+	runner: TransactionRunner<TTx>,
+): IActivityRepo {
+	// findChildById convenience は child-repo の compute-on-read 契約 (§11.1) へ委譲する。
+	const childRepo = createDsqlChildRepo(db, runner);
+
+	const findActivityById = async (id: ActivityId, tenantId: string) => {
+		const result = await db.execute(sql`
+			SELECT ${ACTIVITY_COLUMNS} FROM child_activities
+			WHERE family_id = ${tenantId} AND activity_id = ${id}
+		`);
+		const row = result.rows[0] as unknown as ActivityRow | undefined;
+		return row ? toActivityShape(row) : undefined;
+	};
+
+	return {
+		// ── Activities (CRUD、Activity shape adapter) ──
+
+		async findActivities(tenantId, filter) {
+			const conditions = [sql`family_id = ${tenantId}`, sql`${NOT_ARCHIVED}`];
+			if (filter?.categoryId) conditions.push(sql`category_id = ${filter.categoryId}`);
+			if (!filter?.includeHidden) conditions.push(sql`is_visible = true`);
+			// NOTE: filter.childAge は per-child instance では非適用 (sqlite facade parity、ADR-0055)。
+			const result = await db.execute(sql`
+				SELECT ${ACTIVITY_COLUMNS} FROM child_activities
+				WHERE ${sql.join(conditions, sql` AND `)}
+				ORDER BY sort_order, created_at, activity_id
+			`);
+			return (result.rows as unknown as ActivityRow[]).map(toActivityShape);
+		},
+
+		findActivityById,
+
+		async insertActivity(input, tenantId) {
+			// sqlite facade parity (#2458-A1): tenant 先頭 child に bind。ageMin/ageMax は
+			// per-child instance に存在しないため drop (ADR-0055)。
+			const firstChild = await db.execute(sql`
+				SELECT child_id FROM children WHERE family_id = ${tenantId}
+				ORDER BY created_at, child_id LIMIT 1
+			`);
+			const child = firstChild.rows[0] as { child_id: string } | undefined;
+			if (!child) {
+				throw new Error('insertActivity: tenant に child が存在しないため作成不可');
+			}
+			const result = await db.execute(sql`
+				INSERT INTO child_activities
+					(family_id, child_id, name, category_id, icon, base_points, trigger_hint,
+					 is_main_quest, source_preset_id, priority)
+				VALUES (${tenantId}, ${child.child_id}, ${input.name}, ${input.categoryId},
+					${input.icon}, ${input.basePoints}, ${input.triggerHint ?? null},
+					${(input.isMainQuest ?? 0) !== 0}, ${input.sourcePresetId ?? null},
+					${input.priority ?? 'optional'})
+				RETURNING ${ACTIVITY_COLUMNS}
+			`);
+			return toActivityShape(result.rows[0] as unknown as ActivityRow);
+		},
+
+		async updateActivity(id, input, tenantId) {
+			// ChildActivity に存在しない field (ageMin/ageMax) は drop (sqlite facade parity)。
+			const sets: ReturnType<typeof sql>[] = [];
+			if (input.name !== undefined) sets.push(sql`name = ${input.name}`);
+			if (input.categoryId !== undefined) sets.push(sql`category_id = ${input.categoryId}`);
+			if (input.icon !== undefined) sets.push(sql`icon = ${input.icon}`);
+			if (input.basePoints !== undefined) sets.push(sql`base_points = ${input.basePoints}`);
+			if (input.triggerHint !== undefined) sets.push(sql`trigger_hint = ${input.triggerHint}`);
+			if (input.isMainQuest !== undefined)
+				sets.push(sql`is_main_quest = ${input.isMainQuest !== 0}`);
+			if (input.priority !== undefined) sets.push(sql`priority = ${input.priority}`);
+			if (sets.length === 0) return findActivityById(id, tenantId); // no-op は既存行返却
+			const result = await db.execute(sql`
+				UPDATE child_activities SET ${sql.join(sets, sql`, `)}
+				WHERE family_id = ${tenantId} AND activity_id = ${id}
+				RETURNING ${ACTIVITY_COLUMNS}
+			`);
+			const row = result.rows[0] as unknown as ActivityRow | undefined;
+			return row ? toActivityShape(row) : undefined;
+		},
+
+		async setActivityVisibility(id, visible, tenantId) {
+			const result = await db.execute(sql`
+				UPDATE child_activities SET is_visible = ${visible}
+				WHERE family_id = ${tenantId} AND activity_id = ${id}
+				RETURNING ${ACTIVITY_COLUMNS}
+			`);
+			const row = result.rows[0] as unknown as ActivityRow | undefined;
+			return row ? toActivityShape(row) : undefined;
+		},
+
+		async deleteActivity(id, tenantId) {
+			const result = await db.execute(sql`
+				DELETE FROM child_activities
+				WHERE family_id = ${tenantId} AND activity_id = ${id}
+				RETURNING ${ACTIVITY_COLUMNS}
+			`);
+			const row = result.rows[0] as unknown as ActivityRow | undefined;
+			return row ? toActivityShape(row) : undefined;
+		},
+
+		async hasActivityLogs(activityId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT count(*)::int AS c FROM activity_logs
+				WHERE family_id = ${tenantId} AND activity_id = ${activityId}
+			`);
+			return scalarCount(result) > 0;
+		},
+
+		async getActivityLogCounts(tenantId) {
+			const result = await db.execute(sql`
+				SELECT activity_id, count(*)::int AS c FROM activity_logs
+				WHERE family_id = ${tenantId} AND cancelled = false
+				GROUP BY activity_id
+			`);
+			const counts: Record<string, number> = {};
+			for (const row of result.rows as { activity_id: string; c: number }[]) {
+				counts[row.activity_id] = Number(row.c);
+			}
+			return counts;
+		},
+
+		async countMainQuestActivities(tenantId) {
+			const result = await db.execute(sql`
+				SELECT count(*)::int AS c FROM child_activities
+				WHERE family_id = ${tenantId}
+					AND is_main_quest = true AND is_visible = true AND ${NOT_ARCHIVED}
+			`);
+			return scalarCount(result);
+		},
+
+		async deleteDailyMissionsByActivity(activityId, tenantId) {
+			await db.execute(sql`
+				DELETE FROM daily_missions
+				WHERE family_id = ${tenantId} AND activity_id = ${activityId}
+			`);
+		},
+
+		// ── Children (convenience) ──
+
+		async findChildById(id, tenantId) {
+			return childRepo.findChildById(id, tenantId);
+		},
+
+		// ── Activity Logs ──
+
+		async findDailyLog(childId, activityId, date, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${LOG_COLUMNS} FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND activity_id = ${activityId} AND recorded_date = ${date} AND cancelled = false
+				LIMIT 1
+			`);
+			const row = result.rows[0] as unknown as LogRow | undefined;
+			return row ? toActivityLog(row) : undefined;
+		},
+
+		async findStreakLogs(childId, activityId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT recorded_date FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND activity_id = ${activityId} AND cancelled = false
+				ORDER BY recorded_date DESC
+			`);
+			return (result.rows as { recorded_date: string }[]).map((r) => ({
+				recordedDate: r.recorded_date,
+			}));
+		},
+
+		async insertActivityLog(input, tenantId) {
+			// 単文 primitive (sqlite parity)。record hot path の 5 表複合書込は
+			// record-activity-core.ts (§8 単一 txn) が正 — ここでは重複実装しない。
+			const result = await db.execute(sql`
+				INSERT INTO activity_logs
+					(family_id, child_id, activity_id, points, streak_days, streak_bonus,
+					 recorded_date, recorded_at)
+				VALUES (${tenantId}, ${input.childId}, ${input.activityId}, ${input.points},
+					${input.streakDays}, ${input.streakBonus}, ${input.recordedDate}, ${input.recordedAt})
+				RETURNING ${LOG_COLUMNS}
+			`);
+			return toActivityLog(result.rows[0] as unknown as LogRow);
+		},
+
+		async findActivityLogById(id, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${LOG_COLUMNS} FROM activity_logs
+				WHERE family_id = ${tenantId} AND log_id = ${id}
+			`);
+			const row = result.rows[0] as unknown as LogRow | undefined;
+			return row ? toActivityLog(row) : undefined;
+		},
+
+		async markActivityLogCancelled(id, tenantId) {
+			await db.execute(sql`
+				UPDATE activity_logs SET cancelled = true
+				WHERE family_id = ${tenantId} AND log_id = ${id}
+			`);
+		},
+
+		async findActivityLogs(childId, tenantId, options = {}) {
+			const conditions = [
+				sql`al.family_id = ${tenantId}`,
+				sql`al.child_id = ${childId}`,
+				sql`al.cancelled = false`,
+			];
+			if (options.from) conditions.push(sql`al.recorded_date >= ${options.from}`);
+			if (options.to) conditions.push(sql`al.recorded_date <= ${options.to}`);
+			const result = await db.execute(sql`
+				SELECT al.log_id, ca.name, ca.icon, ca.category_id, al.points, al.streak_days,
+					al.streak_bonus, al.recorded_at
+				FROM activity_logs al
+				INNER JOIN child_activities ca
+					ON ca.family_id = al.family_id AND ca.child_id = al.child_id
+					AND ca.activity_id = al.activity_id
+				WHERE ${sql.join(conditions, sql` AND `)}
+				ORDER BY al.recorded_at DESC
+			`);
+			return (
+				result.rows as {
+					log_id: string;
+					name: string;
+					icon: string;
+					category_id: string;
+					points: number;
+					streak_days: number;
+					streak_bonus: number;
+					recorded_at: string;
+				}[]
+			).map(
+				(r): ActivityLogSummary => ({
+					id: r.log_id,
+					activityName: r.name,
+					activityIcon: r.icon,
+					categoryId: asCategoryId(r.category_id),
+					points: r.points,
+					streakDays: r.streak_days,
+					streakBonus: r.streak_bonus,
+					recordedAt: r.recorded_at,
+				}),
+			);
+		},
+
+		async countTodayActiveRecords(childId, activityId, date, tenantId) {
+			const result = await db.execute(sql`
+				SELECT count(*)::int AS c FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND activity_id = ${activityId} AND recorded_date = ${date} AND cancelled = false
+			`);
+			return scalarCount(result);
+		},
+
+		async getTodayActivityCountsByChild(childId, date, tenantId) {
+			const result = await db.execute(sql`
+				SELECT activity_id, count(*)::int AS c FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND recorded_date = ${date} AND cancelled = false
+				GROUP BY activity_id
+			`);
+			return (result.rows as { activity_id: string; c: number }[]).map((r) => ({
+				activityId: asActivityId(r.activity_id),
+				count: Number(r.c),
+			}));
+		},
+
+		async findTodayRecordedActivityIds(childId, today, tenantId) {
+			const result = await db.execute(sql`
+				SELECT DISTINCT activity_id FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND recorded_date = ${today} AND cancelled = false
+			`);
+			return (result.rows as { activity_id: string }[]).map((r) => asActivityId(r.activity_id));
+		},
+
+		// ── Aggregation queries (SQL 集計 1 クエリ、§3.5.5) ──
+
+		async findDistinctRecordedDates(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT recorded_date FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND cancelled = false
+				GROUP BY recorded_date
+				ORDER BY recorded_date
+			`);
+			return (result.rows as { recorded_date: string }[]).map((r) => ({
+				recordedDate: r.recorded_date,
+			}));
+		},
+
+		async countActiveActivityLogs(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT count(*)::int AS c FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND cancelled = false
+			`);
+			return scalarCount(result);
+		},
+
+		async getCategoryCountsByDate(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT al.recorded_date, count(DISTINCT ca.category_id)::int AS c
+				FROM activity_logs al
+				INNER JOIN child_activities ca
+					ON ca.family_id = al.family_id AND ca.child_id = al.child_id
+					AND ca.activity_id = al.activity_id
+				WHERE al.family_id = ${tenantId} AND al.child_id = ${childId} AND al.cancelled = false
+				GROUP BY al.recorded_date
+			`);
+			return (result.rows as { recorded_date: string; c: number }[]).map((r) => ({
+				recordedDate: r.recorded_date,
+				categoryCount: Number(r.c),
+			}));
+		},
+
+		async countDistinctCategories(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT count(DISTINCT ca.category_id)::int AS c
+				FROM activity_logs al
+				INNER JOIN child_activities ca
+					ON ca.family_id = al.family_id AND ca.child_id = al.child_id
+					AND ca.activity_id = al.activity_id
+				WHERE al.family_id = ${tenantId} AND al.child_id = ${childId} AND al.cancelled = false
+			`);
+			return scalarCount(result);
+		},
+
+		async findTodayLogsWithCategory(childId, date, tenantId) {
+			const result = await db.execute(sql`
+				SELECT al.activity_id, ca.category_id
+				FROM activity_logs al
+				INNER JOIN child_activities ca
+					ON ca.family_id = al.family_id AND ca.child_id = al.child_id
+					AND ca.activity_id = al.activity_id
+				WHERE al.family_id = ${tenantId} AND al.child_id = ${childId}
+					AND al.recorded_date = ${date} AND al.cancelled = false
+			`);
+			return (result.rows as { activity_id: string; category_id: string }[]).map((r) => ({
+				activityId: asActivityId(r.activity_id),
+				categoryId: asCategoryId(r.category_id),
+			}));
+		},
+
+		async getComboPointsGranted(childId, descriptionPrefix, tenantId) {
+			const result = await db.execute(sql`
+				SELECT coalesce(sum(amount), 0)::int AS c FROM point_ledger
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND type = 'combo_bonus' AND description LIKE ${`${descriptionPrefix}%`}
+			`);
+			return scalarCount(result);
+		},
+
+		async countActiveActivityLogsByCategory(childId, categoryId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT count(*)::int AS c
+				FROM activity_logs al
+				INNER JOIN child_activities ca
+					ON ca.family_id = al.family_id AND ca.child_id = al.child_id
+					AND ca.activity_id = al.activity_id
+				WHERE al.family_id = ${tenantId} AND al.child_id = ${childId}
+					AND al.cancelled = false AND ca.category_id = ${categoryId}
+			`);
+			return scalarCount(result);
+		},
+
+		async countPointLedgerEntriesByType(childId, type, tenantId) {
+			const result = await db.execute(sql`
+				SELECT count(*)::int AS c FROM point_ledger
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND type = ${type}
+			`);
+			return scalarCount(result);
+		},
+
+		async countPointLedgerEntriesByTypeAndDate(childId, type, date, tenantId) {
+			// recorded_date 冪等 lookup (§11.2 H21、secondary (family,child,type,recorded_date) covering)。
+			const result = await db.execute(sql`
+				SELECT count(*)::int AS c FROM point_ledger
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND type = ${type} AND recorded_date = ${date}
+			`);
+			return scalarCount(result);
+		},
+
+		async findMustActivitiesWithToday(childId, today, tenantId) {
+			// LEFT JOIN 1 クエリ集計 (§3.5.5 — sqlite の 2 クエリ + app 側 Set 合成にしない)。
+			// GROUP BY は PK (family,child,activity) で functional dependency 充足だが、
+			// 非集約選択列を明示して方言差の解釈余地を残さない。
+			const result = await db.execute(sql`
+				SELECT ca.activity_id, ca.name, ca.icon,
+					CASE WHEN count(al.log_id) > 0 THEN 1 ELSE 0 END AS logged_today
+				FROM child_activities ca
+				LEFT JOIN activity_logs al
+					ON al.family_id = ca.family_id AND al.child_id = ca.child_id
+					AND al.activity_id = ca.activity_id
+					AND al.recorded_date = ${today} AND al.cancelled = false
+				WHERE ca.family_id = ${tenantId} AND ca.child_id = ${childId}
+					AND ca.priority = 'must' AND ca.is_visible = true AND ca.is_archived = false
+				GROUP BY ca.activity_id, ca.name, ca.icon, ca.sort_order, ca.created_at
+				ORDER BY ca.sort_order, ca.created_at, ca.activity_id
+			`);
+			const activities = (
+				result.rows as { activity_id: string; name: string; icon: string; logged_today: number }[]
+			).map((r) => ({
+				id: asActivityId(r.activity_id),
+				name: r.name,
+				icon: r.icon,
+				loggedToday: Number(r.logged_today),
+			}));
+			return {
+				logged: activities.filter((a) => a.loggedToday === 1).length,
+				total: activities.length,
+				activities,
+			};
+		},
+
+		// ── archive / restore (#783) ──
+
+		async archiveActivities(ids, reason, tenantId) {
+			if (ids.length === 0) return;
+			await db.execute(sql`
+				UPDATE child_activities SET is_archived = true, archived_reason = ${reason}
+				WHERE family_id = ${tenantId} AND activity_id IN (${sql.join(
+					ids.map((id) => sql`${id}`),
+					sql`, `,
+				)})
+			`);
+		},
+
+		async restoreArchivedActivities(reason, tenantId) {
+			await db.execute(sql`
+				UPDATE child_activities SET is_archived = false, archived_reason = NULL
+				WHERE family_id = ${tenantId} AND is_archived = true AND archived_reason = ${reason}
+			`);
+		},
+
+		// ── Point Ledger ──
+
+		async insertPointLedger(input, tenantId) {
+			// §5 P7: ledger INSERT + children.total_point 共更新を同一 txn (fitness#14 乖離不能設計)。
+			// child 不在 = 共更新先が無いため throw で txn ごと rollback (point-repo と同判断)。
+			const recordedDate = todayDateJST();
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(sql`
+					INSERT INTO point_ledger
+						(family_id, child_id, amount, type, description, reference_id, recorded_date)
+					VALUES (${tenantId}, ${input.childId}, ${input.amount}, ${input.type},
+						${input.description}, ${input.referenceId ?? null}, ${recordedDate})
+				`);
+				const updated = await tx.execute(sql`
+					UPDATE children SET total_point = total_point + ${input.amount}, updated_at = now()
+					WHERE family_id = ${tenantId} AND child_id = ${input.childId}
+					RETURNING child_id
+				`);
+				if (updated.rows.length === 0) {
+					throw new Error(`insertPointLedger: child not found (${tenantId}/${input.childId})`);
+				}
+			});
+		},
+
+		// ── Retention cleanup (#717, #729) ──
+
+		async deleteActivityLogsBeforeDate(childId, cutoffDate, tenantId) {
+			// strict less than: cutoffDate 当日は削除対象に含まない (interface 契約)。
+			const result = await db.execute(sql`
+				DELETE FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND recorded_date < ${cutoffDate}
+				RETURNING log_id
+			`);
+			return result.rows.length;
+		},
+	};
+}

--- a/tests/unit/db/dsql-activity-log-repo.test.ts
+++ b/tests/unit/db/dsql-activity-log-repo.test.ts
@@ -1,0 +1,592 @@
+// tests/unit/db/dsql-activity-log-repo.test.ts
+// EPIC #3424 / PR-R5 / 設計 SSOT: dsql-data-model.md §11.2 / §3.5.5 / §5(P7) / §P9
+//
+// DSQL IActivityRepo (activities + activity_logs) 実装のテスト。実 schema (pushSchema 適用、
+// dsql-test-db helper)。観点:
+//
+// ── Activities (Activity shape adapter parity) ──
+//   [A1] findActivities: ChildActivity → Activity shape adapter parity (差分 field null 埋め、
+//        0/1 契約、sort_order 順、archived 既定除外、includeHidden / categoryId filter)
+//   [A2] findActivityById / updateActivity (部分更新 + 空 input no-op) / setActivityVisibility /
+//        deleteActivity round-trip、不在は undefined
+//   [A3] insertActivity: tenant 先頭 child bind (sqlite facade parity)、child 不在 tenant は throw
+//   [A4] countMainQuestActivities / archiveActivities / restoreArchivedActivities
+//   [A5] hasActivityLogs / getActivityLogCounts (cancelled 除外) / deleteDailyMissionsByActivity
+//
+// ── Activity Logs ──
+//   [L1] insertActivityLog → findDailyLog / findActivityLogById / countTodayActiveRecords /
+//        markActivityLogCancelled (cancelled 0/1 契約、cancel 後 findDailyLog 不可視)
+//   [L2] findActivityLogs: 日付 range (from/to) filter + cancelled 除外 + recorded_at 降順 +
+//        summary shape (activityName/activityIcon/categoryId) — JOIN 1 クエリ
+//   [L3] findStreakLogs (降順) / findTodayRecordedActivityIds / getTodayActivityCountsByChild
+//
+// ── Aggregation (SQL 集計 1 クエリ、app 側 loop 集計にしない §3.5.5) ──
+//   [G1] findDistinctRecordedDates (重複除去 昇順) / countActiveActivityLogs /
+//        getCategoryCountsByDate / countDistinctCategories / findTodayLogsWithCategory /
+//        countActiveActivityLogsByCategory
+//   [G2] getComboPointsGranted (description prefix) / countPointLedgerEntriesByType /
+//        countPointLedgerEntriesByTypeAndDate (recorded_date 冪等 lookup、§11.2 H21)
+//   [M1] findMustActivitiesWithToday: 単一 LEFT JOIN 集計の正値 (logged/total/loggedToday)
+//
+// ── 不変条件 ──
+//   [P1] insertPointLedger: §5 P7 — ledger INSERT + children.total_point 同一 txn 共更新
+//        (fitness#14 drift 0)、child 不在は throw + rollback
+//   [R1] deleteActivityLogsBeforeDate: strict less-than + 削除件数
+//   [T1] §P9 tenant 分離: 他 family から activities / logs / counts 不可視・write 不能
+
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	type ActivityId,
+	asActivityId,
+	asCategoryId,
+	asChildId,
+	type ChildId,
+} from '../../../src/lib/domain/ids';
+import { createDsqlActivityRepo } from '../../../src/lib/server/db/dsql/activity-repo';
+import { createDsqlChildRepo } from '../../../src/lib/server/db/dsql/child-repo';
+import { findTotalPointDrift } from '../../../src/lib/server/db/dsql/derived-drift';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import type { IActivityRepo } from '../../../src/lib/server/db/interfaces/activity-repo.interface';
+import type { IChildRepo } from '../../../src/lib/server/db/interfaces/child-repo.interface';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+const FAMILY = '00000000-0000-4000-8000-0000000000c1';
+const OTHER_FAMILY = '00000000-0000-4000-8000-0000000000c2';
+const EMPTY_FAMILY = '00000000-0000-4000-8000-0000000000c3';
+
+describe('DSQL activity-repo (PR-R5、実 schema PGlite)', () => {
+	let t: DsqlTestDb;
+	let childRepo: IChildRepo;
+	let repo: IActivityRepo;
+
+	const newChild = async (nickname: string, family = FAMILY): Promise<ChildId> => {
+		const c = await childRepo.insertChild({ nickname, age: 8, birthDate: '2018-01-15' }, family);
+		return c.id;
+	};
+
+	/** child_activities を直接 seed する (per-child bind をテストが制御するため)。 */
+	const seedActivity = async (
+		childId: ChildId,
+		opts: {
+			name?: string;
+			categoryId?: string;
+			icon?: string;
+			basePoints?: number;
+			priority?: 'must' | 'optional';
+			isMainQuest?: boolean;
+			isVisible?: boolean;
+			isArchived?: boolean;
+			sortOrder?: number;
+			family?: string;
+		} = {},
+	): Promise<ActivityId> => {
+		const result = await t.db.execute(sql`
+			INSERT INTO child_activities
+				(family_id, child_id, name, category_id, icon, base_points, priority, is_main_quest,
+				 is_visible, is_archived, sort_order)
+			VALUES (${opts.family ?? FAMILY}, ${String(childId)}, ${opts.name ?? 'かつどう'},
+				${opts.categoryId ?? 'exercise'}, ${opts.icon ?? '🏃'}, ${opts.basePoints ?? 5},
+				${opts.priority ?? 'optional'}, ${opts.isMainQuest ?? false}, ${opts.isVisible ?? true},
+				${opts.isArchived ?? false}, ${opts.sortOrder ?? 0})
+			RETURNING activity_id
+		`);
+		return asActivityId((result.rows[0] as { activity_id: string }).activity_id);
+	};
+
+	/** activity_logs を直接 seed する (recorded_at を決定的に制御するため)。 */
+	const seedLog = async (
+		childId: ChildId,
+		activityId: ActivityId,
+		opts: {
+			date: string;
+			points?: number;
+			cancelled?: boolean;
+			recordedAt?: string;
+			family?: string;
+		},
+	): Promise<string> => {
+		const result = await t.db.execute(sql`
+			INSERT INTO activity_logs
+				(family_id, child_id, activity_id, points, recorded_date, recorded_at, cancelled)
+			VALUES (${opts.family ?? FAMILY}, ${String(childId)}, ${String(activityId)},
+				${opts.points ?? 10}, ${opts.date}, ${opts.recordedAt ?? `${opts.date}T09:00:00Z`},
+				${opts.cancelled ?? false})
+			RETURNING log_id
+		`);
+		return (result.rows[0] as { log_id: string }).log_id;
+	};
+
+	beforeAll(async () => {
+		t = await createDsqlTestDb();
+		const runner = createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 });
+		childRepo = createDsqlChildRepo(t.db, runner);
+		repo = createDsqlActivityRepo(t.db, runner);
+	}, 60_000);
+	afterAll(async () => {
+		await t.close();
+	});
+
+	// ─────────────────── Activities (Activity shape adapter) ───────────────────
+
+	it('[A1] findActivities: Activity shape adapter parity + filter + sort', async () => {
+		const childId = await newChild('形状一郎');
+		await seedActivity(childId, { name: 'あとから', sortOrder: 2, categoryId: 'study' });
+		await seedActivity(childId, { name: 'さいしょ', sortOrder: 1 });
+		await seedActivity(childId, { name: 'かくれ', sortOrder: 3, isVisible: false });
+		await seedActivity(childId, { name: 'そうこ', sortOrder: 4, isArchived: true });
+
+		const visible = await repo.findActivities(FAMILY);
+		expect(visible.map((a) => a.name)).toEqual(['さいしょ', 'あとから']); // sort_order 順
+		const first = visible[0];
+		if (!first) throw new Error('unreachable');
+		// Activity shape adapter parity: 差分 field は null 埋め (sqlite _toActivityShape と同一)
+		expect(first.ageMin).toBe(null);
+		expect(first.ageMax).toBe(null);
+		expect(first.gradeLevel).toBe(null);
+		expect(first.subcategory).toBe(null);
+		expect(first.description).toBe(null);
+		expect(first.isVisible).toBe(1); // boolean → 0/1 契約
+		expect(first.isMainQuest).toBe(0);
+		expect(first.isArchived).toBe(0);
+		expect(first.categoryId).toBe(asCategoryId('exercise'));
+		expect(first.basePoints).toBe(5);
+		expect(typeof first.id).toBe('string');
+		expect(typeof first.createdAt).toBe('string');
+
+		// includeHidden で非表示も返る (archived は依然除外)
+		const withHidden = await repo.findActivities(FAMILY, { includeHidden: true });
+		expect(withHidden.map((a) => a.name)).toEqual(['さいしょ', 'あとから', 'かくれ']);
+		// categoryId filter
+		const study = await repo.findActivities(FAMILY, { categoryId: asCategoryId('study') });
+		expect(study.map((a) => a.name)).toEqual(['あとから']);
+	});
+
+	it('[A2] findActivityById / updateActivity / setActivityVisibility / deleteActivity', async () => {
+		const childId = await newChild('更新二郎');
+		const id = await seedActivity(childId, { name: 'へんしゅう', basePoints: 5 });
+
+		const found = await repo.findActivityById(id, FAMILY);
+		expect(found?.name).toBe('へんしゅう');
+
+		// 部分更新: 指定 field のみ変わる
+		const updated = await repo.updateActivity(
+			id,
+			{ name: 'かいてい', basePoints: 8, priority: 'must' },
+			FAMILY,
+		);
+		expect(updated?.name).toBe('かいてい');
+		expect(updated?.basePoints).toBe(8);
+		expect(updated?.priority).toBe('must');
+		expect(updated?.icon).toBe('🏃'); // 未指定 field は不変
+
+		// 空 input は no-op で既存行を返す (sqlite parity)
+		const noop = await repo.updateActivity(id, {}, FAMILY);
+		expect(noop?.name).toBe('かいてい');
+
+		const hidden = await repo.setActivityVisibility(id, false, FAMILY);
+		expect(hidden?.isVisible).toBe(0);
+
+		const deleted = await repo.deleteActivity(id, FAMILY);
+		expect(deleted?.name).toBe('かいてい');
+		expect(await repo.findActivityById(id, FAMILY)).toBeUndefined();
+
+		// 不在 id は undefined (throw しない)
+		const ghost = asActivityId('00000000-0000-4000-8000-00000000dead');
+		expect(await repo.updateActivity(ghost, { name: 'x' }, FAMILY)).toBeUndefined();
+		expect(await repo.setActivityVisibility(ghost, true, FAMILY)).toBeUndefined();
+		expect(await repo.deleteActivity(ghost, FAMILY)).toBeUndefined();
+	});
+
+	it('[A3] insertActivity: tenant 先頭 child bind + child 不在 tenant は throw', async () => {
+		// 専用 family (child 1 人) で bind 先を決定的にする
+		const soloFamily = '00000000-0000-4000-8000-0000000000c4';
+		const soloChild = await newChild('単独三郎', soloFamily);
+		const created = await repo.insertActivity(
+			{
+				name: 'しんき',
+				categoryId: asCategoryId('life'),
+				icon: '🧹',
+				basePoints: 7,
+				ageMin: null,
+				ageMax: null,
+				priority: 'must',
+				isMainQuest: 1,
+			},
+			soloFamily,
+		);
+		expect(created.name).toBe('しんき');
+		expect(created.basePoints).toBe(7);
+		expect(created.priority).toBe('must');
+		expect(created.isMainQuest).toBe(1);
+		// per-child instance として先頭 child に bind されている
+		const bound = await t.db.execute(sql`
+			SELECT child_id FROM child_activities
+			WHERE family_id = ${soloFamily} AND activity_id = ${String(created.id)}
+		`);
+		expect((bound.rows[0] as { child_id: string }).child_id).toBe(String(soloChild));
+
+		// child 不在 tenant は throw (sqlite parity)
+		await expect(
+			repo.insertActivity(
+				{
+					name: 'x',
+					categoryId: asCategoryId('life'),
+					icon: 'x',
+					basePoints: 1,
+					ageMin: null,
+					ageMax: null,
+				},
+				EMPTY_FAMILY,
+			),
+		).rejects.toThrow();
+	});
+
+	it('[A4] countMainQuestActivities / archive / restore', async () => {
+		const family = '00000000-0000-4000-8000-0000000000c5';
+		const childId = await newChild('メイン四郎', family);
+		const a1 = await seedActivity(childId, { name: 'めいん', isMainQuest: true, family });
+		await seedActivity(childId, { name: 'ふつう', family });
+		await seedActivity(childId, {
+			name: 'めいんかくれ',
+			isMainQuest: true,
+			isVisible: false,
+			family,
+		});
+
+		expect(await repo.countMainQuestActivities(family)).toBe(1); // visible & not archived のみ
+
+		await repo.archiveActivities([a1], 'trial_expired', family);
+		expect(await repo.countMainQuestActivities(family)).toBe(0);
+		const archived = await repo.findActivities(family, { includeHidden: true });
+		expect(archived.some((a) => a.name === 'めいん')).toBe(false); // archived は既定除外
+
+		await repo.restoreArchivedActivities('trial_expired', family);
+		expect(await repo.countMainQuestActivities(family)).toBe(1);
+		const restored = await repo.findActivityById(a1, family);
+		expect(restored?.isArchived).toBe(0);
+		expect(restored?.archivedReason).toBe(null);
+
+		// 空 ids は no-op
+		await expect(repo.archiveActivities([], 'trial_expired', family)).resolves.toBeUndefined();
+	});
+
+	it('[A5] hasActivityLogs / getActivityLogCounts / deleteDailyMissionsByActivity', async () => {
+		const childId = await newChild('記録五郎');
+		const a1 = await seedActivity(childId, { name: 'ろぐあり' });
+		const a2 = await seedActivity(childId, { name: 'ろぐなし' });
+		await seedLog(childId, a1, { date: '2026-06-01' });
+		await seedLog(childId, a1, { date: '2026-06-02' });
+		await seedLog(childId, a1, { date: '2026-06-03', cancelled: true });
+
+		expect(await repo.hasActivityLogs(a1, FAMILY)).toBe(true);
+		expect(await repo.hasActivityLogs(a2, FAMILY)).toBe(false);
+
+		const counts = await repo.getActivityLogCounts(FAMILY);
+		expect(counts[String(a1)]).toBe(2); // cancelled 除外
+		expect(counts[String(a2)]).toBeUndefined();
+
+		// daily_missions: 対象 activity の行だけ消える
+		await t.db.execute(sql`
+			INSERT INTO daily_missions (family_id, child_id, mission_date, activity_id)
+			VALUES
+				(${FAMILY}, ${String(childId)}, '2026-06-01', ${String(a1)}),
+				(${FAMILY}, ${String(childId)}, '2026-06-01', ${String(a2)})
+		`);
+		await repo.deleteDailyMissionsByActivity(a1, FAMILY);
+		const missions = await t.db.execute(sql`
+			SELECT activity_id FROM daily_missions
+			WHERE family_id = ${FAMILY} AND child_id = ${String(childId)}
+		`);
+		expect(missions.rows).toHaveLength(1);
+		expect((missions.rows[0] as { activity_id: string }).activity_id).toBe(String(a2));
+	});
+
+	// ─────────────────── Activity Logs ───────────────────
+
+	it('[L1] insertActivityLog → findDailyLog / findActivityLogById / cancel round-trip', async () => {
+		const childId = await newChild('日誌六郎');
+		const activityId = await seedActivity(childId, { name: 'にっし' });
+
+		const log = await repo.insertActivityLog(
+			{
+				childId,
+				activityId,
+				points: 12,
+				streakDays: 3,
+				streakBonus: 2,
+				recordedDate: '2026-06-10',
+				recordedAt: '2026-06-10T08:30:00Z',
+			},
+			FAMILY,
+		);
+		expect(log.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(log.childId).toBe(childId);
+		expect(log.activityId).toBe(activityId);
+		expect(log.points).toBe(12);
+		expect(log.streakDays).toBe(3);
+		expect(log.streakBonus).toBe(2);
+		expect(log.recordedDate).toBe('2026-06-10');
+		expect(log.cancelled).toBe(0); // boolean → 0/1 契約
+
+		const daily = await repo.findDailyLog(childId, activityId, '2026-06-10', FAMILY);
+		expect(daily?.id).toBe(log.id);
+		expect(await repo.findDailyLog(childId, activityId, '2026-06-11', FAMILY)).toBeUndefined();
+
+		const byId = await repo.findActivityLogById(log.id, FAMILY);
+		expect(byId?.points).toBe(12);
+
+		expect(await repo.countTodayActiveRecords(childId, activityId, '2026-06-10', FAMILY)).toBe(1);
+
+		await repo.markActivityLogCancelled(log.id, FAMILY);
+		const cancelled = await repo.findActivityLogById(log.id, FAMILY);
+		expect(cancelled?.cancelled).toBe(1);
+		// cancel 後は findDailyLog / countTodayActiveRecords から不可視 (dailyLimit 再記録可能)
+		expect(await repo.findDailyLog(childId, activityId, '2026-06-10', FAMILY)).toBeUndefined();
+		expect(await repo.countTodayActiveRecords(childId, activityId, '2026-06-10', FAMILY)).toBe(0);
+	});
+
+	it('[L2] findActivityLogs: 日付 range + cancelled 除外 + 降順 + summary shape', async () => {
+		const childId = await newChild('履歴七郎');
+		const act = await seedActivity(childId, { name: 'れきし', icon: '📖', categoryId: 'study' });
+		await seedLog(childId, act, { date: '2026-06-01', points: 1 });
+		await seedLog(childId, act, { date: '2026-06-05', points: 2 });
+		await seedLog(childId, act, { date: '2026-06-09', points: 3 });
+		await seedLog(childId, act, { date: '2026-06-05', points: 99, cancelled: true });
+
+		const all = await repo.findActivityLogs(childId, FAMILY);
+		expect(all.map((l) => l.points)).toEqual([3, 2, 1]); // recorded_at 降順、cancelled 除外
+		const head = all[0];
+		if (!head) throw new Error('unreachable');
+		expect(head.activityName).toBe('れきし'); // JOIN summary shape
+		expect(head.activityIcon).toBe('📖');
+		expect(head.categoryId).toBe(asCategoryId('study'));
+		expect(typeof head.id).toBe('string');
+
+		const ranged = await repo.findActivityLogs(childId, FAMILY, {
+			from: '2026-06-02',
+			to: '2026-06-08',
+		});
+		expect(ranged.map((l) => l.points)).toEqual([2]);
+		const fromOnly = await repo.findActivityLogs(childId, FAMILY, { from: '2026-06-05' });
+		expect(fromOnly.map((l) => l.points)).toEqual([3, 2]);
+		const toOnly = await repo.findActivityLogs(childId, FAMILY, { to: '2026-06-05' });
+		expect(toOnly.map((l) => l.points)).toEqual([2, 1]);
+	});
+
+	it('[L3] findStreakLogs / findTodayRecordedActivityIds / getTodayActivityCountsByChild', async () => {
+		const childId = await newChild('連続八郎');
+		const a1 = await seedActivity(childId, { name: 'まいにち' });
+		const a2 = await seedActivity(childId, { name: 'ときどき' });
+		await seedLog(childId, a1, { date: '2026-06-01' });
+		await seedLog(childId, a1, { date: '2026-06-02' });
+		await seedLog(childId, a1, { date: '2026-06-03', cancelled: true });
+		await seedLog(childId, a1, {
+			date: '2026-06-04',
+			recordedAt: '2026-06-04T08:00:00Z',
+		});
+		await seedLog(childId, a1, {
+			date: '2026-06-04',
+			recordedAt: '2026-06-04T10:00:00Z',
+		});
+		await seedLog(childId, a2, { date: '2026-06-04' });
+
+		const streak = await repo.findStreakLogs(childId, a1, FAMILY);
+		// 降順 + cancelled 除外 (2026-06-04 は 2 records)
+		expect(streak.map((s) => s.recordedDate)).toEqual([
+			'2026-06-04',
+			'2026-06-04',
+			'2026-06-02',
+			'2026-06-01',
+		]);
+
+		const todayIds = await repo.findTodayRecordedActivityIds(childId, '2026-06-04', FAMILY);
+		expect(new Set(todayIds)).toEqual(new Set([a1, a2]));
+
+		const counts = await repo.getTodayActivityCountsByChild(childId, '2026-06-04', FAMILY);
+		const countMap = new Map(counts.map((c) => [c.activityId, c.count]));
+		expect(countMap.get(a1)).toBe(2);
+		expect(countMap.get(a2)).toBe(1);
+	});
+
+	// ─────────────────── Aggregation (SQL 集計 1 クエリ) ───────────────────
+
+	it('[G1] 集計群: distinct dates / counts / category 集計の正値', async () => {
+		const childId = await newChild('集計九郎');
+		const ex = await seedActivity(childId, { name: 'うんどう', categoryId: 'exercise' });
+		const st = await seedActivity(childId, { name: 'べんきょう', categoryId: 'study' });
+		await seedLog(childId, ex, { date: '2026-06-01', recordedAt: '2026-06-01T08:00:00Z' });
+		await seedLog(childId, ex, { date: '2026-06-01', recordedAt: '2026-06-01T09:00:00Z' });
+		await seedLog(childId, st, { date: '2026-06-01', recordedAt: '2026-06-01T10:00:00Z' });
+		await seedLog(childId, st, { date: '2026-06-02' });
+		await seedLog(childId, ex, { date: '2026-06-03', cancelled: true });
+
+		const dates = await repo.findDistinctRecordedDates(childId, FAMILY);
+		expect(dates.map((d) => d.recordedDate)).toEqual(['2026-06-01', '2026-06-02']); // 重複除去 昇順
+
+		expect(await repo.countActiveActivityLogs(childId, FAMILY)).toBe(4);
+
+		const byDate = await repo.getCategoryCountsByDate(childId, FAMILY);
+		const byDateMap = new Map(byDate.map((r) => [r.recordedDate, r.categoryCount]));
+		expect(byDateMap.get('2026-06-01')).toBe(2); // exercise + study
+		expect(byDateMap.get('2026-06-02')).toBe(1);
+
+		expect(await repo.countDistinctCategories(childId, FAMILY)).toBe(2);
+
+		const todayLogs = await repo.findTodayLogsWithCategory(childId, '2026-06-01', FAMILY);
+		expect(todayLogs).toHaveLength(3);
+		expect(todayLogs.filter((l) => l.categoryId === asCategoryId('exercise'))).toHaveLength(2);
+
+		expect(
+			await repo.countActiveActivityLogsByCategory(childId, asCategoryId('exercise'), FAMILY),
+		).toBe(2); // cancelled 除外
+		expect(
+			await repo.countActiveActivityLogsByCategory(childId, asCategoryId('study'), FAMILY),
+		).toBe(2);
+	});
+
+	it('[G2] point_ledger 集計: combo prefix / type count / type+date count', async () => {
+		const childId = await newChild('台帳十郎');
+		const id = String(childId);
+		await t.db.execute(sql`
+			INSERT INTO point_ledger (family_id, child_id, amount, type, description, recorded_date)
+			VALUES
+				(${FAMILY}, ${id}, 5, 'combo_bonus', 'コンボ2026-06-01:a', '2026-06-01'),
+				(${FAMILY}, ${id}, 3, 'combo_bonus', 'コンボ2026-06-01:b', '2026-06-01'),
+				(${FAMILY}, ${id}, 7, 'combo_bonus', 'コンボ2026-06-02:a', '2026-06-02'),
+				(${FAMILY}, ${id}, 9, 'focus_bonus', 'コンボ2026-06-01:c', '2026-06-01'),
+				(${FAMILY}, ${id}, 4, 'focus_bonus', 'しゅうちゅう', '2026-06-02')
+		`);
+
+		expect(await repo.getComboPointsGranted(childId, 'コンボ2026-06-01', FAMILY)).toBe(8); // 5+3
+		expect(await repo.getComboPointsGranted(childId, 'コンボ2099', FAMILY)).toBe(0); // 該当なし
+
+		expect(await repo.countPointLedgerEntriesByType(childId, 'combo_bonus', FAMILY)).toBe(3);
+		expect(await repo.countPointLedgerEntriesByType(childId, 'none', FAMILY)).toBe(0);
+
+		// recorded_date 冪等 lookup (§11.2 H21)
+		expect(
+			await repo.countPointLedgerEntriesByTypeAndDate(childId, 'combo_bonus', '2026-06-01', FAMILY),
+		).toBe(2);
+		expect(
+			await repo.countPointLedgerEntriesByTypeAndDate(childId, 'focus_bonus', '2026-06-02', FAMILY),
+		).toBe(1);
+	});
+
+	it('[M1] findMustActivitiesWithToday: 単一集計の正値', async () => {
+		const childId = await newChild('約束十一');
+		const m1 = await seedActivity(childId, { name: 'はみがき', priority: 'must', sortOrder: 1 });
+		const m2 = await seedActivity(childId, { name: 'しゅくだい', priority: 'must', sortOrder: 2 });
+		await seedActivity(childId, { name: 'ますとかくれ', priority: 'must', isVisible: false });
+		await seedActivity(childId, {
+			name: 'ますとそうこ',
+			priority: 'must',
+			isArchived: true,
+		});
+		await seedActivity(childId, { name: 'にんい', priority: 'optional' });
+		// m1 は今日 2 回記録 (loggedToday は 1 に正規化)、m2 は cancelled のみ (未達扱い)
+		await seedLog(childId, m1, { date: '2026-06-15', recordedAt: '2026-06-15T08:00:00Z' });
+		await seedLog(childId, m1, { date: '2026-06-15', recordedAt: '2026-06-15T09:00:00Z' });
+		await seedLog(childId, m2, { date: '2026-06-15', cancelled: true });
+		await seedLog(childId, m2, { date: '2026-06-14' }); // 別日は今日に数えない
+
+		const result = await repo.findMustActivitiesWithToday(childId, '2026-06-15', FAMILY);
+		expect(result.total).toBe(2); // visible & active な must のみ
+		expect(result.logged).toBe(1);
+		expect(result.activities.map((a) => a.name)).toEqual(['はみがき', 'しゅくだい']); // sort_order 順
+		expect(result.activities[0]?.loggedToday).toBe(1);
+		expect(result.activities[1]?.loggedToday).toBe(0);
+
+		// must 0 件 child は空集計
+		const noMust = await newChild('約束十二');
+		expect(await repo.findMustActivitiesWithToday(noMust, '2026-06-15', FAMILY)).toEqual({
+			logged: 0,
+			total: 0,
+			activities: [],
+		});
+	});
+
+	// ─────────────────── 不変条件 ───────────────────
+
+	it('[P1] insertPointLedger: §5 P7 total_point 同一 txn 共更新 + child 不在 rollback', async () => {
+		const childId = await newChild('台帳十三');
+		await repo.insertPointLedger(
+			{ childId, amount: 15, type: 'activity', description: 'きろく', referenceId: 'log-1' },
+			FAMILY,
+		);
+		await repo.insertPointLedger(
+			{ childId, amount: -4, type: 'activity_cancel', description: 'とりけし' },
+			FAMILY,
+		);
+		const balance = await t.db.execute(sql`
+			SELECT total_point FROM children
+			WHERE family_id = ${FAMILY} AND child_id = ${String(childId)}
+		`);
+		expect(Number((balance.rows[0] as { total_point: number }).total_point)).toBe(11);
+		// fitness#14: total_point == SUM(point_ledger.amount)
+		const drift = await findTotalPointDrift(t.db);
+		expect(drift.filter((d) => String(d.childId) === String(childId))).toEqual([]);
+
+		// child 不在は throw + ledger 未挿入 (片肺書込 rollback、point-repo と同判断)
+		const ghost = asChildId('00000000-0000-4000-8000-00000000dead');
+		await expect(
+			repo.insertPointLedger({ childId: ghost, amount: 5, type: 'x', description: 'x' }, FAMILY),
+		).rejects.toThrow();
+		const ghostRows = await t.db.execute(sql`
+			SELECT count(*) AS c FROM point_ledger
+			WHERE family_id = ${FAMILY} AND child_id = ${String(ghost)}
+		`);
+		expect(Number((ghostRows.rows[0] as { c: unknown }).c)).toBe(0);
+	});
+
+	it('[R1] deleteActivityLogsBeforeDate: strict less-than + 削除件数', async () => {
+		const childId = await newChild('保持十四');
+		const act = await seedActivity(childId, { name: 'ほじ' });
+		await seedLog(childId, act, { date: '2026-01-01' });
+		await seedLog(childId, act, { date: '2026-02-01' });
+		await seedLog(childId, act, { date: '2026-03-01' });
+
+		const deleted = await repo.deleteActivityLogsBeforeDate(childId, '2026-02-01', FAMILY);
+		expect(deleted).toBe(1); // cutoff 当日は残す (strict less than)
+		const remaining = await repo.findDistinctRecordedDates(childId, FAMILY);
+		expect(remaining.map((d) => d.recordedDate)).toEqual(['2026-02-01', '2026-03-01']);
+
+		expect(await repo.deleteActivityLogsBeforeDate(childId, '2020-01-01', FAMILY)).toBe(0);
+	});
+
+	it('[T1] §P9 tenant 分離: 他 family から不可視・write 不能', async () => {
+		const childId = await newChild('分離十五');
+		const act = await seedActivity(childId, { name: 'じぶんの' });
+		const logId = await seedLog(childId, act, { date: '2026-06-20' });
+
+		// read 系: 他 family からは全て不可視
+		expect(
+			(await repo.findActivities(OTHER_FAMILY)).some((a) => String(a.id) === String(act)),
+		).toBe(false);
+		expect(await repo.findActivityById(act, OTHER_FAMILY)).toBeUndefined();
+		expect(await repo.findDailyLog(childId, act, '2026-06-20', OTHER_FAMILY)).toBeUndefined();
+		expect(await repo.findActivityLogById(logId, OTHER_FAMILY)).toBeUndefined();
+		expect(await repo.findActivityLogs(childId, OTHER_FAMILY)).toEqual([]);
+		expect(await repo.hasActivityLogs(act, OTHER_FAMILY)).toBe(false);
+		expect((await repo.getActivityLogCounts(OTHER_FAMILY))[String(act)]).toBeUndefined();
+		expect(await repo.countActiveActivityLogs(childId, OTHER_FAMILY)).toBe(0);
+		expect(await repo.findChildById(childId, OTHER_FAMILY)).toBeUndefined();
+
+		// write 系: 他 family からの update / delete / cancel は no-op (行が消えない)
+		expect(await repo.updateActivity(act, { name: '侵入' }, OTHER_FAMILY)).toBeUndefined();
+		expect(await repo.deleteActivity(act, OTHER_FAMILY)).toBeUndefined();
+		await repo.markActivityLogCancelled(logId, OTHER_FAMILY);
+		const survived = await repo.findActivityLogById(logId, FAMILY);
+		expect(survived?.cancelled).toBe(0); // 越境 cancel は効かない
+		expect((await repo.findActivityById(act, FAMILY))?.name).toBe('じぶんの');
+		expect(await repo.deleteActivityLogsBeforeDate(childId, '2099-01-01', OTHER_FAMILY)).toBe(0);
+	});
+
+	it('findChildById: child-repo 委譲 (compute-on-read parity)', async () => {
+		const childId = await newChild('存在十六');
+		const found = await repo.findChildById(childId, FAMILY);
+		expect(found?.nickname).toBe('存在十六');
+		expect(found?.age).toBe(8);
+		expect(found?.isArchived).toBe(0);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管 repo 層第 5 弾 = 記録 CUJ の read 側中核）

**解決する課題**: IActivityRepo（activities 検索 / activity_logs / 集計 summary、32 メソッド）の DSQL 実装が無く、child home・admin status 等の主要 read 経路が結線できなかった。

**期待される効果**: 記録 CUJ の read/write primitive が DSQL で完備し、集計は SQL 1 クエリ化（§3.5.5 の N+1 排除方針を repo 単体でも実践）。

## 関連 Issue

- EPIC #3424（§12.2.1 build order PR-2 系。R3 #3590 / R4 #3591 の次）
- related: #2458-A1（sqlite facade の `_toActivityShape` adapter — 本 PR は同契約を DSQL で再現）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | IActivityRepo 全 32 メソッドの DSQL 実装（factory 注入 = fitness#8、§P9 述語、branded id） | `npx vitest run tests/unit/db/dsql-activity-log-repo.test.ts` | HEAD `4232062b` / **15 passed**。**red 実測: import 解決不能 fail → green**（commit message 記録）。本体独立再検証: db+architecture **690/690** + svelte-check 7682 files 0 errors |
| AC2 | 集計の SQL 1 クエリ化: summary / findMustActivitiesWithToday（sqlite の 2 クエリ + app 側 Set 合成を LEFT JOIN 1 クエリ化、§3.5.5） | test G 系 / M1 | HEAD `4232062b` / pass |
| AC3 | **insertPointLedger は §5 P7 準拠の意図的 sqlite 非 parity**: ledger INSERT + total_point 共更新の同一 txn + child 不在 throw/rollback（fitness#14 不変条件。sqlite は単文だが DSQL は設計 SSOT §5 が優先） | test（drift 0 突合） | HEAD `4232062b` / pass |
| AC4 | record hot path（5 表複合 txn）は record-activity-core.ts 委譲のまま重複実装なし。insertActivityLog / markActivityLogCancelled は sqlite parity の単文 primitive | diff + test L 系 | HEAD `4232062b` / pass |
| AC5 | JOIN は全て family_id + child_id を結合条件に含め cross-tenant 結合を構造排除（§P9） | 実装 grep + test P1（tenant 分離） | HEAD `4232062b` / pass |
| AC6 | recorded_date 冪等 lookup（countPointLedgerEntriesByTypeAndDate、§11.2 H21 covering。sqlite の date(created_at) と等価契約） | test R1 | HEAD `4232062b` / pass |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] インフラ: infra/CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)（dsql/activity-repo.ts 新設のみ。schema/interface 無変更）
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（新設 2 file、DATA_SOURCE dispatch 未結線）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: dsql-activity-log-repo.test.ts 15 本新設（pushSchema 実 schema 基盤）
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（未変更）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）**: server 側 repo 新設のみで UI 変更なし（.svelte 変更 0 file）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: interface 契約無変更で backend 追加（OCP）
- [x] **DRY**: record hot path・toChild mapping と重複なし（既存 dsql module へ委譲/共有）
- [x] **YAGNI**: dispatch 結線なし
- [x] **Security（OSS 公開前提）**: §P9 述語 + JOIN 結合条件への tenant 軸包含（cross-tenant 結合の構造排除）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: 集計は SQL 1 クエリ（app 側 loop 集計なし）。N+1 を作らない（§3.5.5）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): §11.2/§5 記載設計の実装であり設計変更なし
- [x] **並行 PR overlap** (#1200): PR-R6（stamp/mission、別 branch）と対象 file 完全独立（worktree 分離）、merge 順不問
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新設のみ）

**レビュー依頼事項・QA（判断ポイント = service 層 cutover 時に再訪する記録）**:
- **insertPointLedger の意図的 sqlite 非 parity**（AC3。§5 P7 が sqlite 単文実装より優先。cutover 後は全 backend が本契約に収斂する方向）
- insertActivity の tenant 先頭 child bind（sqlite facade #2458-A1 の暫定動作と同型。service cutover 時に childId 明示渡しへ移行推奨）
- findActivityById は family + activity_id の 2 軸検索（interface に childId が無いため。§P9 は充足、PK covering 化は interface 進化時）
- markActivityLogCancelled はポイント逆仕訳をしない（sqlite parity — service が負値 insertPointLedger で処理。cancel の単一 txn 化は service DSQL 移行時に §8 と合わせて判断）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（Agent 実装を本体セッションが独立再検証 690/690 + svelte-check 0）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: child-cluster repo は R3/R4（merged）→ 本 PR + R6（並行）→ checklist / battle / 報酬系（次波）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
