### PR TITLE
fix(data-integrity): #3394 restore 冪等 guard の統一 + count 整合 fitness (same-class クラスタ一括根治)

### DIFF
--- a/src/lib/server/db/demo/activity-pref-repo.ts
+++ b/src/lib/server/db/demo/activity-pref-repo.ts
@@ -12,11 +12,12 @@ export async function findAllByChild(
 }
 
 export async function insertForRestore(
-	input: Omit<ChildActivityPreference, 'id'>,
+	_input: Omit<ChildActivityPreference, 'id'>,
 	_tenantId: string,
-): Promise<ChildActivityPreference> {
-	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
-	return { ...input, id: '0' };
+): Promise<ChildActivityPreference | null> {
+	// Stub: demo は書き込み no-op。#3394/#3465: 永続化していないため null を返し
+	// import カウント (activityPrefsImported) を偽装しない (#2263 count 偽装 class)。
+	return null;
 }
 
 export async function findPinnedByChild(

--- a/src/lib/server/db/demo/certificate-repo.ts
+++ b/src/lib/server/db/demo/certificate-repo.ts
@@ -38,11 +38,12 @@ export async function findCertificates(childId: ChildId, tenantId: string): Prom
 }
 
 export async function insertForRestore(
-	input: Omit<Certificate, 'id' | 'tenantId'>,
-	tenantId: string,
+	_input: Omit<Certificate, 'id' | 'tenantId'>,
+	_tenantId: string,
 ): Promise<Certificate | null> {
-	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
-	return { ...input, id: '0', tenantId };
+	// Stub: demo は書き込み no-op。#3394: 永続化していないため null を返し
+	// import カウント (certificatesImported) を偽装しない (#2263 count 偽装 class)。
+	return null;
 }
 
 export async function deleteByTenantId(_tenantId: string): Promise<void> {

--- a/src/lib/server/db/demo/checklist-repo.ts
+++ b/src/lib/server/db/demo/checklist-repo.ts
@@ -281,11 +281,12 @@ export async function findOverridesByChild(
 }
 
 export async function insertOverrideForRestore(
-	input: Omit<ChecklistOverride, 'id'>,
+	_input: Omit<ChecklistOverride, 'id'>,
 	_tenantId: string,
-): Promise<ChecklistOverride> {
-	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
-	return { ...input, id: '0' };
+): Promise<ChecklistOverride | null> {
+	// Stub: demo は書き込み no-op。#3394: 永続化していないため null を返し
+	// import カウント (checklistOverridesImported) を偽装しない (#2263 count 偽装 class)。
+	return null;
 }
 
 export async function insertOverride(

--- a/src/lib/server/db/demo/child-challenge-repo.ts
+++ b/src/lib/server/db/demo/child-challenge-repo.ts
@@ -61,11 +61,12 @@ export async function findById(id: string, _tenantId: string): Promise<ChildChal
 }
 
 export async function insertForRestore(
-	input: Omit<ChildChallenge, 'id'>,
+	_input: Omit<ChildChallenge, 'id'>,
 	_tenantId: string,
-): Promise<ChildChallenge> {
-	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
-	return { ...input, id: '0' };
+): Promise<ChildChallenge | null> {
+	// Stub: demo は書き込み no-op。#3394: 永続化していないため null を返し
+	// import カウント (childChallengesImported) を偽装しない (#2263 count 偽装 class)。
+	return null;
 }
 
 export async function insert(

--- a/src/lib/server/db/demo/message-repo.ts
+++ b/src/lib/server/db/demo/message-repo.ts
@@ -5,11 +5,12 @@ import type { ChildId } from '$lib/domain/ids';
 import type { InsertParentMessageInput, ParentMessage } from '../types';
 
 export async function insertForRestore(
-	input: Omit<ParentMessage, 'id'>,
+	_input: Omit<ParentMessage, 'id'>,
 	_tenantId: string,
-): Promise<ParentMessage> {
-	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
-	return { ...input, id: '0' };
+): Promise<ParentMessage | null> {
+	// Stub: demo は書き込み no-op。#3394/#3420: 永続化していないため null を返し
+	// import カウント (parentMessagesImported) を偽装しない (#2263 count 偽装 class)。
+	return null;
 }
 
 export async function insertMessage(

--- a/src/lib/server/db/demo/reward-redemption-repo.ts
+++ b/src/lib/server/db/demo/reward-redemption-repo.ts
@@ -26,7 +26,7 @@ export async function insertRedemptionRequest(
 }
 
 export async function insertRedemptionForRestore(
-	input: {
+	_input: {
 		childId: ChildId;
 		rewardId: string;
 		requestedAt: number;
@@ -40,19 +40,10 @@ export async function insertRedemptionForRestore(
 		rewardIcon: string | null;
 	},
 	_tenantId: string,
-): Promise<RedemptionRequestRow> {
-	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
-	return {
-		id: '0',
-		childId: input.childId,
-		rewardId: input.rewardId,
-		requestedAt: input.requestedAt,
-		status: input.status,
-		parentNote: input.parentNote,
-		resolvedAt: input.resolvedAt,
-		resolvedByParentId: input.resolvedByParentId,
-		shownToChildAt: input.shownToChildAt,
-	};
+): Promise<RedemptionRequestRow | null> {
+	// Stub: demo は書き込み no-op。#3394: 永続化していないため null を返し
+	// import カウント (rewardRedemptionsImported) を偽装しない (#2263 count 偽装 class)。
+	return null;
 }
 
 export async function findRedemptionRequestsByChild(

--- a/src/lib/server/db/demo/sibling-cheer-repo.ts
+++ b/src/lib/server/db/demo/sibling-cheer-repo.ts
@@ -26,11 +26,12 @@ export async function findAllByTenant(tenantId: string): Promise<SiblingCheer[]>
 }
 
 export async function insertForRestore(
-	input: Omit<SiblingCheer, 'id' | 'tenantId'>,
-	tenantId: string,
-): Promise<SiblingCheer> {
-	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
-	return { ...input, id: '0', tenantId };
+	_input: Omit<SiblingCheer, 'id' | 'tenantId'>,
+	_tenantId: string,
+): Promise<SiblingCheer | null> {
+	// Stub: demo は書き込み no-op。#3420: 永続化していないため null を返し
+	// import カウント (siblingCheersImported) を偽装しない (#2263 count 偽装 class)。
+	return null;
 }
 
 export async function findUnshownCheers(

--- a/src/lib/server/db/demo/stamp-card-repo.ts
+++ b/src/lib/server/db/demo/stamp-card-repo.ts
@@ -96,11 +96,12 @@ export async function findEntriesByCardId(
 }
 
 export async function insertCardForRestore(
-	input: Omit<StampCard, 'id'>,
+	_input: Omit<StampCard, 'id'>,
 	_tenantId: string,
-): Promise<StampCard> {
-	// Stub: demo は書き込み no-op。引数の状態を反映した row を返す。
-	return { ...input, id: '0' };
+): Promise<StampCard | null> {
+	// Stub: demo は書き込み no-op。#3394: 永続化していないため null を返し
+	// import カウント (stampCardsImported) を偽装しない (#2263 count 偽装 class)。
+	return null;
 }
 
 export async function insertEntryForRestore(
@@ -113,8 +114,9 @@ export async function insertEntryForRestore(
 		earnedAt: string;
 	},
 	_tenantId: string,
-): Promise<void> {
-	// Stub: no-op
+): Promise<boolean> {
+	// Stub: demo は書き込み no-op。#3394: false を返し stampEntriesImported を偽装しない。
+	return false;
 }
 
 export async function updateCardStatus(

--- a/src/lib/server/db/demo/voice-repo.ts
+++ b/src/lib/server/db/demo/voice-repo.ts
@@ -41,9 +41,10 @@ export async function findAllByChild(
 export async function insertForRestore(
 	_voice: Omit<ChildCustomVoice, 'id'>,
 	_tenantId: string,
-): Promise<{ id: string }> {
-	// Stub: return dummy id
-	return { id: '0' };
+): Promise<{ id: string } | null> {
+	// Stub: demo は書き込み no-op。#3394: 永続化していないため null を返し
+	// import カウント (childVoicesImported) を偽装しない (#2263 count 偽装 class)。
+	return null;
 }
 
 export async function setActive(

--- a/src/lib/server/db/dsql/activity-pref-repo.ts
+++ b/src/lib/server/db/dsql/activity-pref-repo.ts
@@ -69,15 +69,20 @@ export function createDsqlActivityPrefRepo<TTx extends SqlExecutor>(
 
 		async insertForRestore(input, tenantId) {
 			// #3329: isPinned/pinOrder/日時を verbatim 書き戻す (togglePin の再採番を経由しない)。
-			// 複合 PK 重複は 23505 throw のまま呼び出し側契約 (restore 先は新規 child 前提)。
+			// #3394/#3465 統一冪等契約: 同 (child, activity) 既存 (自然複合 PK 衝突) は DO NOTHING で
+			// skip し null を返す (sqlite idx_child_activity_prefs_unique / dynamodb
+			// attribute_not_exists と機能等価。旧実装の 23505 throw は「重複 = errors 行き」で
+			// backend 間の count 非対称を生んでいた)。
 			const result = await db.execute(sql`
 				INSERT INTO child_activity_preferences
 					(family_id, child_id, activity_id, is_pinned, pin_order, created_at, updated_at)
 				VALUES (${tenantId}, ${input.childId}, ${input.activityId}, ${input.isPinned !== 0},
 					${input.pinOrder}, ${input.createdAt}, ${input.updatedAt})
+				ON CONFLICT (family_id, child_id, activity_id) DO NOTHING
 				RETURNING ${PREF_COLUMNS}
 			`);
-			return toPref(result.rows[0] as unknown as PrefRow);
+			const row = result.rows[0] as unknown as PrefRow | undefined;
+			return row ? toPref(row) : null;
 		},
 
 		async findPinnedByChild(childId, tenantId) {

--- a/src/lib/server/db/dsql/child-challenge-repo.ts
+++ b/src/lib/server/db/dsql/child-challenge-repo.ts
@@ -96,12 +96,6 @@ function toChallenge(row: ChallengeRow): ChildChallenge {
 	};
 }
 
-function firstRowOrThrow(rows: unknown[], context: string): ChallengeRow {
-	const row = rows[0] as ChallengeRow | undefined;
-	if (!row) throw new Error(`${context}: insert returned no row`);
-	return row;
-}
-
 /**
  * DSQL 用 IChildChallengeRepo を生成する (db/runner は注入、fitness#8)。
  * runner は claimRewardAndGrantPoints (#3284/#3342: 条件付き flip + ledger insert +
@@ -194,6 +188,10 @@ export function createDsqlChildChallengeRepo<TTx extends SqlExecutor>(
 
 		async insertForRestore(input, tenantId) {
 			// #3329: 進捗 / 完了 / 請求 / status / 日時を export 値のまま書き戻す (id のみ新規採番)。
+			// #3387/#3394 統一冪等契約: auto:weekly 行の (child, start_date) 重複 (weekly_auto_guard
+			// UNIQUE 衝突) は DO NOTHING で skip し null を返す (sqlite 部分 unique index /
+			// dynamodb AUTO# SK + attribute_not_exists と機能等価。regular 行は guard 列が NULL の
+			// ため衝突せず常に insert される)。
 			const result = await db.execute(sql`
 				INSERT INTO child_challenges
 					(family_id, child_id, title, description, challenge_type, period_type,
@@ -207,9 +205,11 @@ export function createDsqlChildChallengeRepo<TTx extends SqlExecutor>(
 					${input.targetValue}, ${input.completed === 1}, ${input.completedAt},
 					${input.rewardClaimed === 1}, ${input.rewardClaimedAt},
 					${input.createdAt}, ${input.updatedAt})
+				ON CONFLICT DO NOTHING
 				RETURNING ${CHALLENGE_COLUMNS}
 			`);
-			return toChallenge(firstRowOrThrow(result.rows, 'insertForRestore'));
+			const row = result.rows[0] as unknown as ChallengeRow | undefined;
+			return row ? toChallenge(row) : null;
 		},
 
 		async getOrCreateWeeklyAuto(input, tenantId) {

--- a/src/lib/server/db/dsql/stamp-card-repo.ts
+++ b/src/lib/server/db/dsql/stamp-card-repo.ts
@@ -187,6 +187,9 @@ export function createDsqlStampCardRepo<TTx extends SqlExecutor>(
 		async insertCardForRestore(input, tenantId) {
 			// #3329 backup restore: status / redeemed / 日時を verbatim 保全 (insertCard と違い
 			// default に落とさない)。card_id は新規採番 (schema default gen_random_uuid())。
+			// #3394 統一冪等契約: 同 (child, week_start) 既存 (stamp_cards_week_uq 衝突) は
+			// DO NOTHING で skip し null を返す (sqlite onConflictDoNothing / dynamodb
+			// attribute_not_exists と機能等価)。
 			const result = await db.execute(sql`
 				INSERT INTO stamp_cards
 					(family_id, child_id, week_start, week_end, status, redeemed_points, redeemed_at,
@@ -194,17 +197,19 @@ export function createDsqlStampCardRepo<TTx extends SqlExecutor>(
 				VALUES (${tenantId}, ${input.childId}, ${input.weekStart}, ${input.weekEnd},
 					${input.status}, ${input.redeemedPoints}, ${input.redeemedAt},
 					${input.createdAt}::timestamptz, ${input.updatedAt}::timestamptz)
+				ON CONFLICT (family_id, child_id, week_start) DO NOTHING
 				RETURNING ${CARD_COLUMNS}
 			`);
 			const row = result.rows[0] as unknown as CardRow | undefined;
-			if (!row) throw new Error('insertCardForRestore: insert returned no row');
-			return toCard(row);
+			return row ? toCard(row) : null;
 		},
 
 		async insertEntryForRestore(input, tenantId) {
 			// restore 経路も #3562 ③ の tenant 境界 (INSERT ... SELECT 所有検証) を通す。
 			// earned_at は verbatim 保全。重複は DO NOTHING (sqlite parity)。
-			await db.execute(sql`
+			// #3394 統一冪等契約: 実 insert 行有無を RETURNING で判定し boolean を返す
+			// (重複 skip / card 非所有 (orphan) は false → import 側 skip 計上 = count 偽装防止)。
+			const result = await db.execute(sql`
 				INSERT INTO stamp_entries
 					(family_id, card_id, slot, stamp_master_id, omikuji_rank, login_date, earned_at)
 				SELECT c.family_id, c.card_id, ${input.slot}, ${input.stampMasterId},
@@ -212,7 +217,9 @@ export function createDsqlStampCardRepo<TTx extends SqlExecutor>(
 				FROM stamp_cards c
 				WHERE c.family_id = ${tenantId} AND c.card_id = ${input.cardId}
 				ON CONFLICT DO NOTHING
+				RETURNING 1 AS inserted
 			`);
+			return result.rows.length > 0;
 		},
 
 		async updateCardStatus(childId, cardId, input, tenantId) {

--- a/src/lib/server/db/dynamodb/activity-pref-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-pref-repo.ts
@@ -79,11 +79,16 @@ export async function findAllByChild(
 		.sort((a, b) => (a.pinOrder ?? 999) - (b.pinOrder ?? 999));
 }
 
-/** #3329 backup restore 用: isPinned/pinOrder/日時を保全して復元する (childId/activityId 解決済)。 */
+/**
+ * #3329 backup restore 用: isPinned/pinOrder/日時を保全して復元する (childId/activityId 解決済)。
+ * #3394/#3465 統一冪等契約: 同 (childId, activityId) の既存 item を attribute_not_exists(PK) で
+ * silent 上書きしない (SQLite idx_child_activity_prefs_unique と機能等価)。重複は null を返し
+ * (import 側 skip 計上 = count 水増し防止)、その他の失敗は throw する (#3401 例外分類)。
+ */
 export async function insertForRestore(
 	input: Omit<ChildActivityPreference, 'id'>,
 	tenantId: string,
-): Promise<ChildActivityPreference> {
+): Promise<ChildActivityPreference | null> {
 	const key = activityPrefKey(Number(input.childId), Number(input.activityId), tenantId);
 	// activityPref の partition key は (childId, activityId) 複合。id は非キー属性のため
 	// togglePin と同様に Date.now() 由来の一意値を採番する (元 id は保全しない)。
@@ -98,7 +103,18 @@ export async function insertForRestore(
 		createdAt: input.createdAt,
 		updatedAt: input.updatedAt,
 	};
-	await getDocClient().send(new PutCommand({ TableName: TABLE_NAME, Item: item }));
+	try {
+		await getDocClient().send(
+			new PutCommand({
+				TableName: TABLE_NAME,
+				Item: item,
+				ConditionExpression: 'attribute_not_exists(PK)',
+			}),
+		);
+	} catch (e) {
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return null;
+		throw e;
+	}
 	return toChildActivityPreference(item);
 }
 

--- a/src/lib/server/db/dynamodb/certificate-repo.ts
+++ b/src/lib/server/db/dynamodb/certificate-repo.ts
@@ -173,8 +173,11 @@ export async function insertForRestore(
 			}),
 		);
 	} catch (e) {
+		// #3401 例外分類: 重複 (ConditionalCheckFailedException) のみ null = skip。
+		// throttle / network 等の真の write 失敗を null に握り潰すと import が「重複 skip」と
+		// 誤分類し silent loss になるため throw する (import 側 catch が errors に可視化)。
 		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return null;
-		return null;
+		throw e;
 	}
 
 	return certificate;

--- a/src/lib/server/db/dynamodb/child-challenge-repo.ts
+++ b/src/lib/server/db/dynamodb/child-challenge-repo.ts
@@ -224,7 +224,7 @@ export async function insert(
 export async function insertForRestore(
 	input: Omit<ChildChallenge, 'id'>,
 	tenantId: string,
-): Promise<ChildChallenge> {
+): Promise<ChildChallenge | null> {
 	const id = await nextId(ENTITY_NAMES.childChallenge, tenantId);
 	const challenge: ChildChallenge = { ...input, id: String(id) };
 
@@ -233,18 +233,29 @@ export async function insertForRestore(
 			? childChallengeAutoWeeklyKey(Number(input.childId), input.startDate, tenantId)
 			: childChallengeKey(Number(input.childId), id, tenantId);
 
-	await getDocClient().send(
-		new PutCommand({
-			TableName: TABLE_NAME,
-			Item: {
-				...key,
-				...challenge,
-				// stored attributes は数値 id のまま (storage format 不変、#3575)
-				id,
-				childId: Number(input.childId),
-			},
-		}),
-	);
+	try {
+		await getDocClient().send(
+			new PutCommand({
+				TableName: TABLE_NAME,
+				Item: {
+					...key,
+					...challenge,
+					// stored attributes は数値 id のまま (storage format 不変、#3575)
+					id,
+					childId: Number(input.childId),
+				},
+				// #3387/#3394 統一冪等契約: 同キー既存行を silent 上書き (last-writer-wins) しない。
+				// auto:weekly は SQLite 部分 unique index idx_child_challenges_auto_weekly_unique と
+				// 機能等価の重複拒否になる。regular 行は新規採番 id キーのため通常衝突しない
+				// (counter 破損時の上書きも防ぐ defense in depth)。
+				ConditionExpression: 'attribute_not_exists(PK)',
+			}),
+		);
+	} catch (e) {
+		// 重複は null (import 側 skip 計上)。throttle 等その他の失敗は throw (#3401 例外分類)。
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return null;
+		throw e;
+	}
 
 	return challenge;
 }

--- a/src/lib/server/db/dynamodb/stamp-card-repo.ts
+++ b/src/lib/server/db/dynamodb/stamp-card-repo.ts
@@ -209,27 +209,44 @@ export async function findEntriesByCardId(
 // insertCardForRestore / insertEntryForRestore — backup restore 用 (#3329、全フィールド保全)
 // ============================================================
 
+/**
+ * #3391/#3394 統一冪等契約: SK=STMPCARD#<weekStart> への Put に attribute_not_exists(PK) を付け、
+ * 同 (childId, weekStart) の既存 card を silent 上書きしない (SQLite uniqueIndex
+ * idx_stamp_cards_child_week と機能等価)。重複は null を返し (import 側 skip 計上)、
+ * throttle 等その他の失敗は throw する (#3401 例外分類、silent loss 禁止)。
+ */
 export async function insertCardForRestore(
 	input: Omit<StampCard, 'id'>,
 	tenantId: string,
-): Promise<StampCard> {
+): Promise<StampCard | null> {
 	const id = await nextId(ENTITY_NAMES.stampCard, tenantId);
 	const card: StampCard = { ...input, id: String(id) };
-	await getDocClient().send(
-		new PutCommand({
-			TableName: TABLE_NAME,
-			Item: {
-				...stampCardKey(Number(input.childId), input.weekStart, tenantId),
-				...card,
-				// stored attributes は数値 id のまま (storage format 不変、#3575)
-				id,
-				childId: Number(input.childId),
-			},
-		}),
-	);
+	try {
+		await getDocClient().send(
+			new PutCommand({
+				TableName: TABLE_NAME,
+				Item: {
+					...stampCardKey(Number(input.childId), input.weekStart, tenantId),
+					...card,
+					// stored attributes は数値 id のまま (storage format 不変、#3575)
+					id,
+					childId: Number(input.childId),
+				},
+				// SQLite uniqueIndex(child_id, week_start) 等価: 既存 (child, week) を上書きしない。
+				ConditionExpression: 'attribute_not_exists(PK)',
+			}),
+		);
+	} catch (e) {
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return null;
+		throw e;
+	}
 	return card;
 }
 
+/**
+ * #3394 統一冪等契約: 実 insert したら true / 重複 (同 (cardId, slot)) skip は false を返す
+ * (import は true のときのみ imported++ = count 偽装防止 #2263 class)。その他の失敗は throw (#3401)。
+ */
 export async function insertEntryForRestore(
 	input: {
 		cardId: string;
@@ -240,7 +257,7 @@ export async function insertEntryForRestore(
 		earnedAt: string;
 	},
 	tenantId: string,
-): Promise<void> {
+): Promise<boolean> {
 	try {
 		await getDocClient().send(
 			new PutCommand({
@@ -257,8 +274,9 @@ export async function insertEntryForRestore(
 				ConditionExpression: 'attribute_not_exists(PK)',
 			}),
 		);
+		return true;
 	} catch (e) {
-		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return;
+		if (e instanceof Error && e.name === 'ConditionalCheckFailedException') return false;
 		throw e;
 	}
 }

--- a/src/lib/server/db/interfaces/activity-pref-repo.interface.ts
+++ b/src/lib/server/db/interfaces/activity-pref-repo.interface.ts
@@ -10,11 +10,15 @@ export interface IActivityPrefRepo {
 	 * togglePin は pinOrder を MAX+1 で再採番し日時を now にするため round-trip でピン順・日時が
 	 * 失われる。本メソッドは export された値をそのまま書き戻す (id は新規採番、childId/activityId は
 	 * 呼び出し側が import 後の child/childActivity に解決済)。
+	 *
+	 * #3394/#3465 統一冪等契約: 同 (childId, activityId) が既存なら **null** を返す (重複 skip。
+	 * SQLite=idx_child_activity_prefs_unique / DynamoDB=attribute_not_exists / DSQL=自然複合 PK で
+	 * 機能等価)。その他の write 失敗は throw する (#3401)。
 	 */
 	insertForRestore(
 		input: Omit<ChildActivityPreference, 'id'>,
 		tenantId: string,
-	): Promise<ChildActivityPreference>;
+	): Promise<ChildActivityPreference | null>;
 
 	findPinnedByChild(childId: ChildId, tenantId: string): Promise<ChildActivityPreference[]>;
 	togglePin(

--- a/src/lib/server/db/interfaces/checklist-repo.interface.ts
+++ b/src/lib/server/db/interfaces/checklist-repo.interface.ts
@@ -135,11 +135,14 @@ export interface IChecklistRepo {
 	 * #3329 backup restore 用: createdAt を保全して日次 override を復元する。
 	 * insertOverride は createdAt を schema default (now) で発番するため round-trip で作成日時が
 	 * 失われる。本メソッドは export された値をそのまま書き戻す (id は新規採番、childId は解決済)。
+	 *
+	 * #3394 統一冪等契約: 永続化しなかった場合 (demo no-op stub) は **null** を返し、
+	 * import カウント (checklistOverridesImported) を偽装しない (#2263 count 偽装 class)。
 	 */
 	insertOverrideForRestore(
 		input: Omit<ChecklistOverride, 'id'>,
 		tenantId: string,
-	): Promise<ChecklistOverride>;
+	): Promise<ChecklistOverride | null>;
 	/**
 	 * #2845 B1: childId 必須 (composite key)。旧 id-only は DynamoDB 側で
 	 * tenant 無束縛 Scan + 全 tenant delete 可能形状だった。

--- a/src/lib/server/db/interfaces/child-challenge-repo.interface.ts
+++ b/src/lib/server/db/interfaces/child-challenge-repo.interface.ts
@@ -49,8 +49,16 @@ export interface IChildChallengeRepo {
 	 * 通常の insert は currentValue / completed / rewardClaimed / createdAt を初期化するため round-trip で
 	 * 進捗・完了・請求状態が失われる。本メソッドは export された値をそのまま書き戻す (id は新規採番、
 	 * childId は呼び出し側が import 後の child に解決済)。
+	 *
+	 * #3387/#3394 統一冪等契約: auto:weekly 行 (sourceTemplateId='auto:weekly') の
+	 * (childId, startDate) が既存なら **null** を返す (重複 skip。SQLite=部分 unique index /
+	 * DynamoDB=AUTO# 決定的 SK + attribute_not_exists / DSQL=weekly_auto_guard UNIQUE で機能等価)。
+	 * その他の write 失敗は throw する (throttle silent loss 禁止、#3401)。
 	 */
-	insertForRestore(input: Omit<ChildChallenge, 'id'>, tenantId: string): Promise<ChildChallenge>;
+	insertForRestore(
+		input: Omit<ChildChallenge, 'id'>,
+		tenantId: string,
+	): Promise<ChildChallenge | null>;
 
 	/**
 	 * #3245: アプリ週次自動生成 (sourceTemplateId='auto:weekly') の **atomic** get-or-create。

--- a/src/lib/server/db/interfaces/message-repo.interface.ts
+++ b/src/lib/server/db/interfaces/message-repo.interface.ts
@@ -9,8 +9,16 @@ export interface IMessageRepo {
 	 * insertMessage は sentAt を schema default (now) で発番し shownAt を null 固定するため round-trip で
 	 * 送信日時・既読状態が失われる。本メソッドは export された値をそのまま書き戻す (id は新規採番、
 	 * childId は呼び出し側が解決済)。
+	 *
+	 * #3394/#3414 統一冪等契約: 永続化しなかった場合 (demo no-op stub) は **null** を返し、
+	 * import カウントを偽装しない (#2263 class)。id-addressable append のため DB 自然キーは
+	 * 持たず、同一 backup 再取込の重複は import-service の content dedup (merge mode) が防ぐ。
+	 * write 失敗は throw する (#3401)。
 	 */
-	insertForRestore(input: Omit<ParentMessage, 'id'>, tenantId: string): Promise<ParentMessage>;
+	insertForRestore(
+		input: Omit<ParentMessage, 'id'>,
+		tenantId: string,
+	): Promise<ParentMessage | null>;
 
 	findMessages(childId: ChildId, limit: number, tenantId: string): Promise<ParentMessage[]>;
 	findUnshownMessage(childId: ChildId, tenantId: string): Promise<ParentMessage | undefined>;

--- a/src/lib/server/db/interfaces/reward-redemption-repo.interface.ts
+++ b/src/lib/server/db/interfaces/reward-redemption-repo.interface.ts
@@ -57,6 +57,9 @@ export interface IRewardRedemptionRepo {
 	 * 復元する。通常の insertRedemptionRequest は status を pending 固定 + live reward を引くため
 	 * round-trip で承認済/却下/snapshot が失われる。本メソッドは export された値をそのまま書き戻す。
 	 * id は新規採番 (元 id は保全しない、FK は呼び出し側が解決済の rewardId を渡す)。
+	 *
+	 * #3394 統一冪等契約: 永続化しなかった場合 (demo no-op stub) は **null** を返し、
+	 * import カウント (rewardRedemptionsImported) を偽装しない (#2263 count 偽装 class)。
 	 */
 	insertRedemptionForRestore(
 		input: {
@@ -73,7 +76,7 @@ export interface IRewardRedemptionRepo {
 			rewardIcon: string | null;
 		},
 		tenantId: string,
-	): Promise<RedemptionRequestRow>;
+	): Promise<RedemptionRequestRow | null>;
 
 	findRedemptionRequestsByChild(
 		childId: ChildId,

--- a/src/lib/server/db/interfaces/sibling-cheer-repo.interface.ts
+++ b/src/lib/server/db/interfaces/sibling-cheer-repo.interface.ts
@@ -12,11 +12,16 @@ export interface ISiblingCheerRepo {
 	 * insertCheer は sentAt を schema default (now) で発番し shownAt を null 固定するため round-trip で
 	 * 送信日時・既読状態が失われる。本メソッドは export された値をそのまま書き戻す (id は新規採番、
 	 * from/to childId は呼び出し側が解決済)。
+	 *
+	 * #3394/#3420 統一冪等契約: 永続化しなかった場合 (demo no-op stub) は **null** を返し、
+	 * import カウントを偽装しない (#2263 class)。id-addressable append のため DB 自然キーは
+	 * 持たず、同一 backup 再取込の重複は import-service の content dedup (merge mode) が防ぐ。
+	 * write 失敗は throw する (#3401)。
 	 */
 	insertForRestore(
 		input: Omit<SiblingCheer, 'id' | 'tenantId'>,
 		tenantId: string,
-	): Promise<SiblingCheer>;
+	): Promise<SiblingCheer | null>;
 
 	findUnshownCheers(toChildId: ChildId, tenantId: string): Promise<SiblingCheer[]>;
 	markShown(cheerIds: string[], tenantId: string): Promise<void>;

--- a/src/lib/server/db/interfaces/stamp-card-repo.interface.ts
+++ b/src/lib/server/db/interfaces/stamp-card-repo.interface.ts
@@ -40,10 +40,19 @@ export interface IStampCardRepo {
 	 * #3329 backup restore 用: status / redeemedPoints / redeemedAt / 日時を保全して card を復元する。
 	 * insertCard は status 既定化 + redeemed/日時を保持しないため round-trip で交換済状態が失われる。
 	 * id は新規採番、childId は呼び出し側が解決済。
+	 *
+	 * #3394 統一冪等契約: 同 (childId, weekStart) が既存なら **null** を返す (重複 skip。
+	 * SQLite=uniqueIndex / DynamoDB=attribute_not_exists / DSQL=stamp_cards_week_uq で機能等価)。
+	 * その他の write 失敗は throw する (throttle silent loss 禁止、#3401)。
 	 */
-	insertCardForRestore(input: Omit<StampCard, 'id'>, tenantId: string): Promise<StampCard>;
+	insertCardForRestore(input: Omit<StampCard, 'id'>, tenantId: string): Promise<StampCard | null>;
 
-	/** #3329 backup restore 用: earnedAt を保全して押印を復元する (cardId は復元後の card を指す)。 */
+	/**
+	 * #3329 backup restore 用: earnedAt を保全して押印を復元する (cardId は復元後の card を指す)。
+	 * #3394 統一冪等契約: 実際に insert したら true / 重複 ((cardId,slot) or (cardId,loginDate)) で
+	 * skip したら false を返す (import カウントは true のときのみ加算 = count 偽装防止 #2263 class)。
+	 * その他の write 失敗は throw する (#3401)。
+	 */
 	insertEntryForRestore(
 		input: {
 			cardId: string;
@@ -54,7 +63,7 @@ export interface IStampCardRepo {
 			earnedAt: string;
 		},
 		tenantId: string,
-	): Promise<void>;
+	): Promise<boolean>;
 	/**
 	 * #2845 課題①: full composite-key addressing。childId + cardId の複合キーで対象を
 	 * 特定し、repo 入口で child 所有権を構造的に検証する。不一致なら no-op。

--- a/src/lib/server/db/interfaces/voice-repo.interface.ts
+++ b/src/lib/server/db/interfaces/voice-repo.interface.ts
@@ -19,8 +19,14 @@ export interface IVoiceRepo {
 	 * insert は createdAt を now で発番するため round-trip で作成日時が失われる。本メソッドは
 	 * 呼び出し側が新 tenant+childId へ remap 済の filePath/publicUrl をそのまま書き戻す
 	 * (音声ファイル本体は #3077 importStaticFiles が voices/<newChildId>/ へ復元済)。id は新規採番。
+	 *
+	 * #3394 統一冪等契約: 永続化しなかった場合 (demo no-op stub) は **null** を返し、
+	 * import カウント (childVoicesImported) を偽装しない (#2263 count 偽装 class)。
 	 */
-	insertForRestore(voice: Omit<ChildCustomVoice, 'id'>, tenantId: string): Promise<{ id: string }>;
+	insertForRestore(
+		voice: Omit<ChildCustomVoice, 'id'>,
+		tenantId: string,
+	): Promise<{ id: string } | null>;
 
 	setActive(id: string, childId: ChildId, scene: string, tenantId: string): Promise<void>;
 	deleteById(id: string, tenantId: string): Promise<void>;

--- a/src/lib/server/db/restore-idempotency.ts
+++ b/src/lib/server/db/restore-idempotency.ts
@@ -1,0 +1,241 @@
+// src/lib/server/db/restore-idempotency.ts
+// #3394: backup restore の insertForRestore 冪等 guard 分類 SSOT (same-class #3385/#3391/#3387/#3401)。
+//
+// 背景: DynamoDB insertForRestore が SQLite unique index 相当の衝突防御を欠く同型欠陥が
+// 連続発生した (#3385 challenge auto:weekly / #3391 stampcard)。個別パッチでは同 class の
+// 新規 entity 追加時に再発するため、本 registry で「restore 冪等性の種別」と「backend ごとの
+// guard 実装方式」を宣言し、fitness function (tests/unit/db/restore-idempotency-registry.test.ts)
+// が以下を機械検証する (ADR-0061 same-class → guard):
+//   1. no-silent-gap: 各 backend repo の `*ForRestore` 関数は全て本 registry に分類されている
+//   2. guard 対称性: kind='natural-key' の entity は宣言された backend guard (ConditionExpression /
+//      ON CONFLICT / onConflictDoNothing) がソース上に存在する
+//   3. demo stub は null / false を返し import カウントを偽装しない (#3420 count 偽装 #2263 class)
+//
+// 統一契約 (機能等価契約、#3394 / #3401):
+//   - natural-key 重複 → `null` (card/challenge/pref/cert) または `false` (entry) を返す =
+//     import 側は skipped++ (imported に加算しない = count 偽装防止)
+//   - その他の write 失敗 (throttle / network / FK) → **throw** (silent loss 禁止、#3401 例外分類)。
+//     import 側 catch が skipped++ + errors.push で可視化する
+//   - content-dedup (DB 自然キーなし) は import-service 層が merge mode で content key dedup する
+//     (verbatim mode = cutover は bypass、#3653 semantics)
+
+/**
+ * restore 冪等性の種別。
+ * - `natural-key`   : DB レベルの自然キー (unique index / 決定的 key + 条件付き書込) で重複を
+ *                     物理拒否する。重複時は null / false を返す (throw しない)。
+ * - `content-dedup` : DB 自然キーが存在しない (id-addressable append)。import-service が
+ *                     merge mode で content key (既存行 + 同一 import 内) を dedup する。
+ * - `append`        : dedup なしの append (再取込で複製され得る既知の制約)。理由を reason に明記。
+ */
+export type RestoreIdempotencyKind = 'natural-key' | 'content-dedup' | 'append';
+
+/** backend ごとの guard 実装方式 (fitness function がソース上のマーカーを照合する)。 */
+export type RestoreGuardImpl =
+	/** DynamoDB: PutCommand + ConditionExpression 'attribute_not_exists(PK)' */
+	| 'condition-expression'
+	/** drizzle sqlite: .onConflictDoNothing() + returning/changes 判定 */
+	| 'on-conflict-do-nothing'
+	/** DSQL raw SQL: ON CONFLICT ... DO NOTHING + RETURNING 行有無判定 */
+	| 'on-conflict-sql'
+	/** DB 制約なし (dsql certificates 等)。import-service 層の dedup が唯一の防御 */
+	| 'service-layer'
+	/** demo: 書き込み no-op stub。null / false を返し count を偽装しない */
+	| 'null-stub'
+	/** guard 不要 (append / content-dedup で service 層が担う) */
+	| 'none';
+
+export interface RestoreIdempotencyEntry {
+	kind: RestoreIdempotencyKind;
+	/** repo ファイル basename (拡張子なし)。全 backend で同名。 */
+	repoFile: string;
+	/** 当該 entity の restore 関数名 (exported)。 */
+	functionNames: string[];
+	/** natural-key のとき: キーの人間可読表現 */
+	naturalKey?: string;
+	/** content-dedup のとき: import-service が使う content key の表現 */
+	contentKey?: string;
+	/** backend ごとの guard 実装方式 (fitness 照合対象) */
+	guards: {
+		sqlite: RestoreGuardImpl;
+		dynamodb: RestoreGuardImpl;
+		dsql: RestoreGuardImpl;
+		demo: RestoreGuardImpl;
+	};
+	reason: string;
+}
+
+/**
+ * backup restore 対象 entity の冪等 guard 分類 SSOT。
+ * 新規に `*ForRestore` 関数を repo に追加したら本 registry にも追記する
+ * (未追記は restore-idempotency-registry.test.ts の no-silent-gap で fail)。
+ */
+export const RESTORE_IDEMPOTENCY_REGISTRY: Record<string, RestoreIdempotencyEntry> = {
+	childChallenge: {
+		kind: 'natural-key',
+		repoFile: 'child-challenge-repo',
+		functionNames: ['insertForRestore'],
+		naturalKey:
+			'auto:weekly 行のみ (childId, startDate)。sqlite=部分 unique index idx_child_challenges_auto_weekly_unique / dynamodb=AUTO# 決定的 SK + attribute_not_exists / dsql=weekly_auto_guard UNIQUE。regular 行は新規採番 id キーで衝突しない',
+		guards: {
+			sqlite: 'on-conflict-do-nothing',
+			dynamodb: 'condition-expression',
+			dsql: 'on-conflict-sql',
+			demo: 'null-stub',
+		},
+		reason:
+			'#3387: 重複 auto:weekly backup が DynamoDB で silent 上書き + count 偽装される非対称の根治',
+	},
+	stampCard: {
+		kind: 'natural-key',
+		repoFile: 'stamp-card-repo',
+		functionNames: ['insertCardForRestore'],
+		naturalKey:
+			'(childId, weekStart)。sqlite=idx_stamp_cards_child_week / dynamodb=SK STMPCARD#<weekStart> + attribute_not_exists / dsql=stamp_cards_week_uq',
+		guards: {
+			sqlite: 'on-conflict-do-nothing',
+			dynamodb: 'condition-expression',
+			dsql: 'on-conflict-sql',
+			demo: 'null-stub',
+		},
+		reason: '#3391/#3394: dynamodb 無条件 Put の (child,weekStart) silent 上書き根治',
+	},
+	stampEntry: {
+		kind: 'natural-key',
+		repoFile: 'stamp-card-repo',
+		functionNames: ['insertEntryForRestore'],
+		naturalKey:
+			'(cardId, slot) + (cardId, loginDate)。重複は boolean false を返し stampEntriesImported に加算しない',
+		guards: {
+			sqlite: 'on-conflict-do-nothing',
+			dynamodb: 'condition-expression',
+			dsql: 'on-conflict-sql',
+			demo: 'null-stub',
+		},
+		reason: '#3394: 旧実装は重複 skip 後も void 返却で imported++ される count 偽装だった',
+	},
+	certificate: {
+		kind: 'natural-key',
+		repoFile: 'certificate-repo',
+		functionNames: ['insertForRestore'],
+		naturalKey:
+			'(childId, certificateType)。sqlite=idx_certificates_child_type / dynamodb=SK CERT#<type> + attribute_not_exists / dsql=DB 制約なし (§11.2 未設置) のため import-service 層 dedup が唯一の防御',
+		guards: {
+			sqlite: 'on-conflict-do-nothing',
+			dynamodb: 'condition-expression',
+			dsql: 'service-layer',
+			demo: 'null-stub',
+		},
+		reason:
+			'#3401: dynamodb 旧実装は catch-all return null で throttle を「重複 skip」と誤分類していた',
+	},
+	activityPref: {
+		kind: 'natural-key',
+		repoFile: 'activity-pref-repo',
+		functionNames: ['insertForRestore'],
+		naturalKey:
+			'(childId, activityId)。sqlite=idx_child_activity_prefs_unique / dynamodb=SK ACTPREF#<activityId> + attribute_not_exists / dsql=自然複合 PK',
+		guards: {
+			sqlite: 'on-conflict-do-nothing',
+			dynamodb: 'condition-expression',
+			dsql: 'on-conflict-sql',
+			demo: 'null-stub',
+		},
+		reason: '#3465: dynamodb 無条件 Put の silent overwrite + count 水増し根治',
+	},
+	parentMessage: {
+		kind: 'content-dedup',
+		repoFile: 'message-repo',
+		functionNames: ['insertForRestore'],
+		contentKey: '(childId, messageType, stampCode, body, sentAt) — import-service merge mode',
+		guards: {
+			sqlite: 'none',
+			dynamodb: 'none',
+			dsql: 'none',
+			demo: 'null-stub',
+		},
+		reason:
+			'#3414: id-addressable append のため DB 自然キーなし。同一 backup 再取込の複製を service 層 content dedup で防ぐ (verbatim=cutover は bypass)',
+	},
+	siblingCheer: {
+		kind: 'content-dedup',
+		repoFile: 'sibling-cheer-repo',
+		functionNames: ['insertForRestore'],
+		contentKey: '(fromChildId, toChildId, stampCode, sentAt) — import-service merge mode',
+		guards: {
+			sqlite: 'none',
+			dynamodb: 'none',
+			dsql: 'none',
+			demo: 'null-stub',
+		},
+		reason: '#3420: parentMessage と同型。demo stub の虚偽 imported カウントも null 返却で根治',
+	},
+	childVoice: {
+		kind: 'append',
+		repoFile: 'voice-repo',
+		functionNames: ['insertForRestore'],
+		guards: {
+			sqlite: 'none',
+			dynamodb: 'none',
+			dsql: 'none',
+			demo: 'null-stub',
+		},
+		reason:
+			'音声 DB 行は filePath (uuid) が実質識別子で、静的ファイル復元 (#3077) と対で管理される。再取込複製は既知の制約 (backup 対象は同一 uuid path へ上書き復元されるため実害は DB 行の重複のみ)',
+	},
+	restDay: {
+		kind: 'natural-key',
+		repoFile: 'evaluation-repo',
+		functionNames: ['insertRestDayForRestore'],
+		naturalKey:
+			'(childId, date)。sqlite=idx_rest_days_child_date / dsql=自然複合 PK + ON CONFLICT / dynamodb=保存対象外 (no-op stub が undefined を返し skip 計上)',
+		guards: {
+			sqlite: 'on-conflict-do-nothing',
+			dynamodb: 'null-stub',
+			dsql: 'on-conflict-sql',
+			demo: 'null-stub',
+		},
+		reason:
+			'統一契約の既存模範実装 (#3329)。重複 → undefined 返却 + import 側 skip 計上が全 backend で成立済',
+	},
+	checklistOverride: {
+		kind: 'append',
+		repoFile: 'checklist-repo',
+		functionNames: ['insertOverrideForRestore'],
+		guards: {
+			sqlite: 'none',
+			dynamodb: 'none',
+			dsql: 'none',
+			demo: 'null-stub',
+		},
+		reason:
+			'日次 override は (child, targetDate, action, itemName) に DB 一意制約がなく、同日複数 override も正当なため dedup 対象外 (既知の制約、#3329)',
+	},
+	rewardRedemption: {
+		kind: 'append',
+		repoFile: 'reward-redemption-repo',
+		functionNames: ['insertRedemptionForRestore'],
+		guards: {
+			sqlite: 'none',
+			dynamodb: 'none',
+			dsql: 'none',
+			demo: 'null-stub',
+		},
+		reason:
+			'交換履歴は同一 (child, reward, requestedAt) の正当な複数申請があり得る append イベント。dedup 対象外 (既知の制約、#3329。残高の真実は pointLedger が持つ)',
+	},
+};
+
+/** kind='natural-key' の entity 名一覧 (fitness / import-service 参照用)。 */
+export function naturalKeyRestoreEntities(): string[] {
+	return Object.entries(RESTORE_IDEMPOTENCY_REGISTRY)
+		.filter(([, e]) => e.kind === 'natural-key')
+		.map(([name]) => name)
+		.sort();
+}
+
+/** registry が宣言する `repoFile:functionName` の組 (no-silent-gap 照合用)。 */
+export function declaredRestoreFunctions(): string[] {
+	return Object.values(RESTORE_IDEMPOTENCY_REGISTRY)
+		.flatMap((e) => e.functionNames.map((fn) => `${e.repoFile}:${fn}`))
+		.sort();
+}

--- a/src/lib/server/db/restore-idempotency.ts
+++ b/src/lib/server/db/restore-idempotency.ts
@@ -2,7 +2,7 @@
 // #3394: backup restore の insertForRestore 冪等 guard 分類 SSOT (same-class #3385/#3391/#3387/#3401)。
 //
 // 背景: DynamoDB insertForRestore が SQLite unique index 相当の衝突防御を欠く同型欠陥が
-// 連続発生した (#3385 challenge auto:weekly / #3391 stampcard)。個別パッチでは同 class の
+// 連続発生した (#3385 challenge auto:weekly / #3391 stampCard)。個別パッチでは同 class の
 // 新規 entity 追加時に再発するため、本 registry で「restore 冪等性の種別」と「backend ごとの
 // guard 実装方式」を宣言し、fitness function (tests/unit/db/restore-idempotency-registry.test.ts)
 // が以下を機械検証する (ADR-0061 same-class → guard):

--- a/src/lib/server/db/sqlite/activity-pref-repo.ts
+++ b/src/lib/server/db/sqlite/activity-pref-repo.ts
@@ -54,11 +54,15 @@ export async function findAllByChild(
 		.map(toEntity);
 }
 
-/** #3329 backup restore 用: isPinned/pinOrder/日時を保全して復元する (childId/activityId は呼び出し側が解決済)。 */
+/**
+ * #3329 backup restore 用: isPinned/pinOrder/日時を保全して復元する (childId/activityId は呼び出し側が解決済)。
+ * #3394/#3465 統一冪等契約: 同 (childId, activityId) 既存 (idx_child_activity_prefs_unique 衝突) は
+ * onConflictDoNothing で skip し null を返す (DynamoDB attribute_not_exists と機能等価)。
+ */
 export async function insertForRestore(
 	input: Omit<ChildActivityPreference, 'id'>,
 	_tenantId: string,
-): Promise<ChildActivityPreference> {
+): Promise<ChildActivityPreference | null> {
 	const row = db
 		.insert(childActivityPreferences)
 		.values({
@@ -69,9 +73,10 @@ export async function insertForRestore(
 			createdAt: input.createdAt,
 			updatedAt: input.updatedAt,
 		})
+		.onConflictDoNothing()
 		.returning()
 		.get();
-	return toEntity(row);
+	return row ? toEntity(row) : null;
 }
 
 export async function findPinnedByChild(

--- a/src/lib/server/db/sqlite/child-challenge-repo.ts
+++ b/src/lib/server/db/sqlite/child-challenge-repo.ts
@@ -158,11 +158,15 @@ export async function insert(
  * #3329 backup restore 用: 進捗 / 完了 / 請求 / status / 日時を含む全フィールドを保全して復元する。
  * insert と異なり currentValue / completed / rewardClaimed / createdAt 等を引数の値のまま書き戻す。
  * id は新規採番 (元 id は保全しない、childId は呼び出し側が解決済)。
+ *
+ * #3387/#3394 統一冪等契約: auto:weekly 行の (childId, startDate) 重複 (部分 unique index
+ * idx_child_challenges_auto_weekly_unique 衝突) は onConflictDoNothing で skip し null を返す
+ * (DynamoDB AUTO# SK + attribute_not_exists と機能等価。regular 行は一意制約がなく常に insert)。
  */
 export async function insertForRestore(
 	input: Omit<ChildChallenge, 'id'>,
 	_tenantId: string,
-): Promise<ChildChallenge> {
+): Promise<ChildChallenge | null> {
 	const row = db
 		.insert(childChallenges)
 		.values({
@@ -187,10 +191,10 @@ export async function insertForRestore(
 			createdAt: input.createdAt,
 			updatedAt: input.updatedAt,
 		})
+		.onConflictDoNothing()
 		.returning()
 		.get();
-	if (!row) throw new Error('insertForRestore: insert returned no row');
-	return toChallenge(row);
+	return row ? toChallenge(row) : null;
 }
 
 /**

--- a/src/lib/server/db/sqlite/stamp-card-repo.ts
+++ b/src/lib/server/db/sqlite/stamp-card-repo.ts
@@ -152,11 +152,15 @@ export async function findEntriesByCardId(
 		}));
 }
 
-/** #3329 backup restore 用: status / redeemed / 日時を保全して card を復元する。 */
+/**
+ * #3329 backup restore 用: status / redeemed / 日時を保全して card を復元する。
+ * #3394 統一冪等契約: 同 (childId, weekStart) 既存 (idx_stamp_cards_child_week 衝突) は
+ * onConflictDoNothing で skip し null を返す (DynamoDB attribute_not_exists と機能等価)。
+ */
 export async function insertCardForRestore(
 	input: Omit<StampCard, 'id'>,
 	_tenantId: string,
-): Promise<StampCard> {
+): Promise<StampCard | null> {
 	const card = db
 		.insert(schema.stampCards)
 		.values({
@@ -169,13 +173,17 @@ export async function insertCardForRestore(
 			createdAt: input.createdAt,
 			updatedAt: input.updatedAt,
 		})
+		.onConflictDoNothing()
 		.returning()
 		.get();
-	if (!card) throw new Error('insertCardForRestore: insert returned no row');
-	return toCard(card);
+	return card ? toCard(card) : null;
 }
 
-/** #3329 backup restore 用: earnedAt を保全して押印を復元する。 */
+/**
+ * #3329 backup restore 用: earnedAt を保全して押印を復元する。
+ * #3394 統一冪等契約: 実 insert したら true / 重複 ((cardId,slot) or (cardId,loginDate)) skip は
+ * false を返す (import は true のときのみ imported++ = count 偽装防止)。
+ */
 export async function insertEntryForRestore(
 	input: {
 		cardId: string;
@@ -186,8 +194,9 @@ export async function insertEntryForRestore(
 		earnedAt: string;
 	},
 	_tenantId: string,
-): Promise<void> {
-	db.insert(schema.stampEntries)
+): Promise<boolean> {
+	const result = db
+		.insert(schema.stampEntries)
 		.values({
 			cardId: Number(input.cardId),
 			stampMasterId: input.stampMasterId === null ? null : Number(input.stampMasterId),
@@ -198,6 +207,7 @@ export async function insertEntryForRestore(
 		})
 		.onConflictDoNothing()
 		.run();
+	return result.changes > 0;
 }
 
 /** スタンプエントリを挿入（同日重複時は無視） */

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -270,7 +270,14 @@ async function collectForChild(
 	childExportIdMap: Map<ChildId, string>,
 	tenantId: string,
 ): Promise<ChildTransactionData> {
-	const childRef = childExportIdMap.get(childId) ?? `child-${childId}`;
+	// #3414 item 3: 旧 fallback `child-${childId}` (生 id) は import 側 childIdMap のキー
+	// `child-${index+1}` と決して一致せず、silent skip の温床だった。childExportIdMap は
+	// 呼び出し側 (collectTransactionData) が同一 allChildren から構築するため未解決は論理矛盾 =
+	// 到達したら fail-fast で throw し、childRef 不整合な backup を生成しない (明示 skip + error 統一)。
+	const childRef = childExportIdMap.get(childId);
+	if (!childRef) {
+		throw new Error(`collectForChild: childExportIdMap に childId=${childId} がありません`);
+	}
 
 	// 各データを並列取得
 	const [

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -9,6 +9,7 @@ import { EXPORT_FORMAT, type ExportData, isExportableSettingKey } from '$lib/dom
 import { MIGRATABLE_VERSIONS, migrateExportData } from '$lib/domain/export-migrations';
 import { IMPORT_LABELS, type ImportSkipReason } from '$lib/domain/labels';
 import { sanitizeActivityNameField, sanitizeDailyLimit } from '$lib/domain/validation/activity';
+import { MESSAGE_TEXT_MAX_LENGTH, MESSAGE_TYPES } from '$lib/domain/validation/message';
 import {
 	findActivities,
 	findActivityLogs,
@@ -34,6 +35,7 @@ import { setSetting } from '$lib/server/db/settings-repo';
 import { findSpecialRewards, insertSpecialReward } from '$lib/server/db/special-reward-repo';
 import { insertStatusHistory, upsertStatus } from '$lib/server/db/status-repo';
 import { logger } from '$lib/server/logger';
+import { getStampByCode } from '$lib/server/services/sibling-cheer-service';
 import { fileExists, saveFile } from '$lib/server/storage';
 import { storageKeyToPublicUrl, tenantPrefix } from '$lib/server/storage-keys';
 
@@ -81,6 +83,24 @@ async function runConcurrent<T>(
 		}
 	});
 	await Promise.all(runners);
+}
+
+/**
+ * content dedup (#3414/#3420) 用の既存行 prefetch 上限。
+ * parentMessage は findMessages(childId, limit) 契約のため十分大きな値で全件相当を取る
+ * (export 側 MAX_EXPORT_ROWS と同水準の桁。家庭内データで到達しない安全上限)。
+ */
+const RESTORE_DEDUP_FETCH_LIMIT = 100_000;
+
+/** ISO 8601 日時 (先頭 `YYYY-MM-DDTHH:MM` + Date.parse 可) か。restore の verbatim 値検証用 (#3414/#3420)。 */
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+function isValidIsoDateTime(value: string): boolean {
+	return ISO_DATETIME_RE.test(value) && !Number.isNaN(Date.parse(value));
+}
+
+/** bonusPoints の許容範囲 (null または 0〜99,999 の整数)。改竄 backup の範囲外値を弾く (#3414)。 */
+function isValidBonusPoints(value: number | null): boolean {
+	return value === null || (Number.isInteger(value) && value >= 0 && value <= 99_999);
 }
 
 /**
@@ -403,9 +423,11 @@ export async function importFamilyData(
 	// #3329: 証明書 (がんばり/卒業証明書 授与記録) を issuedAt 保全で復元。childIdMap のみ必要。
 	await importCertificatesData(data, childIdMap, tenantId, result);
 	// #3329: 親→子おうえんメッセージを sentAt/shownAt 保全で復元。childIdMap のみ必要。
-	await importParentMessagesData(data, childIdMap, tenantId, result);
+	// #3414: merge mode は content dedup で再取込冪等 (verbatim = cutover は bypass)。
+	await importParentMessagesData(data, childIdMap, tenantId, result, mode);
 	// #3329: きょうだい間おうえんスタンプ。from/to 両 childRef を解決して復元。childIdMap のみ必要。
-	await importSiblingCheersData(data, childIdMap, tenantId, result);
+	// #3420: merge mode は content dedup で再取込冪等 (verbatim = cutover は bypass)。
+	await importSiblingCheersData(data, childIdMap, tenantId, result, mode);
 	await importStatusHistoryData(data, childIdMap, tenantId, result);
 	// #3327/#3328: 評価 (週次評価) の取込。従来 import 関数が無く restore で全喪失していた網羅漏れを解消。
 	await importEvaluationsData(data, childIdMap, tenantId, result);
@@ -502,7 +524,7 @@ async function importRewardRedemptionsData(
 			continue;
 		}
 		try {
-			await insertRedemptionForRestore(
+			const restored = await insertRedemptionForRestore(
 				{
 					childId,
 					rewardId,
@@ -518,7 +540,9 @@ async function importRewardRedemptionsData(
 				},
 				tenantId,
 			);
-			result.rewardRedemptionsImported++;
+			// #3394: null = 永続化なし (demo no-op stub)。imported に加算しない (#2263 count 偽装防止)。
+			if (restored) result.rewardRedemptionsImported++;
+			else result.rewardRedemptionsSkipped++;
 		} catch (e) {
 			result.rewardRedemptionsSkipped++;
 			result.errors.push(
@@ -575,7 +599,7 @@ async function importChildChallengesData(
 			continue;
 		}
 		try {
-			await getRepos().childChallenge.insertForRestore(
+			const restored = await getRepos().childChallenge.insertForRestore(
 				{
 					childId,
 					title: c.title,
@@ -600,7 +624,17 @@ async function importChildChallengesData(
 				},
 				tenantId,
 			);
-			result.childChallengesImported++;
+			// #3387/#3394 統一冪等契約: null = 重複 (auto:weekly 同週既存) skip。imported に加算しない
+			// (count 偽装防止)。demo backend の書込 no-op も null で skip 計上される。
+			if (restored) {
+				result.childChallengesImported++;
+			} else {
+				result.childChallengesSkipped++;
+				result.skipped.constraint++;
+				result.warnings.push(
+					`チャレンジ重複スキップ (child=${c.childRef}, title=${c.title}, week=${c.startDate})`,
+				);
+			}
 		} catch (e) {
 			result.childChallengesSkipped++;
 			result.errors.push(
@@ -654,10 +688,22 @@ async function importStampCardsData(
 				},
 				tenantId,
 			);
+			// #3391/#3394 統一冪等契約: null = 同 (child, weekStart) 重複 skip。card が skip されたら
+			// 配下 entry も貼り先が無いため全件 skip 計上する (入力件数 = imported + skipped 恒等式)。
+			if (!restored) {
+				result.stampCardsSkipped++;
+				result.skipped.constraint++;
+				result.stampEntriesSkipped += card.entries.length;
+				result.warnings.push(
+					`スタンプカード重複スキップ (child=${card.childRef}, week=${card.weekStart})`,
+				);
+				return;
+			}
 			newCardId = restored.id;
 			result.stampCardsImported++;
 		} catch (e) {
 			result.stampCardsSkipped++;
+			result.stampEntriesSkipped += card.entries.length;
 			result.errors.push(
 				`スタンプカード insert 失敗 (child=${card.childRef}, week=${card.weekStart}): ${String(e)}`,
 			);
@@ -665,7 +711,7 @@ async function importStampCardsData(
 		}
 		await runConcurrent(card.entries, async (entry) => {
 			try {
-				await repo.insertEntryForRestore(
+				const inserted = await repo.insertEntryForRestore(
 					{
 						cardId: newCardId,
 						stampMasterId: entry.stampMasterId,
@@ -676,7 +722,14 @@ async function importStampCardsData(
 					},
 					tenantId,
 				);
-				result.stampEntriesImported++;
+				// #3394: 実 insert (true) のときのみ imported++。重複 ((cardId,slot) or (cardId,loginDate))
+				// skip は false → skipped 計上 (旧実装は void 返却で常に imported++ される count 偽装だった)。
+				if (inserted) {
+					result.stampEntriesImported++;
+				} else {
+					result.stampEntriesSkipped++;
+					result.skipped.constraint++;
+				}
 			} catch (e) {
 				result.stampEntriesSkipped++;
 				result.errors.push(
@@ -699,10 +752,37 @@ async function importCertificatesData(
 	tenantId: string,
 	result: ImportResult,
 ): Promise<void> {
-	for (const cert of data.data.certificates ?? []) {
+	const certs = data.data.certificates ?? [];
+	if (certs.length === 0) return;
+
+	// #3394 service 層 dedup (defense in depth): (childId, certificateType) の既存 + 同一 import 内
+	// 重複を DB 到達前に skip する。DSQL は certificates に DB unique 制約を持たない (§11.2 未設置)
+	// ため、この service 層 dedup が SQLite uniqueIndex / DynamoDB attribute_not_exists との
+	// backend 間機能等価を成立させる唯一の防御になる。
+	const seenTypesByChild = new Map<ChildId, Set<string>>();
+	async function seenTypes(childId: ChildId): Promise<Set<string>> {
+		let set = seenTypesByChild.get(childId);
+		if (!set) {
+			const rows = await getRepos().certificate.findCertificates(childId, tenantId);
+			set = new Set(rows.map((r) => r.certificateType));
+			seenTypesByChild.set(childId, set);
+		}
+		return set;
+	}
+
+	for (const cert of certs) {
 		const childId = childIdMap.get(cert.childRef);
 		if (!childId) {
 			result.certificatesSkipped++;
+			continue;
+		}
+		const types = await seenTypes(childId);
+		if (types.has(cert.certificateType)) {
+			result.certificatesSkipped++;
+			result.skipped.constraint++;
+			result.warnings.push(
+				`証明書重複スキップ (child=${cert.childRef}, type=${cert.certificateType})`,
+			);
 			continue;
 		}
 		try {
@@ -717,9 +797,18 @@ async function importCertificatesData(
 				},
 				tenantId,
 			);
-			if (restored) result.certificatesImported++;
-			else result.certificatesSkipped++;
+			if (restored) {
+				result.certificatesImported++;
+				types.add(cert.certificateType);
+			} else {
+				// DB 層 guard (onConflictDoNothing / attribute_not_exists) での重複 skip、
+				// または demo backend の書込 no-op。
+				result.certificatesSkipped++;
+				result.skipped.constraint++;
+			}
 		} catch (e) {
+			// #3401 例外分類: throttle / network 等の真の write 失敗のみここに到達する
+			// (重複は null 返却で上の分岐)。errors に可視化する。
 			result.certificatesSkipped++;
 			result.errors.push(
 				`証明書 insert 失敗 (child=${cert.childRef}, type=${cert.certificateType}): ${String(e)}`,
@@ -729,23 +818,103 @@ async function importCertificatesData(
 }
 
 /**
+ * parentMessage の verbatim 値検証 (#3414 item 2、default-deny)。
+ * 改竄/破損 backup の未知 messageType・範囲外 bonusPoints・不正日時が子供画面のおうえん描画
+ * (ParentMessageOverlay / 履歴ソート) を壊さないよう、import 境界で弾く。
+ * @returns 不正理由 (valid なら null)
+ */
+function validateParentMessageRow(m: {
+	messageType: string;
+	stampCode: string | null;
+	body: string | null;
+	icon: string;
+	sentAt: string;
+	shownAt: string | null;
+	bonusPoints: number | null;
+}): string | null {
+	if (!(MESSAGE_TYPES as readonly string[]).includes(m.messageType)) {
+		return `未知の messageType「${m.messageType}」`;
+	}
+	if (m.messageType === 'stamp' && !m.stampCode) return 'stamp に stampCode がありません';
+	if (m.stampCode !== null && m.stampCode.length > 30) return 'stampCode が長すぎます';
+	if (m.body !== null && m.body.length > MESSAGE_TEXT_MAX_LENGTH) return 'body が長すぎます';
+	if (m.icon.length > 10) return 'icon が長すぎます';
+	if (!isValidBonusPoints(m.bonusPoints)) return `bonusPoints が範囲外 (${m.bonusPoints})`;
+	if (!isValidIsoDateTime(m.sentAt)) return `sentAt が不正 (${m.sentAt})`;
+	if (m.shownAt !== null && !isValidIsoDateTime(m.shownAt)) return `shownAt が不正 (${m.shownAt})`;
+	return null;
+}
+
+/**
  * 親→子おうえんメッセージ (stamp/text/reward_notice) を復元する (#3329)。
  * childRef で取込先 child に解決し insertForRestore で sentAt / shownAt (既読) を保全して書き戻す。
+ *
+ * #3414: id-addressable append で DB 自然キーが無いため、merge mode では
+ * (messageType, stampCode, body, sentAt) の content key で 既存行 + 同一 import 内 を dedup し、
+ * 同一 backup 再取込の全件複製を防ぐ (verbatim = cutover は正当な同時刻複数行を保全するため bypass)。
+ * verbatim 値検証 (validateParentMessageRow) は mode 不問で適用する (整合性 skip は #3653 準拠)。
  */
 async function importParentMessagesData(
 	data: ExportData,
 	childIdMap: Map<string, ChildId>,
 	tenantId: string,
 	result: ImportResult,
+	mode: ImportMode = 'merge',
 ): Promise<void> {
+	const messages = data.data.parentMessages ?? [];
+	if (messages.length === 0) return;
+
+	const contentKey = (m: {
+		messageType: string;
+		stampCode: string | null;
+		body: string | null;
+		sentAt: string;
+	}) => `${m.messageType}|${m.stampCode ?? ''}|${m.body ?? ''}|${m.sentAt}`;
+
+	// merge mode: 取込先 child の既存メッセージ content key を prefetch (再取込冪等化)。
+	const existingKeysByChild = new Map<ChildId, Set<string>>();
+	async function existingKeys(childId: ChildId): Promise<Set<string>> {
+		let set = existingKeysByChild.get(childId);
+		if (!set) {
+			const rows = await getRepos().message.findMessages(
+				childId,
+				RESTORE_DEDUP_FETCH_LIMIT,
+				tenantId,
+			);
+			set = new Set(rows.map(contentKey));
+			existingKeysByChild.set(childId, set);
+		}
+		return set;
+	}
+
 	for (const m of data.data.parentMessages ?? []) {
 		const childId = childIdMap.get(m.childRef);
 		if (!childId) {
+			// #3414 item 3: childRef 未解決の silent skip をやめ、欠落を親に可視化する。
 			result.parentMessagesSkipped++;
+			result.warnings.push(
+				`メッセージスキップ: childRef「${m.childRef}」(type=${m.messageType}) が解決できません`,
+			);
 			continue;
 		}
+		const invalidReason = validateParentMessageRow(m);
+		if (invalidReason) {
+			result.parentMessagesSkipped++;
+			result.warnings.push(`メッセージスキップ (child=${m.childRef}): ${invalidReason}`);
+			continue;
+		}
+		if (mode === 'merge') {
+			const keys = await existingKeys(childId);
+			const key = contentKey(m);
+			if (keys.has(key)) {
+				result.parentMessagesSkipped++;
+				result.skipped.constraint++;
+				continue;
+			}
+			keys.add(key);
+		}
 		try {
-			await getRepos().message.insertForRestore(
+			const restored = await getRepos().message.insertForRestore(
 				{
 					childId,
 					messageType: m.messageType,
@@ -759,7 +928,9 @@ async function importParentMessagesData(
 				},
 				tenantId,
 			);
-			result.parentMessagesImported++;
+			// null = 永続化なし (demo no-op stub)。imported に加算しない (#2263 count 偽装防止)。
+			if (restored) result.parentMessagesImported++;
+			else result.parentMessagesSkipped++;
 		} catch (e) {
 			result.parentMessagesSkipped++;
 			result.errors.push(
@@ -770,25 +941,81 @@ async function importParentMessagesData(
 }
 
 /**
+ * siblingCheer の verbatim 値検証 (#3420 item 3、default-deny)。
+ * 不正 stampCode は SiblingCheerOverlay 描画破損、不正 sentAt は countTodayCheersFrom の
+ * 日次上限 (辞書順比較) とソートを汚染するため import 境界で弾く。
+ * stampCode は CHEER_STAMPS allowlist (送信経路 sendCheer と同一の getStampByCode 判定)。
+ * @returns 不正理由 (valid なら null)
+ */
+function validateSiblingCheerRow(c: {
+	stampCode: string;
+	sentAt: string;
+	shownAt: string | null;
+}): string | null {
+	if (!getStampByCode(c.stampCode)) return `未知の stampCode「${c.stampCode}」`;
+	if (!isValidIsoDateTime(c.sentAt)) return `sentAt が不正 (${c.sentAt})`;
+	if (c.shownAt !== null && !isValidIsoDateTime(c.shownAt)) return `shownAt が不正 (${c.shownAt})`;
+	return null;
+}
+
+/**
  * きょうだい間おうえんスタンプを復元する (#3329)。
  * from/to 両 childRef を取込先 child に解決し、insertForRestore で sentAt/shownAt (既読) を保全する。
- * どちらかの child が解決できない行は skip (FK NOT NULL を満たせないため)。
+ * どちらかの child が解決できない行は skip + warning 可視化 (FK NOT NULL を満たせないため、#3420 item 2)。
+ *
+ * #3420: id-addressable append で DB 自然キーが無いため、merge mode では
+ * (fromChildId, toChildId, stampCode, sentAt) の content key で 既存行 + 同一 import 内 を dedup し、
+ * 同一 backup 再取込のおうえん履歴二重化を防ぐ (verbatim = cutover は bypass)。
  */
 async function importSiblingCheersData(
 	data: ExportData,
 	childIdMap: Map<string, ChildId>,
 	tenantId: string,
 	result: ImportResult,
+	mode: ImportMode = 'merge',
 ): Promise<void> {
-	for (const c of data.data.siblingCheers ?? []) {
+	const cheers = data.data.siblingCheers ?? [];
+	if (cheers.length === 0) return;
+
+	// merge mode: 既存 cheer の content key を tenant 一括 prefetch (findAllByTenant は export でも使用)。
+	let existingKeys: Set<string> | undefined;
+	if (mode === 'merge') {
+		const rows = await getRepos().siblingCheer.findAllByTenant(tenantId);
+		existingKeys = new Set(
+			rows.map((r) => `${r.fromChildId}|${r.toChildId}|${r.stampCode}|${r.sentAt}`),
+		);
+	}
+
+	for (const c of cheers) {
 		const fromChildId = childIdMap.get(c.fromChildRef);
 		const toChildId = childIdMap.get(c.toChildRef);
 		if (!fromChildId || !toChildId) {
+			// #3420 item 2: silent skip をやめ、欠落を親に可視化する。
 			result.siblingCheersSkipped++;
+			result.warnings.push(
+				`おうえんスタンプスキップ: childRef (from=${c.fromChildRef}, to=${c.toChildRef}) が解決できません`,
+			);
 			continue;
 		}
+		const invalidReason = validateSiblingCheerRow(c);
+		if (invalidReason) {
+			result.siblingCheersSkipped++;
+			result.warnings.push(
+				`おうえんスタンプスキップ (from=${c.fromChildRef}, to=${c.toChildRef}): ${invalidReason}`,
+			);
+			continue;
+		}
+		if (existingKeys) {
+			const key = `${fromChildId}|${toChildId}|${c.stampCode}|${c.sentAt}`;
+			if (existingKeys.has(key)) {
+				result.siblingCheersSkipped++;
+				result.skipped.constraint++;
+				continue;
+			}
+			existingKeys.add(key);
+		}
 		try {
-			await getRepos().siblingCheer.insertForRestore(
+			const restored = await getRepos().siblingCheer.insertForRestore(
 				{
 					fromChildId,
 					toChildId,
@@ -798,7 +1025,9 @@ async function importSiblingCheersData(
 				},
 				tenantId,
 			);
-			result.siblingCheersImported++;
+			// null = 永続化なし (demo no-op stub)。imported に加算せず虚偽サマリを防ぐ (#3420 item 2)。
+			if (restored) result.siblingCheersImported++;
+			else result.siblingCheersSkipped++;
 		} catch (e) {
 			result.siblingCheersSkipped++;
 			result.errors.push(
@@ -832,7 +1061,7 @@ async function importActivityPrefsData(
 			continue;
 		}
 		try {
-			await getRepos().activityPref.insertForRestore(
+			const restored = await getRepos().activityPref.insertForRestore(
 				{
 					childId,
 					activityId: activity.id,
@@ -843,7 +1072,17 @@ async function importActivityPrefsData(
 				},
 				tenantId,
 			);
-			result.activityPrefsImported++;
+			// #3394/#3465 統一冪等契約: null = 同 (child, activity) 重複 skip (within-child 同名活動が
+			// name 再結合で同一 activityId に縮約されたケースを含む)。imported に加算しない。
+			if (restored) {
+				result.activityPrefsImported++;
+			} else {
+				result.activityPrefsSkipped++;
+				result.skipped.constraint++;
+				result.warnings.push(
+					`活動設定重複スキップ (child=${p.childRef}, activity=${p.activityName})`,
+				);
+			}
 		} catch (e) {
 			result.activityPrefsSkipped++;
 			result.errors.push(
@@ -870,7 +1109,7 @@ async function importChecklistOverridesData(
 			continue;
 		}
 		try {
-			await insertOverrideForRestore(
+			const restored = await insertOverrideForRestore(
 				{
 					childId,
 					targetDate: o.targetDate,
@@ -881,7 +1120,9 @@ async function importChecklistOverridesData(
 				},
 				tenantId,
 			);
-			result.checklistOverridesImported++;
+			// #3394: null = 永続化なし (demo no-op stub)。imported に加算しない (#2263 count 偽装防止)。
+			if (restored) result.checklistOverridesImported++;
+			else result.checklistOverridesSkipped++;
 		} catch (e) {
 			result.checklistOverridesSkipped++;
 			result.errors.push(
@@ -971,7 +1212,7 @@ async function importChildVoicesData(
 		const filePath = `${tenantPrefix(tenantId)}voices/${childId}/${rest}`;
 		const publicUrl = storageKeyToPublicUrl(filePath);
 		try {
-			await getRepos().voice.insertForRestore(
+			const restored = await getRepos().voice.insertForRestore(
 				{
 					childId,
 					scene: v.scene,
@@ -985,7 +1226,9 @@ async function importChildVoicesData(
 				},
 				tenantId,
 			);
-			result.childVoicesImported++;
+			// #3394: null = 永続化なし (demo no-op stub)。imported に加算しない (#2263 count 偽装防止)。
+			if (restored) result.childVoicesImported++;
+			else result.childVoicesSkipped++;
 		} catch (e) {
 			result.childVoicesSkipped++;
 			result.errors.push(`音声 insert 失敗 (child=${v.childRef}, scene=${v.scene}): ${String(e)}`);

--- a/tests/unit/db/dsql-activity-repos.test.ts
+++ b/tests/unit/db/dsql-activity-repos.test.ts
@@ -484,25 +484,33 @@ describe('DSQL activity-pref-repo (PR-R3、実 schema PGlite)', () => {
 			},
 			FAMILY,
 		);
+		// #3394 統一冪等契約: fresh 行の restore は必ず non-null (null = 重複 skip)
+		if (!restored) throw new Error('insertForRestore returned null for fresh row');
 		expect(restored.isPinned).toBe(1);
 		expect(restored.pinOrder).toBe(42);
 		expect(Date.parse(restored.createdAt)).toBe(Date.parse('2026-01-02T03:04:05.000Z'));
 		expect(Date.parse(restored.updatedAt)).toBe(Date.parse('2026-01-03T03:04:05.000Z'));
 
-		// 複合 PK (family, child, activity) UNIQUE の実効
-		await expect(
-			prefRepo.insertForRestore(
-				{
-					childId: c2,
-					activityId: act,
-					isPinned: 0,
-					pinOrder: null,
-					createdAt: '2026-01-02T03:04:05.000Z',
-					updatedAt: '2026-01-02T03:04:05.000Z',
-				},
-				FAMILY,
-			),
-		).rejects.toThrow();
+		// 複合 PK (family, child, activity) UNIQUE の実効。
+		// #3394 統一冪等契約: 重複は 23505 throw ではなく ON CONFLICT DO NOTHING → null skip
+		// (sqlite onConflictDoNothing / dynamodb attribute_not_exists と機能等価、count 整合)。
+		const duplicate = await prefRepo.insertForRestore(
+			{
+				childId: c2,
+				activityId: act,
+				isPinned: 0,
+				pinOrder: null,
+				createdAt: '2026-01-02T03:04:05.000Z',
+				updatedAt: '2026-01-02T03:04:05.000Z',
+			},
+			FAMILY,
+		);
+		expect(duplicate).toBeNull();
+		// 既存行は上書きされず 1 行のまま (silent overwrite なし)
+		const after = await prefRepo.findAllByChild(c2, FAMILY);
+		expect(after).toHaveLength(1);
+		expect(after[0]?.isPinned).toBe(1);
+		expect(after[0]?.pinOrder).toBe(42);
 	});
 
 	it('[P6] §P9 tenant 分離 + deleteByTenantId は tenant scope のみ削除', async () => {

--- a/tests/unit/db/dsql-certificate-voice-graduation-repos.test.ts
+++ b/tests/unit/db/dsql-certificate-voice-graduation-repos.test.ts
@@ -319,7 +319,7 @@ describe('DSQL certificate / voice / graduation-consent repos (PR-R10、実 sche
 
 	it('[V6] insertForRestore: createdAt / filePath / publicUrl / isActive を verbatim 保全 (新 id)', async () => {
 		const childId = await newChild('声六郎');
-		const { id } = await voiceRepo.insertForRestore(
+		const restored = await voiceRepo.insertForRestore(
 			{
 				childId,
 				scene: 'complete',
@@ -333,6 +333,9 @@ describe('DSQL certificate / voice / graduation-consent repos (PR-R10、実 sche
 			},
 			FAMILY,
 		);
+		// #3394 統一冪等契約: fresh 行の restore は必ず non-null (null = demo no-op stub のみ)
+		if (!restored) throw new Error('insertForRestore returned null for fresh row');
+		const { id } = restored;
 		expect(id).toMatch(UUID_RE);
 		const row = await voiceRepo.findById(id, FAMILY);
 		expect(row?.isActive).toBe(1);

--- a/tests/unit/db/dsql-checklist-repo.test.ts
+++ b/tests/unit/db/dsql-checklist-repo.test.ts
@@ -562,6 +562,8 @@ describe('DSQL checklist-repo (PR-R7、実 schema PGlite、family master + per-c
 			FAMILY,
 		);
 		// verbatim 保全: insertOverride と違い createdAt を default(now) に落とさない
+		// #3394 統一冪等契約: fresh 行の restore は必ず non-null (null = 重複 skip)
+		if (!restored) throw new Error('insertForRestore returned null for fresh row');
 		expect(Date.parse(restored.createdAt)).toBe(Date.parse('2025-12-24T08:00:00+00:00'));
 
 		const all = await repo.findOverridesByChild(child, FAMILY);

--- a/tests/unit/db/dsql-eval-battle-challenge-repos.test.ts
+++ b/tests/unit/db/dsql-eval-battle-challenge-repos.test.ts
@@ -461,6 +461,8 @@ describe('DSQL child-challenge-repo (M4-E PR8b、実 schema PGlite)', () => {
 			},
 			FAMILY,
 		);
+		// #3394 統一冪等契約: fresh 行の restore は必ず non-null (null = 重複 skip)
+		if (!restored) throw new Error('insertForRestore returned null for fresh row');
 		expect(restored.status).toBe('completed');
 		expect(restored.isActive).toBe(0);
 		expect(restored.currentValue).toBe(10);
@@ -468,6 +470,45 @@ describe('DSQL child-challenge-repo (M4-E PR8b、実 schema PGlite)', () => {
 		expect(restored.rewardClaimed).toBe(1);
 		expect(restored.completedAt).not.toBeNull();
 		expect(restored.rewardClaimedAt).not.toBeNull();
+	});
+
+	it('[C9b] insertForRestore (#3387/#3394): auto:weekly の (child, startDate) 重複は null skip (weekly_auto_guard)', async () => {
+		const childId = await newChild('復元週次');
+		const autoInput = (over: Record<string, unknown> = {}) =>
+			({
+				childId,
+				title: '週次チャレンジ',
+				description: null,
+				challengeType: 'cooperative',
+				periodType: 'weekly',
+				startDate: '2026-06-08',
+				endDate: '2026-06-14',
+				targetConfig: TARGET_CONFIG,
+				rewardConfig: REWARD_CONFIG,
+				status: 'active',
+				isActive: 1,
+				sourceTemplateId: 'auto:weekly',
+				currentValue: 3,
+				targetValue: 5,
+				completed: 0,
+				completedAt: null,
+				rewardClaimed: 0,
+				rewardClaimedAt: null,
+				createdAt: '2026-06-08T00:00:00.000Z',
+				updatedAt: '2026-06-08T00:00:00.000Z',
+				...over,
+			}) as Parameters<typeof repo.insertForRestore>[0];
+
+		const first = await repo.insertForRestore(autoInput(), FAMILY);
+		expect(first).not.toBeNull();
+		// 同 (child, startDate) の auto:weekly 重複 backup → ON CONFLICT DO NOTHING で null skip
+		// (sqlite 部分 unique index / dynamodb AUTO# SK + attribute_not_exists と機能等価)。
+		const dup = await repo.insertForRestore(autoInput({ currentValue: 0 }), FAMILY);
+		expect(dup).toBeNull();
+		// 既存行 (進捗 3) は上書きされない (silent last-writer-wins なし)
+		const rows = await repo.findByChildId(childId, FAMILY);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.currentValue).toBe(3);
 	});
 
 	it('[C10] insertBulk + findAllByTenant + deleteByTenantId', async () => {

--- a/tests/unit/db/dsql-reward-message-repos.test.ts
+++ b/tests/unit/db/dsql-reward-message-repos.test.ts
@@ -509,6 +509,8 @@ describe('DSQL reward / message repos (PR-R8、実 schema PGlite)', () => {
 			},
 			FAMILY,
 		);
+		// #3394 統一冪等契約: fresh 行の restore は必ず non-null (null = 重複 skip)
+		if (!restored) throw new Error('insertForRestore returned null for fresh row');
 		expect(restored.status).toBe('rejected'); // pending 固定でなく verbatim
 		expect(restored.requestedAt).toBe(requestedAt);
 		expect(restored.resolvedAt).toBe(resolvedAt);
@@ -586,6 +588,8 @@ describe('DSQL reward / message repos (PR-R8、実 schema PGlite)', () => {
 			},
 			FAMILY,
 		);
+		// #3394 統一冪等契約: fresh 行の restore は必ず non-null (null = 重複 skip)
+		if (!restored) throw new Error('insertForRestore returned null for fresh row');
 		expect(Date.parse(restored.sentAt)).toBe(Date.parse('2025-12-01T08:00:00+00:00'));
 		expect(Date.parse(restored.shownAt ?? '')).toBe(Date.parse('2025-12-02T09:00:00+00:00'));
 		expect(restored.stampCode).toBe('good');
@@ -667,6 +671,8 @@ describe('DSQL reward / message repos (PR-R8、実 schema PGlite)', () => {
 			},
 			family,
 		);
+		// #3394 統一冪等契約: fresh 行の restore は必ず non-null (null = 重複 skip)
+		if (!restored) throw new Error('insertForRestore returned null for fresh row');
 		expect(restored.id).toMatch(UUID_RE);
 		expect(Date.parse(restored.sentAt)).toBe(Date.parse('2025-11-01T10:00:00+00:00'));
 		expect(Date.parse(restored.shownAt ?? '')).toBe(Date.parse('2025-11-02T10:00:00+00:00'));

--- a/tests/unit/db/dsql-stamp-mission-repos.test.ts
+++ b/tests/unit/db/dsql-stamp-mission-repos.test.ts
@@ -289,6 +289,8 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 			},
 			FAMILY,
 		);
+		// #3394 統一冪等契約: fresh 行の restore は必ず non-null (null = 重複 skip)
+		if (!restored) throw new Error('insertForRestore returned null for fresh row');
 		expect(restored.id).toMatch(UUID_RE);
 		expect(restored.status).toBe('redeemed');
 		expect(restored.redeemedPoints).toBe(30);
@@ -312,8 +314,8 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 		expect(Date.parse(raw[0]?.earnedAt ?? '')).toBe(Date.parse('2025-12-01T08:30:00+00:00'));
 		expect(raw[0]?.stampMasterId).toBe(null); // omikuji のみの押印 (master 無し)
 
-		// restore 経路も #3562③ tenant 境界を通る (他 family card への restore は no-op)
-		await stampRepo.insertEntryForRestore(
+		// restore 経路も #3562③ tenant 境界を通る (他 family card への restore は no-op = false)
+		const crossTenant = await stampRepo.insertEntryForRestore(
 			{
 				cardId: restored.id,
 				stampMasterId: null,
@@ -324,6 +326,42 @@ describe('DSQL stamp-card-repo / daily-mission-repo (PR-R6、実 schema PGlite)'
 			},
 			OTHER_FAMILY,
 		);
+		expect(crossTenant).toBe(false); // #3394: 実 insert なし = false (count 偽装防止)
+		expect(await stampRepo.findEntriesByCardId(restored.id, FAMILY)).toHaveLength(1);
+
+		// #3394 統一冪等契約: 同 (child, weekStart) の重複 card restore は null skip
+		// (stamp_cards_week_uq、旧 23505 throw から機能等価契約へ)。既存行は上書きされない。
+		const dupCard = await stampRepo.insertCardForRestore(
+			{
+				childId,
+				weekStart: '2025-12-01',
+				weekEnd: '2025-12-07',
+				status: 'collecting',
+				redeemedPoints: null,
+				redeemedAt: null,
+				createdAt: '2025-12-01T00:00:00+00:00',
+				updatedAt: '2025-12-01T00:00:00+00:00',
+			},
+			FAMILY,
+		);
+		expect(dupCard).toBeNull();
+		const cards = await stampRepo.findCardsByChild(childId, FAMILY);
+		expect(cards).toHaveLength(1);
+		expect(cards[0]?.status).toBe('redeemed'); // silent overwrite されていない
+
+		// 同 (cardId, slot) の重複 entry restore は false skip (imported に加算しない)
+		const dupEntry = await stampRepo.insertEntryForRestore(
+			{
+				cardId: restored.id,
+				stampMasterId: null,
+				omikujiRank: 'kichi',
+				slot: 1,
+				loginDate: '2025-12-03',
+				earnedAt: '2025-12-03T08:30:00+00:00',
+			},
+			FAMILY,
+		);
+		expect(dupEntry).toBe(false);
 		expect(await stampRepo.findEntriesByCardId(restored.id, FAMILY)).toHaveLength(1);
 	});
 

--- a/tests/unit/db/dynamodb-activity-pref-repo.test.ts
+++ b/tests/unit/db/dynamodb-activity-pref-repo.test.ts
@@ -1,0 +1,99 @@
+/**
+ * tests/unit/db/dynamodb-activity-pref-repo.test.ts
+ *
+ * #3394/#3465 (same-class #3385/#3391): DynamoDB activity-pref repo の restore 冪等 guard 単体テスト。
+ *
+ * 旧実装は insertForRestore が無条件 PutCommand で同 (childId, activityId) の既存 item を
+ * silent overwrite し、import カウントを水増ししていた (SQLite idx_child_activity_prefs_unique
+ * throw→skip+error と非対称)。統一契約 (#3394):
+ *   - Put は attribute_not_exists(PK) 条件付き
+ *   - 重複 (ConditionalCheckFailedException) は null を返す (import 側 skip 計上)
+ *   - throttle 等その他の失敗は throw する (#3401 例外分類)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { asActivityId, asChildId } from '$lib/domain/ids';
+
+// AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
+const { mockSend, MockGetCommand, MockPutCommand, MockQueryCommand } = vi.hoisted(() => {
+	const send = vi.fn();
+	class Cmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
+		}
+	}
+	return {
+		mockSend: send,
+		MockGetCommand: class extends Cmd {},
+		MockPutCommand: class extends Cmd {},
+		MockQueryCommand: class extends Cmd {},
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	GetCommand: MockGetCommand,
+	PutCommand: MockPutCommand,
+	QueryCommand: MockQueryCommand,
+}));
+
+async function loadRepo() {
+	return import('../../../src/lib/server/db/dynamodb/activity-pref-repo');
+}
+
+const TENANT = 'tenant-1';
+const CHILD_ID = asChildId(42);
+const ACTIVITY_ID = asActivityId(7);
+
+const restoreInput = {
+	childId: CHILD_ID,
+	activityId: ACTIVITY_ID,
+	isPinned: 1,
+	pinOrder: 2,
+	createdAt: '2026-02-05T00:00:00Z',
+	updatedAt: '2026-02-06T00:00:00Z',
+};
+
+beforeEach(() => {
+	mockSend.mockReset();
+});
+
+describe('#3394/#3465 insertForRestore 冪等 guard', () => {
+	it('Put に ConditionExpression attribute_not_exists(PK) が付く (silent overwrite 禁止)', async () => {
+		mockSend.mockResolvedValueOnce({});
+		const { insertForRestore } = await loadRepo();
+		const pref = await insertForRestore(restoreInput, TENANT);
+		expect(pref?.isPinned).toBe(1);
+		expect(pref?.pinOrder).toBe(2);
+		// createdAt/updatedAt verbatim 保全 (#3465 item 3)
+		expect(pref?.createdAt).toBe('2026-02-05T00:00:00Z');
+		expect(pref?.updatedAt).toBe('2026-02-06T00:00:00Z');
+		const put = mockSend.mock.calls[0]?.[0] as {
+			input: { ConditionExpression?: string; Item?: Record<string, unknown> };
+		};
+		expect(put.input.ConditionExpression).toBe('attribute_not_exists(PK)');
+		expect(put.input.Item?.childId).toBe(42);
+		expect(put.input.Item?.activityId).toBe(7);
+	});
+
+	it('重複 (ConditionalCheckFailedException) は null を返す (SQLite uniqueIndex 等価、count 水増し防止)', async () => {
+		const err = new Error('The conditional request failed');
+		err.name = 'ConditionalCheckFailedException';
+		mockSend.mockRejectedValueOnce(err);
+		const { insertForRestore } = await loadRepo();
+		await expect(insertForRestore(restoreInput, TENANT)).resolves.toBeNull();
+	});
+
+	it('throttle 等その他の write 失敗は throw する (#3401 例外分類)', async () => {
+		const err = new Error('throughput exceeded');
+		err.name = 'ProvisionedThroughputExceededException';
+		mockSend.mockRejectedValueOnce(err);
+		const { insertForRestore } = await loadRepo();
+		await expect(insertForRestore(restoreInput, TENANT)).rejects.toThrow('throughput exceeded');
+	});
+});

--- a/tests/unit/db/dynamodb-certificate-repo.test.ts
+++ b/tests/unit/db/dynamodb-certificate-repo.test.ts
@@ -276,3 +276,47 @@ describe('hasCertificate', () => {
 		await expect(hasCertificate(CHILD_ID, CERT_TYPE, TENANT)).resolves.toBe(false);
 	});
 });
+
+// ============================================================
+// #3401: insertForRestore の例外分類 (throttle silent loss 可視化)
+// ============================================================
+//
+// 旧実装は catch-all `return null` で throttle / network 失敗も「重複 skip」と誤分類し、
+// import が certificatesSkipped++ に計上して silent loss になっていた。
+// 統一契約 (#3394): 重複 (ConditionalCheckFailedException) のみ null、その他は throw。
+
+describe('#3401 insertForRestore 例外分類', () => {
+	const restoreInput = {
+		childId: CHILD_ID,
+		certificateType: CERT_TYPE,
+		title: 'そつぎょうしょうめいしょ',
+		description: null,
+		issuedAt: '2026-02-01T00:00:00Z',
+		metadata: null,
+	};
+
+	it('重複 (ConditionalCheckFailedException) は null を返す (skip)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Attributes: { counter: 10 } })
+			.mockRejectedValueOnce(conditionalCheckFailed());
+		const { insertForRestore } = await loadRepo();
+		await expect(insertForRestore(restoreInput, TENANT)).resolves.toBeNull();
+	});
+
+	it('throttle 等その他の write 失敗は throw する (旧 catch-all null の silent loss を根治)', async () => {
+		const err = new Error('throughput exceeded');
+		err.name = 'ProvisionedThroughputExceededException';
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 11 } }).mockRejectedValueOnce(err);
+		const { insertForRestore } = await loadRepo();
+		await expect(insertForRestore(restoreInput, TENANT)).rejects.toThrow('throughput exceeded');
+	});
+
+	it('成功時は issuedAt を verbatim 保全した Certificate を返す + ConditionExpression 付き Put', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 12 } }).mockResolvedValueOnce({});
+		const { insertForRestore } = await loadRepo();
+		const cert = await insertForRestore(restoreInput, TENANT);
+		expect(cert?.issuedAt).toBe('2026-02-01T00:00:00Z');
+		const put = mockSend.mock.calls[1]?.[0] as { input: { ConditionExpression?: string } };
+		expect(put.input.ConditionExpression).toBe('attribute_not_exists(PK)');
+	});
+});

--- a/tests/unit/db/dynamodb-child-challenge-repo.test.ts
+++ b/tests/unit/db/dynamodb-child-challenge-repo.test.ts
@@ -824,8 +824,8 @@ describe('#3329 insertForRestore dedup key 整合', () => {
 			restoreInput({ sourceTemplateId: 'auto:weekly', currentValue: 4 }),
 			TENANT,
 		);
-		expect(result.id).toBe('201');
-		expect(result.currentValue).toBe(4);
+		expect(result?.id).toBe('201');
+		expect(result?.currentValue).toBe(4);
 		const put = mockSend.mock.calls[1]?.[0] as { input: { Item?: Record<string, unknown> } };
 		// regular SK (CHILDCHAL#<padId>) ではなく dedup SK に置く。
 		expect(put.input.Item?.SK).toBe(AUTO_SK);
@@ -878,6 +878,74 @@ describe('#3329 insertForRestore dedup key 整合', () => {
 		const get = mockSend.mock.calls[0]?.[0] as { input: { Key?: { SK: string } } };
 		expect(get.input.Key?.SK).toBe(AUTO_SK);
 		expect(get.input.Key?.SK).toBe(restoreSK);
+	});
+});
+
+// ============================================================
+// #3387/#3394: insertForRestore の unique-index 相当 guard (統一冪等契約)
+// ============================================================
+//
+// SQLite の部分 unique index idx_child_challenges_auto_weekly_unique と機能等価にするため、
+// Put は attribute_not_exists(PK) 条件付きで発行し、衝突 (重複 backup) は silent 上書き
+// (last-writer-wins) せず null を返す。throttle 等その他の失敗は throw する (#3401 例外分類)。
+
+describe('#3387/#3394 insertForRestore 冪等 guard', () => {
+	function restoreInput(over: Record<string, unknown> = {}) {
+		return {
+			childId: CHILD_ID,
+			title: '復元チャレンジ',
+			description: null,
+			challengeType: 'cooperative',
+			periodType: 'weekly',
+			startDate: '2026-06-01',
+			endDate: '2026-06-07',
+			targetConfig: '{"metric":"count","baseTarget":5}',
+			rewardConfig: '{"points":50}',
+			status: 'active',
+			isActive: 1,
+			sourceTemplateId: null,
+			currentValue: 0,
+			targetValue: 5,
+			completed: 0,
+			completedAt: null,
+			rewardClaimed: 0,
+			rewardClaimedAt: null,
+			createdAt: '2026-06-01T00:00:00.000Z',
+			updatedAt: '2026-06-01T00:00:00.000Z',
+			...over,
+		} as Parameters<Awaited<ReturnType<typeof loadRepo>>['insertForRestore']>[0];
+	}
+
+	it('Put に ConditionExpression attribute_not_exists(PK) が付く (silent 上書き禁止)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 301 } }).mockResolvedValueOnce({});
+		const { insertForRestore } = await loadRepo();
+		await insertForRestore(restoreInput({ sourceTemplateId: 'auto:weekly' }), TENANT);
+		const put = mockSend.mock.calls[1]?.[0] as {
+			input: { ConditionExpression?: string };
+		};
+		expect(put.input.ConditionExpression).toBe('attribute_not_exists(PK)');
+	});
+
+	it('重複 (ConditionalCheckFailedException) は null を返す (SQLite onConflictDoNothing 等価、count 偽装防止)', async () => {
+		const err = new Error('conditional check failed');
+		err.name = 'ConditionalCheckFailedException';
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 302 } }).mockRejectedValueOnce(err);
+		const { insertForRestore } = await loadRepo();
+		const result = await insertForRestore(
+			restoreInput({ sourceTemplateId: 'auto:weekly' }),
+			TENANT,
+		);
+		expect(result).toBeNull();
+	});
+
+	it('throttle 等その他の write 失敗は throw する (#3401: silent loss / 重複誤分類の禁止)', async () => {
+		const err = new Error('Throughput exceeds the current capacity');
+		err.name = 'ProvisionedThroughputExceededException';
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 303 } }).mockRejectedValueOnce(err);
+		const { insertForRestore } = await loadRepo();
+		await expect(
+			insertForRestore(restoreInput({ sourceTemplateId: 'auto:weekly' }), TENANT),
+		).rejects.toThrow('Throughput exceeds');
 	});
 });
 

--- a/tests/unit/db/dynamodb-stamp-card-repo.test.ts
+++ b/tests/unit/db/dynamodb-stamp-card-repo.test.ts
@@ -590,3 +590,86 @@ describe('interface 適合 (IStampCardRepo)', () => {
 		expect(mockSend).toHaveBeenCalled();
 	});
 });
+
+// ============================================================
+// #3391/#3394: insertCardForRestore / insertEntryForRestore の統一冪等契約
+// ============================================================
+//
+// SQLite uniqueIndex idx_stamp_cards_child_week / idx_stamp_entries_card_slot と機能等価にするため、
+// card restore Put は attribute_not_exists(PK) 条件付きで発行し重複は null (silent 上書き禁止)、
+// entry restore は実 insert のとき true / 重複 skip のとき false を返す (count 偽装 #2263 防止)。
+// throttle 等その他の失敗は throw する (#3401 例外分類)。
+
+describe('#3391/#3394 insertCardForRestore 冪等 guard', () => {
+	const restoreCardInput = {
+		childId: CHILD_ID,
+		weekStart: '2026-06-01',
+		weekEnd: '2026-06-07',
+		status: 'redeemed',
+		redeemedPoints: 20,
+		redeemedAt: '2026-06-07T10:00:00Z',
+		createdAt: '2026-06-01T00:00:00Z',
+		updatedAt: '2026-06-07T10:00:00Z',
+	};
+
+	it('Put に ConditionExpression attribute_not_exists(PK) が付く (silent 上書き禁止)', async () => {
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 30 } }).mockResolvedValueOnce({});
+		const { insertCardForRestore } = await loadRepo();
+		const card = await insertCardForRestore(restoreCardInput, TENANT);
+		expect(card?.id).toBe('30');
+		const put = mockSend.mock.calls[1]?.[0] as {
+			input: { ConditionExpression?: string; Item?: Record<string, unknown> };
+		};
+		expect(put.input.ConditionExpression).toBe('attribute_not_exists(PK)');
+		expect(put.input.Item?.SK).toBe('STMPCARD#2026-06-01');
+	});
+
+	it('重複 (ConditionalCheckFailedException) は null を返す (SQLite uniqueIndex 等価)', async () => {
+		const err = new Error('cond');
+		err.name = 'ConditionalCheckFailedException';
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 31 } }).mockRejectedValueOnce(err);
+		const { insertCardForRestore } = await loadRepo();
+		await expect(insertCardForRestore(restoreCardInput, TENANT)).resolves.toBeNull();
+	});
+
+	it('throttle 等その他の write 失敗は throw する (#3401)', async () => {
+		const err = new Error('throughput exceeded');
+		err.name = 'ProvisionedThroughputExceededException';
+		mockSend.mockResolvedValueOnce({ Attributes: { counter: 32 } }).mockRejectedValueOnce(err);
+		const { insertCardForRestore } = await loadRepo();
+		await expect(insertCardForRestore(restoreCardInput, TENANT)).rejects.toThrow(
+			'throughput exceeded',
+		);
+	});
+});
+
+describe('#3394 insertEntryForRestore の count 整合 (boolean 返却)', () => {
+	const restoreEntryInput = {
+		cardId: CARD_ID,
+		stampMasterId: '3',
+		omikujiRank: '大吉',
+		slot: 2,
+		loginDate: '2026-06-02',
+		earnedAt: '2026-06-02T08:00:00Z',
+	};
+
+	it('実 insert したら true を返す', async () => {
+		mockSend.mockResolvedValueOnce({});
+		const { insertEntryForRestore } = await loadRepo();
+		await expect(insertEntryForRestore(restoreEntryInput, TENANT)).resolves.toBe(true);
+	});
+
+	it('重複 (ConditionalCheckFailedException) は false を返す (旧 void 返却の imported++ 偽装を根治)', async () => {
+		const err = new Error('cond');
+		err.name = 'ConditionalCheckFailedException';
+		mockSend.mockRejectedValueOnce(err);
+		const { insertEntryForRestore } = await loadRepo();
+		await expect(insertEntryForRestore(restoreEntryInput, TENANT)).resolves.toBe(false);
+	});
+
+	it('throttle 等その他の write 失敗は throw する (#3401)', async () => {
+		mockSend.mockRejectedValueOnce(new Error('network error'));
+		const { insertEntryForRestore } = await loadRepo();
+		await expect(insertEntryForRestore(restoreEntryInput, TENANT)).rejects.toThrow('network error');
+	});
+});

--- a/tests/unit/db/restore-idempotency-registry.test.ts
+++ b/tests/unit/db/restore-idempotency-registry.test.ts
@@ -120,8 +120,10 @@ describe('#3394 restore-idempotency registry fitness (ADR-0061 same-class → gu
 			'utf-8',
 		);
 		// parentMessage: (messageType, stampCode, body, sentAt) content key
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: source-scan fitness — import-service 内の template literal を文字列として照合する
 		expect(importService).toContain('${m.messageType}|${m.stampCode ?? ');
 		// siblingCheer: (fromChildId, toChildId, stampCode, sentAt) content key
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: source-scan fitness — import-service 内の template literal を文字列として照合する
 		expect(importService).toContain('${fromChildId}|${toChildId}|${c.stampCode}|${c.sentAt}');
 	});
 });

--- a/tests/unit/db/restore-idempotency-registry.test.ts
+++ b/tests/unit/db/restore-idempotency-registry.test.ts
@@ -1,0 +1,127 @@
+// tests/unit/db/restore-idempotency-registry.test.ts
+// #3394: restore 冪等 guard 分類 SSOT (restore-idempotency.ts) の fitness function (ADR-0061)。
+//
+// backup-entity-registry.test.ts の no-silent-gap パターンと同型:
+//   1. no-silent-gap: 4 backend (sqlite/dynamodb/dsql/demo) の `*ForRestore` 関数は全て registry に
+//      分類されている (新規 restore 関数を追加して分類を忘れると本テストが fail する)
+//   2. guard 対称性: kind='natural-key' entity は宣言された backend guard 実装
+//      (ConditionExpression / onConflictDoNothing / ON CONFLICT) がソース上に存在する
+//      (#3385/#3391 の「DynamoDB だけ guard を欠く」同型欠陥を CI で機械検出)
+//   3. demo null-stub: demo backend の restore stub は null/false/undefined を返し
+//      import カウントを偽装しない (#3420 / #2263 count 偽装 class)
+//
+// ソース走査 fitness は「関数出現位置から一定範囲に guard マーカーが存在する」ことを検査する
+// 近似だが、guard を丸ごと外す退行 (silent overwrite 化) は確実に検出できる。
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+	declaredRestoreFunctions,
+	RESTORE_IDEMPOTENCY_REGISTRY,
+	type RestoreGuardImpl,
+} from '../../../src/lib/server/db/restore-idempotency';
+
+const DB_DIR = join(__dirname, '../../../src/lib/server/db');
+const BACKENDS = ['sqlite', 'dynamodb', 'dsql', 'demo'] as const;
+type Backend = (typeof BACKENDS)[number];
+
+/** backend dir 配下の *-repo.ts から `<basename>:<fn>` の ForRestore 関数集合を抽出する。 */
+function scanRestoreFunctions(backend: Backend): Set<string> {
+	const dir = join(DB_DIR, backend);
+	const found = new Set<string>();
+	for (const file of readdirSync(dir)) {
+		if (!file.endsWith('-repo.ts')) continue;
+		const source = readFileSync(join(dir, file), 'utf-8');
+		const basename = file.replace(/\.ts$/, '');
+		// sqlite/dynamodb/demo: `export async function xxxForRestore(` /
+		// dsql (object literal repo): `async xxxForRestore(`
+		const re = /(?:export\s+async\s+function|(?<![\w.])async)\s+(\w*ForRestore)\s*[(<]/g;
+		for (const m of source.matchAll(re)) {
+			found.add(`${basename}:${m[1]}`);
+		}
+	}
+	return found;
+}
+
+/** file 内の関数名出現位置以降のスライス (関数本体近傍) を返す。 */
+function functionVicinity(backend: Backend, repoFile: string, fn: string): string {
+	const source = readFileSync(join(DB_DIR, backend, `${repoFile}.ts`), 'utf-8');
+	const idx = source.indexOf(`${fn}(`);
+	expect(idx, `${backend}/${repoFile}.ts に ${fn} が存在する`).toBeGreaterThanOrEqual(0);
+	return source.slice(idx, idx + 2600);
+}
+
+/** guard 実装方式ごとのソースマーカー。 */
+const GUARD_MARKERS: Record<Exclude<RestoreGuardImpl, 'none' | 'service-layer'>, RegExp> = {
+	'condition-expression': /ConditionExpression/,
+	'on-conflict-do-nothing': /onConflictDoNothing/,
+	'on-conflict-sql': /ON CONFLICT/,
+	'null-stub': /return (?:null|false|undefined)/,
+};
+
+describe('#3394 restore-idempotency registry fitness (ADR-0061 same-class → guard)', () => {
+	it('no-silent-gap: 全 backend の *ForRestore 関数が registry に分類されている (双方向一致)', () => {
+		const union = new Set<string>();
+		for (const backend of BACKENDS) {
+			for (const key of scanRestoreFunctions(backend)) union.add(key);
+		}
+		const declared = new Set(declaredRestoreFunctions());
+
+		const undeclared = [...union].filter((k) => !declared.has(k)).sort();
+		expect(
+			undeclared,
+			'registry 未分類の ForRestore 関数 (restore-idempotency.ts に追記が必要)',
+		).toEqual([]);
+
+		// 逆方向: registry 宣言がどの backend にも実在しない (typo / 撤去漏れ) を検出
+		const missing = [...declared].filter((k) => !union.has(k)).sort();
+		expect(missing, 'registry に宣言されたがソースに存在しない ForRestore 関数').toEqual([]);
+	});
+
+	it('guard 対称性: natural-key entity は宣言された backend guard がソース上に存在する', () => {
+		for (const [name, entry] of Object.entries(RESTORE_IDEMPOTENCY_REGISTRY)) {
+			for (const backend of BACKENDS) {
+				const guard = entry.guards[backend];
+				if (guard === 'none' || guard === 'service-layer') continue;
+				const marker = GUARD_MARKERS[guard];
+				for (const fn of entry.functionNames) {
+					const vicinity = functionVicinity(backend, entry.repoFile, fn);
+					expect(
+						marker.test(vicinity),
+						`${name}: ${backend}/${entry.repoFile}.ts ${fn} に guard (${guard} = ${marker}) が必要`,
+					).toBe(true);
+				}
+			}
+		}
+	});
+
+	it('service-layer guard (dsql certificates 等) は import-service に dedup 実装が存在する', () => {
+		// DSQL certificates は DB unique 制約を持たないため、import-service の service 層 dedup が
+		// backend 間機能等価の唯一の防御。実装 (findCertificates prefetch + certificateType Set) の
+		// 存在をマーカーで検査する。
+		const serviceLayerEntities = Object.entries(RESTORE_IDEMPOTENCY_REGISTRY).filter(([, e]) =>
+			Object.values(e.guards).includes('service-layer'),
+		);
+		expect(serviceLayerEntities.map(([n]) => n)).toEqual(['certificate']);
+
+		const importService = readFileSync(
+			join(__dirname, '../../../src/lib/server/services/import-service.ts'),
+			'utf-8',
+		);
+		expect(/seenTypesByChild|certificateType.*Set|Set.*certificateType/s.test(importService)).toBe(
+			true,
+		);
+	});
+
+	it('content-dedup entity (parentMessage / siblingCheer) は import-service に content key dedup が存在する', () => {
+		const importService = readFileSync(
+			join(__dirname, '../../../src/lib/server/services/import-service.ts'),
+			'utf-8',
+		);
+		// parentMessage: (messageType, stampCode, body, sentAt) content key
+		expect(importService).toContain('${m.messageType}|${m.stampCode ?? ');
+		// siblingCheer: (fromChildId, toChildId, stampCode, sentAt) content key
+		expect(importService).toContain('${fromChildId}|${toChildId}|${c.stampCode}|${c.sentAt}');
+	});
+});

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -206,6 +206,8 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 			},
 			T,
 		);
+		// #3394 統一冪等契約: fresh DB の seed では必ず non-null (null = 重複 skip)
+		if (!stampCard) throw new Error('seed: stamp card insert failed');
 		await getRepos().stampCard.insertEntryForRestore(
 			{
 				cardId: stampCard.id,
@@ -590,11 +592,14 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		testDb.insert(schema.children).values({ nickname: 'あに', age: 10, theme: 'blue' }).run(); // id=1
 		testDb.insert(schema.children).values({ nickname: 'いもうと', age: 7, theme: 'pink' }).run(); // id=2
 
+		// #3420: stampCode は CHEER_STAMPS allowlist (sibling-cheer-service.ts、送信経路と同一 SSOT) の
+		// 実在コードを使う。旧 fixture 'good-job' は allowlist 外で実データに存在し得ず、
+		// import の verbatim 値検証 (改竄 backup 防御) が正しく skip する。
 		await getRepos().siblingCheer.insertForRestore(
 			{
 				fromChildId: asChildId(1),
 				toChildId: asChildId(2),
-				stampCode: 'good-job',
+				stampCode: 'nice',
 				sentAt: '2026-02-15T10:00:00Z',
 				shownAt: '2026-02-15T12:00:00Z',
 			},

--- a/tests/unit/services/import-restore-idempotency.test.ts
+++ b/tests/unit/services/import-restore-idempotency.test.ts
@@ -283,20 +283,20 @@ describe('#3394 restore 冪等 guard 統一 (corrupted backup → skip + count �
 
 		// --- 実 DB 最終状態: 重複が物理的に 1 行へ収束している ---
 		const children = await findAllChildren(T);
-		const yuki = children.find((c) => c.nickname === 'ゆうき');
-		if (!yuki) throw new Error('restored child not found');
-		const challenges = await getRepos().childChallenge.findByChildId(yuki.id, T);
+		const restoredChild = children.find((c) => c.nickname === 'ゆうき');
+		if (!restoredChild) throw new Error('restored child not found');
+		const challenges = await getRepos().childChallenge.findByChildId(restoredChild.id, T);
 		expect(challenges.length, 'DB: auto:weekly 1 行').toBe(1);
-		const cards = await getRepos().stampCard.findCardsByChild(yuki.id, T);
+		const cards = await getRepos().stampCard.findCardsByChild(restoredChild.id, T);
 		expect(cards.length, 'DB: card 1 枚').toBe(1);
 		const cardId = cards[0]?.id as string;
 		const entries = await getRepos().stampCard.findEntriesByCardId(cardId, T);
 		expect(entries.length, 'DB: 押印 1 件').toBe(1);
-		const certs = await getRepos().certificate.findCertificates(yuki.id, T);
+		const certs = await getRepos().certificate.findCertificates(restoredChild.id, T);
 		expect(certs.length, 'DB: 証明書 1 通').toBe(1);
-		const prefs = await getRepos().activityPref.findAllByChild(yuki.id, T);
+		const prefs = await getRepos().activityPref.findAllByChild(restoredChild.id, T);
 		expect(prefs.length, 'DB: 活動設定 1 件').toBe(1);
-		const messages = await getRepos().message.findMessages(yuki.id, 100, T);
+		const messages = await getRepos().message.findMessages(restoredChild.id, 100, T);
 		expect(messages.length, 'DB: メッセージ 1 件').toBe(1);
 
 		// --- #3465 item 3: activityPref createdAt/updatedAt round-trip (ADR-0006) ---

--- a/tests/unit/services/import-restore-idempotency.test.ts
+++ b/tests/unit/services/import-restore-idempotency.test.ts
@@ -1,0 +1,348 @@
+// tests/unit/services/import-restore-idempotency.test.ts
+// #3394 (same-class #3385/#3391/#3387/#3401/#3414/#3420/#3465):
+// backup restore の冪等 guard 統一契約を実 SQLite で検証する (failing-test-first)。
+//
+// 検証する統一契約 (src/lib/server/db/restore-idempotency.ts が SSOT):
+//   1. natural-key 重複 (challenge auto:weekly / stampCard / stampEntry / certificate /
+//      activityPref) は skip され imported に加算されない (count 偽装 #2263 class 防止)
+//   2. content-dedup (parentMessage / siblingCheer) は merge mode で同一 content の重複を skip、
+//      verbatim (cutover #3653) では bypass される
+//   3. verbatim 値検証 (#3414/#3420): 未知 messageType / 未知 stampCode / 不正 sentAt は
+//      mode 不問で skip + warning 可視化
+//   4. count 恒等式: 各 entity で「入力件数 = imported + skipped」(silent loss 検出)
+//   5. timestamps round-trip (#3465 item 3): activityPref の createdAt/updatedAt が保全される
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../../src/lib/server/db/schema';
+import {
+	closeDb,
+	createTestDb,
+	resetDb,
+	seedChildActivities,
+	type TestDb,
+	type TestSqlite,
+} from '../helpers/test-db';
+
+let sqlite: TestSqlite;
+let testDb: TestDb;
+
+vi.mock('$lib/server/db', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { type ActivityId, asCategoryId, asChildId } from '$lib/domain/ids';
+import { findAllChildren } from '../../../src/lib/server/db/child-repo';
+import { getRepos } from '../../../src/lib/server/db/factory';
+import { getChildActivities } from '../../../src/lib/server/services/activity-service';
+import { clearAllFamilyData } from '../../../src/lib/server/services/data-service';
+import { exportFamilyData } from '../../../src/lib/server/services/export-service';
+import { importFamilyData } from '../../../src/lib/server/services/import-service';
+
+const T = 't-restore-idem';
+
+beforeAll(() => {
+	const t = createTestDb();
+	sqlite = t.sqlite;
+	testDb = t.db;
+});
+afterAll(() => {
+	closeDb(sqlite);
+});
+beforeEach(() => {
+	resetDb(sqlite);
+});
+
+/** seed → export → 重複/不正行を注入した「corrupted backup」を作る共通 arrange。 */
+async function buildCorruptedBackup() {
+	// --- seed: 2 children (cheer は from/to 2 child 必要) ---
+	testDb.insert(schema.children).values({ nickname: 'ゆうき', age: 8, theme: 'blue' }).run(); // id=1
+	testDb.insert(schema.children).values({ nickname: 'さくら', age: 6, theme: 'pink' }).run(); // id=2
+	seedChildActivities(testDb, 1, [{ name: 'うんどうA', categoryId: asCategoryId(1), icon: '🏃' }]);
+	const acts = await getChildActivities(asChildId(1), T);
+	const actId = acts[0]?.id as ActivityId;
+
+	// auto:weekly チャレンジ (#3387: (child, weekStart) natural key)
+	await getRepos().childChallenge.insert(
+		{
+			childId: asChildId(1),
+			title: 'こんしゅうのチャレンジ',
+			periodType: 'weekly',
+			startDate: '2026-03-01',
+			endDate: '2026-03-07',
+			targetConfig: '{"metric":"count","baseTarget":3}',
+			rewardConfig: '{"points":50}',
+			targetValue: 3,
+			sourceTemplateId: 'auto:weekly',
+		},
+		T,
+	);
+
+	// スタンプカード + 押印 (#3391: (child, weekStart) / (card, slot) natural key)
+	const card = await getRepos().stampCard.insertCardForRestore(
+		{
+			childId: asChildId(1),
+			weekStart: '2026-02-23',
+			weekEnd: '2026-03-01',
+			status: 'collecting',
+			redeemedPoints: null,
+			redeemedAt: null,
+			createdAt: '2026-02-23T00:00:00Z',
+			updatedAt: '2026-02-23T00:00:00Z',
+		},
+		T,
+	);
+	if (!card) throw new Error('seed: stamp card insert failed');
+	await getRepos().stampCard.insertEntryForRestore(
+		{
+			cardId: card.id,
+			stampMasterId: null,
+			omikujiRank: 'daikichi',
+			slot: 0,
+			loginDate: '2026-02-24',
+			earnedAt: '2026-02-24T08:00:00Z',
+		},
+		T,
+	);
+
+	// 証明書 (#3401/#3394: (child, certificateType) natural key)
+	await getRepos().certificate.insertForRestore(
+		{
+			childId: asChildId(1),
+			certificateType: 'graduation',
+			title: 'そつぎょうしょうめいしょ',
+			description: null,
+			issuedAt: '2026-02-01T00:00:00Z',
+			metadata: null,
+		},
+		T,
+	);
+
+	// 活動設定 (#3465: (child, activity) natural key + timestamps round-trip)
+	await getRepos().activityPref.insertForRestore(
+		{
+			childId: asChildId(1),
+			activityId: actId,
+			isPinned: 1,
+			pinOrder: 1,
+			createdAt: '2026-02-05T00:00:00Z',
+			updatedAt: '2026-02-06T00:00:00Z',
+		},
+		T,
+	);
+
+	// 親→子メッセージ (#3414: content-dedup 対象)
+	await getRepos().message.insertForRestore(
+		{
+			childId: asChildId(1),
+			messageType: 'text',
+			stampCode: null,
+			body: 'よくがんばったね',
+			icon: '💌',
+			sentAt: '2026-02-10T09:00:00Z',
+			shownAt: null,
+			bonusPoints: null,
+			rewardCategory: null,
+		},
+		T,
+	);
+
+	// きょうだいおうえん (#3420: content-dedup 対象、from=2 → to=1)
+	await getRepos().siblingCheer.insertForRestore(
+		{
+			fromChildId: asChildId(2),
+			toChildId: asChildId(1),
+			stampCode: 'ganbare',
+			sentAt: '2026-02-11T10:00:00Z',
+			shownAt: null,
+		},
+		T,
+	);
+
+	// --- export → corrupted backup 化 (重複 + 不正行を注入) ---
+	const data = await exportFamilyData({ tenantId: T });
+	expect(data.data.childChallenges.length).toBe(1);
+	expect(data.data.stampCards.length).toBe(1);
+	expect(data.data.certificates.length).toBe(1);
+	expect(data.data.activityPrefs.length).toBe(1);
+	expect(data.data.parentMessages.length).toBe(1);
+	expect(data.data.siblingCheers.length).toBe(1);
+
+	// natural-key 重複 (手編集 backup 相当): 同 (child, week) auto:weekly / 同 (child, week) card /
+	// 同 (card, slot) entry / 同 (child, type) certificate / 同 (child, activity) pref
+	const challenge0 = data.data.childChallenges[0];
+	const card0 = data.data.stampCards[0];
+	const entry0 = card0?.entries[0];
+	const cert0 = data.data.certificates[0];
+	const pref0 = data.data.activityPrefs[0];
+	const msg0 = data.data.parentMessages[0];
+	const cheer0 = data.data.siblingCheers[0];
+	if (!challenge0 || !card0 || !entry0 || !cert0 || !pref0 || !msg0 || !cheer0) {
+		throw new Error('seed export rows missing');
+	}
+	card0.entries.push({ ...entry0 }); // 同 card 内 slot 重複
+	data.data.childChallenges.push({ ...challenge0 });
+	data.data.stampCards.push(structuredClone(card0)); // 重複 card (entries 2 件込み)
+	data.data.certificates.push({ ...cert0 });
+	data.data.activityPrefs.push({ ...pref0 });
+	// content 重複 (同一 backup 再取込相当) + 不正行 (改竄 backup 相当、#3414/#3420 値検証)
+	data.data.parentMessages.push({ ...msg0 });
+	data.data.parentMessages.push({ ...msg0, messageType: 'evil_type' });
+	data.data.siblingCheers.push({ ...cheer0 });
+	data.data.siblingCheers.push({ ...cheer0, stampCode: 'hacked_code' });
+
+	return data;
+}
+
+describe('#3394 restore 冪等 guard 統一 (corrupted backup → skip + count 整合)', () => {
+	it('merge: natural-key/content 重複は skip され、count 恒等式 (入力 = imported + skipped) が全 entity で成立する', async () => {
+		const data = await buildCorruptedBackup();
+		await clearAllFamilyData(T);
+
+		const result = await importFamilyData(data, T);
+
+		// --- natural-key 重複 → skip + 実 DB は 1 行 ---
+		expect(result.childChallengesImported, 'challenge imported').toBe(1);
+		expect(result.childChallengesSkipped, 'challenge skipped').toBe(1);
+		expect(result.stampCardsImported, 'card imported').toBe(1);
+		expect(result.stampCardsSkipped, 'card skipped').toBe(1);
+		// entries 入力 4 (正 1 + 同 card slot 重複 1 + 重複 card 配下 2) → 実 insert は 1 のみ
+		expect(result.stampEntriesImported, 'entry imported').toBe(1);
+		expect(result.stampEntriesSkipped, 'entry skipped').toBe(3);
+		expect(result.certificatesImported, 'cert imported').toBe(1);
+		expect(result.certificatesSkipped, 'cert skipped').toBe(1);
+		expect(result.activityPrefsImported, 'pref imported').toBe(1);
+		expect(result.activityPrefsSkipped, 'pref skipped').toBe(1);
+
+		// --- content-dedup + 値検証 (入力 3 = 正 1 + content 重複 1 + 不正 1) ---
+		expect(result.parentMessagesImported, 'message imported').toBe(1);
+		expect(result.parentMessagesSkipped, 'message skipped').toBe(2);
+		expect(result.siblingCheersImported, 'cheer imported').toBe(1);
+		expect(result.siblingCheersSkipped, 'cheer skipped').toBe(2);
+		// 不正行は warning で可視化 (silent skip 禁止、#3414/#3420)
+		expect(result.warnings.some((w) => w.includes('evil_type'))).toBe(true);
+		expect(result.warnings.some((w) => w.includes('hacked_code'))).toBe(true);
+
+		// --- count 恒等式 (入力件数 = imported + skipped、silent loss 検出) ---
+		const identity: Array<[string, number, number, number]> = [
+			[
+				'childChallenges',
+				data.data.childChallenges.length,
+				result.childChallengesImported,
+				result.childChallengesSkipped,
+			],
+			[
+				'stampCards',
+				data.data.stampCards.length,
+				result.stampCardsImported,
+				result.stampCardsSkipped,
+			],
+			[
+				'stampEntries',
+				data.data.stampCards.reduce((n, c) => n + c.entries.length, 0),
+				result.stampEntriesImported,
+				result.stampEntriesSkipped,
+			],
+			[
+				'certificates',
+				data.data.certificates.length,
+				result.certificatesImported,
+				result.certificatesSkipped,
+			],
+			[
+				'activityPrefs',
+				data.data.activityPrefs.length,
+				result.activityPrefsImported,
+				result.activityPrefsSkipped,
+			],
+			[
+				'parentMessages',
+				data.data.parentMessages.length,
+				result.parentMessagesImported,
+				result.parentMessagesSkipped,
+			],
+			[
+				'siblingCheers',
+				data.data.siblingCheers.length,
+				result.siblingCheersImported,
+				result.siblingCheersSkipped,
+			],
+		];
+		for (const [name, input, imported, skipped] of identity) {
+			expect(imported + skipped, `count 恒等式: ${name}`).toBe(input);
+		}
+
+		// --- 実 DB 最終状態: 重複が物理的に 1 行へ収束している ---
+		const children = await findAllChildren(T);
+		const yuki = children.find((c) => c.nickname === 'ゆうき');
+		if (!yuki) throw new Error('restored child not found');
+		const challenges = await getRepos().childChallenge.findByChildId(yuki.id, T);
+		expect(challenges.length, 'DB: auto:weekly 1 行').toBe(1);
+		const cards = await getRepos().stampCard.findCardsByChild(yuki.id, T);
+		expect(cards.length, 'DB: card 1 枚').toBe(1);
+		const cardId = cards[0]?.id as string;
+		const entries = await getRepos().stampCard.findEntriesByCardId(cardId, T);
+		expect(entries.length, 'DB: 押印 1 件').toBe(1);
+		const certs = await getRepos().certificate.findCertificates(yuki.id, T);
+		expect(certs.length, 'DB: 証明書 1 通').toBe(1);
+		const prefs = await getRepos().activityPref.findAllByChild(yuki.id, T);
+		expect(prefs.length, 'DB: 活動設定 1 件').toBe(1);
+		const messages = await getRepos().message.findMessages(yuki.id, 100, T);
+		expect(messages.length, 'DB: メッセージ 1 件').toBe(1);
+
+		// --- #3465 item 3: activityPref createdAt/updatedAt round-trip (ADR-0006) ---
+		expect(prefs[0]?.createdAt, 'pref createdAt 保全').toBe('2026-02-05T00:00:00Z');
+		expect(prefs[0]?.updatedAt, 'pref updatedAt 保全').toBe('2026-02-06T00:00:00Z');
+		expect(prefs[0]?.isPinned).toBe(1);
+		expect(prefs[0]?.pinOrder).toBe(1);
+	});
+
+	it('merge: 同一 backup の再取込 (2 回連続 import) でも重複行が増殖しない (冪等)', async () => {
+		const data = await buildCorruptedBackup();
+		await clearAllFamilyData(T);
+
+		await importFamilyData(data, T);
+		// 2 回目: 子は新規作成されるが、各 entity は「その子の中で」重複しないことを検証する
+		// (natural-key / content dedup は per-child scope。同一 backup 内の重複注入分が
+		//  2 回目でも同様に skip され、カウントが偽装されないこと)。
+		const second = await importFamilyData(data, T);
+		expect(second.childChallengesImported).toBe(1);
+		expect(second.childChallengesSkipped).toBe(1);
+		expect(second.stampCardsImported).toBe(1);
+		expect(second.stampEntriesImported).toBe(1);
+		expect(second.certificatesImported).toBe(1);
+		expect(second.activityPrefsImported).toBe(1);
+		expect(second.parentMessagesImported).toBe(1);
+		expect(second.siblingCheersImported).toBe(1);
+	});
+
+	it('verbatim (cutover #3653): content-dedup は bypass されるが natural-key guard と値検証は維持される', async () => {
+		const data = await buildCorruptedBackup();
+		await clearAllFamilyData(T);
+
+		const result = await importFamilyData(data, T, undefined, { mode: 'verbatim' });
+
+		// content 重複は正当な複数行として全復元 (dedup bypass)。不正行 (値検証) のみ skip。
+		expect(result.parentMessagesImported, 'verbatim: message 重複を保全').toBe(2);
+		expect(result.parentMessagesSkipped, 'verbatim: 不正行のみ skip').toBe(1);
+		expect(result.siblingCheersImported, 'verbatim: cheer 重複を保全').toBe(2);
+		expect(result.siblingCheersSkipped, 'verbatim: 不正行のみ skip').toBe(1);
+
+		// natural-key guard は DB 一意制約の物理事実のため verbatim でも維持 (二重化不能)。
+		expect(result.childChallengesImported).toBe(1);
+		expect(result.childChallengesSkipped).toBe(1);
+		expect(result.stampCardsImported).toBe(1);
+		expect(result.stampEntriesImported).toBe(1);
+		expect(result.certificatesImported).toBe(1);
+		expect(result.activityPrefsImported).toBe(1);
+	});
+});

--- a/tests/unit/services/import-service.test.ts
+++ b/tests/unit/services/import-service.test.ts
@@ -1607,7 +1607,8 @@ describe('importFamilyData', () => {
 			data.family.children = [makeChild('c1')];
 			data.data.childVoices = [makeVoice('c1', 'voices/7/abcd-1234.mp3')];
 			mockInsertChild.mockResolvedValue({ id: '101' });
-			mockVoiceInsertForRestore.mockResolvedValue(undefined);
+			// #3394 統一冪等契約: 永続化成功は non-null ({ id }) を返す (undefined/null は skip 計上される)
+			mockVoiceInsertForRestore.mockResolvedValue({ id: '1' });
 
 			const result = await importFamilyData(data, TENANT);
 
@@ -1629,7 +1630,8 @@ describe('importFamilyData', () => {
 				makeVoice('c1', 'voices/7/safe.mp3'), // 正常エントリ (1 件だけ通る)
 			];
 			mockInsertChild.mockResolvedValue({ id: '101' });
-			mockVoiceInsertForRestore.mockResolvedValue(undefined);
+			// #3394 統一冪等契約: 永続化成功は non-null ({ id }) を返す (undefined/null は skip 計上される)
+			mockVoiceInsertForRestore.mockResolvedValue({ id: '1' });
 
 			const result = await importFamilyData(data, TENANT);
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ システム全体（backup restore を使う全家庭）

**解決する課題**: backup restore の insertForRestore 系が backend ごとに冪等 guard を持ったり持たなかったりする非対称 (#3385 challenge / #3391 stampcard で 2 件連続発生した same-class 欠陥) があり、corrupted / 手編集 backup の取込で「DynamoDB では silent 上書き + 取込件数の水増し」「demo では書き込んでいないのに imported++」が起こり得た。throttle 等の真の write 失敗も「重複 skip」と誤分類され silent loss になっていた (#3401)。

**期待される効果**: どの backend (sqlite / DynamoDB / DSQL / demo) でも restore の重複は同一の skip + count 計上になり、取込サマリ (imported / skipped / errors) が実 DB 状態と一致する。改竄 backup の不正値 (未知 messageType / 未知 stampCode / 不正日時) は import 境界で弾かれ、子供画面のおうえん描画・日次上限計算を汚染しない。

## 関連 Issue

closes #3394
closes #3387
closes #3401
closes #3414
closes #3420
related #3465（item 1 = DynamoDB ConditionExpression + count 整合 / item 3 = createdAt・updatedAt round-trip assert を本 PR で充足。item 2 = 同名活動 collapse の安定識別子 rebinding 根治と item 4 = registry flip の partial-backup 可視化は残 AC として同 Issue で継続。残 AC は Issue コメントに明記済）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| #3394-1 | 全 insertForRestore (DynamoDB) に unique index 相当の ConditionExpression を付与し、衝突時は SQLite と同じく skip + 可視化に統一 | `npx vitest run tests/unit/db/restore-idempotency-registry.test.ts`（guard 対称性 source-scan） | HEAD `7f65f944` / 4 passed / `src/lib/server/db/dynamodb/{stamp-card,child-challenge,activity-pref,certificate}-repo.ts` に `attribute_not_exists(PK)` + null 契約 |
| #3394-2 | import カウントは実 insert 成功時のみ加算 (skip / condition fail 時は加算しない) | `npx vitest run tests/unit/services/import-restore-idempotency.test.ts` | HEAD `7f65f944` / 3 passed。count 恒等式「入力 = imported + skipped」を challenge/card/entry/cert/pref/message/cheer の 7 entity で assert（tests/unit/services/import-restore-idempotency.test.ts:206-）。旧実装では同 test が 3 件 red（failing-test-first 証跡は下記） |
| #3394-3 | fitness function: SQLite unique index と DynamoDB ConditionExpression の対称性を検査し、新規 backup 対象追加時の非対称を CI 機械検出 | `npx vitest run tests/unit/db/restore-idempotency-registry.test.ts` | HEAD `7f65f944` / no-silent-gap（4 backend の `*ForRestore` 全 12 関数 × registry 双方向一致）+ guard marker 検査 PASS。SSOT = `src/lib/server/db/restore-idempotency.ts` |
| #3394-4 | 両 backend の dedup 非対称を固定する round-trip test（重複 backup → 同一の skip + count 不加算） | `npx vitest run tests/unit/services/import-restore-idempotency.test.ts tests/unit/db/dynamodb-stamp-card-repo.test.ts tests/unit/db/dsql-stamp-mission-repos.test.ts` | HEAD `7f65f944` / sqlite=実 DB round-trip（corrupted backup 注入）、DynamoDB=repo unit（null/false 契約）、DSQL=PGlite 実 schema（ON CONFLICT → null/false）。全 PASS |
| #3387-1 | DynamoDB insertForRestore の auto:weekly Put に attribute_not_exists 条件を付け、衝突時は SQLite と同じ skip + 可視化 | `npx vitest run tests/unit/db/dynamodb-child-challenge-repo.test.ts` | HEAD `7f65f944` / 38 passed（`#3387/#3394 insertForRestore 冪等 guard` 3 case: ConditionExpression 付与 / 重複 null / throttle throw）/ `src/lib/server/db/dynamodb/child-challenge-repo.ts:221-` |
| #3387-2 | 両 backend に「同一週 auto:weekly 重複 backup → skip + count 不加算」の衝突 test | `npx vitest run tests/unit/db/dsql-eval-battle-challenge-repos.test.ts tests/unit/services/import-restore-idempotency.test.ts` | HEAD `7f65f944` / DSQL=[C9b]（weekly_auto_guard → null + 既存行不変）、sqlite=corrupted backup round-trip（childChallengesImported=1 / Skipped=1 / DB 1 行）。全 PASS |
| #3401-1 | insertForRestore の catch を例外分類: ConditionalCheckFailedException のみ skip (null)、その他は throw or errors へ可視化 | `npx vitest run tests/unit/db/dynamodb-certificate-repo.test.ts` | HEAD `7f65f944` / `#3401 insertForRestore 例外分類` 3 case PASS（重複 null / throttle throw / 成功 verbatim）。旧 catch-all `return null` を撤去（`src/lib/server/db/dynamodb/certificate-repo.ts:175-`） |
| #3401-2 | certificate / challenge / stampcard / reward 等 restore 系全体で観測性を統一 | `grep -n "throw e" src/lib/server/db/dynamodb/{certificate,child-challenge,stamp-card,activity-pref}-repo.ts` + registry fitness | HEAD `7f65f944` / 4 repo とも「重複=null / その他=throw」に統一。import-service は throw を errors[] に push（skip と区別して可視化）。契約は `src/lib/server/db/restore-idempotency.ts` 冒頭コメントに SSOT 化 |
| #3414-1 | append/execute mode の重複取込: idempotency key or 取込済み検出 | `npx vitest run tests/unit/services/import-restore-idempotency.test.ts` | HEAD `7f65f944` / merge mode で content key (messageType, stampCode, body, sentAt) による既存行 + 同一 import 内 dedup（`src/lib/server/services/import-service.ts` importParentMessagesData）。verbatim (cutover #3653) は bypass を test で固定 |
| #3414-2 | verbatim 書き戻しの値検証: messageType/stampCode/body/icon/bonusPoints の allowlist/enum/範囲バリデータ | 同上（不正行 `evil_type` の skip + warning を assert） | HEAD `7f65f944` / `validateParentMessageRow`: MESSAGE_TYPES enum（domain/validation/message.ts SSOT）+ stampCode≤30 / body≤200 / icon≤10 / bonusPoints 0-99999 整数 / sentAt・shownAt ISO 検証。skip + warnings 可視化 |
| #3414-3 | childRef フォールバックを「解決不能 → 明示 skip + error」に統一 | `npx vitest run tests/unit/services/backup-roundtrip-completeness.test.ts` + code path | HEAD `7f65f944` / export 側: 旧 `child-${childId}` fallback を撤去し fail-fast throw（`src/lib/server/services/export-service.ts` collectForChild）。import 側: childRef 未解決を warnings.push で可視化（旧 silent skipped++ を撤去） |
| #3420-1 | append-mode 重複: siblingCheer の二重取込防止 | `npx vitest run tests/unit/services/import-restore-idempotency.test.ts` | HEAD `7f65f944` / content key (fromChildId, toChildId, stampCode, sentAt) で merge mode dedup（findAllByTenant prefetch + 同一 import 内 Set）。verbatim bypass も test 固定 |
| #3420-2 | childRef 未解決の silent skip 可視化 + demo insertForRestore の虚偽カウント根治 | 同上 + `grep -n "return null" src/lib/server/db/demo/sibling-cheer-repo.ts` | HEAD `7f65f944` / childRef 未解決は warnings.push。demo stub は null 返却 → import は skipped 計上（`#2263` count 偽装 class 根治。demo 8 repo の restore stub を一括 null-stub 化、fitness の demo marker 検査で固定） |
| #3420-3 | verbatim 値検証: stampCode allowlist + ISO 形式検証 | 同上（不正行 `hacked_code` の skip + warning を assert） | HEAD `7f65f944` / `validateSiblingCheerRow`: CHEER_STAMPS allowlist（sibling-cheer-service.ts の送信経路 getStampByCode と同一 SSOT）+ sentAt/shownAt ISO 検証 |
| #3465-1 | DynamoDB activity-pref insertForRestore の ConditionExpression + count 整合 | `npx vitest run tests/unit/db/dynamodb-activity-pref-repo.test.ts` | HEAD `7f65f944` / 3 passed（ConditionExpression 付与 / 重複 null / throttle throw）。新規 test file。DSQL 側も ON CONFLICT → null に統一（dsql-activity-repos [P5] を新契約に更新: 重複 null + 既存行不変） |
| #3465-3 | createdAt/updatedAt の round-trip assertion (ADR-0006) | `npx vitest run tests/unit/services/import-restore-idempotency.test.ts tests/unit/db/dsql-activity-repos.test.ts tests/unit/db/dynamodb-activity-pref-repo.test.ts` | HEAD `7f65f944` / sqlite round-trip（createdAt=2026-02-05 / updatedAt=2026-02-06 の verbatim 保全を assert）+ dynamo/dsql repo 層でも同 assert。全 PASS |
| #3465-2 | within-child 同名活動の pin collapse（安定識別子 rebinding） | <!-- ac-verification-skip: related 扱い。name-based 再結合の activityId map 化は activityLog restore と共有の systemic 課題で、本 PR は collapse 時の silent overwrite を「skip + warning 可視化」に留める（#3465 で継続） --> | 残 AC（Issue コメント記載） |
| #3465-4 | registry flip の完了シグナル誤認（partial-backup 可視化） | <!-- ac-verification-skip: related 扱い。#3362 系の partial-backup 可視化と整合させる必要があり #3465 で継続 --> | 残 AC（Issue コメント記載） |

**failing-test-first 証跡 (ADR-0061)**: `git stash push -u -- src/` で旧実装に対し新規 test を実行 → `import-restore-idempotency.test.ts` 3 件 + `dynamodb-activity-pref-repo.test.ts` 2 件 red（count 恒等式破れ / ConditionExpression 欠落 / silent overwrite）→ stash pop（本実装）で全 green。

## 変更タイプ

- [x] fix: バグ修正
- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — schema 変更なし。repo 実装 + interface 契約 + registry SSOT 新設
- [x] サービス層 (`$lib/server/services/`) — import-service / export-service

**影響を受ける画面・機能**: バックアップ復元（設定 > バックアップ / cutover import）。UI 変更なし（server-side のみ）。復元結果サマリの imported/skipped/warnings が実態と一致するようになる。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— Draft 段階では biome / svelte-check / vitest（下記個別実行で PASS 確認済: services 146 file 2404 tests / db 75 file 895 tests / svelte-check 0 errors）。Ready 化時に `--pr` 付き全 step を再実行する
- [x] 追加・変更したテストの概要を以下に記載:
  - 新規: `tests/unit/services/import-restore-idempotency.test.ts`（corrupted backup 実 SQLite round-trip、count 恒等式 + merge/verbatim + 値検証）
  - 新規: `tests/unit/db/restore-idempotency-registry.test.ts`（fitness: no-silent-gap + guard 対称性 source-scan + demo null-stub 検査）
  - 新規: `tests/unit/db/dynamodb-activity-pref-repo.test.ts`（ConditionExpression / null / throw 契約）
  - 追補: dynamodb-{child-challenge,stamp-card,certificate}-repo.test.ts（guard 3 case × 3）/ dsql-{activity,stamp-mission,eval-battle-challenge}-repos.test.ts（重複 → null/false + 既存行不変）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021)**: SQLite + DynamoDB + DSQL + demo の 4 backend 全てを同一契約で更新（片 backend のみ禁止 #1012 準拠）。`node scripts/check-dynamodb-stub.mjs` PASS
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:critical ラベルなし。corrupted backup 限定の data-integrity hardening）

## スクリーンショット / ビジュアルデモ

**該当なし（server-side のみ — repo 層 / import-service / export-service の契約変更で UI 変更なし）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 冪等契約を interface (I) に明文化し、backend 実装 (D) は各 DB の native 機構（ConditionExpression / ON CONFLICT / onConflictDoNothing）へ委譲。分類 SSOT は `restore-idempotency.ts` に単一責任 (S) で分離
- [x] **DRY**: 同 class の欠陥 (#3385/#3391/#3387/#3401/#3414/#3420/#3465) を registry + fitness で class ごと固定。`grep -rn "ForRestore" src/` で全 12 関数 × 4 backend を棚卸し、残存の無条件 Put ゼロを確認
- [x] **YAGNI**: registry は分類宣言のみ（runtime 機構なし）。dedup は既存 DB 制約 / 既存 find* の再利用で新規 index / テーブルを追加しない
- [x] **Security（OSS 公開前提）**: 改竄 backup の default-deny 検証を強化（messageType enum / stampCode allowlist / bonusPoints 範囲 / ISO 日時）。CWE-20 入力検証を import 境界に追加
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: content dedup の prefetch は child 単位 / tenant 単位の 1 回ずつ（N+1 なし）。dynamo の追加 read なし（ConditionExpression は Put に同梱）

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照）:

- [x] E2E / ユニットシード（`tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` / `src/lib/server/demo/demo-data.ts`）と チュートリアル (`tutorial-chapters.ts` / `demo-guide-state.svelte.ts`) を同期 — schema 変更なしのため既存 seed 影響なし（backup-roundtrip-completeness の fixture 1 件を CHEER_STAMPS SSOT 準拠コードに是正）
- [x] **設計書同期** (ADR-0001): DB スキーマ / API / UI 変更なし。restore 冪等契約の SSOT はコード内 registry（`src/lib/server/db/restore-idempotency.ts`）+ interface JSDoc に配置（docs/CLAUDE.md 更新ルール表の対象外）
- [x] **並行 PR overlap** (#1200): rebase 済 develop HEAD (`5f5ac461` #3715 restore ledger 並列化) と衝突なしを rebase + 全 test 再実行で確認
- [x] N/A — 本番/デモ画面・年齢モード・ナビ・labels は変更なし

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

（interface 返り値の `| null` / `boolean` 化は内部契約変更で、呼び出し側は import-service のみ。同 PR 内で全 caller を追従済み。DB スキーマ / API / export format は不変）

**レビュー依頼事項・QA**:
- DSQL activity-pref [P5] は旧「重複 → 23505 throw」assert を新契約「重複 → null + 既存行不変」に更新した。重複を物理拒否する不変条件自体は維持・強化（行数不変 + silent overwrite なしを追加 assert）しており assertion 弱体化 (ADR-0006) には該当しない認識だが、観点確認を依頼
- `backup-roundtrip-completeness.test.ts` の cheer fixture `'good-job'` は CHEER_STAMPS allowlist 外（送信経路 sendCheer では作成不能な値）だったため `'nice'` に是正した

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready` 全 Step PASS** をローカル確認した（PR 未作成モード。Step 1 biome は worktree パスが `biome.json` の `!**/.claude` に一致し `.` 指定が空振りするため、変更 44 file 明示指定で PASS を確認し `--skip-biome` で残 step を実行。Step 9 相当は `node scripts/check-pr-body.mjs --body-file tmp/pr-bodies/3394.md --skip-mergeable` で PASS。Ready 化時に `--pr <num>` 付きで再実行する）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完のまま残る AC は closes 対象に含めていない — #3465 は related とし残 AC を Issue コメントに明記）
- [x] Phase 分割した場合: N/A（Phase 分割なし。#3465 の残 AC は既存 Issue のまま継続で新規分割なし）
- [x] UI 変更時: N/A（server-side のみ、UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
