### PR TITLE
fix: #3606 branded string id の wire contract 確定 + numeric 前提 test 追従 (統合 #3605 blocker 解消)

### DIFF
--- a/src/lib/marketplace/schemas/challenge-set-schema.ts
+++ b/src/lib/marketplace/schemas/challenge-set-schema.ts
@@ -42,7 +42,14 @@ export const ChallengeSetItemSchema = v.object({
 		v.minValue(1, 'durationDays は 1 以上で指定してください'),
 		v.maxValue(90, 'durationDays は 90 以下で指定してください'),
 	),
-	/** 1=undou 2=benkyou 3=seikatsu 4=kouryuu 5=souzou */
+	/**
+	 * 1=undou 2=benkyou 3=seikatsu 4=kouryuu 5=souzou
+	 *
+	 * payload 内で自己完結する「意味的カテゴリ enum」であり、DB エンティティの
+	 * branded CategoryId (string、src/lib/domain/ids.ts) とは別物 (#3606 棚卸しで
+	 * runtime break なしを確認済)。数値直書きは SSOT 不在の技術負債であり、#3607
+	 * (カテゴリ SSOT 統合) で as const satisfies SSOT からの派生参照に置換予定。
+	 */
 	categoryId: v.picklist(
 		[1, 2, 3, 4, 5] as const,
 		'categoryId は 1 (運動) / 2 (勉強) / 3 (生活) / 4 (交流) / 5 (創造) のいずれかで指定してください',

--- a/tests/e2e/admin-activities-delete.spec.ts
+++ b/tests/e2e/admin-activities-delete.spec.ts
@@ -7,9 +7,12 @@
  * (tests/CLAUDE.md §「interactive flow は『操作 → 結果』を必須検証する」)。
  *
  * 検証する 3 sequence (act → outcome assert):
- *   1. 削除 confirm → 確定 click → family 一覧件数が -1 (toHaveCount(before - 1)) + Toast success
- *   2. 削除 confirm → キャンセル click → Dialog close + 件数不変
+ *   1. 削除 confirm → 確定 click → 対象行が一覧から消える (dedicated testid toHaveCount(0)) + Toast success
+ *   2. 削除 confirm → キャンセル click → Dialog close + 対象行が一覧に残存
  *   3. activity-delete-btn が family 各行に visible (entry point 担保)
+ *
+ * #3606: 旧「global 件数 ±1 / 不変」assertion は並列 spec が同一 worker DB を変更すると
+ * race で破綻するため、dedicated item 自身の消滅 / 残存に置換 (検証 goal は同一)。
  *
  * deterministic completion signal: 件数の `toHaveCount` 比較 + Toast の text assertion で
  * waitForTimeout を一切使わず web-first assertion で完遂を verify
@@ -86,7 +89,7 @@ test.describe('#2744 admin/activities Delete UI (AC4 family scope)', () => {
 		await request.delete(`/api/v1/activities/${testId}`);
 	});
 
-	test('削除 button click → 確認 Dialog 表示 → 確定 → 一覧件数 -1 + Toast success', async ({
+	test('削除 button click → 確認 Dialog 表示 → 確定 → 対象行が一覧から消える + Toast success', async ({
 		page,
 		request,
 	}) => {
@@ -96,7 +99,6 @@ test.describe('#2744 admin/activities Delete UI (AC4 family scope)', () => {
 		await page.waitForLoadState('domcontentloaded');
 
 		const dedicatedBtn = page.getByTestId(`activity-delete-btn-${testId}`);
-		const beforeCount = await page.locator('[data-testid^="activity-delete-btn-"]').count();
 		await expect(dedicatedBtn).toBeVisible();
 
 		const dialog = page.getByTestId(`activity-delete-confirm-${testId}`);
@@ -121,15 +123,15 @@ test.describe('#2744 admin/activities Delete UI (AC4 family scope)', () => {
 		//   成功通知は assertive=alert ではなく polite=status。error のみ role="alert")。
 		await expect(page.getByRole('status').filter({ hasText: '活動を削除しました' })).toBeVisible();
 
-		// outcome 3: 一覧件数が確実に -1 (delete action は activity ログがあれば hidden 化、
-		//           なければ hard delete、いずれも一覧表示からは消える)
-		// web-first assertion `toHaveCount` で auto-retry、waitForTimeout 不使用
-		await expect(page.locator('[data-testid^="activity-delete-btn-"]')).toHaveCount(
-			beforeCount - 1,
-		);
+		// outcome 3: 削除対象の行が一覧から確実に消える (delete action は activity ログが
+		//           あれば hidden 化、なければ hard delete、いずれも一覧表示からは消える)
+		// #3606: 旧 assertion「global 件数が -1」は並列 spec が同一 worker DB に活動を
+		// 追加すると破綻する race (CI で 43 期待 / 44 実測の flake を実証)。検証する goal
+		// (削除した item が一覧から消える) は dedicated testid の消滅で正確に assert する。
+		await expect(page.getByTestId(`activity-delete-btn-${testId}`)).toHaveCount(0);
 	});
 
-	test('削除 button click → キャンセル click → Dialog 閉じる + 件数不変', async ({
+	test('削除 button click → キャンセル click → Dialog 閉じる + 対象行が残存', async ({
 		page,
 		request,
 	}) => {
@@ -139,7 +141,6 @@ test.describe('#2744 admin/activities Delete UI (AC4 family scope)', () => {
 		await page.waitForLoadState('domcontentloaded');
 
 		const dedicatedBtn = page.getByTestId(`activity-delete-btn-${testId}`);
-		const beforeCount = await page.locator('[data-testid^="activity-delete-btn-"]').count();
 		await expect(dedicatedBtn).toBeVisible();
 
 		const dialog = page.getByTestId(`activity-delete-confirm-${testId}`);
@@ -153,9 +154,10 @@ test.describe('#2744 admin/activities Delete UI (AC4 family scope)', () => {
 		// outcome 1: Dialog 閉じる
 		await expect(dialog).toBeHidden();
 
-		// outcome 2: 件数は不変 (キャンセル経路の dead-end 検出)
-		// web-first assertion で auto-retry
-		await expect(page.locator('[data-testid^="activity-delete-btn-"]')).toHaveCount(beforeCount);
+		// outcome 2: 削除対象の行が一覧に残存する (キャンセル経路の dead-end 検出)
+		// #3606: global 件数比較は並列 spec の DB 変更と race するため、対象 item 自身の
+		// 残存を assert する
+		await expect(dedicatedBtn).toBeVisible();
 
 		// cleanup: API 経由で削除 (cancel test は cancel path 検証のみ、後始末は API で)
 		await request.delete(`/api/v1/activities/${testId}`);

--- a/tests/e2e/downgrade-flow.spec.ts
+++ b/tests/e2e/downgrade-flow.spec.ts
@@ -373,7 +373,10 @@ test.describe('#754 プレビュー応答の構造検証', () => {
 			expect(child).toHaveProperty('id');
 			expect(child).toHaveProperty('name');
 			expect(child).toHaveProperty('uiMode');
-			expect(typeof child.id).toBe('number');
+			// #3575 (PR-R0) / #3606: id は branded string (opaque token) が wire contract の正。
+			// DSQL では uuid、sqlite では integer PK の 10 進文字列 (src/lib/domain/ids.ts SSOT)。
+			expect(typeof child.id).toBe('string');
+			expect(child.id).not.toBe('');
 			expect(typeof child.name).toBe('string');
 		}
 	});

--- a/tests/unit/server/db/demo/checklist-marketplace.test.ts
+++ b/tests/unit/server/db/demo/checklist-marketplace.test.ts
@@ -22,14 +22,14 @@ describe('demo/checklist-repo — marketplace integration (#2097 B-7)', () => {
 			expect(templates.length).toBeGreaterThanOrEqual(1);
 			expect(templates[0]?.sourcePresetId).toBe('event-pool');
 			// legacy fixture record は childId フィールドを持つ (cast 経由で参照)
-			expect((templates[0] as unknown as { childId?: number }).childId).toBe('903');
+			expect((templates[0] as unknown as { childId?: string }).childId).toBe('903');
 		});
 
 		it('904 (junior F): event-school-start checklist が含まれる', () => {
 			const templates = getDemoMarketplaceChecklistTemplatesByChild(asChildId(904));
 			expect(templates.length).toBeGreaterThanOrEqual(1);
 			expect(templates[0]?.sourcePresetId).toBe('event-school-start');
-			expect((templates[0] as unknown as { childId?: number }).childId).toBe('904');
+			expect((templates[0] as unknown as { childId?: string }).childId).toBe('904');
 		});
 
 		it('901/902/906: marketplace checklist 対象外', () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（第 13 回 develop→main 統合 = 本番リリースの blocker 解消）

**解決する課題**: #3575 (PR-R0) の branded string id 変換により API wire format の id が number → string に変わったが、旧 wire contract (number) を期待する e2e が決定的 fail し統合 PR #3605 が merge 不能。加えて delete UI e2e の global 件数 assertion が並列実行と race し flake を発生させていた。

**期待される効果**: string id wire contract が「意図的な正」であることを棚卸しで確定し、test を正に追従。統合リリースの blocker が解消され、DSQL 移管 (EPIC #3424) の後続作業が正しい wire contract 前提の上に積める。

## 関連 Issue

closes #3606

- 関連: #3575 (PR-R0 branded string id、wire contract 変更の導入元) / EPIC #3424 (DSQL 移管)
- 関連: #3607 (棚卸し中に検出したカテゴリ SSOT 技術負債、本 PR で起票)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | string-id wire format が意図的（DSQL 移行のため）か確認 | `src/lib/domain/ids.ts:1-14` の設計コメント（PO 決裁 2026-07-04、「id は opaque token」「dsql: uuid / sqlite: integer PK の 10 進文字列」）+ `downgrade-service.ts` が `ChildId` をそのまま返却 | **意図的と確定**。wire = string が正 |
| AC2 | numeric id を前提する全 e2e/unit test を string 期待に更新 | `grep -rn "toBe('number')" tests/` で id 系 assertion を全件走査 → 該当は `downgrade-flow.spec.ts:376` の 1 件のみ（string 期待 + 非空 assert に更新）。加えて 8 カテゴリ棚卸しで unit/integration の numeric literal 期待を走査 → `checklist-marketplace.test.ts` の stale 型 cast 1 件を是正（assertion 自体は string で正、cast のみ stale） | PASS（残 0 件） |
| AC3 | 全 API 応答の id serialization を棚卸しし、frontend/consumer が string id を扱えることを検証 | Explore agent による 8 カテゴリ網羅棚卸し（①API 入力 schema ②parseInt/演算 ③typeof ④test 期待 ⑤localStorage/cookie/URL param ⑥hashSeed ⑦backup/export round-trip ⑧demo backend）。詳細は本文下部「棚卸し結果サマリ」 | **runtime break 0 件**。境界変換（write `String→Number` / read `Number→as*`）が対称に完備、frontend は typed sentinel `Id \| 0` パターンで統一済 |
| AC4 | `admin-activities-delete` の「子供が見つかりません」が id 型不整合由来かを判別し根治 | CI run 28793557657 (a11y job) のログ精査: fail 実体は `toHaveCount` Expected 43 / Received 44 で retry #1 PASS（最終判定 flaky）。**id 型不整合ではなく、並列 spec が同一 worker DB に活動を追加する race** | **flake と判別し根治**: global 件数 assertion を dedicated item の消滅/残存 assertion に置換（race 構造を排除。検証 goal 同一で ADR-0006 弱体化に非該当） |
| AC5 | 意図的でないなら serialization で number を維持する修正 | AC1 で意図的と確定 | N/A |
| AC6 | 修正後 downgrade-flow + admin-activities-delete が green | `npx playwright test downgrade-flow.spec.ts admin-activities-delete.spec.ts --project=tablet` ローカル実行 | **PASS: 19 passed (39.7s)、failed 0** |

## 変更タイプ

- [x] fix: バグ修正
- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ドメインモデル (`$lib/domain/`) ※ `challenge-set-schema.ts` のコメント追記のみ（挙動変更なし）
- [x] テスト (`tests/e2e/` 2 spec + `tests/unit/` 1 file の型 cast)

**影響を受ける画面・機能**: なし（production コードの挙動変更ゼロ。test assertion とコメントのみ）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/e2e/downgrade-flow.spec.ts`: id 型期待を string に更新 + 非空 assert 追加（assertion 強化）
  - `tests/e2e/admin-activities-delete.spec.ts`: global 件数 assertion → dedicated item 消滅/残存 assertion（race 根治）
  - `tests/unit/server/db/demo/checklist-marketplace.test.ts`: stale 型 cast 是正
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（priority:high、ADR-0002 対象外）

## スクリーンショット / ビジュアルデモ

**該当なし（test assertion 修正 + コード コメント追記のみ。UI 描画コードの変更ゼロ、視覚差分ゼロ）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（test + コメントのみ）
- [x] **DRY**: 同型の global 件数 assertion が他 spec に残存しないか grep 済（`toHaveCount(beforeCount` は本 spec のみ）
- [x] **YAGNI**: 不要な抽象化なし
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外（test assertion + コメント）

**横展開（本 PR で実施した class 対処)**:
- 「numeric id 前提の残存」class: 8 カテゴリ棚卸しで全消費側を走査し、残存 0 を確認（下記サマリ）
- 「global 件数 assertion の並列 race」class: 同型 assertion の他 spec 残存なしを grep で確認
- 「enum 的ドメイン知識の SSOT 不在」class: 棚卸し中に検出したカテゴリ id↔code 散在（5 箇所）を #3607 として起票（本 PR scope 外の構造改善）

**LP / 販促文言変更時** (ADR-0013): N/A

## 棚卸し結果サマリ (AC3 詳細)

8 カテゴリ全てで runtime break 0 件。移行は以下の機構で一貫完了していることを確認:

1. **API 入力 schema**: `id-schema.ts` の `idLike = z.union([z.string().min(1), z.number().int().positive()])` + `transform(as*)` で string/旧 number 両受容
2. **境界変換**: sqlite repo 層は write `Number()` / read `as*()` が完全対称（`ids.ts` に文書化済みの設計）
3. **frontend**: `$state<ChildId | 0>(0)` typed sentinel パターンで未選択と string id 比較を型安全に分離
4. **hashSeed**: FNV-1a の文字列イテレーションに移行済（数値文字列 / uuid 両対応、unit test で決定性固定）
5. **backup/export/marketplace schema**: entity id を number で持つ valibot フィールドなし（round-trip ValiError リスクなし）
6. **demo backend**: fixture は branded string（`'901'` 等）、比較は全て string 同士
7. **残注記**: `demo/child-activity-repo.ts:33,107` の `Number(childId)*1_000_000` legacy 投影は数値文字列 fixture 前提で現状 safe（demo は uuid 化しない ADR-0048。本 fallback は Phase 7 撤去対象として既存 EPIC #3424 で管理されており本 PR の残作業ではない）
8. **カテゴリ numeric picklist**: branded CategoryId とは別物の意味的 enum で自己完結（runtime 影響なし）。構造改善は #3607

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（wire contract の string 化自体は #3575 で導入済み。本 PR は test の追従とその意図確定）

**レビュー依頼事項・QA**:
- AC4 の判別根拠（CI ログの Expected 43/Received 44 + retry PASS = race であり id 不整合でない）をご確認ください
- #3605 (第 13 回統合) は本 PR の develop merge 後に release ブランチへ取り込むか、audit チーム側で次回統合に回すかの判断をお願いします

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3608` 全 Step PASS** をローカル確認した (Step 1〜8 PASS 確認後に本項を [x] 化し再実行で全 step PASS)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし（視覚差分ゼロ）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
