### PR TITLE
fix(dsql): #3603 assignTemplateToChildren に children JOIN を足し orphan assignment を構造排除 (①)

### DIFF
--- a/src/lib/server/db/dsql/checklist-repo.ts
+++ b/src/lib/server/db/dsql/checklist-repo.ts
@@ -319,13 +319,18 @@ export function createDsqlChecklistRepo<TTx extends SqlExecutor>(
 			// 配信を all-or-nothing に (単一 txn)。#3562 ③ parity: template 所有を INSERT ... SELECT で
 			// 強制し、他 family template / 存在しない template への orphan 配信を構造排除。既配信は
 			// PK ON CONFLICT DO NOTHING で skip し、RETURNING で「実際に追加された」assignment のみ返す。
+			// #3603 ①: DSQL は FK 非対応のため child_id をリテラル無検証で挿入すると同 family 内でも
+			// 存在しない child への orphan assignment を許容する。children を JOIN し child 実在を
+			// 構造強制する (template と child が両方存在するときのみ 1 行 emit)。存在しない child は
+			// JOIN で 0 行 → 挿入されず inserted に載らない (findTemplatesByChild で返らない無害データも作らない)。
 			return runner.runInTransaction(async (tx) => {
 				const inserted: ChecklistTemplateAssignment[] = [];
 				for (const childId of childIds) {
 					const result = await tx.execute(sql`
 						INSERT INTO checklist_template_assignments (family_id, template_id, child_id)
-						SELECT t.family_id, t.template_id, ${String(childId)}
+						SELECT t.family_id, t.template_id, c.child_id
 						FROM checklist_templates t
+						JOIN children c ON c.family_id = t.family_id AND c.child_id = ${String(childId)}
 						WHERE t.family_id = ${tenantId} AND t.template_id = ${templateId}
 						ON CONFLICT (family_id, template_id, child_id) DO NOTHING
 						RETURNING ${ASSIGNMENT_COLUMNS}

--- a/tests/unit/db/dsql-checklist-repo.test.ts
+++ b/tests/unit/db/dsql-checklist-repo.test.ts
@@ -42,7 +42,7 @@
 
 import { sql } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import type { ChildId } from '../../../src/lib/domain/ids';
+import { asChildId, type ChildId } from '../../../src/lib/domain/ids';
 import { createDsqlChecklistRepo } from '../../../src/lib/server/db/dsql/checklist-repo';
 import { createDsqlChildRepo } from '../../../src/lib/server/db/dsql/child-repo';
 import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
@@ -224,6 +224,25 @@ describe('DSQL checklist-repo (PR-R7、実 schema PGlite、family master + per-c
 
 		// 空配列は no-op
 		expect(await repo.assignTemplateToChildren(tpl.id, [], FAMILY)).toEqual([]);
+	});
+
+	// #3603 ①: DSQL は FK 非対応。存在しない child_id への orphan assignment を children JOIN で
+	// 構造排除する (同 family でも children に無い child は 0 行 emit で挿入されない)。
+	it('[A1b] assignTemplateToChildren: 存在しない child は JOIN で構造排除 (orphan を作らない)', async () => {
+		const real = await newChild('実在配信');
+		const ghost = asChildId('00000000-0000-4000-8000-0000009999e1'); // children 未登録
+		const tpl = await repo.insertTemplate({ name: 'ゴースト配信' }, FAMILY);
+
+		const result = await repo.assignTemplateToChildren(tpl.id, [ghost, real], FAMILY);
+		// 実在 child のみ配信され、ghost は載らない
+		expect(result.map((r) => r.childId)).toEqual([real]);
+		// ghost の orphan assignment 行は物理的に存在しない
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM checklist_template_assignments
+					WHERE family_id = ${FAMILY} AND template_id = ${tpl.id} AND child_id = ${String(ghost)}`,
+			),
+		).toBe(0);
 	});
 
 	it('[A2] findAssignmentsByTemplate / findAssignmentsByChild + §P9', async () => {


### PR DESCRIPTION
## 顧客価値・目的

チェックリスト配信 (template → child assignment) が、存在しない子供への orphan データを構造的に作らないようにする。DSQL は FK 非対応のため、children JOIN で child 実在を強制し、cutover 後のデータ整合を守る。

## 関連 Issue

#3603 (DSQL IChecklistRepo hardening、#3602 派生)。本 PR は ① のコード部分を消化。②(upsertLog item マージ粒度) は cutover 後の実利用 UX 評価、insertOverride / insertTemplateItem の caller 供給 id は cutover 結線での確認事項のため #3603 に保持。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| ① 存在しない child への orphan assignment を構造排除 | children JOIN 追加 + `[A1b]` unit test | PASS | tests/unit/db/dsql-checklist-repo.test.ts |
| ① 実在 child のみ配信される (混在時) | `[A1b]` (ghost + real → real のみ) | PASS | 同上 |
| 既存配信挙動不変 (only-new / skip / tenant 境界) | `[A1]` 既存 test | PASS | 同上 (23/23) |

## 変更タイプ

- [x] バグ修正 / hardening (orphan 構造排除)
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dsql/checklist-repo.ts`: `assignTemplateToChildren` の INSERT...SELECT に `JOIN children c ON c.family_id = t.family_id AND c.child_id = <id>` を追加。SELECT は `c.child_id` を emit。
- `tests/unit/db/dsql-checklist-repo.test.ts`: `[A1b]` orphan 排除 test 追加。
- 正常系 caller は実在 childIds を供給するため挙動不変 (存在しない child のみ silently skip、findTemplatesByChild で元々返らない)。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/dsql-checklist-repo.test.ts` = 23/23 PASS
- [x] `npx biome check <changed>` = clean
- [x] 既存 `[A1]` の only-new / skip / tenant 境界 assertion 不変 (ADR-0006)

## スクリーンショット / ビジュアルデモ

N/A — server 側 repo のみで UI 影響なし (`refactor:internal-no-doc-impact` ラベルで ss-embed gate 対象外)。

## コード品質セルフレビュー (#1481)

- template 所有検証 (既存 INSERT...SELECT) と同じ「構造で orphan を排除」方針を child にも適用。DSQL が FK 非対応である事実を JOIN で補い、レビューコメントで anchor/理由を明記。

## 横展開・影響波及チェック

- 同 repo の `insertOverride` / `insertTemplateItem` も caller 供給 id を family タグのみで受理するが、#3603 が cutover 結線での確認事項として扱うため本 PR は assignTemplateToChildren に限定。
- 同型の「child 実在を JOIN/構造で保証」は activity 系の deleteChild cascade (#3592 ③ で検証済) と方針一貫。

## レビュー依頼事項・破壊的変更

破壊的変更なし。存在しない child への配信は元々無害データを作るだけで、それを作らなくする方向の変更。正常系に影響なし。

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 実装 + テストが 1 PR で完結
- [x] 変更ファイルの局所テスト PASS
- [x] biome clean
- [x] base = develop (#3622 込み)

## QM レビュー結果

QM レビュー待ち。
