### PR TITLE
feat(nuc): #3620 AC-C2 factory の pglite 分岐結線 + async init guard (dsql repos 共有)

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,6 +10,9 @@ import { buildEvaluationContext, setEvaluationContext } from '$lib/runtime/evalu
 import { type RuntimeMode, resolveRuntimeMode } from '$lib/runtime/runtime-mode';
 import { getAuthMode, getAuthProvider } from '$lib/server/auth/factory';
 import { getOrInitDb } from '$lib/server/db/client';
+// #3620 AC-C2: DATA_SOURCE=pglite の非同期 init guard 用 (import は side-effect free、
+// PGlite instance は initPgliteConnection() 呼び出し時のみ生成)。
+import { initPgliteConnection } from '$lib/server/db/pglite/connection';
 import { applyDebugPlanOverride } from '$lib/server/debug-plan';
 import {
 	buildDemoNoopResponseBody,
@@ -154,6 +157,13 @@ export const handle: Handle = ({ event, resolve }) =>
 		// globalSetup 完了後) に DB が open されるため、Round 10 H-1 (schema cache
 		// invalidation 失敗) が構造的に解消される。
 		getOrInitDb();
+
+		// #3620 AC-C2 (ADR-0064 案 C): DATA_SOURCE=pglite の非同期 init guard。PGlite の open +
+		// migration は非同期のため、同期 getRepos() が ready singleton を使えるよう request 処理前に
+		// 接続を確立する。idempotent (2nd 以降は cached Promise 即 return) で他 backend では no-op。
+		if (env.DATA_SOURCE === 'pglite') {
+			await initPgliteConnection();
+		}
 
 		// #2994: operator-level PIN reset (PARENT_PIN_RESET env)。プロセスごと初回のみ実評価、
 		// 2 回目以降は同期 return。DB 接続確立 (getOrInitDb) 後である必要がある。

--- a/src/lib/server/db/factory.ts
+++ b/src/lib/server/db/factory.ts
@@ -69,6 +69,7 @@ import { createDsqlRewardRedemptionRepo } from './dsql/reward-redemption-repo';
 import { createDsqlSettingsRepo } from './dsql/settings-repo';
 import { createDsqlSiblingCheerRepo } from './dsql/sibling-cheer-repo';
 import { createDsqlSpecialRewardRepo } from './dsql/special-reward-repo';
+import type { SqlExecutor } from './dsql/sql-executor';
 import { createDsqlStampCardRepo } from './dsql/stamp-card-repo';
 import { createDsqlStatusRepo } from './dsql/status-repo';
 import { createDsqlTrialHistoryRepo } from './dsql/trial-history-repo';
@@ -141,9 +142,14 @@ import type { ISpecialRewardRepo } from './interfaces/special-reward-repo.interf
 import type { IStampCardRepo } from './interfaces/stamp-card-repo.interface';
 import type { IStatusRepo } from './interfaces/status-repo.interface';
 import type { IStorageRepo } from './interfaces/storage.interface';
+import type { TransactionRunner } from './interfaces/transaction.interface';
 import type { ITrialHistoryRepo } from './interfaces/trial-history-repo.interface';
 import type { IViewerTokenRepo } from './interfaces/viewer-token-repo.interface';
 import type { IVoiceRepo } from './interfaces/voice-repo.interface';
+// #3620 AC-C2 (ADR-0064 案 C): NUC=PGlite は dsql (pg-core) repos を verbatim 再利用する。
+// getPglite*Sync は init 済み前提の同期アクセサ (async init は hooks.server.ts の 1st-request
+// guard で await 済み)。pglite 分岐内でのみ呼ぶこと (他 backend で PGlite を open させない)。
+import { getPgliteDbSync, getPgliteTransactionRunnerSync } from './pglite/connection';
 import * as sqliteAccountLockoutRepo from './sqlite/account-lockout-repo';
 import * as sqliteActivityMasteryRepo from './sqlite/activity-mastery-repo';
 import * as sqliteActivityPrefRepo from './sqlite/activity-pref-repo';
@@ -229,6 +235,56 @@ export interface Repositories {
 
 let _repos: Repositories | null = null;
 
+/**
+ * pg-core backend (Aurora DSQL / NUC PGlite 共通) の Repositories を組み立てる。
+ * ADR-0064 案 C: DSQL(cloud) と PGlite(NUC) は同一 dsql repos を共有するため、db(SqlExecutor 面)
+ * と runner を注入する 1 箇所に集約する (dsql/pglite 分岐の 35 repo 二重列挙を防ぐ)。
+ * db は DsqlDatabase / PgliteDatabase いずれも SqlExecutor を構造的に満たす。
+ */
+function buildPgBackendRepos<TTx extends SqlExecutor>(
+	db: SqlExecutor,
+	runner: TransactionRunner<TTx>,
+): Repositories {
+	return {
+		accountLockout: createDsqlAccountLockoutRepo(db),
+		battle: createDsqlBattleRepo(db),
+		cancellationReason: createDsqlCancellationReasonRepo(db),
+		certificate: createDsqlCertificateRepo(db),
+		auth: createDsqlAuthRepo(db, runner),
+		activity: createDsqlActivityRepo(db, runner),
+		activityMastery: createDsqlActivityMasteryRepo(db, runner),
+		activityPref: createDsqlActivityPrefRepo(db, runner),
+		childActivity: createDsqlChildActivityRepo(db, runner),
+		childChallenge: createDsqlChildChallengeRepo(db),
+		checklist: createDsqlChecklistRepo(db, runner),
+		child: createDsqlChildRepo(db, runner),
+		cloudExport: createDsqlCloudExportRepo(db),
+		dailyMission: createDsqlDailyMissionRepo(db),
+		evaluation: createDsqlEvaluationRepo(db, runner),
+		graduationConsent: createDsqlGraduationConsentRepo(db),
+		image: createDsqlImageRepo(db),
+		inquiry: createDsqlInquiryRepo(db),
+		loginBonus: createDsqlLoginBonusRepo(db),
+		message: createDsqlMessageRepo(db),
+		point: createDsqlPointRepo(db, runner),
+		pushSubscription: createDsqlPushSubscriptionRepo(db),
+		// §7 compute-on-read (report_daily_summaries 表は pg-core に存在しない)
+		reportDailySummary: createDsqlReportDailySummaryRepo(db),
+		siblingCheer: createDsqlSiblingCheerRepo(db),
+		settings: createDsqlSettingsRepo(db),
+		rewardRedemption: createDsqlRewardRedemptionRepo(db),
+		specialReward: createDsqlSpecialRewardRepo(db, runner),
+		stampCard: createDsqlStampCardRepo(db, runner),
+		status: createDsqlStatusRepo(db, runner),
+		// storage の実体は S3 (DB backend 非依存)。専用実装は作らず dynamodb/ の実装を再利用する。
+		// #3438 dynamodb 撤去時に storage-repo を dynamodb/ 外へ移設する。
+		storage: dynamoStorageRepo,
+		trialHistory: createDsqlTrialHistoryRepo(db),
+		viewerToken: createDsqlViewerTokenRepo(db),
+		voice: createDsqlVoiceRepo(db, runner),
+	};
+}
+
 export function getRepos(): Repositories {
 	if (_repos) return _repos;
 
@@ -281,48 +337,15 @@ export function getRepos(): Repositories {
 	if (dataSource === 'dsql') {
 		// EPIC #3424: Aurora DSQL backend。db / runner は connection.ts の lazy singleton から
 		// この分岐内でのみ取得する (module-level 呼び出し禁止: sqlite/demo 環境で pool を作らせない)。
-		const db = getDsqlDb();
-		const runner = getDsqlTransactionRunner();
-		const repos: Repositories = {
-			accountLockout: createDsqlAccountLockoutRepo(db),
-			battle: createDsqlBattleRepo(db),
-			cancellationReason: createDsqlCancellationReasonRepo(db),
-			certificate: createDsqlCertificateRepo(db),
-			auth: createDsqlAuthRepo(db, runner),
-			activity: createDsqlActivityRepo(db, runner),
-			activityMastery: createDsqlActivityMasteryRepo(db, runner),
-			activityPref: createDsqlActivityPrefRepo(db, runner),
-			childActivity: createDsqlChildActivityRepo(db, runner),
-			childChallenge: createDsqlChildChallengeRepo(db),
-			checklist: createDsqlChecklistRepo(db, runner),
-			child: createDsqlChildRepo(db, runner),
-			cloudExport: createDsqlCloudExportRepo(db),
-			dailyMission: createDsqlDailyMissionRepo(db),
-			evaluation: createDsqlEvaluationRepo(db, runner),
-			graduationConsent: createDsqlGraduationConsentRepo(db),
-			image: createDsqlImageRepo(db),
-			inquiry: createDsqlInquiryRepo(db),
-			loginBonus: createDsqlLoginBonusRepo(db),
-			message: createDsqlMessageRepo(db),
-			point: createDsqlPointRepo(db, runner),
-			pushSubscription: createDsqlPushSubscriptionRepo(db),
-			// §7 compute-on-read (report_daily_summaries 表は DSQL に存在しない)
-			reportDailySummary: createDsqlReportDailySummaryRepo(db),
-			siblingCheer: createDsqlSiblingCheerRepo(db),
-			settings: createDsqlSettingsRepo(db),
-			rewardRedemption: createDsqlRewardRedemptionRepo(db),
-			specialReward: createDsqlSpecialRewardRepo(db, runner),
-			stampCard: createDsqlStampCardRepo(db, runner),
-			status: createDsqlStatusRepo(db, runner),
-			// storage の実体は S3 (DB backend 非依存)。DSQL 用実装は作らず dynamodb/ の実装を
-			// 再利用する。#3438 dynamodb 撤去時に storage-repo を dynamodb/ 外へ移設する。
-			storage: dynamoStorageRepo,
-			trialHistory: createDsqlTrialHistoryRepo(db),
-			viewerToken: createDsqlViewerTokenRepo(db),
-			voice: createDsqlVoiceRepo(db, runner),
-		};
-		_repos = repos;
-		return repos;
+		_repos = buildPgBackendRepos(getDsqlDb(), getDsqlTransactionRunner());
+		return _repos;
+	}
+	if (dataSource === 'pglite') {
+		// EPIC #3620 (ADR-0064 案 C): NUC=PGlite backend。dsql (pg-core) repos を verbatim 再利用する。
+		// PGlite init は非同期のため hooks.server.ts の 1st-request guard で await 済み前提。
+		// getPglite*Sync は init 未完なら明示 throw する (この分岐内でのみ呼ぶ)。
+		_repos = buildPgBackendRepos(getPgliteDbSync(), getPgliteTransactionRunnerSync());
+		return _repos;
 	}
 	if (dataSource === 'dynamodb') {
 		const repos: Repositories = {

--- a/src/lib/server/db/pglite/connection.ts
+++ b/src/lib/server/db/pglite/connection.ts
@@ -72,6 +72,15 @@ export async function initPgliteConnection(): Promise<void> {
 			'SELECT current_database()',
 		);
 		const dbName = dbNameRes.rows[0]?.current_database ?? 'postgres';
+		// #3629 QM follow-up: dbName は current_database() 由来で安全だが、識別子補間の同型コピーで
+		// SQL injection を招かないよう安全な識別子形状を明示 assert する (parameterize 不能な
+		// DDL 識別子の防御。unsafe pattern の横展開防止)。
+		if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(dbName)) {
+			throw new Error(`[pglite/connection] 不正な database 識別子: ${dbName}`);
+		}
+		// #3629 QM follow-up (両輪、誤除去防止): 下記 2 文は片方だけでは UTC を保証できない。
+		//   ALTER DATABASE = 以後の全 session の既定 (現 session には効かない、pg_db_role_setting 永続)。
+		//   SET TIME ZONE  = 現 session のみ。両方あって初めて「現 session も将来 session も UTC」。
 		await _client.exec(`ALTER DATABASE "${dbName}" SET timezone TO 'UTC';`);
 		await _client.exec("SET TIME ZONE 'UTC';");
 		_db = drizzle(_client, { schema });
@@ -97,6 +106,33 @@ export async function getPgliteDb(): Promise<PgliteDatabase> {
 export async function getPgliteTransactionRunner(): Promise<TransactionRunner<PgliteTx>> {
 	await initPgliteConnection();
 	if (!_runner) throw new Error('[pglite/connection] init 後も runner が null です (到達不能)');
+	return _runner;
+}
+
+/**
+ * #3620 AC-C2: 同期 factory (getRepos) 用の **init 済み前提** アクセサ。
+ * PGlite init は非同期のため、request 前に `initPgliteConnection()` を await 済みであること
+ * (hooks.server.ts の 1st-request guard) を前提に、同期で ready singleton を返す。
+ * 未 init で呼ばれた場合は明示 throw する (silent な空 backend を作らせない)。
+ */
+export function getPgliteDbSync(): PgliteDatabase {
+	if (!_db) {
+		throw new Error(
+			'[pglite/connection] init 未完了。DATA_SOURCE=pglite では request 前に ' +
+				'initPgliteConnection() を await すること (hooks.server.ts の 1st-request guard)。',
+		);
+	}
+	return _db;
+}
+
+/** #3620 AC-C2: 同期 factory 用の init 済み TransactionRunner アクセサ (getPgliteDbSync と同契約)。 */
+export function getPgliteTransactionRunnerSync(): TransactionRunner<PgliteTx> {
+	if (!_runner) {
+		throw new Error(
+			'[pglite/connection] init 未完了。DATA_SOURCE=pglite では request 前に ' +
+				'initPgliteConnection() を await すること (hooks.server.ts の 1st-request guard)。',
+		);
+	}
 	return _runner;
 }
 

--- a/tests/unit/db/factory-pglite-branch.test.ts
+++ b/tests/unit/db/factory-pglite-branch.test.ts
@@ -1,0 +1,126 @@
+// tests/unit/db/factory-pglite-branch.test.ts
+// EPIC #3620 AC-C2 (ADR-0064 案 C) / cutover 配線 / 設計 SSOT: pglite/connection.ts
+//
+// factory.ts の DATA_SOURCE=pglite 分岐のテスト。実 PGlite は open せず `./pglite/connection` を
+// vi.mock して以下を検証する (factory-dsql-branch.test.ts と同型):
+//
+//   [FP1] DATA_SOURCE=pglite: getRepos() が Repositories 全 key を dsql repos で埋め、
+//         db / runner は getPgliteDbSync() / getPgliteTransactionRunnerSync() (mock) から取得
+//   [FP2] DATA_SOURCE=sqlite / demo / dsql: getPglite*Sync が呼ばれない (pglite 分岐内のみ、
+//         他 backend で PGlite を open させない契約)
+//
+// module cache 注意: factory.ts は `_repos` singleton を持つため、各テストで vi.resetModules()
+// + dynamic import で新しい module instance を得る。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/lib/server/db/pglite/connection', () => {
+	// 実 PGlite を open しない fake。repo factory は db.execute / runner.runInTransaction を保持する
+	// だけ (getRepos 時点で SQL 未発行) のため最小 shape で足りる。
+	const fakeDb = {
+		execute: vi.fn(async () => ({ rows: [] })),
+		transaction: vi.fn(),
+	};
+	const fakeRunner = {
+		runInTransaction: vi.fn(async (work: (tx: unknown) => Promise<unknown>) => work(fakeDb)),
+	};
+	return {
+		getPgliteDbSync: vi.fn(() => fakeDb),
+		getPgliteTransactionRunnerSync: vi.fn(() => fakeRunner),
+	};
+});
+
+/** Repositories interface の全 key (factory.ts の interface 定義と同期)。 */
+const REPOSITORY_KEYS = [
+	'accountLockout',
+	'battle',
+	'cancellationReason',
+	'certificate',
+	'auth',
+	'activity',
+	'activityMastery',
+	'activityPref',
+	'childActivity',
+	'childChallenge',
+	'checklist',
+	'child',
+	'cloudExport',
+	'dailyMission',
+	'evaluation',
+	'graduationConsent',
+	'image',
+	'inquiry',
+	'loginBonus',
+	'message',
+	'point',
+	'pushSubscription',
+	'reportDailySummary',
+	'siblingCheer',
+	'settings',
+	'rewardRedemption',
+	'specialReward',
+	'stampCard',
+	'status',
+	'storage',
+	'trialHistory',
+	'viewerToken',
+	'voice',
+] as const;
+
+async function importFreshFactory() {
+	const factory = await import('../../../src/lib/server/db/factory');
+	const connection = await import('../../../src/lib/server/db/pglite/connection');
+	return { factory, connection };
+}
+
+describe('factory DATA_SOURCE=pglite 分岐 (connection mock、実 PGlite を open しない)', () => {
+	const originalDataSource = process.env.DATA_SOURCE;
+
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		if (originalDataSource === undefined) delete process.env.DATA_SOURCE;
+		else process.env.DATA_SOURCE = originalDataSource;
+	});
+
+	it('[FP1] pglite: 全 repo key が dsql repos で埋まり、db/runner は pglite の sync getter から取得', async () => {
+		process.env.DATA_SOURCE = 'pglite';
+		const { factory, connection } = await importFreshFactory();
+
+		const repos = factory.getRepos();
+
+		// db / runner は mock 経由 (= 実 PGlite は open されない、案 C = dsql repos verbatim 再利用)
+		expect(connection.getPgliteDbSync).toHaveBeenCalledTimes(1);
+		expect(connection.getPgliteTransactionRunnerSync).toHaveBeenCalledTimes(1);
+
+		// Repositories 全 field が漏れなく実装オブジェクトで埋まる (キー網羅)
+		expect(Object.keys(repos).sort()).toEqual([...REPOSITORY_KEYS].sort());
+		for (const key of REPOSITORY_KEYS) {
+			const repo = (repos as unknown as Record<string, unknown>)[key];
+			expect(repo, `repos.${key} が未配線`).toBeTruthy();
+			expect(typeof repo, `repos.${key} が object でない`).toBe('object');
+		}
+		// dsql repos を再利用しているため spot check も dsql と同型
+		expect(typeof repos.child.insertChild).toBe('function');
+		expect(typeof repos.point.spendPointsAtomic).toBe('function');
+
+		// singleton: 2 回目は同一 instance を返し、sync getter を再度呼ばない
+		expect(factory.getRepos()).toBe(repos);
+		expect(connection.getPgliteDbSync).toHaveBeenCalledTimes(1);
+	});
+
+	it('[FP2] sqlite/demo/dsql: getPglite*Sync は呼ばれない (pglite 分岐内のみ、他 backend で open させない)', async () => {
+		for (const ds of ['sqlite', 'demo'] as const) {
+			vi.resetModules();
+			vi.clearAllMocks();
+			process.env.DATA_SOURCE = ds;
+			const { factory, connection } = await importFreshFactory();
+			factory.getRepos();
+			expect(connection.getPgliteDbSync, `${ds} で PGlite を open`).not.toHaveBeenCalled();
+			expect(connection.getPgliteTransactionRunnerSync).not.toHaveBeenCalled();
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

NUC (PGlite) を実際にアプリから使えるよう factory に結線する。DATA_SOURCE=pglite で NUC が pg-core repos を verbatim 動かせる状態にし、cutover 可能性を一歩進める。

## 関連 Issue

#3620 (EPIC、AC-C2)。#3628 (AC-C1 接続層) / #3629 (TZ 根治) の後続。#3629 で QM が記録した accepted-residual (識別子補間・両輪誤除去) も本 PR で手当。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| AC-C2: DATA_SOURCE=pglite で全 repo key が dsql repos で埋まる | `[FP1]` factory-pglite-branch | PASS | tests/unit/db/factory-pglite-branch.test.ts |
| AC-C2: 他 backend で PGlite を open しない (lazy 契約) | `[FP2]` sqlite/demo で getPglite*Sync 非呼出 | PASS | 同上 |
| dsql 分岐が helper 抽出後も不変 | `[F1/F2]` factory-dsql-branch | PASS | tests/unit/db/factory-dsql-branch.test.ts |
| QM residual: 識別子形状 assert | connection.ts guard | PASS | diff |

## 変更タイプ

- [x] 新機能 (NUC pglite backend 結線)
- [x] リファクタリング (dsql/pglite repo 構築の DRY 抽出)
- [ ] バグ修正
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `src/lib/server/db/factory.ts`: dsql/pglite 共通の repo 構築を `buildPgBackendRepos(db, runner)` helper に抽出 (35 repo 二重列挙排除)。dsql 分岐を helper 呼び出しに置換 + `pglite` 分岐追加。
- `src/lib/server/db/pglite/connection.ts`: 同期アクセサ `getPgliteDbSync` / `getPgliteTransactionRunnerSync` 追加 (未 init は throw)。#3629 QM residual 手当 (識別子 assert + 両輪コメント)。
- `src/hooks.server.ts`: 1st-request guard に DATA_SOURCE=pglite の async init 前置き追加。
- **既存 backend (sqlite/dsql/dynamodb/demo) は挙動不変**。default 'sqlite' のまま、dsql 分岐は同一 repos を helper 経由で構築 (出力不変、test で担保)。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/factory-pglite-branch.test.ts tests/unit/db/factory-dsql-branch.test.ts` = 5/5 PASS
- [x] `npx vitest run tests/unit/db/pglite-connection.test.ts` = 4/4 PASS (接続層不変)
- [x] `npx biome check <changed>` = clean / `npx cspell <changed>` = 0 issue
- [x] dsql 分岐の出力不変を `[F1]` キー網羅 test で担保 (ADR-0006)

## スクリーンショット / ビジュアルデモ

N/A — server 側 backend 結線のみで UI 影響なし。

## コード品質セルフレビュー (#1481)

- 案 C の本質 (DSQL cloud と NUC PGlite が同一 dsql repos を共有) を `buildPgBackendRepos` の 1 箇所集約で表現。分岐間の drift を構造的に排除。
- PGlite の async init と同期 getRepos() の橋渡しは「hooks の 1st-request guard で await → sync アクセサは ready 前提 throw」で明示。async を getRepos に伝播させない (既存呼出契約不変)。

## 横展開・影響波及チェック

- factory の dsql 分岐は helper 化で内部実装が変わるが、出力 Repositories は不変 (`[F1]` が全 key を検証)。cloud DSQL 本番経路に機能差分なし。
- 旧 sqlite/* の撤去は cutover で default を pglite に切り替える時に行う (本 PR は sqlite 分岐を残し既存経路を保全)。

## レビュー依頼事項・破壊的変更

破壊的変更なし。新 backend 分岐追加 + dsql 分岐の DRY 抽出 (出力不変)。DATA_SOURCE=pglite の実配布は AC-C5 cutover。

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret なし (DATA_SOURCE enum / PGLITE_* は #3628 で追加済 optional)。

## Ready for Review チェックリスト

- [x] 実装 + テストが 1 PR で完結
- [x] 局所テスト PASS
- [x] biome / cspell clean
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
