### PR TITLE
fix: #3424 status_history 順序の非決定性を根治 (CI flake 50%→0、tie-breaker)

### DIFF
--- a/src/lib/server/db/dsql/status-repo.ts
+++ b/src/lib/server/db/dsql/status-repo.ts
@@ -149,7 +149,7 @@ export function createDsqlStatusRepo<TTx extends SqlExecutor>(
 			const result = await db.execute(sql`
 				SELECT ${HISTORY_COLUMNS} FROM status_history
 				WHERE family_id = ${tenantId} AND child_id = ${childId} AND category_id = ${categoryId}
-				ORDER BY recorded_at DESC
+				ORDER BY recorded_at DESC, hist_id DESC
 				LIMIT ${limit}
 			`);
 			return (result.rows as unknown as HistoryRow[]).map(toHistory);
@@ -160,7 +160,7 @@ export function createDsqlStatusRepo<TTx extends SqlExecutor>(
 				SELECT value FROM status_history
 				WHERE family_id = ${tenantId} AND child_id = ${childId} AND category_id = ${categoryId}
 					AND recorded_at < ${beforeDate}::timestamptz
-				ORDER BY recorded_at DESC
+				ORDER BY recorded_at DESC, hist_id DESC
 				LIMIT 1
 			`);
 			const row = result.rows[0] as { value: number } | undefined;

--- a/tests/unit/db/dsql-point-status-repos.test.ts
+++ b/tests/unit/db/dsql-point-status-repos.test.ts
@@ -366,6 +366,13 @@ describe('DSQL point-repo / status-repo (PR-R4、実 schema PGlite)', () => {
 			);
 			expect(entry.id).toMatch(/^[0-9a-f-]{36}$/);
 			expect(entry.value).toBe(i * 10);
+			// defaultNow() は同一ループ内で同時刻になり得る (PGlite/実 DSQL 共通) ため、
+			// 順序契約のテストとして recorded_at を明示的に単調化する。実装側は同時刻でも
+			// 決定的になるよう history_id の tie-breaker を持つ (flake 根治 2026-07-04)。
+			await t.db.execute(sql`
+				UPDATE status_history SET recorded_at = ${`2026-07-04T00:00:0${i - 1}.000Z`}
+				WHERE family_id = ${FAMILY} AND hist_id = ${String(entry.id)}
+			`);
 		}
 		const recent = await statusRepo.findRecentStatusHistory(childId, catId, FAMILY);
 		expect(recent).toHaveLength(7); // 既定 limit


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発チーム全体（CI 信頼性）

**解決する課題**: PR #3591 の CI unit-test(1) で発生し rerun で通過していた flake の根本原因が、`dsql-point-status-repos.test.ts` [S3] の**単独実行 50% fail する非決定性**と判明（実測 2/4 fail）。原因は同一ループ内 insert の recorded_at（defaultNow）が同時刻になり、`ORDER BY recorded_at DESC` に tie-breaker が無く順序非決定 — **PGlite 固有でなく実 DSQL でも起きる実装欠陥**。

**期待される効果**: status_history の読み出し順序が同時刻でも決定的になり、CI flake が根絶される（単独 5 連続 green で実証）。

## 関連 Issue

- EPIC #3424（PR #3591 = R4 の残欠陥の根治。rerun で誤魔化さない ADR-0061 shift-left 方針）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | findRecentStatusHistory / findStatusValueAtDate に hist_id DESC の tie-breaker（同時刻でも決定的順序） | 実装 diff | HEAD `8805ebf9` |
| AC2 | flake 根絶の実証: 修正前 2/4 fail → 修正後**単独 5 連続 green** | `npx vitest run tests/unit/db/dsql-point-status-repos.test.ts` ×5 | HEAD `8805ebf9` / 19 passed ×5 |
| AC3 | テストの順序契約検証は recorded_at を明示単調化（defaultNow の同時刻依存を排除。assert 意図は不変 = 弱体化なし） | test diff | HEAD `8805ebf9` / db suite 636/636 |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)（dsql/status-repo.ts の ORDER BY 2 箇所 + テスト 1 file のみ）
- [ ] サービス層 / API / ページ / UI / ドメイン / インフラ / LP / 設定

**影響を受ける画面・機能**: なし（DATA_SOURCE dispatch 未結線の DSQL backend 内。順序が同時刻タイでのみ変わる = 従来は非決定だった箇所が決定的になる方向のみ）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: [S3] の時刻明示化（assert 意図不変）
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A
- [x] Critical バグ修正の場合: N/A（CI flake、顧客影響なし）

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）**: UI 変更なし

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID/DRY/YAGNI**: ORDER BY への tie-breaker 追加のみの最小修正
- [x] **Security**: 変更なし（述語不変）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: tie-breaker は同一 index scan 内のソート補助でコスト増なし

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] **設計書同期** (ADR-0001): 設計変更なし（決定的順序は §11.2 sort 契約の当然の含意）
- [x] **並行 PR overlap** (#1200): PR #3595（R6）が本 flake の影響で pre-ready 保留中 — 本 PR merge 後に develop 取込で解消する段取り
- [ ] 他項目: N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: 同時刻 tie の順序は hist_id (uuid) 降順で「安定だが時系列意味は持たない」— 同 ms 複数記録の相対順に業務的意味は無いため許容（コメント記載）

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] Phase 分割: N/A（単一 fix）
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
