### PR TITLE
infra: #3459 main 反映済 open issue の close 漏れ検知 report (auto-close なし)

### DIFF
--- a/.github/workflows/close-leak-report.yml
+++ b/.github/workflows/close-leak-report.yml
@@ -1,0 +1,64 @@
+# close-leak-report.yml — Issue #3459 (#3423 AC4)
+#
+# 「fix は main 反映済だが issue が open のまま」の close漏れ候補を週次で検出し、
+# job summary に一覧 report を出す補助 job。**auto-close はしない** (誤爆回避、#3423 選択肢 B 却下)。
+# 人間が report を見て手動 close (AC gate 経由) する棚卸し材料を自動生成する。
+#
+# 設計判断 (integration-pr.yml 相乗りではなく独立 workflow にした理由):
+#   - integration-pr.yml は「統合 PR upsert」専用の薄い orchestrator で、permissions
+#     (pull-requests: write + App token) / concurrency group / checkout 深度が本 job と異なる。
+#     本 job は issues:read + 全 git 履歴 (fetch-depth: 0) が必要で、混載すると両者の
+#     最小権限原則が崩れる。
+#   - weekly-report.yml / code-quality-weekly.yml と同じ「目的別の軽量週次 workflow」慣行に合流。
+#
+# 検出ロジック SSOT: scripts/audit/close-leak-report.mjs (純関数 unit test =
+# tests/unit/audit/close-leak-report.test.ts)。本 workflow は薄い orchestrator (#1442 同型)。
+#
+# 止血の主機構は #3423 AC2 (統合 PR の Closes 集約) + #3458 AC1 (per-PR closing-keyword gate)。
+# 本 job は既存 backlog の取りこぼし (C 層 #3133/#3246/#3088 型) の掃除用。
+
+name: close-leak-report
+
+on:
+  schedule:
+    # 週 1 (月曜 JST 07:00 = 日曜 UTC 22:00)。integration-pr cron (月・木 UTC 21:00) の
+    # 翌朝に前週分の取りこぼしを棚卸しする想定
+    - cron: '0 22 * * 0'
+  workflow_dispatch:
+    inputs:
+      since:
+        description: '走査期間 (git approxidate、例: "30 days ago")'
+        required: false
+        default: '90 days ago'
+        type: string
+
+concurrency:
+  group: close-leak-report
+  cancel-in-progress: false
+
+# report only — issue への書き込みは一切しない (auto-close なし、最小権限)
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  report:
+    name: close漏れ取りこぼし検知 report (auto-close なし)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # main 反映済判定に全 git 履歴が必要 (git log origin/main --since)
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      # script が markdown report を stdout + GITHUB_STEP_SUMMARY へ出力する。
+      # 検出 0 件でも N 件でも exit 0 (gate ではない)。
+      - name: Detect close leaks (report only)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/audit/close-leak-report.mjs --since "${{ inputs.since || '90 days ago' }}"

--- a/docs/sessions/branch-strategy.md
+++ b/docs/sessions/branch-strategy.md
@@ -167,6 +167,7 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 | `code-quality-weekly.yml` | N/A（schedule weekly / dispatch） | — | — | 定期監査 |
 | `security-scan.yml` | N/A（schedule quarterly / dispatch） | — | — | 定期監査 |
 | `weekly-report.yml` | N/A（schedule weekly / dispatch） | — | — | 定期レポート |
+| `close-leak-report.yml` | N/A（schedule weekly / dispatch、main 反映済 open issue の close漏れ候補を job summary へ report。auto-close なし = `issues: read` のみ） | — | — | 定期レポート（#3459、検出 SSOT は `scripts/audit/close-leak-report.mjs`） |
 | `gcp-terraform.yml` | N/A（`workflow_dispatch` のみ） | — | — | infra（手動） |
 | `zenn-lint.yml` | N/A（push/PR `paths:docs/zenn/**`、lint 専用） | — | なし（docs/zenn のみ、lane 非依存） | 軽量（zenn 限定） |
 

--- a/scripts/audit/close-leak-report.mjs
+++ b/scripts/audit/close-leak-report.mjs
@@ -1,0 +1,303 @@
+/**
+ * scripts/audit/close-leak-report.mjs (#3459 = #3423 AC4)
+ *
+ * close漏れ取りこぼし検知 report — 「fix は main 反映済だが issue が open のまま」を検出し
+ * 一覧 report を出力する補助 job。**auto-close は絶対にしない**（誤爆回避、#3423 選択肢 C 却下と同根拠）。
+ *
+ * 背景: 0 件化キャンペーン (2026-07-11 監査セッション) で、この class の close漏れが 35+ 件
+ * 発見・手動 close された。C 層パターン (#3133 / #3246 / #3088 等) = 実装コミットは main 反映済
+ * (conventional commit subject に `fix(scope): #N ...` の形で issue 参照) だが、develop 二層 +
+ * squash merge で closing keyword が main に到達せず GitHub auto-close が不発火 → open のまま残る。
+ * 止血の主機構は #3423 AC2 (統合 PR の Closes 集約) + #3458 AC1 (per-PR gate)。本 script は
+ * 既存 backlog の棚卸し (掃除用 report) を自動化する。
+ *
+ * 検出ヒューリスティック:
+ *   open issue 一覧 (gh issue list) × main コミット log (git log --since) の突合。
+ *   コミット subject の issue 参照 (`#N` / `＃N`、squash PR 番号 `(#N)` 末尾は除外) と
+ *   コミット body の closing keyword 行 (`Closes #N` 等、#3444 の行頭アンカー方式と同型) を採用。
+ *   誤検知 (EPIC / 進行中 workstream / 部分対応 PR の参照) は **report に含めて人間が判断**する
+ *   (auto-close しないため false positive 許容。labels 列 + 該当コミット列で判断材料を併記)。
+ *
+ * GH API / git 呼び出し (副作用) と判定純関数を分離。純関数は
+ * tests/unit/audit/close-leak-report.test.ts で unit test 済。
+ *
+ * 使用例:
+ *   node scripts/audit/close-leak-report.mjs                       # markdown report を stdout へ
+ *   node scripts/audit/close-leak-report.mjs --since "30 days ago" # 走査期間変更
+ *   node scripts/audit/close-leak-report.mjs --json                # JSON 出力 (機械処理用)
+ *
+ * CI: .github/workflows/close-leak-report.yml (週次 cron + workflow_dispatch) が実行し
+ *     GITHUB_STEP_SUMMARY へ report を書き込む。exit code は常に 0 (report only、gate ではない)。
+ */
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+/** 既定の走査期間 (git approxidate)。週次 cron 運用で直近の close漏れを拾いつつ noise を抑える */
+export const DEFAULT_SINCE = '90 days ago';
+
+/** 既定の走査対象 ref (main 反映済判定の基準) */
+export const DEFAULT_REF = 'origin/main';
+
+/** git log の record / field separator (RS / US 制御文字、コミット本文と衝突しない) */
+const RECORD_SEP = '\u001e';
+const FIELD_SEP = '\u001f';
+
+/** merge commit subject (`Merge pull request #N` / `Merge branch ...`) — #N は PR 番号のため subject 走査から除外 */
+const MERGE_SUBJECT_RE = /^Merge (?:pull request #\d+|branch\b|remote-tracking branch\b)/;
+
+/** subject 末尾の squash merge PR 番号 `(#N)` — issue 参照ではないため strip */
+const TRAILING_PR_NUMBER_RE = /\s*\(#\d+\)\s*$/;
+
+/** issue 参照 (半角 `#` / 全角 `＃`、#3444 の under-close 教訓と同型) */
+const ISSUE_REF_RE = /[#＃](\d+)/g;
+
+/**
+ * body 内の行頭 closing keyword 行のみを拾う正規表現 (#3444 `extractClosedIssues` と同型の
+ * 行頭アンカー方式)。body 全参照を拾うと `関連: #N` 等の部分対応参照で noise が増えるため、
+ * closing keyword 宣言のみを採用する。
+ */
+const CLOSING_KEYWORD_LINE_RE =
+	/^[ \t]*(?:[-*+][ \t]+)?(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)[ \t]*:?[ \t]*[#＃](\d+)/gim;
+
+/**
+ * `git log --format=%H%x1f%ad%x1f%s%x1f%b%x1e` の raw 出力をコミット record 配列に parse する純関数。
+ *
+ * @param {string} raw
+ * @returns {Array<{ sha: string; date: string; subject: string; body: string }>}
+ */
+export function parseGitLog(raw) {
+	if (typeof raw !== 'string' || raw.trim() === '') return [];
+	const records = [];
+	for (const chunk of raw.split(RECORD_SEP)) {
+		const trimmed = chunk.replace(/^\s+/, '');
+		if (trimmed === '') continue;
+		const [sha, date, subject, body] = trimmed.split(FIELD_SEP);
+		if (!sha || !subject) continue;
+		records.push({
+			sha,
+			date: date ?? '',
+			subject: subject.trim(),
+			body: (body ?? '').trim(),
+		});
+	}
+	return records;
+}
+
+/**
+ * 1 コミットから issue 参照番号を抽出する純関数。
+ *
+ * - subject: 全 `#N` / `＃N` を採用。ただし merge commit subject は PR 番号のため全体を skip、
+ *   subject 末尾の squash PR 番号 `(#N)` は strip する。
+ * - body: 行頭 closing keyword 行 (`Closes #N` 等) のみ採用 (`関連: #N` は拾わない)。
+ *
+ * PR 番号の誤混入は後段の「open issue 番号との突合」で自然に落ちる (同一連番空間のため
+ * PR 番号が open issue 番号と一致することはない) が、subject 側でも除外して精度を上げる。
+ *
+ * @param {{ subject?: string; body?: string }} commit
+ * @returns {number[]} 昇順・重複排除した issue 番号
+ */
+export function extractCommitIssueRefs(commit) {
+	const set = new Set();
+	const subject = typeof commit?.subject === 'string' ? commit.subject : '';
+	const body = typeof commit?.body === 'string' ? commit.body : '';
+
+	if (subject !== '' && !MERGE_SUBJECT_RE.test(subject)) {
+		const stripped = subject.replace(TRAILING_PR_NUMBER_RE, '');
+		ISSUE_REF_RE.lastIndex = 0;
+		for (const m of stripped.matchAll(ISSUE_REF_RE)) {
+			const n = Number(m[1]);
+			if (Number.isInteger(n) && n > 0) set.add(n);
+		}
+	}
+
+	CLOSING_KEYWORD_LINE_RE.lastIndex = 0;
+	for (const m of body.matchAll(CLOSING_KEYWORD_LINE_RE)) {
+		const n = Number(m[1]);
+		if (Number.isInteger(n) && n > 0) set.add(n);
+	}
+
+	return [...set].sort((a, b) => a - b);
+}
+
+/**
+ * label が epic / tracker 系か (人間判断の材料として flag 付けするのみ、除外はしない)。
+ *
+ * @param {Array<string | { name?: string }>} labels
+ * @returns {boolean}
+ */
+export function isEpicLike(labels) {
+	return (labels ?? []).some((l) => {
+		const name = typeof l === 'string' ? l : (l?.name ?? '');
+		return /epic|tracker/i.test(name);
+	});
+}
+
+/**
+ * open issue 一覧 × main コミット群を突合し close漏れ候補を返す純関数。
+ *
+ * @param {{
+ *   openIssues: Array<{ number: number; title?: string; labels?: Array<string | { name?: string }> }>;
+ *   commits: Array<{ sha: string; date: string; subject: string; body?: string }>;
+ * }} input
+ * @returns {Array<{
+ *   number: number;
+ *   title: string;
+ *   labels: string[];
+ *   epicLike: boolean;
+ *   commits: Array<{ sha: string; date: string; subject: string }>;
+ * }>} issue 番号昇順。main 反映コミットが 1 件も無い open issue は含まれない
+ */
+export function detectCloseLeaks({ openIssues, commits }) {
+	/** @type {Map<number, Array<{ sha: string; date: string; subject: string }>>} */
+	const byIssue = new Map();
+	for (const c of commits ?? []) {
+		for (const n of extractCommitIssueRefs(c)) {
+			if (!byIssue.has(n)) byIssue.set(n, []);
+			byIssue.get(n)?.push({ sha: c.sha, date: c.date, subject: c.subject });
+		}
+	}
+
+	const leaks = [];
+	for (const issue of openIssues ?? []) {
+		const n = Number(issue?.number);
+		if (!Number.isInteger(n) || n <= 0) continue;
+		const matched = byIssue.get(n);
+		if (!matched || matched.length === 0) continue;
+		const labels = (issue.labels ?? []).map((l) => (typeof l === 'string' ? l : (l?.name ?? '')));
+		leaks.push({
+			number: n,
+			title: issue.title ?? '',
+			labels,
+			epicLike: isEpicLike(issue.labels ?? []),
+			commits: matched,
+		});
+	}
+	return leaks.sort((a, b) => a.number - b.number);
+}
+
+/** markdown table cell escape (pipe / 改行) */
+function escapeCell(s) {
+	return String(s ?? '')
+		.replace(/\|/g, '\\|')
+		.replace(/\r?\n/g, ' ');
+}
+
+/**
+ * close漏れ候補の markdown report を組み立てる純関数。
+ *
+ * @param {ReturnType<typeof detectCloseLeaks>} leaks
+ * @param {{ since?: string; ref?: string; totalOpen?: number; totalCommits?: number }} [meta]
+ * @returns {string}
+ */
+export function buildCloseLeakReport(leaks, meta = {}) {
+	const since = meta.since ?? DEFAULT_SINCE;
+	const ref = meta.ref ?? DEFAULT_REF;
+	const lines = [
+		'## close漏れ取りこぼし検知 report (#3459 / #3423 AC4)',
+		'',
+		`- 走査対象: \`${ref}\` の直近コミット (since: ${since})${typeof meta.totalCommits === 'number' ? ` ${meta.totalCommits} 件` : ''}`,
+		`- open issue: ${typeof meta.totalOpen === 'number' ? `${meta.totalOpen} 件` : '(件数不明)'}`,
+		`- **検出: ${leaks.length} 件** (main 反映済コミットが issue 番号を参照しているのに open のまま)`,
+		'',
+		'> **auto-close はしません**。本 report は人間が一覧を見て手動 close (AC gate 経由) するための',
+		'> 棚卸し材料です。EPIC / 進行中 workstream / 部分対応 PR の参照は false positive のため、',
+		'> labels 列と該当コミットを見て判断してください。',
+		'',
+	];
+
+	if (leaks.length === 0) {
+		lines.push('close漏れ候補は検出されませんでした。');
+		lines.push('');
+		return lines.join('\n');
+	}
+
+	lines.push('| Issue | タイトル | labels | main 反映コミット (該当分) |');
+	lines.push('|---|---|---|---|');
+	for (const leak of leaks) {
+		const flag = leak.epicLike ? ' ⚠️epic/tracker' : '';
+		const commits = leak.commits
+			.map((c) => `\`${c.sha.slice(0, 8)}\` (${c.date}) ${escapeCell(c.subject)}`)
+			.join('<br>');
+		lines.push(
+			`| #${leak.number} | ${escapeCell(leak.title)} | ${escapeCell(leak.labels.join(', '))}${flag} | ${commits} |`,
+		);
+	}
+	lines.push('');
+	return lines.join('\n');
+}
+
+/**
+ * CLI 引数 parse (純関数)。
+ *
+ * @param {string[]} argv
+ * @returns {{ since: string; ref: string; limit: number; json: boolean }}
+ */
+export function parseArgs(argv) {
+	const out = { since: DEFAULT_SINCE, ref: DEFAULT_REF, limit: 500, json: false };
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === '--since' && argv[i + 1]) out.since = argv[++i];
+		else if (a === '--ref' && argv[i + 1]) out.ref = argv[++i];
+		else if (a === '--limit' && argv[i + 1]) out.limit = Number(argv[++i]) || out.limit;
+		else if (a === '--json') out.json = true;
+	}
+	return out;
+}
+
+// ---------------------------------------------------------------------------
+// 以下は副作用層 (gh / git 呼び出し + 出力)。純関数の unit test 対象外。
+// ---------------------------------------------------------------------------
+
+/** gh CLI で open issue 一覧を取得する */
+function fetchOpenIssues(limit) {
+	const raw = execFileSync(
+		'gh',
+		['issue', 'list', '--state', 'open', '--limit', String(limit), '--json', 'number,title,labels'],
+		{ encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+	);
+	return JSON.parse(raw);
+}
+
+/** git log を RS/US 区切り raw で取得する */
+function fetchGitLogRaw(ref, since) {
+	return execFileSync(
+		'git',
+		[
+			'log',
+			ref,
+			`--since=${since}`,
+			'--date=short',
+			`--format=%H${FIELD_SEP}%ad${FIELD_SEP}%s${FIELD_SEP}%b${RECORD_SEP}`,
+		],
+		{ encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+	);
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const openIssues = fetchOpenIssues(args.limit);
+	const commits = parseGitLog(fetchGitLogRaw(args.ref, args.since));
+	const leaks = detectCloseLeaks({ openIssues, commits });
+
+	if (args.json) {
+		console.log(JSON.stringify({ since: args.since, ref: args.ref, leaks }, null, 2));
+	} else {
+		const report = buildCloseLeakReport(leaks, {
+			since: args.since,
+			ref: args.ref,
+			totalOpen: openIssues.length,
+			totalCommits: commits.length,
+		});
+		console.log(report);
+		if (process.env.GITHUB_STEP_SUMMARY) {
+			appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${report}\n`, 'utf8');
+		}
+	}
+	// report only — 検出 0 件でも N 件でも exit 0 (gate ではない、AC2)
+	process.exit(0);
+}
+
+const isMain = process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) main();

--- a/scripts/audit/close-leak-report.mjs
+++ b/scripts/audit/close-leak-report.mjs
@@ -177,7 +177,11 @@ export function detectCloseLeaks({ openIssues, commits }) {
 	return leaks.sort((a, b) => a.number - b.number);
 }
 
-/** markdown table cell escape (pipe / 改行) */
+/**
+ * markdown table cell escape (pipe / 改行)
+ * @param {unknown} s
+ * @returns {string}
+ */
 function escapeCell(s) {
 	return String(s ?? '')
 		.replace(/\|/g, '\\|')
@@ -238,10 +242,19 @@ export function parseArgs(argv) {
 	const out = { since: DEFAULT_SINCE, ref: DEFAULT_REF, limit: 500, json: false };
 	for (let i = 0; i < argv.length; i++) {
 		const a = argv[i];
-		if (a === '--since' && argv[i + 1]) out.since = argv[++i];
-		else if (a === '--ref' && argv[i + 1]) out.ref = argv[++i];
-		else if (a === '--limit' && argv[i + 1]) out.limit = Number(argv[++i]) || out.limit;
-		else if (a === '--json') out.json = true;
+		const next = argv[i + 1];
+		if (a === '--since' && next) {
+			out.since = next;
+			i++;
+		} else if (a === '--ref' && next) {
+			out.ref = next;
+			i++;
+		} else if (a === '--limit' && next) {
+			out.limit = Number(next) || out.limit;
+			i++;
+		} else if (a === '--json') {
+			out.json = true;
+		}
 	}
 	return out;
 }
@@ -250,7 +263,11 @@ export function parseArgs(argv) {
 // 以下は副作用層 (gh / git 呼び出し + 出力)。純関数の unit test 対象外。
 // ---------------------------------------------------------------------------
 
-/** gh CLI で open issue 一覧を取得する */
+/**
+ * gh CLI で open issue 一覧を取得する
+ * @param {number} limit
+ * @returns {Array<{ number: number; title?: string; labels?: Array<{ name?: string }> }>}
+ */
 function fetchOpenIssues(limit) {
 	const raw = execFileSync(
 		'gh',
@@ -260,7 +277,12 @@ function fetchOpenIssues(limit) {
 	return JSON.parse(raw);
 }
 
-/** git log を RS/US 区切り raw で取得する */
+/**
+ * git log を RS/US 区切り raw で取得する
+ * @param {string} ref
+ * @param {string} since
+ * @returns {string}
+ */
 function fetchGitLogRaw(ref, since) {
 	return execFileSync(
 		'git',

--- a/tests/unit/audit/close-leak-report.test.ts
+++ b/tests/unit/audit/close-leak-report.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildCloseLeakReport,
+	DEFAULT_REF,
+	DEFAULT_SINCE,
+	detectCloseLeaks,
+	extractCommitIssueRefs,
+	isEpicLike,
+	parseArgs,
+	parseGitLog,
+} from '../../../scripts/audit/close-leak-report.mjs';
+
+const RS = String.fromCharCode(0x1e);
+const US = String.fromCharCode(0x1f);
+
+const commit = (subject: string, body = '', sha = 'a'.repeat(40), date = '2026-07-01') => ({
+	sha,
+	date,
+	subject,
+	body,
+});
+
+describe('parseGitLog', () => {
+	it('RS/US 区切り raw を record 配列に parse する', () => {
+		const raw = [
+			`sha1${US}2026-07-01${US}fix: #100 subject${US}body line${RS}`,
+			`\nsha2${US}2026-07-02${US}feat: #200 second${US}${RS}`,
+		].join('');
+		expect(parseGitLog(raw)).toEqual([
+			{ sha: 'sha1', date: '2026-07-01', subject: 'fix: #100 subject', body: 'body line' },
+			{ sha: 'sha2', date: '2026-07-02', subject: 'feat: #200 second', body: '' },
+		]);
+	});
+
+	it('空入力 / 非文字列は空配列', () => {
+		expect(parseGitLog('')).toEqual([]);
+		expect(parseGitLog('   \n ')).toEqual([]);
+		// @ts-expect-error 純関数の防御動作検証
+		expect(parseGitLog(undefined)).toEqual([]);
+	});
+});
+
+describe('extractCommitIssueRefs — C 層 close漏れパターン (#3133/#3246/#3088 実データ形)', () => {
+	it('#3133 型: conventional subject の issue 参照を拾い、末尾 squash PR 番号 (#N) は除外する', () => {
+		const refs = extractCommitIssueRefs(
+			commit(
+				'fix(security): #3133 /tenants + /uploads/avatars の cross-tenant IDOR を tenant 一致検証で封殺 (#3137)',
+			),
+		);
+		expect(refs).toEqual([3133]); // #3137 (PR 番号) は含まれない
+	});
+
+	it('#3246 型: 括弧内の追加参照 (#3244 HOLD) も候補として拾う (report-only、人間が判断)', () => {
+		const refs = extractCommitIssueRefs(
+			commit(
+				'fix(security): #3246 export endpoint を import と対称な owner/parent gate に揃える（家庭内 IDOR、#3244 HOLD） (#3249)',
+			),
+		);
+		expect(refs).toEqual([3244, 3246]);
+	});
+
+	it('#3088 型: perf prefix でも subject の issue 参照を拾う', () => {
+		const refs = extractCommitIssueRefs(
+			commit(
+				'perf: #3088 admin landing load を並列化 — 逐次 await + per-child N+1 の wall-clock を短縮 (#3120)',
+			),
+		);
+		expect(refs).toEqual([3088]);
+	});
+
+	it('merge commit subject (Merge pull request #N) は PR 番号のため拾わない', () => {
+		expect(
+			extractCommitIssueRefs(
+				commit('Merge pull request #3570 from Takenori-Kusaka/release/2026-07-03'),
+			),
+		).toEqual([]);
+		expect(extractCommitIssueRefs(commit('Merge branch main into develop'))).toEqual([]);
+	});
+
+	it('body の行頭 closing keyword 行 (Closes #N / 全角 ＃) を拾う', () => {
+		const refs = extractCommitIssueRefs(
+			commit('chore: no subject ref', 'Closes #123\nfixes: ＃456\n- resolves #789'),
+		);
+		expect(refs).toEqual([123, 456, 789]);
+	});
+
+	it('body の非 closing 参照 (関連: #N / 文中の closes #N) は拾わない', () => {
+		const refs = extractCommitIssueRefs(
+			commit('docs: update readme', '関連: #999\nsee also closes #888 in prior PR'),
+		);
+		expect(refs).toEqual([]);
+	});
+
+	it('subject の全角 ＃ 参照も拾う (#3444 under-close 教訓と同型)', () => {
+		expect(extractCommitIssueRefs(commit('fix: ＃3200 全角参照'))).toEqual([3200]);
+	});
+
+	it('空 commit は空配列', () => {
+		expect(extractCommitIssueRefs({})).toEqual([]);
+	});
+});
+
+describe('isEpicLike', () => {
+	it('epic / tracker label を flag する (string / object 両対応)', () => {
+		expect(isEpicLike(['epic'])).toBe(true);
+		expect(isEpicLike([{ name: 'type:infra' }, { name: 'EPIC' }])).toBe(true);
+		expect(isEpicLike([{ name: 'tracker' }])).toBe(true);
+		expect(isEpicLike([{ name: 'priority:medium' }])).toBe(false);
+		expect(isEpicLike([])).toBe(false);
+	});
+});
+
+describe('detectCloseLeaks', () => {
+	const commits = [
+		commit('fix(security): #3133 IDOR 封殺 (#3137)', '', 'c1'.padEnd(40, '0'), '2026-06-20'),
+		commit('perf: #3088 admin landing 並列化 (#3120)', '', 'c2'.padEnd(40, '0'), '2026-06-25'),
+		commit('feat: #7777 未 open の参照', '', 'c3'.padEnd(40, '0'), '2026-06-26'),
+	];
+
+	it('open issue × main コミット参照の積集合のみを leak として返す (issue 番号昇順)', () => {
+		const leaks = detectCloseLeaks({
+			openIssues: [
+				{ number: 3133, title: 'IDOR issue', labels: [{ name: 'type:security' }] },
+				{ number: 3088, title: 'perf issue', labels: ['epic'] },
+				{ number: 5000, title: 'main 未反映の open issue', labels: [] },
+			],
+			commits,
+		});
+		expect(leaks.map((l) => l.number)).toEqual([3088, 3133]);
+		expect(leaks[0]).toMatchObject({
+			number: 3088,
+			epicLike: true,
+			labels: ['epic'],
+		});
+		expect(leaks[0].commits).toEqual([
+			{
+				sha: 'c2'.padEnd(40, '0'),
+				date: '2026-06-25',
+				subject: 'perf: #3088 admin landing 並列化 (#3120)',
+			},
+		]);
+		expect(leaks[1]).toMatchObject({ number: 3133, epicLike: false });
+	});
+
+	it('コミット参照 (#7777) があっても open issue に無ければ返さない (closed 済 / PR 番号)', () => {
+		const leaks = detectCloseLeaks({
+			openIssues: [{ number: 1, title: 'unrelated', labels: [] }],
+			commits,
+		});
+		expect(leaks).toEqual([]);
+	});
+
+	it('空入力は空配列', () => {
+		expect(detectCloseLeaks({ openIssues: [], commits: [] })).toEqual([]);
+	});
+});
+
+describe('buildCloseLeakReport', () => {
+	it('0 件時は「検出されませんでした」+ auto-close しない注記', () => {
+		const md = buildCloseLeakReport([], {
+			since: '90 days ago',
+			ref: 'origin/main',
+			totalOpen: 10,
+			totalCommits: 5,
+		});
+		expect(md).toContain('検出: 0 件');
+		expect(md).toContain('auto-close はしません');
+		expect(md).toContain('close漏れ候補は検出されませんでした');
+		expect(md).toContain('open issue: 10 件');
+	});
+
+	it('N 件時は markdown table + epic flag + pipe escape を出力する', () => {
+		const md = buildCloseLeakReport([
+			{
+				number: 3133,
+				title: 'IDOR | pipe を含む title',
+				labels: ['type:security'],
+				epicLike: false,
+				commits: [
+					{ sha: 'abcdef1234567890', date: '2026-06-20', subject: 'fix: #3133 封殺 (#3137)' },
+				],
+			},
+			{
+				number: 3400,
+				title: 'EPIC 親',
+				labels: ['epic'],
+				epicLike: true,
+				commits: [{ sha: 'fedcba0987654321', date: '2026-06-21', subject: 'feat: #3400 partial' }],
+			},
+		]);
+		expect(md).toContain('検出: 2 件');
+		expect(md).toContain('| #3133 | IDOR \\| pipe を含む title |');
+		expect(md).toContain('`abcdef12` (2026-06-20)');
+		expect(md).toContain('⚠️epic/tracker');
+	});
+});
+
+describe('parseArgs', () => {
+	it('デフォルト値 (since 90 days ago / ref origin/main / limit 500 / json false)', () => {
+		expect(parseArgs([])).toEqual({
+			since: DEFAULT_SINCE,
+			ref: DEFAULT_REF,
+			limit: 500,
+			json: false,
+		});
+	});
+
+	it('--since / --ref / --limit / --json を parse する', () => {
+		expect(
+			parseArgs(['--since', '30 days ago', '--ref', 'main', '--limit', '100', '--json']),
+		).toEqual({
+			since: '30 days ago',
+			ref: 'main',
+			limit: 100,
+			json: true,
+		});
+	});
+});

--- a/tests/unit/audit/close-leak-report.test.ts
+++ b/tests/unit/audit/close-leak-report.test.ts
@@ -132,7 +132,7 @@ describe('detectCloseLeaks', () => {
 			epicLike: true,
 			labels: ['epic'],
 		});
-		expect(leaks[0].commits).toEqual([
+		expect(leaks[0]?.commits).toEqual([
 			{
 				sha: 'c2'.padEnd(40, '0'),
 				date: '2026-06-25',


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / PO（backlog 健全性・状況把握）

**解決する課題**: 2026-07-11 の監査セッションで「実装は main 反映済だが issue が open のまま」の close漏れが **35 件以上**発見・手動 close された。止血の主機構 (#3423 AC2 統合 PR Closes 集約 / #3458 AC1 per-PR gate) が導入されても、既存 backlog の取りこぼしと gate をすり抜けた C 層 (#3133/#3246/#3088 型) は残るため、棚卸しを毎回人手で行う必要があった。

**期待される効果**: open issue × main コミット log の突合を週次で自動実行し、close漏れ候補の一覧 report を job summary に出す。**auto-close はしない**（誤爆回避、#3423 選択肢 B 却下と同根拠）ため false positive 許容で recall を優先し、人間が labels + 該当コミットを見て手動 close (AC gate 経由) する。

## 関連 Issue

closes #3459

- related: #3423（親、AC4）/ PR #3444（AC2/AC3/AC5 実装、QM BLOCK 指摘 (3) で AC4 を本 Issue に分離）/ #3458（AC1）/ #2949

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | main 反映済 open issue を検出する補助 job を追加 | ローカル一発実行 + workflow 追加 | ✅ `node scripts/audit/close-leak-report.mjs` → open 105 件 × main 直近 90 日 1,197 commit を突合し **6 件検出**（下記「ローカル実行の実検出結果」）。`.github/workflows/close-leak-report.yml`（週次 cron + workflow_dispatch） |
| AC2 | auto-close しない。検出結果を一覧 report（job summary）出力 | コード検査 + workflow permissions | ✅ script は report 出力のみで常に exit 0（gate ではない）。workflow permissions は `issues: read` のみ（書き込み権限なし = 構造的に auto-close 不能）。report は stdout + `GITHUB_STEP_SUMMARY` へ出力 |
| AC3 | close漏れパターン（C 層 #3133/#3246/#3088）を検出できることを検証 | 実データ形 unit test + 実 git log シミュレーション | ✅ unit test で実コミット subject 形（`fix(security): #3133 ... (#3137)` 等）3 パターンを固定。さらに実 `origin/main` git log × 「#3133/#3246/#3088 が open だったと仮定」で 3/3 検出を実証（下記「C 層 3 件の検出実証」） |
| AC4 | 純関数（参照 issue 抽出 / open 判定）の unit test | `npx vitest run tests/unit/audit/close-leak-report.test.ts` | ✅ 18 passed（parseGitLog / extractCommitIssueRefs / isEpicLike / detectCloseLeaks / buildCloseLeakReport / parseArgs）。GH API / git 呼び出しは副作用層に分離済 |

### ローカル実行の実検出結果（動作実証、2026-07-12 時点）

`node scripts/audit/close-leak-report.mjs`（since: 90 days ago、open 105 件 × main 1,197 commit → **検出 6 件**）:

| Issue | 種別（人間判断の見立て） | main 反映コミット | 判断材料（report 掲載内容） |
|---|---|---|---|
| #2873 | close漏れ候補 | `569c02c4` infra: #2873 AWS staging stack 新設 (#3004) | `quality:ac-incomplete` label 付き、実装コミット main 反映済 |
| #3399 | close漏れ候補 | `eb940f63` docs: #3399 branch-strategy §10 (#3400) | docs SSOT 化コミット main 反映済 |
| #3404 | close漏れ候補 | `07621d78` fix(security): #3404 push 送信側 SSRF 再検証 (#3413) | fix コミット main 反映済、labels なし |
| #3424 | false positive の想定内 | 7 commits | EPIC label → ⚠️epic/tracker flag 付きで report 掲載、進行中 workstream |
| #3533 | false positive の想定内 | 2 commits | EPIC label → flag 付き掲載 |
| #3541 | 進行中 workstream | 2 commits | Phase C 進行中、labels なし → 人間判断 |

→ 設計どおり「真の close漏れ 3 件 + EPIC/進行中 3 件（flag 付き掲載）」が 1 つの report に出て、人間が判断できる。

### C 層 3 件の検出実証（AC3）

手動 close 済の #3133/#3246/#3088 を「open だったと仮定」して実 `origin/main` log（180 days）と突合:

```text
#3088: 3e4871f2 2026-06-18 perf: #3088 admin landing load を並列化 ... (#3120)
#3133: f867a346 2026-06-19 fix(security): #3133 /tenants + /uploads/avatars の cross-tenant IDOR ... (#3137)
#3246: c2172cee 2026-06-23 fix(security): #3246 export endpoint を import と対称な owner/parent gate ... (#3249)
PASS: C 層 3 件すべて検出
```

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] infra: インフラ・CI/CD
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI（`scripts/audit/close-leak-report.mjs` + `.github/workflows/close-leak-report.yml`）
- [x] テスト（`tests/unit/audit/close-leak-report.test.ts`）

**影響を受ける画面・機能**: なし（production code 非影響。週次 CI report job の追加のみ）。

**workflow 配置の設計判断**（Issue 実装方針「既存 cron 相乗り or 新設かは既存構造を見て判断」への回答）: `integration-pr.yml` 相乗りは不採用。同 workflow は統合 PR upsert 専用の薄い orchestrator で、permissions（`pull-requests: write` + App token）/ concurrency / checkout 深度が本 job と異なり、混載すると両者の最小権限原則が崩れる。本 job は `issues: read` + 全 git 履歴（fetch-depth: 0）が必要なため、`weekly-report.yml` / `code-quality-weekly.yml` と同じ「目的別の軽量週次 workflow」慣行に合流して新設した（cron は integration-pr（月・木）の翌朝の月曜 JST 07:00 で前週分を棚卸し）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— N/A（Draft 提出まで。full pre-ready は Ready 化時にメインセッションが実施）。Dev Agent 実施分の局所検証は完了: `npx svelte-check` full 8,154 files 0 errors 0 warnings（TS strict 修正後、検証用 worktree）/ `npx vitest run tests/unit/audit/close-leak-report.test.ts` 18 passed / `npx biome check`（変更 file）clean / `check-internal-terms.mjs` PASS（branch-strategy §4 対応表同期後）/ `check-pr-body.mjs --skip-mergeable` PASS
- [x] 追加・変更したテストの概要: `tests/unit/audit/close-leak-report.test.ts` 18 件 — C 層実データ形 subject 3 パターン / merge・squash PR 番号除外 / 全角 `＃` / body closing keyword 行頭アンカー（`関連: #N` 非検出）/ epic flag / report markdown（0 件・N 件・pipe escape）/ CLI 引数
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（`GH_TOKEN` は workflow 内 `secrets.GITHUB_TOKEN`、新規配布なし）
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（CI report job のみ）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 判定純関数（parseGitLog / extractCommitIssueRefs / detectCloseLeaks / buildCloseLeakReport）と副作用層（gh / git execFileSync + summary 出力）を分離。workflow は薄い orchestrator（#1442 同型）
- [x] **DRY**: body の closing keyword 検出は #3444 `extractClosedIssues` の行頭アンカー方式と同型の正規表現（用途が異なるため参照コメントで紐付け、over-close / under-close 教訓を継承）
- [x] **YAGNI**: Discord 通知は不採用（AC は「任意」、job summary で必要十分。ADR-0010 Pre-PMF 最小実装）。auto-close 機能は no-go どおり実装しない
- [x] **Security（OSS 公開前提）**: workflow permissions は `contents: read` + `issues: read` のみ（issue 書き込み権限なし = auto-close が構造的に不能）。`execFileSync` で shell interpolation なし
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: gh issue list 1 回 + git log 1 回のみ（issue ごとの `git log --grep` N 回実行を避け、単一 log の JS 突合に変更。open 105 件 × 1,197 commit で 2 秒未満）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): N/A — CI 補助 job（report only）で production 挙動・API・DB 非影響。運用位置付けは workflow ヘッダーコメント + 検出ロジック SSOT（script docblock）に記載
- [x] **並行 PR overlap** (#1200): `scripts/audit/close-leak-report.mjs` / `close-leak-report.yml` / `tests/unit/audit/close-leak-report.test.ts` は全て新規 file、既存 file 変更ゼロのため overlap なし。#3458（AC1 per-PR gate）とはファイル・機構とも独立
- [x] N/A — その他並行実装（labels / 年齢モード / demo / ナビ / DB / チュートリアル）の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（新規 file 3 件のみ、既存挙動不変）

**レビュー依頼事項・QA**:
- 検出ヒューリスティックの recall / precision バランス: subject 全参照 + body closing keyword 行のみ採用（`関連: #N` は拾わない）。false positive（EPIC / 進行中 workstream / 括弧内参照 `（#3244 HOLD）`）は flag 付きで report に含め人間判断とする設計の妥当性
- workflow 新設 vs integration-pr.yml 相乗りの判断（上記「影響範囲」の設計判断参照）
- 実検出 6 件のうち #2873 / #3399 / #3404 は真の close漏れ候補に見えるため、merge 後の初回 run を待たず手動 close 判断の材料に使える

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（workflow は `secrets.GITHUB_TOKEN` のみ使用）

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — N/A（Draft 提出まで。Ready 化とその前提の full pre-ready はメインセッションが実施、本 Agent は Ready 化を行わない）
- [x] セルフレビュー済み
- [x] 全 AC が実装済み（AC1-AC4、上記検証マップ参照）
- [x] Phase 分割した場合: 本 PR は #3423 AC4 の分離実装で単独完結（#3458 = AC1 は独立 Issue）
- [x] UI 変更時: N/A

## QM レビュー結果

（QM 記入欄）
