### PR TITLE
fix(data-integrity): #3750 アカウント削除の orphan child partition 混在時 sweep 完全性

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -160,6 +160,21 @@ DynamoDB = parity 実装」の主従関係と二重 SSOT 化で衝突するた�
   (silent partial delete 禁止)、削除は page 単位 streaming で途中失敗後の再実行が冪等。
   regression fitness: `tests/unit/db/dynamodb-bulk-delete.test.ts` (Scan 0 回 / tenant 境界 /
   UnprocessedItems retry / 冪等再開)。
+- **orphan child partition sweep で childIds 非空時の削除完全性を保証する (#3750)**:
+  `deleteChildScopedItems` は childIds 非空時に既知 child partition のみ Query するため、
+  過去の部分失敗で child profile だけ消えて scoped データが残った orphan child partition
+  (childId が active でも archived でもない) を、他に現存児童 ≥1 のとき取り漏らす。
+  `deleteTenantScopedData` は末尾で `child.sweepOrphanChildPartitions(tenantId, childIds)`
+  (`deleteOrphanChildPartitionItems`、bulk-delete.ts) を **childIds 非空時のみ 1 回** 呼び、
+  child partition prefix を Scan して既知 partition を除いた残骸を消す (退会 = 削除権 CUJ の
+  完全性優先)。既知 partition の除外は後続 `deleteAllChildrenData` の児童列挙 → ファイル削除
+  経路を壊さないため。childIds 未供給 (児童 0 人) 時は各 repo の Scan fallback が既に orphan を
+  拾うため呼ばず二重 Scan を避ける。partition storage 固有のため DynamoDB backend のみ実装
+  (relational backend は FK cascade で orphan 行が生じず optional method 未実装)。DSQL の
+  same-class は EPIC #3424 で扱う。regression fitness:
+  `tests/unit/db/dynamodb-bulk-delete.test.ts` (混在時取り漏らし → sweep で残骸のみ削除 /
+  既知 partition・他 tenant 不変) + `tests/unit/services/tenant-cleanup-service.test.ts`
+  (childIds 非空時のみ sweep 呼出 / 0 児童時 skip / sweep 失敗の非ブロック)。
 
 #### 原則 2: tenant 横断 Scan → GSI 移行の閾値
 

--- a/src/lib/server/db/dynamodb/bulk-delete.ts
+++ b/src/lib/server/db/dynamodb/bulk-delete.ts
@@ -187,3 +187,60 @@ export async function deleteChildScopedItems(
 	}
 	return deleted;
 }
+
+/**
+ * orphan child partition (`T#<tenantId>#CHILD#<childId>`) の残骸を sweep する (#3750)。
+ *
+ * `deleteChildScopedItems` は childIds が非空のとき、既知 child の partition のみを
+ * per-child Query で削除する。過去の部分失敗で child profile だけ消えて scoped データが
+ * 残った orphan partition (childId が active でも archived でもない) は、他に現存児童が
+ * ≥1 (= childIds 非空) だと per-child Query 経路では取り漏らす。旧 Scan fallback は PK
+ * prefix で全 child partition を拾っていたため、この orphan を消せていた。
+ *
+ * 本関数は child partition prefix を 1 度だけ Scan し、既知 partition (`knownChildIds`)
+ * を除いた残存 item を削除して混在ケースの完全性を回復する。退会 = 削除権 (GDPR / 個情法)
+ * を伴う CUJ のため、read が全テナント総量に比例する Scan コストを 1 回だけ許容してでも
+ * 取り漏らしを塞ぐ (#3693 の per-repo Scan × 約 25 とは異なり、末尾 1 回の低頻度 fallback)。
+ *
+ * 既知 partition を除外するのは、tenant-cleanup で本 sweep の後続に走る
+ * `deleteAllChildrenData` が children を列挙してファイル (アバター / 音声 / 画像) を
+ * 削除する経路を壊さないため (PROFILE を先に消すと列挙できずファイルが残留する)。
+ *
+ * 児童 0 人 (`knownChildIds` 空) の経路は `deleteChildScopedItems(undefined)` の Scan
+ * fallback が既に orphan を拾うため、呼び出し側で本 sweep を呼ばず二重 Scan を避けること。
+ *
+ * @param tenantId - 対象テナント
+ * @param knownChildIds - 削除対象から除外する既知児童 ID (active + archived)
+ * @returns 削除した orphan item 数 (既知 partition 分は除外済み)
+ */
+export async function deleteOrphanChildPartitionItems(
+	tenantId: string,
+	knownChildIds: readonly ChildId[],
+): Promise<number> {
+	const knownPKs = new Set(knownChildIds.map((id) => childPK(Number(id), tenantId)));
+	const doc = getDocClient();
+	let deleted = 0;
+	let lastKey: Record<string, unknown> | undefined;
+
+	do {
+		const result = await doc.send(
+			new ScanCommand({
+				TableName: TABLE_NAME,
+				FilterExpression: 'begins_with(PK, :pkPrefix)',
+				ExpressionAttributeValues: { ':pkPrefix': `T#${tenantId}#CHILD#` },
+				ProjectionExpression: 'PK, SK',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+
+		const keys = (result.Items ?? [])
+			.map((item) => ({ PK: item.PK as string, SK: item.SK as string }))
+			.filter((key) => !knownPKs.has(key.PK));
+		// streaming: page 単位で即削除 (既知 partition 除外後の orphan 残骸のみ)
+		await batchDeleteKeys(keys);
+		deleted += keys.length;
+		lastKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+
+	return deleted;
+}

--- a/src/lib/server/db/dynamodb/child-repo.ts
+++ b/src/lib/server/db/dynamodb/child-repo.ts
@@ -15,6 +15,7 @@ import type { ChildProgressResetCounts } from '../interfaces/child-repo.interfac
 import { hydrate, withVersion } from '../migration';
 import { writeBackDynamoDB } from '../migration/writeback';
 import type { Child, InsertChildInput, UpdateChildInput } from '../types';
+import { deleteOrphanChildPartitionItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -256,6 +257,19 @@ export async function deleteChild(id: ChildId, tenantId: string): Promise<void> 
 	} while (lastKey);
 
 	await batchDeleteItems(allKeys);
+}
+
+/**
+ * #3750: orphan child partition (childId が active でも archived でもない残骸) を sweep する。
+ * tenant-cleanup が既知 childIds のみ per-child 削除する際の取り漏らし fallback。
+ * partition storage 固有のため DynamoDB backend のみ実装する (relational backend は
+ * FK cascade で orphan 行が生じず未実装 = interface で optional)。
+ */
+export async function sweepOrphanChildPartitions(
+	tenantId: string,
+	knownChildIds: readonly ChildId[],
+): Promise<number> {
+	return deleteOrphanChildPartitionItems(tenantId, knownChildIds);
 }
 
 /** #3152: 子供 1 人分の進捗データを削除 (child profile / 関連 master は残す) */

--- a/src/lib/server/db/interfaces/child-repo.interface.ts
+++ b/src/lib/server/db/interfaces/child-repo.interface.ts
@@ -44,4 +44,17 @@ export interface IChildRepo {
 	archiveChildren(ids: ChildId[], reason: ArchivedReason, tenantId: string): Promise<void>;
 	restoreArchivedChildren(reason: ArchivedReason, tenantId: string): Promise<void>;
 	findArchivedChildren(tenantId: string): Promise<Child[]>;
+
+	/**
+	 * #3750: orphan child partition (childId が active でも archived でもない残骸) を sweep する。
+	 * tenant-cleanup で既知 childIds のみ per-child 削除する DynamoDB 経路の取り漏らし fallback
+	 * (childIds 非空 + orphan 混在時の削除完全性を回復する)。`knownChildIds` は削除対象から除外する。
+	 *
+	 * partition storage 固有の懸念のため DynamoDB backend のみ実装する。relational backend
+	 * (sqlite / dsql / demo) は FK cascade で orphan 行が生じないため未実装 (= optional method、
+	 * 呼び出し側は存在チェックしてから呼ぶ)。DSQL の same-class 検討は EPIC #3424 で扱う。
+	 *
+	 * @returns 削除した orphan item 数
+	 */
+	sweepOrphanChildPartitions?(tenantId: string, knownChildIds: readonly ChildId[]): Promise<number>;
 }

--- a/src/lib/server/services/tenant-cleanup-service.ts
+++ b/src/lib/server/services/tenant-cleanup-service.ts
@@ -340,5 +340,21 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 		logger.warn(`[tenant-cleanup] image 削除失敗: ${String(err)}`);
 	}
 
+	// #3750: orphan child partition sweep (混在ケースの削除完全性保証)。
+	// childIds 非空時、上記 child-scoped repo の deleteByTenantId は既知 child のみ Query する
+	// ため、過去の部分失敗で残った orphan child partition (childId が active でも archived でも
+	// ない + 他に現存児童 ≥1) を取り漏らす。末尾で 1 度だけ child partition prefix を Scan し、
+	// 既知 partition を除いた残骸を消す (退会 = 削除権 CUJ の完全性優先)。
+	// childIds undefined (児童 0 人) の場合は各 repo の Scan fallback が既に orphan を拾うため
+	// 呼ばず、二重 Scan を避ける。DynamoDB backend 固有 (relational backend は
+	// sweepOrphanChildPartitions 未実装 = optional のため skip)。
+	if (childIds && childIds.length > 0 && r.child.sweepOrphanChildPartitions) {
+		try {
+			deleted += await r.child.sweepOrphanChildPartitions(tenantId, childIds);
+		} catch (err) {
+			logger.warn(`[tenant-cleanup] orphan child partition sweep 失敗: ${String(err)}`);
+		}
+	}
+
 	return deleted;
 }

--- a/tests/unit/db/dynamodb-bulk-delete.test.ts
+++ b/tests/unit/db/dynamodb-bulk-delete.test.ts
@@ -329,6 +329,73 @@ describe('BatchWrite 完全性 (#3693 AC3)', () => {
 });
 
 // =========================================================
+// deleteOrphanChildPartitionItems — orphan child partition sweep (#3750)
+// =========================================================
+
+describe('deleteOrphanChildPartitionItems (#3750: orphan child partition sweep)', () => {
+	it('childIds 非空 + orphan partition 混在時、per-child Query は orphan を取り漏らし、sweep が残骸のみ消す', async () => {
+		const t = 'tenant-a';
+		// 既知児童 1, 2 の scoped データ
+		seedTenant(t, [1, 2], { 'STATUS#': 2, 'POINT#': 2 });
+		// 既知児童の PROFILE (deleteAllChildrenData が後続で削除 + file 削除に必要なため sweep 対象外)
+		table.push({ PK: childPkOf(t, 1), SK: 'PROFILE' }, { PK: childPkOf(t, 2), SK: 'PROFILE' });
+		// orphan partition 99: 過去の部分失敗で profile なし・childId が active でも archived でもない
+		// のに scoped データだけ残存 (childIds には含まれない)
+		table.push(
+			{ PK: childPkOf(t, 99), SK: 'STATUS#0000' },
+			{ PK: childPkOf(t, 99), SK: 'POINT#0000' },
+		);
+		// 他 tenant の同名 orphan (tenant 境界の検証)
+		seedTenant('tenant-b', [99], { 'STATUS#': 3 });
+
+		const { deleteChildScopedItems, deleteOrphanChildPartitionItems } = await loadBulkDelete();
+
+		// 1) 旧経路: 既知児童のみ per-child Query で削除 → orphan 99 は取り漏らす (#3750 の gap)
+		await deleteChildScopedItems(t, [asChildId(1), asChildId(2)], 'STATUS#');
+		await deleteChildScopedItems(t, [asChildId(1), asChildId(2)], 'POINT#');
+		expect(table.filter((it) => it.PK === childPkOf(t, 99))).toHaveLength(2);
+
+		// 2) 末尾 sweep: orphan 99 の残骸のみ削除
+		const swept = await deleteOrphanChildPartitionItems(t, [asChildId(1), asChildId(2)]);
+		expect(swept).toBe(2);
+		expect(table.filter((it) => it.PK === childPkOf(t, 99))).toHaveLength(0);
+		// 既知児童 PROFILE は残る (sweep が既知 partition を除外 = file 削除経路を壊さない)
+		expect(table.filter((it) => it.PK === childPkOf(t, 1) && it.SK === 'PROFILE')).toHaveLength(1);
+		expect(table.filter((it) => it.PK === childPkOf(t, 2) && it.SK === 'PROFILE')).toHaveLength(1);
+		// 他 tenant は完全に不変 (tenant 境界)
+		expect(table.filter((it) => it.PK.startsWith('T#tenant-b#'))).toHaveLength(3);
+	});
+
+	it('orphan がない場合 (既知児童のみ) は sweep で何も消さず 0 を返す', async () => {
+		const t = 'tenant-a';
+		seedTenant(t, [1, 2], { 'STATUS#': 2 });
+		table.push({ PK: childPkOf(t, 1), SK: 'PROFILE' });
+
+		const { deleteOrphanChildPartitionItems } = await loadBulkDelete();
+		const swept = await deleteOrphanChildPartitionItems(t, [asChildId(1), asChildId(2)]);
+
+		expect(swept).toBe(0);
+		// 既知児童データは不変 (STATUS# 4 件 + PROFILE 1 件)
+		expect(table.filter((it) => it.PK.startsWith('T#tenant-a#'))).toHaveLength(5);
+	});
+
+	it('knownChildIds が空配列でも child partition prefix 配下を全 sweep する (0 児童 orphan の受け皿)', async () => {
+		const t = 'tenant-a';
+		// 全て orphan (既知児童 0 人 = knownPKs 空)
+		table.push(
+			{ PK: childPkOf(t, 77), SK: 'STATUS#0000' },
+			{ PK: childPkOf(t, 88), SK: 'POINT#0000' },
+		);
+
+		const { deleteOrphanChildPartitionItems } = await loadBulkDelete();
+		const swept = await deleteOrphanChildPartitionItems(t, []);
+
+		expect(swept).toBe(2);
+		expect(table.filter((it) => it.PK.startsWith('T#tenant-a#CHILD#'))).toHaveLength(0);
+	});
+});
+
+// =========================================================
 // repo 配線 (代表: status-repo) — childIds 受領時に Query 化される
 // =========================================================
 

--- a/tests/unit/services/tenant-cleanup-service.test.ts
+++ b/tests/unit/services/tenant-cleanup-service.test.ts
@@ -15,6 +15,8 @@ const mockChildRepo = {
 	// #3693: deleteTenantScopedData は archived 児童も childIds に含める (Scan 時代の削除範囲と同一)
 	findArchivedChildren: vi.fn(),
 	deleteChild: vi.fn().mockResolvedValue(undefined),
+	// #3750: orphan child partition sweep (DynamoDB backend 固有、optional method)
+	sweepOrphanChildPartitions: vi.fn().mockResolvedValue(0),
 };
 
 const mockActivityRepo = {
@@ -253,6 +255,36 @@ describe('deleteTenantScopedData', () => {
 		expect(mockStatusRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
 		expect(mockPointRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT, undefined);
 		expect(mockSettingsRepo.deleteByTenantId).toHaveBeenCalledWith(TENANT);
+	});
+
+	it('#3750: childIds 非空時、末尾で orphan child partition sweep を childIds 付きで 1 回呼ぶ', async () => {
+		mockChildRepo.findAllChildren.mockResolvedValue([{ id: '100' }, { id: '200' }]);
+		mockChildRepo.findArchivedChildren.mockResolvedValue([{ id: '300' }]);
+
+		await deleteTenantScopedData(TENANT);
+
+		// 既知 childIds (active + archived) を除外対象として渡し、orphan 残骸のみ sweep する
+		expect(mockChildRepo.sweepOrphanChildPartitions).toHaveBeenCalledTimes(1);
+		expect(mockChildRepo.sweepOrphanChildPartitions).toHaveBeenCalledWith(TENANT, [
+			'100',
+			'200',
+			'300',
+		]);
+	});
+
+	it('#3750: 児童 0 人 (childIds undefined) 時は sweep を呼ばない (Scan fallback と二重 Scan を避ける)', async () => {
+		// findAllChildren / findArchivedChildren はデフォルトで空 → childIds=undefined
+		await deleteTenantScopedData(TENANT);
+
+		expect(mockChildRepo.sweepOrphanChildPartitions).not.toHaveBeenCalled();
+	});
+
+	it('#3750: orphan sweep が失敗しても他の削除をブロックしない', async () => {
+		mockChildRepo.findAllChildren.mockResolvedValue([{ id: '100' }]);
+		mockChildRepo.sweepOrphanChildPartitions.mockRejectedValueOnce(new Error('scan err'));
+
+		await expect(deleteTenantScopedData(TENANT)).resolves.toBeGreaterThanOrEqual(0);
+		expect(mockChildRepo.sweepOrphanChildPartitions).toHaveBeenCalledTimes(1);
 	});
 
 	it('activities (per-child loop, #2362) / viewerTokens / cloudExports / pushSubscriptions は find+delete パターン', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ システム全体（退会・データ全削除を実行する全顧客）

**解決する課題**: #3748 (#3693) で退会 / data 全削除の全テーブル Scan (約 25 回) を childIds ベースの child partition Query に是正した際、QM Tier2 レビュー (V-2 data-integrity) が非 blocking の残存懸念を検出した。`deleteChildScopedItems` は childIds (active + archived の union) が **非空**（他に現存児童 ≥1）のとき既知 child partition のみを Query するため、過去の部分失敗で child profile だけ消えて scoped データが残った **orphan child partition**（childId が active でも archived でもない）を取り漏らす理論余地が残っていた。旧 Scan fallback は PK prefix で全 child partition を拾えていたためこの orphan も消せていたが、混在ケース（childIds 非空 + orphan）は新実装で未カバーだった。

**期待される効果**: GDPR / 個人情報保護法の「削除権」要請では削除の**完全性が最優先**。退会時に scoped データが silent に残留すると信頼毀損 + 法的リスクに直結するため、混在ケースでも取り漏らしゼロを構造的に保証する。#3748 の perf 改善（read が自 tenant データ量にのみ比例）は維持したまま、末尾 1 回の低頻度 sweep で完全性を回復する。

## 関連 Issue

closes #3750

related: #3748 / #3693 (削除 perf 本体) / ADR-0063 (tenant 分離) / ADR-0065 (DPU 規約) / ADR-0061 (failing-test-first) / EPIC #3424 (DSQL same-class 申し送り先)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | childIds 非空 + orphan child partition 混在時、orphan の残骸が完全に削除される | `npx vitest run tests/unit/db/dynamodb-bulk-delete.test.ts` | HEAD `d894ed71` rebase 後 / 26 passed / `dynamodb-bulk-delete.test.ts` 「childIds 非空 + orphan partition 混在時、per-child Query は orphan を取り漏らし、sweep が残骸のみ消す」= 旧 per-child Query 経路で orphan 99 が残存 (取り漏らし再現) → `deleteOrphanChildPartitionItems` で orphan 99 の STATUS#/POINT# 2 件のみ削除 (swept=2)。failing-test-first (ADR-0061): 実装前 red → 実装後 green |
| AC2 | sweep が既知 child partition (PROFILE 等) と他 tenant を破壊しない | 同上 | 同 test で既知児童 1/2 の PROFILE は不変 (後続 `deleteAllChildrenData` のファイル削除経路を壊さない) + 他 tenant (`T#tenant-b#`) 3 件不変を assert。knownPKs 除外により orphan のみ削除 |
| AC3 | childIds 非空時のみ末尾で sweep を 1 回呼び、児童 0 人時は Scan fallback と二重 Scan を避ける | `npx vitest run tests/unit/services/tenant-cleanup-service.test.ts` | HEAD `d894ed71` / `tenant-cleanup-service.test.ts` 「childIds 非空時、末尾で orphan child partition sweep を childIds 付きで 1 回呼ぶ」= `sweepOrphanChildPartitions(TENANT, [100,200,300])` を 1 回呼出 / 「児童 0 人 (childIds undefined) 時は sweep を呼ばない」= 未呼出 / 「orphan sweep が失敗しても他の削除をブロックしない」= 例外を warn で握って継続 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — スキーマ不変。`dynamodb/bulk-delete.ts` に `deleteOrphanChildPartitionItems` 追加 / `dynamodb/child-repo.ts` に `sweepOrphanChildPartitions` 追加 / `interfaces/child-repo.interface.ts` に optional method 追加
- [x] サービス層 (`$lib/server/services/`) — `tenant-cleanup-service.ts`（`deleteTenantScopedData` 末尾に orphan sweep）
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/` 等)

**影響を受ける画面・機能**: アカウント削除（/admin/account/delete）/ 設定 > データ全削除 / replace import の内包 clear / grace-period 物理削除 cron。UI 表面の挙動・画面変化なし（内部削除完全性の補強のみ、DynamoDB backend 固有）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— worktree に node_modules がないため targeted 検証: `npx vitest run tests/unit/db/dynamodb-bulk-delete.test.ts tests/unit/services/tenant-cleanup-service.test.ts`（26 passed、red→green 確認）+ `tests/unit/db/dynamodb-child-repo-reset.test.ts`（8 passed、regression）+ `biome check`（変更 6 file、error 0）。最終 authoritative は CI lint-and-test
- [x] 追加・変更したテストの概要:
  - `tests/unit/db/dynamodb-bulk-delete.test.ts` に 3 test 追加（fake DocumentClient で混在時取り漏らし再現 → sweep で残骸のみ削除 / 既知 partition・他 tenant 不変 / knownChildIds 空でも全 sweep）
  - `tests/unit/services/tenant-cleanup-service.test.ts` に 3 test 追加（childIds 非空時のみ sweep 呼出 / 0 児童時 skip / sweep 失敗の非ブロック）+ mockChildRepo に `sweepOrphanChildPartitions` を追加
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 追加なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: 本 fix は partition storage 固有の懸念のため DynamoDB backend のみ実装。interface の `sweepOrphanChildPartitions` は **optional method** とし、relational backend（sqlite / dsql / demo）は FK cascade で orphan 行が生じないため未実装（service 側は存在チェックしてから呼ぶ）。`check-dynamodb-stub.mjs` は stub なし（実実装）+ bulk-delete.ts は ALLOW_LIST のため対象外
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — priority:medium

## スクリーンショット / ビジュアルデモ

**該当なし（fix / server 側削除ロジック）** — DynamoDB 削除完全性の補強のみで UI 変更なし（`.svelte` / `.css` / `site/` の変更 0 file）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（sweep 機構は `bulk-delete.ts` に集約、repo は委譲のみ）/ 依存性逆転（service は `IChildRepo` optional method 経由、backend 非依存）
- [x] **DRY**: 既存 `batchDeleteKeys`（UnprocessedItems retry + streaming）を再利用。Scan は `deleteItemsByPkPrefix` と同一 `:pkPrefix` 規約
- [x] **YAGNI**: 追加は末尾 1 回の低頻度 sweep のみ。非同期 saga / job 分割基盤は導入しない（混在 orphan は極低頻度、issue 記載の「BLOCK でない根拠」参照）
- [x] **Security（OSS 公開前提）**: tenant 境界を test で機械検証（他 tenant items 不変 assert）+ 既知 partition 除外で file 削除経路を保全。秘密情報 hardcode なし
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: sweep は child partition prefix の Scan 1 回のみ（#3693 の per-repo Scan × 約 25 とは異なる末尾 1 回 fallback）。childIds 非空時のみ実行し、0 児童時は既存 Scan fallback と二重にならないよう skip

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 設計書同期 (ADR-0001): `docs/design/08-データベース設計書.md` の削除戦略節（原則 1 配下）に orphan child partition sweep の SSOT を追記
- [x] 並行 PR overlap 確認 (#1200): base `origin/develop`（f44eb8fe）に rebase 済。#3748 は develop に merge 済で本 branch はその上に構築、overlap なし
- [x] E2E / ユニットシード + チュートリアルを同期: N/A — スキーマ / seed 値に変更なし（削除経路の完全性補強のみ）
- [x] N/A — 本番/デモ・LP・年齢モード・ナビ・labels SSOT は影響範囲外（UI / 文言変更なし）

**LP / 販促文言変更時** (ADR-0013):

N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** — `sweepOrphanChildPartitions` は optional method で追加のみ。既存経路（childIds 供給 / 未供給）は不変

**レビュー依頼事項・QA**:
- **末尾 sweep の Scan コスト**: orphan は「未知の childId partition」であり Query では特定不能なため、child partition prefix Scan が不可避。ただし childIds 非空時に末尾 1 回のみで、#3693 が排除した per-repo Scan × 約 25 とは桁違いに低頻度。混在 orphan の発生確率は極低（issue「BLOCK でない根拠」参照）で、削除権 CUJ の完全性優先として本コストを許容した
- **既知 partition 除外の理由**: sweep の後続に走る `deleteAllChildrenData` は children を列挙してファイル（アバター/音声/画像）を削除するため、既知児童の PROFILE を先に消すと列挙不能でファイルが残留する。よって knownPKs を除外し orphan のみ sweep する
- **DSQL 側の same-class**: relational backend は FK cascade で orphan 行が生じないため本 fix 対象外（optional method 未実装）。DSQL の削除 round-trip 系検討は EPIC #3424 管轄のため Issue #3750 にコメントで申し送る

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3750` 全 Step PASS** をローカル確認した（worktree に node_modules がないため targeted vitest + biome で代替検証、最終 authoritative は CI lint-and-test）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A — UI 変更なし（SS セクション「該当なし」明記済）
- [x] 認証画面変更時: N/A — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
