### PR TITLE
docs: #3609 dev-session.md に実装モダン性の継続検証原則 + Issue 自由起票運用を反映

### DIFF
--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -343,6 +343,29 @@ UI/UX 指摘（PR レビュー / CI fail / PO 実機 / 外部品質監査）を�
 - 適用ツール方針: VRT = pixelmatch（ADR-0053）/ 配置エンジン = Ark UI 内蔵 Floating UI で充足（単体導入しない）/ a11y = `@axe-core/playwright`。情報設計レビュー（OOUI 成果物）は新規画面・EPIC 級のみ適用
 - **プロセス SSOT**: 4 層自動化モデル（axe / geometry / pixelmatch+Storybook / E2E）・課題一般化フロー・既存資産対応表は [webui-review-process.md](webui-review-process.md) を参照
 
+### 実装モダン性の継続検証原則（#3609、2026-07-08 PO 指示）
+
+「機能が動いている」ことと「実装が洗練されている」ことは別物。あらゆる実装作業・レビュー・棚卸しで、触れたコードとその周辺実装に対し**「これは古い / 不適切 / 非推奨な実装ではないか」を常時疑い**、以下の観点で検証し続ける（Why: magic number 散在等の設計負債は機能テスト緑のまま拡張時 silent 不具合になる。実例: カテゴリ picklist 数値直書き #3607）:
+
+- **モダンか**: 言語・フレームワークの現行推奨イディオムか（例: TS `enum` → `as const satisfies` + 派生 union、Svelte 4 構文 → Runes）
+- **オブジェクト指向 / SOLID か**: 単一責任・依存性逆転・Strategy/Factory/Registry 等の確立パターン適用漏れがないか
+- **公式ベストプラクティスか**: 採用ライブラリの公式ドキュメントが推奨する使い方に沿っているか
+
+**気になった実装を見つけたときのセット運用（3 点で 1 セット、どれか単独では不完全）**:
+
+1. **deep research で妥当性検証** — 一次ソース（公式 docs / OSS 実装 2 件以上、ADR-0014）で「本当にそれが問題か / 対策は妥当か」を裏取りする
+2. **follow-up Issue 起票** — Dev が自由に起票してよい（下記「Issue 起票権限」参照）。issue-triage skill の 7 ステップ + root class 特定（ADR-0061）を適用する
+3. **横展開** — 同 class の残存を grep / Glob で全件調査し、Issue の散在実測表に列挙する（1 箇所だけ直して同型を放置しない）
+
+**Issue 起票権限（2026-07-08 PO 指示、旧「Issue 起票 = PO 専権」を緩和)**: 十分に深く検討・deep research され、対策の妥当性が検証済みで、モダンかつ SOLID 原則に基づき将来性・拡張性がありソフトウェアデザインアーキテクチャに沿った Issue であれば、Dev が PO 確認なしに起票してよい（Why: 過去の PO 専権化は「research 不足のはりぼて Issue 増殖」への対策であり、原因は権限でなく品質）。
+
+**PO 判断としてエスカレーションするケース（以下のみ事前確認必須）**:
+
+1. プロダクトとして機能要件が満たせなくなる
+2. ユーザに影響がある
+3. 他社との差別化ポイントに関わる
+4. モダンな実装と乖離するがどうしても回避できない技術制約がある
+
 ### 3 つ目の類似 service / component 実装時の Strategy/Factory 適用判断（#2373 / AN-5 #2180 補強 6）
 
 PO 側 SSOT (`docs/sessions/po-session.md` §「補佐設計品質ガード 6」MUST-DO 2) と対をなす Dev セッション側ガード。**3 つ目の類似 service / component を実装する前**、Strategy / Factory / Registry パターンの適用判断を行う:
@@ -362,7 +385,8 @@ PO 側 SSOT (`docs/sessions/po-session.md` §「補佐設計品質ガード 6」
 | 作業 | 担当 |
 |---|---|
 | コード実装・修正・削除 / Rebase / 実機動作確認 / SS 生成 | **Dev** |
-| PR レビュー・指摘 / Issue 起票 / ADR 起票 | Reviewer / PO |
+| Issue 起票 | **Dev も可**（#3609、品質バー = §「実装モダン性の継続検証原則」。PO エスカレーション 4 基準該当時のみ事前確認） |
+| PR レビュー・指摘 / ADR 起票 | Reviewer / PO |
 | PR close 判断・方針転換 | PO |
 | PR base branch 切替 (blocker 解消) | Reviewer |
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（Dev セッション運用者 / チーム共有知識の維持）

**解決する課題**: PO 指示 (2026-07-08) の「実装モダン性の継続検証原則」と「Issue 自由起票運用」が Dev セッションの memory (ユーザーローカル) にのみ存在し、チーム共有 SSOT (git 管理 docs) に反映されていない。役割境界表 (#1022) の「Issue 起票 = Reviewer / PO」も新運用と不整合。

**期待される効果**: すべてのセッション・エージェントが同一の品質原則 (モダン / OOP / SOLID / 公式ベストプラクティスの常時検証 + 改善 Issue 起票 + 横展開) と起票権限ルールで動作し、実装が継続的に洗練される。

## 関連 Issue

closes #3609

- 関連: #3607 (本原則の直近適用実例 = カテゴリ magic number 散在の検出 → deep research → 起票 → 横展開)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | dev-session.md に「実装モダン性の継続検証原則」節が追加され、検証観点・起票品質バー・横展開のセット運用・PO エスカレーション 4 基準が記載されている | `grep -n "実装モダン性の継続検証原則" docs/sessions/dev-session.md` | PASS (節新設。検証 3 観点 + 3 点セット運用 + 起票品質バー + エスカレーション 4 基準を記載) |
| AC2 | 役割境界表の「Issue 起票」が新運用 (Dev 自由起票 + 品質バー) と整合している | `grep -n "Issue 起票" docs/sessions/dev-session.md` の役割境界表 | PASS (「Dev も可 (#3609、品質バー = §実装モダン性の継続検証原則)」行に更新) |
| AC3 | docs のみの変更で挙動影響なし (コード変更ゼロ) | `git diff origin/develop --stat` → `docs/sessions/dev-session.md` 1 file のみ | PASS (1 file changed, 25 insertions, 1 deletion) |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ドキュメント (`docs/sessions/dev-session.md` のみ)

**影響を受ける画面・機能**: なし (開発プロセス docs のみ、アプリコード変更ゼロ)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: N/A (docs のみ)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（docs のみの変更、UI 変更ゼロ）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A (docs のみ)
- [x] **DRY**: 本原則の記載箇所は dev-session.md の 1 箇所のみ (issue-triage skill / ADR-0061 へは参照 link で接続、内容の複製なし)
- [x] **YAGNI**: N/A
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外 (session doc のみ)

**docs SSOT 整合**: 本原則の SSOT は dev-session.md 本節。memory 側 (ユーザーローカル) は同内容の pointer として保持し、乖離時は本節が正。`docs/sessions/po-session.md` の補佐設計品質ガードとは補完関係 (起票品質バーは共通、本節は Dev 側の常時検証責務を規定)。

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- 「Issue 起票 = PO 専権」の緩和は PO 本人の指示 (2026-07-08) に基づく明文化です。緩和条件 (品質バー) とエスカレーション 4 基準が指示内容と一致しているかをご確認ください

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし (docs のみ)
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
