### PR TITLE
fix(security): #3334 データ import/復元の認可網羅性 (activities/import owner-gate + 網羅確認)

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -431,6 +431,24 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 - **guard hoist（#3561 ②）**: `account/delete` は本人操作 pattern（`child` / `member`、switch 内で本人 role を個別検証）以外を handler 先頭の single choke-point で owner-gate 必須通過とする（default-deny）。将来 owner 系 pattern を追加しても guard の付け忘れが構造的に発生しない。副作用として、未知 pattern は非 owner に対し 400 より先に 403 を返す。
 - **fitness function**: `tests/unit/routes/admin-owner-guard-rollout.test.ts` が 4 endpoint（`account/delete` は 3 pattern）で owner → 成功経路 / parent・child → 403 + `{ error }` body バイト一致維持、判定が `requireRole(locals, ['owner'])` seam 経由であること、403 文言 = `OWNER_GATE_LABELS` の一致、未知 pattern への default-deny、および `requireRole` の 401 throw が 500 化せず 401 `{ error }` に変換されること（requireRole override 注入）を機械検証する。helper 単体は `tests/unit/auth/owner-gate.test.ts` が 401 / 403 / owner 通過 / 非 HttpError re-throw を検証する。
 
+#### 5.2.6 データ import / 復元 endpoint の認可網羅性（tenant 境界 / IDOR / free 開放の妥当性、#3334）
+
+家族データを取り込む・復元する endpoint は、破壊的（上書き / マージ）かつ PII を扱うため、以下の 4 観点で認可の網羅性を保つ。監査（#3334）で全経路を確認し、抜けていた 1 経路を是正した。
+
+| endpoint | 許可ロール | tenant 境界 | 備考 |
+|---|---|---|---|
+| `POST /api/v1/import`（バックアップファイル取込 preview/execute/replace） | `['owner', 'parent']`（in-handler） | server 由来 `context.tenantId` のみ | checksum 検証 + replace は原子境界 |
+| `POST /api/v1/import/cloud`（PIN クラウド取込） | `['owner', 'parent']`（in-handler） | server 由来 `tenantId` + `targetChildIds` 所有権検証 | template 取込の CWE-639 IDOR 防御 |
+| `POST /api/v1/activities/import`（活動セット取込） | `['owner', 'parent']`（in-handler、#3334 で追加） | server 由来 `tenantId` | 追加前は `/api/v1` ROUTE_RULE 経由で child も到達可だった |
+| `POST /api/v1/admin/account/restore`（ソフトデリート復元） | `['owner']` | server 由来 `tenantId` | grace period 内のみ |
+| `POST /api/v1/admin/downgrade-restore`（アーカイブ復元） | `['owner', 'parent']` | server 由来 `tenantId` | — |
+
+- **tenant 境界（他家庭データ注入の排除）**: 取込先 `tenantId` は常に認証コンテキスト（`context.tenantId`、改竄不可）から取得し、バックアップファイル内に埋め込まれた tenantId / child id は一切信頼しない。`importFamilyData` は子を `insertChild({...安全な項目のみ}, tenantId)` で**新規作成**し、以降の全レコードはバックアップの `childRef`（旧 id）を `childIdMap`（新 child への写像）で remap する。解決できない `childRef` を持つレコードは skip されるため、他テナントの child id を仕込んでも別家庭への注入は成立しない。
+- **IDOR（CWE-639）**: cloud template 取込は `targetChildIds` を `findAllChildren(tenantId)` の所有 child 集合と照合し、非所有 id を含めば `VALIDATION_ERROR` で拒否する（`tests/unit/routes/import-cloud-template-per-child.test.ts` で固定）。
+- **free 開放の妥当性（export 有料 / import 無料の非対称）**: export（`canExport`）はスタンダード以上に tier gate する一方、import（復元）は free 含む全プランに開放する。これは**意図的設計**であり、import はデータの喪失回復・移行という基本的可用性であって収益機能ではないため、プラン制限で締め出すと「自分のデータを取り戻せない」顧客不利益になる。認可は「取込を起こせるのは家庭の管理者（owner / parent）か」という role gate で十分で、tier gate（`canImport`）は設けない。
+- **fail-closed（壊れた / 改竄バックアップ）**: `validateExportData` で構造検証し、checksum 付きバックアップは `verifyChecksum` 不一致で `VALIDATION_ERROR`（破損 / 改ざん検出）。replace 取込は `replaceImportAtomic` で clear + import を原子境界にし、途中失敗時は旧データを必ず復元する（`AtomicReplaceError`）。checksum は正規バックアップの破損検出であって tenant 境界制御ではない（checksum を省いた悪意ある payload も、上記 server 由来 tenantId + childRef remap により自テナント内に閉じる）。
+- **fitness function**: `tests/unit/routes/import-authz-coverage.test.ts` が `/api/v1/activities/import` と `/api/v1/import` で child → 403 / owner・parent → gate 通過を機械検証する。
+
 ### 5.3 ライセンス状態による制限
 
 | ライセンス状態 | アクセス制限 |

--- a/src/routes/api/v1/activities/import/+server.ts
+++ b/src/routes/api/v1/activities/import/+server.ts
@@ -4,6 +4,7 @@ import { CATEGORY_CODES } from '$lib/domain/validation/activity';
 // #2365 (ADR-0052): 新 Strategy + dispatchImport 経由
 import { dispatchImport, marketplaceRegistry } from '$lib/marketplace';
 import type { ActivityPackPayload } from '$lib/marketplace/schemas/activity-pack-schema';
+import { requireRole } from '$lib/server/auth/factory';
 import type { RequestHandler } from './$types';
 
 const validCategoryCodes = new Set<string>(CATEGORY_CODES);
@@ -47,6 +48,10 @@ export const POST: RequestHandler = async ({ request, url, locals }) => {
 	if (!context) {
 		return json({ error: '認証が必要です' }, { status: 401 });
 	}
+	// #3334: 家族データの取込 (管理操作) は owner / parent 専用。ROUTE_RULES の /api/v1 は
+	// child も到達を許すため、他の import 系 endpoint (/api/v1/import, /api/v1/import/cloud) と
+	// 同様に in-handler で owner-gate し、child が家族の活動を勝手に取り込めないようにする。
+	requireRole(locals, ['owner', 'parent']);
 	const tenantId = context.tenantId;
 	const mode = url.searchParams.get('mode') ?? 'preview';
 

--- a/tests/unit/routes/import-authz-coverage.test.ts
+++ b/tests/unit/routes/import-authz-coverage.test.ts
@@ -1,0 +1,122 @@
+// tests/unit/routes/import-authz-coverage.test.ts
+// #3334: データ import / 復元の認可網羅性の回帰固定。
+//
+// ROUTE_RULES の /api/v1 は owner / parent / child すべての到達を許すため、家族データを
+// 取り込む管理操作 endpoint は in-handler で owner / parent に絞る必要がある。
+//
+// 観点:
+// - /api/v1/activities/import: child → 403 (本 PR で追加した gate)、owner / parent は gate 通過
+// - /api/v1/import (ファイル取込): child → 403 (既存 requireRole 防御の回帰固定)、
+//   owner / parent は role gate を通過し後段 (body 検証) に進む
+//
+// tenant 境界 / IDOR (CWE-639) の防御は別テストで固定済:
+// - import-cloud-template-per-child.test.ts: cross-tenant child id 拒否
+// - importFamilyData は server 由来 tenantId + childRef→新規 child remap で他テナント注入を排除
+
+import { isHttpError } from '@sveltejs/kit';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// activities/import は marketplace registry / dispatchImport を使う。owner/parent の gate 通過を
+// preview で確認するため軽量スタブに差し替える (DB 非依存)。
+const mockPreview = vi.fn();
+vi.mock('$lib/marketplace', () => ({
+	marketplaceRegistry: {
+		get: () => ({
+			strategy: {
+				parse: (raw: unknown) => raw,
+				preview: (...args: unknown[]) => mockPreview(...args),
+			},
+		}),
+	},
+	dispatchImport: vi.fn(),
+}));
+
+const { POST: activitiesImport } = await import(
+	'../../../src/routes/api/v1/activities/import/+server'
+);
+const { POST: fileImport } = await import('../../../src/routes/api/v1/import/+server');
+
+type Role = 'owner' | 'parent' | 'child';
+
+function activitiesEvent(role: Role, mode = 'preview') {
+	return {
+		request: new Request(`http://localhost/api/v1/activities/import?mode=${mode}`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ activities: [{ name: 'はしる', categoryCode: 'undou' }] }),
+		}),
+		url: new URL(`http://localhost/api/v1/activities/import?mode=${mode}`),
+		locals: {
+			context: { tenantId: 't-test', role },
+			identity: { type: 'cognito', userId: 'u-caller' },
+		},
+	} as unknown as Parameters<NonNullable<typeof activitiesImport>>[0];
+}
+
+function fileImportEvent(role: Role) {
+	// body は空 (invalid JSON)。role gate を通過すると parseImportRequest の JSON 解析で
+	// VALIDATION_ERROR (Response) になる → 「403 で止まらず後段に進んだ」ことの証跡。
+	return {
+		request: new Request('http://localhost/api/v1/import?mode=preview', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: 'not-json',
+		}),
+		url: new URL('http://localhost/api/v1/import?mode=preview'),
+		locals: {
+			context: { tenantId: 't-test', role },
+			identity: { type: 'cognito', userId: 'u-caller' },
+		},
+	} as unknown as Parameters<NonNullable<typeof fileImport>>[0];
+}
+
+describe('データ import / 復元の認可網羅性 (#3334)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockPreview.mockResolvedValue({
+			total: 1,
+			newItems: 1,
+			duplicates: 0,
+			duplicateNames: [],
+			byCategory: {},
+		});
+	});
+
+	describe('POST /api/v1/activities/import (家族の活動取込)', () => {
+		it('child は 403 で拒否される (本 PR で追加した owner-gate)', async () => {
+			await expect(activitiesImport(activitiesEvent('child'))).rejects.toSatisfy((e: unknown) =>
+				isHttpError(e, 403),
+			);
+			expect(mockPreview).not.toHaveBeenCalled();
+		});
+
+		for (const role of ['owner', 'parent'] as const) {
+			it(`${role} は gate を通過し取込 preview に進む`, async () => {
+				const res = await activitiesImport(activitiesEvent(role));
+				expect(res.status).toBe(200);
+				expect(mockPreview).toHaveBeenCalledWith(
+					expect.anything(),
+					expect.objectContaining({ tenantId: 't-test' }),
+				);
+			});
+		}
+	});
+
+	describe('POST /api/v1/import (バックアップファイル取込)', () => {
+		it('child は 403 で拒否される (既存 requireRole 防御の回帰固定)', async () => {
+			await expect(fileImport(fileImportEvent('child'))).rejects.toSatisfy((e: unknown) =>
+				isHttpError(e, 403),
+			);
+		});
+
+		for (const role of ['owner', 'parent'] as const) {
+			it(`${role} は role gate を通過し後段 (body 検証) に進む (403 で止まらない)`, async () => {
+				// 通過後 invalid JSON body で VALIDATION_ERROR (Response) になる = gate を越えた証跡。
+				const res = await fileImport(fileImportEvent(role));
+				expect(res).toBeInstanceOf(Response);
+				expect(res.status).not.toBe(403);
+				expect(res.status).not.toBe(401);
+			});
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（家族データの取込・復元経路の認可境界を守る基盤）

**解決する課題**: PR #3323 の QM adversarial レビューで「export はスタンダード以上に tier gate される一方、import（復元）は free 含む全ユーザーに開放されている」データ整合性懸念が surface した。import / 復元は家庭データを上書き / マージする破壊的・PII 取扱操作のため、tenant 境界 / IDOR / free 開放の妥当性 / fail-closed を全経路で確認し、抜けがあれば塞ぐ必要があった。

**期待される効果**: 全 import / 復元経路の認可網羅性を確認し設計書に SSOT 化。唯一の抜け（`/api/v1/activities/import` が in-handler role gate を欠き child が家族の活動を取り込めた）を塞ぎ、他の import endpoint と認可を揃える。回帰は fitness function で機械固定する。

## 関連 Issue

closes #3334

関連: PR #3323（#3307 ガイド整合、QM adversarial evidence の出典）/ #2362 PR-3（cloud template per-child IDOR 防御）/ #3326（replace 原子化）/ #3133（cross-tenant 静的ファイル IDOR）/ ADR-0055（per-child データモデル）/ ADR-0010（Pre-PMF scope）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| 1 | import / 復元 endpoint で tenant 境界が検証されているか（他テナントのバックアップで別家庭データを注入できないか） | コード監査 + `importFamilyData` / `importChildrenData` 読解 | 抜けなし。取込先 `tenantId` は常に `context.tenantId`（改竄不可）由来。子は `insertChild({安全項目のみ}, tenantId)` で新規作成し、以降のレコードは backup の `childRef` を `childIdMap`（新 child への写像）で remap、解決不能な `childRef` は skip。backup 埋込 tenantId / child id は一切信頼しない |
| 2 | `targetChildIds` 等で IDOR（自テナント外 child へのデータ注入）が成立しないか | `npx vitest run tests/unit/routes/import-cloud-template-per-child.test.ts` | 抜けなし。cloud template 取込は `targetChildIds` を `findAllChildren(tenantId)` 所有集合と照合し非所有 id を `VALIDATION_ERROR` で拒否（CWE-639、既存 test「execute は cross-tenant child id を拒否する」で固定済） |
| 3 | import を free 開放とする product 判断が妥当か（export 有料 / import 無料の非対称が意図的か。意図的なら設計書に根拠を SSOT 化） | 設計書 §5.2.6 追記 | 意図的と判断し SSOT 化。import は可用性回復（喪失データを取り戻す）であって収益機能ではないため tier gate で締め出さない。認可は role gate（owner / parent）で十分、`canImport` は設けない |
| 4 | 復元時の検証失敗（壊れた / 改竄バックアップ）で fail-closed か | コード監査（`verifyChecksum` / `validateExportData` / `replaceImportAtomic`） | 抜けなし。checksum 付き backup は不一致で `VALIDATION_ERROR`、replace は原子境界で途中失敗時に旧データを必ず復元。checksum は破損検出であり tenant 境界制御ではない旨（checksum 省略 payload も server 由来 tenantId + childRef remap で自テナント内に閉じる）を設計書に明記 |
| 塞いだ抜け | `/api/v1/activities/import` の role gate 欠落を是正 | `npx vitest run tests/unit/routes/import-authz-coverage.test.ts` | `ROUTE_RULES` の `/api/v1` は child 到達を許すが、`/api/v1/import`・`/api/v1/import/cloud` は in-handler で owner-gate 済。`activities/import` のみ未 gate で child が家族活動を取込可能（自テナント内だが管理操作の role 逸脱）だった → `requireRole(['owner','parent'])` を追加。child → 403 / owner・parent → 通過を機械検証 |
| 設計書 | §5.2.6 に認可網羅性（tenant 境界 / IDOR / free 開放根拠 / fail-closed）を SSOT 化（ADR-0001） | 目視 | `docs/design/14-セキュリティ設計書.md` §5.2.6 追加 |

## 変更タイプ

- [x] fix: バグ修正（authz 網羅性の抜けを是正）

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] API エンドポイント (`src/routes/api/`) — `activities/import` に owner-gate 追加

**影響を受ける画面・機能**: 活動セット取込 API（`/api/v1/activities/import`）の認可のみ。owner / parent の取込挙動は不変。child の取込は 403 で拒否されるようになる（本 API は src / tests 内に呼び出し元 0 件で、UI からは owner / parent 経由でのみ叩かれるため実利用への影響なし）。

**確認のみで変更不要だった経路**: `/api/v1/import`・`/api/v1/import/cloud`（既に owner/parent gate + tenant 境界 + IDOR 防御 + fail-closed 済）、`/api/v1/admin/account/restore`（owner）、`/api/v1/admin/downgrade-restore`（owner/parent）。

## テスト & 安全装置セルフチェック

- [x] 追加・変更したテストの概要:
  - `tests/unit/routes/import-authz-coverage.test.ts`（新規）: `/api/v1/activities/import`・`/api/v1/import` で child → 403 / owner・parent → role gate 通過（6 件）
  - 局所検証: `npx vitest run tests/unit/routes/import-authz-coverage.test.ts`（6 passed）+ 回帰確認 `activities-quota-residual-gate` / `admin-activities-import-plan-gate` / `import-cloud-template-per-child` / `import-size-limit` / `activity-import-service`（62 passed）+ `npx biome check <変更 2 files>` PASS + svelte-check 変更ファイル型エラー 0
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A（既存経路の読解確認のみ、実装は role gate 1 行追加）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:critical ではない。自テナント内の role 逸脱で cross-tenant leak なし）

## スクリーンショット / ビジュアルデモ

該当なし（server-side 認可 gate の追加のみ。UI 描画・文言表示の変更なし）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — role gate を既存の `requireRole` seam に委譲、他 import endpoint と同一パターン
- [x] **DRY**: 独自認可を書かず `requireRole(['owner','parent'])` を再利用（`/api/v1/import` と同型）
- [x] **YAGNI**: `canImport` tier gate は追加しない（import = 可用性回復、AC3 の意図的設計）
- [x] **Security（OSS 公開前提）**: role 逸脱経路を封鎖 / tenant 境界・IDOR・fail-closed を確認し SSOT 化 / 秘密情報 hardcode なし
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: N/A（同期 role 判定 1 段の追加のみ）

## 横展開・影響波及チェック

**並行実装ペア**:
- [x] **設計書同期** (ADR-0001): `docs/design/14-セキュリティ設計書.md` §5.2.6 を同一 PR で追加
- [x] **import endpoint 群の認可パターン統一**: `/api/v1/import`・`/import/cloud`・`activities/import` すべて in-handler `requireRole(['owner','parent'])` で揃えた
- [x] **並行 PR overlap** (#1200): 対象 endpoint / 設計書 §5.2 を触る open PR なし
- [x] N/A — デモ / 年齢モード / ナビ / E2E シード / チュートリアルへの波及なし

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

（挙動差分: `/api/v1/activities/import` が child role に対し 403 を返すようになる。本 API は src / tests 内に呼び出し元がなく、admin UI からは owner / parent 経由でのみ到達するため実利用への影響なし。）

**レビュー依頼事項・QA**:
- AC3 の判断（export 有料 / import 無料の非対称は意図的、import = 可用性回復で tier gate 不要）が PO 方針と整合するかご確認ください
- AC4 の fail-closed 評価（checksum は破損検出であって tenant 境界制御ではない。tenant 境界は server 由来 tenantId + childRef remap が担う）の妥当性確認をお願いします

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認する（統合セッションで最終実行）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1-4 確認 + 抜け 1 件を fix + 設計書 SSOT 化）
- [x] Phase 分割: N/A（単一 PR で完結）
- [x] UI 変更時: N/A（server-side gate のみ）
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入。CI 緑 = approve ではない。Issue AC 照合が必須（ADR-0022）。 -->
