### PR TITLE
feat: #3424 PR-R7 — DSQL IChecklistRepo 実装 (family master + per-child assignments、ADR-0055)

### DIFF
--- a/src/lib/server/db/dsql/checklist-repo.ts
+++ b/src/lib/server/db/dsql/checklist-repo.ts
@@ -1,0 +1,579 @@
+// src/lib/server/db/dsql/checklist-repo.ts
+// EPIC #3424 / PR-R7 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §5 / §10 / §11.2 / §P9
+//
+// IChecklistRepo の DSQL backend 実装。child-cluster 最複雑 = ADR-0055 の
+// **family master template + per-child assignments(配信) + per-child progress(logs) +
+// per-child override** モデル (docs/design/dsql-data-model.md §10)。設計契約:
+//   - **factory 注入** (fitness#8: module-level db/client import 禁止)。db (SqlExecutor) と
+//     TransactionRunner を呼び出し側 (client factory / テスト) が渡す。
+//   - **§P9 tenant 述語**: 全メソッドが family_id = tenantId を WHERE に含む。
+//   - **template は family scope の 1 レコード** (ADR-0055 §10): checklist_templates は
+//     (family_id, template_id) で一意化し child ごとに複製しない。per-child view は
+//     assignments (checklist_template_assignments) を join して「配信済 template」を絞る。
+//     「別の子から取込 (copy)」= assignments 追加のみ (template は複製しない)。この非対称を
+//     findTemplatesByChild(assignments join) / assignTemplateToChildren(配信) で表現する。
+//   - **§5 JSON 解体**: checklist_logs.itemsJson は checklist_log_items 子表に解体済 (schema)。
+//     log 読み出しは JSON 復元でなく子表 join で itemsJson (= checked item id の配列) を再構成する。
+//     itemsJson の意味は checklist-service の `JSON.stringify(checkedIds)` (checked な item id 群)。
+//     upsertLog は log 行 + log_items を **単一 txn** で保存する (log と checked 集合の整合)。
+//   - **entity 境界**: isActive / isArchived / completedAll は number (0/1) 契約 — boolean 列を
+//     読み出し時に変換 (既存 sqlite backend と同一 shape)。
+//   - **surrogate 無し表の合成 id** (§11.2、daily-mission の自然キー戦略と同判断):
+//     assignments PK = (family, template, child) / logs PK = (family, child, template, checked_date)
+//     は surrogate id 列を持たないため entity の `id` は複合キーの合成文字列を返す
+//     (ChecklistTemplateAssignment.id / ChecklistLog.id の消費は表示 key のみで grep 確認済 —
+//      checklist-service は a.templateId / a.childId、admin +page は completedAll / points を使う)。
+//   - **tenant 境界 (#3562 ③ parity)**: assignments の INSERT は「template が同 family に属する」
+//     ことを INSERT ... SELECT FROM checklist_templates で強制し orphan / cross-family を構造排除。
+
+import { sql } from 'drizzle-orm';
+import type { ArchivedReason } from '$lib/domain/archive-types';
+import { asChildId } from '$lib/domain/ids';
+import type { IChecklistRepo } from '../interfaces/checklist-repo.interface';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type {
+	ChecklistLog,
+	ChecklistOverride,
+	ChecklistTemplate,
+	ChecklistTemplateAssignment,
+	ChecklistTemplateItem,
+} from '../types';
+import type { SqlExecutor } from './sql-executor';
+
+interface TemplateRow {
+	family_id: string;
+	template_id: string;
+	name: string;
+	icon: string;
+	points_per_item: number;
+	completion_bonus: number;
+	time_slot: string;
+	is_active: boolean;
+	is_archived: boolean;
+	archived_reason: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+interface AssignmentRow {
+	family_id: string;
+	template_id: string;
+	child_id: string;
+	created_at: string;
+}
+
+interface ItemRow {
+	family_id: string;
+	template_id: string;
+	item_id: string;
+	name: string;
+	icon: string;
+	frequency: string;
+	direction: string;
+	sort_order: number;
+	created_at: string;
+}
+
+interface LogRow {
+	family_id: string;
+	child_id: string;
+	template_id: string;
+	checked_date: string;
+	completed_all: boolean;
+	points_awarded: number;
+	created_at: string;
+}
+
+interface OverrideRow {
+	family_id: string;
+	child_id: string;
+	override_id: string;
+	target_date: string;
+	action: string;
+	item_name: string;
+	icon: string;
+	created_at: string;
+}
+
+const TEMPLATE_COLUMNS = sql.raw(
+	`family_id, template_id, name, icon, points_per_item, completion_bonus, time_slot,
+	 is_active, is_archived, archived_reason, created_at, updated_at`,
+);
+const ASSIGNMENT_COLUMNS = sql.raw('family_id, template_id, child_id, created_at');
+const ITEM_COLUMNS = sql.raw(
+	'family_id, template_id, item_id, name, icon, frequency, direction, sort_order, created_at',
+);
+const LOG_COLUMNS = sql.raw(
+	'family_id, child_id, template_id, checked_date, completed_all, points_awarded, created_at',
+);
+const OVERRIDE_COLUMNS = sql.raw(
+	'family_id, child_id, override_id, target_date, action, item_name, icon, created_at',
+);
+
+/** row → ChecklistTemplate entity (boolean → 0/1、sqlite 互換 shape)。
+ * sourcePresetId: DSQL checklist_templates は source_preset_id 列を持たない (§10 marketplace
+ * 帰属記録は将来課題) ため常に null を返す (entity 側は optional)。 */
+function toTemplate(row: TemplateRow): ChecklistTemplate {
+	return {
+		id: row.template_id,
+		tenantId: row.family_id,
+		name: row.name,
+		icon: row.icon,
+		pointsPerItem: row.points_per_item,
+		completionBonus: row.completion_bonus,
+		timeSlot: row.time_slot,
+		isActive: row.is_active ? 1 : 0,
+		isArchived: row.is_archived ? 1 : 0,
+		archivedReason: row.archived_reason,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+		sourcePresetId: null,
+	};
+}
+
+/** 合成 id (§11.2 surrogate 無し): assignments = `${template}:${child}`。 */
+function toAssignment(row: AssignmentRow): ChecklistTemplateAssignment {
+	return {
+		id: `${row.template_id}:${row.child_id}`,
+		templateId: row.template_id,
+		childId: asChildId(row.child_id),
+		createdAt: row.created_at,
+	};
+}
+
+function toItem(row: ItemRow): ChecklistTemplateItem {
+	return {
+		id: row.item_id,
+		templateId: row.template_id,
+		name: row.name,
+		icon: row.icon,
+		frequency: row.frequency,
+		direction: row.direction,
+		sortOrder: row.sort_order,
+		createdAt: row.created_at,
+	};
+}
+
+/** 合成 id (§11.2 surrogate 無し): logs = `${child}:${template}:${date}`。
+ * itemsJson は checklist_log_items 子表を join した checked item id 配列 (§5)。 */
+function toLog(row: LogRow, itemsJson: string): ChecklistLog {
+	return {
+		id: `${row.child_id}:${row.template_id}:${row.checked_date}`,
+		childId: asChildId(row.child_id),
+		templateId: row.template_id,
+		checkedDate: row.checked_date,
+		itemsJson,
+		completedAll: row.completed_all ? 1 : 0,
+		pointsAwarded: row.points_awarded,
+		createdAt: row.created_at,
+	};
+}
+
+function toOverride(row: OverrideRow): ChecklistOverride {
+	return {
+		id: row.override_id,
+		childId: asChildId(row.child_id),
+		targetDate: row.target_date,
+		action: row.action,
+		itemName: row.item_name,
+		icon: row.icon,
+		createdAt: row.created_at,
+	};
+}
+
+/** itemsJson (checked item id の配列文字列) を parse (legacy number 配列も String 正規化)。 */
+function parseCheckedIds(itemsJson: string): string[] {
+	const raw = JSON.parse(itemsJson) as (string | number)[];
+	return raw.map(String);
+}
+
+/** DSQL 用 IChecklistRepo を生成する (db/runner は注入、fitness#8)。 */
+export function createDsqlChecklistRepo<TTx extends SqlExecutor>(
+	db: SqlExecutor,
+	runner: TransactionRunner<TTx>,
+): IChecklistRepo {
+	// 指定 (family, child, template, date) の checked item id 群を子表から復元 (§5)。
+	// item_id 昇順で正規化する (itemsJson は checklist-service で Set 照合されるため順序非依存)。
+	const readCheckedIds = async (
+		childId: string,
+		templateId: string,
+		date: string,
+		tenantId: string,
+	): Promise<string[]> => {
+		const result = await db.execute(sql`
+			SELECT item_id FROM checklist_log_items
+			WHERE family_id = ${tenantId} AND child_id = ${childId}
+				AND template_id = ${templateId} AND checked_date = ${date} AND checked = true
+			ORDER BY item_id
+		`);
+		return (result.rows as { item_id: string }[]).map((r) => r.item_id);
+	};
+
+	return {
+		// ── Templates (family scope) ──────────────────────────────
+
+		async findTemplatesByTenant(tenantId, includeInactive = false) {
+			const conditions = [sql`family_id = ${tenantId}`, sql`is_archived = false`];
+			if (!includeInactive) conditions.push(sql`is_active = true`);
+			const result = await db.execute(sql`
+				SELECT ${TEMPLATE_COLUMNS} FROM checklist_templates
+				WHERE ${sql.join(conditions, sql` AND `)}
+				ORDER BY created_at, template_id
+			`);
+			return (result.rows as unknown as TemplateRow[]).map(toTemplate);
+		},
+
+		async findTemplatesByChild(
+			childId,
+			tenantId,
+			includeInactive = false,
+			includeArchived = false,
+		) {
+			// 配信済 (assignments join) の family master を child 視点で取得 (§10)。
+			const conditions = [sql`a.family_id = ${tenantId}`, sql`a.child_id = ${String(childId)}`];
+			if (!includeArchived) conditions.push(sql`t.is_archived = false`);
+			if (!includeInactive) conditions.push(sql`t.is_active = true`);
+			const result = await db.execute(sql`
+				SELECT t.family_id, t.template_id, t.name, t.icon, t.points_per_item, t.completion_bonus,
+					t.time_slot, t.is_active, t.is_archived, t.archived_reason, t.created_at, t.updated_at
+				FROM checklist_templates t
+				JOIN checklist_template_assignments a
+					ON a.family_id = t.family_id AND a.template_id = t.template_id
+				WHERE ${sql.join(conditions, sql` AND `)}
+				ORDER BY t.created_at, t.template_id
+			`);
+			return (result.rows as unknown as TemplateRow[]).map(toTemplate);
+		},
+
+		async findTemplateById(id, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${TEMPLATE_COLUMNS} FROM checklist_templates
+				WHERE family_id = ${tenantId} AND template_id = ${id}
+			`);
+			const row = result.rows[0] as unknown as TemplateRow | undefined;
+			return row ? toTemplate(row) : undefined;
+		},
+
+		async insertTemplate(input, tenantId) {
+			// 未指定は schema default に合わせた値を明示 (child-activity buildInsertSql と同方針)。
+			const result = await db.execute(sql`
+				INSERT INTO checklist_templates
+					(family_id, name, icon, points_per_item, completion_bonus, time_slot, is_active, is_archived)
+				VALUES (${tenantId}, ${input.name}, ${input.icon ?? '📋'}, ${input.pointsPerItem ?? 2},
+					${input.completionBonus ?? 5}, ${input.timeSlot ?? 'anytime'},
+					${(input.isActive ?? 1) !== 0}, ${(input.isArchived ?? 0) !== 0})
+				RETURNING ${TEMPLATE_COLUMNS}
+			`);
+			return toTemplate(result.rows[0] as unknown as TemplateRow);
+		},
+
+		async updateTemplate(id, input, tenantId) {
+			const sets = [sql`updated_at = now()`];
+			if (input.name !== undefined) sets.push(sql`name = ${input.name}`);
+			if (input.icon !== undefined) sets.push(sql`icon = ${input.icon}`);
+			if (input.pointsPerItem !== undefined)
+				sets.push(sql`points_per_item = ${input.pointsPerItem}`);
+			if (input.completionBonus !== undefined)
+				sets.push(sql`completion_bonus = ${input.completionBonus}`);
+			if (input.timeSlot !== undefined) sets.push(sql`time_slot = ${input.timeSlot}`);
+			if (input.isActive !== undefined) sets.push(sql`is_active = ${input.isActive !== 0}`);
+			const result = await db.execute(sql`
+				UPDATE checklist_templates SET ${sql.join(sets, sql`, `)}
+				WHERE family_id = ${tenantId} AND template_id = ${id}
+				RETURNING ${TEMPLATE_COLUMNS}
+			`);
+			const row = result.rows[0] as unknown as TemplateRow | undefined;
+			return row ? toTemplate(row) : undefined;
+		},
+
+		async deleteTemplate(id, tenantId) {
+			// cascade を単一 txn (fitness#7: work 内 await は tx.execute 直呼びのみ)。子表 →
+			// 親 template の順で削除し orphan を残さない。§P9: family 述語で他 tenant を保護。
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(
+					sql`DELETE FROM checklist_log_items WHERE family_id = ${tenantId} AND template_id = ${id}`,
+				);
+				await tx.execute(
+					sql`DELETE FROM checklist_logs WHERE family_id = ${tenantId} AND template_id = ${id}`,
+				);
+				await tx.execute(
+					sql`DELETE FROM checklist_template_assignments WHERE family_id = ${tenantId} AND template_id = ${id}`,
+				);
+				await tx.execute(
+					sql`DELETE FROM checklist_template_items WHERE family_id = ${tenantId} AND template_id = ${id}`,
+				);
+				await tx.execute(
+					sql`DELETE FROM checklist_templates WHERE family_id = ${tenantId} AND template_id = ${id}`,
+				);
+			});
+		},
+
+		// ── Distribution (assignments) ────────────────────────────
+
+		async findAssignmentsByTemplate(templateId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${ASSIGNMENT_COLUMNS} FROM checklist_template_assignments
+				WHERE family_id = ${tenantId} AND template_id = ${templateId}
+				ORDER BY child_id
+			`);
+			return (result.rows as unknown as AssignmentRow[]).map(toAssignment);
+		},
+
+		async findAssignmentsByChild(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${ASSIGNMENT_COLUMNS} FROM checklist_template_assignments
+				WHERE family_id = ${tenantId} AND child_id = ${String(childId)}
+				ORDER BY template_id
+			`);
+			return (result.rows as unknown as AssignmentRow[]).map(toAssignment);
+		},
+
+		async assignTemplateToChildren(templateId, childIds, tenantId) {
+			if (childIds.length === 0) return [];
+			// 配信を all-or-nothing に (単一 txn)。#3562 ③ parity: template 所有を INSERT ... SELECT で
+			// 強制し、他 family template / 存在しない template への orphan 配信を構造排除。既配信は
+			// PK ON CONFLICT DO NOTHING で skip し、RETURNING で「実際に追加された」assignment のみ返す。
+			return runner.runInTransaction(async (tx) => {
+				const inserted: ChecklistTemplateAssignment[] = [];
+				for (const childId of childIds) {
+					const result = await tx.execute(sql`
+						INSERT INTO checklist_template_assignments (family_id, template_id, child_id)
+						SELECT t.family_id, t.template_id, ${String(childId)}
+						FROM checklist_templates t
+						WHERE t.family_id = ${tenantId} AND t.template_id = ${templateId}
+						ON CONFLICT (family_id, template_id, child_id) DO NOTHING
+						RETURNING ${ASSIGNMENT_COLUMNS}
+					`);
+					const row = result.rows[0] as unknown as AssignmentRow | undefined;
+					if (row) inserted.push(toAssignment(row));
+				}
+				return inserted;
+			});
+		},
+
+		async unassignTemplateFromChildren(templateId, childIds, tenantId) {
+			if (childIds.length === 0) return;
+			await db.execute(sql`
+				DELETE FROM checklist_template_assignments
+				WHERE family_id = ${tenantId} AND template_id = ${templateId}
+					AND child_id IN (${sql.join(
+						childIds.map((c) => sql`${String(c)}`),
+						sql`, `,
+					)})
+			`);
+		},
+
+		async unassignTemplate(templateId, tenantId) {
+			await db.execute(sql`
+				DELETE FROM checklist_template_assignments
+				WHERE family_id = ${tenantId} AND template_id = ${templateId}
+			`);
+		},
+
+		// ── Template items ────────────────────────────────────────
+
+		async findTemplateItems(templateId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${ITEM_COLUMNS} FROM checklist_template_items
+				WHERE family_id = ${tenantId} AND template_id = ${templateId}
+				ORDER BY sort_order, item_id
+			`);
+			return (result.rows as unknown as ItemRow[]).map(toItem);
+		},
+
+		async insertTemplateItem(input, tenantId) {
+			// item_id は schema default (gen_random_uuid())。family_id = tenantId タグ付けで
+			// tenant 越境 write を構造排除 (§P9)。
+			const result = await db.execute(sql`
+				INSERT INTO checklist_template_items
+					(family_id, template_id, name, icon, frequency, direction, sort_order)
+				VALUES (${tenantId}, ${input.templateId}, ${input.name}, ${input.icon ?? '🏫'},
+					${input.frequency ?? 'daily'}, ${input.direction ?? 'bring'}, ${input.sortOrder ?? 0})
+				RETURNING ${ITEM_COLUMNS}
+			`);
+			return toItem(result.rows[0] as unknown as ItemRow);
+		},
+
+		async deleteTemplateItem(templateId, id, tenantId) {
+			// #2845 B1: (family, template, item) composite — 不一致は affected 0 の no-op。
+			await db.execute(sql`
+				DELETE FROM checklist_template_items
+				WHERE family_id = ${tenantId} AND template_id = ${templateId} AND item_id = ${id}
+			`);
+		},
+
+		// ── Per-child progress (logs、§5 子表化) ──────────────────
+
+		async findTodayLog(childId, templateId, date, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${LOG_COLUMNS} FROM checklist_logs
+				WHERE family_id = ${tenantId} AND child_id = ${String(childId)}
+					AND template_id = ${templateId} AND checked_date = ${date}
+			`);
+			const row = result.rows[0] as unknown as LogRow | undefined;
+			if (!row) return undefined;
+			const checkedIds = await readCheckedIds(String(childId), templateId, date, tenantId);
+			return toLog(row, JSON.stringify(checkedIds));
+		},
+
+		async upsertLog(input, tenantId) {
+			// log 行 + checked 集合 (checklist_log_items) を単一 txn で保存 (§5: itemsJson 子表化)。
+			// checked 集合は毎回 delete → re-insert で置換する (checklist-service は全 checked id を
+			// 渡すため差分でなく全置換が正)。log 行は PK ON CONFLICT DO UPDATE (created_at は不変)。
+			const checkedIds = parseCheckedIds(input.itemsJson);
+			const childId = String(input.childId);
+			const { templateId, checkedDate } = input;
+			const completedAll = input.completedAll !== 0;
+			const row = await runner.runInTransaction(async (tx) => {
+				const upserted = await tx.execute(sql`
+					INSERT INTO checklist_logs
+						(family_id, child_id, template_id, checked_date, completed_all, points_awarded)
+					VALUES (${tenantId}, ${childId}, ${templateId}, ${checkedDate}, ${completedAll},
+						${input.pointsAwarded})
+					ON CONFLICT (family_id, child_id, template_id, checked_date)
+					DO UPDATE SET completed_all = ${completedAll}, points_awarded = ${input.pointsAwarded}
+					RETURNING ${LOG_COLUMNS}
+				`);
+				await tx.execute(sql`
+					DELETE FROM checklist_log_items
+					WHERE family_id = ${tenantId} AND child_id = ${childId}
+						AND template_id = ${templateId} AND checked_date = ${checkedDate}
+				`);
+				for (const itemId of checkedIds) {
+					await tx.execute(sql`
+						INSERT INTO checklist_log_items
+							(family_id, child_id, template_id, checked_date, item_id, checked)
+						VALUES (${tenantId}, ${childId}, ${templateId}, ${checkedDate}, ${itemId}, true)
+						ON CONFLICT (family_id, child_id, template_id, checked_date, item_id)
+						DO UPDATE SET checked = true
+					`);
+				}
+				return upserted.rows[0] as unknown as LogRow;
+			});
+			// 返り値の itemsJson は保存した checked 集合を item_id 正規化した配列 (read と同 shape)。
+			return toLog(row, JSON.stringify(checkedIds.slice().sort()));
+		},
+
+		async findLogsByChild(childId, tenantId) {
+			const id = String(childId);
+			const logsResult = await db.execute(sql`
+				SELECT ${LOG_COLUMNS} FROM checklist_logs
+				WHERE family_id = ${tenantId} AND child_id = ${id}
+				ORDER BY checked_date DESC
+			`);
+			const logRows = logsResult.rows as unknown as LogRow[];
+			if (logRows.length === 0) return [];
+			// checked 集合を 1 クエリで取得し (template, date) でグルーピング (N+1 回避)。
+			const itemsResult = await db.execute(sql`
+				SELECT template_id, checked_date, item_id FROM checklist_log_items
+				WHERE family_id = ${tenantId} AND child_id = ${id} AND checked = true
+				ORDER BY item_id
+			`);
+			const grouped = new Map<string, string[]>();
+			for (const r of itemsResult.rows as {
+				template_id: string;
+				checked_date: string;
+				item_id: string;
+			}[]) {
+				const key = `${r.template_id} ${r.checked_date}`;
+				const list = grouped.get(key);
+				if (list) list.push(r.item_id);
+				else grouped.set(key, [r.item_id]);
+			}
+			return logRows.map((row) => {
+				const key = `${row.template_id} ${row.checked_date}`;
+				return toLog(row, JSON.stringify(grouped.get(key) ?? []));
+			});
+		},
+
+		// ── Per-child overrides ───────────────────────────────────
+
+		async findOverrides(childId, date, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${OVERRIDE_COLUMNS} FROM checklist_overrides
+				WHERE family_id = ${tenantId} AND child_id = ${String(childId)} AND target_date = ${date}
+				ORDER BY created_at, override_id
+			`);
+			return (result.rows as unknown as OverrideRow[]).map(toOverride);
+		},
+
+		async insertOverride(input, tenantId) {
+			const result = await db.execute(sql`
+				INSERT INTO checklist_overrides (family_id, child_id, target_date, action, item_name, icon)
+				VALUES (${tenantId}, ${String(input.childId)}, ${input.targetDate}, ${input.action},
+					${input.itemName}, ${input.icon ?? '📦'})
+				RETURNING ${OVERRIDE_COLUMNS}
+			`);
+			return toOverride(result.rows[0] as unknown as OverrideRow);
+		},
+
+		async findOverridesByChild(childId, tenantId) {
+			const result = await db.execute(sql`
+				SELECT ${OVERRIDE_COLUMNS} FROM checklist_overrides
+				WHERE family_id = ${tenantId} AND child_id = ${String(childId)}
+				ORDER BY target_date, override_id
+			`);
+			return (result.rows as unknown as OverrideRow[]).map(toOverride);
+		},
+
+		async insertOverrideForRestore(input, tenantId) {
+			// #3329 backup restore: createdAt を verbatim 保全 (insertOverride と違い default(now)
+			// に落とさない)。override_id は新規採番 (schema default)。
+			const result = await db.execute(sql`
+				INSERT INTO checklist_overrides
+					(family_id, child_id, target_date, action, item_name, icon, created_at)
+				VALUES (${tenantId}, ${String(input.childId)}, ${input.targetDate}, ${input.action},
+					${input.itemName}, ${input.icon}, ${input.createdAt}::timestamptz)
+				RETURNING ${OVERRIDE_COLUMNS}
+			`);
+			return toOverride(result.rows[0] as unknown as OverrideRow);
+		},
+
+		async deleteOverride(childId, id, tenantId) {
+			// #2845 B1: (family, child, override) composite — 不一致は affected 0 の no-op。
+			await db.execute(sql`
+				DELETE FROM checklist_overrides
+				WHERE family_id = ${tenantId} AND child_id = ${String(childId)} AND override_id = ${id}
+			`);
+		},
+
+		// ── archive / restore (family scope) ──────────────────────
+
+		async archiveChecklistTemplates(ids, reason: ArchivedReason, tenantId) {
+			if (ids.length === 0) return;
+			await db.execute(sql`
+				UPDATE checklist_templates
+				SET is_archived = true, archived_reason = ${reason}, updated_at = now()
+				WHERE family_id = ${tenantId} AND template_id IN (${sql.join(
+					ids.map((id) => sql`${id}`),
+					sql`, `,
+				)})
+			`);
+		},
+
+		async restoreArchivedChecklistTemplates(reason: ArchivedReason, tenantId) {
+			await db.execute(sql`
+				UPDATE checklist_templates
+				SET is_archived = false, archived_reason = NULL, updated_at = now()
+				WHERE family_id = ${tenantId} AND is_archived = true AND archived_reason = ${reason}
+			`);
+		},
+
+		// ── Tenant bulk deletion ──────────────────────────────────
+
+		async deleteByTenantId(tenantId) {
+			// 全 6 表を単一 txn で tenant 限定削除 (fitness#7)。sqlite (シングルテナント全行削除) と
+			// 違い family 述語で tenant 限定 (§P9)。子表 → 親の順で削除。
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(sql`DELETE FROM checklist_log_items WHERE family_id = ${tenantId}`);
+				await tx.execute(sql`DELETE FROM checklist_logs WHERE family_id = ${tenantId}`);
+				await tx.execute(sql`DELETE FROM checklist_overrides WHERE family_id = ${tenantId}`);
+				await tx.execute(
+					sql`DELETE FROM checklist_template_assignments WHERE family_id = ${tenantId}`,
+				);
+				await tx.execute(sql`DELETE FROM checklist_template_items WHERE family_id = ${tenantId}`);
+				await tx.execute(sql`DELETE FROM checklist_templates WHERE family_id = ${tenantId}`);
+			});
+		},
+	};
+}

--- a/tests/unit/db/dsql-checklist-repo.test.ts
+++ b/tests/unit/db/dsql-checklist-repo.test.ts
@@ -1,0 +1,678 @@
+// tests/unit/db/dsql-checklist-repo.test.ts
+// EPIC #3424 / PR-R7 (repo 層 build order §12.2.1) / 設計 SSOT: dsql-data-model.md §5 / §10 / §11.2 / §P9
+//
+// DSQL IChecklistRepo 実装のテスト。実 schema (pushSchema 適用、dsql-test-db helper)。
+// checklist は child-cluster 最複雑 = ADR-0055 family master template + per-child assignments
+// + per-child progress(logs) + per-child override モデル (docs/design/dsql-data-model.md §10)。
+//
+// ── Templates (family master) ──
+//   [T1] insertTemplate + findTemplateById round-trip (default 値 / 0-1 契約 / tenantId=family)
+//   [T2] findTemplatesByTenant: includeInactive filter + archived 除外 + §P9 tenant 分離
+//   [T3] updateTemplate: 部分更新 + updated_at 更新 + §P9 (他 tenant は no-op)
+//   [T4] deleteTemplate: cascade (assignments / items / logs / log_items 消去) + §P9
+// ── Distribution (assignments = 配信) ──
+//   [A1] assignTemplateToChildren: only-new 返却 + 既配信 skip + tenant 境界 (他 family template→0)
+//   [A2] findAssignmentsByTemplate / findAssignmentsByChild + §P9
+//   [A3] unassignTemplateFromChildren (subset / 空 no-op) + unassignTemplate (全解除)
+// ── Templates by child (assignments join) ──
+//   [C1] findTemplatesByChild: 配信済 template のみ (assignments join) / includeArchived /
+//        includeInactive / cross-child 分離 / §P9
+//   [CP1] copy (別の子から取込) = assignments 追加。同一 family template を 2 人目に配信しても
+//         template は複製されず (family 1 レコード) 両 child の findTemplatesByChild が同一 id を返す
+// ── Items ──
+//   [I1] insertTemplateItem + findTemplateItems (sort_order 順) + §P9
+//   [I2] deleteTemplateItem: (templateId, id) composite — 別 template を名乗った削除は no-op
+// ── Logs (§5 子表化: itemsJson は checklist_log_items 子表を join で復元、JSON blob でない) ──
+//   [L1] upsertLog insert → findTodayLog が checklist_log_items を join して itemsJson 復元 +
+//        completedAll 0/1 + pointsAwarded + §P9 / cross-child 分離
+//   [L2] upsertLog update (再 upsert): log_items 集合を置換 + created_at 保全
+//   [L3] findLogsByChild: 複数日をバルク取得 (checked_date desc) + §P9
+//   [L4] log + items 単一 txn: checklist_log_items 行数 = checked id 数 / 空 itemsJson → 0 件
+// ── Overrides ──
+//   [O1] insertOverride + findOverrides (child × date) + §P9
+//   [O2] findOverridesByChild (全日) + insertOverrideForRestore (createdAt verbatim 保全)
+//   [O3] deleteOverride: (childId, id) composite — 別 child を名乗った削除は no-op
+// ── archive / restore ──
+//   [R1] archiveChecklistTemplates(ids, reason) → findTemplatesByTenant から除外 +
+//        restoreArchivedChecklistTemplates(reason) 復元 + §P9
+// ── tenant bulk delete ──
+//   [D1] deleteByTenantId: 全 6 表を tenant 限定削除、他 tenant 無傷
+// ── CHECK / UNIQUE 実効 ──
+//   [X1] time_slot CHECK / override action CHECK / assignment PK 二重 / log PK 二重 を直接 INSERT で拒否
+
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { ChildId } from '../../../src/lib/domain/ids';
+import { createDsqlChecklistRepo } from '../../../src/lib/server/db/dsql/checklist-repo';
+import { createDsqlChildRepo } from '../../../src/lib/server/db/dsql/child-repo';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import type { SqlExecutor } from '../../../src/lib/server/db/dsql/sql-executor';
+import type { IChecklistRepo } from '../../../src/lib/server/db/interfaces/checklist-repo.interface';
+import type { IChildRepo } from '../../../src/lib/server/db/interfaces/child-repo.interface';
+import type { TransactionRunner } from '../../../src/lib/server/db/interfaces/transaction.interface';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+const FAMILY = '00000000-0000-4000-8000-0000000000d1';
+const OTHER_FAMILY = '00000000-0000-4000-8000-0000000000d2';
+// tenant-wide list assertion (findTemplatesByTenant / archive / deleteByTenantId) 用の隔離 family。
+const FAM_T2 = '00000000-0000-4000-8000-0000000000d3';
+const FAM_R1 = '00000000-0000-4000-8000-0000000000d4';
+const FAM_D1 = '00000000-0000-4000-8000-0000000000d5';
+const UUID_RE = /^[0-9a-f-]{36}$/;
+
+const sortedIds = (json: string): string[] => (JSON.parse(json) as string[]).slice().sort();
+
+describe('DSQL checklist-repo (PR-R7、実 schema PGlite、family master + per-child)', () => {
+	let t: DsqlTestDb;
+	let childRepo: IChildRepo;
+	let repo: IChecklistRepo;
+	let runner: TransactionRunner<SqlExecutor>;
+
+	const newChild = async (nickname: string, family = FAMILY): Promise<ChildId> => {
+		const c = await childRepo.insertChild({ nickname, age: 8, birthDate: '2018-01-15' }, family);
+		return c.id;
+	};
+
+	const countRows = async (query: ReturnType<typeof sql>): Promise<number> => {
+		const r = await t.db.execute(query);
+		return Number((r.rows[0] as { c: unknown }).c);
+	};
+
+	beforeAll(async () => {
+		t = await createDsqlTestDb();
+		runner = createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 });
+		childRepo = createDsqlChildRepo(t.db, runner);
+		repo = createDsqlChecklistRepo(t.db, runner);
+	}, 60_000);
+	afterAll(async () => {
+		await t.close();
+	});
+
+	// ─────────────────── Templates (family master) ───────────────────
+
+	it('[T1] insertTemplate + findTemplateById: round-trip (default / 0-1 契約 / tenantId=family)', async () => {
+		const created = await repo.insertTemplate({ name: 'あさのしたく' }, FAMILY);
+		expect(created.id).toMatch(UUID_RE);
+		expect(created.tenantId).toBe(FAMILY);
+		expect(created.name).toBe('あさのしたく');
+		expect(created.icon).toBe('📋'); // schema default
+		expect(created.pointsPerItem).toBe(2);
+		expect(created.completionBonus).toBe(5);
+		expect(created.timeSlot).toBe('anytime');
+		expect(created.isActive).toBe(1); // 0/1 契約
+		expect(created.isArchived).toBe(0);
+		expect(created.archivedReason).toBe(null);
+		expect(typeof created.createdAt).toBe('string');
+
+		const found = await repo.findTemplateById(created.id, FAMILY);
+		expect(found?.id).toBe(created.id);
+		expect(found?.name).toBe('あさのしたく');
+		// §P9: 他 family からは不可視
+		expect(await repo.findTemplateById(created.id, OTHER_FAMILY)).toBe(undefined);
+	});
+
+	it('[T2] findTemplatesByTenant: includeInactive filter + archived 除外 + §P9', async () => {
+		const active = await repo.insertTemplate({ name: 'active', isActive: 1 }, FAM_T2);
+		const inactive = await repo.insertTemplate({ name: 'inactive', isActive: 0 }, FAM_T2);
+		const archived = await repo.insertTemplate({ name: 'archived' }, FAM_T2);
+		await repo.archiveChecklistTemplates([archived.id], 'trial_expired', FAM_T2);
+
+		// 既定: active のみ (inactive + archived 除外)
+		const def = await repo.findTemplatesByTenant(FAM_T2);
+		expect(def.map((r) => r.id).sort()).toEqual([active.id].sort());
+
+		// includeInactive: active + inactive (archived は依然除外)
+		const withInactive = await repo.findTemplatesByTenant(FAM_T2, true);
+		expect(withInactive.map((r) => r.id).sort()).toEqual([active.id, inactive.id].sort());
+
+		// §P9
+		expect(await repo.findTemplatesByTenant(FAMILY)).not.toContainEqual(
+			expect.objectContaining({ id: active.id }),
+		);
+	});
+
+	it('[T3] updateTemplate: 部分更新 + updated_at 更新 + §P9 no-op', async () => {
+		const tpl = await repo.insertTemplate(
+			{ name: 'まえ', pointsPerItem: 2, timeSlot: 'morning' },
+			FAMILY,
+		);
+		const updated = await repo.updateTemplate(tpl.id, { name: 'あと', pointsPerItem: 9 }, FAMILY);
+		expect(updated?.name).toBe('あと');
+		expect(updated?.pointsPerItem).toBe(9);
+		expect(updated?.timeSlot).toBe('morning'); // 未指定は不変
+		expect(Date.parse(updated?.updatedAt ?? '')).toBeGreaterThanOrEqual(Date.parse(tpl.updatedAt));
+
+		// §P9: 他 tenant を名乗った update は no-op (undefined) + 実データ不変
+		expect(await repo.updateTemplate(tpl.id, { name: 'X' }, OTHER_FAMILY)).toBe(undefined);
+		expect((await repo.findTemplateById(tpl.id, FAMILY))?.name).toBe('あと');
+	});
+
+	it('[T4] deleteTemplate: cascade (assignments / items / logs / log_items) + §P9', async () => {
+		const child = await newChild('カスケード太郎');
+		const tpl = await repo.insertTemplate({ name: 'けす' }, FAMILY);
+		const item = await repo.insertTemplateItem({ templateId: tpl.id, name: 'ぼうし' }, FAMILY);
+		await repo.assignTemplateToChildren(tpl.id, [child], FAMILY);
+		await repo.upsertLog(
+			{
+				childId: child,
+				templateId: tpl.id,
+				checkedDate: '2026-07-01',
+				itemsJson: JSON.stringify([item.id]),
+				completedAll: 1,
+				pointsAwarded: 7,
+			},
+			FAMILY,
+		);
+
+		// §P9: 他 tenant を名乗った delete は no-op
+		await repo.deleteTemplate(tpl.id, OTHER_FAMILY);
+		expect(await repo.findTemplateById(tpl.id, FAMILY)).toBeDefined();
+
+		await repo.deleteTemplate(tpl.id, FAMILY);
+		expect(await repo.findTemplateById(tpl.id, FAMILY)).toBe(undefined);
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM checklist_template_assignments WHERE template_id = ${tpl.id}`,
+			),
+		).toBe(0);
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM checklist_template_items WHERE template_id = ${tpl.id}`,
+			),
+		).toBe(0);
+		expect(
+			await countRows(sql`SELECT count(*) AS c FROM checklist_logs WHERE template_id = ${tpl.id}`),
+		).toBe(0);
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM checklist_log_items WHERE template_id = ${tpl.id}`,
+			),
+		).toBe(0);
+	});
+
+	// ─────────────────── Distribution (assignments) ───────────────────
+
+	it('[A1] assignTemplateToChildren: only-new 返却 + 既配信 skip + tenant 境界', async () => {
+		const a = await newChild('配信A');
+		const b = await newChild('配信B');
+		const tpl = await repo.insertTemplate({ name: 'くばる' }, FAMILY);
+
+		const first = await repo.assignTemplateToChildren(tpl.id, [a, b], FAMILY);
+		expect(first.map((r) => r.childId).sort()).toEqual([a, b].sort());
+		expect(first[0]?.templateId).toBe(tpl.id);
+
+		// 既配信 a は skip、新規 c のみ返る
+		const c = await newChild('配信C');
+		const second = await repo.assignTemplateToChildren(tpl.id, [a, c], FAMILY);
+		expect(second.map((r) => r.childId)).toEqual([c]);
+
+		// tenant 境界: 他 family template を名乗った配信は 0 件 (orphan assignment を作らない)
+		const foreign = await repo.assignTemplateToChildren(tpl.id, [a], OTHER_FAMILY);
+		expect(foreign).toEqual([]);
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM checklist_template_assignments WHERE family_id = ${OTHER_FAMILY} AND template_id = ${tpl.id}`,
+			),
+		).toBe(0);
+
+		// 空配列は no-op
+		expect(await repo.assignTemplateToChildren(tpl.id, [], FAMILY)).toEqual([]);
+	});
+
+	it('[A2] findAssignmentsByTemplate / findAssignmentsByChild + §P9', async () => {
+		const a = await newChild('照会A');
+		const b = await newChild('照会B');
+		const tpl = await repo.insertTemplate({ name: 'しらべる' }, FAMILY);
+		await repo.assignTemplateToChildren(tpl.id, [a, b], FAMILY);
+
+		const byTpl = await repo.findAssignmentsByTemplate(tpl.id, FAMILY);
+		expect(byTpl.map((r) => r.childId).sort()).toEqual([a, b].sort());
+		expect(await repo.findAssignmentsByTemplate(tpl.id, OTHER_FAMILY)).toEqual([]);
+
+		const byChild = await repo.findAssignmentsByChild(a, FAMILY);
+		expect(byChild.some((r) => r.templateId === tpl.id)).toBe(true);
+		expect(await repo.findAssignmentsByChild(a, OTHER_FAMILY)).toEqual([]);
+	});
+
+	it('[A3] unassignTemplateFromChildren (subset / 空 no-op) + unassignTemplate (全解除)', async () => {
+		const a = await newChild('解除A');
+		const b = await newChild('解除B');
+		const c = await newChild('解除C');
+		const tpl = await repo.insertTemplate({ name: 'はずす' }, FAMILY);
+		await repo.assignTemplateToChildren(tpl.id, [a, b, c], FAMILY);
+
+		// 空配列 no-op
+		await repo.unassignTemplateFromChildren(tpl.id, [], FAMILY);
+		expect((await repo.findAssignmentsByTemplate(tpl.id, FAMILY)).length).toBe(3);
+
+		// subset 解除 (a のみ)
+		await repo.unassignTemplateFromChildren(tpl.id, [a], FAMILY);
+		expect(
+			(await repo.findAssignmentsByTemplate(tpl.id, FAMILY)).map((r) => r.childId).sort(),
+		).toEqual([b, c].sort());
+
+		// §P9: 他 tenant を名乗った解除は no-op
+		await repo.unassignTemplateFromChildren(tpl.id, [b], OTHER_FAMILY);
+		expect((await repo.findAssignmentsByTemplate(tpl.id, FAMILY)).length).toBe(2);
+
+		// 全解除
+		await repo.unassignTemplate(tpl.id, FAMILY);
+		expect(await repo.findAssignmentsByTemplate(tpl.id, FAMILY)).toEqual([]);
+	});
+
+	// ─────────────────── Templates by child ───────────────────
+
+	it('[C1] findTemplatesByChild: 配信済のみ / includeArchived / includeInactive / cross-child / §P9', async () => {
+		const a = await newChild('子視点A');
+		const b = await newChild('子視点B');
+		const active = await repo.insertTemplate({ name: 'active-c', isActive: 1 }, FAMILY);
+		const inactive = await repo.insertTemplate({ name: 'inactive-c', isActive: 0 }, FAMILY);
+		const archived = await repo.insertTemplate({ name: 'archived-c' }, FAMILY);
+		await repo.assignTemplateToChildren(active.id, [a], FAMILY);
+		await repo.assignTemplateToChildren(inactive.id, [a], FAMILY);
+		await repo.assignTemplateToChildren(archived.id, [a], FAMILY);
+		await repo.archiveChecklistTemplates([archived.id], 'trial_expired', FAMILY);
+
+		// 既定: 配信済 かつ active かつ 非 archived のみ → active-c だけ
+		const def = await repo.findTemplatesByChild(a, FAMILY);
+		expect(def.map((r) => r.id)).toEqual([active.id]);
+
+		// includeInactive
+		const withInactive = await repo.findTemplatesByChild(a, FAMILY, true);
+		expect(withInactive.map((r) => r.id).sort()).toEqual([active.id, inactive.id].sort());
+
+		// includeArchived (+ includeInactive) → 3 件
+		const all = await repo.findTemplatesByChild(a, FAMILY, true, true);
+		expect(all.map((r) => r.id).sort()).toEqual([active.id, inactive.id, archived.id].sort());
+
+		// cross-child: b には未配信 → 空
+		expect(await repo.findTemplatesByChild(b, FAMILY, true, true)).toEqual([]);
+		// §P9
+		expect(await repo.findTemplatesByChild(a, OTHER_FAMILY, true, true)).toEqual([]);
+	});
+
+	it('[CP1] copy = assignments 追加: template は複製されず 2 child が同一 template id を共有', async () => {
+		const a = await newChild('コピー元');
+		const b = await newChild('コピー先');
+		const tpl = await repo.insertTemplate({ name: 'きょうつう' }, FAMILY);
+		await repo.assignTemplateToChildren(tpl.id, [a], FAMILY);
+
+		// 「別の子から取込」= 同一 family template を b にも配信 (assignments 追加のみ)
+		await repo.assignTemplateToChildren(tpl.id, [b], FAMILY);
+
+		const forA = await repo.findTemplatesByChild(a, FAMILY);
+		const forB = await repo.findTemplatesByChild(b, FAMILY);
+		expect(forA.map((r) => r.id)).toEqual([tpl.id]);
+		expect(forB.map((r) => r.id)).toEqual([tpl.id]); // 複製でなく同一 id
+		// template は family に 1 レコードのまま
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM checklist_templates WHERE family_id = ${FAMILY} AND template_id = ${tpl.id}`,
+			),
+		).toBe(1);
+	});
+
+	// ─────────────────── Items ───────────────────
+
+	it('[I1] insertTemplateItem + findTemplateItems (sort_order 順) + §P9', async () => {
+		const tpl = await repo.insertTemplate({ name: 'もちもの' }, FAMILY);
+		const i2 = await repo.insertTemplateItem(
+			{ templateId: tpl.id, name: 'ふでばこ', sortOrder: 2 },
+			FAMILY,
+		);
+		const i1 = await repo.insertTemplateItem(
+			{ templateId: tpl.id, name: 'きょうかしょ', sortOrder: 1, icon: '📗', direction: 'take' },
+			FAMILY,
+		);
+		expect(i1.id).toMatch(UUID_RE);
+		expect(i1.templateId).toBe(tpl.id);
+		expect(i1.icon).toBe('📗');
+		expect(i1.direction).toBe('take');
+		expect(i2.icon).toBe('🏫'); // schema default
+
+		const items = await repo.findTemplateItems(tpl.id, FAMILY);
+		expect(items.map((r) => r.id)).toEqual([i1.id, i2.id]); // sort_order 昇順
+		// §P9
+		expect(await repo.findTemplateItems(tpl.id, OTHER_FAMILY)).toEqual([]);
+	});
+
+	it('[I2] deleteTemplateItem: (templateId, id) composite — 別 template 名乗りは no-op', async () => {
+		const tpl = await repo.insertTemplate({ name: 'こうさく' }, FAMILY);
+		const other = await repo.insertTemplate({ name: 'べつ' }, FAMILY);
+		const item = await repo.insertTemplateItem({ templateId: tpl.id, name: 'のり' }, FAMILY);
+
+		// 別 template を名乗った削除は no-op (composite key 不一致)
+		await repo.deleteTemplateItem(other.id, item.id, FAMILY);
+		expect((await repo.findTemplateItems(tpl.id, FAMILY)).length).toBe(1);
+
+		await repo.deleteTemplateItem(tpl.id, item.id, FAMILY);
+		expect(await repo.findTemplateItems(tpl.id, FAMILY)).toEqual([]);
+	});
+
+	// ─────────────────── Logs (§5 子表化) ───────────────────
+
+	it('[L1] upsertLog insert → findTodayLog が checklist_log_items を join して itemsJson 復元', async () => {
+		const child = await newChild('記録太郎');
+		const tpl = await repo.insertTemplate({ name: 'にっか', pointsPerItem: 3 }, FAMILY);
+		const i1 = await repo.insertTemplateItem({ templateId: tpl.id, name: 'A' }, FAMILY);
+		const i2 = await repo.insertTemplateItem({ templateId: tpl.id, name: 'B' }, FAMILY);
+		await repo.assignTemplateToChildren(tpl.id, [child], FAMILY);
+
+		const saved = await repo.upsertLog(
+			{
+				childId: child,
+				templateId: tpl.id,
+				checkedDate: '2026-07-02',
+				itemsJson: JSON.stringify([i1.id, i2.id]),
+				completedAll: 1,
+				pointsAwarded: 11,
+			},
+			FAMILY,
+		);
+		expect(saved.completedAll).toBe(1); // 0/1 契約
+		expect(saved.pointsAwarded).toBe(11);
+
+		const log = await repo.findTodayLog(child, tpl.id, '2026-07-02', FAMILY);
+		expect(log).toBeDefined();
+		// §5: itemsJson は JSON blob でなく checklist_log_items 子表を join して復元する
+		expect(sortedIds(log?.itemsJson ?? '[]')).toEqual([i1.id, i2.id].sort());
+		expect(log?.completedAll).toBe(1);
+		expect(log?.pointsAwarded).toBe(11);
+		expect(log?.childId).toBe(child);
+		expect(log?.templateId).toBe(tpl.id);
+
+		// §P9 / cross-child 分離
+		expect(await repo.findTodayLog(child, tpl.id, '2026-07-02', OTHER_FAMILY)).toBe(undefined);
+		const stranger = await newChild('他人');
+		expect(await repo.findTodayLog(stranger, tpl.id, '2026-07-02', FAMILY)).toBe(undefined);
+	});
+
+	it('[L2] upsertLog update: log_items 集合を置換 + created_at 保全', async () => {
+		const child = await newChild('更新太郎');
+		const tpl = await repo.insertTemplate({ name: 'こうしん' }, FAMILY);
+		const i1 = await repo.insertTemplateItem({ templateId: tpl.id, name: 'A' }, FAMILY);
+		const i2 = await repo.insertTemplateItem({ templateId: tpl.id, name: 'B' }, FAMILY);
+		const i3 = await repo.insertTemplateItem({ templateId: tpl.id, name: 'C' }, FAMILY);
+
+		const first = await repo.upsertLog(
+			{
+				childId: child,
+				templateId: tpl.id,
+				checkedDate: '2026-07-03',
+				itemsJson: JSON.stringify([i1.id, i2.id]),
+				completedAll: 0,
+				pointsAwarded: 4,
+			},
+			FAMILY,
+		);
+		// 再 upsert: checked 集合を {i3} に置換
+		await repo.upsertLog(
+			{
+				childId: child,
+				templateId: tpl.id,
+				checkedDate: '2026-07-03',
+				itemsJson: JSON.stringify([i3.id]),
+				completedAll: 0,
+				pointsAwarded: 2,
+			},
+			FAMILY,
+		);
+		const log = await repo.findTodayLog(child, tpl.id, '2026-07-03', FAMILY);
+		expect(sortedIds(log?.itemsJson ?? '[]')).toEqual([i3.id]); // i1/i2 は消え i3 のみ
+		expect(log?.pointsAwarded).toBe(2);
+		expect(log?.createdAt).toBe(first.createdAt); // 再 upsert で created_at は不変
+		// 行は 1 件のまま (PK upsert)
+		expect(
+			await countRows(sql`
+				SELECT count(*) AS c FROM checklist_logs
+				WHERE family_id = ${FAMILY} AND child_id = ${String(child)}
+					AND template_id = ${tpl.id} AND checked_date = '2026-07-03'
+			`),
+		).toBe(1);
+	});
+
+	it('[L3] findLogsByChild: 複数日をバルク取得 (checked_date desc) + §P9', async () => {
+		const child = await newChild('バルク太郎');
+		const tpl = await repo.insertTemplate({ name: 'まとめ' }, FAMILY);
+		const item = await repo.insertTemplateItem({ templateId: tpl.id, name: 'A' }, FAMILY);
+		for (const date of ['2026-07-01', '2026-07-05', '2026-07-03']) {
+			await repo.upsertLog(
+				{
+					childId: child,
+					templateId: tpl.id,
+					checkedDate: date,
+					itemsJson: JSON.stringify([item.id]),
+					completedAll: 1,
+					pointsAwarded: 5,
+				},
+				FAMILY,
+			);
+		}
+		const logs = await repo.findLogsByChild(child, FAMILY);
+		expect(logs.map((l) => l.checkedDate)).toEqual(['2026-07-05', '2026-07-03', '2026-07-01']);
+		expect(sortedIds(logs[0]?.itemsJson ?? '[]')).toEqual([item.id]);
+		expect(await repo.findLogsByChild(child, OTHER_FAMILY)).toEqual([]);
+	});
+
+	it('[L4] log + items 単一 txn: log_items 行数 = checked 数 / 空 itemsJson → 0 件', async () => {
+		const child = await newChild('原子太郎');
+		const tpl = await repo.insertTemplate({ name: 'げんし' }, FAMILY);
+		const i1 = await repo.insertTemplateItem({ templateId: tpl.id, name: 'A' }, FAMILY);
+		const i2 = await repo.insertTemplateItem({ templateId: tpl.id, name: 'B' }, FAMILY);
+
+		await repo.upsertLog(
+			{
+				childId: child,
+				templateId: tpl.id,
+				checkedDate: '2026-07-06',
+				itemsJson: JSON.stringify([i1.id, i2.id]),
+				completedAll: 1,
+				pointsAwarded: 4,
+			},
+			FAMILY,
+		);
+		const cnt = await countRows(sql`
+			SELECT count(*) AS c FROM checklist_log_items
+			WHERE family_id = ${FAMILY} AND child_id = ${String(child)}
+				AND template_id = ${tpl.id} AND checked_date = '2026-07-06'
+		`);
+		expect(cnt).toBe(2);
+
+		// 空 itemsJson → log 行は残り log_items は 0 件
+		await repo.upsertLog(
+			{
+				childId: child,
+				templateId: tpl.id,
+				checkedDate: '2026-07-06',
+				itemsJson: JSON.stringify([]),
+				completedAll: 0,
+				pointsAwarded: 0,
+			},
+			FAMILY,
+		);
+		const log = await repo.findTodayLog(child, tpl.id, '2026-07-06', FAMILY);
+		expect(JSON.parse(log?.itemsJson ?? 'null')).toEqual([]);
+		expect(
+			await countRows(sql`
+				SELECT count(*) AS c FROM checklist_log_items
+				WHERE family_id = ${FAMILY} AND child_id = ${String(child)}
+					AND template_id = ${tpl.id} AND checked_date = '2026-07-06'
+			`),
+		).toBe(0);
+	});
+
+	// ─────────────────── Overrides ───────────────────
+
+	it('[O1] insertOverride + findOverrides (child × date) + §P9', async () => {
+		const child = await newChild('例外太郎');
+		const ov = await repo.insertOverride(
+			{ childId: child, targetDate: '2026-07-07', action: 'add', itemName: 'かさ', icon: '☂' },
+			FAMILY,
+		);
+		expect(ov.id).toMatch(UUID_RE);
+		expect(ov.action).toBe('add');
+		expect(ov.itemName).toBe('かさ');
+
+		const found = await repo.findOverrides(child, '2026-07-07', FAMILY);
+		expect(found.map((r) => r.id)).toEqual([ov.id]);
+		// 別日は空
+		expect(await repo.findOverrides(child, '2026-07-08', FAMILY)).toEqual([]);
+		// §P9
+		expect(await repo.findOverrides(child, '2026-07-07', OTHER_FAMILY)).toEqual([]);
+	});
+
+	it('[O2] findOverridesByChild (全日) + insertOverrideForRestore (createdAt verbatim)', async () => {
+		const child = await newChild('復元太郎');
+		await repo.insertOverride(
+			{ childId: child, targetDate: '2026-07-10', action: 'remove', itemName: 'A' },
+			FAMILY,
+		);
+		const restored = await repo.insertOverrideForRestore(
+			{
+				childId: child,
+				targetDate: '2026-06-01',
+				action: 'add',
+				itemName: 'B',
+				icon: '📦',
+				createdAt: '2025-12-24T08:00:00+00:00',
+			},
+			FAMILY,
+		);
+		// verbatim 保全: insertOverride と違い createdAt を default(now) に落とさない
+		expect(Date.parse(restored.createdAt)).toBe(Date.parse('2025-12-24T08:00:00+00:00'));
+
+		const all = await repo.findOverridesByChild(child, FAMILY);
+		expect(all.map((r) => r.targetDate)).toEqual(['2026-06-01', '2026-07-10']); // target_date 昇順
+		expect(await repo.findOverridesByChild(child, OTHER_FAMILY)).toEqual([]);
+	});
+
+	it('[O3] deleteOverride: (childId, id) composite — 別 child 名乗りは no-op', async () => {
+		const child = await newChild('削除太郎');
+		const stranger = await newChild('無関係太郎');
+		const ov = await repo.insertOverride(
+			{ childId: child, targetDate: '2026-07-11', action: 'add', itemName: 'A' },
+			FAMILY,
+		);
+		// 別 child を名乗った削除は no-op
+		await repo.deleteOverride(stranger, ov.id, FAMILY);
+		expect((await repo.findOverrides(child, '2026-07-11', FAMILY)).length).toBe(1);
+
+		await repo.deleteOverride(child, ov.id, FAMILY);
+		expect(await repo.findOverrides(child, '2026-07-11', FAMILY)).toEqual([]);
+	});
+
+	// ─────────────────── archive / restore ───────────────────
+
+	it('[R1] archiveChecklistTemplates → findTemplatesByTenant 除外 → restore 復元 + §P9', async () => {
+		const keep = await repo.insertTemplate({ name: 'のこす' }, FAM_R1);
+		const gone = await repo.insertTemplate({ name: 'アーカイブ' }, FAM_R1);
+		await repo.archiveChecklistTemplates([gone.id], 'downgrade_user_selected', FAM_R1);
+
+		expect((await repo.findTemplatesByTenant(FAM_R1)).map((r) => r.id)).toEqual([keep.id]);
+		expect((await repo.findTemplateById(gone.id, FAM_R1))?.isArchived).toBe(1);
+		expect((await repo.findTemplateById(gone.id, FAM_R1))?.archivedReason).toBe(
+			'downgrade_user_selected',
+		);
+
+		// §P9: 他 tenant の archive は本 family に影響しない (reason filter restore)
+		await repo.restoreArchivedChecklistTemplates('downgrade_user_selected', OTHER_FAMILY);
+		expect((await repo.findTemplateById(gone.id, FAM_R1))?.isArchived).toBe(1);
+
+		await repo.restoreArchivedChecklistTemplates('downgrade_user_selected', FAM_R1);
+		expect((await repo.findTemplateById(gone.id, FAM_R1))?.isArchived).toBe(0);
+		expect((await repo.findTemplateById(gone.id, FAM_R1))?.archivedReason).toBe(null);
+		expect((await repo.findTemplatesByTenant(FAM_R1)).map((r) => r.id).sort()).toEqual(
+			[keep.id, gone.id].sort(),
+		);
+	});
+
+	// ─────────────────── tenant bulk delete ───────────────────
+
+	it('[D1] deleteByTenantId: 全 6 表を tenant 限定削除、他 tenant 無傷', async () => {
+		const victim = await newChild('全消し', FAM_D1);
+		const keeper = await newChild('無傷', FAMILY);
+		const vTpl = await repo.insertTemplate({ name: 'victim' }, FAM_D1);
+		const vItem = await repo.insertTemplateItem({ templateId: vTpl.id, name: 'A' }, FAM_D1);
+		await repo.assignTemplateToChildren(vTpl.id, [victim], FAM_D1);
+		await repo.upsertLog(
+			{
+				childId: victim,
+				templateId: vTpl.id,
+				checkedDate: '2026-07-01',
+				itemsJson: JSON.stringify([vItem.id]),
+				completedAll: 1,
+				pointsAwarded: 3,
+			},
+			FAM_D1,
+		);
+		await repo.insertOverride(
+			{ childId: victim, targetDate: '2026-07-01', action: 'add', itemName: 'X' },
+			FAM_D1,
+		);
+		// 無傷側
+		const kTpl = await repo.insertTemplate({ name: 'keep' }, FAMILY);
+		await repo.assignTemplateToChildren(kTpl.id, [keeper], FAMILY);
+
+		await repo.deleteByTenantId(FAM_D1);
+
+		for (const table of [
+			'checklist_templates',
+			'checklist_template_items',
+			'checklist_template_assignments',
+			'checklist_logs',
+			'checklist_log_items',
+			'checklist_overrides',
+		]) {
+			expect(
+				await countRows(
+					sql`SELECT count(*) AS c FROM ${sql.raw(table)} WHERE family_id = ${FAM_D1}`,
+				),
+			).toBe(0);
+		}
+		// 他 tenant は無傷
+		expect(await repo.findTemplateById(kTpl.id, FAMILY)).toBeDefined();
+		expect((await repo.findAssignmentsByChild(keeper, FAMILY)).length).toBe(1);
+	});
+
+	// ─────────────────── CHECK / UNIQUE 実効 ───────────────────
+
+	it('[X1] CHECK / UNIQUE / PK 二重を直接 INSERT で拒否', async () => {
+		const child = await newChild('制約太郎');
+		// time_slot CHECK
+		await expect(
+			t.db.execute(sql`
+				INSERT INTO checklist_templates (family_id, name, time_slot)
+				VALUES (${FAMILY}, 'bad', 'bogus')
+			`),
+		).rejects.toThrow();
+		// override action CHECK
+		await expect(
+			t.db.execute(sql`
+				INSERT INTO checklist_overrides (family_id, child_id, target_date, action, item_name)
+				VALUES (${FAMILY}, ${String(child)}, '2026-07-01', 'bogus', 'X')
+			`),
+		).rejects.toThrow();
+
+		// assignment PK 二重
+		const tpl = await repo.insertTemplate({ name: 'ゆに' }, FAMILY);
+		await repo.assignTemplateToChildren(tpl.id, [child], FAMILY);
+		await expect(
+			t.db.execute(sql`
+				INSERT INTO checklist_template_assignments (family_id, template_id, child_id)
+				VALUES (${FAMILY}, ${tpl.id}, ${String(child)})
+			`),
+		).rejects.toThrow();
+
+		// log PK 二重 (family, child, template, checked_date)
+		await t.db.execute(sql`
+			INSERT INTO checklist_logs (family_id, child_id, template_id, checked_date)
+			VALUES (${FAMILY}, ${String(child)}, ${tpl.id}, '2026-07-09')
+		`);
+		await expect(
+			t.db.execute(sql`
+				INSERT INTO checklist_logs (family_id, child_id, template_id, checked_date)
+				VALUES (${FAMILY}, ${String(child)}, ${tpl.id}, '2026-07-09')
+			`),
+		).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管 repo 層 = child-cluster 最複雑 repo）

**解決する課題**: IChecklistRepo（25 メソッド、ADR-0055 の family master template + per-child assignments モデル）の DSQL 実装が無かった。このモデルは「template は tenant 1 レコード、per-child view は assignments で絞る」という非対称を持ち、単純な per-child CRUD では実装できない。

**期待される効果**: 持ち物チェックリストの template 管理 / 配信（assignment）/ 日次記録 / override が DSQL で動作し、child-cluster の主要 repo が概ね出揃う。

## 関連 Issue

- EPIC #3424（§12.2.1 build order PR-2 系、child-cluster 最複雑）
- related: ADR-0055（per-child 主軸 + family master データモデル）/ §10（§3097 admin リソース正準スロット）
- **#3601（本 PR 実装中に検出した schema/interface gap 2 件 = item_id uuid 制約 / source_preset_id 欠落 を cutover 配線前に判断する課題として起票）**

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | IChecklistRepo 全 25 メソッドの DSQL 実装（factory 注入 = fitness#8、§P9 述語、branded id） | `npx vitest run tests/unit/db/dsql-checklist-repo.test.ts` | HEAD `a19814ae` / **21 passed**。**red 実測: import 解決不能 fail → green**。本体独立再検証: db+architecture **732/732** + svelte-check 7687 files 0 errors |
| AC2 | **template = family scope 1 レコード**: findTemplatesByChild は checklist_template_assignments を join して child 視点に絞る（複製しない） | test（配信済み template のみが child view に出る） | HEAD `a19814ae` / pass |
| AC3 | **copy（別の子から取込）= assignments 追加のみ**: 同一 family template を 2 人目に配信しても templates 行数は 1 のまま | test CP1 | HEAD `a19814ae` / pass |
| AC4 | assignTemplateToChildren = #3562③ parity の `INSERT...SELECT FROM checklist_templates`（template 所有強制）+ `ON CONFLICT DO NOTHING RETURNING`（既配信 skip / only-new 返却）を単一 txn。他 family template への配信は 0 行（orphan 排除） | test | HEAD `a19814ae` / pass |
| AC5 | **checklist_logs / log_items の §5 子表化**: upsertLog は log upsert + log_items の delete→re-insert 全置換を単一 txn、read は子表 join（itemsJson = checked item id 配列の意味を子表で表現） | test（log 保存 → 子表 join 復元） | HEAD `a19814ae` / pass |
| AC6 | daily override（checklist_overrides、per-child per-date） + §P9/cross-child 分離 + CHECK/UNIQUE 実効 | test | HEAD `a19814ae` / pass |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)（dsql/checklist-repo.ts 新設のみ。schema/interface 無変更）
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（新設 2 file、DATA_SOURCE dispatch 未結線）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: dsql-checklist-repo.test.ts 21 本新設（pushSchema 実 schema 基盤、template/assignment 非対称 + 子表 join を検証）
- [x] 新規 env / secret 追加時: N/A
- [x] DynamoDB 実装変更時: N/A（未変更）
- [x] Critical バグ修正の場合: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）**: server 側 repo 新設のみで UI 変更なし（.svelte 変更 0 file）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: interface 契約無変更で backend 追加（OCP）。template/assignment/log の 3 層を責務ごとに実装
- [x] **DRY**: mapping は既存 dsql module の export 共有。hot path 重複なし
- [x] **YAGNI**: dispatch 結線なし。source_preset_id は §10 で将来課題のため列を前倒し追加しない（#3601 で判断）
- [x] **Security（OSS 公開前提）**: §P9 述語 + assignment の template 所有強制（INSERT...SELECT で cross-family 配信を構造排除、TOCTOU なし）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: findByChild は assignments join 1 クエリ。log 全置換は per-log の小規模 delete→insert

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): ADR-0055 / §11.2 / §5 / §10 記載設計の実装であり設計変更なし
- [x] **並行 PR overlap** (#1200): `db/dsql/**` は本セッション直列管理。**本 branch は develop base に整理済**（並行 Agent が古い develop を起点にした誤判断を本体が是正し、checklist の実変更 2 file のみを develop から切った clean branch に移植。child-activity-repo.ts 変更・cspell 追記は develop に既存で差分ゼロを確認）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新設のみ）

**レビュー依頼事項・QA（判断ポイント）**:
- **#3601 に切り出した 2 gap**（cutover 配線前に判断）: ① checklist_log_items.item_id が uuid 型のため override 由来 id（`-<uuid>`）を log に永続不能（現状は uuid 列が loud に拒否 = silent drop しない安全側）② checklist_templates に source_preset_id 列が無く marketplace 取込帰属が read 時 null（§10 で将来課題明記）。いずれも schema 凍結のため R7 では変更せず #3601 で扱う
- 合成 id（`template:child` / `child:template:date`、surrogate 無し表。消費は表示 key のみを grep 確認）と insertTemplateItem の tenant 単位検証（sqlite parity）は R4-R6 と同判断

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（並行 Agent の起点誤判断を本体が是正 = develop base clean branch 化 + 独立再検証 732/732 + svelte-check 0。保留 gap を #3601 に固定）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: child-cluster repo は R3-R6（merged）→ 本 PR → battle / evaluation / 報酬・メッセージ系（次波）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
