### PR TITLE
fix: #3601 DSQL checklist-repo に source_preset_id 配線 (Gap B、marketplace 取込帰属の欠落解消)

### DIFF
--- a/src/lib/server/db/dsql/checklist-repo.ts
+++ b/src/lib/server/db/dsql/checklist-repo.ts
@@ -52,6 +52,7 @@ interface TemplateRow {
 	is_active: boolean;
 	is_archived: boolean;
 	archived_reason: string | null;
+	source_preset_id: string | null;
 	created_at: string;
 	updated_at: string;
 }
@@ -99,7 +100,7 @@ interface OverrideRow {
 
 const TEMPLATE_COLUMNS = sql.raw(
 	`family_id, template_id, name, icon, points_per_item, completion_bonus, time_slot,
-	 is_active, is_archived, archived_reason, created_at, updated_at`,
+	 is_active, is_archived, archived_reason, source_preset_id, created_at, updated_at`,
 );
 const ASSIGNMENT_COLUMNS = sql.raw('family_id, template_id, child_id, created_at');
 const ITEM_COLUMNS = sql.raw(
@@ -113,8 +114,8 @@ const OVERRIDE_COLUMNS = sql.raw(
 );
 
 /** row → ChecklistTemplate entity (boolean → 0/1、sqlite 互換 shape)。
- * sourcePresetId: DSQL checklist_templates は source_preset_id 列を持たない (§10 marketplace
- * 帰属記録は将来課題) ため常に null を返す (entity 側は optional)。 */
+ * sourcePresetId: marketplace 取込 checklist の帰属記録 (#3601 Gap B、兄弟 type child_activities/
+ * special_rewards と同様 source_preset_id 列に永続。非取込は null)。 */
 function toTemplate(row: TemplateRow): ChecklistTemplate {
 	return {
 		id: row.template_id,
@@ -129,7 +130,7 @@ function toTemplate(row: TemplateRow): ChecklistTemplate {
 		archivedReason: row.archived_reason,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
-		sourcePresetId: null,
+		sourcePresetId: row.source_preset_id,
 	};
 }
 
@@ -243,10 +244,12 @@ export function createDsqlChecklistRepo<TTx extends SqlExecutor>(
 			// 未指定は schema default に合わせた値を明示 (child-activity buildInsertSql と同方針)。
 			const result = await db.execute(sql`
 				INSERT INTO checklist_templates
-					(family_id, name, icon, points_per_item, completion_bonus, time_slot, is_active, is_archived)
+					(family_id, name, icon, points_per_item, completion_bonus, time_slot, is_active,
+					 is_archived, source_preset_id)
 				VALUES (${tenantId}, ${input.name}, ${input.icon ?? '📋'}, ${input.pointsPerItem ?? 2},
 					${input.completionBonus ?? 5}, ${input.timeSlot ?? 'anytime'},
-					${(input.isActive ?? 1) !== 0}, ${(input.isArchived ?? 0) !== 0})
+					${(input.isActive ?? 1) !== 0}, ${(input.isArchived ?? 0) !== 0},
+					${input.sourcePresetId ?? null})
 				RETURNING ${TEMPLATE_COLUMNS}
 			`);
 			return toTemplate(result.rows[0] as unknown as TemplateRow);

--- a/tests/unit/db/dsql-checklist-repo.test.ts
+++ b/tests/unit/db/dsql-checklist-repo.test.ts
@@ -102,6 +102,7 @@ describe('DSQL checklist-repo (PR-R7、実 schema PGlite、family master + per-c
 		expect(created.isActive).toBe(1); // 0/1 契約
 		expect(created.isArchived).toBe(0);
 		expect(created.archivedReason).toBe(null);
+		expect(created.sourcePresetId).toBe(null); // 非取込は null (#3601 Gap B)
 		expect(typeof created.createdAt).toBe('string');
 
 		const found = await repo.findTemplateById(created.id, FAMILY);
@@ -109,6 +110,17 @@ describe('DSQL checklist-repo (PR-R7、実 schema PGlite、family master + per-c
 		expect(found?.name).toBe('あさのしたく');
 		// §P9: 他 family からは不可視
 		expect(await repo.findTemplateById(created.id, OTHER_FAMILY)).toBe(undefined);
+	});
+
+	it('[T1b] insertTemplate: sourcePresetId 永続 (#3601 Gap B、marketplace 取込帰属)', async () => {
+		const created = await repo.insertTemplate(
+			{ name: 'イベント持ち物', sourcePresetId: 'event-pool' },
+			FAMILY,
+		);
+		expect(created.sourcePresetId).toBe('event-pool');
+		// read 経路でも保全 (toTemplate が source_preset_id を verbatim 返す)
+		const found = await repo.findTemplateById(created.id, FAMILY);
+		expect(found?.sourcePresetId).toBe('event-pool');
 	});
 
 	it('[T2] findTemplatesByTenant: includeInactive filter + archived 除外 + §P9', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体(DSQL cutover 前必須の checklist 帰属記録)

**解決する課題**: R7(DSQL IChecklistRepo)で保留された 2 gap のうち、marketplace 取込 checklist の出自(`source_preset_id`)が DSQL backend で永続されず、取込帰属分析(#2774/#2775 の 5 type 取込)が欠落していた。

**期待される効果**: DSQL backend でも checklist template の取込元 preset が sqlite / 兄弟 type(activity/reward)と同様に記録され、取込帰属の一貫性が保たれる。

## 関連 Issue

closes #3601

- 関連: EPIC #3424 / ADR-0055 / #2774 #2775(marketplace 取込)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (Gap A 判断) | item_id uuid vs override id 混在の解決要否判断 | develop 実 schema 確認: `checklist_logs.items_json` は M4-C で text 据置(子表 `checklist_log_items` 廃止、schema.ts:618-629) | **解消済**(override の `-<uuid>` を uuid 制約に阻まれず text 配列に verbatim 格納。repo も items_json を verbatim read/write) |
| AC2 (Gap B 判断 + 実装) | source_preset_id の要否判断 → 必要なら配線 | schema には M4-C で `source_preset_id` 列追加済(兄弟 type と同様、schema.ts:478)。repo が R7 時点の stale で `null` ハードコードしていたため実列に配線 | PASS(TemplateRow/TEMPLATE_COLUMNS/toTemplate/insertTemplate の 4 箇所を配線) |
| AC3 | 取込帰属 round-trip の検証 | `tests/unit/db/dsql-checklist-repo.test.ts` [T1b](sourcePresetId 永続 + read 保全)+ [T1] 非取込 null | PASS(22 case green) |
| AC4 | schema 凍結(fitness#9)整合 | PK 不変(source_preset_id は非 PK 列、既に追加済)。column-parity fitness green | PASS |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) ※ DSQL checklist-repo の配線のみ(schema.ts は変更なし = 列は M4-C で追加済)

**影響を受ける画面・機能**: DSQL backend の checklist 取込帰属のみ(sqlite / dynamo は不変。schema 列は既存)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**(#1775 / ADR-0030)
- [x] 追加・変更したテストの概要: [T1b] source_preset_id 永続 + read 保全、[T1] に非取込 null 検証追加
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし(server/db 層の列配線。UI 変更ゼロ、視覚差分ゼロ)**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 兄弟 type(child_activities/special_rewards)の source_preset_id と同じ配線パターンに整合
- [x] **DRY**: stale だった null ハードコードを実列参照に置換(mapping の二重管理解消)
- [x] **YAGNI**: Gap A は M4-C 決定で既に解消のため実装せず(判断のみ)
- [x] **Security**: N/A(family スコープの既存 tenant 述語を維持)
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A(列 1 個の read/write 追加、無視可能)

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] E2E / ユニットシード同期(schema 列は M4-C 追加済、repo 配線のみ)
- [x] N/A — sqlite backend は既に source_preset_id 対応済(本 PR は DSQL 側の追随)

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**(欠落していた列への配線追加。既存の null 挙動は非取込で不変)

**レビュー依頼事項・QA**:
- Gap A(item_id uuid)は M4-C の text 据置決定で構造的に解消済みであることを確認いただき、本 PR で Gap B のみ配線した判断の妥当性をご確認ください

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み(不要な差分・デバッグコードなし)
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
