### PR TITLE
fix(api): #3775 payload 6MB guard 残余 — JSON export 未guard + OCR note 5MB乖離

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -889,6 +889,7 @@ S3 からの画像取得プロキシ。`key` クエリパラメータで対象�
   - `avatars/{childId}/{filename}.png` / `voices/{childId}/{filename}` 等、`tenants/{tenantId}/` prefix 配下のアップロード済みファイル
 - ZIP 同梱対象（`data.json` + 静的ファイル）の合計が 100MB を超える場合は、残りを silent skip せず **fail-closed で 400 を返す**（#3376）。不完全な ZIP を「フルバックアップ」として返すと、再生成不能な avatar/voice が無警告で欠落し manifest も truncated set で整合してしまうため。ユーザーには「バックアップ対象のデータが上限（100MB）を超えています」と明示する
 - **#3694 (Function URL response 6MB cap 整合)**: AWS（aws-prod）は Lambda Function URL（BUFFERED）の response payload も 6MB hard cap のため、100MB fail-closed の**手前**で、構築 ZIP が実効上限（`resolveMaxSyncResponseBytes`、SSOT: `src/lib/server/services/function-url-limit.ts`）を超えた場合は **400 VALIDATION_ERROR で「クラウド共有（PIN コード）経由のバックアップ」を案内**する（edge の沈黙切断 = 「ダウンロードできない」状態を根絶）。NUC / local は Function URL 制約が無いため従来通り直 DL（100MB まで）を許可する
+- **#3775 ① (JSON export 直 DL の 6MB cap 整合)**: `format=json`（既定）の直 DL body も同一の Function URL response 6MB cap 対象。#3694 は ZIP response のみ guard していたため残余だった。JSON body（マルチバイト JP を含むため `Buffer.byteLength` で byte 長判定）が `resolveMaxSyncResponseBytes` を超えた場合は同様に **400 VALIDATION_ERROR + クラウド共有導線**（`SETTINGS_LABELS.dataExportJsonTooLargeForDirectDownload`、JSON は画像・音声を含まないため専用文言）を返す。JSON はテキストのみで 6MB 超は稀だが、edge 沈黙切断の完全性のため塞ぐ。NUC / local は Infinity で従来通り直 DL
 
 > **#3078**: `data.checklistLogs`（チェックリスト完了履歴）は `checklist-repo.findLogsByChild` で child 単位にバルク取得した実データを `templateName` 参照付きで含む（旧来の空配列固定を解消、activity ログと同様に往復対象）。
 
@@ -1021,7 +1022,9 @@ S3 からの画像取得プロキシ。`key` クエリパラメータで対象�
 
 **AIモデル:** AWS Bedrock Claude Haiku（画像入力 + tool_use）— レシート画像をマルチモーダル入力し、金額とテキストを構造化出力で抽出。Bedrock 未利用時は `NO_API_KEY` エラーを返す。
 
-**画像サイズ上限（#3694、Function URL 6MB request cap 整合）:** 画像は base64 JSON body で送信するため、AWS（aws-prod）では base64 化（デコード後 × 4/3）が Function URL 6MB request cap を超えると edge で沈黙拒否される。デコード後上限を runtime 実効値（約 4.14MB、`resolveMaxBase64DecodedBytes`、SSOT: `src/lib/server/services/function-url-limit.ts`）に下方整合し、超過は 400 VALIDATION_ERROR で明示する。NUC / local は Function URL 制約が無いため従来 5MB を維持する。
+**画像サイズ上限（#3694、Function URL 6MB request cap 整合）:** 画像は base64 JSON body で送信するため、AWS（aws-prod）では base64 化（デコード後 × 4/3）が Function URL 6MB request cap を超えると edge で沈黙拒否される。デコード後上限を runtime 実効値（約 4.14MB、`resolveMaxBase64DecodedBytes`、SSOT: `src/lib/server/services/function-url-limit.ts`）に下方整合し、超過は 400 VALIDATION_ERROR で明示する。NUC / local は Function URL 制約が無いため従来 5MB を維持する。受理上限の元定数は `RECEIPT_MAX_IMAGE_BYTES`（`src/lib/server/services/receipt-ocr-service.ts`、5MB）を SSOT とし、route の reject 判定と撮影ボタン note の表示値を同一値から導出する。
+
+**撮影ボタン note の実効値同期（#3775 ②）:** 領収書撮影ボタンの note（`POINTS_LABELS.receiptCaptureButtonNote(maxMb)`）は、旧静的「5MB以下」が aws-prod の実効 reject 閾値（約 4.1MB）と乖離し「5MB と書いてあるのに 4.5MB が弾かれる」UX 齟齬を生んでいた。admin/points の load が `toDisplayMb(resolveMaxBase64DecodedBytes(RECEIPT_MAX_IMAGE_BYTES))` を解決して note に渡し、表示 MB を server の実効 reject 閾値（aws-prod 約 4.1MB / NUC・local 5MB）と一致させる。
 
 #### GET /api/v1/export/cloud (#0294)
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2292,6 +2292,11 @@ export const SETTINGS_LABELS = {
 	// (PINコード、非同期・上限なし) への誘導を返す (ADR-0062)。
 	dataExportTooLargeForDirectDownload: (maxMb: string) =>
 		`画像・音声を含むファイルが直接ダウンロードの上限（${maxMb}MB）を超えています。「クラウド共有（PINコード）」から${BACKUP_TERMS.exportVerb}してください`,
+	// #3775 ①: JSON export (テキストのみ、画像・音声は ZIP 同梱) も aws-prod では Function URL
+	// 6MB response cap を超えると edge 沈黙切断される。JSON は画像・音声を含まないため専用文言で
+	// クラウド共有 (PINコード、非同期・上限なし) へ誘導する (ADR-0062 / dataExportTooLargeForDirectDownload と対)。
+	dataExportJsonTooLargeForDirectDownload: (maxMb: string) =>
+		`${BACKUP_TERMS.canonical}が直接ダウンロードの上限（${maxMb}MB）を超えています。「クラウド共有（PINコード）」から${BACKUP_TERMS.exportVerb}してください`,
 	// #3376: 画像込み ZIP ダウンロードはブラウザの安全性警告（保存の確認）が出ることがある。
 	// 画像込みの完全バックアップは、警告の出ないクラウドバックアップを推奨する導線。
 	dataExportZipCloudHint:
@@ -2991,7 +2996,10 @@ export const POINTS_LABELS = {
 	receiptImageTooLarge: (maxMb: string) => `画像サイズは${maxMb}MB以下にしてください`,
 	receiptLabel: '領収書を撮影して金額を読み取り',
 	receiptCaptureButtonTitle: '領収書を撮影 / 画像を選択',
-	receiptCaptureButtonNote: 'JPEG, PNG, WebP（5MB以下）',
+	// #3775 ②: 表示上限 (MB) は実行環境で異なる (aws-prod ~4.1MB / NUC・local 5MB)。静的 5MB 表記は
+	// aws-prod の実効 reject 閾値と乖離し「5MB と書いてあるのに 4.5MB が弾かれる」UX 齟齬を生むため、
+	// server が実際に reject する実効値 (resolveMaxBase64DecodedBytes → toDisplayMb) を load で解決して渡す。
+	receiptCaptureButtonNote: (maxMb: string) => `JPEG, PNG, WebP（${maxMb}MB以下）`,
 	receiptPreviewAlt: '領収書プレビュー',
 	receiptPreviewClose: 'プレビューを閉じる',
 	receiptScanningText: '金額を読み取り中...',

--- a/src/lib/server/services/receipt-ocr-service.ts
+++ b/src/lib/server/services/receipt-ocr-service.ts
@@ -4,6 +4,14 @@
 import { getAiProvider, isAiAvailable } from '$lib/server/ai/factory';
 import { logger } from '$lib/server/logger';
 
+/**
+ * 領収書 OCR 画像の受理上限 (bytes)。NUC / local はこの 5MB がそのまま実効上限。
+ * aws-prod では base64 JSON body が Function URL 6MB request cap を超えないよう
+ * `resolveMaxBase64DecodedBytes` が更に下方整合する (~4.1MB)。OCR route の reject 判定と
+ * 撮影ボタン note の表示 MB を同一値から導出する SSOT (#3775 ②)。
+ */
+export const RECEIPT_MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
 export interface ReceiptOcrResult {
 	amount: number;
 	rawText: string;

--- a/src/routes/(parent)/admin/points/+page.server.ts
+++ b/src/routes/(parent)/admin/points/+page.server.ts
@@ -5,11 +5,14 @@ import { ConvertMode } from '$lib/domain/validation/point';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
 import { getAllChildren } from '$lib/server/services/child-service';
+import { resolveMaxBase64DecodedBytes } from '$lib/server/services/function-url-limit';
+import { toDisplayMb } from '$lib/server/services/import-limit';
 import {
 	convertPoints,
 	getPointBalance,
 	getPointHistory,
 } from '$lib/server/services/point-service';
+import { RECEIPT_MAX_IMAGE_BYTES } from '$lib/server/services/receipt-ocr-service';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -35,7 +38,13 @@ export const load: PageServerLoad = async ({ locals }) => {
 			};
 		}),
 	);
-	return { children: childrenWithBalance };
+	// #3775 ②: 領収書撮影ボタン note が「実効の受理上限」と一致するよう、OCR route と同一の
+	// 実効値 (aws-prod ~4.1MB / NUC・local 5MB) を server 側で解決して渡す。
+	const maxReceiptImageMb = String(
+		toDisplayMb(resolveMaxBase64DecodedBytes(RECEIPT_MAX_IMAGE_BYTES)),
+	);
+
+	return { children: childrenWithBalance, maxReceiptImageMb };
 };
 
 export const actions: Actions = {

--- a/src/routes/(parent)/admin/points/+page.svelte
+++ b/src/routes/(parent)/admin/points/+page.svelte
@@ -374,7 +374,7 @@ async function handleReceiptFile(event: Event) {
 						>
 							<span class="text-4xl">📸</span>
 							<span class="text-sm font-bold">{POINTS_LABELS.receiptCaptureButtonTitle}</span>
-							<span class="text-xs">{POINTS_LABELS.receiptCaptureButtonNote}</span>
+							<span class="text-xs">{POINTS_LABELS.receiptCaptureButtonNote(data.maxReceiptImageMb)}</span>
 						</Button>
 					{:else}
 						<!-- Preview + Result -->

--- a/src/routes/api/v1/export/+server.ts
+++ b/src/routes/api/v1/export/+server.ts
@@ -60,6 +60,23 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 
 		const exportData = await exportFamilyData({ tenantId, childIds, compact });
 		const jsonStr = compact ? JSON.stringify(exportData) : JSON.stringify(exportData, null, 2);
+
+		// #3775 ①: JSON export も aws-prod の Function URL (BUFFERED) 6MB response cap を超えると
+		// edge で沈黙切断され「ダウンロード不能」になる (#3770 は ZIP response のみ guard 済で JSON が残余)。
+		// マルチバイト JP を含むため char 長ではなく byte 長で判定する。NUC / local は
+		// resolveMaxSyncResponseBytes が Infinity を返すため従来通り直 DL を許可する。
+		const maxResponseBytes = resolveMaxSyncResponseBytes();
+		const jsonByteLength = Buffer.byteLength(jsonStr, 'utf-8');
+		if (jsonByteLength > maxResponseBytes) {
+			return apiError(
+				'VALIDATION_ERROR',
+				SETTINGS_LABELS.dataExportJsonTooLargeForDirectDownload(
+					String(toDisplayMb(maxResponseBytes)),
+				),
+				{ bytes: jsonByteLength, maxBytes: maxResponseBytes },
+			);
+		}
+
 		return new Response(jsonStr, {
 			status: 200,
 			headers: {

--- a/src/routes/api/v1/points/ocr-receipt/+server.ts
+++ b/src/routes/api/v1/points/ocr-receipt/+server.ts
@@ -4,10 +4,9 @@ import { validationError } from '$lib/server/errors';
 import { validateBase64ImageMagicBytes } from '$lib/server/security/magic-bytes';
 import { resolveMaxBase64DecodedBytes } from '$lib/server/services/function-url-limit';
 import { toDisplayMb } from '$lib/server/services/import-limit';
-import { ocrReceipt } from '$lib/server/services/receipt-ocr-service';
+import { ocrReceipt, RECEIPT_MAX_IMAGE_BYTES } from '$lib/server/services/receipt-ocr-service';
 import type { RequestHandler } from './$types';
 
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB（NUC / local の上限。AWS は runtime で下方整合）
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -29,7 +28,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	// base64サイズチェック（base64は元データの約1.33倍）。
 	// #3694: AWS 本番は base64 JSON body が Function URL 6MB request cap を超えると edge で
 	// 沈黙拒否されるため、デコード後上限を runtime 実効値に下方整合する (NUC / local は 5MB 維持)。
-	const maxImageBytes = resolveMaxBase64DecodedBytes(MAX_IMAGE_SIZE);
+	const maxImageBytes = resolveMaxBase64DecodedBytes(RECEIPT_MAX_IMAGE_BYTES);
 	const estimatedSize = (image.length * 3) / 4;
 	if (estimatedSize > maxImageBytes) {
 		return validationError(POINTS_LABELS.receiptImageTooLarge(String(toDisplayMb(maxImageBytes))));

--- a/tests/unit/routes/export-json-6mb-response-guard.test.ts
+++ b/tests/unit/routes/export-json-6mb-response-guard.test.ts
@@ -1,0 +1,107 @@
+// tests/unit/routes/export-json-6mb-response-guard.test.ts
+// #3775 ①: JSON export (format=json、既定) の 6MB response cap 整合。
+//
+// #3770 (#3694) は ZIP response / OCR request に guard を入れたが、JSON export 直 DL 経路が
+// 未 guard のまま残っていた。aws-prod (Function URL BUFFERED) は response も 6MB hard cap で、
+// 6MB 超の JSON body は edge で沈黙切断され「ダウンロード不能」になる。実効上限を超えたら
+// 直 DL せず明示エラー (400) + クラウド共有導線を返すこと (ADR-0062)。NUC / local は制約なし。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------- mocks ----------
+const mockExportFamilyData = vi.fn();
+vi.mock('$lib/server/services/export-service', () => ({
+	exportFamilyData: (...args: unknown[]) => mockExportFamilyData(...args),
+}));
+
+const mockBuildFullBackupZip = vi.fn();
+vi.mock('$lib/server/services/backup-archive', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/server/services/backup-archive')>();
+	return {
+		...actual,
+		buildFullBackupZip: (...args: unknown[]) => mockBuildFullBackupZip(...args),
+	};
+});
+
+const mockResolveFullPlanTier = vi.fn();
+const mockGetPlanLimits = vi.fn();
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	resolveFullPlanTier: (...args: unknown[]) => mockResolveFullPlanTier(...args),
+	getPlanLimits: (...args: unknown[]) => mockGetPlanLimits(...args),
+}));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireRole: vi.fn(),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { resetEnvForTesting } from '../../../src/lib/runtime/env';
+import { GET } from '../../../src/routes/api/v1/export/+server';
+
+const originalFnName = process.env.AWS_LAMBDA_FUNCTION_NAME;
+
+function makeEvent(awsMode: boolean) {
+	if (awsMode) process.env.AWS_LAMBDA_FUNCTION_NAME = 'ganbari-quest-app';
+	else delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+	resetEnvForTesting();
+	return {
+		// format 未指定 = 既定 json
+		url: new URL('https://x/api/v1/export'),
+		locals: { context: { tenantId: 't1', licenseStatus: 'active', plan: 'standard' } },
+		// biome-ignore lint/suspicious/noExplicitAny: minimal RequestEvent stub for handler unit test
+	} as any;
+}
+
+/** JSON.stringify した結果が指定バイト数を超える export data を作る。 */
+function makeLargeExportData(byteLength: number) {
+	return { version: 1, family: { children: [] }, blob: 'x'.repeat(byteLength) };
+}
+
+beforeEach(() => {
+	mockExportFamilyData.mockResolvedValue({ version: 1, family: { children: [] }, data: {} });
+	mockResolveFullPlanTier.mockResolvedValue('standard');
+	mockGetPlanLimits.mockReturnValue({ canExport: true });
+});
+
+afterEach(() => {
+	if (originalFnName === undefined) delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+	else process.env.AWS_LAMBDA_FUNCTION_NAME = originalFnName;
+	resetEnvForTesting();
+	vi.clearAllMocks();
+});
+
+describe('#3775 export JSON — 6MB response cap guard', () => {
+	it('aws-prod: 実効上限超の JSON は 400 + クラウド共有導線 (直 DL しない)', async () => {
+		mockExportFamilyData.mockResolvedValue(makeLargeExportData(6 * 1024 * 1024));
+		const res = await GET(makeEvent(true));
+		expect(res.status).toBe(400);
+		const bodyText = await res.text();
+		expect(bodyText).toContain('クラウド共有');
+		expect(res.headers.get('Content-Type')).not.toContain('application/json; charset=utf-8');
+	});
+
+	it('aws-prod: 実効上限内の JSON は従来通り application/json で直 DL', async () => {
+		mockExportFamilyData.mockResolvedValue(makeLargeExportData(1024));
+		const res = await GET(makeEvent(true));
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toBe('application/json; charset=utf-8');
+	});
+
+	it('local: Function URL 制約なし — 大きな JSON でも直 DL を許可する', async () => {
+		mockExportFamilyData.mockResolvedValue(makeLargeExportData(20 * 1024 * 1024));
+		const res = await GET(makeEvent(false));
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toBe('application/json; charset=utf-8');
+	});
+
+	it('aws-prod: 日本語マルチバイトは byte 長で判定する (char 長ではない)', async () => {
+		// 「あ」= UTF-8 3 bytes。char 長 2.5M でも byte 長 ~7.5M で上限超になる。
+		const data = { version: 1, family: { children: [] }, blob: 'あ'.repeat(2.5 * 1024 * 1024) };
+		mockExportFamilyData.mockResolvedValue(data);
+		const res = await GET(makeEvent(true));
+		expect(res.status).toBe(400);
+	});
+});

--- a/tests/unit/routes/ocr-receipt-6mb-request-guard.test.ts
+++ b/tests/unit/routes/ocr-receipt-6mb-request-guard.test.ts
@@ -10,6 +10,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mockOcrReceipt = vi.fn();
 vi.mock('$lib/server/services/receipt-ocr-service', () => ({
 	ocrReceipt: (...args: unknown[]) => mockOcrReceipt(...args),
+	// #3775 ②: route が受理上限定数を service から import するようになったため mock でも提供する。
+	RECEIPT_MAX_IMAGE_BYTES: 5 * 1024 * 1024,
 }));
 vi.mock('$lib/server/security/magic-bytes', () => ({
 	validateBase64ImageMagicBytes: () => ({ valid: true }),

--- a/tests/unit/routes/receipt-note-runtime-limit.test.ts
+++ b/tests/unit/routes/receipt-note-runtime-limit.test.ts
@@ -1,0 +1,54 @@
+// tests/unit/routes/receipt-note-runtime-limit.test.ts
+// #3775 ②: 領収書撮影ボタンの note が「実効の受理上限」と一致することを保証する。
+//
+// 旧実装は静的 note「JPEG, PNG, WebP（5MB以下）」だったが、aws-prod では base64 JSON body が
+// Function URL 6MB request cap を超えないよう OCR route が ~4.1MB (実効値) で reject する。
+// 「5MB と書いてあるのに 4.5MB が弾かれる」UX 齟齬を防ぐため、note の表示 MB は
+// server が実際に reject する閾値 (resolveMaxBase64DecodedBytes → toDisplayMb) と一致させる。
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { POINTS_LABELS } from '../../../src/lib/domain/labels';
+import { resetEnvForTesting } from '../../../src/lib/runtime/env';
+import { resolveMaxBase64DecodedBytes } from '../../../src/lib/server/services/function-url-limit';
+import { toDisplayMb } from '../../../src/lib/server/services/import-limit';
+import { RECEIPT_MAX_IMAGE_BYTES } from '../../../src/lib/server/services/receipt-ocr-service';
+
+const originalFnName = process.env.AWS_LAMBDA_FUNCTION_NAME;
+
+function setMode(awsMode: boolean) {
+	if (awsMode) process.env.AWS_LAMBDA_FUNCTION_NAME = 'ganbari-quest-app';
+	else delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+	resetEnvForTesting();
+}
+
+afterEach(() => {
+	if (originalFnName === undefined) delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+	else process.env.AWS_LAMBDA_FUNCTION_NAME = originalFnName;
+	resetEnvForTesting();
+});
+
+describe('#3775 ② 領収書 note は実効受理上限と一致する', () => {
+	it('receiptCaptureButtonNote は maxMb を受ける関数で、画像形式と MB 表記を含む', () => {
+		const note = POINTS_LABELS.receiptCaptureButtonNote('4.1');
+		expect(typeof POINTS_LABELS.receiptCaptureButtonNote).toBe('function');
+		expect(note).toContain('JPEG');
+		expect(note).toContain('4.1MB');
+	});
+
+	it('aws-prod: note の MB = OCR route の実効 reject 閾値 (~4.1MB、静的 5MB ではない)', () => {
+		setMode(true);
+		const effectiveMb = toDisplayMb(resolveMaxBase64DecodedBytes(RECEIPT_MAX_IMAGE_BYTES));
+		expect(effectiveMb).toBeLessThan(5);
+		expect(effectiveMb).toBeCloseTo(4.1, 1);
+		// note が実効値を反映していること (5MB 固定でないこと)
+		expect(POINTS_LABELS.receiptCaptureButtonNote(String(effectiveMb))).toContain(
+			`${effectiveMb}MB`,
+		);
+	});
+
+	it('local / NUC: Function URL 制約なし — 実効上限は 5MB のまま', () => {
+		setMode(false);
+		const effectiveMb = toDisplayMb(resolveMaxBase64DecodedBytes(RECEIPT_MAX_IMAGE_BYTES));
+		expect(effectiveMb).toBe(5);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

家族データの JSON バックアップ (直ダウンロード) と領収書 OCR の 2 経路で、AWS 本番の Function URL 6MB cap に起因する「沈黙のダウンロード不能 / 実効値と乖離した表示」を根絶する。#3770 (function-url-limit 6MB SSOT) の QM Tier2 で検出した non-blocking 残余 2 件を同 SSOT に整合させて塞ぐ。

## 関連 Issue

- closes #3775
- 由来: #3770 / #3694 (payload 6MB 整合) / #3325 (import-limit)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | JSON export (format=json 既定) に 6MB response guard 追加。aws-prod で実効上限超は 400 + クラウド共有導線、NUC/local は直 DL | `npx vitest run tests/unit/routes/export-json-6mb-response-guard.test.ts` | HEAD `cae28530` / 4 passed / `src/routes/api/v1/export/+server.ts:58-72` (Buffer.byteLength で byte 長判定) |
| AC2 | OCR note 静的「5MB以下」を実効 reject 閾値と同期 (aws-prod ~4.1MB / NUC・local 5MB) | `npx vitest run tests/unit/routes/receipt-note-runtime-limit.test.ts` | HEAD `cae28530` / 3 passed / `receiptCaptureButtonNote` 関数化 (labels.ts) + admin/points load で解決 |
| AC3 (info) | export guard 閾値精度 (実効境界の直接固定) | 対応方針明記のみ (本 PR scope 外) | function-url-limit.test.ts の fitness (定数 pin) で二重防御済。AWS_EFFECTIVE_PAYLOAD_BYTES±1 直接固定は本 PR 対象外 (low, info) |

## 変更タイプ

- [x] バグ修正 (fix)
- [ ] 新機能 (feat)
- [ ] リファクタリング
- [x] ドキュメント (設計書同期)

## 影響範囲・変更コンポーネント

- `src/routes/api/v1/export/+server.ts` — JSON path に response 6MB guard 追加 (①)
- `src/lib/domain/labels.ts` — `dataExportJsonTooLargeForDirectDownload` 追加 / `receiptCaptureButtonNote` を関数化 (②)
- `src/lib/server/services/receipt-ocr-service.ts` — `RECEIPT_MAX_IMAGE_BYTES` を SSOT 集約
- `src/routes/api/v1/points/ocr-receipt/+server.ts` — local const → 共有定数へ
- `src/routes/(parent)/admin/points/+page.server.ts` / `+page.svelte` — load で実効 MB 解決 → note に注入
- `docs/design/07-API設計書.md` — §GET /api/v1/export + §POST ocr-receipt 同期

## テスト & 安全装置セルフチェック

- [x] failing-test-first (ADR-0061): 両 test を先に赤で確認 → 実装で緑
- [x] `export-json-6mb-response-guard.test.ts` (4) + `receipt-note-runtime-limit.test.ts` (3) 追加
- [x] 既存 `ocr-receipt-6mb-request-guard.test.ts` mock に新定数追加 (回帰保護維持、assertion 弱体化なし)
- [x] `tests/unit/routes/` 全 55 file / 449 tests green
- [x] biome check / cspell / svelte-check (変更 src 0 error) PASS

## スクリーンショット / ビジュアルデモ

領収書撮影ボタンの note を `receiptCaptureButtonNote(maxMb)` に関数化し、server load が解決する実効受理上限を表示する。**本番 (aws-prod runtime) では note の文言が「5MB以下」→「4.1MB以下」に変化する**（Function URL 6MB request cap を base64 逆算した実効値。local / NUC は制約なしのため 5MB のまま）。これは本 PR が意図した可視の成果であり「UI 実描画変更なし」ではない。

撮影は `APP_MODE=aws-prod AUTH_MODE=anonymous DATA_SOURCE=demo` の preview server で本番ルート `/admin/points` を描画し、領収書タブを選択して note を表示させた実画面。修正前 = develop（静的「5MB以下」）／修正後 = 本 PR（aws-prod 実効「4.1MB以下」）を**同一 aws-prod runtime で撮影**し、before/after の blob SHA が相異することを確認済（#2063 偽装防止）。表示ロジックは unit test (`receipt-note-runtime-limit.test.ts`) で aws-prod ~4.1MB / local 5MB を機械検証。

### Desktop

| 修正前 (develop, 静的「5MB以下」) | 修正後 (本 PR, aws-prod 実効「4.1MB以下」) |
|---|---|
| ![before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3789/admin-points-receipt-note-before-desktop.png) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3789/admin-points-receipt-note-after-desktop.png) |

[DOM HTML (before-desktop.dom.html)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3789/admin-points-receipt-note-before-desktop.dom.html) ／ [DOM HTML (after-desktop.dom.html)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3789/admin-points-receipt-note-after-desktop.dom.html)

### Mobile

| 修正前 (develop, 静的「5MB以下」) | 修正後 (本 PR, aws-prod 実効「4.1MB以下」) |
|---|---|
| ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3789/admin-points-receipt-note-before-mobile.png) | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3789/admin-points-receipt-note-after-mobile.png) |

[DOM HTML (before-mobile.dom.html)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3789/admin-points-receipt-note-before-mobile.dom.html) ／ [DOM HTML (after-mobile.dom.html)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3789/admin-points-receipt-note-after-mobile.dom.html)

## コード品質セルフレビュー (#1481)

- [x] MAX_IMAGE_SIZE の二重定義を `RECEIPT_MAX_IMAGE_BYTES` SSOT に集約 (route reject 判定と note 表示を同一値から導出)
- [x] JSON body は char 長でなく `Buffer.byteLength(jsonStr, 'utf-8')` で byte 長判定 (マルチバイト JP 対応)
- [x] JSON は画像・音声を含まないため ZIP と別文言 (`dataExportJsonTooLargeForDirectDownload`)

## 横展開・影響波及チェック

- [x] 4 経路 (import ZIP / export ZIP / OCR base64 / export JSON) の SSOT = `function-url-limit.ts` に整合。JSON export が第 4 経路残余
- [x] `receiptCaptureButtonNote` の全 callsite (admin/points 1 箇所) を関数呼び出しに更新、grep 0 件残存
- [x] labels.ts SSOT companion (generate-lp-labels / sync-lp-fallback) pre-commit PASS

## レビュー依頼事項・破壊的変更

破壊的変更なし。`receiptCaptureButtonNote` を文字列 → 関数化したが唯一の callsite を同 PR で更新済。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (biome / cspell / svelte-check / vitest 該当 step)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了のまま残した AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み (N/A)
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 (N/A — DOM 不変、表示値のみ)
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付 (N/A — 認証画面非該当)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言、QM approve 待ち)

## QM レビュー結果

[QM 5 手順 approve body は docs/sessions/qa-session.md を参照](../docs/sessions/qa-session.md)

