### PR TITLE
fix(test): backup-archive #3405-1 の fixture 不整合を根治 (develop red 統合ブロッカー解消)

### DIFF
--- a/tests/unit/services/backup-archive.test.ts
+++ b/tests/unit/services/backup-archive.test.ts
@@ -286,7 +286,10 @@ describe('buildFullBackupZip (#3376 AC8)', () => {
 		// 旧実装は非圧縮合計 > 100MB で誤 reject していたが、判定を圧縮後 ZIP サイズ基準に是正したため通る。
 		// data.json は per-entry 対象外 (構造化データ) のため parse 側 filter でも drop されず round-trip する。
 		mockListFiles.mockResolvedValue([]);
-		const hugeCompressibleDataJson = `{"format":"ganbari-quest-backup","version":"1.3.0","pad":"${'a'.repeat(
+		// data.json override は manifest.itemCounts (buildFullBackupZip は exportData から算出) と
+		// 整合させる必要がある (#3386 の itemCounts 照合。本番では dataJson=exportData 直列化で常に一致)。
+		// SAMPLE_EXPORT は children 1 件のため family も同一件数で埋める。
+		const hugeCompressibleDataJson = `{"format":"ganbari-quest-backup","version":"1.3.0","family":{"children":[{"id":"1","nickname":"テスト"}]},"pad":"${'a'.repeat(
 			MAX_ZIP_SIZE + 2 * 1024 * 1024,
 		)}"}`;
 		const zip = await buildFullBackupZip('T1', SAMPLE_EXPORT, false, hugeCompressibleDataJson);


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発チーム全体 (develop 統合ブロック解消)

**解決する課題**: develop が `tests/unit/services/backup-archive.test.ts` の #3405-1 で **red** になっており、develop から派生する全 PR (#3790/#3791 等) の unit-test (shard 1) が連鎖 fail する統合ブロッカー。

**期待される効果**: develop が green に復帰し、以降の PR が正常に CI を通せる。

## 関連 Issue

closes #3794

関連: #3405 / #3784 (発生元) / #3386 (itemCounts 照合を導入した PR)

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証手段 | 結果 |
|---|---|---|---|
| AC1 | develop red の根本原因特定 | 二分調査 (isolated PASS / in-file FAIL → 入力依存と判明) | buildFullBackupZip が manifest.itemCounts を `exportData`(SAMPLE_EXPORT=children 1) から算出する一方、data.json は override(children 0) を書いていたため #3386 の itemCounts 照合が不一致検出 → parseBackupZip ok=false |
| AC2 | 修正で backup-archive.test.ts が green | `npx vitest run tests/unit/services/backup-archive.test.ts` | **17 passed (0 fail)** |
| AC3 | 本番実害の非該当を確認 | コード確認 | 本番の唯一の caller は `dataJson = JSON.stringify(exportData)` を渡すため counts は常に一致。テスト fixture のみの不整合で本番影響なし |

## 変更タイプ

- [x] test: テスト改善
- [ ] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**: テスト 1 file のみ (`backup-archive.test.ts` の #3405-1 fixture、+4/-1)。production code 変更なし。

## DB スキーマ変更

なし。

## セキュリティチェックリスト

- [x] N/A (テスト fixture のみ)

## パフォーマンス影響

なし。

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/services/backup-archive.test.ts` → 17 passed (修正前 1 failed)
- [x] `npx biome check --error-on-warnings tests/unit/services/backup-archive.test.ts` → clean
- [x] assertion 弱体化なし (ADR-0006): fixture を itemCounts と整合させただけで、round-trip 検証意図・全 assertion は不変
- [x] 新規 env / secret: N/A
- [x] DynamoDB 実装変更: N/A
- [x] Critical バグ修正 (ADR-0002): N/A

## 配布済み env / secret (ADR-0006)

なし。

## スクリーンショット / ビジュアルデモ

N/A (テスト変更、UI なし)。

## コード品質セルフレビュー (#1481)

- [x] fixture の非整合を根本修正 (override data.json に SAMPLE_EXPORT と同件数の family を追加)。assertion は不変で weakening なし

## 横展開・影響波及チェック

- 同型リスク: 他の test が buildFullBackupZip に「exportData と件数の異なる dataJson override」を渡していないか grep 確認済 (#3405-1 のみ)。将来 override を使う test は itemCounts 整合を要する旨をコメントで明示

## Ready for Review チェックリスト

- [x] backup-archive.test.ts 17 passed / biome clean / check-pr-body PASS
- [x] develop red の根本原因 (manifest itemCounts vs override data.json の不整合) を特定・根治

## QM レビュー結果

(QM 記入欄) — develop 統合ブロッカーの hotfix。優先 merge 推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## レビュー依頼事項・破壊的変更

- 破壊的変更なし (テスト fixture 1 行の整合化のみ)。
- develop 統合ブロッカーの hotfix のため優先 merge を推奨。merge 後、#3790/#3791 等を develop に rebase すれば連鎖 fail が解消する。

