### PR TITLE
refactor: #3607 カテゴリ id↔code↔表示メタの SSOT 統合 (as const satisfies + 派生参照)

### DIFF
--- a/src/lib/data/preset-challenges.ts
+++ b/src/lib/data/preset-challenges.ts
@@ -11,9 +11,9 @@
 // - SEASON_EVENTS は tenant_events table で日付一致時に自動配信される
 // - PRESET_CHALLENGES は setup フロー任意 step で親が明示選択 → sibling_challenges に手動 add
 //
-// CategoryId は src/lib/domain/validation/activity.ts の CATEGORIES 定義に整合:
-//   1=うんどう / 2=べんきょう / 3=せいかつ / 4=こうりゅう / 5=そうぞう
+// カテゴリ id↔code の対応は $lib/domain/categories.ts (SSOT、#3607) に整合。
 
+import { CATEGORY_CODE_TO_ID } from '$lib/domain/categories';
 import { asCategoryId, type CategoryId } from '$lib/domain/ids';
 import { CHILD_TERMS } from '$lib/domain/terms';
 
@@ -54,7 +54,7 @@ export const PRESET_CHALLENGES: readonly PresetChallenge[] = [
 		startMonthDay: '03-01',
 		endMonthDay: '03-03',
 		baseTarget: 3,
-		categoryId: asCategoryId(3), // せいかつ
+		categoryId: asCategoryId(CATEGORY_CODE_TO_ID.seikatsu),
 		rewardPoints: 50,
 		icon: '🎎',
 		autoAddRecommended: false,
@@ -66,7 +66,7 @@ export const PRESET_CHALLENGES: readonly PresetChallenge[] = [
 		startMonthDay: '04-25',
 		endMonthDay: '05-05',
 		baseTarget: 5,
-		categoryId: asCategoryId(5), // そうぞう
+		categoryId: asCategoryId(CATEGORY_CODE_TO_ID.souzou),
 		rewardPoints: 80,
 		icon: '🎏',
 		autoAddRecommended: true,
@@ -90,7 +90,7 @@ export const PRESET_CHALLENGES: readonly PresetChallenge[] = [
 		startMonthDay: '07-20',
 		endMonthDay: '08-31',
 		baseTarget: 10,
-		categoryId: asCategoryId(2), // べんきょう
+		categoryId: asCategoryId(CATEGORY_CODE_TO_ID.benkyou),
 		rewardPoints: 100,
 		icon: '📚',
 		autoAddRecommended: true,
@@ -102,7 +102,7 @@ export const PRESET_CHALLENGES: readonly PresetChallenge[] = [
 		startMonthDay: '09-10',
 		endMonthDay: '09-18',
 		baseTarget: 3,
-		categoryId: asCategoryId(4), // こうりゅう
+		categoryId: asCategoryId(CATEGORY_CODE_TO_ID.kouryuu),
 		rewardPoints: 50,
 		icon: '👴',
 		autoAddRecommended: false,
@@ -114,7 +114,7 @@ export const PRESET_CHALLENGES: readonly PresetChallenge[] = [
 		startMonthDay: 'this-month-start',
 		endMonthDay: 'this-month-end',
 		baseTarget: 15,
-		categoryId: asCategoryId(3), // せいかつ
+		categoryId: asCategoryId(CATEGORY_CODE_TO_ID.seikatsu),
 		rewardPoints: 60,
 		icon: '🏠',
 		autoAddRecommended: true,

--- a/src/lib/domain/battle-types.ts
+++ b/src/lib/domain/battle-types.ts
@@ -4,8 +4,8 @@
  * 子供の日々の活動がRPGステータスに反映され、毎日の敵とバトルする機能。
  * カテゴリ別XPをRPGステータスに変換し、ターン制自動バトルで勝敗を決する。
  */
+import type { CategoryCode } from '$lib/domain/categories';
 import type { ChildId } from '$lib/domain/ids';
-import type { CategoryCode } from '$lib/domain/validation/activity';
 
 // ============================================================
 // RPG ステータス

--- a/src/lib/domain/categories.ts
+++ b/src/lib/domain/categories.ts
@@ -1,0 +1,109 @@
+// src/lib/domain/categories.ts
+// カテゴリ id↔code↔表示メタの SSOT (#3607)。
+//
+// terms.ts atom (ADR-0045) / CONCEPT_ICONS (#2899) / CSS 3 層トークン (ADR-0042) と同型の
+// 「as const オブジェクト + 派生型 + satisfies 網羅性」パターン。カテゴリを追加するときは
+// 本ファイルの CATEGORIES に 1 エントリ追記するだけで、全消費側 (valibot picklist / literal
+// union 型 / id↔code マップ / Record<CategoryCode, ...> 消費側) にコンパイル時伝播する。
+// 網羅性の機械検証は tests/unit/domain/categories.test.ts (AC4)。
+//
+// 設計原則:
+//   - **code (string) が正** — DSQL greenfield schema は categories(code) 自然キーへの論理 FK
+//     (text)。数値 1-5 は marketplace payload / legacy wire / sqlite categories.id の互換投影
+//     (`legacyNumericId`) として保持する。
+//   - branded `CategoryId` (src/lib/domain/ids.ts、opaque string) とは責務が別:
+//     ids.ts = エンティティ参照 (取り違え検出) / 本ファイル = 意味的 enum (値域と表示メタ)。
+//   - color / accent は DB categories テーブル (create-tables.ts) に seed される master 表示メタ
+//     のため SSOT に含める (create-tables.ts と旧 CATEGORY_DEFS の hex 二重定義を解消)。
+//     export-service.ts の独自 palette は歴史的に別値であり、挙動不変のためローカル維持。
+//
+// 本モジュールは依存ゼロの pure module に保つこと — create-tables.ts が相対 import で参照し、
+// その先の scripts/migrate-local.ts (tsx 直接実行) は $lib alias を解決できないため、
+// ここに $lib import を追加すると NUC migrate が壊れる。
+
+interface CategoryMeta {
+	/** sqlite categories.id / marketplace challenge-set payload の数値 id (legacy wire 互換投影) */
+	readonly legacyNumericId: number;
+	/** 日本語表示名 (DB categories.name に seed。子供画面表示はひらがな) */
+	readonly name: string;
+	/** カテゴリアイコン (DB categories.icon に seed) */
+	readonly icon: string;
+	/** master 表示色 (DB categories.color に seed) */
+	readonly color: string;
+	/** アクセント色 (アプリ UI の強調表示用、DB には seed しない) */
+	readonly accent: string;
+}
+
+export const CATEGORIES = {
+	undou: { legacyNumericId: 1, name: 'うんどう', icon: '🏃', color: '#FF6B6B', accent: '#D32F2F' },
+	benkyou: {
+		legacyNumericId: 2,
+		name: 'べんきょう',
+		icon: '📚',
+		color: '#4ECDC4',
+		accent: '#00897B',
+	},
+	seikatsu: {
+		legacyNumericId: 3,
+		name: 'せいかつ',
+		icon: '🏠',
+		color: '#FFE66D',
+		accent: '#F9A825',
+	},
+	kouryuu: {
+		legacyNumericId: 4,
+		name: 'こうりゅう',
+		icon: '🤝',
+		color: '#A8E6CF',
+		accent: '#2E7D32',
+	},
+	souzou: { legacyNumericId: 5, name: 'そうぞう', icon: '🎨', color: '#DDA0DD', accent: '#7B1FA2' },
+} as const satisfies Record<string, CategoryMeta>;
+
+/** カテゴリコード union: 'undou' | 'benkyou' | 'seikatsu' | 'kouryuu' | 'souzou' */
+export type CategoryCode = keyof typeof CATEGORIES;
+/** 日本語表示名 union: 'うんどう' | 'べんきょう' | ... */
+export type CategoryName = (typeof CATEGORIES)[CategoryCode]['name'];
+/** legacy 数値 id union: 1 | 2 | 3 | 4 | 5 (marketplace payload / sqlite categories.id) */
+export type CategoryNumericId = (typeof CATEGORIES)[CategoryCode]['legacyNumericId'];
+
+/** 全カテゴリコード (定義順 = legacyNumericId 昇順) */
+export const CATEGORY_CODES = Object.keys(CATEGORIES) as readonly CategoryCode[];
+
+/** 全 legacy 数値 id (定義順)。valibot `v.picklist(CATEGORY_NUMERIC_IDS)` 等の値域 SSOT */
+export const CATEGORY_NUMERIC_IDS = CATEGORY_CODES.map(
+	(code) => CATEGORIES[code].legacyNumericId,
+) as readonly CategoryNumericId[];
+
+/** legacy 数値 id → code (型レベル total: schema 検証済みの CategoryNumericId で索引する) */
+export const CATEGORY_ID_TO_CODE = Object.fromEntries(
+	CATEGORY_CODES.map((code) => [CATEGORIES[code].legacyNumericId, code]),
+) as Record<CategoryNumericId, CategoryCode>;
+
+/** code → legacy 数値 id (型レベル total) */
+export const CATEGORY_CODE_TO_ID = Object.fromEntries(
+	CATEGORY_CODES.map((code) => [code, CATEGORIES[code].legacyNumericId]),
+) as Record<CategoryCode, CategoryNumericId>;
+
+const ID_TO_CODE_LOOKUP = new Map<number, CategoryCode>(
+	CATEGORY_CODES.map((code) => [CATEGORIES[code].legacyNumericId, code]),
+);
+const CODE_LOOKUP = new Map<string, CategoryNumericId>(
+	CATEGORY_CODES.map((code) => [code, CATEGORIES[code].legacyNumericId]),
+);
+
+/**
+ * 未検証の境界入力 (branded CategoryId 文字列 / 外部 payload の数値) から code を引く。
+ * 検証済み `CategoryNumericId` を持っている場合は `CATEGORY_ID_TO_CODE` の total 索引を使うこと。
+ */
+export function toCategoryCode(id: number | string): CategoryCode | undefined {
+	return ID_TO_CODE_LOOKUP.get(Number(id));
+}
+
+/**
+ * 未検証の境界入力 (import ファイル等の categoryCode 文字列) から legacy 数値 id を引く。
+ * 検証済み `CategoryCode` を持っている場合は `CATEGORY_CODE_TO_ID` の total 索引を使うこと。
+ */
+export function toLegacyCategoryId(code: string): CategoryNumericId | undefined {
+	return CODE_LOOKUP.get(code);
+}

--- a/src/lib/domain/ids.ts
+++ b/src/lib/domain/ids.ts
@@ -20,7 +20,11 @@ type Branded<T, B extends string> = T & { readonly [idBrand]: B };
 export type ChildId = Branded<string, 'ChildId'>;
 /** 活動 id (child_activities.activity_id)。 */
 export type ActivityId = Branded<string, 'ActivityId'>;
-/** カテゴリ id (categories.code への論理 FK)。 */
+/**
+ * カテゴリ id (categories.code への論理 FK)。
+ * 責務はエンティティ参照 (opaque token、取り違え検出) のみ。カテゴリの値域・code↔数値 id
+ * 対応・表示メタ (意味的 enum) は $lib/domain/categories.ts が SSOT (#3607)。
+ */
 export type CategoryId = Branded<string, 'CategoryId'>;
 
 /** 境界 (route param / cookie / 旧 integer PK) からの取り込み。検証はしない (opaque)。 */

--- a/src/lib/domain/marketplace-item.ts
+++ b/src/lib/domain/marketplace-item.ts
@@ -5,6 +5,7 @@
  * into a unified browsable catalog.
  */
 
+import type { CategoryNumericId } from './categories.js';
 import { AGE_TIER_LABELS } from './labels.js';
 import type { ShopCategory } from './shop-category.js';
 import { CONCEPT_ICONS } from './terms.js';
@@ -141,8 +142,8 @@ export interface ChallengeSetPayload {
 		monthDay: string;
 		/** 期間 (日数)。startDate = monthDay の N 日前。endDate = monthDay。 */
 		durationDays: number;
-		/** 1=undou 2=benkyou 3=seikatsu 4=kouryuu 5=souzou */
-		categoryId: 1 | 2 | 3 | 4 | 5;
+		/** legacy 数値カテゴリ id ($lib/domain/categories.ts SSOT 派生、#3607) */
+		categoryId: CategoryNumericId;
 		baseTarget: number;
 		rewardPoints: number;
 		icon: string;

--- a/src/lib/domain/validation/activity.ts
+++ b/src/lib/domain/validation/activity.ts
@@ -1,17 +1,28 @@
 import { z } from 'zod';
+import {
+	CATEGORY_CODES,
+	CATEGORIES as CATEGORY_SSOT,
+	type CategoryCode,
+	type CategoryName,
+} from '$lib/domain/categories';
 import { asCategoryId, type CategoryId } from '$lib/domain/ids';
 import { activityIdSchema, categoryIdSchema, childIdSchema } from './id-schema';
 
-export const CATEGORIES = ['うんどう', 'べんきょう', 'せいかつ', 'こうりゅう', 'そうぞう'] as const;
+export type { CategoryCode };
+// #3607: カテゴリ id↔code↔表示メタの SSOT は $lib/domain/categories.ts へ移設。
+// CATEGORY_CODES / CategoryCode は後方互換のため本モジュールから re-export を維持する。
+export { CATEGORY_CODES };
 
-export type Category = (typeof CATEGORIES)[number];
+export type Category = CategoryName;
+
+/** 日本語表示名一覧 (SSOT 派生)。新規参照は $lib/domain/categories.ts を直接使うこと */
+export const CATEGORIES: readonly Category[] = CATEGORY_CODES.map(
+	(code) => CATEGORY_SSOT[code].name,
+);
 
 // ============================================================
-// カテゴリマスタ定義（サロゲートキー）
+// カテゴリマスタ定義（サロゲートキー、#3607 で SSOT 派生化）
 // ============================================================
-export const CATEGORY_CODES = ['undou', 'benkyou', 'seikatsu', 'kouryuu', 'souzou'] as const;
-export type CategoryCode = (typeof CATEGORY_CODES)[number];
-
 export interface CategoryDef {
 	readonly id: CategoryId;
 	readonly code: CategoryCode;
@@ -21,48 +32,14 @@ export interface CategoryDef {
 	readonly accent: string;
 }
 
-export const CATEGORY_DEFS: readonly CategoryDef[] = [
-	{
-		id: asCategoryId(1),
-		code: 'undou',
-		name: 'うんどう',
-		icon: '🏃',
-		color: '#FF6B6B',
-		accent: '#D32F2F',
-	},
-	{
-		id: asCategoryId(2),
-		code: 'benkyou',
-		name: 'べんきょう',
-		icon: '📚',
-		color: '#4ECDC4',
-		accent: '#00897B',
-	},
-	{
-		id: asCategoryId(3),
-		code: 'seikatsu',
-		name: 'せいかつ',
-		icon: '🏠',
-		color: '#FFE66D',
-		accent: '#F9A825',
-	},
-	{
-		id: asCategoryId(4),
-		code: 'kouryuu',
-		name: 'こうりゅう',
-		icon: '🤝',
-		color: '#A8E6CF',
-		accent: '#2E7D32',
-	},
-	{
-		id: asCategoryId(5),
-		code: 'souzou',
-		name: 'そうぞう',
-		icon: '🎨',
-		color: '#DDA0DD',
-		accent: '#7B1FA2',
-	},
-] as const;
+export const CATEGORY_DEFS: readonly CategoryDef[] = CATEGORY_CODES.map((code) => ({
+	id: asCategoryId(CATEGORY_SSOT[code].legacyNumericId),
+	code,
+	name: CATEGORY_SSOT[code].name,
+	icon: CATEGORY_SSOT[code].icon,
+	color: CATEGORY_SSOT[code].color,
+	accent: CATEGORY_SSOT[code].accent,
+}));
 
 export const CATEGORY_IDS = CATEGORY_DEFS.map((c) => c.id) as [CategoryId, ...CategoryId[]];
 

--- a/src/lib/features/admin/components/activity-types.ts
+++ b/src/lib/features/admin/components/activity-types.ts
@@ -1,3 +1,4 @@
+import type { CategoryName } from '$lib/domain/categories';
 import type { ActivityId, CategoryId } from '$lib/domain/ids';
 /**
  * Shared types for admin activity management components.
@@ -67,8 +68,13 @@ export interface PointGuideEntry {
 	color: string;
 }
 
-/** Shared constants for activity forms */
-export const CATEGORY_INFO: Record<string, CategoryInfo> = {
+/**
+ * Shared constants for activity forms.
+ * #3607: key はカテゴリ SSOT ($lib/domain/categories.ts) の表示名。satisfies で全カテゴリの
+ * 網羅をコンパイル時強制する (カテゴリ追加時に desc / icons の追記漏れが即 compile error)。
+ * 参照側は表示名文字列で lookup するため公開型は Record<string, CategoryInfo> を維持。
+ */
+export const CATEGORY_INFO = {
 	うんどう: {
 		label: 'うんどう',
 		desc: '体を動かす活動（走る、泳ぐ、ボール遊びなど）',
@@ -94,7 +100,7 @@ export const CATEGORY_INFO: Record<string, CategoryInfo> = {
 		desc: '創造的活動（お絵描き、工作、音楽など）',
 		icons: ['🎨', '✂️', '🎹', '🎸', '📷', '🏗️', '🧩', '🎤', '🖍️', '🎲', '📐', '🪡'],
 	},
-};
+} satisfies Record<CategoryName, CategoryInfo> as Record<string, CategoryInfo>;
 
 export const POINT_GUIDE: PointGuideEntry[] = [
 	{

--- a/src/lib/marketplace/schemas/challenge-set-schema.ts
+++ b/src/lib/marketplace/schemas/challenge-set-schema.ts
@@ -14,6 +14,12 @@
  */
 
 import * as v from 'valibot';
+import { CATEGORIES, CATEGORY_CODES, CATEGORY_NUMERIC_IDS } from '$lib/domain/categories.js';
+
+/** picklist エラーメッセージ用の "1 (うんどう) / 2 (べんきょう) / ..." 列挙 (SSOT 派生、#3607) */
+const CATEGORY_ID_CHOICES = CATEGORY_CODES.map(
+	(code) => `${CATEGORIES[code].legacyNumericId} (${CATEGORIES[code].name})`,
+).join(' / ');
 
 /** challenge-set item: 単一のチャレンジ (#2297 ChallengeSetPayload interface 整合) */
 export const ChallengeSetItemSchema = v.object({
@@ -43,16 +49,16 @@ export const ChallengeSetItemSchema = v.object({
 		v.maxValue(90, 'durationDays は 90 以下で指定してください'),
 	),
 	/**
-	 * 1=undou 2=benkyou 3=seikatsu 4=kouryuu 5=souzou
+	 * legacy 数値カテゴリ id ($lib/domain/categories.ts SSOT の `legacyNumericId` 投影、#3607)。
 	 *
 	 * payload 内で自己完結する「意味的カテゴリ enum」であり、DB エンティティの
 	 * branded CategoryId (string、src/lib/domain/ids.ts) とは別物 (#3606 棚卸しで
-	 * runtime break なしを確認済)。数値直書きは SSOT 不在の技術負債であり、#3607
-	 * (カテゴリ SSOT 統合) で as const satisfies SSOT からの派生参照に置換予定。
+	 * runtime break なしを確認済)。値域はカテゴリ SSOT から派生し、カテゴリ追加時は
+	 * SSOT 1 エントリ追記で本 picklist にも自動伝播する。
 	 */
 	categoryId: v.picklist(
-		[1, 2, 3, 4, 5] as const,
-		'categoryId は 1 (運動) / 2 (勉強) / 3 (生活) / 4 (交流) / 5 (創造) のいずれかで指定してください',
+		CATEGORY_NUMERIC_IDS,
+		`categoryId は ${CATEGORY_ID_CHOICES} のいずれかで指定してください`,
 	),
 	/** 達成目標 (例: 累積 10 回) */
 	baseTarget: v.pipe(

--- a/src/lib/server/db/create-tables.ts
+++ b/src/lib/server/db/create-tables.ts
@@ -2,6 +2,17 @@
 // Shared CREATE TABLE SQL — used by both Lambda cold-start init and tests.
 // This is the single source of truth for table structure.
 
+// #3607: categories master seed はカテゴリ SSOT から派生生成 (id/code/name/icon/color の
+// 二重定義を解消。カテゴリ追加は categories.ts 1 エントリ追記で本 seed にも自動伝播)。
+// scripts/migrate-local.ts (tsx 直接実行) が本 file を import するため $lib alias ではなく
+// 相対 import を使う (categories.ts は依存ゼロの pure module)。
+import { CATEGORIES, CATEGORY_CODES } from '../../domain/categories';
+
+const SQL_INSERT_CATEGORIES = CATEGORY_CODES.map((code) => {
+	const c = CATEGORIES[code];
+	return `INSERT OR IGNORE INTO categories VALUES (${c.legacyNumericId}, '${code}', '${c.name}', '${c.icon}', '${c.color}');`;
+}).join('\n\t');
+
 export const SQL_CREATE_TABLES = `
 	CREATE TABLE IF NOT EXISTS categories (
 		id INTEGER PRIMARY KEY,
@@ -11,11 +22,7 @@ export const SQL_CREATE_TABLES = `
 		color TEXT
 	);
 
-	INSERT OR IGNORE INTO categories VALUES (1, 'undou', 'うんどう', '🏃', '#FF6B6B');
-	INSERT OR IGNORE INTO categories VALUES (2, 'benkyou', 'べんきょう', '📚', '#4ECDC4');
-	INSERT OR IGNORE INTO categories VALUES (3, 'seikatsu', 'せいかつ', '🏠', '#FFE66D');
-	INSERT OR IGNORE INTO categories VALUES (4, 'kouryuu', 'こうりゅう', '🤝', '#A8E6CF');
-	INSERT OR IGNORE INTO categories VALUES (5, 'souzou', 'そうぞう', '🎨', '#DDA0DD');
+	${SQL_INSERT_CATEGORIES}
 
 	CREATE TABLE IF NOT EXISTS children (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/lib/server/db/seed.ts
+++ b/src/lib/server/db/seed.ts
@@ -5,6 +5,8 @@
 import Database from 'better-sqlite3';
 import { and, eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
+// #3607: tsx 直接実行 (Usage 参照) のため $lib alias ではなく相対 import
+import { CATEGORY_CODE_TO_ID, type CategoryCode } from '../../domain/categories';
 import * as schema from './schema';
 
 const DATABASE_URL = process.env.DATABASE_URL ?? './data/ganbari-quest.db';
@@ -3003,7 +3005,7 @@ function seed() {
 			name: 'うんどうがんばった',
 			description: 'うんどうのかつどうをたくさんやろう！',
 			icon: '🏃',
-			category: 'undou',
+			category: 'undou' satisfies CategoryCode,
 			conditionType: 'category_activities',
 			conditionValue: 10,
 			bonusPoints: 10,
@@ -3017,7 +3019,7 @@ function seed() {
 			name: 'べんきょうがんばった',
 			description: 'べんきょうのかつどうをたくさんやろう！',
 			icon: '📚',
-			category: 'benkyou',
+			category: 'benkyou' satisfies CategoryCode,
 			conditionType: 'category_activities',
 			conditionValue: 10,
 			bonusPoints: 10,
@@ -3031,7 +3033,7 @@ function seed() {
 			name: 'せいかつマスター',
 			description: 'せいかつのかつどうをたくさんやろう！',
 			icon: '🏠',
-			category: 'seikatsu',
+			category: 'seikatsu' satisfies CategoryCode,
 			conditionType: 'category_activities',
 			conditionValue: 10,
 			bonusPoints: 10,
@@ -3045,7 +3047,7 @@ function seed() {
 			name: 'こうりゅうのたつじん',
 			description: 'こうりゅうのかつどうをたくさんやろう！',
 			icon: '🤝',
-			category: 'kouryuu',
+			category: 'kouryuu' satisfies CategoryCode,
 			conditionType: 'category_activities',
 			conditionValue: 10,
 			bonusPoints: 10,
@@ -3059,7 +3061,7 @@ function seed() {
 			name: 'そうぞうのてんさい',
 			description: 'そうぞうのかつどうをたくさんやろう！',
 			icon: '🎨',
-			category: 'souzou',
+			category: 'souzou' satisfies CategoryCode,
 			conditionType: 'category_activities',
 			conditionValue: 10,
 			bonusPoints: 10,
@@ -3283,7 +3285,7 @@ function seed() {
 		const springActivities: (typeof schema.activities.$inferInsert)[] = [
 			{
 				name: 'おはなみさんぽ',
-				categoryId: catMap.undou ?? 1,
+				categoryId: catMap.undou ?? CATEGORY_CODE_TO_ID.undou,
 				icon: '🌸',
 				basePoints: 8,
 				source: 'seasonal',
@@ -3293,7 +3295,7 @@ function seed() {
 			},
 			{
 				name: 'たねをまく',
-				categoryId: catMap.seikatsu ?? 3,
+				categoryId: catMap.seikatsu ?? CATEGORY_CODE_TO_ID.seikatsu,
 				icon: '🌱',
 				basePoints: 10,
 				source: 'seasonal',
@@ -3303,7 +3305,7 @@ function seed() {
 			},
 			{
 				name: 'はるのむしさがし',
-				categoryId: catMap.undou ?? 1,
+				categoryId: catMap.undou ?? CATEGORY_CODE_TO_ID.undou,
 				icon: '🐝',
 				basePoints: 8,
 				source: 'seasonal',
@@ -3313,7 +3315,7 @@ function seed() {
 			},
 			{
 				name: 'あたらしいおともだちとあそぶ',
-				categoryId: catMap.kouryuu ?? 4,
+				categoryId: catMap.kouryuu ?? CATEGORY_CODE_TO_ID.kouryuu,
 				icon: '🤝',
 				basePoints: 10,
 				source: 'seasonal',
@@ -3323,7 +3325,7 @@ function seed() {
 			},
 			{
 				name: 'はるのおえかき',
-				categoryId: catMap.souzou ?? 5,
+				categoryId: catMap.souzou ?? CATEGORY_CODE_TO_ID.souzou,
 				icon: '🎨',
 				basePoints: 8,
 				source: 'seasonal',
@@ -3333,7 +3335,7 @@ function seed() {
 			},
 			{
 				name: 'しんがっきのもくひょう',
-				categoryId: catMap.benkyou ?? 2,
+				categoryId: catMap.benkyou ?? CATEGORY_CODE_TO_ID.benkyou,
 				icon: '📝',
 				basePoints: 15,
 				source: 'seasonal',

--- a/src/lib/server/demo/demo-data.ts
+++ b/src/lib/server/demo/demo-data.ts
@@ -28,6 +28,7 @@
 
 import { getMarketplaceItem } from '$lib/data/marketplace';
 import type { ActivityPackItem } from '$lib/domain/activity-pack';
+import { CATEGORY_CODE_TO_ID, toLegacyCategoryId } from '$lib/domain/categories';
 import {
 	type ActivityId,
 	asActivityId,
@@ -41,7 +42,6 @@ import type {
 	ChecklistPayload,
 	RewardSetPayload,
 } from '$lib/domain/marketplace-item';
-import { CATEGORY_CODES } from '$lib/domain/validation/activity';
 import { getDefaultUiMode } from '$lib/domain/validation/age-tier';
 import type { RewardCategory } from '$lib/domain/validation/special-reward';
 import type { DailyBattleRow } from '$lib/server/db/interfaces/battle-repo.interface';
@@ -3199,12 +3199,6 @@ const SYN_TEMPLATE_ID_BASE = 5000;
 const SYN_TEMPLATE_ITEM_ID_BASE = 6000;
 const SYN_SPECIAL_REWARD_ID_BASE = 5000;
 
-// Category code → numeric ID (activity-import-service.ts の CATEGORY_CODE_TO_ID と同義)
-const CATEGORY_CODE_TO_ID: Record<string, number> = {};
-for (const [i, code] of CATEGORY_CODES.entries()) {
-	CATEGORY_CODE_TO_ID[code] = i + 1;
-}
-
 /** Marketplace ActivityPackItem → Domain Activity への変換 (production の importActivities と同型) */
 function convertMarketplaceActivitiesToDomain(
 	items: ActivityPackItem[],
@@ -3212,7 +3206,10 @@ function convertMarketplaceActivitiesToDomain(
 	idOffset: number,
 ): Activity[] {
 	return items.map((item, idx) => {
-		const categoryId = asCategoryId(CATEGORY_CODE_TO_ID[item.categoryCode] ?? 3); // fallback: seikatsu
+		// #3607: id↔code は SSOT 派生。未知 code は従来どおり seikatsu に fallback
+		const categoryId = asCategoryId(
+			toLegacyCategoryId(item.categoryCode) ?? CATEGORY_CODE_TO_ID.seikatsu,
+		);
 		return {
 			id: asActivityId(SYN_ACTIVITY_ID_BASE + idOffset + idx),
 			name: item.name,

--- a/src/lib/server/services/activity-import-service.ts
+++ b/src/lib/server/services/activity-import-service.ts
@@ -23,16 +23,17 @@ import { asCategoryId } from '$lib/domain/ids';
 //   生んだ activity 数」、skipped は「全 target child で既存だった activity 数」。
 
 import type { ActivityPackItem } from '$lib/domain/activity-pack';
-import { CATEGORY_CODES } from '$lib/domain/validation/activity';
+import { toLegacyCategoryId } from '$lib/domain/categories';
 import { findActivities } from '$lib/server/db/activity-repo';
 import { findAllChildren } from '$lib/server/db/child-repo';
 import { getRepos } from '$lib/server/db/factory';
 import type { InsertChildActivityInput } from '$lib/server/db/types';
 import { logger } from '$lib/server/logger';
 
-const CATEGORY_CODE_TO_ID: Record<string, CategoryId> = {};
-for (const [i, code] of CATEGORY_CODES.entries()) {
-	CATEGORY_CODE_TO_ID[code] = asCategoryId(i + 1);
+/** categoryCode (未検証文字列) → branded CategoryId (#3607: SSOT 派生、旧 index-based map を撤去) */
+function categoryIdFromCode(code: string): CategoryId | undefined {
+	const legacyId = toLegacyCategoryId(code);
+	return legacyId === undefined ? undefined : asCategoryId(legacyId);
 }
 
 export interface ActivityImportPreview {
@@ -148,7 +149,7 @@ function resolveActivityMeta(
 	categoryId?: CategoryId;
 	priority?: 'must' | 'optional';
 } {
-	const categoryId = CATEGORY_CODE_TO_ID[a.categoryCode];
+	const categoryId = categoryIdFromCode(a.categoryCode);
 	if (!categoryId) {
 		return {
 			ok: false,

--- a/src/lib/server/services/activity-suggest-service.ts
+++ b/src/lib/server/services/activity-suggest-service.ts
@@ -1,8 +1,15 @@
 import type { CategoryId } from '$lib/domain/ids';
 import { asCategoryId } from '$lib/domain/ids';
+
 // src/lib/server/services/activity-suggest-service.ts
 // 自然言語から活動情報を推定するサービス (#721: Bedrock Claude Haiku)
 
+import {
+	CATEGORIES,
+	CATEGORY_CODE_TO_ID,
+	CATEGORY_CODES,
+	type CategoryName,
+} from '$lib/domain/categories';
 import { joinIcon } from '$lib/domain/icon-utils';
 import { getCategoryByName } from '$lib/domain/validation/activity';
 import { getAiProvider, isAiAvailable } from '$lib/server/ai/factory';
@@ -18,13 +25,14 @@ export interface SuggestedActivity {
 	source: 'gemini' | 'fallback';
 }
 
-const CATEGORY_ICONS: Record<string, string[]> = {
+// #3607: key はカテゴリ SSOT の表示名。satisfies で全カテゴリ網羅をコンパイル時強制
+const CATEGORY_ICONS = {
 	うんどう: ['🤸', '⚽', '🏃', '🏊', '🚴', '⚾', '🎾', '🏀'],
 	べんきょう: ['📖', '✏️', '🔢', '📝', '🧮', '📚', '🔬', '🌍'],
 	せいかつ: ['🪥', '🧹', '👕', '🍽️', '🛏️', '🧺', '🚿', '🌱'],
 	こうりゅう: ['🤝', '👋', '💬', '🎉', '👫', '🤗', '📱', '✉️'],
 	そうぞう: ['🎨', '✂️', '🎹', '🎸', '📷', '🏗️', '🧩', '🎤'],
-};
+} satisfies Record<CategoryName, string[]> as Record<string, string[]>;
 
 /** キーワード→アイコンの詳細マッピング */
 const KEYWORD_ICONS: Record<string, string> = {
@@ -172,7 +180,8 @@ const ACTIVITY_TOOL = {
 			nameKanji: { type: 'string', description: '漢字混じり表記' },
 			category: {
 				type: 'string',
-				enum: ['うんどう', 'べんきょう', 'せいかつ', 'こうりゅう', 'そうぞう'],
+				// #3607: カテゴリ SSOT から派生 (カテゴリ追加時に AI tool schema へ自動伝播)
+				enum: CATEGORY_CODES.map((code) => CATEGORIES[code].name),
 				description: '活動カテゴリ',
 			},
 			mainIcon: { type: 'string', description: '活動の主な対象を表す絵文字' },
@@ -255,7 +264,7 @@ async function suggestWithAi(text: string): Promise<SuggestedActivity> {
 
 	// バリデーション
 	const catDef = getCategoryByName(String(obj.category ?? ''));
-	const categoryId = catDef?.id ?? asCategoryId(3);
+	const categoryId = catDef?.id ?? asCategoryId(CATEGORY_CODE_TO_ID.seikatsu);
 	const basePoints = [3, 5, 8, 10].includes(Number(obj.basePoints)) ? Number(obj.basePoints) : 5;
 
 	// 複合アイコン対応
@@ -318,8 +327,8 @@ function suggestByKeywords(text: string): SuggestedActivity {
 				'テニス',
 				'てにす',
 			],
-			categoryName: 'うんどう',
-			categoryId: asCategoryId(1),
+			categoryName: CATEGORIES.undou.name,
+			categoryId: asCategoryId(CATEGORY_CODE_TO_ID.undou),
 			basePoints: 5,
 		},
 		{
@@ -345,8 +354,8 @@ function suggestByKeywords(text: string): SuggestedActivity {
 				'九九',
 				'くく',
 			],
-			categoryName: 'べんきょう',
-			categoryId: asCategoryId(2),
+			categoryName: CATEGORIES.benkyou.name,
+			categoryId: asCategoryId(CATEGORY_CODE_TO_ID.benkyou),
 			basePoints: 5,
 		},
 		{
@@ -377,8 +386,8 @@ function suggestByKeywords(text: string): SuggestedActivity {
 				'水やり',
 				'みずやり',
 			],
-			categoryName: 'せいかつ',
-			categoryId: asCategoryId(3),
+			categoryName: CATEGORIES.seikatsu.name,
+			categoryId: asCategoryId(CATEGORY_CODE_TO_ID.seikatsu),
 			basePoints: 3,
 		},
 		{
@@ -403,8 +412,8 @@ function suggestByKeywords(text: string): SuggestedActivity {
 				'先生',
 				'せんせい',
 			],
-			categoryName: 'こうりゅう',
-			categoryId: asCategoryId(4),
+			categoryName: CATEGORIES.kouryuu.name,
+			categoryId: asCategoryId(CATEGORY_CODE_TO_ID.kouryuu),
 			basePoints: 3,
 		},
 		{
@@ -434,8 +443,8 @@ function suggestByKeywords(text: string): SuggestedActivity {
 				'ギター',
 				'ぎたー',
 			],
-			categoryName: 'そうぞう',
-			categoryId: asCategoryId(5),
+			categoryName: CATEGORIES.souzou.name,
+			categoryId: asCategoryId(CATEGORY_CODE_TO_ID.souzou),
 			basePoints: 5,
 		},
 	];
@@ -456,7 +465,7 @@ function suggestByKeywords(text: string): SuggestedActivity {
 	if (best.score === 0) {
 		return {
 			name: text.slice(0, 50),
-			categoryId: asCategoryId(3),
+			categoryId: asCategoryId(CATEGORY_CODE_TO_ID.seikatsu),
 			icon: '📝',
 			basePoints: 5,
 			...inferNames(text),

--- a/src/lib/server/services/bonus-hook-service.ts
+++ b/src/lib/server/services/bonus-hook-service.ts
@@ -30,6 +30,7 @@ import { asCategoryId } from '$lib/domain/ids';
 // 計算のみ、category-challenge は呼び出し側 (activity-log-service) から渡される
 // today categories count を使う形式とする。
 
+import { CATEGORY_CODE_TO_ID } from '$lib/domain/categories';
 import { calcStreakBonus } from '$lib/domain/validation/activity';
 // #2368 (ADR-0052): bonus state SSOT は marketplace strategy 配下に移動済。
 // 本 import は新 SSOT を直接参照 (旧 rule-preset-import-service の re-export 経由を撤去)。
@@ -208,7 +209,8 @@ export async function evaluateBonusHooks(
 				// 学習系カテゴリ (categoryId === 2 = 勉強) で自主学習 bonus
 				// 仕様簡略化: 学習カテゴリで記録した場合 +10 (本来は memo / 教科判定が必要)
 				// #2895: `しんきかもくボーナス` (新教科判定) は本番判定ロジックがなく死蔵だったため preset から撤去済。
-				if (ctx.categoryId === asCategoryId(2)) {
+				// #3607: 「学習カテゴリ = benkyou」の対応は SSOT 派生で解決 (magic number 2 を撤去)
+				if (ctx.categoryId === asCategoryId(CATEGORY_CODE_TO_ID.benkyou)) {
 					const study = preset.rules.find((r) => r.title === 'じしゅがくしゅうボーナス');
 					if (study) {
 						hits.push({

--- a/src/lib/server/services/challenge-set-import-service.ts
+++ b/src/lib/server/services/challenge-set-import-service.ts
@@ -19,6 +19,7 @@ import type { ChildId } from '$lib/domain/ids';
 //   - $lib/marketplace/strategies/challenge-set-strategy (本 service を内部 callee として参照)
 //   - EPIC #2294 案 B-γ (日本ローカライズ wedge): 日本年間行事パック配信経路
 
+import { toCategoryCode } from '$lib/domain/categories';
 import { toJSTDateString } from '$lib/domain/date-utils';
 import type { ChallengeSetPayload } from '$lib/domain/marketplace-item';
 import { findAllChildren } from '$lib/server/db/child-repo';
@@ -105,15 +106,6 @@ export interface ChallengeSetImportResult {
 	failed: number;
 }
 
-/** カテゴリ ID → コード (preview 集計表示用) */
-const CATEGORY_ID_TO_CODE: Record<string, string> = {
-	1: 'undou',
-	2: 'benkyou',
-	3: 'seikatsu',
-	4: 'kouryuu',
-	5: 'souzou',
-};
-
 /**
  * インポート対象の challenge-set をプレビュー (DB write 禁止)
  *
@@ -133,7 +125,15 @@ export async function previewChallengeSetImport(
 	let newCount = 0;
 
 	for (const ch of challenges) {
-		const catCode = CATEGORY_ID_TO_CODE[ch.categoryId] ?? `category_${ch.categoryId}`;
+		// #3607 AC3: 旧 `category_${id}` silent fallback を撤去し明示エラー化。
+		// ChallengeSetItemSchema (picklist = SSOT 派生) 検証済み payload では到達しない防御線であり、
+		// 未検証 caller が未知 id を流した場合に修正漏れを silent 化せず即座に露出させる。
+		const catCode = toCategoryCode(ch.categoryId);
+		if (!catCode) {
+			throw new Error(
+				`未知の categoryId です: ${ch.categoryId} (カテゴリ SSOT: $lib/domain/categories.ts)`,
+			);
+		}
 		byCategory[catCode] = (byCategory[catCode] ?? 0) + 1;
 
 		if (existingTitles.has(ch.title)) {

--- a/src/lib/server/services/child-challenge-service.ts
+++ b/src/lib/server/services/child-challenge-service.ts
@@ -12,6 +12,12 @@ import { asCategoryId } from '$lib/domain/ids';
 //   - Anti-engagement (ADR-0012): 全員完了で簡素な祝福のみ (admin 画面で表示)、
 //     子供画面で兄弟比較を煽らない
 
+import {
+	CATEGORIES,
+	CATEGORY_CODE_TO_ID,
+	CATEGORY_CODES,
+	CATEGORY_NUMERIC_IDS,
+} from '$lib/domain/categories';
 import { todayDateJST } from '$lib/domain/date-utils';
 import { insertPointLedger } from '$lib/server/db/activity-repo';
 import { findAllChildren } from '$lib/server/db/child-repo';
@@ -32,17 +38,13 @@ import { aggregateActivityLogsByCategory } from '$lib/server/services/activity-l
 // 設計: docs/design/44-チャレンジ設計書.md §3.4 / docs/rationale/12-auto-challenge-generation-rationale.md
 // ============================================================
 
-/** Category IDs from the categories master table */
-const ALL_CATEGORY_IDS: readonly CategoryId[] = [1, 2, 3, 4, 5].map(asCategoryId);
+/** Category IDs from the categories master table (#3607: SSOT 派生) */
+const ALL_CATEGORY_IDS: readonly CategoryId[] = CATEGORY_NUMERIC_IDS.map(asCategoryId);
 
-/** Category names for display (生成 challenge の view 整形でも再利用) */
-export const CATEGORY_NAMES: Record<string, string> = {
-	1: 'うんどう',
-	2: 'べんきょう',
-	3: 'せいかつ',
-	4: 'こうりゅう',
-	5: 'そうぞう',
-};
+/** Category names for display (生成 challenge の view 整形でも再利用、#3607: SSOT 派生) */
+export const CATEGORY_NAMES: Record<string, string> = Object.fromEntries(
+	CATEGORY_CODES.map((code) => [String(CATEGORIES[code].legacyNumericId), CATEGORIES[code].name]),
+);
 
 /** 生成モード。weakness=苦手, strength=得意深掘り週, rescue-strength=連続未達レスキュー, explore=データ不足 (#3194) */
 export type ChallengeProposalMode = 'weakness' | 'strength' | 'rescue-strength' | 'explore';
@@ -163,7 +165,7 @@ export async function aggregateCategoryCounts(
 
 /** 最多記録カテゴリ (得意) を返す。同数は最小 id を優先 (決定的)。 */
 function strongestCategory(counts: Record<string, number>): CategoryId {
-	let best = ALL_CATEGORY_IDS[0] ?? asCategoryId(1);
+	let best = ALL_CATEGORY_IDS[0] ?? asCategoryId(CATEGORY_CODE_TO_ID.undou);
 	let max = -1;
 	for (const catId of ALL_CATEGORY_IDS) {
 		const n = counts[catId] ?? 0;
@@ -220,7 +222,7 @@ function weightedWeakPick(
 		r -= x.w;
 		if (r <= 0) return x.c;
 	}
-	return sorted[0] ?? ALL_CATEGORY_IDS[0] ?? asCategoryId(1);
+	return sorted[0] ?? ALL_CATEGORY_IDS[0] ?? asCategoryId(CATEGORY_CODE_TO_ID.undou);
 }
 
 function reasonFor(mode: ChallengeProposalMode, categoryName: string): string {
@@ -247,7 +249,9 @@ function selectCategory(
 	const totalRecords = Object.values(counts).reduce((a, b) => a + b, 0);
 	if (totalRecords < MIN_RECORDS_FOR_ANALYSIS) {
 		return {
-			categoryId: ALL_CATEGORY_IDS[Math.floor(rand() * ALL_CATEGORY_IDS.length)] ?? asCategoryId(1),
+			categoryId:
+				ALL_CATEGORY_IDS[Math.floor(rand() * ALL_CATEGORY_IDS.length)] ??
+				asCategoryId(CATEGORY_CODE_TO_ID.undou),
 			mode: 'explore',
 		};
 	}
@@ -495,7 +499,7 @@ function weekEndOf(weekStart: string): string {
 
 /** 前週の自動生成 child_challenge を computeProposal の prev 入力 (ChallengePrev 形) に写像する。 */
 function toProposalPrev(row: ChildChallenge): ChallengePrev {
-	let categoryId = asCategoryId(1);
+	let categoryId = asCategoryId(CATEGORY_CODE_TO_ID.undou);
 	let genMissStreak = 0;
 	try {
 		// 旧行の targetConfig は number categoryId (legacy)。asCategoryId で正規化する。
@@ -503,7 +507,10 @@ function toProposalPrev(row: ChildChallenge): ChallengePrev {
 			categoryId?: number | string;
 			genMissStreak?: number;
 		};
-		categoryId = cfg.categoryId != null ? asCategoryId(cfg.categoryId) : asCategoryId(1);
+		categoryId =
+			cfg.categoryId != null
+				? asCategoryId(cfg.categoryId)
+				: asCategoryId(CATEGORY_CODE_TO_ID.undou);
 		genMissStreak = cfg.genMissStreak ?? 0;
 	} catch {
 		// 破損 JSON は既定値で続行

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -1,8 +1,15 @@
 import type { ActivityId, CategoryId, ChildId } from '$lib/domain/ids';
 import { asCategoryId } from '$lib/domain/ids';
+
 // src/lib/server/services/export-service.ts
 // 家族データエクスポートサービス（Phase 1: エクスポートのみ）
 
+import {
+	CATEGORIES,
+	CATEGORY_CODES,
+	type CategoryCode,
+	toCategoryCode,
+} from '$lib/domain/categories';
 import {
 	EXPORT_FORMAT,
 	EXPORT_VERSION,
@@ -37,7 +44,6 @@ import {
 	type ExportTitle,
 	type ExportTransactionData,
 } from '$lib/domain/export-format';
-import { CATEGORY_CODES } from '$lib/domain/validation/activity';
 import { findActivities, findActivityLogs } from '$lib/server/db/activity-repo';
 import {
 	findLogsByChild,
@@ -57,28 +63,30 @@ import { findRecentStatusHistory, findStatuses } from '$lib/server/db/status-rep
 import { logger } from '$lib/server/logger';
 import { tenantPrefix } from '$lib/server/storage-keys';
 
-// カテゴリID → コード マッピング（5件固定）
-const CATEGORY_ID_TO_CODE: Record<string, string> = {
-	1: CATEGORY_CODES[0], // undou
-	2: CATEGORY_CODES[1], // benkyou
-	3: CATEGORY_CODES[2], // seikatsu
-	4: CATEGORY_CODES[3], // kouryuu
-	5: CATEGORY_CODES[4], // souzou
+// エクスポートファイルに埋める hex color は表示層の関心事 (歴史的にカテゴリ SSOT の master
+// palette と別値で出力されてきた) のため、SSOT ($lib/domain/categories.ts) に統合せず
+// 本 service ローカルに留めて挙動不変を維持する (#3607)。
+const EXPORT_CATEGORY_COLORS: Record<CategoryCode, string> = {
+	undou: '#FF6B6B',
+	benkyou: '#4ECDC4',
+	seikatsu: '#45B7D1',
+	kouryuu: '#96CEB4',
+	souzou: '#DDA0DD',
 };
 
-// カテゴリID → 情報マッピング
-const CATEGORY_INFO: ExportCategory[] = [
-	{ id: asCategoryId(1), code: 'undou', name: 'うんどう', icon: '🏃', color: '#FF6B6B' },
-	{ id: asCategoryId(2), code: 'benkyou', name: 'べんきょう', icon: '📚', color: '#4ECDC4' },
-	{ id: asCategoryId(3), code: 'seikatsu', name: 'せいかつ', icon: '🏠', color: '#45B7D1' },
-	{ id: asCategoryId(4), code: 'kouryuu', name: 'こうりゅう', icon: '🤝', color: '#96CEB4' },
-	{ id: asCategoryId(5), code: 'souzou', name: 'そうぞう', icon: '🎨', color: '#DDA0DD' },
-];
+// カテゴリID → 情報マッピング (#3607: id/code/name/icon は SSOT 派生)
+const CATEGORY_INFO: ExportCategory[] = CATEGORY_CODES.map((code) => ({
+	id: asCategoryId(CATEGORIES[code].legacyNumericId),
+	code,
+	name: CATEGORIES[code].name,
+	icon: CATEGORIES[code].icon,
+	color: EXPORT_CATEGORY_COLORS[code],
+}));
 
 const MAX_EXPORT_ROWS = 999999;
 
 function getCategoryCode(categoryId: CategoryId): string {
-	return CATEGORY_ID_TO_CODE[categoryId] ?? 'unknown';
+	return toCategoryCode(categoryId) ?? 'unknown';
 }
 
 /**

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -1,16 +1,14 @@
 import type { ActivityId, CategoryId, ChildId } from '$lib/domain/ids';
 import { asCategoryId } from '$lib/domain/ids';
+
 // src/lib/server/services/import-service.ts
 // 家族データインポートサービス（Phase 2 / #1254）
 
+import { toLegacyCategoryId } from '$lib/domain/categories';
 import { EXPORT_FORMAT, type ExportData, isExportableSettingKey } from '$lib/domain/export-format';
 import { MIGRATABLE_VERSIONS, migrateExportData } from '$lib/domain/export-migrations';
 import { IMPORT_LABELS, type ImportSkipReason } from '$lib/domain/labels';
-import {
-	CATEGORY_CODES,
-	sanitizeActivityNameField,
-	sanitizeDailyLimit,
-} from '$lib/domain/validation/activity';
+import { sanitizeActivityNameField, sanitizeDailyLimit } from '$lib/domain/validation/activity';
 import {
 	findActivities,
 	findActivityLogs,
@@ -39,10 +37,10 @@ import { logger } from '$lib/server/logger';
 import { fileExists, saveFile } from '$lib/server/storage';
 import { storageKeyToPublicUrl, tenantPrefix } from '$lib/server/storage-keys';
 
-// カテゴリコード → ID
-const CATEGORY_CODE_TO_ID: Record<string, CategoryId> = {};
-for (const [i, code] of CATEGORY_CODES.entries()) {
-	CATEGORY_CODE_TO_ID[code] = asCategoryId(i + 1);
+/** categoryCode (未検証文字列) → branded CategoryId (#3607: SSOT 派生、旧 index-based map を撤去) */
+function categoryIdFromCode(code: string): CategoryId | undefined {
+	const legacyId = toLegacyCategoryId(code);
+	return legacyId === undefined ? undefined : asCategoryId(legacyId);
 }
 
 /**
@@ -984,7 +982,7 @@ async function importChildActivitiesData(
 			result.warnings.push(`活動「${a.name}」スキップ: childRef「${a.childRef}」が解決できません`);
 			continue;
 		}
-		const categoryId = CATEGORY_CODE_TO_ID[a.categoryCode];
+		const categoryId = categoryIdFromCode(a.categoryCode);
 		if (!categoryId) {
 			result.warnings.push(`活動「${a.name}」のカテゴリ「${a.categoryCode}」が不明のためスキップ`);
 			continue;
@@ -1088,7 +1086,7 @@ async function importStatusesData(
 ): Promise<void> {
 	for (const status of data.data.statuses) {
 		const childId = childIdMap.get(status.childRef);
-		const categoryId = CATEGORY_CODE_TO_ID[status.categoryCode];
+		const categoryId = categoryIdFromCode(status.categoryCode);
 		if (!childId || !categoryId) continue;
 		try {
 			await upsertStatus(
@@ -1524,7 +1522,7 @@ async function importStatusHistoryData(
 ): Promise<void> {
 	for (const sh of data.data.statusHistory) {
 		const childId = childIdMap.get(sh.childRef);
-		const categoryId = CATEGORY_CODE_TO_ID[sh.categoryCode];
+		const categoryId = categoryIdFromCode(sh.categoryCode);
 		if (!childId || !categoryId) continue;
 
 		try {

--- a/src/lib/server/services/questionnaire-service.ts
+++ b/src/lib/server/services/questionnaire-service.ts
@@ -1,3 +1,4 @@
+import type { CategoryCode } from '$lib/domain/categories';
 import type { ChildId } from '$lib/domain/ids';
 import { logger } from '$lib/server/logger';
 import { addTemplateItem, createTemplate } from '$lib/server/services/checklist-service';
@@ -36,7 +37,9 @@ interface ChecklistPreset {
  * 旧キー (morning/homework/exercise/picky/balanced) は後方互換のため保持し、過去にアンケート回答を
  * 保存済みのテナントが再度クエリしても壊れないようにする。新規 setup フローからは投稿されない。
  */
-const CHALLENGE_CATEGORY_WEIGHTS: Record<string, string[]> = {
+// #3607: 値は CategoryCode 型で SSOT に束縛 (rename / typo をコンパイル時検出)。
+// 配列順は既存挙動維持のため据置 (SSOT 定義順とは独立の重み付け順)。
+const CHALLENGE_CATEGORY_WEIGHTS: Record<string, readonly CategoryCode[]> = {
 	// 新 3 軸（#1592）
 	'homework-daily': ['benkyou'],
 	chores: ['seikatsu'],
@@ -73,8 +76,8 @@ const CHALLENGE_CHECKLIST_MAP: Record<string, string[]> = {
 /**
  * アンケート回答からおすすめカテゴリコードを算出
  */
-export function getRecommendedCategories(challenges: string[]): string[] {
-	const categorySet = new Set<string>();
+export function getRecommendedCategories(challenges: string[]): CategoryCode[] {
+	const categorySet = new Set<CategoryCode>();
 	for (const challenge of challenges) {
 		const categories = CHALLENGE_CATEGORY_WEIGHTS[challenge];
 		if (categories) {
@@ -82,6 +85,7 @@ export function getRecommendedCategories(challenges: string[]): string[] {
 		}
 	}
 	if (categorySet.size === 0) {
+		// #3607: 全カテゴリ fallback。配列順は既存挙動維持のため据置 (SSOT 定義順と souzou/kouryuu が逆)
 		return ['undou', 'benkyou', 'seikatsu', 'souzou', 'kouryuu'];
 	}
 	return [...categorySet];

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { deserialize } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
+import { CATEGORY_CODE_TO_ID } from '$lib/domain/categories';
 import { getActionErrorDisplay } from '$lib/domain/errors';
 import { splitIcon } from '$lib/domain/icon-utils';
 import { asCategoryId, asChildId, type CategoryId, type ChildId } from '$lib/domain/ids';
@@ -138,7 +139,7 @@ const childOptions = $derived<ChildOption[]>(
 
 // AI プレフィル
 let prefillName = $state('');
-let prefillCategoryId = $state<CategoryId>(asCategoryId(1));
+let prefillCategoryId = $state<CategoryId>(asCategoryId(CATEGORY_CODE_TO_ID.undou));
 let prefillMainIcon = $state('🤸');
 let prefillSubIcon = $state('');
 let prefillPoints = $state(5);

--- a/src/routes/api/v1/activities/export/+server.ts
+++ b/src/routes/api/v1/activities/export/+server.ts
@@ -9,17 +9,12 @@
 // v1 export 出力自体は本 PR で停止し、新規出力は v2 envelope のみ。
 
 import { json } from '@sveltejs/kit';
-import { CATEGORY_CODES } from '$lib/domain/validation/activity';
+import { toCategoryCode } from '$lib/domain/categories';
 import { dispatchExportToJson } from '$lib/marketplace/export-dispatcher';
 import type { ActivityPackPayload } from '$lib/marketplace/schemas/activity-pack-schema';
 import { requireRole } from '$lib/server/auth/factory';
 import { getActivities } from '$lib/server/services/activity-service';
 import type { RequestHandler } from './$types';
-
-const CATEGORY_ID_TO_CODE: Record<string, string> = {};
-for (const [i, code] of CATEGORY_CODES.entries()) {
-	CATEGORY_ID_TO_CODE[String(i + 1)] = code;
-}
 
 export const GET: RequestHandler = async ({ locals }) => {
 	// #3246: export は import と同じ owner/parent gate に揃える (child role 到達不可)。
@@ -39,8 +34,8 @@ export const GET: RequestHandler = async ({ locals }) => {
 	const payload: ActivityPackPayload = {
 		activities: activities.map((a) => ({
 			name: a.name,
-			categoryCode: (CATEGORY_ID_TO_CODE[a.categoryId] ??
-				'seikatsu') as ActivityPackPayload['activities'][number]['categoryCode'],
+			// #3607: id→code は SSOT 派生 helper で解決 (未知 id は従来どおり seikatsu に fallback)
+			categoryCode: toCategoryCode(a.categoryId) ?? 'seikatsu',
 			icon: a.icon && a.icon.length > 0 ? a.icon : '📝',
 			basePoints: a.basePoints,
 			ageMin: null,

--- a/tests/unit/domain/categories.test.ts
+++ b/tests/unit/domain/categories.test.ts
@@ -1,0 +1,109 @@
+// tests/unit/domain/categories.test.ts
+// カテゴリ SSOT ($lib/domain/categories.ts) の網羅性・整合性検証 (#3607 AC4)。
+//
+// 目的: 「カテゴリを 1 件追加した場合に全消費側が compile error になる」ことを型レベルで
+// 担保する。CategoryCode / CategoryNumericId は SSOT オブジェクトから派生する union のため、
+// SSOT に 6 番目のカテゴリを追記すると本 file の expectTypeOf / satisfies が即 fail し、
+// 消費側 (Record<CategoryCode, ...> / picklist / literal union) の追随修正を強制する。
+
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+	CATEGORIES,
+	CATEGORY_CODE_TO_ID,
+	CATEGORY_CODES,
+	CATEGORY_ID_TO_CODE,
+	CATEGORY_NUMERIC_IDS,
+	type CategoryCode,
+	type CategoryName,
+	type CategoryNumericId,
+	toCategoryCode,
+	toLegacyCategoryId,
+} from '$lib/domain/categories';
+
+describe('categories SSOT (#3607)', () => {
+	describe('型レベル網羅性 (AC4)', () => {
+		it('CategoryCode union が SSOT キーと一致する (カテゴリ追加時はここが fail し消費側追随を強制)', () => {
+			expectTypeOf<CategoryCode>().toEqualTypeOf<
+				'undou' | 'benkyou' | 'seikatsu' | 'kouryuu' | 'souzou'
+			>();
+		});
+
+		it('CategoryNumericId union が 1-5 と一致する', () => {
+			expectTypeOf<CategoryNumericId>().toEqualTypeOf<1 | 2 | 3 | 4 | 5>();
+		});
+
+		it('CategoryName union が日本語表示名と一致する', () => {
+			expectTypeOf<CategoryName>().toEqualTypeOf<
+				'うんどう' | 'べんきょう' | 'せいかつ' | 'こうりゅう' | 'そうぞう'
+			>();
+		});
+
+		it('派生マップは union 上で total (Record<CategoryNumericId, CategoryCode> / 逆向き)', () => {
+			expectTypeOf(CATEGORY_ID_TO_CODE).toEqualTypeOf<Record<CategoryNumericId, CategoryCode>>();
+			expectTypeOf(CATEGORY_CODE_TO_ID).toEqualTypeOf<Record<CategoryCode, CategoryNumericId>>();
+		});
+
+		it('消費側パターンの網羅性デモ: Record<CategoryCode, T> はカテゴリ追加で compile error になる', () => {
+			// battle-types.ts CATEGORY_TO_STAT / activity-types.ts CATEGORY_INFO 等と同型。
+			// SSOT にカテゴリを追加すると本 satisfies が missing key で即 fail する。
+			const perCategory = {
+				undou: 1,
+				benkyou: 2,
+				seikatsu: 3,
+				kouryuu: 4,
+				souzou: 5,
+			} satisfies Record<CategoryCode, number>;
+			expect(Object.keys(perCategory)).toHaveLength(CATEGORY_CODES.length);
+		});
+	});
+
+	describe('runtime 整合性', () => {
+		it('CATEGORY_CODES / CATEGORY_NUMERIC_IDS は SSOT 定義順 (legacyNumericId 昇順) に並ぶ', () => {
+			expect(CATEGORY_CODES).toEqual(['undou', 'benkyou', 'seikatsu', 'kouryuu', 'souzou']);
+			expect(CATEGORY_NUMERIC_IDS).toEqual([1, 2, 3, 4, 5]);
+		});
+
+		it('legacyNumericId は重複なし (id↔code 全単射)', () => {
+			const ids = CATEGORY_CODES.map((code) => CATEGORIES[code].legacyNumericId);
+			expect(new Set(ids).size).toBe(CATEGORY_CODES.length);
+		});
+
+		it('CATEGORY_ID_TO_CODE と CATEGORY_CODE_TO_ID は互いに逆写像', () => {
+			for (const code of CATEGORY_CODES) {
+				expect(CATEGORY_ID_TO_CODE[CATEGORY_CODE_TO_ID[code]]).toBe(code);
+			}
+			for (const id of CATEGORY_NUMERIC_IDS) {
+				expect(CATEGORY_CODE_TO_ID[CATEGORY_ID_TO_CODE[id]]).toBe(id);
+			}
+		});
+
+		it('表示メタ (name / icon) が従来値を維持する (behavior-preserving、AC6)', () => {
+			expect(CATEGORIES.undou).toMatchObject({ name: 'うんどう', icon: '🏃' });
+			expect(CATEGORIES.benkyou).toMatchObject({ name: 'べんきょう', icon: '📚' });
+			expect(CATEGORIES.seikatsu).toMatchObject({ name: 'せいかつ', icon: '🏠' });
+			expect(CATEGORIES.kouryuu).toMatchObject({ name: 'こうりゅう', icon: '🤝' });
+			expect(CATEGORIES.souzou).toMatchObject({ name: 'そうぞう', icon: '🎨' });
+		});
+	});
+
+	describe('境界 helper (未検証入力)', () => {
+		it('toCategoryCode: 数値 / branded 文字列 id の両方を受ける', () => {
+			expect(toCategoryCode(1)).toBe('undou');
+			expect(toCategoryCode('3')).toBe('seikatsu');
+			expect(toCategoryCode(5)).toBe('souzou');
+		});
+
+		it('toCategoryCode: 未知 id は undefined (silent fallback しない)', () => {
+			expect(toCategoryCode(6)).toBeUndefined();
+			expect(toCategoryCode(0)).toBeUndefined();
+			expect(toCategoryCode('unknown')).toBeUndefined();
+		});
+
+		it('toLegacyCategoryId: 既知 code は数値 id、未知 code は undefined', () => {
+			expect(toLegacyCategoryId('undou')).toBe(1);
+			expect(toLegacyCategoryId('souzou')).toBe(5);
+			expect(toLegacyCategoryId('nonexistent')).toBeUndefined();
+			expect(toLegacyCategoryId('')).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体(カテゴリ拡張時の silent 不具合防止 = 全ペルソナの信頼性基盤)

**解決する課題**: カテゴリの id↔code↔表示メタの対応知識が domain SSOT なしに 20 file へ複製されており(magic number picklist / ローカル map ×2 / index-based 導出 ×4 / `asCategoryId(N)` fallback 群)、カテゴリを 6 番に拡張するとコンパイラの助けゼロで全箇所手修正 + `?? \`category_${id}\`` fallback が修正漏れを silent 化する構造だった(PO 指摘 2026-07-08)。

**期待される効果**: カテゴリ追加は SSOT 1 エントリ追記で全消費側にコンパイル時伝播する。**実証実験: SSOT に 6 番目カテゴリを一時追加すると 8 compile errors / 5 files で fail**(網羅性の機械強制が実際に働くことを確認済)。

## 関連 Issue

closes #3607

- 関連: #3606(棚卸し中に本問題を検出した経緯)/ ADR-0045(terms.ts 2 層)/ #2899(CONCEPT_ICONS)— 同型の確立パターンへの合流

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | categories.ts 新設 + CATEGORY_CODES 移設 re-export(breaking import なし) | `src/lib/domain/categories.ts` + `validation/activity.ts` の re-export + svelte-check 0 errors | PASS |
| AC2 | ローカル複製を SSOT 派生参照に置換 + magic map 削除 | 置換 20 file(commit body に全列挙)+ `grep -rn "CATEGORY_ID_TO_CODE" src/` でローカル複製 0 件 | PASS(create-tables の SQL seed は SSOT 生成が従来リテラルと byte 一致することを確認) |
| AC3 | `?? \`category_${id}\`` silent fallback の撤去 | `challenge-set-import-service.ts` を明示 throw 化 + `grep -rn 'category_\${' src/` 0 件 | PASS(schema 検証済 payload では到達しない防御線) |
| AC4 | カテゴリ 1 件追加で全消費側 compile error になる型担保 | `tests/unit/domain/categories.test.ts`(12 case)+ 実証実験(一時追加 → svelte-check 8 ERRORS / 5 files → revert で 0) | PASS |
| AC5 | marketplace-item.ts の inline literal union 置換 | `marketplace-item.ts:146` → `CategoryNumericId` | PASS |
| AC6 | 挙動不変 + 回帰 green | unit 5,100+ green(domain/marketplace/services 3,540 + server 416 + db 他 1,140)/ svelte-check 0 / biome clean / plan-literals・hardcoded-strings gate PASS | PASS |

## 変更タイプ

- [x] refactor: リファクタリング

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ドメインモデル (`$lib/domain/`) ※ categories.ts 新設 + 派生参照化
- [x] サービス層 (`$lib/server/services/`) ※ mapping 知識の SSOT 参照化(挙動不変)
- [x] DB スキーマ (`$lib/server/db/`) ※ create-tables の seed SQL を SSOT から生成(出力 byte 一致)

**影響を受ける画面・機能**: なし(behavior-preserving。表示・API・DB 出力すべて不変)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**(#1775 / ADR-0030)
- [x] 追加・変更したテストの概要: `tests/unit/domain/categories.test.ts`(SSOT 派生の整合 12 case + 網羅性型テスト)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A(dynamodb/ 不変更)
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし(domain 層 refactor、挙動・視覚差分ゼロ。export-service の歴史的 hex 2 値も挙動不変を優先しローカル維持)**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: SSOT は依存ゼロの pure module(tsx 直実行の create-tables からも参照可能な制約を明文化)
- [x] **DRY**: mapping 知識の複製 0 件を grep で機械確認
- [x] **YAGNI**: 境界 helper は実消費側が必要とする 2 関数のみ
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A(コンパイル時解決、runtime コスト同等)

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] E2E / ユニットシード + チュートリアルを同期(create-tables / seed / demo-data の SSOT 参照化は出力不変を byte 一致で確認)
- [x] N/A — labels / LP / ナビは変更なし(カテゴリ日本語名の domain SSOT は従来から activity.ts 側にあり、labels.ts のページガイド文言は compound 層で責務が別 = 二重定義なしを確認済)

**横展開(class 対処)**: 「enum 的ドメイン知識の SSOT 不在」class の 3 例目を解消(1 例目 terms.ts / 2 例目 CONCEPT_ICONS)。同 class の残存は grep で index-based 導出 0 件を確認

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**(全消費側の出力 byte/値レベルで不変)

**レビュー依頼事項・QA**:
- export-service の hex 2 値(seikatsu/kouryuu)が master palette とドリフトしている歴史的事実を発見しました。統合すると export 画像の視覚差分が出るため本 PR では挙動不変を優先しローカル維持 + コメント化しています(統合の要否は別判断)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み(不要な差分・デバッグコードなし)
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
