### PR TITLE
fix(auth): #3726 invites 2 endpoint の owner-gate hardening (401→500 退行根治 + 403 文言 SSOT、#3673 same-class 完遂)

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -504,6 +504,10 @@ export const OWNER_GATE_LABELS = {
 	memberDelete: ownerOnly('メンバーを削除'),
 	/** POST api/v1/admin/members/[userId]/transfer-ownership */
 	transferOwnership: ownerOnly('権限を移譲'),
+	/** POST api/v1/admin/invites (#3726、置換前文言とバイト一致) */
+	inviteCreate: ownerOnly('招待を作成'),
+	/** DELETE api/v1/admin/invites/[code] (#3726、置換前文言とバイト一致) */
+	inviteRevoke: ownerOnly('招待を取り消し'),
 } as const;
 
 export const SUBSCRIPTION_PLAN_LABELS: Record<string, string> = {

--- a/src/routes/api/v1/admin/invites/+server.ts
+++ b/src/routes/api/v1/admin/invites/+server.ts
@@ -2,11 +2,11 @@
 // GET  /api/v1/admin/invites — 招待一覧取得
 // (#0129, #1111)
 
-import { error, isHttpError, json } from '@sveltejs/kit';
+import { error, json } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
-import { PLAN_GATE_LABELS } from '$lib/domain/labels';
+import { OWNER_GATE_LABELS, PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { createInviteSchema } from '$lib/domain/validation/auth';
-import { requireRole } from '$lib/server/auth/guards';
+import { ownerGateResponse } from '$lib/server/auth/owner-gate';
 import { validationError } from '$lib/server/errors';
 import { createInvite, listInvites } from '$lib/server/services/invite-service';
 import { checkFamilyMemberLimit } from '$lib/server/services/plan-limit-service';
@@ -29,16 +29,10 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 	const tenantId = context.tenantId;
 
-	// #3549 決裁 (a): 招待作成は owner 専用。role 判定は requireRole seam (#3528 fitness#3)
-	// に統一し、response 形は既存 client 互換の {error} JSON を維持する
-	try {
-		requireRole(locals, ['owner']);
-	} catch (e) {
-		if (isHttpError(e, 403)) {
-			return json({ error: 'owner のみ招待を作成できます' }, { status: 403 });
-		}
-		throw e;
-	}
+	// #3549 決裁 (a): 招待作成は owner 専用。#3726 (= #3673 same-class): 401→401 / 403→403 変換と
+	// 文言 SSOT (OWNER_GATE_LABELS) を ownerGateResponse helper に集約 (401 の 500 化退行を構造排除)
+	const gate = ownerGateResponse(locals, OWNER_GATE_LABELS.inviteCreate);
+	if (gate) return gate;
 
 	const identity = locals.identity;
 	if (!identity || identity.type !== 'cognito') {

--- a/src/routes/api/v1/admin/invites/[code]/+server.ts
+++ b/src/routes/api/v1/admin/invites/[code]/+server.ts
@@ -1,7 +1,8 @@
 // DELETE /api/v1/admin/invites/[code] — 招待取消し (#0129)
 
-import { isHttpError, json } from '@sveltejs/kit';
-import { requireRole } from '$lib/server/auth/guards';
+import { json } from '@sveltejs/kit';
+import { OWNER_GATE_LABELS } from '$lib/domain/labels';
+import { ownerGateResponse } from '$lib/server/auth/owner-gate';
 import { revokeInvite } from '$lib/server/services/invite-service';
 import type { RequestHandler } from './$types';
 
@@ -12,16 +13,10 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 	}
 	const tenantId = context.tenantId;
 
-	// #3549 決裁 (a): 招待取消は owner 専用。role 判定は requireRole seam (#3528 fitness#3)
-	// に統一し、response 形は既存 client 互換の {error} JSON を維持する
-	try {
-		requireRole(locals, ['owner']);
-	} catch (e) {
-		if (isHttpError(e, 403)) {
-			return json({ error: 'owner のみ招待を取り消しできます' }, { status: 403 });
-		}
-		throw e;
-	}
+	// #3549 決裁 (a): 招待取消は owner 専用。#3726 (= #3673 same-class): 401→401 / 403→403 変換と
+	// 文言 SSOT (OWNER_GATE_LABELS) を ownerGateResponse helper に集約 (401 の 500 化退行を構造排除)
+	const gate = ownerGateResponse(locals, OWNER_GATE_LABELS.inviteRevoke);
+	if (gate) return gate;
 
 	await revokeInvite(params.code, tenantId);
 	return json({ ok: true });

--- a/tests/unit/routes/admin-invites-owner-gate.test.ts
+++ b/tests/unit/routes/admin-invites-owner-gate.test.ts
@@ -33,9 +33,7 @@ type Role = 'owner' | 'parent' | 'child';
 
 function makeLocals(role: Role | null): App.Locals {
 	return {
-		context: role
-			? { tenantId: 't-invites', role, licenseStatus: 'active', plan: 'family' }
-			: null,
+		context: role ? { tenantId: 't-invites', role, licenseStatus: 'active', plan: 'family' } : null,
 		identity: role ? { type: 'cognito', userId: 'u-1', email: 'o@example.com' } : null,
 	} as unknown as App.Locals;
 }

--- a/tests/unit/routes/admin-invites-owner-gate.test.ts
+++ b/tests/unit/routes/admin-invites-owner-gate.test.ts
@@ -1,0 +1,132 @@
+// tests/unit/routes/admin-invites-owner-gate.test.ts
+// #3726 (= #3673 same-class 残余): invites 2 endpoint の owner-gate hardening 検証。
+//
+// #3673 で account/tenant/members 系 6 route を ownerGateResponse + OWNER_GATE_LABELS に
+// 集約した際、invites 2 endpoint に旧 inline パターン (catch 内 isHttpError(e,403) のみ捕捉 →
+// 401 が outer catch へ伝播し 500 化する潜在退行 + 403 文言 literal 直書き) が残存した。
+// 本テストは hardening 後の契約を固定する:
+//   - 非 owner (parent/child) → 403 + OWNER_GATE_LABELS SSOT 文言 (置換前とバイト一致)
+//   - 未認証 (context 欠落) → 401 + {error: 認証が必要です} (500 化しない)
+//   - owner → gate 通過 (後続処理へ続行)
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OWNER_GATE_LABELS } from '../../../src/lib/domain/labels';
+
+// ---------- service mocks (gate 通過後の後続を無害化) ----------
+
+const mockCreateInvite = vi.fn();
+const mockListInvites = vi.fn();
+const mockRevokeInvite = vi.fn();
+vi.mock('$lib/server/services/invite-service', () => ({
+	createInvite: (...args: unknown[]) => mockCreateInvite(...args),
+	listInvites: (...args: unknown[]) => mockListInvites(...args),
+	revokeInvite: (...args: unknown[]) => mockRevokeInvite(...args),
+}));
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	checkFamilyMemberLimit: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+type Role = 'owner' | 'parent' | 'child';
+
+function makeLocals(role: Role | null): App.Locals {
+	return {
+		context: role
+			? { tenantId: 't-invites', role, licenseStatus: 'active', plan: 'family' }
+			: null,
+		identity: role ? { type: 'cognito', userId: 'u-1', email: 'o@example.com' } : null,
+	} as unknown as App.Locals;
+}
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('POST /api/v1/admin/invites owner-gate (#3726)', () => {
+	const load = () => import('../../../src/routes/api/v1/admin/invites/+server');
+
+	for (const role of ['parent', 'child'] as const) {
+		it(`${role} は 403 + OWNER_GATE_LABELS.inviteCreate (SSOT 文言、旧 literal とバイト一致)`, async () => {
+			const { POST } = await load();
+			const res = await POST({
+				request: new Request('http://t/api/v1/admin/invites', { method: 'POST' }),
+				locals: makeLocals(role),
+			} as never);
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: OWNER_GATE_LABELS.inviteCreate });
+			expect(OWNER_GATE_LABELS.inviteCreate).toBe('owner のみ招待を作成できます');
+			expect(mockCreateInvite).not.toHaveBeenCalled();
+		});
+	}
+
+	it('未認証 (context 欠落) は 500 化せず 401 (401→500 潜在退行の根治)', async () => {
+		const { POST } = await load();
+		const res = await POST({
+			request: new Request('http://t/api/v1/admin/invites', { method: 'POST' }),
+			locals: makeLocals(null),
+		} as never);
+		expect(res.status).toBe(401);
+	});
+
+	it('owner は gate を通過し後続処理へ続行する (403 で遮断されない)', async () => {
+		mockCreateInvite.mockResolvedValue({ code: 'ABC123', role: 'parent' });
+		const { POST } = await load();
+		let res: Response | Error;
+		try {
+			res = await POST({
+				request: new Request('http://t/api/v1/admin/invites', {
+					method: 'POST',
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({ role: 'parent' }),
+				}),
+				locals: makeLocals('owner'),
+			} as never);
+		} catch (e) {
+			res = e as Error;
+		}
+		// gate (401/403) では遮断されない — 後続の validation / service に到達していること
+		if (res instanceof Response) {
+			expect([401, 403]).not.toContain(res.status);
+		}
+	});
+});
+
+describe('DELETE /api/v1/admin/invites/[code] owner-gate (#3726)', () => {
+	const load = () => import('../../../src/routes/api/v1/admin/invites/[code]/+server');
+
+	for (const role of ['parent', 'child'] as const) {
+		it(`${role} は 403 + OWNER_GATE_LABELS.inviteRevoke (SSOT 文言、旧 literal とバイト一致)`, async () => {
+			const { DELETE } = await load();
+			const res = await DELETE({
+				params: { code: 'ABC123' },
+				locals: makeLocals(role),
+			} as never);
+			expect(res.status).toBe(403);
+			await expect(res.json()).resolves.toEqual({ error: OWNER_GATE_LABELS.inviteRevoke });
+			expect(OWNER_GATE_LABELS.inviteRevoke).toBe('owner のみ招待を取り消しできます');
+			expect(mockRevokeInvite).not.toHaveBeenCalled();
+		});
+	}
+
+	it('未認証 (context 欠落) は 500 化せず 401', async () => {
+		const { DELETE } = await load();
+		const res = await DELETE({
+			params: { code: 'ABC123' },
+			locals: makeLocals(null),
+		} as never);
+		expect(res.status).toBe(401);
+	});
+
+	it('owner は gate を通過し revokeInvite に到達する', async () => {
+		mockRevokeInvite.mockResolvedValue(undefined);
+		const { DELETE } = await load();
+		const res = await DELETE({
+			params: { code: 'ABC123' },
+			locals: makeLocals('owner'),
+		} as never);
+		expect(res.status).toBe(200);
+		expect(mockRevokeInvite).toHaveBeenCalledWith('ABC123', 't-invites');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

#3673 で account/tenant/members 系 6 route の owner-gate を hardening した際、**同一 class の invites 2 endpoint が未適用のまま残存** (QM Tier2 same-class 検出、ADR-0061)。未認証で invites API を叩くと clean な 401 でなく 500 (内部エラー) に化ける潜在退行と、403 文言の SSOT 外 literal を根治し、認可 seam の応答一貫性 (NN/G consistency / ADR-0062) を完遂する。

## 関連 Issue

closes #3726 / refs #3673 #3561 #3549 / ADR-0045 ADR-0061 ADR-0062

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証方法 | 結果 |
|---|---|---|---|
| AC1: 2 endpoint が ownerGateResponse 経由 (401→401 / 403→403) | invites/+server.ts (POST) / invites/[code]/+server.ts (DELETE) の inline try/catch を helper 呼出に置換 | `npx vitest run tests/unit/routes/admin-invites-owner-gate.test.ts` — 未認証→401 (500 化しない) を機械検証 | PASS (8/8) |
| AC2: 403 文言が OWNER_GATE_LABELS SSOT 経由 | `inviteCreate` / `inviteRevoke` を ownerOnly() template で追加 — **置換前 literal とバイト一致** (test で `toBe('owner のみ招待を作成できます')` 等を pin、既存 client 互換) | 同 test (parent/child → 403 + SSOT 文言) | PASS |
| AC3: 非 owner→403 / 未認証→401 / owner→続行の unit test | admin-invites-owner-gate.test.ts 新設 (8 件) | 8/8 PASS。erosion なし (既存 test 変更ゼロ、ADR-0006) | PASS |
| AC4: same-class 全数確認 | `grep -rlE "isHttpError\(e, 403\)" src/routes/` → **残 0**。`requireRole(locals,['owner'])` 直呼び 3 route (account/export・restore / data/clear) は raw 伝播 = SvelteKit が 401/403 を正しく返す**別 class で健全** (catch で握らないため 500 化しない) | grep 全数 + 3 route の実装確認 | PASS |

## 変更タイプ

- [x] バグ修正 (fix / auth)
- [x] テスト追加 (test)

## 影響範囲・変更コンポーネント

- `src/routes/api/v1/admin/invites/+server.ts` / `[code]/+server.ts`: gate 置換のみ (invite 業務ロジック不変)
- `src/lib/domain/labels.ts`: OWNER_GATE_LABELS に 2 key 追加 (compound 層、ADR-0045)
- `tests/unit/routes/admin-invites-owner-gate.test.ts` (新規)
- 応答互換: 403 body は文言バイト一致 / 401 は「500 (内部エラー)」→「401 {error}」への**修正方向のみ**の変化

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/routes/admin-invites-owner-gate.test.ts` → 8/8 PASS
- [x] 回帰: `npx vitest run tests/unit/auth/owner-gate.test.ts tests/unit/routes/admin-owner-guard-rollout.test.ts` + invites 系 → 4 files / 63 tests PASS
- [x] `npx svelte-check --threshold error` → 0 errors / `npx biome check` / `npx cspell` → clean
- [x] ADR-0006: 既存 assert 変更ゼロ、追加のみ

## スクリーンショット / ビジュアルデモ

UI 変更なし (API 認可応答のみ)。

## コード品質セルフレビュー (#1481)

- [x] #3673 と完全同型の置換 (helper / labels 構造を再利用、新規パターンなし)
- [x] 文言バイト一致を test で pin (silent 文言変化の検出)

## 横展開・影響波及チェック

- [x] AC4 の grep 全数確認で inline パターン残 0 (本 PR で class 消滅)
- [x] requireRole 直呼び 3 route は raw 伝播で健全 — ownerGateResponse への統一は応答 body 形式の変更 (SvelteKit error page → {error} JSON) を伴うため、必要になれば別 issue で client 互換を検討 (現状問題なし)

## レビュー依頼事項・破壊的変更

破壊的変更なし (401 化は 500 の修正方向のみ)。

## 配布済み env / secret (ADR-0006)

新規なし。

## Ready for Review チェックリスト

- [x] 関連 Issue 番号記載
- [x] AC 検証マップ 4 列記入
- [x] テスト実行結果記載 (8/8 + 63/63 PASS)
- [x] SS 不要
- [x] 横展開チェック実施 (AC4 全数 grep)

## QM レビュー結果

<!-- QM が記入 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)