### PR TITLE
test: #3692 staging DSQL 実機テストの汚染耐性 + timeout 延長 (実測 684s > 600s)

### DIFF
--- a/tests/integration/db/dsql-staging-import-restore.test.ts
+++ b/tests/integration/db/dsql-staging-import-restore.test.ts
@@ -101,6 +101,6 @@ describe.skipIf(!ENDPOINT)(
 				// staging 原状復帰: tenant scope データ + 子供集約を全削除 (専用 family uuid 隔離)
 				await clearAllFamilyData(TENANT).catch(() => {});
 			}
-		}, 600_000);
+		}, 1_500_000);
 	},
 );

--- a/tests/integration/db/dsql-staging-import-restore.test.ts
+++ b/tests/integration/db/dsql-staging-import-restore.test.ts
@@ -67,6 +67,10 @@ describe.skipIf(!ENDPOINT)(
 			const ledgerEntries: { childRef: string; amount: number }[] = exportData.data.pointLedger;
 			expect(ledgerEntries.length).toBe(772);
 
+			// 前回 run が timeout / kill で finally cleanup 未到達だった場合の残骸を除去する
+			// (専用 tenant を import 前に空へ正規化 — 汚染耐性)。
+			await clearAllFamilyData(TENANT).catch(() => {});
+
 			try {
 				const result = await importFamilyData(exportData, TENANT);
 

--- a/tests/integration/db/dsql-staging-import-restore.test.ts
+++ b/tests/integration/db/dsql-staging-import-restore.test.ts
@@ -69,7 +69,16 @@ describe.skipIf(!ENDPOINT)(
 
 			// 前回 run が timeout / kill で finally cleanup 未到達だった場合の残骸を除去する
 			// (専用 tenant を import 前に空へ正規化 — 汚染耐性)。
-			await clearAllFamilyData(TENANT).catch(() => {});
+			// ⚠️ blast radius 注記: 本 test の書込/削除は全て専用 TENANT uuid にスコープされる
+			// (clearAllFamilyData も family_id 述語)。DSQL_ENDPOINT を誤って本番に向けても他 tenant
+			// には触れないが、本番 DB にテスト tenant を書き込むことになるため endpoint は必ず
+			// staging を指定すること。共有 TENANT のため並行実行 (2 者同時) は不可 — solo 前提
+			// (#3683 CI レーン化時に per-run tenant 分離へ移行)。
+			// catch は「tenant が未作成 = 削除対象なし」の正常系のみを許容し、接続断等の真の障害は
+			// 後段 assert を混乱させる前に観測できるよう warn を出す (#3700 握りつぶし教訓)。
+			await clearAllFamilyData(TENANT).catch((e) => {
+				console.warn('[dsql-staging-import-restore] pre-clean skipped:', String(e));
+			});
 
 			try {
 				const result = await importFamilyData(exportData, TENANT);


### PR DESCRIPTION
## 顧客価値・目的

#3715 (restore OCC 根治) の staging DSQL 実機テストを実運用に耐える形に硬化する。中断 run の残骸で誤 fail する / ローカル実行 (日本 → us-east-1) で timeout する状態だと、実機回帰テストが「たまに赤くなる飾り」になり #3692 再発検出力が落ちる。

## 関連 Issue

refs #3692 #3683

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証方法 | 結果 |
|---|---|---|---|
| 中断 run 残骸への汚染耐性 | import 前に `clearAllFamilyData(TENANT)` で専用 tenant を空へ正規化 | 実 staging cluster で再現→修正を実証 (初回 10 分 kill の残骸 4 children で fail → pre-clean 追加後 PASS) | PASS |
| ローカル実行の timeout 実測整合 | it() timeout 600_000 → 1_500_000 | 実測: 実 staging 貫通 684.11s (>600s)。1_500_000 で完走 PASS | PASS |

## 変更タイプ

- [x] テスト追加・修正 (test)

## 影響範囲・変更コンポーネント

`tests/integration/db/dsql-staging-import-restore.test.ts` のみ (+5/-1)。CI では DSQL_ENDPOINT 未設定 skip のため CI 挙動不変。

## テスト & 安全装置セルフチェック

- [x] **実 staging DSQL cluster で完全 PASS**: `DSQL_ENDPOINT=<staging>.dsql.us-east-1.on.aws npx vitest run tests/integration/db/dsql-staging-import-restore.test.ts --testTimeout=1500000` → Test Files 1 passed / Tests 1 passed (684.11s) (2026-07-15、772 ledger errors ゼロ + 残高 = ledger 合算、684s): 本 PR の 2 変更込みの状態で実機 green を確認済み
- [x] biome clean: `npx biome check tests/integration/db/dsql-staging-import-restore.test.ts` → Checked 1 file. No fixes applied
- [x] cspell clean: `npx cspell tests/integration/db/dsql-staging-import-restore.test.ts` → Issues found: 0
- [x] assertion 変更なし (timeout と pre-clean のみ、検証強度は不変)

## スクリーンショット / ビジュアルデモ

UI 変更なし。

## コード品質セルフレビュー (#1481)

- [x] pre-clean は catch(() => {}) で「tenant が既に空」を許容 (冪等)
- [x] timeout は実測値 (684s) + 余裕で 25 分に設定、理由コメントは commit message に記録

## 横展開・影響波及チェック

- [x] 同型の DSQL_ENDPOINT gate テスト (dsql-staging-concurrency.test.ts) は毎 it 冒頭で専用 family を扱い afterAll 削除 — 同一残骸問題は将来 #3683 CI レーン化時に併せて点検

## レビュー依頼事項・破壊的変更

なし (テストのみ)。

## 配布済み env / secret (ADR-0006)

新規なし。

## Ready for Review チェックリスト

- [x] 関連 Issue 番号記載
- [x] AC 検証マップ 4 列記入
- [x] テスト実行結果記載 (実 staging PASS 684s)
- [x] SS 不要
- [x] 横展開チェック実施

## QM レビュー結果

<!-- QM が記入 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
