### PR TITLE
fix(data-integrity): #3574 Family repo 実装担保 — pin/token 再発行 expire-then-purge + push endpoint family scope 再適用 + graduation_consent tamper-evidence

### DIFF
--- a/docs/design/dsql-data-model.md
+++ b/docs/design/dsql-data-model.md
@@ -394,13 +394,13 @@ children (
 | report_daily_summaries | **廃止**（§7） | — | compute-on-read |
 | achievements / child_achievements | **drop 判断（#322 廃止・データ不在）**: drop なら §3/§5 から除外、存続なら milestone_values 子表化 | — | 要確定（§10 追記） |
 | settings | `(family_id, key)` | — | 自然複合 (anchor (b): KVS の 1 key = 1 value は構造的確実。⚠️ sqlite 現行は tenant_id 列なし = cutover で family_id 追加、単一家族は定数 §P10) |
-| push_subscriptions | `(family_id, subscription_id uuid)` | **UNIQUE(endpoint) global**（無 tenant 単点 findByEndpoint） | UUID surrogate（endpoint は rotate される mutable、anchor 無し） |
+| push_subscriptions | `(family_id, subscription_id uuid)` | **UNIQUE(endpoint) global**（findByEndpoint は endpoint 値単独 lookup 後 family scope 再適用、#3574 ② §P9） | UUID surrogate（endpoint は rotate される mutable、anchor 無し） |
 | notification_logs | `(family_id, log_id uuid[v4])` | sent_at は素の列（sort 用途） | UUID surrogate（append-only log、once-per-period 一意なし） |
 | trial_history | `(family_id, trial_id uuid[v4])` | cross-tenant cron 用 secondary(end_date) は計測後 | UUID surrogate（1 tenant N 回トライアル） |
-| viewer_tokens | `(family_id, token_id uuid)` | **UNIQUE(token) global**（無 tenant 単点 findByToken） | UUID surrogate（token は revoke 後再発行あり） |
-| cloud_exports | `(family_id, export_id uuid)` | **UNIQUE(pin_code) global** + secondary(status)（cron findPendingBuilds） | UUID surrogate（pin は expire 後再利用） |
-| cancellation_reasons | `(family_id, reason_id uuid[v4])` | cross-tenant 分析用 secondary(created_at 系) は計測後 | UUID surrogate（append-only、PO KPI 分析表 = hot path は cross-tenant である点を repo PR で明示） |
-| graduation_consent | `(family_id, consent_id uuid[v4])` | secondary(consented, consented_at)（publicSamples/aggregate） | UUID surrogate（複数子×複数回で多数行が正） |
+| viewer_tokens | `(family_id, token_id uuid)` | **UNIQUE(token) global**（無 tenant 単点 findByToken。insert は revoke/expire 後の値再発行を expire-then-purge で担保、#3574 ①） | UUID surrogate（token は revoke 後再発行あり） |
+| cloud_exports | `(family_id, export_id uuid)` | **UNIQUE(pin_code) global** + secondary(status)（cron findPendingBuilds）。insert は expire/DL 上限後の pin 値再発行を expire-then-purge で担保（#3574 ①） | UUID surrogate（pin は expire 後再利用） |
+| cancellation_reasons | `(family_id, reason_id uuid[v4])` | cross-tenant 分析用 secondary(created_at 系) は計測後（#3574 ③: §P5「投機的に張らない」に従い KPI hot path の実 EXPLAIN ANALYZE で必要確認後に追加。family スケールの aggregateRecent/searchFreeText は当面 PK-prefix scan で許容） | UUID surrogate（append-only、PO KPI 分析表 = hot path は cross-tenant である点を repo PR で明示） |
+| graduation_consent | `(family_id, consent_id uuid[v4])` | secondary(consented, consented_at)（publicSamples/aggregate、cross-tenant KPI hot path は #3574 ③ で §P5 計測後追加判断）。**append-only（COPPA 同意証跡）**: repo は UPDATE を定義せず改竄不能（#3574 ④、`dsql-append-only-mutation-allowlist.test.ts` で機械強制） | UUID surrogate（複数子×複数回で多数行が正） |
 | parent_gate_credentials | `(family_id)` | — | 1:1 従属（M2 §1.1、ADR-0050 保護者ゲート。PIN は平文非保持ハッシュ、失敗回数/ロック解除時刻/リセット痕跡は素の列） |
 | loyalty_state | `(family_id)` | — | 1:0..1 従属（M2 §1.1、記念チケット数=点数経済外の第2通貨カウンタ D-LOYALTY） |
 | account_lifecycle | `(family_id)` | — | 1:1 従属（M2 §1.1、状態機械 active/soft-deleted/purged、猶予プラン層→plan_tiers 論理 FK） |

--- a/src/lib/server/db/dsql/cloud-export-repo.ts
+++ b/src/lib/server/db/dsql/cloud-export-repo.ts
@@ -98,6 +98,16 @@ export function createDsqlCloudExportRepo(db: SqlExecutor): ICloudExportRepo {
 		},
 
 		async insert(input) {
+			// #3574 ①: expire-then-purge。pin_code は expire 後の値再利用が前提 (§11.2) だが global
+			// UNIQUE のため、自 family の dead 旧行 (期限切れ or DL 上限到達) が同 pin を占有したまま
+			// 再発行すると UNIQUE 衝突で沈黙失敗する。挿入前に自 family の再利用可能な旧行を purge する。
+			// live 行 (自/他 family) が占有していれば purge 対象外 → UNIQUE 衝突が surface する
+			// (= 2 live 行防止は維持)。purge を自 family scope に限定し他 family の行には触れない (§P9)。
+			await db.execute(sql`
+				DELETE FROM cloud_exports
+				WHERE family_id = ${input.tenantId} AND pin_code = ${input.pinCode}
+					AND (expires_at < now() OR download_count >= max_downloads)
+			`);
 			const result = await db.execute(sql`
 				INSERT INTO cloud_exports
 					(family_id, export_type, pin_code, s3_key, file_size_bytes, label, description,

--- a/src/lib/server/db/dsql/push-subscription-repo.ts
+++ b/src/lib/server/db/dsql/push-subscription-repo.ts
@@ -3,9 +3,10 @@
 //
 // IPushSubscriptionRepo (push_subscriptions + notification_logs) の DSQL backend 実装。設計契約:
 //   - **factory 注入** (fitness#8)。全操作が単文のため txn runner 不要。
-//   - **§P9 tenant 述語**: findByEndpoint / deleteByEndpoint (ブラウザ Push endpoint の無 tenant
-//     値単独 lookup、endpoint global UNIQUE が機能要件 — schema §11.2 で明示された例外。sqlite
-//     backend も tenantId を無視する同 shape) を除く全メソッドが family_id = tenantId を含む。
+//   - **§P9 tenant 述語**: 全メソッドが family_id = tenantId を含む。**#3574 ② で findByEndpoint /
+//     deleteByEndpoint も family scope 再適用に変更**: endpoint (global UNIQUE) は attacker 可制御値
+//     のため、値単独 lookup 後に family_id で再スコープし cross-family read / IDOR-delete を遮断する
+//     (旧「無 tenant lookup」から改訂。DynamoDB backend は PK=T#<tenant>#PUSH_SUB で元から tenant 束縛)。
 //   - **UUID surrogate PK**: subscription_id / log_id は gen_random_uuid() 採番。
 //   - **subscriberRole は Repository 境界で正規化** (#1593 / ADR-0023 I6): 送信側 skip の
 //     二重防御があるため、不正値も string 経由で PushSubscriberRole に渡す (sqlite と同判断)。
@@ -91,10 +92,14 @@ export function createDsqlPushSubscriptionRepo(db: SqlExecutor): IPushSubscripti
 			return (result.rows as unknown as PushSubscriptionRow[]).map(toSubscription);
 		},
 
-		async findByEndpoint(endpoint, _tenantId) {
-			// endpoint global UNIQUE の無 tenant 値単独 lookup (§11.2 機能要件、sqlite と同 shape)。
+		async findByEndpoint(endpoint, tenantId) {
+			// #3574 ②: endpoint (global UNIQUE) の値単独 lookup 後、返却前に family scope を再適用する
+			// (§P9)。呼び出し元 (subscribe route) は body.endpoint = attacker 可制御値 + 認証済 tenantId を
+			// 渡すため、tenantId 無視 lookup は cross-family read (push key 存在オラクル) 経路になる。
+			// endpoint は 1 family にしか属さない (global UNIQUE) ので family 一致時のみ 1 行に解決する。
 			const result = await db.execute(sql`
-				SELECT ${SUBSCRIPTION_COLUMNS} FROM push_subscriptions WHERE endpoint = ${endpoint}
+				SELECT ${SUBSCRIPTION_COLUMNS} FROM push_subscriptions
+				WHERE endpoint = ${endpoint} AND family_id = ${tenantId}
 			`);
 			const row = result.rows[0] as unknown as PushSubscriptionRow | undefined;
 			return row ? toSubscription(row) : undefined;
@@ -113,9 +118,14 @@ export function createDsqlPushSubscriptionRepo(db: SqlExecutor): IPushSubscripti
 			return toSubscription(row);
 		},
 
-		async deleteByEndpoint(endpoint, _tenantId) {
-			// endpoint global UNIQUE 前提の値単独削除 (sqlite backend と同 shape)。
-			await db.execute(sql`DELETE FROM push_subscriptions WHERE endpoint = ${endpoint}`);
+		async deleteByEndpoint(endpoint, tenantId) {
+			// #3574 ②: family scope を再適用する (§P9)。unsubscribe route は body.endpoint (attacker
+			// 可制御) をそのまま渡すため、family 不一致の削除は cross-family IDOR-delete (他家の購読を
+			// 消す) になる。family 一致行のみ削除し不一致は no-op にする。正規呼び出し元 (自 family の
+			// findByTenant 由来 endpoint / 送信失敗 cleanup) は tenantId が endpoint 所有者と一致する。
+			await db.execute(sql`
+				DELETE FROM push_subscriptions WHERE endpoint = ${endpoint} AND family_id = ${tenantId}
+			`);
 		},
 
 		// ── Notification logs ──

--- a/src/lib/server/db/dsql/viewer-token-repo.ts
+++ b/src/lib/server/db/dsql/viewer-token-repo.ts
@@ -64,6 +64,15 @@ export function createDsqlViewerTokenRepo(db: SqlExecutor): IViewerTokenRepo {
 		},
 
 		async insert(input, tenantId) {
+			// #3574 ①: expire-then-purge。token は revoke 後の値再発行が前提 (§11.2) だが global
+			// UNIQUE のため、自 family の dead 旧行 (revoke 済 or 期限切れ) が同 token を占有したまま
+			// 再発行すると UNIQUE 衝突で沈黙失敗する。挿入前に自 family の再利用可能な旧行を purge する。
+			// live 行が占有していれば purge 対象外 → UNIQUE 衝突が surface する (= 2 live 行防止は維持、§P9)。
+			await db.execute(sql`
+				DELETE FROM viewer_tokens
+				WHERE family_id = ${tenantId} AND token = ${input.token}
+					AND (revoked_at IS NOT NULL OR (expires_at IS NOT NULL AND expires_at < now()))
+			`);
 			const result = await db.execute(sql`
 				INSERT INTO viewer_tokens (family_id, token, label, expires_at)
 				VALUES (${tenantId}, ${input.token}, ${input.label ?? null},

--- a/src/lib/server/db/dynamodb/cloud-export-repo.ts
+++ b/src/lib/server/db/dynamodb/cloud-export-repo.ts
@@ -98,7 +98,45 @@ export async function findById(
 	return res.Item ? mapItem(res.Item) : undefined;
 }
 
+/**
+ * #3574 ①: expire-then-purge (DSQL/sqlite backend と parity)。pin_code は expire 後の値再利用が
+ * 前提。DynamoDB は pin_code に一意制約が無い (PK = tenant+id) ため、dead 旧行 (期限切れ or DL 上限
+ * 到達) が同 pin を持ったまま残ると findByPin が非決定的になる。挿入前に自 tenant partition から
+ * 同 pin の dead 行を purge して findByPin の解決を新 live 行に収束させる。
+ */
+async function purgeReusablePin(tenantId: string, pinCode: string): Promise<void> {
+	const now = new Date().toISOString();
+	const pk = cloudExportTenantPK(tenantId);
+	const keys: Array<{ PK: string; SK: string }> = [];
+	let lastKey: Record<string, unknown> | undefined;
+	do {
+		const res = await getDocClient().send(
+			new QueryCommand({
+				TableName: TABLE_NAME,
+				KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+				FilterExpression: 'pinCode = :pin AND (expiresAt < :now OR downloadCount >= maxDownloads)',
+				ExpressionAttributeValues: {
+					':pk': pk,
+					':prefix': cloudExportSKPrefix(),
+					':pin': pinCode,
+					':now': now,
+				},
+				ProjectionExpression: 'PK, SK',
+				ExclusiveStartKey: lastKey,
+			}),
+		);
+		for (const item of res.Items ?? []) {
+			keys.push({ PK: item.PK as string, SK: item.SK as string });
+		}
+		lastKey = res.LastEvaluatedKey as Record<string, unknown> | undefined;
+	} while (lastKey);
+	for (const key of keys) {
+		await getDocClient().send(new DeleteCommand({ TableName: TABLE_NAME, Key: key }));
+	}
+}
+
 export async function insert(input: InsertCloudExportInput): Promise<CloudExportRecord> {
+	await purgeReusablePin(input.tenantId, input.pinCode);
 	const id = await nextId(ENTITY_NAMES.cloudExport, input.tenantId);
 	const now = new Date().toISOString();
 

--- a/src/lib/server/db/dynamodb/viewer-token-repo.ts
+++ b/src/lib/server/db/dynamodb/viewer-token-repo.ts
@@ -75,6 +75,9 @@ export async function insert(
 	input: InsertViewerTokenInput,
 	tenantId: string,
 ): Promise<ViewerToken> {
+	// #3574 ①: DSQL/sqlite の expire-then-purge に相当する挙動を PK 設計で満たす。PK = VTOKEN#<token>
+	// のため同 token の再発行 Put は既存 (revoke 済 / 期限切れ) 行を上書きし、token あたり常に 1 行に
+	// 収束する (2 行併存が構造的に不可能)。したがって明示 purge は不要。
 	const id = await nextId(ENTITY_NAMES.viewerToken, tenantId);
 	const now = new Date().toISOString();
 

--- a/src/lib/server/db/interfaces/push-subscription-repo.interface.ts
+++ b/src/lib/server/db/interfaces/push-subscription-repo.interface.ts
@@ -7,8 +7,18 @@ import type {
 
 export interface IPushSubscriptionRepo {
 	findByTenant(tenantId: string): Promise<PushSubscriptionRecord[]>;
+	/**
+	 * endpoint (global UNIQUE) の値単独 lookup。**#3574 ② で family scope を再適用する契約に変更**:
+	 * endpoint は attacker 可制御値 (subscribe route の body.endpoint) のため、返却前に family_id で
+	 * 再スコープし cross-family read (push key 存在オラクル) を遮断する (§P9)。endpoint は 1 family に
+	 * しか属さない (global UNIQUE) ので family 一致時のみ 1 行に解決する。全 backend で tenantId を使う。
+	 */
 	findByEndpoint(endpoint: string, tenantId: string): Promise<PushSubscriptionRecord | undefined>;
 	insert(input: InsertPushSubscriptionInput): Promise<PushSubscriptionRecord>;
+	/**
+	 * **#3574 ②**: family scope 再適用 (§P9)。unsubscribe route が body.endpoint をそのまま渡すため、
+	 * family 不一致の削除は cross-family IDOR-delete になる。family 一致行のみ削除し不一致は no-op。
+	 */
 	deleteByEndpoint(endpoint: string, tenantId: string): Promise<void>;
 
 	// Notification logs

--- a/src/lib/server/db/sqlite/cloud-export-repo.ts
+++ b/src/lib/server/db/sqlite/cloud-export-repo.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, lt, sql } from 'drizzle-orm';
+import { and, asc, count, desc, eq, lt, or, sql } from 'drizzle-orm';
 import { db } from '../client';
 import { cloudExports } from '../schema';
 import type {
@@ -47,6 +47,22 @@ export async function findById(
 
 export async function insert(input: InsertCloudExportInput): Promise<CloudExportRecord> {
 	const now = new Date().toISOString();
+	// #3574 ①: expire-then-purge (DSQL backend と parity)。pin_code は expire 後の値再利用が前提だが
+	// UNIQUE(pin_code) のため、自 tenant の dead 旧行 (期限切れ or DL 上限到達) が同 pin を占有したまま
+	// 再発行すると UNIQUE 衝突で沈黙失敗する。挿入前に自 tenant の再利用可能な旧行を purge する
+	// (live 行が占有していれば purge 対象外 → UNIQUE 衝突が surface = 2 live 行防止は維持)。
+	db.delete(cloudExports)
+		.where(
+			and(
+				eq(cloudExports.tenantId, input.tenantId),
+				eq(cloudExports.pinCode, input.pinCode),
+				or(
+					lt(cloudExports.expiresAt, now),
+					sql`${cloudExports.downloadCount} >= ${cloudExports.maxDownloads}`,
+				),
+			),
+		)
+		.run();
 	const row = db
 		.insert(cloudExports)
 		.values({

--- a/src/lib/server/db/sqlite/push-subscription-repo.ts
+++ b/src/lib/server/db/sqlite/push-subscription-repo.ts
@@ -34,12 +34,14 @@ export async function findByTenant(tenantId: string): Promise<PushSubscriptionRe
 
 export async function findByEndpoint(
 	endpoint: string,
-	_tenantId: string,
+	tenantId: string,
 ): Promise<PushSubscriptionRecord | undefined> {
+	// #3574 ②: family scope 再適用 (§P9、DSQL backend と parity)。endpoint (attacker 可制御) の
+	// 値単独 lookup 後、tenant 一致行のみ返し cross-family read (push key 存在オラクル) を遮断する。
 	const row = await db
 		.select()
 		.from(pushSubscriptions)
-		.where(eq(pushSubscriptions.endpoint, endpoint))
+		.where(and(eq(pushSubscriptions.endpoint, endpoint), eq(pushSubscriptions.tenantId, tenantId)))
 		.get();
 	return row ? normalizePushRow(row) : undefined;
 }
@@ -62,8 +64,12 @@ export async function insert(input: InsertPushSubscriptionInput): Promise<PushSu
 	return normalizePushRow(row);
 }
 
-export async function deleteByEndpoint(endpoint: string, _tenantId: string): Promise<void> {
-	db.delete(pushSubscriptions).where(eq(pushSubscriptions.endpoint, endpoint)).run();
+export async function deleteByEndpoint(endpoint: string, tenantId: string): Promise<void> {
+	// #3574 ②: family scope 再適用 (§P9、DSQL backend と parity)。unsubscribe が body.endpoint を
+	// そのまま渡すため、tenant 不一致削除は cross-family IDOR-delete になる。tenant 一致行のみ削除する。
+	db.delete(pushSubscriptions)
+		.where(and(eq(pushSubscriptions.endpoint, endpoint), eq(pushSubscriptions.tenantId, tenantId)))
+		.run();
 }
 
 // ============================================================

--- a/src/lib/server/db/sqlite/viewer-token-repo.ts
+++ b/src/lib/server/db/sqlite/viewer-token-repo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, lt, or } from 'drizzle-orm';
 import { db } from '../client';
 import { viewerTokens } from '../schema';
 import type { InsertViewerTokenInput, ViewerToken } from '../types';
@@ -27,6 +27,22 @@ export async function insert(
 	tenantId: string,
 ): Promise<ViewerToken> {
 	const now = new Date().toISOString();
+	// #3574 ①: expire-then-purge (DSQL backend と parity)。token は revoke 後の値再発行が前提だが
+	// UNIQUE(token) のため、自 tenant の dead 旧行 (revoke 済 or 期限切れ) が同 token を占有したまま
+	// 再発行すると UNIQUE 衝突で沈黙失敗する。挿入前に自 tenant の再利用可能な旧行を purge する
+	// (live 行が占有していれば purge 対象外 → UNIQUE 衝突が surface = 2 live 行防止は維持)。
+	db.delete(viewerTokens)
+		.where(
+			and(
+				eq(viewerTokens.tenantId, tenantId),
+				eq(viewerTokens.token, input.token),
+				or(
+					isNotNull(viewerTokens.revokedAt),
+					and(isNotNull(viewerTokens.expiresAt), lt(viewerTokens.expiresAt, now)),
+				),
+			),
+		)
+		.run();
 	const row = db
 		.insert(viewerTokens)
 		.values({

--- a/tests/unit/db/dsql-family-satellite-repos.test.ts
+++ b/tests/unit/db/dsql-family-satellite-repos.test.ts
@@ -9,8 +9,11 @@
 //   - **cross-tenant scan の例外 3 種**: findActiveTrials (cron) / aggregateRecent + searchFreeText
 //     (PO KPI 分析) / findPendingBuilds + findStaleBuildingExports + deleteExpired (cron drain /
 //     retention) は §11.2 で明示された tenant 無し走査。containment assert で他テストの行と共存する。
-//   - **無 tenant 単点 lookup の global UNIQUE 3 種**: viewer_tokens.token / push_subscriptions.
-//     endpoint / cloud_exports.pin_code (§11.2 機能要件)。
+//   - **無 tenant 単点 lookup の global UNIQUE (credential 自体が authz)**: viewer_tokens.token /
+//     cloud_exports.pin_code (§11.2 機能要件、findByToken/findByPin は tenant 無し)。
+//   - **push_subscriptions.endpoint は #3574 ② で family scope 再適用**: findByEndpoint /
+//     deleteByEndpoint は endpoint 値単独 lookup 後 family_id で再スコープし cross-family read /
+//     IDOR-delete を遮断する (endpoint は attacker 可制御値、認証済 tenantId を持つ経路のため)。
 //
 // ── Canon TDD test list ──
 // ── ISettingsRepo ──
@@ -24,7 +27,7 @@
 //   [VT1] insert shape + findByTenant (created_at 降順) + §P9
 //   [VT2] findByToken (無 tenant 単点 lookup) / revoke (tenant no-op → soft revoke) / deleteById
 // ── IPushSubscriptionRepo ──
-//   [PS1] insert + findByTenant §P9 + findByEndpoint / deleteByEndpoint (無 tenant、sqlite 同 shape)
+//   [PS1] insert + findByTenant §P9 + findByEndpoint / deleteByEndpoint (§P9 family scope、#3574 ②)
 //   [PS2] insertLog (success boolean→0/1) + countTodayLogs (UTC 日境界) + findRecentLogs 降順 limit
 // ── ICancellationReasonRepo ──
 //   [CR1] create shape + listByTenant 降順 + §P9
@@ -268,7 +271,7 @@ describe('DSQL 衛星系 family repos (M4-E PR8c、実 schema PGlite)', () => {
 
 	// ─────────────────── IPushSubscriptionRepo ───────────────────
 
-	it('[PS1] insert + findByTenant §P9 + findByEndpoint / deleteByEndpoint (無 tenant)', async () => {
+	it('[PS1] insert + findByTenant §P9 + findByEndpoint / deleteByEndpoint (§P9 family scope、#3574 ②)', async () => {
 		const rec = await pushRepo.insert({
 			tenantId: FAMILY,
 			endpoint: 'https://push.example/ep-1',
@@ -292,12 +295,22 @@ describe('DSQL 衛星系 family repos (M4-E PR8c、実 schema PGlite)', () => {
 		expect((await pushRepo.findByTenant(FAMILY)).length).toBe(2);
 		expect(await pushRepo.findByTenant(OTHER_FAMILY)).toEqual([]); // §P9
 
-		// endpoint global UNIQUE の無 tenant lookup (sqlite backend と同 shape、tenantId 無視)
-		const byEp = await pushRepo.findByEndpoint('https://push.example/ep-2', OTHER_FAMILY);
+		// #3574 ②: endpoint (global UNIQUE) の値単独 lookup 後、返却前に family scope を再適用する (§P9)。
+		// 所有 family は取得できるが、他 family を名乗った lookup は cross-family read 遮断で undefined。
+		const byEp = await pushRepo.findByEndpoint('https://push.example/ep-2', FAMILY);
 		expect(byEp?.subscriberRole).toBe('owner');
 		expect(byEp?.userAgent).toBe(null); // default
+		expect(await pushRepo.findByEndpoint('https://push.example/ep-2', OTHER_FAMILY)).toBe(
+			undefined,
+		);
 
+		// 他 family を名乗った削除 (unsubscribe が body.endpoint をそのまま渡す IDOR 経路) は no-op。
 		await pushRepo.deleteByEndpoint('https://push.example/ep-2', OTHER_FAMILY);
+		expect(
+			(await pushRepo.findByEndpoint('https://push.example/ep-2', FAMILY))?.subscriberRole,
+		).toBe('owner');
+		// 所有 family からの削除は成功する。
+		await pushRepo.deleteByEndpoint('https://push.example/ep-2', FAMILY);
 		expect(await pushRepo.findByEndpoint('https://push.example/ep-2', FAMILY)).toBe(undefined);
 		expect((await pushRepo.findByTenant(FAMILY)).length).toBe(1);
 	});

--- a/tests/unit/db/dynamodb-cloud-export-repo.test.ts
+++ b/tests/unit/db/dynamodb-cloud-export-repo.test.ts
@@ -191,6 +191,7 @@ describe('findById', () => {
 describe('insert', () => {
 	it('counter 採番 → PutItem。downloadCount=0 / maxDownloads 既定 10', async () => {
 		mockSend
+			.mockResolvedValueOnce({ Items: [] }) // #3574 ①: purgeReusablePin Query (再利用可能な旧行なし)
 			.mockResolvedValueOnce({ Attributes: { counter: 42 } }) // nextId
 			.mockResolvedValueOnce({}); // PutCommand
 		const { insert } = await loadRepo();
@@ -206,8 +207,8 @@ describe('insert', () => {
 		expect(r.downloadCount).toBe(0);
 		expect(r.maxDownloads).toBe(10);
 		expect(r.label).toBeNull();
-		// PutCommand の Item に key + record
-		const putArg = callOf(1).input;
+		// PutCommand の Item に key + record (call 0 = purge Query, call 1 = nextId, call 2 = Put)
+		const putArg = callOf(2).input;
 		const item = putArg.Item as Record<string, unknown>;
 		expect(item.PK).toBe(`T#${TENANT}#CEXPORT`);
 		expect(item.SK).toBe('EXPORT#00000042');
@@ -215,7 +216,10 @@ describe('insert', () => {
 	});
 
 	it('maxDownloads 明示時はそれを使う', async () => {
-		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		mockSend
+			.mockResolvedValueOnce({ Items: [] }) // #3574 ①: purgeReusablePin Query
+			.mockResolvedValueOnce({ Attributes: { counter: 1 } })
+			.mockResolvedValueOnce({});
 		const { insert } = await loadRepo();
 		const r = await insert({
 			tenantId: TENANT,
@@ -227,6 +231,28 @@ describe('insert', () => {
 			maxDownloads: 3,
 		});
 		expect(r.maxDownloads).toBe(3);
+	});
+
+	it('#3574 ①: expire-then-purge — 同 pin の dead 旧行を Delete してから Put する', async () => {
+		mockSend
+			// purgeReusablePin Query: 同 pin の dead 行 1 件を返す
+			.mockResolvedValueOnce({ Items: [{ PK: `T#${TENANT}#CEXPORT`, SK: 'EXPORT#00000009' }] })
+			.mockResolvedValueOnce({}) // DeleteCommand (dead 旧行 purge)
+			.mockResolvedValueOnce({ Attributes: { counter: 10 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+		const { insert } = await loadRepo();
+		const r = await insert({
+			tenantId: TENANT,
+			exportType: 'full',
+			pinCode: 'REUSE',
+			s3Key: 'k',
+			fileSizeBytes: 0,
+			expiresAt: '2099-01-01',
+		});
+		expect(r.id).toBe('10');
+		// call 0 = purge Query / call 1 = Delete(旧行) / call 2 = nextId / call 3 = Put
+		expect((callOf(1).input.Key as Record<string, string>).SK).toBe('EXPORT#00000009');
+		expect((callOf(3).input.Item as Record<string, unknown>).pinCode).toBe('REUSE');
 	});
 });
 
@@ -314,7 +340,10 @@ describe('countByTenant', () => {
 
 describe('insert は status を含める (#3504)', () => {
 	it('status 省略時は pending / failureReason=null', async () => {
-		mockSend.mockResolvedValueOnce({ Attributes: { counter: 1 } }).mockResolvedValueOnce({});
+		mockSend
+			.mockResolvedValueOnce({ Items: [] }) // #3574 ①: purgeReusablePin Query
+			.mockResolvedValueOnce({ Attributes: { counter: 1 } })
+			.mockResolvedValueOnce({});
 		const { insert } = await loadRepo();
 		const r = await insert({
 			tenantId: TENANT,
@@ -326,7 +355,7 @@ describe('insert は status を含める (#3504)', () => {
 		});
 		expect(r.status).toBe('pending');
 		expect(r.failureReason).toBeNull();
-		const item = (callOf(1).input.Item as Record<string, unknown>) ?? {};
+		const item = (callOf(2).input.Item as Record<string, unknown>) ?? {};
 		expect(item.status).toBe('pending');
 	});
 });

--- a/tests/unit/db/family-repo-lifecycle-3574.test.ts
+++ b/tests/unit/db/family-repo-lifecycle-3574.test.ts
@@ -1,0 +1,212 @@
+// tests/unit/db/family-repo-lifecycle-3574.test.ts
+// Issue #3574 (Family repo 実装担保、#3573 follow-up) / 設計 SSOT: dsql-data-model.md §11.2 / §P5 / §P9 / §3.4 B6
+//
+// #3573 で Family 系 8 表の DDL (global UNIQUE 含む) を凍結した際、Adversarial Reviewer が
+// 指摘した「repo 実装で担保すべき下流責務」を failing-test-first (ADR-0061) で red→green にする。
+//
+// 本ファイルは DSQL backend (実 schema、PGlite) で 3 つの不変条件を担保する:
+//
+//   ① pin/token 再発行ライフサイクル (expire-then-purge)
+//      cloud_exports.pin_code / viewer_tokens.token は expire/revoke 後の「値再利用」が前提だが
+//      global UNIQUE のため、dead な旧行が値を占有したまま再発行すると UNIQUE 衝突で沈黙失敗する。
+//      insert は「自 family の dead 行 (期限切れ / DL 上限 / revoke 済) を purge してから挿入」する
+//      (§11.2)。live 行が占有していれば UNIQUE 衝突が surface する = 2 live 行防止は維持する。
+//
+//   ② global lookup 後の family scope 再適用 (§P9)
+//      push_subscriptions.endpoint の無 tenant 値単独 lookup (findByEndpoint / deleteByEndpoint) は
+//      request が endpoint (attacker 可制御) + 認証済 tenantId を渡すため、返却/削除は family_id で
+//      再スコープする。再適用漏れは cross-family read/IDOR-delete 経路 (unsubscribe が body.endpoint を
+//      そのまま渡すため実害あり)。cloud_exports.pin / viewer_tokens.token は credential 自体が
+//      authz なので findByPin/findByToken は無 tenant のまま正、後続 mutation が返却 family_id を
+//      使う (incrementDownloadCount/deleteById 等が tenantId 必須) ことで §P9 を満たす。
+//
+//   ④ graduation_consent の COPPA 同意証跡 tamper-evidence (append-only)
+//      卒業同意は COPPA 対象の同意証跡。repo は create/list/aggregate/deleteByTenantId のみを持ち
+//      UPDATE を一切定義しない (改竄不能)。同 tenant で複数回 create しても upsert でなく追記 (多数行が正)。
+//      append-only 契約の機械強制は tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts。
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDsqlCloudExportRepo } from '../../../src/lib/server/db/dsql/cloud-export-repo';
+import { createDsqlGraduationConsentRepo } from '../../../src/lib/server/db/dsql/graduation-consent-repo';
+import { createDsqlPushSubscriptionRepo } from '../../../src/lib/server/db/dsql/push-subscription-repo';
+import { createDsqlViewerTokenRepo } from '../../../src/lib/server/db/dsql/viewer-token-repo';
+import type { ICloudExportRepo } from '../../../src/lib/server/db/interfaces/cloud-export-repo.interface';
+import type { IGraduationConsentRepo } from '../../../src/lib/server/db/interfaces/graduation-consent-repo.interface';
+import type { IPushSubscriptionRepo } from '../../../src/lib/server/db/interfaces/push-subscription-repo.interface';
+import type { IViewerTokenRepo } from '../../../src/lib/server/db/interfaces/viewer-token-repo.interface';
+import type { InsertCloudExportInput } from '../../../src/lib/server/db/types';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+const FAMILY = '00000000-0000-4000-8000-0000000005a1';
+const OTHER_FAMILY = '00000000-0000-4000-8000-0000000005a2';
+const PAST_ISO = '2020-01-01T00:00:00.000Z';
+const FUTURE_ISO = '2099-01-01T00:00:00.000Z';
+
+describe('Family repo 実装担保 (#3574、DSQL 実 schema PGlite)', () => {
+	let t: DsqlTestDb;
+	let exportRepo: ICloudExportRepo;
+	let tokenRepo: IViewerTokenRepo;
+	let pushRepo: IPushSubscriptionRepo;
+	let consentRepo: IGraduationConsentRepo;
+
+	const seedExport = (
+		pinCode: string,
+		over: Partial<InsertCloudExportInput> = {},
+	): Promise<Awaited<ReturnType<ICloudExportRepo['insert']>>> =>
+		exportRepo.insert({
+			tenantId: FAMILY,
+			exportType: 'full',
+			pinCode,
+			s3Key: `exports/${pinCode}.zip`,
+			fileSizeBytes: 0,
+			expiresAt: FUTURE_ISO,
+			...over,
+		});
+
+	beforeAll(async () => {
+		t = await createDsqlTestDb();
+		exportRepo = createDsqlCloudExportRepo(t.db);
+		tokenRepo = createDsqlViewerTokenRepo(t.db);
+		pushRepo = createDsqlPushSubscriptionRepo(t.db);
+		consentRepo = createDsqlGraduationConsentRepo(t.db);
+	}, 60_000);
+	afterAll(async () => {
+		await t.close();
+	});
+
+	// ───────────────── ① cloud_exports pin 再発行ライフサイクル ─────────────────
+
+	it('[CE-reissue] 期限切れ旧行を占有する pin を再発行できる (expire-then-purge)', async () => {
+		// 旧行: 同 family / 同 pin だが既に期限切れ (dead)。
+		const old = await seedExport('910001', { expiresAt: PAST_ISO });
+		// 再発行: 同 pin を live 行として insert → 旧 dead 行を purge してから挿入され成功する。
+		const fresh = await seedExport('910001', { expiresAt: FUTURE_ISO });
+		expect(fresh.pinCode).toBe('910001');
+		expect(fresh.id).not.toBe(old.id); // 新規行 (upsert でない)
+		// global UNIQUE 維持: pin lookup は live 新行 1 件のみに解決する。
+		const resolved = await exportRepo.findByPin('910001');
+		expect(resolved?.id).toBe(fresh.id);
+		expect(Date.parse(resolved?.expiresAt ?? '')).toBe(Date.parse(FUTURE_ISO));
+		expect(await exportRepo.findById(old.id, FAMILY)).toBe(undefined); // 旧行は purge 済
+	});
+
+	it('[CE-reissue] DL 上限到達 (consumed) 旧行を占有する pin も再発行できる', async () => {
+		const old = await seedExport('910002', { maxDownloads: 1 });
+		await exportRepo.incrementDownloadCount(old.id, FAMILY); // downloadCount(1) >= maxDownloads(1) = dead
+		const fresh = await seedExport('910002');
+		expect(fresh.id).not.toBe(old.id);
+		expect(await exportRepo.findById(old.id, FAMILY)).toBe(undefined);
+	});
+
+	it('[CE-reissue] live 行が占有する pin の再発行は UNIQUE 衝突で拒否 (2 live 行防止)', async () => {
+		await seedExport('910003', { expiresAt: FUTURE_ISO }); // live
+		// 同 family / 同 pin の 2 本目 live は purge 対象外 → UNIQUE 衝突 throw。
+		await expect(seedExport('910003', { expiresAt: FUTURE_ISO })).rejects.toThrow();
+	});
+
+	it('[CE-reissue] 他 family の live 行が占有する pin も奪取不可 (cross-family 2 live 行防止)', async () => {
+		await seedExport('910004', { tenantId: OTHER_FAMILY, expiresAt: FUTURE_ISO });
+		// purge は自 family scope のため他 family の live 行に触れない → global UNIQUE 衝突 throw。
+		await expect(seedExport('910004', { tenantId: FAMILY })).rejects.toThrow();
+	});
+
+	// ───────────────── ① viewer_tokens token 再発行ライフサイクル ─────────────────
+
+	it('[VT-reissue] revoke 済旧行を占有する token を再発行できる', async () => {
+		const old = await tokenRepo.insert({ token: 'tok-reissue' }, FAMILY);
+		await tokenRepo.revoke(old.id, FAMILY); // revokedAt set = dead
+		const fresh = await tokenRepo.insert({ token: 'tok-reissue' }, FAMILY);
+		expect(fresh.id).not.toBe(old.id);
+		expect(fresh.revokedAt).toBe(null);
+		const resolved = await tokenRepo.findByToken('tok-reissue');
+		expect(resolved?.id).toBe(fresh.id);
+		expect(resolved?.revokedAt).toBe(null);
+	});
+
+	it('[VT-reissue] 期限切れ旧行を占有する token も再発行できる', async () => {
+		const old = await tokenRepo.insert({ token: 'tok-expired', expiresAt: PAST_ISO }, FAMILY);
+		const fresh = await tokenRepo.insert({ token: 'tok-expired', expiresAt: FUTURE_ISO }, FAMILY);
+		expect(fresh.id).not.toBe(old.id);
+	});
+
+	it('[VT-reissue] live token の再発行は UNIQUE 衝突で拒否 (2 live 行防止)', async () => {
+		await tokenRepo.insert({ token: 'tok-live', expiresAt: FUTURE_ISO }, FAMILY);
+		await expect(
+			tokenRepo.insert({ token: 'tok-live', expiresAt: FUTURE_ISO }, FAMILY),
+		).rejects.toThrow();
+	});
+
+	// ───────────────── ② push_subscriptions global lookup の family 再スコープ ─────────────────
+
+	it('[PS-scope] findByEndpoint は返却前に family scope を再適用する (§P9 cross-family read 遮断)', async () => {
+		await pushRepo.insert({
+			tenantId: FAMILY,
+			endpoint: 'https://push.example/scoped-ep',
+			keysP256dh: 'p256',
+			keysAuth: 'auth',
+			subscriberRole: 'parent',
+		});
+		// 所有 family は取得できる。
+		expect(
+			(await pushRepo.findByEndpoint('https://push.example/scoped-ep', FAMILY))?.tenantId,
+		).toBe(FAMILY);
+		// 他 family を名乗った lookup は endpoint (attacker 可制御) を渡しても解決不能 = cross-family 漏出遮断。
+		expect(await pushRepo.findByEndpoint('https://push.example/scoped-ep', OTHER_FAMILY)).toBe(
+			undefined,
+		);
+	});
+
+	it('[PS-scope] deleteByEndpoint は family 不一致なら no-op (§P9 cross-family IDOR-delete 遮断)', async () => {
+		await pushRepo.insert({
+			tenantId: FAMILY,
+			endpoint: 'https://push.example/del-ep',
+			keysP256dh: 'p256',
+			keysAuth: 'auth',
+			subscriberRole: 'owner',
+		});
+		// 他 family を名乗った削除 (unsubscribe が body.endpoint をそのまま渡す経路) は no-op。
+		await pushRepo.deleteByEndpoint('https://push.example/del-ep', OTHER_FAMILY);
+		expect((await pushRepo.findByEndpoint('https://push.example/del-ep', FAMILY))?.tenantId).toBe(
+			FAMILY,
+		);
+		// 所有 family からの削除は成功する。
+		await pushRepo.deleteByEndpoint('https://push.example/del-ep', FAMILY);
+		expect(await pushRepo.findByEndpoint('https://push.example/del-ep', FAMILY)).toBe(undefined);
+	});
+
+	// ───────────────── ④ graduation_consent COPPA tamper-evidence (append-only) ─────────────────
+
+	it('[GC-append] 同 tenant で複数回 create しても追記される (upsert でなく多数行 = 改竄不能)', async () => {
+		const before = (await consentRepo.listByTenant(FAMILY)).length;
+		const a = await consentRepo.create({
+			tenantId: FAMILY,
+			nickname: 'そつぎょうA',
+			consented: true,
+			userPoints: 100,
+			usagePeriodDays: 30,
+			message: 'ありがとう',
+		});
+		const b = await consentRepo.create({
+			tenantId: FAMILY,
+			nickname: 'そつぎょうB',
+			consented: false,
+			userPoints: 200,
+			usagePeriodDays: 60,
+		});
+		expect(a.id).not.toBe(b.id); // 別行 (surrogate PK)
+		const after = await consentRepo.listByTenant(FAMILY);
+		expect(after.length).toBe(before + 2); // 追記 (上書きでない)
+		// 先の同意証跡 (a) は 2 本目 create で改変されない。
+		const persistedA = after.find((r) => r.id === a.id);
+		expect(persistedA?.consented).toBe(true);
+		expect(persistedA?.userPoints).toBe(100);
+	});
+
+	it('[GC-append] repo は同意行を書き換える mutation メソッドを一切公開しない (改竄面の非露出)', () => {
+		// interface 契約: create / listByTenant / aggregateRecent / deleteByTenantId のみ。
+		// update / setConsent / patch 等の書き換え口が生えていないことを構造検証する
+		// (append-only 表への UPDATE 経路自体が存在しない = tamper-evidence の第一防御)。
+		const methodNames = Object.keys(consentRepo).sort();
+		expect(methodNames).toEqual(['aggregateRecent', 'create', 'deleteByTenantId', 'listByTenant']);
+	});
+});

--- a/tests/unit/db/sqlite/family-repo-lifecycle-3574.test.ts
+++ b/tests/unit/db/sqlite/family-repo-lifecycle-3574.test.ts
@@ -1,0 +1,139 @@
+// tests/unit/db/sqlite/family-repo-lifecycle-3574.test.ts
+// Issue #3574 (Family repo 実装担保) — SQLite backend parity。
+//
+// DSQL 側 (tests/unit/db/family-repo-lifecycle-3574.test.ts) と同セマンティクスを SQLite 実装
+// (挙動 SSOT、NUC/local backend) で固定する:
+//   ① cloud_exports.pin_code / viewer_tokens.token の expire-then-purge 再発行ライフサイクル
+//   ② push_subscriptions.findByEndpoint / deleteByEndpoint の §P9 family scope 再適用
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestDb, type TestSqlite } from '../../helpers/test-db';
+
+const dbHolder: { sqlite: TestSqlite | null; db: ReturnType<typeof createTestDb>['db'] | null } = {
+	sqlite: null,
+	db: null,
+};
+
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		if (!dbHolder.db) throw new Error('test db not initialized');
+		return dbHolder.db;
+	},
+}));
+
+import { findByPin, insert as insertExport } from '$lib/server/db/sqlite/cloud-export-repo';
+// import after mock
+import {
+	deleteByEndpoint,
+	findByEndpoint,
+	insert as insertPush,
+} from '$lib/server/db/sqlite/push-subscription-repo';
+import {
+	findByToken,
+	insert as insertToken,
+	revoke as revokeToken,
+} from '$lib/server/db/sqlite/viewer-token-repo';
+import type { InsertCloudExportInput } from '$lib/server/db/types';
+
+const FAMILY = 't-3574-a';
+const OTHER = 't-3574-b';
+const PAST_ISO = '2020-01-01T00:00:00.000Z';
+const FUTURE_ISO = '2099-01-01T00:00:00.000Z';
+
+const seedExport = (pin: string, over: Partial<InsertCloudExportInput> = {}) =>
+	insertExport({
+		tenantId: FAMILY,
+		exportType: 'full',
+		pinCode: pin,
+		s3Key: `exports/${pin}.zip`,
+		fileSizeBytes: 0,
+		expiresAt: FUTURE_ISO,
+		...over,
+	});
+
+describe('#3574 SQLite backend parity', () => {
+	beforeEach(() => {
+		const { sqlite, db } = createTestDb();
+		dbHolder.sqlite = sqlite;
+		dbHolder.db = db;
+	});
+
+	// ── ① cloud_exports pin 再発行 ──
+
+	it('[CE①] 期限切れ旧行を占有する pin を再発行できる (expire-then-purge)', async () => {
+		const old = await seedExport('910001', { expiresAt: PAST_ISO });
+		const fresh = await seedExport('910001', { expiresAt: FUTURE_ISO });
+		expect(fresh.id).not.toBe(old.id);
+		const resolved = await findByPin('910001');
+		expect(resolved?.id).toBe(fresh.id);
+		expect(resolved?.expiresAt).toBe(FUTURE_ISO);
+	});
+
+	it('[CE①] DL 上限到達旧行を占有する pin も再発行できる', async () => {
+		const old = await seedExport('910002', { maxDownloads: 1 });
+		dbHolder.sqlite?.exec(`UPDATE cloud_exports SET download_count = 1 WHERE id = ${old.id}`);
+		const fresh = await seedExport('910002');
+		expect(fresh.id).not.toBe(old.id);
+	});
+
+	it('[CE①] live 行が占有する pin の再発行は UNIQUE 衝突で拒否 (2 live 行防止)', async () => {
+		await seedExport('910003', { expiresAt: FUTURE_ISO });
+		await expect(seedExport('910003', { expiresAt: FUTURE_ISO })).rejects.toThrow();
+	});
+
+	it('[CE①] 他 tenant の live 行が占有する pin は奪取不可 (cross-tenant 2 live 行防止)', async () => {
+		await seedExport('910004', { tenantId: OTHER, expiresAt: FUTURE_ISO });
+		await expect(seedExport('910004', { tenantId: FAMILY })).rejects.toThrow();
+	});
+
+	// ── ① viewer_tokens token 再発行 ──
+
+	it('[VT①] revoke 済旧行を占有する token を再発行できる', async () => {
+		const old = await insertToken({ token: 'tok-reissue' }, FAMILY);
+		await revokeToken(old.id, FAMILY);
+		const fresh = await insertToken({ token: 'tok-reissue' }, FAMILY);
+		expect(fresh.id).not.toBe(old.id);
+		expect((await findByToken('tok-reissue'))?.revokedAt).toBe(null);
+	});
+
+	it('[VT①] 期限切れ旧行を占有する token も再発行できる', async () => {
+		const old = await insertToken({ token: 'tok-expired', expiresAt: PAST_ISO }, FAMILY);
+		const fresh = await insertToken({ token: 'tok-expired', expiresAt: FUTURE_ISO }, FAMILY);
+		expect(fresh.id).not.toBe(old.id);
+	});
+
+	it('[VT①] live token の再発行は UNIQUE 衝突で拒否', async () => {
+		await insertToken({ token: 'tok-live', expiresAt: FUTURE_ISO }, FAMILY);
+		await expect(
+			insertToken({ token: 'tok-live', expiresAt: FUTURE_ISO }, FAMILY),
+		).rejects.toThrow();
+	});
+
+	// ── ② push_subscriptions family scope 再適用 ──
+
+	it('[PS②] findByEndpoint は family scope を再適用する', async () => {
+		await insertPush({
+			tenantId: FAMILY,
+			endpoint: 'https://push.example/ep',
+			keysP256dh: 'p',
+			keysAuth: 'a',
+			subscriberRole: 'parent',
+		});
+		expect((await findByEndpoint('https://push.example/ep', FAMILY))?.tenantId).toBe(FAMILY);
+		expect(await findByEndpoint('https://push.example/ep', OTHER)).toBe(undefined);
+	});
+
+	it('[PS②] deleteByEndpoint は family 不一致なら no-op', async () => {
+		await insertPush({
+			tenantId: FAMILY,
+			endpoint: 'https://push.example/del',
+			keysP256dh: 'p',
+			keysAuth: 'a',
+			subscriberRole: 'owner',
+		});
+		await deleteByEndpoint('https://push.example/del', OTHER); // no-op
+		expect((await findByEndpoint('https://push.example/del', FAMILY))?.tenantId).toBe(FAMILY);
+		await deleteByEndpoint('https://push.example/del', FAMILY); // 所有 family は削除成功
+		expect(await findByEndpoint('https://push.example/del', FAMILY)).toBe(undefined);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）/ 子供（データ保護）/ システム全体（マルチテナント分離）

**解決する課題**: Family repo (cloud_exports / viewer_tokens / push_subscriptions / graduation_consent) に ① pin/token 再発行時の dead 行残留、② push unsubscribe が attacker 可制御の `body.endpoint` をそのまま渡す cross-family read / IDOR-delete 経路、③ graduation_consent の改竄可能性があった。

**期待される効果**: 家族の同意記録・バックアップ・見守りトークンの整合性とテナント分離を担保し、他家族のデータへの誤アクセス/改竄を構造的に遮断する (ADR-0055 / ADR-0063 整合)。

## 関連 Issue

closes #3574

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | pin/token 再発行 = cloud_exports/viewer_tokens insert に expire-then-purge (自 family dead 旧行 purge → 挿入、live 占有は UNIQUE 衝突で 2 live 行防止維持) | `npx vitest run tests/unit/db/family-repo-lifecycle-3574.test.ts tests/unit/db/sqlite/family-repo-lifecycle-3574.test.ts` | HEAD `bac474ef205278671b6713ccbb0abc781d29bfb8` / 73 passed (5 file)。dsql/sqlite 実装、dynamodb は同 pin dead 行 purge + viewer_token PK 上書き等価、demo stub |
| AC2 | push_subscriptions.findByEndpoint/deleteByEndpoint に family_id scope 再適用 (§P9、cross-family read/IDOR-delete 実害修正) | interfaces/push-subscription-repo.interface.ts + 3 backend | HEAD `bac474ef205278671b6713ccbb0abc781d29bfb8` / dynamodb は元から PK tenant 束縛で回帰なし |
| AC3 | cross-tenant KPI secondary は §P5「投機的に張らない」に従い非追加の決定を記録 | `docs/design/dsql-data-model.md §11.2` | HEAD `bac474ef205278671b6713ccbb0abc781d29bfb8` / 決定記録済 |
| AC4 | graduation_consent は UPDATE 非定義 (改竄不能) + append-only fitness 機械強制 | `npx vitest run tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts` | HEAD `bac474ef205278671b6713ccbb0abc781d29bfb8` / allowlist pass + behavioral テスト追加 |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ / repo (`/server/db/`) — 3 backend (dsql/sqlite/dynamodb) の cloud-export / viewer-token / push-subscription repo + interface
- [x] 設計書 (`docs/design/dsql-data-model.md`)

**影響を受ける画面・機能**: バックアップ (cloud export)、見守り (viewer token)、Push 通知購読、卒業同意記録

## テスト & 安全装置セルフチェック

- [x] **targeted 検証**: vitest 5 file 73 passed / svelte-check 0 error (8230 files, sync 済) / biome 13 file clean / cspell exit 0 / dsql-append-only-mutation-allowlist pass
- [x] 追加・変更したテスト: family-repo-lifecycle-3574 (dsql + sqlite) を failing-test-first で red→green、dsql-family-satellite-repos / dynamodb-cloud-export-repo の回帰
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: dynamodb/cloud-export-repo + viewer-token-repo 更新済 (3 backend parity)
- [x] **Critical バグ修正の場合**: N/A (IDOR 修正だが priority:critical ラベルなし)

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: repo 層 (DB アクセス) の実装担保で UI 描画に影響しない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: expire-then-purge を各 repo の insert に閉じ込め (単一責任)
- [x] **DRY**: 3 backend で同一契約、テスト parity
- [x] **YAGNI**: cross-tenant KPI secondary は投機的に張らない (§P5)
- [x] **Security**: push unsubscribe の family_id scope 再適用で cross-family read/IDOR-delete を遮断、graduation_consent の改竄不能化 (append-only)
- [x] **アクセシビリティ**: N/A (repo 層)
- [x] **パフォーマンス**: N+1 なし、expire-then-purge は自 family scope 限定

## 横展開・影響波及チェック

- [x] 3 backend (dsql/sqlite/dynamodb) parity 済 (demo は stub)
- [x] **設計書同期** (ADR-0001): `docs/design/dsql-data-model.md` §11.2 に KPI secondary 非追加決定 + §P9 scope を記録
- [x] N/A — その他並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない** (既存 live 行の挙動は不変、dead 行 purge のみ追加)

**レビュー依頼事項・QA**: push unsubscribe の family_id scope 再適用 (§P9) が cross-family IDOR を確実に遮断しているか、expire-then-purge が live 占有 (2 live 行防止 UNIQUE) を壊していないかを重点確認願います。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] targeted 検証 全 PASS をローカル確認 (main tree)
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] Phase 分割なし
- [x] UI 変更なし (SS 該当なし)
- [x] 認証画面変更なし

## QM レビュー結果

<!-- QM 記入 -->
