### PR TITLE
fix(infra): #3703 DSQL dashboard/budget 名を staging/prod で一意化 (本番 cutover cluster deploy 衝突の根治)

### DIFF
--- a/infra/lib/dsql-stack.ts
+++ b/infra/lib/dsql-stack.ts
@@ -36,6 +36,12 @@ export class DsqlStack extends cdk.Stack {
 	constructor(scope: Construct, id: string, props?: DsqlStackProps) {
 		super(scope, id, props);
 
+		// #3703 hotfix: staging (GanbariQuestDsqlStaging) と本番 (GanbariQuestDsql) は同一アカウント・
+		// 同一リージョンに同居するため、dashboard / budget の物理名が同名だと CloudFormation
+		// 'already exists' で deploy fail する (本番 cutover 初回で顕在化)。stack id から suffix を
+		// 導出して一意化する (cluster/topic/alarm は論理 ID 由来で自動一意のため対象外)。
+		const nameSuffix = id.toLowerCase().includes('staging') ? '-staging' : '';
+
 		// ── 1. DSQL クラスタ (L1、#3429。DP=true 既定で誤 destroy を物理拒否) ──
 		this.cluster = new dsql.CfnCluster(this, 'Cluster', {
 			deletionProtectionEnabled: props?.deletionProtection ?? true,
@@ -99,7 +105,7 @@ export class DsqlStack extends cdk.Stack {
 		if (props?.opsEmail) {
 			new budgets.CfnBudget(this, 'DsqlBudget', {
 				budget: {
-					budgetName: 'ganbari-quest-dsql-guardrail',
+					budgetName: `ganbari-quest-dsql-guardrail${nameSuffix}`,
 					budgetType: 'COST',
 					timeUnit: 'MONTHLY',
 					budgetLimit: { amount: 1, unit: 'USD' },
@@ -133,7 +139,7 @@ export class DsqlStack extends cdk.Stack {
 			});
 
 		new cloudwatch.Dashboard(this, 'DsqlDashboard', {
-			dashboardName: 'ganbari-quest-dsql',
+			dashboardName: `ganbari-quest-dsql${nameSuffix}`,
 			widgets: [
 				[
 					new cloudwatch.GraphWidget({


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体

**解決する課題**: 本番 DSQL cutover(#3703)の DSQL cluster deploy が CloudFormation `AWS::CloudWatch::Dashboard 'ganbari-quest-dsql' already exists` で fail し、AWS の DSQL 移管が完遂できていない。

**期待される効果**: dashboard/budget の物理名を staging/prod で一意化し、本番 cutover を完遂する。

## 関連 Issue

refs #3424 #3703

## 根本原因

`DsqlStack`(`infra/lib/dsql-stack.ts`)の `dashboardName: 'ganbari-quest-dsql'` / `budgetName: 'ganbari-quest-dsql-guardrail'` が**ハードコード同名**。staging(`GanbariQuestDsqlStaging`)と本番(`GanbariQuestDsql`)は同一アカウント・同一リージョンに同居するため、staging が先に作成した dashboard と本番が衝突。**staging リハーサルは本番 stack `GanbariQuestDsql` 自体を deploy しない**(staging 版を deploy)ため、この本番 stack 固有の名前衝突は検出できなかった(fail-closed + backup で AWS は DynamoDB のまま無傷)。

## 解決策

stack id から `nameSuffix`(staging→`-staging` / prod→`''`)を導出し、dashboard/budget 名を一意化。cluster/topic/alarm は論理 ID 由来で自動一意のため対象外。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | dashboard/budget 名が staging/prod で一意 | `infra/lib/dsql-stack.ts` の `nameSuffix` 分岐 | 本番=`ganbari-quest-dsql` / staging=`ganbari-quest-dsql-staging` |
| AC2 | biome 構文 OK | `npx biome check infra/lib/dsql-stack.ts` | No fixes applied |
| AC3 | staging 再 deploy で旧 dashboard rename | `deploy-aws-staging.yml` dsql lane 再走(run 29211125043) | 実行中 → 完了で旧名解放 |
| AC4 | 本番 cluster deploy 成功 | main merge 後 deploy.yml 再走で `GanbariQuestDsql` CREATE | 本 PR merge 後に確認 |

## 変更タイプ

- [x] fix: バグ修正 / infra

## 影響範囲・変更コンポーネント

- [x] インフラ(`infra/lib/dsql-stack.ts`)

## テスト & 安全装置セルフチェック

- [x] biome check PASS
- [x] 論理変更は dashboard/budget 名のみ(cluster/alarm 不変)
- [x] N/A — 新規 env/secret なし

## スクリーンショット / ビジュアルデモ

該当なし(CDK infra のみ)。

## コード品質セルフレビュー (#1481)

- N/A — 物理名の一意化のみ。

## 横展開・影響波及チェック

- [x] N/A — DsqlStack 内の名前定義のみ。他 stack に波及なし。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない — dashboard/budget の物理名変更のみ(staging dashboard は rename、本番は新規作成)。データ・機能に影響なし。

## 配布済み env / secret (ADR-0006)

- [x] N/A

## Ready for Review チェックリスト

- [x] biome check PASS
- [x] staging 再 deploy で旧 dashboard rename を先行実行(run 29211125043)

## QM レビュー結果

本番 cutover 完遂のための dashboard 名衝突 hotfix。
