### PR TITLE
fix: #3692 本番 restore 504 即効対処 — import insert 並列チャンク化 + 経路 observability

### DIFF
--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -44,6 +44,58 @@ function categoryIdFromCode(code: string): CategoryId | undefined {
 }
 
 /**
+ * #3692: import insert の並列チャンク実行度。
+ *
+ * 本番 restore が Lambda 30s timeout (504) した根因は、実バックアップ ≈ 1,200 行を
+ * 1 insert = 最大 3 DynamoDB 往復 (採番 + denormalize read + Put) で逐次 await して
+ * いたこと (≈ 3,000 往復 × 10-20ms = 30-60s)。件数支配ヘルパは runConcurrent で
+ * 並列化し、往復の壁時計時間を 1/CONCURRENCY に圧縮する。
+ *
+ * 値の根拠: DynamoDB on-demand は並列 25 程度で throttle しない (BatchWriteItem の
+ * 上限 25 と同水準)。PGlite (NUC) は単一接続で内部 queue されるため並列発行しても
+ * 安全、better-sqlite3 は同期実行で実質逐次 — いずれの backend でも正しさに影響しない。
+ */
+const IMPORT_INSERT_CONCURRENCY = 25;
+
+/**
+ * items を最大 concurrency 本の worker で並列処理する (#3692)。
+ *
+ * worker 内でエラーを catch して result.errors に積む既存 import ヘルパの規約を
+ * 前提とする (worker が reject すると全体が reject する — 呼び出し側で try/catch 必須)。
+ * dedup 判定 (Set 参照/更新) は並列区間に入れると race するため、呼び出し側は
+ * 「同期 phase で dedup と insert 対象を確定 → 本関数で insert のみ並列実行」の
+ * 2-phase に分ける。
+ */
+async function runConcurrent<T>(
+	items: readonly T[],
+	worker: (item: T) => Promise<void>,
+	concurrency = IMPORT_INSERT_CONCURRENCY,
+): Promise<void> {
+	let next = 0;
+	const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+		while (next < items.length) {
+			const item = items[next++];
+			// noUncheckedIndexedAccess: next < length で取得するため実際には undefined にならない
+			if (item === undefined) continue;
+			await worker(item);
+		}
+	});
+	await Promise.all(runners);
+}
+
+/**
+ * export data の取込対象行数の概算 (#3692 observability)。
+ * import 開始ログに載せ、Lambda 30s 制約下で「何行の取込にどれだけかかったか」を
+ * CloudWatch で切り分け可能にする (本番 restore 504 は経路無ログで切り分け不能だった)。
+ */
+export function countImportRows(data: ExportData): number {
+	const d = data.data;
+	return Object.values(d)
+		.filter((v): v is unknown[] => Array.isArray(v))
+		.reduce((sum, rows) => sum + rows.length, 0);
+}
+
+/**
  * インポート結果 (#1254 で skipped 内訳追加)
  */
 export interface ImportResult {
@@ -572,12 +624,21 @@ async function importStampCardsData(
 	result: ImportResult,
 ): Promise<void> {
 	const repo = getRepos().stampCard;
+	// #3692 phase 1 (同期): childId 解決。card → entries は親子依存のため card 単位を
+	// worker とし、card insert → 当該 card の entries 並列 insert を worker 内で行う
+	// (card 間は独立なので card レベルで並列化できる)。
+	const tasks: { childId: ChildId; card: NonNullable<ExportData['data']['stampCards']>[number] }[] =
+		[];
 	for (const card of data.data.stampCards ?? []) {
 		const childId = childIdMap.get(card.childRef);
 		if (!childId) {
 			result.stampCardsSkipped++;
 			continue;
 		}
+		tasks.push({ childId, card });
+	}
+	// #3692 phase 2: card 単位で並列チャンク実行
+	await runConcurrent(tasks, async ({ childId, card }) => {
 		let newCardId: string;
 		try {
 			const restored = await repo.insertCardForRestore(
@@ -600,9 +661,9 @@ async function importStampCardsData(
 			result.errors.push(
 				`スタンプカード insert 失敗 (child=${card.childRef}, week=${card.weekStart}): ${String(e)}`,
 			);
-			continue;
+			return;
 		}
-		for (const entry of card.entries) {
+		await runConcurrent(card.entries, async (entry) => {
 			try {
 				await repo.insertEntryForRestore(
 					{
@@ -622,8 +683,8 @@ async function importStampCardsData(
 					`スタンプ押印 insert 失敗 (child=${card.childRef}, slot=${entry.slot}): ${String(e)}`,
 				);
 			}
-		}
-	}
+		});
+	});
 }
 
 /**
@@ -1148,6 +1209,27 @@ async function importActivityLogsData(
 	// 子 A で欠落・子 B で存在のケースで正当な warning を抑制してしまう。
 	const missingActivityKeys = new Set<string>();
 
+	// #3692 phase 0: merge dedup に使う既存ログキーを、登場する child 分だけ並列 prefetch
+	if (mode === 'merge') {
+		const involvedChildIds = [
+			...new Set(
+				data.data.activityLogs
+					.map((log) => childIdMap.get(log.childRef))
+					.filter((id): id is ChildId => !!id),
+			),
+		];
+		await runConcurrent(involvedChildIds, async (childId) => {
+			await getOrFetchActivityLogKeys(childId, tenantId, existingLogKeysByChild);
+		});
+	}
+
+	// #3692 phase 1 (同期): activity 解決 + dedup 判定を同期で確定する。dedup Set の
+	// 参照/更新が insert await を跨ぐと並列化で race するため、Set 操作はここで完結させる。
+	const tasks: {
+		childId: ChildId;
+		activityId: ActivityId;
+		log: (typeof data.data.activityLogs)[number];
+	}[] = [];
 	for (const log of data.data.activityLogs) {
 		const childId = childIdMap.get(log.childRef);
 		if (!childId) continue;
@@ -1167,21 +1249,28 @@ async function importActivityLogsData(
 			continue;
 		}
 
-		const existingKeys = await getOrFetchActivityLogKeys(childId, tenantId, existingLogKeysByChild);
-		const key = `${log.activityName}:${log.recordedAt}`;
 		// #3653: (activityName, recordedAt) dedup は merge のみ。verbatim (cutover) では同時刻の
 		// 正当な複数記録 (DB 一意制約なし) を全行復元する。
-		if (mode === 'merge' && existingKeys.has(key)) {
-			result.activityLogsSkipped++;
-			result.skipped.constraint++;
-			continue;
+		if (mode === 'merge') {
+			const existingKeys = existingLogKeysByChild.get(childId);
+			const key = `${log.activityName}:${log.recordedAt}`;
+			if (existingKeys?.has(key)) {
+				result.activityLogsSkipped++;
+				result.skipped.constraint++;
+				continue;
+			}
+			existingKeys?.add(key);
 		}
+		tasks.push({ childId, activityId: activity.id, log });
+	}
 
+	// #3692 phase 2: insert を並列チャンク実行 (dedup 確定済みで行間依存なし)
+	await runConcurrent(tasks, async ({ childId, activityId, log }) => {
 		try {
 			await insertActivityLog(
 				{
 					childId,
-					activityId: activity.id,
+					activityId,
 					points: log.points,
 					streakDays: log.streakDays,
 					streakBonus: log.streakBonus,
@@ -1191,14 +1280,13 @@ async function importActivityLogsData(
 				tenantId,
 			);
 			result.activityLogsImported++;
-			existingKeys.add(key);
 		} catch (e) {
 			result.activityLogsSkipped++;
 			result.errors.push(
 				`活動ログ insert 失敗 (child=${log.childRef}, activity=${log.activityName}): ${String(e)}`,
 			);
 		}
-	}
+	});
 }
 
 async function getOrFetchActivityLogKeys(
@@ -1224,12 +1312,18 @@ async function importPointLedgerData(
 	tenantId: string,
 	result: ImportResult,
 ): Promise<void> {
+	// #3692 phase 1 (同期): childId 解決と insert 対象確定
+	const tasks: { childId: ChildId; entry: (typeof data.data.pointLedger)[number] }[] = [];
 	for (const entry of data.data.pointLedger) {
 		const childId = childIdMap.get(entry.childRef);
 		if (!childId) {
 			result.pointLedgerSkipped++;
 			continue;
 		}
+		tasks.push({ childId, entry });
+	}
+	// #3692 phase 2: insert を並列チャンク実行 (台帳は append-only で行間依存なし)
+	await runConcurrent(tasks, async ({ childId, entry }) => {
 		try {
 			await insertPointLedger(
 				{
@@ -1247,7 +1341,7 @@ async function importPointLedgerData(
 				`ポイント台帳 insert 失敗 (child=${entry.childRef}, amount=${entry.amount}): ${String(e)}`,
 			);
 		}
-	}
+	});
 }
 
 /**
@@ -1261,23 +1355,37 @@ async function importLoginBonusesData(
 ): Promise<void> {
 	const existingBonusesByChild = new Map<ChildId, Set<string>>();
 
+	// #3692 phase 0: 既存 bonus 日付を、登場する child 分だけ並列 prefetch
+	const involvedChildIds = [
+		...new Set(
+			data.data.loginBonuses
+				.map((lb) => childIdMap.get(lb.childRef))
+				.filter((id): id is ChildId => !!id),
+		),
+	];
+	await runConcurrent(involvedChildIds, async (childId) => {
+		const existing = await findRecentBonuses(childId, tenantId, 365);
+		existingBonusesByChild.set(childId, new Set(existing.map((e) => e.loginDate)));
+	});
+
+	// #3692 phase 1 (同期): (childId, loginDate) dedup を同期で確定 (Set race 回避)
+	const tasks: { childId: ChildId; lb: (typeof data.data.loginBonuses)[number] }[] = [];
 	for (const lb of data.data.loginBonuses) {
 		const childId = childIdMap.get(lb.childRef);
 		if (!childId) continue;
 
-		let existingDates = existingBonusesByChild.get(childId);
-		if (!existingDates) {
-			const existing = await findRecentBonuses(childId, tenantId, 365);
-			existingDates = new Set(existing.map((e) => e.loginDate));
-			existingBonusesByChild.set(childId, existingDates);
-		}
-
-		if (existingDates.has(lb.loginDate)) {
+		const existingDates = existingBonusesByChild.get(childId);
+		if (existingDates?.has(lb.loginDate)) {
 			result.loginBonusesSkipped++;
 			result.skipped.constraint++;
 			continue;
 		}
+		existingDates?.add(lb.loginDate);
+		tasks.push({ childId, lb });
+	}
 
+	// #3692 phase 2: insert を並列チャンク実行
+	await runConcurrent(tasks, async ({ childId, lb }) => {
 		try {
 			await insertLoginBonus(
 				{
@@ -1292,14 +1400,13 @@ async function importLoginBonusesData(
 				tenantId,
 			);
 			result.loginBonusesImported++;
-			existingDates.add(lb.loginDate);
 		} catch (e) {
 			result.loginBonusesSkipped++;
 			result.errors.push(
 				`ログインボーナス insert 失敗 (child=${lb.childRef}, date=${lb.loginDate}): ${String(e)}`,
 			);
 		}
-	}
+	});
 }
 
 /** checklistLog の再マップに使う、childId 単位の template id 解決マップ群。 */
@@ -1554,11 +1661,20 @@ async function importStatusHistoryData(
 	tenantId: string,
 	result: ImportResult,
 ): Promise<void> {
+	// #3692 phase 1 (同期): childId / categoryId 解決と insert 対象確定
+	const tasks: {
+		childId: ChildId;
+		categoryId: CategoryId;
+		sh: (typeof data.data.statusHistory)[number];
+	}[] = [];
 	for (const sh of data.data.statusHistory) {
 		const childId = childIdMap.get(sh.childRef);
 		const categoryId = categoryIdFromCode(sh.categoryCode);
 		if (!childId || !categoryId) continue;
-
+		tasks.push({ childId, categoryId, sh });
+	}
+	// #3692 phase 2: insert を並列チャンク実行 (履歴は append-only で行間依存なし)
+	await runConcurrent(tasks, async ({ childId, categoryId, sh }) => {
 		try {
 			await insertStatusHistory(
 				{
@@ -1577,7 +1693,7 @@ async function importStatusHistoryData(
 				`ステータス履歴 insert 失敗 (child=${sh.childRef}, category=${sh.categoryCode}): ${String(e)}`,
 			);
 		}
-	}
+	});
 }
 
 async function importSpecialRewards(

--- a/src/routes/api/v1/import/+server.ts
+++ b/src/routes/api/v1/import/+server.ts
@@ -8,6 +8,7 @@ import { apiError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
 import { type ParsedBackupZip, parseBackupZip } from '$lib/server/services/backup-archive';
 import {
+	countImportRows,
 	importFamilyData,
 	previewImport,
 	validateExportData,
@@ -86,7 +87,16 @@ export const POST: RequestHandler = async ({ request, url, locals }) => {
 
 	if (mode === 'execute') {
 		try {
+			// #3692: 本番 restore timeout の切り分けで execute 経路が無ログだったため、
+			// 開始 (取込行数) / 完了 (所要 ms) を記録する。Lambda 30s 制約下の消費時間を可視化。
+			logger.info('[import] インポート開始', {
+				context: { tenantId, rows: countImportRows(validation.data) },
+			});
+			const startedAt = Date.now();
 			const result = await importFamilyData(validation.data, tenantId, staticFiles);
+			logger.info('[import] インポート完了', {
+				context: { tenantId, durationMs: Date.now() - startedAt, errors: result.errors.length },
+			});
 			return json({ ok: true, result });
 		} catch (err) {
 			logger.error('[import] インポート失敗', { error: String(err) });
@@ -99,8 +109,14 @@ export const POST: RequestHandler = async ({ request, url, locals }) => {
 		try {
 			// #3326: clear + import を原子境界で実行。途中失敗時は旧データを必ず復元する
 			// (SQLite=BEGIN/ROLLBACK / DynamoDB=backup-before-clear)。clear 先行の永久喪失を廃止。
-			logger.info('[import] 置換インポート開始 (原子化)', { context: { tenantId } });
+			logger.info('[import] 置換インポート開始 (原子化)', {
+				context: { tenantId, rows: countImportRows(validation.data) },
+			});
+			const startedAt = Date.now();
 			const result = await replaceImportAtomic(validation.data, tenantId, staticFiles);
+			logger.info('[import] 置換インポート完了', {
+				context: { tenantId, durationMs: Date.now() - startedAt, errors: result.errors.length },
+			});
 			return json({ ok: true, result });
 		} catch (err) {
 			if (err instanceof AtomicReplaceError) {

--- a/tests/unit/services/import-service-concurrency.test.ts
+++ b/tests/unit/services/import-service-concurrency.test.ts
@@ -1,0 +1,302 @@
+// tests/unit/services/import-service-concurrency.test.ts
+// #3692: 本番 restore 504 (Lambda 30s timeout) の即効対処 — import の件数支配ヘルパ
+// (activityLogs / pointLedger / loginBonuses / statusHistory / stampCards) が
+// insert を並列チャンク実行することを検証する。
+//
+// 障害の算数: 実バックアップ ≈ 1,200 行 × 1 insert あたり最大 3 DynamoDB 往復
+// (採番 UpdateCommand + denormalize read + PutCommand) ≈ 3,000 逐次往復 × 10-20ms
+// = 30-60s > Lambda 30s。並列度 >1 を機械検証し、逐次退行 (30s timeout 再発) を
+// unit 層で検出する (ADR-0061 push-down-pyramid: e2e/staging 実測より下層で担保)。
+//
+// 検証方式: insert mock を deferred にし、同時 in-flight 数の最大値を記録する。
+// 逐次実装では常に 1、並列実装では >1 になる。加えて件数・dedup 結果の不変
+// (正しさの保存) も同一 test 内で assert する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------- 並列度トラッカ ----------
+
+/** insert mock の同時 in-flight 数を記録する deferred tracker。 */
+function makeConcurrencyTracker() {
+	let inFlight = 0;
+	let maxInFlight = 0;
+	const tracked = vi.fn(async () => {
+		inFlight++;
+		maxInFlight = Math.max(maxInFlight, inFlight);
+		// timer 1 tick 待つことで、並列実装なら他 worker の insert が同時に in-flight になる
+		await new Promise((resolve) => setTimeout(resolve, 1));
+		inFlight--;
+		return { id: 'inserted' };
+	});
+	return { tracked, max: () => maxInFlight };
+}
+
+const pointLedgerTracker = makeConcurrencyTracker();
+const activityLogTracker = makeConcurrencyTracker();
+const statusHistoryTracker = makeConcurrencyTracker();
+const loginBonusTracker = makeConcurrencyTracker();
+const stampEntryTracker = makeConcurrencyTracker();
+
+// ---------- Top-level mocks (import-service.test.ts と同構成の最小 subset) ----------
+
+const mockFindActivities = vi.fn();
+const mockFindActivityLogs = vi.fn();
+const mockInsertChild = vi.fn();
+const mockFindRecentBonuses = vi.fn();
+const mockChildActivityFindByChild = vi.fn();
+const mockStampInsertCardForRestore = vi.fn();
+
+vi.mock('$lib/server/db/activity-repo', () => ({
+	findActivities: (...args: unknown[]) => mockFindActivities(...args),
+	findActivityLogs: (...args: unknown[]) => mockFindActivityLogs(...args),
+	insertActivity: vi.fn(),
+	insertActivityLog: () => activityLogTracker.tracked(),
+	insertPointLedger: () => pointLedgerTracker.tracked(),
+}));
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		childActivity: {
+			insertActivity: vi.fn(),
+			findActivitiesByChild: (...args: unknown[]) => mockChildActivityFindByChild(...args),
+		},
+		voice: { insertForRestore: vi.fn() },
+		stampCard: {
+			insertCardForRestore: (...args: unknown[]) => mockStampInsertCardForRestore(...args),
+			insertEntryForRestore: () => stampEntryTracker.tracked(),
+		},
+		certificate: { insertForRestore: vi.fn() },
+		childChallenge: { insertForRestore: vi.fn() },
+		message: { insertForRestore: vi.fn() },
+		siblingCheer: { insertForRestore: vi.fn() },
+		activityPref: { upsertForRestore: vi.fn() },
+	}),
+}));
+
+vi.mock('$lib/server/db/child-repo', () => ({
+	insertChild: (...args: unknown[]) => mockInsertChild(...args),
+}));
+
+vi.mock('$lib/server/db/status-repo', () => ({
+	upsertStatus: vi.fn(),
+	insertStatusHistory: () => statusHistoryTracker.tracked(),
+}));
+
+vi.mock('$lib/server/db/achievement-repo', () => ({
+	findAllAchievements: vi.fn().mockResolvedValue([]),
+	insertChildAchievement: vi.fn(),
+}));
+
+vi.mock('$lib/server/db/login-bonus-repo', () => ({
+	findRecentBonuses: (...args: unknown[]) => mockFindRecentBonuses(...args),
+	insertLoginBonus: () => loginBonusTracker.tracked(),
+}));
+
+vi.mock('$lib/server/db/checklist-repo', () => ({
+	insertTemplate: vi.fn(),
+	insertTemplateItem: vi.fn(),
+	findTemplatesByChild: vi.fn().mockResolvedValue([]),
+	assignTemplateToChildren: vi.fn(),
+	findLogsByChild: vi.fn().mockResolvedValue([]),
+	insertOverrideForRestore: vi.fn(),
+	upsertLog: vi.fn(),
+}));
+
+vi.mock('$lib/server/db/evaluation-repo', () => ({
+	insertEvaluation: vi.fn(),
+	insertRestDayForRestore: vi.fn(),
+}));
+
+vi.mock('$lib/server/db/reward-redemption-repo', () => ({
+	insertRedemptionForRestore: vi.fn(),
+}));
+
+vi.mock('$lib/server/db/settings-repo', () => ({
+	setSetting: vi.fn(),
+}));
+
+vi.mock('$lib/server/db/special-reward-repo', () => ({
+	findSpecialRewards: vi.fn().mockResolvedValue([]),
+	insertSpecialReward: vi.fn(),
+}));
+
+vi.mock('$lib/server/storage', () => ({
+	saveFile: vi.fn(),
+	fileExists: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('$lib/server/db/image-repo', () => ({
+	updateChildAvatarUrl: vi.fn(),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ---------- Import after mocks ----------
+
+import type { ExportData } from '../../../src/lib/domain/export-format';
+import { importFamilyData } from '../../../src/lib/server/services/import-service';
+
+// ---------- Helpers ----------
+
+const TENANT = 'test-tenant-3692';
+const N = 12; // 並列判定に十分な行数 (concurrency > 1 が観測できる最小限より余裕を持つ)
+
+function makeExportData(overrides: Partial<ExportData['data']> = {}): ExportData {
+	return {
+		format: 'ganbari-quest-backup',
+		version: '1.1.0',
+		exportedAt: new Date().toISOString(),
+		checksum: 'test-checksum',
+		master: { categories: [], activities: [], titles: [], achievements: [], avatarItems: [] },
+		family: {
+			children: [
+				{
+					exportId: 'child-1',
+					nickname: 'テスト太郎',
+					age: 8,
+					birthDate: '2018-01-15',
+					theme: 'blue',
+					uiMode: 'elementary',
+					avatarUrl: null,
+					activeTitle: null,
+					createdAt: '2025-06-01T00:00:00Z',
+				},
+			],
+		},
+		data: {
+			childActivities: [],
+			activityLogs: [],
+			pointLedger: [],
+			statuses: [],
+			statusHistory: [],
+			childAchievements: [],
+			childTitles: [],
+			loginBonuses: [],
+			evaluations: [],
+			specialRewards: [],
+			checklistTemplates: [],
+			checklistLogs: [],
+			childAvatarItems: [],
+			dailyMissions: [],
+			rewardRedemptions: [],
+			settings: [],
+			...overrides,
+		},
+	} as ExportData;
+}
+
+beforeEach(() => {
+	mockInsertChild.mockReset().mockResolvedValue({ id: '101' });
+	mockFindActivities.mockReset().mockResolvedValue([]);
+	mockFindActivityLogs.mockReset().mockResolvedValue([]);
+	mockFindRecentBonuses.mockReset().mockResolvedValue([]);
+	mockChildActivityFindByChild.mockReset().mockResolvedValue([]);
+	mockStampInsertCardForRestore.mockReset().mockResolvedValue({ id: 'card-1' });
+});
+
+// ============================================================
+// #3692: 件数支配ヘルパの insert 並列度 >1 (30s timeout 逐次退行ガード)
+// ============================================================
+
+describe('#3692 import insert 並列チャンク実行', () => {
+	it('pointLedger: insert が並列 in-flight >1 で実行され、全件 import される', async () => {
+		const data = makeExportData({
+			pointLedger: Array.from({ length: N }, (_, i) => ({
+				childRef: 'child-1',
+				amount: 10 + i,
+				type: 'earn',
+				description: `entry-${i}`,
+				createdAt: '2026-07-01T00:00:00Z',
+			})),
+		});
+		const result = await importFamilyData(data, TENANT);
+		expect(result.pointLedgerImported).toBe(N);
+		expect(pointLedgerTracker.max()).toBeGreaterThan(1);
+	});
+
+	it('statusHistory: insert が並列 in-flight >1 で実行され、全件 import される', async () => {
+		const data = makeExportData({
+			statusHistory: Array.from({ length: N }, (_, i) => ({
+				childRef: 'child-1',
+				categoryCode: 'undou',
+				value: 50 + i,
+				changeAmount: 1,
+				changeType: 'activity',
+				recordedAt: `2026-07-01T00:${String(i).padStart(2, '0')}:00Z`,
+			})),
+		});
+		const result = await importFamilyData(data, TENANT);
+		expect(result.statusHistoryImported).toBe(N);
+		expect(statusHistoryTracker.max()).toBeGreaterThan(1);
+	});
+
+	it('activityLogs: insert が並列 in-flight >1 で実行され、merge dedup (バッチ内重複 skip) も保存される', async () => {
+		// child の活動マスタ lookup に「たいそう」を持たせ、activityLogs が bind できるようにする
+		mockChildActivityFindByChild.mockResolvedValue([{ id: 'act-1', name: 'たいそう' }]);
+		const uniqueLogs = Array.from({ length: N }, (_, i) => ({
+			childRef: 'child-1',
+			activityName: 'たいそう',
+			activityCategory: 'undou',
+			points: 10,
+			streakDays: 1,
+			streakBonus: 0,
+			recordedDate: '2026-07-01',
+			recordedAt: `2026-07-01T00:${String(i).padStart(2, '0')}:00Z`,
+			cancelled: false,
+		}));
+		// バッチ内重複 1 件 (merge mode では skip されるべき — 並列化後も dedup 不変)
+		const data = makeExportData({ activityLogs: [...uniqueLogs, ...uniqueLogs.slice(0, 1)] });
+		const result = await importFamilyData(data, TENANT);
+		expect(result.activityLogsImported).toBe(N);
+		expect(result.activityLogsSkipped).toBe(1);
+		expect(activityLogTracker.max()).toBeGreaterThan(1);
+	});
+
+	it('loginBonuses: insert が並列 in-flight >1 で実行され、既存日付 dedup も保存される', async () => {
+		// 既存 bonus 1 件 (2026-07-01) — この日付の行は skip されるべき
+		mockFindRecentBonuses.mockResolvedValue([{ loginDate: '2026-07-01' }]);
+		const data = makeExportData({
+			loginBonuses: Array.from({ length: N + 1 }, (_, i) => ({
+				childRef: 'child-1',
+				loginDate: `2026-07-${String(i + 1).padStart(2, '0')}`,
+				rank: 'normal',
+				basePoints: 5,
+				multiplier: 1,
+				totalPoints: 5,
+				consecutiveDays: i + 1,
+				createdAt: '2026-07-01T00:00:00Z',
+			})),
+		});
+		const result = await importFamilyData(data, TENANT);
+		expect(result.loginBonusesImported).toBe(N);
+		expect(result.loginBonusesSkipped).toBe(1);
+		expect(loginBonusTracker.max()).toBeGreaterThan(1);
+	});
+
+	it('stampCards: entry insert が並列 in-flight >1 で実行され、card/entry とも全件 import される', async () => {
+		const cards = Array.from({ length: 3 }, (_, c) => ({
+			childRef: 'child-1',
+			weekStart: `2026-06-${String(c * 7 + 1).padStart(2, '0')}`,
+			weekEnd: `2026-06-${String(c * 7 + 7).padStart(2, '0')}`,
+			status: 'completed',
+			redeemedPoints: 0,
+			redeemedAt: null,
+			createdAt: '2026-06-01T00:00:00Z',
+			updatedAt: '2026-06-07T00:00:00Z',
+			entries: Array.from({ length: 4 }, (_, s) => ({
+				stampMasterId: 'stamp-1',
+				omikujiRank: 'kichi',
+				slot: s + 1,
+				loginDate: `2026-06-${String(c * 7 + s + 1).padStart(2, '0')}`,
+				earnedAt: '2026-06-01T00:00:00Z',
+			})),
+		}));
+		const data = makeExportData({ stampCards: cards });
+		const result = await importFamilyData(data, TENANT);
+		expect(result.stampCardsImported).toBe(3);
+		expect(result.stampEntriesImported).toBe(12);
+		expect(stampEntryTracker.max()).toBeGreaterThan(1);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: 本番ローカル NUC でバックアップした zip を本番 AWS 環境にインポートすると **504 (Lambda 30s timeout)** で失敗し、実データを持つ顧客がバックアップ復元 = 中核 CUJ を実行できない。

**期待される効果**: 実バックアップ規模 (≈ 1,200 行) の取込を Lambda 30s 制約内に収め、restore が成功するようにする。あわせて経路の所要時間を可視化し、今後の性能回帰を CloudWatch で切り分け可能にする。

## 関連 Issue

refs #3692

> **auto-close しない (QM BLOCK ② 対処)**: #3692 は priority:critical・タイトルが「チャンク化 + 非同期 saga 根治」= saga 根治までを scope とする。本 PR は即効①（チャンク化 = insert 並列化）のみで、本番実機 restore 検証 / 6MB payload の UI feedback (#3694) / saga 根治は未達。ADR-0002 (critical 5 要件) 抵触を避けるため `closes` を `refs` に降格し、#3692 は saga 根治まで OPEN 維持する。残る saga 根治は #3692 本体で継続する。

## 根本原因

`/api/v1/import` の `importFamilyData` は件数支配ヘルパ (activityLogs / pointLedger / loginBonuses / statusHistory / stampCards) を `for...of { await insert() }` で **逐次 await** していた。1 insert = 最大 3 DynamoDB 往復 (採番 UpdateCommand + denormalize read + PutCommand)。実バックアップ ≈ 1,200 行 → ≈ 3,000 逐次往復 × 10-20ms = **30-60s > Lambda 30s (LWA)**。障害リクエスト `15dd8dd9` の CloudWatch ログは `Task timed out after 30.05 seconds` のみで、execute 経路が完全無ログ = 切り分け不能だった。

## 解決策 (即効。恒久 saga 化は #3692 の残タスクとして扱う)

1. **2-phase 化**: 各件数支配ヘルパを「同期 phase (childId 解決 + dedup 判定を確定) → 並列 phase (`runConcurrent` で insert のみ concurrency=25 で並列実行)」に分離。dedup Set の参照/更新は insert await を跨ぐと race するため同期 phase に閉じ込めた。repo 層は不変。
2. **observability**: execute / replace 経路に開始 (取込行数) / 完了 (所要 ms + errors 数) ログを追加。無言 504 の再発時に「何行の取込に何 ms かかったか」を CloudWatch で追える。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 件数支配 5 ヘルパの insert が並列 in-flight >1 で実行される (逐次退行ガード) | `npx vitest run tests/unit/services/import-service-concurrency.test.ts` | HEAD `775ef080` / 5 passed / 実装前は 5/5 red (failing-test-first, ADR-0061) |
| AC2 | 並列化後も件数・dedup 結果が不変 (正しさの保存) | 同 test 内で `activityLogsImported` / `Skipped` / loginBonus 既存日付 skip を assert | HEAD `775ef080` / activityLogs N+1→imported N/skipped 1、loginBonus N+1→imported N/skipped 1 PASS |
| AC3 | 既存 import 回帰なし | `npx vitest run tests/unit/services/` | HEAD `775ef080` / 145 files 2401 passed |
| AC4 | 実 DB (PGlite/DSQL/better-sqlite3) 経路の回帰なし | `npx vitest run tests/unit/db/` | 73 files 876 passed (実行 branch base、import 経路含む) |
| AC5 | 型・lint 健全 | `npx svelte-check --threshold error` / `npx biome check` | 0 errors / No fixes applied |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)

**影響を受ける画面・機能**: 親管理画面のバックアップ復元 (`/api/v1/import` execute / replace)。子供画面・UI 描画には影響しない。

## テスト & 安全装置セルフチェック

- [x] 追加・変更したテストの概要: `tests/unit/services/import-service-concurrency.test.ts` を新規追加 — insert mock を deferred にし同時 in-flight 数の最大値を記録、逐次実装なら常に 1・並列実装なら >1 になることで並列度を機械検証。件数/dedup 不変も同 test で assert。
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: repo 層は不変 (並列化は service 層のみ)。`scripts/check-dynamodb-stub.mjs` 対象外
- [x] **Critical バグ修正の場合**: N/A (priority:critical bug だが本 PR は即効の性能修正。5 年齢モード横断 UI 変更なし)

## スクリーンショット / ビジュアルデモ

該当なし（サービス層 + API の性能修正、UI 変更なし）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `runConcurrent` は汎用 worker-pool util として単一責任。各ヘルパは「dedup 確定 → 並列 insert」の同型に揃えた
- [x] **DRY**: 5 ヘルパで同一パターン (2-phase) を `runConcurrent` に集約。並列度定数 `IMPORT_INSERT_CONCURRENCY` は 1 箇所 SSOT
- [x] **YAGNI**: concurrency は固定定数 (可変 config 化しない)。恒久 saga 化は本 PR に含めず #3692 続きで判断
- [x] **Security**: tenantId scope 不変 (並列化は同一 tenant 内の insert 順序のみ変更)。台帳・履歴は append-only で行間依存なし
- [x] **パフォーマンス**: 逐次 N 往復 → concurrency 25 の並列で壁時計 1/25 に圧縮。dedup 用 read も child 単位で並列 prefetch

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外 (import service の内部並列化のみ、demo/LP/年齢モード/ナビに波及しない)

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: 並列 insert で dedup Set の race を作らないため「同期 phase で Set 確定 → 並列 phase で insert のみ」の 2-phase を厳守している点を確認してほしい。activityLogs / loginBonuses の dedup は同期 phase 内で `existingKeys.add(key)` まで済ませてから並列区間に入る。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（下記コマンド証跡）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更なし（SS 該当なし）

pre-ready 相当検証（実行済コマンドと結果）:
- `npx biome check src/lib/server/services/import-service.ts src/routes/api/v1/import/+server.ts tests/unit/services/import-service-concurrency.test.ts` → No fixes applied
- `npx cspell` (変更 3 ファイル) → Issues found: 0
- `npx svelte-check --threshold error` → 0 errors 0 warnings
- `npx vitest run tests/unit/services/` → 2401 passed
- `npx vitest run tests/unit/db/` → 876 passed

## QM レビュー結果

QM レビュー依頼中。
