### PR TITLE
feat(infra): #3424/#3620 本番 DSQL/PGlite cutover — deploy に lane 移植 + cutover 前 backup

### DIFF
--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -207,6 +207,28 @@ jobs:
       # DP=false (staging は捨てて作り直す前提)。cluster は scale-to-zero + 無料枠内 (¥0 圏)。
       # bin/app.ts は本番 stack 群を無条件 instantiate するため、DsqlStaging のみの deploy でも
       # synth には compute-stack の必須 context (opsSecretKey 等) が要る (cycle 1 の学び)。
+      # #3702 rehearsal: 本番 deploy.yml Phase 2.9 相当の cutover 前 DynamoDB backup を staging で検証。
+      # staging table (ganbari-quest-staging) は空でも create-backup の動作 (fail-closed 含む) を確認する。
+      - name: Pre-cutover DynamoDB backup (staging rehearsal, fail-closed #3702)
+        if: env.DSQL_LANE == 'true'
+        run: |
+          BACKUP_NAME="staging-pre-cutover-$(date -u +%Y%m%d-%H%M%S)"
+          ARN=$(aws dynamodb create-backup --table-name "$ECR_REPOSITORY" --backup-name "$BACKUP_NAME" \
+            --region "$AWS_REGION" --query 'BackupDetails.BackupArn' --output text)
+          echo "::notice::staging DynamoDB backup: $BACKUP_NAME ($ARN)"
+          ST=""
+          for i in $(seq 1 30); do
+            ST=$(aws dynamodb describe-backup --backup-arn "$ARN" --region "$AWS_REGION" \
+              --query 'BackupDescription.BackupDetails.BackupStatus' --output text)
+            echo "backup status: $ST"
+            [ "$ST" = "AVAILABLE" ] && break
+            sleep 5
+          done
+          if [ "$ST" != "AVAILABLE" ]; then
+            echo "::error::staging DynamoDB backup が AVAILABLE になりませんでした"
+            exit 1
+          fi
+
       - name: Deploy DSQL staging cluster (dsql lane)
         if: env.DSQL_LANE == 'true'
         working-directory: infra/

--- a/.github/workflows/deploy-nuc.yml
+++ b/.github/workflows/deploy-nuc.yml
@@ -103,10 +103,35 @@ jobs:
             "# DO NOT EDIT MANUALLY. Rotate via: gh secret set <NAME> --body <value> --repo Takenori-Kusaka/ganbari-quest",
             "PARENT_GATE_COOKIE_SECRET=$env:PARENT_GATE_COOKIE_SECRET",
             "AI_PROVIDER=gemini",
-            "ORIGIN=http://0.0.0.0:3000"
+            "ORIGIN=http://0.0.0.0:3000",
+            "DATA_SOURCE=pglite",
+            "PGLITE_DATA_DIR=/app/data/pglite"
           )
           Set-Content -Path .env -Value $envLines -Encoding ASCII
           Write-Host "Wrote .env from GitHub Secrets ($($envLines.Count) lines, secret values masked)"
+
+      # Step 2.5 (EPIC #3620 本番 cutover / #3702): SQLite → PGlite データ移行 (非破壊 import-then-swap)。
+      # deploy-nuc-staging.yml の pglite lane を本番へ移植。旧 sqlite DB は削除せず保持し、
+      # cutover CLI が export → PGlite import (data/pglite) → 件数突合。count-mismatch / errors>0 で
+      # abort (legacy DB untouched = ロールバック可能)。旧 DB 不在なら fresh PGlite で起動。
+      # backup は #3702 で別途 (deploy 前に手動 + backup-1 コンテナ)。旧 sqlite を消さないため二重安全。
+      - name: PGlite cutover (SQLite → PGlite, 非破壊)
+        run: |
+          if (-not (Test-Path ".\data\ganbari-quest.db")) {
+            Write-Host "::notice::legacy sqlite DB not found -> skip cutover, boot fresh PGlite"
+          } else {
+            # 既存 PGlite dataDir があれば作り直す (再デプロイ冪等)。旧 sqlite は温存。
+            if (Test-Path ".\data\pglite") {
+              Remove-Item -Recurse -Force ".\data\pglite"
+              Write-Host "removed previous pglite dataDir (re-cutover)"
+            }
+            docker compose run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts export --db /app/data/ganbari-quest.db --out /app/data/.cutover-export.json
+            if ($LASTEXITCODE -ne 0) { throw "cutover export failed (exit $LASTEXITCODE)" }
+            docker compose run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts import --in /app/data/.cutover-export.json --data-dir /app/data/pglite
+            if ($LASTEXITCODE -ne 0) { throw "cutover import failed (exit $LASTEXITCODE; count-mismatch or errors>0 abort, legacy sqlite untouched)" }
+            Remove-Item -Force ".\data\.cutover-export.json" -ErrorAction SilentlyContinue
+            Write-Host "::notice::cutover passed (export -> import -> count verification). Booting with PGlite backend"
+          }
 
       # Step 3: Rebuild and start containers (stop -> build -> up order is critical for WAL safety)
       # Dockerfile regenerates APP_VERSION at build time (#711), so no host-side tsx required.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,6 +228,78 @@ jobs:
           fi
           # Note: Cost Anomaly Monitoring はデフォルトモニターを使用（CDK管理外）
 
+      # Phase 2.9 (EPIC #3424 M5 本番 cutover / #3702): cutover 前 DynamoDB backup + DSQL cluster/schema。
+      # deploy-aws-staging.yml の dsql lane を本番へ移植。backup fail-closed → cluster deploy → schema migrate。
+      # 本番は cutover 恒久化のため常時 DSQL (staging の workflow_dispatch opt-in と異なり常時実行)。
+      # DynamoDB データは PO 合意でデータ移行不要 (zero users) だが、#2510 教訓で backup-first 厳守。
+      - name: Pre-cutover DynamoDB backup (fail-closed, #3702)
+        run: |
+          BACKUP_NAME="pre-dsql-cutover-$(date -u +%Y%m%d-%H%M%S)"
+          ARN=$(aws dynamodb create-backup --table-name "$ECR_REPOSITORY" --backup-name "$BACKUP_NAME" \
+            --region "$AWS_REGION" --query 'BackupDetails.BackupArn' --output text)
+          echo "::notice::DynamoDB backup 作成: $BACKUP_NAME ($ARN)"
+          ST=""
+          for i in $(seq 1 30); do
+            ST=$(aws dynamodb describe-backup --backup-arn "$ARN" --region "$AWS_REGION" \
+              --query 'BackupDescription.BackupDetails.BackupStatus' --output text)
+            echo "backup status: $ST"
+            [ "$ST" = "AVAILABLE" ] && break
+            sleep 5
+          done
+          if [ "$ST" != "AVAILABLE" ]; then
+            echo "::error::DynamoDB backup が AVAILABLE になりませんでした (cutover 中止)"
+            exit 1
+          fi
+
+      # DSQL cluster を deploy (GanbariQuestDsql, DP=true)。bin/app.ts は本番 stack 群を無条件 synth
+      # するため、cluster のみの deploy でも Phase 3 と同じ全 context が synth に要る。
+      - name: Deploy DSQL cluster (production)
+        working-directory: infra/
+        run: >-
+          npx cdk deploy GanbariQuestDsql --require-approval never
+          -c dsqlEnabled=true
+          -c domainName=${{ env.DOMAIN_NAME }}
+          -c certificateArn=${{ env.CERTIFICATE_ARN }}
+          -c staticAssetsS3Offload=true
+          -c feedbackDiscordWebhookUrl=${{ secrets.FEEDBACK_DISCORD_WEBHOOK_URL }}
+          -c geminiApiKey=${{ secrets.GEMINI_API_KEY }}
+          -c adminAllowedIps=${{ secrets.ADMIN_ALLOWED_IPS }}
+          -c stripeSecretKey=${{ secrets.STRIPE_SECRET_KEY }}
+          -c stripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          -c stripePriceStandardMonthly=${{ vars.STRIPE_PRICE_STANDARD_MONTHLY }}
+          -c stripePriceFamilyMonthly=${{ vars.STRIPE_PRICE_FAMILY_MONTHLY }}
+          -c useLookupKey=${{ vars.USE_LOOKUP_KEY || 'true' }}
+          -c stripeWebhookShadowMode=${{ vars.STRIPE_WEBHOOK_SHADOW_MODE || 'false' }}
+          -c stripeWebhookSecretTest=${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }}
+          -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }}
+          -c cronSecret=${{ secrets.CRON_SECRET }}
+          -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
+          -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }}
+          -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }}
+          ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
+          ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }}
+
+      - name: Resolve DSQL outputs (production)
+        run: |
+          ENDPOINT=$(aws cloudformation describe-stacks --stack-name GanbariQuestDsql \
+            --region "$AWS_REGION" \
+            --query "Stacks[0].Outputs[?OutputKey=='ClusterEndpoint'].OutputValue" --output text)
+          ARN=$(aws cloudformation describe-stacks --stack-name GanbariQuestDsql \
+            --region "$AWS_REGION" \
+            --query "Stacks[0].Outputs[?OutputKey=='ClusterArn'].OutputValue" --output text)
+          if [ -z "$ENDPOINT" ] || [ -z "$ARN" ] || [ "$ENDPOINT" = "None" ] || [ "$ARN" = "None" ]; then
+            echo "::error::DSQL outputs (ClusterEndpoint/ClusterArn) の取得に失敗しました"
+            exit 1
+          fi
+          echo "DSQL_ENDPOINT=$ENDPOINT" >> $GITHUB_ENV
+          echo "DSQL_CLUSTER_ARN=$ARN" >> $GITHUB_ENV
+          echo "::notice::DSQL production cluster resolved: $ENDPOINT"
+
+      - name: Provision DSQL schema (production)
+        env:
+          DSQL_ENDPOINT: ${{ env.DSQL_ENDPOINT }}
+        run: npm run dsql:migrate
+
       # Phase 3: Replacement check + Deploy Compute + Network stacks (Lambda, CloudFront)
       # #1400: Auth / Network / Compute スタック（特に Cognito User Pool）の Replacement を検知
       - name: CDK diff — replacement check (all stacks)
@@ -238,6 +310,9 @@ jobs:
           # replacement-approved マーカー検出には先頭で十分なため 64KB に truncate する。
           COMMIT_MSG=$(git log -1 --pretty=%B | head -c 65536)
           npx cdk diff --all \
+            -c dsqlEnabled=true \
+            -c dsqlEndpoint=$DSQL_ENDPOINT \
+            -c dsqlClusterArn=$DSQL_CLUSTER_ARN \
             -c domainName=${{ env.DOMAIN_NAME }} \
             -c certificateArn=${{ env.CERTIFICATE_ARN }} \
             -c staticAssetsS3Offload=true \
@@ -264,6 +339,9 @@ jobs:
         working-directory: infra/
         run: >-
           npx cdk deploy --all --require-approval never --outputs-file cdk-outputs.json
+          -c dsqlEnabled=true
+          -c dsqlEndpoint=$DSQL_ENDPOINT
+          -c dsqlClusterArn=$DSQL_CLUSTER_ARN
           -c domainName=${{ env.DOMAIN_NAME }}
           -c certificateArn=${{ env.CERTIFICATE_ARN }}
           -c staticAssetsS3Offload=true
@@ -284,6 +362,20 @@ jobs:
           -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }}
+
+      # Phase 3.5 (#3646 本番 cutover): DSQL app role (app_user) provisioning。Lambda 実行 role は
+      # dsql:DbConnect のみ持つ (最小権限) が DSQL 認可仕様では DbConnect は custom database role 専用の
+      # ため、CREATE ROLE + AWS IAM GRANT (Lambda role ARN 紐付け) + 表 GRANT を冪等適用する。
+      # compute deploy 後 = Lambda 実行 role ARN 確定後、health check 前に置く。
+      - name: Grant DSQL app role to Lambda (production)
+        env:
+          DSQL_ENDPOINT: ${{ env.DSQL_ENDPOINT }}
+        run: |
+          LAMBDA_ROLE_ARN=$(aws lambda get-function-configuration \
+            --function-name "$LAMBDA_FUNCTION" --region "$AWS_REGION" \
+            --query 'Role' --output text)
+          echo "::notice::Granting app_user to $LAMBDA_ROLE_ARN"
+          npm run dsql:grant -- --iam-role-arn "$LAMBDA_ROLE_ARN"
 
       # Phase 4: Update Lambda to use the new image
       - name: Update Lambda function image (production)


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ 運営 / システム全体

**解決する課題**: DSQL/PGlite 移管は「コード + staging 検証」まで完了していたが、**本番 deploy に cutover 経路が組み込まれておらず**、本番が DynamoDB(AWS)/ SQLite(NUC)のままだった(移管完遂の誤報告の是正)。これにより本番 restore が DynamoDB の往復 latency で 504(#3692)になる根本原因も残っていた。

**期待される効果**: 本番 deploy に DSQL/PGlite cutover 経路を組み込み、本番を DSQL/PGlite に切り替える。DSQL は SQL 一括処理のため、DynamoDB の「1 行ずつ往復」による restore 504 が構造的に解消する。

## 関連 Issue

refs #3424 #3620 #3702

> cutover 完遂は各 EPIC の最終ゲート。本 PR は本番 deploy 経路の組込。#3692(restore 504)も DSQL cutover で根治見込み。

## ⚠️ この PR の重大性(必読)

- **main merge = 本番 cutover 発火**。deploy.yml は main push で自動実行され、本番を DSQL に切り替える。deploy-nuc.yml は NUC で SQLite→PGlite 移行を実行する。
- **本番専用のため PR CI(ci.yml)では cutover 実動作を検証できない**。lane ロジック自体は staging(`deploy-aws-staging.yml` dsql lane / `deploy-nuc-staging.yml` pglite lane)で実証済み。
- **backup 済み**: cutover 前に手動冗長 backup を取得済み(下記)。

## 変更内容

### deploy.yml(AWS DSQL、+92 行)
1. **Phase 2.9 — cutover 前 DynamoDB backup**(`create-backup` + AVAILABLE 待ち、**fail-closed** #3702)
2. **DSQL cluster deploy**(`GanbariQuestDsql`, DP=true)→ endpoint/ARN 解決 → `dsql:migrate`(schema)
3. **Phase 3** の cdk diff/deploy に `dsqlEnabled=true` + endpoint/ARN context 追加 → Lambda `DATA_SOURCE=dsql`
4. **Phase 3.5 — dsql:grant**(Lambda 実行 role へ app_user 権限)

### deploy-nuc.yml(NUC PGlite、+27 行)
1. `.env` に `DATA_SOURCE=pglite` + `PGLITE_DATA_DIR=/app/data/pglite`
2. **Step 2.5 — SQLite→PGlite cutover**(`nuc-pglite-cutover.ts` export→import、**非破壊 import-then-swap**、count-mismatch / errors>0 で abort、旧 sqlite 温存)

## データ移行方針

- **DynamoDB**: PO 合意でデータ移行不要(zero users)。空 DSQL に切替。
- **NUC SQLite**: cutover CLI で SQLite→PGlite にデータ移行(非破壊、旧 .db 保持)。

## 取得済みバックアップ(cutover 前、手動冗長)

| 対象 | backup | 場所 | 検証 |
|---|---|---|---|
| DynamoDB | オンデマンド backup | AWS `pre-dsql-cutover-20260712`(AVAILABLE) | 933KB |
| DynamoDB | 生 JSON | `C:\Docker\ganbari-quest-backups\dynamodb-...json` | 4,064 items 全件 |
| NUC SQLite | logical backup | NUC data\backups + data dir 外 + このマシン | integrity: **ok** |

## ロールバック手順

- **DSQL → DynamoDB**: deploy.yml から DSQL lane を revert → 再デプロイで `DATA_SOURCE=dynamodb` に戻る(DynamoDB データ生存)
- **PGlite → SQLite**: deploy-nuc.yml から PGlite lane を revert → `DATA_SOURCE=sqlite` に戻る(旧 sqlite 温存、非破壊のため無傷)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 両 workflow YAML valid | `node -e "yaml.load(...)"` | PASS(deploy.yml / deploy-nuc.yml とも valid) |
| AC2 | lane ロジックは staging 実証済み | `gh run list --workflow=deploy-aws-staging.yml`(dsql lane success `29150840039`) | staging cluster CREATE_COMPLETE + full cycle success |
| AC3 | backup fail-closed | deploy.yml Phase 2.9 の `[ "$ST" != "AVAILABLE" ] && exit 1` | 実装済 |
| AC4 | 非破壊 cutover(ロールバック可能) | deploy-nuc.yml の「旧 sqlite 温存 + count-mismatch abort」/ DynamoDB データ保持 | 実装済 |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

- [x] 設定・CI(`.github/workflows/deploy.yml` / `deploy-nuc.yml`)

## スクリーンショット / ビジュアルデモ

該当なし(deploy workflow のみ)。

## テスト & 安全装置セルフチェック

- [x] YAML valid(両 workflow)
- [x] cutover 前手動 backup 取得済(DynamoDB オンデマンド + 生 JSON / NUC logical、冗長)
- [x] backup fail-closed(DynamoDB backup が AVAILABLE でないと cutover に進まない)
- [x] 非破壊 cutover(旧 DynamoDB / 旧 sqlite を保持、ロールバック可能)

## 推奨 merge プロセス(レビュアー向け)

本番専用のため、以下の順序を推奨:
1. staging(`deploy-aws-staging.yml` / `deploy-nuc-staging.yml`)に本 PR 相当の **backup step を追加して workflow_dispatch で最終リハーサル**(create-backup が staging table で成功するか)
2. staging green + backup 確認後に Ready → main merge(= 本番 cutover 発火)
3. merge 後、`gh run watch` で deploy.yml を監視。health / e2e-production green を確認
4. 本番実機で restore(#3692)が DSQL で成功するか確認

## 配布済み env / secret (ADR-0006)

- [x] N/A — 既存 secret(DSQL は IAM role 認証、新規 secret なし)

## コード品質セルフレビュー (#1481)

- N/A — deploy workflow(YAML)の変更のみ。アプリコード変更なし。lane ロジックは staging 実証済みの移植。

## 横展開・影響波及チェック

- [x] AWS(deploy.yml)/ NUC(deploy-nuc.yml)両トラックに cutover lane を移植(片手落ちの同時是正)
- [x] staging workflow(deploy-aws-staging.yml)にも backup step を追加し最終リハーサル可能に
- [x] N/A — アプリ実装・年齢モード・LP には波及しない(deploy 経路のみ)

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれる → 本番 backend 切替(DynamoDB→DSQL / NUC SQLite→PGlite)

**影響範囲**: 本番の全データアクセスが DSQL/PGlite 経由になる。**マイグレーション手順**: backup(取得済)→ deploy lane が cluster/schema provisioning + cutover 実行。**既存データ**: DynamoDB は破棄(zero users、backup 保持)/ NUC SQLite は PGlite へ非破壊移行(旧 .db 温存)。ロールバック手順は上記「ロールバック手順」節。

## Ready for Review チェックリスト

- [x] **Draft 運用**: staging 最終リハーサル + レビュー承認まで Ready にしない(本番 cutover 発火のため、本 PR は Draft 維持)
- [x] YAML valid 確認済
- [x] cutover 前 backup 取得済

## QM レビュー結果

Draft。本番 cutover の重大変更のため、staging 最終リハーサル + レビューを経て Ready 化する。
