### PR TITLE
fix(dsql): #3593 point ledger retention 削除を DB 側 count 集約に置換 (scale/memory 安全化、①)

### DIFF
--- a/src/lib/server/db/dsql/point-repo.ts
+++ b/src/lib/server/db/dsql/point-repo.ts
@@ -123,14 +123,20 @@ export function createDsqlPointRepo<TTx extends SqlExecutor>(
 			// authoritative な残高であり、過去明細を消しても残高は変わらない (#729「ポイントは
 			// 消えず過去明細だけが消える」)。pruning 後は SUM(ledger) < total_point となり得るが、
 			// 本番正しさは単一プリミティブ + 同一 txn `+= amount` で構造担保する (fitness#14 再定義)。
-			// SqlExecutor は rowCount 非公開のため RETURNING で削除件数を rows で数える。
+			// #3593 ①: SqlExecutor は rowCount 非公開だが、`RETURNING ledger_id` を JS 側で数えると
+			// 長期利用 child の大量明細で全 PK を client に materialize する scale/memory リスクがある。
+			// CTE で削除行を DB 側 count(*) 集約し、返るのは単一スカラのみにする (carryover 廃止済 =
+			// reset-plan 決定#4 のため SUM は不要、件数のみ。sqlite 版 `result.changes` と同じ count 契約)。
 			const deleted = await db.execute(sql`
-				DELETE FROM point_ledger
-				WHERE family_id = ${tenantId} AND child_id = ${childId}
-					AND created_at < ${cutoffDate}::timestamptz
-				RETURNING ledger_id
+				WITH deleted AS (
+					DELETE FROM point_ledger
+					WHERE family_id = ${tenantId} AND child_id = ${childId}
+						AND created_at < ${cutoffDate}::timestamptz
+					RETURNING 1
+				)
+				SELECT count(*)::int AS c FROM deleted
 			`);
-			return deleted.rows.length;
+			return Number((deleted.rows[0] as { c: number }).c);
 		},
 	};
 }


### PR DESCRIPTION
## 顧客価値・目的

retention cleanup (保持期間外明細の削除) を、長期利用の子供 (大量明細) でも memory 安全に実行できるようにする。削除件数を DB 側で集約し、削除全行の PK を client に載せる scale リスクを除去して cutover の信頼性を上げる。

## 関連 Issue

#3593 (DSQL point repo hardening、#3591 派生)。本 PR は ① のコード部分を消化。②(retention cutoff TZ 整合=caller/orchestration) / ③(deleteByTenantId 後の PII 物理消去=account-deletion 経路) / ④(archived 加点 service guard / carryover description SSOT / market_benchmarks authz) は上位層・cutover 領域のため #3593 に保持。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| ① 削除件数を DB 側 count(*) で集約し全 PK を materialize しない | CTE (`WITH deleted AS (DELETE...RETURNING 1) SELECT count(*)`) へ置換 | PASS | src/lib/server/db/dsql/point-repo.ts diff |
| count 契約不変 (削除 2 件 → 2) | `[P9]` unit test | PASS | tests/unit/db/dsql-point-status-repos.test.ts |
| 0 件時 0 返却 | `[P9b]` unit test | PASS | 同上 |
| total_point 不触 (carryover 廃止) 維持 | `[P9]` (残高 22 不変) | PASS | 同上 |

## 変更タイプ

- [x] リファクタリング / hardening (memory-safe な集約置換、挙動不変)
- [ ] バグ修正
- [ ] 新機能
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dsql/point-repo.ts`: `deletePointLedgerBeforeDate` の `RETURNING ledger_id` + `.rows.length` を CTE DB 側 count 集約へ置換。戻り値 (削除件数 number) の契約は不変。
- caller (retention-cleanup-service) は削除件数を集計に使うのみで影響なし。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/dsql-point-status-repos.test.ts` = 20/20 PASS
- [x] `npx biome check <changed>` = clean
- [x] count 契約は既存 `[P9]`/`[P9b]` assertion で不変を保証 (ADR-0006)

## スクリーンショット / ビジュアルデモ

N/A — server 側 repo のみで UI 影響なし (`refactor:internal-no-doc-impact` ラベルで ss-embed gate 対象外)。

## コード品質セルフレビュー (#1481)

- carryover は reset-plan 決定#4 で廃止済のため SUM ではなく件数集約で足りる。sqlite 版 `result.changes` と同じ count 契約に揃え、backend 間の意味的 parity を保つ。

## 横展開・影響波及チェック

- 同型の `RETURNING <pk>` + `.rows.length` パターンが他の retention 削除 (deleteActivityLogsBeforeDate / deleteLoginBonusesBeforeDate) にも存在するかは #3593 に横展開候補として記録し、本 PR は point repo に限定 (scope 明確化)。

## レビュー依頼事項・破壊的変更

破壊的変更なし。戻り値・削除挙動は不変で、内部集約方式のみ変更。

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 実装 + テストが 1 PR で完結 (既存 test が count 契約を担保)
- [x] 変更ファイルの局所テスト PASS
- [x] biome clean
- [x] base = develop (#3622 込み)

## QM レビュー結果

QM レビュー待ち。
