### PR TITLE
test(flake): #3661 heavy-init spec の timeout 設計是正 (dynamic import/CDK synth 初回 5s 超の same-class 4 spec)

### DIFF
--- a/tests/unit/ai-evaluation/stagehand-v3-api-surface.test.ts
+++ b/tests/unit/ai-evaluation/stagehand-v3-api-surface.test.ts
@@ -116,7 +116,13 @@ async function loadAxe(): Promise<AxeRunnerModule> {
 	)) as unknown as AxeRunnerModule;
 }
 
-describe('Stagehand v3 module export surface', () => {
+// #3661: @browserbasehq/stagehand / stagehand-runner.mjs / axe-runner.mjs の dynamic import は
+// 初回 (module cache cold、fresh npm ci 直後の cold FS) や並列 worktree agent 稼働中の高負荷環境で
+// 5s 級の解決時間を要する (実測 7.9s → 再実行 pass の flake)。hooks-integration.test.ts と同型の
+// describe-level timeout で吸収する (assertion 内容は不変、ADR-0061 same-class 対処)。
+const HEAVY_INIT_TIMEOUT = 30_000;
+
+describe('Stagehand v3 module export surface', { timeout: HEAVY_INIT_TIMEOUT }, () => {
 	it('@browserbasehq/stagehand exports Stagehand and V3 (alias) classes', async () => {
 		const sdk = await import('@browserbasehq/stagehand');
 		expect(sdk.Stagehand).toBeDefined();
@@ -137,7 +143,7 @@ describe('Stagehand v3 module export surface', () => {
 	});
 });
 
-describe('Mock Stagehand instance — v3 API surface 整合', () => {
+describe('Mock Stagehand instance — v3 API surface 整合', { timeout: HEAVY_INIT_TIMEOUT }, () => {
 	it('createStagehand({ mock: true }) は context.addCookies / context.activePage を持つ', async () => {
 		const { createStagehand } = await loadModule();
 		const sh = await createStagehand({ baseUrl: 'http://localhost:5180', mock: true });
@@ -199,7 +205,7 @@ describe('Mock Stagehand instance — v3 API surface 整合', () => {
 	});
 });
 
-describe('setChildContext / executeStep — v3 形態で動作', () => {
+describe('setChildContext / executeStep — v3 形態で動作', { timeout: HEAVY_INIT_TIMEOUT }, () => {
 	it('setChildContext は stagehand.context.addCookies 経由で cookie 追加', async () => {
 		const { createStagehand, setChildContext } = await loadModule();
 		const sh = await createStagehand({ baseUrl: 'http://localhost:5180', mock: true });
@@ -261,7 +267,9 @@ describe('setChildContext / executeStep — v3 形態で動作', () => {
 	});
 });
 
-describe('axe-runner — mock mode で realistic 5 violations', () => {
+describe('axe-runner — mock mode で realistic 5 violations', {
+	timeout: HEAVY_INIT_TIMEOUT,
+}, () => {
 	it('runAxeAudit が mock page で 5 件 dummy violations を返す + JSON 出力', async () => {
 		const { runAxeAudit } = await loadAxe();
 		const mockPage = { _mockMode: true };
@@ -329,7 +337,9 @@ describe('axe-runner — mock mode で realistic 5 violations', () => {
 	});
 });
 
-describe('Anti-regression — v2 API patterns must NOT appear in mock', () => {
+describe('Anti-regression — v2 API patterns must NOT appear in mock', {
+	timeout: HEAVY_INIT_TIMEOUT,
+}, () => {
 	it('mock instance は **v2 の stagehand.page プロパティ** を持たない', async () => {
 		const { createStagehand } = await loadModule();
 		const sh = await createStagehand({ baseUrl: 'http://localhost:5180', mock: true });

--- a/tests/unit/ai-evaluation/stagehand-v3-construction.test.ts
+++ b/tests/unit/ai-evaluation/stagehand-v3-construction.test.ts
@@ -16,7 +16,12 @@
 
 import { describe, expect, it } from 'vitest';
 
-describe('Stagehand v3 SDK construction (cost $0、init/Chrome 起動なし)', () => {
+// #3661: @browserbasehq/stagehand の dynamic import (初回 module cache cold) が高負荷環境で
+// vitest 既定 5s を超える (実測 5-8s、--testTimeout=30000 で PASS)。hooks-integration.test.ts と
+// 同型の describe-level timeout で吸収する (assertion 内容は不変、ADR-0061 same-class 対処)。
+describe('Stagehand v3 SDK construction (cost $0、init/Chrome 起動なし)', {
+	timeout: 30_000,
+}, () => {
 	it('new Stagehand({ env: LOCAL, ... }) で instance 構築可能 (v3 V3Options 整合)', async () => {
 		const { Stagehand } = await import('@browserbasehq/stagehand');
 		// 実 init() は呼ばない (Chrome 起動 + ANTHROPIC API call が発生するため)

--- a/tests/unit/infra/dsql-cutover-wiring.test.ts
+++ b/tests/unit/infra/dsql-cutover-wiring.test.ts
@@ -78,7 +78,13 @@ function allPolicyActions(template: Template): string[] {
 	return actions;
 }
 
-describe('compute-stack DSQL cutover 配線 (EPIC #3424 M5 DoD3、flag-gated)', () => {
+// #3661: aws-cdk-lib の初回ロード + 各 test の ComputeStack synth (Template.fromStack) が
+// 高負荷環境で vitest 既定 5s を超える (実測 5-8s、--testTimeout=30000 で PASS)。
+// hooks-integration.test.ts と同型の describe-level timeout で吸収する
+// (assertion 内容は不変、ADR-0061 same-class 対処)。
+describe('compute-stack DSQL cutover 配線 (EPIC #3424 M5 DoD3、flag-gated)', {
+	timeout: 30_000,
+}, () => {
 	it('[W1 prod 不変 guard] dsqlEnabled 無し: DATA_SOURCE=dynamodb 維持 + dsql:* policy ゼロ', () => {
 		const compute = buildCompute();
 		const template = Template.fromStack(compute);

--- a/tests/unit/marketplace/strategies/reward-set-strategy.test.ts
+++ b/tests/unit/marketplace/strategies/reward-set-strategy.test.ts
@@ -280,7 +280,10 @@ describe('rewardSetStrategy.apply', () => {
 // dispatcher integration
 // =====================================================
 
-describe('marketplace dispatcher + reward-set', () => {
+// #3661 same-class: $lib/marketplace 全体の dynamic import (registry eager-load) が
+// cold FS / 高負荷環境で vitest 既定 5s を超える (実測 5.2-5.3s、--testTimeout=30000 で PASS)。
+// stagehand-v3-construction.test.ts と同型の describe-level timeout で吸収する (assertion 内容は不変)。
+describe('marketplace dispatcher + reward-set', { timeout: 30_000 }, () => {
 	it('Registry 経由で reward-set が解決でき、dispatchImport が成立', async () => {
 		// eager-load が走るよう $lib/marketplace import
 		const { marketplaceRegistry, dispatchImport } = await import('../../../../src/lib/marketplace');

--- a/tests/unit/services/cron-idempotency.test.ts
+++ b/tests/unit/services/cron-idempotency.test.ts
@@ -38,7 +38,11 @@ vi.mock('$lib/server/logger', () => ({
 // cleanupExpiredData (retention-cleanup endpoint)
 // ============================================================
 
-describe('#1377 idempotency — cleanupExpiredData', () => {
+// #3661: vi.resetModules() + service graph の dynamic import を毎 test 再実行するため、
+// 高負荷環境 (並列 worktree agent 稼働中) で vitest 既定 5s を超える (実測 5-8s、
+// --testTimeout=30000 で PASS)。hooks-integration.test.ts と同型の describe-level timeout で
+// 吸収する (assertion 内容は不変、ADR-0061 same-class 対処)。
+describe('#1377 idempotency — cleanupExpiredData', { timeout: 30_000 }, () => {
 	const listAllTenantsMock = vi.fn();
 	const findAllChildrenMock = vi.fn();
 	const deleteActivityLogsMock = vi.fn();
@@ -136,7 +140,7 @@ describe('#1377 idempotency — cleanupExpiredData', () => {
 // processTrialNotifications (trial-notifications endpoint)
 // ============================================================
 
-describe('#1377 idempotency — processTrialNotifications', () => {
+describe('#1377 idempotency — processTrialNotifications', { timeout: 30_000 }, () => {
 	beforeEach(() => {
 		vi.resetModules();
 		vi.clearAllMocks();


### PR DESCRIPTION
# test(flake): #3661 heavy-init spec の timeout 設計是正 (same-class 4 spec)

## 顧客価値・目的

`npm run pre-ready` の vitest step が高負荷環境 (並列 worktree agent 稼働中 / fresh npm ci 直後の cold FS) で非決定的に timeout fail し、無関係な PR の Ready 化を阻害する flake を根治する。開発フローの決定性向上 = 顧客への修正 deliver 速度の維持 (テスト決定性、ADR-0005 Bucket A)。

closes #3661

## 関連 Issue

- closes #3661 (stagehand-v3-api-surface dynamic import timeout flake)
- 関連: Issue #3661 コメントの横展開実測 (2026-07-11、同 class 3 spec が `--testTimeout=30000` で PASS / 既定 5s で fail)
- 関連: #2476 (vitest 並列実行 SSOT — default testTimeout 5s 明示 + per-file `vi.setConfig` band-aid 撤去)
- 関連: ADR-0061 (same-class 対処の機械強制)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 該当 test の timeout 調整 or warm 化で、cold 環境 (fresh npm ci 直後) でも決定的に pass | `npx vitest run <5 specs>` 実行 | PASS (Test Files 5 passed / Tests 55 passed、tests 27.5s — CDK esbuild bundling 単発 3.9s 等 heavy-init を実測確認)。describe-level `{ timeout: 30_000 }` で 5s 級遅延を吸収 |
| AC2 | flake の再現条件 (cold FS) をコメントに記録 | 各 spec の describe 直上コメントを目視 | 5 spec すべてに「初回 module cache cold / 高負荷環境で既定 5s 超 (実測値付き)」+ #3661 参照コメントを記載 |

## 変更タイプ

- [x] テスト修正 (flake 是正、timeout 設計)
- [ ] 新機能 / バグ修正 / リファクタリング / ドキュメント / インフラ

## 影響範囲・変更コンポーネント

test のみ 5 file (アプリ本体コード変更なし):

- `tests/unit/ai-evaluation/stagehand-v3-api-surface.test.ts` — 5 describe に `{ timeout: HEAVY_INIT_TIMEOUT }` (30s)
- `tests/unit/ai-evaluation/stagehand-v3-construction.test.ts` — 1 describe に `{ timeout: 30_000 }`
- `tests/unit/infra/dsql-cutover-wiring.test.ts` — 1 describe に `{ timeout: 30_000 }`
- `tests/unit/services/cron-idempotency.test.ts` — 2 describe に `{ timeout: 30_000 }`
- `tests/unit/marketplace/strategies/reward-set-strategy.test.ts` — 1 describe (marketplace dispatcher + reward-set) に `{ timeout: 30_000 }`（`$lib/marketplace` registry eager-load の dynamic import が cold FS / 高負荷で既定 5s 超、実測 5.2-5.3s。same-class 5 例目）

### 採用した対処案と根拠

**(a) describe-level per-suite timeout 明示** を採用 (warmup 分離 (b) / config 全体引上げ (c) は不採用):

1. **repo 内確立パターンに整合**: `tests/unit/services/hooks-integration.test.ts:161` が同一 class (vi.resetModules + dynamic import が並列実行時に既定 5s 不足) に対し `describe('...', { timeout: 30_000 }, ...)` を既に採用済。同型で統一。
2. **(b) beforeAll warmup を不採用の理由**: `cron-idempotency.test.ts` は `vi.resetModules()` を beforeEach で実行するため warmup した module cache が毎 test 破棄され効果がない。`dsql-cutover-wiring.test.ts` は重コストが import ではなく**各 test 内の CDK synth (`Template.fromStack` + esbuild bundling、実測 1 asset 3.9s)** のため warmup で解決しない。Issue コメント実測でも「単独再実行 (= FS cache warm) でも fail、30s で PASS (実所要 5-8s)」= cold import 単独ではなく実行自体が負荷下で 5s 超のため、per-suite timeout が正解。
3. **(c) vitest 全体 testTimeout 引上げを不採用の理由**: `vite.config.ts` #2476 で「default 5s 明示 + per-file `vi.setConfig` band-aid 撤去」を SSOT 化済。全体緩和は他 spec の遅延検出力を落とすため禁止 (指示の禁止事項どおり)。
4. **assertion 弱体化なし (ADR-0006)**: timeout は待ち上限のみで、expect の検証内容・件数は 1 つも変えていない。

### 他の same-class 候補 (報告のみ、本 PR 非対象)

grep (`Template.fromStack|resetModules` in tests/unit) + #2476 経緯コメントより、初回 heavy init を持つが timeout 未設定の候補。現時点で timeout fail 未観測のため変更せず、観測時に本 PR と同パターンを適用する:

- CDK synth 系 (6): `tests/unit/infra/staging-cdk.test.ts` / `multi-lambda-cdk.test.ts` / `dsql-cdk.test.ts` / `static-assets-s3-offload.test.ts` / `health-check-lambda.test.ts` / `cloudwatch-retention.test.ts`
- resetModules + dynamic import 系 (3): `tests/unit/services/analytics-service.test.ts` (#2476 で過去 flake 記録あり) / `cognito-jwt.test.ts` / `admin-bypass-metrics.test.ts`
- 対処済 (参考): `hooks-integration.test.ts` (30s) / `marketplace/strategies/checklist-strategy.test.ts` (15s) / `scripts/nuc-pglite-cutover-cli.test.ts` (120s)

## テスト & 安全装置セルフチェック

- [x] 対象 5 spec 実行: `npx vitest run tests/unit/ai-evaluation/stagehand-v3-api-surface.test.ts tests/unit/ai-evaluation/stagehand-v3-construction.test.ts tests/unit/infra/dsql-cutover-wiring.test.ts tests/unit/services/cron-idempotency.test.ts tests/unit/marketplace/strategies/reward-set-strategy.test.ts` → **Test Files 5 passed / Tests 55 passed** (tests 27.5s)
- [x] `npx biome check <5 files>` → No fixes applied (整形済)
- [x] assertion 弱体化なし (ADR-0006): expect 内容は不変、timeout 上限のみ変更
- [x] カバレッジ閾値変更なし / test.skip 追加なし
- [x] flake 再現確認は負荷依存のため不実施 (Issue 指示どおり)

## スクリーンショット / ビジュアルデモ

該当なし（test のみ）

## コード品質セルフレビュー (#1481)

- [x] 変更は test の timeout オプション + 説明コメントのみ、アプリ本体 / config 変更ゼロ
- [x] repo 既存パターン (`hooks-integration.test.ts` describe-level timeout) と同型で一貫性維持
- [x] マジックナンバー回避: api-surface は複数 describe 共有のため `HEAVY_INIT_TIMEOUT` 定数化、単一 describe の file は直値 30_000 (precedent 同様)
- [x] 各 spec に flake 再現条件 (cold FS / 高負荷 / 実測値) と #3661 / ADR-0061 参照コメントを記録 (AC2)

## 横展開・影響波及チェック

- [x] Issue #3661 コメントの横展開 3 spec (stagehand-v3-construction / dsql-cutover-wiring / cron-idempotency) + 追加観測の reward-set-strategy (same-class 5 例目) を同 PR で全て対処 (ADR-0061 same-class)
- [x] 追加の same-class 候補 9 spec を grep で洗い出し、上記「他の same-class 候補」に列挙 (未観測のため報告のみ)
- [x] 並行実装ペア該当なし (labels / 年齢モード / demo / ナビ / DB スキーマ / チュートリアルいずれも非変更)
- [x] 設計書同期不要 (test timeout 設計は tests/ 局所、SSOT 変更なし)

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。CI 実行時間への影響は「fail 時の待ち上限が 5s → 30s になる」のみで、pass 時の実行時間は不変
- レビュー観点: describe-level 30s の粒度が適切か (per-it 個別指定より diff 小 / hooks-integration precedent 同型)

## 配布済み env / secret (ADR-0006)

該当なし（env / secret 変更なし）

## Ready for Review チェックリスト

N/A（Draft PR — Ready 化は本 PR の scope 外の指示。Ready 化時に `npm run pre-ready -- --pr <num>` 全 step PASS / QA 承認・動作確認 / AC 検証マップ 4 列 / CI 全緑を完遂してから `gh pr ready` する）

## QM レビュー結果

（QM 記入欄）

