### PR TITLE
feat(nuc): #3620 AC-C4 cross-backend round-trip 実証 + local tenantId の backend-aware 化

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -79,6 +79,7 @@
 		"datconfig",
 		"datname",
 		"Idents",
+		"hana",
 		"ILIKE",
 		"multiplexing",
 		"multitenant",

--- a/src/lib/server/auth/local-tenant.ts
+++ b/src/lib/server/auth/local-tenant.ts
@@ -1,0 +1,28 @@
+// src/lib/server/auth/local-tenant.ts
+// EPIC #3620 AC-C4 — NUC (AUTH_MODE=local) 単一テナントの tenantId SSOT。
+//
+// 背景: 旧 sqlite/dynamodb backend の tenant_id は text 型で、local auth は固定文字列 'local' を
+// 使ってきた。新 pg-core schema (PGlite/DSQL) の family_id は **uuid 型**のため、'local' のままだと
+// 全クエリが uuid parse error になる (cross-backend round-trip test で実証)。
+//
+// 解決: backend に応じて tenantId を解決する。
+//   - pglite / dsql (pg-core 新 schema) → LOCAL_TENANT_UUID (固定 UUID)
+//   - sqlite / dynamodb (旧 schema)      → 'local' (既存データの帰属キーと後方互換)
+// cutover (旧→新 backend のデータ移行) では、旧 backend から export したデータを
+// LOCAL_TENANT_UUID を tenantId として import する (export データ自体は tenant 非依存、
+// importFamilyData の引数で新テナントに帰属させる = §12.2 import-then-swap)。
+
+/**
+ * NUC 単一テナントの固定 UUID。
+ * ⚠️ 一度 cutover したら不変 (この値が新 DB 全行の帰属キーになる)。変更はデータ孤立を招く。
+ */
+export const LOCAL_TENANT_UUID = '00000000-0000-4000-8000-00000000c0ca';
+
+/**
+ * local auth (NUC 単一テナント) の tenantId を DATA_SOURCE に応じて解決する。
+ * pg-core 系 backend は uuid 型 family_id のため UUID を、旧 backend は既存データとの
+ * 後方互換のため 'local' を返す。
+ */
+export function resolveLocalTenantId(dataSource: string | undefined): string {
+	return dataSource === 'pglite' || dataSource === 'dsql' ? LOCAL_TENANT_UUID : 'local';
+}

--- a/src/lib/server/auth/providers/local.ts
+++ b/src/lib/server/auth/providers/local.ts
@@ -3,6 +3,8 @@
 
 import type { RequestEvent } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { getEnv } from '$lib/runtime/env';
+import { resolveLocalTenantId } from '../local-tenant';
 import type { AuthContext, AuthProvider, AuthResult, Identity } from '../types';
 
 export class LocalAuthProvider implements AuthProvider {
@@ -12,9 +14,11 @@ export class LocalAuthProvider implements AuthProvider {
 	}
 
 	async resolveContext(_event: RequestEvent, _identity: Identity | null): Promise<AuthContext> {
-		// 単一テナント固定、常に owner
+		// 単一テナント固定、常に owner。tenantId は backend-aware (#3620 AC-C4):
+		// pg-core 系 (pglite/dsql) は uuid 型 family_id のため固定 UUID、旧 backend は 'local'
+		// (既存データの帰属キー) を維持する。SSOT: ../local-tenant.ts
 		return {
-			tenantId: 'local',
+			tenantId: resolveLocalTenantId(getEnv().DATA_SOURCE),
 			role: 'owner',
 			licenseStatus: AUTH_LICENSE_STATUS.NONE,
 		};

--- a/src/lib/server/services/last-active-touch.ts
+++ b/src/lib/server/services/last-active-touch.ts
@@ -12,6 +12,7 @@
 //     ため、in-memory cache (LRU 風 Map) で十分
 //   - cache は 10000 テナント上限で truncation する (Pre-PMF 想定 << 10000)
 
+import { LOCAL_TENANT_UUID } from '$lib/server/auth/local-tenant';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 
@@ -39,11 +40,13 @@ export function _resetLastActiveTouchCacheForTesting(): void {
  * - 当日中に既に書き込み済みなら no-op (DB に行かない)
  * - 失敗しても例外は投げない (hooks のホットパスを止めないため)
  *
- * @param tenantId 対象テナント。'demo' / 'local' / falsy ならスキップ。
+ * @param tenantId 対象テナント。'demo' / 'local' / LOCAL_TENANT_UUID / falsy ならスキップ。
  */
 export async function touchTenantLastActive(tenantId: string | undefined | null): Promise<void> {
 	if (!tenantId) return;
-	if (tenantId === 'demo' || tenantId === 'local') return;
+	// #3620 AC-C4: NUC 単一テナントは pg-core backend では固定 UUID になる (local-tenant.ts SSOT)。
+	// 旧 'local' と同様に touch 対象外 (NUC は analytics 対象外の単一家庭)。
+	if (tenantId === 'demo' || tenantId === 'local' || tenantId === LOCAL_TENANT_UUID) return;
 
 	const today = getDayKey();
 	const lastDay = lastTouchCache.get(tenantId);

--- a/src/lib/server/services/pin-operator-reset.ts
+++ b/src/lib/server/services/pin-operator-reset.ts
@@ -16,11 +16,9 @@
 
 import { env } from '$lib/runtime/env';
 import { getAuthMode } from '$lib/server/auth/factory';
+import { resolveLocalTenantId } from '$lib/server/auth/local-tenant';
 import { getSetting, setSetting } from '$lib/server/db/settings-repo';
 import { logger } from '$lib/server/logger';
-
-/** AUTH_MODE=local は単一 tenant ('local' 固定、local.ts provider と同値) */
-const LOCAL_TENANT_ID = 'local';
 
 /** プロセスごとに 1 回だけ評価する (2 回目以降は同期 return で zero cost) */
 let evaluatedThisProcess = false;
@@ -53,7 +51,12 @@ export async function applyOperatorPinResetIfRequested(): Promise<void> {
 		return;
 	}
 
-	const applied = await getSetting('pin_reset_applied', LOCAL_TENANT_ID);
+	// #3620 AC-C4 (QM BLOCK remedy): tenantId は local-tenant.ts SSOT で backend-aware に解決する。
+	// 旧ハードコード 'local' のままだと pglite cutover 後に実 PIN (LOCAL_TENANT_UUID 配下) と
+	// reset 書込先 ('local') が分裂し、operator reset が silent no-op になる (保護者 PIN 復旧不能)。
+	const localTenantId = resolveLocalTenantId(env.DATA_SOURCE);
+
+	const applied = await getSetting('pin_reset_applied', localTenantId);
 	if (applied === token) {
 		// 適用済 token: 冪等 no-op。env の unset 忘れ (Metabase 反面教師) でも再 reset しない
 		logger.info('[PIN_RESET] PARENT_PIN_RESET は適用済みです (env の削除を推奨)', {
@@ -64,14 +67,14 @@ export async function applyOperatorPinResetIfRequested(): Promise<void> {
 
 	// 既定状態に初期化: pin_hash 空 (= isPinConfigured false → #2992 初回作成フロー) +
 	// 失敗カウンタ / ロックアウトも解除 (ロック中に忘れたケースの救済)
-	await setSetting('pin_hash', '', LOCAL_TENANT_ID);
-	await setSetting('pin_failed_attempts', '0', LOCAL_TENANT_ID);
-	await setSetting('pin_locked_until', '', LOCAL_TENANT_ID);
-	await setSetting('pin_reset_applied', token, LOCAL_TENANT_ID);
+	await setSetting('pin_hash', '', localTenantId);
+	await setSetting('pin_failed_attempts', '0', localTenantId);
+	await setSetting('pin_locked_until', '', localTenantId);
+	await setSetting('pin_reset_applied', token, localTenantId);
 
 	// audit log (適用事実の記録、AC6)
 	logger.warn(
 		'[AUDIT] [PIN_RESET] operator PIN reset を適用しました — PIN は未設定状態に戻り、次回アクセスで新規作成フローになります。適用後は PARENT_PIN_RESET env を削除してください',
-		{ context: { tokenPrefix: token.slice(0, 8), tenantId: LOCAL_TENANT_ID } },
+		{ context: { tokenPrefix: token.slice(0, 8), tenantId: localTenantId } },
 	);
 }

--- a/tests/unit/auth/local-tenant.test.ts
+++ b/tests/unit/auth/local-tenant.test.ts
@@ -1,0 +1,28 @@
+// tests/unit/auth/local-tenant.test.ts
+// EPIC #3620 AC-C4 — NUC local auth tenantId の backend-aware 解決 (local-tenant.ts SSOT)。
+//
+// 背景: pg-core 新 schema (PGlite/DSQL) の family_id は uuid 型で、旧固定文字列 'local' は
+// 全クエリ uuid parse error になる (cross-backend round-trip test で実証)。backend に応じた
+// 解決契約を固定し、cutover 前後の帰属キー不整合を防ぐ。
+
+import { describe, expect, it } from 'vitest';
+import { LOCAL_TENANT_UUID, resolveLocalTenantId } from '../../../src/lib/server/auth/local-tenant';
+
+describe('local-tenant (#3620 AC-C4、backend-aware tenantId)', () => {
+	it('[LT1] pg-core 系 (pglite/dsql) は固定 UUID を返す', () => {
+		expect(resolveLocalTenantId('pglite')).toBe(LOCAL_TENANT_UUID);
+		expect(resolveLocalTenantId('dsql')).toBe(LOCAL_TENANT_UUID);
+	});
+
+	it('[LT2] 旧 backend (sqlite/dynamodb/未指定) は後方互換の "local" を返す', () => {
+		expect(resolveLocalTenantId('sqlite')).toBe('local');
+		expect(resolveLocalTenantId('dynamodb')).toBe('local');
+		expect(resolveLocalTenantId(undefined)).toBe('local');
+	});
+
+	it('[LT3] LOCAL_TENANT_UUID は uuid 形式 (pg uuid 列に挿入可能)', () => {
+		expect(LOCAL_TENANT_UUID).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+		);
+	});
+});

--- a/tests/unit/services/pglite-cutover-roundtrip.test.ts
+++ b/tests/unit/services/pglite-cutover-roundtrip.test.ts
@@ -74,11 +74,25 @@ describe('NUC cutover cross-backend round-trip (#3620 AC-C4、旧 sqlite → PGl
 		const hana = await reposA.child.insertChild({ nickname: '移行花子', age: 6 }, TENANT);
 
 		const act1 = await reposA.activity.insertActivity(
-			{ name: 'はみがき', categoryId: asCategoryId('3'), icon: '🦷', basePoints: 5, ageMin: null, ageMax: null },
+			{
+				name: 'はみがき',
+				categoryId: asCategoryId('3'),
+				icon: '🦷',
+				basePoints: 5,
+				ageMin: null,
+				ageMax: null,
+			},
 			TENANT,
 		);
 		await reposA.activity.insertActivity(
-			{ name: 'おてつだい', categoryId: asCategoryId('3'), icon: '🧹', basePoints: 10, ageMin: null, ageMax: null },
+			{
+				name: 'おてつだい',
+				categoryId: asCategoryId('3'),
+				icon: '🧹',
+				basePoints: 10,
+				ageMin: null,
+				ageMax: null,
+			},
 			TENANT,
 		);
 

--- a/tests/unit/services/pglite-cutover-roundtrip.test.ts
+++ b/tests/unit/services/pglite-cutover-roundtrip.test.ts
@@ -17,6 +17,7 @@
 // settings / login bonus) で件数・内容一致を確認する (重複検証しない)。
 
 import { afterAll, describe, expect, it, vi } from 'vitest';
+import { asCategoryId } from '../../../src/lib/domain/ids';
 
 // ── Phase A 用の旧 sqlite test-db mock (既存 backup-roundtrip と同型)。
 // resetModules 後の Phase B では pglite 分岐が client を参照しないため、この mock は無害に残る。
@@ -73,11 +74,11 @@ describe('NUC cutover cross-backend round-trip (#3620 AC-C4、旧 sqlite → PGl
 		const hana = await reposA.child.insertChild({ nickname: '移行花子', age: 6 }, TENANT);
 
 		const act1 = await reposA.activity.insertActivity(
-			{ name: 'はみがき', categoryId: '3', icon: '🦷', basePoints: 5 },
+			{ name: 'はみがき', categoryId: asCategoryId('3'), icon: '🦷', basePoints: 5, ageMin: null, ageMax: null },
 			TENANT,
 		);
 		await reposA.activity.insertActivity(
-			{ name: 'おてつだい', categoryId: '3', icon: '🧹', basePoints: 10 },
+			{ name: 'おてつだい', categoryId: asCategoryId('3'), icon: '🧹', basePoints: 10, ageMin: null, ageMax: null },
 			TENANT,
 		);
 

--- a/tests/unit/services/pglite-cutover-roundtrip.test.ts
+++ b/tests/unit/services/pglite-cutover-roundtrip.test.ts
@@ -1,0 +1,173 @@
+// tests/unit/services/pglite-cutover-roundtrip.test.ts
+// EPIC #3620 AC-C4 (ADR-0064 §12.2) — NUC cutover の cross-backend round-trip 機械検証。
+//
+// 「旧 NUC (better-sqlite3、integer PK 旧 schema) で export → 新 PGlite (pg-core、UUID PK 新
+// schema) へ import」が **id 非保全・自然キー再解決** (ADR-0064 §結果「§12.2 backup round-trip
+// は backend 差に非依存で整合」) で成立することを実証する。これが成立すれば NUC cutover の
+// データ移行機構 = 既存 export/import service の組み合わせで足りることが機械証明される。
+//
+// 構成 (1 it 内で 2 phase 直列 — module graph を跨ぐ state は plain JSON の exportData のみ):
+//   Phase A: DATA_SOURCE=sqlite + test-db mock → repos 直 seed → exportFamilyData → ExportData
+//   Phase B: vi.resetModules + DATA_SOURCE=pglite → initPglite (in-memory、実 migration 適用)
+//            → importFamilyData(exportData) → dsql repos で件数 + 自然キー内容を検証
+//
+// 完全網羅 (全 source 実体) は既存 backup-roundtrip-completeness.test.ts が sqlite 内 round-trip
+// で担保済み。本テストの責務は「pg backend への import 経路が cross-backend で貫通する」ことの
+// 検証に限定し、代表 source 実体 (children / activities / logs / ledger / rewards / checklist /
+// settings / login bonus) で件数・内容一致を確認する (重複検証しない)。
+
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+// ── Phase A 用の旧 sqlite test-db mock (既存 backup-roundtrip と同型)。
+// resetModules 後の Phase B では pglite 分岐が client を参照しないため、この mock は無害に残る。
+let testDb: unknown;
+let testSqlite: { close(): void } | null = null;
+
+vi.mock('$lib/server/db', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		return testDb;
+	},
+	getOrInitDb() {
+		return testDb;
+	},
+}));
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+// 新 schema (pg-core) の family_id は uuid 型のため、cutover 先 tenant は UUID 必須。
+// 旧 NUC (sqlite) の tenant_id は text で非 UUID (local auth 固定値) — export データ自体は
+// tenant 非依存 (importFamilyData の tenantId 引数で新 tenant を指定) のため、cutover では
+// 「新環境の UUID tenant を発行して import する」のが正 (本 test はその契約を実証する)。
+const TENANT = '00000000-0000-4000-8000-00000000cc41';
+const originalDataSource = process.env.DATA_SOURCE;
+
+afterAll(async () => {
+	if (originalDataSource === undefined) delete process.env.DATA_SOURCE;
+	else process.env.DATA_SOURCE = originalDataSource;
+	testSqlite?.close();
+});
+
+describe('NUC cutover cross-backend round-trip (#3620 AC-C4、旧 sqlite → PGlite)', () => {
+	it('旧 sqlite で export した家族データが PGlite (pg-core 新 schema) に自然キー再解決で復元される', async () => {
+		// ═══ Phase A: 旧 sqlite backend で seed → export ═══
+		process.env.DATA_SOURCE = 'sqlite';
+		const { createTestDb } = await import('../helpers/test-db');
+		const t = createTestDb();
+		testDb = t.db;
+		testSqlite = t.sqlite;
+
+		const { getRepos: getReposA } = await import('../../../src/lib/server/db/factory');
+		const reposA = getReposA();
+
+		// 代表 source 実体を seed (自然キーで後段検証できる値を使う)
+		const taro = await reposA.child.insertChild(
+			{ nickname: '移行太郎', age: 8, birthDate: '2018-02-10' },
+			TENANT,
+		);
+		const hana = await reposA.child.insertChild({ nickname: '移行花子', age: 6 }, TENANT);
+
+		const act1 = await reposA.activity.insertActivity(
+			{ name: 'はみがき', categoryId: '3', icon: '🦷', basePoints: 5 },
+			TENANT,
+		);
+		await reposA.activity.insertActivity(
+			{ name: 'おてつだい', categoryId: '3', icon: '🧹', basePoints: 10 },
+			TENANT,
+		);
+
+		await reposA.activity.insertActivityLog(
+			{
+				childId: taro.id,
+				activityId: act1.id,
+				points: 5,
+				streakDays: 1,
+				streakBonus: 0,
+				recordedDate: '2026-07-01',
+				recordedAt: '2026-07-01T09:00:00.000Z',
+			},
+			TENANT,
+		);
+
+		await reposA.point.insertPointEntry(
+			{ childId: taro.id, amount: 15, type: 'activity', description: '記録' },
+			TENANT,
+		);
+		await reposA.point.insertPointEntry(
+			{ childId: taro.id, amount: -5, type: 'redeem', description: '交換' },
+			TENANT,
+		);
+
+		await reposA.specialReward.insertSpecialReward(
+			{ childId: hana.id, title: 'アイスけん', points: 30, category: 'privilege' },
+			TENANT,
+		);
+
+		const tpl = await reposA.checklist.insertTemplate({ name: 'あさのじゅんび' }, TENANT);
+		await reposA.checklist.insertTemplateItem({ templateId: tpl.id, name: 'ぼうし' }, TENANT);
+		await reposA.checklist.assignTemplateToChildren(tpl.id, [taro.id], TENANT);
+
+		const { exportFamilyData } = await import('../../../src/lib/server/services/export-service');
+		const exportData = await exportFamilyData({ tenantId: TENANT });
+
+		// export 自体の健全性 (phase A 内 assert — export が空なら後段は無意味)
+		expect(exportData.family.children.map((c) => c.nickname).sort()).toEqual(
+			['移行太郎', '移行花子'].sort(),
+		);
+		expect(exportData.master.activities.length).toBeGreaterThanOrEqual(2);
+
+		// ═══ Phase B: PGlite backend (pg-core 新 schema) へ import → 検証 ═══
+		// module graph を作り直し、factory を pglite 分岐で再構築する。exportData は plain JSON
+		// なので graph を跨いで安全に持ち運べる (id は自然キー再解決のため保全不要 = ADR-0064)。
+		vi.resetModules();
+		process.env.DATA_SOURCE = 'pglite';
+		delete process.env.PGLITE_DATA_DIR; // in-memory (実 migration = drizzle/pglite/ を適用)
+
+		const pgliteConn = await import('../../../src/lib/server/db/pglite/connection');
+		await pgliteConn.resetPgliteConnectionForTesting();
+		await pgliteConn.initPgliteConnection();
+
+		try {
+			const { importFamilyData } = await import('../../../src/lib/server/services/import-service');
+			const result = await importFamilyData(exportData, TENANT);
+
+			// hard error ゼロ (部分失敗の silent 成功は不可)
+			expect(result.errors, `import errors: ${JSON.stringify(result.errors)}`).toEqual([]);
+
+			// pg backend の repos (dsql、PGlite executor) で自然キー検証
+			const { getRepos: getReposB } = await import('../../../src/lib/server/db/factory');
+			const reposB = getReposB();
+
+			const childrenB = await reposB.child.findAllChildren(TENANT);
+			expect(childrenB.map((c) => c.nickname).sort()).toEqual(['移行太郎', '移行花子'].sort());
+			const taroB = childrenB.find((c) => c.nickname === '移行太郎');
+			expect(taroB?.birthDate).toBe('2018-02-10');
+			// point 残高 = ledger 合算 (15 - 5 = 10) が新 backend でも一致
+			expect(await reposB.point.getBalance(taroB!.id, TENANT)).toBe(10);
+
+			const activitiesB = await reposB.activity.findActivities(TENANT, { includeHidden: true });
+			expect(activitiesB.map((a) => a.name).sort()).toEqual(['おてつだい', 'はみがき'].sort());
+
+			const logsB = await reposB.activity.findActivityLogs(taroB!.id, TENANT);
+			expect(logsB.length).toBe(1);
+			expect(logsB[0]?.recordedAt).toContain('2026-07-01'); // 記録日時保全 (summary shape は recordedAt)
+			expect(logsB[0]?.activityName).toBe('はみがき'); // 活動への再結合 (自然キー再解決の実証)
+
+			const hanaB = childrenB.find((c) => c.nickname === '移行花子');
+			const rewardsB = await reposB.specialReward.findSpecialRewards(hanaB!.id, TENANT);
+			expect(rewardsB.map((r) => r.title)).toEqual(['アイスけん']);
+
+			const templatesB = await reposB.checklist.findTemplatesByChild(taroB!.id, TENANT);
+			expect(templatesB.map((tp) => tp.name)).toEqual(['あさのじゅんび']);
+			const itemsB = await reposB.checklist.findTemplateItems(templatesB[0]!.id, TENANT);
+			expect(itemsB.map((i) => i.name)).toEqual(['ぼうし']);
+		} finally {
+			await pgliteConn.resetPgliteConnectionForTesting();
+		}
+	}, 120_000);
+});

--- a/tests/unit/services/pin-operator-reset.test.ts
+++ b/tests/unit/services/pin-operator-reset.test.ts
@@ -27,7 +27,7 @@ vi.mock('$lib/server/logger', () => ({
 	logger: { error: vi.fn(), info: mockLoggerInfo, warn: mockLoggerWarn },
 }));
 
-const envState: { PARENT_PIN_RESET?: string } = {};
+const envState: { PARENT_PIN_RESET?: string; DATA_SOURCE?: string } = {};
 vi.mock('$lib/runtime/env', () => ({
 	get env() {
 		return envState;
@@ -43,6 +43,7 @@ describe('applyOperatorPinResetIfRequested (#2994)', () => {
 		vi.clearAllMocks();
 		resetOperatorPinResetForTesting();
 		envState.PARENT_PIN_RESET = undefined;
+		envState.DATA_SOURCE = undefined;
 		mockGetAuthMode.mockReturnValue('local');
 		mockGetSetting.mockResolvedValue(undefined);
 		mockSetSetting.mockResolvedValue(undefined);
@@ -53,6 +54,25 @@ describe('applyOperatorPinResetIfRequested (#2994)', () => {
 
 		expect(mockGetSetting).not.toHaveBeenCalled();
 		expect(mockSetSetting).not.toHaveBeenCalled();
+	});
+
+	it('pglite backend: reset は LOCAL_TENANT_UUID 配下に書く (#3620 AC-C4 QM remedy、silent no-op 防止)', async () => {
+		// 旧ハードコード 'local' のままだと pglite cutover 後に実 PIN (UUID 配下) と reset 書込先
+		// ('local') が分裂し operator reset が silent no-op になる regression を固定する。
+		const { LOCAL_TENANT_UUID } = await import('../../../src/lib/server/auth/local-tenant');
+		envState.PARENT_PIN_RESET = 'reset-pglite-1';
+		envState.DATA_SOURCE = 'pglite';
+		await applyOperatorPinResetIfRequested();
+
+		expect(mockGetSetting).toHaveBeenCalledWith('pin_reset_applied', LOCAL_TENANT_UUID);
+		expect(mockSetSetting).toHaveBeenCalledWith('pin_hash', '', LOCAL_TENANT_UUID);
+		expect(mockSetSetting).toHaveBeenCalledWith(
+			'pin_reset_applied',
+			'reset-pglite-1',
+			LOCAL_TENANT_UUID,
+		);
+		// 旧 'local' への書込が残っていない (分裂そのものの検出)
+		expect(mockSetSetting).not.toHaveBeenCalledWith('pin_hash', '', 'local');
 	});
 
 	it('未適用 token: pin_hash 空文字化 (未設定化) + 失敗カウンタ/ロック解除 + 冪等フラグ書込', async () => {


### PR DESCRIPTION
## 顧客価値・目的

NUC の子供たちのデータ（がんばり記録・ポイント・ごほうび・チェックリスト）を、旧 SQLite から新 PGlite backend へ**失わずに移行できる**ことを機械実証する。実証過程で発見した cutover blocker（tenantId 型不整合 = 切替後に全クエリが落ちる欠陥）も根治し、NUC cutover（ADR-0064 §12.2）の実行可能性を確立する。

## 関連 Issue

#3620 (EPIC、AC-C4 前段)。ADR-0064 §結果「backup round-trip は id 非保全・自然キー再解決ゆえ backend 差に非依存」の実証。cutover CLI + runbook は AC-C4 後段、NUC staging pglite 経路は AC-C5 で扱う。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| 旧 sqlite export → PGlite import が hard error ゼロで貫通 | cross-backend round-trip test (実 migration 適用の PGlite へ importFamilyData) | PASS | tests/unit/services/pglite-cutover-roundtrip.test.ts |
| 自然キー再解決で内容保全 (birthDate/残高/log 再結合/reward/checklist 配信) | 同 test の内容 assert | PASS | 同上 |
| local tenantId が pg-core backend で uuid 型に整合 | `[LT1-3]` (pglite/dsql→UUID / 旧→'local' / UUID 形式) | PASS | tests/unit/auth/local-tenant.test.ts |
| 横展開: UUID 化で last-active touch skip が外れない | skip 条件に LOCAL_TENANT_UUID 追加 | PASS | diff + 既存 test 緑 |
| 既存 auth/service テスト回帰なし | auth 76 + 影響 suite | PASS (90/90) | ローカル実行ログ |

## 変更タイプ

- [x] 新機能 (cutover データ移行の機械実証)
- [x] バグ修正 (tenantId 型不整合 = cutover blocker の根治)
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `tests/unit/services/pglite-cutover-roundtrip.test.ts` (新規): Phase A (sqlite test-db + export) → Phase B (vi.resetModules + DATA_SOURCE=pglite + 実 migration + import) の 2 phase 直列検証。
- `src/lib/server/auth/local-tenant.ts` (新規 SSOT): `LOCAL_TENANT_UUID`（cutover 後の帰属キー、不変）+ `resolveLocalTenantId(dataSource)`。
- `src/lib/server/auth/providers/local.ts`: resolveContext を backend-aware 化（旧 backend は 'local' 不変 = 既存 NUC 運用に影響ゼロ）。
- `src/lib/server/services/last-active-touch.ts`: skip 条件に LOCAL_TENANT_UUID 追加（NUC は analytics 対象外を維持）。
- `.cspell.json`: hana (テスト変数名)。

## テスト & 安全装置セルフチェック

- [x] 新規 2 test file = 4/4 PASS (round-trip は実 migration 適用の実 PGlite 上)
- [x] auth 既存 4 file 76/76 + 影響 suite 90/90 PASS (回帰なし)
- [x] `npx biome check <changed>` = clean / `npx cspell <changed>` = 0 issue
- [x] 現行 NUC (DATA_SOURCE=sqlite) の tenantId は 'local' のまま不変（後方互換、[LT2] で固定）

## スクリーンショット / ビジュアルデモ

N/A — server 側 auth/service/test のみで UI 影響なし。

## コード品質セルフレビュー (#1481)

- round-trip test は既存 backup-roundtrip-completeness (sqlite 内・全実体網羅) と責務分離し、「pg 経路の cross-backend 貫通」に限定（重複検証しない）。
- tenantId 発見は test-first で顕在化（uuid parse error の実 fail → 根治 → green）。ADR-0061 failing-test-first 整合。

## 横展開・影響波及チェック

- `tenantId === 'local'` 依存箇所を全 grep: hooks fallback / sqlite/auth-repo (旧 backend 内で整合) / E2E global-setup (sqlite 環境で整合) は影響なし。実影響は last-active-touch と **pin-operator-reset (QM Review Agent 検出、定数代入形 LOCAL_TENANT_ID='local' — 当初 grep のパターン不備で漏れ)** の 2 箇所で、いずれも本 PR 内で SSOT 経由に統一 + regression test 固定済み。定数代入形を含む re-grep で他の同型なしを確認。
- cutover 手順への帰結を SSOT コメントに明記: 旧 DB export → LOCAL_TENANT_UUID で import → DATA_SOURCE=pglite 切替で帰属一貫。

## レビュー依頼事項・破壊的変更

破壊的変更なし。旧 backend (現行 NUC/E2E/dev) の tenantId は 'local' のまま（[LT2] が固定）。UUID が効くのは DATA_SOURCE=pglite/dsql のみ（未 cutover 環境に存在しない）。

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 実装 + テストが 1 PR で完結
- [x] 局所テスト PASS
- [x] biome / cspell clean
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。

