### PR TITLE
fix(dsql): #3646 app_user role provisioning (DbConnect IAM 不整合根治) + UPDATE 除外 GRANT + 接続 timeout

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -9,11 +9,7 @@
 			"addWords": true
 		}
 	],
-	"dictionaries": [
-		"project-words",
-		"softwareTerms",
-		"fonts"
-	],
+	"dictionaries": ["project-words", "softwareTerms", "fonts"],
 	"ignorePaths": [
 		"node_modules",
 		".svelte-kit",
@@ -64,22 +60,15 @@
 	"overrides": [
 		{
 			"filename": "**/*.css",
-			"ignoreRegExpList": [
-				"/[a-zA-Z0-9-]+:\\s*[^;]+;/g"
-			]
+			"ignoreRegExpList": ["/[a-zA-Z0-9-]+:\\s*[^;]+;/g"]
 		},
 		{
 			"filename": "**/package.json",
-			"ignoreRegExpList": [
-				"/\"@?[a-zA-Z0-9/_.-]+\"\\s*:/g"
-			]
+			"ignoreRegExpList": ["/\"@?[a-zA-Z0-9/_.-]+\"\\s*:/g"]
 		},
 		{
 			"filename": "infra/**/*.ts",
-			"ignoreRegExpList": [
-				"/[a-z0-9]{20,}/g",
-				"/\\._domainkey/g"
-			]
+			"ignoreRegExpList": ["/[a-z0-9]{20,}/g", "/\\._domainkey/g"]
 		}
 	],
 	"words": [

--- a/.cspell.json
+++ b/.cspell.json
@@ -85,6 +85,7 @@
 		"datconfig",
 		"datname",
 		"hana",
+		"millis",
 		"multiplexing",
 		"multitenant",
 		"reinit",

--- a/.cspell.json
+++ b/.cspell.json
@@ -9,7 +9,11 @@
 			"addWords": true
 		}
 	],
-	"dictionaries": ["project-words", "softwareTerms", "fonts"],
+	"dictionaries": [
+		"project-words",
+		"softwareTerms",
+		"fonts"
+	],
 	"ignorePaths": [
 		"node_modules",
 		".svelte-kit",
@@ -60,38 +64,47 @@
 	"overrides": [
 		{
 			"filename": "**/*.css",
-			"ignoreRegExpList": ["/[a-zA-Z0-9-]+:\\s*[^;]+;/g"]
+			"ignoreRegExpList": [
+				"/[a-zA-Z0-9-]+:\\s*[^;]+;/g"
+			]
 		},
 		{
 			"filename": "**/package.json",
-			"ignoreRegExpList": ["/\"@?[a-zA-Z0-9/_.-]+\"\\s*:/g"]
+			"ignoreRegExpList": [
+				"/\"@?[a-zA-Z0-9/_.-]+\"\\s*:/g"
+			]
 		},
 		{
 			"filename": "infra/**/*.ts",
-			"ignoreRegExpList": ["/[a-z0-9]{20,}/g", "/\\._domainkey/g"]
+			"ignoreRegExpList": [
+				"/[a-z0-9]{20,}/g",
+				"/\\._domainkey/g"
+			]
 		}
 	],
 	"words": [
 		"BCNF",
 		"BIGSERIAL",
+		"ILIKE",
+		"Idents",
+		"NONNEG",
+		"PDCA",
+		"SMALLSERIAL",
+		"STAYPUT",
 		"bigserial",
 		"chunker",
 		"datconfig",
 		"datname",
-		"Idents",
 		"hana",
-		"ILIKE",
 		"multiplexing",
 		"multitenant",
-		"NONNEG",
-		"PDCA",
 		"reinit",
+		"rolcanlogin",
+		"rolname",
 		"schemaname",
 		"setconfig",
 		"setdatabase",
 		"setrole",
-		"SMALLSERIAL",
-		"STAYPUT",
 		"tablename",
 		"testcluster"
 	]

--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -274,6 +274,21 @@ jobs:
               -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
           done
 
+      # Step 11.5 (#3646、DSQL lane のみ): アプリ実行 role (app_user) の provisioning。
+      # Lambda 実行 role は dsql:DbConnect のみ持ち (M3 §3.4 B6 最小権限)、DSQL の認可仕様では
+      # DbConnect は custom database role 専用のため、CREATE ROLE + AWS IAM GRANT (Lambda role
+      # ARN 紐付け) + 表 GRANT (UPDATE 除外表は SELECT/INSERT/DELETE のみ) を冪等適用する。
+      # compute deploy 後 = Lambda 実行 role ARN 確定後、health check 前に置く。
+      - name: Grant DSQL app role to Lambda (dsql lane)
+        if: env.DSQL_LANE == 'true'
+        run: |
+          LAMBDA_ROLE_ARN=$(aws lambda get-function-configuration \
+            --function-name $LAMBDA_FUNCTION \
+            --region $AWS_REGION \
+            --query 'Role' --output text)
+          echo "Granting app_user to $LAMBDA_ROLE_ARN"
+          npm run dsql:grant -- --iam-role-arn "$LAMBDA_ROLE_ARN"
+
       # Step 12: staging Lambda を今回 push した sha image に明示更新 (deploy.yml Phase 4 同型 —
       # `latest` タグは CFN が新 push を検知できないため)。
       - name: Update Lambda function image (staging)

--- a/docs/design/dsql/m3-physical-model.md
+++ b/docs/design/dsql/m3-physical-model.md
@@ -271,11 +271,11 @@ RLS 非対応（P8）ゆえ DB エンジン強制の砦なし。代替防御線�
 
 | 用途 | 接続ロール | 権限 |
 |---|---|---|
-| **アプリ実行時** | 専用最小権限 postgres role（`DbConnect` 系 IAM、`DbConnectAdmin` でない） | tenant 表への SELECT/INSERT + 業務上必要な UPDATE のみ。**append-only 表（`consents`/`point_ledger`/`status_history`/`*_logs`/`trial_history`/`cancellation_reasons`/`graduation_consent`/`notification_logs`）への UPDATE/DELETE grant を与えない**（I-CONS 等の追記性を DB GRANT で物理担保） |
+| **アプリ実行時** | 専用最小権限 postgres role `app_user`（`DbConnect` 系 IAM、`DbConnectAdmin` でない。provisioning = `dsql/migration/app-role.ts` + `npm run dsql:grant`、#3646） | tenant 表への SELECT/INSERT/DELETE + 業務上必要な UPDATE のみ。**UPDATE 除外表（`consents`/`point_ledger`/`status_history`/`checklist_logs`/`notification_logs`/`usage_logs`/`cancellation_reasons`/`graduation_consent` — SSOT は `app-role.ts` `UPDATE_EXCLUDED_TABLES`）への UPDATE grant を与えない**（I-CONS 等の追記性 = 改竄不能を DB GRANT で物理担保）。**DELETE は除外しない** — 退会（tenant 全削除）/ retention cleanup（ADR-0049 物理削除）/ child 削除の正当業務経路が DELETE を発行するため（#3646 で「UPDATE/DELETE 除外」から是正）。`activity_logs`（cancelled soft-cancel）/ `trial_history`（状態更新）は実装が UPDATE を必要とするため除外対象外 |
 | **migration / admin** | 別クレデンシャル（`DbConnectAdmin`） | DDL・GRANT 管理。アプリ実行経路から到達不能 |
 
-- **fitness**: append-only 表への UPDATE/DELETE を repo 層で非定義 + GRANT 除外 + AST lint の 3 層（RLS 不在の代替、consent 削除・台帳改竄の物理防御）。
-- **⚠️ 本番 cutover 前 hard blocker（Round 2 [should] 格上げ、#3429）**: role 分離の**実 IAM policy JSON の実装は「M4 spike」でなく本番 cutover 前の hard blocker**。GRANT を防御線に名指す本設計は、実 IAM policy（実行 role = DbConnect 最小権限 + append-only 表 GRANT 除外 / migration = DbConnectAdmin）が**未実装だと design-only で無防備**（DbConnectAdmin 付与のままだと台帳改竄・consent 削除が素通り）。→ 本番稼働の gate に含める（データモデルゲート #3429 の CDK 構成 spike とは別に、role 分離だけは cutover 必須）。L1 `AWS::DSQL::Cluster` の IAM grant helper 欠如（手書き）は #3429 で吸収。
+- **fitness**: UPDATE 除外表への UPDATE を GRANT 除外（runtime、`tests/unit/db/dsql-app-role.test.ts` [G2]）+ 静的走査（`tests/unit/architecture/dsql-append-only-update-fitness.test.ts`）の 2 層（RLS 不在の代替、台帳改竄の物理防御）。
+- **role 分離の実装（#3646 で cutover gate 消化済）**: 実行 role = `app_user`（DbConnect、compute-stack が `DSQL_USER=app_user` 注入）/ migration・grant = `DbConnectAdmin` 経路（`dsql:migrate` → compute deploy → `dsql:grant --iam-role-arn <Lambda 実行 role>` の順で deploy workflow が適用）。DSQL の認可仕様上 DbConnect は custom database role 専用（admin は DbConnectAdmin 必要）のため、この provisioning なしでは DbConnect 最小権限の Lambda は一切接続できない。
 
 ---
 

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -327,7 +327,11 @@ export class ComputeStack extends cdk.Stack {
 						SES_CONFIG_SET_NAME: 'ganbari-quest-config',
 						// EPIC #3424 M5: dsqlEnabled 時のみ backend を DSQL へ切替 (後勝ち上書き)。
 						// flag なしでは spread 空 = 上の DATA_SOURCE: 'dynamodb' が維持され template 不変。
-						...(dsqlEnabled ? { DATA_SOURCE: 'dsql', DSQL_ENDPOINT: dsqlEndpoint } : {}),
+						// DSQL_USER=app_user (#3646): dsql:DbConnect は custom db role 専用 (admin は
+						// DbConnectAdmin が必要)。role 実体は deploy workflow の dsql:grant が provisioning。
+						...(dsqlEnabled
+							? { DATA_SOURCE: 'dsql', DSQL_ENDPOINT: dsqlEndpoint, DSQL_USER: 'app_user' }
+							: {}),
 					}
 				: {
 						...stagingEnvironment,
@@ -337,7 +341,10 @@ export class ComputeStack extends cdk.Stack {
 						// EPIC #3424 M5 DoD4: staging を DSQL backend で起動し §3.7#5 (post-deploy
 						// health green) を新 backend で検証する経路 (deploy-aws-staging.yml が
 						// -c dsqlEnabled=true -c dsqlEndpoint=... を渡したときのみ)。
-						...(dsqlEnabled ? { DATA_SOURCE: 'dsql', DSQL_ENDPOINT: dsqlEndpoint } : {}),
+						// DSQL_USER=app_user (#3646): 本番側と同型 (dsql:grant が role provisioning)。
+						...(dsqlEnabled
+							? { DATA_SOURCE: 'dsql', DSQL_ENDPOINT: dsqlEndpoint, DSQL_USER: 'app_user' }
+							: {}),
 					},
 		});
 		this.fn.node.addDependency(logGroup);

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
 		"dsql:migrate": "tsx scripts/dsql-migrate.ts",
+		"dsql:grant": "tsx scripts/dsql-grant.ts",
 		"db:push": "drizzle-kit push",
 		"db:studio": "drizzle-kit studio",
 		"db:seed": "tsx src/lib/server/db/seed.ts",

--- a/scripts/dsql-grant.ts
+++ b/scripts/dsql-grant.ts
@@ -1,0 +1,68 @@
+// scripts/dsql-grant.ts — DSQL アプリ実行 role (app_user) の provisioning CLI (EPIC #3424 M5 / #3646)
+//
+// Lambda 実行 role は IAM action `dsql:DbConnect` のみ持つ (compute-stack #3637、M3 §3.4 B6
+// 最小権限)。DSQL の認可仕様では DbConnect は custom database role 専用のため、本 CLI が
+// role 作成 + AWS IAM GRANT (Lambda role ARN 紐付け) + 表 GRANT (UPDATE 除外表は
+// SELECT/INSERT/DELETE のみ) を冪等に適用する。core logic は
+// src/lib/server/db/dsql/migration/app-role.ts (unit test 済) に集約し、本 CLI は接続確立 +
+// 引数処理のみの thin wrapper (使い捨て script ではない恒久運用ツール #1442)。
+//
+// 実行 (tsx、DbConnectAdmin 相当の AWS credential が必要。dsql-migrate と同経路):
+//   DSQL_ENDPOINT=<id>.dsql.<region>.on.aws npm run dsql:grant -- --iam-role-arn arn:aws:iam::<acct>:role/<lambda-role>
+//   DSQL_ENDPOINT=... npm run dsql:grant                # role + 表 GRANT のみ (IAM 紐付けなし)
+//
+// deploy workflow では compute-stack deploy 後 (Lambda 実行 role ARN 確定後) に実行する。
+// migration (dsql:migrate) が先、grant が後 — 表 GRANT は information_schema の実在表に
+// 対して行うため。
+
+import { AuroraDSQLPool } from '@aws/aurora-dsql-node-postgres-connector';
+import { provisionAppRole } from '../src/lib/server/db/dsql/migration/app-role';
+import type { RawSqlExecutor } from '../src/lib/server/db/dsql/migration/async-index-poll';
+
+function readArg(name: string): string | undefined {
+	const idx = process.argv.indexOf(name);
+	if (idx >= 0) return process.argv[idx + 1];
+	const eq = process.argv.find((a) => a.startsWith(`${name}=`));
+	return eq?.slice(name.length + 1);
+}
+
+async function main(): Promise<void> {
+	const endpoint = process.env.DSQL_ENDPOINT;
+	if (!endpoint) {
+		console.error(
+			'[dsql-grant] DSQL_ENDPOINT が未設定です。DsqlStack の ClusterEndpoint 出力を設定してください。',
+		);
+		process.exit(1);
+	}
+	const iamRoleArn = readArg('--iam-role-arn');
+
+	// grant は DbConnectAdmin 経路 (admin role)。実行時アプリの DbConnect とは分離 (M3 §3.4 B6)。
+	const pool = new AuroraDSQLPool({
+		host: endpoint,
+		user: process.env.DSQL_MIGRATE_USER ?? 'admin',
+		database: process.env.DSQL_DATABASE ?? 'postgres',
+		ssl: true,
+	});
+	const executor: RawSqlExecutor = {
+		execute: async (sqlText: string) => {
+			const res = await pool.query(sqlText);
+			return { rows: (res as { rows?: unknown[] }).rows ?? [] };
+		},
+	};
+
+	try {
+		const result = await provisionAppRole(executor, { iamRoleArn });
+		console.log(
+			`[dsql-grant] role=${result.roleName} (created=${result.roleCreated}) iamGranted=${result.iamGranted}`,
+		);
+		for (const g of result.granted) console.log(`[grant] ${g.table}: ${g.privileges}`);
+		console.log(`[dsql-grant] 完了: ${result.granted.length} 表に GRANT 適用`);
+	} finally {
+		await (pool as unknown as { end(): Promise<void> }).end();
+	}
+}
+
+main().catch((err) => {
+	console.error('[dsql-grant] 失敗:', err);
+	process.exit(1);
+});

--- a/src/lib/server/db/dsql/connection.ts
+++ b/src/lib/server/db/dsql/connection.ts
@@ -86,6 +86,10 @@ function buildDsqlPoolConfig(): ConstructorParameters<typeof AuroraDSQLPool>[0] 
 		database: env.DSQL_DATABASE ?? 'postgres',
 		ssl: true,
 		// connector が region を hostname から自動判定 (検証 9 (b))。token 生成・更新も connector 任せ。
+		// 接続確立 timeout (#3646): pg 既定は 0 = 無期限待ちで、接続不能時に caller (health probe 等)
+		// が hang し Lambda invoke timeout (Function URL 502) 化する。error にして 503 fail-close へ
+		// 落とす (staging cycle 4 の LWA readiness 連鎖の再発防止)。
+		connectionTimeoutMillis: 5_000,
 	};
 }
 

--- a/src/lib/server/db/dsql/migration/app-role.ts
+++ b/src/lib/server/db/dsql/migration/app-role.ts
@@ -1,0 +1,133 @@
+// src/lib/server/db/dsql/migration/app-role.ts
+// EPIC #3424 M5 / #3646 — アプリ実行 role (app_user) の provisioning。
+//
+// DSQL の IAM 認可仕様 (AWS 公式 authentication-authorization.html):
+//   - `admin` role で接続 = IAM action `dsql:DbConnectAdmin` が必要
+//   - custom database role で接続 = `dsql:DbConnect` + 事前の `AWS IAM GRANT <role> TO '<arn>'`
+// compute-stack (#3637) は Lambda に DbConnect のみ付与する (M3 §3.4 B6 最小権限) ため、
+// 対応する custom role を本 module が provisioning しないと Lambda は一切接続できない
+// (staging cycle 4 で実機露呈: health probe 接続不能 → 503 → LWA readiness 未達 → 502)。
+//
+// GRANT 方針 (M3 §3.4「追記性の物理担保」を実装事実に整合させた確定形):
+//   - UPDATE 除外表 (下記 UPDATE_EXCLUDED_TABLES): SELECT/INSERT/DELETE のみ付与。
+//     台帳・同意・履歴の**書き換え (UPDATE) を DB GRANT で物理的に不能**にする。
+//     DELETE は除外しない — 退会 (tenant 全削除) / retention cleanup (ADR-0049 物理削除) /
+//     child 削除の正当業務経路が DELETE を発行するため (M3 §3.4 の「UPDATE/DELETE 除外」は
+//     ADR-0049 と矛盾しており、DELETE 許可へ是正。#3646 記録)。
+//   - その他の表: SELECT/INSERT/UPDATE/DELETE を付与。
+//   - 表列挙は information_schema から動的に行う (migration で新表が増えても再実行で自動 cover、
+//     GRANT は冪等)。dsql_migrations (適用管理表) はアプリ経路に不要のため付与しない。
+//
+// 実行経路: dsql-migrate と同じ DbConnectAdmin credential (deploy workflow / 運用者)。
+// アプリ実行 role からは到達不能 (M3 §3.4 B6 経路分離)。
+
+import type { RawSqlExecutor } from './async-index-poll';
+
+/** postgres identifier として安全な形式のみ許可する (SQL injection 防御、raw executor のため)。 */
+const IDENT_RE = /^[a-z_][a-z0-9_]*$/;
+
+function assertIdent(name: string, label: string): void {
+	if (!IDENT_RE.test(name)) {
+		throw new Error(`[app-role] ${label} が identifier 形式ではありません: ${name}`);
+	}
+}
+
+/** IAM role ARN の許容形式 (AWS IAM GRANT に埋め込むため厳格に検証する)。 */
+const ARN_RE = /^arn:aws:iam::\d{12}:(role|user)\/[\w+=,.@/-]+$/;
+
+/**
+ * UPDATE を GRANT しない表 (= SELECT/INSERT/DELETE のみ)。
+ * M3 §3.4 の append-only 群のうち、**実装 (dsql repos) が UPDATE を発行しない表**に限定する。
+ * activity_logs (cancelled soft-cancel) / trial_history (状態更新) は実装が UPDATE を必要と
+ * するため除外リストに入れない。この集合の表に将来 UPDATE を書くと staging/本番で権限エラーに
+ * なる = 追記性違反の物理検出として機能する (対応する静的検査:
+ * tests/unit/architecture/dsql-append-only-update-fitness.test.ts)。
+ */
+export const UPDATE_EXCLUDED_TABLES: ReadonlySet<string> = new Set([
+	'point_ledger',
+	'consents',
+	'status_history',
+	'checklist_logs',
+	'notification_logs',
+	'usage_logs',
+	'cancellation_reasons',
+	'graduation_consent',
+]);
+
+export interface AppRoleProvisionOptions {
+	/** 作成する db role 名 (既定 'app_user')。 */
+	roleName?: string;
+	/** 指定時、この IAM role/user ARN に AWS IAM GRANT で紐付ける (Lambda 実行 role)。 */
+	iamRoleArn?: string;
+}
+
+export interface AppRoleProvisionResult {
+	roleName: string;
+	roleCreated: boolean;
+	iamGranted: boolean;
+	granted: { table: string; privileges: string }[];
+}
+
+/** アプリ実行 role の既定名。compute-stack が Lambda env DSQL_USER に注入する値と一致させる。 */
+export const APP_ROLE_NAME = 'app_user';
+
+/**
+ * app role を provisioning する (冪等 — role/mapping は存在チェック、GRANT は重複適用が no-op)。
+ * 1 文ずつ autocommit 適用する (DSQL は 1txn 1DDL、runner と同じ前提)。
+ */
+export async function provisionAppRole(
+	executor: RawSqlExecutor,
+	opts: AppRoleProvisionOptions = {},
+): Promise<AppRoleProvisionResult> {
+	const roleName = opts.roleName ?? APP_ROLE_NAME;
+	assertIdent(roleName, 'roleName');
+	if (opts.iamRoleArn && !ARN_RE.test(opts.iamRoleArn)) {
+		throw new Error(
+			`[app-role] iamRoleArn が IAM role/user ARN 形式ではありません: ${opts.iamRoleArn}`,
+		);
+	}
+
+	// 1) role 作成 (存在チェック → CREATE。DSQL/pg に CREATE ROLE IF NOT EXISTS は無い)
+	const existing = await executor.execute(`SELECT 1 FROM pg_roles WHERE rolname = '${roleName}'`);
+	const roleCreated = existing.rows.length === 0;
+	if (roleCreated) {
+		await executor.execute(`CREATE ROLE ${roleName} WITH LOGIN`);
+	}
+
+	// 2) IAM mapping (指定時のみ)。sys.iam_pg_role_mappings で冪等化 —
+	//    AWS IAM GRANT の重複適用挙動は公式 doc に明記が無いため、既存 mapping はスキップする。
+	let iamGranted = false;
+	if (opts.iamRoleArn) {
+		const mapped = await executor.execute(
+			`SELECT 1 FROM sys.iam_pg_role_mappings WHERE arn = '${opts.iamRoleArn}' AND pg_role_name = '${roleName}'`,
+		);
+		if (mapped.rows.length === 0) {
+			await executor.execute(`AWS IAM GRANT ${roleName} TO '${opts.iamRoleArn}'`);
+			iamGranted = true;
+		}
+	}
+
+	// 3) 表 GRANT (information_schema から動的列挙、冪等)。
+	//    `GRANT USAGE ON SCHEMA public` は発行しない — DSQL では public schema が system entity
+	//    (0A000 feature not supported、実機確認 #3646)。pg 系では public の USAGE は PUBLIC role
+	//    に既定付与されるため、表 GRANT のみでアクセス可能になる (dsql-app-role.test.ts [G2]/[G3]
+	//    が実権限を assert)。
+	const tables = await executor.execute(
+		`SELECT table_name FROM information_schema.tables
+		 WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+		 ORDER BY table_name`,
+	);
+	const granted: AppRoleProvisionResult['granted'] = [];
+	for (const row of tables.rows as { table_name: string }[]) {
+		const table = row.table_name;
+		if (table === 'dsql_migrations') continue; // 適用管理表はアプリ経路に不要
+		assertIdent(table, 'table_name');
+		const privileges = UPDATE_EXCLUDED_TABLES.has(table)
+			? 'SELECT, INSERT, DELETE'
+			: 'SELECT, INSERT, UPDATE, DELETE';
+		await executor.execute(`GRANT ${privileges} ON ${table} TO ${roleName}`);
+		granted.push({ table, privileges });
+	}
+
+	return { roleName, roleCreated, iamGranted, granted };
+}

--- a/tests/unit/architecture/dsql-append-only-update-fitness.test.ts
+++ b/tests/unit/architecture/dsql-append-only-update-fitness.test.ts
@@ -1,0 +1,58 @@
+// tests/unit/architecture/dsql-append-only-update-fitness.test.ts
+// #3646 / M3 §3.4 — 追記性 (UPDATE 禁止) の静的 fitness function (ADR-0061)。
+//
+// UPDATE_EXCLUDED_TABLES (app-role.ts SSOT) の表は本番 GRANT で UPDATE 権限を持たない。
+// repo 層にこれらの表への UPDATE を書くと **staging/本番で初めて権限エラーになる** ため、
+// CI 段階で dsql repo source を走査して検出する (shift-left)。GRANT (runtime) と本テスト
+// (static) の両輪で台帳・同意・履歴の改竄経路を封じる。
+//
+// 対象: src/lib/server/db/dsql/*.ts の raw SQL (`UPDATE <table>`)。dsql repos は raw sql
+// template が主体のため文字列走査で十分 (drizzle .update(table) 形も併せて検出)。
+// 誤検出回避: コメント行は除外する。
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { UPDATE_EXCLUDED_TABLES } from '../../../src/lib/server/db/dsql/migration/app-role';
+
+const DSQL_DIR = join(__dirname, '../../../src/lib/server/db/dsql');
+
+/** コメント行 (// / *) を落とした実効コード行を返す。 */
+function effectiveLines(source: string): { line: string; no: number }[] {
+	return source
+		.split('\n')
+		.map((line, i) => ({ line, no: i + 1 }))
+		.filter(({ line }) => {
+			const trimmed = line.trim();
+			return !trimmed.startsWith('//') && !trimmed.startsWith('*') && !trimmed.startsWith('/*');
+		});
+}
+
+describe('DSQL append-only UPDATE fitness (#3646、M3 §3.4)', () => {
+	it('UPDATE 除外表への UPDATE 文が dsql repo 層に存在しない', () => {
+		const files = readdirSync(DSQL_DIR).filter((f) => f.endsWith('.ts'));
+		const violations: string[] = [];
+		for (const file of files) {
+			const source = readFileSync(join(DSQL_DIR, file), 'utf-8');
+			for (const { line, no } of effectiveLines(source)) {
+				for (const table of UPDATE_EXCLUDED_TABLES) {
+					// raw SQL: `UPDATE <table>` / drizzle: `.update(<camelCase>)`
+					const camel = table.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+					if (
+						new RegExp(`\\bUPDATE\\s+${table}\\b`, 'i').test(line) ||
+						new RegExp(`\\.update\\(\\s*${camel}\\s*\\)`).test(line)
+					) {
+						violations.push(`${file}:${no} → ${table}: ${line.trim()}`);
+					}
+				}
+			}
+		}
+		expect(
+			violations,
+			`UPDATE 除外表 (app-role.ts UPDATE_EXCLUDED_TABLES) への UPDATE を検出しました。` +
+				`これらの表は本番 GRANT で UPDATE 権限が無く実行時に権限エラーになります。` +
+				`業務上 UPDATE が必要になった場合は app-role.ts の除外リストから外し、` +
+				`M3 §3.4 (追記性の物理担保) との整合を設計判断として記録してください。\n${violations.join('\n')}`,
+		).toEqual([]);
+	});
+});

--- a/tests/unit/db/dsql-app-role.test.ts
+++ b/tests/unit/db/dsql-app-role.test.ts
@@ -1,0 +1,115 @@
+// tests/unit/db/dsql-app-role.test.ts
+// #3646 / EPIC #3424 M5 — アプリ実行 role provisioning (app-role.ts) の契約テスト。
+//
+// 実 schema PGlite (実 Postgres WASM) で provisionAppRole を実行し:
+//   [G1] role 作成 + 表 GRANT が通る (冪等: 2 回目も成功)
+//   [G2] UPDATE 除外表 (point_ledger 等) は UPDATE 権限が付与されない = 台帳改竄の物理防御
+//        (M3 §3.4、has_table_privilege で DB 実権限を assert)
+//   [G3] 通常表 (children 等) は SELECT/INSERT/UPDATE/DELETE 全付与
+//   [G4] DELETE は UPDATE 除外表にも付与される (退会 / retention ADR-0049 の正当経路)
+//   [G5] AWS IAM GRANT (DSQL 固有構文、PGlite 非対応) は fake executor で SQL 文字列 + 冪等
+//        スキップを検証
+//   [G6] roleName / iamRoleArn の形式検証 (raw SQL 埋め込みの injection 防御)
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	APP_ROLE_NAME,
+	provisionAppRole,
+	UPDATE_EXCLUDED_TABLES,
+} from '../../../src/lib/server/db/dsql/migration/app-role';
+import type { RawSqlExecutor } from '../../../src/lib/server/db/dsql/migration/async-index-poll';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+const ARN = 'arn:aws:iam::443370718249:role/staging-lambda-role';
+
+describe('DSQL app role provisioning (#3646、実 schema PGlite)', () => {
+	let t: DsqlTestDb;
+	let executor: RawSqlExecutor;
+
+	beforeAll(async () => {
+		t = await createDsqlTestDb();
+		executor = {
+			execute: async (sqlText: string) => {
+				const res = await t.client.query(sqlText);
+				return { rows: (res.rows ?? []) as unknown[] };
+			},
+		};
+	}, 120_000);
+	afterAll(async () => {
+		await t.close();
+	});
+
+	async function privilege(table: string, priv: string): Promise<boolean> {
+		const res = await t.client.query(
+			`SELECT has_table_privilege('${APP_ROLE_NAME}', '${table}', '${priv}') AS ok`,
+		);
+		return (res.rows[0] as { ok: boolean }).ok;
+	}
+
+	it('[G1] role 作成 + 表 GRANT が通り、冪等 (2 回目は roleCreated=false で成功)', async () => {
+		const first = await provisionAppRole(executor);
+		expect(first.roleName).toBe(APP_ROLE_NAME);
+		expect(first.roleCreated).toBe(true);
+		expect(first.granted.length).toBeGreaterThan(50); // 実 schema 全表 (59 表) に適用
+		const second = await provisionAppRole(executor);
+		expect(second.roleCreated).toBe(false);
+		expect(second.granted.length).toBe(first.granted.length);
+	}, 120_000);
+
+	it('[G2] UPDATE 除外表は UPDATE 権限が付与されない (台帳改竄の物理防御、M3 §3.4)', async () => {
+		for (const table of UPDATE_EXCLUDED_TABLES) {
+			expect(await privilege(table, 'UPDATE'), `${table} に UPDATE が付与されている`).toBe(false);
+			expect(await privilege(table, 'SELECT'), `${table} に SELECT が無い`).toBe(true);
+			expect(await privilege(table, 'INSERT'), `${table} に INSERT が無い`).toBe(true);
+		}
+	}, 60_000);
+
+	it('[G3] 通常表 (children / activity_logs / trial_history) は UPDATE 込み全権付与', async () => {
+		// activity_logs (cancelled soft-cancel) / trial_history (状態更新) は実装が UPDATE を
+		// 発行するため除外リスト外であること自体も本 assert が固定する。
+		for (const table of ['children', 'activity_logs', 'trial_history']) {
+			for (const priv of ['SELECT', 'INSERT', 'UPDATE', 'DELETE']) {
+				expect(await privilege(table, priv), `${table} に ${priv} が無い`).toBe(true);
+			}
+		}
+	}, 60_000);
+
+	it('[G4] DELETE は UPDATE 除外表にも付与される (退会 / retention ADR-0049 の正当経路)', async () => {
+		for (const table of ['point_ledger', 'consents', 'graduation_consent']) {
+			expect(await privilege(table, 'DELETE'), `${table} に DELETE が無い`).toBe(true);
+		}
+	}, 60_000);
+
+	it('[G5] AWS IAM GRANT: fake executor で SQL 文字列を検証し、mapping 既存時はスキップ', async () => {
+		const executed: string[] = [];
+		const fake = (mapped: boolean): RawSqlExecutor => ({
+			execute: async (sqlText: string) => {
+				executed.push(sqlText);
+				if (sqlText.includes('pg_roles')) return { rows: [{ ok: 1 }] }; // role 既存
+				if (sqlText.includes('iam_pg_role_mappings')) return { rows: mapped ? [{ ok: 1 }] : [] };
+				if (sqlText.includes('information_schema.tables')) return { rows: [] };
+				return { rows: [] };
+			},
+		});
+
+		// mapping 不在 → AWS IAM GRANT が発行される
+		const r1 = await provisionAppRole(fake(false), { iamRoleArn: ARN });
+		expect(r1.iamGranted).toBe(true);
+		expect(executed).toContain(`AWS IAM GRANT ${APP_ROLE_NAME} TO '${ARN}'`);
+
+		// mapping 既存 → スキップ (冪等)
+		executed.length = 0;
+		const r2 = await provisionAppRole(fake(true), { iamRoleArn: ARN });
+		expect(r2.iamGranted).toBe(false);
+		expect(executed.some((s) => s.startsWith('AWS IAM GRANT'))).toBe(false);
+	});
+
+	it('[G6] roleName / iamRoleArn の形式検証 (raw SQL injection 防御)', async () => {
+		await expect(
+			provisionAppRole(executor, { roleName: 'x; DROP TABLE children;--' }),
+		).rejects.toThrow(/identifier/);
+		await expect(
+			provisionAppRole(executor, { iamRoleArn: "arn:aws:iam::123:role/x' ; DROP TABLE y;--" }),
+		).rejects.toThrow(/ARN/);
+	});
+});

--- a/tests/unit/infra/dsql-cutover-wiring.test.ts
+++ b/tests/unit/infra/dsql-cutover-wiring.test.ts
@@ -102,6 +102,9 @@ describe('compute-stack DSQL cutover 配線 (EPIC #3424 M5 DoD3、flag-gated)', 
 		const envVars = mainFnEnv(template);
 		expect(envVars.DATA_SOURCE).toBe('dsql');
 		expect(envVars.DSQL_ENDPOINT).toBe(TEST_DSQL_ENDPOINT);
+		// #3646: DbConnect は custom db role 専用 (admin は DbConnectAdmin 必要)。既定 admin の
+		// まま接続すると staging cycle 4 同様に接続不能になるため app_user 注入を固定する。
+		expect(envVars.DSQL_USER).toBe('app_user');
 
 		// DbConnect が cluster ARN 限定で付与される (ワイルドカード禁止)
 		template.hasResourceProperties('AWS::IAM::Policy', {


### PR DESCRIPTION
## 顧客価値・目的

staging cycle 4 で実機露呈した「Lambda が DSQL に一切接続できない」cutover blocker を根治し、DSQL 実接続の初エビデンス (health 200 + dataSource=dsql + schemaValid=true) を取得する。同時に M3 §3.4「台帳改竄の物理防御」(UPDATE 除外 GRANT) を本番 cutover gate から前倒し実装する。

## 関連 Issue

closes #3646 (EPIC #3424 M5 / staging PDCA cycle 4 の学び)

## 根本原因

接続 user 既定 `admin` × Lambda IAM `dsql:DbConnect` の不整合。DSQL 認可仕様 (AWS 公式) では admin role は `dsql:DbConnectAdmin` が必要で、`DbConnect` は custom database role 専用 (事前の `AWS IAM GRANT` 紐付け必須)。custom role が未 provisioning だったため、この組は成立しなかった。cycle 3 は旧 health の sqlite probe 偽陽性 (200) で隠れており、probePg (#3644) の実接続化で初露呈。error chain は CloudWatch 実ログで確定: probe 接続不能 → 503 fail-close (アプリは正常動作) → LWA readiness check (`AWS_LWA_READINESS_CHECK_PATH=/api/health`) 未達 → invoke 30s timeout → Function URL 502。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| AC1: app role provisioning (CREATE ROLE + AWS IAM GRANT + 表 GRANT) が idempotent | `tests/unit/db/dsql-app-role.test.ts` [G1] (実 schema PGlite、2 回実行) + [G5] (AWS IAM GRANT は fake executor で SQL 文字列 + 冪等スキップ) | PASS (7 tests) | vitest log |
| AC2: UPDATE 除外表に UPDATE grant が付与されない (M3 §3.4 物理担保) | [G2] has_table_privilege で DB 実権限 assert + `tests/unit/architecture/dsql-append-only-update-fitness.test.ts` (repo 層への UPDATE 混入を CI 静的検出) | PASS | vitest log |
| AC3: compute-stack が DSQL_USER=app_user 注入 (dsqlEnabled 時のみ) | `tests/unit/infra/dsql-cutover-wiring.test.ts` [W2] に assert 追加 ([W1] prod 不変 guard は既存のまま PASS) | PASS (4 tests) | vitest log |
| AC4: 接続 timeout で hang→502 を根絶 | `connectionTimeoutMillis: 5000` (pg 既定 0 = 無期限)。接続不能は error → health 503 fail-close (dsql-connection.test.ts 8 tests PASS) | PASS | code + vitest |
| AC5: staging で DSQL 実接続エビデンス | **実機前倒し検証済み**: staging cluster へ `npm run dsql:grant` 実適用 (59 表 GRANT + IAM mapping) → Lambda env に DSQL_USER=app_user 注入 → **health 200 `{"status":"ok","dataSource":"dsql","schema":{"schemaValid":true}}`** (2026-07-11T10:22:18Z)。merge 後の dsql lane 再 dispatch (cycle 5) で workflow 全貫通を最終確認し run URL を EPIC #3424 に記録して完了とする | PASS (前倒し実機) | health レスポンス実物 (下記) |

AC5 実機エビデンス (staging Function URL への実 GET):

```
STATUS: 200
{"status":"ok","timestamp":"2026-07-11T10:22:18.587Z","version":"v1.20260711.1","dataSource":"dsql","region":"us-east-1","uptime":3,"schema":{"schemaValid":true,"migrationsApplied":0,"schemaWarnings":0}}
```

probePg は `SELECT 1` + `SELECT count(*) FROM children` を DATA_SOURCE の実 backend で実行するため、この 200 は DSQL 実接続なしには返らない (cycle 3 偽陽性との質的差異)。

## 設計判断の記録 (M3 §3.4 の是正)

M3 §3.4 の「append-only 表への UPDATE/**DELETE** grant を与えない」は、退会 (tenant 全削除) / retention cleanup (ADR-0049 物理削除) / child 削除の正当業務経路 (dsql repos に実在) と矛盾していた。**UPDATE のみ除外 (改竄不能)、DELETE は付与 (ADR-0049 準拠)** に是正し、m3-physical-model.md §3.4 を実装事実に同期。activity_logs (cancelled soft-cancel) / trial_history (状態更新) は実装が UPDATE を必要とするため除外対象外。除外リスト SSOT は `app-role.ts` `UPDATE_EXCLUDED_TABLES` (8 表)。

また `GRANT USAGE ON SCHEMA public` は DSQL で 0A000 (system entity、実機確認)。pg 系では public の USAGE は PUBLIC role に既定付与のため発行しない (表 GRANT のみでアクセス可、[G2]/[G3] が実権限 assert)。

## 変更タイプ

- [x] バグ修正 (DSQL 接続不能 = cutover blocker)
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dsql/migration/app-role.ts` (新規、provisioning core) / `scripts/dsql-grant.ts` (新規 thin CLI) / `package.json` (`dsql:grant`)
- `deploy-aws-staging.yml` Step 11.5 (dsql lane のみ。旧 backend lane / NUC lane 不変)
- `infra/lib/compute-stack.ts` (dsqlEnabled 時のみ DSQL_USER 注入。flag なし template 不変 = [W1] guard PASS)
- `src/lib/server/db/dsql/connection.ts` (connectionTimeoutMillis 追加のみ)
- `docs/design/dsql/m3-physical-model.md` §3.4 (設計是正の同期)

## テスト & 安全装置セルフチェック

- [x] 新規 module に対応する unit test 同梱 (dsql-app-role.test.ts 6 cases、実 schema PGlite で DB 実権限を assert)
- [x] fitness function 追加 (dsql-append-only-update-fitness.test.ts、ADR-0061 shift-left)
- [x] prod 不変 guard ([W1]) PASS = dsqlEnabled なし template 完全不変
- [x] raw SQL 埋め込みは identifier regex + ARN regex で injection 防御 ([G6])
- [x] 局所テスト: dsql-app-role / append-only-fitness / dsql-cutover-wiring / dsql-connection 全 PASS

## スクリーンショット / ビジュアルデモ

N/A — backend 接続層のみ (UI 変更なし)。実機エビデンスは AC5 の health レスポンス。

## コード品質セルフレビュー (#1481)

- provisioning は information_schema 動的列挙で新表を自動 cover (migration 追加時の GRANT 漏れを構造的に防止)
- 冪等設計 (role/mapping 存在チェック + GRANT 重複 no-op) で PDCA 再実行・手動先行適用と workflow 適用が衝突しない

## 横展開・影響波及チェック

- 本番 deploy.yml への DSQL 配線は M5 cutover gate で本 PR と同構成 (dsql:migrate → deploy → dsql:grant) を適用する (M3 §3.4 に手順を明記済み)
- NUC (PGlite) は IAM 無関係で対象外 (単一プロセス直結)
- pin-operator 等の他 CLI への影響なし (dsql-grant は独立 script)

## レビュー依頼事項・破壊的変更

破壊的変更なし (flag-gated + 冪等)。レビュー観点: UPDATE_EXCLUDED_TABLES の 8 表選定 (実装事実ベース) と M3 §3.4 是正の妥当性。

## 配布済み env / secret (ADR-0006)

N/A — 新規 secret なし。DSQL_USER は CDK context 経由の非 secret env (dsqlEnabled 時のみ)。

## Ready for Review チェックリスト

- [x] 実装 + テスト + 設計書同期が 1 PR で完結
- [x] 局所テスト全 PASS + 実機検証 (staging cluster) 済み
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
