### PR TITLE
fix: #3584 IChildRepo follow-up (CHILD_SCOPED_TABLES fitness / deleteChild rollback test / birth_date cutover gate)

### DIFF
--- a/scripts/nuc-pglite-cutover.ts
+++ b/scripts/nuc-pglite-cutover.ts
@@ -103,6 +103,24 @@ async function runImport(opts: Record<string, string>): Promise<void> {
 	process.env.PGLITE_DATA_DIR = resolve(dataDir);
 
 	const data = JSON.parse(readFileSync(inPath, 'utf-8'));
+
+	// #3584 ③ birth_date backfill gate: 新 model は age 列を持たず compute-on-read (§11.1) のため、
+	// birth_date NULL の child は age=0 → preschool UI に固定される (中高生が幼児 UI を見せられる
+	// 誤 tier)。PO B2「cutover backfill 必須」を機械 gate 化し、NULL 行があれば dataDir 構築前に
+	// fail-fast する (旧 DB 側で生年月日を登録 → 再 export → 再実行)。
+	const nullBirthChildren = (
+		(data.family?.children ?? []) as { nickname?: string; birthDate?: string | null }[]
+	).filter((c) => !c.birthDate);
+	if (nullBirthChildren.length > 0) {
+		const names = nullBirthChildren.map((c) => c.nickname ?? '(無名)').join(', ');
+		fail(
+			`birth_date 未設定の child が ${nullBirthChildren.length} 人います (${names})。` +
+				'新 model は birth_date が唯一の年齢ソース (compute-on-read §11.1) のため、未設定のまま ' +
+				'cutover すると当該 child は age=0 (preschool UI) に固定されます。' +
+				'旧環境で生年月日を登録してから export し直して再実行してください (#3584 ③)。',
+		);
+	}
+
 	const { LOCAL_TENANT_UUID } = await import('../src/lib/server/auth/local-tenant');
 	const pglite = await import('../src/lib/server/db/pglite/connection');
 

--- a/src/lib/server/db/dsql/child-repo.ts
+++ b/src/lib/server/db/dsql/child-repo.ts
@@ -83,8 +83,10 @@ export function toChild(row: ChildRow): Child {
 	};
 }
 
-/** deleteChild で消す child 配下の表 (child_id 列を持つ全テナント表、§3 集約境界)。 */
-const CHILD_SCOPED_TABLES = [
+/** deleteChild で消す child 配下の表 (child_id 列を持つ全テナント表、§3 集約境界)。
+ * #3584 ①: schema との網羅性突合は tests/unit/architecture/dsql-child-scoped-tables-fitness.test.ts
+ * が機械保証する (新表追加時の list 未更新 = orphan 行残存を CI で検出)。export は同 fitness 用。 */
+export const CHILD_SCOPED_TABLES = [
 	'child_activities',
 	'activity_logs',
 	'point_ledger',

--- a/tests/unit/architecture/dsql-child-scoped-tables-fitness.test.ts
+++ b/tests/unit/architecture/dsql-child-scoped-tables-fitness.test.ts
@@ -1,0 +1,99 @@
+// tests/unit/architecture/dsql-child-scoped-tables-fitness.test.ts
+// #3584 ① — deleteChild の CHILD_SCOPED_TABLES 網羅性 fitness (ADR-0061 fitness function)。
+//
+// 背景: deleteChild は FK/CASCADE 非対応の DSQL (§P4) で child 集約 27+ 表を明示 DELETE する。
+// 旧検証は「CHILD_SCOPED_TABLES と test の削除確認 list が同一」のトートロジーで、将来
+// child_id 列を持つ表を schema に追加した際、list 未更新でも test 緑のまま通り本番で
+// orphan 行が残る (支払い/記録データの残骸 = プライバシー/整合性事故)。
+//
+// 本 fitness は **drizzle schema (実物) を introspect** して child 参照列を持つ全表を列挙し、
+// CHILD_SCOPED_TABLES ∪ 明示特例 と完全一致することを assert する。schema に新表を足すと
+// (a) CHILD_SCOPED_TABLES に追加するか (b) 本 test の特例に理由付きで登録するまで CI が fail する
+// (no-silent-gap、admin-resource-model-registry の除外リスト方式と同型)。
+
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+import { CHILD_SCOPED_TABLES } from '../../../src/lib/server/db/dsql/child-repo';
+import * as schema from '../../../src/lib/server/db/dsql/schema';
+
+/** child_id 列そのものを持つが CHILD_SCOPED_TABLES の一括 DELETE 対象にしない表 (理由必須)。 */
+const EXPLICIT_EXCLUSIONS: Record<string, string> = {
+	// deleteChild の最後に単独 DELETE される集約 root (CHILD_SCOPED_TABLES は「配下」のみ)
+	children: 'child 集約 root。deleteChild が最後に単独 DELETE する',
+	// auth 集約: 招待は期限切れで自然消滅させる (child-repo.ts 冒頭コメントの設計判断)
+	invites: 'auth 集約のため touch しない (招待は期限切れで自然消滅、child-repo.ts §設計契約)',
+};
+
+/** child_id という名前ではないが child を参照する列を持つ表 (deleteChild 内で個別処理)。 */
+const NON_STANDARD_CHILD_REFS: Record<string, string> = {
+	// from_child_id / to_child_id の 2 軸参照 → deleteChild が OR 条件で個別 DELETE
+	sibling_cheers: 'from_child_id / to_child_id の 2 参照軸 (deleteChild 内で個別 DELETE)',
+	// child_id 列なし (card_id 参照) → stamp_cards の削除前に subquery で個別 DELETE
+	stamp_entries: 'card_id 経由の子孫表 (deleteChild が stamp_cards より先に subquery DELETE)',
+};
+
+describe('#3584 ① CHILD_SCOPED_TABLES 網羅性 fitness (schema 実物と突合)', () => {
+	// drizzle schema の全 pgTable を introspect する
+	const allTables = Object.values(schema)
+		.map((v) => {
+			try {
+				return getTableConfig(v as Parameters<typeof getTableConfig>[0]);
+			} catch {
+				return null; // pgTable 以外の export (enum / relation 等) は無視
+			}
+		})
+		.filter((c): c is NonNullable<typeof c> => c !== null);
+
+	it('schema が空でない (introspection 自体の健全性)', () => {
+		expect(allTables.length).toBeGreaterThan(20);
+	});
+
+	it('child_id 列を持つ全表 = CHILD_SCOPED_TABLES ∪ 明示特例 (漏れ・過剰の両方向を検出)', () => {
+		const tablesWithChildId = allTables
+			.filter((t) => t.columns.some((c) => c.name === 'child_id'))
+			.map((t) => t.name)
+			.sort();
+
+		const covered = [...CHILD_SCOPED_TABLES, ...Object.keys(EXPLICIT_EXCLUSIONS)].sort();
+
+		// 漏れ方向: schema にあるのに deleteChild が消さない表 → orphan 行が残る (本 fitness の主目的)
+		const uncovered = tablesWithChildId.filter((t) => !covered.includes(t));
+		expect(
+			uncovered,
+			`child_id 列を持つのに CHILD_SCOPED_TABLES にも EXPLICIT_EXCLUSIONS にも無い表: ${uncovered.join(', ')} — deleteChild に追加するか、理由付きで除外登録すること (#3584)`,
+		).toEqual([]);
+
+		// 過剰方向: CHILD_SCOPED_TABLES にあるのに schema に child_id 列が無い表 → DELETE が
+		// 実行時エラー (undefined column) になるか、意図しない表を指している
+		const phantom = CHILD_SCOPED_TABLES.filter((t) => !tablesWithChildId.includes(t));
+		expect(
+			phantom,
+			`CHILD_SCOPED_TABLES に登録されているが schema に child_id 列が無い表: ${phantom.join(', ')}`,
+		).toEqual([]);
+	});
+
+	it('非標準 child 参照列 (*_child_id) を持つ表は全て個別処理特例に登録されている', () => {
+		const nonStandard = allTables
+			.filter(
+				(t) =>
+					!t.columns.some((c) => c.name === 'child_id') &&
+					t.columns.some((c) => c.name.endsWith('child_id')),
+			)
+			.map((t) => t.name)
+			.sort();
+		const unhandled = nonStandard.filter((t) => !(t in NON_STANDARD_CHILD_REFS));
+		expect(
+			unhandled,
+			`child を参照する非標準列 (*_child_id) を持つのに特例登録が無い表: ${unhandled.join(', ')} — deleteChild で個別処理を実装し NON_STANDARD_CHILD_REFS に理由を登録すること`,
+		).toEqual([]);
+	});
+
+	it('stamp_entries (card_id 経由の子孫) が deleteChild の個別処理特例として認知されている', () => {
+		// stamp_entries は child_id 列も *_child_id 列も持たないため上 2 test の網には掛からない。
+		// deleteChild 実装 (stamp_cards 削除前の subquery DELETE) との対応をここで明示 pin する。
+		const stampEntries = allTables.find((t) => t.name === 'stamp_entries');
+		expect(stampEntries, 'schema に stamp_entries が存在する').toBeTruthy();
+		expect(stampEntries?.columns.some((c) => c.name === 'card_id')).toBe(true);
+		expect(NON_STANDARD_CHILD_REFS.stamp_entries).toBeTruthy();
+	});
+});

--- a/tests/unit/db/dsql-child-repo.test.ts
+++ b/tests/unit/db/dsql-child-repo.test.ts
@@ -200,6 +200,76 @@ describe('DSQL child-repo (PR-R1、実 schema PGlite)', () => {
 		expect(Number((entries.rows[0] as { c: unknown }).c)).toBe(1); // 兄弟 card の entry のみ残存
 	});
 
+	it('[C7b] #3584 ②: deleteChild が mid-txn で失敗すると部分削除は全て rollback される (原子性)', async () => {
+		// [C7] は正常系のみ。本 test は txn 途中で失敗を注入し、先行した DELETE が
+		// rollback されて全表が元に戻ることを実証する (TransactionRunner の atomicity を回帰固定。
+		// FK/CASCADE 非対応 DSQL では repo の明示 DELETE 列が唯一の整合性装置のため、部分失敗で
+		// 「一部の表だけ消えた child」が残ると復旧不能な半壊状態になる)。
+		const victim = await repo.insertChild({ nickname: '巻戻対象', age: 7 }, FAMILY);
+		const vid = String(victim.id);
+		const act = await t.db.execute(sql`
+			INSERT INTO child_activities (family_id, child_id, name, category_id, icon)
+			VALUES (${FAMILY}, ${vid}, '巻戻活動', '1', '🏃') RETURNING activity_id
+		`);
+		const activityId = (act.rows[0] as { activity_id: string }).activity_id;
+		await t.db.execute(sql`
+			INSERT INTO activity_logs (family_id, child_id, activity_id, points, recorded_date, recorded_at)
+			VALUES (${FAMILY}, ${vid}, ${activityId}, 10, '2026-07-05', now())
+		`);
+		await t.db.execute(sql`
+			INSERT INTO point_ledger (family_id, child_id, amount, type, recorded_date)
+			VALUES (${FAMILY}, ${vid}, 10, 'activity', '2026-07-05')
+		`);
+
+		// 失敗注入 runner: work に渡す tx を proxy し、N 回目以降の execute で throw する。
+		// CHILD_SCOPED_TABLES 先頭数表の DELETE を実行させた後に失敗させる (= 部分削除状態を作る)。
+		const runner = createDsqlTransactionRunner(t.db, { maxAttempts: 1, baseDelayMs: 1 });
+		const failAfter = 4;
+		const failingRunner: typeof runner = {
+			runInTransaction: (work) =>
+				runner.runInTransaction((tx) => {
+					let calls = 0;
+					const proxy = new Proxy(tx as object, {
+						get(target, prop, receiver) {
+							if (prop === 'execute') {
+								return (...args: unknown[]) => {
+									calls++;
+									if (calls > failAfter) throw new Error('inject: mid-txn failure (#3584②)');
+									return (target as { execute: (...a: unknown[]) => Promise<unknown> }).execute(
+										...args,
+									);
+								};
+							}
+							return Reflect.get(target, prop, receiver);
+						},
+					});
+					return work(proxy as Parameters<typeof work>[0]);
+				}),
+		};
+		const failingRepo = createDsqlChildRepo(t.db, failingRunner);
+
+		await expect(failingRepo.deleteChild(victim.id, FAMILY)).rejects.toThrow(
+			'inject: mid-txn failure',
+		);
+
+		// 全表が元のまま (先行 DELETE 分も rollback 済み = 半壊 child が残らない)
+		const countFor = async (table: string) =>
+			Number(
+				(
+					(await t.db.execute(
+						sql`SELECT count(*) AS c FROM ${sql.raw(table)} WHERE family_id = ${FAMILY} AND child_id = ${vid}`,
+					)) as { rows: { c: unknown }[] }
+				).rows[0]?.c,
+			);
+		expect(await repo.findChildById(victim.id, FAMILY), 'child 本体が残存').toBeTruthy();
+		expect(await countFor('child_activities'), 'child_activities rollback').toBe(1);
+		expect(await countFor('activity_logs'), 'activity_logs rollback').toBe(1);
+		expect(await countFor('point_ledger'), 'point_ledger rollback').toBe(1);
+
+		// 後始末 (正常 runner で本削除)
+		await repo.deleteChild(victim.id, FAMILY);
+	});
+
 	it('[C8] resetChildProgressData: allowlist 3 表 + total_point 0 (statuses は survive)', async () => {
 		const c = await repo.insertChild({ nickname: 'リセット', age: 8 }, FAMILY);
 		const id = String(c.id);

--- a/tests/unit/scripts/nuc-pglite-cutover-cli.test.ts
+++ b/tests/unit/scripts/nuc-pglite-cutover-cli.test.ts
@@ -77,7 +77,11 @@ beforeAll(async () => {
 	testSqlite = t.sqlite;
 	const { getRepos } = await import('../../../src/lib/server/db/factory');
 	const repos = getRepos();
-	const child = await repos.child.insertChild({ nickname: 'CLI検証子', age: 7 }, 'local');
+	// birth_date は #3584 ③ gate (backfill 必須) を通すため設定する (実運用の export と同形)
+	const child = await repos.child.insertChild(
+		{ nickname: 'CLI検証子', age: 7, birthDate: '2019-01-15' },
+		'local',
+	);
 	await repos.point.insertPointEntry(
 		{ childId: child.id, amount: 5, type: 'activity', description: 'x' },
 		'local',
@@ -113,10 +117,28 @@ describe('cutover CLI fail-close (#3620 AC-C4 後段、実子プロセス)', () 
 		expect(readFileSync(join(dataDir, 'existing.bin'), 'utf-8')).toBe('x'); // 既存内容は無傷
 	}, 60_000);
 
+	it('[CLI4] #3584 ③ birth_date backfill gate: NULL birth_date の child がいると dataDir 構築前に fail-fast する', () => {
+		// 新 model は birth_date が唯一の年齢ソース (compute-on-read §11.1)。NULL のまま cutover
+		// すると当該 child は age=0 (preschool UI) 固定 = 中高生が幼児 UI を見せられる誤 tier。
+		const noBirth = JSON.parse(readFileSync(exportJsonPath, 'utf-8'));
+		noBirth.family.children = [{ ...noBirth.family.children[0], birthDate: null }];
+		const noBirthPath = join(freshDir('no-birth-json'), 'no-birth.json');
+		mkdirSync(join(noBirthPath, '..'), { recursive: true });
+		writeFileSync(noBirthPath, JSON.stringify(noBirth));
+
+		const dataDir = freshDir('no-birth');
+		const r = runCli(['import', '--in', noBirthPath, '--data-dir', dataDir]);
+		expect(r.status).not.toBe(0);
+		expect(r.output).toContain('birth_date 未設定');
+		expect(existsSync(dataDir), 'fail-fast のため dataDir は構築されない').toBe(false);
+	}, 60_000);
+
 	it('[CLI3] errors>0 abort: 壊れた export JSON は exit≠0 + 部分構築 dataDir が削除される', () => {
-		// children を必須 field 欠落 ({}) に破壊 → importFamilyData が errors を返す実経路を通す
+		// children を必須 field (nickname) 欠落に破壊 → importFamilyData が errors を返す実経路を通す。
+		// birthDate は保持する (#3584 ③ の birth_date gate より先に落ちないよう、import 層の
+		// errors>0 abort 経路そのものを検証する)。
 		const broken = JSON.parse(readFileSync(exportJsonPath, 'utf-8'));
-		broken.family.children = [{}];
+		broken.family.children = [{ birthDate: '2019-01-15' }];
 		const brokenPath = join(freshDir('broken-json'), 'broken.json');
 		mkdirSync(join(brokenPath, '..'), { recursive: true });
 		writeFileSync(brokenPath, JSON.stringify(broken));


### PR DESCRIPTION
## 顧客価値・目的

deleteChild は FK/CASCADE 非対応の DSQL で child 集約 25+ 表を明示 DELETE する唯一の整合性装置。網羅性がトートロジー検証のままだと、新表追加時に**削除漏れ = 子供の記録の残骸 (プライバシー/整合性事故)** が本番でしか発覚しない。また birth_date 未設定のまま cutover すると**中高生が幼児 UI に固定される誤 tier** が起きる。3 点とも「本番でしか露見しない」class の欠陥を CI/CLI gate へ shift-left する (#3582 QM/Adversarial 裏取りの follow-up 完遂)。

## 関連 Issue

closes #3584 / refs #3424 #3620 #3582

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証方法 | 結果 |
|---|---|---|---|
| ① CHILD_SCOPED_TABLES 網羅性の機械保証 | drizzle schema 実物を `getTableConfig` introspect → child_id 列を持つ全表と両方向突合 (漏れ/過剰)。特例 (children/invites/sibling_cheers/stamp_entries) は理由必須 registry | `npx vitest run tests/unit/architecture/dsql-child-scoped-tables-fitness.test.ts` → 4/4 PASS (現行 25 表の網羅性も同時実証) | PASS |
| ② deleteChild 部分失敗 rollback 原子性 | [C7b]: tx proxy で 5 回目以降の execute に throw 注入 → 部分削除が全 rollback | `npx vitest run tests/unit/db/dsql-child-repo.test.ts` → 11/11 PASS (実 PGlite) | PASS |
| ③ birth_date backfill cutover gate | cutover CLI import が export JSON の birth_date NULL child を dataDir 構築前に fail-fast (名前列挙 + 対処指示) | `npx vitest run tests/unit/scripts/nuc-pglite-cutover-cli.test.ts` → 4/4 PASS ([CLI4] 新設 + [CLI1/3] fixture 分離) | PASS |

## 変更タイプ

- [x] バグ修正 (fix)
- [x] テスト追加 (test)

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dsql/child-repo.ts`: CHILD_SCOPED_TABLES を export 化 (+コメント、ロジック不変)
- `scripts/nuc-pglite-cutover.ts`: import subcommand に birth_date gate (fail-fast、+17 行)
- テスト 3 file (新規 fitness 1 + [C7b] + [CLI4])
- 本番挙動変更なし (gate は cutover CLI のみ、fitness は CI のみ)

## テスト & 安全装置セルフチェック

- [x] `npx vitest run` 対象 3 file → 19/19 PASS + `pglite-cutover-roundtrip` 回帰 PASS (計 20/20)
- [x] `npx biome check` (変更 5 files) → clean / `npx cspell` (同) → Issues 0
- [x] ADR-0006: [CLI3] fixture 変更は「gate より先に落ちない形へ分離」であり検証強度は向上 (gate 経路 [CLI4] + import error 経路 [CLI3] を独立検証)

## スクリーンショット / ビジュアルデモ

UI 変更なし。

## コード品質セルフレビュー (#1481)

- [x] fitness は特例に理由文字列を必須化 (no-silent-gap、admin-resource-model-registry の除外 registry と同型)
- [x] birth_date gate は dataDir 構築前の fail-fast (abort/cleanup 経路にすら入らない = 最も安全)
- [x] [C7b] は後始末 (正常削除) 込みで worker DB を汚さない

## 横展開・影響波及チェック

- [x] resetChildProgressData の allowlist 3 表は本 fitness の対象外 (削除でなくリセットの別契約、[C8] が既存担保)
- [x] deleteByTenantId (tenant 全削除) の同型網羅性は #3658 (UPDATE 除外 deny-by-default) / #3593 ③ の scope
- [x] birth_date gate は cutover CLI のみ (通常 restore は age=0 fallback 仕様を維持 — 誤 tier は cutover 恒久移行時のみ致命)

## レビュー依頼事項・破壊的変更

破壊的変更なし。cutover CLI は birth_date NULL データに対して従来 silent 成功 → 明示 fail に変わる (安全側)。

## 配布済み env / secret (ADR-0006)

新規なし。

## Ready for Review チェックリスト

- [x] 関連 Issue 番号記載
- [x] AC 検証マップ 4 列記入
- [x] テスト実行結果記載 (20/20 PASS)
- [x] SS 不要
- [x] 横展開チェック実施

## QM レビュー結果

<!-- QM が記入 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)