### PR TITLE
feat(infra): #3424 M5 AWS staging に DSQL opt-in lane (DoD 4、cluster+provisioning+配線の貫通)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -83,6 +83,7 @@
 		"multiplexing",
 		"multitenant",
 		"NONNEG",
+		"PDCA",
 		"schemaname",
 		"setconfig",
 		"setdatabase",

--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -37,6 +37,15 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      # EPIC #3424 M5 DoD4: DSQL staging lane (opt-in)。true で DsqlStaging cluster deploy →
+      # schema provisioning (dsql:migrate) → staging Lambda を DATA_SOURCE=dsql で起動し、
+      # post-deploy health を DSQL backend で検証する (audit-team.md §3.7#5 の新 backend 適用)。
+      # pull_request trigger (統合 PR) では inputs 不在 = 常に現行 dynamodb lane (不変)。
+      dsqlEnabled:
+        description: 'DSQL backend で staging を deploy (EPIC #3424 M5 PDCA)'
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -54,6 +63,8 @@ env:
   # staging 3 stack の明示列挙 (--all 禁止)。deploy 順は Storage → Auth → Compute 固定
   # (Auth が SSM cognito param を書き、Compute が deploy-time に解決するため順序依存)。
   STAGING_STACKS: GanbariQuestStorageStaging GanbariQuestAuthStaging GanbariQuestComputeStaging
+  # DSQL lane 判定 (DoD4)。dispatch + dsqlEnabled=true のときのみ 'true'。
+  DSQL_LANE: ${{ github.event_name == 'workflow_dispatch' && inputs.dsqlEnabled == true && 'true' || 'false' }}
 
 jobs:
   deploy-aws-staging:
@@ -190,12 +201,51 @@ jobs:
           cache-to: type=gha,mode=max
 
       # Step 10: ADR-0019 gate (staging 3 stack)
+      # Step 10.5 (EPIC #3424 M5 DoD4、DSQL lane のみ): DSQL staging cluster を deploy し、
+      # outputs (endpoint/ARN) を解決 → schema provisioning (dsql:migrate) を実行する。
+      # DP=false (staging は捨てて作り直す前提)。cluster は scale-to-zero + 無料枠内 (¥0 圏)。
+      - name: Deploy DSQL staging cluster (dsql lane)
+        if: env.DSQL_LANE == 'true'
+        working-directory: infra/
+        run: |
+          npx cdk deploy GanbariQuestDsqlStaging --require-approval never \
+            -c dsqlStagingEnabled=true
+
+      - name: Resolve DSQL staging outputs (dsql lane)
+        if: env.DSQL_LANE == 'true'
+        run: |
+          ENDPOINT=$(aws cloudformation describe-stacks --stack-name GanbariQuestDsqlStaging \
+            --region $AWS_REGION \
+            --query "Stacks[0].Outputs[?OutputKey=='ClusterEndpoint'].OutputValue" --output text)
+          ARN=$(aws cloudformation describe-stacks --stack-name GanbariQuestDsqlStaging \
+            --region $AWS_REGION \
+            --query "Stacks[0].Outputs[?OutputKey=='ClusterArn'].OutputValue" --output text)
+          if [ -z "$ENDPOINT" ] || [ -z "$ARN" ] || [ "$ENDPOINT" = "None" ] || [ "$ARN" = "None" ]; then
+            echo "::error::DSQL staging outputs (ClusterEndpoint/ClusterArn) の取得に失敗しました"
+            exit 1
+          fi
+          echo "DSQL_ENDPOINT=$ENDPOINT" >> $GITHUB_ENV
+          echo "DSQL_CLUSTER_ARN=$ARN" >> $GITHUB_ENV
+          echo "::notice::DSQL staging cluster resolved: $ENDPOINT"
+
+      # schema provisioning (#3638 CLI)。OIDC role に dsql:DbConnectAdmin が必要 —
+      # 権限不足で fail した場合はこの step のログが PDCA cycle の学びになる (silent skip しない)。
+      - name: Provision DSQL schema (dsql lane)
+        if: env.DSQL_LANE == 'true'
+        env:
+          DSQL_ENDPOINT: ${{ env.DSQL_ENDPOINT }}
+        run: npm run dsql:migrate
+
       - name: CDK diff — replacement check (staging 3 stacks)
         working-directory: infra/
         run: |
           COMMIT_MSG=$(git log -1 --pretty=%B)
+          DSQL_CTX=""
+          if [ "$DSQL_LANE" = "true" ]; then
+            DSQL_CTX="-c dsqlEnabled=true -c dsqlEndpoint=$DSQL_ENDPOINT -c dsqlClusterArn=$DSQL_CLUSTER_ARN"
+          fi
           npx cdk diff $STAGING_STACKS \
-            -c stagingEnabled=true \
+            -c stagingEnabled=true $DSQL_CTX \
             -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
             -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
             2>&1 | COMMIT_MSG="$COMMIT_MSG" node ../scripts/check-cdk-replacement.mjs
@@ -203,13 +253,19 @@ jobs:
       # Step 11: staging 3 stack を明示列挙で deploy (`--all` 禁止 — 本番 6 stack 混線防止)。
       # Auth → Compute の順序は SSM param (cognito/*) の deploy-time 解決に必要なため、
       # 1 stack ずつ直列に deploy する (Auth/Compute 間に CFN 依存辺は意図的に無い)。
+      # DSQL lane では compute-stack の flag-gated 配線 (#3637) に endpoint/ARN を渡し、
+      # staging Lambda を DATA_SOURCE=dsql で起動する。
       - name: CDK Deploy staging stacks (explicit enumeration)
         working-directory: infra/
         run: |
+          DSQL_CTX=""
+          if [ "$DSQL_LANE" = "true" ]; then
+            DSQL_CTX="-c dsqlEnabled=true -c dsqlEndpoint=$DSQL_ENDPOINT -c dsqlClusterArn=$DSQL_CLUSTER_ARN"
+          fi
           for stack in $STAGING_STACKS; do
             echo "=== cdk deploy $stack ==="
             npx cdk deploy "$stack" --require-approval never \
-              -c stagingEnabled=true \
+              -c stagingEnabled=true $DSQL_CTX \
               -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
               -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
           done

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -123,6 +123,20 @@ if (dsqlEnabled) {
 	});
 }
 
+// --- DSQL staging cluster (EPIC #3424 M5 DoD4 / #3429) ---
+// `-c dsqlStagingEnabled=true` 時のみ instantiate。deploy-aws-staging.yml の dsql opt-in lane が
+// deploy し、staging Lambda (DATA_SOURCE=dsql) の接続先 + schema provisioning (dsql:migrate) の
+// 対象になる。staging は捨てて作り直す前提のため deletion protection を外す (本番 Dsql は DP=true
+// 既定のまま)。alarm/Budgets subscription は本番系に限定 (opsEmail 非注入 = 通知ノイズ防止)。
+const dsqlStagingEnabled = String(app.node.tryGetContext('dsqlStagingEnabled')) === 'true';
+if (dsqlStagingEnabled) {
+	new DsqlStack(app, `${appName}DsqlStaging`, {
+		env,
+		description: 'Aurora DSQL staging cluster (EPIC #3424 M5 DoD4、PDCA 用・DP なし)',
+		deletionProtection: false,
+	});
+}
+
 // --- AWS staging 3 stack (#2873 / EPIC #2861 D 系) ---
 // `-c stagingEnabled=true` 時のみ instantiate する context gate。
 // 本番の `cdk deploy --all` / `cdk diff --all` (deploy.yml) は context 無しで実行されるため

--- a/infra/lib/dsql-stack.ts
+++ b/infra/lib/dsql-stack.ts
@@ -193,5 +193,11 @@ export class DsqlStack extends cdk.Stack {
 			value: `${clusterId}.dsql.${this.region}.on.aws`,
 			description: 'DSQL 接続 endpoint (connection.ts の DSQL_ENDPOINT に配布)',
 		});
+		// EPIC #3424 M5 DoD4: deploy workflow が describe-stacks で取得し、compute-stack の
+		// dsql:DbConnect resource 限定 (-c dsqlClusterArn) に渡す。
+		new cdk.CfnOutput(this, 'ClusterArn', {
+			value: this.cluster.attrResourceArn,
+			description: 'DSQL cluster ARN (dsql:DbConnect の resource 限定に使用)',
+		});
 	}
 }

--- a/tests/unit/infra/dsql-cdk.test.ts
+++ b/tests/unit/infra/dsql-cdk.test.ts
@@ -36,6 +36,12 @@ describe('DsqlStack (EPIC #3424 M4-E item 12)', () => {
 		});
 	});
 
+	it('[I2b] ClusterEndpoint / ClusterArn output を持つ (M5 DoD4: workflow が OutputKey 名で解決する契約)', () => {
+		// deploy-aws-staging.yml (DSQL lane) が describe-stacks --query OutputKey==... で取得する。
+		template.hasOutput('ClusterEndpoint', {});
+		template.hasOutput('ClusterArn', {});
+	});
+
 	it('[I3] コストガードレール alarm 2 本 (TotalDPU 日次 3,225 / Storage 0.8GiB) (#3431)', () => {
 		template.resourceCountIs('AWS::CloudWatch::Alarm', 2);
 		template.hasResourceProperties('AWS::CloudWatch::Alarm', {


### PR DESCRIPTION
## 顧客価値・目的

EPIC #3424（DynamoDB→DSQL 移管）の staging 実機検証を可能にする。staging を DSQL backend で deploy → schema 構築 → health 検証まで 1 workflow で貫通させ、本番 cutover 前の PDCA（PO 承認済 2026-07-11）を回せる状態にする（audit-team.md §3.7#5 を新 backend で満たす経路）。

## 関連 Issue

#3424 (EPIC、DoD 4) / #3429 (cluster deploy)。#3637 (compute 配線) / #3638 (provisioning CLI) merge 済みの上に成立。実 deploy 起動（workflow_dispatch）は本 PR merge 後に PDCA cycle 1 として実施する。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| pull_request trigger（統合 PR）は現行 dynamodb lane 完全不変 | DSQL_LANE 判定は dispatch + input true のみ。inputs 不在 = false | PASS | workflow diff（if 条件） |
| DsqlStaging stack が gate 経由でのみ合成（DP=false / opsEmail 非注入） | bin/app.ts dsqlStagingEnabled gate + [I2] DP test | PASS | tests/unit/infra/dsql-cdk.test.ts |
| ClusterEndpoint/ClusterArn output 契約（workflow が OutputKey 名で解決） | `[I2b]` hasOutput | PASS | 同上 |
| outputs 取得失敗は fail-close（silent 誤配線防止） | workflow の空/None チェック → exit 1 | PASS | workflow diff |
| 既存 infra テスト回帰なし | infra 全体 | PASS (84/84) | ローカル実行ログ |
| YAML 構文 valid | yaml parse | PASS | ローカル検証 |

## 変更タイプ

- [x] 新機能 (staging DSQL opt-in lane)
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `deploy-aws-staging.yml`: dispatch input `dsqlEnabled`（default false）。DSQL lane = DsqlStaging deploy → outputs 解決 → `npm run dsql:migrate`（schema 構築）→ staging 3 stack に `-c dsqlEnabled/-c dsqlEndpoint/-c dsqlClusterArn` → 既存 health が DSQL Lambda を検証。
- `infra/bin/app.ts`: `dsqlStagingEnabled` gate（DP=false、opsEmail 非注入）。本番 Dsql gate は不変。
- `infra/lib/dsql-stack.ts`: ClusterArn CfnOutput 追加。
- `.cspell.json`: PDCA 追加。
- **既定経路（pull_request / flag なし dispatch）は workflow・template とも完全不変**。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/infra/` = 84/84 PASS
- [x] `npx biome check <changed>` = clean / `npx cspell <changed>` = 0 issue / YAML valid
- [x] fail-close: outputs 取得失敗 exit 1 / provisioning fail は step fail（silent skip なし）
- [x] DSQL lane は opt-in（dispatch input）のみ。統合 PR の staging 検証（dynamodb）に影響ゼロ

## スクリーンショット / ビジュアルデモ

N/A — infra (CDK/workflow) + test のみで UI 影響なし。

## コード品質セルフレビュー (#1481)

- 留意（synth 混入、無害）: DSQL lane の staging synth では `-c dsqlEnabled=true` により app.ts の本番 Dsql stack も合成されるが、diff/deploy は STAGING_STACKS 明示列挙のため対象外（deploy されない）。本番 cutover では同 flag が cluster+配線の両方を ON にする一貫設計。
- provisioning step は OIDC role に `dsql:DbConnectAdmin` が必要。不足時は step fail がそのまま PDCA cycle 1 の学びになる設計（コメント明示、silent skip しない）。

## 横展開・影響波及チェック

- NUC staging の PGlite 経路は AC-C4（データ移行）が前提のため別 PR（EPIC #3620）。
- 本番 deploy.yml への DSQL lane 追加は staging PDCA green 後の DoD 5（ユーザー承認事項）。

## レビュー依頼事項・破壊的変更

破壊的変更なし。opt-in lane 追加のみで既定経路完全不変。実 deploy（cluster 作成）は本 PR merge 後の dispatch 起動時（PO 承認済 staging PDCA、コストは scale-to-zero + 無料枠内）。

## 配布済み env / secret (ADR-0006)

新規 secret なし。endpoint/ARN は workflow 内で CFN outputs から動的解決（配布不要）。staging OIDC role への `dsql:DbConnectAdmin` / `dsql:CreateCluster` 等の権限追加が cycle 1 で必要になる可能性あり（不足時は該当 step fail のログで特定 → ユーザーへ依頼）。

## Ready for Review チェックリスト

- [x] 実装 + テストが 1 PR で完結
- [x] 局所テスト PASS (infra 84/84)
- [x] biome / cspell / YAML clean
- [x] base = develop（#3637/#3638 merge 済みの上に rebase 済み、DoD4 差分のみ）

## QM レビュー結果

QM レビュー待ち。
