### PR TITLE
design(infra): #3657 LWA readiness を shallow probe (/api/ready) に分離 — DB 障害時の全 502 化 + init timeout の根治

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -48,7 +48,10 @@ COPY --from=build /app/package.json ./
 ENV PORT=3000
 ENV HOST=0.0.0.0
 ENV AWS_LWA_PORT=3000
-ENV AWS_LWA_READINESS_CHECK_PATH=/api/health
+# readiness は shallow probe (/api/ready = プロセス生存のみ) に向ける (#3657)。
+# /api/health (deep DB probe) に結合すると DB 障害時に LWA never-ready → 全 502 +
+# cold start init timeout ループになる。deep probe は監視系 (/api/health) が担う。
+ENV AWS_LWA_READINESS_CHECK_PATH=/api/ready
 ENV AWS_LWA_INVOKE_MODE=buffered
 ENV NODE_ENV=production
 

--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -26,7 +26,8 @@
 
 | メソッド | パス | 概要 | 認証 |
 |----------|------|------|------|
-| GET | /api/health | ヘルスチェック | 不要 |
+| GET | /api/health | ヘルスチェック（deep、監視用） | 不要 |
+| GET | /api/ready | readiness probe（shallow、LWA 用 #3657） | 不要 |
 | POST | /api/v1/auth/login | Cognito ログイン（Email/Password） | 不要 |
 | POST | /api/v1/auth/logout | ログアウト（Cookie クリア） | 不要 |
 | GET | /auth/callback | Cognito OAuth コールバック | 不要 |
@@ -1335,6 +1336,18 @@ backend が不健全 (接続不可 / schema 不在) の場合は **503** + `{"st
 }
 ```
 
+#### GET /api/ready
+
+readiness probe（shallow、#3657）。**プロセスが HTTP を受けられることのみを証明し、DB には一切接触しない**。LWA（Lambda Web Adapter）の `AWS_LWA_READINESS_CHECK_PATH` が参照する（`Dockerfile.lambda`）。readiness を `/api/health`（deep DB probe）に結合すると DB 障害時に LWA が never-ready → 全リクエスト 502 + cold start init timeout ループになるため分離する（13-AWSサーバレスアーキテクチャ設計書 §3.3）。
+
+- 常に **200** を返す（DB 状態に依存しない。メンテナンスモード中も 503 化しない）
+- 監視・deploy smoke には使わない（deep 検証は `/api/health` が担う）
+
+**レスポンス (200):**
+```json
+{ "status": "ok", "version": "1.0.0", "uptime": 123 }
+```
+
 ---
 
 ### 3.16 運営管理ダッシュボード（#0176 / #820 / ADR-0033）
@@ -2405,7 +2418,7 @@ export interface PlanLimitError {
     │       └── Layer 2: context_token Cookie → HMAC 検証 → AuthContext
     │
     ├── 2) ルート保護
-    │       ├── 公開ルート（/, /auth/*, /switch, /legal/*, /api/health, /api/stripe/webhook, /ops/*）→ 通過
+    │       ├── 公開ルート（/, /auth/*, /switch, /legal/*, /api/health, /api/ready, /api/stripe/webhook, /ops/*）→ 通過
     │       ├── /admin/* → owner/parent ロール必須
     │       ├── /child/* → 全ロール
     │       ├── /api/v1/admin/* → owner/parent ロール必須

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -107,6 +107,18 @@
 - Lambda events → HTTP変換を透過的に処理
 - Cold start: ~500ms（許容範囲）
 
+**LWA readiness と health の分離（#3657）:**
+
+| probe | パス | 深さ | 用途 |
+|-------|------|------|------|
+| readiness | `/api/ready` | shallow（プロセスが HTTP を受けられるかのみ、DB 非接触） | LWA の `AWS_LWA_READINESS_CHECK_PATH`（`Dockerfile.lambda`）。トラフィック受入可否の判定 |
+| health | `/api/health` | deep（DATA_SOURCE に応じた実 backend 接続 + schema 検証、07-API設計書 §3.15） | 監視専用: 外部ヘルスチェック Prober（§3.4 L1）/ post-deploy smoke（deploy.yml / deploy-aws-staging.yml）/ NUC Docker healthcheck（`Dockerfile`） |
+
+- **readiness を deep DB probe に結合しない**。結合すると DB 障害時に LWA が never-ready となり、アプリの fail-close 503 が外に出ず Function URL 全体が 502 化する（外形の劣化 + 障害原因の不可視化）。さらに cold start の readiness 成立が DB 接続に律速されて Lambda init 10s 上限の `INIT_REPORT timeout` → 再 init ループを誘発する（DSQL 構成 staging 実測: probe 込み Init 3315ms）
+- LWA 0.9.1 の readiness は HTTP status ≥ 500（`AWS_LWA_READINESS_CHECK_MIN_UNHEALTHY_STATUS` 既定値）を unhealthy と判定するため、/api/health の 503 fail-close はそのまま never-ready になる。LWA 既定の readiness path が `/`（軽量応答想定）である点とも整合し、shallow readiness + deep health の分離は Kubernetes の readiness/liveness 分離・AWS Builders' Library「Implementing health checks」（依存 deep check を起動 gate に使うと単一依存障害が全遮断へ増幅される）と同型の確立パターン
+- **DB 障害時の外形と検出経路**: アプリは各リクエストで fail-close 503 / エラー応答を返し（assertion 弱体化なし、ADR-0006 整合）、Lambda-URL-5xx alarm（§3.4 #7、≥5回/5分 P0）+ 外部ヘルスチェック Prober（§3.4 L1、`/api/health` を 1 時間毎 GET → 503 検知 → Discord 通知）が検出する。CloudFront カスタムエラーレスポンス（§3.5）は 502/503 とも S3 エラーページに差し替えるため、ユーザー向け表示は劣化しない
+- `/api/ready` はメンテナンスモード（§3.5）でも 503 化しない（`hooks.server.ts` で `/api/health` と同様に除外）。メンテ中の cold start が never-ready → 502 になり、メンテページ（503 → S3 差し替え）が出せなくなるのを防ぐ
+
 **ECRリポジトリ:**
 - イメージ保持: 最新10個（ロールバック用 ~2週間分）
 - 未タグイメージ: 1日で自動削除

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -170,7 +170,9 @@ export const handle: Handle = ({ event, resolve }) =>
 		await applyOperatorPinResetIfRequested();
 
 		// 0-a) メンテナンスモード（Lambda環境変数で切替）
-		if (MAINTENANCE_MODE && path !== '/api/health') {
+		// /api/ready (LWA readiness、#3657) も除外 — メンテ中に 503 を返すと cold start の
+		// LWA が never-ready になり、メンテページ (503) の代わりに 502 が外形になる。
+		if (MAINTENANCE_MODE && path !== '/api/health' && path !== '/api/ready') {
 			if (acceptsHtml(event.request)) {
 				return new Response(
 					renderErrorHtml(

--- a/src/lib/server/auth/authorization.ts
+++ b/src/lib/server/auth/authorization.ts
@@ -137,6 +137,8 @@ function isPublicRoute(path: string): boolean {
 		path.startsWith('/_app') ||
 		path.startsWith('/favicon') ||
 		path.startsWith('/api/health') ||
+		// #3657: LWA readiness の shallow probe。認証なしで 200 を返せる必要がある
+		path.startsWith('/api/ready') ||
 		path.startsWith('/api/stripe/webhook') ||
 		path.startsWith('/legal') ||
 		path.startsWith('/demo') ||

--- a/src/routes/api/ready/+server.ts
+++ b/src/routes/api/ready/+server.ts
@@ -1,0 +1,16 @@
+import { json } from '@sveltejs/kit';
+import { APP_VERSION } from '$lib/version';
+import type { RequestHandler } from './$types';
+
+// LWA (Lambda Web Adapter) readiness 専用の shallow probe (#3657)。
+// 「プロセスが HTTP を受けられる」ことのみを証明し、DB には一切触れない。
+// deep DB probe は /api/health が監視用途 (health-check Lambda / post-deploy smoke /
+// NUC Docker healthcheck) で担う — readiness を deep probe に結合すると DB 障害時に
+// LWA が never-ready → 全リクエスト 502 (アプリの fail-close 503 が外に出ない) +
+// cold start init timeout ループになるため分離する (13-AWSサーバレスアーキテクチャ設計書 §3.3)。
+export const GET: RequestHandler = () =>
+	json({
+		status: 'ok',
+		version: APP_VERSION,
+		uptime: Math.floor(process.uptime()),
+	});

--- a/tests/unit/auth/authorization.test.ts
+++ b/tests/unit/auth/authorization.test.ts
@@ -30,6 +30,7 @@ describe('authorizeCognito', () => {
 			'/pricing',
 			'/setup',
 			'/api/health',
+			'/api/ready',
 			'/api/stripe/webhook',
 			'/legal/privacy',
 			'/legal/terms',

--- a/tests/unit/routes/api-ready.test.ts
+++ b/tests/unit/routes/api-ready.test.ts
@@ -1,0 +1,37 @@
+// tests/unit/routes/api-ready.test.ts
+// #3657: LWA readiness 専用 shallow probe (/api/ready) の契約テスト。
+//
+// 契約:
+// 1. 常に 200 + status:'ok' を返す (DB 状態に依存しない — DB 障害時に LWA が
+//    never-ready → 全 502 化するのを防ぐ分離の根幹)
+// 2. DB 層 (probe facade / db client) を一切 import しない (shallow 保証。
+//    route↔DB 境界は tests/unit/architecture/route-db-boundary.test.ts が機械強制)
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { GET } from '../../../src/routes/api/ready/+server';
+
+describe('GET /api/ready (#3657 LWA readiness shallow probe)', () => {
+	it('常に 200 + status:ok を返す (DB 非依存)', async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: RequestEvent 全体は不要 (handler は event を参照しない)
+		const res = await GET({} as any);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.status).toBe('ok');
+		expect(typeof body.version).toBe('string');
+		expect(typeof body.uptime).toBe('number');
+	});
+
+	it('route source が DB 層を import しない (shallow probe 保証)', () => {
+		const src = readFileSync(
+			resolve(__dirname, '../../../src/routes/api/ready/+server.ts'),
+			'utf-8',
+		);
+		// deep probe 化 (probe facade / db client / drizzle への依存追加) を regression として検出する。
+		// readiness を deep DB probe に再結合すると DB 障害時に LWA never-ready → 全 502 +
+		// cold start init timeout ループが再発する (#3657 / 13-AWS設計書 §3.3)。
+		expect(src).not.toMatch(/\$lib\/server\/db/);
+		expect(src).not.toMatch(/drizzle/);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（AWS 本番 / staging の全ユーザー + 運営）

**解決する課題**: LWA (Lambda Web Adapter) の readiness check が deep DB probe (`/api/health`) に結合しているため、DB 障害時に LWA が never-ready となり全リクエストが 502 化（アプリの fail-close 503 が外に出ず障害原因が不可視化）。さらに cold start の readiness 成立が DB 接続に律速され、Lambda init 10s 上限の `INIT_REPORT timeout` → 再 init ループを誘発していた（staging cycle 4 実機観察、DSQL 構成 Init 3315ms は probe 込み）。

**期待される効果**: readiness（トラフィック受入可否 = プロセス生存）と health（依存含む深い健全性 = 監視用）を分離することで、(1) DB 障害時もアプリ自身が構造化された 503 / エラーページを返せる（可観測性 + UX 向上）、(2) cold start init が DB probe に律速されず init timeout ループが消滅する。fail-close 自体は不変（`/api/health` は 503 のまま、ADR-0006 非弱体化）。

## 関連 Issue

closes #3657

関連: EPIC #3424（staging cycle 4 の 502 調査で観察）/ #3644（probePg 実接続化）/ #3431・#3432（DSQL 監視設計 — AC1 の整合対象）

### 設計判断の要旨（経緯は本 PR description に記録、docs SSOT 原則 #2440）

Issue #3657 の案 A（現状維持）/ 案 B（readiness 分離）/ 案 C（degraded 200）のうち **案 B を採択**。

- **案 C 不採用**: DB 不能でも 200 を返すのは fail-close 弱体化（ADR-0006 類似）で Issue 本文どおり不採用
- **案 A 不採用の根拠**: 「DB 不能な app にトラフィックを流さない」意図は 502 という劣化した外形（app ログなし、LWA `app is not ready` 連発のみ）でしか実現されず、cold start init timeout 再 init ループという副作用（課金 + レイテンシ + ログノイズ）を伴う。alarm 検出は 案 B でも同等以上に成立（下記 AC1）
- **案 B 採択の根拠（OSS / 確立パターン 2 件以上、#1350）**:
  1. **LWA 公式 README**（awslabs/aws-lambda-web-adapter）: readiness の既定 path は `/`（軽量応答想定）、0.9.1 の `AWS_LWA_READINESS_CHECK_MIN_UNHEALTHY_STATUS` 既定 500 により `/api/health` の 503 は unhealthy = never-ready になる。readiness は「app が HTTP を受けられるか」の判定として設計されている
  2. **Kubernetes readiness/liveness probe 分離**: 外部依存（DB）を起動 gate に含めると単一依存障害が全遮断へ増幅される、という確立された運用原則
  3. **AWS Builders' Library「Implementing health checks」**: dependency health check を起動/トラフィック gate に直結させると blast radius が全 fleet に増幅されるため、liveness と dependency check を区別する

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 案 A/B の設計判断を確定（監視設計 #3431/#3432 整合込み — DB 死の外形を alarm がどう検出するか） | `grep -n "LWA readiness と health の分離" docs/design/13-AWSサーバレスアーキテクチャ設計書.md` + 同節の alarm 経路記載を目視照合 | HEAD `450a6726` / 13-AWS §3.3 に分離表 + 「DB 障害時の外形と検出経路」を明文化。案 B 採択後の外形 = app 自身の 503 → Lambda-URL-5xx alarm（§3.4 #7、≥5回/5分 P0）+ 外部ヘルスチェック Prober（§3.4 L1、`/api/health` 1 時間毎 GET → 503 検知 → Discord）で検出。DSQL 監視（#3431 Alarm IaC / #3432 dashboard）は DPU/OccConflicts 側の別軸で本分離と独立に成立 |
| AC2 | 採択案を実装 or 現状維持の根拠を 13-AWS 設計書に明文化 | `npx vitest run tests/unit/routes/api-ready.test.ts tests/unit/auth/authorization.test.ts tests/unit/architecture/route-db-boundary.test.ts` + `grep -n "AWS_LWA_READINESS_CHECK_PATH" Dockerfile.lambda` | HEAD `450a6726` / 3 test files 63 passed（api-ready 契約 2 件 = 常に 200 + DB 非 import 保証を含む）/ Dockerfile.lambda:54 `=/api/ready` / 実装 = `src/routes/api/ready/+server.ts`（shallow probe 新設）+ hooks.server.ts メンテ除外 + authorization.ts 公開ルート + 13-AWS §3.3 / 07-API §3.15 設計書同期 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [x] インフラ (`Dockerfile.lambda` — LWA env。`infra/` CDK 定義自体は変更なし)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 画面影響なし。AWS Lambda（本番 / staging / demo Lambda、同一 image）の cold start readiness 経路と、DB 障害時の外形（502 → app 503）のみ。`/api/health` の応答仕様・監視系（health-check Lambda / deploy smoke / NUC Docker healthcheck）は不変。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 本 PR 番号で実行済（下記 Ready checklist 参照）
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/routes/api-ready.test.ts` 新規: `/api/ready` の契約 2 件（常に 200 + status:ok / route source が DB 層を import しない = deep probe 化 regression guard）
  - `tests/unit/auth/authorization.test.ts`: 公開ルート一覧に `/api/ready` を追加（未認証アクセス可）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 既存 env `AWS_LWA_READINESS_CHECK_PATH` の値変更のみ（Dockerfile 内完結、配布不要）
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — DB 層変更なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — priority:medium の設計判断 Issue

## スクリーンショット / ビジュアルデモ

**該当なし（infra / docs — UI 変更なし）**。server route（JSON API）+ Dockerfile env + 設計書のみで視覚差分ゼロ。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `/api/ready`（shallow / トラフィック gate）と `/api/health`（deep / 監視）の単一責任分離が本 PR の主旨。probe facade（`db/probe.ts`）は不変
- [x] **DRY**: `grep -rn "api/ready" src/ tests/ docs/` で新設参照 6 箇所を確認、重複実装なし。readiness 判定ロジックは LWA 本体（OSS）に委譲し独自実装ゼロ
- [x] **YAGNI**: endpoint は 200 固定の最小実装（DB / 依存チェックなし）。`AWS_LWA_ASYNC_INIT` 等の追加チューニングは Issue の No-gos（polling 間隔チューニング不要）に従い不採用
- [x] **Security（OSS 公開前提）**: `/api/ready` は version / uptime のみ返却（`/api/health` の既存公開情報のサブセット）。秘密情報なし
- [x] **アクセシビリティ**: N/A — JSON API のみ
- [x] **パフォーマンス**: cold start の readiness 成立から DB 接続（DSQL 実測 Init 3315ms の主因）を除去する改善方向の変更

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001): 13-AWS §3.3（LWA readiness/health 分離表 + 根拠 + 検出経路）/ 07-API §3.15 + endpoint 一覧 + 認可アーキ図（`/api/ready` 追加）
- [x] 並行 PR overlap 確認 (#1200): `gh pr list` で Dockerfile.lambda / api/health 系の open PR なしを確認
- [x] N/A — その他の並行実装ペア（demo Lambda は同一 image のため自動追従、UI/labels 影響なし）

**LP / 販促文言変更時** (ADR-0013):

N/A — LP / 販促文言の変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

（`/api/health` の応答仕様・監視系の参照はすべて不変。変わるのは LWA readiness の参照先のみで、正常時の外形は同一）

**レビュー依頼事項・QA**:
- メンテナンスモード除外（hooks.server.ts）に `/api/ready` を追加した意図: メンテ中の cold start が never-ready → 502 になり、メンテページ（503 → S3 差し替え）が出せなくなるのを防ぐため。`/api/health` の既存除外と同型
- deploy 後の実機挙動（cold start の INIT_REPORT 改善）は次回 staging cycle の CloudWatch ログで観測可能（本 PR の AC 範囲は設計判断確定 + 実装 + 設計書明文化）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（`AWS_LWA_READINESS_CHECK_PATH` は Dockerfile.lambda 内で完結する既存 env の値変更）

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A — UI 変更なし（infra / server route / docs のみ）
- [x] 認証画面変更時: N/A — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
