### PR TITLE
fix(security): #3741 XSS gate の bracket 記法 innerHTML + document.write 素通り封鎖 (#3671 same-class 残余)

### DIFF
--- a/scripts/check-no-at-html.mjs
+++ b/scripts/check-no-at-html.mjs
@@ -36,13 +36,16 @@ const AT_HTML = /\{@html\b/;
 const ALLOW_AT_HTML = /eslint-disable(?:-next-line)?\s+svelte\/no-at-html-tags|allow-at-html:/;
 // TS/JS echo sink (#3450 item2 + #3741 bracket/document.write 拡張):
 //   1. innerHTML / outerHTML への代入 — dot (`el.innerHTML`) と bracket (`el['innerHTML']` /
-//      `el["innerHTML"]`) を同値カバーし、演算子は = / += / ||= / ??= を検出。
+//      `el["innerHTML"]` / `el[`innerHTML`]`) を同値カバーし、演算子は = / += / ||= / ??= を検出。
 //      `(?!=)` で比較演算子 (== / === / !==) を除外する。
 //   2. insertAdjacentHTML 呼び出し — dot / bracket 両形。
 //   3. document.write / document.writeln 呼び出し — dot / bracket 両形 (`document` レシーバ
 //      限定。`writer.write(chunk)` 等の一般 write は誤検出しない)。
+// bracket key の quote 文字クラスは single/double/backtick の 3 種 (`['"`]`) を許容する。
+// backtick を欠くと `el[`innerHTML`] = x` 等の template-literal key evasion が MISS する
+// (#3741 が塞ぐ bracket 回避の同一クラス兄弟、ADR-0061 same-class→guard)。
 const TS_SINK =
-	/(?:\.(?:innerHTML|outerHTML)|\[\s*['"](?:innerHTML|outerHTML)['"]\s*\])\s*(?:\+|\|\||\?\?)?=(?!=)|(?:\binsertAdjacentHTML|\[\s*['"]insertAdjacentHTML['"]\s*\])\s*\(|\bdocument\s*(?:\.\s*write(?:ln)?|\[\s*['"]write(?:ln)?['"]\s*\])\s*\(/;
+	/(?:\.(?:innerHTML|outerHTML)|\[\s*['"`](?:innerHTML|outerHTML)['"`]\s*\])\s*(?:\+|\|\||\?\?)?=(?!=)|(?:\binsertAdjacentHTML|\[\s*['"`]insertAdjacentHTML['"`]\s*\])\s*\(|\bdocument\s*(?:\.\s*write(?:ln)?|\[\s*['"`]write(?:ln)?['"`]\s*\])\s*\(/;
 const ALLOW_SINK = /allow-innerhtml:/;
 // sanitizer 実呼び出しパターン (#3450 item3)。DOMPurify (ADR-0025) を第一級とし、
 // 同等 sanitizer (sanitize-html 等) の呼び出し形も許容する。

--- a/scripts/check-no-at-html.mjs
+++ b/scripts/check-no-at-html.mjs
@@ -6,6 +6,11 @@
 //   item3 — opt-out マーカーは「存在」だけでなく「同一ファイル内に DOMPurify.sanitize 等の
 //            sanitizer 実呼び出しが実在する」ことを構造検証する (マーカーだけで未 sanitize の
 //            {@html} / innerHTML を恒久許可できる構造的穴を封鎖)。
+// #3741 (#3671 same-class 残余): dot 記法限定だった TS sink 検出を同値 sink まで拡張。
+//   - bracket 記法 `el['innerHTML'] = x` / `el["outerHTML"] += x` / `el['insertAdjacentHTML'](...)`
+//     (QM Tier2 が実証した gate 素通り evasion、dot と同一 sink)
+//   - `document.write(x)` / `document.writeln(x)` (+ bracket 形) — 古典的 HTML 注入 sink
+//   - logical assignment `??=` / `||=` (exotic だが同 regex で吸収)
 //
 // 背景: error message 等のサーバ値を `{@html}` / `innerHTML` で描画すると stored/echo XSS が
 // 成立する。不変条件「サーバ値は textContent 補間で描画する」は従来 06-UI設計書 + コメント +
@@ -29,9 +34,15 @@ const ROOT = process.cwd();
 const SRC = join(ROOT, 'src');
 const AT_HTML = /\{@html\b/;
 const ALLOW_AT_HTML = /eslint-disable(?:-next-line)?\s+svelte\/no-at-html-tags|allow-at-html:/;
-// TS/JS echo sink (#3450 item2): 代入 (= / +=) と insertAdjacentHTML 呼び出し。
-// `(?!=)` で比較演算子 (== / === / !==) を除外する。
-const TS_SINK = /\.(?:innerHTML|outerHTML)\s*\+?=(?!=)|\binsertAdjacentHTML\s*\(/;
+// TS/JS echo sink (#3450 item2 + #3741 bracket/document.write 拡張):
+//   1. innerHTML / outerHTML への代入 — dot (`el.innerHTML`) と bracket (`el['innerHTML']` /
+//      `el["innerHTML"]`) を同値カバーし、演算子は = / += / ||= / ??= を検出。
+//      `(?!=)` で比較演算子 (== / === / !==) を除外する。
+//   2. insertAdjacentHTML 呼び出し — dot / bracket 両形。
+//   3. document.write / document.writeln 呼び出し — dot / bracket 両形 (`document` レシーバ
+//      限定。`writer.write(chunk)` 等の一般 write は誤検出しない)。
+const TS_SINK =
+	/(?:\.(?:innerHTML|outerHTML)|\[\s*['"](?:innerHTML|outerHTML)['"]\s*\])\s*(?:\+|\|\||\?\?)?=(?!=)|(?:\binsertAdjacentHTML|\[\s*['"]insertAdjacentHTML['"]\s*\])\s*\(|\bdocument\s*(?:\.\s*write(?:ln)?|\[\s*['"]write(?:ln)?['"]\s*\])\s*\(/;
 const ALLOW_SINK = /allow-innerhtml:/;
 // sanitizer 実呼び出しパターン (#3450 item3)。DOMPurify (ADR-0025) を第一級とし、
 // 同等 sanitizer (sanitize-html 等) の呼び出し形も許容する。
@@ -110,8 +121,9 @@ export function findUnsanitizedAtHtmlOptOuts(content) {
 }
 
 /**
- * TS/JS の innerHTML 系 echo sink を抽出する純粋関数 (#3450 item2)。
- * 検出対象: `.innerHTML =` / `.innerHTML +=` / `.outerHTML =` / `insertAdjacentHTML(`。
+ * TS/JS の innerHTML 系 echo sink を抽出する純粋関数 (#3450 item2 / #3741 拡張)。
+ * 検出対象: innerHTML / outerHTML への代入 (= / += / ||= / ??=、dot・bracket 両記法) /
+ * `insertAdjacentHTML(` (dot・bracket 両形) / `document.write(` / `document.writeln(`。
  * コメント行は除外。当該行または直前行の `allow-innerhtml:` マーカーで opt-out できるが、
  * opt-out には同一ファイル内の sanitizer 実呼び出しが必須 (item3 と同一原則)。
  *
@@ -203,9 +215,10 @@ function main() {
 		);
 		for (const v of sinkViolations) console.error(`  ${v}`);
 		console.error(
-			'\nDOM への HTML 文字列注入 (`innerHTML =` / `insertAdjacentHTML` / `outerHTML =`) は' +
-				' textContent / DOM API で代替してください。正当な sanitize 済注入が必要なら当該行直前に' +
-				' `allow-innerhtml:` コメントを置き、同一ファイル内で DOMPurify.sanitize を実呼び出ししてください。',
+			'\nDOM への HTML 文字列注入 (`innerHTML =` / `insertAdjacentHTML` / `outerHTML =` /' +
+				' `document.write`、bracket 記法含む #3741) は textContent / DOM API で代替してください。' +
+				'正当な sanitize 済注入が必要なら当該行直前に `allow-innerhtml:` コメントを置き、' +
+				'同一ファイル内で DOMPurify.sanitize を実呼び出ししてください。',
 		);
 	}
 

--- a/tests/unit/scripts/check-no-at-html.test.ts
+++ b/tests/unit/scripts/check-no-at-html.test.ts
@@ -185,6 +185,43 @@ describe('findTsSinkViolations (#3741 bracket 記法 / document.write / logical 
 		);
 	});
 
+	// #3741 follow-up: backtick (template literal) bracket key の evasion 回帰 fixture。
+	// quote 文字クラスが single/double のみで backtick を欠くと以下が MISS する
+	// (dot/single/double を回避する同一クラス兄弟、ADR-0061 same-class→guard)。
+	it('backtick bracket 記法 el[`innerHTML`] = x を違反として検出する', () => {
+		expect(findTsSinkViolations('el[`innerHTML`] = userInput;').violations).toEqual([1]);
+	});
+
+	it('backtick bracket 記法 el[`outerHTML`] = x を検出する', () => {
+		expect(findTsSinkViolations('node[`outerHTML`] = replacement;').violations).toEqual([1]);
+	});
+
+	it('backtick bracket 記法 el[`innerHTML`] += x (logical/加算代入) を検出する', () => {
+		expect(findTsSinkViolations('el[`innerHTML`] += chunk;').violations).toEqual([1]);
+	});
+
+	it('backtick bracket 記法 insertAdjacentHTML 呼び出し el[`insertAdjacentHTML`](...) を検出する', () => {
+		expect(findTsSinkViolations('el[`insertAdjacentHTML`](`beforeend`, html);').violations).toEqual(
+			[1],
+		);
+	});
+
+	it('backtick bracket 記法 document[`write`](x) を検出する', () => {
+		expect(findTsSinkViolations('document[`write`](payload);').violations).toEqual([1]);
+	});
+
+	it('backtick bracket 記法 document[`writeln`](x) を検出する', () => {
+		expect(findTsSinkViolations('document[`writeln`](payload);').violations).toEqual([1]);
+	});
+
+	it('backtick bracket 記法でも比較演算 (el[`innerHTML`] === x) は検出しない', () => {
+		expect(findTsSinkViolations('if (el[`innerHTML`] === ``) { reset(); }').violations).toEqual([]);
+	});
+
+	it('backtick bracket 記法の読み取り (const s = el[`innerHTML`];) は検出しない', () => {
+		expect(findTsSinkViolations('const snapshot = el[`innerHTML`];').violations).toEqual([]);
+	});
+
 	it('document.write(x) を HTML 注入 sink として検出する', () => {
 		expect(findTsSinkViolations('document.write(payload);').violations).toEqual([1]);
 	});

--- a/tests/unit/scripts/check-no-at-html.test.ts
+++ b/tests/unit/scripts/check-no-at-html.test.ts
@@ -159,3 +159,84 @@ describe('findTsSinkViolations (#3450 item2 TS/JS innerHTML sink 検出)', () =>
 		expect(findTsSinkViolations(content).violations).toEqual([1, 3]);
 	});
 });
+
+describe('findTsSinkViolations (#3741 bracket 記法 / document.write / logical assign residual)', () => {
+	// #3671 QM Tier2 で実証された evasion (dot 記法限定 gap) の回帰 fixture (ADR-0006:
+	// 危険コードで実 fail を assert する)。ここが MISS に戻ったら gate の網羅宣言が偽になる。
+	it("bracket 記法 el['innerHTML'] = x (single quote) を違反として検出する", () => {
+		expect(findTsSinkViolations("el['innerHTML'] = userInput;").violations).toEqual([1]);
+	});
+
+	it('bracket 記法 el["innerHTML"] += x (double quote) を検出する', () => {
+		expect(findTsSinkViolations('el["innerHTML"] += chunk;').violations).toEqual([1]);
+	});
+
+	it("bracket 記法 el['outerHTML'] = x を検出する", () => {
+		expect(findTsSinkViolations("node['outerHTML'] = replacement;").violations).toEqual([1]);
+	});
+
+	it("bracket 記法 el[ 'innerHTML' ] = x (空白入り) も検出する", () => {
+		expect(findTsSinkViolations("el[ 'innerHTML' ] = userInput;").violations).toEqual([1]);
+	});
+
+	it("bracket 記法 insertAdjacentHTML 呼び出し el['insertAdjacentHTML'](...) を検出する", () => {
+		expect(findTsSinkViolations("el['insertAdjacentHTML']('beforeend', html);").violations).toEqual(
+			[1],
+		);
+	});
+
+	it('document.write(x) を HTML 注入 sink として検出する', () => {
+		expect(findTsSinkViolations('document.write(payload);').violations).toEqual([1]);
+	});
+
+	it('document.writeln(x) を検出する', () => {
+		expect(findTsSinkViolations('document.writeln(payload);').violations).toEqual([1]);
+	});
+
+	it("bracket 記法 document['write'](x) も検出する", () => {
+		expect(findTsSinkViolations("document['write'](payload);").violations).toEqual([1]);
+	});
+
+	it('logical assign innerHTML ??= x を検出する', () => {
+		expect(findTsSinkViolations('el.innerHTML ??= fallbackHtml;').violations).toEqual([1]);
+	});
+
+	it('logical assign innerHTML ||= x を検出する', () => {
+		expect(findTsSinkViolations('el.innerHTML ||= fallbackHtml;').violations).toEqual([1]);
+	});
+
+	it("bracket 記法でも比較演算 (el['innerHTML'] === x) は検出しない", () => {
+		const content = [
+			"if (el['innerHTML'] === '') { reset(); }",
+			'if (el["outerHTML"] == raw) {}',
+		].join('\n');
+		expect(findTsSinkViolations(content).violations).toEqual([]);
+	});
+
+	it("bracket 記法の読み取り (const s = el['innerHTML'];) は検出しない", () => {
+		expect(findTsSinkViolations("const snapshot = el['innerHTML'];").violations).toEqual([]);
+	});
+
+	it('document.write を含むコメント行は検出しない', () => {
+		expect(findTsSinkViolations('// NG 例: document.write(x) は禁止').violations).toEqual([]);
+	});
+
+	it('writer.write(chunk) 等の document 以外の write 呼び出しは検出しない', () => {
+		const content = ['writer.write(chunk);', 'stream.writeln(line);'].join('\n');
+		expect(findTsSinkViolations(content).violations).toEqual([]);
+	});
+
+	it('bracket sink も allow-innerhtml: マーカー + sanitizer 実呼び出しで opt-out できる', () => {
+		const content = [
+			'const clean = DOMPurify.sanitize(raw);',
+			'// allow-innerhtml: DOMPurify 済 (ADR-0025)',
+			"el['innerHTML'] = clean;",
+		].join('\n');
+		expect(findTsSinkViolations(content)).toEqual({ violations: [], unsanitizedOptOuts: [] });
+	});
+
+	it('bracket sink の opt-out でも sanitizer 実呼び出しが無ければ違反 (#3450 item3 と同一原則)', () => {
+		const content = ['// allow-innerhtml: 済のつもり', "el['innerHTML'] = raw;"].join('\n');
+		expect(findTsSinkViolations(content)).toEqual({ violations: [], unsanitizedOptOuts: [2] });
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者 / 運営（security gate 完全性）— 最終的には子供 PII を守る全ユーザー

**解決する課題**: PR #3671 で強化した XSS gate（`check-no-at-html.mjs`）の TS sink 検出が dot 記法限定で、QM Tier2 が実証した evasion（`el['innerHTML'] = x` bracket 記法 / `document.write(x)` / logical assign `??=` `||=`）が CI を素通りしていた。将来 bracket 記法で未 sanitize の子供データを innerHTML に流す実装が merge されると stored/echo XSS を出荷しうる。

**期待される効果**: dot / bracket 同値 sink + `document.write` / `document.writeln` + logical assignment を gate が網羅し、Issue 表題「TS innerHTML sink 網羅」の宣言と実体が一致する（false-negative 封鎖）。

## 関連 Issue

closes #3741

関連: #3671（親、XSS gate 強化）/ #3450 / ADR-0061（same-class→guard）/ ADR-0025（LP innerHTML XSS）/ ADR-0006（危険コードで実 fail を assert する回帰 fixture）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `TS_SINK` に bracket 記法 `['innerHTML']` / `['outerHTML']` 代入を追加（dot/bracket 同値カバー） | 検出関数を node 直接実行する red→green harness（26 fixture、QM Tier2 と同一手法） | HEAD `b3422f13` / scripts/check-no-at-html.mjs:52 / 拡張前 red 11 件 fail を実証 → 拡張後 green pass=26 fail=0（bracket single/double quote / 空白入り / outerHTML 全 HIT） |
| AC2 | `document.write` / `document.writeln` を HTML 注入 sink として追加 | 同上 harness + `tests/unit/scripts/check-no-at-html.test.ts` 新規 fixture | HEAD `b3422f13` / tests/unit/scripts/check-no-at-html.test.ts:207-217 / `document.write(x)` `document.writeln(x)` `document['write'](x)` 全 HIT、`writer.write(chunk)` は非検出（document レシーバ限定で false positive なし） |
| AC3 | evasion パターンの検出回帰テスト（ADR-0006、危険コードで実 fail を assert） | `npx vitest run tests/unit/scripts/check-no-at-html.test.ts`（CI lint-and-test で実行。worktree は node_modules 不在のため同一 fixture を node 直接実行 harness で検証済） | HEAD `b3422f13` / tests/unit/scripts/check-no-at-html.test.ts:180-275 に 16 test 追加（evasion 検出 10 + false positive 防止 4 + opt-out sanitizer 実在検証 2）/ failing-test-first: 拡張前に red 11 件を実証してから regex 拡張 |
| AC4 | logical assign（`??=` と logical-or 代入）を同 regex で吸収 | 同上 harness | HEAD `b3422f13` / scripts/check-no-at-html.mjs:52 で代入演算子 alternation を = / += / logical-or 代入 / `??=` に拡張 / `el.innerHTML ??= x` と logical-or 代入形の両 fixture が HIT、比較演算（`===` / `==`）は引き続き非検出 |
| AC5 | 自リポジトリで違反 0 のまま（false positive なし） | `node scripts/check-no-at-html.mjs` 実走 + `grep -rP "document\s*\.\s*write" src/` | HEAD `b3422f13` / gate exit 0「src 配下 238 svelte に {@html} なし / 992 script file に未許可 innerHTML sink なし」/ grep 0 件（bracket 記法 / document.write / logical assign いずれも src に存在せず） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — CI gate script `scripts/check-no-at-html.mjs` + unit test

**影響を受ける画面・機能**: なし（CI gate の検出網羅性拡張のみ。アプリ本体コードは無変更、gate 実走で既存コード違反 0 を確認済）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— worktree に node_modules 不在のため、本 worktree では `npx biome check`（変更 2 file、No fixes applied / Found 0 errors）+ cspell（Issues found: 0）+ gate 実走（exit 0）+ node 直接実行 harness（26 fixture green）を個別 PASS 済。vitest / svelte-check は CI lint-and-test で検証
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/scripts/check-no-at-html.test.ts` に describe「findTsSinkViolations (#3741 bracket 記法 / document.write / logical assign residual)」16 test 追加。evasion 検出 10（bracket 記法代入 4 / bracket insertAdjacentHTML 1 / document.write 系 3 / logical assign 2）+ false positive 防止 4（bracket 比較 / bracket 読み取り / コメント行 / 非 document write）+ opt-out sanitizer 実在検証 2
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（severity should-fix、live 脆弱性 0 件の gate 網羅性修正）

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）** — CI gate script + unit test のみの変更で UI 変更なし。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 検出ロジックは既存の純粋関数 `findTsSinkViolations` に閉じ、regex 定数 `TS_SINK` の拡張のみ（単一責任維持、呼び出し側 API 不変）
- [x] **DRY**: `grep -n "TS_SINK" scripts/check-no-at-html.mjs` で定義 1 箇所を確認、opt-out / sanitizer 実在検証は既存機構を再利用（重複実装なし）
- [x] **YAGNI**: issue 記載範囲（bracket / document.write / logical assign）のみ追加。eval / setTimeout(string) 等の別系統 sink は本 issue の scope 外
- [x] **Security（OSS 公開前提）**: 本 PR 自体が XSS gate の false-negative 封鎖。秘密情報 hardcode なし
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: regex 1 本の alternation 拡張のみ、走査計算量は不変（`node scripts/check-no-at-html.mjs` 992 file 実走で即時完了）

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] N/A — 並行実装の影響範囲外（LP HTML の innerHTML は別 gate `check-lp-innerhtml-tags.mjs` が担当し変更なし。eslint svelte 層 `svelte/no-at-html-tags` は `{@html}` 専任で責務分離を維持）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- `TS_SINK` の document.write 検出は `document` レシーバ限定（`\bdocument\s*(?:\.\s*write(?:ln)?|\[...\])\s*\(`）。`writer.write(chunk)` / `stream.writeln(line)` 等の一般 write は非検出であることを fixture で担保済。`iframe.contentDocument.write` 等の間接レシーバ形は issue 記載範囲外
- QM Tier2 と同じ node 直接実行での evasion 再検証を推奨: `node -e "import('./scripts/check-no-at-html.mjs').then(m => console.log(m.findTsSinkViolations(\"el['innerHTML'] = x\")))"` → `{ violations: [ 1 ], unsanitizedOptOuts: [] }`

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3752` 全 Step PASS** をローカル確認した（node_modules 完備の clone で全 step 実走。#3741 の backtick bracket 拡張後）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— 変更は `TS_SINK` の bracket key quote クラス `['"]` → `['"`]`（backtick 追加）+ 回帰 fixture 8 件のみ
- [x] 全 AC が実装済み（AC1-AC5 + #3741 で塞いだ bracket 回避の backtick template-literal key 残余を根治、危険コード実走で gate exit 1 を確認済）
- [x] Phase 分割なし（単一 PR で完結、子 Issue 起票不要のため N/A）
- [x] UI 変更なし（CI gate script + unit test のみ、SS 対象外のため N/A）
- [x] 認証画面変更なし（`npm run dev:cognito` 対象外のため N/A）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

