### PR TITLE
fix(nuc): #3620 Dockerfile に scripts/lib 同梱 (cutover CLI の ERR_MODULE_NOT_FOUND 根治)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,9 @@ COPY --from=build /app/drizzle.config.ts ./
 # docs/runbooks/nuc-pglite-cutover.md。
 COPY --from=build /app/src ./src
 COPY --from=build /app/scripts/nuc-pglite-cutover.ts ./scripts/nuc-pglite-cutover.ts
+# CLI が import する scripts/lib/ (nuc-cutover-verify 等) を丸ごと同梱する — 単体ファイル COPY だと
+# lib module 追加のたびに漏れる (staging PGlite cycle 2 で ERR_MODULE_NOT_FOUND 実機露呈、#3620)
+COPY --from=build /app/scripts/lib ./scripts/lib
 COPY --from=build /app/drizzle ./drizzle
 COPY --from=build /app/tsconfig.json ./
 # root tsconfig は .svelte-kit/tsconfig.json を extends し $lib paths はそちら側 (svelte-kit sync


### PR DESCRIPTION
## 顧客価値・目的

NUC staging PGlite cycle 2 を止めた cutover CLI の ERR_MODULE_NOT_FOUND を根治し、NUC cutover 実機リハーサル (本番リリース可否判断の最終エビデンス) を前進させる。

## 関連 Issue

#3620 (AC-C5 staging PDCA cycle 2 の学び) / #3643 (verify module の scripts/lib 移設に Dockerfile が未追随)。

## 根本原因

#3643 で QM 指摘 (services/ 配置境界違反) を受け件数突合 module を `scripts/lib/nuc-cutover-verify.ts` へ移設した際、NUC Dockerfile runtime stage の COPY が `scripts/nuc-pglite-cutover.ts` **単体ファイルのみ**のままで、import 先の `scripts/lib/` が image に入らなかった (横展開漏れ)。cycle 2 (run 29149563283) で `docker compose run ... cutover export` が ERR_MODULE_NOT_FOUND で fail し実機露呈。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| cutover CLI の import する lib module が image に同梱される | `COPY --from=build /app/scripts/lib ./scripts/lib` (単体ファイルでなくディレクトリ COPY = 以後の lib 追加でも漏れない構造) | PASS (diff 3 行) | Dockerfile diff |
| 他 Dockerfile への波及なし | `grep -l nuc-pglite-cutover Dockerfile*` → root Dockerfile のみが cutover CLI を同梱 (Lambda 系は DSQL 経路で対象外) | PASS | grep 結果 |
| 実機貫通 | merge 後の pglite lane 再 dispatch (cycle 3) で cutover rehearsal 貫通を最終確認。run URL を EPIC に記録して完了とする | 手順確立済 | workflow 既存 |

## 変更タイプ

- [x] バグ修正 (staging PGlite lane blocker)
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- NUC `Dockerfile` runtime stage の COPY 1 箇所のみ (+3 行、ロジック不変)。scripts/lib は 92KB (6 file) で image size 影響は無視できる。

## テスト & 安全装置セルフチェック

- [x] 変更は COPY 追加のみ、既存 layer / entrypoint 不変
- [x] 単体ファイル COPY → ディレクトリ COPY で same-class 再発 (lib module 追加時の漏れ) を構造的に封止

## スクリーンショット / ビジュアルデモ

N/A — Dockerfile のみ。

## コード品質セルフレビュー (#1481)

同種の「移設に COPY 未追随」は cycle 2 PDCA で 3 件目 (ts-node×TS7 / prepare.mjs / 本件)。deploy 供給線は staging PDCA でしか露呈しない層のため、staging cycle を回すこと自体が検証手段 (EPIC #3424/#3620 の PDCA 方針どおり)。

## 横展開・影響波及チェック

- Dockerfile.lambda / infra/lambda 系は cutover CLI を同梱しない (AWS は DSQL 経路) ため対象外を grep で確認済み
- deploy-nuc.yml (本番) も同じ root Dockerfile を build するため、本修正で本番 cutover 実行手順 (runbook) も同時に成立する

## レビュー依頼事項・破壊的変更

破壊的変更なし。

## 配布済み env / secret (ADR-0006)

N/A。

## Ready for Review チェックリスト

- [x] 修正が 1 PR で完結 (Dockerfile +3 行)
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
