### PR TITLE
refactor(db): #3438 Phase 1 — S3 storage-repo を dynamodb/ から s3/ へ移設 (撤去 unblock)

### DIFF
--- a/scripts/check-no-direct-env-access.mjs
+++ b/scripts/check-no-direct-env-access.mjs
@@ -54,7 +54,9 @@ const GRANDFATHER = new Set(
 		'src/lib/server/cookie-config.ts',
 		'src/lib/server/db/client.ts',
 		'src/lib/server/db/dynamodb/client.ts',
-		'src/lib/server/db/dynamodb/storage-repo.ts',
+		// #3438 Phase 1 で src/lib/server/db/dynamodb/storage-repo.ts から相対移動 (pure relocate)。
+		// grandfather の意図 (既存の直接 env 参照を維持) を保つため path のみ追随更新。
+		'src/lib/server/db/s3/storage-repo.ts',
 		'src/lib/server/db/factory.ts',
 		'src/lib/server/db/seed.ts',
 		'src/lib/server/debug-plan.ts',

--- a/src/lib/server/db/factory.ts
+++ b/src/lib/server/db/factory.ts
@@ -106,7 +106,6 @@ import * as dynamoSiblingCheerRepo from './dynamodb/sibling-cheer-repo';
 import * as dynamoSpecialRewardRepo from './dynamodb/special-reward-repo';
 import * as dynamoStampCardRepo from './dynamodb/stamp-card-repo';
 import * as dynamoStatusRepo from './dynamodb/status-repo';
-import * as dynamoStorageRepo from './dynamodb/storage-repo';
 import * as dynamoTrialHistoryRepo from './dynamodb/trial-history-repo';
 import * as dynamoViewerTokenRepo from './dynamodb/viewer-token-repo';
 import * as dynamoVoiceRepo from './dynamodb/voice-repo';
@@ -150,6 +149,7 @@ import type { IVoiceRepo } from './interfaces/voice-repo.interface';
 // getPglite*Sync は init 済み前提の同期アクセサ (async init は hooks.server.ts の 1st-request
 // guard で await 済み)。pglite 分岐内でのみ呼ぶこと (他 backend で PGlite を open させない)。
 import { getPgliteDbSync, getPgliteTransactionRunnerSync } from './pglite/connection';
+import * as s3StorageRepo from './s3/storage-repo';
 import * as sqliteAccountLockoutRepo from './sqlite/account-lockout-repo';
 import * as sqliteActivityMasteryRepo from './sqlite/activity-mastery-repo';
 import * as sqliteActivityPrefRepo from './sqlite/activity-pref-repo';
@@ -276,9 +276,8 @@ function buildPgBackendRepos<TTx extends SqlExecutor>(
 		specialReward: createDsqlSpecialRewardRepo(db, runner),
 		stampCard: createDsqlStampCardRepo(db, runner),
 		status: createDsqlStatusRepo(db, runner),
-		// storage の実体は S3 (DB backend 非依存)。専用実装は作らず dynamodb/ の実装を再利用する。
-		// #3438 dynamodb 撤去時に storage-repo を dynamodb/ 外へ移設する。
-		storage: dynamoStorageRepo,
+		// storage の実体は S3 (DB backend 非依存)。#3438 Phase 1 で dynamodb/ → s3/ へ移設済。
+		storage: s3StorageRepo,
 		trialHistory: createDsqlTrialHistoryRepo(db),
 		viewerToken: createDsqlViewerTokenRepo(db),
 		voice: createDsqlVoiceRepo(db, runner),
@@ -380,7 +379,8 @@ export function getRepos(): Repositories {
 			specialReward: dynamoSpecialRewardRepo,
 			stampCard: dynamoStampCardRepo,
 			status: dynamoStatusRepo,
-			storage: dynamoStorageRepo,
+			// storage は S3 (DB backend 非依存)。dynamodb backend も S3 実装を共有 (#3438 Phase 1 で s3/ へ移設)。
+			storage: s3StorageRepo,
 			trialHistory: dynamoTrialHistoryRepo,
 			viewerToken: dynamoViewerTokenRepo,
 			voice: dynamoVoiceRepo,

--- a/src/lib/server/db/s3/storage-repo.ts
+++ b/src/lib/server/db/s3/storage-repo.ts
@@ -1,5 +1,7 @@
-// src/lib/server/db/dynamodb/storage-repo.ts
-// S3（Lambda）向けストレージ実装
+// src/lib/server/db/s3/storage-repo.ts
+// S3（Lambda）向けストレージ実装。DB backend 非依存の S3 層 (#3438 Phase 1 で dynamodb/ から移設)。
+// 旧配置は dynamodb/ だが DynamoDB 依存はゼロ (@aws-sdk/client-s3 のみ)。dsql/pglite/dynamodb
+// いずれの backend でも本 S3 実装を共有する (factory.ts が注入)。
 
 import type { FileData, IStorageRepo } from '../interfaces/storage.interface';
 

--- a/tests/unit/db/s3-storage-repo.test.ts
+++ b/tests/unit/db/s3-storage-repo.test.ts
@@ -1,5 +1,5 @@
 /**
- * tests/unit/db/dynamodb-storage-repo.test.ts
+ * tests/unit/db/s3-storage-repo.test.ts (#3438 Phase 1 で dynamodb-storage-repo.test.ts から改称)
  *
  * #3504 (async-backup-export.md §3.4): S3 storage の getDownloadUrl が presigned GET URL を
  * 発行し `{ kind: 'redirect', url }` を返すことを検証する。@aws-sdk/s3-request-presigner を
@@ -32,7 +32,7 @@ afterEach(() => {
 describe('dynamodb storage-repo getDownloadUrl (#3504)', () => {
 	it('presigned GET URL を対象 key 限定・指定 TTL で発行し redirect を返す', async () => {
 		mockGetSignedUrl.mockResolvedValueOnce('https://s3.example.com/presigned?sig=abc');
-		const { getDownloadUrl } = await import('../../../src/lib/server/db/dynamodb/storage-repo');
+		const { getDownloadUrl } = await import('../../../src/lib/server/db/s3/storage-repo');
 
 		const result = await getDownloadUrl('exports/t1/ABC234/backup.zip', { expiresIn: 300 });
 


### PR DESCRIPTION
## 顧客価値・目的

EPIC #3424 (DynamoDB→DSQL 移管) の最終 close gate = **#3438 DynamoDB backend 撤去**の Phase 1。撤去を阻む唯一の cross-coupling（live な DSQL/PGlite backend が `dynamodb/storage-repo.ts` を再利用している点）を先に解消する。本体撤去 (Phase 2) を安全な小 PR に分解するための下ごしらえで、顧客影響ゼロ（純内部 refactor）。

## 関連 Issue

- #3438 Phase 1（EPIC #3424 の close gate 系）。撤去計画全体は #3438 の impact-analysis コメント参照。Phase 2 (dynamodb/ 本体削除 + CI gate 撤去)・Phase 3 (deploy.yml + Storage stack、AWS 要) は後続 PR。

## AC 検証マップ (ADR-0004)

| AC (Phase 1) | 実装 | 検証 | 状態 |
|---|---|---|---|
| storage-repo を DB backend 非依存の neutral 層へ移設 | `dynamodb/storage-repo.ts` → `s3/storage-repo.ts` (git mv、純 S3 実装で DynamoDB 依存ゼロ) | `git diff` = header のみ変更、実装不変 | ✅ |
| factory.ts の 3 参照を更新 | import (L109) + dsql/pglite path + dynamodb path の `storage:` を `s3StorageRepo` に | `rg dynamoStorageRepo` = 0 件、svelte-check exit 0 | ✅ |
| 挙動不変 (S3 presigned URL 契約) | test も `s3-storage-repo.test.ts` に改称 + import 更新 | `npx vitest run` = PASS | ✅ |
| CI 撤去 gate に影響なし | storage-repo は stub 0 のため parity inventory 不変 | `check-dynamodb-stub-parity` / `check-dynamodb-stub` = OK | ✅ |

## 変更タイプ

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタ (誤配置ファイルの移設、挙動不変)
- [x] テスト (改称 + import 更新)

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dynamodb/storage-repo.ts` → `src/lib/server/db/s3/storage-repo.ts` (git mv、header コメントのみ更新)
- `tests/unit/db/dynamodb-storage-repo.test.ts` → `tests/unit/db/s3-storage-repo.test.ts` (git mv、import path 更新)
- `src/lib/server/db/factory.ts` (import 1 + usage 2 = dsql/pglite path + dynamodb path)
- **blast radius**: impact-analysis (#3438 コメント) の通り dynamodb/ の外部 consumer は factory.ts のみ。storage-repo は純 S3 (import は `@aws-sdk/client-s3` + `interfaces/storage.interface` のみ) で全 backend が共有する S3 層。

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/db/s3-storage-repo.test.ts tests/unit/db/factory-pglite-branch.test.ts` → 3 passed
- `npx svelte-check --threshold error` → exit 0
- `node scripts/check-dynamodb-stub-parity.mjs` / `check-dynamodb-stub.mjs` → OK (storage-repo は stub 0 のため inventory 不変)
- `rg "dynamoStorageRepo|dynamodb/storage-repo" src tests` → 0 件 (dangling ゼロ)

## スクリーンショット / ビジュアルデモ

N/A (内部 refactor、UI 変更なし)。

## コード品質セルフレビュー (#1481)

- `npx biome check` → clean
- git mv で履歴継承。実装は 1 行も変えず header コメントのみ更新 (誤配置の是正 = DynamoDB 依存ゼロの S3 実装が dynamodb/ に居た問題)。
- factory.ts の dynamodb path も S3 storage を共有する形に更新（DynamoDB backend もファイルは S3 保存のため正しい）。Phase 2 で dynamodb path 自体を削除する。

## 横展開・影響波及チェック

- impact-analysis skill (4 layer) を #3438 で実施済。storage-repo 以外に dsql/pglite path が dynamodb/ を跨ぐ点は無い (L3 で確認)。
- `db/s3/` は新規サブ層。codebase-map.md は db/ サブディレクトリを列挙しないため更新不要。
- Phase 2 (dynamodb/ 本体削除) はこの移設完了が前提。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし (IStorageRepo 契約・S3 挙動不変、frontend 影響ゼロ)。
- レビュー観点: factory.ts の 2 usage (dsql/pglite path + dynamodb path) がともに `s3StorageRepo` に更新されたか。

## 配布済み env / secret (ADR-0006)

新規 env なし (`ASSETS_BUCKET` は既存、移設で不変)。

## Ready for Review チェックリスト

- [x] AC 全て実装 + 検証済 (Phase 1 scope)
- [x] svelte-check / biome / parity gates clean
- [x] dangling ref ゼロ
- [x] pre-ready 全 step PASS (実行して確認)

## QM レビュー結果

(QM 記入欄)
