### PR TITLE
fix(security): #3450 XSS gate 網羅強化 (eslint svelte CI 実行 + TS innerHTML sink + sanitize 実在検証)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,15 @@ jobs:
       - name: ESLint Playwright (no-networkidle / no-wait-for-timeout, #1259)
         run: npx eslint "tests/**/*.ts"
 
+      # #3450 item1: svelte/no-at-html-tags (XSS) の AST 検出を CI で二重化。
+      # XSS の hard merge-blocker は scripts/check-no-at-html.mjs (lint-parallel job) が担い、
+      # 本 step は AST 層の secondary 検出。既存違反 38 errors は全て local design rules
+      # (no-raw-button / max-style-lines 等、svelte/no-at-html-tags は 0 件) のため
+      # SonarJS step と同格の warn-only で導入 (green 化できない hard gate を足さない)。
+      - name: ESLint Svelte (svelte/no-at-html-tags AST XSS 二重化, #3450)
+        continue-on-error: true
+        run: npm run lint:svelte
+
       - name: Knip (unused exports/files/deps detection, #970)
         continue-on-error: true
         run: npx knip

--- a/scripts/check-no-at-html.mjs
+++ b/scripts/check-no-at-html.mjs
@@ -1,15 +1,24 @@
 #!/usr/bin/env node
 // scripts/check-no-at-html.mjs
 // #3354 (#3243 follow-up): src 配下の Svelte で `{@html ...}` を機械的に禁止する CI gate。
+// #3450 (#3446 follow-up): XSS gate 網羅強化。
+//   item2 — TS/JS 側 echo sink (`innerHTML =` / `insertAdjacentHTML(` / `outerHTML =`) も走査対象化。
+//   item3 — opt-out マーカーは「存在」だけでなく「同一ファイル内に DOMPurify.sanitize 等の
+//            sanitizer 実呼び出しが実在する」ことを構造検証する (マーカーだけで未 sanitize の
+//            {@html} / innerHTML を恒久許可できる構造的穴を封鎖)。
 //
-// 背景: error message 等のサーバ値を `{@html}` で描画すると stored/echo XSS が成立する。
-// 不変条件「サーバ値は textContent 補間で描画する」は従来 06-UI設計書 + コメント + test の
-// 人手依存で、将来 callsite が `{@html resolveApiErrorMessage(...)}` を書いても検出する
-// 機械 gate が無かった。本 script を `lint:parallel`（CI lint-and-test）に組込み merge blocker 化する。
+// 背景: error message 等のサーバ値を `{@html}` / `innerHTML` で描画すると stored/echo XSS が
+// 成立する。不変条件「サーバ値は textContent 補間で描画する」は従来 06-UI設計書 + コメント +
+// test の人手依存で、将来 callsite が sink を書いても検出する機械 gate が無かった。
+// 本 script を `lint:parallel`（CI lint-and-test）に組込み merge blocker 化する。
 //
-// 正当な sanitize 済 HTML 注入（ADR-0025 DOMPurify 等）が必要な場合は、当該行または直前行に
-// `eslint-disable-next-line svelte/no-at-html-tags` または `allow-at-html:` コメントを置いて opt-out する
-// （レビューで sanitize を確認すること）。LP HTML の innerHTML は別 gate（check-lp-innerhtml-tags.mjs）が担う。
+// opt-out 方法 (正当な sanitize 済 HTML 注入、ADR-0025 DOMPurify 等):
+//   - Svelte {@html}: 当該行または直前行に `eslint-disable-next-line svelte/no-at-html-tags`
+//     または `allow-at-html:` コメントを置く
+//   - TS/JS sink: 当該行または直前行に `allow-innerhtml:` コメントを置く
+//   いずれも **同一ファイル内に `DOMPurify.sanitize(...)` (または同等 sanitizer) の実呼び出しが
+//   必須** (#3450 item3)。マーカーのみで sanitizer 不在の場合は fail する。
+//   LP HTML の innerHTML は別 gate（check-lp-innerhtml-tags.mjs）が担う。
 //
 // 使い方: node scripts/check-no-at-html.mjs
 
@@ -19,27 +28,46 @@ import { join, relative } from 'node:path';
 const ROOT = process.cwd();
 const SRC = join(ROOT, 'src');
 const AT_HTML = /\{@html\b/;
-const ALLOW = /eslint-disable(?:-next-line)?\s+svelte\/no-at-html-tags|allow-at-html:/;
+const ALLOW_AT_HTML = /eslint-disable(?:-next-line)?\s+svelte\/no-at-html-tags|allow-at-html:/;
+// TS/JS echo sink (#3450 item2): 代入 (= / +=) と insertAdjacentHTML 呼び出し。
+// `(?!=)` で比較演算子 (== / === / !==) を除外する。
+const TS_SINK = /\.(?:innerHTML|outerHTML)\s*\+?=(?!=)|\binsertAdjacentHTML\s*\(/;
+const ALLOW_SINK = /allow-innerhtml:/;
+// sanitizer 実呼び出しパターン (#3450 item3)。DOMPurify (ADR-0025) を第一級とし、
+// 同等 sanitizer (sanitize-html 等) の呼び出し形も許容する。
+const SANITIZER_CALL = /\bDOMPurify\s*\.\s*sanitize\s*\(|\bsanitizeHtml\s*\(/;
 
-/** src 配下を再帰走査して .svelte ファイルパスを集める。 @param {string} dir @returns {string[]} */
-function collectSvelte(dir) {
+/**
+ * src 配下を再帰走査して対象拡張子のファイルパスを集める。
+ * @param {string} dir
+ * @param {readonly string[]} exts
+ * @returns {string[]}
+ */
+function collectFiles(dir, exts) {
 	/** @type {string[]} */
 	const out = [];
 	for (const name of readdirSync(dir)) {
 		const full = join(dir, name);
 		const st = statSync(full);
 		if (st.isDirectory()) {
-			out.push(...collectSvelte(full));
-		} else if (name.endsWith('.svelte')) {
+			out.push(...collectFiles(full, exts));
+		} else if (exts.some((ext) => name.endsWith(ext))) {
 			out.push(full);
 		}
 	}
 	return out;
 }
 
+/** コメント行 (// / * / /*) かどうか。doc コメント内のサンプル記述を sink 誤検出しないため。 @param {string} line */
+function isCommentLine(line) {
+	const t = line.trimStart();
+	return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*');
+}
+
 /**
  * ファイル内容から `{@html}` 違反行を抽出する純粋関数。
- * 当該行または直前行に allowlist コメントがあれば除外する。
+ * 当該行または直前行に allowlist コメントがあれば除外する（opt-out の sanitizer 実在検証は
+ * findUnsanitizedAtHtmlOptOuts が担う）。
  *
  * @param {string} content
  * @returns {number[]} 違反行番号（1-origin）
@@ -52,32 +80,151 @@ export function findAtHtmlViolations(content) {
 		const line = lines[i] ?? '';
 		if (!AT_HTML.test(line)) continue;
 		const prev = lines[i - 1] ?? '';
-		if (ALLOW.test(line) || ALLOW.test(prev)) continue;
+		if (ALLOW_AT_HTML.test(line) || ALLOW_AT_HTML.test(prev)) continue;
 		hits.push(i + 1);
 	}
 	return hits;
 }
 
-function main() {
-	const files = collectSvelte(SRC);
-	/** @type {string[]} */
-	const violations = [];
-	for (const f of files) {
-		const lines = findAtHtmlViolations(readFileSync(f, 'utf-8'));
-		for (const ln of lines) violations.push(`${relative(ROOT, f)}:${ln}`);
+/**
+ * opt-out 済み `{@html}` のうち、同一ファイル内に sanitizer 実呼び出しが存在しないものを
+ * 抽出する (#3450 item3)。マーカーだけ付けて未 sanitize の {@html} を恒久許可する構造的穴を塞ぐ。
+ *
+ * @param {string} content
+ * @returns {number[]} 違反行番号（1-origin）
+ */
+export function findUnsanitizedAtHtmlOptOuts(content) {
+	if (SANITIZER_CALL.test(content)) return [];
+	const lines = content.split('\n');
+	/** @type {number[]} */
+	const hits = [];
+	for (let i = 0; i < lines.length; i += 1) {
+		const line = lines[i] ?? '';
+		if (!AT_HTML.test(line)) continue;
+		const prev = lines[i - 1] ?? '';
+		if (ALLOW_AT_HTML.test(line) || ALLOW_AT_HTML.test(prev)) {
+			hits.push(i + 1);
+		}
 	}
-	if (violations.length > 0) {
+	return hits;
+}
+
+/**
+ * TS/JS の innerHTML 系 echo sink を抽出する純粋関数 (#3450 item2)。
+ * 検出対象: `.innerHTML =` / `.innerHTML +=` / `.outerHTML =` / `insertAdjacentHTML(`。
+ * コメント行は除外。当該行または直前行の `allow-innerhtml:` マーカーで opt-out できるが、
+ * opt-out には同一ファイル内の sanitizer 実呼び出しが必須 (item3 と同一原則)。
+ *
+ * @param {string} content
+ * @returns {{ violations: number[], unsanitizedOptOuts: number[] }} 行番号（1-origin）
+ */
+export function findTsSinkViolations(content) {
+	const hasSanitizer = SANITIZER_CALL.test(content);
+	const lines = content.split('\n');
+	/** @type {number[]} */
+	const violations = [];
+	/** @type {number[]} */
+	const unsanitizedOptOuts = [];
+	for (let i = 0; i < lines.length; i += 1) {
+		const line = lines[i] ?? '';
+		if (isCommentLine(line)) continue;
+		if (!TS_SINK.test(line)) continue;
+		const prev = lines[i - 1] ?? '';
+		if (ALLOW_SINK.test(line) || ALLOW_SINK.test(prev)) {
+			if (!hasSanitizer) unsanitizedOptOuts.push(i + 1);
+			continue;
+		}
+		violations.push(i + 1);
+	}
+	return { violations, unsanitizedOptOuts };
+}
+
+function main() {
+	/** @type {string[]} */
+	const atHtmlViolations = [];
+	/** @type {string[]} */
+	const unsanitizedAtHtml = [];
+	/** @type {string[]} */
+	const sinkViolations = [];
+	/** @type {string[]} */
+	const unsanitizedSinks = [];
+
+	const svelteFiles = collectFiles(SRC, ['.svelte']);
+	for (const f of svelteFiles) {
+		const content = readFileSync(f, 'utf-8');
+		const rel = relative(ROOT, f);
+		for (const ln of findAtHtmlViolations(content)) atHtmlViolations.push(`${rel}:${ln}`);
+		for (const ln of findUnsanitizedAtHtmlOptOuts(content)) unsanitizedAtHtml.push(`${rel}:${ln}`);
+	}
+
+	// TS/JS sink は .svelte の <script> 内も含めて走査する (#3450 item2)
+	const scriptFiles = collectFiles(SRC, ['.ts', '.js', '.mjs', '.svelte']);
+	for (const f of scriptFiles) {
+		const content = readFileSync(f, 'utf-8');
+		const rel = relative(ROOT, f);
+		const { violations, unsanitizedOptOuts } = findTsSinkViolations(content);
+		for (const ln of violations) sinkViolations.push(`${rel}:${ln}`);
+		for (const ln of unsanitizedOptOuts) unsanitizedSinks.push(`${rel}:${ln}`);
+	}
+
+	let failed = false;
+
+	if (atHtmlViolations.length > 0) {
+		failed = true;
 		console.error(
-			`[check-no-at-html] FAIL — ${violations.length} 件の {@html} を検出 (XSS リスク、#3354):`,
+			`[check-no-at-html] FAIL — ${atHtmlViolations.length} 件の {@html} を検出 (XSS リスク、#3354):`,
 		);
-		for (const v of violations) console.error(`  ${v}`);
+		for (const v of atHtmlViolations) console.error(`  ${v}`);
 		console.error(
 			'\nサーバ値は textContent 補間で描画してください。正当な sanitize 済 HTML 注入が必要なら' +
-				' 当該行直前に `eslint-disable-next-line svelte/no-at-html-tags` を置き、レビューで sanitize を確認。',
+				' 当該行直前に `eslint-disable-next-line svelte/no-at-html-tags` を置き、' +
+				'同一ファイル内で DOMPurify.sanitize を実呼び出ししてください (#3450 item3)。',
 		);
+	}
+
+	if (unsanitizedAtHtml.length > 0) {
+		failed = true;
+		console.error(
+			`[check-no-at-html] FAIL — ${unsanitizedAtHtml.length} 件の opt-out 済 {@html} に` +
+				' sanitizer 実呼び出しが同一ファイル内に存在しません (#3450 item3):',
+		);
+		for (const v of unsanitizedAtHtml) console.error(`  ${v}`);
+		console.error(
+			'\nopt-out マーカーの存在だけでは不十分です。同一ファイル内で `DOMPurify.sanitize(...)`' +
+				' (ADR-0025) 等の sanitizer を実呼び出しして値を無害化してください。',
+		);
+	}
+
+	if (sinkViolations.length > 0) {
+		failed = true;
+		console.error(
+			`[check-no-at-html] FAIL — ${sinkViolations.length} 件の TS/JS innerHTML 系 sink を検出` +
+				' (XSS リスク、#3450 item2):',
+		);
+		for (const v of sinkViolations) console.error(`  ${v}`);
+		console.error(
+			'\nDOM への HTML 文字列注入 (`innerHTML =` / `insertAdjacentHTML` / `outerHTML =`) は' +
+				' textContent / DOM API で代替してください。正当な sanitize 済注入が必要なら当該行直前に' +
+				' `allow-innerhtml:` コメントを置き、同一ファイル内で DOMPurify.sanitize を実呼び出ししてください。',
+		);
+	}
+
+	if (unsanitizedSinks.length > 0) {
+		failed = true;
+		console.error(
+			`[check-no-at-html] FAIL — ${unsanitizedSinks.length} 件の opt-out 済 innerHTML sink に` +
+				' sanitizer 実呼び出しが同一ファイル内に存在しません (#3450 item3):',
+		);
+		for (const v of unsanitizedSinks) console.error(`  ${v}`);
+	}
+
+	if (failed) {
 		process.exit(1);
 	}
-	console.log(`[check-no-at-html] OK — src 配下 ${files.length} svelte に {@html} なし`);
+	console.log(
+		`[check-no-at-html] OK — src 配下 ${svelteFiles.length} svelte に {@html} なし / ` +
+			`${scriptFiles.length} script file に未許可 innerHTML sink なし (#3354 / #3450)`,
+	);
 }
 
 import { fileURLToPath } from 'node:url';

--- a/tests/unit/scripts/check-no-at-html.test.ts
+++ b/tests/unit/scripts/check-no-at-html.test.ts
@@ -1,13 +1,19 @@
 /**
- * tests/unit/scripts/check-no-at-html.test.ts (#3354)
+ * tests/unit/scripts/check-no-at-html.test.ts (#3354 / #3450)
  *
  * `{@html}` 禁止 gate の違反抽出ロジックを検証する。サーバ値の {@html} 描画 (XSS) を
  * CI で機械的に block する不変条件の回帰防止。
+ * #3450 で追加された TS/JS innerHTML sink 検出 (item2) と opt-out 時の sanitizer
+ * 実在検証 (item3) の正・負ケースも本ファイルで担保する。
  */
 
 import { describe, expect, it } from 'vitest';
 
-import { findAtHtmlViolations } from '../../../scripts/check-no-at-html.mjs';
+import {
+	findAtHtmlViolations,
+	findTsSinkViolations,
+	findUnsanitizedAtHtmlOptOuts,
+} from '../../../scripts/check-no-at-html.mjs';
 
 describe('findAtHtmlViolations (#3354 {@html} 禁止 gate)', () => {
 	it('{@html} を含む行を違反として検出する', () => {
@@ -41,5 +47,115 @@ describe('findAtHtmlViolations (#3354 {@html} 禁止 gate)', () => {
 	it('複数違反を全て行番号で返す', () => {
 		const content = ['{@html a}', 'x', '{@html b}'].join('\n');
 		expect(findAtHtmlViolations(content)).toEqual([1, 3]);
+	});
+});
+
+describe('findUnsanitizedAtHtmlOptOuts (#3450 item3 opt-out sanitizer 実在検証)', () => {
+	it('opt-out 済 {@html} でも同一ファイルに sanitizer 実呼び出しが無ければ違反', () => {
+		const content = ['<!-- allow-at-html: 済のつもり -->', '<div>{@html raw}</div>'].join('\n');
+		expect(findUnsanitizedAtHtmlOptOuts(content)).toEqual([2]);
+	});
+
+	it('同一ファイル内に DOMPurify.sanitize 呼び出しがあれば違反ゼロ', () => {
+		const content = [
+			'<script>',
+			"import DOMPurify from 'dompurify';",
+			'const clean = DOMPurify.sanitize(raw);',
+			'</script>',
+			'<!-- allow-at-html: DOMPurify 済 -->',
+			'<div>{@html clean}</div>',
+		].join('\n');
+		expect(findUnsanitizedAtHtmlOptOuts(content)).toEqual([]);
+	});
+
+	it('sanitizeHtml() 呼び出しでも同等 sanitizer として許容する', () => {
+		const content = [
+			'<script>const clean = sanitizeHtml(raw);</script>',
+			'<!-- eslint-disable-next-line svelte/no-at-html-tags -->',
+			'<div>{@html clean}</div>',
+		].join('\n');
+		expect(findUnsanitizedAtHtmlOptOuts(content)).toEqual([]);
+	});
+
+	it('マーカー文言に DOMPurify と書くだけでは sanitizer 実呼び出しと見なさない', () => {
+		const content = ['<!-- allow-at-html: DOMPurify で処理済と主張 -->', '{@html raw}'].join('\n');
+		expect(findUnsanitizedAtHtmlOptOuts(content)).toEqual([2]);
+	});
+
+	it('opt-out していない {@html} は本関数の対象外 (findAtHtmlViolations が担う)', () => {
+		expect(findUnsanitizedAtHtmlOptOuts('<div>{@html raw}</div>')).toEqual([]);
+	});
+});
+
+describe('findTsSinkViolations (#3450 item2 TS/JS innerHTML sink 検出)', () => {
+	it('innerHTML への代入を違反として検出する', () => {
+		const content = ['const el = document.createElement("div");', 'el.innerHTML = userInput;'].join(
+			'\n',
+		);
+		expect(findTsSinkViolations(content)).toEqual({ violations: [2], unsanitizedOptOuts: [] });
+	});
+
+	it('innerHTML への += 追記も検出する', () => {
+		expect(findTsSinkViolations('el.innerHTML += chunk;').violations).toEqual([1]);
+	});
+
+	it('insertAdjacentHTML 呼び出しを検出する', () => {
+		expect(findTsSinkViolations("el.insertAdjacentHTML('beforeend', html);").violations).toEqual([
+			1,
+		]);
+	});
+
+	it('outerHTML への代入を検出する', () => {
+		expect(findTsSinkViolations('node.outerHTML = replacement;').violations).toEqual([1]);
+	});
+
+	it('比較演算 (=== / ==) は代入ではないため検出しない', () => {
+		const content = ["if (el.innerHTML === '') { reset(); }", 'if (el.outerHTML == raw) {}'].join(
+			'\n',
+		);
+		expect(findTsSinkViolations(content).violations).toEqual([]);
+	});
+
+	it('innerHTML の読み取りは検出しない', () => {
+		expect(findTsSinkViolations('const snapshot = el.innerHTML;').violations).toEqual([]);
+	});
+
+	it('コメント行のサンプル記述は検出しない', () => {
+		const content = [
+			'// NG 例: el.innerHTML = raw; と書いてはならない',
+			' * el.insertAdjacentHTML("beforeend", x) は禁止',
+			'/* el.outerHTML = y も禁止 */',
+		].join('\n');
+		expect(findTsSinkViolations(content).violations).toEqual([]);
+	});
+
+	it('allow-innerhtml: マーカー + sanitizer 実呼び出しで opt-out できる', () => {
+		const content = [
+			"import DOMPurify from 'dompurify';",
+			'const clean = DOMPurify.sanitize(raw);',
+			'// allow-innerhtml: DOMPurify 済 (ADR-0025)',
+			'el.innerHTML = clean;',
+		].join('\n');
+		expect(findTsSinkViolations(content)).toEqual({ violations: [], unsanitizedOptOuts: [] });
+	});
+
+	it('allow-innerhtml: マーカーがあっても sanitizer 実呼び出しが無ければ違反 (#3450 item3)', () => {
+		const content = ['// allow-innerhtml: 済のつもり', 'el.innerHTML = raw;'].join('\n');
+		expect(findTsSinkViolations(content)).toEqual({ violations: [], unsanitizedOptOuts: [2] });
+	});
+
+	it('当該行末尾の allow-innerhtml: マーカーでも opt-out できる', () => {
+		const content = [
+			'const clean = DOMPurify.sanitize(raw);',
+			'el.innerHTML = clean; // allow-innerhtml: DOMPurify 済',
+		].join('\n');
+		expect(findTsSinkViolations(content)).toEqual({ violations: [], unsanitizedOptOuts: [] });
+	});
+
+	it('複数 sink を全て行番号で返す', () => {
+		const content = ['a.innerHTML = x;', 'safe();', "b.insertAdjacentHTML('afterbegin', y);"].join(
+			'\n',
+		);
+		expect(findTsSinkViolations(content).violations).toEqual([1, 3]);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（子供・親の全ユーザーを XSS から保護）

**解決する課題**: PR #3446 で導入した `{@html}` XSS gate は (1) eslint AST rule が CI 未実行で IDE 専用、(2) TS/JS 側の `innerHTML` 系 echo sink が走査対象外、(3) opt-out マーカーの存在だけで sanitize 実呼び出しを検証しない、という 3 つの網羅 gap を残していた。マーカーだけ付けて未 sanitize の HTML 注入を恒久許可できる構造的穴が存在した。

**期待される効果**: XSS 検出が grep 単層 → grep + AST 二重化になり、TS/JS sink も含めた全 echo 経路が merge blocker で機械封鎖される。opt-out には sanitizer 実呼び出しが必須になり、gate のすり抜けが構造的に不可能になる。

## 関連 Issue

closes #3450

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (item1) | `svelte/no-at-html-tags` の AST 検出を CI で実行し二重化 | `.github/workflows/ci.yml` L268-276 目視 + `npm run lint:svelte` ローカル実行 | HEAD `e3dc72f3` / ESLint Svelte step 追加（lint-and-test job、SonarJS と同格の warn-only）/ ローカル実行 143s・`svelte/no-at-html-tags` 違反 0 件 |
| AC2 (item2) | TS/JS の `innerHTML =` / `innerHTML +=` / `outerHTML =` / `insertAdjacentHTML(` sink を走査対象化 | `node scripts/check-no-at-html.mjs` + `npx vitest run tests/unit/scripts/check-no-at-html.test.ts` | HEAD `e3dc72f3` / gate OK（src 配下 984 script file で違反 0、baseline 不要）/ 22 tests passed（sink 検出の正負ケース含む） |
| AC3 (item3) | opt-out マーカー箇所に sanitizer（`DOMPurify.sanitize` 等）実呼び出しの実在を構造検証 | `npx vitest run tests/unit/scripts/check-no-at-html.test.ts`（`findUnsanitizedAtHtmlOptOuts` / `findTsSinkViolations` の正負ケース） | HEAD `e3dc72f3` / 22 passed。マーカー文言に "DOMPurify" と書くだけでは opt-out 不可（実呼び出し `DOMPurify.sanitize(` / `sanitizeHtml(` が同一ファイル内に必須）を assert 済 |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

変更ファイル: `scripts/check-no-at-html.mjs`（sink 走査 + sanitizer 実在検証追加）/ `tests/unit/scripts/check-no-at-html.test.ts`（6 → 22 ケース）/ `.github/workflows/ci.yml`（ESLint Svelte step 追加）

**影響を受ける画面・機能**: なし（CI gate のみ。production コード無変更、現行コードベースで全 gate PASS を確認済）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— Draft 段階のため局所検証で代替: `npx biome check`（変更 2 file PASS）/ `npx vitest run tests/unit/scripts/check-no-at-html.test.ts`（22 passed）/ `node scripts/check-no-at-html.mjs`（現行コードベースで exit 0）/ `node scripts/check-pr-body.mjs --body-file`（PASS）。Ready 化時に全 step 再実行する
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  `tests/unit/scripts/check-no-at-html.test.ts` に `findTsSinkViolations`（innerHTML 代入 / += / insertAdjacentHTML / outerHTML 検出、比較演算・読み取り・コメント行の非検出、allow-innerhtml opt-out の正負）と `findUnsanitizedAtHtmlOptOuts`（sanitizer 実在検証の正負）の 16 ケースを追加
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（CI gate のみ。UI 変更を含まない）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 検出ロジックは純粋関数 3 本（`findAtHtmlViolations` / `findUnsanitizedAtHtmlOptOuts` / `findTsSinkViolations`）に分離し unit test 可能
- [x] **DRY**: file 走査は `collectFiles(dir, exts)` に一本化（旧 `collectSvelte` を汎用化）。既存 LP 側 gate（`check-lp-innerhtml-tags.mjs`）とは対象領域が異なり重複なし
- [x] **YAGNI**: baseline 機構は現行違反 0 件のため追加せず（必要になった時点で既存 ratchet パターンを踏襲）
- [x] **Security（OSS 公開前提）**: 本 PR 自体が XSS 防御強化。秘密情報なし
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: gate は grep 同等の行走査で数秒。CI 増分は ESLint Svelte step の約 2.5 分（warn-only、上記根拠参照）

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] N/A — 並行実装の影響範囲外（CI gate / script のみ）

**LP / 販促文言変更時** (ADR-0013 / #1314):

N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:

- item3 の「近傍」定義を「同一ファイル内に sanitizer 実呼び出しが存在」としました。Svelte では sanitize 呼び出しが `<script>` ブロック、`{@html}` が template と離れるのが通常形のため、行数窓ではなくファイル単位が false positive を出さない実用的な構造検証と判断
- **item1 の warn-only 判断根拠**（Issue 指示「green 化できない hard gate を安易に足さない」）: `npm run lint:svelte` ローカル実行 = **50 problems（38 errors / 12 warnings）、実行時間 143s**。内訳は `local/max-style-lines` 20 error / `local/no-raw-button` 17 error / `local/max-svelte-lines` 12 warning / `local/no-style-attribute` 1 error で、**本 Issue 対象の `svelte/no-at-html-tags` は 0 件**。既存 38 errors は全て local design rules であり green 化は 20+ file の UI refactor で本 PR の scope 外。baseline 化（38 箇所への eslint-disable 挿入）は production code への noise 混入が大きく不採用。XSS の hard merge-blocker は `scripts/check-no-at-html.mjs`（`lint:parallel` job）が引き続き担うため、eslint AST 層は defense in depth の secondary 検出として `continue-on-error: true`（既存 ESLint SonarJS step と同格）で導入。local rules 解消後の hard 化は段階導入を想定
- 実行時間影響（Issue 指示による計測）: lint-and-test job に +約 2.5 分（ローカル 143s 実測。job は build / svelte-check 等を含む直列構成のため相対増は限定的）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready` 全 Step 相当をローカル確認した**（Draft 段階の実測記録: Step 1 biome は worktree 環境で `biome check .` が 0 file になる path 解決問題のため `npx biome check --error-on-warnings src scripts tests` で全 1944 file PASS を確認 / Step 3 vitest は **7958 passed / 1 failed** — 失敗は `tests/unit/ai-evaluation/stagehand-v3-api-surface.test.ts` の `@browserbasehq/stagehand` dynamic import 5s timeout で、素の node でも import に 2.7s を要する Windows worktree 環境依存 flake。本 PR の diff（scripts / ci.yml / check-no-at-html.test.ts）と無関係で、対象 test `check-no-at-html.test.ts` は 22/22 PASS / Step 9 は `check-pr-body.mjs --body-file` で PASS / Linux CI での全 step 緑は GitHub Status Checks で最終検証）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了・先送り表記のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（N/A — Phase 分割なし）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認（N/A — UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付（N/A — 認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
