### PR TITLE
fix(ci): deploy の COMMIT_MSG 64KB truncate (統合 merge commit 147KB による exit 126 の hotfix)

### DIFF
--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -149,7 +149,8 @@ jobs:
       - name: CDK diff — replacement check (StorageStaging)
         working-directory: infra/
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%B)
+          # 統合 PR merge commit は 100KB 超になり得る (env 上限 128KB 超過対策、deploy.yml と同型)。
+          COMMIT_MSG=$(git log -1 --pretty=%B | head -c 65536)
           npx cdk diff GanbariQuestStorageStaging \
             -c stagingEnabled=true \
             -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
@@ -243,7 +244,8 @@ jobs:
       - name: CDK diff — replacement check (staging 3 stacks)
         working-directory: infra/
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%B)
+          # 統合 PR merge commit は 100KB 超になり得る (env 上限 128KB 超過対策、deploy.yml と同型)。
+          COMMIT_MSG=$(git log -1 --pretty=%B | head -c 65536)
           DSQL_CTX=""
           if [ "$DSQL_LANE" = "true" ]; then
             DSQL_CTX="-c dsqlEnabled=true -c dsqlEndpoint=$DSQL_ENDPOINT -c dsqlClusterArn=$DSQL_CLUSTER_ARN"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,10 @@ jobs:
       - name: CDK diff — replacement check (Storage)
         working-directory: infra/
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%B)
+          # 統合 PR の merge commit は PR body 全体を含み 100KB 超になり得る (第 14 回統合で 147KB、
+          # Linux の単一 env 上限 128KB 超過で node が Argument list too long / exit 126)。
+          # replacement-approved マーカー検出には先頭で十分なため 64KB に truncate する。
+          COMMIT_MSG=$(git log -1 --pretty=%B | head -c 65536)
           npx cdk diff GanbariQuestStorage \
             -c domainName=${{ env.DOMAIN_NAME }} \
             -c certificateArn=${{ env.CERTIFICATE_ARN }} \
@@ -230,7 +233,10 @@ jobs:
       - name: CDK diff — replacement check (all stacks)
         working-directory: infra/
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%B)
+          # 統合 PR の merge commit は PR body 全体を含み 100KB 超になり得る (第 14 回統合で 147KB、
+          # Linux の単一 env 上限 128KB 超過で node が Argument list too long / exit 126)。
+          # replacement-approved マーカー検出には先頭で十分なため 64KB に truncate する。
+          COMMIT_MSG=$(git log -1 --pretty=%B | head -c 65536)
           npx cdk diff --all \
             -c domainName=${{ env.DOMAIN_NAME }} \
             -c certificateArn=${{ env.CERTIFICATE_ARN }} \


### PR DESCRIPTION
## 顧客価値・目的

第 14 回統合 (#3686) merge 後の本番 deploy (run 29175988860) が CDK replacement check の node 起動で **Argument list too long (exit 126)** となり停止した。本番サービスは旧バージョン (v1.20260704.1) で稼働継続中 (health 200、ユーザー影響なし) だが、deploy 供給線が死んでいるため hotfix で復旧する。

## 関連 Issue

なし (deploy 供給線の hotfix)

## 根本原因

`gh pr merge --merge` は PR body 全体を merge commit body に含める。統合 PR #3686 の body (エビデンス表 + 含有 50 PR 一覧) により merge commit message が **147KB** となり、`COMMIT_MSG=$(git log -1 --pretty=%B)` の env 渡しが Linux の単一 env/arg 上限 (MAX_ARG_STRLEN 128KB) を超過、node の execve が exit 126 で失敗した。

## AC 検証マップ (ADR-0004)

| AC | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| 1 | exit 126 の根治 | `git log -1 --pretty=%B \| head -c 65536` で 64KB truncate (単一 env 安全圏)。replacement-approved マーカーは commit 冒頭記載の運用 (infra/CLAUDE.md) のため検出力不変 | PASS (ロジック不変、上限内化) |
| 2 | 横展開 (same-class 全数) | `grep -rn "pretty=%B)$" .github/workflows/` — deploy.yml ×2 + deploy-aws-staging.yml ×2 の計 4 箇所全て修正、残 0 件 | PASS |
| 3 | YAML valid | `node -e "yaml.parse(...)"` | PASS |
| 4 | 実機貫通 | merge 後の main push で deploy.yml が自動再走し、replacement check 通過 → Lambda update → post-deploy health を確認する | 手順確立済 |

## 変更タイプ

- [x] バグ修正 (deploy 供給線 hotfix)
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・変更コンポーネント

- `.github/workflows/deploy.yml` (2 箇所) / `deploy-aws-staging.yml` (2 箇所) — COMMIT_MSG 取得の truncate のみ、check ロジック不変

## テスト & 安全装置セルフチェック

- [x] 4 箇所とも同一修正 (same-class 全数)
- [x] マーカー検出力不変 (replacement-approved は commit message 冒頭記載の運用)

## スクリーンショット / ビジュアルデモ

N/A — workflow のみ。

## コード品質セルフレビュー (#1481)

- file 経由渡しへの再設計はより堅牢だが script 側変更を伴う。hotfix は最小 diff (truncate) とし、再設計の要否は復旧後に判断

## 横展開・影響波及チェック

- deploy-nuc*.yml は COMMIT_MSG env パターン不使用 (grep 確認)
- back-merge で develop にも本修正が届く

## レビュー依頼事項・破壊的変更

破壊的変更なし。

## 配布済み env / secret (ADR-0006)

N/A。

## Ready for Review チェックリスト

- [x] hotfix + 横展開 + 検証が 1 PR で完結
- [x] base = main (hotfix lane)

## QM レビュー結果

lab レビュー待ち (hotfix lane)。
