### PR TITLE
docs(adr): ADR-0064 NUC 新 model repo 構築方式 = PGlite 採択 (#3620 AC1、PO 承認済)

### DIFF
--- a/docs/decisions/0064-sqlite-core-repo-strategy.md
+++ b/docs/decisions/0064-sqlite-core-repo-strategy.md
@@ -1,0 +1,52 @@
+# 0064. NUC 新 model repo 構築方式 — PGlite 一次採用 (dialect 税ゼロ) + raw SQLite fallback
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | proposed |
+| 日付 | 2026-07-09 |
+| 起票者 | Dev (Claude) |
+| 関連 Issue | EPIC #3620 (AC1) / 親 #3424 / #3531 (PGlite 採用) |
+
+## コンテキスト
+
+DSQL 移行 M4 (#3614) は **クラウド = Postgres(DSQL) 側のみ**を実装し、NUC(local) の新 clean model は未着手。M4 は「同一 repo を 2 方言で再利用」する当初設計 (dsql-data-model §9 / m4-plan §143) を採らず **raw pg SQL** を採用したため、`src/lib/server/db/dsql/*` の repo 33 本は pg 固有機能に依存する:
+
+- STORED 生成列 (`generatedAlwaysAs` の `CASE WHEN`) × 3 = **条件付き一意の DB 強制** (§6.6 `owner_guard` owner≤1 / `email_lower` / `weekly_auto_guard` auto:weekly 行のみ一意)。DSQL は部分 index 非対応のためこの生成列パターンが唯一の代替
+- `SELECT … FOR UPDATE` = write-skew 防止 (非負残高 point-repo / owner 移譲 auth-repo / daily-mission / activity-pin)。read 値を条件に別行を書く不変条件を write-intent 化
+- `gen_random_uuid()` / `::timestamptz` / pg 版 `ON CONFLICT`(53) / `RETURNING`(90) / `jsonb`
+
+これらは SQLite で動かず「同一 repo 再利用」が不成立。`src/lib/server/db/sqlite/*` は旧実装 (counter.ts / padId / hydrate) のまま。新 model の sqlite repos をどう構築するかが本 ADR の判断対象 (実装は AC2-AC6 の sub で別途)。既存 factory は `DbBackend = 'sqlite'|'dsql'|...` の 1-interface / backend 別 impl 構造 (`db/backend.ts`)。
+
+## 検討した選択肢 (8 軸 deep research サマリ、詳細は EPIC #3620 コメント)
+
+### 案 A: sqlite-core 用の別 raw SQL repo 群 (dsql/ と対の sqlite2/)
+- pg raw SQL を SQLite 方言に手書き翻訳: 生成列→app 側計算 + trigger/部分 UNIQUE、`FOR UPDATE`→`BEGIN IMMEDIATE` (SQLite は txn 開始で DB 全体 lock ゆえ本来不要)、`gen_random_uuid`→`$defaultFn(randomUUID)`、`RETURNING` は SQLite 3.35+ で可、`::timestamptz`→text ISO
+- **独自実装量**: repo 33 本 × 2 (最大)。恒久 dialect-parity 税を fitness で機械強制
+- **pg 固有並行制御の担保**: SQLite 単一 writer + `BEGIN IMMEDIATE` で write-skew 消滅 (parity は保てるが機構は別物 = 二重検証必要)
+- **NUC 基盤リスク**: なし (better-sqlite3 WAL/docker 現状維持)。OSS = drizzle sqlite-core (公式サポート)
+
+### 案 B: drizzle query-builder で dialect 非依存 repo に書き直し (hybrid)
+- **致命的問題**: drizzle は `pgTable`/`sqliteTable` を意図的に分離、runtime dialect swap 不可 (公式 Discussion #5269/#3396)。共有は「app 側 interface 層」で行う設計 = 既存 factory と同じ。builder 化しても §6.6 の pg 固有不変条件 (`FOR UPDATE` は sqlite-core に存在せず / 生成列式・条件付き一意は方言差) は **backend 別 raw に退避必須** = hard 20% は結局 2 本
+- さらに **既に shipping 済・test 済の raw pg repo 33 本を builder へ全面書き直す回帰リスク** をクラウド完成側に負う (「動くものを触る」)。80% を builder 化しても 20% の split は残り、書き直し税が上乗せ = 最悪
+
+### 案 C: NUC を PGlite (@electric-sql/pglite、組込 Postgres WASM) で動かし pg repos を完全再利用
+- **決定的事実**: pg repos 33 本は **既に PGlite 上で全 unit test が通っている** (`tests/unit/db/dsql-*.test.ts`、#3531 で採用済 dev dep `^0.5.4`)。repo コメントが PGlite 挙動 (FOR UPDATE / boolean / bigint / TZ) を明示的に前提化済 = **dialect 税ゼロ・書き直しゼロ**
+- **並行制御**: PGlite は実 pg の locking を持つ (`FOR UPDATE` 本物)。DSQL の OCC 40001 は再現しないが (research §D)、NUC = 単一世帯・単一 writer envelope では locking の方が強い (write-skew 原理的に不在)。`withOccRetry` は no-op (案 A の `BEGIN IMMEDIATE` と同格)
+- **懸念 (一次ソース)**: PGlite は single-user mode = 単一接続 (v0.4 で multiplexing 追加も単一 WASM プロセス)。公式 positioning は **embedded / local-first / dev tool** で「複数同時ユーザーには不適」と明記。永続化は Node FS VFS (query 毎 flush)。長期本番サーバの durability/backup は better-sqlite3 ほど battle-tested でない。TZ はローカル継承 (DSQL は UTC 固定 P10) → `PGTZ=UTC` 明示が必要
+
+## 決定
+
+**案 C (PGlite for NUC) を一次推奨とし、PGlite 本番運用の PO 承認を gate とする。承認されない場合は案 A を fallback とする。案 B は却下。**
+
+決定的根拠: (1) 案 C は pg repos を verbatim 再利用し、**恒久 dialect-parity 税を唯一ゼロにする**唯一の案。(2) その再利用可能性は「33 repos が PGlite で test green」という実測で既に裏付け済 (推測でない)。(3) NUC の単一世帯・単一 writer 実行 envelope は PGlite single-connection 制約と一致 (better-sqlite3 と同じ単一 writer モデル)。(4) 案 B は shipping 済 pg repo の全面書き直し回帰 + hard 20% の split 残存で最悪、当初の EPIC lean (B hybrid 軸) は本 research で反転した。
+
+## 結果 (トレードオフ)
+
+- **案 C 採択時**: repo 実装 = 追加ゼロ (schema は pg-core 1 本を NUC でも使用)。撤去対象 = 旧 sqlite/* + counter.ts + padId + hydrate。§12.2 backup round-trip は id 非保全・自然キー再解決ゆえ backend 差に非依存で整合。代償 = NUC 実行基盤を better-sqlite3→PGlite に変更 (WAL/docker/backup 再設計)、PGlite durability の本番検証、`PGTZ=UTC` 固定
+- **案 A fallback 時**: NUC 基盤不変で安全だが repo 33×2 の恒久税 + parity fitness を CI に常設
+- dialect-parity fitness (AC2) は **案 C なら不要** (schema 1 本)、案 A なら必須 — 方式決定が後続 AC の工数を大きく分岐させる
+
+## ユーザー承認を要する判断点 (PO エスカレーション)
+
+- **NUC 本番実行基盤の変更 (案 C)**: SQLite(better-sqlite3) → PGlite への切替は「NUC = 越境ゼロ・データ家庭内」訴求 (ADR-0013) の実行基盤を変える判断。PGlite 公式が本番長期運用を第一用途としない点 (durability/backup が dev-tool positioning) が「モダン実装と乖離する技術制約」に該当しうる → **PO 判断必須**
+- gate 項目: (a) Node FS VFS の crash-safe durability + backup 手順の検証、(b) 単一世帯負荷での常駐メモリ/性能 (vs better-sqlite3)、(c) PGlite 本番採用の OSS 実績。gate 不合格なら案 A に確定

--- a/docs/decisions/0064-sqlite-core-repo-strategy.md
+++ b/docs/decisions/0064-sqlite-core-repo-strategy.md
@@ -2,7 +2,7 @@
 
 | 項目 | 内容 |
 |------|------|
-| ステータス | proposed |
+| ステータス | accepted (2026-07-09 PO 承認: NUC 基盤 PGlite 化をロールバック可能前提で許可) |
 | 日付 | 2026-07-09 |
 | 起票者 | Dev (Claude) |
 | 関連 Issue | EPIC #3620 (AC1) / 親 #3424 / #3531 (PGlite 採用) |
@@ -36,9 +36,11 @@ DSQL 移行 M4 (#3614) は **クラウド = Postgres(DSQL) 側のみ**を実装�
 
 ## 決定
 
-**案 C (PGlite for NUC) を一次推奨とし、PGlite 本番運用の PO 承認を gate とする。承認されない場合は案 A を fallback とする。案 B は却下。**
+**案 C (PGlite for NUC) を採択する (2026-07-09 PO 承認)。案 B は却下、案 A は fallback として温存。**
 
-決定的根拠: (1) 案 C は pg repos を verbatim 再利用し、**恒久 dialect-parity 税を唯一ゼロにする**唯一の案。(2) その再利用可能性は「33 repos が PGlite で test green」という実測で既に裏付け済 (推測でない)。(3) NUC の単一世帯・単一 writer 実行 envelope は PGlite single-connection 制約と一致 (better-sqlite3 と同じ単一 writer モデル)。(4) 案 B は shipping 済 pg repo の全面書き直し回帰 + hard 20% の split 残存で最悪、当初の EPIC lean (B hybrid 軸) は本 research で反転した。
+PO 判断 (2026-07-09): 「PGlite にしたいのは SQLite がクエリ複雑度に耐えられないからか?」への回答は **No — SQLite は複雑クエリ対応可 (部分 index 等 DSQL に無い機能すら持つ)。案 C の理由は複雑度でなく、pg repos の verbatim 再利用による二重実装税ゼロ化とクラウド挙動 parity**。「どちらにせよ (旧→新 schema の) マイグレーションは不可避」を確認のうえ、**ロールバック可能を前提に PGlite 化を許可**。
+
+決定的根拠: (1) 案 C は pg repos を verbatim 再利用し、**恒久 dialect-parity 税を唯一ゼロにする**。(2) 再利用可能性は「33 repos が PGlite で test green」の実測で裏付け済。(3) NUC の単一世帯・単一 writer envelope は PGlite single-connection 制約と一致。(4) 案 B は shipping 済 pg repo の全面書き直し回帰 + hard 20% split 残存で最悪。
 
 ## 結果 (トレードオフ)
 
@@ -46,7 +48,15 @@ DSQL 移行 M4 (#3614) は **クラウド = Postgres(DSQL) 側のみ**を実装�
 - **案 A fallback 時**: NUC 基盤不変で安全だが repo 33×2 の恒久税 + parity fitness を CI に常設
 - dialect-parity fitness (AC2) は **案 C なら不要** (schema 1 本)、案 A なら必須 — 方式決定が後続 AC の工数を大きく分岐させる
 
-## ユーザー承認を要する判断点 (PO エスカレーション)
+## ロールバック保証 (PO 承認の前提条件、§12.2 整合)
 
-- **NUC 本番実行基盤の変更 (案 C)**: SQLite(better-sqlite3) → PGlite への切替は「NUC = 越境ゼロ・データ家庭内」訴求 (ADR-0013) の実行基盤を変える判断。PGlite 公式が本番長期運用を第一用途としない点 (durability/backup が dev-tool positioning) が「モダン実装と乖離する技術制約」に該当しうる → **PO 判断必須**
-- gate 項目: (a) Node FS VFS の crash-safe durability + backup 手順の検証、(b) 単一世帯負荷での常駐メモリ/性能 (vs better-sqlite3)、(c) PGlite 本番採用の OSS 実績。gate 不合格なら案 A に確定
+案 C 採択の前提 = **ロールバック可能**。cutover は非破壊 import-then-swap で担保する:
+1. 旧 NUC DB (better-sqlite3) は **読み取りのみ**でエクスポート (非破壊)、新 PGlite DB は別途構築
+2. **検証 OK まで旧 DB のまま稼働**、round-trip completeness `errors > 0` で swap 中止 → 旧 DB に戻す
+3. 切替後も**旧 DB を物理保持**。PGlite 実行基盤に問題が出れば env/runtime を旧 sqlite に戻すだけで復帰
+4. 残注意: 切替後の新 DB 書込は旧 DB 復帰で検証窓分を失う (単一世帯 NUC の短い検証窓で許容)
+
+## 実装時の検証 gate (AC 消化中に確認、不合格なら案 A へ)
+
+案 C の残懸念は実装 sub で検証する (不合格時は案 A fallback が生きている):
+- (a) PGlite の Node FS VFS crash-safe durability + backup 手順、(b) 単一世帯負荷の常駐メモリ/性能 (vs better-sqlite3)、(c) `PGTZ=UTC` 固定 (DSQL は UTC 固定 P10、PGlite はローカル TZ 継承)。実際の NUC 本番 cutover はバックアップ取得を作業直前に行う最終ゲート付き

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -186,6 +186,7 @@ ADR を現場の常時参照ルールとして機能させるため、以下の�
 | 0061 | [band-aid サイクル打破 + shift-left の機械強制 (failing-test-first / same-class-N→guard / push-down-pyramid / fitness function / accepted-residual gate)](0061-band-aid-breaking-shift-left-mechanization.md) | accepted | 2026-06-20 |
 | 0062 | [統一エラー通知設計 (種別×手段マッピング + 内部例外非露出 + role/aria SSOT)](0062-unified-error-notification.md) | accepted | 2026-06-22 |
 | 0063 | [DSQL pool マルチテナント分離 (信頼 claim/context + アプリ層単一強制点 + fitness function、RLS 非対応の代替防御線)](0063-dsql-pool-multitenant-isolation.md) | accepted | 2026-06-29 |
+| 0064 | [NUC 新 model repo 構築方式 — PGlite 一次採用 (dialect 税ゼロ) + raw SQLite fallback](0064-sqlite-core-repo-strategy.md) | accepted | 2026-07-09 |
 
 > 注 (2026-06-04 #2440 PR-A5): 番号は欠番を許容する（削除済 ADR の番号は再利用しない、git 履歴で追跡可能）。新規 ADR は最大番号 +1 で採番する。renumber 規約は §renumber 規約 を参照。
 >

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -346,3 +346,13 @@ active 総数: 41 件 (棚卸後、ADR-0061 +1)。
 **1-in-1-out 履行**: ADR-0060 / 0061 起票時と同様、active 大幅超過の現状を踏まえ 1-in-1-out は **2026-06 最終週の月 1 棚卸** で archive 候補 (ADR-0014 proposed 据置 / per-ADR ボリューム超過) と併せて消化する (本 PR scope 外)。
 
 active 総数: 42 件 (棚卸後、ADR-0063 +1)。
+
+### 2026-07-09 棚卸 (ADR-0064 起票)
+
+**完了項目**:
+
+1. **ADR-0064 新規追加**: NUC 新 model repo 構築方式 = PGlite 一次採用 (dialect 税ゼロ) + raw SQLite fallback。EPIC #3424 (DynamoDB → Aurora DSQL 移管) の NUC (セルフホスト) トラックで、DSQL 用 pg repos 33 本を書き直さず NUC でも動かすため、案 C = NUC を PGlite (@electric-sql/pglite) で駆動し pg repos を verbatim 再利用する決定 (PO 承認 2026-07-09、ロールバック可能前提 = 非破壊 import-then-swap / 旧 DB 物理保持 / errors>0 abort)。決定的根拠 = pg repos が既に PGlite で全 test green (`tests/unit/db/dsql-*.test.ts`、#3531 で dev dep 採用済) で二重実装税ゼロ + クラウド parity。選択肢 3 案比較 (案 A: drizzle sqlite-core の別 raw SQL repo 群 / 案 B: drizzle query-builder で方言非依存 repo に書き直し / 案 C: PGlite で pg repos 再利用) を本文に記載し、案 B 却下・案 A は fallback 温存。Pre-PMF Bucket A (ADR-0010 整合)。
+
+**1-in-1-out 履行**: ADR-0060 / 0061 / 0063 起票時と同様、active 大幅超過の現状を踏まえ 1-in-1-out は **2026-07 最終週の月 1 棚卸** で archive 候補 (ADR-0014 proposed 据置 / per-ADR ボリューム超過) と併せて消化する (本 PR scope 外)。
+
+active 総数: 43 件 (棚卸後、ADR-0064 +1)。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営(DSQL 移行の NUC トラック設計判断)

**解決する課題**: DSQL M4 は pg 側のみ実装し、NUC(SQLite)cutover に必要な新 model repo 構築方式が未決だった。案 A(SQLite 再実装)/ B(drizzle builder)/ C(PGlite 再利用)の設計判断を ADR で確定する。

**期待される効果**: EPIC #3620 の後続 AC(SQLite-core 実装)の方式が確定し、工数の大分岐(案 C なら dialect-parity fitness 不要)が解消される。

## 関連 Issue

closes なし(EPIC #3620 は本 ADR で AC1 のみ充足、AC2-6 は sub で継続のため #3620 は open 維持)

- 関連: EPIC #3620(AC1 = 本 ADR)/ 親 #3424 / #3531(PGlite 採用実績)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1(#3620) | repo 構築方式の設計判断を ADR 化(案 A/B/C 比較 + OSS 調査、ADR-0014) | `docs/decisions/0064-sqlite-core-repo-strategy.md`(8 軸 deep research サマリ + 案 C 採択 + PO 承認記録) | PASS(62 行 / 6 セクション、ボリューム上限内。README active 表追記) |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] ドキュメント (`docs/decisions/` の ADR-0064 新設 + README 表追記)

**影響を受ける画面・機能**: なし(設計判断の記録のみ、コード変更ゼロ)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**(#1775 / ADR-0030)
- [x] 追加・変更したテストの概要: N/A(ADR docs)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし(ADR docs のみ、UI 変更ゼロ)**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A(docs)
- [x] **DRY**: 案 C は pg repos verbatim 再利用で二重実装を回避する決定
- [x] **YAGNI**: 案 A/B の恒久 dialect 税を避ける
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: 実装時 gate に PGlite 常駐メモリ/性能検証を明記

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — ADR docs(設計判断の記録)

**ADR 運用**: active 表に 0064 追記済。1-in-1-out は active 大幅超過(43 件)の現状を踏まえ 2026-07 最終週の月 1 棚卸で消化(ADR-0060/0061/0063 起票時と同運用)

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- 案 C(NUC を PGlite 化)は PO 承認済み(ロールバック可能前提)。ADR の決定・ロールバック保証・実装時 gate の妥当性をご確認ください

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み(不要な差分・デバッグコードなし)
- [x] 全 AC が実装済み(AC1 のみ、AC2-6 は #3620 sub で継続)
- [x] UI 変更時: 該当なし
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
