### PR TITLE
fix(security): #3827 user-content 配信不変条件の明文化 + fitness function (Lambda 経由 / Content-Disposition + nosniff 機械強制)

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -670,6 +670,16 @@ HTTP レスポンスヘッダーで CSP を付与できないため、`<meta htt
 - ユーザー入力はサーバー側でもバリデーション
 - **user 由来静的ファイルの安全配信（#3105）**: user がアップロード / ZIP import 復元した静的ファイル（`/tenants/[...path]` / `/uploads/avatars/[filename]`）は、ラスタ画像（`image/jpeg` / `image/png` / `image/webp`）のみ `Content-Disposition: inline`、それ以外（**`image/svg+xml`** / `audio/*` / 不明 type）は `attachment` で配信する。SVG は XML 文書として `script` を含み得るため、CSP が `script-src 'self' 'unsafe-inline'` の本アプリでは inline 配信すると top-level navigation で stored XSS が成立する（#3105、ZIP import 復元路が avatar 防御を bypass していた）。判定は `file-sanitizer.ts` の `safeContentDisposition()` に集約し、全静的配信路で対称に適用する。`<img>` 等の subresource 読込は `Content-Disposition` を無視するため、正規の fallback SVG avatar 表示は維持される（img 経由 SVG では script も実行されない）。
 
+#### 7.2.1 user-content 配信不変条件（Lambda 経由 / Content-Disposition 強制、#3827 / EPIC #3408 slice A）
+
+user-content（avatar / ZIP import 由来ファイル等、attacker が content-type を左右し得るバイト）の配信は以下の不変条件を守る。これらは stored-XSS の本丸対処（#3105 / #3111）を「新経路追加時に silent に破らせない」ための構造ルールであり、fitness function で機械強制する（ADR-0061 no-silent-gap）。
+
+1. **常に Lambda 経由配信**: user-content は SvelteKit endpoint（`+server.ts`）が storage `readFile()` から取得して配信する。`static/` 直配信 / CDN からの S3 直配信で bypass しない。認証・tenant 一致（§5.2.1）・content-type 正規化・`Content-Disposition` 付与を配信点で必ず通すためである。
+2. **`nosniff` + `Content-Disposition` 必須**: 配信レスポンスは `X-Content-Type-Options: nosniff`（`hooks.server.ts` の**単一強制点**で全レスポンスに付与、§7.1）と `Content-Disposition`（経路ごとに `safeContentDisposition()` 経由で付与）を必ず持つ。ラスタ画像のみ `inline`、SVG / audio / 不明 type は `attachment`。`nosniff` により whitelist 外 type を `application/octet-stream` に落とした際の MIME スニッフィング再解釈を封じる。
+3. **S3 直配信 behavior 追加時は object metadata で `Content-Disposition` 強制**: 将来 CloudFront/S3 から user-content を直配信する behavior を足す場合、Lambda ヘッダを bypass するため、S3 object metadata に `Content-Disposition`（および content-type）を書き込んで配信点と同等の防御を担保する（現状は Lambda 経由のみ）。
+
+**機械強制（fitness function）**: `tests/unit/architecture/user-content-delivery-headers-fitness.test.ts` が (A) user-content 配信 route（`/uploads/avatars/[filename]` / `/tenants/[...path]`）を実 GET handler で呼び「`Content-Disposition` が付く + SVG→attachment / raster→inline」を behavioral に表明（header を外すと red）、(B) `hooks.server.ts` の nosniff 単一強制点の存在、(C) storage `readFile()` でバイトを配信する全 `+server.ts` が「user-content 配信」か「own-data download（ユーザー自身の生成物、固定 attachment。例: `/api/v1/export/cloud/[id]/download`）」に分類済であること（新規 readFile 配信 route を未分類で追加すると red = no-silent-gap）を検証する。
+
 ### 7.3 CSRF 対策
 
 - SvelteKit の Form Actions は組み込みの CSRF トークン検証を実施

--- a/tests/unit/architecture/user-content-delivery-headers-fitness.test.ts
+++ b/tests/unit/architecture/user-content-delivery-headers-fitness.test.ts
@@ -1,0 +1,280 @@
+// tests/unit/architecture/user-content-delivery-headers-fitness.test.ts
+// #3827 (EPIC #3408 slice A / ADR-0061): user-content 配信不変条件の fitness function 化。
+//
+// 不変条件 (14-セキュリティ設計書 §7.2 「user-content 配信不変条件」):
+//   ① user-content (avatar / import 由来ファイル等) は常に Lambda (SvelteKit endpoint) 経由配信。
+//   ② その配信レスポンスは `X-Content-Type-Options: nosniff` (全レスポンス共通、hooks.server.ts の
+//      単一強制点) + `Content-Disposition` (経路ごとに付与) を必ず持つ。ラスタ画像のみ inline、
+//      SVG / audio / 不明 type は attachment (#3105 stored-XSS 封殺)。
+//   ③ S3 直配信 behavior を足す場合は object metadata で `Content-Disposition` を強制する
+//      (現状は Lambda 経由のみ。直配信 route が増える時に本 fitness の no-silent-gap で気づける)。
+//
+// root class (#3112 構造リスク 3): 「user-content が常に Lambda 経由 + Content-Disposition が付く」
+// が人の注意依存で、新 user-content 配信 route 追加時に silent に破れる。ADR-0061 の
+// same-class→guard / no-silent-gap に従い機械表明する。route-db-boundary / schema-range-ssot と
+// 同型の Architecture Fitness Function (Building Evolutionary Architecture / Neal Ford 他)。
+// 新規ツール導入ゼロ (既存 vitest + node fs + createMockEvent behavioral probe)。
+//
+// 本テストの表明:
+//   (A) 経路レベル behavioral probe (failing-test-first): user-content 配信 route (avatar / tenants) を
+//       実 GET handler で呼び、`Content-Disposition` が必ず付く + SVG→attachment / raster→inline を
+//       確認する。route から `Content-Disposition` を外すと (A) が red になる (= guard 実効性)。
+//   (B) 全レスポンス nosniff: hooks.server.ts の単一強制点が `X-Content-Type-Options: nosniff` を
+//       付与している。強制点を外すと (B) が red になる。
+//   (C) no-silent-gap: storage の `readFile()` でバイトを配信する全 +server.ts が「user-content 配信」
+//       か「own-data download (ユーザー自身の生成物、固定 attachment)」のいずれかに分類済である。
+//       新規に readFile 配信 route を足して未分類なら red (silent skip 禁止、
+//       admin-resource-model-registry の NON_CANONICAL 方式 / schema-range-ssot の分類方式と同型)。
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockEvent } from '../../helpers/mock-event';
+
+// storage / child-service を mock (behavioral probe は配信ヘッダの検証が目的で、実 storage / DB は不要)。
+vi.mock('$lib/server/storage', () => ({ readFile: vi.fn() }));
+vi.mock('$lib/server/services/child-service', () => ({ getChildById: vi.fn() }));
+
+import { getChildById } from '$lib/server/services/child-service';
+import { readFile } from '$lib/server/storage';
+import { GET as tenantsGET } from '../../../src/routes/tenants/[...path]/+server';
+import { GET as avatarsGET } from '../../../src/routes/uploads/avatars/[filename]/+server';
+
+const readFileMock = vi.mocked(readFile);
+const getChildByIdMock = vi.mocked(getChildById);
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const ROUTES_DIR = resolve(REPO_ROOT, 'src/routes');
+const HOOKS_FILE = resolve(REPO_ROOT, 'src/hooks.server.ts');
+
+const rel = (abs: string) => relative(REPO_ROOT, abs).replace(/\\/g, '/');
+
+// ── SSOT registry (no-silent-gap の分類、#3827 AC3) ───────────────────────────
+//
+// user-content 配信 route = user がアップロード / ZIP import 復元した「attacker が content-type を
+// 左右し得る」バイトを、stored content-type から導出した Content-Type で配信する route。#3105 の
+// stored-XSS 防御対象。これらは safeContentDisposition() 経由で SVG / 不明 type を attachment 配信する。
+const USER_CONTENT_DELIVERY_ROUTES = [
+	'src/routes/uploads/avatars/[filename]/+server.ts',
+	'src/routes/tenants/[...path]/+server.ts',
+] as const;
+
+// own-data download = ユーザー自身が生成したバックアップ (JSON / ZIP) を配信する route。
+// content-type は attacker-controllable ではなく (サーバー生成の application/zip 等)、常に
+// `Content-Disposition: attachment` の固定配信のため stored-XSS の inline 実行経路にならない。
+// user-content (avatar / import 由来) とは性質が異なるため別バケットで明示分類する (silent skip 禁止)。
+const OWN_DATA_DOWNLOAD_ROUTES: Record<string, string> = {
+	'src/routes/api/v1/export/cloud/[id]/download/+server.ts':
+		'ユーザー自身が生成したバックアップ ZIP を固定 attachment で配信 (attacker-controllable content-type ではない、#3504)',
+};
+
+// ── readFile 配信 route の discovery (no-silent-gap の走査対象、#3827 AC3) ──────
+// storage の `readFile()` を呼んでバイトを返す +server.ts を FS 走査で列挙する。新規に readFile 配信
+// route を足したら本走査に必ず載り、registry / allowlist に分類しない限り (C) が red になる。
+const READFILE_CALL = /\breadFile\s*\(/;
+
+function walkServerFiles(dir: string, acc: string[]): string[] {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = resolve(dir, entry.name);
+		if (entry.isDirectory()) {
+			walkServerFiles(full, acc);
+		} else if (entry.name === '+server.ts') {
+			acc.push(full);
+		}
+	}
+	return acc;
+}
+
+function findReadFileServingRoutes(): string[] {
+	return walkServerFiles(ROUTES_DIR, [])
+		.filter((f) => READFILE_CALL.test(readFileSync(f, 'utf-8')))
+		.map(rel)
+		.sort();
+}
+
+/** 配信レスポンスが Content-Disposition (+ Content-Type) を必ず持つことを表明する behavioral 検証。 */
+function expectDeliveredWithDisposition(res: Response, expected: 'inline' | 'attachment') {
+	expect(res.status).toBe(200);
+	const disposition = res.headers.get('Content-Disposition');
+	// failing-test-first の核: route から Content-Disposition を外すと null になり必ず red。
+	expect(
+		disposition,
+		'user-content 配信レスポンスは Content-Disposition 必須 (#3105/#3827、safeContentDisposition 経由)',
+	).not.toBeNull();
+	expect(disposition).toBe(expected);
+	expect(
+		res.headers.get('Content-Type'),
+		'Content-Type は safeContentType 経由で必須',
+	).not.toBeNull();
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	// 既定は raster 画像 (png) を配信する正常 Child (avatarUrl が要求 filename を指す)。
+	readFileMock.mockResolvedValue({ data: Buffer.from([1, 2, 3]), contentType: 'image/png' });
+	getChildByIdMock.mockResolvedValue({
+		id: '1',
+		tenantId: 't-self',
+		avatarUrl: '/uploads/avatars/avatar-1-abc.png',
+		// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小 Child スタブ
+	} as any);
+});
+
+describe('#3827 user-content 配信不変条件 fitness (EPIC #3408 slice A / ADR-0061)', () => {
+	// ── (A) 経路レベル behavioral probe (AC2) ────────────────────────────────
+	describe('(A) user-content 配信 route は Content-Disposition を必ず付与し SVG を attachment 化する', () => {
+		it('/uploads/avatars/[filename]: raster(png) は inline 配信 + Content-Disposition あり', async () => {
+			const event = createMockEvent({
+				url: '/uploads/avatars/avatar-1-abc.png',
+				params: { filename: 'avatar-1-abc.png' },
+				context: { tenantId: 't-self', role: 'parent' },
+			});
+			expectDeliveredWithDisposition((await avatarsGET(event)) as Response, 'inline');
+		});
+
+		it('/uploads/avatars/[filename]: SVG は attachment 配信 (stored-XSS 封殺、#3105)', async () => {
+			readFileMock.mockResolvedValue({
+				data: Buffer.from('<svg/>'),
+				contentType: 'image/svg+xml',
+			});
+			getChildByIdMock.mockResolvedValue({
+				id: '1',
+				tenantId: 't-self',
+				avatarUrl: '/uploads/avatars/avatar-1-abc.svg',
+				// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小 Child スタブ
+			} as any);
+			const event = createMockEvent({
+				url: '/uploads/avatars/avatar-1-abc.svg',
+				params: { filename: 'avatar-1-abc.svg' },
+				context: { tenantId: 't-self', role: 'parent' },
+			});
+			expectDeliveredWithDisposition((await avatarsGET(event)) as Response, 'attachment');
+		});
+
+		it('/tenants/[...path]: raster(png) は inline 配信 + Content-Disposition あり', async () => {
+			const event = createMockEvent({
+				url: '/tenants/t-self/avatars/1/x.png',
+				params: { path: 't-self/avatars/1/x.png' },
+				context: { tenantId: 't-self', role: 'child' },
+			});
+			expectDeliveredWithDisposition((await tenantsGET(event)) as Response, 'inline');
+		});
+
+		it('/tenants/[...path]: SVG は attachment 配信 (stored-XSS 封殺、#3105)', async () => {
+			readFileMock.mockResolvedValue({
+				data: Buffer.from('<svg/>'),
+				contentType: 'image/svg+xml',
+			});
+			const event = createMockEvent({
+				url: '/tenants/t-self/generated/1/x.svg',
+				params: { path: 't-self/generated/1/x.svg' },
+				context: { tenantId: 't-self', role: 'child' },
+			});
+			expectDeliveredWithDisposition((await tenantsGET(event)) as Response, 'attachment');
+		});
+
+		it('/tenants/[...path]: 不明 type も attachment (whitelist 外は octet-stream + attachment)', async () => {
+			readFileMock.mockResolvedValue({
+				data: Buffer.from('%PDF-1.4'),
+				contentType: 'application/pdf',
+			});
+			const event = createMockEvent({
+				url: '/tenants/t-self/generated/1/x.pdf',
+				params: { path: 't-self/generated/1/x.pdf' },
+				context: { tenantId: 't-self', role: 'child' },
+			});
+			const res = (await tenantsGET(event)) as Response;
+			expectDeliveredWithDisposition(res, 'attachment');
+			// safeContentType の whitelist 外は octet-stream に落とす (MIME スニッフィング前提を潰す)。
+			expect(res.headers.get('Content-Type')).toBe('application/octet-stream');
+		});
+
+		it('guard 非トートロジー証明: Content-Disposition 無しの Response は本検証で必ず fail する', () => {
+			// route が Content-Disposition を落とした場合を模擬。expectDeliveredWithDisposition が
+			// これを検出できることを示す (= 検証が vacuous でない)。
+			const noDisposition = new Response(new Uint8Array([1]), {
+				headers: { 'Content-Type': 'image/png' },
+			});
+			expect(() => expectDeliveredWithDisposition(noDisposition, 'inline')).toThrow();
+		});
+	});
+
+	// ── (B) 全レスポンス nosniff の単一強制点 (AC2) ──────────────────────────
+	describe('(B) hooks.server.ts が全レスポンスに X-Content-Type-Options: nosniff を付与する', () => {
+		const hooksSource = readFileSync(HOOKS_FILE, 'utf-8');
+
+		it('nosniff 強制点が存在する (外すと red = MIME スニッフィング防御の喪失)', () => {
+			// 全レスポンス共通の単一強制点。user-content 配信 route はこれに依存して nosniff を得る
+			// (各 route での重複付与は不要)。この 1 行を消すと本テストが red になる。
+			expect(
+				/response\.headers\.set\(\s*['"]X-Content-Type-Options['"]\s*,\s*['"]nosniff['"]\s*\)/.test(
+					hooksSource,
+				),
+				'hooks.server.ts の全レスポンス強制点で nosniff を付与すること (14-セキュリティ設計書 §7.1)',
+			).toBe(true);
+		});
+
+		it('nosniff は単一 SSOT (強制点は 1 箇所)', () => {
+			const count = (hooksSource.match(/['"]X-Content-Type-Options['"]/g) ?? []).length;
+			expect(count, 'nosniff の付与点は hooks.server.ts の 1 箇所に集約する (散在させない)').toBe(
+				1,
+			);
+		});
+	});
+
+	// ── (C) no-silent-gap (AC3) ──────────────────────────────────────────────
+	describe('(C) readFile 配信の全 +server.ts が user-content / own-data に分類済', () => {
+		const servingRoutes = findReadFileServingRoutes();
+		const classified = new Set<string>([
+			...USER_CONTENT_DELIVERY_ROUTES,
+			...Object.keys(OWN_DATA_DOWNLOAD_ROUTES),
+		]);
+
+		it('storage.readFile() 配信 route を FS 走査できている (sanity)', () => {
+			expect(servingRoutes.length).toBeGreaterThan(0);
+		});
+
+		it('readFile 配信の全 route が registry / allowlist に分類済 (未分類 = fail)', () => {
+			const unclassified = servingRoutes.filter((f) => !classified.has(f));
+			expect(
+				unclassified,
+				`未分類の readFile 配信 route:\n${unclassified.map((f) => `  - ${f}`).join('\n')}\n` +
+					'→ user-content (attacker-controllable content-type、safeContentDisposition 経由) なら ' +
+					'USER_CONTENT_DELIVERY_ROUTES へ追加し (A) の behavioral probe 対象にする。' +
+					'ユーザー自身の生成物 (固定 attachment) なら OWN_DATA_DOWNLOAD_ROUTES に理由付きで pin する (#3827 AC3)',
+			).toEqual([]);
+		});
+
+		it('registry / allowlist は stale でない (実在 route と一致、= 空振り走査を許さない)', () => {
+			const servingSet = new Set(servingRoutes);
+			const stale = [...classified].filter((f) => !servingSet.has(f));
+			expect(
+				stale,
+				`実在しない / readFile 配信でない分類エントリ (削除してください):\n${stale
+					.map((f) => `  - ${f}`)
+					.join('\n')}`,
+			).toEqual([]);
+		});
+
+		it('user-content 配信 route が safeContentDisposition() を経由する (集約点の実効性)', () => {
+			for (const route of USER_CONTENT_DELIVERY_ROUTES) {
+				const src = readFileSync(resolve(REPO_ROOT, route), 'utf-8');
+				expect(
+					src.includes('safeContentDisposition'),
+					`${route} は file-sanitizer.ts の safeContentDisposition() 経由で配信すること (#3105 集約点)`,
+				).toBe(true);
+			}
+		});
+
+		it('own-data download route は Content-Disposition: attachment を固定付与する', () => {
+			for (const route of Object.keys(OWN_DATA_DOWNLOAD_ROUTES)) {
+				const src = readFileSync(resolve(REPO_ROOT, route), 'utf-8');
+				expect(
+					/content-disposition['"]\s*:\s*[`'"]attachment/i.test(src),
+					`${route} はバックアップを attachment で配信すること (inline 化しない)`,
+				).toBe(true);
+			}
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（子供の顔写真 / import 由来ファイルを扱う全ユーザーの安全）

**解決する課題**: stored-XSS 本丸（ZIP import SVG の inline 実行、#3105/#3111）は attachment 配信 + nosniff で実閉鎖済だが、「user-content が常に Lambda 経由配信され Content-Disposition が付く」不変条件が**人の注意依存**で、新 user-content 配信 route 追加時や将来の S3 直配信 behavior 追加時に silent に破れる構造リスクが残る（#3112 item3）。

**期待される効果**: 不変条件を 14-セキュリティ設計書に明文化し fitness function で機械強制することで、将来どの改修が配信ヘッダを落としても CI が即 red になり、stored-XSS の再発経路を構造的に封じる（defense-in-depth の institutionalize）。

## 関連 Issue

closes #3827

related: #3408 (EPIC) / #3112 / #3105 / #3111 / ADR-0061

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 14-セキュリティ設計書に user-content 配信不変条件（Lambda 経由 / S3 直配信時 Content-Disposition 強制 / nosniff）を明文化 | `docs/design/14-セキュリティ設計書.md` §7.2.1 目視 | HEAD 9762ec8439d620c1209824a85d9191696909129b / §7.2.1「user-content 配信不変条件」に不変条件 3 点 + fitness 参照を記載 |
| AC2 | fitness function で「user-content 配信 route が Content-Disposition + nosniff を必ず付ける」を機械表明（failing-test-first、guard を外すと CI red） | `npx vitest run tests/unit/architecture/user-content-delivery-headers-fitness.test.ts` | HEAD 9762ec8439d620c1209824a85d9191696909129b / 13 passed。red→green 実証: avatar の Content-Disposition 削除で 2 failed / hooks の nosniff 削除で 2 failed。復元で green |
| AC3 | 新規 user-content 配信 route 追加時に不変条件を強制する CI gate（no-silent-gap） | `npx vitest run tests/unit/architecture/user-content-delivery-headers-fitness.test.ts` | HEAD 9762ec8439d620c1209824a85d9191696909129b / `src/routes/**/+server.ts` の readFile 配信 route を FS 走査し registry 未分類なら red。registry から avatar 削除で 1 failed を実証、復元で green |

## 変更タイプ

- [x] fix: バグ修正（defense-in-depth の構造強化）
- [x] test: テスト改善（fitness function 新設）
- [x] docs: ドキュメント（設計書同期、ADR-0001）

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI（`tests/unit/architecture/` fitness function + `docs/design/` 設計書）

**影響を受ける画面・機能**: production 挙動の変更なし。既存 user-content 配信 route（`/uploads/avatars/[filename]` / `/tenants/[...path]`）の #3105 実装を変更せず「表明」するのみ（git diff 差分ゼロ）。

## テスト & 安全装置セルフチェック

- [x] targeted 検証コマンド（main tree で実行）:
- [x] `npx vitest run tests/unit/architecture/user-content-delivery-headers-fitness.test.ts` → 13 passed
- [x] `npx biome check` → clean / `npx cspell` → exit 0 / `npx svelte-check` → 0 error (8179 files) / `node scripts/check-doc-code-references.mjs` → baseline 内
- [x] 追加・変更したテスト: (A) avatar/tenants 配信の behavioral probe（Content-Disposition + SVG→attachment / raster→inline / 不明→octet-stream+attachment）、(B) hooks nosniff 単一強制点、(C) readFile 配信 route の no-silent-gap 分類（13 test）
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（priority:medium、defense-in-depth）

## スクリーンショット / ビジュアルデモ

**該当なし**: UI 変更なし（設計書 + fitness test のみ）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID / DRY**: 既存 fitness（route-db-boundary / schema-range-ssot）と同型の Architecture Fitness Function、新規 dep ゼロ
- [x] **YAGNI**: production コード無改変、表明のみ
- [x] **Security**: user-content 配信の nosniff + Content-Disposition を機械強制し stored-XSS 再発経路を封鎖（defense-in-depth）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A（静的走査 + mock behavioral probe）

## 横展開・影響波及チェック

- [x] readFile 配信 route を FS 走査で網羅: `/uploads/avatars/[filename]`・`/tenants/[...path]`（user-content）+ `/api/v1/export/cloud/[id]/download`（own-data、固定 attachment）の 3 経路を registry/allowlist に分類済。以後の新規 readFile 配信 route は (C) no-silent-gap で分類を強制
- [x] **設計書同期** (ADR-0001): 14-セキュリティ設計書 §7.2.1
- [x] N/A — その他並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（net-new 挙動なし、production コード無改変）

**レビュー依頼事項・QA**: fitness の nosniff 検証は hooks.server.ts の単一強制点（静的表明）、Content-Disposition は各 route の behavioral probe（実 GET handler 呼出）という 2 段構成。nosniff をグローバル単一点に集約する現行アーキテクチャを表明（各 route 重複付与は不要）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret なし

## Ready for Review チェックリスト

- [x] fitness 13 passed / biome / cspell / svelte-check / doc-code-references clean をローカル確認（main tree）
- [x] 設計書同期完了（14-セキュリティ設計書 §7.2.1）
- [x] failing-test-first の red→green を実証（ADR-0061）
- [x] production 挙動の無改変を確認（既存実装を表明のみ）
- [x] UI 変更なし / 認証画面変更なし

## QM レビュー結果

<!-- QM 記入 -->
