### PR TITLE
fix(data-integrity): #3603 checklist insertTemplateItem/insertOverride の caller 供給 id を INSERT...SELECT で構造検証 (orphan 排除)

### DIFF
--- a/src/lib/server/db/dsql/checklist-repo.ts
+++ b/src/lib/server/db/dsql/checklist-repo.ts
@@ -380,16 +380,29 @@ export function createDsqlChecklistRepo<TTx extends SqlExecutor>(
 		},
 
 		async insertTemplateItem(input, tenantId) {
-			// item_id は schema default (gen_random_uuid())。family_id = tenantId タグ付けで
-			// tenant 越境 write を構造排除 (§P9)。
+			// item_id は schema default (gen_random_uuid())。
+			// #3603 ①: DSQL は FK 非対応。template_id を family タグのみで受理すると、同 family 内でも
+			// 存在しない / archive 済でない別 template を名乗った item が orphan として挿入され得る
+			// (assignTemplateToChildren の children JOIN と同じ穴)。INSERT ... SELECT FROM
+			// checklist_templates で「template が同 family に実在する」ことを構造強制し、family_id は
+			// 親 template 行から採る (§P9: template が別 tenant なら 0 行 → 挿入されない)。0 行 emit は
+			// caller の programming error (実在しない template) ゆえ silent drop せず loud に throw する。
 			const result = await db.execute(sql`
 				INSERT INTO checklist_template_items
 					(family_id, template_id, name, icon, frequency, direction, sort_order)
-				VALUES (${tenantId}, ${input.templateId}, ${input.name}, ${input.icon ?? '🏫'},
-					${input.frequency ?? 'daily'}, ${input.direction ?? 'bring'}, ${input.sortOrder ?? 0})
+				SELECT t.family_id, t.template_id, ${input.name}, ${input.icon ?? '🏫'},
+					${input.frequency ?? 'daily'}, ${input.direction ?? 'bring'}, ${input.sortOrder ?? 0}
+				FROM checklist_templates t
+				WHERE t.family_id = ${tenantId} AND t.template_id = ${input.templateId}
 				RETURNING ${ITEM_COLUMNS}
 			`);
-			return toItem(result.rows[0] as unknown as ItemRow);
+			const row = result.rows[0] as unknown as ItemRow | undefined;
+			if (!row) {
+				throw new Error(
+					'checklist insertTemplateItem: template not found in tenant (orphan item rejected)',
+				);
+			}
+			return toItem(row);
 		},
 
 		async deleteTemplateItem(templateId, id, tenantId) {
@@ -458,13 +471,28 @@ export function createDsqlChecklistRepo<TTx extends SqlExecutor>(
 		},
 
 		async insertOverride(input, tenantId) {
+			// #3603 ①: DSQL は FK 非対応。child_id を family タグのみで受理すると、同 family 内でも
+			// 存在しない child を名乗った override が orphan として挿入され得る
+			// (assignTemplateToChildren の children JOIN と同じ穴)。INSERT ... SELECT FROM children で
+			// 「child が同 family に実在する」ことを構造強制し、family_id は children 行から採る
+			// (§P9: child が別 tenant なら 0 行 → 挿入されない)。0 行 emit は caller の programming error
+			// (実在しない child) ゆえ silent drop せず loud に throw する。backup restore 経路
+			// (insertOverrideForRestore) は child 復元順序に依存するため本 guard の対象外。
 			const result = await db.execute(sql`
 				INSERT INTO checklist_overrides (family_id, child_id, target_date, action, item_name, icon)
-				VALUES (${tenantId}, ${String(input.childId)}, ${input.targetDate}, ${input.action},
-					${input.itemName}, ${input.icon ?? '📦'})
+				SELECT c.family_id, c.child_id, ${input.targetDate}, ${input.action},
+					${input.itemName}, ${input.icon ?? '📦'}
+				FROM children c
+				WHERE c.family_id = ${tenantId} AND c.child_id = ${String(input.childId)}
 				RETURNING ${OVERRIDE_COLUMNS}
 			`);
-			return toOverride(result.rows[0] as unknown as OverrideRow);
+			const row = result.rows[0] as unknown as OverrideRow | undefined;
+			if (!row) {
+				throw new Error(
+					'checklist insertOverride: child not found in tenant (orphan override rejected)',
+				);
+			}
+			return toOverride(row);
 		},
 
 		async findOverridesByChild(childId, tenantId) {

--- a/tests/unit/db/dsql-checklist-repo.test.ts
+++ b/tests/unit/db/dsql-checklist-repo.test.ts
@@ -383,6 +383,35 @@ describe('DSQL checklist-repo (PR-R7、実 schema PGlite、family master + per-c
 		expect(await repo.findTemplateItems(tpl.id, FAMILY)).toEqual([]);
 	});
 
+	// #3603 ①: DSQL は FK 非対応。存在しない / 他 family の template_id を名乗った item 挿入を
+	// INSERT ... SELECT FROM checklist_templates で構造排除する (0 行 emit → orphan item を作らず
+	// loud に throw。silent drop しない安全側)。assignTemplateToChildren の children JOIN と同型。
+	it('[I1c] insertTemplateItem: 存在しない / 他 family template は orphan item を作らず throw', async () => {
+		const ghostTemplateId = '00000000-0000-4000-8000-00000000f001'; // templates 未登録
+		await expect(
+			repo.insertTemplateItem({ templateId: ghostTemplateId, name: 'ゴースト item' }, FAMILY),
+		).rejects.toThrow();
+		// orphan item 行は物理的に存在しない
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM checklist_template_items
+					WHERE family_id = ${FAMILY} AND template_id = ${ghostTemplateId}`,
+			),
+		).toBe(0);
+
+		// 他 family の実在 template を名乗っても (tenant 越境) 0 行 → throw
+		const foreignTpl = await repo.insertTemplate({ name: '他 family 帳票' }, OTHER_FAMILY);
+		await expect(
+			repo.insertTemplateItem({ templateId: foreignTpl.id, name: '越境 item' }, FAMILY),
+		).rejects.toThrow();
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM checklist_template_items
+					WHERE template_id = ${foreignTpl.id}`,
+			),
+		).toBe(0);
+	});
+
 	// ─────────────────── Logs (§5 items_json text 据置) ───────────────────
 
 	it('[L1] upsertLog insert → findTodayLog が items_json を verbatim 返す', async () => {
@@ -550,6 +579,42 @@ describe('DSQL checklist-repo (PR-R7、実 schema PGlite、family master + per-c
 		expect(await repo.findOverrides(child, '2026-07-08', FAMILY)).toEqual([]);
 		// §P9
 		expect(await repo.findOverrides(child, '2026-07-07', OTHER_FAMILY)).toEqual([]);
+	});
+
+	// #3603 ①: DSQL は FK 非対応。存在しない / 他 family の child_id を名乗った override 挿入を
+	// INSERT ... SELECT FROM children で構造排除する (0 行 emit → orphan override を作らず loud に
+	// throw)。assignTemplateToChildren の children JOIN と同型。insertOverrideForRestore (backup
+	// restore 経路) は child 復元順序に依存するため本 guard 対象外 (issue #3603 ① scope)。
+	it('[O1b] insertOverride: 存在しない / 他 family child は orphan override を作らず throw', async () => {
+		const ghostChild = asChildId('00000000-0000-4000-8000-0000009999f1'); // children 未登録
+		await expect(
+			repo.insertOverride(
+				{ childId: ghostChild, targetDate: '2026-07-07', action: 'add', itemName: 'ゴースト' },
+				FAMILY,
+			),
+		).rejects.toThrow();
+		// orphan override 行は物理的に存在しない
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM checklist_overrides
+					WHERE family_id = ${FAMILY} AND child_id = ${String(ghostChild)}`,
+			),
+		).toBe(0);
+
+		// 他 family の実在 child を名乗っても (tenant 越境) 0 行 → throw
+		const foreignChild = await newChild('他 family っ子', OTHER_FAMILY);
+		await expect(
+			repo.insertOverride(
+				{ childId: foreignChild, targetDate: '2026-07-07', action: 'add', itemName: '越境' },
+				FAMILY,
+			),
+		).rejects.toThrow();
+		expect(
+			await countRows(
+				sql`SELECT count(*) AS c FROM checklist_overrides
+					WHERE family_id = ${FAMILY} AND child_id = ${String(foreignChild)}`,
+			),
+		).toBe(0);
 	});
 
 	it('[O2] findOverridesByChild (全日) + insertOverrideForRestore (createdAt verbatim)', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管 checklist repo の data-integrity 防御線）

**解決する課題**: #3603 ① hardening の残 scope。`assignTemplateToChildren` の orphan 排除（children JOIN、#3626）は develop に merge 済だが、同一 class の穴が `insertTemplateItem`（template_id）/ `insertOverride`（child_id）に残っていた。DSQL は FK 非対応のため、caller 供給 id を family タグのみで受理すると、同 family 内でも存在しない template / child を名乗った **orphan 行**が構造的に挿入され得る。

**期待される効果**: checklist の item / override 挿入が「親（template / child）が同 family に実在する」ことを DB 層で構造強制し、orphan 行を物理的に作れなくする。

## 関連 Issue

closes #3603

前段: #3602（DSQL IChecklistRepo 本体、merged）/ #3626（① assignTemplateToChildren orphan 排除、merged）。related: EPIC #3424 / ADR-0055 / ADR-0061。② upsertLog マージは issue 本文が「cutover 後の実利用で評価」と明示 defer のため本 PR では評価済・対象外（下記レビュー依頼事項）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `insertTemplateItem` が存在しない / 他 family の template を名乗った item を orphan として作らない（INSERT...SELECT 構造排除、0 行 loud throw） | `npx vitest run tests/unit/db/dsql-checklist-repo.test.ts -t "I1c"` | HEAD `b820114e2e3c3bb5c13858e5732401676966848f` / red 実測: orphan item 挿入 resolve → green（throw + 物理行 0）。full suite 26 passed |
| AC2 | `insertOverride` が存在しない / 他 family の child を名乗った override を orphan として作らない（INSERT...SELECT FROM children 構造排除、0 行 loud throw） | `npx vitest run tests/unit/db/dsql-checklist-repo.test.ts -t "O1b"` | HEAD `b820114e2e3c3bb5c13858e5732401676966848f` / red 実測: orphan override が childId=ghost で実生成 → green |
| AC3 | #3626 と同型 INSERT...SELECT で統一。既存 25 メソッドに回帰なし | full suite 再実行 | HEAD `b820114e2e3c3bb5c13858e5732401676966848f` / 26 passed（24 既存 + 2 新規、回帰 0） |
| AC4 | ② upsertLog merge 粒度: 現行 items_json 全置換が sanctioned design であることを評価し対象外と結論 | 設計精査 + issue defer 文言 | HEAD `b820114e2e3c3bb5c13858e5732401676966848f` / issue 本文「cutover 後の実利用で評価」に整合。log 行 PK OCC 直列化で lost-update なし |

## 変更タイプ

- [x] fix: バグ修正
- [x] test: テスト改善

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ / repo (`/server/db/`) — dsql/checklist-repo.ts の 2 メソッド（schema/interface 無変更）

**影響を受ける画面・機能**: なし（DSQL backend の内部挙動のみ。sqlite backend は未変更）。

## テスト & 安全装置セルフチェック

- [x] targeted 検証（main tree, HEAD `b820114e2e3c3bb5c13858e5732401676966848f`）: vitest 26 passed / append-only allowlist pass / svelte-check 0 error (8230 files, sync 済) / biome 2 file clean / cspell exit 0
- [x] 追加・変更したテスト: `[I1c]`（orphan item 排除）/ `[O1b]`（orphan override 排除）を failing-test-first で追加。実 schema PGlite で「throw + 物理行 0」を assert
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A（orphan 排除は DSQL 専用 = FK 非対応が root cause。sqlite/dynamodb は storage 差異で対象外、demo は no-op stub）
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（server 側 data-integrity）**: DSQL repo の 2 メソッドのみで UI 変更なし（.svelte 変更 0）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: interface 契約無変更で backend 内部を hardening（LSP 維持）。#3626 と同型 INSERT...SELECT で統一
- [x] **DRY**: children / checklist_templates JOIN パターンを既存 assignTemplateToChildren と揃え独自機構を足さない
- [x] **YAGNI**: schema 追加なし。0 行 emit を loud throw に留め余計な fallback を作らない
- [x] **Security**: §P9 tenant 述語 + INSERT...SELECT で cross-family / orphan を構造排除（TOCTOU なし = 単一 statement）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: insert 1 件あたり PK 等価 JOIN 1 回（ADR-0065 DPU 単一行 write txn 範囲内）

## 横展開・影響波及チェック

- [x] **backend parity**: orphan 排除は #3626 確立の DSQL 専用パターンに整合。sqlite/dynamodb は storage 差異、demo は no-op stub のため本 guard 不要
- [x] **設計書同期** (ADR-0001): ADR-0055 / `dsql-data-model.md` §P9 の構造排除方針の実装であり設計変更なし
- [x] N/A — 本番アプリ+デモ / LP / 年齢モード / ナビ / labels（server 側 data-integrity）

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（DSQL backend 内部の hardening。0 行 throw は実在しない親を渡した programming error 時のみ発火し、service 層の全 caller は検証済 id を渡すため実挙動不変）

**レビュー依頼事項・QA**:
- **② upsertLog item マージ粒度は対象外**とした根拠: 現行 `items_json` 全置換は §5 の sanctioned design（子表 checklist_log_items 廃止、text 列据置、reset-plan 決定#1）。log 行は PK ON CONFLICT の OCC で直列化され lost-update なし。残る「同時チェックの後着が先着を消す」は UX 特性で、repo は full-set しか受け取らず delta 情報が無いため repo 単独で改善不可（service/interface 契約変更を要する）。issue #3603 ② が「cutover 後の実利用で評価」と明示 defer、ADR-0010 Pre-PMF 整合で現行挙動を維持。②を「評価完了」と見るか QM/PO の最終判断に委ねます

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] vitest 26/26 + biome / cspell / svelte-check clean をローカル確認（main tree）
- [x] セルフレビュー済み（failing-test-first で red→green 実証）
- [x] 全 AC が実装済み（① 完遂、② は評価済で対象外を明記）
- [x] Phase 分割なし
- [x] UI 変更なし
- [x] 認証画面変更なし

## QM レビュー結果

<!-- QM 記入 -->
