### PR TITLE
docs: #3461 DSQL docs SSOT 整合 (rationale/13 supersede marking + research doc region 矛盾解消)

### DIFF
--- a/docs/rationale/13-aurora-dsql-migration-evaluation-rationale.md
+++ b/docs/rationale/13-aurora-dsql-migration-evaluation-rationale.md
@@ -2,6 +2,8 @@
 
 <!-- 命名規則: NN-機能名-rationale.md -->
 
+> **⚠️ superseded by EPIC #3424（2026-06-28、marking 2026-07-09 #3461）**: 本 rationale の当時の結論「Pre-PMF では DynamoDB 継続（DSQL は将来候補）」は、**ゼロユーザー期＝データ移行不要により deferral 前提が崩れた**ため EPIC #3424 で supersede された（採用案は「案 A: 今すぐ DSQL へ移管」に反転）。移管方針・料金・特性の現行 SSOT は [`docs/research/2026-06-28-aurora-dsql-adoption.md`](../research/2026-06-28-aurora-dsql-adoption.md)。本文書は「なぜ当初は見送り判断だったか」の設計経緯記録として保持する（active な結論ではない）。
+
 ## 議論の発端
 
 - **日時**: 2026-06-28
@@ -46,7 +48,7 @@
 
 | 案 | 概要 | 検討した理由 |
 |----|------|-----------|
-| 採用案: DynamoDB 継続（DSQL は将来候補として記録） | 現状維持。DSQL を「料金クリア・技術的有力」と評価したうえで Pre-PMF では移管しない | Pre-PMF（ADR-0010）で純リファクタの大移行リスクを取らない |
+| ~~当時の採用案: DynamoDB 継続（DSQL は将来候補として記録）~~ **← EPIC #3424 で supersede** | 現状維持。DSQL を「料金クリア・技術的有力」と評価したうえで Pre-PMF では移管しない | Pre-PMF（ADR-0010）で純リファクタの大移行リスクを取らない。**ゼロユーザー期＝移行コスト最小の窓により前提が崩れ、案 A に反転（#3424）** |
 | 案 A: 今すぐ DSQL へ移管 | AWS backend を DynamoDB→DSQL、`db/dynamodb/` を削除し relational 一本化 | 二重実装税の恒久解消 |
 | 案 B: SQLite 互換サーバーレス（Turso/libSQL）へ一本化 | ローカル SQLite とさらに直接的に一本化 | パラダイム差を最小移植で解消 |
 

--- a/docs/research/2026-06-28-aurora-dsql-adoption.md
+++ b/docs/research/2026-06-28-aurora-dsql-adoption.md
@@ -5,7 +5,7 @@
 | 調査日 | 2026-06-28（転記 2026-06-29） |
 | 関連 EPIC | #3424（DynamoDB → Aurora DSQL 移管） |
 | 関連 rationale | `docs/rationale/13-aurora-dsql-migration-evaluation-rationale.md`（料金・特性 SSOT、結論は EPIC #3424 で supersede） |
-| 前提 | 既存 DynamoDB データ移行は**不要**（ゼロから DSQL に作り直す）。料金は無料枠 + scale-to-zero で **≤¥100/月**。東京 $0.00001/DPU・$0.40/GB-month |
+| 前提 | 既存 DynamoDB データ移行は**不要**（ゼロから DSQL に作り直す）。料金は無料枠 + scale-to-zero で **≤¥100/月**。移管先 us-east-1（`infra/bin/app.ts`）で $0.000008/DPU・$0.33/GB-month（§11.1） |
 
 > 本ファイルは EPIC #3424 の調査 SSOT。設計 Sub / PoC spike の前提となるガードレールを一次ソース付きで集約する。PoC spike 完了時は各 issue の実測結果を本ファイル末尾「PoC 実測ログ」に追記する。
 
@@ -75,14 +75,14 @@
 ## 7. CDK プロビジョニング
 
 - `AWS::DSQL::Cluster`（CloudFormation）あり。プロパティ: DeletionProtectionEnabled / KmsEncryptionKey / MultiRegionProperties / PolicyDocument（≤20KB）/ Tags。GetAtt: Identifier / ResourceArn / Endpoint / Status / VpcEndpointServiceName / CreationTime。
-- 東京シングルリージョン = MultiRegionProperties 指定しないだけ。CDK は aws-cdk-lib L1 `CfnCluster`（aws_dsql）。L2 標準なし。本番 DeletionProtectionEnabled:true（ADR-0019 Replacement gate 整合確認）。
+- us-east-1 シングルリージョン（本番同一、§11.1）= MultiRegionProperties 指定しないだけ。CDK は aws-cdk-lib L1 `CfnCluster`（aws_dsql）。L2 標準なし。本番 DeletionProtectionEnabled:true（ADR-0019 Replacement gate 整合確認）。
 
 ## 8. EPIC 事前整理 Issue（設計 = 紙上確定 / PoC = 実機検証 の別）
 
 起票済（EPIC #3424 配下）:
 
 - **設計 Sub**: #3430 DPU クエリ規約 ADR / #3431 CloudWatch Alarm+Budgets+Anomaly IaC / #3432 DSQL アラーム dashboard / #3433 sqlite→pg 型差分洗い出し / #3434 tenantId 列分離 fitness function / #3435 OCC retry ラッパ / #3436 backup 一括 import チャンク+saga 設計 / #3437 DSQL backup(AWS Backup) とアプリ backup 役割分担 / #3438 db/dynamodb 撤去計画 + rationale 13 supersede
-- **PoC spike**（新サービスゆえ実測必須）: #3425 実 DPU/OCC 競合率 / #3426 Lambda 接続再利用 + cold start / #3427 drizzle-kit DDL 制約適合（ASYNC index 等）/ #3428 一括 import 3,000 行/10MiB 抵触実測 / #3429 L1 CfnCluster 東京最小構成 spike。
+- **PoC spike**（新サービスゆえ実測必須）: #3425 実 DPU/OCC 競合率 / #3426 Lambda 接続再利用 + cold start / #3427 drizzle-kit DDL 制約適合（ASYNC index 等）/ #3428 一括 import 3,000 行/10MiB 抵触実測 / #3429 L1 CfnCluster us-east-1 最小構成 spike。
 
 ---
 
@@ -92,7 +92,7 @@
 
 | リスク | verdict | 要旨 |
 |---|---|---|
-| B コスト | **NOT-TRIGGERED** | scale-to-zero は本物・固定費/最低課金なし、無料枠 perpetual。本ワークロード試算 約180 DPU/月（無料枠 0.18%）→ 実費 ¥0 見込み。東京単価は要最終確認 |
+| B コスト | **NOT-TRIGGERED** | scale-to-zero は本物・固定費/最低課金なし、無料枠 perpetual。本ワークロード試算 約180 DPU/月（無料枠 0.18%）→ 実費 ¥0 見込み。単価は us-east-1（$0.000008/DPU・$0.33/GB、§11.1）で確定、PoC spike#1 実測 TotalDPU 3.53 で裏取り済 |
 | C 性能 | **NOT-TRIGGERED**（定常）/ Lambda 接続 **NEEDS-POC** | 単一リージョン・低競合で read 数ms・write 低ms と DynamoDB 同等。OCC 300ms 罰則は書込競合時のみ＝1家族では非該当。Lambda cold 接続確立のみ実測 |
 | A スキーマ一本化 | **NOT-TRIGGERED** | AWS 公式 Drizzle blog: pg-core schema 1 本で済む（差は SERIAL→UUID 等の型選択のみ）。FK→relations / SERIAL→UUID / JSONB→TEXT の片方向移植。SQLite 残置 2 バックエンドは不採用 |
 | F CDK/IaC | **NOT-TRIGGERED** | L1 `AWS::DSQL::Cluster` 主要プロパティ No-interruption（ADR-0019 Replacement リスク低）。alpha L2 `aws_dsql_alpha` 実在（要 pin）。IAM grant helper 欠如のみ手書き |


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営(DSQL 移管 EPIC #3424 の docs を読む開発者・AI 補佐)

**解決する課題**: rationale/13 が「Pre-PMF では DynamoDB 継続」をヘッダ無しの active 結論として保持し、research doc は「移管確定」で矛盾していた(二重 SSOT)。research doc 内部でも header/§9 の「東京単価」と §11.1 の「us-east-1 が正」が矛盾(stale-context)。

**期待される効果**: 読者が「継続 vs 移管確定」の相反 SSOT を同時に見る事故がなくなり、リージョン単価も現状の正解(us-east-1)に一本化される。

## 関連 Issue

closes #3461

- 関連: #3438(rationale/13 supersede は M5 cutover Sub の担当だが本 PR で前倒し marking)/ #3415(task 3 = §7 アンカー是正は #3415 が担当)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | rationale/13 の supersede marking 前倒し(二重 SSOT 解消) | 冒頭 supersede ヘッダ + 代替案表の「DynamoDB 継続」に取消線 + #3424 反転注記 | PASS(active 結論を経緯記録に降格、現行 SSOT へ pointer) |
| AC2 | research doc の region 内部矛盾解消(東京→us-east-1) | `grep -c 東京` = 1(残 1 は §11.1 の訂正記述で経緯説明として正当)。header/§7/§9/spike の 4 箇所を us-east-1 実測値に伝播 | PASS |
| AC3 | docs 参照整合 | `node scripts/check-doc-code-references.mjs` | PASS(baseline 内、新規違反 0) |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ドキュメント (`docs/rationale/` + `docs/research/` の 2 file)

**影響を受ける画面・機能**: なし(docs truth 補修のみ、コード変更ゼロ)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**(#1775 / ADR-0030)
- [x] 追加・変更したテストの概要: N/A(docs のみ)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし(docs のみ、UI 変更ゼロ)**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A(docs)
- [x] **DRY**: 二重 SSOT を解消(rationale/13 を pointer 化し research doc に一本化)
- [x] **YAGNI**: task 3 は #3415 に委譲し scope を絞る
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — docs truth 補修(docs SSOT 原則: 現状の正解のみ端的に記述)

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み(不要な差分・デバッグコードなし)
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし(docs のみ)
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
