### PR TITLE
docs(code): #3581 ① ids.ts の数値依存 claim を実態に是正 (層別実態 + dynamodb/demo への uuid 流入禁止を明文化)

### DIFF
--- a/src/lib/domain/ids.ts
+++ b/src/lib/domain/ids.ts
@@ -4,14 +4,24 @@
 // DSQL 移管 (§11.2) で id は uuid ベースの string になる。repo interface / service / route の
 // id 型を素の string でなく branded string にすることで:
 //   - ChildId と ActivityId の取り違え (ADR-0055 child-scope 越境の関心事) をコンパイル時に検出
-//   - 「id は opaque token」(2026-07-04 調査: 数値意味依存は hashSeed 1 点のみ) を型で明文化
+//   - 「id は opaque token」を型で明文化
+//
+// ⚠️ 数値意味依存の実態 (#3581 ① で claim 是正、2026-07-15 再調査):
+//   - **service/domain 層**: hashSeed (child-challenge-service.ts、childId 文字列を hash) の
+//     1 点のみ — こちらは opaque string でも成立する (文字列 hash であり数値解釈しない)。
+//   - **dynamodb / demo backend 内部**: `Number(childId)` 等の数値変換・数値 key 合成が
+//     多数残存する (activity-mastery-repo / activity-pref-repo ほか)。これらの backend は
+//     integer 由来 id ('903' 等) 前提の legacy 実装で、uuid id を渡すと NaN key になる。
+//     本番 (dsql) / NUC (pglite) は cutover 済のため実害は demo fixture / dynamodb 撤去
+//     (#3438) までの残債扱い。**uuid id を dynamodb/demo backend に流してはならない**。
 //
 // 値の実態は backend 依存の opaque string:
-//   - dsql: uuid v4 (gen_random_uuid)
-//   - sqlite (NUC cutover §12.2 まで): 既存 integer PK の 10 進文字列 (repo 境界で String()/Number() 変換)
+//   - dsql / pglite: uuid v4 (gen_random_uuid)
+//   - sqlite (legacy、#3438 撤去まで): 既存 integer PK の 10 進文字列 (repo 境界で String()/Number() 変換)
 //   - demo: '903' 等の数値文字列 fixture (ADR-0048 stateless、uuid 化しない)
 // よって as* コンストラクタは number も受ける (境界変換用)。branded は compile-time のみで
-// runtime コストゼロ。
+// runtime コストゼロ。trust 境界 (route param / cookie / form) での形式 validation は
+// #3581 ② の scope (pg 層の findChildById uuid guard は #3709 で導入済、pg-uuid.ts)。
 
 declare const idBrand: unique symbol;
 type Branded<T, B extends string> = T & { readonly [idBrand]: B };


### PR DESCRIPTION
## 顧客価値・目的

ids.ts の「数値意味依存は hashSeed 1 点のみ」という claim は実態と乖離しており (dynamodb/demo backend 内部に `Number(childId)` 数値変換が多数残存)、この誤った前提を信じた将来の実装が uuid id を legacy backend に流して NaN key の silent データ喪失を起こすリスクがある。SSOT コメントを実態に是正し、禁止事項を明文化する (#3581 ①)。

## 関連 Issue

refs #3581 (① のみ。② trust 境界 validation は別 PR)

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証方法 | 結果 |
|---|---|---|---|
| ① claim 是正 | 層別の実態 (service/domain = hashSeed 1 点で opaque 成立 / dynamodb・demo = Number() 依存残存) + uuid 流入禁止 + #3438 残債 pointer を header コメントに記載 | `grep -rnE "Number\((child|activity)" src/lib/server/db/dynamodb/` で残存を実測確認 (activity-mastery / activity-pref ほか) | PASS |
| 型・挙動の不変 | コメントのみの変更 | `npx vitest run tests/unit/domain/` → 47 files / 875 tests PASS | PASS |

## 変更タイプ

- [x] ドキュメント (docs — コード内 SSOT コメント)

## 影響範囲・変更コンポーネント

`src/lib/domain/ids.ts` の header コメントのみ (コード変更なし)。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/domain/` → 875/875 PASS
- [x] `npx biome check src/lib/domain/ids.ts` → No fixes applied / `npx cspell src/lib/domain/ids.ts` → Issues 0
- [x] ADR-0006: assert 変更なし

## スクリーンショット / ビジュアルデモ

UI 変更なし。

## コード品質セルフレビュー (#1481)

- [x] 是正は再調査 (2026-07-15) の実測に基づく (推測でなく grep 実証)
- [x] ② (trust 境界 validation) との責務境界を pointer で明示 (pg 層 uuid guard は #3709 で導入済)

## 横展開・影響波及チェック

- [x] hashSeed (child-challenge-service.ts) は文字列 hash であり uuid 化後も成立することを確認
- [x] dynamodb/demo の Number() 依存は #3438 (dynamodb 撤去) で消滅する残債として紐付け

## レビュー依頼事項・破壊的変更

なし (コメントのみ)。

## 配布済み env / secret (ADR-0006)

新規なし。

## Ready for Review チェックリスト

- [x] 関連 Issue 番号記載
- [x] AC 検証マップ 4 列記入
- [x] テスト実行結果記載 (875/875 PASS)
- [x] SS 不要
- [x] 横展開チェック実施

## QM レビュー結果

<!-- QM が記入 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)