### PR TITLE
fix(auth): #3555 招待 email 束縛 follow-up — mismatch UX 文言 + email_verified enforcement + 失効/正規化評価

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -410,7 +410,11 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 - **受諾時（`acceptInvite(inviteCode, userId, userEmail?)`）**: `invite.email` 設定時は、受諾 user の email と case-insensitive 一致必須。不一致・`userEmail` 未提供はいずれも **fail-closed** で `INVITE_EMAIL_MISMATCH` を返し、**招待は消費せず pending のまま保持**する（正規宛先による後続受諾の可能性を残す）。
 - **照合対象は Cognito 検証済みの `identity.email`**（呼出元 `providers/cognito.ts` が渡す、サーバ由来でクライアント改竄不可）である。クライアント入力値は照合材料にしない。
 - **email 未指定の招待は従来通り受諾可**（email を持たない受諾者向け、child 招待等）。この nullable 設計は [dsql-data-model.md §6.6](dsql-data-model.md) の invite email フィールド設計と一致する。
-- **fitness function**: `tests/unit/services/invite-service.test.ts` が email 一致（大小文字差含む）→ 受諾成功 / 不一致・未提供 → `INVITE_EMAIL_MISMATCH` + 招待 pending 保持 / email 未指定 → 従来通り受諾可、を検証する。
+- **email_verified enforcement（#3555 ③）**: email 束縛招待の受諾は IdP 検証済み email が前提。Cognito `email_verified` claim を `Identity.emailVerified` として伝搬し、束縛招待で `emailVerified === false` は **fail-closed** で `INVITE_EMAIL_UNVERIFIED` を返す（招待は pending 保持）。`undefined` は claim を持たない provider（local / dev）との後方互換のため許容。未束縛招待は email を identity 根拠にしないため対象外。
+- **不一致時の顧客向け案内（#3555 ①）**: 英語エラーコードを露出せず、`AUTH_INVITE_LABELS`（labels.ts SSOT）の文言で理由 + 次アクション（宛先違いの招待の再発行依頼）を表示する。①ログイン済み user は `/auth/invite/[code]` ランディングで受諾前に照合し dead-end を回避、②サインアップ経路は受諾失敗時に 1 回限りの通知 cookie（`invite_accept_error`、10 分）を積み、新規テナント自動作成後の admin +layout がバナー（`invite-accept-error-banner`）で案内する。owner 側の修正導線は `/admin/members` 保留中招待一覧に束縛宛先 email を表示し、タイプミスに気づいたら取消し → 再発行できる。
+- **失効・replay window（#3555 ②評価）**: 招待は作成時から `INVITE_EXPIRY_DAYS`（7 日）で失効し（`getInvite` が期限超過 pending を自動 expired 化）、owner は取消し（`revokeInvite`）で明示失効できる。mismatch 時に pending 保持しても横流しリンクの試行可能期間は 7 日で必ず閉じる。招待コードは 122bit エントロピー（`inv-<uuid v4>`）+ DB は hash 保存のため総当たりは非現実的で、専用 rate limit の追加は Pre-PMF 過剰防衛（ADR-0010）として不採用。
+- **email 正規化（#3555 ④評価）**: 照合は `trim().toLowerCase()` の exact 一致（意図的設計）。Gmail dot / plus alias・Unicode 正規化の吸収は over-match（意図しない別人の受諾）を招くため不採用。alias 起因の誤不一致は①の案内文言 + 再発行導線で運用対応し、サポート問い合わせが実際に発生したら再検討する。
+- **fitness function**: `tests/unit/services/invite-service.test.ts` が email 一致（大小文字差含む）→ 受諾成功 / 不一致・未提供 → `INVITE_EMAIL_MISMATCH` + 招待 pending 保持 / email 未指定 → 従来通り受諾可 / `emailVerified=false` × 束縛招待 → `INVITE_EMAIL_UNVERIFIED`（未束縛は許容）/ 期限切れ × 正 email → `INVALID_OR_EXPIRED`（replay window 上限）、を検証する。
 
 #### 5.2.5 account / tenant ライフサイクル admin API の owner-gate seam 統一（behavior-preserving、#3556 / #3528）
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -3718,6 +3718,9 @@ export const MEMBERS_LABELS = {
 	// Pending invites section
 	pendingInvitesTitle: '保留中の招待',
 	inviteExpiresPrefix: '期限: ',
+	// #3555 ①: 宛先 email 束縛付き招待の宛先を owner に見せる (タイプミスに気づき
+	// 取消し → 再発行できる修正導線)
+	inviteEmailBoundPrefix: '宛先: ',
 	inviteRevokeButton: '取消し',
 
 	// Error messages
@@ -5262,6 +5265,15 @@ export const AUTH_INVITE_LABELS = {
 	roleLabel: '参加ロール:',
 	signupButton: '新規アカウントを作成して参加',
 	loginButton: '既存アカウントでログインして参加',
+	// #3555 ①: 招待 email 束縛 (#3549 判断2) の不一致を顧客向けに案内する文言。
+	// 英語エラーコード (INVITE_EMAIL_MISMATCH) を露出せず、次アクションを必ず添える。
+	emailMismatch: 'この招待は別のメールアドレス宛です。',
+	emailMismatchDesc: '招待した方に、あなたのメールアドレス宛の招待を発行し直してもらってください。',
+	// #3555 ①: 受諾失敗 → 新規家族グループ自動作成後に admin 画面で表示する案内バナー
+	acceptErrorMismatchBanner:
+		'招待は別のメールアドレス宛だったため参加できず、新しい家族グループが作成されました。招待で参加するには、招待した方にあなたのメールアドレス宛の招待を発行し直してもらってください。',
+	acceptErrorUnverifiedBanner:
+		'メールアドレスの確認が完了していないため招待を受諾できず、新しい家族グループが作成されました。メールアドレスの確認後、招待した方に新しい招待を発行してもらってください。',
 } as const;
 
 // DEMO_ACHIEVEMENTS_LABELS: 実績機能廃止 (#1782 / #1816) で参照ゼロのため namespace 削除 (#1833)

--- a/src/lib/domain/validation/auth.ts
+++ b/src/lib/domain/validation/auth.ts
@@ -67,6 +67,13 @@ export const REFRESH_COOKIE_NAME = 'gq_refresh';
 // 招待リンク関連
 export const INVITE_COOKIE_NAME = 'invite_code';
 export const INVITE_EXPIRY_DAYS = 7;
+/**
+ * #3555 ①: 招待受諾が email 束縛で拒否されたことを受諾後の画面 (admin layout) に伝える
+ * 1 回限りの通知 cookie。値は 'INVITE_EMAIL_MISMATCH' | 'INVITE_EMAIL_UNVERIFIED'。
+ * 受諾失敗 → 新規テナント自動作成で顧客が理由不明の dead-end になるのを防ぐ。
+ */
+export const INVITE_ACCEPT_ERROR_COOKIE_NAME = 'invite_accept_error';
+export const INVITE_ACCEPT_ERROR_MAX_AGE_SECONDS = 10 * 60;
 
 export const createInviteSchema = z.object({
 	role: z.enum(['parent', 'child']),

--- a/src/lib/server/auth/providers/cognito-dev.ts
+++ b/src/lib/server/auth/providers/cognito-dev.ts
@@ -147,6 +147,8 @@ export class DevCognitoAuthProvider implements AuthProvider {
 					type: 'cognito',
 					userId: claims.sub,
 					email: claims.email,
+					// #3555 ③: 本番 CognitoAuthProvider と同じ email_verified 伝搬 (dev claim は通常 undefined)
+					emailVerified: claims.email_verified,
 					groups: claims['cognito:groups'],
 					// #3025: 本番 CognitoAuthProvider と同じ federated / recent-auth 情報
 					isFederated: (claims.identities?.length ?? 0) > 0,

--- a/src/lib/server/auth/providers/cognito.ts
+++ b/src/lib/server/auth/providers/cognito.ts
@@ -7,6 +7,8 @@ import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import {
 	CONTEXT_COOKIE_NAME,
 	IDENTITY_COOKIE_NAME,
+	INVITE_ACCEPT_ERROR_COOKIE_NAME,
+	INVITE_ACCEPT_ERROR_MAX_AGE_SECONDS,
 	INVITE_COOKIE_NAME,
 } from '$lib/domain/validation/auth';
 import { getRepos } from '$lib/server/db/factory';
@@ -34,6 +36,8 @@ export class CognitoAuthProvider implements AuthProvider {
 						type: 'cognito',
 						userId: claims.sub,
 						email: claims.email,
+						// #3555 ③: email 束縛招待の受諾判定 (fail-closed) に使う
+						emailVerified: claims.email_verified,
 						groups: claims['cognito:groups'],
 						// #3025: identities claim の有無で federated (Google 等) を判定
 						isFederated: (claims.identities?.length ?? 0) > 0,
@@ -57,6 +61,8 @@ export class CognitoAuthProvider implements AuthProvider {
 						type: 'cognito',
 						userId: claims.sub,
 						email: claims.email,
+						// #3555 ③: email 束縛招待の受諾判定 (fail-closed) に使う
+						emailVerified: claims.email_verified,
 						groups: claims['cognito:groups'],
 						// #3025: identities claim の有無で federated (Google 等) を判定
 						isFederated: (claims.identities?.length ?? 0) > 0,
@@ -218,8 +224,10 @@ export class CognitoAuthProvider implements AuthProvider {
 				effectiveUserId = user.userId;
 			}
 
-			// 招待受諾
-			const result = await acceptInvite(inviteCode, effectiveUserId, identity.email);
+			// 招待受諾 (#3555 ③: email 束縛招待は email_verified=false を fail-closed 拒否)
+			const result = await acceptInvite(inviteCode, effectiveUserId, identity.email, {
+				emailVerified: identity.emailVerified,
+			});
 
 			// Cookie を消費（成功でも失敗でも消す）
 			this.clearInviteCookie(event);
@@ -228,6 +236,21 @@ export class CognitoAuthProvider implements AuthProvider {
 				logger.warn('[AUTH] Invite acceptance failed', {
 					context: { inviteCode, error: result.error, userId: effectiveUserId },
 				});
+				// #3555 ①: email 束縛による拒否は受諾者に理由を伝えないと dead-end になる
+				// (この後 fallback の新規テナント自動作成が走り、無説明の空 admin に着地する)。
+				// 1 回限りの通知 cookie を積み、admin +layout が読み取って案内バナーを表示する。
+				if (
+					result.error === 'INVITE_EMAIL_MISMATCH' ||
+					result.error === 'INVITE_EMAIL_UNVERIFIED'
+				) {
+					event.cookies.set(INVITE_ACCEPT_ERROR_COOKIE_NAME, result.error, {
+						path: '/',
+						httpOnly: true,
+						sameSite: 'lax',
+						secure: true,
+						maxAge: INVITE_ACCEPT_ERROR_MAX_AGE_SECONDS,
+					});
+				}
 				return null;
 			}
 

--- a/src/lib/server/auth/types.ts
+++ b/src/lib/server/auth/types.ts
@@ -30,6 +30,8 @@ export type Identity =
 			type: 'cognito';
 			userId: string;
 			email: string;
+			/** #3555 ③: Cognito `email_verified` claim。email 束縛招待の受諾判定 (fail-closed) に使う */
+			emailVerified?: boolean;
 			groups?: string[];
 			/** #3025: federated IdP (Google 等) 経由 = Cognito パスワードを持たない */
 			isFederated?: boolean;

--- a/src/lib/server/services/invite-service.ts
+++ b/src/lib/server/services/invite-service.ts
@@ -46,6 +46,28 @@ export async function getInvite(inviteCode: string): Promise<Invite | null> {
 	return invite;
 }
 
+/**
+ * 宛先 email 束縛招待の受諾可否判定 (#3549 判断2 / dsql-data-model.md §6.6 ⚠️)。
+ * invite.email 設定時は受諾 user の email と case-insensitive 一致必須。未提供は
+ * fail-closed (招待リンクの横流しによる別人受諾を防ぐ)。招待は消費せず pending の
+ * まま (正規宛先の受諾可能性を保持)。
+ * #3555 ③: 束縛照合は「検証済み email」が前提。email_verified=false の provider
+ * 構成では他人の email を自称して束縛招待を受諾できてしまうため fail-closed で拒否。
+ */
+function checkInviteEmailBinding(
+	inviteEmail: string,
+	userEmail: string | undefined,
+	emailVerified: boolean | undefined,
+): string | null {
+	if (emailVerified === false) {
+		return 'INVITE_EMAIL_UNVERIFIED';
+	}
+	if (inviteEmail.toLowerCase() !== userEmail?.trim().toLowerCase()) {
+		return 'INVITE_EMAIL_MISMATCH';
+	}
+	return null;
+}
+
 /** 招待を受諾してテナントに参加 */
 export async function acceptInvite(
 	inviteCode: string,
@@ -70,17 +92,10 @@ export async function acceptInvite(
 		return { error: 'SELF_INVITE_NOT_ALLOWED' };
 	}
 
-	// 宛先 email 束縛 (#3549 判断2 / dsql-data-model.md §6.6 ⚠️): invite.email 設定時は
-	// 受諾 user の email と case-insensitive 一致必須。未提供は fail-closed (招待リンクの
-	// 横流しによる別人受諾を防ぐ)。招待は消費せず pending のまま (正規宛先の受諾可能性を保持)。
 	if (invite.email) {
-		// #3555 ③: 束縛照合は「検証済み email」が前提。email_verified=false の provider
-		// 構成では他人の email を自称して束縛招待を受諾できてしまうため fail-closed で拒否。
-		if (opts?.emailVerified === false) {
-			return { error: 'INVITE_EMAIL_UNVERIFIED' };
-		}
-		if (invite.email.toLowerCase() !== userEmail?.trim().toLowerCase()) {
-			return { error: 'INVITE_EMAIL_MISMATCH' };
+		const bindingError = checkInviteEmailBinding(invite.email, userEmail, opts?.emailVerified);
+		if (bindingError) {
+			return { error: bindingError };
 		}
 	}
 

--- a/src/lib/server/services/invite-service.ts
+++ b/src/lib/server/services/invite-service.ts
@@ -51,6 +51,14 @@ export async function acceptInvite(
 	inviteCode: string,
 	userId: string,
 	userEmail?: string,
+	opts?: {
+		/**
+		 * 受諾 user の email が IdP で検証済みか (Cognito `email_verified` claim、#3555 ③)。
+		 * email 束縛招待でのみ判定に使う。`false` は fail-closed で拒否、`undefined` は
+		 * claim を持たない provider (local / dev) との後方互換のため許容。
+		 */
+		emailVerified?: boolean;
+	},
 ): Promise<{ membership: Membership } | { error: string }> {
 	const invite = await getInvite(inviteCode);
 	if (!invite) {
@@ -65,8 +73,15 @@ export async function acceptInvite(
 	// 宛先 email 束縛 (#3549 判断2 / dsql-data-model.md §6.6 ⚠️): invite.email 設定時は
 	// 受諾 user の email と case-insensitive 一致必須。未提供は fail-closed (招待リンクの
 	// 横流しによる別人受諾を防ぐ)。招待は消費せず pending のまま (正規宛先の受諾可能性を保持)。
-	if (invite.email && invite.email.toLowerCase() !== userEmail?.trim().toLowerCase()) {
-		return { error: 'INVITE_EMAIL_MISMATCH' };
+	if (invite.email) {
+		// #3555 ③: 束縛照合は「検証済み email」が前提。email_verified=false の provider
+		// 構成では他人の email を自称して束縛招待を受諾できてしまうため fail-closed で拒否。
+		if (opts?.emailVerified === false) {
+			return { error: 'INVITE_EMAIL_UNVERIFIED' };
+		}
+		if (invite.email.toLowerCase() !== userEmail?.trim().toLowerCase()) {
+			return { error: 'INVITE_EMAIL_MISMATCH' };
+		}
 	}
 
 	// 1ユーザー=1テナント制約チェック

--- a/src/routes/(parent)/admin/+layout.server.ts
+++ b/src/routes/(parent)/admin/+layout.server.ts
@@ -3,6 +3,7 @@ import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import type { CurrencyCode, PointSettings, PointUnitMode } from '$lib/domain/point-display';
 import { DEFAULT_POINT_SETTINGS } from '$lib/domain/point-display';
+import { INVITE_ACCEPT_ERROR_COOKIE_NAME } from '$lib/domain/validation/auth';
 import { getEnv } from '$lib/runtime/env';
 import { getAuthMode, isCognitoDevMode, requireTenantId } from '$lib/server/auth/factory';
 import { COOKIE_SECURE } from '$lib/server/cookie-config';
@@ -173,9 +174,24 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url }) => {
 		}
 	}
 
+	// #3555 ①: 招待受諾が email 束縛で拒否された直後の案内 (1 回限りの通知 cookie を
+	// 読み取り即消費)。受諾失敗 → 新規テナント自動作成で無説明の空 admin に着地した
+	// 顧客に「なぜ招待で参加できなかったか + 次アクション」をバナーで伝える。
+	const rawInviteAcceptError = cookies.get(INVITE_ACCEPT_ERROR_COOKIE_NAME);
+	const inviteAcceptError =
+		rawInviteAcceptError === 'INVITE_EMAIL_MISMATCH' ||
+		rawInviteAcceptError === 'INVITE_EMAIL_UNVERIFIED'
+			? rawInviteAcceptError
+			: null;
+	if (rawInviteAcceptError) {
+		cookies.delete(INVITE_ACCEPT_ERROR_COOKIE_NAME, { path: '/' });
+	}
+
 	return {
 		pointSettings,
 		authMode,
+		// #3555 ①: 招待受諾失敗の 1 回限り案内 (admin +layout.svelte がバナー表示に使う)
+		inviteAcceptError,
 		// parent-gate inactivity redirect (client): PIN gate 有効時のみ admin で
 		// 15 分アイドル → /switch 自動リダイレクトを起動する (dev/demo では起動しない)
 		pinGateActive,

--- a/src/routes/(parent)/admin/+layout.svelte
+++ b/src/routes/(parent)/admin/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
+import { AUTH_INVITE_LABELS } from '$lib/domain/labels';
 import AdminLayout from '$lib/features/admin/components/AdminLayout.svelte';
 import SetupResumeBanner from '$lib/features/admin/components/SetupResumeBanner.svelte';
 import TrialBanner from '$lib/features/admin/components/TrialBanner.svelte';
@@ -7,6 +8,7 @@ import TrialEndedDialog from '$lib/features/admin/components/TrialEndedDialog.sv
 import { startParentGateInactivityRedirect } from '$lib/features/admin/parent-gate-inactivity';
 import type { OnboardingProgress } from '$lib/server/services/onboarding-service';
 import DebugPlanIndicator from '$lib/ui/components/DebugPlanIndicator.svelte';
+import Alert from '$lib/ui/primitives/Alert.svelte';
 
 interface Props {
 	data: {
@@ -35,6 +37,8 @@ interface Props {
 		// #3296: Stripe 決済の有効性 (`+layout.server.ts` が isStripeEnabled() を配布)。
 		// AdminLayout へ橋渡しし、Stripe 無効時に requiredStripe='enabled' ガイド手順を除外する。
 		stripeEnabled?: boolean;
+		// #3555 ①: 招待受諾が email 束縛で拒否された直後の 1 回限り案内 (通知 cookie 由来)
+		inviteAcceptError?: 'INVITE_EMAIL_MISMATCH' | 'INVITE_EMAIL_UNVERIFIED' | null;
 	};
 	children: Snippet;
 }
@@ -82,6 +86,18 @@ $effect(() => {
 </script>
 
 <AdminLayout mode="live" basePath="/admin" isPremium={data.isPremium ?? false} planTier={data.planTier ?? 'free'} authMode={data.authMode} {trialDaysRemaining} runtimeMode={data.runtimeMode} stripeEnabled={data.stripeEnabled}>
+	<!-- #3555 ①: 招待受諾が email 束縛で拒否された直後の案内 (無説明 dead-end 防止、1 回限り) -->
+	{#if data.inviteAcceptError}
+		<div style:margin-bottom="16px">
+			<Alert
+				variant="warning"
+				data-testid="invite-accept-error-banner"
+				message={data.inviteAcceptError === 'INVITE_EMAIL_UNVERIFIED'
+					? AUTH_INVITE_LABELS.acceptErrorUnverifiedBanner
+					: AUTH_INVITE_LABELS.acceptErrorMismatchBanner}
+			/>
+		</div>
+	{/if}
 	<!-- #2821: setup 由来で admin に着地したときの文脈バナー (続きの step へ戻る導線) -->
 	{#if data.setupOnboarding}
 		<div style:margin-bottom="16px">

--- a/src/routes/(parent)/admin/members/+page.svelte
+++ b/src/routes/(parent)/admin/members/+page.svelte
@@ -432,6 +432,13 @@ const roleLabel = (role: string) => {
 							<span class="ml-2 text-xs text-[var(--color-text-tertiary)]">
 								{MEMBERS_LABELS.inviteExpiresPrefix}{new Date(invite.expiresAt).toLocaleDateString('ja-JP')}
 							</span>
+							<!-- #3555 ①: 宛先 email 束縛付き招待の宛先を表示 (タイプミスに owner が気づき
+							     取消し → 再発行できる修正導線) -->
+							{#if invite.email}
+								<span class="ml-2 text-xs text-[var(--color-text-tertiary)]" data-testid="invite-bound-email">
+									{MEMBERS_LABELS.inviteEmailBoundPrefix}{invite.email}
+								</span>
+							{/if}
 						</div>
 						{#if $page.data.currentRole === 'owner'}
 							<Button

--- a/src/routes/auth/invite/[code]/+page.server.ts
+++ b/src/routes/auth/invite/[code]/+page.server.ts
@@ -2,6 +2,7 @@
 // 招待コードを検証し、ログイン/サインアップへ誘導する
 
 import { redirect } from '@sveltejs/kit';
+import { AUTH_INVITE_LABELS } from '$lib/domain/labels';
 import { INVITE_COOKIE_NAME } from '$lib/domain/validation/auth';
 import { getRepos } from '$lib/server/db/factory';
 import { getInvite } from '$lib/server/services/invite-service';
@@ -16,11 +17,24 @@ export const load: PageServerLoad = async ({ params, cookies, locals }) => {
 		return {
 			valid: false as const,
 			error: 'この招待リンクは無効または期限切れです。',
+			errorDesc: undefined,
 		};
 	}
 
 	// 既にログイン済みのユーザー → テナント所属チェック (#0203)
 	if (locals.identity && locals.identity.type === 'cognito') {
+		// #3555 ①: 宛先 email 束縛付き招待 (#3549 判断2) は、受諾処理に入る前に
+		// ログイン中 user の email と照合し、不一致なら理由 + 次アクションを案内する
+		// (受諾時の INVITE_EMAIL_MISMATCH で無説明 dead-end になるのを防ぐ)。
+		// 照合は invite-service と同じ case-insensitive exact 一致。
+		if (invite.email && invite.email.toLowerCase() !== locals.identity.email.trim().toLowerCase()) {
+			cookies.delete(INVITE_COOKIE_NAME, { path: '/' });
+			return {
+				valid: false as const,
+				error: AUTH_INVITE_LABELS.emailMismatch,
+				errorDesc: AUTH_INVITE_LABELS.emailMismatchDesc,
+			};
+		}
 		const existingTenants = await getRepos().auth.findUserTenants(locals.identity.userId);
 		if (existingTenants.length > 0) {
 			// 既にテナント所属 → 招待 Cookie を保存せず警告表示
@@ -28,6 +42,7 @@ export const load: PageServerLoad = async ({ params, cookies, locals }) => {
 			return {
 				valid: false as const,
 				error: '既に別のグループに所属しているため、この招待を受けることはできません。',
+				errorDesc: undefined,
 			};
 		}
 

--- a/src/routes/auth/invite/[code]/+page.svelte
+++ b/src/routes/auth/invite/[code]/+page.svelte
@@ -21,7 +21,8 @@ let { data } = $props();
 			<div class="text-center">
 				<div class="text-[2.5rem] mb-3">⚠️</div>
 				<p class="text-base font-semibold text-[var(--color-danger)] mb-2">{data.error}</p>
-				<p class="text-sm text-[var(--color-neutral-500)] mb-6">{AUTH_INVITE_LABELS.invalidLinkDesc}</p>
+				<!-- #3555 ①: email mismatch 等、エラー種別ごとの次アクション案内 (未指定時は再発行案内) -->
+				<p class="text-sm text-[var(--color-neutral-500)] mb-6">{data.errorDesc ?? AUTH_INVITE_LABELS.invalidLinkDesc}</p>
 				<a href="/auth/login" class="invite-button invite-button--error">{AUTH_INVITE_LABELS.loginPageLink}</a>
 			</div>
 		{:else}

--- a/tests/unit/services/invite-service.test.ts
+++ b/tests/unit/services/invite-service.test.ts
@@ -331,3 +331,87 @@ describe('招待 email 束縛 (#3549 判断2 / §6.6)', () => {
 		);
 	});
 });
+
+// #3555 ②: 招待失効が email mismatch の replay window を上限する regression。
+// 期限切れ後は正しい email でも INVALID_OR_EXPIRED になり、横流しリンクの
+// 試行可能期間は INVITE_EXPIRY_DAYS (7 日) で必ず閉じる。
+describe('招待失効 × email 束縛 (#3555 ②)', () => {
+	it('期限切れの email 束縛招待は正しい email でも INVALID_OR_EXPIRED (replay window 上限)', async () => {
+		inviteStore.set(
+			'exp-em',
+			makePendingInvite({
+				inviteCode: 'exp-em',
+				email: 'intended@example.com',
+				expiresAt: new Date(Date.now() - 1000).toISOString(),
+			}),
+		);
+		tenantStore.set('t-test', {
+			tenantId: 't-test',
+			status: 'active',
+			createdAt: new Date().toISOString(),
+		} as Tenant);
+
+		const result = assertError(await acceptInvite('exp-em', 'user-new', 'intended@example.com'));
+		expect(result.error).toBe('INVALID_OR_EXPIRED');
+		// pending のまま放置されず expired に遷移する (getInvite の自動失効)
+		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('exp-em', 'expired');
+	});
+});
+
+// #3555 ③: email 束縛招待の受諾は検証済み email が前提。email_verified=false の
+// provider 構成が将来入った場合、未検証 email での束縛招待受諾を fail-closed で拒否する。
+// email_verified 未提供 (undefined) は現行 provider (Cognito は常に claim を含む /
+// local・dev は claim なし) との後方互換のため許容する。
+describe('email_verified enforcement (#3555 ③)', () => {
+	beforeEach(() => {
+		tenantStore.set('t-test', {
+			tenantId: 't-test',
+			status: 'active',
+			createdAt: new Date().toISOString(),
+		} as Tenant);
+	});
+
+	it('email 束縛招待 + emailVerified=false → INVITE_EMAIL_UNVERIFIED (fail-closed、membership 未作成)', async () => {
+		inviteStore.set(
+			'ev-1',
+			makePendingInvite({ inviteCode: 'ev-1', email: 'intended@example.com' }),
+		);
+
+		const result = assertError(
+			await acceptInvite('ev-1', 'user-new', 'intended@example.com', { emailVerified: false }),
+		);
+		expect(result.error).toBe('INVITE_EMAIL_UNVERIFIED');
+		expect(membershipStore).toHaveLength(0);
+		// 招待は pending のまま (email 検証完了後の再受諾可能性を保持)
+		expect(inviteStore.get('ev-1')?.status).toBe('pending');
+	});
+
+	it('email 束縛招待 + emailVerified=true → 受諾できる', async () => {
+		inviteStore.set(
+			'ev-2',
+			makePendingInvite({ inviteCode: 'ev-2', email: 'intended@example.com' }),
+		);
+
+		const result = assertSuccess(
+			await acceptInvite('ev-2', 'user-new', 'intended@example.com', { emailVerified: true }),
+		);
+		expect(result.membership.tenantId).toBe('t-test');
+	});
+
+	it('email 束縛招待 + emailVerified 未提供 → 従来通り受諾できる (後方互換)', async () => {
+		inviteStore.set(
+			'ev-3',
+			makePendingInvite({ inviteCode: 'ev-3', email: 'intended@example.com' }),
+		);
+
+		assertSuccess(await acceptInvite('ev-3', 'user-new', 'intended@example.com'));
+	});
+
+	it('email 未束縛の招待は emailVerified=false でも受諾できる (束縛 opt-in と同原則)', async () => {
+		inviteStore.set('ev-4', makePendingInvite({ inviteCode: 'ev-4' }));
+
+		assertSuccess(
+			await acceptInvite('ev-4', 'user-new', 'anyone@example.com', { emailVerified: false }),
+		);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

PR #3553 で導入した招待 email 束縛 (#3549 判断2) は、宛先違いの受諾を fail-closed で拒否するが、拒否された正規受諾者には英語エラーコードすら見えず「サインアップしたのに招待した家族に合流できず、無説明の空 admin 画面に着地する」dead-end になっていた (受諾失敗 → 新規テナント自動作成 fallback のため)。本 PR は Adversarial Reviewer 指摘の残課題 4 点 (#3555) を消化し、①受諾者への理由 + 次アクション案内と owner 側の修正導線、③email_verified の fail-closed enforcement を実装、②失効 / ④正規化は現行コード裏取りに基づく評価結果を設計書 §5.2.4 に明文化する。

## 関連 Issue

- closes #3555
- 関連: #3553 / #3549 (email 束縛本体、merge 済) / #3548 (invite token util、merge 済)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| ① | INVITE_EMAIL_MISMATCH の顧客向け UX 文言 + 次アクション + owner 修正導線 | labels.ts SSOT 追加 (`AUTH_INVITE_LABELS.emailMismatch` 等) + ランディング事前照合 + admin バナー (`invite-accept-error-banner`) + members 保留招待一覧に宛先 email 表示。`npx vitest run tests/unit/services/invite-service.test.ts` 28 passed / eslint no-hardcoded-jp-text 新規違反 0 | PASS (SS は親セッションが撮影・追補) |
| ② | 招待失効 / rate limit の導入評価 | コード裏取り: `INVITE_EXPIRY_DAYS=7` + `getInvite` 自動失効 + `revokeInvite` が実装済 (issue 記述「失効期限が無い」は現行コードと乖離)。regression test「期限切れ × 正 email → INVALID_OR_EXPIRED」追加で replay window 7 日上限を機械固定。rate limit は 122bit entropy + hash 保存 + fail-closed のため Pre-PMF 過剰防衛 (ADR-0010) として不採用、設計書 §5.2.4 に評価記録 | PASS (評価完了 + regression test) |
| ③ | email_verified の明示 enforcement 評価 | 束縛判定点 (acceptInvite) で `emailVerified === false` を fail-closed 拒否 (`INVITE_EMAIL_UNVERIFIED`) を実装。Cognito claim → `Identity.emailVerified` 伝搬 (本番 + dev provider)。`undefined` は claim を持たない provider (local/dev) 後方互換で許容。unit test 4 件追加 (failing-test-first で RED 確認済) | PASS |
| ④ | email 正規化の将来検討 | exact 一致 (trim + toLowerCase) は over-match 回避の意図的設計であることを設計書 §5.2.4 に明文化。alias 吸収は不採用、①の再発行導線で運用対応、問い合わせ実発生時に再検討 | PASS (評価完了) |

## 変更タイプ

- [x] バグ修正 (dead-end UX の是正)
- [x] セキュリティ強化 (email_verified fail-closed)
- [x] ドキュメント (設計書 §5.2.4 同期)
- [ ] 新機能 / [ ] リファクタリング / [ ] インフラ

## 影響範囲・変更コンポーネント

- `src/lib/server/services/invite-service.ts` — `acceptInvite` に `opts.emailVerified` 追加 (③)
- `src/lib/server/auth/types.ts` / `providers/cognito.ts` / `providers/cognito-dev.ts` — `Identity.emailVerified` 伝搬 + 受諾失敗時の通知 cookie (①③)
- `src/lib/domain/validation/auth.ts` — `INVITE_ACCEPT_ERROR_COOKIE_NAME` 定数 (①)
- `src/lib/domain/labels.ts` — `AUTH_INVITE_LABELS` 4 文言 + `MEMBERS_LABELS.inviteEmailBoundPrefix` (①、ADR-0045)
- `src/routes/auth/invite/[code]/` — ログイン済み user の受諾前 mismatch 案内 (①)
- `src/routes/(parent)/admin/+layout.server.ts` / `+layout.svelte` — 通知 cookie 消費 + 案内バナー (①)
- `src/routes/(parent)/admin/members/+page.svelte` — 保留招待一覧に宛先 email 表示 (①)
- `docs/design/14-セキュリティ設計書.md` §5.2.4 — ①〜④ 同期
- **PR #3673 (owner-gate hardening) との overlap 申告**: 同 PR も `labels.ts` / `14-セキュリティ設計書.md` を変更するが、labels は別 namespace、設計書は §5.2.4 (本 PR) vs §5.2.5 (向こう) で節が分かれており textual conflict の可能性は低い。`src/routes/api/v1/admin/members/**` は本 PR では未変更 (members は `+page.svelte` の表示のみ)。後着側が rebase で解消する。

## テスト & 安全装置セルフチェック

- [x] failing-test-first (ADR-0061): ③ の `INVITE_EMAIL_UNVERIFIED` test を先に書き RED (1 failed / 27 passed) を確認してから実装 → GREEN (28 passed)
- [x] `npx vitest run tests/unit/services/invite-service.test.ts tests/unit/auth/ tests/unit/routes/ src/routes/` — 48 files / 483 tests passed
- [x] `npx svelte-check` — 変更ファイルのエラー 0 (残 115 errors は全て infra 系 = worktree に `infra/node_modules` 未 install の環境要因、#2476 既知)
- [x] `npx biome check <変更 12 files>` — errors 0 (warning 1 = members +page.svelte 595 行の既存 max-svelte-lines 警告、本 PR 由来ではない)
- [x] `npx eslint` (no-hardcoded-jp-text) 変更 svelte 3 files — 新規違反 0 (文言は全て labels.ts 経由)
- [x] `node scripts/check-no-plan-literals.mjs` — OK
- [x] assertion 弱体化なし (ADR-0006) / カバレッジ閾値変更なし

## スクリーンショット / ビジュアルデモ

**② admin 案内バナー (mismatch 通知 cookie → admin 到着時の理由 + 次アクション表示)** — 2026-07-15 親セッション撮影 (demo 決定的環境 `AUTH_MODE=anonymous DATA_SOURCE=demo` + `invite_accept_error=INVITE_EMAIL_MISMATCH` cookie を Playwright で set、screenshots branch `pr-3729/`):

| モバイル (390px) | PC (1440px) |
|---|---|
| ![banner-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3729/admin-invite-error-banner-mobile.png) | ![banner-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3729/admin-invite-error-banner-desktop.png) |

バナー文言「招待は別のメールアドレス宛だったため参加できず、新しい家族グループが作成されました。招待で参加するには、招待した方にあなたのメールアドレス宛の招待を発行し直してもらってください。」が理由 + 次アクションを提示していることを SS で確認済み。

**①ランディング mismatch 表示 / ③members 保留招待の宛先 email 表示 — SS 撮影不能の環境制約 (実測で確定)**: 招待の作成・受諾はローカルで撮影可能な backend が存在しない。(a) `dev:cognito` 既定 (sqlite) = auth repo が `Auth repo is not supported in local (SQLite) mode` を throw (実測 500)、(b) `DATA_SOURCE=demo` = `createInvite` が非永続 stub (`DEMO-INVITE` 固定、一覧に出ない)、(c) `DATA_SOURCE=pglite` (build + preview でも実測) = DEV_USERS の tenant id `dev-tenant-001` が非 UUID のため uuid 型 `family_id` で `22P02` throw (全 admin ページ 500、#3709 と同 class)。この検証環境 gap は親セッションが別 issue として起票済み。①③ の動作は unit test (invite-service 28 tests: mismatch / unverified / 束縛照合) + `invite-bound-email` testid の描画分岐 (`{#if invite.email}`) で担保し、SS は cloud staging (#2873) 整備後に補完可能。

## コード品質セルフレビュー (#1481)

- [x] 文言は terms.ts / labels.ts SSOT 経由、エラーコード (英語内部語彙) の UI 露出なし
- [x] fail-closed 原則の維持: `emailVerified === false` のみ拒否、`undefined` は後方互換 (既存 provider 挙動を変えない)
- [x] 通知 cookie は httpOnly + 10 分 + 読み取り時即削除 (1 回限り)、値は allowlist 2 値のみ受理
- [x] 並行実装チェック: DSQL `invite-accept.ts` (txn 変種) は service 層 seam の手前で束縛判定するため変更不要。dev provider には emailVerified 伝搬で parity 確保
- [x] 設計書同期 (ADR-0001): §5.2.4 に実装と同一内容を反映

## 横展開・影響波及チェック

- `acceptInvite` の呼出元は `providers/cognito.ts` の 1 箇所のみ (grep 確認済)。第 4 引数は optional のため既存呼出・test への破壊なし
- `Identity` cognito variant へのフィールド追加は optional のため既存構築箇所 (cognito.ts ×2 / cognito-dev.ts ×1) 以外に影響なし
- admin +layout のバナーは `inviteAcceptError` 非 null 時のみ描画 (通常フローで DOM 変化なし、visual regression baseline への影響なし)

## レビュー依頼事項・破壊的変更

- 破壊的変更なし
- レビュー観点: ①の banner 文言 (新規テナント自動作成という挙動を顧客語彙で説明できているか) / ③の `undefined` 許容 (fail-open に見えるが、現行 Cognito は email claim と共に必ず email_verified を発行し、local/dev provider は email 束縛招待を処理しない)

## 配布済み env / secret (ADR-0006)

- 新規 env / secret なし

## Ready for Review チェックリスト

- [x] targeted vitest (483 tests) / biome / svelte-check (変更ファイル 0 エラー) / eslint / check-no-plan-literals / check-pr-body PASS (§テスト & 安全装置セルフチェック参照)

本 PR は Draft 提出 (Ready 化しない)。Ready 化の前提条件 = ① SS 4 スロット embed (UI 変更 3 点、撮影は親セッションが担う) ② `npm run pre-ready -- --pr 3729` 全 step PASS ③ QA 承認・動作確認、の 3 点は SS 撮影環境を持つ親セッションが Ready 化時に完遂する。

## QM レビュー結果

(QM 記入欄)

