### PR TITLE
fix(data-integrity): #3566 child 集約 Slice B — reward snapshot 権威 (LEFT JOIN) + storage key tenant-scoped guard + granted_by 監査

### DIFF
--- a/src/lib/server/db/dsql/image-repo.ts
+++ b/src/lib/server/db/dsql/image-repo.ts
@@ -14,6 +14,7 @@
 
 import { sql } from 'drizzle-orm';
 import { asChildId } from '$lib/domain/ids';
+import { assertTenantScopedStorageKey } from '$lib/server/storage-keys';
 import type { IImageRepo } from '../interfaces/image-repo.interface';
 import type { CharacterImage } from '../types';
 import { CHILD_COLUMNS, type ChildRow, toChild } from './child-repo';
@@ -56,6 +57,10 @@ export function createDsqlImageRepo(db: SqlExecutor): IImageRepo {
 		},
 
 		async insertCharacterImage(input, tenantId) {
+			// #3566 ③ (§9.4): file_path が tenant プレフィックス配下であることを DB 書込前に強制する。
+			// prefix 外 / cross-tenant key を永続化すると account 削除の deleteByPrefix で消えない
+			// 孤児バイト (COPPA/GDPR) や越境参照 (IDOR/LFI) を生む。mis-scoped は throw で拒否。
+			assertTenantScopedStorageKey(input.filePath, tenantId);
 			await db.execute(sql`
 				INSERT INTO character_images (family_id, child_id, type, file_path, prompt_hash)
 				VALUES (${tenantId}, ${input.childId}, ${input.type}, ${input.filePath},

--- a/src/lib/server/db/dsql/reward-redemption-repo.ts
+++ b/src/lib/server/db/dsql/reward-redemption-repo.ts
@@ -74,9 +74,12 @@ function toRequestRow(row: RequestRow): RedemptionRequestRow {
 }
 
 // #2832 snapshot fallback: 申請時点 snapshot を優先し、旧行 (NULL) は live JOIN 値に fallback。
-const SNAPSHOT_TITLE = sql`COALESCE(rr.reward_title, sr.title)`;
+// #3566 ①: JOIN は LEFT JOIN のため reward 削除後は sr.* が NULL になりうる。snapshot が権威
+// (申請時点の約束を守る) であり、reward 消失 + 旧行 (snapshot NULL) の稀ケースにも非 NULL の
+// 既定値 (title='' / points=0) を返して RedemptionRequestWithDetails の型契約 (非 null) を満たす。
+const SNAPSHOT_TITLE = sql`COALESCE(rr.reward_title, sr.title, '')`;
 const SNAPSHOT_ICON = sql`COALESCE(rr.reward_icon, sr.icon)`;
-const SNAPSHOT_POINTS = sql`COALESCE(rr.reward_points, sr.points)`;
+const SNAPSHOT_POINTS = sql`COALESCE(rr.reward_points, sr.points, 0)`;
 
 /**
  * DSQL 用 IRewardRedemptionRepo を生成する (db/runner は注入、fitness#8)。
@@ -180,7 +183,7 @@ export function createDsqlRewardRedemptionRepo<TTx extends SqlExecutor>(
 					${SNAPSHOT_POINTS} AS reward_points
 				FROM reward_redemption_requests rr
 				JOIN children c ON c.family_id = rr.family_id AND c.child_id = rr.child_id
-				JOIN special_rewards sr
+				LEFT JOIN special_rewards sr
 					ON sr.family_id = rr.family_id AND sr.child_id = rr.child_id AND sr.reward_id = rr.reward_id
 				WHERE ${tenantConditions(tenantId, opts)}
 				ORDER BY rr.requested_at DESC, rr.redemption_id DESC
@@ -242,7 +245,7 @@ export function createDsqlRewardRedemptionRepo<TTx extends SqlExecutor>(
 					rr.parent_note, rr.resolved_at, rr.resolved_by_parent_id, rr.shown_to_child_at,
 					${SNAPSHOT_TITLE} AS reward_title, ${SNAPSHOT_ICON} AS reward_icon
 				FROM reward_redemption_requests rr
-				JOIN special_rewards sr
+				LEFT JOIN special_rewards sr
 					ON sr.family_id = rr.family_id AND sr.child_id = rr.child_id AND sr.reward_id = rr.reward_id
 				WHERE rr.family_id = ${tenantId} AND rr.child_id = ${childId}
 					AND rr.status IN ('approved', 'rejected') AND rr.shown_to_child_at IS NULL

--- a/src/lib/server/db/dsql/sibling-cheer-repo.ts
+++ b/src/lib/server/db/dsql/sibling-cheer-repo.ts
@@ -82,15 +82,32 @@ export function createDsqlSiblingCheerRepo(db: SqlExecutor): ISiblingCheerRepo {
 		},
 
 		async insertForRestore(input, tenantId) {
-			// #3329: sent_at / shown_at を verbatim 書き戻す (from/to は呼び出し側が解決済)。
+			// #3329: sent_at / shown_at を verbatim 書き戻す。
+			// #3566 ②: restore 入力は untrusted backup 由来のため、insertCheer と同型に
+			// from/to child ∈ family を INSERT ... SELECT JOIN children で構造強制する
+			// (storage-key の insertForRestore が assertTenantScopedStorageKey で repo 入口を
+			// 防御するのと同じ defense-in-depth)。caller (import-service) は childRef を解決済だが、
+			// crafted backup / 解決バグで family 外・dangling な child を差し込む余地を repo で塞ぐ。
+			// どちらかが tenant の children に不在なら SELECT 0 行 → 挿入なし → RETURNING 空 → throw。
+			// sent_at / shown_at は明示 ::timestamptz cast で verbatim 保全する (shown_at=null は
+			// NULL::timestamptz = NULL)。SELECT 射影列は VALUES と違い型が明示されないため cast する。
 			const result = await db.execute(sql`
 				INSERT INTO sibling_cheers
 					(family_id, from_child_id, to_child_id, stamp_code, sent_at, shown_at)
-				VALUES (${tenantId}, ${input.fromChildId}, ${input.toChildId}, ${input.stampCode},
-					${input.sentAt}, ${input.shownAt})
+				SELECT cf.family_id, cf.child_id, ct.child_id, ${input.stampCode},
+					${input.sentAt}::timestamptz, ${input.shownAt}::timestamptz
+				FROM children cf
+				JOIN children ct ON ct.family_id = cf.family_id AND ct.child_id = ${input.toChildId}
+				WHERE cf.family_id = ${tenantId} AND cf.child_id = ${input.fromChildId}
 				RETURNING ${CHEER_COLUMNS}
 			`);
-			return toCheer(result.rows[0] as unknown as CheerRow);
+			const row = result.rows[0] as unknown as CheerRow | undefined;
+			if (!row) {
+				// from / to のどちらかが tenant の children に不在 (cross-family 混入 or dangling child)。
+				// 戻り値契約 (Promise<SiblingCheer>、非 null) を保つため throw で拒否する (insertCheer と同型)。
+				throw new Error('sibling cheer restore rejected: from/to child not in family');
+			}
+			return toCheer(row);
 		},
 
 		async findUnshownCheers(toChildId, tenantId) {

--- a/src/lib/server/db/dsql/voice-repo.ts
+++ b/src/lib/server/db/dsql/voice-repo.ts
@@ -17,6 +17,7 @@
 
 import { sql } from 'drizzle-orm';
 import { asChildId } from '$lib/domain/ids';
+import { assertTenantScopedStorageKey } from '$lib/server/storage-keys';
 import type { TransactionRunner } from '../interfaces/transaction.interface';
 import type { IVoiceRepo } from '../interfaces/voice-repo.interface';
 import type { ChildCustomVoice } from '../types';
@@ -86,6 +87,9 @@ export function createDsqlVoiceRepo<TTx extends SqlExecutor>(
 		},
 
 		async insert(voice) {
+			// #3566 ③ (§9.4): file_path が tenant プレフィックス配下であることを DB 書込前に強制する
+			// (孤児バイト / cross-tenant 参照防止、image-repo と同判断)。voice.tenantId が family scope の正。
+			assertTenantScopedStorageKey(voice.filePath, voice.tenantId);
 			// isActive number(0/1) → boolean。voice.tenantId が family scope の正 (非 restore 経路)。
 			const result = await db.execute(sql`
 				INSERT INTO child_custom_voices
@@ -105,6 +109,9 @@ export function createDsqlVoiceRepo<TTx extends SqlExecutor>(
 			// #3329 backup restore: created_at / file_path / public_url / is_active を verbatim 保全。
 			// voice_id は新規採番 (schema default)。tenantId 引数が復元先 family の正 (voice.tenantId は
 			// export 時点の旧値のため使わない、certificate insertForRestore と同判断)。
+			// #3566 ③ (§9.4): 呼び出し側 (import-service) は file_path を復元先 tenant へ再キー済だが、
+			// untrusted backup 由来のため repo 入口でも tenant プレフィックスを強制する (cross-tenant LFI 防止)。
+			assertTenantScopedStorageKey(voice.filePath, tenantId);
 			const result = await db.execute(sql`
 				INSERT INTO child_custom_voices
 					(family_id, child_id, scene, label, file_path, public_url, duration_ms, is_active,

--- a/src/lib/server/db/dynamodb/image-repo.ts
+++ b/src/lib/server/db/dynamodb/image-repo.ts
@@ -4,6 +4,7 @@
 import { GetCommand, PutCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type { ChildId } from '$lib/domain/ids';
 import { asChildId } from '$lib/domain/ids';
+import { assertTenantScopedStorageKey } from '$lib/server/storage-keys';
 import type { CharacterImage, InsertCharacterImageInput } from '../types';
 import { deleteChildScopedItems } from './bulk-delete';
 import { getDocClient, TABLE_NAME } from './client';
@@ -43,6 +44,8 @@ export async function insertCharacterImage(
 	input: InsertCharacterImageInput,
 	tenantId: string,
 ): Promise<void> {
+	// #3566 ③ (§9.4): file_path が tenant プレフィックス配下必須 (孤児バイト防止、DSQL と整合)。
+	assertTenantScopedStorageKey(input.filePath, tenantId);
 	const id = await nextId(ENTITY_NAMES.characterImage, tenantId);
 	const now = new Date().toISOString();
 

--- a/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
+++ b/src/lib/server/db/dynamodb/sibling-cheer-repo.ts
@@ -22,14 +22,20 @@
 //
 // 関連: ADR-0055 / docs/design/08-データベース設計書.md / sqlite/sibling-cheer-repo.ts (SSOT)
 
-import { PutCommand, QueryCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import {
+	GetCommand,
+	PutCommand,
+	QueryCommand,
+	ScanCommand,
+	UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
 import { todayDateJST } from '$lib/domain/date-utils';
 import type { ChildId } from '$lib/domain/ids';
 import { asChildId } from '$lib/domain/ids';
 import type { InsertSiblingCheerInput, SiblingCheer } from '../types';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
-import { ENTITY_NAMES, siblingCheerKey, siblingCheerPrefix, tenantPK } from './keys';
+import { childKey, ENTITY_NAMES, siblingCheerKey, siblingCheerPrefix, tenantPK } from './keys';
 import { stripKeys } from './repo-helpers';
 
 const PREFIX = siblingCheerPrefix();
@@ -117,6 +123,24 @@ export async function insertForRestore(
 	input: Omit<SiblingCheer, 'id' | 'tenantId'>,
 	tenantId: string,
 ): Promise<SiblingCheer> {
+	// #3566 ②: restore 入力は untrusted backup 由来のため、from/to child が同 tenant に
+	// 実在する (= 同 family に属する) ことを書込前に強制する。DSQL insertForRestore の
+	// INSERT ... SELECT JOIN children guard / storage-key の assertTenantScopedStorageKey と
+	// 同型の defense-in-depth (dangling / cross-tenant 拒否)。childKey は PK に tenantId を
+	// 埋めるため、GetItem が空 = その child は tenant に存在しない → throw で拒否する
+	// (採番より先に検証し、拒否時は counter を消費しない)。
+	const doc = getDocClient();
+	const [fromChild, toChild] = await Promise.all([
+		doc.send(
+			new GetCommand({ TableName: TABLE_NAME, Key: childKey(Number(input.fromChildId), tenantId) }),
+		),
+		doc.send(
+			new GetCommand({ TableName: TABLE_NAME, Key: childKey(Number(input.toChildId), tenantId) }),
+		),
+	]);
+	if (!fromChild.Item || !toChild.Item) {
+		throw new Error('sibling cheer restore rejected: from/to child not in family');
+	}
 	const id = await nextId(ENTITY_NAMES.siblingCheer, tenantId);
 	const cheer: SiblingCheer = { ...input, id: String(id), tenantId };
 	await getDocClient().send(

--- a/src/lib/server/db/dynamodb/voice-repo.ts
+++ b/src/lib/server/db/dynamodb/voice-repo.ts
@@ -7,6 +7,7 @@ import {
 } from '@aws-sdk/lib-dynamodb';
 import type { ChildId } from '$lib/domain/ids';
 import { asChildId } from '$lib/domain/ids';
+import { assertTenantScopedStorageKey } from '$lib/server/storage-keys';
 import type { ChildCustomVoice } from '../types';
 import { getDocClient, TABLE_NAME } from './client';
 import { nextId } from './counter';
@@ -88,6 +89,8 @@ export async function findActiveVoice(
 export async function insert(
 	voice: Omit<ChildCustomVoice, 'id' | 'createdAt'>,
 ): Promise<{ id: string }> {
+	// #3566 ③ (§9.4): file_path が tenant プレフィックス配下必須 (孤児バイト防止、DSQL と整合)。
+	assertTenantScopedStorageKey(voice.filePath, voice.tenantId);
 	const id = await nextId('voice', voice.tenantId);
 	const now = new Date().toISOString();
 	await getDocClient().send(
@@ -135,6 +138,8 @@ export async function insertForRestore(
 	voice: Omit<ChildCustomVoice, 'id'>,
 	_tenantId: string,
 ): Promise<{ id: string }> {
+	// #3566 ③ (§9.4): 復元行の file_path も tenant プレフィックス強制 (cross-tenant LFI 防止)。
+	assertTenantScopedStorageKey(voice.filePath, voice.tenantId);
 	const id = await nextId('voice', voice.tenantId);
 	await getDocClient().send(
 		new PutCommand({

--- a/src/lib/server/db/sqlite/image-repo.ts
+++ b/src/lib/server/db/sqlite/image-repo.ts
@@ -3,6 +3,7 @@
 
 import { and, eq } from 'drizzle-orm';
 import { asChildId, type ChildId } from '$lib/domain/ids';
+import { assertTenantScopedStorageKey } from '$lib/server/storage-keys';
 import { db } from '../client';
 import { characterImages, children } from '../schema';
 import type { CharacterImage, Child, InsertCharacterImageInput } from '../types';
@@ -29,7 +30,10 @@ export async function findCachedImage(
 }
 
 /** 画像レコードを挿入 */
-export async function insertCharacterImage(input: InsertCharacterImageInput, _tenantId: string) {
+export async function insertCharacterImage(input: InsertCharacterImageInput, tenantId: string) {
+	// #3566 ③ (§9.4): file_path が tenant プレフィックス配下であることを DB 書込前に強制する
+	// (孤児バイト / cross-tenant 参照防止、DSQL image-repo と cross-backend 整合)。
+	assertTenantScopedStorageKey(input.filePath, tenantId);
 	db.insert(characterImages)
 		.values({ ...input, childId: Number(input.childId) })
 		.run();

--- a/src/lib/server/db/sqlite/reward-redemption-repo.ts
+++ b/src/lib/server/db/sqlite/reward-redemption-repo.ts
@@ -33,11 +33,14 @@ const THIRTY_DAYS_SECONDS = 30 * 24 * 60 * 60;
 // 新規行は insert 時に reward_* snapshot を保存し、編集後も「申請時点の内容 (名前/ポイント)」で
 // 表示・控除する (DynamoDB 非正規化 item と等価の仕様)。snapshot 列導入前の旧行 (NULL) は
 // live JOIN 値に fallback する。
-const snapshotTitle = sql<string>`COALESCE(${rewardRedemptionRequests.rewardTitle}, ${specialRewards.title})`;
+// #3566 ①: JOIN は leftJoin のため reward 削除後は specialRewards.* が NULL になりうる。snapshot が
+// 権威 (申請時点の約束) であり、reward 消失 + 旧行 (snapshot NULL) の稀ケースにも非 NULL 既定値
+// (title='' / points=0) を返して WithDetails の型契約を満たす。
+const snapshotTitle = sql<string>`COALESCE(${rewardRedemptionRequests.rewardTitle}, ${specialRewards.title}, '')`;
 const snapshotIcon = sql<
 	string | null
 >`COALESCE(${rewardRedemptionRequests.rewardIcon}, ${specialRewards.icon})`;
-const snapshotPoints = sql<number>`COALESCE(${rewardRedemptionRequests.rewardPoints}, ${specialRewards.points})`;
+const snapshotPoints = sql<number>`COALESCE(${rewardRedemptionRequests.rewardPoints}, ${specialRewards.points}, 0)`;
 
 /**
  * 交換申請を作成 (#2832: 申請時点 snapshot を保存 / #3356 (1): server-side idempotency 内蔵)。
@@ -208,7 +211,9 @@ export async function findRedemptionRequestsByTenant(
 		})
 		.from(rewardRedemptionRequests)
 		.innerJoin(children, eq(rewardRedemptionRequests.childId, children.id))
-		.innerJoin(specialRewards, eq(rewardRedemptionRequests.rewardId, specialRewards.id))
+		// #3566 ①: leftJoin で snapshot を権威化。reward が改名/削除されても申請行は一覧から
+		// 脱落せず snapshot (申請時点の約束) を返す。INNER だと reward 消失で申請が消え顧客期待報酬が失われる。
+		.leftJoin(specialRewards, eq(rewardRedemptionRequests.rewardId, specialRewards.id))
 		.where(conditions.length > 0 ? and(...conditions) : undefined)
 		.orderBy(desc(rewardRedemptionRequests.requestedAt))
 		.limit(opts?.limit ?? 50)
@@ -302,7 +307,8 @@ export async function findUnshownResultByChild(
 			rewardIcon: snapshotIcon,
 		})
 		.from(rewardRedemptionRequests)
-		.innerJoin(specialRewards, eq(rewardRedemptionRequests.rewardId, specialRewards.id))
+		// #3566 ①: leftJoin で snapshot 権威化 (reward 削除後も未表示通知が snapshot 値で残る)。
+		.leftJoin(specialRewards, eq(rewardRedemptionRequests.rewardId, specialRewards.id))
 		.where(
 			and(
 				eq(rewardRedemptionRequests.childId, Number(childId)),

--- a/src/lib/server/db/sqlite/sibling-cheer-repo.ts
+++ b/src/lib/server/db/sqlite/sibling-cheer-repo.ts
@@ -2,7 +2,7 @@ import { and, count, eq, gte, isNull } from 'drizzle-orm';
 import { todayDateJST } from '$lib/domain/date-utils';
 import { asChildId, type ChildId } from '$lib/domain/ids';
 import { db } from '../client';
-import { siblingCheers } from '../schema';
+import { children, siblingCheers } from '../schema';
 import type { InsertSiblingCheerInput, SiblingCheer } from '../types';
 
 type CheerRow = typeof siblingCheers.$inferSelect;
@@ -38,11 +38,29 @@ export async function findAllByTenant(_tenantId: string): Promise<SiblingCheer[]
 	return db.select().from(siblingCheers).orderBy(siblingCheers.sentAt).all().map(toCheer);
 }
 
-/** #3329 backup restore 用: sentAt / shownAt を保全して復元する (from/to childId は呼び出し側が解決済)。 */
+/** #3329 backup restore 用: sentAt / shownAt を保全して復元する。 */
 export async function insertForRestore(
 	input: Omit<SiblingCheer, 'id' | 'tenantId'>,
 	tenantId: string,
 ): Promise<SiblingCheer> {
+	// #3566 ②: restore 入力は untrusted backup 由来のため、from/to child が実在する
+	// (= 同 family に属する) ことを書込前に強制する。DSQL insertForRestore の
+	// INSERT ... SELECT JOIN children guard と同型の defense-in-depth (dangling 拒否)。
+	// sqlite はシングルテナントのため family 帰属 = children テーブル実在で判定する
+	// (FK pragma に依存せず repo 層で fail-loud 拒否)。どちらか不在なら 0 行挿入で throw。
+	const fromExists = db
+		.select({ id: children.id })
+		.from(children)
+		.where(eq(children.id, Number(input.fromChildId)))
+		.get();
+	const toExists = db
+		.select({ id: children.id })
+		.from(children)
+		.where(eq(children.id, Number(input.toChildId)))
+		.get();
+	if (!fromExists || !toExists) {
+		throw new Error('sibling cheer restore rejected: from/to child not in family');
+	}
 	return toCheer(
 		db
 			.insert(siblingCheers)

--- a/src/lib/server/db/sqlite/voice-repo.ts
+++ b/src/lib/server/db/sqlite/voice-repo.ts
@@ -1,5 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 import { asChildId, type ChildId } from '$lib/domain/ids';
+import { assertTenantScopedStorageKey } from '$lib/server/storage-keys';
 import { db } from '../client';
 import { childCustomVoices } from '../schema';
 import type { ChildCustomVoice } from '../types';
@@ -58,6 +59,8 @@ export async function findActiveVoice(
 export async function insert(
 	voice: Omit<ChildCustomVoice, 'id' | 'createdAt'>,
 ): Promise<{ id: string }> {
+	// #3566 ③ (§9.4): file_path が tenant プレフィックス配下必須 (孤児バイト防止、DSQL と整合)。
+	assertTenantScopedStorageKey(voice.filePath, voice.tenantId);
 	const now = new Date().toISOString();
 	const result = db
 		.insert(childCustomVoices)
@@ -85,6 +88,9 @@ export async function insertForRestore(
 	voice: Omit<ChildCustomVoice, 'id'>,
 	_tenantId: string,
 ): Promise<{ id: string }> {
+	// #3566 ③ (§9.4): 復元行の file_path も tenant プレフィックス強制 (untrusted backup 由来の
+	// cross-tenant LFI 防止)。呼び出し側 (import-service) は復元先 tenant へ再キー済 = voice.tenantId。
+	assertTenantScopedStorageKey(voice.filePath, voice.tenantId);
 	const result = db
 		.insert(childCustomVoices)
 		.values({ ...voice, childId: Number(voice.childId) })

--- a/src/lib/server/storage-keys.ts
+++ b/src/lib/server/storage-keys.ts
@@ -42,3 +42,30 @@ export function voiceKey(tenantId: string, childId: ChildId, ext: string): strin
 export function storageKeyToPublicUrl(key: string): string {
 	return `/${key}`;
 }
+
+/**
+ * #3566 ③ (§9.4): DB に永続化する storage key が tenant プレフィックス配下であることを保証する。
+ *
+ * `character_images.file_path` / `child_custom_voices.file_path` など、要保護メディア (子供の顔写真 /
+ * 録音) の storage key を DB に書く前に本 guard を通す。これにより DB key と `IStorageRepo` 実バイトの
+ * 孤児整合を repo 層で構造的に担保する:
+ *   - **blob あり row 無し (孤児バイト残存)**: account 削除の `deleteByPrefix('tenants/<tenantId>/')`
+ *     (account-deletion-service) が「DB が参照する全バイト」を漏れなく削除できる。全ての DB key が
+ *     `tenants/<tenantId>/` 配下である保証がなければ、prefix 外に置かれたバイトが account 削除後も
+ *     残り COPPA 16CFR312.10 / GDPR Art.17 違反の孤児になる。
+ *   - **cross-tenant 混入 (IDOR / LFI 相当)**: `tenants/<other>/...` を A の DB 行に書けば、A の
+ *     配信経路が他 tenant のバイトを参照する孤児 = 越境になる (untrusted backup の細工 relPath も同型、
+ *     import-service §voices restore の cross-tenant LFI 懸念)。prefix 一致で構造遮断する (ADR-0063 整合)。
+ *   - **path traversal**: `..` を含む key は prefix 一致を満たしても FS 経路で越境しうるため拒否する。
+ *
+ * mis-scoped key は Error を throw (呼び出し側の key 生成バグ / 細工 input を fail-loud にする)。
+ * 正規の呼び出し側 (`avatarKey` / `generatedImageKey` / `voiceKey` / import restore の再キー) は
+ * 常に `tenants/<tenantId>/` を生成するため本 guard は defense-in-depth の backstop として作用する。
+ * error message には key 値そのもの (child id / path を含みうる) を載せない (機微情報を露出しない)。
+ */
+export function assertTenantScopedStorageKey(key: string, tenantId: string): void {
+	const prefix = tenantPrefix(tenantId);
+	if (typeof key !== 'string' || !key.startsWith(prefix) || key.includes('..')) {
+		throw new Error(`storage key is not tenant-scoped (expected prefix "${prefix}")`);
+	}
+}

--- a/tests/unit/db/dsql-certificate-voice-graduation-repos.test.ts
+++ b/tests/unit/db/dsql-certificate-voice-graduation-repos.test.ts
@@ -22,6 +22,7 @@
 //   [V5] findAllByChild (scene 不問、export) + §P9
 //   [V6] insertForRestore: createdAt / filePath / publicUrl / isActive を verbatim 保全 (新 id)
 //   [V7] deleteById / deleteByChild + §P9
+//   [V8] #3566 ③ (§9.4): file_path が tenant プレフィックス外 / cross-tenant なら insert / insertForRestore 拒否
 //
 // ── IGraduationConsentRepo ──
 //   [G1] create + listByTenant (consented_at DESC) + §P9 tenant 分離 + boolean 契約
@@ -234,8 +235,9 @@ describe('DSQL certificate / voice / graduation-consent repos (PR-R10、実 sche
 		voiceRepo.insert({
 			childId,
 			scene,
+			// #3566 ③: file_path は tenant プレフィックス配下必須 (§9.4 孤児バイト防止)。
 			label,
-			filePath: `voices/${String(childId)}/${label}.webm`,
+			filePath: `tenants/${family}/voices/${String(childId)}/${label}.webm`,
 			publicUrl: `https://cdn/${label}.webm`,
 			durationMs: 1234,
 			isActive,
@@ -251,7 +253,9 @@ describe('DSQL certificate / voice / graduation-consent repos (PR-R10、実 sche
 		const complete = await voiceRepo.findByChild(childId, 'complete', FAMILY);
 		expect(complete).toHaveLength(1);
 		expect(complete[0]?.label).toBe('よくできました');
-		expect(complete[0]?.filePath).toBe(`voices/${String(childId)}/よくできました.webm`);
+		expect(complete[0]?.filePath).toBe(
+			`tenants/${FAMILY}/voices/${String(childId)}/よくできました.webm`,
+		);
 		expect(complete[0]?.isActive).toBe(0); // number 0/1 契約
 		expect(complete[0]?.durationMs).toBe(1234);
 		expect(complete[0]?.tenantId).toBe(FAMILY);
@@ -324,7 +328,7 @@ describe('DSQL certificate / voice / graduation-consent repos (PR-R10、実 sche
 				childId,
 				scene: 'complete',
 				label: '復元声',
-				filePath: `voices/${String(childId)}/restored.webm`,
+				filePath: `tenants/${FAMILY}/voices/${String(childId)}/restored.webm`,
 				publicUrl: 'https://cdn/restored.webm',
 				durationMs: 5000,
 				isActive: 1,
@@ -339,9 +343,43 @@ describe('DSQL certificate / voice / graduation-consent repos (PR-R10、実 sche
 		expect(id).toMatch(UUID_RE);
 		const row = await voiceRepo.findById(id, FAMILY);
 		expect(row?.isActive).toBe(1);
-		expect(row?.filePath).toBe(`voices/${String(childId)}/restored.webm`);
+		expect(row?.filePath).toBe(`tenants/${FAMILY}/voices/${String(childId)}/restored.webm`);
 		expect(row?.durationMs).toBe(5000);
 		expect(Date.parse(row?.createdAt ?? '')).toBe(Date.parse('2025-03-04T05:06:07+00:00'));
+	});
+
+	it('[V8] #3566 ③ (§9.4): filePath が tenant プレフィックス配下でなければ insert / insertForRestore 拒否', async () => {
+		const childId = await newChild('声八郎');
+		const baseVoice = {
+			childId,
+			scene: 'complete',
+			label: '越境声',
+			publicUrl: 'https://cdn/x.webm',
+			durationMs: 100,
+			isActive: 0 as const,
+			tenantId: FAMILY,
+		};
+		// (a) prefix 外 key は拒否
+		await expect(
+			voiceRepo.insert({ ...baseVoice, filePath: 'voices/loose.webm' }),
+		).rejects.toThrow();
+		// (b) cross-tenant key は拒否 (他 family のバイトを A の DB 行が参照する越境)
+		await expect(
+			voiceRepo.insert({ ...baseVoice, filePath: `tenants/${OTHER_FAMILY}/voices/steal.webm` }),
+		).rejects.toThrow();
+		// (c) insertForRestore も同様に tenant プレフィックス強制 (untrusted backup 由来の cross-tenant LFI 防止)
+		await expect(
+			voiceRepo.insertForRestore(
+				{
+					...baseVoice,
+					filePath: `tenants/${OTHER_FAMILY}/voices/steal.webm`,
+					createdAt: '2025-03-04T05:06:07+00:00',
+				},
+				FAMILY,
+			),
+		).rejects.toThrow();
+		// 拒否ケースでは 1 行も追加されていない
+		expect(await voiceRepo.findAllByChild(childId, FAMILY)).toEqual([]);
 	});
 
 	it('[V7] deleteById / deleteByChild + §P9', async () => {

--- a/tests/unit/db/dsql-family-satellite-repos.test.ts
+++ b/tests/unit/db/dsql-family-satellite-repos.test.ts
@@ -44,6 +44,7 @@
 //   [IM1] insertCharacterImage + findCachedImage (type+hash 一致のみ) + §P9
 //   [IM2] updateChildAvatarUrl (tenant no-op) + findChildForImage (§P9)
 //   [IM3] deleteByTenantId は §P9 tenant 限定
+//   [IM4] #3566 ③ (§9.4): file_path が tenant プレフィックス外 / cross-tenant / traversal なら insert 拒否 (孤児バイト防止)
 
 import { sql } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -527,14 +528,16 @@ describe('DSQL 衛星系 family repos (M4-E PR8c、実 schema PGlite)', () => {
 
 	it('[IM1] insertCharacterImage + findCachedImage (type+hash 一致のみ) + §P9', async () => {
 		const childId = await newChild('画像一郎');
+		// #3566 ③: file_path は tenant プレフィックス配下必須 (§9.4 孤児バイト防止)。
+		const filePath = `tenants/${FAMILY}/generated/${childId}/hash-1.png`;
 		await imageRepo.insertCharacterImage(
-			{ childId, type: 'avatar', filePath: 'images/av-1.png', promptHash: 'hash-1' },
+			{ childId, type: 'avatar', filePath, promptHash: 'hash-1' },
 			FAMILY,
 		);
 		const cached = await imageRepo.findCachedImage(childId, 'avatar', 'hash-1', FAMILY);
 		expect(cached?.id).toMatch(UUID_RE);
 		expect(cached?.childId).toBe(childId);
-		expect(cached?.filePath).toBe('images/av-1.png');
+		expect(cached?.filePath).toBe(filePath);
 		expect(cached?.promptHash).toBe('hash-1');
 		expect(cached?.generatedAt).toBeTruthy();
 
@@ -564,15 +567,69 @@ describe('DSQL 衛星系 family repos (M4-E PR8c、実 schema PGlite)', () => {
 		expect(await imageRepo.findChildForImage(childId, OTHER_FAMILY)).toBe(undefined);
 	});
 
+	it('[IM4] #3566 ③ (§9.4): filePath が tenant プレフィックス配下でなければ insert 拒否 (孤児バイト防止)', async () => {
+		const childId = await newChild('画像四郎');
+		const countImages = async (): Promise<number> => {
+			const r = await t.db.execute(
+				sql`SELECT count(*) AS c FROM character_images WHERE family_id = ${FAMILY}`,
+			);
+			return Number((r.rows[0] as { c: unknown }).c);
+		};
+		const before = await countImages();
+		// (a) tenant 配下の key は許容 (正規の generatedImageKey 相当)
+		await imageRepo.insertCharacterImage(
+			{ childId, type: 'avatar', filePath: `tenants/${FAMILY}/generated/ok.png`, promptHash: 'h4' },
+			FAMILY,
+		);
+		// (b) prefix 外 key は拒否 (account 削除 deleteByPrefix で消えない孤児バイトになるため)
+		await expect(
+			imageRepo.insertCharacterImage(
+				{ childId, type: 'avatar', filePath: 'images/loose.png', promptHash: 'h4b' },
+				FAMILY,
+			),
+		).rejects.toThrow();
+		// (c) cross-tenant key は拒否 (他 family のバイトを A の DB 行が参照する越境 = IDOR/LFI)
+		await expect(
+			imageRepo.insertCharacterImage(
+				{
+					childId,
+					type: 'avatar',
+					filePath: `tenants/${OTHER_FAMILY}/generated/steal.png`,
+					promptHash: 'h4c',
+				},
+				FAMILY,
+			),
+		).rejects.toThrow();
+		// (d) path traversal を含む key は prefix 一致でも拒否
+		await expect(
+			imageRepo.insertCharacterImage(
+				{ childId, type: 'avatar', filePath: `tenants/${FAMILY}/../x.png`, promptHash: 'h4d' },
+				FAMILY,
+			),
+		).rejects.toThrow();
+		// 拒否ケースでは 1 行のみ (a のみ) 追加され、b/c/d は書かれていない
+		expect(await countImages()).toBe(before + 1);
+	});
+
 	it('[IM3] deleteByTenantId: §P9 tenant 限定 (他 tenant 無傷)', async () => {
 		const mine = await newChild('画像三郎');
 		const other = await newChild('他家三郎', OTHER_FAMILY);
 		await imageRepo.insertCharacterImage(
-			{ childId: mine, type: 'avatar', filePath: 'images/m.png', promptHash: 'hm' },
+			{
+				childId: mine,
+				type: 'avatar',
+				filePath: `tenants/${FAMILY}/generated/m.png`,
+				promptHash: 'hm',
+			},
 			FAMILY,
 		);
 		await imageRepo.insertCharacterImage(
-			{ childId: other, type: 'avatar', filePath: 'images/o.png', promptHash: 'ho' },
+			{
+				childId: other,
+				type: 'avatar',
+				filePath: `tenants/${OTHER_FAMILY}/generated/o.png`,
+				promptHash: 'ho',
+			},
 			OTHER_FAMILY,
 		);
 		await imageRepo.deleteByTenantId(FAMILY);

--- a/tests/unit/db/dsql-reward-message-repos.test.ts
+++ b/tests/unit/db/dsql-reward-message-repos.test.ts
@@ -19,10 +19,12 @@
 //   [SR3] updateSpecialReward (composite key、部分更新 / 空更新 = 現状返却 / 他 child no-op)
 //   [SR4] deleteSpecialReward (解決済 redemption も同 txn cascade、他 child no-op) + hasPending は残す
 //   [SR5] deleteByTenantId は §P9 tenant 限定 (他 tenant 無傷)
+//   [SR6] #3566 ③: granted_by (polymorphic text 旧int/新uuid/null) を verbatim 保全 + tenant-scoped read (COPPA 追跡性)
 // ── IRewardRedemptionRepo ──
 //   [RR1] insertRedemptionRequest: pending 固定 + 申請時点 snapshot 保存 + §P9
 //   [RR2] epoch↔timestamptz round-trip (requestedAt を秒精度で保全)
 //   [RR3] findByTenant (JOIN child/reward、snapshot 優先 COALESCE) + countByTenant (limit なし)
+//   [RR3b] #3566 ①: LEFT JOIN で snapshot 権威化 — live reward 削除後も申請が snapshot 値で残る
 //   [RR4] updateRedemptionRequestStatus 遷移 (composite key、resolvedAt epoch 保全、他 child no-op)
 //   [RR5] status CHECK 実効 (不正 status 直 INSERT 拒否)
 //   [RR6] pending dedup (#3356 (1)) / findUnshownResultByChild / markRedemptionResultShown
@@ -250,6 +252,39 @@ describe('DSQL reward / message repos (PR-R8、実 schema PGlite)', () => {
 		expect((await rewardRepo.findSpecialRewards(keep, FAMILY)).length).toBe(1);
 	});
 
+	it('[SR6] #3566 ③: granted_by (polymorphic text) 付与主体を verbatim 保全 + tenant-scoped read (COPPA 追跡性)', async () => {
+		// granted_by は polymorphic text (旧 int 由来の数値文字列 / 新 uuid / null 混在)。
+		// 付与主体の監査証跡 (誰がごほうびを付与したか) を repo が coerce せず verbatim 保全し、
+		// かつ read が §P9 tenant-scoped であることを担保する (cross-tenant で付与者が漏れない)。
+		const childId = await newChild('付与六郎');
+		const legacyIntGrantor = '42'; // 旧 integer granted_by 由来の数値文字列
+		const uuidGrantor = '00000000-0000-4000-8000-0000000000ab'; // 新 uuid 由来
+		await rewardRepo.insertSpecialReward(
+			{ childId, title: '旧付与', points: 10, category: 'privilege', grantedBy: legacyIntGrantor },
+			FAMILY,
+		);
+		await new Promise((r) => setTimeout(r, 5));
+		await rewardRepo.insertSpecialReward(
+			{ childId, title: '新付与', points: 20, category: 'privilege', grantedBy: uuidGrantor },
+			FAMILY,
+		);
+		await new Promise((r) => setTimeout(r, 5));
+		await rewardRepo.insertSpecialReward(
+			{ childId, title: '付与者なし', points: 30, category: 'privilege' },
+			FAMILY,
+		);
+
+		const list = await rewardRepo.findSpecialRewards(childId, FAMILY);
+		const byTitle = Object.fromEntries(list.map((r) => [r.title, r.grantedBy]));
+		// polymorphic の両形式 + null が coerce されず verbatim で返る (監査で付与主体を追跡可能)
+		expect(byTitle['旧付与']).toBe(legacyIntGrantor);
+		expect(byTitle['新付与']).toBe(uuidGrantor);
+		expect(byTitle['付与者なし']).toBe(null);
+
+		// §P9: cross-tenant read は付与主体 (granted_by) を一切露出しない
+		expect(await rewardRepo.findSpecialRewards(childId, OTHER_FAMILY)).toEqual([]);
+	});
+
 	// ─────────────────── IRewardRedemptionRepo ───────────────────
 
 	it('[RR1] insertRedemptionRequest: pending 固定 + 申請時点 snapshot 保存 + §P9', async () => {
@@ -334,6 +369,49 @@ describe('DSQL reward / message repos (PR-R8、実 schema PGlite)', () => {
 			status: 'pending_parent_approval',
 		});
 		expect(pendingOnly.length).toBe(2);
+	});
+
+	it('[RR3b] #3566 ①: 申請一覧は snapshot を権威とする — live reward 削除後も申請が snapshot 値で残る', async () => {
+		// 元 reward が削除・改名された後も「申請時点の約束 (title/points/icon)」を守る。
+		// INNER JOIN special_rewards だと reward 消失で申請行が一覧から脱落し顧客期待報酬が消える。
+		// snapshot 権威 = LEFT JOIN で、reward 不在でも rr.reward_* snapshot を返す。
+		const family = '00000000-0000-4000-8000-0000000000d6';
+		const childId = await newChild('約束六郎', family);
+		const reward = await rewardRepo.insertSpecialReward(
+			{ childId, title: 'ゲーム機', points: 500, icon: '🎮', category: 'physical' },
+			family,
+		);
+		const req = mustRow(
+			await redemptionRepo.insertRedemptionRequest(
+				{ childId, rewardId: reward.id, requestedAt: Math.floor(Date.now() / 1000) },
+				family,
+			),
+		);
+		// 承認 + unshown のまま (child 側 findUnshownResultByChild が拾える状態にする)
+		await redemptionRepo.updateRedemptionRequestStatus(
+			childId,
+			req.id,
+			{ status: 'approved', resolvedAt: Math.floor(Date.now() / 1000) },
+			family,
+		);
+
+		// live reward を物理削除 (backup restore で reward 未再取込 / 将来の削除経路を模した orphan)。
+		await t.db.execute(sql`
+			DELETE FROM special_rewards
+			WHERE family_id = ${family} AND child_id = ${childId} AND reward_id = ${reward.id}
+		`);
+
+		// 親向け申請一覧: reward 消失後も snapshot 値で 1 件残る (顧客期待報酬を消さない)。
+		const details = await redemptionRepo.findRedemptionRequestsByTenant(family);
+		expect(details).toHaveLength(1);
+		expect(details[0]?.rewardTitle).toBe('ゲーム機');
+		expect(details[0]?.rewardPoints).toBe(500);
+		expect(details[0]?.rewardIcon).toBe('🎮');
+
+		// child 側の未表示通知 (承認結果) も snapshot 権威で残る。
+		const unshown = await redemptionRepo.findUnshownResultByChild(childId, family);
+		expect(unshown?.rewardTitle).toBe('ゲーム機');
+		expect(unshown?.rewardIcon).toBe('🎮');
 	});
 
 	it('[RR4] updateRedemptionRequestStatus: 遷移 + resolvedAt epoch 保全 + composite no-op', async () => {

--- a/tests/unit/db/dsql-reward-message-repos.test.ts
+++ b/tests/unit/db/dsql-reward-message-repos.test.ts
@@ -41,6 +41,7 @@
 //   [SC3] findAllByTenant + insertForRestore (sentAt/shownAt verbatim)
 //   [SC4] #3566 ②: from/to child ∈ family を INSERT ... SELECT JOIN children で構造強制
 //         (cross-family child は 0 行 → throw、行は書かれない)
+//   [SC5] #3566 ②: insertForRestore も同型 guard (dangling/cross-family backup 行を repo 入口で拒否)
 // ── ILoginBonusRepo ──
 //   [LB1] insertLoginBonus 冪等 (自然複合 PK ON CONFLICT、id=child:date 合成) + findTodayBonus + §P9
 //   [LB2] findRecentBonuses (login_date 降順 limit) / findChildById (§P9)
@@ -826,6 +827,66 @@ describe('DSQL reward / message repos (PR-R8、実 schema PGlite)', () => {
 
 		// 拒否ケースでは 1 行も追加されていない (structural: 0 行挿入)
 		expect((await cheerRepo.findAllByTenant(family)).length).toBe(before);
+	});
+
+	it('[SC5] #3566 ②: insertForRestore も from/to child ∈ family を構造強制 (dangling backup 拒否)', async () => {
+		// restore 経路は untrusted backup 由来。insertCheer の [SC4] guard と同型に、
+		// INSERT ... SELECT JOIN children で from/to child ∈ family を強制する (VALUES 直書きだと
+		// dangling / cross-family 行が入る #3566 ② の gap を repo 入口で塞ぐ)。
+		const family = '00000000-0000-4000-8000-0000000000d6';
+		const from = await newChild('復元元五郎', family);
+		const to = await newChild('復元先五郎', family);
+		const alien = await newChild('他家の復元子', OTHER_FAMILY);
+		const ghost = '00000000-0000-4000-8000-00000000faff' as ChildId;
+
+		const before = (await cheerRepo.findAllByTenant(family)).length;
+
+		// (a) 同一 family の from/to → 成功 (sentAt/shownAt verbatim も保全)
+		const ok = await cheerRepo.insertForRestore(
+			{
+				fromChildId: from,
+				toChildId: to,
+				stampCode: 'restore-ok',
+				sentAt: '2025-10-01T09:00:00+00:00',
+				shownAt: '2025-10-02T09:00:00+00:00',
+			},
+			family,
+		);
+		if (!ok) throw new Error('insertForRestore returned null for fresh in-family row');
+		expect(ok.fromChildId).toBe(from);
+		expect(ok.toChildId).toBe(to);
+		expect(Date.parse(ok.sentAt)).toBe(Date.parse('2025-10-01T09:00:00+00:00'));
+		expect(Date.parse(ok.shownAt ?? '')).toBe(Date.parse('2025-10-02T09:00:00+00:00'));
+
+		const seeded = (await cheerRepo.findAllByTenant(family)).length;
+		expect(seeded).toBe(before + 1);
+
+		// (b1) 送信先が family 外 child → 拒否 (SELECT 0 行 → throw、行は書かれない)
+		await expect(
+			cheerRepo.insertForRestore(
+				{ fromChildId: from, toChildId: alien, stampCode: 'x', sentAt: ok.sentAt, shownAt: null },
+				family,
+			),
+		).rejects.toThrow();
+
+		// (b2) 送信元が family 外 child → 拒否
+		await expect(
+			cheerRepo.insertForRestore(
+				{ fromChildId: alien, toChildId: to, stampCode: 'x', sentAt: ok.sentAt, shownAt: null },
+				family,
+			),
+		).rejects.toThrow();
+
+		// (b3) どの family にも存在しない dangling child id → 拒否
+		await expect(
+			cheerRepo.insertForRestore(
+				{ fromChildId: from, toChildId: ghost, stampCode: 'x', sentAt: ok.sentAt, shownAt: null },
+				family,
+			),
+		).rejects.toThrow();
+
+		// 拒否ケースでは 1 行も追加されていない (structural: guard を外すと dangling 行が入り fail する)
+		expect((await cheerRepo.findAllByTenant(family)).length).toBe(seeded);
 	});
 
 	// ─────────────────── ILoginBonusRepo ───────────────────

--- a/tests/unit/db/dynamodb-reward-redemption-repo.test.ts
+++ b/tests/unit/db/dynamodb-reward-redemption-repo.test.ts
@@ -369,6 +369,31 @@ describe('findRedemptionRequestsByTenant', () => {
 		const rows = await findRedemptionRequestsByTenant(TENANT, { limit: 2 });
 		expect(rows.map((r) => r.id)).toEqual(['3', '2']);
 	});
+
+	it('#3566 ①: reward 削除後 (item に denorm snapshot が残る) も申請は snapshot 値で残る (snapshot 権威)', async () => {
+		// DynamoDB は JOIN でなく insert 時 denorm 保存のため、reward item 不在でも申請 item の
+		// denorm (rewardTitle/points/icon) が権威となり、申請が Scan 結果から脱落しない
+		// (sqlite/dsql の LEFT JOIN snapshot 権威と cross-backend 等価)。
+		mockSend.mockResolvedValueOnce({
+			Items: [
+				makeItem({
+					id: 1,
+					status: 'approved',
+					rewardTitle: 'ゲーム機',
+					rewardIcon: '🎮',
+					rewardPoints: 500,
+				}),
+			],
+		});
+		const { findRedemptionRequestsByTenant } = await loadRepo();
+		const rows = await findRedemptionRequestsByTenant(TENANT);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			rewardTitle: 'ゲーム機',
+			rewardIcon: '🎮',
+			rewardPoints: 500,
+		});
+	});
 });
 
 // ============================================================

--- a/tests/unit/db/dynamodb-sibling-cheer-repo.test.ts
+++ b/tests/unit/db/dynamodb-sibling-cheer-repo.test.ts
@@ -18,23 +18,30 @@ import { asChildId } from '$lib/domain/ids';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // AWS SDK Mock (vi.hoisted で先にモック関数と Command クラスを確保)
-const { mockSend, MockPutCommand, MockQueryCommand, MockUpdateCommand, MockScanCommand } =
-	vi.hoisted(() => {
-		const send = vi.fn();
-		class Cmd {
-			input: unknown;
-			constructor(input: unknown) {
-				this.input = input;
-			}
+const {
+	mockSend,
+	MockGetCommand,
+	MockPutCommand,
+	MockQueryCommand,
+	MockUpdateCommand,
+	MockScanCommand,
+} = vi.hoisted(() => {
+	const send = vi.fn();
+	class Cmd {
+		input: unknown;
+		constructor(input: unknown) {
+			this.input = input;
 		}
-		return {
-			mockSend: send,
-			MockPutCommand: class extends Cmd {},
-			MockQueryCommand: class extends Cmd {},
-			MockUpdateCommand: class extends Cmd {},
-			MockScanCommand: class extends Cmd {},
-		};
-	});
+	}
+	return {
+		mockSend: send,
+		MockGetCommand: class extends Cmd {},
+		MockPutCommand: class extends Cmd {},
+		MockQueryCommand: class extends Cmd {},
+		MockUpdateCommand: class extends Cmd {},
+		MockScanCommand: class extends Cmd {},
+	};
+});
 
 vi.mock('@aws-sdk/client-dynamodb', () => ({
 	DynamoDBClient: class {},
@@ -42,6 +49,7 @@ vi.mock('@aws-sdk/client-dynamodb', () => ({
 
 vi.mock('@aws-sdk/lib-dynamodb', () => ({
 	DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+	GetCommand: MockGetCommand,
 	PutCommand: MockPutCommand,
 	QueryCommand: MockQueryCommand,
 	UpdateCommand: MockUpdateCommand,
@@ -121,6 +129,96 @@ describe('insertCheer', () => {
 		expect(putCall.input.Item?.SK).toBe('CHEER#00000101');
 		expect(putCall.input.Item?.fromChildId).toBe(FROM_CHILD);
 		expect(putCall.input.Item?.stampCode).toBe('ganbare');
+	});
+});
+
+// ============================================================
+// insertForRestore — #3566 ② from/to child ∈ family guard (dangling backup 拒否)
+// ============================================================
+
+describe('insertForRestore', () => {
+	it('from/to child 実在を検証 → 採番 → 受信 child partition に PutItem し sentAt/shownAt を verbatim 復元', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Item: { id: FROM_CHILD } }) // Get from child (存在)
+			.mockResolvedValueOnce({ Item: { id: TO_CHILD } }) // Get to child (存在)
+			.mockResolvedValueOnce({ Attributes: { counter: 205 } }) // nextId
+			.mockResolvedValueOnce({}); // PutCommand
+
+		const { insertForRestore } = await loadRepo();
+		const result = await insertForRestore(
+			{
+				fromChildId: asChildId(FROM_CHILD),
+				toChildId: asChildId(TO_CHILD),
+				stampCode: 'restore',
+				sentAt: '2025-11-01T10:00:00.000Z',
+				shownAt: '2025-11-02T10:00:00.000Z',
+			},
+			TENANT,
+		);
+
+		expect(result.id).toBe('205');
+		expect(result).toMatchObject({
+			fromChildId: asChildId(FROM_CHILD),
+			toChildId: asChildId(TO_CHILD),
+			stampCode: 'restore',
+			tenantId: TENANT,
+			sentAt: '2025-11-01T10:00:00.000Z',
+			shownAt: '2025-11-02T10:00:00.000Z', // verbatim (insertCheer は null 固定だが restore は保全)
+		});
+
+		// from/to child は tenant-scoped childKey (PK に tenantId 埋込) で GetItem 検証している
+		const getFrom = mockSend.mock.calls[0]?.[0] as { input: { Key?: Record<string, unknown> } };
+		const getTo = mockSend.mock.calls[1]?.[0] as { input: { Key?: Record<string, unknown> } };
+		expect(getFrom.input.Key?.PK).toBe(`T#${TENANT}#CHILD#${FROM_CHILD}`);
+		expect(getTo.input.Key?.PK).toBe(`T#${TENANT}#CHILD#${TO_CHILD}`);
+		// Put は受信 child (toChildId) partition
+		const putCall = mockSend.mock.calls[3]?.[0] as { input: { Item?: Record<string, unknown> } };
+		expect(putCall.input.Item?.PK).toBe(`T#${TENANT}#CHILD#${TO_CHILD}`);
+		expect(putCall.input.Item?.SK).toBe('CHEER#00000205');
+	});
+
+	it('from child が tenant に不在 → 拒否 (throw、採番も Put もしない = dangling backup 拒否)', async () => {
+		mockSend
+			.mockResolvedValueOnce({}) // Get from child → 不在 (Item なし)
+			.mockResolvedValueOnce({ Item: { id: TO_CHILD } }); // Get to child (存在)
+
+		const { insertForRestore } = await loadRepo();
+		await expect(
+			insertForRestore(
+				{
+					fromChildId: asChildId(999),
+					toChildId: asChildId(TO_CHILD),
+					stampCode: 'x',
+					sentAt: '2025-11-01T10:00:00.000Z',
+					shownAt: null,
+				},
+				TENANT,
+			),
+		).rejects.toThrow(/not in family/);
+
+		// 検証 (Get) 2 回のみ。nextId (counter Update) / Put は呼ばれない (0 行挿入)
+		expect(mockSend.mock.calls.length).toBe(2);
+	});
+
+	it('to child が tenant に不在 → 拒否 (throw)', async () => {
+		mockSend
+			.mockResolvedValueOnce({ Item: { id: FROM_CHILD } }) // Get from (存在)
+			.mockResolvedValueOnce({}); // Get to → 不在
+
+		const { insertForRestore } = await loadRepo();
+		await expect(
+			insertForRestore(
+				{
+					fromChildId: asChildId(FROM_CHILD),
+					toChildId: asChildId(888),
+					stampCode: 'x',
+					sentAt: '2025-11-01T10:00:00.000Z',
+					shownAt: null,
+				},
+				TENANT,
+			),
+		).rejects.toThrow(/not in family/);
+		expect(mockSend.mock.calls.length).toBe(2);
 	});
 });
 

--- a/tests/unit/db/sqlite/sibling-cheer-restore-guard-3566.test.ts
+++ b/tests/unit/db/sqlite/sibling-cheer-restore-guard-3566.test.ts
@@ -1,0 +1,113 @@
+// tests/unit/db/sqlite/sibling-cheer-restore-guard-3566.test.ts
+//
+// #3566 ②: SQLite insertForRestore の from/to child ∈ family guard (dangling backup 拒否)。
+//
+// DSQL 側 (dsql-reward-message-repos.test.ts [SC5]) / DynamoDB 側
+// (dynamodb-sibling-cheer-repo.test.ts insertForRestore) と同セマンティクスを SQLite 実装
+// (挙動 SSOT) で固定する: restore 入力は untrusted backup 由来のため、from/to child が実在
+// (= 同 family に属する) しない場合は 1 行も書かず throw で拒否する。
+// guard を外すと dangling 行が入り本 test が fail する検出力を持つ (failing-test-first, ADR-0061)。
+
+import { count } from 'drizzle-orm';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestDb, type TestSqlite } from '../../helpers/test-db';
+
+const dbHolder: { sqlite: TestSqlite | null; db: ReturnType<typeof createTestDb>['db'] | null } = {
+	sqlite: null,
+	db: null,
+};
+
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		if (!dbHolder.db) throw new Error('test db not initialized');
+		return dbHolder.db;
+	},
+}));
+
+import { asChildId } from '$lib/domain/ids';
+// import after mock
+import { children, siblingCheers } from '$lib/server/db/schema';
+import { findAllByTenant, insertForRestore } from '$lib/server/db/sqlite/sibling-cheer-repo';
+
+const TENANT = 't-3566';
+
+describe('#3566 ②: SQLite insertForRestore from/to ∈ family guard', () => {
+	let fromChildId: number;
+	let toChildId: number;
+
+	beforeEach(() => {
+		const { sqlite, db } = createTestDb();
+		dbHolder.sqlite = sqlite;
+		dbHolder.db = db;
+
+		const c1 = db
+			.insert(children)
+			.values({ nickname: '応援元', age: 8, theme: 'default', uiMode: 'elementary' })
+			.returning()
+			.get();
+		fromChildId = c1.id;
+		const c2 = db
+			.insert(children)
+			.values({ nickname: '応援先', age: 6, theme: 'default', uiMode: 'elementary' })
+			.returning()
+			.get();
+		toChildId = c2.id;
+	});
+
+	const cheerCount = (): number => {
+		const db = dbHolder.db;
+		if (!db) throw new Error('no db');
+		return db.select({ c: count() }).from(siblingCheers).get()?.c ?? 0;
+	};
+
+	it('from/to child が実在すれば sentAt/shownAt を verbatim 復元する', async () => {
+		const restored = await insertForRestore(
+			{
+				fromChildId: asChildId(fromChildId),
+				toChildId: asChildId(toChildId),
+				stampCode: 'restore-ok',
+				sentAt: '2025-10-01T09:00:00.000Z',
+				shownAt: '2025-10-02T09:00:00.000Z',
+			},
+			TENANT,
+		);
+		expect(restored?.fromChildId).toBe(asChildId(fromChildId));
+		expect(restored?.toChildId).toBe(asChildId(toChildId));
+		expect(restored?.sentAt).toBe('2025-10-01T09:00:00.000Z');
+		expect(restored?.shownAt).toBe('2025-10-02T09:00:00.000Z');
+		expect(cheerCount()).toBe(1);
+		expect((await findAllByTenant(TENANT)).length).toBe(1);
+	});
+
+	it('from child が実在しない dangling backup → 拒否 (throw、1 行も書かれない)', async () => {
+		await expect(
+			insertForRestore(
+				{
+					fromChildId: asChildId(999999),
+					toChildId: asChildId(toChildId),
+					stampCode: 'x',
+					sentAt: '2025-10-01T09:00:00.000Z',
+					shownAt: null,
+				},
+				TENANT,
+			),
+		).rejects.toThrow(/not in family/);
+		expect(cheerCount()).toBe(0);
+	});
+
+	it('to child が実在しない dangling backup → 拒否 (throw、1 行も書かれない)', async () => {
+		await expect(
+			insertForRestore(
+				{
+					fromChildId: asChildId(fromChildId),
+					toChildId: asChildId(888888),
+					stampCode: 'x',
+					sentAt: '2025-10-01T09:00:00.000Z',
+					shownAt: null,
+				},
+				TENANT,
+			),
+		).rejects.toThrow(/not in family/);
+		expect(cheerCount()).toBe(0);
+	});
+});

--- a/tests/unit/services/storage-keys.test.ts
+++ b/tests/unit/services/storage-keys.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { asChildId } from '$lib/domain/ids';
 import {
+	assertTenantScopedStorageKey,
 	avatarKey,
 	childPrefix,
 	generatedImageKey,
@@ -80,6 +81,50 @@ describe('storage-keys', () => {
 			expect(storageKeyToPublicUrl('tenants/t1/avatars/1/abc.png')).toBe(
 				'/tenants/t1/avatars/1/abc.png',
 			);
+		});
+	});
+
+	describe('assertTenantScopedStorageKey (#3566 ③ §9.4)', () => {
+		it('tenant プレフィックス配下の key は通す (正規の avatar/generated/voice key)', () => {
+			expect(() =>
+				assertTenantScopedStorageKey(avatarKey(tenantId, asChildId(childId), 'png'), tenantId),
+			).not.toThrow();
+			expect(() =>
+				assertTenantScopedStorageKey(voiceKey(tenantId, asChildId(childId), 'mp3'), tenantId),
+			).not.toThrow();
+			expect(() =>
+				assertTenantScopedStorageKey(`tenants/${tenantId}/generated/x.png`, tenantId),
+			).not.toThrow();
+		});
+
+		it('prefix 外 key は throw (孤児バイト = account 削除 deleteByPrefix で消えない)', () => {
+			expect(() => assertTenantScopedStorageKey('images/loose.png', tenantId)).toThrow();
+			expect(() => assertTenantScopedStorageKey('avatars/1/x.png', tenantId)).toThrow();
+		});
+
+		it('cross-tenant key は throw (他 family バイトの越境参照 = IDOR/LFI)', () => {
+			expect(() =>
+				assertTenantScopedStorageKey('tenants/other-tenant/generated/steal.png', tenantId),
+			).toThrow();
+			// 前方一致だけ満たす別 tenant (prefix 末尾 / が境界を守る) も拒否
+			expect(() =>
+				assertTenantScopedStorageKey(`tenants/${tenantId}-evil/x.png`, tenantId),
+			).toThrow();
+		});
+
+		it('path traversal (..) を含む key は prefix 一致でも throw', () => {
+			expect(() =>
+				assertTenantScopedStorageKey(`tenants/${tenantId}/../other/x.png`, tenantId),
+			).toThrow();
+		});
+
+		it('error message に key 値 (child id / path 等の機微情報) を載せない', () => {
+			try {
+				assertTenantScopedStorageKey('tenants/secret-child-999/x.png', tenantId);
+				throw new Error('should have thrown');
+			} catch (e) {
+				expect((e as Error).message).not.toContain('secret-child-999');
+			}
 		});
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（DSQL 移管の read/write 整合基盤）+ ごほうび交換を使う家族

**解決する課題**: PR #3564（Child 集約 Slice B DDL）承認時に Adversarial Reviewer が指摘した repo/route の下流責務 3 点が未担保だった。
- ① 元 reward を改名/削除すると、申請一覧（親の見守り画面）と child 側通知から交換申請が **silent に脱落**（INNER JOIN 起因）し、子供に約束したごほうびが消える。
- ③ 子供の顔写真/録音の storage key が tenant プレフィックス外に書けると、account 削除の `deleteByPrefix` で消えない **孤児バイト（COPPA/GDPR 違反）** や cross-tenant 参照（IDOR/LFI）を生む。
- ③ 付与主体 `granted_by`（COPPA 追跡性）が coerce/欠落しうる。

**期待される効果**: 「申請時点の約束を守る」snapshot 権威が全 backend で成立し、要保護メディアの DB↔storage 孤児整合が repo 層で構造的に担保される。

## 関連 Issue

closes #3566

親: PR #3564 / #3563 / EPIC #3424 Phase C / `dsql-data-model.md` §9.4 / §11.2 / §11.3 / ADR-0063。AC② sibling_cheers の **live insertCheer** cross-family guard は develop 取込済。**restore 経路 (insertForRestore) の guard 欠落を本 PR で解消**（QM Tier2 指摘、下記 AC② 参照）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC① | reward_redemption_requests の申請一覧を snapshot 権威とし live 誤参照で顧客期待報酬を消さない | `npx vitest run tests/unit/db/dsql-reward-message-repos.test.ts` [RR3b] + dynamodb-reward-redemption | HEAD 2da71916205b45d9efac6d024f3a06fa616a5064 / red 実測: INNER JOIN で reward 削除後 expected [] to have length 1 → dsql/sqlite LEFT JOIN + COALESCE 既定値で green。dynamodb は denorm で元々権威（回帰固定）、demo=[] stub |
| AC② | sibling_cheers の from/to child が同一 family に属することを **全 insert 経路（live + restore）**でアプリ層 assert（cross-family/IDOR/dangling 防止） | `npx vitest run tests/unit/db/dsql-reward-message-repos.test.ts` [SC4]/[SC5] + `tests/unit/db/sqlite/sibling-cheer-restore-guard-3566.test.ts` + `tests/unit/db/dynamodb-sibling-cheer-repo.test.ts`（insertForRestore） | HEAD 86b4b012326b0392ec9a7c75038be0e4821043ca / live insertCheer guard は develop 取込済（[SC4]）。**QM Tier2 が restore 経路の gap を指摘**: insertForRestore が VALUES 直書きで JOIN guard を欠き dangling/cross-family backup 行を受理（本 PR は storage-key restore には defense-in-depth を適用済なのに sibling_cheers restore には未適用の不整合）。→ dsql=INSERT...SELECT JOIN children（sent_at/shown_at verbatim）/ sqlite=children 実在 pre-check / dynamodb=childKey GetItem 検証 で 3 backend の insertForRestore に from/to ∈ family guard を追加し 0 行挿入で throw 拒否。[SC5]/sqlite/dynamodb dangling 拒否 test を追加（guard 外すと dangling 行が入り fail する検出力）。green |
| AC③ granted_by | granted_by（polymorphic text 旧int/新uuid/null）を verbatim 保全 + tenant-scoped read（COPPA 追跡性） | `npx vitest run tests/unit/db/dsql-reward-message-repos.test.ts` [SR6] | HEAD 2da71916205b45d9efac6d024f3a06fa616a5064 / 回帰 guard（両 polymorphic 形式 + null が coerce されず返る + cross-tenant で granted_by 非露出） |
| AC③ storage 孤児 | character_images / child_custom_voices の DB key を tenant プレフィックス配下へ強制し blob 孤児/越境を repo 層で保証（§9.4） | `npx vitest run tests/unit/db/dsql-family-satellite-repos.test.ts tests/unit/services/storage-keys.test.ts` [IM4]/[V8] | HEAD 2da71916205b45d9efac6d024f3a06fa616a5064 / red 実測: guard 無しで越境 key が resolved instead of rejecting → `assertTenantScopedStorageKey` を dsql/sqlite/dynamodb の image+voice insert/insertForRestore に追加で green（demo=stub） |

## 変更タイプ

- [x] fix: バグ修正（AC① snapshot 脱落 + AC③ storage 越境）

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ層 repo (`$lib/server/db/`) — reward-redemption / image / voice の 3 backend
- [x] その他: `$lib/server/storage-keys.ts`（guard helper 新設）

**影響を受ける画面・機能**: 親の見守り画面のごほうび交換申請一覧 + child 側の交換結果通知（reward 削除後も表示継続）。アバター/録音の DB 書込（tenant プレフィックス外を fail-loud 拒否、正規経路は不変）。

## テスト & 安全装置セルフチェック

- [x] targeted 検証コマンド（main tree で実行）:
- [x] `npx vitest run tests/unit/db/dsql-reward-message-repos.test.ts tests/unit/db/dsql-family-satellite-repos.test.ts tests/unit/db/dsql-certificate-voice-graduation-repos.test.ts tests/unit/db/dynamodb-reward-redemption-repo.test.ts tests/unit/services/storage-keys.test.ts` → 111 passed
- [x] `npx svelte-check` → 0 error (8230 files) / `npx biome check` → 14 file clean / `npx cspell` → exit 0 / append-only allowlist → pass
- [x] 追加・変更テスト: [RR3b]（snapshot 権威 red→green）/ [IM4]/[V8]（storage guard red→green）/ [SR6]（granted_by 回帰 guard）/ dynamodb snapshot parity / storage-keys helper 単体（正常/prefix外/cross-tenant/traversal/機微情報非露出）
- [x] **AC② restore guard 追加検証（QM Tier2 指摘対応）**: `npx vitest run tests/unit/db/dsql-reward-message-repos.test.ts tests/unit/db/dynamodb-sibling-cheer-repo.test.ts tests/unit/db/sqlite/sibling-cheer-restore-guard-3566.test.ts` → 3 backend の insertForRestore dangling 拒否 green。非退行: `npx vitest run tests/unit/db/`（84 files / 1006 tests）+ 変更ファイル biome/svelte-check clean。HEAD 86b4b012326b0392ec9a7c75038be0e4821043ca
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: image/voice insert に guard、reward-redemption は denorm で権威（変更なし + parity test）
- [x] **Critical バグ修正の場合**: AC① 顧客期待報酬消失は snapshot 権威 unit で担保、UI 変更なし

## スクリーンショット / ビジュアルデモ

**該当なし**（repo 層 SQL + guard + test のみ。UI 変更なし）

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `assertTenantScopedStorageKey` は単一責務の pure guard。全 backend が同一 helper を共有（実装分散なし）
- [x] **DRY**: storage key 構造 SSOT（storage-keys.ts）に guard を同居。COALESCE fallback を dsql/sqlite で同型化
- [x] **YAGNI**: 新規 reconciliation job/interface method は追加せず、insert-time 不変条件で担保（ADR-0010 Pre-PMF）
- [x] **Security**: cross-tenant/prefix外/traversal を fail-loud 拒否（IDOR/LFI/孤児バイト、ADR-0063）。error message に key 値を載せない
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: LEFT JOIN 化は plan 差のみ（PK 述語不変）。guard は文字列 startsWith のみ

## 横展開・影響波及チェック

- [x] 4-backend parity: dsql / sqlite / dynamodb を更新、demo は stub（明記）
- [x] **設計書同期** (ADR-0001): 列レベル契約は §9.4 / §11.2 に既述、本 PR は repo 実装で契約を強制（drizzle schema SSOT 不変）
- [x] **sibling_cheers 4-backend parity（AC② restore guard）**: dsql / sqlite / dynamodb の insertForRestore に from/to ∈ family guard を適用、demo は非永続 stub（null 返却で偽装なし、guard 対象外）。live insertCheer との防御姿勢を一致させた
- [x] N/A — LP / labels / 年齢モード / ナビ

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（正規の storage key 生成経路 avatarKey/generatedImageKey/voiceKey/import restore 再キーは常に tenant-scoped。guard は defense-in-depth backstop）

**レビュー依頼事項・QA**: (1) storage guard を全 backend に適用したが production caller は全て tenant-scoped key を渡すため無害（image-service/voice-service/import-service で確認済）。(2) sqlite reward-redemption は DSQL PGlite の [RR3b] が SQL 意味論を担保 + 対称的 leftJoin 変更 + 既存 sqlite-backed test green で parity 確認。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret なし

## Ready for Review チェックリスト

- [x] 変更 suite 111 + append-only allowlist + svelte-check（変更ファイル 0 error）green をローカル確認（main tree）
- [x] biome / cspell 通過
- [x] 全 AC 実装済み（AC② は live=develop 取込済 + **restore=本 PR で insertForRestore guard 追加**により全 insert 経路で担保）
- [x] failing-test-first (ADR-0061): RR3b/IM4/V8 + **[SC5]/sqlite/dynamodb restore dangling 拒否** の red→green（guard 外すと dangling 行が入り fail する検出力）
- [x] Phase 分割なし
- [x] UI 変更なし / 認証画面変更なし

## QM レビュー結果

<!-- QM 記入 -->

