### PR TITLE
fix(nuc): #3653 cutover import に verbatim mode 追加 (merge-dedup による正当データ欠落の根治)

### DIFF
--- a/scripts/nuc-pglite-cutover.ts
+++ b/scripts/nuc-pglite-cutover.ts
@@ -117,7 +117,9 @@ async function runImport(opts: Record<string, string>): Promise<void> {
 	const { importFamilyData } = await import('../src/lib/server/services/import-service');
 	const verify = await import('./lib/nuc-cutover-verify');
 
-	const result = await importFamilyData(data, LOCAL_TENANT_UUID);
+	// #3653: cutover は fresh DB への完全移行のため verbatim (dedup bypass)。merge semantics だと
+	// 実本番に存在する同 child 同 title 行等が skip され件数突合で abort する (cycle 3 実検出)。
+	const result = await importFamilyData(data, LOCAL_TENANT_UUID, undefined, { mode: 'verbatim' });
 	if (result.errors.length > 0) {
 		console.error(`[nuc-cutover] import errors (${result.errors.length} 件):`);
 		for (const e of result.errors) console.error(`  - ${e}`);

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -1134,6 +1134,7 @@ async function importStatusesData(
 /**
  * 活動ログを import (#1254 G2: pre-fetch で (activityId, recordedAt) セット構築 → 事前スキップ)
  */
+// biome-ignore lint/complexity/useMaxParams: import ヘルパ群の既存引数列 + mode (#3653)。オブジェクト引数化は import 系一括 refactor (別 Issue) で扱う
 async function importActivityLogsData(
 	data: ExportData,
 	childIdMap: Map<string, ChildId>,
@@ -1346,6 +1347,7 @@ async function loadChildChecklistState(
 }
 
 /** 1 件の checklist template を import (重複スキップ / 新規作成) し、exportId を id に登録する。 */
+// biome-ignore lint/complexity/useMaxParams: import ヘルパ群の既存引数列 + mode (#3653)。オブジェクト引数化は import 系一括 refactor (別 Issue) で扱う
 async function importOneChecklistTemplate(
 	tpl: ExportData['data']['checklistTemplates'][number],
 	childId: ChildId,

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -260,6 +260,22 @@ export async function previewImport(data: ExportData, tenantId: string): Promise
 }
 
 /**
+ * import の重複解決 semantics (#3653)。
+ *
+ * - `merge` (既定、現行挙動): 既存 DB / 同一 import 内の同名・同 preset・同時刻行を dedup skip する。
+ *   バックアップの再取込・marketplace 二重取込の防止が目的 (merge import)。
+ * - `verbatim`: dedup を bypass し全行を復元する。cutover (fresh DB への完全移行、#3620) 用 —
+ *   実本番 DB には同 child 同 title の specialRewards 等が正当に存在し (NUC staging cycle 3 で
+ *   件数突合が export=9 → imported=2 の欠落を実検出)、merge semantics では移行にならない。
+ *   childRef / FK 解決不能・allowlist・path 検証などの整合性 skip は mode に関わらず維持する。
+ */
+export type ImportMode = 'merge' | 'verbatim';
+
+export interface ImportOptions {
+	mode?: ImportMode;
+}
+
+/**
  * 家族データをインポート (#1254: silent try-catch を pre-fetch 方式に統一)
  *
  * 処理順: 活動マスタ → 子供作成 → ステータス → 活動ログ → ポイント台帳 → ログインボーナス
@@ -268,12 +284,15 @@ export async function previewImport(data: ExportData, tenantId: string): Promise
  *
  * @param staticFiles #3077: ZIP 同梱の静的ファイル (相対パス → bytes)。
  *   JSON のみインポート時は undefined (後方互換)。
+ * @param options #3653: mode='verbatim' で dedup を bypass (cutover 用)。既定 merge = 現行不変。
  */
 export async function importFamilyData(
 	data: ExportData,
 	tenantId: string,
 	staticFiles?: Record<string, Uint8Array>,
+	options?: ImportOptions,
 ): Promise<ImportResult> {
+	const mode: ImportMode = options?.mode ?? 'merge';
 	// #3326 系: lazy マイグレーション。旧 version の backup を現 shape に正規化してから取り込む。
 	// checksum 検証は呼び出し側 (route) で本処理の前に済んでいる (version 書換は checksum 後でなければ mismatch する)。
 	data = migrateExportData(
@@ -301,13 +320,19 @@ export async function importFamilyData(
 	const activityLookupByChild = await buildActivityLookupByChild(childIdMap, tenantId);
 
 	await importStatusesData(data, childIdMap, tenantId, result);
-	await importActivityLogsData(data, childIdMap, activityLookupByChild, tenantId, result);
+	await importActivityLogsData(data, childIdMap, activityLookupByChild, tenantId, result, mode);
 	// #3329: per-child 活動設定 (ピン留め)。activityName を取込先 childActivity に再解決して復元。
 	// 活動 lookup (name→新 id) が必要なので buildActivityLookupByChild の後に実行する。
 	await importActivityPrefsData(data, childIdMap, activityLookupByChild, tenantId, result);
 	await importPointLedgerData(data, childIdMap, tenantId, result);
 	await importLoginBonusesData(data, childIdMap, tenantId, result);
-	const templateIdMap = await importChecklistTemplatesData(data, childIdMap, tenantId, result);
+	const templateIdMap = await importChecklistTemplatesData(
+		data,
+		childIdMap,
+		tenantId,
+		result,
+		mode,
+	);
 	await importChecklistLogsData(data, childIdMap, templateIdMap, tenantId, result);
 	// #3329: チェックリスト日次 override を createdAt 保全で復元。childIdMap のみ必要。
 	await importChecklistOverridesData(data, childIdMap, tenantId, result);
@@ -315,7 +340,7 @@ export async function importFamilyData(
 	await importRestDaysData(data, childIdMap, tenantId, result);
 	// #3329: 子のカスタム音声 DB 行を復元 (filePath/publicUrl を新 tenant+childId へ remap)。childIdMap のみ必要。
 	await importChildVoicesData(data, childIdMap, tenantId, result);
-	await importSpecialRewards(data, childIdMap, tenantId, result);
+	await importSpecialRewards(data, childIdMap, tenantId, result, mode);
 	// #3329: ごほうび交換/購入履歴。reward を先に取込済 (FK rewardRef → rewardId を再解決) なので
 	// importSpecialRewards の後に実行する。
 	await importRewardRedemptionsData(data, childIdMap, tenantId, result);
@@ -1115,6 +1140,7 @@ async function importActivityLogsData(
 	activityLookupByChild: Map<ChildId, Map<string, { id: ActivityId; name: string }>>,
 	tenantId: string,
 	result: ImportResult,
+	mode: ImportMode = 'merge',
 ): Promise<void> {
 	const existingLogKeysByChild = new Map<ChildId, Set<string>>();
 	// #3327: 「見つからない」warning の dedup は (childId, name) で行う。name のみだと
@@ -1142,7 +1168,9 @@ async function importActivityLogsData(
 
 		const existingKeys = await getOrFetchActivityLogKeys(childId, tenantId, existingLogKeysByChild);
 		const key = `${log.activityName}:${log.recordedAt}`;
-		if (existingKeys.has(key)) {
+		// #3653: (activityName, recordedAt) dedup は merge のみ。verbatim (cutover) では同時刻の
+		// 正当な複数記録 (DB 一意制約なし) を全行復元する。
+		if (mode === 'merge' && existingKeys.has(key)) {
 			result.activityLogsSkipped++;
 			result.skipped.constraint++;
 			continue;
@@ -1324,6 +1352,7 @@ async function importOneChecklistTemplate(
 	state: ChildChecklistState,
 	tenantId: string,
 	result: ImportResult,
+	mode: ImportMode = 'merge',
 ): Promise<void> {
 	// #3107: 解決先 templateId を round-trip キー (exportId) に登録する (スキップ時も既存 id を登録)。
 	const register = (templateId: string) => {
@@ -1332,13 +1361,15 @@ async function importOneChecklistTemplate(
 
 	// #3107: 同一 import data 内に同じ exportId が 2 度現れたら真の重複 → 既存解決先を再登録して skip。
 	//   (export-service は templateId ごとに distinct exportId を発番するため通常は発生しないが防御的に処理)
+	//   #3653: exportId は source template ごとに distinct 保証 = 真の重複判定のため verbatim でも維持。
 	if (tpl.exportId && state.exportIdToId.has(tpl.exportId)) {
 		result.skipped.name++;
 		return;
 	}
 
-	// #1254 G1: preset_duplicate → name_duplicate の順で判定
-	if (tpl.sourcePresetId && state.presetIds.has(tpl.sourcePresetId)) {
+	// #1254 G1: preset_duplicate → name_duplicate の順で判定 (merge のみ、#3653。verbatim = cutover は
+	// name/preset に DB 一意制約が無く、正当な同名 template を collapse させないため bypass)
+	if (mode === 'merge' && tpl.sourcePresetId && state.presetIds.has(tpl.sourcePresetId)) {
 		result.skipped.preset++;
 		const dupId = state.idByPreset.get(tpl.sourcePresetId);
 		if (dupId !== undefined) register(dupId);
@@ -1352,7 +1383,7 @@ async function importOneChecklistTemplate(
 	//   - exportId なし (旧 backup): 従来通り full names (preExisting + 当 import 作成分) で name-dedup
 	//     し後方互換を維持する。
 	const nameDedupSet = tpl.exportId ? state.preExistingNames : state.names;
-	if (nameDedupSet.has(tpl.name)) {
+	if (mode === 'merge' && nameDedupSet.has(tpl.name)) {
 		result.skipped.name++;
 		const dupId = state.idByName.get(tpl.name);
 		if (dupId !== undefined) register(dupId);
@@ -1414,6 +1445,7 @@ async function importChecklistTemplatesData(
 	childIdMap: Map<string, ChildId>,
 	tenantId: string,
 	result: ImportResult,
+	mode: ImportMode = 'merge',
 ): Promise<ChecklistTemplateIdMaps> {
 	const stateByChild = new Map<ChildId, ChildChecklistState>();
 
@@ -1426,7 +1458,7 @@ async function importChecklistTemplatesData(
 			state = await loadChildChecklistState(childId, tenantId);
 			stateByChild.set(childId, state);
 		}
-		await importOneChecklistTemplate(tpl, childId, state, tenantId, result);
+		await importOneChecklistTemplate(tpl, childId, state, tenantId, result, mode);
 	}
 
 	const byName = new Map<ChildId, Map<string, string>>();
@@ -1551,6 +1583,7 @@ async function importSpecialRewards(
 	childIdMap: Map<string, ChildId>,
 	tenantId: string,
 	result: ImportResult,
+	mode: ImportMode = 'merge',
 ): Promise<void> {
 	const { errors, warnings } = result;
 	const existingByChild = new Map<ChildId, { titles: Set<string>; presetIds: Set<string> }>();
@@ -1568,13 +1601,15 @@ async function importSpecialRewards(
 			existingByChild.set(childId, existing);
 		}
 
-		// #1254 G1: preset_duplicate → name_duplicate の順で判定
-		if (sr.sourcePresetId && existing.presetIds.has(sr.sourcePresetId)) {
+		// #1254 G1: preset_duplicate → name_duplicate の順で判定 (merge のみ、#3653)。
+		// verbatim (cutover) では同 child 同 title の正当な複数行 (title に DB 一意制約なし、
+		// NUC cycle 3 で export=9 → imported=2 の実欠落) を全行復元する。
+		if (mode === 'merge' && sr.sourcePresetId && existing.presetIds.has(sr.sourcePresetId)) {
 			result.specialRewardsSkipped++;
 			result.skipped.preset++;
 			continue;
 		}
-		if (existing.titles.has(sr.title)) {
+		if (mode === 'merge' && existing.titles.has(sr.title)) {
 			result.specialRewardsSkipped++;
 			result.skipped.name++;
 			continue;

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -922,3 +922,74 @@ describe('#3507 field-level ratchet — entity 内 field 取りこぼし class �
 		expect(restored?.sourcePresetId, 'sourcePresetId').toBe('preset-chk');
 	});
 });
+
+// ============================================================
+// #3653: cutover verbatim mode — merge-dedup が正当データを落とす実障害の再現
+// ============================================================
+// NUC staging PGlite cycle 3 (run 29150840787) で件数突合が検出した実障害の最小再現:
+// importFamilyData の merge-dedup (同 child 同 title は 2 件目以降 skip、L1597 の
+// existing.titles.add) が、cutover (fresh DB への完全移行) では実本番に存在する正当な
+// 同 title 複数行 (specialRewards export=9 → imported=2) を欠落させる。
+// verbatim mode は dedup を bypass し全行復元する。merge mode (既定) は現行挙動不変。
+describe('#3653 cutover verbatim mode (dedup bypass)', () => {
+	it('[verbatim] 同 child 同 title の specialRewards 複数行が全件復元される (cycle 3 実障害の最小再現)', async () => {
+		const child = await getRepos().child.insertChild({ nickname: 'ふたごA', age: 7 }, T);
+		// 実本番データに実在するパターン: 同 title のごほうびを points 違いで複数登録
+		for (const points of [50, 100, 150]) {
+			await insertSpecialReward(
+				{
+					childId: child.id,
+					title: 'アイス',
+					description: undefined,
+					points,
+					icon: undefined,
+					category: 'money',
+					sourcePresetId: null,
+				},
+				T,
+			);
+		}
+
+		const data = await exportFamilyData({ tenantId: T });
+		expect(data.data.specialRewards.length, 'export: 同 title 3 行').toBe(3);
+
+		await clearAllFamilyData(T);
+		const result = await importFamilyData(data, T, undefined, { mode: 'verbatim' });
+		expect(result.errors, 'import errors').toEqual([]);
+
+		const children = testDb.select().from(schema.children).all();
+		const cid = children[0]?.id as number;
+		expect(
+			(await findSpecialRewards(asChildId(cid), T)).length,
+			'verbatim: 同 title 3 行が全件復元 (merge-dedup で欠落しない)',
+		).toBe(3);
+	});
+
+	it('[merge 既定] 同 title は従来どおり dedup される (後方互換、バックアップ二重取込防止)', async () => {
+		const child = await getRepos().child.insertChild({ nickname: 'ふたごB', age: 9 }, T);
+		for (const points of [50, 100]) {
+			await insertSpecialReward(
+				{
+					childId: child.id,
+					title: 'ケーキ',
+					description: undefined,
+					points,
+					icon: undefined,
+					category: 'money',
+					sourcePresetId: null,
+				},
+				T,
+			);
+		}
+		const data = await exportFamilyData({ tenantId: T });
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T); // mode 省略 = merge (現行挙動)
+
+		const children = testDb.select().from(schema.children).all();
+		const cid = children[0]?.id as number;
+		expect(
+			(await findSpecialRewards(asChildId(cid), T)).length,
+			'merge: 同 title は 1 件に dedup (現行挙動の固定)',
+		).toBe(1);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

NUC cutover で子供のごほうび等の正当データが欠落する重大バグ (specialRewards export=9 → imported=2、staging cycle 3 の件数突合が実本番 snapshot で検出) を根治し、cutover rehearsal の 14 軸全一致 (= 本番リリース可否判断のエビデンス) に到達可能にする。

## 関連 Issue

closes #3653 (EPIC #3620 AC-C5 の cutover blocker)

## 根本原因

importFamilyData は merge import (バックアップ再取込・二重取込防止) の semantics で設計され、同 child 同 title 等を dedup skip する。cutover (fresh PGlite への完全移行) では実本番に正当に存在する同 title 複数行が skip され移行にならない。dedup Set への「import 済み行の追加」(バッチ内 dedup) が fresh DB でも欠落を起こす直接原因。

## 設計 (dedup 全数分類 → 最小 touch)

import 系全 20+ 関数の skip/dedup 判定を精査し 3 分類:

- **(A) バッチ内 dedup + DB backstop 無し = fresh DB でも欠落** → mode guard 必須 3 関数: `importSpecialRewards` (title/preset) / `importOneChecklistTemplate` (name 両パス/preset) / `importActivityLogsData` (activityName:recordedAt)
- **(B) DB PK が backstop** (login_bonuses の login_date PK / checklist_logs の PK+upsert) → 多重化不能のため touch 不要 (最小変更)
- **(C) 整合性 skip** (childRef/FK 解決不能・allowlist・zip-slip 検証・exportId 真重複判定) → mode に関わらず維持。exportId は export-service が source 行ごとに distinct 発番するため「同 exportId 再出現 = 真の重複」で verbatim でも維持が正しい

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| AC1: failing-test-first | `npx vitest run tests/unit/services/backup-roundtrip-completeness.test.ts` — fixture 追加直後 (実装前) に **1 failed | 10 passed** の red を確認 → 実装後 **11 passed** | PASS (red→green) | 実行ログ (下記) |
| AC2: verbatim で dedup bypass / merge (既定) 現行不変 | [verbatim] 3 行全復元 + [merge 既定] 1 行 dedup の両 test | PASS | vitest 11/11 |
| AC2 続 (回帰なし) | `npx vitest run tests/unit/services/ tests/unit/scripts/ tests/unit/routes/import-cloud-template-per-child.test.ts` | PASS (**Test Files 181 passed / Tests 3025 passed**) | vitest log |
| AC3: cutover CLI が verbatim 指定 | `scripts/nuc-pglite-cutover.ts` L120 に `{ mode: 'verbatim' }` + 理由コメント。CLI test ([CLI1]-[CLI3]) は import 経路を実子プロセスで貫通しており全 green | PASS | diff + vitest |
| AC4: staging cycle 4 で 14 軸全一致 | merge 後に pglite lane 再 dispatch し、実 snapshot での件数突合全一致 + PGlite boot + health green を run URL とともに EPIC #3620 へ記録して完了とする | 手順確立済 | workflow 既存 |

## 変更タイプ

- [x] バグ修正 (cutover blocker、データ欠落 class)
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `import-service.ts`: `ImportOptions`/`ImportMode` 追加 + 3 関数に mode guard (既定 merge、**options 未指定の全既存 caller は挙動不変**)
- `scripts/nuc-pglite-cutover.ts`: import 呼出に verbatim 指定 (1 行 + コメント)
- `backup-roundtrip-completeness.test.ts`: verbatim/merge 両挙動の固定 test 追加

### 検証コマンド証跡

- `npx vitest run tests/unit/services/backup-roundtrip-completeness.test.ts` → 実装前: `Tests  1 failed | 10 passed` ([verbatim] が dedup 縮約で red) / 実装後: `Tests  11 passed`
- `npx vitest run tests/unit/services/ tests/unit/scripts/ tests/unit/routes/import-cloud-template-per-child.test.ts` → `Test Files  181 passed (181)` / `Tests  3025 passed (3025)`
- `npx biome check --error-on-warnings src/lib/server/services/import-service.ts scripts/nuc-pglite-cutover.ts tests/unit/services/backup-roundtrip-completeness.test.ts` → No fixes applied / error 0
- `npx cspell --no-progress <変更 3 ファイル>` → Issues found: 0

## テスト & 安全装置セルフチェック

- [x] failing-test-first (red 確認 → 実装 → green、ADR-0061)
- [x] merge 既定挙動を test で固定 (バックアップ再取込・marketplace 二重取込防止の既存価値は不変)
- [x] (C) 整合性 skip (CWE-22 path 検証 / allowlist / FK 解決) は mode に関わらず全維持
- [x] 回帰 3025 tests green

## スクリーンショット / ビジュアルデモ

N/A — server service + CLI のみ。

## コード品質セルフレビュー (#1481)

- mode は使う 3 関数にだけ引数伝搬 (20+ 関数への一律伝搬は不採用 — DB backstop の有無で必要性を分類した最小 touch)
- verbatim でも dedup Set の構築/add は残す (無害 + diff 最小)。guard は has 判定のみ

## 横展開・影響波及チェック

- 既存 caller (backup 復元 route / marketplace 取込) は options 未指定 = merge のまま挙動不変
- DSQL (AWS) 側は cutover でデータ移行なし (ゼロユーザー期 greenfield) のため本 mode の対象外

## レビュー依頼事項・破壊的変更

破壊的変更なし (後方互換 optional 引数)。レビュー観点: (B) 群 (login_bonuses/checklist_logs) を touch しない判断 (DB PK backstop で欠落不能、export 元も同 PK 制約で重複データを持ち得ない) の妥当性。

## 配布済み env / secret (ADR-0006)

N/A。

## Ready for Review チェックリスト

- [x] failing-test-first + 実装 + 回帰確認が 1 PR で完結
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。
