### PR TITLE
infra: #3730 DSQL alarm description に runbook link 追記 (#3432 residual)

### DIFF
--- a/infra/lib/dsql-stack.ts
+++ b/infra/lib/dsql-stack.ts
@@ -77,7 +77,7 @@ export class DsqlStack extends cdk.Stack {
 			comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
 			treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
 			alarmDescription:
-				'DSQL TotalDPU が無料枠ペース (10万 DPU/月 ≈ 3,225/日) を超過 (#3431。DPU 単価: Write は Read の約 27 倍)',
+				'DSQL TotalDPU が無料枠ペース (10万 DPU/月 ≈ 3,225/日) を超過 (#3431。DPU 単価: Write は Read の約 27 倍) 一次対応: docs/runbooks/dsql-alert-response.md',
 		});
 		totalDpuAlarm.addAlarmAction(alarmAction);
 
@@ -94,7 +94,8 @@ export class DsqlStack extends cdk.Stack {
 			evaluationPeriods: 1,
 			comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
 			treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-			alarmDescription: 'DSQL storage が無料枠 1GB の 80% に接近 (#3431)',
+			alarmDescription:
+				'DSQL storage が無料枠 1GB の 80% に接近 (#3431) 一次対応: docs/runbooks/dsql-alert-response.md',
 		});
 		storageAlarm.addAlarmAction(alarmAction);
 

--- a/tests/unit/infra/dsql-cdk.test.ts
+++ b/tests/unit/infra/dsql-cdk.test.ts
@@ -58,6 +58,18 @@ describe('DsqlStack (EPIC #3424 M4-E item 12)', () => {
 		});
 	});
 
+	it('[I3b] 両 alarm の description が一次対応 runbook link を含む (#3730、2am 発見時の可観測性)', () => {
+		// runbook link が silent に消えると alarm 発火時の一次対応導線が失われる (#3432 residual)。
+		const alarms = template.findResources('AWS::CloudWatch::Alarm');
+		const descriptions = Object.values(alarms).map(
+			(alarm) => alarm.Properties.AlarmDescription as string,
+		);
+		expect(descriptions).toHaveLength(2);
+		for (const description of descriptions) {
+			expect(description).toContain('docs/runbooks/dsql-alert-response.md');
+		}
+	});
+
 	it('[I4] alarm は SNS topic に通知し、opsEmail が subscribe される', () => {
 		template.resourceCountIs('AWS::SNS::Topic', 1);
 		template.hasResourceProperties('AWS::SNS::Subscription', {


### PR DESCRIPTION
## 顧客価値・目的

DSQL alarm (`TotalDpuDaily` / `StorageSize`、SNS email 通知) を受信した operator が、一次対応 runbook (`docs/runbooks/dsql-alert-response.md`、#3432 AC3) の存在を知らないと辿り着けない発見可能性ギャップを恒久解消する。alarm email 本文に載る `alarmDescription` へ runbook path を 1 行追記するだけで、深夜 (2am) 受信時も対応手順へ直行できる。#3432 residual。

## 関連 Issue

- Closes #3730
- refs #3432 (DSQL 可観測性 dashboard、runbook 起源) / #3431 (alarm + Budgets 設計) / related PR #3728 (adversarial review objection 2 起源)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 両 alarm の alarmDescription に runbook path が含まれる | `infra/lib/dsql-stack.ts` の TotalDpuDaily (L80) / StorageSize (L97) 両 alarmDescription 末尾に `一次対応: docs/runbooks/dsql-alert-response.md` を追記 | 実装済。`npx vitest run tests/unit/infra/dsql-cdk.test.ts` 12 passed (新規 `[I3b]` が両 description の runbook 含有を assert) |
| AC2 | dsql-cdk.test.ts が description 内 runbook 参照を pin (削除退行の検出) | `[I3b]` test を追加し、synthesized template の全 alarm (2 本) の AlarmDescription が `docs/runbooks/dsql-alert-response.md` を含むことを assert | 実装済。link を消すと `[I3b]` が fail する regression pin |
| AC3 | staging/prod 両 stack に反映 (nameSuffix 機構で自動) | alarmDescription は stack id 非依存の固定文字列のため、既存 `[N1]/[N2]/[N3]` nameSuffix guard が保証する staging/prod 両合成経路で同一 description が反映される | 検証済。`alarmDescription` は `nameSuffix` に依存せず両 stack で同値 |

## 変更タイプ

- [x] インフラ / IaC (CDK stack 文字列 1 行 × 2 + test 同期)
- [ ] 機能追加 / バグ修正 / UI / DB スキーマ / ドキュメント

CloudWatch alarmDescription は max 1024 chars。追記後も両 description は 100 chars 未満で余裕あり。

## 影響範囲・変更コンポーネント

- `infra/lib/dsql-stack.ts` — `TotalDpuDaily` / `StorageSize` の `alarmDescription` に runbook path を追記 (2 箇所)
- `tests/unit/infra/dsql-cdk.test.ts` — `[I3b]` regression pin を追加 (1 test)

alarm 本数・通知チャネル・閾値・SNS subscription・Budgets・dashboard は不変。DSQL stack は `-c dsqlEnabled=true` context gate 経由でのみ合成されるため既存 deploy 経路への副作用なし。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/infra/dsql-cdk.test.ts` — 12 passed (新規 `[I3b]` 含む)
- [x] `npx biome check --write infra/lib/dsql-stack.ts tests/unit/infra/dsql-cdk.test.ts` — No fixes applied (clean)
- [x] regression pin: alarmDescription から runbook link が silent に消えると `[I3b]` が hard-fail する (ADR-0006 assertion 弱体化なし)
- [x] `cd infra && npm ci` 実行済 (infra deps、`tests/unit/infra/` 実行前提)

## スクリーンショット / ビジュアルデモ

N/A — infra (CDK stack 文字列) 変更のみで UI 差分なし。

## コード品質セルフレビュー (#1481)

- [x] 既存 `alarmDescription` の #3431 テキストは保持し、末尾に runbook path を追記するのみ (情報削除なし)
- [x] test は既存 `[I1]〜[I7]` の introspection style (`template.findResources` + Properties assert) を踏襲し `[I3b]` として自然に挿入
- [x] runbook path はハードコード文字列だが、alarmDescription 自体が CloudFormation リテラルであり SSOT 分離の余地なし。test 側で path 一致を pin することで drift を機械検出
- [x] Pre-PMF Bucket A 最小改善 (SNS 整形 Lambda 等の過剰防衛を採らない、ADR-0010)

## 横展開・影響波及チェック

- [x] DSQL alarm は本 stack の 2 本のみ。同種 alarmDescription を持つ他 stack への横展開対象なし
- [x] `docs/runbooks/dsql-alert-response.md` は既存 (#3432 で作成済)。参照 path の物理存在を確認済
- [x] `check-doc-code-references` 観点: コード → docs runbook への参照追加であり、逆参照 (docs → 実装) の同期義務は発生しない

## レビュー依頼事項・破壊的変更

破壊的変更なし。alarmDescription 文字列追記のみで CloudFormation リソースの置換・削除は発生しない (ADR-0019 replacement なし)。次回 DSQL stack deploy 時に既存 alarm の description が in-place 更新される。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] AC 全項目を実装・検証した (AC1-AC3、上記マップ参照)
- [x] `npx vitest run tests/unit/infra/dsql-cdk.test.ts` 全 PASS
- [x] biome clean
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: 実装 + test + biome を worktree で完遂)
- [x] origin/develop rebase 済 (pre-push hook で drift verify PASS)

Draft のまま提出 (Ready 化 = `gh pr ready` は QM/PO レビュー後の判断)。

## QM レビュー結果

未実施 (Draft PR)。QM/PO レビュー待ち。
