### PR TITLE
docs: #3560 06-UI設計書 §10.6 の stale /admin/license を /admin/subscription に更新

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -446,7 +446,7 @@ setup 完了後の子供画面初回遷移時に 1 回だけ表示する dialog 
 | `/admin/settings/notifications` | notification (1 section、軽量) | 行 929 |
 | `/admin/settings/data` | data / cloud / clear (Danger Zone) | 行 1188 / 1473 / 1695 |
 | `/admin/settings/support` | founderInquiry / feedback / appInfo | 行 1776 / 1792 / 1885 |
-| `/admin/license` | プラン・課金 (deep link、settings 配下に新設しない) | — |
+| `/admin/subscription` | プラン・課金 (deep link、settings 配下に新設しない) | — |
 
 #### サブナビ仕様 (`/admin/settings/+layout.svelte`)
 
@@ -471,7 +471,7 @@ setup 完了後の子供画面初回遷移時に 1 回だけ表示する dialog 
 
 - `auto-fill, minmax(280px, 1fr)` で responsive grid
 - 各カードは `🔑` `🎯` `🔔` `💾` `💬` `💎` の icon + title + 1 行 desc
-- plan deep link カード (`/admin/license`) は `↗` マーク付き (外部っぽさを明示)
+- plan deep link カード (`/admin/subscription`) は `↗` マーク付き (外部っぽさを明示)
 - grace バナー (cancellation grace period) は hub に **1 回だけ** 表示 (child route には出さない)
 
 #### setup hard-code 代替実装 (#2322 / rule-preset 集約代替案 A)
@@ -915,7 +915,7 @@ admin リソース管理 3 画面（活動 / チェックリスト / ごほう�
 - `src/routes/(parent)/admin/billing/cancel/+page.server.ts` — form action
 - `src/routes/(parent)/admin/billing/cancel/thanks/+page.svelte` — 送信完了
 
-**注**: `4.20 ChurnPreventionModal` (`/admin/license`) とは別フロー。Anti-engagement の方針上、両者を併用しない（PO 判断で将来的にいずれかに統合可能）。
+**注**: `4.20 ChurnPreventionModal` (`/admin/subscription`) とは別フロー。Anti-engagement の方針上、両者を併用しない（PO 判断で将来的にいずれかに統合可能）。
 
 ---
 
@@ -1539,11 +1539,11 @@ P1（画面内に個別アップセル CTA を置かない）は **quota / 上�
 1. TrialBanner（not-started）→ 「7日間 無料で試す」 → `?/startTrial` action → トライアル開始 → 即座に有料機能解放（ただし license plan は free のまま）
 2. TrialBanner / PlanStatusCard / FeatureGate popover のプラン画面リンク（§10.2.1）→ プラン画面（`/admin/subscription`）→ Stripe Checkout → webhook で license plan 更新 → 次回 admin ロード時に PremiumWelcome 表示（EPIC #3533 で FeatureGate 個別 CTA → popover リンク一本化）
 
-**ダウングレード**: 詳細フローと超過リソース処理の確認画面は #738 / #754 で別途設計（現状は `/admin/license` から Stripe Customer Portal を経由）。
+**ダウングレード**: 詳細フローと超過リソース処理の確認画面は #738 / #754 で別途設計（現状は `/admin/subscription` から Stripe Customer Portal を経由）。
 
 #### 10.6.1 NUC vs SaaS 実行モード分岐 (EPIC #2327 / ADR-0051)
 
-`/admin/license` は **`data.runtimeMode === 'nuc-prod'`** で 2 panel に分岐する (薄ラッパー実装):
+`/admin/subscription` は **`data.runtimeMode === 'nuc-prod'`** で 2 panel に分岐する (薄ラッパー実装):
 
 | runtimeMode | 表示 panel | セクション数 | 主要訴求 |
 |---|---|---|---|
@@ -1661,8 +1661,8 @@ AdminHome.svelte
 サインアップ画面 (`src/routes/auth/signup/+page.svelte`) の入力項目は **メールアドレス / パスワード / パスワード確認 + 3 種の同意チェック（利用規約 / プライバシーポリシー / 米国域外移転 #1638）** のみ。Google OAuth でのサインアップも併設する。メール登録時は確認コード入力 step（`SIGNUP_CODE_EXPIRY_MINUTES`）を経て登録が完了する。
 
 - **ライセンスキー入力経路は存在しない（#2810 Phase 7 PR-L1）**: サインアップ画面に「ライセンスキーをお持ちの方」トグル / `GQ-XXXX-XXXX-XXXX` 形式のキー入力欄 / 「一回限り使用に同意」チェック / 確認ダイアログは設けない。サインアップ時点でのプラン昇格手段は存在しない。
-- **有料機能の認可 SSOT は Stripe サブスクリプション**: 有料プランの entitlement は、サインアップ後に `/admin/license` から Stripe Checkout を経由し、**Stripe Webhook が `tenant.status = ACTIVE` + `stripeSubscriptionId` を設定する**ことで確定する（サインアップ時のキー入力ではない）。判定経路の詳細は [billing-redesign/phase1-license-key-removal-final-requirements.md](billing-redesign/phase1-license-key-removal-final-requirements.md)（license key 全廃 → Stripe Subscription 一本化 SSOT）を参照。
-- **NUC セルフホスト版は対象外**: NUC は「全機能無制限・課金なし」（`NUC_EDITION_TERMS`）の信頼ベース運用で、ライセンスキー判定を行わない。SaaS サインアップ画面の入力経路撤去は、NUC のライセンスキー仕様（`/admin/license` の `NucLicensePanel` / `site/help/license-key.html`）には影響しない。
+- **有料機能の認可 SSOT は Stripe サブスクリプション**: 有料プランの entitlement は、サインアップ後に `/admin/subscription` から Stripe Checkout を経由し、**Stripe Webhook が `tenant.status = ACTIVE` + `stripeSubscriptionId` を設定する**ことで確定する（サインアップ時のキー入力ではない）。判定経路の詳細は [billing-redesign/phase1-license-key-removal-final-requirements.md](billing-redesign/phase1-license-key-removal-final-requirements.md)（license key 全廃 → Stripe Subscription 一本化 SSOT）を参照。
+- **NUC セルフホスト版は対象外**: NUC は「全機能無制限・課金なし」（`NUC_EDITION_TERMS`）の信頼ベース運用で、ライセンスキー判定を行わない。SaaS サインアップ画面の入力経路撤去は、NUC のライセンスキー仕様（`/admin/subscription` の `NucLicensePanel` / `site/help/license-key.html`）には影響しない。
 
 ### セットアップ（初回導入フロー）
 
@@ -1822,7 +1822,7 @@ PO 判断 #4=β に基づき情報密度バランスと Pre-PMF コスト最小�
 | (廃止) アナリティクス | `/admin/analytics` | **#2284**: 親管理画面には可視化を置かない。直接アクセスは SvelteKit 既定 404 (legacy-url-map エントリなし)。**運用者向け機能は `/ops/analytics` へ集約**: Activation Funnel / Cancellation Reasons / Retention Cohort (月単位) は `/ops/analytics`、Sean Ellis は `/ops/pmf-survey` で提供。詳細: `13-AWSサーバレスアーキテクチャ設計書.md §7.2`。 |
 | パック管理 | `/admin/packs` | 活動パック管理 |
 | メンバー管理 | `/admin/members` | 家族メンバー招待・管理 |
-| ライセンス | `/admin/license` | プラン・課金管理 |
+| プラン | `/admin/subscription` | プラン・課金管理（ナビラベルは `NAV_ITEM_LABELS.license` = 「プラン」、旧 `/admin/license` は `legacy-url-map.ts` で 308 redirect） |
 | 設定 | `/admin/settings` | アプリ設定。データインポート／エクスポート・クラウドエクスポート（PIN 共有）・クラウドインポート（PIN 入力）も本画面から実行。エクスポートは standard 以上（`canExport`）/ 詳細は 07-API設計書 §/api/v1/export。**#backup-terms**: UI 文言は内部フォーマット（JSON / ZIP）を露出せず `BACKUP_TERMS`（atom、terms.ts）で「バックアップデータ / バックアップファイル」に統一する（DESIGN.md §6）。画像・音声を含めるか（内部的に ZIP か JSON か）は「画像・音声ファイルも含める」チェックの機能差として表現し、形式名は出さない。LP/FAQ も同 atom 参照で統一し、CSV 非実装（家族 export は JSON/ZIP のみ）の不正確訴求を是正済（ADR-0013）。**#773**: free プランはデータ管理カードとクラウド共有カードの両方でアップセル表示＋ボタン無効化を行い、`PremiumBadge` と `/pricing` への CTA を表示する（バックエンド 403 を踏ませない）。paid プランでは `保管枠 {使用数} / {maxCloudExports}` のスロットカウンタを表示。**#3095 (AC1/AC2、partial-restore 可視化)**: import の done step は結果に `errors[]` があるとき緑「インポート完了」ではなく `importHadErrors` 派生で「⚠️ 一部のデータを復元できませんでした」警告（`role="alert"`、testid `data-import-partial-warning`）を表示する。置換（replace）モードは `clearAllFamilyData` で全削除後に逐次復元するため、途中失敗で「旧データ削除済 + 新データ部分復元」の半損が成功扱いで残るのを防ぐ目的で「既存データはクリア済みのため復元できなかった項目は失われています」と明示する（NN/G #1 visibility of system status、silent-skip 禁止 #1254）。あわせて `import-service.ts` の `ImportResult` が返す静的ファイル / チェックリスト履歴 / ごほうびの restored / skipped 件数と errors / warnings 内訳を結果（testid `data-import-result` / `data-import-errors`）に surface する。文言は `SETTINGS_LABELS`（labels.ts SSOT）。 |
 | ボーナスルール | `/admin/settings/rules` | マーケットプレイス取込済の bonus rule-preset を管理。bonus preset 5 種 (streak-bonus / early-bird / weekend-special / category-challenge / self-study-reward) の ON/OFF 切替 + 削除（`settings.rule_preset_bonus_overrides` JSON）。exchange は `/admin/rewards` 側で管理（リンク表示のみ）。penalty / special は ADR-0012 §6 細則により非表示。`bonus-hook-service.ts` が活動記録時に enabled な 5 種を評価しポイント計算に反映する。weekend-special は土日活動ポイント 2 倍、self-study-reward は自主学習 +10pt / 週次マスター +30pt を適用する。`?import=<presetId>` query で marketplace 詳細から遷移すると即取込 + toast 表示（rule bonus は family scope のため child 選択不要）。empty state に `/marketplace?type=rule-preset` への secondary link を配置（DESIGN.md §10 bulk import bridge ルール整合）。family-wide 一覧のみで per-child タブを持たない（ADR-0055 family master scope）。demo 環境では write-guard が no-op を返し「デモではお試し用です」toast を表示（`ADMIN_RULES_PAGE_LABELS.importDemo`）。回帰ガードは `tests/e2e/demo-lambda/rule-preset-import-demo.spec.ts`。**#3339**: 本ページに「ごほうび交換のしかた」トグル（settings KVS `reward_auto_approve`、既定 OFF = 保護者承認必須 ⇄ ON = 承認なしで即時交換）を追加（`?/setRewardAutoApprove` action）。子供側の即時交換挙動 + TOCTOU 二重減算防御は §15.3.6 / §15.4.4 を参照。 |
 

--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1232,9 +1232,9 @@ Stripe Checkout セッションを作成し、リダイレクト URL を返す�
 - **認可**: `requireRole(locals, ['owner', 'parent'])`（child → 403）
 - **リクエスト**: FormData `planId: 'monthly' | 'yearly' | 'family-monthly' | 'family-yearly'`
 - **成功レスポンス**: Stripe Checkout URL へリダイレクト
-- **`success_url`**: `${origin}/admin/license?session_id={CHECKOUT_SESSION_ID}`
+- **`success_url`**: `${origin}/admin/subscription?session_id={CHECKOUT_SESSION_ID}`
 - **`cancel_url`**: `${origin}/pricing`
-- **完了時の処理**: webhook `checkout.session.completed` → `handleCheckoutCompleted` でテナント plan を更新し、ライセンスキーを発行
+- **完了時の処理**: webhook `checkout.session.completed` → `handleCheckoutCompleted` でテナント plan を更新する
 
 #### POST /api/stripe/portal
 
@@ -1245,7 +1245,7 @@ Stripe カスタマーポータルの URL を作成し、ユーザーをリダ�
   - `pinConfigured = true` のテナント: PIN（4-6 桁）入力 → `verifyPin`
   - `pinConfigured = false` のテナント: 確認フレーズ「`プランを変更します`」入力
   - 失敗時のエラーコード: `PIN_REQUIRED` (401) / `INVALID_PIN` (401) / `LOCKED_OUT` (423) / `CONFIRM_PHRASE_REQUIRED` (401)
-- **`return_url`**: `${origin}/admin/license`
+- **`return_url`**: `${origin}/admin/subscription`
 - **Customer Portal で実行可能な操作（Stripe ダッシュボード設定で有効化済）**:
   - プラン変更（standard ↔ family、月額 ↔ 年額）
   - 解約（次回更新日まで利用可能）
@@ -1255,7 +1255,7 @@ Stripe カスタマーポータルの URL を作成し、ユーザーをリダ�
 
 ##### 月額 ↔ 年額切替と proration ポリシー (#786)
 
-- **切替動線**: `/admin/license` → 「プラン管理ポータル」ボタン → Stripe Customer Portal → プラン変更 → 月額/年額の Price ID を選択
+- **切替動線**: `/admin/subscription` → 「プラン管理ポータル」ボタン → Stripe Customer Portal → プラン変更 → 月額/年額の Price ID を選択
 - **Stripe 設定**: `proration_behavior = 'create_prorations'`（Stripe デフォルト）
   - **アップグレード（月額 → 年額、standard → family）**:
     - 即時切替。残り期間の月額分を日割り返金 → 新プラン分を日割り課金 → 差額を次回請求にマージ
@@ -2313,7 +2313,7 @@ export interface PlanLimitError {
   message: string;                              // 人間可読（日本語）
   currentTier: 'free' | 'standard' | 'family';  // リクエスト時点のテナントプラン
   requiredTier: 'standard' | 'family';          // 許可される最小プラン
-  upgradeUrl: '/admin/license';                 // アップグレード導線。固定
+  upgradeUrl: '/admin/subscription';            // アップグレード導線。固定
 }
 ```
 
@@ -2326,7 +2326,7 @@ export interface PlanLimitError {
     "message": "AI 活動提案はスタンダードプラン以上でご利用いただけます",
     "currentTier": "free",
     "requiredTier": "standard",
-    "upgradeUrl": "/admin/license"
+    "upgradeUrl": "/admin/subscription"
   }
 }
 ```


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者・AI エージェント（設計書参照者）→ 間接的に全ユーザー

**解決する課題**: `docs/design/06-UI設計書.md` §10.6 ほかに #2818 で rename 済みの旧 route `/admin/license` が残存し、実装 (`/admin/subscription` canonical) と設計書が内部矛盾していた。将来実装者が旧 URL を新規実装に持ち込む誤誘導リスク。

**期待される効果**: 設計書 = SSOT (ADR-0001) の整合が回復し、プラン・課金画面に関する将来実装の誤誘導を防止する。

## 関連 Issue

closes #3560

- PR #3559 / #3542 / #2818（rename 元）/ EPIC #3533

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 06-UI設計書.md の stale route `/admin/license` を canonical `/admin/subscription` に更新（8 箇所） | `grep -n "/admin/license" docs/design/06-UI設計書.md` | PASS — 残存 1 件のみ（L1825、legacy-url-map 308 redirect の経緯注記として意図的に保持） |
| AC2 | プロダクト名としての「ライセンス」(NucLicensePanel / NUC ライセンスキー仕様) は文脈維持 | 差分目視 — `NucLicensePanel` / `site/help/license-key.html` 参照は非変更 | PASS |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — docs/design/06-UI設計書.md のみ（コード変更ゼロ）

**影響を受ける画面・機能**: なし（docs-only、アプリ挙動への影響ゼロ）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: N/A（docs-only）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（docs-only、UI 変更を含まない）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（docs-only）
- [x] **DRY**: `grep -rn "/admin/license" docs/design/` で他設計書の残存も確認（06-UI設計書.md のみが対象、他は経緯記述で正当）
- [x] **YAGNI**: 現要件に不要な抽象化なし
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 設計書同期 (ADR-0001) — 本 PR 自体が設計書同期
- [x] N/A — 並行実装の影響範囲外（docs-only）

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
L1825 のナビ一覧表は route 更新に加え、実装実態（`NAV_ITEM_LABELS.license` = 「プラン」、旧 URL は legacy-url-map 308 redirect）を注記した。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（Ready 化直前に実行、証跡はコメント参照）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし（docs-only）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
