### PR TITLE
fix(dsql): #3592 activity mastery repo の write-value guard + anchor 前提 cascade regression (①③)

### DIFF
--- a/src/lib/server/db/dsql/activity-mastery-repo.ts
+++ b/src/lib/server/db/dsql/activity-mastery-repo.ts
@@ -67,6 +67,16 @@ export function createDsqlActivityMasteryRepo<TTx extends SqlExecutor>(
 		},
 
 		async upsert(childId, activityId, totalCount, level, tenantId) {
+			// #3592 ①: CRUD 契約 (呼び出し側算出値を書く) の最小 write-value guard。
+			// service 層 (activity-log-service / record-activity-core) は count+1 / masteryLevelFor で
+			// 常に非負整数を算出するが、facade 直呼び等の不正値注入・監査証跡欠落に対する repo 層の
+			// 最終防衛線として非負整数を強制する (cutover 後に service validate 前提が崩れても不変)。
+			if (!Number.isInteger(totalCount) || totalCount < 0) {
+				throw new Error(`upsert: totalCount は非負整数 (got ${totalCount})`);
+			}
+			if (!Number.isInteger(level) || level < 0) {
+				throw new Error(`upsert: level は非負整数 (got ${level})`);
+			}
 			const result = await db.execute(sql`
 				INSERT INTO activity_mastery (family_id, child_id, activity_id, total_count, level)
 				VALUES (${tenantId}, ${childId}, ${activityId}, ${totalCount}, ${level})

--- a/tests/unit/db/dsql-activity-repos.test.ts
+++ b/tests/unit/db/dsql-activity-repos.test.ts
@@ -580,4 +580,22 @@ describe('DSQL activity-mastery-repo (PR-R3、実 schema PGlite)', () => {
 		expect(await masteryRepo.findAllByChild(otherChild, OTHER_FAMILY)).toEqual([]);
 		expect((await masteryRepo.findAllByChild(child, FAMILY)).length).toBe(2); // FAMILY 残存
 	});
+
+	// [M3 write-value guard] #3592 ①: CRUD 契約の repo 層最終防衛線。不正値は書込前に throw し、
+	// 行が作られない (監査証跡欠落を防ぐ) ことを検証する。M1/M2 が触らない専用 activity を使う。
+	it('[M3] upsert は totalCount / level の負値・非整数を拒否し行を書かない', async () => {
+		const actGuard = (
+			await activityRepo.insertActivity(activityInput(child, { name: 'mGuard' }), FAMILY)
+		).id;
+		await expect(masteryRepo.upsert(child, actGuard, -1, 1, FAMILY)).rejects.toThrow(/totalCount/);
+		await expect(masteryRepo.upsert(child, actGuard, 1, -1, FAMILY)).rejects.toThrow(/level/);
+		await expect(masteryRepo.upsert(child, actGuard, 1.5, 1, FAMILY)).rejects.toThrow(/totalCount/);
+		await expect(masteryRepo.upsert(child, actGuard, 1, 2.5, FAMILY)).rejects.toThrow(/level/);
+		// 拒否された upsert は行を作らない。
+		expect(await masteryRepo.findByChildAndActivity(child, actGuard, FAMILY)).toBeUndefined();
+		// 境界: 0 は許容 (非負整数)。
+		const zero = await masteryRepo.upsert(child, actGuard, 0, 0, FAMILY);
+		expect(zero.totalCount).toBe(0);
+		expect(zero.level).toBe(0);
+	});
 });

--- a/tests/unit/db/dsql-child-repo.test.ts
+++ b/tests/unit/db/dsql-child-repo.test.ts
@@ -124,6 +124,18 @@ describe('DSQL child-repo (PR-R1、実 schema PGlite)', () => {
 				INSERT INTO activity_logs (family_id, child_id, activity_id, points, recorded_date, recorded_at)
 				VALUES (${FAMILY}, ${childId}, ${activityId}, 10, '2026-07-04', now())
 			`);
+			// #3592 ③: pin 直列化 anchor は「pin 対象 activity の child が存在する」前提で成立する。
+			// DSQL は FK 非対応のため orphan pref/mastery が残ると anchor が silent no-op になり
+			// write-skew を招く。deleteChild が preferences/mastery を同 txn で cascade 除去し orphan を
+			// 生じさせないことを [C7] で検証し、cascade からの脱落を regression として捕捉する。
+			await t.db.execute(sql`
+				INSERT INTO child_activity_preferences (family_id, child_id, activity_id, is_pinned, pin_order)
+				VALUES (${FAMILY}, ${childId}, ${activityId}, true, 1)
+			`);
+			await t.db.execute(sql`
+				INSERT INTO activity_mastery (family_id, child_id, activity_id, total_count, level)
+				VALUES (${FAMILY}, ${childId}, ${activityId}, 3, 1)
+			`);
 			await t.db.execute(sql`
 				INSERT INTO point_ledger (family_id, child_id, amount, type, recorded_date)
 				VALUES (${FAMILY}, ${childId}, 10, 'activity', '2026-07-04')
@@ -155,7 +167,14 @@ describe('DSQL child-repo (PR-R1、実 schema PGlite)', () => {
 					)) as { rows: { c: unknown }[] }
 				).rows[0]?.c,
 			);
-		for (const table of ['child_activities', 'activity_logs', 'point_ledger', 'stamp_cards']) {
+		for (const table of [
+			'child_activities',
+			'activity_logs',
+			'point_ledger',
+			'stamp_cards',
+			'child_activity_preferences', // #3592 ③ anchor 前提保証
+			'activity_mastery', // #3592 ③ anchor 前提保証
+		]) {
 			expect(await countFor(table, String(target.id)), `${table} 消滅`).toBe(0);
 			expect(await countFor(table, String(sibling.id)), `${table} 兄弟 survive`).toBe(1);
 		}


### PR DESCRIPTION
## 顧客価値・目的

DSQL cutover 後も活動習熟度データの整合性を守るため、mastery repo の CRUD 契約に repo 層の write-value 防衛線を敷き、pin 直列化 anchor の前提（orphan 不在）を regression で固定する。データ破損・監査証跡欠落を書込前に遮断し、cutover の信頼性を上げる。

## 関連 Issue

#3592 (DSQL activity repo hardening、#3590 派生)。本 PR は ① / ③ のコード部分を消化。② (本番 DSQL での真の並行検証) は実クラスタ前提のため #3592 に保持し M5 で扱う。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| ① upsert が非負整数を強制し不正値で行を作らない | `[M3]` unit test | PASS | tests/unit/db/dsql-activity-repos.test.ts |
| ① 境界 0 は許容 | `[M3]` unit test | PASS | 同上 |
| ③ deleteChild が preferences/mastery を cascade 除去 (anchor 前提保証) | `[C7]` unit test 拡張 | PASS | tests/unit/db/dsql-child-repo.test.ts |
| 既存挙動不変 | 2 ファイル 30/30 PASS | PASS | ローカル実行ログ |

## 変更タイプ

- [x] バグ修正 / hardening (防御的 assertion + regression)
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dsql/activity-mastery-repo.ts`: `upsert` に totalCount/level 非負整数 guard を追加 (throw)。
- `tests/unit/db/dsql-activity-repos.test.ts`: `[M3]` guard test 追加。
- `tests/unit/db/dsql-child-repo.test.ts`: `[C7]` に preferences/mastery cascade 検証を追加。
- 正常系呼び出し (activity-log-service = count+1/masteryLevelFor、record-activity-core = inline) は常に非負整数のため挙動不変。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/dsql-activity-repos.test.ts tests/unit/db/dsql-child-repo.test.ts` = 30/30 PASS
- [x] `npx biome check <changed>` = clean
- [x] guard は書込前検証で行を作らない ([M3] で行非生成を assert)

## スクリーンショット / ビジュアルデモ

N/A — server 側 repo / test のみで UI 影響なし (`refactor:internal-no-doc-impact` ラベルで ss-embed gate 対象外)。

## コード品質セルフレビュー (#1481)

- guard は既存 dsql repo の `throw new Error('<method>: <reason>')` idiom に整合。
- ③ は DSQL が FK 非対応である事実を踏まえ、FK の代替として「cascade でのみ orphan を防ぐ」構造をテストで固定。コメントで anchor との因果を明記。

## 横展開・影響波及チェック

- mastery `upsert` の facade 呼び出し元は activity-log-service のみ (常に非負整数)。DSQL record 経路は inline upsert で本 guard を経由しないが、txn 内で count+1 / masteryLevelFor 算出のため常に有効値。
- deleteChild の cascade 対象表 (CHILD_TABLES) に preferences/mastery が含まれることを [C7] が固定。将来 cascade から脱落すれば CI が落ちる。

## レビュー依頼事項・破壊的変更

破壊的変更なし。① guard は不正値のみ throw し正常系に影響しない。

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 実装 + テストが 1 PR で完結
- [x] 変更ファイルの局所テスト PASS
- [x] biome clean
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
