### PR TITLE
infra: #3399 develop→main 統合自動化 S0→S4 SSOT + no-diff 早期 exit ガード + S1/S2 sub-issue 起票

### DIFF
--- a/.github/workflows/integration-pr.yml
+++ b/.github/workflows/integration-pr.yml
@@ -27,6 +27,12 @@
 #   初期 = 週 1-2 回 cron (月・木の UTC 21:00 = JST 06:00) から開始。運用安定後に daily へ引き上げる
 #   (daily 化は cron を '0 21 * * *' に変更するだけ、B-6 runbook に手順記載)。
 #   段階導入の意図: drift 蓄積を防ぎつつ GitHub Actions 分の消費を抑制 (Pre-PMF、ADR-0010)。
+#
+# no-diff 早期 exit ガード (branch-strategy.md §10、tracker #3399):
+#   develop==main (git rev-list --count origin/main..origin/develop = 0) の日は upsert / 重量 step を
+#   一切回さず即 skip する (無差分日に重量レーンを空回しさせない)。has_diff==false で後続 upsert 系 step は
+#   skip され、`No-diff early exit (no-op)` step が no-op を job summary に明示する (silent success にしない)。
+#   同ガードは audit run schedule dispatch 側 / staging deploy トリガ側にも徹底する (branch-strategy.md §10)。
 
 name: integration-pr
 
@@ -93,6 +99,21 @@ jobs:
             echo "has_diff=false" >> "$GITHUB_OUTPUT"
             echo "develop と main に差分なし → 統合 PR 不要 (no-op)"
           fi
+
+      # ----------------------------------------------------------------------
+      # 1b. no-diff 早期 exit (no-op) — develop==main の日は後続 upsert / 重量 step を
+      #     一切回さず即 skip し、no-op を job summary に明示する (branch-strategy.md §10 / #3399)。
+      #     後続 step は全て has_diff=='true' gate を持つため、本 step 以降は自動的に skip される。
+      # ----------------------------------------------------------------------
+      - name: No-diff early exit (no-op)
+        if: steps.diff.outputs.has_diff != 'true'
+        run: |
+          echo "::notice::develop==main (no-diff) のため統合 PR upsert / 重量 step を skip します (branch-strategy.md §10 / #3399)。"
+          {
+            echo "### develop→main 統合 PR (#2871)"
+            echo ""
+            echo "- 状態: ⏭️ no-diff early exit (develop==main、統合すべき差分なし)。upsert / 重量 step を skip。"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # ----------------------------------------------------------------------
       # 2. develop の merge 履歴から含有 PR 一覧を取得する (前回統合 merge 以降分、AC3)

--- a/docs/sessions/branch-strategy.md
+++ b/docs/sessions/branch-strategy.md
@@ -262,6 +262,17 @@ develop→main 統合の運用を **手動（audit-manager が release ブラン
 
 **S1 frozen 標的の担保（§3.1 整合）**: S1 で手動 cut を廃し standing 統合 PR を vehicle 化しても、§3.1 の「動く標的」問題（#3063）を再導入しないため、approve→merge は **frozen な HEAD（audit 時点の commit）に対してのみ成立**させる。standing PR の HEAD が develop の進行で動いた場合は adversarial evidence（TTL 30 分、ADR-0056）を無効化し再監査する（approve HEAD = merge HEAD の一致を必須）。vehicle 化は cut の手作業を省く範囲に留め、frozen 標的での監査・TTL 30 分 evidence の不変条件は維持する。
 
+### no-diff 早期 exit ガード（全段共通の必須ガード、#3399）
+
+develop と main に差分が無い日は、release cut / 統合 PR upsert / 重量 CI（audit run / staging deploy）を**一切回さず即 skip する**。無差分日に重量レーンを空回しさせないための必須ガードであり、S0〜S4 の全段・全トリガに徹底する（CI 実行時間・GitHub Actions 分・staging deploy コストの浪費防止、Pre-PMF / ADR-0010）。
+
+- **判定条件**: `git rev-list --count origin/main..origin/develop` = 0（develop に main 未取込 commit なし）なら no-diff。job を早期 success 終了し、後続の重量 step を実行しない。
+- **適用トリガ**:
+  - **standing 統合 PR upsert（`integration-pr.yml`）**: `Detect develop⇔main diff` step の `has_diff=false` で後続 upsert 系 step を skip し、`No-diff early exit (no-op)` step が no-op を job summary に明示する（silent 終了させない）。
+  - **audit run schedule dispatch（S2 で自動化、cloud routine）**: run 冒頭ガードで no-diff を判定し即終了する。監査 agent 起動・adversarial evidence 生成・health check を回さない。
+  - **staging deploy トリガ（AWS / NUC）**: 統合対象差分が無い run では staging deploy を発火させない。
+- **観測性**: no-diff 早期 exit は silent success ではなく job summary / run log に「no-diff → skip」を必ず残す（後から「なぜ回らなかったか」を追跡可能にする）。
+
 ### follow-up 起票の半自動設計
 
 failure 時の follow-up Issue 起票は「素スクリプト自動化」を**不採用**とする（ADR-0003 issue 品質＝根本原因・AC・dedup を満たせず dup spam を生む）。代わりに **schedule 起動の AI audit-manager agent が構造化 evidence から判断起票する半自動**とする（人手でも素スクリプトでもない第 3 の自動化）。品質ガード:
@@ -277,3 +288,21 @@ failure 時の follow-up Issue 起票は「素スクリプト自動化」を**�
 
 - 手動 release ブランチ方式を継続（§3.1）。standing 統合 PR は **S0 観察として残し、各手動 run で supersede close**（自動 body / 含有 PR 列挙の正確性を S1 gate の判定材料として毎サイクル観察）。
 - 各段の移行は #3399 配下の個別 sub-issue で着手する。
+
+### S0→S1 移行 gate の観測ログ運用（AC2、#3399）
+
+S0→S1 の移行 gate =「standing 統合 PR（#3397 系）の自動 body / 含有 PR 列挙が **N サイクル連続で正確**」を判定するため、毎手動 run（standing PR の supersede close 時）に自動 body の正確性を観察記録する。素スクリプトで正確性を機械判定せず、audit-manager が実 body と実含有 PR を突き合わせて人間 verify した結果を記録する（False accuracy claim を避ける）。
+
+- **置き場所**: tracker Issue #3399 のコメントに 1 サイクル 1 行を追記する（累積ログ）。監査 run 全体の証跡は監査 run 証跡表（audit-team.md §3.8 step 8）に含め、そこから抽出した gate 判定行を #3399 に転記する。専用ファイル / 専用 script は新設しない（Pre-PMF、#1442）。
+- **記録項目（1 サイクル分）**:
+
+  | 項目 | 内容 |
+  |---|---|
+  | cycle | 通し番号（第 N 回リリース run） |
+  | standing PR | supersede close した standing 統合 PR 番号（#3397 系） |
+  | 含有 PR 列挙 | 過不足判定（`過不足なし` / `欠落 N 件` / `余分 N 件`）— 自動 body の含有 PR 一覧 vs 実 merge 済 PR |
+  | Closes 集約 | closing keyword 集約の過不足判定（over-close / under-close 有無、#3423 / #3462 整合） |
+  | drift_days | 自動 body に出力された前回統合からの経過日数の妥当性 |
+  | 判定 | `正確` / `不正確`（1 項目でも過不足があれば不正確） |
+  | 連続カウント | 直近の `正確` 連続回数（`不正確` で 0 リセット） |
+- **移行判定**: 連続カウントが gate 閾値 N（初期値 = 3 サイクル）に到達したら S1 移行 sub-issue に着手可とする。`不正確` が出たサイクルは真因を #3399 コメントに併記し、`integration-pr-body.mjs` / 検出規約の修正で潰してからカウントを再開する。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（ソロ PO / audit-manager）・システム全体

**解決する課題**: develop→main 統合の運用を「手動 release cut + 監査 + approve/merge」から段階自動化（S0→S4）する際、各段の移行 gate・no-diff 早期 exit・後続 Issue 起票の半自動設計が SSOT 化されておらず、判断が属人化していた。

**期待される効果**: S0→S4 移管表・no-diff 早期 exit ガード・S0→S1 観測ログ運用を `branch-strategy.md §10` に SSOT 化し、`integration-pr.yml` に no-diff no-op を明示する step を追加。無差分日の重量レーン空回しをゼロにし、段階移行を gate 観測で進められるようにする。EPIC #2861 close の前提となる tracker #3399 の AC1/AC2/AC3 を消化。

## 関連 Issue

closes #3399

（本 PR で起票した S1/S2 sub-issue: #3795 / #3796 = AC3）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | branch-strategy.md に §「自動化段階移管（S0→S4）」+ no-diff 早期 exit + 後続 Issue 起票の半自動設計を SSOT 化 | `docs/sessions/branch-strategy.md §10` 目視 + grep | HEAD `e62eef3d` / §10 に S0→S4 表 + 「### no-diff 早期 exit ガード」+「### 後続 Issue 起票の半自動設計」を含む（branch-strategy.md L265-L307 帯） |
| AC2 | S0→S1 移行 gate（#3397 の自動 body が N サイクル正確）の観測ログを残す運用を定義 | `branch-strategy.md §10` の「### S0→S1 移行 gate の観測ログ運用」目視 | HEAD `e62eef3d` / 置き場所（tracker #3399 コメント）+ 記録項目 7 列表 + 移行判定（N=3 連続正確）を定義 |
| AC3 | 各段の移行は個別 sub-issue で着手（本 issue は統括 tracker） | `gh issue view 3795` / `gh issue view 3796` | S1=#3795（standing 統合 PR vehicle 化）/ S2=#3796（audit run 自動 dispatch + no-diff ガード徹底）を起票、blocked_by #3399 |
| AC4 | 後続 Issue 起票の品質ガード（schema / policy filter / dedup / HOLD escalation）を audit-team.md or audit-manager 定義に明文化 | `docs/sessions/audit-team.md §3.6` + `branch-strategy.md §10` 後続起票節 | 既充足（PR #3400 で audit-team.md §3.6 に明文化済、本 PR で branch-strategy.md §10 にも後続起票の半自動設計を集約）。#3399 コメント（2026-07-11）で AC1-AC4 充足済と確認 |
| PO-1 | no-diff 早期 exit を workflow に実体化（develop==main の日は upsert / 重量 step を skip、PO 指示） | `node -e "yaml.load(...)"` で parse + step 一覧 | HEAD `e62eef3d` / YAML parse OK（12 steps）/ step `No-diff early exit (no-op)` を diff detection 直後に追加（has_diff!='true' で job summary に no-op 明示） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] docs: ドキュメント
- [ ] test: テスト改善
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — `.github/workflows/integration-pr.yml`
- [x] ドキュメント (`docs/sessions/branch-strategy.md`)

**影響を受ける画面・機能**: develop→main 統合 PR 自動運用（`integration-pr.yml` cron/dispatch）。UI 変更なし。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready` 相当の局所検証**: `check-doc-code-references.mjs` PASS（baseline 内 139 件 / 新規違反なし）/ `check-terminology-coherence.ts` PASS（UX coherence 問題なし）/ workflow YAML parse OK（12 steps）。full biome/svelte-check/vitest/cspell は main tree で Ready 化前に実施
- [x] 追加・変更したテスト: N/A（doc + workflow のみ。`integration-pr-body.mjs` pure function は未変更のため既存 `tests/unit/github/integration-pr-body.test.ts` に影響なし。追加 step は既存 has_diff gate と同一 output を参照する no-op ログ step で振る舞い不変）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: docs（branch-strategy.md）+ CI workflow（integration-pr.yml）のみの変更で UI 差分なし。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: workflow の no-diff early-exit step は既存 `Detect develop⇔main diff` の output を参照するだけで責務追加なし。本文生成は既存 `integration-pr-body.mjs` SSOT に不介入
- [x] **DRY**: no-diff 判定は既存 `has_diff` output を再利用（重複判定を追加しない）。branch-strategy.md §10 は audit-team.md §3.6 と後続起票設計を相互参照で集約
- [x] **YAGNI**: S1/S2 の実装自体は sub-issue に切り出し、本 PR は doc SSOT + 最小 workflow step に限定
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。workflow の権限・secret 参照は不変
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: no-diff 日の重量 step skip でむしろ CI 消費削減

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): 統合運用の SSOT である `docs/sessions/branch-strategy.md §10` を同 PR で更新。`.github/CLAUDE.md` / `docs/CLAUDE.md` の統合 PR 記述と整合（既存参照先を変更せず追記のみ）
- [x] **並行 PR overlap** (#1200): `branch-strategy.md` / `integration-pr.yml` を同時期に変更する open PR なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**: no-diff early-exit step は既存の has_diff gate（全後続 step が `if: has_diff=='true'`）と重複せず、no-diff 日に silent success だった挙動へ「no-op を job summary に明示する」観測性のみを追加している点を確認いただきたい。S1/S2 の実装は本 PR scope 外（#3795 / #3796）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready` 相当の局所検証 PASS** をローカル確認した（doc-code-references / terminology-coherence / YAML parse）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了・保留のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（S1=#3795 / S2=#3796、親 tracker #3399）
- [x] UI 変更時: N/A（UI 差分なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

