### PR TITLE
fix(test): #3424 本番 smoke ヘルスチェック dataSource 期待値を dsql に更新 (cutover 完遂 hotfix)

### DIFF
--- a/tests/e2e/production-smoke.spec.ts
+++ b/tests/e2e/production-smoke.spec.ts
@@ -66,7 +66,8 @@ test.describe('本番環境 - 基本動作', () => {
 		expect(response.status()).toBe(200);
 		const body = await response.json();
 		expect(body.status).toBe('ok');
-		expect(body.dataSource).toBe('dynamodb');
+		// 本番は EPIC #3424 cutover 完遂で恒久 DSQL (deploy.yml が常時 -c dsqlEnabled=true)。
+		expect(body.dataSource).toBe('dsql');
 	});
 
 	test('ログインページが表示される', async ({ page }) => {


### PR DESCRIPTION
## 背景

本番 DSQL cutover が **完遂** (run 29220831561 の deploy job green: DSQL cluster deploy → schema migrate → CDK all stacks → Lambda `DATA_SOURCE=dsql` → Grant → Health check success)。本番 `/api/health` は `{"status":"ok","dataSource":"dsql",...,"schemaValid":true}` を返す。

しかし後段 `e2e-production` の production-smoke ヘルスチェックが `expect(body.dataSource).toBe('dynamodb')` と stale なため fail し、run 全体が red + release/release-notes が skip された。cutover 自体は成功しており本番は DSQL で稼働中。

## 変更

`tests/e2e/production-smoke.spec.ts` の dataSource 期待値を `'dynamodb'` → `'dsql'` に更新。本番は deploy.yml が常時 `-c dsqlEnabled=true` で恒久 DSQL 化 (main deploy.yml L233「本番は cutover 恒久化のため常時 DSQL」) のため、恒久状態 'dsql' が正。

## 影響

テスト assertion のみ (1 行 + コメント)。プロダクションコード変更なし。本 hotfix merge 後に deploy.yml を再 dispatch すれば e2e-production green + release 発行。

## follow-up

- develop 側 production-smoke.spec.ts も同 assertion のため、次回 develop→main 統合前に同期が必要 (cutover 群の main→develop back-merge 一括で吸収)。
- adversarial reviewer 指摘: `id.includes('staging')` 命名 heuristic の unit/fitness guard 不在 / Budget rename による staging cost-alert 履歴断絶 (別 Issue 起票予定)。

refs #3424 #3703

🤖 Generated with [Claude Code](https://claude.com/claude-code)