### PR TITLE
fix(data-integrity): #3596 ② activity cancel の単一 txn 原子化 (部分コミット class 根絶)

### DIFF
--- a/docs/design/dsql/m3-physical-model.md
+++ b/docs/design/dsql/m3-physical-model.md
@@ -355,6 +355,7 @@ M2 の GrowthJournal 集約 atomic 境界（activity_log 生成 + status 更新 
 
 - **core = 単一 txn**（activity_log + status + status_history + mastery + point_ledger base + total_point 加算）。
 - **optional = core commit 後の独立 best-effort mini-txn**（combo/mission/challenge/certificate/special_reward、各 additive かつ冪等、失敗隔離 + ログ）。**欠落許容は要 PO 確認**（M2/big-policy §10-8: 現状の握り潰しと同等で regression なし）。
+- **cancel も対称に単一 txn**（#3596 ②、`cancel-activity-core.ts`）: activity_log soft-cancel（`cancelled=true`）+ mastery count−1 + point_ledger(−)+total_point 減 + status 復元（clampDecayFloor 契約保存）+ status_history を all-or-nothing 書込。冪等 guard = cancel UPDATE の affected 行判定（2 連打は同一行 UPDATE の OCC 40001 retry で 0 行 → ALREADY_CANCELLED、二重返金なし）。record core と同じく DATA_SOURCE=dsql のみ本経路（sqlite/pglite は逐次 await 経路を温存、単一接続で並行競合なし）。
 
 ### §6.2 派生列 compute-on-write（total_point 等、構造決定 + PoC 保留）
 

--- a/src/lib/server/db/dsql/cancel-activity-core.ts
+++ b/src/lib/server/db/dsql/cancel-activity-core.ts
@@ -1,0 +1,170 @@
+// src/lib/server/db/dsql/cancel-activity-core.ts
+// EPIC #3424 / #3596 ② (cancel atomicity) / 設計 SSOT: dsql-data-model.md §8 / §5(P7)
+//
+// cancelActivity の core を単一 txn (all-or-nothing) で書く。record-activity-core.ts と対称。
+// 現行 activity-log-service.ts cancelActivityLog の「txn 無し・逐次 4 await」による部分コミット
+// (log は cancelled 化したが point 未返金 / status 戻したが ledger 未計上 等) を根絶する
+// (§8。2026-07-15 restore 障害と同じ「共有行を跨ぐ非原子 write」class)。
+//
+// 設計契約 (§8):
+//   - **冪等 guard = txn 内 cancel UPDATE の affected 行**: activity_logs を
+//     `cancelled = false` 条件で UPDATE → RETURNING で affected を数える。2 連打 (同一 log の
+//     二重 cancel) は同一行 UPDATE ゆえ DSQL 40001 → runner retry → 再実行時 cancelled=true で
+//     0 行 → ALREADY_CANCELLED を返す (二重返金を serialization point で防ぐ)。txn 境界を HTTP に
+//     晒さない。cancel 可否 (cancel window / NOT_FOUND) の事前判定は service 層 read-only。
+//   - **point_ledger INSERT(−) + children.total_point 減算は同一 txn** (§5 P7、SUM 乖離不能。
+//     fitness#14 findTotalPointDrift が突合)。child 不在なら throw で txn ごと rollback。
+//   - **status 復元は clampDecayFloor 契約を保存する** (updateStatus の減衰 floor と parity):
+//     currentXp − refundPoints ではなく revertStatusXp (= max(0, clampDecayFloor(currentXp,
+//     refundPoints, peakXp))) を注入する。peak_xp は high-water mark ゆえ復元で減らさない。
+//   - **categoryId=null (activity 削除済) は status 復元を skip** (legacy `if (activity)` parity)。
+//   - **mastery は total_count>0 のときのみ count−1** (legacy `if (mastery && count>0)` parity)。
+//   - **fitness#7 準拠**: work 内 await は全て tx.execute 直呼び。level/floor 算出は sync 注入。
+//   - work は再実行可能 (40001 retry で全体再実行、cancel UPDATE の affected 判定が冪等性を守る)。
+//
+// **返金額の非対称メモ (#3596 ②)**: refundPoints は legacy と同一に log.points + log.streak_bonus
+//   を service が算出する。記録時 ledger は base+streak+mastery_bonus を計上するため mastery_bonus
+//   分は返金されない既存挙動を本 core は保存する (atomicity の是正のみが scope)。厳密な対称返金
+//   (原 ledger 額の巻戻し) は別途 follow-up (#3596 の後続 or 新規) で扱う。
+
+import { sql } from 'drizzle-orm';
+import type { TransactionRunner } from '../interfaces/transaction.interface';
+import type { SqlExecutor } from './sql-executor';
+
+export interface CancelActivityCoreInput {
+	familyId: string;
+	childId: string;
+	activityId: string;
+	/** cancel 対象の activity_logs.log_id。 */
+	logId: string;
+	/** status/status_history 復元先カテゴリ。null=activity 削除済で status 復元を skip。 */
+	categoryId: string | null;
+	/** 返金額 (正の整数)。log.points + log.streak_bonus (legacy 同一計算、service が算出)。 */
+	refundPoints: number;
+	/** point_ledger.recorded_date ('YYYY-MM-DD'、冪等 lookup 用 §11.2)。cancel 実行日。 */
+	recordedDate: string;
+	/** ISO 8601。temporal 列に一貫適用 (テスト決定性)。 */
+	now: string;
+	/** point_ledger.description ('キャンセル')。 */
+	description: string;
+	/** status_history.change_type ('activity_cancel')。 */
+	changeType: string;
+	/** 習熟度 count → level (sync。fitness#7: work 内 await 禁止のため関数注入)。 */
+	masteryLevelFor: (totalCount: number) => number;
+	/** status XP 復元値算出 (sync)。= max(0, clampDecayFloor(currentXp, refundPoints, peakXp))。 */
+	revertStatusXp: (currentXp: number, peakXp: number) => number;
+	/** 復元後 XP → status level (sync)。 */
+	statusLevelFor: (totalXp: number) => number;
+}
+
+export type CancelActivityCoreResult =
+	| { ok: true; refundedPoints: number }
+	| { ok: false; reason: 'ALREADY_CANCELLED' };
+
+/** 冪等 guard 不成立 (既 cancel 済) を rollback とともに運ぶ内部シグナル。 */
+class CancelAbort extends Error {
+	constructor(readonly reason: 'ALREADY_CANCELLED') {
+		super(`cancel aborted: ${reason}`);
+	}
+}
+
+/** cancel core (log-cancel / mastery 復元 / ledger+total_point / status 復元 / history) を単一 txn で書く。 */
+export async function cancelActivityCore<TTx extends SqlExecutor>(
+	runner: TransactionRunner<TTx>,
+	input: CancelActivityCoreInput,
+): Promise<CancelActivityCoreResult> {
+	const {
+		familyId,
+		childId,
+		activityId,
+		logId,
+		categoryId,
+		refundPoints,
+		recordedDate,
+		now,
+		description,
+		changeType,
+		masteryLevelFor,
+		revertStatusXp,
+		statusLevelFor,
+	} = input;
+
+	try {
+		return await runner.runInTransaction(async (tx) => {
+			// ① 冪等 cancel guard + serialization anchor: cancelled=false のときだけ true 化。
+			//    2 連打は同一行 UPDATE ゆえ 40001 → retry → 0 行 → ALREADY_CANCELLED (二重返金防止)。
+			const cancelled = await tx.execute(sql`
+				UPDATE activity_logs SET cancelled = true
+				WHERE family_id = ${familyId} AND child_id = ${childId} AND log_id = ${logId}
+					AND cancelled = false
+				RETURNING log_id
+			`);
+			if (cancelled.rows.length === 0) {
+				throw new CancelAbort('ALREADY_CANCELLED');
+			}
+
+			// ② activity_mastery: total_count>0 のとき count−1 → level 再計算 → upsert (legacy parity)。
+			const masteryRead = await tx.execute(sql`
+				SELECT total_count FROM activity_mastery
+				WHERE family_id = ${familyId} AND child_id = ${childId} AND activity_id = ${activityId}
+			`);
+			const currentCount = Number(
+				(masteryRead.rows[0] as { total_count: number } | undefined)?.total_count ?? 0,
+			);
+			if (currentCount > 0) {
+				const revertedCount = currentCount - 1;
+				const revertedLevel = masteryLevelFor(revertedCount);
+				await tx.execute(sql`
+					UPDATE activity_mastery SET total_count = ${revertedCount}, level = ${revertedLevel}, updated_at = ${now}
+					WHERE family_id = ${familyId} AND child_id = ${childId} AND activity_id = ${activityId}
+				`);
+			}
+
+			// ③ point_ledger INSERT(−) + children.total_point 減算 (§5 P7、同一 txn 必須)。
+			await tx.execute(sql`
+				INSERT INTO point_ledger (family_id, child_id, amount, type, description, reference_id, recorded_date, created_at)
+				VALUES (${familyId}, ${childId}, ${-refundPoints}, 'cancel', ${description}, ${logId}, ${recordedDate}, ${now})
+			`);
+			const updatedChild = await tx.execute(sql`
+				UPDATE children SET total_point = total_point - ${refundPoints}, updated_at = ${now}
+				WHERE family_id = ${familyId} AND child_id = ${childId}
+				RETURNING child_id
+			`);
+			if (updatedChild.rows.length === 0) {
+				// child 不在 = total_point 共更新不能。throw で txn ごと rollback (§5 P7、片肺書込禁止)。
+				throw new Error(`cancelActivityCore: child not found (${familyId}/${childId})`);
+			}
+
+			// ④ statuses 復元 (categoryId=null は activity 削除済で skip、legacy parity)。
+			//    XP は clampDecayFloor 契約 (revertStatusXp)、peak_xp は減らさない (high-water mark)。
+			if (categoryId !== null) {
+				const statusRead = await tx.execute(sql`
+					SELECT total_xp, peak_xp FROM statuses
+					WHERE family_id = ${familyId} AND child_id = ${childId} AND category_id = ${categoryId}
+				`);
+				const prev = statusRead.rows[0] as { total_xp: number; peak_xp: number } | undefined;
+				const currentXp = Number(prev?.total_xp ?? 0);
+				const peakXp = Number(prev?.peak_xp ?? 0);
+				const revertedXp = revertStatusXp(currentXp, peakXp);
+				const revertedLevel = statusLevelFor(revertedXp);
+				await tx.execute(sql`
+					INSERT INTO statuses (family_id, child_id, category_id, total_xp, level, peak_xp, updated_at)
+					VALUES (${familyId}, ${childId}, ${categoryId}, ${revertedXp}, ${revertedLevel}, ${peakXp}, ${now})
+					ON CONFLICT (family_id, child_id, category_id)
+					DO UPDATE SET total_xp = ${revertedXp}, level = ${revertedLevel}, peak_xp = ${peakXp}, updated_at = ${now}
+				`);
+
+				// ⑤ status_history INSERT (value=復元後 XP、change_amount=−refundPoints)。
+				await tx.execute(sql`
+					INSERT INTO status_history (family_id, child_id, category_id, value, change_amount, change_type, recorded_at)
+					VALUES (${familyId}, ${childId}, ${categoryId}, ${revertedXp}, ${-refundPoints}, ${changeType}, ${now})
+				`);
+			}
+
+			return { ok: true, refundedPoints: refundPoints } as const;
+		});
+	} catch (err) {
+		if (err instanceof CancelAbort) return { ok: false, reason: err.reason };
+		throw err;
+	}
+}

--- a/src/lib/server/services/activity-cancel-dsql.ts
+++ b/src/lib/server/services/activity-cancel-dsql.ts
@@ -1,0 +1,72 @@
+// src/lib/server/services/activity-cancel-dsql.ts
+// EPIC #3424 / #3596 ② (cancel atomicity) / 設計 SSOT: dsql-data-model.md §8
+//
+// DATA_SOURCE=dsql の cancelActivityLog 経路 (activity-log-service.ts から dispatch される):
+//
+//   1. 事前 guard (read-only、legacy と同一契約): findActivityLogById → 未存在/既 cancel は
+//      NOT_FOUND、cancel window 超過は CANCEL_EXPIRED。findActivityById で categoryId 解決
+//      (削除済は null で status 復元 skip = legacy `if (activity)` parity)。
+//   2. core (log-cancel / mastery 復元 / point_ledger(−)+total_point / status 復元 / history) を
+//      cancelActivityCore の単一 txn で all-or-nothing 書込。二重 cancel (2 連打) は core の
+//      cancel UPDATE affected 判定 (§8) で ALREADY_CANCELLED → NOT_FOUND に写像 (legacy parity)。
+//
+// legacy (sqlite/dynamo/demo) 経路は activity-log-service.ts に温存。error 契約
+// ({refundedPoints} / NOT_FOUND / CANCEL_EXPIRED) は backend 間で不変 (frontend 契約凍結)。
+//
+// fitness#7: 本 module に runInTransaction callsite は無い (txn は core 内)。
+
+import { todayDateJST } from '$lib/domain/date-utils';
+import { CANCEL_WINDOW_MS, calcMasteryLevel } from '$lib/domain/validation/activity';
+import { calcLevelFromXp, clampDecayFloor } from '$lib/domain/validation/status';
+import { findActivityById, findActivityLogById } from '$lib/server/db/activity-repo';
+import { cancelActivityCore } from '$lib/server/db/dsql/cancel-activity-core';
+import { getDsqlTransactionRunner } from '$lib/server/db/dsql/connection';
+
+/**
+ * DATA_SOURCE=dsql の活動キャンセル。error 契約 (NOT_FOUND / CANCEL_EXPIRED) と
+ * 返却 shape ({ refundedPoints }) は sqlite 経路と同一 (frontend 契約不変)。
+ */
+export async function cancelActivityDsql(
+	logId: string,
+	tenantId: string,
+): Promise<{ refundedPoints: number } | { error: 'NOT_FOUND' } | { error: 'CANCEL_EXPIRED' }> {
+	// 1. 事前 guard (read-only、legacy と同一)
+	const log = await findActivityLogById(logId, tenantId);
+	if (!log) return { error: 'NOT_FOUND' };
+	if (log.cancelled) return { error: 'NOT_FOUND' };
+
+	const recordedTime = new Date(log.recordedAt).getTime();
+	if (Date.now() - recordedTime > CANCEL_WINDOW_MS) {
+		return { error: 'CANCEL_EXPIRED' };
+	}
+
+	// 返金額 = log.points + log.streak_bonus (legacy と同一計算)。
+	const refundPoints = log.points + log.streakBonus;
+
+	// activity 削除済なら categoryId=null で status 復元を skip (legacy `if (activity)` parity)。
+	const activity = await findActivityById(log.activityId, tenantId);
+
+	// 2. core 単一 txn (冪等性の正 = cancel UPDATE の affected 判定、§8)
+	const now = new Date().toISOString();
+	const result = await cancelActivityCore(getDsqlTransactionRunner(), {
+		familyId: tenantId,
+		childId: String(log.childId),
+		activityId: String(log.activityId),
+		logId,
+		categoryId: activity ? String(activity.categoryId) : null,
+		refundPoints,
+		recordedDate: todayDateJST(),
+		now,
+		description: 'キャンセル',
+		changeType: 'activity_cancel',
+		masteryLevelFor: calcMasteryLevel,
+		// updateStatus の減衰 floor 契約を保存 (currentXp−refund ではなく peak*0.7 を下限とする)。
+		revertStatusXp: (currentXp, peakXp) =>
+			Math.max(0, clampDecayFloor(currentXp, refundPoints, peakXp)),
+		statusLevelFor: (xp) => calcLevelFromXp(xp).level,
+	});
+
+	// 二重 cancel (並行 2 連打) は ALREADY_CANCELLED → NOT_FOUND に写像 (legacy: 既 cancel = NOT_FOUND)。
+	if (!result.ok) return { error: 'NOT_FOUND' };
+	return { refundedPoints: result.refundedPoints };
+}

--- a/src/lib/server/services/activity-log-service.ts
+++ b/src/lib/server/services/activity-log-service.ts
@@ -23,6 +23,7 @@ import {
 } from '$lib/server/db/activity-repo';
 // EPIC #3424 Phase Z (#3541): DATA_SOURCE=dsql は core 単一 txn + optional 隔離経路へ dispatch (§8)
 import { isDsqlBackend } from '$lib/server/db/backend';
+import { cancelActivityDsql } from '$lib/server/services/activity-cancel-dsql';
 import {
 	type ActivityLogEntry,
 	type ActivityLogSummary,
@@ -391,6 +392,13 @@ export async function cancelActivityLog(
 	logId: string,
 	tenantId: string,
 ): Promise<{ refundedPoints: number } | { error: 'NOT_FOUND' } | { error: 'CANCEL_EXPIRED' }> {
+	// #3596 ②: DSQL backend は cancel core 単一 txn (log-cancel / mastery / ledger+total_point /
+	// status / history を all-or-nothing)。sqlite / dynamo / demo は従来の逐次 await 経路 (以下、
+	// 現行挙動の凍結)。record 経路 (#3541) と同型の backend 分岐。
+	if (isDsqlBackend()) {
+		return cancelActivityDsql(logId, tenantId);
+	}
+
 	const log = await findActivityLogById(logId, tenantId);
 	if (!log) return { error: 'NOT_FOUND' };
 	if (log.cancelled) return { error: 'NOT_FOUND' };

--- a/tests/integration/db/dsql-staging-concurrency.test.ts
+++ b/tests/integration/db/dsql-staging-concurrency.test.ts
@@ -24,6 +24,7 @@ import { AuroraDSQLPool } from '@aws/aurora-dsql-node-postgres-connector';
 import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { cancelActivityCore } from '../../../src/lib/server/db/dsql/cancel-activity-core';
 import { isOccConflict } from '../../../src/lib/server/db/dsql/occ-retry';
 import {
 	type RecordActivityCoreInput,
@@ -202,5 +203,59 @@ describe.skipIf(!ENDPOINT)('実 DSQL staging 並行アクセス検証 (#3545/#35
 			sql`SELECT total_xp FROM statuses WHERE family_id = ${FAMILY} AND child_id = ${childId} AND category_id = 'undou'`,
 		);
 		expect(Number((status.rows[0] as { total_xp: unknown }).total_xp)).toBe(PARALLEL * 10);
+	}, 180_000);
+
+	it('[V4] cancel 原子化 (#3596 ②): 同一 log を 8 並行 cancel → exactly-once 返金 (二重返金なし)', async () => {
+		const childId = crypto.randomUUID();
+		const activityId = crypto.randomUUID();
+		await seedChild(childId);
+
+		// 1) 1 件記録 (base 10、cancel 対象の log を作る)
+		const runner = createDsqlTransactionRunner<Tx>(db, { maxAttempts: 12, baseDelayMs: 20 });
+		const rec = await recordActivityCore(runner, coreInput(childId, activityId, 0));
+		expect(rec.ok).toBe(true);
+		if (!rec.ok) return;
+		const logId = rec.logId;
+
+		// 2) 同一 log を 8 並行 cancel。冪等 guard (cancel UPDATE affected 行判定) が
+		//    OCC 40001 retry と協調し exactly-once 返金になることを実 DSQL で確認する。
+		const cancelInput = {
+			familyId: FAMILY,
+			childId,
+			activityId,
+			logId,
+			categoryId: 'undou',
+			refundPoints: 10,
+			recordedDate: TODAY,
+			now: NOW,
+			description: 'キャンセル',
+			changeType: 'activity_cancel',
+			masteryLevelFor: (c: number) => Math.floor(c / 10) + 1,
+			revertStatusXp: (cur: number) => Math.max(0, cur - 10),
+			statusLevelFor: (xp: number) => Math.floor(xp / 100) + 1,
+		};
+		const results = await Promise.all(
+			Array.from({ length: PARALLEL }, () => cancelActivityCore(runner, cancelInput)),
+		);
+		const okCount = results.filter((r) => r.ok).length;
+		const alreadyCount = results.filter((r) => !r.ok && r.reason === 'ALREADY_CANCELLED').length;
+		console.log(`[V4] ok=${okCount} alreadyCancelled=${alreadyCount}`);
+		// 勝者 1 件のみが返金し、残りは ALREADY_CANCELLED (二重返金を serialization anchor が防ぐ)
+		expect(okCount).toBe(1);
+		expect(alreadyCount).toBe(PARALLEL - 1);
+
+		// cancel ledger(−10) は 1 行だけ。原 +10 と相殺し total_point == SUM(ledger) == 0。
+		const cancelLedger = await db.execute(
+			sql`SELECT count(*) AS c FROM point_ledger WHERE family_id = ${FAMILY} AND child_id = ${childId} AND type = 'cancel'`,
+		);
+		expect(Number((cancelLedger.rows[0] as { c: unknown }).c)).toBe(1);
+		const child = await db.execute(
+			sql`SELECT total_point FROM children WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+		);
+		const ledgerSum = await db.execute(
+			sql`SELECT coalesce(sum(amount),0) AS s FROM point_ledger WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+		);
+		expect(Number((child.rows[0] as { total_point: unknown }).total_point)).toBe(0);
+		expect(Number((ledgerSum.rows[0] as { s: unknown }).s)).toBe(0);
 	}, 180_000);
 });

--- a/tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts
+++ b/tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts
@@ -148,6 +148,14 @@ const MUTATION_ALLOWLIST: MutationAllowlistEntry[] = [
 			'記録取消の soft-cancel flip (P7 設計済み遷移。行は削除せず cancelled=true、台帳側は相殺行を追記)',
 	},
 	{
+		file: 'cancel-activity-core.ts',
+		table: 'activity_logs',
+		op: 'UPDATE',
+		marker: /SET\s+cancelled\s*=\s*true/,
+		reason:
+			'記録取消の単一 txn core (#3596 ②) の soft-cancel flip (activity-repo.ts と同一遷移。cancelled=false 条件で冪等 guard を兼ねる。台帳側は相殺行を追記)',
+	},
+	{
 		file: 'trial-history-repo.ts',
 		table: 'trial_history',
 		op: 'UPDATE',

--- a/tests/unit/db/dsql-cancel-activity-core.test.ts
+++ b/tests/unit/db/dsql-cancel-activity-core.test.ts
@@ -1,0 +1,336 @@
+// tests/unit/db/dsql-cancel-activity-core.test.ts
+// EPIC #3424 / #3596 ② (cancel atomicity) / 設計 SSOT: dsql-data-model.md §8 / §5(P7)
+//
+// cancelActivity core の単一 txn 原子化 (record-activity-core.ts と対称):
+//   ① activity_logs cancel (冪等 guard + serialization anchor) ② activity_mastery count−1
+//   ③ point_ledger INSERT(−) + children.total_point 減算 ④ statuses 復元 ⑤ status_history。
+//   現行 cancelActivityLog の「txn 無し・逐次 4 await」による部分コミット (log は cancel 化したが
+//   point 未返金 等) を all-or-nothing で根絶する。
+//
+// ── Canon TDD test list ──
+//   [C1] cancel 成功: log=cancelled / mastery count−1 / ledger(−) / total_point 減 / status 復元 / history
+//   [C2] 二重 cancel (同一 log 2 回目): ALREADY_CANCELLED + 副作用は 1 回のみ (二重返金なし)
+//   [C3] 途中失敗 (child 不在 → total_point 更新不能): 全 rollback (log の cancelled も戻る)
+//   [C4] categoryId=null (activity 削除済): status/history 復元 skip、log/mastery/ledger は実行
+//   [C5] mastery 未存在 (count=0): mastery 書込 skip、他は実行
+//   [C6] status 復元は revertStatusXp 注入値を verbatim 使用 (単純減算を core に hardcode しない)
+//   [C7] fitness#14 整合: cancel 後 total_point == SUM(ledger)
+
+import { PGlite } from '@electric-sql/pglite';
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/pglite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const FAMILY = '00000000-0000-4000-8000-0000000000c1';
+const NOW = '2026-07-16T10:00:00+00:00';
+const TODAY = '2026-07-16';
+
+describe('#3596 ②: cancelActivityCore 単一 txn (§8 cancel all-or-nothing)', () => {
+	let client: PGlite;
+	let db: ReturnType<typeof drizzle>;
+	let seq = 0;
+
+	beforeAll(async () => {
+		client = new PGlite();
+		db = drizzle(client);
+		// core txn が触る 6 表の最小 fixture (完全 DDL は dsql/schema.ts が SSOT)。
+		const ddl = [
+			`CREATE TABLE children (
+				family_id uuid NOT NULL, child_id uuid NOT NULL,
+				total_point integer NOT NULL DEFAULT 0,
+				updated_at timestamptz NOT NULL DEFAULT now(),
+				PRIMARY KEY (family_id, child_id))`,
+			`CREATE TABLE activity_logs (
+				family_id uuid NOT NULL, child_id uuid NOT NULL,
+				log_id uuid NOT NULL DEFAULT gen_random_uuid(),
+				activity_id uuid NOT NULL, points integer NOT NULL,
+				streak_days integer NOT NULL DEFAULT 1, streak_bonus integer NOT NULL DEFAULT 0,
+				recorded_date text NOT NULL, recorded_at timestamptz NOT NULL,
+				cancelled boolean NOT NULL DEFAULT false,
+				PRIMARY KEY (family_id, child_id, log_id))`,
+			`CREATE TABLE activity_mastery (
+				family_id uuid NOT NULL, child_id uuid NOT NULL, activity_id uuid NOT NULL,
+				total_count integer NOT NULL DEFAULT 0, level integer NOT NULL DEFAULT 1,
+				updated_at timestamptz NOT NULL,
+				PRIMARY KEY (family_id, child_id, activity_id))`,
+			`CREATE TABLE point_ledger (
+				family_id uuid NOT NULL, child_id uuid NOT NULL,
+				ledger_id uuid NOT NULL DEFAULT gen_random_uuid(),
+				amount integer NOT NULL, type text NOT NULL, description text,
+				reference_id text, recorded_date text NOT NULL,
+				created_at timestamptz NOT NULL DEFAULT now(),
+				PRIMARY KEY (family_id, child_id, ledger_id))`,
+			`CREATE TABLE statuses (
+				family_id uuid NOT NULL, child_id uuid NOT NULL, category_id text NOT NULL,
+				total_xp integer NOT NULL DEFAULT 0, level integer NOT NULL DEFAULT 1,
+				peak_xp integer NOT NULL DEFAULT 0, updated_at timestamptz NOT NULL,
+				PRIMARY KEY (family_id, child_id, category_id))`,
+			`CREATE TABLE status_history (
+				family_id uuid NOT NULL, child_id uuid NOT NULL, category_id text NOT NULL,
+				hist_id uuid NOT NULL DEFAULT gen_random_uuid(),
+				value real NOT NULL, change_amount real NOT NULL, change_type text NOT NULL,
+				recorded_at timestamptz NOT NULL,
+				PRIMARY KEY (family_id, child_id, category_id, hist_id))`,
+		];
+		for (const stmt of ddl) await db.execute(sql.raw(stmt));
+	});
+	afterAll(async () => {
+		await client.close();
+	});
+
+	/**
+	 * 記録済 (cancel 対象) を seed する: children.total_point / activity_logs / activity_mastery /
+	 * statuses / 原 point_ledger(+) を整合させて用意し、cancel 対象の logId を返す。
+	 */
+	const seedRecorded = async (opts?: {
+		points?: number;
+		streakBonus?: number;
+		masteryCount?: number;
+		xp?: number;
+		peak?: number;
+		category?: string;
+	}) => {
+		seq++;
+		const childId = `c0000000-0000-4000-8000-${String(seq).padStart(12, '0')}`;
+		const activityId = `a0000000-0000-4000-8000-${String(seq).padStart(12, '0')}`;
+		const points = opts?.points ?? 10;
+		const streakBonus = opts?.streakBonus ?? 2;
+		const refund = points + streakBonus;
+		const masteryCount = opts?.masteryCount ?? 1;
+		const xp = opts?.xp ?? refund;
+		const peak = opts?.peak ?? xp;
+		const category = opts?.category ?? 'undou';
+		await db.execute(
+			sql`INSERT INTO children (family_id, child_id, total_point) VALUES (${FAMILY}, ${childId}, ${refund})`,
+		);
+		const inserted = await db.execute(sql`
+			INSERT INTO activity_logs (family_id, child_id, activity_id, points, streak_bonus, recorded_date, recorded_at)
+			VALUES (${FAMILY}, ${childId}, ${activityId}, ${points}, ${streakBonus}, ${TODAY}, ${NOW})
+			RETURNING log_id`);
+		const logId = (inserted.rows[0] as { log_id: string }).log_id;
+		if (masteryCount > 0) {
+			await db.execute(sql`
+				INSERT INTO activity_mastery (family_id, child_id, activity_id, total_count, level, updated_at)
+				VALUES (${FAMILY}, ${childId}, ${activityId}, ${masteryCount}, 1, ${NOW})`);
+		}
+		await db.execute(sql`
+			INSERT INTO statuses (family_id, child_id, category_id, total_xp, level, peak_xp, updated_at)
+			VALUES (${FAMILY}, ${childId}, ${category}, ${xp}, 1, ${peak}, ${NOW})`);
+		await db.execute(sql`
+			INSERT INTO point_ledger (family_id, child_id, amount, type, description, reference_id, recorded_date, created_at)
+			VALUES (${FAMILY}, ${childId}, ${refund}, 'activity', '記録', ${logId}, ${TODAY}, ${NOW})`);
+		return { childId, activityId, logId, refund, category };
+	};
+
+	const makeCore = async (over: Record<string, unknown>) => {
+		const { createDsqlTransactionRunner } = await import(
+			'../../../src/lib/server/db/dsql/run-in-transaction'
+		);
+		const { cancelActivityCore } = await import(
+			'../../../src/lib/server/db/dsql/cancel-activity-core'
+		);
+		const runner = createDsqlTransactionRunner(db, { maxAttempts: 3, baseDelayMs: 1 });
+		return cancelActivityCore(runner, {
+			familyId: FAMILY,
+			recordedDate: TODAY,
+			now: NOW,
+			description: 'キャンセル',
+			changeType: 'activity_cancel',
+			masteryLevelFor: (count: number) => Math.floor(count / 5) + 1,
+			// 既定は単純減算 (0 clamp)。clampDecayFloor 契約検証は [C6] で個別注入。
+			revertStatusXp: (cur: number, _peak: number) =>
+				Math.max(0, cur - (over.refundPoints as number)),
+			statusLevelFor: (xp: number) => Math.floor(xp / 100) + 1,
+			...over,
+		} as never);
+	};
+
+	const totalPoint = async (childId: string) =>
+		Number(
+			(
+				(
+					await db.execute(
+						sql`SELECT total_point FROM children WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+					)
+				).rows[0] as { total_point: number }
+			).total_point,
+		);
+	const ledgerSum = async (childId: string) =>
+		Number(
+			(
+				(
+					await db.execute(
+						sql`SELECT COALESCE(SUM(amount),0)::int AS s FROM point_ledger WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+					)
+				).rows[0] as { s: number }
+			).s,
+		);
+	const ledgerCount = async (childId: string) =>
+		Number(
+			(
+				(
+					await db.execute(
+						sql`SELECT count(*) AS c FROM point_ledger WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+					)
+				).rows[0] as { c: unknown }
+			).c,
+		);
+	const isCancelled = async (logId: string) =>
+		(
+			(
+				await db.execute(
+					sql`SELECT cancelled FROM activity_logs WHERE family_id = ${FAMILY} AND log_id = ${logId}`,
+				)
+			).rows[0] as { cancelled: boolean }
+		).cancelled;
+	const masteryCount = async (childId: string) => {
+		const r = (
+			await db.execute(
+				sql`SELECT total_count FROM activity_mastery WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+			)
+		).rows[0] as { total_count: number } | undefined;
+		return r ? Number(r.total_count) : null;
+	};
+	const status = async (childId: string, category: string) =>
+		(
+			await db.execute(
+				sql`SELECT total_xp FROM statuses WHERE family_id = ${FAMILY} AND child_id = ${childId} AND category_id = ${category}`,
+			)
+		).rows[0] as { total_xp: number } | undefined;
+	const historyCount = async (childId: string) =>
+		Number(
+			(
+				(
+					await db.execute(
+						sql`SELECT count(*) AS c FROM status_history WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+					)
+				).rows[0] as { c: unknown }
+			).c,
+		);
+
+	it('[C1] cancel 成功: log=cancelled / mastery count−1 / ledger(−) / total_point 減 / status 復元 / history', async () => {
+		const { childId, activityId, logId, refund, category } = await seedRecorded();
+		const result = await makeCore({
+			childId,
+			activityId,
+			logId,
+			categoryId: category,
+			refundPoints: refund,
+		});
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.refundedPoints).toBe(refund);
+		expect(await isCancelled(logId)).toBe(true);
+		expect(await totalPoint(childId)).toBe(0);
+		expect(await ledgerSum(childId)).toBe(0); // +refund と −refund で相殺
+		expect(await ledgerCount(childId)).toBe(2);
+		expect(await masteryCount(childId)).toBe(0);
+		expect((await status(childId, category))?.total_xp).toBe(0); // 単純減算 refund→0
+		expect(await historyCount(childId)).toBe(1);
+	});
+
+	it('[C2] 二重 cancel: 2 回目は ALREADY_CANCELLED + 副作用は 1 回のみ (二重返金なし)', async () => {
+		const { childId, activityId, logId, refund, category } = await seedRecorded();
+		const first = await makeCore({
+			childId,
+			activityId,
+			logId,
+			categoryId: category,
+			refundPoints: refund,
+		});
+		expect(first.ok).toBe(true);
+		const tpAfterFirst = await totalPoint(childId);
+		const second = await makeCore({
+			childId,
+			activityId,
+			logId,
+			categoryId: category,
+			refundPoints: refund,
+		});
+		expect(second.ok).toBe(false);
+		if (second.ok) return;
+		expect(second.reason).toBe('ALREADY_CANCELLED');
+		// 2 回目は何も書かない: total_point / ledger 件数不変
+		expect(await totalPoint(childId)).toBe(tpAfterFirst);
+		expect(await ledgerCount(childId)).toBe(2); // 原+1 と cancel−1 のみ (2 回目の −1 は入らない)
+	});
+
+	it('[C3] 途中失敗 (child 不在 → total_point 更新不能): 全 rollback (cancelled も戻る)', async () => {
+		const { childId, activityId, logId, refund, category } = await seedRecorded();
+		// cancel UPDATE は通るが total_point 共更新先の children 行を消しておく → ③ で 0 行 → throw → rollback。
+		await db.execute(
+			sql`DELETE FROM children WHERE family_id = ${FAMILY} AND child_id = ${childId}`,
+		);
+		await expect(
+			makeCore({ childId, activityId, logId, categoryId: category, refundPoints: refund }),
+		).rejects.toThrow(/child not found/);
+		// log の cancelled は元の false のまま (部分コミット禁止 = ① cancel UPDATE も巻戻る)
+		expect(await isCancelled(logId)).toBe(false);
+		// ledger の cancel(−) 行も入っていない
+		expect(await ledgerCount(childId)).toBe(1); // 原 +refund のみ
+	});
+
+	it('[C4] categoryId=null (activity 削除済): status/history 復元 skip、log/mastery/ledger は実行', async () => {
+		const { childId, activityId, logId, refund, category } = await seedRecorded();
+		const before = await status(childId, category);
+		const result = await makeCore({
+			childId,
+			activityId,
+			logId,
+			categoryId: null,
+			refundPoints: refund,
+		});
+		expect(result.ok).toBe(true);
+		expect(await isCancelled(logId)).toBe(true);
+		expect(await totalPoint(childId)).toBe(0);
+		expect(await masteryCount(childId)).toBe(0);
+		// status は触られない (削除済カテゴリ復元は skip)
+		expect((await status(childId, category))?.total_xp).toBe(before?.total_xp);
+		expect(await historyCount(childId)).toBe(0);
+	});
+
+	it('[C5] mastery 未存在 (count=0): mastery 書込 skip、他は実行', async () => {
+		const { childId, activityId, logId, refund, category } = await seedRecorded({
+			masteryCount: 0,
+		});
+		const result = await makeCore({
+			childId,
+			activityId,
+			logId,
+			categoryId: category,
+			refundPoints: refund,
+		});
+		expect(result.ok).toBe(true);
+		expect(await masteryCount(childId)).toBe(null); // 行なしのまま
+		expect(await totalPoint(childId)).toBe(0);
+	});
+
+	it('[C6] status 復元は revertStatusXp 注入値を verbatim 使用 (clampDecayFloor 契約を core が hardcode しない)', async () => {
+		const { childId, activityId, logId, refund, category } = await seedRecorded({
+			xp: 100,
+			peak: 100,
+		});
+		// 減衰 floor 契約: 復元後 = max(0, clampDecayFloor(cur, refund, peak)) を注入し core が verbatim 使用することを確認。
+		// clampDecayFloor(100, 12, 100) = max(100-12, round(100*0.7)) = max(88, 70) = 88
+		const result = await makeCore({
+			childId,
+			activityId,
+			logId,
+			categoryId: category,
+			refundPoints: refund,
+			revertStatusXp: (cur: number, peak: number) =>
+				Math.max(0, Math.max(cur - refund, Math.round(peak * 0.7))),
+		});
+		expect(result.ok).toBe(true);
+		expect((await status(childId, category))?.total_xp).toBe(88);
+	});
+
+	it('[C7] fitness#14 整合: cancel 後 total_point == SUM(ledger)', async () => {
+		const { childId, activityId, logId, refund, category } = await seedRecorded({
+			points: 30,
+			streakBonus: 5,
+		});
+		await makeCore({ childId, activityId, logId, categoryId: category, refundPoints: refund });
+		expect(await totalPoint(childId)).toBe(await ledgerSum(childId));
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

活動キャンセルが**途中で失敗しても「ポイントは戻ったのに記録は残る／記録は消えたのにポイントが戻らない」という壊れた残高状態を作らない**。現行の cancel は txn 無しの逐次 4 write のため、DSQL(本番) で 1 つでも失敗すると部分コミットが残る — 2026-07-15 の本番 restore 障害 (共有行を跨ぐ非原子 write) と同じ class。これを record 経路と対称の単一 txn (all-or-nothing) で根絶する。

## 関連 Issue

- #3596 ② (cancel atomicity)。本 PR は #3596 の item ② のみを実装する (item ①=P7 SSOT は消化済 / ③ insertActivity facade 再評価 / ④ 本番統合検証 は #3596 に残す)。
- 対称元: #3541 (record-activity-core.ts)。
- 実 DSQL 並行検証レーン: #3683。

<!-- no-issue-close: #3596 は 4 項目複合 issue。本 PR は item ② (cancel atomicity) のみ実装し、① P7 SSOT 統合(消化済) / ③ insertActivity facade 再評価 / ④ 本番 DSQL 統合検証 は #3596 に残置するため、over-close を避け closing keyword を宣言しない (残タスク③④は #3596 で継続) -->


## AC 検証マップ (ADR-0004)

| AC (#3596 ②) | 実装 | 検証 | 状態 |
|---|---|---|---|
| cancel を単一 txn で all-or-nothing 化 | `src/lib/server/db/dsql/cancel-activity-core.ts` (log-cancel / mastery / ledger+total_point / status / history を 1 txn) | `tests/unit/db/dsql-cancel-activity-core.test.ts` [C1][C3][C7] | ✅ |
| 二重 cancel (2 連打) の二重返金を防ぐ | cancel UPDATE `cancelled=false` 条件の affected 行判定 = serialization anchor (OCC 40001 retry と協調) | [C2] (sequential) + staging [V4] (実 OCC 8 並行) | ✅ |
| status 復元は clampDecayFloor 契約を保存 | `revertStatusXp` 注入 (= max(0, clampDecayFloor(cur, refund, peak)))、peak_xp 不減 | [C6] | ✅ |
| legacy 挙動 parity (activity 削除済 / mastery 未存在 / error 契約) | categoryId=null で status skip、count=0 で mastery skip、ALREADY_CANCELLED→NOT_FOUND 写像 | [C4][C5] + `activity-log-service.test.ts` | ✅ |
| backend 分岐 (dsql のみ core、他は温存) | `cancelActivityLog` に `isDsqlBackend()` 分岐 (record 経路と同型) | `activity-record-dispatch.test.ts` PASS | ✅ |

## 変更タイプ

- [x] バグ修正 (data-integrity / 部分コミット根絶)
- [ ] 新機能
- [ ] リファクタ
- [x] テスト追加
- [x] ドキュメント (設計書同期)

## 影響範囲・変更コンポーネント

- 新規: `src/lib/server/db/dsql/cancel-activity-core.ts` (単一 txn core) / `src/lib/server/services/activity-cancel-dsql.ts` (read-only guard + core 呼び出し、record-dsql と対称)
- 変更: `src/lib/server/services/activity-log-service.ts` (`cancelActivityLog` に dsql 分岐を追加、legacy 経路は無変更で温存)
- テスト: `tests/unit/db/dsql-cancel-activity-core.test.ts` (新規 7) / `tests/integration/db/dsql-staging-concurrency.test.ts` ([V4] 追加)
- 設計書: `docs/design/dsql/m3-physical-model.md` §6.1
- **backend 影響**: DATA_SOURCE=dsql (本番) のみ新経路。sqlite / pglite(NUC) / dynamodb / demo は逐次 await 経路を維持 (record 経路と同じ選択 = 単一接続で並行競合なし)。

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/db/dsql-cancel-activity-core.test.ts` → 7 passed
- `npx vitest run tests/unit/architecture/dsql-txn-work-allowlist.test.ts tests/unit/architecture/dsql-append-only-update-fitness.test.ts tests/unit/services/activity-log-service.test.ts tests/unit/services/activity-record-dispatch.test.ts` → 49 passed (fitness#7 txn work / append-only UPDATE gate 含む)
- `npx vitest run tests/unit/services/activity-record-dsql-pglite.test.ts tests/unit/routes/login-stamp-retry.test.ts` → 12 passed
- `npx svelte-check --threshold error` → exit 0
- staging [V4] は DSQL_ENDPOINT gate で local skip (実 OCC は #3683 lane / 手動 creds で実行)。
- 安全装置: 部分コミット禁止を [C3] (child 不在 → 全 rollback、cancelled も戻る) で機械検証。fitness#14 整合を [C7] で担保。

## スクリーンショット / ビジュアルデモ

N/A (server 層のデータ整合修正、UI 変更なし)。

## コード品質セルフレビュー (#1481)

- `npx biome check` → clean (自己レビューコマンド実行済)
- record-activity-core.ts と構造・命名・コメント密度を対称に揃えた (RecordAbort↔CancelAbort、injected sync 関数、fitness#7 準拠で work 内 await は全て tx.execute 直呼び)。
- 返金額の非対称 (mastery_bonus 未返金) は legacy 挙動を保存し scope 外とした旨をコードコメントと本文に明記 (silent に変えない)。

## 横展開・影響波及チェック

- record 経路 (#3541) が同じ「dsql のみ core / 他 backend 逐次 await」を選択済 → 本 PR は同型で一貫。
- pglite(NUC) も本 core を使わない点は record と同じ既存境界。単一接続ゆえ並行競合はなく、mid-sequence 失敗の部分コミットのみが残る低 severity 事項 (record と共通、この判断は #3596 に残置)。
- append-only-update fitness (#3658 系) は activity_logs の cancelled UPDATE を既に許容 (soft-cancel、m3 §3.4) → 新規違反なし (gate PASS 確認済)。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし (error 契約 {refundedPoints}/NOT_FOUND/CANCEL_EXPIRED と返却 shape は backend 間で不変)。
- レビュー観点: ① cancel UPDATE affected 判定を serialization anchor とする設計が二重返金を防ぐ論理 (concurrent 同一 log / 同一 child 別 log の両ケース) ② clampDecayFloor 契約の保存が updateStatus parity になっているか。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] AC 検証マップの全 AC が実装 + テストで裏付け済 (item ② scope)
- [x] 設計書同期済 (m3-physical-model.md §6.1)
- [x] 既存テスト回帰なし (fitness / service / sibling PASS)
- [x] biome / svelte-check clean
- [x] pre-ready 全 step PASS (実行して確認)

## QM レビュー結果

(QM 記入欄)

