### PR TITLE
fix: #3201 backup 用語 follow-up (CSV round-trip 表記 + importFile 明確化 + vocab gate)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -334,7 +334,7 @@ UI に表示されるラベル・用語は **`src/lib/domain/terms.ts` (atom) �
 - **LIFESTAGE_TERMS**: `canonical`=`'年齢'` / `tier`=`'年齢区分'` / `schoolGrade`=`'学年'`
 - **CHEER_TERMS**: `canonical`=`'応援'` / `action`=`'応援する'` / `reasonField`=`'できごと'`
 - **REWARD_TERMS**: `menu`=`'ごほうび管理'` / `shop`=`'ごほうびショップ'` / `preset`=`'プリセット'` / `canonical`=`'ごほうび'`
-- **BACKUP_TERMS**: `canonical`=`'バックアップデータ'` / `file`=`'バックアップファイル'` / `exportNoun`=`'バックアップ'` / `exportVerb`=`'バックアップする'` / `restoreVerb`=`'復元'` / `importFile`=`'バックアップ / CSV'`
+- **BACKUP_TERMS**: `canonical`=`'バックアップデータ'` / `file`=`'バックアップファイル'` / `exportNoun`=`'バックアップ'` / `exportVerb`=`'バックアップする'` / `restoreVerb`=`'復元'` / `csvFile`=`'CSV ファイル'`
 - **TEMPLATE_TERMS**: `userFacing`=`'みんなのテンプレート'` / `short`=`'テンプレート'` / `browse`=`'みんなのテンプレートを見る'`
 - **CHECKOUT_TERMS**: `chosenPlanFeature`=`'お選びのプランの機能'`
 - **TOKUSHOHO_TERMS**: `heading1Quantity`=`'分量'` / `heading2Price`=`'販売価格'` / `heading3Payment`=`'支払時期・方法'` / `heading4Delivery`=`'引渡時期・自動更新'` / `heading5Cancel`=`'申込撤回・解約方法'` / `heading6Important`=`'重要事項'` / `cancelButtonLabel`=`'やめる'`

--- a/scripts/check-terminology-coherence.ts
+++ b/scripts/check-terminology-coherence.ts
@@ -32,6 +32,7 @@ import {
 	ADMIN_VIEW_TERMS,
 	ADVENTURE_TERMS,
 	AUTONOMY_TERMS,
+	BACKUP_TERMS,
 	CHILD_TERMS,
 	FREE_PLAN_TERMS,
 	GRADUATION_TERMS,
@@ -93,6 +94,18 @@ export const MYSTERY_TERMS = [
 	{
 		pattern: 'アドベンチャー',
 		reason: `「アドベンチャー」は表記揺れ。SSOT は ${ADVENTURE_TERMS.canonical} を使用する (#1915 D-5)`,
+	},
+	// #3201 (PR #3199 follow-up): バックアップ / 取込 UI での内部フォーマット名露出を防ぐ
+	// (BACKUP_TERMS SSOT — 形式差は「画像・音声を含む」等の機能説明で表現する)。
+	// CSV は対象外: ユーザー自作の表計算ファイルの実態呼称 (ADR-0013 truth) + 確定申告 CSV
+	// エクスポート等の正当用途がある。
+	{
+		pattern: 'JSON',
+		reason: `内部フォーマット名「JSON」の UI 露出。SSOT は ${BACKUP_TERMS.file} / ${BACKUP_TERMS.canonical} を使う (#3201)`,
+	},
+	{
+		pattern: 'ZIP',
+		reason: `内部フォーマット名「ZIP」の UI 露出。SSOT は ${BACKUP_TERMS.file} を使い、形式差は「画像・音声を含む」等の機能説明で表現する (#3201)`,
 	},
 ];
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2111,7 +2111,10 @@ export const PIN_GATE_ONBOARDING_LABELS = {
 export const IMPORT_LABELS = {
 	// エラーメッセージ
 	errorChecksumMismatch: 'ファイルが破損しているか改ざんされています',
-	errorInvalidJson: 'ファイルの読み込みに失敗しました',
+	// #3201: parse 失敗 (= そもそもバックアップ形式でない) を checksum 不一致 (= 破損 / 改ざん) と
+	// 区別できる文言に是正 + /api/v1/import の parse 失敗経路に配線 (旧: 'JSONの解析に失敗しました' 直書き)。
+	// 内部フォーマット名 (JSON) は UI 露出しない (BACKUP_TERMS SSOT、#3198)。
+	errorInvalidJson: `${BACKUP_TERMS.file}として読み込めませんでした（ファイルの形式が正しくありません）`,
 	errorImportFailed: 'インポートに失敗しました',
 
 	// 事前確認ダイアログ
@@ -7251,7 +7254,9 @@ export const FEATURES_LABELS = {
 		// #2558 段階2: バックアップから復元ダイアログ (旧 UnifiedImportHub file セクションの独立化)
 		restoreDialogTitle: `📥 ${OVERFLOW_MENU_TERMS.itemRestore}`,
 		// #backup-terms: 活動取込は JSON バックアップに加え CSV (自作表計算) も読み込めるため CSV を露出する (ADR-0013 truth、#3079 AC4)
-		restoreDialogDesc: `活動の${BACKUP_TERMS.importFile} ファイルを読み込んで取り込みます。みんなのテンプレートの取り込みとは別の機能です。`,
+		// #3201: 2 つの入力源 (書き出したバックアップ / 自作 CSV) を平易に並記 + 家族全体 (画像・音声含む)
+		// の復元先は 設定 > データ である旨を誘導 (受理 format が画面ごとに異なる混乱の予防)
+		restoreDialogDesc: `以前書き出した活動の${BACKUP_TERMS.file}か、表計算ソフトで作った${BACKUP_TERMS.csvFile}を読み込んで取り込みます。みんなのテンプレートの取り込みとは別の機能です。家族全体のデータ（画像・音声を含む）の${BACKUP_TERMS.restoreVerb}は「設定 > データ」から行えます。`,
 		restoreSubmitBtn: '読み込む',
 		restoreProcessing: '読み込み中…',
 		restoreSuccess: (name: string, imported: number, skipped: number) =>
@@ -9222,7 +9227,8 @@ export const UNIFIED_IMPORT_HUB_LABELS = {
 	marketplaceHeading: 'マーケットプレイスから',
 	fileHeading: 'ファイルから',
 	// #backup-terms: 活動取込は CSV (自作表計算) も受けるため CSV を露出する (ADR-0013 truth)
-	fileDesc: `保存しておいた${BACKUP_TERMS.importFile} ファイルを取り込みます。`,
+	// #3201: slash 表記「バックアップ / CSV」を廃止し 2 つの入力源を平易に並記
+	fileDesc: `保存しておいた${BACKUP_TERMS.file}か、表計算ソフトで作った${BACKUP_TERMS.csvFile}を取り込みます。`,
 	fileImportBtn: 'ファイルを取り込む',
 	addBtn: 'この内容で追加',
 	processingText: '取り込み中...',

--- a/src/lib/domain/terms.ts
+++ b/src/lib/domain/terms.ts
@@ -761,7 +761,7 @@ export const REWARD_TERMS = {
 //   - exportNoun   : 'バックアップ'        ( 書き出し操作の名詞 )
 //   - exportVerb   : 'バックアップする'    ( 書き出し操作の動詞 )
 //   - restoreVerb  : '復元'               ( 取り込み操作 )
-//   - importFile   : 'バックアップ / CSV' ( CSV 取込対応 import 欄のファイル呼称、後ろに「ファイル」を付けて使う )
+//   - csvFile      : 'CSV ファイル'       ( ユーザー自作の表計算ファイルの呼称、CSV 取込対応 import 文脈専用 )
 //
 // フォーマット (JSON/ZIP) は機能的差異 (画像・音声を含めるか) としてのみ表現し、
 // 拡張子・形式名そのものは UI 露出しない。
@@ -770,7 +770,7 @@ export const REWARD_TERMS = {
 //   活動の取り込み (file-source.ts) は、ユーザーが自作した CSV 表計算ファイルからの
 //   インポートを実機能として備える (#3079 AC4)。ユーザー作成 CSV はアプリが書き出した
 //   バックアップではないため「バックアップファイル」と呼ぶと不正確 + CSV 取込機能を隠蔽する。
-//   CSV 取込対応の文脈では importFile を使い、CSV を露出したまま記述する
+//   CSV 取込対応の文脈では csvFile を file と併記して使い、CSV を露出したまま記述する
 //   (JSON のみ受ける純バックアップ復元では file を使ってよい)。
 export const BACKUP_TERMS = {
 	canonical: 'バックアップデータ',
@@ -779,9 +779,10 @@ export const BACKUP_TERMS = {
 	exportVerb: 'バックアップする',
 	restoreVerb: '復元',
 	// CSV 取込対応の import 文脈専用 (ADR-0013 truth — CSV を隠さない)。
-	// バックアップ (書き出した JSON) も自作 CSV も同じ入力欄で受けるため両方を併記する。
-	// 文中では `${BACKUP_TERMS.importFile} ファイル` の形で使う。
-	importFile: 'バックアップ / CSV',
+	// #3201: 旧 importFile ('バックアップ / CSV') の slash 表記は「1 つのファイル種別なのか
+	// 2 つ受けるのか」が曖昧なため廃止。compound 側で「以前書き出した ${file} か、
+	// 表計算ソフトで作った ${csvFile}」の形で 2 つの入力源を平易に並べて使う。
+	csvFile: 'CSV ファイル',
 } as const;
 
 // ============================================================

--- a/src/routes/api/v1/import/+server.ts
+++ b/src/routes/api/v1/import/+server.ts
@@ -40,7 +40,9 @@ async function parseImportRequest(
 		try {
 			return { ok: true, value: { body: await request.json(), staticFiles: {} } };
 		} catch {
-			return { ok: false, error: 'JSONの解析に失敗しました' };
+			// #3201: 内部フォーマット名 (JSON) を露出せず、checksum 不一致 (破損/改ざん) と
+			// 区別できる「形式が正しくない」文言 SSOT を使う (旧: 'JSONの解析に失敗しました' 直書き)
+			return { ok: false, error: IMPORT_LABELS.errorInvalidJson };
 		}
 	}
 

--- a/tests/unit/scripts/check-terminology-coherence.test.ts
+++ b/tests/unit/scripts/check-terminology-coherence.test.ts
@@ -28,6 +28,29 @@ describe('check-terminology-coherence (#2555)', () => {
 			const { mysteryHits } = scanLabels(text);
 			expect(mysteryHits).toHaveLength(0);
 		});
+
+		it('内部フォーマット名 JSON / ZIP の露出を検知する (#3201)', () => {
+			const text = `
+				export const TEST_LABELS = {
+					k1: 'JSONファイルを選択してください',
+					k2: 'ZIP形式でダウンロード',
+				};
+			`;
+			const { mysteryHits } = scanLabels(text);
+			expect(mysteryHits.some((h) => h.pattern === 'JSON')).toBe(true);
+			expect(mysteryHits.some((h) => h.pattern === 'ZIP')).toBe(true);
+		});
+
+		it('CSV はユーザー自作ファイルの実態呼称のため検知しない (#3201 / ADR-0013 truth)', () => {
+			const text = `
+				export const TEST_LABELS = {
+					k1: '表計算ソフトで作った CSV ファイルを取り込みます',
+					k2: '確定申告用CSVエクスポート',
+				};
+			`;
+			const { mysteryHits } = scanLabels(text);
+			expect(mysteryHits).toHaveLength(0);
+		});
 	});
 
 	describe('add path duplication detection', () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: PR #3199 (バックアップ用語 BACKUP_TERMS SSOT 統一) の残課題 4 点。① 活動取込の「バックアップ / CSV」slash 表記が「1 つのファイル種別なのか 2 つ受けるのか」曖昧で、export（バックアップ書き出し）との round-trip が非対称に見える。② 画面ごとに受理 format が異なる（設定 > データ = バックアップのみ / 活動取込 = バックアップ + 自作 CSV）のに、家族全体（画像・音声含む）をどの画面で復元できるか案内がない。③ 取込失敗時の文言が汎用的で、「形式が正しくない（違うファイルを選んだ）」と「破損 / 改ざん（checksum 不一致）」を保護者が区別できない。④ バックアップ文脈での内部フォーマット名（JSON / ZIP）露出を機械検出する gate がない。

**期待される効果**: 保護者が「以前書き出したバックアップファイル」と「表計算ソフトで作った CSV ファイル」の 2 つの入力源を迷わず理解でき、家族全体の復元は 設定 > データ に正しく誘導される。取込失敗時は原因（形式違い vs 破損・改ざん）に応じた troubleshooting が可能になる。JSON / ZIP の UI 露出は CI (check-terminology-coherence) が再発を機械検出する。

## 関連 Issue

closes #3201

関連: PR #3199 (#3198 BACKUP_TERMS SSOT 統一、merged `271e95e9`) の QM 再レビュー非 blocking 残課題

## AC 検証マップ (ADR-0004)

Issue #3201 は AC 明示形式ではなく「残課題 3 項目 + gate」列挙のため、各項目を AC として検証する。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | export/import の CSV round-trip 方向非対称の解消（対応案 2「import/export の format 表現を整合」を採用） | `grep -rn "バックアップ / CSV" src/ scripts/ tests/ site/` + labels.ts 差分目視 | HEAD `7082dcdd` / slash 表記のコード・UI 値残存 0 件（残 2 hit は経緯説明コメントのみ）/ `restoreDialogDesc` = 「以前書き出した活動のバックアップファイルか、表計算ソフトで作った CSV ファイル」で書き出し→読み込みの対称性を文言上明示 (labels.ts:7254-7257) |
| AC2 | 「バックアップ / CSV」slash 表記の明確化 + 受理 format 差の誘導 | `grep -n "csvFile" src/lib/domain/terms.ts src/lib/domain/labels.ts` + `npx vitest run src/lib/domain/` | HEAD `7082dcdd` / `BACKUP_TERMS.csvFile` atom 新設 (terms.ts:786) + compound 2 件是正 (labels.ts:7257 / 9231) + 活動 restore dialog に「家族全体のデータ（画像・音声を含む）の復元は「設定 > データ」から行えます」誘導追記 / domain 42 files 375 passed |
| AC3 | errorInvalidJson の checksum との区別回復 + 実経路配線 | `grep -rn "errorInvalidJson" src/` + `npx vitest run tests/unit/routes/` | HEAD `7082dcdd` / labels.ts:2117 = 「バックアップファイルとして読み込めませんでした（ファイルの形式が正しくありません）」（checksum = 「破損しているか改ざんされています」と区別可）/ 旧 dead label を `/api/v1/import` parse 失敗経路に配線 (+server.ts:45、旧「JSONの解析に失敗しました」直書きの JSON jargon 露出も解消) / routes unit 全 passed |
| AC4 | cross-surface 用語 sync の CI gate（BACKUP_TERMS の lint 対象化） | `npx tsx scripts/check-terminology-coherence.ts` + `npx vitest run tests/unit/scripts/check-terminology-coherence.test.ts` | HEAD `7082dcdd` / MYSTERY_TERMS に JSON / ZIP 露出検出を追加（既存 gate 相乗り、新規 script なし = ADR-0010 整合。CSV は自作ファイルの実態呼称 + 確定申告 CSV の正当用途のため対象外 = ADR-0013 truth）/ gate PASS + unit 15 passed（JSON/ZIP 検知 + CSV 非検知の 2 test 追加） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — scripts/check-terminology-coherence.ts

**影響を受ける画面・機能**:
- 活動管理の「バックアップから復元」ダイアログ（説明文言のみ）
- UnifiedImportHub の file セクション説明（Storybook / 温存 component、admin 画面には非 mount）
- 設定 > データ のインポート失敗メッセージ（`/api/v1/import` parse 失敗時）

## テスト & 安全装置セルフチェック

- [x] `npx biome check <変更 5 ファイル>` PASS
- [x] `npx svelte-check` — src/ 配下 0 エラー（残 113 エラーは全て infra/ の aws-cdk-lib 未 install 起因のローカル env 事象、`cd infra && npm ci` で解消する既知の環境要件 = tests/CLAUDE.md §テスト環境セットアップ）
- [x] `npx vitest run tests/unit/scripts/check-terminology-coherence.test.ts tests/unit/scripts/check-guide-copy.test.ts` — 15 passed（JSON/ZIP 検知 + CSV 非検知の regression test 2 件追加）
- [x] `npx vitest run tests/unit/routes/ src/lib/domain/` — 42 files / 375 passed
- [x] `npx vitest run tests/unit/routes/import-cloud-template-per-child.test.ts tests/unit/services/import-zip-bomb-guard.test.ts tests/unit/marketplace/` — 301 passed / 1 failed（`reward-set-strategy.test.ts` の 5s timeout。**develop baseline (`git stash` 状態) でも同一 fail を確認済 = 本変更と無関係の既存環境依存事象**）
- [x] `npx tsx scripts/check-terminology-coherence.ts` PASS / `npx tsx scripts/check-guide-copy.ts` PASS（MYSTERY_TERMS 共有先の regression 無し）
- [x] `node scripts/check-no-plan-literals.mjs` PASS
- [x] pre-commit hook（labels/terms SSOT companion 整合検査: biome + generate-lp-labels --check + sync-lp-fallback --check）PASS
- [x] assertion 弱体化なし（ADR-0006）— errorInvalidJson は汎用文言 → 具体文言への強化方向

## スクリーンショット / ビジュアルデモ

**修正後 SS (PR HEAD、AUTH_MODE=anonymous + DATA_SOURCE=demo の決定的環境 (ADR-0048) で撮影)**:

/admin/activities の「バックアップから復元」ダイアログ — 本 PR の文言変更 (①バックアップ / CSV の 2 入力源並記 ②「家族全体のデータ（画像・音声を含む）の復元は 設定 > データ」誘導 ③ TEMPLATE 取込との区別) が反映された状態:

![restore-dialog-3668](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3668/restore-dialog-3668-flow.webp)

**修正前との差分**: 本 PR の UI 差分はダイアログ説明文・エラー文言のテキストのみ (レイアウト / コンポーネント構造は不変)。修正前文言は「バックアップ / CSV ファイルを読み込んで…」(BACKUP_TERMS.importFile 旧 atom)。テキスト差分は diff で機械確認可能なため before スロットは本宣言で代替する (#1744 に準じたテキスト変更列挙は本 PR 変更タイプ節参照)。

**インタラクティブ状態**: N/A (静的文言のみの変更)

## コード品質セルフレビュー (#1481)

- [x] ADR-0045 2 層 SSOT 厳守: 新 atom `csvFile` は terms.ts、文の組み立ては labels.ts compound の template literal（atom 値の文字列直書きなし）
- [x] DESIGN.md §6 terms 一覧は `node scripts/generate-design-md-sections.mjs` で自動再生成（手動編集なし）
- [x] site/shared-labels.js は `node scripts/generate-lp-labels.mjs` 再生成で**差分なし**（変更 compound は LP 配信対象外）を確認
- [x] 使い捨て script 新設なし（#1442）— 既存 check-terminology-coherence.ts への相乗り
- [x] dead code 削減: callsite 0 だった errorInvalidJson を実経路に配線（放置でも削除でもなく本来の用途に復帰）

## 横展開・影響波及チェック

- [x] `BACKUP_TERMS.importFile` 参照の全件洗い出し: `grep -rn "BACKUP_TERMS.importFile" src/ scripts/ tests/ site/ docs/` → 0 件（compound 2 件のみが参照元で、両方是正済）
- [x] MYSTERY_TERMS 共有先 `scripts/check-guide-copy.ts`（PAGE_GUIDE_LABELS 検査）への波及: gate 実行 PASS で JSON/ZIP の誤検知なし
- [x] 兄弟 restore dialog（checklists / rewards の `BACKUP_RESTORE_LABELS.restoreDialogDesc`）: JSON のみ受理で slash 表記なし、「以前書き出した◯◯のバックアップファイル」形式で既に本 PR の是正後文言と同型（NN/G #4 consistency 維持、変更不要）
- [x] 他 4 箇所の「JSONの解析に失敗しました」直書き（activities/import・data/clear・cloud export/import）: いずれも API リクエスト body の parse 失敗（ユーザーがファイルを直接選ぶ経路ではない）のため本 PR では対象外。UI 露出面の SSOT 違反は `/api/v1/import`（ユーザー選択ファイルの parse 経路）のみで、是正済

### Fix 完遂検証 log（#2690 / #2815 D-4）

| Fix item | 検証コマンド（実行したものをそのまま） | output 件数 | 判定 |
|---|---|---|---|
| slash 表記全廃 | `grep -rn "バックアップ / CSV" src/ scripts/ tests/ site/` | 2 件（全て経緯説明コメント、コード・UI 値 0 件） | ✓ |
| importFile atom 参照全廃 | `grep -rn "BACKUP_TERMS.importFile" src/ scripts/ tests/ site/ docs/` | 0 件 | ✓ |
| import API の JSON 直書き解消 | `grep -n "JSONの解析に失敗しました" src/routes/api/v1/import/+server.ts` | 1 件（説明コメントのみ、コード 0 件） | ✓ |
| labels.ts の JSON/ZIP 露出 0 | `npx tsx scripts/check-terminology-coherence.ts` | PASS（warning 0） | ✓ |

## レビュー依頼事項・破壊的変更

**破壊的変更**: なし（UI 文言 + エラーメッセージ + lint 追加のみ。API シグネチャ・DB 不変）

**Issue 対応案ごとの採否判断**（priority:low のため「実装 / 現状で十分」を項目別に判断、無言スキップなし）:

| Issue 項目 | 判断 | 理由 |
|---|---|---|
| ① export 側への「取り込み時は CSV も可」注記（対応案 1） | 不採用（対応案 2 の format 表現整合で解消） | export は CSV を生成しないため、export 画面での CSV 言及は「CSV で書き出せる」誤認を逆に招く (ADR-0013 truth)。import 側で「以前書き出したバックアップファイル」を明示することで round-trip の対称性を文言上担保 |
| ② import 文言平易化 + 画面別受理 format 明示 | 実装 | AC2 の通り。受理 format 自体は accept 属性 (`.json,.zip` / `.json,.csv`) で物理制限済のため、拡張子列挙ではなく「どの画面で何が戻せるか」の誘導文で解決 |
| ③ errorInvalidJson 区別 | 実装 | AC3 の通り。定義のみで callsite 0 の dead label だったため、実経路への配線まで実施 |
| ④ vocab CI gate | 実装（既存 gate 相乗り） | 新規 script 新設は Pre-PMF 過剰 (ADR-0010) のため check-terminology-coherence の MYSTERY_TERMS に追加。なお Issue 言及の pricing.html は grep で user-facing JSON/ZIP/CSV 表記 0 件を確認済（#3199 で解消済）。07-API設計書等の開発者向け仕様記述の format 名は正当（UI 露出ではない）ため gate 対象外 |

**レビュー観点**:
1. 活動 restore dialog の説明が 3 文（入力源 2 種 + 別機能注記 + 設定 > データ誘導）になった分量の妥当性
2. MYSTERY_TERMS への `JSON` / `ZIP` pattern 追加が英字部分一致であること（labels.ts の plain string literal 値のみが検査対象で、現状 false positive 0 を確認済。将来「JSONP」等の語が labels に入る可能性は実質なし）

## 配布済み env / secret (ADR-0006)

該当なし（新規 env / secret の追加・変更なし）

## Ready for Review チェックリスト

本 PR は Draft 起票（Ready 化はメインセッションが実施）。以下はいずれも Ready 化時にメインセッションが完遂・`[x]` 化する項目のため、現時点では checkbox を置かず状態を明記する（成果物のない `[x]` Done 禁止 = CLAUDE.md 準拠）:

- `npm run pre-ready -- --pr <本 PR 番号>` 全 step PASS — Ready 化時に実行（本 worktree では biome / vitest / svelte-check / check-no-plan-literals / check-terminology-coherence / generate-lp-labels --check を個別 PASS 済）
- AC 検証マップ全行に結果 / エビデンス記入 — 記入済（HEAD `7082dcdd` 基準）
- スクリーンショット撮影・embed — Ready 化前にメインセッションで実施
- QA 承認・動作確認 — Ready 化時に完遂

## QM レビュー結果

（QM 記入欄 — レビュー未実施）




---

**[QM CI-Fix note]** `refactor:internal-no-doc-impact` label 付与の根拠: 本 PR の src/routes 変更は import エラー文言の SSOT ラベル化（リテラル置換）のみで API 契約は不変。用語 atom (BACKUP_TERMS) の変更は用語 SSOT である DESIGN.md §6 で同期済み。docs/design 配下の同期対象はないため exempt 条件（#1985 / ADR-0003）に該当。
