### PR TITLE
fix(nuc): #3620 staging PGlite rehearsal の文字列リテラル ASCII 化 (PS5.1 CP932 ParseException 根治)

### DIFF
--- a/.github/workflows/deploy-nuc-staging.yml
+++ b/.github/workflows/deploy-nuc-staging.yml
@@ -211,15 +211,15 @@ jobs:
             Write-Host "removed previous staging pglite dataDir (fresh rehearsal)"
           }
           if (-not (Test-Path ".\data\ganbari-quest.db")) {
-            Write-Host "::notice::旧 sqlite DB が無い (fixture fallback) -> cutover skip、fresh PGlite で起動します"
+            Write-Host "::notice::legacy sqlite DB not found (fixture fallback) -> skip cutover, boot fresh PGlite"
             exit 0
           }
           docker compose -p ganbari-quest-staging run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts export --db /app/data/ganbari-quest.db --out /app/data/.cutover-export.json
           if ($LASTEXITCODE -ne 0) { throw "cutover export failed (exit $LASTEXITCODE)" }
           docker compose -p ganbari-quest-staging run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts import --in /app/data/.cutover-export.json --data-dir /app/data/pglite
-          if ($LASTEXITCODE -ne 0) { throw "cutover import failed (exit $LASTEXITCODE、件数突合 or errors>0 abort。旧 DB は無傷)" }
+          if ($LASTEXITCODE -ne 0) { throw "cutover import failed (exit $LASTEXITCODE; count-mismatch or errors>0 abort, legacy DB untouched)" }
           Remove-Item -Force ".\data\.cutover-export.json" -ErrorAction SilentlyContinue
-          Write-Host "::notice::cutover rehearsal passed (export -> import -> 件数突合)。PGlite backend で起動します"
+          Write-Host "::notice::cutover rehearsal passed (export -> import -> count verification). Booting with PGlite backend"
 
       - name: Start (staging)
         run: |


### PR DESCRIPTION
## 顧客価値・目的

NUC staging PGlite cycle 1 を止めた ParseException を根治し、NUC cutover の実機リハーサル（本番リリース可否判断の最終エビデンス取得）を前進させる。

## 関連 Issue

#3620 (AC-C5 の staging PDCA cycle 1 の学び) / #3014 (PS5.1 CP932 既知制約の再発事例)。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| rehearsal step の文字列リテラルが ASCII のみ | 全 run block 非 ASCII 機械走査 (`node -e` yaml parse + regex) | PASS (リテラル 3 箇所を英語化、残る非 ASCII は PS コメントのみ = cycle 1 success 実績の既存同型) | 走査ログ |
| YAML valid | `node -e "yaml.parse(...)"` | PASS | ローカル検証 |
| 実機貫通 | merge 後の pglite lane 再 dispatch (cycle 2) で最終確認。run URL を EPIC に記録して完了とする | 手順確立済 | workflow diff |

## 変更タイプ

- [x] バグ修正 (PS5.1 ParseException = staging PGlite lane blocker)
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `deploy-nuc-staging.yml` rehearsal step の文字列リテラル 3 箇所のみ英語化 (ロジック不変)。他 step / 他 lane 不変。

## テスト & 安全装置セルフチェック

- [x] 全 run block の非 ASCII を機械走査し、リテラル違反ゼロを確認 (#3014 の線引き = リテラルのみ NG、PS コメントは既存 success 実績)
- [x] YAML valid

## スクリーンショット / ビジュアルデモ

N/A — workflow 文言のみ。

## コード品質セルフレビュー (#1481)

- 冒頭 NOTE (#3014) に明記されていた既知制約を私が見落として踏んだもの。走査を機械化して横展開漏れゼロを確認した。

## 横展開・影響波及チェック

- deploy-nuc.yml (本番) は今回変更なし・既存リテラルは ASCII 準拠 (同走査で確認可能)。deploy-aws-staging.yml は bash のため対象外。

## レビュー依頼事項・破壊的変更

破壊的変更なし。文言 ASCII 化のみ。

## 配布済み env / secret (ADR-0006)

N/A。

## Ready for Review チェックリスト

- [x] 修正 + 機械走査検証が 1 PR で完結
- [x] YAML valid
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
