### PR TITLE
fix(backup): #3382 #3386 #3490 backup 検証/security クラスタ (allowlist 機械強制 + manifest エラー非露出 + path guard 制御文字)

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -146,8 +146,8 @@
 |----------|------|------|------|
 | GET | /api/v1/images | 画像取得（S3 プロキシ） | 全ロール |
 | POST | /api/v1/images | 画像アップロード | owner/parent |
-| GET | /api/v1/export | データエクスポート（JSON / ZIP）。ZIP は `data.json` + 静的ファイル（avatars/voices/generated）+ `manifest.json` を同梱。#3375: `manifest.json` に全エントリの SHA-256 + バイト数を記録し、画像含む同梱バイナリの**偶発的破損**を import 前に照合可能にする（既存 `data.json` checksum は論理内容のみを保護）。`dataVersion` / `itemCounts` も記録するが現状 import 側未使用の将来用メタデータ。`manifest` は未署名のため意図的改竄の防止は対象外（将来スコープ）。圧縮は per-entry 制御（既圧縮画像=store / 構造化=deflate） | owner/parent |
-| POST | /api/v1/import | データインポート（JSON / ZIP、静的ファイル復元）。#3375: ZIP に `manifest.json` があれば SHA-256 / サイズ / 存在を復元前に照合し、**偶発的破損（SHA-256/バイト数/存在の不一致）と manifest 記載ファイルの欠落、manifest 記載外ファイルの混入（注入）を明示エラー化**（記載外ファイルは fail-closed で復元拒否）。`manifest` は未署名のため**意図的改竄の防止は対象外**（manifest 再計算 / manifest 削除での downgrade が可能、将来スコープ）。`manifest.json` 無しの旧 ZIP / 旧 JSON は検証スキップで後方互換 | owner/parent |
+| GET | /api/v1/export | データエクスポート（JSON / ZIP）。ZIP は `data.json` + 静的ファイル（avatars/voices/generated）+ `manifest.json` を同梱。#3375: `manifest.json` に全エントリの SHA-256 + バイト数を記録し、画像含む同梱バイナリの**偶発的破損**を import 前に照合可能にする（既存 `data.json` checksum は論理内容のみを保護）。`itemCounts`（主要エンティティ件数）も記録し **#3386 で import 側が data.json 実件数と照合**（部分欠損検出）。`dataVersion` は将来用メタデータ（復元 migration dispatch 未実装）。`manifest` は未署名のため意図的改竄の防止は対象外（将来スコープ）。圧縮は per-entry 制御（既圧縮画像=store / 構造化=deflate） | owner/parent |
+| POST | /api/v1/import | データインポート（JSON / ZIP、静的ファイル復元）。#3375: ZIP に `manifest.json` があれば SHA-256 / サイズ / 存在を復元前に照合し、**偶発的破損（SHA-256/バイト数/存在の不一致）と manifest 記載ファイルの欠落、manifest 記載外ファイルの混入（注入）、#3386: itemCounts と data.json 実件数の不一致（部分欠損）を明示エラー化**（記載外ファイル・件数不一致は fail-closed で復元拒否）。#3386 / ADR-0062: エラー文言は内部 reason コード / 生パスを露出せず `labels.ts` 汎用文言を返す（内部詳細は logger のみ）。#3382: 設定値は allowlist キーでも import 時に値域/型/enum/制御文字を検証し不正値は skip。`manifest` は未署名のため**意図的改竄の防止は対象外**（manifest 再計算 / manifest 削除での downgrade が可能、将来スコープ）。`manifest.json` 無しの旧 ZIP / 旧 JSON は検証スキップで後方互換 | owner/parent |
 | GET | /api/v1/export/cloud | クラウドエクスポート一覧取得 | owner/parent |
 | POST | /api/v1/export/cloud | クラウドエクスポート作成 | owner/parent |
 | DELETE | /api/v1/export/cloud/[id] | クラウドエクスポート削除 | owner/parent |

--- a/docs/design/backup-import-redesign.md
+++ b/docs/design/backup-import-redesign.md
@@ -42,6 +42,8 @@
 **実装（`src/lib/domain/export-format.ts` / `src/lib/server/services/export-service.ts`）**:
 - フォーマット = `EXPORT_FORMAT='ganbari-quest-backup'` / `EXPORT_VERSION='1.7.0'`。下位互換読込は持たない（D5）。
 - **settings は default-deny allowlist**（`EXPORTABLE_SETTING_KEYS` / `isExportableSettingKey`）。`pin_hash` / `pin_locked_until` / `pin_failed_attempts` / `pin_reset_applied` / `session_token` / `session_expires_at` を export からも import からも除外（CWE-522/916、import 側でも再 filter する多層防御）。
+- **設定キー分類 SSOT（#3382）**: get/setSetting で実在する全設定キーを `EXPORTABLE_SETTING_KEYS`（載せる）/ `SECRET_SETTING_KEYS`（秘匿、絶対載せない）/ `NON_EXPORTABLE_SETTING_KEYS`（課金・ライフサイクル・派生キャッシュ等の意図的除外）に**必ず分類**する。`tests/unit/domain/settings-backup-classification.test.ts` が (a) src 全走査で未分類の新キーを fail（silent round-trip 喪失の silent-gap ガード）(b) 秘匿キー ∩ allowlist = ∅ を機械強制する。
+- **import 時の値バリデーション（#3382）**: allowlist キーでも ZIP 由来 value を verbatim 書き戻さず、`isValidSettingValue(key, value)`（`SETTING_VALUE_VALIDATORS`、domain 層 SSOT、ADR-0066 と同型）で範囲・型・enum・制御文字を検証してから `setSetting` する。改竄/破損 backup の範囲外 `decay_intensity` / 非数値 `point_rate` / 未知 enum は skip + warning で fail-closed（`settingsSkipped` 計上）。
 - per-child instance は **参照（ref）で出力**し、import で新 childId / 新 id に再解決する（§3.3）: `childRef`（child）/ `rewardExportId`（ごほうび安定識別子 `reward-<childRef>-<rewardId>`、交換履歴の優先再結合キー、#3381）+ `rewardRef`（ごほうび title、旧 backup / fallback）/ `activityName`（per-child 活動名）/ `templateExportId`（checklist template、#3107）/ `voiceRelPath`（音声ファイル相対パス、tenant prefix 除去済）/ `from`-`toChildRef`（兄弟応援）。
   - **安定識別子 vs title/name（#3107 / #3381）**: title / name は mutable なため、改名後 / 同名複数時に再結合が silent skip / collapse する。checklist（`exportId` / `templateExportId`）と交換履歴（`exportId` / `rewardExportId`）は **`<種別>-<childRef>-<元id>` 形の安定識別子を優先キー**にし、title/name は旧 backup 用の fallback に降格する（いずれも optional で後方互換、EXPORT_VERSION 1.7.0）。activity（`activityName`）は同型の安定 id 化が follow-up（#3465(2)、`findActivityLogs` の projection に activityId を carry させる必要あり）。
 - 音声 / アバター等の静的ファイルは `backup-archive.ts` が ZIP に同梱（`MAX_ZIP_SIZE=100MB`、fail-closed）。DB 行は tenant prefix を除いた相対パスを持ち、import で新 tenant+childId に再構成する（#3077）。
@@ -50,7 +52,9 @@
 - per-child 実体を **正しい child へ復元**（childIdMap で元 child に対応付け。findFirstChild 一律 bind をやめる）。
 - **未実装の取込を実装**（evaluations 等、網羅）。
 - **依存順序**を保証（children → per-child 実体 → ログ/履歴系。lookup 依存は復元順で解決）。
-- **失敗集計**: skip/warning を種別ごとに集計し、>0 なら結果に部分失敗を明示。UI で「N 件取り込めませんでした」を表示。
+- **失敗集計**: skip/warning を種別ごとに集計し、>0 なら結果に部分失敗を明示。UI で「N 件取り込めませんでした」を表示。復元完了 UI（`admin/settings/data`）は活動ログ / ポイント / ごほうび / チェックリスト履歴 / 画像・音声ファイルに加え **お子さまの音声（childVoices）/ 各種設定（settings）の復元・skip 件数も可視化**する（#3490、silent-skip 禁止）。
+- **エラー文言の内部非露出（#3386 / ADR-0062）**: ZIP manifest 整合性検証の失敗は内部 reason コード（`checksum-mismatch` / `size-mismatch` / `missing-file` / `unexpected-file`）と生パスを保護者に露出せず、`labels.ts` の汎用文言（`SETTINGS_LABELS.dataImportBackupCorrupt` 等）を返す。内部 reason / path は診断用に logger のみへ残す。
+- **path guard の制御文字拒否（#3490）**: 静的ファイル / 音声の相対パス検証 `isSafeRelativePath`（`import-service.ts`）は `..` / 絶対 / バックスラッシュに加え **NUL / 制御文字（C0/DEL/C1）も無条件拒否**する（poison-null-byte / CWE-22 の理論上残余の閉塞）。実効的 path injection 防御は本関数が担い、manifest の `unexpected-file` は「偶発混入検出」に限定される役割分担（`backup-manifest.ts` 冒頭コメント参照）。
 - **atomicity（#3326 実装済）**: replace は **「途中失敗時に旧データを必ず復元可能」な原子境界**で clear + import を実行する。clear 先行の永久喪失を廃止。単一強制点は `src/lib/server/services/replace-import-service.ts` の `replaceImportAtomic`（全 replace 経路 = `/api/v1/import` / `/api/v1/import/cloud` が経由）。**success-on-partial-failure ban**: import 中に hard error（例外を伴う取込失敗、`ImportResult.errors > 0`）が 1 件でもあれば原子境界を中止し旧データを復元する（childRef 不在等の skip は `*Skipped` に積まれ中止対象外）。中止時は呼び出し側へ `AtomicReplaceError` を送出し、API は「既存データは保全されています」を返す。
 - 復元後に**派生を再計算**（statuses 現在値/balance/streak 等の projection rebuild。source の statusHistory は再計算せず recordedAt 保持で復元）。
 
@@ -103,7 +107,7 @@ backup 形式は **5 つの責務を層で分離**する。「旧版を読む」
 
 | 層 | 責務 | 所有 |
 |---|---|---|
-| **L1 整合性** | 改竄/破損検出 | `verifyChecksum`（migrate より前。元バイト列に対して検証） |
+| **L1 整合性** | 改竄/破損検出 | `verifyChecksum`（migrate より前。元バイト列に対して検証） + ZIP は `backup-manifest.ts` で全エントリ SHA-256 / バイト数 / 集合一致 + **itemCounts 件数照合**（#3386、data.json 実件数 vs manifest.itemCounts の部分欠損検出、fail-closed） |
 | **L2 版識別 + 旧 shape 読取** | 対応版の判定 + 旧→現 shape 変換 | **`src/lib/domain/export-migrations.ts` 単独**。`MIGRATABLE_VERSIONS` が対応版 SSOT（`validateExportData` の allowlist はここから導出。二重列挙禁止）。`migrateExportData` が import 入口で 1 回 eager 実行（copy-transform、lazy-on-read の N+1 を避ける） |
 | **L3 DTO 抽象** | DB スキーマからの decoupling | `export-format.ts` の自然キー（`childRef` / `categoryCode` / `rewardRef` 等）。DSQL の sqlite→pg 型差はここで吸収 |
 | **L4 ref→id 再解決** | DTO を取込先の新 id に lowering | `import-service.ts` の `childIdMap` / lookup |

--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -77,6 +77,128 @@ export function isExportableSettingKey(key: string): boolean {
 }
 
 // ============================================================
+// #3382: 設定キー分類 SSOT (silent round-trip 喪失 / 秘匿混入の機械強制)
+// ============================================================
+// EXPORTABLE_SETTING_KEYS は「載せてよいキー」の allowlist だが、それだけでは (a) 今後追加される
+// 非秘匿キーが backup から黙って脱落しても検知できず、(b) session_token 等の秘匿キーが allowlist に
+// 誤混入しても CI を素通りしてしまう。そこで get/setSetting で実在する全キーを「exportable /
+// secret / non-exportable」のいずれかに **必ず分類**し、`settings-backup-classification.test.ts` が
+// (1) src 全体を走査して未分類の新キーを fail (silent-gap ガード)、(2) secret ∩ exportable = ∅ を assert する。
+
+/**
+ * 秘匿 / 認証状態キー (CWE-522 平文認証情報 / CWE-916 不十分なハッシュ保護)。
+ * backup allowlist に **絶対に含めてはならない**。fitness test が非交差を機械強制する。
+ */
+export const SECRET_SETTING_KEYS = [
+	'pin_failed_attempts',
+	'pin_hash',
+	'pin_locked_until',
+	'pin_reset_applied',
+	'session_expires_at',
+	'session_token',
+] as const;
+
+/**
+ * 環境間で移送すべきでない課金 / アカウントライフサイクル / 一時状態キー (意図的除外)。
+ * 秘匿ではないが backup で別環境へ持ち出すと状態が壊れるため allowlist から外す。
+ */
+export const NON_EXPORTABLE_SETTING_KEYS = [
+	'deletion_grace_plan_tier',
+	'dormant_reactivation_sent',
+	'marketing_unsubscribed_at',
+	'onboarding_child_screen_visited',
+	'physical_deletion_date',
+	'premium_welcome_shown',
+	// questionnaire_activity_display_count は questionnaire_activity_level から getActivityDisplayCount で
+	// 一意に導出される派生キャッシュ。level 自体が exportable なので導出値の backup は冗長 (除外で現挙動維持)。
+	'questionnaire_activity_display_count',
+	'soft_deleted_at',
+	'trial_expiration_modal_shown',
+] as const;
+
+// ============================================================
+// #3382: 取込時の設定値バリデータ (改竄 / 破損 backup の範囲外・型不正・未知 enum を fail-closed 化)
+// ============================================================
+// importSettingsData は ZIP 由来 value を `setSetting` で verbatim 書き戻すため、allowlist キーでも
+// `decay_intensity=<範囲外>` / `point_rate=<非数値>` / `point_unit_mode=<未知 enum>` が通ると復元後に
+// 表示崩れ・計算誤りを招く (#3379 injection 対策と整合)。allowlist キーごとの値バリデータを import で適用する。
+// 値域方針は ADR-0066 (export/import 値域 SSOT) と同型 — 値域を domain 層に集約し validator で述語化する。
+
+/** 制御文字 (C0 0x00-0x1f / DEL 0x7f / C1 0x80-0x9f) を含むか (poison-null-byte 等の混入防御)。 */
+function hasControlChar(value: string): boolean {
+	for (let i = 0; i < value.length; i++) {
+		const code = value.charCodeAt(i);
+		if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return true;
+	}
+	return false;
+}
+
+const BOOL_SETTING_VALUES = new Set(['true', 'false', '0', '1']);
+// HH:MM (24h)。notifications / quiet hours の time input が生成する形式。
+const TIME_HHMM_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+// tutorial_started_at / completed_at は `new Date().toISOString()`。
+const ISO_DATETIME_PREFIX_RE = /^\d{4}-\d{2}-\d{2}T/;
+const DECAY_INTENSITY_VALUES = new Set(['none', 'gentle', 'normal', 'strict']); // validation/status.ts DecayIntensity SSOT
+const POINT_UNIT_MODE_VALUES = new Set(['point', 'currency']); // point-display.ts PointUnitMode SSOT
+const CURRENCY_CODE_VALUES = new Set(['JPY', 'USD', 'EUR', 'GBP', 'AUD', 'CAD']); // point-display.ts CurrencyCode SSOT
+const ACTIVITY_LEVEL_VALUES = new Set(['few', 'normal', 'many']); // setup/questionnaire SSOT
+const WEEKDAY_VALUES = new Set([
+	'monday',
+	'tuesday',
+	'wednesday',
+	'thursday',
+	'friday',
+	'saturday',
+	'sunday',
+]);
+
+const isBoolSetting = (v: string): boolean => BOOL_SETTING_VALUES.has(v);
+const isTimeSetting = (v: string): boolean => TIME_HHMM_RE.test(v);
+const isIsoDatetime = (v: string): boolean =>
+	v.length <= 40 && ISO_DATETIME_PREFIX_RE.test(v) && !Number.isNaN(Date.parse(v));
+
+/**
+ * 設定キーごとの値バリデータ (allowlist の 20 キー全てを網羅)。
+ * fitness test が「EXPORTABLE_SETTING_KEYS の各キーに validator が存在する」ことを機械強制する。
+ */
+export const SETTING_VALUE_VALIDATORS: Record<string, (value: string) => boolean> = {
+	decay_intensity: (v) => DECAY_INTENSITY_VALUES.has(v),
+	notification_achievements_enabled: isBoolSetting,
+	notification_quiet_end: isTimeSetting,
+	notification_quiet_start: isTimeSetting,
+	notification_reminder_time: isTimeSetting,
+	notification_reminders_enabled: isBoolSetting,
+	notification_streak_enabled: isBoolSetting,
+	pin_gate_onboarding_seen: isBoolSetting,
+	point_currency: (v) => CURRENCY_CODE_VALUES.has(v),
+	point_rate: (v) => {
+		const n = Number(v);
+		return v.trim() !== '' && Number.isFinite(n) && n > 0 && n <= 100000;
+	},
+	point_unit_mode: (v) => POINT_UNIT_MODE_VALUES.has(v),
+	questionnaire_activity_level: (v) => ACTIVITY_LEVEL_VALUES.has(v),
+	// challenge 名の CSV。自由記述だが暴走的な長大値のみ弾く (bounded length)。
+	questionnaire_challenges: (v) => v.length <= 1000,
+	reward_auto_approve: isBoolSetting,
+	sibling_ranking_enabled: isBoolSetting,
+	tutorial_banner_dismissed: isBoolSetting,
+	tutorial_completed_at: isIsoDatetime,
+	tutorial_started_at: isIsoDatetime,
+	weekly_report_day: (v) => WEEKDAY_VALUES.has(v),
+	weekly_report_enabled: isBoolSetting,
+};
+
+/**
+ * #3382: 取込対象の設定値が妥当か (allowlist キーの想定範囲・型・enum に収まるか)。
+ * 制御文字を含む値・validator 未定義キー・validator 不合格は false (= import 側で skip する)。
+ */
+export function isValidSettingValue(key: string, value: string): boolean {
+	if (typeof value !== 'string' || hasControlChar(value)) return false;
+	const validator = SETTING_VALUE_VALIDATORS[key];
+	return validator ? validator(value) : false;
+}
+
+// ============================================================
 // マスタデータ型
 // ============================================================
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2352,6 +2352,11 @@ export const SETTINGS_LABELS = {
 		`チェックリスト履歴: ${imported}件${Number(skipped) > 0 ? `（${skipped}件スキップ）` : ''}`,
 	dataImportResultStaticFiles: (restored: number | string, skipped: number | string) =>
 		`画像・音声ファイル: ${restored}件復元${Number(skipped) > 0 ? `（${skipped}件スキップ）` : ''}`,
+	// #3490: childVoices (お子さまの音声) / 各種設定の復元・skip 件数を summary に surface (silent-skip 可視化)
+	dataImportResultChildVoices: (imported: number | string, skipped: number | string) =>
+		`お子さまの音声: ${imported}件復元${Number(skipped) > 0 ? `（${skipped}件スキップ）` : ''}`,
+	dataImportResultSettings: (imported: number | string, skipped: number | string) =>
+		`各種設定: ${imported}件復元${Number(skipped) > 0 ? `（${skipped}件スキップ）` : ''}`,
 	dataImportWarningsTitle: (n: number | string) => `警告 (${n}件):`,
 	dataImportErrorsTitle: (n: number | string) => `エラー (${n}件):`,
 	// #3095: partial-restore の data-integrity 可視化 — errors があれば「完了」でなく部分復元として警告する。
@@ -2362,6 +2367,17 @@ export const SETTINGS_LABELS = {
 	dataImportPartialBodyAdd:
 		'復元できなかった項目があります。下記の内容をご確認のうえ、必要に応じて再度インポートしてください。',
 	dataImportClose: '閉じる',
+	// #3386: バックアップ ZIP の整合性検証失敗メッセージ (ADR-0062 — 内部 reason コード / 生パスを露出しない
+	// ユーザー向け文言。内部 reason は logger のみに残す)。checksum/size/missing 破損は共通の破損文言で、
+	// unexpected-file (混入) のみ別文言にして「作り直し」の次アクションを促す。
+	dataImportManifestCorrupt:
+		'バックアップファイルが壊れているため復元できません。もう一度エクスポートしてください',
+	dataImportBackupCorrupt:
+		'バックアップファイルの内容が壊れているため復元できません。もう一度エクスポートしてください',
+	dataImportBackupUnexpectedFile:
+		'バックアップファイルに想定外のデータが含まれているため復元できません。もう一度エクスポートしてください',
+	dataImportBackupCountMismatch:
+		'バックアップファイルの一部が欠けているため復元できません。もう一度エクスポートしてください',
 
 	// クラウドエクスポート
 	cloudSectionTitle: '☁️ クラウド共有',

--- a/src/lib/server/services/backup-archive.ts
+++ b/src/lib/server/services/backup-archive.ts
@@ -18,6 +18,7 @@ import { listFiles, readFile } from '$lib/server/storage';
 import { tenantPrefix } from '$lib/server/storage-keys';
 import {
 	BACKUP_MANIFEST_FILENAME,
+	type BackupManifest,
 	buildBackupManifest,
 	parseBackupManifest,
 	verifyBackupManifest,
@@ -205,22 +206,58 @@ export async function parseBackupZip(
 		return { ok: false, error: 'data.json の解析に失敗しました' };
 	}
 
+	// #3386: itemCounts 件数照合 (選択肢 B の配線)。manifest.itemCounts (エクスポート時の主要エンティティ件数)
+	// と、実際に data.json から数え直した件数が食い違えば、data.json 側の部分欠損 (途中切詰め/改竄) として
+	// fail-closed で弾く。件数不一致は「ファイルの一部が欠けている」旨の汎用文言を返し、内部差分は log のみ。
+	if (manifestCheck.manifest?.itemCounts) {
+		const actual = countExportItems(body as ExportData);
+		const countError = findItemCountMismatch(manifestCheck.manifest.itemCounts, actual);
+		if (countError) {
+			logger.warn('[backup-archive] itemCounts 照合に失敗 (data.json 部分欠損の疑い)', {
+				context: countError,
+			});
+			return { ok: false, error: SETTINGS_LABELS.dataImportBackupCountMismatch };
+		}
+	}
+
 	return { ok: true, value: { body, staticFiles: collectStaticFiles(entries) } };
 }
 
 /**
+ * #3386: manifest.itemCounts と data.json 実件数を照合し、最初の不一致 key を返す (一致なら null)。
+ * manifest に記載のある key のみ照合する (将来 key 追加時の後方互換: 旧 backup に無い key は無視)。
+ */
+function findItemCountMismatch(
+	expected: Record<string, number>,
+	actual: Record<string, number>,
+): { key: string; expected: number; actual: number } | null {
+	for (const [key, expectedCount] of Object.entries(expected)) {
+		const actualCount = actual[key] ?? 0;
+		if (actualCount !== expectedCount) {
+			return { key, expected: expectedCount, actual: actualCount };
+		}
+	}
+	return null;
+}
+
+/**
  * #3375: 展開済み ZIP エントリに manifest.json があれば整合性照合する。
- * manifest が無い旧 ZIP は検証スキップ（後方互換）で ok を返す。
+ * manifest が無い旧 ZIP は検証スキップ（後方互換）で ok を返す（manifest は undefined）。
+ *
+ * #3386 (ADR-0062): ユーザーに返す `error` は内部 reason コード (`checksum-mismatch` /
+ * `size-mismatch` / `missing-file` / `unexpected-file`) と生パスを **露出させない** 汎用文言にする。
+ * 内部 reason / path は診断用に logger にのみ残す (監視で追える + 保護者には無害な文言を出す)。
  */
 async function verifyManifestIfPresent(
 	entries: Record<string, Uint8Array>,
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<{ ok: true; manifest?: BackupManifest } | { ok: false; error: string }> {
 	const manifestBytes = entries[BACKUP_MANIFEST_FILENAME];
 	if (!manifestBytes) return { ok: true };
 
 	const manifest = parseBackupManifest(manifestBytes);
 	if (!manifest) {
-		return { ok: false, error: 'バックアップの manifest.json が壊れています' };
+		logger.warn('[backup-archive] manifest.json のパース/構造検証に失敗', {});
+		return { ok: false, error: SETTINGS_LABELS.dataImportManifestCorrupt };
 	}
 
 	const entriesForVerify: Record<string, Uint8Array> = {};
@@ -231,13 +268,17 @@ async function verifyManifestIfPresent(
 
 	const verdict = await verifyBackupManifest(entriesForVerify, manifest);
 	if (!verdict.ok) {
-		const detail =
+		// 内部 reason / path は診断用 log のみ。ユーザー文言では露出しない (ADR-0062)。
+		logger.warn('[backup-archive] manifest 整合性検証に失敗', {
+			context: { reason: verdict.reason, path: verdict.path },
+		});
+		const error =
 			verdict.reason === 'unexpected-file'
-				? `manifest に記載のないファイルが含まれています（${verdict.path}）`
-				: `バックアップが破損しています（${verdict.path}: ${verdict.reason}）`;
-		return { ok: false, error: `${detail}。再エクスポートしてください` };
+				? SETTINGS_LABELS.dataImportBackupUnexpectedFile
+				: SETTINGS_LABELS.dataImportBackupCorrupt;
+		return { ok: false, error };
 	}
-	return { ok: true };
+	return { ok: true, manifest };
 }
 
 /**

--- a/src/lib/server/services/backup-manifest.ts
+++ b/src/lib/server/services/backup-manifest.ts
@@ -10,16 +10,22 @@
 //
 // 保護対象と非対象 (truth、ADR-0013):
 // - 検出できる: 転送/保存中の偶発的破損 (SHA-256 / バイト数の不一致)、manifest 記載ファイルの欠落、
-//   manifest 記載外ファイルの混入 (注入)。
+//   manifest 記載外ファイルの混入 (整合性外ファイルの検出)、data.json 側の部分欠損 (itemCounts 照合、#3386)。
 // - 検出できない (将来スコープ): **意図的改竄の防止**。manifest は未署名のため、攻撃者は改竄後に
 //   manifest を再計算でき検証を通せる。また manifest.json を削除した旧 ZIP は後方互換で検証スキップ
 //   される (downgrade)。改竄防止が必要になったら署名 (HMAC / 公開鍵) を別途導入する。
 //
+// #3386 注入防御の役割分担 (誤認防止): 本モジュールの `unexpected-file` チェックは「manifest 記載外
+// ファイルの混入検出」であり、**完全に攻撃者制御された ZIP (manifest を再計算可) には無力**である。
+// 実効的な path injection / zip-slip 防御は `import-service.ts` の `isSafeRelativePath` /
+// `STATIC_FILE_PATH_RE` (#3077 / #3490) が担う (復元時に tenant 境界外パスを弾く default-deny)。
+// 本 manifest は「偶発的破損 + 集合不一致 + 件数不一致」の検出専用と位置づける。
+//
 // 後方互換: manifest.json を持たない旧 ZIP / 旧 JSON バックアップは検証スキップ (従来どおり復元可)。
 //
-// dataVersion / itemCounts は manifest に記録するが、**現状 import 側 (verifyBackupManifest /
-// verifyManifestIfPresent) では未使用の将来用メタデータ**である (件数照合による部分欠損検査・
-// 復元マイグレーション dispatch は未実装。配線時に本コメントを更新する)。
+// dataVersion は manifest に記録するが現状 import 側では未使用の将来用メタデータ (復元マイグレーション
+// dispatch は未実装)。itemCounts は #3386 で配線済 — parseBackupZip が data.json 実件数と照合し部分欠損を
+// fail-closed 検出する。
 
 /** manifest 内の 1 エントリの整合性情報。 */
 export interface BackupManifestFileEntry {
@@ -41,7 +47,7 @@ export interface BackupManifest {
 	createdAt: string;
 	/** path → 整合性情報 (data.json と全静的ファイルを含む)。 */
 	files: Record<string, BackupManifestFileEntry>;
-	/** 主要エンティティの件数。将来用メタデータ (現状 import では未使用。件数照合による部分欠損検査は未実装)。 */
+	/** 主要エンティティの件数。#3386 で配線済 — import 時に data.json 実件数と照合し部分欠損を fail-closed 検出する。 */
 	itemCounts: Record<string, number>;
 }
 

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -5,7 +5,12 @@ import { asCategoryId } from '$lib/domain/ids';
 // 家族データインポートサービス（Phase 2 / #1254）
 
 import { toLegacyCategoryId } from '$lib/domain/categories';
-import { EXPORT_FORMAT, type ExportData, isExportableSettingKey } from '$lib/domain/export-format';
+import {
+	EXPORT_FORMAT,
+	type ExportData,
+	isExportableSettingKey,
+	isValidSettingValue,
+} from '$lib/domain/export-format';
 import { MIGRATABLE_VERSIONS, migrateExportData } from '$lib/domain/export-migrations';
 import { IMPORT_LABELS, type ImportSkipReason } from '$lib/domain/labels';
 import { sanitizeActivityNameField, sanitizeDailyLimit } from '$lib/domain/validation/activity';
@@ -612,6 +617,13 @@ async function importSettingsData(
 			// 秘匿 / 非 allowlist キーは書き戻さない (多層防御)。
 			result.settingsSkipped++;
 			result.warnings.push(`設定「${s.key}」は backup 対象外のためスキップしました`);
+			continue;
+		}
+		// #3382: allowlist キーでも値域/型/enum を検証してから書き戻す (改竄/破損 backup の
+		// 範囲外 decay_intensity・非数値 point_rate・未知 enum・制御文字混入を fail-closed で弾く)。
+		if (typeof s.value !== 'string' || !isValidSettingValue(s.key, s.value)) {
+			result.settingsSkipped++;
+			result.warnings.push(`設定「${s.key}」の値が不正なためスキップしました`);
 			continue;
 		}
 		try {
@@ -2154,9 +2166,18 @@ const STATIC_FILE_PATH_RE = /^(avatars|voices|generated)\/(\d+)\/(.+)$/;
  * 相対 storage パスに path-escape (`..` や絶対パス) が含まれていないか検証する (zip-slip / CWE-22 防御)。
  * `STATIC_FILE_PATH_RE` の `rest` (`.+`、importStaticFiles) / `VOICE_REL_PATH_RE` の `rest`
  * (`.+`、importChildVoicesData) は任意文字を許すため、ここで `..` セグメント・先頭スラッシュ・
- * Windows ドライブ・バックスラッシュ等を弾く。安全なら true。
+ * Windows ドライブ・バックスラッシュ・NUL/制御文字等を弾く。安全なら true。
+ *
+ * #3490: NUL/制御文字も拒否する (poison-null-byte / CWE-22 の理論上残余)。本パスは現状 FS read に
+ * 直結せず DB 行 + publicUrl 参照に留まるため実害は無いが、「path に制御文字を混在させない」不変条件を
+ * 明示強制し、将来 storage 実装が FS/URL parse に渡しても切詰め攻撃が成立しないようにする。
  */
 function isSafeRelativePath(relPath: string): boolean {
+	// NUL / 制御文字 (C0 0x00-0x1f / DEL 0x7f / C1 0x80-0x9f) を含むパスは無条件拒否する (#3490)。
+	for (let i = 0; i < relPath.length; i++) {
+		const code = relPath.charCodeAt(i);
+		if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) return false;
+	}
 	// バックスラッシュは OS 非依存で無条件拒否する (Linux では `\` がファイル名のリテラル
 	// 文字になり segment 分割では escape を検知できないため、含むパスはすべて弾く)。
 	if (relPath.includes('\\')) return false;

--- a/src/routes/(parent)/admin/settings/data/+page.svelte
+++ b/src/routes/(parent)/admin/settings/data/+page.svelte
@@ -62,6 +62,11 @@ let importResult = $state<{
 	checklistLogsSkipped: number;
 	staticFilesRestored: number;
 	staticFilesSkipped: number;
+	// #3490: childVoices (お子さまの音声) / 各種設定の復元・skip 件数を summary に surface
+	childVoicesImported: number;
+	childVoicesSkipped: number;
+	settingsImported: number;
+	settingsSkipped: number;
 	errors: string[];
 	warnings: string[];
 } | null>(null);
@@ -853,6 +858,22 @@ const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChec
 									{SETTINGS_LABELS.dataImportResultStaticFiles(
 										importResult.staticFilesRestored,
 										importResult.staticFilesSkipped,
+									)}
+								</li>
+							{/if}
+							{#if importResult.childVoicesImported > 0 || importResult.childVoicesSkipped > 0}
+								<li data-testid="data-import-result-child-voices">
+									{SETTINGS_LABELS.dataImportResultChildVoices(
+										importResult.childVoicesImported,
+										importResult.childVoicesSkipped,
+									)}
+								</li>
+							{/if}
+							{#if importResult.settingsImported > 0 || importResult.settingsSkipped > 0}
+								<li data-testid="data-import-result-settings">
+									{SETTINGS_LABELS.dataImportResultSettings(
+										importResult.settingsImported,
+										importResult.settingsSkipped,
 									)}
 								</li>
 							{/if}

--- a/tests/unit/domain/settings-backup-classification.test.ts
+++ b/tests/unit/domain/settings-backup-classification.test.ts
@@ -1,0 +1,154 @@
+// tests/unit/domain/settings-backup-classification.test.ts
+// #3382: settings backup allowlist の機械強制強化。
+// (1) get/setSetting で実在する全設定キーが exportable / secret / non-exportable のいずれかに分類済 (silent-gap ガード)
+// (2) 秘匿キーが EXPORTABLE_SETTING_KEYS に混入していない (CWE-522/916)
+// (3) 全 exportable キーに値バリデータが存在し、範囲外・型不正・未知 enum・制御文字を弾く
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+	EXPORTABLE_SETTING_KEYS,
+	isValidSettingValue,
+	NON_EXPORTABLE_SETTING_KEYS,
+	SECRET_SETTING_KEYS,
+	SETTING_VALUE_VALIDATORS,
+} from '../../../src/lib/domain/export-format';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const srcRoot = join(REPO_ROOT, 'src');
+
+/** src 配下を再帰走査して .ts / .svelte のパス一覧を返す。 */
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+	for (const name of readdirSync(dir)) {
+		const full = join(dir, name);
+		const st = statSync(full);
+		if (st.isDirectory()) {
+			collectSourceFiles(full, acc);
+		} else if (full.endsWith('.ts') || full.endsWith('.svelte')) {
+			acc.push(full);
+		}
+	}
+	return acc;
+}
+
+/**
+ * src 全体から getSetting / setSetting / getSettings の文字列リテラルキーを抽出する。
+ * これが「実在する設定キー」の SSOT。新キーが分類漏れのまま追加されたら本テストが fail する。
+ */
+function collectUsedSettingKeys(): Set<string> {
+	const keys = new Set<string>();
+	// getSetting('x' / setSetting('x'
+	const singleRe = /(?:getSetting|setSetting)\(\s*'([a-z_][a-z0-9_]*)'/g;
+	// getSettings(['x', 'y', ...]) の配列内リテラル
+	const multiRe = /getSettings\(\s*\[([^\]]*)\]/g;
+	const literalInArray = /'([a-z_][a-z0-9_]*)'/g;
+	for (const file of collectSourceFiles(srcRoot)) {
+		// テスト用モック等が混ざる server/db/*-repo の getSetting 定義自体は key リテラルを持たないため対象外。
+		const text = readFileSync(file, 'utf8');
+		for (const match of text.matchAll(singleRe)) {
+			if (match[1]) keys.add(match[1]);
+		}
+		for (const match of text.matchAll(multiRe)) {
+			const inner = match[1] ?? '';
+			for (const lit of inner.matchAll(literalInArray)) {
+				if (lit[1]) keys.add(lit[1]);
+			}
+		}
+	}
+	return keys;
+}
+
+describe('#3382 settings backup key 分類 SSOT (silent-gap ガード)', () => {
+	const classified = new Set<string>([
+		...EXPORTABLE_SETTING_KEYS,
+		...SECRET_SETTING_KEYS,
+		...NON_EXPORTABLE_SETTING_KEYS,
+	]);
+
+	it('get/setSetting で実在する全キーが exportable / secret / non-exportable に分類済 (未分類 = fail)', () => {
+		const used = collectUsedSettingKeys();
+		// sanity: 走査が機能していること (代表キーが拾えている)
+		expect(used.has('decay_intensity')).toBe(true);
+		expect(used.has('pin_hash')).toBe(true);
+
+		const unclassified = [...used].filter((k) => !classified.has(k)).sort();
+		expect(
+			unclassified,
+			`未分類の設定キーがあります。export-format.ts の EXPORTABLE_SETTING_KEYS / SECRET_SETTING_KEYS / NON_EXPORTABLE_SETTING_KEYS のいずれかに追加してください: ${unclassified.join(', ')}`,
+		).toEqual([]);
+	});
+
+	it('秘匿キーは 1 件も EXPORTABLE_SETTING_KEYS に含まれない (CWE-522/916)', () => {
+		const leaked = SECRET_SETTING_KEYS.filter((k) =>
+			(EXPORTABLE_SETTING_KEYS as readonly string[]).includes(k),
+		);
+		expect(leaked, `秘匿キーが backup allowlist に混入しています: ${leaked.join(', ')}`).toEqual(
+			[],
+		);
+	});
+
+	it('non-exportable キーも EXPORTABLE_SETTING_KEYS に含まれない (排他分類)', () => {
+		const overlap = NON_EXPORTABLE_SETTING_KEYS.filter((k) =>
+			(EXPORTABLE_SETTING_KEYS as readonly string[]).includes(k),
+		);
+		expect(overlap).toEqual([]);
+	});
+
+	it('exportable / secret / non-exportable は相互に重複しない', () => {
+		const total =
+			EXPORTABLE_SETTING_KEYS.length +
+			SECRET_SETTING_KEYS.length +
+			NON_EXPORTABLE_SETTING_KEYS.length;
+		expect(classified.size).toBe(total);
+	});
+});
+
+describe('#3382 設定値バリデータ (import 時の fail-closed)', () => {
+	it('全 exportable キーに値バリデータが定義されている (網羅)', () => {
+		const missing = (EXPORTABLE_SETTING_KEYS as readonly string[]).filter(
+			(k) => typeof SETTING_VALUE_VALIDATORS[k] !== 'function',
+		);
+		expect(missing, `validator 未定義の exportable キー: ${missing.join(', ')}`).toEqual([]);
+	});
+
+	it('正常値は受理する', () => {
+		expect(isValidSettingValue('decay_intensity', 'normal')).toBe(true);
+		expect(isValidSettingValue('point_rate', '1')).toBe(true);
+		expect(isValidSettingValue('point_rate', '0.5')).toBe(true);
+		expect(isValidSettingValue('point_unit_mode', 'currency')).toBe(true);
+		expect(isValidSettingValue('point_currency', 'JPY')).toBe(true);
+		expect(isValidSettingValue('notification_quiet_start', '21:00')).toBe(true);
+		expect(isValidSettingValue('weekly_report_day', 'monday')).toBe(true);
+		expect(isValidSettingValue('weekly_report_enabled', '1')).toBe(true);
+		expect(isValidSettingValue('reward_auto_approve', 'true')).toBe(true);
+		expect(isValidSettingValue('tutorial_started_at', '2026-03-15T08:30:00.000Z')).toBe(true);
+		expect(isValidSettingValue('questionnaire_activity_level', 'few')).toBe(true);
+	});
+
+	it('範囲外 / 型不正 / 未知 enum は拒否する', () => {
+		expect(isValidSettingValue('decay_intensity', 'extreme')).toBe(false); // 未知 enum
+		expect(isValidSettingValue('point_rate', 'abc')).toBe(false); // 非数値
+		expect(isValidSettingValue('point_rate', '-1')).toBe(false); // 範囲外 (負)
+		expect(isValidSettingValue('point_rate', '0')).toBe(false); // 範囲外 (0)
+		expect(isValidSettingValue('point_unit_mode', 'bitcoin')).toBe(false); // 未知 enum
+		expect(isValidSettingValue('point_currency', 'XYZ')).toBe(false); // 未知通貨
+		expect(isValidSettingValue('notification_quiet_start', '25:99')).toBe(false); // 不正時刻
+		expect(isValidSettingValue('weekly_report_day', 'someday')).toBe(false); // 未知曜日
+		expect(isValidSettingValue('reward_auto_approve', 'maybe')).toBe(false); // 非 bool
+		expect(isValidSettingValue('tutorial_started_at', 'not-a-date')).toBe(false); // 不正日時
+	});
+
+	it('制御文字 (NUL 含む) を含む値は拒否する (poison-null-byte)', () => {
+		const NUL = String.fromCharCode(0);
+		expect(isValidSettingValue('point_currency', `JPY${NUL}`)).toBe(false);
+		const BEL = String.fromCharCode(7);
+		expect(isValidSettingValue('questionnaire_challenges', `a${BEL}b`)).toBe(false);
+	});
+
+	it('allowlist 外キーは常に false (validator 未定義)', () => {
+		expect(isValidSettingValue('pin_hash', 'whatever')).toBe(false);
+		expect(isValidSettingValue('session_token', 'x')).toBe(false);
+	});
+});

--- a/tests/unit/services/backup-archive.test.ts
+++ b/tests/unit/services/backup-archive.test.ts
@@ -6,6 +6,7 @@
 import { zipSync } from 'fflate';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ExportData } from '../../../src/lib/domain/export-format';
+import { SETTINGS_LABELS } from '../../../src/lib/domain/labels';
 import {
 	BackupSizeLimitError,
 	buildFullBackupZip,
@@ -102,7 +103,7 @@ describe('parseBackupZip (#3376)', () => {
 		expect(Object.keys(res.value.staticFiles)).toEqual(['avatars/1/a.png']);
 	});
 
-	it('manifest と中身が食い違う ZIP は破損として弾く', async () => {
+	it('manifest と中身が食い違う ZIP は破損として弾く (#3386: 内部 reason/path を露出しない)', async () => {
 		// manifest を正しく作った後、静的ファイルだけ差し替えた ZIP を組む
 		const original = {
 			'data.json': enc(VALID_DATA_JSON),
@@ -117,7 +118,87 @@ describe('parseBackupZip (#3376)', () => {
 		const res = await parseBackupZip(tamperedZip);
 		expect(res.ok).toBe(false);
 		if (res.ok) return;
-		expect(res.error).toContain('破損');
+		// ADR-0062: ユーザー向け文言は labels.ts SSOT 経由。内部 reason コード / 生パスを露出しない。
+		expect(res.error).toBe(SETTINGS_LABELS.dataImportBackupCorrupt);
+		expect(res.error).not.toContain('checksum-mismatch');
+		expect(res.error).not.toContain('size-mismatch');
+		expect(res.error).not.toContain('avatars/1/a.png');
+	});
+
+	it('#3386: manifest 記載外ファイルの混入は専用文言で弾く (内部 reason/path 非露出)', async () => {
+		const original = { 'data.json': enc(VALID_DATA_JSON) };
+		const manifest = await buildBackupManifest(original, '1.3.0', {}, '2026-06-28T00:00:00.000Z');
+		const injectedZip = zipSync({
+			'data.json': enc(VALID_DATA_JSON),
+			'avatars/9/injected.png': new Uint8Array([7, 7, 7]), // manifest に無い注入ファイル
+			[BACKUP_MANIFEST_FILENAME]: enc(JSON.stringify(manifest)),
+		});
+		const res = await parseBackupZip(injectedZip);
+		expect(res.ok).toBe(false);
+		if (res.ok) return;
+		expect(res.error).toBe(SETTINGS_LABELS.dataImportBackupUnexpectedFile);
+		expect(res.error).not.toContain('unexpected-file');
+		expect(res.error).not.toContain('avatars/9/injected.png');
+	});
+
+	it('#3386: 壊れた manifest.json は専用文言で弾く (内部詳細非露出)', async () => {
+		const zip = zipSync({
+			'data.json': enc(VALID_DATA_JSON),
+			[BACKUP_MANIFEST_FILENAME]: enc('{ this is not valid json'),
+		});
+		const res = await parseBackupZip(zip);
+		expect(res.ok).toBe(false);
+		if (res.ok) return;
+		expect(res.error).toBe(SETTINGS_LABELS.dataImportManifestCorrupt);
+	});
+
+	it('#3386: manifest.itemCounts と data.json 実件数が食い違えば部分欠損として弾く', async () => {
+		// data.json は children 1 件だが、manifest.itemCounts は children:5 を主張 → 部分欠損
+		const dataJson = JSON.stringify({
+			format: 'ganbari-quest-backup',
+			version: '1.3.0',
+			exportedAt: '2026-06-28T00:00:00.000Z',
+			family: { children: [{ id: '1', nickname: 'A' }] },
+			data: {},
+		});
+		const files = { 'data.json': enc(dataJson) };
+		const manifest = await buildBackupManifest(
+			files,
+			'1.3.0',
+			{ children: 5 }, // 実際は 1 件 → 照合で mismatch
+			'2026-06-28T00:00:00.000Z',
+		);
+		const zip = zipSync({
+			'data.json': enc(dataJson),
+			[BACKUP_MANIFEST_FILENAME]: enc(JSON.stringify(manifest)),
+		});
+		const res = await parseBackupZip(zip);
+		expect(res.ok).toBe(false);
+		if (res.ok) return;
+		expect(res.error).toBe(SETTINGS_LABELS.dataImportBackupCountMismatch);
+	});
+
+	it('#3386: manifest.itemCounts が data.json 実件数と一致すれば通る', async () => {
+		const dataJson = JSON.stringify({
+			format: 'ganbari-quest-backup',
+			version: '1.3.0',
+			exportedAt: '2026-06-28T00:00:00.000Z',
+			family: { children: [{ id: '1', nickname: 'A' }] },
+			data: { activityLogs: [{ x: 1 }, { x: 2 }] },
+		});
+		const files = { 'data.json': enc(dataJson) };
+		const manifest = await buildBackupManifest(
+			files,
+			'1.3.0',
+			{ children: 1, activityLogs: 2 },
+			'2026-06-28T00:00:00.000Z',
+		);
+		const zip = zipSync({
+			'data.json': enc(dataJson),
+			[BACKUP_MANIFEST_FILENAME]: enc(JSON.stringify(manifest)),
+		});
+		const res = await parseBackupZip(zip);
+		expect(res.ok).toBe(true);
 	});
 
 	it('data.json が無い ZIP はエラー', async () => {

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -172,7 +172,8 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 
 		// #3329: 設定 KVS。allowlist キー (point_unit_mode) + 秘匿キー (pin_hash) を seed し、
 		// 秘匿キーが export に載らない (default-deny) こと + allowlist キーが round-trip することを検証。
-		await setSetting('point_unit_mode', 'custom', T);
+		// #3382: import 側で値バリデーションが入ったため、round-trip 検証は妥当値 ('currency') を使う。
+		await setSetting('point_unit_mode', 'currency', T);
 		await setSetting('pin_hash', '$2b$10$fake.hash.not.restored', T);
 
 		// #3329: チャレンジを 1 件 seed し進捗を進める。round-trip 後に currentValue/status が保全されることを検証。
@@ -365,7 +366,7 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		expect(restoredRedemptions[0]?.rewardTitle, '交換履歴 snapshot 保全').toBe('ごほうびX');
 
 		// #3329: 設定の round-trip — allowlist キーは復元、秘匿キーは clear 後も復元されない。
-		expect(await getSetting('point_unit_mode', T), '設定 round-trip').toBe('custom');
+		expect(await getSetting('point_unit_mode', T), '設定 round-trip').toBe('currency');
 		expect(await getSetting('pin_hash', T), '秘匿キー非復元').toBeUndefined();
 
 		// #3329: チャレンジが進捗 (currentValue) を保って復元される。

--- a/tests/unit/services/import-service.test.ts
+++ b/tests/unit/services/import-service.test.ts
@@ -62,6 +62,13 @@ vi.mock('$lib/server/db/child-repo', () => ({
 	insertChild: (...args: unknown[]) => mockInsertChild(...args),
 }));
 
+// #3382: 各種設定 (settings) の書き戻しは setSetting 経由。値バリデーションで skip される値は
+// setSetting が呼ばれないことを検証するため spy 化する。
+const mockSetSetting = vi.fn();
+vi.mock('$lib/server/db/settings-repo', () => ({
+	setSetting: (...args: unknown[]) => mockSetSetting(...args),
+}));
+
 vi.mock('$lib/server/db/status-repo', () => ({
 	upsertStatus: (...args: unknown[]) => mockUpsertStatus(...args),
 	insertStatusHistory: (...args: unknown[]) => mockInsertStatusHistory(...args),
@@ -1649,6 +1656,91 @@ describe('importFamilyData', () => {
 				expect(String(row.filePath).startsWith(`tenants/${TENANT}/voices/`)).toBe(true);
 			}
 			expect(result.warnings.some((w) => w.includes('不正なパス'))).toBe(true);
+		});
+
+		it('#3490: voiceRelPath の rest に NUL/制御文字が含まれると insert されず skip + warning になる', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			const NUL = String.fromCharCode(0);
+			data.data.childVoices = [
+				makeVoice('c1', `voices/7/evil${NUL}.mp3`), // rest に NUL (poison-null-byte)
+				makeVoice('c1', 'voices/7/safe.mp3'), // 正常エントリ (1 件だけ通る)
+			];
+			mockInsertChild.mockResolvedValue({ id: '101' });
+			mockVoiceInsertForRestore.mockResolvedValue({ id: '1' });
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.childVoicesImported).toBe(1);
+			expect(result.childVoicesSkipped).toBe(1);
+			expect(mockVoiceInsertForRestore).toHaveBeenCalledTimes(1);
+			// 制御文字混入パスは一切 insert されない
+			for (const call of mockVoiceInsertForRestore.mock.calls) {
+				const [row] = call;
+				expect(String(row.filePath)).not.toContain(NUL);
+			}
+			expect(result.warnings.some((w) => w.includes('不正なパス'))).toBe(true);
+		});
+	});
+
+	describe('各種設定 (settings) のインポート (#3382 値バリデーション)', () => {
+		const makeSetting = (key: string, value: string) => ({ key, value });
+
+		it('allowlist キーの正常値は setSetting で書き戻され settingsImported に計上される', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			mockInsertChild.mockResolvedValue({ id: '101' });
+			data.data.settings = [
+				makeSetting('decay_intensity', 'normal'),
+				makeSetting('point_rate', '2'),
+				makeSetting('weekly_report_day', 'friday'),
+			];
+			mockSetSetting.mockResolvedValue(undefined);
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.settingsImported).toBe(3);
+			expect(result.settingsSkipped).toBe(0);
+			expect(mockSetSetting).toHaveBeenCalledTimes(3);
+		});
+
+		it('範囲外/型不正/未知 enum の値は書き戻されず skip + warning になる (fail-closed)', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			mockInsertChild.mockResolvedValue({ id: '101' });
+			data.data.settings = [
+				makeSetting('decay_intensity', 'EXTREME'), // 未知 enum
+				makeSetting('point_rate', 'not-a-number'), // 非数値
+				makeSetting('point_unit_mode', 'bitcoin'), // 未知 enum
+				makeSetting('decay_intensity', 'gentle'), // 正常 (1 件だけ通る)
+			];
+			mockSetSetting.mockResolvedValue(undefined);
+
+			const result = await importFamilyData(data, TENANT);
+
+			// 正常 1 件のみ setSetting、不正 3 件は skip
+			expect(result.settingsImported).toBe(1);
+			expect(result.settingsSkipped).toBe(3);
+			expect(mockSetSetting).toHaveBeenCalledTimes(1);
+			expect(mockSetSetting).toHaveBeenCalledWith('decay_intensity', 'gentle', TENANT);
+			expect(result.warnings.some((w) => w.includes('値が不正'))).toBe(true);
+		});
+
+		it('秘匿/非 allowlist キーは値の妥当性以前に書き戻されない (多層防御)', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			mockInsertChild.mockResolvedValue({ id: '101' });
+			data.data.settings = [
+				makeSetting('pin_hash', '$2b$10$whatever'), // 秘匿キー (allowlist 外)
+				makeSetting('session_token', 'abc'), // 秘匿キー (allowlist 外)
+			];
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.settingsImported).toBe(0);
+			expect(result.settingsSkipped).toBe(2);
+			expect(mockSetSetting).not.toHaveBeenCalled();
+			expect(result.warnings.some((w) => w.includes('backup 対象外'))).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

保護者が NUC ↔ AWS 間や環境間でデータを backup / restore する際の **安全性と信頼性** を高める。改竄・破損した backup が silent に不正値を復元して表示崩れを起こす / 内部エラーコードや生パスが保護者にそのまま露出する / 復元時に一部データ (音声・設定) が黙って欠落する、といった Pre-PMF の品質欠陥 3 件を same-class として一括根治する。

## 関連 Issue

- closes #3382 (settings backup allowlist の機械強制強化)
- closes #3386 (backup manifest 検証エラーの内部 reason 非露出 + labels SSOT + itemCounts 照合)
- closes #3490 (restore path guard の制御文字拒否 + childVoices 部分復元の可視化)
- 関連: #3329 / #3354 / #3375 / #3379 / #3077 / #3486 / ADR-0062 / ADR-0066 / ADR-0061

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| #3382-1 | 将来キーの silent round-trip 喪失ガード | `settings-backup-classification.test.ts`「全キーが分類済 (未分類=fail)」= src 全走査の silent-gap ガード。走査で未分類キー `questionnaire_activity_display_count` を検出し派生キャッシュとして分類 | PASS (9 test) |
| #3382-2 | 秘匿キー除外の機械強制 (11 件全て) | 同 test「秘匿キーは 1 件も allowlist に含まれない」+「排他分類」で `SECRET_SETTING_KEYS` 6 + lifecycle 8 全件 assert | PASS |
| #3382-3 | import の値検証 (範囲/型/enum) | `SETTING_VALUE_VALIDATORS` / `isValidSettingValue` 追加。`import-service.test.ts`「範囲外/型不正/未知 enum は skip + warning」+ 制御文字拒否 | PASS |
| #3386-1 | エラー文言の内部 reason/raw path 非露出 (ADR-0062) | `backup-archive.test.ts`「内部 reason/path を露出しない」= `res.error` が labels SSOT と一致 + `checksum-mismatch`/path を含まない。内部 reason は logger のみ | PASS |
| #3386-2 | 注入防御の役割分担明確化 | `backup-manifest.ts` 冒頭コメントで `unexpected-file` (偶発混入検出) vs `isSafeRelativePath` (実効防御) を明記 | doc 反映 |
| #3386-3 | itemCounts 件数照合の実装 | `parseBackupZip` が data.json 実件数と manifest.itemCounts を照合。`backup-archive.test.ts`「件数不一致で弾く」/「一致で通る」 | PASS |
| #3490-1 | isSafeRelativePath に NUL/制御文字拒否 + test 固定 | `import-service.test.ts`「voiceRelPath の rest に NUL が含まれると skip + warning」+ 分類 test の制御文字ケース | PASS |
| #3490-2 | restore 完了 UI に skip 件数可視化 (childVoices に限らず) | `+page.svelte` に childVoices / settings の復元・skip 件数 `<li>` 追加 (testid 付き)。既存 warnings リストと併存 | 実装 (UI) |
| #3490-3 | childVoices DB 行 ↔ #3077 ファイル本体の相互整合 要否判断 | 現状は skip warning 可視化で dangling 行を surface する方針。相互整合チェックは backup-import-redesign.md に役割分担を記載 (追加の fail-closed 化は over-scope と判断) | 判断記載 |

## 変更タイプ

- [x] バグ修正 (security / data-integrity hardening)
- [ ] 新機能
- [x] リファクタリング (設定キー分類 SSOT / エラー文言 SSOT 化)
- [x] ドキュメント

## 影響範囲・変更コンポーネント

- `src/lib/domain/export-format.ts` — 設定キー分類 SSOT (SECRET / NON_EXPORTABLE) + 値バリデータ (SETTING_VALUE_VALIDATORS / isValidSettingValue)
- `src/lib/server/services/import-service.ts` — importSettingsData 値検証 / isSafeRelativePath 制御文字拒否
- `src/lib/server/services/backup-archive.ts` — verifyManifestIfPresent の内部 reason 非露出 + itemCounts 照合
- `src/lib/server/services/backup-manifest.ts` — コメント (役割分担 / itemCounts 配線済)
- `src/lib/domain/labels.ts` — manifest エラー文言 + childVoices/settings summary ラベル
- `src/routes/(parent)/admin/settings/data/+page.svelte` — restore 完了 UI の skip 可視化
- 設計書: `backup-import-redesign.md` / `07-API設計書.md`

## テスト & 安全装置セルフチェック

- [x] failing-test-first (ADR-0061): secret 混入 / 内部 reason 露出 / 制御文字混入 / 値域外を再現 red → 修正 → green
- [x] 新規 fitness test `settings-backup-classification.test.ts` (silent-gap ガード + 秘匿排他 + 値検証、9 test)
- [x] `import-service.test.ts` +4 test / `backup-archive.test.ts` +5 test / `backup-roundtrip-completeness.test.ts` seed 値更新
- [x] targeted vitest: 影響 52 file / 993 test PASS
- [x] biome check (変更 9 file) PASS / svelte-check 変更 src file にエラー 0 (残 117 は worktree の infra aws-cdk-lib 未 install の既知環境差)

## スクリーンショット / ビジュアルデモ

`/admin/settings/data` ページ全体 SS（2026-07-16 親セッション撮影、demo 決定的環境 `AUTH_MODE=anonymous DATA_SOURCE=demo` + `?screenshot=all`、screenshots branch `pr-3776/`）:

| モバイル (390px) | PC (1440px) |
|---|---|
| ![data-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3776/admin-settings-data-mobile.png) | ![data-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3776/admin-settings-data-desktop.png) |

restore 完了 UI に「お子さまの音声: N 件復元」「各種設定: N 件復元」の skip 可視化行を追加 (`data-import-result-child-voices` / `data-import-result-settings`)。**この skip 可視化バナーは復元操作を実行し skip が発生した後にのみ描画される transient 状態**のため、静的 SS には現れない（上記 SS は settings/data ページが正しく描画されることの担保）。skip 可視化の動作は E2E `data-import-partial-restore.spec.ts`（`toContainText` で additive 非破壊）+ unit test で担保する。#3382/#3386 は backend（設定キー分類 SSOT / manifest 検証エラー非露出）で UI 描画変化なし。

## コード品質セルフレビュー (#1481)

- 値バリデータは domain 層に集約 (ADR-0066 「値域を domain 層に SSOT 集約し validator で述語化」と同型)。
- エラー文言は labels.ts SSOT 経由 (ADR-0062 内部例外非露出)。内部 reason は logger.context のみ。
- 設定キー分類は「実在キーを src 走査で機械照合」する no-silent-gap 契約 (backup-entity-registry の silent-gap ガードと同型)。

## 横展開・影響波及チェック

- 設定キー分類 test は src 全体を走査するため、今後 getSetting/setSetting で新キーを足すと未分類で CI fail (横展開の自動強制)。
- `backup-roundtrip-completeness.test.ts` の seed 値 `point_unit_mode='custom'` (無効値) を妥当値 `'currency'` に是正 (値検証導入に伴う正当な test 更新、round-trip 検証意図は不変)。
- 並行実装: export/import の値域は ADR-0066 EPIC #3151 の SSOT 方針と整合。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。旧 backup (manifest 無し / 旧値) は後方互換 (検証スキップ or 妥当値は通過)。
- 値検証は allowlist キーのみ・不正値は skip + warning (全 restore は止めない)。既存の妥当な backup は影響なし。
- #3490-3 (childVoices ↔ ファイル本体の dangling 相互整合の fail-closed 化) は skip 可視化で surface する方針とし、追加の相互整合ガードは over-scope として本 PR では役割分担の doc 化に留めた。要否は QM 判断を仰ぐ。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] `npm run pre-ready` 相当の targeted 検証 (biome / svelte-check / vitest / doc-code-references / no-plan-literals) を worktree で実施
- [x] AC 検証マップ 4 列で全 AC を消化
- [x] 設計書同期 (backup-import-redesign.md / 07-API設計書.md)
- [x] failing-test-first で red → green
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: unit/fitness 993 test green + biome/型 clean)

## QM レビュー結果

(QM 記入欄 — merge は QM/POREVIEWER 責務)


