### PR TITLE
docs(adr): #3430 ADR-0065 DSQL DPU コスト規約 (service 層 5 原則、#3425 実測裏付け)

### DIFF
--- a/docs/decisions/0065-dsql-dpu-query-rules.md
+++ b/docs/decisions/0065-dsql-dpu-query-rules.md
@@ -1,0 +1,48 @@
+# 0065. DSQL DPU コスト規約 — service 層クエリの 5 原則 (実測裏付け)
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | accepted |
+| 日付 | 2026-07-11 |
+| 起票者 | Dev (Claude 補佐) |
+| 関連 Issue | #3430 / #3425 (実測) / EPIC #3424 |
+
+## コンテキスト
+
+DSQL の課金は DPU (処理バイト + CPU 秒) で、行数課金ではない。設計を誤ると「機能は正しいがコストが爆発する」クエリが CI を素通りする。規約の前提は #3425 の staging 実測で裏取り済み:
+
+- **write txn には Transaction minimum 0.05 WriteDPU / read に 0.00375 ReadDPU** が適用される (EXPLAIN ANALYZE VERBOSE 実測)。小さい write を N txn に分けると、内容に関わらず 0.05×N が課金される
+- WriteDPU は同量処理で ReadDPU の約 27 倍のコスト密度 (公式 billing-metering)
+- **スキャンした全行が課金対象** (フィルタ後の返却行ではない)。非 PK filter は統計未反映時 full scan になる (Phase 1 PoC 検証 7)
+- 代表クエリ実測: home read 0.050 / 履歴 50 件 0.056 / ledger INSERT 0.022 / 残高 UPDATE 0.012 DPU — 定常運用は無料枠の 1% 未満であり、**規約の目的は「正常時の節約」ではなく「事故 (full scan / N+1 の常態化) の構造的防止**」
+
+## 検討した選択肢（OSS / 確立パターン — #1350）
+
+### 選択肢 A: DynamoDB 時代の RCU/WCU 規約の踏襲 (確立パターン)
+- 概要: 旧 backend で運用していた「PK アクセス必須 / scan 禁止」の慣行
+- メリット: チームに既知。DSQL の PK prefix 原則と同型
+- デメリット: txn minimum 課金・DPU の read/write 非対称という DSQL 固有の軸を持たない
+
+### 選択肢 B: pgMustard 等の EXPLAIN 解析 SaaS・OSS
+- 概要: Postgres の実行計画を継続解析しコスト回帰を検出する製品群
+- メリット: 成熟した回帰検出
+- デメリット: DSQL の DPU Estimate は独自拡張で対応外。外部 SaaS は Pre-PMF 過剰 (ADR-0010)
+
+### 選択肢 C: 本 ADR (5 原則 + EXPLAIN 相対チェック運用)
+- A の PK 原則を継承しつつ、DSQL 固有 (txn minimum / DPU 非対称 / ASYNC index 制約) を実測値で規約化。ツール導入ゼロ
+
+## 決定 — service 層クエリの 5 原則
+
+1. **フルスキャン禁止 (PK prefix 必須)**: 全クエリは `WHERE family_id = ...` を先頭に持つ複合 PK prefix でアクセスする (ADR-0063 tenant 分離と同一の機械強制点)。非 PK filter を追加する場合は PK prefix で範囲を絞った上で適用する
+2. **N+1 禁止・write は束ねる**: 同一操作の複数 write は単一 txn にまとめる (txn minimum 0.05 WriteDPU × N の防止、実測裏付け)。模範 = `recordActivityCore` (core 5 行 1 txn、#3541)。ループ内 `await repo.insert()` の逐次 txn は禁止
+3. **secondary index は既定で張らない (PoC 保留原則)**: 全 index が write 課金対象 (≤24/table)。追加は実データ規模での実測 (m3-physical-model §5.2) を経て採否判断。「張れば効く」は統計未反映時に成立しない (Phase 1 PoC 検証 7)
+4. **hot key write を作らない**: 連番・固定 key への write 集中は OCC 競合 → retry 再実行の二重課金。UUID v4 PK 分散を維持 (§P9)
+5. **一括処理は 3,000 行 / 10MiB チャンク + 冪等 upsert**: import/復元は txn ハード上限 (P5) 内に分割 (§6.4)
+
+**EXPLAIN 運用**: `EXPLAIN ANALYZE VERBOSE` の Statement DPU Estimate は **相対比較 (変更前後の回帰確認) 用**とし、絶対閾値の CI gate にはしない (Estimate は billing-grade でない + データ量依存)。重い新規クエリ (集計 / cross-tenant cron) を追加する PR は、PR body に代表データでの DPU Estimate を記録する (レビュー判断材料。機械 gate 化は実運用の回帰実績が出てから再判断)
+
+## 結果
+
+- コスト事故 (full scan 常態化 / N+1) がコードレビューの明文基準になる。監視側は CloudWatch TotalDPU 日次 alarm (#3431) が defense-in-depth
+- トレードオフ: 原則 3 により当面 secondary index なしで読み性能は PK 依存。家庭スケール (実測: home read 0.05 DPU / CommitLatency 2.87ms) では問題なし、成長時は実測で個別解禁
+- 10 枠超過の 1-in-1-out は 2026-07 最終週の月 1 棚卸で消化する (ADR-0060〜0064 と同運用)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -187,6 +187,7 @@ ADR を現場の常時参照ルールとして機能させるため、以下の�
 | 0062 | [統一エラー通知設計 (種別×手段マッピング + 内部例外非露出 + role/aria SSOT)](0062-unified-error-notification.md) | accepted | 2026-06-22 |
 | 0063 | [DSQL pool マルチテナント分離 (信頼 claim/context + アプリ層単一強制点 + fitness function、RLS 非対応の代替防御線)](0063-dsql-pool-multitenant-isolation.md) | accepted | 2026-06-29 |
 | 0064 | [NUC 新 model repo 構築方式 — PGlite 一次採用 (dialect 税ゼロ) + raw SQLite fallback](0064-sqlite-core-repo-strategy.md) | accepted | 2026-07-09 |
+| 0065 | [DSQL DPU コスト規約 — service 層クエリの 5 原則 (実測裏付け)](0065-dsql-dpu-query-rules.md) | accepted | 2026-07-11 |
 
 > 注 (2026-06-04 #2440 PR-A5): 番号は欠番を許容する（削除済 ADR の番号は再利用しない、git 履歴で追跡可能）。新規 ADR は最大番号 +1 で採番する。renumber 規約は §renumber 規約 を参照。
 >

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -357,3 +357,14 @@ active 総数: 42 件 (棚卸後、ADR-0063 +1)。
 **1-in-1-out 履行**: ADR-0060 / 0061 / 0063 起票時と同様、active 大幅超過の現状を踏まえ 1-in-1-out は **2026-07 最終週の月 1 棚卸** で archive 候補 (ADR-0014 proposed 据置 / per-ADR ボリューム超過) と併せて消化する (本 PR scope 外)。
 
 active 総数: 43 件 (棚卸後、ADR-0064 +1)。
+
+### 2026-07-11 棚卸 (ADR-0065 起票)
+
+**完了項目**:
+
+1. **ADR-0065 新規追加**: DSQL DPU コスト規約 — service 層クエリの 5 原則 (実測裏付け)。EPIC #3424 の設計 Sub #3430 を、staging cluster 実測 (#3425: write txn minimum 0.05 WriteDPU / 代表クエリ DPU / OccConflicts・CommitLatency 2.87ms) で裏取りして規約化。フルスキャン禁止 (PK prefix、ADR-0063 と同一強制点) / N+1 禁止・write 束ね (recordActivityCore 模範) / secondary index PoC 保留 / hot key 回避 (UUID v4) / 一括 3,000 行・10MiB チャンク。EXPLAIN ANALYZE VERBOSE は相対回帰用 (絶対閾値 gate 不向き) を明文化。Pre-PMF Bucket A (ADR-0010 整合、ツール導入ゼロ)。
+
+**1-in-1-out 履行**: ADR-0060〜0064 起票時と同様、active 大幅超過の現状を踏まえ 1-in-1-out は **2026-07 最終週の月 1 棚卸** で archive 候補 (ADR-0014 proposed 据置 / per-ADR ボリューム超過) と併せて消化する (本 PR scope 外)。
+
+active 総数: 44 件 (棚卸後、ADR-0065 +1)。
+


### PR DESCRIPTION
## 顧客価値・目的

DSQL 移管後の「機能は正しいがコストが爆発するクエリ」を構造的に防止する service 層規約を ADR 化する (#3430、L3.5 設計課題の最終残)。運用費 ≤¥100/月 制約 (EPIC #3424 前提) の恒久担保。

## 関連 Issue

closes #3430 (blocked_by だった #3425 実測は 2026-07-11 完了済み)

## AC 検証マップ (ADR-0004)

| AC | 検証方法 | 結果 | 証跡 |
|---|---|---|---|
| AC1: 規約 ADR 起票 (10 枠ルール整合) | `docs/decisions/0065-dsql-dpu-query-rules.md` (48 行 ≤150 / 4 セクション ≤7、OSS 比較 2 件 = DynamoDB 慣行 / pgMustard) + README 表追補。1-in-1-out は 2026-07 月 1 棚卸で消化 (0060-0064 と同運用を本文明記) | PASS | diff |
| AC2: WriteDPU 集約の目安 + 書込を束ねるパターン | 原則 2 (txn minimum 0.05 WriteDPU × N の実測根拠 + recordActivityCore 模範) | PASS | ADR 本文 |
| AC3: EXPLAIN の CI 相対回帰方針 | 「相対比較用・絶対閾値 gate 不向き」+ 重いクエリ PR の DPU Estimate 記録運用を明文化 | PASS | ADR 本文 |
| AC4: #3425 実測で裏取り | コンテキスト節の全数値が staging 実測 (#3425 コメント) 由来 (txn minimum / 代表クエリ DPU / CommitLatency) | PASS | #3425 実測表 |

### 検証コマンド証跡

- `npx cspell --no-progress docs/decisions/0065-dsql-dpu-query-rules.md` → Issues found: 0 (README.md の HMAC 2 件は既存行 + docs は CI cspell glob 対象外)
- `wc -l docs/decisions/0065-dsql-dpu-query-rules.md` → 48 行 (≤150 上限)

## 変更タイプ

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント (ADR)

## 影響範囲・変更コンポーネント

- `docs/decisions/0065-dsql-dpu-query-rules.md` (新規) / `docs/decisions/README.md` (表 1 行追補)。コード変更なし。

## テスト & 安全装置セルフチェック

- [x] ADR ボリューム上限 (`wc -l` → 48 行 / 4 セクション) 遵守
- [x] OSS 先調査 2 件 (README テンプレ必須要件)

## スクリーンショット / ビジュアルデモ

N/A — docs のみ。

## コード品質セルフレビュー (#1481)

- 数値は全て実測 (#3425) か公式 doc 由来で、推定値を確定と称していない (M3 の「構造決定 vs PoC 保留」規律整合)

## 横展開・影響波及チェック

- 原則 1 (PK prefix) は ADR-0063 fitness と同一強制点のため新規 lint 不要。原則 2 の機械化 (ループ内逐次 txn 検出) は実運用の回帰実績が出てから再判断 (本文明記、Pre-PMF 過剰防衛回避)

## レビュー依頼事項・破壊的変更

破壊的変更なし。レビュー観点: EXPLAIN を CI hard gate にしない判断 (AC3) の妥当性。

## 配布済み env / secret (ADR-0006)

N/A。

## Ready for Review チェックリスト

- [x] ADR + README 追補が 1 PR で完結
- [x] base = develop

## QM レビュー結果

QM レビュー待ち。