### PR TITLE
fix(data-integrity): #3355 評価取込冪等性+createdAt / #3464 resolvedByParentId restore normalize / #3381 交換履歴 reward 再結合安定識別子化 (restore 冪等/再結合クラスタ)

### DIFF
--- a/docs/design/backup-import-redesign.md
+++ b/docs/design/backup-import-redesign.md
@@ -40,9 +40,10 @@
 - **PIN（おやカギ pin_hash）取扱**（監査 §3 セキュリティ caveat、CWE-522/916）: backup から除外し復元後に再設定、または別パスフレーズで暗号化。無防備同梱しない（PO 判断、§4）。
 
 **実装（`src/lib/domain/export-format.ts` / `src/lib/server/services/export-service.ts`）**:
-- フォーマット = `EXPORT_FORMAT='ganbari-quest-backup'` / `EXPORT_VERSION='1.6.0'`。下位互換読込は持たない（D5）。
+- フォーマット = `EXPORT_FORMAT='ganbari-quest-backup'` / `EXPORT_VERSION='1.7.0'`。下位互換読込は持たない（D5）。
 - **settings は default-deny allowlist**（`EXPORTABLE_SETTING_KEYS` / `isExportableSettingKey`）。`pin_hash` / `pin_locked_until` / `pin_failed_attempts` / `pin_reset_applied` / `session_token` / `session_expires_at` を export からも import からも除外（CWE-522/916、import 側でも再 filter する多層防御）。
-- per-child instance は **自然キー参照（ref）で出力**し、import で新 childId / 新 id に再解決する（§3.3）: `childRef`（child）/ `rewardRef`（ごほうび title）/ `activityName`（per-child 活動名）/ `templateExportId`（checklist template）/ `voiceRelPath`（音声ファイル相対パス、tenant prefix 除去済）/ `from`-`toChildRef`（兄弟応援）。
+- per-child instance は **参照（ref）で出力**し、import で新 childId / 新 id に再解決する（§3.3）: `childRef`（child）/ `rewardExportId`（ごほうび安定識別子 `reward-<childRef>-<rewardId>`、交換履歴の優先再結合キー、#3381）+ `rewardRef`（ごほうび title、旧 backup / fallback）/ `activityName`（per-child 活動名）/ `templateExportId`（checklist template、#3107）/ `voiceRelPath`（音声ファイル相対パス、tenant prefix 除去済）/ `from`-`toChildRef`（兄弟応援）。
+  - **安定識別子 vs title/name（#3107 / #3381）**: title / name は mutable なため、改名後 / 同名複数時に再結合が silent skip / collapse する。checklist（`exportId` / `templateExportId`）と交換履歴（`exportId` / `rewardExportId`）は **`<種別>-<childRef>-<元id>` 形の安定識別子を優先キー**にし、title/name は旧 backup 用の fallback に降格する（いずれも optional で後方互換、EXPORT_VERSION 1.7.0）。activity（`activityName`）は同型の安定 id 化が follow-up（#3465(2)、`findActivityLogs` の projection に activityId を carry させる必要あり）。
 - 音声 / アバター等の静的ファイルは `backup-archive.ts` が ZIP に同梱（`MAX_ZIP_SIZE=100MB`、fail-closed）。DB 行は tenant prefix を除いた相対パスを持ち、import で新 tenant+childId に再構成する（#3077）。
 
 ### 3.3 import

--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -13,7 +13,11 @@ export const EXPORT_FORMAT = 'ganbari-quest-backup' as const;
 // #3422: 1.6.0 で childActivity の `dailyLimit` / `nameKana` / `nameKanji` を追加。create/update では
 //   persist 是正済だが backup round-trip では同 3 列が silent drop され、復元後 dailyLimit が null
 //   (= 1 日 1 回固定) に戻る取りこぼしの修正。いずれも optional で後方互換 (旧 backup は schema default)。
-export const EXPORT_VERSION = '1.6.0' as const;
+// #3381: 1.7.0 で specialReward の `exportId` / rewardRedemption の `rewardExportId` を追加。交換履歴の
+//   reward 再結合を mutable な title でなく安定識別子 (rewardId 由来の exportId) で行い、reward 改名後 /
+//   同名 reward 複数時に交換履歴が silent skip / collapse する restore edge を根治する。いずれも optional で
+//   後方互換 (旧 backup は rewardRef=title で従来どおり fallback 再結合、#3107 checklist exportId と同型)。
+export const EXPORT_VERSION = '1.7.0' as const;
 
 // ============================================================
 // 退役キー名の予約 (Protobuf `reserved` / Avro alias の安価な代替)。
@@ -247,12 +251,20 @@ export interface ExportSpecialReward {
 	grantedAt: string;
 	// #1254 G1: マーケットプレイスプリセット由来の識別子 (v1.2.0+)
 	sourcePresetId?: string | null;
+	// #3381: export 内で安定な reward 識別子 (v1.7.0+、`reward-${childRef}-${rewardId}`)。
+	// rewardRedemption の再結合キーに使い、reward が改名されても / 同名 reward が複数あっても
+	// 交換履歴を取り違えない。旧 export には無いため optional (title fallback へ縮退)。
+	exportId?: string;
 }
 
 export interface ExportRewardRedemption {
 	childRef: string;
-	/** import 後に FK rewardId を再解決するための reward タイトル (per-child で一意) */
+	/** import 後に FK rewardId を再解決するための reward タイトル (per-child で一意、旧 backup / fallback 用) */
 	rewardRef: string;
+	// #3381: 紐づく reward の安定識別子 (v1.7.0+、ExportSpecialReward.exportId 参照)。import 側はこれを
+	// 優先して新 rewardId に再マップし、無い場合 (旧 export) のみ rewardRef (title) で fallback する。
+	// reward 改名後 / 同名 reward 複数時の silent skip / collapse を根治する。
+	rewardExportId?: string | null;
 	requestedAt: number;
 	status: string;
 	parentNote: string | null;

--- a/src/lib/domain/export-migrations.ts
+++ b/src/lib/domain/export-migrations.ts
@@ -40,6 +40,9 @@ const STEPS: readonly MigrationStep[] = [
 	{ from: '1.3.0', to: '1.4.0', migrate: identity },
 	{ from: '1.4.0', to: '1.5.0', migrate: identity },
 	{ from: '1.5.0', to: '1.6.0', migrate: identity },
+	// #3381: specialReward.exportId / rewardRedemption.rewardExportId 追加 (追加のみ、import 側は
+	// exportId 欠落時に rewardRef=title で fallback するため identity で足りる)。
+	{ from: '1.6.0', to: '1.7.0', migrate: identity },
 ];
 
 /** STEPS が辿れる version の集合 (chain の起点 + 各 step の to)。テストの網羅検証に使う。 */

--- a/src/lib/server/db/demo/evaluation-repo.ts
+++ b/src/lib/server/db/demo/evaluation-repo.ts
@@ -33,7 +33,8 @@ export async function insertEvaluation(
 		weekEnd: input.weekEnd,
 		scoresJson: input.scoresJson,
 		bonusPoints: input.bonusPoints,
-		createdAt: new Date().toISOString(),
+		// #3355: backup restore が渡した createdAt を保全 (省略時は取込時刻)。
+		createdAt: input.createdAt ?? new Date().toISOString(),
 	};
 }
 

--- a/src/lib/server/db/dsql/evaluation-repo.ts
+++ b/src/lib/server/db/dsql/evaluation-repo.ts
@@ -105,10 +105,11 @@ export function createDsqlEvaluationRepo<TTx extends SqlExecutor>(
 
 		async insertEvaluation(input, tenantId) {
 			// scores_json は verbatim text 据置 (子表化しない、§4.2)。
+			// #3355: created_at は backup restore が渡した値を保全 (省略時は DB default = now)。
 			const result = await db.execute(sql`
-				INSERT INTO evaluations (family_id, child_id, week_start, week_end, scores_json, bonus_points)
+				INSERT INTO evaluations (family_id, child_id, week_start, week_end, scores_json, bonus_points, created_at)
 				VALUES (${tenantId}, ${input.childId}, ${input.weekStart}, ${input.weekEnd},
-					${input.scoresJson}, ${input.bonusPoints})
+					${input.scoresJson}, ${input.bonusPoints}, ${input.createdAt ?? sql`DEFAULT`})
 				RETURNING ${EVALUATION_COLUMNS}
 			`);
 			return toEvaluation(result.rows[0] as unknown as EvaluationRow);

--- a/src/lib/server/db/dsql/reward-redemption-repo.ts
+++ b/src/lib/server/db/dsql/reward-redemption-repo.ts
@@ -27,6 +27,7 @@ import {
 	type RedemptionRequestWithReward,
 } from '../interfaces/reward-redemption-repo.interface';
 import type { TransactionRunner } from '../interfaces/transaction.interface';
+import { normalizeResolvedByParentId } from '../reward-redemption-normalize';
 import type { SqlExecutor } from './sql-executor';
 
 interface RequestRow {
@@ -153,7 +154,7 @@ export function createDsqlRewardRedemptionRepo<TTx extends SqlExecutor>(
 				VALUES (${tenantId}, ${input.childId}, ${input.rewardId}, ${epochToIso(input.requestedAt)},
 					${input.status}, ${input.parentNote},
 					${input.resolvedAt === null ? null : epochToIso(input.resolvedAt)},
-					${input.resolvedByParentId},
+					${normalizeResolvedByParentId(input.resolvedByParentId)},
 					${input.shownToChildAt === null ? null : epochToIso(input.shownToChildAt)},
 					${input.rewardTitle}, ${input.rewardPoints}, ${input.rewardIcon})
 				RETURNING ${REQUEST_COLUMNS}

--- a/src/lib/server/db/dynamodb/evaluation-repo.ts
+++ b/src/lib/server/db/dynamodb/evaluation-repo.ts
@@ -84,7 +84,8 @@ export async function insertEvaluation(
 		weekEnd: input.weekEnd,
 		scoresJson: input.scoresJson,
 		bonusPoints: input.bonusPoints,
-		createdAt: now,
+		// #3355: backup restore が渡した createdAt を保全 (省略時は取込時刻)。
+		createdAt: input.createdAt ?? now,
 	};
 
 	const key = evaluationKey(Number(input.childId), input.weekStart, tenantId);

--- a/src/lib/server/db/dynamodb/reward-redemption-repo.ts
+++ b/src/lib/server/db/dynamodb/reward-redemption-repo.ts
@@ -43,6 +43,7 @@ import {
 	type RedemptionRequestWithDetails,
 	type RedemptionRequestWithReward,
 } from '../interfaces/reward-redemption-repo.interface';
+import { normalizeResolvedByParentId } from '../reward-redemption-normalize';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
 import {
@@ -67,16 +68,8 @@ interface DenormFields {
 	rewardPoints: number;
 }
 
-// #3337: legacy DynamoDB レコードは resolvedByParentId=0 (number) を持つ (旧 approve/reject の
-// placeholder)。`?? null` は 0 が nullish でないため legacy 0 を素通しし、string|null 型に number が
-// 紛れる coercion trap になる。read-side で 0 / '0' / null/undefined を null に正規化し、SQLite
-// (lazy-startup-migrations で legacy 0→NULL 正規化済) と cross-backend 表現を揃える。
-// 実 parent userId は string で保存されるためそのまま String 化して返す。
-function normalizeResolvedByParentId(raw: unknown): string | null {
-	if (raw === null || raw === undefined || raw === 0 || raw === '0') return null;
-	return String(raw);
-}
-
+// #3337 / #3464: resolvedByParentId の legacy `0`/`'0'` → null 正規化は
+// `../reward-redemption-normalize` の SSOT (read + restore write 共有) を使う。
 // DynamoDB item から PK/SK + 非正規化フィールドを除いた RedemptionRequestRow を作る。
 function toRow(item: Record<string, unknown>): RedemptionRequestRow {
 	const stripped = stripKeys(item) as Record<string, unknown>;
@@ -278,7 +271,8 @@ export const insertRedemptionForRestore: IRewardRedemptionRepo['insertRedemption
 			status: input.status,
 			parentNote: input.parentNote,
 			resolvedAt: input.resolvedAt,
-			resolvedByParentId: input.resolvedByParentId,
+			// #3464: legacy `0`/`'0'` を物理 null 化して書き戻す (read 正規化と SSOT 共有)。
+			resolvedByParentId: normalizeResolvedByParentId(input.resolvedByParentId),
 			shownToChildAt: input.shownToChildAt,
 		};
 

--- a/src/lib/server/db/reward-redemption-normalize.ts
+++ b/src/lib/server/db/reward-redemption-normalize.ts
@@ -1,0 +1,21 @@
+// src/lib/server/db/reward-redemption-normalize.ts
+// #3464: resolvedByParentId の値域正規化 SSOT。
+//
+// 背景 (#3331 / #3337): resolvedByParentId は cognito sub を保持する TEXT 監査カラムだが、旧
+// approve/reject 経路は placeholder として `0` (number) / `'0'` を書いていた。`?? null` は 0 が
+// nullish でないため legacy 0 を素通しし、string|null 型に number/`'0'` が紛れる coercion trap になる。
+// #3337 は **read 経路 (DynamoDB toRow / SQLite lazy-startup-migration)** で 0/'0' → null に収束させたが、
+// restore write (insertRedemptionForRestore) が `input.resolvedByParentId` を verbatim 書込するため、
+// legacy 0 を含む旧 backup を復元すると「書込 0 / read null」の物理値ドリフト (#3464 item1) が残っていた。
+//
+// 本 SSOT を read 正規化と restore write の双方が使うことで、`0` / `'0'` が物理 DB に再混入しない
+// (round-trip が物理値レベルで閉じる)。実 parent userId は string 保存のためそのまま String 化する。
+
+/**
+ * resolvedByParentId を正規化する。legacy placeholder (`0` / `'0'`) と null/undefined を `null` に、
+ * 実 parent id (string / 数値 id) は文字列へ収束させる。read (toRow) と restore write の共通 SSOT。
+ */
+export function normalizeResolvedByParentId(raw: unknown): string | null {
+	if (raw === null || raw === undefined || raw === 0 || raw === '0') return null;
+	return String(raw);
+}

--- a/src/lib/server/db/sqlite/reward-redemption-repo.ts
+++ b/src/lib/server/db/sqlite/reward-redemption-repo.ts
@@ -10,6 +10,7 @@ import {
 	type RedemptionRequestWithDetails,
 	type RedemptionRequestWithReward,
 } from '../interfaces/reward-redemption-repo.interface';
+import { normalizeResolvedByParentId } from '../reward-redemption-normalize';
 import { children, rewardRedemptionRequests, specialRewards } from '../schema';
 
 type RequestRow = typeof rewardRedemptionRequests.$inferSelect;
@@ -148,7 +149,9 @@ export async function insertRedemptionForRestore(
 				status: input.status,
 				parentNote: input.parentNote,
 				resolvedAt: input.resolvedAt,
-				resolvedByParentId: input.resolvedByParentId,
+				// #3464: legacy `0`/`'0'` を物理 null 化して書き戻す (read 正規化と SSOT 共有、
+				// 「書込 0 / read null」の物理値ドリフト防止)。
+				resolvedByParentId: normalizeResolvedByParentId(input.resolvedByParentId),
 				shownToChildAt: input.shownToChildAt,
 				rewardTitle: input.rewardTitle,
 				rewardPoints: input.rewardPoints,

--- a/src/lib/server/db/types/index.ts
+++ b/src/lib/server/db/types/index.ts
@@ -479,6 +479,10 @@ export interface InsertEvaluationInput {
 	weekEnd: string;
 	scoresJson: string;
 	bonusPoints: number;
+	// #3355: backup restore で作成日時を保全する (省略時は schema default = 取込時刻)。
+	// 週次評価の createdAt は growth-book / reports の時系列軸のため、復元で取込時刻へ
+	// 書き換わると履歴が歪む。旧 backup 後方互換のため optional。
+	createdAt?: string;
 }
 
 export interface InsertLoginBonusInput {

--- a/src/lib/server/services/export-service.ts
+++ b/src/lib/server/services/export-service.ts
@@ -431,14 +431,18 @@ async function collectForChild(
 		category: sr.category,
 		grantedAt: sr.grantedAt,
 		sourcePresetId: sr.sourcePresetId,
+		// #3381: 安定 reward 識別子。交換履歴 (rewardExportId) の再結合キー (改名/同名衝突に頑健)。
+		exportId: `reward-${childRef}-${sr.id}`,
 	}));
 
-	// #3329: 交換履歴。FK rewardId は import 後に変わるため rewardRef (reward title) で再結合する。
-	// WithDetails の rewardTitle は snapshot 優先で解決済 (COALESCE(snapshot, live))。
+	// #3329: 交換履歴。FK rewardId は import 後に変わるため再結合が必要。
+	// #3381: 安定識別子 rewardExportId (reward の exportId) を優先キーにし、rewardRef (snapshot title) は
+	// 旧 backup / fallback 用に残す。WithDetails の rewardTitle は snapshot 優先で解決済 (COALESCE(snapshot, live))。
 	warnIfTruncated('rewardRedemptions', childId, redemptions.length);
 	const rewardRedemptionsOut: ExportRewardRedemption[] = redemptions.map((r) => ({
 		childRef,
 		rewardRef: r.rewardTitle,
+		rewardExportId: `reward-${childRef}-${r.rewardId}`,
 		requestedAt: r.requestedAt,
 		status: r.status,
 		parentNote: r.parentNote,

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -26,7 +26,11 @@ import {
 	upsertLog,
 } from '$lib/server/db/checklist-repo';
 import { insertChild } from '$lib/server/db/child-repo';
-import { insertEvaluation, insertRestDayForRestore } from '$lib/server/db/evaluation-repo';
+import {
+	findEvaluationsByChild,
+	insertEvaluation,
+	insertRestDayForRestore,
+} from '$lib/server/db/evaluation-repo';
 import { getRepos } from '$lib/server/db/factory';
 import { updateChildAvatarUrl } from '$lib/server/db/image-repo';
 import { findRecentBonuses, insertLoginBonus } from '$lib/server/db/login-bonus-repo';
@@ -412,10 +416,11 @@ export async function importFamilyData(
 	await importRestDaysData(data, childIdMap, tenantId, result);
 	// #3329: 子のカスタム音声 DB 行を復元 (filePath/publicUrl を新 tenant+childId へ remap)。childIdMap のみ必要。
 	await importChildVoicesData(data, childIdMap, tenantId, result);
-	await importSpecialRewards(data, childIdMap, tenantId, result, mode);
-	// #3329: ごほうび交換/購入履歴。reward を先に取込済 (FK rewardRef → rewardId を再解決) なので
-	// importSpecialRewards の後に実行する。
-	await importRewardRedemptionsData(data, childIdMap, tenantId, result);
+	// #3381: importSpecialRewards が返す exportId → 新 rewardId マップを交換履歴の安定再結合に使う。
+	const rewardIdByExportId = await importSpecialRewards(data, childIdMap, tenantId, result, mode);
+	// #3329: ごほうび交換/購入履歴。reward を先に取込済なので importSpecialRewards の後に実行する。
+	// #3381: rewardExportId (安定識別子) 優先 → rewardRef (title) fallback で再結合する。
+	await importRewardRedemptionsData(data, childIdMap, rewardIdByExportId, tenantId, result);
 	// #3329: per-child チャレンジ (auto:weekly 含む) を進捗/完了/請求保全で復元。childIdMap のみ必要。
 	await importChildChallengesData(data, childIdMap, tenantId, result);
 	// #3329: スタンプカード + 押印。card を復元 → 新 cardId に entry を貼り直す。childIdMap のみ必要。
@@ -448,15 +453,43 @@ export async function importFamilyData(
  * 従来 importFamilyData に評価の取込経路が無く、export には含まれるのに restore で全喪失していた
  * 網羅漏れ (本番 t-82c17558 で評価 22→0 を実証) を解消する。
  */
+/** 評価 dedup の既存行 prefetch 上限 (週次 = 年 52 行程度、10 年でも十分な余裕)。 */
+const EVALUATION_DEDUP_PREFETCH = 100_000;
+
 async function importEvaluationsData(
 	data: ExportData,
 	childIdMap: Map<string, ChildId>,
 	tenantId: string,
 	result: ImportResult,
 ): Promise<void> {
-	for (const ev of data.data.evaluations ?? []) {
+	const evaluations = data.data.evaluations ?? [];
+	if (evaluations.length === 0) return;
+
+	// #3355: (childId, weekStart) は週次評価の自然キー (1 週 1 評価)。他 importer
+	// (importLoginBonusesData / importActivityLogsData) と同型の pre-fetch dedup で、同一 backup の
+	// 再取込 (merge) や重複行を二重計上しない (旧実装は無条件 insert で growth-book/reports の数値汚染)。
+	// 既存 DB 行 + 同一 import 内の両方を dedup 対象にする (loginBonuses と同じく mode 非依存 = 自然キーは
+	// verbatim でも重複が正当化されないため常に dedup)。
+	const existingWeeksByChild = new Map<ChildId, Set<string>>();
+	async function existingWeeks(childId: ChildId): Promise<Set<string>> {
+		let set = existingWeeksByChild.get(childId);
+		if (!set) {
+			const rows = await findEvaluationsByChild(childId, EVALUATION_DEDUP_PREFETCH, tenantId);
+			set = new Set(rows.map((e) => e.weekStart));
+			existingWeeksByChild.set(childId, set);
+		}
+		return set;
+	}
+
+	for (const ev of evaluations) {
 		const childId = childIdMap.get(ev.childRef);
 		if (!childId) {
+			result.evaluationsSkipped++;
+			continue;
+		}
+		const weeks = await existingWeeks(childId);
+		if (weeks.has(ev.weekStart)) {
+			// 既存 or 同一 import 内の同 (child, weekStart) → skip (二重計上防止)。
 			result.evaluationsSkipped++;
 			continue;
 		}
@@ -468,9 +501,12 @@ async function importEvaluationsData(
 					weekEnd: ev.weekEnd,
 					scoresJson: ev.scoresJson,
 					bonusPoints: ev.bonusPoints,
+					// #3355: 作成日時を保全 (取込時刻に書き換えると growth-book/reports の時系列が歪む)。
+					createdAt: ev.createdAt,
 				},
 				tenantId,
 			);
+			weeks.add(ev.weekStart);
 			result.evaluationsImported++;
 		} catch (e) {
 			result.evaluationsSkipped++;
@@ -482,15 +518,20 @@ async function importEvaluationsData(
 }
 
 /**
- * ごほうびショップ交換/購入履歴を復元する (#3329)。
- * FK rewardId は import で振り直されるため、export の `rewardRef` (reward title) を取込先 child の
- * reward 一覧から再解決して結合する。reward が解決できない行 (元 reward 未取込/同名衝突) は
- * skip + warning (FK NOT NULL を満たせないため。残高への影響は別途 pointLedger が真実を持つ)。
- * status / 解決情報 / snapshot は insertRedemptionForRestore で申請時点のまま書き戻す。
+ * ごほうびショップ交換/購入履歴を復元する (#3329 / #3381)。
+ * FK rewardId は import で振り直されるため再結合が必要。
+ * #3381: 安定識別子 `rewardExportId` (importSpecialRewards が返す exportId→新 rewardId マップ) を
+ * 優先キーに再結合し、無い場合 (旧 backup) のみ `rewardRef` (snapshot title) で取込先 child の reward
+ * 一覧から fallback 解決する。これにより reward が redemption 後に改名されても / 同名 reward が複数あっても
+ * 交換履歴が silent skip / collapse しない (旧実装は live title 照合のみで改名後 skip していた)。
+ * reward が解決できない行 (元 reward 未取込) は skip + warning (FK NOT NULL を満たせないため。残高への
+ * 影響は別途 pointLedger が真実を持つ)。status / 解決情報 / snapshot は insertRedemptionForRestore で
+ * 申請時点のまま書き戻す。
  */
 async function importRewardRedemptionsData(
 	data: ExportData,
 	childIdMap: Map<string, ChildId>,
+	rewardIdByExportId: Map<ChildId, Map<string, string>>,
 	tenantId: string,
 	result: ImportResult,
 ): Promise<void> {
@@ -515,7 +556,10 @@ async function importRewardRedemptionsData(
 			result.rewardRedemptionsSkipped++;
 			continue;
 		}
-		const rewardId = (await rewardLookup(childId)).get(r.rewardRef);
+		// #3381: 安定識別子 (rewardExportId) を優先、無ければ snapshot title で fallback 解決。
+		const rewardId =
+			(r.rewardExportId ? rewardIdByExportId.get(childId)?.get(r.rewardExportId) : undefined) ??
+			(await rewardLookup(childId)).get(r.rewardRef);
 		if (!rewardId) {
 			result.rewardRedemptionsSkipped++;
 			result.warnings.push(
@@ -1966,68 +2010,137 @@ async function importStatusHistoryData(
 	});
 }
 
+/** child 単位の specialReward import 状態 (既存 + 当 import で作成した reward の id 解決)。 */
+interface SpecialRewardChildState {
+	titles: Set<string>;
+	presetIds: Set<string>;
+	idByTitle: Map<string, string>;
+	idByPreset: Map<string, string>;
+}
+
+/** child の既存 reward から import 状態を初期化する (#3381)。 */
+async function loadSpecialRewardState(
+	childId: ChildId,
+	tenantId: string,
+): Promise<SpecialRewardChildState> {
+	const rows = await findSpecialRewards(childId, tenantId);
+	return {
+		titles: new Set(rows.map((r) => r.title)),
+		presetIds: new Set(rows.map((r) => r.sourcePresetId).filter((p): p is string => !!p)),
+		idByTitle: new Map(rows.map((r) => [r.title, r.id])),
+		idByPreset: new Map(
+			rows.filter((r) => r.sourcePresetId).map((r) => [r.sourcePresetId as string, r.id]),
+		),
+	};
+}
+
+/**
+ * 1 件の specialReward を import (重複スキップ / 新規作成) し、解決先 rewardId を register に渡す (#3381)。
+ * skip 時も既存 rewardId を register し、交換履歴が正しい reward に再結合できるようにする
+ * (#3107 checklist の register と同型)。
+ */
+// biome-ignore lint/complexity/useMaxParams: import ヘルパ群の既存引数列に合わせる (checklist と同型)。
+async function importOneSpecialReward(
+	sr: ExportData['data']['specialRewards'][number],
+	childId: ChildId,
+	state: SpecialRewardChildState,
+	tenantId: string,
+	result: ImportResult,
+	register: (rewardId: string) => void,
+	mode: ImportMode,
+): Promise<void> {
+	// #1254 G1: preset_duplicate → name_duplicate の順で判定 (merge のみ、#3653)。
+	// verbatim (cutover) では同 child 同 title の正当な複数行 (title に DB 一意制約なし、
+	// NUC cycle 3 で export=9 → imported=2 の実欠落) を全行復元する。
+	if (mode === 'merge' && sr.sourcePresetId && state.presetIds.has(sr.sourcePresetId)) {
+		result.specialRewardsSkipped++;
+		result.skipped.preset++;
+		const dupId = state.idByPreset.get(sr.sourcePresetId);
+		if (dupId !== undefined) register(dupId);
+		return;
+	}
+	if (mode === 'merge' && state.titles.has(sr.title)) {
+		result.specialRewardsSkipped++;
+		result.skipped.name++;
+		const dupId = state.idByTitle.get(sr.title);
+		if (dupId !== undefined) register(dupId);
+		return;
+	}
+
+	try {
+		const created = await insertSpecialReward(
+			{
+				childId,
+				title: sr.title,
+				description: sr.description ?? undefined,
+				points: sr.points,
+				icon: sr.icon ?? undefined,
+				category: sr.category,
+				sourcePresetId: sr.sourcePresetId ?? null,
+			},
+			tenantId,
+		);
+		result.specialRewardsImported++;
+		state.titles.add(sr.title);
+		state.idByTitle.set(sr.title, created.id);
+		if (sr.sourcePresetId) {
+			state.presetIds.add(sr.sourcePresetId);
+			state.idByPreset.set(sr.sourcePresetId, created.id);
+		}
+		register(created.id);
+	} catch (e) {
+		result.errors.push(`ごほうび「${sr.title}」のインポートに失敗: ${String(e)}`);
+	}
+}
+
+/**
+ * ごほうび (specialReward) を import し、`exportId → 新 rewardId` の再結合マップを返す (#3329 / #3381)。
+ *
+ * #3381: 返すマップは交換履歴 (importRewardRedemptionsData) が **安定識別子 (exportId)** で reward を
+ * 再結合するための SSOT。新規 insert / 重複 skip いずれの reward も exportId → 解決先 rewardId を登録する
+ * ため、reward が改名されても / 同名 reward が複数あっても交換履歴を取り違えない。exportId を持たない旧
+ * backup は本マップに載らず、履歴側が title (rewardRef) で fallback する。
+ */
 async function importSpecialRewards(
 	data: ExportData,
 	childIdMap: Map<string, ChildId>,
 	tenantId: string,
 	result: ImportResult,
 	mode: ImportMode = 'merge',
-): Promise<void> {
-	const { errors, warnings } = result;
-	const existingByChild = new Map<ChildId, { titles: Set<string>; presetIds: Set<string> }>();
+): Promise<Map<ChildId, Map<string, string>>> {
+	// #3381: exportId → 解決先 rewardId (child 単位)。交換履歴の安定再結合キー。
+	const rewardIdByExportId = new Map<ChildId, Map<string, string>>();
+	const stateByChild = new Map<ChildId, SpecialRewardChildState>();
+
 	for (const sr of data.data.specialRewards) {
 		const childId = childIdMap.get(sr.childRef);
 		if (!childId) continue;
 
-		let existing = existingByChild.get(childId);
-		if (!existing) {
-			const rows = await findSpecialRewards(childId, tenantId);
-			existing = {
-				titles: new Set(rows.map((r) => r.title)),
-				presetIds: new Set(rows.map((r) => r.sourcePresetId).filter((p): p is string => !!p)),
-			};
-			existingByChild.set(childId, existing);
+		let state = stateByChild.get(childId);
+		if (!state) {
+			state = await loadSpecialRewardState(childId, tenantId);
+			stateByChild.set(childId, state);
 		}
 
-		// #1254 G1: preset_duplicate → name_duplicate の順で判定 (merge のみ、#3653)。
-		// verbatim (cutover) では同 child 同 title の正当な複数行 (title に DB 一意制約なし、
-		// NUC cycle 3 で export=9 → imported=2 の実欠落) を全行復元する。
-		if (mode === 'merge' && sr.sourcePresetId && existing.presetIds.has(sr.sourcePresetId)) {
-			result.specialRewardsSkipped++;
-			result.skipped.preset++;
-			continue;
-		}
-		if (mode === 'merge' && existing.titles.has(sr.title)) {
-			result.specialRewardsSkipped++;
-			result.skipped.name++;
-			continue;
-		}
+		const register = (rewardId: string) => {
+			if (!sr.exportId) return;
+			let m = rewardIdByExportId.get(childId);
+			if (!m) {
+				m = new Map<string, string>();
+				rewardIdByExportId.set(childId, m);
+			}
+			m.set(sr.exportId, rewardId);
+		};
 
-		try {
-			await insertSpecialReward(
-				{
-					childId,
-					title: sr.title,
-					description: sr.description ?? undefined,
-					points: sr.points,
-					icon: sr.icon ?? undefined,
-					category: sr.category,
-					sourcePresetId: sr.sourcePresetId ?? null,
-				},
-				tenantId,
-			);
-			result.specialRewardsImported++;
-			existing.titles.add(sr.title);
-			if (sr.sourcePresetId) existing.presetIds.add(sr.sourcePresetId);
-		} catch (e) {
-			errors.push(`ごほうび「${sr.title}」のインポートに失敗: ${String(e)}`);
-		}
+		await importOneSpecialReward(sr, childId, state, tenantId, result, register, mode);
 	}
+
 	if (result.specialRewardsSkipped > 0) {
-		warnings.push(
+		result.warnings.push(
 			`ごほうび ${result.specialRewardsSkipped} 件が既存と同名または同一プリセットのためスキップされました`,
 		);
 	}
+	return rewardIdByExportId;
 }
 
 // ============================================================

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -1003,3 +1003,165 @@ describe('#3653 cutover verbatim mode (dedup bypass)', () => {
 		).toBe(1);
 	});
 });
+
+// ============================================================
+// #3355 / #3464 / #3381: backup restore 冪等 / 再結合クラスタ (failing-test-first、ADR-0061)
+// ============================================================
+
+describe('#3355 評価取込の冪等性 (二重計上根治) + createdAt 保全', () => {
+	// 旧実装 (importEvaluationsData 無条件 insert) は同一 (child, weekStart) の重複行を 2 件 insert し
+	// growth-book/reports の数値を汚染していた。他 importer (loginBonuses/activityLogs) と同型の
+	// pre-fetch dedup を追加し、自然キー (child, weekStart) で 1 件に収束させる。
+	it('同一 (child, weekStart) の評価重複行が dedup され二重計上しない', async () => {
+		testDb.insert(schema.children).values({ nickname: 'ゆい', age: 8, theme: 'blue' }).run();
+		await insertEvaluation(
+			{
+				childId: asChildId(1),
+				weekStart: '2026-04-06',
+				weekEnd: '2026-04-12',
+				scoresJson: '{}',
+				bonusPoints: 10,
+			},
+			T,
+		);
+		const data = await exportFamilyData({ tenantId: T });
+		expect(data.data.evaluations.length, 'export:評価 1 件').toBe(1);
+		// 破損 / 重複 backup 再現: 同一 (childRef, weekStart) の評価を複製する。
+		const dup = { ...(data.data.evaluations[0] as (typeof data.data.evaluations)[number]) };
+		data.data.evaluations.push(dup);
+
+		await clearAllFamilyData(T);
+		const result = await importFamilyData(data, T);
+		const cid = testDb.select().from(schema.children).all()[0]?.id as number;
+		// 旧実装: 無条件 insert で 2 件 (二重計上)。本実装: (child, weekStart) 自然キー dedup で 1 件。
+		expect(
+			(await findEvaluationsByChild(asChildId(cid), 999, T)).length,
+			'評価は 1 件 (dedup)',
+		).toBe(1);
+		expect(result.evaluationsImported, 'imported=1').toBe(1);
+		expect(result.evaluationsSkipped, 'skipped=1 (重複)').toBe(1);
+	});
+
+	it('評価の createdAt が round-trip で保全される (取込時刻に書き換わらない)', async () => {
+		testDb.insert(schema.children).values({ nickname: 'かい', age: 9, theme: 'green' }).run();
+		await insertEvaluation(
+			{
+				childId: asChildId(1),
+				weekStart: '2026-04-13',
+				weekEnd: '2026-04-19',
+				scoresJson: '{}',
+				bonusPoints: 5,
+			},
+			T,
+		);
+		const data = await exportFamilyData({ tenantId: T });
+		const seededCreatedAt = data.data.evaluations[0]?.createdAt;
+		expect(seededCreatedAt, 'export:createdAt 非空').toBeTruthy();
+
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T);
+		const cid = testDb.select().from(schema.children).all()[0]?.id as number;
+		const restored = await findEvaluationsByChild(asChildId(cid), 999, T);
+		expect(restored.length, '評価 1 件').toBe(1);
+		// 旧実装: createdAt が insertEvaluation に渡らず取込時刻へ書き換わる。本実装: export 値を保全。
+		expect(restored[0]?.createdAt, 'createdAt 保全').toBe(seededCreatedAt);
+	});
+});
+
+describe('#3464 resolvedByParentId restore 時の物理 null 正規化', () => {
+	// #3337 は read 経路で legacy 0/'0' → null を正規化したが、restore write は verbatim 書込のため
+	// legacy 0 を含む旧 backup を復元すると「書込 0 / read null」の物理値ドリフトが残っていた。
+	it('legacy resolvedByParentId=0 が restore で物理 null 化される (0 再混入しない)', async () => {
+		testDb.insert(schema.children).values({ nickname: 'れい', age: 10, theme: 'blue' }).run();
+		const reward = await insertSpecialReward(
+			{
+				childId: asChildId(1),
+				title: 'ごほうびZ',
+				description: undefined,
+				points: 30,
+				icon: undefined,
+				category: 'money',
+				sourcePresetId: null,
+			},
+			T,
+		);
+		const red = await insertRedemptionRequest(
+			{ childId: asChildId(1), rewardId: reward.id, requestedAt: 1_700_000_000_000 },
+			T,
+		);
+		if ('error' in red) throw new Error('seed: unexpected DUPLICATE_REQUEST');
+		await updateRedemptionRequestStatus(
+			asChildId(1),
+			red.id,
+			{ status: 'approved', resolvedAt: 1_700_000_100_000, resolvedByParentId: 'parent-1' },
+			T,
+		);
+
+		const data = await exportFamilyData({ tenantId: T });
+		expect(data.data.rewardRedemptions.length, 'export:交換履歴 1 件').toBe(1);
+		// legacy 破損 backup 再現: resolvedByParentId を旧 placeholder '0' に差し替える。
+		(data.data.rewardRedemptions[0] as { resolvedByParentId: string | null }).resolvedByParentId =
+			'0';
+
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T);
+		// 物理値を raw select で確認: '0' が再混入せず null。
+		const rows = testDb.select().from(schema.rewardRedemptionRequests).all();
+		expect(rows.length, '交換履歴 1 件').toBe(1);
+		expect(rows[0]?.resolvedByParentId, "物理 null 化 (0/'0' 再混入しない)").toBeNull();
+	});
+});
+
+describe('#3381 交換履歴の reward 再結合を安定識別子 (exportId) で行う', () => {
+	// 旧実装は redemption の rewardRef (snapshot title) を取込先 reward の live title で照合するため、
+	// reward が改名されると snapshot ≠ live で交換履歴が silent skip されていた。安定識別子 rewardExportId
+	// で再結合し、title 不一致でも履歴を復元する。
+	it('snapshot title ≠ live title でも rewardExportId 経由で交換履歴が復元される', async () => {
+		testDb.insert(schema.children).values({ nickname: 'そう', age: 8, theme: 'blue' }).run();
+		const reward = await insertSpecialReward(
+			{
+				childId: asChildId(1),
+				title: 'ごほうびA',
+				description: undefined,
+				points: 40,
+				icon: undefined,
+				category: 'money',
+				sourcePresetId: null,
+			},
+			T,
+		);
+		const red = await insertRedemptionRequest(
+			{ childId: asChildId(1), rewardId: reward.id, requestedAt: 1_700_000_000_000 },
+			T,
+		);
+		if ('error' in red) throw new Error('seed: unexpected DUPLICATE_REQUEST');
+		await updateRedemptionRequestStatus(
+			asChildId(1),
+			red.id,
+			{ status: 'approved', resolvedAt: 1_700_000_100_000, resolvedByParentId: 'parent-1' },
+			T,
+		);
+
+		const data = await exportFamilyData({ tenantId: T });
+		expect(data.data.rewardRedemptions.length, 'export:交換履歴 1 件').toBe(1);
+		expect(data.data.specialRewards[0]?.exportId, 'reward exportId 発番').toBeTruthy();
+		expect(data.data.rewardRedemptions[0]?.rewardExportId, 'redemption rewardExportId 発番').toBe(
+			data.data.specialRewards[0]?.exportId,
+		);
+		// reward 改名を再現: redemption の snapshot title (rewardRef) を取込先 reward の live title と
+		// 一致しない旧名に固定する。旧実装はこの行を title 照合できず skip する。
+		(data.data.rewardRedemptions[0] as { rewardRef: string }).rewardRef = '改名前の旧い名前';
+
+		await clearAllFamilyData(T);
+		await importFamilyData(data, T);
+		const cid = testDb.select().from(schema.children).all()[0]?.id as number;
+		// 旧実装: rewardRef (旧名) が live title (ごほうびA) に一致せず skip → 0 件。
+		// 本実装: rewardExportId で再結合 → 復元 (1 件、status 保全)。
+		const restored = await findRedemptionRequestsByTenant(T, {
+			childId: asChildId(cid),
+			limit: 999,
+		});
+		expect(restored.length, '交換履歴が exportId 再結合で復元 (改名でも skip しない)').toBe(1);
+		expect(restored[0]?.status, 'status 保全').toBe('approved');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

家庭の大切なデータ（週次評価・ごほうび交換履歴）を backup から復元したとき、**数値が二重に膨らんだり、ごほうびを改名した後の交換履歴が黙って消えたりしない**ようにする。restore の 冪等性 (何度取り込んでも同じ結果) と 再結合の正確さ (改名・同名でも履歴が正しい reward に繋がる) を守り、「復元したら成長グラフの数字がおかしい / 交換履歴が減った」という信頼毀損を根治する。merge 済 #3719（restore 冪等 guard 統一）と同じ SSOT 方針で、restore の 冪等/再結合 同クラスを一体で固める。

## 関連 Issue

- closes #3355（評価取込の冪等性 + createdAt 保全 + 網羅 fitness）
- related #3381（交換履歴 reward 再結合の安定識別子化: item(1) 実装 / item(2) は残 AC を issue に記録）
- related #3464（resolvedByParentId restore normalize: item(1) 実装 / item(2)(3) は残 AC を issue に記録）
- related #3465（activityPref/activity 再結合: item(1)(3) は #3719 済 / item(2) は #3465 に残 AC 記録 / item(4) は #3362 が担当）
- 基盤: #3719（restore 冪等 guard 統一・restore-idempotency.ts）/ #3107（checklist exportId 再結合パターン）/ #3358（isVisible/sortOrder）/ #3507（field-level ratchet）/ #3362（entity registry）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| #3355(1) | 評価取込に pre-fetch dedup を追加し merge 二重計上を根治 + createdAt 保全 | `backup-roundtrip-completeness.test.ts` 追加 2 case（`(child,weekStart)` 重複 dedup → imported=1/skipped=1 / createdAt round-trip） | 実装済（red→green）。`importEvaluationsData` に自然キー dedup、`InsertEvaluationInput.createdAt?` を 4 backend が honor |
| #3355(2) | isVisible/sortOrder round-trip fidelity | #3358 で code 完了 + #3507 field-ratchet（isVisible=0/sortOrder=7 で round-trip 固定）で回帰済 | 消化済（既存機構で担保、本 PR は evaluations dedup test を追加） |
| #3355(3) | 完全性テストの網羅規律の自動化 | #3507（export field key freeze + 非既定値 round-trip）+ #3362（entity registry source/派生/除外）が機械化済 | 消化済（既存 fitness が該当規律を担保） |
| #3381(1) | reward 再結合を mutable title でなく安定識別子で行う | `backup-roundtrip-completeness.test.ts` 追加 case（snapshot title≠live title で rewardExportId 経由復元） | 実装済（red→green）。`exportId`/`rewardExportId`（EXPORT_VERSION 1.7.0）+ importSpecialRewards が map 返却 |
| #3381(2) | parentIdMap（cross-tenant resolvedByParentId） | inert write-only audit カラム（read consumer 0）のため cross-tenant 解決は本 PR scope 外。残 AC を #3381 に記録 | related（#3464(1) の normalize で legacy 0 は解消済） |
| #3464(1) | insertRedemptionForRestore の write 時 normalize | `backup-roundtrip-completeness.test.ts` 追加 case（legacy `0` → 物理 null を raw select 確認） | 実装済（red→green）。normalize SSOT を read/write 共有 |
| #3464(2)(3) | dirty-0 backfill / #3337 close 意図 | 監査 UI 出荷時の一回限り backfill と #3337 close 判断は本 PR scope 外。残 AC を #3464 に記録 | related |
| #3465(1)(3) | activityPref ConditionExpression + count 整合 + createdAt/updatedAt assert | #3719 で実装済 | 消化済（#3719） |
| #3465(2) | activity 同名 collapse（name→安定 id 再結合） | `ActivityLogSummary` が activityId を carry せず 4 backend の projection 変更を要すため本 PR scope 外。残 AC を #3465 に記録 | related（reward の同型実装が本 PR で先行、pattern 確立） |
| #3465(4) | partial-backup 可視化 | #3362 が担当 | related |

## 変更タイプ

- [x] バグ修正（データ整合性 / restore 冪等・再結合）
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント（設計書同期）
- [ ] インフラ / CI

## 影響範囲・変更コンポーネント

- **backup 形式**: `src/lib/domain/export-format.ts`（`ExportSpecialReward.exportId` / `ExportRewardRedemption.rewardExportId` 追加、EXPORT_VERSION 1.6.0→1.7.0、いずれも optional で後方互換）+ `export-migrations.ts`（1.6.0→1.7.0 identity step）
- **export/import service**: `export-service.ts`（exportId/rewardExportId emit）/ `import-service.ts`（importEvaluationsData 冪等 dedup + createdAt、importSpecialRewards が exportId→rewardId map 返却、importRewardRedemptionsData が安定識別子優先で再結合）
- **DB 層**: `InsertEvaluationInput.createdAt?` + evaluation-repo 4 backend（sqlite spread / dynamodb / dsql / demo）/ 新 SSOT `reward-redemption-normalize.ts`（normalizeResolvedByParentId）+ reward-redemption-repo 4 backend（restore write normalize / dynamodb read も SSOT import）
- **テスト**: `backup-roundtrip-completeness.test.ts` に 4 case 追加
- **docs**: `docs/design/backup-import-redesign.md` 同期（EXPORT_VERSION + rewardExportId 安定識別子原則）
- 後方互換: 旧 backup（exportId 欠落）は title/name の従来 fallback で復元、legacy `0` は物理 null 化

## テスト & 安全装置セルフチェック

- [x] failing-test-first（ADR-0061）: 各欠陥（評価二重計上 / createdAt 書換 / resolvedByParentId 0 再混入 / reward 改名 skip）を赤で再現する case を追加し green 化
- [x] 4 backend 等価性: evaluations createdAt / reward-redemption normalize は sqlite・dsql・dynamodb・demo で挙動を揃えた（dynamodb 評価は自然キー再 put で二重計上せず、sqlite/dsql は service 層 dedup で収束）
- [x] restore-idempotency registry no-silent-gap（`restore-idempotency-registry.test.ts`）: 新規 `*ForRestore` 関数は追加していない（evaluations dedup は loginBonuses/activityLogs と同型の service 層 pre-fetch）ため registry 変更不要
- [x] biome check clean（変更 13 file）
- [ ] vitest / svelte-check は CI で実行（worktree に node_modules 無し・共有 node_modules 破損回避のため local 実行せず CI 委譲）

## スクリーンショット / ビジュアルデモ

UI 変更なし（backup restore の service / DB 層と backup 形式のみ）。画面表示・文言・レイアウトへの影響なし。

## コード品質セルフレビュー (#1481)

- [x] normalizeResolvedByParentId を SSOT 化し read（#3337）と restore write の二重定義を解消（dynamodb module-local を撤去し共有 import）
- [x] importSpecialRewards の cognitive complexity を helper 分割（`loadSpecialRewardState` / `importOneSpecialReward`）で解消、#3107 checklist の register パターンと同型に整合
- [x] exportId は `<種別>-<childRef>-<元id>` の checklist 既存規約に統一、mutable title/name は fallback へ降格
- [x] 追加フィールドは全て optional + migration identity step で後方互換を機械保証

## 横展開・影響波及チェック

- [x] evaluation-repo は 4 backend 全て createdAt を honor（並行実装ペア整合）
- [x] reward-redemption-repo restore write normalize を sqlite/dsql/dynamodb 3 実装へ適用、demo は no-op stub のため対象外
- [x] EXPORT_VERSION bump に伴う `export-migrations.test.ts`（bump tripwire）/ `export-key-stability.test.ts`（RESERVED 非交差）整合を確認
- [x] activity 同型 再結合（#3465(2)）は `ActivityLogSummary.activityId` の projection 前提が必要な旨を issue に記録し、本 PR では reward で pattern を先行確立

## レビュー依頼事項・破壊的変更

- 破壊的変更なし（backup 形式は additive optional + 下位互換読込方針は元々「持たない」D5 だが、旧版は migration identity で受理）
- 確認依頼: (a) dsql `insertEvaluation` の `created_at` に `DEFAULT` キーワードを条件分岐で渡す実装（`input.createdAt ?? sql`DEFAULT``）の妥当性、(b) evaluations 冪等 dedup を loginBonuses と同じく mode 非依存（自然キーは verbatim でも重複が正当化されない）とした判断

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] AC 検証マップを 4 列で記載し、消化 / related を明示
- [x] biome check clean（変更ファイル）
- [x] 設計書同期（backup-import-redesign.md）
- [x] failing-test-first の red→green を各修正に用意
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言: 実装・test・docs・lint を完遂。vitest/svelte-check は CI 緑で最終確認）
- [x] `npm run pre-ready` 相当を実施（biome check は変更 13 file で local PASS 済。vitest/svelte-check/その他 step は worktree に node_modules が無く共有 node_modules 破損回避のため CI 環境で全 step 実行・確認する）

## QM レビュー結果

未レビュー（Draft）。QM/POREVIEWER の approve/merge を待つ。
