### PR TITLE
fix(point-economy): #3787 activity cancel の mastery_bonus 対称返金 (farming vector 消滅)

### DIFF
--- a/docs/design/dsql/m3-physical-model.md
+++ b/docs/design/dsql/m3-physical-model.md
@@ -356,6 +356,7 @@ M2 の GrowthJournal 集約 atomic 境界（activity_log 生成 + status 更新 
 - **core = 単一 txn**（activity_log + status + status_history + mastery + point_ledger base + total_point 加算）。
 - **optional = core commit 後の独立 best-effort mini-txn**（combo/mission/challenge/certificate/special_reward、各 additive かつ冪等、失敗隔離 + ログ）。**欠落許容は要 PO 確認**（M2/big-policy §10-8: 現状の握り潰しと同等で regression なし）。
 - **cancel も対称に単一 txn**（#3596 ②、`cancel-activity-core.ts`）: activity_log soft-cancel（`cancelled=true`）+ mastery count−1 + point_ledger(−)+total_point 減 + status 復元（clampDecayFloor 契約保存）+ status_history を all-or-nothing 書込。冪等 guard = cancel UPDATE の affected 行判定（2 連打は同一行 UPDATE の OCC 40001 retry で 0 行 → ALREADY_CANCELLED、二重返金なし）。record core と同じく DATA_SOURCE=dsql のみ本経路（sqlite/pglite は逐次 await 経路を温存、単一接続で並行競合なし）。
+- **返金額は base+streak+mastery_bonus の対称返金**（#3787）: record 時 ledger は base+streak+mastery_bonus を計上するため、cancel も同額を相殺しないと record→cancel cycle で mastery_bonus（per-record 付与、`floor(level/5)`）が balance に残り point 経済が壊れる。refundPoints は service 層（`activity-cancel-dsql.ts` / legacy sqlite 経路とも）が `log.points + log.streak_bonus + calcMasteryBonusRefundOnCancel(mastery.total_count)` で算出する（記録前 level = `calcMasteryLevel(count-1)` を基準に付与時と同一式で復元、latest record の cancel で厳密一致）。core は refundPoints を ledger(−)/total_point/status に一貫適用するのみ（額算出責務は service 層に凝集、旧 #3596 ② の非対称挙動を是正）。
 
 ### §6.2 派生列 compute-on-write（total_point 等、構造決定 + PoC 保留）
 

--- a/src/lib/domain/validation/activity.ts
+++ b/src/lib/domain/validation/activity.ts
@@ -300,5 +300,19 @@ export function calcMasteryBonus(level: number): number {
 	return Math.floor(level / 5);
 }
 
+/**
+ * cancel 時に対称返金すべき mastery_bonus を、cancel 対象 log の記録で増えた mastery 総回数
+ * (post-record count) から再構成する (#3787)。
+ *
+ * 記録時 (`prepareActivityRecord`) は「記録前 level」= `calcMasteryLevel(count - 1)` を基準に
+ * `calcMasteryBonus` を付与する (mastery は per-record 付与)。cancel の point_ledger 相殺行も
+ * 同一式で額を復元し、record→cancel cycle で mastery_bonus が balance に残らない (farming vector
+ * 消滅)。latest record の cancel では付与額と厳密一致する (既存の mastery count 巻戻しと同精度)。
+ */
+export function calcMasteryBonusRefundOnCancel(postRecordCount: number): number {
+	if (postRecordCount <= 0) return 0;
+	return calcMasteryBonus(calcMasteryLevel(postRecordCount - 1));
+}
+
 /** 節目レベル（派手な演出対象） */
 export const MASTERY_MILESTONE_LEVELS = new Set([5, 10, 20, 30, 50, 99]);

--- a/src/lib/server/db/dsql/cancel-activity-core.ts
+++ b/src/lib/server/db/dsql/cancel-activity-core.ts
@@ -22,10 +22,13 @@
 //   - **fitness#7 準拠**: work 内 await は全て tx.execute 直呼び。level/floor 算出は sync 注入。
 //   - work は再実行可能 (40001 retry で全体再実行、cancel UPDATE の affected 判定が冪等性を守る)。
 //
-// **返金額の非対称メモ (#3596 ②)**: refundPoints は legacy と同一に log.points + log.streak_bonus
-//   を service が算出する。記録時 ledger は base+streak+mastery_bonus を計上するため mastery_bonus
-//   分は返金されない既存挙動を本 core は保存する (atomicity の是正のみが scope)。厳密な対称返金
-//   (原 ledger 額の巻戻し) は別途 follow-up (#3596 の後続 or 新規) で扱う。
+// **返金額の対称化 (#3787)**: refundPoints は service (activity-cancel-dsql.ts) が
+//   log.points + log.streak_bonus + mastery_bonus を算出して渡す (legacy sqlite 経路と同一計算)。
+//   記録時 ledger は base+streak+mastery_bonus を計上するため、mastery_bonus も相殺しないと
+//   record→cancel farming で balance に残る (point 経済破綻)。mastery_bonus 額は付与時と同一式
+//   (記録前 level = calcMasteryLevelFor(count-1)) で再構成する (計算 SSOT = activity.ts の
+//   calcMasteryBonusRefundOnCancel)。本 core は refundPoints を ledger(−)/total_point/status に
+//   一貫適用するのみで、額の算出責務は service 層に凝集する (旧 #3596 ② の非対称挙動を是正)。
 
 import { sql } from 'drizzle-orm';
 import type { TransactionRunner } from '../interfaces/transaction.interface';

--- a/src/lib/server/services/activity-cancel-dsql.ts
+++ b/src/lib/server/services/activity-cancel-dsql.ts
@@ -16,8 +16,13 @@
 // fitness#7: 本 module に runInTransaction callsite は無い (txn は core 内)。
 
 import { todayDateJST } from '$lib/domain/date-utils';
-import { CANCEL_WINDOW_MS, calcMasteryLevel } from '$lib/domain/validation/activity';
+import {
+	CANCEL_WINDOW_MS,
+	calcMasteryBonusRefundOnCancel,
+	calcMasteryLevel,
+} from '$lib/domain/validation/activity';
 import { calcLevelFromXp, clampDecayFloor } from '$lib/domain/validation/status';
+import { findByChildAndActivity as findMastery } from '$lib/server/db/activity-mastery-repo';
 import { findActivityById, findActivityLogById } from '$lib/server/db/activity-repo';
 import { cancelActivityCore } from '$lib/server/db/dsql/cancel-activity-core';
 import { getDsqlTransactionRunner } from '$lib/server/db/dsql/connection';
@@ -40,8 +45,14 @@ export async function cancelActivityDsql(
 		return { error: 'CANCEL_EXPIRED' };
 	}
 
-	// 返金額 = log.points + log.streak_bonus (legacy と同一計算)。
-	const refundPoints = log.points + log.streakBonus;
+	// 返金額 = log.points + log.streak_bonus + mastery_bonus (#3787 対称返金)。記録時 ledger は
+	// base+streak+mastery を計上するため、mastery_bonus も相殺しないと record→cancel farming で
+	// balance に残る。mastery_bonus 額は付与時と同一式 (記録前 level) で再構成する (計算 SSOT = activity.ts)。
+	// mastery 読取は refund 額算出用 (count 巻戻し自体は core が in-txn で実施)。
+	const mastery = await findMastery(log.childId, log.activityId, tenantId);
+	const masteryBonusRefund =
+		mastery && mastery.totalCount > 0 ? calcMasteryBonusRefundOnCancel(mastery.totalCount) : 0;
+	const refundPoints = log.points + log.streakBonus + masteryBonusRefund;
 
 	// activity 削除済なら categoryId=null で status 復元を skip (legacy `if (activity)` parity)。
 	const activity = await findActivityById(log.activityId, tenantId);

--- a/src/lib/server/services/activity-log-service.ts
+++ b/src/lib/server/services/activity-log-service.ts
@@ -1,6 +1,7 @@
 import type { ActivityId, CategoryId, ChildId } from '$lib/domain/ids';
 import {
 	CANCEL_WINDOW_MS,
+	calcMasteryBonusRefundOnCancel,
 	calcMasteryLevel,
 	getActivityDisplayName,
 	getCategoryById,
@@ -408,7 +409,13 @@ export async function cancelActivityLog(
 		return { error: 'CANCEL_EXPIRED' };
 	}
 
-	const totalPoints = log.points + log.streakBonus;
+	// #3787: mastery_bonus 対称返金。記録時 ledger / status は base+streak+mastery を計上したため、
+	// cancel も同額を返金しないと record→cancel farming で mastery_bonus が balance に残り point 経済が
+	// 壊れる。mastery_bonus 額は付与時と同一式 (記録前 level) で再構成する (計算 SSOT = activity.ts)。
+	const mastery = await findMastery(log.childId, log.activityId, tenantId);
+	const masteryBonusRefund =
+		mastery && mastery.totalCount > 0 ? calcMasteryBonusRefundOnCancel(mastery.totalCount) : 0;
+	const totalPoints = log.points + log.streakBonus + masteryBonusRefund;
 
 	// 活動のカテゴリを取得してステータスXPを戻す
 	const activity = await findActivityById(log.activityId, tenantId);
@@ -417,7 +424,6 @@ export async function cancelActivityLog(
 	}
 
 	// 習熟度を戻す（count-1、レベル再計算）
-	const mastery = await findMastery(log.childId, log.activityId, tenantId);
 	if (mastery && mastery.totalCount > 0) {
 		const revertedCount = Math.max(0, mastery.totalCount - 1);
 		const revertedLevel = calcMasteryLevel(revertedCount);

--- a/tests/unit/domain/activity-mastery.test.ts
+++ b/tests/unit/domain/activity-mastery.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	calcMasteryBonus,
+	calcMasteryBonusRefundOnCancel,
 	calcMasteryLevel,
 	countToNextMasteryLevel,
 	MASTERY_LEVEL_TABLE,
@@ -109,6 +110,25 @@ describe('calcMasteryBonus', () => {
 
 	it('Lv99 → +19pt', () => {
 		expect(calcMasteryBonus(99)).toBe(19);
+	});
+});
+
+describe('calcMasteryBonusRefundOnCancel (#3787 対称返金)', () => {
+	it('post-record count 0 / 1 は返金 0 (記録前 Lv1 = bonus 0)', () => {
+		expect(calcMasteryBonusRefundOnCancel(0)).toBe(0);
+		expect(calcMasteryBonusRefundOnCancel(1)).toBe(0);
+	});
+
+	it('付与時と同一額を復元する: 記録前 level = calcMasteryLevel(count-1) の bonus', () => {
+		// count=31 (post-record) → 記録前 count=30 → Lv5 → bonus 1
+		expect(calcMasteryBonusRefundOnCancel(31)).toBe(calcMasteryBonus(calcMasteryLevel(30)));
+		expect(calcMasteryBonusRefundOnCancel(31)).toBe(1);
+		// count=51 → 記録前 50 → Lv6 → bonus 1
+		expect(calcMasteryBonusRefundOnCancel(51)).toBe(calcMasteryBonus(calcMasteryLevel(50)));
+	});
+
+	it('負値は 0 に丸める (防御)', () => {
+		expect(calcMasteryBonusRefundOnCancel(-5)).toBe(0);
 	});
 });
 

--- a/tests/unit/services/activity-log-service.test.ts
+++ b/tests/unit/services/activity-log-service.test.ts
@@ -365,6 +365,44 @@ describe('cancelActivityLog', () => {
 	});
 });
 
+describe('cancelActivityLog: mastery_bonus 対称返金 (#3787)', () => {
+	beforeEach(() => {
+		seedBase();
+		mockToday = '2026-02-20';
+	});
+
+	/** childId の point_ledger 合計 (record +total / cancel −refund の net)。 */
+	function ledgerBalance(childId: number): number {
+		return testDb
+			.select()
+			.from(schema.pointLedger)
+			.all()
+			.filter((e) => Number(e.childId) === childId)
+			.reduce((sum, e) => sum + e.amount, 0);
+	}
+
+	it('mastery_bonus 付与済 (level ≥ 5) の record→cancel は mastery_bonus も返金し net 0 (farming vector 消滅)', async () => {
+		// 習熟レベル 5 (totalCount=30) を seed → 次の record で masteryBonus = floor(5/5) = 1 が付与される
+		testDb
+			.insert(schema.activityMastery)
+			.values({ childId: 1, activityId: 1, totalCount: 30, level: 5 })
+			.run();
+
+		const recorded = assertSuccess(await recordActivity(asChildId(1), asActivityId(1), TENANT));
+		// 前提: この record で mastery_bonus が実際に付与されている (0 だと本テストが farming を検出できない)
+		expect(recorded.masteryBonus).toBeGreaterThan(0);
+		expect(ledgerBalance(1)).toBe(recorded.totalPoints);
+
+		const cancelResult = await cancelActivityLog(recorded.id, TENANT);
+		if ('error' in cancelResult) throw new Error(`Unexpected error: ${cancelResult.error}`);
+
+		// 対称返金: cancel は base+streak だけでなく mastery_bonus 込みの totalPoints 全額を返金する
+		expect(cancelResult.refundedPoints).toBe(recorded.totalPoints);
+		// record +total / cancel −total で net 0。mastery_bonus が balance に残らない
+		expect(ledgerBalance(1)).toBe(0);
+	});
+});
+
 describe('recordActivity: 習熟度（mastery）', () => {
 	beforeEach(() => {
 		seedBase();

--- a/tests/unit/services/activity-record-dsql-pglite.test.ts
+++ b/tests/unit/services/activity-record-dsql-pglite.test.ts
@@ -37,13 +37,17 @@ vi.mock('$lib/server/db/dsql/connection', () => ({
 import { createDsqlChildActivityRepo } from '../../../src/lib/server/db/dsql/child-activity-repo';
 import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
 // サービス層 (dispatch 元) は mock 設定後に import
-import { recordActivity } from '../../../src/lib/server/services/activity-log-service';
+import {
+	cancelActivityLog,
+	recordActivity,
+} from '../../../src/lib/server/services/activity-log-service';
 
 const FAMILY = '00000000-0000-4000-8000-0000000000e1';
 
 let t: DsqlTestDb;
 let childId: ChildId;
 let activityId: string;
+let activityId2: string;
 
 const count = async (table: string, cid: string) =>
 	Number(
@@ -83,11 +87,12 @@ beforeAll(async () => {
 		{ childId, name: 'たいそう', categoryId: asCategoryId('1'), icon: '🤸', basePoints: 5 },
 		FAMILY,
 	);
-	await repo.insertActivity(
+	const a2 = await repo.insertActivity(
 		{ childId, name: 'えほん', categoryId: asCategoryId('2'), icon: '📖', basePoints: 5 },
 		FAMILY,
 	);
 	activityId = a1.id;
+	activityId2 = a2.id;
 }, 60_000);
 
 afterAll(async () => {
@@ -145,5 +150,27 @@ describe('#3541 Phase Z: dsql 経路 end-to-end (PGlite 実 schema + 実 core)',
 		expect(await count('activity_logs', childId)).toBe(1);
 		expect(await count('status_history', childId)).toBe(1);
 		expect(await totalPoint(childId)).toBe(5);
+	});
+
+	it('[E3] #3787: mastery_bonus 付与済 record→cancel は対称返金し total_point net 0', async () => {
+		// activityId2 に習熟 Lv5 (total_count=30) を seed → 次の record で masteryBonus = floor(5/5) = 1
+		await t.db.execute(sql`
+			INSERT INTO activity_mastery (family_id, child_id, activity_id, total_count, level)
+			VALUES (${FAMILY}, ${childId}, ${activityId2}, 30, 5)
+		`);
+
+		const recorded = assertSuccess(await recordActivity(childId, activityId2 as never, FAMILY));
+		// この record で mastery_bonus が実際に付与されている (前提)。totalPoints は base+streak+mastery。
+		expect(recorded.masteryBonus).toBeGreaterThan(0);
+		// achievement 解禁分の別 ledger が混ざるため total_point の絶対値ではなく cancel の相殺量で検証する。
+		const afterRecord = await totalPoint(childId);
+
+		const cancelResult = await cancelActivityLog(recorded.id, FAMILY);
+		if ('error' in cancelResult) throw new Error(`Unexpected error: ${cancelResult.error}`);
+		// 対称返金: cancel は base+streak だけでなく mastery_bonus 込みの totalPoints 全額を返金する
+		// (pre-fix は base+streak のみで mastery_bonus 分が balance に残った)。
+		expect(cancelResult.refundedPoints).toBe(recorded.totalPoints);
+		// cancel は activity ledger 相殺のみ (achievement 分は据置)。total_point は正確に totalPoints 減る。
+		expect(await totalPoint(childId)).toBe(afterRecord - recorded.totalPoints);
 	});
 });

--- a/tests/unit/services/backup-archive.test.ts
+++ b/tests/unit/services/backup-archive.test.ts
@@ -286,7 +286,10 @@ describe('buildFullBackupZip (#3376 AC8)', () => {
 		// 旧実装は非圧縮合計 > 100MB で誤 reject していたが、判定を圧縮後 ZIP サイズ基準に是正したため通る。
 		// data.json は per-entry 対象外 (構造化データ) のため parse 側 filter でも drop されず round-trip する。
 		mockListFiles.mockResolvedValue([]);
-		const hugeCompressibleDataJson = `{"format":"ganbari-quest-backup","version":"1.3.0","pad":"${'a'.repeat(
+		// data.json override は manifest.itemCounts (buildFullBackupZip は exportData から算出) と
+		// 整合させる必要がある (#3386 の itemCounts 照合。本番では dataJson=exportData 直列化で常に一致)。
+		// SAMPLE_EXPORT は children 1 件のため family も同一件数で埋める。
+		const hugeCompressibleDataJson = `{"format":"ganbari-quest-backup","version":"1.3.0","family":{"children":[{"id":"1","nickname":"テスト"}]},"pad":"${'a'.repeat(
 			MAX_ZIP_SIZE + 2 * 1024 * 1024,
 		)}"}`;
 		const zip = await buildFullBackupZip('T1', SAMPLE_EXPORT, false, hugeCompressibleDataJson);


### PR DESCRIPTION
## 顧客価値・目的

活動記録のキャンセルで習熟ボーナス (mastery_bonus) が返金されず、record→cancel の繰り返しでポイントを不正に稼げる (farming vector) point 経済の破綻を根絶する。ポイント台帳を対称化し、記録と取消が必ず net 0 になることを保証する。

## 関連 Issue

- closes #3787
- 由来: PR #3771 / #3596 ② (cancel atomicity) / fitness#14 (point_ledger 整合) / #3718 (ledger 原子化)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | mastery_bonus の付与ロジックが per-record か per-milestone か確認 | `src/lib/server/services/activity-record-preparation.ts:111-113` 読解 | HEAD `92628eea` / **per-record** と確定 (`calcMasteryBonus(currentMasteryLevel)` を毎 record 付与、level≥5 で毎回 +floor(level/5))。farming vector 成立 |
| AC2 | farming vector 成立時 cancel で mastery_bonus も返金 (対称化) | `npx vitest run tests/unit/services/activity-log-service.test.ts` | HEAD `92628eea` / 31 passed / 新規 test「mastery_bonus 対称返金」で record→cancel net 0 (5→6 で red→green) |
| AC3 | 両 backend (sqlite/dynamo/demo + dsql) で対称化 | `npx vitest run tests/unit/services/activity-record-dsql-pglite.test.ts` | HEAD `92628eea` / 3 passed / [E3] dsql pglite 経路で refundedPoints=totalPoints (mastery込) 検証 (pre-fix 5→6 red 実証済) |
| AC4 | 意図的でない非返金の是正を明文化 | 設計書 + code コメント同期 | HEAD `92628eea` / `docs/design/dsql/m3-physical-model.md §6.1` + `cancel-activity-core.ts` 非対称メモを対称返金へ更新 |

## 変更タイプ

- [x] バグ修正 (fix)
- [ ] 新機能 (feat)
- [x] ドキュメント (設計書同期)

## 影響範囲・変更コンポーネント

- `src/lib/domain/validation/activity.ts` — `calcMasteryBonusRefundOnCancel()` SSOT 追加 (付与時と同一式)
- `src/lib/server/services/activity-log-service.ts` — legacy (sqlite/dynamo/demo) cancel の refundPoints + status 復元に mastery_bonus 加算
- `src/lib/server/services/activity-cancel-dsql.ts` — dsql cancel の refundPoints に mastery_bonus 加算
- `src/lib/server/db/dsql/cancel-activity-core.ts` — 非対称メモを対称返金メモへ更新 (comment のみ、txn ロジック不変)
- `docs/design/dsql/m3-physical-model.md` — §6.1 cancel 返金額の同期

## テスト & 安全装置セルフチェック

- [x] failing-test-first (ADR-0061): sqlite 経路 + dsql pglite [E3] 両方で red (5) → green (6) を実証
- [x] domain unit test で `calcMasteryBonusRefundOnCancel` を検証 (付与時額の復元 / 境界 / 防御)
- [x] fitness#14 (total_point == SUM(ledger)) は維持 (record +total / cancel −total で両辺同額減、net 0)
- [x] 既存 cancel test (`refundedPoints === totalPoints`) は mastery=0 case で従来通り green
- [x] biome / cspell / svelte-check (変更 src 0 error) PASS

## スクリーンショット / ビジュアルデモ

UI 変更なし (server 側 point 台帳ロジックの是正のみ)。挙動は unit / integration test で機械検証 (record→cancel が net 0)。

## コード品質セルフレビュー (#1481)

- [x] mastery_bonus 返金額を domain SSOT (`calcMasteryBonusRefundOnCancel`) に集約し 2 backend で共有 (二重実装なし)
- [x] 額算出責務を service 層に凝集 (dsql core は refundPoints を一貫適用するのみ、責務分離)
- [x] mastery_bonus は activity_logs に未永続のため、付与時と同一式 (記録前 level = count-1) で再構成 (既存 mastery count 巻戻しと同精度)

## 横展開・影響波及チェック

- [x] cancel の全 backend 経路 (legacy sqlite/dynamo/demo + dsql) を両方修正 (frontend 契約 {refundedPoints} 不変)
- [x] record 側 (activity-record-preparation.ts) の mastery_bonus 付与式と cancel 側の返金式が対称であることを確認
- [x] status XP 復元も対称化 (record 時 +total と一致、clampDecayFloor 契約は dsql core が保存)

## レビュー依頼事項・破壊的変更

破壊的変更なし。frontend 契約 (`{ refundedPoints }` / NOT_FOUND / CANCEL_EXPIRED) は不変。非 latest record を cancel する稀ケースでは mastery_bonus 復元が近似になるが、これは既存の mastery count 巻戻しと同精度で許容範囲。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した (biome / cspell / svelte-check / vitest 該当 step)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了のまま残した AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み (N/A)
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 (N/A — server ロジックのみ)
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付 (N/A — 認証画面非該当)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言、QM approve 待ち)

## QM レビュー結果

[QM 5 手順 approve body は docs/sessions/qa-session.md を参照](../docs/sessions/qa-session.md)
