### PR TITLE
fix(test): #3424 DSQL RR7 expireOldRedemptions を専用 family に隔離 (日付依存 time-bomb 解消)

### DIFF
--- a/tests/unit/db/dsql-reward-message-repos.test.ts
+++ b/tests/unit/db/dsql-reward-message-repos.test.ts
@@ -377,19 +377,23 @@ describe('DSQL reward / message repos (PR-R8、実 schema PGlite)', () => {
 	});
 
 	it('[RR7] expireOldRedemptions (30 日超 pending → expired) / hasPendingByReward', async () => {
-		const childId = await newChild('期限七郎');
-		const reward = await seedReward(childId, '期限報酬', 10);
+		// expireOldRedemptions は tenant 全体を走査するため、[RR3] と同様に専用 family へ隔離する。
+		// 共有 FAMILY だと他 case が残す pending (例 [RR2] の固定 epoch) が cutoff を跨いだ日に
+		// 混入し expired 件数が非決定になる (time-bomb)。tenant 隔離で件数を決定的にする。
+		const family = '00000000-0000-4000-8000-0000000000d7';
+		const childId = await newChild('期限七郎', family);
+		const reward = await seedReward(childId, '期限報酬', 10, family);
 		const old = Math.floor(Date.now() / 1000) - 40 * 24 * 60 * 60; // 40 日前
 		await redemptionRepo.insertRedemptionRequest(
 			{ childId, rewardId: reward.id, requestedAt: old },
-			FAMILY,
+			family,
 		);
-		expect(await redemptionRepo.hasPendingByReward(reward.id, FAMILY)).toBe(true);
+		expect(await redemptionRepo.hasPendingByReward(reward.id, family)).toBe(true);
 
-		const expired = await redemptionRepo.expireOldRedemptions(FAMILY);
+		const expired = await redemptionRepo.expireOldRedemptions(family);
 		expect(expired).toBe(1);
-		expect(await redemptionRepo.hasPendingByReward(reward.id, FAMILY)).toBe(false);
-		const rows = await redemptionRepo.findRedemptionRequestsByChild(childId, FAMILY);
+		expect(await redemptionRepo.hasPendingByReward(reward.id, family)).toBe(false);
+		const rows = await redemptionRepo.findRedemptionRequestsByChild(childId, family);
 		expect(rows[0]?.status).toBe('expired');
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

develop の unit test が 2026-07-10 以降、日付依存で決定的に fail するようになり、全 PR と develop→main 統合 (#3605) の CI を止めていた。この time-bomb を除去し、develop を release 品質で維持する。

## 関連 Issue

#3424 (EPIC DSQL 移管、当該テストの実装元)

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| RR7 が日付非依存で pass する | `npx vitest run tests/unit/db/dsql-reward-message-repos.test.ts` | PASS (22/22) | ローカル実行ログ |
| 他 case の pending 残置から独立 | 専用 family (d7) 隔離で tenant 全体走査を分離 | PASS | diff |
| assertion を弱めない (ADR-0006) | `expect(expired).toBe(1)` 等を不変で維持 | PASS | diff |

## 変更タイプ

- [x] バグ修正 (test isolation / time-bomb)
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `tests/unit/db/dsql-reward-message-repos.test.ts` の [RR7] のみ。テスト隔離の family を FAMILY から専用 tenant (d7) へ変更。プロダクションコードの変更なし。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/dsql-reward-message-repos.test.ts` = 22/22 PASS
- [x] `npx biome check <changed>` = clean
- [x] assertion 不変 (ADR-0006 準拠、件数 1 / status expired を維持)

## スクリーンショット / ビジュアルデモ

N/A — テストコードのみの変更で UI/画面への影響なし (`refactor:internal-no-doc-impact` ラベルで ss-embed gate 対象外)。

## コード品質セルフレビュー (#1481)

- 既存 [RR3] が tenant 全体 count のために専用 family (d3) を使う規約に倣い、tenant 全体 expire を行う [RR7] も専用 family (d7) へ揃えた。原因と対処をコメントで明記。

## 横展開・影響波及チェック

- 同ファイル内で tenant 全体走査を行うのは [RR7] (expire) と [RR3] (count) のみ。[RR3] は既に専用 family で隔離済。他 case は child/reward 単位の局所走査で共有 FAMILY を跨ぐ集計を持たないため影響なし。

## レビュー依頼事項・破壊的変更

破壊的変更なし。テスト隔離の修正のみ。

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 実装 + テストが 1 PR で完結
- [x] 変更ファイルの局所テスト PASS
- [x] biome clean
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
