### PR TITLE
fix(perf): #3693 アカウント削除/data 全削除の全テーブル Scan を child partition Query 化

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -148,6 +148,18 @@ DynamoDB = parity 実装」の主従関係と二重 SSOT 化で衝突するた�
   `findByPin` (公開 PIN download、no-tenant read) / `deleteExpired` (tenant 横断 cron) /
   trial-history の active-trial cron Scan / cancellation-reason (tenant 横断 ops read)。
   いずれも read または cron で、原則 2 の閾値超過時に GSI 移行を起票する。
+- **tenant cleanup (退会 / data 全削除) の deleteByTenantId 群は child partition Query が正 (#3693)**:
+  `tenant-cleanup-service.deleteTenantScopedData` が児童一覧 (active + archived) を先頭で 1 回だけ
+  解決し、child-scoped 15 repo の `deleteByTenantId(tenantId, childIds)` に引き渡す。各 repo は
+  `deleteChildScopedItems` (bulk-delete.ts) で child partition への Query (並列 chunk) に解決し、
+  全テーブル Scan を排除する (旧実装は約 25 回の全テーブル Scan が直列実行され、read 量が
+  全テナント総量に比例して Lambda 30s / 504 リスク)。childIds 未供給時 (列挙失敗 / 児童 0 人 /
+  standalone 呼び出し) は Scan fallback で削除完全性を優先する。PK に埋まる ID を列挙できない
+  エンティティ (checklist `CKTPL#<tplId>` / stamp entry `STMPCARD#<cardId>`) のみ tenant あたり
+  1 Scan を維持。BatchWrite の UnprocessedItems は指数 backoff retry + 上限超過 throw
+  (silent partial delete 禁止)、削除は page 単位 streaming で途中失敗後の再実行が冪等。
+  regression fitness: `tests/unit/db/dynamodb-bulk-delete.test.ts` (Scan 0 回 / tenant 境界 /
+  UnprocessedItems retry / 冪等再開)。
 
 #### 原則 2: tenant 横断 Scan → GSI 移行の閾値
 
@@ -822,7 +834,7 @@ DynamoDB 実装 (`src/lib/server/db/dynamodb/sibling-cheer-repo.ts`) を持つ�
 | `findUnshownCheers(toChildId)` | Query（受信 child partition）+ in-memory filter | `PK = T#<tid>#CHILD#<toChildId> AND begins_with(SK, 'CHEER#')` で取得し `shown_at IS NULL` を filter |
 | `countTodayCheersFrom(fromChildId)` | Scan（`fromChildId` + `sentAt >= 当日00:00:00` filter） | 送信者軸の read（送信時 1 日上限 ≤5/日 チェック、低頻度）。データは受信 child partition に分散するため tenant Scan で集計。sentAt 比較は SQLite と同じ ISO 文字列辞書順 |
 | `markShown(cheerIds[])` | Scan（id filter）で PK/SK 解決 → 個別 UpdateItem | toChildId を受けないため id 集合で対象 item を tenant Scan 1 回で一括解決（message-repo / stamp-card-repo の id 解決 Scan と同型、overlay 表示直後の低頻度経路） |
-| `deleteByTenantId` | Scan → BatchWrite | `CHILD#*` 配下の `CHEER#` を削除（`deleteItemsByPkPrefix`） |
+| `deleteByTenantId` | child partition Query → BatchWrite（childIds 供給時。未供給時 Scan fallback、#3693） | `CHILD#*` 配下の `CHEER#` を削除（`deleteChildScopedItems`） |
 
 新規 SK prefix `CHEER#` は既存テーブルにそのまま乗るため **CDK 変更不要**（追加 GSI なし）。
 きょうだいおうえんは child 画面の `SiblingCheerOverlay` で active であり、本 repo は #2263 hotfix で
@@ -1459,7 +1471,7 @@ instance を child partition 配下に置き、`findRedemptionRequestsByChild` �
 | `findRedemptionRequestsByTenant` / `expireOldRedemptions` / `hasPendingByReward` | Scan（`begins_with(PK, T#<tid>#CHILD#)` + `begins_with(SK, REDEMPT#)`） | child partition に分散するため tenant 横断は Scan。親確認 / cron / 削除（低頻度）のみで GSI 不要（Pre-PMF / ADR-0010）。status / childId / limit は in-memory filter |
 | `updateRedemptionRequestStatus(childId, id)` / `markRedemptionResultShown(childId, id)` | composite key で UpdateItem 直接実行（`ALL_NEW` + `attribute_exists(PK)`） | #2845 課題①: childId + id で PK/SK を直接構成（Scan 不使用）。不一致は ConditionalCheckFailed → undefined。undefined はスキップ / null は明示 SET（SQLite `.set({...})` 等価） |
 | `findPendingByChildAndReward` / `findUnshownResultByChild` | Query（child partition）+ in-memory filter | 二重申請 / 未表示通知。後者は reward 結合フィールドを露出 |
-| `deleteByTenantId` | Scan → BatchWrite | `CHILD#*` 配下の `REDEMPT#` を削除（`deleteItemsByPkPrefix`） |
+| `deleteByTenantId` | child partition Query → BatchWrite（childIds 供給時。未供給時 Scan fallback、#3693） | `CHILD#*` 配下の `REDEMPT#` + `REDEMPTPEND#` を削除（`deleteChildScopedItems`） |
 
 **残高整合:** ポイント減算は service 層（`reward-redemption-service.approveRedemption`）が
 `insertPointEntry` で別途行う（SQLite と同じ責務分割）。本 repo は status 更新のみ担い残高に
@@ -1706,7 +1718,7 @@ GetItem 1 回で完結させる。entry は `findEntriesWithMasterByCardId(cardI
 | `findEntriesWithMasterByCardId(cardId)` | Query | `PK = T#<tid>#STMPCARD#<cardId> AND begins_with(SK, 'STMPENT#')`。slot 昇順 + master JOIN(name/emoji/rarity) は in-memory（LEFT JOIN miss は null、SQLite SSOT と一致） |
 | `insertEntry` | PutItem（`attribute_not_exists(PK)`） | SQLite onConflictDoNothing 等価（同 (cardId, slot) 既存なら no-op） |
 | `updateCardStatus(childId, id)` / `updateCardStatusIfCollecting(childId, id)` | child partition Query（id filter、全ページ走査）で PK/SK 解決 → UpdateItem | #2845 課題①: tenant + child 境界を KeyCondition で構造的に担保（tenant Scan 撤去）。後者は `ConditionExpression: #status = collecting` で冪等ガード（成功=1 / ConditionalCheckFailed=0、SQLite `result.changes` 等価） |
-| `deleteByTenantId` | Scan → BatchWrite（2 経路） | `CHILD#*` 配下の `STMPCARD#`（cards）と `STMPCARD#*` 配下の `STMPENT#`（entries）を削除（`deleteItemsByPkPrefix`） |
+| `deleteByTenantId` | cards = child partition Query（childIds 供給時、#3693）/ entries = Scan（cardId が PK 埋込で列挙不能のため維持） | `CHILD#*` 配下の `STMPCARD#`（cards、`deleteChildScopedItems`）と `STMPCARD#*` 配下の `STMPENT#`（entries、`deleteItemsByPkPrefix`） |
 
 新規 SK prefix `STMPCARD#` / `STMPENT#` は既存テーブルにそのまま乗るため **CDK 変更不要**
 （追加 GSI なし）。schema 自体に変更はなく DynamoDB 実装の追加のみ。
@@ -1764,7 +1776,7 @@ child partition 配下に置き、`findMessages` / `findUnshownMessage` / `count
 | `findMessages(childId, limit)` | Query | `PK = T<tid>#CHILD#<childId> AND begins_with(SK, 'MSG#')`。sent_at 降順（同値は id 降順 tiebreaker）+ limit は in-memory（SQLite SSOT と一致） |
 | `findUnshownMessage(childId)` / `countUnshownMessages(childId)` | Query（child partition）+ in-memory filter | `shown_at IS NULL` を filter。前者は最新 1 件、後者は件数 |
 | `markMessageShown(childId, messageId)` | composite key（`parentMessageKey`）で UpdateItem 直接実行（`ALL_NEW` + `attribute_exists(PK)`） | #2845 課題①: childId + messageId で PK/SK を直接構成（Scan 不使用）。不一致は ConditionalCheckFailed → undefined |
-| `deleteByTenantId` | Scan → BatchWrite | `CHILD#*` 配下の `MSG#` を削除（`deleteItemsByPkPrefix`） |
+| `deleteByTenantId` | child partition Query → BatchWrite（childIds 供給時。未供給時 Scan fallback、#3693） | `CHILD#*` 配下の `MSG#` を削除（`deleteChildScopedItems`） |
 
 新規 SK prefix `MSG#` は既存テーブルにそのまま乗るため **CDK 変更不要**（追加 GSI なし）。
 おうえんメッセージは LP (`feature-cheer-message`) が訴求する機能であり、本 repo は #2263 hotfix で

--- a/src/lib/server/db/dynamodb/activity-mastery-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-mastery-repo.ts
@@ -5,7 +5,7 @@ import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import type { ActivityId, ChildId } from '$lib/domain/ids';
 import { asActivityId, asChildId } from '$lib/domain/ids';
 import type { ActivityMastery } from '../types';
-import { deleteItemsByPkPrefix } from './bulk-delete';
+import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { activityMasteryKey, activityMasteryPrefix, childPK, tenantPK } from './keys';
 
@@ -89,7 +89,10 @@ export async function upsert(
 	return toActivityMastery(item);
 }
 
-/** テナントの全活動習熟度を削除（CHILD#* パーティション配下の MAST# アイテム） */
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), activityMasteryPrefix());
+/** テナントの全活動習熟度を削除（CHILD#* パーティション配下の MAST# アイテム、#3693: childIds 指定時は Query 化） */
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	await deleteChildScopedItems(tenantId, childIds, activityMasteryPrefix());
 }

--- a/src/lib/server/db/dynamodb/activity-mastery-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-mastery-repo.ts
@@ -7,7 +7,7 @@ import { asActivityId, asChildId } from '$lib/domain/ids';
 import type { ActivityMastery } from '../types';
 import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
-import { activityMasteryKey, activityMasteryPrefix, childPK, tenantPK } from './keys';
+import { activityMasteryKey, activityMasteryPrefix, childPK } from './keys';
 
 function stripKeys<T extends Record<string, unknown>>(
 	item: T,

--- a/src/lib/server/db/dynamodb/activity-pref-repo.ts
+++ b/src/lib/server/db/dynamodb/activity-pref-repo.ts
@@ -5,7 +5,7 @@ import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import type { ActivityId, CategoryId, ChildId } from '$lib/domain/ids';
 import { asActivityId, asChildId } from '$lib/domain/ids';
 import type { ActivityUsageCount, ChildActivityPreference } from '../types';
-import { deleteItemsByPkPrefix } from './bulk-delete';
+import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { activityLogPrefix, activityPrefKey, activityPrefPrefix, childPK, tenantPK } from './keys';
 
@@ -216,6 +216,9 @@ export async function getUsageCounts(
 }
 
 /** テナントの全活動ピン留め設定を削除（CHILD#* 配下の ACTPREF# アイテム） */
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), activityPrefPrefix());
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	await deleteChildScopedItems(tenantId, childIds, activityPrefPrefix());
 }

--- a/src/lib/server/db/dynamodb/bulk-delete.ts
+++ b/src/lib/server/db/dynamodb/bulk-delete.ts
@@ -1,14 +1,76 @@
 // src/lib/server/db/dynamodb/bulk-delete.ts
-// Shared utility for bulk-deleting DynamoDB items by PK prefix (tenant data cleanup).
+// Shared utility for bulk-deleting DynamoDB items (tenant data cleanup).
+//
+// #3693: アカウント削除 / data 全削除の deleteByTenantId 群 (約 25 呼び出し) が
+// 全テーブル Scan に fan-out し、read 量が全テナント総量に比例して Lambda 30s /
+// API GW 504 (restore 504 #3692 と同 class) に到達する問題への是正。
+//
+// - childIds が既知の経路 (tenant-cleanup-service) は `deleteChildScopedItems` で
+//   child partition への Query に置換する (read が自 tenant のデータ量にのみ比例)。
+// - childIds が得られない経路は従来どおり Scan fallback (`deleteItemsByPkPrefix`) で
+//   削除完全性を優先する (退会 = 法的要請を伴う CUJ のため取り漏らし禁止)。
+// - 全経路とも page 単位の streaming 削除 (収集完了を待たず削除) + BatchWrite
+//   UnprocessedItems の retry で、途中失敗しても再実行で残存が消える (冪等再開)。
 
-import { BatchWriteCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
+import { BatchWriteCommand, QueryCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
+import type { ChildId } from '$lib/domain/ids';
 import { getDocClient, TABLE_NAME } from './client';
+import { childPK } from './keys';
 
+/** BatchWriteItem の上限 (DynamoDB 仕様) */
 const BATCH_SIZE = 25;
+/** child partition Query の同時実行数 (#3693: 表ごと独立のため並列可、過剰 burst は避ける) */
+const CHILD_QUERY_CONCURRENCY = 5;
+/** UnprocessedItems retry 上限。超過時は throw (silent partial delete 禁止) */
+const UNPROCESSED_RETRY_LIMIT = 5;
+const UNPROCESSED_RETRY_BASE_MS = 25;
+
+type ItemKey = { PK: string; SK: string };
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * keys を 25 件ずつ BatchWrite で削除する。
+ * UnprocessedItems は指数 backoff で retry し、上限超過時は throw する
+ * (握りつぶすと退会 / data 全削除で取り漏らしが silent に残るため)。
+ */
+async function batchDeleteKeys(keys: ItemKey[]): Promise<void> {
+	const doc = getDocClient();
+	for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+		let requests = keys.slice(i, i + BATCH_SIZE).map((key) => ({
+			DeleteRequest: { Key: key },
+		}));
+		let attempt = 0;
+		while (requests.length > 0) {
+			const result = await doc.send(
+				new BatchWriteCommand({
+					RequestItems: { [TABLE_NAME]: requests },
+				}),
+			);
+			const unprocessed = (result.UnprocessedItems?.[TABLE_NAME] ?? []) as typeof requests;
+			if (unprocessed.length === 0) break;
+			attempt++;
+			if (attempt > UNPROCESSED_RETRY_LIMIT) {
+				throw new Error(
+					`[bulk-delete] BatchWrite unprocessed items remain after ${UNPROCESSED_RETRY_LIMIT} retries (${unprocessed.length} keys)`,
+				);
+			}
+			await sleep(UNPROCESSED_RETRY_BASE_MS * 2 ** (attempt - 1));
+			requests = unprocessed;
+		}
+	}
+}
 
 /**
  * Scan for all items whose PK begins with `pkPrefix` and batch-delete them.
  * Handles pagination (LastEvaluatedKey) and batching (25 items per BatchWrite).
+ *
+ * ⚠️ 全テーブル Scan のため read 量が全テナント総量に比例する (#3693)。
+ * child partition の PK (`T#<t>#CHILD#<id>`) が既知なら `deleteChildScopedItems` /
+ * `deleteItemsByExactPk` を使うこと。本関数は PK に埋まる ID を列挙できない
+ * エンティティ (CKTPL#<tplId> / STMPCARD#<cardId> 等) と fallback 専用。
  *
  * @param pkPrefix - The PK prefix to match, e.g. `T#<tenantId>#CHILD#`
  * @param skPrefix - Optional SK prefix to further narrow the scan
@@ -16,7 +78,7 @@ const BATCH_SIZE = 25;
  */
 export async function deleteItemsByPkPrefix(pkPrefix: string, skPrefix?: string): Promise<number> {
 	const doc = getDocClient();
-	const allKeys: Array<{ PK: string; SK: string }> = [];
+	let deleted = 0;
 	let lastKey: Record<string, unknown> | undefined;
 
 	const filterParts = ['begins_with(PK, :pkPrefix)'];
@@ -38,71 +100,90 @@ export async function deleteItemsByPkPrefix(pkPrefix: string, skPrefix?: string)
 			}),
 		);
 
-		for (const item of result.Items ?? []) {
-			allKeys.push({ PK: item.PK as string, SK: item.SK as string });
-		}
+		const keys = (result.Items ?? []).map((item) => ({
+			PK: item.PK as string,
+			SK: item.SK as string,
+		}));
+		// streaming: page 単位で即削除 (10 万行 scale でも全 key をメモリ滞留させない +
+		// 途中失敗時も削除済み分は確定し、再実行で残存だけを消せる)
+		await batchDeleteKeys(keys);
+		deleted += keys.length;
 		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
 	} while (lastKey);
 
-	// Batch delete in chunks of 25
-	for (let i = 0; i < allKeys.length; i += BATCH_SIZE) {
-		const batch = allKeys.slice(i, i + BATCH_SIZE);
-		await doc.send(
-			new BatchWriteCommand({
-				RequestItems: {
-					[TABLE_NAME]: batch.map((key) => ({
-						DeleteRequest: { Key: key },
-					})),
-				},
-			}),
-		);
-	}
-
-	return allKeys.length;
+	return deleted;
 }
 
 /**
- * Delete all items whose PK exactly matches a single value.
- * Uses Query (more efficient than Scan) when we know the full PK.
+ * Delete all items under a single exact PK via Query (no table Scan).
  *
  * @param pk - The exact PK value
+ * @param skPrefix - Optional SK prefix (`begins_with`) to narrow the deletion
  * @returns The number of items deleted
  */
-export async function deleteItemsByExactPk(pk: string): Promise<number> {
-	const { QueryCommand } = await import('@aws-sdk/lib-dynamodb');
+export async function deleteItemsByExactPk(pk: string, skPrefix?: string): Promise<number> {
 	const doc = getDocClient();
-	const allKeys: Array<{ PK: string; SK: string }> = [];
+	let deleted = 0;
 	let lastKey: Record<string, unknown> | undefined;
+
+	const keyCondParts = ['PK = :pk'];
+	const exprValues: Record<string, unknown> = { ':pk': pk };
+	if (skPrefix) {
+		keyCondParts.push('begins_with(SK, :skPrefix)');
+		exprValues[':skPrefix'] = skPrefix;
+	}
 
 	do {
 		const result = await doc.send(
 			new QueryCommand({
 				TableName: TABLE_NAME,
-				KeyConditionExpression: 'PK = :pk',
-				ExpressionAttributeValues: { ':pk': pk },
+				KeyConditionExpression: keyCondParts.join(' AND '),
+				ExpressionAttributeValues: exprValues,
 				ProjectionExpression: 'PK, SK',
 				ExclusiveStartKey: lastKey,
 			}),
 		);
 
-		for (const item of result.Items ?? []) {
-			allKeys.push({ PK: item.PK as string, SK: item.SK as string });
-		}
+		const keys = (result.Items ?? []).map((item) => ({
+			PK: item.PK as string,
+			SK: item.SK as string,
+		}));
+		await batchDeleteKeys(keys);
+		deleted += keys.length;
 		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
 	} while (lastKey);
 
-	for (let i = 0; i < allKeys.length; i += BATCH_SIZE) {
-		const batch = allKeys.slice(i, i + BATCH_SIZE);
-		await doc.send(
-			new BatchWriteCommand({
-				RequestItems: {
-					[TABLE_NAME]: batch.map((key) => ({
-						DeleteRequest: { Key: key },
-					})),
-				},
-			}),
-		);
+	return deleted;
+}
+
+/**
+ * child partition (`T#<tenantId>#CHILD#<childId>`) 配下の items を SK prefix で削除する。
+ *
+ * #3693: childIds が与えられた場合は child ごとの Query (並列 chunk) で削除し、
+ * 全テーブル Scan を回避する。childIds が undefined の場合 (呼び出し元が children を
+ * 列挙できなかった場合) は Scan fallback で削除完全性を優先する。
+ *
+ * @param tenantId - 対象テナント
+ * @param childIds - 対象テナントの全児童 ID (archived 含む)。undefined で Scan fallback
+ * @param skPrefix - SK prefix (`begins_with`)。省略時は child partition 全件
+ * @returns The number of items deleted
+ */
+export async function deleteChildScopedItems(
+	tenantId: string,
+	childIds: readonly ChildId[] | undefined,
+	skPrefix?: string,
+): Promise<number> {
+	if (!childIds) {
+		return deleteItemsByPkPrefix(`T#${tenantId}#CHILD#`, skPrefix);
 	}
 
-	return allKeys.length;
+	let deleted = 0;
+	for (let i = 0; i < childIds.length; i += CHILD_QUERY_CONCURRENCY) {
+		const chunk = childIds.slice(i, i + CHILD_QUERY_CONCURRENCY);
+		const results = await Promise.all(
+			chunk.map((childId) => deleteItemsByExactPk(childPK(Number(childId), tenantId), skPrefix)),
+		);
+		for (const count of results) deleted += count;
+	}
+	return deleted;
 }

--- a/src/lib/server/db/dynamodb/certificate-repo.ts
+++ b/src/lib/server/db/dynamodb/certificate-repo.ts
@@ -187,9 +187,12 @@ export async function insertForRestore(
 // deleteByTenantId — テナントの全証明書を削除 (#3329)
 // ============================================================
 
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), PREFIX);
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	const { deleteChildScopedItems } = await import('./bulk-delete');
+	await deleteChildScopedItems(tenantId, childIds, PREFIX);
 }
 
 // ============================================================

--- a/src/lib/server/db/dynamodb/checklist-repo.ts
+++ b/src/lib/server/db/dynamodb/checklist-repo.ts
@@ -31,7 +31,7 @@ import type {
 	UpdateChecklistTemplateInput,
 	UpsertChecklistLogInput,
 } from '../types';
-import { deleteItemsByPkPrefix } from './bulk-delete';
+import { deleteChildScopedItems, deleteItemsByPkPrefix } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -765,14 +765,16 @@ export async function deleteOverride(
  * - T#<tenantId>#CKTPL#<tplId> 配下: ITEM# (item) / ASSIGN# (assignment)
  * - CHILD#* 配下: CKLOG# (ログ), CKOVER# (override)
  */
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	// Templates 本体
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	// Templates 本体 + Items/Assignments (#3693: PK=T#<t>#CKTPL と T#<t>#CKTPL#<tplId> は
+	// 同一 begins_with prefix のため 1 Scan に統合。tplId は PK 埋込で列挙不能のため Scan 継続)
 	await deleteItemsByPkPrefix(tenantPK('CKTPL', tenantId));
-	// Items + Assignments (PK=T#<tenantId>#CKTPL#*)
-	await deleteItemsByPkPrefix(tenantPK('CKTPL#', tenantId));
 	// Logs / Overrides (CHILD#* 配下)
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), checklistLogPrefix());
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), checklistOverridePrefix());
+	await deleteChildScopedItems(tenantId, childIds, checklistLogPrefix());
+	await deleteChildScopedItems(tenantId, childIds, checklistOverridePrefix());
 }
 
 // ============================================================

--- a/src/lib/server/db/dynamodb/daily-mission-repo.ts
+++ b/src/lib/server/db/dynamodb/daily-mission-repo.ts
@@ -11,7 +11,7 @@ import {
 import type { ActivityId, ChildId } from '$lib/domain/ids';
 import { asActivityId, asCategoryId } from '$lib/domain/ids';
 import type { Activity, DailyMissionWithActivity } from '../types';
-import { deleteItemsByPkPrefix } from './bulk-delete';
+import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -330,6 +330,9 @@ export async function insertDailyMission(
 }
 
 /** テナントの全デイリーミッションを削除（CHILD#* 配下の MISSION# アイテム） */
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), dailyMissionPrefix());
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	await deleteChildScopedItems(tenantId, childIds, dailyMissionPrefix());
 }

--- a/src/lib/server/db/dynamodb/evaluation-repo.ts
+++ b/src/lib/server/db/dynamodb/evaluation-repo.ts
@@ -12,7 +12,7 @@ import type {
 	InsertEvaluationInput,
 	RestDay,
 } from '../types';
-import { deleteItemsByPkPrefix } from './bulk-delete';
+import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -300,6 +300,9 @@ export async function insertRestDayForRestore(
 }
 
 /** テナントの全評価データを削除（CHILD#* 配下の EVAL# アイテム） */
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), evaluationPrefix());
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	await deleteChildScopedItems(tenantId, childIds, evaluationPrefix());
 }

--- a/src/lib/server/db/dynamodb/image-repo.ts
+++ b/src/lib/server/db/dynamodb/image-repo.ts
@@ -5,7 +5,7 @@ import { GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type { ChildId } from '$lib/domain/ids';
 import { asChildId } from '$lib/domain/ids';
 import type { CharacterImage, InsertCharacterImageInput } from '../types';
-import { deleteItemsByPkPrefix } from './bulk-delete';
+import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import { characterImageKey, characterImagePrefix, childKey, ENTITY_NAMES, tenantPK } from './keys';
@@ -97,6 +97,9 @@ export async function updateChildAvatarUrl(
 }
 
 /** テナントの全キャラクター画像レコードを削除（CHILD#* 配下の IMG# アイテム） */
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), characterImagePrefix());
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	await deleteChildScopedItems(tenantId, childIds, characterImagePrefix());
 }

--- a/src/lib/server/db/dynamodb/image-repo.ts
+++ b/src/lib/server/db/dynamodb/image-repo.ts
@@ -8,7 +8,7 @@ import type { CharacterImage, InsertCharacterImageInput } from '../types';
 import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
-import { characterImageKey, characterImagePrefix, childKey, ENTITY_NAMES, tenantPK } from './keys';
+import { characterImageKey, characterImagePrefix, childKey, ENTITY_NAMES } from './keys';
 import { stripKeys } from './repo-helpers';
 
 // biome-ignore lint/performance/noBarrelFile: 後方互換 re-export のため維持、削除は別 Issue で検討

--- a/src/lib/server/db/dynamodb/login-bonus-repo.ts
+++ b/src/lib/server/db/dynamodb/login-bonus-repo.ts
@@ -5,7 +5,7 @@ import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import type { ChildId } from '$lib/domain/ids';
 import { asChildId } from '$lib/domain/ids';
 import type { InsertLoginBonusInput, LoginBonus } from '../types';
-import { deleteItemsByPkPrefix } from './bulk-delete';
+import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import { childPK, ENTITY_NAMES, loginBonusKey, loginBonusPrefix, tenantPK } from './keys';
@@ -104,8 +104,11 @@ export async function insertLoginBonus(
 }
 
 /** テナントの全ログインボーナスを削除（CHILD#* 配下の LOGIN# アイテム） */
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), loginBonusPrefix());
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	await deleteChildScopedItems(tenantId, childIds, loginBonusPrefix());
 }
 
 // ============================================================

--- a/src/lib/server/db/dynamodb/login-bonus-repo.ts
+++ b/src/lib/server/db/dynamodb/login-bonus-repo.ts
@@ -8,7 +8,7 @@ import type { InsertLoginBonusInput, LoginBonus } from '../types';
 import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
-import { childPK, ENTITY_NAMES, loginBonusKey, loginBonusPrefix, tenantPK } from './keys';
+import { childPK, ENTITY_NAMES, loginBonusKey, loginBonusPrefix } from './keys';
 import { batchDeleteItems, stripKeys } from './repo-helpers';
 
 // stored item は数値 id のまま (storage format 不変、#3575)。repo 境界で branded string に変換する。

--- a/src/lib/server/db/dynamodb/message-repo.ts
+++ b/src/lib/server/db/dynamodb/message-repo.ts
@@ -194,9 +194,12 @@ export async function markMessageShown(
 // deleteByTenantId — テナントの全メッセージを削除
 // ============================================================
 
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), PREFIX);
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	const { deleteChildScopedItems } = await import('./bulk-delete');
+	await deleteChildScopedItems(tenantId, childIds, PREFIX);
 }
 
 // ============================================================

--- a/src/lib/server/db/dynamodb/message-repo.ts
+++ b/src/lib/server/db/dynamodb/message-repo.ts
@@ -25,7 +25,7 @@ import { asChildId } from '$lib/domain/ids';
 import type { InsertParentMessageInput, ParentMessage } from '../types';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
-import { childPK, ENTITY_NAMES, parentMessageKey, parentMessagePrefix, tenantPK } from './keys';
+import { childPK, ENTITY_NAMES, parentMessageKey, parentMessagePrefix } from './keys';
 import { stripKeys } from './repo-helpers';
 
 const PREFIX = parentMessagePrefix();

--- a/src/lib/server/db/dynamodb/point-repo.ts
+++ b/src/lib/server/db/dynamodb/point-repo.ts
@@ -21,7 +21,6 @@ import {
 	pointLedgerIdempotencyKey,
 	pointLedgerKey,
 	pointLedgerPrefix,
-	tenantPK,
 } from './keys';
 import { batchDeleteItems, stripKeys } from './repo-helpers';
 

--- a/src/lib/server/db/dynamodb/point-repo.ts
+++ b/src/lib/server/db/dynamodb/point-repo.ts
@@ -11,7 +11,7 @@ import {
 import type { ChildId } from '$lib/domain/ids';
 import { asChildId } from '$lib/domain/ids';
 import type { InsertPointLedgerInput, PointLedgerEntry } from '../types';
-import { deleteItemsByPkPrefix } from './bulk-delete';
+import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -246,13 +246,16 @@ export async function spendPointsAtomic(
 }
 
 /** テナントの全ポイント台帳・残高を削除（CHILD#* 配下の POINT# + POINTIDEM# + BALANCE アイテム） */
-export async function deleteByTenantId(tenantId: string): Promise<void> {
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
 	// Delete point ledger entries (POINT#...)
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), pointLedgerPrefix());
+	await deleteChildScopedItems(tenantId, childIds, pointLedgerPrefix());
 	// Delete idempotency markers (POINTIDEM#..., #3284)
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), 'POINTIDEM#');
+	await deleteChildScopedItems(tenantId, childIds, 'POINTIDEM#');
 	// Delete balance records (BALANCE)
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), 'BALANCE');
+	await deleteChildScopedItems(tenantId, childIds, 'BALANCE');
 }
 
 // ============================================================

--- a/src/lib/server/db/dynamodb/reward-redemption-repo.ts
+++ b/src/lib/server/db/dynamodb/reward-redemption-repo.ts
@@ -558,11 +558,12 @@ export const hasPendingByReward: IRewardRedemptionRepo['hasPendingByReward'] = a
 
 export const deleteByTenantId: IRewardRedemptionRepo['deleteByTenantId'] = async (
 	tenantId,
+	childIds,
 ): Promise<void> => {
-	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), PREFIX);
+	const { deleteChildScopedItems } = await import('./bulk-delete');
+	await deleteChildScopedItems(tenantId, childIds, PREFIX);
 	// #3356 (1): pending marker (REDEMPTPEND#) も併せて削除
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), 'REDEMPTPEND#');
+	await deleteChildScopedItems(tenantId, childIds, 'REDEMPTPEND#');
 };
 
 // ============================================================

--- a/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
+++ b/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
@@ -213,9 +213,12 @@ export async function countTodayCheersFrom(
 // deleteByTenantId — テナントの全おうえんを削除
 // ============================================================
 
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), PREFIX);
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	const { deleteChildScopedItems } = await import('./bulk-delete');
+	await deleteChildScopedItems(tenantId, childIds, PREFIX);
 }
 
 // ============================================================

--- a/src/lib/server/db/dynamodb/special-reward-repo.ts
+++ b/src/lib/server/db/dynamodb/special-reward-repo.ts
@@ -6,7 +6,7 @@ import type { ChildId } from '$lib/domain/ids';
 import { asChildId } from '$lib/domain/ids';
 import type { UpdateSpecialRewardInput } from '../interfaces/special-reward-repo.interface';
 import type { InsertSpecialRewardInput, SpecialReward } from '../types';
-import { deleteItemsByPkPrefix } from './bulk-delete';
+import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -337,6 +337,9 @@ export async function deleteSpecialReward(
 }
 
 /** テナントの全特別報酬を削除（CHILD#* 配下の REWARD# アイテム） */
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), specialRewardPrefix());
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	await deleteChildScopedItems(tenantId, childIds, specialRewardPrefix());
 }

--- a/src/lib/server/db/dynamodb/special-reward-repo.ts
+++ b/src/lib/server/db/dynamodb/special-reward-repo.ts
@@ -15,7 +15,6 @@ import {
 	rewardRedemptionPrefix,
 	specialRewardKey,
 	specialRewardPrefix,
-	tenantPK,
 } from './keys';
 
 /** Strip PK/SK/GSI keys from a DynamoDB item */

--- a/src/lib/server/db/dynamodb/stamp-card-repo.ts
+++ b/src/lib/server/db/dynamodb/stamp-card-repo.ts
@@ -417,11 +417,15 @@ export async function updateCardStatusIfCollecting(
 // deleteByTenantId — テナントの全カード・エントリを削除
 // ============================================================
 
-export async function deleteByTenantId(tenantId: string): Promise<void> {
-	const { deleteItemsByPkPrefix } = await import('./bulk-delete');
-	// cards: child partition 配下の STMPCARD# item。
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), CARD_PREFIX);
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
+	const { deleteChildScopedItems, deleteItemsByPkPrefix } = await import('./bulk-delete');
+	// cards: child partition 配下の STMPCARD# item (#3693: childIds 指定時は Query 化)。
+	await deleteChildScopedItems(tenantId, childIds, CARD_PREFIX);
 	// entries: 専用 STMPCARD#<cardId> partition 配下の STMPENT# item。
+	// cardId は PK 埋込で列挙不能のため Scan 継続 (#3693: tenant あたり 1 Scan のみ)。
 	await deleteItemsByPkPrefix(tenantPK('STMPCARD#', tenantId), ENTRY_PREFIX);
 }
 

--- a/src/lib/server/db/dynamodb/status-repo.ts
+++ b/src/lib/server/db/dynamodb/status-repo.ts
@@ -34,7 +34,6 @@ import {
 	statusHistoryPrefix,
 	statusKey,
 	statusPrefix,
-	tenantPK,
 } from './keys';
 import { queryAllItems, stripKeys } from './repo-helpers';
 

--- a/src/lib/server/db/dynamodb/status-repo.ts
+++ b/src/lib/server/db/dynamodb/status-repo.ts
@@ -19,7 +19,7 @@ import type {
 	Status,
 	StatusHistoryEntry,
 } from '../types';
-import { deleteItemsByPkPrefix } from './bulk-delete';
+import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -445,9 +445,12 @@ export async function findLastActivityDates(
  * テナントの全ステータスデータを削除（CHILD#* 配下の STATUS# + STATHIST# アイテム）。
  * market_benchmarks はグローバルなマスターデータのため削除しない。
  */
-export async function deleteByTenantId(tenantId: string): Promise<void> {
+export async function deleteByTenantId(
+	tenantId: string,
+	childIds?: readonly ChildId[],
+): Promise<void> {
 	// Delete status records (STATUS#...)
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), statusPrefix());
+	await deleteChildScopedItems(tenantId, childIds, statusPrefix());
 	// Delete status history records (STATHIST#...)
-	await deleteItemsByPkPrefix(tenantPK('CHILD#', tenantId), statusHistoryPrefix());
+	await deleteChildScopedItems(tenantId, childIds, statusHistoryPrefix());
 }

--- a/src/lib/server/db/interfaces/activity-mastery-repo.interface.ts
+++ b/src/lib/server/db/interfaces/activity-mastery-repo.interface.ts
@@ -15,5 +15,5 @@ export interface IActivityMasteryRepo {
 		level: number,
 		tenantId: string,
 	): Promise<ActivityMastery>;
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/activity-pref-repo.interface.ts
+++ b/src/lib/server/db/interfaces/activity-pref-repo.interface.ts
@@ -37,5 +37,5 @@ export interface IActivityPrefRepo {
 		sinceDate: string,
 		tenantId: string,
 	): Promise<ActivityUsageCount[]>;
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/certificate-repo.interface.ts
+++ b/src/lib/server/db/interfaces/certificate-repo.interface.ts
@@ -27,5 +27,5 @@ export interface ICertificateRepo {
 	): Promise<Certificate | null>;
 
 	/** #3329: テナントの全証明書を削除 (clear / テナント削除時。child_id は no-cascade のため明示削除が必要)。 */
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/checklist-repo.interface.ts
+++ b/src/lib/server/db/interfaces/checklist-repo.interface.ts
@@ -157,5 +157,5 @@ export interface IChecklistRepo {
 
 	// ── Tenant bulk deletion ────────────────────────────────────────
 
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/daily-mission-repo.interface.ts
+++ b/src/lib/server/db/interfaces/daily-mission-repo.interface.ts
@@ -55,5 +55,5 @@ export interface IDailyMissionRepo {
 		activityId: ActivityId,
 		tenantId: string,
 	): Promise<void>;
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/evaluation-repo.interface.ts
+++ b/src/lib/server/db/interfaces/evaluation-repo.interface.ts
@@ -49,5 +49,5 @@ export interface IEvaluationRepo {
 		tenantId: string,
 	): Promise<RestDay | undefined>;
 
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/image-repo.interface.ts
+++ b/src/lib/server/db/interfaces/image-repo.interface.ts
@@ -11,5 +11,5 @@ export interface IImageRepo {
 	insertCharacterImage(input: InsertCharacterImageInput, tenantId: string): Promise<void>;
 	updateChildAvatarUrl(childId: ChildId, avatarUrl: string | null, tenantId: string): Promise<void>;
 	findChildForImage(childId: ChildId, tenantId: string): Promise<Child | undefined>;
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/login-bonus-repo.interface.ts
+++ b/src/lib/server/db/interfaces/login-bonus-repo.interface.ts
@@ -10,7 +10,7 @@ export interface ILoginBonusRepo {
 	findRecentBonuses(childId: ChildId, tenantId: string, limit?: number): Promise<LoginBonus[]>;
 	insertLoginBonus(input: InsertLoginBonusInput, tenantId: string): Promise<LoginBonus>;
 	findChildById(id: ChildId, tenantId: string): Promise<Child | undefined>;
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 
 	// Retention cleanup (#717, #729)
 	/**

--- a/src/lib/server/db/interfaces/message-repo.interface.ts
+++ b/src/lib/server/db/interfaces/message-repo.interface.ts
@@ -33,5 +33,5 @@ export interface IMessageRepo {
 		messageId: string,
 		tenantId: string,
 	): Promise<ParentMessage | undefined>;
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/point-repo.interface.ts
+++ b/src/lib/server/db/interfaces/point-repo.interface.ts
@@ -25,7 +25,7 @@ export interface IPointRepo {
 		tenantId: string,
 	): Promise<PointLedgerEntry | { error: 'INSUFFICIENT_POINTS' }>;
 	findChildById(id: ChildId, tenantId: string): Promise<Child | undefined>;
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 
 	// Retention cleanup (#717, #729)
 	/**

--- a/src/lib/server/db/interfaces/reward-redemption-repo.interface.ts
+++ b/src/lib/server/db/interfaces/reward-redemption-repo.interface.ts
@@ -133,5 +133,5 @@ export interface IRewardRedemptionRepo {
 
 	hasPendingByReward(rewardId: string, tenantId: string): Promise<boolean>;
 
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/sibling-cheer-repo.interface.ts
+++ b/src/lib/server/db/interfaces/sibling-cheer-repo.interface.ts
@@ -26,5 +26,5 @@ export interface ISiblingCheerRepo {
 	findUnshownCheers(toChildId: ChildId, tenantId: string): Promise<SiblingCheer[]>;
 	markShown(cheerIds: string[], tenantId: string): Promise<void>;
 	countTodayCheersFrom(fromChildId: ChildId, tenantId: string): Promise<number>;
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/special-reward-repo.interface.ts
+++ b/src/lib/server/db/interfaces/special-reward-repo.interface.ts
@@ -42,5 +42,5 @@ export interface ISpecialRewardRepo {
 	 * #2845 課題①: childId 所有権検証付き。
 	 */
 	deleteSpecialReward(childId: ChildId, rewardId: string, tenantId: string): Promise<boolean>;
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/stamp-card-repo.interface.ts
+++ b/src/lib/server/db/interfaces/stamp-card-repo.interface.ts
@@ -81,5 +81,5 @@ export interface IStampCardRepo {
 		input: UpdateStampCardStatusInput,
 		tenantId: string,
 	): Promise<number>;
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/interfaces/status-repo.interface.ts
+++ b/src/lib/server/db/interfaces/status-repo.interface.ts
@@ -62,5 +62,5 @@ export interface IStatusRepo {
 		childId: ChildId,
 		tenantId: string,
 	): Promise<{ category: number | string; lastDate: string | null }[]>;
-	deleteByTenantId(tenantId: string): Promise<void>;
+	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/services/tenant-cleanup-service.ts
+++ b/src/lib/server/services/tenant-cleanup-service.ts
@@ -35,6 +35,7 @@
 //     → 上記に加えて メンバーシップ / 招待 / Cognito / tenant レコード
 //        も削除する（`fullTenantDeletion` で実装）
 
+import type { ChildId } from '$lib/domain/ids';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { invalidateRequestCaches } from '$lib/server/request-context';
@@ -99,11 +100,30 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 	let deleted = 0;
 	const r = repos();
 
+	// #3693: 児童一覧を先頭で 1 回だけ解決し、以降の per-child ループと
+	// DynamoDB backend の deleteByTenantId 群 (child partition Query 化) で共有する。
+	// childIds には archived 児童も含める (旧 Scan 実装の削除範囲と同一に保つ)。
+	// 列挙に失敗した場合は childIds を undefined のまま渡し、各 repo の Scan fallback で
+	// 削除完全性を優先する (退会 = 法的要請を伴う CUJ のため取り漏らし禁止)。
+	// 児童 0 人時も undefined (orphan child partition の残骸まで Scan で拾う)。
+	let children: Awaited<ReturnType<typeof r.child.findAllChildren>> = [];
+	let childIds: readonly ChildId[] | undefined;
+	try {
+		const [activeChildren, archivedChildren] = await Promise.all([
+			r.child.findAllChildren(tenantId),
+			r.child.findArchivedChildren(tenantId),
+		]);
+		children = activeChildren;
+		const all = [...activeChildren, ...archivedChildren];
+		childIds = all.length > 0 ? all.map((c) => c.id) : undefined;
+	} catch (err) {
+		logger.warn(`[tenant-cleanup] children 列挙失敗 (Scan fallback で継続): ${String(err)}`);
+	}
+
 	// Activities (#2362 PR-3 / ADR-0055): per-child instance loop
 	// 旧 tenant-wide enumeration を child loop + per-child deleteActivity(id, childId, tenantId) に置換。
 	// 旧 activities table drop (Phase 7b-2) 後、child cascade delete に委譲予定。
 	try {
-		const children = await r.child.findAllChildren(tenantId);
 		for (const child of children) {
 			const activities = await r.childActivity.findActivitiesByChild(child.id, tenantId, {
 				includeArchived: true,
@@ -150,9 +170,8 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 		logger.warn(`[tenant-cleanup] pushSubscriptions 削除失敗: ${String(err)}`);
 	}
 
-	// Voice（子供ごとに deleteByChild 可能）
+	// Voice（子供ごとに deleteByChild 可能。#3693: 先頭で解決済みの children を再利用）
 	try {
-		const children = await r.child.findAllChildren(tenantId);
 		for (const child of children) {
 			await r.voice.deleteByChild(child.id, tenantId);
 			deleted++;
@@ -171,7 +190,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Checklists（templates, items, logs, overrides）
 	try {
-		await r.checklist.deleteByTenantId(tenantId);
+		await r.checklist.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] checklists 削除失敗: ${String(err)}`);
@@ -179,7 +198,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Daily missions
 	try {
-		await r.dailyMission.deleteByTenantId(tenantId);
+		await r.dailyMission.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] dailyMissions 削除失敗: ${String(err)}`);
@@ -187,7 +206,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Evaluations（evaluations + rest_days）
 	try {
-		await r.evaluation.deleteByTenantId(tenantId);
+		await r.evaluation.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] evaluations 削除失敗: ${String(err)}`);
@@ -195,7 +214,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Points（point_ledger）
 	try {
-		await r.point.deleteByTenantId(tenantId);
+		await r.point.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] points 削除失敗: ${String(err)}`);
@@ -203,7 +222,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Stamp cards + entries
 	try {
-		await r.stampCard.deleteByTenantId(tenantId);
+		await r.stampCard.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] stampCards 削除失敗: ${String(err)}`);
@@ -211,7 +230,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Status（statuses + status_history + market_benchmarks）
 	try {
-		await r.status.deleteByTenantId(tenantId);
+		await r.status.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] status 削除失敗: ${String(err)}`);
@@ -219,7 +238,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Login bonuses
 	try {
-		await r.loginBonus.deleteByTenantId(tenantId);
+		await r.loginBonus.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] loginBonus 削除失敗: ${String(err)}`);
@@ -229,7 +248,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 	// special_rewards 削除より先に消す。残すと special_rewards 削除が FK で失敗し、さらに
 	// special_rewards.child_id (no cascade) が children 削除も阻む (replace import で子ごと喪失)。
 	try {
-		await r.rewardRedemption.deleteByTenantId(tenantId);
+		await r.rewardRedemption.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] rewardRedemption 削除失敗: ${String(err)}`);
@@ -237,7 +256,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Special rewards
 	try {
-		await r.specialReward.deleteByTenantId(tenantId);
+		await r.specialReward.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] specialReward 削除失敗: ${String(err)}`);
@@ -246,7 +265,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 	// #3329: 証明書 (certificates)。child_id が no-cascade のため children 削除より先に明示削除する
 	// (残すと children 削除が FK で失敗し replace import で子ごと喪失する。redemption と同型の修正)。
 	try {
-		await r.certificate.deleteByTenantId(tenantId);
+		await r.certificate.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] certificate 削除失敗: ${String(err)}`);
@@ -254,7 +273,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Activity preferences（pin settings）
 	try {
-		await r.activityPref.deleteByTenantId(tenantId);
+		await r.activityPref.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] activityPref 削除失敗: ${String(err)}`);
@@ -262,7 +281,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Activity mastery
 	try {
-		await r.activityMastery.deleteByTenantId(tenantId);
+		await r.activityMastery.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] activityMastery 削除失敗: ${String(err)}`);
@@ -270,7 +289,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Parent messages
 	try {
-		await r.message.deleteByTenantId(tenantId);
+		await r.message.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] message 削除失敗: ${String(err)}`);
@@ -294,7 +313,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Sibling cheers
 	try {
-		await r.siblingCheer.deleteByTenantId(tenantId);
+		await r.siblingCheer.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] siblingCheer 削除失敗: ${String(err)}`);
@@ -315,7 +334,7 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 
 	// Character images
 	try {
-		await r.image.deleteByTenantId(tenantId);
+		await r.image.deleteByTenantId(tenantId, childIds);
 		deleted++;
 	} catch (err) {
 		logger.warn(`[tenant-cleanup] image 削除失敗: ${String(err)}`);

--- a/tests/unit/db/dynamodb-bulk-delete.test.ts
+++ b/tests/unit/db/dynamodb-bulk-delete.test.ts
@@ -1,0 +1,363 @@
+/**
+ * tests/unit/db/dynamodb-bulk-delete.test.ts
+ *
+ * #3693: アカウント削除 / data 全削除の全テーブル Scan → tenant-scoped Query 化の regression test。
+ *
+ * 旧実装は deleteByTenantId 群 (約 25 呼び出し) の大半が `deleteItemsByPkPrefix` =
+ * **テーブル全体 Scan (FilterExpression) + 逐次 BatchWrite** で、read 量が
+ * 全テナント総量に比例して線形悪化し、退会 CUJ が Lambda 30s / API GW 504 に到達する
+ * (restore 504 #3692 と同 class)。本テストは in-memory fake DynamoDB DocumentClient で
+ * 以下を fitness 化する:
+ *
+ * - AC2: childIds が与えられた場合、child partition への Query のみで削除し Scan 0 回
+ *        (read が対象 tenant のデータ量にのみ比例し、他 tenant 総量に依存しない)
+ * - AC1 (proxy): 他 tenant のデータ量を増やしても Query 回数 = 児童数 × prefix 数で不変
+ * - 件数保証: 対象 items のみ削除し、同 PK の他 SK / 他 tenant は不変 (tenant 境界)
+ * - AC3: BatchWrite UnprocessedItems の retry で silent partial delete を残さない、
+ *        途中失敗後の再実行 (冪等) で残存が完全に消える
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { asChildId } from '$lib/domain/ids';
+
+// --- AWS SDK mock (既存 dynamodb repo test と同パターン: vi.hoisted + command class) ---
+
+const { mockSend, MockScanCommand, MockQueryCommand, MockBatchWriteCommand } = vi.hoisted(() => {
+	const send = vi.fn();
+	class Cmd {
+		input: Record<string, unknown>;
+		constructor(input: Record<string, unknown>) {
+			this.input = input;
+		}
+	}
+	return {
+		mockSend: send,
+		MockScanCommand: class extends Cmd {},
+		MockQueryCommand: class extends Cmd {},
+		MockBatchWriteCommand: class extends Cmd {},
+	};
+});
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+	DynamoDBClient: class {
+		destroy() {}
+	},
+}));
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	ScanCommand: MockScanCommand,
+	QueryCommand: MockQueryCommand,
+	BatchWriteCommand: MockBatchWriteCommand,
+	// 他 repo が static import する command は本 test では未使用 (bulk-delete 経由のみ)
+	GetCommand: class {},
+	PutCommand: class {},
+	DeleteCommand: class {},
+	UpdateCommand: class {},
+	TransactWriteCommand: class {},
+}));
+
+// --- in-memory fake table ---
+
+type Item = { PK: string; SK: string };
+
+let table: Item[] = [];
+let counts = { scan: 0, query: 0, batchWrite: 0 };
+let commandLog: string[] = [];
+/** 次の BatchWrite を 1 回だけ reject させる (途中失敗 → 再実行の冪等検証用) */
+let batchWriteRejectOnce = false;
+/** 次の BatchWrite で前半 key を UnprocessedItems として 1 回だけ返す */
+let unprocessedOnce = false;
+/** Scan / Query の 1 ページあたり返却件数 (pagination 検証用) */
+let pageSize = 1000;
+
+function cmpKey(a: Item, b: Item): number {
+	return a.PK === b.PK ? a.SK.localeCompare(b.SK) : a.PK.localeCompare(b.PK);
+}
+
+function paginate(matched: Item[], exclusiveStartKey?: Item) {
+	const sorted = [...matched].sort(cmpKey);
+	const after = exclusiveStartKey
+		? sorted.filter((it) => cmpKey(it, exclusiveStartKey) > 0)
+		: sorted;
+	const page = after.slice(0, pageSize);
+	const hasMore = after.length > pageSize;
+	const last = page[page.length - 1];
+	return {
+		Items: page.map((it) => ({ PK: it.PK, SK: it.SK })),
+		LastEvaluatedKey: hasMore && last ? { PK: last.PK, SK: last.SK } : undefined,
+	};
+}
+
+function installFakeTable() {
+	mockSend.mockImplementation(async (cmd: { input: Record<string, unknown> }) => {
+		const input = cmd.input as {
+			ExpressionAttributeValues?: Record<string, string>;
+			ExclusiveStartKey?: Item;
+			RequestItems?: Record<string, Array<{ DeleteRequest: { Key: Item } }>>;
+		};
+		if (cmd instanceof MockScanCommand) {
+			counts.scan++;
+			commandLog.push('scan');
+			const v = input.ExpressionAttributeValues ?? {};
+			const pkPrefix = v[':pkPrefix'];
+			const skPrefix = v[':skPrefix'];
+			const matched = table.filter(
+				(it) =>
+					(!pkPrefix || it.PK.startsWith(pkPrefix)) && (!skPrefix || it.SK.startsWith(skPrefix)),
+			);
+			return paginate(matched, input.ExclusiveStartKey);
+		}
+		if (cmd instanceof MockQueryCommand) {
+			counts.query++;
+			commandLog.push('query');
+			const v = input.ExpressionAttributeValues ?? {};
+			const pk = v[':pk'];
+			const skPrefix = v[':skPrefix'];
+			const matched = table.filter(
+				(it) => it.PK === pk && (!skPrefix || it.SK.startsWith(skPrefix)),
+			);
+			return paginate(matched, input.ExclusiveStartKey);
+		}
+		if (cmd instanceof MockBatchWriteCommand) {
+			counts.batchWrite++;
+			commandLog.push('batchWrite');
+			if (batchWriteRejectOnce) {
+				batchWriteRejectOnce = false;
+				throw new Error('simulated transient BatchWrite failure');
+			}
+			const entries = Object.entries(input.RequestItems ?? {});
+			const [tableName, requests] = entries[0] ?? ['', []];
+			let toProcess = requests;
+			let unprocessed: typeof requests = [];
+			if (unprocessedOnce && requests.length > 1) {
+				unprocessedOnce = false;
+				const half = Math.floor(requests.length / 2);
+				unprocessed = requests.slice(0, half);
+				toProcess = requests.slice(half);
+			}
+			const keys = toProcess.map((r) => r.DeleteRequest.Key);
+			table = table.filter((it) => !keys.some((k) => k.PK === it.PK && k.SK === it.SK));
+			return unprocessed.length > 0 ? { UnprocessedItems: { [tableName]: unprocessed } } : {};
+		}
+		throw new Error(`unexpected command: ${cmd.constructor.name}`);
+	});
+}
+
+async function loadBulkDelete() {
+	return import('../../../src/lib/server/db/dynamodb/bulk-delete');
+}
+
+const childPkOf = (tenantId: string, childId: number) => `T#${tenantId}#CHILD#${childId}`;
+
+/** tenant 1 つ分の child-scoped データを seed する */
+function seedTenant(tenantId: string, childIds: number[], skPrefixCounts: Record<string, number>) {
+	for (const childId of childIds) {
+		for (const [skPrefix, n] of Object.entries(skPrefixCounts)) {
+			for (let i = 0; i < n; i++) {
+				table.push({
+					PK: childPkOf(tenantId, childId),
+					SK: `${skPrefix}${String(i).padStart(4, '0')}`,
+				});
+			}
+		}
+	}
+}
+
+beforeEach(() => {
+	mockSend.mockReset();
+	table = [];
+	counts = { scan: 0, query: 0, batchWrite: 0 };
+	commandLog = [];
+	batchWriteRejectOnce = false;
+	unprocessedOnce = false;
+	pageSize = 1000;
+	installFakeTable();
+});
+
+// =========================================================
+// deleteChildScopedItems — Scan → Query 化 (AC2)
+// =========================================================
+
+describe('deleteChildScopedItems (#3693 AC2: Scan → child partition Query)', () => {
+	it('childIds 指定時は Scan 0 回で対象 prefix のみ削除し、他 tenant / 他 SK は不変', async () => {
+		seedTenant('tenant-a', [1, 2], { 'STATUS#': 3, 'POINT#': 2 });
+		seedTenant('tenant-b', [1], { 'STATUS#': 4 });
+
+		const { deleteChildScopedItems } = await loadBulkDelete();
+		const deleted = await deleteChildScopedItems(
+			'tenant-a',
+			[asChildId(1), asChildId(2)],
+			'STATUS#',
+		);
+
+		// 件数保証: tenant-a の STATUS# 6 件のみ削除
+		expect(deleted).toBe(6);
+		expect(counts.scan).toBe(0);
+		// tenant-a の POINT# は残る (SK 境界)
+		expect(
+			table.filter((it) => it.PK.startsWith('T#tenant-a#') && it.SK.startsWith('POINT#')),
+		).toHaveLength(4);
+		// tenant-b は完全に不変 (tenant 境界)
+		expect(table.filter((it) => it.PK.startsWith('T#tenant-b#'))).toHaveLength(4);
+		// tenant-a の STATUS# は 0
+		expect(
+			table.filter((it) => it.PK.startsWith('T#tenant-a#') && it.SK.startsWith('STATUS#')),
+		).toHaveLength(0);
+	});
+
+	it('AC1 proxy: 他 tenant のデータ量が増えても read (Query) 回数は自 tenant の児童数のみに比例する', async () => {
+		// 対象 tenant: 児童 2 人 × STATUS# 2 件
+		seedTenant('tenant-a', [1, 2], { 'STATUS#': 2 });
+		// 他 tenant 50 件 × 20 items (全テーブル Scan なら read 量がこれに比例してしまう)
+		for (let t = 0; t < 50; t++) {
+			seedTenant(`other-${t}`, [1], { 'STATUS#': 20 });
+		}
+
+		const { deleteChildScopedItems } = await loadBulkDelete();
+		const deleted = await deleteChildScopedItems(
+			'tenant-a',
+			[asChildId(1), asChildId(2)],
+			'STATUS#',
+		);
+
+		expect(deleted).toBe(4);
+		expect(counts.scan).toBe(0);
+		// Query は児童 1 人 1 ページ = 2 回 (他 tenant 総量に非依存)
+		expect(counts.query).toBe(2);
+		// 他 tenant は不変
+		expect(table.filter((it) => it.PK.startsWith('T#other-'))).toHaveLength(50 * 20);
+	});
+
+	it('childIds undefined 時は従来の Scan fallback で同じ削除結果になる (完全性優先)', async () => {
+		seedTenant('tenant-a', [1, 2], { 'STATUS#': 3 });
+		seedTenant('tenant-b', [1], { 'STATUS#': 4 });
+
+		const { deleteChildScopedItems } = await loadBulkDelete();
+		const deleted = await deleteChildScopedItems('tenant-a', undefined, 'STATUS#');
+
+		expect(deleted).toBe(6);
+		expect(counts.scan).toBeGreaterThan(0);
+		expect(table.filter((it) => it.PK.startsWith('T#tenant-a#'))).toHaveLength(0);
+		expect(table.filter((it) => it.PK.startsWith('T#tenant-b#'))).toHaveLength(4);
+	});
+});
+
+// =========================================================
+// deleteItemsByExactPk — skPrefix 対応 + streaming
+// =========================================================
+
+describe('deleteItemsByExactPk', () => {
+	it('skPrefix 指定時は同一 PK 内の別 SK を残す', async () => {
+		table.push(
+			{ PK: 'T#t1#SETTING', SK: 'A#1' },
+			{ PK: 'T#t1#SETTING', SK: 'A#2' },
+			{ PK: 'T#t1#SETTING', SK: 'B#1' },
+		);
+		const { deleteItemsByExactPk } = await loadBulkDelete();
+		const deleted = await deleteItemsByExactPk('T#t1#SETTING', 'A#');
+		expect(deleted).toBe(2);
+		expect(table).toEqual([{ PK: 'T#t1#SETTING', SK: 'B#1' }]);
+		expect(counts.scan).toBe(0);
+	});
+
+	it('複数ページでも page ごとに削除しながら全件消す (streaming)', async () => {
+		pageSize = 2;
+		table.push(
+			{ PK: 'T#t1#SETTING', SK: 'A#1' },
+			{ PK: 'T#t1#SETTING', SK: 'A#2' },
+			{ PK: 'T#t1#SETTING', SK: 'A#3' },
+			{ PK: 'T#t1#SETTING', SK: 'A#4' },
+			{ PK: 'T#t1#SETTING', SK: 'A#5' },
+		);
+		const { deleteItemsByExactPk } = await loadBulkDelete();
+		const deleted = await deleteItemsByExactPk('T#t1#SETTING');
+		expect(deleted).toBe(5);
+		expect(table).toHaveLength(0);
+		// streaming: 2 ページ目の Query の前に 1 ページ目の BatchWrite が完了している
+		const firstBatch = commandLog.indexOf('batchWrite');
+		const secondQuery = commandLog.indexOf('query', commandLog.indexOf('query') + 1);
+		expect(firstBatch).toBeGreaterThan(-1);
+		expect(secondQuery).toBeGreaterThan(firstBatch);
+	});
+});
+
+// =========================================================
+// BatchWrite UnprocessedItems retry + 冪等再開 (AC3)
+// =========================================================
+
+describe('BatchWrite 完全性 (#3693 AC3)', () => {
+	it('UnprocessedItems は retry され silent partial delete を残さない', async () => {
+		seedTenant('tenant-a', [1], { 'STATUS#': 10 });
+		unprocessedOnce = true;
+
+		const { deleteChildScopedItems } = await loadBulkDelete();
+		const deleted = await deleteChildScopedItems('tenant-a', [asChildId(1)], 'STATUS#');
+
+		expect(deleted).toBe(10);
+		expect(table).toHaveLength(0);
+		// retry で BatchWrite が 2 回以上呼ばれている
+		expect(counts.batchWrite).toBeGreaterThanOrEqual(2);
+	});
+
+	it('途中失敗は throw し (silent success 禁止)、再実行で残存が完全に消える (冪等再開)', async () => {
+		seedTenant('tenant-a', [1, 2], { 'STATUS#': 3 });
+		batchWriteRejectOnce = true;
+
+		const { deleteChildScopedItems } = await loadBulkDelete();
+		await expect(
+			deleteChildScopedItems('tenant-a', [asChildId(1), asChildId(2)], 'STATUS#'),
+		).rejects.toThrow('simulated transient BatchWrite failure');
+
+		// 再実行 (冪等): 残存が全て消える
+		const deletedOnRetry = await deleteChildScopedItems(
+			'tenant-a',
+			[asChildId(1), asChildId(2)],
+			'STATUS#',
+		);
+		expect(deletedOnRetry).toBeGreaterThan(0);
+		expect(table.filter((it) => it.SK.startsWith('STATUS#'))).toHaveLength(0);
+
+		// 3 回目 (全消化後) は 0 件削除でエラーなく完了する
+		const deletedThird = await deleteChildScopedItems(
+			'tenant-a',
+			[asChildId(1), asChildId(2)],
+			'STATUS#',
+		);
+		expect(deletedThird).toBe(0);
+	});
+});
+
+// =========================================================
+// repo 配線 (代表: status-repo) — childIds 受領時に Query 化される
+// =========================================================
+
+describe('status-repo.deleteByTenantId 配線 (#3693)', () => {
+	it('childIds 指定時に STATUS# + STATHIST# を Scan 0 回で削除する', async () => {
+		const t = 'tenant-a';
+		table.push(
+			{ PK: childPkOf(t, 1), SK: 'STATUS#exercise' },
+			{ PK: childPkOf(t, 1), SK: 'STATHIST#2026-07-01' },
+			{ PK: childPkOf(t, 1), SK: 'POINT#0001' },
+			{ PK: childPkOf(t, 2), SK: 'STATUS#study' },
+		);
+		const statusRepo = await import('../../../src/lib/server/db/dynamodb/status-repo');
+		await statusRepo.deleteByTenantId(t, [asChildId(1), asChildId(2)]);
+
+		expect(counts.scan).toBe(0);
+		expect(table.filter((it) => it.SK.startsWith('STATUS#'))).toHaveLength(0);
+		expect(table.filter((it) => it.SK.startsWith('STATHIST#'))).toHaveLength(0);
+		// 別 prefix (POINT#) は残る
+		expect(table.filter((it) => it.SK.startsWith('POINT#'))).toHaveLength(1);
+	});
+
+	it('childIds なし (従来呼び出し) では Scan fallback で削除される (後方互換)', async () => {
+		const t = 'tenant-a';
+		table.push({ PK: childPkOf(t, 1), SK: 'STATUS#exercise' });
+		const statusRepo = await import('../../../src/lib/server/db/dynamodb/status-repo');
+		await statusRepo.deleteByTenantId(t);
+
+		expect(counts.scan).toBeGreaterThan(0);
+		expect(table.filter((it) => it.SK.startsWith('STATUS#'))).toHaveLength(0);
+	});
+});

--- a/tests/unit/services/tenant-cleanup-service.test.ts
+++ b/tests/unit/services/tenant-cleanup-service.test.ts
@@ -12,6 +12,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockChildRepo = {
 	findAllChildren: vi.fn(),
+	// #3693: deleteTenantScopedData は archived 児童も childIds に含める (Scan 時代の削除範囲と同一)
+	findArchivedChildren: vi.fn(),
 	deleteChild: vi.fn().mockResolvedValue(undefined),
 };
 
@@ -126,6 +128,7 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	// デフォルトで children は空
 	mockChildRepo.findAllChildren.mockResolvedValue([]);
+	mockChildRepo.findArchivedChildren.mockResolvedValue([]);
 });
 
 // =========================================================
@@ -190,26 +193,66 @@ describe('deleteTenantScopedData', () => {
 	it('trial_history を含む全テナントスコープ repo の deleteByTenantId が呼ばれる', async () => {
 		await deleteTenantScopedData(TENANT);
 
+		// tenant 直下 PK のみの repo は childIds を受け取らない
 		expect(mockTrialHistoryRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
 		expect(mockSettingsRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockChecklistRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockSpecialRewardRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockDailyMissionRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockEvaluationRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockPointRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockStampCardRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockStatusRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockLoginBonusRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockActivityPrefRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockActivityMasteryRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockMessageRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
+		expect(mockReportDailySummaryRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
+		// #3693: child-scoped repo は childIds を受け取る (児童 0 人時は undefined = Scan fallback)
+		expect(mockChecklistRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockSpecialRewardRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockDailyMissionRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockEvaluationRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockPointRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockStampCardRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockStatusRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockLoginBonusRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockActivityPrefRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockActivityMasteryRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockMessageRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
 		// #2295: tenantEvent / seasonEvent 削除済
 		// #2458 (Path B sibling drop): mockSiblingChallengeRepo.deleteByTenantId assertion 削除済 (2026-05-26)、
 		// table 物理 drop 済のため tenant-cleanup-service も呼び出さない。child-challenges は child cascade で削除。
-		expect(mockSiblingCheerRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
+		expect(mockSiblingCheerRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
 		// #3213: autoChallenge.deleteByTenantId assertion 削除済 (auto_challenges 廃止、child cascade で削除)
-		expect(mockReportDailySummaryRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
-		expect(mockImageRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
+		expect(mockImageRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+	});
+
+	it('#3693: childIds (active + archived) を child-scoped repo の deleteByTenantId に渡す', async () => {
+		mockChildRepo.findAllChildren.mockResolvedValue([{ id: '100' }, { id: '200' }]);
+		mockChildRepo.findArchivedChildren.mockResolvedValue([{ id: '300' }]);
+
+		await deleteTenantScopedData(TENANT);
+
+		const expectedIds = ['100', '200', '300'];
+		expect(mockStatusRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, expectedIds);
+		expect(mockPointRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, expectedIds);
+		expect(mockChecklistRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, expectedIds);
+		expect(mockStampCardRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, expectedIds);
+		expect(mockImageRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, expectedIds);
+		// tenant 直下 PK の repo には渡さない
+		expect(mockSettingsRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
+		// voice / activities の per-child ループは active 児童のみ (従来挙動を維持)
+		expect(mockVoiceRepo.deleteByChild).toHaveBeenCalledTimes(2);
+	});
+
+	it('#3693: 児童一覧は先頭で 1 回だけ解決される (Scan 重複の排除)', async () => {
+		mockChildRepo.findAllChildren.mockResolvedValue([{ id: '100' }]);
+
+		await deleteTenantScopedData(TENANT);
+
+		// 旧実装は activities 用 + voice 用に 2 回列挙していた
+		expect(mockChildRepo.findAllChildren).toHaveBeenCalledTimes(1);
+		expect(mockChildRepo.findArchivedChildren).toHaveBeenCalledTimes(1);
+	});
+
+	it('#3693: 児童列挙が失敗しても childIds=undefined (Scan fallback) で削除を継続する', async () => {
+		mockChildRepo.findAllChildren.mockRejectedValue(new Error('enumeration failed'));
+
+		await deleteTenantScopedData(TENANT);
+
+		expect(mockStatusRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockPointRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
+		expect(mockSettingsRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
 	});
 
 	it('activities (per-child loop, #2362) / viewerTokens / cloudExports / pushSubscriptions は find+delete パターン', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ システム全体

**解決する課題**: アカウント削除（退会）/ data 全削除の実行時に、DynamoDB backend では約 25 回の全テーブル Scan が直列実行され、read 量が全テナント総量に比例して Lambda 30s / API GW 504 に到達するリスクがあった（restore 504 実障害 #3692 と同 class）。実顧客の退会操作が 504 で失敗すると「退会できない」という信頼毀損 + 法的リスク（削除権）に直結する。

**期待される効果**: 削除経路の read が「自テナントのデータ量」にのみ比例するようになり、他テナント / 全体のデータ増加で退会・データ全削除が劣化しない。BatchWrite の UnprocessedItems retry により silent partial delete（削除の取り漏らし）も構造的に排除される。

## 関連 Issue

closes #3693

related: #3692 (restore 504 same-class) / ADR-0061 (failing-test-first) / ADR-0049 (物理削除ポリシー)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 本番実データ規模で退会が 30s 内に完了 or 非同期化 | `npx vitest run tests/unit/db/dynamodb-bulk-delete.test.ts`（fake DocumentClient に他 tenant 50 件 × 20 items を合成 seed し、対象 tenant 削除の read 回数が他 tenant 総量に非依存であることを assert） | HEAD `3518bd30` / 9 passed / tests/unit/db/dynamodb-bulk-delete.test.ts:209「AC1 proxy: 他 tenant のデータ量が増えても read (Query) 回数は自 tenant の児童数のみに比例する」= Query 2 回・Scan 0 回で不変。30s リスクの根本原因（read が全テナント総量に線形比例する全テーブル Scan × 25）を排除し、実行時間を自 tenant データ量のみに束縛した（非同期化は不要と判断、下記レビュー依頼事項参照） |
| AC2 | Scan 回数の削減（計測 test で write/scan 呼び出し数を fitness 化） | `npx vitest run tests/unit/db/dynamodb-bulk-delete.test.ts tests/unit/services/tenant-cleanup-service.test.ts` | HEAD `3518bd30` / 20 passed / 全テーブル Scan 約 25 回 → childIds 供給時 Scan 0 回（fitness: `expect(counts.scan).toBe(0)` L196・L340）。残 Scan は PK 埋込 ID が列挙不能な CKTPL / STMPCARD# entries の tenant あたり計 2 回のみ（checklist は 2 Scan → 1 Scan に統合、src/lib/server/db/dynamodb/checklist-repo.ts:769）。service 層は児童列挙を先頭 1 回に統合（旧 2 回、tests/unit/services/tenant-cleanup-service.test.ts「児童一覧は先頭で 1 回だけ解決される」） |
| AC3 | 部分削除で中断した場合の再開安全性（冪等） | `npx vitest run tests/unit/db/dynamodb-bulk-delete.test.ts -t "冪等"` | HEAD `3518bd30` / PASS / tests/unit/db/dynamodb-bulk-delete.test.ts:296「途中失敗は throw し (silent success 禁止)、再実行で残存が完全に消える (冪等再開)」+ L281 UnprocessedItems retry。実装は page 単位 streaming 削除（src/lib/server/db/dynamodb/bulk-delete.ts:107-115）+ 指数 backoff retry 上限超過 throw（同 L56-63） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — スキーマ自体は不変。dynamodb repo 15 file + interfaces 15 file + bulk-delete.ts のアクセスパターン変更のみ
- [x] サービス層 (`$lib/server/services/`) — tenant-cleanup-service.ts（児童列挙 1 回化 + childIds 引き渡し）
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: アカウント削除（/admin/account/delete）/ 設定 > データ全削除 / replace import の内包 clear / grace-period 物理削除 cron。UI 表面の挙動・画面変化なし（内部アクセスパターンの最適化）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— Ready 化前に `npm run pre-ready -- --pr <PR番号>` を実行し全 step PASS を確認する（Draft 起票時点では targeted 検証: `npx vitest run tests/unit/db/ tests/unit/services/` 226 files / 3349 passed + `npx biome check`（変更 34 file、error 0）+ `npx svelte-check --tsconfig ./tsconfig.json`（変更 file 起因の error 0）で確認済）
- [x] 追加・変更したテストの概要を以下に記載:
  - 新規 `tests/unit/db/dynamodb-bulk-delete.test.ts`（9 tests、failing-test-first ADR-0061: 実装前 8 failed → 実装後 9 passed）: in-memory fake DocumentClient（Scan/Query/BatchWrite 意味論 + pagination + UnprocessedItems 注入）で Scan 0 回 fitness / tenant 境界 / SK 境界 / streaming / UnprocessedItems retry / 冪等再開 / status-repo 配線 / Scan fallback 後方互換を検証
  - 既存 `tests/unit/services/tenant-cleanup-service.test.ts` に 3 tests 追加: childIds（active + archived）の引き渡し / 児童列挙 1 回化 / 列挙失敗時の Scan fallback 継続
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret の追加なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: SQLite / DSQL / demo 実装は interface の optional 引数追加（`childIds?: readonly ChildId[]`）に対し無変更で互換（TypeScript の少引数実装は interface を満たす）。`node scripts/check-dynamodb-stub.mjs` は stub 追加なしのため対象外、`npx vitest run tests/unit/db/` 全 backend テスト 226 files passed で両実装等価性を確認
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — priority:high（critical ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）** — server 側 DB アクセスパターンの最適化のみで UI 変更なし（`.svelte` / `.css` / `site/` の変更 0 file）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（bulk-delete.ts に削除機構を集約、repo は prefix 指定のみ）/ 依存性逆転（service 層は repo interface 経由、`childIds?` は optional param で全 backend 互換）
- [x] **DRY**: 25 箇所に散在していた Scan 呼び出しを `deleteChildScopedItems` 1 関数に集約。`grep -rn "deleteItemsByPkPrefix" src/lib/server/db/dynamodb/` で残存呼び出しは fallback 分岐 + CKTPL / STMPCARD entries / battle-repo（tenant-cleanup 経路外）のみであることを確認済
- [x] **YAGNI**: 非同期 saga / job 分割基盤は導入せず（Scan 排除で root cause 解消のため。Issue 解決策 2 の構造対応は #3692 側の共通基盤判断に委ねる — レビュー依頼事項参照）
- [x] **Security（OSS 公開前提）**: tenant 境界を test で機械検証（他 tenant items 不変 assert）。秘密情報 hardcode なし
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: 本 PR の主目的。全テーブル Scan 約 25 回 → child partition Query（並列 chunk 5）+ 残 Scan 2 回。児童列挙も 3 回 → 1 回（active）+ 1 回（archived）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 設計書同期 (ADR-0001): `docs/design/08-データベース設計書.md` に削除戦略 SSOT（原則 1 配下）追記 + per-repo 表 4 行（sibling-cheer / reward-redemption / stamp-card / message）を現状同期
- [x] 並行 PR overlap 確認 (#1200): 起票時に db 層 file が overlap し得た #3719（restore 冪等）/ #3718（ledger 原子化）は**両方とも develop に merge 済**（base `origin/develop` = 01d68d36 に含有、`git log --oneline origin/develop --grep` で確認）。本 branch は merge 後の develop から作成しており overlap なし
- [x] E2E / ユニットシード + チュートリアルを同期: N/A — スキーマ / seed 値 / 陳列に変更なし（アクセスパターンのみ）。`tests/unit/services/tenant-cleanup-service.test.ts` の mock は findArchivedChildren 追加に追従済
- [x] N/A — 本番/デモ・LP・年齢モード・ナビ・labels SSOT は影響範囲外（UI / 文言変更なし）

**LP / 販促文言変更時** (ADR-0013):

N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** — `deleteByTenantId` の第 2 引数は optional のため既存呼び出し（childIds なし）は Scan fallback で従来挙動を完全維持

**レビュー依頼事項・QA**:
- **非同期化（Issue 解決策 2）を本 PR で採らなかった判断**: 30s リスクの root cause は「read が全テナント総量に比例する全テーブル Scan × 25 直列」であり、child partition Query 化で実行時間は自 tenant のデータ量のみに束縛される（家族単位 tenant の実データ規模では数百 ms オーダー）。grace-period 機構による soft-delete 即返しは既存のまま。job 分割の共通基盤は #3692（restore 504）側の設計と合流すべきで、本 PR で独自基盤を先行させると二重投資になるため見送った（ADR-0010 / Issue「実装時は #3692 と共通基盤を検討」整合）。
- **DSQL 側の same-class**: DSQL repos の deleteByTenantId は `DELETE FROM x WHERE family_id = $1` 形式で全表 Scan class ではないが、約 25 回の直列 round-trip は残る。EPIC #3424 管轄のため Issue #3693 にコメントで申し送り済み。
- **archived 児童の扱い**: childIds には archived 児童も含めた（旧 Scan 実装の削除範囲とのパリティ維持）。activities / voice の per-child ループは従来どおり active のみ（挙動不変）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3748` 全 Step PASS** をローカル確認した（Step 1 biome は worktree 既知事象で `biome check .` が 0 file になるため、CI 同一 flag の `npx biome check --error-on-warnings <変更 34 file>` で代替検証し error/warning 0 を確認。残 step は `--skip-biome` で全 PASS。最終 authoritative は CI lint-and-test）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A — UI 変更なし（SS セクション「該当なし」明記済）
- [x] 認証画面変更時: N/A — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
