### PR TITLE
infra: #3695 cron 30 秒 self-limiting + 持ち越し規約 (dispatcher timeout は救済にならない — 設計判断 + リスク中 2 ジョブ実装)

### DIFF
--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -155,6 +155,17 @@ EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 - **認証ヘッダ**: dispatcher は `Authorization: Bearer <CRON_SECRET>` を送信。endpoint 側は `verifyCronAuth` (`src/lib/server/auth/cron-auth.ts`) で `Authorization: Bearer` と `x-cron-secret` の両ヘッダを受理する (#1377 で統一、NUC scheduler / AWS dispatcher 双方互換)
 - **Sub A-3 検証層** (#1377): `tests/unit/cron/schedule-consistency.test.ts` が registry / CDK / dispatcher の整合性を検証する。Sub A-3 対象 endpoint (retention-cleanup / trial-notifications) は 0 tolerance で厳密検証する一方、`age-recalc` は EventBridge / dispatcher 未反映の既知 drift として `KNOWN_DRIFT_OUT_OF_SCOPE` で除外している (上表「✗」と整合)。`scripts/check-cron-observability.mjs` (`npm run check:cron-observability`) が logger / Alarm 定義の存在を静的検査する
 
+**Cron ジョブ実行時間予算 — 30 秒 self-limiting + 持ち越し規約 (#3695):**
+
+全 cron ジョブの実処理は `EventBridge → cron-dispatcher → HTTP POST → SvelteKitFn (timeout 30 秒)` 上で走るため、dispatcher 側の timeout (Lambda 5 分 / HTTP client 270 秒) は「アプリ Lambda が 504 を返すまで待つだけ」で救済にならず、**全ジョブが実質 30 秒制約下にある**。「cron だから長く走れる」という前提で設計してはならない。
+
+- **規約**: 処理量がデータ量 (テナント数 / pending 件数等) に比例する cron ジョブは、**1 回の実行で 30 秒予算内に処理できる分だけ処理し、残りは次回実行に持ち越す** (self-limiting)。実装は `src/lib/server/cron/time-budget.ts` の `createTimeBudget` (既定 20 秒 = 30 秒 − 認証・前処理・in-flight 完走・レスポンス直列化のヘッドルーム 10 秒) と件数上限の併用。予算超過チェックは item 間で行い、着手した item は完走させる (中断は stale 'building' 等の中途状態を量産するため)
+- **観測性**: 持ち越し発生時は件数 (`remaining` / `skipped`) を log warn + レスポンスに必ず含める (silent 持ち越し禁止、ADR-0006 整合)
+- **適用済**: `export-build` (`drainPendingExports`: limit 5 + stale reclaim + 時間予算。5 分毎 cron が持ち越し分を自然回収) / `grace-period-deletion` (`purgeExpiredSoftDeletedTenants`: limit 5 + 時間予算。残件は翌日実行に持ち越し — 個人情報保護法 22 条は努力義務であり 1-2 日の持ち越しは許容範囲)
+- **他ジョブ**: retention-cleanup / analytics・challenge aggregate 系もテナント数比例だが、現規模 (Pre-PMF、~100 tenants) では 30 秒内に収まる。顕在化 (CronDispatcherErrors alarm での 504 / timeout 検出) 時に本規約を同パターンで適用する
+- **代替案と発動条件**: dispatcher からの専用長時間 Lambda 直接 invoke (案 B) は関数分離 + コード配布 2 系統の運用負荷、Step Functions (案 C) は Pre-PMF 過剰 (ADR-0010) のため不採用。**self-limiting でも 1 スケジュールスパン内に消化しきれないバックログが定常化した時点** (例: export-build の pending 滞留が 1 時間超 / grace-period の持ち越しが 3 日連続) **で案 B を再検討**する
+- **新規ジョブ追加時**: `schedule-registry.ts` 冒頭の checklist に従う (本規約 + KNOWN_ENDPOINTS / CRON_JOBS 並行登録)
+
 ### 3.4 OpsStack（監視・コスト防衛）
 
 **SNS 通知基盤:**

--- a/src/lib/server/cron/schedule-registry.ts
+++ b/src/lib/server/cron/schedule-registry.ts
@@ -6,6 +6,19 @@
 //
 // cronExpression は Asia/Tokyo タイムゾーンで解釈される（コンテナ TZ=Asia/Tokyo）。
 // AWS EventBridge は UTC 固定のため、Sub A-2 (#1376) 実装時に utcExpression も参照すること。
+//
+// 新規 cron ジョブ追加 checklist (#3695、規約 SSOT: 13-AWS設計書 §3.3「Cron ジョブ実行時間予算」):
+//   1. 【30 秒予算】全 cron の実処理は Function URL 経由でアプリ Lambda (timeout 30 秒) 上で
+//      走る。dispatcher の timeout (5 分) は「504 を待つだけ」で救済にならない — 30 秒予算で
+//      設計すること (「cron だから長く走れる」前提は誤り)。
+//   2. 【self-limiting + 持ち越し】処理量がデータ量 (テナント数 / pending 件数等) に比例する
+//      ジョブは、1 回の実行で処理する量に件数上限 + 時間予算 ($lib/server/cron/time-budget.ts
+//      createTimeBudget) を設け、残りは次回実行に持ち越す。持ち越し件数は log + レスポンスで
+//      必ず報告する (silent 持ち越し禁止)。前例: cloud-export-service.drainPendingExports /
+//      grace-period-service.purgeExpiredSoftDeletedTenants。
+//   3. 【並行登録】KNOWN_ENDPOINTS (infra/lambda/cron-dispatcher/index.ts) + CRON_JOBS
+//      (infra/lib/compute-stack.ts) にも登録し、13-AWS設計書 §3.3 の Cron ジョブ一覧表を更新
+//      (tests/unit/cron/schedule-consistency.test.ts が整合検証)。
 
 export interface CronJob {
 	/** ジョブ識別名（ログ・監視用） */

--- a/src/lib/server/cron/time-budget.ts
+++ b/src/lib/server/cron/time-budget.ts
@@ -1,0 +1,39 @@
+// src/lib/server/cron/time-budget.ts
+// #3695: cron ジョブの 30 秒 self-limiting + 持ち越し規約の実装ヘルパ。
+//
+// 全 cron ジョブの実処理は EventBridge → cron-dispatcher → HTTP POST → アプリ Lambda
+// (timeout 30 秒) 上で走るため、dispatcher 側の timeout (5 分) は救済にならず
+// 全ジョブが実質 30 秒制約下にある。処理量がデータ量に比例するジョブは本ヘルパで
+// 「予算内に処理できた分だけ処理し、残りは次回実行に持ち越す」。
+// 規約 SSOT: docs/design/13-AWSサーバレスアーキテクチャ設計書.md §3.3
+// 「Cron ジョブ実行時間予算」。
+
+/**
+ * cron ジョブが item ループで消費してよい既定時間予算 (20 秒)。
+ *
+ * アプリ Lambda timeout 30 秒から、認証 / 前処理 I/O / 処理中 item の完走 /
+ * レスポンス直列化のヘッドルーム 10 秒を差し引いた値。予算超過チェックは
+ * item 間 (ループ先頭) で行い、処理中の item は中断しない。
+ */
+export const CRON_TIME_BUDGET_MS = 20_000;
+
+/** {@link createTimeBudget} が返す時間予算トラッカー。 */
+export interface TimeBudget {
+	/** 予算を使い切ったら true。item ループの先頭で確認する。 */
+	exceeded(): boolean;
+	/** 開始からの経過 ms (持ち越しログ用)。 */
+	elapsedMs(): number;
+}
+
+/**
+ * 時間予算トラッカーを生成する。cron endpoint 起動直後に 1 つ作り、
+ * service 層の item ループへ渡す。テストでは fake 実装
+ * (`{ exceeded: () => true, elapsedMs: () => 0 }`) を注入して予算超過経路を検証する。
+ */
+export function createTimeBudget(budgetMs: number = CRON_TIME_BUDGET_MS): TimeBudget {
+	const start = Date.now();
+	return {
+		exceeded: () => Date.now() - start >= budgetMs,
+		elapsedMs: () => Date.now() - start,
+	};
+}

--- a/src/lib/server/services/cloud-export-service.ts
+++ b/src/lib/server/services/cloud-export-service.ts
@@ -4,6 +4,7 @@ import type { CategoryId, ChildId } from '$lib/domain/ids';
 
 import { randomInt } from 'node:crypto';
 import { PLAN_GATE_LABELS } from '$lib/domain/labels';
+import { createTimeBudget, type TimeBudget } from '$lib/server/cron/time-budget';
 import { getRepos } from '$lib/server/db/factory';
 import type { CloudExportRecord, CloudExportType } from '$lib/server/db/types';
 import { logger } from '$lib/server/logger';
@@ -262,6 +263,8 @@ export interface DrainResult {
 	failed: number;
 	/** #3509: stale 'building' から 'failed' へ reclaim (fail-closed) した件数。 */
 	reclaimed: number;
+	/** #3695: 時間予算超過で今回 build せず次回実行 (5 分毎) へ持ち越した件数。 */
+	skipped: number;
 }
 
 /**
@@ -299,15 +302,27 @@ export async function reclaimStaleBuildingExports(
  * #3509 QM 是正: build 開始前に {@link reclaimStaleBuildingExports} を呼び、cron worker が
  * kill/timeout して 'building' のまま永久 stuck したレコードを 'failed' へ fail-closed してから
  * 通常の pending drain を行う。
+ *
+ * #3695 (30 秒 self-limiting + 持ち越し規約、13-AWS設計書 §3.3): ZIP build は 1 件が重く
+ * limit 件で 30 秒 (アプリ Lambda timeout) を超えうるため、build 間で時間予算を確認し、
+ * 予算超過時は残りを build せず次回実行 (5 分毎 cron) に持ち越す (`skipped` で報告)。
+ * 予算内に着手した build は完走させる (中断すると #3509 の stale 'building' を自ら量産するため)。
  */
-export async function drainPendingExports(limit = 5): Promise<DrainResult> {
+export async function drainPendingExports(
+	limit = 5,
+	budget: TimeBudget = createTimeBudget(),
+): Promise<DrainResult> {
 	const repos = getRepos();
 	const reclaimed = await reclaimStaleBuildingExports();
 	const pending = await repos.cloudExport.findPendingBuilds(limit);
 	let ready = 0;
 	let failed = 0;
+	let attempted = 0;
 
 	for (const record of pending) {
+		// #3695: 予算超過なら残りは次回 5 分毎 cron が拾う (pending のまま残す)。
+		if (budget.exceeded()) break;
+		attempted++;
 		const { id, tenantId, exportType, s3Key } = record;
 		try {
 			await repos.cloudExport.updateStatus(id, tenantId, 'building');
@@ -341,7 +356,15 @@ export async function drainPendingExports(limit = 5): Promise<DrainResult> {
 		}
 	}
 
-	return { processed: pending.length, ready, failed, reclaimed };
+	const skipped = pending.length - attempted;
+	if (skipped > 0) {
+		// #3695: silent 持ち越し禁止 (ADR-0006 整合) — 持ち越し発生を必ずログに残す。
+		logger.warn('[cloud-export] drain 時間予算超過、残件を次回実行へ持ち越し', {
+			context: { skipped, attempted, limit, elapsedMs: budget.elapsedMs() },
+		});
+	}
+
+	return { processed: attempted, ready, failed, reclaimed, skipped };
 }
 
 /**

--- a/src/lib/server/services/grace-period-service.ts
+++ b/src/lib/server/services/grace-period-service.ts
@@ -9,6 +9,7 @@
 //   standard: 7日間
 //   family:   30日間
 
+import { createTimeBudget, type TimeBudget } from '$lib/server/cron/time-budget';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import type { PlanTier } from './plan-limit-service';
@@ -264,18 +265,36 @@ export function getGracePeriodDays(planTier: PlanTier): number {
  *
  * dryRun=true の場合は対象一覧のみ返し、削除は実行しない。
  *
+ * #3695 (30 秒 self-limiting + 持ち越し規約、13-AWS設計書 §3.3): テナント物理削除は
+ * 1 件あたりが重い (Cognito + DynamoDB 全域 + Stripe) ため、1 回の実行で処理するのは
+ * 最大 limit 件 (既定 {@link DEFAULT_PURGE_LIMIT}) + 時間予算内に留め、残りは翌日の
+ * 実行に持ち越す (`tenantsRemaining` で報告)。個人情報保護法 22 条は努力義務であり
+ * 1-2 日の持ち越しは許容範囲。
+ *
  * 個人情報保護法 22 条「不要となった個人データの遅滞なく消去する努力義務」遵守 +
  * DB 肥大化リスク解消が目的（ADR-0010 過剰防衛禁止に該当しない最小実装）。
  */
-export async function purgeExpiredSoftDeletedTenants(opts?: { dryRun?: boolean }): Promise<{
+export const DEFAULT_PURGE_LIMIT = 5;
+
+export async function purgeExpiredSoftDeletedTenants(opts?: {
+	dryRun?: boolean;
+	/** #3695: 1 回の実行で物理削除を試行する最大テナント数。 */
+	limit?: number;
+	/** #3695: 時間予算 (テスト注入用。省略時は endpoint 側が生成した予算 or 新規生成)。 */
+	budget?: TimeBudget;
+}): Promise<{
 	tenantsProcessed: number;
 	tenantsDeleted: number;
 	tenantsFailed: number;
+	/** #3695: limit / 時間予算により今回処理せず次回実行へ持ち越した件数。 */
+	tenantsRemaining: number;
 	dryRun: boolean;
 	expired: Array<{ tenantId: string; planTier: PlanTier; physicalDeletionDate: string }>;
 	errors: Array<{ tenantId: string; error: string }>;
 }> {
 	const dryRun = opts?.dryRun ?? false;
+	const limit = opts?.limit ?? DEFAULT_PURGE_LIMIT;
+	const budget = opts?.budget ?? createTimeBudget();
 	const expired = await findExpiredSoftDeletedTenants();
 
 	if (dryRun || expired.length === 0) {
@@ -286,6 +305,7 @@ export async function purgeExpiredSoftDeletedTenants(opts?: { dryRun?: boolean }
 			tenantsProcessed: expired.length,
 			tenantsDeleted: 0,
 			tenantsFailed: 0,
+			tenantsRemaining: 0,
 			dryRun,
 			expired,
 			errors: [],
@@ -299,8 +319,12 @@ export async function purgeExpiredSoftDeletedTenants(opts?: { dryRun?: boolean }
 	const repos = getRepos();
 	const errors: Array<{ tenantId: string; error: string }> = [];
 	let deleted = 0;
+	let attempted = 0;
 
 	for (const item of expired) {
+		// #3695: 30 秒 self-limiting — 件数上限 or 時間予算超過で残りを次回実行へ持ち越す。
+		if (attempted >= limit || budget.exceeded()) break;
+		attempted++;
 		try {
 			const members = await repos.auth.findTenantMembers(item.tenantId);
 			const owner = members.find((m) => m.role === 'owner');
@@ -334,10 +358,19 @@ export async function purgeExpiredSoftDeletedTenants(opts?: { dryRun?: boolean }
 		}
 	}
 
+	const remaining = expired.length - attempted;
+	if (remaining > 0) {
+		// #3695: silent 持ち越し禁止 (ADR-0006 整合) — 持ち越し発生を必ずログに残す。
+		logger.warn('[grace-period] purge carried over remaining tenants to next run', {
+			context: { remaining, attempted, limit, elapsedMs: budget.elapsedMs() },
+		});
+	}
+
 	return {
-		tenantsProcessed: expired.length,
+		tenantsProcessed: attempted,
 		tenantsDeleted: deleted,
 		tenantsFailed: errors.length,
+		tenantsRemaining: remaining,
 		dryRun: false,
 		expired,
 		errors,

--- a/tests/unit/cron/time-budget.test.ts
+++ b/tests/unit/cron/time-budget.test.ts
@@ -1,0 +1,41 @@
+// tests/unit/cron/time-budget.test.ts
+// #3695: cron 30 秒 self-limiting 規約の時間予算ヘルパ (13-AWS設計書 §3.3)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CRON_TIME_BUDGET_MS, createTimeBudget } from '$lib/server/cron/time-budget';
+
+describe('time-budget (#3695)', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('既定予算は 20 秒 (アプリ Lambda 30 秒 − ヘッドルーム 10 秒)', () => {
+		expect(CRON_TIME_BUDGET_MS).toBe(20_000);
+	});
+
+	it('予算内は exceeded() が false', () => {
+		const budget = createTimeBudget();
+		vi.advanceTimersByTime(CRON_TIME_BUDGET_MS - 1);
+		expect(budget.exceeded()).toBe(false);
+	});
+
+	it('予算到達で exceeded() が true になる', () => {
+		const budget = createTimeBudget();
+		vi.advanceTimersByTime(CRON_TIME_BUDGET_MS);
+		expect(budget.exceeded()).toBe(true);
+	});
+
+	it('budgetMs を指定できる + elapsedMs が経過時間を返す', () => {
+		const budget = createTimeBudget(1_000);
+		vi.advanceTimersByTime(500);
+		expect(budget.exceeded()).toBe(false);
+		expect(budget.elapsedMs()).toBe(500);
+		vi.advanceTimersByTime(500);
+		expect(budget.exceeded()).toBe(true);
+		expect(budget.elapsedMs()).toBe(1_000);
+	});
+});

--- a/tests/unit/services/cloud-export-service.test.ts
+++ b/tests/unit/services/cloud-export-service.test.ts
@@ -265,7 +265,7 @@ describe('cloud-export-service', () => {
 
 			const result = await drainPendingExports(5);
 
-			expect(result).toEqual({ processed: 1, ready: 1, failed: 0, reclaimed: 0 });
+			expect(result).toEqual({ processed: 1, ready: 1, failed: 0, reclaimed: 0, skipped: 0 });
 			// building → ready の 2 回
 			expect(mockCloudExportRepo.updateStatus).toHaveBeenNthCalledWith(
 				1,
@@ -359,7 +359,7 @@ describe('cloud-export-service', () => {
 		it('pending 0 件のとき何もしない', async () => {
 			mockCloudExportRepo.findPendingBuilds.mockResolvedValue([]);
 			const result = await drainPendingExports();
-			expect(result).toEqual({ processed: 0, ready: 0, failed: 0, reclaimed: 0 });
+			expect(result).toEqual({ processed: 0, ready: 0, failed: 0, reclaimed: 0, skipped: 0 });
 			expect(mockStorageRepo.saveFile).not.toHaveBeenCalled();
 		});
 
@@ -390,6 +390,39 @@ describe('cloud-export-service', () => {
 
 			expect(result.reclaimed).toBe(0);
 			expect(result.ready).toBe(1);
+		});
+
+		it('#3695: 時間予算超過で残件を build せず skipped として持ち越す (pending のまま残す)', async () => {
+			mockCloudExportRepo.findPendingBuilds.mockResolvedValue([
+				pendingRecord({ id: '1' }),
+				pendingRecord({ id: '2' }),
+				pendingRecord({ id: '3' }),
+			]);
+			// 1 件目の build 後に予算超過する fake budget (2 回目の exceeded() から true)
+			let calls = 0;
+			const budget = { exceeded: () => ++calls > 1, elapsedMs: () => 20_001 };
+
+			const result = await drainPendingExports(5, budget);
+
+			expect(result).toEqual({ processed: 1, ready: 1, failed: 0, reclaimed: 0, skipped: 2 });
+			// 2 件目以降は building 遷移していない (pending のまま = 次回 cron が拾う)
+			const buildingIds = mockCloudExportRepo.updateStatus.mock.calls
+				.filter((c) => c[2] === 'building')
+				.map((c) => c[0]);
+			expect(buildingIds).toEqual(['1']);
+		});
+
+		it('#3695: 開始時点で予算超過なら 1 件も build せず全件持ち越す', async () => {
+			mockCloudExportRepo.findPendingBuilds.mockResolvedValue([
+				pendingRecord({ id: '1' }),
+				pendingRecord({ id: '2' }),
+			]);
+			const budget = { exceeded: () => true, elapsedMs: () => 20_001 };
+
+			const result = await drainPendingExports(5, budget);
+
+			expect(result).toEqual({ processed: 0, ready: 0, failed: 0, reclaimed: 0, skipped: 2 });
+			expect(mockStorageRepo.saveFile).not.toHaveBeenCalled();
 		});
 	});
 

--- a/tests/unit/services/grace-period-service.test.ts
+++ b/tests/unit/services/grace-period-service.test.ts
@@ -18,6 +18,7 @@ const mockSetSetting = vi.fn(async (key: string, value: string, _tenantId: strin
 });
 const mockListAllTenants = vi.fn().mockResolvedValue([]);
 const mockUpdateTenantStripe = vi.fn();
+const mockFindTenantMembers = vi.fn().mockResolvedValue([{ userId: 'owner-1', role: 'owner' }]);
 
 vi.mock('$lib/server/db/factory', () => ({
 	getRepos: () => ({
@@ -28,8 +29,17 @@ vi.mock('$lib/server/db/factory', () => ({
 		auth: {
 			listAllTenants: mockListAllTenants,
 			updateTenantStripe: mockUpdateTenantStripe,
+			findTenantMembers: mockFindTenantMembers,
 		},
 	}),
+}));
+
+// #3695: purge の実削除経路 (dynamic import) を spy 化して self-limiting を検証する
+const mockDeleteOwnerOnlyAccount = vi.fn().mockResolvedValue(undefined);
+const mockDeleteOwnerFullDelete = vi.fn().mockResolvedValue(undefined);
+vi.mock('$lib/server/services/account-deletion-service', () => ({
+	deleteOwnerOnlyAccount: mockDeleteOwnerOnlyAccount,
+	deleteOwnerFullDelete: mockDeleteOwnerFullDelete,
 }));
 
 vi.mock('$lib/server/auth/factory', () => ({
@@ -308,8 +318,60 @@ describe('grace-period-service', () => {
 
 			expect(result.tenantsProcessed).toBe(0);
 			expect(result.tenantsDeleted).toBe(0);
+			expect(result.tenantsRemaining).toBe(0);
 			expect(result.expired).toHaveLength(0);
 			expect(result.errors).toHaveLength(0);
+		});
+
+		// #3695: 30 秒 self-limiting + 持ち越し (13-AWS設計書 §3.3)
+		function seedExpiredTenants(ids: string[]) {
+			const pastDate = new Date();
+			pastDate.setDate(pastDate.getDate() - 5);
+			// settingsStore 経由の既定実装で全テナントが期限切れ扱いになる
+			settingsStore.set('soft_deleted_at', new Date(Date.now() - 35 * 86400000).toISOString());
+			settingsStore.set('deletion_grace_plan_tier', 'family');
+			settingsStore.set('physical_deletion_date', pastDate.toISOString());
+			mockListAllTenants.mockResolvedValue(ids.map((tenantId) => ({ tenantId })));
+			mockFindTenantMembers.mockResolvedValue([{ userId: 'owner-1', role: 'owner' }]);
+			mockDeleteOwnerOnlyAccount.mockResolvedValue(undefined);
+			mockDeleteOwnerFullDelete.mockResolvedValue(undefined);
+		}
+
+		it('#3695: limit 超過分は削除せず tenantsRemaining として翌日実行へ持ち越す', async () => {
+			seedExpiredTenants(['t1', 't2', 't3']);
+
+			const result = await purgeExpiredSoftDeletedTenants({ dryRun: false, limit: 2 });
+
+			expect(result.tenantsProcessed).toBe(2);
+			expect(result.tenantsDeleted).toBe(2);
+			expect(result.tenantsRemaining).toBe(1);
+			expect(mockDeleteOwnerOnlyAccount).toHaveBeenCalledTimes(2);
+			expect(mockDeleteOwnerOnlyAccount).toHaveBeenCalledWith('t1', 'owner-1');
+			expect(mockDeleteOwnerOnlyAccount).toHaveBeenCalledWith('t2', 'owner-1');
+		});
+
+		it('#3695: 時間予算超過なら以降のテナントを削除せず持ち越す', async () => {
+			seedExpiredTenants(['t1', 't2']);
+			// 1 件目の処理後に予算超過する fake budget (2 回目の exceeded() から true)
+			let calls = 0;
+			const budget = { exceeded: () => ++calls > 1, elapsedMs: () => 20_001 };
+
+			const result = await purgeExpiredSoftDeletedTenants({ dryRun: false, budget });
+
+			expect(result.tenantsProcessed).toBe(1);
+			expect(result.tenantsDeleted).toBe(1);
+			expect(result.tenantsRemaining).toBe(1);
+			expect(mockDeleteOwnerOnlyAccount).toHaveBeenCalledTimes(1);
+		});
+
+		it('#3695: limit 内 + 予算内なら全件削除し持ち越し 0', async () => {
+			seedExpiredTenants(['t1', 't2']);
+
+			const result = await purgeExpiredSoftDeletedTenants({ dryRun: false });
+
+			expect(result.tenantsProcessed).toBe(2);
+			expect(result.tenantsDeleted).toBe(2);
+			expect(result.tenantsRemaining).toBe(0);
 		});
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（間接的に全ユーザー — 解約後の確実なデータ削除・エクスポート完遂の信頼性）

**解決する課題**: cron 構造 = EventBridge → cron-dispatcher Lambda → Function URL HTTP POST → アプリ Lambda (timeout 30 秒) のため、dispatcher の 4.5 分 timeout は「アプリ Lambda が 504 を返すまで待つだけ」で救済にならず、全 cron ジョブが実質 30 秒制約下にある。「cron だから長く走れる」という暗黙前提が全ジョブで誤りだった（2026-07-12 全数監査クラス 4）。テナント数・pending 件数が増えると grace-period-deletion（テナント物理削除）/ export-build（ZIP build）が 30 秒で途中 kill され、中途状態（削除しきれない / stale 'building'）が silent に発生するリスクがあった。

**期待される効果**: 「30 秒予算で self-limiting + 持ち越し」規約を SSOT 化（13-AWS 設計書 §3.3）し、リスク中の 2 ジョブに件数上限 + 時間予算 + 持ち越し報告を実装。ジョブは予算内で処理できる分だけ処理し、残りは次回実行（export-build は 5 分後 / grace-period は翌日）が確実に回収する。持ち越しは log + レスポンスで必ず可視化される（silent 持ち越し禁止、ADR-0006 整合）。

## 関連 Issue

closes #3695

- 関連 ADR: ADR-0010（Pre-PMF — Step Functions 不採用判断）/ ADR-0006（silent 化禁止 — 持ち越しの必須報告）
- 前例: #3504 / #3509（export-build の limit=5 + stale reclaim = self-limiting の既存前例）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 案の確定 (A) を 13-AWS 設計書に明文化 —「cron ジョブは 30 秒予算で self-limiting + 持ち越し」規約 | `grep -n "Cron ジョブ実行時間予算" docs/design/13-AWSサーバレスアーキテクチャ設計書.md` + `node scripts/check-doc-code-references.mjs` | HEAD `ccc4db30` / §3.3 に新設（規約 / 観測性 / 適用済 2 ジョブ / 他ジョブの発動条件 / 案 B・C 不採用理由と再検討トリガ）/ doc gate PASS「baseline 内 (150 件)。新規違反なし」 |
| AC2 | リスク中の 2 ジョブ (grace-period-deletion / export-build drain) に処理量上限 + 持ち越しを実装 | `npx vitest run tests/unit/cron/time-budget.test.ts tests/unit/services/grace-period-service.test.ts tests/unit/services/cloud-export-service.test.ts` | HEAD `ccc4db30` / 51 passed (3 files) / `grace-period-service.ts` L303-311: limit(既定 5) + `budget.exceeded()` break + `tenantsRemaining` 報告 / `cloud-export-service.ts` L318-323: build 間 budget check + `skipped` 報告（着手 build は完走 = #3509 stale 'building' を自ら量産しない） |
| AC3 | 新規 cron ジョブ追加時の checklist に本規約を追加 (schedule-registry のコメント) | `grep -n "新規 cron ジョブ追加 checklist" src/lib/server/cron/schedule-registry.ts` | HEAD `ccc4db30` / `schedule-registry.ts` L10-22: 30 秒予算 / self-limiting + 持ち越し / KNOWN_ENDPOINTS + CRON_JOBS 並行登録の 3 項目 checklist を冒頭コメントに追加 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
- 画面変更なし。cron バッチ 2 本の実行時挙動のみ: `/api/cron/grace-period-deletion`（1 回の実行で最大 5 テナント + 20 秒予算、残件は翌日持ち越し）/ `/api/cron/export-build`（limit 5 のまま build 間で 20 秒予算を確認、残件は 5 分後の次回実行が回収）
- `src/lib/server/cron/time-budget.ts`（新設共通ヘルパ）/ `src/lib/server/cron/schedule-registry.ts`（コメントのみ）/ `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §3.3（規約新設）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/cron/time-budget.test.ts`（新設 4 件）: 既定 20 秒 / 予算内 false / 到達で true / budgetMs 指定 + elapsedMs
  - `tests/unit/services/grace-period-service.test.ts`（+3 件）: limit 超過分の持ち越し（`tenantsRemaining`）/ 時間予算超過で以降スキップ / limit + 予算内なら全件削除・持ち越し 0
  - `tests/unit/services/cloud-export-service.test.ts`（+2 件、既存 2 assert を `skipped: 0` 込みに更新）: 予算超過で残件を build せず `skipped` 報告（2 件目以降 'building' 遷移なし = pending のまま）/ 開始時点で超過なら全件持ち越し
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret の追加なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — repo 層変更なし（service 層のループ制御のみ）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — priority:medium の設計判断 issue

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）** — UI 変更なし（service 層 + cron ヘルパ + 設計書のみ。`.svelte` / `.css` / `site/` 変更ゼロ）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — 時間予算は `time-budget.ts` に分離し 2 service から注入可能（テストで fake 注入）。既存 service の責務は不変
- [x] **DRY**: `grep -rn "createTimeBudget" src/` で共通ヘルパ経由を確認（grace-period / cloud-export の 2 箇所 + 定義元のみ、独自 Date.now() 直書きの重複なし）
- [x] **YAGNI**: 案 B（専用長時間 Lambda）/ 案 C（Step Functions）のインフラは追加せず、発動条件のみ設計書に明文化（ADR-0010 Pre-PMF）
- [x] **Security（OSS 公開前提）**: 秘密情報 hardcode なし / cron 認証（verifyCronAuth）不変
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: N+1 追加なし。予算 check は `Date.now()` 比較のみ（O(1)/item）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 設計書同期 (ADR-0001): `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §3.3 を同 PR で更新（AWS インフラ変更 → 13 の規約通り）
- [x] 並行 PR overlap 確認 (#1200): `gh pr list --state open --json files` で確認。`grace-period-service.ts` / `cloud-export-service.ts` / `schedule-registry.ts` を触る open PR なし。**PR #3739 (#3657 LWA readiness) と `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` のみ重複**するが、本 PR は §3.3 cron 表直後への新規小節追加・#3739 は LWA readiness 節で編集箇所が異なる。後から merge される側が rebase して整合させる（conflict 時も新規小節追加のため解消は機械的）
- [x] N/A — 本番アプリ/デモ・年齢モード・ナビ・LP・labels SSOT・E2E シード・チュートリアルはいずれも対象外（UI / ラベル / スキーマ変更なし）。NUC scheduler は AWS と同一 endpoint / 同一 service コードパスを回すため self-limiting は自動で両環境に適用される（NUC 側は timeout 制約自体が緩いが持ち越しは無害）

**LP / 販促文言変更時** (ADR-0013):

N/A — LP / 販促文言の変更なし

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

（`purgeExpiredSoftDeletedTenants` の戻り値に `tenantsRemaining`、`DrainResult` に `skipped` を追加 — いずれもフィールド追加のみで既存呼び出し元 [cron endpoint の spread] は後方互換。`tenantsProcessed` / `processed` の意味は「検出数」→「試行数」に精密化されるが、limit 内・予算内では従来と同値）

**レビュー依頼事項・QA**:
- 時間予算の既定 20 秒（= Lambda 30 秒 − headroom 10 秒）の妥当性。予算超過チェックは item 間のみで、着手した item（テナント削除 / ZIP build）は完走させる設計（中断すると #3509 の stale 'building' を自ら量産するため）
- grace-period の limit 既定 5 の妥当性（テナント物理削除は Cognito + DynamoDB 全域 + Stripe を触る重処理。現規模では同日 5 件超の期限切れはほぼ発生しない想定）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A — UI 変更なし（該当なし）
- [x] 認証画面変更時: N/A — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

