### PR TITLE
docs: #3732 invite/members 系の local 検証不可 (sqlite/demo/pglite) を CLAUDE.md に明記 (対応案 3)

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -134,6 +134,16 @@ npm run dev:cognito-signup  # signup ページは COGNITO_DEV_MODE 無しが必�
 
 使用必須: 認証画面変更 PR の Ready 前 / SS 撮影 / login / signup / ops group / プラン別 UI / 管理画面の変更時。
 
+### local 検証不可: invite / members (auth repo) 系 (#3732)
+
+招待 (invites) / メンバー (memberships) 系の作成〜受諾フローは **どの local backend でも検証できない**。cloud staging (#2873) で検証する:
+
+| backend | 検証不可の理由 |
+|---|---|
+| sqlite (`dev:cognito` 既定) | auth repo 非対応 (`sqlite/auth-repo.ts` が `AUTH_MODE=cognito` 要求で 500) |
+| `DATA_SOURCE=demo` | `createInvite` が非永続 stub (一覧に出ず受諾不可) |
+| `DATA_SOURCE=pglite` | `DEV_USERS` の tenant id が非 UUID のため uuid 型 column で 22P02 (全 admin ページ 500) |
+
 ## 巨大 docs refactor PR 分割ガイドライン (#2225)
 
 #2223 (Epic 2 / 142 file) / #2224 (Epic 3 / 146 file) で連続発生した「docs/sessions/ SSOT 削除 + 60+ ファイル参照未更新 + 機械生成ツール暴走」(両 PR BLOCK / Close) の構造的再発防止。


### PR DESCRIPTION
# docs: #3732 invite/members 系の local 検証不可を CLAUDE.md に明記 (対応案 3)

## 顧客価値・目的

**対象ユーザー**: 開発者 (Dev / QA Agent)

**解決する課題**: 招待 (invites) / メンバー (memberships) 系の UI 変更 PR で、local backend では検証・SS 撮影が不能 (PR #3729 で実害) にもかかわらず、その事実がどの CLAUDE.md にも書かれておらず、毎回 3 backend (sqlite / demo / pglite) を試して失敗する調査コストが発生していた。

**期待される効果**: docs/CLAUDE.md §ローカル Cognito 認証検証環境 に「invite / members 系は local 検証不可、cloud staging (#2873) で検証」を backend 別理由付きで明記し、無駄な再調査を根絶する。

## 関連 Issue

related #3732 (対応案 3 のみ実装。案 1 = DEV_USERS の UUID 化は影響調査を issue コメントに記録済、実装は本 PR scope 外 — ADR-0060 整合で closes を付けない)

## AC 検証マップ (ADR-0004)

<!-- Issue #3732 は提案 3 案併記型で formal AC を持たないため、対応案 3 の完遂条件を AC 化 -->

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | docs/CLAUDE.md に invite / members 系の local 検証不可 (sqlite / demo / pglite の 3 backend 別理由) + cloud staging (#2873) 検証先を明記 | `grep -n "local 検証不可" docs/CLAUDE.md` | HEAD `81c68ec8` / docs/CLAUDE.md:137 に §「local 検証不可: invite / members (auth repo) 系 (#3732)」新設、3 backend 理由表 + staging 誘導 |
| AC2 | docs SSOT 原則 (#2440) 準拠 — 経緯 narrative なし、現状の正解のみ端的に | 本文目視 + `node scripts/check-doc-code-references.mjs` | HEAD `81c68ec8` / 追加 10 行のみ、datestamp / 変更履歴記述なし。check-doc-code-references: baseline 内・新規違反なし PASS |
| AC3 | 案 1 (DEV_USERS UUID 化) の影響調査を issue コメントに記録 | Issue #3732 コメント | `dev-tenant-*` literal が tests/e2e/global-setup.ts / plan-*.spec.ts / trial-flow.spec.ts / pricing-page-signup.spec.ts / capture-specs に横断残存する調査結果をコメント済 (下記「レビュー依頼事項」参照) |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — docs/CLAUDE.md のみ (コード変更なし)

**影響を受ける画面・機能**: なし (ドキュメントのみ。runtime 挙動変更ゼロ)

## テスト & 安全装置セルフチェック

- [x] **pre-ready 相当の検証 PASS**（#1775 / ADR-0030）: worktree 環境では `biome check .` が 0 file となり pre-ready Step 1 が構造的 FAIL (biome path 制約、コード起因ではない) のため、変更ファイル (docs/CLAUDE.md のみ = biome lint 対象外の .md) に対する該当 step を個別実行で代替 — `check-doc-code-references` PASS / `check-terminology-coherence` PASS / `check-pr-body --pr 3735` PASS。CI (`ci.yml`) が同等コマンドを非 worktree 環境で再実行する
- [x] 追加・変更したテストの概要: N/A (docs のみ、runtime surface なし)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

個別検証済み: `node scripts/check-doc-code-references.mjs` (baseline 内・新規違反なし PASS) / `npx tsx scripts/check-terminology-coherence.ts` (PASS)

## スクリーンショット / ビジュアルデモ

**該当なし（docs/CLAUDE.md のみの変更で UI 変更なし）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A (docs のみ)
- [x] **DRY**: 同内容の記述が tests/CLAUDE.md / ルート CLAUDE.md に無いことを grep 確認 (docs/CLAUDE.md §ローカル Cognito 認証検証環境 が単独 SSOT。tests/CLAUDE.md に関連節なし)
- [x] **YAGNI**: 追加は 3 backend 理由表 + staging 誘導のみ
- [x] **Security（OSS 公開前提）**: 秘密情報なし (エラー文言 / 公開 issue 番号のみ)
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): docs/CLAUDE.md 自体が対象 SSOT。設計書 (docs/design/) への波及なし
- [x] **並行 PR overlap** (#1200): docs/CLAUDE.md §ローカル Cognito 認証検証環境 を触る open PR なしを確認
- その他の並行実装ペア (本番/デモ同期・年齢モード・ナビ・labels SSOT): N/A (docs のみ)

## レビュー依頼事項・破壊的変更

**破壊的変更**: なし

**レビュー観点**: 記載位置 (docs/CLAUDE.md §ローカル Cognito 認証検証環境 直下のサブセクション) の妥当性。tests/CLAUDE.md には dev:cognito local backend 検証に関する既存節が無いため追記していない (SSOT 単独配置)。

**scope 明記 (ADR-0060)**: Issue #3732 の対応案 1 (DEV_USERS tenant id の固定 UUID 化) は本 PR に含めない。影響調査結果 (issue コメント記録済):
- `dev-tenant-001` 等の literal が `tests/e2e/global-setup.ts` (trial seed SQL) / `tests/e2e/plan-{free,standard,family}.spec.ts` / `trial-flow.spec.ts` / `pricing-page-signup.spec.ts` / `account-deletion.spec.ts` / `scripts/capture-specs/flows/setup-challenges-2306.mjs` に横断残存
- 既存 sqlite dev DB (`*.db` ローカル) は旧 id で row が key 済のため、UUID 化すると既存 dev 環境のデータ参照が切れる (再 seed 必要)
- 実装する場合は E2E fixture / capture-specs / global-setup の同期変更 + 移行手順が必要 → 別 Issue / 別 PR

## 配布済み env / secret (ADR-0006)

N/A (env / secret 変更なし)

## Ready for Review チェックリスト

- [x] AC 検証マップが 4 列形式で全行埋まっている
- [x] pre-ready 相当の検証 PASS (worktree biome 0-file 制約のため個別実行代替、詳細は「テスト & 安全装置セルフチェック」欄)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: docs のみ、検証 3 script PASS + 本文目視確認済)

## QM レビュー結果

(QM 記入欄)

