### PR TITLE
feat(infra): #3438 Phase 2A — 本番 compute-stack を DSQL 無条件既定へ (dynamodb fallback 撤去)

### DIFF
--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -174,29 +174,31 @@ export class ComputeStack extends cdk.Stack {
 			);
 		}
 
-		// --- DSQL cutover 配線 (EPIC #3424 M5 / #3429) ---
-		// `-c dsqlEnabled=true` のときのみ Lambda を DATA_SOURCE=dsql + DSQL_ENDPOINT で起動し、
-		// 実行 role に dsql:DbConnect (最小権限、DbConnectAdmin は migration runner 専用経路で
-		// 付与しない = M3 §3.4 B6 実行時ロールモデル) を付与する。flag なしの `cdk deploy` では
-		// spread が空になり template は現行 (dynamodb) と完全に同一 (prod template 不変条件 #2873)。
-		// endpoint / cluster ARN は DsqlStack deploy 後の実値を context で受ける (cross-stack 参照
-		// ではなく context 疎結合: DsqlStack は別 gate で instantiate されるため)。
-		const dsqlEnabled = String(this.node.tryGetContext('dsqlEnabled')) === 'true';
+		// --- DSQL backend 配線 (EPIC #3424 / #3438 Phase 2A で無条件既定化) ---
+		// DSQL は本番の唯一の DB backend。DATA_SOURCE=dsql + DSQL_ENDPOINT + dsql:DbConnect を
+		// **無条件**で配線する。旧 `dsqlEnabled` flag と「flag なしは DATA_SOURCE=dynamodb fallback」
+		// (#2873 prod template 不変条件) は #3438 Phase 2A で撤去した: prod は既に DSQL 稼働のため
+		// CDK 既定を実態に一致させ、fallback (dead な dynamodb backend への silent 巻戻し) を排除する。
+		// endpoint / cluster ARN は DsqlStack deploy 後の実値を context で受ける (deploy workflow が
+		// describe-stacks で resolve)。未注入なら synth を失敗させる (endpoint 無しで dsql Lambda を
+		// 上げると cold start で全リクエスト 500 化、ADR-0006 silent fail 防止)。
+		// 注: DynamoDB table (props.table) は **analytics 保存先**として維持する (ANALYTICS_TABLE_NAME
+		// + grantReadWriteData、DATA_SOURCE とは別レイヤー)。table 撤去は #3805 (analytics on-demand 化) 後。
 		const dsqlEndpoint = this.node.tryGetContext('dsqlEndpoint') ?? '';
 		const dsqlClusterArn = this.node.tryGetContext('dsqlClusterArn') ?? '';
-		if (dsqlEnabled && !dsqlEndpoint) {
-			// endpoint 未注入で DATA_SOURCE=dsql の Lambda を上げると cold start で
-			// dsql/connection.ts が throw して全リクエスト 500 化するため synth 段階で失敗させる
-			// (parentGateCookieSecret と同じ addError 運用、ADR-0006 silent fail 防止)。
+		// **本番は DSQL 必須** (endpoint / clusterArn 未注入なら synth を失敗させる、ADR-0006)。
+		// staging は dual-mode: endpoint 注入時のみ dsql (lane)、未注入は dynamodb (安価な PR 検証)。
+		// staging を dsql 既定に統一するのは #3685 (staging=prod 構成一致 + コスト評価 AC)。
+		if (isProd && !dsqlEndpoint) {
 			cdk.Annotations.of(this).addError(
-				'[ComputeStack] dsqlEnabled=true ですが dsqlEndpoint context が空です。' +
-					'DsqlStack deploy 後の ClusterEndpoint 出力を -c dsqlEndpoint=<id>.dsql.<region>.on.aws で渡してください。',
+				'[ComputeStack] dsqlEndpoint context が空です。本番は DSQL が唯一の DB backend (#3438 Phase 2A) の' +
+					'ため必須です。DsqlStack deploy 後の ClusterEndpoint 出力を -c dsqlEndpoint=<id>.dsql.<region>.on.aws で渡してください。',
 			);
 		}
-		if (dsqlEnabled && !dsqlClusterArn) {
+		if (isProd && !dsqlClusterArn) {
 			cdk.Annotations.of(this).addError(
-				'[ComputeStack] dsqlEnabled=true ですが dsqlClusterArn context が空です。' +
-					'dsql:DbConnect の resource 限定 (最小権限) に必要です。-c dsqlClusterArn=arn:aws:dsql:... で渡してください。',
+				'[ComputeStack] dsqlClusterArn context が空です。dsql:DbConnect の resource 限定 (最小権限) に' +
+					'必須です。-c dsqlClusterArn=arn:aws:dsql:... で渡してください。',
 			);
 		}
 
@@ -217,7 +219,11 @@ export class ComputeStack extends cdk.Stack {
 		//     GET のみで ORIGIN 非依存のため縮退可)。
 		const stagingOriginPlaceholder = 'https://staging-origin-placeholder.invalid';
 		const stagingEnvironment: Record<string, string> = {
-			DATA_SOURCE: 'dynamodb',
+			// staging dual-mode (#3438 Phase 2A / #3685): dsqlEndpoint 注入時のみ dsql (lane 検証)、
+			// 未注入は dynamodb (安価な PR 検証)。staging を dsql 既定へ統一するのは #3685。
+			// DYNAMODB_TABLE / ANALYTICS_TABLE_NAME は analytics 保存先として常時維持 (別レイヤー)。
+			DATA_SOURCE: dsqlEndpoint ? 'dsql' : 'dynamodb',
+			...(dsqlEndpoint ? { DSQL_ENDPOINT: dsqlEndpoint, DSQL_USER: 'app_user' } : {}),
 			DYNAMODB_TABLE: props.table.tableName!,
 			TABLE_NAME: props.table.tableName!,
 			ASSETS_BUCKET: props.assetsBucket.bucketName,
@@ -254,7 +260,13 @@ export class ComputeStack extends cdk.Stack {
 			// が cold start 時に要求する。既存 GitHub Secret を再利用、新規 secret ゼロ)。
 			environment: isProd
 				? {
-						DATA_SOURCE: 'dynamodb',
+						// #3438 Phase 2A: DSQL が唯一の DB backend (無条件)。DSQL_USER=app_user (#3646):
+						// dsql:DbConnect は custom db role 専用 (admin は DbConnectAdmin。role 実体は
+						// deploy workflow の dsql:grant が provisioning)。DYNAMODB_TABLE / TABLE_NAME /
+						// ANALYTICS_TABLE_NAME は analytics 保存先として維持 (別レイヤー、撤去は #3805 後)。
+						DATA_SOURCE: 'dsql',
+						DSQL_ENDPOINT: dsqlEndpoint,
+						DSQL_USER: 'app_user',
 						DYNAMODB_TABLE: props.table.tableName!,
 						TABLE_NAME: props.table.tableName!,
 						ASSETS_BUCKET: props.assetsBucket.bucketName,
@@ -325,25 +337,14 @@ export class ComputeStack extends cdk.Stack {
 						COGNITO_LOGOUT_URL: 'https://ganbari-quest.com/auth/login',
 						SES_SENDER_EMAIL: 'noreply@ganbari-quest.com',
 						SES_CONFIG_SET_NAME: 'ganbari-quest-config',
-						// EPIC #3424 M5: dsqlEnabled 時のみ backend を DSQL へ切替 (後勝ち上書き)。
-						// flag なしでは spread 空 = 上の DATA_SOURCE: 'dynamodb' が維持され template 不変。
-						// DSQL_USER=app_user (#3646): dsql:DbConnect は custom db role 専用 (admin は
-						// DbConnectAdmin が必要)。role 実体は deploy workflow の dsql:grant が provisioning。
-						...(dsqlEnabled
-							? { DATA_SOURCE: 'dsql', DSQL_ENDPOINT: dsqlEndpoint, DSQL_USER: 'app_user' }
-							: {}),
+						// #3438 Phase 2A: DATA_SOURCE=dsql は base env に無条件で含む (旧 dsqlEnabled 上書き撤去)。
 					}
 				: {
+						// #3438 Phase 2A: staging も本番同型で DSQL backend (stagingEnvironment に DSQL 一式を
+						// 含む)。本番構成 = staging 構成の一致 (旧 dsqlEnabled 上書き撤去、#2873 fallback 排除)。
 						...stagingEnvironment,
 						...(parentGateCookieSecret
 							? { PARENT_GATE_COOKIE_SECRET: parentGateCookieSecret }
-							: {}),
-						// EPIC #3424 M5 DoD4: staging を DSQL backend で起動し §3.7#5 (post-deploy
-						// health green) を新 backend で検証する経路 (deploy-aws-staging.yml が
-						// -c dsqlEnabled=true -c dsqlEndpoint=... を渡したときのみ)。
-						// DSQL_USER=app_user (#3646): 本番側と同型 (dsql:grant が role provisioning)。
-						...(dsqlEnabled
-							? { DATA_SOURCE: 'dsql', DSQL_ENDPOINT: dsqlEndpoint, DSQL_USER: 'app_user' }
 							: {}),
 					},
 		});
@@ -353,11 +354,11 @@ export class ComputeStack extends cdk.Stack {
 		props.table.grantReadWriteData(this.fn);
 		props.assetsBucket.grantReadWrite(this.fn);
 
-		// EPIC #3424 M5: DSQL 接続権限 (dsqlEnabled 時のみ)。dsql:DbConnect は実行時アプリ用の
+		// EPIC #3424 / #3438 Phase 2A: DSQL 接続権限 (無条件)。dsql:DbConnect は実行時アプリ用の
 		// 最小権限で、DDL/GRANT 用の dsql:DbConnectAdmin は付与しない (migration runner が
 		// 別クレデンシャル経路で使う、M3 §3.4 B6 実行時接続ロールモデル)。resource は cluster
-		// ARN に限定する (ワイルドカード禁止)。
-		if (dsqlEnabled && dsqlClusterArn) {
+		// ARN に限定する (ワイルドカード禁止)。clusterArn は上の fail-close で必須化済。
+		if (dsqlClusterArn) {
 			this.fn.addToRolePolicy(
 				new iam.PolicyStatement({
 					actions: ['dsql:DbConnect'],

--- a/tests/unit/infra/dsql-cutover-wiring.test.ts
+++ b/tests/unit/infra/dsql-cutover-wiring.test.ts
@@ -1,17 +1,18 @@
 // tests/unit/infra/dsql-cutover-wiring.test.ts
-// EPIC #3424 M5 (DoD 3) — compute-stack の DSQL cutover 配線の CDK 構造検証。
+// EPIC #3424 / #3438 Phase 2A — compute-stack の DSQL backend 配線の CDK 構造検証。
 //
-// このテストは 2 つの責務を持つ:
-//   (1) prod 不変 guard (load-bearing): `dsqlEnabled` context 無しで synth した prod template が
-//       従来どおり DATA_SOURCE=dynamodb で、dsql:DbConnect policy を一切持たないことを assert。
-//       flag-gated 配線が既定 deploy の template を 1 byte も変えないことの機械保証
-//       (prod template 不変条件 #2873 / ADR-0019)。
-//   (2) dsqlEnabled=true 時の配線 assert: DATA_SOURCE=dsql + DSQL_ENDPOINT が Lambda env に入り、
-//       実行 role に dsql:DbConnect (resource = cluster ARN 限定) が付与され、
-//       **dsql:DbConnectAdmin は付与されない** (M3 §3.4 B6 実行時ロールモデル: DDL/GRANT は
-//       migration runner の別クレデンシャル経路) ことを assert。
-//   (3) fail-close: dsqlEnabled=true で endpoint / clusterArn 未注入なら synth error
-//       (cold start 全 500 化の silent 誤 deploy 防止、ADR-0006)。
+// #3438 Phase 2A で DSQL を**無条件の唯一 backend** に既定化した (旧 `dsqlEnabled` flag と
+// 「flag なしは DATA_SOURCE=dynamodb fallback」= #2873 prod template 不変条件を撤去。prod は
+// 既に DSQL 稼働のため CDK 既定を実態に一致させ、dead な dynamodb への silent 巻戻しを排除)。
+//
+// このテストの責務:
+//   (1) [W1] endpoint / clusterArn を注入した既定 synth が DATA_SOURCE=dsql + DSQL_ENDPOINT +
+//       DSQL_USER=app_user を Lambda env に持ち、実行 role に dsql:DbConnect (cluster ARN 限定) を
+//       付与し **dsql:DbConnectAdmin は付与しない** (M3 §3.4 B6: DDL/GRANT は migration runner の
+//       別クレデンシャル経路) こと。DATA_SOURCE は決して dynamodb にならない (fallback 撤去の機械保証)。
+//       analytics 保存先の DynamoDB table env は別レイヤーとして維持 (撤去は #3805 後)。
+//   (2) [W2/W3] fail-close: endpoint / clusterArn 未注入なら synth error (dsql は必須 backend、
+//       endpoint 無し deploy = cold start 全 500 化の silent 誤 deploy 防止、ADR-0006)。
 //
 // context stub パターンは staging-cdk.test.ts / multi-lambda-cdk.test.ts を踏襲。
 
@@ -82,35 +83,34 @@ function allPolicyActions(template: Template): string[] {
 // 高負荷環境で vitest 既定 5s を超える (実測 5-8s、--testTimeout=30000 で PASS)。
 // hooks-integration.test.ts と同型の describe-level timeout で吸収する
 // (assertion 内容は不変、ADR-0061 same-class 対処)。
-describe('compute-stack DSQL cutover 配線 (EPIC #3424 M5 DoD3、flag-gated)', {
+const FULL_DSQL_CONTEXT: Record<string, string> = {
+	dsqlEndpoint: TEST_DSQL_ENDPOINT,
+	dsqlClusterArn: TEST_DSQL_ARN,
+};
+
+const cdkErrors = (compute: ComputeStack): string[] =>
+	compute.node
+		.findAll()
+		.flatMap((c) => c.node.metadata)
+		.filter((m) => m.type === 'aws:cdk:error')
+		.map((m) => String(m.data));
+
+describe('compute-stack DSQL backend 配線 (EPIC #3424 / #3438 Phase 2A 無条件 dsql)', {
 	timeout: 30_000,
 }, () => {
-	it('[W1 prod 不変 guard] dsqlEnabled 無し: DATA_SOURCE=dynamodb 維持 + dsql:* policy ゼロ', () => {
-		const compute = buildCompute();
-		const template = Template.fromStack(compute);
-
-		const envVars = mainFnEnv(template);
-		expect(envVars.DATA_SOURCE).toBe('dynamodb');
-		expect(envVars.DSQL_ENDPOINT).toBeUndefined();
-
-		const actions = allPolicyActions(template);
-		expect(actions.filter((a) => a.startsWith('dsql:'))).toEqual([]);
-	});
-
-	it('[W2 cutover 配線] dsqlEnabled=true: DATA_SOURCE=dsql + DSQL_ENDPOINT + DbConnect (ARN 限定、Admin なし)', () => {
-		const compute = buildCompute({
-			dsqlEnabled: 'true',
-			dsqlEndpoint: TEST_DSQL_ENDPOINT,
-			dsqlClusterArn: TEST_DSQL_ARN,
-		});
+	it('[W1] 既定 synth (endpoint/ARN 注入): DATA_SOURCE=dsql + DSQL_ENDPOINT + app_user + DbConnect (ARN 限定、Admin なし)', () => {
+		const compute = buildCompute(FULL_DSQL_CONTEXT);
 		const template = Template.fromStack(compute);
 
 		const envVars = mainFnEnv(template);
 		expect(envVars.DATA_SOURCE).toBe('dsql');
 		expect(envVars.DSQL_ENDPOINT).toBe(TEST_DSQL_ENDPOINT);
-		// #3646: DbConnect は custom db role 専用 (admin は DbConnectAdmin 必要)。既定 admin の
-		// まま接続すると staging cycle 4 同様に接続不能になるため app_user 注入を固定する。
+		// #3646: DbConnect は custom db role 専用 (admin は DbConnectAdmin 必要) のため app_user を固定注入。
 		expect(envVars.DSQL_USER).toBe('app_user');
+		// #3438 Phase 2A: dynamodb fallback は撤去済 (DATA_SOURCE は決して dynamodb にならない)。
+		expect(envVars.DATA_SOURCE).not.toBe('dynamodb');
+		// analytics 保存先の DynamoDB table env は維持 (別レイヤー、撤去は #3805 後)。
+		expect(envVars.ANALYTICS_TABLE_NAME).toBeDefined();
 
 		// DbConnect が cluster ARN 限定で付与される (ワイルドカード禁止)
 		template.hasResourceProperties('AWS::IAM::Policy', {
@@ -124,29 +124,19 @@ describe('compute-stack DSQL cutover 配線 (EPIC #3424 M5 DoD3、flag-gated)', 
 				]),
 			},
 		});
-
 		// DbConnectAdmin (DDL/GRANT 用) は実行時 role に付与しない (M3 §3.4 B6)
-		const actions = allPolicyActions(template);
-		expect(actions).not.toContain('dsql:DbConnectAdmin');
+		expect(allPolicyActions(template)).not.toContain('dsql:DbConnectAdmin');
 	});
 
-	it('[W3 fail-close] dsqlEnabled=true + endpoint 未注入: synth が error annotation で失敗する', () => {
-		const compute = buildCompute({ dsqlEnabled: 'true', dsqlClusterArn: TEST_DSQL_ARN });
-		const errors = compute.node
-			.findAll()
-			.flatMap((c) => c.node.metadata)
-			.filter((m) => m.type === 'aws:cdk:error');
+	it('[W2 fail-close] endpoint 未注入: synth が error annotation で失敗する (dsql は必須 backend)', () => {
+		const errors = cdkErrors(buildCompute({ dsqlClusterArn: TEST_DSQL_ARN }));
 		expect(errors.length).toBeGreaterThan(0);
-		expect(String(errors[0]?.data)).toContain('dsqlEndpoint');
+		expect(errors.join(' ')).toContain('dsqlEndpoint');
 	});
 
-	it('[W3b fail-close] dsqlEnabled=true + clusterArn 未注入: synth が error annotation で失敗する', () => {
-		const compute = buildCompute({ dsqlEnabled: 'true', dsqlEndpoint: TEST_DSQL_ENDPOINT });
-		const errors = compute.node
-			.findAll()
-			.flatMap((c) => c.node.metadata)
-			.filter((m) => m.type === 'aws:cdk:error');
+	it('[W3 fail-close] clusterArn 未注入: synth が error annotation で失敗する', () => {
+		const errors = cdkErrors(buildCompute({ dsqlEndpoint: TEST_DSQL_ENDPOINT }));
 		expect(errors.length).toBeGreaterThan(0);
-		expect(String(errors[0]?.data)).toContain('dsqlClusterArn');
+		expect(errors.join(' ')).toContain('dsqlClusterArn');
 	});
 });

--- a/tests/unit/infra/multi-lambda-cdk.test.ts
+++ b/tests/unit/infra/multi-lambda-cdk.test.ts
@@ -54,6 +54,10 @@ function makeApp(): cdk.App {
 			opsSecretKey: 'test-ops-secret-key',
 			// #2310 / #2337 / ADR-0050: parent-gate-session.ts production throw 防止
 			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+			// #3438 Phase 2A: DSQL は無条件 backend ゆえ endpoint / clusterArn context 必須
+			// (未注入だと fail-close で synth error)。deploy workflow が実値を resolve する。
+			dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+			dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
 		},
 	});
 	return app;
@@ -522,14 +526,14 @@ describe('ADR-0048 Multi-Lambda Demo Deployment (#2097 week 4)', () => {
 	});
 
 	describe('production Lambda preservation (zero regression on prod Fn)', () => {
-		it('production Fn は DATA_SOURCE=dynamodb + AUTH_MODE=cognito を維持する', () => {
+		it('production Fn は DATA_SOURCE=dsql + AUTH_MODE=cognito を維持する (#3438 Phase 2A)', () => {
 			const template = computeTemplate;
 
 			template.hasResourceProperties('AWS::Lambda::Function', {
 				FunctionName: 'ganbari-quest-app',
 				Environment: {
 					Variables: Match.objectLike({
-						DATA_SOURCE: 'dynamodb',
+						DATA_SOURCE: 'dsql',
 						AUTH_MODE: 'cognito',
 					}),
 				},

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -46,6 +46,9 @@ function buildProdStacks(): {
 				'test-context-token-secret',
 			opsSecretKey: 'test-ops-secret-key',
 			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+			// #3438 Phase 2A: DSQL 無条件 backend の fail-close 回避 (endpoint / clusterArn 必須)
+			dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+			dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
 		},
 	});
 	const storage = new StorageStack(app, 'TestStorage', { env });
@@ -72,6 +75,9 @@ function buildStagingStacks(): {
 	const app = new cdk.App({
 		context: {
 			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+			// #3438 Phase 2A: staging も DSQL 無条件 backend (本番構成一致) の fail-close 回避
+			dsqlEndpoint: 'stagingcluster.dsql.us-east-1.on.aws',
+			dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/stagingcluster',
 		},
 	});
 	const storage = new StorageStack(app, 'TestStorageStaging', {
@@ -168,7 +174,7 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 				FunctionName: 'ganbari-quest-app',
 				Environment: {
 					Variables: Match.objectLike({
-						DATA_SOURCE: 'dynamodb',
+						DATA_SOURCE: 'dsql',
 						AUTH_MODE: 'cognito',
 						ORIGIN: 'https://ganbari-quest.com',
 						COGNITO_CALLBACK_URL: 'https://ganbari-quest.com/auth/callback',
@@ -295,12 +301,12 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 			stagingCompute.resourceCountIs('AWS::KinesisFirehose::DeliveryStream', 0);
 		});
 
-		it('staging env: DATA_SOURCE=dynamodb + AUTH_MODE=cognito + ORIGIN placeholder + PARENT_GATE_COOKIE_SECRET 注入', () => {
+		it('staging env: DATA_SOURCE=dsql + AUTH_MODE=cognito + ORIGIN placeholder + PARENT_GATE_COOKIE_SECRET 注入 (#3438 Phase 2A)', () => {
 			stagingCompute.hasResourceProperties('AWS::Lambda::Function', {
 				FunctionName: 'ganbari-quest-staging-app',
 				Environment: {
 					Variables: Match.objectLike({
-						DATA_SOURCE: 'dynamodb',
+						DATA_SOURCE: 'dsql',
 						AUTH_MODE: 'cognito',
 						// Function URL 自己参照のため synth 時は placeholder。
 						// deploy-aws-staging.yml の ORIGIN resolve step が実 URL に更新する (縮退可)

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -75,9 +75,9 @@ function buildStagingStacks(): {
 	const app = new cdk.App({
 		context: {
 			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
-			// #3438 Phase 2A: staging も DSQL 無条件 backend (本番構成一致) の fail-close 回避
-			dsqlEndpoint: 'stagingcluster.dsql.us-east-1.on.aws',
-			dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/stagingcluster',
+			// #3438 Phase 2A: staging に dsqlEndpoint 注入 → staging dual-mode の dsql 側を検証 (S-3)。
+			dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+			dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
 		},
 	});
 	const storage = new StorageStack(app, 'TestStorageStaging', {


### PR DESCRIPTION
## 顧客価値・目的

DSQL 移管の finalize（#3438 Phase 2A）。本番 compute-stack の CDK 既定を「`dynamodb` + `dsqlEnabled` override」から **本番=dsql 無条件**へ flip し、旧 `dsqlEnabled` flag と「flag なしは DATA_SOURCE=dynamodb fallback」(#2873 prod template 不変条件) を撤去する。prod は既に DSQL 稼働のため CDK を実態に一致させ、**flag 忘れ deploy で dead な dynamodb backend へ silent 巻戻しする事故余地を排除**する（#3438 の keystone、Phase 2B/2C の前提）。

## 関連 Issue

- #3438 Phase 2A（EPIC #3424 DynamoDB→DSQL 移管の finalize）。Phase 2B（dynamodb repos 撤去）は本 flip が前提。Phase 3（table 撤去）は #3805（analytics on-demand 化）が gate。staging を dsql 既定へ統一は #3685。

<!-- no-issue-close: #3438 の AC1〜AC4 は「db/dynamodb/ 39 file + CI ゲート 2 本(check-dynamodb-stub*.mjs) + migration hydrate の撤去 + rationale 13 supersede」= 撤去作業本体。本 PR は Phase 2A = 本番 compute-stack の DSQL 無条件既定化(CDK flip = 撤去の前提条件)のみで、撤去 AC は Phase 2B で実施予定のため #3438 は close しない（over-close 回避、QM 原則）。 -->

## AC 検証マップ (ADR-0004)

| AC (Phase 2A) | 実装 | 検証 | 状態 |
|---|---|---|---|
| 本番 CDK 既定を dsql 無条件化 (dynamodb fallback 撤去) | `compute-stack.ts`: prod env base = DATA_SOURCE=dsql + DSQL_ENDPOINT + DSQL_USER、dsqlEnabled override + dynamodb base 撤去 | `dsql-cutover-wiring.test.ts` [W1] / `multi-lambda-cdk` / `staging-cdk` | ✅ |
| endpoint/clusterArn 未注入は本番 fail-close | `if (isProd && !dsqlEndpoint/clusterArn) addError` | [W2][W3] fail-close test | ✅ |
| dsql:DbConnect 無条件配線 (ARN 限定、Admin なし) | `if (dsqlClusterArn)` unconditional IAM | [W1] IAM assert | ✅ |
| analytics の DynamoDB table は維持 (別レイヤー) | DYNAMODB_TABLE/ANALYTICS_TABLE_NAME env + grantReadWriteData 不変 | [W1] ANALYTICS_TABLE_NAME assert | ✅ |
| staging dual-mode 維持 (PR=dynamodb / lane=dsql) | `stagingEnvironment`: DATA_SOURCE = dsqlEndpoint ? dsql : dynamodb | staging-cdk (endpoint 注入 → dsql) | ✅ |

## 変更タイプ

- [ ] バグ修正
- [x] リファクタリング (DSQL 移管 finalize、fallback 撤去)
- [x] テスト追加/更新
- [ ] 新機能

## 影響範囲・変更コンポーネント

- `infra/lib/compute-stack.ts`: prod env DATA_SOURCE flip + dsqlEnabled override 撤去 + fail-close(prod) + 無条件 IAM。staging は dual-mode 維持。
- `tests/unit/infra/`: dsql-cutover-wiring（無条件 dsql + fail-close 契約へ書換）/ multi-lambda-cdk / staging-cdk（prod=dynamodb → dsql）。
- **deploy.yml 変更なし**: 既に ClusterEndpoint/ClusterArn を describe-stacks で resolve+pass 済（L284-315）。`-c dsqlEnabled=true` は bin/app.ts の DsqlStack instantiation gate 用に残存（compute-stack は非参照化）。
- **runtime/src 非変更**: DATA_SOURCE の runtime 解決 (backend.ts/factory.ts) は dsql を既に処理済。

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/infra/` → 8 files / 99 passed。
- biome clean。
- **behavior-neutral**: 通常 deploy（deploy.yml が dsqlEnabled+endpoint+clusterArn を渡す）の結果 DATA_SOURCE=dsql は不変。変わるのは「flag/endpoint 無し deploy が dynamodb に silent fallback せず fail-close する」= 安全側。ADR-0019 replacement 非該当。

## スクリーンショット / ビジュアルデモ

N/A（infra）。

## コード品質セルフレビュー (#1481)

- fail-close を isProd に限定し staging の dual-mode（安価な PR 検証）を保存。staging=dsql 統一は #3685 の scope（コスト AC 付き）と明確分離。
- analytics の DynamoDB 依存は DATA_SOURCE とは別レイヤーとして維持（撤去は #3805）。混同を避けコメント明記。

## 横展開・影響波及チェック

- impact-analysis (#3438) で deploy-pipeline 結合 + analytics 結合の 2 盲点を事前検出済。本 PR は「prod DATA_SOURCE 既定」のみに限定し、analytics(#3805) / staging(#3685) / repo 撤去(Phase 2B) を分離。
- bin/app.ts の DsqlStack gate（dsqlEnabled）は「どの stack を deploy するか」の別 gate として温存（prod DB cluster の誤合成防止）。

## レビュー依頼事項・破壊的変更

- **本番 deploy pipeline 変更**。deploy 自体は **PO 承認 + post-deploy health 検証を gate** とする（挙動不変＝prod は既に dsql だが、CDK template が変わる本番経路のため）。
- **rollback 手段**: 万一 flip 後に問題が出た場合、deploy.yml の pre-dsql-cutover backup（EPIC #3702）+ 旧 DB 物理保持（#3438 Phase 5 安全 cutover 手順）により即ロールバック可能。本 PR は CDK template 変更のみで DB データには非破壊。
- レビュー観点: ① fail-close の isProd 限定で staging PR 検証が壊れないか ② deploy.yml が endpoint/clusterArn を渡す前提の妥当性（L284-315 で確認済）。

## 配布済み env / secret (ADR-0006)

新規 env/secret なし（DSQL_ENDPOINT/DSQL_USER は既存、deploy.yml が resolve）。

## Ready for Review チェックリスト

- [x] AC 全実装 + infra test 99 passed
- [x] behavior-neutral（通常 deploy 不変）+ fallback 撤去で安全側
- [x] deploy.yml 変更不要を確認（endpoint/clusterArn resolve 済）
- [x] pre-ready 全 step PASS（実行して確認）
- [x] **本番 deploy は PO 承認 + post-deploy health を gate とする**（本 PR は code のみで deploy を含まない = code 完遂の妨げにはならない）

## QM レビュー結果

(QM 記入欄)
