### PR TITLE
test(dsql): #3545 実 DSQL staging 並行アクセス検証の恒久 test + 実測ログ (#3425 AC4)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -9,11 +9,7 @@
 			"addWords": true
 		}
 	],
-	"dictionaries": [
-		"project-words",
-		"softwareTerms",
-		"fonts"
-	],
+	"dictionaries": ["project-words", "softwareTerms", "fonts"],
 	"ignorePaths": [
 		"node_modules",
 		".svelte-kit",
@@ -64,22 +60,15 @@
 	"overrides": [
 		{
 			"filename": "**/*.css",
-			"ignoreRegExpList": [
-				"/[a-zA-Z0-9-]+:\\s*[^;]+;/g"
-			]
+			"ignoreRegExpList": ["/[a-zA-Z0-9-]+:\\s*[^;]+;/g"]
 		},
 		{
 			"filename": "**/package.json",
-			"ignoreRegExpList": [
-				"/\"@?[a-zA-Z0-9/_.-]+\"\\s*:/g"
-			]
+			"ignoreRegExpList": ["/\"@?[a-zA-Z0-9/_.-]+\"\\s*:/g"]
 		},
 		{
 			"filename": "infra/**/*.ts",
-			"ignoreRegExpList": [
-				"/[a-z0-9]{20,}/g",
-				"/\\._domainkey/g"
-			]
+			"ignoreRegExpList": ["/[a-z0-9]{20,}/g", "/\\._domainkey/g"]
 		}
 	],
 	"words": [

--- a/.cspell.json
+++ b/.cspell.json
@@ -9,7 +9,11 @@
 			"addWords": true
 		}
 	],
-	"dictionaries": ["project-words", "softwareTerms", "fonts"],
+	"dictionaries": [
+		"project-words",
+		"softwareTerms",
+		"fonts"
+	],
 	"ignorePaths": [
 		"node_modules",
 		".svelte-kit",
@@ -60,15 +64,22 @@
 	"overrides": [
 		{
 			"filename": "**/*.css",
-			"ignoreRegExpList": ["/[a-zA-Z0-9-]+:\\s*[^;]+;/g"]
+			"ignoreRegExpList": [
+				"/[a-zA-Z0-9-]+:\\s*[^;]+;/g"
+			]
 		},
 		{
 			"filename": "**/package.json",
-			"ignoreRegExpList": ["/\"@?[a-zA-Z0-9/_.-]+\"\\s*:/g"]
+			"ignoreRegExpList": [
+				"/\"@?[a-zA-Z0-9/_.-]+\"\\s*:/g"
+			]
 		},
 		{
 			"filename": "infra/**/*.ts",
-			"ignoreRegExpList": ["/[a-z0-9]{20,}/g", "/\\._domainkey/g"]
+			"ignoreRegExpList": [
+				"/[a-z0-9]{20,}/g",
+				"/\\._domainkey/g"
+			]
 		}
 	],
 	"words": [

--- a/docs/research/2026-06-28-aurora-dsql-adoption.md
+++ b/docs/research/2026-06-28-aurora-dsql-adoption.md
@@ -180,9 +180,25 @@
 
 **結論**: §9-§10 の de-risking 推定が実機で全件裏取りされた。特に最重要の **RLS 非対応が確定**し、テナント分離設計（pool + 信頼 claim/context + fitness function + cross-tenant E2E）が唯一解であることが確証された。サプライズなし。残る実機検証（Lambda warm 接続再利用・cold start・drizzle-kit 実 migration 適用・一括 import チャンク実装）は設計 Sub 着手時に実施。
 
-### 11.2 今後の spike（#3425-#3429 着手時に追記）
+### 11.2 staging 実測（2026-07-11、staging cluster us-east-1、#3425 / #3426 / #3545 / #3550）
 
-- （未実施: Lambda 接続再利用 + cold start / drizzle-kit 実 migration 適用 / 一括 import チャンク実装 / CDK CfnCluster 構成）
+staging DSQL lane（EPIC #3424 M5 PDCA）の生きた cluster で実測。詳細な生データは各 Issue コメント（#3425 / #3426 / #3545）を参照。
+
+**並行アクセス（#3545/#3550、`tests/integration/db/dsql-staging-concurrency.test.ts` — DSQL_ENDPOINT 指定時のみ実行の恒久 test）**:
+
+| 検証 | 実測 |
+|---|---|
+| retry なし 8 並行 recordActivityCore（同一 child 共有行 write） | SQLSTATE 40001 = **7/8 件**（spike#8 の M=8→6 件と整合） |
+| withOccRetry 込み 8 並行（dailyLimit=1） | **exactly-once**（ok=1 / ALREADY_RECORDED=7、point_ledger 1 行、total_point=SUM 整合） |
+| withOccRetry 込み 8 並行（無制限） | **lost update ゼロ**（mastery total_count=8 / total_point=80=SUM / statuses XP=80） |
+
+**DPU（#3425、EXPLAIN ANALYZE VERBOSE Statement DPU Estimate）**: home read 0.050 / ledger 履歴 50 件 0.056 / 冪等 guard count 0.025 / ledger INSERT 0.022 / children UPDATE 0.012。**write txn には Transaction minimum 0.05 WriteDPU** が適用され、活動記録 1 回 ≈ 0.1 DPU → 1 家族 300 記録/月 ≈ 30 DPU ≈ $0.00024/月（§P0 の「実費 ¥0 見込み」を service クエリ粒度で裏取り）。
+
+**CloudWatch（#3425 AC3）**: `AWS/AuroraDSQL` の TotalDPU（233.19、Compute 88%）/ **OccConflicts（85 件 — retry 内競合も全部観測）** / CommitLatency（平均 **2.87ms**）を ClusterId dimension で観測可能と確証。
+
+**Lambda 接続層（#3426）**: cold start Init = DSQL 構成 3315ms vs dynamodb 構成 3073ms（**+242ms = IAM token + TLS + probe 2 クエリ**）、warm 36ms。connector（AuroraDSQLPool singleton）+ drizzle は app_user role（dsql:DbConnect + AWS IAM GRANT 紐付け、#3646）で実運用動作を確認。
+
+**残実測**: #3426 AC1（60 分 token 期限跨ぎの warm 継続 — DSQL 構成の持続観測窓で実施）/ 一括 import チャンク実装（#3427 系）。
 
 ---
 

--- a/tests/integration/db/dsql-staging-concurrency.test.ts
+++ b/tests/integration/db/dsql-staging-concurrency.test.ts
@@ -1,0 +1,204 @@
+// tests/integration/db/dsql-staging-concurrency.test.ts
+// #3545 / #3550 / EPIC #3424 — **実 Aurora DSQL cluster** での真の並行アクセス検証。
+//
+// PGlite (単一接続 WASM) では構造的に再現できない「複数接続からの同時 txn → commit 時
+// OCC 40001 → withOccRetry → txn 内 re-read」の実挙動を、staging cluster への複数接続
+// pool で実測する (cutover 前必須、#3545/#3550 の中核主張の実証):
+//
+//   [V1] OCC 実発生: retry なし runner で同一 child へ N 並行 → SQLSTATE 40001 が実際に
+//        発生する (共有行 children.total_point / mastery / statuses の write-write を
+//        DSQL adjudicator が commit 時検出する、という設計前提そのものの存在証明)
+//   [V2] 冪等 guard (dailyLimit=1): retry 込み runner で N 並行 → ok:true はちょうど 1 件、
+//        残りは ALREADY_RECORDED。point_ledger 1 行 / total_point 整合 (#3545 中核主張 =
+//        連打・HTTP 再送での二重付与防止)
+//   [V3] lost update なし (dailyLimit=0 無制限): N 並行全部 ok → mastery total_count = N /
+//        total_point = N×points / ledger N 行 (re-read→upsert が OCC で直列化される実証、
+//        #3550 ② core 整合)
+//
+// 実行方法 (CI では skip — DSQL_ENDPOINT 未設定のため。DbConnectAdmin 相当 credential 必要):
+//   DSQL_ENDPOINT=<id>.dsql.us-east-1.on.aws npx vitest run tests/integration/db/dsql-staging-concurrency.test.ts
+//
+// 検証データは専用 family uuid に隔離し afterAll で全削除する (staging を汚さない)。
+
+import { AuroraDSQLPool } from '@aws/aurora-dsql-node-postgres-connector';
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { isOccConflict } from '../../../src/lib/server/db/dsql/occ-retry';
+import {
+	type RecordActivityCoreInput,
+	recordActivityCore,
+} from '../../../src/lib/server/db/dsql/record-activity-core';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import type { TransactionRunner } from '../../../src/lib/server/db/interfaces/transaction.interface';
+
+const ENDPOINT = process.env.DSQL_ENDPOINT;
+const FAMILY = '00000000-0000-4000-8000-00000000c04c'; // 検証専用 family (afterAll で全削除)
+const PARALLEL = 8;
+const NOW = new Date().toISOString();
+const TODAY = NOW.slice(0, 10);
+
+type Db = ReturnType<typeof drizzle>;
+type Tx = Parameters<Parameters<Db['transaction']>[0]>[0];
+
+function coreInput(
+	childId: string,
+	activityId: string,
+	dailyLimit: number | null,
+): RecordActivityCoreInput {
+	return {
+		familyId: FAMILY,
+		childId,
+		activityId,
+		categoryId: 'undou',
+		basePoints: 10,
+		streakBonus: 0,
+		masteryBonus: 0,
+		streakDays: 1,
+		recordedDate: TODAY,
+		now: NOW,
+		dailyLimit,
+		description: 'staging 並行検証 (#3545)',
+		changeType: 'activity_record',
+		masteryLevelFor: (c) => Math.floor(c / 10) + 1,
+		statusLevelFor: (xp) => Math.floor(xp / 100) + 1,
+	};
+}
+
+describe.skipIf(!ENDPOINT)('実 DSQL staging 並行アクセス検証 (#3545/#3550、cutover 前必須)', () => {
+	let pool: AuroraDSQLPool;
+	let db: Db;
+
+	beforeAll(async () => {
+		pool = new AuroraDSQLPool({
+			host: ENDPOINT,
+			user: process.env.DSQL_MIGRATE_USER ?? 'admin',
+			database: 'postgres',
+			max: PARALLEL + 2, // 並行 txn は接続 1:1 (DSQL は 1 接続 1 txn)
+			connectionTimeoutMillis: 15_000,
+		});
+		db = drizzle(pool);
+	}, 60_000);
+
+	afterAll(async () => {
+		// 検証 family の全行を削除して staging を原状復帰する (family_id 隔離済み)
+		for (const table of [
+			'status_history',
+			'statuses',
+			'point_ledger',
+			'activity_mastery',
+			'activity_logs',
+			'children',
+		]) {
+			await db.execute(sql.raw(`DELETE FROM ${table} WHERE family_id = '${FAMILY}'`));
+		}
+		await pool.end();
+	}, 120_000);
+
+	async function seedChild(childId: string): Promise<void> {
+		// children は age 列を持たない (§11.1 compute-on-read)。他列は default で埋まる。
+		await db.execute(sql`
+			INSERT INTO children (family_id, child_id, nickname)
+			VALUES (${FAMILY}, ${childId}, ${'並行検証子'})
+		`);
+	}
+
+	it('[V1] OCC 実発生: retry なしで同一 child へ 8 並行 → SQLSTATE 40001 を実測', async () => {
+		const childId = crypto.randomUUID();
+		const activityId = crypto.randomUUID();
+		await seedChild(childId);
+
+		// retry を挟まない素の runner (40001 を生で観測する)
+		const rawRunner: TransactionRunner<Tx> = {
+			runInTransaction: (work) => db.transaction((tx) => work(tx)),
+		};
+		const results = await Promise.allSettled(
+			Array.from({ length: PARALLEL }, () =>
+				recordActivityCore(rawRunner, coreInput(childId, activityId, 0)),
+			),
+		);
+		const occErrors = results.filter(
+			(r) => r.status === 'rejected' && isOccConflict(r.reason),
+		).length;
+		const otherErrors = results.filter(
+			(r) => r.status === 'rejected' && !isOccConflict((r as PromiseRejectedResult).reason),
+		);
+		console.log(
+			`[V1] fulfilled=${results.length - occErrors - otherErrors.length} occ40001=${occErrors} other=${otherErrors.length}`,
+		);
+		expect(
+			otherErrors,
+			JSON.stringify(otherErrors.map((r) => String((r as PromiseRejectedResult).reason))),
+		).toEqual([]);
+		// 共有行 write-write の同時 commit で 40001 が実際に出る (spike#8 実測の staging 再確認)。
+		expect(occErrors).toBeGreaterThan(0);
+	}, 120_000);
+
+	it('[V2] 冪等 guard: retry 込み 8 並行 (dailyLimit=1) → exactly-once (二重付与なし)', async () => {
+		const childId = crypto.randomUUID();
+		const activityId = crypto.randomUUID();
+		await seedChild(childId);
+
+		// 8 並行の敗者は最悪 7 回 40001 を踏み得るため attempts を引き上げる (本番既定 3 は
+		// 家庭スケール 2-3 並行前提、§8。ここでは mechanism の検証が目的)
+		const runner = createDsqlTransactionRunner<Tx>(db, { maxAttempts: 12, baseDelayMs: 20 });
+		const results = await Promise.all(
+			Array.from({ length: PARALLEL }, () =>
+				recordActivityCore(runner, coreInput(childId, activityId, null)),
+			),
+		);
+		const okCount = results.filter((r) => r.ok).length;
+		const alreadyCount = results.filter((r) => !r.ok && r.reason === 'ALREADY_RECORDED').length;
+		console.log(`[V2] ok=${okCount} already=${alreadyCount}`);
+		expect(okCount).toBe(1);
+		expect(alreadyCount).toBe(PARALLEL - 1);
+
+		const ledger = await db.execute(
+			sql`SELECT count(*) AS c, coalesce(sum(amount),0) AS s FROM point_ledger WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+		);
+		expect(Number((ledger.rows[0] as { c: unknown }).c)).toBe(1);
+		const child = await db.execute(
+			sql`SELECT total_point FROM children WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+		);
+		// fitness#14 整合: total_point == SUM(ledger) == 10 (1 回分のみ)
+		expect(Number((child.rows[0] as { total_point: unknown }).total_point)).toBe(10);
+		expect(Number((ledger.rows[0] as { s: unknown }).s)).toBe(10);
+	}, 180_000);
+
+	it('[V3] lost update なし: retry 込み 8 並行 (dailyLimit=0 無制限) → 全 commit + 完全整合', async () => {
+		const childId = crypto.randomUUID();
+		const activityId = crypto.randomUUID();
+		await seedChild(childId);
+
+		const runner = createDsqlTransactionRunner<Tx>(db, { maxAttempts: 12, baseDelayMs: 20 });
+		const results = await Promise.all(
+			Array.from({ length: PARALLEL }, () =>
+				recordActivityCore(runner, coreInput(childId, activityId, 0)),
+			),
+		);
+		expect(results.filter((r) => r.ok).length).toBe(PARALLEL);
+
+		// mastery re-read→upsert の lost update が OCC で防がれる = total_count が正確に N
+		const mastery = await db.execute(
+			sql`SELECT total_count FROM activity_mastery WHERE family_id = ${FAMILY} AND child_id = ${childId} AND activity_id = ${activityId}`,
+		);
+		expect(Number((mastery.rows[0] as { total_count: unknown }).total_count)).toBe(PARALLEL);
+
+		const ledger = await db.execute(
+			sql`SELECT count(*) AS c, coalesce(sum(amount),0) AS s FROM point_ledger WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+		);
+		expect(Number((ledger.rows[0] as { c: unknown }).c)).toBe(PARALLEL);
+		const child = await db.execute(
+			sql`SELECT total_point FROM children WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+		);
+		// fitness#14 整合: total_point == SUM(ledger) == N×10
+		expect(Number((child.rows[0] as { total_point: unknown }).total_point)).toBe(PARALLEL * 10);
+		expect(Number((ledger.rows[0] as { s: unknown }).s)).toBe(PARALLEL * 10);
+
+		// statuses の XP 累積も lost update なし
+		const status = await db.execute(
+			sql`SELECT total_xp FROM statuses WHERE family_id = ${FAMILY} AND child_id = ${childId} AND category_id = 'undou'`,
+		);
+		expect(Number((status.rows[0] as { total_xp: unknown }).total_xp)).toBe(PARALLEL * 10);
+	}, 180_000);
+});

--- a/tests/integration/db/dsql-staging-concurrency.test.ts
+++ b/tests/integration/db/dsql-staging-concurrency.test.ts
@@ -92,7 +92,7 @@ describe.skipIf(!ENDPOINT)('実 DSQL staging 並行アクセス検証 (#3545/#35
 		]) {
 			await db.execute(sql.raw(`DELETE FROM ${table} WHERE family_id = '${FAMILY}'`));
 		}
-		await pool.end();
+		await (pool as unknown as { end(): Promise<void> }).end(); // 型定義に end 無し (dsql-migrate.ts と同キャスト)
 	}, 120_000);
 
 	async function seedChild(childId: string): Promise<void> {

--- a/tests/integration/db/dsql-staging-concurrency.test.ts
+++ b/tests/integration/db/dsql-staging-concurrency.test.ts
@@ -65,6 +65,8 @@ function coreInput(
 	};
 }
 
+// #3545 恒久 opt-in skip: 実 DSQL cluster (DSQL_ENDPOINT + AWS creds) が必要な staging 検証のため
+// CI では常時 skip する設計 (deadline なし)。owner: @Takenori-Kusaka。実行方法は本ファイル冒頭コメント。
 describe.skipIf(!ENDPOINT)('実 DSQL staging 並行アクセス検証 (#3545/#3550、cutover 前必須)', () => {
 	let pool: AuroraDSQLPool;
 	let db: Db;


### PR DESCRIPTION
## 顧客価値・目的

「子供のポイント二重付与」(顧客信頼に直結する重大リスク、#3545) を防ぐ冪等 guard の中核主張を、**実 Aurora DSQL cluster での真の並行アクセス**で実証した検証を恒久 artifact 化する。PGlite (単一接続 WASM) では構造的に検証不能だった「複数接続同時 txn → OCC 40001 → retry → re-read」の実挙動を、cutover 前後で何度でも再実行できる形にする。

## 関連 Issue

closes #3545 / #3425 (AC4 = research doc 追記を本 PR で消化。AC1-AC3 は Issue コメントに実測記録済み)。related: #3550 (② 並行検証を本 test がカバー、① service 層アラート結線は cutover PR scope で Issue 継続)。

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| #3545 AC (staging 実 DSQL への統合テストで同時多重実行 → 二重付与なしを確認) | `tests/integration/db/dsql-staging-concurrency.test.ts` を staging cluster に対し実行 (2026-07-11): [V1] retry なし 8 並行 → **SQLSTATE 40001 = 7/8 実発生** / [V2] withOccRetry 込み dailyLimit=1 の 8 並行 → **ok=1 / ALREADY_RECORDED=7、point_ledger 1 行、total_point=10=SUM** / [V3] 無制限 8 並行 → **8/8 commit、mastery=8、total_point=80=SUM、XP=80 (lost update ゼロ)** | PASS (3/3) | #3545 コメントの実測表 + 実行ログ |
| CI で偽 green にならない | `describe.skipIf(!DSQL_ENDPOINT)` — CI では skip (3 tests skipped を本 worktree で確認)。実行方法は test ヘッダーに明記 | PASS | vitest log |
| staging を汚さない | 検証データは専用 family uuid に隔離し afterAll で 6 表 DELETE (原状復帰) | PASS | code |
| #3425 AC4 (research doc 追記) | `docs/research/2026-06-28-aurora-dsql-adoption.md` §11.2 に staging 実測 (並行 / DPU / CloudWatch / cold start) を追記 | PASS | diff |

## 変更タイプ

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] テスト (検証 artifact) + research doc

## 影響範囲・変更コンポーネント

- `tests/integration/db/dsql-staging-concurrency.test.ts` (新規、CI では skip のため既存 CI 挙動不変)
- `docs/research/2026-06-28-aurora-dsql-adoption.md` §11.2 (追記のみ)
- `.cspell.json` (millis 追加 — #3647 と同一変更のため merge 順不問)

### 検証コマンド証跡

- `DSQL_ENDPOINT=evt5hizwkk5puaw6eqfpvp4phu.dsql.us-east-1.on.aws npx vitest run tests/integration/db/dsql-staging-concurrency.test.ts` (env creds 経由、2026-07-11 実 staging cluster) → `Tests  3 passed (3)`。実測ログ: [V1] fulfilled=1 occ40001=7 other=0 / [V2] ok=1 already=7 / [V3] 8/8 commit・mastery=8・total_point=80
- `npx vitest run tests/integration/db/dsql-staging-concurrency.test.ts` (DSQL_ENDPOINT なし = CI 相当) → `3 skipped` (偽 green を生まない)
- `npx cspell --no-progress tests/integration/db/dsql-staging-concurrency.test.ts docs/research/2026-06-28-aurora-dsql-adoption.md` → 対象追記行 Issues 0 (millis は辞書追加済)
- `npx biome check --error-on-warnings tests/integration/db/dsql-staging-concurrency.test.ts` → error 0

## テスト & 安全装置セルフチェック

- [x] 実 staging cluster で 3 tests PASS を実確認 (2026-07-11、env creds 経由)
- [x] CI (DSQL_ENDPOINT なし) では skip を確認 — 偽 green /偽 red いずれも生まない
- [x] 検証データの afterAll 全削除 (staging 原状復帰)

## スクリーンショット / ビジュアルデモ

N/A — test + docs のみ。

## コード品質セルフレビュー (#1481)

- 実行に AWS credential が必要な点は test ヘッダーに明記 (vitest からは env creds 形式が必要 — SSO profile の ini parser が vitest 環境で不整合)
- maxAttempts=12 は 8 並行の人工負荷用で、本番既定 3 (§8 家庭スケール前提) の変更ではない (コメントで明示)

## 横展開・影響波及チェック

- 同種の staging 実測 (cutover 直前の受入検証) は本 test の再実行で担保可能 (使い捨て script でなく恒久 test、#1442)
- #3550 ① (fitness#11 の service 層アラート結線) は cutover PR scope のため Issue を open 維持

## レビュー依頼事項・破壊的変更

破壊的変更なし。レビュー観点: skipIf 設計 (CI 空洞化でなく「実行環境が無い検証の明示 opt-in」として妥当か)。

## 配布済み env / secret (ADR-0006)

N/A — DSQL_ENDPOINT は実行者のローカル env (CI 配布不要)。

## Ready for Review チェックリスト

- [x] test + docs + 実測消化が 1 PR で完結
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
