### PR TITLE
feat: #3424 PR-R6 — DSQL stamp/daily-mission repo 実装 (QM follow-up #3562 3 点消化)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -536,3 +536,15 @@ validationexception
 # ===== #3512 fitness#6 temporal dialect-parity guard =====
 # timestamptz = PostgreSQL/DSQL の標準型名 (TIMESTAMP WITH TIME ZONE の略記、造語ではない)
 timestamptz
+
+# ===== #3424 PR-R6 pg_catalog 列名 (pg_index / pg_attribute / pg_constraint、PostgreSQL 標準カタログ語彙) =====
+attname
+attnum
+attrelid
+conname
+conrelid
+contype
+indisprimary
+indkey
+indrelid
+regclass

--- a/src/lib/server/db/dsql/child-activity-repo.ts
+++ b/src/lib/server/db/dsql/child-activity-repo.ts
@@ -31,7 +31,7 @@ import type {
 import { createDsqlChildRepo } from './child-repo';
 import type { SqlExecutor } from './sql-executor';
 
-interface ChildActivityRow {
+export interface ChildActivityRow {
 	family_id: string;
 	child_id: string;
 	activity_id: string;
@@ -54,14 +54,16 @@ interface ChildActivityRow {
 	created_at: string;
 }
 
-const ACTIVITY_COLUMNS = sql.raw(
+/** child_activities の SELECT 列 (daily-mission repo の findVisibleActivities も共有、二重管理禁止)。 */
+export const ACTIVITY_COLUMNS = sql.raw(
 	`family_id, child_id, activity_id, name, category_id, icon, base_points, is_visible,
 	 daily_limit, sort_order, source, name_kana, name_kanji, trigger_hint, is_main_quest,
 	 is_archived, archived_reason, source_preset_id, priority, created_at`,
 );
 
-/** row → ChildActivity entity (boolean → 0/1 数値契約 = sqlite 互換 shape)。 */
-function toChildActivity(row: ChildActivityRow): ChildActivity {
+/** row → ChildActivity entity (boolean → 0/1 数値契約 = sqlite 互換 shape)。
+ * daily-mission repo の findVisibleActivities からも共有する (mapping 二重実装禁止)。 */
+export function toChildActivity(row: ChildActivityRow): ChildActivity {
 	return {
 		id: asActivityId(row.activity_id),
 		childId: asChildId(row.child_id),

--- a/src/lib/server/db/dsql/daily-mission-repo.ts
+++ b/src/lib/server/db/dsql/daily-mission-repo.ts
@@ -1,0 +1,184 @@
+// src/lib/server/db/dsql/daily-mission-repo.ts
+// EPIC #3424 / PR-R6 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §8 / §11.2 / §P9
+//
+// IDailyMissionRepo の DSQL backend 実装。設計契約:
+//   - **factory 注入** (fitness#8: module-level db/client import 禁止)。全メソッドが単文のため
+//     TransactionRunner は不要 (txn を要する完了+bonus 経路は daily-mission-complete.ts が正)。
+//   - **§P9 tenant 述語**: 全メソッドが family_id = tenantId を WHERE に含む。
+//   - **daily_missions は自然複合 PK (family, child, mission_date, activity_id、§11.2 凍結)**:
+//     surrogate id 列を持たないため、entity の `id` は複合キーの合成文字列
+//     (`child:date:activity`) を返す (status-repo の §4 自然キー戦略と同判断。
+//     DailyMissionWithActivity.id の消費は UI 表示 key のみで grep 確認済)。
+//   - **complete 系の委譲 (fitness#10)**: 「完了 flip + 全完了 bonus 付与」の単一 txn は
+//     daily-mission-complete.ts (completeMissionAndMaybeGrantBonus) が実装済の正であり、
+//     本 repo は重複実装しない。interface の markMissionCompleted は void 契約 (bonus 引数 /
+//     結果を持たない) のため完全委譲は契約不一致 — 本メソッドは flag flip 単体のみを担い、
+//     fitness#10 と同じ **conditional UPDATE (completed = false → true)** を serialization
+//     point として使う (再実行は 0 行 no-op = completed_at を上書きしない)。service cutover 時、
+//     bonus を伴う完了経路は completeMissionAndMaybeGrantBonus を呼ぶこと (count-then-insert の
+//     TOCTOU 二重付与を再導入しない)。
+//   - **insertDailyMission は PK への ON CONFLICT DO NOTHING** (#2565 parity: 並行 generate の
+//     重複 INSERT を constraint violation にせず同一 mission set に収束)。
+//   - findMissionBonusRecord は point_ledger type='daily_mission' filter (sqlite parity。
+//     daily-mission-complete.ts の 'mission_bonus' は cutover 後経路で別 type)。
+//   - entity 境界: completed は number (0/1) 契約 — boolean 列を読み出し時に変換
+//     (sqlite backend と同一 shape)。
+
+import { sql } from 'drizzle-orm';
+import { type ActivityId, asActivityId, asCategoryId, type ChildId } from '$lib/domain/ids';
+import type { IDailyMissionRepo } from '../interfaces/daily-mission-repo.interface';
+import { ACTIVITY_COLUMNS, type ChildActivityRow, toChildActivity } from './child-activity-repo';
+import { CHILD_COLUMNS, type ChildRow, toChild } from './child-repo';
+import type { SqlExecutor } from './sql-executor';
+
+interface MissionJoinRow {
+	child_id: string;
+	mission_date: string;
+	activity_id: string;
+	completed: boolean;
+	activity_name: string;
+	activity_icon: string;
+	category_id: string;
+}
+
+/** 自然複合 PK の合成 id (`child:date:activity`、surrogate 列なし §11.2)。 */
+function missionId(childId: string, date: string, activityId: string): string {
+	return `${childId}:${date}:${activityId}`;
+}
+
+/** DSQL 用 IDailyMissionRepo を生成する (db は注入、fitness#8)。 */
+export function createDsqlDailyMissionRepo(db: SqlExecutor): IDailyMissionRepo {
+	return {
+		async findTodayMissions(childId, date, tenantId) {
+			// child_activities join は (family, child, activity) の 3 軸 = PK 完全一致 (§P9)。
+			const result = await db.execute(sql`
+				SELECT dm.child_id, dm.mission_date, dm.activity_id, dm.completed,
+					ca.name AS activity_name, ca.icon AS activity_icon, ca.category_id
+				FROM daily_missions dm
+				JOIN child_activities ca
+					ON ca.family_id = dm.family_id AND ca.child_id = dm.child_id
+					AND ca.activity_id = dm.activity_id
+				WHERE dm.family_id = ${tenantId} AND dm.child_id = ${childId}
+					AND dm.mission_date = ${date}
+				ORDER BY dm.activity_id
+			`);
+			return (result.rows as unknown as MissionJoinRow[]).map((r) => ({
+				id: missionId(r.child_id, r.mission_date, r.activity_id),
+				activityId: asActivityId(r.activity_id),
+				completed: r.completed ? 1 : 0,
+				activityName: r.activity_name,
+				activityIcon: r.activity_icon,
+				categoryId: asCategoryId(r.category_id),
+			}));
+		},
+
+		async findMissionBonusRecord(childId, description, tenantId) {
+			// sqlite parity: type='daily_mission' + description 一致の既付与 lookup。
+			const result = await db.execute(sql`
+				SELECT amount FROM point_ledger
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND type = 'daily_mission' AND description = ${description}
+				LIMIT 1
+			`);
+			const row = result.rows[0] as { amount: number } | undefined;
+			return row ? { amount: Number(row.amount) } : undefined;
+		},
+
+		async findMissionByActivity(childId, date, activityId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT child_id, mission_date, activity_id, completed FROM daily_missions
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND mission_date = ${date} AND activity_id = ${activityId}
+			`);
+			const row = result.rows[0] as unknown as MissionJoinRow | undefined;
+			if (!row) return undefined;
+			return {
+				id: missionId(row.child_id, row.mission_date, row.activity_id),
+				completed: row.completed ? 1 : 0,
+			};
+		},
+
+		async markMissionCompleted(childId, date, activityId, tenantId) {
+			// #2845 B1: 複合キー完全一致 (不在 / 不一致は silent no-op)。completed = false 条件は
+			// fitness#10 の serialization point と同型 (再実行は 0 行 = completed_at 不変)。
+			// bonus を伴う完了経路は daily-mission-complete.ts に委譲すること (header 注記)。
+			await db.execute(sql`
+				UPDATE daily_missions SET completed = true, completed_at = now()
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND mission_date = ${date} AND activity_id = ${activityId}
+					AND completed = false
+			`);
+		},
+
+		async findAllMissionStatuses(childId, date, tenantId) {
+			const result = await db.execute(sql`
+				SELECT completed FROM daily_missions
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND mission_date = ${date}
+				ORDER BY activity_id
+			`);
+			return (result.rows as { completed: boolean }[]).map((r) => ({
+				completed: r.completed ? 1 : 0,
+			}));
+		},
+
+		async findChildForMission(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${CHILD_COLUMNS} FROM children
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+			`);
+			const row = result.rows[0] as unknown as ChildRow | undefined;
+			return row ? toChild(row) : undefined;
+		},
+
+		async findVisibleActivities(tenantId) {
+			// sqlite parity: is_visible のみ filter (archived は filter しない)。DSQL は
+			// multi-tenant のため §P9 family 述語を追加 (callsite の child filter は service 側)。
+			const result = await db.execute(sql`
+				SELECT ${ACTIVITY_COLUMNS} FROM child_activities
+				WHERE family_id = ${tenantId} AND is_visible = true
+				ORDER BY child_id, sort_order, created_at, activity_id
+			`);
+			return (result.rows as unknown as ChildActivityRow[]).map(toChildActivity);
+		},
+
+		async findPreviousDayMissionIds(childId, date, tenantId): Promise<ActivityId[]> {
+			const result = await db.execute(sql`
+				SELECT activity_id FROM daily_missions
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND mission_date = ${date}
+			`);
+			return (result.rows as { activity_id: string }[]).map((r) => asActivityId(r.activity_id));
+		},
+
+		async findRecentActivityIds(childId, sinceDate, tenantId): Promise<ActivityId[]> {
+			const result = await db.execute(sql`
+				SELECT DISTINCT activity_id FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND recorded_date >= ${sinceDate} AND cancelled = false
+			`);
+			return (result.rows as { activity_id: string }[]).map((r) => asActivityId(r.activity_id));
+		},
+
+		async findAllRecordedActivityIds(childId, tenantId): Promise<ActivityId[]> {
+			const result = await db.execute(sql`
+				SELECT DISTINCT activity_id FROM activity_logs
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND cancelled = false
+			`);
+			return (result.rows as { activity_id: string }[]).map((r) => asActivityId(r.activity_id));
+		},
+
+		async insertDailyMission(childId: ChildId, date, activityId, tenantId) {
+			// #2565 parity: 並行 generate の重複 INSERT は PK ON CONFLICT で silent skip し
+			// 同一 mission set に収束させる (constraint violation の 500 を出さない)。
+			await db.execute(sql`
+				INSERT INTO daily_missions (family_id, child_id, mission_date, activity_id)
+				VALUES (${tenantId}, ${childId}, ${date}, ${activityId})
+				ON CONFLICT (family_id, child_id, mission_date, activity_id) DO NOTHING
+			`);
+		},
+
+		async deleteByTenantId(tenantId) {
+			// sqlite (シングルテナント全行削除) と違い family 述語で tenant 限定 (§P9)。
+			await db.execute(sql`DELETE FROM daily_missions WHERE family_id = ${tenantId}`);
+		},
+	};
+}

--- a/src/lib/server/db/dsql/stamp-card-repo.ts
+++ b/src/lib/server/db/dsql/stamp-card-repo.ts
@@ -1,0 +1,248 @@
+// src/lib/server/db/dsql/stamp-card-repo.ts
+// EPIC #3424 / PR-R6 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §3 / §11.2 / §P9
+// follow-up 担保: #3562 ①②③ (PR #3547 Adversarial Reviewer 指摘)
+//
+// IStampCardRepo の DSQL backend 実装。設計契約:
+//   - **factory 注入** (fitness#8: module-level db/client import 禁止)。
+//   - **§P9 tenant 述語**: 全メソッドが family_id = tenantId を WHERE に含む。
+//   - **UUID surrogate PK (PO 決裁 2026-07-03、PR #3547)**: card_id は gen_random_uuid() 採番
+//     (counter 不使用)。PK は (family_id, child_id, card_id) で week_start を含まない。
+//   - **#3562 ① 可逆性設計**: 「1子1週1枚」は PK と独立した droppable UNIQUE
+//     stamp_cards_week_uq (family_id, child_id, week_start) が担う。シーズン/イベントカード
+//     復活時は **この UNIQUE を DROP するだけで PK 不変** (§P1 の PK 後変更不可に抵触しない)。
+//     insertCard の冪等化もこの UNIQUE への ON CONFLICT に anchor しており、UNIQUE DROP 後は
+//     ON CONFLICT 節を撤去して「常に新規カード」へ 1 箇所修正で移行できる。
+//     テスト固定: dsql-stamp-mission-repos.test.ts [SC3]。
+//   - **#3562 ② H7/H8 性能**: UUID surrogate 化で「今週のカード」lookup は PK covering から
+//     外れ UNIQUE index 経由の 2 段 fetch になる。実測は PGlite では不可能 (planner / latency が
+//     実 DSQL と別物) のため **cutover 後に実 DSQL で計測するタスク** であり、本 repo では
+//     推測の数値を書かない。必要なら covering index 追加を計測後に判断する (#3562 ②)。
+//   - **#3562 ③ tenant 境界 assertion**: DSQL は FK 非対応 + card_id が独立乱数のため、
+//     stamp_entries の INSERT は「card_id が同一 family_id の stamp_cards に属する」ことを
+//     INSERT ... SELECT ... FROM stamp_cards (単一文 = 同一 txn 内検証) で強制する。
+//     所属しない card への挿入は 0 行 no-op になり cross-family / orphan entry を構造排除。
+//   - **stamp master は in-memory SSOT** (stamp-master-defaults.ts、dynamodb backend と同判断):
+//     stamp_masters は tenant 別カスタマイズなしのグローバル master (§11.2) で、DSQL schema に
+//     表を持たない。findEnabledStampMasters / master join は getDefaultStampMasters() で解決する。
+//   - entry の重複押印 (同 slot / 同 login_date) は ON CONFLICT DO NOTHING で silent skip
+//     (sqlite parity: onConflictDoNothing)。
+
+import { sql } from 'drizzle-orm';
+import { asChildId } from '$lib/domain/ids';
+import type { IStampCardRepo } from '../interfaces/stamp-card-repo.interface';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import { getDefaultStampMasters } from '../stamp-master-defaults';
+import type { StampCard, StampEntryWithMaster, StampMaster } from '../types';
+import type { SqlExecutor } from './sql-executor';
+
+interface CardRow {
+	child_id: string;
+	card_id: string;
+	week_start: string;
+	week_end: string;
+	status: string;
+	redeemed_points: number | null;
+	redeemed_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+interface EntryRow {
+	card_id: string;
+	slot: number;
+	stamp_master_id: string | null;
+	omikuji_rank: string | null;
+	login_date: string;
+	earned_at: string;
+}
+
+const CARD_COLUMNS = sql.raw(
+	`child_id, card_id, week_start, week_end, status, redeemed_points, redeemed_at,
+	 created_at, updated_at`,
+);
+const ENTRY_COLUMNS = sql.raw(
+	'card_id, slot, stamp_master_id, omikuji_rank, login_date, earned_at',
+);
+
+/** row → StampCard entity (id = card_id uuid 文字列、sqlite の数値 id 文字列化と同 shape 契約)。 */
+function toCard(row: CardRow): StampCard {
+	return {
+		id: row.card_id,
+		childId: asChildId(row.child_id),
+		weekStart: row.week_start,
+		weekEnd: row.week_end,
+		status: row.status,
+		redeemedPoints: row.redeemed_points,
+		redeemedAt: row.redeemed_at,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+/** DSQL 用 IStampCardRepo を生成する (db/runner は注入、fitness#8)。 */
+export function createDsqlStampCardRepo<TTx extends SqlExecutor>(
+	db: SqlExecutor,
+	runner: TransactionRunner<TTx>,
+): IStampCardRepo {
+	// グローバル master SSOT (tenant 非依存 §11.2)。id → master の join 用 map。
+	const masterById = new Map<string, StampMaster>(getDefaultStampMasters().map((m) => [m.id, m]));
+
+	const findCard = async (where: ReturnType<typeof sql>): Promise<StampCard | undefined> => {
+		const result = await db.execute(sql`SELECT ${CARD_COLUMNS} FROM stamp_cards WHERE ${where}`);
+		const row = result.rows[0] as unknown as CardRow | undefined;
+		return row ? toCard(row) : undefined;
+	};
+
+	return {
+		async findEnabledStampMasters(_tenantId) {
+			// in-memory SSOT (dynamodb parity #2845 課題④: isEnabled=0 を除外する filter parity)。
+			return getDefaultStampMasters().filter((m) => m.isEnabled === 1);
+		},
+
+		async findCardByChildAndWeek(childId, weekStart, tenantId) {
+			return findCard(
+				sql`family_id = ${tenantId} AND child_id = ${childId} AND week_start = ${weekStart}`,
+			);
+		},
+
+		async insertCard(input, tenantId) {
+			// findOrCreate 冪等化: week UNIQUE (stamp_cards_week_uq) への ON CONFLICT DO NOTHING。
+			// 既存週の再要求 (並行 loginStamp 等) は挿入 0 行 → 既存 card を SELECT して返す
+			// (どちらの経路でも「その週のカード」1 枚に収束、#2565 と同思想)。
+			const inserted = await db.execute(sql`
+				INSERT INTO stamp_cards (family_id, child_id, week_start, week_end, status)
+				VALUES (${tenantId}, ${input.childId}, ${input.weekStart}, ${input.weekEnd},
+					${input.status ?? 'collecting'})
+				ON CONFLICT (family_id, child_id, week_start) DO NOTHING
+				RETURNING ${CARD_COLUMNS}
+			`);
+			const row = inserted.rows[0] as unknown as CardRow | undefined;
+			if (row) return toCard(row);
+			const existing = await this.findCardByChildAndWeek(input.childId, input.weekStart, tenantId);
+			if (!existing) throw new Error('Failed to create stamp card');
+			return existing;
+		},
+
+		async findEntriesWithMasterByCardId(cardId, tenantId): Promise<StampEntryWithMaster[]> {
+			// master join は in-memory SSOT で解決 (stamp_masters 表なし、dynamodb parity)。
+			const result = await db.execute(sql`
+				SELECT ${ENTRY_COLUMNS} FROM stamp_entries
+				WHERE family_id = ${tenantId} AND card_id = ${cardId}
+				ORDER BY slot
+			`);
+			return (result.rows as unknown as EntryRow[]).map((r) => {
+				const master = r.stamp_master_id ? masterById.get(r.stamp_master_id) : undefined;
+				return {
+					slot: r.slot,
+					stampMasterId: r.stamp_master_id,
+					omikujiRank: r.omikuji_rank,
+					loginDate: r.login_date,
+					name: master?.name ?? null,
+					emoji: master?.emoji ?? null,
+					rarity: master?.rarity ?? null,
+				};
+			});
+		},
+
+		async insertEntry(input, tenantId) {
+			// #3562 ③: card 所有検証を INSERT ... SELECT の単一文 (= 同一 txn) で強制。
+			// card が同 family に属さない場合は SELECT 0 行 → 挿入なし (orphan / cross-family 排除)。
+			// 重複 (同 slot PK / 同 login_date UNIQUE) は DO NOTHING で silent skip (sqlite parity)。
+			await db.execute(sql`
+				INSERT INTO stamp_entries (family_id, card_id, slot, stamp_master_id, omikuji_rank, login_date)
+				SELECT c.family_id, c.card_id, ${input.slot}, ${input.stampMasterId},
+					${input.omikujiRank}, ${input.loginDate}
+				FROM stamp_cards c
+				WHERE c.family_id = ${tenantId} AND c.card_id = ${input.cardId}
+				ON CONFLICT DO NOTHING
+			`);
+		},
+
+		async findCardsByChild(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${CARD_COLUMNS} FROM stamp_cards
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+				ORDER BY week_start
+			`);
+			return (result.rows as unknown as CardRow[]).map(toCard);
+		},
+
+		async findEntriesByCardId(cardId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${ENTRY_COLUMNS} FROM stamp_entries
+				WHERE family_id = ${tenantId} AND card_id = ${cardId}
+				ORDER BY slot
+			`);
+			return (result.rows as unknown as EntryRow[]).map((r) => ({
+				stampMasterId: r.stamp_master_id,
+				omikujiRank: r.omikuji_rank,
+				slot: r.slot,
+				loginDate: r.login_date,
+				earnedAt: r.earned_at,
+			}));
+		},
+
+		async insertCardForRestore(input, tenantId) {
+			// #3329 backup restore: status / redeemed / 日時を verbatim 保全 (insertCard と違い
+			// default に落とさない)。card_id は新規採番 (schema default gen_random_uuid())。
+			const result = await db.execute(sql`
+				INSERT INTO stamp_cards
+					(family_id, child_id, week_start, week_end, status, redeemed_points, redeemed_at,
+					 created_at, updated_at)
+				VALUES (${tenantId}, ${input.childId}, ${input.weekStart}, ${input.weekEnd},
+					${input.status}, ${input.redeemedPoints}, ${input.redeemedAt},
+					${input.createdAt}::timestamptz, ${input.updatedAt}::timestamptz)
+				RETURNING ${CARD_COLUMNS}
+			`);
+			const row = result.rows[0] as unknown as CardRow | undefined;
+			if (!row) throw new Error('insertCardForRestore: insert returned no row');
+			return toCard(row);
+		},
+
+		async insertEntryForRestore(input, tenantId) {
+			// restore 経路も #3562 ③ の tenant 境界 (INSERT ... SELECT 所有検証) を通す。
+			// earned_at は verbatim 保全。重複は DO NOTHING (sqlite parity)。
+			await db.execute(sql`
+				INSERT INTO stamp_entries
+					(family_id, card_id, slot, stamp_master_id, omikuji_rank, login_date, earned_at)
+				SELECT c.family_id, c.card_id, ${input.slot}, ${input.stampMasterId},
+					${input.omikujiRank}, ${input.loginDate}, ${input.earnedAt}::timestamptz
+				FROM stamp_cards c
+				WHERE c.family_id = ${tenantId} AND c.card_id = ${input.cardId}
+				ON CONFLICT DO NOTHING
+			`);
+		},
+
+		async updateCardStatus(childId, cardId, input, tenantId) {
+			// #2845 課題①: (family, child, card) = PK 完全一致で cross-child access を構造排除。
+			await db.execute(sql`
+				UPDATE stamp_cards
+				SET status = ${input.status}, redeemed_points = ${input.redeemedPoints},
+					redeemed_at = ${input.redeemedAt}, updated_at = ${input.updatedAt}::timestamptz
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND card_id = ${cardId}
+			`);
+		},
+
+		async updateCardStatusIfCollecting(childId, cardId, input, tenantId) {
+			// status='collecting' の行のみ遷移 (冪等ガード)。affected 行数を返す (sqlite parity)。
+			const result = await db.execute(sql`
+				UPDATE stamp_cards
+				SET status = ${input.status}, redeemed_points = ${input.redeemedPoints},
+					redeemed_at = ${input.redeemedAt}, updated_at = ${input.updatedAt}::timestamptz
+				WHERE family_id = ${tenantId} AND child_id = ${childId} AND card_id = ${cardId}
+					AND status = 'collecting'
+				RETURNING card_id
+			`);
+			return result.rows.length;
+		},
+
+		async deleteByTenantId(tenantId) {
+			// 2 表削除を単一 txn (fitness#7: work 内 await は tx.execute 直呼びのみ)。
+			// sqlite (シングルテナント全行削除) と違い family 述語で tenant 限定 (§P9)。
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(sql`DELETE FROM stamp_entries WHERE family_id = ${tenantId}`);
+				await tx.execute(sql`DELETE FROM stamp_cards WHERE family_id = ${tenantId}`);
+			});
+		},
+	};
+}

--- a/tests/unit/db/dsql-stamp-mission-repos.test.ts
+++ b/tests/unit/db/dsql-stamp-mission-repos.test.ts
@@ -37,20 +37,17 @@
 
 import { sql } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import {
-	type ActivityId,
-	asActivityId,
-	asChildId,
-	type ChildId,
-} from '../../../src/lib/domain/ids';
+import { type ActivityId, asActivityId, type ChildId } from '../../../src/lib/domain/ids';
 import { createDsqlChildRepo } from '../../../src/lib/server/db/dsql/child-repo';
 import { completeMissionAndMaybeGrantBonus } from '../../../src/lib/server/db/dsql/daily-mission-complete';
 import { createDsqlDailyMissionRepo } from '../../../src/lib/server/db/dsql/daily-mission-repo';
 import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import type { SqlExecutor } from '../../../src/lib/server/db/dsql/sql-executor';
 import { createDsqlStampCardRepo } from '../../../src/lib/server/db/dsql/stamp-card-repo';
 import type { IChildRepo } from '../../../src/lib/server/db/interfaces/child-repo.interface';
 import type { IDailyMissionRepo } from '../../../src/lib/server/db/interfaces/daily-mission-repo.interface';
 import type { IStampCardRepo } from '../../../src/lib/server/db/interfaces/stamp-card-repo.interface';
+import type { TransactionRunner } from '../../../src/lib/server/db/interfaces/transaction.interface';
 import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
 
 const FAMILY = '00000000-0000-4000-8000-0000000000c1';
@@ -62,7 +59,7 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 	let childRepo: IChildRepo;
 	let stampRepo: IStampCardRepo;
 	let missionRepo: IDailyMissionRepo;
-	let runner: ReturnType<typeof createDsqlTransactionRunner>;
+	let runner: TransactionRunner<SqlExecutor>;
 
 	/** 新規 child を作って id を返す (各テストは自分の child で分離)。 */
 	const newChild = async (nickname: string, family = FAMILY): Promise<ChildId> => {
@@ -181,7 +178,13 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 			FAMILY,
 		);
 		await stampRepo.insertEntry(
-			{ cardId: card.id, stampMasterId: '11', omikujiRank: 'daikichi', slot: 1, loginDate: '2026-06-01' },
+			{
+				cardId: card.id,
+				stampMasterId: '11',
+				omikujiRank: 'daikichi',
+				slot: 1,
+				loginDate: '2026-06-01',
+			},
 			FAMILY,
 		);
 		// 同 loginDate の重複押印は UNIQUE (family, card, login_date) で silent skip (sqlite parity)
@@ -232,7 +235,9 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 			},
 			FAMILY,
 		);
-		expect(await countRows(sql`SELECT count(*) AS c FROM stamp_entries WHERE card_id = ${card.id}`)).toBe(0);
+		expect(
+			await countRows(sql`SELECT count(*) AS c FROM stamp_entries WHERE card_id = ${card.id}`),
+		).toBe(0);
 		expect(
 			await countRows(
 				sql`SELECT count(*) AS c FROM stamp_entries WHERE card_id = '00000000-0000-4000-8000-00000000dead'`,
@@ -252,7 +257,13 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 		expect(await stampRepo.findCardsByChild(childId, OTHER_FAMILY)).toEqual([]);
 
 		await stampRepo.insertEntry(
-			{ cardId: older.id, stampMasterId: '5', omikujiRank: 'kichi', slot: 3, loginDate: '2026-06-03' },
+			{
+				cardId: older.id,
+				stampMasterId: '5',
+				omikujiRank: 'kichi',
+				slot: 3,
+				loginDate: '2026-06-03',
+			},
 			FAMILY,
 		);
 		const raw = await stampRepo.findEntriesByCardId(older.id, FAMILY);
@@ -296,7 +307,9 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 			FAMILY,
 		);
 		const raw = await stampRepo.findEntriesByCardId(restored.id, FAMILY);
-		expect(raw[0]?.earnedAt).toContain('2025-12-01T08:30');
+		// timestamptz の文字列表現は driver 依存 (PGlite はローカル offset 表記) のため、
+		// verbatim 保全は瞬間 (epoch) 一致で assert する。
+		expect(Date.parse(raw[0]?.earnedAt ?? '')).toBe(Date.parse('2025-12-01T08:30:00+00:00'));
 		expect(raw[0]?.stampMasterId).toBe(null); // omikuji のみの押印 (master 無し)
 
 		// restore 経路も #3562③ tenant 境界を通る (他 family card への restore は no-op)
@@ -353,7 +366,9 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 			updatedAt: '2026-07-19T10:00:00+00:00',
 		};
 		expect(await stampRepo.updateCardStatusIfCollecting(stranger, card.id, redeem, FAMILY)).toBe(0);
-		expect(await stampRepo.updateCardStatusIfCollecting(childId, card.id, redeem, OTHER_FAMILY)).toBe(0);
+		expect(
+			await stampRepo.updateCardStatusIfCollecting(childId, card.id, redeem, OTHER_FAMILY),
+		).toBe(0);
 		expect(await stampRepo.updateCardStatusIfCollecting(childId, card.id, redeem, FAMILY)).toBe(1);
 		// 二重 redeem は 0 (status ガード)
 		expect(await stampRepo.updateCardStatusIfCollecting(childId, card.id, redeem, FAMILY)).toBe(0);
@@ -370,7 +385,13 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 			OTHER_FAMILY,
 		);
 		await stampRepo.insertEntry(
-			{ cardId: mineCard.id, stampMasterId: '1', omikujiRank: null, slot: 1, loginDate: '2026-06-29' },
+			{
+				cardId: mineCard.id,
+				stampMasterId: '1',
+				omikujiRank: null,
+				slot: 1,
+				loginDate: '2026-06-29',
+			},
 			OTHER_FAMILY,
 		);
 		const keepCard = await stampRepo.insertCard(
@@ -378,14 +399,26 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 			FAMILY,
 		);
 		await stampRepo.insertEntry(
-			{ cardId: keepCard.id, stampMasterId: '1', omikujiRank: null, slot: 1, loginDate: '2026-06-29' },
+			{
+				cardId: keepCard.id,
+				stampMasterId: '1',
+				omikujiRank: null,
+				slot: 1,
+				loginDate: '2026-06-29',
+			},
 			FAMILY,
 		);
 
 		await stampRepo.deleteByTenantId(OTHER_FAMILY);
 
-		expect(await countRows(sql`SELECT count(*) AS c FROM stamp_cards WHERE family_id = ${OTHER_FAMILY}`)).toBe(0);
-		expect(await countRows(sql`SELECT count(*) AS c FROM stamp_entries WHERE family_id = ${OTHER_FAMILY}`)).toBe(0);
+		expect(
+			await countRows(sql`SELECT count(*) AS c FROM stamp_cards WHERE family_id = ${OTHER_FAMILY}`),
+		).toBe(0);
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM stamp_entries WHERE family_id = ${OTHER_FAMILY}`,
+			),
+		).toBe(0);
 		expect((await stampRepo.findCardsByChild(keep, FAMILY)).length).toBe(1);
 		expect((await stampRepo.findEntriesByCardId(keepCard.id, FAMILY)).length).toBe(1);
 	});
@@ -437,9 +470,9 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 		const before = await missionRepo.findMissionByActivity(childId, '2026-07-02', actId, FAMILY);
 		expect(before?.completed).toBe(0);
 		// mission に無い activity は undefined
-		expect(
-			await missionRepo.findMissionByActivity(childId, '2026-07-02', otherAct, FAMILY),
-		).toBe(undefined);
+		expect(await missionRepo.findMissionByActivity(childId, '2026-07-02', otherAct, FAMILY)).toBe(
+			undefined,
+		);
 		// §P9: 他 tenant からの mark は no-op
 		await missionRepo.markMissionCompleted(childId, '2026-07-02', actId, OTHER_FAMILY);
 		expect(
@@ -478,7 +511,9 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 		const statuses = await missionRepo.findAllMissionStatuses(childId, '2026-07-03', FAMILY);
 		expect(statuses).toHaveLength(2);
 		expect(statuses.map((s) => s.completed).sort()).toEqual([0, 1]);
-		expect(await missionRepo.findAllMissionStatuses(childId, '2026-07-03', OTHER_FAMILY)).toEqual([]);
+		expect(await missionRepo.findAllMissionStatuses(childId, '2026-07-03', OTHER_FAMILY)).toEqual(
+			[],
+		);
 	});
 
 	it('[M4] findMissionBonusRecord: type=daily_mission filter (sqlite parity)', async () => {
@@ -498,7 +533,11 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 		expect(found?.amount).toBe(10); // type filter で activity 行 (99) は拾わない
 		expect(await missionRepo.findMissionBonusRecord(childId, 'ほかの説明', FAMILY)).toBe(undefined);
 		expect(
-			await missionRepo.findMissionBonusRecord(childId, '[2026-07-04] ミッションボーナス', OTHER_FAMILY),
+			await missionRepo.findMissionBonusRecord(
+				childId,
+				'[2026-07-04] ミッションボーナス',
+				OTHER_FAMILY,
+			),
 		).toBe(undefined);
 	});
 
@@ -526,7 +565,9 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 		await missionRepo.insertDailyMission(childId, '2026-07-04', a, FAMILY);
 
 		expect(await missionRepo.findPreviousDayMissionIds(childId, '2026-07-04', FAMILY)).toEqual([a]);
-		expect(await missionRepo.findPreviousDayMissionIds(childId, '2026-07-04', OTHER_FAMILY)).toEqual([]);
+		expect(
+			await missionRepo.findPreviousDayMissionIds(childId, '2026-07-04', OTHER_FAMILY),
+		).toEqual([]);
 
 		const id = String(childId);
 		await t.db.execute(sql`
@@ -567,10 +608,16 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 			bonusDescription: '[2026-07-05] ミッションボーナス',
 			now: '2026-07-05T09:00:00+00:00',
 		};
-		const first = await completeMissionAndMaybeGrantBonus(runner, { ...base, activityId: String(a) });
+		const first = await completeMissionAndMaybeGrantBonus(runner, {
+			...base,
+			activityId: String(a),
+		});
 		expect(first).toEqual({ completedNow: true, allComplete: false, bonusGranted: false });
 
-		const last = await completeMissionAndMaybeGrantBonus(runner, { ...base, activityId: String(b) });
+		const last = await completeMissionAndMaybeGrantBonus(runner, {
+			...base,
+			activityId: String(b),
+		});
 		expect(last).toEqual({ completedNow: true, allComplete: true, bonusGranted: true });
 
 		// 二連打の 2 回目は flip も bonus も起きない (exactly-once)
@@ -598,7 +645,11 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 
 		await missionRepo.deleteByTenantId(OTHER_FAMILY);
 
-		expect(await countRows(sql`SELECT count(*) AS c FROM daily_missions WHERE family_id = ${OTHER_FAMILY}`)).toBe(0);
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM daily_missions WHERE family_id = ${OTHER_FAMILY}`,
+			),
+		).toBe(0);
 		expect((await missionRepo.findTodayMissions(keep, '2026-07-06', FAMILY)).length).toBe(1);
 	});
 });

--- a/tests/unit/db/dsql-stamp-mission-repos.test.ts
+++ b/tests/unit/db/dsql-stamp-mission-repos.test.ts
@@ -1,0 +1,604 @@
+// tests/unit/db/dsql-stamp-mission-repos.test.ts
+// EPIC #3424 / PR-R6 / 設計 SSOT: dsql-data-model.md §3 / §11.2 / §P9 / #3562 ①③
+//
+// DSQL IStampCardRepo + IDailyMissionRepo 実装のテスト。実 schema (pushSchema 適用、
+// dsql-test-db helper):
+//
+// ── IStampCardRepo ──
+//   [SC1] insertCard findOrCreate 冪等 (week UNIQUE、同一 card_id が返る + 行は 1 件)
+//   [SC2] findCardByChildAndWeek round-trip + §P9 tenant 分離
+//   [SC3] #3562 ①: PK は (family, child, card_id) で week_start を含まない +
+//         週一意は droppable UNIQUE (stamp_cards_week_uq) — 「シーズンカード復活時は
+//         UNIQUE DROP のみで PK 不変」の可逆性設計を catalog レベルで固定
+//   [SM1] findEnabledStampMasters: in-memory SSOT 16 件 (stamp-master-defaults、dynamodb parity)
+//   [SE1] insertEntry + findEntriesWithMasterByCardId (master join + 1日1押印 UNIQUE skip)
+//   [SE2] #3562 ③: 他 family card / 存在しない card への entry 挿入拒否 (tenant 境界 assertion)
+//   [SE3] findCardsByChild (week_start 順) / findEntriesByCardId (earnedAt raw 保全)
+//   [SR1] insertCardForRestore / insertEntryForRestore: status・redeemed・日時 verbatim 保全 +
+//         restore 経路も #3562 ③ の tenant 境界を通る
+//   [SU1] updateCardStatus: (childId, cardId) composite addressing (他 child は no-op)
+//   [SU2] updateCardStatusIfCollecting: collecting のみ 1、再実行 / 他 child は 0
+//   [SD1] deleteByTenantId: cards+entries を tenant 限定削除、他 tenant 無傷
+//   [SX1] UNIQUE / CHECK 実効: 不正 status 拒否 + week UNIQUE 直接 INSERT 拒否
+//
+// ── IDailyMissionRepo ──
+//   [M1] insertDailyMission 冪等 (PK ON CONFLICT) + findTodayMissions (child_activities join)
+//   [M2] findMissionByActivity + markMissionCompleted (conditional flip、completed_at 不変) +
+//        §P9 / composite key no-op
+//   [M3] findAllMissionStatuses (0/1 契約)
+//   [M4] findMissionBonusRecord (type='daily_mission' filter、sqlite parity)
+//   [M5] findVisibleActivities: is_visible + §P9 filter、ChildActivity shape (0/1)
+//   [M6] findPreviousDayMissionIds / findRecentActivityIds (cancelled 除外) /
+//        findAllRecordedActivityIds
+//   [M7] findChildForMission round-trip + §P9
+//   [M8] complete 委譲経路: repo 生成 mission → completeMissionAndMaybeGrantBonus
+//        (daily-mission-complete.ts、fitness#10) が exactly-once で bonus 付与
+//   [M9] deleteByTenantId tenant 限定削除
+
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	type ActivityId,
+	asActivityId,
+	asChildId,
+	type ChildId,
+} from '../../../src/lib/domain/ids';
+import { createDsqlChildRepo } from '../../../src/lib/server/db/dsql/child-repo';
+import { completeMissionAndMaybeGrantBonus } from '../../../src/lib/server/db/dsql/daily-mission-complete';
+import { createDsqlDailyMissionRepo } from '../../../src/lib/server/db/dsql/daily-mission-repo';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import { createDsqlStampCardRepo } from '../../../src/lib/server/db/dsql/stamp-card-repo';
+import type { IChildRepo } from '../../../src/lib/server/db/interfaces/child-repo.interface';
+import type { IDailyMissionRepo } from '../../../src/lib/server/db/interfaces/daily-mission-repo.interface';
+import type { IStampCardRepo } from '../../../src/lib/server/db/interfaces/stamp-card-repo.interface';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+const FAMILY = '00000000-0000-4000-8000-0000000000c1';
+const OTHER_FAMILY = '00000000-0000-4000-8000-0000000000c2';
+const UUID_RE = /^[0-9a-f-]{36}$/;
+
+describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)', () => {
+	let t: DsqlTestDb;
+	let childRepo: IChildRepo;
+	let stampRepo: IStampCardRepo;
+	let missionRepo: IDailyMissionRepo;
+	let runner: ReturnType<typeof createDsqlTransactionRunner>;
+
+	/** 新規 child を作って id を返す (各テストは自分の child で分離)。 */
+	const newChild = async (nickname: string, family = FAMILY): Promise<ChildId> => {
+		const c = await childRepo.insertChild({ nickname, age: 8, birthDate: '2018-01-15' }, family);
+		return c.id;
+	};
+
+	/** child_activities を直接 seed して activity_id を返す。 */
+	const seedActivity = async (
+		childId: ChildId,
+		name: string,
+		family = FAMILY,
+		isVisible = true,
+	): Promise<ActivityId> => {
+		const r = await t.db.execute(sql`
+			INSERT INTO child_activities (family_id, child_id, name, category_id, icon, is_visible)
+			VALUES (${family}, ${String(childId)}, ${name}, 'exercise', '🏃', ${isVisible})
+			RETURNING activity_id
+		`);
+		return asActivityId((r.rows[0] as { activity_id: string }).activity_id);
+	};
+
+	const countRows = async (query: ReturnType<typeof sql>): Promise<number> => {
+		const r = await t.db.execute(query);
+		return Number((r.rows[0] as { c: unknown }).c);
+	};
+
+	beforeAll(async () => {
+		t = await createDsqlTestDb();
+		runner = createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 });
+		childRepo = createDsqlChildRepo(t.db, runner);
+		stampRepo = createDsqlStampCardRepo(t.db, runner);
+		missionRepo = createDsqlDailyMissionRepo(t.db);
+	}, 60_000);
+	afterAll(async () => {
+		await t.close();
+	});
+
+	// ─────────────────── IStampCardRepo ───────────────────
+
+	it('[SC1] insertCard: findOrCreate 冪等 (week UNIQUE、同一 card + 行 1 件)', async () => {
+		const childId = await newChild('シール一郎');
+		const first = await stampRepo.insertCard(
+			{ childId, weekStart: '2026-06-29', weekEnd: '2026-07-05' },
+			FAMILY,
+		);
+		expect(first.id).toMatch(UUID_RE);
+		expect(first.childId).toBe(childId);
+		expect(first.status).toBe('collecting'); // 既定 status
+		expect(first.redeemedPoints).toBe(null);
+		expect(typeof first.createdAt).toBe('string');
+
+		// 同 (child, week) への再 insert は既存 card を返す (ON CONFLICT 冪等、#2565 と同思想)
+		const second = await stampRepo.insertCard(
+			{ childId, weekStart: '2026-06-29', weekEnd: '2026-07-05' },
+			FAMILY,
+		);
+		expect(second.id).toBe(first.id);
+		expect(
+			await countRows(sql`
+				SELECT count(*) AS c FROM stamp_cards
+				WHERE family_id = ${FAMILY} AND child_id = ${String(childId)}
+			`),
+		).toBe(1);
+	});
+
+	it('[SC2] findCardByChildAndWeek: round-trip + §P9 tenant 分離', async () => {
+		const childId = await newChild('シール二郎');
+		const created = await stampRepo.insertCard(
+			{ childId, weekStart: '2026-07-06', weekEnd: '2026-07-12', status: 'redeemable' },
+			FAMILY,
+		);
+		expect(created.status).toBe('redeemable'); // input.status 尊重
+
+		const found = await stampRepo.findCardByChildAndWeek(childId, '2026-07-06', FAMILY);
+		expect(found?.id).toBe(created.id);
+		expect(found?.weekEnd).toBe('2026-07-12');
+
+		expect(await stampRepo.findCardByChildAndWeek(childId, '2026-07-06', OTHER_FAMILY)).toBe(
+			undefined,
+		);
+		expect(await stampRepo.findCardByChildAndWeek(childId, '2000-01-03', FAMILY)).toBe(undefined);
+	});
+
+	it('[SC3] #3562①: week 一意は droppable UNIQUE、PK は week_start を含まない (可逆性設計)', async () => {
+		// PK 列 = (family_id, child_id, card_id): シーズン/イベントカード復活時は
+		// stamp_cards_week_uq を DROP するだけで PK 不変 (§P1 の PK 後変更不可に抵触しない)。
+		const pk = await t.db.execute(sql`
+			SELECT a.attname FROM pg_index i
+			JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+			WHERE i.indrelid = 'stamp_cards'::regclass AND i.indisprimary
+		`);
+		const pkCols = (pk.rows as { attname: string }[]).map((r) => r.attname).sort();
+		expect(pkCols).toEqual(['card_id', 'child_id', 'family_id']);
+
+		// 週一意は PK と独立した UNIQUE 制約として存在する (= 単独 DROP 可能)
+		const uq = await t.db.execute(sql`
+			SELECT conname FROM pg_constraint
+			WHERE conrelid = 'stamp_cards'::regclass AND contype = 'u'
+		`);
+		const names = (uq.rows as { conname: string }[]).map((r) => r.conname);
+		expect(names).toContain('stamp_cards_week_uq');
+	});
+
+	it('[SM1] findEnabledStampMasters: in-memory SSOT 16 件 (dynamodb parity)', async () => {
+		const masters = await stampRepo.findEnabledStampMasters(FAMILY);
+		expect(masters).toHaveLength(16);
+		expect(masters.every((m) => m.isEnabled === 1)).toBe(true);
+		expect(masters.find((m) => m.id === '11')?.name).toBe('ドラゴン');
+	});
+
+	it('[SE1] insertEntry + findEntriesWithMasterByCardId: master join + 1日1押印 UNIQUE skip', async () => {
+		const childId = await newChild('押印三郎');
+		const card = await stampRepo.insertCard(
+			{ childId, weekStart: '2026-06-01', weekEnd: '2026-06-07' },
+			FAMILY,
+		);
+		await stampRepo.insertEntry(
+			{ cardId: card.id, stampMasterId: '11', omikujiRank: 'daikichi', slot: 1, loginDate: '2026-06-01' },
+			FAMILY,
+		);
+		// 同 loginDate の重複押印は UNIQUE (family, card, login_date) で silent skip (sqlite parity)
+		await stampRepo.insertEntry(
+			{ cardId: card.id, stampMasterId: '3', omikujiRank: null, slot: 2, loginDate: '2026-06-01' },
+			FAMILY,
+		);
+		await stampRepo.insertEntry(
+			{ cardId: card.id, stampMasterId: '3', omikujiRank: null, slot: 2, loginDate: '2026-06-02' },
+			FAMILY,
+		);
+
+		const entries = await stampRepo.findEntriesWithMasterByCardId(card.id, FAMILY);
+		expect(entries).toHaveLength(2);
+		expect(entries[0]).toEqual({
+			slot: 1,
+			stampMasterId: '11',
+			omikujiRank: 'daikichi',
+			loginDate: '2026-06-01',
+			name: 'ドラゴン',
+			emoji: '🐉',
+			rarity: 'SR',
+		});
+		expect(entries[1]?.name).toBe('スター');
+		// §P9: 他 tenant からは不可視
+		expect(await stampRepo.findEntriesWithMasterByCardId(card.id, OTHER_FAMILY)).toEqual([]);
+	});
+
+	it('[SE2] #3562③: 他 family card / 存在しない card への entry 挿入は拒否 (tenant 境界)', async () => {
+		const childId = await newChild('越境四郎');
+		const card = await stampRepo.insertCard(
+			{ childId, weekStart: '2026-06-08', weekEnd: '2026-06-14' },
+			FAMILY,
+		);
+		// 他 family を名乗った insert: card は FAMILY 所有のため挿入されない
+		await stampRepo.insertEntry(
+			{ cardId: card.id, stampMasterId: '1', omikujiRank: null, slot: 1, loginDate: '2026-06-08' },
+			OTHER_FAMILY,
+		);
+		// 存在しない card への insert: orphan entry を作らない
+		await stampRepo.insertEntry(
+			{
+				cardId: '00000000-0000-4000-8000-00000000dead',
+				stampMasterId: '1',
+				omikujiRank: null,
+				slot: 1,
+				loginDate: '2026-06-08',
+			},
+			FAMILY,
+		);
+		expect(await countRows(sql`SELECT count(*) AS c FROM stamp_entries WHERE card_id = ${card.id}`)).toBe(0);
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM stamp_entries WHERE card_id = '00000000-0000-4000-8000-00000000dead'`,
+			),
+		).toBe(0);
+	});
+
+	it('[SE3] findCardsByChild (week_start 順) / findEntriesByCardId (earnedAt raw 保全)', async () => {
+		const childId = await newChild('週次五郎');
+		await stampRepo.insertCard({ childId, weekStart: '2026-06-15', weekEnd: '2026-06-21' }, FAMILY);
+		const older = await stampRepo.insertCard(
+			{ childId, weekStart: '2026-06-01', weekEnd: '2026-06-07' },
+			FAMILY,
+		);
+		const cards = await stampRepo.findCardsByChild(childId, FAMILY);
+		expect(cards.map((c) => c.weekStart)).toEqual(['2026-06-01', '2026-06-15']);
+		expect(await stampRepo.findCardsByChild(childId, OTHER_FAMILY)).toEqual([]);
+
+		await stampRepo.insertEntry(
+			{ cardId: older.id, stampMasterId: '5', omikujiRank: 'kichi', slot: 3, loginDate: '2026-06-03' },
+			FAMILY,
+		);
+		const raw = await stampRepo.findEntriesByCardId(older.id, FAMILY);
+		expect(raw).toHaveLength(1);
+		expect(raw[0]?.stampMasterId).toBe('5');
+		expect(raw[0]?.slot).toBe(3);
+		expect(typeof raw[0]?.earnedAt).toBe('string');
+		expect(await stampRepo.findEntriesByCardId(older.id, OTHER_FAMILY)).toEqual([]);
+	});
+
+	it('[SR1] insertCardForRestore / insertEntryForRestore: verbatim 保全 + tenant 境界', async () => {
+		const childId = await newChild('復元六郎');
+		const restored = await stampRepo.insertCardForRestore(
+			{
+				childId,
+				weekStart: '2025-12-01',
+				weekEnd: '2025-12-07',
+				status: 'redeemed',
+				redeemedPoints: 30,
+				redeemedAt: '2025-12-07T09:00:00+00:00',
+				createdAt: '2025-12-01T00:00:00+00:00',
+				updatedAt: '2025-12-07T09:00:00+00:00',
+			},
+			FAMILY,
+		);
+		expect(restored.id).toMatch(UUID_RE);
+		expect(restored.status).toBe('redeemed');
+		expect(restored.redeemedPoints).toBe(30);
+		expect(restored.redeemedAt).toContain('2025-12-07');
+		expect(restored.createdAt).toContain('2025-12-01'); // insertCard と違い verbatim 保全
+
+		await stampRepo.insertEntryForRestore(
+			{
+				cardId: restored.id,
+				stampMasterId: null,
+				omikujiRank: 'daikichi',
+				slot: 1,
+				loginDate: '2025-12-01',
+				earnedAt: '2025-12-01T08:30:00+00:00',
+			},
+			FAMILY,
+		);
+		const raw = await stampRepo.findEntriesByCardId(restored.id, FAMILY);
+		expect(raw[0]?.earnedAt).toContain('2025-12-01T08:30');
+		expect(raw[0]?.stampMasterId).toBe(null); // omikuji のみの押印 (master 無し)
+
+		// restore 経路も #3562③ tenant 境界を通る (他 family card への restore は no-op)
+		await stampRepo.insertEntryForRestore(
+			{
+				cardId: restored.id,
+				stampMasterId: null,
+				omikujiRank: null,
+				slot: 2,
+				loginDate: '2025-12-02',
+				earnedAt: '2025-12-02T08:30:00+00:00',
+			},
+			OTHER_FAMILY,
+		);
+		expect(await stampRepo.findEntriesByCardId(restored.id, FAMILY)).toHaveLength(1);
+	});
+
+	it('[SU1] updateCardStatus: (childId, cardId) composite addressing (#2845 課題①)', async () => {
+		const childId = await newChild('更新七郎');
+		const stranger = await newChild('他人八郎');
+		const card = await stampRepo.insertCard(
+			{ childId, weekStart: '2026-06-22', weekEnd: '2026-06-28' },
+			FAMILY,
+		);
+		const input = {
+			status: 'redeemable',
+			redeemedPoints: null,
+			redeemedAt: null,
+			updatedAt: '2026-06-28T00:00:00+00:00',
+		};
+		// 他 child を名乗った update は no-op
+		await stampRepo.updateCardStatus(stranger, card.id, input, FAMILY);
+		expect((await stampRepo.findCardByChildAndWeek(childId, '2026-06-22', FAMILY))?.status).toBe(
+			'collecting',
+		);
+		// 正しい composite key で更新される
+		await stampRepo.updateCardStatus(childId, card.id, input, FAMILY);
+		expect((await stampRepo.findCardByChildAndWeek(childId, '2026-06-22', FAMILY))?.status).toBe(
+			'redeemable',
+		);
+	});
+
+	it('[SU2] updateCardStatusIfCollecting: collecting のみ 1、再実行 / 他 child は 0', async () => {
+		const childId = await newChild('冪等九郎');
+		const stranger = await newChild('他人十郎');
+		const card = await stampRepo.insertCard(
+			{ childId, weekStart: '2026-07-13', weekEnd: '2026-07-19' },
+			FAMILY,
+		);
+		const redeem = {
+			status: 'redeemed',
+			redeemedPoints: 25,
+			redeemedAt: '2026-07-19T10:00:00+00:00',
+			updatedAt: '2026-07-19T10:00:00+00:00',
+		};
+		expect(await stampRepo.updateCardStatusIfCollecting(stranger, card.id, redeem, FAMILY)).toBe(0);
+		expect(await stampRepo.updateCardStatusIfCollecting(childId, card.id, redeem, OTHER_FAMILY)).toBe(0);
+		expect(await stampRepo.updateCardStatusIfCollecting(childId, card.id, redeem, FAMILY)).toBe(1);
+		// 二重 redeem は 0 (status ガード)
+		expect(await stampRepo.updateCardStatusIfCollecting(childId, card.id, redeem, FAMILY)).toBe(0);
+		const after = await stampRepo.findCardByChildAndWeek(childId, '2026-07-13', FAMILY);
+		expect(after?.status).toBe('redeemed');
+		expect(after?.redeemedPoints).toBe(25);
+	});
+
+	it('[SD1] deleteByTenantId: cards+entries を tenant 限定削除、他 tenant 無傷', async () => {
+		const mine = await newChild('全削除十一郎', OTHER_FAMILY);
+		const keep = await newChild('無傷十二郎');
+		const mineCard = await stampRepo.insertCard(
+			{ childId: mine, weekStart: '2026-06-29', weekEnd: '2026-07-05' },
+			OTHER_FAMILY,
+		);
+		await stampRepo.insertEntry(
+			{ cardId: mineCard.id, stampMasterId: '1', omikujiRank: null, slot: 1, loginDate: '2026-06-29' },
+			OTHER_FAMILY,
+		);
+		const keepCard = await stampRepo.insertCard(
+			{ childId: keep, weekStart: '2026-06-29', weekEnd: '2026-07-05' },
+			FAMILY,
+		);
+		await stampRepo.insertEntry(
+			{ cardId: keepCard.id, stampMasterId: '1', omikujiRank: null, slot: 1, loginDate: '2026-06-29' },
+			FAMILY,
+		);
+
+		await stampRepo.deleteByTenantId(OTHER_FAMILY);
+
+		expect(await countRows(sql`SELECT count(*) AS c FROM stamp_cards WHERE family_id = ${OTHER_FAMILY}`)).toBe(0);
+		expect(await countRows(sql`SELECT count(*) AS c FROM stamp_entries WHERE family_id = ${OTHER_FAMILY}`)).toBe(0);
+		expect((await stampRepo.findCardsByChild(keep, FAMILY)).length).toBe(1);
+		expect((await stampRepo.findEntriesByCardId(keepCard.id, FAMILY)).length).toBe(1);
+	});
+
+	it('[SX1] UNIQUE / CHECK 実効: 不正 status 拒否 + week UNIQUE 直接 INSERT 拒否', async () => {
+		const childId = await newChild('制約十三郎');
+		await expect(
+			t.db.execute(sql`
+				INSERT INTO stamp_cards (family_id, child_id, week_start, week_end, status)
+				VALUES (${FAMILY}, ${String(childId)}, '2026-08-03', '2026-08-09', 'bogus')
+			`),
+		).rejects.toThrow(); // stamp_cards_status_ck
+		await stampRepo.insertCard({ childId, weekStart: '2026-08-03', weekEnd: '2026-08-09' }, FAMILY);
+		await expect(
+			t.db.execute(sql`
+				INSERT INTO stamp_cards (family_id, child_id, week_start, week_end)
+				VALUES (${FAMILY}, ${String(childId)}, '2026-08-03', '2026-08-09')
+			`),
+		).rejects.toThrow(); // stamp_cards_week_uq
+	});
+
+	// ─────────────────── IDailyMissionRepo ───────────────────
+
+	it('[M1] insertDailyMission 冪等 + findTodayMissions (child_activities join)', async () => {
+		const childId = await newChild('ミッション一郎');
+		const actId = await seedActivity(childId, 'なわとび');
+		await missionRepo.insertDailyMission(childId, '2026-07-01', actId, FAMILY);
+		// PK ON CONFLICT 冪等 (#2565 parity: 並行 generate でも UNIQUE violation を出さない)
+		await missionRepo.insertDailyMission(childId, '2026-07-01', actId, FAMILY);
+
+		const missions = await missionRepo.findTodayMissions(childId, '2026-07-01', FAMILY);
+		expect(missions).toHaveLength(1);
+		expect(missions[0]?.activityId).toBe(actId);
+		expect(missions[0]?.activityName).toBe('なわとび');
+		expect(missions[0]?.activityIcon).toBe('🏃');
+		expect(missions[0]?.categoryId).toBe('exercise');
+		expect(missions[0]?.completed).toBe(0); // 0/1 契約
+		expect(typeof missions[0]?.id).toBe('string');
+		// §P9 tenant 分離
+		expect(await missionRepo.findTodayMissions(childId, '2026-07-01', OTHER_FAMILY)).toEqual([]);
+	});
+
+	it('[M2] findMissionByActivity + markMissionCompleted: conditional flip + composite no-op', async () => {
+		const childId = await newChild('ミッション二郎');
+		const actId = await seedActivity(childId, 'ほんよみ');
+		const otherAct = await seedActivity(childId, 'そうじ');
+		await missionRepo.insertDailyMission(childId, '2026-07-02', actId, FAMILY);
+
+		const before = await missionRepo.findMissionByActivity(childId, '2026-07-02', actId, FAMILY);
+		expect(before?.completed).toBe(0);
+		// mission に無い activity は undefined
+		expect(
+			await missionRepo.findMissionByActivity(childId, '2026-07-02', otherAct, FAMILY),
+		).toBe(undefined);
+		// §P9: 他 tenant からの mark は no-op
+		await missionRepo.markMissionCompleted(childId, '2026-07-02', actId, OTHER_FAMILY);
+		expect(
+			(await missionRepo.findMissionByActivity(childId, '2026-07-02', actId, FAMILY))?.completed,
+		).toBe(0);
+
+		await missionRepo.markMissionCompleted(childId, '2026-07-02', actId, FAMILY);
+		const after = await missionRepo.findMissionByActivity(childId, '2026-07-02', actId, FAMILY);
+		expect(after?.completed).toBe(1);
+
+		// 再 mark は conditional (completed=false→true) ガードで completed_at を上書きしない
+		const at1 = await t.db.execute(sql`
+			SELECT completed_at FROM daily_missions
+			WHERE family_id = ${FAMILY} AND child_id = ${String(childId)}
+				AND mission_date = '2026-07-02' AND activity_id = ${String(actId)}
+		`);
+		await missionRepo.markMissionCompleted(childId, '2026-07-02', actId, FAMILY);
+		const at2 = await t.db.execute(sql`
+			SELECT completed_at FROM daily_missions
+			WHERE family_id = ${FAMILY} AND child_id = ${String(childId)}
+				AND mission_date = '2026-07-02' AND activity_id = ${String(actId)}
+		`);
+		expect((at2.rows[0] as { completed_at: string }).completed_at).toBe(
+			(at1.rows[0] as { completed_at: string }).completed_at,
+		);
+	});
+
+	it('[M3] findAllMissionStatuses: 0/1 契約', async () => {
+		const childId = await newChild('ミッション三郎');
+		const a = await seedActivity(childId, 'たいそう');
+		const b = await seedActivity(childId, 'おてつだい');
+		await missionRepo.insertDailyMission(childId, '2026-07-03', a, FAMILY);
+		await missionRepo.insertDailyMission(childId, '2026-07-03', b, FAMILY);
+		await missionRepo.markMissionCompleted(childId, '2026-07-03', a, FAMILY);
+
+		const statuses = await missionRepo.findAllMissionStatuses(childId, '2026-07-03', FAMILY);
+		expect(statuses).toHaveLength(2);
+		expect(statuses.map((s) => s.completed).sort()).toEqual([0, 1]);
+		expect(await missionRepo.findAllMissionStatuses(childId, '2026-07-03', OTHER_FAMILY)).toEqual([]);
+	});
+
+	it('[M4] findMissionBonusRecord: type=daily_mission filter (sqlite parity)', async () => {
+		const childId = await newChild('ボーナス四郎');
+		const id = String(childId);
+		await t.db.execute(sql`
+			INSERT INTO point_ledger (family_id, child_id, amount, type, description, recorded_date)
+			VALUES
+				(${FAMILY}, ${id}, 10, 'daily_mission', '[2026-07-04] ミッションボーナス', '2026-07-04'),
+				(${FAMILY}, ${id}, 99, 'activity', '[2026-07-04] ミッションボーナス', '2026-07-04')
+		`);
+		const found = await missionRepo.findMissionBonusRecord(
+			childId,
+			'[2026-07-04] ミッションボーナス',
+			FAMILY,
+		);
+		expect(found?.amount).toBe(10); // type filter で activity 行 (99) は拾わない
+		expect(await missionRepo.findMissionBonusRecord(childId, 'ほかの説明', FAMILY)).toBe(undefined);
+		expect(
+			await missionRepo.findMissionBonusRecord(childId, '[2026-07-04] ミッションボーナス', OTHER_FAMILY),
+		).toBe(undefined);
+	});
+
+	it('[M5] findVisibleActivities: is_visible + §P9 filter、ChildActivity shape', async () => {
+		const childId = await newChild('一覧五郎', OTHER_FAMILY);
+		const visible = await seedActivity(childId, 'みえる', OTHER_FAMILY, true);
+		await seedActivity(childId, 'みえない', OTHER_FAMILY, false);
+
+		const acts = await missionRepo.findVisibleActivities(OTHER_FAMILY);
+		const mine = acts.filter((a) => 'childId' in a && a.childId === childId);
+		expect(mine).toHaveLength(1);
+		expect(mine[0]?.id).toBe(visible);
+		expect(mine[0]?.isVisible).toBe(1); // 0/1 契約
+		expect(mine[0]?.basePoints).toBe(5);
+		// §P9: 他 tenant の行は返さない
+		expect(acts.every((a) => !('childId' in a) || String(a.childId) !== '')).toBe(true);
+		const fromMyFamily = await missionRepo.findVisibleActivities(FAMILY);
+		expect(fromMyFamily.some((a) => a.id === visible)).toBe(false);
+	});
+
+	it('[M6] findPreviousDayMissionIds / findRecentActivityIds (cancelled 除外) / findAllRecordedActivityIds', async () => {
+		const childId = await newChild('履歴六郎');
+		const a = await seedActivity(childId, 'かたづけ');
+		const b = await seedActivity(childId, 'はみがき');
+		await missionRepo.insertDailyMission(childId, '2026-07-04', a, FAMILY);
+
+		expect(await missionRepo.findPreviousDayMissionIds(childId, '2026-07-04', FAMILY)).toEqual([a]);
+		expect(await missionRepo.findPreviousDayMissionIds(childId, '2026-07-04', OTHER_FAMILY)).toEqual([]);
+
+		const id = String(childId);
+		await t.db.execute(sql`
+			INSERT INTO activity_logs (family_id, child_id, activity_id, points, recorded_date, cancelled)
+			VALUES
+				(${FAMILY}, ${id}, ${String(a)}, 5, '2026-06-01', false),
+				(${FAMILY}, ${id}, ${String(b)}, 5, '2026-07-01', false),
+				(${FAMILY}, ${id}, ${String(b)}, 5, '2026-07-03', true)
+		`);
+		// sinceDate 以降 + cancelled 除外
+		expect(await missionRepo.findRecentActivityIds(childId, '2026-06-15', FAMILY)).toEqual([b]);
+		const all = await missionRepo.findAllRecordedActivityIds(childId, FAMILY);
+		expect(all.sort()).toEqual([a, b].sort()); // cancelled 行は除外だが b は 07-01 の有効行で入る
+	});
+
+	it('[M7] findChildForMission: round-trip + §P9', async () => {
+		const childId = await newChild('本人七郎');
+		const child = await missionRepo.findChildForMission(childId, FAMILY);
+		expect(child?.nickname).toBe('本人七郎');
+		expect(child?.age).toBe(8);
+		expect(await missionRepo.findChildForMission(childId, OTHER_FAMILY)).toBe(undefined);
+	});
+
+	it('[M8] complete 委譲経路: repo 生成 mission → completeMissionAndMaybeGrantBonus が exactly-once', async () => {
+		// fitness#10: 完了 flip + bonus 付与 txn は daily-mission-complete.ts が正 (重複実装しない)。
+		// repo の insertDailyMission で作った行がそのまま委譲経路の serialization point になる。
+		const childId = await newChild('委譲八郎');
+		const a = await seedActivity(childId, 'ランニング');
+		const b = await seedActivity(childId, 'にっき');
+		await missionRepo.insertDailyMission(childId, '2026-07-05', a, FAMILY);
+		await missionRepo.insertDailyMission(childId, '2026-07-05', b, FAMILY);
+
+		const base = {
+			familyId: FAMILY,
+			childId: String(childId),
+			missionDate: '2026-07-05',
+			bonusPoints: 10,
+			bonusDescription: '[2026-07-05] ミッションボーナス',
+			now: '2026-07-05T09:00:00+00:00',
+		};
+		const first = await completeMissionAndMaybeGrantBonus(runner, { ...base, activityId: String(a) });
+		expect(first).toEqual({ completedNow: true, allComplete: false, bonusGranted: false });
+
+		const last = await completeMissionAndMaybeGrantBonus(runner, { ...base, activityId: String(b) });
+		expect(last).toEqual({ completedNow: true, allComplete: true, bonusGranted: true });
+
+		// 二連打の 2 回目は flip も bonus も起きない (exactly-once)
+		const dup = await completeMissionAndMaybeGrantBonus(runner, { ...base, activityId: String(b) });
+		expect(dup).toEqual({ completedNow: false, allComplete: true, bonusGranted: false });
+
+		expect(
+			await countRows(sql`
+				SELECT count(*) AS c FROM point_ledger
+				WHERE family_id = ${FAMILY} AND child_id = ${String(childId)} AND type = 'mission_bonus'
+			`),
+		).toBe(1);
+		// repo 読み出しにも完了が反映される (委譲経路と repo の整合)
+		const statuses = await missionRepo.findAllMissionStatuses(childId, '2026-07-05', FAMILY);
+		expect(statuses.map((s) => s.completed)).toEqual([1, 1]);
+	});
+
+	it('[M9] deleteByTenantId: tenant 限定削除、他 tenant 無傷', async () => {
+		const mine = await newChild('掃除九郎', OTHER_FAMILY);
+		const keep = await newChild('無傷十郎');
+		const mineAct = await seedActivity(mine, 'すてる', OTHER_FAMILY);
+		const keepAct = await seedActivity(keep, 'のこる');
+		await missionRepo.insertDailyMission(mine, '2026-07-06', mineAct, OTHER_FAMILY);
+		await missionRepo.insertDailyMission(keep, '2026-07-06', keepAct, FAMILY);
+
+		await missionRepo.deleteByTenantId(OTHER_FAMILY);
+
+		expect(await countRows(sql`SELECT count(*) AS c FROM daily_missions WHERE family_id = ${OTHER_FAMILY}`)).toBe(0);
+		expect((await missionRepo.findTodayMissions(keep, '2026-07-06', FAMILY)).length).toBe(1);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管 repo 層第 6 弾 = スタンプ・デイリーミッション集約）

**解決する課題**: IStampCardRepo / IDailyMissionRepo の DSQL 実装が無く、また QM 追加指摘 #3562（stamp 領域 3 点: droppable UNIQUE 可逆性 / H7,H8 性能 / stamp_entries tenant 境界）が未消化だった。

**期待される効果**: 週次スタンプカードとデイリーミッションの全操作が DSQL で動作し、#3562 の 3 点が実装 + テスト + コメントで消化される。ミッション完了の exactly-once は fitness#10 実装済経路（daily-mission-complete.ts）が正のまま。

## 関連 Issue

- EPIC #3424（§12.2.1 build order PR-2 系。R5 = PR #3594 と並行実装、対象 file 完全独立）
- **closes #3562**（QM 追加指摘 3 点 — 消化内訳は AC2-AC4。② H7/H8 は「実 DSQL 計測タスク」として明記 = 起票趣旨どおり PGlite での推測数値を書かない対応）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 2 repo 全メソッドの DSQL 実装（factory 注入 = fitness#8、§P9 述語、branded id）。insertCard は week UNIQUE の ON CONFLICT で findOrCreate 冪等 | `npx vitest run tests/unit/db/dsql-stamp-mission-repos.test.ts` | HEAD `3692ac70` / **21 passed**（stamp 12 + mission 9）。**red 実測: red commit `098b38e5` を分離**（テスト先行 → 実装 commit）。本体独立再検証: db+architecture **696/696** + svelte-check 7683 files 0 errors |
| AC2 | **#3562 ①**: droppable UNIQUE(week_start) の可逆性（PK に week 不含 + 独立 UNIQUE = シーズンカード復活時は UNIQUE DROP のみで PK 不変）を pg catalog レベルのテスト [SC3] + repo コメントで固定 | test SC3 | HEAD `3692ac70` / pass |
| AC3 | **#3562 ②**: H7/H8 性能検証は PGlite では planner/latency が実 DSQL と別物のため実施せず、「cutover 後の実 DSQL 計測タスク」と repo コメントに明記（推測数値なし） | repo header コメント | HEAD `3692ac70` / 明記済 |
| AC4 | **#3562 ③**: stamp_entries の tenant 境界 — INSERT（通常 + restore）を `INSERT...SELECT FROM stamp_cards WHERE family_id=...` の単一文で card 所有検証し、cross-family / orphan card への entry を拒否 | test [SE2]/[SR1] | HEAD `3692ac70` / pass |
| AC5 | mission complete の exactly-once は daily-mission-complete.ts（fitness#10 の conditional UPDATE serialization point）委譲のまま重複実装なし。repo の markMissionCompleted は interface 契約（void）どおり flag flip 単体（同型の conditional UPDATE） | test [M8]（repo 生成 mission → completeMissionAndMaybeGrantBonus の exactly-once） | HEAD `3692ac70` / pass |
| AC6 | stamp master は in-memory SSOT（stamp-master-defaults.ts、グローバル master §11.2 = dynamodb backend と同判断）で map 解決 | test + diff | HEAD `3692ac70` / pass |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)（dsql/stamp-card-repo.ts + daily-mission-repo.ts 新設、child-activity-repo.ts の ACTIVITY_COLUMNS/toChildActivity export 化（共有）。schema/interface 無変更）
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI（`.cspell/project-words.txt` に pg_catalog 標準語彙 10 語を理由コメント付き追記のみ）

**影響を受ける画面・機能**: なし（新設 + export 化のみ、DATA_SOURCE dispatch 未結線）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: dsql-stamp-mission-repos.test.ts 21 本新設（pushSchema 実 schema 基盤。earnedAt の assert は driver 依存の文字列表現差を避け epoch 一致 = 「瞬間の保全」契約で不変、弱体化ではない）
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（未変更）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）**: server 側 repo 新設のみで UI 変更なし（.svelte 変更 0 file）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: interface 契約無変更で backend 追加（OCP）。完了 txn の正は daily-mission-complete.ts 単一（SRP）
- [x] **DRY**: mapping は export 共有（ACTIVITY_COLUMNS/toChildActivity）。hot path 重複なし
- [x] **YAGNI**: dispatch 結線なし。H7/H8 の推測最適化をしない（計測後）
- [x] **Security（OSS 公開前提）**: stamp_entries の cross-family/orphan 拒否を単一文 INSERT...SELECT で構造化（#3562 ③、check-then-act の TOCTOU も排除）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: findOrCreate は ON CONFLICT 1 往復。master join は in-memory map（DB join 不要）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): §11.2 記載設計（stamp_cards surrogate + droppable UNIQUE は #3547 PO 決裁済）の実装であり設計変更なし
- [x] **並行 PR overlap** (#1200): PR #3594（R5）と worktree 分離で並行実装、対象 file 完全独立、merge 順不問
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新設のみ）

**レビュー依頼事項・QA（service cutover PR への引継ぎ判断 2 点を含む）**:
- **現行 service の mission bonus 経路は count-then-insert の TOCTOU 二重付与形状** — service cutover PR で `completeMissionAndMaybeGrantBonus`（fitness#10）への切替が必須（repo header に注記済。本 PR の markMissionCompleted は interface 契約どおり flag flip 単体）
- **bonus type の二重系**（現行 service = `daily_mission` / daily-mission-complete.ts = `mission_bonus`）— cutover 時の収斂先決定が必要
- insertEntry の所有検証は family 単位（interface が childId を受けないため。child 単位化は interface 進化時）
- `.cspell/project-words.txt` への pg_catalog 語彙追記（テストが pg catalog を直接引くため。理由コメント付き）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（Agent 実装を本体セッションが独立再検証 696/696 + svelte-check 0。#3562 3 点の消化を個別確認）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: child-cluster repo は R3/R4/R5（merged/Ready）→ 本 PR → checklist / battle / 報酬系（次波）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
