### PR TITLE
fix(infra): #3703 DSQL dashboard/budget 名の staging/prod 一意化を develop へ back-merge (本番 cutover blocker 根治)

### DIFF
--- a/infra/lib/dsql-stack.ts
+++ b/infra/lib/dsql-stack.ts
@@ -36,6 +36,12 @@ export class DsqlStack extends cdk.Stack {
 	constructor(scope: Construct, id: string, props?: DsqlStackProps) {
 		super(scope, id, props);
 
+		// #3703 hotfix: staging (GanbariQuestDsqlStaging) と本番 (GanbariQuestDsql) は同一アカウント・
+		// 同一リージョンに同居するため、dashboard / budget の物理名が同名だと CloudFormation
+		// 'already exists' で deploy fail する (本番 cutover 初回で顕在化)。stack id から suffix を
+		// 導出して一意化する (cluster/topic/alarm は論理 ID 由来で自動一意のため対象外)。
+		const nameSuffix = id.toLowerCase().includes('staging') ? '-staging' : '';
+
 		// ── 1. DSQL クラスタ (L1、#3429。DP=true 既定で誤 destroy を物理拒否) ──
 		this.cluster = new dsql.CfnCluster(this, 'Cluster', {
 			deletionProtectionEnabled: props?.deletionProtection ?? true,
@@ -99,7 +105,7 @@ export class DsqlStack extends cdk.Stack {
 		if (props?.opsEmail) {
 			new budgets.CfnBudget(this, 'DsqlBudget', {
 				budget: {
-					budgetName: 'ganbari-quest-dsql-guardrail',
+					budgetName: `ganbari-quest-dsql-guardrail${nameSuffix}`,
 					budgetType: 'COST',
 					timeUnit: 'MONTHLY',
 					budgetLimit: { amount: 1, unit: 'USD' },
@@ -133,7 +139,7 @@ export class DsqlStack extends cdk.Stack {
 			});
 
 		new cloudwatch.Dashboard(this, 'DsqlDashboard', {
-			dashboardName: 'ganbari-quest-dsql',
+			dashboardName: `ganbari-quest-dsql${nameSuffix}`,
 			widgets: [
 				[
 					new cloudwatch.GraphWidget({


### PR DESCRIPTION
## 背景 / 根本原因

本番 DSQL cutover (deploy.yml) が **4 回連続 fail**。真因は CloudWatch Dashboard 物理名 `ganbari-quest-dsql` を staging stack (`GanbariQuestDsqlStaging`) が保持し、本番 stack (`GanbariQuestDsql`) の dashboard 作成が `already exists in stack ...GanbariQuestDsqlStaging` で衝突していたこと。

修正 (`nameSuffix` 導出、d62adca1 / #3703) は **main のみに存在し develop 未反映**。staging deploy (deploy-aws-staging.yml) は **develop HEAD** を checkout するため、staging を再 deploy しても un-suffixed 名を再取得し名前が解放されない = 本番 cutover が永久に unblock できない状態だった。

## 変更

`main` の d62adca1 を develop へ cherry-pick (infra/lib/dsql-stack.ts のみ、8 insertions / 2 deletions)。stack id から `nameSuffix` (`-staging`) を導出し dashboard/budget 物理名を一意化する。

- staging → `ganbari-quest-dsql-staging` / `ganbari-quest-dsql-guardrail-staging`
- 本番 → `ganbari-quest-dsql` / `ganbari-quest-dsql-guardrail` (従来通り)

これにより develop から staging を再 deploy すると staging dashboard が `-staging` 化し、本番 `ganbari-quest-dsql` 名が解放される。develop/main の命名則も収束し将来の再衝突を根絶。

## 影響範囲

infra CDK naming のみ。ロジック変更なし。main では検証済み (cutover blocker として特定)。

refs #3424 #3703

🤖 Generated with [Claude Code](https://claude.com/claude-code)