### PR TITLE
feat(nuc): #3620 AC-C5 NUC staging PGlite lane + health の実 backend probe 化 (cutover 実機リハーサル)

### DIFF
--- a/.github/workflows/deploy-nuc-staging.yml
+++ b/.github/workflows/deploy-nuc-staging.yml
@@ -37,10 +37,23 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      # EPIC #3620 AC-C5: PGlite staging lane (opt-in)。true で snapshot 済み旧 sqlite DB を
+      # cutover CLI (export→import、image 同梱) で PGlite へ移行し、DATA_SOURCE=pglite で staging を
+      # 起動して health (probePg = 実 backend 実接続) を検証する = NUC cutover の実機リハーサル。
+      # pull_request trigger (統合 PR) では inputs 不在 = 常に現行 sqlite lane (不変)。
+      pgliteEnabled:
+        description: 'PGlite backend で staging を deploy (EPIC #3620 cutover リハーサル)'
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-nuc-staging
   cancel-in-progress: true
+
+env:
+  # PGlite lane 判定 (AC-C5)。dispatch + pgliteEnabled=true のときのみ 'true'。
+  PGLITE_LANE: ${{ github.event_name == 'workflow_dispatch' && inputs.pgliteEnabled == true && 'true' || 'false' }}
 
 jobs:
   deploy-nuc-staging:
@@ -121,6 +134,12 @@ jobs:
             "PORT=3100",
             "ORIGIN=http://0.0.0.0:3100"
           )
+          if ($env:PGLITE_LANE -eq 'true') {
+            # EPIC #3620 AC-C5: PGlite lane。cutover CLI (次 step) が data/pglite を構築し、
+            # アプリは同 dataDir を PGlite backend として起動する (runbook §手順 4 の swap と同一形)。
+            $envLines += "DATA_SOURCE=pglite"
+            $envLines += "PGLITE_DATA_DIR=/app/data/pglite"
+          }
           Set-Content -Path .env -Value $envLines -Encoding ASCII
           Write-Host "Wrote staging .env from GitHub Secrets ($($envLines.Count) lines, secret values masked)"
 
@@ -172,10 +191,38 @@ jobs:
       # stop -> build -> up 順は WAL safety のため重要 (deploy-nuc.yml と同型)。
       # BUILD_TIMESTAMP で build-stage cache を bust (#711)。`-p` で本番 project と隔離。
       # PORT=3100 は .env (env_file) 経由で docker-compose.yml の `${PORT:-3000}` に注入される。
-      - name: Build and start (staging)
+      - name: Build (staging)
         run: |
           $env:BUILD_TIMESTAMP = (Get-Date -Format "yyyyMMddHHmmss")
           docker compose -p ganbari-quest-staging build
+          if ($LASTEXITCODE -ne 0) { throw "docker compose build failed (exit $LASTEXITCODE)" }
+
+      # Step 5.5 (EPIC #3620 AC-C5、PGlite lane のみ): cutover リハーサル。
+      # snapshot 済み旧 sqlite DB (Step 4) を image 同梱 cutover CLI で export → PGlite import →
+      # 件数突合。runbook (docs/runbooks/nuc-pglite-cutover.md) §手順 2-3 と同一コマンドを
+      # staging container image で実行する (本番 cutover の実機リハーサル)。
+      # 旧 DB 不在 (fixture fallback) の場合は cutover を skip し fresh PGlite で起動する
+      # (health/probePg は migration 適用済み schema を検証する)。
+      - name: PGlite cutover rehearsal (pglite lane)
+        if: env.PGLITE_LANE == 'true'
+        run: |
+          if (Test-Path ".\data\pglite") {
+            Remove-Item -Recurse -Force ".\data\pglite"
+            Write-Host "removed previous staging pglite dataDir (fresh rehearsal)"
+          }
+          if (-not (Test-Path ".\data\ganbari-quest.db")) {
+            Write-Host "::notice::旧 sqlite DB が無い (fixture fallback) -> cutover skip、fresh PGlite で起動します"
+            exit 0
+          }
+          docker compose -p ganbari-quest-staging run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts export --db /app/data/ganbari-quest.db --out /app/data/.cutover-export.json
+          if ($LASTEXITCODE -ne 0) { throw "cutover export failed (exit $LASTEXITCODE)" }
+          docker compose -p ganbari-quest-staging run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts import --in /app/data/.cutover-export.json --data-dir /app/data/pglite
+          if ($LASTEXITCODE -ne 0) { throw "cutover import failed (exit $LASTEXITCODE、件数突合 or errors>0 abort。旧 DB は無傷)" }
+          Remove-Item -Force ".\data\.cutover-export.json" -ErrorAction SilentlyContinue
+          Write-Host "::notice::cutover rehearsal passed (export -> import -> 件数突合)。PGlite backend で起動します"
+
+      - name: Start (staging)
+        run: |
           docker compose -p ganbari-quest-staging up -d
 
       # Step 6: Post-deploy health check (#2872 AC6 / AC8 = §3.8 step 9 NUC 側)。

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,19 @@ COPY --from=build /app/src/lib/server/db/seed.ts ./src/lib/server/db/seed.ts
 COPY --from=build /app/src/lib/server/db/schema.ts ./src/lib/server/db/schema.ts
 COPY --from=build /app/drizzle.config.ts ./
 
+# EPIC #3620 AC-C5: PGlite cutover を image 同梱ツールで実行可能にする (staging/本番 同一手順)。
+# `docker compose run --rm app npx tsx scripts/nuc-pglite-cutover.ts <export|import> ...`
+# tsx は node_modules に既存 (devDeps 込み COPY)、$lib alias は tsconfig paths を tsx が解決、
+# drizzle/pglite は PGlite boot 時 migration の SSOT (connection.ts)。手順 SSOT は
+# docs/runbooks/nuc-pglite-cutover.md。
+COPY --from=build /app/src ./src
+COPY --from=build /app/scripts/nuc-pglite-cutover.ts ./scripts/nuc-pglite-cutover.ts
+COPY --from=build /app/drizzle ./drizzle
+COPY --from=build /app/tsconfig.json ./
+# root tsconfig は .svelte-kit/tsconfig.json を extends し $lib paths はそちら側 (svelte-kit sync
+# 生成物、build stage に存在)。tsx の alias 解決に必要な該当ファイルのみ COPY する。
+COPY --from=build /app/.svelte-kit/tsconfig.json ./.svelte-kit/tsconfig.json
+
 # Copy entrypoint script (strip Windows CRLF line endings)
 COPY scripts/docker-entrypoint.sh /docker-entrypoint.sh
 RUN sed -i 's/\r$//' /docker-entrypoint.sh && chmod +x /docker-entrypoint.sh

--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1312,12 +1312,26 @@ Stripe からの Webhook イベントを受信する。Stripe 署名ヘッダ（
 
 #### GET /api/health
 
-**レスポンス:**
+liveness probe。**DATA_SOURCE に応じた実 backend への実接続検証**を行う (#3620 AC-C5 / EPIC #3424。probe 実体は `src/lib/server/db/probe.ts` facade、route↔DB 境界 #3184):
+
+| DATA_SOURCE | probe | schema 検証 |
+|---|---|---|
+| `sqlite` (既定) | `probeSqlite` — rawSqlite `SELECT 1` | lazy migration の validation 結果 (`schemaValid` / `migrationsApplied` / `schemaWarnings`) |
+| `dynamodb` | `probeDynamoDB` — DescribeTable ACTIVE | なし (`schema` は空 object) |
+| `dsql` / `pglite` | `probePg` — 実 backend へ `SELECT 1` + `children` 表 count | children count 成功 = migration 適用済み schema 実在 (`schemaValid: true`) |
+
+backend が不健全 (接続不可 / schema 不在) の場合は **503** + `{"status":"error", "error":..., "dataSource":...}` を返す (空 backend の偽陽性 200 を返さない)。
+
+**レスポンス (200):**
 ```json
 {
   "status": "ok",
   "timestamp": "2026-02-19T18:30:00Z",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "dataSource": "pglite",
+  "region": "local",
+  "uptime": 123,
+  "schema": { "schemaValid": true, "migrationsApplied": 0, "schemaWarnings": 0 }
 }
 ```
 

--- a/docs/runbooks/nuc-pglite-cutover.md
+++ b/docs/runbooks/nuc-pglite-cutover.md
@@ -11,6 +11,9 @@ EPIC #3620 / ADR-0064 §ロールバック保証 (非破壊 import-then-swap) �
 
 ## 手順
 
+CLI は **app image に同梱** (Dockerfile runtime stage、AC-C5) されており、host に node_modules は不要。
+`docker compose run` で実行する (staging lane = `deploy-nuc-staging.yml` の PGlite lane と同一コマンド)。
+
 ```bash
 # 0. (本番のみ) 直前バックアップ
 cp data/ganbari-quest.db* backup/pre-pglite-cutover-$(date +%Y%m%d)/
@@ -18,12 +21,14 @@ cp data/ganbari-quest.db* backup/pre-pglite-cutover-$(date +%Y%m%d)/
 # 1. アプリ停止 (WAL flush。NUC デプロイ順序と同じ)
 docker compose stop app
 
-# 2. export (旧 DB → JSON。原本 read-only、copy に対して実行)
-npx tsx scripts/nuc-pglite-cutover.ts export --db data/ganbari-quest.db --out tmp/cutover-export.json
+# 2. export (旧 DB → JSON。原本 read-only、copy に対して実行。CLI は image 同梱)
+docker compose run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts export \
+  --db /app/data/ganbari-quest.db --out /app/data/.cutover-export.json
 #    → counts が表示される (14 軸)。控えておく。
 
 # 3. import (fresh PGlite 構築 + migration 適用 + import + 件数突合)
-npx tsx scripts/nuc-pglite-cutover.ts import --in tmp/cutover-export.json --data-dir data/pglite
+docker compose run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts import \
+  --in /app/data/.cutover-export.json --data-dir /app/data/pglite
 #    → 「import + 件数突合 完了」が出れば成功。
 #    → errors>0 または件数不一致なら CLI が dataDir を削除して exit 1 (旧 DB 無傷、原因解消後に再実行)。
 
@@ -31,9 +36,9 @@ npx tsx scripts/nuc-pglite-cutover.ts import --in tmp/cutover-export.json --data
 #    DATA_SOURCE=pglite
 #    PGLITE_DATA_DIR=/app/data/pglite   (コンテナ内 path。docker-compose の volume に合わせる)
 
-# 5. 起動 + health
-docker compose build && docker compose up -d
-curl -s http://localhost:3000/api/health   # 200 を確認
+# 5. 起動 + health (health は probePg = PGlite への実接続 + schema 実在検証)
+docker compose up -d
+curl -s http://localhost:3000/api/health   # 200 + "dataSource":"pglite" + schemaValid:true を確認
 
 # 6. 実画面確認 (子供一覧 / ポイント残高 / 活動記録 1 件)
 ```

--- a/src/lib/server/db/probe.ts
+++ b/src/lib/server/db/probe.ts
@@ -40,3 +40,25 @@ export async function probeDynamoDB(): Promise<void> {
 		throw new Error('dynamodb_table_not_active');
 	}
 }
+
+/**
+ * pg 系 backend (dsql / pglite) の liveness + schema 検証 (#3620 AC-C5 / EPIC #3424)。
+ * **実 backend への実接続**で SELECT 1 + children 表 count を実行する — 従来 health は
+ * dynamodb 以外を一律 sqlite probe しており、DATA_SOURCE=dsql/pglite の Lambda/NUC でも
+ * 「空 sqlite が触れた」だけで 200 を返す偽陽性だった (staging cycle 3 の反省)。
+ * children count が通る = migration 適用済み schema が実在する、を schemaValid とする。
+ */
+export async function probePg(dataSource: 'dsql' | 'pglite'): Promise<SqliteProbeResult> {
+	const { sql } = await import('drizzle-orm');
+	const db =
+		dataSource === 'dsql'
+			? (await import('./dsql/connection')).getDsqlDb()
+			: (await import('./pglite/connection')).getPgliteDbSync();
+	const ping = await db.execute(sql`SELECT 1 AS ok`);
+	if (Number((ping.rows[0] as { ok: number } | undefined)?.ok) !== 1) {
+		throw new Error('db_check_failed');
+	}
+	// schema 実在検証: 中核表 children への count が通れば migration 適用済み。
+	await db.execute(sql`SELECT count(*) FROM children`);
+	return { schemaValid: true, migrationsApplied: 0, schemaWarnings: 0 };
+}

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,16 +1,20 @@
 import { json } from '@sveltejs/kit';
-import { probeDynamoDB, probeSqlite, type SqliteProbeResult } from '$lib/server/db/probe';
+import { probeDynamoDB, probePg, probeSqlite, type SqliteProbeResult } from '$lib/server/db/probe';
 import { APP_VERSION } from '$lib/version';
 import type { RequestHandler } from './$types';
 
 const DATA_SOURCE = process.env.DATA_SOURCE ?? 'sqlite';
 
 // #3184 item4: liveness probe の raw DB touch は db/probe facade に集約 (route↔DB 境界 / ADR-0061)。
+// #3620 AC-C5: dsql/pglite は probePg で**実 backend を実接続 probe** する (従来は dynamodb 以外を
+// 一律 sqlite probe しており、pg 系 backend でも空 sqlite 経由で 200 を返す偽陽性だった)。
 export const GET: RequestHandler = async () => {
 	let schemaInfo: Partial<SqliteProbeResult> = {};
 	try {
 		if (DATA_SOURCE === 'dynamodb') {
 			await probeDynamoDB();
+		} else if (DATA_SOURCE === 'dsql' || DATA_SOURCE === 'pglite') {
+			schemaInfo = await probePg(DATA_SOURCE);
 		} else {
 			schemaInfo = await probeSqlite();
 		}

--- a/tests/unit/db/probe-pg.test.ts
+++ b/tests/unit/db/probe-pg.test.ts
@@ -1,0 +1,34 @@
+// tests/unit/db/probe-pg.test.ts
+// #3620 AC-C5 / EPIC #3424 — pg 系 backend の health probe (probePg) の実機テスト。
+//
+// 背景 (staging cycle 3 の反省): 従来 /api/health は dynamodb 以外を一律 sqlite probe しており、
+// DATA_SOURCE=dsql/pglite でも「空 sqlite が触れた」だけで 200 を返す偽陽性だった。probePg は
+// **実 backend への実接続** (SELECT 1 + children count) で liveness + schema 実在を検証する。
+//
+//   [PP1] migration 適用済み PGlite に対して probePg('pglite') が schemaValid=true を返す
+//   [PP2] 未 init (schema なし相当) は throw する (偽陽性で 200 を返さない)
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	initPgliteConnection,
+	resetPgliteConnectionForTesting,
+} from '../../../src/lib/server/db/pglite/connection';
+import { probePg } from '../../../src/lib/server/db/probe';
+
+describe('probePg (#3620 AC-C5、実 backend 実接続 probe)', () => {
+	afterEach(async () => {
+		await resetPgliteConnectionForTesting();
+	});
+
+	it('[PP1] migration 適用済み PGlite: schemaValid=true (children 表 count 実行)', async () => {
+		delete process.env.PGLITE_DATA_DIR; // in-memory + 実 migration 適用
+		await initPgliteConnection();
+		const result = await probePg('pglite');
+		expect(result.schemaValid).toBe(true);
+	});
+
+	it('[PP2] 未 init: throw する (空 backend の偽陽性 200 を防ぐ)', async () => {
+		await resetPgliteConnectionForTesting();
+		await expect(probePg('pglite')).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

NUC の PGlite 移行を**実機（staging）でリハーサル可能**にし、本番 cutover の安全性を担保する。あわせて staging cycle 3 の反省として自己検出した **health 偽陽性**（dsql/pglite でも空 sqlite probe で 200 を返す）を根治し、health が「実 backend への実接続 + schema 実在」を証明するようにする。

## 関連 Issue

#3620 (EPIC、AC-C5) / #3424 (health probe は DSQL 側 L3 エビデンスの品質にも直結)。#3643 (cutover CLI) の上に stack (CLI を staging container で実行するため)。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| probePg: migration 済み PGlite で schemaValid=true | `npx vitest run tests/unit/db/probe-pg.test.ts` ([PP1]) | PASS | 実 PGlite 接続 (in-memory + 実 migration) |
| probePg: 未 init は throw (偽陽性 200 防止) | 同 ([PP2]) | PASS | 同上 |
| 既存 pglite 接続契約に回帰なし | `npx vitest run tests/unit/db/pglite-connection.test.ts` | PASS (6/6 計) | ローカル実行ログ |
| pull_request trigger は現行 sqlite lane 完全不変 | PGLITE_LANE 判定 (dispatch + input true のみ) | PASS | workflow diff |
| YAML / 型 / 品質 | `node -e "yaml.parse(...)"` + `npx svelte-check` (0 ERRORS) + `npx biome check` | PASS | ローカル実行ログ |
| staging での実機貫通 | merge 後の dispatch run が最終検証 (cutover rehearsal → PGlite 起動 → health)。run URL は EPIC #3424/#3620 に記録して完了とする | 手順確立済 | 本 PR の workflow diff |

## 変更タイプ

- [x] 新機能 (NUC staging PGlite lane + cutover rehearsal)
- [x] バグ修正 (health 偽陽性の根治 = pg 系 backend の実接続 probe)
- [ ] リファクタリング
- [x] ドキュメント (runbook を image 同梱実行形式に更新)

## 影響範囲・変更コンポーネント

- `src/lib/server/db/probe.ts` + `src/routes/api/health/+server.ts`: `probePg` 追加、DATA_SOURCE=dsql/pglite は実 backend を実接続 probe (SELECT 1 + children count)。sqlite/dynamodb 経路は不変。
- `Dockerfile` (NUC) runtime stage: cutover CLI 実行に必要な `src/` + CLI + `drizzle/` + tsconfig ($lib paths = `.svelte-kit/tsconfig.json`) を COPY — staging/本番とも `docker compose run` で同一手順実行可能に。
- `deploy-nuc-staging.yml`: dispatch input `pgliteEnabled`。PGlite lane = snapshot → build → cutover rehearsal (export→import→件数突合、fail-close) → `DATA_SOURCE=pglite` 起動 → 既存 health。
- `docs/runbooks/nuc-pglite-cutover.md`: 実行コマンドを image 同梱 (`docker compose run`) 形式に更新。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/probe-pg.test.ts tests/unit/db/pglite-connection.test.ts` = 6/6 PASS
- [x] `npx svelte-check --tsconfig ./tsconfig.json` = 0 ERRORS / biome / cspell clean (yml の LASTEXITCODE は CI cspell 対象外)
- [x] cutover rehearsal step は各コマンド `$LASTEXITCODE` 検査で fail-close (silent skip なし)
- [x] AWS 側への波及: 次回 DSQL staging run の health が「DSQL 実 runtime 接続」を初めて実証する (cycle 3 エビデンスの解釈修正を含む — EPIC に記録済み)

## スクリーンショット / ビジュアルデモ

N/A — server probe / infra / workflow / runbook のみで UI 影響なし。

## コード品質セルフレビュー (#1481)

- health 偽陽性は自己検出 (AC-C5 設計中に「health が pglite で何を検証するか」を確認して発見)。cycle 3 の DoD 4 エビデンス解釈は「Lambda 起動 + provisioning 実適用は本物 / health の DSQL 接続証明は未達」に修正し、probePg 導入後の cycle 4 で完全化する。
- runtime image への src COPY は cutover 運用の自己完結性 (host node_modules 不要) を優先。image サイズ増は数 MB 程度。

## 横展開・影響波及チェック

- probe の分岐追加は health のみ (probe facade 利用箇所を grep 確認)。
- deploy-nuc.yml (本番) は変更なし — 本番 PGlite 化は runbook 手順 + ユーザー承認で行う (workflow 自動化しない設計)。

## レビュー依頼事項・破壊的変更

破壊的変更なし。health の pg 系分岐は「これまで誤って sqlite probe していた経路」の是正で、sqlite/dynamodb backend の応答は不変。

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 実装 + テスト + runbook が 1 PR で完結
- [x] 局所テスト PASS
- [x] biome / cspell / svelte-check / YAML clean
- [x] base = develop (#3643 に stack、merge 後 rebase で AC-C5 差分のみに縮む)

## QM レビュー結果

QM レビュー待ち。
