### PR TITLE
refactor(marketplace): #3151 slice2 reward-set 値域 SSOT 化 (domain/wire 二重定義撤廃 + boundary probe COVERED)

### DIFF
--- a/docs/decisions/0066-export-import-schema-range-ssot.md
+++ b/docs/decisions/0066-export-import-schema-range-ssot.md
@@ -54,5 +54,5 @@ slice1 (activity-pack) で是正した値: basePoints 10000→100 / age 18→20 
 ## 結果
 
 - #3132 class (値域ドリフト) の再混入は unit fitness (T1、<30s) が per-PR で検出し、重量 e2e まで到達しない (shift-left、ADR-0061 整合)
-- 残 4 type (reward-set / checklist / challenge-set / rule-preset) の SSOT 化、parse-don't-validate 全面化 (選択肢 B 方向)、fast-check property 格上げ、snapshot canary は EPIC #3151 の残 phase で段階消化 (fitness test の RANGE_SSOT_TODO が pin)
+- COVERED は activity-pack / reward-set の 2 type。残 3 type (checklist / challenge-set / rule-preset) の SSOT 化、parse-don't-validate 全面化 (選択肢 B 方向)、fast-check property 格上げ、snapshot canary は EPIC #3151 の残 phase で段階消化 (fitness test の RANGE_SSOT_TODO が pin)
 - トレードオフ: schema 構造の二重定義は残る (値域のみ SSOT)。構造の不一致は round-trip テスト群 (#3143) が引き続き担う

--- a/src/lib/domain/validation/special-reward.ts
+++ b/src/lib/domain/validation/special-reward.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 import { SHOP_CATEGORIES } from '$lib/domain/shop-category';
+// #3151 slice2 (ADR-0066): icon の値域は「grapheme 数」で判定する。grapheme 計数は activity と
+// 同一実装 (countIconGraphemes) を共有し、値でなく述語を SSOT 化する (ADR-0066 原則 2)。
+import { countIconGraphemes } from './activity';
 import { childIdSchema } from './id-schema';
 
 // 特別報酬カテゴリ
@@ -20,12 +23,44 @@ export const rewardCategorySchema = z.enum(REWARD_CATEGORIES);
 // SHOP_CATEGORIES は shop-category.ts の SSOT を再利用 (重複定義しない)。
 export const shopCategorySchema = z.enum(SHOP_CATEGORIES);
 
+// ============================================================
+// ごほうび 値域 SSOT (#3151 slice2 / ADR-0066)
+// ============================================================
+// domain Zod schema (本ファイル grantSpecialRewardSchema / rewardTemplateSchema) と wire
+// Valibot schema (src/lib/marketplace/schemas/reward-set-schema.ts) の両方が本定数を参照する。
+// 値域 literal の二重定義は #3132 (reward points 値域ドリフト blocker) の root class のため禁止。
+// domain⊆wire 包含は tests/unit/architecture/schema-range-ssot.test.ts が boundary probe で機械表明する。
+
+export const REWARD_TITLE_MIN = 1;
+export const REWARD_TITLE_MAX = 100;
+export const REWARD_POINTS_MIN = 1;
+/** ポイント経済設計の上限。#3132 で domain / wire を本値に統一 (往復破綻の再発防止) */
+export const REWARD_POINTS_MAX = 10000;
+export const REWARD_DESCRIPTION_MAX = 500;
+export const REWARD_ICON_MIN_GRAPHEMES = 1;
+export const REWARD_ICON_MAX_GRAPHEMES = 2;
+
+/**
+ * ごほうび icon 値域 (1〜2 grapheme) 判定。domain Zod refine と wire Valibot check の共有 oracle (#3151)。
+ * 旧 domain 側 `max(10)` (UTF-16 units 基準) は ZWJ 連結絵文字 1 個 (👨‍👩‍👧‍👦 = 11 units) を弾き、
+ * wire 側 `maxLength(20)` はそれを受理していたため両者が非対称だった。grapheme 判定への統一で
+ * 「単一の絵文字」という意図を表現方式ごと SSOT 化し、domain / wire を同一境界に揃える。
+ */
+export function isValidRewardIcon(val: string): boolean {
+	const count = countIconGraphemes(val);
+	return count >= REWARD_ICON_MIN_GRAPHEMES && count <= REWARD_ICON_MAX_GRAPHEMES;
+}
+
 export const grantSpecialRewardSchema = z.object({
 	childId: childIdSchema,
-	title: z.string().min(1).max(100),
-	description: z.string().max(500).optional(),
-	points: z.number().int().positive().max(10000),
-	icon: z.string().max(10).optional(),
+	title: z.string().min(REWARD_TITLE_MIN).max(REWARD_TITLE_MAX),
+	description: z.string().max(REWARD_DESCRIPTION_MAX).optional(),
+	points: z.number().int().min(REWARD_POINTS_MIN).max(REWARD_POINTS_MAX),
+	icon: z
+		.string()
+		.min(1)
+		.refine(isValidRewardIcon, { message: 'アイコンは1〜2つの絵文字で指定してください' })
+		.optional(),
 	category: rewardCategorySchema,
 	// #3147: 親が選ぶショップ陳列系統。省略時は表示側 deriveShopCategory に委ねる
 	shopCategory: shopCategorySchema.optional(),
@@ -36,9 +71,13 @@ export const specialRewardQuerySchema = z.object({
 });
 
 export const rewardTemplateSchema = z.object({
-	title: z.string().min(1).max(100),
-	points: z.number().int().positive().max(10000),
-	icon: z.string().max(10).optional(),
+	title: z.string().min(REWARD_TITLE_MIN).max(REWARD_TITLE_MAX),
+	points: z.number().int().min(REWARD_POINTS_MIN).max(REWARD_POINTS_MAX),
+	icon: z
+		.string()
+		.min(1)
+		.refine(isValidRewardIcon, { message: 'アイコンは1〜2つの絵文字で指定してください' })
+		.optional(),
 	category: rewardCategorySchema,
 });
 

--- a/src/lib/marketplace/schemas/reward-set-schema.ts
+++ b/src/lib/marketplace/schemas/reward-set-schema.ts
@@ -2,35 +2,52 @@
  * Marketplace `reward-set` payload schema (Valibot).
  *
  * Issue #2364 (EPIC #2362 P1): MarketplacePayloadMap 5 type schema SSOT.
+ * Issue #3151 slice2 (ADR-0066): 値域 literal の直書きを禁止し、domain 層の値域 SSOT 定数
+ * (`$lib/domain/validation/special-reward.ts`) を参照する。domain Zod (grantSpecialRewardSchema)
+ * と本 wire schema の値域一致 (domain⊆wire) は tests/unit/architecture/schema-range-ssot.test.ts
+ * が boundary probe で機械表明する。
  *
  * 既存 SSOT: src/lib/domain/marketplace-item.ts `RewardSetPayload`
  */
 
 import * as v from 'valibot';
 import { SHOP_CATEGORIES } from '$lib/domain/shop-category.js';
-import { REWARD_CATEGORIES } from '$lib/domain/validation/special-reward.js';
+import {
+	isValidRewardIcon,
+	REWARD_CATEGORIES,
+	REWARD_DESCRIPTION_MAX,
+	REWARD_POINTS_MAX,
+	REWARD_POINTS_MIN,
+	REWARD_TITLE_MAX,
+	REWARD_TITLE_MIN,
+} from '$lib/domain/validation/special-reward.js';
 
 /** reward-set item: 単一のごほうび (`RewardSetPayload['rewards'][number]` の rebuild) */
 export const RewardSetItemSchema = v.object({
 	title: v.pipe(
 		v.string('ごほうび名は文字列で指定してください'),
-		v.minLength(1, 'ごほうび名は必須です'),
-		v.maxLength(100, 'ごほうび名は 100 文字以内で指定してください'),
+		v.minLength(REWARD_TITLE_MIN, 'ごほうび名は必須です'),
+		v.maxLength(REWARD_TITLE_MAX, `ごほうび名は ${REWARD_TITLE_MAX} 文字以内で指定してください`),
 	),
 	points: v.pipe(
 		v.number('points は数値で指定してください'),
 		v.integer('points は整数で指定してください'),
-		v.minValue(1, 'points は 1 以上で指定してください'),
-		v.maxValue(10000, 'points は 10000 以下で指定してください'),
+		v.minValue(REWARD_POINTS_MIN, `points は ${REWARD_POINTS_MIN} 以上で指定してください`),
+		v.maxValue(REWARD_POINTS_MAX, `points は ${REWARD_POINTS_MAX} 以下で指定してください`),
 	),
-	// icon は単一の emoji を想定 (ZWJ 連結 emoji 例: 👨‍👩‍👧‍👦 = 11 UTF-16 code units)
-	// を許容するため maxLength=20 (ZWJ profession sequences は ~17 で安全圏)
-	icon: v.pipe(v.string(), v.minLength(1, 'icon は必須です'), v.maxLength(20)),
+	// icon は domain と同一 oracle (isValidRewardIcon、1〜2 grapheme) で判定 (#3151 slice2)。
+	// 旧 maxLength(20) (UTF-16 units 基準) は domain 側 max(10) と非対称で、単一の絵文字という
+	// 意図が表現方式ごとに二重定義されていた。isValidRewardIcon 共有で表現方式ごと統一。
+	icon: v.pipe(
+		v.string(),
+		v.minLength(1, 'icon は必須です'),
+		v.check(isValidRewardIcon, 'icon は 1〜2 個の絵文字で指定してください'),
+	),
 	category: v.picklist(
 		REWARD_CATEGORIES,
 		'category は REWARD_CATEGORIES のいずれかで指定してください',
 	),
-	description: v.optional(v.pipe(v.string(), v.maxLength(500))),
+	description: v.optional(v.pipe(v.string(), v.maxLength(REWARD_DESCRIPTION_MAX))),
 	// #3147: ショップ陳列系統 (physical/money/privilege)。省略時は取込側で推定 fallback。
 	// RewardCategory(6値) とは直交する軸 (登録カテゴリとショップ陳列の分離)。
 	shopCategory: v.optional(

--- a/tests/unit/architecture/schema-range-ssot.test.ts
+++ b/tests/unit/architecture/schema-range-ssot.test.ts
@@ -1,5 +1,5 @@
 // tests/unit/architecture/schema-range-ssot.test.ts
-// #3151 slice1 (ADR-0066): export/import 値域ドリフト根絶の fitness function。
+// #3151 slice1/slice2 (ADR-0066): export/import 値域ドリフト根絶の fitness function。
 //
 // root class (#3104→#3132 の 2 サイクル連続 blocker): domain validation (Zod) と
 // wire schema (Valibot) が別ファイル・別ライブラリで値域を二重定義し、
@@ -11,16 +11,19 @@
 //       「explicit TODO (RANGE_SSOT_TODO、#3151 残 phase で消化)」のいずれかに分類される。
 //       新 type 追加時に本分類へ登録しなければ CI で fail する (silent skip 禁止、
 //       admin-resource-model-registry の NON_CANONICAL 方式と同型)。
-//   (2) activity-pack (COVERED): domain Zod (createActivitySchema) と wire Valibot
-//       (ActivityPackItemSchema) が値域 SSOT 定数 (`$lib/domain/validation/activity.ts`)
+//   (2) activity-pack / reward-set (COVERED): domain Zod (createActivitySchema /
+//       grantSpecialRewardSchema) と wire Valibot (ActivityPackItemSchema /
+//       RewardSetItemSchema) が値域 SSOT 定数 (`$lib/domain/validation/{activity,special-reward}.ts`)
 //       の同一境界で受理/拒否する (boundary probe による behavior-level の同値表明)。
 //       実 validator を oracle として呼ぶため、どちらか一方が SSOT 定数を離れて
 //       literal を直書き (再ドリフト) すると必ず fail する (#3153 oracle 方式の拡張)。
 //
-// 他 4 type の SSOT 化は #3151 Phase 2 (Issue コメントの残 phase 分割案) で消化する。
+// 残 3 type (checklist / challenge-set / rule-preset) の SSOT 化は #3151 残 phase で消化する
+// (RANGE_SSOT_TODO で explicit に pin し silent skip しない)。
 
 import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
+import { asChildId } from '$lib/domain/ids';
 import {
 	ACTIVITY_AGE_MAX,
 	ACTIVITY_AGE_MIN,
@@ -32,24 +35,32 @@ import {
 	ACTIVITY_TRIGGER_HINT_MAX,
 	createActivitySchema,
 } from '$lib/domain/validation/activity';
+import {
+	grantSpecialRewardSchema,
+	REWARD_CATEGORIES,
+	REWARD_DESCRIPTION_MAX,
+	REWARD_ICON_MAX_GRAPHEMES,
+	REWARD_POINTS_MAX,
+	REWARD_POINTS_MIN,
+	REWARD_TITLE_MAX,
+} from '$lib/domain/validation/special-reward';
 import { ActivityPackItemSchema } from '$lib/marketplace/schemas/activity-pack-schema';
+import { RewardSetItemSchema } from '$lib/marketplace/schemas/reward-set-schema';
 import { MARKETPLACE_TYPE_CODES, type MarketplaceTypeCode } from '$lib/marketplace/types';
 
 // ── (1) no-silent-gap 分類 ──────────────────────────────────────────
 
 /** 値域 SSOT (domain 定数を domain/wire 両 schema が参照) 適用済の type */
-const COVERED_TYPES: readonly MarketplaceTypeCode[] = ['activity-pack'];
+const COVERED_TYPES: readonly MarketplaceTypeCode[] = ['activity-pack', 'reward-set'];
 
 /**
- * 値域 SSOT 未適用の type (explicit TODO)。#3151 Phase 2 で 1 type ずつ SSOT 化し、
+ * 値域 SSOT 未適用の type (explicit TODO)。#3151 残 phase で 1 type ずつ SSOT 化し、
  * COVERED_TYPES へ移す。理由なしにこのリストへ追加してはならない (新 type は原則 COVERED で作る)。
  */
 const RANGE_SSOT_TODO: Partial<Record<MarketplaceTypeCode, string>> = {
-	'reward-set':
-		'points 値域は reward-set-roundtrip-domain.test.ts が domain oracle 済。定数 SSOT 化は #3151 Phase 2',
-	checklist: 'label/icon/order の定数 SSOT 化は #3151 Phase 2',
-	'challenge-set': 'durationDays/baseTarget/rewardPoints の定数 SSOT 化は #3151 Phase 2',
-	'rule-preset': 'round-trip 網羅自体が未整備 (#3143 追加 finding (a))。#3151 Phase 2/4 で消化',
+	checklist: 'label/icon/order の定数 SSOT 化は #3151 残 phase',
+	'challenge-set': 'durationDays/baseTarget/rewardPoints の定数 SSOT 化は #3151 残 phase',
+	'rule-preset': 'round-trip 網羅自体が未整備 (#3143 追加 finding (a))。#3151 残 phase で消化',
 };
 
 // ── (2) boundary probe 用の valid base item ────────────────────────
@@ -84,6 +95,42 @@ const wireOk = (data: unknown) => v.safeParse(ActivityPackItemSchema, data).succ
 function expectBothSchemas(field: string, value: unknown, expected: boolean) {
 	expect(domainOk(domainItem({ [field]: value })), `domain ${field}=${value}`).toBe(expected);
 	expect(wireOk(wireItem({ [field]: value })), `wire ${field}=${value}`).toBe(expected);
+}
+
+// ── (2b) reward-set boundary probe 用の valid base item ─────────────
+// 注: domain (grantSpecialRewardSchema) は icon が optional だが、export 経路 (/api/v1/
+// special-rewards/export) は DB の null icon を '🎁' へ既定化してから wire schema へ渡すため、
+// round-trip では icon は常に present。よって本 probe は「present な icon 値」の境界のみ検証し、
+// activity exemplar と同様に「icon 省略」ケースは domain⊆wire の対象外とする。
+
+/** domain (grantSpecialRewardSchema) 用 valid base */
+const rewardDomainItem = (over: Record<string, unknown> = {}) => ({
+	childId: asChildId(1),
+	title: 'ゲームのじかん',
+	points: 50,
+	icon: '🎁',
+	category: REWARD_CATEGORIES[0],
+	...over,
+});
+
+/** wire (RewardSetItemSchema) 用 valid base */
+const rewardWireItem = (over: Record<string, unknown> = {}) => ({
+	title: 'ゲームのじかん',
+	points: 50,
+	icon: '🎁',
+	category: REWARD_CATEGORIES[0],
+	...over,
+});
+
+const rewardDomainOk = (data: unknown) => grantSpecialRewardSchema.safeParse(data).success;
+const rewardWireOk = (data: unknown) => v.safeParse(RewardSetItemSchema, data).success;
+
+/** reward の domain / wire 両 schema が同一 field 値で受理/拒否一致することを表明する */
+function expectBothReward(field: string, value: unknown, expected: boolean) {
+	expect(rewardDomainOk(rewardDomainItem({ [field]: value })), `domain ${field}=${value}`).toBe(
+		expected,
+	);
+	expect(rewardWireOk(rewardWireItem({ [field]: value })), `wire ${field}=${value}`).toBe(expected);
 }
 
 describe('#3151 値域 SSOT fitness (domain⊆wire、ADR-0066)', () => {
@@ -149,6 +196,40 @@ describe('#3151 値域 SSOT fitness (domain⊆wire、ADR-0066)', () => {
 			expectBothSchemas('icon', zwjFamily.repeat(ACTIVITY_ICON_MAX_GRAPHEMES), true);
 			expectBothSchemas('icon', zwjFamily.repeat(ACTIVITY_ICON_MAX_GRAPHEMES + 1), false);
 			expectBothSchemas('icon', '', false);
+		});
+	});
+
+	describe('(2b) reward-set: domain と wire が SSOT 境界で一致 (boundary probe)', () => {
+		it('points: SSOT max (10000) 受理 / max+1 拒否 / min (1) 受理 / min-1 拒否 が両 schema で一致', () => {
+			// #3132 root class の regression lock: domain (grantSpecialRewardSchema) と wire
+			// (RewardSetItemSchema) の points 上限が乖離すると export→restore 往復が境界値で破綻する。
+			expectBothReward('points', REWARD_POINTS_MAX, true);
+			expectBothReward('points', REWARD_POINTS_MAX + 1, false);
+			expectBothReward('points', REWARD_POINTS_MIN, true);
+			expectBothReward('points', REWARD_POINTS_MIN - 1, false);
+		});
+
+		it('title: SSOT max 文字 受理 / max+1 拒否 が両 schema で一致', () => {
+			expectBothReward('title', 'あ'.repeat(REWARD_TITLE_MAX), true);
+			expectBothReward('title', 'あ'.repeat(REWARD_TITLE_MAX + 1), false);
+		});
+
+		it('description: SSOT max 文字 受理 / max+1 拒否 が両 schema で一致', () => {
+			expectBothReward('description', 'あ'.repeat(REWARD_DESCRIPTION_MAX), true);
+			expectBothReward('description', 'あ'.repeat(REWARD_DESCRIPTION_MAX + 1), false);
+		});
+
+		it('icon: ZWJ 連結絵文字 (1 grapheme / 11 UTF-16 units) 受理 / 3 grapheme 拒否 が両 schema で一致', () => {
+			// #3151 slice2 是正の regression lock (failing-test-first): 旧 domain icon max(10)
+			// (UTF-16 units) は ZWJ 家族絵文字 1 個 (11 units) を拒否し、wire maxLength(20) は受理して
+			// いたため両者が非対称 (=SSOT 化前は domain=false / wire=true でこの assert が fail していた)。
+			// isValidRewardIcon 共有 oracle への統一で domain / wire を同一境界へ揃える。
+			const zwjFamily = '👨‍👩‍👧‍👦';
+			expect(REWARD_ICON_MAX_GRAPHEMES).toBe(2);
+			expectBothReward('icon', zwjFamily, true);
+			expectBothReward('icon', '🎁🎈', true); // 2 grapheme (境界内)
+			expectBothReward('icon', zwjFamily.repeat(REWARD_ICON_MAX_GRAPHEMES + 1), false); // 3 grapheme
+			expectBothReward('icon', '', false);
 		});
 	});
 });

--- a/tests/unit/marketplace/reward-set-roundtrip-domain.test.ts
+++ b/tests/unit/marketplace/reward-set-roundtrip-domain.test.ts
@@ -10,11 +10,17 @@
 import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 import { asChildId } from '$lib/domain/ids';
-import { grantSpecialRewardSchema, REWARD_CATEGORIES } from '$lib/domain/validation/special-reward';
+import {
+	grantSpecialRewardSchema,
+	REWARD_CATEGORIES,
+	REWARD_POINTS_MAX,
+} from '$lib/domain/validation/special-reward';
 import { RewardSetPayloadSchema } from '$lib/marketplace/schemas/reward-set-schema';
 
 const CAT = REWARD_CATEGORIES[0];
-const POINTS_MAX = 10000;
+// #3151 slice2 (ADR-0066): 上限を hardcode せず domain 層 SSOT 定数から導出する。
+// domain / wire どちらかが定数を離れて値域を広げれば本 test が落ち、#3132 class の再混入を検出する。
+const POINTS_MAX = REWARD_POINTS_MAX;
 
 const rewardSetPayload = (points: number) => ({
 	rewards: [{ title: 'テスト', points, icon: '🎁', category: CAT }],


### PR DESCRIPTION
## 顧客価値・目的

ごほうび (reward-set) の export / import 値域ドリフトを構造的に根絶する。domain validation (Zod) と wire schema (Valibot) が別ファイル・別ライブラリで値域 literal を二重定義していたため、`#3132` (reward points 値域) を含む「アプリが許容する値域 ⊄ export/import が往復できる値域 (domain⊆wire 違反)」が機械表明されておらず、バックアップ復元 / みんなのテンプレート取込が境界値で破綻するリスクが残っていた。slice1 (activity-pack、`#3680`) が確立した正準パターンを reward-set に横展開し、顧客のデータ往復 (エクスポート → 復元) が壊れない保証を CI に焼き込む。

## 関連 Issue

#3151 (slice2, tracking — EPIC 継続のため Closes しない)

<!-- no-issue-close: EPIC slice -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | reward の値域二重定義 (title / points / description / icon) を domain 層 SSOT 定数に集約し、domain Zod と wire Valibot の両方が import する | `src/lib/domain/validation/special-reward.ts` に `REWARD_TITLE_MIN/MAX` `REWARD_POINTS_MIN/MAX` `REWARD_DESCRIPTION_MAX` `REWARD_ICON_MIN/MAX_GRAPHEMES` + `isValidRewardIcon` を新設。`reward-set-schema.ts` が同定数を import して literal 直書きを撤廃 | 両 file の diff。`npx biome check --error-on-warnings` clean |
| AC2 | fitness に reward-set を COVERED として追加し、domain / wire が SSOT 境界で受理・拒否一致することを boundary probe で機械表明 | `tests/unit/architecture/schema-range-ssot.test.ts` に reward-set 用 base builder + `expectBothReward` probe (points / title / description / icon) を追加、COVERED_TYPES へ移動 | `npx vitest run tests/unit/architecture/schema-range-ssot.test.ts` 全 green (27 test) |
| AC3 | #3132 の points 実ドリフト + icon 実ドリフトを是正し、往復不能行を作らない (failing-test-first) | icon probe (ZWJ 家族絵文字 = 1 grapheme / 11 UTF-16 units 受理) は是正前 domain=false / wire=true で fail する回帰 lock。points は既存 `reward-set-roundtrip-domain.test.ts` が domain⊆wire を固定済 (SSOT 定数導出へ更新) | vitest green。ZWJ family = 11 units > 旧 domain `max(10)` の物理検証 (Intl.Segmenter) |
| AC4 | 狭めた境界 (icon 3+ grapheme) が既存データの往復を壊さない (ADR-0066 原則 4) | preset JSON (10 file 全 reward) / demo-data (82 icon) / e2e seed (`🎁` `🔔` `💎`) を全数 grapheme 計数 = すべて 1 grapheme | 下記「横展開・影響波及チェック」の全数検証結果表 |
| AC5 | 残 3 type (checklist / challenge-set / rule-preset) は fitness の未 COVERED pin (RANGE_SSOT 分類) を維持し silent skip しない | fitness の no-silent-gap guard が全 marketplace type の分類を強制 | `schema-range-ssot.test.ts` の未 COVERED pin リスト (RANGE_SSOT 分類) に 3 type を理由付きで継続 pin、no-silent-gap test green |

## 変更タイプ

- [x] リファクタリング (refactor) — 値域 SSOT 集約。icon は実ドリフト是正 (単一絵文字の意図へ収斂)

## 影響範囲・変更コンポーネント

- `src/lib/domain/validation/special-reward.ts` — 値域 SSOT 定数 + `isValidRewardIcon` predicate 追加、`grantSpecialRewardSchema` / `rewardTemplateSchema` が定数参照 (points は `.positive()` → `.min(REWARD_POINTS_MIN)` = 受理集合不変、icon は `max(10 UTF-16)` → grapheme 判定)
- `src/lib/marketplace/schemas/reward-set-schema.ts` — literal 直書き撤廃、domain 定数 + `isValidRewardIcon` を import
- `tests/unit/architecture/schema-range-ssot.test.ts` — reward-set COVERED 化 + boundary probe
- `tests/unit/marketplace/reward-set-roundtrip-domain.test.ts` — hardcode 10000 → `REWARD_POINTS_MAX` 導出
- `docs/decisions/0066-export-import-schema-range-ssot.md` — §結果の COVERED 現状記述を accuracy 更新 (activity-pack / reward-set の 2 type)

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/architecture/schema-range-ssot.test.ts tests/unit/marketplace/reward-set-roundtrip-domain.test.ts tests/unit/marketplace/export-import-roundtrip-invariants.test.ts` → 3 files / 27 tests PASS
- `npx vitest run tests/unit/marketplace/ src/lib/domain/validation/ src/lib/server/services/special-reward-service` → 20 files / 291 tests PASS
- `tests/unit/domain/special-reward-validation.test.ts` + `tests/unit/marketplace/schemas/reward-set-schema.test.ts` → 2 files / 37 tests PASS (icon 省略許容 / points 0 拒否 / 単一絵文字 icon 受理を回帰確認)
- `npx svelte-check --threshold error` → 0 errors / 0 warnings (infra deps link 後、変更 file 型 clean)
- `npx biome check --error-on-warnings` (変更 file) → No fixes / clean
- `npx cspell` (変更 file) → 0 issues
- failing-test-first: icon probe は SSOT 化前 domain=false / wire=true で fail する (ADR-0061)

## スクリーンショット / ビジュアルデモ

N/A — UI 変更なし (schema / validation 定数 + fitness test のみ)。描画・文言・レイアウトへの影響なし。

## コード品質セルフレビュー (#1481)

- 値域を「値」ではなく domain 層の 1 定数として集約し、domain / wire が同一 import 元を参照 (ADR-0066 原則 1)
- icon の表現方式差 (UTF-16 units vs grapheme) は `isValidRewardIcon` predicate + `countIconGraphemes` 共有で述語 SSOT 化 (ADR-0066 原則 2)。activity の `countIconGraphemes` を再利用し grapheme 計数ロジックを重複させない (循環 import なし: activity → special-reward の一方向)
- `.positive().max(10000)` → `.int().min(REWARD_POINTS_MIN).max(REWARD_POINTS_MAX)` は整数上で受理集合が完全一致 (0 は両者拒否)、挙動不変の pure refactor
- boundary probe は実 validator (`grantSpecialRewardSchema` / `RewardSetItemSchema`) を oracle として呼ぶため、片側が定数を離れて literal 直書きすれば必ず fail する

## 横展開・影響波及チェック

- **icon 是正の全数検証 (ADR-0066 原則 4 = 既存データの往復を壊さない側へ統一)**:

| データソース | 検証コマンド | 最大 grapheme 数 | 判定 |
|---|---|---|---|
| marketplace preset (10 file 全 reward) | `Intl.Segmenter` で全 icon 計数 | 1 grapheme (最大 UTF-16 = 3 units) | ✓ 新境界 (≤2 grapheme) 内 |
| demo-data (`special_rewards` 系 82 icon) | 同上 | 1 grapheme | ✓ |
| e2e seed (`global-setup.ts`) | `🎁` `🔔` `💎` | 1 grapheme | ✓ |

→ 狭めた側 (3+ grapheme) に該当する実データ 0 件のため migration 不要。逆に旧 domain `max(10 UTF-16)` が拒否していた ZWJ 家族絵文字 1 個 (単一絵文字) は新境界で受理され、`export-import-roundtrip-invariants.test.ts` §③b (reward-set が ZWJ family を受理) と domain / wire が一致する。

- **wire icon 経路**: `/api/v1/special-rewards/export` は DB の null icon を `🎁` 既定化してから wire schema へ渡すため、round-trip で icon は常に present (probe は present 値の境界のみ検証、domain の icon optional は grant API 境界限定で round-trip 対象外)
- **残 3 type**: checklist / challenge-set / rule-preset は fitness の未 COVERED pin リストに理由付きで継続 pin。no-silent-gap guard が分類漏れを CI 検出

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。points / title / description の受理集合は不変。icon のみ「単一絵文字」の意図へ収斂 (3+ grapheme の非絵文字文字列を新たに拒否) するが、全実データが 1 grapheme のため往復破綻なし
- 論点: reward icon の max grapheme を activity と同じ `2` に揃えた (cross-type consistency + 2-emoji tolerance で round-trip 安全側)。実データは 1 grapheme のみだが 2 まで許容することで狭めすぎを回避

## 配布済み env / secret (ADR-0006)

N/A — 新規 env / secret の追加・変更なし。

## Ready for Review チェックリスト

- [x] AC を満たす実装が完了している (AC1-AC5 検証マップ参照)
- [x] テスト (unit / fitness) を追加し全 PASS
- [x] `npx biome check` / `svelte-check` / `cspell` clean
- [x] 設計書 / ADR 同期 (ADR-0066 §結果の COVERED 現状記述を更新)
- [x] 横展開・影響波及チェック済 (icon 全数検証)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言: 全検証コマンド green、Draft で QM レビュー待ち)

## QM レビュー結果

(QM レビュー記入欄)
