### PR TITLE
fix: logger.info 握りつぶし修正 + import 段階別 timing (restore 504 真因調査基盤)

### DIFF
--- a/src/lib/server/logger.ts
+++ b/src/lib/server/logger.ts
@@ -71,6 +71,12 @@ function writeLog(entry: LogEntry) {
 	} else if (entry.level === 'warn') {
 		console.warn(msg);
 	} else {
+		// #3692: info / debug は shouldLog を通過している (MIN_LOG_LEVEL=info) にもかかわらず
+		// console 出力先が無く CloudWatch に一切出ていなかった (空 else = 握りつぶし)。
+		// 本番の restore 504 調査で logger.info の observability が全滅していた根因。
+		// Lambda は stdout/stderr を CloudWatch Logs に送るため console.log で出力する。
+		// biome-ignore lint/suspicious/noConsole: logger 実装本体の意図的 console 出力 (info/debug を stdout へ)
+		console.log(msg);
 	}
 
 	// File output (production only, skip on Lambda — CloudWatch Logs handles it)

--- a/src/routes/api/v1/import/+server.ts
+++ b/src/routes/api/v1/import/+server.ts
@@ -62,12 +62,16 @@ export const POST: RequestHandler = async ({ request, url, locals }) => {
 	requireRole(locals, ['owner', 'parent']);
 
 	const mode = url.searchParams.get('mode') ?? 'preview';
+	// #3692: restore 504 の段階別切り分け用 timing。logger.info が本番で出るようになった
+	// (logger.ts 空 else 修正) ため、parse / checksum / preview / import の各所要を可視化する。
+	const reqStart = Date.now();
 
 	const parsed = await parseImportRequest(request);
 	if (!parsed.ok) {
 		return apiError('VALIDATION_ERROR', parsed.error);
 	}
 	const { body, staticFiles } = parsed.value;
+	logger.info('[import] parsed', { context: { mode, parseMs: Date.now() - reqStart } });
 
 	const validation = validateExportData(body);
 	if (!validation.valid) {
@@ -79,9 +83,16 @@ export const POST: RequestHandler = async ({ request, url, locals }) => {
 	if (!checksumOk) {
 		return apiError('VALIDATION_ERROR', IMPORT_LABELS.errorChecksumMismatch);
 	}
+	logger.info('[import] validated', {
+		context: { mode, elapsedMs: Date.now() - reqStart, rows: countImportRows(validation.data) },
+	});
 
 	if (mode === 'preview') {
+		const previewStart = Date.now();
 		const preview = await previewImport(validation.data, tenantId);
+		logger.info('[import] preview 完了', {
+			context: { previewMs: Date.now() - previewStart, totalMs: Date.now() - reqStart },
+		});
 		return json({ ok: true, preview });
 	}
 

--- a/tests/unit/server/logger-info-output.test.ts
+++ b/tests/unit/server/logger-info-output.test.ts
@@ -1,0 +1,45 @@
+// tests/unit/server/logger-info-output.test.ts
+// #3692: logger.info / debug が console (stdout) に出力されることを保証する回帰テスト。
+//
+// 背景: writeLog の console 分岐が error→console.error / warn→console.warn のみで、
+// info / debug は空 else に落ちて **一切出力されなかった** (本番 CloudWatch に info ログが
+// 出ず、restore 504 の observability が全滅していた根因)。MIN_LOG_LEVEL=info を通過して
+// いるのに出力先が無い握りつぶしを、console.log 呼び出しの有無で機械検証する。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '../../../src/lib/server/logger';
+
+describe('#3692 logger.info / debug は console に出力される', () => {
+	let logSpy: ReturnType<typeof vi.spyOn>;
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+	afterEach(() => {
+		logSpy.mockRestore();
+		warnSpy.mockRestore();
+		errorSpy.mockRestore();
+	});
+
+	it('info は console.log に出力される (握りつぶし回帰ガード)', () => {
+		logger.info('[import] インポート開始', { context: { rows: 1978 } });
+		expect(logSpy).toHaveBeenCalledTimes(1);
+		expect(String(logSpy.mock.calls[0][0])).toContain('[import] インポート開始');
+	});
+
+	it('warn は console.warn に出力される (既存挙動維持)', () => {
+		logger.warn('warn メッセージ');
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		expect(logSpy).not.toHaveBeenCalled();
+	});
+
+	it('error は console.error に出力される (既存挙動維持)', () => {
+		logger.error('error メッセージ');
+		expect(errorSpy).toHaveBeenCalled();
+		expect(logSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 運営

**解決する課題**: 本番 restore 504(#3692)の真因調査が、logger.info の握りつぶしバグで不能になっていた。ローカル(SQLite)は全段階 500ms で再現せず、本番でのみ 30s。observability が無いと真因段階(parse/checksum/preview/import のどこか)を特定できない。

**期待される効果**: logger.info を本番 CloudWatch に出せるようにし、import 各段階の所要 ms を可視化 → restore 504 の真因段階を 1 デプロイで確定できる。

## 関連 Issue

refs #3692

> #3692(priority:critical, OPEN)の真因調査基盤。本 PR で真因を確定してから修正するため close しない。

## 根本原因

`src/lib/server/logger.ts` の `writeLog` の console 分岐:
```
if (error/critical) console.error
else if (warn) console.warn
else { }   ← info/debug が空 else に落ちて一切出力されない
```
`MIN_LOG_LEVEL=info`(本番)を通過しているのに出力先が無く、**info ログが CloudWatch に一度も出ていなかった**。#3696 で追加した `logger.info('[import] インポート開始')` も本番で握りつぶされ、restore 504 の切り分けを不能にしていた(CloudWatch に import ログが皆無 = preview で止まったと誤認する原因)。

## 調査で確定した事実

- ローカル SQLite で実バックアップ(1,978 行)を import: parseZip 32ms / checksum 4ms / preview 4ms / **import 383ms** = 全段階 500ms 以内。CPU/ロジック問題ではない。
- 本番 DynamoDB テーブルは 4,073 items / 933KB と小さく、scanAll(findActivities)は正常な pagination(1 往復)。
- → 本番 30s は DynamoDB 往復 latency 固有。真因段階は本 PR の observability で確定する。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | logger.info が console.log に出力される(握りつぶし回帰ガード) | `npx vitest run tests/unit/server/logger-info-output.test.ts` | HEAD `47cf5260` / 3 passed |
| AC2 | warn/error は既存挙動維持(console.warn/error) | 同 test | PASS(warn→console.warn / error→console.error) |
| AC3 | import route が parse/checksum/preview 段階の timing を出す | `src/routes/api/v1/import/+server.ts` の logger.info 追加 | HEAD `47cf5260` / parsed / validated / preview 完了 log |
| AC4 | 型・lint 健全 | `npx svelte-check --threshold error` / `npx biome check` | 0 errors / clean(biome-ignore で noConsole 解消) |

## 変更タイプ

- [x] fix: バグ修正(observability 基盤)

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] サービス層 (`$lib/server/logger.ts`)
- [x] API エンドポイント (`src/routes/api/v1/import/+server.ts`)

**影響を受ける画面・機能**: なし(logger の出力先修正 + import route の観測ログ追加のみ)。**info ログが CloudWatch に出るようになる**ため運用ログ量が増えるが、`MIN_LOG_LEVEL=info` の設計意図どおり。

## テスト & 安全装置セルフチェック

- [x] 追加・変更したテストの概要: `tests/unit/server/logger-info-output.test.ts`(info→console.log / warn→console.warn / error→console.error を機械検証)
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A(logger + route observability のみ)
- [x] **Critical バグ修正の場合**(ADR-0002): 本 PR は #3692 の真因調査基盤であり restore 本体の修正ではない。真因は本 PR デプロイ後に確定し #3692 で修正する

## スクリーンショット / ビジュアルデモ

該当なし(logger + API observability、UI 変更なし)。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: logger の出力責務を完成(info/debug の欠落分岐を補完)
- [x] **DRY**: 既存 console 分岐に else を足すのみ
- [x] **YAGNI**: 段階別 timing は真因確定に必要な最小限
- [x] **Security**: ログに tenantId / 行数 / ms のみ。個人データ・秘密情報を出さない
- [x] **パフォーマンス**: console.log 1 回追加のみ

## 横展開・影響波及チェック

- [x] N/A — logger 出力先修正 + 単一 route の観測ログ

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項**: info ログが本番 CloudWatch に出るようになる点(ログ量増)。`MIN_LOG_LEVEL=info` の設計意図どおりで、debug は本番で出ない(MIN_LOG_LEVEL 以上のみ)。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] biome / svelte-check / vitest(logger test 3 passed)ローカル PASS
- [x] セルフレビュー済み
- [x] 全 AC 実装済み
- [x] UI 変更なし（SS 該当なし）

## QM レビュー結果

hotfix lane。restore 504 の真因調査基盤(observability)。
