### PR TITLE
infra(hardening): #3745 workflow_dispatch input の run 直展開を env 経由に (script injection 防御 + same-class 2 workflow 横展開)

### DIFF
--- a/.github/workflows/audit-run.yml
+++ b/.github/workflows/audit-run.yml
@@ -180,11 +180,16 @@ jobs:
       - name: Pipeline CLI smoke (sample fixture → 集約レポート)
         # 固定 fixture (scripts/audit/fixtures/sample-evidence.json) を evidence dir に置き、
         # verify → run-pipeline --strict が exit 0 になることを確認する (pipeline 配線の健全性)。
+        # workflow_dispatch input は run: へ ${{ }} 直展開せず env 経由で渡す
+        # (script injection 定石、#3745。run_id は自由文字列 input のため特に必須)
+        env:
+          RUN_ID: ${{ inputs.run_id }}
+          SCOPE: ${{ inputs.scope }}
         run: |
           mkdir -p tmp/audit-evidence
           cp scripts/audit/fixtures/sample-evidence.json tmp/audit-evidence/sample.json
           node scripts/audit/verify-audit-evidence.mjs --file tmp/audit-evidence/sample.json
-          node scripts/audit/run-pipeline.mjs --run-id "${{ inputs.run_id }}" --scope "${{ inputs.scope }}" --strict
+          node scripts/audit/run-pipeline.mjs --run-id "$RUN_ID" --scope "$SCOPE" --strict
       - name: Upload pipeline report artifact
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/close-leak-report.yml
+++ b/.github/workflows/close-leak-report.yml
@@ -58,7 +58,11 @@ jobs:
 
       # script が markdown report を stdout + GITHUB_STEP_SUMMARY へ出力する。
       # 検出 0 件でも N 件でも exit 0 (gate ではない)。
+      # workflow_dispatch input は run: へ ${{ }} 直展開せず env 経由で渡す
+      # (GitHub Actions script injection 定石、#3745。shell が $SINCE を展開するため
+      #  input 値が shell 構文として解釈されない)
       - name: Detect close leaks (report only)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: node scripts/audit/close-leak-report.mjs --since "${{ inputs.since || '90 days ago' }}"
+          SINCE: ${{ inputs.since || '90 days ago' }}
+        run: node scripts/audit/close-leak-report.mjs --since "$SINCE"

--- a/.github/workflows/integration-attest.yml
+++ b/.github/workflows/integration-attest.yml
@@ -115,11 +115,15 @@ jobs:
 
       - name: No-op summary (統合 merge でない)
         if: steps.classify.outputs.is_integration != 'true'
+        # workflow_dispatch input (自由文字列) は run: へ ${{ }} 直展開せず env 経由で渡す
+        # (script injection 定石、#3745)
+        env:
+          TARGET_SHA: ${{ inputs.sha || github.sha }}
         run: |
           {
             echo "## integration-attest: no-op";
             echo "";
-            echo "- 対象 SHA: \`${{ inputs.sha || github.sha }}\`";
+            echo "- 対象 SHA: \`$TARGET_SHA\`";
             echo "- 理由: ${{ steps.classify.outputs.reason }}";
             echo "";
             echo "統合 PR (base=main + head=develop|release/*) の merge ではないため attestation を発行しません (silent fail なし)。";


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（OSS 公開前提のリポジトリ利用者を含む）

**解決する課題**: PR #3675 の `close-leak-report.yml` が `workflow_dispatch` input を `run:` に `${{ inputs.since }}` で直接補間しており、GitHub Actions script injection の典型アンチパターンだった（write 権限者のみトリガ可 + read-only token のため blast radius は小だが、OSS 公開前提の hardening として是正）。横断確認で同型 2 workflow（audit-run.yml の `run_id`/`scope`、integration-attest.yml の `sha`）も検出した。

**期待される効果**: input 値が shell 構文として解釈される経路を全廃し（env 経由化で shell の `$VAR` 展開に切替）、workflow への悪意ある入力によるコマンド実行の芽を摘む。GitHub 公式 security hardening guide の定石に整合。

## 関連 Issue

Closes #3745

関連: PR #3675 / #3459（close 漏れ検知本体）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | close-leak-report.yml の `${{ inputs.since }}` run 直展開を env 経由に変更 | `grep -n "SINCE" .github/workflows/close-leak-report.yml` | HEAD `31988d4a` / L67 `SINCE: ${{ inputs.since \|\| '90 days ago' }}` + L68 `run: ... --since "$SINCE"`（Issue 記載の方針そのまま） |
| AC2 | 同 workflow 内の他 input 直展開なし | `grep -n 'inputs\.' .github/workflows/close-leak-report.yml` | HEAD `31988d4a` / input は `since` 1 つのみ、env 行 L67 の 1 出現のみ（run 直展開 0） |
| AC3 | 他 workflow の same-class（`${{ inputs.* }}` / `${{ github.event.* }}` の run 直接補間）を横断確認し是正 | run block 追跡 scan（下記横展開表のコマンド） | HEAD `31988d4a` / audit-run.yml（run_id/scope → env RUN_ID/SCOPE）+ integration-attest.yml（sha → env TARGET_SHA）を是正、残存 `inputs.*` run 直展開 0 件 |
| AC4 | 変更 3 file の YAML 構文が valid | `python -c "import yaml; yaml.safe_load(open(f))"` × 3 file | HEAD `31988d4a` / 3 file とも YAML OK（parse エラーなし） |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — workflow 3 file のみ

**影響を受ける画面・機能**: なし（週次 report workflow / 手動監査 run / attestation の入力受け渡し方法のみ変更。コマンドの実引数値は不変）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— worktree 制約（full-repo biome が 0 file になる既知事象）のため、変更 3 file の YAML parse 検証 + check-pr-body で検証済。full-repo pre-ready は Ready 化前に親セッションが実施する分担。app コード変更ゼロのため vitest / svelte-check への影響なし
- [x] 追加・変更したテストの概要: N/A（workflow YAML のみの hardening。検出ロジック script `scripts/audit/close-leak-report.mjs` 本体は不変で、既存 unit test `tests/unit/audit/close-leak-report.test.ts` がカバー継続）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（workflow step ローカルの env 変数のみ。GitHub Secrets / SSM への新規配布物なし）
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:low）

## スクリーンショット / ビジュアルデモ

**該当なし**（CI workflow YAML のみの変更で UI 差分ゼロ）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（YAML 設定変更のみ）
- [x] **DRY**: 3 箇所とも同一の env 経由パターンに統一（`env:` 宣言 + `"$VAR"` 参照 + 定石コメント）
- [x] **YAGNI**: 検出 lint の新設は見送り（本 repo は同型 3 件で全数是正済。actionlint 等の導入は Pre-PMF 過剰防衛 ADR-0010 と判断、必要になれば Issue 起点で再検討）
- [x] **Security（OSS 公開前提）**: GitHub Actions script injection 定石（[Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)）に整合。token 権限は不変（read-only 維持）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**: 

- [x] N/A — 並行実装の影響範囲外（workflow YAML のみ、アプリ / LP / labels / 設計書対象外。CI workflow の変更は設計書更新対象外で `.github/` 内コメントが仕様記述）

**same-class 横展開の全数確認（Issue「他 workflow の同型横断確認」の実施記録）**:

| 確認対象 | 検証コマンド | output 件数 | 判定 |
|---|---|---|---|
| `${{ inputs.* }}` の全出現（workflows + composite actions） | `grep -rn '\${{ *inputs\.' .github/` | 11 件 → run 直展開は 3 workflow（本 PR で全数是正）、残 8 件は `with: name:`（artifact 名、shell 非経由）/ `env:` 宣言（既に定石準拠）のみ | ✓ |
| run: block 内の `inputs.*` / `github.event.*` / `head_ref` 直展開（インデント追跡 scan、multiline `run: \|` 対応） | Python scan（run block 判定 + pattern match、コミットメッセージ記載の手法） | 是正後 `inputs.*` = 0 件。`github.event.*` 残 7 件は `pull_request.number`（GitHub 生成の整数）/ `base.sha` / `head.sha`（40-hex）のみで shell metacharacter を含み得ない構造的安全値（GitHub hardening guide の危険 field = title / body / branch 名 / commit message 等に非該当） | ✓ |
| 変更 3 file の YAML 構文 | `python -c "import yaml; yaml.safe_load(...)"` | 3 file とも parse OK | ✓ |

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

（3 workflow とも入力値の実引数は不変。workflow_dispatch の入力仕様 / cron / permissions / concurrency に変更なし）

**レビュー依頼事項・QA**:
`github.event.pull_request.number` / `base.sha` / `head.sha` の run 直展開 7 件（ci.yml / pr-info.yml / pr-quality-gate.yml）は、GitHub が生成する整数 / 40-hex 値で injection 不能のため意図的に scope 外とした（Issue の same-class 定義 = `inputs.*` / `github.event.*.body` に非該当）。この分類の妥当性を確認いただきたい。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（workflow step ローカルの env 変数のみ）

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** — worktree 個別検証（YAML parse 3 file / check-pr-body / same-class scan 残存 0）済。full-repo 実行は Ready 化前に親セッションが実施する分担
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装のまま残っている AC がない）
- [x] Phase 分割した場合: N/A（単一 PR で完結）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
