### PR TITLE
infra: #3763 dependabot で typescript 7.x を条件付き ignore（kit peer 未対応まで保留）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,11 @@ updates:
       # 12.12+ は再提案を許可 (修正版採用時は scripts/check-native-dep-pin.mjs の pin と同期更新)。
       - dependency-name: "better-sqlite3"
         versions: ["12.11.x"]
+      # #3636: typescript 7.x は @sveltejs/kit@2.69.x の peer (^5.3.3 || ^6.0.0) が除外し
+      # npm ci が ERESOLVE で失敗する。kit が TS7 peer 対応版を出したら本 ignore を削除して TS7 を取り込む。
+      # major (6→7) のみ保留し 6.x の minor/patch 更新は許可する。
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         # #3311: grouped update が per-dependency ignore (上記 better-sqlite3 12.11.x) を


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発プロセス / CI）

**解決する課題**: Dependabot PR #3636（typescript 6.0.3 → 7.0.2）は `@sveltejs/kit@2.69.2` の peer 制約 `typescript@"^5.3.3 || ^6.0.0"` が TS7 を除外するため `npm ci` が ERESOLVE で失敗し、CI 6 checks が全滅した。TS7 は kit がまだ peer 対応しておらず、現時点で取り込むと依存解決自体が破綻する。

**期待される効果**: typescript の major (6→7) 更新のみを条件付き ignore することで、kit が TS7 対応するまで無駄な失敗 PR を再生成させず、かつ 6.x の minor/patch 更新は継続追従する。恒久拒否ではなく「解除条件付きの保留」であることをコメントに残し、kit 対応時に取り込める状態を保つ。

## 関連 Issue

closes #3763

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | root npm ecosystem の `ignore` に typescript major (`version-update:semver-major`) の ignore を追加（既存 better-sqlite3 #3302 と同じ commented スタイルで解除条件明記） | `git show HEAD:.github/dependabot.yml` / YAML parse | HEAD `28f9eeb1` / `.github/dependabot.yml:35-40` に typescript major ignore + 解除条件コメント追加。js-yaml parse で `ignore[2] = {dependency-name: typescript, update-types: [version-update:semver-major]}` を確認 |
| AC2 | 6.x の minor/patch 更新は許可されたまま（major のみ保留） | dependabot.yml の ignore 定義確認 | HEAD `28f9eeb1` / ignore は `version-update:semver-major` のみ指定。minor/patch は非対象のため許可維持。group `npm-minor-patch` は minor/patch のみのため無変更 |
| AC3 | #3636 を `@dependabot ignore this major version` で close し TS7 major を保留 | 本 PR merge 後に #3636 へ comment 投稿 | 本 PR と同時に #3636 に `@dependabot ignore this major version` + 人間向け説明 comment を投稿（Dev Agent 実施） |
| AC4 | 解除条件を dependabot.yml コメントに残す | `git show HEAD:.github/dependabot.yml` | HEAD `28f9eeb1` / `.github/dependabot.yml:35-37` に「kit が TS7 peer 対応版を出したら本 ignore を削除して TS7 を取り込む」を明記 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（Dependabot の依存更新提案挙動のみ変更。アプリ実行時の挙動には影響しない）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**: 設定ファイル（`.github/dependabot.yml`）のみの変更で、YAML parse による ignore 定義検証を実施済み（js-yaml で ignore 配列を確認）。アプリコード・LP・labels に変更がないため build/test に影響なし
- [x] 追加・変更したテストの概要: N/A（Dependabot 設定変更のためテスト対象コードなし）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

該当なし（`.github/dependabot.yml` の設定変更のみ。UI 変更なし）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（設定ファイル 1 行追加）
- [x] **DRY**: 既存 better-sqlite3 (#3302) の条件付き ignore と同一パターン・同一スタイルで統一
- [x] **YAGNI**: major のみ ignore し過剰な全 major ignore や group 変更を追加していない
- [x] **Security（OSS 公開前提）**: N/A（秘密情報なし）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（Dependabot 設定のみ）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: typescript は major (6→7) のみ ignore し 6.x の minor/patch は許可を維持している点、および解除条件（kit が TS7 peer 対応版を出したら ignore 削除）がコメントに明記されている点を確認してください。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（設定変更のため YAML parse 検証で代替、build/test 非影響）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完のまま残っている AC がない）
- [x] Phase 分割: N/A
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

（QM が記入）
