### PR TITLE
docs: #3681 07-API /ops/license 節の個別 endpoint 見出しに deprecated マーカー付与

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1411,7 +1411,7 @@ backend が不健全 (接続不可 / schema 不在) の場合は **503** + `{"st
 
 > **deprecated (Epic #2525 license key 全廃)**: 以下の `/ops/license` / `/ops/license/[key]` / `/ops/license/issue` / `/ops/license/legacy-count` 系統はすべて物理削除された (PR-L3 PR #2822)。割引・campaign 配布は Stripe Coupon / Promotion Code (Stripe Dashboard) で代替する。リンク先 `license-hmac-migration-plan.md` も deprecated (HMAC 移行は機構全廃により不要、歴史記録)。本節以降の `/ops/license/*` 仕様は歴史記録として残す。
 
-#### GET /ops/license （ライセンスキー管理 - 一覧 / 検索 #805）
+#### GET /ops/license （ライセンスキー管理 - 一覧 / 検索 #805） — deprecated (Epic #2525 で削除)
 
 **認証:** Cognito User Pool `ops` group メンバーであること
 
@@ -1422,7 +1422,7 @@ backend が不健全 (接続不可 / schema 不在) の場合は **503** + `{"st
 **URL パラメータ:**
 - `limit` (query, number): イベント取得件数。デフォルト 50、最大 200
 
-#### GET /ops/license/[key] （ライセンスキー詳細 #805）
+#### GET /ops/license/[key] （ライセンスキー詳細 #805） — deprecated (Epic #2525 で削除)
 
 **認証:** Cognito User Pool `ops` group メンバーであること
 
@@ -1434,7 +1434,7 @@ backend が不健全 (接続不可 / schema 不在) の場合は **503** + `{"st
 - 当該キーの `license_events` 履歴（最新 200 件）
 - `status='active'` のときのみ「失効」ボタンを表示
 
-#### POST /ops/license/[key]?/revoke （ライセンスキー失効 form action #805）
+#### POST /ops/license/[key]?/revoke （ライセンスキー失効 form action #805） — deprecated (Epic #2525 で削除)
 
 **認証:** Cognito User Pool `ops` group メンバーであること
 
@@ -1457,7 +1457,7 @@ backend が不健全 (接続不可 / schema 不在) の場合は **503** + `{"st
 - `license_events` に `eventType='revoked'` を記録 (#804)
 - `ops_audit_log` に `action='license.revoke'` / `target=<key>` / `metadata={reason, note}` を記録 (#820)
 
-#### GET /ops/license/issue （キャンペーンキー一括発行ページ #802）
+#### GET /ops/license/issue （キャンペーンキー一括発行ページ #802） — deprecated (Epic #2525 で削除)
 
 **認証:** Cognito User Pool `ops` group メンバーであること
 
@@ -1465,7 +1465,7 @@ backend が不健全 (接続不可 / schema 不在) の場合は **503** + `{"st
 - Stripe を経由しないキャンペーン配布・サポート補償・プレゼント用のライセンスキーを一括発行する入力画面
 - 発行結果は同一ページでテキスト表示 + CSV ダウンロード（`campaign-keys-YYYY-MM-DD.csv`）
 
-#### POST /ops/license/issue?/issue （キャンペーンキー一括発行 form action #802）
+#### POST /ops/license/issue?/issue （キャンペーンキー一括発行 form action #802） — deprecated (Epic #2525 で削除)
 
 **認証:** Cognito User Pool `ops` group メンバーであること
 
@@ -1491,7 +1491,7 @@ backend が不健全 (接続不可 / schema 不在) の場合は **503** + `{"st
 - `license_events` に `eventType='issued'` を各キー分記録 (#804)
 - `ops_audit_log` に `action='license.issue'` / `target=<tenantId>` / `metadata={plan, quantity, reason, keys, errors?}` を 1 件記録 (#820)
 
-#### GET /ops/license/legacy-count （legacy 形式 license key 残存数 集計 #2484）
+#### GET /ops/license/legacy-count （legacy 形式 license key 残存数 集計 #2484） — deprecated (Epic #2525 で削除)
 
 **認証:** Cognito User Pool `ops` group メンバーであること (`src/routes/ops/+layout.server.ts` の `isOpsMember(locals.identity)` で gate)
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（設計書を参照する開発者・監査者）

**解決する課題**: 07-API設計書の `/ops/license` 節は Epic #2525 で実体が物理削除済みだが、節内 6 endpoint の見出しが現行 spec の体裁のまま残っており、見出し単位で参照した読者が「現行 API が存在する」と誤読する false completeness があった（QM residual #3655 検出）。

**期待される効果**: 節内 6 endpoint 見出し全てに既存先例（L1205 / L1211 / L1349）と同型の「— deprecated (Epic #2525 で削除)」マーカーが付き、どの見出しから読み始めても歴史記録であることが即時に判別できる。

## 関連 Issue

closes #3681

- 検出元: QM approve body #3655（/admin/license rename class とは別 URL class として独立検出）
- 歴史記録の保全方針: #2892（節ごと削除は不採用、Issue 本文 Alternatives 参照）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | /ops/license 節に deprecated ヘッダ付与 (L2236 と同型) | `grep -n "deprecated" docs/design/07-API設計書.md`（/ops/license 節 L1410-1524 内） | HEAD `74a26a60` / 包括 blockquote ヘッダは L1410-1412 に既存（#2893 で付与済、L2236 と同型）。本 PR で QM 指摘の「個別 deprecated ヘッダ欠落」を解消: 節内 6 endpoint 見出し（L1414 / L1425 / L1437 / L1460 / L1468 / L1494）に「— deprecated (Epic #2525 で削除)」suffix を付与（L1205 / L1211 / L1349 の既存先例と同型） |
| AC2 | 同節内に現行 spec と誤読される記述が残っていないか全数確認 | 節 L1410-1524 全行目視 + `grep -n "ops/license" docs/design/07-API設計書.md` 全 12 出現確認 | HEAD `74a26a60` / 節内の全 endpoint 記述は包括ヘッダ「本節以降の `/ops/license/*` 仕様は歴史記録として残す」+ 個別見出しマーカーの 2 層で歴史記録と明示。節外の出現は L2242-2244（§3.X 表内、L2236 の deprecated ヘッダ配下）のみで現行 spec 体裁の残存 0 件 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/` 等)

上記いずれにも該当なし: `docs/design/07-API設計書.md` のみ（見出し 6 行、+6/-6）。

**影響を受ける画面・機能**: なし（docs のみ、実装コード変更 0 件）

## テスト & 安全装置セルフチェック

- [x] **pre-ready 検証**（#1775 / ADR-0030）— docs-only PR（変更は `docs/design/07-API設計書.md` +6/-6 のみ、コード / UI / LP 変更 0 件）のため関連 step を個別実行し全 PASS: Step 1 biome（対象 file なし、pre-push hook でも確認済）/ Step 1b cspell（CI scope は `src`/`tests`/`infra`/`site` のみで docs 対象外）/ Step 9 `check-pr-body.mjs --pr 3720` PASS / Step 10 `check-doc-code-references.mjs` PASS（baseline 内 149 件・61 ファイル、新規違反 0）。svelte-check / vitest / LP 系 step はソース変更 0 件のため対象外
- [x] 追加・変更したテストの概要: N/A（docs のみ。`node scripts/check-doc-code-references.mjs` PASS = baseline 内 149 件 / 61 ファイル、新規違反 0）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（docs のみの変更、UI 変更を含まない）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（docs のみ）
- [x] **DRY**: 同型の deprecated マーカー欠落が他 doc にないか確認 — license 系 stale は #2892 で全 file deprecation 済、07-API 内の /admin/license 系は #3655 で是正済、本節が最後の残（QM 独立分類どおり）
- [x] **YAGNI**: 見出し suffix のみ、新規節・新規機構なし
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外（docs のみ）
- [x] **設計書同期** (ADR-0001): 本 PR 自体が設計書の精度是正

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: Issue #3681 AC1 は「節冒頭に L2236 と同型ヘッダ付与」だが、包括 blockquote ヘッダは #2893（2026-06-04）で既に L1410-1412 に付与済みであることを確認した。検出元 QM approve body #3655 の原文は「**個別** deprecated ヘッダ欠落（potential false completeness）」であるため、本 PR は残る gap = 6 endpoint 見出しの個別マーカー付与を実施した（既存ヘッダとの二重付与はしない）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **pre-ready 検証をローカル確認した**（docs-only PR のため関連 step 個別実行で全 PASS — 上記「テスト & 安全装置セルフチェック」参照）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし — diff は見出し 6 行 +6/-6 のみ）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A（分割なし）
- [x] UI 変更時: N/A（docs のみ）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
