### PR TITLE
fix: #3611 prepare script を Node 化 (Windows cmd.exe quote 非互換の根治)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"version:generate": "tsx scripts/generate-version.ts",
 		"build": "vite build",
 		"preview": "vite preview",
-		"prepare": "(svelte-kit sync || echo '[prepare] svelte-kit sync failed — node_modules incomplete の可能性。npm install を再実行してください') && (husky || echo '[prepare] husky failed — CI / Lambda build 環境では正常 (husky 未インストール)') && (cd infra && npm ci --no-audit --no-fund || echo '[prepare] cd infra && npm ci FAILED — infra/marketplace 系テストが Cannot find module で fail します。手動実行: cd infra && npm ci')",
+		"prepare": "node scripts/prepare.mjs",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test": "vitest run",

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -1,0 +1,52 @@
+// scripts/prepare.mjs — npm `prepare` lifecycle の cross-platform 実装 (#3611)
+//
+// 旧実装は package.json 内の POSIX sh 構文 (single quote + `||` echo フォールバック) で、
+// Windows の npm script shell (cmd.exe) では quote 解釈が壊れて **npm ci / npm install が
+// 毎回 exit 1** になっていた (日本語文言 + em-dash が cmd の構文エラーを誘発)。
+// npm scripts の複雑な分岐は Node script に寄せるのが cross-platform の標準解のため、
+// 本 script に移管する (shell 構文非依存)。
+//
+// 挙動契約 (#2476 の意図を保持):
+//   - 3 step (svelte-kit sync / husky / cd infra && npm ci) を順次実行
+//   - 各 step の失敗は warning を出して継続 (CI / Lambda build で husky 不在は正常)
+//   - 全体は常に exit 0 (prepare 失敗で install 自体を止めない)
+//   - warning 文言は旧実装と同一 (tests/CLAUDE.md の案内 / 既存 grep 互換)
+
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const repoRoot = join(import.meta.dirname, '..');
+
+/** step を実行し、失敗時は warning を出して false を返す (throw しない)。 */
+function runStep(label, command, args, options = {}) {
+	const result = spawnSync(command, args, {
+		cwd: repoRoot,
+		stdio: 'inherit',
+		// Windows で .cmd shim (npx.cmd / npm.cmd) を解決するため shell 経由で起動する。
+		// 引数は本 script 内の固定値のみ (ユーザー入力を通さない)。
+		shell: true,
+		...options,
+	});
+	if (result.status !== 0) {
+		console.warn(`[prepare] ${label}`);
+		return false;
+	}
+	return true;
+}
+
+runStep(
+	'svelte-kit sync failed — node_modules incomplete の可能性。npm install を再実行してください',
+	'npx',
+	['svelte-kit', 'sync'],
+);
+
+runStep('husky failed — CI / Lambda build 環境では正常 (husky 未インストール)', 'npx', ['husky']);
+
+runStep(
+	'cd infra && npm ci FAILED — infra/marketplace 系テストが Cannot find module で fail します。手動実行: cd infra && npm ci',
+	'npm',
+	['ci', '--no-audit', '--no-fund'],
+	{ cwd: join(repoRoot, 'infra') },
+);
+
+process.exit(0);

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -14,7 +14,7 @@ cd infra && npm ci      # infra 配下も install (必須)
 cd ..
 ```
 
-`prepare` script (root `package.json`) が 2 ステップ目を自動実行するが、`prepare` の各ステップは `||` 経由で warning を出すだけで silent fail する設計のため、**手動確認推奨**:
+`prepare` script (`scripts/prepare.mjs`、#3611 で Node 化) が 2 ステップ目を自動実行するが、`prepare` の各ステップは warning を出すだけで継続する設計のため、**手動確認推奨**:
 
 ```bash
 ls node_modules/valibot/                    # marketplace schemas で必要
@@ -30,9 +30,9 @@ ls node_modules/canvas-confetti/            # tests/unit/features/reward-celebra
 | `Cannot find module 'aws-cdk-lib'` (`tests/unit/infra/multi-lambda-cdk.test.ts`) | `infra/node_modules/` 未 install | `cd infra && npm ci` を手動実行 |
 | `Cannot find module 'canvas-confetti'` (`tests/unit/features/reward-celebration.test.ts`) | root `node_modules/` 不整合 | `npm ci` または `rm -rf node_modules && npm install` |
 
-### `prepare` script の挙動 (#2476)
+### `prepare` script の挙動 (#2476 / #3611)
 
-`package.json` `prepare` script は 3 ステップ実行する: `svelte-kit sync` / `husky` / `cd infra && npm ci`。各ステップ失敗時は `[prepare] ... FAILED — ...` の warning が標準出力に出るため、`npm install` / `npm ci` の出力末尾を確認する習慣をつける。
+`prepare` は `scripts/prepare.mjs` (Node、cross-platform) が 3 ステップ実行する: `svelte-kit sync` / `husky` / `cd infra && npm ci`。各ステップ失敗時は `[prepare] ... FAILED — ...` の warning が標準出力に出るため、`npm install` / `npm ci` の出力末尾を確認する習慣をつける。旧実装 (package.json 内 POSIX sh 構文) は Windows cmd.exe で quote 解釈が壊れ npm ci が毎回 exit 1 になっていたため #3611 で Node script 化した (挙動契約・warning 文言は不変)。
 
 CI ログでも同 warning が出るため、PR の CI fail 調査時にまず確認する箇所。
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営(Windows 開発環境の全 contributor / AI 補佐)

**解決する課題**: `prepare` script が POSIX sh 構文のため Windows cmd.exe で quote 解釈が壊れ、`npm ci` / `npm install` が毎回 exit 1 になる。prepare の 3 step が 1 つも実行されず、#2476 が防ぎたかった「Cannot find module」が Windows では必ず発生していた。

**期待される効果**: Windows / Linux / CI で `npm ci` が一貫して完走し、環境セットアップの再現性が回復する。

## 関連 Issue

closes #3611

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | Windows で `npm ci` が exit 0 で完走し、prepare 3 step が実行される | Windows 実機で `node scripts/prepare.mjs` / `npm run prepare` を実行 | PASS(両方 exit 0、svelte-kit sync + husky + infra npm ci「added 29 packages」完走) |
| AC2 | Linux CI で従来と同一挙動(fail 時 warning 継続、全体 exit 0) | `scripts/prepare.mjs` の runStep 実装(spawnSync 失敗 → console.warn + 継続、末尾 `process.exit(0)`) | PASS(挙動契約をコードで保証。CI の本 PR lint-and-test が prepare 経由の npm ci を貫通) |
| AC3 | `tests/CLAUDE.md` §テスト環境セットアップ / §prepare script の挙動 を新実装に同期 | `grep -n "prepare" tests/CLAUDE.md` | PASS(scripts/prepare.mjs 参照 + Node 化の経緯 1 行を追記) |
| AC4 | 各 step の warning 文言は現行を維持(grep 検出互換) | `scripts/prepare.mjs` の label 文字列と旧 echo 文言の diff 照合 | PASS(3 文言とも同一。prefix `[prepare] ` も維持) |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json` prepare 1 行 + `scripts/prepare.mjs` 新設)
- [x] ドキュメント (`tests/CLAUDE.md` 同期)

**影響を受ける画面・機能**: なし(install lifecycle のみ。アプリコード変更ゼロ)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**(#1775 / ADR-0030)
- [x] 追加・変更したテストの概要: N/A(install lifecycle script。実機検証は AC1 の Windows 実行 + CI の npm ci 貫通が担う)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし(install script のみ、UI 変更ゼロ)**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: runStep 単一責務、固定引数のみ(ユーザー入力を通さない)
- [x] **DRY**: 3 step を共通 runStep に集約
- [x] **YAGNI**: 分岐・オプションなし(prepare の意味論のみ)
- [x] **Security**: shell:true は固定文字列引数のみに使用(injection 面なし、コメント明記)
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外(install lifecycle)

**横展開**: 「npm scripts への POSIX 専用構文直書き」class は package.json 全 scripts を確認し、他 script は単純コマンド連結のみで cmd.exe 互換(quote + 日本語文言の組合せは prepare のみ)であることを確認済

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**(prepare の外部挙動 = 3 step 実行 + warning 継続 + exit 0 は不変)

**レビュー依頼事項・QA**: なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み(不要な差分・デバッグコードなし)
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
