### PR TITLE
test(flake): #3687 Menu.stories play の pointer-events wait SSOT 化 + 遅延注入の決定性検証

### DIFF
--- a/src/lib/ui/primitives/Menu.stories.svelte
+++ b/src/lib/ui/primitives/Menu.stories.svelte
@@ -3,6 +3,7 @@ import { defineMeta } from '@storybook/addon-svelte-csf';
 import { expect, fn, screen, userEvent, waitFor } from 'storybook/test';
 import { STORYBOOK_LABELS } from '$lib/domain/labels';
 import Menu from './Menu.svelte';
+import { assertPointerInteractive } from './story-play-helpers';
 
 const L = STORYBOOK_LABELS.menu;
 
@@ -67,11 +68,7 @@ const { Story } = defineMeta({
 		// #3687: Ark UI Menu の open transition 中は content が pointer-events:none。CI の遅い
 		// 描画では visible 直後の click が「pointer-events: none」で fail する (ローカルでは再現せず)。
 		// transition 完了 = pointer-events 解除を明示的に待ってから click する。
-		await waitFor(() => {
-			if (getComputedStyle(editItem).pointerEvents === 'none') {
-				throw new Error('menu content is still in open transition (pointer-events: none)');
-			}
-		});
+		await waitFor(() => assertPointerInteractive(editItem));
 		// item select → onSelect spy 発火 (dead-end でない前提)
 		await userEvent.click(editItem);
 		await waitFor(() => expect(editSpy).toHaveBeenCalledTimes(1));

--- a/src/lib/ui/primitives/OverflowMenu.stories.svelte
+++ b/src/lib/ui/primitives/OverflowMenu.stories.svelte
@@ -3,6 +3,7 @@ import { defineMeta } from '@storybook/addon-svelte-csf';
 import { expect, fn, screen, userEvent, waitFor } from 'storybook/test';
 import { OVERFLOW_MENU_LABELS, STORYBOOK_LABELS } from '$lib/domain/labels';
 import OverflowMenu from './OverflowMenu.svelte';
+import { assertPointerInteractive } from './story-play-helpers';
 
 const L = STORYBOOK_LABELS.overflowMenu;
 const items = OVERFLOW_MENU_LABELS.items;
@@ -142,11 +143,7 @@ const { Story } = defineMeta({
 		);
 		await expect(marketplaceItem).toBeVisible();
 		// #3687: open transition 中 (pointer-events:none) の click は CI で fail する (Menu と同型)。
-		await waitFor(() => {
-			if (getComputedStyle(marketplaceItem).pointerEvents === 'none') {
-				throw new Error('menu content is still in open transition (pointer-events: none)');
-			}
-		});
+		await waitFor(() => assertPointerInteractive(marketplaceItem));
 		await userEvent.click(marketplaceItem);
 		await waitFor(() => expect(marketplaceSpy).toHaveBeenCalledTimes(1));
 		// #3687 第 2 形態: open のまま終了すると zag-js focus-visible cleanup が unhandled

--- a/src/lib/ui/primitives/story-play-helpers.ts
+++ b/src/lib/ui/primitives/story-play-helpers.ts
@@ -1,0 +1,29 @@
+// story-play-helpers.ts — Storybook play 関数共有ヘルパ (#3687)
+//
+// Ark UI Menu 系 primitive (Menu / OverflowMenu) は open transition 中、content が
+// `pointer-events: none` になる。`userEvent.click` は click 前に pointer-events を検査する
+// ため、CI runner の遅い描画では「item visible 直後の click」が transition 完了前に発火し
+// 「Unable to perform pointer interaction as the element has pointer-events: none」で fail
+// する (ローカルの速い描画では再現しない timing flake、Issue #3687 / 統合 PR #3686 CI)。
+//
+// 対策: item click 前に `waitFor(() => assertPointerInteractive(item))` を挟み、
+// transition 完了 (= pointer-events 解除) を明示的に待つ。waitFor は条件成立まで poll する
+// ため、描画遅延の大小に依らず決定的に pass する (固定待ち waitForTimeout は不採用、
+// tests/CLAUDE.md 禁止事項)。
+//
+// 本ヘルパは `storybook/test` に依存しない純粋な同期 assert として切り出し、
+// - stories 側: `await waitFor(() => assertPointerInteractive(el))` で使用
+// - unit test 側: `tests/unit/ui/story-play-helpers.test.ts` が遅延注入で決定性を検証
+// の両方から単一 SSOT として参照する (Menu / OverflowMenu の同一ロジック重複を排除)。
+
+/**
+ * 要素が pointer 操作可能 (pointer-events !== 'none') であることを assert する。
+ * open transition 中 (pointer-events: none) は throw し、`waitFor` の retry 対象になる。
+ *
+ * @throws {Error} 要素がまだ open transition 中 (pointer-events: none) の場合
+ */
+export function assertPointerInteractive(element: Element): void {
+	if (getComputedStyle(element).pointerEvents === 'none') {
+		throw new Error('element is still in open transition (pointer-events: none)');
+	}
+}

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -155,7 +155,7 @@ interactive primitive の play 関数 coverage:
 | primitive | play で検証する操作 → 結果 | 備考 |
 |---|---|---|
 | `Dialog` | close button click → `onOpenChange({open:false})` / `closable=false` で × button 非 render / `role=dialog` + accessible name | Esc / backdrop close は Ark UI のグローバル listener 依存で Storybook vitest 環境では非決定的 → Playwright (統合層) に委譲 |
-| `Menu` | trigger click → item visible → item select → `onSelect` 発火 / disabled item は `data-disabled` | Ark UI Menu は `userEvent.click` (full pointer sequence) で select、`element.click()` では発火しない |
+| `Menu` | trigger click → item visible → item select → `onSelect` 発火 / disabled item は `data-disabled` | Ark UI Menu は `userEvent.click` (full pointer sequence) で select、`element.click()` では発火しない。item click 前に open transition 完了待ち必須 (#3687、下記「Ark UI Menu 系 play の CI flake 対策」) |
 | `OverflowMenu` | ⋮ trigger click → item visible → select → `onSelect` 発火 | 同上 (Ark UI Menu wrapper) |
 | `FormField` | input type → value 反映 / `WithError` で `role=alert` + `aria-invalid=true` / `Disabled` で input 編集不可 | canvasElement 内 render、`within` 使用 |
 | `PinInput` | 全桁入力 → `onComplete({valueAsString})` 発火 | mask=false (unmasked) で `role=textbox` query 可能。mask=true は type=password で role 無し |
@@ -163,6 +163,13 @@ interactive primitive の play 関数 coverage:
 | `ChildSelectionDialog` | confirm → `onConfirm('all')` / 複数選択 → `onConfirm([id...])` / empty children 防御 | per-child 取込 SSOT、Portal 経由のため `screen` 使用 |
 
 **Portal 経由 component の query 原則**: Dialog / Menu / OverflowMenu / ChildSelectionDialog は Ark UI `<Portal>` で document.body 直下に render するため、`canvasElement` 起点の `within` では届かない。`screen` (document.body 起点の Testing Library query) + `waitFor` (非同期 mount 待ち) を使う。
+
+**Ark UI Menu 系 play の CI flake 対策 (#3687)**: Ark UI Menu (Menu / OverflowMenu) の open transition 中は content が `pointer-events: none` であり、`userEvent.click` は click 前に pointer-events を検査するため、CI runner の遅い描画では「item visible 直後の click」が「Unable to perform pointer interaction as the element has pointer-events: none」で fail する (ローカルの速い描画では再現しない timing flake)。対策は 2 点セット:
+
+1. **open transition 完了待ち**: item click 前に `await waitFor(() => assertPointerInteractive(item))` を挟む。wait 条件 SSOT は `src/lib/ui/primitives/story-play-helpers.ts` (遅延注入での決定性検証は `tests/unit/ui/story-play-helpers.test.ts`)。固定待ち (`waitForTimeout`) は不採用 (本ファイル禁止事項)
+2. **close 遷移を play 内で完結**: menu を open したまま play を終えると unmount 時の zag-js focus-visible cleanup が Storybook instrumentation と衝突し unhandled TypeError (Illegal invocation) を CI で leak する。`userEvent.keyboard('{Escape}')` → `not.toBeVisible()` で閉じてから終える
+
+横展開確認 (#3687 AC2): `ChildSelectionDialog` の play は `element.click()` (DOM click、pointer-events 非検査) で confirm/cancel を押すため本 flake class の対象外。新規に Menu 系 primitive の play で `userEvent.click(item)` を書く場合は上記 2 点セットを必ず適用する。
 
 ## 顧客レビュー前 CX 版 DoR (12 条件 SSOT、#2553 + #2657 後段フェーズ拡張 2026-05-30)
 

--- a/tests/unit/ui/story-play-helpers.test.ts
+++ b/tests/unit/ui/story-play-helpers.test.ts
@@ -1,0 +1,45 @@
+// tests/unit/ui/story-play-helpers.test.ts
+// #3687 — Menu.stories / OverflowMenu.stories の play が CI でのみ
+// 「pointer-events: none」で fail する timing flake の根治検証。
+//
+// stories 側は `waitFor(() => assertPointerInteractive(item))` で Ark UI Menu の
+// open transition 完了 (= pointer-events 解除) を待つ。本 test は CI 相当の描画遅延を
+// setTimeout で注入し、遅延の大小に依らず wait 条件が決定的に成立する (AC1) ことを
+// jsdom で検証する。固定待ち (waitForTimeout) ではなく条件 poll であることの証跡。
+
+import { waitFor } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { assertPointerInteractive } from '../../../src/lib/ui/primitives/story-play-helpers';
+
+function createElement(pointerEvents: string): HTMLElement {
+	const el = document.createElement('div');
+	el.style.pointerEvents = pointerEvents;
+	document.body.appendChild(el);
+	return el;
+}
+
+describe('assertPointerInteractive (#3687 Menu play flake 根治)', () => {
+	it('pointer-events: none (open transition 中) は throw する — waitFor の retry 対象になる', () => {
+		const el = createElement('none');
+		expect(() => assertPointerInteractive(el)).toThrowError(/pointer-events: none/);
+		el.remove();
+	});
+
+	it('pointer-events 解除済 (transition 完了) は throw しない', () => {
+		const el = createElement('auto');
+		expect(() => assertPointerInteractive(el)).not.toThrow();
+		el.remove();
+	});
+
+	it('[遅延注入] CI 相当の遅い transition 完了でも waitFor + assert で決定的に pass する (AC1)', async () => {
+		// CI runner の遅い描画を模擬: 開始時は pointer-events: none、遅延後に解除される。
+		const el = createElement('none');
+		setTimeout(() => {
+			el.style.pointerEvents = 'auto';
+		}, 120);
+		// stories と同一の合成 (waitFor は条件成立まで poll): 遅延量に依らず決定的に resolve する。
+		await waitFor(() => assertPointerInteractive(el));
+		expect(getComputedStyle(el).pointerEvents).not.toBe('none');
+		el.remove();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（CI パイプラインの決定性）

**解決する課題**: 統合 PR #3686 の CI (storybook-test) で `Menu.stories.svelte` 等 2 tests が「Unable to perform pointer interaction as the element has pointer-events: none」で 2 回連続 fail した（同一コードのローカル実行は全 PASS = CI runner 環境依存の timing flake）。Ark UI Menu の open transition 中は content が pointer-events: none であり、CI の遅い描画では `userEvent.click` が transition 完了前に発火する。flake が残ると統合 PR の重量レーンで rerun 運用コストが常態化する。

**期待される効果**: wait 条件（pointer-events 解除待ち）を SSOT helper に集約し、遅延注入 unit test で決定性を機械検証。同型 play への横展開状態も tests/CLAUDE.md に明文化され、新規 Menu 系 play で同 flake class が再発しない。

## 関連 Issue

closes #3687

- 関連: 統合 PR #3686 CI run 29170226020（2 回 fail の観測元）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | CI 環境相当 (遅延注入) で決定的に pass する wait 条件の追加 | `npx vitest run tests/unit/ui/story-play-helpers.test.ts` | HEAD `aef2271c` / 3 passed (「[遅延注入] CI 相当の遅い transition 完了でも waitFor + assert で決定的に pass する」を含む) / wait 条件 SSOT = src/lib/ui/primitives/story-play-helpers.ts:27 (`assertPointerInteractive`)、Menu.stories.svelte:71 / OverflowMenu.stories.svelte:146 が `waitFor(() => assertPointerInteractive(item))` で参照 |
| AC2 | 同型の play (OverflowMenu / ChildSelectionDialog) への横展開確認 | `STORYBOOK_TESTS=true npx vitest run --project storybook` (`npm run test:storybook`) + `grep -n "assertPointerInteractive" src/lib/ui/primitives/*.svelte` | HEAD `aef2271c` / 36 files 198 tests 全 PASS / OverflowMenu.stories.svelte:146 で同 helper 適用済。ChildSelectionDialog.stories.svelte は `element.click()` (DOM click、pointer-events 非検査) 使用のため本 flake class 対象外 — tests/CLAUDE.md §「Ark UI Menu 系 play の CI flake 対策 (#3687)」に横展開判定を明文化 |

補足（Issue 対処案 2 点目）: tests/CLAUDE.md §Storybook interaction test の Menu 行 + 新設「Ark UI Menu 系 play の CI flake 対策 (#3687)」節に、pointer-events wait + Escape close の 2 点セットと横展開判定を追記済。`waitForTimeout` 固定待ちは不使用（No-gos 遵守、wait は条件 poll の `waitFor` のみ）。

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`) — stories / test helper のみ（primitive 本体の挙動変更なし）
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（Storybook play 関数 + unit test + tests/CLAUDE.md のみ。本番 UI コード無変更）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 本 worktree では biome が `.claude/worktrees/` 配下を ignore し `biome check .` が 0 file になる環境制約があるため、test-only 変更に対する同等検証を個別実行で完遂: `npx biome check <変更 4 file>` PASS / `npx cspell <変更 file>`（CI 同一 scope の .ts/.svelte は指摘 0、tests/CLAUDE.md の Baymard 4 件は既存かつ CI cspell scope 外）/ `npx vitest run tests/unit/ui/story-play-helpers.test.ts` 3 passed / `npm run test:storybook` 36 files 198 tests PASS / `check-hardcoded-strings` 0 violation / `check-no-plan-literals` OK / `node scripts/check-pr-body.mjs --pr 3724` OK
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/ui/story-play-helpers.test.ts` 新規: pointer-events none で throw / 解除で pass / 遅延注入 (120ms) でも `waitFor` 合成で決定的 resolve の 3 ケース
  - `Menu.stories.svelte` / `OverflowMenu.stories.svelte`: inline の pointer-events 待ち waitFor block を `assertPointerInteractive` (SSOT helper) 参照に置換（挙動同一、重複排除）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore 相当 — Storybook play 関数 / unit test / tests/CLAUDE.md のみで UI 変更なし、本番 UI の視覚差分ゼロ）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: wait 条件を単一責務の pure 関数 `assertPointerInteractive` に分離（S）、stories / unit test の両方が同一 SSOT を参照
- [x] **DRY**: `grep -rn "pointerEvents === 'none'" src/` で inline 重複 0 件を確認（Menu / OverflowMenu の 2 箇所を helper に集約済）
- [x] **YAGNI**: helper は throw する assert 1 関数のみ、追加抽象なし
- [x] **Security（OSS 公開前提）**: N/A（テストコードのみ）
- [x] **アクセシビリティ**: N/A（UI 挙動変更なし）
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外（Storybook play / unit test のみ。横展開は AC2 で Menu 系 primitive 3 種を判定済み: Menu / OverflowMenu = helper 適用、ChildSelectionDialog = element.click() のため対象外）

**LP / 販促文言変更時** (ADR-0013): N/A

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**: pointer-events wait + Escape close の主修正自体は release #3686 統合時に hotfix として Menu / OverflowMenu へ適用済み（develop back-merge 済）。本 PR は Issue #3687 の残 AC（wait 条件の SSOT 化 + 遅延注入での決定性検証 + 横展開判定の明文化）を完遂するもの。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（biome は worktree 環境制約により変更ファイル個別実行で代替 PASS、詳細は「テスト & 安全装置セルフチェック」）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし（視覚差分ゼロの test 変更）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)



---

> **gate exemption 根拠 (QM Fix)**: 本 PR は Storybook `play` 関数 / helper / unit test / tests/CLAUDE.md のみの test-only 変更で、production Menu.svelte / OverflowMenu.svelte は不変・視覚差分ゼロ (screenshot-check が `src/lib/ui/**` glob で発火するのは `.stories.svelte` の play ロジック変更に反応したもの)。`refactor:internal-no-doc-impact` label で screenshot-check を exempt。flake 修正ロジック (pointer-events wait の SSOT 化) は helper に verbatim 抽出され `tests/unit/ui/story-play-helpers.test.ts` で決定性検証済 (弱体化なし)。
