### PR TITLE
fix(dsql): #3625 mutation 件数取得を DB 側 count(*) 集約に統一 + regression guard (same-class-N sweep)

### DIFF
--- a/src/lib/server/db/dsql/activity-repo.ts
+++ b/src/lib/server/db/dsql/activity-repo.ts
@@ -574,13 +574,17 @@ export function createDsqlActivityRepo<TTx extends SqlExecutor>(
 
 		async deleteActivityLogsBeforeDate(childId, cutoffDate, tenantId) {
 			// strict less than: cutoffDate 当日は削除対象に含まない (interface 契約)。
+			// #3625: 削除件数は CTE で DB 側 count 集約し、削除全行を client に materialize しない。
 			const result = await db.execute(sql`
-				DELETE FROM activity_logs
-				WHERE family_id = ${tenantId} AND child_id = ${childId}
-					AND recorded_date < ${cutoffDate}
-				RETURNING log_id
+				WITH deleted AS (
+					DELETE FROM activity_logs
+					WHERE family_id = ${tenantId} AND child_id = ${childId}
+						AND recorded_date < ${cutoffDate}
+					RETURNING 1
+				)
+				SELECT count(*)::int AS c FROM deleted
 			`);
-			return result.rows.length;
+			return Number((result.rows[0] as { c: number }).c);
 		},
 	};
 }

--- a/src/lib/server/db/dsql/child-challenge-repo.ts
+++ b/src/lib/server/db/dsql/child-challenge-repo.ts
@@ -247,15 +247,20 @@ export function createDsqlChildChallengeRepo(db: SqlExecutor): IChildChallengeRe
 		},
 
 		async claimReward(id, tenantId) {
-			// #3333: 条件付き flip。実際に flip した行数を RETURNING で数えて返す (TOCTOU 防止)。
+			// #3333: 条件付き flip。実際に flip した行数を返す (TOCTOU 防止)。
+			// #3625: 件数は CTE で DB 側 count 集約し idiom を統一する (affected は高々 1 行だが
+			// dsql 全体の「mutation 件数は CTE count」規律に揃え、guard の false-positive を避ける)。
 			const result = await db.execute(sql`
-				UPDATE child_challenges
-				SET reward_claimed = true, reward_claimed_at = now(), updated_at = now()
-				WHERE family_id = ${tenantId} AND challenge_id = ${id}
-					AND reward_claimed = false AND completed = true
-				RETURNING challenge_id
+				WITH updated AS (
+					UPDATE child_challenges
+					SET reward_claimed = true, reward_claimed_at = now(), updated_at = now()
+					WHERE family_id = ${tenantId} AND challenge_id = ${id}
+						AND reward_claimed = false AND completed = true
+					RETURNING 1
+				)
+				SELECT count(*)::int AS c FROM updated
 			`);
-			return result.rows.length;
+			return Number((result.rows[0] as { c: number }).c);
 		},
 
 		async update(id, input: UpdateChildChallengeInput, tenantId) {

--- a/src/lib/server/db/dsql/child-repo.ts
+++ b/src/lib/server/db/dsql/child-repo.ts
@@ -200,23 +200,34 @@ export function createDsqlChildRepo<TTx extends SqlExecutor>(
 			// 不変条件 (== SUM(point_ledger)) を保つため同一 txn で 0 リセットする。
 			// fitness#7 (tx-bound await のみ許可) 準拠のため helper 閉包を挟まず inline に await する。
 			return runner.runInTransaction(async (tx) => {
-				const logs = await tx.execute(
-					sql`DELETE FROM activity_logs WHERE family_id = ${tenantId} AND child_id = ${id} RETURNING 1`,
-				);
-				const ledger = await tx.execute(
-					sql`DELETE FROM point_ledger WHERE family_id = ${tenantId} AND child_id = ${id} RETURNING 1`,
-				);
-				const bonuses = await tx.execute(
-					sql`DELETE FROM login_bonuses WHERE family_id = ${tenantId} AND child_id = ${id} RETURNING 1`,
-				);
+				// #3625: 削除件数は CTE で DB 側 count 集約し、削除全行を client に materialize しない
+				// (progress reset は長期 child で大量明細を削除しうる)。fitness#7: tx.execute 直呼び。
+				const logs = await tx.execute(sql`
+					WITH deleted AS (
+						DELETE FROM activity_logs WHERE family_id = ${tenantId} AND child_id = ${id} RETURNING 1
+					)
+					SELECT count(*)::int AS c FROM deleted
+				`);
+				const ledger = await tx.execute(sql`
+					WITH deleted AS (
+						DELETE FROM point_ledger WHERE family_id = ${tenantId} AND child_id = ${id} RETURNING 1
+					)
+					SELECT count(*)::int AS c FROM deleted
+				`);
+				const bonuses = await tx.execute(sql`
+					WITH deleted AS (
+						DELETE FROM login_bonuses WHERE family_id = ${tenantId} AND child_id = ${id} RETURNING 1
+					)
+					SELECT count(*)::int AS c FROM deleted
+				`);
 				await tx.execute(sql`
 					UPDATE children SET total_point = 0, updated_at = now()
 					WHERE family_id = ${tenantId} AND child_id = ${id}
 				`);
 				return {
-					activityLogs: logs.rows.length,
-					pointLedger: ledger.rows.length,
-					loginBonuses: bonuses.rows.length,
+					activityLogs: Number((logs.rows[0] as { c: number }).c),
+					pointLedger: Number((ledger.rows[0] as { c: number }).c),
+					loginBonuses: Number((bonuses.rows[0] as { c: number }).c),
 					childAchievements: 0,
 					pointBalance: 0,
 				};

--- a/src/lib/server/db/dsql/cloud-export-repo.ts
+++ b/src/lib/server/db/dsql/cloud-export-repo.ts
@@ -170,11 +170,15 @@ export function createDsqlCloudExportRepo(db: SqlExecutor): ICloudExportRepo {
 		},
 
 		async deleteExpired(now) {
+			// #3625: 削除件数は CTE で DB 側 count 集約し、削除全行を client に materialize しない。
 			const result = await db.execute(sql`
-				DELETE FROM cloud_exports WHERE expires_at < ${now}::timestamptz
-				RETURNING export_id
+				WITH deleted AS (
+					DELETE FROM cloud_exports WHERE expires_at < ${now}::timestamptz
+					RETURNING 1
+				)
+				SELECT count(*)::int AS c FROM deleted
 			`);
-			return result.rows.length;
+			return Number((result.rows[0] as { c: number }).c);
 		},
 
 		async countByTenant(tenantId) {

--- a/src/lib/server/db/dsql/login-bonus-repo.ts
+++ b/src/lib/server/db/dsql/login-bonus-repo.ts
@@ -118,12 +118,16 @@ export function createDsqlLoginBonusRepo(db: SqlExecutor): ILoginBonusRepo {
 
 		async deleteLoginBonusesBeforeDate(childId, cutoffDate, tenantId) {
 			// #717/#729: login_date < cutoffDate (strict less than、当日は残す)。
+			// #3625: 削除件数は CTE で DB 側 count 集約し、削除全行を client に materialize しない。
 			const result = await db.execute(sql`
-				DELETE FROM login_bonuses
-				WHERE family_id = ${tenantId} AND child_id = ${childId} AND login_date < ${cutoffDate}
-				RETURNING login_date
+				WITH deleted AS (
+					DELETE FROM login_bonuses
+					WHERE family_id = ${tenantId} AND child_id = ${childId} AND login_date < ${cutoffDate}
+					RETURNING 1
+				)
+				SELECT count(*)::int AS c FROM deleted
 			`);
-			return result.rows.length;
+			return Number((result.rows[0] as { c: number }).c);
 		},
 	};
 }

--- a/src/lib/server/db/dsql/reward-redemption-repo.ts
+++ b/src/lib/server/db/dsql/reward-redemption-repo.ts
@@ -249,13 +249,18 @@ export function createDsqlRewardRedemptionRepo(db: SqlExecutor): IRewardRedempti
 
 		async expireOldRedemptions(tenantId) {
 			// 30 日超 pending → expired。timestamptz 比較で now() - interval を使う (§11.3)。
+			// #3625: affected 件数は CTE で DB 側 count 集約し、更新全行を client に materialize しない
+			// (tenant 全体走査で大量 pending を expire しうる)。
 			const result = await db.execute(sql`
-				UPDATE reward_redemption_requests SET status = 'expired'
-				WHERE family_id = ${tenantId} AND status = 'pending_parent_approval'
-					AND requested_at < now() - interval '30 days'
-				RETURNING redemption_id
+				WITH updated AS (
+					UPDATE reward_redemption_requests SET status = 'expired'
+					WHERE family_id = ${tenantId} AND status = 'pending_parent_approval'
+						AND requested_at < now() - interval '30 days'
+					RETURNING 1
+				)
+				SELECT count(*)::int AS c FROM updated
 			`);
-			return result.rows.length;
+			return Number((result.rows[0] as { c: number }).c);
 		},
 
 		async hasPendingByReward(rewardId, tenantId) {

--- a/src/lib/server/db/dsql/stamp-card-repo.ts
+++ b/src/lib/server/db/dsql/stamp-card-repo.ts
@@ -227,15 +227,20 @@ export function createDsqlStampCardRepo<TTx extends SqlExecutor>(
 
 		async updateCardStatusIfCollecting(childId, cardId, input, tenantId) {
 			// status='collecting' の行のみ遷移 (冪等ガード)。affected 行数を返す (sqlite parity)。
+			// #3625: 件数は CTE で DB 側 count 集約し idiom を統一する (affected は高々 1 行だが
+			// dsql 全体の「mutation 件数は CTE count」規律に揃え、guard の false-positive を避ける)。
 			const result = await db.execute(sql`
-				UPDATE stamp_cards
-				SET status = ${input.status}, redeemed_points = ${input.redeemedPoints},
-					redeemed_at = ${input.redeemedAt}, updated_at = ${input.updatedAt}::timestamptz
-				WHERE family_id = ${tenantId} AND child_id = ${childId} AND card_id = ${cardId}
-					AND status = 'collecting'
-				RETURNING card_id
+				WITH updated AS (
+					UPDATE stamp_cards
+					SET status = ${input.status}, redeemed_points = ${input.redeemedPoints},
+						redeemed_at = ${input.redeemedAt}, updated_at = ${input.updatedAt}::timestamptz
+					WHERE family_id = ${tenantId} AND child_id = ${childId} AND card_id = ${cardId}
+						AND status = 'collecting'
+					RETURNING 1
+				)
+				SELECT count(*)::int AS c FROM updated
 			`);
-			return result.rows.length;
+			return Number((result.rows[0] as { c: number }).c);
 		},
 
 		async deleteByTenantId(tenantId) {

--- a/src/lib/server/db/dsql/webhook-event-repo.ts
+++ b/src/lib/server/db/dsql/webhook-event-repo.ts
@@ -81,11 +81,16 @@ export function createDsqlWebhookEventRepo(db: SqlExecutor): IWebhookEventRepo {
 		},
 
 		async deleteOlderThan(cutoffIso) {
+			// #3625: 削除件数は CTE で DB 側 count 集約し、削除全行を client に materialize しない
+			// (retention cron で大量 webhook event を削除しうる)。
 			const result = await db.execute(sql`
-				DELETE FROM stripe_webhook_events WHERE processed_at < ${cutoffIso}::timestamptz
-				RETURNING event_id
+				WITH deleted AS (
+					DELETE FROM stripe_webhook_events WHERE processed_at < ${cutoffIso}::timestamptz
+					RETURNING 1
+				)
+				SELECT count(*)::int AS c FROM deleted
 			`);
-			return result.rows.length;
+			return Number((result.rows[0] as { c: number }).c);
 		},
 	};
 }

--- a/tests/unit/architecture/dsql-mutation-count-cte-fitness.test.ts
+++ b/tests/unit/architecture/dsql-mutation-count-cte-fitness.test.ts
@@ -1,0 +1,95 @@
+// tests/unit/architecture/dsql-mutation-count-cte-fitness.test.ts
+// EPIC #3424 / #3625 / 設計 SSOT: ADR-0061 (same-class-N→guard) / ADR-0010 (Pre-PMF)
+//
+// **mutation 件数取得は DB 側 count(*) 集約に固定する (regression guard)**:
+//   DSQL の SqlExecutor は rowCount を公開しないため、DELETE/UPDATE の affected 件数を
+//   `RETURNING <col>` + JS `.rows.length` で数える実装が横展開して残存していた (#3625)。
+//   長期利用 child の大量明細 retention / tenant 全体 expire 等で削除・更新全行の PK を client に
+//   materialize する scale/memory リスクがある。正しい idiom は
+//     WITH deleted AS (DELETE/UPDATE ... RETURNING 1) SELECT count(*)::int AS c FROM deleted
+//   で DB 側集約し、返るのを単一スカラにすること。
+//
+//   本 fitness は「dsql repo 内で `.rows.length` を **件数値** として使う (= 比較演算子が続かない)」
+//   pattern を CI hard-fail で禁止し、count は CTE 集約へ強制する。存在チェック
+//   (`.rows.length === 0` / `> 0` 等、比較演算子が続く) は正当なため許容する。
+//   ADR-0061 の「same-class-N→guard」機械化 (#3625 で 8 サイトを sweep 後の再混入防止)。
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const DSQL_DIR = resolve(REPO_ROOT, 'src/lib/server/db/dsql');
+
+/** `.rows.length` の直後に比較演算子が続けば存在チェック (正当)、続かなければ件数値使用 (禁止)。 */
+const COMPARISON_AFTER = /^\s*(===|!==|==|!=|>=|<=|>|<)/;
+const ROWS_LENGTH = /\.rows\.length/g;
+
+interface Violation {
+	file: string;
+	line: number;
+	snippet: string;
+}
+
+/** source 内の「件数値として使う `.rows.length`」を検出する (存在チェックは除外)。 */
+function findBareRowsLengthCounts(source: string, file: string): Violation[] {
+	const found: Violation[] = [];
+	let m = ROWS_LENGTH.exec(source);
+	while (m) {
+		const after = source.slice(m.index + m[0].length);
+		if (!COMPARISON_AFTER.test(after)) {
+			const line = source.slice(0, m.index).split('\n').length;
+			const lineStart = source.lastIndexOf('\n', m.index) + 1;
+			const lineEnd = source.indexOf('\n', m.index);
+			found.push({
+				file,
+				line,
+				snippet: source.slice(lineStart, lineEnd === -1 ? undefined : lineEnd).trim(),
+			});
+		}
+		m = ROWS_LENGTH.exec(source);
+	}
+	return found;
+}
+
+function listDsqlSourceFiles(): string[] {
+	if (!existsSync(DSQL_DIR)) return [];
+	return readdirSync(DSQL_DIR)
+		.filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
+		.map((f) => resolve(DSQL_DIR, f));
+}
+
+describe('DSQL mutation 件数は DB 側 count(*) 集約に固定 (#3625 same-class-N→guard)', () => {
+	const files = listDsqlSourceFiles();
+
+	it('[armed] dsql module が実在する (armed-before-use)', () => {
+		expect(files.length).toBeGreaterThan(20);
+	});
+
+	it('[fixture] 件数値としての .rows.length を検出できる (非トートロジー証明)', () => {
+		const bad = findBareRowsLengthCounts(
+			['const r = await db.execute(sql`DELETE ...`);', 'return r.rows.length;'].join('\n'),
+			'fixture-repo.ts',
+		);
+		expect(bad).toHaveLength(1);
+		// 存在チェックは誤検出しない
+		const ok = findBareRowsLengthCounts('if (r.rows.length === 0) return;', 'fixture-repo.ts');
+		expect(ok).toHaveLength(0);
+	});
+
+	it('[main] dsql repo は .rows.length を件数値に使わない (count は CTE 集約へ)', () => {
+		const violations = files.flatMap((f) =>
+			findBareRowsLengthCounts(readFileSync(f, 'utf-8'), basename(f)),
+		);
+		expect(
+			violations,
+			[
+				'.rows.length を件数値として使う実装を検出 (#3625: DELETE/UPDATE 全行を client に materialize)。',
+				'affected 件数は CTE で DB 側集約すること: WITH x AS (DELETE/UPDATE ... RETURNING 1) SELECT count(*)::int AS c FROM x',
+				'(存在チェック `.rows.length === 0` / `> 0` は許容):',
+				...violations.map((v) => `  ${v.file}:${v.line}  ${v.snippet}`),
+			].join('\n'),
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

retention cron / tenant 全体 expire / progress reset など「削除・更新した件数を返す」全経路を、大量行でも memory 安全に実行する。affected 件数を DB 側 count(*) 集約に統一し、全行を client に materialize する scale リスクを dsql backend 全体から除去。ADR-0061 same-class-N→guard で再混入も機械防止する。

## 関連 Issue

#3625 (#3593 ① の横展開 sweep + guard、ADR-0061)。#3593 ① (point-repo) は #3624 で merge 済み、本 PR は残り同型サイトを sweep + guard 化する。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| ① retention/expiry unbounded 5 サイトを CTE DB 側 count に統一 | 各 repo test の件数 assertion | PASS | dsql-reward-message / family-satellite / activity-log / child-repo / webhook-event test |
| ① bounded 2 サイト (child-challenge/stamp-card) も idiom 統一 | dsql-eval-battle-challenge / stamp-mission test | PASS | 同上 |
| ② `.rows.length` 件数値使用の再混入を CI hard-fail | 新 fitness `dsql-mutation-count-cte-fitness.test.ts` (armed + fixture + main) | PASS | tests/unit/architecture/ |
| 件数契約不変 (存在チェックは許容) | 全 affected repo test 緑 | PASS | ローカル実行ログ |

## 変更タイプ

- [x] リファクタリング / hardening (memory-safe な集約統一、挙動不変)
- [x] regression guard 追加 (fitness function)
- [ ] バグ修正
- [ ] 新機能

## 影響範囲・変更コンポーネント

- sweep 8 サイト (戻り値 number 契約不変): `activity-repo.deleteActivityLogsBeforeDate` / `login-bonus-repo.deleteLoginBonusesBeforeDate` / `cloud-export-repo.deleteExpired` / `reward-redemption-repo.expireOldRedemptions` / `webhook-event-repo.deleteOlderThan` / `child-repo.resetChildProgressData` (×3) / `child-challenge-repo.claimReward` / `stamp-card-repo.updateCardStatusIfCollecting`。
- 新規 guard: `tests/unit/architecture/dsql-mutation-count-cte-fitness.test.ts`。
- caller は件数を集計/判定に使うのみで挙動不変。

## テスト & 安全装置セルフチェック

- [x] 各 affected repo の件数 assertion test 緑 (dsql-reward-message / family-satellite / activity-log / child-repo / webhook-event / eval-battle-challenge / stamp-mission、計 100+ tests)
- [x] 新 guard `dsql-mutation-count-cte-fitness` = 3/3 PASS (fixture で非トートロジー証明)
- [x] `npx biome check <changed>` = clean
- [x] 件数契約不変 (ADR-0006、CTE count は同値)

## スクリーンショット / ビジュアルデモ

N/A — server 側 repo + fitness test のみで UI 影響なし (`refactor:internal-no-doc-impact` ラベルで ss-embed gate 対象外)。

## コード品質セルフレビュー (#1481)

- 全 mutation 件数取得を単一 idiom (`WITH x AS (... RETURNING 1) SELECT count(*)`) に揃え、guard で固定。sqlite 版 `result.changes` と同じ count 契約に整合。
- guard は存在チェック (`.rows.length === 0` / `> 0`) を誤検出せず、件数値使用のみ禁止 (fixture で両方を証明)。

## 横展開・影響波及チェック

- 当初 #3625 の 4 サイト列挙は不完全で、guard 導入過程で reward-redemption / webhook-event / child-challenge / stamp-card の残存を追加検出 (enumeration 漏れを guard が捕捉 = ADR-0061 の意図を実証)。sweep 後 dsql の bare `.rows.length` 件数使用は 0 件。
- 以後 `.rows.length` を件数値に使う新規実装は CI hard-fail で阻止される。

## レビュー依頼事項・破壊的変更

破壊的変更なし。戻り値 (削除/更新件数 number) は全サイトで不変、内部集約方式のみ変更。

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 実装 + guard + テストが 1 PR で完結
- [x] 変更ファイルの局所テスト PASS
- [x] biome clean
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
