### PR TITLE
feat: #3541 Phase Z — recordActivity の DATA_SOURCE=dsql dispatch 結線 + fitness#11 アラート結線

### DIFF
--- a/src/lib/server/services/activity-log-service.ts
+++ b/src/lib/server/services/activity-log-service.ts
@@ -1,9 +1,7 @@
 import type { ActivityId, CategoryId, ChildId } from '$lib/domain/ids';
 import {
 	CANCEL_WINDOW_MS,
-	calcMasteryBonus,
 	calcMasteryLevel,
-	calcStreakBonus,
 	getActivityDisplayName,
 	getCategoryById,
 	MASTERY_MILESTONE_LEVELS,
@@ -16,25 +14,24 @@ import {
 } from '$lib/server/db/activity-mastery-repo';
 import {
 	countActiveActivityLogs,
-	countTodayActiveRecords,
 	findActivityById,
-	findActivityByIdForChild,
 	findActivityLogById,
-	findChildById,
-	findStreakLogs,
 	getTodayActivityCountsByChild,
 	insertActivityLog,
 	insertPointLedger,
 	markActivityLogCancelled,
 } from '$lib/server/db/activity-repo';
+// EPIC #3424 Phase Z (#3541): DATA_SOURCE=dsql は core 単一 txn + optional 隔離経路へ dispatch (§8)
+import { isDsqlBackend } from '$lib/server/db/backend';
 import {
 	type ActivityLogEntry,
 	type ActivityLogSummary,
 	aggregateActivityLogsByCategory,
 } from '$lib/server/services/activity-log-aggregation';
+import { recordActivityDsql } from '$lib/server/services/activity-record-dsql';
+// 書込前計算 (検証 / streak / mastery / bonus-hook) は sqlite / dsql 両経路の共有 SSOT (#3541)
+import { prepareActivityRecord } from '$lib/server/services/activity-record-preparation';
 import { trackActivationFirstActivityCompleted } from '$lib/server/services/analytics-service';
-// #2138 MP-3: bonus-hook-service - マーケットプレイス取込済 bonus preset 6 件評価
-import { evaluateBonusHooks } from '$lib/server/services/bonus-hook-service';
 import { type ComboResult, checkAndGrantCombo } from '$lib/server/services/combo-service';
 import { checkMissionCompletion } from '$lib/server/services/daily-mission-service';
 import { type LevelUpInfo, updateStatus } from '$lib/server/services/status-service';
@@ -116,91 +113,31 @@ export async function recordActivity(
 	| { error: 'DAILY_LIMIT_REACHED' }
 	| { error: 'NOT_FOUND'; target: string }
 > {
-	const today = todayDate();
-
-	// Verify child exists
-	const child = await findChildById(childId, tenantId);
-	if (!child) return { error: 'NOT_FOUND', target: 'child' };
-
-	// Verify activity exists AND belongs to this child (CWE-598 / ADR-0055 §3.1 cross-child guard、#2520)。
-	// child A の context で child B の child_activities.id を渡す越境を構造的に防ぐ。
-	// tenant スコープのみの `findActivityById` ではなく id+child+tenant の 3 軸版を使う。
-	const activity = await findActivityByIdForChild(activityId, childId, tenantId);
-	if (!activity) return { error: 'NOT_FOUND', target: 'activity' };
-
-	// Count today's active records for this child+activity
-	const todayCount = await countTodayActiveRecords(childId, activityId, today, tenantId);
-
-	// Check daily limit: null=1回, 0=無制限, N=N回
-	const effectiveLimit = activity.dailyLimit ?? 1;
-	if (effectiveLimit !== 0 && todayCount >= effectiveLimit) {
-		return effectiveLimit === 1
-			? { error: 'ALREADY_RECORDED' as const }
-			: { error: 'DAILY_LIMIT_REACHED' as const };
+	// EPIC #3424 Phase Z (#3541): DSQL backend は core 単一 txn + optional 隔離の専用経路。
+	// sqlite / dynamo / demo は従来経路 (以下) を無変更で通る (現行挙動の凍結)。
+	if (isDsqlBackend()) {
+		return recordActivityDsql(childId, activityId, tenantId);
 	}
 
-	// Streak: only award on first record of the day
-	const isFirstToday = todayCount === 0;
-	const streakDays = isFirstToday ? await calculateStreak(childId, activityId, today, tenantId) : 1;
-	const defaultStreakBonus = isFirstToday ? calcStreakBonus(streakDays) : 0;
-
-	// 習熟度ボーナス
-	const mastery = await findMastery(childId, activityId, tenantId);
-	const currentLevel = mastery?.level ?? 1;
-	const masteryBonus = calcMasteryBonus(currentLevel);
-
-	// #2138 MP-3: bonus-hook-service による 6 件マーケットプレイス bonus 評価
-	// (取込済 preset が無ければ totalBonus=0 / pointsMultiplier=1.0 で regression なし)
-	// #2458-A1 (ADR-0055): per-child instance API (`getChildActivities`) に migrate。
-	// 旧 `findActivities(tenantId)` は tenant aggregate (兄弟全 child の合算) のため、
-	// distinct カテゴリ計算が膨らみすぎる UX 退行があった。child scope に絞る。
-	let todayDistinctCategoryCount = 0;
-	try {
-		const todayCounts = await getTodayActivityCountsByChild(childId, today, tenantId);
-		const todayActivityIds = new Set(todayCounts.map((c) => c.activityId));
-		// 今回記録する activity も含めて distinct カテゴリを数える
-		todayActivityIds.add(activityId);
-		const { getChildActivities } = await import('$lib/server/services/activity-service');
-		const childActivities = await getChildActivities(childId, tenantId, {});
-		const todayCategoryIds = new Set<CategoryId>();
-		for (const a of childActivities) {
-			if (todayActivityIds.has(a.id)) {
-				todayCategoryIds.add(a.categoryId);
-			}
-		}
-		todayDistinctCategoryCount = todayCategoryIds.size;
-	} catch {
-		// distinct カテゴリ計算失敗は bonus hook を no-op で続行
-	}
-
-	let hookResult: Awaited<ReturnType<typeof evaluateBonusHooks>> = {
-		totalBonus: 0,
-		pointsMultiplier: 1.0,
-		hits: [],
-	};
-	try {
-		hookResult = await evaluateBonusHooks(
-			{
-				consecutiveDays: streakDays,
-				recordedAt: new Date(),
-				todayDistinctCategoryCount,
-				isFirstToday,
-				categoryId: activity.categoryId,
-			},
-			tenantId,
-		);
-	} catch {
-		// bonus-hook 失敗は活動記録フローを止めない (regression なし)
-	}
-
-	// 合計 streakBonus = default + bonus-hook
-	const streakBonus = defaultStreakBonus + hookResult.totalBonus;
-	const mainQuestMultiplier = activity.isMainQuest ? 2 : 1;
-	const weekendMultiplier = hookResult.pointsMultiplier; // weekend-special で 2.0 等
-	const effectiveBasePoints = Math.floor(
-		activity.basePoints * mainQuestMultiplier * weekendMultiplier,
-	);
-	const totalPoints = effectiveBasePoints + streakBonus + masteryBonus;
+	// 書込前計算 (検証 / dailyLimit / streak / mastery / bonus-hook / 倍率) は
+	// activity-record-preparation.ts に抽出済 (dsql 経路と共有、#3541。挙動・順序は不変)
+	const prep = await prepareActivityRecord(childId, activityId, tenantId);
+	if ('error' in prep) return prep;
+	const {
+		child,
+		activity,
+		today,
+		isFirstToday,
+		streakDays,
+		streakBonus,
+		masteryBonus,
+		currentMasteryLevel: currentLevel,
+		newMasteryCount: newCount,
+		newMasteryLevel: newLevel,
+		effectiveBasePoints,
+		totalPoints,
+		ledgerDescription,
+	} = prep;
 
 	// Insert activity log
 	const now = new Date().toISOString();
@@ -225,23 +162,20 @@ export async function recordActivity(
 		trackActivationFirstActivityCompleted(tenantId, childId, activityId);
 	}
 
-	// 習熟度更新（count+1 → レベル再計算）
-	const newCount = (mastery?.totalCount ?? 0) + 1;
-	const newLevel = calcMasteryLevel(newCount);
+	// 習熟度更新（count+1 → レベル再計算。計算は prepareActivityRecord 済、#3541）
 	const masteryLeveledUp =
 		newLevel > currentLevel
 			? { oldLevel: currentLevel, newLevel, isMilestone: MASTERY_MILESTONE_LEVELS.has(newLevel) }
 			: null;
 	await upsertMastery(childId, activityId, newCount, newLevel, tenantId);
 
-	// Insert point ledger entry
-	const mainQuestLabel = activity.isMainQuest ? ' (メインクエスト\u00d72)' : '';
+	// Insert point ledger entry (description は prepareActivityRecord が両経路共通で組み立て済)
 	await insertPointLedger(
 		{
 			childId,
 			amount: totalPoints,
 			type: 'activity',
-			description: `${activity.name}${mainQuestLabel}${streakBonus > 0 ? ` (${streakDays}日連続+${streakBonus})` : ''}${masteryBonus > 0 ? ` (習熟Lv.${newLevel}+${masteryBonus})` : ''}`,
+			description: ledgerDescription,
 			referenceId: log.id,
 		},
 		tenantId,
@@ -533,37 +467,4 @@ export async function hasAnyActivityRecords(childId: ChildId, tenantId: string):
 	return count > 0;
 }
 
-/** Calculate streak (consecutive days including today). */
-async function calculateStreak(
-	childId: ChildId,
-	activityId: ActivityId,
-	today: string,
-	tenantId: string,
-): Promise<number> {
-	// Get all recorded dates for this child+activity, ordered desc
-	const rows = await findStreakLogs(childId, activityId, tenantId);
-
-	if (rows.length === 0) return 1; // First time = day 1
-
-	// Check if yesterday is in the list, then day before, etc.
-	let streak = 1; // Today counts as day 1
-	let checkDate = prevDate(today);
-
-	for (const row of rows) {
-		if (row.recordedDate === checkDate) {
-			streak++;
-			checkDate = prevDate(checkDate);
-		} else if (row.recordedDate < checkDate) {
-			break; // Gap found
-		}
-	}
-
-	return streak;
-}
-
-/** Get previous date string (YYYY-MM-DD). */
-function prevDate(dateStr: string): string {
-	const d = new Date(`${dateStr}T00:00:00Z`);
-	d.setUTCDate(d.getUTCDate() - 1);
-	return d.toISOString().slice(0, 10);
-}
+// calculateStreak / prevDate は activity-record-preparation.ts へ移設 (#3541、sqlite/dsql 共有)。

--- a/src/lib/server/services/activity-record-dsql.ts
+++ b/src/lib/server/services/activity-record-dsql.ts
@@ -1,0 +1,327 @@
+// src/lib/server/services/activity-record-dsql.ts
+// EPIC #3424 / 実装 #3541 Phase Z (+ #3550 ①) / 設計 SSOT: dsql-data-model.md §8
+//
+// DATA_SOURCE=dsql の recordActivity 経路 (activity-log-service.ts から dispatch される):
+//
+//   1. 事前 guard + bonus 計算 = prepareActivityRecord (read-only、sqlite 経路と共有 SSOT)。
+//   2. core 5 行 (activity_logs / activity_mastery / point_ledger + total_point / statuses /
+//      status_history) を recordActivityCore の単一 txn で all-or-nothing 書込 (§8 最大の質的改善)。
+//      冪等性の正は core の txn 内 re-read (ALREADY_RECORDED / DAILY_LIMIT_REACHED は core 判定)。
+//   3. optional (combo / mission / challenge進捗 / focus / 証明書 / 通知 / special_reward /
+//      activation 計測) は core commit 後の独立 best-effort (SAVEPOINT 非対応 spike#4)。
+//      失敗は runOptionalWrite で隔離し、fitness#11 counter
+//      (optional-write-alert: logger.error + Discord) に emit する。core は rollback しない。
+//   4. RecordActivityResult は「確定値のみ描画」(§8 演出契約): core Result の確定値
+//      (logId / totalPoints / masteryLevel / totalXp / statusLevel) + optional 結果から組み立て、
+//      optional 失敗 field は null / [] で返す (sqlite 経路の try-catch swallow と同じ UI 契約)。
+//
+// fitness#7: 本 module に runInTransaction callsite は無い (txn 内 await は core / optional
+// プリミティブの内部のみ)。fitness#16: DB アクセスは repo facade / dsql プリミティブ経由。
+
+import type { ActivityId, ChildId } from '$lib/domain/ids';
+import {
+	CANCEL_WINDOW_MS,
+	calcMasteryLevel,
+	getActivityDisplayName,
+	getCategoryById,
+	MASTERY_MILESTONE_LEVELS,
+} from '$lib/domain/validation/activity';
+import { calcLevelFromXp } from '$lib/domain/validation/status';
+import { countActiveActivityLogs } from '$lib/server/db/activity-repo';
+import { getDsqlTransactionRunner } from '$lib/server/db/dsql/connection';
+import { runOptionalWrite } from '$lib/server/db/dsql/optional-write-guard';
+import { recordActivityCore } from '$lib/server/db/dsql/record-activity-core';
+import type { RecordActivityResult, XpGainInfo } from '$lib/server/services/activity-log-service';
+import {
+	type PreparedActivityRecord,
+	prepareActivityRecord,
+} from '$lib/server/services/activity-record-preparation';
+import { trackActivationFirstActivityCompleted } from '$lib/server/services/analytics-service';
+import { checkAndGrantCombo } from '$lib/server/services/combo-service';
+import { checkMissionCompletion } from '$lib/server/services/daily-mission-service';
+import { createOptionalWriteFailureHandler } from '$lib/server/services/optional-write-alert';
+import type { LevelUpInfo } from '$lib/server/services/status-service';
+
+/** status-service updateStatus の maxValue と同一値 (xpGain 契約、UI ゲージ上限)。 */
+const STATUS_MAX_VALUE = 100000;
+
+/**
+ * DATA_SOURCE=dsql の活動記録。error 契約 (ALREADY_RECORDED / DAILY_LIMIT_REACHED /
+ * NOT_FOUND) と RecordActivityResult shape は sqlite 経路と同一 (frontend 契約不変)。
+ */
+export async function recordActivityDsql(
+	childId: ChildId,
+	activityId: ActivityId,
+	tenantId: string,
+): Promise<
+	| RecordActivityResult
+	| { error: 'ALREADY_RECORDED' }
+	| { error: 'DAILY_LIMIT_REACHED' }
+	| { error: 'NOT_FOUND'; target: string }
+> {
+	// 1. 書込前計算 (sqlite 経路と共有。cheap guard: 明白な重複はここで弾く)
+	const prep = await prepareActivityRecord(childId, activityId, tenantId);
+	if ('error' in prep) return prep;
+
+	// 2. core 5 行の単一 txn (冪等性の正 = txn 内 re-read、§8)
+	const now = new Date().toISOString();
+	const core = await recordActivityCore(getDsqlTransactionRunner(), {
+		familyId: tenantId,
+		childId: String(childId),
+		activityId: String(activityId),
+		categoryId: String(prep.activity.categoryId),
+		basePoints: prep.effectiveBasePoints,
+		streakBonus: prep.streakBonus,
+		masteryBonus: prep.masteryBonus,
+		streakDays: prep.streakDays,
+		recordedDate: prep.today,
+		now,
+		dailyLimit: prep.activity.dailyLimit ?? null,
+		description: prep.ledgerDescription,
+		changeType: 'activity_record',
+		masteryLevelFor: calcMasteryLevel,
+		statusLevelFor: (totalXp) => calcLevelFromXp(totalXp).level,
+	});
+	if (!core.ok) return { error: core.reason };
+
+	// 3. 演出契約 (§8): levelUp / xpGain / masteryLeveledUp は core 確定値から組み立てる
+	const xpAfter = core.totalXp;
+	const xpBefore = xpAfter - core.totalPoints;
+	const beforeLevel = calcLevelFromXp(xpBefore);
+	const afterLevel = calcLevelFromXp(xpAfter);
+	const catDef = getCategoryById(prep.activity.categoryId);
+	const levelUp: LevelUpInfo | null =
+		afterLevel.level > beforeLevel.level
+			? {
+					oldLevel: beforeLevel.level,
+					oldTitle: beforeLevel.title,
+					newLevel: afterLevel.level,
+					newTitle: afterLevel.title,
+					categoryId: prep.activity.categoryId,
+					categoryName: catDef?.name ?? '',
+					spGranted: 0,
+				}
+			: null;
+	const xpGain: XpGainInfo = {
+		categoryId: prep.activity.categoryId,
+		categoryName: catDef?.name ?? '',
+		xpBefore,
+		xpAfter,
+		maxValue: STATUS_MAX_VALUE,
+		levelBefore: beforeLevel.level,
+		levelAfter: afterLevel.level,
+	};
+	const masteryLeveledUp =
+		core.masteryLevel > prep.currentMasteryLevel
+			? {
+					oldLevel: prep.currentMasteryLevel,
+					newLevel: core.masteryLevel,
+					isMilestone: MASTERY_MILESTONE_LEVELS.has(core.masteryLevel),
+				}
+			: null;
+
+	// 4. optional phase (core commit 後の独立 best-effort、失敗は fitness#11 counter へ)
+	const optional = await runOptionalPhase({
+		childId,
+		activityId,
+		tenantId,
+		prep,
+		totalPoints: core.totalPoints,
+		levelUp,
+		xpGain,
+	});
+
+	return {
+		id: core.logId,
+		childId,
+		activityId,
+		activityName: getActivityDisplayName(prep.activity, prep.child.age),
+		basePoints: prep.effectiveBasePoints,
+		streakDays: prep.streakDays,
+		streakBonus: prep.streakBonus,
+		masteryBonus: prep.masteryBonus,
+		masteryLevel: core.masteryLevel,
+		masteryLeveledUp,
+		totalPoints: core.totalPoints,
+		recordedAt: now,
+		cancelableUntil: new Date(Date.now() + CANCEL_WINDOW_MS).toISOString(),
+		// 実績システム廃止（#322）— 常に空配列
+		unlockedAchievements: [],
+		comboBonus: optional.comboBonus,
+		missionComplete: optional.missionComplete,
+		// #2295 (EPIC #2294 ①): シーズン/カレンダーイベント撤去済 — 型整合のため空配列
+		eventMissions: [],
+		calendarEvents: [],
+		siblingChallenges: optional.siblingChallenges,
+		focusBonus: optional.focusBonus,
+		levelUp,
+		xpGain,
+		// #1782: カスタム実績機能廃止 — 常に空配列
+		customUnlocked: [],
+		specialReward: optional.specialReward,
+	};
+}
+
+interface OptionalPhaseInput {
+	childId: ChildId;
+	activityId: ActivityId;
+	tenantId: string;
+	prep: PreparedActivityRecord;
+	totalPoints: number;
+	levelUp: LevelUpInfo | null;
+	xpGain: XpGainInfo;
+}
+
+interface OptionalPhaseResult {
+	comboBonus: RecordActivityResult['comboBonus'];
+	missionComplete: RecordActivityResult['missionComplete'];
+	siblingChallenges: RecordActivityResult['siblingChallenges'];
+	focusBonus: RecordActivityResult['focusBonus'];
+	specialReward: RecordActivityResult['specialReward'];
+}
+
+/**
+ * optional 書込群を sqlite 経路と同順で実行する。各項目は runOptionalWrite で隔離され、
+ * 失敗しても他項目・core 結果に波及しない (§8。欠落は fitness#11 counter に emit)。
+ */
+async function runOptionalPhase(input: OptionalPhaseInput): Promise<OptionalPhaseResult> {
+	const { childId, activityId, tenantId, prep, totalPoints, levelUp, xpGain } = input;
+	const onFailure = createOptionalWriteFailureHandler({ childId: String(childId), tenantId });
+	const catDef = getCategoryById(prep.activity.categoryId);
+
+	// #831: Activation Funnel Step 3 — テナント初の活動記録 (計測のみ、point 書込なし)
+	await runOptionalWrite(
+		'activation_track',
+		async () => {
+			const activeCount = await countActiveActivityLogs(childId, tenantId);
+			if (activeCount === 1) {
+				trackActivationFirstActivityCompleted(tenantId, childId, activityId);
+			}
+		},
+		onFailure,
+	);
+
+	// コンボボーナスチェック
+	const comboRaw = await runOptionalWrite(
+		'combo_bonus',
+		() => checkAndGrantCombo(childId, prep.today, tenantId),
+		onFailure,
+	);
+
+	// デイリーミッション判定
+	const missionRaw = await runOptionalWrite(
+		'mission_bonus',
+		() => checkMissionCompletion(childId, activityId, tenantId),
+		onFailure,
+	);
+
+	// per-child チャレンジ進捗チェック (#2458-B / #3213: child_challenges 一本化)
+	const siblingChallenges =
+		(await runOptionalWrite(
+			'challenge_progress',
+			async () => {
+				const { updateChildChallengeProgress } = await import(
+					'$lib/server/services/child-challenge-service'
+				);
+				const perChildResults = await updateChildChallengeProgress(
+					childId,
+					activityId,
+					prep.activity.categoryId,
+					tenantId,
+				);
+				// shape adapter: per-child completed → allSiblingsComplete 互換 (sqlite 経路と同一)
+				return perChildResults.map((r) => ({
+					challengeId: r.challengeId,
+					allSiblingsComplete: r.completed,
+					challengeTitle: r.challengeTitle,
+				}));
+			},
+			onFailure,
+		)) ?? [];
+
+	// フォーカスモードおすすめ3件達成ボーナスチェック
+	const focusBonus =
+		(await runOptionalWrite(
+			'focus_bonus',
+			async () => {
+				const { checkAndGrantFocusBonus, selectRecommendations } = await import(
+					'$lib/server/services/recommendation-service'
+				);
+				const { getChildActivities } = await import('$lib/server/services/activity-service');
+				const childActs = await getChildActivities(childId, tenantId, {
+					childAge: prep.child.age,
+				});
+				const recs = selectRecommendations(childActs, prep.today, 3);
+				return checkAndGrantFocusBonus(
+					childId,
+					recs.map((r) => r.activityId),
+					tenantId,
+				);
+			},
+			onFailure,
+		)) ?? null;
+
+	// プッシュ通知: 達成通知・レベルアップ通知
+	await runOptionalWrite(
+		'achievement_notification',
+		async () => {
+			const { sendAchievementNotification } = await import(
+				'$lib/server/services/notification-service'
+			);
+			await sendAchievementNotification(tenantId, {
+				childName: prep.child.nickname,
+				activityName: getActivityDisplayName(prep.activity, prep.child.age),
+				totalPoints,
+				levelUp,
+				unlockedAchievements: [],
+			});
+		},
+		onFailure,
+	);
+
+	// がんばり証明書: ストリーク・レベルアップ・カテゴリマスター自動発行
+	await runOptionalWrite(
+		'certificate',
+		async () => {
+			const {
+				checkAndIssueStreakCertificates,
+				checkAndIssueLevelCertificates,
+				issueCategoryMasterCertificate,
+			} = await import('$lib/server/services/certificate-service');
+			if (prep.isFirstToday && prep.streakDays >= 7) {
+				await checkAndIssueStreakCertificates(childId, prep.streakDays, tenantId);
+			}
+			if (levelUp) {
+				await checkAndIssueLevelCertificates(childId, levelUp.newLevel, tenantId);
+			}
+			if (xpGain.levelAfter >= 5 && xpGain.levelBefore < 5 && catDef) {
+				await issueCategoryMasterCertificate(childId, String(catDef.id), catDef.name, tenantId);
+			}
+		},
+		onFailure,
+	);
+
+	// 固定間隔特別報酬チェック（予告型: 毎N回記録でごほうび）
+	const specialRewardRaw = await runOptionalWrite(
+		'special_reward',
+		async () => {
+			const { checkAndGrantFixedIntervalReward } = await import(
+				'$lib/server/services/special-reward-service'
+			);
+			const reward = await checkAndGrantFixedIntervalReward(childId, tenantId);
+			return reward
+				? { id: reward.id, title: reward.title, points: reward.points, icon: reward.icon }
+				: null;
+		},
+		onFailure,
+	);
+
+	return {
+		comboBonus:
+			comboRaw && (comboRaw.totalNewBonus > 0 || comboRaw.hints.length > 0) ? comboRaw : null,
+		missionComplete: missionRaw?.missionCompleted ? missionRaw : null,
+		siblingChallenges,
+		focusBonus,
+		specialReward: specialRewardRaw ?? null,
+	};
+}

--- a/src/lib/server/services/activity-record-preparation.ts
+++ b/src/lib/server/services/activity-record-preparation.ts
@@ -1,0 +1,227 @@
+// src/lib/server/services/activity-record-preparation.ts
+// EPIC #3424 / 実装 #3541 Phase Z / 設計 SSOT: dsql-data-model.md §8
+//
+// recordActivity の「書込前 read-only 計算部」を sqlite / dsql 両経路で共有する SSOT。
+// 事前 guard (child/activity 存在・所有 CWE-598、dailyLimit 事前判定) と bonus 計算
+// (streak / mastery / bonus-hook / メインクエスト×週末倍率) をここに集約し、二重実装を禁止する。
+//
+// - sqlite 経路 (activity-log-service.ts): 本結果を使って従来どおり逐次書込 (挙動不変)。
+// - dsql 経路 (activity-record-dsql.ts): 本結果を RecordActivityCoreInput に写像し、
+//   core 5 行を単一 txn で書く (§8)。dailyLimit の正判定は core の txn 内 re-read が担い、
+//   ここでの事前判定は「明白な重複を txn 前に弾く」cheap guard に留まる。
+//
+// 本 module は read-only (書込 API を呼ばない)。書込順序・エラー優先順位
+// (NOT_FOUND child → NOT_FOUND activity → ALREADY_RECORDED / DAILY_LIMIT_REACHED) は
+// 旧 activity-log-service.ts のインライン実装から変更していない。
+
+import type { ActivityId, CategoryId, ChildId } from '$lib/domain/ids';
+import {
+	calcMasteryBonus,
+	calcMasteryLevel,
+	calcStreakBonus,
+	todayDate,
+} from '$lib/domain/validation/activity';
+import { findByChildAndActivity as findMastery } from '$lib/server/db/activity-mastery-repo';
+import {
+	countTodayActiveRecords,
+	findActivityByIdForChild,
+	findChildById,
+	findStreakLogs,
+	getTodayActivityCountsByChild,
+} from '$lib/server/db/activity-repo';
+// #2138 MP-3: bonus-hook-service - マーケットプレイス取込済 bonus preset 6 件評価
+import { evaluateBonusHooks } from '$lib/server/services/bonus-hook-service';
+
+/** findChildById の非 null 戻り値 (repo entity 型を再宣言しない)。 */
+export type ActivityRecordChild = NonNullable<Awaited<ReturnType<typeof findChildById>>>;
+/** findActivityByIdForChild の非 null 戻り値。 */
+export type ActivityRecordActivity = NonNullable<
+	Awaited<ReturnType<typeof findActivityByIdForChild>>
+>;
+
+/** 書込前計算の結果 (read-only)。sqlite / dsql 両経路がこの値から書込を行う。 */
+export interface PreparedActivityRecord {
+	child: ActivityRecordChild;
+	activity: ActivityRecordActivity;
+	/** 'YYYY-MM-DD' (JST)。 */
+	today: string;
+	todayCount: number;
+	isFirstToday: boolean;
+	streakDays: number;
+	/** default streak bonus + bonus-hook 合算。 */
+	streakBonus: number;
+	masteryBonus: number;
+	/** 記録前の習熟レベル (masteryLeveledUp 判定の基準)。 */
+	currentMasteryLevel: number;
+	/** 記録後の習熟 count (事前 read + 1。dsql 経路の正は core txn 内 re-read)。 */
+	newMasteryCount: number;
+	/** 記録後の習熟レベル (事前予測。dsql 経路の正は core txn 内 re-read)。 */
+	newMasteryLevel: number;
+	/** 倍率 (メインクエスト×2 / 週末) 適用後の基礎点。 */
+	effectiveBasePoints: number;
+	/** effectiveBasePoints + streakBonus + masteryBonus。 */
+	totalPoints: number;
+	/** point_ledger.description (両経路で同一書式)。 */
+	ledgerDescription: string;
+}
+
+export type PrepareActivityRecordError =
+	| { error: 'ALREADY_RECORDED' }
+	| { error: 'DAILY_LIMIT_REACHED' }
+	| { error: 'NOT_FOUND'; target: string };
+
+/**
+ * recordActivity の書込前計算 (検証 → streak → 習熟 → bonus-hook → 倍率 → 合計点)。
+ * 旧 activity-log-service.ts recordActivity 前半のインライン実装を無変更で抽出したもの。
+ */
+export async function prepareActivityRecord(
+	childId: ChildId,
+	activityId: ActivityId,
+	tenantId: string,
+): Promise<PreparedActivityRecord | PrepareActivityRecordError> {
+	const today = todayDate();
+
+	// Verify child exists
+	const child = await findChildById(childId, tenantId);
+	if (!child) return { error: 'NOT_FOUND', target: 'child' };
+
+	// Verify activity exists AND belongs to this child (CWE-598 / ADR-0055 §3.1 cross-child guard、#2520)。
+	// child A の context で child B の child_activities.id を渡す越境を構造的に防ぐ。
+	// tenant スコープのみの `findActivityById` ではなく id+child+tenant の 3 軸版を使う。
+	const activity = await findActivityByIdForChild(activityId, childId, tenantId);
+	if (!activity) return { error: 'NOT_FOUND', target: 'activity' };
+
+	// Count today's active records for this child+activity
+	const todayCount = await countTodayActiveRecords(childId, activityId, today, tenantId);
+
+	// Check daily limit: null=1回, 0=無制限, N=N回
+	const effectiveLimit = activity.dailyLimit ?? 1;
+	if (effectiveLimit !== 0 && todayCount >= effectiveLimit) {
+		return effectiveLimit === 1
+			? { error: 'ALREADY_RECORDED' as const }
+			: { error: 'DAILY_LIMIT_REACHED' as const };
+	}
+
+	// Streak: only award on first record of the day
+	const isFirstToday = todayCount === 0;
+	const streakDays = isFirstToday ? await calculateStreak(childId, activityId, today, tenantId) : 1;
+	const defaultStreakBonus = isFirstToday ? calcStreakBonus(streakDays) : 0;
+
+	// 習熟度ボーナス
+	const mastery = await findMastery(childId, activityId, tenantId);
+	const currentMasteryLevel = mastery?.level ?? 1;
+	const masteryBonus = calcMasteryBonus(currentMasteryLevel);
+
+	// #2138 MP-3: bonus-hook-service による 6 件マーケットプレイス bonus 評価
+	// (取込済 preset が無ければ totalBonus=0 / pointsMultiplier=1.0 で regression なし)
+	// #2458-A1 (ADR-0055): per-child instance API (`getChildActivities`) に migrate。
+	// 旧 `findActivities(tenantId)` は tenant aggregate (兄弟全 child の合算) のため、
+	// distinct カテゴリ計算が膨らみすぎる UX 退行があった。child scope に絞る。
+	let todayDistinctCategoryCount = 0;
+	try {
+		const todayCounts = await getTodayActivityCountsByChild(childId, today, tenantId);
+		const todayActivityIds = new Set(todayCounts.map((c) => c.activityId));
+		// 今回記録する activity も含めて distinct カテゴリを数える
+		todayActivityIds.add(activityId);
+		const { getChildActivities } = await import('$lib/server/services/activity-service');
+		const childActivities = await getChildActivities(childId, tenantId, {});
+		const todayCategoryIds = new Set<CategoryId>();
+		for (const a of childActivities) {
+			if (todayActivityIds.has(a.id)) {
+				todayCategoryIds.add(a.categoryId);
+			}
+		}
+		todayDistinctCategoryCount = todayCategoryIds.size;
+	} catch {
+		// distinct カテゴリ計算失敗は bonus hook を no-op で続行
+	}
+
+	let hookResult: Awaited<ReturnType<typeof evaluateBonusHooks>> = {
+		totalBonus: 0,
+		pointsMultiplier: 1.0,
+		hits: [],
+	};
+	try {
+		hookResult = await evaluateBonusHooks(
+			{
+				consecutiveDays: streakDays,
+				recordedAt: new Date(),
+				todayDistinctCategoryCount,
+				isFirstToday,
+				categoryId: activity.categoryId,
+			},
+			tenantId,
+		);
+	} catch {
+		// bonus-hook 失敗は活動記録フローを止めない (regression なし)
+	}
+
+	// 合計 streakBonus = default + bonus-hook
+	const streakBonus = defaultStreakBonus + hookResult.totalBonus;
+	const mainQuestMultiplier = activity.isMainQuest ? 2 : 1;
+	const weekendMultiplier = hookResult.pointsMultiplier; // weekend-special で 2.0 等
+	const effectiveBasePoints = Math.floor(
+		activity.basePoints * mainQuestMultiplier * weekendMultiplier,
+	);
+	const totalPoints = effectiveBasePoints + streakBonus + masteryBonus;
+
+	// 習熟度更新の事前計算（count+1 → レベル再計算）
+	const newMasteryCount = (mastery?.totalCount ?? 0) + 1;
+	const newMasteryLevel = calcMasteryLevel(newMasteryCount);
+
+	// point_ledger.description (両経路で同一書式)
+	const mainQuestLabel = activity.isMainQuest ? ' (メインクエスト×2)' : '';
+	const ledgerDescription = `${activity.name}${mainQuestLabel}${streakBonus > 0 ? ` (${streakDays}日連続+${streakBonus})` : ''}${masteryBonus > 0 ? ` (習熟Lv.${newMasteryLevel}+${masteryBonus})` : ''}`;
+
+	return {
+		child,
+		activity,
+		today,
+		todayCount,
+		isFirstToday,
+		streakDays,
+		streakBonus,
+		masteryBonus,
+		currentMasteryLevel,
+		newMasteryCount,
+		newMasteryLevel,
+		effectiveBasePoints,
+		totalPoints,
+		ledgerDescription,
+	};
+}
+
+/** Calculate streak (consecutive days including today). */
+async function calculateStreak(
+	childId: ChildId,
+	activityId: ActivityId,
+	today: string,
+	tenantId: string,
+): Promise<number> {
+	// Get all recorded dates for this child+activity, ordered desc
+	const rows = await findStreakLogs(childId, activityId, tenantId);
+
+	if (rows.length === 0) return 1; // First time = day 1
+
+	// Check if yesterday is in the list, then day before, etc.
+	let streak = 1; // Today counts as day 1
+	let checkDate = prevDate(today);
+
+	for (const row of rows) {
+		if (row.recordedDate === checkDate) {
+			streak++;
+			checkDate = prevDate(checkDate);
+		} else if (row.recordedDate < checkDate) {
+			break; // Gap found
+		}
+	}
+
+	return streak;
+}
+
+/** Get previous date string (YYYY-MM-DD). */
+function prevDate(dateStr: string): string {
+	const d = new Date(`${dateStr}T00:00:00Z`);
+	d.setUTCDate(d.getUTCDate() - 1);
+	return d.toISOString().slice(0, 10);
+}

--- a/src/lib/server/services/optional-write-alert.ts
+++ b/src/lib/server/services/optional-write-alert.ts
@@ -1,0 +1,59 @@
+// src/lib/server/services/optional-write-alert.ts
+// EPIC #3424 / 実装 #3550 ① / 設計 SSOT: dsql-data-model.md §8 / §13.1 fitness#11
+//
+// optional 書込 (combo / mission / challenge / certificate / special_reward / 通知) の
+// 欠落観測カウンタの service 層 bind。db 層 (optional-write-guard.ts) は analytics /
+// logger に依存しない (層分離) ため、onFailure の実体はここで結線する:
+//
+//   1. `logger.error` — structured context (kind / name / childId / tenantId / cause)。
+//      CloudWatch Logs Insights で `filter context.kind = "optional-write-failed"` query 可能。
+//   2. `sendDiscordAlert` — fire-and-forget (stripe/alert.ts と同 pattern)。alert 失敗は
+//      記録フローをブロックしない。throttle は discord-alert.ts 側が担う。
+//
+// fitness#14 (total_point 突合) は「行が書かれない欠落」を drift=0 で検出できないため、
+// 本カウンタが欠落率の唯一の可観測点になる (§13.1 fitness#11)。silent swallow 禁止。
+
+import type { OptionalWriteFailureHandler } from '$lib/server/db/dsql/optional-write-guard';
+import { sendDiscordAlert } from '$lib/server/discord-alert';
+import { logger } from '$lib/server/logger';
+
+export interface OptionalWriteAlertContext {
+	childId: string;
+	tenantId: string;
+}
+
+/**
+ * runOptionalWrite に渡す onFailure handler を生成する (fitness#11 counter emitter)。
+ * handler 自体は同期 signature (`(name, error) => void`) のため Discord 通知は
+ * fire-and-forget で起動する。
+ */
+export function createOptionalWriteFailureHandler(
+	ctx: OptionalWriteAlertContext,
+): OptionalWriteFailureHandler {
+	return (name, error) => {
+		const cause = error instanceof Error ? error.message : String(error);
+
+		// 1. structured logger (検索 key: context.kind / context.name)
+		logger.error(`[optional-write] ${name} の optional 書込が欠落 (core commit 済、fitness#11)`, {
+			tenantId: ctx.tenantId,
+			service: 'activity-record',
+			context: {
+				kind: 'optional-write-failed',
+				name,
+				childId: ctx.childId,
+				cause,
+			},
+		});
+
+		// 2. Discord alert (fire-and-forget、記録フローをブロックしない)
+		void sendDiscordAlert({
+			level: 'error',
+			message: `[optional-write-failed] ${name} (recordActivity optional 欠落)`,
+			tenantId: ctx.tenantId,
+			errorSummary: cause,
+		}).catch((err) => {
+			// alert 自体の失敗は logger.warn に留める (recursive alert を避ける)
+			logger.warn(`[optional-write] Discord alert dispatch failed for ${name}: ${String(err)}`);
+		});
+	};
+}

--- a/tests/unit/services/activity-record-dispatch.test.ts
+++ b/tests/unit/services/activity-record-dispatch.test.ts
@@ -1,0 +1,353 @@
+import { asActivityId, asCategoryId, asChildId } from '$lib/domain/ids';
+// tests/unit/services/activity-record-dispatch.test.ts
+// EPIC #3424 / 実装 #3541 Phase Z (+ #3550 ①) / 設計 SSOT: dsql-data-model.md §8
+//
+// recordActivity の DATA_SOURCE=dsql dispatch 結線テスト:
+//   [D1] sqlite 経路の regression 凍結: isDsqlBackend=false では従来どおり sqlite repo に
+//        書き込み、recordActivityCore は一切呼ばれない
+//   [D2] dsql 経路: recordActivityCore が「bonus 計算結果込みの正しい Input」で呼ばれ、
+//        core Result が RecordActivityResult に写像される (確定値のみ描画、§8 演出契約)。
+//        sqlite 側 activity_logs には書かれない (書込は core 単一 txn のみ)
+//   [D3] error 契約: core の ALREADY_RECORDED / DAILY_LIMIT_REACHED が両経路と同一 shape で返る
+//   [D4] NOT_FOUND guard は core 呼び出し前に short-circuit する (read-only 事前 guard 共有)
+//   [D5] optional 失敗の隔離: optional 書込が throw しても core 結果 (成功 result) を壊さず、
+//        fitness#11 counter (logger.error + Discord alert) に emit される (#3550 ①)
+//   [D6] levelUp / masteryLeveledUp が core 確定値から組み立てられる
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { calcLevelFromXp } from '../../../src/lib/domain/validation/status';
+import type { RecordActivityCoreResult } from '../../../src/lib/server/db/dsql/record-activity-core';
+import * as schema from '../../../src/lib/server/db/schema';
+import { assertSuccess } from '../helpers/assert-result';
+import {
+	closeDb,
+	createTestDb,
+	resetDb,
+	seedChildActivities,
+	type TestDb,
+	type TestSqlite,
+} from '../helpers/test-db';
+
+let sqlite: TestSqlite;
+let testDb: TestDb;
+
+// dispatch 切替 flag (vi.mock は hoist されるため vi.hoisted で共有)
+const h = vi.hoisted(() => ({ isDsql: false }));
+
+// todayDate をモックして日付を制御 (既存 activity-log-service.test.ts と同一 pattern)
+const mockToday = '2026-02-20';
+vi.mock('$lib/domain/date-utils', () => ({
+	todayDateJST: () => mockToday,
+	toJSTDateString: (date: Date) => {
+		const jst = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+		return jst.toISOString().slice(0, 10);
+	},
+}));
+
+// DB モック: SQLite リポジトリがテスト用インメモリ DB を使うようにする
+vi.mock('$lib/server/db', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+
+// backend 判定のみ差し替え (resolveDbBackend 等は原本のまま)
+vi.mock('$lib/server/db/backend', async (importOriginal) => {
+	const orig = await importOriginal<typeof import('../../../src/lib/server/db/backend')>();
+	return { ...orig, isDsqlBackend: () => h.isDsql };
+});
+
+// DSQL 接続層: 実 pool を張らないダミー runner (core 自体を mock するため未使用)
+vi.mock('$lib/server/db/dsql/connection', () => ({
+	getDsqlDb: vi.fn(),
+	getDsqlTransactionRunner: vi.fn(() => ({
+		runInTransaction: async <T>(work: (tx: unknown) => Promise<T>) => work({}),
+	})),
+}));
+
+// core 単一 txn を mock (Input 検証 + Result 写像検証の要)
+vi.mock('$lib/server/db/dsql/record-activity-core', () => ({
+	recordActivityCore: vi.fn(),
+}));
+
+// optional の 1 項目 (challenge 進捗) を制御可能にする ([D5] 隔離検証用)
+vi.mock('$lib/server/services/child-challenge-service', () => ({
+	updateChildChallengeProgress: vi.fn(async () => []),
+}));
+
+// ロガー / Discord alert (fitness#11 emit の観測点)
+vi.mock('$lib/server/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+vi.mock('$lib/server/discord-alert', () => ({
+	sendDiscordAlert: vi.fn(async () => undefined),
+}));
+
+import { recordActivityCore } from '../../../src/lib/server/db/dsql/record-activity-core';
+import { sendDiscordAlert } from '../../../src/lib/server/discord-alert';
+import { logger } from '../../../src/lib/server/logger';
+// サービス層をインポート（モック設定後に行う）
+import { recordActivity } from '../../../src/lib/server/services/activity-log-service';
+import { updateChildChallengeProgress } from '../../../src/lib/server/services/child-challenge-service';
+
+const TENANT = 'test-tenant';
+const coreMock = vi.mocked(recordActivityCore);
+const challengeMock = vi.mocked(updateChildChallengeProgress);
+
+/** core 成功 Result の既定値 (base 5 / bonus 0 の初回記録相当)。 */
+function coreOk(over: Partial<Extract<RecordActivityCoreResult, { ok: true }>> = {}) {
+	return {
+		ok: true as const,
+		logId: 'core-log-1',
+		totalPoints: 5,
+		masteryCount: 1,
+		masteryLevel: 1,
+		totalXp: 5,
+		statusLevel: 1,
+		...over,
+	};
+}
+
+beforeAll(() => {
+	({ sqlite, db: testDb } = createTestDb());
+});
+
+afterAll(() => {
+	closeDb(sqlite);
+});
+
+function seedBase() {
+	resetDb(sqlite);
+	testDb.insert(schema.children).values({ nickname: 'テスト子', age: 4, theme: 'pink' }).run();
+	seedChildActivities(testDb, 1, [
+		{ name: 'たいそう', categoryId: asCategoryId(1), icon: '🤸', basePoints: 5 },
+		{ name: 'えほん', categoryId: asCategoryId(2), icon: '📖', basePoints: 5 },
+	]);
+}
+
+beforeEach(() => {
+	seedBase();
+	h.isDsql = false;
+	vi.clearAllMocks();
+	coreMock.mockResolvedValue(coreOk());
+	challengeMock.mockResolvedValue([]);
+});
+
+describe('[D1] sqlite 経路の regression 凍結 (isDsqlBackend=false)', () => {
+	it('従来どおり sqlite repo に書き込み、recordActivityCore は呼ばれない', async () => {
+		const result = assertSuccess(await recordActivity(asChildId(1), asActivityId(1), TENANT));
+		expect(result.basePoints).toBe(5);
+		expect(result.totalPoints).toBe(5);
+		expect(result.activityName).toBe('たいそう');
+		// sqlite 側に activity_logs / point_ledger が実在する (従来経路の書込)
+		expect(testDb.select().from(schema.activityLogs).all()).toHaveLength(1);
+		expect(
+			testDb
+				.select()
+				.from(schema.pointLedger)
+				.all()
+				.filter((e) => e.type === 'activity'),
+		).toHaveLength(1);
+		// core は dsql 経路専用 (dispatch されていない)
+		expect(coreMock).not.toHaveBeenCalled();
+	});
+
+	it('ledger description は抽出後も従来書式 (計算部共有の出力不変担保)', async () => {
+		assertSuccess(await recordActivity(asChildId(1), asActivityId(1), TENANT));
+		const entry = testDb
+			.select()
+			.from(schema.pointLedger)
+			.all()
+			.find((e) => e.type === 'activity');
+		// 初回: streakBonus 0 / masteryBonus 0 → 活動名のみ (旧インライン実装と同一書式)
+		expect(entry?.description).toBe('たいそう');
+	});
+});
+
+describe('[D2] dsql 経路: core Input / Result 写像', () => {
+	beforeEach(() => {
+		h.isDsql = true;
+	});
+
+	it('recordActivityCore が bonus 計算結果込みの Input で 1 回呼ばれる', async () => {
+		assertSuccess(await recordActivity(asChildId(1), asActivityId(1), TENANT));
+		expect(coreMock).toHaveBeenCalledTimes(1);
+		const [runner, input] = coreMock.mock.calls[0] ?? [];
+		expect(runner).toBeDefined();
+		expect(input).toMatchObject({
+			familyId: TENANT,
+			childId: '1',
+			activityId: '1',
+			categoryId: '1',
+			basePoints: 5,
+			streakBonus: 0,
+			masteryBonus: 0,
+			streakDays: 1,
+			recordedDate: mockToday,
+			dailyLimit: null,
+			description: 'たいそう',
+			changeType: 'activity_record',
+		});
+		// sync 注入関数は domain の正規計算と一致する (fitness#7: work 内 await 禁止のため関数注入)
+		expect(input?.masteryLevelFor(4)).toBe(1);
+		expect(input?.masteryLevelFor(5)).toBe(2);
+		expect(input?.statusLevelFor(0)).toBe(calcLevelFromXp(0).level);
+		expect(input?.statusLevelFor(5000)).toBe(calcLevelFromXp(5000).level);
+	});
+
+	it('core Result が RecordActivityResult に写像され、sqlite 側には書かれない', async () => {
+		const result = assertSuccess(await recordActivity(asChildId(1), asActivityId(1), TENANT));
+		expect(result.id).toBe('core-log-1');
+		expect(result.totalPoints).toBe(5);
+		expect(result.masteryLevel).toBe(1);
+		expect(result.masteryLeveledUp).toBeNull();
+		expect(result.levelUp).toBeNull();
+		expect(result.xpGain).toMatchObject({
+			categoryId: asCategoryId(1),
+			xpBefore: 0,
+			xpAfter: 5,
+			levelBefore: 1,
+			levelAfter: 1,
+			maxValue: 100000,
+		});
+		expect(result.unlockedAchievements).toEqual([]);
+		expect(result.eventMissions).toEqual([]);
+		expect(result.customUnlocked).toEqual([]);
+		// 書込は core 単一 txn のみ: sqlite 側 activity_logs / point_ledger は 0 行
+		expect(testDb.select().from(schema.activityLogs).all()).toHaveLength(0);
+		expect(testDb.select().from(schema.pointLedger).all()).toHaveLength(0);
+	});
+
+	it('[D6] core 確定値から levelUp / masteryLeveledUp を組み立てる', async () => {
+		// totalXp 5000 で必ず levelBefore < levelAfter になるよう core 値を設定
+		const xpAfter = 5000;
+		const totalPoints = 5;
+		coreMock.mockResolvedValue(
+			coreOk({ totalPoints, totalXp: xpAfter, masteryCount: 5, masteryLevel: 2, statusLevel: 9 }),
+		);
+		const expectedBefore = calcLevelFromXp(xpAfter - totalPoints);
+		const expectedAfter = calcLevelFromXp(xpAfter);
+		expect(expectedAfter.level).toBeGreaterThan(0); // sanity
+
+		const result = assertSuccess(await recordActivity(asChildId(1), asActivityId(1), TENANT));
+		expect(result.masteryLevel).toBe(2);
+		expect(result.masteryLeveledUp).toEqual({
+			oldLevel: 1,
+			newLevel: 2,
+			isMilestone: false,
+		});
+		if (expectedAfter.level > expectedBefore.level) {
+			expect(result.levelUp).toMatchObject({
+				oldLevel: expectedBefore.level,
+				newLevel: expectedAfter.level,
+				categoryId: asCategoryId(1),
+			});
+		} else {
+			expect(result.levelUp).toBeNull();
+		}
+		expect(result.xpGain.xpBefore).toBe(xpAfter - totalPoints);
+		expect(result.xpGain.xpAfter).toBe(xpAfter);
+	});
+});
+
+describe('[D3] error 契約は両経路で同一 shape', () => {
+	beforeEach(() => {
+		h.isDsql = true;
+	});
+
+	it('core の ALREADY_RECORDED は { error } shape に写像される', async () => {
+		coreMock.mockResolvedValue({ ok: false, reason: 'ALREADY_RECORDED' });
+		const result = await recordActivity(asChildId(1), asActivityId(1), TENANT);
+		expect(result).toEqual({ error: 'ALREADY_RECORDED' });
+	});
+
+	it('core の DAILY_LIMIT_REACHED も同様', async () => {
+		coreMock.mockResolvedValue({ ok: false, reason: 'DAILY_LIMIT_REACHED' });
+		const result = await recordActivity(asChildId(1), asActivityId(1), TENANT);
+		expect(result).toEqual({ error: 'DAILY_LIMIT_REACHED' });
+	});
+});
+
+describe('[D4] NOT_FOUND guard は core 前に short-circuit', () => {
+	beforeEach(() => {
+		h.isDsql = true;
+	});
+
+	it('存在しない child は NOT_FOUND で core 未呼出', async () => {
+		const result = await recordActivity(asChildId(999), asActivityId(1), TENANT);
+		expect(result).toEqual({ error: 'NOT_FOUND', target: 'child' });
+		expect(coreMock).not.toHaveBeenCalled();
+	});
+
+	it('child 越境 activity は NOT_FOUND で core 未呼出 (CWE-598 guard 共有)', async () => {
+		const result = await recordActivity(asChildId(1), asActivityId(999), TENANT);
+		expect(result).toEqual({ error: 'NOT_FOUND', target: 'activity' });
+		expect(coreMock).not.toHaveBeenCalled();
+	});
+});
+
+describe('[D5] optional 失敗の隔離 + fitness#11 counter emit (#3550 ①)', () => {
+	beforeEach(() => {
+		h.isDsql = true;
+	});
+
+	it('optional (challenge 進捗) が throw しても core 成功 result を壊さない', async () => {
+		challengeMock.mockRejectedValueOnce(new Error('challenge write failed'));
+		const result = assertSuccess(await recordActivity(asChildId(1), asActivityId(1), TENANT));
+		// core 確定値はそのまま返り、失敗した optional field は空 fallback
+		expect(result.id).toBe('core-log-1');
+		expect(result.totalPoints).toBe(5);
+		expect(result.siblingChallenges).toEqual([]);
+	});
+
+	it('欠落は logger.error (構造化 kind/name/childId/tenantId/cause) + Discord alert に emit される', async () => {
+		challengeMock.mockRejectedValueOnce(new Error('challenge write failed'));
+		assertSuccess(await recordActivity(asChildId(1), asActivityId(1), TENANT));
+
+		const errorCalls = vi.mocked(logger.error).mock.calls;
+		const emitted = errorCalls.find(
+			([, meta]) =>
+				(meta?.context as Record<string, unknown> | undefined)?.kind === 'optional-write-failed',
+		);
+		expect(emitted, 'fitness#11 counter (logger.error) が emit されていない').toBeDefined();
+		expect(emitted?.[1]).toMatchObject({
+			tenantId: TENANT,
+			context: {
+				kind: 'optional-write-failed',
+				name: 'challenge_progress',
+				childId: '1',
+				cause: 'challenge write failed',
+			},
+		});
+
+		expect(vi.mocked(sendDiscordAlert)).toHaveBeenCalledWith(
+			expect.objectContaining({
+				level: 'error',
+				message: expect.stringContaining('challenge_progress'),
+				tenantId: TENANT,
+			}),
+		);
+	});
+
+	it('optional が成功する場合は counter を emit しない (偽陽性なし)', async () => {
+		assertSuccess(await recordActivity(asChildId(1), asActivityId(1), TENANT));
+		const emitted = vi
+			.mocked(logger.error)
+			.mock.calls.find(
+				([, meta]) =>
+					(meta?.context as Record<string, unknown> | undefined)?.kind === 'optional-write-failed',
+			);
+		expect(emitted).toBeUndefined();
+		expect(vi.mocked(sendDiscordAlert)).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/services/activity-record-dsql-pglite.test.ts
+++ b/tests/unit/services/activity-record-dsql-pglite.test.ts
@@ -1,0 +1,149 @@
+// tests/unit/services/activity-record-dsql-pglite.test.ts
+// EPIC #3424 / 実装 #3541 Phase Z / 設計 SSOT: dsql-data-model.md §8
+//
+// recordActivity の dsql 経路を **実 schema (PGlite + pushSchema) + 実 recordActivityCore** で
+// end-to-end 検証する。mock は接続層 (getDsqlDb / getDsqlTransactionRunner) のみ差し替え、
+// service dispatch → prepareActivityRecord (dsql repo 読取) → core 単一 txn → optional 隔離
+// までを本物の code path で通す:
+//   [E1] 記録成功: ledger / total_point / statuses / status_history / activity_logs 反映
+//        (§5 P7: total_point == SUM(point_ledger) の共更新)
+//   [E2] 二重記録: ALREADY_RECORDED + 全表不変 (冪等)
+//
+// ⚠️ PGlite は単一接続 (dsql-test-db.ts 注記)。本テストは逐次 await のみで deadlock 形なし。
+
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { asCategoryId, asChildId, type ChildId } from '../../../src/lib/domain/ids';
+import { assertSuccess } from '../helpers/assert-result';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+// vi.mock より先に実行される hoisted block で backend を dsql に固定する
+// ($lib/runtime/env は module load 時に getEnv() を評価するため、import 前に設定が必要)
+const holder = vi.hoisted(() => {
+	process.env.DATA_SOURCE = 'dsql';
+	return {
+		db: null as unknown,
+		runner: null as unknown,
+	};
+});
+
+// 接続層のみ差し替え: 実 DSQL pool の代わりに PGlite (実 schema 適用済) を返す。
+// factory.ts の dsql 分岐 / recordActivityDsql はこの mock 経由で PGlite に接続する。
+vi.mock('$lib/server/db/dsql/connection', () => ({
+	getDsqlDb: () => holder.db,
+	getDsqlTransactionRunner: () => holder.runner,
+}));
+
+import { createDsqlChildActivityRepo } from '../../../src/lib/server/db/dsql/child-activity-repo';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+// サービス層 (dispatch 元) は mock 設定後に import
+import { recordActivity } from '../../../src/lib/server/services/activity-log-service';
+
+const FAMILY = '00000000-0000-4000-8000-0000000000e1';
+
+let t: DsqlTestDb;
+let childId: ChildId;
+let activityId: string;
+
+const count = async (table: string, cid: string) =>
+	Number(
+		(
+			(await t.db.execute(
+				sql.raw(
+					`SELECT count(*) AS c FROM ${table} WHERE family_id = '${FAMILY}' AND child_id = '${cid}'`,
+				),
+			)) as { rows: { c: unknown }[] }
+		).rows[0]?.c,
+	);
+
+const totalPoint = async (cid: string) =>
+	(
+		(
+			await t.db.execute(
+				sql`SELECT total_point FROM children WHERE family_id = ${FAMILY} AND child_id = ${cid}`,
+			)
+		).rows[0] as { total_point: number }
+	).total_point;
+
+beforeAll(async () => {
+	t = await createDsqlTestDb();
+	holder.db = t.db;
+	holder.runner = createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 });
+
+	// seed: child 1 人 + activity 2 件 (focus bonus が「全おすすめ達成」にならない構成)
+	const res = await t.db.execute(sql`
+		INSERT INTO children (family_id, nickname, birth_date, theme, ui_mode)
+		VALUES (${FAMILY}, 'ぴぐちゃん', '2018-01-15', 'blue', 'preschool')
+		RETURNING child_id
+	`);
+	childId = asChildId((res.rows[0] as { child_id: string }).child_id);
+
+	const repo = createDsqlChildActivityRepo(t.db as never, holder.runner as never);
+	const a1 = await repo.insertActivity(
+		{ childId, name: 'たいそう', categoryId: asCategoryId('1'), icon: '🤸', basePoints: 5 },
+		FAMILY,
+	);
+	await repo.insertActivity(
+		{ childId, name: 'えほん', categoryId: asCategoryId('2'), icon: '📖', basePoints: 5 },
+		FAMILY,
+	);
+	activityId = a1.id;
+}, 60_000);
+
+afterAll(async () => {
+	await t.close();
+});
+
+describe('#3541 Phase Z: dsql 経路 end-to-end (PGlite 実 schema + 実 core)', () => {
+	it('[E1] 記録成功: core 5 表反映 + total_point == SUM(point_ledger) (§5 P7)', async () => {
+		const result = assertSuccess(await recordActivity(childId, activityId as never, FAMILY));
+
+		// RecordActivityResult 契約 (frontend 契約不変)
+		expect(result.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(result.basePoints).toBe(5);
+		expect(result.streakDays).toBe(1);
+		expect(result.streakBonus).toBe(0);
+		expect(result.masteryBonus).toBe(0);
+		expect(result.totalPoints).toBe(5);
+		expect(result.masteryLevel).toBe(1);
+		expect(result.activityName).toBe('たいそう');
+		expect(result.xpGain).toMatchObject({ xpBefore: 0, xpAfter: 5 });
+
+		// core 5 表 all-or-nothing 反映
+		expect(await count('activity_logs', childId)).toBe(1);
+		expect(await count('activity_mastery', childId)).toBe(1);
+		expect(await count('statuses', childId)).toBe(1);
+		expect(await count('status_history', childId)).toBe(1);
+
+		// §5 P7: ledger INSERT + total_point 共更新 (activity type 1 行 = 5pt)
+		const ledger = (
+			await t.db.execute(
+				sql`SELECT amount, type, description FROM point_ledger
+					WHERE family_id = ${FAMILY} AND child_id = ${childId} AND type = 'activity'`,
+			)
+		).rows as { amount: number; type: string; description: string }[];
+		expect(ledger).toHaveLength(1);
+		expect(ledger[0]?.amount).toBe(5);
+		expect(ledger[0]?.description).toBe('たいそう');
+		expect(await totalPoint(childId)).toBe(5);
+
+		// statuses xp 反映 (XP = ポイント統合)
+		const status = (
+			await t.db.execute(
+				sql`SELECT total_xp, category_id FROM statuses
+					WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+			)
+		).rows[0] as { total_xp: number; category_id: string };
+		expect(status.total_xp).toBe(5);
+		expect(status.category_id).toBe('1');
+	});
+
+	it('[E2] 二重記録: ALREADY_RECORDED で全表不変 (冪等)', async () => {
+		const second = await recordActivity(childId, activityId as never, FAMILY);
+		expect(second).toEqual({ error: 'ALREADY_RECORDED' });
+
+		expect(await count('activity_logs', childId)).toBe(1);
+		expect(await count('status_history', childId)).toBe(1);
+		expect(await totalPoint(childId)).toBe(5);
+	});
+});

--- a/tests/unit/services/optional-write-alert.test.ts
+++ b/tests/unit/services/optional-write-alert.test.ts
@@ -1,0 +1,88 @@
+// tests/unit/services/optional-write-alert.test.ts
+// EPIC #3424 / 実装 #3550 ① / 設計 SSOT: dsql-data-model.md §8 / §13.1 fitness#11
+//
+// createOptionalWriteFailureHandler (optional 欠落カウンタの service 層 bind) の結線テスト:
+//   [A1] logger.error に構造化 context (kind/name/childId/tenantId/cause) で emit する
+//   [A2] sendDiscordAlert を fire-and-forget で起動する (level=error)
+//   [A3] Discord alert 自体の失敗が handler から漏れず、記録フローをブロックしない
+//   [A4] Error 以外の throw 値も cause に文字列化される
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+vi.mock('$lib/server/discord-alert', () => ({
+	sendDiscordAlert: vi.fn(async () => undefined),
+}));
+
+import { sendDiscordAlert } from '../../../src/lib/server/discord-alert';
+import { logger } from '../../../src/lib/server/logger';
+import { createOptionalWriteFailureHandler } from '../../../src/lib/server/services/optional-write-alert';
+
+const alertMock = vi.mocked(sendDiscordAlert);
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	alertMock.mockResolvedValue(undefined);
+});
+
+describe('#3550 ① fitness#11: optional 欠落カウンタの service 層 bind', () => {
+	it('[A1] logger.error に kind/name/childId/tenantId/cause の構造化 context で emit する', () => {
+		const handler = createOptionalWriteFailureHandler({ childId: 'c-1', tenantId: 't-1' });
+		handler('combo_bonus', new Error('mini-txn failed'));
+
+		expect(logger.error).toHaveBeenCalledTimes(1);
+		const [message, meta] = vi.mocked(logger.error).mock.calls[0] ?? [];
+		expect(message).toContain('combo_bonus');
+		expect(meta).toMatchObject({
+			tenantId: 't-1',
+			service: 'activity-record',
+			context: {
+				kind: 'optional-write-failed',
+				name: 'combo_bonus',
+				childId: 'c-1',
+				cause: 'mini-txn failed',
+			},
+		});
+	});
+
+	it('[A2] sendDiscordAlert を level=error + tenantId + errorSummary で起動する', () => {
+		const handler = createOptionalWriteFailureHandler({ childId: 'c-1', tenantId: 't-1' });
+		handler('mission_bonus', new Error('boom'));
+
+		expect(alertMock).toHaveBeenCalledTimes(1);
+		expect(alertMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				level: 'error',
+				message: expect.stringContaining('mission_bonus'),
+				tenantId: 't-1',
+				errorSummary: 'boom',
+			}),
+		);
+	});
+
+	it('[A3] Discord alert 自体の失敗は handler から throw せず logger.warn に留まる', async () => {
+		alertMock.mockRejectedValueOnce(new Error('webhook down'));
+		const handler = createOptionalWriteFailureHandler({ childId: 'c-1', tenantId: 't-1' });
+
+		expect(() => handler('certificate', new Error('x'))).not.toThrow();
+		// fire-and-forget の rejection が処理されるのを待つ
+		await vi.waitFor(() => {
+			expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('certificate'));
+		});
+	});
+
+	it('[A4] Error 以外の throw 値も cause に文字列化される', () => {
+		const handler = createOptionalWriteFailureHandler({ childId: 'c-9', tenantId: 't-9' });
+		handler('special_reward', 'string failure');
+
+		const [, meta] = vi.mocked(logger.error).mock.calls[0] ?? [];
+		expect((meta?.context as Record<string, unknown>)?.cause).toBe('string failure');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体(DSQL 移行の cutover 準備最終段)

**解決する課題**: EPIC #3424 で recordActivityCore(core 単一 txn)/ optional 隔離プリミティブ / fitness#11 欠落カウンタは実装済みだが、`DATA_SOURCE=dsql` 時に service 層 recordActivity からそこへ dispatch する結線が未実装で、onFailure カウンタも誰にも通知されず溜まるだけだった。この 2 点が cutover の最後の未配線。

**期待される効果**: DSQL backend で活動記録が「core 5 行 all-or-nothing + optional 隔離」の原子性を得る(現行 sqlite/dynamo は非原子で部分コミットし得た)。optional 欠落(combo/mission/challenge/証明書/通知)が silent degradation にならず logger + Discord に通知される。

## 関連 Issue

closes #3541

- 関連: #3550 (① fitness#11 アラート結線は本 PR で完遂。② 実 DSQL/staging 並行検証は cutover 後の運用検証事項として EPIC 残に留める。#3550 自体は ② 完了時に close)

- 関連: EPIC #3424(M5 cutover の残 = NUC データ / dynamodb 撤去 / 実 IAM / 本番 deploy はユーザー決裁)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (#3541 第3AC) | DATA_SOURCE=dsql で recordActivity が core + optional 隔離経路へ dispatch | `activity-log-service.ts` の `isDsqlBackend()` 分岐 → `recordActivityDsql` + `tests/unit/services/activity-record-dispatch.test.ts` | PASS |
| AC2 | sqlite/dynamo/demo 経路の挙動不変 | 書込前計算を `activity-record-preparation.ts` に抽出し両経路共有。既存 service test 143 files / **2392 件が無変更で green** | PASS(関数抽出のみ、挙動・順序不変) |
| AC3 (#3550 ①) | fitness#11 欠落カウンタの service 層アラート結線 | `optional-write-alert.ts`(onFailure → logger.error 構造化 + Discord best-effort)+ `tests/unit/services/optional-write-alert.test.ts` | PASS(emit を spy で assert) |
| AC4 | RecordActivityResult / error 契約が両経路同一 | dispatch test で shape 一致 + core dailyLimit 判定で ALREADY_RECORDED/DAILY_LIMIT_REACHED/NOT_FOUND を担保 | PASS |
| AC5 | dsql 経路の end-to-end 動作 | `tests/unit/services/activity-record-dsql-pglite.test.ts`(実 schema PGlite: 記録→ledger/total_point/status 反映 + 二重記録 ALREADY_RECORDED) | PASS |
| AC6 | 回帰 + 安全装置 | fitness (txn work allowlist 含む 67) green / svelte-check 7744 files 0 errors / biome --error-on-warnings clean / check-no-direct-env-access PASS | PASS |

## 変更タイプ

- [x] feat: 新機能

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`)

**影響を受ける画面・機能**: DSQL backend 選択時のみ活動記録経路が変わる。現行本番(dynamodb)/ ローカル(sqlite)は挙動不変(既存 test 2392 件が担保)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**(#1775 / ADR-0030)
- [x] 追加・変更したテストの概要: dispatch 分岐 regression 凍結 / PGlite 実 schema end-to-end / onFailure 結線 emit(全 18 case)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A(dynamodb 経路は分岐で bypass、実装不変)
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし(service 層の記録経路 dispatch。UI / 描画コード変更ゼロ、視覚差分ゼロ)**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: dsql 経路を別関数に分離(単一責任)。計算部は両経路共有の 1 SSOT に抽出(DIP)
- [x] **DRY**: bonus 計算 / streak / description 組立を prepareActivityRecord に集約(二重実装排除)
- [x] **YAGNI**: 現要件(2 backend の dispatch)のみ、投機的抽象なし
- [x] **Security**: env は isDsqlBackend 経由(process.env 直接参照なし、check PASS)
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: core は単一 txn で往復削減(現行の逐次 await 5+ 回より原子的)

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — sqlite/dynamo/demo は分岐で従来経路を無変更で通る(並行実装の対称性を dispatch で保つ)

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**(dsql は opt-in backend、既定経路不変)

**レビュー依頼事項・QA**:
- 計算部抽出(activity-record-preparation.ts)後も sqlite 経路の出力が不変であることは既存 service test 2392 件の無変更 green で担保しています。抽出の等価性を重点確認ください
- 実 DSQL / staging での真の並行検証(#3550②)は cutover 後の運用検証事項として本 PR scope 外(#3550 は ① 結線のみ本 PR で完遂し、② は EPIC 残として保持する)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み(不要な差分・デバッグコードなし)
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
