### PR TITLE
fix(tooling): #3649 pre-ready に Step 1b cspell 追加 (CI 整合 gap 根治、self-report 乖離の機械封止)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,9 @@ Ready 化前は依然として `npm run pre-ready -- --pr <num>` 全 step PASS �
 
 ### Ready 化前チェック（必須）
 
-`npm run pre-ready -- --pr <num>` 一括実行 (ADR-0030 / #1775 / #1920 / #2918 で SSOT 検証 step 拡張)。全 14 step (Step 1〜12 + 7b / 11b) を順次実行し各 fail で即停止 + 修正方針表示。**step 一覧の SSOT は `npm run pre-ready -- --help`** (#2929 で同期):
+`npm run pre-ready -- --pr <num>` 一括実行 (ADR-0030 / #1775 / #1920 / #2918 で SSOT 検証 step 拡張)。全 15 step (Step 1〜12 + 1b / 7b / 11b) を順次実行し各 fail で即停止 + 修正方針表示。**step 一覧の SSOT は `npm run pre-ready -- --help`** (#2929 で同期):
 
-1. biome check / 2. svelte-check / 3. vitest run / 4. check-hardcoded-strings (#1452) / 5. measure-lp-dimensions (#1163, LP 変更時のみ) / 6. sync-lp-fallback --check (#1945, LP / labels.ts 変更時のみ) / 7. check-no-plan-literals (#972) / 7b. check-license-key-leak (#2836) / 8. generate-lp-labels --check (#1917, labels.ts / terms.ts / age-tier.ts 変更時のみ) / 9. Readiness gate = check-pr-body (PR 番号必須) / 10. check-doc-code-references (#2577) / 11. check-terminology-coherence (#2555) / 11b. SS embed gate (#2918, UI 変更 PR の SS 未 embed hard-fail) / 12. capture (UI 変更時のみガイダンス)
+1. biome check / 1b. cspell (#3649, CI 同一コマンド) / 2. svelte-check / 3. vitest run / 4. check-hardcoded-strings (#1452) / 5. measure-lp-dimensions (#1163, LP 変更時のみ) / 6. sync-lp-fallback --check (#1945, LP / labels.ts 変更時のみ) / 7. check-no-plan-literals (#972) / 7b. check-license-key-leak (#2836) / 8. generate-lp-labels --check (#1917, labels.ts / terms.ts / age-tier.ts 変更時のみ) / 9. Readiness gate = check-pr-body (PR 番号必須) / 10. check-doc-code-references (#2577) / 11. check-terminology-coherence (#2555) / 11b. SS embed gate (#2918, UI 変更 PR の SS 未 embed hard-fail) / 12. capture (UI 変更時のみガイダンス)
 
 E2E / Storybook は別途 (`npx playwright test` / `npm run test:storybook`)。任意: `npx eslint "src/**/*.ts"` (#977) / `npm run type-coverage` / `npm run knip` (#970)。CI 自動拒否は `.github/workflows/ci.yml` 参照。
 

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -138,7 +138,7 @@
 | `npm run dev` | 開発サーバー (port 5173、local モード) |
 | `npm run dev:cognito` | Cognito 認証画面 (#1026、認証画面 PR Ready 前必須) |
 | `npm run build` | SvelteKit production build |
-| `npm run pre-ready -- --pr <num>` | Ready 化前 全 14 step 検証 (ADR-0030 / #1920 / #2918。一覧 SSOT は `--help`) |
+| `npm run pre-ready -- --pr <num>` | Ready 化前 全 15 step 検証 (ADR-0030 / #1920 / #2918。一覧 SSOT は `--help`) |
 | `npx biome check .` | Biome lint (Tier T1) |
 | `npx svelte-check` | Svelte 型チェック |
 | `npx vitest run` | unit / integration テスト |

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -621,9 +621,21 @@ async function main() {
 		console.log(`\n[pre-ready] ⚠ fail-open: ${note}`);
 	}
 
+	// #3649: --skip-* で step を飛ばした実行は「ALL PASS」を名乗らない。skip flag は開発中の
+	// 部分確認用であり、Ready 化判定 (=「pre-ready ALL PASS」という self-report) には skip なし
+	// 実行が必要 (skip 込みで ALL PASS 表示すると self-report ↔ CI 乖離の温床になる)。
+	if (skipped.length > 0) {
+		console.log(
+			`\n[pre-ready] PARTIAL PASS — 実行した ${steps.length - skipped.length} step は PASS しましたが、` +
+				`${skipped.length} step が --skip 指定で未実行です (${skipped.join(', ')})。\n` +
+				`  これは開発中の部分確認結果であり、Ready 化 (gh pr ready) 判定には\n` +
+				`  skip なしの \`npm run pre-ready -- --pr ${args.pr ?? '<num>'}\` 全 step PASS が必要です。\n`,
+		);
+		return 0;
+	}
+
 	console.log(
 		`\n[pre-ready] ALL PASS${failOpenNotes.length > 0 ? ` (fail-open ${failOpenNotes.length} 件あり — 上記 ⚠ を確認)` : ''} — Ready for Review に進めます。\n` +
-			`  実行: ${steps.length - skipped.length} step / skip: ${skipped.length} step (${skipped.join(', ') || 'none'})\n` +
 			`  次の手順:\n` +
 			`    1. node scripts/check-gh-account-before-pr.mjs   # gh アカウント確認 (#1728)\n` +
 			`    2. gh pr ready ${args.pr ?? '<num>'}                            # Ready for Review に変更\n` +

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -57,6 +57,7 @@ const failOpenNotes = [];
 
 const SKIP_FLAGS = {
 	'--skip-biome': 'skipBiome',
+	'--skip-cspell': 'skipCspell',
 	'--skip-svelte-check': 'skipSvelteCheck',
 	'--skip-vitest': 'skipVitest',
 	'--skip-hardcoded': 'skipHardcoded',
@@ -117,6 +118,7 @@ Usage:
 Options:
   --pr <num>             GitHub PR 番号 (Step 9 PR body / mergeable 検証用)
   --skip-biome           Step 1 biome check をスキップ
+  --skip-cspell          Step 1b cspell spell check をスキップ
   --skip-svelte-check    Step 2 svelte-check をスキップ
   --skip-vitest          Step 3 vitest をスキップ (重いので高速確認時のみ)
   --skip-hardcoded       Step 4 hardcoded JP text 検査をスキップ
@@ -134,6 +136,7 @@ Options:
 
 Steps:
   1.  biome check                 — lint
+  1b. cspell                      — spell check (CI lint-and-test と同一コマンド、#3649)
   2.  svelte-check                — TS strict 型チェック
   3.  vitest run                  — unit test (storybook 以外)
   4.  check-hardcoded-strings.mjs — JP ハードコード baseline 監視 (#1452)
@@ -330,6 +333,17 @@ function buildSteps(args, changedFiles) {
 			fixHint:
 				'  npx biome check --error-on-warnings --write .   # 自動修正可能なものを修正\n' +
 				'  remaining warning / error は手動で修正してから再実行 (CI は warning=error 扱い)',
+		},
+		{
+			name: 'cspell',
+			label: 'Step 1b/12: cspell (CI lint-and-test と同一コマンド — #3649)',
+			skip: args.skipCspell,
+			// #3649: CI lint-and-test の `npm run cspell` (#1432 warning=error) と同一。
+			// pre-ready に本 step が無かった gap により「pre-ready ALL PASS ↔ CI cspell red」の
+			// self-report 乖離が反復 (PR #3647 の Millis 等)。glob は package.json "cspell" が SSOT。
+			runner: () => run('cspell', ['npm', 'run', 'cspell']),
+			fixHint:
+				'  typo なら修正 / 正当な技術語・固有名詞なら .cspell.json の words に追加 (小文字で登録、大文字小文字非依存)',
 		},
 		{
 			name: 'svelte-check',


### PR DESCRIPTION
## 顧客価値・目的

「pre-ready ALL PASS」報告と CI 実態 (cspell red) の乖離 (QM 指摘、PR #3647 で顕在化) を構造的に根絶する。以後、spell 検査は Ready 化前にローカルで機械検出され、CI 初検出による BLOCK 往復 (レビューサイクルの浪費) がなくなる。

## 関連 Issue

closes #3649

## 根本原因

pre-ready (#1775/#1920) の設計原則は「CI と同じ検査の先回り」(Step 1 biome は #2503 で CI と完全一致化) だが、CI lint-and-test に存在する `npm run cspell` (#1432 warning=error) が pre-ready に組み込まれていなかった (意図的除外の設計記録なし = 歴史的 gap)。従来は「既知の罠としてローカル cspell を人が手動先行実行」で回避しており、ADR-0061 が禁じる人の注意依存になっていた (PR #3647 で connection.ts への追記分をチェック漏れし再発)。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| AC1: pre-ready が cspell を実行し、未知語で fail + fixHint 表示 | mutation 検証 — 未知語 fixture (`xqzzyblorf`) を src に一時作成 → Step 1b が `Unknown word` + fixHint で FAIL、除去で ALL PASS 復帰 | PASS (両経路) | 実行ログ |
| AC2: --help の step 一覧に反映 (SSOT、#2929) | Options に `--skip-cspell` / Steps に `1b. cspell` 追記 | PASS | diff |
| AC3: CLAUDE.md の step 列挙に反映 | ルート CLAUDE.md (全 15 step + 1b 追記) + docs/codebase-map.md (14→15) 同期 | PASS | diff |
| CI と同一コマンド | Step 1b は `npm run cspell` を呼ぶ (glob は package.json "cspell" が SSOT、二重定義しない) | PASS | code |

## 変更タイプ

- [x] バグ修正 (検証 gap)
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `scripts/pre-ready.mjs` (Step 1b 追加 + skip flag + help)、`CLAUDE.md` / `docs/codebase-map.md` (step 数同期)。既存 step の順序・挙動不変。

## テスト & 安全装置セルフチェック

- [x] PASS / FAIL 両経路を mutation 検証 (未知語 fixture の作成→検出→除去→復帰)
- [x] コマンドは CI と同一 (`npm run cspell`)、glob 二重定義なし

## スクリーンショット / ビジュアルデモ

N/A — CLI tooling のみ。

## コード品質セルフレビュー (#1481)

- 実行時間 +~10s (cspell 1699 files、CI 実測)。`--skip-cspell` で高速確認時は回避可能 (他 step と同型)

## 横展開・影響波及チェック

- pre-push (husky) は軽量 verify chain の設計 (ADR-0030) のため追加しない (重い全体検査は pre-ready 側)
- QM が #3645 approve body に記録した「非 ASCII 実行時 literal の CI 静的検出 lint」は別 class (workflow yml の PS5.1 対策) であり本 PR の対象外 (QM 記録側で追跡)

## レビュー依頼事項・破壊的変更

破壊的変更なし。pre-ready 実行者は cspell fail 時に .cspell.json への語追加が必要になる (fixHint で案内)。

## 配布済み env / secret (ADR-0006)

N/A。

## Ready for Review チェックリスト

- [x] 実装 + mutation 検証 + docs 同期が 1 PR で完結
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。

