### PR TITLE
fix(data-integrity): #3782 evaluations DB unique backstop + #3781 childVoices dangling fail-closed (restore hardening)

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -586,6 +586,8 @@ checklist_templates.kind 列削除（持ち物純化）と引き換えに、活�
 | bonus_points | INTEGER | NO | 0 | ボーナスポイント |
 | created_at | TEXT | NO | CURRENT_TIMESTAMP | 作成日時 |
 
+**ユニーク制約:** idx_evaluations_child_week(child_id, week_start)（#3782、「1子1週1評価」の自然キーを兄弟表 rest_days / login_bonuses / stamp_cards と同型に DB 層で物理一意化。DSQL は `evaluations_week_uq` droppable UNIQUE。service 層 dedup を経由しない別 insert 経路・並行 import の重複を canonical guard で拒否、ADR-0061 push-down-pyramid）
+
 **scores_json 例:**
 ```json
 {
@@ -2020,7 +2022,10 @@ export const evaluations = sqliteTable('evaluations', {
   scoresJson: text('scores_json').notNull(),
   bonusPoints: integer('bonus_points').notNull().default(0),
   createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-});
+}, (table) => [
+  // #3782: 「1子1週1評価」の自然キーを物理一意化（DSQL は evaluations_week_uq droppable UNIQUE）
+  uniqueIndex('idx_evaluations_child_week').on(table.childId, table.weekStart),
+]);
 
 export const marketBenchmarks = sqliteTable('market_benchmarks', {
   id: integer('id').primaryKey({ autoIncrement: true }),

--- a/drizzle/pglite/0002_evaluations_week_unique.sql
+++ b/drizzle/pglite/0002_evaluations_week_unique.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "evaluations_week_uq" ON "evaluations" USING btree ("family_id","child_id","week_start");

--- a/drizzle/pglite/meta/0002_snapshot.json
+++ b/drizzle/pglite/meta/0002_snapshot.json
@@ -1,0 +1,4941 @@
+{
+  "id": "7d3f1a2c-0e5b-4c9a-9f21-3b8e6a1d40f2",
+  "prevId": "65b942b7-90ef-44bd-9b86-7f46dd637603",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_lifecycle": {
+      "name": "account_lifecycle",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "soft_deleted_at": {
+          "name": "soft_deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grace_plan_tier": {
+          "name": "grace_plan_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purge_scheduled_date": {
+          "name": "purge_scheduled_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "account_lifecycle_family_id_pk": {
+          "name": "account_lifecycle_family_id_pk",
+          "columns": [
+            "family_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "streak_days": {
+          "name": "streak_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "streak_bonus": {
+          "name": "streak_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recorded_date": {
+          "name": "recorded_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "activity_logs_family_id_child_id_log_id_pk": {
+          "name": "activity_logs_family_id_child_id_log_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "log_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_mastery": {
+      "name": "activity_mastery",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "activity_mastery_family_id_child_id_activity_id_pk": {
+          "name": "activity_mastery_family_id_child_id_activity_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "activity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_policy": {
+      "name": "approval_policy",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_approve": {
+          "name": "auto_approve",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "approval_policy_family_id_pk": {
+          "name": "approval_policy_family_id_pk",
+          "columns": [
+            "family_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bonus_rules": {
+      "name": "bonus_rules",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "condition_type": {
+          "name": "condition_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_config": {
+          "name": "trigger_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bonus_points": {
+          "name": "bonus_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "bonus_rules_family_id_rule_id_pk": {
+          "name": "bonus_rules_family_id_rule_id_pk",
+          "columns": [
+            "family_id",
+            "rule_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cancellation_reasons": {
+      "name": "cancellation_reasons",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_id": {
+          "name": "reason_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "free_text": {
+          "name": "free_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_at_cancellation": {
+          "name": "plan_at_cancellation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cancellation_reasons_family_id_reason_id_pk": {
+          "name": "cancellation_reasons_family_id_reason_id_pk",
+          "columns": [
+            "family_id",
+            "reason_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "categories_code_pk": {
+          "name": "categories_code_pk",
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificates": {
+      "name": "certificates",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificate_id": {
+          "name": "certificate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "certificate_type": {
+          "name": "certificate_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "certificates_family_id_child_id_certificate_id_pk": {
+          "name": "certificates_family_id_child_id_certificate_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "certificate_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_images": {
+      "name": "character_images",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "character_images_family_id_child_id_image_id_pk": {
+          "name": "character_images_family_id_child_id_image_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "image_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_logs": {
+      "name": "checklist_logs",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_date": {
+          "name": "checked_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "items_json": {
+          "name": "items_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "completed_all": {
+          "name": "completed_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "points_awarded": {
+          "name": "points_awarded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "checklist_logs_family_id_child_id_template_id_checked_date_pk": {
+          "name": "checklist_logs_family_id_child_id_template_id_checked_date_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "template_id",
+            "checked_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_overrides": {
+      "name": "checklist_overrides",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_id": {
+          "name": "override_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'📦'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "checklist_overrides_family_id_child_id_override_id_pk": {
+          "name": "checklist_overrides_family_id_child_id_override_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "override_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "checklist_overrides_action_ck": {
+          "name": "checklist_overrides_action_ck",
+          "value": "\"checklist_overrides\".\"action\" IN ('add', 'remove')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.checklist_template_assignments": {
+      "name": "checklist_template_assignments",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "checklist_template_assignments_child_idx": {
+          "name": "checklist_template_assignments_child_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "checklist_template_assignments_family_id_template_id_child_id_pk": {
+          "name": "checklist_template_assignments_family_id_template_id_child_id_pk",
+          "columns": [
+            "family_id",
+            "template_id",
+            "child_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_template_items": {
+      "name": "checklist_template_items",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'🏫'"
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bring'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "checklist_template_items_family_id_template_id_item_id_pk": {
+          "name": "checklist_template_items_family_id_template_id_item_id_pk",
+          "columns": [
+            "family_id",
+            "template_id",
+            "item_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_templates": {
+      "name": "checklist_templates",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'📋'"
+        },
+        "points_per_item": {
+          "name": "points_per_item",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "completion_bonus": {
+          "name": "completion_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'anytime'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_reason": {
+          "name": "archived_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_preset_id": {
+          "name": "source_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "checklist_templates_family_id_template_id_pk": {
+          "name": "checklist_templates_family_id_template_id_pk",
+          "columns": [
+            "family_id",
+            "template_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "checklist_templates_time_slot_ck": {
+          "name": "checklist_templates_time_slot_ck",
+          "value": "\"checklist_templates\".\"time_slot\" IN ('morning', 'afternoon', 'evening', 'anytime')"
+        },
+        "checklist_templates_archived_reason_ck": {
+          "name": "checklist_templates_archived_reason_ck",
+          "value": "\"checklist_templates\".\"archived_reason\" IN ('trial_expired', 'downgrade_user_selected', 'dunning_canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.child_activities": {
+      "name": "child_activities",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_points": {
+          "name": "base_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'seed'"
+        },
+        "name_kana": {
+          "name": "name_kana",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_kanji": {
+          "name": "name_kanji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_hint": {
+          "name": "trigger_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main_quest": {
+          "name": "is_main_quest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_reason": {
+          "name": "archived_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_preset_id": {
+          "name": "source_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'optional'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "child_activities_family_id_child_id_activity_id_pk": {
+          "name": "child_activities_family_id_child_id_activity_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "activity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "child_activities_priority_ck": {
+          "name": "child_activities_priority_ck",
+          "value": "\"child_activities\".\"priority\" IN ('must', 'optional')"
+        },
+        "child_activities_archived_reason_ck": {
+          "name": "child_activities_archived_reason_ck",
+          "value": "\"child_activities\".\"archived_reason\" IN ('trial_expired', 'downgrade_user_selected', 'dunning_canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.child_activity_preferences": {
+      "name": "child_activity_preferences",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pin_order": {
+          "name": "pin_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "child_activity_preferences_family_id_child_id_activity_id_pk": {
+          "name": "child_activity_preferences_family_id_child_id_activity_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "activity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_challenges": {
+      "name": "child_challenges",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cooperative'"
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'weekly'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_config": {
+          "name": "target_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_config": {
+          "name": "reward_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source_template_id": {
+          "name": "source_template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "target_value": {
+          "name": "target_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_claimed": {
+          "name": "reward_claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reward_claimed_at": {
+          "name": "reward_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "weekly_auto_guard": {
+          "name": "weekly_auto_guard",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN source_template_id = 'auto:weekly' THEN (child_id::text || ':' || start_date) ELSE NULL END",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "child_challenges_status_idx": {
+          "name": "child_challenges_status_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "child_challenges_family_id_child_id_challenge_id_pk": {
+          "name": "child_challenges_family_id_child_id_challenge_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "challenge_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "child_challenges_weekly_auto_guard_unique": {
+          "name": "child_challenges_weekly_auto_guard_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "weekly_auto_guard"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "child_challenges_status_ck": {
+          "name": "child_challenges_status_ck",
+          "value": "\"child_challenges\".\"status\" IN ('active', 'completed', 'expired')"
+        },
+        "child_challenges_period_type_ck": {
+          "name": "child_challenges_period_type_ck",
+          "value": "\"child_challenges\".\"period_type\" IN ('weekly', 'monthly', 'custom')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.child_custom_voices": {
+      "name": "child_custom_voices",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voice_id": {
+          "name": "voice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scene": {
+          "name": "scene",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_url": {
+          "name": "public_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "child_custom_voices_family_id_child_id_voice_id_pk": {
+          "name": "child_custom_voices_family_id_child_id_voice_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "voice_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.children": {
+      "name": "children",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pink'"
+        },
+        "ui_mode": {
+          "name": "ui_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preschool'"
+        },
+        "ui_mode_manually_set": {
+          "name": "ui_mode_manually_set",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_config": {
+          "name": "display_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday_bonus_multiplier": {
+          "name": "birthday_bonus_multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_birthday_bonus_year": {
+          "name": "last_birthday_bonus_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_point": {
+          "name": "total_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_reason": {
+          "name": "archived_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "children_family_id_child_id_pk": {
+          "name": "children_family_id_child_id_pk",
+          "columns": [
+            "family_id",
+            "child_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "children_ui_mode_ck": {
+          "name": "children_ui_mode_ck",
+          "value": "\"children\".\"ui_mode\" IN ('baby', 'preschool', 'elementary', 'junior', 'senior')"
+        },
+        "children_theme_ck": {
+          "name": "children_theme_ck",
+          "value": "\"children\".\"theme\" IN ('pink', 'blue', 'green', 'orange', 'purple')"
+        },
+        "children_archived_reason_ck": {
+          "name": "children_archived_reason_ck",
+          "value": "\"children\".\"archived_reason\" IN ('trial_expired', 'downgrade_user_selected', 'dunning_canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cloud_exports": {
+      "name": "cloud_exports",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "export_id": {
+          "name": "export_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "export_type": {
+          "name": "export_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin_code": {
+          "name": "pin_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_downloads": {
+          "name": "max_downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "build_started_at": {
+          "name": "build_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cloud_exports_status_idx": {
+          "name": "cloud_exports_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cloud_exports_family_id_export_id_pk": {
+          "name": "cloud_exports_family_id_export_id_pk",
+          "columns": [
+            "family_id",
+            "export_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "cloud_exports_pin_code_unique": {
+          "name": "cloud_exports_pin_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pin_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "cloud_exports_status_ck": {
+          "name": "cloud_exports_status_ck",
+          "value": "\"cloud_exports\".\"status\" IN ('pending', 'building', 'ready', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "consent_id": {
+          "name": "consent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "consents_family_type_at_idx": {
+          "name": "consents_family_type_at_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consented_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "consents_consent_id_pk": {
+          "name": "consents_consent_id_pk",
+          "columns": [
+            "consent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "consents_type_ck": {
+          "name": "consents_type_ck",
+          "value": "\"consents\".\"type\" IN ('terms', 'privacy')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_battles": {
+      "name": "daily_battles",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enemy_id": {
+          "name": "enemy_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_points": {
+          "name": "reward_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "turns_used": {
+          "name": "turns_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "player_stats_json": {
+          "name": "player_stats_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_battles_family_id_child_id_date_pk": {
+          "name": "daily_battles_family_id_child_id_date_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "daily_battles_status_ck": {
+          "name": "daily_battles_status_ck",
+          "value": "\"daily_battles\".\"status\" IN ('pending', 'completed')"
+        },
+        "daily_battles_outcome_ck": {
+          "name": "daily_battles_outcome_ck",
+          "value": "\"daily_battles\".\"outcome\" IN ('win', 'lose')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.daily_missions": {
+      "name": "daily_missions",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mission_date": {
+          "name": "mission_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_missions_family_id_child_id_mission_date_activity_id_pk": {
+          "name": "daily_missions_family_id_child_id_mission_date_activity_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "mission_date",
+            "activity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.decay_policy": {
+      "name": "decay_policy",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intensity": {
+          "name": "intensity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "grace_days": {
+          "name": "grace_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "decay_policy_family_id_pk": {
+          "name": "decay_policy_family_id_pk",
+          "columns": [
+            "family_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_login_lockouts": {
+      "name": "email_login_lockouts",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_attempts": {
+          "name": "failed_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "email_login_lockouts_email_pk": {
+          "name": "email_login_lockouts_email_pk",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enemy_collection": {
+      "name": "enemy_collection",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enemy_id": {
+          "name": "enemy_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_defeated_at": {
+          "name": "first_defeated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "defeat_count": {
+          "name": "defeat_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "enemy_collection_family_id_child_id_enemy_id_pk": {
+          "name": "enemy_collection_family_id_child_id_enemy_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "enemy_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluations": {
+      "name": "evaluations",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eval_id": {
+          "name": "eval_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_end": {
+          "name": "week_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores_json": {
+          "name": "scores_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bonus_points": {
+          "name": "bonus_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evaluations_week_uq": {
+          "name": "evaluations_week_uq",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "evaluations_family_id_child_id_eval_id_pk": {
+          "name": "evaluations_family_id_child_id_eval_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "eval_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.families": {
+      "name": "families",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_expires_at": {
+          "name": "plan_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_used_at": {
+          "name": "trial_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "families_family_id_pk": {
+          "name": "families_family_id_pk",
+          "columns": [
+            "family_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "families_stripe_customer_id_unique": {
+          "name": "families_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "families_status_ck": {
+          "name": "families_status_ck",
+          "value": "\"families\".\"status\" IN ('active', 'grace_period', 'suspended', 'terminated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.graduation_consent": {
+      "name": "graduation_consent",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_id": {
+          "name": "consent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consented": {
+          "name": "consented",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_points": {
+          "name": "user_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usage_period_days": {
+          "name": "usage_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "graduation_consent_public_idx": {
+          "name": "graduation_consent_public_idx",
+          "columns": [
+            {
+              "expression": "consented",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consented_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "graduation_consent_family_id_consent_id_pk": {
+          "name": "graduation_consent_family_id_consent_id_pk",
+          "columns": [
+            "family_id",
+            "consent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inquiries": {
+      "name": "inquiries",
+      "schema": "",
+      "columns": {
+        "inquiry_id": {
+          "name": "inquiry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_email": {
+          "name": "reply_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "inquiries_inquiry_id_pk": {
+          "name": "inquiries_inquiry_id_pk",
+          "columns": [
+            "inquiry_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "inquiries_status_ck": {
+          "name": "inquiries_status_ck",
+          "value": "\"inquiries\".\"status\" IN ('open', 'replied', 'closed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_family_id_idx": {
+          "name": "invites_family_id_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "invites_invite_id_pk": {
+          "name": "invites_invite_id_pk",
+          "columns": [
+            "invite_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_status_ck": {
+          "name": "invites_status_ck",
+          "value": "\"invites\".\"status\" IN ('pending', 'accepted', 'revoked', 'expired')"
+        },
+        "invites_role_ck": {
+          "name": "invites_role_ck",
+          "value": "\"invites\".\"role\" IN ('owner', 'parent', 'child')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.login_bonuses": {
+      "name": "login_bonuses",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login_date": {
+          "name": "login_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_points": {
+          "name": "base_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multiplier": {
+          "name": "multiplier",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "total_points": {
+          "name": "total_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_days": {
+          "name": "consecutive_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "login_bonuses_family_id_child_id_login_date_pk": {
+          "name": "login_bonuses_family_id_child_id_login_date_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "login_date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loyalty_state": {
+      "name": "loyalty_state",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "continuation_months": {
+          "name": "continuation_months",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "memento_tickets": {
+          "name": "memento_tickets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_granted_month": {
+          "name": "last_granted_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "loyalty_state_family_id_pk": {
+          "name": "loyalty_state_family_id_pk",
+          "columns": [
+            "family_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.market_benchmarks": {
+      "name": "market_benchmarks",
+      "schema": "",
+      "columns": {
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mean": {
+          "name": "mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "std_dev": {
+          "name": "std_dev",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "market_benchmarks_age_category_id_pk": {
+          "name": "market_benchmarks_age_category_id_pk",
+          "columns": [
+            "age",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_guard": {
+          "name": "owner_guard",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "CASE WHEN role = 'owner' THEN family_id END",
+            "type": "stored"
+          }
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_user_id_idx": {
+          "name": "memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "memberships_family_id_user_id_pk": {
+          "name": "memberships_family_id_user_id_pk",
+          "columns": [
+            "family_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "memberships_owner_guard_unique": {
+          "name": "memberships_owner_guard_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner_guard"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "memberships_role_ck": {
+          "name": "memberships_role_ck",
+          "value": "\"memberships\".\"role\" IN ('owner', 'parent', 'child')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notification_logs": {
+      "name": "notification_logs",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_logs_family_id_log_id_pk": {
+          "name": "notification_logs_family_id_log_id_pk",
+          "columns": [
+            "family_id",
+            "log_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_enabled": {
+          "name": "reminder_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reminder_time": {
+          "name": "reminder_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_enabled": {
+          "name": "consecutive_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "quiet_hours": {
+          "name": "quiet_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "notification_settings_family_id_pk": {
+          "name": "notification_settings_family_id_pk",
+          "columns": [
+            "family_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_gate_credentials": {
+      "name": "parent_gate_credentials",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pin_hash": {
+          "name": "pin_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_attempts": {
+          "name": "failed_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_trace": {
+          "name": "reset_trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "parent_gate_credentials_family_id_pk": {
+          "name": "parent_gate_credentials_family_id_pk",
+          "columns": [
+            "family_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_messages": {
+      "name": "parent_messages",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "msg_id": {
+          "name": "msg_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stamp_code": {
+          "name": "stamp_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'💌'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bonus_points": {
+          "name": "bonus_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_category": {
+          "name": "reward_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "parent_messages_family_id_child_id_msg_id_pk": {
+          "name": "parent_messages_family_id_child_id_msg_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "msg_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "parent_messages_message_type_ck": {
+          "name": "parent_messages_message_type_ck",
+          "value": "\"parent_messages\".\"message_type\" IN ('stamp', 'text', 'reward_notice')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.plan_tiers": {
+      "name": "plan_tiers",
+      "schema": "",
+      "columns": {
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grace_days": {
+          "name": "grace_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plan_tiers_plan_tier_pk": {
+          "name": "plan_tiers_plan_tier_pk",
+          "columns": [
+            "plan_tier"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "plan_code": {
+          "name": "plan_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plans_plan_code_pk": {
+          "name": "plans_plan_code_pk",
+          "columns": [
+            "plan_code"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_conversion_policy": {
+      "name": "point_conversion_policy",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_mode": {
+          "name": "unit_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'point'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'JPY'"
+        },
+        "conversion_rate": {
+          "name": "conversion_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "point_conversion_policy_family_id_pk": {
+          "name": "point_conversion_policy_family_id_pk",
+          "columns": [
+            "family_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_ledger": {
+      "name": "point_ledger",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ledger_id": {
+          "name": "ledger_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_date": {
+          "name": "recorded_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "point_ledger_type_date_idx": {
+          "name": "point_ledger_type_date_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "point_ledger_idempotency_uq": {
+          "name": "point_ledger_idempotency_uq",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "point_ledger_family_id_child_id_ledger_id_pk": {
+          "name": "point_ledger_family_id_child_id_ledger_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "ledger_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_p256dh": {
+          "name": "keys_p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keys_auth": {
+          "name": "keys_auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriber_role": {
+          "name": "subscriber_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'parent'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "push_subscriptions_family_id_subscription_id_pk": {
+          "name": "push_subscriptions_family_id_subscription_id_pk",
+          "columns": [
+            "family_id",
+            "subscription_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rest_days": {
+      "name": "rest_days",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rest'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rest_days_family_id_child_id_date_pk": {
+          "name": "rest_days_family_id_child_id_date_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_redemption_requests": {
+      "name": "reward_redemption_requests",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redemption_id": {
+          "name": "redemption_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_id": {
+          "name": "reward_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_parent_approval'"
+        },
+        "parent_note": {
+          "name": "parent_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_parent_id": {
+          "name": "resolved_by_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shown_to_child_at": {
+          "name": "shown_to_child_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_title": {
+          "name": "reward_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_points": {
+          "name": "reward_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_icon": {
+          "name": "reward_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "redemption_child_status_idx": {
+          "name": "redemption_child_status_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "redemption_status_requested_idx": {
+          "name": "redemption_status_requested_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reward_redemption_requests_family_id_redemption_id_pk": {
+          "name": "reward_redemption_requests_family_id_redemption_id_pk",
+          "columns": [
+            "family_id",
+            "redemption_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reward_redemption_requests_status_ck": {
+          "name": "reward_redemption_requests_status_ck",
+          "value": "\"reward_redemption_requests\".\"status\" IN ('pending_parent_approval', 'approved', 'rejected', 'expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "settings_family_id_key_pk": {
+          "name": "settings_family_id_key_pk",
+          "columns": [
+            "family_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sibling_cheers": {
+      "name": "sibling_cheers",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cheer_id": {
+          "name": "cheer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_child_id": {
+          "name": "from_child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_child_id": {
+          "name": "to_child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stamp_code": {
+          "name": "stamp_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sibling_cheers_to_shown_idx": {
+          "name": "sibling_cheers_to_shown_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "shown_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sibling_cheers_family_id_cheer_id_pk": {
+          "name": "sibling_cheers_family_id_cheer_id_pk",
+          "columns": [
+            "family_id",
+            "cheer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.special_rewards": {
+      "name": "special_rewards",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_id": {
+          "name": "reward_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_preset_id": {
+          "name": "source_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shop_category": {
+          "name": "shop_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "special_rewards_granted_idx": {
+          "name": "special_rewards_granted_idx",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "granted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "special_rewards_family_id_child_id_reward_id_pk": {
+          "name": "special_rewards_family_id_child_id_reward_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "reward_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stamp_cards": {
+      "name": "stamp_cards",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_end": {
+          "name": "week_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'collecting'"
+        },
+        "redeemed_points": {
+          "name": "redeemed_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stamp_cards_family_id_child_id_card_id_pk": {
+          "name": "stamp_cards_family_id_child_id_card_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "stamp_cards_week_uq": {
+          "name": "stamp_cards_week_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "family_id",
+            "child_id",
+            "week_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "stamp_cards_status_ck": {
+          "name": "stamp_cards_status_ck",
+          "value": "\"stamp_cards\".\"status\" IN ('collecting', 'redeemable', 'redeemed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stamp_entries": {
+      "name": "stamp_entries",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stamp_master_id": {
+          "name": "stamp_master_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "omikuji_rank": {
+          "name": "omikuji_rank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_date": {
+          "name": "login_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stamp_entries_family_id_card_id_slot_pk": {
+          "name": "stamp_entries_family_id_card_id_slot_pk",
+          "columns": [
+            "family_id",
+            "card_id",
+            "slot"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "stamp_entries_daily_uq": {
+          "name": "stamp_entries_daily_uq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "family_id",
+            "card_id",
+            "login_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stamp_masters": {
+      "name": "stamp_masters",
+      "schema": "",
+      "columns": {
+        "stamp_code": {
+          "name": "stamp_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stamp_masters_stamp_code_pk": {
+          "name": "stamp_masters_stamp_code_pk",
+          "columns": [
+            "stamp_code"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.status_history": {
+      "name": "status_history",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hist_id": {
+          "name": "hist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_amount": {
+          "name": "change_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "status_history_family_id_child_id_category_id_hist_id_pk": {
+          "name": "status_history_family_id_child_id_category_id_hist_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "category_id",
+            "hist_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.statuses": {
+      "name": "statuses",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_xp": {
+          "name": "total_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "peak_xp": {
+          "name": "peak_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "statuses_family_id_child_id_category_id_pk": {
+          "name": "statuses_family_id_child_id_category_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "handler_result": {
+          "name": "handler_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "stripe_webhook_events_processed_at_idx": {
+          "name": "stripe_webhook_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_webhook_events_type_result_idx": {
+          "name": "stripe_webhook_events_type_result_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handler_result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stripe_webhook_events_event_id_pk": {
+          "name": "stripe_webhook_events_event_id_pk",
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trial_history": {
+      "name": "trial_history",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trial_id": {
+          "name": "trial_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upgrade_reason": {
+          "name": "upgrade_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_start_source": {
+          "name": "trial_start_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "trial_history_family_id_trial_id_pk": {
+          "name": "trial_history_family_id_trial_id_pk",
+          "columns": [
+            "family_id",
+            "trial_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_logs": {
+      "name": "usage_logs",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "usage_logs_family_id_child_id_log_id_pk": {
+          "name": "usage_logs_family_id_child_id_log_id_pk",
+          "columns": [
+            "family_id",
+            "child_id",
+            "log_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_lower": {
+          "name": "email_lower",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "lower(email)",
+            "type": "stored"
+          }
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_user_id_pk": {
+          "name": "users_user_id_pk",
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_lower_unique": {
+          "name": "users_email_lower_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_lower"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_provider_ck": {
+          "name": "users_provider_ck",
+          "value": "\"users\".\"provider\" IN ('cognito')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.viewer_tokens": {
+      "name": "viewer_tokens",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "viewer_tokens_family_id_token_id_pk": {
+          "name": "viewer_tokens_family_id_token_id_pk",
+          "columns": [
+            "family_id",
+            "token_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "viewer_tokens_token_unique": {
+          "name": "viewer_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/pglite/meta/_journal.json
+++ b/drizzle/pglite/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1784100586276,
       "tag": "0001_overrated_roland_deschain",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784500000000,
+      "tag": "0002_evaluations_week_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/create-tables.ts
+++ b/src/lib/server/db/create-tables.ts
@@ -169,6 +169,9 @@ export const SQL_CREATE_TABLES = `
 		bonus_points INTEGER NOT NULL DEFAULT 0,
 		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 	);
+	-- #3782: 1子1週1評価の自然キー物理一意化 (fresh DB は create-tables、既存 DB は lazy-startup-migrations で dedup→index)
+	CREATE UNIQUE INDEX IF NOT EXISTS idx_evaluations_child_week
+		ON evaluations(child_id, week_start);
 
 	CREATE TABLE IF NOT EXISTS market_benchmarks (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/lib/server/db/dsql/evaluation-repo.ts
+++ b/src/lib/server/db/dsql/evaluation-repo.ts
@@ -106,13 +106,32 @@ export function createDsqlEvaluationRepo<TTx extends SqlExecutor>(
 		async insertEvaluation(input, tenantId) {
 			// scores_json は verbatim text 据置 (子表化しない、§4.2)。
 			// #3355: created_at は backup restore が渡した値を保全 (省略時は DB default = now)。
+			// #3782: eval_id は random UUID surrogate のため PK は衝突しないが、week UNIQUE
+			// (evaluations_week_uq、family_id/child_id/week_start) への ON CONFLICT DO NOTHING で
+			// 「1週1評価」を冪等化する (stamp_cards insertCard と同型)。並行 insert / restore backstop
+			// でも二重行を作らず、conflict 時は既存行を返す。
 			const result = await db.execute(sql`
 				INSERT INTO evaluations (family_id, child_id, week_start, week_end, scores_json, bonus_points, created_at)
 				VALUES (${tenantId}, ${input.childId}, ${input.weekStart}, ${input.weekEnd},
 					${input.scoresJson}, ${input.bonusPoints}, ${input.createdAt ?? sql`DEFAULT`})
+				ON CONFLICT (family_id, child_id, week_start) DO NOTHING
 				RETURNING ${EVALUATION_COLUMNS}
 			`);
-			return toEvaluation(result.rows[0] as unknown as EvaluationRow);
+			const inserted = result.rows[0] as unknown as EvaluationRow | undefined;
+			if (inserted) return toEvaluation(inserted);
+			// conflict = 同 (family, child, week) 行が既存。既存行を返す (throw しない)。
+			const existing = await db.execute(sql`
+				SELECT ${EVALUATION_COLUMNS} FROM evaluations
+				WHERE family_id = ${tenantId} AND child_id = ${input.childId}
+					AND week_start = ${input.weekStart}
+				LIMIT 1
+			`);
+			const existingRow = existing.rows[0] as unknown as EvaluationRow | undefined;
+			if (existingRow) return toEvaluation(existingRow);
+			// 到達しない (conflict した = 既存行あり)。型安全 (Evaluation 非 null) のため明示。
+			throw new Error(
+				`insertEvaluation: conflict without existing row (child=${input.childId}, week=${input.weekStart})`,
+			);
 		},
 
 		async findAllChildren(tenantId): Promise<Child[]> {

--- a/src/lib/server/db/dsql/schema.ts
+++ b/src/lib/server/db/dsql/schema.ts
@@ -558,7 +558,14 @@ export const evaluations = pgTable(
 			.notNull()
 			.defaultNow(),
 	},
-	(t) => [primaryKey({ columns: [t.familyId, t.childId, t.evalId] })],
+	(t) => [
+		primaryKey({ columns: [t.familyId, t.childId, t.evalId] }),
+		// #3782: eval_id は random UUID surrogate のため PK だけでは (child, weekStart) 重複を許容する。
+		// 「1子1週1評価」を droppable UNIQUE で維持 (stamp_cards_week_uq と同型。将来 seasonal 多重評価が
+		// 必要になれば index を DROP するだけで PK 不変)。service 層 dedup (#3355) の canonical backstop
+		// (ADR-0061 push-down-pyramid)。async index build は transform.ts が CREATE UNIQUE INDEX ASYNC へ変換。
+		uniqueIndex('evaluations_week_uq').on(t.familyId, t.childId, t.weekStart),
+	],
 );
 
 // rest_days — おやすみ日 (自然複合 PK 昇格、anchor (a) ADR-0012: 1日1回 = policy invariant §11.2)。

--- a/src/lib/server/db/migration/lazy-startup-migrations.ts
+++ b/src/lib/server/db/migration/lazy-startup-migrations.ts
@@ -231,6 +231,44 @@ function migratePointLedgerIdempotencyUnique(db: Database.Database): void {
 }
 
 /**
+ * #3782: evaluations に (child_id, week_start) unique index を追加。「1子1週1評価」の自然キーを
+ * 兄弟表 (rest_days / login_bonuses / stamp_cards) と同型に DB 層で物理一意化し、service 層
+ * pre-fetch dedup (#3355) を経由しない別 insert 経路・並行 import での重複行を canonical guard で
+ * 不可能化する (ADR-0061 push-down-pyramid)。
+ *
+ * 既存 production DB に重複行 (= service dedup 導入前の再取込 / 並行 insert の実痕跡) があると
+ * CREATE UNIQUE INDEX が失敗するため、先に dedup (各 (child_id, week_start) で最小 id を残し他を
+ * 削除。growth-book/reports が参照する評価は 1 週 1 枚が正で、重複は数値汚染そのもの) してから
+ * index を作成する (#3245 / #3284 と同パターン)。冪等: index 既存なら skip。
+ */
+function migrateEvaluationChildWeekUnique(db: Database.Database): void {
+	if (!tableExists(db, 'evaluations')) return;
+	if (indexExists(db, 'idx_evaluations_child_week')) return;
+
+	const run = db.transaction(() => {
+		const dedup = db
+			.prepare(`
+			DELETE FROM evaluations
+			WHERE id NOT IN (
+				SELECT MIN(id) FROM evaluations GROUP BY child_id, week_start
+			)
+		`)
+			.run();
+		if (dedup.changes > 0) {
+			console.info(
+				`[lazy-migrate #3782] deduped ${dedup.changes} duplicate (child, week) evaluations rows`,
+			);
+		}
+		db.exec(
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_evaluations_child_week
+			 ON evaluations(child_id, week_start);`,
+		);
+		console.info('[lazy-migrate #3782] created unique index for evaluations (child, week)');
+	});
+	run();
+}
+
+/**
  * #2362 PR-3 (Phase 7b-2a): activity 系テーブルの FK target を
  * 旧 `activities` から `child_activities` に切替。
  *
@@ -989,6 +1027,9 @@ export function applyLazyStartupMigrations(db: Database.Database): void {
 		// #3284: point_ledger に付与冪等キー (dedup → 部分 unique index)。#3245 と同パターンで
 		// child_challenges の直後・FK switchover の前に実行 (point_ledger は switchover 対象外)。
 		migratePointLedgerIdempotencyUnique(db);
+		// #3782: evaluations に (child, week) unique index (dedup → index)。evaluations は FK switchover
+		// 対象外だが、重複 dedup は他 dedup 群と同じ FK OFF window で実行するのが安全なため前段に置く。
+		migrateEvaluationChildWeekUnique(db);
 		migrateActivityFkSwitchover(db);
 		// #2510 / #2513: FK switchover (dim 3) の **後** に data copy (dim 4) を実行。
 		// FK target が child_activities になった後でないと remap が整合しないため順序固定。

--- a/src/lib/server/db/restore-idempotency.ts
+++ b/src/lib/server/db/restore-idempotency.ts
@@ -180,7 +180,7 @@ export const RESTORE_IDEMPOTENCY_REGISTRY: Record<string, RestoreIdempotencyEntr
 			demo: 'null-stub',
 		},
 		reason:
-			'音声 DB 行は filePath (uuid) が実質識別子で、静的ファイル復元 (#3077) と対で管理される。再取込複製は既知の制約 (backup 対象は同一 uuid path へ上書き復元されるため実害は DB 行の重複のみ)',
+			'音声 DB 行は filePath (uuid) が実質識別子で、静的ファイル復元 (#3077) と対で管理される。再取込複製は既知の制約 (backup 対象は同一 uuid path へ上書き復元されるため実害は DB 行の重複のみ)。#3781: import-service 層で DB 行↔本体ファイル (staticFiles) の相互整合を fail-closed 検証 — 本体を欠く行は insert せず skip + warning で dangling publicUrl を生まない',
 	},
 	restDay: {
 		kind: 'natural-key',

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -246,17 +246,25 @@ export const statusHistory = sqliteTable(
 // ============================================================
 // evaluations - 週次評価
 // ============================================================
-export const evaluations = sqliteTable('evaluations', {
-	id: integer('id').primaryKey({ autoIncrement: true }),
-	childId: integer('child_id')
-		.notNull()
-		.references(() => children.id),
-	weekStart: text('week_start').notNull(),
-	weekEnd: text('week_end').notNull(),
-	scoresJson: text('scores_json').notNull(),
-	bonusPoints: integer('bonus_points').notNull().default(0),
-	createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-});
+export const evaluations = sqliteTable(
+	'evaluations',
+	{
+		id: integer('id').primaryKey({ autoIncrement: true }),
+		childId: integer('child_id')
+			.notNull()
+			.references(() => children.id),
+		weekStart: text('week_start').notNull(),
+		weekEnd: text('week_end').notNull(),
+		scoresJson: text('scores_json').notNull(),
+		bonusPoints: integer('bonus_points').notNull().default(0),
+		createdAt: text('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
+	},
+	// #3782: 「1子1週1評価」の自然キー (childId, weekStart) を DB 層で物理一意化
+	// (兄弟表 rest_days=idx_rest_days_child_date / login_bonuses=idx_login_bonuses_child_date /
+	// stamp_cards=idx_stamp_cards_child_week と同型)。service 層 pre-fetch dedup (#3355) を経由しない
+	// 別 insert 経路・並行 import でも重複行を作れない canonical guard (ADR-0061 push-down-pyramid)。
+	(table) => [uniqueIndex('idx_evaluations_child_week').on(table.childId, table.weekStart)],
+);
 
 // ============================================================
 // market_benchmarks - 市場ベンチマーク

--- a/src/lib/server/db/sqlite/evaluation-repo.ts
+++ b/src/lib/server/db/sqlite/evaluation-repo.ts
@@ -70,12 +70,30 @@ export async function insertEvaluation(
 	input: InsertEvaluationInput,
 	_tenantId: string,
 ): Promise<Evaluation> {
-	return toEvaluation(
-		db
-			.insert(evaluations)
-			.values({ ...input, childId: Number(input.childId) })
-			.returning()
-			.get(),
+	// #3782: (child_id, week_start) unique index (idx_evaluations_child_week) との衝突は「1週1評価」の
+	// 冪等 no-op として扱う (throw しない)。status page の並行ロード (findWeekEvaluation guard を race)
+	// や restore backstop で二重行を作らず、既存行を返す。
+	const inserted = db
+		.insert(evaluations)
+		.values({ ...input, childId: Number(input.childId) })
+		.onConflictDoNothing()
+		.returning()
+		.get();
+	if (inserted) return toEvaluation(inserted);
+	const existing = db
+		.select()
+		.from(evaluations)
+		.where(
+			and(
+				eq(evaluations.childId, Number(input.childId)),
+				eq(evaluations.weekStart, input.weekStart),
+			),
+		)
+		.get();
+	if (existing) return toEvaluation(existing);
+	// 到達しない: conflict した = 同 (child, week) 行が必ず存在する。型安全 (Evaluation 非 null) のため明示。
+	throw new Error(
+		`insertEvaluation: conflict without existing row (child=${input.childId}, week=${input.weekStart})`,
 	);
 }
 

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -431,7 +431,8 @@ export async function importFamilyData(
 	// #3329: おやすみ日を createdAt 保全で復元。childIdMap のみ必要 (DynamoDB では insert が no-op)。
 	await importRestDaysData(data, childIdMap, tenantId, result);
 	// #3329: 子のカスタム音声 DB 行を復元 (filePath/publicUrl を新 tenant+childId へ remap)。childIdMap のみ必要。
-	await importChildVoicesData(data, childIdMap, tenantId, result);
+	// #3781: DB 行↔ファイル本体の dangling 相互整合を fail-closed 検証するため staticFiles を渡す。
+	await importChildVoicesData(data, childIdMap, tenantId, result, staticFiles);
 	// #3381: importSpecialRewards が返す exportId → 新 rewardId マップを交換履歴の安定再結合に使う。
 	const rewardIdByExportId = await importSpecialRewards(data, childIdMap, tenantId, result, mode);
 	// #3329: ごほうび交換/購入履歴。reward を先に取込済なので importSpecialRewards の後に実行する。
@@ -1259,14 +1260,26 @@ const VOICE_REL_PATH_RE = /^voices\/\d+\/(.+)$/;
  * filePath = `<tenantPrefix>voices/<newChildId>/<rest>` / publicUrl = `/<filePath>` を新環境向けに
  * 再構成して書き戻す (音声ファイル本体は #3077 importStaticFiles が同一パスへ復元済)。createdAt/
  * scene/label/durationMs/isActive を保全。child or path 解決不能行は skip。
+ *
+ * #3781: childVoice DB 行 ↔ #3077 ファイル本体の dangling 相互整合を fail-closed 検証する。
+ * - 前方 (DB 行 → 本体): 参照する本体ファイル (voiceRelPath) が同一 import payload (staticFiles) に
+ *   無い行は insert せず skip + warning。JSON-only import (staticFiles 未指定) や ZIP に本体を欠く
+ *   backup で「実体の無い publicUrl を指す DB 行」= dangling を生まない (#3490 AC-3 の deferral 解消)。
+ * - 逆方向 (本体 → DB 行): どの childVoice からも参照されない voices/* 本体は orphan として warning
+ *   で surface する (実害は未参照バイトのみのため fail-closed でなく可視化)。
  */
 async function importChildVoicesData(
 	data: ExportData,
 	childIdMap: Map<string, ChildId>,
 	tenantId: string,
 	result: ImportResult,
+	staticFiles?: Record<string, Uint8Array>,
 ): Promise<void> {
-	for (const v of data.data.childVoices ?? []) {
+	const voices = data.data.childVoices ?? [];
+	// #3781 逆方向: childVoice が参照する本体パス集合。staticFiles 側の未参照 voices/* を orphan 検出。
+	const referencedVoicePaths = new Set(voices.map((v) => v.voiceRelPath));
+
+	for (const v of voices) {
 		const childId = childIdMap.get(v.childRef);
 		if (!childId) {
 			result.childVoicesSkipped++;
@@ -1293,6 +1306,16 @@ async function importChildVoicesData(
 			);
 			continue;
 		}
+		// #3781 前方 (fail-closed): 本体ファイルが同一 import payload に無ければ dangling publicUrl を
+		// 生むため insert しない。staticFiles のキーは export 時の相対パス (voices/<oldChildId>/<rest>) =
+		// v.voiceRelPath と一致する。JSON-only import (staticFiles 未指定) は全 childVoice が本体を欠く。
+		if (!staticFiles || !(v.voiceRelPath in staticFiles)) {
+			result.childVoicesSkipped++;
+			result.warnings.push(
+				`音声スキップ: 本体ファイル「${v.voiceRelPath}」が取込データに含まれないため復元しません (child=${v.childRef})`,
+			);
+			continue;
+		}
 		const filePath = `${tenantPrefix(tenantId)}voices/${childId}/${rest}`;
 		const publicUrl = storageKeyToPublicUrl(filePath);
 		try {
@@ -1316,6 +1339,29 @@ async function importChildVoicesData(
 		} catch (e) {
 			result.childVoicesSkipped++;
 			result.errors.push(`音声 insert 失敗 (child=${v.childRef}, scene=${v.scene}): ${String(e)}`);
+		}
+	}
+
+	// #3781 逆方向: staticFiles に含まれるが、どの childVoice DB 行からも参照されない voices/* 本体を
+	// orphan として surface する (importStaticFiles が storage に配置しても参照する DB 行が無い状態)。
+	warnUnreferencedVoiceFiles(staticFiles, referencedVoicePaths, result);
+}
+
+/**
+ * #3781 逆方向: staticFiles の voices/* のうち、どの childVoice DB 行からも参照されない本体を
+ * orphan として warning で surface する (実害は未参照バイトのみのため fail-closed でなく可視化)。
+ */
+function warnUnreferencedVoiceFiles(
+	staticFiles: Record<string, Uint8Array> | undefined,
+	referencedVoicePaths: Set<string>,
+	result: ImportResult,
+): void {
+	if (!staticFiles) return;
+	for (const relPath of Object.keys(staticFiles)) {
+		if (relPath.startsWith('voices/') && !referencedVoicePaths.has(relPath)) {
+			result.warnings.push(
+				`音声本体「${relPath}」は参照する音声データが無いため未参照ファイルになります`,
+			);
 		}
 	}
 }

--- a/tests/unit/db/dsql-evaluation-repo.test.ts
+++ b/tests/unit/db/dsql-evaluation-repo.test.ts
@@ -198,6 +198,37 @@ describe('DSQL evaluation-repo (M4-D PR6、実 schema PGlite)', () => {
 		expect(await repo.findWeekEvaluation(child, '2026-05-11', FAMILY)).toBeUndefined();
 	});
 
+	it('[E5b] #3782: 同 (child, weekStart) 再 insert は week UNIQUE (evaluations_week_uq) で冪等 — 二重行を作らず既存行を返す', async () => {
+		const child = await seedChild(FAMILY, 'E5b');
+		const first = await repo.insertEvaluation(
+			{
+				childId: child,
+				weekStart: '2026-08-03',
+				weekEnd: '2026-08-09',
+				scoresJson: '{"a":1}',
+				bonusPoints: 10,
+			},
+			FAMILY,
+		);
+		// 同一 (family, child, weekStart) を再 insert (並行ロード / restore backstop 相当)
+		const second = await repo.insertEvaluation(
+			{
+				childId: child,
+				weekStart: '2026-08-03',
+				weekEnd: '2026-08-09',
+				scoresJson: '{"a":999}', // 内容が違っても新規行は作らない
+				bonusPoints: 999,
+			},
+			FAMILY,
+		);
+		// ON CONFLICT DO NOTHING → 既存行 (first) がそのまま返る (throw しない)
+		expect(second.id).toBe(first.id);
+		expect(second.scoresJson).toBe('{"a":1}'); // 既存行が保全される (上書きしない)
+		// 物理的に 1 行のみ (二重計上なし)
+		const all = await repo.findEvaluationsByChild(child, 100, FAMILY);
+		expect(all.filter((e) => e.weekStart === '2026-08-03')).toHaveLength(1);
+	});
+
 	it('[E6] findAllChildren: archive 不問 + compute-on-read (age 導出)', async () => {
 		const fam = '00000000-0000-4000-8000-0000000000c6';
 		const active = await seedChild(fam, 'E6-active', '2018-01-15');

--- a/tests/unit/db/lazy-startup-migrations.test.ts
+++ b/tests/unit/db/lazy-startup-migrations.test.ts
@@ -1010,4 +1010,85 @@ describe('applyLazyStartupMigrations', () => {
 			expect(() => applyLazyStartupMigrations(db)).not.toThrow();
 		});
 	});
+
+	describe('#3782: evaluations (child, week) unique index (dedup → index)', () => {
+		function seedLegacyEvaluations(): void {
+			// unique index を欠く旧 evaluations (child_id, week_start 重複を許容していた状態)。
+			db.exec(`
+				CREATE TABLE evaluations (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					child_id INTEGER NOT NULL,
+					week_start TEXT NOT NULL,
+					week_end TEXT NOT NULL,
+					scores_json TEXT NOT NULL,
+					bonus_points INTEGER NOT NULL DEFAULT 0,
+					created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+				);
+			`);
+		}
+
+		function indexExists(name: string): boolean {
+			return !!db
+				.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?")
+				.get(name);
+		}
+
+		function evalCount(): number {
+			return (db.prepare('SELECT COUNT(*) AS c FROM evaluations').get() as { c: number }).c;
+		}
+
+		it('重複 (child, week) 行を dedup (最小 id を残す) してから unique index を作成する', () => {
+			seedLegacyEvaluations();
+			// (1, 2026-06-01) を 2 件、(1, 2026-06-08) を 1 件、(2, 2026-06-01) を 1 件 = 計 4 行
+			db.exec(`
+				INSERT INTO evaluations (child_id, week_start, week_end, scores_json, bonus_points) VALUES
+					(1, '2026-06-01', '2026-06-07', '{"a":1}', 10),
+					(1, '2026-06-01', '2026-06-07', '{"a":2}', 20),
+					(1, '2026-06-08', '2026-06-14', '{"a":3}', 5),
+					(2, '2026-06-01', '2026-06-07', '{"a":4}', 0);
+			`);
+			expect(evalCount()).toBe(4);
+
+			applyLazyStartupMigrations(db);
+
+			// dedup: (1, 2026-06-01) が 1 件に縮約 → 計 3 行。最小 id (最初の行 scores '{"a":1}') が残る。
+			expect(evalCount()).toBe(3);
+			const kept = db
+				.prepare(
+					"SELECT scores_json FROM evaluations WHERE child_id = 1 AND week_start = '2026-06-01'",
+				)
+				.all() as { scores_json: string }[];
+			expect(kept).toHaveLength(1);
+			expect(kept[0]?.scores_json).toBe('{"a":1}'); // MIN(id) 行が保全される
+
+			// unique index が作成され、以後 (child, week) 重複 INSERT は物理拒否される
+			expect(indexExists('idx_evaluations_child_week')).toBe(true);
+			expect(() =>
+				db
+					.prepare(
+						"INSERT INTO evaluations (child_id, week_start, week_end, scores_json) VALUES (1, '2026-06-01', '2026-06-07', '{}')",
+					)
+					.run(),
+			).toThrow();
+		});
+
+		it('冪等: index 既存の DB に再適用しても no-op (dedup しない / throw しない)', () => {
+			seedLegacyEvaluations();
+			db.exec(`
+				INSERT INTO evaluations (child_id, week_start, week_end, scores_json, bonus_points) VALUES
+					(1, '2026-06-01', '2026-06-07', '{"a":1}', 10),
+					(1, '2026-06-08', '2026-06-14', '{"a":3}', 5);
+			`);
+			applyLazyStartupMigrations(db);
+			expect(indexExists('idx_evaluations_child_week')).toBe(true);
+			const after1 = evalCount();
+			expect(() => applyLazyStartupMigrations(db)).not.toThrow();
+			expect(evalCount()).toBe(after1);
+		});
+
+		it('evaluations 不在でも例外を投げない', () => {
+			expect(() => applyLazyStartupMigrations(db)).not.toThrow();
+			expect(indexExists('idx_evaluations_child_week')).toBe(false);
+		});
+	});
 });

--- a/tests/unit/db/schema.test.ts
+++ b/tests/unit/db/schema.test.ts
@@ -138,6 +138,7 @@ beforeAll(() => {
 			bonus_points INTEGER NOT NULL DEFAULT 0,
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);
+		CREATE UNIQUE INDEX idx_evaluations_child_week ON evaluations(child_id, week_start);
 
 		CREATE TABLE market_benchmarks (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/unit/db/sqlite/evaluation-week-unique-3782.test.ts
+++ b/tests/unit/db/sqlite/evaluation-week-unique-3782.test.ts
@@ -1,0 +1,101 @@
+// tests/unit/db/sqlite/evaluation-week-unique-3782.test.ts
+//
+// #3782: evaluations の (child_id, week_start) 一意性 + 冪等 insertEvaluation を実 SQLite で固定する。
+// 兄弟表 (rest_days / login_bonuses / stamp_cards) と同型に「1子1週1評価」を DB 層で物理一意化し、
+// service 層 pre-fetch dedup (#3355) を経由しない別 insert 経路・並行ロードでも二重行を作らない
+// (ADR-0061 push-down-pyramid)。#3245 auto:weekly unique と同型の回帰固定。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestDb, type TestSqlite } from '../../helpers/test-db';
+
+const dbHolder: { sqlite: TestSqlite | null; db: ReturnType<typeof createTestDb>['db'] | null } = {
+	sqlite: null,
+	db: null,
+};
+
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		if (!dbHolder.db) throw new Error('test db not initialized');
+		return dbHolder.db;
+	},
+}));
+
+import { asChildId } from '$lib/domain/ids';
+import { children, evaluations as evaluationsTable } from '$lib/server/db/schema';
+import { insertEvaluation } from '$lib/server/db/sqlite/evaluation-repo';
+
+const TENANT = 't-3782';
+
+function evalInput(childId: number, weekStart: string, scoresJson = '{"a":1}') {
+	return {
+		childId: asChildId(childId),
+		weekStart,
+		weekEnd: '2026-06-07',
+		scoresJson,
+		bonusPoints: 10,
+	};
+}
+
+describe('#3782 evaluations (child, week) 一意性 / 冪等 insertEvaluation', () => {
+	let childId: number;
+
+	beforeEach(() => {
+		const { sqlite, db } = createTestDb();
+		dbHolder.sqlite = sqlite;
+		dbHolder.db = db;
+		childId = db
+			.insert(children)
+			.values({ nickname: 'けんた', age: 8, theme: 'default', uiMode: 'elementary' })
+			.returning()
+			.get().id;
+	});
+
+	it('同 (child, weekStart) の再 insert は冪等 — 二重行を作らず既存行を返す (throw しない)', async () => {
+		const first = await insertEvaluation(evalInput(childId, '2026-06-01', '{"a":1}'), TENANT);
+		// 内容が違っても新規行は作らない (並行ロード / restore backstop 相当)
+		const second = await insertEvaluation(evalInput(childId, '2026-06-01', '{"a":999}'), TENANT);
+
+		expect(second.id).toBe(first.id);
+		expect(second.scoresJson).toBe('{"a":1}'); // 既存行が保全される (上書きしない)
+
+		// DB 上も (child, weekStart) 行は 1 件のみ (= growth-book/reports の数値汚染源 = 二重行 が存在しない)
+		const rows = dbHolder
+			.db!.select()
+			.from(evaluationsTable)
+			.all()
+			.filter((e) => e.childId === childId && e.weekStart === '2026-06-01');
+		expect(rows.length).toBe(1);
+	});
+
+	it('並行 insert (Promise.all) が 1 行に収束する (二重計上なし)', async () => {
+		await Promise.all(
+			Array.from({ length: 5 }, () => insertEvaluation(evalInput(childId, '2026-06-08'), TENANT)),
+		);
+		const rows = dbHolder
+			.db!.select()
+			.from(evaluationsTable)
+			.all()
+			.filter((e) => e.childId === childId && e.weekStart === '2026-06-08');
+		expect(rows.length).toBe(1);
+	});
+
+	it('別週 (別 weekStart) は別行として共存できる', async () => {
+		await insertEvaluation(evalInput(childId, '2026-06-01'), TENANT);
+		await insertEvaluation(evalInput(childId, '2026-06-08'), TENANT);
+		const rows = dbHolder.db!.select().from(evaluationsTable).all();
+		expect(rows.filter((e) => e.childId === childId).length).toBe(2);
+	});
+
+	it('生 INSERT の重複は unique index (idx_evaluations_child_week) で物理拒否される', () => {
+		dbHolder
+			.db!.insert(evaluationsTable)
+			.values({ childId, weekStart: '2026-06-15', weekEnd: '2026-06-21', scoresJson: '{}' })
+			.run();
+		expect(() =>
+			dbHolder
+				.db!.insert(evaluationsTable)
+				.values({ childId, weekStart: '2026-06-15', weekEnd: '2026-06-21', scoresJson: '{}' })
+				.run(),
+		).toThrow();
+	});
+});

--- a/tests/unit/helpers/test-db.ts
+++ b/tests/unit/helpers/test-db.ts
@@ -202,6 +202,9 @@ export const SQL_TABLES = `
 		bonus_points INTEGER NOT NULL DEFAULT 0,
 		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 	);
+	-- #3782: 1子1週1評価の自然キー物理一意化 (schema.ts idx_evaluations_child_week と同期)
+	CREATE UNIQUE INDEX idx_evaluations_child_week
+		ON evaluations(child_id, week_start);
 
 	-- ============================================================
 	-- market_benchmarks

--- a/tests/unit/services/backup-archive.test.ts
+++ b/tests/unit/services/backup-archive.test.ts
@@ -286,7 +286,10 @@ describe('buildFullBackupZip (#3376 AC8)', () => {
 		// 旧実装は非圧縮合計 > 100MB で誤 reject していたが、判定を圧縮後 ZIP サイズ基準に是正したため通る。
 		// data.json は per-entry 対象外 (構造化データ) のため parse 側 filter でも drop されず round-trip する。
 		mockListFiles.mockResolvedValue([]);
-		const hugeCompressibleDataJson = `{"format":"ganbari-quest-backup","version":"1.3.0","pad":"${'a'.repeat(
+		// data.json override は manifest.itemCounts (buildFullBackupZip は exportData から算出) と
+		// 整合させる必要がある (#3386 の itemCounts 照合。本番では dataJson=exportData 直列化で常に一致)。
+		// SAMPLE_EXPORT は children 1 件のため family も同一件数で埋める。
+		const hugeCompressibleDataJson = `{"format":"ganbari-quest-backup","version":"1.3.0","family":{"children":[{"id":"1","nickname":"テスト"}]},"pad":"${'a'.repeat(
 			MAX_ZIP_SIZE + 2 * 1024 * 1024,
 		)}"}`;
 		const zip = await buildFullBackupZip('T1', SAMPLE_EXPORT, false, hugeCompressibleDataJson);

--- a/tests/unit/services/backup-roundtrip-completeness.test.ts
+++ b/tests/unit/services/backup-roundtrip-completeness.test.ts
@@ -332,8 +332,10 @@ describe('#3328 backup round-trip 完全性 — 全 source 実体が export→cl
 		);
 
 		// --- replace = clear → import ---
+		// #3781: 実 backup ZIP は音声本体を staticFiles に同梱する。DB 行↔本体の相互整合を満たすため
+		// voiceRelPath (voices/1/sample.mp3) の本体を渡す (未指定だと dangling として skip される)。
 		await clearAllFamilyData(T);
-		await importFamilyData(data, T);
+		await importFamilyData(data, T, { 'voices/1/sample.mp3': new Uint8Array([1, 2, 3]) });
 
 		// --- 復元後の child ---
 		const children = testDb.select().from(schema.children).all();

--- a/tests/unit/services/import-service.test.ts
+++ b/tests/unit/services/import-service.test.ts
@@ -1640,7 +1640,10 @@ describe('importFamilyData', () => {
 			// #3394 統一冪等契約: 永続化成功は non-null ({ id }) を返す (undefined/null は skip 計上される)
 			mockVoiceInsertForRestore.mockResolvedValue({ id: '1' });
 
-			const result = await importFamilyData(data, TENANT);
+			// #3781: DB 行の本体ファイルが staticFiles に存在するときのみ復元される (dangling fail-closed)。
+			const result = await importFamilyData(data, TENANT, {
+				'voices/7/abcd-1234.mp3': new Uint8Array([1, 2, 3]),
+			});
 
 			expect(result.childVoicesImported).toBe(1);
 			expect(result.childVoicesSkipped).toBe(0);
@@ -1663,7 +1666,10 @@ describe('importFamilyData', () => {
 			// #3394 統一冪等契約: 永続化成功は non-null ({ id }) を返す (undefined/null は skip 計上される)
 			mockVoiceInsertForRestore.mockResolvedValue({ id: '1' });
 
-			const result = await importFamilyData(data, TENANT);
+			// 正常エントリのみ本体を同梱。トラバーサル 3 件は path-safety で本体チェック前に落ちる。
+			const result = await importFamilyData(data, TENANT, {
+				'voices/7/safe.mp3': new Uint8Array([1]),
+			});
 
 			// 正常 1 件のみ insert、トラバーサル 3 件は skip
 			expect(result.childVoicesImported).toBe(1);
@@ -1692,7 +1698,10 @@ describe('importFamilyData', () => {
 			mockInsertChild.mockResolvedValue({ id: '101' });
 			mockVoiceInsertForRestore.mockResolvedValue({ id: '1' });
 
-			const result = await importFamilyData(data, TENANT);
+			// 正常エントリのみ本体を同梱。NUL エントリは path-safety で本体チェック前に落ちる。
+			const result = await importFamilyData(data, TENANT, {
+				'voices/7/safe.mp3': new Uint8Array([1]),
+			});
 
 			expect(result.childVoicesImported).toBe(1);
 			expect(result.childVoicesSkipped).toBe(1);
@@ -1703,6 +1712,62 @@ describe('importFamilyData', () => {
 				expect(String(row.filePath)).not.toContain(NUL);
 			}
 			expect(result.warnings.some((w) => w.includes('不正なパス'))).toBe(true);
+		});
+
+		it('#3781: 本体ファイルが取込データ (staticFiles) に無い DB 行は insert されず skip + warning (dangling fail-closed)', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.childVoices = [makeVoice('c1', 'voices/7/abcd-1234.mp3')];
+			mockInsertChild.mockResolvedValue({ id: '101' });
+			mockVoiceInsertForRestore.mockResolvedValue({ id: '1' });
+
+			// staticFiles に本体が無い (別の voice のみ) → 参照先ファイル欠落 = dangling publicUrl になるため skip。
+			const result = await importFamilyData(data, TENANT, {
+				'voices/7/other-file.mp3': new Uint8Array([9]),
+			});
+
+			expect(result.childVoicesImported).toBe(0);
+			expect(result.childVoicesSkipped).toBe(1);
+			// insert は一切呼ばれない (dangling 行を作らない)
+			expect(mockVoiceInsertForRestore).not.toHaveBeenCalled();
+			expect(result.warnings.some((w) => w.includes('取込データに含まれない'))).toBe(true);
+		});
+
+		it('#3781: JSON-only import (staticFiles 未指定) では全 childVoice が本体欠落で skip される', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.childVoices = [
+				makeVoice('c1', 'voices/7/a.mp3'),
+				makeVoice('c1', 'voices/7/b.mp3'),
+			];
+			mockInsertChild.mockResolvedValue({ id: '101' });
+			mockVoiceInsertForRestore.mockResolvedValue({ id: '1' });
+
+			// staticFiles 未指定 = JSON-only → 全行が本体を持たず dangling。1 件も復元されない。
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.childVoicesImported).toBe(0);
+			expect(result.childVoicesSkipped).toBe(2);
+			expect(mockVoiceInsertForRestore).not.toHaveBeenCalled();
+		});
+
+		it('#3781: どの childVoice からも参照されない voices 本体は orphan warning で surface される (逆方向)', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			data.data.childVoices = [makeVoice('c1', 'voices/7/referenced.mp3')];
+			mockInsertChild.mockResolvedValue({ id: '101' });
+			mockVoiceInsertForRestore.mockResolvedValue({ id: '1' });
+
+			// referenced.mp3 は DB 行と対 (正常復元)、orphan.mp3 は参照する DB 行が無い (未参照本体)。
+			const result = await importFamilyData(data, TENANT, {
+				'voices/7/referenced.mp3': new Uint8Array([1]),
+				'voices/7/orphan.mp3': new Uint8Array([2]),
+			});
+
+			expect(result.childVoicesImported).toBe(1);
+			expect(
+				result.warnings.some((w) => w.includes('orphan.mp3') && w.includes('未参照ファイル')),
+			).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

家庭のバックアップ復元・週次評価データの整合性を「あるべき姿」まで硬化する restore hardening クラスタ。① 週次評価が二重計上され成長レポート / グラフの数値が汚染される経路を DB 層 unique で根絶し、② 音声(childVoice)が「実体ファイルの無い publicUrl を指す壊れた DB 行(dangling)」として復元される経路を fail-closed で塞ぐ。いずれも顧客データの信頼性(記録が正しく残る)を守る。

## 関連 Issue

- closes #3782 (priority:medium): evaluations に DB 層 unique(family_id, child_id, week_start) backstop 追加 (ADR-0061 push-down-pyramid、#3355 の後続)
- closes #3781 (priority:low): childVoices DB 行↔ファイル本体の dangling 相互整合 fail-closed 化 (#3490 AC-3 deferral 解消)
- 関連: PR #3774 (#3355 評価取込冪等) / #3776 (#3490 backup 検証) / #3245 / #3284 (unique index dedup 前例) / ADR-0061

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| #3782-1 | sqlite evaluations に UNIQUE(child_id, week_start) 追加 | `schema.ts` uniqueIndex + `create-tables.ts` + `test-db.ts` + `tests/unit/db/sqlite/evaluation-week-unique-3782.test.ts` (生 INSERT 重複が throw) | 実装済 / test 追加 |
| #3782-2 | dsql evaluations に UNIQUE(family_id, child_id, week_start) droppable 追加 | `dsql/schema.ts` uniqueIndex('evaluations_week_uq') + `drizzle/pglite/0002_*.sql` + `tests/unit/db/dsql-evaluation-repo.test.ts [E5b]` | 実装済 / test 追加 |
| #3782-3 | 並行実装同期 (schema.ts / dsql/schema.ts / global-setup / test-db / demo-data) | test-db.ts 追加、global-setup は `drizzle-kit push --force` で schema.ts から自動生成、demo-data は fixture で (child,week) 重複なし・stub のため不要 | 同期済 |
| #3782-4 | 既存 prod DB migration (重複 dedup → index) | `lazy-startup-migrations.ts` migrateEvaluationChildWeekUnique (MIN id 保全 dedup、#3245/#3284 同型) + `tests/unit/db/lazy-startup-migrations.test.ts` | 実装済 / test 追加 |
| #3782-5 | 別 insert 経路 / 並行 import で二重行を作らない (canonical guard) | insertEvaluation を sqlite/dsql とも ON CONFLICT DO NOTHING + 既存行返却で冪等化 (throw しない)。dynamodb は決定的 SK で既に一意 | 実装済 |
| #3781-1 | DB 行↔本体ファイルの dangling を fail-closed 検出 | import-service: 本体を欠く childVoice 行は insert せず skip+warning。`tests/unit/services/import-service.test.ts` (#3781 3 テスト) | 実装済 / test 追加 |
| #3781-2 | 逆方向 (本体→DB 行) の未参照 orphan を surface | `warnUnreferencedVoiceFiles` で orphan warning | 実装済 / test 追加 |

## 変更タイプ

- [x] バグ修正 / データ整合性 (backup restore hardening)
- [x] DB スキーマ変更 (unique index 追加、破壊的でない)
- [ ] 新機能 / UI 変更 / インフラ変更

## 影響範囲・変更コンポーネント

- **DB schema**: `schema.ts` / `dsql/schema.ts` / `create-tables.ts` (evaluations unique index)
- **migration**: `lazy-startup-migrations.ts` (sqlite 既存 DB dedup→index) / `drizzle/pglite/0002_evaluations_week_unique.sql` + `_journal.json` + `0002_snapshot.json` (dsql/PGlite prod provision)
- **repo**: `sqlite/evaluation-repo.ts` / `dsql/evaluation-repo.ts` (insertEvaluation 冪等化)
- **service**: `services/import-service.ts` (childVoices dangling fail-closed + orphan 検出)
- **SSOT**: `restore-idempotency.ts` (childVoice reason に #3781 追記) / `docs/design/08-データベース設計書.md` (evaluations unique 制約)
- **tests**: sqlite/dsql/lazy-migration/childVoices 回帰 + 既存 childVoices/roundtrip テストの staticFiles 対応

## テスト & 安全装置セルフチェック

- failing-test-first (ADR-0061): sqlite `evaluation-week-unique-3782.test.ts` / dsql `[E5b]` / lazy-migration dedup / childVoices #3781 3 件を red→green で追加
- `npx biome check --error-on-warnings` 14 files clean / `cspell --config .cspell.json` 全変更 src+tests clean
- 型 (svelte-check) / 全 vitest / E2E は worktree に node_modules 無いため CI に委譲
- ADR-0006: assertion 弱体化なし (insertEvaluation の unreachable branch は fail-loud throw = 強化)
- DSQL append-only allowlist: evaluations は append-only 表ではなく UPDATE/DELETE 追加もないため登録不要

## スクリーンショット / ビジュアルデモ

UI 変更なし (DB / service / migration のみ) のため SS は N/A。

## コード品質セルフレビュー (#1481)

- 兄弟表 (rest_days / login_bonuses / stamp_cards) と同型の unique index + 同型の dedup→index migration (#3245/#3284) を踏襲し独自機構を作らない
- insertEvaluation の返り値は既存全 caller が未使用のため冪等化 (ON CONFLICT + 既存行返却) で契約 `Promise<Evaluation>` 不変
- childVoices の複雑度超過を helper 抽出 (`warnUnreferencedVoiceFiles`) で解消

## 横展開・影響波及チェック

- evaluations restore は `insertEvaluation` 直呼び (`*ForRestore` 関数ではない) のため restore-idempotency registry の no-silent-gap 対象外。childVoice reason のみ #3781 で更新
- 実 backup ZIP は音声本体を staticFiles 同梱するため通常 restore は不変 (fail-closed が効くのは JSON-only import 等の本体欠落時のみ)
- 週次評価の唯一の本番呼出元 (status page) は `findWeekEvaluation` で pre-check 済 + 冪等化で並行ロード時も 500 化しない

## レビュー依頼事項・破壊的変更

- 破壊的変更なし (unique index 追加は既存正常データに無影響。重複がある既存 sqlite DB は起動時 dedup で MIN id を保全)
- `drizzle/pglite/0002_snapshot.json` は node_modules 不在のため drizzle-kit generate ではなく 0001 スナップショットからの手編集 (index 追加 + id/prevId bump)。migrator は journal+sql のみ参照するため runtime は影響なし。次回 drizzle-kit generate 前に再生成推奨

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。N/A。

## Ready for Review チェックリスト

- [x] AC 検証マップを 4 列で記載
- [x] biome check --error-on-warnings + cspell ローカル PASS
- [x] 設計書同期済 (docs/design/08-データベース設計書.md)
- [x] 実装完遂 (partial 実装なし)。型 / vitest / E2E は CI に委譲し緑を Ready 化前に確認
- [x] QA 承認・動作確認は QM 責務 (Dev 実装完遂宣言、feedback_no_autonomous_qa_merge.md)

## QM レビュー結果

(QM が記入)
