### PR TITLE
fix(a11y): #3670 /admin/reports teaser「プランを見る →」低コントラスト是正 (WCAG 1.4.3)

### DIFF
--- a/src/routes/(parent)/admin/reports/+page.svelte
+++ b/src/routes/(parent)/admin/reports/+page.svelte
@@ -140,7 +140,7 @@ function maxCategoryCount(breakdown: Record<string, number>): number {
 			<div class="mt-3">
 				<a
 					href="/pricing"
-					class="inline-flex items-center gap-1 rounded-lg bg-[var(--color-action-trial-upgrade)] px-3 py-1.5 text-xs font-semibold text-[var(--color-text-inverse)] hover:bg-[var(--color-action-trial-upgrade-hover)]"
+					class="inline-flex items-center gap-1 rounded-lg bg-[var(--color-premium)] px-3 py-1.5 text-xs font-semibold text-[var(--color-text-inverse)] hover:opacity-90"
 				>
 					{REPORTS_LABELS.weeklyEmailUpsellLink}
 				</a>

--- a/src/routes/(parent)/admin/settings/data/+page.svelte
+++ b/src/routes/(parent)/admin/settings/data/+page.svelte
@@ -451,7 +451,7 @@ const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChec
 						</p>
 						<a
 							href="/pricing"
-							class="inline-block px-4 py-2 bg-[var(--color-action-primary)] text-[var(--color-text-inverse)] text-sm font-semibold rounded-lg no-underline hover:brightness-110 transition-all"
+							class="inline-block px-4 py-2 bg-[var(--color-premium)] text-[var(--color-text-inverse)] text-sm font-semibold rounded-lg no-underline hover:opacity-90 transition-all"
 							data-testid="export-upsell-cta"
 						>
 							{SETTINGS_LABELS.dataExportUpsellCta}
@@ -854,7 +854,7 @@ const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChec
 					</p>
 					<a
 						href="/pricing"
-						class="inline-block px-4 py-2 bg-[var(--color-action-primary)] text-[var(--color-text-inverse)] text-sm font-semibold rounded-lg no-underline hover:brightness-110 transition-all"
+						class="inline-block px-4 py-2 bg-[var(--color-premium)] text-[var(--color-text-inverse)] text-sm font-semibold rounded-lg no-underline hover:opacity-90 transition-all"
 						data-testid="cloud-export-upsell-cta"
 					>
 						{SETTINGS_LABELS.cloudUpsellCta}

--- a/tests/e2e/a11y-critical-cuj.spec.ts
+++ b/tests/e2e/a11y-critical-cuj.spec.ts
@@ -49,8 +49,15 @@ test.describe('CX-DoR #10 Accessibility — critical CUJ (WCAG 2.2 AA)', () => {
 
 	// ============================================================
 	// 2. 受領 admin 3 page (activities / checklists / rewards)
+	//    + /admin/reports (#3670: feature-teaser 低コントラスト検出を機に scan 対象化。
+	//      無料→有料導線の teaser CTA を持つ page で WCAG 2.2 AA 回帰を機械検出する)
 	// ============================================================
-	for (const adminPath of ['/admin/activities', '/admin/checklists', '/admin/rewards']) {
+	for (const adminPath of [
+		'/admin/activities',
+		'/admin/checklists',
+		'/admin/rewards',
+		'/admin/reports',
+	]) {
 		test(`受領 admin (${adminPath}) に critical/serious a11y 違反がない`, async ({ page }) => {
 			test.slow();
 			const res = await page.goto(adminPath, { waitUntil: 'domcontentloaded' });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）— 無料プランで `/admin/reports` を閲覧し、週次メールレポートのアップグレード導線を目にするユーザー

**解決する課題**: `/admin/reports` の週次レポート teaser 内「プランを見る →」リンクが白文字 × `--color-warning` (#ff9800) でコントラスト比 2.16:1 しかなく、WCAG 2.2 AA (1.4.3 Contrast (Minimum) = 4.5:1) を満たさずほぼ視認できない（EPIC #3533 M5 検証 SS で実測観察）。リンクが視認できなければ解消導線の recognition が不能で dead-end 相当となり、無料→有料導線 (V2MOM M) が毀損する。

**期待される効果**: アップグレード CTA が 5.70:1 のコントラストで確実に視認でき、同 class の cloud-export teaser CTA ×2 (3.34:1 → 5.70:1) も同時是正。upsell CTA の色が AiSuggest 系 premium CTA と同一トークン (`--color-premium`) に統一され NN/G #4 consistency も向上する。

## 関連 Issue

closes #3670

- 発見元: EPIC #3533 (feature-teaser paywall M5 検証、screenshots branch `issue-3533-m5/` 5c-teaser-weekly-report-mobile.png)
- Round 18 PR-A11Y-2 (@axe-core/playwright 導入、`tests/e2e/a11y-critical-cuj.spec.ts`)

## コントラスト比 計測記録 (AC1)

WCAG 2.2 relative luminance 式による算出（sRGB → linear → L = 0.2126R + 0.7152G + 0.0722B、ratio = (L1+0.05)/(L2+0.05)）:

| 箇所 | 文字色 | 背景色 | 修正前 | 修正後 |
|---|---|---|---|---|
| `/admin/reports` weekly teaser CTA | `--color-text-inverse` #ffffff | 前: `--color-action-trial-upgrade` (= `--color-warning` #ff9800) → 後: `--color-premium` (= `--color-violet-600` #7c3aed) | **2.16:1 FAIL** | **5.70:1 PASS** |
| `/admin/settings/data` export upsell CTA ×2 (AC3 横展開) | `--color-text-inverse` #ffffff | 前: `--color-action-primary` (= `--color-brand-600` #4a90d9) → 後: `--color-premium` #7c3aed | **3.34:1 FAIL** | **5.70:1 PASS** |
| hover 状態 (`hover:opacity-90`、#7c3aed@90% を banner 背景 `--color-surface-trial` #f5f3ff / white 上でブレンド ≈ #884DEF) | #ffffff | ブレンド後背景 | — | **4.82:1 PASS** |

対象テキストは text-xs (12px) / text-sm (14px) semibold = 通常テキスト（4.5:1 必要）。全て 4.5:1 以上。

**AC3 横展開の全数確認**（同型 feature-teaser 4 箇所、#3533 M5 の 5a〜5d）:

| teaser | 実装 | 判定 |
|---|---|---|
| 5a AI 提案 (AiSuggest*Panel.svelte) | `bg-[var(--color-premium)]` + 白文字 = 5.70:1 | 既に PASS（変更不要、本 PR の統一先パターン） |
| 5b cloud-export (`/admin/settings/data` ×2) | 白文字 × brand-600 = 3.34:1 | **FAIL → 本 PR で修正** |
| 5c 週次レポート (`/admin/reports`) | 白文字 × #ff9800 = 2.16:1 | **FAIL → 本 PR で修正** |
| 5d きょうだいランキング (`/admin/settings/activities`) | `underline` + `--color-text-link` #3878b8 on white = 4.62:1 | PASS（underline の非色手がかりあり、変更不要） |

共通 component ではなく個別実装のため、FAIL 全件 (5b/5c) を本 PR で修正（AC3「個別実装なら全件修正」）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 「プランを見る →」リンクのコントラスト比が 4.5:1 以上（計測値を PR に記録） | WCAG relative luminance 算出（上記「コントラスト比 計測記録」表） | HEAD `a622211a` / #ffffff on #7c3aed = **5.70:1**（修正前 2.16:1）/ src/routes/(parent)/admin/reports/+page.svelte:143 |
| AC2 | 修正は Semantic トークン経由（hex 直書きなし、stylelint PASS） | `git diff origin/develop --unified=0 -- "src/routes/(parent)/admin/**"` で hex 出現 0 確認 + `npx biome check <変更 file>` | HEAD `a622211a` / 変更は `var(--color-premium)`（`app.css` L362 定義の Semantic alias、AiSuggest 系 upgrade CTA の既存先例パターン）+ `hover:opacity-90` のみ。hex 直書き 0 件 / biome PASS |
| AC3 | 同型 teaser 全箇所への横展開確認（個別実装なら全件修正） | `grep -rn "プランを見る" src/` + 上記横展開表の 4 箇所全数照合 | HEAD `a622211a` / 個別実装 4 箇所を全数照合、FAIL 2 class (5b ×2 / 5c) を修正、PASS 2 class (5a / 5d) は変更不要（上表） |
| AC4 | 修正前後 SS 4 スロット添付 + axe (serious 以上 0 件) 確認 | `tests/e2e/a11y-critical-cuj.spec.ts` + SS 4 スロット | HEAD `a622211a` / `/admin/reports` を a11y spec の admin loop に追加（tests/e2e/a11y-critical-cuj.spec.ts:53）。SS は親セッションが撮影して「スクリーンショット」セクションに追補する（本 agent 環境では dev server / capture 実行不可のため、CI screenshot-quality-check + lp/app visual regression が authoritative）。なお axe color-contrast rule は既知違反として baseline pin 済（tests/e2e/a11y-baseline.json）のため、本修正の contrast 検証は上記計測記録が一次エビデンス |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI（E2E spec: `tests/e2e/a11y-critical-cuj.spec.ts` に `/admin/reports` 追加）

**影響を受ける画面・機能**: `/admin/reports`（free プラン時の週次レポート teaser CTA）/ `/admin/settings/data`（free プラン時の export upsell CTA ×2）。いずれも CTA link の色のみ変更、DOM 構造・testid・文言は不変（`tests/e2e/plan-*.spec.ts` が参照する `weekly-report-upsell` / `export-upsell-cta` / `cloud-export-upsell-cta` testid は無変更）。

## テスト & 安全装置セルフチェック

- [x] **pre-ready 検証**（#1775 / ADR-0030）— 変更 surface が class 属性のトークン差し替え + E2E spec への page 追加のみ（+11/-4、型・ロジック・文言変更 0 件）のため関連 step を個別実行し全 PASS: Step 1 `npx biome check <変更 3 file>` PASS（push 時 pre-push hook でも PASS）/ Step 3 targeted vitest = `tests/unit/architecture/base-token-routes-ratchet.test.ts` 2 passed（`--color-premium` は非番号 Semantic alias のため Base トークン ratchet baseline 221 に不算入を機械確認。`npx vitest run src/routes/` は該当 unit test 0 件）/ Step 4 `check-hardcoded-strings.mjs` violations 0 (baseline 0) / Step 7 `check-no-plan-literals.mjs` OK / Step 9 `check-pr-body.mjs --pr 3721` PASS。svelte-check / 全量 vitest / E2E は CI (`ci.yml`) が同コマンドを実行（class 文字列のみの変更で型影響なし）。Step 11b (SS embed gate) は SS を親セッションが撮影・embed 後に CI screenshot-quality-check が authoritative（#2929）
- [x] 追加・変更したテストの概要: `tests/e2e/a11y-critical-cuj.spec.ts` の受領 admin loop に `/admin/reports` を追加（axe-core WCAG 2.2 AA scan 対象化、Issue 解決策 4）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:low）

## スクリーンショット / ビジュアルデモ

**4 スロット添付**（#1740、修正後は 2026-07-15 親セッション撮影: DEBUG_PLAN=free + AUTH_MODE=anonymous + DATA_SOURCE=demo 決定的環境、`?screenshot=all`、screenshots branch `pr-3721/`）:

`/admin/reports` (5c weekly teaser):

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/issue-3533-m5/5c-teaser-weekly-report-mobile.png) | （#3533 M5 では mobile のみ実測。desktop の修正前は同一トークン #ff9800 のため色は同一） |
| **修正後** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3721/admin-reports-screenshot-all-mobile.png) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3721/admin-reports-screenshot-all-desktop.png) |

`/admin/settings/data` (5b export upsell CTA、AC3 横展開)【修正後】:

| モバイル (375px) | PC (1440px) |
|---|---|
| ![after-data-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3721/admin-settings-data-screenshot-all-mobile.png) | ![after-data-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3721/admin-settings-data-screenshot-all-desktop.png) |

修正後 SS で「プランを見る →」/「プランを見る」CTA が `--color-premium` #7c3aed × 白文字 (5.70:1) で明瞭に視認できることを確認済み。色変更の一次エビデンスは上記「コントラスト比 計測記録」の変更前後トークン + 算出比。

**インタラクティブ状態**: N/A（CTA link の色のみ変更。disabled / エラー / 空状態への影響なし）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（class 属性の色トークン差し替えのみ）
- [x] **DRY**: `grep -rn "プランを見る" src/` + `grep -rn "action-trial-upgrade" src/` で同 class 全数調査済み。upsell CTA 4 箇所を全数照合し FAIL 2 class を本 PR で修正（横展開表参照）。`--color-action-trial-upgrade` の残存使用は `BattleHPBar.svelte` の bar 塗り（テキストなし、WCAG 1.4.3 対象外）のみ
- [x] **YAGNI**: 新規トークン・新規 component 追加なし（既存 Semantic alias `--color-premium` の既存先例パターンに統一）
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: コントラスト WCAG AA 1.4.3 — 本 PR の主目的。全変更箇所 4.5:1 以上（計測記録表）。キーボード操作 / ARIA は不変
- [x] **パフォーマンス**: N/A（CSS class のみ）

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照）:

- [x] N/A — 並行実装の影響範囲外（admin 専用画面、demo Lambda は本番ルートを env 駆動で host するため自動同期 #2097 PR-B3 / 子供画面・ナビ・DB・チュートリアル影響なし）
- [x] **labels SSOT** (ADR-0009): 文言変更なし（`REPORTS_LABELS.weeklyEmailUpsellLink` / `SETTINGS_LABELS.*UpsellCta` は不変）
- [x] **設計書同期** (ADR-0001): 設計仕様（画面構成・API・DB）変更なし。色トークンの適用是正のみで docs/DESIGN.md §2 の既存トークン定義内
- [x] **並行 PR overlap** (#1200): `gh pr list` で同 file を触る open PR なしを確認

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A（LP / pricing / plan-features 変更なし）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- 修正パターンの選定根拠: `--color-action-trial-upgrade`（orange）の Semantic 値変更は `BattleHPBar.svelte`（HP bar 中間色）に波及するため不採用。routes で許容される Semantic トークンのうち、AiSuggest 系 upgrade CTA の既存先例（`bg-[var(--color-premium)]` + `text-[var(--color-text-inverse)]` + `hover:opacity-90`）と同一パターンに統一した（premium = violet はプラン画面・plan-nav と同系統で意味整合）。
- 白文字 × `--color-action-primary`（brand-600、3.34:1）は Button primitive の primary variant にも存在する系統的課題だが、primitive 全体の是正は本 Issue（priority:low、teaser 局所）の scope 外。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **pre-ready 検証をローカル確認した**（変更 surface に関連する step の個別実行で全 PASS — 上記「テスト & 安全装置セルフチェック」参照。svelte-check / 全量 vitest / E2E は CI が実行）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC4 の SS 4 スロットのみ親セッション撮影で完了させる。上記 SS セクション参照）
- [x] Phase 分割した場合: N/A（分割なし）
- [x] UI 変更時: SS は親セッションが撮影・embed 後に GitHub 上で表示確認する。DESIGN.md §9 禁忌 6 点（hex 直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / style 50 行超）は diff 上で違反 0 を確認済
- [x] 認証画面変更時: N/A（認証画面ではない）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)




---

**[QM CI-Fix note]** `refactor:internal-no-doc-impact` label 付与の根拠: 本 PR の src/routes 変更は upsell CTA の色トークン差し替え（WCAG 1.4.3 コントラスト是正）のみで、CTA のトークン割当を規定した設計書は存在せず、DESIGN.md §2 のトークン定義（新規・値変更なし）も不変。設計仕様は変わらないため design-doc-check の exempt 条件（#1985 / ADR-0003）に該当。
