### PR TITLE
fix: #3499 edit 再遷移の stale form ({#key} guard) + childIdOverride の per-child scope 境界を URL 優先に是正

### DIFF
--- a/src/lib/features/admin/components/ActivityEditForm.svelte
+++ b/src/lib/features/admin/components/ActivityEditForm.svelte
@@ -1,0 +1,197 @@
+<!--
+	#3499: 活動編集フォーム (seed-once $state を安全に保つための component 分割)。
+
+	編集欄の $state は props.activity から「component 初期化時に一度だけ」seed する。
+	SvelteKit は同一 route の param 変更 (edit/1 → edit/2) で page component を remount
+	しないため、seed-once $state を +page.svelte に直接置くと古い activity のフォーム値が
+	残る stale form になる (#3498 QM adversarial 検出)。本 component は親
+	(+page.svelte) が `{#key data.activity.id}` で必ず remount するため、seed-once が
+	activity 単位で常に正しく再実行される。
+
+	lint 方針 (#3499 AC3): `svelte-ignore state_referenced_locally` の行単位恒久化は
+	「親が {#key} で remount を保証している seed-once form」に限り許容する。guard なしの
+	+page.svelte 直置き seed-once に対する ignore 追加は不可 (将来 reactivity 要件を
+	silent 化するため)。
+-->
+<script lang="ts">
+import { enhance } from '$app/forms';
+import { joinIcon, splitIcon } from '$lib/domain/icon-utils';
+import type { CategoryId } from '$lib/domain/ids';
+import { ACTIVITY_FORM_LABELS as L, ACTIVITY_PRIORITY_FORM_LABELS as P } from '$lib/domain/labels';
+import type { ActivityItem } from '$lib/features/admin/components/activity-types';
+import {
+	DAILY_LIMIT_OPTIONS,
+	SUB_ICON_PRESETS,
+} from '$lib/features/admin/components/activity-types';
+import CompoundIcon from '$lib/ui/components/CompoundIcon.svelte';
+import Button from '$lib/ui/primitives/Button.svelte';
+import Card from '$lib/ui/primitives/Card.svelte';
+import FormField from '$lib/ui/primitives/FormField.svelte';
+import NativeSelect from '$lib/ui/primitives/NativeSelect.svelte';
+
+let {
+	activity,
+	categoryDefs,
+}: {
+	activity: ActivityItem;
+	categoryDefs: ReadonlyArray<{ id: CategoryId; name: string }>;
+} = $props();
+
+// svelte-ignore state_referenced_locally
+const parsed = splitIcon(activity.icon);
+
+// svelte-ignore state_referenced_locally
+let editName = $state(activity.name);
+// svelte-ignore state_referenced_locally
+let editCategoryId = $state(activity.categoryId);
+let editMainIcon = $state(parsed.main);
+let editSubIcon = $state(parsed.sub ?? '');
+const editIcon = $derived(joinIcon(editMainIcon, editSubIcon || null));
+// svelte-ignore state_referenced_locally
+let editPoints = $state(activity.basePoints);
+// #2362 PR-3 Phase 7b-2c: ChildActivity は ageMin/ageMax を持たないため空初期化。
+// per-child instance 移行後は年齢 filter 概念が消えるため、edit UI 上は空入力 = 制限なし扱い。
+// Phase 7b-2d 以降で UI から age 入力欄を撤去予定。
+let editAgeMin = $state('');
+let editAgeMax = $state('');
+// svelte-ignore state_referenced_locally
+let editDailyLimit = $state<string>(activity.dailyLimit != null ? String(activity.dailyLimit) : '');
+// svelte-ignore state_referenced_locally
+let editNameKana = $state(activity.nameKana ?? '');
+// svelte-ignore state_referenced_locally
+let editNameKanji = $state(activity.nameKanji ?? '');
+// svelte-ignore state_referenced_locally
+let editTriggerHint = $state(activity.triggerHint ?? '');
+// #1756 (#1709-B): must トグル
+// svelte-ignore state_referenced_locally
+let editIsMust = $state(activity.priority === 'must');
+let saving = $state(false);
+</script>
+
+<Card padding="md">
+	{#snippet children()}
+	<form
+		method="POST"
+		action="?/save"
+		use:enhance={() => {
+			saving = true;
+			return async ({ update }) => {
+				await update();
+				saving = false;
+			};
+		}}
+		class="space-y-4"
+	>
+		<!-- #1756 (#1709-B): 「今日のおやくそく」トグル — must / optional 切替 -->
+		<div
+			class="rounded-md border border-[var(--color-border-warning)] bg-[var(--color-feedback-warning-bg)] p-3 space-y-1"
+			data-testid="must-toggle-section"
+		>
+			<label class="flex items-start gap-2 cursor-pointer">
+				<input
+					type="checkbox"
+					name="priority"
+					value="must"
+					bind:checked={editIsMust}
+					class="mt-1 size-4 cursor-pointer accent-[var(--color-warning)]"
+					data-testid="must-toggle-checkbox"
+				/>
+				<div class="flex-1">
+					<span class="font-bold text-sm text-[var(--color-feedback-warning-text)]">
+						{P.toggleLabel}
+					</span>
+					<p class="text-xs text-[var(--color-text-warm-muted)] mt-1 leading-relaxed">
+						{P.toggleHint}
+					</p>
+				</div>
+			</label>
+		</div>
+
+		<!-- 名前 -->
+		<FormField label={L.editNameLabel} type="text" name="name" bind:value={editName} required />
+
+		<!-- アイコン -->
+		<div>
+			<span class="block text-xs font-bold text-[var(--color-text-muted)] mb-1">{L.editIconLabel}</span>
+			<div class="flex gap-1 items-center">
+				<input type="text" class="w-10 px-1 py-1.5 border rounded text-sm text-center"
+					value={editMainIcon}
+					oninput={(e) => { const v = (e.target as HTMLInputElement).value; if (v) editMainIcon = v; }}
+				/>
+				<span class="text-xs text-[var(--color-text-disabled)]">{L.editIconJoiner}</span>
+				<input type="text" class="w-10 px-1 py-1.5 border rounded text-sm text-center" placeholder={L.editIconSubPlaceholder}
+					value={editSubIcon}
+					oninput={(e) => { editSubIcon = (e.target as HTMLInputElement).value; }}
+				/>
+				<CompoundIcon icon={editIcon} size="md" />
+			</div>
+			<div class="flex flex-wrap gap-0.5 mt-1">
+				<button type="button" class="w-7 h-7 rounded text-xs flex items-center justify-center {editSubIcon === '' ? 'bg-[var(--color-brand-100)]' : 'bg-[var(--color-surface-muted)] hover:bg-[var(--color-neutral-100)]'}" onclick={() => editSubIcon = ''}>{L.subIconNoneOption}</button>
+				{#each SUB_ICON_PRESETS.slice(0, 8) as ic}
+					<button type="button" class="w-7 h-7 rounded text-sm flex items-center justify-center {editSubIcon === ic ? 'bg-[var(--color-brand-100)]' : 'bg-[var(--color-surface-muted)] hover:bg-[var(--color-neutral-100)]'}" onclick={() => editSubIcon = ic}>{ic}</button>
+				{/each}
+			</div>
+			<input type="hidden" name="icon" value={editIcon} />
+		</div>
+
+		<!-- カテゴリ + ポイント -->
+		<div class="grid grid-cols-2 gap-2">
+			<NativeSelect
+				name="categoryId"
+				label={L.categoryLabel}
+				bind:value={editCategoryId}
+				options={categoryDefs.map((catDef) => ({ value: catDef.id, label: catDef.name }))}
+			/>
+			<FormField label={L.editPointsLabel} type="number" name="basePoints" bind:value={editPoints} min="1" max="100" />
+		</div>
+
+		<!-- 年齢 -->
+		<div class="grid grid-cols-2 gap-2">
+			<FormField label={L.editAgeMinLabel} type="number" name="ageMin" bind:value={editAgeMin} min="0" max="18" placeholder={L.editAgePlaceholderNone} />
+			<FormField label={L.editAgeMaxLabel} type="number" name="ageMax" bind:value={editAgeMax} min="0" max="18" placeholder={L.editAgePlaceholderNone} />
+		</div>
+
+		<!-- 1日の制限 -->
+		<div>
+			<span class="block text-xs font-bold text-[var(--color-text-muted)] mb-1">{L.dailyLimitLabel}</span>
+			<div class="flex gap-1">
+				{#each DAILY_LIMIT_OPTIONS as opt}
+					<Button
+						type="button"
+						variant={editDailyLimit === opt.val ? 'primary' : 'ghost'}
+						size="sm"
+						class={editDailyLimit === opt.val
+							? 'flex-1'
+							: 'flex-1 bg-[var(--color-neutral-100)] text-[var(--color-text-muted)] hover:bg-[var(--color-neutral-200)]'}
+						onclick={() => editDailyLimit = opt.val}
+					>
+						{opt.label}
+					</Button>
+				{/each}
+			</div>
+			<input type="hidden" name="dailyLimit" value={editDailyLimit} />
+		</div>
+
+		<!-- かな・漢字 -->
+		<div class="grid grid-cols-2 gap-2">
+			<FormField label={L.editNameKanaLabel} type="text" name="nameKana" bind:value={editNameKana} maxlength={50} placeholder={L.editKanaPlaceholderOptional} />
+			<FormField label={L.editNameKanjiLabel} type="text" name="nameKanji" bind:value={editNameKanji} maxlength={50} placeholder={L.editKanaPlaceholderOptional} />
+		</div>
+
+		<!-- トリガーヒント -->
+		<FormField label={L.editTriggerHintLabel} type="text" name="triggerHint" bind:value={editTriggerHint} maxlength={30} placeholder={L.editTriggerHintPlaceholder} hint={L.editTriggerHintNote} />
+
+		<div class="flex gap-2 pt-2">
+			<Button type="submit" variant="primary" size="md" class="flex-1" disabled={saving} data-testid="activity-edit-save">
+				{P.editSaveButton}
+			</Button>
+			<a
+				href="/admin/activities"
+				class="px-4 py-2 rounded-lg font-bold text-sm bg-[var(--color-neutral-100)] text-[var(--color-text-muted)] hover:bg-[var(--color-neutral-200)] transition-colors flex items-center"
+			>
+				{P.editBackButton}
+			</a>
+		</div>
+	</form>
+	{/snippet}
+</Card>

--- a/src/lib/features/admin/components/ActivityEditForm.svelte
+++ b/src/lib/features/admin/components/ActivityEditForm.svelte
@@ -2,11 +2,12 @@
 	#3499: 活動編集フォーム (seed-once $state を安全に保つための component 分割)。
 
 	編集欄の $state は props.activity から「component 初期化時に一度だけ」seed する。
-	SvelteKit は同一 route の param 変更 (edit/1 → edit/2) で page component を remount
-	しないため、seed-once $state を +page.svelte に直接置くと古い activity のフォーム値が
-	残る stale form になる (#3498 QM adversarial 検出)。本 component は親
-	(+page.svelte) が `{#key data.activity.id}` で必ず remount するため、seed-once が
-	activity 単位で常に正しく再実行される。
+	page component が remount されず data prop だけ更新される経路 (SvelteKit の component
+	再利用 / invalidateAll / shallow routing — remount 有無は version 依存の実装詳細) では、
+	seed-once $state を +page.svelte に直接置くと古い activity のフォーム値が残る stale
+	form になる (#3498 QM adversarial 検出)。本 component は親 (+page.svelte) が
+	`{#key data.activity.id}` で必ず remount するため、seed-once が activity 単位で常に
+	正しく再実行される。
 
 	lint 方針 (#3499 AC3): `svelte-ignore state_referenced_locally` の行単位恒久化は
 	「親が {#key} で remount を保証している seed-once form」に限り許容する。guard なしの

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -69,9 +69,10 @@ let restoreLoading = $state(false);
 // per-child scope 不整合を解消 (memory `feedback_per_child_scope_consistency` 整合)。
 //
 // #3499: childIdOverride は「ユーザーの tab click による明示上書き」だけを保持する。
-// 旧実装は data.initialChildId を $state seed に一度だけ複製しており、同一 route の
-// client-side 再遷移 (?childId 変更で load 再実行) や invalidateAll 後に stale seed が
-// URL と食い違う per-child scope 境界があった。URL 由来値は $derived fallback chain で
+// 旧実装は data.initialChildId を $state seed に一度だけ複製しており、page component が
+// remount されず data prop だけ更新される経路 (SvelteKit の component 再利用 /
+// invalidateAll / shallow routing — remount 有無は version 依存の実装詳細) で stale seed
+// が URL と食い違う per-child scope 境界があった。URL 由来値は $derived fallback chain で
 // 常に data から読み、load 再実行で ?childId が変わったら override を破棄して URL を優先する。
 let childIdOverride = $state<ChildId | undefined>(undefined);
 // 直前の URL 由来値 (?childId)。$effect 内でのみ比較・更新するため非 reactive な plain let でよい。

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -67,19 +67,31 @@ let restoreLoading = $state(false);
 // Round 18 Cluster K (#1870 評価 Round 3): cookie fallback を fallback chain に追加。
 // marketplace (ひな選択) → admin/activities 遷移時に「たろうくんタブが active」になる
 // per-child scope 不整合を解消 (memory `feedback_per_child_scope_consistency` 整合)。
-// svelte-ignore state_referenced_locally
-let childIdOverride = $state<ChildId | undefined>(
-	data.initialChildId != null && data.children.some((c) => c.id === data.initialChildId)
-		? data.initialChildId
-		: undefined,
-);
+//
+// #3499: childIdOverride は「ユーザーの tab click による明示上書き」だけを保持する。
+// 旧実装は data.initialChildId を $state seed に一度だけ複製しており、同一 route の
+// client-side 再遷移 (?childId 変更で load 再実行) や invalidateAll 後に stale seed が
+// URL と食い違う per-child scope 境界があった。URL 由来値は $derived fallback chain で
+// 常に data から読み、load 再実行で ?childId が変わったら override を破棄して URL を優先する。
+let childIdOverride = $state<ChildId | undefined>(undefined);
+// 直前の URL 由来値 (?childId)。$effect 内でのみ比較・更新するため非 reactive な plain let でよい。
+// undefined = 未観測 sentinel (data.initialChildId は ChildId | null で undefined を取らない)。
+let lastInitialChildId: ChildId | null | undefined;
+$effect(() => {
+	if (lastInitialChildId !== undefined && data.initialChildId !== lastInitialChildId) {
+		childIdOverride = undefined;
+	}
+	lastInitialChildId = data.initialChildId;
+});
 const selectedChildId = $derived(
 	childIdOverride !== undefined && data.children.some((c) => c.id === childIdOverride)
 		? childIdOverride
-		: data.initialChildIdFromCookie != null &&
-				data.children.some((c) => c.id === data.initialChildIdFromCookie)
-			? data.initialChildIdFromCookie
-			: (data.children[0]?.id ?? asChildId('')),
+		: data.initialChildId != null && data.children.some((c) => c.id === data.initialChildId)
+			? data.initialChildId
+			: data.initialChildIdFromCookie != null &&
+					data.children.some((c) => c.id === data.initialChildIdFromCookie)
+				? data.initialChildIdFromCookie
+				: (data.children[0]?.id ?? asChildId('')),
 );
 const selectedChild = $derived(data.children.find((c) => c.id === selectedChildId));
 

--- a/src/routes/(parent)/admin/activities/[id]/edit/+page.svelte
+++ b/src/routes/(parent)/admin/activities/[id]/edit/+page.svelte
@@ -27,8 +27,9 @@ let { data, form } = $props();
 		</div>
 	{/if}
 
-	<!-- #3499: edit/1 → edit/2 の非アンマウント再遷移 (同一 route の param 変更は component を
-	     remount しない) で seed-once $state が古い activity を指す stale form を防ぐため、
+	<!-- #3499: page component が remount されず data prop だけ更新される経路 (SvelteKit の
+	     component 再利用 / invalidateAll / shallow routing — remount 有無は version 依存の
+	     実装詳細) で seed-once $state が古い activity を指す stale form を防ぐため、
 	     activity.id を key に ActivityEditForm を必ず remount して再 seed する。 -->
 	{#key data.activity.id}
 		<ActivityEditForm activity={data.activity} categoryDefs={data.categoryDefs} />

--- a/src/routes/(parent)/admin/activities/[id]/edit/+page.svelte
+++ b/src/routes/(parent)/admin/activities/[id]/edit/+page.svelte
@@ -1,54 +1,8 @@
 <script lang="ts">
-import { enhance } from '$app/forms';
-import { joinIcon, splitIcon } from '$lib/domain/icon-utils';
-import {
-	APP_LABELS,
-	ACTIVITY_FORM_LABELS as L,
-	ACTIVITY_PRIORITY_FORM_LABELS as P,
-	PAGE_TITLES,
-} from '$lib/domain/labels';
-import {
-	DAILY_LIMIT_OPTIONS,
-	SUB_ICON_PRESETS,
-} from '$lib/features/admin/components/activity-types';
-import CompoundIcon from '$lib/ui/components/CompoundIcon.svelte';
-import Button from '$lib/ui/primitives/Button.svelte';
-import Card from '$lib/ui/primitives/Card.svelte';
-import FormField from '$lib/ui/primitives/FormField.svelte';
-import NativeSelect from '$lib/ui/primitives/NativeSelect.svelte';
+import { APP_LABELS, ACTIVITY_PRIORITY_FORM_LABELS as P } from '$lib/domain/labels';
+import ActivityEditForm from '$lib/features/admin/components/ActivityEditForm.svelte';
 
 let { data, form } = $props();
-
-const a = $derived(data.activity);
-// svelte-ignore state_referenced_locally
-const parsed = splitIcon(data.activity.icon);
-
-// svelte-ignore state_referenced_locally
-let editName = $state(a.name);
-// svelte-ignore state_referenced_locally
-let editCategoryId = $state(a.categoryId);
-let editMainIcon = $state(parsed.main);
-let editSubIcon = $state(parsed.sub ?? '');
-const editIcon = $derived(joinIcon(editMainIcon, editSubIcon || null));
-// svelte-ignore state_referenced_locally
-let editPoints = $state(a.basePoints);
-// #2362 PR-3 Phase 7b-2c: ChildActivity は ageMin/ageMax を持たないため空初期化。
-// per-child instance 移行後は年齢 filter 概念が消えるため、edit UI 上は空入力 = 制限なし扱い。
-// Phase 7b-2d 以降で UI から age 入力欄を撤去予定。
-let editAgeMin = $state('');
-let editAgeMax = $state('');
-// svelte-ignore state_referenced_locally
-let editDailyLimit = $state<string>(a.dailyLimit != null ? String(a.dailyLimit) : '');
-// svelte-ignore state_referenced_locally
-let editNameKana = $state(a.nameKana ?? '');
-// svelte-ignore state_referenced_locally
-let editNameKanji = $state(a.nameKanji ?? '');
-// svelte-ignore state_referenced_locally
-let editTriggerHint = $state(a.triggerHint ?? '');
-// #1756 (#1709-B): must トグル
-// svelte-ignore state_referenced_locally
-let editIsMust = $state(a.priority === 'must');
-let saving = $state(false);
 </script>
 
 <svelte:head>
@@ -73,131 +27,10 @@ let saving = $state(false);
 		</div>
 	{/if}
 
-	<Card padding="md">
-		{#snippet children()}
-		<form
-			method="POST"
-			action="?/save"
-			use:enhance={() => {
-				saving = true;
-				return async ({ update }) => {
-					await update();
-					saving = false;
-				};
-			}}
-			class="space-y-4"
-		>
-			<!-- #1756 (#1709-B): 「今日のおやくそく」トグル — must / optional 切替 -->
-			<div
-				class="rounded-md border border-[var(--color-border-warning)] bg-[var(--color-feedback-warning-bg)] p-3 space-y-1"
-				data-testid="must-toggle-section"
-			>
-				<label class="flex items-start gap-2 cursor-pointer">
-					<input
-						type="checkbox"
-						name="priority"
-						value="must"
-						bind:checked={editIsMust}
-						class="mt-1 size-4 cursor-pointer accent-[var(--color-warning)]"
-						data-testid="must-toggle-checkbox"
-					/>
-					<div class="flex-1">
-						<span class="font-bold text-sm text-[var(--color-feedback-warning-text)]">
-							{P.toggleLabel}
-						</span>
-						<p class="text-xs text-[var(--color-text-warm-muted)] mt-1 leading-relaxed">
-							{P.toggleHint}
-						</p>
-					</div>
-				</label>
-			</div>
-
-			<!-- 名前 -->
-			<FormField label={L.editNameLabel} type="text" name="name" bind:value={editName} required />
-
-			<!-- アイコン -->
-			<div>
-				<span class="block text-xs font-bold text-[var(--color-text-muted)] mb-1">{L.editIconLabel}</span>
-				<div class="flex gap-1 items-center">
-					<input type="text" class="w-10 px-1 py-1.5 border rounded text-sm text-center"
-						value={editMainIcon}
-						oninput={(e) => { const v = (e.target as HTMLInputElement).value; if (v) editMainIcon = v; }}
-					/>
-					<span class="text-xs text-[var(--color-text-disabled)]">{L.editIconJoiner}</span>
-					<input type="text" class="w-10 px-1 py-1.5 border rounded text-sm text-center" placeholder={L.editIconSubPlaceholder}
-						value={editSubIcon}
-						oninput={(e) => { editSubIcon = (e.target as HTMLInputElement).value; }}
-					/>
-					<CompoundIcon icon={editIcon} size="md" />
-				</div>
-				<div class="flex flex-wrap gap-0.5 mt-1">
-					<button type="button" class="w-7 h-7 rounded text-xs flex items-center justify-center {editSubIcon === '' ? 'bg-[var(--color-brand-100)]' : 'bg-[var(--color-surface-muted)] hover:bg-[var(--color-neutral-100)]'}" onclick={() => editSubIcon = ''}>{L.subIconNoneOption}</button>
-					{#each SUB_ICON_PRESETS.slice(0, 8) as ic}
-						<button type="button" class="w-7 h-7 rounded text-sm flex items-center justify-center {editSubIcon === ic ? 'bg-[var(--color-brand-100)]' : 'bg-[var(--color-surface-muted)] hover:bg-[var(--color-neutral-100)]'}" onclick={() => editSubIcon = ic}>{ic}</button>
-					{/each}
-				</div>
-				<input type="hidden" name="icon" value={editIcon} />
-			</div>
-
-			<!-- カテゴリ + ポイント -->
-			<div class="grid grid-cols-2 gap-2">
-				<NativeSelect
-					name="categoryId"
-					label={L.categoryLabel}
-					bind:value={editCategoryId}
-					options={data.categoryDefs.map((catDef) => ({ value: catDef.id, label: catDef.name }))}
-				/>
-				<FormField label={L.editPointsLabel} type="number" name="basePoints" bind:value={editPoints} min="1" max="100" />
-			</div>
-
-			<!-- 年齢 -->
-			<div class="grid grid-cols-2 gap-2">
-				<FormField label={L.editAgeMinLabel} type="number" name="ageMin" bind:value={editAgeMin} min="0" max="18" placeholder={L.editAgePlaceholderNone} />
-				<FormField label={L.editAgeMaxLabel} type="number" name="ageMax" bind:value={editAgeMax} min="0" max="18" placeholder={L.editAgePlaceholderNone} />
-			</div>
-
-			<!-- 1日の制限 -->
-			<div>
-				<span class="block text-xs font-bold text-[var(--color-text-muted)] mb-1">{L.dailyLimitLabel}</span>
-				<div class="flex gap-1">
-					{#each DAILY_LIMIT_OPTIONS as opt}
-						<Button
-							type="button"
-							variant={editDailyLimit === opt.val ? 'primary' : 'ghost'}
-							size="sm"
-							class={editDailyLimit === opt.val
-								? 'flex-1'
-								: 'flex-1 bg-[var(--color-neutral-100)] text-[var(--color-text-muted)] hover:bg-[var(--color-neutral-200)]'}
-							onclick={() => editDailyLimit = opt.val}
-						>
-							{opt.label}
-						</Button>
-					{/each}
-				</div>
-				<input type="hidden" name="dailyLimit" value={editDailyLimit} />
-			</div>
-
-			<!-- かな・漢字 -->
-			<div class="grid grid-cols-2 gap-2">
-				<FormField label={L.editNameKanaLabel} type="text" name="nameKana" bind:value={editNameKana} maxlength={50} placeholder={L.editKanaPlaceholderOptional} />
-				<FormField label={L.editNameKanjiLabel} type="text" name="nameKanji" bind:value={editNameKanji} maxlength={50} placeholder={L.editKanaPlaceholderOptional} />
-			</div>
-
-			<!-- トリガーヒント -->
-			<FormField label={L.editTriggerHintLabel} type="text" name="triggerHint" bind:value={editTriggerHint} maxlength={30} placeholder={L.editTriggerHintPlaceholder} hint={L.editTriggerHintNote} />
-
-			<div class="flex gap-2 pt-2">
-				<Button type="submit" variant="primary" size="md" class="flex-1" disabled={saving} data-testid="activity-edit-save">
-					{P.editSaveButton}
-				</Button>
-				<a
-					href="/admin/activities"
-					class="px-4 py-2 rounded-lg font-bold text-sm bg-[var(--color-neutral-100)] text-[var(--color-text-muted)] hover:bg-[var(--color-neutral-200)] transition-colors flex items-center"
-				>
-					{P.editBackButton}
-				</a>
-			</div>
-		</form>
-		{/snippet}
-	</Card>
+	<!-- #3499: edit/1 → edit/2 の非アンマウント再遷移 (同一 route の param 変更は component を
+	     remount しない) で seed-once $state が古い activity を指す stale form を防ぐため、
+	     activity.id を key に ActivityEditForm を必ず remount して再 seed する。 -->
+	{#key data.activity.id}
+		<ActivityEditForm activity={data.activity} categoryDefs={data.categoryDefs} />
+	{/key}
 </div>

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -50,16 +50,28 @@ const errorMessage = $derived(getErrorMessage(form?.error));
 
 // #2362 PR-4: 子供タブ切替 UI
 //   `?childId=<n>` query で初期 child 復元、未指定なら最初の child
-// svelte-ignore state_referenced_locally
-let childIdOverride = $state<ChildId | undefined>(
-	data.initialChildId != null && data.children.some((c) => c.id === data.initialChildId)
-		? data.initialChildId
-		: undefined,
-);
+//
+// #3499: childIdOverride は「ユーザーの tab click による明示上書き」だけを保持する
+// (admin/activities と同型)。URL 由来値 (?childId) は $derived fallback chain で常に
+// data から読み、load 再実行で ?childId が変わったら override を破棄して URL を優先する。
+// 旧 seed-once $state は client-side 再遷移 / invalidateAll 後に stale seed が URL と
+// 食い違う per-child scope 境界があった。
+let childIdOverride = $state<ChildId | undefined>(undefined);
+// 直前の URL 由来値 (?childId)。$effect 内でのみ比較・更新するため非 reactive な plain let でよい。
+// undefined = 未観測 sentinel (data.initialChildId は ChildId | null で undefined を取らない)。
+let lastInitialChildId: ChildId | null | undefined;
+$effect(() => {
+	if (lastInitialChildId !== undefined && data.initialChildId !== lastInitialChildId) {
+		childIdOverride = undefined;
+	}
+	lastInitialChildId = data.initialChildId;
+});
 const selectedChildId = $derived(
 	childIdOverride !== undefined && data.children.some((c) => c.id === childIdOverride)
 		? childIdOverride
-		: (data.children[0]?.id ?? asChildId('')),
+		: data.initialChildId != null && data.children.some((c) => c.id === data.initialChildId)
+			? data.initialChildId
+			: (data.children[0]?.id ?? asChildId('')),
 );
 const selectedChild = $derived(data.children.find((c) => c.id === selectedChildId));
 

--- a/src/routes/(parent)/admin/rewards/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/+page.svelte
@@ -54,8 +54,9 @@ const errorMessage = $derived(getErrorMessage(form?.error));
 // #3499: childIdOverride は「ユーザーの tab click による明示上書き」だけを保持する
 // (admin/activities と同型)。URL 由来値 (?childId) は $derived fallback chain で常に
 // data から読み、load 再実行で ?childId が変わったら override を破棄して URL を優先する。
-// 旧 seed-once $state は client-side 再遷移 / invalidateAll 後に stale seed が URL と
-// 食い違う per-child scope 境界があった。
+// 旧 seed-once $state は page component が remount されず data prop だけ更新される経路
+// (SvelteKit の component 再利用 / invalidateAll / shallow routing — remount 有無は
+// version 依存の実装詳細) で stale seed が URL と食い違う per-child scope 境界があった。
 let childIdOverride = $state<ChildId | undefined>(undefined);
 // 直前の URL 由来値 (?childId)。$effect 内でのみ比較・更新するため非 reactive な plain let でよい。
 // undefined = 未観測 sentinel (data.initialChildId は ChildId | null で undefined を取らない)。

--- a/tests/e2e/admin-child-scope-and-edit-reseed.spec.ts
+++ b/tests/e2e/admin-child-scope-and-edit-reseed.spec.ts
@@ -16,10 +16,25 @@
  * intercept させる anchor を app container 内に注入して client-side 遷移を再現する。
  * `window.__spaMarker` が遷移後も残ることを assert し、「full reload で偶然 PASS する」
  * false-green を排除する (full reload なら marker が消えて必ず fail)。
+ *
+ * 判別力 note (#3499 実測): 現行 SvelteKit バージョンは同一 route の client-side 遷移でも
+ * page component を remount する (DOM identity probe で実測確認) ため、本 spec の遷移系
+ * test は旧実装 (seed-once) でも PASS する「挙動契約の regression guard」である。
+ * 非 remount で data prop だけが更新される経路 (invalidateAll / 将来の SvelteKit component
+ * 再利用最適化 / shallow routing) の判別 (red→green) は unit test
+ * `tests/unit/routes/activity-edit-reseed.test.ts` (rerender = 同一 instance への data 更新)
+ * が担う。SvelteKit の remount 戦略は version 依存の実装詳細であり、本 spec は router
+ * 挙動が変わっても「再遷移後に正しい値が表示される」ことを固定し続ける。
+ *
+ * hydration 耐性: Vite dev 環境では hydration 完了前の click が空振りする既知 race がある
+ * (`admin-activities-add-ux.spec.ts` openMenu / `admin-activities-delete.spec.ts`
+ * openDeleteDialog と同根)。本 spec は repo 前例に倣い「click → 観測可能な状態変化」を
+ * bounded retry で待つ (ADR-0006 適合: assertion は弱めず interaction のみ retry)。
  */
 
-import { expect, type Page, test } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
 import { asCategoryId } from '../../src/lib/domain/ids';
+import { SUB_ICON_PRESETS } from '../../src/lib/features/admin/components/activity-types';
 
 /** dedicated activity を API 経由で作成 (seed 非破壊、admin-activities-delete.spec と同型) */
 async function createDedicatedActivity(
@@ -70,6 +85,52 @@ async function expectSpaMarkerAlive(page: Page): Promise<void> {
 	expect(marker, 'client-side 遷移であること (full reload なら marker が消える)').toBe(1);
 }
 
+/**
+ * 子供タブを click し aria-selected が反映されるまで bounded retry。
+ * hydration 完了前の click 空振り (dev 環境の既知 race) を吸収する。
+ * retry を使い切ったら最終 assert で hard fail (skip / weakening しない、ADR-0006)。
+ */
+async function clickTabUntilSelected(tab: Locator): Promise<void> {
+	for (let attempt = 0; attempt < 10; attempt++) {
+		await tab.click();
+		try {
+			await expect(tab).toHaveAttribute('aria-selected', 'true', { timeout: 2_000 });
+			return;
+		} catch {
+			// hydration 未完 / Vite dev cold compile 中の click 空振りを再 click で吸収
+		}
+	}
+	await expect(tab, 'tab click not reflected after 10 attempts').toHaveAttribute(
+		'aria-selected',
+		'true',
+		{ timeout: 5_000 },
+	);
+}
+
+/**
+ * edit フォームの hydration 完了を確認する probe。サブアイコン preset button を click し、
+ * Svelte re-render (選択状態 class 付与) が観測できるまで bounded retry → none button で
+ * 元の seed 状態 (editSubIcon='') に戻す。injected anchor の client-side 遷移は router
+ * (hydration 後に attach) が前提のため、遷移前に本 probe で hydration を確定させる。
+ */
+async function ensureEditFormHydrated(page: Page): Promise<void> {
+	const presetBtn = page.getByRole('button', { name: SUB_ICON_PRESETS[0], exact: true });
+	for (let attempt = 0; attempt < 10; attempt++) {
+		await presetBtn.click();
+		try {
+			await expect(presetBtn).toHaveClass(/brand-100/, { timeout: 2_000 });
+			// editSubIcon を seed 値 ('') に戻す (none button click → 選択解除を確認)
+			const noneBtn = presetBtn.locator('xpath=preceding-sibling::button[1]');
+			await noneBtn.click();
+			await expect(presetBtn).not.toHaveClass(/brand-100/);
+			return;
+		} catch {
+			// hydration 未完 / Vite dev cold compile 中の click 空振りを再 click で吸収
+		}
+	}
+	throw new Error('edit form hydration not detected after 10 attempts');
+}
+
 test.describe('#3499 AC1: edit 再遷移の stale form guard', () => {
 	test('edit/A → edit/B の client-side 再遷移でフォームが B の値に再 seed される', async ({
 		page,
@@ -87,14 +148,18 @@ test.describe('#3499 AC1: edit 再遷移の stale form guard', () => {
 			const nameInput = page.locator('input[name="name"]');
 			await expect(nameInput).toHaveValue(nameA, { timeout: 30_000 });
 
+			// hydration 完了を確定させる (router attach 前に anchor click すると full reload になり
+			// marker assert で fail する。dev 環境の hydration race を probe で吸収)
+			await ensureEditFormHydrated(page);
+
 			// client-side で edit/B へ再遷移 (同一 route param 変更 = component 非 remount 経路)
 			await setSpaMarker(page);
 			await clientSideNavigate(page, `/admin/activities/${idB}/edit`);
 			await page.waitForURL(`**/admin/activities/${idB}/edit`, { timeout: 15_000 });
 			await expectSpaMarkerAlive(page);
 
-			// {#key data.activity.id} guard により B の値へ再 seed される
-			// (guard 無しの旧実装では A の値が残り fail する = #3498 stale form)
+			// {#key data.activity.id} guard により B の値へ再 seed される (挙動契約の固定。
+			// 非 remount 経路の判別は unit test 側 — 冒頭「判別力 note」参照)
 			await expect(nameInput).toHaveValue(nameB, { timeout: 10_000 });
 		} finally {
 			// cleanup: worker DB 共有 spec のため dedicated fixture を除去 (tests/CLAUDE.md #3163)
@@ -125,12 +190,8 @@ test.describe('#3499 AC2: childIdOverride の per-child scope 境界', () => {
 		const idFirst = await idOf(0);
 		const idSecond = await idOf(1);
 
-		// tab click で override = 2 人目
-		await tabs.nth(1).click();
-		await expect(page.getByTestId(`child-tab-${idSecond}`)).toHaveAttribute(
-			'aria-selected',
-			'true',
-		);
+		// tab click で override = 2 人目 (hydration race を bounded retry で吸収)
+		await clickTabUntilSelected(page.getByTestId(`child-tab-${idSecond}`));
 
 		// client-side で ?childId=<1 人目> へ遷移 (load 再実行) → URL が override に勝つ
 		await setSpaMarker(page);
@@ -141,7 +202,8 @@ test.describe('#3499 AC2: childIdOverride の per-child scope 境界', () => {
 		);
 		await expectSpaMarkerAlive(page);
 
-		// 旧実装 (seed-once override) では 2 人目タブが active のまま残り fail する
+		// URL (?childId) が tab click 上書きより優先される契約を固定する
+		// (非 remount 経路での seed-once stale 判別は冒頭「判別力 note」参照)
 		await expect(page.getByTestId(`child-tab-${idFirst}`)).toHaveAttribute(
 			'aria-selected',
 			'true',
@@ -171,11 +233,8 @@ test.describe('#3499 AC2: childIdOverride の per-child scope 境界', () => {
 		const idFirst = await idOf(0);
 		const idSecond = await idOf(1);
 
-		await tabs.nth(1).click();
-		await expect(page.getByTestId(`rewards-child-tab-${idSecond}`)).toHaveAttribute(
-			'aria-selected',
-			'true',
-		);
+		// tab click で override = 2 人目 (hydration race を bounded retry で吸収)
+		await clickTabUntilSelected(page.getByTestId(`rewards-child-tab-${idSecond}`));
 
 		await setSpaMarker(page);
 		await clientSideNavigate(page, `/admin/rewards?childId=${idFirst}`);

--- a/tests/e2e/admin-child-scope-and-edit-reseed.spec.ts
+++ b/tests/e2e/admin-child-scope-and-edit-reseed.spec.ts
@@ -1,0 +1,253 @@
+/**
+ * #3499 — edit 再遷移の stale form ({#key} guard) + childIdOverride の per-child scope 境界
+ *
+ * PR #3498 QM adversarial が検出した 2 つの seed-once $state 境界の回帰 spec:
+ *
+ *   AC1: /admin/activities/[id]/edit は同一 route の param 変更 (edit/A → edit/B) で
+ *        component を remount しないため、seed-once の編集欄が古い activity を指す
+ *        stale form になる。`{#key data.activity.id}` guard (ActivityEditForm 分割) で
+ *        再遷移時に必ず再 seed されることを verify する。
+ *   AC2: admin/activities・admin/rewards の childIdOverride (tab click 上書き) は
+ *        client-side の `?childId` 変更 (load 再実行) で URL を優先して破棄され、
+ *        marketplace 取込 → admin 復帰 (invalidateAll) 後も選択中 child scope が
+ *        維持されることを verify する。
+ *
+ * 実装 note: UI 上に edit→edit / ?childId 変更の直接 link は無いため、SvelteKit router に
+ * intercept させる anchor を app container 内に注入して client-side 遷移を再現する。
+ * `window.__spaMarker` が遷移後も残ることを assert し、「full reload で偶然 PASS する」
+ * false-green を排除する (full reload なら marker が消えて必ず fail)。
+ */
+
+import { expect, type Page, test } from '@playwright/test';
+import { asCategoryId } from '../../src/lib/domain/ids';
+
+/** dedicated activity を API 経由で作成 (seed 非破壊、admin-activities-delete.spec と同型) */
+async function createDedicatedActivity(
+	request: import('@playwright/test').APIRequestContext,
+	name: string,
+): Promise<number> {
+	const res = await request.post('/api/v1/activities', {
+		data: {
+			name,
+			icon: '🧪',
+			basePoints: 1,
+			categoryId: asCategoryId(1),
+			ageMin: null,
+			ageMax: null,
+		},
+	});
+	expect(res.status()).toBe(201);
+	const body = await res.json();
+	expect(body.id).toBeDefined();
+	return body.id as number;
+}
+
+/** SvelteKit router に intercept させる client-side 遷移 (app container 内 anchor 注入 + click) */
+async function clientSideNavigate(page: Page, href: string): Promise<void> {
+	await page.evaluate((h) => {
+		// SvelteKit の click listener 圏内 (app container 内) に anchor を注入する
+		const container = document.body.querySelector('div') ?? document.body;
+		const a = document.createElement('a');
+		a.href = h;
+		a.textContent = 'e2e-nav';
+		a.setAttribute('data-testid', 'e2e-injected-nav');
+		container.appendChild(a);
+		a.click();
+		a.remove();
+	}, href);
+}
+
+async function setSpaMarker(page: Page): Promise<void> {
+	await page.evaluate(() => {
+		(window as unknown as { __spaMarker?: number }).__spaMarker = 1;
+	});
+}
+
+async function expectSpaMarkerAlive(page: Page): Promise<void> {
+	const marker = await page.evaluate(
+		() => (window as unknown as { __spaMarker?: number }).__spaMarker,
+	);
+	expect(marker, 'client-side 遷移であること (full reload なら marker が消える)').toBe(1);
+}
+
+test.describe('#3499 AC1: edit 再遷移の stale form guard', () => {
+	test('edit/A → edit/B の client-side 再遷移でフォームが B の値に再 seed される', async ({
+		page,
+		request,
+	}) => {
+		test.slow(); // Vite dev コールドコンパイル耐性
+		const nameA = `#3499-reseed-A-${Date.now()}`;
+		const nameB = `#3499-reseed-B-${Date.now()}`;
+		const idA = await createDedicatedActivity(request, nameA);
+		const idB = await createDedicatedActivity(request, nameB);
+
+		try {
+			// full load で A の編集画面 → seed 値 = A
+			await page.goto(`/admin/activities/${idA}/edit`, { waitUntil: 'domcontentloaded' });
+			const nameInput = page.locator('input[name="name"]');
+			await expect(nameInput).toHaveValue(nameA, { timeout: 30_000 });
+
+			// client-side で edit/B へ再遷移 (同一 route param 変更 = component 非 remount 経路)
+			await setSpaMarker(page);
+			await clientSideNavigate(page, `/admin/activities/${idB}/edit`);
+			await page.waitForURL(`**/admin/activities/${idB}/edit`, { timeout: 15_000 });
+			await expectSpaMarkerAlive(page);
+
+			// {#key data.activity.id} guard により B の値へ再 seed される
+			// (guard 無しの旧実装では A の値が残り fail する = #3498 stale form)
+			await expect(nameInput).toHaveValue(nameB, { timeout: 10_000 });
+		} finally {
+			// cleanup: worker DB 共有 spec のため dedicated fixture を除去 (tests/CLAUDE.md #3163)
+			await request.delete(`/api/v1/activities/${idA}`);
+			await request.delete(`/api/v1/activities/${idB}`);
+		}
+	});
+});
+
+test.describe('#3499 AC2: childIdOverride の per-child scope 境界', () => {
+	test('admin/activities: tab click 上書き後の client-side ?childId 遷移は URL を優先する', async ({
+		page,
+	}) => {
+		test.slow();
+		await page.goto('/admin/activities', { waitUntil: 'domcontentloaded' });
+		const tabs = page.locator('[data-testid^="child-tab-"]');
+		await expect(tabs.first()).toBeVisible({ timeout: 30_000 });
+		const tabCount = await tabs.count();
+		expect(
+			tabCount,
+			'2 child 以上の seed が必要 (global-setup.ts TEST_CHILDREN)',
+		).toBeGreaterThanOrEqual(2);
+
+		const idOf = async (i: number): Promise<string> => {
+			const testid = await tabs.nth(i).getAttribute('data-testid');
+			return (testid ?? '').replace('child-tab-', '');
+		};
+		const idFirst = await idOf(0);
+		const idSecond = await idOf(1);
+
+		// tab click で override = 2 人目
+		await tabs.nth(1).click();
+		await expect(page.getByTestId(`child-tab-${idSecond}`)).toHaveAttribute(
+			'aria-selected',
+			'true',
+		);
+
+		// client-side で ?childId=<1 人目> へ遷移 (load 再実行) → URL が override に勝つ
+		await setSpaMarker(page);
+		await clientSideNavigate(page, `/admin/activities?childId=${idFirst}`);
+		await page.waitForURL(
+			(u) => u.pathname.endsWith('/admin/activities') && u.searchParams.get('childId') === idFirst,
+			{ timeout: 15_000 },
+		);
+		await expectSpaMarkerAlive(page);
+
+		// 旧実装 (seed-once override) では 2 人目タブが active のまま残り fail する
+		await expect(page.getByTestId(`child-tab-${idFirst}`)).toHaveAttribute(
+			'aria-selected',
+			'true',
+			{
+				timeout: 10_000,
+			},
+		);
+		await expect(page.getByTestId(`child-tab-${idSecond}`)).toHaveAttribute(
+			'aria-selected',
+			'false',
+		);
+	});
+
+	test('admin/rewards: tab click 上書き後の client-side ?childId 遷移は URL を優先する', async ({
+		page,
+	}) => {
+		test.slow();
+		await page.goto('/admin/rewards', { waitUntil: 'domcontentloaded' });
+		const tabs = page.locator('[data-testid^="rewards-child-tab-"]');
+		await expect(tabs.first()).toBeVisible({ timeout: 30_000 });
+		expect(await tabs.count()).toBeGreaterThanOrEqual(2);
+
+		const idOf = async (i: number): Promise<string> => {
+			const testid = await tabs.nth(i).getAttribute('data-testid');
+			return (testid ?? '').replace('rewards-child-tab-', '');
+		};
+		const idFirst = await idOf(0);
+		const idSecond = await idOf(1);
+
+		await tabs.nth(1).click();
+		await expect(page.getByTestId(`rewards-child-tab-${idSecond}`)).toHaveAttribute(
+			'aria-selected',
+			'true',
+		);
+
+		await setSpaMarker(page);
+		await clientSideNavigate(page, `/admin/rewards?childId=${idFirst}`);
+		await page.waitForURL(
+			(u) => u.pathname.endsWith('/admin/rewards') && u.searchParams.get('childId') === idFirst,
+			{ timeout: 15_000 },
+		);
+		await expectSpaMarkerAlive(page);
+
+		await expect(page.getByTestId(`rewards-child-tab-${idFirst}`)).toHaveAttribute(
+			'aria-selected',
+			'true',
+			{ timeout: 10_000 },
+		);
+	});
+
+	test('marketplace 取込 → admin 復帰 CUJ: 取込確定 (invalidateAll) 後も選択中 child scope が維持される', async ({
+		page,
+	}) => {
+		test.slow();
+		// marketplace 復帰時の URL 文脈 (?childId=<X>&import=<presetId>) を再現。
+		// X には既定 fallback (1 人目) では検出できない 2 人目 child を使う。
+		await page.goto('/admin/activities', { waitUntil: 'domcontentloaded' });
+		const tabs = page.locator('[data-testid^="child-tab-"]');
+		await expect(tabs.first()).toBeVisible({ timeout: 30_000 });
+		expect(await tabs.count()).toBeGreaterThanOrEqual(2);
+		const targetId = ((await tabs.nth(1).getAttribute('data-testid')) ?? '').replace(
+			'child-tab-',
+			'',
+		);
+
+		await page.goto(`/admin/activities?childId=${targetId}&import=kinder-starter`, {
+			waitUntil: 'domcontentloaded',
+		});
+
+		// URL 由来 scope: 取込前から対象 child タブが active
+		await expect(page.getByTestId(`child-tab-${targetId}`)).toHaveAttribute(
+			'aria-selected',
+			'true',
+			{ timeout: 30_000 },
+		);
+
+		// ChildSelectionDialog auto-open → 対象 child を選択 → 確定 (act → outcome assert)
+		const dialog = page.getByTestId('import-child-selection-dialog');
+		await expect(dialog).toBeVisible({ timeout: 10_000 });
+		const childOption = page.getByTestId(`child-selection-${targetId}`);
+		await expect(childOption).toBeVisible();
+		await childOption.check();
+
+		const confirm = page.getByTestId('child-selection-confirm');
+		await expect(confirm).toBeEnabled();
+		const [resp] = await Promise.all([
+			page.waitForResponse((r) => /\?\/importPackToChildren/.test(r.url())),
+			confirm.click(),
+		]);
+		expect(
+			resp.ok(),
+			`importPackToChildren response not OK (status ${resp.status()})`,
+		).toBeTruthy();
+
+		// invalidateAll 後も per-child scope (対象 child タブ + context banner) が維持される
+		await expect(page.getByTestId(`child-tab-${targetId}`)).toHaveAttribute(
+			'aria-selected',
+			'true',
+			{ timeout: 10_000 },
+		);
+		const targetNickname = (await page.getByTestId(`child-tab-${targetId}`).textContent())?.replace(
+			/\(\d+\)/,
+			'',
+		);
+		await expect(page.getByTestId('child-context-banner')).toContainText(
+			(targetNickname ?? '').trim(),
+		);
+	});
+});

--- a/tests/unit/routes/activity-edit-reseed.test.ts
+++ b/tests/unit/routes/activity-edit-reseed.test.ts
@@ -1,13 +1,13 @@
 // tests/unit/routes/activity-edit-reseed.test.ts
-// #3499 AC1: /admin/activities/[id]/edit の編集フォームは data.activity の切替
-// (= 同一 route の param 変更による非アンマウント再遷移) で必ず再 seed される。
+// #3499 AC1: /admin/activities/[id]/edit の編集フォームは data.activity の切替で必ず再 seed される。
 //
-// SvelteKit は edit/1 → edit/2 の client-side 遷移で page component を remount せず
-// props (`data`) だけを更新する。seed-once $state を +page.svelte に直接置くと古い
+// seed-once $state を +page.svelte に直接置くと、page component が remount されずに
+// `data` prop だけが更新される経路 (SvelteKit の component 再利用 / invalidateAll /
+// shallow routing。remount するか否かは SvelteKit version 依存の実装詳細) で古い
 // activity のフォーム値が残る stale form になる (#3498 QM adversarial 検出)。
 // 本 test は @testing-library/svelte の `rerender` で「同一 component instance への
-// data 更新」を忠実に再現し、`{#key data.activity.id}` guard (ActivityEditForm 分割)
-// が無いと RED になる (failing-test-first、ADR-0061)。
+// data 更新」を再現し、`{#key data.activity.id}` guard (ActivityEditForm 分割)
+// が無いと RED になる (failing-test-first、ADR-0061。旧実装での RED 実測済)。
 
 import { cleanup, render } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/tests/unit/routes/activity-edit-reseed.test.ts
+++ b/tests/unit/routes/activity-edit-reseed.test.ts
@@ -1,0 +1,121 @@
+// tests/unit/routes/activity-edit-reseed.test.ts
+// #3499 AC1: /admin/activities/[id]/edit の編集フォームは data.activity の切替
+// (= 同一 route の param 変更による非アンマウント再遷移) で必ず再 seed される。
+//
+// SvelteKit は edit/1 → edit/2 の client-side 遷移で page component を remount せず
+// props (`data`) だけを更新する。seed-once $state を +page.svelte に直接置くと古い
+// activity のフォーム値が残る stale form になる (#3498 QM adversarial 検出)。
+// 本 test は @testing-library/svelte の `rerender` で「同一 component instance への
+// data 更新」を忠実に再現し、`{#key data.activity.id}` guard (ActivityEditForm 分割)
+// が無いと RED になる (failing-test-first、ADR-0061)。
+
+import { cleanup, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$app/forms', () => ({
+	enhance: () => ({ destroy: () => {} }),
+}));
+
+import type { Component } from 'svelte';
+import { asActivityId, asCategoryId, asChildId } from '../../../src/lib/domain/ids';
+import { CATEGORY_DEFS } from '../../../src/lib/domain/validation/activity';
+import EditPageRaw from '../../../src/routes/(parent)/admin/activities/[id]/edit/+page.svelte';
+
+function makeActivity(overrides: {
+	id: string;
+	name: string;
+	nameKana?: string | null;
+	dailyLimit?: number | null;
+	priority?: 'must' | 'optional';
+}) {
+	return {
+		id: asActivityId(overrides.id),
+		childId: asChildId('901'),
+		name: overrides.name,
+		categoryId: asCategoryId(1),
+		icon: '🏃',
+		basePoints: 5,
+		isVisible: 1,
+		dailyLimit: overrides.dailyLimit ?? null,
+		sortOrder: 0,
+		source: 'manual',
+		nameKana: overrides.nameKana ?? null,
+		nameKanji: null,
+		triggerHint: null,
+		isMainQuest: 0,
+		isArchived: 0,
+		archivedReason: null,
+		createdAt: '2026-01-01T00:00:00Z',
+		priority: overrides.priority ?? ('optional' as const),
+	};
+}
+
+function makeData(activity: ReturnType<typeof makeActivity>) {
+	return { activity, categoryDefs: CATEGORY_DEFS };
+}
+
+// PageData には layout 由来 field (role / planTier / requestId 等) が merge されるが、
+// 本 page component は data.activity / data.categoryDefs しか参照しないため、
+// test では page 固有 load 分のみを渡す (型は component 側で最小化して受ける)。
+const EditPage = EditPageRaw as unknown as Component<{
+	data: ReturnType<typeof makeData>;
+	form: null;
+}>;
+
+describe('/admin/activities/[id]/edit — 再遷移時のフォーム再 seed (#3499 AC1)', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('初期表示で data.activity の値が seed される', () => {
+		const { container } = render(EditPage, {
+			data: makeData(makeActivity({ id: '1', name: 'あさランニング' })),
+			form: null,
+		});
+		const nameInput = container.querySelector<HTMLInputElement>('input[name="name"]');
+		expect(nameInput?.value).toBe('あさランニング');
+	});
+
+	it('data.activity が別 activity に変わったらフォーム値が再 seed される (stale form 防止)', async () => {
+		const activityA = makeActivity({
+			id: '1',
+			name: 'あさランニング',
+			nameKana: 'あさらんにんぐ',
+			dailyLimit: 3,
+			priority: 'must',
+		});
+		const activityB = makeActivity({
+			id: '2',
+			name: 'ほんをよむ',
+			nameKana: null,
+			dailyLimit: null,
+			priority: 'optional',
+		});
+		const { container, rerender } = render(EditPage, {
+			data: makeData(activityA),
+			form: null,
+		});
+
+		// precondition: A の値が seed 済
+		expect(container.querySelector<HTMLInputElement>('input[name="name"]')?.value).toBe(
+			'あさランニング',
+		);
+		expect(
+			container.querySelector<HTMLInputElement>('[data-testid="must-toggle-checkbox"]')?.checked,
+		).toBe(true);
+
+		// SvelteKit の同一 route param 遷移 (edit/1 → edit/2) = 同一 instance への data 更新
+		await rerender({ data: makeData(activityB), form: null });
+
+		// {#key data.activity.id} guard により ActivityEditForm が remount → B の値へ再 seed。
+		// guard 無し (旧実装) では A の値が残り RED になる。
+		expect(container.querySelector<HTMLInputElement>('input[name="name"]')?.value).toBe(
+			'ほんをよむ',
+		);
+		expect(container.querySelector<HTMLInputElement>('input[name="nameKana"]')?.value).toBe('');
+		expect(
+			container.querySelector<HTMLInputElement>('[data-testid="must-toggle-checkbox"]')?.checked,
+		).toBe(false);
+		expect(container.querySelector<HTMLInputElement>('input[name="dailyLimit"]')?.value).toBe('');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: 活動編集画面のフォーム値と子供タブ選択 (childIdOverride) が seed-once $state で保持されており、page component が remount されず `data` prop だけが更新される経路 (invalidateAll / SvelteKit の component 再利用 / shallow routing) で「古い活動のフォーム値が残る stale form」「URL と表示中の子供が食い違う per-child scope 取り違え」の境界があった (#3498 QM adversarial 検出。remount 有無は SvelteKit version 依存の実装詳細で、依存してよい保証がない)。

**期待される効果**: 編集フォームは常に URL の活動を表示し、子供タブは URL (`?childId`) とユーザーの tab click の意図が正しく優先順位付けされる。誤った子供のデータを編集 / 閲覧してしまう事故の芽を構造的に排除する。

## 関連 Issue

closes #3499

関連: #3498 (svelte-check green 化で svelte-ignore した seed-once $state の既存懸念) / #1432

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | edit ページに `{#key data.activity.id}` guard を追加し再遷移時にフォームが正しく再 seed される (E2E 1 本) | `npx vitest run tests/unit/routes/activity-edit-reseed.test.ts` (failing-test-first、red→green) + `npx playwright test admin-child-scope-and-edit-reseed --project=tablet` | HEAD `49082510` / unit: 旧実装で RED 実測 (`expected 'あさランニング' to be 'ほんをよむ'`) → guard 実装で 2 passed / E2E 「edit/A → edit/B の client-side 再遷移でフォームが B の値に再 seed される」 passed (SPA marker で full-reload false-green 排除) / src/routes/(parent)/admin/activities/[id]/edit/+page.svelte:34 `{#key data.activity.id}` |
| AC2 | childIdOverride が invalidateAll 後も正しい per-child scope を指すことを E2E で担保 (marketplace 取込→admin 復帰 CUJ) | `npx playwright test admin-child-scope-and-edit-reseed --project=tablet` (activities / rewards の URL 優先境界 2 test + `?import=kinder-starter` 取込確定 → invalidateAll 後の scope 維持 CUJ 1 test) | HEAD `49082510` / E2E 4 passed。**判別力の正直な申告**: DOM identity probe 実測で現行 SvelteKit は同一 route の client-side 遷移でも page component を remount するため、遷移系 E2E は旧実装でも PASS する「挙動契約の regression guard」(spec 冒頭「判別力 note」に明記)。非 remount で data prop だけ更新される経路 (invalidateAll / 将来の component 再利用 / shallow routing) の判別 red→green は AC1 unit test が担う / src/routes/(parent)/admin/activities/+page.svelte:77-96 / src/routes/(parent)/admin/rewards/+page.svelte:60-79 |
| AC3 (任意) | 行単位 svelte-ignore の恒久化が将来 reactivity 要件を silent 化しないか、lint レベルでの方針整理 | `grep -rn "svelte-ignore state_referenced_locally" "src/routes/(parent)/admin/activities/" "src/routes/(parent)/admin/rewards/"` → 0 件 | HEAD `49082510` / 対象 3 file の ignore を全廃 (activities / rewards は seed-once 撤去で根本解消、edit page は component 分割)。ignore は `{#key}` remount guard 付き `ActivityEditForm.svelte` にのみ残し、冒頭コメントに「remount guard 必須 / guard なし +page.svelte 直置き seed-once への ignore 追加は不可」の方針を明文化 (src/lib/features/admin/components/ActivityEditForm.svelte:11-15)。`npx svelte-check` 0 ERRORS 0 WARNINGS |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- `/admin/activities/[id]/edit` (活動編集フォーム — `ActivityEditForm.svelte` に分割 + `{#key}` guard、見た目 / form action は不変)
- `/admin/activities` / `/admin/rewards` (子供タブの選択優先順位: tab click 上書き → URL `?childId` → cookie (activities のみ) → 先頭 child。同一 URL での表示は従来と同一)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— worktree では Step 1 の `biome check .` が構造的に 0 file (worktree 既知制約) のため、Step 1 は変更 6 file への `npx biome check <files>` (PASS) で等価実施、残 step (svelte-check 0/0 / vitest / check-hardcoded-strings / check-no-plan-literals / check-license-key-leak / check-pr-body / check-doc-code-references / check-terminology-coherence) は個別実行で PASS を確認
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/routes/activity-edit-reseed.test.ts` (新規): edit page へ `rerender` で data.activity を差し替え、フォームが再 seed されることを component 層で検証 (failing-test-first、旧実装で RED 確認済)
  - `tests/e2e/admin-child-scope-and-edit-reseed.spec.ts` (新規): ① edit/A → edit/B client-side 再遷移の再 seed ② activities / rewards の tab click 上書き後 `?childId` client-side 遷移で URL 優先 ③ marketplace 取込 → admin 復帰 CUJ (`?childId=<X>&import=kinder-starter` → ChildSelectionDialog 確定 → invalidateAll 後も child scope 維持)。SPA marker (`window.__spaMarker`) で「full reload による false-green」を排除
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (priority:critical ではない、#3499 は低優先)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR は視覚的出力を変更しない。edit フォームは既存 markup をそのまま `ActivityEditForm.svelte` へ移動 + `{#key}` で包んだのみ (DOM 構造 / class / testid 不変)、childIdOverride は選択優先順位ロジックのみの変更で同一 URL での描画結果は従来と同一。視覚差分が生じないため before/after SS は同一画像になる。UI 挙動の証跡は E2E (`admin-child-scope-and-edit-reseed.spec.ts`) の act → outcome assert で担保。必要であれば親セッションが撮影・追補する。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（S）— 編集フォームを `ActivityEditForm.svelte` に分離し、page は「URL → key → form」の接続のみ担当
- [x] **DRY**: activities / rewards の childIdOverride 修正は同型パターンで統一 (`grep -rn childIdOverride src/` で checklists / certificates は override 初期値が元々 undefined で本境界なしを確認)
- [x] **YAGNI**: 現要件に不要な抽象化を追加していない (helper 化は 2 箇所同型のため見送り、3 箇所目で Registry 判断 = 補佐設計品質ガード 6 整合)
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし / 認可境界の変更なし
- [x] **アクセシビリティ**: role="tab" / aria-selected は既存実装のまま。フォームの label / aria も移動のみで不変
- [x] **パフォーマンス**: `{#key}` remount は activity 切替時のみ発火。N+1 なし / バンドル増なし (コード移動のみ)

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ + デモ版を同期 — demo Lambda は本番ルートを直接 host (#2097 PR-B3) のため本修正がそのまま適用される
- [ ] **LP ↔ アプリ双方向整合**: N/A (LP 文言変更なし)
- [ ] 全年齢モード 5 種に横展開: N/A (親管理画面のみ)
- [ ] ナビゲーション 3 種に反映: N/A
- [ ] E2E / ユニットシード同期: シード変更なし (E2E は既存 seed + dedicated fixture を API 作成 → cleanup)
- [x] **labels SSOT** (ADR-0009): 新規文言なし (既存 labels.ts 参照を component へ移動のみ)
- [x] **設計書同期** (ADR-0001): UI 機能 / 画面仕様の変更なし (挙動 guard + 内部分割のみ) のため設計書更新対象なし。lint 方針 (AC3) は `ActivityEditForm.svelte` 冒頭コメントを SSOT とした
- [x] **並行 PR overlap** (#1200): `gh pr list --state open` で activities / rewards +page.svelte を変更する open PR がないことを確認
- [x] 横展開調査: 同型の childIdOverride を持つ `admin/checklists` / `admin/certificates` は初期値が元々 `undefined` (URL seed 複製なし) で本境界の対象外であることを確認

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- childIdOverride の優先順位を「tab click 上書き → URL `?childId` → cookie (activities) → 先頭 child」に再構成し、**load 再実行で `?childId` が変わったら tab click 上書きを破棄して URL を優先**する仕様にした。tab click 直後は `replaceState` で URL 同期するため load は再実行されず、上書きは保持される (従来挙動維持)。この優先順位の妥当性を確認いただきたい
- E2E の client-side 遷移は UI 上に直接 link が無い境界のため anchor 注入 + SPA marker で再現している。手法の妥当性 (tests/CLAUDE.md 禁止事項には非抵触: waitForTimeout / networkidle / isVisible+toBe の新規 assertion 不使用) を確認いただきたい
- **実測による前提修正の申告**: Issue の根本原因欄は「同一 route の param 変更は component を remount しない」前提だったが、DOM identity probe 実測では現行 SvelteKit は remount する。したがって本 defect が今日顕在化する経路は「remount されず data だけ更新される経路」(invalidateAll / 将来の SvelteKit component 再利用最適化 / shallow routing) に限られる。guard は defense-in-depth として実装し、判別 red→green は unit test で担保した (低優先という Issue の位置付けと整合)
- ローカル環境での既知 flake: `admin-activities-per-child.spec.ts` の 2 test (「子供タブクリックで URL 同期」/「取込後件数水増しなし」) は **origin/develop の旧コードでも同様に fail する** (対照実験実施済、dev server の hydration 完了前 click 空振り race、retry なし素 click のため)。本 PR の regression ではない (本 PR の新 spec は同 race を bounded retry で吸収済)。CI (preview build) では従来通り PASS 見込み

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（worktree の Step 1 制約と等価実施の詳細は「テスト & 安全装置セルフチェック」1 項目目を参照）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完のまま残っている AC がない）
- [x] Phase 分割した場合: N/A（Phase 分割なし、単一 PR で完結）
- [x] UI 変更時: 視覚差分なし（markup 移動 + 選択優先順位ロジックのみ、SS セクションに該当なし理由を明記）。DESIGN.md §9 禁忌 6 点は既存 markup の移動のため非該当を確認
- [x] 認証画面変更時: N/A（認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)



---

> **gate exemption 根拠 (QM Fix)**: 視覚仕様不変 (verbatim component 抽出 + 状態 seeding lifecycle のみの内部修正) のため `refactor:internal-no-doc-impact` label を付与し design-doc-check / screenshot-check を exempt。static SS は before/after 同一画像となり #2063 SS偽装 gate に抵触するため添付せず、UI 挙動の証跡は E2E `admin-child-scope-and-edit-reseed.spec.ts` の act→outcome assert で担保する。
