### PR TITLE
test/ci: #3352 #3351 stripe-checkout E2E の CI 実行化 (test key lane 供給 + honest skip + hydration gate 展開)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,12 +785,33 @@ jobs:
           PARENT_GATE_COOKIE_SECRET: e2e-test-parent-gate-secret-do-not-use
         run: npm run build
 
+      # #3352 (A): stripe-checkout spec を CI で実 assertion 実行させるため、test mode の
+      # Stripe key を供給する前に sk_test_ prefix を検証する fail-closed gate。
+      # live 用 secrets.STRIPE_SECRET_KEY (deploy.yml / weekly-report.yml 専用) を誤って
+      # 本 lane に流し込む事故を機械的に遮断する (live key の E2E 使用禁止)。
+      - name: Validate Stripe key is test mode (live key E2E 使用禁止 #3352)
+        env:
+          STRIPE_KEY_CANDIDATE: ${{ secrets.STRIPE_SECRET_KEY_TEST }}
+        run: |
+          if [ -n "$STRIPE_KEY_CANDIDATE" ] && [[ "$STRIPE_KEY_CANDIDATE" != sk_test_* ]]; then
+            echo "::error::STRIPE_SECRET_KEY_TEST must be a Stripe test mode key (sk_test_...). Refusing to run E2E with a non-test key."
+            exit 1
+          fi
+          echo "Stripe key validation passed (empty = degrade to skip, sk_test_* = enabled)."
+
       - name: Run cognito-dev E2E tests
         env:
           AUTH_MODE: cognito
           COGNITO_DEV_MODE: "true"
           # #2310 / #2337 / ADR-0050: parent-gate-session.ts E2E requirement
           PARENT_GATE_COOKIE_SECRET: e2e-test-parent-gate-secret-do-not-use
+          # #3352 (A): test mode Stripe key + 月額 price ID。playwright webServer (preview server)
+          # が本 step の env を継承し isStripeEnabled()=true で plan card を描画、stripe-checkout
+          # spec の全 failure-path assertion が CI で実 exercise される。fork PR では secrets 非供給
+          # (空文字) のため従来どおり honest skip に degrade する。
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY_TEST }}
+          STRIPE_PRICE_STANDARD_MONTHLY: ${{ vars.STRIPE_PRICE_STANDARD_MONTHLY_TEST }}
+          STRIPE_PRICE_FAMILY_MONTHLY: ${{ vars.STRIPE_PRICE_FAMILY_MONTHLY_TEST }}
           CI: "true"
         run: npx playwright test --config playwright.cognito-dev.config.ts
 

--- a/scripts/check-test-antipatterns.js
+++ b/scripts/check-test-antipatterns.js
@@ -20,15 +20,28 @@ let hasError = false;
 
 const TEST_SKIP_PATTERN = 'test\\.skip\\|test\\.fixme\\|it\\.skip\\|describe\\.skip';
 
-function sumGitGrepCountOutput(output) {
+// #3352: 明示 escape hatch。環境 capability 由来の「条件付き skip + reason」(Playwright 公式
+// pattern) を honest SKIPPED 計上へ是正する際、同一行に `// ratchet-allow: #<issue>` を付けた
+// 行のみ ratchet 集計から除外する (eslint-disable-line と同型の可視・監査可能な annotation)。
+// - default 挙動は不変: marker なしの test.skip/fixme 増加は従来どおり BLOCK
+// - marker には Issue 番号必須 (根拠 traceability)。check-skip-deadlines.mjs の metadata gate
+//   (ADR-0006) も全 skip に引き続き適用される (二重ガード)
+// - 背景: 本 ratchet が count-only だったため「return-skip で PASSED 偽装」という より悪い
+//   anti-pattern を誘発していた (#3352 (B) Goodhart hazard)。honest skip を可視 annotation 付きで
+//   許容し、偽装 skip への逃げ道を断つ
+const RATCHET_ALLOW_RE = /\/\/\s*ratchet-allow:\s*#\d+/;
+
+function countSkipLines(gitGrepRef) {
+	// gitGrepRef: '' = working tree / 'origin/main' = main 側。同一ロジックで両側を数える。
+	const cmd = gitGrepRef
+		? `git grep -n "${TEST_SKIP_PATTERN}" ${gitGrepRef} -- "tests/e2e/" || true`
+		: `git grep -n "${TEST_SKIP_PATTERN}" -- "tests/e2e/" || true`;
+	const output = execSync(cmd, { encoding: 'utf-8' });
 	return output
 		.trim()
 		.split('\n')
 		.filter(Boolean)
-		.reduce((sum, line) => {
-			const match = line.match(/:(\d+)$/);
-			return sum + (match ? Number.parseInt(match[1], 10) : 0);
-		}, 0);
+		.filter((line) => !RATCHET_ALLOW_RE.test(line)).length;
 }
 
 // --- 1. Check for new clearDialogGhosts usage in diff ---
@@ -72,28 +85,26 @@ try {
 }
 
 // --- 2. Count test.skip / test.fixme and compare vs origin/main ---
+// #3352: ratchet-allow annotation 付き行 (条件付き環境 skip の明示許容) は両側とも除外して比較する。
 try {
-	const skipCount = execSync(`git grep -c "${TEST_SKIP_PATTERN}" -- "tests/e2e/" || echo "0"`, {
-		encoding: 'utf-8',
-	});
+	const totalSkips = countSkipLines('');
 
-	const totalSkips = sumGitGrepCountOutput(skipCount);
-
-	console.log(`  test.skip/fixme count in e2e: ${totalSkips}`);
+	console.log(`  test.skip/fixme count in e2e (ratchet-allow 除外後): ${totalSkips}`);
 
 	// Compare vs origin/main without mutating the working tree
 	try {
-		const mainSkipCount = execSync(
-			`git grep -c "${TEST_SKIP_PATTERN}" origin/main -- "tests/e2e/" || echo "0"`,
-			{ encoding: 'utf-8' },
-		);
-		const mainTotalSkips = sumGitGrepCountOutput(mainSkipCount);
+		const mainTotalSkips = countSkipLines('origin/main');
 
-		console.log(`  test.skip/fixme count in origin/main e2e: ${mainTotalSkips}`);
+		console.log(
+			`  test.skip/fixme count in origin/main e2e (ratchet-allow 除外後): ${mainTotalSkips}`,
+		);
 
 		if (totalSkips > mainTotalSkips) {
 			console.error(
-				`BLOCKED: test.skip/fixme count increased in e2e (${mainTotalSkips} -> ${totalSkips}).`,
+				`BLOCKED: test.skip/fixme count increased in e2e (${mainTotalSkips} -> ${totalSkips}).\n` +
+					'条件付き環境 skip (Playwright 公式 pattern) として正当な場合のみ、同一行に\n' +
+					'`// ratchet-allow: #<issue>` annotation を付与して除外できる (#3352)。\n' +
+					'無条件 skip / fixme でテストを黙らせる用途への annotation 濫用は QM レビューで BLOCK 対象。',
 			);
 			hasError = true;
 		} else {

--- a/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
+++ b/tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts
@@ -11,33 +11,56 @@
 // 本 spec は (A) 年額トグル撤去 + 月額固定表示、(B) checkout 失敗時のエラー提示、
 // (C) 月額 planId が checkout に送信されることを検証する。
 //
+//   - #3352: CI (e2e-cognito-dev lane) に test mode STRIPE_SECRET_KEY_TEST を供給し本 spec を
+//     実 assertion 実行させる (A) + return-skip (PASSED 偽装) を honest SKIPPED 計上に是正 (B)。
+//   - #3351: hydration gate + strict-mode `.first()` を #3204 test にも展開、共通 helper 化。
+//
 // テスト分類: Integration (page.route() で Stripe API モック、cognito-dev 認証必須)
 // 実行: npx playwright test --config playwright.cognito-dev.config.ts stripe-checkout-monthly-yearly
 
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 test.describe('#3204 月額固定 checkout + 失敗フィードバック — /admin/subscription', () => {
 	test.use({ storageState: 'playwright/.auth/free.json' });
 
-	/** Stripe 未設定環境 (plan card 非表示) では月額ボタンが出ないため skip 判定に使う */
-	async function skipIfStripeDisabled(page: import('@playwright/test').Page): Promise<boolean> {
+	/**
+	 * Stripe 未設定環境 (plan card 非表示) では checkout UI が描画されないため、honest に
+	 * SKIPPED 計上する (#3352 (B))。旧実装は return false + 呼び出し側 early-return で
+	 * runner に PASSED 計上され「fail-closed path 検証済」と誤認される Goodhart hazard だった。
+	 * CI (e2e-cognito-dev lane) には #3352 (A) で test mode の STRIPE_SECRET_KEY_TEST が
+	 * 供給されるため、本 skip が発火するのは secrets 非供給環境 (fork PR / key 未設定 local) のみ。
+	 */
+	async function skipIfStripeDisabled(page: Page): Promise<void> {
 		const monthlyCheckoutBtn = page.getByTestId('standard-plan-card');
 		const visible = await monthlyCheckoutBtn
 			.waitFor({ state: 'visible', timeout: 5_000 })
 			.then(() => true)
 			.catch(() => false);
-		if (!visible) {
-			test.info().annotations.push({
-				type: 'skip-reason',
-				description: 'Stripe 未設定環境 (stripeEnabled=false で plan card 非表示) のためスキップ',
+		// #3352: 環境 capability 由来の条件付き skip (unconditional disable ではない)。
+		// ratchet-allow marker は check-test-antipatterns.js の明示 escape hatch (同一行必須)。
+		test.skip(!visible, 'Stripe 未設定 (plan card 非表示) のためスキップ'); // ratchet-allow: #3352
+	}
+
+	/**
+	 * hydration ゲート (#3351): skipIfStripeDisabled は SSR 描画済 plan card の visible のみ
+	 * 待つため、interactive island の hydration 完了前に click すると onclick が発火しない。
+	 * plan card 選択 (selectedTier) が checkout button label に反映される (= hydration 完了)
+	 * まで poll-click し、確実に interactive 化を待ってから checkout を起動する (flaky 防止)。
+	 * card click は checkout API を呼ばないため route mock の call count には影響しない。
+	 */
+	async function ensureCheckoutHydrated(page: Page): Promise<void> {
+		await page.waitForLoadState('load');
+		await expect(async () => {
+			await page.getByTestId('family-plan-card').click();
+			await expect(page.getByRole('button', { name: 'プレミアムプランで始める' })).toBeVisible({
+				timeout: 1_000,
 			});
-		}
-		return visible;
+		}).toPass({ timeout: 15_000 });
 	}
 
 	test('年額トグルが撤去され月額固定で表示される (#2719 年額廃止と UI 整合)', async ({ page }) => {
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
-		if (!(await skipIfStripeDisabled(page))) return;
+		await skipIfStripeDisabled(page);
 
 		// 年額トグル・年額専用 UI が物理的に存在しないこと (年額選択 → INVALID_PLAN 経路の根絶)
 		await expect(page.getByRole('button', { name: /年額/ })).toHaveCount(0);
@@ -60,14 +83,17 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 		});
 
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
-		if (!(await skipIfStripeDisabled(page))) return;
+		await skipIfStripeDisabled(page);
 
-		// プレミアム選択 → 「プレミアムプランで始める」押下
-		await page.getByTestId('family-plan-card').click();
+		// プレミアム選択 (hydration 完了まで poll-click、#3351) → 「プレミアムプランで始める」押下
+		await ensureCheckoutHydrated(page);
 		await page.getByRole('button', { name: /プランで始める/ }).click();
 
-		// silent no-op でなく、サーバーメッセージが画面に提示されること (Alert / Toast の 2 層 feedback)
-		await expect(page.getByText('プランが正しくありません')).toBeVisible({ timeout: 8_000 });
+		// silent no-op でなく、サーバーメッセージが画面に提示されること。
+		// 2 層 feedback (Alert banner + Toast、DESIGN.md §5) で同一文言が複数描画されるため first() (#3351)
+		await expect(page.getByText('プランが正しくありません').first()).toBeVisible({
+			timeout: 8_000,
+		});
 	});
 
 	// #3209: 503 STRIPE_DISABLED (demo/staging 頻出) path の test 補完。汎用「時間をおいて再度…」
@@ -88,20 +114,10 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 		});
 
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
-		if (!(await skipIfStripeDisabled(page))) return;
+		await skipIfStripeDisabled(page);
 
-		// hydration ゲート: skipIfStripeDisabled は SSR 描画済 plan card の visible のみ待つため、
-		// interactive island の hydration 完了前に click すると onclick が発火しない。plan card 選択
-		// (selectedTier) が checkout button label に反映される (= hydration 完了) まで poll-click し、
-		// 確実に interactive 化を待ってから checkout を起動する (flaky 防止)。card click は checkout を
-		// 呼ばないため checkoutCallCount には影響しない。
-		await page.waitForLoadState('load');
-		await expect(async () => {
-			await page.getByTestId('family-plan-card').click();
-			await expect(page.getByRole('button', { name: 'プレミアムプランで始める' })).toBeVisible({
-				timeout: 1_000,
-			});
-		}).toPass({ timeout: 15_000 });
+		// hydration ゲート (#3351 で共通 helper 化。詳細は ensureCheckoutHydrated の docblock 参照)
+		await ensureCheckoutHydrated(page);
 
 		const checkoutBtn = page.getByRole('button', { name: /プランで始める/ });
 		await checkoutBtn.click();
@@ -138,20 +154,10 @@ test.describe('#3204 月額固定 checkout + 失敗フィードバック — /ad
 		});
 
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
-		if (!(await skipIfStripeDisabled(page))) return;
+		await skipIfStripeDisabled(page);
 
-		// hydration ゲート: skipIfStripeDisabled は SSR 描画済 plan card の visible のみ待つため、
-		// interactive island の hydration 完了前に click すると onclick が発火しない。plan card 選択
-		// (selectedTier) が checkout button label に反映される (= hydration 完了) まで poll-click し、
-		// 確実に interactive 化を待ってから checkout を起動する (flaky 防止)。card click は checkout を
-		// 呼ばないため checkoutCallCount には影響しない。
-		await page.waitForLoadState('load');
-		await expect(async () => {
-			await page.getByTestId('family-plan-card').click();
-			await expect(page.getByRole('button', { name: 'プレミアムプランで始める' })).toBeVisible({
-				timeout: 1_000,
-			});
-		}).toPass({ timeout: 15_000 });
+		// hydration ゲート (#3351 で共通 helper 化。詳細は ensureCheckoutHydrated の docblock 参照)
+		await ensureCheckoutHydrated(page);
 
 		const checkoutBtn = page.getByRole('button', { name: /プランで始める/ });
 		await checkoutBtn.click();


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（品質保証基盤）/ 間接的に課金導線を使う親（管理者）

**解決する課題**: `tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts` の checkout 失敗 path test が CI で 1 行も assertion を実行しないまま **PASSED 計上**されており（STRIPE key 未供給で skip + return-skip の PASSED 偽装）、#3204 / #3209 が守るべき「checkout 失敗時に silent no-op しない」回帰を CI が検出できない状態だった（Goodhart hazard）。

**期待される効果**: CI (e2e-cognito-dev lane) で stripe-checkout spec の全 failure-path assertion が実 exercise され、課金導線 (checkout 失敗フィードバック / fail-closed 不変条件) の回帰が merge 前に機械検出される。skip する環境 (fork PR / key 未設定 local) では honest に SKIPPED 計上され、監査が pass count を誤読しない。

## 関連 Issue

closes #3352
closes #3351

- #3352 コメント (2026-07 時点) で「item B (honest skip 化) 撤回」の経緯があるが、撤回根拠 (b)「skip しても CI で assertion が走らない」は本 PR の item A（test key lane 供給、本日 secrets/vars 登録済）で解消され、根拠 (a) anti-skip ratchet 抵触は `check-test-antipatterns.js` の明示 annotation 機構（下記）で「無条件 skip 濫用の遮断」を維持したまま解消した。旧 PR #3447（B 単独、close 済）とは前提条件が異なる。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (#3352 A) | E2E test lane に test mode Stripe key を供給し、少なくとも 1 つの CI 経路で当 spec が実 assertion を exercise する | `.github/workflows/ci.yml` diff 目視 + `npx --yes @action-validator/cli .github/workflows/ci.yml` | HEAD `9ffcf399` / ci.yml:803-805 で `STRIPE_SECRET_KEY: secrets.STRIPE_SECRET_KEY_TEST` + 月額 price vars 2 種を e2e-cognito-dev Run step に供給（playwright webServer が preview server に継承、`isStripeEnabled()` は `process.env` runtime 読取のため build step 不要）/ schema OK |
| AC2 (#3352 A 派生) | live 用 `secrets.STRIPE_SECRET_KEY` を E2E lane に使わない（test mode key のみ） | ci.yml grep + sk_test_ prefix 検証 gate | HEAD `9ffcf399` / ci.yml:783-791 で `sk_test_*` prefix を検証し非 test key なら exit 1 で E2E 実行前に fail-closed / `grep -n "secrets.STRIPE_SECRET_KEY[^_]" .github/workflows/ci.yml` = 0 件 |
| AC3 (#3352 B) | return-skip (PASSED 計上) を `test.skip(condition, reason)` に変え honest SKIPPED 計上、spec 全 callsite に展開 | key 未設定 local で `npx playwright test --config playwright.cognito-dev.config.ts tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts --grep "年額トグル"` | HEAD `9ffcf399` / spec:41 で `test.skip(!visible, ...)` 化、callsite 4 箇所 (spec:63/86/117/157) から `if (!(...)) return;` を全廃 / local 実行結果「`-` (skipped) / 1 skipped」= SKIPPED 計上を実機確認（従来は passed 計上） |
| AC4 (#3351) | 兄弟 test (#3204 checkout 失敗 非 2xx) に hydration gate を適用 | spec diff 目視 + `--list` で 5 test 列挙維持 | HEAD `9ffcf399` / spec:89 で `ensureCheckoutHydrated(page)` を #3204 test に適用（#3209 の 2 test と同一ゲート）/ `--list` = 5 tests + setup 6 |
| AC5 (#3351) | 2 層 feedback 文言の strict-mode violation を `.first()` で回避（意図維持） | spec grep | HEAD `9ffcf399` / spec:94 `getByText('プランが正しくありません').first()` 化（#3209 の 2 test spec:127/168 と同型） |
| AC6 (#3351) | hydration 待ちを共通 helper 化し全 failure-path test で再利用（3 箇所重複の DRY 化、#1442） | spec grep | HEAD `9ffcf399` / spec:51 `ensureCheckoutHydrated` helper 新設、spec:89/120/160 の 3 callsite が参照（旧: 同一 8 行 block が 2 箇所 inline + 1 箇所未適用） |
| AC7 (横断) | anti-skip ratchet (`check-test-antipatterns.js`) と skip metadata gate (`check-skip-deadlines.mjs`) が PASS | `node scripts/check-test-antipatterns.js` / `node scripts/check-skip-deadlines.mjs` | HEAD `9ffcf399` / ratchet: 26 → 26 (ratchet-allow 除外後、増加なし) exit 0 / skip-deadlines: 26 known orphans all in baseline exit 0（新規 skip 行は同一行 `// ratchet-allow: #3352` が Issue metadata を兼ねる） |

## 変更タイプ

- [x] test: テスト改善
- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- CI e2e-cognito-dev lane（stripe-checkout spec が実 assertion 実行に変化。同 lane の他 spec — upgrade-checkout / upgrade-flow / stripe-checkout-labels 等 — も stripe 有効 (plan card 描画) 状態で走るようになるが、各 spec は stripe 有効環境向けに書かれており、未認証 API test の期待値 `[401, 403, 503]` は 401/403 側で PASS 維持を確認済）
- `scripts/check-test-antipatterns.js`（ratchet-allow annotation 機構。marker なしの test.skip/fixme 増加は従来どおり BLOCK、default 挙動不変）
- アプリ本体 (`src/`) のコード変更なし

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— full 実行はメインセッションが Ready 化前に実施する分担（本 PR は Draft 提出まで）。変更に関連する検証の個別 PASS 一覧は「Ready for Review チェックリスト」参照
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts`: honest skip 化（`test.skip(condition, reason)`、4 callsite）+ hydration gate 共通 helper `ensureCheckoutHydrated` + `.first()` 展開。test 件数は 5 で増減なし、assertion の削除・弱体化なし（ADR-0006 遵守 — 変更は skip 計上方式と操作前提の安定化のみ）
- [x] **新規 env / secret 追加時**（ADR-0006）: 末尾の「配布済み env / secret」セクションに証跡を記載
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（CI/test のみの変更で UI 変更を含まない）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: skip 判定と hydration 待ちを単一責任 helper 2 つに分離（S）
- [x] **DRY**: 同一 8 行の hydration block 2 箇所 + 未適用 1 箇所を `ensureCheckoutHydrated` に集約。`grep -rn "return-skip\|skipIfStripeDisabled" tests/` で同型 return-skip の残存を確認 — `tests/e2e/integration/upgrade-checkout.spec.ts:48` に類似 annotation 方式（return-skip）が 1 件残存するが、#3352 の scope は当 spec と CI lane であり、同 lane への key 供給により当該 spec も CI で実行されるようになる（skip 自体が発火しなくなる）ため本 PR では対象外と判断（レビュー依頼事項に記載）
- [x] **YAGNI**: ratchet-allow は正規表現 1 本 + filter 1 行の最小機構。baseline ファイル等の新規機構は追加しない
- [x] **Security（OSS 公開前提）**: secret は GitHub Actions Secrets 参照のみ（hardcode なし）。sk_test_ prefix 検証 gate で live key 混入を実行前遮断。fork PR では secrets 非供給 → 空文字 → `isStripeEnabled()=false` → honest skip に degrade（fail-safe）
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: hydration gate は既存 2 test で実績ある poll-click（上限 15s）。CI 時間への追加影響は #3204 test 1 件分のみ

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] N/A — 並行実装の影響範囲外（tests/ + scripts/ + .github/ のみ、アプリ本体・LP・labels 変更なし）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:

1. **`check-test-antipatterns.js` の ratchet-allow annotation 機構**（本 PR の判断ポイント）: Issue #3352 コメントで「honest skip 化は anti-skip ratchet に抵触するため撤回（旧 PR #3447 close）」の経緯がある。本 PR は前提条件が変わった（test key の CI 供給 = 撤回根拠 (b) の解消）うえで、ratchet 側に **同一行 `// ratchet-allow: #<issue>` 必須の明示 escape hatch**（eslint-disable-line と同型）を導入して根拠 (a) を解消した。default 挙動（marker なし skip 増加の BLOCK）は不変で、`check-skip-deadlines.mjs` の metadata gate も全 skip に引き続き適用される（二重ガード）。count-only ratchet が「return-skip で PASSED 偽装」というより悪い anti-pattern を誘発していた構造（#3352 (B) の根本原因）への対処として妥当かをレビューいただきたい。
2. **e2e-cognito-dev lane 全体への stripe 有効化の blast radius**: 同 lane の他 spec（upgrade-checkout / stripe-checkout-labels / upgrade-flow / plan-* / trial-* 等）が stripe 有効状態で走るようになる。事前調査では (i) 未認証 API test の期待値 `[401, 403, 503]` は 401/403 側で PASS 維持、(ii) plan card 前提の spec 群は「stripe 有効環境でのみ実行される」設計（従来 CI では skip されていた）のため、初回 CI 実行で顕在化する潜在不整合がないか CI 結果を確認いただきたい。
3. `tests/e2e/integration/upgrade-checkout.spec.ts:48` に同型の return-skip が 1 件残存する（上記 DRY 欄参照）。本 PR の key 供給により CI では skip 自体が発火しなくなるため実害は解消されるが、計上方式の統一を行う場合の扱いは QM 判断を仰ぎたい。

## 配布済み env / secret (ADR-0006)

- 配布済み: STRIPE_SECRET_KEY_TEST → GitHub Actions Secrets（本日登録済、Stripe テストモード sk_test_。ci.yml e2e-cognito-dev lane で参照）
- 配布済み: STRIPE_PRICE_STANDARD_MONTHLY_TEST → GitHub Actions Variables（`price_1Ts03YBgMFbHJZ0ZJFwyW2u3`、¥500/月）
- 配布済み: STRIPE_PRICE_FAMILY_MONTHLY_TEST → GitHub Actions Variables（`price_1Ts03ZBgMFbHJZ0ZsKMbXn2O`、¥780/月）

いずれも CI E2E 専用（deploy 経路では従来どおり live 用 `STRIPE_SECRET_KEY` を使用、本 PR は deploy.yml に変更なし）。

## Ready for Review チェックリスト

- [x] **変更に関連する検証を全て PASS 確認した**（full `pre-ready` はメインセッションが Ready 化前に実施する分担。gitignored worktree では biome `.` 指定が 0 files になる環境固有事象もあり、変更ファイル起点で個別実行）: biome `--error-on-warnings`（変更 2 files）PASS / cspell（変更 2 files）0 issues / svelte-check 0 errors 0 warnings / spec `--list` 5 tests 列挙維持 / key 未設定での honest SKIPPED 実機確認 / `check-test-antipatterns.js` 26→26 PASS / `check-skip-deadlines.mjs` PASS / ci.yml schema 検証 OK / hardcoded-strings・no-plan-literals・license-key-leak・doc-code-references・terminology-coherence 各 PASS / Step 9 相当 = `check-pr-body.mjs --body-file --skip-mergeable` PASS
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — N/A（Phase 分割なし）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付 — N/A（認証画面変更なし）

（本 PR は Draft のまま提出し、Ready 化は QM / 統合フローの判断に委ねる）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
