### PR TITLE
fix(billing): #3669 活動 source 意味論を SSOT 化し quota 未執行を根治 (producer/consumer 三重乖離)

### DIFF
--- a/docs/design/data-model-resource-scope.md
+++ b/docs/design/data-model-resource-scope.md
@@ -113,6 +113,22 @@ child_activities
 
 **禁忌**: child context が確定している経路 (child home / setup の child binding 後) では必ず `getChildActivities` を使う。`getActivities` (tenant aggregate) を child 経路で使うと 5 children 環境で同名 activity が 5 倍に重複 render される UX 退行が再発する (#2471 教訓)。
 
+#### `source` 列の意味論 SSOT (#3669)
+
+`child_activities.source` の値域・経路別の保存値・集計述語は **`src/lib/domain/activity-source.ts`** (`ACTIVITY_SOURCES`、`as const satisfies` パターン #3607 同型) が単一定義点。producer / consumer が個別に文字列リテラルを持つことを禁止する。
+
+| source 値 | 保存する経路 (producer) | quota 集計対象 |
+|---|---|---|
+| `custom` | 親手動作成 = admin/activities 単体追加 / 一括追加 / `api/v1/activities` (`createActivity` が `normalizeParentCreatedSource` で強制。正準定数 `PARENT_CREATED_SOURCE`) | ✅ |
+| `seed` | 初期 seed (`seed.ts`) / marketplace 取込 (`activity-import-service` — 取込元は `source_preset_id` で識別) / backup 復元 / cloud import (source 未指定 → repo 既定 = schema default 同値) | — |
+| `curriculum` | 年齢別カリキュラムプリセット (`seed.ts`) | — |
+| (元活動の値を保全) | 兄弟 copy (`copyActivitiesAcrossChildren`) — custom の copy は custom のまま (copy 経由の quota 迂回禁止) | 元の値に従う |
+| `parent` (legacy wire 値) | 保存されない (persist 前に `custom` へ正規化)。zod `SOURCES` enum は後方互換で受理のみ | ✅ (防御的) |
+
+- **consumer 共通述語**: `countsTowardActivityQuota(source)` — `checkActivityLimit` (plan-limit-service) / `/admin/subscription` 活動カウンタ / downgrade preview・検証 (downgrade-service) / trial 終了 archive (resource-archive-service) の 4 consumer が同一述語を参照する
+- **整合 lock**: `tests/unit/services/activity-source-quota-roundtrip.test.ts` が「UI 作成 → `checkActivityLimit.current` +1」の producer×consumer round-trip を実 SQLite で assert (ADR-0061 same-class guard)
+- **禁忌**: `InsertChildActivityInput.source` を経由せず repo 直 insert で source 文字列を直書きしない / consumer 側で `a.source === '...'` の直比較を書かない (必ず SSOT 述語を使う)
+
 **実装状況 PR-A1 (2026-05-26、#2458 Path A)**:
 
 - ✅ facade rewrite (`src/lib/server/db/sqlite/activity-repo.ts`) — 全 write method (insertActivity / updateActivity / setActivityVisibility / deleteActivity / archiveActivities / restoreArchivedActivities) を `child_activities` 経由に切替。**旧 `activities` table への write が 0 件 = #2458-C drop ready**

--- a/src/lib/domain/activity-source.ts
+++ b/src/lib/domain/activity-source.ts
@@ -1,0 +1,83 @@
+// src/lib/domain/activity-source.ts
+// 活動 `source` 列挙値の意味論 SSOT (#3669)
+//
+// 背景: producer (作成経路) と consumer (quota / カウンタ) が三者三様の source 値
+// ('seed' 保存 / 'custom' 集計 / 'parent' 表示) を前提にして drift し、free プランの
+// 活動数上限 (maxActivities=3) が全プランで実質未執行になっていた。本 module が
+// 「どの経路が何を保存し、誰が何を数えるか」の単一定義点 (#3607 categories SSOT と
+// 同じ `as const satisfies` パターン)。
+//
+// 経路別の source 値 (producer 4 経路):
+//   - 手動作成 (admin UI 単体/一括追加、api/v1/activities): `custom` (quota 集計対象)
+//   - marketplace 取込 (activity-import-service / cloud import): 未指定 → repo 既定 `seed`
+//     (取込元は `sourcePresetId` で識別。プリセット取込は custom quota を消費しない)
+//   - 初期 seed (seed.ts): `seed` / 年齢別カリキュラム: `curriculum`
+//   - 兄弟 copy (copyActivitiesAcrossChildren): 元活動の source を保全
+//     (custom の copy は custom のまま。copy による quota 迂回を防ぐ)
+//
+// 設計 doc: docs/design/data-model-resource-scope.md §4.1
+
+export interface ActivitySourceDef {
+	/** DB `child_activities.source` に保存される値 */
+	readonly value: string;
+	/** 親作成 quota (PLAN_LIMITS.maxActivities) / subscription カウンタの集計対象か */
+	readonly countsTowardQuota: boolean;
+	/** 意味論 (どの経路が保存するか) */
+	readonly description: string;
+}
+
+export const ACTIVITY_SOURCES = {
+	seed: {
+		value: 'seed',
+		countsTowardQuota: false,
+		description: '初期 seed / marketplace 取込 / backup 復元 (schema default)',
+	},
+	curriculum: {
+		value: 'curriculum',
+		countsTowardQuota: false,
+		description: '年齢別カリキュラムプリセット (seed.ts)',
+	},
+	custom: {
+		value: 'custom',
+		countsTowardQuota: true,
+		description: '親が UI から手動作成 (単体追加 / 一括追加 / api/v1/activities)',
+	},
+} as const satisfies Record<string, ActivitySourceDef>;
+
+export type ActivitySourceCode = keyof typeof ACTIVITY_SOURCES;
+
+/** 親手動作成の正準 source 値。producer (admin add / bulkAdd / createActivity) はこれを保存する */
+export const PARENT_CREATED_SOURCE = ACTIVITY_SOURCES.custom.value;
+
+/**
+ * 旧 wire 値 'parent'。DB には保存された実績が無い (insert 境界で drop されていた) が、
+ * 旧クライアント / 既存 zod enum が受理するため、persist 前に `custom` へ正規化する。
+ */
+export const LEGACY_PARENT_SOURCE = 'parent';
+
+/**
+ * wire (createActivitySchema) が受理する source 値域。
+ * `src/lib/domain/validation/activity.ts` の zod `z.enum(SOURCES)` から参照される。
+ */
+export const ACTIVITY_SOURCE_WIRE_VALUES = ['seed', 'curriculum', 'custom', 'parent'] as const;
+
+export type ActivitySourceWireValue = (typeof ACTIVITY_SOURCE_WIRE_VALUES)[number];
+
+/**
+ * 親手動作成経路の source 正規化 (producer 単一強制点、ADR-0061 push-down)。
+ * 未指定 / legacy 'parent' は正準 `custom` に倒す。明示された既知値はそのまま通す
+ * (内部経路が seed/curriculum を意図的に指定するケースを壊さない)。
+ */
+export function normalizeParentCreatedSource(source: string | undefined): string {
+	if (source === undefined || source === LEGACY_PARENT_SOURCE) return PARENT_CREATED_SOURCE;
+	return source;
+}
+
+/**
+ * quota (checkActivityLimit) / subscription カウンタ / downgrade archive が
+ * 「親作成 (custom) 活動」として数える述語 (consumer 共通 SSOT)。
+ * legacy 'parent' も防御的に数える (repo 直 write 等で将来混入しても課金境界を守る)。
+ */
+export function countsTowardActivityQuota(source: string): boolean {
+	return source === PARENT_CREATED_SOURCE || source === LEGACY_PARENT_SOURCE;
+}

--- a/src/lib/domain/validation/activity.ts
+++ b/src/lib/domain/validation/activity.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ACTIVITY_SOURCE_WIRE_VALUES } from '$lib/domain/activity-source';
 import {
 	CATEGORY_CODES,
 	CATEGORIES as CATEGORY_SSOT,
@@ -66,7 +67,9 @@ export const GRADE_LEVELS = [
 
 export type GradeLevel = (typeof GRADE_LEVELS)[number];
 
-export const SOURCES = ['seed', 'curriculum', 'custom', 'parent'] as const;
+// #3669: source 意味論の SSOT は $lib/domain/activity-source.ts。本 tuple は wire 受理値域
+// (zod enum 用) の再 export。'parent' は legacy wire 値で persist 前に 'custom' へ正規化される。
+export const SOURCES = ACTIVITY_SOURCE_WIRE_VALUES;
 
 export type Source = (typeof SOURCES)[number];
 

--- a/src/lib/server/db/demo/child-activity-repo.ts
+++ b/src/lib/server/db/demo/child-activity-repo.ts
@@ -138,7 +138,8 @@ export async function insertActivity(
 		// #3422: 親入力の 1 日上限 / 読み仮名 / 漢字表記を persist (旧実装は null 固定で drop していた)
 		dailyLimit: input.dailyLimit ?? null,
 		sortOrder: input.sortOrder ?? 0,
-		source: 'demo',
+		// #3669: input.source を透過 (返り値 shape の backend parity)。省略時は demo stub 既定
+		source: input.source ?? 'demo',
 		nameKana: input.nameKana ?? null,
 		nameKanji: input.nameKanji ?? null,
 		triggerHint: input.triggerHint ?? null,

--- a/src/lib/server/db/dsql/child-activity-repo.ts
+++ b/src/lib/server/db/dsql/child-activity-repo.ts
@@ -19,6 +19,7 @@
 //     isVisible/sortOrder/dailyLimit 等は default に落とす)。
 
 import { sql } from 'drizzle-orm';
+import { ACTIVITY_SOURCES } from '$lib/domain/activity-source';
 import { asActivityId, asCategoryId, asChildId } from '$lib/domain/ids';
 import type { IChildActivityRepo } from '../interfaces/child-activity-repo.interface';
 import type { TransactionRunner } from '../interfaces/transaction.interface';
@@ -89,20 +90,22 @@ export function toChildActivity(row: ChildActivityRow): ChildActivity {
 
 /**
  * INSERT 文を構築する (insertActivity / insertActivitiesBulk で共有)。
- * `source` 列は schema default ('seed') に委ねる (sqlite parity: insert 側は指定しない)。
+ * `source` 列は input.source を persist し、省略時は 'seed' (schema default 同値、sqlite parity)。
+ * #3669: 旧実装は source を指定せず全経路が 'seed' に落ち、親手動作成 'custom' が
+ * quota 集計から漏れていた。
  */
 function buildInsertSql(input: InsertChildActivityInput, tenantId: string) {
 	return sql`
 		INSERT INTO child_activities
 			(family_id, child_id, name, category_id, icon, base_points, trigger_hint, is_main_quest,
 			 source_preset_id, priority, is_visible, sort_order, is_archived, archived_reason,
-			 daily_limit, name_kana, name_kanji)
+			 daily_limit, name_kana, name_kanji, source)
 		VALUES (${tenantId}, ${input.childId}, ${input.name}, ${input.categoryId}, ${input.icon},
 			${input.basePoints}, ${input.triggerHint ?? null}, ${(input.isMainQuest ?? 0) !== 0},
 			${input.sourcePresetId ?? null}, ${input.priority ?? 'optional'},
 			${(input.isVisible ?? 1) !== 0}, ${input.sortOrder ?? 0}, ${(input.isArchived ?? 0) !== 0},
 			${input.archivedReason ?? null}, ${input.dailyLimit ?? null}, ${input.nameKana ?? null},
-			${input.nameKanji ?? null})
+			${input.nameKanji ?? null}, ${input.source ?? ACTIVITY_SOURCES.seed.value})
 		RETURNING ${ACTIVITY_COLUMNS}
 	`;
 }
@@ -242,6 +245,8 @@ export function createDsqlChildActivityRepo<TTx extends SqlExecutor>(
 				isMainQuest: a.isMainQuest,
 				sourcePresetId: a.sourcePresetId,
 				priority: a.priority,
+				// #3669: 元活動の source を保全 (copy 経由の quota 迂回と provenance 喪失を防ぐ)
+				source: a.source,
 			}));
 			return insertActivitiesBulk(inputs, tenantId);
 		},

--- a/src/lib/server/db/dynamodb/child-activity-repo.ts
+++ b/src/lib/server/db/dynamodb/child-activity-repo.ts
@@ -18,6 +18,7 @@
 // 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/child-activity-repo.ts (SSOT)
 
 import { DeleteCommand, GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { ACTIVITY_SOURCES } from '$lib/domain/activity-source';
 import type { ArchivedReason } from '$lib/domain/archive-types';
 import type { ActivityId, ChildId } from '$lib/domain/ids';
 import { asActivityId, asCategoryId, asChildId } from '$lib/domain/ids';
@@ -146,7 +147,9 @@ function buildChildActivity(
 		// #3422: 親入力の 1 日上限 / 読み仮名 / 漢字表記を persist (旧実装は null 固定で drop していた)
 		dailyLimit: input.dailyLimit ?? null,
 		sortOrder: input.sortOrder ?? 0,
-		source: 'seed',
+		// #3669: 作成経路の source を persist (旧実装は 'seed' 固定で親手動作成 'custom' が
+		// quota 集計から漏れていた)。省略時は従来どおり 'seed' (sqlite schema default parity)。
+		source: input.source ?? ACTIVITY_SOURCES.seed.value,
 		nameKana: input.nameKana ?? null,
 		nameKanji: input.nameKanji ?? null,
 		triggerHint: input.triggerHint ?? null,
@@ -343,6 +346,8 @@ export async function copyActivitiesAcrossChildren(
 		isMainQuest: a.isMainQuest,
 		sourcePresetId: a.sourcePresetId,
 		priority: a.priority,
+		// #3669: 元活動の source を保全 (copy 経由の quota 迂回と provenance 喪失を防ぐ)
+		source: a.source,
 	}));
 
 	return insertActivitiesBulk(inputs, tenantId);

--- a/src/lib/server/db/sqlite/child-activity-repo.ts
+++ b/src/lib/server/db/sqlite/child-activity-repo.ts
@@ -14,6 +14,7 @@
 // Phase 6/7 で全 callsite 移行後に drop。
 
 import { and, count, eq, inArray, isNull, or } from 'drizzle-orm';
+import { ACTIVITY_SOURCES } from '$lib/domain/activity-source';
 import type { ArchivedReason } from '$lib/domain/archive-types';
 import {
 	type ActivityId,
@@ -147,6 +148,9 @@ export async function insertActivity(
 			dailyLimit: input.dailyLimit ?? null,
 			nameKana: input.nameKana ?? null,
 			nameKanji: input.nameKanji ?? null,
+			// #3669: 作成経路の source を persist (旧型は field 不在で常に schema default 'seed' に
+			// 落ち、親手動作成 'custom' が quota 集計から漏れていた)。省略時は従来どおり 'seed'。
+			source: input.source ?? ACTIVITY_SOURCES.seed.value,
 		})
 		.returning()
 		.get();
@@ -265,6 +269,9 @@ export async function copyActivitiesAcrossChildren(
 		isMainQuest: a.isMainQuest,
 		sourcePresetId: a.sourcePresetId,
 		priority: a.priority,
+		// #3669: 元活動の source を保全 (custom の copy は custom のまま quota に数える。
+		// copy 経由の quota 迂回と provenance 喪失を防ぐ)
+		source: a.source,
 	}));
 
 	return insertActivitiesBulk(inputs, tenantId);

--- a/src/lib/server/db/types/index.ts
+++ b/src/lib/server/db/types/index.ts
@@ -414,6 +414,10 @@ export interface InsertChildActivityInput {
 	dailyLimit?: number | null;
 	nameKana?: string | null;
 	nameKanji?: string | null;
+	// #3669: 作成経路の意味論 (SSOT: $lib/domain/activity-source.ts)。旧型は本 field を持たず
+	// 全 insert が schema default 'seed' に落ち、親手動作成が quota (maxActivities) 集計から
+	// 漏れていた。省略時は repo 既定 'seed' (marketplace 取込 / backup 復元は quota 非対象)。
+	source?: string;
 }
 
 export interface UpdateChildActivityInput {

--- a/src/lib/server/services/activity-service.ts
+++ b/src/lib/server/services/activity-service.ts
@@ -1,3 +1,4 @@
+import { normalizeParentCreatedSource } from '$lib/domain/activity-source';
 import type { ActivityId, CategoryId, ChildId } from '$lib/domain/ids';
 import {
 	type GradeLevel,
@@ -141,10 +142,15 @@ async function _resolveChildIdForActivity(
 /**
  * `CreateActivityInput` (Activity master 型) を `InsertChildActivityInput` に変換。
  *
- * ageMin / ageMax / gradeLevel / subcategory / description / source は child_activities に
- * 列が無いため drop。dailyLimit / nameKana / nameKanji は child_activities に列が存在するため
- * persist する (#3422: 旧実装は「存在しない」と誤認して drop し、親の 1 日上限設定が常に無視され
+ * ageMin / ageMax / gradeLevel / subcategory / description は child_activities に列が無いため
+ * drop。dailyLimit / nameKana / nameKanji は child_activities に列が存在するため persist する
+ * (#3422: 旧実装は「存在しない」と誤認して drop し、親の 1 日上限設定が常に無視され
  * ProdDashboardSections の dailyLimit ?? 1 で 1 日 1 回固定になっていた = NN/G #1 visibility 違反)。
+ *
+ * source は正規化して persist する (#3669: 旧実装は「列が無い」と誤認して drop し、UI 手動作成が
+ * schema default 'seed' で保存され quota (maxActivities) / subscription カウンタが常に 0 だった)。
+ * createActivity は親手動作成 (admin UI / api/v1/activities) の経路なので、未指定 / legacy
+ * 'parent' は正準 'custom' に倒す (SSOT: $lib/domain/activity-source.ts)。
  */
 function _toChildActivityInsertInput(
 	input: CreateActivityInput,
@@ -164,6 +170,9 @@ function _toChildActivityInsertInput(
 		dailyLimit: sanitizeDailyLimit(input.dailyLimit),
 		nameKana: sanitizeActivityNameField(input.nameKana),
 		nameKanji: sanitizeActivityNameField(input.nameKanji),
+		// #3669: 親手動作成の source 正規化 (undefined / 'parent' → 'custom')。service 層の
+		// 単一強制点 (ADR-0061 push-down) — form / API どの callsite からでも quota 整合が保たれる
+		source: normalizeParentCreatedSource(input.source),
 	};
 }
 

--- a/src/lib/server/services/downgrade-service.ts
+++ b/src/lib/server/services/downgrade-service.ts
@@ -1,3 +1,4 @@
+import { countsTowardActivityQuota } from '$lib/domain/activity-source';
 import type { ActivityId, ChildId } from '$lib/domain/ids';
 // src/lib/server/services/downgrade-service.ts
 // #738: ダウングレード前の超過リソースプレビュー・選択アーカイブ
@@ -54,7 +55,7 @@ export async function getDowngradePreview(
 
 	// --- Activities (custom only) ---
 	const allActivities = await findActivities(tenantId, { includeHidden: false });
-	const customActivities = allActivities.filter((a) => a.source === 'custom');
+	const customActivities = allActivities.filter((a) => countsTowardActivityQuota(a.source));
 	const activityPreviews: ActivityPreview[] = customActivities.map((a) => ({
 		id: a.id,
 		name: a.name,
@@ -157,7 +158,7 @@ export async function archiveForDowngrade(
 	// Activities
 	if (limits.maxActivities !== null) {
 		const allActivities = await findActivities(tenantId, { includeHidden: false });
-		const customActivities = allActivities.filter((a) => a.source === 'custom');
+		const customActivities = allActivities.filter((a) => countsTowardActivityQuota(a.source));
 		const remaining = customActivities.length - selection.activityIds.length;
 		if (remaining > limits.maxActivities) {
 			return {

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -2,6 +2,7 @@ import type { ChildId } from '$lib/domain/ids';
 // src/lib/server/services/plan-limit-service.ts
 // プラン別機能制限サービス (#0196, #0269, #0270)
 
+import { countsTowardActivityQuota } from '$lib/domain/activity-source';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { getAuthMode } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
@@ -253,7 +254,8 @@ export async function checkActivityLimit(
 	let current = 0;
 	for (const child of children) {
 		const activities = await repos.childActivity.findActivitiesByChild(child.id, tenantId);
-		current += activities.filter((a) => a.source === 'custom').length;
+		// #3669: 集計述語は domain SSOT (producer と同一定義点) を参照
+		current += activities.filter((a) => countsTowardActivityQuota(a.source)).length;
 	}
 
 	return {

--- a/src/lib/server/services/resource-archive-service.ts
+++ b/src/lib/server/services/resource-archive-service.ts
@@ -1,3 +1,4 @@
+import { countsTowardActivityQuota } from '$lib/domain/activity-source';
 import type { ActivityId, ChildId } from '$lib/domain/ids';
 // src/lib/server/services/resource-archive-service.ts
 // #783: トライアル終了時の超過リソース archive / アップグレード時の restore
@@ -70,7 +71,7 @@ export async function archiveExcessResources(tenantId: string): Promise<{
 	// --- Activities ---
 	if (limits.maxActivities !== null) {
 		const activities = await findActivities(tenantId);
-		const custom = activities.filter((a) => a.source === 'custom');
+		const custom = activities.filter((a) => countsTowardActivityQuota(a.source));
 		if (custom.length > limits.maxActivities) {
 			const sorted = [...custom].sort((a, b) => compareOpaqueIdAsc(a.id, b.id));
 			const excess = sorted.slice(limits.maxActivities);

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -1,4 +1,6 @@
 import { fail } from '@sveltejs/kit';
+// #3669: 親手動作成の source は SSOT 定数 'custom' で保存する (quota / カウンタ集計と整合)
+import { PARENT_CREATED_SOURCE } from '$lib/domain/activity-source';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
@@ -193,7 +195,7 @@ export const actions: Actions = {
 					ageMin,
 					ageMax,
 					dailyLimit,
-					source: 'parent',
+					source: PARENT_CREATED_SOURCE,
 					nameKana,
 					nameKanji,
 					triggerHint,
@@ -619,7 +621,7 @@ export const actions: Actions = {
 			icon,
 			basePoints,
 			dailyLimit,
-			source: 'parent' as const,
+			source: PARENT_CREATED_SOURCE,
 		}));
 
 		try {

--- a/src/routes/(parent)/admin/subscription/+page.server.ts
+++ b/src/routes/(parent)/admin/subscription/+page.server.ts
@@ -6,6 +6,9 @@
 // restoreArchivedResources) を撤去。subscription 管理 (プラン表示 / trial / Stripe 連携) のみ残す。
 
 import { fail } from '@sveltejs/kit';
+// #3669: 活動カウンタは quota (checkActivityLimit) と同一の SSOT 述語で集計する
+// (旧実装は 'parent' を数えており、producer/quota と三重乖離して常に 0 表示だった)
+import { countsTowardActivityQuota } from '$lib/domain/activity-source';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { TRIAL_LABELS } from '$lib/domain/labels';
@@ -40,7 +43,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	let activityCount = 0;
 	try {
 		const acts = await getActivities(tenantId, { includeHidden: false });
-		activityCount = acts.filter((a) => a.source === 'parent').length;
+		activityCount = acts.filter((a) => countsTowardActivityQuota(a.source)).length;
 	} catch {
 		/* fallback */
 	}

--- a/tests/unit/services/activity-source-quota-roundtrip.test.ts
+++ b/tests/unit/services/activity-source-quota-roundtrip.test.ts
@@ -1,0 +1,206 @@
+// tests/unit/services/activity-source-quota-roundtrip.test.ts
+// #3669: 活動 source 意味論の producer × consumer round-trip 整合 lock (ADR-0061 same-class guard)
+//
+// 三重乖離の再現と修正 lock:
+//   - producer: UI 手動作成 (`createActivity`) が source を drop → schema default 'seed'
+//   - consumer1: `checkActivityLimit` は `'custom'` を集計 → 常に 0 = quota 未執行
+//   - consumer2: `/admin/subscription` カウンタは `'parent'` を集計 → 常に 0 表示
+//
+// 本 test は「UI 作成 → checkActivityLimit.current が +1」の round-trip を実 SQLite で
+// 直接 assert する (failing-test-first: 修正前は current=0 で red)。producer 4 経路
+// (手動 / marketplace 取込 / seed / 兄弟 copy) の source 値を DB 実体で lock する。
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../../src/lib/server/db/schema';
+import { closeDb, createTestDb, resetDb, type TestDb, type TestSqlite } from '../helpers/test-db';
+
+let sqlite: TestSqlite;
+let testDb: TestDb;
+
+vi.mock('$lib/server/db', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+// #2919: resolvePlanTier が debug-plan 経由で $app/environment.dev を参照するため mock
+vi.mock('$app/environment', () => ({ dev: false }));
+
+// resolveFullPlanTier が依存する trial-service は本 test の対象外のため固定 mock
+vi.mock('$lib/server/services/trial-service', () => ({
+	getTrialStatus: vi.fn().mockResolvedValue({
+		isTrialActive: false,
+		trialUsed: false,
+		trialStartDate: null,
+		trialEndDate: null,
+		trialTier: null,
+		daysRemaining: 0,
+		source: null,
+	}),
+}));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	getAuthMode: () => 'cognito',
+}));
+
+import { countsTowardActivityQuota, PARENT_CREATED_SOURCE } from '$lib/domain/activity-source';
+import { asCategoryId, asChildId } from '$lib/domain/ids';
+import { getRepos } from '$lib/server/db/factory';
+import { createActivity, getActivities } from '$lib/server/services/activity-service';
+import { checkActivityLimit } from '$lib/server/services/plan-limit-service';
+
+const TENANT = 't-3669';
+// AUTH_MODE=cognito + licenseStatus 'none' → free tier (maxActivities=3)
+const FREE_LICENSE = 'none';
+
+beforeAll(() => {
+	const t = createTestDb();
+	sqlite = t.sqlite;
+	testDb = t.db;
+});
+afterAll(() => {
+	closeDb(sqlite);
+});
+beforeEach(() => {
+	resetDb(sqlite);
+	// child 2 名 (id=1, 2)
+	testDb.insert(schema.children).values({ nickname: 'ゆうき', age: 8, theme: 'blue' }).run();
+	testDb.insert(schema.children).values({ nickname: 'たくみ', age: 6, theme: 'pink' }).run();
+});
+
+function uiCreateInput(name: string) {
+	// admin/activities add action と同型の input (UI 手動作成経路)
+	return {
+		name,
+		categoryId: asCategoryId(1),
+		icon: '🏃',
+		basePoints: 5,
+		ageMin: null,
+		ageMax: null,
+		source: PARENT_CREATED_SOURCE,
+	};
+}
+
+describe('#3669 activity source round-trip (producer × consumer 整合)', () => {
+	it('AC1/AC5: UI 手動作成 (createActivity) → checkActivityLimit.current が +1 される', async () => {
+		const before = await checkActivityLimit(TENANT, FREE_LICENSE);
+		expect(before.current).toBe(0);
+
+		await createActivity(uiCreateInput('カスタム活動1'), TENANT, asChildId(1));
+
+		const after = await checkActivityLimit(TENANT, FREE_LICENSE);
+		expect(after.current).toBe(1);
+		expect(after.allowed).toBe(true);
+	});
+
+	it("AC1: UI 手動作成した活動は DB に source='custom' で保存される", async () => {
+		await createActivity(uiCreateInput('カスタム活動1'), TENANT, asChildId(1));
+		const row = sqlite
+			.prepare('SELECT source FROM child_activities WHERE name = ?')
+			.get('カスタム活動1') as { source: string };
+		expect(row.source).toBe('custom');
+	});
+
+	it("旧 wire 値 'parent' / source 未指定 (api/v1 経路) も 'custom' に正規化して persist する", async () => {
+		await createActivity({ ...uiCreateInput('レガシー'), source: 'parent' }, TENANT, asChildId(1));
+		await createActivity({ ...uiCreateInput('未指定'), source: undefined }, TENANT, asChildId(1));
+		const rows = sqlite
+			.prepare('SELECT name, source FROM child_activities ORDER BY id')
+			.all() as Array<{ name: string; source: string }>;
+		expect(rows.map((r) => r.source)).toEqual(['custom', 'custom']);
+	});
+
+	it('AC2: free プランで custom 活動 3 件作成後、4 件目は allowed=false (quota gate 発動)', async () => {
+		await createActivity(uiCreateInput('活動1'), TENANT, asChildId(1));
+		await createActivity(uiCreateInput('活動2'), TENANT, asChildId(1));
+		await createActivity(uiCreateInput('活動3'), TENANT, asChildId(2));
+
+		const check = await checkActivityLimit(TENANT, FREE_LICENSE);
+		expect(check.current).toBe(3);
+		expect(check.max).toBe(3);
+		expect(check.allowed).toBe(false);
+	});
+
+	it('AC3: /admin/subscription カウンタ (同一 SSOT 述語) が実作成数を反映する', async () => {
+		await createActivity(uiCreateInput('活動1'), TENANT, asChildId(1));
+		await createActivity(uiCreateInput('活動2'), TENANT, asChildId(2));
+
+		// subscription +page.server.ts と同一の集計 (getActivities + countsTowardActivityQuota)
+		const acts = await getActivities(TENANT, { includeHidden: false });
+		const counted = acts.filter((a) => countsTowardActivityQuota(a.source)).length;
+		expect(counted).toBe(2);
+	});
+
+	it('AC4: 一括追加経路 (insertActivitiesBulk + PARENT_CREATED_SOURCE) も quota に数えられる', async () => {
+		const repos = getRepos();
+		await repos.childActivity.insertActivitiesBulk(
+			[1, 2].map((cid) => ({
+				childId: asChildId(cid),
+				name: '一括活動',
+				categoryId: asCategoryId(1),
+				icon: '📝',
+				basePoints: 5,
+				source: PARENT_CREATED_SOURCE,
+			})),
+			TENANT,
+		);
+		const check = await checkActivityLimit(TENANT, FREE_LICENSE);
+		expect(check.current).toBe(2);
+	});
+
+	it('AC4: marketplace 取込 / seed 経路 (source 未指定の repo 直 insert) は quota に数えない', async () => {
+		const repos = getRepos();
+		// marketplace 取込 (activity-import-service) / restore は source 未指定 → schema default 'seed'
+		await repos.childActivity.insertActivity(
+			{
+				childId: asChildId(1),
+				name: 'プリセット活動',
+				categoryId: asCategoryId(1),
+				icon: '🏃',
+				basePoints: 5,
+				sourcePresetId: 'preset-001',
+			},
+			TENANT,
+		);
+		const row = sqlite
+			.prepare('SELECT source FROM child_activities WHERE name = ?')
+			.get('プリセット活動') as { source: string };
+		expect(row.source).toBe('seed');
+
+		const check = await checkActivityLimit(TENANT, FREE_LICENSE);
+		expect(check.current).toBe(0);
+	});
+
+	it('AC4: 兄弟 copy 経路は元活動の source を保全する (custom の copy は custom のまま数えられる)', async () => {
+		await createActivity(uiCreateInput('カスタム活動'), TENANT, asChildId(1));
+		const repos = getRepos();
+		await repos.childActivity.copyActivitiesAcrossChildren(asChildId(1), asChildId(2), TENANT);
+
+		const rows = sqlite
+			.prepare('SELECT child_id, source FROM child_activities ORDER BY id')
+			.all() as Array<{ child_id: number; source: string }>;
+		expect(rows).toHaveLength(2);
+		expect(rows[1]?.child_id).toBe(2);
+		expect(rows[1]?.source).toBe('custom');
+
+		const check = await checkActivityLimit(TENANT, FREE_LICENSE);
+		expect(check.current).toBe(2);
+	});
+
+	it("SSOT 述語: countsTowardActivityQuota は 'custom' と legacy 'parent' のみ true", () => {
+		expect(countsTowardActivityQuota('custom')).toBe(true);
+		expect(countsTowardActivityQuota('parent')).toBe(true); // 防御的 forward 互換 (repo 直 write 対策)
+		expect(countsTowardActivityQuota('seed')).toBe(false);
+		expect(countsTowardActivityQuota('curriculum')).toBe(false);
+		expect(countsTowardActivityQuota('pack')).toBe(false);
+		expect(countsTowardActivityQuota('marketplace')).toBe(false);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ システム全体（課金境界）

**解決する課題**: free プランの活動数上限（カスタム活動 3 件）が全プランで実質未執行だった。UI から手動作成した活動が DB に `source='seed'` で保存される一方、quota 集計は `'custom'`、`/admin/subscription` カウンタは `'parent'` を数えるという producer/consumer 三重乖離により、無料プランで無制限にカスタム活動を作成でき（有料プラン価値の毀損）、活動カウンタも常に 0 表示だった（NN/G #1 visibility 違反）。

**期待される効果**: 親が UI から作成した活動が正しく `'custom'` として保存・集計され、free プランで 4 件目の追加が quota gate（🔒 → /admin/subscription 誘導）で正しくブロックされる。`/admin/subscription` の「カスタム活動 X / 3」カウンタが実作成数を反映する。EPIC #3533 で統一した quota ゲート UI が自然操作で発動するようになる。

## 関連 Issue

closes #3669

関連: EPIC #3533（ゲーティング UI 統一 — 本 defect により自然発動不能だった）/ #3422（同 helper の dailyLimit drop 同族事例）/ #3132・EPIC #3151（cross-site semantic drift 同族 root class）/ ADR-0061（failing-test-first / same-class guard）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | UI（admin/activities「+ 追加 > 手動」）で作成した活動が `source='custom'` で保存される | `npx vitest run tests/unit/services/activity-source-quota-roundtrip.test.ts` | HEAD `5eeec5bf` / 9 passed。test「AC1: UI 手動作成した活動は DB に source='custom' で保存される」が実 SQLite の row を直接 assert。producer 実装: `src/lib/server/services/activity-service.ts` `_toChildActivityInsertInput`（`normalizeParentCreatedSource` 適用）+ `src/routes/(parent)/admin/activities/+page.server.ts`（`PARENT_CREATED_SOURCE` 参照 2 箇所） |
| AC2 | free プランで custom 活動 3 件作成後、4 件目の手動追加が locked になる（E2E または service unit test） | 同上（service unit test 選択肢で充足） | HEAD `5eeec5bf` / test「AC2: free プランで custom 活動 3 件作成後、4 件目は allowed=false」PASS（current=3 / max=3 / allowed=false）。UI 側 gate は `checkActivityLimit` の戻り値を参照する既存実装（#3533、`admin/activities/+page.server.ts:95`）で入力データ側の是正により自然発動 |
| AC3 | `/admin/subscription` の活動カウンタが実作成数を反映する | 同上 + `grep -n "countsTowardActivityQuota" "src/routes/(parent)/admin/subscription/+page.server.ts"` | HEAD `5eeec5bf` / test「AC3: /admin/subscription カウンタ（同一 SSOT 述語）が実作成数を反映する」PASS。`+page.server.ts:47` が quota と同一の `countsTowardActivityQuota` を参照（旧 `'parent'` 直比較 0 件: `grep -rn "source === 'parent'" src/` → 0） |
| AC4 | source 意味論の SSOT 定数が domain 層に定義され、producer 4 経路（手動 / marketplace 取込 / seed / 兄弟 copy）と consumer 2 箇所が同 SSOT を参照する | `grep -rln "activity-source" src/ --include="*.ts"` | HEAD `5eeec5bf` / SSOT: `src/lib/domain/activity-source.ts`（`ACTIVITY_SOURCES` as const satisfies、#3607 categories 同型）。参照 12 file（producer: activity-service + admin/activities + 4 backend repo / consumer: plan-limit-service + subscription + downgrade-service + resource-archive-service）。marketplace 取込・seed は省略時 repo 既定 `'seed'`（`ACTIVITY_SOURCES.seed.value` 経由）、兄弟 copy は元 source 保全を test で lock |
| AC5 | producer×consumer 整合の round-trip unit test が追加され、red→green を確認（failing-test-first、ADR-0061） | `npx vitest run tests/unit/services/activity-source-quota-roundtrip.test.ts` | red: SSOT + test のみの状態で **7 failed / 2 passed**（`expected +0 to be 1`（round-trip current=0）/ `expected 'seed' to be 'custom'`（DB 実体））→ 修正後 green: **9 passed**。本文「red→green 証跡」参照 |
| AC6 | `docs/design/data-model-resource-scope.md` 等の該当設計書に source 意味論を同期（ADR-0001） | `grep -n "source.*意味論 SSOT" docs/design/data-model-resource-scope.md` | HEAD `5eeec5bf` / §4.1 に「`source` 列の意味論 SSOT (#3669)」を追加（値域 × 経路 × 集計対象の表 + consumer 共通述語 + 禁忌） |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) ※ repo 実装のみ。schema（列・default）は不変
- [x] サービス層 (`$lib/server/services/`)
- [x] ページ / レイアウト (`src/routes/`) ※ `+page.server.ts` のみ（UI コンポーネント変更なし）
- [x] ドメインモデル (`$lib/domain/`)

**影響を受ける画面・機能**:
- `/admin/activities` 単体追加 / 一括追加（保存される source 値が `'custom'` になる）
- `/admin/subscription` カスタム活動カウンタ（実作成数を表示するようになる）
- free プランの活動 quota gate（🔒）が自然操作で発動するようになる
- ダウングレード preview / trial 終了 archive の「custom 活動」抽出（同一 SSOT 述語に統一）

## テスト & 安全装置セルフチェック

- [x] **pre-ready 相当の局所検証 PASS**: biome check（変更 15 file、0 error）/ svelte-check（8158 files, 0 errors 0 warnings）/ cspell（新規 2 file, 0 issues）/ 関連 vitest（`tests/unit/services/` + `tests/unit/db/dsql-activity-repos` + `src/lib/server/` + `src/lib/domain/` + `tests/unit/routes/` = **188 files / 2799 tests 全 PASS**、round-trip 新規 test・両 backend repo test 含む）/ `check-pr-body --body-file` PASS。`npm run pre-ready -- --pr <num>` 全 Step 一括はメインセッションが Ready 化前に実行する（本 PR は Draft 提出まで）
- [x] 追加・変更したテストの概要:
  - **新規** `tests/unit/services/activity-source-quota-roundtrip.test.ts`（9 test）— 「UI 作成 → `checkActivityLimit.current` +1」round-trip を実 SQLite で assert（ADR-0061 same-class guard）。producer 4 経路（手動 / 一括 / marketplace 相当の source 未指定 insert / 兄弟 copy）× consumer（quota / カウンタ述語）の整合を lock
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: SQLite + DSQL + DynamoDB + demo の 4 backend を同 PR 内で完成（`input.source ?? 'seed'` persist + copy の source 保全）。段階的リリースなし（#1012）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:high）

### red→green 証跡（ADR-0061 failing-test-first）

1. **red**: domain SSOT（`activity-source.ts`）+ round-trip test のみ追加した時点で実行 → **7 failed / 2 passed**
   - `AC1/AC5: UI 手動作成 → checkActivityLimit.current が +1 される` → `AssertionError: expected +0 to be 1`
   - `AC1: DB に source='custom' で保存される` → `expected 'seed' to be 'custom'`
   - `AC4: 兄弟 copy 経路は元活動の source を保全する` → `expected 'seed' to be 'custom'`
   - passed 2 件 = 修正前から成立すべき guard（marketplace 取込は数えない / SSOT 述語単体）
2. **green**: producer / repo / consumer 修正後 → **9 passed**（Tests 9 passed (9)、Duration 7.11s）

### backfill 実施しない判断根拠（Issue 解決策 5）

既存 DB の `source='seed'` 行には「初期 seed / プリセット取込」と「旧バグで 'seed' に落ちた親手動作成」が混在し、遡及識別する手掛かり（作成経路の記録）が存在しないため、backfill は不可能。forward-fix のみとし、既存ユーザーの quota 消費は新規作成分から正しく数え始める（quota が緩い側に倒れるため顧客不利益なし。DB スキーマ・default `'seed'` は不変）。

### 重量 e2e 敏感領域チェックリスト（#3173 (a)-(d)）

- [x] **(a) 並行実装ペア確認**: DB スキーマ不変（列・default 変更なし）のため schema 系ペア追従は不要。repo 4 backend（sqlite / dsql / dynamodb / demo）を同 PR で同期。`tests/e2e/global-setup.ts` / `test-db.ts` / `demo-data.ts` は source 列を既に持ち値域も不変のため変更不要
- [x] **(b) 該当重量 e2e のローカル実行 + baseline 切り分け**: `npx playwright test tests/e2e/admin-activities-per-child.spec.ts --project=tablet`（取込 / copy 経路の insert に最も近い spec）を **変更後 HEAD と変更前 baseline（origin/develop `d7985614`）の両方**でローカル実行し比較:
  - 変更後: 7 passed / 2 failed（`:30` URL 同期 / `:267` 件数水増し）
  - baseline（変更前）: 6 passed / 3 failed（`:30` / `:50` / `:267` — 変更後の fail 集合はこの部分集合）
  - → **本変更による新規 fail は 0 件**（fail はローカル Windows 環境の既存要因。copy / 取込の主要 goal test `:62` `:143` `:171` は変更後 PASS）。最終判定は CI の重量レーン（e2e 必須 job）で機械検証される
- [x] **(c) e2e seed / test-db 同期**: 値域・schema 不変のため同期対象なし（`test-db.ts` の `child_activities.source` 列は既存）
- [x] **(d) domain 値域 ⊆ wire(export) schema 値域**: `SOURCES` の値域は不変（`['seed','curriculum','custom','parent']`）。activities export schema は source を含まないため round-trip 制約に影響なし（restore は従来どおり省略 → `'seed'`）

### Fix 完遂検証 log（#2690 / #2815 D-4）

| Fix item | 検証コマンド（原文） | output 件数 | 判定 |
|---|---|---|---|
| B1: consumer の source 直比較 全件解消 | `grep -rn "source === 'custom'\|source === 'parent'" src/ --include="*.ts"` | 0 件 | ✓ |
| B2: producer の `source: 'parent'` 直書き 全件解消 | `grep -rn "source: 'parent'" src/ --include="*.ts"` | 0 件 | ✓ |
| B3: SSOT 参照が producer/consumer 全 12 file に配線 | `grep -rln "activity-source" src/ --include="*.ts"` | 12 件 | ✓ |

## スクリーンショット / ビジュアルデモ

**該当なし（UI 変更なし — server-side の保存値・集計述語の是正のみ）**。UI コンポーネント / スタイル / DOM 構造の変更は 0 file。`/admin/subscription` カウンタは既存 UI の表示数値が正しいデータを受け取るようになるのみ（数値以外の見た目変化なし）。カウンタ実数値の実機確認 SS が必要と判断される場合は Ready 化前にメインセッションで撮影する。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: source 意味論を domain 層の単一定義点（`activity-source.ts`）に集約（S）。consumer は述語関数経由で値リテラルに依存しない（D）
- [x] **DRY**: `grep -rn "source === '" src/` で直比較の残存 0 件を確認（Fix 完遂検証 log B1）。同族の直比較を downgrade-service / resource-archive-service まで横展開して統一
- [x] **YAGNI**: SSOT は値・述語・正規化の 3 export のみ。将来の source 追加用の抽象レイヤ等は追加していない
- [x] **Security（OSS 公開前提）**: 課金境界（quota 執行）の是正そのもの。入力 source は zod `z.enum(SOURCES)` で値域検証済 + service 層で正規化（default-deny 側に倒す）
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: 集計クエリの構造は不変（per-child loop 既存のまま）。追加の DB round-trip なし

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照）:

- [x] E2E / ユニットシード: schema・値域不変のため同期対象なし（source 列は既存、seed の `'seed'`/`'curriculum'` 値も不変）
- [x] **設計書同期** (ADR-0001): `docs/design/data-model-resource-scope.md` §4.1 に source 意味論 SSOT 表を追加
- [x] **並行 PR overlap** (#1200): `gh pr list` で本 PR 変更ファイルを触る open PR がないことを確認
- [x] 4 backend repo（sqlite / dsql / dynamodb / demo）への横展開を同 PR 内で完遂（両 backend 完成必須 #1012）
- [x] 同族の consumer（downgrade-service / resource-archive-service）も同一 SSOT 述語に統一（quota と archive 対象の意味論一致を担保）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

（挙動変更の明示: free プランで従来素通りだった 4 件目以降の手動追加が仕様どおり 403 + upgrade 誘導になる。これは #196 で定義済み・#3533 で UI 統一済みの本来仕様の回復であり、既存データの変更・migration は不要）

**レビュー依頼事項・QA**:
- 兄弟 copy の source 保全（`copyActivitiesAcrossChildren` が元活動の source を引き継ぐ）は「custom の copy も quota に数える」意味論を含む。copy で `sourcePresetId` を保全している既存意図との整合・quota 迂回（作成 → copy → 元を削除）防止の観点で採用したが、意味論判断のため要確認
- `countsTowardActivityQuota` が legacy `'parent'` も防御的に数える設計（DB に保存実績はないが、将来の repo 直 write 混入時に課金境界が緩まないよう安全側に倒した）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] pre-ready 相当の局所検証（biome / svelte-check / cspell / 関連 vitest 188 files / check-pr-body）をローカル PASS 確認した。`npm run pre-ready -- --pr <num>` 全 Step 一括は Ready 化前にメインセッションが実行する（Draft 段階の本 checklist は Dev 完遂宣言）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし — `git diff origin/develop` 全 15 file を目視確認）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A（単一 PR で完結）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
