### PR TITLE
test: #3592②/#3600② 実 DSQL staging 実測 (FOR UPDATE=write-intent の実測是正 + covering index 不要判断)

### DIFF
--- a/docs/design/dsql/m3-physical-model.md
+++ b/docs/design/dsql/m3-physical-model.md
@@ -367,7 +367,7 @@ M2 の GrowthJournal 集約 atomic 境界（activity_log 生成 + status 更新 
 
 - 40001（OC000）= 冪等 txn のみ **指数バックオフ + jitter で abort & retry**、service 層に共通ラッパ 1 箇所集約。
 - **40001 と 23505 / rowCount=0 を厳密分岐**（invite 受諾等）: `23505`=業務失敗（ALREADY_IN_TENANT、retry 禁止）/ `rowCount=0`=業務失敗（retry 禁止）/ `40001`=競合（retry）。owner_guard の `23505` は即エラー返却。
-- **【実測確定・検証5】OCC 競合率**: 同一行並行 = `40001(OC000)` 再現・**lost update なし**（一方が確実に fail、正しく直列化）。**disjoint key（別行 = 1 家族相当のキー非重複ワークロード）= 40001 0 件**。→ retry ラッパは必須だが正しいキー設計下の常用競合率は極小。
+- **【実測確定・検証5】OCC 競合率**: 同一行並行 = `40001(OC000)` 再現・**lost update なし**（一方が確実に fail、正しく直列化）。**disjoint key（別行 = 1 家族相当のキー非重複ワークロード）= 40001 0 件**。→ retry ラッパは必須だが正しいキー設計下の常用競合率は極小。**#3592② staging 実測 (2026-07-15) 追補**: 同一行 anchor (FOR UPDATE 行) へ意図的に競合させる採番系 (pin の MAX+1) は N 並行バーストで成功数が occ-retry maxAttempts に律速される (N=8 で 4〜7 成功、失敗は clean な 40001 枯渇のみ / committed 分の整合は常に成立 / N=2 は retry で全成功)。「anchor = 整合性保証」であり「直列化 (全成功) 保証」ではない。バーストが仕様化する経路は write 束ね (ADR-0065 原則 2) を使う。
 
 ### §6.4 一括 import / 復元の chunk saga（I-4、P5、**実測確定・検証4**）
 

--- a/src/lib/server/db/dsql/activity-pref-repo.ts
+++ b/src/lib/server/db/dsql/activity-pref-repo.ts
@@ -10,9 +10,15 @@
 //     行う。この read-then-write は同一 child の別 activity を並行 pin すると write-skew を起こす
 //     (両 txn が同じ MAX をスナップショット読取 → 同じ nextOrder を別行に INSERT → 別行ゆえ OCC
 //     40001 は発火せず pin_order が tie。設計書 §4.1: read-write 依存は非検出 = write skew を
-//     OCC では防げない)。よって txn 冒頭で children 行を FOR UPDATE ロックし、同一 child の pin
-//     操作を直列化する (§8。#3546 daily-mission と同型の serialization anchor)。異なる child は
-//     別行ロックで非競合。sqlite は同期ドライバで暗黙直列のため parity 上も等価。
+//     OCC では防げない)。よって txn 冒頭で children 行を FOR UPDATE し、この read を write-intent
+//     化する (#3546 daily-mission と同型の anchor)。
+//     ⚠️ **DSQL の FOR UPDATE は blocking lock ではない** (#3592 ② staging 実測 2026-07-15):
+//     同一 children 行への並行 write-intent は commit 時に 40001 で検出され occ-retry が吸収する
+//     — write-skew (pin_order tie) は構造的に防がれるが「直列化 (全成功)」は保証されない。
+//     現実的並行度 (N=2、二重 click) は maxAttempts=3 で全成功、N=8 バーストでは一部が
+//     clean な OCC 枯渇 fail になり得る (committed 分の tie なし連番は常に成立)。実測 test =
+//     tests/integration/db/dsql-staging-pin-bulk-latency.test.ts [M1][M1b]。異なる child は
+//     別行 intent で非競合。sqlite は同期ドライバで暗黙直列のため parity 上も等価。
 //     work 内 await は tx.execute(...) 直呼びのみ (fitness#7、helper 閉包経由 await 禁止)。
 //   - upsert は複合 PK への ON CONFLICT DO UPDATE (record-activity-core.ts と同型)。
 //   - sqlite parity: findAllByChild の並びは pin_order ASC で NULL 先頭 (SQLite の NULL 順)。

--- a/tests/integration/db/dsql-staging-pin-bulk-latency.test.ts
+++ b/tests/integration/db/dsql-staging-pin-bulk-latency.test.ts
@@ -1,0 +1,247 @@
+// tests/integration/db/dsql-staging-pin-bulk-latency.test.ts
+// #3592 ② / #3600 ② — **実 Aurora DSQL cluster** での並行検証 + hot path latency 実測。
+//
+// PGlite (単一接続) では再現・計測できない 3 点を staging cluster で検証する:
+//   [M1] #3592 ②: togglePin の children 行 FOR UPDATE 直列化 — 同一 child の別 activity を
+//        N 並行 pin しても pin_order が tie しない (write-skew は OCC 非検出 §4.1 のため
+//        FOR UPDATE anchor が唯一の防御。真の並行接続でのみ検証可能)
+//   [M2] #3592 ②: insertActivitiesBulk の部分失敗 rollback — mid-bulk で CHECK 違反 (23514) を
+//        注入し、先行 INSERT が全て rollback される (all-or-nothing) ことを実 DSQL で検証
+//   [M3] #3600 ② (#3562 ②): 「今週のカード」lookup (UUID surrogate 化で UNIQUE index 経由
+//        2 段 fetch) の latency 実測 — SELECT 1 baseline との差分でサーバ側コストを近似し、
+//        covering index 追加の要否判断材料を issue に記録する
+//
+// 実行方法 (CI では skip — DSQL_ENDPOINT 未設定のため。#3683 の staging CI レーン化で常設予定):
+//   eval "$(aws configure export-credentials --format env)"
+//   DSQL_ENDPOINT=<staging-id>.dsql.us-east-1.on.aws \
+//     npx vitest run tests/integration/db/dsql-staging-pin-bulk-latency.test.ts
+//
+// ⚠️ latency の絶対値は実行元 (ローカル日本 ≈ +150ms RTT) に依存する。判断は
+//   「lookup − SELECT 1 baseline」の差分 (サーバ側コスト近似) で行い、Lambda 同 region の
+//   実効値は baseline 差分にほぼ一致する。
+//
+// 検証データは専用 family uuid に隔離し afterAll で全削除する (staging を汚さない)。
+
+import { writeFileSync } from 'node:fs';
+import { AuroraDSQLPool } from '@aws/aurora-dsql-node-postgres-connector';
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { asChildId } from '../../../src/lib/domain/ids';
+import { createDsqlActivityPrefRepo } from '../../../src/lib/server/db/dsql/activity-pref-repo';
+import { createDsqlChildActivityRepo } from '../../../src/lib/server/db/dsql/child-activity-repo';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import { createDsqlStampCardRepo } from '../../../src/lib/server/db/dsql/stamp-card-repo';
+
+const ENDPOINT = process.env.DSQL_ENDPOINT;
+// 検証専用 family (afterAll で全削除。concurrency=c04c / import-restore=e515 と別枠)
+const FAMILY = '00000000-0000-4000-8000-00000000ea92';
+const PARALLEL = 8;
+
+type Db = ReturnType<typeof drizzle>;
+type Tx = Parameters<Parameters<Db['transaction']>[0]>[0];
+
+function percentile(sorted: number[], p: number): number {
+	const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+	return sorted[Math.max(0, idx)] ?? 0;
+}
+
+describe.skipIf(!ENDPOINT)('実 DSQL pin 並行 + bulk rollback + latency (#3592②/#3600②)', () => {
+	let pool: AuroraDSQLPool;
+	let db: Db;
+	let childId: string;
+	const activityIds: string[] = [];
+
+	beforeAll(async () => {
+		pool = new AuroraDSQLPool({
+			host: ENDPOINT,
+			user: process.env.DSQL_MIGRATE_USER ?? 'admin',
+			database: 'postgres',
+			max: PARALLEL + 2, // 並行 txn は接続 1:1 (DSQL は 1 接続 1 txn)
+			connectionTimeoutMillis: 15_000,
+		});
+		db = drizzle(pool);
+		// 専用 family の残骸を除去 (前回 run が中断していた場合の汚染耐性)
+		for (const t of ['child_activity_preferences', 'stamp_cards', 'child_activities', 'children']) {
+			await db.execute(sql`DELETE FROM ${sql.raw(t)} WHERE family_id = ${FAMILY}`);
+		}
+		// 検証 child + activities (N=PARALLEL) を seed
+		const child = await db.execute(sql`
+			INSERT INTO children (family_id, nickname, birth_date, theme, ui_mode)
+			VALUES (${FAMILY}, '実測子', '2018-01-15', 'blue', 'elementary') RETURNING child_id
+		`);
+		childId = (child.rows[0] as { child_id: string }).child_id;
+		for (let i = 0; i < PARALLEL; i++) {
+			const a = await db.execute(sql`
+				INSERT INTO child_activities (family_id, child_id, name, category_id, icon, base_points)
+				VALUES (${FAMILY}, ${childId}, ${`実測活動${i + 1}`}, '1', '🏃', 5) RETURNING activity_id
+			`);
+			activityIds.push((a.rows[0] as { activity_id: string }).activity_id);
+		}
+	}, 120_000);
+
+	afterAll(async () => {
+		try {
+			for (const t of [
+				'child_activity_preferences',
+				'stamp_cards',
+				'child_activities',
+				'children',
+			]) {
+				await db.execute(sql`DELETE FROM ${sql.raw(t)} WHERE family_id = ${FAMILY}`);
+			}
+		} finally {
+			await pool.end();
+		}
+	}, 60_000);
+
+	it('[M1] 高並行 (N=8) pin: committed 分は tie なし連番 / 失敗は OCC 枯渇のみ (整合性は破れない)', async () => {
+		// 実測での確定事実 (2026-07-15 初回計測): DSQL の FOR UPDATE は **write-intent 化であり
+		// blocking lock ではない** — 同一 children 行への並行 write-intent は commit 時 40001 で
+		// 検出され、occ-retry (maxAttempts=3) が吸収する。N=8 バーストでは retry 上限を超え
+		// 一部が「Failed query: commit」で fail し得る (初回実測: 8 中 1 fail)。
+		// **契約 = 整合性 (committed 分の tie なし連番) は常に成立 / 失敗は clean な OCC 枯渇のみ**。
+		// throughput (全成功) は契約ではない — 現実的並行度 (N=2、二重 click / 2 端末) は [M1b]。
+		const runner = createDsqlTransactionRunner<Tx>(db); // 既定 occ-retry (maxAttempts=3)
+		const repo = createDsqlActivityPrefRepo(db, runner);
+
+		const results = await Promise.allSettled(
+			activityIds.map((aid) =>
+				repo.togglePin(asChildId(childId), asChildId(aid) as never, 1, FAMILY),
+			),
+		);
+		const fulfilled = results.filter((r) => r.status === 'fulfilled').length;
+		const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+		console.log(
+			`[M1 report] N=${PARALLEL} fulfilled=${fulfilled} rejected=${rejected.length} reasons=${rejected.map((r) => String(r.reason).slice(0, 80)).join(' / ')}`,
+		);
+		// 失敗が出る場合は OCC 枯渇 (commit 失敗) のみ許容 — 他エラー (constraint 等) は契約違反
+		for (const r of rejected) {
+			expect(String(r.reason), 'OCC 枯渇以外の失敗は契約違反').toMatch(/commit|40001|OC000/);
+		}
+		// 成功数はバースト時 maxAttempts (=3 rounds、各 round で最低 1 commit 確定) に律速される
+		// (実測: 8 並行で 4〜7 成功と高分散)。下限は理論保証値 = maxAttempts。
+		expect(fulfilled, '各 retry round で最低 1 commit は確定する').toBeGreaterThanOrEqual(3);
+
+		const orders = await db.execute(sql`
+			SELECT pin_order FROM child_activity_preferences
+			WHERE family_id = ${FAMILY} AND child_id = ${childId} AND is_pinned = true
+			ORDER BY pin_order
+		`);
+		const values = (orders.rows as { pin_order: number }[]).map((r) => Number(r.pin_order));
+		// 整合性契約: committed 分は tie なし (write-skew 不発) + 1 起点の連番 (欠番なし)
+		expect(new Set(values).size, `pin_order tie 検出: ${values.join(',')}`).toBe(fulfilled);
+		expect(values).toEqual(Array.from({ length: fulfilled }, (_, i) => i + 1));
+	}, 120_000);
+
+	it('[M1b] 現実的並行度 (N=2) は retry が吸収し全成功する', async () => {
+		// 二重 click / 2 端末同時 pin 相当。maxAttempts=3 で吸収できることを実 DSQL で保証する。
+		const runner = createDsqlTransactionRunner<Tx>(db);
+		const repo = createDsqlActivityPrefRepo(db, runner);
+		// M1 の pin を全解除して盤面を初期化
+		for (const aid of activityIds) {
+			await repo.togglePin(asChildId(childId), asChildId(aid) as never, 0, FAMILY);
+		}
+		const two = activityIds.slice(0, 2);
+		const results = await Promise.allSettled(
+			two.map((aid) => repo.togglePin(asChildId(childId), asChildId(aid) as never, 1, FAMILY)),
+		);
+		expect(
+			results
+				.filter((r) => r.status === 'rejected')
+				.map((r) => String((r as PromiseRejectedResult).reason)),
+			'N=2 は全成功 (retry 吸収)',
+		).toEqual([]);
+		const orders = await db.execute(sql`
+			SELECT pin_order FROM child_activity_preferences
+			WHERE family_id = ${FAMILY} AND child_id = ${childId} AND is_pinned = true
+			ORDER BY pin_order
+		`);
+		expect((orders.rows as { pin_order: number }[]).map((r) => Number(r.pin_order))).toEqual([
+			1, 2,
+		]);
+	}, 120_000);
+
+	it('[M2] insertActivitiesBulk は mid-bulk CHECK 違反で全 rollback (all-or-nothing)', async () => {
+		const runner = createDsqlTransactionRunner<Tx>(db);
+		const repo = createDsqlChildActivityRepo(db, runner);
+
+		const before = await db.execute(sql`
+			SELECT count(*) AS c FROM child_activities WHERE family_id = ${FAMILY}
+		`);
+		const beforeCount = Number((before.rows[0] as { c: unknown }).c);
+
+		const mkInput = (name: string, priority = 'optional') => ({
+			childId: asChildId(childId),
+			name,
+			categoryId: '1' as never,
+			icon: '🧪',
+			basePoints: 5,
+			priority,
+		});
+		// 3 行目で priority CHECK (enum SSOT) 違反 → 23514。先行 2 行が rollback されること。
+		await expect(
+			repo.insertActivitiesBulk(
+				[
+					mkInput('bulk-ok-1'),
+					mkInput('bulk-ok-2'),
+					mkInput('bulk-broken', 'INVALID_PRIORITY'),
+					mkInput('bulk-never'),
+				] as never,
+				FAMILY,
+			),
+		).rejects.toThrow();
+
+		const after = await db.execute(sql`
+			SELECT count(*) AS c FROM child_activities WHERE family_id = ${FAMILY}
+		`);
+		expect(Number((after.rows[0] as { c: unknown }).c), '先行 INSERT が rollback 済').toBe(
+			beforeCount,
+		);
+	}, 120_000);
+
+	it('[M3] 週カード lookup latency 実測 (baseline 差分でサーバ側コスト近似、#3600②)', async () => {
+		const runner = createDsqlTransactionRunner<Tx>(db);
+		const stampRepo = createDsqlStampCardRepo(db, runner);
+		// 今週のカードを 1 枚 seed
+		const weekStart = '2026-07-13';
+		await db.execute(sql`
+			INSERT INTO stamp_cards (family_id, child_id, week_start, week_end)
+			VALUES (${FAMILY}, ${childId}, ${weekStart}, '2026-07-19')
+			ON CONFLICT ON CONSTRAINT stamp_cards_week_uq DO NOTHING
+		`);
+
+		const N = 50;
+		const baseline: number[] = [];
+		const lookup: number[] = [];
+		// warm-up (接続確立・plan cache の初回コストを除外)
+		await db.execute(sql`SELECT 1`);
+		await stampRepo.findCardByChildAndWeek(asChildId(childId), weekStart, FAMILY);
+		for (let i = 0; i < N; i++) {
+			let t0 = performance.now();
+			await db.execute(sql`SELECT 1`);
+			baseline.push(performance.now() - t0);
+			t0 = performance.now();
+			const card = await stampRepo.findCardByChildAndWeek(asChildId(childId), weekStart, FAMILY);
+			lookup.push(performance.now() - t0);
+			expect(card, 'lookup が今週のカードを返す').toBeTruthy();
+		}
+		baseline.sort((a, b) => a - b);
+		lookup.sort((a, b) => a - b);
+		const report = {
+			n: N,
+			baselineMs: { p50: percentile(baseline, 50), p95: percentile(baseline, 95) },
+			lookupMs: { p50: percentile(lookup, 50), p95: percentile(lookup, 95) },
+			serverCostApproxMs: {
+				p50: percentile(lookup, 50) - percentile(baseline, 50),
+				p95: percentile(lookup, 95) - percentile(baseline, 95),
+			},
+		};
+		// 判断材料を issue へ転記するための実測 report (絶対閾値 gate にはしない、ADR-0065)
+		console.log(`[M3 latency report] ${JSON.stringify(report, null, 1)}`);
+		// vitest reporter は PASS test の stdout を抑制することがあるため file にも残す (git 管理外 tmp/)
+		writeFileSync('tmp/m3-latency-report.json', JSON.stringify(report, null, 1));
+		// 健全性 bound のみ (回線劣化検出。covering index 要否は baseline 差分で人が判断する)
+		expect(report.lookupMs.p95).toBeLessThan(2_000);
+	}, 300_000);
+});

--- a/tests/integration/db/dsql-staging-pin-bulk-latency.test.ts
+++ b/tests/integration/db/dsql-staging-pin-bulk-latency.test.ts
@@ -46,6 +46,9 @@ function percentile(sorted: number[], p: number): number {
 	return sorted[Math.max(0, idx)] ?? 0;
 }
 
+// #3592②/#3600② 恒久 opt-in skip: 実 Aurora DSQL cluster (DSQL_ENDPOINT + AWS creds) を要する
+// staging 実測のため CI では常時 skip する設計。#3683 の staging CI レーン常設で置換予定
+// (deadline 目標 2026-09-13)。owner: @Takenori-Kusaka。実行方法は本ファイル冒頭コメント参照。
 describe.skipIf(!ENDPOINT)('実 DSQL pin 並行 + bulk rollback + latency (#3592②/#3600②)', () => {
 	let pool: AuroraDSQLPool;
 	let db: Db;
@@ -91,7 +94,8 @@ describe.skipIf(!ENDPOINT)('実 DSQL pin 並行 + bulk rollback + latency (#3592
 				await db.execute(sql`DELETE FROM ${sql.raw(t)} WHERE family_id = ${FAMILY}`);
 			}
 		} finally {
-			await pool.end();
+			// 型定義に end 無し (dsql-staging-concurrency.test.ts / dsql-migrate.ts と同キャスト)
+			await (pool as unknown as { end(): Promise<void> }).end();
 		}
 	}, 60_000);
 
@@ -107,7 +111,7 @@ describe.skipIf(!ENDPOINT)('実 DSQL pin 並行 + bulk rollback + latency (#3592
 
 		const results = await Promise.allSettled(
 			activityIds.map((aid) =>
-				repo.togglePin(asChildId(childId), asChildId(aid) as never, 1, FAMILY),
+				repo.togglePin(asChildId(childId), asChildId(aid) as never, true, FAMILY),
 			),
 		);
 		const fulfilled = results.filter((r) => r.status === 'fulfilled').length;
@@ -140,11 +144,11 @@ describe.skipIf(!ENDPOINT)('実 DSQL pin 並行 + bulk rollback + latency (#3592
 		const repo = createDsqlActivityPrefRepo(db, runner);
 		// M1 の pin を全解除して盤面を初期化
 		for (const aid of activityIds) {
-			await repo.togglePin(asChildId(childId), asChildId(aid) as never, 0, FAMILY);
+			await repo.togglePin(asChildId(childId), asChildId(aid) as never, false, FAMILY);
 		}
 		const two = activityIds.slice(0, 2);
 		const results = await Promise.allSettled(
-			two.map((aid) => repo.togglePin(asChildId(childId), asChildId(aid) as never, 1, FAMILY)),
+			two.map((aid) => repo.togglePin(asChildId(childId), asChildId(aid) as never, true, FAMILY)),
 		);
 		expect(
 			results


### PR DESCRIPTION
## 顧客価値・目的

PGlite では構造的に検証不能だった 3 点 (#3592②/#3600②、cutover 前必須とされた検証) を実 DSQL staging cluster で実測。「FOR UPDATE で直列化」という設計前提の誤りを実機で発見・是正し、pin 操作の実挙動 (整合性は常に成立 / バーストで clean fail あり得る) を契約としてテスト固定した。子供ホーム hot path の covering index 要否も実測で決着。

## 関連 Issue

refs #3592 (②) / refs #3600 (② = #3562②) / refs #3424 #3683

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証方法 | 結果 |
|---|---|---|---|
| #3592② pin の真の並行検証 | [M1] N=8 並行 pin / [M1b] N=2 現実的並行度 | **staging 実 cluster 実行 4/4 PASS (2026-07-15)**。発見: DSQL の FOR UPDATE は write-intent 化 (blocking でない) — committed 分の tie なし連番は常に成立、N=8 で成功数は maxAttempts 律速 (実測 4〜7/8、失敗は clean OCC 枯渇のみ)、N=2 は全成功 | PASS |
| #3592② bulk 部分失敗 rollback | [M2] mid-bulk CHECK 違反 (23514) 注入 | 先行 INSERT 全 rollback を実 DSQL で確認 | PASS |
| #3600② 週カード lookup 実測 | [M3] SELECT 1 baseline 差分方式 (n=50、RTT 控除) | **サーバ側コスト p50 1.07ms / p95 2.97ms → covering index 不要** (判断材料を issue に記録) | PASS |
| 設計コメントの実測是正 | activity-pref-repo.ts の「FOR UPDATE ロックで直列化」を write-intent 検出の実態に修正 (実測 test への pointer 付き) | コード review | PASS |

## 変更タイプ

- [x] テスト追加 (test)
- [x] ドキュメント (コード内設計コメント是正)

## 影響範囲・変更コンポーネント

- `tests/integration/db/dsql-staging-pin-bulk-latency.test.ts` (新規、DSQL_ENDPOINT gate — CI では skip)
- `src/lib/server/db/dsql/activity-pref-repo.ts` (設計コメントのみ、ロジック不変)

## テスト & 安全装置セルフチェック

- [x] staging 実 cluster で `DSQL_ENDPOINT=... npx vitest run tests/integration/db/dsql-staging-pin-bulk-latency.test.ts` → 4/4 PASS
- [x] `npx biome check` / `npx cspell` → clean
- [x] 専用 family uuid 隔離 + beforeAll pre-clean (汚染耐性) + afterAll 全削除 (staging 原状復帰)
- [x] latency は絶対閾値 gate にしない (ADR-0065、健全性 bound のみ)。判断は baseline 差分で人が行う

## スクリーンショット / ビジュアルデモ

UI 変更なし。

## コード品質セルフレビュー (#1481)

- [x] [M1] の契約は「整合性 = 必須 / throughput = maxAttempts 律速の理論下限」に精密化 (実測 2 run の分散 4〜7/8 を反映)
- [x] M3 report は file 出力 (tmp/) 併用 — vitest reporter の stdout 抑制で実測値が失われる罠に対処

## 横展開・影響波及チェック

- [x] 同型 anchor の #3546 (daily-mission completeMissionAndMaybeGrantBonus) も同じ write-intent 意味論 — 全完了 bonus は「二重付与防止」目的のため commit 時検出で契約成立 (直列化不要)、追加対応不要と判断
- [x] pin バーストが実仕様化する場合 (一括 pin 機能等) は write 束ね (ADR-0065 原則 2) が必要 — #3592 に記録

## レビュー依頼事項・破壊的変更

なし (テスト + コメントのみ)。

## 配布済み env / secret (ADR-0006)

新規なし。

## Ready for Review チェックリスト

- [x] 関連 Issue 番号記載
- [x] AC 検証マップ 4 列記入
- [x] テスト実行結果記載 (staging 実機 4/4 PASS)
- [x] SS 不要
- [x] 横展開チェック実施

## QM レビュー結果

<!-- QM が記入 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)