### PR TITLE
fix(data-integrity): #3593 point repo hardening — retention cutoff JST 整合 + archived 加点ガード + ledger description SSOT + 退会 PII 回帰固定

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -9381,3 +9381,19 @@ export const UNIFIED_EMPTY_STATE_LABELS = {
 	pickChildHint: '対象の子供を選んでから取り込みできます。',
 	disabledReason: '権限が不足しています',
 } as const;
+
+// #3593 ④: system 生成 ポイント台帳 (point_ledger) description の SSOT。
+// これらは DB に data 値として保存されると同時に、ポイント履歴 UI に表示される system 文言。
+// ADR-0045 に従い service 層のコード直書きを避け、labels compound に集約する
+// (「ポイント」は POINT_TERMS.unitFull atom を参照)。
+export const POINT_LEDGER_LABELS = {
+	/** baby モード初期ポイント付与 (親設定) の ledger description */
+	initialSetup: '親による初期ポイント設定',
+	/** ポイント → おこづかい変換の ledger description (変換モード別サフィックス付き) */
+	convert(amount: number, mode: 'preset' | 'manual' | 'receipt'): string {
+		const base = `${amount}${POINT_TERMS.unitFull}をおこづかいにかえました`;
+		if (mode === 'manual') return `${base}（手動入力）`;
+		if (mode === 'receipt') return `${base}（領収書読み取り）`;
+		return base;
+	},
+} as const;

--- a/src/lib/server/db/dsql/point-repo.ts
+++ b/src/lib/server/db/dsql/point-repo.ts
@@ -134,11 +134,16 @@ export function createDsqlPointRepo<TTx extends SqlExecutor>(
 			// 長期利用 child の大量明細で全 PK を client に materialize する scale/memory リスクがある。
 			// CTE で削除行を DB 側 count(*) 集約し、返るのは単一スカラのみにする (carryover 廃止済 =
 			// reset-plan 決定#4 のため SUM は不要、件数のみ。sqlite 版 `result.changes` と同じ count 契約)。
+			// #3593 ②: cutoffDate (YYYY-MM-DD) は JST 当日境界 (getHistoryCutoffDate SSOT)。
+			// `${cutoffDate}::timestamptz` は session TZ 依存で「session TZ の深夜 0:00」に解釈され、
+			// DSQL の既定 session (UTC) では JST とずれ、0:00〜9:00 JST の明細を 1 日早く削除する
+			// (#729 retention 監査契約違反)。offset 付き ISO8601 (`...T00:00:00+09:00`) を明示連結して
+			// JST 深夜 0:00 の instant に TZ-qualify し、session TZ に依存しない境界に固定する。
 			const deleted = await db.execute(sql`
 				WITH deleted AS (
 					DELETE FROM point_ledger
 					WHERE family_id = ${tenantId} AND child_id = ${childId}
-						AND created_at < ${cutoffDate}::timestamptz
+						AND created_at < (${cutoffDate} || 'T00:00:00+09:00')::timestamptz
 					RETURNING 1
 				)
 				SELECT count(*)::int AS c FROM deleted

--- a/src/lib/server/db/interfaces/point-repo.interface.ts
+++ b/src/lib/server/db/interfaces/point-repo.interface.ts
@@ -30,8 +30,12 @@ export interface IPointRepo {
 	// Retention cleanup (#717, #729)
 	/**
 	 * 指定した子供の `created_at < cutoffDate` に該当する point_ledger を削除する。
-	 * cutoffDate は `YYYY-MM-DD` 形式。`created_at` は ISO timestamp で格納されているため、
-	 * 実装側で `cutoffDate + 'T00:00:00'` との辞書順比較で判定する。
+	 * cutoffDate は `YYYY-MM-DD` 形式で **JST 当日境界** (getHistoryCutoffDate SSOT、#3593 ②)。
+	 * #729: 過去明細のみが消え残高 (total_point) は不触 (carryover 廃止、reset-plan 決定#4)。
+	 * TZ 整合 (#3593 ②): cutoffDate の「当日 0:00」は JST 深夜 0:00 の instant として解釈する。
+	 * - DSQL: `created_at < (cutoffDate || 'T00:00:00+09:00')::timestamptz` で session TZ 非依存に固定。
+	 * - sqlite/dynamodb: `created_at` (ISO/UTC) を cutoffDate と辞書順比較 (date 境界)。
+	 *   JST 正当性は caller (getHistoryCutoffDate) が JST 基準の date を渡すことで担保する。
 	 * @returns 削除件数
 	 */
 	deletePointLedgerBeforeDate(

--- a/src/lib/server/db/interfaces/status-repo.interface.ts
+++ b/src/lib/server/db/interfaces/status-repo.interface.ts
@@ -44,6 +44,17 @@ export interface IStatusRepo {
 		tenantId: string,
 	): Promise<MarketBenchmark | undefined>;
 	findAllBenchmarks(tenantId: string): Promise<MarketBenchmark[]>;
+	/**
+	 * market_benchmarks (世代別平均値) を upsert する。
+	 *
+	 * ⚠️ 書込 authz (#3593 ④、明文化): market_benchmarks は **グローバル master** (tenant 非依存、
+	 * 全テナントで共有される統計基準値) である。したがって本 upsert は「1 テナントの書込が全テナントに
+	 * 波及する」書込であり、**ops/admin 相当の権限に限定**されるべき (通常の保護者操作から到達させない)。
+	 * `tenantId` 引数は audit/observability 用であり分離キーではない (findBenchmark も tenant 非依存で
+	 * 全テナント共通行を返す)。呼出は現状 `/admin/status` (parent-admin ルート、hooks.server.ts の
+	 * admin 認可下) のみ。将来グローバル書込を ops group 限定に厳格化する場合は上位ルート層で行う
+	 * (repo は primitive、権限判断を持たない)。
+	 */
 	upsertBenchmark(
 		age: number,
 		categoryId: CategoryId,

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -4,6 +4,7 @@ import type { ChildId } from '$lib/domain/ids';
 
 import { countsTowardActivityQuota } from '$lib/domain/activity-source';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { todayDateJST } from '$lib/domain/date-utils';
 import { getAuthMode } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { getDebugPlanTier } from '$lib/server/debug-plan';
@@ -162,15 +163,26 @@ export function getPlanLimits(tier: PlanTier): PlanLimits {
 	return PLAN_LIMITS[tier];
 }
 
-/** 保持期間カットオフ日を取得。null = 制限なし */
+/**
+ * 保持期間カットオフ日 (YYYY-MM-DD、JST 基準) を取得。null = 制限なし。
+ *
+ * #3593 ②: JST 深夜境界の TZ 整合。旧実装は `new Date()` + local getter (`getFullYear` 等) で
+ * 日付を導出していたため、Lambda (UTC) 実行時は JST とずれ、0:00〜9:00 JST に記録された明細が
+ * 保持期間判定で 1 日早く削除/残置される (retention 監査契約 #729 違反)。date-utils の
+ * 「サービス層は UTC 混在禁止・todayDateJST 起点」方針に従い、JST 当日を基点に UTC ベースの
+ * 日付演算 (setUTCDate) で days を減算する (runner の local TZ に依存しない)。
+ * 返す cutoff は「JST 当日境界の date」であり、下流 (deletePointLedgerBeforeDate) は
+ * これを JST 深夜 0:00 の instant として TZ-qualified に解釈する。
+ */
 export function getHistoryCutoffDate(tier: PlanTier): string | null {
 	const limits = PLAN_LIMITS[tier];
 	if (limits.historyRetentionDays === null) return null;
-	const d = new Date();
-	d.setDate(d.getDate() - limits.historyRetentionDays);
-	const y = d.getFullYear();
-	const m = String(d.getMonth() + 1).padStart(2, '0');
-	const day = String(d.getDate()).padStart(2, '0');
+	// JST 当日 0:00 を UTC 上の date 演算基点に固定し、local TZ getter を使わない。
+	const d = new Date(`${todayDateJST()}T00:00:00Z`);
+	d.setUTCDate(d.getUTCDate() - limits.historyRetentionDays);
+	const y = d.getUTCFullYear();
+	const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+	const day = String(d.getUTCDate()).padStart(2, '0');
 	return `${y}-${m}-${day}`;
 }
 

--- a/src/lib/server/services/point-service.ts
+++ b/src/lib/server/services/point-service.ts
@@ -2,6 +2,7 @@ import type { ChildId } from '$lib/domain/ids';
 // src/lib/server/services/point-service.ts
 // ポイント管理サービス層
 
+import { POINT_LEDGER_LABELS } from '$lib/domain/labels';
 import { type ConvertMode, POINTS_PER_CONVERT_UNIT } from '$lib/domain/validation/point';
 import {
 	findChildById,
@@ -57,33 +58,31 @@ export async function getPointHistory(
 	return { history };
 }
 
-/** 変換モード別の説明文サフィックス */
-function convertDescription(amount: number, mode: ConvertMode): string {
-	const base = `${amount}ポイントをおこづかいにかえました`;
-	if (mode === 'manual') return `${base}（手動入力）`;
-	if (mode === 'receipt') return `${base}（領収書読み取り）`;
-	return base;
-}
-
 /** baby モードの初期ポイント付与（親が設定した積み立てポイント） */
 export async function grantInitialPoints(
 	childId: ChildId,
 	points: number,
 	tenantId: string,
 ): Promise<
-	{ success: true; balance: number } | { error: 'NOT_FOUND' } | { error: 'INVALID_AMOUNT' }
+	| { success: true; balance: number }
+	| { error: 'NOT_FOUND' }
+	| { error: 'INVALID_AMOUNT' }
+	| { error: 'CHILD_ARCHIVED' }
 > {
 	if (points <= 0 || points > 10000) return { error: 'INVALID_AMOUNT' };
 
 	const child = await findChildById(childId, tenantId);
 	if (!child) return { error: 'NOT_FOUND' };
+	// #3593 ④: insertPointEntry (writer) は is_archived を filter しない primitive のため、
+	// archived な子への加点可否は本 service 層 business rule でガードする (archived = 加点不可)。
+	if (child.isArchived) return { error: 'CHILD_ARCHIVED' };
 
 	await insertPointEntry(
 		{
 			childId,
 			amount: points,
 			type: 'initial_setup',
-			description: '親による初期ポイント設定',
+			description: POINT_LEDGER_LABELS.initialSetup,
 		},
 		tenantId,
 	);
@@ -107,7 +106,7 @@ export async function convertPoints(
 		return { error: 'INSUFFICIENT_POINTS' };
 	}
 
-	const description = convertDescription(amount, mode);
+	const description = POINT_LEDGER_LABELS.convert(amount, mode);
 
 	// ポイント消費エントリを台帳に記録（マイナス値）
 	await insertPointEntry(

--- a/tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts
+++ b/tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts
@@ -135,8 +135,10 @@ const MUTATION_ALLOWLIST: MutationAllowlistEntry[] = [
 		file: 'point-repo.ts',
 		table: 'point_ledger',
 		op: 'DELETE',
-		marker: /created_at\s*<\s*\$\{cutoffDate\}/,
-		reason: 'retention pruning (ADR-0049、保持期間外の物理削除。child 単位 + cutoff 述語)',
+		// #3593 ②: cutoff を JST 深夜 0:00 の instant に TZ-qualify (session TZ 非依存)。
+		marker: /created_at\s*<\s*\(\$\{cutoffDate\}\s*\|\|\s*'T00:00:00\+09:00'\)/,
+		reason:
+			'retention pruning (ADR-0049、保持期間外の物理削除。child 単位 + JST-qualified cutoff 述語、#3593 ②)',
 	},
 	{
 		file: 'status-repo.ts',

--- a/tests/unit/db/dsql-point-status-repos.test.ts
+++ b/tests/unit/db/dsql-point-status-repos.test.ts
@@ -286,6 +286,39 @@ describe('DSQL point-repo / status-repo (PR-R4、実 schema PGlite)', () => {
 		expect(Number((rows.rows[0] as { c: unknown }).c)).toBe(1); // 繰越なし・元 1 件のまま
 	});
 
+	it('[P9c] deletePointLedgerBeforeDate: cutoff を JST 深夜 0:00 境界で TZ-qualified 解釈する (#3593 ②)', async () => {
+		// #3593 ②: cutoffDate は JST 当日境界。deletePointLedgerBeforeDate は
+		// `created_at < cutoffDate::timestamptz` を session TZ 依存で解釈してはならない。
+		// session TZ を UTC に固定した状態で「JST cutoff 当日の未明 (UTC 前日 20:00) の明細」が
+		// 保持 (非削除) されることを検証する。旧実装 (session TZ 依存) では UTC 深夜 0:00 境界に
+		// なり、この明細を誤って削除してしまう。
+		await t.db.execute(sql`SET TIME ZONE 'UTC'`);
+		const childId = await newChild('境界十二郎');
+		const id = String(childId);
+		// Row A: created_at 2026-01-14T20:00Z = JST 2026-01-15 05:00 (business day = cutoff 当日) → 保持
+		// Row B: created_at 2026-01-14T10:00Z = JST 2026-01-14 19:00 (cutoff 前日) → 削除
+		await t.db.execute(sql`
+			INSERT INTO point_ledger (family_id, child_id, amount, type, recorded_date, created_at)
+			VALUES
+				(${FAMILY}, ${id}, 10, 'activity', '2026-01-15', '2026-01-14T20:00:00Z'),
+				(${FAMILY}, ${id}, 5, 'activity', '2026-01-14', '2026-01-14T10:00:00Z')
+		`);
+		await t.db.execute(
+			sql`UPDATE children SET total_point = 15 WHERE family_id = ${FAMILY} AND child_id = ${id}`,
+		);
+
+		const deleted = await pointRepo.deletePointLedgerBeforeDate(childId, '2026-01-15', FAMILY);
+		// JST 境界解釈: cutoff 前日の Row B (5) のみ削除。cutoff 当日未明の Row A (10) は保持。
+		expect(deleted).toBe(1);
+		const remaining = await t.db.execute(sql`
+			SELECT amount FROM point_ledger
+			WHERE family_id = ${FAMILY} AND child_id = ${id} ORDER BY amount
+		`);
+		const rows = remaining.rows as { amount: number }[];
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.amount).toBe(10); // JST cutoff 当日の明細は残る
+	});
+
 	it('[P11] spendPointsAtomic 二重引落: FOR UPDATE で残高非負維持 (I-BAL-NONNEG)', async () => {
 		// I-BAL-NONNEG (§6.6, F7): 残高 30 に対し 20 の spend を 2 本並行させる。FOR UPDATE の
 		// write-intent により高々 1 本のみ成功し、最終残高は非負 (真の 40001 write-skew 阻止は
@@ -344,6 +377,39 @@ describe('DSQL point-repo / status-repo (PR-R4、実 schema PGlite)', () => {
 		expect(found?.nickname).toBe('存在確認');
 		expect(found?.age).toBe(8);
 		expect(found?.isArchived).toBe(0);
+	});
+
+	it('[P12] child 削除で PII (children 行) + point_ledger が同一 txn 消去される (#3593 ③ 退会 PII)', async () => {
+		// #3593 ③: point-repo.deleteByTenantId は ledger のみ削除する primitive (children 行 =
+		// nickname/birth_date PII は不触)。退会時の PII 物理消去は child 削除 cascade
+		// (deleteChild → children + child-scoped 全表を同一 txn 削除) が担う。本 test は
+		// 「child を消すと point_ledger も children (PII) も両方消える」cutover 配線を回帰固定する。
+		const childId = await newChild('退会PII太郎');
+		const id = String(childId);
+		await pointRepo.insertPointEntry(
+			{ childId, amount: 40, type: 'activity', description: 'x' },
+			FAMILY,
+		);
+		// 削除前: children (PII) + point_ledger の双方が存在
+		const beforeChild = await pointRepo.findChildById(childId, FAMILY);
+		expect(beforeChild?.nickname).toBe('退会PII太郎');
+		const ledgerCount = async () => {
+			const r = await t.db.execute(
+				sql`SELECT count(*)::int AS c FROM point_ledger WHERE family_id = ${FAMILY} AND child_id = ${id}`,
+			);
+			return Number((r.rows[0] as { c: number }).c);
+		};
+		expect(await ledgerCount()).toBe(1);
+
+		await childRepo.deleteChild(childId, FAMILY);
+
+		// 削除後: children 行 (PII) が消え、point_ledger も消えている
+		const piiRow = await t.db.execute(
+			sql`SELECT nickname, birth_date FROM children WHERE family_id = ${FAMILY} AND child_id = ${id}`,
+		);
+		expect(piiRow.rows).toHaveLength(0);
+		expect(await pointRepo.findChildById(childId, FAMILY)).toBeUndefined();
+		expect(await ledgerCount()).toBe(0);
 	});
 
 	// ─────────────────── IStatusRepo ───────────────────

--- a/tests/unit/services/plan-limit-service.test.ts
+++ b/tests/unit/services/plan-limit-service.test.ts
@@ -346,23 +346,30 @@ describe('plan-limit-service', () => {
 	});
 
 	describe('getHistoryCutoffDate', () => {
-		it('free: returns date 90 days ago', () => {
-			const cutoff = getHistoryCutoffDate('free');
-			expect(cutoff).not.toBeNull();
-			// 実装と同じロジックで期待値を算出（setDate ベース）
-			const expected = new Date();
-			expected.setDate(expected.getDate() - 90);
-			const expectedStr = `${expected.getFullYear()}-${String(expected.getMonth() + 1).padStart(2, '0')}-${String(expected.getDate()).padStart(2, '0')}`;
-			expect(cutoff).toBe(expectedStr);
+		afterEach(() => {
+			vi.useRealTimers();
 		});
 
-		it('standard: returns date 365 days ago', () => {
+		/** JST 基準で `todayJst - days` の YYYY-MM-DD を算出（runner の local TZ 非依存）。 */
+		const jstCutoff = (todayJst: string, days: number): string => {
+			const d = new Date(`${todayJst}T00:00:00Z`);
+			d.setUTCDate(d.getUTCDate() - days);
+			return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+		};
+
+		it('free: returns date 90 days ago (JST 基準)', () => {
+			const cutoff = getHistoryCutoffDate('free');
+			expect(cutoff).not.toBeNull();
+			// #3593 ②: JST 基準（todayDateJST 起点）で期待値を算出。実 impl と独立に JST 減算する。
+			const todayJst = new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+			expect(cutoff).toBe(jstCutoff(todayJst, 90));
+		});
+
+		it('standard: returns date 365 days ago (JST 基準)', () => {
 			const cutoff = getHistoryCutoffDate('standard');
 			expect(cutoff).not.toBeNull();
-			const expected = new Date();
-			expected.setDate(expected.getDate() - 365);
-			const expectedStr = `${expected.getFullYear()}-${String(expected.getMonth() + 1).padStart(2, '0')}-${String(expected.getDate()).padStart(2, '0')}`;
-			expect(cutoff).toBe(expectedStr);
+			const todayJst = new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+			expect(cutoff).toBe(jstCutoff(todayJst, 365));
 		});
 
 		it('family: returns null (no limit)', () => {
@@ -373,6 +380,19 @@ describe('plan-limit-service', () => {
 		it('cutoff date format is YYYY-MM-DD', () => {
 			const cutoff = getHistoryCutoffDate('free');
 			expect(cutoff).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		});
+
+		// #3593 ②: JST 深夜境界の TZ 整合。UTC 上では前日だが JST では当日となる瞬間
+		// (UTC 20:00 = JST 翌 05:00) では、cutoff は JST 当日基準で算出されねばならない。
+		// 旧実装は new Date() + local getters で Lambda(UTC) だと 1 日ずれ、0:00〜9:00 JST に
+		// 記録された明細が保持期間判定で 1 日早く削除/残置される (retention 監査契約 #729 違反)。
+		it('JST 深夜境界: UTC 前日 20:00 (=JST 当日 05:00) でも cutoff は JST 当日基準', () => {
+			// 2026-01-14T20:00:00Z ⇔ JST 2026-01-15 05:00。JST today = 2026-01-15。
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-01-14T20:00:00Z'));
+			// free = 90 日: 2026-01-15 − 90 日 = 2025-10-17 (JST 基準)。
+			// 旧 UTC-local 実装なら 2026-01-14 − 90 日 = 2025-10-16 となり 1 日ずれる。
+			expect(getHistoryCutoffDate('free')).toBe('2025-10-17');
 		});
 	});
 

--- a/tests/unit/services/point-service.test.ts
+++ b/tests/unit/services/point-service.test.ts
@@ -27,10 +27,12 @@ vi.mock('$lib/server/db/client', () => ({
 	},
 }));
 
+import { POINT_LEDGER_LABELS } from '../../../src/lib/domain/labels';
 import {
 	convertPoints,
 	getPointBalance,
 	getPointHistory,
+	grantInitialPoints,
 } from '../../../src/lib/server/services/point-service';
 
 beforeAll(() => {
@@ -89,6 +91,52 @@ describe('point-service', () => {
 	it('存在しない子供のポイント残高はNOT_FOUND', async () => {
 		const result = await getPointBalance(asChildId(999), 'test-tenant');
 		expect(result).toEqual({ error: 'NOT_FOUND' });
+	});
+
+	// #3593 ④: archived child への加点は service 層 business rule で拒否する (repo は primitive)。
+	// insertPointEntry (writer) は is_archived を filter せず total_point を加点するため、
+	// 「archived な子には加点しない」判断は service で担保する。
+	describe('grantInitialPoints: archived 子への加点ガード (#3593 ④)', () => {
+		function seedArchivedChild() {
+			resetDb();
+			testDb
+				.insert(schema.children)
+				.values({ nickname: 'アーカイブちゃん', age: 4, theme: 'pink', isArchived: 1 })
+				.run();
+		}
+
+		it('archived child への grantInitialPoints は CHILD_ARCHIVED を返し加点しない', async () => {
+			seedArchivedChild();
+			const result = await grantInitialPoints(asChildId(1), 500, 'test-tenant');
+			expect(result).toEqual({ error: 'CHILD_ARCHIVED' });
+			// 加点されていない (total は 0 のまま)
+			const rows = testDb.select().from(schema.pointLedger).all();
+			expect(rows.length).toBe(0);
+		});
+
+		it('active child への grantInitialPoints は成功して加点する', async () => {
+			seedChild(); // active child (isArchived 未指定 = 0)
+			const result = assertSuccess(await grantInitialPoints(asChildId(1), 500, 'test-tenant'));
+			expect(result.balance).toBe(500);
+		});
+	});
+
+	// #3593 ④: system 生成 ledger description は labels SSOT (POINT_LEDGER_LABELS) 経由。
+	// UI (ポイント履歴) に表示される system 文言をコード直書きせず 1 箇所に集約する (ADR-0045)。
+	describe('ledger description は labels SSOT 経由 (#3593 ④)', () => {
+		it('grantInitialPoints の description は POINT_LEDGER_LABELS.initialSetup と一致', async () => {
+			seedChild();
+			assertSuccess(await grantInitialPoints(asChildId(1), 100, 'test-tenant'));
+			const rows = testDb.select().from(schema.pointLedger).all();
+			expect(rows[0]?.description).toBe(POINT_LEDGER_LABELS.initialSetup);
+		});
+
+		it('convertPoints の description は POINT_LEDGER_LABELS.convert(mode) と一致', async () => {
+			seedChild();
+			addPoints(1, 1000, 'activity', '元手');
+			const result = assertSuccess(await convertPoints(asChildId(1), 500, 'test-tenant', 'manual'));
+			expect(result.message).toBe(POINT_LEDGER_LABELS.convert(500, 'manual'));
+		});
 	});
 
 	// 履歴取得


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（データ整合性・プライバシー COPPA/GDPR）

**解決する課題**: 保持期間（retention）ポイント台帳削除の日付境界が UTC 基準のため、深夜 0:00〜9:00 JST に記録された明細が 1 日ずれて削除/残置される（#729 retention 監査契約違反）。あわせて archived な子への誤加点、ポイント履歴の system 文言のハードコード、退会時 PII 物理消去の回帰未固定があった。

**期待される効果**: retention 削除境界を JST に整合、archived 子への加点を service 層でガード、ledger description を SSOT 化、退会 PII cascade を回帰テストで固定。

## 関連 Issue

closes #3593

関連: PR #3591 / #3624（① DB count 集約、実装済）/ EPIC #3424 §12.2 / #729 retention 監査契約 / ADR-0049 / ADR-0055 / ADR-0061 / ADR-0045（terms SSOT）。① carryover DB 集約は #3624 で既に count(*) 集約済のため本 PR は回帰固定のみ。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| ① | carryover removedSum を DB 側集約に置換 | `npx vitest run tests/unit/db/dsql-point-status-repos.test.ts` P9/P9b | 既に #3624 で CTE count(*) 集約済。P9/P9b が回帰固定（本 PR 変更なし） |
| ②A | getHistoryCutoffDate の JST 境界整合 | `TZ=UTC npx vitest run tests/unit/services/plan-limit-service.test.ts -t "getHistoryCutoffDate"` | HEAD fb3297068746010b3b29d0f53b5b63b51caeb363 / red（2025-10-16 を期待 2025-10-17）→ green 5 passed（TZ=UTC / Asia/Tokyo 両方） |
| ②B | DSQL cutoff の TZ-anchored 化 | `npx vitest run tests/unit/db/dsql-point-status-repos.test.ts -t "P9c"` | HEAD fb3297068746010b3b29d0f53b5b63b51caeb363 / red（JST cutoff 当日行を誤削除 expected 2 to be 1）→ green 22 passed |
| ③ | deleteByTenantId 後の PII 消去経路 | `npx vitest run tests/unit/db/dsql-point-status-repos.test.ts -t "P12"` | HEAD fb3297068746010b3b29d0f53b5b63b51caeb363 / point repo deleteByTenantId は ledger primitive。退会 PII 消去は child 削除 cascade（同一 txn）が担う配線を [P12] で回帰固定。green |
| ④ | archived 加点ガード / ledger description SSOT / market_benchmarks authz 明文化 | `npx vitest run tests/unit/services/point-service.test.ts` | HEAD fb3297068746010b3b29d0f53b5b63b51caeb363 / grantInitialPoints に CHILD_ARCHIVED ガード、system description を POINT_LEDGER_LABELS に集約、upsertBenchmark authz を interface に明文化。19 passed |

## 変更タイプ

- [x] fix: バグ修正
- [x] refactor: リファクタリング
- [x] test: テスト改善
- [x] docs: ドキュメント

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ / repo (`$lib/server/db/`) — dsql/point-repo.ts（cutoff TZ-qualify）+ interface doc
- [x] サービス層 (`$lib/server/services/`) — plan-limit-service（JST cutoff）/ point-service（archived ガード + description SSOT）
- [x] ドメインモデル (`$lib/domain/`) — labels.ts（POINT_LEDGER_LABELS 追加、POINT_TERMS atom 参照）

**影響を受ける画面・機能**: retention cleanup の日付境界（JST 化）、baby モード初期ポイント付与（archived ガード）。ledger description の DB 保存値・UI 表示は不変（同一文字列を SSOT 経由に置換）。

## テスト & 安全装置セルフチェック

- [x] targeted 検証コマンド（main tree で実行）:
- [x] `npx vitest run tests/unit/services/plan-limit-service.test.ts tests/unit/services/point-service.test.ts tests/unit/db/dsql-point-status-repos.test.ts tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts` → 127 passed
- [x] `node scripts/check-no-plan-literals.mjs` → OK / `node scripts/check-hardcoded-strings.mjs` → 0 violations / `node scripts/generate-lp-labels.mjs --check` → 最新
- [x] `npx biome check` → 10 file clean / `npx cspell` → exit 0 / `npx svelte-check` → 0 error (8230 files)
- [x] 追加・変更したテスト: plan-limit（JST 深夜境界）/ point-service（archived ガード + description SSOT）/ dsql-point-status [P9c] TZ 境界 + [P12] PII cascade。append-only allowlist は既存 retention DELETE の marker を新 SQL に追随（新規 mutation なし）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A（archived ガード・description は service 層で全 backend 適用。TZ は DSQL 該当実装、sqlite/dynamodb は date-lexical 比較で JST cutoff を受ける、demo は stub）
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし**: server / repo / service 層のみで UI 差分なし（ledger description は同一文字列を SSOT 経由に置換したのみで表示不変）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: repo は primitive 維持（archived 判断・権限判断を持ち込まない）。business rule は service、権限は上位ルート層に配置
- [x] **DRY**: description を POINT_TERMS atom 参照の compound（ADR-0045）に集約
- [x] **YAGNI**: 0 行 emit を loud throw に留め余計な fallback を作らない
- [x] **Security**: 退会 PII cascade を回帰固定、archived 子への誤加点をガード
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: TZ 整合は caller が JST date 算出 + DSQL repo が JST 深夜 instant に TZ-qualify（session TZ 非依存）。N+1 なし

## 横展開・影響波及チェック

- [x] **backend parity**: archived ガード・description SSOT は service 層で dsql/sqlite/dynamodb/demo 一律適用。TZ 修正は DSQL 該当実装、sqlite/dynamodb は date-lexical 比較、demo は stub
- [x] **labels SSOT** (ADR-0045): POINT_LEDGER_LABELS を POINT_TERMS atom 参照で追加、リテラル直書きなし（check-no-plan-literals OK）
- [x] **設計書同期** (ADR-0001): interface doc に TZ 契約 / authz を明記。挙動仕様の設計変更なし
- [x] N/A — 本番アプリ+デモ / LP / 年齢モード / ナビ

**LP / 販促文言変更時**: N/A（POINT_LEDGER_LABELS は内部 ledger 文言、LP 非波及。generate-lp-labels --check 最新）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（grantInitialPoints 返り値 union に CHILD_ARCHIVED 追加は既存呼出側の else 分岐が 404 にフォールバック）

**レビュー依頼事項・QA**: ② の TZ 整合（getHistoryCutoffDate = JST date 算出 / DSQL cutoff = +09:00 offset で instant 化）が retention / 履歴フィルタ全般に一貫適用されているか、④ market_benchmarks の upsertBenchmark authz 明文化（グローバル master 書込 = ops/admin 相当限定）の範囲をご確認願います。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] vitest 127 passed / label 系 gate（no-plan-literals / hardcoded-strings / lp-labels）/ biome / cspell / svelte-check clean をローカル確認（main tree）
- [x] failing-test-first: ②A / ②B / ④ を red→green で実証（ADR-0061）
- [x] 全 AC が実装済み（① は #3624 で解消済・回帰固定、②③④ 完遂）
- [x] Phase 分割なし
- [x] UI 変更なし
- [x] 認証画面変更なし

## QM レビュー結果

<!-- QM 記入 -->
