### PR TITLE
fix(infra): #3708 cutover 群 main→develop 逆マージ (silent revert 防止) + dsql-stack nameSuffix guard test

### DIFF
--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -207,6 +207,28 @@ jobs:
       # DP=false (staging は捨てて作り直す前提)。cluster は scale-to-zero + 無料枠内 (¥0 圏)。
       # bin/app.ts は本番 stack 群を無条件 instantiate するため、DsqlStaging のみの deploy でも
       # synth には compute-stack の必須 context (opsSecretKey 等) が要る (cycle 1 の学び)。
+      # #3702 rehearsal: 本番 deploy.yml Phase 2.9 相当の cutover 前 DynamoDB backup を staging で検証。
+      # staging table (ganbari-quest-staging) は空でも create-backup の動作 (fail-closed 含む) を確認する。
+      - name: Pre-cutover DynamoDB backup (staging rehearsal, fail-closed #3702)
+        if: env.DSQL_LANE == 'true'
+        run: |
+          BACKUP_NAME="staging-pre-cutover-$(date -u +%Y%m%d-%H%M%S)"
+          ARN=$(aws dynamodb create-backup --table-name "$ECR_REPOSITORY" --backup-name "$BACKUP_NAME" \
+            --region "$AWS_REGION" --query 'BackupDetails.BackupArn' --output text)
+          echo "::notice::staging DynamoDB backup: $BACKUP_NAME ($ARN)"
+          ST=""
+          for i in $(seq 1 30); do
+            ST=$(aws dynamodb describe-backup --backup-arn "$ARN" --region "$AWS_REGION" \
+              --query 'BackupDescription.BackupDetails.BackupStatus' --output text)
+            echo "backup status: $ST"
+            [ "$ST" = "AVAILABLE" ] && break
+            sleep 5
+          done
+          if [ "$ST" != "AVAILABLE" ]; then
+            echo "::error::staging DynamoDB backup が AVAILABLE になりませんでした"
+            exit 1
+          fi
+
       - name: Deploy DSQL staging cluster (dsql lane)
         if: env.DSQL_LANE == 'true'
         working-directory: infra/

--- a/.github/workflows/deploy-nuc.yml
+++ b/.github/workflows/deploy-nuc.yml
@@ -115,16 +115,19 @@ jobs:
       # cutover CLI が export → PGlite import (data/pglite) → 件数突合。count-mismatch / errors>0 で
       # abort (legacy DB untouched = ロールバック可能)。旧 DB 不在なら fresh PGlite で起動。
       # backup は #3702 で別途 (deploy 前に手動 + backup-1 コンテナ)。旧 sqlite を消さないため二重安全。
-      - name: PGlite cutover (SQLite → PGlite, 非破壊)
+      #
+      # ★ #3711 (adversarial reviewer 検出): PGlite dataDir が既に存在する場合は cutover を skip する。
+      #   cutover 完遂後のアプリ書込み先は PGlite で旧 sqlite は凍結される。旧実装 (pglite dir を毎回
+      #   削除して再 import) だと、cutover 後の通常 deploy のたびに cutover 時点の凍結 snapshot へ
+      #   silent ロールバックし、家族の記録 (活動・ポイント・スタンプ) が消失する。意図的な再 cutover は
+      #   NUC 上で data\pglite を手動削除してから deploy を dispatch する (runbook: docs/runbooks/nuc-pglite-cutover.md)。
+      - name: PGlite cutover (SQLite → PGlite, 非破壊・初回のみ)
         run: |
-          if (-not (Test-Path ".\data\ganbari-quest.db")) {
+          if (Test-Path ".\data\pglite") {
+            Write-Host "::notice::PGlite dataDir already exists -> skip cutover (PGlite is live; re-import would roll back post-cutover data). To re-cutover intentionally, remove data\pglite manually first."
+          } elseif (-not (Test-Path ".\data\ganbari-quest.db")) {
             Write-Host "::notice::legacy sqlite DB not found -> skip cutover, boot fresh PGlite"
           } else {
-            # 既存 PGlite dataDir があれば作り直す (再デプロイ冪等)。旧 sqlite は温存。
-            if (Test-Path ".\data\pglite") {
-              Remove-Item -Recurse -Force ".\data\pglite"
-              Write-Host "removed previous pglite dataDir (re-cutover)"
-            }
             docker compose run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts export --db /app/data/ganbari-quest.db --out /app/data/.cutover-export.json
             if ($LASTEXITCODE -ne 0) { throw "cutover export failed (exit $LASTEXITCODE)" }
             docker compose run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts import --in /app/data/.cutover-export.json --data-dir /app/data/pglite

--- a/.github/workflows/deploy-nuc.yml
+++ b/.github/workflows/deploy-nuc.yml
@@ -103,10 +103,35 @@ jobs:
             "# DO NOT EDIT MANUALLY. Rotate via: gh secret set <NAME> --body <value> --repo Takenori-Kusaka/ganbari-quest",
             "PARENT_GATE_COOKIE_SECRET=$env:PARENT_GATE_COOKIE_SECRET",
             "AI_PROVIDER=gemini",
-            "ORIGIN=http://0.0.0.0:3000"
+            "ORIGIN=http://0.0.0.0:3000",
+            "DATA_SOURCE=pglite",
+            "PGLITE_DATA_DIR=/app/data/pglite"
           )
           Set-Content -Path .env -Value $envLines -Encoding ASCII
           Write-Host "Wrote .env from GitHub Secrets ($($envLines.Count) lines, secret values masked)"
+
+      # Step 2.5 (EPIC #3620 本番 cutover / #3702): SQLite → PGlite データ移行 (非破壊 import-then-swap)。
+      # deploy-nuc-staging.yml の pglite lane を本番へ移植。旧 sqlite DB は削除せず保持し、
+      # cutover CLI が export → PGlite import (data/pglite) → 件数突合。count-mismatch / errors>0 で
+      # abort (legacy DB untouched = ロールバック可能)。旧 DB 不在なら fresh PGlite で起動。
+      # backup は #3702 で別途 (deploy 前に手動 + backup-1 コンテナ)。旧 sqlite を消さないため二重安全。
+      - name: PGlite cutover (SQLite → PGlite, 非破壊)
+        run: |
+          if (-not (Test-Path ".\data\ganbari-quest.db")) {
+            Write-Host "::notice::legacy sqlite DB not found -> skip cutover, boot fresh PGlite"
+          } else {
+            # 既存 PGlite dataDir があれば作り直す (再デプロイ冪等)。旧 sqlite は温存。
+            if (Test-Path ".\data\pglite") {
+              Remove-Item -Recurse -Force ".\data\pglite"
+              Write-Host "removed previous pglite dataDir (re-cutover)"
+            }
+            docker compose run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts export --db /app/data/ganbari-quest.db --out /app/data/.cutover-export.json
+            if ($LASTEXITCODE -ne 0) { throw "cutover export failed (exit $LASTEXITCODE)" }
+            docker compose run --rm --no-deps app npx tsx scripts/nuc-pglite-cutover.ts import --in /app/data/.cutover-export.json --data-dir /app/data/pglite
+            if ($LASTEXITCODE -ne 0) { throw "cutover import failed (exit $LASTEXITCODE; count-mismatch or errors>0 abort, legacy sqlite untouched)" }
+            Remove-Item -Force ".\data\.cutover-export.json" -ErrorAction SilentlyContinue
+            Write-Host "::notice::cutover passed (export -> import -> count verification). Booting with PGlite backend"
+          }
 
       # Step 3: Rebuild and start containers (stop -> build -> up order is critical for WAL safety)
       # Dockerfile regenerates APP_VERSION at build time (#711), so no host-side tsx required.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,6 +228,78 @@ jobs:
           fi
           # Note: Cost Anomaly Monitoring はデフォルトモニターを使用（CDK管理外）
 
+      # Phase 2.9 (EPIC #3424 M5 本番 cutover / #3702): cutover 前 DynamoDB backup + DSQL cluster/schema。
+      # deploy-aws-staging.yml の dsql lane を本番へ移植。backup fail-closed → cluster deploy → schema migrate。
+      # 本番は cutover 恒久化のため常時 DSQL (staging の workflow_dispatch opt-in と異なり常時実行)。
+      # DynamoDB データは PO 合意でデータ移行不要 (zero users) だが、#2510 教訓で backup-first 厳守。
+      - name: Pre-cutover DynamoDB backup (fail-closed, #3702)
+        run: |
+          BACKUP_NAME="pre-dsql-cutover-$(date -u +%Y%m%d-%H%M%S)"
+          ARN=$(aws dynamodb create-backup --table-name "$ECR_REPOSITORY" --backup-name "$BACKUP_NAME" \
+            --region "$AWS_REGION" --query 'BackupDetails.BackupArn' --output text)
+          echo "::notice::DynamoDB backup 作成: $BACKUP_NAME ($ARN)"
+          ST=""
+          for i in $(seq 1 30); do
+            ST=$(aws dynamodb describe-backup --backup-arn "$ARN" --region "$AWS_REGION" \
+              --query 'BackupDescription.BackupDetails.BackupStatus' --output text)
+            echo "backup status: $ST"
+            [ "$ST" = "AVAILABLE" ] && break
+            sleep 5
+          done
+          if [ "$ST" != "AVAILABLE" ]; then
+            echo "::error::DynamoDB backup が AVAILABLE になりませんでした (cutover 中止)"
+            exit 1
+          fi
+
+      # DSQL cluster を deploy (GanbariQuestDsql, DP=true)。bin/app.ts は本番 stack 群を無条件 synth
+      # するため、cluster のみの deploy でも Phase 3 と同じ全 context が synth に要る。
+      - name: Deploy DSQL cluster (production)
+        working-directory: infra/
+        run: >-
+          npx cdk deploy GanbariQuestDsql --require-approval never
+          -c dsqlEnabled=true
+          -c domainName=${{ env.DOMAIN_NAME }}
+          -c certificateArn=${{ env.CERTIFICATE_ARN }}
+          -c staticAssetsS3Offload=true
+          -c feedbackDiscordWebhookUrl=${{ secrets.FEEDBACK_DISCORD_WEBHOOK_URL }}
+          -c geminiApiKey=${{ secrets.GEMINI_API_KEY }}
+          -c adminAllowedIps=${{ secrets.ADMIN_ALLOWED_IPS }}
+          -c stripeSecretKey=${{ secrets.STRIPE_SECRET_KEY }}
+          -c stripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          -c stripePriceStandardMonthly=${{ vars.STRIPE_PRICE_STANDARD_MONTHLY }}
+          -c stripePriceFamilyMonthly=${{ vars.STRIPE_PRICE_FAMILY_MONTHLY }}
+          -c useLookupKey=${{ vars.USE_LOOKUP_KEY || 'true' }}
+          -c stripeWebhookShadowMode=${{ vars.STRIPE_WEBHOOK_SHADOW_MODE || 'false' }}
+          -c stripeWebhookSecretTest=${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }}
+          -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }}
+          -c cronSecret=${{ secrets.CRON_SECRET }}
+          -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
+          -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }}
+          -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }}
+          ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
+          ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }}
+
+      - name: Resolve DSQL outputs (production)
+        run: |
+          ENDPOINT=$(aws cloudformation describe-stacks --stack-name GanbariQuestDsql \
+            --region "$AWS_REGION" \
+            --query "Stacks[0].Outputs[?OutputKey=='ClusterEndpoint'].OutputValue" --output text)
+          ARN=$(aws cloudformation describe-stacks --stack-name GanbariQuestDsql \
+            --region "$AWS_REGION" \
+            --query "Stacks[0].Outputs[?OutputKey=='ClusterArn'].OutputValue" --output text)
+          if [ -z "$ENDPOINT" ] || [ -z "$ARN" ] || [ "$ENDPOINT" = "None" ] || [ "$ARN" = "None" ]; then
+            echo "::error::DSQL outputs (ClusterEndpoint/ClusterArn) の取得に失敗しました"
+            exit 1
+          fi
+          echo "DSQL_ENDPOINT=$ENDPOINT" >> $GITHUB_ENV
+          echo "DSQL_CLUSTER_ARN=$ARN" >> $GITHUB_ENV
+          echo "::notice::DSQL production cluster resolved: $ENDPOINT"
+
+      - name: Provision DSQL schema (production)
+        env:
+          DSQL_ENDPOINT: ${{ env.DSQL_ENDPOINT }}
+        run: npm run dsql:migrate
+
       # Phase 3: Replacement check + Deploy Compute + Network stacks (Lambda, CloudFront)
       # #1400: Auth / Network / Compute スタック（特に Cognito User Pool）の Replacement を検知
       - name: CDK diff — replacement check (all stacks)
@@ -238,6 +310,9 @@ jobs:
           # replacement-approved マーカー検出には先頭で十分なため 64KB に truncate する。
           COMMIT_MSG=$(git log -1 --pretty=%B | head -c 65536)
           npx cdk diff --all \
+            -c dsqlEnabled=true \
+            -c dsqlEndpoint=$DSQL_ENDPOINT \
+            -c dsqlClusterArn=$DSQL_CLUSTER_ARN \
             -c domainName=${{ env.DOMAIN_NAME }} \
             -c certificateArn=${{ env.CERTIFICATE_ARN }} \
             -c staticAssetsS3Offload=true \
@@ -264,6 +339,9 @@ jobs:
         working-directory: infra/
         run: >-
           npx cdk deploy --all --require-approval never --outputs-file cdk-outputs.json
+          -c dsqlEnabled=true
+          -c dsqlEndpoint=$DSQL_ENDPOINT
+          -c dsqlClusterArn=$DSQL_CLUSTER_ARN
           -c domainName=${{ env.DOMAIN_NAME }}
           -c certificateArn=${{ env.CERTIFICATE_ARN }}
           -c staticAssetsS3Offload=true
@@ -284,6 +362,20 @@ jobs:
           -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }}
+
+      # Phase 3.5 (#3646 本番 cutover): DSQL app role (app_user) provisioning。Lambda 実行 role は
+      # dsql:DbConnect のみ持つ (最小権限) が DSQL 認可仕様では DbConnect は custom database role 専用の
+      # ため、CREATE ROLE + AWS IAM GRANT (Lambda role ARN 紐付け) + 表 GRANT を冪等適用する。
+      # compute deploy 後 = Lambda 実行 role ARN 確定後、health check 前に置く。
+      - name: Grant DSQL app role to Lambda (production)
+        env:
+          DSQL_ENDPOINT: ${{ env.DSQL_ENDPOINT }}
+        run: |
+          LAMBDA_ROLE_ARN=$(aws lambda get-function-configuration \
+            --function-name "$LAMBDA_FUNCTION" --region "$AWS_REGION" \
+            --query 'Role' --output text)
+          echo "::notice::Granting app_user to $LAMBDA_ROLE_ARN"
+          npm run dsql:grant -- --iam-role-arn "$LAMBDA_ROLE_ARN"
 
       # Phase 4: Update Lambda to use the new image
       - name: Update Lambda function image (production)

--- a/tests/e2e/production-smoke.spec.ts
+++ b/tests/e2e/production-smoke.spec.ts
@@ -66,7 +66,8 @@ test.describe('本番環境 - 基本動作', () => {
 		expect(response.status()).toBe(200);
 		const body = await response.json();
 		expect(body.status).toBe('ok');
-		expect(body.dataSource).toBe('dynamodb');
+		// 本番は EPIC #3424 cutover 完遂で恒久 DSQL (deploy.yml が常時 -c dsqlEnabled=true)。
+		expect(body.dataSource).toBe('dsql');
 	});
 
 	test('ログインページが表示される', async ({ page }) => {

--- a/tests/unit/infra/dsql-cdk.test.ts
+++ b/tests/unit/infra/dsql-cdk.test.ts
@@ -108,3 +108,42 @@ describe('DsqlStack (EPIC #3424 M4-E item 12)', () => {
 		}
 	});
 });
+
+// #3703 / #3708: dashboard / budget の物理名は staging / prod で一意でなければならない。
+// 同一アカウント・同一リージョンに GanbariQuestDsql (本番) と GanbariQuestDsqlStaging が同居するため、
+// 物理名がハードコード同名だと CloudFormation 'already exists' で本番 cutover deploy が fail する
+// (2026-07-13 本番 cutover が 4 回連続 fail した実障害)。nameSuffix 導出 (stack id に 'staging' を
+// 含むか) の guard test。heuristic が壊れる / 削られると本番・staging の名前衝突が再発するため、
+// 実 stack id (deploy workflows が使う 'GanbariQuestDsql' / 'GanbariQuestDsqlStaging') で assert する。
+describe('DsqlStack nameSuffix guard (#3703 / #3708 staging・prod 物理名一意性)', () => {
+	/** stack id で synth し dashboard / budget 物理名を取り出す。 */
+	function physicalNames(stackId: string): { dashboard: string; budget: string } {
+		const app = new cdk.App();
+		const stack = new DsqlStack(app, stackId, { opsEmail: 'ops@example.com' });
+		const template = Template.fromStack(stack);
+		const dashboards = template.findResources('AWS::CloudWatch::Dashboard');
+		const budgets = template.findResources('AWS::Budgets::Budget');
+		const dashboard = Object.values(dashboards)[0]?.Properties?.DashboardName as string;
+		const budget = Object.values(budgets)[0]?.Properties?.Budget?.BudgetName as string;
+		return { dashboard, budget };
+	}
+
+	it('[N1] 本番 stack id (GanbariQuestDsql) は suffix 無しの物理名', () => {
+		const names = physicalNames('GanbariQuestDsql');
+		expect(names.dashboard).toBe('ganbari-quest-dsql');
+		expect(names.budget).toBe('ganbari-quest-dsql-guardrail');
+	});
+
+	it('[N2] staging stack id (GanbariQuestDsqlStaging) は -staging suffix 付き物理名', () => {
+		const names = physicalNames('GanbariQuestDsqlStaging');
+		expect(names.dashboard).toBe('ganbari-quest-dsql-staging');
+		expect(names.budget).toBe('ganbari-quest-dsql-guardrail-staging');
+	});
+
+	it('[N3] 本番と staging の物理名は衝突しない (cutover 4 連続 fail の再発 guard)', () => {
+		const prod = physicalNames('GanbariQuestDsql');
+		const staging = physicalNames('GanbariQuestDsqlStaging');
+		expect(prod.dashboard).not.toBe(staging.dashboard);
+		expect(prod.budget).not.toBe(staging.budget);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

本番 DSQL/PGlite cutover (2026-07-13 完遂) の修正群が main 先行のまま develop 未反映だと、次回 develop→main 統合で cutover 群が silent revert され本番 deploy が再破壊される (dashboard 名衝突再発 / 本番 backend が dynamodb へ silent 回帰し顧客データ split-brain / NUC 記録消失)。本 PR で恒久状態を develop に同期し、命名 guard test + NUC データロールバック防止ガードで顧客の記録を保全する。

## 関連 Issue

refs #3708 (item 1 + item 2) / refs #3424 / refs #3620

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証方法 | 結果 |
|---|---|---|---|
| #3708 item1: main→develop 逆マージ (deploy.yml DSQL lane / deploy-nuc PGlite lane / staging backup / smoke dsql) | 4 ファイルを origin/main から back-merge | `git diff origin/main -- <4 files>` が deploy-nuc の意図的修正を除き 0 | PASS |
| #3708 item2: dsql-stack nameSuffix guard test | `tests/unit/infra/dsql-cdk.test.ts` [N1-N3] 追加 | `npx vitest run tests/unit/infra/dsql-cdk.test.ts` | PASS (11/11) |
| adversarial 検出: deploy-nuc 再deploy データロールバック防止 | cutover step を「pglite dir 既存なら skip」に変更 | workflow diff レビュー + staging は意図挙動 (fresh rehearsal) のため対象外を確認 | PASS |
| #3708 item3: staging Budget 履歴断絶 | 記録のみ (Issue 本文) | コード変更なし | N/A |

## 変更タイプ

- [x] バグ修正 (fix)
- [x] テスト追加 (test)
- [x] インフラ (infra)

## 影響範囲・変更コンポーネント

- `.github/workflows/deploy.yml` — 本番 DSQL lane (backup fail-closed → cluster deploy → schema migrate → dsqlEnabled context → app role grant、#3703 由来 +124行)
- `.github/workflows/deploy-nuc.yml` — PGlite env + 非破壊 cutover step (#3703 由来) + **初回のみガード (本 PR 修正)**
- `.github/workflows/deploy-aws-staging.yml` — staging rehearsal backup step (#3702 由来)
- `tests/e2e/production-smoke.spec.ts` — dataSource 期待値 'dsql' (#3707 由来)
- `tests/unit/infra/dsql-cdk.test.ts` — nameSuffix guard [N1-N3] 追加
- src / アプリ本体への変更なし。UI 変更なし

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/infra/dsql-cdk.test.ts` → 11 passed (11)
- [x] `npx biome check tests/unit/infra/dsql-cdk.test.ts` → clean
- [x] `npx cspell` (CI glob 対象の test 2 files) → Issues 0 (workflow は CI cspell 対象外)
- [x] assertion 弱体化なし (ADR-0006) — 既存 assert は不変、新規 guard test 追加のみ
- [x] deploy-nuc 修正は「削除 → skip」への安全側変更 (データ保全強化)

## スクリーンショット / ビジュアルデモ

UI 変更なし (workflow / infra test のみ) のため対象外。

## コード品質セルフレビュー (#1481)

- [x] back-merge 4 ファイルは main の CI green 実績あり (cutover run 29222693715 fully green)
- [x] nameSuffix guard test は実 stack id (GanbariQuestDsql / GanbariQuestDsqlStaging) で assert し、heuristic 破壊で CI 即 fail
- [x] deploy-nuc ガードは 3 分岐 (pglite 既存 skip / sqlite 不在 fresh / 初回 cutover) を明示しコメントで理由記載

## 横展開・影響波及チェック

- [x] deploy-nuc-staging.yml の同型 step を点検 → staging は使い捨て snapshot からの fresh rehearsal が意図 (dispatch opt-in のみ) のため変更不要と判断
- [x] src 側 hotfix (logger #3700 / import 並列化 #3698) は develop 反映済 (diff 0) を確認
- [x] `scripts/nuc-pglite-cutover.ts` / `dsql:migrate` / `dsql:grant` の develop 存在を確認
- adversarial reviewer residual (accepted): deploy.yml の DynamoDB backup step は table teardown (#3438) 時に hard-fail する — #3438 実施時に backup step の撤去/条件化を同時に行う旨を #3438 へ記録

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。deploy-nuc の cutover step 挙動変更は「再 cutover が手動 opt-in になる」のみ (データ保全側)
- **重要**: main 側の deploy-nuc.yml には未修正の旧 step が残存 (次の src/** main push で NUC データロールバックの危険)。#3713 (priority:critical) で追跡済み。本 PR の main 反映 (統合) が #3713 の解消条件

## 配布済み env / secret (ADR-0006)

新規 env / secret なし (back-merge した workflow が参照する secrets は全て配布済み・本番稼働実績あり)。

## Ready for Review チェックリスト

- [x] 関連 Issue 番号記載 (refs #3708)
- [x] AC 検証マップ 4 列記入
- [x] テスト実行結果記載 (11/11 PASS)
- [x] SS 不要 (UI 変更なし)
- [x] 横展開チェック実施

## QM レビュー結果

<!-- QM が記入 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
