### PR TITLE
fix(billing): #3740 api/v1 POST の quota gate + wire source 'custom' 強制 + copyFromChild gate (#3678 same-class 残余)

### DIFF
--- a/docs/design/data-model-resource-scope.md
+++ b/docs/design/data-model-resource-scope.md
@@ -119,14 +119,15 @@ child_activities
 
 | source 値 | 保存する経路 (producer) | quota 集計対象 |
 |---|---|---|
-| `custom` | 親手動作成 = admin/activities 単体追加 / 一括追加 / `api/v1/activities` (`createActivity` が `normalizeParentCreatedSource` で強制。正準定数 `PARENT_CREATED_SOURCE`) | ✅ |
+| `custom` | 親手動作成 = admin/activities 単体追加 / 一括追加 / `api/v1/activities` (`createActivity` が `normalizeParentCreatedSource` で強制。正準定数 `PARENT_CREATED_SOURCE`)。client-facing wire 経路 (`api/v1/activities` POST) は client 供給 `source` を信頼せず endpoint で `custom` を強制する — seed/curriculum を指定できるのは内部 caller (seed.ts / import-service) のみ (trust 境界分離、#3740) | ✅ |
 | `seed` | 初期 seed (`seed.ts`) / marketplace 取込 (`activity-import-service` — 取込元は `source_preset_id` で識別) / backup 復元 / cloud import (source 未指定 → repo 既定 = schema default 同値) | — |
 | `curriculum` | 年齢別カリキュラムプリセット (`seed.ts`) | — |
 | (元活動の値を保全) | 兄弟 copy (`copyActivitiesAcrossChildren`) — custom の copy は custom のまま (copy 経由の quota 迂回禁止) | 元の値に従う |
 | `parent` (legacy wire 値) | 保存されない (persist 前に `custom` へ正規化)。zod `SOURCES` enum は後方互換で受理のみ | ✅ (防御的) |
 
 - **consumer 共通述語**: `countsTowardActivityQuota(source)` — `checkActivityLimit` (plan-limit-service) / `/admin/subscription` 活動カウンタ / downgrade preview・検証 (downgrade-service) / trial 終了 archive (resource-archive-service) の 4 consumer が同一述語を参照する
-- **整合 lock**: `tests/unit/services/activity-source-quota-roundtrip.test.ts` が「UI 作成 → `checkActivityLimit.current` +1」の producer×consumer round-trip を実 SQLite で assert (ADR-0061 same-class guard)
+- **producer 側 quota gate (`checkActivityLimit`) 適用経路**: admin/activities `create` / `bulkCreateForChildren` (#2894) / `importPack` / `importPackToChildren` (#2894) / `copyFromChild` (#3740、copy は custom source を保全して quota を消費するため) / `api/v1/activities` POST (#3740)
+- **整合 lock**: `tests/unit/services/activity-source-quota-roundtrip.test.ts` が「UI 作成 → `checkActivityLimit.current` +1」の producer×consumer round-trip を実 SQLite で assert (ADR-0061 same-class guard)。残余 2 経路 (api/v1 POST の wire source 注入 / copyFromChild 未 gate) は `tests/unit/routes/activities-quota-residual-gate.test.ts` が gate + `custom` 強制を assert (#3740)
 - **禁忌**: `InsertChildActivityInput.source` を経由せず repo 直 insert で source 文字列を直書きしない / consumer 側で `a.source === '...'` の直比較を書かない (必ず SSOT 述語を使う)
 
 **実装状況 PR-A1 (2026-05-26、#2458 Path A)**:

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -532,6 +532,22 @@ export const actions: Actions = {
 			return fail(400, { error: 'コピー先のお子さまが必要です' });
 		}
 
+		// #3740: copy は元活動の source ('custom' 含む) を保全して複製するため quota を消費する。
+		// gate 未通過だと free tier が上限到達後も copy で custom 活動を増殖できた
+		// (#2894 importPackToChildren gate と同型の課金境界執行)。
+		const copyLicenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
+		const copyLimitCheck = await checkActivityLimit(tenantId, copyLicenseStatus);
+		if (!copyLimitCheck.allowed) {
+			const tier = await resolveFullPlanTier(tenantId, copyLicenseStatus, locals.context?.plan);
+			return fail(403, {
+				error: createPlanLimitError(
+					tier,
+					'standard',
+					`カスタム活動は最大${copyLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+				),
+			});
+		}
+
 		try {
 			const target = targetChildIds[0];
 			if (targetChildIds.length === 1 && target !== undefined) {

--- a/src/routes/api/v1/activities/+server.ts
+++ b/src/routes/api/v1/activities/+server.ts
@@ -1,8 +1,12 @@
 import { json } from '@sveltejs/kit';
+// #3740: client-facing 経路の wire source は信頼せず正準 'custom' を強制する (trust 境界分離)
+import { PARENT_CREATED_SOURCE } from '$lib/domain/activity-source';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { activitiesQuerySchema, createActivitySchema } from '$lib/domain/validation/activity';
 import { findChildById } from '$lib/server/db/activity-repo';
-import { validationError } from '$lib/server/errors';
+import { apiError, validationError } from '$lib/server/errors';
 import { createActivity, getActivities } from '$lib/server/services/activity-service';
+import { checkActivityLimit } from '$lib/server/services/plan-limit-service';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ url, locals }) => {
@@ -43,6 +47,24 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		return validationError(parsed.error.issues[0]?.message ?? '入力が不正です');
 	}
 
-	const activity = await createActivity(parsed.data, tenantId);
+	// #3740: 親手動作成経路 (admin `create` action と同型) の quota gate。gate 未通過だと
+	// free tier (maxActivities=3) が raw API 反復で上限を無制限に回避できる (課金境界執行)。
+	const licenseStatus = context.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
+	const limitCheck = await checkActivityLimit(tenantId, licenseStatus);
+	if (!limitCheck.allowed) {
+		return apiError(
+			'PLAN_LIMIT_EXCEEDED',
+			`カスタム活動は最大${limitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+			{ current: limitCheck.current, max: limitCheck.max },
+		);
+	}
+
+	// #3740: wire `source` ('seed'/'curriculum' 含む) を信頼すると quota 集計対象外の値を
+	// 注入して上限を回避できるため、client-facing 経路では正準 'custom' を強制する。
+	// seed / curriculum を指定できるのは内部 caller (seed.ts / import-service) のみ (trust 境界分離)。
+	const activity = await createActivity(
+		{ ...parsed.data, source: PARENT_CREATED_SOURCE },
+		tenantId,
+	);
 	return json(activity, { status: 201 });
 };

--- a/tests/integration/api/activity-api.test.ts
+++ b/tests/integration/api/activity-api.test.ts
@@ -111,6 +111,22 @@ const SQL_TABLES = `
 		description TEXT, reference_id INTEGER,
 		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 	);
+	-- #3740: POST /api/v1/activities の checkActivityLimit が resolveFullPlanTier 経由で
+	-- trial_history を読むため、quota gate 追加に伴い本テスト DB にも同テーブルが必要。
+	CREATE TABLE trial_history (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		tenant_id TEXT NOT NULL,
+		start_date TEXT NOT NULL,
+		end_date TEXT NOT NULL,
+		tier TEXT NOT NULL DEFAULT 'standard',
+		source TEXT NOT NULL,
+		campaign_id TEXT,
+		stripe_subscription_id TEXT,
+		upgrade_reason TEXT,
+		trial_start_source TEXT,
+		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+	CREATE INDEX idx_trial_history_tenant ON trial_history(tenant_id);
 `;
 
 vi.mock('$lib/server/db', () => ({

--- a/tests/unit/routes/activities-quota-residual-gate.test.ts
+++ b/tests/unit/routes/activities-quota-residual-gate.test.ts
@@ -1,0 +1,314 @@
+// tests/unit/routes/activities-quota-residual-gate.test.ts
+// #3740: #3678 same-class 残余 — 課金境界 (maxActivities quota) の producer 側 gating 残余 2 経路の回帰 lock。
+//
+// 根本原因 (QM Tier2 レビュー実確認):
+//   1. api/v1/activities POST が checkActivityLimit 未通過で createActivity を呼び、かつ
+//      createActivitySchema が client 供給 source ('seed'/'curriculum' 含む) を受理 +
+//      normalizeParentCreatedSource が既知値を透過するため、free ユーザーが
+//      `POST {"source":"seed"}` 反復で countsTowardActivityQuota=false の活動を無制限作成できた。
+//   2. copyFromChild action が checkActivityLimit 未通過で copy を実行 (copy は元活動の
+//      source='custom' を保全して quota を消費するため、上限到達後も copy で増殖できた)。
+//
+// 修正 (failing-test-first、ADR-0061):
+//   1. api/v1 POST に checkActivityLimit gate + wire source を信頼せず PARENT_CREATED_SOURCE
+//      ('custom') 強制 (trust 境界分離: seed/curriculum を指定できるのは内部 caller のみ)。
+//   2. copyFromChild に checkActivityLimit gate (importPackToChildren #2894 と同型)。
+//
+// **設計判断**: admin-activities-import-plan-gate.test.ts (#2894) と同型。SvelteKit CSRF を
+// 回避するため action / endpoint handler を直接呼び出して検証する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PARENT_CREATED_SOURCE } from '$lib/domain/activity-source';
+import { asCategoryId } from '$lib/domain/ids';
+
+// --- モック ---
+const mockRequireTenantId = vi.fn();
+const mockResolveFullPlanTier = vi.fn();
+const mockCheckActivityLimit = vi.fn();
+const mockCreateActivity = vi.fn();
+const mockCopyToSibling = vi.fn();
+const mockCopyToSiblings = vi.fn();
+const mockGetAllChildren = vi.fn();
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: mockRequireTenantId,
+	getAuthMode: vi.fn(() => 'cognito'),
+}));
+
+vi.mock('$lib/server/services/plan-limit-service', async () => {
+	const actual = await vi.importActual<typeof import('$lib/server/services/plan-limit-service')>(
+		'$lib/server/services/plan-limit-service',
+	);
+	return {
+		...actual,
+		resolveFullPlanTier: mockResolveFullPlanTier,
+		checkActivityLimit: mockCheckActivityLimit,
+	};
+});
+
+vi.mock('$lib/marketplace', () => ({
+	dispatchImport: vi.fn(),
+}));
+
+vi.mock('$lib/marketplace/sources/marketplace-source', () => ({
+	loadFromMarketplace: vi.fn(),
+}));
+
+vi.mock('$lib/marketplace/sources/file-source', () => ({
+	FileSourceError: class FileSourceError extends Error {},
+	loadActivityPackFromFile: vi.fn(),
+}));
+
+vi.mock('$lib/server/services/child-service', () => ({
+	getAllChildren: mockGetAllChildren,
+}));
+
+vi.mock('$lib/server/services/activity-service', () => ({
+	createActivity: mockCreateActivity,
+	deleteActivityWithCleanup: vi.fn(),
+	getActivities: vi.fn(async () => []),
+	getActivityLogCounts: vi.fn(async () => ({})),
+	getMainQuestCount: vi.fn(async () => 0),
+	hasActivityLogs: vi.fn(async () => false),
+	MAIN_QUEST_MAX: 3,
+	setActivityVisibility: vi.fn(),
+	setMainQuest: vi.fn(),
+	updateActivity: vi.fn(),
+}));
+
+vi.mock('$lib/server/services/child-activity-copy-service', () => ({
+	copyChildActivitiesToSibling: mockCopyToSibling,
+	copyChildActivitiesToSiblings: mockCopyToSiblings,
+}));
+
+// api/v1/activities GET が参照 (POST 経路では未使用)
+vi.mock('$lib/server/db/activity-repo', () => ({
+	findChildById: vi.fn(async () => undefined),
+}));
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: vi.fn(() => ({
+		childActivity: {
+			findActivitiesByChild: vi.fn(async () => []),
+			insertActivitiesBulk: vi.fn(async () => []),
+		},
+	})),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const apiMod = await import('../../../src/routes/api/v1/activities/+server');
+const adminMod = await import('../../../src/routes/(parent)/admin/activities/+page.server');
+
+type PlanLimitErrorShape = {
+	code: 'PLAN_LIMIT_EXCEEDED';
+	message: string;
+	currentTier: 'free' | 'standard' | 'family';
+	requiredTier: 'standard' | 'family';
+	upgradeUrl: '/admin/subscription';
+};
+type ActionResult = {
+	status?: number;
+	data?: { error: PlanLimitErrorShape | string };
+	copyResult?: boolean;
+	copiedCount?: number;
+	errorCount?: number;
+};
+
+const apiPost = apiMod.POST as unknown as (event: {
+	request: Request;
+	locals: App.Locals;
+}) => Promise<Response>;
+const copyFromChildAction = adminMod.actions.copyFromChild as unknown as (event: {
+	request: Request;
+	locals: App.Locals;
+}) => Promise<ActionResult>;
+
+function makeLocals(opts: { licenseStatus?: string; plan?: string } = {}) {
+	return {
+		context: {
+			tenantId: 'tenant-1',
+			licenseStatus: opts.licenseStatus ?? 'none',
+			plan: opts.plan,
+		},
+	} as unknown as App.Locals;
+}
+
+function makeJsonRequest(body: Record<string, unknown>): Request {
+	return new Request('http://localhost/api/v1/activities', {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+}
+
+function makeFormRequest(fields: Record<string, string | number>): Request {
+	const form = new FormData();
+	for (const [k, v] of Object.entries(fields)) {
+		form.append(k, String(v));
+	}
+	return new Request('http://localhost/admin/activities', { method: 'POST', body: form });
+}
+
+function validActivityBody(overrides: Record<string, unknown> = {}) {
+	return {
+		name: 'あたらしい活動',
+		categoryId: asCategoryId(1),
+		icon: '🏃',
+		basePoints: 5,
+		ageMin: null,
+		ageMax: null,
+		...overrides,
+	};
+}
+
+describe('#3740 quota 残余経路 gate (api/v1 POST + copyFromChild)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockRequireTenantId.mockReturnValue('tenant-1');
+		mockGetAllChildren.mockResolvedValue([
+			{ id: '902', nickname: 'preschool', tenantId: 'tenant-1' },
+			{ id: '903', nickname: 'elementary', tenantId: 'tenant-1' },
+		]);
+		mockCreateActivity.mockResolvedValue({ id: 'act-1', name: 'あたらしい活動' });
+	});
+
+	describe('api/v1/activities POST — checkActivityLimit gate', () => {
+		it('free tier が上限到達済みなら 403 PLAN_LIMIT_EXCEEDED を返し createActivity を呼ばない', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+			mockCheckActivityLimit.mockResolvedValue({ allowed: false, current: 3, max: 3 });
+
+			const res = await apiPost({
+				request: makeJsonRequest(validActivityBody()),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(res.status).toBe(403);
+			const body = (await res.json()) as { error: { code: string; message: string } };
+			expect(body.error.code).toBe('PLAN_LIMIT_EXCEEDED');
+			expect(body.error.message).toContain('3');
+			expect(mockCreateActivity).not.toHaveBeenCalled();
+		});
+
+		it("wire source='seed' 注入で quota gate を回避できない (上限到達時は seed 指定でも 403)", async () => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+			mockCheckActivityLimit.mockResolvedValue({ allowed: false, current: 3, max: 3 });
+
+			const res = await apiPost({
+				request: makeJsonRequest(validActivityBody({ source: 'seed' })),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(res.status).toBe(403);
+			expect(mockCreateActivity).not.toHaveBeenCalled();
+		});
+
+		it('上限未満なら 201 で作成する', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+			mockCheckActivityLimit.mockResolvedValue({ allowed: true, current: 1, max: 3 });
+
+			const res = await apiPost({
+				request: makeJsonRequest(validActivityBody()),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(res.status).toBe(201);
+			expect(mockCreateActivity).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("api/v1/activities POST — wire source 信頼しない ('custom' 強制、trust 境界分離)", () => {
+		beforeEach(() => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+			mockCheckActivityLimit.mockResolvedValue({ allowed: true, current: 0, max: 3 });
+		});
+
+		it.each([
+			'seed',
+			'curriculum',
+			'parent',
+		] as const)("client 供給 source='%s' は persist 前に 'custom' へ強制される", async (wireSource) => {
+			const res = await apiPost({
+				request: makeJsonRequest(validActivityBody({ source: wireSource })),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(res.status).toBe(201);
+			expect(mockCreateActivity).toHaveBeenCalledWith(
+				expect.objectContaining({ source: PARENT_CREATED_SOURCE }),
+				'tenant-1',
+			);
+		});
+
+		it("source 未指定も 'custom' で作成される", async () => {
+			const res = await apiPost({
+				request: makeJsonRequest(validActivityBody()),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(res.status).toBe(201);
+			expect(mockCreateActivity).toHaveBeenCalledWith(
+				expect.objectContaining({ source: PARENT_CREATED_SOURCE }),
+				'tenant-1',
+			);
+		});
+	});
+
+	describe('copyFromChild action — checkActivityLimit gate (#2894 importPack と同型)', () => {
+		it('free tier が上限到達済みなら 403 PlanLimitError を返し copy を実行しない', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+			mockCheckActivityLimit.mockResolvedValue({ allowed: false, current: 3, max: 3 });
+
+			const result = await copyFromChildAction({
+				request: makeFormRequest({ sourceChildId: '902', targetChildId: '903' }),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(result.status).toBe(403);
+			const err = result.data?.error as PlanLimitErrorShape;
+			expect(err).toMatchObject({
+				code: 'PLAN_LIMIT_EXCEEDED',
+				currentTier: 'free',
+				requiredTier: 'standard',
+				upgradeUrl: '/admin/subscription',
+			});
+			expect(err.message).toContain('3');
+			expect(mockCopyToSibling).not.toHaveBeenCalled();
+			expect(mockCopyToSiblings).not.toHaveBeenCalled();
+		});
+
+		it('上限未満なら単一 target への copy を実行する', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('free');
+			mockCheckActivityLimit.mockResolvedValue({ allowed: true, current: 1, max: 3 });
+			mockCopyToSibling.mockResolvedValue([{ id: 'a1' }, { id: 'a2' }]);
+
+			const result = await copyFromChildAction({
+				request: makeFormRequest({ sourceChildId: '902', targetChildId: '903' }),
+				locals: makeLocals({ licenseStatus: 'none' }),
+			});
+
+			expect(result.status).toBeUndefined();
+			expect(result.copyResult).toBe(true);
+			expect(result.copiedCount).toBe(2);
+			expect(mockCopyToSibling).toHaveBeenCalledTimes(1);
+		});
+
+		it('paid tier (standard、max=null) は複数 target への copy を実行する', async () => {
+			mockResolveFullPlanTier.mockResolvedValue('standard');
+			mockCheckActivityLimit.mockResolvedValue({ allowed: true, current: 0, max: null });
+			mockCopyToSiblings.mockResolvedValue({ totalCopied: 4, errors: [] });
+
+			const result = await copyFromChildAction({
+				request: makeFormRequest({ sourceChildId: '902', targetChildIds: '903,904' }),
+				locals: makeLocals({ licenseStatus: 'active', plan: 'standard_monthly' }),
+			});
+
+			expect(result.status).toBeUndefined();
+			expect(result.copyResult).toBe(true);
+			expect(result.copiedCount).toBe(4);
+			expect(mockCopyToSiblings).toHaveBeenCalledTimes(1);
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（課金境界）/ 開発者

**解決する課題**: PR #3678 (#3669) で活動 source 意味論を SSOT 化し admin UI 経路の quota 未執行を根治したが、QM Tier2 レビューで producer 側 gating の same-class 残余 2 件が検出された。① `api/v1/activities` POST が `checkActivityLimit` 未通過 + client 供給 `source` (`'seed'`/`'curriculum'`) を受理するため、free ユーザーが `POST {"source":"seed"}` 反復で `maxActivities=3` を無制限回避できた。② `copyFromChild` action が gate 未通過で copy を実行するため、上限到達後も copy で custom 活動を増殖できた。

**期待される効果**: quota（有料転換 driver）の課金境界が raw API / copy 経路でも完全執行され、free → 有料転換圧力が毀損しない。client-facing wire 経路で `source` を信頼しない trust 境界が確立し、同型の quota 回避が構造的に再発しない。

## 関連 Issue

closes #3740

関連: #3678（親、activity source SSOT）/ #3669 / ADR-0055（per-child quota）/ #2894（importPack gate 先例）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `api/v1/activities` POST に `checkActivityLimit` gate 追加（上限到達時 403、`createActivity` 不実行） | `npx vitest run tests/unit/routes/activities-quota-residual-gate.test.ts` | HEAD `8f6b1d42` / 10 passed（うち gate 3 件: 403 + PLAN_LIMIT_EXCEEDED + createActivity 未呼出）/ `src/routes/api/v1/activities/+server.ts:53-63` |
| AC2 | 親作成 client-facing 経路で wire `source` を信頼せず `'custom'` 強制（内部 caller のみ seed/curriculum 許可 = trust 境界分離） | 同上（`it.each(['seed','curriculum','parent'])` + 未指定の 4 件） | HEAD `8f6b1d42` / client 供給 source が全て `PARENT_CREATED_SOURCE` で `createActivity` に渡ることを assert / `src/routes/api/v1/activities/+server.ts:65-71` |
| AC3 | `copyFromChild` action に `checkActivityLimit` gate 追加（#2894 importPack gate と同型） | 同上（copyFromChild describe 3 件） | HEAD `8f6b1d42` / 上限到達時 403 PlanLimitError + copy 未実行、上限未満 / paid tier は copy 実行を assert / `src/routes/(parent)/admin/activities/+page.server.ts:535-549` |
| AC4 | api/v1 endpoint gating + wire source 注入の quota 回帰テスト（ADR-0006） | failing-test-first: テスト先行 commit 前に赤で実行 → 修正 → 緑 | HEAD `8f6b1d42` / red: 7 failed / 3 passed（修正前）→ green: 10 passed（修正後）/ `tests/unit/routes/activities-quota-residual-gate.test.ts`（新規 335 行） |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)

**影響を受ける画面・機能**:
- `POST /api/v1/activities`（活動作成 API）— free tier で上限到達時に 403 PLAN_LIMIT_EXCEEDED を返すようになる（従来は無制限に 201）。client 供給 `source` は persist 前に `'custom'` に強制される
- 親管理画面「他の子から copy」（`/admin/activities` の `copyFromChild` action）— free tier で上限到達時に PlanLimitError（アップグレード導線付き）を返す

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— worktree では biome が 0 file になる既知制約のため、同等検証を個別実行で完了: `npx biome check <変更 3 file>` PASS / `npx svelte-check`（変更ファイル起因エラー 0、既存エラーは worktree の infra deps 未 install 起因で本 PR 変更と無関係）/ `npx vitest run` targeted 4 suite 28 passed / `node scripts/check-pr-body.mjs --pr 3753` PASS。full-repo `pre-ready` は Ready 化前に main repo で親セッションが必須実行（Ready 化前 5 項目 SSOT）
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/routes/activities-quota-residual-gate.test.ts`（新規、10 件）: api/v1 POST の quota gate（403 / createActivity 未呼出）、wire source `'seed'`/`'curriculum'`/`'parent'` 注入の `'custom'` 強制、copyFromChild の gate（403 PlanLimitError / copy 未実行）+ 上限未満・paid tier の正常系。#2894 の `admin-activities-import-plan-gate.test.ts` と同型 harness（action / endpoint handler 直接呼出）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（repo 層変更なし、route / action 層のみ）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（severity medium、priority 標準）

## スクリーンショット / ビジュアルデモ

**該当なし（API endpoint の quota gate + form action の gate 追加のみで UI 変更なし。copyFromChild の 403 PlanLimitError 表示は既存の PlanLimitError ハンドリング UI をそのまま使用）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: gate は既存 `checkActivityLimit`（plan-limit-service の単一強制点）を再利用、endpoint / action に判定ロジックを重複実装していない
- [x] **DRY**: `grep -n "checkActivityLimit" src/` で producer 全経路を確認 — create / bulkCreateForChildren / importPack / importPackToChildren（#2894 済）+ 本 PR の copyFromChild / api/v1 POST で全経路 gate 済。PATCH (`api/v1/activities/[id]`) は `_toChildActivityUpdateInput` が source を map しないため source 書換え経路は構造的に存在しないことを確認
- [x] **YAGNI**: 新規抽象化なし（既存 `apiError('PLAN_LIMIT_EXCEEDED', ...)` / `createPlanLimitError` の慣例に合流）
- [x] **Security（OSS 公開前提）**: 信頼境界の是正そのもの（client 供給 wire `source` を server 側で信頼しない = input trust 境界分離）。認可は既存 `locals.context` 経由で変更なし
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: `checkActivityLimit` は per-child loop 集計（既存 create action と同一コスト）。copyFromChild / POST に各 1 回のみ追加で N+1 なし

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] **設計書同期** (ADR-0001): `docs/design/data-model-resource-scope.md` §「`source` 列の意味論 SSOT」に trust 境界分離（client-facing wire は `'custom'` 強制）+ producer 側 quota gate 適用経路一覧（6 経路）を同 PR で更新
- [x] **並行 PR overlap** (#1200): `api/v1/activities/+server.ts` / `admin/activities/+page.server.ts` を変更する open PR が他に無いことを確認
- [x] 横展開確認: 同型の copy action を持つ `admin/rewards` の `copyFromChild` は reward に per-plan 数量上限（maxRewards 相当）が存在しないため gate 対象外。`admin/checklists` の copy は assignments 追加（template 複製なし）で `checkChecklistTemplateLimit` の集計対象を増やさないため対象外
- [x] N/A — 上記以外（demo / 年齢モード / ナビ / seed / labels）は本変更の影響範囲外（UI 文言・スキーマ変更なし）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

（api/v1 POST の挙動変更は「free tier 上限到達時に 403」「client 供給 source の無視」の 2 点だが、いずれも課金境界仕様（PLAN_LIMITS.free.maxActivities=3 / source 意味論 SSOT #3669）への準拠であり、正規クライアント（admin UI は form action 経由で `PARENT_CREATED_SOURCE` を明示送信）には影響しない）

**レビュー依頼事項・QA**:
- copyFromChild の gate は「copy 実行前の上限到達チェック」（#2894 importPack gate と同型の事前判定）。copy される活動のうち custom 分だけ数えて「copy 後に上限を超えるか」まで精査する厳密判定は、gate の複雑化に対し課金境界防御の追加効果が乏しい（上限到達後の増殖は本 gate で遮断済み）ため不採用とした。この判断の妥当性を確認いただきたい

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — worktree の biome 0 file 既知制約により個別実行で同等検証済（詳細は上記「テスト & 安全装置セルフチェック」）。full-repo `pre-ready` は Ready 化前に main repo で親セッションが必須実行
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割した場合: N/A（分割なし）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

