### PR TITLE
test(fitness): #3684 COPY-import fitness の resolveSpecifier 近似限界明文化 + unresolved 検出 + backup mount 構造保証

### DIFF
--- a/tests/unit/architecture/dockerfile-copy-import-fitness.test.ts
+++ b/tests/unit/architecture/dockerfile-copy-import-fitness.test.ts
@@ -13,9 +13,18 @@
 // 対象外:
 //   - backup コンテナ: scripts/ を volume mount (docker-compose.yml `./scripts:/app/scripts:ro`)
 //     で実行時に全体が見えるため COPY 不整合 class が構造的に起きない
+//     (この「mount 設計であること」自体は下記 [backup class 構造保証] test が機械検証する、#3684 AC2)
 //   - node_modules import: deps stage で丸ごと COPY 済み (パッケージ解決は npm ci が担保)
 //   - $lib alias: tsconfig paths 経由。src/ が COPY されている Dockerfile では relative 同様に
 //     src/lib/ へ写像して検証する
+//
+// 近似限界の明文化 (#3684 AC3、QM residual #3654):
+//   - resolveSpecifier は tsx の実解決を「候補列」(拡張子付与 / .js→.ts 写像 / index.ts) で
+//     近似する。package.json exports 解決 / tsconfig paths の全 alias ($lib 以外) /
+//     node_modules 内部のファイル解決は scope 外 (external として意図的に skip)
+//   - 旧実装は relative / $lib specifier が候補列で解決不能なとき silent に対象外
+//     (false negative の余地) だった → unresolved として収集し 1 件でも fail する (#3684 AC1)。
+//     候補列の近似が実 import パターンに追随できていない場合、この fail が可視化する
 
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, posix, relative, resolve } from 'node:path';
@@ -78,15 +87,26 @@ function extractSpecifiers(sourceText: string): string[] {
 	return specifiers;
 }
 
-/** specifier をファイル実体へ解決する (tsx 同等: .js 指定は .ts 実体も試す)。解決不能は null。 */
-function resolveSpecifier(fromFileAbs: string, specifier: string): string | null {
+/**
+ * specifier 解決の結果 (#3684 AC1)。
+ * - resolved:   候補列でファイル実体に解決できた (graph 走査対象)
+ * - external:   node_modules / builtin — 意図的対象外 (deps stage COPY / npm ci が担保)
+ * - unresolved: relative / $lib なのに候補列で解決不能 — silent 対象外にせず fail させる
+ */
+type ResolveOutcome =
+	| { kind: 'resolved'; abs: string }
+	| { kind: 'external' }
+	| { kind: 'unresolved' };
+
+/** specifier をファイル実体へ解決する (tsx 同等の近似: .js 指定は .ts 実体も試す)。 */
+function resolveSpecifier(fromFileAbs: string, specifier: string): ResolveOutcome {
 	let baseAbs: string;
 	if (specifier.startsWith('./') || specifier.startsWith('../')) {
 		baseAbs = resolve(dirname(fromFileAbs), specifier);
 	} else if (specifier.startsWith('$lib/')) {
 		baseAbs = resolve(REPO_ROOT, 'src/lib', specifier.slice('$lib/'.length));
 	} else {
-		return null; // node_modules / builtin — 対象外
+		return { kind: 'external' }; // node_modules / builtin — 対象外 (ヘッダー「近似限界」参照)
 	}
 	const candidates = [
 		baseAbs,
@@ -103,18 +123,24 @@ function resolveSpecifier(fromFileAbs: string, specifier: string): string | null
 			// directory そのものに match した場合は index 解決のみ許す
 			if (c === baseAbs && existsSync(join(c, 'index.ts'))) continue;
 			try {
-				if (readFileSync(c, 'utf-8') !== undefined) return c;
+				if (readFileSync(c, 'utf-8') !== undefined) return { kind: 'resolved', abs: c };
 			} catch {
 				// directory 等は読めない → 次候補
 			}
 		}
 	}
-	return null;
+	return { kind: 'unresolved' };
 }
 
-/** entry から relative/$lib import graph を再帰解決し、repo パス集合を返す。 */
-function collectImportGraph(entryAbs: string): string[] {
+/**
+ * entry から relative/$lib import graph を再帰解決する。
+ * files:      解決できた repo パス集合 (COPY カバレッジ検証対象)
+ * unresolved: 候補列で解決不能だった relative/$lib specifier (`<from> -> <specifier>` 形式)。
+ *             silent 対象外 (false negative) を根絶するため呼出側で 0 件を assert する (#3684 AC1)
+ */
+function collectImportGraph(entryAbs: string): { files: string[]; unresolved: string[] } {
 	const visited = new Set<string>();
+	const unresolved = new Set<string>();
 	const queue = [entryAbs];
 	while (queue.length > 0) {
 		const file = queue.pop();
@@ -122,11 +148,18 @@ function collectImportGraph(entryAbs: string): string[] {
 		visited.add(file);
 		const source = readFileSync(file, 'utf-8');
 		for (const spec of extractSpecifiers(source)) {
-			const resolved = resolveSpecifier(file, spec);
-			if (resolved && !visited.has(resolved)) queue.push(resolved);
+			const outcome = resolveSpecifier(file, spec);
+			if (outcome.kind === 'resolved' && !visited.has(outcome.abs)) {
+				queue.push(outcome.abs);
+			} else if (outcome.kind === 'unresolved') {
+				unresolved.add(`${toRepoPath(file)} -> ${spec}`);
+			}
 		}
 	}
-	return [...visited].map(toRepoPath).sort();
+	return {
+		files: [...visited].map(toRepoPath).sort(),
+		unresolved: [...unresolved].sort(),
+	};
 }
 
 /** 検証対象: Dockerfile → image 同梱 entry (CMD / cutover rehearsal が実行するもの)。 */
@@ -144,7 +177,17 @@ describe('Dockerfile COPY ↔ CLI import 一致 fitness (#3652、ADR-0061)', () 
 			for (const entry of target.entries) {
 				expect(isCovered(entry, copyRoots), `entry ${entry} 自体が COPY されていない`).toBe(true);
 				const graph = collectImportGraph(join(REPO_ROOT, entry));
-				const missing = graph.filter((p) => !isCovered(p, copyRoots));
+				// #3684 AC1: 候補列で解決不能な relative/$lib specifier を silent 対象外にしない。
+				// unresolved が出た場合は「候補列 (resolveSpecifier) の近似が実 import に追随できて
+				// いない」or「import 先の実体が存在しない」のどちらかで、放置すると COPY 漏れ検証の
+				// 空白地帯 (false negative) になる。
+				expect(
+					graph.unresolved,
+					`${entry} の import graph に resolveSpecifier で解決不能な specifier があります ` +
+						`(silent 対象外 = false negative 温床、#3684)。候補列の追補 or import の見直しが必要:\n` +
+						graph.unresolved.join('\n'),
+				).toEqual([]);
+				const missing = graph.files.filter((p) => !isCovered(p, copyRoots));
 				expect(
 					missing,
 					`${target.dockerfile} の COPY に含まれない import 解決先があります (実行時 ERR_MODULE_NOT_FOUND、` +
@@ -160,9 +203,37 @@ describe('Dockerfile COPY ↔ CLI import 一致 fitness (#3652、ADR-0061)', () 
 			(root) => root !== 'scripts/lib/runtime',
 		);
 		const graph = collectImportGraph(join(REPO_ROOT, 'scripts/nuc-pglite-cutover.ts'));
-		const missing = graph.filter((p) => !isCovered(p, mutated));
+		const missing = graph.files.filter((p) => !isCovered(p, mutated));
 		// scripts/lib COPY (#3648、#3659 で runtime/ に分離) を欠く = cycle 2 の実障害状態を再現 → 必ず検出される
 		expect(missing.some((p) => p.startsWith('scripts/lib/runtime/'))).toBe(true);
+	});
+
+	it('[unresolved 演繹] 解決不能な relative specifier は unresolved として検出される (#3684 AC1)', () => {
+		const entry = join(REPO_ROOT, 'scripts/scheduler.ts');
+		// 実体が存在しない relative specifier → unresolved (silent skip しない)
+		expect(resolveSpecifier(entry, './does-not-exist-3684').kind).toBe('unresolved');
+		expect(resolveSpecifier(entry, '$lib/does-not-exist-3684').kind).toBe('unresolved');
+		// node_modules / builtin は意図的対象外 (external) のまま — 近似 scope の境界を固定する
+		expect(resolveSpecifier(entry, 'node:fs').kind).toBe('external');
+		expect(resolveSpecifier(entry, 'vitest').kind).toBe('external');
+	});
+
+	it('[backup class 構造保証] docker-compose.yml の backup service が ./scripts:/app/scripts mount を保持する (#3684 AC2)', () => {
+		// backup コンテナを本 fitness の対象外とする根拠は「scripts/ を volume mount する設計」
+		// にある (ヘッダー「対象外」)。compose から mount を外すと backup の実行時 import が
+		// COPY にも mount にも守られない fitness 空白地帯になるため、mount の存在自体を assert する。
+		const composeText = readFileSync(join(REPO_ROOT, 'docker-compose.yml'), 'utf-8');
+		const lines = composeText.split('\n');
+		const start = lines.findIndex((l) => /^ {2}backup:\s*$/.test(l));
+		expect(start, 'docker-compose.yml に backup service が存在する').toBeGreaterThan(-1);
+		const rest = lines.slice(start + 1);
+		// 次の top-level service (インデント 2 の非コメント行) までを backup block とみなす
+		const endOffset = rest.findIndex((l) => /^ {2}\S/.test(l) && !/^ {2}#/.test(l));
+		const block = rest.slice(0, endOffset === -1 ? undefined : endOffset).join('\n');
+		expect(
+			block,
+			'backup service の volumes に `./scripts:/app/scripts` mount が必要 (撤去 = fitness 空白化)',
+		).toMatch(/-\s*\.\/scripts:\/app\/scripts(?::ro)?\s*$/m);
 	});
 
 	it('[parser 健全性] COPY 形式 (--from / 直 COPY / dir / file) を正しく抽出する', () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（deploy 安全性の防御網品質）

**解決する課題**: COPY-import fitness (`dockerfile-copy-import-fitness.test.ts`、#3652) の残余リスク 2 点が QM residual (#3654 approve body) として記録されていた。(1) `resolveSpecifier` は tsx の実解決を候補列で近似しており、解決できない relative/$lib specifier が silent に対象外になる (false negative の余地)。(2) backup コンテナを fitness 対象外とする根拠「volume mount 設計であること」自体が機械検証されておらず、compose から mount を外すと fitness の空白地帯になる。

**期待される効果**: 解決不能 specifier が 1 件でも出れば fail する可視化により silent 対象外を根絶し、backup service の `./scripts:/app/scripts` mount 撤去も即検出。近似限界がヘッダーに明文化され、将来の保守者が fitness の守備範囲を誤認しない。

## 関連 Issue

closes #3684

- 関連: #3652 (fitness 導入元) / #3654 (QM residual 記録元 approve body) / ADR-0061

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | unresolved relative specifier の検出 (silent 対象外の根絶) | `npx vitest run tests/unit/architecture/dockerfile-copy-import-fitness.test.ts` | HEAD `1fc2d307` / 6 passed。`resolveSpecifier` を discriminated result (resolved / external / unresolved) 化し、main test で `expect(graph.unresolved).toEqual([])` を assert (現状 0 件)。演繹 test「[unresolved 演繹]」が `./does-not-exist-3684` / `$lib/does-not-exist-3684` → `unresolved`、`node:fs` / `vitest` → `external` を固定 |
| AC2 | backup service の scripts mount 存在 assert | 同上 + `grep -n "scripts:/app/scripts" docker-compose.yml` | HEAD `1fc2d307` / test「[backup class 構造保証]」が docker-compose.yml の backup service block から `- ./scripts:/app/scripts(:ro)` mount を assert (PASS)。docker-compose.yml L58 に実体あり |
| AC3 | 近似限界 (node_modules/exports 非対応) を test ヘッダーに明文化 | `grep -n "近似限界" tests/unit/architecture/dockerfile-copy-import-fitness.test.ts` | HEAD `1fc2d307` / ヘッダー「近似限界の明文化 (#3684 AC3)」節に package.json exports / tsconfig paths 全 alias / node_modules 内部解決が scope 外である旨 + unresolved fail 化の関係を明記 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

上記いずれにも該当なし: `tests/unit/architecture/dockerfile-copy-import-fitness.test.ts` 単一ファイルの fitness test 強化のみ（本番コード / Dockerfile / compose 無変更）

**影響を受ける画面・機能**: なし（CI fitness test のみ）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 本 worktree では biome が `.claude/worktrees/` 配下を ignore し `biome check .` が 0 file になる環境制約のため Step 1 のみ `npx biome check <変更ファイル>` の個別実行 (PASS) で代替、残 step は `--skip-biome` で全 PASS
- [x] 追加・変更したテストの概要を以下に記載:
  - `resolveSpecifier` を discriminated result 化し、`collectImportGraph` が unresolved specifier を収集 → main test で 0 件 assert (AC1)
  - 「[unresolved 演繹]」test 新規: 解決不能 specifier → unresolved / node_modules・builtin → external の境界固定
  - 「[backup class 構造保証]」test 新規: docker-compose.yml backup service の `./scripts:/app/scripts` mount 存在 assert (AC2)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore 相当 — fitness test 単一ファイルの変更で UI 変更なし）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: resolveSpecifier の戻り値を discriminated union で型化し、external (意図的対象外) と unresolved (検出対象) の責務を分離
- [x] **DRY**: `grep -rn "resolveSpecifier" tests/` で本ファイル以外に重複実装なしを確認
- [x] **YAGNI**: tsx resolver の完全再実装は不採用 (Issue No-gos 遵守)、候補列近似 + unresolved 可視化に留める
- [x] **Security（OSS 公開前提）**: N/A（テストコードのみ）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A（静的ファイル走査のみ、test 実行時間への影響僅少）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外（fitness test 単一ファイル。同型の COPY-import fitness は他に存在しないことを `grep -rln "parseDockerfileCopyRoots" tests/` で確認: 1 file のみ）

**LP / 販促文言変更時** (ADR-0013): N/A

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**: backup block 抽出は YAML parser を導入せず行 scan (インデント 2 の非コメント行を次 service 境界とみなす) で実装。compose の構造が大きく変わる場合は要追随だが、fitness 用途には十分と判断 (Pre-PMF / ADR-0010、依存追加ゼロ)。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（biome は worktree 環境制約により変更ファイル個別実行で代替 PASS）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: 該当なし（fitness test のみ）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
