### PR TITLE
fix(api): #3694 payload 上限を Function URL 6MB に整合 (export ZIP response / OCR base64 request)

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -888,6 +888,7 @@ S3 からの画像取得プロキシ。`key` クエリパラメータで対象�
   - `data.json`（JSON ファイルと同内容）
   - `avatars/{childId}/{filename}.png` / `voices/{childId}/{filename}` 等、`tenants/{tenantId}/` prefix 配下のアップロード済みファイル
 - ZIP 同梱対象（`data.json` + 静的ファイル）の合計が 100MB を超える場合は、残りを silent skip せず **fail-closed で 400 を返す**（#3376）。不完全な ZIP を「フルバックアップ」として返すと、再生成不能な avatar/voice が無警告で欠落し manifest も truncated set で整合してしまうため。ユーザーには「バックアップ対象のデータが上限（100MB）を超えています」と明示する
+- **#3694 (Function URL response 6MB cap 整合)**: AWS（aws-prod）は Lambda Function URL（BUFFERED）の response payload も 6MB hard cap のため、100MB fail-closed の**手前**で、構築 ZIP が実効上限（`resolveMaxSyncResponseBytes`、SSOT: `src/lib/server/services/function-url-limit.ts`）を超えた場合は **400 VALIDATION_ERROR で「クラウド共有（PIN コード）経由のバックアップ」を案内**する（edge の沈黙切断 = 「ダウンロードできない」状態を根絶）。NUC / local は Function URL 制約が無いため従来通り直 DL（100MB まで）を許可する
 
 > **#3078**: `data.checklistLogs`（チェックリスト完了履歴）は `checklist-repo.findLogsByChild` で child 単位にバルク取得した実データを `templateName` 参照付きで含む（旧来の空配列固定を解消、activity ログと同様に往復対象）。
 
@@ -1019,6 +1020,8 @@ S3 からの画像取得プロキシ。`key` クエリパラメータで対象�
 レシート画像を OCR で読み取り、金額を抽出する。
 
 **AIモデル:** AWS Bedrock Claude Haiku（画像入力 + tool_use）— レシート画像をマルチモーダル入力し、金額とテキストを構造化出力で抽出。Bedrock 未利用時は `NO_API_KEY` エラーを返す。
+
+**画像サイズ上限（#3694、Function URL 6MB request cap 整合）:** 画像は base64 JSON body で送信するため、AWS（aws-prod）では base64 化（デコード後 × 4/3）が Function URL 6MB request cap を超えると edge で沈黙拒否される。デコード後上限を runtime 実効値（約 4.14MB、`resolveMaxBase64DecodedBytes`、SSOT: `src/lib/server/services/function-url-limit.ts`）に下方整合し、超過は 400 VALIDATION_ERROR で明示する。NUC / local は Function URL 制約が無いため従来 5MB を維持する。
 
 #### GET /api/v1/export/cloud (#0294)
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2282,6 +2282,11 @@ export const SETTINGS_LABELS = {
 	// 不完全な部分バックアップを黙って作らず明示エラーにする (再生成不能な avatar/voice の silent 欠落防止)。
 	dataExportTooLarge: (maxMb: string) =>
 		`バックアップ対象のデータが上限（${maxMb}MB）を超えています。不要な画像・音声を整理してから、もう一度お試しください。`,
+	// #3694: AWS 本番の Function URL (BUFFERED) は response も 6MB hard cap。画像込み ZIP が
+	// 直接ダウンロードの実効上限を超えると edge で沈黙切断されるため、明示エラー + クラウド共有
+	// (PINコード、非同期・上限なし) への誘導を返す (ADR-0062)。
+	dataExportTooLargeForDirectDownload: (maxMb: string) =>
+		`画像・音声を含むファイルが直接ダウンロードの上限（${maxMb}MB）を超えています。「クラウド共有（PINコード）」から${BACKUP_TERMS.exportVerb}してください`,
 	// #3376: 画像込み ZIP ダウンロードはブラウザの安全性警告（保存の確認）が出ることがある。
 	// 画像込みの完全バックアップは、警告の出ないクラウドバックアップを推奨する導線。
 	dataExportZipCloudHint:
@@ -2960,6 +2965,9 @@ export const POINTS_LABELS = {
 	manualMaxButton: '全額変換',
 
 	// 領収書モード
+	// #3694: OCR 画像は base64 JSON body で送るため、AWS 本番は Function URL 6MB request cap に
+	// 整合した実効上限をサーバが返す (デコード後上限は runtime で下方整合される)。
+	receiptImageTooLarge: (maxMb: string) => `画像サイズは${maxMb}MB以下にしてください`,
 	receiptLabel: '領収書を撮影して金額を読み取り',
 	receiptCaptureButtonTitle: '領収書を撮影 / 画像を選択',
 	receiptCaptureButtonNote: 'JPEG, PNG, WebP（5MB以下）',

--- a/src/lib/server/services/function-url-limit.ts
+++ b/src/lib/server/services/function-url-limit.ts
@@ -1,0 +1,57 @@
+// src/lib/server/services/function-url-limit.ts
+// #3694: AWS Lambda Function URL (BUFFERED) の request/response 各 6MB hard cap を、
+// 「同期に body を運ぶ」全経路 (import ZIP 受信 / export ZIP 送信 / OCR base64 受信) の
+// アプリ側上限 SSOT にする。
+//
+// 本番公開経路は CloudFront → Lambda Function URL (BUFFERED) で、request / response とも
+// payload 上限は **6MB (hard limit)**。これを超える body は Lambda に到達せず edge で弾かれ
+// (413 / 接続切断)、アプリのエラーハンドリングも UI feedback も効かない「沈黙のハング」になる。
+// そこで各経路の上限を platform 実効値に整合させ、超過は edge 切断ではなくアプリの明示エラー
+// (ADR-0062) に統一し、大容量はクラウド共有 (PIN) 経由の非同期経路へ誘導する。
+//
+// request-side の ZIP import 上限 (raw binary) は import-limit.ts が SSOT (AWS_MAX_IMPORT_BYTES)。
+// 本 module は response-side (export ZIP) と base64 JSON body (OCR) の実効上限を追加で担う。
+
+import { getEnv, type TypedEnv } from '$lib/runtime/env';
+import { resolveRuntimeMode } from '$lib/runtime/runtime-mode';
+
+/** Function URL (BUFFERED) の request/response hard cap = 6 MiB (AWS 固定値、platform 上限)。 */
+export const FUNCTION_URL_PAYLOAD_CAP_BYTES = 6 * 1024 * 1024;
+
+/**
+ * hard cap に対する安全側 margin 比率。encoding / HTTP header / JSON wrapper 分を差し引いて
+ * edge 拒否を確実に回避する。実効上限 = cap * (1 - margin)。
+ */
+const SAFETY_MARGIN_RATIO = 0.08;
+
+/** AWS 実効の同期 payload 上限 (request/response 共通、bytes)。約 5.52MB。 */
+export const AWS_EFFECTIVE_PAYLOAD_BYTES = Math.floor(
+	FUNCTION_URL_PAYLOAD_CAP_BYTES * (1 - SAFETY_MARGIN_RATIO),
+);
+
+/**
+ * base64 JSON body で運ぶバイナリ (OCR 画像) の**デコード後**実効上限。base64 は元データの
+ * 約 4/3 に膨張するため、AWS 実効 payload を 3/4 して逆算する。約 4.14MB。
+ */
+export const AWS_EFFECTIVE_BASE64_DECODED_BYTES = Math.floor((AWS_EFFECTIVE_PAYLOAD_BYTES * 3) / 4);
+
+/**
+ * aws-prod のときのみ AWS 実効 response 上限 (bytes) を返す。他モード (NUC / local) は
+ * Function URL 制約が無いため制約なし (Infinity) を返す。export ZIP 直 DL の response サイズ
+ * 判定に使う。
+ */
+export function resolveMaxSyncResponseBytes(env: TypedEnv = getEnv()): number {
+	return resolveRuntimeMode({ env }) === 'aws-prod'
+		? AWS_EFFECTIVE_PAYLOAD_BYTES
+		: Number.POSITIVE_INFINITY;
+}
+
+/**
+ * aws-prod のとき、渡された localMax と AWS の base64 デコード後実効上限の小さい方を返す。
+ * 他モードは localMax をそのまま返す。OCR 画像 (base64 JSON body) のデコード後サイズ判定に使う。
+ */
+export function resolveMaxBase64DecodedBytes(localMax: number, env: TypedEnv = getEnv()): number {
+	return resolveRuntimeMode({ env }) === 'aws-prod'
+		? Math.min(localMax, AWS_EFFECTIVE_BASE64_DECODED_BYTES)
+		: localMax;
+}

--- a/src/lib/server/services/import-limit.ts
+++ b/src/lib/server/services/import-limit.ts
@@ -16,6 +16,10 @@ import { getEnv, type TypedEnv } from '$lib/runtime/env';
 import { resolveRuntimeMode } from '$lib/runtime/runtime-mode';
 import { MAX_ZIP_SIZE } from '$lib/server/services/backup-archive';
 
+// #3694: platform cap (6MB) の SSOT は function-url-limit.ts。本 module は request-side (ZIP 受信)
+// の実効上限を担い、response-side (export ZIP) / base64 (OCR) は function-url-limit.ts が担う。
+// FUNCTION_URL_PAYLOAD_CAP_BYTES との関係は tests/unit/services/function-url-limit.test.ts が
+// fitness assert する (AWS_MAX_IMPORT_BYTES < platform cap)。
 /** AWS Lambda Function URL (BUFFERED) の 6MB hard cap に対する安全側の実効上限 (5.5MB)。 */
 export const AWS_MAX_IMPORT_BYTES = Math.floor(5.5 * 1024 * 1024);
 

--- a/src/routes/api/v1/export/+server.ts
+++ b/src/routes/api/v1/export/+server.ts
@@ -6,12 +6,14 @@ import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { todayDateJST } from '$lib/domain/date-utils';
 import type { ExportData } from '$lib/domain/export-format';
 import { asChildId } from '$lib/domain/ids';
-import { PLAN_GATE_LABELS } from '$lib/domain/labels';
+import { PLAN_GATE_LABELS, SETTINGS_LABELS } from '$lib/domain/labels';
 import { requireRole } from '$lib/server/auth/factory';
 import { apiError } from '$lib/server/errors';
 import { logger } from '$lib/server/logger';
 import { BackupSizeLimitError, buildFullBackupZip } from '$lib/server/services/backup-archive';
 import { exportFamilyData } from '$lib/server/services/export-service';
+import { resolveMaxSyncResponseBytes } from '$lib/server/services/function-url-limit';
+import { toDisplayMb } from '$lib/server/services/import-limit';
 import { getPlanLimits, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { RequestHandler } from './$types';
 
@@ -82,6 +84,19 @@ async function buildZipResponse(
 	compact: boolean,
 ): Promise<Response> {
 	const zipData = await buildFullBackupZip(tenantId, exportData, compact);
+
+	// #3694: AWS 本番の Function URL (BUFFERED) は response も 6MB hard cap。構築 ZIP が実効上限
+	// (MAX_ZIP_SIZE=100MB は request/response の platform cap と別) を超えると edge で沈黙切断され
+	// 「ダウンロード不能」になるため、明示エラー + クラウド共有 (非同期・上限なし) へ誘導する。
+	// NUC / local は resolveMaxSyncResponseBytes が Infinity を返すため従来通り直 DL を許可する。
+	const maxResponseBytes = resolveMaxSyncResponseBytes();
+	if (zipData.byteLength > maxResponseBytes) {
+		return apiError(
+			'VALIDATION_ERROR',
+			SETTINGS_LABELS.dataExportTooLargeForDirectDownload(String(toDisplayMb(maxResponseBytes))),
+			{ bytes: zipData.byteLength, maxBytes: maxResponseBytes },
+		);
+	}
 
 	return new Response(zipData.buffer as ArrayBuffer, {
 		status: 200,

--- a/src/routes/api/v1/points/ocr-receipt/+server.ts
+++ b/src/routes/api/v1/points/ocr-receipt/+server.ts
@@ -1,10 +1,13 @@
 import { json } from '@sveltejs/kit';
+import { POINTS_LABELS } from '$lib/domain/labels';
 import { validationError } from '$lib/server/errors';
 import { validateBase64ImageMagicBytes } from '$lib/server/security/magic-bytes';
+import { resolveMaxBase64DecodedBytes } from '$lib/server/services/function-url-limit';
+import { toDisplayMb } from '$lib/server/services/import-limit';
 import { ocrReceipt } from '$lib/server/services/receipt-ocr-service';
 import type { RequestHandler } from './$types';
 
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB（NUC / local の上限。AWS は runtime で下方整合）
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -23,10 +26,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		return validationError('対応していない画像形式です。JPEG、PNG、WebPをお使いください。');
 	}
 
-	// base64サイズチェック（base64は元データの約1.33倍）
+	// base64サイズチェック（base64は元データの約1.33倍）。
+	// #3694: AWS 本番は base64 JSON body が Function URL 6MB request cap を超えると edge で
+	// 沈黙拒否されるため、デコード後上限を runtime 実効値に下方整合する (NUC / local は 5MB 維持)。
+	const maxImageBytes = resolveMaxBase64DecodedBytes(MAX_IMAGE_SIZE);
 	const estimatedSize = (image.length * 3) / 4;
-	if (estimatedSize > MAX_IMAGE_SIZE) {
-		return validationError('画像サイズは5MB以下にしてください');
+	if (estimatedSize > maxImageBytes) {
+		return validationError(POINTS_LABELS.receiptImageTooLarge(String(toDisplayMb(maxImageBytes))));
 	}
 
 	// マジックバイト検証（Content-Type偽装対策）

--- a/tests/unit/routes/export-zip-6mb-response-guard.test.ts
+++ b/tests/unit/routes/export-zip-6mb-response-guard.test.ts
@@ -1,0 +1,93 @@
+// tests/unit/routes/export-zip-6mb-response-guard.test.ts
+// #3694 AC2/AC3: export ZIP 直 DL の 6MB response cap 整合。
+//
+// AWS 本番 (aws-prod) は Function URL (BUFFERED) の response 6MB hard cap を超える ZIP が
+// edge で沈黙切断される。構築 ZIP が実効上限を超えたら、直 DL せず明示エラー (400) +
+// クラウド共有導線を返すこと (ADR-0062)。NUC / local は制約なしで従来通り直 DL を許可する。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------- mocks ----------
+const mockExportFamilyData = vi.fn();
+vi.mock('$lib/server/services/export-service', () => ({
+	exportFamilyData: (...args: unknown[]) => mockExportFamilyData(...args),
+}));
+
+const mockBuildFullBackupZip = vi.fn();
+vi.mock('$lib/server/services/backup-archive', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/server/services/backup-archive')>();
+	return {
+		...actual,
+		buildFullBackupZip: (...args: unknown[]) => mockBuildFullBackupZip(...args),
+	};
+});
+
+const mockResolveFullPlanTier = vi.fn();
+const mockGetPlanLimits = vi.fn();
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	resolveFullPlanTier: (...args: unknown[]) => mockResolveFullPlanTier(...args),
+	getPlanLimits: (...args: unknown[]) => mockGetPlanLimits(...args),
+}));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireRole: vi.fn(),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { resetEnvForTesting } from '../../../src/lib/runtime/env';
+import { GET } from '../../../src/routes/api/v1/export/+server';
+
+const originalFnName = process.env.AWS_LAMBDA_FUNCTION_NAME;
+
+function makeEvent(format: string, awsMode: boolean) {
+	if (awsMode) process.env.AWS_LAMBDA_FUNCTION_NAME = 'ganbari-quest-app';
+	else delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+	resetEnvForTesting();
+	return {
+		url: new URL(`https://x/api/v1/export?format=${format}`),
+		locals: { context: { tenantId: 't1', licenseStatus: 'active', plan: 'standard' } },
+		// biome-ignore lint/suspicious/noExplicitAny: minimal RequestEvent stub for handler unit test
+	} as any;
+}
+
+beforeEach(() => {
+	mockExportFamilyData.mockResolvedValue({ version: 1, family: { children: [] }, data: {} });
+	mockResolveFullPlanTier.mockResolvedValue('standard');
+	mockGetPlanLimits.mockReturnValue({ canExport: true });
+});
+
+afterEach(() => {
+	if (originalFnName === undefined) delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+	else process.env.AWS_LAMBDA_FUNCTION_NAME = originalFnName;
+	resetEnvForTesting();
+	vi.clearAllMocks();
+});
+
+describe('#3694 export ZIP — 6MB response cap guard', () => {
+	it('aws-prod: 実効上限超の ZIP は 400 + クラウド共有導線 (直 DL しない)', async () => {
+		// 6MB 超の構築 ZIP を模す
+		mockBuildFullBackupZip.mockResolvedValue(new Uint8Array(6 * 1024 * 1024 + 1));
+		const res = await GET(makeEvent('zip', true));
+		expect(res.status).toBe(400);
+		const bodyText = await res.text();
+		expect(bodyText).toContain('クラウド共有');
+		expect(res.headers.get('Content-Type')).not.toBe('application/zip');
+	});
+
+	it('aws-prod: 実効上限内の ZIP は従来通り application/zip で直 DL', async () => {
+		mockBuildFullBackupZip.mockResolvedValue(new Uint8Array(1024));
+		const res = await GET(makeEvent('zip', true));
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toBe('application/zip');
+	});
+
+	it('local: Function URL 制約なし — 大きな ZIP でも直 DL を許可する', async () => {
+		mockBuildFullBackupZip.mockResolvedValue(new Uint8Array(20 * 1024 * 1024));
+		const res = await GET(makeEvent('zip', false));
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toBe('application/zip');
+	});
+});

--- a/tests/unit/routes/ocr-receipt-6mb-request-guard.test.ts
+++ b/tests/unit/routes/ocr-receipt-6mb-request-guard.test.ts
@@ -1,0 +1,75 @@
+// tests/unit/routes/ocr-receipt-6mb-request-guard.test.ts
+// #3694 AC2: OCR 画像 (base64 JSON body) の 6MB request cap 整合。
+//
+// AWS 本番 (aws-prod) は base64 が Function URL 6MB request cap を超えると edge で沈黙拒否される。
+// デコード後上限を runtime 実効値 (約 4.14MB) に下方整合し、AWS では 4.14MB〜5MB の画像を明示
+// エラー (400) で弾く。NUC / local は Function URL 制約が無いため従来 5MB 上限を維持する。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockOcrReceipt = vi.fn();
+vi.mock('$lib/server/services/receipt-ocr-service', () => ({
+	ocrReceipt: (...args: unknown[]) => mockOcrReceipt(...args),
+}));
+vi.mock('$lib/server/security/magic-bytes', () => ({
+	validateBase64ImageMagicBytes: () => ({ valid: true }),
+}));
+
+import { resetEnvForTesting } from '../../../src/lib/runtime/env';
+import { POST } from '../../../src/routes/api/v1/points/ocr-receipt/+server';
+
+const originalFnName = process.env.AWS_LAMBDA_FUNCTION_NAME;
+
+/** decoded バイト数から base64 文字数 (= decoded * 4/3) 相当の文字列を作る。 */
+function base64OfDecodedBytes(decodedBytes: number): string {
+	return 'A'.repeat(Math.floor((decodedBytes * 4) / 3));
+}
+
+function makeEvent(image: string, awsMode: boolean) {
+	if (awsMode) process.env.AWS_LAMBDA_FUNCTION_NAME = 'ganbari-quest-app';
+	else delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+	resetEnvForTesting();
+	return {
+		request: new Request('https://x/api/v1/points/ocr-receipt', {
+			method: 'POST',
+			body: JSON.stringify({ image, mimeType: 'image/png' }),
+		}),
+		locals: { context: { tenantId: 't1' } },
+		// biome-ignore lint/suspicious/noExplicitAny: minimal RequestEvent stub for handler unit test
+	} as any;
+}
+
+beforeEach(() => {
+	mockOcrReceipt.mockResolvedValue({ amount: 100 });
+});
+
+afterEach(() => {
+	if (originalFnName === undefined) delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+	else process.env.AWS_LAMBDA_FUNCTION_NAME = originalFnName;
+	resetEnvForTesting();
+	vi.clearAllMocks();
+});
+
+describe('#3694 OCR receipt — 6MB request cap guard', () => {
+	// デコード後 4.5MB: AWS 実効上限 (約 4.14MB) 超だが従来 5MB 未満
+	const decoded4_5MB = base64OfDecodedBytes(Math.floor(4.5 * 1024 * 1024));
+
+	it('aws-prod: 4.5MB 画像は実効上限超で 400 (edge 沈黙拒否の前にアプリが明示)', async () => {
+		const res = await POST(makeEvent(decoded4_5MB, true));
+		expect(res.status).toBe(400);
+		expect(mockOcrReceipt).not.toHaveBeenCalled();
+	});
+
+	it('local: 4.5MB 画像は従来 5MB 上限内で受理し OCR に進む', async () => {
+		const res = await POST(makeEvent(decoded4_5MB, false));
+		expect(res.status).toBe(200);
+		expect(mockOcrReceipt).toHaveBeenCalledTimes(1);
+	});
+
+	it('local: 5MB 超はどの環境でも一貫して 400', async () => {
+		const decoded6MB = base64OfDecodedBytes(6 * 1024 * 1024);
+		const res = await POST(makeEvent(decoded6MB, false));
+		expect(res.status).toBe(400);
+		expect(mockOcrReceipt).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/services/function-url-limit.test.ts
+++ b/tests/unit/services/function-url-limit.test.ts
@@ -1,0 +1,73 @@
+// tests/unit/services/function-url-limit.test.ts
+// #3694 fitness: AWS Lambda Function URL (BUFFERED) の request/response 各 6MB hard cap を
+// 「同期に body を運ぶ」全経路 (import ZIP 受信 / export ZIP 送信 / OCR base64 受信) の
+// アプリ側上限 SSOT にする。各実効上限が実際に転送されるバイト数で platform cap を超えない
+// (= 上限定数 ≤ platform cap) ことを static assert する (ADR-0061 fitness function)。
+
+import { describe, expect, it } from 'vitest';
+import type { TypedEnv } from '../../../src/lib/runtime/env';
+import {
+	AWS_EFFECTIVE_BASE64_DECODED_BYTES,
+	AWS_EFFECTIVE_PAYLOAD_BYTES,
+	FUNCTION_URL_PAYLOAD_CAP_BYTES,
+	resolveMaxBase64DecodedBytes,
+	resolveMaxSyncResponseBytes,
+} from '../../../src/lib/server/services/function-url-limit';
+import { AWS_MAX_IMPORT_BYTES } from '../../../src/lib/server/services/import-limit';
+
+/** resolveRuntimeMode が参照するフィールドのみ埋めた TypedEnv を作る。 */
+function envOf(overrides: Partial<TypedEnv>): TypedEnv {
+	return {
+		NODE_ENV: 'test',
+		APP_MODE: undefined,
+		IS_NUC_DEPLOY: undefined,
+		AWS_LAMBDA_FUNCTION_NAME: undefined,
+		...overrides,
+	} as TypedEnv;
+}
+
+describe('#3694 function-url-limit — platform cap 整合 fitness', () => {
+	it('platform hard cap は Function URL BUFFERED の 6 MiB', () => {
+		expect(FUNCTION_URL_PAYLOAD_CAP_BYTES).toBe(6 * 1024 * 1024);
+	});
+
+	it('AWS 実効 payload 上限 ≤ platform cap (request/response 共通)', () => {
+		expect(AWS_EFFECTIVE_PAYLOAD_BYTES).toBeLessThan(FUNCTION_URL_PAYLOAD_CAP_BYTES);
+	});
+
+	it('import ZIP request 上限 (import-limit AWS_MAX_IMPORT_BYTES) ≤ platform cap', () => {
+		// import-limit.ts の request-side SSOT が同一 platform cap に整合していること (横断 SSOT)。
+		expect(AWS_MAX_IMPORT_BYTES).toBeLessThan(FUNCTION_URL_PAYLOAD_CAP_BYTES);
+	});
+
+	it('OCR base64 デコード後上限は、base64 化 (4/3 膨張) + wrapper 後も platform cap 未満', () => {
+		// 実際に転送されるのは base64 文字列 (デコード後 * 4/3)。膨張後でも cap を超えないこと。
+		const transportedBase64Bytes = Math.ceil((AWS_EFFECTIVE_BASE64_DECODED_BYTES * 4) / 3);
+		expect(transportedBase64Bytes).toBeLessThan(FUNCTION_URL_PAYLOAD_CAP_BYTES);
+	});
+
+	it('resolveMaxSyncResponseBytes: aws-prod は AWS 実効上限、他は制約なし (Infinity)', () => {
+		expect(
+			resolveMaxSyncResponseBytes(envOf({ AWS_LAMBDA_FUNCTION_NAME: 'ganbari-quest-app' })),
+		).toBe(AWS_EFFECTIVE_PAYLOAD_BYTES);
+		expect(resolveMaxSyncResponseBytes(envOf({ APP_MODE: 'aws-prod' }))).toBe(
+			AWS_EFFECTIVE_PAYLOAD_BYTES,
+		);
+		expect(resolveMaxSyncResponseBytes(envOf({ IS_NUC_DEPLOY: true }))).toBe(
+			Number.POSITIVE_INFINITY,
+		);
+		expect(resolveMaxSyncResponseBytes(envOf({}))).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it('resolveMaxBase64DecodedBytes: aws-prod は localMax と AWS 上限の小さい方、他は localMax', () => {
+		const localMax = 5 * 1024 * 1024;
+		expect(resolveMaxBase64DecodedBytes(localMax, envOf({ AWS_LAMBDA_FUNCTION_NAME: 'app' }))).toBe(
+			Math.min(localMax, AWS_EFFECTIVE_BASE64_DECODED_BYTES),
+		);
+		// AWS 実効上限は localMax (5MB) より小さいので、AWS では下方整合される
+		expect(AWS_EFFECTIVE_BASE64_DECODED_BYTES).toBeLessThan(localMax);
+		// NUC / local は Function URL 制約が無いため従来上限を維持
+		expect(resolveMaxBase64DecodedBytes(localMax, envOf({ IS_NUC_DEPLOY: true }))).toBe(localMax);
+		expect(resolveMaxBase64DecodedBytes(localMax, envOf({}))).toBe(localMax);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

写真つきバックアップの DL や 5MB 近いレシート画像の OCR が、AWS 本番では Lambda Function URL (BUFFERED) の 6MB payload hard cap に阻まれ「edge で沈黙切断され、エラーも UI feedback も出ない」状態になっていた。本 PR は 3 経路のアプリ側上限を platform 実効値に整合させ、超過時に必ずユーザー向けエラー + 代替導線 (クラウド共有) を返すようにする。「操作したのに何も起きない / DL できない」を根絶する。

## 関連 Issue

closes #3694

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 3 箇所の上限値と検証基準を platform 実効値に整合 (fitness: 上限定数 ≤ platform cap の static assert) | `npx vitest run tests/unit/services/function-url-limit.test.ts` (6 assert) | PASS — FUNCTION_URL_PAYLOAD_CAP_BYTES=6MB を SSOT 化。AWS 実効 payload / base64 転送後 / import ZIP request 上限が全て cap 未満を static assert |
| AC2 | 超過時のユーザー向けエラーメッセージ (無言 413/504 の根絶) | `npx vitest run tests/unit/routes/ocr-receipt-6mb-request-guard.test.ts` + export guard | PASS — export: 400 + クラウド共有導線 / OCR: 400 + `POINTS_LABELS.receiptImageTooLarge`。両者 `apiError`/`validationError` (ADR-0062) |
| AC3 | export ZIP の 6MB 超ケースの動線確定 (presigned or 分割) | `npx vitest run tests/unit/routes/export-zip-6mb-response-guard.test.ts` (3 assert) | PASS — aws-prod で 6MB 超 ZIP は直 DL せず 400 + 既存クラウド共有 (PIN、非同期・上限なし = 既存 presigned 動線) へ誘導。NUC/local は従来通り直 DL |

検証コマンド (red→green 確認済):
```
npx vitest run tests/unit/services/function-url-limit.test.ts tests/unit/services/import-limit.test.ts tests/unit/routes/export-zip-6mb-response-guard.test.ts tests/unit/routes/ocr-receipt-6mb-request-guard.test.ts
# → Test Files 4 passed / Tests 18 passed
npx biome check src/lib/server/services/function-url-limit.ts src/routes/api/v1/export/+server.ts src/routes/api/v1/points/ocr-receipt/+server.ts
# → No fixes applied (clean)
node scripts/check-no-plan-literals.mjs   # → OK
```

補足: point2 (import MAX_IMPORT_BYTES 100MB) は #3325 (#3674) で `resolveMaxImportBytes` 化により既に platform 整合済。本 PR は残る export ZIP response cap と OCR base64 request cap を塞ぎ、fitness で 3 経路を横断 SSOT 化した。

## 変更タイプ

- [x] バグ修正 (fix)
- [ ] 新機能 (feat)
- [ ] リファクタリング
- [x] ドキュメント

## 影響範囲・変更コンポーネント

- 新設 SSOT: `src/lib/server/services/function-url-limit.ts` (platform cap + AWS 実効 request/response/base64 上限 + runtime resolver)
- `src/lib/server/services/import-limit.ts` — 横断 SSOT の相互参照コメント (値は不変)
- `src/routes/api/v1/export/+server.ts` — ZIP response 6MB guard
- `src/routes/api/v1/points/ocr-receipt/+server.ts` — base64 request 実効上限の下方整合
- `src/lib/domain/labels.ts` — `SETTINGS_LABELS.dataExportTooLargeForDirectDownload` / `POINTS_LABELS.receiptImageTooLarge` 追加
- テスト 3 file (fitness + export guard + ocr guard、計 18 assert)
- `docs/design/07-API設計書.md` — export / OCR の 6MB 整合を同期

## テスト & 安全装置セルフチェック

- [x] 単体テスト追加（failing-test-first、ADR-0061）: fitness 6 + export guard 3 + ocr guard 3 = 18 assert green
- [x] 既存 `import-limit.test.ts` 回帰なし (同時実行で 6 tests PASS)
- [x] biome check（変更ファイル）: clean
- [x] svelte-check: 変更ファイル 0 error（残 error は worktree の infra deps 未 install に起因、CI 委譲）
- [x] `check-no-plan-literals`: OK

## スクリーンショット / ビジュアルデモ

UI 画面変更なし（サーバー側 API のエラーレスポンス整合 + ラベル追加のみ）。ユーザー可視の文言変更はエラーメッセージ 2 種で、labels.ts SSOT 経由。

## コード品質セルフレビュー (#1481)

- SSOT 集約: platform cap 定数を 1 箇所 (`function-url-limit.ts`) に集約し、import/export/OCR + fitness が同一定数を参照。値の二重定義を排除。
- 内部例外非露出 (ADR-0062): 返すのは `apiError`/`validationError` の統一レスポンス + labels 文言のみ。
- 純関数化: runtime 分岐は env 注入可能な純関数寄り (`resolveMaxSyncResponseBytes(env)` / `resolveMaxBase64DecodedBytes(localMax, env)`) にし unit test で 5 mode を検証。
- Pre-PMF (ADR-0010): 短期の明示エラー化に留め、S3 presigned への完全移行 (恒久策) は既存クラウド共有導線への誘導で代替。インフラ変更 (Function URL → ALB 等) は Issue の No-go 通り不採用。

## 横展開・影響波及チェック

- 「同期 body を運ぶ」3 経路 (import ZIP 受信 / export ZIP 送信 / OCR base64 受信) を洗い出し、request/response/base64 の 3 種の実効上限で網羅。import は #3325 で解決済のため fitness の横断 assert のみ追加。
- cloud export (`/api/v1/export/cloud`) は非同期 build + presigned DL のため 6MB cap の影響外（本 PR の誘導先）。
- ラベルは labels.ts SSOT 追加のみで LP / fallback 同期対象外（pre-commit の generate-lp-labels/sync-lp-fallback --check PASS 済）。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。NUC / local は全経路で従来上限を維持（`resolveMaxSyncResponseBytes`=Infinity / base64=5MB）。挙動が変わるのは aws-prod のみ。
- SAFETY_MARGIN_RATIO=0.08 (実効 ≈5.52MB) と base64 デコード後 ≈4.14MB の margin 妥当性をレビュー観点として明記。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。runtime 判定は既存 `resolveRuntimeMode` (AWS_LAMBDA_FUNCTION_NAME / APP_MODE / IS_NUC_DEPLOY) を再利用。

## Ready for Review チェックリスト

- [x] AC 全項目を満たし検証マップに証跡を記載
- [x] failing-test-first で red→green を確認
- [x] 設計書同期 (07-API設計書) 済
- [x] biome / 変更ファイル型チェック clean
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言。full pre-ready は親セッションが Ready 化時に実行）

## QM レビュー結果

（QM 記入欄）
