### PR TITLE
feat: #3533 残ゲートを §10.2.4 で分類確定 + 家族招待 403 文言 SSOT 化 (sub-task 5 完了)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1473,6 +1473,17 @@ P1（画面内に個別アップセル CTA を置かない）は **quota / 上�
 
 判定基準: **同一制約が 1 画面に複数表現で散在するか（= quota gate、収斂対象）** / **1 機能の存在を 1 箇所で teaser 提示するか（= feature paywall、現状維持）**。AI 提案パネルは後者のため、EPIC #3533 では **実装変更せず本区別を明文化**する（teaser の CTA は業界標準 UX で、header 導線 P3 と二重に見えても「機能 teaser」と「tier 導線」で意味分離）。
 
+**EPIC #3533 で評価した全ゲートの分類（sub-task 5 の結論）**: 本判定基準を残ゲートに適用した結果、以下に分類確定した。quota gate 3 画面（checklists / rewards / activities）は locked-but-active に収斂済（§10.2.3）。他は feature-teaser paywall で現状維持。
+
+| ゲート | 実装箇所 | gate 種別 | 分類 | 対応 |
+|---|---|---|---|---|
+| checklists / rewards / activities の「+追加」manual | 各 `admin/<res>/+page.svelte` | quota / binary | quota gate | **収斂済**（§10.2.3 locked-but-active、#3583/#3587/#3589） |
+| AI 提案（`AiSuggestPanel` / `AiSuggestChecklistPanel`） | activities / checklists の add dialog | binary（premium / family） | feature-teaser paywall | 現状維持 |
+| クラウドエクスポート（ローカル / クラウド） | `admin/settings/data` | binary（`canExport` / `maxCloudExports=0`） | feature-teaser paywall | 現状維持（`保管枠 n/max` は paid の利用メータで upsell カウンタではない） |
+| 週次メールレポート | `admin/reports` | binary（`canReceiveWeeklyEmail`） | feature-teaser paywall | 現状維持 |
+| きょうだいランキング | `admin/settings/activities` | binary（family 限定 `canSiblingRanking`） | feature-teaser paywall | 現状維持（disabled + 説明 + CTA は §10.2.4 標準） |
+| 家族メンバー招待 | `admin/members` + `api/v1/admin/invites` | quota（`maxFamilyMembers`） | quota gate（性質上） | **画面内に撤去対象の quota カウンタ・個別 CTA は無し**（gate は server 403 のみ）。403 文言のみ `PLAN_GATE_LABELS.memberLimitReached` に SSOT 化（§10.7 / P5、#3533） |
+
 ### 10.3 トライアル表示（header pill + TrialBanner）仕様
 
 **header 残日数 pill（#3033）**: trial active 中は `AdminLayout` header に `⭐ 残り N 日` pill（`data-testid="header-trial-pill"`、`TRIAL_LABELS.headerPillLabel`）を常時表示し、tap で `/admin/subscription` へ遷移する。demo / `AUTH_MODE=anonymous` では非表示（upgrade-btn と同条件）。

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -444,6 +444,15 @@ export const PLAN_GATE_LABELS = {
 	viewerTokenFamilyOnly: `${PLAN_FULL_TERMS.premium}限定の機能です`,
 
 	/**
+	 * "メンバー上限（{max}人）に達しています。プランをアップグレードしてください。"
+	 *
+	 * 家族メンバー招待の quota 上限 (maxFamilyMembers) 到達時の 403 文言 (#1111 / EPIC #3533 §10.7)。
+	 * 旧 `api/v1/admin/invites/+server.ts` 内ハードコードを SSOT 経由に是正 (ADR-0045 / P5)。
+	 */
+	memberLimitReached: (max: number | string) =>
+		`メンバー上限（${max}人）に達しています。プランをアップグレードしてください。`,
+
+	/**
 	 * プラン制限エラー banner / toast に併記するアップグレード導線リンクのラベル (#2894 AC3)。
 	 *
 	 * PlanLimitError (`upgradeUrl='/admin/subscription'`) を受領した admin 取込フローで、

--- a/src/routes/api/v1/admin/invites/+server.ts
+++ b/src/routes/api/v1/admin/invites/+server.ts
@@ -4,6 +4,7 @@
 
 import { error, isHttpError, json } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { createInviteSchema } from '$lib/domain/validation/auth';
 import { requireRole } from '$lib/server/auth/guards';
 import { validationError } from '$lib/server/errors';
@@ -58,7 +59,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		return json(
 			{
 				error: 'MEMBER_LIMIT_REACHED',
-				message: `メンバー上限（${memberLimit.max}人）に達しています。プランをアップグレードしてください。`,
+				message: PLAN_GATE_LABELS.memberLimitReached(memberLimit.max ?? 0),
 				current: memberLimit.current,
 				max: memberLimit.max,
 			},


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: EPIC #3533 sub-task 5 の残ゲート（cloud-export / 週次レポート / 家族招待 / きょうだいランキング）を §10.2.4 の判定基準（quota gate か feature-teaser paywall か）で分類し、収斂対象を確定する。加えて家族招待の 403 文言がハードコードで §10.7 SSOT から乖離していた点を是正する。

**期待される効果**: 残ゲートの分類を設計書に記録し、feature-teaser paywall（現状維持が正しい）を誤って「収斂」する将来の手戻りを防ぐ。SSOT 化で用語変更時の伝播も担保。

## 関連 Issue

EPIC #3533 sub-task 5 の残ゲート分類 + SSOT 化。統合 PR で集約 close されるため close 宣言せず参照に留める。
関連: #3533

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC5-r1 | 残 4 ゲートを §10.2.4 で分類（3=feature paywall 現状維持 / 家族招待=quota だが UI 収斂対象なし） | `docs/design/06-UI設計書.md` §10.2.4 分類表 目視 | HEAD `77a15af0` / 分類表 6 行追記 |
| AC5-r2 | 家族招待 403 文言を PLAN_GATE_LABELS.memberLimitReached に SSOT 化 | `grep -c "メンバー上限（${memberLimit.max}人）" src/routes/api/v1/admin/invites/+server.ts` | HEAD `77a15af0` / ハードコード 0 件、label 経由 |
| AC5-r3 | 描画/挙動回帰なし（typecheck/lint、文言テキスト不変） | `npx svelte-check` / `npx biome check` / `node scripts/check-hardcoded-strings.mjs` | HEAD `77a15af0` / svelte-check 0 err / biome 0 / hardcoded 0 / message テキスト不変（テスト非依存） |

## 変更タイプ

- [x] feat: 新機能

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] API エンドポイント (`src/routes/api/`) — `invites/+server.ts`（403 文言を SSOT 経由に）
- [x] ドメインモデル (`$lib/domain/`) — labels.ts（`memberLimitReached` 追加）
- [x] 設定・CI（`docs/design/06-UI設計書.md` §10.2.4 分類表）

**影響を受ける画面・機能**: 家族メンバー招待 API の 403 レスポンス文言（テキスト不変、SSOT 経由化のみ）。他ゲートは分類記録のみで実装変更なし。

## テスト & 安全装置セルフチェック

- [x] **svelte-check / biome / hardcoded / doc-code ローカル PASS**: `npx svelte-check` 0 err / `npx biome check` 0 / `node scripts/check-hardcoded-strings.mjs` 0 / `node scripts/check-doc-code-references.mjs` 新規違反なし
- [x] 追加・変更したテストの概要: N/A（403 文言テキスト不変で SSOT 経由化のみ。既存テストは message テキストを assert していないことを grep で確認）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（server / docs のみ）**: UI 変更なし（invites API の 403 文言を SSOT 経由化 + 設計書分類記録）。3 つの feature-teaser paywall（cloud-export / 週次レポート / きょうだいランキング）は §10.2.4 で現状維持と分類し実装変更しない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（文言 SSOT 化 + docs）
- [x] **DRY**: 家族招待文言を `PLAN_GATE_LABELS.memberLimitReached` に集約（ハードコード解消）
- [x] **YAGNI**: feature-teaser paywall 3 画面は現状 UX が業界標準のため不要な実装変更を避け分類記録に留めた
- [x] **Security**: N/A（403 gate ロジックは不変）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): §10.2.4 に残ゲート分類表を追記（sub-task 5 の結論記録）
- [x] **labels SSOT** (ADR-0045): 家族招待文言を `PLAN_GATE_LABELS.memberLimitReached` に SSOT 化（§10.7 / P5）
- [x] **並行 PR overlap** (#1200): 変更は labels.ts / invites +server.ts / 設計書。同時変更の open PR なし
- [x] N/A — 本番/デモ同期・年齢モード・ナビ・E2E は本変更の性質上対象外（server 403 文言 + docs）

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（403 文言テキスト不変、gate ロジック不変）

**レビュー依頼事項・QA**: 残 4 ゲートの分類判断（3 = feature-teaser paywall 現状維持 / 家族招待 = quota だが UI 収斂対象なし）が §10.2.4 の判定基準と整合するか。特に cloud-export の「保管枠 n/max」カウンタを「paid の利用メータ（upsell カウンタではない）」として現状維持とした点。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] svelte-check / biome / hardcoded / doc-code ローカル PASS
- [x] セルフレビュー済み（不要な差分なし）
- [x] 全 AC が実装済み（sub-task 5 完了。残るは AC6 の CX-DoR M5 + at-limit E2E）
- [x] Phase 分割: EPIC #3533 で PO 合意済み
- [x] UI 変更時: N/A（server / docs のみ）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
