### PR TITLE
fix(devinfra): #3806 check-gh-account を GraphQL viewer 一次検証化 (REST /user 503 誤ブロック根治)

### DIFF
--- a/scripts/check-gh-account-before-pr.mjs
+++ b/scripts/check-gh-account-before-pr.mjs
@@ -6,6 +6,12 @@
  * `gh pr create` を実行する直前に、active な gh アカウントが
  * Takenori-Kusaka であることを検証するガードスクリプト。
  *
+ * #3806: active アカウント判定を `gh api graphql {viewer{login}}` (一次) +
+ *   `gh auth status` (fallback) の 2 段構成にした。GitHub 側で認証付き REST
+ *   `/user` だけが 503 を返す部分障害時、`gh auth status` は「keyring invalid」を
+ *   誤報し hook が全 push を誤ブロックする。GraphQL は REST 503 の影響を受けない
+ *   ため、これを一次検証ソースにして誤ブロックを根治する。
+ *
  * ADR-0022 (#1481) で定めた役割分担:
  *   - Takenori-Kusaka  → Dev (PR 作成・push)
  *   - ganbariquestsupport-lab → QA (approve・merge・PR コメントのみ)
@@ -46,11 +52,76 @@ export const QA_ACCOUNT = 'ganbariquestsupport-lab';
 const ALLOWED_PR_AUTHOR = process.env.ALLOWED_PR_AUTHOR ?? ALLOWED_PR_AUTHOR_DEFAULT;
 
 /**
+ * `gh api graphql -f query='{viewer{login}}'` の JSON 応答文字列から
+ * viewer.login を抽出する純粋関数。
+ *
+ * 一次検証を GraphQL にする理由 (#3806):
+ *   GitHub 側で認証付き REST データエンドポイント (`/user`) だけが 503 を返す
+ *   部分障害が起きると、`gh auth status` はトークン検証 (REST `/user`) に失敗し
+ *   「The token in keyring is invalid」と誤報する。これは keyring 障害ではなく、
+ *   再認証でも直らない。GraphQL `{viewer{login}}` は REST 503 の影響を受けず
+ *   active アカウントを返せるため、hook の誤ブロックを根治できる。
+ *
+ * @param {string} jsonStr  gh api graphql の標準出力 (JSON 文字列)
+ * @returns {string|null}   viewer.login / パース不能・欠落なら null
+ */
+export function extractViewerLoginFromGraphql(jsonStr) {
+	const trimmed = String(jsonStr ?? '').trim();
+	if (trimmed === '') return null;
+	try {
+		const parsed = JSON.parse(trimmed);
+		const login = parsed?.data?.viewer?.login;
+		return typeof login === 'string' && login.length > 0 ? login : null;
+	} catch {
+		// REST 503 の HTML エラーページ等、JSON 非準拠の応答は null 扱い。
+		return null;
+	}
+}
+
+/**
+ * `gh api graphql -f query='{viewer{login}}'` を実行し active アカウント login を返す。
+ * REST `/user` 503 (#3806) の影響を受けない一次検証経路。
+ *
+ * @returns {{ok: boolean, login: string|null, reason: string|null}}
+ */
+function runGhGraphqlViewer() {
+	const result = spawnSync('gh', ['api', 'graphql', '-f', 'query={viewer{login}}'], {
+		encoding: 'utf8',
+		shell: process.platform === 'win32',
+	});
+
+	if (result.error) {
+		return { ok: false, login: null, reason: `gh コマンドの起動に失敗: ${result.error.message}` };
+	}
+	if (result.status !== 0) {
+		return {
+			ok: false,
+			login: null,
+			reason: `gh api graphql が exit ${result.status} で終了しました。`,
+		};
+	}
+
+	const login = extractViewerLoginFromGraphql(result.stdout ?? '');
+	if (login === null) {
+		return {
+			ok: false,
+			login: null,
+			reason: 'GraphQL 応答から viewer.login を抽出できませんでした。',
+		};
+	}
+	return { ok: true, login, reason: null };
+}
+
+/**
  * `gh auth status` を実行して標準出力を返す。
  * gh CLI 未インストール / 未ログインなら null を返す。
  *
  * 注: `gh auth status` は active アカウントが存在する場合 stdout に出力するが、
  * バージョンによっては stderr に出すこともあるため、両方を結合して扱う。
+ *
+ * #3806 以降、本関数は GraphQL 一次検証が不達だった場合の fallback に降格した。
+ * `gh auth status` はトークン検証で REST `/user` を叩くため、GitHub 側の
+ * 認証付き REST 部分障害 (503) 時に false-negative を出しうる。
  */
 function runGhAuthStatus() {
 	const result = spawnSync('gh', ['auth', 'status'], {
@@ -137,28 +208,58 @@ export function evaluateActiveAccount(activeAccount, opts = {}) {
 	};
 }
 
-function main() {
+/**
+ * active アカウント login を解決する。
+ *
+ * 1) 一次: `gh api graphql {viewer{login}}` (REST `/user` 503 の影響を受けない、#3806)
+ * 2) fallback: `gh api graphql` 不達時のみ `gh auth status` を解析
+ *
+ * @returns {{account: string|null, source: 'graphql'|'auth-status'|null, rawStatusOutput: string|null}}
+ */
+function resolveActiveAccount() {
+	const graphql = runGhGraphqlViewer();
+	if (graphql.ok) {
+		return { account: graphql.login, source: 'graphql', rawStatusOutput: null };
+	}
+
+	// GraphQL 不達 (真の未ログイン / gh 未インストール / GraphQL 側障害) → auth status fallback。
 	const status = runGhAuthStatus();
 	if (!status.ok) {
-		process.stderr.write(`[check-gh-account-before-pr] FAIL: ${status.reason}\n`);
+		return { account: null, source: null, rawStatusOutput: status.output };
+	}
+	return {
+		account: extractActiveAccount(status.output),
+		source: 'auth-status',
+		rawStatusOutput: status.output,
+	};
+}
+
+function main() {
+	const { account, source, rawStatusOutput } = resolveActiveAccount();
+
+	if (account === null) {
+		process.stderr.write(
+			'[check-gh-account-before-pr] FAIL: active アカウントを判定できませんでした。\n',
+		);
+		if (rawStatusOutput) {
+			process.stderr.write(`  gh auth status raw output:\n${rawStatusOutput}\n`);
+		}
 		process.stderr.write(
 			'  対処: `gh auth login --hostname github.com` でログインしてください。\n',
 		);
 		process.exit(1);
 	}
 
-	const activeAccount = extractActiveAccount(status.output);
-	const verdict = evaluateActiveAccount(activeAccount, { allowed: ALLOWED_PR_AUTHOR });
+	const verdict = evaluateActiveAccount(account, { allowed: ALLOWED_PR_AUTHOR });
 
 	if (verdict.ok) {
-		process.stdout.write(`[check-gh-account-before-pr] OK: active=${activeAccount} (PR 作成可)\n`);
+		process.stdout.write(
+			`[check-gh-account-before-pr] OK: active=${account} (source=${source}, PR 作成可)\n`,
+		);
 		process.exit(0);
 	}
 
 	process.stderr.write(`[check-gh-account-before-pr] FAIL: ${verdict.reason}\n`);
-	if (activeAccount === null) {
-		process.stderr.write(`  raw output:\n${status.output}\n`);
-	}
 	if (verdict.isQa) {
 		process.stderr.write(
 			`  ${QA_ACCOUNT} は QA レビュー (approve / merge) 専用アカウントです。PR 作成は禁止 (ADR-0022 amendment 1, #1728)。\n`,

--- a/tests/unit/scripts/check-gh-account-before-pr.test.ts
+++ b/tests/unit/scripts/check-gh-account-before-pr.test.ts
@@ -22,6 +22,7 @@ import {
 	ALLOWED_PR_AUTHOR_DEFAULT,
 	evaluateActiveAccount,
 	extractActiveAccount,
+	extractViewerLoginFromGraphql,
 	QA_ACCOUNT,
 } from '../../../scripts/check-gh-account-before-pr.mjs';
 
@@ -64,6 +65,46 @@ describe('extractActiveAccount', () => {
 			'  - Active account: true',
 		].join('\r\n');
 		expect(extractActiveAccount(output)).toBe('Takenori-Kusaka');
+	});
+});
+
+describe('extractViewerLoginFromGraphql (#3806 — REST /user 503 耐性)', () => {
+	// 真因: GitHub 側で認証付き REST `/user` だけが 503 を返す部分障害時、
+	// `gh auth status` はトークン検証 (REST /user) に失敗し「keyring invalid」と
+	// 誤報する。GraphQL `{viewer{login}}` は REST 503 の影響を受けず active
+	// アカウントを返せるため、これを一次検証ソースにする (hook 誤ブロック根治)。
+	it('正常な GraphQL 応答から viewer.login を抽出する', () => {
+		const json = '{"data":{"viewer":{"login":"Takenori-Kusaka"}}}';
+		expect(extractViewerLoginFromGraphql(json)).toBe('Takenori-Kusaka');
+	});
+
+	it('QA アカウントの viewer.login も抽出できる', () => {
+		const json = '{"data":{"viewer":{"login":"ganbariquestsupport-lab"}}}';
+		expect(extractViewerLoginFromGraphql(json)).toBe('ganbariquestsupport-lab');
+	});
+
+	it('前後に空白/改行があっても抽出できる (gh 出力の trailing newline)', () => {
+		const json = '\n  {"data":{"viewer":{"login":"Takenori-Kusaka"}}}\n';
+		expect(extractViewerLoginFromGraphql(json)).toBe('Takenori-Kusaka');
+	});
+
+	it('REST 503 の HTML エラーページ (invalid JSON) → null', () => {
+		// gh api user が返す「invalid character \'<\'」の元。JSON パース不能。
+		const html = '<!DOCTYPE html>\n<html><body>503 Service Unavailable</body></html>';
+		expect(extractViewerLoginFromGraphql(html)).toBeNull();
+	});
+
+	it('空文字列 → null', () => {
+		expect(extractViewerLoginFromGraphql('')).toBeNull();
+	});
+
+	it('data.viewer が欠落した応答 → null', () => {
+		expect(extractViewerLoginFromGraphql('{"data":{}}')).toBeNull();
+	});
+
+	it('GraphQL errors 応答 (viewer なし) → null', () => {
+		const json = '{"errors":[{"message":"Bad credentials"}]}';
+		expect(extractViewerLoginFromGraphql(json)).toBeNull();
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（全開発チーム: Dev / QM / 監査）

**解決する課題**: GitHub 側で認証付き REST `/user` だけが 503 を返す部分障害時、pre-push hook `check-gh-account-before-pr.mjs` が「token in keyring is invalid」を誤検知し**全チームの push を誤ブロック**する。再認証でも直らず開発が全面停止する。

**期待される効果**: hook が REST 503 の影響を受けない GraphQL 経路でアカウント検証するため、GitHub の認証付き REST 部分障害中でも Dev アカウントの正当性を確認して push を継続できる。

## 関連 Issue

closes #3806

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | GraphQL viewer 一次検証 + auth status fallback の 2 段構成 | `scripts/check-gh-account-before-pr.mjs` `resolveActiveAccount` | HEAD `824120b2779f81824c1313fe864ec361027504e6` / check-gh-account-before-pr.mjs:219-235 |
| AC2 | REST /user 503 下でも hook が PASS | `node scripts/check-gh-account-before-pr.mjs` を REST 503 発生中に実行 | HEAD `824120b2779f81824c1313fe864ec361027504e6` / 出力 `OK: active=Takenori-Kusaka (source=graphql, PR 作成可)` exit=0。**本 PR の push 自体が self-bootstrap で成功**（hook が修正版を GraphQL 経路で実行し通過） |
| AC3 | failing-test-first 回帰テスト追加 (ADR-0061) | `npx vitest run tests/unit/scripts/check-gh-account-before-pr.test.ts` | HEAD `824120b2779f81824c1313fe864ec361027504e6` / 19 passed（新規 `extractViewerLoginFromGraphql` 7 件、REST 503 HTML 応答→null 含む） |
| AC4 | 既存純粋関数のユニットテスト互換維持 | 同上 | HEAD `824120b2779f81824c1313fe864ec361027504e6` / `extractActiveAccount` / `evaluateActiveAccount` 既存 12 件 pass |
| AC5 | QA アカウント拒否ロジック保全 | `evaluateActiveAccount` 温存 + isQa テスト | HEAD `824120b2779f81824c1313fe864ec361027504e6` / check-gh-account-before-pr.mjs:191-209 未改変、isQa test pass |

## 変更タイプ

- [x] fix: バグ修正
- [x] infra: インフラ・CI/CD

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/` 等) — `scripts/check-gh-account-before-pr.mjs` (pre-push hook / #1879)

**影響を受ける画面・機能**: pre-push hook 経由の全 push フロー（UI 影響なし）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready`**: 変更範囲（scripts + unit test）に対し biome clean / 対象 vitest 19 passed をローカル検証
- [x] 追加・変更したテストの概要: `tests/unit/scripts/check-gh-account-before-pr.test.ts` に `extractViewerLoginFromGraphql` の 7 ケース（正常 JSON / QA login / trailing newline / REST 503 HTML→null / 空→null / viewer 欠落→null / GraphQL errors→null）を failing-test-first で追加
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（priority:critical ではない。開発基盤の devinfra fix）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: pre-push hook スクリプト（`scripts/`）+ unit test のみの変更で UI 描画に一切影響しない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `extractViewerLoginFromGraphql`（純粋関数・単一責任）と副作用を持つ `runGhGraphqlViewer` / `resolveActiveAccount` を分離
- [x] **DRY**: 既存 `evaluateActiveAccount` を GraphQL 経路でも再利用（判定ロジック二重化なし）
- [x] **YAGNI**: GraphQL 一次 + auth-status fallback の 2 段のみ。過剰な抽象化なし
- [x] **Security**: トークン等の hardcode なし。アカウント検証を偽装困難な GraphQL viewer（active token の実 login）に強化
- [x] **アクセシビリティ**: N/A（CLI スクリプト）
- [x] **パフォーマンス**: GraphQL 1 コール（成功時 auth-status を叩かない）で従来より軽量

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外（開発基盤 hook、アプリ本体・LP・年齢モードに非波及）

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**: GraphQL 不達（真の未ログイン / gh 未インストール）時に `gh auth status` fallback → それも不達なら exit 1 で正しく FAIL する経路を `resolveActiveAccount` で確認願います。QA アカウント（ganbariquestsupport-lab）が active のとき isQa=true で FAIL する契約は温存済み。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] biome clean / 対象 vitest 19 passed をローカル確認（変更範囲限定のため pre-ready 全 step は該当外部分を除き検証）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] Phase 分割なし
- [x] UI 変更なし（SS 該当なし）
- [x] 認証画面変更なし

## QM レビュー結果

<!-- QM 記入。**最優先（PO 指示）**: gh REST 部分障害が続く間、全チームの push が誤ブロックされるため develop → main に速やかに取り込む。 -->
