### PR TITLE
feat(nuc): #3620 AC-C3 PGlite durability gate 検証 + init self-heal (#3630 QM follow-up)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -85,6 +85,7 @@
 		"multitenant",
 		"NONNEG",
 		"PDCA",
+		"reinit",
 		"schemaname",
 		"setconfig",
 		"setdatabase",

--- a/src/lib/server/db/pglite/connection.ts
+++ b/src/lib/server/db/pglite/connection.ts
@@ -87,7 +87,19 @@ export async function initPgliteConnection(): Promise<void> {
 		// 生成済み pg-core migration を適用 (drizzle-kit 非依存、本番 boot 経路)。
 		await migrate(_db, { migrationsFolder: migrationsDir() });
 		_runner = createDsqlTransactionRunner<PgliteTx>(_db);
-	})();
+	})().catch((err) => {
+		// #3630 QM follow-up (self-heal): init が reject すると `_ready` に rejected promise が残り、
+		// 以後の全呼出が `if (_ready) return _ready` で恒久的に同じ失敗を返す (permanent brick、retry
+		// 不能)。失敗時は singleton 状態を破棄し、次回呼出で再 init を試せるようにする (成功は memoize
+		// 維持)。self-heal を `_ready` 自体に付けるため並列呼出も同一 promise を共有する。
+		const failedClient = _client;
+		_client = null;
+		_db = null;
+		_runner = null;
+		_ready = null;
+		if (failedClient) void failedClient.close().catch(() => {}); // best-effort cleanup
+		throw err;
+	});
 	return _ready;
 }
 

--- a/tests/unit/db/pglite-durability.test.ts
+++ b/tests/unit/db/pglite-durability.test.ts
@@ -78,17 +78,24 @@ describe('PGlite durability gate + self-heal (#3620 AC-C3、ADR-0064 §検証 ga
 		// reopen 後も UTC 既定が catalog に残る (#3629 接続レベル TZ の永続実証)
 		const tz = await getPgliteDbSync().execute(sql`SHOW timezone`);
 		expect((tz.rows[0] as { TimeZone?: string }).TimeZone).toBe('UTC');
-	});
+	}, 60_000);
 
-	it('[C3-2] self-heal: init reject 後も次回 init で自己回復する (permanent brick 回避)', async () => {
-		// 存在しない migrations dir を指すと migrate() が throw → init reject
+	it('[C3-2] self-heal: init reject 後、reset を経ずに init 直接再呼出で自己回復する (permanent brick 回避)', async () => {
+		// 1st init: 存在しない migrations dir で migrate() が throw → init reject。
+		// (この準備段階のみ reinitWithEnv = reset 込みで clean 状態から開始する)
 		const bogus = join(tmpdir(), `pglite-missing-migrations-${Date.now()}`);
 		await expect(reinitWithEnv({ PGLITE_MIGRATIONS_DIR: bogus })).rejects.toThrow();
 
-		// _ready が破棄されているため、正しい migrations dir で再 init すると成功する
-		await reinitWithEnv({ PGLITE_MIGRATIONS_DIR: undefined });
+		// 2nd init: **resetPgliteConnectionForTesting() を一切呼ばず**、env 修正のみで
+		// initPgliteConnection() を直接再呼出する (QM 指摘のトートロジー是正)。
+		// self-heal (.catch が _ready を null に破棄) が無ければ 1st の rejected promise が
+		// memoize されたまま再利用され、本 step は fail する (mutation 演繹で確認済み —
+		// connection.ts の .catch self-heal を外すと本 step が同じ migrate ENOENT で fail)。
+		delete process.env.PGLITE_MIGRATIONS_DIR;
+		resetEnvForTesting(); // env cache のみ再 parse (pglite singleton には触れない)
+		await initPgliteConnection(); // ← self-heal の _ready=null だけが再試行を可能にする
 		const repo = createDsqlChildRepo(getPgliteDbSync(), getPgliteTransactionRunnerSync());
 		const created = await repo.insertChild({ nickname: '回復くん', age: 8 }, FAMILY);
 		expect(created.id).toMatch(/^[0-9a-f-]{36}$/);
-	});
+	}, 60_000);
 });

--- a/tests/unit/db/pglite-durability.test.ts
+++ b/tests/unit/db/pglite-durability.test.ts
@@ -1,0 +1,94 @@
+// tests/unit/db/pglite-durability.test.ts
+// EPIC #3620 AC-C3 (ADR-0064 §検証 gate) — PGlite FS 永続の durability gate + init self-heal。
+//
+// ADR-0064 は案 C 採択の前提として「PGlite durability を実装時に検証、不合格なら案 A fallback」を
+// 定める。本テストは:
+//   [C3-1] FS 永続: PGLITE_DATA_DIR に書いた child が close→reopen 後も残る (durability gate)
+//          + reopen 後も UTC 既定が catalog に残る (#3629 接続レベル TZ が永続する実証)
+//   [C3-2] self-heal: init が reject しても _ready を破棄し、次回 init で自己回復する (#3630 QM follow-up、
+//          permanent brick 回避)
+// を検証する。env は getEnv() cache を挟むため resetEnvForTesting() で毎回再 parse させる。
+
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sql } from 'drizzle-orm';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resetEnvForTesting } from '../../../src/lib/runtime/env';
+import { createDsqlChildRepo } from '../../../src/lib/server/db/dsql/child-repo';
+import {
+	getPgliteDbSync,
+	getPgliteTransactionRunnerSync,
+	initPgliteConnection,
+	resetPgliteConnectionForTesting,
+} from '../../../src/lib/server/db/pglite/connection';
+
+const FAMILY = '00000000-0000-4000-8000-00000000c3a1';
+const tempDirs: string[] = [];
+
+/** 一意な temp dataDir を確保する (afterEach で削除)。Date.now は test 環境で使用可。 */
+function freshDataDir(tag: string): string {
+	const dir = join(tmpdir(), `pglite-${tag}-${Date.now()}-${tempDirs.length}`);
+	tempDirs.push(dir);
+	return dir;
+}
+
+async function reinitWithEnv(patch: Record<string, string | undefined>): Promise<void> {
+	for (const [k, v] of Object.entries(patch)) {
+		if (v === undefined) delete process.env[k];
+		else process.env[k] = v;
+	}
+	resetEnvForTesting();
+	await resetPgliteConnectionForTesting();
+	await initPgliteConnection();
+}
+
+describe('PGlite durability gate + self-heal (#3620 AC-C3、ADR-0064 §検証 gate)', () => {
+	afterEach(async () => {
+		delete process.env.PGLITE_DATA_DIR;
+		delete process.env.PGLITE_MIGRATIONS_DIR;
+		resetEnvForTesting();
+		await resetPgliteConnectionForTesting();
+		for (const d of tempDirs.splice(0)) {
+			if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+		}
+	});
+
+	it('[C3-1] FS 永続: close→reopen 後も child が残り、UTC 既定も catalog に永続する', async () => {
+		const dataDir = freshDataDir('dur');
+
+		// 1st open: child を書き込む
+		await reinitWithEnv({ PGLITE_DATA_DIR: dataDir });
+		const repo1 = createDsqlChildRepo(getPgliteDbSync(), getPgliteTransactionRunnerSync());
+		const created = await repo1.insertChild(
+			{ nickname: '永続くん', age: 8, birthDate: '2018-01-15' },
+			FAMILY,
+		);
+
+		// close (FS flush) → 同 dataDir で reopen
+		await resetPgliteConnectionForTesting();
+		await initPgliteConnection();
+
+		// reopen 後も child が残る = durability gate PASS
+		const repo2 = createDsqlChildRepo(getPgliteDbSync(), getPgliteTransactionRunnerSync());
+		const found = await repo2.findChildById(created.id, FAMILY);
+		expect(found?.id).toBe(created.id);
+		expect(found?.nickname).toBe('永続くん');
+
+		// reopen 後も UTC 既定が catalog に残る (#3629 接続レベル TZ の永続実証)
+		const tz = await getPgliteDbSync().execute(sql`SHOW timezone`);
+		expect((tz.rows[0] as { TimeZone?: string }).TimeZone).toBe('UTC');
+	});
+
+	it('[C3-2] self-heal: init reject 後も次回 init で自己回復する (permanent brick 回避)', async () => {
+		// 存在しない migrations dir を指すと migrate() が throw → init reject
+		const bogus = join(tmpdir(), `pglite-missing-migrations-${Date.now()}`);
+		await expect(reinitWithEnv({ PGLITE_MIGRATIONS_DIR: bogus })).rejects.toThrow();
+
+		// _ready が破棄されているため、正しい migrations dir で再 init すると成功する
+		await reinitWithEnv({ PGLITE_MIGRATIONS_DIR: undefined });
+		const repo = createDsqlChildRepo(getPgliteDbSync(), getPgliteTransactionRunnerSync());
+		const created = await repo.insertChild({ nickname: '回復くん', age: 8 }, FAMILY);
+		expect(created.id).toMatch(/^[0-9a-f-]{36}$/);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

NUC PGlite を本番採用してよいかの判断根拠（durability gate）を機械検証し、init 失敗時に永久 brick せず自己回復するようにする。子供のデータが reopen 後も確実に残ることを保証し、cutover の信頼性を上げる。

## 関連 Issue

#3620 (EPIC、AC-C3)。#3628/#3629/#3630 の後続。#3630 で QM が記録した accepted-residual #1 (init reject の permanent brick) を本 PR で手当。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| AC-C3: FS 永続 durability (close→reopen で child 保持) | `[C3-1]` temp dataDir round-trip | PASS (gate 通過) | tests/unit/db/pglite-durability.test.ts |
| AC-C3: reopen 後も UTC 既定が catalog に永続 | `[C3-1]` SHOW timezone | PASS | 同上 |
| QM #1: init reject 後の self-heal (brick 回避) | `[C3-2]` 不正 dir で reject → 正 dir で成功 | PASS | 同上 |
| 既存 [C1-*] 契約不変 | connection test | PASS (4/4) | tests/unit/db/pglite-connection.test.ts |

## 変更タイプ

- [x] バグ修正 / hardening (init self-heal、permanent brick 回避)
- [x] 新機能 (durability gate 検証)
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `src/lib/server/db/pglite/connection.ts`: init の promise-memoization に self-heal `.catch` を付与 (失敗時 `_client/_db/_runner/_ready` を破棄し再 init 可能に、成功は memoize 維持)。
- `tests/unit/db/pglite-durability.test.ts` (新規): FS 永続 durability gate + self-heal 回帰。
- `.cspell.json`: `reinit` (テストヘルパー名) を words に追加。
- PGlite backend 限定。既存 backend / 既存 [C1-*] 契約は不変。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/pglite-durability.test.ts` = 2/2 PASS
- [x] `npx vitest run tests/unit/db/pglite-connection.test.ts` = 4/4 PASS (self-heal 追加後も接続契約不変)
- [x] `npx biome check <changed>` = clean / `npx cspell <changed>` = 0 issue
- [x] durability gate PASS = ADR-0064 の案 A fallback は不要と実証

## スクリーンショット / ビジュアルデモ

N/A — server 側接続層 + test のみで UI 影響なし。

## コード品質セルフレビュー (#1481)

- self-heal は `_ready` 自体に `.catch` を付けることで並列呼出も同一 self-healing promise を共有 (guard 判定と代入の間に await なし = race-safe by construction を維持)。close は best-effort fire-and-forget。
- durability test は env cache (getEnv) を `resetEnvForTesting()` で毎回再 parse し、temp dataDir を afterEach で確実に削除 (副作用の worker 汚染なし)。

## 横展開・影響波及チェック

- durability gate PASS により ADR-0064 案 C (PGlite for NUC) の実装可能性が確認され、案 A (SQLite 再実装) fallback は発動不要。
- QM 残 residual #2 (runtime mode × DATA_SOURCE 整合 guardrail = cloud 誤設定で PGlite に全家族集約 → ADR-0063 tenant 分離消失の config-only blast radius) / #3 (非 HTTP entrypoint init 保証) は cutover gate 事項として #3620 に保持。

## レビュー依頼事項・破壊的変更

破壊的変更なし。self-heal は失敗経路のみ挙動追加 (正常系不変)。durability test は temp dir 使用で本番影響なし。

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 実装 + テストが 1 PR で完結
- [x] 局所テスト PASS
- [x] biome / cspell clean
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
