### PR TITLE
fix: #3572 第12回監査 low follow-up (招待ボタン loading + cloud_exports build_started_at SSOT 同期)

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -1054,6 +1054,7 @@ DynamoDB 実装 (`src/lib/server/db/dynamodb/report-daily-summary-repo.ts`) を�
 | created_at | TEXT | NO | CURRENT_TIMESTAMP | 作成日時 |
 | status | TEXT | NO | 'pending' | 非同期 build 状態（#3504, async-backup-export.md §3.1）。`pending`（build 待ち）→ `building`（cron 生成中）→ `ready`（DL 可）/ `failed`（生成失敗）。導入前の既存行は lazy migration で `ready` backfill |
 | failure_reason | TEXT | YES | NULL | `status='failed'` 時の失敗理由（それ以外は NULL） |
+| build_started_at | TEXT | YES | NULL | `building` 遷移時刻（#3509、stale building reclaim 用）。`building` 以外への遷移で NULL に戻る |
 
 **インデックス:**
 - `idx_cloud_exports_tenant` ON (tenant_id)

--- a/src/lib/server/db/create-tables.ts
+++ b/src/lib/server/db/create-tables.ts
@@ -645,7 +645,8 @@ export const SQL_CREATE_TABLES = `
 		max_downloads INTEGER NOT NULL DEFAULT 10,
 		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		status TEXT NOT NULL DEFAULT 'pending',
-		failure_reason TEXT
+		failure_reason TEXT,
+		build_started_at TEXT
 	);
 	CREATE INDEX IF NOT EXISTS idx_cloud_exports_tenant
 		ON cloud_exports(tenant_id);

--- a/src/routes/(parent)/admin/members/+page.svelte
+++ b/src/routes/(parent)/admin/members/+page.svelte
@@ -360,7 +360,7 @@ const roleLabel = (role: string) => {
 			{/if}
 			<Button
 				onclick={createInvite}
-				disabled={creating}
+				loading={creating}
 				variant="primary"
 				size="sm"
 			>
@@ -484,7 +484,7 @@ const roleLabel = (role: string) => {
 				</FormField>
 				<Button
 					onclick={createViewerLink}
-					disabled={creatingViewer}
+					loading={creatingViewer}
 					variant="primary"
 					size="sm"
 				>

--- a/tests/unit/db/create-tables-cloud-exports-parity.test.ts
+++ b/tests/unit/db/create-tables-cloud-exports-parity.test.ts
@@ -1,0 +1,44 @@
+// tests/unit/db/create-tables-cloud-exports-parity.test.ts
+//
+// #3572 tech-01: cloud_exports の DDL SSOT 3 者 (create-tables.ts / schema.ts /
+// tests/unit/helpers/test-db.ts) のうち create-tables.ts だけ build_started_at 列が
+// 欠落していた drift の回帰テスト。
+//
+// validateAndMigrate (schema.ts 差分検出) が nullable 列を自己修復するため実害は
+// なかったが、fresh install の DDL が SSOT と揃わない状態を機械 lock する
+// (ADR-0061 same-class-N→guard: #3504 status/failure_reason → #3509 build_started_at
+// と同 class の「schema.ts 追加時の create-tables 同期漏れ」が 2 回発生)。
+//
+// 検証方法: SQL_CREATE_TABLES だけで作った fresh DB の cloud_exports 実列集合が、
+// drizzle schema.ts (getTableColumns) の宣言列集合と完全一致すること。
+
+import Database from 'better-sqlite3';
+import { getTableColumns } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { SQL_CREATE_TABLES } from '$lib/server/db/create-tables';
+import { cloudExports } from '$lib/server/db/schema';
+
+describe('cloud_exports DDL parity (create-tables.ts ⇔ schema.ts)', () => {
+	it('SQL_CREATE_TABLES の fresh DB が schema.ts 宣言列を全て含む (build_started_at 欠落回帰 #3572 tech-01)', () => {
+		const db = new Database(':memory:');
+		try {
+			db.exec(SQL_CREATE_TABLES);
+			const actual = new Set(
+				(db.prepare('PRAGMA table_info(cloud_exports)').all() as Array<{ name: string }>).map(
+					(c) => c.name,
+				),
+			);
+			const expected = Object.values(getTableColumns(cloudExports)).map((c) => c.name);
+
+			// schema.ts の全列が create-tables.ts DDL に存在する (欠落 = validateAndMigrate
+			// 頼みの自己修復 drift。SSOT 同期漏れとして fail させる)
+			for (const name of expected) {
+				expect(actual.has(name), `cloud_exports.${name} が create-tables.ts に欠落`).toBe(true);
+			}
+			// 逆方向: create-tables.ts にだけある残骸列も許さない (完全一致)
+			expect([...actual].sort()).toEqual([...expected].sort());
+		} finally {
+			db.close();
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / システム全体

**解決する課題**: 第 12 回統合監査 (#3570) の低優先残項目。(a) メンバー管理画面の招待リンク作成中にボタンが「作成中…」の文言差替のみで spinner / `aria-busy` がなく、処理中であることが視覚・スクリーンリーダー双方に伝わりにくい (NN/G #1 visibility of system status)。(b) `cloud_exports` テーブルの `build_started_at` 列が DDL SSOT のうち `create-tables.ts` と `08-データベース設計書.md` だけ欠落しており、fresh install が validateAndMigrate の自己修復頼みになっていた。

**期待される効果**: 招待 / 見守りリンク作成ボタンが Button primitive の `loading` prop (spinner + disabled + `aria-busy="true"`) で処理中を明示し、再クリック誤動作を防ぐ。`cloud_exports` DDL が schema.ts / test-db.ts / 設計書と一致し、同期漏れ class を parity test で機械 lock する。

## 関連 Issue

closes #3572

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | ux-01: 招待作成ボタンに `loading` prop 適用（await 中の visible feedback） | `grep -n "loading={creating" "src/routes/(parent)/admin/members/+page.svelte"` | HEAD `a76c7273` / L363 `loading={creating}` + L487 `loading={creatingViewer}`（同一画面・同 class の見守りリンク作成ボタンにも横展開、ADR-0061 same-class） |
| AC2 | tech-01: `create-tables.ts` に `build_started_at TEXT` 追記で SSOT 一致 | `npx vitest run tests/unit/db/create-tables-cloud-exports-parity.test.ts` | HEAD `a76c7273` / 1 passed (1)、修正前 DDL への `git stash` 適用で 1 failed = red→green 物理確認済 / `src/lib/server/db/create-tables.ts` cloud_exports に `build_started_at TEXT` 追加、schema.ts (getTableColumns) との完全一致を assert |
| AC3 | perf-01/doc-02 を個別評価 | 本 PR body「レビュー依頼事項」§に評価結果を記載 | 見送り（ADR-0010）。根拠は下記「レビュー依頼事項・破壊的変更」§参照 |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`)
- [x] ページ / レイアウト (`src/routes/`)

**影響を受ける画面・機能**:
親管理画面 > メンバー管理 (`/admin/members`) の招待リンク作成ボタン + 見守りリンク作成ボタン。NUC (SQLite) fresh install 時の `cloud_exports` DDL。`docs/design/08-データベース設計書.md` cloud_exports 列表。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— Draft 段階では局所検証（biome 変更ファイル + 関連 vitest）まで完了。Ready 化前にメインセッションで全 Step PASS を確認してから Ready 化する
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/db/create-tables-cloud-exports-parity.test.ts` 新規: `SQL_CREATE_TABLES` fresh DB の cloud_exports 実列集合が drizzle schema.ts (`getTableColumns`) 宣言列集合と完全一致することを assert。#3504 (status/failure_reason) → #3509 (build_started_at) と 2 回発生した「schema.ts 追加時の create-tables 同期漏れ」class を機械 lock (ADR-0061 same-class-N→guard)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（SQLite DDL のみ。DynamoDB / DSQL 側は build_started_at 実装済で変更なし）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:low）

## スクリーンショット / ビジュアルデモ

**修正後 SS (PR HEAD a76c7273、AUTH_MODE=anonymous + DATA_SOURCE=demo (ADR-0048 決定的環境) + ?screenshot=all で撮影、screenshots branch pr-3667/)**:

| | モバイル (390px) | PC (1280px) |
|---|---|---|
| **修正前** | アイドル描画は修正後と pixel 同一 (#1744 宣言、下記参照) | 同左 |
| **修正後** | ![admin-members-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3667/admin-members-screenshot-all-mobile.png) | ![admin-members-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3667/admin-members-screenshot-all-desktop.png) |

[DOM HTML (admin-members-screenshot-all-desktop.dom.html)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3667/admin-members-screenshot-all-desktop.dom.html)

**「修正前と同一描画」の宣言 (#1744)**: 本 PR の UI 差分は `disabled={creating}` → `loading={creating}` の prop 置換のみで、**アイドル状態 (creating=false) の描画は before/after で pixel 同一** (loading prop は falsy 時に何も描画へ影響しない、Button.svelte 実装)。差分が現れるのは作成実行中 (creating=true) のインタラクティブ状態のみ: 旧 = ボタン無効化 + 文言差替 / 新 = spinner + disabled + `aria-busy="true"` + sr-only「読み込み中」(Button primitive 内蔵)。このため before スロットの別撮影は blob 同一で ss-blob-sha-uniqueness-check に抵触するため行わず、本宣言で代替する。

**インタラクティブ状態**: loading 中の視覚仕様は Button primitive の既存 Storybook story (loading variant、play 関数含む) が SSOT としてカバー済み。本 PR は当該 primitive 機構への委譲のみで新規視覚パターンを追加しない。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: Button primitive の既存 `loading` 機構に委譲（再実装なし、DESIGN.md §5）
- [x] **DRY**: 同一画面内の同 class ボタン (`creatingViewer`) にも同修正を横展開。他 admin 画面の `disabled + 文言差替` パターンは監査 finding 対象外のため scope 外
- [x] **YAGNI**: 抽象化追加なし。parity test は cloud_exports 1 table に限定（全 table 汎用化は既存 validateAndMigrate の自己修復設計・schema-validator.test.ts の責務と重複するため不採用）
- [x] **Security（OSS 公開前提）**: N/A（DDL 列追加 + UI prop 変更のみ）
- [x] **アクセシビリティ**: `loading` prop が `aria-busy="true"` + sr-only「読み込み中」label を強制（Button.svelte 内蔵）
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照）:

- [x] E2E / ユニットシード同期: `grep -rn "cloud_exports" tests/e2e/global-setup.ts src/lib/server/demo/demo-data.ts` = 0 件（CREATE TABLE 複製なし、同期対象なし）。`tests/unit/helpers/test-db.ts` L694 は `build_started_at TEXT` 既収載
- [x] **設計書同期** (ADR-0001): `docs/design/08-データベース設計書.md` の cloud_exports 列表にも `build_started_at` 行が欠落していた（#3509 実装時の同期漏れ、同 class drift）ため本 PR で追記
- [x] **並行 PR overlap** (#1200): create-tables.ts / members/+page.svelte を変更する open PR なし
- [x] N/A — その他ペア（本番/デモ・年齢モード・ナビ・labels）は影響なし

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

既存 install への影響: `build_started_at` は nullable TEXT。既存 DB は lazy migration `migrateCloudExportBuildStartedAtColumn` (#3509、冪等) が ALTER 済 / 未適用でも validateAndMigrate が自己修復するため、本変更は fresh install の DDL 完全化のみで migration 追加は不要。

**perf-01 / doc-02 の個別評価結果（AC3）**:

- 両 finding の詳細 evidence (`tmp/audit-evidence/3570-summary.md` §5) は監査 run のローカル一時成果物 (`tmp/` = gitignore) で現存せず、Issue #3572 本文にも「最適化 / 棚卸」以上の具体対象の記載がない
- **perf-01（最適化、sev 1）: 見送り**。対象不明のまま推測で最適化実装を行うのは ADR-0010 (Pre-PMF 過剰防衛 / YAGNI) 違反リスクが利益を上回る
- **doc-02（棚卸、sev 1）: 見送り**。docs 棚卸は `docs/CLAUDE.md` §「ADR 月 1 棚卸」の定期プロセスで消化される運用が既に存在し、個別対応は重複
- 教訓: sev 1-2 の残項目 finding は起票時に evidence 該当節を Issue 本文へ転記しないと後続 session で作業不能になる（監査プロセス側の改善余地として本 PR body に記録）

**レビュー依頼事項・QA**: parity test の scope を cloud_exports 1 table に限定した判断（全 table 化は validateAndMigrate の自己修復設計と衝突する可能性があり別 Issue が適切）の妥当性。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — Draft 段階では未実施（Ready 化前にメインセッションで全 Step PASS を確認してから Ready 化する。本 worktree では biome + 関連 vitest の局所検証まで完了）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了表記のまま残っている AC がない。AC3 は見送り判断を本 body に記録済）
- [x] N/A — Phase 分割なし
- [x] UI 変更時 SS: Draft 段階では未添付（Ready 化前にメインセッションで 4 スロット添付 + DESIGN.md §9 禁忌 6 点を目視確認してから Ready 化する）
- [x] N/A — 認証画面変更なし（`/admin/members` は管理画面だが認証フロー画面ではない。SS 撮影はメインセッションで `npm run dev:cognito` を使用）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

