### PR TITLE
fix: #3324 #3325 #3372 import UX 堅牢化 (進捗可視化 + AbortController + 6MB 整合 + partial-backup 警告)

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -910,7 +910,7 @@ S3 からの画像取得プロキシ。`key` クエリパラメータで対象�
 **リクエストボディ:**
 
 - `Content-Type: application/json`: エクスポートされた JSON 全体（`ExportData`）。
-- `Content-Type: application/zip`（#3077）: GET `/api/v1/export?format=zip` が出力した ZIP。`data.json` を export body として解析し、同梱の `avatars/{childId}/**` / `voices/{childId}/**` をインポート後の新 `childId` 配下（`tenants/{tenantId}/{type}/{newChildId}/...`）に復元する。子供の `avatarUrl` 参照は新 storage key（公開 URL）へ貼り替える。受理上限は export ZIP と整合する 100MB。JSON のみインポートは後方互換で動作する。
+- `Content-Type: application/zip`（#3077）: GET `/api/v1/export?format=zip` が出力した ZIP。`data.json` を export body として解析し、同梱の `avatars/{childId}/**` / `voices/{childId}/**` をインポート後の新 `childId` 配下（`tenants/{tenantId}/{type}/{newChildId}/...`）に復元する。子供の `avatarUrl` 参照は新 storage key（公開 URL）へ貼り替える。受理上限は実行環境で分岐する（#3325、SSOT: `src/lib/server/services/import-limit.ts`）: AWS（aws-prod）は Lambda Function URL（BUFFERED）の request payload 6MB hard cap に整合する 5.5MB、NUC / local は Function URL 制約が無いため export ZIP（`MAX_ZIP_SIZE`）と整合する 100MB。超過時は 400 VALIDATION_ERROR で「クラウド共有（PIN コード）経由の復元」を案内する（沈黙のハング禁止）。UI（settings/data）も同値を load 経由で受け取り、ファイル選択時に client-side pre-check する。JSON のみインポートは後方互換で動作する。
 
 > **#3077 id 再マップ**: `ExportData.family.children[].sourceChildId`（v1.3.0 相当の追加フィールド、export 元の数値 childId）を介して ZIP 内パスの `{oldChildId}` を新 `childId` に解決する。`sourceChildId` が解決できない孤立ファイルはスキップする（`result.staticFilesSkipped`）。
 >

--- a/docs/design/backup-import-redesign.md
+++ b/docs/design/backup-import-redesign.md
@@ -92,7 +92,7 @@ D1-D4 は補佐推奨どおり承認、D5 は「下位互換不要」で決定�
 | P2 | 分類レジストリ + 機械検証 + export source 全網羅 + per-child binding 保持（#3329） | 実装済み（ratchet 空） |
 | P3 | per-child 正復元 + 未実装取込 + 失敗集計 + import 原子化（#3327/#3326） | 実装済み |
 | P4 | 復元時 projection rebuild | 実装済み |
-| P5 | UX/安全: 進捗フィードバック + クライアント timeout + 上限の実態整合 + partial-backup 警告（#3324/#3325/#3372） | 実装済み（cloud export status polling UI / import fetch AbortController 120s / 実行環境別 import 上限 = AWS 5.5MB・NUC 100MB `import-limit.ts` / registry 駆動 partial-backup 警告）。20 年×子供数 scale（全メモリ export / 逐次 import）の抜本対応は将来課題 |
+| P5 | UX/安全: 進捗フィードバック + クライアント timeout + 上限の実態整合 + partial-backup 警告（#3324/#3325/#3372） | 実装済み（cloud export status polling UI / import fetch AbortController 120s = 直接 import（`postImport`）と cloud import（`postCloudImport`、preview / execute）の両経路 / 実行環境別 import 上限 = AWS 5.5MB・NUC 100MB `import-limit.ts` / registry 駆動 partial-backup 警告）。20 年×子供数 scale（全メモリ export / 逐次 import）の抜本対応は将来課題 |
 
 各段階に round-trip 完全性テスト（`backup-roundtrip-completeness.test.ts`、#3328）。source/派生/除外の三分類原則の ADR 昇格は未判断。
 

--- a/docs/design/backup-import-redesign.md
+++ b/docs/design/backup-import-redesign.md
@@ -92,7 +92,7 @@ D1-D4 は補佐推奨どおり承認、D5 は「下位互換不要」で決定�
 | P2 | 分類レジストリ + 機械検証 + export source 全網羅 + per-child binding 保持（#3329） | 実装済み（ratchet 空） |
 | P3 | per-child 正復元 + 未実装取込 + 失敗集計 + import 原子化（#3327/#3326） | 実装済み |
 | P4 | 復元時 projection rebuild | 実装済み |
-| P5 | UX/安全: 進捗フィードバック + クライアント timeout + 大容量・スケール対応（#3324/#3325） | 未実装（20 年×子供数 scale = 全メモリ export / 逐次 import / 100MB ZIP 上限の見直し） |
+| P5 | UX/安全: 進捗フィードバック + クライアント timeout + 上限の実態整合 + partial-backup 警告（#3324/#3325/#3372） | 実装済み（cloud export status polling UI / import fetch AbortController 120s / 実行環境別 import 上限 = AWS 5.5MB・NUC 100MB `import-limit.ts` / registry 駆動 partial-backup 警告）。20 年×子供数 scale（全メモリ export / 逐次 import）の抜本対応は将来課題 |
 
 各段階に round-trip 完全性テスト（`backup-roundtrip-completeness.test.ts`、#3328）。source/派生/除外の三分類原則の ADR 昇格は未判断。
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2154,6 +2154,10 @@ export const IMPORT_LABELS = {
 	// 内部フォーマット名 (JSON) は UI 露出しない (BACKUP_TERMS SSOT、#3198)。
 	errorInvalidJson: `${BACKUP_TERMS.file}として読み込めませんでした（ファイルの形式が正しくありません）`,
 	errorImportFailed: 'インポートに失敗しました',
+	// #3325 AC3: 実行環境の実効上限 (AWS = Function URL 6MB 弱) 超過時のエラー + クラウド導線案内。
+	// API (import/+server.ts) と UI (settings/data の送信前 pre-check) の双方で共有する。
+	errorFileTooLargeCloudGuide: (maxMb: number | string) =>
+		`ファイルサイズが大きすぎます（最大${maxMb}MB）。大きな${BACKUP_TERMS.canonical}はクラウド共有（PINコード）経由で${BACKUP_TERMS.restoreVerb}してください`,
 
 	// 事前確認ダイアログ
 	previewDialogTitle: 'インポート内容の確認',
@@ -2302,6 +2306,13 @@ export const SETTINGS_LABELS = {
 	// #3285 uiux-3: settings/data の import 検証 / クラウド連携メッセージを SSOT 集約 (旧: 直書き)
 	dataImportNoFile: `${BACKUP_TERMS.file}が選択されていません`,
 	dataImportFileTooLarge: (maxMb: string) => `ファイルサイズが大きすぎます（最大${maxMb}MB）`,
+	// #3324: import fetch の client timeout (AbortController) 発火時の明示エラー (無限ハング防止)
+	dataImportTimeoutError:
+		'処理がタイムアウトしました。通信状況をご確認のうえ、しばらくしてから再度お試しください',
+	// #3372: registry (backup-entity-registry) 駆動の partial-backup 警告 (NN/G visibility)。
+	// 未 export の source 実体が存在する間のみ表示し、export 実装が進むと自動で消える。
+	dataImportPartialBackupWarning: (items: string) =>
+		`この${BACKUP_TERMS.exportNoun}形式にはまだ含まれないデータがあります（${items}）。これらは${BACKUP_TERMS.restoreVerb}されません。`,
 	cloudExportPinIssued: (pinCode: string, expiry: string) =>
 		`PINコード: ${pinCode}（有効期限: ${expiry}）`,
 	cloudImportNoChildren:
@@ -2368,6 +2379,11 @@ export const SETTINGS_LABELS = {
 	cloudStoredExpiry: (date: string) => `期限: ${date}`,
 	cloudStoredDownloads: (count: number | string, max: number | string) => `DL: ${count}/${max}回`,
 	cloudStoredDelete: '削除',
+	// #3324 / #3509: 非同期 build 状態 (pending/building/ready/failed) の可視フィードバック
+	cloudStatusPending: '受付済み・生成待ち',
+	cloudStatusBuilding: '生成中…',
+	cloudStatusFailed: (reason: string) => `作成に失敗しました${reason ? `（${reason}）` : ''}`,
+	cloudDownloadAction: 'ダウンロード',
 	cloudImportTitle: 'PINコードでインポート',
 	cloudImportDesc: '共有されたPINコードを入力してデータを取り込みます。',
 	cloudImportPinPlaceholder: 'PINコード（6桁）',

--- a/src/lib/server/db/backup-entity-registry.ts
+++ b/src/lib/server/db/backup-entity-registry.ts
@@ -40,6 +40,12 @@ export interface BackupEntityEntry {
 	schemaTable?: string;
 	/** source のときのみ: export/import で round-trip 済か。'not-yet-exported' は #3329 残課題 */
 	backupStatus?: BackupExportStatus;
+	/**
+	 * #3372: backupStatus='not-yet-exported' の source に必須の UI 表示名。
+	 * import/restore UI の partial-backup 警告が本値を列挙する (内部コード露出禁止のため
+	 * 内部実体名をそのまま UI に出さない。必須性は backup-entity-registry.test.ts が機械強制)。
+	 */
+	displayLabel?: string;
 	/** excluded のときのみ: 恒久除外 / 繰延除外 (Phase 2 で再分類) の区別 */
 	excludedKind?: BackupExcludedKind;
 	reason: string;
@@ -412,6 +418,19 @@ export function notYetExportedSourceEntities(): string[] {
 	return Object.entries(BACKUP_ENTITY_REGISTRY)
 		.filter(([, e]) => e.classification === 'source' && e.backupStatus === 'not-yet-exported')
 		.map(([name]) => name)
+		.sort();
+}
+
+/**
+ * #3372: 未 export source の UI 表示名一覧 (import/restore UI の partial-backup 警告用)。
+ * registry SSOT 駆動のため、export 実装が進み not-yet-exported が減ると警告も自動で縮む。
+ * displayLabel 未設定の場合は内部実体名に fallback するが、not-yet-exported source への
+ * displayLabel 設定は backup-entity-registry.test.ts が機械強制する (内部コード露出禁止)。
+ */
+export function notYetExportedSourceLabels(): string[] {
+	return Object.entries(BACKUP_ENTITY_REGISTRY)
+		.filter(([, e]) => e.classification === 'source' && e.backupStatus === 'not-yet-exported')
+		.map(([name, e]) => e.displayLabel ?? name)
 		.sort();
 }
 

--- a/src/lib/server/services/import-limit.ts
+++ b/src/lib/server/services/import-limit.ts
@@ -1,0 +1,37 @@
+// src/lib/server/services/import-limit.ts
+// #3325 AC3: バックアップ import 受理上限の実態整合 SSOT。
+//
+// AWS 本番の公開経路は CloudFront → Lambda Function URL (BUFFERED) で、Function URL の
+// request payload 上限は **6MB (hard limit)**。旧実装のアプリ側 100MB 許容は実態と乖離し、
+// 6MB 超の body はハンドラに到達せず edge で弾かれ「沈黙のハング」になっていた。
+// 本 module は実行環境 (runtime mode) に応じた実効上限を 1 箇所で解決する:
+//   - aws-prod  : 6MB 弱 (5.5MB、multipart/encoding overhead margin) — 超過時は API が
+//                 明示エラー + クラウド経由の復元導線を案内する (NN/G error prevention)。
+//   - nuc-prod / local-debug / それ以外 : Function URL 制約が無いため従来上限
+//                 (export ZIP の MAX_ZIP_SIZE = 100MB と整合) を維持する。
+//
+// UI (settings/data) は load 経由で本値を受け取り、送信前 client-side pre-check にも使う。
+
+import { getEnv, type TypedEnv } from '$lib/runtime/env';
+import { resolveRuntimeMode } from '$lib/runtime/runtime-mode';
+import { MAX_ZIP_SIZE } from '$lib/server/services/backup-archive';
+
+/** AWS Lambda Function URL (BUFFERED) の 6MB hard cap に対する安全側の実効上限 (5.5MB)。 */
+export const AWS_MAX_IMPORT_BYTES = Math.floor(5.5 * 1024 * 1024);
+
+/** NUC / local の受理上限。export ZIP 構築上限 (backup-archive MAX_ZIP_SIZE) と整合させる。 */
+export const LOCAL_MAX_IMPORT_BYTES = MAX_ZIP_SIZE;
+
+/**
+ * 実行環境に応じた import 受理上限 (bytes) を返す。
+ * env を明示注入できる純関数寄りの形にし、unit test で runtime mode 分岐を検証可能にする。
+ */
+export function resolveMaxImportBytes(env: TypedEnv = getEnv()): number {
+	const mode = resolveRuntimeMode({ env });
+	return mode === 'aws-prod' ? AWS_MAX_IMPORT_BYTES : LOCAL_MAX_IMPORT_BYTES;
+}
+
+/** bytes → ユーザー向け MB 表示 (小数 1 桁。例: 5767168 → 5.5)。 */
+export function toDisplayMb(maxBytes: number): number {
+	return Math.round((maxBytes / (1024 * 1024)) * 10) / 10;
+}

--- a/src/routes/(parent)/admin/settings/data/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/data/+page.server.ts
@@ -5,9 +5,11 @@ import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import type { ChildId } from '$lib/domain/ids';
 import { requireTenantId } from '$lib/server/auth/factory';
+import { notYetExportedSourceLabels } from '$lib/server/db/backup-entity-registry';
 import { findAllChildren } from '$lib/server/db/child-repo';
 import { logger } from '$lib/server/logger';
 import { clearAllFamilyData, getDataSummary } from '$lib/server/services/data-service';
+import { resolveMaxImportBytes } from '$lib/server/services/import-limit';
 import { getPlanLimits, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { Actions, PageServerLoad } from './$types';
 
@@ -56,6 +58,11 @@ export const load: PageServerLoad = async ({ locals }) => {
 		canExport: planLimits.canExport,
 		maxCloudExports: planLimits.maxCloudExports,
 		children,
+		// #3325 AC3: 実行環境の実効 import 上限 (AWS = Function URL 6MB 弱 / NUC・local = 100MB)。
+		// UI 側のファイル選択時 client-side pre-check に使う (送信前に気付ける、NN/G error prevention)。
+		maxImportBytes: resolveMaxImportBytes(),
+		// #3372: registry 駆動の partial-backup 警告 (未 export source の表示名。空なら警告非表示)。
+		notYetExportedLabels: notYetExportedSourceLabels(),
 	};
 };
 

--- a/src/routes/(parent)/admin/settings/data/+page.svelte
+++ b/src/routes/(parent)/admin/settings/data/+page.svelte
@@ -149,6 +149,9 @@ async function postImport(mode: string): Promise<Response> {
 		}
 		const text = await importFile.text();
 		const json = JSON.parse(text);
+		// fetch-error-exempt (#3324): 失敗は呼び出し側 (handleImportPreview / executeImport) が
+		// res.ok チェック + catch → importError で可視化する (ADR-0062 の可視フィードバック要件は
+		// caller が充足)。helper は Response を返すのみでエラー処理を co-locate しない。
 		return await fetch(`/api/v1/import?mode=${mode}`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
@@ -177,6 +180,9 @@ async function postCloudImport(
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), IMPORT_FETCH_TIMEOUT_MS);
 	try {
+		// fetch-error-exempt (#3324): 失敗は呼び出し側 (handleCloudImportPreview / executeCloudImport)
+		// が res.ok チェック + catch → cloudImportError で可視化する (ADR-0062 の可視フィードバック要件は
+		// caller が充足)。helper は Response を返すのみでエラー処理を co-locate しない。
 		return await fetch(`/api/v1/import/cloud?mode=${mode}`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },

--- a/src/routes/(parent)/admin/settings/data/+page.svelte
+++ b/src/routes/(parent)/admin/settings/data/+page.svelte
@@ -165,6 +165,29 @@ function isAbortError(err: unknown): boolean {
 	return err instanceof DOMException && err.name === 'AbortError';
 }
 
+/**
+ * #3324 (cloud 経路横展開): cloud import fetch も AbortController + timeout で包み、
+ * 応答が返らない場合の client 無限ハングを防止する (直接 import 経路 postImport と同型)。
+ * サーバが edge で kill された場合などに catch/finally へ到達させ cloudImportLoading を必ず戻す。
+ */
+async function postCloudImport(
+	mode: string,
+	body: { pinCode: string; targetChildIds?: ChildId[] },
+): Promise<Response> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), IMPORT_FETCH_TIMEOUT_MS);
+	try {
+		return await fetch(`/api/v1/import/cloud?mode=${mode}`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(body),
+			signal: controller.signal,
+		});
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
 async function handleImportFileChange(e: Event) {
 	if (anyFormBusy) return;
 	const input = e.target as HTMLInputElement;
@@ -344,11 +367,7 @@ async function handleCloudImportPreview() {
 	cloudImportLoading = true;
 	cloudImportError = '';
 	try {
-		const res = await fetch('/api/v1/import/cloud?mode=preview', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ pinCode: cloudImportPin.trim() }),
-		});
+		const res = await postCloudImport('preview', { pinCode: cloudImportPin.trim() });
 		const d = await res.json().catch(() => null);
 		if (!res.ok) {
 			cloudImportError = resolveApiErrorMessage(res.status, d?.error?.message ?? '');
@@ -356,8 +375,11 @@ async function handleCloudImportPreview() {
 		}
 		cloudImportPreview = d.preview;
 		cloudImportStep = 'preview';
-	} catch {
-		cloudImportError = ERROR_NOTIFY_LABELS.generic;
+	} catch (err) {
+		// #3324: timeout 中断は明示文言、それ以外は generic (直接 import 経路と同型)
+		cloudImportError = isAbortError(err)
+			? SETTINGS_LABELS.dataImportTimeoutError
+			: ERROR_NOTIFY_LABELS.generic;
 	} finally {
 		cloudImportLoading = false;
 	}
@@ -389,11 +411,7 @@ async function executeCloudImport(targetChildIds: ChildId[] | null) {
 		if (targetChildIds && targetChildIds.length > 0) {
 			body.targetChildIds = targetChildIds;
 		}
-		const res = await fetch('/api/v1/import/cloud?mode=execute', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(body),
-		});
+		const res = await postCloudImport('execute', body);
 		const d = await res.json().catch(() => null);
 		if (!res.ok) {
 			cloudImportError = resolveApiErrorMessage(res.status, d?.error?.message ?? '');
@@ -401,8 +419,11 @@ async function executeCloudImport(targetChildIds: ChildId[] | null) {
 		}
 		cloudImportResult = d.result;
 		cloudImportStep = 'done';
-	} catch {
-		cloudImportError = ERROR_NOTIFY_LABELS.generic;
+	} catch (err) {
+		// #3324: timeout 中断は明示文言、それ以外は generic (直接 import 経路と同型)
+		cloudImportError = isAbortError(err)
+			? SETTINGS_LABELS.dataImportTimeoutError
+			: ERROR_NOTIFY_LABELS.generic;
 	} finally {
 		cloudImportLoading = false;
 	}

--- a/src/routes/(parent)/admin/settings/data/+page.svelte
+++ b/src/routes/(parent)/admin/settings/data/+page.svelte
@@ -82,6 +82,9 @@ let cloudExports = $state<
 		downloadCount: number;
 		maxDownloads: number;
 		createdAt: string;
+		// #3324 / #3509: 非同期 build 状態。旧レコードは server 側で 'ready' に backfill 済。
+		status: 'pending' | 'building' | 'ready' | 'failed';
+		failureReason: string | null;
 	}>
 >([]);
 let cloudLoading = $state(false);
@@ -118,28 +121,48 @@ const anyFormBusy = $derived(
 );
 
 // #3077: JSON は 10MB、ZIP (静的ファイル同梱) は export ZIP と整合する 100MB を許容。
+// #3325 AC3: さらに実行環境の実効上限 (data.maxImportBytes、AWS = Function URL 6MB 弱) で下方制限する。
 const MAX_JSON_BYTES = 10 * 1024 * 1024;
 const MAX_ZIP_BYTES = 100 * 1024 * 1024;
 
+// #3324: import fetch の client timeout。サーバ側は Lambda/CloudFront 30 秒で必ず決着するため、
+// NUC の大きめ import (制約なし) も考慮した安全上限として 120 秒で打ち切り、無限ハングを防止する。
+const IMPORT_FETCH_TIMEOUT_MS = 120_000;
+
 /**
  * #3077: 選択ファイルが ZIP なら raw bytes を application/zip で、JSON なら従来通り JSON で送る。
+ * #3324: AbortController + timeout で応答が返らない場合の client 無限ハングを防止する
+ * (サーバが edge で kill された場合など、`finally` の importLoading=false に到達させる)。
  */
 async function postImport(mode: string): Promise<Response> {
 	if (!importFile) throw new Error(SETTINGS_LABELS.dataImportNoFile);
-	if (importFile.name.endsWith('.zip')) {
-		return fetch(`/api/v1/import?mode=${mode}`, {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), IMPORT_FETCH_TIMEOUT_MS);
+	try {
+		if (importFile.name.endsWith('.zip')) {
+			return await fetch(`/api/v1/import?mode=${mode}`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/zip' },
+				body: importFile,
+				signal: controller.signal,
+			});
+		}
+		const text = await importFile.text();
+		const json = JSON.parse(text);
+		return await fetch(`/api/v1/import?mode=${mode}`, {
 			method: 'POST',
-			headers: { 'Content-Type': 'application/zip' },
-			body: importFile,
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(json),
+			signal: controller.signal,
 		});
+	} finally {
+		clearTimeout(timer);
 	}
-	const text = await importFile.text();
-	const json = JSON.parse(text);
-	return fetch(`/api/v1/import?mode=${mode}`, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify(json),
-	});
+}
+
+/** #3324: AbortController による timeout 中断かを判定する (明示エラー文言の出し分け用)。 */
+function isAbortError(err: unknown): boolean {
+	return err instanceof DOMException && err.name === 'AbortError';
 }
 
 async function handleImportFileChange(e: Event) {
@@ -158,9 +181,16 @@ async function handleImportFileChange(e: Event) {
 		importFile = null;
 		return;
 	}
-	const maxBytes = isZip ? MAX_ZIP_BYTES : MAX_JSON_BYTES;
+	// #3325 AC3: 実行環境の実効上限 (AWS = 6MB 弱) で下方制限。超過は送信前にクラウド導線案内付きで弾く。
+	const staticMaxBytes = isZip ? MAX_ZIP_BYTES : MAX_JSON_BYTES;
+	const maxBytes = Math.min(staticMaxBytes, data.maxImportBytes);
 	if (importFile.size > maxBytes) {
-		importError = SETTINGS_LABELS.dataImportFileTooLarge(isZip ? '100' : '10');
+		importError =
+			maxBytes < staticMaxBytes
+				? IMPORT_LABELS.errorFileTooLargeCloudGuide(
+						Math.round((maxBytes / (1024 * 1024)) * 10) / 10,
+					)
+				: SETTINGS_LABELS.dataImportFileTooLarge(isZip ? '100' : '10');
 		importFile = null;
 		return;
 	}
@@ -177,8 +207,11 @@ async function handleImportFileChange(e: Event) {
 		}
 		importPreview = d.preview;
 		importStep = 'preview';
-	} catch {
-		importError = ERROR_NOTIFY_LABELS.generic;
+	} catch (err) {
+		// #3324: timeout 中断は明示文言、それ以外は generic
+		importError = isAbortError(err)
+			? SETTINGS_LABELS.dataImportTimeoutError
+			: ERROR_NOTIFY_LABELS.generic;
 		importFile = null;
 	} finally {
 		importLoading = false;
@@ -199,8 +232,11 @@ async function handleImportExecute() {
 		}
 		importResult = d.result;
 		importStep = 'done';
-	} catch {
-		importError = ERROR_NOTIFY_LABELS.generic;
+	} catch (err) {
+		// #3324: timeout 中断は明示文言、それ以外は generic
+		importError = isAbortError(err)
+			? SETTINGS_LABELS.dataImportTimeoutError
+			: ERROR_NOTIFY_LABELS.generic;
 	} finally {
 		importLoading = false;
 	}
@@ -397,6 +433,21 @@ $effect(() => {
 	}
 });
 
+// #3324: 非同期 build (pending/building) が残っている間のみ一覧を polling し、
+// 「受付 → 生成中 → 完了 (DL 可)」の進捗を可視化する。全件決着 (ready/failed) で自動停止
+// (ADR-0012: 常時 polling や過剰演出はしない)。
+const CLOUD_EXPORT_POLL_MS = 5_000;
+const hasInFlightCloudExports = $derived(
+	cloudExports.some((e) => e.status === 'pending' || e.status === 'building'),
+);
+$effect(() => {
+	if (!hasInFlightCloudExports) return;
+	const timer = setInterval(() => {
+		void loadCloudExports();
+	}, CLOUD_EXPORT_POLL_MS);
+	return () => clearInterval(timer);
+});
+
 const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChecked);
 </script>
 
@@ -535,6 +586,22 @@ const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChec
 				<h4 class="text-sm font-bold text-[var(--color-text)] mb-2">
 					{SETTINGS_LABELS.dataImportTitle}
 				</h4>
+
+				<!-- #3372: partial-backup 警告 (registry 駆動)。未 export の source 実体が
+				     存在するときのみ表示し、export 実装が進むと自動で消える (NN/G visibility)。 -->
+				{#if data.notYetExportedLabels.length > 0}
+					<div
+						class="bg-[var(--color-feedback-warning-bg)] border border-[var(--color-feedback-warning-border)] rounded-lg p-3 mb-3"
+						role="status"
+						data-testid="import-partial-backup-warning"
+					>
+						<p class="text-xs text-[var(--color-feedback-warning-text)]">
+							{SETTINGS_LABELS.dataImportPartialBackupWarning(
+								data.notYetExportedLabels.join('、'),
+							)}
+						</p>
+					</div>
+				{/if}
 
 				{#if importError}
 					<ErrorAlert message={importError} severity="warning" action="fix_input" />
@@ -952,16 +1019,54 @@ const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChec
 													exp.maxDownloads,
 												)}
 											</p>
+											<!-- #3324: 非同期 build の進捗フィードバック (受付/生成中/失敗)。 -->
+											{#if exp.status === 'pending' || exp.status === 'building'}
+												<p
+													class="text-xs text-[var(--color-feedback-info-text)] flex items-center gap-1"
+													role="status"
+													data-testid="cloud-export-status-{exp.id}"
+												>
+													<span
+														class="inline-block w-3 h-3 border-2 border-[var(--color-feedback-info-text)] border-t-transparent rounded-full animate-spin"
+														aria-hidden="true"
+													></span>
+													{exp.status === 'pending'
+														? SETTINGS_LABELS.cloudStatusPending
+														: SETTINGS_LABELS.cloudStatusBuilding}
+												</p>
+											{:else if exp.status === 'failed'}
+												<p
+													class="text-xs text-[var(--color-feedback-error-text)]"
+													role="status"
+													data-testid="cloud-export-status-{exp.id}"
+												>
+													{SETTINGS_LABELS.cloudStatusFailed(exp.failureReason ?? '')}
+												</p>
+											{/if}
 										</div>
-										<Button
-											type="button"
-											variant="ghost"
-											size="sm"
-											class="text-[var(--color-feedback-error-text)] hover:brightness-75"
-											onclick={() => handleDeleteCloudExport(exp.id)}
-										>
-											{SETTINGS_LABELS.cloudStoredDelete}
-										</Button>
+										<div class="flex items-center gap-2">
+											<!-- #3324: ready 時のみ DL 導線を出す (#3509 の一時 DL 経路へ)。 -->
+											{#if exp.status === 'ready'}
+												<Button
+													href="/api/v1/export/cloud/{exp.id}/download"
+													variant="ghost"
+													size="sm"
+													class="text-[var(--color-text-link)] hover:brightness-75"
+													data-testid="cloud-export-download-link"
+												>
+													{SETTINGS_LABELS.cloudDownloadAction}
+												</Button>
+											{/if}
+											<Button
+												type="button"
+												variant="ghost"
+												size="sm"
+												class="text-[var(--color-feedback-error-text)] hover:brightness-75"
+												onclick={() => handleDeleteCloudExport(exp.id)}
+											>
+												{SETTINGS_LABELS.cloudStoredDelete}
+											</Button>
+										</div>
 									</div>
 								{/each}
 							</div>

--- a/src/routes/api/v1/import/+server.ts
+++ b/src/routes/api/v1/import/+server.ts
@@ -7,6 +7,7 @@ import { requireRole } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
 import { type ParsedBackupZip, parseBackupZip } from '$lib/server/services/backup-archive';
+import { resolveMaxImportBytes, toDisplayMb } from '$lib/server/services/import-limit';
 import {
 	countImportRows,
 	importFamilyData,
@@ -19,9 +20,6 @@ import {
 	replaceImportAtomic,
 } from '$lib/server/services/replace-import-service';
 import type { RequestHandler } from './$types';
-
-// #3077: ZIP インポートの上限。export ZIP (backup-archive MAX_ZIP_SIZE) と整合させる。
-const MAX_IMPORT_BYTES = 100 * 1024 * 1024; // 100MB
 
 /**
  * リクエスト本文を JSON / ZIP のいずれかとして解析する (#3077)。
@@ -46,9 +44,15 @@ async function parseImportRequest(
 		}
 	}
 
+	// #3325 AC3: 実行環境の実効上限で受理判定する (AWS = Function URL 6MB 弱 / NUC・local = 100MB)。
+	// 上限超過は「沈黙のハング」ではなく明示エラー + クラウド共有経由の復元案内を返す。
+	const maxImportBytes = resolveMaxImportBytes();
 	const buffer = await request.arrayBuffer();
-	if (buffer.byteLength > MAX_IMPORT_BYTES) {
-		return { ok: false, error: 'ファイルサイズが大きすぎます（最大100MB）' };
+	if (buffer.byteLength > maxImportBytes) {
+		return {
+			ok: false,
+			error: IMPORT_LABELS.errorFileTooLargeCloudGuide(toDisplayMb(maxImportBytes)),
+		};
 	}
 
 	return parseBackupZip(new Uint8Array(buffer));

--- a/tests/unit/db/backup-entity-registry.test.ts
+++ b/tests/unit/db/backup-entity-registry.test.ts
@@ -20,6 +20,7 @@ import {
 	classifiedSchemaTables,
 	deferredExcludedEntities,
 	notYetExportedSourceEntities,
+	notYetExportedSourceLabels,
 } from '../../../src/lib/server/db/backup-entity-registry';
 
 const DB_DIR = join(process.cwd(), 'src/lib/server/db');
@@ -133,5 +134,27 @@ describe('#3329 backup-entity-registry — silent-gap ガード', () => {
 		// Phase 2 等で source / derived 化したら本ベースラインから外す (意図的更新)。
 		// 「暫定除外のまま放置」を禁止し、実装フェーズ到来時の再分類を強制する。
 		expect(deferredExcludedEntities()).toEqual(['characterImage', 'dailyMission']);
+	});
+
+	it('#3372: notYetExportedSourceLabels は not-yet-exported source の表示名一覧を返す (現ベースライン 0 件)', () => {
+		// import/restore UI の partial-backup 警告が本関数を registry SSOT として参照する。
+		// #3329 完遂により現状は空 = UI 警告非表示。not-yet-exported source を追加すると
+		// 一覧が非空になり警告が自動表示される (registry 駆動)。
+		expect(notYetExportedSourceLabels()).toEqual(notYetExportedSourceEntities());
+		expect(notYetExportedSourceLabels()).toEqual([]);
+	});
+
+	it('#3372: not-yet-exported な source は displayLabel (UI 表示名) が必須 (内部コード露出禁止)', () => {
+		// partial-backup 警告は displayLabel を UI に列挙する。displayLabel 無しで
+		// not-yet-exported source を追加すると内部実体名がそのまま UI に露出するため、
+		// 本 assert が追加時点で fail し表示名の付与を強制する。
+		for (const [name, entry] of Object.entries(BACKUP_ENTITY_REGISTRY)) {
+			if (entry.classification === 'source' && entry.backupStatus === 'not-yet-exported') {
+				expect(
+					entry.displayLabel,
+					`${name} (not-yet-exported source) は displayLabel 必須`,
+				).toBeTruthy();
+			}
+		}
 	});
 });

--- a/tests/unit/routes/import-size-limit.test.ts
+++ b/tests/unit/routes/import-size-limit.test.ts
@@ -1,0 +1,84 @@
+// tests/unit/routes/import-size-limit.test.ts
+// #3325 AC3: POST /api/v1/import が実行環境の実効上限 (resolveMaxImportBytes) で受理判定し、
+// 超過時は「沈黙のハング」ではなく明示エラー + クラウド共有経由の復元案内を返すことを検証する。
+// (旧実装は固定 100MB で AWS Function URL 6MB 実態と乖離し、超過 body は edge で弾かれていた)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 実効上限を小さく mock して route の受理判定パスを決定的に検証する (1KB)。
+const TEST_MAX_BYTES = 1024;
+
+vi.mock('$lib/server/services/import-limit', () => ({
+	resolveMaxImportBytes: () => TEST_MAX_BYTES,
+	toDisplayMb: (bytes: number) => Math.round((bytes / (1024 * 1024)) * 10) / 10,
+}));
+
+const mockParseBackupZip = vi.fn();
+vi.mock('$lib/server/services/backup-archive', () => ({
+	parseBackupZip: (...args: unknown[]) => mockParseBackupZip(...args),
+}));
+
+const mockValidateExportData = vi.fn();
+vi.mock('$lib/server/services/import-service', () => ({
+	importFamilyData: vi.fn(),
+	previewImport: vi.fn(),
+	validateExportData: (...args: unknown[]) => mockValidateExportData(...args),
+	verifyChecksum: vi.fn(),
+}));
+
+vi.mock('$lib/server/services/replace-import-service', () => ({
+	AtomicReplaceError: class extends Error {},
+	replaceImportAtomic: vi.fn(),
+}));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireRole: vi.fn(),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { POST } from '../../../src/routes/api/v1/import/+server';
+
+function locals(): App.Locals {
+	return { context: { tenantId: 't-1', role: 'parent' } } as unknown as App.Locals;
+}
+
+async function postZip(sizeBytes: number): Promise<Response> {
+	const url = new URL('http://localhost/api/v1/import?mode=preview');
+	const request = new Request(url, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/zip' },
+		body: new Uint8Array(sizeBytes),
+	});
+	return (await POST({ request, url, locals: locals() } as never)) as Response;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('#3325 POST /api/v1/import — 実効上限の受理判定', () => {
+	it('上限超過 ZIP は 400 + クラウド共有経由の復元案内を明示して返す (沈黙のハング禁止)', async () => {
+		const res = await postZip(TEST_MAX_BYTES + 1);
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error.code).toBe('VALIDATION_ERROR');
+		expect(body.error.message).toContain('ファイルサイズが大きすぎます');
+		expect(body.error.message).toContain('クラウド共有');
+		// 超過 body は ZIP 解析に進まない
+		expect(mockParseBackupZip).not.toHaveBeenCalled();
+	});
+
+	it('上限以内の ZIP は受理され ZIP 解析へ進む', async () => {
+		mockParseBackupZip.mockResolvedValue({ ok: true, value: { body: {}, staticFiles: {} } });
+		mockValidateExportData.mockReturnValue({ valid: false, error: 'stop-here' });
+		const res = await postZip(TEST_MAX_BYTES - 1);
+		expect(mockParseBackupZip).toHaveBeenCalledTimes(1);
+		// validate で意図的に止めている (受理判定の検証が目的)
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error.message).toBe('stop-here');
+	});
+});

--- a/tests/unit/services/import-limit.test.ts
+++ b/tests/unit/services/import-limit.test.ts
@@ -1,0 +1,59 @@
+// tests/unit/services/import-limit.test.ts
+// #3325 AC3: import 受理上限の実態整合 SSOT (import-limit.ts) の runtime 分岐検証。
+//
+// AWS 本番 (aws-prod) は CloudFront → Lambda Function URL (BUFFERED) の 6MB hard cap が
+// binding constraint のため 6MB 弱 (5.5MB) に下方整合し、NUC / local は Function URL 制約が
+// 無いため export ZIP と整合する従来上限 (100MB) を維持することを assert する。
+
+import { describe, expect, it } from 'vitest';
+import type { TypedEnv } from '../../../src/lib/runtime/env';
+import { MAX_ZIP_SIZE } from '../../../src/lib/server/services/backup-archive';
+import {
+	AWS_MAX_IMPORT_BYTES,
+	LOCAL_MAX_IMPORT_BYTES,
+	resolveMaxImportBytes,
+	toDisplayMb,
+} from '../../../src/lib/server/services/import-limit';
+
+/** resolveRuntimeMode が参照するフィールドのみ埋めた TypedEnv を作る。 */
+function envOf(overrides: Partial<TypedEnv>): TypedEnv {
+	return {
+		NODE_ENV: 'test',
+		APP_MODE: undefined,
+		IS_NUC_DEPLOY: undefined,
+		AWS_LAMBDA_FUNCTION_NAME: undefined,
+		...overrides,
+	} as TypedEnv;
+}
+
+describe('#3325 import-limit — 実行環境別の受理上限', () => {
+	it('aws-prod (AWS_LAMBDA_FUNCTION_NAME 設定) は Function URL 6MB 弱 (5.5MB) に整合する', () => {
+		const env = envOf({ AWS_LAMBDA_FUNCTION_NAME: 'ganbari-quest-app' });
+		expect(resolveMaxImportBytes(env)).toBe(AWS_MAX_IMPORT_BYTES);
+		// 6MB hard cap 未満であること (multipart/encoding overhead margin)
+		expect(AWS_MAX_IMPORT_BYTES).toBeLessThan(6 * 1024 * 1024);
+		expect(AWS_MAX_IMPORT_BYTES).toBe(Math.floor(5.5 * 1024 * 1024));
+	});
+
+	it('nuc-prod (IS_NUC_DEPLOY=true) は Function URL 制約が無いため従来上限 100MB を維持する', () => {
+		const env = envOf({ IS_NUC_DEPLOY: true });
+		expect(resolveMaxImportBytes(env)).toBe(LOCAL_MAX_IMPORT_BYTES);
+	});
+
+	it('local-debug (既定) も従来上限 100MB を維持する', () => {
+		expect(resolveMaxImportBytes(envOf({}))).toBe(LOCAL_MAX_IMPORT_BYTES);
+	});
+
+	it('APP_MODE=aws-prod の明示 override でも AWS 上限になる', () => {
+		expect(resolveMaxImportBytes(envOf({ APP_MODE: 'aws-prod' }))).toBe(AWS_MAX_IMPORT_BYTES);
+	});
+
+	it('NUC/local 上限は export ZIP 構築上限 (backup-archive MAX_ZIP_SIZE) と整合する (SSOT)', () => {
+		expect(LOCAL_MAX_IMPORT_BYTES).toBe(MAX_ZIP_SIZE);
+	});
+
+	it('toDisplayMb は小数 1 桁のユーザー向け MB 表示を返す', () => {
+		expect(toDisplayMb(AWS_MAX_IMPORT_BYTES)).toBe(5.5);
+		expect(toDisplayMb(LOCAL_MAX_IMPORT_BYTES)).toBe(100);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: バックアップの import / cloud export で「スピナーのまま何も分からない」「6MB 超がエッジで沈黙のまま弾かれる」「未 export データが無警告で失われる」という 3 つの不可視・不整合を解消する。

**期待される効果**:
- cloud export の「受付済み → 生成中 → ダウンロード可能 / 失敗」が UI で追える（#3324、NN/G #1 visibility）。ready になったらその場でダウンロードできる
- import が応答不能になっても client が無限ハングせず、明示エラーで再試行判断ができる（#3324）
- AWS 本番で 6MB 超のバックアップを選んだ時点で「上限超過 + クラウド共有経由の復元案内」が出る（#3325、NN/G error prevention。旧: エッジで弾かれ沈黙ハング）
- バックアップ形式に未収録のデータ種別があれば import 画面に registry 駆動で明示される（#3372。#3376 fail-closed export 完遂により現ベースラインは空 = 警告非表示）

## 関連 Issue

closes #3324
closes #3325
closes #3372

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| 3324-AC1 | replace モードで timeout が起きてもデータ消失しない | `npx vitest run tests/unit/services/replace-import-atomic.test.ts`（#3326 で実装済、本 PR は無改変） | HEAD `186c3480` / `src/lib/server/services/replace-import-service.ts` の `replaceImportAtomic` を route が使用（`src/routes/api/v1/import/+server.ts:100-104`）/ vitest PASS |
| 3324-AC2 | 大きめ backup でも import が完走する | 非同期 cloud export（#3509 実装済: `drainPendingExports` cron build）+ クラウド共有経由の復元経路 `/api/v1/import/cloud` | HEAD `186c3480` / `src/lib/server/services/cloud-export-service.ts:303` `drainPendingExports` / 6MB 超は cloud 経路へ誘導（3325-AC2） |
| 3324-AC3 | クライアントが無限ハングしない（AbortController/timeout でエラー表示） | code + 目視: `postImport` に AbortController + 120s timeout、abort 時 `SETTINGS_LABELS.dataImportTimeoutError` 表示 | HEAD `186c3480` / `src/routes/(parent)/admin/settings/data/+page.svelte:141-176`（controller + `isAbortError` 分岐）/ `src/lib/domain/labels.ts` `dataImportTimeoutError` |
| 3324-AC4 | 長時間処理に「受付/処理中/完了」の可視フィードバックがある | code + 目視: cloud export 一覧に status 表示（pending=受付済み・生成待ち / building=生成中… / failed=理由付き / ready=ダウンロード導線）+ in-flight 中のみ 5s polling | HEAD `186c3480` / `+page.svelte` `hasInFlightCloudExports` `$effect` polling（決着で自動停止、ADR-0012 整合）/ `data-testid="cloud-export-status-*"` / `cloud-export-download-link` |
| 3324-AC5 | 本番相当データ量での import 実機検証 | 28.86s 事象の直接原因（同期 build / clear-then-import / 無 timeout）は #3326 / #3509 で解消・検証済。本 PR の UI 層は Ready 化前にメインセッションの実ブラウザ確認（SS 撮影）で最終検証する | HEAD `186c3480` / backend 検証は `tests/unit/services/replace-import-atomic*.test.ts` + `cloud-export-service.test.ts` PASS（routes/services 全 suite exit 0） |
| 3324-AC6 | 設計書同期（07-API / 06-UI / 13-AWS 等） | `git diff` で docs 同期確認 | HEAD `186c3480` / `docs/design/07-API設計書.md`（import 受理上限の runtime 分岐）+ `docs/design/backup-import-redesign.md` P5 行更新 |
| 3325-AC1 | 6MB 超 backup でも import が配信・完走できる（S3 経由 or 同等） | クラウド共有経路（S3 保管 + PIN 復元 `/api/v1/import/cloud`、Function URL body 制約を迂回）が存在し、超過エラーが同経路を案内する | HEAD `186c3480` / `src/routes/api/v1/import/cloud/+server.ts` / 案内文言 `IMPORT_LABELS.errorFileTooLargeCloudGuide` |
| 3325-AC2 | 上限超過時に「沈黙のハング」でなく明確なエラー + 代替手段案内 | `npx vitest run tests/unit/routes/import-size-limit.test.ts` | HEAD `186c3480` / 2 passed（超過 → 400 VALIDATION_ERROR + 「クラウド共有」含む message / 以内 → 受理）/ `src/routes/api/v1/import/+server.ts:46-52` |
| 3325-AC3 | アプリ側上限（MAX_IMPORT_BYTES）と実インフラ上限の整合 | `npx vitest run tests/unit/services/import-limit.test.ts` | HEAD `186c3480` / 6 passed（aws-prod=5.5MB < 6MB hard cap / nuc-prod・local=100MB=`MAX_ZIP_SIZE`）/ `src/lib/server/services/import-limit.ts` |
| 3325-AC4 | 実サイズ（avatars/voices 同梱）backup での実機検証 | 上限判定は unit test で決定的検証（route mock で 1KB 境界の両側を検証）+ UI client-side pre-check は Ready 化前にメインセッションの実ブラウザ確認で最終検証する | HEAD `186c3480` / `tests/unit/routes/import-size-limit.test.ts` 2 passed / `+page.svelte` pre-check（`Math.min(staticMax, data.maxImportBytes)`） |
| 3325-AC5 | 設計書同期（07-API / 13-AWS のうち該当） | `git diff docs/design/07-API設計書.md` | HEAD `186c3480` / 受理上限の実行環境分岐 + SSOT パス + 超過時案内を明記（インフラ構成変更なしのため 13-AWS は対象外） |
| 3372-AC1 | import/restore UI に「未 export = 復元されない source」を registry 駆動で明示 | code + `npx vitest run tests/unit/db/backup-entity-registry.test.ts` | HEAD `186c3480` / `notYetExportedSourceLabels()`（`backup-entity-registry.ts`）→ `+page.server.ts` load → `+page.svelte` `role="status"` / `data-testid="import-partial-backup-warning"` |
| 3372-AC2 | 表示は非空のときのみ（export 実装が進むと自動で縮む） | 同上 vitest（ベースライン空 = 非表示を assert）+ `{#if data.notYetExportedLabels.length > 0}` | HEAD `186c3480` / `notYetExportedSourceLabels()` = `[]`（#3376 fail-closed 完遂後）/ 警告 block は非空時のみ描画 |
| 3372-AC3 | 内部コード露出禁止（not-yet-exported source の UI 表示名を強制） | `npx vitest run tests/unit/db/backup-entity-registry.test.ts` | HEAD `186c3480` / 「not-yet-exported な source は displayLabel 必須」test が追加時点で fail する機械強制（7 passed） |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — `backup-entity-registry.ts`（分類 SSOT、schema 変更なし）
- [x] サービス層 (`$lib/server/services/`) — `import-limit.ts` 新設
- [x] API エンドポイント (`src/routes/api/`) — `api/v1/import`
- [x] ページ / レイアウト (`src/routes/`) — `(parent)/admin/settings/data`
- [x] ドメインモデル (`$lib/domain/`) — labels.ts（SSOT ラベル追加）

**影響を受ける画面・機能**: 親管理画面 設定 > データ（export / import / クラウド共有）、`POST /api/v1/import` の受理上限

## テスト & 安全装置セルフチェック

- [ ] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— Ready 化前にメインセッションで実施する（Draft 時点: biome / svelte-check / vitest / cspell / hardcoded-strings / check-no-plan-literals / check-pr-body をローカル個別 PASS 済）
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/services/import-limit.test.ts`（新規）: 実行環境別上限（aws-prod 5.5MB / nuc-prod・local 100MB）+ `MAX_ZIP_SIZE` 整合 + 表示 MB 変換
  - `tests/unit/routes/import-size-limit.test.ts`（新規）: `POST /api/v1/import` の超過 400 + クラウド案内 / 以内受理の境界検証
  - `tests/unit/db/backup-entity-registry.test.ts`（更新）: `notYetExportedSourceLabels()` ベースライン空 + not-yet-exported source への `displayLabel` 必須の機械強制
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high / medium）

## スクリーンショット / ビジュアルデモ

**修正後 SS (PR HEAD 186c3480、AUTH_MODE=anonymous + DATA_SOURCE=demo の決定的環境 (ADR-0048) + ?screenshot=all で撮影)**:

| モバイル (390px) | PC (1280px) |
|---|---|
| ![settings-data-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3674/admin-settings-data-screenshot-all-mobile.png) | ![settings-data-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3674/admin-settings-data-screenshot-all-desktop.png) |

[DOM HTML (desktop)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3674/admin-settings-data-screenshot-all-desktop.dom.html) / [DOM HTML (mobile)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3674/admin-settings-data-screenshot-all-mobile.dom.html)

**修正前との差分**: 本 PR の UI 差分は (a) cloud export 一覧への status 表示 (pending / building spinner / failed / ready DL リンク — demo fixture では cloud export 0 件のため通常状態では非表示) (b) import ファイル選択時の client-side サイズ超過エラー文言 (c) partial-backup 警告 (`data-testid="import-partial-backup-warning"`、not-yet-exported source が非空のときのみ表示 — 現 baseline では #3376 fail-closed export 完遂により空 = 非表示)。(a)-(c) はいずれも**条件付き表示**でデフォルト描画は不変のため、デフォルト状態 SS を添付し、条件付き UI は各 unit test (import-limit.test.ts / import-size-limit.test.ts / backup-entity-registry.test.ts、17 passed) の DOM assert で担保する。

**インタラクティブ状態**: polling (building 中 5 秒間隔) / AbortController timeout (120s) は unit test で検証済み (視覚は role="status" スピナーのみ)。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 上限解決を `import-limit.ts` に単一責任で分離（route / load の 2 呼出点から共有）。registry 表示名は `backup-entity-registry.ts` の SSOT に閉じる
- [x] **DRY**: 上限値・案内文言は SSOT 1 箇所（`import-limit.ts` / `IMPORT_LABELS.errorFileTooLargeCloudGuide`）を server / client で共有。既存 `MAX_ZIP_SIZE` を再利用し重複定数を作らない
- [x] **YAGNI**: SSE / 専用 status endpoint は追加せず既存 `listCloudExports` polling のみ（async-backup-export.md §3.3 準拠）
- [x] **Security（OSS 公開前提）**: 新規エンドポイントなし。DL 導線は既存の認証 + tenant 束縛 + DL カウンタ経路（#3504 §3.4）への `<a>` のみ。エラー文言は labels SSOT で内部情報非露出
- [x] **アクセシビリティ**: status / 警告は `role="status"`、spinner は `aria-hidden`、DL / 削除は Button primitive
- [x] **パフォーマンス**: polling は in-flight 存在時のみ 5s、全件決着で `clearInterval`（常時 polling なし、ADR-0012 整合）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] **labels SSOT** (ADR-0009): 新規文言は全て `labels.ts`（`SETTINGS_LABELS.cloudStatus*` / `dataImportTimeoutError` / `dataImportPartialBackupWarning`、`IMPORT_LABELS.errorFileTooLargeCloudGuide`）経由。リテラル直書きなし（`check-hardcoded-strings` baseline 0 維持 / `check-no-plan-literals` PASS）
- [x] **設計書同期** (ADR-0001): `docs/design/07-API設計書.md`（import 受理上限）+ `docs/design/backup-import-redesign.md`（P5 実装状況）を同 PR で更新
- [x] **並行 PR overlap** (#1200): settings/data / import route を変更する他の open PR なし（`gh pr list` 確認）
- [x] N/A — 子供画面 / 年齢モード / ナビ / デモ fixture / チュートリアルは対象外（親管理画面 1 画面 + API 1 本のみ）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（AWS の import 受理上限は 100MB → 5.5MB に狭まるが、旧上限は Function URL 6MB hard cap によりそもそも到達不能で、実挙動は「沈黙のハング → 明示エラー + 代替案内」への改善）

**レビュー依頼事項・QA**:
- **NUC 上限分岐の設計判断**: NUC（セルフホスト）は Lambda Function URL を経由しないため 6MB 制約が存在しない。`$lib/runtime`（`resolveRuntimeMode`）確認の結果、`aws-prod`（`AWS_LAMBDA_FUNCTION_NAME` 検出）のときのみ 5.5MB（6MB hard cap - encoding/multipart margin）へ下方整合し、`nuc-prod` / `local-debug` は従来の 100MB（export ZIP `MAX_ZIP_SIZE` と同値）を維持する設計とした。判定は既存の runtime mode 純関数を再利用し、env 直接参照はしない（`import-limit.ts` が `getEnv()` 経由、test は env 注入で分岐検証）
- client timeout 120s の妥当性: サーバ側は Lambda/CloudFront 30s で必ず決着する一方、NUC の大きめ import は制約がないため、安全上限として 120s を採用（`IMPORT_FETCH_TIMEOUT_MS` 1 箇所で調整可能）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **pre-ready 構成 step のローカル検証**: biome / cspell / svelte-check / vitest（routes / services / db 対象 suite）/ check-hardcoded-strings / check-no-plan-literals / check-pr-body を個別 PASS。`npm run pre-ready -- --pr <num>` の一括再実行（Step 11b SS embed gate 含む）は Ready 化直前にメインセッションが実施する（本 PR は Draft のまま引き渡し、`gh pr ready` は行わない）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完遂のまま残っている AC がない。AC 検証マップ参照）
- [x] Phase 分割した場合: N/A（本 PR で 3 Issue の残 scope を完遂）
- [x] UI 変更時 SS の扱い: Draft 時点では未添付。Ready 化前にメインセッションで撮影・添付し、GitHub 上での表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点の目視確認まで行ってから Ready 化する
- [x] 認証画面変更時: N/A（settings/data は認証画面ではない）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

