### PR TITLE
infra: #3765 typescript 7 ignore 解除手順 (2 手順) を dependabot.yml コメントに durable 記録

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,13 @@ updates:
       # #3636: typescript 7.x は @sveltejs/kit@2.69.x の peer (^5.3.3 || ^6.0.0) が除外し
       # npm ci が ERESOLVE で失敗する。kit が TS7 peer 対応版を出したら本 ignore を削除して TS7 を取り込む。
       # major (6→7) のみ保留し 6.x の minor/patch 更新は許可する。
+      # 【解除手順 (#3765、2 手順必須)】@sveltejs/kit が peer に typescript@^7 を含む版を release したら:
+      #   1. 本 ignore エントリ + 本コメントを削除する PR を出す (yml 側の抑止解除)
+      #   2. 加えて dependabot に `@dependabot unignore typescript` を実行し、PR #3636 の
+      #      `@dependabot ignore this major version` 由来の internal ignore も解除する。
+      #      yml と comment 由来 ignore は独立した別々の抑止機構であり、yml 削除だけでは TS7 が再開されない。
+      #   3. その後 @sveltejs/kit を TS7 対応版へ bump → dependabot が TS7 を再提案 (npm ci が通り mergeable)。
+      #   ※ 解除前に @sveltejs/kit@2.x の peer が実際に typescript@^7 を含むか確認 (ERESOLVE 再発防止)。
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
     groups:


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発プロセス / CI 保守）

**解決する課題**: TypeScript 7.x への major bump は `@sveltejs/kit` の peer 制約（`typescript@"^5.3.3 || ^6.0.0"`）が除外しており、取り込むと `npm ci` が ERESOLVE で失敗する（PR #3636 で CI 6 checks 全滅を確認）。#3763（PR #3764）で dependabot.yml に typescript major の条件付き ignore を追加済だが、QM Tier2 が指摘した「yml と `@dependabot ignore this major version` は独立した別々の抑止機構であり、yml 削除だけでは TS7 が再開されない」という **2 手順の解除手順** が durable に記録されていなかった。

**期待される効果**: kit が TS7 peer 対応版を出した将来、解除手順を思い出す手掛かりが yml コメントに残り、yml 削除だけで済ませて TS7 が再開されない事故を防ぐ（#3765）。

## 関連 Issue

closes #3763
closes #3765

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| #3763-AC1 | root npm ecosystem の ignore に typescript major (`version-update:semver-major`) ignore を追加 | `node -e` で YAML parse し typescript ignore を抽出 | HEAD `8497e647` / typescript ignore 1 件 = `{update-types:["version-update:semver-major"]}`（dependabot.yml:45-46）。本体は #3763(PR #3764) で develop merge 済、本 PR は comment 統合のみ |
| #3763-AC2 | 6.x の minor/patch 更新は許可（major のみ保留） | yml 目視 + group 設定確認 | HEAD `8497e647` / ignore は `version-update:semver-major` のみ指定 → minor/patch は非 ignore。`npm-minor-patch` group は typescript 未除外（dependabot.yml:47-56） |
| #3763-AC3 | #3636 を `@dependabot ignore this major version` で close し TS7 保留 | GitHub 上で PR #3636 状態確認 | PR #3636 は closed 済（#3765 背景に記載）。本 PR scope 外の GitHub 操作 |
| #3763-AC4 | 解除条件を dependabot.yml コメントに残す | yml コメント目視 | HEAD `8497e647` / dependabot.yml:36「kit が TS7 peer 対応版を出したら本 ignore を削除して TS7 を取り込む」 |
| #3765-AC1 | 解除手順（2 手順必須 = yml 削除 + @dependabot unignore）を durable 記録 | yml コメント目視 | HEAD `8497e647` / dependabot.yml:38-43 に 3 ステップ（yml 削除 / @dependabot unignore / kit bump）+ 「2 つの抑止機構は独立」明記 |
| #3765-AC2 | 解除前に kit peer が typescript@^7 を含むか確認する前提を記載 | yml コメント目視 | HEAD `8497e647` / dependabot.yml:44「解除前に @sveltejs/kit@2.x の peer が実際に typescript@^7 を含むか確認 (ERESOLVE 再発防止)」 |

## 変更タイプ

- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/` 等) — `.github/dependabot.yml` のコメントのみ

**影響を受ける画面・機能**: なし（Dependabot の TypeScript major bump 抑止コメントの durable 化のみ）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready`** — 本 PR は yml コメントのみの変更。親セッションが Ready 化前に main tree で全 step 実施。worktree では YAML parse 検証（`node -e` で js-yaml load）で typescript ignore 1 件を確認済
- [x] 追加・変更したテストの概要: N/A（Dependabot 設定コメントのみ、テスト対象なし）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

該当なし（`.github/dependabot.yml` コメントのみの infra 変更、UI 変更なし）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（設定ファイルコメント）
- [x] **DRY**: 既存の typescript major ignore エントリ（#3763 で追加済）に comment 統合し、重複エントリを作らない方針を徹底
- [x] **YAGNI**: 不要な抽象化なし
- [x] **Security**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（Dependabot 設定のみ）

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: #3763 の ignore ルール本体は PR #3764 で develop に merge 済（conventional-commit prefix のため auto-close されず OPEN のまま残存）。本 PR は #3765 の 2 手順解除手順を既存コメントに統合し、両 issue を closes する。重複 ignore エントリは作らず 1 件に統合した点をご確認ください。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready`** 相当の YAML parse 検証をローカル確認した（親セッションが main tree で全 step 実施）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完の作業・保留項目が残っている AC がない）
- [x] Phase 分割: N/A
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入。CI 緑 = approve ではない。Issue AC 照合と SS 目視が必須（ADR-0022）。 -->
