### PR TITLE
test(fitness): #3117 admin 契約 guardrail 残 3 項目 (intruder allowlist + 0-items exercise + ADR-0055 drift gate)

### DIFF
--- a/src/lib/features/admin/admin-resource-model-registry.ts
+++ b/src/lib/features/admin/admin-resource-model-registry.ts
@@ -37,6 +37,18 @@
 export type AdminResourceOrganizingModel = 'per-child-tabs' | 'family-distribute';
 export type AdminResourceBinding = 'child-selection-dialog' | 'visibility-chip';
 
+/**
+ * ADR-0055 データ scope 宣言 (#3117 項目 3)。organizingModel (UI 表示軸) とは**別レイヤー** (#3096)。
+ *
+ * - `'per-child-instance'` — aggregate root が child に閉じる (activity / reward)。
+ * - `'family-master-template'` — family master template + per-child assignments/progress (checklist)。
+ *
+ * SSOT は `docs/design/data-model-resource-scope.md` §3 (ADR-0055)。本宣言と doc 表の整合は
+ * `tests/unit/features/admin-resource-model-registry.test.ts` の drift gate が機械検証する
+ * (doc 側だけ / registry 側だけ変更すると CI fail)。
+ */
+export type AdminResourceDataScope = 'per-child-instance' | 'family-master-template';
+
 export interface AdminResourceModel {
 	/** リソース種別キー (registry の key と一致) */
 	readonly resource: 'activity' | 'reward' | 'checklist';
@@ -46,14 +58,20 @@ export interface AdminResourceModel {
 	readonly organizingModel: AdminResourceOrganizingModel;
 	/** 取込 / 追加時の child 紐付け UI */
 	readonly binding: AdminResourceBinding;
+	/** ADR-0055 データ scope (UI とは別レイヤー、doc 表と drift gate で照合、#3117) */
+	readonly dataScope: AdminResourceDataScope;
 	/**
 	 * DOM 整合検証用の代表 testid。
 	 * - `childTabsTestid` — 子供タブ row (per-child-tabs では必須出現)。
 	 * - `visibilityChipTestid` — family-distribute の配信先 chip (DOM 上に存在すべきか判定)。
 	 *   per-child-tabs リソースでは null (配信 chip を持たない)。
+	 * - `emptyStateTestid` — 一覧 / 検索結果が 0 件のとき描画される UnifiedEmptyState (SSOT、
+	 *   DESIGN.md §5) の testid。fitness function の 0-items exercise (#3117 項目 2) が
+	 *   「空表示でもスロット契約が成立する」ことを assert するために使う。
 	 */
 	readonly childTabsTestid: string;
 	readonly visibilityChipTestid: string | null;
+	readonly emptyStateTestid: string;
 }
 
 /**
@@ -154,12 +172,13 @@ export const REQUIRED_SLOT_NAMES: readonly string[] = CANONICAL_SLOT_ORDER.filte
  * checklist = family master「配信される」(family-distribute + visibility-chip)。
  *   Sub-2 (#3096) で checklist を per-child-tabs に更新予定だが、本 PR では現状を宣言する。
  *
- * **ADR-0055 との関係 (Sub-1 暫定宣言)**: per-child / family master のデータモデル原則は ADR-0055 が
+ * **ADR-0055 との関係**: per-child / family master のデータモデル原則は ADR-0055 が
  * SSOT だが、ADR-0055 は設計 doc であり code-level の共有 type を持たない (本 registry 起票時点で
  * `organizingModel` / `binding` の TypeScript 型は本ファイルが初出)。よって本宣言は ADR-0055 の値を
- * **再宣言ではなく初の code 化**であり二重 SSOT ではない。将来 ADR-0055 由来の共有 scope 型
- * (`data-model-resource-scope`) が code 化された場合は、Sub-2 (#3096) で本 registry をそれに寄せて
- * 統一し、drift gate (registry 値 ⇄ schema/ADR 整合の CI 照合) を併設する。
+ * **再宣言ではなく初の code 化**であり二重 SSOT ではない。#3117 項目 3 で `dataScope` 宣言を追加し、
+ * `docs/design/data-model-resource-scope.md` §3 表との整合を
+ * `tests/unit/features/admin-resource-model-registry.test.ts` の drift gate が機械検証する
+ * (doc 側だけ / registry 側だけ変更すると CI fail)。
  */
 export const ADMIN_RESOURCE_MODEL_REGISTRY = {
 	activity: {
@@ -167,16 +186,24 @@ export const ADMIN_RESOURCE_MODEL_REGISTRY = {
 		route: '/admin/activities',
 		organizingModel: 'per-child-tabs',
 		binding: 'child-selection-dialog',
+		// ADR-0055 §3: aggregate root = ChildActivity (per-child instance)
+		dataScope: 'per-child-instance',
 		childTabsTestid: 'admin-activities-child-tabs',
 		visibilityChipTestid: null,
+		// ActivityEmptyState (UnifiedEmptyState thin wrapper) は testid override せず default を使う
+		emptyStateTestid: 'unified-empty-state',
 	},
 	reward: {
 		resource: 'reward',
 		route: '/admin/rewards',
 		organizingModel: 'per-child-tabs',
 		binding: 'child-selection-dialog',
+		// ADR-0055 §3: aggregate root = ChildReward (per-child instance)
+		dataScope: 'per-child-instance',
 		childTabsTestid: 'admin-rewards-child-tabs',
 		visibilityChipTestid: null,
+		// 検索結果 0 件の filter-empty 表示 (UnifiedEmptyState、#2268 / Round 18)
+		emptyStateTestid: 'rewards-search-empty',
 	},
 	checklist: {
 		resource: 'checklist',
@@ -191,12 +218,44 @@ export const ADMIN_RESOURCE_MODEL_REGISTRY = {
 		//   visibilityChipTestid は null (page top に配信 chip を常設しない)。
 		organizingModel: 'per-child-tabs',
 		binding: 'child-selection-dialog',
+		// ADR-0055 §3: family master template + per-child assignments/progress (UI とは別レイヤー、#3096)
+		dataScope: 'family-master-template',
 		childTabsTestid: 'admin-checklists-child-tabs',
 		visibilityChipTestid: null,
+		// 一覧 / 検索結果 0 件の空表示 (UnifiedEmptyState、Round 18 CX-DoR #11)
+		emptyStateTestid: 'admin-checklists-empty-state',
 	},
 } as const satisfies Record<string, AdminResourceModel>;
 
 export type AdminResourceKey = keyof typeof ADMIN_RESOURCE_MODEL_REGISTRY;
+
+/**
+ * #3117 項目 1: intruder scan の allowlist (fails-closed)。
+ *
+ * fitness function (`tests/e2e/admin-resource-layout-contract.spec.ts`) は canonical スロット間の
+ * direct-child 帯に出現した「`data-testid` を持つ slot-level 兄弟要素」を走査する。旧実装は
+ * `admin-<res>-` prefix 名前空間の regex でのみ判定していたため、bare 名 testid
+ * (例: `data-testid="promo-banner"`) の drift slot を素通りする false-negative があった。
+ *
+ * 本 allowlist 方式では **canonical slot testid + 本リストに明示列挙された既知 (B) ドメイン
+ * section のみを許可**し、未知の testid は全て intruder として fail する (fails-closed、ADR-0006
+ * assertion 弱体化禁止と整合)。新規 section を canonical スロット間に置きたい場合は、
+ * DESIGN.md §10 正準スロット契約との整合を確認したうえで本リストに reason 付きで追加すること。
+ *
+ * scope 境界: `data-testid` を持たない純装飾要素 (spacing wrapper 等) は本 scan の対象外
+ * (legit な装飾要素の false-positive とのバランス、Issue #3117 項目 1)。
+ */
+export const ALLOWED_NON_CANONICAL_SLOT_TESTIDS: Record<AdminResourceKey, readonly string[]> = {
+	activity: [],
+	reward: [],
+	checklist: [
+		// marketplace 取込結果メッセージ + browse link section (#2558 段階2)。
+		// ChildSelectionDialog auto-open + 取込結果表示として E2E (marketplace-checklist-import /
+		// bug1-import-dead-end / goal-flows-exemplar) が依存する既知 (B) ドメイン section。
+		// slot 6 (action-message) と slot 7 (list) の間に配置される。
+		'marketplace-import-section',
+	],
+};
 
 /**
  * #3134: 正準スロット契約 (ADMIN_RESOURCE_MODEL_REGISTRY) の **scope 外**と判断した admin リソース

--- a/tests/e2e/admin-resource-layout-contract.spec.ts
+++ b/tests/e2e/admin-resource-layout-contract.spec.ts
@@ -21,7 +21,9 @@
 import { expect, type Page, test } from '@playwright/test';
 import {
 	ADMIN_RESOURCE_MODEL_REGISTRY,
+	type AdminResourceKey,
 	type AdminResourceModel,
+	ALLOWED_NON_CANONICAL_SLOT_TESTIDS,
 	CANONICAL_SLOT_ORDER,
 	REQUIRED_SLOT_NAMES,
 } from '../../src/lib/features/admin/admin-resource-model-registry';
@@ -100,7 +102,15 @@ async function readVisibleSlotsInDomOrder(
  * 間に正準でない section / banner が挿入されても部分列照合では見えない (順序は崩れていないため PASS)。
  * これを塞ぐため、canonical スロット要素の共通親 (LCA) を求め、その **直接の子要素**を document 順に
  * 走査し、「canonical スロットを含む子」の連続帯 (first〜last canonical child) の中に、
- * canonical でない `data-testid` を持つ slot-level 兄弟が割り込んでいないかを assert する。
+ * 正準でも allowlist でもない `data-testid` を持つ slot-level 兄弟が割り込んでいないかを assert する。
+ *
+ * #3117 項目 1 (allowlist 方式、fails-closed): 旧実装は `admin-<res>-` prefix 名前空間の regex での
+ * 判定だったため、bare 名 testid (例: `data-testid="promo-banner"`) の drift slot を素通りする
+ * false-negative があった。本実装は **canonical slot testid + `ALLOWED_NON_CANONICAL_SLOT_TESTIDS`
+ * (registry SSOT に明示列挙された既知 (B) ドメイン section) のみを許可**し、それ以外の testid を持つ
+ * 直接の子は全て intruder として報告する (未知 = fail、fails-closed)。
+ * `data-testid` を持たない純装飾要素は対象外 (false-positive とのバランス、registry の allowlist
+ * doc comment 参照)。
  *
  * 返り値: 割り込んでいた非正準 testid の配列 (空なら drift なし)。
  */
@@ -111,8 +121,9 @@ async function findIntruderTestidsBetweenSlots(
 	const canonicalTestids = CANONICAL_SLOT_ORDER.map((slot) => slot.testid(resource)).filter(
 		(t): t is string => Boolean(t),
 	);
+	const allowedNonCanonical = ALLOWED_NON_CANONICAL_SLOT_TESTIDS[resource as AdminResourceKey];
 	return page.evaluate(
-		({ canonicalTestids, allCanonicalTestids }) => {
+		({ canonicalTestids, allCanonicalTestids, allowedNonCanonical }) => {
 			// canonical スロット要素群の lowest common ancestor (LCA) を返す (browser context helper)。
 			const findLca = (els: Element[]): Element | null => {
 				let lca: Element | null = els[0] ?? null;
@@ -145,23 +156,16 @@ async function findIntruderTestidsBetweenSlots(
 			const lastIdx = canonicalChildIdx[canonicalChildIdx.length - 1];
 			if (firstIdx === undefined || lastIdx === undefined) return [];
 
-			// first〜last の帯の中で、canonical スロットを含まないのに「slot 名前空間 testid」を持つ
-			// 直接の子 = 割り込み (drift)。
-			//
-			// 判定対象は **slot 名前空間** `admin-<res>-*` (+ `<res>-action-message` /
-			// `<res>-child-context-banner` の variant) とする。`admin-<res>-` で始まる testid を持つ
-			// 直接の子は「page-level slot」を名乗っているとみなし、canonical 集合外なら割り込み (新規 slot)
-			// として捕捉する (例: `admin-checklists-promo-banner` を search と list の間に追加)。
-			//
-			// (B) 正当なドメインセクション (marketplace-import-section / checklist-distribution-section-*
-			// 等) は `admin-<res>-` 接頭辞を持たない固有 testid であり、かつ各自の canonical スロット内に
-			// 置かれる限り「canonical を含む子」として帯から除外されるため誤検出しない。
-			const slotNamespaceRe =
-				/^admin-(activities|rewards|checklists)-|-(action-message|child-context-banner)$/;
+			// first〜last の帯の中で、canonical スロットを含まないのに data-testid を持つ直接の子は、
+			// allowlist (canonical 全集合 + registry の ALLOWED_NON_CANONICAL_SLOT_TESTIDS) に無ければ
+			// 全て割り込み (drift) として報告する (#3117 項目 1、fails-closed)。
+			// 旧 regex 方式 (`admin-<res>-` prefix のみ検出) では bare 名 testid (例: `promo-banner`) が
+			// 素通りしていた false-negative を封じる。
+			const allowed = new Set<string>([...allCanonicalTestids, ...allowedNonCanonical]);
 			const isIntruder = (child: Element): string | null => {
 				if (containsCanonical(child)) return null;
 				const tid = child.getAttribute('data-testid');
-				return tid && slotNamespaceRe.test(tid) && !allCanonicalTestids.includes(tid) ? tid : null;
+				return tid && !allowed.has(tid) ? tid : null;
 			};
 
 			const intruders: string[] = [];
@@ -172,7 +176,11 @@ async function findIntruderTestidsBetweenSlots(
 			}
 			return intruders;
 		},
-		{ canonicalTestids, allCanonicalTestids: Array.from(ALL_CANONICAL_TESTIDS) },
+		{
+			canonicalTestids,
+			allCanonicalTestids: Array.from(ALL_CANONICAL_TESTIDS),
+			allowedNonCanonical: Array.from(allowedNonCanonical),
+		},
 	);
 }
 
@@ -266,6 +274,46 @@ test.describe('#3097 admin リソース正準スロット契約 (activities / re
 				// (= page-top に配信 chip を常設しない契約)。per-child リソースが配信 chip を page-top に
 				// 常設したら toBeHidden が fail する。
 				await expect(page.getByTestId('checklist-distribution-visibility')).toBeHidden();
+			});
+
+			test('(e) 一覧 0 件 (filter-empty) でも slot 契約が成立する (UnifiedEmptyState 経由、#3117 項目 2)', async ({
+				page,
+			}) => {
+				// demo fixture がデータを seed するため、通常描画では一覧の 0 件分岐が本 spec の CI 実行で
+				// 一度も踏まれない (#3117 項目 2 = 0-items パスの CI exercise 欠落)。新規 fixture variant を
+				// 作らず (Pre-PMF、ADR-0010)、既存 UI の search filter で一覧を 0 件に倒し、
+				// UnifiedEmptyState (empty state SSOT、DESIGN.md §5 / §10) 経由の空表示でも
+				// スロット契約が item 数に依存せず成立することを assert する。
+				const searchTestid = CANONICAL_SLOT_ORDER.find((s) => s.name === 'search')?.testid(
+					model.resource,
+				);
+				expect(
+					searchTestid,
+					'search スロットの testid が registry に定義されていない',
+				).toBeTruthy();
+				await page
+					.getByTestId(searchTestid as string)
+					.getByRole('searchbox')
+					.fill('zzz-no-match-3117');
+
+				// 0 件分岐: UnifiedEmptyState (SSOT) の empty state が描画される (registry 宣言 testid)。
+				await expect(page.getByTestId(model.emptyStateTestid)).toBeVisible();
+
+				// item 数に依存しない slot 契約: 必須スロットは空表示でも欠けず、正準順を保ち、
+				// intruder 0 件のまま (test (a)/(b) と同じ assert を 0 件状態で再適用)。
+				const observed = await readVisibleSlotsInDomOrder(page, model.resource);
+				for (const required of REQUIRED_SLOT_NAMES) {
+					expect(observed, `0 件表示で必須スロット "${required}" が消えた`).toContain(required);
+				}
+				expect(
+					isSubsequence(observed, CANONICAL_NAMES),
+					`0 件表示の slot 順 ${JSON.stringify(observed)} が canonical の部分列ではない`,
+				).toBe(true);
+				const intruders = await findIntruderTestidsBetweenSlots(page, model.resource);
+				expect(
+					intruders,
+					`0 件表示で canonical スロット間に非正準 slot が割り込んだ: ${JSON.stringify(intruders)}`,
+				).toEqual([]);
 			});
 		});
 	}

--- a/tests/unit/features/admin-resource-model-registry.test.ts
+++ b/tests/unit/features/admin-resource-model-registry.test.ts
@@ -2,15 +2,20 @@
 // #3134: admin リソース正準契約の no-silent-gap guard。
 // DESIGN.md §10 の全 admin リソース管理画面が、正準 registry か明示除外リストの
 // いずれかで必ず説明されること (= 契約が自身の網羅漏れを silent に見逃さない) を保証する。
+// #3117 項目 3: registry の dataScope 宣言 ⇄ ADR-0055 SSOT doc
+// (docs/design/data-model-resource-scope.md §3 表) の drift gate を併設する。
 
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
 	ADMIN_RESOURCE_MODEL_REGISTRY,
 	ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY,
+	type AdminResourceDataScope,
+	type AdminResourceKey,
 	ALL_ADMIN_RESOURCE_PAGES,
+	ALLOWED_NON_CANONICAL_SLOT_TESTIDS,
 	classifyAdminPageRoute,
 	NON_CANONICAL_ADMIN_RESOURCES,
 	NON_RESOURCE_ADMIN_PAGE_ROUTES,
@@ -142,5 +147,114 @@ describe('#3164 母数を実 route FS から導出する (literal 未更新の s
 		expect(classifyAdminPageRoute('badges-not-registered-yet')).toBe('unclassified');
 		expect(classifyAdminPageRoute('activities')).toBe('resource');
 		expect(classifyAdminPageRoute('settings')).toBe('non-resource');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #3117 項目 3: registry ⇄ ADR-0055 SSOT doc の drift gate
+// ---------------------------------------------------------------------------
+// `ADMIN_RESOURCE_MODEL_REGISTRY` の `dataScope` 宣言 (ADR-0055 の code 化) と、ADR-0055 の
+// 設計 doc SSOT `docs/design/data-model-resource-scope.md` §3「6 type の scope 適用表」の
+// 「採択 scope」列を機械照合する。doc 側だけ scope を変える / registry 側だけ変える、の
+// 片側更新 (3-way drift) を CI で検出する fitness test (新規 script は作らない、tests/unit/ 内で完結)。
+//
+// parse 方式: doc §3 表の行は `| **<type>** | <採択 scope> | ...` 形式 (太字 type 名) で
+// 安定しているため、doc 側に machine-readable マーカーを追加せず既存表を直接 parse する
+// (最小コスト、check-doc-code-references と同じ「doc 実体を読む」方式)。見出し・行形式が
+// 変わった場合は parser 側 assert が fail する (fails-closed、silent pass しない)。
+
+const DATA_MODEL_SCOPE_DOC = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	'../../../docs/design/data-model-resource-scope.md',
+);
+
+/** registry key → doc §3 表の Type 列 (太字内の literal)。 */
+const REGISTRY_KEY_TO_DOC_TYPE: Record<AdminResourceKey, string> = {
+	activity: 'activity',
+	reward: 'reward (exchange)',
+	checklist: 'checklist',
+};
+
+/** doc の「採択 scope」自然文セルを registry の dataScope enum に正規化する。未知の文言は null (= fail)。 */
+function normalizeDocScope(cell: string): AdminResourceDataScope | null {
+	if (cell.startsWith('per-child instance')) return 'per-child-instance';
+	if (cell.startsWith('family master template')) return 'family-master-template';
+	return null;
+}
+
+/** doc §3 の scope 適用表から `Type (太字) → 採択 scope セル` の Map を得る。 */
+function parseDocScopeTable(): Map<string, string> {
+	const md = readFileSync(DATA_MODEL_SCOPE_DOC, 'utf-8');
+	const start = md.indexOf('## 3. 6 type の scope 適用表');
+	expect(
+		start,
+		`data-model-resource-scope.md に見出し「## 3. 6 type の scope 適用表」が見つからない ` +
+			'(doc 再構成時は本 drift gate の parser も同期更新すること)',
+	).toBeGreaterThanOrEqual(0);
+	// §3.1 以降のサブ表 (dedup scope 表) を除外し、§3 本表のみを対象にする。
+	const section = md.slice(start).split('### 3.1')[0] ?? '';
+	const rows = new Map<string, string>();
+	for (const line of section.split('\n')) {
+		// 例: | **activity** | per-child instance | `ChildActivity` | ...
+		const m = /^\|\s*\*\*(.+?)\*\*\s*\|\s*(.+?)\s*\|/.exec(line);
+		if (m?.[1] && m[2]) rows.set(m[1], m[2]);
+	}
+	return rows;
+}
+
+describe('#3117 registry dataScope ⇄ data-model-resource-scope.md §3 (ADR-0055 SSOT) drift gate', () => {
+	const docRows = parseDocScopeTable();
+
+	it('doc §3 表が parse でき、registry 対象 3 type の行が存在する (parser sanity、fails-closed)', () => {
+		for (const [key, docType] of Object.entries(REGISTRY_KEY_TO_DOC_TYPE)) {
+			expect(
+				docRows.has(docType),
+				`doc §3 表に registry resource "${key}" に対応する行 "**${docType}**" が無い ` +
+					'(doc の type 名変更時は REGISTRY_KEY_TO_DOC_TYPE を同期更新すること)',
+			).toBe(true);
+		}
+	});
+
+	it('registry の dataScope が doc §3「採択 scope」列と一致する (片側更新 = drift を検出)', () => {
+		for (const model of Object.values(ADMIN_RESOURCE_MODEL_REGISTRY)) {
+			const docType = REGISTRY_KEY_TO_DOC_TYPE[model.resource];
+			const cell = docRows.get(docType);
+			expect(cell, `doc §3 表に "${docType}" 行が無い`).toBeTruthy();
+			const docScope = normalizeDocScope(cell as string);
+			expect(
+				docScope,
+				`doc §3 "${docType}" の採択 scope セル "${cell}" を既知の scope に正規化できない ` +
+					'(scope 表現の変更時は normalizeDocScope と registry を同時更新すること)',
+			).not.toBeNull();
+			expect(
+				model.dataScope,
+				`registry "${model.resource}" の dataScope (${model.dataScope}) が doc §3 の採択 scope ` +
+					`(${docScope}) と乖離している (ADR-0055 SSOT drift)。doc と registry を同一 PR で同期すること`,
+			).toBe(docScope);
+		}
+	});
+
+	it('registry の organizingModel は UI 表示軸としてデータ scope と独立に per-child-tabs で統一されている (#3098)', () => {
+		// data-model-resource-scope.md は「データ scope」の SSOT であり UI 表示軸は宣言しない。
+		// UI 表示軸の統一 (3 資源とも child 主軸) は DESIGN.md §10 の宣言で、checklist が
+		// family-master-template (データ) でも per-child-tabs (UI) である「別レイヤー」原則 (#3096) を
+		// ここで固定する (dataScope に引きずられて organizingModel を書き換える誤同期の防止)。
+		for (const model of Object.values(ADMIN_RESOURCE_MODEL_REGISTRY)) {
+			expect(
+				model.organizingModel,
+				`registry "${model.resource}" の organizingModel が per-child-tabs でない (DESIGN.md §10 逸脱)`,
+			).toBe('per-child-tabs');
+		}
+	});
+
+	it('intruder allowlist (ALLOWED_NON_CANONICAL_SLOT_TESTIDS) は registry の全 resource key を網羅する', () => {
+		// #3117 項目 1 の allowlist が resource 追加時に定義漏れで undefined アクセスにならないよう
+		// (Record 型で強制されるが、satisfies 崩れ等の退行を runtime でも固定)。
+		for (const key of Object.keys(ADMIN_RESOURCE_MODEL_REGISTRY)) {
+			expect(
+				Array.isArray(ALLOWED_NON_CANONICAL_SLOT_TESTIDS[key as AdminResourceKey]),
+				`ALLOWED_NON_CANONICAL_SLOT_TESTIDS に resource "${key}" のエントリが無い`,
+			).toBe(true);
+		}
 	});
 });


### PR DESCRIPTION
# test(fitness): #3117 admin 契約 guardrail 残 3 項目 (intruder allowlist + 0-items exercise + ADR-0055 drift gate)

## 顧客価値・目的

**対象ユーザー**: システム全体（間接的に親・子供の全ユーザー）

**解決する課題**: admin リソース管理 3 画面 (活動 / ごほうび / チェックリスト) の正準スロット契約 fitness function (#3097) に、PR #3100 QM 再レビューで確認された guardrail の穴 3 点が残っていた — ① bare 名 testid の drift slot を素通りする intruder scan の false-negative、② 一覧 0 件分岐が CI で未 exercise、③ registry の ADR-0055 宣言 ⇄ 設計 doc の drift gate 欠落。穴が残ったままだと「契約が守られている」という architectural assurance が偽りになり、画面ドリフト (PO 約 12 回指摘の再発クラス) を CI が見逃す。

**期待される効果**: 契約逸脱・空表示崩れ・SSOT drift のいずれも CI が機械検出するようになり、admin 3 画面の UI 一貫性 (NN/G #4 consistency) が実装者の注意力に依存せず維持される (ADR-0061 shift-left 機械強制)。

## 関連 Issue

closes #3117

（項目 4 = checklist per-child UX mismatch は #3098 で解消済みのため本 PR の対象外。残 3 項目を本 PR で完遂し Issue を close する）

## AC 検証マップ (ADR-0004)

<!-- Issue #3117 は AC checkbox 形式でなく「残課題 1〜3」列挙のため、各項目を AC として検証する -->

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | intruder scan を allowlist 方式 (既知 slot testid の明示列挙 + 未知 testid は fail) に移行し、bare 名 testid の false-negative を封止 | `npx playwright test tests/e2e/admin-resource-layout-contract.spec.ts` (`findIntruderTestidsBetweenSlots` の fails-closed 判定を test (a)/(e) が実行) | tree `b7e85955` (= HEAD `10d3f59e` と関連 file 同一、rebase 差分は AdminResourceHeader.stories のみ) / tablet project 15/15 passed (test-results.json、3 resource × 5 test。ローカル実行の制約は「レビュー依頼事項」参照) / allowlist SSOT = `src/lib/features/admin/admin-resource-model-registry.ts` `ALLOWED_NON_CANONICAL_SLOT_TESTIDS` (実 DOM 棚卸しで checklist `marketplace-import-section` 1 件のみ登録) |
| AC2 | 一覧 0 件分岐 (UnifiedEmptyState 経由の空表示) を CI で exercise し、item 数に依存せず slot 契約 (必須スロット存在 + 正準順 + intruder 0) を assert | `npx playwright test tests/e2e/admin-resource-layout-contract.spec.ts` (新 test (e) × 3 resource) | tree `b7e85955` / test (e) 3 resource とも tablet で passed (test-results.json) / search filter で 0 件に倒し `emptyStateTestid` (registry 宣言) visible + REQUIRED_SLOT_NAMES + subsequence + intruder 0 を assert |
| AC3 | registry の organizingModel / データ scope 宣言と `docs/design/data-model-resource-scope.md` (ADR-0055 SSOT) の整合を機械検証する unit fitness test (新規 script なし) | `npx vitest run tests/unit/features/admin-resource-model-registry.test.ts` | HEAD `10d3f59e` / 13 passed (既存 9 + 新規 4)、rebase 後に再実行済 / registry に `dataScope` 宣言を追加し、doc §3 表を parse して照合 (parser は見出し・行欠落で fail する fails-closed 設計) |

## 変更タイプ

- [x] test: テスト改善
- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`) — `admin-resource-model-registry.ts` (契約 SSOT の宣言追加のみ、UI 描画変更なし)
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 実行時挙動の変更なし (registry への readonly 宣言追加 + テスト強化のみ)。守られる対象は `/admin/activities` / `/admin/rewards` / `/admin/checklists` の正準スロット契約。

**変更ファイル**:
- `src/lib/features/admin/admin-resource-model-registry.ts` — `dataScope` / `emptyStateTestid` field 追加 + `ALLOWED_NON_CANONICAL_SLOT_TESTIDS` (intruder allowlist SSOT) 追加
- `tests/e2e/admin-resource-layout-contract.spec.ts` — intruder scan を regex → allowlist 方式に移行 + test (e) 0-items exercise 追加
- `tests/unit/features/admin-resource-model-registry.test.ts` — ADR-0055 doc drift gate 4 test 追加

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/e2e/admin-resource-layout-contract.spec.ts` test (e) × 3 resource: search filter で一覧 0 件に倒し UnifiedEmptyState 経由の空表示でも slot 契約成立を assert
  - 同 spec `findIntruderTestidsBetweenSlots`: allowlist 方式 (fails-closed) に移行、bare 名 testid も検出
  - `tests/unit/features/admin-resource-model-registry.test.ts`: doc §3 表 parse + registry `dataScope` 照合の drift gate 4 test
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（test / fitness function + registry 宣言追加のみで UI 描画の変更が 0 行のため）**

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — allowlist / dataScope / emptyStateTestid はいずれも registry (契約 SSOT) に集約し、spec / unit test は参照のみ
- [x] **DRY**: intruder 判定・slot 走査ロジックは既存 helper を拡張 (再実装なし)。doc parse は tests/unit 内で完結し新規 script を作らない (#1442 / Pre-PMF)
- [x] **YAGNI**: 検出対象は `data-testid` を持つ slot-level 直接子のみ (testid なし装飾要素の検出は false-positive バランスから scope 外と明記)
- [x] **Security（OSS 公開前提）**: N/A (テスト・宣言のみ)
- [x] **アクセシビリティ**: N/A (UI 変更なし)
- [x] **パフォーマンス**: N/A (テスト実行時のみのコード)

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照）:

- [x] N/A — 並行実装の影響範囲外 (テスト + registry 宣言のみ、UI ラベル / 年齢モード / ナビ / DB スキーマ / チュートリアル変更なし)
- [x] **設計書同期** (ADR-0001): `data-model-resource-scope.md` §3 は現状の正解のまま変更不要 — 本 PR は doc を SSOT として registry 側を機械照合する gate を足す方向 (doc 変更 0 行)。DESIGN.md §10 の fitness function 記述と整合 (assert 内容の拡張であり記述の骨子は不変)
- [x] **並行 PR overlap** (#1200): `admin-resource-model-registry.ts` / 同 spec / 同 unit test を変更する open PR は他に無いことを確認済み

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- intruder allowlist の初期値は実 DOM 棚卸しの結果 checklist の `marketplace-import-section` 1 件のみ (activities / rewards は canonical 帯内に非正準 testid の直接子が存在しない)。allowlist へ新規追加する際は registry の doc comment に従い reason 併記を要求する運用で良いか確認いただきたい
- `data-testid` を持たない要素は intruder scan の対象外 (Issue #3117 項目 1 の「legit な装飾要素の false-positive とのバランス」に基づく明示的な scope 境界。registry / spec 双方の doc comment に記載)
- **E2E ローカル実行の環境制約 (Windows dev 環境)**: 本 spec のローカル実行では playwright の file filter が効かず全 suite (~913 test) が走った。本 spec は tablet project で 15/15 passed。mobile project は本 spec 以外の無関係 spec 27 件 fail (visual-regression の win32 platform snapshot 差分 / cognito-dev 依存系等の既知ローカル環境起因) により dependency chain (`mobile` は `tablet` 依存) が中断し未実行。fail 27 件はいずれも本 PR の変更 scope 外 (registry は本 spec + unit test のみが import し runtime 挙動変更 0 行、rebase 前後の関連 file diff 0 で確認済み)。mobile project を含む最終判定は CI 重量レーンで行う |

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — N/A (Phase 分割なし、残 3 項目を本 PR で完遂)
- [x] UI 変更時: SS 添付 — N/A (UI 描画変更 0 行)
- [x] 認証画面変更時: `npm run dev:cognito` SS — N/A (認証画面変更なし)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
