### PR TITLE
fix(security): #3404 push endpoint の url.href 正規化保存 + INVALID_ENDPOINT 発生可視化 (残 2 項目)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -512,6 +512,7 @@ webapi
 webp
 webpush
 webui
+whatwg
 whsec
 worktree
 writeback

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -765,7 +765,9 @@ cron の server push (web-push) は `push_subscriptions` に保存済の `endpoi
 | 観点 | 仕様 | 実体 |
 |---|---|---|
 | 検証ロジック | `validatePushEndpoint(endpoint)` / `isValidPushKey(key, maxLen)` を独立モジュールに集約 | `src/lib/server/services/push-endpoint-validation.ts` |
-| API ガード | subscribe で保存前に検証し、不正 endpoint は `400` + `code: 'INVALID_ENDPOINT'`、不正 key は `400` + `code: 'INVALID_KEY'` を返す (理由は `logger.warn`、ユーザーには汎用文言) | `src/routes/api/v1/notifications/subscribe/+server.ts` |
+| API ガード | subscribe で保存前に検証し、不正 endpoint は `400` + `code: 'INVALID_ENDPOINT'`、不正 key は `400` + `code: 'INVALID_KEY'` を返す (理由は server 内部観測のみ、ユーザーには汎用文言) | `src/routes/api/v1/notifications/subscribe/+server.ts` |
+| 正規化保存 (#3404 item2) | `validatePushEndpoint` は ok 時に raw 入力ではなく WHATWG `new URL()` の `.href` (host 小文字化 / default port 除去) を返し、subscribe はこの正規化形で `findByEndpoint` / `insert` する。「検証 = WHATWG parse / 送信 = web-push の legacy `url.parse()`」の parser-differential を保存時点で排除。ok/NG 判定は scheme/host のみに依存するため raw 形で保存済みの既存 subscription も送信側再検証を従来どおり通過し、既存チェックは正規化形 miss 時に raw 形 fallback 照合で重複 insert を防ぐ | `src/lib/server/services/push-endpoint-validation.ts` / `subscribe/+server.ts` |
+| 拒否発生の可視化 (#3404 item3) | `INVALID_ENDPOINT` / `INVALID_KEY` 拒否時に `reportPushValidationRejection` が structured `logger.warn` (`context.kind = 'push-validation-rejected'` / `code` / `reason`、Logs Insights で集計可能) + `sendDiscordAlert` fire-and-forget (throttle は `discord-alert.ts` 側) を発火。ベンダー host 変更で正規ブラウザの subscribe が無言停止する事業継続リスクの観測点。custom CloudWatch metric / CDK alarm 新設は既存 pattern 不在 + free-tier alarm 枠逼迫のため不採用 (ADR-0010) | `src/lib/server/services/push-validation-alert.ts` |
 | scheme 制限 | `https:` のみ許可 (それ以外は拒否) | 同上 |
 | host allowlist | 既知 Web Push service host のみ許可。`fcm.googleapis.com` / `android.googleapis.com` (FCM、Chrome/Edge) は exact 一致、`.push.services.mozilla.com` (Firefox) / `.push.apple.com` (Safari) / `.notify.windows.com` / `.wns.windows.com` (WNS) は dot-suffix 末尾一致。末尾一致のため `fcm.googleapis.com.attacker.com` 等の偽装ホストおよび internal host は弾かれる | 同上 |
 | endpoint 長 | 2048 文字上限 | 同上 |
@@ -788,7 +790,7 @@ subscribe API の保存前検証だけでは、過去レコード混入 / repo �
 
 **allowlist 通過後の redirect / DNS 層 (#3421 残課題、現状 scope 外)**: 本 hardening は endpoint の hostname 文字列照合のみで、実 POST は web-push (Node `https` raw) が後段で行う。現状 web-push は 3xx redirect を自動追従しないため、allowlist 通過後に internal host へ redirect される live SSRF は成立しない。また DNS rebinding は単発 POST かつ allowlist host 限定のため現実的リスクが低い。よって redirect 追従 / DNS 解決層の検証は現状 scope 外とする。ただし **上流 (web-push / Node https) が redirect 自動追従を有効化した場合 / 任意 host を許す設定変更時は residual リスクが顕在化する**ため、その際は redirect 非追従の明示 (`maxRedirects: 0` 相当) / 解決 IP の private-range 再検証を追加する (ADR-0010 Pre-PMF: 現状の web-push 挙動では不要)。
 
-#3404 のうち item2 (`url.href` 正規化) / item3 (`INVALID_ENDPOINT` metric / alarm) は runtime bypass が無く observability の範疇のため、本対応では扱わず Pre-PMF scope 外とする (ADR-0010)。#3421 のうち再購読プロンプト UI (subscribe フローでの再登録導線 / status 表示) は UI 体験範疇のため Pre-PMF scope 外とし、上記の確定 SSRF cleanup + 証跡を優先する。**allowlist 網羅漏れ subscription の削除は再購読 UI とセット**で別途扱う (再購読導線が無い現状で一律削除すると正規購読が自力回復不能になるため、#3455 で確定 SSRF のみ削除に保守化済)。
+#3404 の item2 (`url.href` 正規化保存) / item3 (`INVALID_ENDPOINT` / `INVALID_KEY` 発生可視化) は上表 (§8.9) のとおり実装済。#3421 のうち再購読プロンプト UI (subscribe フローでの再登録導線 / status 表示) は UI 体験範疇のため Pre-PMF scope 外とし、上記の確定 SSRF cleanup + 証跡を優先する。**allowlist 網羅漏れ subscription の削除は再購読 UI とセット**で別途扱う (再購読導線が無い現状で一律削除すると正規購読が自力回復不能になるため、#3455 で確定 SSRF のみ削除に保守化済)。
 
 ---
 

--- a/src/lib/server/services/push-endpoint-validation.ts
+++ b/src/lib/server/services/push-endpoint-validation.ts
@@ -50,7 +50,15 @@ function isAllowedPushHost(hostname: string): boolean {
 /**
  * push endpoint URL を検証する。https + 既知 push service host のみ許可 (SSRF 防御)。
  *
- * @returns ok=true で通過、ok=false で reason に拒否理由 (logger 用、ユーザーには汎用文言を返す)
+ * #3404 item2: ok=true の `url` は raw 入力ではなく WHATWG `new URL()` の `.href` (正規化形:
+ * host 小文字化 / default port 除去 / percent-encoding 正規化) を返す。保存経路 (subscribe) が
+ * この正規化形を永続化することで、「検証 = WHATWG parse / 送信 = web-push の legacy `url.parse()`」
+ * の parser-differential を runtime 挙動に依存せず排除する。
+ * 後方互換: ok/NG の判定自体は parse 結果の scheme/host にのみ依存するため、raw 形で保存済みの
+ * 既存 subscription も送信側再検証 (`notification-service.ts`) で従来どおり通過する。
+ *
+ * @returns ok=true で通過 (url は正規化済 href)、ok=false で reason に拒否理由
+ *          (logger 用、ユーザーには汎用文言を返す)
  */
 export function validatePushEndpoint(
 	endpoint: unknown,
@@ -73,7 +81,7 @@ export function validatePushEndpoint(
 	if (!isAllowedPushHost(url.hostname)) {
 		return { ok: false, reason: `endpoint host not in push-service allowlist (${url.hostname})` };
 	}
-	return { ok: true, url: endpoint };
+	return { ok: true, url: url.href };
 }
 
 /**

--- a/src/lib/server/services/push-validation-alert.ts
+++ b/src/lib/server/services/push-validation-alert.ts
@@ -1,0 +1,63 @@
+// src/lib/server/services/push-validation-alert.ts
+// #3404 item3: subscribe endpoint での INVALID_ENDPOINT / INVALID_KEY 発生の可視化。
+//
+// 背景: push service ベンダーが endpoint host を新設 / 移行すると、静的 allowlist
+// (push-endpoint-validation.ts) が正規ブラウザの subscribe を拒否し、その browser セグメントの
+// 通知が「無言で」止まる事業継続リスクがある。拒否は 400 で返るだけで運用が気づけないため、
+// 発生を能動的に観測可能にする。
+//
+// 実装方式 (ADR-0010 Pre-PMF 最小、既存基盤へ合流):
+//   1. `logger.warn` — structured context (kind='push-validation-rejected' / code / reason)。
+//      CloudWatch Logs Insights で `filter context.kind = "push-validation-rejected"` query 可能
+//      (optional-write-alert.ts の fitness#11 counter と同 pattern)。将来 metric filter / alarm を
+//      CDK 化する場合もこの stable key を filterPattern にそのまま使える。
+//   2. `sendDiscordAlert` — fire-and-forget (stripe/alert.ts / optional-write-alert.ts と同 pattern)。
+//      throttle (5 分窓 / 3 件でまとめ通知) は discord-alert.ts 側が担うため、攻撃者による
+//      不正 endpoint 連投でも alert が洪水化しない。
+//
+// custom CloudWatch metric (EMF / putMetricData) + CDK alarm 新設は不採用: repo に custom metric の
+// 既存 pattern が無く (ops-stack.ts は AWS 標準 metric のみ、free-tier basic alarm 枠 9/10 使用済)、
+// Pre-PMF で新規機構を持ち込むより既存 log + Discord 基盤で可視化する方が導入 / 保守コストが小さい。
+
+import { sendDiscordAlert } from '$lib/server/discord-alert';
+import { logger } from '$lib/server/logger';
+
+export type PushValidationRejectionCode = 'INVALID_ENDPOINT' | 'INVALID_KEY';
+
+export interface PushValidationRejection {
+	tenantId: string;
+	code: PushValidationRejectionCode;
+	/** 拒否理由 (validatePushEndpoint().reason 等)。server 内部観測用、client には返さない。 */
+	reason: string;
+}
+
+/**
+ * push subscribe の validation 拒否を structured log + Discord alert で観測可能にする。
+ * subscribe response をブロックしない (alert は fire-and-forget)。
+ */
+export function reportPushValidationRejection(rejection: PushValidationRejection): void {
+	// 1. structured logger (検索 key: context.kind / context.code)
+	logger.warn(`[notifications/subscribe] push validation 拒否 (${rejection.code})`, {
+		tenantId: rejection.tenantId,
+		service: 'push-subscribe',
+		context: {
+			kind: 'push-validation-rejected',
+			code: rejection.code,
+			reason: rejection.reason,
+		},
+	});
+
+	// 2. Discord alert (fire-and-forget、subscribe response をブロックしない)。
+	//    ベンダー host 変更で正規ブラウザが弾かれ始めた場合、同一 reason が連続するため
+	//    discord-alert.ts の throttle key (path + errorSummary) でまとめ通知に収束する。
+	void sendDiscordAlert({
+		level: 'error',
+		message: `[push-validation-rejected] ${rejection.code} (push subscribe 拒否 — ベンダー host 変更の可能性を確認)`,
+		path: '/api/v1/notifications/subscribe',
+		tenantId: rejection.tenantId,
+		errorSummary: rejection.reason,
+	}).catch((err) => {
+		// alert 自体の失敗は warn に留める (recursive alert を避ける)
+		logger.warn(`[push-validation-alert] Discord alert dispatch failed: ${String(err)}`);
+	});
+}

--- a/src/routes/api/v1/notifications/subscribe/+server.ts
+++ b/src/routes/api/v1/notifications/subscribe/+server.ts
@@ -15,6 +15,7 @@ import {
 	isValidPushKey,
 	validatePushEndpoint,
 } from '$lib/server/services/push-endpoint-validation';
+import { reportPushValidationRejection } from '$lib/server/services/push-validation-alert';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -51,30 +52,44 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 		// #3188 SSRF hardening: endpoint は https + 既知 push service host のみ許可。
 		// cron の server push が internal host へ POST する CWE-918 を防ぐ。
+		// #3404 item3: 拒否発生は reportPushValidationRejection で可視化する (ベンダー host 変更で
+		// 正規ブラウザの subscribe が無言停止する事業継続リスクの観測点)。
 		const endpointCheck = validatePushEndpoint(body.endpoint);
 		if (!endpointCheck.ok) {
-			logger.warn('[notifications/subscribe] 不正な push endpoint を拒否', {
-				context: { tenantId: context.tenantId, reason: endpointCheck.reason },
+			reportPushValidationRejection({
+				tenantId: context.tenantId,
+				code: 'INVALID_ENDPOINT',
+				reason: endpointCheck.reason,
 			});
 			return json({ error: 'Invalid push endpoint', code: 'INVALID_ENDPOINT' }, { status: 400 });
 		}
 		// #3188: key は base64url 形式 + 長さ上限のみ検証 (raw 保存前の最小サニタイズ)。
 		if (!isValidPushKey(body.keys.p256dh) || !isValidPushKey(body.keys.auth, 64)) {
-			logger.warn('[notifications/subscribe] 不正な push key 形式を拒否', {
-				context: { tenantId: context.tenantId },
+			reportPushValidationRejection({
+				tenantId: context.tenantId,
+				code: 'INVALID_KEY',
+				reason: 'push key failed base64url format / length validation',
 			});
 			return json({ error: 'Invalid push key', code: 'INVALID_KEY' }, { status: 400 });
 		}
 
-		// 既存チェック（同じ endpoint が登録済みならスキップ）
-		const existing = await findByEndpoint(body.endpoint, context.tenantId);
+		// #3404 item2: 保存は raw 入力ではなく WHATWG 正規化済 URL (`url.href`) を使う。
+		// 検証 (new URL) / 保存 / 送信 (web-push legacy url.parse) の parser-differential を
+		// 保存時点で潰す。既存チェックは正規化形で照合し、正規化前の raw 形で保存された
+		// 既存レコードとも fallback 照合して重複 insert (= 二重通知) を防ぐ。
+		const normalizedEndpoint = endpointCheck.url;
+		const existing =
+			(await findByEndpoint(normalizedEndpoint, context.tenantId)) ??
+			(body.endpoint !== normalizedEndpoint
+				? await findByEndpoint(body.endpoint, context.tenantId)
+				: undefined);
 		if (existing) {
 			return json({ success: true, message: 'Already subscribed' });
 		}
 
 		await insert({
 			tenantId: context.tenantId,
-			endpoint: body.endpoint,
+			endpoint: normalizedEndpoint,
 			keysP256dh: body.keys.p256dh,
 			keysAuth: body.keys.auth,
 			userAgent: request.headers.get('user-agent'),

--- a/tests/unit/routes/notifications-subscribe-api.test.ts
+++ b/tests/unit/routes/notifications-subscribe-api.test.ts
@@ -18,6 +18,12 @@ vi.mock('$lib/server/logger', () => ({
 	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
+// #3404 item3: validation 拒否の可視化 (structured log + Discord alert) は結線のみ検証
+const mockReportRejection = vi.fn();
+vi.mock('$lib/server/services/push-validation-alert', () => ({
+	reportPushValidationRejection: mockReportRejection,
+}));
+
 const { POST } = await import('../../../src/routes/api/v1/notifications/subscribe/+server');
 
 type Role = 'owner' | 'parent' | 'child';
@@ -186,6 +192,84 @@ describe('POST /api/v1/notifications/subscribe (#1593 ADR-0023 I6)', () => {
 		);
 		expect(res.status).toBe(400);
 		expect(mockInsert).not.toHaveBeenCalled();
+		// #3404 item3: INVALID_ENDPOINT 発生が可視化基盤へ report される
+		expect(mockReportRejection).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tenantId: 'tenant-1',
+				code: 'INVALID_ENDPOINT',
+				reason: expect.any(String),
+			}),
+		);
+	});
+
+	// ============================================================
+	// #3404 item2: url.href 正規化保存
+	// ============================================================
+
+	it('大文字 host / default port の endpoint は正規化形 (.href) で保存される', async () => {
+		const res = await POST(
+			makeEvent({
+				role: 'parent',
+				body: {
+					endpoint: 'https://FCM.googleapis.com:443/fcm/send/abc',
+					keys: { p256dh: 'p256-key', auth: 'auth-key' },
+				},
+			}),
+		);
+		expect(res.status).toBe(200);
+		// 既存チェックも正規化形で照合される
+		expect(mockFindByEndpoint).toHaveBeenCalledWith(
+			'https://fcm.googleapis.com/fcm/send/abc',
+			'tenant-1',
+		);
+		expect(mockInsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				endpoint: 'https://fcm.googleapis.com/fcm/send/abc',
+			}),
+		);
+	});
+
+	it('正規化形で miss しても raw 形で保存済みの既存レコードと fallback 照合し重複 insert しない', async () => {
+		const rawEndpoint = 'https://FCM.googleapis.com:443/fcm/send/abc';
+		// 正規化形 lookup は miss、raw 形 lookup で hit する既存レコード (正規化導入前の保存分)
+		mockFindByEndpoint.mockImplementation(async (endpoint: string) =>
+			endpoint === rawEndpoint
+				? {
+						id: '77',
+						tenantId: 'tenant-1',
+						endpoint: rawEndpoint,
+						keysP256dh: 'p',
+						keysAuth: 'a',
+						userAgent: null,
+						subscriberRole: 'parent',
+						createdAt: '',
+					}
+				: undefined,
+		);
+		const res = await POST(
+			makeEvent({
+				role: 'parent',
+				body: {
+					endpoint: rawEndpoint,
+					keys: { p256dh: 'p256-key', auth: 'auth-key' },
+				},
+			}),
+		);
+		expect(res.status).toBe(200);
+		expect(mockInsert).not.toHaveBeenCalled();
+		// 正規化形 → raw 形の順で 2 回照合される
+		expect(mockFindByEndpoint).toHaveBeenNthCalledWith(
+			1,
+			'https://fcm.googleapis.com/fcm/send/abc',
+			'tenant-1',
+		);
+		expect(mockFindByEndpoint).toHaveBeenNthCalledWith(2, rawEndpoint, 'tenant-1');
+	});
+
+	it('入力が既に正規化形なら raw 形 fallback 照合は行わない (lookup 1 回)', async () => {
+		const res = await POST(makeEvent({ role: 'parent' }));
+		expect(res.status).toBe(200);
+		expect(mockFindByEndpoint).toHaveBeenCalledTimes(1);
 	});
 
 	it('非 https endpoint は 400 で拒否する', async () => {
@@ -215,5 +299,19 @@ describe('POST /api/v1/notifications/subscribe (#1593 ADR-0023 I6)', () => {
 		);
 		expect(res.status).toBe(400);
 		expect(mockInsert).not.toHaveBeenCalled();
+		// #3404 item3: INVALID_KEY 発生が可視化基盤へ report される
+		expect(mockReportRejection).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tenantId: 'tenant-1',
+				code: 'INVALID_KEY',
+				reason: expect.any(String),
+			}),
+		);
+	});
+
+	it('正常 subscribe では validation 拒否 report は発火しない', async () => {
+		const res = await POST(makeEvent({ role: 'parent' }));
+		expect(res.status).toBe(200);
+		expect(mockReportRejection).not.toHaveBeenCalled();
 	});
 });

--- a/tests/unit/services/push-endpoint-validation.test.ts
+++ b/tests/unit/services/push-endpoint-validation.test.ts
@@ -28,6 +28,38 @@ describe('validatePushEndpoint (#3188 SSRF hardening)', () => {
 		}
 	});
 
+	// #3404 item2: 検証は WHATWG new URL() → 返却 url は .href (正規化形)。
+	// 保存経路が正規化形を永続化することで、web-push の legacy url.parse() との
+	// parser-differential を runtime 挙動に依存せず排除する。
+	it('大文字 host / default port / 空 path を .href に正規化して返す (#3404 item2)', () => {
+		// host 小文字化
+		expect(validatePushEndpoint('https://FCM.googleapis.com/fcm/send/AbC')).toEqual({
+			ok: true,
+			url: 'https://fcm.googleapis.com/fcm/send/AbC', // path の大文字は保持される
+		});
+		// default port (:443) 除去
+		expect(validatePushEndpoint('https://fcm.googleapis.com:443/fcm/send/abc')).toEqual({
+			ok: true,
+			url: 'https://fcm.googleapis.com/fcm/send/abc',
+		});
+		// 空 path は末尾スラッシュ付与 (WHATWG 正規化)
+		expect(validatePushEndpoint('https://web.push.apple.com')).toEqual({
+			ok: true,
+			url: 'https://web.push.apple.com/',
+		});
+	});
+
+	it('既に正規化済みの endpoint は入力と同一文字列で返る (既存保存分と互換)', () => {
+		const ep = 'https://updates.push.services.mozilla.com/wpush/v2/gAAAA';
+		expect(validatePushEndpoint(ep)).toEqual({ ok: true, url: ep });
+	});
+
+	it('raw 形 (非正規化) で保存済みの既存 endpoint も ok 判定は変わらず通過する (送信側再検証の後方互換)', () => {
+		// 判定は scheme/host のみに依存し正規化形とは無関係 → 送信側 (notification-service) の
+		// validatePushEndpoint(sub.endpoint).ok 再検証で raw 保存分が落ちない
+		expect(validatePushEndpoint('https://FCM.googleapis.com:443/fcm/send/legacy').ok).toBe(true);
+	});
+
 	it('https 以外 (http / file / gopher) を拒否', () => {
 		for (const ep of [
 			'http://fcm.googleapis.com/fcm/send/abc',

--- a/tests/unit/services/push-validation-alert.test.ts
+++ b/tests/unit/services/push-validation-alert.test.ts
@@ -1,0 +1,91 @@
+// tests/unit/services/push-validation-alert.test.ts
+// #3404 item3: subscribe validation 拒否 (INVALID_ENDPOINT / INVALID_KEY) 可視化の結線テスト:
+//   [B1] logger.warn に構造化 context (kind/code/reason) で emit する (Logs Insights query 用 stable key)
+//   [B2] sendDiscordAlert を fire-and-forget で起動する (level=error / path / errorSummary)
+//   [B3] Discord alert 自体の失敗が throw せず logger.warn に留まる (subscribe response をブロックしない)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+vi.mock('$lib/server/discord-alert', () => ({
+	sendDiscordAlert: vi.fn(async () => undefined),
+}));
+
+import { sendDiscordAlert } from '../../../src/lib/server/discord-alert';
+import { logger } from '../../../src/lib/server/logger';
+import { reportPushValidationRejection } from '../../../src/lib/server/services/push-validation-alert';
+
+const alertMock = vi.mocked(sendDiscordAlert);
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	alertMock.mockResolvedValue(undefined);
+});
+
+describe('#3404 item3: reportPushValidationRejection (発生可視化)', () => {
+	it('[B1] logger.warn に kind/code/reason の構造化 context で emit する', () => {
+		reportPushValidationRejection({
+			tenantId: 't-1',
+			code: 'INVALID_ENDPOINT',
+			reason: 'endpoint host not in push-service allowlist (push.new-vendor.example.com)',
+		});
+
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		const [message, meta] = vi.mocked(logger.warn).mock.calls[0] ?? [];
+		expect(message).toContain('INVALID_ENDPOINT');
+		expect(meta).toMatchObject({
+			tenantId: 't-1',
+			service: 'push-subscribe',
+			context: {
+				kind: 'push-validation-rejected',
+				code: 'INVALID_ENDPOINT',
+				reason: 'endpoint host not in push-service allowlist (push.new-vendor.example.com)',
+			},
+		});
+	});
+
+	it('[B2] sendDiscordAlert を level=error + path + tenantId + errorSummary で起動する', () => {
+		reportPushValidationRejection({
+			tenantId: 't-2',
+			code: 'INVALID_KEY',
+			reason: 'push key failed base64url format / length validation',
+		});
+
+		expect(alertMock).toHaveBeenCalledTimes(1);
+		expect(alertMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				level: 'error',
+				message: expect.stringContaining('INVALID_KEY'),
+				path: '/api/v1/notifications/subscribe',
+				tenantId: 't-2',
+				errorSummary: 'push key failed base64url format / length validation',
+			}),
+		);
+	});
+
+	it('[B3] Discord alert 自体の失敗は throw せず logger.warn に留まる', async () => {
+		alertMock.mockRejectedValueOnce(new Error('webhook down'));
+
+		expect(() =>
+			reportPushValidationRejection({
+				tenantId: 't-3',
+				code: 'INVALID_ENDPOINT',
+				reason: 'x',
+			}),
+		).not.toThrow();
+
+		// fire-and-forget の rejection が処理されるのを待つ
+		await vi.waitFor(() => {
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('Discord alert dispatch failed'),
+			);
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ 運営 / システム全体

**解決する課題**: Web Push の SSRF defense-in-depth 残 2 項目。(a) 検証は WHATWG `new URL()`・保存は raw・送信は web-push の legacy `url.parse()` という parser-differential が runtime 挙動の収束に依存して残存していた。(b) push service ベンダーが endpoint host を変更した際、静的 allowlist が正規ブラウザの subscribe を 400 で拒否し、その browser セグメントの通知が運用に気づかれず停止する事業継続リスクがあった。

**期待される効果**: endpoint を正規化形 (`url.href`) で保存することで parser-differential を保存時点で構造的に排除。INVALID_ENDPOINT / INVALID_KEY の発生を structured log + Discord alert で能動観測可能にし、ベンダー host 変更による通知の無言停止を早期検知できる。

## 関連 Issue

closes #3404

（#3404 の 4 項目のうち項目 1 = 送信側 host 再検証 / 項目 4 = subscribe catch 内部例外非露出は PR #3413 / #3455 で実装済・develop 反映済。本 PR で残 2 項目（項目 2 / 3）を完了するため closes とする。項目 5 記載の #3188 item1 / item2 は #3404 の scope 外（同 issue #3188 残置）。）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (項目 1) | 送信側 host 再検証: `webpush.sendNotification` 直前に allowlist 再検証 | `grep -n "#3404" src/lib/server/services/notification-service.ts` | 実装済 (PR #3413、develop 反映済)。HEAD `6188d4ea` / `notification-service.ts:229-244` (validatePushEndpoint 再検証 + skip) / 本 PR 差分外 |
| AC2 (項目 2) | `validatePushEndpoint` が `url.href` (正規化) を返し、subscribe 保存経路も正規化済 URL を保存。raw 保存済み既存 subscription が送信時再検証で落ちない | `npx vitest run tests/unit/services/push-endpoint-validation.test.ts tests/unit/routes/notifications-subscribe-api.test.ts` | 本 PR 実装。HEAD `6188d4ea` / 31 passed。`push-endpoint-validation.ts:87` (`url: url.href`) / `subscribe/+server.ts:78-93` (正規化保存 + raw 形 fallback 照合)。後方互換 test: `push-endpoint-validation.test.ts`「raw 形 (非正規化) で保存済みの既存 endpoint も ok 判定は変わらず通過する」PASS |
| AC3 (項目 3) | INVALID_ENDPOINT / INVALID_KEY 発生の可視化 (metric/alarm 相当) | `npx vitest run tests/unit/services/push-validation-alert.test.ts` | 本 PR 実装。HEAD `6188d4ea` / 3 passed。`push-validation-alert.ts` 新設 (structured `logger.warn` kind=`push-validation-rejected` + `sendDiscordAlert` fire-and-forget) / `subscribe/+server.ts:52-73` で両拒否 path から発火。方式判断根拠は下記「レビュー依頼事項」参照 |
| AC4 (項目 4) | subscribe catch の内部例外を client へ露出しない (ADR-0062) | `grep -n "ADR-0062" src/routes/api/v1/notifications/subscribe/+server.ts` | 実装済 (PR #3455、develop 反映済)。HEAD `6188d4ea` / `subscribe/+server.ts:100-108` (汎用 message `Subscription failed` のみ返却、詳細は server log) / 本 PR 差分外 |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)

**影響を受ける画面・機能**:
Web Push 通知の subscribe API (`/api/v1/notifications/subscribe`) と endpoint 検証 service。UI 変更なし (server-side のみ)。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— Draft 段階のため biome / vitest (関連 spec) をローカル個別実行済。Ready 化前に PR 番号付きで全 step 実行する
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/services/push-endpoint-validation.test.ts`: 大文字 host / default port (`:443`) / 空 path の `.href` 正規化 3 ケース + 正規化済み入力の round-trip + raw 保存分の送信側再検証後方互換
  - `tests/unit/routes/notifications-subscribe-api.test.ts`: 正規化形での insert / findByEndpoint 照合、raw 形 fallback 照合で重複 insert しない、正規化済み入力は lookup 1 回、INVALID_ENDPOINT / INVALID_KEY 拒否時の report 発火、正常時は report 非発火
  - `tests/unit/services/push-validation-alert.test.ts` (新規): structured log context (kind/code/reason) / Discord alert 引数 / alert 失敗時に throw せず warn に留まる (fire-and-forget)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（repo interface 変更なし、endpoint 文字列の値のみ正規化）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（非ブロッカー defense-in-depth、Issue 出典に非ブロッカー明記）

## スクリーンショット / ビジュアルデモ

**該当なし（server-side のみ、UI 変更なし）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 可視化 (`push-validation-alert.ts`) を検証 (`push-endpoint-validation.ts`、純関数維持) から分離。既存 `optional-write-alert.ts` と同型の service 層 bind
- [x] **DRY**: 可視化 pattern は `optional-write-alert.ts` / `stripe/alert.ts` の既存 fire-and-forget pattern に合流（新規機構を発明しない）。`grep -rn "sendDiscordAlert" src/` で既存 4 callsite と整合確認済
- [x] **YAGNI**: custom metric 基盤 / CDK alarm / EMF helper 等の新規抽象を追加していない
- [x] **Security（OSS 公開前提）**: 拒否 reason は server log / Discord のみに送り client には汎用文言 (`Invalid push endpoint` / `Invalid push key`) を維持 (ADR-0062 整合)。正規化は WHATWG URL 標準動作のみで独自 parse なし
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: fallback lookup は「入力が非正規化形かつ正規化形で miss」の場合のみ +1 クエリ（ブラウザ産 endpoint は通常正規化済のため実質 0）。alert は fire-and-forget で response をブロックしない

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] N/A — 並行実装の影響範囲外（server-side push 検証のみ。UI ラベル / 年齢モード / ナビ / DB スキーマ / チュートリアル変更なし。DB は endpoint 文字列の値のみで schema 不変）
- [x] **設計書同期** (ADR-0001): `docs/design/14-セキュリティ設計書.md` §8.9 を同 PR で更新 — 正規化保存 (#3404 item2) / 拒否発生の可視化 (#3404 item3) の 2 行を仕様表に追加し、旧「item2 / item3 は scope 外」記述を実装済に是正。07-API 設計書の subscribe API contract (request/response) は不変

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:

**項目 3 の方式判断根拠 (CloudWatch custom metric 不採用、既存 log + Discord 基盤へ合流)**:

1. **既存パターン調査結果**: repo 内に custom CloudWatch metric (EMF / `putMetricData`) の使用実績は 0 件。`infra/lib/ops-stack.ts` の alarm は AWS 標準 metric (Lambda Errors / Throttles / DynamoDB 等) のみで、free-tier basic alarm 枠は 9/10 使用済。アプリ層の異常可視化の既存慣行は「structured `logger.warn/error` (CloudWatch Logs → Logs Insights query 可能) + `sendDiscordAlert` fire-and-forget (throttle 内蔵)」（`optional-write-alert.ts` fitness#11 / `stripe/alert.ts` / `hooks.server.ts` 5xx）。
2. **判断**: 本件の目的は「ベンダー host 変更による subscribe 拒否の早期検知」であり、運用者が実際に見る導線は Discord。既存基盤への合流で (a) 検知の実効性 (Discord 通知が届く)、(b) 定量 query 可能性 (`filter context.kind = "push-validation-rejected"` を Logs Insights で集計、将来 metric filter を CDK 化する場合も同 key を filterPattern に流用可) の両方を満たす。EMF / putMetric + CDK alarm 新設は既存 pattern 不在 + alarm 枠逼迫 + Pre-PMF (ADR-0010) で過剰と判断。
3. **alert 洪水対策**: 攻撃者による不正 endpoint 連投は `discord-alert.ts` の throttle (5 分窓 / 3 件でまとめ通知 → 以降無音) で収束。ベンダー host 変更時は同一 reason が連続するため同様にまとめ通知へ収束する。

**項目 2 の後方互換設計**: ok/NG 判定は parse 結果の scheme/host のみに依存し正規化形と無関係なため、raw 形で保存済みの既存 subscription は送信側再検証 (`notification-service.ts`) で従来どおり通過する（テストで固定）。subscribe の既存チェックは正規化形で miss した場合に raw 形でも fallback 照合し、正規化導入前の保存分との重複 insert (= 二重通知) を防ぐ。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完のまま残っている AC がない）
- [x] Phase 分割した場合: N/A（Phase 分割なし、残 2 項目を本 PR で完遂）
- [x] UI 変更時: 該当なし（server-side のみ）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
