### PR TITLE
fix: #3535 runInTransaction ネスト呼出を fail-loud で禁止 (AsyncLocalStorage guard、SAVEPOINT 非対応の DSQL 契約保護)

### DIFF
--- a/src/lib/server/db/dsql/run-in-transaction.ts
+++ b/src/lib/server/db/dsql/run-in-transaction.ts
@@ -9,6 +9,7 @@
 //    core txn に入れてはならない — core commit 後の独立 best-effort にする (#N4-2)。
 
 import type { TransactionRunner } from '../interfaces/transaction.interface';
+import { assertNotNestedTransaction, runWithTransactionContext } from '../txn-nest-guard';
 import { type OccRetryOptions, withOccRetry } from './occ-retry';
 
 /** drizzle pg database の transaction 部分だけを構造的に要求する (driver 非依存)。 */
@@ -25,7 +26,13 @@ export function createDsqlTransactionRunner<TTx>(
 	opts?: OccRetryOptions,
 ): TransactionRunner<TTx> {
 	return {
-		runInTransaction: <T>(work: (tx: TTx) => Promise<T>): Promise<T> =>
-			withOccRetry(() => db.transaction((tx) => work(tx)), opts),
+		runInTransaction: <T>(work: (tx: TTx) => Promise<T>): Promise<T> => {
+			// #3535: ネスト呼出は fail-loud (SAVEPOINT 非対応 + OCC retry = txn 全体再実行の契約)。
+			assertNotNestedTransaction('dsql');
+			return withOccRetry(
+				() => db.transaction((tx) => runWithTransactionContext(() => work(tx))),
+				opts,
+			);
+		},
 	};
 }

--- a/src/lib/server/db/sqlite/run-in-transaction.ts
+++ b/src/lib/server/db/sqlite/run-in-transaction.ts
@@ -12,6 +12,7 @@
 
 import type { Database } from 'better-sqlite3';
 import type { TransactionRunner } from '../interfaces/transaction.interface';
+import { assertNotNestedTransaction, runWithTransactionContext } from '../txn-nest-guard';
 
 /**
  * SQLite 用 TransactionRunner を生成する。
@@ -24,9 +25,12 @@ export function createSqliteTransactionRunner<TTx>(
 ): TransactionRunner<TTx> {
 	return {
 		async runInTransaction<T>(work: (tx: TTx) => Promise<T>): Promise<T> {
+			// #3535: ネスト呼出は fail-loud。native の 'cannot start a transaction within a
+			// transaction' より前に、原因が特定できる message で throw する (dsql 側と同一契約)。
+			assertNotNestedTransaction('sqlite');
 			sqlite.exec('BEGIN IMMEDIATE');
 			try {
-				const result = await work(txHandle);
+				const result = await runWithTransactionContext(() => work(txHandle));
 				sqlite.exec('COMMIT');
 				return result;
 			} catch (err) {

--- a/src/lib/server/db/txn-nest-guard.ts
+++ b/src/lib/server/db/txn-nest-guard.ts
@@ -17,14 +17,27 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-const inTransaction = new AsyncLocalStorage<true>();
+/**
+ * txn work の進行状態。ALS context は work 内で spawn された fire-and-forget promise の
+ * async chain にも**外側 txn 完了後まで**伝播する (継続作成時に bind される) ため、
+ * boolean でなく mutable な done flag を持つ:
+ *   - done=false (work 実行中) のネスト呼出 → 真のネスト。fail-loud に throw
+ *   - done=true (外側 txn 完了後、spawn された子孫 chain からの呼出) → 独立 txn として許容
+ *     (#N4-2 の「core commit 後の独立 best-effort」を async 子孫から行う正当パターンを殺さない)
+ */
+interface TxnContext {
+	done: boolean;
+}
+
+const inTransaction = new AsyncLocalStorage<TxnContext>();
 
 /**
- * runInTransaction 冒頭で呼ぶ。既に txn work の中なら fail-loud に throw する。
+ * runInTransaction 冒頭で呼ぶ。**進行中の** txn work の中なら fail-loud に throw する。
  * @param backend エラーメッセージ用の backend 識別子 ('dsql' | 'sqlite' 等)
  */
 export function assertNotNestedTransaction(backend: string): void {
-	if (inTransaction.getStore()) {
+	const ctx = inTransaction.getStore();
+	if (ctx && !ctx.done) {
 		throw new Error(
 			`[run-in-transaction] ネスト呼出を検出しました (backend=${backend})。` +
 				'DSQL は SAVEPOINT 非対応で OCC retry は txn 全体再実行が契約のため、' +
@@ -35,6 +48,13 @@ export function assertNotNestedTransaction(backend: string): void {
 }
 
 /** work を「txn 実行中」context で走らせる (runInTransaction 内部専用)。 */
-export function runWithTransactionContext<T>(fn: () => Promise<T>): Promise<T> {
-	return inTransaction.run(true, fn);
+export async function runWithTransactionContext<T>(fn: () => Promise<T>): Promise<T> {
+	const ctx: TxnContext = { done: false };
+	try {
+		return await inTransaction.run(ctx, fn);
+	} finally {
+		// commit / rollback を問わず work 終了で done 化。以後、work 内から spawn された
+		// async 子孫 chain の runInTransaction は独立 txn として通る (false-positive 防止)。
+		ctx.done = true;
+	}
 }

--- a/src/lib/server/db/txn-nest-guard.ts
+++ b/src/lib/server/db/txn-nest-guard.ts
@@ -1,0 +1,40 @@
+// src/lib/server/db/txn-nest-guard.ts
+// #3535: runInTransaction のネスト呼出を fail-loud で禁止する共有 guard。
+//
+// 背景 (設計判断 = 「合流」ではなく「禁止」):
+//   - DSQL は SAVEPOINT 非対応 (spike#4: 0A000) — ネストの局所巻戻しは原理的に不可能。
+//   - dsql runner の OCC retry は「txn 全体の再実行」契約 (§8)。ネスト内側だけ retry すると
+//     abort 済み外側 txn の中で再実行する無効な状態になる。
+//   - drizzle の `db.transaction` を txn 内で呼ぶと **別接続の独立 txn** が作られ、外側の
+//     未 commit write が見えない stale read / pool 枯渇の温床になる (SQL の NESTED ではない)。
+//   - sqlite runner は `BEGIN IMMEDIATE` の native error で落ちるが文言が不明瞭。
+//   fitness#7 (txn work 内は tx-bound await のみ、helper 閉包禁止) の設計意図とも一貫して、
+//   ネストは呼び出し構造の欠陥として即 throw で顕在化させる。
+//
+// AsyncLocalStorage で「runInTransaction の work 実行中」を追跡する。process 内の全 runner
+// (dsql / pglite = createDsqlTransactionRunner 共用 / sqlite) が本 guard を共有するため、
+// backend を跨いだネスト (通常起きないが factory 誤配線等) も検出する。
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const inTransaction = new AsyncLocalStorage<true>();
+
+/**
+ * runInTransaction 冒頭で呼ぶ。既に txn work の中なら fail-loud に throw する。
+ * @param backend エラーメッセージ用の backend 識別子 ('dsql' | 'sqlite' 等)
+ */
+export function assertNotNestedTransaction(backend: string): void {
+	if (inTransaction.getStore()) {
+		throw new Error(
+			`[run-in-transaction] ネスト呼出を検出しました (backend=${backend})。` +
+				'DSQL は SAVEPOINT 非対応で OCC retry は txn 全体再実行が契約のため、' +
+				'runInTransaction を txn work の中から呼んではならない (#3535)。' +
+				'外側の tx handle を引き回すか、呼び出し構造を単一 txn に組み直すこと。',
+		);
+	}
+}
+
+/** work を「txn 実行中」context で走らせる (runInTransaction 内部専用)。 */
+export function runWithTransactionContext<T>(fn: () => Promise<T>): Promise<T> {
+	return inTransaction.run(true, fn);
+}

--- a/tests/unit/db/dsql-run-in-transaction.test.ts
+++ b/tests/unit/db/dsql-run-in-transaction.test.ts
@@ -268,4 +268,42 @@ describe('#3535: runInTransaction ネスト呼出 guard', () => {
 		expect(sqlite.inTransaction).toBe(false);
 		sqlite.close();
 	});
+
+	it('[T12] work 内で spawn した fire-and-forget 子孫は外側 commit 後なら独立 txn を張れる (false-positive 防止)', async () => {
+		// ALS context は spawn された async chain に外側 txn 完了後まで伝播する。done flag が
+		// 無いと #N4-2 型「core commit 後の独立 best-effort」を async 子孫から行う正当パターンが
+		// 誤 throw で殺される (adversarial review objection 1)。guard は「進行中のネスト」のみ拒否する。
+		const { createDsqlTransactionRunner } = await import(
+			'../../../src/lib/server/db/dsql/run-in-transaction'
+		);
+		const client = new PGlite();
+		const db = drizzle(client);
+		await db.execute(sql`CREATE TABLE ff_probe (id int PRIMARY KEY)`);
+		const runner = createDsqlTransactionRunner(db);
+		try {
+			let resolveOuterDone: () => void = () => {};
+			const outerDone = new Promise<void>((r) => {
+				resolveOuterDone = r;
+			});
+			let descendant: Promise<void> | undefined;
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(sql`INSERT INTO ff_probe VALUES (1)`);
+				// fire (未 await): 外側 commit を待ってから独立 txn を張る子孫 chain
+				descendant = (async () => {
+					await outerDone; // 外側 txn 完了まで待機 (PGlite 単一接続の deadlock 回避も兼ねる)
+					await runner.runInTransaction(async (tx2) => {
+						await tx2.execute(sql`INSERT INTO ff_probe VALUES (2)`);
+					});
+				})();
+			});
+			resolveOuterDone();
+			await expect(descendant, '子孫の独立 txn は誤 throw されない').resolves.toBeUndefined();
+			const rows = (await db.execute(sql`SELECT id FROM ff_probe ORDER BY id`)).rows as {
+				id: number;
+			}[];
+			expect(rows.map((r) => r.id)).toEqual([1, 2]);
+		} finally {
+			await client.close();
+		}
+	});
 });

--- a/tests/unit/db/dsql-run-in-transaction.test.ts
+++ b/tests/unit/db/dsql-run-in-transaction.test.ts
@@ -197,3 +197,75 @@ describe('#N1-1: sqlite runInTransaction (BEGIN IMMEDIATE)', () => {
 		sqlite.close();
 	});
 });
+
+// #3535: ネスト呼出の fail-loud guard (SAVEPOINT 非対応 + OCC retry = txn 全体再実行の契約)。
+// ネストは drizzle では「別接続の独立 txn」になり外側の未 commit write が見えない stale read の
+// 温床のため、合流ではなく禁止 (設計判断は src/lib/server/db/txn-nest-guard.ts 冒頭に記録)。
+describe('#3535: runInTransaction ネスト呼出 guard', () => {
+	it('[T9] pg: txn work 内から runInTransaction を再呼出すると明示 message で throw + 外側 rollback', async () => {
+		const { createDsqlTransactionRunner } = await import(
+			'../../../src/lib/server/db/dsql/run-in-transaction'
+		);
+		const client = new PGlite();
+		const db = drizzle(client);
+		await db.execute(sql`CREATE TABLE nest_probe (id int PRIMARY KEY)`);
+		const runner = createDsqlTransactionRunner(db);
+		try {
+			await expect(
+				runner.runInTransaction(async (tx) => {
+					await tx.execute(sql`INSERT INTO nest_probe VALUES (1)`);
+					// ネスト呼出 (誤った呼び出し構造の再現)
+					await runner.runInTransaction(async () => {});
+				}),
+			).rejects.toThrow(/ネスト呼出を検出しました \(backend=dsql\)/);
+			// 外側 txn ごと rollback される (部分 commit なし)
+			const rows = (await db.execute(sql`SELECT id FROM nest_probe`)).rows;
+			expect(rows).toHaveLength(0);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('[T10] pg: 逐次 (非ネスト) の連続呼出は guard に阻害されない', async () => {
+		const { createDsqlTransactionRunner } = await import(
+			'../../../src/lib/server/db/dsql/run-in-transaction'
+		);
+		const client = new PGlite();
+		const db = drizzle(client);
+		await db.execute(sql`CREATE TABLE seq_probe (id int PRIMARY KEY)`);
+		const runner = createDsqlTransactionRunner(db);
+		try {
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(sql`INSERT INTO seq_probe VALUES (1)`);
+			});
+			await runner.runInTransaction(async (tx) => {
+				await tx.execute(sql`INSERT INTO seq_probe VALUES (2)`);
+			});
+			const rows = (await db.execute(sql`SELECT id FROM seq_probe ORDER BY id`)).rows as {
+				id: number;
+			}[];
+			expect(rows.map((r) => r.id)).toEqual([1, 2]);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('[T11] sqlite: ネスト呼出も同一契約で throw (native error より明確な message)', async () => {
+		const { createSqliteTransactionRunner } = await import(
+			'../../../src/lib/server/db/sqlite/run-in-transaction'
+		);
+		const sqlite = new Database(':memory:');
+		sqlite.exec('CREATE TABLE nest_probe (id INTEGER PRIMARY KEY)');
+		const runner = createSqliteTransactionRunner(sqlite, sqlite);
+		await expect(
+			runner.runInTransaction(async (tx) => {
+				tx.prepare('INSERT INTO nest_probe VALUES (1)').run();
+				await runner.runInTransaction(async () => {});
+			}),
+		).rejects.toThrow(/ネスト呼出を検出しました \(backend=sqlite\)/);
+		// 外側 rollback 済み + txn が閉じている
+		expect(sqlite.prepare('SELECT count(*) AS c FROM nest_probe').get()).toEqual({ c: 0 });
+		expect(sqlite.inTransaction).toBe(false);
+		sqlite.close();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

runInTransaction は本番 DSQL / NUC PGlite の全 write path が共有する txn プリミティブだが、ネスト呼出時の挙動が未定義だった (#3532 QM Adversarial 指摘)。DSQL は SAVEPOINT 非対応のため、ネストが混入すると「別接続の独立 txn による stale read」「abort 済み txn 内での無効 retry」という**発見困難な整合性バグ**として顧客データ (記録・ポイント) に波及する。cutover 完遂で本プリミティブは本番稼働中 — 配線拡大前に fail-loud guard で構造的に封じる。

## 関連 Issue

closes #3535 / refs #3531 #3424

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証方法 | 結果 |
|---|---|---|---|
| ネスト検知機構 | `src/lib/server/db/txn-nest-guard.ts` (AsyncLocalStorage で txn work 実行中を追跡、共有 module) | `npx vitest run tests/unit/db/dsql-run-in-transaction.test.ts` [T9][T11] | PASS |
| 検知時挙動の設計判断 | **禁止 (fail-loud throw)** を採択。理由: SAVEPOINT 非対応 / OCC retry = txn 全体再実行契約 / drizzle ネスト = 別接続 stale read / fitness#7 と一貫 (guard 冒頭コメントに記録) | 設計根拠のコード内 SSOT 化 | PASS |
| unit test で保証 | [T9] pg: ネスト → 明示 message throw + 外側 rollback / [T10] 逐次連続呼出は非阻害 / [T11] sqlite: 同一契約 (native error より明確) | `npx vitest run tests/unit/db/dsql-run-in-transaction.test.ts` → 11 passed (11) | PASS |
| 既存フローに正当ネストが無いことの確認 | 全 write path 回帰 | `npx vitest run tests/unit/db/ tests/unit/services/` → **219 files / 3,283 tests PASS** | PASS |

## 変更タイプ

- [x] バグ修正 (fix)
- [x] テスト追加 (test)

## 影響範囲・変更コンポーネント

- `src/lib/server/db/txn-nest-guard.ts` (新規、+40 行): 共有 guard
- `src/lib/server/db/dsql/run-in-transaction.ts`: guard 適用 (pglite backend は本 runner 共用のためカバー)
- `src/lib/server/db/sqlite/run-in-transaction.ts`: guard 適用
- 正常 (非ネスト) 経路の挙動は完全不変 (ALS の read 1 回のみ追加)

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/db/dsql-run-in-transaction.test.ts` → 11 passed (11)
- [x] `npx vitest run tests/unit/db/ tests/unit/services/` → 219 files / 3,283 tests all PASS
- [x] `npx biome check <変更 4 files>` → No fixes applied / `npx cspell <同>` → Issues 0
- [x] ADR-0006: 既存 assert 不変、fail-loud 追加のみ

## スクリーンショット / ビジュアルデモ

UI 変更なし (server txn 基盤のみ)。

## コード品質セルフレビュー (#1481)

- [x] guard は共有 module 1 箇所 (両 backend で重複実装しない)
- [x] 設計判断 (禁止 vs 合流) の理由を guard 冒頭コメントに SSOT 化
- [x] AsyncLocalStorage は Node 標準 (新規依存なし)、backend 跨ぎのネストも検出

## 横展開・影響波及チェック

- [x] pglite backend は createDsqlTransactionRunner 共用のため自動カバー ([T9] は実 PGlite で検証)
- [x] demo / dynamodb backend は TransactionRunner 非使用 (対象外)
- [x] fitness#7 (txn work AST allowlist、#3531 粒度(2)) とは補完関係 — 静的 lint が漏らした動的ネストを runtime guard が捕捉する二層防御

## レビュー依頼事項・破壊的変更

破壊的変更なし (ネスト呼出は従来も不定挙動/native error で壊れていた — 明確な message での即 throw に変わるのみ)。

## 配布済み env / secret (ADR-0006)

新規なし。

## Ready for Review チェックリスト

- [x] 関連 Issue 番号記載
- [x] AC 検証マップ 4 列記入
- [x] テスト実行結果記載 (11/11 + 3,283/3,283 PASS)
- [x] SS 不要
- [x] 横展開チェック実施

## QM レビュー結果

<!-- QM が記入 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)