### PR TITLE
feat(infra): #3424 M5 compute-stack の DSQL cutover 配線 (flag-gated、prod template 不変)

### DIFF
--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -174,6 +174,32 @@ export class ComputeStack extends cdk.Stack {
 			);
 		}
 
+		// --- DSQL cutover 配線 (EPIC #3424 M5 / #3429) ---
+		// `-c dsqlEnabled=true` のときのみ Lambda を DATA_SOURCE=dsql + DSQL_ENDPOINT で起動し、
+		// 実行 role に dsql:DbConnect (最小権限、DbConnectAdmin は migration runner 専用経路で
+		// 付与しない = M3 §3.4 B6 実行時ロールモデル) を付与する。flag なしの `cdk deploy` では
+		// spread が空になり template は現行 (dynamodb) と完全に同一 (prod template 不変条件 #2873)。
+		// endpoint / cluster ARN は DsqlStack deploy 後の実値を context で受ける (cross-stack 参照
+		// ではなく context 疎結合: DsqlStack は別 gate で instantiate されるため)。
+		const dsqlEnabled = String(this.node.tryGetContext('dsqlEnabled')) === 'true';
+		const dsqlEndpoint = this.node.tryGetContext('dsqlEndpoint') ?? '';
+		const dsqlClusterArn = this.node.tryGetContext('dsqlClusterArn') ?? '';
+		if (dsqlEnabled && !dsqlEndpoint) {
+			// endpoint 未注入で DATA_SOURCE=dsql の Lambda を上げると cold start で
+			// dsql/connection.ts が throw して全リクエスト 500 化するため synth 段階で失敗させる
+			// (parentGateCookieSecret と同じ addError 運用、ADR-0006 silent fail 防止)。
+			cdk.Annotations.of(this).addError(
+				'[ComputeStack] dsqlEnabled=true ですが dsqlEndpoint context が空です。' +
+					'DsqlStack deploy 後の ClusterEndpoint 出力を -c dsqlEndpoint=<id>.dsql.<region>.on.aws で渡してください。',
+			);
+		}
+		if (dsqlEnabled && !dsqlClusterArn) {
+			cdk.Annotations.of(this).addError(
+				'[ComputeStack] dsqlEnabled=true ですが dsqlClusterArn context が空です。' +
+					'dsql:DbConnect の resource 限定 (最小権限) に必要です。-c dsqlClusterArn=arn:aws:dsql:... で渡してください。',
+			);
+		}
+
 		// --- Discord Webhook URLs（CDK context 経由で GitHub Actions Secrets から取得） ---
 		const feedbackDiscordWebhookUrl = this.node.tryGetContext('feedbackDiscordWebhookUrl') ?? '';
 		const discordWebhookSignup = this.node.tryGetContext('discordWebhookSignup') ?? '';
@@ -299,12 +325,19 @@ export class ComputeStack extends cdk.Stack {
 						COGNITO_LOGOUT_URL: 'https://ganbari-quest.com/auth/login',
 						SES_SENDER_EMAIL: 'noreply@ganbari-quest.com',
 						SES_CONFIG_SET_NAME: 'ganbari-quest-config',
+						// EPIC #3424 M5: dsqlEnabled 時のみ backend を DSQL へ切替 (後勝ち上書き)。
+						// flag なしでは spread 空 = 上の DATA_SOURCE: 'dynamodb' が維持され template 不変。
+						...(dsqlEnabled ? { DATA_SOURCE: 'dsql', DSQL_ENDPOINT: dsqlEndpoint } : {}),
 					}
 				: {
 						...stagingEnvironment,
 						...(parentGateCookieSecret
 							? { PARENT_GATE_COOKIE_SECRET: parentGateCookieSecret }
 							: {}),
+						// EPIC #3424 M5 DoD4: staging を DSQL backend で起動し §3.7#5 (post-deploy
+						// health green) を新 backend で検証する経路 (deploy-aws-staging.yml が
+						// -c dsqlEnabled=true -c dsqlEndpoint=... を渡したときのみ)。
+						...(dsqlEnabled ? { DATA_SOURCE: 'dsql', DSQL_ENDPOINT: dsqlEndpoint } : {}),
 					},
 		});
 		this.fn.node.addDependency(logGroup);
@@ -312,6 +345,19 @@ export class ComputeStack extends cdk.Stack {
 		// Grant Lambda access to DynamoDB and S3
 		props.table.grantReadWriteData(this.fn);
 		props.assetsBucket.grantReadWrite(this.fn);
+
+		// EPIC #3424 M5: DSQL 接続権限 (dsqlEnabled 時のみ)。dsql:DbConnect は実行時アプリ用の
+		// 最小権限で、DDL/GRANT 用の dsql:DbConnectAdmin は付与しない (migration runner が
+		// 別クレデンシャル経路で使う、M3 §3.4 B6 実行時接続ロールモデル)。resource は cluster
+		// ARN に限定する (ワイルドカード禁止)。
+		if (dsqlEnabled && dsqlClusterArn) {
+			this.fn.addToRolePolicy(
+				new iam.PolicyStatement({
+					actions: ['dsql:DbConnect'],
+					resources: [dsqlClusterArn],
+				}),
+			);
+		}
 
 		// staging (#2873): SES / Cost Explorer grant は付与しない (本番外部サービスへの
 		// 副作用ゼロ + blast radius 最小化。SES env も非注入のためアプリは送信経路を持たない)。

--- a/tests/unit/infra/dsql-cutover-wiring.test.ts
+++ b/tests/unit/infra/dsql-cutover-wiring.test.ts
@@ -1,0 +1,143 @@
+// tests/unit/infra/dsql-cutover-wiring.test.ts
+// EPIC #3424 M5 (DoD 3) — compute-stack の DSQL cutover 配線の CDK 構造検証。
+//
+// このテストは 2 つの責務を持つ:
+//   (1) prod 不変 guard (load-bearing): `dsqlEnabled` context 無しで synth した prod template が
+//       従来どおり DATA_SOURCE=dynamodb で、dsql:DbConnect policy を一切持たないことを assert。
+//       flag-gated 配線が既定 deploy の template を 1 byte も変えないことの機械保証
+//       (prod template 不変条件 #2873 / ADR-0019)。
+//   (2) dsqlEnabled=true 時の配線 assert: DATA_SOURCE=dsql + DSQL_ENDPOINT が Lambda env に入り、
+//       実行 role に dsql:DbConnect (resource = cluster ARN 限定) が付与され、
+//       **dsql:DbConnectAdmin は付与されない** (M3 §3.4 B6 実行時ロールモデル: DDL/GRANT は
+//       migration runner の別クレデンシャル経路) ことを assert。
+//   (3) fail-close: dsqlEnabled=true で endpoint / clusterArn 未注入なら synth error
+//       (cold start 全 500 化の silent 誤 deploy 防止、ADR-0006)。
+//
+// context stub パターンは staging-cdk.test.ts / multi-lambda-cdk.test.ts を踏襲。
+
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { describe, expect, it } from 'vitest';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+
+const TEST_DSQL_ENDPOINT = 'testcluster1234.dsql.us-east-1.on.aws';
+const TEST_DSQL_ARN = 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234';
+
+// cspell:ignore TESTPOOL
+const BASE_CONTEXT: Record<string, string> = {
+	'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+		'us-east-1_TESTPOOL',
+	'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+		'test-client-id',
+	'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+		'auth.ganbari-quest.com',
+	'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+		'test-context-token-secret',
+	opsSecretKey: 'test-ops-secret-key',
+	parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+};
+
+function buildCompute(extraContext: Record<string, string> = {}): ComputeStack {
+	const app = new cdk.App({ context: { ...BASE_CONTEXT, ...extraContext } });
+	const storage = new StorageStack(app, 'TestStorage', { env });
+	return new ComputeStack(app, 'TestCompute', {
+		env,
+		table: storage.table,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+}
+
+/** SvelteKitFn (prod main Fn) の env Variables を template から取り出す。 */
+function mainFnEnv(template: Template): Record<string, unknown> {
+	const fns = template.findResources('AWS::Lambda::Function', {
+		Properties: { FunctionName: 'ganbari-quest-app' },
+	});
+	const fn = Object.values(fns)[0] as {
+		Properties: { Environment: { Variables: Record<string, unknown> } };
+	};
+	return fn.Properties.Environment.Variables;
+}
+
+/** template 内の全 IAM Policy から Action 文字列を平坦収集する。 */
+function allPolicyActions(template: Template): string[] {
+	const policies = template.findResources('AWS::IAM::Policy');
+	const actions: string[] = [];
+	for (const p of Object.values(policies) as {
+		Properties: { PolicyDocument: { Statement: { Action: string | string[] }[] } };
+	}[]) {
+		for (const stmt of p.Properties.PolicyDocument.Statement) {
+			const a = stmt.Action;
+			if (Array.isArray(a)) actions.push(...a);
+			else if (typeof a === 'string') actions.push(a);
+		}
+	}
+	return actions;
+}
+
+describe('compute-stack DSQL cutover 配線 (EPIC #3424 M5 DoD3、flag-gated)', () => {
+	it('[W1 prod 不変 guard] dsqlEnabled 無し: DATA_SOURCE=dynamodb 維持 + dsql:* policy ゼロ', () => {
+		const compute = buildCompute();
+		const template = Template.fromStack(compute);
+
+		const envVars = mainFnEnv(template);
+		expect(envVars.DATA_SOURCE).toBe('dynamodb');
+		expect(envVars.DSQL_ENDPOINT).toBeUndefined();
+
+		const actions = allPolicyActions(template);
+		expect(actions.filter((a) => a.startsWith('dsql:'))).toEqual([]);
+	});
+
+	it('[W2 cutover 配線] dsqlEnabled=true: DATA_SOURCE=dsql + DSQL_ENDPOINT + DbConnect (ARN 限定、Admin なし)', () => {
+		const compute = buildCompute({
+			dsqlEnabled: 'true',
+			dsqlEndpoint: TEST_DSQL_ENDPOINT,
+			dsqlClusterArn: TEST_DSQL_ARN,
+		});
+		const template = Template.fromStack(compute);
+
+		const envVars = mainFnEnv(template);
+		expect(envVars.DATA_SOURCE).toBe('dsql');
+		expect(envVars.DSQL_ENDPOINT).toBe(TEST_DSQL_ENDPOINT);
+
+		// DbConnect が cluster ARN 限定で付与される (ワイルドカード禁止)
+		template.hasResourceProperties('AWS::IAM::Policy', {
+			PolicyDocument: {
+				Statement: Match.arrayWith([
+					Match.objectLike({
+						Action: 'dsql:DbConnect',
+						Effect: 'Allow',
+						Resource: TEST_DSQL_ARN,
+					}),
+				]),
+			},
+		});
+
+		// DbConnectAdmin (DDL/GRANT 用) は実行時 role に付与しない (M3 §3.4 B6)
+		const actions = allPolicyActions(template);
+		expect(actions).not.toContain('dsql:DbConnectAdmin');
+	});
+
+	it('[W3 fail-close] dsqlEnabled=true + endpoint 未注入: synth が error annotation で失敗する', () => {
+		const compute = buildCompute({ dsqlEnabled: 'true', dsqlClusterArn: TEST_DSQL_ARN });
+		const errors = compute.node
+			.findAll()
+			.flatMap((c) => c.node.metadata)
+			.filter((m) => m.type === 'aws:cdk:error');
+		expect(errors.length).toBeGreaterThan(0);
+		expect(String(errors[0]?.data)).toContain('dsqlEndpoint');
+	});
+
+	it('[W3b fail-close] dsqlEnabled=true + clusterArn 未注入: synth が error annotation で失敗する', () => {
+		const compute = buildCompute({ dsqlEnabled: 'true', dsqlEndpoint: TEST_DSQL_ENDPOINT });
+		const errors = compute.node
+			.findAll()
+			.flatMap((c) => c.node.metadata)
+			.filter((m) => m.type === 'aws:cdk:error');
+		expect(errors.length).toBeGreaterThan(0);
+		expect(String(errors[0]?.data)).toContain('dsqlClusterArn');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

EPIC #3424（DynamoDB→DSQL 移管）の真の完了に向けた cutover 配線。監査 (2026-07-11) で「EPIC CLOSED だが本番 Lambda は今も dynamodb で、DSQL へ切り替える CDK 経路自体が存在しない」ことが確定した (ADR-0060 DoD 違反として EPIC 再オープン済)。本 PR はその欠落経路を flag-gated で実装し、staging/本番の DSQL 起動を可能にする。

## 関連 Issue

#3424 (EPIC 再オープン、DoD 3) / #3429 (CDK IAM 連携)。実 deploy (cluster 作成 / staging / 本番) はユーザー承認事項のため本 PR に含まない。migration runner の deploy 結線は DoD 2 として別 PR で扱う。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| flag なしの既定 deploy は template 完全不変 (prod 不変条件) | `[W1]` DATA_SOURCE=dynamodb 維持 + dsql:* policy ゼロ | PASS | tests/unit/infra/dsql-cutover-wiring.test.ts |
| dsqlEnabled=true で DATA_SOURCE=dsql + DSQL_ENDPOINT 注入 | `[W2]` | PASS | 同上 |
| DbConnect は cluster ARN 限定 + DbConnectAdmin 不在 (M3 §3.4 B6) | `[W2]` | PASS | 同上 |
| endpoint / clusterArn 未注入は synth error (fail-close) | `[W3]/[W3b]` | PASS | 同上 |
| 既存 infra テスト回帰なし | infra 全体 | PASS (83/83) | ローカル実行ログ |

## 変更タイプ

- [x] 新機能 (DSQL cutover 配線、flag-gated)
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `infra/lib/compute-stack.ts`: dsqlEnabled/dsqlEndpoint/dsqlClusterArn context 読取 + fail-close validation + prod/staging 両 env への flag-gated 上書き + DbConnect IAM (ARN 限定)。
- `tests/unit/infra/dsql-cutover-wiring.test.ts` (新規): 4 assert。
- **flag なしでは template 1 byte も変わらない** (spread 空 + if skip、[W1] が機械保証)。本番/staging の現行 deploy への影響ゼロ。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/infra/` = 83/83 PASS (新規 4 + 既存回帰なし)
- [x] `npx biome check <changed>` = clean / `npx cspell <changed>` = 0 issue
- [x] fail-close: 未注入 context での誤 deploy は synth 段階で失敗 (ADR-0006)
- [x] prod template 不変 guard ([W1]) で既定経路の無変更を機械保証

## スクリーンショット / ビジュアルデモ

N/A — infra (CDK) + test のみで UI 影響なし。

## コード品質セルフレビュー (#1481)

- addError 運用は parentGateCookieSecret の既存 idiom と同型 (silent fail 防止)。
- IAM は最小権限: DbConnect のみ・resource ARN 限定・Admin 分離 (migration runner 別経路、M3 §3.4 B6)。
- endpoint/ARN は cross-stack 参照でなく context 疎結合 (DsqlStack は別 gate で instantiate されるため)。

## 横展開・影響波及チェック

- staging env にも同配線済み → deploy-aws-staging.yml が flag を渡すだけで staging DSQL 検証 (DoD 4) に進める。
- 残 DoD: 2 (migration runner 結線) / 4 (staging DSQL 実行) / 5 (本番) / 6 (dynamodb 撤去 #3438) は EPIC #3424 の DoD コメントで追跡。

## レビュー依頼事項・破壊的変更

破壊的変更なし。flag なしで template 不変を [W1] が保証。実 deploy は本 PR の scope 外 (ユーザー承認事項)。

## 配布済み env / secret (ADR-0006)

新規 secret なし。dsqlEndpoint / dsqlClusterArn は DsqlStack deploy 後の CloudFormation 出力値を deploy workflow が `-c` で渡す運用 (secret ではなく資源識別子)。配布は M5 実 deploy 時。

## Ready for Review チェックリスト

- [x] 実装 + テストが 1 PR で完結
- [x] 局所テスト PASS (infra 83/83)
- [x] biome / cspell clean
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
