### PR TITLE
feat(dsql): #3424 M5 schema provisioning CLI (migration runner の実行経路結線、DoD 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"format": "biome format --write .",
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
+		"dsql:migrate": "tsx scripts/dsql-migrate.ts",
 		"db:push": "drizzle-kit push",
 		"db:studio": "drizzle-kit studio",
 		"db:seed": "tsx src/lib/server/db/seed.ts",

--- a/scripts/dsql-migrate.ts
+++ b/scripts/dsql-migrate.ts
@@ -1,0 +1,81 @@
+// scripts/dsql-migrate.ts — DSQL cluster への schema provisioning CLI (EPIC #3424 M5 DoD 2)
+//
+// 生成済み migration (drizzle/pglite/、dsql/schema.ts の drizzle-kit generate 出力) を
+// transform (DSQL 方言変換) → autocommit 適用 → ASYNC index poll の経路で DSQL cluster に
+// 適用する。core logic は src/lib/server/db/dsql/migration/provision.ts (unit test 済) に集約し、
+// 本 CLI は接続確立 + 引数処理のみの thin wrapper (使い捨て script ではない恒久運用ツール #1442)。
+//
+// 実行 (tsx、DbConnectAdmin 相当の AWS credential が必要):
+//   DSQL_ENDPOINT=<id>.dsql.<region>.on.aws npm run dsql:migrate            # 適用
+//   DSQL_ENDPOINT=... npm run dsql:migrate -- --dry-run                     # plan 表示のみ
+//
+// ⚠️ 運用制約 (provision.ts 設計判断): applied 管理は tag 単位。tag 途中で失敗した場合、
+//    その tag は未記録のまま = 再実行は同 tag 先頭から適用し既存 object と衝突し得る。
+//    ゼロユーザー期 (EPIC #3424 前提) は対象 schema を落として再適用が最も安全:
+//      DROP TABLE 全表 (または cluster 再作成) → 本 CLI 再実行
+//
+// migration 経路の credential は実行時アプリ (dsql:DbConnect) と分離された DbConnectAdmin
+// (M3 §3.4 B6)。deploy workflow への組込は staging DSQL 経路 (EPIC #3424 DoD 4) で行う。
+
+import { resolve } from 'node:path';
+import { AuroraDSQLPool } from '@aws/aurora-dsql-node-postgres-connector';
+import type { RawSqlExecutor } from '../src/lib/server/db/dsql/migration/async-index-poll';
+import {
+	loadMigrationFiles,
+	provisionDsqlSchema,
+} from '../src/lib/server/db/dsql/migration/provision';
+import { transformDrizzleSqlToDsql } from '../src/lib/server/db/dsql/migration/transform';
+
+const dryRun = process.argv.includes('--dry-run');
+const migrationsDir =
+	process.env.DSQL_MIGRATIONS_DIR ?? resolve(process.cwd(), 'drizzle', 'pglite');
+
+async function main(): Promise<void> {
+	if (dryRun) {
+		// 接続不要: transform 結果 (DDL 文数 / ASYNC index) を表示して終了。
+		for (const file of loadMigrationFiles(migrationsDir)) {
+			const plan = transformDrizzleSqlToDsql(file.sqlText);
+			const asyncCount = plan.ddl.filter((s) => s.asyncIndexName).length;
+			console.log(`[dry-run] ${file.tag}: ddl=${plan.ddl.length} 文 (ASYNC index=${asyncCount})`);
+		}
+		return;
+	}
+
+	const endpoint = process.env.DSQL_ENDPOINT;
+	if (!endpoint) {
+		console.error(
+			'[dsql-migrate] DSQL_ENDPOINT が未設定です。DsqlStack の ClusterEndpoint 出力を設定してください。',
+		);
+		process.exit(1);
+	}
+
+	// migration は DbConnectAdmin 経路 (admin role)。実行時アプリの DbConnect とは分離 (M3 §3.4 B6)。
+	const pool = new AuroraDSQLPool({
+		host: endpoint,
+		user: process.env.DSQL_MIGRATE_USER ?? 'admin',
+		database: process.env.DSQL_DATABASE ?? 'postgres',
+		ssl: true,
+	});
+	const executor: RawSqlExecutor = {
+		execute: async (sqlText: string) => {
+			const res = await pool.query(sqlText);
+			return { rows: (res as { rows?: unknown[] }).rows ?? [] };
+		},
+	};
+
+	try {
+		const result = await provisionDsqlSchema(migrationsDir, executor);
+		for (const s of result.skipped) console.log(`[skip] ${s} (適用済み)`);
+		for (const a of result.applied) console.log(`[applied] ${a.tag} (ddl=${a.plan.ddl.length} 文)`);
+		console.log(
+			`[dsql-migrate] 完了: applied=${result.applied.length} / skipped=${result.skipped.length}`,
+		);
+	} finally {
+		await (pool as unknown as { end(): Promise<void> }).end();
+	}
+}
+
+main().catch((err) => {
+	console.error('[dsql-migrate] 失敗:', err);
+	process.exit(1);
+});

--- a/src/lib/server/db/dsql/migration/provision.ts
+++ b/src/lib/server/db/dsql/migration/provision.ts
@@ -1,0 +1,91 @@
+// src/lib/server/db/dsql/migration/provision.ts
+// EPIC #3424 M5 (DoD 2) — 生成済み migration (drizzle/pglite/) を DSQL cluster へ適用する
+// provisioning orchestration。runner.ts (autocommit 適用 + ASYNC poll) の上位層として、
+// journal 順の tag 列挙 / applied 管理 (dsql_migrations 表) / 冪等 skip を担う。
+//
+// 設計判断:
+//   - **migration SQL の SSOT は drizzle/pglite/** (dsql/schema.ts から drizzle-kit generate)。
+//     PGlite (NUC) と DSQL (cloud) は同一 pg-core schema のため生成物を共有し、DSQL 固有の
+//     方言差 (CREATE INDEX ASYNC / 1txn1DDL) は transform.ts が吸収する (二重生成しない)。
+//   - **applied 管理は tag 単位** (dsql_migrations 表、drizzle 標準 __drizzle_migrations と
+//     同思想)。statement 単位 resume は持たない: EPIC #3424 は「ゼロユーザー期に DSQL へ
+//     作り直す」前提で、部分失敗時は cluster 内の対象 schema を落として再適用が最も安全・単純
+//     (Pre-PMF、ADR-0010)。この制約は CLI (--help) にも明示する。
+//   - executor は RawSqlExecutor (runner と同じ最小面) を注入: 実 DSQL (AuroraDSQLPool) でも
+//     テスト (PGlite / fake) でも同じ経路を検証できる。
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { RawSqlExecutor } from './async-index-poll';
+import { type ApplyMigrationOptions, runDsqlMigration } from './runner';
+import type { DsqlMigrationPlan } from './transform';
+
+/** drizzle-kit journal (meta/_journal.json) の最小形状。 */
+interface DrizzleJournal {
+	entries: { idx: number; tag: string }[];
+}
+
+export interface MigrationFile {
+	tag: string;
+	sqlText: string;
+}
+
+/** journal 順 (idx 昇順) に migration SQL を読み込む。 */
+export function loadMigrationFiles(migrationsDir: string): MigrationFile[] {
+	const journal = JSON.parse(
+		readFileSync(join(migrationsDir, 'meta', '_journal.json'), 'utf-8'),
+	) as DrizzleJournal;
+	return [...journal.entries]
+		.sort((a, b) => a.idx - b.idx)
+		.map((e) => ({
+			tag: e.tag,
+			sqlText: readFileSync(join(migrationsDir, `${e.tag}.sql`), 'utf-8'),
+		}));
+}
+
+/** applied 管理表。tag 単位の冪等 skip に使う (statement 単位 resume は持たない — 上記設計判断)。 */
+const APPLIED_TABLE_DDL = `CREATE TABLE IF NOT EXISTS dsql_migrations (
+	tag text PRIMARY KEY,
+	applied_at timestamptz NOT NULL DEFAULT now()
+)`;
+
+/** 適用済み tag 集合を取得する (管理表が無ければ作る)。 */
+export async function fetchAppliedTags(executor: RawSqlExecutor): Promise<Set<string>> {
+	await executor.execute(APPLIED_TABLE_DDL);
+	const res = await executor.execute('SELECT tag FROM dsql_migrations');
+	return new Set((res.rows as { tag: string }[]).map((r) => r.tag));
+}
+
+export interface ProvisionResult {
+	applied: { tag: string; plan: DsqlMigrationPlan }[];
+	skipped: string[];
+}
+
+/**
+ * 生成済み migration を journal 順に DSQL へ適用する (tag 単位冪等)。
+ * 各 tag: transform → autocommit 1 文ずつ適用 (+ ASYNC index poll) → 成功後に applied 記録。
+ * 途中失敗はその tag が未記録のまま throw する (再実行時は同 tag 先頭から。部分適用が残る場合は
+ * ゼロユーザー期のため schema を落として再適用が運用手順 — CLI help に明示)。
+ */
+export async function provisionDsqlSchema(
+	migrationsDir: string,
+	executor: RawSqlExecutor,
+	opts: ApplyMigrationOptions = {},
+): Promise<ProvisionResult> {
+	const files = loadMigrationFiles(migrationsDir);
+	const appliedTags = await fetchAppliedTags(executor);
+	const result: ProvisionResult = { applied: [], skipped: [] };
+	for (const file of files) {
+		if (appliedTags.has(file.tag)) {
+			result.skipped.push(file.tag);
+			continue;
+		}
+		const plan = await runDsqlMigration(file.sqlText, executor, opts);
+		// 成功した tag のみ記録 (INSERT 自体も autocommit 単文)。
+		await executor.execute(
+			`INSERT INTO dsql_migrations (tag) VALUES ('${file.tag.replace(/'/g, "''")}')`,
+		);
+		result.applied.push({ tag: file.tag, plan });
+	}
+	return result;
+}

--- a/tests/unit/db/dsql-migration-provision.test.ts
+++ b/tests/unit/db/dsql-migration-provision.test.ts
@@ -1,0 +1,126 @@
+// tests/unit/db/dsql-migration-provision.test.ts
+// EPIC #3424 M5 (DoD 2) — DSQL schema provisioning orchestration (provision.ts) のテスト。
+//
+//   [PV1] loadMigrationFiles: journal idx 順に tag + sqlText を読む
+//   [PV2] fetchAppliedTags: 管理表を作成し適用済み tag 集合を返す
+//   [PV3] provisionDsqlSchema: 未適用 tag のみ適用し、成功後に applied 記録 (冪等 skip)
+//   [PV4] 途中失敗: 失敗 tag は applied 記録されず throw (再実行で再試行される)
+//   [PV5] 実 migration SSOT 貫通: drizzle/pglite/ の実 journal + SQL が transform を通り
+//         plan (ddl>0) を生成できる (dry-run 経路の実データ検証、45 表 schema の supply line)
+//
+// executor は fake (実行 SQL を記録) — runner の適用 semantics (autocommit / ASYNC poll) は
+// dsql-migration-runner.test.ts が担保済のため、本テストは orchestration (順序 / 冪等 / 記録) に
+// 限定する (重複検証しない)。
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { RawSqlExecutor } from '../../../src/lib/server/db/dsql/migration/async-index-poll';
+import {
+	fetchAppliedTags,
+	loadMigrationFiles,
+	provisionDsqlSchema,
+} from '../../../src/lib/server/db/dsql/migration/provision';
+import { transformDrizzleSqlToDsql } from '../../../src/lib/server/db/dsql/migration/transform';
+
+const tempDirs: string[] = [];
+
+/** journal + sql ファイルを持つ temp migrations dir を作る。 */
+function makeMigrationsDir(entries: { idx: number; tag: string; sql: string }[]): string {
+	const dir = join(tmpdir(), `dsql-prov-${Date.now()}-${tempDirs.length}`);
+	tempDirs.push(dir);
+	mkdirSync(join(dir, 'meta'), { recursive: true });
+	writeFileSync(
+		join(dir, 'meta', '_journal.json'),
+		JSON.stringify({ version: '7', dialect: 'postgresql', entries }),
+	);
+	for (const e of entries) {
+		writeFileSync(join(dir, `${e.tag}.sql`), e.sql);
+	}
+	return dir;
+}
+
+/** 実行 SQL を記録する fake executor。applied 管理表を素朴に再現する。 */
+function makeFakeExecutor(opts: { failOn?: string; preApplied?: string[] } = {}) {
+	const executed: string[] = [];
+	const applied = new Set<string>(opts.preApplied ?? []);
+	const executor: RawSqlExecutor = {
+		execute: async (sqlText: string) => {
+			executed.push(sqlText);
+			if (opts.failOn && sqlText.includes(opts.failOn)) {
+				throw new Error(`fake failure on: ${opts.failOn}`);
+			}
+			if (sqlText.startsWith('SELECT tag FROM dsql_migrations')) {
+				return { rows: [...applied].map((tag) => ({ tag })) };
+			}
+			const insert = sqlText.match(/INSERT INTO dsql_migrations \(tag\) VALUES \('(.+)'\)/);
+			if (insert?.[1]) applied.add(insert[1]);
+			return { rows: [] };
+		},
+	};
+	return { executor, executed, applied };
+}
+
+afterEach(() => {
+	for (const d of tempDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe('DSQL schema provisioning (#3424 M5 DoD2、provision.ts)', () => {
+	it('[PV1] loadMigrationFiles: journal idx 順に読む (journal 逆順でも昇順に整列)', () => {
+		const dir = makeMigrationsDir([
+			{ idx: 1, tag: '0001_second', sql: 'CREATE TABLE b (id int);' },
+			{ idx: 0, tag: '0000_first', sql: 'CREATE TABLE a (id int);' },
+		]);
+		const files = loadMigrationFiles(dir);
+		expect(files.map((f) => f.tag)).toEqual(['0000_first', '0001_second']);
+		expect(files[0]?.sqlText).toContain('CREATE TABLE a');
+	});
+
+	it('[PV2] fetchAppliedTags: 管理表 DDL を発行し適用済み集合を返す', async () => {
+		const { executor, executed } = makeFakeExecutor({ preApplied: ['0000_first'] });
+		const tags = await fetchAppliedTags(executor);
+		expect(executed[0]).toContain('CREATE TABLE IF NOT EXISTS dsql_migrations');
+		expect(tags).toEqual(new Set(['0000_first']));
+	});
+
+	it('[PV3] provisionDsqlSchema: 未適用のみ適用 + applied 記録 (再実行は全 skip = 冪等)', async () => {
+		const dir = makeMigrationsDir([
+			{ idx: 0, tag: '0000_first', sql: 'CREATE TABLE a (id int);' },
+			{ idx: 1, tag: '0001_second', sql: 'CREATE TABLE b (id int);' },
+		]);
+		const { executor } = makeFakeExecutor({ preApplied: ['0000_first'] });
+
+		const first = await provisionDsqlSchema(dir, executor);
+		expect(first.skipped).toEqual(['0000_first']);
+		expect(first.applied.map((a) => a.tag)).toEqual(['0001_second']);
+
+		// 再実行: 全 tag が applied 済み → 全 skip (冪等)
+		const second = await provisionDsqlSchema(dir, executor);
+		expect(second.skipped).toEqual(['0000_first', '0001_second']);
+		expect(second.applied).toEqual([]);
+	});
+
+	it('[PV4] 途中失敗: 失敗 tag は applied 記録されず throw する (再実行で再試行可能)', async () => {
+		const dir = makeMigrationsDir([
+			{ idx: 0, tag: '0000_ok', sql: 'CREATE TABLE a (id int);' },
+			{ idx: 1, tag: '0001_bad', sql: 'CREATE TABLE broken_table (id int);' },
+		]);
+		const { executor, applied } = makeFakeExecutor({ failOn: 'broken_table' });
+
+		await expect(provisionDsqlSchema(dir, executor)).rejects.toThrow('broken_table');
+		// 成功した 0000 のみ記録され、失敗した 0001 は未記録 (再実行対象のまま)
+		expect(applied.has('0000_ok')).toBe(true);
+		expect(applied.has('0001_bad')).toBe(false);
+	});
+
+	it('[PV5] 実 migration SSOT: drizzle/pglite の実 journal + SQL が transform を貫通し plan を生成する', () => {
+		const realDir = resolve(process.cwd(), 'drizzle', 'pglite');
+		const files = loadMigrationFiles(realDir);
+		expect(files.length).toBeGreaterThan(0);
+		for (const file of files) {
+			const plan = transformDrizzleSqlToDsql(file.sqlText);
+			expect(plan.ddl.length, `${file.tag} の ddl が空`).toBeGreaterThan(0);
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

EPIC #3424（DynamoDB→DSQL 移管）の真の完了に向けた schema 構築経路の結線。監査 (2026-07-11) で「migration runner は実装済だがどこからも呼ばれず、DSQL cluster に schema を構築する手段が無い」ことが確定した (EPIC 再オープン DoD 2)。本 PR で provisioning CLI を実装し、cluster deploy 後に schema を構築できる状態にする。

## 関連 Issue

#3424 (EPIC 再オープン、DoD 2) / #3427 (migration runner PoC の実運用化)。deploy workflow への組込 (staging DSQL 経路) は DoD 4 として別 PR。実 cluster への適用はユーザー承認事項。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| journal 順に migration を列挙する | `[PV1]` (逆順 journal でも idx 昇順) | PASS | tests/unit/db/dsql-migration-provision.test.ts |
| applied 管理 (dsql_migrations 表) + 冪等 skip | `[PV2]/[PV3]` (再実行は全 skip) | PASS | 同上 |
| 失敗 tag は未記録で throw (再試行可能) | `[PV4]` | PASS | 同上 |
| 実 migration SSOT (drizzle/pglite) が transform 貫通 | `[PV5]` (45 表 supply line) | PASS | 同上 |
| CLI dry-run 実機貫通 | `npm run dsql:migrate -- --dry-run` = ddl 73 文 / ASYNC index 14 | PASS | ローカル実行ログ |

## 変更タイプ

- [x] 新機能 (DSQL schema provisioning CLI)
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dsql/migration/provision.ts` (新規): orchestration 層 (journal 列挙 / applied 管理 / runner 呼出)。runner/transform/poll は無変更。
- `scripts/dsql-migrate.ts` + `package.json` の `dsql:migrate` script (新規): AuroraDSQLPool (DbConnectAdmin 経路) thin CLI。使い捨て script ではなく恒久運用ツール (#1442 整合)。
- migration SQL の SSOT は `drizzle/pglite/` を共有 (PGlite/NUC と DSQL/cloud は同一 pg-core schema、DSQL 方言差は既存 transform.ts が吸収 — 二重生成しない)。
- 既存 runtime 経路への影響ゼロ (新規 module + CLI のみ、アプリからの import なし)。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/dsql-migration-provision.test.ts` = 5/5 PASS
- [x] CLI dry-run 実機確認 (接続不要経路)
- [x] `npx biome check <changed>` = clean / `npx cspell <changed>` = 0 issue
- [x] runner の適用 semantics (autocommit / ASYNC poll) は既存 dsql-migration-runner.test.ts が担保 (重複検証しない)

## スクリーンショット / ビジュアルデモ

N/A — server 側 module + CLI のみで UI 影響なし。

## コード品質セルフレビュー (#1481)

- credential 分離: CLI は DbConnectAdmin (migration)、実行時アプリは DbConnect のみ (M3 §3.4 B6) — #3637 の compute-stack 配線と対。
- 運用制約 (tag 単位 applied / statement resume なし / 部分失敗はゼロユーザー期につき schema 落として再適用) を module コメント + CLI ヘッダに明示 (silent 制約にしない)。

## 横展開・影響波及チェック

- PGlite (NUC) の boot 時 migrator と DSQL の provisioning CLI が同一生成物 (drizzle/pglite/) を共有するため、schema drift の温床となる二重生成を構造的に回避。
- deploy workflow (staging → 本番) への組込は DoD 4 で扱い、本 PR は実行可能経路の確立まで。

## レビュー依頼事項・破壊的変更

破壊的変更なし。新規 module + CLI のみで既存経路不変。実 DSQL への適用は AWS credential + ユーザー承認が前提 (dry-run は無害)。

## 配布済み env / secret (ADR-0006)

新規 secret なし。DSQL_ENDPOINT / DSQL_MIGRATE_USER / DSQL_MIGRATIONS_DIR は CLI 実行時の env (実 cluster deploy 時に値が決まる資源識別子)。

## Ready for Review チェックリスト

- [x] 実装 + テストが 1 PR で完結
- [x] 局所テスト PASS (5/5 + dry-run 実機)
- [x] biome / cspell clean
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
