### PR TITLE
docs(runbook): #3713 AC3 意図的な再 cutover 手順の明文化 (dataDir 退避 → dispatch)

### DIFF
--- a/docs/runbooks/nuc-pglite-cutover.md
+++ b/docs/runbooks/nuc-pglite-cutover.md
@@ -54,6 +54,14 @@ curl -s http://localhost:3000/api/health   # 200 + "dataSource":"pglite" + schem
 2. `docker compose up -d` — 旧 sqlite DB は無変更のためそのまま復帰
 3. 失敗した `data/pglite` dir は調査後に削除可
 
+## 意図的な再 cutover 手順 (#3713 AC3)
+
+deploy-nuc.yml の cutover step は **`data/pglite` が既存なら skip する** (PGlite 稼働後の deploy で cutover 後データを凍結 snapshot で上書きしないため、PR #3711)。旧 sqlite snapshot から意図的にやり直す場合のみ、以下を手動実行する:
+
+1. NUC 上で PGlite dataDir を退避または削除: `mv data/pglite data/pglite.discard-$(date +%Y%m%d)` — **cutover 以降の記録データは失われる**ことを PO に確認してから実行する
+2. `gh workflow run deploy-nuc.yml` を dispatch — Step 2.5 が「dataDir 不在 + legacy sqlite 存在」を検知し cutover を再実行する
+3. 完了後 `/api/health` で `dataSource:"pglite"` + 実画面で子供一覧を確認
+
 ## 検証済みエビデンス (2026-07-11、AC-C4)
 
 - cross-backend round-trip test: `tests/unit/services/pglite-cutover-roundtrip.test.ts` (内容保全・自然キー再解決)


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: NUC (セルフホスト) 運用者 / 運用引き継ぎ者

**解決する課題**: #3713 で deploy-nuc.yml の cutover step に「PGlite dataDir 既存なら skip」ガードが入った (PR #3711、develop 反映済) が、**意図的に再 cutover したい場合の正規手順が runbook に無く**、運用者が独自判断で `data/pglite` を削除する事故 (cutover 後データの誤消失) の余地が残っていた。

**期待される効果**: 再 cutover は「PO 確認 → dataDir 退避 → dispatch」の 3 step 正規手順に一本化され、skip ガードと矛盾しない運用が明文化される。

## 関連 Issue

関連: #3713 (AC3 のみ本 PR で消化。AC1 = deploy-nuc.yml ガードは PR #3711 で develop 反映済 / AC2 = main 反映後の実機検証は develop→main 統合後の運用作業のため本 PR scope 外)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC3 (#3713) | runbook に意図的再 cutover 手順 (data/pglite 手動削除 → dispatch) を追記 | docs/runbooks/nuc-pglite-cutover.md §「意図的な再 cutover 手順」 | 追記済 (+8 行)。skip ガード (PR #3711) の挙動前提・PO 確認 step・health 検証 step を含む |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] docs (runbook 1 file、+8 行のみ)

**影響を受ける画面・機能**: なし (運用文書のみ)。

## DB スキーマ変更

なし。

## セキュリティチェックリスト

- [x] 認可境界の変更なし / secret の記載なし (コマンド例のみ)

## パフォーマンス影響

なし。

## テスト & 安全装置セルフチェック

- [x] docs-only のため vitest / E2E 対象外。`node scripts/check-doc-code-references.mjs` PASS (新規デッドリンク 0) / `npx tsx scripts/check-terminology-coherence.ts` PASS / `node scripts/check-pr-body.mjs --pr 3734` PASS
- [x] 追加・変更したテストの概要: N/A (docs)
- [x] 新規 env / secret 追加: N/A
- [x] DynamoDB 実装変更: N/A
- [x] Critical バグ修正 (ADR-0002): N/A (docs 追記。#3713 本体の critical 対処は PR #3711)

## スクリーンショット / ビジュアルデモ

N/A (docs-only、UI 変更なし)。

## コード品質セルフレビュー (#1481)

- [x] docs SSOT 原則 (#2440): 現状の正解のみ端的に記述、経緯 narrative なし (issue 番号 pointer のみ)
- [x] 手順は skip ガード実装 (PR #3711 の deploy-nuc.yml Step 2.5) と整合

## 横展開・影響波及チェック

- staging (deploy-nuc-staging.yml) は fresh rehearsal が意図のため対象外 (#3713 no-gos 整合、runbook にも staging 手順は追加しない)

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。AC2 (main 反映後の実機 skip ログ確認) は統合後の運用作業として issue に残る

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## 配布済み env / secret (ADR-0006)

なし (docs-only)。

## Ready for Review チェックリスト

- [x] 全 AC (本 PR scope = #3713 AC3) 消化済み
- [x] `node scripts/check-doc-code-references.mjs` / `npx tsx scripts/check-terminology-coherence.ts` / `node scripts/check-pr-body.mjs --pr 3734` PASS
- [x] 設計書同期: runbook 自体が SSOT (追加設計書なし)

## QM レビュー結果

(QM 記入欄)
