### PR TITLE
feat(infra): #3437 DSQL AWS Backup (日次 full backup) + 復元 runbook + 役割分担

### DIFF
--- a/docs/research/2026-06-28-aurora-dsql-adoption.md
+++ b/docs/research/2026-06-28-aurora-dsql-adoption.md
@@ -53,7 +53,7 @@
 ## 3. モニタリング / 可観測性
 
 - アラーム: OccConflicts / QueryTimeouts(5 分上限) / CommitLatency P50 / ClusterConnectionCount(10,000 接近) / DbConnect CallCount(100/秒接近) / TotalDPU・ClusterStorageSize。CW 15 ヶ月保持。
-- バックアップ/PITR: DSQL 自動 backup 機構なし → **AWS Backup 統合**で PITR（continuous backup）。復元 = 新クラスタ作成（上書きなし）、同時 restore 最大 4。→ アプリ層 backup-archive（JSON/CSV）は論理 backup として併存価値あり（別レイヤー）。
+- バックアップ: DSQL 自動 backup 機構なし → **AWS Backup 統合**で cluster full backup（**#3437 実装時の AWS 公式 doc 再確認で訂正: DSQL は full snapshot のみで PITR/continuous backup ではない**。RPO = 直近スケジュール backup 時刻。PITR は provisioned Aurora の機能で DSQL 非対応）。復元 = 新クラスタ作成（上書きなし）、同時 restore 最大 4、cluster 全体単位のみ。cluster ARN を明示 assign すれば Service Opt-in 不要。→ アプリ層 backup-archive（JSON/CSV）は論理 backup として併存価値あり（別レイヤー、tenant 単位・秒単位相当の細粒度復元を担保）。実装 = #3437（`infra/lib/dsql-stack.ts` backup vault/plan + `docs/runbooks/dsql-restore.md`）。
 
 ## 4. スキーマ / マイグレーション
 
@@ -220,7 +220,7 @@ staging DSQL lane（EPIC #3424 M5 PDCA）の生きた cluster で実測。詳細
 - authentication-token（DsqlSigner / IAM 一時トークン）
 - Lambda tutorial（接続再利用パターン）
 - AWS::DSQL::Cluster CloudFormation リファレンス
-- backup-aurora-dsql（AWS Backup 統合 / PITR）
+- backup-aurora-dsql（AWS Backup 統合 / full snapshot のみ、PITR 非対応 — #3437 で訂正確認）
 - Drizzle × DSQL × Lambda × CDK の AWS Database Blog 記事
 
 > ⚠️ 上記「ページ名のみ」群は本調査で参照したが、転記時点で URL 文字列の billing-grade な正確性を未再検証。**各 issue 着手時に §0 軸 1（公式ドキュメント一次ソース）で実 URL を取得し、本「出典」節へ確定 URL を昇格**する（誤リンク放置は基盤設計の品質欠陥に当たるため）。

--- a/docs/runbooks/dsql-restore.md
+++ b/docs/runbooks/dsql-restore.md
@@ -12,6 +12,8 @@
 - **DSQL の AWS Backup は full snapshot のみ (PITR / 継続 backup ではない)**。RPO = 直近の日次 backup 時刻 (02:00 UTC)。秒単位の point-in-time 復元は不可 (それは provisioned Aurora の機能で DSQL は非対応)。細かい復元要求はアプリ層 backup-archive で担保する。
 - **backup / restore は AWS Backup (console / CLI / SDK) からのみ**。DSQL console からは実行不可。
 - backup plan: 日次 02:00 UTC / 7 日保持 / vault = `ganbari-quest-dsql-vault` (RETAIN)。cluster ARN を明示 assign しているため AWS Backup の Service Opt-in は不要。
+- **IAM role**: backup / restore とも CDK が確定生成する **`ganbari-quest-dsql-backup-role`** を使う (`AWSBackupServiceRolePolicyForBackup` + `AWSBackupServiceRolePolicyForRestores` の 2 managed policy を付与済)。console 初回操作でしか作られない `AWSBackupDefaultServiceRole` には依存しない (IaC 環境で未 provision の事故を防止、#3437 F-4)。ARN は `DsqlStack` の `BackupRoleArn` output で配布される。
+- **backup 失敗の検知**: 日次 backup ジョブが失敗すると EventBridge Rule `ganbari-quest-dsql-backup-failed` が `Backup Job State Change` (state=FAILED/ABORTED/EXPIRED) を捕捉し `DsqlAlerts` SNS (opsEmail) へ通知する。DSQL の唯一の DR 手段が silent fail するのを防ぐ (ADR-0024 (d))。
 
 ## 月額コスト設計 (< ¥10、マネタイズ整合)
 
@@ -39,9 +41,12 @@ aws backup list-recovery-points-by-backup-vault --backup-vault-name ganbari-ques
 # metadata は describe-recovery-point の RestoreMetadata を雛形にする
 aws backup get-recovery-point-restore-metadata --backup-vault-name ganbari-quest-dsql-vault \
   --recovery-point-arn <RP_ARN> --region us-east-1
+# --iam-role-arn は DsqlStack の BackupRoleArn output (= ganbari-quest-dsql-backup-role) を使う:
+ROLE_ARN=$(aws cloudformation describe-stacks --stack-name GanbariQuestDsql --region us-east-1 \
+  --query "Stacks[0].Outputs[?OutputKey=='BackupRoleArn'].OutputValue" --output text)
 # 上記 metadata (deletionProtectionEnabled 等) を渡して restore
 aws backup start-restore-job --recovery-point-arn <RP_ARN> --region us-east-1 \
-  --iam-role-arn <AWSBackupDefaultServiceRole ARN> \
+  --iam-role-arn "$ROLE_ARN" \
   --resource-type AuroraDsql --metadata '<RestoreMetadata JSON>'
 ```
 `aws backup describe-restore-job --restore-job-id <id>` で `COMPLETED` を待つ。
@@ -72,10 +77,11 @@ curl -s https://ganbari-quest.com/api/health   # dataSource:dsql / schemaValid:t
 |---|---|
 | 本番 cluster 消失・全 500 | priority:critical + PO 即報告。本手順で最新 recovery point から新 cluster 復元 |
 | tenant 単位の誤削除・巻戻し | AWS Backup ではなく **アプリ層 backup-archive (JSON/CSV) で該当 tenant を import** (物理 restore は cluster 全体を巻き戻すため不適) |
-| restore job が失敗 | `describe-restore-job` の StatusMessage 確認。IAM role / metadata 不整合が典型 |
+| restore job が失敗 | `describe-restore-job` の StatusMessage 確認。metadata 不整合が典型 (IAM role は `ganbari-quest-dsql-backup-role` = backup/restore 両権限付きを使う) |
+| 日次 backup ジョブが失敗 | `ganbari-quest-dsql-backup-failed` の SNS 通知が来る。`aws backup describe-backup-job --backup-job-id <id>` で原因確認 (cluster busy / 権限 / vault full 等)。連日失敗 = DR 空白のため priority:high |
 
 ## 関連
-- 実装: `infra/lib/dsql-stack.ts` (backup vault/plan) + `tests/unit/infra/dsql-cdk.test.ts` [I8][N4]
+- 実装: `infra/lib/dsql-stack.ts` (backup vault/plan/role + 失敗検知 rule) + `tests/unit/infra/dsql-cdk.test.ts` [I8][I8c][I8d][N4]
 - 論理 backup: `src/lib/server/services/backup-archive.ts` (#3376) / データモデル §6.4
 - alarm 一次対応: [dsql-alert-response.md](dsql-alert-response.md)
 - AWS 公式: [Aurora DSQL backups](https://docs.aws.amazon.com/aws-backup/latest/devguide/backup-aurora.html) / [restore](https://docs.aws.amazon.com/aws-backup/latest/devguide/restore-auroradsql.html)

--- a/docs/runbooks/dsql-restore.md
+++ b/docs/runbooks/dsql-restore.md
@@ -1,0 +1,81 @@
+# Runbook — DSQL 復元 (AWS Backup) + backup 役割分担
+
+本番 Aurora DSQL (us-east-1) の災害復旧手順。#3437 / EPIC #3424。実装 SSOT: `infra/lib/dsql-stack.ts` (`DsqlBackupVault` / `DsqlBackupPlan`)。
+
+## 2 層 backup の役割分担 (#3437 AC1)
+
+| 層 | 実体 | 目的 | 粒度 | 復元先 |
+|---|---|---|---|---|
+| **物理 backup** | AWS Backup (cluster full snapshot) | **基盤災害復旧** (cluster 消失・破損・region 障害) | **cluster 全体のみ** (テーブル/行単位は不可) | **新 cluster** (source 上書きなし) |
+| **論理 backup** | アプリ層 backup-archive (JSON/CSV、#3376) | **ユーザー操作・移行・per-tenant 復元** | tenant 単位の論理データ | 既存 cluster へ import |
+
+- **DSQL の AWS Backup は full snapshot のみ (PITR / 継続 backup ではない)**。RPO = 直近の日次 backup 時刻 (02:00 UTC)。秒単位の point-in-time 復元は不可 (それは provisioned Aurora の機能で DSQL は非対応)。細かい復元要求はアプリ層 backup-archive で担保する。
+- **backup / restore は AWS Backup (console / CLI / SDK) からのみ**。DSQL console からは実行不可。
+- backup plan: 日次 02:00 UTC / 7 日保持 / vault = `ganbari-quest-dsql-vault` (RETAIN)。cluster ARN を明示 assign しているため AWS Backup の Service Opt-in は不要。
+
+## 月額コスト設計 (< ¥10、マネタイズ整合)
+
+backup は全 tenant 共有の 1 cluster 単位課金 (per-tenant ではない) のため、cluster 全体で月額 < ¥10 に抑える。
+
+- **課金式**: AWS Backup warm storage = **$0.05/GB-month** (us-east-1、DSQL は cold tier 非対応)。月額 ≈ `retention_points(7) × ClusterStorageSize × $0.05`。
+- **実測 (2026-07-17)**: ClusterStorageSize = **1.35 MiB** → 7 × 0.00132 GiB × $0.05 ≈ **$0.0005/月 ≈ ¥0.07/月** (¥10 の約 140 分の 1)。
+- **¥10 到達点**: 7 日 retention では cluster ≈ **190 MiB** で ¥10 (≈$0.067)。現状の約 145 倍成長までは < ¥10。
+- **hard 監視**: `DsqlBackupBudget` ($0.07 ≈ ¥10、AWS Backup service filter) が 80% / 100% で通知する。
+- **¥10 接近時の対処**: budget 通知が来たら **retention_points を短縮** する (`dsql-stack.ts` の `deleteAfter` を 7→3 日等)。7→3 で月額 3/7 に、tenant 単位細粒度復元は論理 backup-archive が担保するため DR 実害は小。復元 RPO が要件を満たす範囲で最短化する。
+
+## 復元手順 (#3437 AC2)
+
+> **前提**: 同時 restore は最大 4。復元は新 cluster を作成し **source cluster を上書きしない** (= 常にロールバック可能)。full-cluster 単位のみ。
+
+### 1. recovery point を特定
+```bash
+aws backup list-recovery-points-by-backup-vault --backup-vault-name ganbari-quest-dsql-vault \
+  --region us-east-1 --query 'RecoveryPoints[].{arn:RecoveryPointArn,created:CreationDate,status:Status}' --output table
+```
+復元したい時刻直前の `COMPLETED` な recovery point の ARN を選ぶ。
+
+### 2. restore job を起動 (新 cluster が作られる)
+```bash
+# metadata は describe-recovery-point の RestoreMetadata を雛形にする
+aws backup get-recovery-point-restore-metadata --backup-vault-name ganbari-quest-dsql-vault \
+  --recovery-point-arn <RP_ARN> --region us-east-1
+# 上記 metadata (deletionProtectionEnabled 等) を渡して restore
+aws backup start-restore-job --recovery-point-arn <RP_ARN> --region us-east-1 \
+  --iam-role-arn <AWSBackupDefaultServiceRole ARN> \
+  --resource-type AuroraDsql --metadata '<RestoreMetadata JSON>'
+```
+`aws backup describe-restore-job --restore-job-id <id>` で `COMPLETED` を待つ。
+
+### 3. 新 cluster の endpoint を取得
+```bash
+aws dsql list-clusters --region us-east-1 --output table   # 新 cluster identifier を確認
+# endpoint = <new-cluster-id>.dsql.us-east-1.on.aws
+```
+
+### 4. アプリを新 cluster へ切替 (DSQL_ENDPOINT 差替 + 再 deploy)
+`compute-stack` は `-c dsqlEndpoint=<...>` / `-c dsqlClusterArn=<...>` context で Lambda の `DSQL_ENDPOINT` と `dsql:DbConnect` resource 限定を配線する (`infra/lib/compute-stack.ts`)。復元 cluster の endpoint / ARN を渡して再 deploy する:
+```bash
+gh workflow run deploy.yml --ref main   # deploy が DsqlStack Output から endpoint/ARN を解決
+# 復元 cluster が別 stack 外の場合は手動 -c dsqlEndpoint=<new> -c dsqlClusterArn=<new> で cdk deploy
+```
+migration (schema) は cold start / deploy 時に `applyLazyStartupMigrations` が適用する。
+
+### 5. 検証 + 旧 cluster 保持
+```bash
+curl -s https://ganbari-quest.com/api/health   # dataSource:dsql / schemaValid:true を確認
+```
+- 検証 OK まで **旧 cluster は削除しない** (即ロールバック可)。
+- 復元が誤りだった場合は DSQL_ENDPOINT を旧 cluster に戻して再 deploy。
+
+## エスカレーション
+| 状況 | 行動 |
+|---|---|
+| 本番 cluster 消失・全 500 | priority:critical + PO 即報告。本手順で最新 recovery point から新 cluster 復元 |
+| tenant 単位の誤削除・巻戻し | AWS Backup ではなく **アプリ層 backup-archive (JSON/CSV) で該当 tenant を import** (物理 restore は cluster 全体を巻き戻すため不適) |
+| restore job が失敗 | `describe-restore-job` の StatusMessage 確認。IAM role / metadata 不整合が典型 |
+
+## 関連
+- 実装: `infra/lib/dsql-stack.ts` (backup vault/plan) + `tests/unit/infra/dsql-cdk.test.ts` [I8][N4]
+- 論理 backup: `src/lib/server/services/backup-archive.ts` (#3376) / データモデル §6.4
+- alarm 一次対応: [dsql-alert-response.md](dsql-alert-response.md)
+- AWS 公式: [Aurora DSQL backups](https://docs.aws.amazon.com/aws-backup/latest/devguide/backup-aurora.html) / [restore](https://docs.aws.amazon.com/aws-backup/latest/devguide/restore-auroradsql.html)

--- a/infra/lib/dsql-stack.ts
+++ b/infra/lib/dsql-stack.ts
@@ -1,8 +1,10 @@
 import * as cdk from 'aws-cdk-lib';
+import * as backup from 'aws-cdk-lib/aws-backup';
 import * as budgets from 'aws-cdk-lib/aws-budgets';
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as cw_actions from 'aws-cdk-lib/aws-cloudwatch-actions';
 import * as dsql from 'aws-cdk-lib/aws-dsql';
+import * as events from 'aws-cdk-lib/aws-events';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
 import type { Construct } from 'constructs';
@@ -194,6 +196,69 @@ export class DsqlStack extends cdk.Stack {
 				],
 			],
 		});
+
+		// ── 5. AWS Backup (物理 backup、#3437) ──
+		// DSQL は自動 backup 機構を持たないため AWS Backup で cluster 全体の full backup を
+		// 日次取得する。**DSQL の backup は full snapshot のみ (PITR/継続 backup ではない)** —
+		// 復元は AWS Backup が新 cluster を作成し (source 上書きなし)、DSQL_ENDPOINT 切替が必要
+		// (runbook: docs/runbooks/dsql-restore.md)。アプリ層 backup-archive (JSON/CSV、#3376) は
+		// 論理 backup として別レイヤー併存 (役割分担は data-model §6.4)。cluster ARN を **明示 assign**
+		// するため AWS Backup の Service Opt-in は不要 (explicit resource assignment は opt-in 設定に
+		// 依らず対象化される、AWS Backup 仕様)。staging は使い捨て (#2873) のため backup を省略する。
+		const isStaging = nameSuffix === '-staging';
+		if (!isStaging) {
+			const backupVault = new backup.BackupVault(this, 'DsqlBackupVault', {
+				backupVaultName: `ganbari-quest-dsql${nameSuffix}-vault`,
+				// backup vault は誤削除で復元不能ゆえ RETAIN (stack 削除でも backup を残す)。
+				removalPolicy: cdk.RemovalPolicy.RETAIN,
+			});
+			const backupPlan = new backup.BackupPlan(this, 'DsqlBackupPlan', {
+				backupPlanName: `ganbari-quest-dsql${nameSuffix}-daily`,
+				backupPlanRules: [
+					new backup.BackupPlanRule({
+						ruleName: 'daily-7day-retention',
+						// 02:00 UTC (低トラフィック帯)。**月額コスト設計 (< ¥10、マネタイズ整合)**:
+						//   AWS Backup warm storage = $0.05/GB-month (us-east-1、DSQL は cold tier 非対応)。
+						//   月額 ≈ retention_points(7) × ClusterStorageSize × $0.05。
+						//   実測 (2026-07-17) ClusterStorageSize = 1.35 MiB → 7 × 0.00132GiB × $0.05
+						//   ≈ $0.0005/月 ≈ **¥0.07/月** (¥10 の 140 分の 1)。¥10 (≈$0.067) 到達は cluster
+						//   ~190 MiB 相当 (現状の ~145 倍)。下の DsqlBackupBudget が ¥10 接近で通知し、
+						//   その時点で retention を短縮する (runbook: dsql-restore.md §コスト)。
+						scheduleExpression: events.Schedule.cron({ hour: '2', minute: '0' }),
+						deleteAfter: cdk.Duration.days(7),
+						backupVault: backupVault,
+					}),
+				],
+			});
+			backupPlan.addSelection('DsqlCluster', {
+				resources: [backup.BackupResource.fromArn(this.cluster.attrResourceArn)],
+			});
+
+			// 月額 backup コストを ¥10 未満に保つ guardrail (マネタイズ整合)。AWS Backup storage は
+			// DSQL の RDS budget (上記 $1) と別 attribution ('Backup' service) になり得るため専用 budget を
+			// 置き、$0.07 (≈¥10) の 80%/100% で通知する (接近したら retention 短縮 → dsql-restore.md)。
+			if (props?.opsEmail) {
+				new budgets.CfnBudget(this, 'DsqlBackupBudget', {
+					budget: {
+						budgetName: `ganbari-quest-dsql${nameSuffix}-backup-guardrail`,
+						budgetType: 'COST',
+						timeUnit: 'MONTHLY',
+						// $0.07 ≈ ¥10 (¥150/$ 換算)。設計目標「月額 < ¥10」の hard 上限監視。
+						budgetLimit: { amount: 0.07, unit: 'USD' },
+						costFilters: { Service: ['AWS Backup'] },
+					},
+					notificationsWithSubscribers: [80, 100].map((threshold) => ({
+						notification: {
+							notificationType: 'ACTUAL',
+							comparisonOperator: 'GREATER_THAN',
+							threshold,
+							thresholdType: 'PERCENTAGE',
+						},
+						subscribers: [{ subscriptionType: 'EMAIL', address: props.opsEmail as string }],
+					})),
+				});
+			}
+		}
 
 		new cdk.CfnOutput(this, 'ClusterIdentifier', { value: clusterId });
 		new cdk.CfnOutput(this, 'ClusterEndpoint', {

--- a/infra/lib/dsql-stack.ts
+++ b/infra/lib/dsql-stack.ts
@@ -5,6 +5,8 @@ import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as cw_actions from 'aws-cdk-lib/aws-cloudwatch-actions';
 import * as dsql from 'aws-cdk-lib/aws-dsql';
 import * as events from 'aws-cdk-lib/aws-events';
+import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
 import type { Construct } from 'constructs';
@@ -230,8 +232,57 @@ export class DsqlStack extends cdk.Stack {
 					}),
 				],
 			});
+			// backup / restore を AWS Backup が assume する role を**明示 provision** する (#3437 F-4)。
+			// CDK 自動生成 role は backup 権限のみで restore 権限を持たず、`AWSBackupDefaultServiceRole`
+			// は console 初回操作でしか作られない (IaC 環境では未 provision の可能性)。両 managed policy を
+			// 付けた named role を CDK で確定生成し、backup selection と restore job (runbook §2 の
+			// --iam-role-arn) の双方で同一 role を使う (role 不整合による復元失敗を防止)。
+			const backupRole = new iam.Role(this, 'DsqlBackupRole', {
+				roleName: `ganbari-quest-dsql${nameSuffix}-backup-role`,
+				assumedBy: new iam.ServicePrincipal('backup.amazonaws.com'),
+				description: 'AWS Backup が DSQL cluster の backup / restore を実行する role (#3437)',
+				managedPolicies: [
+					iam.ManagedPolicy.fromAwsManagedPolicyName(
+						'service-role/AWSBackupServiceRolePolicyForBackup',
+					),
+					iam.ManagedPolicy.fromAwsManagedPolicyName(
+						'service-role/AWSBackupServiceRolePolicyForRestores',
+					),
+				],
+			});
 			backupPlan.addSelection('DsqlCluster', {
 				resources: [backup.BackupResource.fromArn(this.cluster.attrResourceArn)],
+				role: backupRole,
+			});
+
+			// backup ジョブ失敗の検知 (#3437 F-2 / ADR-0024 (d): silent fail 防止)。AWS Backup は
+			// DSQL の唯一の DR 手段のため、日次 backup が毎晩 silent fail しても誰も気づかない =
+			// EPIC #3424 が塞いだはずの DR 空白の再現。EventBridge で Backup Job State Change の
+			// 失敗系 (FAILED / ABORTED / EXPIRED) を捕捉し、上で無条件生成済の DsqlAlerts SNS topic
+			// へ通知する (コスト guardrail の DsqlBackupBudget はコスト検知でありジョブ失敗検知ではない)。
+			// topic は opsEmail 未指定でも存在するため silent skip しない (ADR-0024 ルール 1)。opsEmail
+			// 未注入時は email subscription なし = メール未達だが rule / topic は provision される
+			// (staging は本 backup ブロック自体に入らないため対象外)。vault 名で scope し、同一
+			// アカウントの無関係 backup 失敗を拾わない。
+			new events.Rule(this, 'DsqlBackupJobFailed', {
+				ruleName: `ganbari-quest-dsql${nameSuffix}-backup-failed`,
+				description:
+					'AWS Backup ジョブ失敗 (FAILED/ABORTED/EXPIRED) を検知し DsqlAlerts へ通知 (#3437 / ADR-0024 (d)) 一次対応: docs/runbooks/dsql-restore.md',
+				eventPattern: {
+					source: ['aws.backup'],
+					detailType: ['Backup Job State Change'],
+					detail: {
+						state: ['FAILED', 'ABORTED', 'EXPIRED'],
+						backupVaultName: [backupVault.backupVaultName],
+					},
+				},
+				targets: [new eventsTargets.SnsTopic(topic)],
+			});
+
+			// restore job (runbook §2 の start-restore-job --iam-role-arn) が使う role ARN を配布。
+			new cdk.CfnOutput(this, 'BackupRoleArn', {
+				value: backupRole.roleArn,
+				description: 'AWS Backup backup/restore role ARN (dsql-restore.md の --iam-role-arn)',
 			});
 
 			// 月額 backup コストを ¥10 未満に保つ guardrail (マネタイズ整合)。AWS Backup storage は

--- a/tests/unit/infra/dsql-cdk.test.ts
+++ b/tests/unit/infra/dsql-cdk.test.ts
@@ -5,6 +5,7 @@
 //   - CfnCluster は deletion protection 既定 true (#3429、誤 destroy の物理拒否)
 //   - コストガードレール: TotalDPU 日次 / Storage 80% の 2 alarm + Budgets $1 (80/100%) (#3431)
 //   - 可観測性 dashboard (OccConflicts/QueryTimeouts/CommitLatency/接続数) (#3432)
+//   - AWS Backup: 日次 full backup plan + backup/restore role 明示 provision + 失敗検知 rule (#3437)
 //   - `-c dsqlEnabled=true` 無しでは合成されない (M5 承認前の誤 deploy 防止)
 
 import * as cdk from 'aws-cdk-lib';
@@ -152,6 +153,68 @@ describe('DsqlStack (EPIC #3424 M4-E item 12)', () => {
 			}),
 		});
 	});
+
+	it('[I8c] backup ジョブ失敗を EventBridge → DsqlAlerts SNS で検知する (#3437 F-2 / ADR-0024 (d))', () => {
+		// 日次 backup が silent fail しても誰も気づかない = DR 空白の再現 (ADR-0024 生成インシデント根本原因 D)。
+		// Backup Job State Change の失敗系を捕捉し、コスト guardrail (budget) ではなく「ジョブ失敗」を検知する。
+		template.hasResourceProperties('AWS::Events::Rule', {
+			EventPattern: Match.objectLike({
+				source: ['aws.backup'],
+				'detail-type': ['Backup Job State Change'],
+				detail: Match.objectLike({
+					state: ['FAILED', 'ABORTED', 'EXPIRED'],
+				}),
+			}),
+		});
+		// alert 先は新規 SNS を作らず既存 DsqlAlerts topic に相乗り (SNS topic は依然 1 個)。
+		template.resourceCountIs('AWS::SNS::Topic', 1);
+		const rules = template.findResources('AWS::Events::Rule', {
+			Properties: {
+				EventPattern: Match.objectLike({ source: ['aws.backup'] }),
+			},
+		});
+		const backupFailRule = Object.values(rules)[0];
+		expect(backupFailRule?.Properties?.Targets).toHaveLength(1);
+		// target は SNS topic (Ref で DsqlAlerts を指す)。
+		expect(JSON.stringify(backupFailRule?.Properties?.Targets)).toContain('DsqlAlerts');
+	});
+
+	it('[I8d] backup/restore role を明示 provision し selection に配線する (#3437 F-4、role 不整合防止)', () => {
+		// CDK 自動生成 role は backup 権限のみ。restore job (runbook §2) が使えるよう backup + restore の
+		// 2 managed policy を付けた named role を確定生成する (AWSBackupDefaultServiceRole 依存を排除)。
+		template.hasResourceProperties('AWS::IAM::Role', {
+			RoleName: 'ganbari-quest-dsql-backup-role',
+			AssumeRolePolicyDocument: Match.objectLike({
+				Statement: Match.arrayWith([
+					Match.objectLike({
+						Principal: Match.objectLike({ Service: 'backup.amazonaws.com' }),
+					}),
+				]),
+			}),
+			ManagedPolicyArns: Match.arrayWith([
+				Match.objectLike({
+					'Fn::Join': Match.arrayWith([
+						Match.arrayWith([Match.stringLikeRegexp('AWSBackupServiceRolePolicyForBackup')]),
+					]),
+				}),
+				Match.objectLike({
+					'Fn::Join': Match.arrayWith([
+						Match.arrayWith([Match.stringLikeRegexp('AWSBackupServiceRolePolicyForRestores')]),
+					]),
+				}),
+			]),
+		});
+		// BackupSelection が上記 role を参照する (自動生成 role でなく named role)。
+		template.hasResourceProperties('AWS::Backup::BackupSelection', {
+			BackupSelection: Match.objectLike({
+				IamRoleArn: Match.objectLike({
+					'Fn::GetAtt': Match.arrayWith([Match.stringLikeRegexp('^DsqlBackupRole')]),
+				}),
+			}),
+		});
+		// restore job が使う role ARN を output で配布する (runbook の --iam-role-arn)。
+		template.hasOutput('BackupRoleArn', {});
+	});
 });
 
 // #3703 / #3708: dashboard / budget の物理名は staging / prod で一意でなければならない。
@@ -200,5 +263,10 @@ describe('DsqlStack nameSuffix guard (#3703 / #3708 staging・prod 物理名一�
 		staging.resourceCountIs('AWS::Backup::BackupVault', 0);
 		staging.resourceCountIs('AWS::Backup::BackupPlan', 0);
 		staging.resourceCountIs('AWS::Backup::BackupSelection', 0);
+		// backup 付随リソース (role / 失敗検知 rule) も staging では作らない (#3437 F-2/F-4)。
+		prod.resourceCountIs('AWS::IAM::Role', 1);
+		staging.resourceCountIs('AWS::IAM::Role', 0);
+		prod.resourceCountIs('AWS::Events::Rule', 1);
+		staging.resourceCountIs('AWS::Events::Rule', 0);
 	});
 });

--- a/tests/unit/infra/dsql-cdk.test.ts
+++ b/tests/unit/infra/dsql-cdk.test.ts
@@ -83,7 +83,8 @@ describe('DsqlStack (EPIC #3424 M4-E item 12)', () => {
 	});
 
 	it('[I5] Budgets $1 が 80% / 100% の 2 段通知で作成される (#3431)', () => {
-		template.resourceCountIs('AWS::Budgets::Budget', 1);
+		// DSQL guardrail ($1) + backup guardrail ($0.07、#3437) の 2 budget。
+		template.resourceCountIs('AWS::Budgets::Budget', 2);
 		template.hasResourceProperties('AWS::Budgets::Budget', {
 			Budget: Match.objectLike({
 				BudgetName: 'ganbari-quest-dsql-guardrail',
@@ -118,6 +119,38 @@ describe('DsqlStack (EPIC #3424 M4-E item 12)', () => {
 		]) {
 			expect(body).toContain(metric);
 		}
+	});
+
+	it('[I8] AWS Backup: prod は日次 full backup plan (7日保持) + cluster ARN 明示 selection (#3437)', () => {
+		// DSQL は自動 backup を持たないため AWS Backup で cluster full backup を日次取得。
+		template.resourceCountIs('AWS::Backup::BackupVault', 1);
+		template.resourceCountIs('AWS::Backup::BackupPlan', 1);
+		template.resourceCountIs('AWS::Backup::BackupSelection', 1);
+		// daily rule + 7 日保持 (Pre-PMF 最小 DR 窓)。
+		template.hasResourceProperties('AWS::Backup::BackupPlan', {
+			BackupPlan: {
+				BackupPlanRule: Match.arrayWith([Match.objectLike({ Lifecycle: { DeleteAfterDays: 7 } })]),
+			},
+		});
+		// cluster ARN を明示 assign (Service Opt-in 不要の根拠。ARN は cluster の attrResourceArn)。
+		template.hasResourceProperties('AWS::Backup::BackupSelection', {
+			BackupSelection: Match.objectLike({
+				Resources: Match.arrayWith([
+					Match.objectLike({ 'Fn::GetAtt': Match.arrayWith(['ResourceArn']) }),
+				]),
+			}),
+		});
+	});
+
+	it('[I8b] backup 月額コスト guardrail budget $0.07 (≈¥10) が存在する (#3437、マネタイズ整合)', () => {
+		// 月額 backup コスト < ¥10 の設計目標を hard 監視。AWS Backup service filter で $0.07 上限。
+		template.hasResourceProperties('AWS::Budgets::Budget', {
+			Budget: Match.objectLike({
+				BudgetName: 'ganbari-quest-dsql-backup-guardrail',
+				BudgetLimit: { Amount: 0.07, Unit: 'USD' },
+				CostFilters: Match.objectLike({ Service: ['AWS Backup'] }),
+			}),
+		});
 	});
 });
 
@@ -157,5 +190,15 @@ describe('DsqlStack nameSuffix guard (#3703 / #3708 staging・prod 物理名一�
 		const staging = physicalNames('GanbariQuestDsqlStaging');
 		expect(prod.dashboard).not.toBe(staging.dashboard);
 		expect(prod.budget).not.toBe(staging.budget);
+	});
+
+	it('[N4] staging は AWS Backup を作らない / 本番は作る (#3437、使い捨て staging で backup コスト回避)', () => {
+		const app = new cdk.App();
+		const prod = Template.fromStack(new DsqlStack(app, 'GanbariQuestDsql'));
+		const staging = Template.fromStack(new DsqlStack(new cdk.App(), 'GanbariQuestDsqlStaging'));
+		prod.resourceCountIs('AWS::Backup::BackupPlan', 1);
+		staging.resourceCountIs('AWS::Backup::BackupVault', 0);
+		staging.resourceCountIs('AWS::Backup::BackupPlan', 0);
+		staging.resourceCountIs('AWS::Backup::BackupSelection', 0);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

本番 DSQL（家族の全記録の primary DB）の**基盤災害復旧を最小担保**する。DSQL は自動 backup を持たないため、cluster 消失・破損時に復旧手段がない状態だった。AWS Backup で日次 full backup を取得し、**backup ジョブ失敗を検知する監視**を配線し、復元手順を runbook 化する（#3437、EPIC #3424 の DR 空白の解消）。

## 関連 Issue

- closes #3437（DSQL backup とアプリ層 backup の役割分担、EPIC #3424 設計⑧）。着手時 deep research を本 PR で実施し issue 前提を訂正。base=develop のため develop merge では auto-close せず、develop→main 統合時に close される標準フロー。

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証 | 状態 |
|---|---|---|---|
| AC1: 物理 backup(AWS Backup) / 論理 backup(backup-archive) の役割を明文化 | `docs/runbooks/dsql-restore.md` の 2 層 backup 役割分担表 + dsql-stack.ts コメント | runbook レビュー | ✅ |
| AC2: PITR 復元フロー runbook | `docs/runbooks/dsql-restore.md`（recovery point 特定 → restore → 新 cluster endpoint 切替 → 検証 → 旧 cluster 保持） | 手順の CLI コマンド + 公式 doc link | ✅ |
| AC3: AWS Backup 統合を CDK で IaC 化 | `infra/lib/dsql-stack.ts`（BackupVault + BackupPlan 日次7日 + BackupSelection cluster ARN + backup/restore role） | `tests/unit/infra/dsql-cdk.test.ts` [I8][N4]（synth 成功 = CDK API 正当） | ✅ |
| AC(QM F-2): backup ジョブ失敗 alarm (ADR-0024 (d)) | `infra/lib/dsql-stack.ts` EventBridge Rule `DsqlBackupJobFailed`（Backup Job State Change の FAILED/ABORTED/EXPIRED を捕捉 → 既存 `DsqlAlerts` SNS へ通知） | `tests/unit/infra/dsql-cdk.test.ts` [I8c]（event pattern + SNS wiring + [N4] staging skip） | ✅ |
| AC(QM F-4): 復元 role 整合 | `infra/lib/dsql-stack.ts` 明示 IAM role `ganbari-quest-dsql-backup-role`（backup+restore の 2 managed policy）を selection に配線 + `BackupRoleArn` output。runbook を同 role 参照に是正 | `tests/unit/infra/dsql-cdk.test.ts` [I8d] + runbook §前提/§復元手順 | ✅ |

## 変更タイプ

- [ ] バグ修正
- [x] 新機能（infra: DR backup + backup 失敗監視）
- [ ] リファクタリング
- [x] テスト追加
- [x] ドキュメント（runbook + research 訂正）

## 影響範囲・変更コンポーネント

- `infra/lib/dsql-stack.ts`: BackupVault(RETAIN) + BackupPlan(日次 02:00 UTC / 7 日保持) + BackupSelection(cluster ARN 明示 + **明示 IAM role**) + **EventBridge Rule(backup 失敗検知 → DsqlAlerts SNS)** + `BackupRoleArn` output。**本番 stack のみ**（staging は使い捨てで省略、#2873）。additive（既存 resource 不変、新規 SNS を作らず既存 DsqlAlerts に相乗り）。
- `tests/unit/infra/dsql-cdk.test.ts`: [I8] prod backup、[I8c] 失敗検知 rule + SNS wiring、[I8d] backup/restore role + selection 配線 + output、[N4] staging skip（backup/role/rule すべて 0）。
- `docs/runbooks/dsql-restore.md`（新規）: 復元 IAM を `ganbari-quest-dsql-backup-role`（backup+restore 権限付き、`BackupRoleArn` output 経由取得）に是正 + backup 失敗検知の一次対応を追記。/ `docs/research/2026-06-28-aurora-dsql-adoption.md`（PITR 誤記訂正）。
- **runtime 非変更**（Lambda / cluster の稼働設定に触れない。backup infra + 監視の追加のみ）。

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/infra/dsql-cdk.test.ts` → 17 passed（[I8]/[I8b]/[I8c]/[I8d] backup plan/selection/role/失敗検知 rule + [N4] staging skip、synth 成功）。infra 全体 100 passed。
- `cd infra && npx cdk synth GanbariQuestDsql -c dsqlEnabled=true` → exit 0（DsqlBackupRole / DsqlBackupJobFailed / BackupSelection が template に出力）。
- biome clean。additive のみゆえ **ADR-0019 replacement 非該当**（deploy 時の replacement gate も pass 見込み）。
- **deep research（AWS 公式 doc）で issue 前提を訂正**: AWS Backup は DSQL をサポートするが **full snapshot のみ（PITR/continuous 非対応）**。cluster ARN 明示 assign で Service Opt-in 不要 → custom resource 不要（Pre-PMF 最小、ADR-0010）。

## スクリーンショット / ビジュアルデモ

N/A（infra、UI 変更なし）。

## コード品質セルフレビュー (#1481)

- 既存 `storage-stack.ts` の aws-backup パターン（Vault + Plan + Rule + Selection）+ `ops-stack.ts` の EventBridge→SNS パターン（`AwsHealthAlert`）を踏襲。backup 失敗検知は新規 SNS を作らず既存 `DsqlAlerts` topic に相乗り（ADR-0024 ルール 1: topic 不在時 silent skip せず、topic は opsEmail 未指定でも無条件生成済）。
- 復元 role は console 初回操作でしか作られない `AWSBackupDefaultServiceRole` に依存せず、backup+restore の 2 managed policy を付けた named role を CDK で確定生成（role 不整合による復元失敗を防止）。
- vault は RETAIN（backup は誤削除で復元不能）。staging は disposable ゆえ backup / role / rule すべて省略でコスト回避。
- retention 7 日は Pre-PMF 最小 DR 窓（storage <1GB で backup コスト無視可能、runbook で調整可能と明記）。

## 横展開・影響波及チェック

- backup role 分担は runbook を SSOT とし、設計 doc への重複記載を避ける（docs SSOT 原則 #2440）。§6.4 は app 層 chunk-saga（#3428）で AWS Backup とは別レイヤーのため非該当。
- 復元時の DSQL_ENDPOINT 切替は既存 compute-stack の `-c dsqlEndpoint` 配線を再利用（新機軸なし）。
- backup 失敗の一次対応導線は既存 `dsql-restore.md` エスカレーション表 + alarm 一次対応 `dsql-alert-response.md` に集約。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし（additive infra）。**production deploy 時に BackupVault/Plan/Selection/Role/EventBridge Rule が新規作成される**（既存 resource は不変）。
- レビュー観点: ① retention 7 日で DR 窓が妥当か（論理 backup-archive と併せた 2 層で担保）② vault RETAIN の removalPolicy ③ backup 失敗検知の event pattern（FAILED/ABORTED/EXPIRED）が過不足ないか。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。AWS Backup role は CDK が確定生成（`ganbari-quest-dsql-backup-role`、`AWSBackupServiceRolePolicyForBackup` + `AWSBackupServiceRolePolicyForRestores`）。backup 失敗通知は既存 `DsqlAlerts` SNS（opsEmail subscription）に相乗り。

## follow-up 推奨（本 PR scope 外、Orchestrator 判断で別 Issue 起票）

- F-3 (medium): post-deploy backup smoke（初回 on-demand `start-backup-job` 検証）不在。deploy 後に 1 回 on-demand backup を起動して COMPLETED を確認する smoke を deploy workflow に追加する余地。
- F-5 (minor): Issue #3437 の AC 表現が「PITR」のまま stale（実装は full snapshot、DSQL は PITR 非対応）。PO による AC 追認 / Issue 更新。

## Ready for Review チェックリスト

- [x] AC1-3 + QM F-2 / F-4 実装 + 検証済
- [x] infra test 17 passed（synth 成功）/ infra 全体 100 passed / biome clean
- [x] backup ジョブ失敗 alarm（EventBridge → DsqlAlerts SNS）配線 + CDK test [I8c]
- [x] 復元 role 整合（named role + runbook 是正）+ CDK test [I8d]
- [x] deep research で issue 前提訂正（PITR → full snapshot）+ runbook + research doc 同期
- [x] additive のみ（ADR-0019 replacement 非該当）
- [x] pre-ready 全 step PASS（実行して確認）

## QM レビュー結果

(QM 記入欄)
