### PR TITLE
fix(docker): #3424 全 Dockerfile deps stage に prepare.mjs を COPY (staging PDCA cycle 2 検出、全 build 系統の根治)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM node:22-alpine AS deps
 RUN apk add --no-cache python3 make g++
 WORKDIR /app
 COPY package*.json ./
+# npm の prepare lifecycle は scripts/prepare.mjs を実行する (#3611 で inline sh から Node 化)。
+# package*.json のみの stage では MODULE_NOT_FOUND で npm ci が exit 1 するため同 script を
+# 先に COPY する (staging PDCA cycle 2 で検出、EPIC #3424。prepare.mjs は常に exit 0 設計)。
+COPY scripts/prepare.mjs ./scripts/prepare.mjs
 RUN npm ci
 
 # Stage 2: Build

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -3,6 +3,11 @@ FROM node:22-alpine AS deps
 RUN apk add --no-cache python3 make g++
 WORKDIR /app
 COPY package*.json ./
+# npm の prepare lifecycle は scripts/prepare.mjs を実行する (#3611 で inline sh から Node 化)。
+# package*.json のみの stage では MODULE_NOT_FOUND で npm ci が exit 1 するため同 script を
+# 先に COPY する (staging PDCA cycle 2 で検出、EPIC #3424。prepare.mjs は常に exit 0 設計で
+# devDep 不在の stage でも warning のみで無害)。
+COPY scripts/prepare.mjs ./scripts/prepare.mjs
 RUN npm ci
 
 # Stage 2: Build SvelteKit
@@ -22,6 +27,8 @@ FROM node:22-alpine AS prod-deps
 RUN apk add --no-cache python3 make g++
 WORKDIR /app
 COPY package*.json ./
+# prepare lifecycle 用 (deps stage と同理由、#3611 / staging PDCA cycle 2)
+COPY scripts/prepare.mjs ./scripts/prepare.mjs
 RUN npm ci --omit=dev
 
 # Stage 4: Lambda runtime

--- a/Dockerfile.scheduler
+++ b/Dockerfile.scheduler
@@ -10,6 +10,10 @@ FROM node:22-alpine AS deps
 RUN apk add --no-cache python3 make g++
 WORKDIR /app
 COPY package*.json ./
+# npm の prepare lifecycle は scripts/prepare.mjs を実行する (#3611 で inline sh から Node 化)。
+# package*.json のみの stage では MODULE_NOT_FOUND で npm ci が exit 1 するため同 script を
+# 先に COPY する (staging PDCA cycle 2 で検出、EPIC #3424。prepare.mjs は常に exit 0 設計)。
+COPY scripts/prepare.mjs ./scripts/prepare.mjs
 RUN npm ci
 
 # Stage 2: Runtime（最小コピー）


### PR DESCRIPTION
## 顧客価値・目的

AWS staging / 本番 Lambda / NUC / scheduler の**全 Docker build 系統**を止めていた潜伏バグ（#3611 の prepare Node 化が deps stage で MODULE_NOT_FOUND）を根治する。staging PDCA cycle 2 が main 到達前に検出したもので、放置すると次回の本番 deploy も NUC deploy も fail していた。

## 関連 Issue

#3424 (EPIC、staging PDCA cycle 2 の学び)。起因 = #3611 (prepare script の Node 化、機能自体は正しい — Docker COPY との組合せ盲点)。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| deps stage 相当環境で npm ci の prepare が exit 0 | 模擬環境 (package*.json + prepare.mjs のみ、node_modules 不在) で `node scripts/prepare.mjs` 実行 | PASS (warning のみ exit 0) | ローカル実行ログ |
| 3 Dockerfile 全対象 stage (4 箇所) に COPY 追加 | diff (Dockerfile / Dockerfile.lambda deps+prod-deps / Dockerfile.scheduler) | PASS | diff |
| 横展開漏れなし | `grep -rn "npm ci" Dockerfile*` 全 4 箇所を網羅 | PASS | 調査ログ |

## 変更タイプ

- [x] バグ修正 (全 Docker build 系統の deploy blocker 根治)
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `Dockerfile` (NUC) / `Dockerfile.lambda` (deps + prod-deps) / `Dockerfile.scheduler`: npm ci 前に `COPY scripts/prepare.mjs ./scripts/prepare.mjs` を追加（各 1 行 + 理由コメント）。
- prepare.mjs は「全 step warning で継続 + 常に exit 0」設計（#3611 の挙動契約）のため、devDep 不在 stage でも副作用なし。
- image 内容への影響: runtime stage は build/prod-deps からの COPY 構成のため最終 image に scripts/prepare.mjs は乗らない（deps 系 stage のみ）。

## テスト & 安全装置セルフチェック

- [x] 模擬 deps 環境で prepare.mjs = warning のみ exit 0 を実証
- [x] CI の docker-build job (Dockerfile paths) が実 build を検証
- [x] 修正は COPY 追加のみで既存 build 手順・成果物不変

## スクリーンショット / ビジュアルデモ

N/A — Dockerfile のみで UI 影響なし。

## コード品質セルフレビュー (#1481)

- `--ignore-scripts` での回避は better-sqlite3 等 native module の install script も止める band-aid のため不採用（ADR-0061）。prepare の実体を COPY する最小・正攻法。
- 4 箇所に同一コメントで理由を明記（将来 Dockerfile 追加時の同型再発への説明効果）。

## 横展開・影響波及チェック

- `npm ci` を実行する Dockerfile 全 4 箇所を網羅（grep 検証）。CI workflow の npm ci は repo full checkout 済みのため非該当。
- 同型の「CI で検出できない deploy-time 依存破壊」2 例目（1 例目 = #3640 ts-node×TS7）。deps 供給線監査 (audit-team.md §3.5.1) の実効性を裏付け。

## レビュー依頼事項・破壊的変更

破壊的変更なし。COPY 1 行 ×4 の追加のみ。

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 修正 + 検証が 1 PR で完結
- [x] 模擬環境で実証
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
