### PR TITLE
infra: #3458 develop 向け feat/fix PR に closing keyword 必須 gate (bare #N fail + no-issue-close skip)

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -7,7 +7,7 @@
 - 新規チケットは `gh issue create`。`docs/tickets/` への新規ファイル禁止（レガシー、参照のみ）
 - テンプレート: `.github/ISSUE_TEMPLATE/dev_ticket.yml` / `bug_report.yml` / `feature_request.yml`
 - ラベル: `type:feat|fix|refactor|infra|design|docs|marketing|test` / `priority:critical|high|medium|low` / `status:blocked|in-progress|on-hold` / `area:auth|billing|child-ui|admin|lp|db`
-- PR / コミットでの自動クローズは **`Closes #<num>` / `Fixes #<num>`（closing keyword の直後に `#番号`）が default branch（= `main`）に到達した時のみ**発火する。**conventional-commit prefix（`fix:` / `feat:` / `docs:` / `infra:` `#<num>`）は Issue 参照であって closing keyword ではなく、merge しても auto-close しない**。develop 二層では base=develop（非 default branch）かつ commit 規約が conventional-commit のため、**個別 PR の develop merge では Issue は auto-close されない**。ただし **develop→main 統合 PR は含有 PR の `## 関連 Issue` の close 宣言（`closes/fixes/resolves #N`）を `integration-pr-body.mjs` が `Closes #N` に集約し、main 反映で一括 auto-close する**（#3423。over-close 防止のため section 内 行頭 closing keyword のみ集約、#3444。issue-close-gate は PR-keyword close を skip するため reopen storm は起きない）。集約の residual edge 3 件は #3462 で封鎖: ① conventional-commit prefix 行（`fix: #N subject…` のように issue 番号の後に subject テキストを伴うコロン形）は集約しない（`Closes: #N` の裸コロン宣言は集約維持）/ ② `## 関連 Issue` 見出しは軽微な揺れ（前後空白・`##`〜`####` レベル差・「関連Issue」空白有無・末尾コロン）を正規化して検出（under-close 防止）/ ③ **`epic` label 付き tracking issue は集約 `Closes` から除外**し統合 PR 本文に「(tracking, close 対象外)」と注記（AC 未検証 force-close 防止、close は AC 検証のうえ手動）。close 運用の SSOT は [docs/sessions/branch-strategy.md §3.2](../docs/sessions/branch-strategy.md)（個別 close は手動 `- [x]` close + AC gate、統合 PR で集約 `Closes #N` 一括 close）
+- PR / コミットでの自動クローズは **`Closes #<num>` / `Fixes #<num>`（closing keyword の直後に `#番号`）が default branch（= `main`）に到達した時のみ**発火する。**conventional-commit prefix（`fix:` / `feat:` / `docs:` / `infra:` `#<num>`）は Issue 参照であって closing keyword ではなく、merge しても auto-close しない**。develop 二層では base=develop（非 default branch）かつ commit 規約が conventional-commit のため、**個別 PR の develop merge では Issue は auto-close されない**。ただし **develop→main 統合 PR は含有 PR の `## 関連 Issue` の close 宣言（`closes/fixes/resolves #N`）を `integration-pr-body.mjs` が `Closes #N` に集約し、main 反映で一括 auto-close する**（#3423。over-close 防止のため section 内 行頭 closing keyword のみ集約、#3444。issue-close-gate は PR-keyword close を skip するため reopen storm は起きない）。この集約が空振りしないよう、**develop 向け `type:feat` / `type:fix` PR は `## 関連 Issue` への closing keyword 記入を `pr-template-gate.yml` job 6（`closing keyword の記入 (feat/fix)`）が必須化する**（#3458 / #3423 AC1。issue を閉じない PR は `<!-- no-issue-close: 理由 -->` 宣言で skip）。集約の residual edge 3 件は #3462 で封鎖: ① conventional-commit prefix 行（`fix: #N subject…` のように issue 番号の後に subject テキストを伴うコロン形）は集約しない（`Closes: #N` の裸コロン宣言は集約維持）/ ② `## 関連 Issue` 見出しは軽微な揺れ（前後空白・`##`〜`####` レベル差・「関連Issue」空白有無・末尾コロン）を正規化して検出（under-close 防止）/ ③ **`epic` label 付き tracking issue は集約 `Closes` から除外**し統合 PR 本文に「(tracking, close 対象外)」と注記（AC 未検証 force-close 防止、close は AC 検証のうえ手動）。close 運用の SSOT は [docs/sessions/branch-strategy.md §3.2](../docs/sessions/branch-strategy.md)（個別 close は手動 `- [x]` close + AC gate、統合 PR で集約 `Closes #N` 一括 close）
 
 ## Issue 起票ルール（CRITICAL — ADR-0003）
 
@@ -41,7 +41,7 @@ AI エージェントも 4 フィールド全て埋める。`Blocked by` 未解�
 ### Dependabot CI exempt（#1808）
 
 Dependabot / Renovate の依存更新 PR は以下を自動 skip（`dependencies` ラベル + `actor != bot`）:
-`pr-template-gate.yml` 5 ジョブ / `pr-ac-verification-check.yml` / `pr-merge-gate.yml` / **`pr-author-guard.yml` (#2430 で追加、#1994 由来の exempt 抜け修復)**。AC マップ・Ready チェックは依存更新に該当しない。`pr-author-guard.yml` は ADR-0022 役割分離 (Takenori-Kusaka 作成 / ganbariquestsupport-lab approve) の機械強制 gate だが、bot は同分離の対象外。
+`pr-template-gate.yml` 6 ジョブ / `pr-ac-verification-check.yml` / `pr-merge-gate.yml` / **`pr-author-guard.yml` (#2430 で追加、#1994 由来の exempt 抜け修復)**。AC マップ・Ready チェックは依存更新に該当しない。`pr-author-guard.yml` は ADR-0022 役割分離 (Takenori-Kusaka 作成 / ganbariquestsupport-lab approve) の機械強制 gate だが、bot は同分離の対象外。
 
 ### AC / merge gate の lane-aware 化（#2945 / Phase A、親 #2942）
 
@@ -55,7 +55,7 @@ Dependabot / Renovate の依存更新 PR は以下を自動 skip（`dependencies
 
 検証ロジックは `scripts/check-ac-verification-map.mjs` / `scripts/check-merge-gate-checklist.mjs`（unit test 済、inline 重複なし）。required context 名は不変。lane 別の全 gate 対応表は `docs/sessions/branch-strategy.md`（A-6）が SSOT。
 
-**integration lane の label/comment skip 無効化（#3071、空洞化防止）**: `type:docs` / `dependencies` label / 明示 skip コメント（`<!-- ac-verification-skip -->`）による検証 skip は **feature / hotfix lane でのみ有効**。統合 PR（lane=integration）に誤って `type:docs` 等が付いても §3.5 マージ判定エビデンス表 / 統合用 section / template gate の検証を必ず実行する（誤ラベルで required check が空洞緑化するのを防ぐ）。`pr-template-gate-checks.mjs` の 5 check も同様（`hasDependenciesLabel` / `type:docs` skip を integration で無効化）。dependabot lane（bot actor）は `dependabotSkip(lane)` で従来どおり skip 維持（#1808）。
+**integration lane の label/comment skip 無効化（#3071、空洞化防止）**: `type:docs` / `dependencies` label / 明示 skip コメント（`<!-- ac-verification-skip -->`）による検証 skip は **feature / hotfix lane でのみ有効**。統合 PR（lane=integration）に誤って `type:docs` 等が付いても §3.5 マージ判定エビデンス表 / 統合用 section / template gate の検証を必ず実行する（誤ラベルで required check が空洞緑化するのを防ぐ）。`pr-template-gate-checks.mjs` の 6 check も同様（`hasDependenciesLabel` / `type:docs` skip を integration で無効化）。dependabot lane（bot actor）は `dependabotSkip(lane)` で従来どおり skip 維持（#1808）。
 
 ## 巨大 docs refactor PR の分割 (#2225)
 
@@ -111,7 +111,7 @@ gh pr ready <PR番号>
 
 ## PR テンプレート必須ゲート（`pr-template-gate.yml`）
 
-5 ジョブ並列 hard-fail（Ready PR / non-Dependabot のみ）。テンプレ動的読込のため template 変更で workflow 修正不要（PR HEAD 読込、#1855）。
+6 ジョブ並列 hard-fail（Ready PR / non-Dependabot のみ）。テンプレ動的読込のため template 変更で workflow 修正不要（PR HEAD 読込、#1855）。
 
 | ジョブ | 検証 |
 |---|---|
@@ -120,10 +120,11 @@ gh pr ready <PR番号>
 | 変更タイプ | `[x]` 1 つ以上 |
 | 顧客価値・目的 | プレースホルダー残存なし |
 | テスト実行結果 | `<!-- PASS / FAIL -->` 残存なし（type:docs は skip） |
+| closing keyword の記入 (feat/fix) | develop 向け `type:feat`/`type:fix` PR は `## 関連 Issue` に行頭 closing keyword（`Closes #N` / `Fixes #N` / `Resolves #N`、コロン形 / 全角 `＃` 許容）必須。bare `#N` / `関連: #N` のみは fail。issue を閉じない PR は `<!-- no-issue-close: 理由 -->` 宣言で skip。検出規約は `integration-pr-body.mjs` `extractClosedIssues` と共有（#3458 / #3423 AC1） |
 
 AC 検証マップ (`pr-ac-verification-check.yml`) も hard-fail。
 
-セットアップ: Branch Ruleset の `required_status_checks` に 5 ジョブ追加（管理者作業）。
+セットアップ: Branch Ruleset の `required_status_checks` に 6 ジョブ追加（管理者作業。`closing keyword の記入 (feat/fix)` は #3458 で新設、required 化には ruleset 追加登録が必要）。
 
 ### type:* label 自動付与 — title 接頭辞が SSOT（#2495）
 

--- a/.github/workflows/pr-template-gate.yml
+++ b/.github/workflows/pr-template-gate.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 # PR テンプレート (.github/PULL_REQUEST_TEMPLATE.md) の必須項目が
-# 適切に記入されているかを 5 つの並列ジョブで検証する。
+# 適切に記入されているかを 6 つの並列ジョブで検証する。
 # いずれか 1 つでも失敗すると PR がブロックされる（hard-fail）。
 #
 # 対象: Ready for Review 済みの全 PR（Draft は除外）
@@ -31,6 +31,8 @@ concurrency:
 # ★ required check context 名 (= job の name) は変更しない (#2944 AC6 / no-go):
 #   main ruleset に登録済の 5 context (必須セクションの存在確認 / 関連 Issue 番号の記入 /
 #   変更タイプの選択 / 顧客価値・目的の記入 / テスト実行結果の記入) を 1 つも改名しない。
+#   Job 6 (closing keyword の記入、#3458) は新規 context — required 化には Branch Ruleset の
+#   required_status_checks への登録 (管理者作業) が必要。
 
 on:
   pull_request:
@@ -214,6 +216,47 @@ jobs:
           printf '%s' "${PR_LABELS}" > /tmp/pr-labels.json
           node scripts/pr-template-gate-checks.mjs \
             --check test-results --lane "${LANE}" \
+            --body-file /tmp/pr-body.md \
+            --labels-json /tmp/pr-labels.json \
+            --template-file .github/PULL_REQUEST_TEMPLATE.md
+
+  # ============================================================
+  # Job 6: closing keyword の必須化 (#3458 / #3423 AC1、lane-aware)
+  #   feature (develop 向け) × type:feat/type:fix = `## 関連 Issue` に行頭 closing keyword
+  #   (Closes/Fixes/Resolves #N、コロン形 / 全角 ＃ 許容) を必須化。
+  #   bare `#N` / `関連: #N` のみは fail。issue を閉じない PR は
+  #   `<!-- no-issue-close: 理由 -->` 宣言で skip。
+  #   integration = skip (#3423 集約側 integration-pr-body.mjs が担う) /
+  #   hotfix = skip (main 直行は GitHub が直接 auto-close) / dependabot = skip。
+  #   検出規約は scripts/integration-pr-body.mjs extractClosedIssues と共有 (二重実装なし、#3444)。
+  #   check=closing-keyword。
+  # ============================================================
+  check-closing-keyword:
+    name: "closing keyword の記入 (feat/fix)"
+    runs-on: ubuntu-latest
+    if: "github.event.pull_request.draft == false"
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Classify PR lane (actions/pr-lane SSOT)
+        id: lane
+        uses: ./actions/pr-lane
+      - name: Verify closing keyword declared (lane-aware)
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          LANE: ${{ steps.lane.outputs.lane }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${PR_BODY}" > /tmp/pr-body.md
+          printf '%s' "${PR_LABELS}" > /tmp/pr-labels.json
+          node scripts/pr-template-gate-checks.mjs \
+            --check closing-keyword --lane "${LANE}" \
             --body-file /tmp/pr-body.md \
             --labels-json /tmp/pr-labels.json \
             --template-file .github/PULL_REQUEST_TEMPLATE.md

--- a/docs/sessions/branch-strategy.md
+++ b/docs/sessions/branch-strategy.md
@@ -59,7 +59,7 @@ develop 二層では feature/fix/docs PR の base が `develop`（非 default br
 
 - **develop merge 時点では Issue を手動 close しない**。`closes #N` を付けた PR を develop へ merge しても Issue は **OPEN のまま**で正常。これを「未対応」と誤認しない。
 - **個別 feature/fix PR の commit prefix では auto-close しない**。本リポジトリの commit 規約は conventional-commit prefix（`fix: #N` / `feat: #N` / `docs: #N`）で、コロンを挟む形は Issue **参照**であって closing keyword ではないため、develop merge / 個別 PR では auto-close は発火しない。
-- **統合 PR は含有 PR の close 宣言を集約し、main 反映で一括 auto-close する（#3423）**。`integration-pr-body.mjs`（pure function SSOT）が各含有 PR の `## 関連 Issue` section に書かれた `closes/fixes/resolves #N` を収集し、統合 PR（`release/* → main`）本文に `Closes #N` を集約する。merge commit が main に到達すると GitHub が該当 issue を auto-close し、close漏れ（fix は main 反映済だが issue が OPEN のまま）を構造的に防ぐ。集約は **`## 関連 Issue` section 内の行頭 closing keyword のみ**を対象とし、code fence / inline code / 否定文中の引用・本文中の参照（`#3133 (#3131 監査検出)` 等）は除外する（over-close 防止、#3444）。GitHub 許容形のコロン `Closes: #N` / 全角 `＃` も拾う。closing keyword の無い部分対応 PR（`関連: #N`）は閉じない（partial を尊重）。residual edge 3 件は #3462 で封鎖: conventional-commit prefix 行（`fix: #N subject…`、issue 番号後に subject テキストを伴うコロン形）は集約しない / `## 関連 Issue` 見出しは軽微な揺れ（前後空白・`##`〜`####` レベル差・「関連Issue」空白有無・末尾コロン）を正規化検出する（under-close 防止）/ **`epic` label 付き tracking issue は集約 `Closes` から除外**し統合 PR 本文に「(tracking, close 対象外)」と注記する（AC 未検証 force-close 防止。tracking issue の close は AC 検証のうえ手動で行う。除外一覧は `integration-pr.yml` が `gh issue list --label epic` で取得し `--tracking-issues` で script へ渡す）。
+- **統合 PR は含有 PR の close 宣言を集約し、main 反映で一括 auto-close する（#3423）**。`integration-pr-body.mjs`（pure function SSOT）が各含有 PR の `## 関連 Issue` section に書かれた `closes/fixes/resolves #N` を収集し、統合 PR（`release/* → main`）本文に `Closes #N` を集約する。merge commit が main に到達すると GitHub が該当 issue を auto-close し、close漏れ（fix は main 反映済だが issue が OPEN のまま）を構造的に防ぐ。集約は **`## 関連 Issue` section 内の行頭 closing keyword のみ**を対象とし、code fence / inline code / 否定文中の引用・本文中の参照（`#3133 (#3131 監査検出)` 等）は除外する（over-close 防止、#3444）。GitHub 許容形のコロン `Closes: #N` / 全角 `＃` も拾う。closing keyword の無い部分対応 PR（`関連: #N`）は閉じない（partial を尊重）。集約が空振りしないよう、develop 向け `type:feat` / `type:fix` PR には `pr-template-gate.yml` job 6（`closing keyword の記入 (feat/fix)`、#3458）が `## 関連 Issue` への closing keyword 記入を必須化する（issue を閉じない PR は `<!-- no-issue-close: 理由 -->` 宣言で skip。検出規約は同じ `extractClosedIssues` を共有し二重実装しない）。residual edge 3 件は #3462 で封鎖: conventional-commit prefix 行（`fix: #N subject…`、issue 番号後に subject テキストを伴うコロン形）は集約しない / `## 関連 Issue` 見出しは軽微な揺れ（前後空白・`##`〜`####` レベル差・「関連Issue」空白有無・末尾コロン）を正規化検出する（under-close 防止）/ **`epic` label 付き tracking issue は集約 `Closes` から除外**し統合 PR 本文に「(tracking, close 対象外)」と注記する（AC 未検証 force-close 防止。tracking issue の close は AC 検証のうえ手動で行う。除外一覧は `integration-pr.yml` が `gh issue list --label epic` で取得し `--tracking-issues` で script へ渡す）。
 - **統合 PR の一括 auto-close は issue-close-gate を素通りする**。`issue-close-gate.yml` は PR/commit keyword 経由の auto-close を skip するため（[.github/CLAUDE.md](../../.github/CLAUDE.md) §「issue-close-gate auto-reopen の挙動」）、統合 PR merge による一括 close で AC gate の reopen storm は起きない。
 - **close は例外パスでも行う**: wontfix / duplicate / PO 保留など意図的 close、および含有 PR が closing keyword を付け忘れた Issue の close は、Issue body の `- [x]` 化（証跡コメント付き）または `wontfix` / `duplicate` label で `issue-close-gate.yml` の AC 検証 gate を通す（ADR-0038 / [.github/CLAUDE.md](../../.github/CLAUDE.md) §「issue-close-gate auto-reopen の挙動」）。Issue body の `- [ ]` 残存で gate が reopen ループを起こすため、`- [x]` 化を先に済ませること。
 
@@ -89,7 +89,7 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 | `unit-test`（×2 shard）+ `unit-test-merge` | vitest + coverage ratchet | 約 259s |
 | `site-check` | site/ HTML / forbidden terms（site 変更時） | ≤ 53s |
 | `new-env-distribution-check` / `schema-change-tests-check` / `schema-migration-completeness-check` | env 配布証跡 / スキーマ互換 | ≤ 53s |
-| PR テンプレ gate（`pr-template-gate.yml` 5 job / `pr-ac-verification-check.yml`） | 必須セクション / AC マップ | ≤ 53s |
+| PR テンプレ gate（`pr-template-gate.yml` 6 job / `pr-ac-verification-check.yml`） | 必須セクション / AC マップ / closing keyword（#3458） | ≤ 53s |
 
 ### 重量レーン（release/* → main 統合 PR、§3.1）
 
@@ -132,7 +132,7 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 | workflow | lane 帰属 | required context（★） | lane 分岐（A-1 SSOT 経由） | 重量/軽量 |
 |---|---|---|---|---|
 | `ci.yml` | feature+integration（`branches:[main,develop]`） | ★`ci-gate` | あり（inline `base_ref=='main' && (head_ref=='develop' \|\| startsWith(head_ref,'release/'))` = `pr-lane.mjs` rule 2 SSOT。重量 job を統合 PR で保証発火、develop PR で skip） | 軽量 job=軽量 / 重量 job=重量 |
-| `pr-template-gate.yml` | 全 PR lane（`branches` 無指定） | ★`必須セクションの存在確認` / ★`関連 Issue 番号の記入` / ★`変更タイプの選択` / ★`顧客価値・目的の記入` / ★`テスト実行結果の記入`（5 job） | あり（`uses: ./actions/pr-lane` → 各 job が `--lane`。feature/hotfix vs integration vs dependabot=skip 相当、#2944） | 軽量 |
+| `pr-template-gate.yml` | 全 PR lane（`branches` 無指定） | ★`必須セクションの存在確認` / ★`関連 Issue 番号の記入` / ★`変更タイプの選択` / ★`顧客価値・目的の記入` / ★`テスト実行結果の記入` / `closing keyword の記入 (feat/fix)`（6 job。closing keyword job は #3458 新設、required 化は ruleset 追加登録待ち） | あり（`uses: ./actions/pr-lane` → 各 job が `--lane`。feature/hotfix vs integration vs dependabot=skip 相当、#2944。closing keyword は feature×feat/fix のみ検証、integration=#3423 集約側 / hotfix=main 直接 auto-close で skip、#3458） | 軽量 |
 | `pr-ac-verification-check.yml` | 全 PR lane | ★`Verify AC map in PR body` | あり（`uses: ./actions/pr-lane`。feature/hotfix=AC マップ 4 列 / integration=マージ判定エビデンス表、#2945） | 軽量 |
 | `pr-merge-gate.yml` | 全 PR lane | ★`PR チェックリスト完了確認` | あり（`uses: ./actions/pr-lane`。feature/hotfix=2 section / integration=統合用 section、#2945） | 軽量 |
 | `pr-quality-gate.yml` | 全 PR lane | ★`screenshot-check` | あり（`uses: ./actions/pr-lane`。feature/hotfix=before/after 4 スロット / integration=VR 3 層委譲、#2946） | 軽量 |
@@ -173,7 +173,7 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 
 > **required context 数 = 10**（★ 印）。`gh api repos/Takenori-Kusaka/ganbari-quest/rulesets/14673945` の `required_status_checks` 配列（`ci-gate` / `screenshot-check` / `Verify AC map in PR body` / `Measure LP dimensions and lint forbidden terms` / `PR チェックリスト完了確認` / `必須セクションの存在確認` / `関連 Issue 番号の記入` / `変更タイプの選択` / `顧客価値・目的の記入` / `テスト実行結果の記入`）が真の SSOT。本表は「どの workflow がどの context を生むか」のマッピングであり、ruleset 変更時は本表も同期する（#2948 no-go: ruleset と乖離させない）。
 >
-> **A-2〜A-5 で lane-aware 化した required gate**: `pr-template-gate.yml`（5 job、#2944）/ `pr-ac-verification-check.yml`（#2945）/ `pr-merge-gate.yml`（#2945）/ `pr-quality-gate.yml`（#2946）の 4 workflow（5+1+1+1 = 8 required context）が `actions/pr-lane` 経由で観点切替する。`dependabot-auto-merge.yml`（#2947）は `BOT_ACTORS` SSOT を参照（required ではないが bot lane 判定を共通化）。`ci.yml`（#2874）は inline 式で `pr-lane.mjs` rule 2 と同一判定を行い重量 job を統合 PR で保証発火する。
+> **A-2〜A-5 で lane-aware 化した required gate**: `pr-template-gate.yml`（6 job、#2944 / #3458）/ `pr-ac-verification-check.yml`（#2945）/ `pr-merge-gate.yml`（#2945）/ `pr-quality-gate.yml`（#2946）の 4 workflow（5+1+1+1 = 8 required context）が `actions/pr-lane` 経由で観点切替する。`dependabot-auto-merge.yml`（#2947）は `BOT_ACTORS` SSOT を参照（required ではないが bot lane 判定を共通化）。`ci.yml`（#2874）は inline 式で `pr-lane.mjs` rule 2 と同一判定を行い重量 job を統合 PR で保証発火する。
 
 ### 実装状況（§8 step 2、#2931 で実施済み / #2874 で重量レーン拡張）
 

--- a/scripts/pr-template-gate-checks.mjs
+++ b/scripts/pr-template-gate-checks.mjs
@@ -2,8 +2,8 @@
 /**
  * scripts/pr-template-gate-checks.mjs — Issue #2944 (Phase A/A-2、親 #2942 / EPIC #2861)
  *
- * `.github/workflows/pr-template-gate.yml` の 5 job (必須セクション存在 / 関連 Issue 番号 /
- * 変更タイプ / 顧客価値 / テスト実行結果) の検証ロジックを **lane-aware な純粋関数**として
+ * `.github/workflows/pr-template-gate.yml` の 6 job (必須セクション存在 / 関連 Issue 番号 /
+ * 変更タイプ / 顧客価値 / テスト実行結果 / closing keyword #3458) の検証ロジックを **lane-aware な純粋関数**として
  * 集約した SSOT。各 job の `actions/github-script` に inline されていた判定を本 script に移し、
  * unit test (tests/unit/github/pr-template-gate-checks.test.ts) で 4 lane (feature /
  * integration / hotfix / dependabot) 全てを fixture 入力で検証可能にする (#2944 実装方針)。
@@ -41,6 +41,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { extractClosedIssues } from './integration-pr-body.mjs';
 
 /**
  * @typedef {'feature' | 'integration' | 'hotfix' | 'dependabot'} Lane
@@ -276,6 +277,167 @@ export function checkIssueReference({ body, labels, template, lane }) {
 			`❌ 「${heading}」セクションに Issue 番号の参照がありません。\n\n` +
 			'`closes #123` の形式で関連する Issue 番号を記載してください。\n' +
 			'Issue が存在しない場合は `closes` 行を削除し理由を明記してください。',
+	};
+}
+
+/**
+ * closing keyword 必須化 (#3458) の対象 type label。
+ * develop 向け (feature lane) の feat / fix PR のみ closing keyword を必須とする
+ * (refactor / docs / chore 等 issue を閉じない type は対象外、AC3)。
+ * @type {readonly string[]}
+ */
+export const CLOSING_KEYWORD_TARGET_LABELS = Object.freeze(['type:feat', 'type:fix']);
+
+/**
+ * `<!-- no-issue-close: 理由 -->` 宣言 (#3458 AC3)。
+ * issue を閉じない PR (follow-up fix / issue なし小修正等) の明示的 escape hatch。
+ * 理由が空の宣言は fail とする (空宣言による gate 空洞化防止)。
+ */
+const NO_ISSUE_CLOSE_RE = /<!--\s*no-issue-close:([\s\S]*?)-->/i;
+
+/**
+ * conventional-commit 形式の PR title 引用行 (`fix: #N <subject>` / `fix(scope): #N <subject>`)
+ * を検出する正規表現 (#3458 AC / #3462 残課題 1 の gate 側ガード)。
+ *
+ * 共有規約 `CLOSING_KEYWORD_LINE_RE` (integration-pr-body.mjs、#3444) はコロン形
+ * `Fixes: #N` を許容するため、副作用として conventional-commit prefix `fix: #N subject`
+ * (title 引用) も match しうる。`.github/CLAUDE.md` SSOT は「conventional-commit prefix は
+ * Issue 参照であって closing keyword ではない」と定めるため、gate 側では
+ * **小文字 `fix` type token + コロン + `#N` + 後続 subject 本文がある行** のみを
+ * title 引用とみなし走査対象から除外する。判別基準:
+ *   - 小文字 `fix` 限定 (conventional-commit type は小文字規約、#2495 title 接頭辞 SSOT と一致)。
+ *     `Fixes: #N` / `Closes: #N` (大文字・複数形の正規コロン closing 形) は除外しない。
+ *   - `#N` の後に subject 本文 (`[ \t]+\S`) が続く行のみ。`fix: #N` 単独行は closing 宣言として尊重。
+ * regex 本体の根治 (共有規約側での区別) は #3462 が担い、本ガードはその gate 局所の防御。
+ */
+const CONVENTIONAL_COMMIT_FIX_TITLE_RE =
+	/^[ \t]*(?:[-*+][ \t]+)?fix(?:\([^)\r\n]*\))?!?:[ \t]*[#＃]\d+[ \t]+\S/;
+
+/**
+ * conventional-commit 形式の title 引用行を除去する純粋関数 (#3458)。
+ * 行単位の除去のため section 見出し構造 (`## `) は保たれ、除去後の本文を
+ * `extractClosedIssues` (section 限定走査) にそのまま渡せる。
+ * @param {string} text
+ * @returns {string}
+ */
+export function stripConventionalCommitFixTitleLines(text) {
+	return text
+		.split('\n')
+		.filter((l) => !CONVENTIONAL_COMMIT_FIX_TITLE_RE.test(l))
+		.join('\n');
+}
+
+/**
+ * Check 6: closing keyword の必須化 (#3458、#3423 AC1 / PR #3444 QM BLOCK 指摘 (3))。
+ *
+ * develop 向け (feature lane) の `type:feat` / `type:fix` PR は、`## 関連 Issue` section に
+ * **行頭 closing keyword** (`Closes #N` / `Fixes #N` / `Resolves #N`、コロン形 `Closes: #N` /
+ * 全角 `＃` 許容) を必須とする。含有 PR が bare `#N` 参照だけだと develop→main 統合 PR の
+ * `Closes #N` 集約 (#3423 / integration-pr-body.mjs) が空になり close 漏れ防止機構が
+ * inert になるため、per-PR gate で宣言を強制する。
+ *
+ * 検出規約は `extractClosedIssues` (integration-pr-body.mjs、#3444 で section 限定 +
+ * code-fence strip + 行頭アンカー化済) を **単一 PR body で呼び出して共有**する (AC4、
+ * 二重実装なし)。集約側と gate 側で「何が closing 宣言か」の判定が常に一致する。
+ *
+ * lane 別:
+ * - feature: type:feat / type:fix のみ検証。`<!-- no-issue-close: 理由 -->` 宣言で skip (AC3)。
+ *   back-merge label PR は機械生成のため skip (classifyForContainedList と同基準)。
+ * - integration: skip (統合 PR は #3423 集約側 = renderIntegrationPrBody が担う)。
+ * - hotfix: skip (main = default branch 直行のため merge 時に GitHub が直接 auto-close する。
+ *   #3458 の scope は develop 向け PR のみ)。
+ * - dependabot: skip。
+ *
+ * @param {CheckInput} input
+ * @returns {CheckResult}
+ */
+export function checkClosingKeyword({ body, labels, lane }) {
+	const dep = dependabotSkip(lane);
+	if (dep) return dep;
+	if (hasDependenciesLabel(labels, lane)) {
+		return { ok: true, skipped: true, message: '依存関係更新 PR のためスキップ', lane };
+	}
+	if (lane === 'integration') {
+		return {
+			ok: true,
+			skipped: true,
+			lane,
+			message:
+				'[integration] 統合 PR は含有 PR の close 宣言を integration-pr-body.mjs (#3423) が集約するためスキップ',
+		};
+	}
+	if (lane === 'hotfix') {
+		return {
+			ok: true,
+			skipped: true,
+			lane,
+			message:
+				'[hotfix] main (default branch) 直行 PR は merge 時に GitHub が直接 auto-close するためスキップ (#3458 scope は develop 向けのみ)',
+		};
+	}
+	if (labels.includes('back-merge')) {
+		return {
+			ok: true,
+			skipped: true,
+			lane,
+			message: 'back-merge PR (機械生成) のためスキップ',
+		};
+	}
+	if (!CLOSING_KEYWORD_TARGET_LABELS.some((l) => labels.includes(l))) {
+		return {
+			ok: true,
+			skipped: true,
+			lane,
+			message: `type:feat / type:fix 以外 (labels: ${labels.join(', ') || 'なし'}) のためスキップ (#3458 AC3)`,
+		};
+	}
+
+	const noClose = body.match(NO_ISSUE_CLOSE_RE);
+	if (noClose) {
+		const reason = (noClose[1] ?? '').trim();
+		if (reason.length === 0) {
+			return {
+				ok: false,
+				lane,
+				message:
+					'❌ `<!-- no-issue-close: 理由 -->` 宣言に理由が記載されていません。\n\n' +
+					'issue を閉じない PR は `<!-- no-issue-close: follow-up 修正で対応 issue なし -->` のように\n' +
+					'理由を必ず記載してください (#3458 AC3、空宣言による gate 空洞化防止)。',
+			};
+		}
+		return {
+			ok: true,
+			skipped: true,
+			lane,
+			message: `✅ no-issue-close 宣言によりスキップ (理由: ${reason})`,
+		};
+	}
+
+	// 共有規約 (extractClosedIssues) を単一 PR body で呼び出す。section 限定 / code-fence strip /
+	// 行頭アンカーの 3 段絞り込み (#3444) がそのまま適用される。conventional-commit title 引用行のみ
+	// gate 側で事前除去する (#3462 残課題 1 の局所ガード)。
+	const closedIssues = extractClosedIssues([
+		{ number: 0, body: stripConventionalCommitFixTitleLines(body) },
+	]);
+	if (closedIssues.length > 0) {
+		return {
+			ok: true,
+			lane,
+			message: `✅ closing keyword 宣言: ${closedIssues.map((n) => `Closes #${n}`).join(' / ')}`,
+		};
+	}
+
+	return {
+		ok: false,
+		lane,
+		message:
+			'❌ 「## 関連 Issue」section に closing keyword (`Closes #N` / `Fixes #N` / `Resolves #N`) がありません。\n\n' +
+			'develop 向け type:feat / type:fix PR は、解決対象 issue を行頭の closing keyword で宣言してください\n' +
+			'(develop→main 統合 PR が `Closes #N` を集約し main merge 時に一括 auto-close します、#3423/#3458)。\n\n' +
+			'- 単なる `#N` 参照 / `関連: #N` は closing 宣言ではないため不可\n' +
+			'- conventional-commit prefix の title 引用 (`fix: #N subject`) は closing 宣言と見なされません\n' +
+			'- issue を閉じない PR は `<!-- no-issue-close: 理由 -->` を本文に記載すれば skip されます\n\n' +
+			'例:\n```\n## 関連 Issue\n\ncloses #1234\n```',
 	};
 }
 
@@ -574,6 +736,7 @@ export const CHECKS = {
 	'change-type': checkChangeType,
 	'customer-value': checkCustomerValue,
 	'test-results': checkTestResults,
+	'closing-keyword': checkClosingKeyword,
 };
 
 /**

--- a/tests/unit/github/pr-template-gate-checks.test.ts
+++ b/tests/unit/github/pr-template-gate-checks.test.ts
@@ -11,7 +11,9 @@
 //   - AC5: dependabot lane は全 check が skip 相当 (挙動不変)。
 import { describe, expect, it } from 'vitest';
 import {
+	CLOSING_KEYWORD_TARGET_LABELS,
 	checkChangeType,
+	checkClosingKeyword,
 	checkCustomerValue,
 	checkIssueReference,
 	checkSectionPresence,
@@ -22,6 +24,7 @@ import {
 	extractTemplateSections,
 	INTEGRATION_REQUIRED_SECTIONS,
 	parseArgs,
+	stripConventionalCommitFixTitleLines,
 } from '../../../scripts/pr-template-gate-checks.mjs';
 
 // --- 最小だが現行構造に一致する template fixture ---
@@ -483,6 +486,7 @@ describe('dependabot lane: 全 check skip 相当 (#2944 AC5)', () => {
 		['change-type', checkChangeType],
 		['customer-value', checkCustomerValue],
 		['test-results', checkTestResults],
+		['closing-keyword', checkClosingKeyword],
 	] as const) {
 		it(`${name}: dependabot は skip 相当 (ok:true skipped:true)`, () => {
 			const r = fn(base);
@@ -507,6 +511,197 @@ describe('dependencies label skip (lane と直交)', () => {
 		});
 		expect(r.ok).toBe(true);
 		expect(r.skipped).toBe(true);
+	});
+});
+
+// =====================================================================
+// #3458: closing keyword 必須 gate (develop 向け feat/fix、#3423 AC1)
+//   検出規約は integration-pr-body.mjs extractClosedIssues と共有 (二重実装なし、AC4)。
+// =====================================================================
+describe('closing-keyword gate (#3458)', () => {
+	const base = {
+		labels: ['type:fix'],
+		template: TEMPLATE,
+		ssotSections: SSOT_SECTIONS,
+		lane: 'feature' as const,
+	};
+
+	/** `## 関連 Issue` section に任意行を持つ最小 body を組み立てる。 */
+	const bodyWith = (issueSectionLines: string) => `## 顧客価値・目的
+
+gate の検証用 body。
+
+## 関連 Issue
+
+${issueSectionLines}
+
+## 変更タイプ
+
+- [x] fix: バグ修正
+`;
+
+	// --- PASS: closing keyword 各形 (AC1) ---
+	it('PASS: Closes #N (基本形)', () => {
+		const r = checkClosingKeyword({ ...base, body: bodyWith('Closes #3458') });
+		expect(r.ok).toBe(true);
+		expect(r.skipped).toBeFalsy();
+		expect(r.message).toContain('#3458');
+	});
+	it('PASS: fixes #N (小文字 + 別 keyword)', () => {
+		expect(checkClosingKeyword({ ...base, body: bodyWith('fixes #123') }).ok).toBe(true);
+	});
+	it('PASS: Resolves: #N (コロン形)', () => {
+		expect(checkClosingKeyword({ ...base, body: bodyWith('Resolves: #3458') }).ok).toBe(true);
+	});
+	it('PASS: closes ＃N (全角 ＃)', () => {
+		expect(checkClosingKeyword({ ...base, body: bodyWith('closes ＃3458') }).ok).toBe(true);
+	});
+	it('PASS: list marker 付き (- closes #N)', () => {
+		expect(checkClosingKeyword({ ...base, body: bodyWith('- closes #3458') }).ok).toBe(true);
+	});
+	it('PASS: type:feat label でも検証対象', () => {
+		const r = checkClosingKeyword({
+			...base,
+			labels: ['type:feat'],
+			body: bodyWith('Closes #3458'),
+		});
+		expect(r.ok).toBe(true);
+		expect(r.skipped).toBeFalsy();
+	});
+
+	// --- FAIL: closing keyword なし (AC2) ---
+	it('FAIL: bare #N 参照のみ', () => {
+		const r = checkClosingKeyword({ ...base, body: bodyWith('#3458') });
+		expect(r.ok).toBe(false);
+		expect(r.message).toContain('closing keyword');
+	});
+	it('FAIL: 関連: #N のみ', () => {
+		expect(checkClosingKeyword({ ...base, body: bodyWith('関連: #3458') }).ok).toBe(false);
+	});
+	it('FAIL: 本文中の言及 (see closes #N) は行頭アンカーで除外 (#3444 規約共有)', () => {
+		expect(
+			checkClosingKeyword({ ...base, body: bodyWith('前 PR では closes #3458 と書いた') }).ok,
+		).toBe(false);
+	});
+	it('FAIL: code fence 内の closes #N は strip される (#3444 規約共有)', () => {
+		expect(checkClosingKeyword({ ...base, body: bodyWith('```\ncloses #999\n```') }).ok).toBe(
+			false,
+		);
+	});
+	it('FAIL: closing keyword が 関連 Issue section 外にあると section 限定走査で除外 (#3444 規約共有)', () => {
+		const body = `## 顧客価値・目的
+
+Closes #3458
+
+## 関連 Issue
+
+#3458 のみ参照
+
+## 変更タイプ
+
+- [x] fix: バグ修正
+`;
+		expect(checkClosingKeyword({ ...base, body }).ok).toBe(false);
+	});
+
+	// --- conventional-commit prefix を closing と誤認しない ---
+	it('FAIL: conventional-commit title 引用 (fix: #N subject) のみでは closing と誤認しない', () => {
+		const r = checkClosingKeyword({
+			...base,
+			body: bodyWith('fix: #3458 closing keyword gate を追加'),
+		});
+		expect(r.ok).toBe(false);
+	});
+	it('PASS: title 引用 + 正規の closes #N が併記されていれば PASS', () => {
+		const r = checkClosingKeyword({
+			...base,
+			body: bodyWith('fix: #3458 closing keyword gate を追加\n\ncloses #3458'),
+		});
+		expect(r.ok).toBe(true);
+	});
+	it('stripConventionalCommitFixTitleLines: fix(scope): #N subject 行を除去し、Fixes: #N 説明 (正規コロン形) は残す', () => {
+		const text = [
+			'fix: #3458 subject あり',
+			'fix(admin): #3458 scope 付き',
+			'Fixes: #3458 ログインバグ',
+			'fix: #3458',
+			'closes #3458',
+		].join('\n');
+		const stripped = stripConventionalCommitFixTitleLines(text);
+		expect(stripped).not.toContain('subject あり');
+		expect(stripped).not.toContain('scope 付き');
+		expect(stripped).toContain('Fixes: #3458 ログインバグ');
+		expect(stripped).toContain('fix: #3458'); // subject なし単独行は closing 宣言として尊重
+		expect(stripped).toContain('closes #3458');
+	});
+
+	// --- skip: no-issue-close 宣言 (AC3) ---
+	it('SKIP: <!-- no-issue-close: 理由 --> 宣言で skip', () => {
+		const r = checkClosingKeyword({
+			...base,
+			body: bodyWith('<!-- no-issue-close: follow-up 修正で対応 issue なし -->\n#3458 関連'),
+		});
+		expect(r.ok).toBe(true);
+		expect(r.skipped).toBe(true);
+		expect(r.message).toContain('follow-up 修正で対応 issue なし');
+	});
+	it('FAIL: no-issue-close 宣言の理由が空 (空洞化防止)', () => {
+		const r = checkClosingKeyword({
+			...base,
+			body: bodyWith('<!-- no-issue-close: -->'),
+		});
+		expect(r.ok).toBe(false);
+		expect(r.message).toContain('理由');
+	});
+
+	// --- skip: 対象外 lane / label ---
+	it('SKIP: type:feat / type:fix 以外 (refactor) は対象外', () => {
+		const r = checkClosingKeyword({
+			...base,
+			labels: ['type:refactor'],
+			body: bodyWith('#3458 のみ'),
+		});
+		expect(r.ok).toBe(true);
+		expect(r.skipped).toBe(true);
+	});
+	it('SKIP: integration lane (#3423 集約側が担う)', () => {
+		const r = checkClosingKeyword({
+			...base,
+			lane: 'integration',
+			body: bodyWith('#3458 のみ'),
+		});
+		expect(r.ok).toBe(true);
+		expect(r.skipped).toBe(true);
+	});
+	it('SKIP: hotfix lane (main 直行は GitHub 直接 auto-close)', () => {
+		const r = checkClosingKeyword({
+			...base,
+			lane: 'hotfix',
+			body: bodyWith('#3458 のみ'),
+		});
+		expect(r.ok).toBe(true);
+		expect(r.skipped).toBe(true);
+	});
+	it('SKIP: back-merge label (機械生成 PR)', () => {
+		const r = checkClosingKeyword({
+			...base,
+			labels: ['type:fix', 'back-merge'],
+			body: bodyWith('#3458 のみ'),
+		});
+		expect(r.ok).toBe(true);
+		expect(r.skipped).toBe(true);
+	});
+	it('SKIP: dependencies label', () => {
+		const r = checkClosingKeyword({
+			...base,
+			labels: ['type:fix', 'dependencies'],
+			body: bodyWith('#3458 のみ'),
+		});
+		expect(r.ok).toBe(true);
+		expect(r.skipped).toBe(true);
+	});
+	it('CLOSING_KEYWORD_TARGET_LABELS は type:feat / type:fix の 2 種', () => {
+		expect([...CLOSING_KEYWORD_TARGET_LABELS]).toEqual(['type:feat', 'type:fix']);
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（開発フロー）

**解決する課題**: #3423 で統合 PR（release/* → main）が含有 PR の `Closes #N` を集約して issue を一括 auto-close する機構を導入したが、含有 PR が `## 関連 Issue` に closing keyword を書かず bare `#N` 参照だけだと集約結果が空になり本機構が largely inert になる（PR #3444 QM BLOCK 指摘 (3)）。close 漏れ（fix は main 反映済だが issue が OPEN のまま）が ADR-0060 完了報告の虚偽化につながる。

**期待される効果**: develop 向け `type:feat` / `type:fix` PR に closing keyword 記入を per-PR gate で機械強制し、統合 PR の `Closes #N` 集約が構造的に空振りしなくなる。**正規運用では追加負担ゼロ** — `.github/PULL_REQUEST_TEMPLATE.md` の `## 関連 Issue` 雛形が既に `closes #` 形式のため、template どおりに番号を埋めれば gate は自動 PASS する。

## 関連 Issue

closes #3458

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | type:feat/type:fix の develop 向け PR に closing keyword（Closes/Fixes/Resolves #N、コロン形/全角 ＃ 許容）を required check で強制 | `npx vitest run tests/unit/github/pr-template-gate-checks.test.ts` + CLI 実行 | HEAD `be243ca0` / 64 passed（PASS 系: `Closes #N` / `fixes #N` / `Resolves: #N` / `closes ＃N` / list marker 形）/ `scripts/pr-template-gate-checks.mjs` `checkClosingKeyword` + workflow Job 6 `check-closing-keyword`（`.github/workflows/pr-template-gate.yml`） |
| AC2 | bare `#N` / `関連: #N` のみは fail し Ready 化（merge）をブロック | 同 unit test + CLI fail 経路 | HEAD `be243ca0` / test「FAIL: bare #N 参照のみ」「FAIL: 関連: #N のみ」PASS / CLI `--check closing-keyword` で bare `#N` body → exit 1 を実測 |
| AC3 | issue を閉じない PR は `<!-- no-issue-close: 理由 -->` 宣言で skip 可 | 同 unit test | HEAD `be243ca0` / test「SKIP: no-issue-close 宣言で skip」PASS + 空理由宣言は fail（gate 空洞化防止）/ type:refactor 等の非対象 label は宣言不要で skip |
| AC4 | 検出ロジックは `extractClosedIssues`（scripts/integration-pr-body.mjs）と同一規約を共有し二重実装しない | コード実体 + 規約共有の境界 test | HEAD `be243ca0` / `checkClosingKeyword` は `extractClosedIssues([{ number: 0, body }])` を直接呼び出し（`scripts/pr-template-gate-checks.mjs` L44 import、regex/section slice/code-fence strip の再実装ゼロ）/ test「code fence 内は strip」「section 外は除外」「行頭アンカー」が #3444 規約の共有を実証 |
| AC5 | 純関数 unit test で closing-keyword 有無の境界を固定 | `npx vitest run tests/unit/github/pr-template-gate-checks.test.ts` | HEAD `be243ca0` / 64 passed（本 PR で 21 test 追加: closing 各形 5 / fail 境界 5 / conventional-commit 誤認なし 3 / no-issue-close 2 / lane・label skip 6）/ `tests/unit/github/pr-template-gate-checks.test.ts` |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
UI 影響なし。CI gate（`pr-template-gate.yml`）と PR 運用ドキュメント（`.github/CLAUDE.md` / `docs/sessions/branch-strategy.md`）のみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  `tests/unit/github/pr-template-gate-checks.test.ts` に describe「closing-keyword gate (#3458)」21 test 追加（closing keyword 各形 PASS / bare `#N`・`関連: #N` fail / `fix: #N subject` を closing と誤認しない / no-issue-close 宣言 skip + 空理由 fail / integration・hotfix・dependabot・back-merge・dependencies skip / #3444 規約共有の境界 3 件）+ dependabot 全 check skip loop に closing-keyword を追加
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

### テスト実行結果

| テスト種別 | コマンド | 結果 | 備考 |
|---|---|---|---|
| Lint | `npx biome check scripts/pr-template-gate-checks.mjs tests/unit/github/pr-template-gate-checks.test.ts` | PASS | 変更ファイル 0 error |
| 単体テスト（gate） | `npx vitest run tests/unit/github/pr-template-gate-checks.test.ts` | 64 passed | 本 PR で 21 test 追加 |
| 単体テスト（共有元回帰） | `npx vitest run tests/unit/github/integration-pr-body.test.ts` | 38 passed | `integration-pr-body.mjs` は import のみで無変更（回帰ゼロ） |
| CLI 実挙動 | `node scripts/pr-template-gate-checks.mjs --check closing-keyword --lane feature ...` | PASS | bare `#N` body → exit 1 / `closes #3458` body → exit 0 を実測 |
| YAML 構文 | `node -e "require('js-yaml').load(...)"` | PASS | `pr-template-gate.yml` parse OK |
| cspell | `npx cspell tests/unit/github/pr-template-gate-checks.test.ts` | PASS | Issues found: 0 |

## スクリーンショット / ビジュアルデモ

**該当なし（CI gate のみ。UI 変更を含まない infra 変更のため 4 スロット添付は対象外）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（`checkClosingKeyword` は closing 宣言検証のみ）/ 検出規約は `extractClosedIssues` に委譲（依存方向は gate → 集約 SSOT の一方向）
- [x] **DRY**: closing keyword 検出 regex / section slice / code-fence strip を再実装せず `extractClosedIssues` を単一 PR body で呼び出して共有（AC4）。並行 PR #3462（regex 本体の根治）と衝突しないよう `integration-pr-body.mjs` は import のみで無変更
- [x] **YAGNI**: 新規 workflow を新設せず既存 `pr-template-gate.yml` に job 追加（Issue 選択肢 A、#1442 使い捨て回避）
- [x] **Security（OSS 公開前提）**: 秘密情報なし / PR body は既存 job と同じ `printf > /tmp` 経路で処理（インジェクション面の新規増加なし）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: N/A（CI job 1 本追加、timeout 2 分・軽量）

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] **設計書同期** (ADR-0001): `.github/CLAUDE.md`（チケット管理 close 運用 + pr-template-gate 表 6 job 化 + Dependabot exempt 記述）/ `docs/sessions/branch-strategy.md`（§3.2 close 運用 SSOT + gate 対応表 + lane-aware 注記）を同 PR で同期
- [x] **並行 PR overlap** (#1200): #3462（`integration-pr-body.mjs` regex 修正）と並行作業中のため、本 PR は同ファイルを **import のみ（無変更）** とし conflict を構造的に回避。#3462 が regex を根治すれば本 gate の判定も自動で追従する（規約共有の利点）
- [x] N/A — 上記以外（本番/デモ・年齢モード・ナビ・labels SSOT・LP）は CI gate のみのため影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- **conventional-commit title 引用の gate 側ガード**: 共有規約（#3444 のコロン形許容）は `fix: #N subject` も match しうるが、`.github/CLAUDE.md` SSOT は「conventional-commit prefix は closing keyword ではない」と定めるため、gate 側で **小文字 `fix` + コロン + `#N` + 後続 subject がある行**のみを事前除去した（`stripConventionalCommitFixTitleLines`、`Fixes: #N 説明` の正規コロン形は除去しない）。regex 本体の根治は #3462 が担い、本ガードは gate 局所の防御（`integration-pr-body.mjs` には触れていない）
- **required 化は管理者作業**: 新 context `closing keyword の記入 (feat/fix)` を Branch Ruleset の `required_status_checks` に追加登録が必要（既存 5 context は改名なし、#2944 AC6 遵守）
- **hotfix lane を skip とした判断**: Issue の scope は「develop 向け feat/fix PR」。hotfix（`fix/*` → main）は default branch 直行のため GitHub が merge 時に直接 auto-close し、集約機構（#3423）を経由しない

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（本 PR は Phase 分割なし）
- [x] UI 変更時: SS 添付（本 PR は UI 変更なしのため該当なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) SS 添付（本 PR は認証画面変更なしのため該当なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
