### PR TITLE
fix(auth): #3561 owner-gate seam hardening (403 文言 SSOT + guard hoist + 401 伝播)

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -398,7 +398,7 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 | `DELETE /api/v1/admin/members/[userId]`（メンバー削除） | `['owner']` | 403 |
 | `POST /api/v1/admin/members/[userId]/transfer-ownership`（owner 移譲） | `['owner']` | 403 |
 
-- **response 形の互換**: 既存 client（`admin/members/+page.svelte` が `d.error` を表示）が依存する `{ error: <日本語文言> }` body 形と 403 status を維持するため、`requireRole` が throw する `HttpError(403)` を `isHttpError(e, 403)` で捕捉し、endpoint 固有の `{ error }` JSON に変換して返す（401 等は re-throw）。
+- **response 形の互換**: 既存 client（`admin/members/+page.svelte` が `d.error` を表示）が依存する `{ error: <日本語文言> }` body 形と 403 status を維持するため、`requireRole` が throw する `HttpError(403)` を捕捉し、endpoint 固有の `{ error }` JSON に変換して返す。members 系 2 endpoint（メンバー削除 / owner 移譲）はこの変換を共通 helper `ownerGateResponse`（`src/lib/server/auth/owner-gate.ts`、#3561）に集約し、403 文言は `OWNER_GATE_LABELS`（`src/lib/domain/labels.ts` SSOT、ADR-0062）から参照する。invites 系 2 endpoint はハンドラ内で `isHttpError(e, 403)` を捕捉する形（401 等は re-throw）。
 - **UI 整合**: `admin/members/+page.svelte` は `currentRole === 'owner'` のときのみ招待リンク作成カード・保留中招待の取消ボタンを描画し、parent には招待 UI 自体を非表示にして 403 到達導線を消す（API gate と UI 非表示の二段）。
 - **fitness function**: `tests/unit/routes/admin-role-mutation-authz.test.ts` が 4 endpoint すべてで owner → 成功経路 / parent・child → 403 + `{ error }` body 維持、および判定が `requireRole(locals, ['owner'])` seam 経由であることを spy で機械検証する。
 
@@ -423,8 +423,9 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 | `POST /api/v1/admin/tenant/cancel`（解約申請） | `['owner']` | 403 |
 | `POST /api/v1/admin/tenant/reactivate`（解約キャンセル） | `['owner']` | 403 |
 
-- **response 形の互換**: 既存 client が依存する endpoint 固有の `{ error: <日本語文言> }` body と 403 status を維持するため、`requireRole` が throw する `HttpError(403)` を `isHttpError(e, 403)` で捕捉して各 endpoint の `{ error }` JSON に変換する（401 等は re-throw）。`account/delete` は 3 pattern で判定を共有するため `ownerGuardResponse(locals)` helper に集約する。
-- **fitness function**: `tests/unit/routes/admin-owner-guard-rollout.test.ts` が 4 endpoint（`account/delete` は 3 pattern）で owner → 成功経路 / parent・child → 403 + `{ error }` body バイト一致維持、および判定が `requireRole(locals, ['owner'])` seam 経由であることを spy で機械検証する。
+- **response 形の互換（#3561 ①③ で helper 集約）**: 既存 client が依存する endpoint 固有の `{ error: <日本語文言> }` body と 403 status を維持するため、`requireRole` が throw する `HttpError` を共通 helper `ownerGateResponse(locals, forbiddenMessage)`（`src/lib/server/auth/owner-gate.ts`）で `{ error }` JSON に変換する。403 文言は `OWNER_GATE_LABELS`（`src/lib/domain/labels.ts` SSOT、ADR-0062 error body 統一）から参照し、値は置換前ハードコードとバイト一致。`HttpError(401)`（認証 context 欠落）も `{ error: 認証が必要です }` の 401 JSON に変換し、上流の `!context` 早期 return が将来消えても outer try/catch で 500 化しない（401 伝播頑健化）。401/403 以外の例外は re-throw。
+- **guard hoist（#3561 ②）**: `account/delete` は本人操作 pattern（`child` / `member`、switch 内で本人 role を個別検証）以外を handler 先頭の single choke-point で owner-gate 必須通過とする（default-deny）。将来 owner 系 pattern を追加しても guard の付け忘れが構造的に発生しない。副作用として、未知 pattern は非 owner に対し 400 より先に 403 を返す。
+- **fitness function**: `tests/unit/routes/admin-owner-guard-rollout.test.ts` が 4 endpoint（`account/delete` は 3 pattern）で owner → 成功経路 / parent・child → 403 + `{ error }` body バイト一致維持、判定が `requireRole(locals, ['owner'])` seam 経由であること、403 文言 = `OWNER_GATE_LABELS` の一致、未知 pattern への default-deny、および `requireRole` の 401 throw が 500 化せず 401 `{ error }` に変換されること（requireRole override 注入）を機械検証する。helper 単体は `tests/unit/auth/owner-gate.test.ts` が 401 / 403 / owner 通過 / 非 HttpError re-throw を検証する。
 
 ### 5.3 ライセンス状態による制限
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -472,6 +472,40 @@ export const PLAN_GATE_LABELS = {
 	lockedItemIcon: '🔒',
 } as const;
 
+// ============================================================
+// OWNER_GATE_LABELS — owner-gate 403 / 401 エラー文言 SSOT (#3561 ①③)
+// ============================================================
+//
+// account / tenant / members 系 owner-gate endpoint (requireRole(locals, ['owner'])
+// seam、#3528 fitness#3 / #3556) の {error} body 文言を PLAN_GATE_LABELS 同様に
+// compound 層へ集約する (ADR-0062 §2 error body 統一の territory)。既存 client
+// 互換のため、各値は置換前のハードコード文言とバイト一致で維持する。
+// endpoint 側の変換 helper は src/lib/server/auth/owner-gate.ts (ownerGateResponse)。
+
+/** "owner のみ{action}できます" — owner-gate 403 文言の共通テンプレート (#3561 ①) */
+const ownerOnly = (action: string) => `owner のみ${action}できます`;
+
+export const OWNER_GATE_LABELS = {
+	/**
+	 * 401: 認証コンテキスト欠落。requireRole が throw する HttpError(401) を
+	 * endpoint 文言へ変換する際の body (#3561 ③)。各 endpoint 上流の
+	 * `!context` 早期 return と同一文言（バイト一致）。
+	 */
+	authRequired: '認証が必要です',
+	/** POST api/v1/admin/account/delete (owner 系 3 pattern 共通) */
+	accountDelete: ownerOnly('実行'),
+	/** GET api/v1/admin/account/deletion-info */
+	deletionInfo: ownerOnly('取得'),
+	/** POST api/v1/admin/tenant/cancel */
+	tenantCancel: ownerOnly(`${CANCEL_TERMS.canonical}申請`),
+	/** POST api/v1/admin/tenant/reactivate */
+	tenantReactivate: ownerOnly(`${CANCEL_TERMS.canonical}キャンセル`),
+	/** DELETE api/v1/admin/members/[userId] */
+	memberDelete: ownerOnly('メンバーを削除'),
+	/** POST api/v1/admin/members/[userId]/transfer-ownership */
+	transferOwnership: ownerOnly('権限を移譲'),
+} as const;
+
 export const SUBSCRIPTION_PLAN_LABELS: Record<string, string> = {
 	monthly: 'スタンダード月額',
 	yearly: 'スタンダード年額',

--- a/src/lib/server/auth/owner-gate.ts
+++ b/src/lib/server/auth/owner-gate.ts
@@ -1,0 +1,38 @@
+// src/lib/server/auth/owner-gate.ts
+// owner-gate seam の共通 Response 変換 (#3561、#3558 follow-up)
+//
+// requireRole(locals, ['owner']) seam (#3528 fitness#3 / #3556) が throw する
+// HttpError を、既存 client 互換の {error} JSON body へ変換する共通 helper。
+// account / tenant / members 系の owner-gate endpoint はハンドラ内に
+// try/catch を複製せず本 helper を経由する。
+//
+// - 403: endpoint 別文言 (OWNER_GATE_LABELS、#3561 ①) を呼び出し側が指定
+// - 401: 上流の `!context` 早期 return が将来リファクタで消えても outer
+//   try/catch での 500 化 (潜在退行) をさせず、上流と同一文言の
+//   `{error}` 401 JSON に変換する (#3561 ③)
+// - それ以外の HttpError / 例外は re-throw (呼び出し側の責務)
+
+import { isHttpError, json } from '@sveltejs/kit';
+import { OWNER_GATE_LABELS } from '$lib/domain/labels';
+import { requireRole } from './guards';
+
+/**
+ * owner-gate 判定を requireRole seam 経由で行い、結果を Response に変換する。
+ *
+ * @returns owner なら null（続行可）。非 owner なら 403 Response、
+ *          認証コンテキスト欠落なら 401 Response。
+ */
+export function ownerGateResponse(locals: App.Locals, forbiddenMessage: string): Response | null {
+	try {
+		requireRole(locals, ['owner']);
+		return null;
+	} catch (e) {
+		if (isHttpError(e, 401)) {
+			return json({ error: OWNER_GATE_LABELS.authRequired }, { status: 401 });
+		}
+		if (isHttpError(e, 403)) {
+			return json({ error: forbiddenMessage }, { status: 403 });
+		}
+		throw e;
+	}
+}

--- a/src/routes/api/v1/admin/account/delete/+server.ts
+++ b/src/routes/api/v1/admin/account/delete/+server.ts
@@ -17,9 +17,10 @@
 // 詳細: docs/design/account-deletion-flow.md §3 / §4.2 (#741 Stripe キャンセル先行原則)。
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { isHttpError, json } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
-import { requireRole } from '$lib/server/auth/guards';
+import { OWNER_GATE_LABELS } from '$lib/domain/labels';
+import { ownerGateResponse } from '$lib/server/auth/owner-gate';
 import { logger } from '$lib/server/logger';
 import {
 	deleteChildAccount,
@@ -41,20 +42,13 @@ interface DeleteRequestBody {
 	newOwnerId?: string;
 }
 
-// #3556: owner 系 3 pattern (owner-only / owner-with-transfer / owner-full-delete) の
-// role 判定は requireRole seam (#3528 fitness#3) に統一。response 形は既存 client 互換の
-// {error} JSON を維持する（403 の status / body は置換前とバイト一致）。
-function ownerGuardResponse(locals: App.Locals): Response | null {
-	try {
-		requireRole(locals, ['owner']);
-		return null;
-	} catch (e) {
-		if (isHttpError(e, 403)) {
-			return json({ error: 'owner のみ実行できます' }, { status: 403 });
-		}
-		throw e;
-	}
-}
+// #3561 ②: 本人操作（自分自身の削除）pattern。これ以外の pattern は owner-gate を
+// handler 先頭の single choke-point で必須通過させる（default-deny）。将来 4 つ目の
+// owner 系 pattern を追加しても guard の付け忘れが構造的に発生しない。
+const SELF_SERVICE_PATTERNS: ReadonlySet<DeleteRequestBody['pattern']> = new Set([
+	'child',
+	'member',
+]);
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: 複雑なビジネスロジックのため、別 Issue でリファクタ予定
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -80,14 +74,21 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		return json({ error: 'pattern パラメータが必要です' }, { status: 400 });
 	}
 
+	// #3561 ②: owner-gate single choke-point (guard hoist、#3558 follow-up)。
+	// SELF_SERVICE_PATTERNS (child / member、後段の switch 内で本人 role を個別検証)
+	// 以外の pattern は、未知 pattern を含めここで owner-gate を必須通過させる
+	// (default-deny: 非 owner の未知 pattern は 400 より先に 403 を返す)。
+	// 403 / 401 の {error} body 変換は ownerGateResponse (owner-gate.ts) に集約。
+	if (!SELF_SERVICE_PATTERNS.has(pattern)) {
+		const guard = ownerGateResponse(locals, OWNER_GATE_LABELS.accountDelete);
+		if (guard) {
+			return guard;
+		}
+	}
+
 	try {
 		switch (pattern) {
 			case 'owner-only': {
-				const guard = ownerGuardResponse(locals);
-				if (guard) {
-					return guard;
-				}
-
 				// #1781: プラン別グレースピリオド配線。
 				// 経路選択は plan tier で決まる（free=即時 / standard=7d / family=30d）。
 				//
@@ -137,10 +138,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			}
 
 			case 'owner-with-transfer': {
-				const guard = ownerGuardResponse(locals);
-				if (guard) {
-					return guard;
-				}
 				if (!newOwnerId) {
 					return json({ error: '移譲先 (newOwnerId) が必要です' }, { status: 400 });
 				}
@@ -152,11 +149,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			}
 
 			case 'owner-full-delete': {
-				const guard = ownerGuardResponse(locals);
-				if (guard) {
-					return guard;
-				}
-
 				// #1781: 全削除パターンも同様にグレースピリオドを適用する。
 				// 有料プランでは soft-delete のみ実施し、cron が物理削除時に
 				// 全メンバーの Cognito 削除と他メンバーへのメール通知を行う。

--- a/src/routes/api/v1/admin/account/deletion-info/+server.ts
+++ b/src/routes/api/v1/admin/account/deletion-info/+server.ts
@@ -2,8 +2,10 @@
 // Owner 削除前の情報取得（他メンバー一覧、移譲先候補）
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { isHttpError, json } from '@sveltejs/kit';
-import { requireRole } from '$lib/server/auth/guards';
+import { json } from '@sveltejs/kit';
+import { ERROR_NOTIFY_LABELS, OWNER_GATE_LABELS } from '$lib/domain/labels';
+import { ownerGateResponse } from '$lib/server/auth/owner-gate';
+import { logger } from '$lib/server/logger';
 import { getOwnerDeletionInfo } from '$lib/server/services/account-deletion-service';
 
 export const GET: RequestHandler = async ({ locals }) => {
@@ -17,20 +19,22 @@ export const GET: RequestHandler = async ({ locals }) => {
 	const tenantId = context.tenantId;
 
 	// #3556: role 判定は requireRole seam (#3528 fitness#3) に統一。
-	// response 形は既存 client 互換の {error} JSON を維持する
-	try {
-		requireRole(locals, ['owner']);
-	} catch (e) {
-		if (isHttpError(e, 403)) {
-			return json({ error: 'owner のみ取得できます' }, { status: 403 });
-		}
-		throw e;
+	// #3561: 403 文言は OWNER_GATE_LABELS (SSOT)、401/403 変換は ownerGateResponse に集約。
+	const guard = ownerGateResponse(locals, OWNER_GATE_LABELS.deletionInfo);
+	if (guard) {
+		return guard;
 	}
 
 	try {
 		const info = await getOwnerDeletionInfo(tenantId, identity.userId);
 		return json(info);
 	} catch (err) {
-		return json({ error: String(err) }, { status: 500 });
+		// ADR-0062 §2: 内部例外メッセージ (String(err)) をユーザに露出しない。
+		// 生例外は logger のみに残し、レスポンスは固定のユーザ向け文言にする (#3561)。
+		logger.error('[deletion-info] 削除前情報取得失敗', {
+			error: String(err),
+			context: { tenantId },
+		});
+		return json({ error: ERROR_NOTIFY_LABELS.server }, { status: 500 });
 	}
 };

--- a/src/routes/api/v1/admin/members/[userId]/+server.ts
+++ b/src/routes/api/v1/admin/members/[userId]/+server.ts
@@ -2,8 +2,9 @@
 // メンバー削除（owner のみ）
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { isHttpError, json } from '@sveltejs/kit';
-import { requireRole } from '$lib/server/auth/guards';
+import { json } from '@sveltejs/kit';
+import { OWNER_GATE_LABELS } from '$lib/domain/labels';
+import { ownerGateResponse } from '$lib/server/auth/owner-gate';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { sendMemberRemovedEmail } from '$lib/server/services/email-service';
@@ -17,14 +18,11 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 	const targetUserId = (params as Record<string, string>).userId ?? '';
 
 	// #3528: role 判定は requireRole seam に統一。response 形は既存 client
-	// (admin/members/+page.svelte が d.error を表示) 互換の {error} JSON を維持する
-	try {
-		requireRole(locals, ['owner']);
-	} catch (e) {
-		if (isHttpError(e, 403)) {
-			return json({ error: 'owner のみメンバーを削除できます' }, { status: 403 });
-		}
-		throw e;
+	// (admin/members/+page.svelte が d.error を表示) 互換の {error} JSON を維持する。
+	// #3561: 403 文言は OWNER_GATE_LABELS (SSOT)、401/403 変換は ownerGateResponse に集約。
+	const guard = ownerGateResponse(locals, OWNER_GATE_LABELS.memberDelete);
+	if (guard) {
+		return guard;
 	}
 
 	if (!targetUserId) {

--- a/src/routes/api/v1/admin/members/[userId]/transfer-ownership/+server.ts
+++ b/src/routes/api/v1/admin/members/[userId]/transfer-ownership/+server.ts
@@ -2,8 +2,9 @@
 // owner 権限移譲（owner のみ）
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { isHttpError, json } from '@sveltejs/kit';
-import { requireRole } from '$lib/server/auth/guards';
+import { json } from '@sveltejs/kit';
+import { OWNER_GATE_LABELS } from '$lib/domain/labels';
+import { ownerGateResponse } from '$lib/server/auth/owner-gate';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { sendMemberJoinedEmail } from '$lib/server/services/email-service';
@@ -18,14 +19,11 @@ export const POST: RequestHandler = async ({ params, locals }) => {
 	const targetUserId = (params as Record<string, string>).userId ?? '';
 
 	// #3528: role 判定は requireRole seam に統一。response 形は既存 client
-	// (admin/members/+page.svelte が d.error を表示) 互換の {error} JSON を維持する
-	try {
-		requireRole(locals, ['owner']);
-	} catch (e) {
-		if (isHttpError(e, 403)) {
-			return json({ error: 'owner のみ権限を移譲できます' }, { status: 403 });
-		}
-		throw e;
+	// (admin/members/+page.svelte が d.error を表示) 互換の {error} JSON を維持する。
+	// #3561: 403 文言は OWNER_GATE_LABELS (SSOT)、401/403 変換は ownerGateResponse に集約。
+	const guard = ownerGateResponse(locals, OWNER_GATE_LABELS.transferOwnership);
+	if (guard) {
+		return guard;
 	}
 
 	if (!identity || identity.type !== 'cognito') {

--- a/src/routes/api/v1/admin/tenant/cancel/+server.ts
+++ b/src/routes/api/v1/admin/tenant/cancel/+server.ts
@@ -16,9 +16,10 @@
 // DB 更新をスキップさせる（#741 のアカウント削除と同じパターン）。
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { error, isHttpError, json } from '@sveltejs/kit';
+import { error, json } from '@sveltejs/kit';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
-import { requireRole } from '$lib/server/auth/guards';
+import { OWNER_GATE_LABELS } from '$lib/domain/labels';
+import { ownerGateResponse } from '$lib/server/auth/owner-gate';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { notifyCancellation } from '$lib/server/services/discord-notify-service';
@@ -35,14 +36,10 @@ export const POST: RequestHandler = async ({ locals }) => {
 	}
 
 	// #3556: role 判定は requireRole seam (#3528 fitness#3) に統一。
-	// response 形は既存 client 互換の {error} JSON を維持する
-	try {
-		requireRole(locals, ['owner']);
-	} catch (e) {
-		if (isHttpError(e, 403)) {
-			return json({ error: 'owner のみ解約申請できます' }, { status: 403 });
-		}
-		throw e;
+	// #3561: 403 文言は OWNER_GATE_LABELS (SSOT)、401/403 変換は ownerGateResponse に集約。
+	const guard = ownerGateResponse(locals, OWNER_GATE_LABELS.tenantCancel);
+	if (guard) {
+		return guard;
 	}
 
 	const tenantId = context.tenantId;

--- a/src/routes/api/v1/admin/tenant/reactivate/+server.ts
+++ b/src/routes/api/v1/admin/tenant/reactivate/+server.ts
@@ -8,9 +8,10 @@
 // 誘導する。
 
 import type { RequestHandler } from '@sveltejs/kit';
-import { isHttpError, json } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
-import { requireRole } from '$lib/server/auth/guards';
+import { OWNER_GATE_LABELS } from '$lib/domain/labels';
+import { ownerGateResponse } from '$lib/server/auth/owner-gate';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { notifyCancellationReverted } from '$lib/server/services/discord-notify-service';
@@ -23,14 +24,10 @@ export const POST: RequestHandler = async ({ locals }) => {
 	}
 
 	// #3556: role 判定は requireRole seam (#3528 fitness#3) に統一。
-	// response 形は既存 client 互換の {error} JSON を維持する
-	try {
-		requireRole(locals, ['owner']);
-	} catch (e) {
-		if (isHttpError(e, 403)) {
-			return json({ error: 'owner のみ解約キャンセルできます' }, { status: 403 });
-		}
-		throw e;
+	// #3561: 403 文言は OWNER_GATE_LABELS (SSOT)、401/403 変換は ownerGateResponse に集約。
+	const guard = ownerGateResponse(locals, OWNER_GATE_LABELS.tenantReactivate);
+	if (guard) {
+		return guard;
 	}
 
 	const tenantId = context.tenantId;

--- a/tests/unit/auth/owner-gate.test.ts
+++ b/tests/unit/auth/owner-gate.test.ts
@@ -1,0 +1,60 @@
+// tests/unit/auth/owner-gate.test.ts
+// #3561 (#3558 follow-up): owner-gate seam 共通 Response 変換 helper
+// (src/lib/server/auth/owner-gate.ts ownerGateResponse) の直接検証。
+//
+// テスト観点:
+// - ① 403: 非 owner は呼び出し側指定の文言 (OWNER_GATE_LABELS SSOT) で 403 JSON
+// - ③ 401: 認証 context 欠落 (requireRole が throw する HttpError(401)) は
+//   500 化させず `{error: 認証が必要です}` 401 JSON へ変換する (機械検証)
+// - owner は null (続行可)
+// - HttpError(401/403) 以外の例外は re-throw (握りつぶさない)
+
+import { describe, expect, it } from 'vitest';
+import { OWNER_GATE_LABELS } from '../../../src/lib/domain/labels';
+import { ownerGateResponse } from '../../../src/lib/server/auth/owner-gate';
+
+type Role = 'owner' | 'parent' | 'child';
+
+function createLocals(role: Role | null): App.Locals {
+	return {
+		context: role ? { tenantId: 't-test', role } : null,
+	} as unknown as App.Locals;
+}
+
+describe('ownerGateResponse (#3561 owner-gate seam hardening)', () => {
+	it('owner は null を返し続行可 (positive)', () => {
+		expect(ownerGateResponse(createLocals('owner'), OWNER_GATE_LABELS.accountDelete)).toBeNull();
+	});
+
+	for (const role of ['parent', 'child'] as const) {
+		it(`${role} は 403 + 呼び出し側指定の {error} body (① SSOT 文言)`, async () => {
+			const res = ownerGateResponse(createLocals(role), OWNER_GATE_LABELS.tenantCancel);
+			expect(res).not.toBeNull();
+			expect(res?.status).toBe(403);
+			await expect(res?.json()).resolves.toEqual({ error: OWNER_GATE_LABELS.tenantCancel });
+		});
+	}
+
+	it('認証 context 欠落は 500 化せず 401 + {error: 認証が必要です} に変換される (③ 401 伝播頑健化)', async () => {
+		// requireRole は !locals.context で HttpError(401) を throw する。
+		// 上流の `!context` 早期 return が将来消えても、本 helper が 401 JSON に
+		// 変換するため outer try/catch での 500 化 (潜在退行) が起きないことを機械検証。
+		const res = ownerGateResponse(createLocals(null), OWNER_GATE_LABELS.accountDelete);
+		expect(res).not.toBeNull();
+		expect(res?.status).toBe(401);
+		await expect(res?.json()).resolves.toEqual({ error: OWNER_GATE_LABELS.authRequired });
+	});
+
+	it('401/403 の HttpError 以外は re-throw する (握りつぶし禁止)', () => {
+		// requireRole を通常経路で通過させず、locals 参照自体が失敗する異常系を模す。
+		// (context getter が throw する = HttpError ではない例外)
+		const broken = {
+			get context(): never {
+				throw new Error('unexpected non-http error');
+			},
+		} as unknown as App.Locals;
+		expect(() => ownerGateResponse(broken, OWNER_GATE_LABELS.accountDelete)).toThrowError(
+			'unexpected non-http error',
+		);
+	});
+});

--- a/tests/unit/routes/admin-owner-guard-rollout.test.ts
+++ b/tests/unit/routes/admin-owner-guard-rollout.test.ts
@@ -13,13 +13,24 @@
 // - negative (parent / child): 403 + 既存 `{ error: <既存日本語文言> }` body が
 //   バイト一致で維持されること (回帰固定: 現実装でも green)
 // - positive (owner): 成功経路に入ること (回帰固定: 現実装でも green)
+//
+// #3561 (#3558 follow-up) 追加観点:
+// - ①: 403 文言が OWNER_GATE_LABELS (labels.ts SSOT) と一致すること
+// - ②: account/delete の owner-gate が handler 先頭の single choke-point に hoist され、
+//   未知 pattern にも default-deny が効くこと
+// - ③: requireRole が throw する 401 が 500 化せず endpoint の
+//   `{error: 認証が必要です}` 401 に変換されること (requireRole override で機械検証)
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { error } from '@sveltejs/kit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OWNER_GATE_LABELS } from '../../../src/lib/domain/labels';
 
 // ---------- mocks ----------
 
-// requireRole seam の spy: 実装 (throw error(401/403)) はそのまま使い、呼び出しを観測する
+// requireRole seam の spy: 実装 (throw error(401/403)) はそのまま使い、呼び出しを観測する。
+// #3561 ③: requireRoleImpl を差し替えると 401 throw 等の異常系を機械的に注入できる。
 const requireRoleSpy = vi.fn();
+let requireRoleImpl: ((...args: unknown[]) => void) | null = null;
 vi.mock('$lib/server/auth/guards', async () => {
 	const actual =
 		await vi.importActual<typeof import('../../../src/lib/server/auth/guards')>(
@@ -29,6 +40,9 @@ vi.mock('$lib/server/auth/guards', async () => {
 		...actual,
 		requireRole: (...args: Parameters<typeof actual.requireRole>) => {
 			requireRoleSpy(...args);
+			if (requireRoleImpl) {
+				return requireRoleImpl(...args);
+			}
 			return actual.requireRole(...args);
 		},
 	};
@@ -139,6 +153,7 @@ function expectSeamCalledWith(role: Role) {
 describe('owner-only ad-hoc guard 残存 route の requireRole seam 統一 (#3556)', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		requireRoleImpl = null;
 		mockRepos.auth.findTenantById.mockResolvedValue({
 			status: 'active',
 			stripeSubscriptionId: 'sub_1',
@@ -280,6 +295,75 @@ describe('owner-only ad-hoc guard 残存 route の requireRole seam 統一 (#355
 					expect(mockDeleteOwnerFullDelete).not.toHaveBeenCalled();
 					expect(mockTransferOwnershipAndLeave).not.toHaveBeenCalled();
 				});
+			});
+		}
+	});
+
+	describe('#3561 ①: 403 文言は OWNER_GATE_LABELS (labels.ts SSOT) と一致する', () => {
+		it('endpoint 別文言が置換前ハードコードとバイト一致で SSOT 化されている', () => {
+			expect(OWNER_GATE_LABELS.accountDelete).toBe('owner のみ実行できます');
+			expect(OWNER_GATE_LABELS.deletionInfo).toBe('owner のみ取得できます');
+			expect(OWNER_GATE_LABELS.tenantCancel).toBe('owner のみ解約申請できます');
+			expect(OWNER_GATE_LABELS.tenantReactivate).toBe('owner のみ解約キャンセルできます');
+			expect(OWNER_GATE_LABELS.memberDelete).toBe('owner のみメンバーを削除できます');
+			expect(OWNER_GATE_LABELS.transferOwnership).toBe('owner のみ権限を移譲できます');
+			expect(OWNER_GATE_LABELS.authRequired).toBe('認証が必要です');
+		});
+	});
+
+	describe('#3561 ②: account/delete owner-gate single choke-point (default-deny)', () => {
+		it('未知 pattern + parent は switch より先に choke-point guard が 403 を返す (default-deny)', async () => {
+			const res = await accountDelete(createDeleteEvent('parent', 'future-owner-pattern'));
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: OWNER_GATE_LABELS.accountDelete });
+			expectSeamCalledWith('parent');
+		});
+
+		it('未知 pattern + owner は choke-point 通過後、従来通り 400 (不明な pattern)', async () => {
+			const res = await accountDelete(createDeleteEvent('owner', 'future-owner-pattern'));
+			expect(res.status).toBe(400);
+			expectSeamCalledWith('owner');
+		});
+
+		it('child pattern (本人操作) は choke-point guard を経由しない (switch 内の本人 role 判定へ委譲)', async () => {
+			await accountDelete(createDeleteEvent('child', 'child'));
+			expect(requireRoleSpy).not.toHaveBeenCalled();
+		});
+
+		it('member pattern (本人操作) は choke-point guard を経由しない', async () => {
+			await accountDelete(createDeleteEvent('parent', 'member'));
+			expect(requireRoleSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('#3561 ③: requireRole の 401 は 500 化せず endpoint の 401 {error} に変換される', () => {
+		beforeEach(() => {
+			// 上流の `!context` 早期 return が消えた状態 (requireRole が 401 を throw する
+			// 唯一の経路) を機械的に注入し、outer try/catch での 500 化がないことを検証する
+			requireRoleImpl = () => {
+				throw error(401, 'Unauthorized');
+			};
+		});
+
+		afterEach(() => {
+			requireRoleImpl = null;
+		});
+
+		const cases: Array<[string, () => Promise<Response>]> = [
+			['POST tenant/cancel', () => tenantCancel(createSimpleEvent('owner'))],
+			['POST tenant/reactivate', () => tenantReactivate(createSimpleEvent('owner'))],
+			['GET account/deletion-info', () => deletionInfo(createSimpleEvent('owner'))],
+			[
+				'POST account/delete (owner-only)',
+				() => accountDelete(createDeleteEvent('owner', 'owner-only')),
+			],
+		];
+
+		for (const [name, invoke] of cases) {
+			it(`${name}: 401 + {error: 認証が必要です}`, async () => {
+				const res = await invoke();
+				expect(res.status).toBe(401);
+				await expect(res.json()).resolves.toEqual({ error: OWNER_GATE_LABELS.authRequired });
 			});
 		}
 	});

--- a/tests/unit/routes/admin-owner-guard-rollout.test.ts
+++ b/tests/unit/routes/admin-owner-guard-rollout.test.ts
@@ -349,7 +349,8 @@ describe('owner-only ad-hoc guard 残存 route の requireRole seam 統一 (#355
 			requireRoleImpl = null;
 		});
 
-		const cases: Array<[string, () => Promise<Response>]> = [
+		// RequestHandler の戻り値は MaybePromise<Response> (Response | Promise<Response>)
+		const cases: Array<[string, () => Response | Promise<Response>]> = [
 			['POST tenant/cancel', () => tenantCancel(createSimpleEvent('owner'))],
 			['POST tenant/reactivate', () => tenantReactivate(createSimpleEvent('owner'))],
 			['GET account/deletion-info', () => deletionInfo(createSimpleEvent('owner'))],


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（親（管理者）アカウントの認可境界を守る基盤）

**解決する課題**: アカウント削除・解約・メンバー管理という不可逆操作の owner-gate が、endpoint ごとに 403 文言をハードコードし、account/delete では pattern ごとに guard を個別呼び出ししていた。将来の pattern 追加時の guard 付け忘れや、上流リファクタで 401 が 500 化する潜在退行の温床だった（PR #3558 承認時に Adversarial Reviewer が指摘した hardening 課題）。

**期待される効果**: owner-gate の 403/401 変換が単一 helper + labels.ts SSOT に集約され、guard は account/delete handler 先頭の single choke-point で default-deny になる。将来の変更に対して認可の抜け・文言の分散・401 の 500 化が構造的に起きなくなる。

## 関連 Issue

closes #3561

関連: PR #3558（owner-gate seam 統一、behavior-preserving）/ #3556 / #3528（fitness#3）/ #3552（role-mutation authz hardening）/ ADR-0062（error body 統一・内部例外非露出）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (①) | account/tenant/members 系 owner-gate の 403 `{error}` 文言を labels.ts SSOT（`OWNER_GATE_LABELS`）に集約（置換前とバイト一致） | `npx vitest run tests/unit/routes/admin-owner-guard-rollout.test.ts`（「#3561 ①: 403 文言は OWNER_GATE_LABELS…」+ 既存 403 body バイト一致 pin 全 PASS）+ `grep -rn "owner のみ.*できます" src/routes/`（route 側リテラル 0 件、invites 2 endpoint のみ scope 外で残存） | HEAD `af648c8e` / 32 passed / `src/lib/domain/labels.ts:489-518`（`OWNER_GATE_LABELS`、解約系は `CANCEL_TERMS.canonical` atom 参照）/ 6 endpoint 置換: account/delete・deletion-info・tenant/cancel・tenant/reactivate・members/[userId]・transfer-ownership |
| AC2 (②) | account/delete の owner-gate を handler 先頭の single choke-point に hoist（将来 pattern 追加時の付け忘れを構造的に防止） | `npx vitest run tests/unit/routes/admin-owner-guard-rollout.test.ts`（「#3561 ②: … single choke-point (default-deny)」describe 4 件: 未知 pattern + 非 owner → 403 / 未知 pattern + owner → 400 維持 / child・member pattern は guard 非経由） | HEAD `af648c8e` / 4 passed / `src/routes/api/v1/admin/account/delete/+server.ts:82-92`（`SELF_SERVICE_PATTERNS` 以外を default-deny で必須通過、per-case guard 3 箇所を撤去） |
| AC3 (③) | requireRole の 401 が outer try/catch で 500 化せず endpoint 文言の 401 に変換される + seam spy test に 401 経路の機械検証を追加 | `npx vitest run tests/unit/auth/owner-gate.test.ts`（helper 直接検証: 401 変換 / 403 / owner 通過 / 非 HttpError re-throw）+ `admin-owner-guard-rollout.test.ts`（「#3561 ③」describe: requireRole override で 401 throw を注入 → 4 endpoint が 401 `{error: 認証が必要です}` を返す） | HEAD `af648c8e` / owner-gate.test.ts 5 passed + ③ describe 4 passed / `src/lib/server/auth/owner-gate.ts:27-40`（`isHttpError(e, 401)` → `OWNER_GATE_LABELS.authRequired` 401 JSON、401/403 以外は re-throw） |
| AC4 (回帰) | 既存挙動の回帰なし（owner 成功経路 / 403 body バイト一致 / seam spy / プラン別 dispatch） | `npx vitest run tests/unit/routes/ tests/unit/auth/` | HEAD `af648c8e` / 47 files 465 passed（rollout 65 件 + admin-role-mutation-authz + account-delete-api 含む全緑） |
| AC5 (設計書同期) | `docs/design/14-セキュリティ設計書.md` §5.2.3 / §5.2.5 に helper 集約 + guard hoist + 401 頑健化を反映（ADR-0001） | 目視 + `node scripts/check-doc-code-references.mjs`（pre-ready Step 10 相当） | HEAD `af648c8e` / §5.2.3 response 形の互換（members 系 2 endpoint の helper 集約）+ §5.2.5 bullet 3 点更新（`ownerGateResponse` / `OWNER_GATE_LABELS` / default-deny / fitness function 追記） |

補足（scope 判断）: invites 系 2 endpoint（招待発行 / 取消）は §5.2.3 role-mutation の一部だが、Issue ① の scope 指定「account/tenant/members 系」および列挙 5 動詞（実行/取得/解約申請/解約キャンセル/削除）の対象外のため本 PR では変更しない（scope 勝手拡大禁止）。付随修正として、deletion-info の 500 応答が `String(err)` を露出していた点を ADR-0062 §2（内部例外非露出）準拠に是正した（logger のみに残し `ERROR_NOTIFY_LABELS.server` 固定文言化 — 本 PR が触る同一 seam 内の一貫レスポンス要件）。

## 変更タイプ

- [x] fix: バグ修正
- [x] refactor: リファクタリング

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] API エンドポイント (`src/routes/api/`)
- [x] ドメインモデル (`$lib/domain/`)
- [x] サービス層 (`$lib/server/auth/` — 共通 helper `owner-gate.ts` 新設)

**影響を受ける画面・機能**:
親管理画面のアカウント削除 / 解約申請・解約キャンセル / メンバー削除・owner 移譲の API 認可境界（403/401 応答）。正常系（owner 操作）の挙動・response は不変。403 body は置換前とバイト一致。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / cspell / svelte-check / vitest / hardcoded-strings / no-plan-literals / license-key-leak / generate-lp-labels / check-pr-body（本 body で PASS）/ doc-code-references / terminology-coherence をローカル一括検証（LP 変更なしのため LP 系 step は skip 判定）
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/auth/owner-gate.test.ts`（新設）: helper 直接検証 — owner → null / parent・child → 403 SSOT 文言 / context 欠落 → 401 `{error: 認証が必要です}` / 非 HttpError re-throw
  - `tests/unit/routes/admin-owner-guard-rollout.test.ts`（拡張）: ① SSOT バイト一致 / ② default-deny choke-point 4 件 / ③ requireRole override による 401 変換 4 endpoint
  - 局所検証: `npx vitest run tests/unit/routes/ tests/unit/auth/` → 47 files 465 passed / `npx biome check <変更 10 files>` PASS / `npx cspell` 新規 2 files 0 issues / `check-no-plan-literals` OK / `check-hardcoded-strings` violations 0 / `generate-lp-labels --check` 同期済
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:critical ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（server-side 認可 seam のみの変更。UI 描画・文言表示の変更なし — `OWNER_GATE_LABELS` は API error body 専用 compound で、値は置換前ハードコードとバイト一致のため画面表示も不変）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — 401/403 変換を `owner-gate.ts` に分離（guards.ts は純粋判定のまま）。requireRole seam（#3528）への依存は維持
- [x] **DRY**: 6 endpoint に複製されていた try/requireRole/catch/isHttpError ブロックを単一 helper に集約。`grep -rn "owner のみ" src/routes/` で route 側リテラル残存 0 件を確認（invites 2 件は scope 外で意図的残存）
- [x] **YAGNI**: 新規抽象は helper 1 関数 + labels namespace 1 個のみ。invites への先回り適用はしない
- [x] **Security（OSS 公開前提）**: default-deny 化（②）で認可の構造的堅牢化 / deletion-info の内部例外露出（CWE-209 類型）を是正 / 秘密情報 hardcode なし
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: N/A（同期関数 1 段の追加のみ）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] **labels SSOT** (ADR-0009 / ADR-0045): 403/401 文言は `labels.ts` の `OWNER_GATE_LABELS` compound 経由、解約系は `CANCEL_TERMS.canonical` atom から組立。リテラル直書きを 6 route から撤去
- [x] **設計書同期** (ADR-0001): `docs/design/14-セキュリティ設計書.md` §5.2.3 / §5.2.5 を同 PR で更新
- [x] **並行 PR overlap** (#1200): 対象 6 route を変更する open PR なし（`gh pr list` 確認）
- [x] N/A — デモ / 年齢モード / ナビ / E2E シード / チュートリアルへの波及なし（server-side API のみ）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

（挙動差分の明示: ② default-deny の副作用として、`account/delete` の未知 pattern は非 owner に対し 400 より先に 403 を返すようになる。owner には従来通り 400「不明な pattern」。既存 client は既知 pattern のみ送信するため実質影響なし。テストで新挙動を pin 済み）

**レビュー依頼事項・QA**:
- ② の default-deny（未知 pattern + 非 owner → 403）を「behavior-preserving 逸脱」と見るか「hardening として妥当」と見るかの判断確認をお願いします（Issue ② の趣旨 = 構造的 guard 付け忘れ防止に沿う設計として選択）
- invites 2 endpoint を scope 外とした判断（Issue 本文の「account/tenant/members 系」+ 5 動詞列挙に準拠）の妥当性確認

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完のまま残っている AC がない）
- [x] Phase 分割: N/A（単一 PR で完結）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証 UI 画面の変更なし、server-side API のみ）

## QM レビュー結果

<!-- QM が記入。フォーマット・必須手順は docs/sessions/qa-session.md「Tier 2 手順 5」を参照。
     CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（ADR-0022）。 -->
