### PR TITLE
fix(a11y): #3743 members ページ残 6 await 駆動ボタンに loading 適用 (#3667 same-class)

### DIFF
--- a/src/routes/(parent)/admin/members/+page.svelte
+++ b/src/routes/(parent)/admin/members/+page.svelte
@@ -68,8 +68,13 @@ async function createInvite() {
 	}
 }
 
+// #3743: await 駆動ハンドラの実行中フラグ (DESIGN.md §5 Button loading prop、#3667 same-class)。
+// 対象 item の id を保持し、該当ボタンのみ spinner + disabled + aria-busy にする。
+let revokingInviteCode = $state<string | null>(null);
+
 async function revokeInvite(code: string) {
 	if (!confirm(MEMBERS_LABELS.revokeConfirm)) return;
+	revokingInviteCode = code;
 	try {
 		const res = await fetch(`/api/v1/admin/invites/${code}`, { method: 'DELETE' });
 		// #3225: 取り消し失敗を silent にしない (失敗時は reload せず error Toast)
@@ -77,11 +82,12 @@ async function revokeInvite(code: string) {
 			await notifyApiError(res);
 			return;
 		}
+		window.location.reload();
 	} catch {
 		notifyNetworkError();
-		return;
+	} finally {
+		revokingInviteCode = null;
 	}
-	window.location.reload();
 }
 
 async function copyLink() {
@@ -132,8 +138,17 @@ async function createViewerLink() {
 	}
 }
 
+// #3743: 閲覧リンク行の revoke / delete 実行中フラグ。同一行の 2 ボタン同時発火 (二重送信) を
+// 防ぐため、どちらかが実行中なら両ボタンを disabled にする (viewerActionPending)。
+let revokingViewerTokenId = $state<string | null>(null);
+let deletingViewerTokenId = $state<string | null>(null);
+const viewerActionPending = $derived(
+	revokingViewerTokenId !== null || deletingViewerTokenId !== null,
+);
+
 async function revokeViewerToken(id: string) {
 	if (!confirm(MEMBERS_LABELS.viewerRevokeConfirm)) return;
+	revokingViewerTokenId = id;
 	try {
 		const res = await fetch(`/api/v1/admin/viewer-tokens/${id}?action=revoke`, {
 			method: 'DELETE',
@@ -142,26 +157,29 @@ async function revokeViewerToken(id: string) {
 			await notifyApiError(res);
 			return;
 		}
+		window.location.reload();
 	} catch {
 		notifyNetworkError();
-		return;
+	} finally {
+		revokingViewerTokenId = null;
 	}
-	window.location.reload();
 }
 
 async function deleteViewerToken(id: string) {
 	if (!confirm(MEMBERS_LABELS.viewerDeleteConfirm)) return;
+	deletingViewerTokenId = id;
 	try {
 		const res = await fetch(`/api/v1/admin/viewer-tokens/${id}`, { method: 'DELETE' });
 		if (!res.ok) {
 			await notifyApiError(res);
 			return;
 		}
+		window.location.reload();
 	} catch {
 		notifyNetworkError();
-		return;
+	} finally {
+		deletingViewerTokenId = null;
 	}
-	window.location.reload();
 }
 
 async function copyViewerLink() {
@@ -174,9 +192,19 @@ async function copyViewerLink() {
 
 let memberError = $state('');
 
+// #3743: メンバー操作 (オーナー移譲 / 削除 / 離脱) の実行中フラグ。特にオーナー移譲・離脱は
+// 冪等でない不可逆操作のため、実行中はメンバー操作系ボタン全体を disabled にして二重送信を防ぐ。
+let transferringUserId = $state<string | null>(null);
+let removingUserId = $state<string | null>(null);
+let leavingGroup = $state(false);
+const memberActionPending = $derived(
+	transferringUserId !== null || removingUserId !== null || leavingGroup,
+);
+
 async function removeMember(userId: string, email: string) {
 	if (!confirm(MEMBERS_LABELS.removeMemberConfirm(email))) return;
 	memberError = '';
+	removingUserId = userId;
 	try {
 		const res = await fetch(`/api/v1/admin/members/${userId}`, { method: 'DELETE' });
 		if (!res.ok) {
@@ -187,12 +215,15 @@ async function removeMember(userId: string, email: string) {
 		window.location.reload();
 	} catch {
 		memberError = MEMBERS_LABELS.networkError;
+	} finally {
+		removingUserId = null;
 	}
 }
 
 async function transferOwnership(userId: string, email: string) {
 	if (!confirm(MEMBERS_LABELS.transferConfirm(email))) return;
 	memberError = '';
+	transferringUserId = userId;
 	try {
 		const res = await fetch(`/api/v1/admin/members/${userId}/transfer-ownership`, {
 			method: 'POST',
@@ -205,12 +236,15 @@ async function transferOwnership(userId: string, email: string) {
 		window.location.reload();
 	} catch {
 		memberError = MEMBERS_LABELS.networkError;
+	} finally {
+		transferringUserId = null;
 	}
 }
 
 async function leaveGroup() {
 	if (!confirm(MEMBERS_LABELS.leaveGroupConfirm)) return;
 	memberError = '';
+	leavingGroup = true;
 	try {
 		const res = await fetch('/api/v1/admin/members/leave', { method: 'POST' });
 		if (!res.ok) {
@@ -221,6 +255,8 @@ async function leaveGroup() {
 		window.location.href = '/auth/login';
 	} catch {
 		memberError = MEMBERS_LABELS.networkError;
+	} finally {
+		leavingGroup = false;
 	}
 }
 
@@ -283,6 +319,8 @@ const roleLabel = (role: string) => {
 										variant="ghost"
 										size="sm"
 										title={MEMBERS_LABELS.transferTitle}
+										loading={transferringUserId === member.userId}
+										disabled={memberActionPending}
 									>
 										{MEMBERS_LABELS.transferButton}
 									</Button>
@@ -291,6 +329,8 @@ const roleLabel = (role: string) => {
 										variant="danger"
 										size="sm"
 										title={MEMBERS_LABELS.removeTitle}
+										loading={removingUserId === member.userId}
+										disabled={memberActionPending}
 									>
 										{MEMBERS_LABELS.removeButton}
 									</Button>
@@ -309,6 +349,8 @@ const roleLabel = (role: string) => {
 					onclick={leaveGroup}
 					variant="danger"
 					size="sm"
+					loading={leavingGroup}
+					disabled={memberActionPending}
 				>
 					{MEMBERS_LABELS.leaveGroupButton}
 				</Button>
@@ -445,6 +487,8 @@ const roleLabel = (role: string) => {
 								onclick={() => revokeInvite(invite.inviteCode)}
 								variant="danger"
 								size="sm"
+								loading={revokingInviteCode === invite.inviteCode}
+								disabled={revokingInviteCode !== null}
 							>
 								{MEMBERS_LABELS.inviteRevokeButton}
 							</Button>
@@ -572,6 +616,8 @@ const roleLabel = (role: string) => {
 										onclick={() => revokeViewerToken(vt.id)}
 										variant="ghost"
 										size="sm"
+										loading={revokingViewerTokenId === vt.id}
+										disabled={viewerActionPending}
 									>
 										{MEMBERS_LABELS.viewerRevokeButton}
 									</Button>
@@ -580,6 +626,8 @@ const roleLabel = (role: string) => {
 									onclick={() => deleteViewerToken(vt.id)}
 									variant="danger"
 									size="sm"
+									loading={deletingViewerTokenId === vt.id}
+									disabled={viewerActionPending}
 								>
 									{MEMBERS_LABELS.viewerDeleteButton}
 								</Button>


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: メンバー管理ページの取り消し / 削除 / オーナー移譲 / 離脱ボタンは await を伴う fetch を実行するが、クリック後に視覚 feedback が無く「動作したか不明」なまま再クリックできてしまう（NN/G #1 visibility of system status 違反、CX-DoR #9）。特にオーナー移譲・グループ離脱は不可逆操作であり、二重送信リスクが重大。

**期待される効果**: 6 つの await 駆動ボタン全てに spinner + disabled + `aria-busy` の visible feedback が出て、処理中の再クリック誤動作が構造的に防止される。スクリーンリーダー利用者にも「処理中」が伝わる（DESIGN.md §5 Button loading prop 準拠）。

## 関連 Issue

closes #3743

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 残 6 ハンドラ (revokeInvite / revokeViewerToken / deleteViewerToken / removeMember / transferOwnership / leaveGroup) の Button に `loading` prop を適用 | `git show HEAD:"src/routes/(parent)/admin/members/+page.svelte" \| grep -c "loading={"` | HEAD `ded498e4` / 8 件 (既存 create 系 2 + 本 PR 6) / src/routes/(parent)/admin/members/+page.svelte:311,319,341,470,514,608 |
| AC2 | 各ハンドラは try/finally で busy state を確実に reset | `git show HEAD:"src/routes/(parent)/admin/members/+page.svelte" \| grep -c "finally {"` | HEAD `ded498e4` / 8 件 (既存 2 + 本 PR 6、全ハンドラ finally reset) / 同ファイル L92-98, L165-186, L207-233, L248-297 |
| AC3 | 不可逆操作 (オーナー移譲 / 離脱) の二重送信ガード: 実行中はメンバー操作系ボタン全体を disabled | `grep -n "memberActionPending\|viewerActionPending" "src/routes/(parent)/admin/members/+page.svelte"` | HEAD `ded498e4` / memberActionPending 4 箇所 (定義 + transfer/remove/leave の disabled) / viewerActionPending 3 箇所 (定義 + revoke/delete の disabled) |
| AC4 | 変更ファイルの lint PASS | `npx biome check "src/routes/(parent)/admin/members/+page.svelte"` | HEAD `ded498e4` / Checked 1 file. No fixes applied (エラー 0) |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: `/admin/members` (メンバー管理) のみ。招待取り消し / 閲覧リンク無効化・削除 / メンバー削除 / オーナー移譲 / グループ離脱の 6 ボタン。API・サーバー側の変更なし (client 側 state のみ)。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 本 Agent は worktree (node_modules 非配置) のため、実行可能な step を個別実行済: `npx biome check "src/routes/(parent)/admin/members/+page.svelte"` PASS (Checked 1 file, No fixes)。svelte-check / vitest / pre-ready 一括は CI と親セッションの Ready 化工程が検証する (本 PR は Draft)
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）: N/A — 既存 Button primitive の `loading` prop (spinner + disabled + aria-busy は `src/lib/ui/primitives/Button.svelte` で単体検証済) を適用するのみで、新規ロジックなし。PR #3667 (同 class の招待ボタン loading 適用) もテスト追加なしの先例
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (priority:low、a11y same-class 残余)

## スクリーンショット / ビジュアルデモ

`/admin/members` ページ全体 SS（2026-07-15 親セッション撮影、demo 決定的環境 `AUTH_MODE=anonymous DATA_SOURCE=demo` + `?screenshot=all`、screenshots branch `pr-3755/`）:

| モバイル (390px) | PC (1440px) |
|---|---|
| ![members-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3755/admin-members-mobile.png) | ![members-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3755/admin-members-desktop.png) |

**loading spinner 状態の可視化制約（正直な申告）**: 本 PR が loading を追加した 6 ボタン（revokeInvite / revokeViewerToken / deleteViewerToken / removeMember / transferOwnership / leaveGroup）は、**保留中の招待・閲覧トークン・複数メンバーが存在する時のみ描画**される。demo fixture にはこれらの状態が無いため（招待/トークン 0 件・メンバー 1 名）、静的 SS には該当ボタンが現れない。加えて loading spinner は await 中のみの transient 状態で静的キャプチャに写らない。したがって本変更の証跡は **コード検証**（`loading={` 8 件 = 既存 2 + 新規 6 / `finally {` 8 件で state reset を grep 確認）を一次エビデンスとし、SS は「members ページが正しく描画される」ことの担保とする。実 loading 表示の人間検証は cloud staging（#2873）整備後に補完可能。

**インタラクティブ状態**: loading 中は Button primitive が `aria-busy="true"` + `disabled` を強制（不可逆操作の二重送信防止も `memberActionPending` / `viewerActionPending` の相互 disabled で担保）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — busy state は各ハンドラに 1:1 対応、UI 表示は Button primitive の `loading` prop に委譲 (再実装なし)
- [x] **DRY**: 同一パターン (loading 未適用の await ボタン) の残存を `grep -n "onclick=" "src/routes/(parent)/admin/members/+page.svelte"` で全件確認 — copyLink / copyViewerLink (clipboard、即時完了・非破壊) を除き全 await fetch ボタンに適用済
- [x] **YAGNI**: 新規抽象化なし ($state + $derived のみ)
- [x] **Security（OSS 公開前提）**: N/A — client 側 UI state のみ、認可・入力検証の変更なし
- [x] **アクセシビリティ**: `loading` prop が `aria-busy="true"` + `disabled` を強制 (Button.svelte 実装)。sr-only の処理中ラベルも primitive 側で付与
- [x] **パフォーマンス**: N/A — fetch 回数・payload 不変

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] N/A — 並行実装の影響範囲外（`/admin/members` は demo Lambda でも同一ルートを host (ADR-0048)、デモ側の別実装なし。ラベル変更なし・DB 変更なし・ナビ変更なし）

**同 class 残余の確認 (Fix 完遂検証 log)**:

| Fix item | 検証コマンド | output 件数 | 判定 |
|---|---|---|---|
| 6 ハンドラ全てに loading 適用 | `git show HEAD:"src/routes/(parent)/admin/members/+page.svelte" \| grep -c "loading={"` | 8 件 (既存 2 + 新規 6) | ✓ |
| 全ハンドラ try/finally reset | `git show HEAD:"src/routes/(parent)/admin/members/+page.svelte" \| grep -c "finally {"` | 8 件 | ✓ |

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**:
- 成功時は `window.location.reload()` (既存挙動) のため、finally の busy reset は reload 開始直前に一瞬走るが実害なし (Issue 方針の try/finally reset に従う)
- メンバー操作 3 ボタン (移譲 / 削除 / 離脱) は `memberActionPending` で相互 disabled とした (同一メンバーへの移譲 + 削除の同時発火防止)。Issue 本文の「二重送信リスク」への対応として意図的に self-loading より一段広いガードにしている

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — worktree 制約により個別 step 実行 (biome PASS)。skip なし一括実行は親セッションの Ready 化工程が実施 (本 PR は Draft 提出)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了表記のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — N/A (Phase 分割なし)
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認 — SS embed は親セッション担当工程 (Draft 段階)。§9 禁忌 6 点はコード上で確認済 (hex 直書きなし / primitive 再実装なし / インラインスタイルなし / style ブロック増加なし)
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A (認証画面ではない)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

<!-- QM: refactor:internal-no-doc-impact label 付与済 (loading-prop のみ・視覚仕様不変・DESIGN.md §5 既記載で docs/design 同期対象ゼロ)。design-doc-check 再走用 edited trigger。 -->
