### PR TITLE
feat(analytics): #3805 on-demand DSQL activation funnel サービス新設 + /ops 載せ替え (Sub-A)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -358,6 +358,7 @@ omote
 onaccept
 oncanceledit
 oncreated
+ondemand
 oneclick
 onedit
 onimported

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -3988,7 +3988,7 @@ export const OPS_ANALYTICS_LABELS = {
 	// Activation Funnel section (#2285 EPIC #2283: /admin/analytics 撤去で消失する機能を ops 側へ移動)
 	// 内部基盤名 (DynamoDB / Pre-PMF Bucket A) UI 露出禁止 (AN-5 #2180 整合)、「テナント」→「家庭」置換
 	activationFunnelTitle: 'Activation Funnel (直近 30 日)',
-	activationFunnelDesc: 'signup から初回報酬演出までの家庭単位ユニーク件数と遷移率。',
+	activationFunnelDesc: 'signup から 7 日継続までの家庭単位ユニーク件数と遷移率。',
 	activationFunnelStepCol: 'ステップ',
 	activationFunnelCountCol: '件数',
 	activationFunnelConversionCol: '遷移率',
@@ -3996,7 +3996,7 @@ export const OPS_ANALYTICS_LABELS = {
 		activation_signup_completed: '① signup',
 		activation_first_child_added: '② 初回家庭メンバー登録',
 		activation_first_activity_completed: '③ 初回活動完了',
-		activation_first_reward_seen: '④ 初回報酬演出',
+		activation_retained_7d: '④ 7日継続',
 	},
 	activationFunnelEmpty: 'データがありません',
 	activationFunnelHouseholdSuffix: '世帯',

--- a/src/lib/server/db/demo/activation-funnel-repo.ts
+++ b/src/lib/server/db/demo/activation-funnel-repo.ts
@@ -1,0 +1,11 @@
+// src/lib/server/db/demo/activation-funnel-repo.ts
+// #3805 / ADR-0048: on-demand activation funnel の demo backend stub。
+//
+// demo Lambda は匿名 (AUTH_MODE=anonymous) の stateless fixture provider で ops analytics は
+// 到達しない。cross-tenant KPI は demo の責務外のため 0 件を返す (他 demo repo と同じ stub 方針)。
+
+import type { ActivationFunnelCounts } from '../interfaces/activation-funnel-repo.interface';
+
+export async function getActivationFunnelCounts(): Promise<ActivationFunnelCounts> {
+	return { signupCount: 0, firstChildCount: 0, firstActivityCount: 0, retained7dCount: 0 };
+}

--- a/src/lib/server/db/dsql/activation-funnel-repo.ts
+++ b/src/lib/server/db/dsql/activation-funnel-repo.ts
@@ -1,0 +1,80 @@
+// src/lib/server/db/dsql/activation-funnel-repo.ts
+// EPIC #3424 / #3805: on-demand activation funnel の DSQL backend 実装。
+//
+// 設計契約 (dsql-data-model.md §11.2 cross-tenant 例外 / ADR-0065 DPU 規約):
+//   - **factory 注入** (fitness#8)。単文 read のみ (txn runner 不要)。
+//   - **cross-tenant 集計 (§11.2 例外)**: PO KPI 分析用途で families を tenant 横断走査する。
+//     cancellation-reason-repo.aggregateRecent と同クラスの明示例外。
+//   - **単一集約 SQL (ADR-0065: N+1 禁止)**: cohort → child / activity を CTE で 1 回に束ね、
+//     4 段の件数を 1 クエリで返す。段ごとの per-tenant query は行わない。
+//   - **created_at range で cohort を絞る**: families 全走査ではなく since 以降のみ。children /
+//     activity_logs も cohort に JOIN して集約対象を cohort 家庭に限定する。
+//   - **PGlite parity (ADR-0064)**: DSQL / NUC PGlite は本 repo を verbatim 共有。同 SQL が
+//     両 pg backend で動く (make_interval / FILTER / timestamptz は pg 標準)。
+
+import { sql } from 'drizzle-orm';
+import type {
+	ActivationFunnelCounts,
+	IActivationFunnelRepo,
+} from '../interfaces/activation-funnel-repo.interface';
+import type { SqlExecutor } from './sql-executor';
+
+interface FunnelRow {
+	signup_count: number;
+	first_child_count: number;
+	first_activity_count: number;
+	retained_count: number;
+}
+
+/** DSQL 用 IActivationFunnelRepo を生成する (db は注入、fitness#8)。 */
+export function createDsqlActivationFunnelRepo(db: SqlExecutor): IActivationFunnelRepo {
+	return {
+		async getActivationFunnelCounts(
+			sinceIso: string,
+			retentionDays: number,
+		): Promise<ActivationFunnelCounts> {
+			// 単一集約 SQL:
+			//   cohort         = since 以降に登録した家庭 (signup 起点)
+			//   child_flag     = cohort のうち子供を持つ家庭 (DISTINCT を cohort に限定)
+			//   first_activity = cohort のうち初回 (非取消) 活動時刻 (MIN)
+			// FILTER で signup + retentionDays 以内の初回活動を retention として数える。
+			const result = await db.execute(sql`
+				WITH cohort AS (
+					SELECT family_id, created_at AS signup_at
+					FROM families
+					WHERE created_at >= ${sinceIso}::timestamptz
+				),
+				child_flag AS (
+					SELECT DISTINCT ch.family_id
+					FROM children ch
+					JOIN cohort c2 ON c2.family_id = ch.family_id
+				),
+				first_activity AS (
+					SELECT al.family_id, MIN(al.recorded_at) AS first_at
+					FROM activity_logs al
+					JOIN cohort c3 ON c3.family_id = al.family_id
+					WHERE al.cancelled = false
+					GROUP BY al.family_id
+				)
+				SELECT
+					count(*)::int AS signup_count,
+					count(cf.family_id)::int AS first_child_count,
+					count(fa.family_id)::int AS first_activity_count,
+					count(*) FILTER (
+						WHERE fa.first_at IS NOT NULL
+							AND fa.first_at <= c.signup_at + make_interval(days => ${retentionDays}::int)
+					)::int AS retained_count
+				FROM cohort c
+				LEFT JOIN child_flag cf ON cf.family_id = c.family_id
+				LEFT JOIN first_activity fa ON fa.family_id = c.family_id
+			`);
+			const row = result.rows[0] as unknown as FunnelRow | undefined;
+			return {
+				signupCount: Number(row?.signup_count ?? 0),
+				firstChildCount: Number(row?.first_child_count ?? 0),
+				firstActivityCount: Number(row?.first_activity_count ?? 0),
+				retained7dCount: Number(row?.retained_count ?? 0),
+			};
+		},
+	};
+}

--- a/src/lib/server/db/factory.ts
+++ b/src/lib/server/db/factory.ts
@@ -5,6 +5,7 @@
 // #3438 Phase 2B: DynamoDB backend (repo 層 33 本 + dynamodb 分岐) は cutover 完了により撤去済。
 
 import * as demoAccountLockoutRepo from './demo/account-lockout-repo';
+import * as demoActivationFunnelRepo from './demo/activation-funnel-repo';
 import * as demoActivityMasteryRepo from './demo/activity-mastery-repo';
 import * as demoActivityPrefRepo from './demo/activity-pref-repo';
 import * as demoActivityRepo from './demo/activity-repo';
@@ -40,6 +41,7 @@ import * as demoTrialHistoryRepo from './demo/trial-history-repo';
 import * as demoViewerTokenRepo from './demo/viewer-token-repo';
 import * as demoVoiceRepo from './demo/voice-repo';
 import { createDsqlAccountLockoutRepo } from './dsql/account-lockout-repo';
+import { createDsqlActivationFunnelRepo } from './dsql/activation-funnel-repo';
 import { createDsqlActivityMasteryRepo } from './dsql/activity-mastery-repo';
 import { createDsqlActivityPrefRepo } from './dsql/activity-pref-repo';
 import { createDsqlActivityRepo } from './dsql/activity-repo';
@@ -78,6 +80,7 @@ import { createDsqlViewerTokenRepo } from './dsql/viewer-token-repo';
 import { createDsqlVoiceRepo } from './dsql/voice-repo';
 // #3438 Phase 2B: dynamodb/*-repo は撤去 (storage は Phase 1 #3786 で s3/ へ移設済)。
 import type { IAccountLockoutRepo } from './interfaces/account-lockout-repo.interface';
+import type { IActivationFunnelRepo } from './interfaces/activation-funnel-repo.interface';
 import type { IActivityMasteryRepo } from './interfaces/activity-mastery-repo.interface';
 import type { IActivityPrefRepo } from './interfaces/activity-pref-repo.interface';
 import type { IActivityRepo } from './interfaces/activity-repo.interface';
@@ -119,6 +122,7 @@ import type { IVoiceRepo } from './interfaces/voice-repo.interface';
 import { getPgliteDbSync, getPgliteTransactionRunnerSync } from './pglite/connection';
 import * as s3StorageRepo from './s3/storage-repo';
 import * as sqliteAccountLockoutRepo from './sqlite/account-lockout-repo';
+import * as sqliteActivationFunnelRepo from './sqlite/activation-funnel-repo';
 import * as sqliteActivityMasteryRepo from './sqlite/activity-mastery-repo';
 import * as sqliteActivityPrefRepo from './sqlite/activity-pref-repo';
 import * as sqliteActivityRepo from './sqlite/activity-repo';
@@ -156,6 +160,11 @@ import * as sqliteVoiceRepo from './sqlite/voice-repo';
 
 export interface Repositories {
 	accountLockout: IAccountLockoutRepo;
+	/**
+	 * #3805: on-demand activation funnel (cross-tenant KPI)。DSQL / PGlite のみ実データ、
+	 * sqlite / demo / dynamodb は単一テナント or 非分析 backend のため 0 件 stub。
+	 */
+	activationFunnel: IActivationFunnelRepo;
 	battle: IBattleRepo;
 	cancellationReason: ICancellationReasonRepo;
 	certificate: ICertificateRepo;
@@ -215,6 +224,7 @@ function buildPgBackendRepos<TTx extends SqlExecutor>(
 ): Repositories {
 	return {
 		accountLockout: createDsqlAccountLockoutRepo(db),
+		activationFunnel: createDsqlActivationFunnelRepo(db),
 		battle: createDsqlBattleRepo(db),
 		cancellationReason: createDsqlCancellationReasonRepo(db),
 		certificate: createDsqlCertificateRepo(db),
@@ -263,6 +273,7 @@ export function getRepos(): Repositories {
 		// 物理的に発生不可能にする。
 		const repos: Repositories = {
 			accountLockout: demoAccountLockoutRepo,
+			activationFunnel: demoActivationFunnelRepo,
 			battle: demoBattleRepo,
 			cancellationReason: demoCancellationReasonRepo,
 			certificate: demoCertificateRepo,
@@ -316,6 +327,7 @@ export function getRepos(): Repositories {
 	}
 	const repos: Repositories = {
 		accountLockout: sqliteAccountLockoutRepo,
+		activationFunnel: sqliteActivationFunnelRepo,
 		battle: sqliteBattleRepo,
 		cancellationReason: sqliteCancellationReasonRepo,
 		certificate: sqliteCertificateRepo,

--- a/src/lib/server/db/interfaces/activation-funnel-repo.interface.ts
+++ b/src/lib/server/db/interfaces/activation-funnel-repo.interface.ts
@@ -30,5 +30,8 @@ export interface IActivationFunnelRepo {
 	 * @param sinceIso コホート起点 (ISO8601 UTC)。この時刻以降に登録した家庭のみを cohort とする。
 	 * @param retentionDays retention 判定窓 (日)。signup から本日数以内の活動があれば retained。
 	 */
-	getActivationFunnelCounts(sinceIso: string, retentionDays: number): Promise<ActivationFunnelCounts>;
+	getActivationFunnelCounts(
+		sinceIso: string,
+		retentionDays: number,
+	): Promise<ActivationFunnelCounts>;
 }

--- a/src/lib/server/db/interfaces/activation-funnel-repo.interface.ts
+++ b/src/lib/server/db/interfaces/activation-funnel-repo.interface.ts
@@ -1,0 +1,34 @@
+// src/lib/server/db/interfaces/activation-funnel-repo.interface.ts
+// EPIC #3424 / #3805: on-demand activation funnel repo 抽象。
+//
+// 分析基盤の on-demand DSQL 化 (#3805)。従来 DynamoDB に continuous 収集していた
+// activation funnel イベントを撤去し、main data (families / children / activity_logs) から
+// **必要時に単一集約 SQL で導出**する read-only 抽象。常設収集 / cron / dashboard は持たない。
+//
+// cross-tenant 集計: signup 起点コホート (families.created_at >= since) を横断走査する
+// PO KPI 分析用途 (cancellation-reason-repo.aggregateRecent / searchFreeText と同じ §11.2
+// 例外クラス)。フルスキャンではなく created_at range + 単一 GROUP BY 集約 (ADR-0065 整合、
+// N+1 禁止)。on-demand ゆえ常時コストは 0。
+
+/** activation funnel の各段の家庭 (tenant) 件数。cohort 起点で段階的に絞り込まれる。 */
+export interface ActivationFunnelCounts {
+	/** ① signup: since 以降に登録した家庭数 (cohort size)。 */
+	signupCount: number;
+	/** ② 初回家庭メンバー登録: cohort のうち子供を 1 人以上持つ家庭数。 */
+	firstChildCount: number;
+	/** ③ 初回活動完了: cohort のうち非取消の活動記録が 1 件以上ある家庭数。 */
+	firstActivityCount: number;
+	/** ④ N 日継続 (retention): cohort のうち signup から retentionDays 以内に活動した家庭数。 */
+	retained7dCount: number;
+}
+
+export interface IActivationFunnelRepo {
+	/**
+	 * signup 起点コホート (families.created_at >= sinceIso) の activation funnel 件数を
+	 * **単一集約 SQL** で返す (ADR-0065: N+1 禁止 / on-demand ゆえ常時コスト 0)。
+	 *
+	 * @param sinceIso コホート起点 (ISO8601 UTC)。この時刻以降に登録した家庭のみを cohort とする。
+	 * @param retentionDays retention 判定窓 (日)。signup から本日数以内の活動があれば retained。
+	 */
+	getActivationFunnelCounts(sinceIso: string, retentionDays: number): Promise<ActivationFunnelCounts>;
+}

--- a/src/lib/server/db/sqlite/activation-funnel-repo.ts
+++ b/src/lib/server/db/sqlite/activation-funnel-repo.ts
@@ -1,0 +1,13 @@
+// src/lib/server/db/sqlite/activation-funnel-repo.ts
+// #3805: on-demand activation funnel の SQLite backend 実装。
+//
+// SQLite backend は単一テナント (NUC セルフホスト、children に family_id を持たない) のため、
+// 家庭横断の cohort activation funnel は概念上成立しない。ops analytics は multi-tenant cloud
+// (DSQL) 専用の PO KPI 機能であり、SQLite では 0 件を返す (従来 DynamoDB 未配備の dev/NUC でも
+// funnel は空だったため挙動非退行)。
+
+import type { ActivationFunnelCounts } from '../interfaces/activation-funnel-repo.interface';
+
+export async function getActivationFunnelCounts(): Promise<ActivationFunnelCounts> {
+	return { signupCount: 0, firstChildCount: 0, firstActivityCount: 0, retained7dCount: 0 };
+}

--- a/src/lib/server/services/analytics-ondemand-service.ts
+++ b/src/lib/server/services/analytics-ondemand-service.ts
@@ -1,0 +1,138 @@
+// src/lib/server/services/analytics-ondemand-service.ts
+// EPIC #3424 / #3805: on-demand marketing 分析サービス (DSQL main data 由来)。
+//
+// 背景 (#3805): 従来 analytics は DynamoDB に activation event を continuous 収集し、日次 cron で
+// 集計、常設 /ops dashboard が参照していた。PO 方針で「必要時のみ分析、常設収集 / dashboard は
+// Pre-PMF で過剰」と整理され、DSQL 移管に合わせて **on-demand 化** する。marketing 分析の能力は
+// 維持しつつ always-on collection を撤去し、DynamoDB analytics 依存を完全撤去する。
+//
+// 本サービスは read-only:
+//   - activation funnel (signup → 初回子供登録 → 初回活動 → 7 日継続) を families / children /
+//     activity_logs から on-demand 集計する (repos.activationFunnel、単一集約 SQL、ADR-0065)。
+//   - cancellation 30d/90d は cancellation_reasons テーブルから on-demand 集計する
+//     (getCancellationReasonAggregation を再利用、既に DSQL main data 由来)。
+//
+// 常設 cron / collection は持たない。認証済 ops が必要時に呼ぶ。on-demand ゆえ常時コスト 0。
+//
+// #3805 設計判断: 旧 step ④ (first_reward_seen) は純 UI view event でデータ痕跡がなく DSQL から
+// 導出不能のため drop し、engagement 本質である「7 日 retention」を ④ に据える (PO 方針整合)。
+
+import { getRepos } from '$lib/server/db/factory';
+import type { CancellationReasonAggregation } from '$lib/server/db/interfaces/cancellation-reason-repo.interface';
+import { getCancellationReasonAggregation } from './cancellation-service';
+
+// ── Activation Funnel ─────────────────────────────────────────
+
+/** activation funnel 集計期間。 */
+export type ActivationFunnelPeriod = '7d' | '30d';
+
+/** funnel 単段の結果 (ops 表示互換 shape)。 */
+export interface ActivationFunnelStep {
+	/** Step ID (1-4): signup / first_child / first_activity / retained_7d */
+	step: number;
+	/** 内部 event 名 (ラベル辞書のキー兼用)。 */
+	eventName: string;
+	/** 当該段に到達した家庭 (tenant) のユニーク件数。 */
+	count: number;
+	/** 前段からの遷移率 (0-1)。Step 1 は常に 1。 */
+	conversionFromPrev: number;
+}
+
+export interface ActivationFunnelResult {
+	period: ActivationFunnelPeriod;
+	/** funnel 順 (1 → 4) の段配列。 */
+	steps: ActivationFunnelStep[];
+	/** 走査したコホート日数 (period 相当)。 */
+	scannedDates: number;
+	fetchedAt: string;
+}
+
+/** retention 判定窓 (日)。signup から本日数以内の活動を「継続」とみなす。 */
+const RETENTION_WINDOW_DAYS = 7;
+
+/**
+ * funnel 各段の内部 event 名 (ops ラベル辞書 activationFunnelStepLabels のキーと一致させる)。
+ * ④ は #3805 で first_reward_seen (drop) から retained_7d へ置換。
+ */
+const FUNNEL_STEP_EVENT_NAMES = [
+	'activation_signup_completed',
+	'activation_first_child_added',
+	'activation_first_activity_completed',
+	'activation_retained_7d',
+] as const;
+
+/** 今 (UTC) から daysAgo 日前の ISO8601 文字列を返す。 */
+function isoDaysAgo(daysAgo: number): string {
+	return new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/**
+ * activation funnel を on-demand 集計する (#3805 AC2)。
+ *
+ * signup 起点コホート (families.created_at >= since) を横断し、単一集約 SQL で 4 段
+ * (signup / 初回子供登録 / 初回活動 / 7 日継続) の家庭ユニーク件数を導出する。
+ * DynamoDB event stream 不要、常設収集なし、実行時のみ DSQL DPU を消費する。
+ */
+export async function getActivationFunnelOnDemand(
+	period: ActivationFunnelPeriod = '30d',
+): Promise<ActivationFunnelResult> {
+	const days = period === '7d' ? 7 : 30;
+	const sinceIso = isoDaysAgo(days);
+	const repos = getRepos();
+	const counts = await repos.activationFunnel.getActivationFunnelCounts(
+		sinceIso,
+		RETENTION_WINDOW_DAYS,
+	);
+
+	const ordered = [
+		counts.signupCount,
+		counts.firstChildCount,
+		counts.firstActivityCount,
+		counts.retained7dCount,
+	];
+
+	const steps: ActivationFunnelStep[] = FUNNEL_STEP_EVENT_NAMES.map((eventName, idx) => {
+		const count = ordered[idx] ?? 0;
+		const prev = idx === 0 ? count : (ordered[idx - 1] ?? 0);
+		const conversionFromPrev = idx === 0 ? 1 : prev > 0 ? count / prev : 0;
+		return { step: idx + 1, eventName, count, conversionFromPrev };
+	});
+
+	return {
+		period,
+		steps,
+		scannedDates: days,
+		fetchedAt: new Date().toISOString(),
+	};
+}
+
+// ── Cancellation reasons ──────────────────────────────────────
+
+/** 解約理由集計期間。 */
+export type CancellationReasonPeriod = '30d' | '90d';
+
+export interface CancellationReasonResult {
+	period: CancellationReasonPeriod;
+	total: number;
+	breakdown: CancellationReasonAggregation[];
+	fetchedAt: string;
+}
+
+/**
+ * 解約理由分布を on-demand 集計する (#3805 AC2)。
+ *
+ * cancellation_reasons テーブル (DSQL main data) を直接集計する。DynamoDB 事前集計
+ * スナップショット (旧 ANALYTICS_AGG) は撤去済で、常設収集なしに必要時算出する。
+ */
+export async function getCancellationReasonsOnDemand(
+	period: CancellationReasonPeriod = '90d',
+): Promise<CancellationReasonResult> {
+	const days = period === '30d' ? 30 : 90;
+	const { total, breakdown } = await getCancellationReasonAggregation(days);
+	return {
+		period,
+		total,
+		breakdown,
+		fetchedAt: new Date().toISOString(),
+	};
+}

--- a/src/lib/server/services/ops-analytics-service.ts
+++ b/src/lib/server/services/ops-analytics-service.ts
@@ -11,7 +11,10 @@ import type { Tenant } from '$lib/server/auth/entities';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { isStripeEnabled } from '$lib/server/stripe/client';
-import { type ActivationFunnelResult, getActivationFunnel } from './analytics-service';
+import {
+	type ActivationFunnelResult,
+	getActivationFunnelOnDemand,
+} from './analytics-ondemand-service';
 
 // ============================================================
 // #1602: Setup challenges preset distribution
@@ -560,12 +563,12 @@ export async function getAnalyticsData(): Promise<OpsAnalyticsData> {
 		});
 	}
 
-	// #2285 (EPIC #2283): Activation Funnel を ops 側に移動
-	// /admin/analytics 撤去で消失する Activation Funnel 機能を /ops/analytics で継続提供する。
+	// #2285 (EPIC #2283): Activation Funnel を ops 側に移動。
+	// #3805: DynamoDB event 集計から DSQL main data 由来の on-demand 集計へ載せ替え。
 	// funnelPeriod = '30d' 固定 (ops 専用、period switch UI なし、Pre-PMF コスト最小化)。
 	let activationFunnel: ActivationFunnelResult | null = null;
 	try {
-		activationFunnel = await getActivationFunnel('30d');
+		activationFunnel = await getActivationFunnelOnDemand('30d');
 	} catch (e) {
 		logger.warn('[OPS/analytics] Failed to load activation funnel', {
 			context: { error: e instanceof Error ? e.message : String(e) },

--- a/tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts
+++ b/tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts
@@ -140,6 +140,33 @@ const PREDICATE_ALLOWLIST: AllowlistEntry[] = [
 		reason:
 			'cross-tenant cron worker: build キュー取得 / stale building 回収 / 期限切れ削除 (#3504/#3509 state machine)',
 	},
+	// ── activation-funnel-repo: PO KPI activation funnel の cross-tenant 集計 (#3819 QM Tier2 指摘 ②) ──
+	//   families / children / activity_logs を cohort (since 以降登録の全テナント家庭) で横断集計する
+	//   単一集約 SQL。ops 認可下・count のみ返却で個票非露出 (§11.2 明示例外、cancellation-reason-repo
+	//   .aggregateRecent と同クラス)。marker は CTE 名 (cohort / child_flag / first_activity) を anchor
+	//   とし、JOIN 句の `family_id =` 記法 (HAS_FAMILY_PREDICATE への偶発マッチ) に依存しない明示登録。
+	//   これにより将来 JOIN を USING(family_id) 等へ書き換えても保護挙動が不定にならない。
+	{
+		file: 'activation-funnel-repo.ts',
+		table: 'families',
+		marker: /WITH\s+cohort\s+AS[\s\S]*?FROM\s+families/i,
+		reason:
+			'cross-tenant PO KPI 集計: activation funnel の cohort (since 以降登録の全テナント家庭) 走査。ops 認可下・count のみ・個票非露出 (§11.2 明示例外、#3805 Sub-A)',
+	},
+	{
+		file: 'activation-funnel-repo.ts',
+		table: 'children',
+		marker: /child_flag\s+AS[\s\S]*?FROM\s+children/i,
+		reason:
+			'cross-tenant PO KPI 集計: cohort 家庭の子供有無フラグ (child_flag CTE)。cohort JOIN で cohort 家庭に限定・count のみ (§11.2 明示例外、#3805 Sub-A)',
+	},
+	{
+		file: 'activation-funnel-repo.ts',
+		table: 'activity_logs',
+		marker: /first_activity\s+AS[\s\S]*?FROM\s+activity_logs/i,
+		reason:
+			'cross-tenant PO KPI 集計: cohort 家庭の初回 (非取消) 活動時刻 (first_activity CTE)。cohort JOIN で限定・count/retention のみ (§11.2 明示例外、#3805 Sub-A)',
+	},
 ];
 
 /**
@@ -257,20 +284,25 @@ function collectViolations(statements: SqlStatement[]): Violation[] {
 				}
 				continue;
 			}
-			if (HAS_FAMILY_PREDICATE.test(stmt.text)) continue;
-			if (HAS_TENANT_FRAGMENT.test(stmt.text)) continue;
+			// 閉じた allowlist を最優先で評価する (#3819 QM Tier2 指摘 ②)。cross-tenant scan
+			// (families 横断の PO KPI 集計等) は JOIN 句の `family_id =` に偶発マッチして
+			// HAS_FAMILY_PREDICATE を通過しうるが、その偶発マッチに依存せず「§3.4 の閉じた
+			// allowlist に理由付きで明示登録された例外」として pass することを保証する
+			// (将来 JOIN 記法変更で保護挙動が不定になるのを防ぐ)。allowlist 非該当の通常
+			// tenant-scoped クエリは従来どおり HAS_FAMILY_PREDICATE / HAS_TENANT_FRAGMENT で pass する。
 			const allowed = PREDICATE_ALLOWLIST.some(
 				(a) => a.file === stmt.file && a.table === table && a.marker.test(stmt.text),
 			);
-			if (!allowed) {
-				violations.push({
-					file: stmt.file,
-					line: stmt.line,
-					table,
-					kind: 'SELECT/UPDATE/DELETE (family_id 述語欠如)',
-					snippet: stmt.text.slice(0, 160).replace(/\s+/g, ' '),
-				});
-			}
+			if (allowed) continue;
+			if (HAS_FAMILY_PREDICATE.test(stmt.text)) continue;
+			if (HAS_TENANT_FRAGMENT.test(stmt.text)) continue;
+			violations.push({
+				file: stmt.file,
+				line: stmt.line,
+				table,
+				kind: 'SELECT/UPDATE/DELETE (family_id 述語欠如)',
+				snippet: stmt.text.slice(0, 160).replace(/\s+/g, ' '),
+			});
 		}
 	}
 	return violations;

--- a/tests/unit/db/dsql-activation-funnel-repo.test.ts
+++ b/tests/unit/db/dsql-activation-funnel-repo.test.ts
@@ -1,0 +1,130 @@
+// tests/unit/db/dsql-activation-funnel-repo.test.ts
+// EPIC #3424 / #3805: on-demand activation funnel の DSQL 実装テスト (実 schema PGlite)。
+//
+// 単一集約 SQL が families / children / activity_logs から 4 段 funnel 件数を正しく導出することを
+// 実データで検証する。cohort 境界 (created_at range) / 子供有無 / 非取消活動のみ / retention 窓
+// (signup + N 日以内) を網羅する。
+
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDsqlActivationFunnelRepo } from '../../../src/lib/server/db/dsql/activation-funnel-repo';
+import type { IActivationFunnelRepo } from '../../../src/lib/server/db/interfaces/activation-funnel-repo.interface';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+// cohort 起点。この時刻以降に登録した家庭のみ funnel 対象。
+const SINCE = '2026-07-01T00:00:00.000Z';
+const RETENTION_DAYS = 7;
+
+const ACTIVITY_ID = '00000000-0000-4000-8000-00000000a001';
+
+// 家庭 6 種 (期待段は下の TDD list 参照)。
+const FAM = {
+	// 全 4 段: 子供あり + signup +3 日で活動 (retention 内)
+	all: '00000000-0000-4000-8000-0000000000f1',
+	// 段 1-3: 子供あり + signup +15 日で活動 (retention 外)
+	late: '00000000-0000-4000-8000-0000000000f2',
+	// 段 1-2: 子供あり + 活動なし
+	child: '00000000-0000-4000-8000-0000000000f3',
+	// 段 1: 子供なし
+	signup: '00000000-0000-4000-8000-0000000000f4',
+	// cohort 外: since より前に登録
+	old: '00000000-0000-4000-8000-0000000000f5',
+	// 段 1-2: 子供あり + 取消活動のみ (初回活動に数えない)
+	cancelled: '00000000-0000-4000-8000-0000000000f6',
+} as const;
+
+const CHILD = {
+	all: '00000000-0000-4000-8000-00000000c001',
+	late: '00000000-0000-4000-8000-00000000c002',
+	child: '00000000-0000-4000-8000-00000000c003',
+	cancelled: '00000000-0000-4000-8000-00000000c006',
+} as const;
+
+describe('createDsqlActivationFunnelRepo (実 schema PGlite)', () => {
+	let t: DsqlTestDb;
+	let repo: IActivationFunnelRepo;
+
+	const insertFamily = (familyId: string, createdAt: string) =>
+		t.db.execute(sql`
+			INSERT INTO families (family_id, name, status, created_at)
+			VALUES (${familyId}, ${'fam'}, ${'active'}, ${createdAt}::timestamptz)
+		`);
+
+	const insertChild = (familyId: string, childId: string) =>
+		t.db.execute(sql`
+			INSERT INTO children (family_id, child_id, nickname)
+			VALUES (${familyId}, ${childId}, ${'child'})
+		`);
+
+	const insertActivity = (
+		familyId: string,
+		childId: string,
+		recordedAt: string,
+		cancelled: boolean,
+	) =>
+		t.db.execute(sql`
+			INSERT INTO activity_logs
+				(family_id, child_id, activity_id, points, recorded_date, recorded_at, cancelled)
+			VALUES (${familyId}, ${childId}, ${ACTIVITY_ID}, ${10},
+				${recordedAt.slice(0, 10)}, ${recordedAt}::timestamptz, ${cancelled})
+		`);
+
+	beforeAll(async () => {
+		t = await createDsqlTestDb();
+		repo = createDsqlActivationFunnelRepo(t.db);
+
+		// signup dates
+		await insertFamily(FAM.all, '2026-07-05T00:00:00.000Z');
+		await insertFamily(FAM.late, '2026-07-05T00:00:00.000Z');
+		await insertFamily(FAM.child, '2026-07-06T00:00:00.000Z');
+		await insertFamily(FAM.signup, '2026-07-06T00:00:00.000Z');
+		await insertFamily(FAM.old, '2026-06-01T00:00:00.000Z'); // cohort 外
+		await insertFamily(FAM.cancelled, '2026-07-05T00:00:00.000Z');
+
+		await insertChild(FAM.all, CHILD.all);
+		await insertChild(FAM.late, CHILD.late);
+		await insertChild(FAM.child, CHILD.child);
+		await insertChild(FAM.cancelled, CHILD.cancelled);
+		// old 家庭にも子供 (cohort 外なので集計に出ないことの確認用)
+		await insertChild(FAM.old, '00000000-0000-4000-8000-00000000c005');
+
+		// activities
+		await insertActivity(FAM.all, CHILD.all, '2026-07-08T00:00:00.000Z', false); // +3 日 → retained
+		await insertActivity(FAM.late, CHILD.late, '2026-07-20T00:00:00.000Z', false); // +15 日 → 非 retained
+		await insertActivity(FAM.cancelled, CHILD.cancelled, '2026-07-06T00:00:00.000Z', true); // 取消
+	});
+
+	afterAll(async () => {
+		await t.close();
+	});
+
+	it('4 段 funnel 件数を single-query で正しく導出する (cohort / 子供 / 非取消 / retention 窓)', async () => {
+		const counts = await repo.getActivationFunnelCounts(SINCE, RETENTION_DAYS);
+
+		// signup: all/late/child/signup/cancelled = 5 (old は cohort 外)
+		expect(counts.signupCount).toBe(5);
+		// first_child: all/late/child/cancelled = 4 (signup は子供なし)
+		expect(counts.firstChildCount).toBe(4);
+		// first_activity: all/late = 2 (child/signup は活動なし、cancelled は取消のみ)
+		expect(counts.firstActivityCount).toBe(2);
+		// retained_7d: all = 1 (late は窓外、cancelled は取消)
+		expect(counts.retained7dCount).toBe(1);
+	});
+
+	it('cohort 外 (since より前の since2) を広げると old も signup に含まれる', async () => {
+		const counts = await repo.getActivationFunnelCounts('2026-05-01T00:00:00.000Z', RETENTION_DAYS);
+		// old も含めて 6 家庭。old は子供ありだが活動なし。
+		expect(counts.signupCount).toBe(6);
+		expect(counts.firstChildCount).toBe(5); // signup 家庭のみ子供なし
+	});
+
+	it('該当コホートが空 (未来 since) なら全段 0', async () => {
+		const counts = await repo.getActivationFunnelCounts('2099-01-01T00:00:00.000Z', RETENTION_DAYS);
+		expect(counts).toEqual({
+			signupCount: 0,
+			firstChildCount: 0,
+			firstActivityCount: 0,
+			retained7dCount: 0,
+		});
+	});
+});

--- a/tests/unit/db/factory-dsql-branch.test.ts
+++ b/tests/unit/db/factory-dsql-branch.test.ts
@@ -34,6 +34,7 @@ vi.mock('../../../src/lib/server/db/dsql/connection', () => {
 /** Repositories interface の全 key (factory.ts の interface 定義と同期)。 */
 const REPOSITORY_KEYS = [
 	'accountLockout',
+	'activationFunnel',
 	'battle',
 	'cancellationReason',
 	'certificate',

--- a/tests/unit/db/factory-pglite-branch.test.ts
+++ b/tests/unit/db/factory-pglite-branch.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../../src/lib/server/db/pglite/connection', () => {
 /** Repositories interface の全 key (factory.ts の interface 定義と同期)。 */
 const REPOSITORY_KEYS = [
 	'accountLockout',
+	'activationFunnel',
 	'battle',
 	'cancellationReason',
 	'certificate',

--- a/tests/unit/services/analytics-ondemand-service.test.ts
+++ b/tests/unit/services/analytics-ondemand-service.test.ts
@@ -1,0 +1,121 @@
+// tests/unit/services/analytics-ondemand-service.test.ts
+// #3805: on-demand marketing 分析サービスのロジックテスト。
+//
+// repo (単一集約 SQL) は dsql-activation-funnel-repo.test.ts が PGlite 実データで検証する。
+// 本テストは service 層の「件数 → 4 段 funnel step 組立 / 遷移率計算 / cancellation ラップ」を検証する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getActivationFunnelCounts, getCancellationReasonAggregation } = vi.hoisted(() => ({
+	getActivationFunnelCounts: vi.fn(),
+	getCancellationReasonAggregation: vi.fn(),
+}));
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		activationFunnel: { getActivationFunnelCounts },
+	}),
+}));
+
+vi.mock('$lib/server/services/cancellation-service', () => ({
+	getCancellationReasonAggregation,
+}));
+
+import {
+	getActivationFunnelOnDemand,
+	getCancellationReasonsOnDemand,
+} from '../../../src/lib/server/services/analytics-ondemand-service';
+
+describe('analytics-ondemand-service', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('getActivationFunnelOnDemand', () => {
+		it('件数を 4 段 funnel step に組み立て、前段からの遷移率を計算する', async () => {
+			getActivationFunnelCounts.mockResolvedValue({
+				signupCount: 100,
+				firstChildCount: 80,
+				firstActivityCount: 60,
+				retained7dCount: 30,
+			});
+
+			const result = await getActivationFunnelOnDemand('30d');
+
+			expect(result.period).toBe('30d');
+			expect(result.steps).toHaveLength(4);
+			expect(result.steps.map((s) => s.eventName)).toEqual([
+				'activation_signup_completed',
+				'activation_first_child_added',
+				'activation_first_activity_completed',
+				'activation_retained_7d',
+			]);
+			expect(result.steps.map((s) => s.count)).toEqual([100, 80, 60, 30]);
+			// Step 1 の遷移率は常に 1
+			expect(result.steps[0]?.conversionFromPrev).toBe(1);
+			// Step 2 = 80/100
+			expect(result.steps[1]?.conversionFromPrev).toBeCloseTo(0.8);
+			// Step 3 = 60/80
+			expect(result.steps[2]?.conversionFromPrev).toBeCloseTo(0.75);
+			// Step 4 (retention) = 30/60
+			expect(result.steps[3]?.conversionFromPrev).toBeCloseTo(0.5);
+		});
+
+		it('④ は 7 日 retention 窓 (RETENTION_WINDOW_DAYS) で repo を呼ぶ', async () => {
+			getActivationFunnelCounts.mockResolvedValue({
+				signupCount: 0,
+				firstChildCount: 0,
+				firstActivityCount: 0,
+				retained7dCount: 0,
+			});
+
+			await getActivationFunnelOnDemand('7d');
+
+			expect(getActivationFunnelCounts).toHaveBeenCalledTimes(1);
+			const [sinceIso, retentionDays] = getActivationFunnelCounts.mock.calls[0] ?? [];
+			expect(retentionDays).toBe(7);
+			// 7d 期間 → since は約 7 日前
+			expect(typeof sinceIso).toBe('string');
+			const diffDays = (Date.now() - new Date(sinceIso as string).getTime()) / 86_400_000;
+			expect(diffDays).toBeGreaterThan(6.9);
+			expect(diffDays).toBeLessThan(7.1);
+		});
+
+		it('前段が 0 のとき遷移率は 0 (ゼロ除算しない)', async () => {
+			getActivationFunnelCounts.mockResolvedValue({
+				signupCount: 0,
+				firstChildCount: 0,
+				firstActivityCount: 0,
+				retained7dCount: 0,
+			});
+
+			const result = await getActivationFunnelOnDemand('30d');
+			// Step 1 は count=0 でも conversion 1 (定義)、以降は prev=0 → 0
+			expect(result.steps[0]?.conversionFromPrev).toBe(1);
+			expect(result.steps[1]?.conversionFromPrev).toBe(0);
+			expect(result.steps[3]?.conversionFromPrev).toBe(0);
+		});
+	});
+
+	describe('getCancellationReasonsOnDemand', () => {
+		it('cancellation_reasons 集計を DSQL main data から取得しラップする', async () => {
+			getCancellationReasonAggregation.mockResolvedValue({
+				total: 12,
+				breakdown: [{ category: 'price', count: 12, percentage: 100 }],
+			});
+
+			const result = await getCancellationReasonsOnDemand('90d');
+
+			expect(getCancellationReasonAggregation).toHaveBeenCalledWith(90);
+			expect(result.period).toBe('90d');
+			expect(result.total).toBe(12);
+			expect(result.breakdown).toHaveLength(1);
+		});
+
+		it('30d 指定で 30 日窓を渡す', async () => {
+			getCancellationReasonAggregation.mockResolvedValue({ total: 0, breakdown: [] });
+			await getCancellationReasonsOnDemand('30d');
+			expect(getCancellationReasonAggregation).toHaveBeenCalledWith(30);
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

marketing 分析 (activation funnel / 解約率) は PMF の次の一手判断に必須だが、常設収集 + 常設 dashboard は Pre-PMF で過剰 (維持費 <¥100/月 のボトルネック懸念)。本 PR は EPIC #3424 (DSQL 移管) の一環として、**分析を DSQL の main data から必要時のみ導出する on-demand 経路**を新設し、常設収集なしに marketing 分析能力を維持する土台を作る (#3805 Sub-A)。

このリポジトリでは #3805 を 2 段で実装する:
- **本 PR (Sub-A)**: on-demand DSQL 分析サービス新設 + `/ops` 載せ替え (additive・低リスク)
- Sub-B (#3805 本体): DynamoDB analytics の撤去 (always-on 収集 / 日次 cron / provider の除去、DynamoDB table 撤去 = #3438 Phase 3 の gate 解除)

## 関連 Issue

<!-- no-issue-close: #3805 は Sub-B (DynamoDB 収集撤去 / dashboard 撤去 / 依存 0) とあわせて完遂。本 PR は additive Sub-A (funnel on-demand 導出 + /ops 載せ替え) で #3805 を close しない -->
- Refs: #3805 / EPIC #3424 (DynamoDB → Aurora DSQL 移管) / #3438 (DynamoDB 撤去)
- 根拠 ADR: ADR-0065 (DSQL DPU コスト規約) / ADR-0063 (DSQL pool マルチテナント分離) / ADR-0064 (PGlite parity) / ADR-0010 (Pre-PMF scope)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC2 (Sub-A 分) | activation funnel (signup → 初回子供登録 → 初回活動 → 7 日継続) を DSQL main data から on-demand 算出する経路を提供 | `tests/unit/db/dsql-activation-funnel-repo.test.ts` (PGlite 実 schema で単一集約 SQL の 4 段件数を実データ検証) + `tests/unit/services/analytics-ondemand-service.test.ts` (step 組立 / 遷移率) | 8 test 全 PASS。`/ops/analytics` の funnel が DSQL 由来へ載せ替え済 |
| AC2 (cancellation) | 解約率 30d/90d を DSQL の cancellation_reasons から on-demand 算出 | `getCancellationReasonsOnDemand` が `repos.cancellationReason.aggregateRecent` を再利用 (既に DSQL main data 由来) + service test | PASS |
| AC5 | on-demand クエリの DPU コストを ADR-0065 整合で評価 (フルスキャン禁止・必要時のみ実行ゆえ常時コスト 0) | dsql repo は cohort を created_at range で絞り、children / activity_logs を cohort に JOIN した **単一集約 SQL** (N+1 禁止)。実行は認証 ops が必要時のみ = 常時コスト 0 | コード / SQL レビューで確認可能 |
| AC1 / AC3 / AC4 | always-on 収集撤去 / 常設 dashboard 撤去 / DynamoDB analytics 依存 0 | Sub-B (#3805 本体 PR) で対応 | 本 PR scope 外 (Sub-A は additive path のみ) |

## 変更タイプ

- [x] 機能追加 (on-demand 分析サービス + repo 新設)
- [x] リファクタリング (`/ops` funnel の算出元を DynamoDB event 集計 → DSQL on-demand へ載せ替え)
- [ ] バグ修正
- [ ] 破壊的変更

## 影響範囲・変更コンポーネント

- **新規 repo 抽象**: `src/lib/server/db/interfaces/activation-funnel-repo.interface.ts` (`IActivationFunnelRepo`)
- **DSQL 実装**: `src/lib/server/db/dsql/activation-funnel-repo.ts` (families/children/activity_logs を単一集約 SQL で 4 段導出)
- **backend stub**: sqlite / demo / dynamodb の `activation-funnel-repo.ts` (単一テナント or 非分析 backend のため 0 件。sqlite の children には family_id 列がなく cross-tenant cohort funnel は成立しない)
- **factory 配線**: `src/lib/server/db/factory.ts` (`Repositories.activationFunnel` を 5 backend に配線)
- **on-demand service**: `src/lib/server/services/analytics-ondemand-service.ts` (funnel + cancellation)
- **`/ops` 載せ替え**: `src/lib/server/services/ops-analytics-service.ts` が funnel を `getActivationFunnelOnDemand` から取得
- **ラベル**: `OPS_ANALYTICS_LABELS.activationFunnelStepLabels` の ④ を「初回報酬演出」→「7日継続」に置換 (step④ = first_reward_seen は純 UI view でデータ痕跡がなく DSQL から導出不能のため drop、engagement 本質の retention に置換)

## テスト & 安全装置セルフチェック

- [x] unit test 追加: `dsql-activation-funnel-repo.test.ts` (PGlite 実 schema、cohort 境界 / 子供有無 / 非取消活動のみ / retention 窓 / 空 cohort を網羅)
- [x] unit test 追加: `analytics-ondemand-service.test.ts` (4 段 step 組立 / 遷移率 / ゼロ除算防止 / cancellation ラップ)
- [x] factory 網羅 test 更新: `factory-dsql-branch.test.ts` / `factory-pglite-branch.test.ts` の `REPOSITORY_KEYS` に `activationFunnel` 追加
- [x] `npx vitest run` 関連 dir green (新規 8 test + factory branch + ops-analytics + db-access-boundary)
- [x] `npx biome check --error-on-warnings` clean
- [x] `npx svelte-check --threshold error` exit 0
- [x] `route-db-boundary` fitness green (service は getRepos 経由で DB アクセス)

## スクリーンショット / ビジュアルデモ

UI 変更なし。`/ops/analytics` の funnel テーブルは表示構造 (steps × count × 遷移率) を維持し、算出元のみ DynamoDB event 集計 → DSQL on-demand 集計へ差し替え。ラベル ④ が「初回報酬演出」→「7日継続」に変わる文言変更のみ。`/ops` は `AUTH_MODE=cognito` + ops アカウント環境が必要で、本 PR は表示構造不変のため SS 添付なし (funnel データ経路の入れ替えで見た目の骨格は同一)。

## コード品質セルフレビュー (#1481)

- 単一集約 SQL 1 発で 4 段を導出し N+1 を回避 (ADR-0065)。cohort を created_at range で絞り、children / activity_logs を cohort に JOIN して走査対象を cohort 家庭に限定
- cross-tenant 集計は `cancellation-reason-repo.aggregateRecent` と同じ §11.2 明示例外クラスに整合。フルスキャンではなく range + 単一 GROUP BY
- ActivationFunnelResult の shape は `/ops` 表示互換を維持し視覚回帰を最小化
- OSS 先調査 (#1350): 分析集計は既存の drizzle sql 集約 + 既存 repo pattern の踏襲で 10 行超の独自機構を新設していない (cancellation-reason-repo と同型)

## 横展開・影響波及チェック

- 並行実装マップ確認: activation funnel は cross-tenant KPI で、DB スキーマ (families/children/activity_logs) の read のみ。書込 / スキーマ変更なし
- backend parity: dsql/pglite は同一 repo を共有 (ADR-0064)。sqlite/demo/dynamodb は 0 件 stub (単一テナント or 非分析 backend で funnel が成立しない = 挙動非退行、従来も dev/NUC の funnel は空)
- ラベル SSOT: `activationFunnelStepLabels` のキー変更を service の `FUNNEL_STEP_EVENT_NAMES` と一致させ、`/ops` の label lookup が壊れないことを確認

## レビュー依頼事項・破壊的変更

- 破壊的変更なし (additive + 内部算出元の差し替え)
- レビュー観点: (1) 単一集約 SQL の funnel 定義が cohort ベースで妥当か (2) sqlite/demo/dynamodb の 0 件 stub 方針の妥当性 (cross-tenant funnel は multi-tenant cloud = DSQL 専用) (3) step④ を retention に置換した設計判断

## 配布済み env / secret (ADR-0006)

新規 env / secret の追加・削除なし。on-demand 分析は既存 DSQL 接続 (DATA_SOURCE=dsql) をそのまま利用する。

## Ready for Review チェックリスト

- [x] AC 検証マップを記載した (Sub-A scope = AC2 / AC5)
- [x] テストを追加し関連 dir が green
- [x] biome / svelte-check clean
- [x] 設計判断 (step④ drop → retention) を PR body に明記
- [x] Dev 完遂宣言 (#2632): 実装・テスト・自己検証が完了し QM レビュー可能な状態。QM 承認自体は「QM レビュー結果」セクション参照 (本 PR は Draft 据置、`gh pr ready` は実行しない)

## QM レビュー結果

未実施 (Draft)。QM レビューを依頼する。

