### PR TITLE
fix(auth): #3588 #3585 invite auth-repo hardening — inviteId 鍵 interface 進化 + hash SSOT 統合 + 状態機械

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -161,7 +161,7 @@
 |----------|------|------|------|
 | GET | /api/v1/admin/invites | 招待一覧取得 | owner/parent |
 | POST | /api/v1/admin/invites | 招待リンク作成 | owner/parent |
-| DELETE | /api/v1/admin/invites/[code] | 招待リンク取消 | owner/parent |
+| DELETE | /api/v1/admin/invites/[id] | 招待リンク取消 | owner/parent |
 | GET | /api/v1/admin/license | ライセンス情報取得 (Epic #2525 で削除済、§3.X 参照) | — |
 | POST | /admin/license?/applyLicenseKey | ライセンスキー適用 (Epic #2525 で削除済、§3.X 参照) | — |
 | DELETE | /api/v1/admin/members/[userId] | メンバー削除 | owner |
@@ -1205,9 +1205,9 @@ PINコードを使って他テナントのクラウドエクスポートデー�
 }
 ```
 
-#### DELETE /api/v1/admin/invites/[code]
+#### DELETE /api/v1/admin/invites/[id]
 
-招待リンクを取り消す。
+招待リンクを取り消す。パスセグメントは招待レコードの内部 ID（`inviteId`、`inv-<uuid v4>`）。取消（`revokeInvite` → `updateInviteStatus`）は query 層で `family_id` 述語により対象テナントの招待に限定され、cross-tenant mutation を物理排除する（ADR-0063 単一強制点）。
 
 #### GET /api/v1/admin/license — deprecated (Epic #2525 で削除)
 

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -394,7 +394,7 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 | role-mutation endpoint | 許可ロール（`requireRole`） | parent / child |
 |---|---|---|
 | `POST /api/v1/admin/invites`（招待発行、#3549） | `['owner']` | 403 |
-| `DELETE /api/v1/admin/invites/[code]`（招待取消、#3549） | `['owner']` | 403 |
+| `DELETE /api/v1/admin/invites/[id]`（招待取消、#3549） | `['owner']` | 403 |
 | `DELETE /api/v1/admin/members/[userId]`（メンバー削除） | `['owner']` | 403 |
 | `POST /api/v1/admin/members/[userId]/transfer-ownership`（owner 移譲） | `['owner']` | 403 |
 
@@ -403,6 +403,7 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 - **owner 移譲の owner 不在化防止（#3552 ①）**: `transfer-ownership` は ① 移譲先メンバーの存在を確認し不在なら 404 で早期 return（role を一切変更しない）、② 「新 owner 昇格 → 旧 owner 降格」の順で操作し、どの中間状態でも owner が最低 1 人（昇格前は旧 owner / 昇格後は新 owner）残るようにする。旧実装の「旧 owner 降格 → 新 owner 昇格」順は降格〜昇格間に owner 0 人の window があり、途中失敗で owner 不在家族（復旧困難）が発生し得たため是正した。
 - **UI 整合**: `admin/members/+page.svelte` は `currentRole === 'owner'` のときのみ招待リンク作成カード・保留中招待の取消ボタンを描画する（API gate と UI 非表示の二段）。owner 移譲後に owner が単一障害点化しないよう parent には保留中招待一覧の下に「招待の発行・取り消しはオーナーのみ行えます。変更が必要な場合はオーナーにご依頼ください。」の案内を表示し（`MEMBERS_LABELS.inviteOwnerOnlyNote`、#3552 ③）、取消ボタンが消えるだけの「認知的宙吊り」を解消する。
 - **fitness function**: `tests/unit/routes/admin-role-mutation-authz.test.ts` が 4 endpoint すべてで owner → 成功経路 / parent・child → 403 + `{ error }` body 維持、判定が `requireRole(locals, ['owner'])` seam 経由であること、403 拒否時の監査ログ記録（#3552 ②）、および `transfer-ownership` の移譲先不在 404 / 昇格 → 降格 順序（#3552 ①）を機械検証する。helper 単体の監査ログ・401/403 変換は `tests/unit/auth/owner-gate.test.ts` が検証する。
+- **cross-tenant mutation の物理排除（#3588 / ADR-0063）**: 招待取消（`revokeInvite`）が呼ぶ `updateInviteStatus` は、query 層で `family_id`（tenantId）述語を必須とし、認可を通過した owner でも自テナント外の招待レコードを更新できない（inviteId 総当たりによる別テナント招待の改竄を DB クエリで塞ぐ）。これは owner-gate（role 軸）と直交する tenant 分離の単一強制点であり、fitness `dsql-tenant-predicate-fitness`（`tests/unit/architecture/`）が全 tenant-scoped mutation の述語存在を機械検証する。
 
 #### 5.2.4 招待の宛先 email 束縛（招待リンク横流し防止、#3549 判断2）
 

--- a/docs/research/2026-06-11-audit-infra-gap-list.md
+++ b/docs/research/2026-06-11-audit-infra-gap-list.md
@@ -212,7 +212,7 @@ audit-team.md §3.7（初回事前準備 5 項目）/ §3.8（毎回 9 ステッ
 **未カバー endpoint 一覧（専用テスト不在、優先度別）**:
 
 - **高（コア業務ロジック / AI）**: `special-rewards/[childId]`・`special-rewards/[rewardId]/shown`・`special-rewards/suggest`・`cheer/suggest`・`checklists/suggest`・`messages/[childId]`(POST)・`messages/[messageId]/shown`・`rest-days/[childId]`(CRUD)・`settings/decay`・`evaluations/[childId]`・`achievements/[childId]`・`points/ocr-receipt`・`children/[id]/voices`(CRUD)
-- **中（admin / データライフサイクル）**: `admin/account/{export,grace-status,restore}`・`admin/downgrade-{archive,preview,restore}`・`admin/invites/[code]`(DELETE)・`admin/members/{[userId],transfer-ownership,leave}`・`admin/trial-expiration`・`admin/viewer-tokens`(CRUD)・`admin/migration`・`admin/cleanup-orphans`・`admin/notifications/{reminder,streak-warning}`
+- **中（admin / データライフサイクル）**: `admin/account/{export,grace-status,restore}`・`admin/downgrade-{archive,preview,restore}`・`admin/invites/[id]`(DELETE)・`admin/members/{[userId],transfer-ownership,leave}`・`admin/trial-expiration`・`admin/viewer-tokens`(CRUD)・`admin/migration`・`admin/cleanup-orphans`・`admin/notifications/{reminder,streak-warning}`
 - **低（export/import / 設定）**: `activities/export`・`special-rewards/export`・`checklists/export`・`export/cloud`(CRUD)・`import/cloud`・`data/{summary,clear}`・`settings/{tutorial,pin-gate-onboarding,vapid-key}`・`notifications/unsubscribe`・`inquiry/founder`・`images`(GET/POST)・`analytics`系
 
 **`07-API設計書.md` doc-vs-code 差分**（AC5 副産物、ADR-0001 同期 gap）:

--- a/src/lib/server/auth/entities.ts
+++ b/src/lib/server/auth/entities.ts
@@ -80,6 +80,19 @@ export type InviteStatus = (typeof INVITE_STATUSES)[number];
 
 /** 招待リンク */
 export interface Invite {
+	/**
+	 * 管理操作 (updateInviteStatus / deleteInvite / 一覧からの revoke) の安定鍵 (#3585)。
+	 * 呼び出し側にとって opaque な backend 定義のハンドル:
+	 *   - DSQL: invites.invite_id (DB 採番 uuid)。raw code は token_hash のみ保存で復元不能 (CWE-522)
+	 *   - DynamoDB: raw inviteCode と同値 (PK=INVITE#<code> を管理鍵に流用)
+	 * findTenantInvites はこの inviteId を返し、inviteCode は空文字にする (raw は作成時のみ露出)。
+	 */
+	inviteId: string;
+	/**
+	 * raw 招待コード (受諾リンクに埋め込む capability)。作成時 (createInvite) と
+	 * 受諾照合 (findInviteByCode、raw 提示者 = capability 保持者) でのみ非空。
+	 * 一覧 (findTenantInvites) では復元不能 (DSQL) / 非露出 (統一) のため空文字。
+	 */
 	inviteCode: string;
 	tenantId: string;
 	invitedBy: string;

--- a/src/lib/server/auth/invite-code-hash.ts
+++ b/src/lib/server/auth/invite-code-hash.ts
@@ -1,20 +1,33 @@
 // src/lib/server/auth/invite-code-hash.ts
 // EPIC #3424 / PR-R2 / 設計 SSOT: dsql-data-model.md §6.6 invites.token_hash
 //
-// 招待コード hash の SSOT。DSQL invites 表は raw 招待コードを保存せず、
-// sha256(raw) の hex のみを token_hash に保存する (CWE-522: bare bearer token の
+// 招待秘密 (raw 招待コード / DSQL-native token) の hash SSOT。DSQL invites 表は raw を
+// 保存せず、sha256(raw) の hex のみを token_hash に保存する (CWE-522: bare bearer token の
 // DB 平文保存による機密性退行を防ぐ。DB dump が漏れても招待リンクとして使えない)。
 //
-// - lookup は WHERE token_hash = hashInviteCode(raw) の等値照合。ユーザ入力と
+// - lookup は WHERE token_hash = hashInviteSecret(raw) の等値照合。ユーザ入力と
 //   秘密の直接比較を行わないため、B-tree 照合の timing で raw が漏れる面は
 //   hash の前像困難性で遮断される (現行 DynamoDB inviteCode capability 機構の写像)。
 // - salt / pepper は不採用: 招待コードは inv-<uuid v4> で 122bit エントロピーがあり
 //   総当たり・レインボー表が成立しない (パスワード hash とは脅威モデルが異なる)。
 //   決定的 hash でないと WHERE 等値 lookup ができない。
+//
+// #3588 ①: 本ファイルが招待秘密 hash の唯一の SSOT。`invite-token.ts` の hashInviteToken /
+// verifyInviteTokenHash も本 hashInviteSecret に委譲する。現行 inviteCode 写像 (hashInviteCode) と
+// DSQL-native token (hashInviteToken) は用途表記が異なるだけで同一写像 (sha256 hex) であり、
+// 二重定義すると将来のアルゴリズム変更時に片側更新漏れで invite lookup 不整合を招くため統合する。
 
 import { createHash } from 'node:crypto';
 
-/** 招待コード raw → invites.token_hash 保存値 (sha256 hex、決定的)。 */
+/** 招待秘密 raw → invites.token_hash 保存値 (sha256 hex、決定的)。招待秘密 hash の唯一 SSOT (#3588 ①)。 */
+export function hashInviteSecret(secret: string): string {
+	return createHash('sha256').update(secret, 'utf8').digest('hex');
+}
+
+/**
+ * 招待コード raw → token_hash。`hashInviteSecret` の別名 (現行 inviteCode 写像の呼称)。
+ * DSQL auth-repo の lookup 鍵算出に使う。
+ */
 export function hashInviteCode(code: string): string {
-	return createHash('sha256').update(code).digest('hex');
+	return hashInviteSecret(code);
 }

--- a/src/lib/server/auth/invite-token.ts
+++ b/src/lib/server/auth/invite-token.ts
@@ -16,8 +16,13 @@
 //         sha256(token) で十分 (token 自体が 256bit 高エントロピーのため salt / pepper 不要、
 //         パスワードと違い辞書攻撃が成立しない)。
 //   - raw token は生成時に呼び出し元へ返すのみ。DB には tokenHash (UNIQUE(token_hash)) だけを保存する。
+//
+// #3588 ①: token の hash は `invite-code-hash.ts` の hashInviteSecret に委譲する (SSOT 統合)。
+//   hashInviteToken と hashInviteCode は同一写像 (sha256 hex) の別呼称であり、二重定義を廃して
+//   将来のアルゴリズム変更時の片側更新漏れ (invite lookup 不整合) を構造排除する。
 
-import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import { hashInviteSecret } from './invite-code-hash';
 
 /** invite token のエントロピー (bytes)。32 bytes = 256 bit、base64url で 43 chars */
 export const INVITE_TOKEN_BYTES = 32;
@@ -36,9 +41,10 @@ export function generateInviteToken(): { token: string; tokenHash: string } {
 /**
  * 提示された token を照合用にハッシュ化する (DB lookup キー算出)。
  * generateInviteToken と同一写像 (sha256 hex 小文字) であることが contract。
+ * #3588 ①: hashInviteSecret (SSOT) に委譲。hashInviteCode と同一写像。
  */
 export function hashInviteToken(token: string): string {
-	return createHash('sha256').update(token, 'utf8').digest('hex');
+	return hashInviteSecret(token);
 }
 
 /**

--- a/src/lib/server/db/demo/auth-repo.ts
+++ b/src/lib/server/db/demo/auth-repo.ts
@@ -178,6 +178,7 @@ export async function deleteMembership(_userId: string, _tenantId: string): Prom
 export async function createInvite(input: CreateInviteInput): Promise<Invite> {
 	const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
 	return {
+		inviteId: 'DEMO-INVITE-ID',
 		inviteCode: 'DEMO-INVITE',
 		tenantId: input.tenantId,
 		invitedBy: input.invitedBy,
@@ -194,19 +195,19 @@ export async function findInviteByCode(_inviteCode: string): Promise<Invite | un
 }
 
 export async function updateInviteStatus(
-	_inviteCode: string,
+	_inviteId: string,
 	_status: Invite['status'],
 	_acceptedBy?: string,
 ): Promise<void> {
-	// Stub: no-op
+	// Stub: no-op (#3585: 管理鍵は inviteId)
 }
 
 export async function findTenantInvites(_tenantId: string): Promise<Invite[]> {
 	return [];
 }
 
-export async function deleteInvite(_inviteCode: string, _tenantId: string): Promise<void> {
-	// Stub: no-op
+export async function deleteInvite(_inviteId: string, _tenantId: string): Promise<void> {
+	// Stub: no-op (#3585: 管理鍵は inviteId)
 }
 
 // ---------- Consent ----------

--- a/src/lib/server/db/demo/auth-repo.ts
+++ b/src/lib/server/db/demo/auth-repo.ts
@@ -196,10 +196,11 @@ export async function findInviteByCode(_inviteCode: string): Promise<Invite | un
 
 export async function updateInviteStatus(
 	_inviteId: string,
+	_tenantId: string,
 	_status: Invite['status'],
 	_acceptedBy?: string,
 ): Promise<void> {
-	// Stub: no-op (#3585: 管理鍵は inviteId)
+	// Stub: no-op (#3585: 管理鍵は inviteId、#3588: tenant scope 引数)
 }
 
 export async function findTenantInvites(_tenantId: string): Promise<Invite[]> {

--- a/src/lib/server/db/dsql/auth-repo.ts
+++ b/src/lib/server/db/dsql/auth-repo.ts
@@ -443,8 +443,10 @@ export function createDsqlAuthRepo<TTx extends SqlExecutor>(
 			return row ? toInvite(row, inviteCode) : undefined;
 		},
 
-		async updateInviteStatus(inviteId, status, acceptedBy) {
+		async updateInviteStatus(inviteId, tenantId, status, acceptedBy) {
 			// 管理系遷移 (revoke / expire / 旧経路 accept)。鍵は invite_id (#3585)。
+			// tenant scope: AND family_id = ${tenantId} で cross-tenant mutation を query 層が物理排除する
+			// (deleteInvite と対称、ADR-0063 §3.4 単一強制点。RLS 非対応の代替防御線。#3588)。
 			// #3588 ③ 状態機械: pending からの遷移のみ許可 (AND status = 'pending')。
 			// 失効済 / 受諾済 invite への再遷移は 0 行 = no-op で乱用余地を塞ぐ。
 			// 全呼び出し側は既に pending を確認してから呼ぶため defense-in-depth。
@@ -452,13 +454,13 @@ export function createDsqlAuthRepo<TTx extends SqlExecutor>(
 			if (acceptedBy) {
 				await db.execute(sql`
 					UPDATE invites SET status = ${status}, accepted_by = ${acceptedBy}, accepted_at = now()
-					WHERE invite_id = ${inviteId} AND status = 'pending'
+					WHERE invite_id = ${inviteId} AND family_id = ${tenantId} AND status = 'pending'
 				`);
 				return;
 			}
 			await db.execute(sql`
 				UPDATE invites SET status = ${status}
-				WHERE invite_id = ${inviteId} AND status = 'pending'
+				WHERE invite_id = ${inviteId} AND family_id = ${tenantId} AND status = 'pending'
 			`);
 		},
 

--- a/src/lib/server/db/dsql/auth-repo.ts
+++ b/src/lib/server/db/dsql/auth-repo.ts
@@ -11,7 +11,8 @@
 //   - **invite は token_hash のみ保存** (CWE-522、raw 非保存)。hash SSOT は
 //     $lib/server/auth/invite-code-hash.ts。raw code を知るのは作成時の呼び出し側だけ。
 //   - **invite 受諾は invite-accept.ts が正** (§6.6 厳密分岐の単一 txn)。本 repo の
-//     updateInviteStatus は revoke / expire 等の管理系遷移用で pending 条件を課さない。
+//     updateInviteStatus / deleteInvite は invite_id 鍵の管理系操作 (#3585)。
+//     updateInviteStatus は pending からの遷移のみ許可する状態機械 (#3588 ③)。
 //   - 23505 (email_lower / owner_guard UNIQUE 違反) は throw のまま呼び出し側契約
 //     (dynamo backend の ConditionExpression 失敗 throw / invite-accept の catch と同型)。
 
@@ -137,9 +138,13 @@ const INVITE_COLUMNS = sql.raw(
 	 accepted_by, accepted_at, created_at`,
 );
 
-/** row → Invite。raw code は DB に無い (CWE-522) ため呼び出し側が inviteCode を供給する。 */
+/**
+ * row → Invite。inviteId = invite_id (管理鍵、#3585)。raw code は DB に無い (CWE-522) ため
+ * 呼び出し側が inviteCode を供給する (受諾照合は raw、一覧は '' で raw 非露出)。
+ */
 function toInvite(row: InviteRow, inviteCode: string): Invite {
 	return {
+		inviteId: row.invite_id,
 		inviteCode,
 		tenantId: row.family_id,
 		invitedBy: row.invited_by,
@@ -438,39 +443,42 @@ export function createDsqlAuthRepo<TTx extends SqlExecutor>(
 			return row ? toInvite(row, inviteCode) : undefined;
 		},
 
-		async updateInviteStatus(inviteCode, status, acceptedBy) {
-			// 管理系遷移 (revoke / expire / 旧経路 accept)。pending→accepted の厳密分岐
-			// (rowCount=0 / 23505 / 40001) は invite-accept.ts が正 (§6.6)。
+		async updateInviteStatus(inviteId, status, acceptedBy) {
+			// 管理系遷移 (revoke / expire / 旧経路 accept)。鍵は invite_id (#3585)。
+			// #3588 ③ 状態機械: pending からの遷移のみ許可 (AND status = 'pending')。
+			// 失効済 / 受諾済 invite への再遷移は 0 行 = no-op で乱用余地を塞ぐ。
+			// 全呼び出し側は既に pending を確認してから呼ぶため defense-in-depth。
+			// pending→accepted の厳密分岐 (rowCount=0 / 23505 / 40001) は invite-accept.ts が正 (§6.6)。
 			if (acceptedBy) {
 				await db.execute(sql`
 					UPDATE invites SET status = ${status}, accepted_by = ${acceptedBy}, accepted_at = now()
-					WHERE token_hash = ${hashInviteCode(inviteCode)}
+					WHERE invite_id = ${inviteId} AND status = 'pending'
 				`);
 				return;
 			}
 			await db.execute(sql`
-				UPDATE invites SET status = ${status} WHERE token_hash = ${hashInviteCode(inviteCode)}
+				UPDATE invites SET status = ${status}
+				WHERE invite_id = ${inviteId} AND status = 'pending'
 			`);
 		},
 
 		async findTenantInvites(tenantId) {
-			// ⚠️ raw code は非保存で復元不能 (CWE-522)。一覧 entity の inviteCode には
-			// invite_id (uuid) を入れる。したがって一覧から得た「code」を findInviteByCode /
-			// updateInviteStatus / deleteInvite (hash 照合) に渡しても一致しない — 管理操作は
-			// inviteId ベースへの interface 進化が必要 (cutover 配線 PR で対応、issue 起票は
-			// 本体セッション)。この挙動はテスト [I2] で固定している。
+			// #3585: inviteId (= invite_id) を管理鍵として返し、inviteCode は '' (raw 非露出)。
+			// raw code は token_hash のみ保存で復元不能 (CWE-522)。一覧から得た inviteId を
+			// updateInviteStatus / deleteInvite に渡すと invite_id 照合で正しく反応する
+			// (旧: inviteCode 位置に invite_id を入れ hash 照合で不一致 no-op となる債務を解消)。
 			const result = await db.execute(sql`
 				SELECT ${INVITE_COLUMNS} FROM invites
 				WHERE family_id = ${tenantId} ORDER BY created_at, invite_id
 			`);
-			return (result.rows as unknown as InviteRow[]).map((row) => toInvite(row, row.invite_id));
+			return (result.rows as unknown as InviteRow[]).map((row) => toInvite(row, ''));
 		},
 
-		async deleteInvite(inviteCode, tenantId) {
-			// family_id 束縛必須 (§P9): 他 tenant の invite は hash が一致しても消せない。
+		async deleteInvite(inviteId, tenantId) {
+			// 鍵は invite_id (#3585)。family_id 束縛必須 (§P9): 他 tenant の invite は消せない。
 			await db.execute(sql`
 				DELETE FROM invites
-				WHERE token_hash = ${hashInviteCode(inviteCode)} AND family_id = ${tenantId}
+				WHERE invite_id = ${inviteId} AND family_id = ${tenantId}
 			`);
 		},
 

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -419,6 +419,9 @@ export const createInvite: IAuthRepo['createInvite'] = async (input) => {
 	const now = new Date();
 	const expiresAt = new Date(now.getTime() + INVITE_EXPIRY_DAYS * MS_PER_DAY);
 	const invite: Invite = {
+		// #3585: DynamoDB は raw code を PK=INVITE#<code> に採る。管理鍵 inviteId は raw code と
+		// 同値にし、updateInviteStatus / deleteInvite が inviteKey(inviteId) を解決できるようにする。
+		inviteId: inviteCode,
 		inviteCode,
 		tenantId: input.tenantId,
 		invitedBy: input.invitedBy,
@@ -458,15 +461,17 @@ export const findInviteByCode: IAuthRepo['findInviteByCode'] = async (inviteCode
 };
 
 export const updateInviteStatus: IAuthRepo['updateInviteStatus'] = async (
-	inviteCode,
+	inviteId,
 	status,
 	acceptedBy,
 ) => {
 	const now = new Date().toISOString();
 
+	// #3585: inviteId は raw code と同値 (PK=INVITE#<code>)。inviteKey(inviteId) で primary を引く。
 	// Get current invite to find tenantId for adjacency update
-	const current = await findInviteByCode(inviteCode);
+	const current = await findInviteByCode(inviteId);
 	if (!current) return;
+	const inviteCode = inviteId;
 
 	const updates: string[] = ['#status = :status', '#updatedAt = :now'];
 	const names: Record<string, string> = { '#status': 'status', '#updatedAt': 'updatedAt' };
@@ -514,15 +519,18 @@ export const findTenantInvites: IAuthRepo['findTenantInvites'] = async (tenantId
 			},
 		}),
 	);
-	return (result.Items ?? []).map(itemToInvite);
+	// #3585: 一覧は inviteId を管理鍵として返し、raw inviteCode は空にする (作成時のみ露出、
+	// DSQL backend と統一)。管理操作は inviteId 経由で行う。
+	return (result.Items ?? []).map((item) => ({ ...itemToInvite(item), inviteCode: '' }));
 };
 
-export const deleteInvite: IAuthRepo['deleteInvite'] = async (inviteCode, tenantId) => {
+export const deleteInvite: IAuthRepo['deleteInvite'] = async (inviteId, tenantId) => {
+	// #3585: inviteId は raw code と同値 (PK=INVITE#<code>)。inviteKey(inviteId) で解決。
 	// Delete primary invite item (INVITE#<code>)
-	await doc().send(new DeleteCommand({ TableName: TABLE_NAME, Key: inviteKey(inviteCode) }));
+	await doc().send(new DeleteCommand({ TableName: TABLE_NAME, Key: inviteKey(inviteId) }));
 	// Delete tenant adjacency item (TENANT#<tenantId>, INVITE#<code>)
 	await doc().send(
-		new DeleteCommand({ TableName: TABLE_NAME, Key: tenantInviteKey(tenantId, inviteCode) }),
+		new DeleteCommand({ TableName: TABLE_NAME, Key: tenantInviteKey(tenantId, inviteId) }),
 	);
 };
 
@@ -571,8 +579,11 @@ function itemToMembership(item: Record<string, unknown>): Membership {
 }
 
 function itemToInvite(item: Record<string, unknown>): Invite {
+	const inviteCode = item.inviteCode as string;
 	return {
-		inviteCode: item.inviteCode as string,
+		// #3585: inviteId は管理鍵。既存 (inviteId 未保存) item は raw code に fallback。
+		inviteId: (item.inviteId as string | undefined) ?? inviteCode,
+		inviteCode,
 		tenantId: item.tenantId as string,
 		invitedBy: item.invitedBy as string,
 		role: item.role as Role,

--- a/src/lib/server/db/dynamodb/auth-repo.ts
+++ b/src/lib/server/db/dynamodb/auth-repo.ts
@@ -462,6 +462,7 @@ export const findInviteByCode: IAuthRepo['findInviteByCode'] = async (inviteCode
 
 export const updateInviteStatus: IAuthRepo['updateInviteStatus'] = async (
 	inviteId,
+	tenantId,
 	status,
 	acceptedBy,
 ) => {
@@ -471,6 +472,9 @@ export const updateInviteStatus: IAuthRepo['updateInviteStatus'] = async (
 	// Get current invite to find tenantId for adjacency update
 	const current = await findInviteByCode(inviteId);
 	if (!current) return;
+	// tenant scope: 他 tenant の invite は更新しない (DSQL の family_id 述語と対称、
+	// ADR-0063 単一強制点。cross-tenant mutation を no-op で排除。#3588)。
+	if (current.tenantId !== tenantId) return;
 	const inviteCode = inviteId;
 
 	const updates: string[] = ['#status = :status', '#updatedAt = :now'];

--- a/src/lib/server/db/interfaces/auth-repo.interface.ts
+++ b/src/lib/server/db/interfaces/auth-repo.interface.ts
@@ -60,16 +60,25 @@ export interface IAuthRepo {
 	createMembership(input: CreateMembershipInput): Promise<Membership>;
 	deleteMembership(userId: string, tenantId: string): Promise<void>;
 
-	// --- Invite ---
+	// --- Invite (#3585: 管理操作は inviteId 鍵、受諾のみ raw inviteCode 鍵) ---
 	createInvite(input: CreateInviteInput): Promise<Invite>;
+	/** 受諾フロー専用: raw code (capability) から invite を引く。返る Invite の inviteCode は引数の raw。 */
 	findInviteByCode(inviteCode: string): Promise<Invite | undefined>;
+	/**
+	 * 管理系の状態遷移 (revoke / expire / 旧経路 accept)。鍵は inviteId (#3585)。
+	 * pending からの遷移のみ許可する状態機械 (#3588 ③): 失効済 / 受諾済 invite への
+	 * 再遷移は no-op (乱用余地を塞ぐ)。tenant scope は呼び出し側 (findTenantInvites 経由の
+	 * 一覧束縛) が担保する。
+	 */
 	updateInviteStatus(
-		inviteCode: string,
+		inviteId: string,
 		status: Invite['status'],
 		acceptedBy?: string,
 	): Promise<void>;
+	/** 一覧。各 Invite の inviteId は管理鍵、inviteCode は空 (raw 非露出、#3585)。 */
 	findTenantInvites(tenantId: string): Promise<Invite[]>;
-	deleteInvite(inviteCode: string, tenantId: string): Promise<void>;
+	/** 物理削除。鍵は inviteId、tenant 束縛必須 (他 tenant の invite は消せない、#3585 / §P9)。 */
+	deleteInvite(inviteId: string, tenantId: string): Promise<void>;
 
 	// --- Consent (#0192) ---
 	recordConsent(input: RecordConsentInput): Promise<ConsentRecord>;

--- a/src/lib/server/db/interfaces/auth-repo.interface.ts
+++ b/src/lib/server/db/interfaces/auth-repo.interface.ts
@@ -67,11 +67,16 @@ export interface IAuthRepo {
 	/**
 	 * 管理系の状態遷移 (revoke / expire / 旧経路 accept)。鍵は inviteId (#3585)。
 	 * pending からの遷移のみ許可する状態機械 (#3588 ③): 失効済 / 受諾済 invite への
-	 * 再遷移は no-op (乱用余地を塞ぐ)。tenant scope は呼び出し側 (findTenantInvites 経由の
-	 * 一覧束縛) が担保する。
+	 * 再遷移は no-op (乱用余地を塞ぐ)。
+	 *
+	 * tenant scope は query 層が `family_id = tenantId` 述語で強制する (deleteInvite と対称、
+	 * ADR-0063 §3.4 単一強制点。RLS 非対応の代替防御線)。他 tenant の inviteId を渡しても
+	 * 述語不一致で 0 行 = no-op となり cross-tenant mutation (他家族の status / accepted_by 書込)
+	 * を物理排除する。呼び出し側の一覧束縛に依存しない (caller-discipline 非依存、#3588)。
 	 */
 	updateInviteStatus(
 		inviteId: string,
+		tenantId: string,
 		status: Invite['status'],
 		acceptedBy?: string,
 	): Promise<void>;

--- a/src/lib/server/services/account-deletion-service.ts
+++ b/src/lib/server/services/account-deletion-service.ts
@@ -133,21 +133,20 @@ async function revokeAndDeleteAllInvites(tenantId: string): Promise<number> {
 
 	for (const invite of invites) {
 		try {
+			// #3585: 管理鍵は inviteId (findTenantInvites の inviteCode は '' で raw 非露出)。
 			// まずステータスを revoked に（pending の場合のみ条件付き更新）
 			if (invite.status === 'pending') {
 				try {
-					await repos().auth.updateInviteStatus(invite.inviteCode, 'revoked');
+					await repos().auth.updateInviteStatus(invite.inviteId, 'revoked');
 				} catch {
 					// conditional write failure は無視
 				}
 			}
 			// 物理削除: 招待レコード自体を削除（テナント側・招待コード側の両方）
-			await repos().auth.deleteInvite(invite.inviteCode, tenantId);
+			await repos().auth.deleteInvite(invite.inviteId, tenantId);
 			deleted++;
 		} catch (err) {
-			logger.warn(
-				`[account-deletion] 招待削除失敗 inviteCode=${invite.inviteCode}: ${String(err)}`,
-			);
+			logger.warn(`[account-deletion] 招待削除失敗 inviteId=${invite.inviteId}: ${String(err)}`);
 		}
 	}
 

--- a/src/lib/server/services/account-deletion-service.ts
+++ b/src/lib/server/services/account-deletion-service.ts
@@ -137,7 +137,8 @@ async function revokeAndDeleteAllInvites(tenantId: string): Promise<number> {
 			// まずステータスを revoked に（pending の場合のみ条件付き更新）
 			if (invite.status === 'pending') {
 				try {
-					await repos().auth.updateInviteStatus(invite.inviteId, 'revoked');
+					// #3588: tenant scope は tenantId (family_id 述語) で query 層が強制する
+					await repos().auth.updateInviteStatus(invite.inviteId, tenantId, 'revoked');
 				} catch {
 					// conditional write failure は無視
 				}

--- a/src/lib/server/services/account-deletion-service.ts
+++ b/src/lib/server/services/account-deletion-service.ts
@@ -175,8 +175,13 @@ async function fullTenantDeletion(
 	// 3. 子供データ削除
 	itemsDeleted += await deleteAllChildrenData(tenantId);
 
-	// 4. 全メンバーの Cognito ユーザー削除 + メンバーシップ削除
+	// 4. 全メンバーの メンバーシップ削除 → Cognito / global users 削除 の順 (#3588 ②)。
+	// DSQL cutover 安全性: memberships (family_id 述語付き tenant scope) を global users 表の
+	// 削除より先に掃除する。FK 非対応 (§P4) ゆえ deleteUser を先に行うと membership 行が
+	// 存在しない user_id を指す dangling 窓が生じる。owner_user_id cache は step 6 の
+	// deleteTenant (families 行ごと削除) で消えるため別途掃除不要。
 	const members = await repos().auth.findTenantMembers(tenantId);
+	itemsDeleted += await deleteAllMemberships(tenantId);
 	for (const member of members) {
 		try {
 			await deleteCognitoUser(member.userId);
@@ -185,7 +190,6 @@ async function fullTenantDeletion(
 			logger.warn(`[account-deletion] ユーザー削除失敗 userId=${member.userId}: ${String(err)}`);
 		}
 	}
-	itemsDeleted += await deleteAllMemberships(tenantId);
 
 	// 5. 招待リンク無効化 + 物理削除
 	itemsDeleted += await revokeAndDeleteAllInvites(tenantId);

--- a/src/lib/server/services/invite-service.ts
+++ b/src/lib/server/services/invite-service.ts
@@ -37,7 +37,8 @@ export async function getInvite(inviteCode: string): Promise<Invite | null> {
 	// 有効期限チェック
 	if (new Date(invite.expiresAt) < new Date()) {
 		try {
-			await repos().auth.updateInviteStatus(inviteCode, 'expired');
+			// #3585: 状態遷移は inviteId 鍵。invite は raw code で引いた本物のため inviteId は信頼できる
+			await repos().auth.updateInviteStatus(invite.inviteId, 'expired');
 		} catch {
 			// conditional write failure は無視（既に別ステータスに遷移済み）
 		}
@@ -109,7 +110,8 @@ export async function acceptInvite(
 
 	// 招待ステータス更新（accepted）
 	try {
-		await repos().auth.updateInviteStatus(inviteCode, 'accepted', userId);
+		// #3585: 状態遷移は inviteId 鍵 (invite は getInvite が raw code で引いた本物)
+		await repos().auth.updateInviteStatus(invite.inviteId, 'accepted', userId);
 	} catch {
 		// conditional write failure — 既に受諾済み（race condition）
 		// メンバーシップは作成済みなので続行
@@ -139,16 +141,23 @@ export async function acceptInvite(
 	return { membership };
 }
 
-/** 招待を取り消す */
-export async function revokeInvite(inviteCode: string, tenantId: string): Promise<void> {
-	const invite = await repos().auth.findInviteByCode(inviteCode);
-	if (!invite || invite.tenantId !== tenantId || invite.status !== 'pending') {
+/**
+ * 招待を取り消す (#3585: 管理鍵は inviteId)。
+ *
+ * raw code は一覧から復元不能 (CWE-522) のため、admin UI は inviteId を渡す。tenant scope は
+ * findTenantInvites (tenant 束縛) の一覧に inviteId が存在することで担保する — 他 tenant の
+ * inviteId を渡しても一覧に無いため no-op となり cross-tenant revoke を防ぐ。
+ */
+export async function revokeInvite(inviteId: string, tenantId: string): Promise<void> {
+	const invites = await repos().auth.findTenantInvites(tenantId);
+	const target = invites.find((i) => i.inviteId === inviteId);
+	if (!target || target.status !== 'pending') {
 		return;
 	}
 	try {
-		await repos().auth.updateInviteStatus(inviteCode, 'revoked');
+		await repos().auth.updateInviteStatus(inviteId, 'revoked');
 	} catch {
-		// conditional write failure は無視
+		// conditional write failure は無視 (状態機械が pending 以外を弾く)
 	}
 }
 

--- a/src/lib/server/services/invite-service.ts
+++ b/src/lib/server/services/invite-service.ts
@@ -38,7 +38,8 @@ export async function getInvite(inviteCode: string): Promise<Invite | null> {
 	if (new Date(invite.expiresAt) < new Date()) {
 		try {
 			// #3585: 状態遷移は inviteId 鍵。invite は raw code で引いた本物のため inviteId は信頼できる
-			await repos().auth.updateInviteStatus(invite.inviteId, 'expired');
+			// #3588: tenant scope (family_id 述語) を query 層で強制するため invite.tenantId を渡す
+			await repos().auth.updateInviteStatus(invite.inviteId, invite.tenantId, 'expired');
 		} catch {
 			// conditional write failure は無視（既に別ステータスに遷移済み）
 		}
@@ -111,7 +112,8 @@ export async function acceptInvite(
 	// 招待ステータス更新（accepted）
 	try {
 		// #3585: 状態遷移は inviteId 鍵 (invite は getInvite が raw code で引いた本物)
-		await repos().auth.updateInviteStatus(invite.inviteId, 'accepted', userId);
+		// #3588: tenant scope は invite.tenantId (受諾対象 family) を query 層 family_id 述語で強制
+		await repos().auth.updateInviteStatus(invite.inviteId, invite.tenantId, 'accepted', userId);
 	} catch {
 		// conditional write failure — 既に受諾済み（race condition）
 		// メンバーシップは作成済みなので続行
@@ -155,7 +157,8 @@ export async function revokeInvite(inviteId: string, tenantId: string): Promise<
 		return;
 	}
 	try {
-		await repos().auth.updateInviteStatus(inviteId, 'revoked');
+		// #3588: tenant scope は tenantId (family_id 述語) で query 層が強制する
+		await repos().auth.updateInviteStatus(inviteId, tenantId, 'revoked');
 	} catch {
 		// conditional write failure は無視 (状態機械が pending 以外を弾く)
 	}

--- a/src/routes/(parent)/admin/members/+page.svelte
+++ b/src/routes/(parent)/admin/members/+page.svelte
@@ -70,13 +70,13 @@ async function createInvite() {
 
 // #3743: await 駆動ハンドラの実行中フラグ (DESIGN.md §5 Button loading prop、#3667 same-class)。
 // 対象 item の id を保持し、該当ボタンのみ spinner + disabled + aria-busy にする。
-let revokingInviteCode = $state<string | null>(null);
+let revokingInviteId = $state<string | null>(null);
 
-async function revokeInvite(code: string) {
+async function revokeInvite(inviteId: string) {
 	if (!confirm(MEMBERS_LABELS.revokeConfirm)) return;
-	revokingInviteCode = code;
+	revokingInviteId = inviteId;
 	try {
-		const res = await fetch(`/api/v1/admin/invites/${code}`, { method: 'DELETE' });
+		const res = await fetch(`/api/v1/admin/invites/${inviteId}`, { method: 'DELETE' });
 		// #3225: 取り消し失敗を silent にしない (失敗時は reload せず error Toast)
 		if (!res.ok) {
 			await notifyApiError(res);
@@ -86,7 +86,7 @@ async function revokeInvite(code: string) {
 	} catch {
 		notifyNetworkError();
 	} finally {
-		revokingInviteCode = null;
+		revokingInviteId = null;
 	}
 }
 
@@ -484,11 +484,11 @@ const roleLabel = (role: string) => {
 						</div>
 						{#if $page.data.currentRole === 'owner'}
 							<Button
-								onclick={() => revokeInvite(invite.inviteCode)}
+								onclick={() => revokeInvite(invite.inviteId)}
 								variant="danger"
 								size="sm"
-								loading={revokingInviteCode === invite.inviteCode}
-								disabled={revokingInviteCode !== null}
+								loading={revokingInviteId === invite.inviteId}
+								disabled={revokingInviteId !== null}
 							>
 								{MEMBERS_LABELS.inviteRevokeButton}
 							</Button>

--- a/src/routes/api/v1/admin/invites/[id]/+server.ts
+++ b/src/routes/api/v1/admin/invites/[id]/+server.ts
@@ -1,4 +1,6 @@
-// DELETE /api/v1/admin/invites/[code] — 招待取消し (#0129)
+// DELETE /api/v1/admin/invites/[id] — 招待取消し (#0129)
+// #3585: パスセグメントは inviteId (管理鍵)。raw code は一覧から復元不能 (CWE-522) のため、
+//        admin UI は一覧の inviteId を渡す。revokeInvite が tenant 束縛で検証する。
 
 import { json } from '@sveltejs/kit';
 import { OWNER_GATE_LABELS } from '$lib/domain/labels';
@@ -18,10 +20,10 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 	// #3552 ②: role-mutation の 403 拒否は監査ログに残す (招待濫用試行の追跡)。
 	const gate = ownerGateResponse(locals, OWNER_GATE_LABELS.inviteRevoke, {
 		auditAction: 'invites.revoke',
-		targetId: params.code,
+		targetId: params.id,
 	});
 	if (gate) return gate;
 
-	await revokeInvite(params.code, tenantId);
+	await revokeInvite(params.id, tenantId);
 	return json({ ok: true });
 };

--- a/src/routes/api/v1/admin/tenant-cleanup/+server.ts
+++ b/src/routes/api/v1/admin/tenant-cleanup/+server.ts
@@ -146,7 +146,8 @@ async function deleteTenantData(
 	const invites = await repos.auth.findTenantInvites(tenantId);
 	for (const invite of invites) {
 		if (invite.status === 'pending') {
-			await repos.auth.updateInviteStatus(invite.inviteCode, 'revoked');
+			// #3585: 管理鍵は inviteId (findTenantInvites の inviteCode は '' で raw 非露出)
+			await repos.auth.updateInviteStatus(invite.inviteId, 'revoked');
 			itemsDeleted++;
 		}
 	}

--- a/src/routes/api/v1/admin/tenant-cleanup/+server.ts
+++ b/src/routes/api/v1/admin/tenant-cleanup/+server.ts
@@ -147,7 +147,8 @@ async function deleteTenantData(
 	for (const invite of invites) {
 		if (invite.status === 'pending') {
 			// #3585: 管理鍵は inviteId (findTenantInvites の inviteCode は '' で raw 非露出)
-			await repos.auth.updateInviteStatus(invite.inviteId, 'revoked');
+			// #3588: tenant scope は tenantId (family_id 述語) で query 層が強制する
+			await repos.auth.updateInviteStatus(invite.inviteId, tenantId, 'revoked');
 			itemsDeleted++;
 		}
 	}

--- a/tests/unit/auth/invite-token.test.ts
+++ b/tests/unit/auth/invite-token.test.ts
@@ -6,6 +6,7 @@
 
 import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
+import { hashInviteCode, hashInviteSecret } from '../../../src/lib/server/auth/invite-code-hash';
 import {
 	generateInviteToken,
 	hashInviteToken,
@@ -65,6 +66,21 @@ describe('hashInviteToken', () => {
 
 	it('sha256 hex (64 chars 小文字) を返す', () => {
 		expect(hashInviteToken('any-token')).toMatch(SHA256_HEX_RE);
+	});
+});
+
+// #3588 ①: 招待秘密 hash の SSOT 統合。hashInviteToken / hashInviteCode は hashInviteSecret に
+// 委譲し、同一写像 (sha256 hex) であることを regression guard する。将来アルゴリズムを変えても
+// 片側更新漏れ (invite lookup 不整合) を構造的に起こさない。
+describe('hash SSOT 統合 (#3588 ①)', () => {
+	it('hashInviteToken / hashInviteCode / hashInviteSecret は同一写像', () => {
+		for (const input of ['', 'inv-abc', 'a'.repeat(43), '日本語コード', 'inv-0123-XYZ_-~']) {
+			const secret = hashInviteSecret(input);
+			expect(hashInviteToken(input)).toBe(secret);
+			expect(hashInviteCode(input)).toBe(secret);
+			// 独立に計算した sha256(input) hex とも一致 (アルゴリズム固定の contract)
+			expect(secret).toBe(createHash('sha256').update(input, 'utf8').digest('hex'));
+		}
 	});
 });
 

--- a/tests/unit/db/dsql-auth-repo.test.ts
+++ b/tests/unit/db/dsql-auth-repo.test.ts
@@ -20,6 +20,7 @@
 //   [I3] invite email の小文字正規化 (§6.6)
 //   [I4] updateInviteStatus (inviteId 鍵、acceptedBy/acceptedAt 設定、#3585)
 //   [I5] deleteInvite の inviteId 鍵 + tenant 束縛 (他 tenant からは消せない、#3585)
+//   [I8] updateInviteStatus の tenant 束縛 (他 tenant の inviteId は no-op、cross-tenant mutation 排除、#3588 / ADR-0063)
 //   [I6] updateInviteStatus 状態機械: pending 以外からの再遷移は no-op (#3588 ③)
 //   [I7] 一覧の inviteId → revoke/delete が正しく反応する (raw 非保存の債務解消、#3585 / #3588 ④)
 //   [N1] consent append-only + findLatestConsent (consented_at 降順) + §P9 tenant 分離
@@ -349,8 +350,8 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 			invitedBy: USER_A,
 			role: 'parent',
 		});
-		// #3585: 管理鍵は inviteId (raw code ではない)
-		await repo.updateInviteStatus(inv1.inviteId, 'revoked');
+		// #3585: 管理鍵は inviteId (raw code ではない)。#3588: tenant scope は family_id 述語
+		await repo.updateInviteStatus(inv1.inviteId, tenant.tenantId, 'revoked');
 		expect((await repo.findInviteByCode(inv1.inviteCode))?.status).toBe('revoked');
 
 		const inv2 = await repo.createInvite({
@@ -358,7 +359,7 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 			invitedBy: USER_A,
 			role: 'parent',
 		});
-		await repo.updateInviteStatus(inv2.inviteId, 'accepted', USER_B);
+		await repo.updateInviteStatus(inv2.inviteId, tenant.tenantId, 'accepted', USER_B);
 		const accepted = await repo.findInviteByCode(inv2.inviteCode);
 		expect(accepted?.status).toBe('accepted');
 		expect(accepted?.acceptedBy).toBe(USER_B);
@@ -370,7 +371,7 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 			invitedBy: USER_A,
 			role: 'parent',
 		});
-		await repo.updateInviteStatus(NO_SUCH, 'revoked');
+		await repo.updateInviteStatus(NO_SUCH, tenant.tenantId, 'revoked');
 		expect((await repo.findInviteByCode(inv3.inviteCode))?.status).toBe('pending');
 	});
 
@@ -390,6 +391,32 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 		expect(await repo.findInviteByCode(invite.inviteCode)).toBeUndefined();
 	});
 
+	it('[I8] updateInviteStatus は tenant 束縛 (他 tenant の inviteId は no-op、cross-tenant mutation 排除、#3588 / ADR-0063)', async () => {
+		// deleteInvite ([I5]) と対称の family_id 述語検証。他家族の invite の status / accepted_by を
+		// 書き換えられないことを assert する (述語を外すと fail する検出力)。
+		const mine = await repo.createTenant({ name: '本家', ownerId: USER_A });
+		const other = await repo.createTenant({ name: '別家', ownerId: USER_B });
+		const invite = await repo.createInvite({
+			tenantId: mine.tenantId,
+			invitedBy: USER_A,
+			role: 'parent',
+		});
+
+		// 他 tenant の family_id 指定 → family_id 述語不一致で 0 行 = no-op (revoke されない)
+		await repo.updateInviteStatus(invite.inviteId, other.tenantId, 'revoked');
+		expect((await repo.findInviteByCode(invite.inviteCode))?.status).toBe('pending');
+
+		// 他 tenant の family_id 指定 + acceptedBy 経路も no-op (accepted_by を書き込めない)
+		await repo.updateInviteStatus(invite.inviteId, other.tenantId, 'accepted', USER_C);
+		const afterCrossTenant = await repo.findInviteByCode(invite.inviteCode);
+		expect(afterCrossTenant?.status).toBe('pending');
+		expect(afterCrossTenant?.acceptedBy).toBeUndefined();
+
+		// 正しい family_id なら遷移する (regression の対照)
+		await repo.updateInviteStatus(invite.inviteId, mine.tenantId, 'revoked');
+		expect((await repo.findInviteByCode(invite.inviteCode))?.status).toBe('revoked');
+	});
+
 	it('[I6] updateInviteStatus 状態機械: pending 以外からの再遷移は no-op (#3588 ③)', async () => {
 		const tenant = await repo.createTenant({ name: '機械家', ownerId: USER_A });
 		const invite = await repo.createInvite({
@@ -397,14 +424,14 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 			invitedBy: USER_A,
 			role: 'parent',
 		});
-		// pending → revoked は許可
-		await repo.updateInviteStatus(invite.inviteId, 'revoked');
+		// pending → revoked は許可 (#3588: tenant scope は family_id 述語)
+		await repo.updateInviteStatus(invite.inviteId, tenant.tenantId, 'revoked');
 		expect((await repo.findInviteByCode(invite.inviteCode))?.status).toBe('revoked');
 
 		// revoked → accepted / pending / expired への再遷移は状態機械が弾く (no-op)
-		await repo.updateInviteStatus(invite.inviteId, 'accepted', USER_B);
-		await repo.updateInviteStatus(invite.inviteId, 'pending');
-		await repo.updateInviteStatus(invite.inviteId, 'expired');
+		await repo.updateInviteStatus(invite.inviteId, tenant.tenantId, 'accepted', USER_B);
+		await repo.updateInviteStatus(invite.inviteId, tenant.tenantId, 'pending');
+		await repo.updateInviteStatus(invite.inviteId, tenant.tenantId, 'expired');
 		const stillRevoked = await repo.findInviteByCode(invite.inviteCode);
 		expect(stillRevoked?.status).toBe('revoked');
 		expect(stillRevoked?.acceptedBy).toBeUndefined();
@@ -420,7 +447,7 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 		expect(listed).toBeDefined();
 		if (!listed) throw new Error('invite not listed');
 		expect(listed.inviteCode).toBe(''); // raw は非露出
-		await repo.updateInviteStatus(listed.inviteId, 'revoked');
+		await repo.updateInviteStatus(listed.inviteId, tenant.tenantId, 'revoked');
 		const afterRevoke = await repo.findTenantInvites(tenant.tenantId);
 		expect(afterRevoke[0]?.status).toBe('revoked');
 

--- a/tests/unit/db/dsql-auth-repo.test.ts
+++ b/tests/unit/db/dsql-auth-repo.test.ts
@@ -15,11 +15,13 @@
 //   [M1] membership CRUD (findUserTenants / findTenantMembers / deleteMembership + 非存在 no-op)
 //   [M2] deleteMembership が唯一の owner をブロック (I-OWN ≥1 app 層、M3 §3.3、FOR UPDATE)
 //   [M3] owner 移譲後は旧 owner (parent 降格) を削除可能
-//   [I1] createInvite → findInviteByCode round-trip (raw code 維持、DB は token_hash のみ保存)
-//   [I2] findTenantInvites の inviteCode = invite_id (raw 非保存のため復元不能、挙動固定)
+//   [I1] createInvite → findInviteByCode round-trip (raw code 維持 + inviteId 採番、DB は token_hash のみ保存)
+//   [I2] findTenantInvites は inviteId を管理鍵に返し inviteCode は '' (raw 非露出、#3585)
 //   [I3] invite email の小文字正規化 (§6.6)
-//   [I4] updateInviteStatus (hash 照合、acceptedBy/acceptedAt 設定)
-//   [I5] deleteInvite の tenant 束縛 (他 tenant からは消せない)
+//   [I4] updateInviteStatus (inviteId 鍵、acceptedBy/acceptedAt 設定、#3585)
+//   [I5] deleteInvite の inviteId 鍵 + tenant 束縛 (他 tenant からは消せない、#3585)
+//   [I6] updateInviteStatus 状態機械: pending 以外からの再遷移は no-op (#3588 ③)
+//   [I7] 一覧の inviteId → revoke/delete が正しく反応する (raw 非保存の債務解消、#3585 / #3588 ④)
 //   [N1] consent append-only + findLatestConsent (consented_at 降順) + §P9 tenant 分離
 
 import { sql } from 'drizzle-orm';
@@ -280,6 +282,9 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 		});
 		// 作成時のみ raw code を返す (dynamo backend と同形式)
 		expect(invite.inviteCode).toMatch(/^inv-/);
+		// #3585: inviteId (管理鍵) は DB 採番 uuid で raw code とは独立
+		expect(invite.inviteId).toMatch(UUID_RE);
+		expect(invite.inviteId).not.toBe(invite.inviteCode);
 		expect(invite.status).toBe('pending');
 		expect(invite.childId).toBe(CHILD_1);
 		// expiresAt ≈ +7 日 (INVITE_EXPIRY_DAYS)
@@ -297,13 +302,14 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 
 		const found = await repo.findInviteByCode(invite.inviteCode);
 		expect(found?.inviteCode).toBe(invite.inviteCode); // 引数の raw code を維持
+		expect(found?.inviteId).toBe(invite.inviteId); // 同一 invite の inviteId を復元
 		expect(found?.tenantId).toBe(tenant.tenantId);
 		expect(found?.invitedBy).toBe(USER_A);
 		expect(found?.role).toBe('parent');
 		expect(await repo.findInviteByCode('inv-unknown')).toBeUndefined();
 	});
 
-	it('[I2] findTenantInvites の inviteCode = invite_id (raw 非保存で復元不能、挙動固定)', async () => {
+	it('[I2] findTenantInvites は inviteId を管理鍵に返し inviteCode は空 (raw 非露出、#3585)', async () => {
 		const tenant = await repo.createTenant({ name: '一覧家', ownerId: USER_A });
 		const created = await repo.createInvite({
 			tenantId: tenant.tenantId,
@@ -313,9 +319,11 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 
 		const listed = await repo.findTenantInvites(tenant.tenantId);
 		expect(listed).toHaveLength(1);
-		// raw code は復元不能 → invite_id (uuid) を返す (interface 進化までの固定挙動)
-		expect(listed[0]?.inviteCode).toMatch(UUID_RE);
-		expect(listed[0]?.inviteCode).not.toBe(created.inviteCode);
+		// #3585: 管理鍵 inviteId (= 作成時の inviteId) を返す
+		expect(listed[0]?.inviteId).toBe(created.inviteId);
+		expect(listed[0]?.inviteId).toMatch(UUID_RE);
+		// raw code は復元不能 (CWE-522) のため一覧では '' (作成時のみ露出)
+		expect(listed[0]?.inviteCode).toBe('');
 		expect(listed[0]?.role).toBe('child');
 		// §P9: 他 tenant の一覧には出ない
 		const other = await repo.createTenant({ name: '別家', ownerId: USER_B });
@@ -334,14 +342,15 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 		expect((await repo.findInviteByCode(invite.inviteCode))?.email).toBe('aunt.mari@example.com');
 	});
 
-	it('[I4] updateInviteStatus: hash 照合 + acceptedBy/acceptedAt 設定', async () => {
+	it('[I4] updateInviteStatus: inviteId 鍵 + acceptedBy/acceptedAt 設定 (#3585)', async () => {
 		const tenant = await repo.createTenant({ name: '状態家', ownerId: USER_A });
 		const inv1 = await repo.createInvite({
 			tenantId: tenant.tenantId,
 			invitedBy: USER_A,
 			role: 'parent',
 		});
-		await repo.updateInviteStatus(inv1.inviteCode, 'revoked');
+		// #3585: 管理鍵は inviteId (raw code ではない)
+		await repo.updateInviteStatus(inv1.inviteId, 'revoked');
 		expect((await repo.findInviteByCode(inv1.inviteCode))?.status).toBe('revoked');
 
 		const inv2 = await repo.createInvite({
@@ -349,14 +358,23 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 			invitedBy: USER_A,
 			role: 'parent',
 		});
-		await repo.updateInviteStatus(inv2.inviteCode, 'accepted', USER_B);
+		await repo.updateInviteStatus(inv2.inviteId, 'accepted', USER_B);
 		const accepted = await repo.findInviteByCode(inv2.inviteCode);
 		expect(accepted?.status).toBe('accepted');
 		expect(accepted?.acceptedBy).toBe(USER_B);
 		expect(accepted?.acceptedAt).toBeDefined();
+
+		// 存在しない inviteId (有効 uuid) は invite_id 照合で一致せず no-op
+		const inv3 = await repo.createInvite({
+			tenantId: tenant.tenantId,
+			invitedBy: USER_A,
+			role: 'parent',
+		});
+		await repo.updateInviteStatus(NO_SUCH, 'revoked');
+		expect((await repo.findInviteByCode(inv3.inviteCode))?.status).toBe('pending');
 	});
 
-	it('[I5] deleteInvite は tenant 束縛 (他 tenant からは消せない)', async () => {
+	it('[I5] deleteInvite は inviteId 鍵 + tenant 束縛 (他 tenant からは消せない、#3585)', async () => {
 		const mine = await repo.createTenant({ name: '自家', ownerId: USER_A });
 		const other = await repo.createTenant({ name: '他家', ownerId: USER_B });
 		const invite = await repo.createInvite({
@@ -365,11 +383,50 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 			role: 'parent',
 		});
 
-		await repo.deleteInvite(invite.inviteCode, other.tenantId); // 他 tenant → no-op
+		await repo.deleteInvite(invite.inviteId, other.tenantId); // 他 tenant → no-op
 		expect(await repo.findInviteByCode(invite.inviteCode)).toBeDefined();
 
-		await repo.deleteInvite(invite.inviteCode, mine.tenantId);
+		await repo.deleteInvite(invite.inviteId, mine.tenantId);
 		expect(await repo.findInviteByCode(invite.inviteCode)).toBeUndefined();
+	});
+
+	it('[I6] updateInviteStatus 状態機械: pending 以外からの再遷移は no-op (#3588 ③)', async () => {
+		const tenant = await repo.createTenant({ name: '機械家', ownerId: USER_A });
+		const invite = await repo.createInvite({
+			tenantId: tenant.tenantId,
+			invitedBy: USER_A,
+			role: 'parent',
+		});
+		// pending → revoked は許可
+		await repo.updateInviteStatus(invite.inviteId, 'revoked');
+		expect((await repo.findInviteByCode(invite.inviteCode))?.status).toBe('revoked');
+
+		// revoked → accepted / pending / expired への再遷移は状態機械が弾く (no-op)
+		await repo.updateInviteStatus(invite.inviteId, 'accepted', USER_B);
+		await repo.updateInviteStatus(invite.inviteId, 'pending');
+		await repo.updateInviteStatus(invite.inviteId, 'expired');
+		const stillRevoked = await repo.findInviteByCode(invite.inviteCode);
+		expect(stillRevoked?.status).toBe('revoked');
+		expect(stillRevoked?.acceptedBy).toBeUndefined();
+	});
+
+	it('[I7] 一覧の inviteId で revoke / delete が正しく反応する (raw 非保存の債務解消、#3585 / #3588 ④)', async () => {
+		const tenant = await repo.createTenant({ name: '債務家', ownerId: USER_A });
+		await repo.createInvite({ tenantId: tenant.tenantId, invitedBy: USER_A, role: 'parent' });
+
+		// 一覧から得た inviteId で管理操作 → 一致して状態遷移する (旧: inviteCode 位置の
+		// invite_id を hash 照合し不一致 no-op となる債務)。
+		const listed = (await repo.findTenantInvites(tenant.tenantId))[0];
+		expect(listed).toBeDefined();
+		if (!listed) throw new Error('invite not listed');
+		expect(listed.inviteCode).toBe(''); // raw は非露出
+		await repo.updateInviteStatus(listed.inviteId, 'revoked');
+		const afterRevoke = await repo.findTenantInvites(tenant.tenantId);
+		expect(afterRevoke[0]?.status).toBe('revoked');
+
+		// 一覧の inviteId で物理削除も反応する
+		await repo.deleteInvite(listed.inviteId, tenant.tenantId);
+		expect(await repo.findTenantInvites(tenant.tenantId)).toEqual([]);
 	});
 
 	// ---------------------------------------------------------- Consent

--- a/tests/unit/routes/admin-invites-owner-gate.test.ts
+++ b/tests/unit/routes/admin-invites-owner-gate.test.ts
@@ -91,14 +91,14 @@ describe('POST /api/v1/admin/invites owner-gate (#3726)', () => {
 	});
 });
 
-describe('DELETE /api/v1/admin/invites/[code] owner-gate (#3726)', () => {
-	const load = () => import('../../../src/routes/api/v1/admin/invites/[code]/+server');
+describe('DELETE /api/v1/admin/invites/[id] owner-gate (#3726)', () => {
+	const load = () => import('../../../src/routes/api/v1/admin/invites/[id]/+server');
 
 	for (const role of ['parent', 'child'] as const) {
 		it(`${role} は 403 + OWNER_GATE_LABELS.inviteRevoke (SSOT 文言、旧 literal とバイト一致)`, async () => {
 			const { DELETE } = await load();
 			const res = await DELETE({
-				params: { code: 'ABC123' },
+				params: { id: 'ABC123' },
 				locals: makeLocals(role),
 			} as never);
 			expect(res.status).toBe(403);
@@ -111,7 +111,7 @@ describe('DELETE /api/v1/admin/invites/[code] owner-gate (#3726)', () => {
 	it('未認証 (context 欠落) は 500 化せず 401', async () => {
 		const { DELETE } = await load();
 		const res = await DELETE({
-			params: { code: 'ABC123' },
+			params: { id: 'ABC123' },
 			locals: makeLocals(null),
 		} as never);
 		expect(res.status).toBe(401);
@@ -121,7 +121,7 @@ describe('DELETE /api/v1/admin/invites/[code] owner-gate (#3726)', () => {
 		mockRevokeInvite.mockResolvedValue(undefined);
 		const { DELETE } = await load();
 		const res = await DELETE({
-			params: { code: 'ABC123' },
+			params: { id: 'ABC123' },
 			locals: makeLocals('owner'),
 		} as never);
 		expect(res.status).toBe(200);

--- a/tests/unit/routes/admin-role-mutation-authz.test.ts
+++ b/tests/unit/routes/admin-role-mutation-authz.test.ts
@@ -76,7 +76,7 @@ const { DELETE: deleteMember } = await import(
 );
 const { POST: createInvitePost } = await import('../../../src/routes/api/v1/admin/invites/+server');
 const { DELETE: revokeInviteDelete } = await import(
-	'../../../src/routes/api/v1/admin/invites/[code]/+server'
+	'../../../src/routes/api/v1/admin/invites/[id]/+server'
 );
 
 // ---------- helpers ----------
@@ -110,7 +110,7 @@ function createInviteCreateEvent(role: Role) {
 
 function createInviteRevokeEvent(role: Role) {
 	return {
-		params: { code: 'invite-code-1' },
+		params: { id: 'invite-code-1' },
 		locals: {
 			context: { tenantId: 't-test', role },
 			identity: { type: 'cognito', userId: 'u-caller' },
@@ -311,7 +311,7 @@ describe('owner 専用 member mutation API の requireRole seam 統一 (#3528 fi
 		});
 	});
 
-	describe('DELETE /api/v1/admin/invites/[code] (#3549 (a) 招待取消の owner 専用化)', () => {
+	describe('DELETE /api/v1/admin/invites/[id] (#3549 (a) 招待取消の owner 専用化)', () => {
 		beforeEach(() => {
 			mockRevokeInvite.mockResolvedValue(undefined);
 		});

--- a/tests/unit/services/account-deletion-service.test.ts
+++ b/tests/unit/services/account-deletion-service.test.ts
@@ -193,6 +193,13 @@ describe('account-deletion-service', () => {
 			expect(result.pattern).toBe('owner-only');
 			expect(mockAuthRepo.deleteTenant).toHaveBeenCalledWith(TENANT_ID);
 			expect(mockAuthRepo.deleteUser).toHaveBeenCalledWith(OWNER_ID);
+
+			// #3588 ②: DSQL cutover 安全性 — membership (tenant scope) を global user 削除より先に
+			// 掃除する (FK 非対応ゆえ dangling user_id 窓を作らない)。
+			const deleteMembershipOrder =
+				mockAuthRepo.deleteMembership.mock.invocationCallOrder[0] ?? Infinity;
+			const deleteUserOrder = mockAuthRepo.deleteUser.mock.invocationCallOrder[0] ?? -Infinity;
+			expect(deleteMembershipOrder).toBeLessThan(deleteUserOrder);
 		});
 
 		it('他メンバーがいる場合はエラー', async () => {

--- a/tests/unit/services/invite-service.test.ts
+++ b/tests/unit/services/invite-service.test.ts
@@ -48,16 +48,21 @@ const mockAuthRepo: Partial<IAuthRepo> = {
 		return inviteStore.get(code);
 	}),
 	// #3585: 管理系は inviteId 鍵。store は inviteCode で引くため inviteId で線形検索する。
-	updateInviteStatus: vi.fn(async (inviteId: string, status: string, acceptedBy?: string) => {
-		const invite = [...inviteStore.values()].find((i) => i.inviteId === inviteId);
-		if (invite) {
-			invite.status = status as Invite['status'];
-			if (acceptedBy) {
-				invite.acceptedBy = acceptedBy;
-				invite.acceptedAt = new Date().toISOString();
+	// #3588: tenant scope は tenantId 引数 (family_id 述語相当) で他 tenant の invite を弾く。
+	updateInviteStatus: vi.fn(
+		async (inviteId: string, tenantId: string, status: string, acceptedBy?: string) => {
+			const invite = [...inviteStore.values()].find(
+				(i) => i.inviteId === inviteId && i.tenantId === tenantId,
+			);
+			if (invite) {
+				invite.status = status as Invite['status'];
+				if (acceptedBy) {
+					invite.acceptedBy = acceptedBy;
+					invite.acceptedAt = new Date().toISOString();
+				}
 			}
-		}
-	}),
+		},
+	),
 	findTenantInvites: vi.fn(async (tenantId: string) => {
 		return Array.from(inviteStore.values()).filter((i) => i.tenantId === tenantId);
 	}),
@@ -160,7 +165,7 @@ describe('getInvite', () => {
 		const result = await getInvite('past');
 		expect(result).toBeNull();
 		// #3585: 状態遷移は inviteId 鍵 (code ではなく invite.inviteId を渡す)
-		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('id-past', 'expired');
+		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('id-past', 't-test', 'expired');
 	});
 });
 
@@ -242,7 +247,7 @@ describe('revokeInvite (#3585 inviteId 鍵)', () => {
 		inviteStore.set('rev-1', makePendingInvite({ inviteCode: 'rev-1' }));
 
 		await revokeInvite('id-rev-1', 't-test');
-		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('id-rev-1', 'revoked');
+		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('id-rev-1', 't-test', 'revoked');
 	});
 
 	it('別テナントの inviteId は取り消せない (一覧に無い → no-op、cross-tenant 防止)', async () => {
@@ -369,7 +374,7 @@ describe('招待失効 × email 束縛 (#3555 ②)', () => {
 		const result = assertError(await acceptInvite('exp-em', 'user-new', 'intended@example.com'));
 		expect(result.error).toBe('INVALID_OR_EXPIRED');
 		// pending のまま放置されず expired に遷移する (getInvite の自動失効、#3585 inviteId 鍵)
-		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('id-exp-em', 'expired');
+		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('id-exp-em', 't-test', 'expired');
 	});
 });
 

--- a/tests/unit/services/invite-service.test.ts
+++ b/tests/unit/services/invite-service.test.ts
@@ -10,9 +10,13 @@ let membershipStore: Membership[];
 let tenantStore: Map<string, Tenant>;
 let userTenantStore: Map<string, Membership[]>;
 
+// #3585: inviteId は管理鍵、inviteCode は raw code。unit mock では inviteId を code から
+// 派生 (id-<code>) して一意にし「service が inviteId を渡す (code ではない)」ことを検証可能にする。
 function makePendingInvite(overrides: Partial<Invite> = {}): Invite {
+	const inviteCode = overrides.inviteCode ?? 'test-code-123';
 	return {
-		inviteCode: 'test-code-123',
+		inviteId: `id-${inviteCode}`,
+		inviteCode,
 		tenantId: 't-test',
 		invitedBy: 'user-owner',
 		role: 'parent',
@@ -25,8 +29,10 @@ function makePendingInvite(overrides: Partial<Invite> = {}): Invite {
 
 const mockAuthRepo: Partial<IAuthRepo> = {
 	createInvite: vi.fn(async (input) => {
+		const inviteCode = `inv-${Date.now()}`;
 		const invite: Invite = {
-			inviteCode: `inv-${Date.now()}`,
+			inviteId: `id-${inviteCode}`,
+			inviteCode,
 			tenantId: input.tenantId,
 			invitedBy: input.invitedBy,
 			role: input.role,
@@ -41,8 +47,9 @@ const mockAuthRepo: Partial<IAuthRepo> = {
 	findInviteByCode: vi.fn(async (code: string) => {
 		return inviteStore.get(code);
 	}),
-	updateInviteStatus: vi.fn(async (code: string, status: string, acceptedBy?: string) => {
-		const invite = inviteStore.get(code);
+	// #3585: 管理系は inviteId 鍵。store は inviteCode で引くため inviteId で線形検索する。
+	updateInviteStatus: vi.fn(async (inviteId: string, status: string, acceptedBy?: string) => {
+		const invite = [...inviteStore.values()].find((i) => i.inviteId === inviteId);
 		if (invite) {
 			invite.status = status as Invite['status'];
 			if (acceptedBy) {
@@ -152,7 +159,8 @@ describe('getInvite', () => {
 
 		const result = await getInvite('past');
 		expect(result).toBeNull();
-		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('past', 'expired');
+		// #3585: 状態遷移は inviteId 鍵 (code ではなく invite.inviteId を渡す)
+		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('id-past', 'expired');
 	});
 });
 
@@ -227,25 +235,32 @@ describe('acceptInvite', () => {
 	});
 });
 
-describe('revokeInvite', () => {
-	it('pending の招待を取り消せる', async () => {
+// #3585: revoke は inviteId 鍵 (admin 一覧の inviteId を受ける)。tenant scope は
+// findTenantInvites (tenant 束縛一覧) に inviteId が存在することで担保する。
+describe('revokeInvite (#3585 inviteId 鍵)', () => {
+	it('一覧の inviteId で pending の招待を取り消せる', async () => {
 		inviteStore.set('rev-1', makePendingInvite({ inviteCode: 'rev-1' }));
 
-		await revokeInvite('rev-1', 't-test');
-		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('rev-1', 'revoked');
+		await revokeInvite('id-rev-1', 't-test');
+		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('id-rev-1', 'revoked');
 	});
 
-	it('別テナントの招待は取り消せない', async () => {
+	it('別テナントの inviteId は取り消せない (一覧に無い → no-op、cross-tenant 防止)', async () => {
 		inviteStore.set('rev-2', makePendingInvite({ inviteCode: 'rev-2', tenantId: 't-other' }));
 
-		await revokeInvite('rev-2', 't-test');
+		await revokeInvite('id-rev-2', 't-test');
 		expect(mockAuthRepo.updateInviteStatus).not.toHaveBeenCalled();
 	});
 
-	it('既に accepted の招待は取り消せない', async () => {
+	it('既に accepted の招待は取り消せない (状態機械)', async () => {
 		inviteStore.set('rev-3', makePendingInvite({ inviteCode: 'rev-3', status: 'accepted' }));
 
-		await revokeInvite('rev-3', 't-test');
+		await revokeInvite('id-rev-3', 't-test');
+		expect(mockAuthRepo.updateInviteStatus).not.toHaveBeenCalled();
+	});
+
+	it('存在しない inviteId は no-op', async () => {
+		await revokeInvite('id-nonexistent', 't-test');
 		expect(mockAuthRepo.updateInviteStatus).not.toHaveBeenCalled();
 	});
 });
@@ -353,8 +368,8 @@ describe('招待失効 × email 束縛 (#3555 ②)', () => {
 
 		const result = assertError(await acceptInvite('exp-em', 'user-new', 'intended@example.com'));
 		expect(result.error).toBe('INVALID_OR_EXPIRED');
-		// pending のまま放置されず expired に遷移する (getInvite の自動失効)
-		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('exp-em', 'expired');
+		// pending のまま放置されず expired に遷移する (getInvite の自動失効、#3585 inviteId 鍵)
+		expect(mockAuthRepo.updateInviteStatus).toHaveBeenCalledWith('id-exp-em', 'expired');
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ システム全体（認証・招待・アカウント削除）

**解決する課題**: 招待 (invite) の取消 (revoke/delete) が raw `inviteCode` を鍵にしていたため、① 一覧の inviteId で取消操作が反応しない (hash 不一致 no-op) 債務、② raw code の interface 露出 (CWE-522)、③ fullTenantDeletion で global users を memberships 掃除前に削除する dangling 窓、④ hash 関数の二重定義があった。加えて QM Tier2 レビューで、⑤ `updateInviteStatus` が `deleteInvite` と非対称に **tenant (family_id) 述語を欠き**、cross-tenant mutation (他家族 invite の status / accepted_by 書込) の latent ベクタになっていた点 (ADR-0063 §3.4 違反) が検出された。

**期待される効果**: 招待取消が確実に反応し、raw code を露出しない安全な inviteId 鍵の interface に統一。テナント削除の掃除順を是正し FK 非対応環境での dangling を解消。`updateInviteStatus` を `deleteInvite` と対称化し、query 層の `family_id` 述語で cross-tenant mutation を物理排除する (ADR-0063 単一強制点、caller-discipline 非依存)。

## 関連 Issue

closes #3588
closes #3585

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (#3585) | IAuthRepo の update/deleteInvite を inviteId 鍵に進化 (findInviteByCode のみ raw code 維持) | `npx vitest run tests/unit/db/dsql-auth-repo.test.ts` | HEAD `c94bf1b5` / 24 passed |
| AC2 (#3585) | findTenantInvites が inviteId を返し inviteCode='' で raw 非露出 (CWE-522) | interfaces/auth-repo.interface.ts + 4 backend parity | HEAD `c94bf1b5` / dsql/dynamodb/demo/sqlite 実装 |
| AC3 (#3585) | admin UI 取消を inviteId 化 (route [code]→[id]) | `ls src/routes/api/v1/admin/invites/` | HEAD `c94bf1b5` / `[id]/` のみ (旧 [code] 削除完遂) |
| AC4 (#3588①) | hashInviteCode/hashInviteToken を hashInviteSecret SSOT に統合 | invite-code-hash.ts / invite-token.ts | HEAD `c94bf1b5` / invite-token.test.ts pass |
| AC5 (#3588②) | fullTenantDeletion を memberships 掃除 → global users 削除順に是正 | `npx vitest run tests/unit/services/account-deletion-service.test.ts` | HEAD `c94bf1b5` / invocationCallOrder guard pass |
| AC6 (#3588③) | updateInviteStatus に AND status='pending' 状態機械 (再遷移 no-op) **+ AND family_id=${tenantId} tenant 述語** (ADR-0063 §3.4 単一強制点、deleteInvite と対称。QM Tier2 指摘対応) | `npx vitest run tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts tests/unit/db/dsql-auth-repo.test.ts tests/unit/services/invite-service.test.ts` | HEAD `c94bf1b5` / fitness `[main]` green + `[allowlist-live]` green (allowlist 追記なしで正当 green 化) + dsql `[I8]` cross-tenant no-op + invite-service pass |
| AC7 (#3588④) | 一覧 inviteId で revoke/delete が反応 (旧 hash 不一致 no-op 解消) | dsql-auth-repo [I7] failing-test-first | HEAD `c94bf1b5` / red→green |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ / repo (`/server/db/`) — 4 backend auth-repo (dsql/dynamodb/demo + interface)、updateInviteStatus に tenantId 引数追加
- [x] サービス層 (`/server/services/`) — invite-service / account-deletion-service (updateInviteStatus 呼び出しに tenantId 引き回し)
- [x] API エンドポイント (`src/routes/api/`) — invites/[id] (rename) / tenant-cleanup (updateInviteStatus に tenantId)
- [x] ページ / レイアウト (`src/routes/`) — admin/members/+page.svelte
- [x] 認証 (`/server/auth/`) — entities / invite-code-hash / invite-token

**影響を受ける画面・機能**: 親管理画面の招待 (members) 取消、テナント削除フロー

## テスト & 安全装置セルフチェック

- [x] **targeted 検証 (CI が回す fitness function 含む)**: `dsql-tenant-predicate-fitness` [main]/[allowlist-live] green (前回 red の直因、本 fix で green 化) / `dsql-auth-repo` 24 passed ([I8] cross-tenant no-op 追加) / `invite-service` 22 passed / `account-deletion-service` pass / biome 9 file clean / svelte-check は変更 8 file に error 0 (残 149 error は全て `infra/` の aws-cdk-lib 未 install 環境問題で本 PR 無関係)
- [x] 追加・変更したテスト: dsql-auth-repo に **[I8] updateInviteStatus の tenant 束縛 (他 tenant inviteId は no-op、述語を外すと fail する検出力)** を push-down-pyramid で追加 (deleteInvite [I5] と対称)。既存 [I4]/[I6]/[I7] と invite-service mock を新シグネチャに更新
- [x] **PREDICATE_ALLOWLIST 追記なし**: deleteInvite が正しく述語付きである以上、非対称放置に正当理由なし。gate を黙らせる回避 (ADR-0006/0061 assertion-erosion) ではなく SQL 本体を是正して fitness を green 化
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: dynamodb/auth-repo.ts に `current.tenantId !== tenantId` cross-tenant guard 追加 (4 backend parity 維持)
- [x] **Critical バグ修正の場合**: N/A

> **前回 self-review の是正 (ADR-0060)**: 初版 body は「svelte-check 0 error / 全 PASS」と記載したが、手選び file の vitest のみで CI が回す `dsql-tenant-predicate-fitness` を検証対象に含めておらず、CI (`unit-test` / `ci-gate`) が red だった。本 fix で fitness を検証対象に組み込み green 化を確認。

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: admin/members の変更は取消操作の鍵を inviteId 化する内部変更で、視覚レイアウトは不変。updateInviteStatus の tenantId 述語追加も query 層の内部変更で UI 描画の見た目差分なし。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: hash 関数を hashInviteSecret SSOT に統合 (単一責任)、inviteId 鍵で interface 分離
- [x] **DRY**: hashInviteCode/hashInviteToken の二重定義を撤廃
- [x] **YAGNI**: 過剰抽象化なし
- [x] **Security**: raw inviteCode の interface 露出を撤廃 (CWE-522)、fullTenantDeletion の掃除順是正で FK 非対応環境の dangling 解消、**updateInviteStatus に family_id 述語追加で cross-tenant mutation を物理排除 (ADR-0063 §3.4、RLS 非対応の代替防御線)**
- [x] **アクセシビリティ**: N/A (内部鍵変更、UI 表示不変)
- [x] **パフォーマンス**: N+1 なし

## 横展開・影響波及チェック

- [x] 4 backend (dsql/dynamodb/demo/sqlite) parity 済 (updateInviteStatus シグネチャに tenantId を全 backend で反映)
- [x] **設計書同期** (ADR-0001): endpoint route rename `/api/v1/admin/invites/[code]` → `[id]` を設計書 3 file に同期 (`07-API設計書.md` 一覧表 + DELETE 詳細節見出し、`14-セキュリティ設計書.md` §5.2.3 role-mutation 表)。あわせて `updateInviteStatus` の cross-tenant mutation 物理排除 (ADR-0063 §3.4 単一強制点、fitness `dsql-tenant-predicate-fitness`) を §5.2.3 に SSOT 化。`grep "admin/invites/[code]" docs/` == 0 件を確認 (QM Tier2 false-exempt 指摘の是正)
- [x] N/A — その他並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** (route [code]→[id] は admin 内部 API、LEGACY_URL_MAP 対象外の未公開 endpoint。updateInviteStatus は internal repo interface のシグネチャ変更で全 caller を同 PR で更新済)

**レビュー依頼事項・QA**: ① updateInviteStatus の family_id 述語が deleteInvite と対称であること (dsql `[I8]` + fitness `[main]`)、② fullTenantDeletion の掃除順 (memberships → global users) の invocationCallOrder guard、③ findTenantInvites の inviteCode='' (raw 非露出) を重点確認願います。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] targeted 検証 全 PASS をローカル確認 (CI fitness function 含む)
- [x] セルフレビュー済み
- [x] 全 AC が実装済み (AC6 に tenant 述語対応込み)
- [x] Phase 分割なし
- [x] UI 変更なし (SS 該当なし)
- [x] 認証画面変更: 内部鍵変更のため実ブラウザ操作 SS 不要 (視覚差分なし)

## QM レビュー結果

<!-- QM 記入 -->

